### PR TITLE
refactor: split internal/tx into layered packages (core / applystate / sign / engine / ter)

### DIFF
--- a/internal/ledger/inbound/replay_delta.go
+++ b/internal/ledger/inbound/replay_delta.go
@@ -19,6 +19,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
@@ -590,7 +591,7 @@ func (r *ReplayDelta) Apply(engineCfg tx.EngineConfig) (*ledger.Ledger, error) {
 		engineCfg.Rules = rules
 	}
 
-	engine := tx.NewEngine(child, engineCfg)
+	engine := txengine.NewEngine(child, engineCfg)
 
 	// R6b.1: on a flag ledger with featureNegativeUNL, apply pending
 	// ValidatorToDisable / ValidatorToReEnable transitions BEFORE

--- a/internal/ledger/openledger/apply.go
+++ b/internal/ledger/openledger/apply.go
@@ -7,6 +7,8 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
+
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 )
 
@@ -127,7 +129,7 @@ type ApplyConfig struct {
 //
 // Shared by ApplyTxs's per-pass inner loop and OpenLedger.Submit so the
 // success/tec/retry classification lives in exactly one place.
-func applyAndClassify(view *ledger.Ledger, bp *tx.BlockProcessor, transaction tx.Transaction, blob []byte, certainRetry bool, mode Mode, logger xrpllog.Logger) Result {
+func applyAndClassify(view *ledger.Ledger, bp *txengine.BlockProcessor, transaction tx.Transaction, blob []byte, certainRetry bool, mode Mode, logger xrpllog.Logger) Result {
 	result, applyErr := bp.ApplyTransaction(transaction, blob)
 	if applyErr != nil {
 		// Surface the error rather than swallowing it. A non-nil applyErr
@@ -192,14 +194,14 @@ func applyOneSingle(view *ledger.Ledger, transaction tx.Transaction, blob []byte
 	if retry {
 		engineConfig.ApplyFlags |= tx.TapRETRY
 	}
-	engine := tx.NewEngine(view, engineConfig)
+	engine := txengine.NewEngine(view, engineConfig)
 	// Seed the engine's txCount from the view so the TransactionIndex assigned
 	// to this tx reflects all txs already in the open view — mirrors rippled's
 	// OpenView::txCount() = baseTxCount_ + txs_.size(). Without this seed, a
 	// non-TxQ Submit path hitting applyOneSingle twice in a row on the same
 	// view would assign TransactionIndex=0 to both txs.
 	engine.SetBaseTxCount(view.TxCount())
-	bp := tx.NewBlockProcessor(engine)
+	bp := txengine.NewBlockProcessor(engine)
 	logger := cfg.Logger
 	if logger == nil {
 		logger = xrpllog.Discard()
@@ -234,7 +236,7 @@ func ApplyTxs(view *ledger.Ledger, txs []PendingTx, retries *[]PendingTx, cfg Ap
 	// the previous pass) or has already been settled (Success/Failure).
 	retrySet := make([]int, 0, len(txs))
 
-	buildEngine := func(certainRetry, skipSig bool) *tx.BlockProcessor {
+	buildEngine := func(certainRetry, skipSig bool) *txengine.BlockProcessor {
 		engineConfig := tx.EngineConfig{
 			BaseFee:                   cfg.BaseFee,
 			ReserveBase:               cfg.ReserveBase,
@@ -251,7 +253,7 @@ func ApplyTxs(view *ledger.Ledger, txs []PendingTx, retries *[]PendingTx, cfg Ap
 		if certainRetry {
 			engineConfig.ApplyFlags |= tx.TapRETRY
 		}
-		engine := tx.NewEngine(view, engineConfig)
+		engine := txengine.NewEngine(view, engineConfig)
 		// Issue #470: the per-pass engine's txCount starts at 0. Without
 		// re-seeding from the view's current tx count, txs committed on a
 		// retry pass would re-use TxIndex values already assigned to txs
@@ -262,7 +264,7 @@ func ApplyTxs(view *ledger.Ledger, txs []PendingTx, retries *[]PendingTx, cfg Ap
 		// = baseTxCount_ + txs_.size() where baseTxCount_ accumulates
 		// across the build's apply passes.
 		engine.SetBaseTxCount(view.TxCount())
-		return tx.NewBlockProcessor(engine)
+		return txengine.NewBlockProcessor(engine)
 	}
 
 	// Initial single pass over txs (OpenLedger.h:220-238). retry=true on

--- a/internal/ledger/openledger/openledger.go
+++ b/internal/ledger/openledger/openledger.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/internal/txq"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 )
@@ -371,7 +372,7 @@ type SubmitOutcome struct {
 	// Class is the OpenLedger 3-pass classification (Success/Failure/Retry).
 	Class Result
 	// Result is the engine TER, terQUEUED, or the rejection code.
-	Result tx.Result
+	Result ter.Result
 	// Applied is true only when the tx was committed to the open view.
 	Applied bool
 	// Queued is true when TxQ held the tx for a later ledger (terQUEUED).
@@ -403,22 +404,22 @@ func (o *OpenLedger) SubmitDetailed(ptx PendingTx, cfg ApplyConfig, queue *txq.T
 	cfg.Mode = OpenLedgerMode
 	var out SubmitOutcome
 	out.Class = ResultFailure
-	out.Result = tx.TefINTERNAL
+	out.Result = ter.TefINTERNAL
 	out.Changed = o.Modify(func(view *ledger.Ledger) bool {
 		// Pre-filter: tx already in view → drop (BuildLedger.cpp:125-129).
 		// Surface tefALREADY so callers can report the duplicate distinctly
 		// from a generic failure.
 		if view.TxExists(ptx.Hash) {
 			out.Class = ResultFailure
-			out.Result = tx.TefALREADY
-			out.Message = tx.TefALREADY.Message()
+			out.Result = ter.TefALREADY
+			out.Message = ter.TefALREADY.Message()
 			return false
 		}
 		parsed, err := tx.ParseFromBinary(ptx.Blob)
 		if err != nil {
 			out.Class = ResultFailure
-			out.Result = tx.TemMALFORMED
-			out.Message = tx.TemMALFORMED.Message()
+			out.Result = ter.TemMALFORMED
+			out.Message = ter.TemMALFORMED.Message()
 			return false
 		}
 		parsed.SetRawBytes(ptx.Blob)
@@ -440,7 +441,7 @@ func (o *OpenLedger) SubmitDetailed(ptx PendingTx, cfg ApplyConfig, queue *txq.T
 				out.Applied = true
 				out.Class = ResultSuccess
 				return true
-			case applyRes.Result == tx.TerQUEUED:
+			case applyRes.Result == ter.TerQUEUED:
 				// Held for a later ledger — view is unchanged but the
 				// tx is in flight, so classify as Success (matches
 				// OpenLedger.cpp:183 treating terQUEUED as applied). Nothing

--- a/internal/ledger/openledger/txqadapter.go
+++ b/internal/ledger/openledger/txqadapter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/internal/txq"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -171,8 +172,8 @@ func (a *TxqAdapter) ApplyTransaction(txn tx.Transaction) (ter.Result, bool) {
 		FeeTrack:                  a.cfg.FeeTrack,
 		EnforceLoadFee:            true,
 	}
-	engine := tx.NewEngine(a.view, engineCfg)
-	bp := tx.NewBlockProcessor(engine)
+	engine := txengine.NewEngine(a.view, engineCfg)
+	bp := txengine.NewBlockProcessor(engine)
 
 	result, err := bp.ApplyTransaction(txn, blob)
 	if err != nil {
@@ -218,7 +219,7 @@ func (a *TxqAdapter) PreflightTransaction(txn tx.Transaction) ter.Result {
 		Rules:                     a.cfg.Rules,
 		FeeTrack:                  a.cfg.FeeTrack,
 	}
-	return tx.NewEngine(a.view, engineCfg).Preflight(txn)
+	return txengine.NewEngine(a.view, engineCfg).Preflight(txn)
 }
 
 // PreclaimTransaction runs a preclaim-style check for the multiTxn path
@@ -284,7 +285,7 @@ func (a *TxqAdapter) PreclaimTransaction(txn tx.Transaction, accountID [20]byte,
 		FeeTrack:                  a.cfg.FeeTrack,
 		EnforceLoadFee:            true,
 	}
-	engine := tx.NewEngine(clone, engineCfg)
+	engine := txengine.NewEngine(clone, engineCfg)
 	return engine.Preclaim(txn, txHash)
 }
 

--- a/internal/ledger/openledger/txqadapter.go
+++ b/internal/ledger/openledger/txqadapter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/internal/txq"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -141,14 +142,14 @@ func (a *TxqAdapter) GetBaseFee(_ tx.Transaction) uint64 {
 // applied = isTesSuccess || isTecClaim (matches rippled
 // Transactor.cpp:1108-1218). On applied=true the tx+meta is written to
 // the view's tx map so subsequent GetTxInLedger / TxExists reflect it.
-func (a *TxqAdapter) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
+func (a *TxqAdapter) ApplyTransaction(txn tx.Transaction) (ter.Result, bool) {
 	if a.view == nil || txn == nil {
-		return tx.TefINTERNAL, false
+		return ter.TefINTERNAL, false
 	}
 
 	blob := txn.GetRawBytes()
 	if len(blob) == 0 {
-		return tx.TefINTERNAL, false
+		return ter.TefINTERNAL, false
 	}
 
 	// TxQ.Apply / TxQ.Accept target the open ledger but run with
@@ -175,7 +176,7 @@ func (a *TxqAdapter) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
 
 	result, err := bp.ApplyTransaction(txn, blob)
 	if err != nil {
-		return tx.TefINTERNAL, false
+		return ter.TefINTERNAL, false
 	}
 	applyRes := result.ApplyResult
 	a.lastApply = &applyRes
@@ -201,9 +202,9 @@ func (a *TxqAdapter) LastApplyResult() *tx.ApplyResult {
 // resulting TER. TxQ.Apply calls this before holding a transaction so a
 // malformed or badly-signed submission is rejected with its preflight code
 // instead of terQUEUED (rippled TxQ.cpp:743-745).
-func (a *TxqAdapter) PreflightTransaction(txn tx.Transaction) tx.Result {
+func (a *TxqAdapter) PreflightTransaction(txn tx.Transaction) ter.Result {
 	if a.view == nil || txn == nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	engineCfg := tx.EngineConfig{
 		BaseFee:                   a.cfg.BaseFee,
@@ -226,41 +227,41 @@ func (a *TxqAdapter) PreflightTransaction(txn tx.Transaction) tx.Result {
 // queued txs, then runs preclaim. terINSUF_FEE_B / terPRE_SEQ / similar
 // codes here indicate the tx would fail once the queued chain lands —
 // surfaced to the caller so the tx is rejected rather than queued.
-func (a *TxqAdapter) PreclaimTransaction(txn tx.Transaction, accountID [20]byte, adjustedBalance uint64, adjustedSeq uint32) tx.Result {
+func (a *TxqAdapter) PreclaimTransaction(txn tx.Transaction, accountID [20]byte, adjustedBalance uint64, adjustedSeq uint32) ter.Result {
 	if a.view == nil || txn == nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	blob := txn.GetRawBytes()
 	if len(blob) == 0 {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	txHash, hashErr := tx.ComputeTransactionHash(txn)
 	if hashErr != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	clone, err := a.view.MutableSnapshot()
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	key := keylet.Account(accountID)
 	data, err := clone.Read(key)
 	if err != nil || data == nil {
-		return tx.TerNO_ACCOUNT
+		return ter.TerNO_ACCOUNT
 	}
 	ar, err := state.ParseAccountRoot(data)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	ar.Sequence = adjustedSeq
 	ar.Balance = adjustedBalance
 	updated, err := state.SerializeAccountRoot(ar)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := clone.Update(key, updated); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Run preclaim with OpenLedger=false + EnforceLoadFee=true, mirroring
@@ -310,7 +311,7 @@ type txqSandbox struct {
 	child  *TxqAdapter
 }
 
-func (s *txqSandbox) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
+func (s *txqSandbox) ApplyTransaction(txn tx.Transaction) (ter.Result, bool) {
 	return s.child.ApplyTransaction(txn)
 }
 

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
@@ -389,7 +390,7 @@ func computeBaseFeeForTx(view tx.LedgerView, parsedTx tx.Transaction, cfg tx.Eng
 	if signerCount > maxMultiSigners(cfg.Rules) {
 		return cfg.BaseFee
 	}
-	return tx.CalculateMultiSigFee(cfg.BaseFee, signerCount)
+	return sign.CalculateMultiSigFee(cfg.BaseFee, signerCount)
 }
 
 // maxMultiSigners mirrors rippled STTx::maxMultiSigners (STTx.h:55-63).

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/internal/txq"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
@@ -22,7 +23,7 @@ import (
 // SubmitResult contains the result of submitting a transaction
 type SubmitResult struct {
 	// Result is the engine result code
-	Result tx.Result
+	Result ter.Result
 
 	// Applied indicates if the transaction was applied to the ledger
 	Applied bool
@@ -96,8 +97,8 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 	ptx, parseErr := openledger.ParsePendingTx(blob)
 	if parseErr != nil {
 		return &SubmitResult{
-			Result:        tx.TemMALFORMED,
-			Message:       tx.TemMALFORMED.Message(),
+			Result:        ter.TemMALFORMED,
+			Message:       ter.TemMALFORMED.Message(),
 			CurrentLedger: s.openLedgerView.Current().Sequence(),
 		}, nil
 	}
@@ -139,8 +140,8 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 	// and relay (1685-1689) so the caller learns about the failure
 	// immediately without a delayed re-application.
 	if rawBlob != nil && s.localTxs != nil {
-		ter := outcome.Result
-		if (!failHard || ter == tx.TesSUCCESS) && ter != tx.TefALREADY {
+		tr := outcome.Result
+		if (!failHard || tr == ter.TesSUCCESS) && tr != ter.TefALREADY {
 			s.localTxs.PushBack(currentSeq, ptx)
 		}
 	}

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -7,6 +7,8 @@ import (
 	"math/bits"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
+
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
@@ -542,7 +544,7 @@ func (s *Service) SimulateTransaction(transaction tx.Transaction) (*SubmitResult
 	}
 
 	// Create engine with the snapshot view
-	engine := tx.NewEngine(simView, engineConfig)
+	engine := txengine.NewEngine(simView, engineConfig)
 
 	// Apply the transaction (changes go to the snapshot, not the real ledger)
 	applyResult := engine.Apply(transaction)

--- a/internal/ledger/service/tx_query_submit_test.go
+++ b/internal/ledger/service/tx_query_submit_test.go
@@ -9,6 +9,7 @@ import (
 	testenv "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // signedPaymentWithFee builds a signed Payment blob carrying an explicit
@@ -75,7 +76,7 @@ func TestService_SubmitTransaction_AppliesAtOrAboveFeeLevel(t *testing.T) {
 	if !res.Applied {
 		t.Fatalf("Applied = false, want true (result=%s)", res.Result)
 	}
-	if res.Result != tx.TesSUCCESS {
+	if res.Result != ter.TesSUCCESS {
 		t.Fatalf("Result = %s, want tesSUCCESS", res.Result)
 	}
 	if !svc.OpenLedgerHasTx(hash) {
@@ -101,7 +102,7 @@ func TestService_SubmitTransaction_QueuesBelowFeeLevel(t *testing.T) {
 
 	res := submitBlob(t, svc, blob, false)
 
-	if res.Result != tx.TerQUEUED {
+	if res.Result != ter.TerQUEUED {
 		t.Fatalf("Result = %s, want terQUEUED", res.Result)
 	}
 	if res.Applied {
@@ -130,7 +131,7 @@ func TestService_SubmitTransaction_FailHardNotQueued(t *testing.T) {
 	if res.Applied {
 		t.Errorf("Applied = true, want false")
 	}
-	if res.Result == tx.TerQUEUED {
+	if res.Result == ter.TerQUEUED {
 		t.Errorf("Result = terQUEUED, want a rejection under fail_hard")
 	}
 	if svc.OpenLedgerHasTx(hash) {

--- a/internal/replaytool/replay.go
+++ b/internal/replaytool/replay.go
@@ -12,6 +12,10 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
+
+	"github.com/spf13/cobra"
+
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/cmdexit"
@@ -21,7 +25,6 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
-	"github.com/spf13/cobra"
 )
 
 // Fixture file structures matching xrpl-state-compare export format
@@ -392,8 +395,8 @@ func (r *replayRunner) executeReplayVerbose(state *StateFixture, env *EnvFixture
 		Rules:                     rules,
 	}
 
-	engine := tx.NewEngine(openLedger, engineConfig)
-	blockProcessor := tx.NewBlockProcessor(engine)
+	engine := txengine.NewEngine(openLedger, engineConfig)
+	blockProcessor := txengine.NewBlockProcessor(engine)
 
 	for _, txEntry := range txs.Transactions {
 		txInfo := TxApplyInfo{
@@ -423,7 +426,7 @@ func (r *replayRunner) executeReplayVerbose(state *StateFixture, env *EnvFixture
 		}
 
 		// Parse and prepare the transaction
-		parsedTx, err := tx.ParseAndPrepare(txBlob)
+		parsedTx, err := txengine.ParseAndPrepare(txBlob)
 		if err != nil {
 			txInfo.Error = fmt.Sprintf("failed to parse: %v", err)
 			txInfo.Applied = false

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -10,6 +10,10 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
+
+	"github.com/spf13/cobra"
+
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/cmdexit"
@@ -20,7 +24,6 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
-	"github.com/spf13/cobra"
 )
 
 // replayRangeRunner holds one `replay-range` invocation's flags and output sink.
@@ -653,8 +656,8 @@ func (r *replayRangeRunner) processBlock(
 		Rules:                     rules,
 	}
 
-	engine := tx.NewEngine(openLedger, engineConfig)
-	blockProcessor := tx.NewBlockProcessor(engine)
+	engine := txengine.NewEngine(openLedger, engineConfig)
+	blockProcessor := txengine.NewBlockProcessor(engine)
 
 	// Apply transactions
 	for _, txEntry := range txs {
@@ -675,7 +678,7 @@ func (r *replayRangeRunner) processBlock(
 		}
 
 		// Parse transaction
-		parsedTx, err := tx.ParseAndPrepare(txEntry.TxBlob)
+		parsedTx, err := txengine.ParseAndPrepare(txEntry.TxBlob)
 		if err != nil {
 			txInfo.Error = fmt.Sprintf("failed to parse: %v", err)
 			result.TxResults = append(result.TxResults, txInfo)

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 )
 
 // signCredentials holds the signing credential parameters common to both
@@ -292,7 +293,7 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 	txCommon := transaction.GetCommon()
 	txCommon.SigningPubKey = publicKey
 
-	signature, err := tx.SignTransaction(transaction, privateKey)
+	signature, err := sign.SignTransaction(transaction, privateKey)
 	if err != nil {
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to sign transaction: %v", err))
 	}

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
@@ -202,7 +203,7 @@ func (a *LedgerServiceAdapter) SubmitTransactionFailHard(txJSON []byte, txBlobHe
 // errorSubmitResult builds a non-applied SubmitResult whose engine fields are
 // sourced from the canonical TER table, so the result token, code, and message
 // stay in lockstep with rippled.
-func errorSubmitResult(r tx.Result) *types.SubmitResult {
+func errorSubmitResult(r ter.Result) *types.SubmitResult {
 	return &types.SubmitResult{
 		EngineResult:        r.String(),
 		EngineResultCode:    int(r),
@@ -212,11 +213,11 @@ func errorSubmitResult(r tx.Result) *types.SubmitResult {
 }
 
 func malformedSubmitResult() *types.SubmitResult {
-	return errorSubmitResult(tx.TemMALFORMED)
+	return errorSubmitResult(ter.TemMALFORMED)
 }
 
 func internalSubmitResult() *types.SubmitResult {
-	return errorSubmitResult(tx.TefINTERNAL)
+	return errorSubmitResult(ter.TefINTERNAL)
 }
 
 func (a *LedgerServiceAdapter) submitTransaction(txJSON []byte, txBlobHex string, failHard bool) (*types.SubmitResult, error) {
@@ -265,7 +266,7 @@ func (a *LedgerServiceAdapter) submitTransaction(txJSON []byte, txBlobHex string
 	// retry code. fail_hard suppresses relay on non-apply (matches
 	// NetworkOPs.cpp:1688 `&& !enforceFailHard`).
 	broadcast := false
-	relayable := result.Applied || result.Result == tx.TerQUEUED
+	relayable := result.Applied || result.Result == ter.TerQUEUED
 	if failHard && !result.Applied {
 		relayable = false
 	}
@@ -281,9 +282,9 @@ func (a *LedgerServiceAdapter) submitTransaction(txJSON []byte, txBlobHex string
 	// are kept too (they age out of LocalTxs after at most 5 ledgers). This
 	// is the exact condition Service.SubmitTransaction uses for the localTxs
 	// push, so the wire value reflects the actual held-pool decision.
-	queued := result.Result == tx.TerQUEUED
-	kept := (!failHard || result.Result == tx.TesSUCCESS) &&
-		result.Result != tx.TefALREADY
+	queued := result.Result == ter.TerQUEUED
+	kept := (!failHard || result.Result == ter.TesSUCCESS) &&
+		result.Result != ter.TefALREADY
 
 	return &types.SubmitResult{
 		EngineResult:        result.Result.String(),

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -6,14 +6,16 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	txall "github.com/LeJamon/go-xrpl/internal/tx/all"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // The simulate handler now performs an STTx-ctor-parity Validate()
@@ -1093,7 +1095,7 @@ func TestSimulateMethod_RealMetadataShape(t *testing.T) {
 			},
 		},
 		TransactionIndex:  0,
-		TransactionResult: tx.TesSUCCESS,
+		TransactionResult: ter.TesSUCCESS,
 	}
 	mock.simulateResult = &types.SubmitResult{
 		EngineResult:        "tesSUCCESS",

--- a/internal/testing/enginefuzz/harness_test.go
+++ b/internal/testing/enginefuzz/harness_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // maxSteps bounds the number of generated transactions per fuzz iteration and
@@ -27,8 +28,8 @@ const (
 // oracle: the engine runs the full internal/tx/invariants set on every apply
 // and squashes any violation into one of these codes.
 var (
-	invariantTec = tx.TecINVARIANT_FAILED.String()
-	invariantTef = tx.TefINVARIANT_FAILED.String()
+	invariantTec = ter.TecINVARIANT_FAILED.String()
+	invariantTef = ter.TefINVARIANT_FAILED.String()
 )
 
 // run drives one fuzz iteration: build a seeded ledger and apply the

--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/all"
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
 	"github.com/LeJamon/go-xrpl/internal/txq"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/shamap"
@@ -109,7 +110,7 @@ type TestEnv struct {
 	// invariantViolationHook, when set, is installed on the per-submit engine
 	// to force an invariant violation. Used by invariant-escalation tests; nil
 	// for every normal submission.
-	invariantViolationHook tx.InvariantViolationHook
+	invariantViolationHook txengine.InvariantViolationHook
 
 	// closingTxTotal tracks the total transaction count including inner batch
 	// transactions. In rippled, the closed ledger's tx map includes inner
@@ -355,7 +356,7 @@ func (e *TestEnv) SetBypassTxQ(bypass bool) {
 // submitted transaction's engine, forcing the invariant pass to report a
 // violation. Used to exercise the tec→tecINVARIANT_FAILED→tefINVARIANT_FAILED
 // escalation. Pass nil to clear it.
-func (e *TestEnv) SetInvariantViolationHook(hook tx.InvariantViolationHook) {
+func (e *TestEnv) SetInvariantViolationHook(hook txengine.InvariantViolationHook) {
 	e.invariantViolationHook = hook
 }
 

--- a/internal/testing/env_signing.go
+++ b/internal/testing/env_signing.go
@@ -4,6 +4,8 @@ import (
 	"encoding/hex"
 	"strconv"
 
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
+
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
@@ -227,7 +229,7 @@ func (e *TestEnv) submitWithSigVerification(txn tx.Transaction) TxResult {
 		OpenLedger:                e.openLedger,
 	}
 
-	engine := tx.NewEngine(e.ledger, engineConfig)
+	engine := txengine.NewEngine(e.ledger, engineConfig)
 	applyResult := engine.Apply(txn)
 
 	return TxResult{

--- a/internal/testing/env_signing.go
+++ b/internal/testing/env_signing.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -55,7 +56,7 @@ func (e *TestEnv) SignWith(txn tx.Transaction, signer *Account) tx.Transaction {
 		// This ensures identical binary serialization and tx hashes.
 		common.TxnSignature = "00"
 	} else {
-		sig, err := tx.SignTransaction(txn, privateKeyHex(signer))
+		sig, err := sign.SignTransaction(txn, privateKeyHex(signer))
 		if err != nil {
 			e.t.Fatalf("Failed to sign transaction: %v", err)
 		}
@@ -72,7 +73,7 @@ func (e *TestEnv) signReal(txn tx.Transaction, signer *Account) {
 	e.t.Helper()
 	common := txn.GetCommon()
 	common.SigningPubKey = hex.EncodeToString(signer.PublicKey)
-	sig, err := tx.SignTransaction(txn, privateKeyHex(signer))
+	sig, err := sign.SignTransaction(txn, privateKeyHex(signer))
 	if err != nil {
 		e.t.Fatalf("Failed to sign transaction: %v", err)
 	}
@@ -155,12 +156,12 @@ func (e *TestEnv) SubmitMultiSigned(transaction any, signers []*Account) TxResul
 
 	// Each signer signs and is added (AddMultiSigner maintains sorted order)
 	for _, signer := range signers {
-		sig, err := tx.SignTransactionForMultiSign(txn, signer.Address, privateKeyHex(signer))
+		sig, err := sign.SignTransactionForMultiSign(txn, signer.Address, privateKeyHex(signer))
 		if err != nil {
 			e.t.Fatalf("Failed to multi-sign for %s: %v", signer.Name, err)
 		}
 
-		err = tx.AddMultiSigner(txn, signer.Address, hex.EncodeToString(signer.PublicKey), sig)
+		err = sign.AddMultiSigner(txn, signer.Address, hex.EncodeToString(signer.PublicKey), sig)
 		if err != nil {
 			e.t.Fatalf("Failed to add multi-signer %s: %v", signer.Name, err)
 		}

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/internal/txq"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
@@ -619,7 +620,7 @@ func (e *TestEnv) submitViaTxQ(txn tx.Transaction) TxResult {
 		e.addHeldTransaction(accountAddr, txn)
 
 		return TxResult{
-			Code:    tx.TerQUEUED.String(),
+			Code:    ter.TerQUEUED.String(),
 			Success: false,
 			Message: "Transaction queued",
 		}
@@ -649,14 +650,14 @@ func (e *TestEnv) submitViaTxQ(txn tx.Transaction) TxResult {
 // isRetryable returns true if the transaction result indicates the transaction
 // might succeed later (e.g., terPRE_SEQ, terINSUF_FEE_B).
 // Reference: rippled isTerRetry()
-func isRetryable(result tx.Result) bool {
+func isRetryable(result ter.Result) bool {
 	return result >= -99 && result < 0
 }
 
 // isTelLocal returns true if the result is a tel (local error) code.
 // tel codes are in the range -399 to -300.
 // Reference: rippled TER.h telLOCAL_ERROR = -399, telCAN_NOT_QUEUE = -381
-func isTelLocal(result tx.Result) bool {
+func isTelLocal(result ter.Result) bool {
 	return result >= -399 && result <= -300
 }
 
@@ -833,7 +834,7 @@ func (e *TestEnv) drainQueue() {
 // process. When certainRetry is true, TapRETRY is set so that tec results
 // are not applied (matching rippled's retry pass behavior).
 // Returns the result code and whether the transaction was actually applied.
-func (e *TestEnv) applyForReplay(txn tx.Transaction, certainRetry bool) (tx.Result, bool) {
+func (e *TestEnv) applyForReplay(txn tx.Transaction, certainRetry bool) (ter.Result, bool) {
 	// Use the ledger's stored ParentCloseTime, matching applyDirect().
 	// Both paths use the ledger header so time-dependent checks produce
 	// the same result during initial apply and during replay.
@@ -1283,7 +1284,7 @@ func (c *testTxQApplyContext) GetLedgerSequence() uint32 {
 	return c.env.ledger.Sequence()
 }
 
-func (c *testTxQApplyContext) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
+func (c *testTxQApplyContext) ApplyTransaction(txn tx.Transaction) (ter.Result, bool) {
 	parentCloseTime := uint32(c.env.clock.Now().Unix() - protocol.RippleEpochUnix)
 	// Transactions applied through the TxQ must NOT check open-ledger fee
 	// adequacy. In rippled, TxQ::tryDirectApply calls ripple::apply() with
@@ -1353,7 +1354,7 @@ type testTxQSandbox struct {
 	accum  *txqSandboxAccum
 }
 
-func (s *testTxQSandbox) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
+func (s *testTxQSandbox) ApplyTransaction(txn tx.Transaction) (ter.Result, bool) {
 	return s.child.ApplyTransaction(txn)
 }
 
@@ -1371,7 +1372,7 @@ func (s *testTxQSandbox) Commit() error {
 	return nil
 }
 
-func (c *testTxQApplyContext) PreflightTransaction(txn tx.Transaction) tx.Result {
+func (c *testTxQApplyContext) PreflightTransaction(txn tx.Transaction) ter.Result {
 	// Mirror the engine config used by ApplyTransaction so TxQ admission
 	// preflight (rippled TxQ.cpp:743-745) matches the direct-apply path.
 	view := c.applyView()
@@ -1391,7 +1392,7 @@ func (c *testTxQApplyContext) PreflightTransaction(txn tx.Transaction) tx.Result
 	return tx.NewEngine(view, engineConfig).Preflight(txn)
 }
 
-func (c *testTxQApplyContext) PreclaimTransaction(txn tx.Transaction, account [20]byte, adjustedBalance uint64, adjustedSeq uint32) tx.Result {
+func (c *testTxQApplyContext) PreclaimTransaction(txn tx.Transaction, account [20]byte, adjustedBalance uint64, adjustedSeq uint32) ter.Result {
 	// Simplified simulation of rippled's multiTxn preclaim path (TxQ.cpp:1167-1170).
 	// rippled creates a modified view with adjusted balance and sequence,
 	// then runs a full preclaim(). We only check the checkFee portion here
@@ -1401,13 +1402,13 @@ func (c *testTxQApplyContext) PreclaimTransaction(txn tx.Transaction, account [2
 	// Reference: rippled Transactor::checkFee (Transactor.cpp line ~310)
 	common := txn.GetCommon()
 	if common == nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	fee, _ := strconv.ParseUint(common.Fee, 10, 64)
 
 	if adjustedBalance < fee {
-		return tx.TerINSUF_FEE_B
+		return ter.TerINSUF_FEE_B
 	}
 
 	// If preclaim passes, return 0 (tesSUCCESS) to indicate likely to claim fee.
@@ -1444,7 +1445,7 @@ func (c *testTxQAcceptContext) GetAccountSequence(account [20]byte) uint32 {
 	return accountRoot.Sequence
 }
 
-func (c *testTxQAcceptContext) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
+func (c *testTxQAcceptContext) ApplyTransaction(txn tx.Transaction) (ter.Result, bool) {
 	parentCloseTime := uint32(c.env.clock.Now().Unix() - protocol.RippleEpochUnix)
 	// TxQ accept (drain on close) applies queued transactions with tapNONE
 	// flags in rippled — NOT tapOPEN_LEDGER. This prevents the engine's

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
+
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -490,7 +492,7 @@ func (e *TestEnv) applyDirect(txn tx.Transaction) TxResult {
 		FeeTrack:                  e.feeTrack,
 	}
 
-	engine := tx.NewEngine(e.ledger, engineConfig)
+	engine := txengine.NewEngine(e.ledger, engineConfig)
 	// Seed the engine's txCount from the env's tx-in-ledger counter so
 	// metadata.TransactionIndex matches what rippled assigns. e.ledger
 	// is the open ledger and env.Submit does NOT call AddTransactionWithMeta,
@@ -855,7 +857,7 @@ func (e *TestEnv) applyForReplay(txn tx.Transaction, certainRetry bool) (ter.Res
 		engineConfig.ApplyFlags = tx.TapRETRY
 	}
 
-	engine := tx.NewEngine(e.ledger, engineConfig)
+	engine := txengine.NewEngine(e.ledger, engineConfig)
 	// Seed the engine's txCount from the env's tx-in-ledger counter so
 	// metadata.TransactionIndex matches what rippled assigns. e.ledger
 	// is the open ledger and env.Submit does NOT call AddTransactionWithMeta,
@@ -1310,7 +1312,7 @@ func (c *testTxQApplyContext) ApplyTransaction(txn tx.Transaction) (ter.Result, 
 		EnforceLoadFee:            true,
 	}
 
-	engine := tx.NewEngine(view, engineConfig)
+	engine := txengine.NewEngine(view, engineConfig)
 	applyResult := engine.Apply(txn)
 
 	applied := applyResult.Result.IsApplied()
@@ -1389,7 +1391,7 @@ func (c *testTxQApplyContext) PreflightTransaction(txn tx.Transaction) ter.Resul
 		ParentHash:                view.ParentHash(),
 		FeeTrack:                  c.env.feeTrack,
 	}
-	return tx.NewEngine(view, engineConfig).Preflight(txn)
+	return txengine.NewEngine(view, engineConfig).Preflight(txn)
 }
 
 func (c *testTxQApplyContext) PreclaimTransaction(txn tx.Transaction, account [20]byte, adjustedBalance uint64, adjustedSeq uint32) ter.Result {
@@ -1468,7 +1470,7 @@ func (c *testTxQAcceptContext) ApplyTransaction(txn tx.Transaction) (ter.Result,
 		EnforceLoadFee:            true,
 	}
 
-	engine := tx.NewEngine(c.env.ledger, engineConfig)
+	engine := txengine.NewEngine(c.env.ledger, engineConfig)
 	applyResult := engine.Apply(txn)
 
 	applied := applyResult.Result.IsApplied()
@@ -1606,7 +1608,7 @@ func (e *TestEnv) SubmitPseudo(transaction any) TxResult {
 		OpenLedger:                false,
 	}
 
-	engine := tx.NewEngine(e.ledger, engineConfig)
+	engine := txengine.NewEngine(e.ledger, engineConfig)
 	applyResult := engine.ApplyPseudo(txn)
 
 	return TxResult{

--- a/internal/testing/invariants/tec_invariants_test.go
+++ b/internal/testing/invariants/tec_invariants_test.go
@@ -9,7 +9,10 @@ package invariants_test
 import (
 	"testing"
 
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
+
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+
 	offerbuild "github.com/LeJamon/go-xrpl/internal/testing/offer"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -57,9 +60,9 @@ func TestInvariant_TecResult_EscalatesToTecINVARIANT_FAILED(t *testing.T) {
 
 	// Force a violation only on the first (original-tec) pass. The fee-only
 	// retry passes cleanly, so the result settles at tecINVARIANT_FAILED.
-	env.SetInvariantViolationHook(func(result ter.Result, _ *tx.ApplyStateTable) *tx.InvariantViolationValue {
+	env.SetInvariantViolationHook(func(result ter.Result, _ *tx.ApplyStateTable) *txengine.InvariantViolationValue {
 		if result == ter.TecUNFUNDED_OFFER {
-			return tx.NewInvariantViolation("Injected", "forced tec-path violation")
+			return txengine.NewInvariantViolation("Injected", "forced tec-path violation")
 		}
 		return nil
 	})
@@ -89,8 +92,8 @@ func TestInvariant_TecResult_EscalatesToTefINVARIANT_FAILED(t *testing.T) {
 
 	// Force a violation on every pass — the fee-only retry also violates, so the
 	// result escalates to tefINVARIANT_FAILED.
-	env.SetInvariantViolationHook(func(_ ter.Result, _ *tx.ApplyStateTable) *tx.InvariantViolationValue {
-		return tx.NewInvariantViolation("Injected", "forced persistent violation")
+	env.SetInvariantViolationHook(func(_ ter.Result, _ *tx.ApplyStateTable) *txengine.InvariantViolationValue {
+		return txengine.NewInvariantViolation("Injected", "forced persistent violation")
 	})
 	defer env.SetInvariantViolationHook(nil)
 

--- a/internal/testing/invariants/tec_invariants_test.go
+++ b/internal/testing/invariants/tec_invariants_test.go
@@ -9,12 +9,12 @@ package invariants_test
 import (
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
 	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
 
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 
 	offerbuild "github.com/LeJamon/go-xrpl/internal/testing/offer"
-	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
@@ -60,7 +60,7 @@ func TestInvariant_TecResult_EscalatesToTecINVARIANT_FAILED(t *testing.T) {
 
 	// Force a violation only on the first (original-tec) pass. The fee-only
 	// retry passes cleanly, so the result settles at tecINVARIANT_FAILED.
-	env.SetInvariantViolationHook(func(result ter.Result, _ *tx.ApplyStateTable) *txengine.InvariantViolationValue {
+	env.SetInvariantViolationHook(func(result ter.Result, _ *applystate.ApplyStateTable) *txengine.InvariantViolationValue {
 		if result == ter.TecUNFUNDED_OFFER {
 			return txengine.NewInvariantViolation("Injected", "forced tec-path violation")
 		}
@@ -92,7 +92,7 @@ func TestInvariant_TecResult_EscalatesToTefINVARIANT_FAILED(t *testing.T) {
 
 	// Force a violation on every pass — the fee-only retry also violates, so the
 	// result escalates to tefINVARIANT_FAILED.
-	env.SetInvariantViolationHook(func(_ ter.Result, _ *tx.ApplyStateTable) *txengine.InvariantViolationValue {
+	env.SetInvariantViolationHook(func(_ ter.Result, _ *applystate.ApplyStateTable) *txengine.InvariantViolationValue {
 		return txengine.NewInvariantViolation("Injected", "forced persistent violation")
 	})
 	defer env.SetInvariantViolationHook(nil)

--- a/internal/testing/invariants/tec_invariants_test.go
+++ b/internal/testing/invariants/tec_invariants_test.go
@@ -12,6 +12,7 @@ import (
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	offerbuild "github.com/LeJamon/go-xrpl/internal/testing/offer"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // TestInvariant_TecResult_CleanRecovery_KeepsTec verifies that a tec result
@@ -56,8 +57,8 @@ func TestInvariant_TecResult_EscalatesToTecINVARIANT_FAILED(t *testing.T) {
 
 	// Force a violation only on the first (original-tec) pass. The fee-only
 	// retry passes cleanly, so the result settles at tecINVARIANT_FAILED.
-	env.SetInvariantViolationHook(func(result tx.Result, _ *tx.ApplyStateTable) *tx.InvariantViolationValue {
-		if result == tx.TecUNFUNDED_OFFER {
+	env.SetInvariantViolationHook(func(result ter.Result, _ *tx.ApplyStateTable) *tx.InvariantViolationValue {
+		if result == ter.TecUNFUNDED_OFFER {
 			return tx.NewInvariantViolation("Injected", "forced tec-path violation")
 		}
 		return nil
@@ -88,7 +89,7 @@ func TestInvariant_TecResult_EscalatesToTefINVARIANT_FAILED(t *testing.T) {
 
 	// Force a violation on every pass — the fee-only retry also violates, so the
 	// result escalates to tefINVARIANT_FAILED.
-	env.SetInvariantViolationHook(func(_ tx.Result, _ *tx.ApplyStateTable) *tx.InvariantViolationValue {
+	env.SetInvariantViolationHook(func(_ ter.Result, _ *tx.ApplyStateTable) *tx.InvariantViolationValue {
 		return tx.NewInvariantViolation("Injected", "forced persistent violation")
 	})
 	defer env.SetInvariantViolationHook(nil)

--- a/internal/testing/p2p/replay_delta_apply_integration_test.go
+++ b/internal/testing/p2p/replay_delta_apply_integration_test.go
@@ -11,12 +11,15 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	xrplgoTesting "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 	"github.com/LeJamon/go-xrpl/protocol"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestReplayDelta_Apply_Integration verifies end-to-end that
@@ -235,7 +238,7 @@ func buildClosedSuccessor(
 		parentCloseTime = uint32(parent.CloseTime().Unix() - protocol.RippleEpochUnix)
 	}
 
-	engine := tx.NewEngine(child, tx.EngineConfig{
+	engine := txengine.NewEngine(child, tx.EngineConfig{
 		BaseFee:                   10,
 		ReserveBase:               200_000_000,
 		ReserveIncrement:          50_000_000,

--- a/internal/testing/pathfuzz/harness_test.go
+++ b/internal/testing/pathfuzz/harness_test.go
@@ -12,6 +12,7 @@ import (
 	paymentb "github.com/LeJamon/go-xrpl/internal/testing/payment"
 	trustsetb "github.com/LeJamon/go-xrpl/internal/testing/trustset"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // maxSteps bounds the number of generated transactions per fuzz iteration.
@@ -32,8 +33,8 @@ const stepBudget = 5 * time.Second
 // runs on every apply (and that rippled exercises under Antithesis). A hit is by
 // construction a consensus-safety bug.
 var (
-	invariantTec = tx.TecINVARIANT_FAILED.String()
-	invariantTef = tx.TefINVARIANT_FAILED.String()
+	invariantTec = ter.TecINVARIANT_FAILED.String()
+	invariantTef = ter.TefINVARIANT_FAILED.String()
 )
 
 // gateway is an issuer paired with the single currency it issues in the scenario.

--- a/internal/testing/pseudotx/preflight_test.go
+++ b/internal/testing/pseudotx/preflight_test.go
@@ -7,17 +7,20 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
+
+	"github.com/stretchr/testify/require"
+
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
 	"github.com/LeJamon/go-xrpl/protocol"
-	"github.com/stretchr/testify/require"
 )
 
 // closedEngine builds an engine pinned to a closed-ledger view, which is the
 // only configuration under which ApplyPseudo legally executes per rippled
 // Change::preclaim.
-func closedEngine(t *testing.T, rules *amendment.Rules) (*tx.Engine, *jtx.TestEnv) {
+func closedEngine(t *testing.T, rules *amendment.Rules) (*txengine.Engine, *jtx.TestEnv) {
 	t.Helper()
 	env := jtx.NewTestEnv(t)
 	cfg := tx.EngineConfig{
@@ -29,7 +32,7 @@ func closedEngine(t *testing.T, rules *amendment.Rules) (*tx.Engine, *jtx.TestEn
 		OpenLedger:                false,
 		Rules:                     rules,
 	}
-	return tx.NewEngine(env.Ledger(), cfg), env
+	return txengine.NewEngine(env.Ledger(), cfg), env
 }
 
 func newAmendmentTx() *pseudo.EnableAmendment {
@@ -259,7 +262,7 @@ func TestSetFee_PreclaimRejectsUnparseableBaseFee(t *testing.T) {
 
 // closedEngineWithNetwork mirrors closedEngine but lets the test pin
 // EngineConfig.NetworkID so the NetworkID branch of preflight0 fires.
-func closedEngineWithNetwork(t *testing.T, rules *amendment.Rules, networkID uint32) *tx.Engine {
+func closedEngineWithNetwork(t *testing.T, rules *amendment.Rules, networkID uint32) *txengine.Engine {
 	t.Helper()
 	env := jtx.NewTestEnv(t)
 	cfg := tx.EngineConfig{
@@ -272,7 +275,7 @@ func closedEngineWithNetwork(t *testing.T, rules *amendment.Rules, networkID uin
 		Rules:                     rules,
 		NetworkID:                 networkID,
 	}
-	return tx.NewEngine(env.Ledger(), cfg)
+	return txengine.NewEngine(env.Ledger(), cfg)
 }
 
 // TestPseudoPreflight_TfInnerBatchTxnRejected rejects a pseudo-tx carrying

--- a/internal/testing/pseudotx/pseudotx_test.go
+++ b/internal/testing/pseudotx/pseudotx_test.go
@@ -7,11 +7,14 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
+
+	"github.com/stretchr/testify/require"
+
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
 	"github.com/LeJamon/go-xrpl/protocol"
-	"github.com/stretchr/testify/require"
 )
 
 // TestPseudoTx_IsPseudoTransaction verifies that the type system correctly
@@ -78,7 +81,7 @@ func TestPseudoTx_Prevented(t *testing.T) {
 		OpenLedger:                true,
 		Rules:                     amendment.AllSupportedRules(),
 	}
-	engine := tx.NewEngine(env.Ledger(), engineConfig)
+	engine := txengine.NewEngine(env.Ledger(), engineConfig)
 
 	// Test that each pseudo-transaction type is rejected by Apply()
 	// Reference: rippled PseudoTx_test.cpp line 97:
@@ -142,7 +145,7 @@ func TestPseudoTx_Prevented(t *testing.T) {
 	t.Run("EnableAmendment allowed via ApplyPseudo", func(t *testing.T) {
 		closedConfig := engineConfig
 		closedConfig.OpenLedger = false
-		closedEngine := tx.NewEngine(env.Ledger(), closedConfig)
+		closedEngine := txengine.NewEngine(env.Ledger(), closedConfig)
 
 		amendTx := &pseudo.EnableAmendment{
 			BaseTx: *tx.NewBaseTx(tx.TypeAmendment, protocol.ZeroAccount),

--- a/internal/tx/account/account_delete.go
+++ b/internal/tx/account/account_delete.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
 	"github.com/LeJamon/go-xrpl/internal/tx/oracle"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -35,10 +36,10 @@ func (a *AccountDelete) Validate() error {
 		return err
 	}
 	if a.Destination == "" {
-		return tx.Errorf(tx.TemDST_NEEDED, "Destination is required")
+		return ter.Errorf(ter.TemDST_NEEDED, "Destination is required")
 	}
 	if a.Account == a.Destination {
-		return tx.Errorf(tx.TemDST_IS_SRC, "cannot delete account to self")
+		return ter.Errorf(ter.TemDST_IS_SRC, "cannot delete account to self")
 	}
 	present := a.CredentialIDs != nil || a.GetCommon().HasField("CredentialIDs")
 	if err := credential.CheckFields(a.CredentialIDs, present, "Duplicate credential ID"); err != nil {
@@ -70,7 +71,7 @@ func (a *AccountDelete) ApplyOnTec(ctx *tx.ApplyContext) {
 	credential.RemoveExpiredCredentials(ctx, a.CredentialIDs)
 }
 
-func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
+func (a *AccountDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("account delete apply",
 		"account", a.Account,
 		"destination", a.Destination,
@@ -78,18 +79,18 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	rules := ctx.Rules()
 	if len(a.CredentialIDs) > 0 && !rules.Enabled(amendment.FeatureCredentials) {
-		return tx.TemDISABLED
+		return ter.TemDISABLED
 	}
 	destAccount, destID, result := ctx.LookupAccount(a.Destination)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 	destKey := keylet.Account(destID)
 	if (destAccount.Flags&state.LsfRequireDestTag) != 0 && a.DestinationTag == nil {
-		return tx.TecDST_TAG_NEEDED
+		return ter.TecDST_TAG_NEEDED
 	}
 	if len(a.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-		if result := credential.ValidateCredentialIDs(ctx, a.CredentialIDs); result != tx.TesSUCCESS {
+		if result := credential.ValidateCredentialIDs(ctx, a.CredentialIDs); result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -97,7 +98,7 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 		if rules.Enabled(amendment.FeatureDepositAuth) && (destAccount.Flags&state.LsfDepositAuth) != 0 {
 			preauthKey := keylet.DepositPreauth(destID, ctx.AccountID)
 			if exists, _ := ctx.View.Exists(preauthKey); !exists {
-				return tx.TecNO_PERMISSION
+				return ter.TecNO_PERMISSION
 			}
 		}
 	}
@@ -105,13 +106,13 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	// to match rippled's DeleteAccount::preclaim() order.
 	if rules.Enabled(amendment.FeatureNonFungibleTokensV1) {
 		if ctx.Account.MintedNFTokens != ctx.Account.BurnedNFTokens {
-			return tx.TecHAS_OBLIGATIONS
+			return ter.TecHAS_OBLIGATIONS
 		}
 		first := keylet.NFTokenPageMin(ctx.AccountID)
 		last := keylet.NFTokenPageMax(ctx.AccountID)
 		succKey, _, succFound, succErr := ctx.View.Succ(first.Key)
 		if succErr == nil && succFound && keyLessEqual(succKey, last.Key) {
-			return tx.TecHAS_OBLIGATIONS
+			return ter.TecHAS_OBLIGATIONS
 		}
 	}
 	// Check minimum ledger gap: account sequence must be far enough behind the ledger.
@@ -131,7 +132,7 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 		acctSeq = *a.GetCommon().Sequence
 	}
 	if acctSeq+seqDelta > ctx.Config.LedgerSequence {
-		return tx.TecTOO_SOON
+		return ter.TecTOO_SOON
 	}
 	if rules.Enabled(amendment.FeatureFixNFTokenRemint) {
 		firstNFTSeq := uint32(0)
@@ -139,7 +140,7 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 			firstNFTSeq = ctx.Account.FirstNFTokenSequence
 		}
 		if uint64(firstNFTSeq)+uint64(ctx.Account.MintedNFTokens)+uint64(seqDelta) > uint64(ctx.Config.LedgerSequence) {
-			return tx.TecTOO_SOON
+			return ter.TecTOO_SOON
 		}
 	}
 	// Verify deposit preauth with credentials BEFORE cleaning up owned objects.
@@ -148,7 +149,7 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled DeleteAccount.cpp doApply() — verifyDepositPreauth
 	// is called before cleanupOnAccountDelete.
 	if rules.Enabled(amendment.FeatureDepositAuth) && len(a.CredentialIDs) > 0 {
-		if r := credential.VerifyDepositPreauth(ctx, a.CredentialIDs, ctx.AccountID, destID, destAccount); r != tx.TesSUCCESS {
+		if r := credential.VerifyDepositPreauth(ctx, a.CredentialIDs, ctx.AccountID, destID, destAccount); r != ter.TesSUCCESS {
 			return r
 		}
 	}
@@ -160,17 +161,17 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 		entryKeys = append(entryKeys, itemKey)
 		return nil
 	}); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	for _, itemKey := range entryKeys {
 		ik := keylet.Keylet{Key: itemKey}
 		data, err := ctx.View.Read(ik)
 		if err != nil || data == nil {
-			return tx.TefBAD_LEDGER
+			return ter.TefBAD_LEDGER
 		}
 		etRaw, err := state.GetLedgerEntryType(data)
 		if err != nil {
-			return tx.TecHAS_OBLIGATIONS
+			return ter.TecHAS_OBLIGATIONS
 		}
 		et := entry.Type(etRaw)
 		deleter := nonObligationDeleter(et)
@@ -178,13 +179,13 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 			ctx.Log.Error("account delete: undeletable item in owner directory",
 				"entryType", etRaw,
 			)
-			return tx.TecHAS_OBLIGATIONS
+			return ter.TecHAS_OBLIGATIONS
 		}
 		deletableCount++
 		if deletableCount > maxDeletableDirEntries {
-			return tx.TefTOO_BIG
+			return ter.TefTOO_BIG
 		}
-		if r := deleter(ctx, ownerDirKey, ik, data); r != tx.TesSUCCESS {
+		if r := deleter(ctx, ownerDirKey, ik, data); r != ter.TesSUCCESS {
 			return r
 		}
 	}
@@ -194,12 +195,12 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	destData, err := ctx.View.Read(destKey)
 	if err != nil {
 		ctx.Log.Error("account delete: failed to re-read destination account")
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	destAccount, err = state.ParseAccountRoot(destData)
 	if err != nil {
 		ctx.Log.Error("account delete: failed to parse destination account")
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	sourceBalance := ctx.Account.Balance
 	destAccount.Balance += sourceBalance
@@ -207,16 +208,16 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	if sourceBalance > 0 && (destAccount.Flags&state.LsfPasswordSpent) != 0 {
 		destAccount.Flags &^= state.LsfPasswordSpent
 	}
-	if r := ctx.UpdateAccountRoot(destID, destAccount); r != tx.TesSUCCESS {
+	if r := ctx.UpdateAccountRoot(destID, destAccount); r != ter.TesSUCCESS {
 		return r
 	}
-	if r := ctx.UpdateAccountRoot(ctx.AccountID, ctx.Account); r != tx.TesSUCCESS {
+	if r := ctx.UpdateAccountRoot(ctx.AccountID, ctx.Account); r != ter.TesSUCCESS {
 		return r
 	}
 	if err := ctx.View.Erase(keylet.Account(ctx.AccountID)); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // entryDeleter removes one account-owned object during AccountDelete cleanup.
@@ -226,7 +227,7 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 // (offerDelete, removeTicketFromLedger, removeNFTokenOfferFromLedger, ...),
 // all of which propagate ledger corruption as tef.
 // Reference: rippled DeleteAccount.cpp nonObligationDeleter and its deleters.
-type entryDeleter func(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) tx.Result
+type entryDeleter func(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) ter.Result
 
 // nonObligationDeleter returns the deleter for a non-obligation ledger entry
 // type, or nil if the type is an obligation that blocks account deletion.
@@ -264,46 +265,46 @@ func removeFromDir(ctx *tx.ApplyContext, dir keylet.Keylet, hint uint64, itemKey
 	return err == nil && res.Success
 }
 
-func deleteOffer(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) tx.Result {
+func deleteOffer(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) ter.Result {
 	offer, err := state.ParseLedgerOfferFromBytes(data)
 	if err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if !removeFromDir(ctx, ownerDirKey, offer.OwnerNode, ik.Key, false) {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	bdk := keylet.Keylet{Type: 100, Key: offer.BookDirectory}
 	if !removeFromDir(ctx, bdk, offer.BookNode, ik.Key, false) {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if err := ctx.View.Erase(ik); err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	decrementOwnerCount(ctx)
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
-func deleteTicket(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) tx.Result {
+func deleteTicket(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) ter.Result {
 	if !removeFromDir(ctx, ownerDirKey, state.GetOwnerNode(data), ik.Key, true) {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if err := ctx.View.Erase(ik); err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	decrementOwnerCount(ctx)
 	if ctx.Account.TicketCount > 0 {
 		ctx.Account.TicketCount--
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
-func deleteNFTokenOffer(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) tx.Result {
+func deleteNFTokenOffer(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) ter.Result {
 	nftOffer, err := state.ParseNFTokenOffer(data)
 	if err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if !removeFromDir(ctx, ownerDirKey, nftOffer.OwnerNode, ik.Key, false) {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	var tdk keylet.Keylet
 	if nftOffer.Flags&entry.LsfSellNFToken != 0 {
@@ -312,55 +313,55 @@ func deleteNFTokenOffer(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, dat
 		tdk = keylet.NFTBuys(nftOffer.NFTokenID)
 	}
 	if !removeFromDir(ctx, tdk, nftOffer.NFTokenOfferNode, ik.Key, false) {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if err := ctx.View.Erase(ik); err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	decrementOwnerCount(ctx)
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
-func deleteDepositPreauth(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) tx.Result {
+func deleteDepositPreauth(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) ter.Result {
 	pe, err := state.ParseDepositPreauth(data)
 	if err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if !removeFromDir(ctx, ownerDirKey, pe.OwnerNode, ik.Key, false) {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if err := ctx.View.Erase(ik); err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	decrementOwnerCount(ctx)
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
-func deleteDID(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) tx.Result {
+func deleteDID(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) ter.Result {
 	dd, err := state.ParseDID(data)
 	if err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if !removeFromDir(ctx, ownerDirKey, dd.OwnerNode, ik.Key, false) {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if err := ctx.View.Erase(ik); err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	decrementOwnerCount(ctx)
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
-func deleteSignerList(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) tx.Result {
+func deleteSignerList(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) ter.Result {
 	signerList, err := state.ParseSignerList(data)
 	if err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if !removeFromDir(ctx, ownerDirKey, signerList.OwnerNode, ik.Key, false) {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if err := ctx.View.Erase(ik); err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	// A post-MultiSignReserve list (lsfOneOwnerCount) costs a single owner unit;
 	// a legacy list costs 2 plus one per signer entry.
@@ -369,47 +370,47 @@ func deleteSignerList(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data 
 		removeCount = 2 + uint32(len(signerList.SignerEntries))
 	}
 	decrementOwnerCountBy(ctx, removeCount)
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
-func deleteDelegate(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) tx.Result {
+func deleteDelegate(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) ter.Result {
 	dd, err := state.ParseDelegate(data)
 	if err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if !removeFromDir(ctx, ownerDirKey, dd.OwnerNode, ik.Key, false) {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if err := ctx.View.Erase(ik); err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	decrementOwnerCount(ctx)
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // deleteCredential and deleteOracle delegate to helpers that own their full
 // deletion (directory removal, owner-count adjustment through the view, and
 // erase), so the deleter only maps a non-nil error to tefBAD_LEDGER.
-func deleteCredential(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) tx.Result {
+func deleteCredential(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) ter.Result {
 	cred, err := credential.ParseCredentialEntry(data)
 	if err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
-	if result := credential.DeleteSLE(ctx, ik, cred); result != tx.TesSUCCESS {
+	if result := credential.DeleteSLE(ctx, ik, cred); result != ter.TesSUCCESS {
 		return result
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
-func deleteOracle(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) tx.Result {
+func deleteOracle(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) ter.Result {
 	od, err := state.ParseOracle(data)
 	if err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
-	if r := oracle.DeleteOracleFromView(ctx.View, ik, od, ctx.AccountID, nil); r != tx.TesSUCCESS {
-		return tx.TefBAD_LEDGER
+	if r := oracle.DeleteOracleFromView(ctx.View, ik, od, ctx.AccountID, nil); r != ter.TesSUCCESS {
+		return ter.TefBAD_LEDGER
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 func decrementOwnerCount(ctx *tx.ApplyContext) {

--- a/internal/tx/account/account_set.go
+++ b/internal/tx/account/account_set.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
@@ -152,7 +153,7 @@ func (a *AccountSet) Validate() error {
 	// Check for invalid transaction flags
 	// Reference: rippled SetAccount.cpp:71-75
 	if txFlags&AccountSetTxFlagMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid transaction flags")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid transaction flags")
 	}
 
 	// Cannot set and clear the same non-zero flag. SetFlag/ClearFlag of 0
@@ -166,7 +167,7 @@ func (a *AccountSet) Validate() error {
 		uClearFlag = *a.ClearFlag
 	}
 	if uSetFlag != 0 && uSetFlag == uClearFlag {
-		return tx.Errorf(tx.TemINVALID_FLAG, "cannot set and clear the same flag")
+		return ter.Errorf(ter.TemINVALID_FLAG, "cannot set and clear the same flag")
 	}
 
 	// Check for contradictory RequireAuth flags
@@ -176,7 +177,7 @@ func (a *AccountSet) Validate() error {
 	clearRequireAuth := (txFlags&AccountSetTxFlagOptionalAuth != 0) ||
 		(a.ClearFlag != nil && *a.ClearFlag == AccountSetFlagRequireAuth)
 	if setRequireAuth && clearRequireAuth {
-		return tx.Errorf(tx.TemINVALID_FLAG, "contradictory RequireAuth flags")
+		return ter.Errorf(ter.TemINVALID_FLAG, "contradictory RequireAuth flags")
 	}
 
 	// Check for contradictory RequireDest flags
@@ -186,7 +187,7 @@ func (a *AccountSet) Validate() error {
 	clearRequireDest := (txFlags&AccountSetTxFlagOptionalDestTag != 0) ||
 		(a.ClearFlag != nil && *a.ClearFlag == AccountSetFlagRequireDest)
 	if setRequireDest && clearRequireDest {
-		return tx.Errorf(tx.TemINVALID_FLAG, "contradictory RequireDest flags")
+		return ter.Errorf(ter.TemINVALID_FLAG, "contradictory RequireDest flags")
 	}
 
 	// Check for contradictory DisallowXRP flags
@@ -196,7 +197,7 @@ func (a *AccountSet) Validate() error {
 	clearDisallowXRP := (txFlags&AccountSetTxFlagAllowXRP != 0) ||
 		(a.ClearFlag != nil && *a.ClearFlag == AccountSetFlagDisallowXRP)
 	if setDisallowXRP && clearDisallowXRP {
-		return tx.Errorf(tx.TemINVALID_FLAG, "contradictory DisallowXRP flags")
+		return ter.Errorf(ter.TemINVALID_FLAG, "contradictory DisallowXRP flags")
 	}
 
 	// TransferRate validation
@@ -204,10 +205,10 @@ func (a *AccountSet) Validate() error {
 	if a.TransferRate != nil {
 		tr := *a.TransferRate
 		if tr != 0 && tr < protocol.TransferRateMin {
-			return tx.Errorf(tx.TemBAD_TRANSFER_RATE, "transfer rate too small")
+			return ter.Errorf(ter.TemBAD_TRANSFER_RATE, "transfer rate too small")
 		}
 		if tr > protocol.TransferRateMax {
-			return tx.Errorf(tx.TemBAD_TRANSFER_RATE, "transfer rate too large")
+			return ter.Errorf(ter.TemBAD_TRANSFER_RATE, "transfer rate too large")
 		}
 	}
 
@@ -216,7 +217,7 @@ func (a *AccountSet) Validate() error {
 	if a.TickSize != nil {
 		ts := *a.TickSize
 		if ts != 0 && (ts < protocol.TickSizeMin || ts > protocol.TickSizeMax) {
-			return tx.Errorf(tx.TemBAD_TICK_SIZE, "tick size must be 0 or 3-16")
+			return ter.Errorf(ter.TemBAD_TICK_SIZE, "tick size must be 0 or 3-16")
 		}
 	}
 
@@ -226,7 +227,7 @@ func (a *AccountSet) Validate() error {
 	if a.MessageKey != nil && *a.MessageKey != "" {
 		mkBytes, err := hex.DecodeString(*a.MessageKey)
 		if err != nil || !tx.IsValidPublicKey(mkBytes) {
-			return tx.Errorf(tx.TelBAD_PUBLIC_KEY, "invalid message key specified")
+			return ter.Errorf(ter.TelBAD_PUBLIC_KEY, "invalid message key specified")
 		}
 	}
 
@@ -234,7 +235,7 @@ func (a *AccountSet) Validate() error {
 	// Reference: rippled SetAccount.cpp:170-175
 	// Domain is stored as hex, so max hex length is 2*256 = 512
 	if a.Domain != nil && len(*a.Domain) > MaxDomainLength*2 {
-		return tx.Errorf(tx.TelBAD_DOMAIN, "domain too long")
+		return ter.Errorf(ter.TelBAD_DOMAIN, "domain too long")
 	}
 
 	return nil
@@ -246,14 +247,14 @@ func (a *AccountSet) Validate() error {
 // featureNonFungibleTokensV1, so callers invoke it only once that amendment is
 // enabled.
 // Reference: rippled SetAccount.cpp:177-187
-func (a *AccountSet) validateNFTokenMinter() tx.Result {
+func (a *AccountSet) validateNFTokenMinter() ter.Result {
 	if a.SetFlag != nil && *a.SetFlag == AccountSetFlagAuthorizedNFTokenMinter && a.NFTokenMinter == "" {
-		return tx.TemMALFORMED
+		return ter.TemMALFORMED
 	}
 	if a.ClearFlag != nil && *a.ClearFlag == AccountSetFlagAuthorizedNFTokenMinter && a.NFTokenMinter != "" {
-		return tx.TemMALFORMED
+		return ter.TemMALFORMED
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 func (a *AccountSet) Flatten() (map[string]any, error) {
@@ -278,7 +279,7 @@ func (a *AccountSet) EnableDefaultRipple() {
 	a.SetFlag = &flag
 }
 
-func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
+func (a *AccountSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("account set apply",
 		"account", a.Account,
 		"setFlag", a.SetFlag,
@@ -300,7 +301,7 @@ func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	// NFTokenMinter field presence is validated only once NonFungibleTokensV1 is
 	// enabled, mirroring rippled's amendment-gated preflight check.
 	if ctx.Rules().Enabled(amendment.FeatureNonFungibleTokensV1) {
-		if r := a.validateNFTokenMinter(); r != tx.TesSUCCESS {
+		if r := a.validateNFTokenMinter(); r != ter.TesSUCCESS {
 			return r
 		}
 	}
@@ -321,14 +322,14 @@ func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	if ctx.Rules().Enabled(amendment.FeatureClawback) {
 		if uSetFlag == AccountSetFlagAllowTrustLineClawback {
 			if uFlagsIn&state.LsfNoFreeze != 0 {
-				return tx.TecNO_PERMISSION
+				return ter.TecNO_PERMISSION
 			}
 			if !ownerDirIsEmpty(ctx.View, ctx.AccountID) {
-				return tx.TecOWNERS
+				return ter.TecOWNERS
 			}
 		}
 		if uSetFlag == AccountSetFlagNoFreeze && uFlagsIn&state.LsfAllowTrustLineClawback != 0 {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	}
 
@@ -342,7 +343,7 @@ func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	// (consensus) path in rippled.
 	if bSetRequireAuth && (uFlagsIn&state.LsfRequireAuth) == 0 {
 		if !ownerDirIsEmpty(ctx.View, ctx.AccountID) {
-			return tx.TecOWNERS
+			return ter.TecOWNERS
 		}
 		uFlagsOut |= state.LsfRequireAuth
 	}
@@ -372,14 +373,14 @@ func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Must use master key to disable master key.
 		// Reference: rippled SetAccount.cpp:404-408
 		if !ctx.SignedWithMaster {
-			return tx.TecNEED_MASTER_KEY
+			return ter.TecNEED_MASTER_KEY
 		}
 		// Account has no regular key or multi-signer signer list.
 		// Reference: rippled SetAccount.cpp:410-415
 		hasRegularKey := account.RegularKey != ""
 		hasSignerList, _ := ctx.View.Exists(keylet.SignerList(ctx.AccountID))
 		if !hasRegularKey && !hasSignerList {
-			return tx.TecNO_ALTERNATIVE_KEY
+			return ter.TecNO_ALTERNATIVE_KEY
 		}
 		uFlagsOut |= state.LsfDisableMaster
 	}
@@ -399,7 +400,7 @@ func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Must be signed with master key (unless master is already disabled)
 	if uSetFlag == AccountSetFlagNoFreeze {
 		if !ctx.SignedWithMaster && (uFlagsIn&state.LsfDisableMaster) == 0 {
-			return tx.TecNEED_MASTER_KEY
+			return ter.TecNEED_MASTER_KEY
 		}
 		uFlagsOut |= state.LsfNoFreeze
 	}
@@ -564,7 +565,7 @@ func (a *AccountSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		account.Flags = uFlagsOut
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // ownerDirIsEmpty reports whether the account's owner directory has no

--- a/internal/tx/account/account_set_test.go
+++ b/internal/tx/account/account_set_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // Helper function to create a uint32 pointer
@@ -392,10 +393,10 @@ func TestAccountSetNFTokenMinter(t *testing.T) {
 			}
 			got := accountSet.validateNFTokenMinter()
 			if tt.expectError {
-				if got != tx.TemMALFORMED {
+				if got != ter.TemMALFORMED {
 					t.Errorf("expected TemMALFORMED, got %v", got)
 				}
-			} else if got != tx.TesSUCCESS {
+			} else if got != ter.TesSUCCESS {
 				t.Errorf("expected TesSUCCESS, got %v", got)
 			}
 		})

--- a/internal/tx/amm/amm_bid.go
+++ b/internal/tx/amm/amm_bid.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -47,7 +48,7 @@ func (a *AMMBid) Validate() error {
 	}
 
 	if a.GetFlags()&tfAMMBidMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for AMMBid")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for AMMBid")
 	}
 
 	// Reference: rippled AMMBid.cpp preflight lines 48-53
@@ -74,7 +75,7 @@ func (a *AMMBid) Validate() error {
 	// amendment rules.
 	// Reference: rippled AMMBid.cpp preflight lines 73-96
 	if len(a.AuthAccounts) > auctionSlotMaxAuthAccounts {
-		return tx.Errorf(tx.TemMALFORMED, "cannot have more than 4 AuthAccounts")
+		return ter.Errorf(ter.TemMALFORMED, "cannot have more than 4 AuthAccounts")
 	}
 
 	return nil
@@ -91,15 +92,15 @@ func (a *AMMBid) RequiredAmendments() [][32]byte {
 // Preclaim validates the AMM, the bidder's LP holdings, and the bid bounds.
 // Reference: rippled AMMBid.cpp preclaim (plus the fixAMMv1_3-gated AuthAccounts
 // duplicate/self check that rippled performs in preflight).
-func (a *AMMBid) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Result {
+func (a *AMMBid) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Result {
 	amm, _, result := readAMM(view, a.Asset, a.Asset2)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 
 	lptAMMBalance := amm.LPTokenBalance
 	if lptAMMBalance.IsZero() {
-		return tx.TecAMM_EMPTY
+		return ter.TecAMM_EMPTY
 	}
 
 	// Reject duplicate or self-authorized AuthAccounts. This is a preflight check
@@ -111,7 +112,7 @@ func (a *AMMBid) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Result 
 		for _, authAcct := range a.AuthAccounts {
 			acct := authAcct.AuthAccount.Account
 			if acct == a.Common.Account || seen[acct] {
-				return tx.TemMALFORMED
+				return ter.TemMALFORMED
 			}
 			seen[acct] = true
 		}
@@ -121,49 +122,49 @@ func (a *AMMBid) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Result 
 	for _, authAcct := range a.AuthAccounts {
 		authAccountID, err := state.DecodeAccountID(authAcct.AuthAccount.Account)
 		if err != nil {
-			return tx.TerNO_ACCOUNT
+			return ter.TerNO_ACCOUNT
 		}
 		if exists, _ := view.Exists(keylet.Account(authAccountID)); !exists {
-			return tx.TerNO_ACCOUNT
+			return ter.TerNO_ACCOUNT
 		}
 	}
 
 	accountID, err := state.DecodeAccountID(a.Account)
 	if err != nil {
-		return tx.TecAMM_INVALID_TOKENS
+		return ter.TecAMM_INVALID_TOKENS
 	}
 	lpTokens := ammLPHolds(view, amm, accountID)
 	if lpTokens.IsZero() {
-		return tx.TecAMM_INVALID_TOKENS
+		return ter.TecAMM_INVALID_TOKENS
 	}
 
 	// BidMin / BidMax must be LP tokens, within the bidder's holdings and the
 	// pool, and ordered. Reference: rippled AMMBid.cpp preclaim lines 137-172
 	if a.BidMin != nil {
 		if a.BidMin.Currency != lpTokens.Currency || a.BidMin.Issuer != lpTokens.Issuer {
-			return tx.TemBAD_AMM_TOKENS
+			return ter.TemBAD_AMM_TOKENS
 		}
 		if isGreater(*a.BidMin, lpTokens) || isGreaterOrEqual(*a.BidMin, lptAMMBalance) {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 	}
 	if a.BidMax != nil {
 		if a.BidMax.Currency != lpTokens.Currency || a.BidMax.Issuer != lpTokens.Issuer {
-			return tx.TemBAD_AMM_TOKENS
+			return ter.TemBAD_AMM_TOKENS
 		}
 		if isGreater(*a.BidMax, lpTokens) || isGreaterOrEqual(*a.BidMax, lptAMMBalance) {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 	}
 	if a.BidMin != nil && a.BidMax != nil && isGreater(*a.BidMin, *a.BidMax) {
-		return tx.TecAMM_INVALID_TOKENS
+		return ter.TecAMM_INVALID_TOKENS
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // Reference: rippled AMMBid.cpp applyBid
-func (a *AMMBid) Apply(ctx *tx.ApplyContext) tx.Result {
+func (a *AMMBid) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("amm bid apply",
 		"account", a.Account,
 		"asset", a.Asset,
@@ -175,19 +176,19 @@ func (a *AMMBid) Apply(ctx *tx.ApplyContext) tx.Result {
 	accountID := ctx.AccountID
 
 	amm, ammKey, result := readAMM(ctx.View, a.Asset, a.Asset2)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 
 	lptAMMBalance := amm.LPTokenBalance
 	if lptAMMBalance.IsZero() {
-		return tx.TecAMM_EMPTY
+		return ter.TecAMM_EMPTY
 	}
 
 	// Reference: rippled AMMBid.cpp preclaim line 129
 	lpTokens := ammLPHolds(ctx.View, amm, accountID)
 	if lpTokens.IsZero() {
-		return tx.TecAMM_INVALID_TOKENS
+		return ter.TecAMM_INVALID_TOKENS
 	}
 
 	// Compare against lpTokens.issue(), matching rippled exactly:
@@ -221,7 +222,7 @@ func (a *AMMBid) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled AMMBid.cpp lines 192-203 — fixInnerObjTemplate enforcement
 	if amm.AuctionSlot == nil {
 		if ctx.Rules().Enabled(amendment.FeatureFixInnerObjTemplate) {
-			return tx.TefEXCEPTION
+			return ter.TefEXCEPTION
 		}
 		amm.AuctionSlot = &AuctionSlotData{
 			AuthAccounts: make([][20]byte, 0),
@@ -295,7 +296,7 @@ func (a *AMMBid) Apply(ctx *tx.ApplyContext) tx.Result {
 			payPrice = maxAmount(computedPrice, bidMin)
 		} else {
 			ctx.Log.Debug("amm bid: not in range", "computedPrice", computedPrice, "bidMin", bidMin, "bidMax", bidMax)
-			return tx.TecAMM_FAILED
+			return ter.TecAMM_FAILED
 		}
 	} else if hasBidMin {
 		payPrice = maxAmount(computedPrice, bidMin)
@@ -304,14 +305,14 @@ func (a *AMMBid) Apply(ctx *tx.ApplyContext) tx.Result {
 			payPrice = computedPrice
 		} else {
 			ctx.Log.Debug("amm bid: not in range", "computedPrice", computedPrice, "bidMax", bidMax)
-			return tx.TecAMM_FAILED
+			return ter.TecAMM_FAILED
 		}
 	} else {
 		payPrice = computedPrice
 	}
 
 	if isGreater(payPrice, lpTokens) {
-		return tx.TecAMM_INVALID_TOKENS
+		return ter.TecAMM_INVALID_TOKENS
 	}
 
 	// Reference: rippled AMMBid.cpp:345-367
@@ -323,7 +324,7 @@ func (a *AMMBid) Apply(ctx *tx.ApplyContext) tx.Result {
 		refund = fractionRemaining.Mul(pricePurchased, false)
 		if isGreater(refund, payPrice) {
 			ctx.Log.Error("amm bid: refund exceeds payPrice", "refund", refund, "payPrice", payPrice)
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		burn, _ = payPrice.Sub(refund)
 
@@ -332,7 +333,7 @@ func (a *AMMBid) Apply(ctx *tx.ApplyContext) tx.Result {
 		if !refund.IsZero() {
 			refundWithIssue := state.NewIssuedAmountFromValue(
 				refund.Mantissa(), refund.Exponent(), lptCurrency, lptIssuer)
-			if r := transferLPTokens(ctx.View, accountID, amm.AuctionSlot.Account, amm.Account, refundWithIssue); r != tx.TesSUCCESS {
+			if r := transferLPTokens(ctx.View, accountID, amm.AuctionSlot.Account, amm.Account, refundWithIssue); r != ter.TesSUCCESS {
 				return r
 			}
 		}
@@ -343,18 +344,18 @@ func (a *AMMBid) Apply(ctx *tx.ApplyContext) tx.Result {
 	saBurn := adjustLPTokens(lptAMMBalance, burn, false)
 	if isGreaterOrEqual(saBurn, lptAMMBalance) {
 		ctx.Log.Error("amm bid: LP token burn exceeds AMM balance", "burn", saBurn, "lptAMMBalance", lptAMMBalance)
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	if !saBurn.IsZero() {
 		burnWithIssue := state.NewIssuedAmountFromValue(
 			saBurn.Mantissa(), saBurn.Exponent(), lptCurrency, lptIssuer)
-		if r := redeemLPTokens(ctx.View, accountID, amm.Account, burnWithIssue); r != tx.TesSUCCESS {
+		if r := redeemLPTokens(ctx.View, accountID, amm.Account, burnWithIssue); r != ter.TesSUCCESS {
 			return r
 		}
 	}
 	newLPBalance, err := amm.LPTokenBalance.Sub(saBurn)
 	if err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	amm.LPTokenBalance = newLPBalance
 
@@ -377,21 +378,21 @@ func (a *AMMBid) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	ammBytes, err := serializeAMMData(amm)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(ammKey, ammBytes); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // redeemLPTokens debits an account's LP token trust line, sending tokens back to the AMM (issuer).
 // This is the LP token equivalent of rippled's redeemIOU().
 // Reference: rippled Ledger/View.cpp redeemIOU()
-func redeemLPTokens(view tx.LedgerView, accountID, ammAccountID [20]byte, amount tx.Amount) tx.Result {
+func redeemLPTokens(view tx.LedgerView, accountID, ammAccountID [20]byte, amount tx.Amount) ter.Result {
 	if amount.IsZero() {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	return adjustLPTrustLine(view, accountID, ammAccountID, amount, false)
 }
@@ -399,12 +400,12 @@ func redeemLPTokens(view tx.LedgerView, accountID, ammAccountID [20]byte, amount
 // transferLPTokens transfers LP tokens from one account to another via the AMM (issuer).
 // This debits the sender's trust line and credits the receiver's trust line.
 // Reference: rippled Ledger/View.cpp accountSend() → rippleCredit()
-func transferLPTokens(view tx.LedgerView, from, to, ammAccountID [20]byte, amount tx.Amount) tx.Result {
+func transferLPTokens(view tx.LedgerView, from, to, ammAccountID [20]byte, amount tx.Amount) ter.Result {
 	if amount.IsZero() || from == to {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	// Debit sender → AMM (issuer)
-	if r := adjustLPTrustLine(view, from, ammAccountID, amount, false); r != tx.TesSUCCESS {
+	if r := adjustLPTrustLine(view, from, ammAccountID, amount, false); r != ter.TesSUCCESS {
 		return r
 	}
 	// Credit AMM (issuer) → receiver
@@ -414,16 +415,16 @@ func transferLPTokens(view tx.LedgerView, from, to, ammAccountID [20]byte, amoun
 // adjustLPTrustLine modifies the LP token trust line balance between an account and the AMM.
 // If isCredit is true, the account's balance increases; if false, it decreases.
 // Reference: rippled Ledger/View.cpp rippleCredit()
-func adjustLPTrustLine(view tx.LedgerView, accountID, ammAccountID [20]byte, amount tx.Amount, isCredit bool) tx.Result {
+func adjustLPTrustLine(view tx.LedgerView, accountID, ammAccountID [20]byte, amount tx.Amount, isCredit bool) ter.Result {
 	trustLineKey := keylet.Line(accountID, ammAccountID, amount.Currency)
 	data, err := view.Read(trustLineKey)
 	if err != nil || data == nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	rs, err := state.ParseRippleState(data)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Determine if the LP account is the low account
@@ -451,7 +452,7 @@ func adjustLPTrustLine(view tx.LedgerView, accountID, ammAccountID [20]byte, amo
 		}
 	}
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	rs.Balance = state.NewIssuedAmountFromValue(
@@ -461,12 +462,12 @@ func adjustLPTrustLine(view tx.LedgerView, accountID, ammAccountID [20]byte, amo
 
 	rsBytes, err := state.SerializeRippleState(rs)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if err := view.Update(trustLineKey, rsBytes); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/amm/amm_clawback.go
+++ b/internal/tx/amm/amm_clawback.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -57,39 +58,39 @@ func (a *AMMClawback) Validate() error {
 	}
 
 	if a.GetFlags()&tfAMMClawbackMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for AMMClawback")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for AMMClawback")
 	}
 
 	// Reference: rippled AMMClawback.cpp preflight lines 52-57
 	if a.Holder == a.Common.Account {
-		return tx.Errorf(tx.TemMALFORMED, "Holder cannot be the same as issuer")
+		return ter.Errorf(ter.TemMALFORMED, "Holder cannot be the same as issuer")
 	}
 
 	// Reference: rippled AMMClawback.cpp preflight line 63
 	if isXRPAsset(a.Asset) {
-		return tx.Errorf(tx.TemMALFORMED, "Asset cannot be XRP")
+		return ter.Errorf(ter.TemMALFORMED, "Asset cannot be XRP")
 	}
 
 	// If tfClawTwoAssets is set, both assets must be issued by the same issuer
 	// Reference: rippled AMMClawback.cpp preflight lines 66-72
 	if a.GetFlags()&tfClawTwoAssets != 0 {
 		if a.Asset.Issuer != a.Asset2.Issuer {
-			return tx.Errorf(tx.TemINVALID_FLAG, "tfClawTwoAssets requires both assets to have the same issuer")
+			return ter.Errorf(ter.TemINVALID_FLAG, "tfClawTwoAssets requires both assets to have the same issuer")
 		}
 	}
 
 	// Reference: rippled AMMClawback.cpp preflight lines 74-79
 	if a.Asset.Issuer != a.Common.Account {
-		return tx.Errorf(tx.TemMALFORMED, "Asset issuer must match Account")
+		return ter.Errorf(ter.TemMALFORMED, "Asset issuer must match Account")
 	}
 
 	// Reference: rippled AMMClawback.cpp preflight lines 81-89
 	if a.Amount != nil {
 		if a.Amount.Currency != a.Asset.Currency || a.Amount.Issuer != a.Asset.Issuer {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "Amount issue must match Asset")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "Amount issue must match Asset")
 		}
 		if a.Amount.IsZero() || a.Amount.IsNegative() {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "Amount must be positive")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
 		}
 	}
 
@@ -107,34 +108,34 @@ func (a *AMMClawback) RequiredAmendments() [][32]byte {
 // Preclaim requires the holder and AMM to exist and the issuer to permit
 // clawback (lsfAllowTrustLineClawback set, lsfNoFreeze clear).
 // Reference: rippled AMMClawback.cpp preclaim
-func (a *AMMClawback) Preclaim(view tx.LedgerView, _ tx.EngineConfig) tx.Result {
+func (a *AMMClawback) Preclaim(view tx.LedgerView, _ tx.EngineConfig) ter.Result {
 	issuerData, err := view.Read(keylet.Account(getIssuerBytes(a.Common.Account)))
 	if err != nil || issuerData == nil {
 		return TerNO_ACCOUNT
 	}
 	issuer, err := state.ParseAccountRoot(issuerData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	holderID, err := state.DecodeAccountID(a.Holder)
 	if err != nil {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 	if exists, _ := view.Exists(keylet.Account(holderID)); !exists {
 		return TerNO_ACCOUNT
 	}
 
-	if _, _, result := readAMM(view, a.Asset, a.Asset2); result != tx.TesSUCCESS {
+	if _, _, result := readAMM(view, a.Asset, a.Asset2); result != ter.TesSUCCESS {
 		return result
 	}
 
 	if (issuer.Flags&state.LsfAllowTrustLineClawback) == 0 ||
 		(issuer.Flags&state.LsfNoFreeze) != 0 {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // Rippled flow: AMMClawback delegates to AMMWithdraw infrastructure which
@@ -144,7 +145,7 @@ func (a *AMMClawback) Preclaim(view tx.LedgerView, _ tx.EngineConfig) tx.Result 
 // For non-clawed asset2: AMM pool decreases, holder gains.
 //
 // Reference: rippled AMMClawback.cpp preclaim + applyGuts
-func (a *AMMClawback) Apply(ctx *tx.ApplyContext) tx.Result {
+func (a *AMMClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("amm clawback apply",
 		"account", a.Account,
 		"holder", a.Holder,
@@ -156,7 +157,7 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	holderID, err := state.DecodeAccountID(a.Holder)
 	if err != nil {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 	holderKey := keylet.Account(holderID)
 	holderData, err := ctx.View.Read(holderKey)
@@ -165,11 +166,11 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) tx.Result {
 	}
 	holderAccount, err := state.ParseAccountRoot(holderData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	loaded, result := loadAMM(ctx.View, a.Asset, a.Asset2, a.Asset)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 	amm := loaded.Data
@@ -186,23 +187,23 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) tx.Result {
 	if ctx.Rules().Enabled(amendment.FeatureFixAMMClawbackRounding) {
 		lpTokenBalance := ammLPHolds(ctx.View, amm, holderID)
 		if lpTokenBalance.IsZero() {
-			return tx.TecAMM_BALANCE
+			return ter.TecAMM_BALANCE
 		}
-		if result := verifyAndAdjustLPTokenBalance(ctx.View, lpTokenBalance, amm, holderID); result != tx.TesSUCCESS {
+		if result := verifyAndAdjustLPTokenBalance(ctx.View, lpTokenBalance, amm, holderID); result != ter.TesSUCCESS {
 			return result
 		}
 	}
 
 	lptAMMBalance := amm.LPTokenBalance
 	if lptAMMBalance.IsZero() {
-		return tx.TecAMM_BALANCE
+		return ter.TecAMM_BALANCE
 	}
 
 	// Get holder's LP token balance from trustline
 	// Reference: rippled AMMClawback.cpp applyGuts line 185
 	holdLPTokens := ammLPHolds(ctx.View, amm, holderID)
 	if holdLPTokens.IsZero() {
-		return tx.TecAMM_BALANCE
+		return ter.TecAMM_BALANCE
 	}
 
 	flags := a.GetFlags()
@@ -232,7 +233,7 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) tx.Result {
 		clawAmount := *a.Amount
 
 		if assetBalance1.IsZero() {
-			return tx.TecAMM_BALANCE
+			return ter.TecAMM_BALANCE
 		}
 		frac := numberDiv(toIOUForCalc(clawAmount), toIOUForCalc(assetBalance1))
 
@@ -255,7 +256,7 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) tx.Result {
 			if ctx.Rules().Enabled(amendment.FeatureFixAMMClawbackRounding) {
 				tokensAdj := getRoundedLPTokens(fixV1_3, lptAMMBalance, frac, false)
 				if tokensAdj.IsZero() {
-					return tx.TecAMM_INVALID_TOKENS
+					return ter.TecAMM_INVALID_TOKENS
 				}
 				frac = adjustFracByTokens(fixV1_3, lptAMMBalance, tokensAdj, frac)
 				amountRounded := getRoundedAsset(fixV1_3, assetBalance1, frac, false)
@@ -281,17 +282,17 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) tx.Result {
 	w2EqualsB2 := toIOUForCalc(withdrawAmount2).Compare(toIOUForCalc(assetBalance2)) == 0
 	// Cannot withdraw one side of the pool while leaving the other.
 	if (w1EqualsB1 && !w2EqualsB2) || (w2EqualsB2 && !w1EqualsB1) {
-		return tx.TecAMM_BALANCE
+		return ter.TecAMM_BALANCE
 	}
 	// Withdrawing all LP tokens must drain both sides exactly.
 	if toIOUForCalc(lpTokensToWithdraw).Compare(toIOUForCalc(lptAMMBalance)) == 0 &&
 		(!w1EqualsB1 || !w2EqualsB2) {
-		return tx.TecAMM_BALANCE
+		return ter.TecAMM_BALANCE
 	}
 	// Cannot withdraw more than the pool holds.
 	if isGreater(toIOUForCalc(withdrawAmount1), toIOUForCalc(assetBalance1)) ||
 		isGreater(toIOUForCalc(withdrawAmount2), toIOUForCalc(assetBalance2)) {
-		return tx.TecAMM_BALANCE
+		return ter.TecAMM_BALANCE
 	}
 
 	// Rippled flow per asset:
@@ -312,7 +313,7 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Asset1 cannot be XRP (enforced in preflight).
 	if !isXRP1 && !withdrawAmount1.IsZero() {
 		if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset, withdrawAmount1.Negate(), ctx.View); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
@@ -321,7 +322,7 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Clawback asset2 too. Same net effect as asset1.
 		if !isXRP2 && !withdrawAmount2.IsZero() {
 			if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset2, withdrawAmount2.Negate(), ctx.View); err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 		} else if isXRP2 && !withdrawAmount2.IsZero() {
 			// XRP clawback: AMM loses XRP, issuer gains
@@ -334,7 +335,7 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Transfer from AMM to holder.
 		if !isXRP2 && !withdrawAmount2.IsZero() {
 			if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset2, withdrawAmount2.Negate(), ctx.View); err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			// Credit holder's trust line with asset2 issuer — BUT skip if
 			// holder IS the issuer (the IOU is just returned/destroyed).
@@ -343,7 +344,7 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) tx.Result {
 			issuer2ID, _ := state.DecodeAccountID(a.Asset2.Issuer)
 			if holderID != issuer2ID {
 				if err := updateTrustlineBalanceInView(holderID, issuer2ID, a.Asset2.Currency, withdrawAmount2, ctx.View); err != nil {
-					return tx.TefINTERNAL
+					return ter.TefINTERNAL
 				}
 			}
 		} else if isXRP2 && !withdrawAmount2.IsZero() {
@@ -361,40 +362,40 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) tx.Result {
 		ammAccountAddr, _ := state.EncodeAccountID(amm.Account)
 		redeemAmt := state.NewIssuedAmountFromValue(
 			lpTokensToWithdraw.Mantissa(), lpTokensToWithdraw.Exponent(), lptCurrency, ammAccountAddr)
-		if r := redeemIOUWithCleanup(ctx.View, holderID, amm.Account, redeemAmt); r != tx.TesSUCCESS {
+		if r := redeemIOUWithCleanup(ctx.View, holderID, amm.Account, redeemAmt); r != ter.TesSUCCESS {
 			return r
 		}
 	}
 
 	newLPBalance, err := lptAMMBalance.Sub(lpTokensToWithdraw)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	deleteResult := deleteAMMAccountIfEmpty(ctx.View, ammKey, ammAccountKey,
 		newLPBalance, a.Asset, a.Asset2, amm, ammAccount)
-	if deleteResult != tx.TesSUCCESS && deleteResult != tx.TecINCOMPLETE {
+	if deleteResult != ter.TesSUCCESS && deleteResult != ter.TecINCOMPLETE {
 		return deleteResult
 	}
 
 	// Persist updated AMM account XRP balance if AMM still exists
-	if !newLPBalance.IsZero() || deleteResult == tx.TecINCOMPLETE {
+	if !newLPBalance.IsZero() || deleteResult == ter.TecINCOMPLETE {
 		ammAccountBytes, err := state.SerializeAccountRoot(ammAccount)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := ctx.View.Update(ammAccountKey, ammAccountBytes); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
 	accountKey := keylet.Account(issuerID)
 	accountBytes, err := state.SerializeAccountRoot(ctx.Account)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(accountKey, accountBytes); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Re-read holder account from view — redeemIOUWithCleanup may have
@@ -403,22 +404,22 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) tx.Result {
 	// redeemIOUWithCleanup wrote.
 	holderData2, err := ctx.View.Read(holderKey)
 	if err != nil || holderData2 == nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	holderAccount2, err := state.ParseAccountRoot(holderData2)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	// Apply any XRP balance change from our local holderAccount to the
 	// version that redeemIOUWithCleanup persisted.
 	holderAccount2.Balance = holderAccount.Balance
 	holderBytes, err := state.SerializeAccountRoot(holderAccount2)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(holderKey, holderBytes); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/amm/amm_create.go
+++ b/internal/tx/amm/amm_create.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -54,12 +55,12 @@ func (a *AMMCreate) Validate() error {
 	}
 
 	if a.GetFlags()&tfAMMCreateMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for AMMCreate")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for AMMCreate")
 	}
 
 	// Reference: rippled AMMCreate.cpp line 52-57
 	if a.Amount.Currency == a.Amount2.Currency && a.Amount.Issuer == a.Amount2.Issuer {
-		return tx.Errorf(tx.TemBAD_AMM_TOKENS, "tokens can not have the same currency/issuer")
+		return ter.Errorf(ter.TemBAD_AMM_TOKENS, "tokens can not have the same currency/issuer")
 	}
 
 	// Validate amounts using invalidAMMAmount logic. The error code
@@ -74,7 +75,7 @@ func (a *AMMCreate) Validate() error {
 
 	// TradingFee must be 0-1000 (0-1%)
 	if a.TradingFee > tradingFeeThreshold {
-		return tx.Errorf(tx.TemBAD_FEE, "TradingFee must be 0-1000")
+		return ter.Errorf(ter.TemBAD_FEE, "TradingFee must be 0-1000")
 	}
 
 	return nil
@@ -100,13 +101,13 @@ func (a *AMMCreate) RequiredAmendments() [][32]byte {
 // pseudo-account collision (featureSingleAssetVault), and the clawback gate.
 // The view's source-account balance is already the pre-fee balance.
 // Reference: rippled AMMCreate.cpp preclaim
-func (a *AMMCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Result {
+func (a *AMMCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Result {
 	accountID, err := state.DecodeAccountID(a.Account)
 	if err != nil {
-		return tx.TemBAD_SRC_ACCOUNT
+		return ter.TemBAD_SRC_ACCOUNT
 	}
 	account, result := readAccount(view, accountID)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -116,25 +117,25 @@ func (a *AMMCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Resu
 	// Reference: rippled AMMCreate.cpp line 95-100
 	ammKey := computeAMMKeylet(asset1, asset2)
 	if exists, _ := view.Exists(ammKey); exists {
-		return tx.TecDUPLICATE
+		return ter.TecDUPLICATE
 	}
 
 	// Reference: rippled AMMCreate.cpp line 102-116
-	if result := tx.RequireAuth(view, asset1, accountID); result != tx.TesSUCCESS {
+	if result := tx.RequireAuth(view, asset1, accountID); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := tx.RequireAuth(view, asset2, accountID); result != tx.TesSUCCESS {
+	if result := tx.RequireAuth(view, asset2, accountID); result != ter.TesSUCCESS {
 		return result
 	}
 
 	// Reference: rippled AMMCreate.cpp line 119-124
 	if tx.IsFrozen(view, accountID, asset1) || tx.IsFrozen(view, accountID, asset2) {
-		return tx.TecFROZEN
+		return ter.TecFROZEN
 	}
 
 	// Reference: rippled AMMCreate.cpp line 126-142
 	if noDefaultRipple(view, asset1) || noDefaultRipple(view, asset2) {
-		return tx.TerNO_RIPPLE
+		return ter.TerNO_RIPPLE
 	}
 
 	// Check reserve for the LP token trustline, then sufficient funding for both
@@ -152,7 +153,7 @@ func (a *AMMCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Resu
 
 	// Reference: rippled AMMCreate.cpp line 172-184
 	if isLPToken(view, a.Amount) || isLPToken(view, a.Amount2) {
-		return tx.TecAMM_INVALID_TOKENS
+		return ter.TecAMM_INVALID_TOKENS
 	}
 
 	// Check for pseudo-account collision with featureSingleAssetVault. This
@@ -162,26 +163,26 @@ func (a *AMMCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Resu
 	// Reference: rippled AMMCreate.cpp preclaim lines 186-192
 	if config.GetRules().Enabled(amendment.FeatureSingleAssetVault) {
 		if pseudoAccountAddress(view, config.ParentHash, ammKey.Key) == ([20]byte{}) {
-			return tx.TerADDRESS_COLLISION
+			return ter.TerADDRESS_COLLISION
 		}
 	}
 
 	// Check clawback - if featureAMMClawback is not enabled, reject clawback-enabled issuers.
 	// Reference: rippled AMMCreate.cpp preclaim lines 194-214
 	if !config.GetRules().Enabled(amendment.FeatureAMMClawback) {
-		if result := clawbackDisabled(view, asset1); result != tx.TesSUCCESS {
+		if result := clawbackDisabled(view, asset1); result != ter.TesSUCCESS {
 			return result
 		}
-		if result := clawbackDisabled(view, asset2); result != tx.TesSUCCESS {
+		if result := clawbackDisabled(view, asset2); result != ter.TesSUCCESS {
 			return result
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // Reference: rippled AMMCreate.cpp applyCreate
-func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
+func (a *AMMCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("amm create apply",
 		"account", a.Account,
 		"amount", a.Amount,
@@ -200,7 +201,7 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled View.cpp createPseudoAccount → pseudoAccountAddress
 	ammAccountID := pseudoAccountAddress(ctx.View, ctx.Config.ParentHash, ammKey.Key)
 	if ammAccountID == ([20]byte{}) {
-		return tx.TecDUPLICATE
+		return ter.TecDUPLICATE
 	}
 	ammAccountAddr, _ := encodeAccountID(ammAccountID)
 
@@ -208,7 +209,7 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	ammAccountKey := keylet.Account(ammAccountID)
 	acctExists, _ := ctx.View.Exists(ammAccountKey)
 	if acctExists {
-		return tx.TecDUPLICATE
+		return ter.TecDUPLICATE
 	}
 
 	// Reference: rippled AMMCreate.cpp line 262-264
@@ -221,7 +222,7 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	lptKey := keylet.Line(accountID, lptIssuerID, lptCurrency)
 	lptExists, _ := ctx.View.Exists(lptKey)
 	if lptExists {
-		return tx.TecDUPLICATE
+		return ter.TecDUPLICATE
 	}
 
 	// Initial LP token balance: sqrt(amount1 * amount2).
@@ -229,7 +230,7 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	fixV1_3 := ctx.Rules().Enabled(amendment.FeatureFixAMMv1_3)
 	lpTokenBalanceRaw := calculateLPTokens(sortedAmount1, sortedAmount2, fixV1_3)
 	if lpTokenBalanceRaw.IsZero() {
-		return tx.TecAMM_BALANCE
+		return ter.TecAMM_BALANCE
 	}
 	// Set the correct issue (currency + issuer) on the LP token balance.
 	// The LP token currency is derived from the asset pair and the issuer
@@ -307,11 +308,11 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	ammAccountBytes, err := state.SerializeAccountRoot(ammAccount)
 	if err != nil {
 		ctx.Log.Error("amm create: failed to create pseudo account")
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Insert(ammAccountKey, ammAccountBytes); err != nil {
 		ctx.Log.Error("amm create: failed to insert pseudo account")
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Link the AMM entry into the AMM pseudo-account's owner directory and
@@ -324,16 +325,16 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		dir.Owner = ammAccountID
 	})
 	if err != nil {
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 	ammData.OwnerNode = dirResult.Page
 
 	ammBytes, err := serializeAMMData(ammData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Insert(ammKey, ammBytes); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Reference: rippled AMMCreate.cpp line 278-283
@@ -363,7 +364,7 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 			return TecNO_LINE
 		}
 		if err := setAMMNodeFlag(ammAccountID, sortedAsset1, ctx.View); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		// Debit from creator's trustline (skip if creator is the issuer —
 		// issuers have unlimited supply and no self-trust-line).
@@ -391,7 +392,7 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 			return TecNO_LINE
 		}
 		if err := setAMMNodeFlag(ammAccountID, sortedAsset2, ctx.View); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		issuerID2, _ := state.DecodeAccountID(sortedAsset2.Issuer)
 		if accountID != issuerID2 {
@@ -418,18 +419,18 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	accountKey := keylet.Account(accountID)
 	accountBytes, err := state.SerializeAccountRoot(ctx.Account)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(accountKey, accountBytes); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	ammAccountBytes, err = state.SerializeAccountRoot(ammAccount)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(ammAccountKey, ammAccountBytes); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	ctx.Log.Debug("amm create: success",
@@ -439,7 +440,7 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		"amount2", sortedAmount2,
 	)
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // sortAssets returns assets and amounts in canonical order, mirroring rippled's

--- a/internal/tx/amm/amm_delete.go
+++ b/internal/tx/amm/amm_delete.go
@@ -3,6 +3,7 @@ package amm
 import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // AMMDelete deletes an empty AMM.
@@ -39,7 +40,7 @@ func (a *AMMDelete) Validate() error {
 	// nothing else here; a missing/invalid asset pair surfaces as terNO_AMM when
 	// the AMM lookup fails in preclaim.
 	if a.GetFlags()&tfAMMDeleteMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for AMMDelete")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for AMMDelete")
 	}
 
 	return nil
@@ -55,19 +56,19 @@ func (a *AMMDelete) RequiredAmendments() [][32]byte {
 
 // Preclaim requires the AMM to exist and be empty.
 // Reference: rippled AMMDelete.cpp preclaim
-func (a *AMMDelete) Preclaim(view tx.LedgerView, _ tx.EngineConfig) tx.Result {
+func (a *AMMDelete) Preclaim(view tx.LedgerView, _ tx.EngineConfig) ter.Result {
 	amm, _, result := readAMM(view, a.Asset, a.Asset2)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 	if !amm.LPTokenBalance.IsZero() {
-		return tx.TecAMM_NOT_EMPTY
+		return ter.TecAMM_NOT_EMPTY
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // Reference: rippled AMMDelete.cpp doApply
-func (a *AMMDelete) Apply(ctx *tx.ApplyContext) tx.Result {
+func (a *AMMDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("amm delete apply",
 		"account", a.Account,
 		"asset", a.Asset,

--- a/internal/tx/amm/amm_delete_account.go
+++ b/internal/tx/amm/amm_delete_account.go
@@ -3,6 +3,7 @@ package amm
 import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -16,31 +17,31 @@ const maxDeletableAMMTrustLines = 512
 // It removes the trust line from both accounts' owner directories, erases it,
 // and decrements the non-AMM account's OwnerCount.
 // Reference: rippled View.cpp deleteAMMTrustLine (line 2720)
-func deleteAMMTrustLine(view tx.LedgerView, lineKey keylet.Keylet, rs *state.RippleState, ammAccountID [20]byte) tx.Result {
+func deleteAMMTrustLine(view tx.LedgerView, lineKey keylet.Keylet, rs *state.RippleState, ammAccountID [20]byte) ter.Result {
 	lowAccountID, err := state.DecodeAccountID(rs.LowLimit.Issuer)
 	if err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	highAccountID, err := state.DecodeAccountID(rs.HighLimit.Issuer)
 	if err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	lowAccountData, err := view.Read(keylet.Account(lowAccountID))
 	if err != nil || lowAccountData == nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	lowAccount, err := state.ParseAccountRoot(lowAccountData)
 	if err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	highAccountData, err := view.Read(keylet.Account(highAccountID))
 	if err != nil || highAccountData == nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	highAccount, err := state.ParseAccountRoot(highAccountData)
 	if err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	zeroHash := [32]byte{}
@@ -49,19 +50,19 @@ func deleteAMMTrustLine(view tx.LedgerView, lineKey keylet.Keylet, rs *state.Rip
 
 	// Can't both be AMM
 	if ammLow && ammHigh {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	// At least one must be AMM
 	if !ammLow && !ammHigh {
-		return tx.TerNO_AMM
+		return ter.TerNO_AMM
 	}
 	// One must be the target AMM
 	if lowAccountID != ammAccountID && highAccountID != ammAccountID {
-		return tx.TerNO_AMM
+		return ter.TerNO_AMM
 	}
 
 	if trustDelete(view, lineKey, lowAccountID, highAccountID, rs.LowNode, rs.HighNode) != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 
 	// Decrement OwnerCount for each non-AMM side that has a reserve flag set.
@@ -77,10 +78,10 @@ func deleteAMMTrustLine(view tx.LedgerView, lineKey keylet.Keylet, rs *state.Rip
 		}
 		lowBytes, err := state.SerializeAccountRoot(lowAccount)
 		if err != nil {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 		if err := view.Update(keylet.Account(lowAccountID), lowBytes); err != nil {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 	}
 	if rs.Flags&state.LsfHighReserve != 0 && !ammHigh {
@@ -89,31 +90,31 @@ func deleteAMMTrustLine(view tx.LedgerView, lineKey keylet.Keylet, rs *state.Rip
 		}
 		highBytes, err := state.SerializeAccountRoot(highAccount)
 		if err != nil {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 		if err := view.Update(keylet.Account(highAccountID), highBytes); err != nil {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // deleteAMMTrustLines iterates the AMM account's owner directory and deletes
 // trust lines up to maxTrustlinesToDelete. If more trust lines remain, returns
 // tecINCOMPLETE. Skips AMM entries (ltAMM type).
 // Reference: rippled AMMUtils.cpp deleteAMMTrustLines (line 237)
-func deleteAMMTrustLines(view tx.LedgerView, ammAccountID [20]byte, maxTrustlinesToDelete int) tx.Result {
+func deleteAMMTrustLines(view tx.LedgerView, ammAccountID [20]byte, maxTrustlinesToDelete int) ter.Result {
 	ownerDirKey := keylet.OwnerDir(ammAccountID)
 
 	rootData, err := view.Read(ownerDirKey)
 	if err != nil || rootData == nil {
-		return tx.TesSUCCESS // No directory = nothing to delete
+		return ter.TesSUCCESS // No directory = nothing to delete
 	}
 
 	root, err := state.ParseDirectoryNode(rootData)
 	if err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	deleted := 0
@@ -129,7 +130,7 @@ func deleteAMMTrustLines(view tx.LedgerView, ammAccountID [20]byte, maxTrustline
 			if maxTrustlinesToDelete > 0 {
 				deleted++
 				if deleted > maxTrustlinesToDelete {
-					return tx.TecINCOMPLETE
+					return ter.TecINCOMPLETE
 				}
 			}
 
@@ -138,12 +139,12 @@ func deleteAMMTrustLines(view tx.LedgerView, ammAccountID [20]byte, maxTrustline
 
 			itemData, err := view.Read(itemKeylet)
 			if err != nil || itemData == nil {
-				return tx.TefBAD_LEDGER
+				return ter.TefBAD_LEDGER
 			}
 
 			entryType, err := state.GetLedgerEntryType(itemData)
 			if err != nil {
-				return tx.TecINTERNAL
+				return ter.TecINTERNAL
 			}
 
 			// Skip the AMM SLE that coexists with the trust lines in this dir.
@@ -153,19 +154,19 @@ func deleteAMMTrustLines(view tx.LedgerView, ammAccountID [20]byte, maxTrustline
 			}
 
 			if entry.Type(entryType) != entry.TypeRippleState {
-				return tx.TecINTERNAL
+				return ter.TecINTERNAL
 			}
 
 			rs, err := state.ParseRippleState(itemData)
 			if err != nil {
-				return tx.TecINTERNAL
+				return ter.TecINTERNAL
 			}
 			if !rs.Balance.IsZero() {
-				return tx.TecINTERNAL
+				return ter.TecINTERNAL
 			}
 
 			result := deleteAMMTrustLine(view, itemKeylet, rs, ammAccountID)
-			if result != tx.TesSUCCESS {
+			if result != ter.TesSUCCESS {
 				return result
 			}
 
@@ -180,7 +181,7 @@ func deleteAMMTrustLines(view tx.LedgerView, ammAccountID [20]byte, maxTrustline
 			}
 			currentPage, err = state.ParseDirectoryNode(pageData)
 			if err != nil {
-				return tx.TecINTERNAL
+				return ter.TecINTERNAL
 			}
 		}
 
@@ -200,11 +201,11 @@ func deleteAMMTrustLines(view tx.LedgerView, ammAccountID [20]byte, maxTrustline
 		}
 		currentPage, err = state.ParseDirectoryNode(pageData)
 		if err != nil {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // DeleteAMMAccount performs full cleanup of an AMM account:
@@ -213,16 +214,16 @@ func deleteAMMTrustLines(view tx.LedgerView, ammAccountID [20]byte, maxTrustline
 // 3. Deletes empty owner directory
 // 4. Erases AMM SLE and account root
 // Reference: rippled AMMUtils.cpp deleteAMMAccount (line 283)
-func DeleteAMMAccount(view tx.LedgerView, asset, asset2 tx.Asset) tx.Result {
+func DeleteAMMAccount(view tx.LedgerView, asset, asset2 tx.Asset) ter.Result {
 	ammKey := computeAMMKeylet(asset, asset2)
 	ammRawData, err := view.Read(ammKey)
 	if err != nil || ammRawData == nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	amm, err := parseAMMData(ammRawData)
 	if err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	ammAccountID := amm.Account
@@ -230,10 +231,10 @@ func DeleteAMMAccount(view tx.LedgerView, asset, asset2 tx.Asset) tx.Result {
 	ammAccountKey := keylet.Account(ammAccountID)
 	ammAccountData, err := view.Read(ammAccountKey)
 	if err != nil || ammAccountData == nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
-	if result := deleteAMMTrustLines(view, ammAccountID, maxDeletableAMMTrustLines); result != tx.TesSUCCESS {
+	if result := deleteAMMTrustLines(view, ammAccountID, maxDeletableAMMTrustLines); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -254,13 +255,13 @@ func DeleteAMMAccount(view tx.LedgerView, asset, asset2 tx.Asset) tx.Result {
 	}
 
 	if err := view.Erase(ammKey); err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	if err := view.Erase(ammAccountKey); err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // deleteAMMAccountIfEmpty is called from AMMWithdraw when LP tokens reach zero.
@@ -269,50 +270,50 @@ func DeleteAMMAccount(view tx.LedgerView, asset, asset2 tx.Asset) tx.Result {
 // and requires AMMDelete to finish cleanup.
 // Reference: rippled AMMWithdraw.cpp deleteAMMAccountIfEmpty (line 718)
 func deleteAMMAccountIfEmpty(view tx.LedgerView, ammKey keylet.Keylet, ammAccountKey keylet.Keylet,
-	lpTokenBalance tx.Amount, asset, asset2 tx.Asset, amm *AMMData, ammAccount *state.AccountRoot) tx.Result {
+	lpTokenBalance tx.Amount, asset, asset2 tx.Asset, amm *AMMData, ammAccount *state.AccountRoot) ter.Result {
 	if !lpTokenBalance.IsZero() {
 		// Not empty, just update the AMM
 		amm.LPTokenBalance = lpTokenBalance
 		ammBytes, err := serializeAMMData(amm)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := view.Update(ammKey, ammBytes); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		ammAccountBytes, err := state.SerializeAccountRoot(ammAccount)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := view.Update(ammAccountKey, ammAccountBytes); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// LP tokens are zero — try to delete the AMM account
 	result := DeleteAMMAccount(view, asset, asset2)
-	if result != tx.TesSUCCESS && result != tx.TecINCOMPLETE {
+	if result != ter.TesSUCCESS && result != ter.TecINCOMPLETE {
 		return result
 	}
 
-	if result == tx.TecINCOMPLETE {
+	if result == ter.TecINCOMPLETE {
 		// Too many trust lines to delete in one tx. Set LPTokenBalance=0 but
 		// keep the AMM entry so AMMDelete can finish cleanup.
 		amm.LPTokenBalance = lpTokenBalance // zero
 		ammBytes, err := serializeAMMData(amm)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := view.Update(ammKey, ammBytes); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		ammAccountBytes, err := state.SerializeAccountRoot(ammAccount)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := view.Update(ammAccountKey, ammAccountBytes); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 

--- a/internal/tx/amm/amm_deposit.go
+++ b/internal/tx/amm/amm_deposit.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -69,7 +70,7 @@ func (a *AMMDeposit) Validate() error {
 
 	// Reference: rippled AMMDeposit.cpp line 42-46
 	if flags&tfAMMDepositMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for AMMDeposit")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for AMMDeposit")
 	}
 
 	// Exactly one deposit mode flag must be set.
@@ -80,7 +81,7 @@ func (a *AMMDeposit) Validate() error {
 		flagCount++
 	}
 	if flagCount != 1 {
-		return tx.Errorf(tx.TemMALFORMED, "must specify exactly one deposit mode flag")
+		return ter.Errorf(ter.TemMALFORMED, "must specify exactly one deposit mode flag")
 	}
 
 	// Reference: rippled AMMDeposit.cpp lines 65-98
@@ -93,32 +94,32 @@ func (a *AMMDeposit) Validate() error {
 	if flags&tfLPToken != 0 {
 		// tfLPToken: LPTokenOut required, [Amount, Amount2] optional but must be both or neither, no EPrice, no TradingFee
 		if !hasLPTokens || hasEPrice || (hasAmount && !hasAmount2) || (!hasAmount && hasAmount2) || hasTradingFee {
-			return tx.Errorf(tx.TemMALFORMED, "tfLPToken requires LPTokenOut, optional Amount+Amount2 pair")
+			return ter.Errorf(ter.TemMALFORMED, "tfLPToken requires LPTokenOut, optional Amount+Amount2 pair")
 		}
 	} else if flags&tfSingleAsset != 0 {
 		// tfSingleAsset: Amount required, no Amount2, no EPrice, no TradingFee
 		if !hasAmount || hasAmount2 || hasEPrice || hasTradingFee {
-			return tx.Errorf(tx.TemMALFORMED, "tfSingleAsset requires Amount only")
+			return ter.Errorf(ter.TemMALFORMED, "tfSingleAsset requires Amount only")
 		}
 	} else if flags&tfTwoAsset != 0 {
 		// tfTwoAsset: Amount and Amount2 required, no EPrice, no TradingFee
 		if !hasAmount || !hasAmount2 || hasEPrice || hasTradingFee {
-			return tx.Errorf(tx.TemMALFORMED, "tfTwoAsset requires Amount and Amount2")
+			return ter.Errorf(ter.TemMALFORMED, "tfTwoAsset requires Amount and Amount2")
 		}
 	} else if flags&tfOneAssetLPToken != 0 {
 		// tfOneAssetLPToken: Amount and LPTokenOut required, no Amount2, no EPrice, no TradingFee
 		if !hasAmount || !hasLPTokens || hasAmount2 || hasEPrice || hasTradingFee {
-			return tx.Errorf(tx.TemMALFORMED, "tfOneAssetLPToken requires Amount and LPTokenOut")
+			return ter.Errorf(ter.TemMALFORMED, "tfOneAssetLPToken requires Amount and LPTokenOut")
 		}
 	} else if flags&tfLimitLPToken != 0 {
 		// tfLimitLPToken: Amount and EPrice required, no LPTokens, no Amount2, no TradingFee
 		if !hasAmount || !hasEPrice || hasLPTokens || hasAmount2 || hasTradingFee {
-			return tx.Errorf(tx.TemMALFORMED, "tfLimitLPToken requires Amount and EPrice")
+			return ter.Errorf(ter.TemMALFORMED, "tfLimitLPToken requires Amount and EPrice")
 		}
 	} else if flags&tfTwoAssetIfEmpty != 0 {
 		// tfTwoAssetIfEmpty: Amount and Amount2 required, no EPrice, no LPTokens
 		if !hasAmount || !hasAmount2 || hasEPrice || hasLPTokens {
-			return tx.Errorf(tx.TemMALFORMED, "tfTwoAssetIfEmpty requires Amount and Amount2")
+			return ter.Errorf(ter.TemMALFORMED, "tfTwoAssetIfEmpty requires Amount and Amount2")
 		}
 	}
 
@@ -130,14 +131,14 @@ func (a *AMMDeposit) Validate() error {
 	// Reference: rippled AMMDeposit.cpp lines 108-113
 	if hasAmount && hasAmount2 {
 		if a.Amount.Currency == a.Amount2.Currency && a.Amount.Issuer == a.Amount2.Issuer {
-			return tx.Errorf(tx.TemBAD_AMM_TOKENS, "Amount and Amount2 have same issue")
+			return ter.Errorf(ter.TemBAD_AMM_TOKENS, "Amount and Amount2 have same issue")
 		}
 	}
 
 	// Reference: rippled AMMDeposit.cpp lines 115-119
 	if hasLPTokens {
 		if a.LPTokenOut.IsZero() || a.LPTokenOut.IsNegative() {
-			return tx.Errorf(tx.TemBAD_AMM_TOKENS, "invalid LPTokens")
+			return ter.Errorf(ter.TemBAD_AMM_TOKENS, "invalid LPTokens")
 		}
 	}
 
@@ -164,7 +165,7 @@ func (a *AMMDeposit) Validate() error {
 
 	// Reference: rippled AMMDeposit.cpp lines 156-160
 	if a.TradingFee > tradingFeeThreshold {
-		return tx.Errorf(tx.TemBAD_FEE, "TradingFee must be 0-1000")
+		return ter.Errorf(ter.TemBAD_FEE, "TradingFee must be 0-1000")
 	}
 
 	return nil
@@ -183,18 +184,18 @@ func (a *AMMDeposit) RequiredAmendments() [][32]byte {
 // funding (including the LP-token-trustline reserve), and the LPTokenOut issue.
 // The view's source-account balance is already the pre-fee balance.
 // Reference: rippled AMMDeposit.cpp preclaim
-func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Result {
+func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Result {
 	accountID, err := state.DecodeAccountID(a.Account)
 	if err != nil {
-		return tx.TemBAD_SRC_ACCOUNT
+		return ter.TemBAD_SRC_ACCOUNT
 	}
 	account, result := readAccount(view, accountID)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 
 	amm, _, result := readAMM(view, a.Asset, a.Asset2)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 	ammAccountID := amm.Account
@@ -208,19 +209,19 @@ func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Res
 
 	if flags&tfTwoAssetIfEmpty != 0 {
 		if !lptBalance.IsZero() {
-			return tx.TecAMM_NOT_EMPTY
+			return ter.TecAMM_NOT_EMPTY
 		}
 		if !assetBalance1.IsZero() || !assetBalance2.IsZero() {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 	} else {
 		if lptBalance.IsZero() {
-			return tx.TecAMM_EMPTY
+			return ter.TecAMM_EMPTY
 		}
 		if assetBalance1.IsZero() || assetBalance1.IsNegative() ||
 			assetBalance2.IsZero() || assetBalance2.IsNegative() ||
 			lptBalance.IsNegative() {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 	}
 
@@ -232,30 +233,30 @@ func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Res
 	// AMMClawback is enabled.
 	// Reference: rippled AMMDeposit.cpp lines 244-273
 	if config.GetRules().Enabled(amendment.FeatureAMMClawback) {
-		if result := tx.RequireAuth(view, a.Asset, accountID); result != tx.TesSUCCESS {
+		if result := tx.RequireAuth(view, a.Asset, accountID); result != ter.TesSUCCESS {
 			return result
 		}
-		if result := tx.RequireAuth(view, a.Asset2, accountID); result != tx.TesSUCCESS {
+		if result := tx.RequireAuth(view, a.Asset2, accountID); result != ter.TesSUCCESS {
 			return result
 		}
 		if tx.IsFrozen(view, accountID, a.Asset) || tx.IsFrozen(view, accountID, a.Asset2) {
-			return tx.TecFROZEN
+			return ter.TecFROZEN
 		}
 	}
 
-	checkAmount := func(amt *tx.Amount, checkBalance bool) tx.Result {
+	checkAmount := func(amt *tx.Amount, checkBalance bool) ter.Result {
 		if amt == nil {
-			return tx.TesSUCCESS
+			return ter.TesSUCCESS
 		}
 		amtAsset := tx.Asset{Currency: amt.Currency, Issuer: amt.Issuer}
-		if result := tx.RequireAuth(view, amtAsset, accountID); result != tx.TesSUCCESS {
+		if result := tx.RequireAuth(view, amtAsset, accountID); result != ter.TesSUCCESS {
 			return result
 		}
 		if tx.IsFrozen(view, ammAccountID, amtAsset) {
-			return tx.TecFROZEN
+			return ter.TecFROZEN
 		}
 		if tx.IsIndividualFrozen(view, accountID, amtAsset) {
-			return tx.TecFROZEN
+			return ter.TecFROZEN
 		}
 		if checkBalance {
 			if isXRPAsset(amtAsset) {
@@ -284,26 +285,26 @@ func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Res
 				}
 			}
 		}
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
-	checkFreezeForAsset := func(asset tx.Asset) tx.Result {
+	checkFreezeForAsset := func(asset tx.Asset) ter.Result {
 		amt := zeroAmount(asset)
 		return checkAmount(&amt, false)
 	}
 
 	if flags&tfLPToken != 0 {
-		if r := checkFreezeForAsset(a.Asset); r != tx.TesSUCCESS {
+		if r := checkFreezeForAsset(a.Asset); r != ter.TesSUCCESS {
 			return r
 		}
-		if r := checkFreezeForAsset(a.Asset2); r != tx.TesSUCCESS {
+		if r := checkFreezeForAsset(a.Asset2); r != ter.TesSUCCESS {
 			return r
 		}
 	} else {
-		if r := checkAmount(a.Amount, true); r != tx.TesSUCCESS {
+		if r := checkAmount(a.Amount, true); r != ter.TesSUCCESS {
 			return r
 		}
-		if r := checkAmount(a.Amount2, true); r != tx.TesSUCCESS {
+		if r := checkAmount(a.Amount2, true); r != ter.TesSUCCESS {
 			return r
 		}
 	}
@@ -313,7 +314,7 @@ func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Res
 	if a.LPTokenOut != nil {
 		if a.LPTokenOut.Currency != amm.LPTokenBalance.Currency ||
 			a.LPTokenOut.Issuer != amm.LPTokenBalance.Issuer {
-			return tx.TemBAD_AMM_TOKENS
+			return ter.TemBAD_AMM_TOKENS
 		}
 	}
 
@@ -325,11 +326,11 @@ func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Res
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // Reference: rippled AMMDeposit.cpp applyGuts
-func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
+func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("amm deposit apply",
 		"account", a.Account,
 		"asset", a.Asset,
@@ -345,7 +346,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 	// (now fee-deducted) view. Preclaim has already validated state.
 	// Reference: rippled AMMDeposit.cpp applyGuts re-peeks the AMM.
 	loaded, result := loadAMM(ctx.View, a.Asset, a.Asset2, a.Asset)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 	amm := loaded.Data
@@ -432,7 +433,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Proportional deposit for specified LP tokens (equalDepositTokens)
 		// Reference: rippled AMMDeposit.cpp equalDepositTokens()
 		if lpTokensRequested.IsZero() || lptBalance.IsZero() {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 
 		// adjustLPTokensOut
@@ -440,7 +441,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 		if fixV1_3 {
 			tokensAdj = adjustLPTokens(lptBalance, lpTokensRequested, true)
 			if tokensAdj.IsZero() {
-				return tx.TecAMM_INVALID_TOKENS
+				return ter.TecAMM_INVALID_TOKENS
 			}
 		}
 
@@ -474,7 +475,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 			assetBalance = assetBalance2
 			depositAmt = amount1
 		} else {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 
 		// adjustLPTokensOut
@@ -483,12 +484,12 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 			tokens = adjustLPTokens(lptBalance, tokens, true)
 		}
 		if tokens.IsZero() {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 		// factor in the adjusted tokens
 		tokensAdj, amountDepositAdj := adjustAssetInByTokens(fixV1_3, assetBalance, depositAmt, lptBalance, tokens, tfee)
 		if fixV1_3 && tokensAdj.IsZero() {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 		lpTokensToIssue = tokensAdj
 		isSingleAssetDeposit = true
@@ -512,9 +513,9 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 
 		if tokensAdj.IsZero() {
 			if fixV1_3 {
-				return tx.TecAMM_INVALID_TOKENS
+				return ter.TecAMM_INVALID_TOKENS
 			}
-			return tx.TecAMM_FAILED
+			return ter.TecAMM_FAILED
 		}
 		// factor in the adjusted tokens
 		frac = adjustFracByTokens(fixV1_3, lptBalance, tokensAdj, frac)
@@ -526,7 +527,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 			lpTokensToIssue = tokensAdj
 			// Check lpTokensDepositMin
 			if lpTokensDepositMin != nil && toIOUForCalc(lpTokensToIssue).Compare(toIOUForCalc(*lpTokensDepositMin)) < 0 {
-				return tx.TecAMM_FAILED
+				return ter.TecAMM_FAILED
 			}
 		} else {
 			// Try the other way
@@ -535,9 +536,9 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 
 			if tokensAdj.IsZero() {
 				if fixV1_3 {
-					return tx.TecAMM_INVALID_TOKENS
+					return ter.TecAMM_INVALID_TOKENS
 				}
-				return tx.TecAMM_FAILED
+				return ter.TecAMM_FAILED
 			}
 			frac = adjustFracByTokens(fixV1_3, lptBalance, tokensAdj, frac)
 			amountDeposit := getRoundedAsset(fixV1_3, assetBalance1, frac, true)
@@ -547,10 +548,10 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 				depositAmount2 = amount2
 				lpTokensToIssue = tokensAdj
 				if lpTokensDepositMin != nil && toIOUForCalc(lpTokensToIssue).Compare(toIOUForCalc(*lpTokensDepositMin)) < 0 {
-					return tx.TecAMM_FAILED
+					return ter.TecAMM_FAILED
 				}
 			} else {
-				return tx.TecAMM_FAILED
+				return ter.TecAMM_FAILED
 			}
 		}
 
@@ -566,7 +567,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 		} else if isDepositForAsset2 {
 			assetBalance = assetBalance2
 		} else {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 
 		// adjustLPTokensOut
@@ -574,14 +575,14 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 		if fixV1_3 {
 			tokensAdj = adjustLPTokens(lptBalance, lpTokensRequested, true)
 			if tokensAdj.IsZero() {
-				return tx.TecAMM_INVALID_TOKENS
+				return ter.TecAMM_INVALID_TOKENS
 			}
 		}
 
 		// the adjusted tokens are factored in
 		amountDeposit := ammAssetIn(assetBalance, lptBalance, tokensAdj, tfee, fixV1_3)
 		if isGreater(toIOUForCalc(amountDeposit), toIOUForCalc(amount1)) {
-			return tx.TecAMM_FAILED
+			return ter.TecAMM_FAILED
 		}
 
 		isSingleAssetDeposit = true
@@ -608,7 +609,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 		} else if isDepositForAsset2 {
 			assetBalance = assetBalance2
 		} else {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 
 		ePrice := *a.EPrice
@@ -625,14 +626,14 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 				// yields no tokens. Reference: rippled AMMDeposit.cpp
 				// singleDepositEPrice() lines 916-922.
 				if fixV1_3 {
-					return tx.TecAMM_INVALID_TOKENS
+					return ter.TecAMM_INVALID_TOKENS
 				}
-				return tx.TecAMM_FAILED
+				return ter.TecAMM_FAILED
 			} else {
 				// factor in the adjusted tokens
 				tokensAdj, amountDepositAdj := adjustAssetInByTokens(fixV1_3, assetBalance, amount1, lptBalance, tokens, tfee)
 				if fixV1_3 && tokensAdj.IsZero() {
-					return tx.TecAMM_INVALID_TOKENS
+					return ter.TecAMM_INVALID_TOKENS
 				}
 				// Check effective price: ep = amountDeposit / tokens
 				ep := numberDiv(toIOUForCalc(amountDepositAdj), toIOUForCalc(tokensAdj))
@@ -689,7 +690,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 			},
 			true)
 		if amountDeposit.IsZero() || amountDeposit.IsNegative() {
-			return tx.TecAMM_FAILED
+			return ter.TecAMM_FAILED
 		}
 
 		tokens := getRoundedLPTokensCb(fixV1_3,
@@ -703,7 +704,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 		// factor in the adjusted tokens
 		tokensAdj, amountDepositAdj := adjustAssetInByTokens(fixV1_3, assetBalance, amountDeposit, lptBalance, tokens, tfee)
 		if fixV1_3 && tokensAdj.IsZero() {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 
 		lpTokensToIssue = tokensAdj
@@ -721,7 +722,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 	case flags&tfTwoAssetIfEmpty != 0:
 		// Deposit into empty AMM
 		if !lptBalance.IsZero() {
-			return tx.TecAMM_NOT_EMPTY
+			return ter.TecAMM_NOT_EMPTY
 		}
 		lpTokensToIssue = calculateLPTokens(amount1, amount2, fixV1_3)
 		depositAmount1 = amount1
@@ -733,7 +734,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	default:
 		ctx.Log.Error("amm deposit: invalid options")
-		return tx.TemMALFORMED
+		return ter.TemMALFORMED
 	}
 
 	// Run adjustAmountsByLPTokens for deposit — matches rippled's deposit() wrapper.
@@ -774,7 +775,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 	}
 
 	if lpTokensToIssue.IsZero() {
-		return tx.TecAMM_INVALID_TOKENS
+		return ter.TecAMM_INVALID_TOKENS
 	}
 
 	// tfLPToken deposit minimums: compare the POST-adjustment deposit amounts
@@ -782,10 +783,10 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 	// adjustAmountsByLPTokens (and after the zero-tokens guard above).
 	// Reference: rippled AMMDeposit.cpp deposit() lines 553-565
 	if depositMin1 != nil && isGreater(toIOUForCalc(*depositMin1), toIOUForCalc(depositAmount1)) {
-		return tx.TecAMM_FAILED
+		return ter.TecAMM_FAILED
 	}
 	if depositMin2 != nil && isGreater(toIOUForCalc(*depositMin2), toIOUForCalc(depositAmount2)) {
-		return tx.TecAMM_FAILED
+		return ter.TecAMM_FAILED
 	}
 
 	// Check LP token deposit minimum: when LPTokenOut is provided with modes that
@@ -795,7 +796,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled AMMDeposit.cpp deposit() lines 553-563
 	if a.LPTokenOut != nil && (flags&(tfSingleAsset|tfTwoAsset) != 0) {
 		if toIOUForCalc(lpTokensToIssue).Compare(toIOUForCalc(*a.LPTokenOut)) < 0 {
-			return tx.TecAMM_FAILED
+			return ter.TecAMM_FAILED
 		}
 	}
 
@@ -808,16 +809,16 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled AMMDeposit.cpp deposit() lines 512-514, 566-572, 590-598
 	isXRP1 := isXRPAsset(a.Asset)
 	isXRP2 := isXRPAsset(a.Asset2)
-	checkBalancePositive := func(amt tx.Amount, isXRP bool) tx.Result {
+	checkBalancePositive := func(amt tx.Amount, isXRP bool) ter.Result {
 		if amt.IsNegative() || amt.IsZero() {
-			return tx.TemBAD_AMOUNT
+			return ter.TemBAD_AMOUNT
 		}
 		// For XRP, the IOU representation may be non-zero but convert to 0 drops.
 		// rippled's checkBalance uses beast::zero comparison after Number → STAmount conversion.
 		if isXRP && iouToDrops(amt) <= 0 {
-			return tx.TemBAD_AMOUNT
+			return ter.TemBAD_AMOUNT
 		}
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	// Match rippled's deposit() checkBalance calling pattern:
 	// - For single-asset deposits: only check the deposited asset
@@ -827,19 +828,19 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled AMMDeposit.cpp deposit() lines 566-598
 	if isSingleAssetDeposit {
 		if singleDepositIsAsset2 {
-			if r := checkBalancePositive(depositAmount2, isXRP2); r != tx.TesSUCCESS {
+			if r := checkBalancePositive(depositAmount2, isXRP2); r != ter.TesSUCCESS {
 				return r
 			}
 		} else {
-			if r := checkBalancePositive(depositAmount1, isXRP1); r != tx.TesSUCCESS {
+			if r := checkBalancePositive(depositAmount1, isXRP1); r != ter.TesSUCCESS {
 				return r
 			}
 		}
 	} else {
-		if r := checkBalancePositive(depositAmount1, isXRP1); r != tx.TesSUCCESS {
+		if r := checkBalancePositive(depositAmount1, isXRP1); r != ter.TesSUCCESS {
 			return r
 		}
-		if r := checkBalancePositive(depositAmount2, isXRP2); r != tx.TesSUCCESS {
+		if r := checkBalancePositive(depositAmount2, isXRP2); r != ter.TesSUCCESS {
 			return r
 		}
 	}
@@ -907,7 +908,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 	if !isXRP1 && !depositAmount1.IsZero() {
 		issuerID, err := state.DecodeAccountID(a.Asset.Issuer)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		// Skip the depositor's debit if it IS the issuer — issuers issue from
 		// thin air. Reference: rippled accountSend() handles this internally.
@@ -923,7 +924,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 	if !isXRP2 && !depositAmount2.IsZero() {
 		issuerID, err := state.DecodeAccountID(a.Asset2.Issuer)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		// Skip if depositor IS the issuer.
 		if accountID != issuerID {
@@ -938,7 +939,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	newLPBalance, err := amm.LPTokenBalance.Add(lpTokensToIssue)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	amm.LPTokenBalance = newLPBalance
 
@@ -971,28 +972,28 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	ammBytes, err := serializeAMMData(amm)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(ammKey, ammBytes); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	ammAccountBytes, err := state.SerializeAccountRoot(ammAccount)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(ammAccountKey, ammAccountBytes); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	accountKey := keylet.Account(accountID)
 	accountBytes, err := state.SerializeAccountRoot(ctx.Account)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(accountKey, accountBytes); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/amm/amm_load.go
+++ b/internal/tx/amm/amm_load.go
@@ -3,13 +3,14 @@ package amm
 import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 // readAMM reads and parses the AMM ledger entry for the (asset, asset2) pair.
 // It returns terNO_AMM when the entry is absent and tefINTERNAL on a parse
 // failure, matching the inline load that opens every AMM transactor.
-func readAMM(view tx.LedgerView, asset, asset2 tx.Asset) (*AMMData, keylet.Keylet, tx.Result) {
+func readAMM(view tx.LedgerView, asset, asset2 tx.Asset) (*AMMData, keylet.Keylet, ter.Result) {
 	ammKey := computeAMMKeylet(asset, asset2)
 	ammRawData, err := view.Read(ammKey)
 	if err != nil || ammRawData == nil {
@@ -17,24 +18,24 @@ func readAMM(view tx.LedgerView, asset, asset2 tx.Asset) (*AMMData, keylet.Keyle
 	}
 	amm, err := parseAMMData(ammRawData)
 	if err != nil {
-		return nil, ammKey, tx.TefINTERNAL
+		return nil, ammKey, ter.TefINTERNAL
 	}
-	return amm, ammKey, tx.TesSUCCESS
+	return amm, ammKey, ter.TesSUCCESS
 }
 
 // readAccount reads and parses an AccountRoot by its decoded ID. It returns
 // tefINTERNAL when the entry is missing or unparseable; callers that need a
 // distinct "account absent" code should check existence separately.
-func readAccount(view tx.LedgerView, accountID [20]byte) (*state.AccountRoot, tx.Result) {
+func readAccount(view tx.LedgerView, accountID [20]byte) (*state.AccountRoot, ter.Result) {
 	data, err := view.Read(keylet.Account(accountID))
 	if err != nil || data == nil {
-		return nil, tx.TefINTERNAL
+		return nil, ter.TefINTERNAL
 	}
 	account, err := state.ParseAccountRoot(data)
 	if err != nil {
-		return nil, tx.TefINTERNAL
+		return nil, ter.TefINTERNAL
 	}
-	return account, tx.TesSUCCESS
+	return account, ter.TesSUCCESS
 }
 
 // loadedAMM bundles the AMM ledger entry, its pseudo-account, and the current
@@ -57,11 +58,11 @@ type loadedAMM struct {
 // preclaim already confirmed the AMM exists, an absent entry here is an
 // internal inconsistency and returns tecINTERNAL (matching applyGuts); a parse
 // failure returns tefINTERNAL.
-func loadAMM(view tx.LedgerView, asset, asset2, txAsset tx.Asset) (*loadedAMM, tx.Result) {
+func loadAMM(view tx.LedgerView, asset, asset2, txAsset tx.Asset) (*loadedAMM, ter.Result) {
 	amm, ammKey, result := readAMM(view, asset, asset2)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		if result == TerNO_AMM {
-			return nil, tx.TecINTERNAL
+			return nil, ter.TecINTERNAL
 		}
 		return nil, result
 	}
@@ -70,11 +71,11 @@ func loadAMM(view tx.LedgerView, asset, asset2, txAsset tx.Asset) (*loadedAMM, t
 	ammAccountKey := keylet.Account(ammAccountID)
 	ammAccountData, err := view.Read(ammAccountKey)
 	if err != nil {
-		return nil, tx.TefINTERNAL
+		return nil, ter.TefINTERNAL
 	}
 	ammAccount, err := state.ParseAccountRoot(ammAccountData)
 	if err != nil {
-		return nil, tx.TefINTERNAL
+		return nil, ter.TefINTERNAL
 	}
 
 	assetBalance1, assetBalance2, lptBalance := AMMHolds(view, amm, false)
@@ -91,5 +92,5 @@ func loadAMM(view tx.LedgerView, asset, asset2, txAsset tx.Asset) (*loadedAMM, t
 		AssetBalance1:  assetBalance1,
 		AssetBalance2:  assetBalance2,
 		LPTokenBalance: lptBalance,
-	}, tx.TesSUCCESS
+	}, ter.TesSUCCESS
 }

--- a/internal/tx/amm/amm_vote.go
+++ b/internal/tx/amm/amm_vote.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // AMMVote votes on the trading fee for an AMM.
@@ -41,7 +42,7 @@ func (a *AMMVote) Validate() error {
 	}
 
 	if a.GetFlags()&tfAMMVoteMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for AMMVote")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for AMMVote")
 	}
 
 	// Reference: rippled AMMVote.cpp preflight lines 39-44
@@ -50,7 +51,7 @@ func (a *AMMVote) Validate() error {
 	}
 
 	if a.TradingFee > tradingFeeThreshold {
-		return tx.Errorf(tx.TemBAD_FEE, "TradingFee must be 0-1000")
+		return ter.Errorf(ter.TemBAD_FEE, "TradingFee must be 0-1000")
 	}
 
 	return nil
@@ -66,26 +67,26 @@ func (a *AMMVote) RequiredAmendments() [][32]byte {
 
 // Preclaim requires the AMM to exist, be non-empty, and the voter to hold LP
 // tokens. Reference: rippled AMMVote.cpp preclaim
-func (a *AMMVote) Preclaim(view tx.LedgerView, _ tx.EngineConfig) tx.Result {
+func (a *AMMVote) Preclaim(view tx.LedgerView, _ tx.EngineConfig) ter.Result {
 	amm, _, result := readAMM(view, a.Asset, a.Asset2)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 	if amm.LPTokenBalance.IsZero() {
-		return tx.TecAMM_EMPTY
+		return ter.TecAMM_EMPTY
 	}
 	accountID, err := state.DecodeAccountID(a.Account)
 	if err != nil {
-		return tx.TecAMM_INVALID_TOKENS
+		return ter.TecAMM_INVALID_TOKENS
 	}
 	if ammLPHolds(view, amm, accountID).IsZero() {
-		return tx.TecAMM_INVALID_TOKENS
+		return ter.TecAMM_INVALID_TOKENS
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // Reference: rippled AMMVote.cpp applyVote
-func (a *AMMVote) Apply(ctx *tx.ApplyContext) tx.Result {
+func (a *AMMVote) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("amm vote apply",
 		"account", a.Account,
 		"asset", a.Asset,
@@ -96,25 +97,25 @@ func (a *AMMVote) Apply(ctx *tx.ApplyContext) tx.Result {
 	accountID := ctx.AccountID
 
 	amm, ammKey, result := readAMM(ctx.View, a.Asset, a.Asset2)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 
 	lptAMMBalance := amm.LPTokenBalance
 	if lptAMMBalance.IsZero() {
-		return tx.TecAMM_EMPTY
+		return ter.TecAMM_EMPTY
 	}
 
 	lpTokensNew := ammLPHolds(ctx.View, amm, accountID)
 	if lpTokensNew.IsZero() {
 		ctx.Log.Debug("amm vote: account is not LP", "account", a.Account)
-		return tx.TecAMM_INVALID_TOKENS
+		return ter.TecAMM_INVALID_TOKENS
 	}
 
 	// Check fixInnerObjTemplate: AuctionSlot must exist when amendment is enabled
 	// Reference: rippled AMMVote.cpp lines 202-205
 	if amm.AuctionSlot == nil && ctx.Rules().Enabled(amendment.FeatureFixInnerObjTemplate) {
-		return tx.TefEXCEPTION
+		return ter.TefEXCEPTION
 	}
 
 	feeNew := a.TradingFee
@@ -233,11 +234,11 @@ func (a *AMMVote) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	ammBytes, err := serializeAMMData(amm)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(ammKey, ammBytes); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/amm/amm_withdraw.go
+++ b/internal/tx/amm/amm_withdraw.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -62,7 +63,7 @@ func (a *AMMWithdraw) Validate() error {
 	}
 
 	if a.GetFlags()&tfAMMWithdrawMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for AMMWithdraw")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for AMMWithdraw")
 	}
 
 	flags := a.GetFlags()
@@ -76,7 +77,7 @@ func (a *AMMWithdraw) Validate() error {
 		flagCount++
 	}
 	if flagCount != 1 {
-		return tx.Errorf(tx.TemMALFORMED, "exactly one withdraw mode flag must be set")
+		return ter.Errorf(ter.TemMALFORMED, "exactly one withdraw mode flag must be set")
 	}
 
 	hasAmount := a.Amount != nil
@@ -87,37 +88,37 @@ func (a *AMMWithdraw) Validate() error {
 	if flags&tfLPToken != 0 {
 		// LPToken mode: LPTokenIn required, no amount/amount2/ePrice
 		if !hasLPTokenIn || hasAmount || hasAmount2 || hasEPrice {
-			return tx.Errorf(tx.TemMALFORMED, "tfLPToken requires LPTokenIn only")
+			return ter.Errorf(ter.TemMALFORMED, "tfLPToken requires LPTokenIn only")
 		}
 	} else if flags&tfWithdrawAll != 0 {
 		// WithdrawAll mode: no fields needed
 		if hasLPTokenIn || hasAmount || hasAmount2 || hasEPrice {
-			return tx.Errorf(tx.TemMALFORMED, "tfWithdrawAll requires no amount fields")
+			return ter.Errorf(ter.TemMALFORMED, "tfWithdrawAll requires no amount fields")
 		}
 	} else if flags&tfOneAssetWithdrawAll != 0 {
 		// OneAssetWithdrawAll mode: Amount required (identifies which asset)
 		if !hasAmount || hasLPTokenIn || hasAmount2 || hasEPrice {
-			return tx.Errorf(tx.TemMALFORMED, "tfOneAssetWithdrawAll requires Amount only")
+			return ter.Errorf(ter.TemMALFORMED, "tfOneAssetWithdrawAll requires Amount only")
 		}
 	} else if flags&tfSingleAsset != 0 {
 		// SingleAsset mode: Amount required
 		if !hasAmount || hasLPTokenIn || hasAmount2 || hasEPrice {
-			return tx.Errorf(tx.TemMALFORMED, "tfSingleAsset requires Amount only")
+			return ter.Errorf(ter.TemMALFORMED, "tfSingleAsset requires Amount only")
 		}
 	} else if flags&tfTwoAsset != 0 {
 		// TwoAsset mode: Amount and Amount2 required
 		if !hasAmount || !hasAmount2 || hasLPTokenIn || hasEPrice {
-			return tx.Errorf(tx.TemMALFORMED, "tfTwoAsset requires Amount and Amount2")
+			return ter.Errorf(ter.TemMALFORMED, "tfTwoAsset requires Amount and Amount2")
 		}
 	} else if flags&tfOneAssetLPToken != 0 {
 		// OneAssetLPToken mode: Amount and LPTokenIn required
 		if !hasAmount || !hasLPTokenIn || hasAmount2 || hasEPrice {
-			return tx.Errorf(tx.TemMALFORMED, "tfOneAssetLPToken requires Amount and LPTokenIn")
+			return ter.Errorf(ter.TemMALFORMED, "tfOneAssetLPToken requires Amount and LPTokenIn")
 		}
 	} else if flags&tfLimitLPToken != 0 {
 		// LimitLPToken mode: Amount and EPrice required
 		if !hasAmount || !hasEPrice || hasLPTokenIn || hasAmount2 {
-			return tx.Errorf(tx.TemMALFORMED, "tfLimitLPToken requires Amount and EPrice")
+			return ter.Errorf(ter.TemMALFORMED, "tfLimitLPToken requires Amount and EPrice")
 		}
 	}
 
@@ -128,13 +129,13 @@ func (a *AMMWithdraw) Validate() error {
 
 	if hasAmount && hasAmount2 {
 		if a.Amount.Currency == a.Amount2.Currency && a.Amount.Issuer == a.Amount2.Issuer {
-			return tx.Errorf(tx.TemBAD_AMM_TOKENS, "Amount and Amount2 cannot have the same issue")
+			return ter.Errorf(ter.TemBAD_AMM_TOKENS, "Amount and Amount2 cannot have the same issue")
 		}
 	}
 
 	if hasLPTokenIn {
 		if a.LPTokenIn.IsZero() || a.LPTokenIn.IsNegative() {
-			return tx.Errorf(tx.TemBAD_AMM_TOKENS, "invalid LPTokenIn")
+			return ter.Errorf(ter.TemBAD_AMM_TOKENS, "invalid LPTokenIn")
 		}
 	}
 
@@ -174,14 +175,14 @@ func (a *AMMWithdraw) RequiredAmendments() [][32]byte {
 // view: AMM existence and pool sanity, per-amount balance/authorization/freeze,
 // the withdrawer's LP holdings, and the LPTokenIn / EPrice issues.
 // Reference: rippled AMMWithdraw.cpp preclaim
-func (a *AMMWithdraw) Preclaim(view tx.LedgerView, _ tx.EngineConfig) tx.Result {
+func (a *AMMWithdraw) Preclaim(view tx.LedgerView, _ tx.EngineConfig) ter.Result {
 	accountID, err := state.DecodeAccountID(a.Account)
 	if err != nil {
-		return tx.TemBAD_SRC_ACCOUNT
+		return ter.TemBAD_SRC_ACCOUNT
 	}
 
 	amm, _, result := readAMM(view, a.Asset, a.Asset2)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 	ammAccountID := amm.Account
@@ -192,12 +193,12 @@ func (a *AMMWithdraw) Preclaim(view tx.LedgerView, _ tx.EngineConfig) tx.Result 
 	}
 
 	if lptBalance.IsZero() {
-		return tx.TecAMM_EMPTY
+		return ter.TecAMM_EMPTY
 	}
 	if assetBalance1.IsZero() || assetBalance1.IsNegative() ||
 		assetBalance2.IsZero() || assetBalance2.IsNegative() ||
 		lptBalance.IsNegative() {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	balanceForAmount := func(amt *tx.Amount) tx.Amount {
@@ -211,65 +212,65 @@ func (a *AMMWithdraw) Preclaim(view tx.LedgerView, _ tx.EngineConfig) tx.Result 
 		return assetBalance2
 	}
 
-	checkAmount := func(amt *tx.Amount, balance tx.Amount) tx.Result {
+	checkAmount := func(amt *tx.Amount, balance tx.Amount) ter.Result {
 		if amt == nil {
-			return tx.TesSUCCESS
+			return ter.TesSUCCESS
 		}
 		amtAsset := tx.Asset{Currency: amt.Currency, Issuer: amt.Issuer}
 		if isGreater(toIOUForCalc(*amt), toIOUForCalc(balance)) {
-			return tx.TecAMM_BALANCE
+			return ter.TecAMM_BALANCE
 		}
-		if result := tx.RequireAuth(view, amtAsset, accountID); result != tx.TesSUCCESS {
+		if result := tx.RequireAuth(view, amtAsset, accountID); result != ter.TesSUCCESS {
 			return result
 		}
 		if tx.IsFrozen(view, ammAccountID, amtAsset) {
-			return tx.TecFROZEN
+			return ter.TecFROZEN
 		}
 		if tx.IsIndividualFrozen(view, accountID, amtAsset) {
-			return tx.TecFROZEN
+			return ter.TecFROZEN
 		}
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
-	if r := checkAmount(a.Amount, balanceForAmount(a.Amount)); r != tx.TesSUCCESS {
+	if r := checkAmount(a.Amount, balanceForAmount(a.Amount)); r != ter.TesSUCCESS {
 		return r
 	}
-	if r := checkAmount(a.Amount2, balanceForAmount(a.Amount2)); r != tx.TesSUCCESS {
+	if r := checkAmount(a.Amount2, balanceForAmount(a.Amount2)); r != ter.TesSUCCESS {
 		return r
 	}
 
 	lpTokensHeld := ammLPHolds(view, amm, accountID)
 	if lpTokensHeld.IsZero() {
-		return tx.TecAMM_BALANCE
+		return ter.TecAMM_BALANCE
 	}
 
 	if a.LPTokenIn != nil {
 		if a.LPTokenIn.Currency != amm.LPTokenBalance.Currency || a.LPTokenIn.Issuer != amm.LPTokenBalance.Issuer {
-			return tx.TemBAD_AMM_TOKENS
+			return ter.TemBAD_AMM_TOKENS
 		}
 		if isGreater(toIOUForCalc(*a.LPTokenIn), toIOUForCalc(lpTokensHeld)) {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 	}
 	if a.EPrice != nil {
 		if a.EPrice.Currency != amm.LPTokenBalance.Currency || a.EPrice.Issuer != amm.LPTokenBalance.Issuer {
-			return tx.TemBAD_AMM_TOKENS
+			return ter.TemBAD_AMM_TOKENS
 		}
 	}
 
 	if a.GetFlags()&(tfLPToken|tfWithdrawAll) != 0 {
-		if r := checkAmount(&assetBalance1, assetBalance1); r != tx.TesSUCCESS {
+		if r := checkAmount(&assetBalance1, assetBalance1); r != ter.TesSUCCESS {
 			return r
 		}
-		if r := checkAmount(&assetBalance2, assetBalance2); r != tx.TesSUCCESS {
+		if r := checkAmount(&assetBalance2, assetBalance2); r != ter.TesSUCCESS {
 			return r
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // Reference: rippled AMMWithdraw.cpp applyGuts
-func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
+func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("amm withdraw apply",
 		"account", a.Account,
 		"asset", a.Asset,
@@ -285,7 +286,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 	// (now fee-deducted) view. Preclaim has already validated state.
 	// Reference: rippled AMMWithdraw.cpp applyGuts re-peeks the AMM.
 	loaded, result := loadAMM(ctx.View, a.Asset, a.Asset2, a.Asset)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 	amm := loaded.Data
@@ -329,7 +330,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 	// might not match the LP's trustline balance.
 	// Reference: rippled AMMWithdraw.cpp:311-317
 	if ctx.Rules().Enabled(amendment.FeatureFixAMMv1_1) {
-		if result := verifyAndAdjustLPTokenBalance(ctx.View, lpTokensHeld, amm, accountID); result != tx.TesSUCCESS {
+		if result := verifyAndAdjustLPTokenBalance(ctx.View, lpTokensHeld, amm, accountID); result != ter.TesSUCCESS {
 			return result
 		}
 		// Refresh lptBalance since verifyAndAdjustLPTokenBalance may have modified amm.LPTokenBalance
@@ -355,10 +356,10 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Proportional withdrawal (equalWithdrawTokens)
 		// Reference: rippled AMMWithdraw.cpp equalWithdrawTokens()
 		if lpTokensWithdraw.IsZero() || lptBalance.IsZero() {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 		if isGreater(toIOUForCalc(lpTokensWithdraw), toIOUForCalc(lpTokensHeld)) {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 
 		// Withdrawing all tokens in the pool
@@ -372,7 +373,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 			if fixV1_3 && !isWithdrawAll {
 				tokensAdj = adjustLPTokens(lptBalance, lpTokensWithdraw, false)
 				if tokensAdj.IsZero() {
-					return tx.TecAMM_INVALID_TOKENS
+					return ter.TecAMM_INVALID_TOKENS
 				}
 			}
 
@@ -387,7 +388,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 			// of LP tokens is likely too small and results in one-sided pool
 			// withdrawal due to round off.
 			if withdrawAmount1.IsZero() || withdrawAmount2.IsZero() {
-				return tx.TecAMM_FAILED
+				return ter.TecAMM_FAILED
 			}
 			lpTokensToRedeem = tokensAdj
 		}
@@ -396,7 +397,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Withdraw all LP tokens as a single asset (singleWithdrawTokens)
 		// Reference: rippled routes tfOneAssetWithdrawAll to singleWithdrawTokens()
 		if lpTokensHeld.IsZero() {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 		isWithdrawAsset1 := matchesAsset(a.Amount, a.Asset)
 
@@ -418,7 +419,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 		amountWithdraw := ammAssetOut(assetBalance, lptBalance, tokensAdj, tfee, fixV1_3)
 		// For OneAssetWithdrawAll, amount==zero or amountWithdraw >= amount
 		if !amount1.IsZero() && toIOUForCalc(amountWithdraw).Compare(toIOUForCalc(amount1)) < 0 {
-			return tx.TecAMM_FAILED
+			return ter.TecAMM_FAILED
 		}
 
 		if isWithdrawAsset1 {
@@ -434,7 +435,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Single asset withdrawal (singleWithdraw)
 		// Reference: rippled AMMWithdraw.cpp singleWithdraw()
 		if amount1.IsZero() {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 		isWithdrawAsset1 := matchesAsset(a.Amount, a.Asset)
 
@@ -457,12 +458,12 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 			tokens = adjustLPTokens(lptBalance, tokens, false)
 		}
 		if tokens.IsZero() {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 		// factor in the adjusted tokens
 		tokensAdj, amountWithdrawAdj := adjustAssetOutByTokens(fixV1_3, assetBalance, withdrawAmt, lptBalance, tokens, tfee)
 		if fixV1_3 && tokensAdj.IsZero() {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 
 		if isWithdrawAsset1 {
@@ -478,13 +479,13 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Two asset withdrawal with limits (equalWithdrawLimit)
 		// Reference: rippled AMMWithdraw.cpp equalWithdrawLimit()
 		if amount1.IsZero() || amount2.IsZero() {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 
 		frac := numberDiv(toIOUForCalc(amount1), toIOUForCalc(assetBalance1))
 		tokensAdj := getRoundedLPTokens(fixV1_3, lptBalance, frac, false)
 		if fixV1_3 && tokensAdj.IsZero() {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 		// factor in the adjusted tokens
 		frac = adjustFracByTokens(fixV1_3, lptBalance, tokensAdj, frac)
@@ -498,13 +499,13 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 			frac = numberDiv(toIOUForCalc(amount2), toIOUForCalc(assetBalance2))
 			tokensAdj = getRoundedLPTokens(fixV1_3, lptBalance, frac, false)
 			if fixV1_3 && tokensAdj.IsZero() {
-				return tx.TecAMM_INVALID_TOKENS
+				return ter.TecAMM_INVALID_TOKENS
 			}
 			frac = adjustFracByTokens(fixV1_3, lptBalance, tokensAdj, frac)
 			amountWithdraw := getRoundedAsset(fixV1_3, assetBalance1, frac, false)
 
 			if fixV1_3 && toIOUForCalc(amountWithdraw).Compare(toIOUForCalc(amount1)) > 0 {
-				return tx.TecAMM_FAILED
+				return ter.TecAMM_FAILED
 			}
 
 			withdrawAmount1 = amountWithdraw
@@ -516,11 +517,11 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Single asset withdrawal for specific LP tokens (singleWithdrawTokens)
 		// Reference: rippled AMMWithdraw.cpp singleWithdrawTokens()
 		if lpTokensRequested.IsZero() {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 		if isGreater(toIOUForCalc(lpTokensRequested), toIOUForCalc(lpTokensHeld)) ||
 			isGreater(toIOUForCalc(lpTokensRequested), toIOUForCalc(lptBalance)) {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 		isWithdrawAsset1 := matchesAsset(a.Amount, a.Asset)
 
@@ -540,7 +541,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 		if fixV1_3 {
 			tokensAdj = adjustLPTokens(lptBalance, lpTokensRequested, false)
 			if tokensAdj.IsZero() {
-				return tx.TecAMM_INVALID_TOKENS
+				return ter.TecAMM_INVALID_TOKENS
 			}
 		}
 
@@ -556,7 +557,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 			}
 			lpTokensToRedeem = tokensAdj
 		} else {
-			return tx.TecAMM_FAILED
+			return ter.TecAMM_FAILED
 		}
 
 	case flags&tfLimitLPToken != 0:
@@ -565,7 +566,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Note: amount1 == 0 is valid — it means no minimum on withdrawal amount.
 		// rippled AMMWithdraw.cpp:1079: if (amount == beast::zero || amountWithdraw >= amount)
 		if a.EPrice == nil || a.EPrice.IsZero() {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 
 		isWithdrawAsset1 := matchesAsset(a.Amount, a.Asset)
@@ -605,9 +606,9 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 
 		if tokensAdj.IsZero() || tokensAdj.IsNegative() {
 			if fixV1_3 {
-				return tx.TecAMM_INVALID_TOKENS
+				return ter.TecAMM_INVALID_TOKENS
 			}
-			return tx.TecAMM_FAILED
+			return ter.TecAMM_FAILED
 		}
 
 		tokensAdjIOU := toIOUForCalc(tokensAdj)
@@ -629,16 +630,16 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 			}
 			lpTokensToRedeem = tokensAdj
 		} else {
-			return tx.TecAMM_FAILED
+			return ter.TecAMM_FAILED
 		}
 
 	default:
 		ctx.Log.Error("amm withdraw: invalid options")
-		return tx.TemMALFORMED
+		return ter.TemMALFORMED
 	}
 
 	if lpTokensToRedeem.IsZero() {
-		return tx.TecAMM_INVALID_TOKENS
+		return ter.TecAMM_INVALID_TOKENS
 	}
 
 	// Run adjustAmountsByLPTokens for withdrawal (non-withdrawAll modes)
@@ -678,28 +679,28 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	// Verify LP tokens
 	if lpTokensToRedeem.IsZero() || isGreater(toIOUForCalc(lpTokensToRedeem), toIOUForCalc(lpTokensHeld)) {
-		return tx.TecAMM_INVALID_TOKENS
+		return ter.TecAMM_INVALID_TOKENS
 	}
 
 	// Verify withdrawal doesn't exceed balances
 	if isGreater(toIOUForCalc(withdrawAmount1), toIOUForCalc(assetBalance1)) {
-		return tx.TecAMM_BALANCE
+		return ter.TecAMM_BALANCE
 	}
 	if isGreater(toIOUForCalc(withdrawAmount2), toIOUForCalc(assetBalance2)) {
-		return tx.TecAMM_BALANCE
+		return ter.TecAMM_BALANCE
 	}
 
 	// Per rippled: Cannot withdraw one side of the pool while leaving the other
 	w1EqualsB1 := toIOUForCalc(withdrawAmount1).Compare(toIOUForCalc(assetBalance1)) == 0
 	w2EqualsB2 := toIOUForCalc(withdrawAmount2).Compare(toIOUForCalc(assetBalance2)) == 0
 	if (w1EqualsB1 && !w2EqualsB2) || (w2EqualsB2 && !w1EqualsB1) {
-		return tx.TecAMM_BALANCE
+		return ter.TecAMM_BALANCE
 	}
 
 	// May happen if withdrawing an amount close to one side of the pool
 	if toIOUForCalc(lpTokensToRedeem).Compare(toIOUForCalc(lptBalance)) == 0 &&
 		(!w1EqualsB1 || !w2EqualsB2) {
-		return tx.TecAMM_BALANCE
+		return ter.TecAMM_BALANCE
 	}
 
 	isXRP1 := isXRPAsset(a.Asset)
@@ -726,18 +727,18 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 	if !isXRP1 && !withdrawAmount1.IsZero() {
 		issuerID, err := state.DecodeAccountID(a.Asset.Issuer)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
-		if result := withdrawIOUToAccount(ctx, accountID, issuerID, ammAccountID, a.Asset, withdrawAmount1, enabledFixAMMv1_2); result != tx.TesSUCCESS {
+		if result := withdrawIOUToAccount(ctx, accountID, issuerID, ammAccountID, a.Asset, withdrawAmount1, enabledFixAMMv1_2); result != ter.TesSUCCESS {
 			return result
 		}
 	}
 	if !isXRP2 && !withdrawAmount2.IsZero() {
 		issuerID, err := state.DecodeAccountID(a.Asset2.Issuer)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
-		if result := withdrawIOUToAccount(ctx, accountID, issuerID, ammAccountID, a.Asset2, withdrawAmount2, enabledFixAMMv1_2); result != tx.TesSUCCESS {
+		if result := withdrawIOUToAccount(ctx, accountID, issuerID, ammAccountID, a.Asset2, withdrawAmount2, enabledFixAMMv1_2); result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -750,13 +751,13 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 		ammAccountAddr, _ := state.EncodeAccountID(amm.Account)
 		redeemAmt := state.NewIssuedAmountFromValue(
 			lpTokensToRedeem.Mantissa(), lpTokensToRedeem.Exponent(), lptCurrency, ammAccountAddr)
-		if r := redeemIOUWithCleanup(ctx.View, accountID, amm.Account, redeemAmt); r != tx.TesSUCCESS {
+		if r := redeemIOUWithCleanup(ctx.View, accountID, amm.Account, redeemAmt); r != ter.TesSUCCESS {
 			return r
 		}
 	}
 	newLPBalance, err := amm.LPTokenBalance.Sub(lpTokensToRedeem)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	// NOTE: Asset balances are NOT stored in AMM entry
 	// They are updated by the balance transfers above:
@@ -766,7 +767,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled AMMWithdraw.cpp deleteAMMAccountIfEmpty (line 718)
 	deleteResult := deleteAMMAccountIfEmpty(ctx.View, ammKey, ammAccountKey,
 		newLPBalance, a.Asset, a.Asset2, amm, ammAccount)
-	if deleteResult != tx.TesSUCCESS && deleteResult != tx.TecINCOMPLETE {
+	if deleteResult != ter.TesSUCCESS && deleteResult != ter.TecINCOMPLETE {
 		return deleteResult
 	}
 
@@ -776,15 +777,15 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
 	accountKey := keylet.Account(accountID)
 	accountData, err := ctx.View.Read(accountKey)
 	if err != nil || accountData == nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	accountFromView, err := state.ParseAccountRoot(accountData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	ctx.Account.OwnerCount = accountFromView.OwnerCount
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // withdrawIOUToAccount handles IOU transfer from AMM to withdrawer, including
@@ -797,23 +798,23 @@ func withdrawIOUToAccount(
 	asset tx.Asset,
 	amount tx.Amount,
 	enabledFixAMMv1_2 bool,
-) tx.Result {
+) ter.Result {
 	// When the withdrawer IS the issuer, no trust line is needed between them.
 	// Just debit the AMM's trust line (which is between AMM and issuer).
 	// Reference: rippled accountSend → rippleCredit handles issuer case by only
 	// adjusting the single AMM-issuer trust line.
 	if accountID == issuerID {
 		if err := createOrUpdateAMMTrustline(ammAccountID, asset, amount.Negate(), ctx.View); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Check if withdrawer already has a trust line for this IOU.
 	trustLineKey := keylet.Line(accountID, issuerID, asset.Currency)
 	trustLineExists, err := ctx.View.Exists(trustLineKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if !trustLineExists {
@@ -829,29 +830,29 @@ func withdrawIOUToAccount(
 				// reduces the balance, so prior (pre-fee) balance is the larger
 				// term. Reference: rippled AMMWithdraw.cpp:599.
 				if ctx.PriorBalance() < reserve {
-					return tx.TecINSUFFICIENT_RESERVE
+					return ter.TecINSUFFICIENT_RESERVE
 				}
 			}
 		}
 
 		// Create trust line for the withdrawer.
 		// Reference: rippled uses accountSend → rippleCredit → trustCreate
-		if result := createWithdrawTrustLine(ctx, accountID, issuerID, asset, amount); result != tx.TesSUCCESS {
+		if result := createWithdrawTrustLine(ctx, accountID, issuerID, asset, amount); result != ter.TesSUCCESS {
 			return result
 		}
 	} else {
 		// Trust line exists — just credit the withdrawer's balance.
 		if err := updateTrustlineBalanceInView(accountID, issuerID, asset.Currency, amount, ctx.View); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
 	// Debit AMM's trust line (negative delta)
 	if err := createOrUpdateAMMTrustline(ammAccountID, asset, amount.Negate(), ctx.View); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // createWithdrawTrustLine creates a new trust line between withdrawer and
@@ -863,8 +864,8 @@ func createWithdrawTrustLine(
 	accountID, issuerID [20]byte,
 	asset tx.Asset,
 	amount tx.Amount,
-) tx.Result {
-	if result := trustCreate(ctx.View, accountID, issuerID, asset.Currency, amount, trustCreateOpts{setNoRipple: true}); result != tx.TesSUCCESS {
+) ter.Result {
+	if result := trustCreate(ctx.View, accountID, issuerID, asset.Currency, amount, trustCreateOpts{setNoRipple: true}); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -877,5 +878,5 @@ func createWithdrawTrustLine(
 	_ = tx.AdjustOwnerCount(ctx.View, accountID, 1)
 	ctx.Account.OwnerCount++
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/amm/asset.go
+++ b/internal/tx/amm/asset.go
@@ -3,6 +3,7 @@ package amm
 import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -156,14 +157,14 @@ func withinRelativeDistance(calc, req, dist tx.Amount) bool {
 // LPToken line, and the one or two asset trust lines. Any LPToken trust line to
 // a different account means there is a second provider (false). A structurally
 // impossible directory yields tecINTERNAL.
-func isOnlyLiquidityProvider(view tx.LedgerView, lptCurrency string, ammAccountID, lpAccountID [20]byte) (bool, tx.Result) {
+func isOnlyLiquidityProvider(view tx.LedgerView, lptCurrency string, ammAccountID, lpAccountID [20]byte) (bool, ter.Result) {
 	ammAccountAddr, err := encodeAccountID(ammAccountID)
 	if err != nil {
-		return false, tx.TecINTERNAL
+		return false, ter.TecINTERNAL
 	}
 	lpAccountAddr, err := encodeAccountID(lpAccountID)
 	if err != nil {
-		return false, tx.TecINTERNAL
+		return false, ter.TecINTERNAL
 	}
 
 	var nLPTokenTrustLines, nIOUTrustLines uint8
@@ -172,11 +173,11 @@ func isOnlyLiquidityProvider(view tx.LedgerView, lptCurrency string, ammAccountI
 	ownerDirKey := keylet.OwnerDir(ammAccountID)
 	rootData, err := view.Read(ownerDirKey)
 	if err != nil || rootData == nil {
-		return false, tx.TecINTERNAL
+		return false, ter.TecINTERNAL
 	}
 	currentPage, err := state.ParseDirectoryNode(rootData)
 	if err != nil {
-		return false, tx.TecINTERNAL
+		return false, ter.TecINTERNAL
 	}
 
 	// At most three trust lines plus one AMM object, so ten pages is ample.
@@ -184,27 +185,27 @@ func isOnlyLiquidityProvider(view tx.LedgerView, lptCurrency string, ammAccountI
 		for _, key := range currentPage.Indexes {
 			itemData, err := view.Read(keylet.Keylet{Key: key})
 			if err != nil || itemData == nil {
-				return false, tx.TecINTERNAL
+				return false, ter.TecINTERNAL
 			}
 			entryType, err := state.GetLedgerEntryType(itemData)
 			if err != nil {
-				return false, tx.TecINTERNAL
+				return false, ter.TecINTERNAL
 			}
 
 			if entry.Type(entryType) == entry.TypeAMM {
 				if hasAMM {
-					return false, tx.TecINTERNAL
+					return false, ter.TecINTERNAL
 				}
 				hasAMM = true
 				continue
 			}
 			if entry.Type(entryType) != entry.TypeRippleState {
-				return false, tx.TecINTERNAL
+				return false, ter.TecINTERNAL
 			}
 
 			rs, err := state.ParseRippleState(itemData)
 			if err != nil {
-				return false, tx.TecINTERNAL
+				return false, ter.TecINTERNAL
 			}
 
 			isLPTrustline := rs.LowLimit.Issuer == lpAccountAddr ||
@@ -216,37 +217,37 @@ func isOnlyLiquidityProvider(view tx.LedgerView, lptCurrency string, ammAccountI
 			case isLPTrustline:
 				if isLPTokenTrustline {
 					if nLPTokenTrustLines++; nLPTokenTrustLines > 1 {
-						return false, tx.TecINTERNAL
+						return false, ter.TecINTERNAL
 					}
 				} else if nIOUTrustLines++; nIOUTrustLines > 2 {
-					return false, tx.TecINTERNAL
+					return false, ter.TecINTERNAL
 				}
 			case isLPTokenTrustline:
-				return false, tx.TesSUCCESS
+				return false, ter.TesSUCCESS
 			default:
 				if nIOUTrustLines++; nIOUTrustLines > 2 {
-					return false, tx.TecINTERNAL
+					return false, ter.TecINTERNAL
 				}
 			}
 		}
 
 		if currentPage.IndexNext == 0 {
 			if nLPTokenTrustLines != 1 || nIOUTrustLines == 0 || nIOUTrustLines > 2 {
-				return false, tx.TecINTERNAL
+				return false, ter.TecINTERNAL
 			}
-			return true, tx.TesSUCCESS
+			return true, ter.TesSUCCESS
 		}
 
 		pageData, err := view.Read(keylet.DirPage(ownerDirKey.Key, currentPage.IndexNext))
 		if err != nil || pageData == nil {
-			return false, tx.TecINTERNAL
+			return false, ter.TecINTERNAL
 		}
 		currentPage, err = state.ParseDirectoryNode(pageData)
 		if err != nil {
-			return false, tx.TecINTERNAL
+			return false, ter.TecINTERNAL
 		}
 	}
-	return false, tx.TecINTERNAL
+	return false, ter.TecINTERNAL
 }
 
 // isLPTokenIssue reports whether a trust-line limit's issue is the AMM's LP

--- a/internal/tx/amm/constants.go
+++ b/internal/tx/amm/constants.go
@@ -2,6 +2,7 @@ package amm
 
 import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // AMM constants matching rippled.
@@ -68,9 +69,9 @@ const (
 
 // Result code aliases for AMM-specific codes
 var (
-	TecUNFUNDED_AMM       = tx.TecUNFUNDED_AMM
-	TecNO_LINE            = tx.TecNO_LINE
-	TecINSUF_RESERVE_LINE = tx.TecINSUF_RESERVE_LINE
-	TerNO_AMM             = tx.TerNO_AMM
-	TerNO_ACCOUNT         = tx.TerNO_ACCOUNT
+	TecUNFUNDED_AMM       = ter.TecUNFUNDED_AMM
+	TecNO_LINE            = ter.TecNO_LINE
+	TecINSUF_RESERVE_LINE = ter.TecINSUF_RESERVE_LINE
+	TerNO_AMM             = ter.TerNO_AMM
+	TerNO_ACCOUNT         = ter.TerNO_ACCOUNT
 )

--- a/internal/tx/amm/formulas.go
+++ b/internal/tx/amm/formulas.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // getAccountTradingFee returns the trading fee for an account interacting with
@@ -528,10 +529,10 @@ func initializeFeeAuctionVote(amm *AMMData, accountID [20]byte, lptCurrency stri
 // verifyAndAdjustLPTokenBalance adjusts the AMM SLE's LPTokenBalance when
 // the last LP's trust line balance differs from it due to rounding.
 // Reference: rippled AMMUtils.cpp verifyAndAdjustLPTokenBalance (lines 468-494)
-func verifyAndAdjustLPTokenBalance(view tx.LedgerView, lpTokens tx.Amount, amm *AMMData, lpAccountID [20]byte) tx.Result {
+func verifyAndAdjustLPTokenBalance(view tx.LedgerView, lpTokens tx.Amount, amm *AMMData, lpAccountID [20]byte) ter.Result {
 	lptCurrency := GenerateAMMLPTCurrency(amm.Asset.Currency, amm.Asset2.Currency)
 	onlyLP, res := isOnlyLiquidityProvider(view, lptCurrency, amm.Account, lpAccountID)
-	if res != tx.TesSUCCESS {
+	if res != ter.TesSUCCESS {
 		return res
 	}
 	if onlyLP {
@@ -540,9 +541,9 @@ func verifyAndAdjustLPTokenBalance(view tx.LedgerView, lpTokens tx.Amount, amm *
 		if withinRelativeDistance(lpTokens, amm.LPTokenBalance, tolerance) {
 			amm.LPTokenBalance = lpTokens
 		} else {
-			return tx.TecAMM_INVALID_TOKENS
+			return ter.TecAMM_INVALID_TOKENS
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/amm/testhooks.go
+++ b/internal/tx/amm/testhooks.go
@@ -1,6 +1,9 @@
 package amm
 
-import "github.com/LeJamon/go-xrpl/internal/tx"
+import (
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
 
 // This file exposes a handful of unexported AMM internals so the
 // internal/testing/amm package (a separate package, so export_test.go does not
@@ -19,6 +22,6 @@ func AMMAssetOutExported(assetBalance, lptBalance, lpTokens tx.Amount, tfee uint
 }
 
 // IsOnlyLiquidityProviderExported wraps isOnlyLiquidityProvider.
-func IsOnlyLiquidityProviderExported(view tx.LedgerView, lptCurrency string, ammAccountID, lpAccountID [20]byte) (bool, tx.Result) {
+func IsOnlyLiquidityProviderExported(view tx.LedgerView, lptCurrency string, ammAccountID, lpAccountID [20]byte) (bool, ter.Result) {
 	return isOnlyLiquidityProvider(view, lptCurrency, ammAccountID, lpAccountID)
 }

--- a/internal/tx/amm/trustline.go
+++ b/internal/tx/amm/trustline.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -40,7 +41,7 @@ type trustCreateOpts struct {
 // 0/-100 limits, the receiver's reserve flag, the optional lsfAMMNode and
 // DefaultRipple-derived NoRipple flags, links both owner directories, and
 // records the deletion hints. It mirrors rippled's trustCreate.
-func trustCreate(view tx.LedgerView, receiverID, counterpartyID [20]byte, currency string, amount tx.Amount, opts trustCreateOpts) tx.Result {
+func trustCreate(view tx.LedgerView, receiverID, counterpartyID [20]byte, currency string, amount tx.Amount, opts trustCreateOpts) ter.Result {
 	receiverIsLow := keylet.IsLowAccount(receiverID, counterpartyID)
 	lowID, highID := counterpartyID, receiverID
 	if receiverIsLow {
@@ -98,7 +99,7 @@ func trustCreate(view tx.LedgerView, receiverID, counterpartyID [20]byte, curren
 		dir.Owner = lowID
 	})
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	rs.LowNode = lowDirResult.Page
 
@@ -106,18 +107,18 @@ func trustCreate(view tx.LedgerView, receiverID, counterpartyID [20]byte, curren
 		dir.Owner = highID
 	})
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	rs.HighNode = highDirResult.Page
 
 	rsBytes, err := state.SerializeRippleState(rs)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := view.Insert(lineKey, rsBytes); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // trustDelete removes a trust line from the low and high owner directories and
@@ -235,7 +236,7 @@ func createOrUpdateAMMTrustline(ammAccountID [20]byte, asset tx.Asset, amount tx
 	}
 
 	// Trustline doesn't exist - create the AMM-owned line.
-	if result := trustCreate(view, ammAccountID, issuerID, asset.Currency, amount, trustCreateOpts{setAMMNode: true}); result != tx.TesSUCCESS {
+	if result := trustCreate(view, ammAccountID, issuerID, asset.Currency, amount, trustCreateOpts{setAMMNode: true}); result != ter.TesSUCCESS {
 		return errors.New("trust create failed")
 	}
 	return nil
@@ -457,7 +458,7 @@ func createLPTokenTrustline(accountID [20]byte, lptAsset tx.Asset, amount tx.Amo
 
 	// Trustline doesn't exist - create the holder's LP token line. The holder
 	// receives the tokens; NoRipple is set per each side's DefaultRipple flag.
-	if result := trustCreate(view, accountID, ammAccountID, lptAsset.Currency, amount, trustCreateOpts{setNoRipple: true}); result != tx.TesSUCCESS {
+	if result := trustCreate(view, accountID, ammAccountID, lptAsset.Currency, amount, trustCreateOpts{setNoRipple: true}); result != ter.TesSUCCESS {
 		return errors.New("trust create failed")
 	}
 	return nil
@@ -467,20 +468,20 @@ func createLPTokenTrustline(accountID [20]byte, lptAsset tx.Asset, amount tx.Amo
 // the line when its balance reaches zero (matching rippled's redeemIOU +
 // updateTrustLine + trustDelete flow).
 // Reference: rippled View.cpp redeemIOU (line 2288)
-func redeemIOUWithCleanup(view tx.LedgerView, holderID, ammAccountID [20]byte, amount tx.Amount) tx.Result {
+func redeemIOUWithCleanup(view tx.LedgerView, holderID, ammAccountID [20]byte, amount tx.Amount) ter.Result {
 	if amount.IsZero() {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	trustLineKey := keylet.Line(holderID, ammAccountID, amount.Currency)
 	data, err := view.Read(trustLineKey)
 	if err != nil || data == nil {
-		return tx.TefINTERNAL // LP token trust line must exist
+		return ter.TefINTERNAL // LP token trust line must exist
 	}
 
 	rs, err := state.ParseRippleState(data)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	holderHigh := !keylet.IsLowAccount(holderID, ammAccountID)
@@ -495,7 +496,7 @@ func redeemIOUWithCleanup(view tx.LedgerView, holderID, ammAccountID [20]byte, a
 	// Holder is redeeming (sending back to AMM/issuer), so balance decreases
 	saBalance, err = saBalance.Sub(amount)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Reference: rippled View.cpp updateTrustLine (line 2135) + redeemIOU (line 2323)
@@ -544,10 +545,10 @@ func redeemIOUWithCleanup(view tx.LedgerView, holderID, ammAccountID [20]byte, a
 			holderAccount.OwnerCount--
 			holderBytes, err := state.SerializeAccountRoot(holderAccount)
 			if err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			if err := view.Update(keylet.Account(holderID), holderBytes); err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 		}
 
@@ -578,24 +579,24 @@ func redeemIOUWithCleanup(view tx.LedgerView, holderID, ammAccountID [20]byte, a
 
 	rsBytes, err := state.SerializeRippleState(rs)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := view.Update(trustLineKey, rsBytes); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // trustDeleteRippleState removes a trust line from both owner directories and
 // erases it. Reference: rippled View.cpp trustDelete (line 1534)
-func trustDeleteRippleState(view tx.LedgerView, lineKey keylet.Keylet, rs *state.RippleState, id1, id2 [20]byte, id1IsHigh bool) tx.Result {
+func trustDeleteRippleState(view tx.LedgerView, lineKey keylet.Keylet, rs *state.RippleState, id1, id2 [20]byte, id1IsHigh bool) ter.Result {
 	lowID, highID := id1, id2
 	if id1IsHigh {
 		lowID, highID = id2, id1
 	}
 	if trustDelete(view, lineKey, lowID, highID, rs.LowNode, rs.HighNode) != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/amm/validate.go
+++ b/internal/tx/amm/validate.go
@@ -2,6 +2,7 @@ package amm
 
 import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -14,18 +15,18 @@ var badCurrencyBytes = [20]byte{12: 'X', 13: 'R', 14: 'P'}
 // asset whose currency is the bad "XRP" 160-bit code is temBAD_CURRENCY, an XRP
 // asset paired with a non-zero issuer is temBAD_ISSUER, and — when a pair is
 // supplied — an asset matching neither member is temBAD_AMM_TOKENS.
-func invalidAMMAsset(asset tx.Asset, pair *[2]tx.Asset) tx.Result {
+func invalidAMMAsset(asset tx.Asset, pair *[2]tx.Asset) ter.Result {
 	if keylet.CurrencyBytes(asset.Currency) == badCurrencyBytes {
-		return tx.TemBAD_CURRENCY
+		return ter.TemBAD_CURRENCY
 	}
 	isXRP := isXRPAsset(asset)
 	if isXRP && asset.Issuer != "" {
-		return tx.TemBAD_ISSUER
+		return ter.TemBAD_ISSUER
 	}
 	if pair != nil && !matchesAssetByIssue(asset, pair[0]) && !matchesAssetByIssue(asset, pair[1]) {
-		return tx.TemBAD_AMM_TOKENS
+		return ter.TemBAD_AMM_TOKENS
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // amountAsset returns the issue (currency + issuer) of an amount.
@@ -49,11 +50,11 @@ func validateAMMAmountWithPair(amt tx.Amount, asset1, asset2 *tx.Asset, validZer
 	if asset1 != nil && asset2 != nil {
 		pair = &[2]tx.Asset{*asset1, *asset2}
 	}
-	if res := invalidAMMAsset(amountAsset(amt), pair); res != tx.TesSUCCESS {
-		return tx.Errorf(res, "invalid amount asset")
+	if res := invalidAMMAsset(amountAsset(amt), pair); res != ter.TesSUCCESS {
+		return ter.Errorf(res, "invalid amount asset")
 	}
 	if amt.IsNegative() || (!validZero && amt.IsZero()) {
-		return tx.Errorf(tx.TemBAD_AMOUNT, "amount must be positive")
+		return ter.Errorf(ter.TemBAD_AMOUNT, "amount must be positive")
 	}
 	return nil
 }
@@ -62,13 +63,13 @@ func validateAMMAmountWithPair(amt tx.Amount, asset1, asset2 *tx.Asset, validZer
 // the two assets must not be the same issue, and each must be a valid AMM asset.
 func validateAssetPair(asset1, asset2 tx.Asset) error {
 	if matchesAssetByIssue(asset1, asset2) {
-		return tx.Errorf(tx.TemBAD_AMM_TOKENS, "asset pair has same issue")
+		return ter.Errorf(ter.TemBAD_AMM_TOKENS, "asset pair has same issue")
 	}
-	if res := invalidAMMAsset(asset1, nil); res != tx.TesSUCCESS {
-		return tx.Errorf(res, "invalid asset")
+	if res := invalidAMMAsset(asset1, nil); res != ter.TesSUCCESS {
+		return ter.Errorf(res, "invalid asset")
 	}
-	if res := invalidAMMAsset(asset2, nil); res != tx.TesSUCCESS {
-		return tx.Errorf(res, "invalid asset2")
+	if res := invalidAMMAsset(asset2, nil); res != ter.TesSUCCESS {
+		return ter.Errorf(res, "invalid asset2")
 	}
 	return nil
 }

--- a/internal/tx/amm/view_helpers.go
+++ b/internal/tx/amm/view_helpers.go
@@ -3,6 +3,7 @@ package amm
 import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -112,29 +113,29 @@ func setAMMNodeFlag(ammAccountID [20]byte, asset tx.Asset, view tx.LedgerView) e
 // lsfAllowTrustLineClawback set, tecINTERNAL when the issuer cannot be read,
 // and tesSUCCESS otherwise. XRP always passes.
 // Reference: rippled AMMCreate.cpp preclaim lines 201-210
-func clawbackDisabled(view tx.LedgerView, asset tx.Asset) tx.Result {
+func clawbackDisabled(view tx.LedgerView, asset tx.Asset) ter.Result {
 	if isXRPAsset(asset) {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	issuerID, err := state.DecodeAccountID(asset.Issuer)
 	if err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	issuerData, err := view.Read(keylet.Account(issuerID))
 	if err != nil || issuerData == nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	issuerAccount, err := state.ParseAccountRoot(issuerData)
 	if err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	if (issuerAccount.Flags & state.LsfAllowTrustLineClawback) != 0 {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/apply.go
+++ b/internal/tx/apply.go
@@ -288,14 +288,14 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 
 	// Create a minimal ApplyContext for pseudo-transactions
 	ctx := &ApplyContext{
-		View:     table,
-		Account:  nil, // No account for pseudo-transactions
-		Config:   e.config,
-		TxHash:   txHash,
-		Metadata: metadata,
-		Engine:   e,
-		Log:      e.logger,
-		Ctx:      reqCtx,
+		View:            table,
+		Account:         nil, // No account for pseudo-transactions
+		Config:          e.config,
+		TxHash:          txHash,
+		Metadata:        metadata,
+		InnerInvariants: e,
+		Log:             e.logger,
+		Ctx:             reqCtx,
 	}
 
 	// Apply the transaction

--- a/internal/tx/apply.go
+++ b/internal/tx/apply.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -26,7 +27,7 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 	txType := tx.TxType()
 	if txType.IsPseudoTransaction() {
 		return ApplyResult{
-			Result:  TemINVALID,
+			Result:  ter.TemINVALID,
 			Applied: false,
 			Message: "pseudo-transactions cannot be submitted",
 		}
@@ -58,7 +59,7 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 	txHash, err := computeTransactionHash(tx)
 	if err != nil {
 		return ApplyResult{
-			Result:  TefINTERNAL,
+			Result:  ter.TefINTERNAL,
 			Applied: false,
 			Message: fmt.Sprintf("failed to compute transaction hash: %v", err),
 		}
@@ -69,7 +70,7 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 	// engine computes the id here, so the equivalent guard runs before preclaim.
 	if txHash == ([32]byte{}) {
 		return ApplyResult{
-			Result:  TemINVALID,
+			Result:  ter.TemINVALID,
 			Applied: false,
 			Message: "transaction id may not be zero",
 		}
@@ -113,7 +114,7 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 	// Step 5: Apply the transaction
 	metadata := &Metadata{
 		AffectedNodes:     make([]AffectedNode, 0),
-		TransactionResult: TesSUCCESS,
+		TransactionResult: ter.TesSUCCESS,
 	}
 
 	if result.IsSuccess() {
@@ -260,7 +261,7 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 	txHash, err := computeTransactionHash(tx)
 	if err != nil {
 		return ApplyResult{
-			Result:  TefINTERNAL,
+			Result:  ter.TefINTERNAL,
 			Applied: false,
 			Message: fmt.Sprintf("failed to compute transaction hash: %v", err),
 		}
@@ -269,10 +270,10 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 	// A zero transaction id is never valid (rippled preflight0, Transactor.cpp).
 	if txHash == ([32]byte{}) {
 		return ApplyResult{
-			Result:   TemINVALID,
+			Result:   ter.TemINVALID,
 			Applied:  false,
 			Fee:      0,
-			Metadata: &Metadata{TransactionResult: TemINVALID},
+			Metadata: &Metadata{TransactionResult: ter.TemINVALID},
 			Message:  "transaction id may not be zero",
 		}
 	}
@@ -280,7 +281,7 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 	// Create metadata
 	metadata := &Metadata{
 		AffectedNodes:     make([]AffectedNode, 0),
-		TransactionResult: TesSUCCESS,
+		TransactionResult: ter.TesSUCCESS,
 	}
 
 	// Create ApplyStateTable to track changes
@@ -299,11 +300,11 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 	}
 
 	// Apply the transaction
-	var result Result
+	var result ter.Result
 	if appliable, ok := tx.(Appliable); ok {
 		result = appliable.Apply(ctx)
 	} else {
-		result = TesSUCCESS
+		result = ter.TesSUCCESS
 	}
 
 	metadata.TransactionResult = result
@@ -313,7 +314,7 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 		generatedMeta, err := table.Apply()
 		if err != nil {
 			return ApplyResult{
-				Result:   TefINTERNAL,
+				Result:   ter.TefINTERNAL,
 				Applied:  false,
 				Metadata: metadata,
 				Message:  fmt.Sprintf("failed to apply state changes: %v", err),
@@ -343,18 +344,18 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 // payDelegatedFeeOnTable) so the fee/seq commit semantics stay in lockstep.
 // Reference: rippled applySteps.cpp — likelyToClaimFee tec still enters
 // Transactor::operator() which calls reset(fee) before returning.
-func (e *Engine) commitPreclaimTec(ctx context.Context, tx Transaction, txHash [32]byte, fee uint64, origResult Result, metadata *Metadata) (Result, uint64) {
+func (e *Engine) commitPreclaimTec(ctx context.Context, tx Transaction, txHash [32]byte, fee uint64, origResult ter.Result, metadata *Metadata) (ter.Result, uint64) {
 	common := tx.GetCommon()
 	accountID, _ := state.DecodeAccountID(common.Account)
 	accountKey := keylet.Account(accountID)
 
 	accountData, readErr := e.view.Read(accountKey)
 	if readErr != nil || accountData == nil {
-		return TefINTERNAL, 0
+		return ter.TefINTERNAL, 0
 	}
 	recoveredAccount, parseErr := state.ParseAccountRoot(accountData)
 	if parseErr != nil {
-		return TefINTERNAL, 0
+		return ter.TefINTERNAL, 0
 	}
 
 	st := &applyState{
@@ -376,14 +377,14 @@ func (e *Engine) commitPreclaimTec(ctx context.Context, tx Transaction, txHash [
 	tecTable := NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, e.rules())
 
 	if st.isTicket {
-		if r := e.consumeTicketForRecovery(st, tecTable); r != TesSUCCESS {
+		if r := e.consumeTicketForRecovery(st, tecTable); r != ter.TesSUCCESS {
 			return r, 0
 		}
 	}
-	if r := e.writeRecoveryAccount(st, tecTable, recoveredAccount); r != TesSUCCESS {
+	if r := e.writeRecoveryAccount(st, tecTable, recoveredAccount); r != ter.TesSUCCESS {
 		return r, 0
 	}
-	if r := e.payDelegatedFeeOnTable(st, tecTable); r != TesSUCCESS {
+	if r := e.payDelegatedFeeOnTable(st, tecTable); r != ter.TesSUCCESS {
 		return r, 0
 	}
 
@@ -399,7 +400,7 @@ func (e *Engine) commitPreclaimTec(ctx context.Context, tx Transaction, txHash [
 
 	generatedMeta, applyErr := tecTable.Apply()
 	if applyErr != nil {
-		return TefINTERNAL, 0
+		return ter.TefINTERNAL, 0
 	}
 	metadata.AffectedNodes = generatedMeta.AffectedNodes
 	return origResult, st.chargedFee

--- a/internal/tx/apply_context.go
+++ b/internal/tx/apply_context.go
@@ -37,8 +37,10 @@ type ApplyContext struct {
 	// Metadata allows transactions to set DeliveredAmount (used by Payment)
 	Metadata *Metadata
 
-	// Engine provides access to shared helper methods (dirInsert, dirRemove, etc.)
-	Engine *Engine
+	// InnerInvariants runs the per-inner-transaction invariant pass that Batch
+	// needs for each isolated inner delta. It is a narrow interface — satisfied
+	// by the engine — so the contract layer never holds the concrete orchestrator.
+	InnerInvariants InnerInvariantChecker
 
 	// SignedWithMaster is true when the transaction was signed with the account's master key.
 	// Reference: rippled SetAccount.cpp sigWithMaster — derived from SigningPubKey.
@@ -54,6 +56,16 @@ type ApplyContext struct {
 	// construction site; callers that build an ApplyContext directly must
 	// pass a non-nil context.
 	Ctx context.Context
+}
+
+// InnerInvariantChecker runs the invariant pass for a single Batch inner
+// transaction against its own isolated delta. Batch reaches the engine through
+// this narrow interface so the contract layer (ApplyContext) does not depend on
+// the engine package. innerTable is the inner tx's isolated state delta — an
+// *ApplyStateTable in practice, accepted here as a LedgerView so the interface
+// stays free of the apply-state package.
+type InnerInvariantChecker interface {
+	CheckInnerInvariants(innerTx Transaction, result Result, innerTable LedgerView) Result
 }
 
 // AccountReserve calculates the total reserve required for an account with the given owner count.

--- a/internal/tx/apply_context.go
+++ b/internal/tx/apply_context.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 )
@@ -65,7 +66,7 @@ type ApplyContext struct {
 // *ApplyStateTable in practice, accepted here as a LedgerView so the interface
 // stays free of the apply-state package.
 type InnerInvariantChecker interface {
-	CheckInnerInvariants(innerTx Transaction, result Result, innerTable LedgerView) Result
+	CheckInnerInvariants(innerTx Transaction, result ter.Result, innerTable LedgerView) ter.Result
 }
 
 // AccountReserve calculates the total reserve required for an account with the given owner count.
@@ -87,7 +88,7 @@ func (ctx *ApplyContext) CanCreateNewObject(priorBalance uint64, currentOwnerCou
 
 // CheckReserveIncrease validates that an account can afford the reserve increase
 // for creating a new ledger object. Returns TecINSUFFICIENT_RESERVE if not enough funds.
-func (ctx *ApplyContext) CheckReserveIncrease(priorBalance uint64, currentOwnerCount uint32) Result {
+func (ctx *ApplyContext) CheckReserveIncrease(priorBalance uint64, currentOwnerCount uint32) ter.Result {
 	return ctx.Config.CheckReserveIncrease(priorBalance, currentOwnerCount)
 }
 
@@ -104,39 +105,39 @@ func (ctx *ApplyContext) Rules() *amendment.Rules {
 //   - TemINVALID if the address cannot be decoded
 //   - TecNO_DST if the account does not exist
 //   - TefINTERNAL if the account data cannot be read or parsed
-func (ctx *ApplyContext) LookupAccount(account string) (*state.AccountRoot, [20]byte, Result) {
+func (ctx *ApplyContext) LookupAccount(account string) (*state.AccountRoot, [20]byte, ter.Result) {
 	var zeroID [20]byte
 	accountID, err := state.DecodeAccountID(account)
 	if err != nil {
-		return nil, zeroID, TemINVALID
+		return nil, zeroID, ter.TemINVALID
 	}
 
 	accountRoot, err := ReadAccountRoot(ctx.View, accountID)
 	if err != nil {
 		// A real storage or parse failure is an internal fault.
-		return nil, zeroID, TefINTERNAL
+		return nil, zeroID, ter.TefINTERNAL
 	}
 	if accountRoot == nil {
-		return nil, zeroID, TecNO_DST
+		return nil, zeroID, ter.TecNO_DST
 	}
 
-	return accountRoot, accountID, TesSUCCESS
+	return accountRoot, accountID, ter.TesSUCCESS
 }
 
 // LookupDestination loads and parses a destination account.
 // In addition to LookupAccount checks, it also rejects pseudo-accounts
 // (AMM / Vault), matching rippled's isPseudoAccount test (View.cpp:1138).
-func (ctx *ApplyContext) LookupDestination(account string) (*state.AccountRoot, [20]byte, Result) {
+func (ctx *ApplyContext) LookupDestination(account string) (*state.AccountRoot, [20]byte, ter.Result) {
 	dest, destID, result := ctx.LookupAccount(account)
-	if result != TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return nil, destID, result
 	}
 
 	if dest.IsPseudoAccount() {
-		return nil, destID, TecNO_PERMISSION
+		return nil, destID, ter.TecNO_PERMISSION
 	}
 
-	return dest, destID, TesSUCCESS
+	return dest, destID, ter.TesSUCCESS
 }
 
 // PriorBalance returns the source account's balance before its own fee was
@@ -151,26 +152,26 @@ func (ctx *ApplyContext) PriorBalance() uint64 {
 // given owner count using its prior balance (before its fee was deducted),
 // allowing it to dip into the reserve to pay the fee. Returns
 // TecINSUFFICIENT_RESERVE if the prior balance is below the reserve.
-func (ctx *ApplyContext) CheckReserveWithFee(ownerCountAfter uint32) Result {
+func (ctx *ApplyContext) CheckReserveWithFee(ownerCountAfter uint32) ter.Result {
 	if ctx.PriorBalance() < ctx.AccountReserve(ownerCountAfter) {
-		return TecINSUFFICIENT_RESERVE
+		return ter.TecINSUFFICIENT_RESERVE
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // UpdateAccountRoot serializes an AccountRoot and writes it back to the ledger view.
 // Encapsulates the serialize + view.Update pattern repeated across Apply() methods.
 // Returns TefINTERNAL on serialization or update failure, TesSUCCESS otherwise.
-func (ctx *ApplyContext) UpdateAccountRoot(accountID [20]byte, account *state.AccountRoot) Result {
+func (ctx *ApplyContext) UpdateAccountRoot(accountID [20]byte, account *state.AccountRoot) ter.Result {
 	data, err := state.SerializeAccountRoot(account)
 	if err != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	accountKey := keylet.Account(accountID)
 	if err := ctx.View.Update(accountKey, data); err != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // SyncSenderOwnerCount refreshes ctx.Account.OwnerCount from the view. Use it

--- a/internal/tx/applystate/apply_metadata_bench_test.go
+++ b/internal/tx/applystate/apply_metadata_bench_test.go
@@ -1,4 +1,4 @@
-package tx
+package applystate
 
 import (
 	"testing"

--- a/internal/tx/applystate/apply_metadata_parity_test.go
+++ b/internal/tx/applystate/apply_metadata_parity_test.go
@@ -1,10 +1,11 @@
-package tx
+package applystate
 
 import (
 	"bytes"
 	"reflect"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ledgerfields"
 )
 
@@ -132,7 +133,7 @@ func assertParityDeleted(t *testing.T, key [32]byte, orig, curr []byte) {
 	assertAffectedNodeEqual(t, "DeletedNode", generic, typed)
 }
 
-func assertAffectedNodeEqual(t *testing.T, label string, want, got AffectedNode) {
+func assertAffectedNodeEqual(t *testing.T, label string, want, got tx.AffectedNode) {
 	t.Helper()
 	if want.NodeType != got.NodeType {
 		t.Errorf("%s: NodeType differ: generic=%s typed=%s", label, want.NodeType, got.NodeType)

--- a/internal/tx/applystate/apply_state_table.go
+++ b/internal/tx/applystate/apply_state_table.go
@@ -1,4 +1,4 @@
-package tx
+package applystate
 
 import (
 	"bytes"
@@ -9,6 +9,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/invariants"
 	"github.com/LeJamon/go-xrpl/internal/tx/ledgerfields"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -68,7 +69,7 @@ type ThreadedOwner struct {
 // ApplyStateTable wraps a LedgerView and tracks all modifications
 // for automatic metadata generation, similar to rippled's ApplyStateTable
 type ApplyStateTable struct {
-	base             LedgerView
+	base             tx.LedgerView
 	items            map[[32]byte]*TrackedEntry
 	threadOnlyOwners map[[32]byte]*ThreadedOwner
 	drops            drops.XRPAmount
@@ -80,7 +81,7 @@ type ApplyStateTable struct {
 // NewApplyStateTable creates a new ApplyStateTable wrapping the given base view.
 // rules controls amendment-gated behaviour (threading, metadata flags).
 // If nil, defaults to all amendments enabled.
-func NewApplyStateTable(base LedgerView, txHash [32]byte, txSeq uint32, rules *amendment.Rules) *ApplyStateTable {
+func NewApplyStateTable(base tx.LedgerView, txHash [32]byte, txSeq uint32, rules *amendment.Rules) *ApplyStateTable {
 	return &ApplyStateTable{
 		base:             base,
 		items:            make(map[[32]byte]*TrackedEntry),
@@ -341,14 +342,14 @@ func (t *ApplyStateTable) Succ(key [32]byte) ([32]byte, []byte, bool, error) {
 // Threading is applied first (PreviousTxnID/PreviousTxnLgrSeq updates),
 // then metadata is generated from the final state.
 // Reference: rippled ApplyStateTable.cpp apply() lines 113-292
-func (t *ApplyStateTable) Apply() (*Metadata, error) {
+func (t *ApplyStateTable) Apply() (*tx.Metadata, error) {
 	// Phase 1: Apply threading to all entries
 	// This updates PreviousTxnID/PreviousTxnLgrSeq on entries and their owners
 	t.applyThreading()
 
 	// Phase 2: Generate metadata and apply to base
-	metadata := &Metadata{
-		AffectedNodes: make([]AffectedNode, 0),
+	metadata := &tx.Metadata{
+		AffectedNodes: make([]tx.AffectedNode, 0),
 	}
 
 	for key, entry := range t.items {
@@ -417,7 +418,7 @@ func (t *ApplyStateTable) Apply() (*Metadata, error) {
 		}
 		if owner.OldPreviousTxnID != ([32]byte{}) {
 			// OLD prev fields per rippled ApplyStateTable.cpp:570-571.
-			node := AffectedNode{
+			node := tx.AffectedNode{
 				NodeType:          "ModifiedNode",
 				LedgerEntryType:   owner.EntryType,
 				LedgerIndex:       strings.ToUpper(hex.EncodeToString(key[:])),
@@ -447,7 +448,7 @@ func (t *ApplyStateTable) Apply() (*Metadata, error) {
 // AllSupportedRules() or EmptyRules() explicitly.
 func (t *ApplyStateTable) effectiveRules() *amendment.Rules {
 	if t.rules == nil {
-		panic("tx.ApplyStateTable: rules is nil — caller must pass " +
+		panic("applystate.ApplyStateTable: rules is nil — caller must pass " +
 			"amendment.Rules at construction (NewApplyStateTable).")
 	}
 	return t.rules
@@ -676,10 +677,10 @@ func (t *ApplyStateTable) GetItems() map[[32]byte]*TrackedEntry {
 }
 
 // buildCreatedNode creates metadata for a newly created entry
-func (t *ApplyStateTable) buildCreatedNode(key [32]byte, data []byte) (AffectedNode, error) {
+func (t *ApplyStateTable) buildCreatedNode(key [32]byte, data []byte) (tx.AffectedNode, error) {
 	entryType := state.EntryType(data)
 
-	node := AffectedNode{
+	node := tx.AffectedNode{
 		NodeType:        "CreatedNode",
 		LedgerEntryType: entryType,
 		LedgerIndex:     strings.ToUpper(hex.EncodeToString(key[:])),
@@ -734,10 +735,10 @@ func (t *ApplyStateTable) modifiedNodePrevTxn(key [32]byte, origEntry ledgerfiel
 }
 
 // buildModifiedNode creates metadata for a modified entry
-func (t *ApplyStateTable) buildModifiedNode(key [32]byte, original, current []byte) (AffectedNode, error) {
+func (t *ApplyStateTable) buildModifiedNode(key [32]byte, original, current []byte) (tx.AffectedNode, error) {
 	entryType := state.EntryType(current)
 
-	node := AffectedNode{
+	node := tx.AffectedNode{
 		NodeType:        "ModifiedNode",
 		LedgerEntryType: entryType,
 		LedgerIndex:     strings.ToUpper(hex.EncodeToString(key[:])),
@@ -877,11 +878,11 @@ func (t *ApplyStateTable) buildModifiedNode(key [32]byte, original, current []by
 
 // buildDeletedNode creates metadata for a deleted entry
 // original = state when first read, current = state just before deletion
-func (t *ApplyStateTable) buildDeletedNode(key [32]byte, original, current []byte) (AffectedNode, error) {
+func (t *ApplyStateTable) buildDeletedNode(key [32]byte, original, current []byte) (tx.AffectedNode, error) {
 	// Use current for entry type (it's the state just before deletion)
 	entryType := state.EntryType(current)
 
-	node := AffectedNode{
+	node := tx.AffectedNode{
 		NodeType:        "DeletedNode",
 		LedgerEntryType: entryType,
 		LedgerIndex:     strings.ToUpper(hex.EncodeToString(key[:])),

--- a/internal/tx/applystate/apply_state_table_test.go
+++ b/internal/tx/applystate/apply_state_table_test.go
@@ -1,4 +1,4 @@
-package tx
+package applystate
 
 import (
 	"bytes"

--- a/internal/tx/applystate/field_metadata.go
+++ b/internal/tx/applystate/field_metadata.go
@@ -1,4 +1,4 @@
-package tx
+package applystate
 
 import (
 	"encoding/hex"

--- a/internal/tx/applystate/threading.go
+++ b/internal/tx/applystate/threading.go
@@ -1,4 +1,4 @@
-package tx
+package applystate
 
 import (
 	"encoding/hex"

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -71,27 +72,27 @@ const (
 // Batch errors. Inner-tx errors mirror the per-inner rejections in rippled
 // Batch.cpp:249-374 (Batch::preflight inner loop).
 var (
-	ErrBatchTooFewTxns            = tx.Errorf(tx.TemARRAY_EMPTY, "batch must have at least 2 transactions")
-	ErrBatchTooManyTxns           = tx.Errorf(tx.TemARRAY_TOO_LARGE, "batch exceeds 8 transactions")
-	ErrBatchInvalidFlags          = tx.Errorf(tx.TemINVALID_FLAG, "invalid batch flags")
-	ErrBatchMustHaveOneFlag       = tx.Errorf(tx.TemINVALID_FLAG, "exactly one batch mode flag required")
-	ErrBatchTooManySigners        = tx.Errorf(tx.TemARRAY_TOO_LARGE, "batch signers exceeds 8 entries")
-	ErrBatchDuplicateSigner       = tx.Errorf(tx.TemREDUNDANT, "duplicate batch signer")
-	ErrBatchSignerIsOuter         = tx.Errorf(tx.TemBAD_SIGNER, "batch signer cannot be outer account")
-	ErrBatchSignerNotRequired     = tx.Errorf(tx.TemBAD_SIGNER, "no account signature for inner txn")
-	ErrBatchMissingSigner         = tx.Errorf(tx.TemBAD_SIGNER, "missing batch signer for inner txn account")
-	ErrBatchInvalidSignature      = tx.Errorf(tx.TemBAD_SIGNATURE, "invalid batch txn signature")
-	ErrBatchNilInnerTx            = tx.Errorf(tx.TemMALFORMED, "inner transaction cannot be nil")
-	ErrBatchDuplicateInnerTx      = tx.Errorf(tx.TemREDUNDANT, "duplicate inner transaction")
-	ErrBatchInnerIsBatch          = tx.Errorf(tx.TemINVALID, "inner transaction cannot itself be a Batch")
-	ErrBatchInnerMissingFlag      = tx.Errorf(tx.TemINVALID_FLAG, "inner transaction missing tfInnerBatchTxn flag")
-	ErrBatchInnerHasTxnSignature  = tx.Errorf(tx.TemBAD_SIGNATURE, "inner transaction cannot include TxnSignature")
-	ErrBatchInnerHasSigners       = tx.Errorf(tx.TemBAD_SIGNER, "inner transaction cannot include Signers")
-	ErrBatchInnerHasSigningPubKey = tx.Errorf(tx.TemBAD_REGKEY, "inner transaction SigningPubKey must be empty")
-	ErrBatchInnerBadFee           = tx.Errorf(tx.TemBAD_FEE, "inner transaction must have a fee of 0")
-	ErrBatchInnerSeqAndTicket     = tx.Errorf(tx.TemSEQ_AND_TICKET, "inner transaction must have exactly one of Sequence and TicketSequence")
-	ErrBatchInnerDupSeqOrTicket   = tx.Errorf(tx.TemREDUNDANT, "duplicate inner Sequence or TicketSequence for account")
-	ErrBatchInnerHashUncomputable = tx.Errorf(tx.TemINVALID, "failed to compute inner transaction hash")
+	ErrBatchTooFewTxns            = ter.Errorf(ter.TemARRAY_EMPTY, "batch must have at least 2 transactions")
+	ErrBatchTooManyTxns           = ter.Errorf(ter.TemARRAY_TOO_LARGE, "batch exceeds 8 transactions")
+	ErrBatchInvalidFlags          = ter.Errorf(ter.TemINVALID_FLAG, "invalid batch flags")
+	ErrBatchMustHaveOneFlag       = ter.Errorf(ter.TemINVALID_FLAG, "exactly one batch mode flag required")
+	ErrBatchTooManySigners        = ter.Errorf(ter.TemARRAY_TOO_LARGE, "batch signers exceeds 8 entries")
+	ErrBatchDuplicateSigner       = ter.Errorf(ter.TemREDUNDANT, "duplicate batch signer")
+	ErrBatchSignerIsOuter         = ter.Errorf(ter.TemBAD_SIGNER, "batch signer cannot be outer account")
+	ErrBatchSignerNotRequired     = ter.Errorf(ter.TemBAD_SIGNER, "no account signature for inner txn")
+	ErrBatchMissingSigner         = ter.Errorf(ter.TemBAD_SIGNER, "missing batch signer for inner txn account")
+	ErrBatchInvalidSignature      = ter.Errorf(ter.TemBAD_SIGNATURE, "invalid batch txn signature")
+	ErrBatchNilInnerTx            = ter.Errorf(ter.TemMALFORMED, "inner transaction cannot be nil")
+	ErrBatchDuplicateInnerTx      = ter.Errorf(ter.TemREDUNDANT, "duplicate inner transaction")
+	ErrBatchInnerIsBatch          = ter.Errorf(ter.TemINVALID, "inner transaction cannot itself be a Batch")
+	ErrBatchInnerMissingFlag      = ter.Errorf(ter.TemINVALID_FLAG, "inner transaction missing tfInnerBatchTxn flag")
+	ErrBatchInnerHasTxnSignature  = ter.Errorf(ter.TemBAD_SIGNATURE, "inner transaction cannot include TxnSignature")
+	ErrBatchInnerHasSigners       = ter.Errorf(ter.TemBAD_SIGNER, "inner transaction cannot include Signers")
+	ErrBatchInnerHasSigningPubKey = ter.Errorf(ter.TemBAD_REGKEY, "inner transaction SigningPubKey must be empty")
+	ErrBatchInnerBadFee           = ter.Errorf(ter.TemBAD_FEE, "inner transaction must have a fee of 0")
+	ErrBatchInnerSeqAndTicket     = ter.Errorf(ter.TemSEQ_AND_TICKET, "inner transaction must have exactly one of Sequence and TicketSequence")
+	ErrBatchInnerDupSeqOrTicket   = ter.Errorf(ter.TemREDUNDANT, "duplicate inner Sequence or TicketSequence for account")
+	ErrBatchInnerHashUncomputable = ter.Errorf(ter.TemINVALID, "failed to compute inner transaction hash")
 )
 
 // NewBatch creates a new Batch transaction
@@ -443,7 +444,7 @@ func (b *Batch) GetBatchSigners() []tx.BatchSignerInfo {
 
 // It decodes and processes each inner transaction according to the batch mode flag.
 // Reference: rippled apply.cpp applyBatchTransactions()
-func (b *Batch) Apply(ctx *tx.ApplyContext) tx.Result {
+func (b *Batch) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("batch apply",
 		"account", b.Account,
 		"txCount", len(b.RawTransactions),
@@ -451,7 +452,7 @@ func (b *Batch) Apply(ctx *tx.ApplyContext) tx.Result {
 	)
 
 	if len(b.RawTransactions) == 0 {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	// Write the outer account state (with fee deducted and sequence incremented
@@ -459,10 +460,10 @@ func (b *Batch) Apply(ctx *tx.ApplyContext) tx.Result {
 	accountKey := keylet.Account(ctx.AccountID)
 	outerAccountData, err := state.SerializeAccountRoot(ctx.Account)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(accountKey, outerAccountData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	flags := b.GetFlags()
@@ -513,13 +514,13 @@ func (b *Batch) Apply(ctx *tx.ApplyContext) tx.Result {
 	// writes back the correct balance/sequence after Apply() returns.
 	syncAccountFromView(ctx)
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // applyAllOrNothing processes inner transactions with AllOrNothing semantics.
 // All inner txns must succeed, or all changes are rolled back.
 // Reference: rippled Batch.cpp applyBatchTransactions() with tfAllOrNothing
-func (b *Batch) applyAllOrNothing(ctx *tx.ApplyContext, innerTxns []tx.Transaction) tx.Result {
+func (b *Batch) applyAllOrNothing(ctx *tx.ApplyContext, innerTxns []tx.Transaction) ter.Result {
 	// Create a batch-level state table wrapping ctx.View
 	batchTable := tx.NewApplyStateTable(ctx.View, ctx.TxHash, ctx.Config.LedgerSequence, ctx.Config.Rules)
 
@@ -538,39 +539,39 @@ func (b *Batch) applyAllOrNothing(ctx *tx.ApplyContext, innerTxns []tx.Transacti
 	for _, innerTx := range innerTxns {
 		if innerTx == nil {
 			// Nil inner tx in AllOrNothing → rollback
-			return tx.TesSUCCESS
+			return ter.TesSUCCESS
 		}
 
 		result := applyInnerTransaction(batchCtx, innerTx)
 		if !result.IsSuccess() {
 			// Any failure in AllOrNothing → discard batch table (rollback)
-			return tx.TesSUCCESS
+			return ter.TesSUCCESS
 		}
 	}
 
 	// All succeeded — commit batch-level changes to ctx.View
 	_, err := batchTable.Apply()
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Sync ctx.Account with the final state in the view
 	syncAccountFromView(ctx)
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // applyInnerTransaction processes a single inner transaction against the given view.
 // It validates the sequence, increments it, and applies the transaction.
 // Failed transactions still increment the sequence.
 // Reference: rippled apply.cpp applyTransaction() with tapBATCH
-func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) tx.Result {
+func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) ter.Result {
 	common := innerTx.GetCommon()
 
 	// Decode the inner transaction's account
 	accountID, err := state.DecodeAccountID(common.Account)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	accountKey := keylet.Account(accountID)
@@ -578,21 +579,21 @@ func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) tx.Resu
 	// Read account from the view
 	exists, err := ctx.View.Exists(accountKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if !exists {
-		return tx.TerNO_ACCOUNT
+		return ter.TerNO_ACCOUNT
 	}
 
 	accountData, err := ctx.View.Read(accountKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	account, err := state.ParseAccountRoot(accountData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Determine whether this inner tx uses a ticket or a regular sequence.
@@ -605,23 +606,23 @@ func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) tx.Resu
 
 		// Ticket must have been created already (ticketSeq < account.Sequence)
 		if account.Sequence <= ticketSeq {
-			return tx.TerPRE_SEQ // terPRE_TICKET equivalent
+			return ter.TerPRE_SEQ // terPRE_TICKET equivalent
 		}
 
 		// Check ticket exists in the view
 		ticketKey := keylet.Ticket(accountID, ticketSeq)
 		ticketExists, tickErr := ctx.View.Exists(ticketKey)
 		if tickErr != nil || !ticketExists {
-			return tx.TefPAST_SEQ // tefNO_TICKET equivalent
+			return ter.TefPAST_SEQ // tefNO_TICKET equivalent
 		}
 	} else {
 		// Regular sequence-based inner transaction
 		if common.Sequence != nil {
 			if *common.Sequence < account.Sequence {
-				return tx.TefPAST_SEQ
+				return ter.TefPAST_SEQ
 			}
 			if *common.Sequence > account.Sequence {
-				return tx.TerPRE_SEQ
+				return ter.TerPRE_SEQ
 			}
 		}
 	}
@@ -644,10 +645,10 @@ func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) tx.Resu
 			ticketPage = state.GetOwnerNode(ticketData)
 		}
 		if res, err := state.DirRemove(perTxTable, ownerDirKey, ticketPage, ticketKey.Key, true); err != nil || !res.Success {
-			return tx.TefBAD_LEDGER
+			return ter.TefBAD_LEDGER
 		}
 		if err := perTxTable.Erase(ticketKey); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		if account.OwnerCount > 0 {
@@ -665,7 +666,7 @@ func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) tx.Resu
 	// This must happen after sequence increment because tec results still advance the sequence.
 	// Reference: rippled Transactor::checkPermission — verifies that the delegate
 	// account has a Delegate SLE granting permission for this tx type.
-	var delegateResult tx.Result
+	var delegateResult ter.Result
 	if common.Delegate != "" {
 		delegateResult = checkDelegatePermission(ctx, accountID, innerTx)
 	}
@@ -684,13 +685,13 @@ func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) tx.Resu
 	}
 
 	// Apply the inner transaction (skip if delegate check failed)
-	var result tx.Result
-	if delegateResult != tx.TesSUCCESS {
+	var result ter.Result
+	if delegateResult != ter.TesSUCCESS {
 		result = delegateResult
 	} else if appliable, ok := innerTx.(tx.Appliable); ok {
 		result = appliable.Apply(innerCtx)
 	} else {
-		result = tx.TesSUCCESS
+		result = ter.TesSUCCESS
 	}
 
 	// On success, write the sender account (with its fee/sequence/balance
@@ -703,10 +704,10 @@ func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) tx.Resu
 		if accountExists, _ := perTxTable.Exists(accountKey); accountExists {
 			updatedData, err := state.SerializeAccountRoot(account)
 			if err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			if err := perTxTable.Update(accountKey, updatedData); err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 		}
 	}
@@ -724,17 +725,17 @@ func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) tx.Resu
 
 	if result.IsSuccess() {
 		if _, err := perTxTable.Apply(); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	} else {
 		// TEC/TEF/TER: sequence increments but transaction effects are discarded.
 		// Update account state (sequence) directly in the parent view.
 		updatedData, err := state.SerializeAccountRoot(account)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := ctx.View.Update(accountKey, updatedData); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
@@ -762,25 +763,25 @@ func syncAccountFromView(ctx *tx.ApplyContext) {
 // checkDelegatePermission checks whether the Delegate on an inner tx has permission
 // to execute the transaction on behalf of the account.
 // Reference: rippled Transactor::checkPermission in Transactor.cpp
-func checkDelegatePermission(ctx *tx.ApplyContext, accountID [20]byte, innerTx tx.Transaction) tx.Result {
+func checkDelegatePermission(ctx *tx.ApplyContext, accountID [20]byte, innerTx tx.Transaction) ter.Result {
 	common := innerTx.GetCommon()
 	delegateID, delegateErr := state.DecodeAccountID(common.Delegate)
 	if delegateErr != nil {
-		return tx.TecNO_DELEGATE_PERMISSION
+		return ter.TecNO_DELEGATE_PERMISSION
 	}
 	delegateKeylet := keylet.Delegate(accountID, delegateID)
 	delegateData, readErr := ctx.View.Read(delegateKeylet)
 	if readErr != nil || delegateData == nil {
-		return tx.TecNO_DELEGATE_PERMISSION
+		return ter.TecNO_DELEGATE_PERMISSION
 	}
 	delegateEntry, parseErr := state.ParseDelegate(delegateData)
 	if parseErr != nil {
-		return tx.TecNO_DELEGATE_PERMISSION
+		return ter.TecNO_DELEGATE_PERMISSION
 	}
 	// Check if the delegate SLE grants permission for this tx type.
 	txTypeValue := uint32(innerTx.TxType())
 	if !delegateEntry.HasTxPermission(txTypeValue) {
-		return tx.TecNO_DELEGATE_PERMISSION
+		return ter.TecNO_DELEGATE_PERMISSION
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -522,7 +523,7 @@ func (b *Batch) Apply(ctx *tx.ApplyContext) ter.Result {
 // Reference: rippled Batch.cpp applyBatchTransactions() with tfAllOrNothing
 func (b *Batch) applyAllOrNothing(ctx *tx.ApplyContext, innerTxns []tx.Transaction) ter.Result {
 	// Create a batch-level state table wrapping ctx.View
-	batchTable := tx.NewApplyStateTable(ctx.View, ctx.TxHash, ctx.Config.LedgerSequence, ctx.Config.Rules)
+	batchTable := applystate.NewApplyStateTable(ctx.View, ctx.TxHash, ctx.Config.LedgerSequence, ctx.Config.Rules)
 
 	batchCtx := &tx.ApplyContext{
 		View:            batchTable,
@@ -628,7 +629,7 @@ func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) ter.Res
 	}
 
 	// Create per-tx state table for isolation
-	perTxTable := tx.NewApplyStateTable(ctx.View, ctx.TxHash, ctx.Config.LedgerSequence, ctx.Config.Rules)
+	perTxTable := applystate.NewApplyStateTable(ctx.View, ctx.TxHash, ctx.Config.LedgerSequence, ctx.Config.Rules)
 
 	if isTicket {
 		// Ticket-based: consume the ticket (delete it, adjust owner/ticket counts).

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -524,15 +524,15 @@ func (b *Batch) applyAllOrNothing(ctx *tx.ApplyContext, innerTxns []tx.Transacti
 	batchTable := tx.NewApplyStateTable(ctx.View, ctx.TxHash, ctx.Config.LedgerSequence, ctx.Config.Rules)
 
 	batchCtx := &tx.ApplyContext{
-		View:      batchTable,
-		Account:   ctx.Account,
-		AccountID: ctx.AccountID,
-		Config:    ctx.Config,
-		TxHash:    ctx.TxHash,
-		Metadata:  ctx.Metadata,
-		Engine:    ctx.Engine,
-		Log:       ctx.Log,
-		Ctx:       ctx.Ctx,
+		View:            batchTable,
+		Account:         ctx.Account,
+		AccountID:       ctx.AccountID,
+		Config:          ctx.Config,
+		TxHash:          ctx.TxHash,
+		Metadata:        ctx.Metadata,
+		InnerInvariants: ctx.InnerInvariants,
+		Log:             ctx.Log,
+		Ctx:             ctx.Ctx,
 	}
 
 	for _, innerTx := range innerTxns {
@@ -672,15 +672,15 @@ func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) tx.Resu
 
 	// Create inner apply context
 	innerCtx := &tx.ApplyContext{
-		View:      perTxTable,
-		Account:   account,
-		AccountID: accountID,
-		Config:    ctx.Config,
-		TxHash:    ctx.TxHash,
-		Metadata:  ctx.Metadata,
-		Engine:    ctx.Engine,
-		Log:       ctx.Log,
-		Ctx:       ctx.Ctx,
+		View:            perTxTable,
+		Account:         account,
+		AccountID:       accountID,
+		Config:          ctx.Config,
+		TxHash:          ctx.TxHash,
+		Metadata:        ctx.Metadata,
+		InnerInvariants: ctx.InnerInvariants,
+		Log:             ctx.Log,
+		Ctx:             ctx.Ctx,
 	}
 
 	// Apply the inner transaction (skip if delegate check failed)
@@ -719,7 +719,7 @@ func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) tx.Resu
 	// invariant-failed code so the inner delta is discarded below, exactly as a
 	// tec result is.
 	if result.IsSuccess() {
-		result = ctx.Engine.CheckInnerInvariants(innerTx, result, perTxTable)
+		result = ctx.InnerInvariants.CheckInnerInvariants(innerTx, result, perTxTable)
 	}
 
 	if result.IsSuccess() {

--- a/internal/tx/check/check_cancel.go
+++ b/internal/tx/check/check_cancel.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -42,7 +43,7 @@ func (c *CheckCancel) Validate() error {
 	}
 
 	if c.CheckID == "" {
-		return tx.Errorf(tx.TemMALFORMED, "CheckID is required")
+		return ter.Errorf(ter.TemMALFORMED, "CheckID is required")
 	}
 
 	return nil
@@ -57,7 +58,7 @@ func (c *CheckCancel) RequiredAmendments() [][32]byte {
 }
 
 // Apply implements preclaim + doApply matching rippled's CancelCheck.
-func (c *CheckCancel) Apply(ctx *tx.ApplyContext) tx.Result {
+func (c *CheckCancel) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("check cancel apply",
 		"account", c.Account,
 		"checkID", c.CheckID,
@@ -66,7 +67,7 @@ func (c *CheckCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Parse check ID
 	checkID, err := hex.DecodeString(c.CheckID)
 	if err != nil || len(checkID) != 32 {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	var checkKeyBytes [32]byte
@@ -78,13 +79,13 @@ func (c *CheckCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 	checkData, err := ctx.View.Read(checkKey)
 	if err != nil || checkData == nil {
 		ctx.Log.Warn("check cancel: check does not exist", "checkID", c.CheckID)
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	// Parse check
 	check, err := state.ParseCheck(checkData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	accountID := ctx.AccountID
@@ -100,7 +101,7 @@ func (c *CheckCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 	// cancel it; once expired, anyone can.
 	if !tx.HasExpiredField(check.Expiration, ctx.Config.ParentCloseTime) {
 		if !isCreator && !isDestination {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	}
 
@@ -113,7 +114,7 @@ func (c *CheckCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: CancelCheck.cpp L102-113
 	if srcID != dstID {
 		destDirKey := keylet.OwnerDir(dstID)
-		if result := tx.DirRemoveOrBadLedger(ctx.View, destDirKey, check.DestinationNode, checkKeyBytes); result != tx.TesSUCCESS {
+		if result := tx.DirRemoveOrBadLedger(ctx.View, destDirKey, check.DestinationNode, checkKeyBytes); result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -121,7 +122,7 @@ func (c *CheckCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Remove check from owner directory.
 	// Reference: CancelCheck.cpp L114-122
 	ownerDirKey := keylet.OwnerDir(srcID)
-	if result := tx.DirRemoveOrBadLedger(ctx.View, ownerDirKey, check.OwnerNode, checkKeyBytes); result != tx.TesSUCCESS {
+	if result := tx.DirRemoveOrBadLedger(ctx.View, ownerDirKey, check.OwnerNode, checkKeyBytes); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -141,12 +142,12 @@ func (c *CheckCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 		if err == nil && creatorData != nil {
 			creatorAccount, err := state.ParseAccountRoot(creatorData)
 			if err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			if creatorAccount.OwnerCount > 0 {
 				creatorAccount.OwnerCount--
 			}
-			if result := ctx.UpdateAccountRoot(check.Account, creatorAccount); result != tx.TesSUCCESS {
+			if result := ctx.UpdateAccountRoot(check.Account, creatorAccount); result != ter.TesSUCCESS {
 				return result
 			}
 		}
@@ -156,8 +157,8 @@ func (c *CheckCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: CancelCheck.cpp L129
 	if err := ctx.View.Erase(checkKey); err != nil {
 		ctx.Log.Error("check cancel: unable to delete check", "checkID", c.CheckID)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -49,7 +50,7 @@ func (c *CheckCash) Validate() error {
 	}
 
 	if c.CheckID == "" {
-		return tx.Errorf(tx.TemMALFORMED, "CheckID is required")
+		return ter.Errorf(ter.TemMALFORMED, "CheckID is required")
 	}
 
 	// Must have exactly one of Amount or DeliverMin
@@ -58,26 +59,26 @@ func (c *CheckCash) Validate() error {
 	hasDeliverMin := c.DeliverMin != nil
 
 	if hasAmount == hasDeliverMin {
-		return tx.Errorf(tx.TemMALFORMED, "must specify exactly one of Amount or DeliverMin")
+		return ter.Errorf(ter.TemMALFORMED, "must specify exactly one of Amount or DeliverMin")
 	}
 
 	// Validate the provided amount
 	// Reference: CashCheck.cpp L65-77
 	if hasAmount {
 		if c.Amount.Signum() <= 0 {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "Amount must be positive")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
 		}
 		if !c.Amount.IsNative() && c.Amount.Currency == "XRP" {
-			return tx.Errorf(tx.TemBAD_CURRENCY, "invalid currency")
+			return ter.Errorf(ter.TemBAD_CURRENCY, "invalid currency")
 		}
 	}
 
 	if hasDeliverMin {
 		if c.DeliverMin.Signum() <= 0 {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "DeliverMin must be positive")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "DeliverMin must be positive")
 		}
 		if !c.DeliverMin.IsNative() && c.DeliverMin.Currency == "XRP" {
-			return tx.Errorf(tx.TemBAD_CURRENCY, "invalid currency")
+			return ter.Errorf(ter.TemBAD_CURRENCY, "invalid currency")
 		}
 	}
 
@@ -105,7 +106,7 @@ func (c *CheckCash) RequiredAmendments() [][32]byte {
 }
 
 // Apply implements preclaim + doApply matching rippled's CashCheck.
-func (c *CheckCash) Apply(ctx *tx.ApplyContext) tx.Result {
+func (c *CheckCash) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("check cash apply",
 		"account", c.Account,
 		"checkID", c.CheckID,
@@ -116,7 +117,7 @@ func (c *CheckCash) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Parse check ID
 	checkIDBytes, err := hex.DecodeString(c.CheckID)
 	if err != nil || len(checkIDBytes) != 32 {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	var checkKeyBytes [32]byte
@@ -127,27 +128,27 @@ func (c *CheckCash) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: CashCheck.cpp L85-90
 	checkData, err := ctx.View.Read(checkKey)
 	if err != nil || checkData == nil {
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	// Parse check
 	check, err := state.ParseCheck(checkData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Verify the account is the destination
 	// Reference: CashCheck.cpp L93-98
 	accountID := ctx.AccountID
 	if check.DestinationID != accountID {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// A check written to self should have been caught at creation time, but
 	// guard defensively here as rippled does.
 	// Reference: CashCheck.cpp L99-106
 	if check.Account == accountID {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	// Read source (check writer) and destination accounts. If the check
@@ -156,29 +157,29 @@ func (c *CheckCash) Apply(ctx *tx.ApplyContext) tx.Result {
 	srcKey := keylet.Account(check.Account)
 	srcData, err := ctx.View.Read(srcKey)
 	if err != nil || srcData == nil {
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	destKey := keylet.Account(accountID)
 	destData, err := ctx.View.Read(destKey)
 	if err != nil || destData == nil {
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 	destAccount, err := state.ParseAccountRoot(destData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Check RequireDestTag on destination
 	// Reference: CashCheck.cpp L118-126
 	if (destAccount.Flags&state.LsfRequireDestTag) != 0 && !check.HasDestTag {
-		return tx.TecDST_TAG_NEEDED
+		return ter.TecDST_TAG_NEEDED
 	}
 
 	// Check expiration
 	// Reference: CashCheck.cpp L129-133
 	if tx.HasExpiredField(check.Expiration, ctx.Config.ParentCloseTime) {
-		return tx.TecEXPIRED
+		return ter.TecEXPIRED
 	}
 
 	// Currency and issuer of the requested amount (Amount or DeliverMin) must
@@ -190,7 +191,7 @@ func (c *CheckCash) Apply(ctx *tx.ApplyContext) tx.Result {
 	if value == nil {
 		value = c.DeliverMin
 	}
-	if result := matchesCheckSendMax(*value, check.SendMaxAmount); result != tx.TesSUCCESS {
+	if result := matchesCheckSendMax(*value, check.SendMaxAmount); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -206,24 +207,24 @@ func (c *CheckCash) Apply(ctx *tx.ApplyContext) tx.Result {
 // rippled's preclaim where the currency is compared before the issuer.
 // XRP and an issued currency never match (their currencies differ).
 // Reference: CashCheck.cpp L144-155.
-func matchesCheckSendMax(value, sendMax state.Amount) tx.Result {
+func matchesCheckSendMax(value, sendMax state.Amount) ter.Result {
 	if value.IsNative() != sendMax.IsNative() {
-		return tx.TemMALFORMED
+		return ter.TemMALFORMED
 	}
 	if value.IsNative() {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	if value.Currency != sendMax.Currency {
-		return tx.TemMALFORMED
+		return ter.TemMALFORMED
 	}
 	if value.Issuer != sendMax.Issuer {
-		return tx.TemMALFORMED
+		return ter.TemMALFORMED
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // applyCashWithAmount handles the exact Amount case for both XRP and IOU.
-func (c *CheckCash) applyCashWithAmount(ctx *tx.ApplyContext, check *state.CheckData, checkKey keylet.Keylet) tx.Result {
+func (c *CheckCash) applyCashWithAmount(ctx *tx.ApplyContext, check *state.CheckData, checkKey keylet.Keylet) ter.Result {
 	amount := c.Amount
 
 	// For XRP checks
@@ -236,7 +237,7 @@ func (c *CheckCash) applyCashWithAmount(ctx *tx.ApplyContext, check *state.Check
 }
 
 // applyCashWithDeliverMin handles the DeliverMin case for both XRP and IOU.
-func (c *CheckCash) applyCashWithDeliverMin(ctx *tx.ApplyContext, check *state.CheckData, checkKey keylet.Keylet) tx.Result {
+func (c *CheckCash) applyCashWithDeliverMin(ctx *tx.ApplyContext, check *state.CheckData, checkKey keylet.Keylet) ter.Result {
 	deliverMin := c.DeliverMin
 
 	// For XRP checks
@@ -253,22 +254,22 @@ func (c *CheckCash) applyCashWithDeliverMin(ctx *tx.ApplyContext, check *state.C
 // (minimum); isDeliverMin selects which. rippled handles both in one path:
 // after the funds checks it delivers min(srcLiquid, SendMax) for DeliverMin and
 // exactly the requested drops for Amount. Reference: CashCheck.cpp L294-334.
-func (c *CheckCash) applyCashXRP(ctx *tx.ApplyContext, check *state.CheckData, checkKey keylet.Keylet, requestedDrops uint64, isDeliverMin bool) tx.Result {
+func (c *CheckCash) applyCashXRP(ctx *tx.ApplyContext, check *state.CheckData, checkKey keylet.Keylet, requestedDrops uint64, isDeliverMin bool) ter.Result {
 	// Requested amount cannot exceed SendMax.
 	// Reference: CashCheck.cpp L156-160
 	if requestedDrops > check.SendMax {
-		return tx.TecPATH_PARTIAL
+		return ter.TecPATH_PARTIAL
 	}
 
 	// Check creator has sufficient liquid XRP
 	creatorKey := keylet.Account(check.Account)
 	creatorData, err := ctx.View.Read(creatorKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	creatorAccount, err := state.ParseAccountRoot(creatorData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Preclaim funds check: the creator's zero-clamped liquid XRP plus one
@@ -277,7 +278,7 @@ func (c *CheckCash) applyCashXRP(ctx *tx.ApplyContext, check *state.CheckData, c
 	// tecPATH_PARTIAL when the writer is at or above their reserve.
 	// Reference: CashCheck.cpp L162-185.
 	if requestedDrops > xrpAvailableFunds(creatorAccount, ctx) {
-		return tx.TecPATH_PARTIAL
+		return ter.TecPATH_PARTIAL
 	}
 
 	// doApply funds check: xrpLiquid with the released check reserve (-1 owner
@@ -287,7 +288,7 @@ func (c *CheckCash) applyCashXRP(ctx *tx.ApplyContext, check *state.CheckData, c
 	// never exceeds srcLiquid). Reference: CashCheck.cpp L304-319.
 	srcLiquid := xrpLiquidAfterCheck(creatorAccount, ctx)
 	if srcLiquid < requestedDrops {
-		return tx.TecUNFUNDED_PAYMENT
+		return ter.TecUNFUNDED_PAYMENT
 	}
 
 	// For DeliverMin, deliver as much as possible up to SendMax; for an exact
@@ -309,7 +310,7 @@ func (c *CheckCash) applyCashXRP(ctx *tx.ApplyContext, check *state.CheckData, c
 	ctx.Account.Balance += cashAmount
 
 	// Remove check from directories before erasing
-	if result := removeCheckFromDirectories(ctx, check, checkKey.Key); result != tx.TesSUCCESS {
+	if result := removeCheckFromDirectories(ctx, check, checkKey.Key); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -319,16 +320,16 @@ func (c *CheckCash) applyCashXRP(ctx *tx.ApplyContext, check *state.CheckData, c
 	}
 
 	// Update creator account
-	if result := ctx.UpdateAccountRoot(check.Account, creatorAccount); result != tx.TesSUCCESS {
+	if result := ctx.UpdateAccountRoot(check.Account, creatorAccount); result != ter.TesSUCCESS {
 		return result
 	}
 
 	// Delete the check
 	if err := ctx.View.Erase(checkKey); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // xrpAvailableFunds returns the check writer's preclaim-stage available XRP:
@@ -365,7 +366,7 @@ func xrpLiquidAfterCheck(creator *state.AccountRoot, ctx *tx.ApplyContext) uint6
 // When isDeliverMin is true, the requestedAmount is treated as the minimum and
 // the flow engine delivers as much as possible up to SendMax.
 // Reference: CashCheck.cpp L252-end
-func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckData, checkKey keylet.Keylet, requestedAmount tx.Amount, isDeliverMin bool) tx.Result {
+func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckData, checkKey keylet.Keylet, requestedAmount tx.Amount, isDeliverMin bool) ter.Result {
 	accountID := ctx.AccountID
 	sendMax := check.SendMaxAmount
 
@@ -377,12 +378,12 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 	// Requested amount (whether Amount or DeliverMin) cannot exceed SendMax
 	// Reference: CashCheck.cpp L156-160
 	if requestedAmount.Compare(sendMax) > 0 {
-		return tx.TecPATH_PARTIAL
+		return ter.TecPATH_PARTIAL
 	}
 
 	issuerID, err := state.DecodeAccountID(sendMax.Issuer)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	srcID := check.Account
@@ -393,7 +394,7 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 	// where value is either Amount or DeliverMin).
 	srcFunds := tx.AccountFunds(ctx.View, srcID, requestedAmount, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
 	if requestedAmount.Compare(srcFunds) > 0 {
-		return tx.TecPATH_PARTIAL
+		return ter.TecPATH_PARTIAL
 	}
 
 	// IOU-specific preclaim: destination is not issuer
@@ -407,7 +408,7 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 		checkCashMakesTrustLine := rules.Enabled(amendment.FeatureCheckCashMakesTrustLine)
 
 		if !trustLineExists && !checkCashMakesTrustLine {
-			return tx.TecNO_LINE
+			return ter.TecNO_LINE
 		}
 
 		// Check issuer existence
@@ -415,11 +416,11 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 		issuerKey := keylet.Account(issuerID)
 		issuerData, err := ctx.View.Read(issuerKey)
 		if err != nil || issuerData == nil {
-			return tx.TecNO_ISSUER
+			return ter.TecNO_ISSUER
 		}
 		issuerAccount, err := state.ParseAccountRoot(issuerData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Check RequireAuth on issuer
@@ -427,17 +428,17 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 		if (issuerAccount.Flags & state.LsfRequireAuth) != 0 {
 			if !trustLineExists {
 				// Can't auto-create trust line when auth is required
-				return tx.TecNO_AUTH
+				return ter.TecNO_AUTH
 			}
 
 			// Check if destination is authorized
 			trustLineData, err := ctx.View.Read(trustLineKey)
 			if err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			trustLine, err := state.ParseRippleState(trustLineData)
 			if err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 
 			// Check auth flag based on canonical ordering
@@ -452,7 +453,7 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 			}
 
 			if (trustLine.Flags & authFlag) == 0 {
-				return tx.TecNO_AUTH
+				return ter.TecNO_AUTH
 			}
 		}
 
@@ -462,7 +463,7 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 		// 1. Global freeze on issuer
 		// 2. Issuer's freeze flag on the trust line
 		if isIssuerFrozenForAccount(ctx.View, accountID, issuerID, sendMax.Currency) {
-			return tx.TecFROZEN
+			return ter.TecFROZEN
 		}
 	}
 
@@ -487,11 +488,11 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 			priorBalance := ctx.Account.Balance + feeDrops
 			reserve := ctx.AccountReserve(ctx.Account.OwnerCount + 1)
 			if priorBalance < reserve {
-				return tx.TecNO_LINE_INSUF_RESERVE
+				return ter.TecNO_LINE_INSUF_RESERVE
 			}
 
 			// Create trust line
-			if result := createTrustLineForCheckCash(ctx, accountID, issuerID, sendMax.Currency); result != tx.TesSUCCESS {
+			if result := createTrustLineForCheckCash(ctx, accountID, issuerID, sendMax.Currency); result != ter.TesSUCCESS {
 				return result
 			}
 		}
@@ -507,11 +508,11 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 		trustLineKey := keylet.Line(accountID, issuerID, sendMax.Currency)
 		trustLineData, err := ctx.View.Read(trustLineKey)
 		if err != nil {
-			return tx.TecNO_LINE
+			return ter.TecNO_LINE
 		}
 		rs, err := state.ParseRippleState(trustLineData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Save and tweak the destination's limit
@@ -527,10 +528,10 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 
 		updatedData, err := state.SerializeRippleState(rs)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := ctx.View.Update(trustLineKey, updatedData); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
@@ -561,7 +562,7 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 	)
 	actualOut, sandbox, flowResult := rc.ActualOut, rc.Sandbox, rc.Result
 
-	if flowResult != tx.TesSUCCESS && flowResult != tx.TecPATH_PARTIAL {
+	if flowResult != ter.TesSUCCESS && flowResult != ter.TecPATH_PARTIAL {
 		ctx.Log.Warn("check cash: flow failed", "result", flowResult)
 		// Restore the trust line limit before returning
 		if savedLimit != nil {
@@ -580,23 +581,23 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 			if savedLimit != nil {
 				restoreTrustLineLimit(ctx, accountID, issuerID, sendMax.Currency, destLow, *savedLimit)
 			}
-			return tx.TecPATH_PARTIAL
+			return ter.TecPATH_PARTIAL
 		}
 	}
 
 	// For exact Amount, flow must have succeeded
-	if !isDeliverMin && flowResult != tx.TesSUCCESS {
+	if !isDeliverMin && flowResult != ter.TesSUCCESS {
 		// Restore the trust line limit before returning
 		if savedLimit != nil {
 			restoreTrustLineLimit(ctx, accountID, issuerID, sendMax.Currency, destLow, *savedLimit)
 		}
-		return tx.TecPATH_PARTIAL
+		return ter.TecPATH_PARTIAL
 	}
 
 	// Apply flow sandbox changes
 	if sandbox != nil {
 		if err := sandbox.ApplyToView(ctx.View); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
@@ -619,7 +620,7 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 
 	// Remove check from directories before erasing.
 	// Reference: CashCheck.cpp L487-508
-	if result := removeCheckFromDirectories(ctx, check, checkKey.Key); result != tx.TesSUCCESS {
+	if result := removeCheckFromDirectories(ctx, check, checkKey.Key); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -627,27 +628,27 @@ func (c *CheckCash) applyCashIOUAmount(ctx *tx.ApplyContext, check *state.CheckD
 	creatorKey := keylet.Account(srcID)
 	creatorData, err := ctx.View.Read(creatorKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	creatorAccount, err := state.ParseAccountRoot(creatorData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if creatorAccount.OwnerCount > 0 {
 		creatorAccount.OwnerCount--
 	}
 
-	if result := ctx.UpdateAccountRoot(srcID, creatorAccount); result != tx.TesSUCCESS {
+	if result := ctx.UpdateAccountRoot(srcID, creatorAccount); result != ter.TesSUCCESS {
 		return result
 	}
 
 	// Delete the check
 	if err := ctx.View.Erase(checkKey); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // isIssuerFrozenForAccount reports rippled's isFrozen(view, account, currency,
@@ -676,12 +677,12 @@ func isIssuerFrozenForAccount(view tx.LedgerView, accountID, issuerID [20]byte, 
 // transaction sender, so its OwnerCount is bumped on ctx.Account, which the
 // engine writes back.
 // Reference: CashCheck.cpp L349-412, View.cpp trustCreate L1329-1445
-func createTrustLineForCheckCash(ctx *tx.ApplyContext, destID, issuerID [20]byte, currency string) tx.Result {
+func createTrustLineForCheckCash(ctx *tx.ApplyContext, destID, issuerID [20]byte, currency string) ter.Result {
 	trustLineKey := keylet.Line(destID, issuerID, currency)
 
 	destStr, err := state.EncodeAccountID(destID)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// The account-being-set's (casher's) noRipple is derived from its own
@@ -689,11 +690,11 @@ func createTrustLineForCheckCash(ctx *tx.ApplyContext, destID, issuerID [20]byte
 	// Reference: rippled CashCheck.cpp:393 (sleDst->getFlags() & lsfDefaultRipple) == 0.
 	destData, err := ctx.View.Read(keylet.Account(destID))
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	destAccount, err := state.ParseAccountRoot(destData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	destNoRipple := destAccount.Flags&state.LsfDefaultRipple == 0
 
@@ -709,14 +710,14 @@ func createTrustLineForCheckCash(ctx *tx.ApplyContext, destID, issuerID [20]byte
 		Balance:     state.NewIssuedAmountFromValue(0, state.MinExponent, currency, state.AccountOneAddress),
 		Limit:       state.NewIssuedAmountFromValue(0, state.MinExponent, currency, destStr),
 	})
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 
 	// The casher owns the new line and pays its reserve.
 	ctx.Account.OwnerCount++
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // restoreTrustLineLimit restores the original trust line limit after flow.
@@ -748,14 +749,14 @@ func restoreTrustLineLimit(ctx *tx.ApplyContext, destID, issuerID [20]byte, curr
 // removeCheckFromDirectories removes a check from both source and destination
 // owner directories. Must be called before erasing the check SLE.
 // Reference: CashCheck.cpp L487-508
-func removeCheckFromDirectories(ctx *tx.ApplyContext, check *state.CheckData, checkKeyBytes [32]byte) tx.Result {
+func removeCheckFromDirectories(ctx *tx.ApplyContext, check *state.CheckData, checkKeyBytes [32]byte) ter.Result {
 	srcID := check.Account
 	dstID := check.DestinationID
 
 	// Remove from destination directory (if not self-send)
 	if srcID != dstID {
 		destDirKey := keylet.OwnerDir(dstID)
-		if result := tx.DirRemoveOrBadLedger(ctx.View, destDirKey, check.DestinationNode, checkKeyBytes); result != tx.TesSUCCESS {
+		if result := tx.DirRemoveOrBadLedger(ctx.View, destDirKey, check.DestinationNode, checkKeyBytes); result != ter.TesSUCCESS {
 			return result
 		}
 	}

--- a/internal/tx/check/check_create.go
+++ b/internal/tx/check/check_create.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -52,33 +53,33 @@ func (c *CheckCreate) Validate() error {
 	}
 
 	if c.Destination == "" {
-		return tx.Errorf(tx.TemDST_NEEDED, "Destination is required")
+		return ter.Errorf(ter.TemDST_NEEDED, "Destination is required")
 	}
 
 	// Cannot create check to self
 	// Reference: CreateCheck.cpp L47-52
 	if c.Account == c.Destination {
-		return tx.Errorf(tx.TemREDUNDANT, "cannot create check to self")
+		return ter.Errorf(ter.TemREDUNDANT, "cannot create check to self")
 	}
 
 	// SendMax must be positive
 	// Reference: CreateCheck.cpp L55-61
 	if c.SendMax.Signum() <= 0 {
-		return tx.Errorf(tx.TemBAD_AMOUNT, "SendMax must be positive")
+		return ter.Errorf(ter.TemBAD_AMOUNT, "SendMax must be positive")
 	}
 
 	// Cannot use bad currency (XRP as IOU or null currency)
 	// Reference: CreateCheck.cpp L63-67
 	if !c.SendMax.IsNative() {
 		if c.SendMax.Currency == "XRP" || c.SendMax.Currency == "\x00\x00\x00" || c.SendMax.Currency == "" {
-			return tx.Errorf(tx.TemBAD_CURRENCY, "invalid currency")
+			return ter.Errorf(ter.TemBAD_CURRENCY, "invalid currency")
 		}
 	}
 
 	// Expiration must not be zero if provided
 	// Reference: CreateCheck.cpp L70-77
 	if c.Expiration != nil && *c.Expiration == 0 {
-		return tx.Errorf(tx.TemBAD_EXPIRATION, "expiration must not be zero")
+		return ter.Errorf(ter.TemBAD_EXPIRATION, "expiration must not be zero")
 	}
 
 	return nil
@@ -93,7 +94,7 @@ func (c *CheckCreate) RequiredAmendments() [][32]byte {
 }
 
 // Apply implements preclaim + doApply matching rippled's CreateCheck.
-func (c *CheckCreate) Apply(ctx *tx.ApplyContext) tx.Result {
+func (c *CheckCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("check create apply",
 		"account", c.Account,
 		"destination", c.Destination,
@@ -105,7 +106,7 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Verify destination exists and is not a pseudo-account
 	// Reference: CreateCheck.cpp L85-90, L100-105
 	destAccount, destID, result := ctx.LookupDestination(c.Destination)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -114,14 +115,14 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	rules := ctx.Rules()
 	if rules.Enabled(amendment.FeatureDisallowIncoming) {
 		if destAccount.Flags&state.LsfDisallowIncomingCheck != 0 {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	}
 
 	// Check RequireDestTag on destination
 	// Reference: CreateCheck.cpp L107-113
 	if destAccount.Flags&state.LsfRequireDestTag != 0 && c.DestinationTag == nil {
-		return tx.TecDST_TAG_NEEDED
+		return ter.TecDST_TAG_NEEDED
 	}
 
 	// IOU-specific checks
@@ -129,7 +130,7 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	if !c.SendMax.IsNative() {
 		issuerID, err := state.DecodeAccountID(c.SendMax.Issuer)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Check global freeze on issuer
@@ -137,14 +138,14 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		issuerKey := keylet.Account(issuerID)
 		issuerData, err := ctx.View.Read(issuerKey)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		issuerAccount, err := state.ParseAccountRoot(issuerData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if issuerAccount.Flags&state.LsfGlobalFreeze != 0 {
-			return tx.TecFROZEN
+			return ter.TecFROZEN
 		}
 
 		accountID := ctx.AccountID
@@ -154,28 +155,28 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		// shared issuer-side individual freeze check.
 		// Reference: CreateCheck.cpp L131-145
 		if tx.IsTrustlineFrozen(ctx.View, accountID, issuerID, c.SendMax.Currency) {
-			return tx.TecFROZEN
+			return ter.TecFROZEN
 		}
 
 		// Check destination trust line freeze (if dest is not issuer): check if
 		// the destination froze their own side (not issuer freeze).
 		// Reference: CreateCheck.cpp L146-159
 		if isTrustLineFrozenBySelf(ctx.View, destID, issuerID, c.SendMax.Currency) {
-			return tx.TecFROZEN
+			return ter.TecFROZEN
 		}
 	}
 
 	// Check expiration
 	// Reference: CreateCheck.cpp L162-166
 	if tx.HasExpired(c.Expiration, ctx.Config.ParentCloseTime) {
-		return tx.TecEXPIRED
+		return ter.TecEXPIRED
 	}
 
 	// --- doApply ---
 
 	// Reserve check: account must afford owner count + 1
 	// Reference: CreateCheck.cpp L181-186
-	if result := ctx.CheckReserveWithFee(ctx.Account.OwnerCount + 1); result != tx.TesSUCCESS {
+	if result := ctx.CheckReserveWithFee(ctx.Account.OwnerCount + 1); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -188,18 +189,18 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Serialize check
 	checkData, err := serializeCheck(c, accountID, destID, sequence, c.SendMax)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Insert check
 	if err := ctx.View.Insert(checkKey, checkData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Parse the check SLE to update with directory page numbers
 	checkSLE, err := state.ParseCheck(checkData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Insert check into destination's owner directory (not self-send).
@@ -211,7 +212,7 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		})
 		if err != nil {
 			ctx.Log.Error("check create: destination directory full", "error", err)
-			return tx.TecDIR_FULL
+			return ter.TecDIR_FULL
 		}
 		checkSLE.DestinationNode = destResult.Page
 		checkSLE.HasDestNode = true
@@ -225,23 +226,23 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	})
 	if err != nil {
 		ctx.Log.Error("check create: owner directory full", "error", err)
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 	checkSLE.OwnerNode = ownerResult.Page
 
 	// Re-serialize check with updated OwnerNode/DestinationNode
 	updatedData, err := state.SerializeCheckFromData(checkSLE)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(checkKey, updatedData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Increase owner count
 	ctx.Account.OwnerCount++
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // isTrustLineFrozenBySelf reports whether the trust line between account and

--- a/internal/tx/checkfee_loadfeetrack_test.go
+++ b/internal/tx/checkfee_loadfeetrack_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // newFeeTestTx builds a minimal AccountSet-typed transaction carrying the
@@ -33,13 +34,13 @@ func TestCheckFee_LoadFeeTrackScaling(t *testing.T) {
 		fee        string
 		feeTrack   *feetrack.LoadFeeTrack
 		openLedger bool
-		want       Result
+		want       ter.Result
 	}{
-		{name: "nil tracker, fee meets base", fee: "10", feeTrack: nil, openLedger: true, want: TesSUCCESS},
-		{name: "nil tracker, fee below base", fee: "9", feeTrack: nil, openLedger: true, want: TelINSUF_FEE_P},
-		{name: "loaded, fee below scaled floor", fee: "10", feeTrack: loaded, openLedger: true, want: TelINSUF_FEE_P},
-		{name: "loaded, fee meets scaled floor", fee: "20", feeTrack: loaded, openLedger: true, want: TesSUCCESS},
-		{name: "loaded but ledger closed: no scaling", fee: "10", feeTrack: loaded, openLedger: false, want: TesSUCCESS},
+		{name: "nil tracker, fee meets base", fee: "10", feeTrack: nil, openLedger: true, want: ter.TesSUCCESS},
+		{name: "nil tracker, fee below base", fee: "9", feeTrack: nil, openLedger: true, want: ter.TelINSUF_FEE_P},
+		{name: "loaded, fee below scaled floor", fee: "10", feeTrack: loaded, openLedger: true, want: ter.TelINSUF_FEE_P},
+		{name: "loaded, fee meets scaled floor", fee: "20", feeTrack: loaded, openLedger: true, want: ter.TesSUCCESS},
+		{name: "loaded but ledger closed: no scaling", fee: "10", feeTrack: loaded, openLedger: false, want: ter.TesSUCCESS},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -73,14 +74,14 @@ func TestCheckFee_UnlimitedCarveOut(t *testing.T) {
 	// Non-unlimited floor: 10*320/256 = 12 (truncated). fee=10 is short.
 	e := &Engine{config: EngineConfig{BaseFee: baseFee, OpenLedger: true, FeeTrack: tr}}
 	txn := newFeeTestTx("10")
-	if got := e.checkFee(txn, txn.GetCommon(), account); got != TelINSUF_FEE_P {
+	if got := e.checkFee(txn, txn.GetCommon(), account); got != ter.TelINSUF_FEE_P {
 		t.Fatalf("checkFee(non-unlimited) = %v, want TelINSUF_FEE_P", got)
 	}
 
 	// Unlimited floor: carve-out drops feeFactor to remFee (256), so the
 	// floor is 10*256/256 = 10 and fee=10 now suffices.
 	eUnlimited := &Engine{config: EngineConfig{BaseFee: baseFee, OpenLedger: true, FeeTrack: tr, ApplyFlags: TapUNLIMITED}}
-	if got := eUnlimited.checkFee(txn, txn.GetCommon(), account); got != TesSUCCESS {
+	if got := eUnlimited.checkFee(txn, txn.GetCommon(), account); got != ter.TesSUCCESS {
 		t.Fatalf("checkFee(unlimited) = %v, want TesSUCCESS", got)
 	}
 }
@@ -102,13 +103,13 @@ func TestCheckFee_EnforceLoadFee(t *testing.T) {
 		fee      string
 		feeTrack *feetrack.LoadFeeTrack
 		enforce  bool
-		want     Result
+		want     ter.Result
 	}{
-		{name: "enforce, elevated load, fee below scaled floor", fee: "10", feeTrack: loaded, enforce: true, want: TelINSUF_FEE_P},
-		{name: "enforce, elevated load, fee meets scaled floor", fee: "20", feeTrack: loaded, enforce: true, want: TesSUCCESS},
-		{name: "enforce, normal load: floor inert (admission covers base)", fee: "5", feeTrack: feetrack.New(), enforce: true, want: TesSUCCESS},
-		{name: "enforce, nil tracker: floor inert", fee: "5", feeTrack: nil, enforce: true, want: TesSUCCESS},
-		{name: "no enforce, elevated load (closed apply): never scales", fee: "10", feeTrack: loaded, enforce: false, want: TesSUCCESS},
+		{name: "enforce, elevated load, fee below scaled floor", fee: "10", feeTrack: loaded, enforce: true, want: ter.TelINSUF_FEE_P},
+		{name: "enforce, elevated load, fee meets scaled floor", fee: "20", feeTrack: loaded, enforce: true, want: ter.TesSUCCESS},
+		{name: "enforce, normal load: floor inert (admission covers base)", fee: "5", feeTrack: feetrack.New(), enforce: true, want: ter.TesSUCCESS},
+		{name: "enforce, nil tracker: floor inert", fee: "5", feeTrack: nil, enforce: true, want: ter.TesSUCCESS},
+		{name: "no enforce, elevated load (closed apply): never scales", fee: "10", feeTrack: loaded, enforce: false, want: ter.TesSUCCESS},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -138,12 +139,12 @@ func TestCheckFee_InsufficientBalance(t *testing.T) {
 		name       string
 		balance    uint64
 		openLedger bool
-		want       Result
+		want       ter.Result
 	}{
-		{name: "closed ledger, non-zero balance below fee", balance: 50, openLedger: false, want: TecINSUFF_FEE},
-		{name: "closed ledger, zero balance", balance: 0, openLedger: false, want: TerINSUF_FEE_B},
-		{name: "open ledger, non-zero balance below fee", balance: 50, openLedger: true, want: TerINSUF_FEE_B},
-		{name: "open ledger, zero balance", balance: 0, openLedger: true, want: TerINSUF_FEE_B},
+		{name: "closed ledger, non-zero balance below fee", balance: 50, openLedger: false, want: ter.TecINSUFF_FEE},
+		{name: "closed ledger, zero balance", balance: 0, openLedger: false, want: ter.TerINSUF_FEE_B},
+		{name: "open ledger, non-zero balance below fee", balance: 50, openLedger: true, want: ter.TerINSUF_FEE_B},
+		{name: "open ledger, zero balance", balance: 0, openLedger: true, want: ter.TerINSUF_FEE_B},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/tx/clawback/clawback.go
+++ b/internal/tx/clawback/clawback.go
@@ -6,18 +6,19 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
 
 // Clawback errors
 var (
-	ErrClawbackAmountRequired  = tx.Errorf(tx.TemBAD_AMOUNT, "Amount is required")
-	ErrClawbackAmountNotToken  = tx.Errorf(tx.TemBAD_AMOUNT, "cannot claw back XRP")
-	ErrClawbackAmountNotPos    = tx.Errorf(tx.TemBAD_AMOUNT, "Amount must be positive")
-	ErrClawbackHolderWithToken = tx.Errorf(tx.TemMALFORMED, "Holder field cannot be present for token clawback")
-	ErrClawbackHolderRequired  = tx.Errorf(tx.TemMALFORMED, "Holder is required for MPToken clawback")
-	ErrClawbackHolderIsSelf    = tx.Errorf(tx.TemMALFORMED, "Holder cannot be the same as issuer")
+	ErrClawbackAmountRequired  = ter.Errorf(ter.TemBAD_AMOUNT, "Amount is required")
+	ErrClawbackAmountNotToken  = ter.Errorf(ter.TemBAD_AMOUNT, "cannot claw back XRP")
+	ErrClawbackAmountNotPos    = ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
+	ErrClawbackHolderWithToken = ter.Errorf(ter.TemMALFORMED, "Holder field cannot be present for token clawback")
+	ErrClawbackHolderRequired  = ter.Errorf(ter.TemMALFORMED, "Holder is required for MPToken clawback")
+	ErrClawbackHolderIsSelf    = ter.Errorf(ter.TemMALFORMED, "Holder cannot be the same as issuer")
 )
 
 // Clawback claws back tokens from a trust line or MPToken.
@@ -120,7 +121,7 @@ func (c *Clawback) Validate() error {
 }
 
 // Reference: rippled Clawback.cpp preclaim() + applyHelper<Issue>() / applyHelper<MPTIssue>()
-func (c *Clawback) Apply(ctx *tx.ApplyContext) tx.Result {
+func (c *Clawback) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("clawback apply",
 		"account", c.Account,
 		"amount", c.Amount,
@@ -135,23 +136,23 @@ func (c *Clawback) Apply(ctx *tx.ApplyContext) tx.Result {
 
 // applyMPT handles MPToken clawback when Amount is an MPT type.
 // Reference: rippled Clawback.cpp preclaimHelper<MPTIssue>() + applyHelper<MPTIssue>()
-func (c *Clawback) applyMPT(ctx *tx.ApplyContext) tx.Result {
+func (c *Clawback) applyMPT(ctx *tx.ApplyContext) ter.Result {
 	// Read the holder's AccountRoot and reject a pseudo-account / AMM holder
 	// before the per-issue preclaim checks, mirroring rippled's preclaim order.
 	// Reference: rippled Clawback.cpp:202-216
 	holderID, err := state.DecodeAccountID(c.Holder)
 	if err != nil {
-		return tx.TecNO_DST
+		return ter.TecNO_DST
 	}
 	holderAccountData, err := ctx.View.Read(keylet.Account(holderID))
 	if err != nil || holderAccountData == nil {
-		return tx.TerNO_ACCOUNT
+		return ter.TerNO_ACCOUNT
 	}
 	holderAccount, err := state.ParseAccountRoot(holderAccountData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
-	if result := clawbackHolderGuard(ctx, holderAccount); result != tx.TesSUCCESS {
+	if result := clawbackHolderGuard(ctx, holderAccount); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -166,7 +167,7 @@ func (c *Clawback) applyMPT(ctx *tx.ApplyContext) tx.Result {
 	issuanceIDBytes, err := hex.DecodeString(mptIDHex)
 	if err != nil || len(issuanceIDBytes) != 24 {
 		// If the ID is invalid/empty, the issuance won't be found
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 	copy(mptID[:], issuanceIDBytes)
 
@@ -174,45 +175,45 @@ func (c *Clawback) applyMPT(ctx *tx.ApplyContext) tx.Result {
 	issuanceKey := keylet.MPTIssuance(mptID)
 	issuanceRaw, err := ctx.View.Read(issuanceKey)
 	if err != nil || issuanceRaw == nil {
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	issuance, err := state.ParseMPTokenIssuance(issuanceRaw)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Issuance must have CanClawback flag
 	if issuance.Flags&entry.LsfMPTCanClawback == 0 {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Caller must be the issuer
 	if issuance.Issuer != ctx.AccountID {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Look up holder's MPToken
 	tokenKey := keylet.MPToken(issuanceKey.Key, holderID)
 	tokenRaw, err := ctx.View.Read(tokenKey)
 	if err != nil || tokenRaw == nil {
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	token, err := state.ParseMPToken(tokenRaw)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Holder must have a positive balance
 	if token.MPTAmount == 0 {
-		return tx.TecINSUFFICIENT_FUNDS
+		return ter.TecINSUFFICIENT_FUNDS
 	}
 
 	// Extract requested amount as uint64 from the IOU-style Amount
 	requested := amountToUint64(c.Amount)
 	if requested == 0 {
-		return tx.TecINSUFFICIENT_FUNDS
+		return ter.TecINSUFFICIENT_FUNDS
 	}
 
 	// Compute actual clawback amount = min(balance, requested)
@@ -228,21 +229,21 @@ func (c *Clawback) applyMPT(ctx *tx.ApplyContext) tx.Result {
 
 	updatedToken, err := state.SerializeMPToken(token)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(tokenKey, updatedToken); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	updatedIssuance, err := state.SerializeMPTokenIssuance(issuance)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(issuanceKey, updatedIssuance); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // amountToUint64 converts an Amount to a uint64 integer value.
@@ -275,25 +276,25 @@ func amountToUint64(a state.Amount) uint64 {
 // Reference: rippled Clawback.cpp:210-216. When featureSingleAssetVault is
 // enabled the pseudo-account check subsumes the sfAMMID check (an AMM account is
 // itself a pseudo-account), so the order is preserved.
-func clawbackHolderGuard(ctx *tx.ApplyContext, holder *state.AccountRoot) tx.Result {
+func clawbackHolderGuard(ctx *tx.ApplyContext, holder *state.AccountRoot) ter.Result {
 	if ctx.Rules().Enabled(amendment.FeatureSingleAssetVault) && holder.IsPseudoAccount() {
-		return tx.TecPSEUDO_ACCOUNT
+		return ter.TecPSEUDO_ACCOUNT
 	}
 	if holder.HasAMMID() {
-		return tx.TecAMM_ACCOUNT
+		return ter.TecAMM_ACCOUNT
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // applyIOU handles IOU token clawback (original path).
 // Reference: rippled Clawback.cpp preclaim() + applyHelper<Issue>()
-func (c *Clawback) applyIOU(ctx *tx.ApplyContext) tx.Result {
+func (c *Clawback) applyIOU(ctx *tx.ApplyContext) ter.Result {
 	// --- Preclaim checks ---
 
 	// 1. Decode holder from Amount.Issuer
 	holderID, err := state.DecodeAccountID(c.Amount.Issuer)
 	if err != nil {
-		return tx.TecNO_TARGET
+		return ter.TecNO_TARGET
 	}
 
 	// 2. Read holder's account — terNO_ACCOUNT if missing
@@ -301,17 +302,17 @@ func (c *Clawback) applyIOU(ctx *tx.ApplyContext) tx.Result {
 	holderAccountKey := keylet.Account(holderID)
 	holderAccountData, err := ctx.View.Read(holderAccountKey)
 	if err != nil || holderAccountData == nil {
-		return tx.TerNO_ACCOUNT
+		return ter.TerNO_ACCOUNT
 	}
 	holderAccount, err := state.ParseAccountRoot(holderAccountData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// 3. Reject a pseudo-account / AMM holder.
 	// Reference: rippled Clawback.cpp:210-216, evaluated before the per-issue
 	// preclaim checks.
-	if result := clawbackHolderGuard(ctx, holderAccount); result != tx.TesSUCCESS {
+	if result := clawbackHolderGuard(ctx, holderAccount); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -319,10 +320,10 @@ func (c *Clawback) applyIOU(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled Clawback.cpp preclaimHelper<Issue>() lines 117-123
 	// AllowTrustLineClawback must be set, NoFreeze must NOT be set
 	if (ctx.Account.Flags & state.LsfAllowTrustLineClawback) == 0 {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 	if (ctx.Account.Flags & state.LsfNoFreeze) != 0 {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// 5. Read trust line
@@ -330,11 +331,11 @@ func (c *Clawback) applyIOU(ctx *tx.ApplyContext) tx.Result {
 	trustKey := keylet.Line(holderID, ctx.AccountID, c.Amount.Currency)
 	trustData, err := ctx.View.Read(trustKey)
 	if err != nil || trustData == nil {
-		return tx.TecNO_LINE
+		return ter.TecNO_LINE
 	}
 	rs, err := state.ParseRippleState(trustData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// 6. Balance direction check
@@ -346,10 +347,10 @@ func (c *Clawback) applyIOU(ctx *tx.ApplyContext) tx.Result {
 	// If balance < 0, issuer must be LOW (issuer < holder)
 	issuerIsLow := state.CompareAccountIDs(ctx.AccountID, holderID) < 0
 	if rs.Balance.Signum() > 0 && issuerIsLow {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 	if rs.Balance.Signum() < 0 && !issuerIsLow {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// 7. Check holder has funds (accountHolds equivalent, ignoring freeze)
@@ -363,7 +364,7 @@ func (c *Clawback) applyIOU(ctx *tx.ApplyContext) tx.Result {
 		holderBalance = rs.Balance.Negate()
 	}
 	if holderBalance.Signum() <= 0 {
-		return tx.TecINSUFFICIENT_FUNDS
+		return ter.TecINSUFFICIENT_FUNDS
 	}
 
 	// --- Apply ---
@@ -391,7 +392,7 @@ func (c *Clawback) applyIOU(ctx *tx.ApplyContext) tx.Result {
 		rs.Balance, err = rs.Balance.Add(actualAmount)
 	}
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// 10. Check if trust line should be deleted (default state)
@@ -430,15 +431,15 @@ func (c *Clawback) applyIOU(ctx *tx.ApplyContext) tx.Result {
 		}
 		lowDirKey := keylet.OwnerDir(lowAccountID)
 		if res, err := state.DirRemove(ctx.View, lowDirKey, rs.LowNode, trustKey.Key, false); err != nil || !res.Success {
-			return tx.TefBAD_LEDGER
+			return ter.TefBAD_LEDGER
 		}
 		highDirKey := keylet.OwnerDir(highAccountID)
 		if res, err := state.DirRemove(ctx.View, highDirKey, rs.HighNode, trustKey.Key, false); err != nil || !res.Success {
-			return tx.TefBAD_LEDGER
+			return ter.TefBAD_LEDGER
 		}
 
 		if err := ctx.View.Erase(trustKey); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Decrement OwnerCount for both sides
@@ -449,7 +450,7 @@ func (c *Clawback) applyIOU(ctx *tx.ApplyContext) tx.Result {
 			holderAccount.OwnerCount--
 		}
 
-		if result := ctx.UpdateAccountRoot(holderID, holderAccount); result != tx.TesSUCCESS {
+		if result := ctx.UpdateAccountRoot(holderID, holderAccount); result != ter.TesSUCCESS {
 			return result
 		}
 	} else {
@@ -467,14 +468,14 @@ func (c *Clawback) applyIOU(ctx *tx.ApplyContext) tx.Result {
 
 		updatedData, serErr := state.SerializeRippleState(rs)
 		if serErr != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := ctx.View.Update(trustKey, updatedData); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // ClawbackAmount returns the Amount field for use by the ValidClawback invariant checker.

--- a/internal/tx/credential/constant.go
+++ b/internal/tx/credential/constant.go
@@ -1,6 +1,6 @@
 package credential
 
-import "github.com/LeJamon/go-xrpl/internal/tx"
+import "github.com/LeJamon/go-xrpl/internal/tx/ter"
 
 // Credential constants matching rippled Protocol.h
 const (
@@ -13,12 +13,12 @@ const (
 
 // Credential validation errors
 var (
-	ErrCredentialTypeTooLong = tx.Errorf(tx.TemMALFORMED, "CredentialType exceeds maximum length")
-	ErrCredentialTypeEmpty   = tx.Errorf(tx.TemMALFORMED, "CredentialType is empty")
-	ErrCredentialURITooLong  = tx.Errorf(tx.TemMALFORMED, "URI exceeds maximum length")
-	ErrCredentialURIEmpty    = tx.Errorf(tx.TemMALFORMED, "URI is empty")
-	ErrCredentialNoSubject   = tx.Errorf(tx.TemMALFORMED, "Subject is required")
-	ErrCredentialNoIssuer    = tx.Errorf(tx.TemINVALID_ACCOUNT_ID, "Issuer field zeroed")
-	ErrCredentialNoFields    = tx.Errorf(tx.TemMALFORMED, "No Subject or Issuer fields")
-	ErrCredentialZeroAccount = tx.Errorf(tx.TemINVALID_ACCOUNT_ID, "Subject or Issuer field zeroed")
+	ErrCredentialTypeTooLong = ter.Errorf(ter.TemMALFORMED, "CredentialType exceeds maximum length")
+	ErrCredentialTypeEmpty   = ter.Errorf(ter.TemMALFORMED, "CredentialType is empty")
+	ErrCredentialURITooLong  = ter.Errorf(ter.TemMALFORMED, "URI exceeds maximum length")
+	ErrCredentialURIEmpty    = ter.Errorf(ter.TemMALFORMED, "URI is empty")
+	ErrCredentialNoSubject   = ter.Errorf(ter.TemMALFORMED, "Subject is required")
+	ErrCredentialNoIssuer    = ter.Errorf(ter.TemINVALID_ACCOUNT_ID, "Issuer field zeroed")
+	ErrCredentialNoFields    = ter.Errorf(ter.TemMALFORMED, "No Subject or Issuer fields")
+	ErrCredentialZeroAccount = ter.Errorf(ter.TemINVALID_ACCOUNT_ID, "Subject or Issuer field zeroed")
 )

--- a/internal/tx/credential/credential.go
+++ b/internal/tx/credential/credential.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -63,7 +64,7 @@ func (c *CredentialAccept) Validate() error {
 	}
 	decoded, err := hex.DecodeString(c.CredentialType)
 	if err != nil {
-		return tx.Errorf(tx.TemMALFORMED, "CredentialType must be valid hex string")
+		return ter.Errorf(ter.TemMALFORMED, "CredentialType must be valid hex string")
 	}
 	if len(decoded) == 0 {
 		return ErrCredentialTypeEmpty
@@ -121,18 +122,18 @@ func (c *CredentialAccept) ApplyOnTec(ctx *tx.ApplyContext) {
 	// Use DeleteSLE to properly clean up directories and owner counts.
 	// Failures here cannot change the transaction result; rippled's
 	// removal helpers only log them.
-	if result := DeleteSLE(ctx, credKeylet, cred); result != tx.TesSUCCESS {
+	if result := DeleteSLE(ctx, credKeylet, cred); result != ter.TesSUCCESS {
 		ctx.Log.Warn("failed to delete expired credential", "result", result)
 	}
 }
 
 // Reference: rippled Credentials.cpp CredentialAccept::doApply()
-func (c *CredentialAccept) Apply(ctx *tx.ApplyContext) tx.Result {
+func (c *CredentialAccept) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Check for invalid flags, gated behind fixInvalidTxFlags
 	// Reference: rippled Credentials.cpp:304-308
 	if ctx.Rules().Enabled(amendment.FeatureFixInvalidTxFlags) {
 		if c.GetFlags()&tx.TfUniversalMask != 0 {
-			return tx.TemINVALID_FLAG
+			return ter.TemINVALID_FLAG
 		}
 	}
 
@@ -143,18 +144,18 @@ func (c *CredentialAccept) Apply(ctx *tx.ApplyContext) tx.Result {
 	)
 
 	if c.Issuer == "" || c.CredentialType == "" {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	issuerID, err := state.DecodeAccountID(c.Issuer)
 	if err != nil {
-		return tx.TecNO_TARGET
+		return ter.TecNO_TARGET
 	}
 
 	// Decode credential type from hex to bytes
 	credTypeBytes, err := hex.DecodeString(c.CredentialType)
 	if err != nil {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	// Preclaim check: verify issuer account exists
@@ -162,7 +163,7 @@ func (c *CredentialAccept) Apply(ctx *tx.ApplyContext) tx.Result {
 	issuerExists, err := ctx.View.Exists(issuerAccountKeylet)
 	if err != nil || !issuerExists {
 		ctx.Log.Warn("credential accept: no issuer", "issuer", c.Issuer)
-		return tx.TecNO_ISSUER
+		return ter.TecNO_ISSUER
 	}
 
 	// Compute correct keylet: credential(subject, issuer, credType)
@@ -174,34 +175,34 @@ func (c *CredentialAccept) Apply(ctx *tx.ApplyContext) tx.Result {
 	if err != nil || credData == nil {
 		ctx.Log.Warn("credential accept: no credential",
 			"subject", c.Account, "issuer", c.Issuer, "credentialType", c.CredentialType)
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	// Parse the credential entry
 	cred, err := ParseCredentialEntry(credData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if cred.IsAccepted() {
 		ctx.Log.Warn("credential accept: credential already accepted",
 			"subject", c.Account, "issuer", c.Issuer, "credentialType", c.CredentialType)
-		return tx.TecDUPLICATE
+		return ter.TecDUPLICATE
 	}
 
 	closeTime := ctx.Config.ParentCloseTime
 	if CheckCredentialExpired(cred, closeTime) {
 		// Delete the expired credential, cleaning up both owner directories and
 		// the issuer's owner count, even though the accept itself fails.
-		if result := DeleteSLE(ctx, credKeylet, cred); result != tx.TesSUCCESS {
+		if result := DeleteSLE(ctx, credKeylet, cred); result != ter.TesSUCCESS {
 			return result
 		}
-		return tx.TecEXPIRED
+		return ter.TecEXPIRED
 	}
 
 	// Check reserve for subject (ctx.Account) using the prior balance (before the
 	// actual fee was deducted), matching rippled's mPriorBalance comparison.
-	if result := ctx.CheckReserveWithFee(ctx.Account.OwnerCount + 1); result != tx.TesSUCCESS {
+	if result := ctx.CheckReserveWithFee(ctx.Account.OwnerCount + 1); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -210,23 +211,23 @@ func (c *CredentialAccept) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Serialize and update the credential
 	updatedCredData, err := serializeCredentialEntry(cred)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if err := ctx.View.Update(credKeylet, updatedCredData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Transfer ownership: decrease issuer's owner count, increase subject's owner count
 	// Read issuer account
 	issuerData, err := ctx.View.Read(issuerAccountKeylet)
 	if err != nil || issuerData == nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	issuerAccount, err := state.ParseAccountRoot(issuerData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Decrease issuer's owner count
@@ -235,12 +236,12 @@ func (c *CredentialAccept) Apply(ctx *tx.ApplyContext) tx.Result {
 	}
 
 	// Serialize and update issuer account
-	if result := ctx.UpdateAccountRoot(issuerID, issuerAccount); result != tx.TesSUCCESS {
+	if result := ctx.UpdateAccountRoot(issuerID, issuerAccount); result != ter.TesSUCCESS {
 		return result
 	}
 
 	// Increase subject's owner count
 	ctx.Account.OwnerCount++
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/credential/credential_create.go
+++ b/internal/tx/credential/credential_create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -69,7 +70,7 @@ func (c *CredentialCreate) Validate() error {
 	if c.URI != "" || c.HasField("URI") {
 		decoded, err := hex.DecodeString(c.URI)
 		if err != nil {
-			return tx.Errorf(tx.TemMALFORMED, "URI must be valid hex string")
+			return ter.Errorf(ter.TemMALFORMED, "URI must be valid hex string")
 		}
 		if len(decoded) == 0 {
 			return ErrCredentialURIEmpty
@@ -86,7 +87,7 @@ func (c *CredentialCreate) Validate() error {
 	}
 	decoded, err := hex.DecodeString(c.CredentialType)
 	if err != nil {
-		return tx.Errorf(tx.TemMALFORMED, "CredentialType must be valid hex string")
+		return ter.Errorf(ter.TemMALFORMED, "CredentialType must be valid hex string")
 	}
 	if len(decoded) == 0 {
 		return ErrCredentialTypeEmpty
@@ -107,12 +108,12 @@ func (c *CredentialCreate) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled Credentials.cpp CredentialCreate::doApply()
-func (c *CredentialCreate) Apply(ctx *tx.ApplyContext) tx.Result {
+func (c *CredentialCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Check for invalid flags, gated behind fixInvalidTxFlags
 	// Reference: rippled Credentials.cpp:66-71
 	if ctx.Rules().Enabled(amendment.FeatureFixInvalidTxFlags) {
 		if c.GetFlags()&tx.TfUniversalMask != 0 {
-			return tx.TemINVALID_FLAG
+			return ter.TemINVALID_FLAG
 		}
 	}
 
@@ -123,18 +124,18 @@ func (c *CredentialCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	)
 
 	if c.Subject == "" || c.CredentialType == "" {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	subjectID, err := state.DecodeAccountID(c.Subject)
 	if err != nil {
-		return tx.TecNO_TARGET
+		return ter.TecNO_TARGET
 	}
 
 	// Decode credential type from hex to bytes
 	credTypeBytes, err := hex.DecodeString(c.CredentialType)
 	if err != nil {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	// Compute correct keylet: credential(subject, issuer, credType)
@@ -145,29 +146,29 @@ func (c *CredentialCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	subjectAccountKeylet := keylet.Account(subjectID)
 	subjectExists, err := ctx.View.Exists(subjectAccountKeylet)
 	if err != nil || !subjectExists {
-		return tx.TecNO_TARGET
+		return ter.TecNO_TARGET
 	}
 
 	// Preclaim check: verify credential doesn't already exist
 	exists, err := ctx.View.Exists(credKeylet)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if exists {
-		return tx.TecDUPLICATE
+		return ter.TecDUPLICATE
 	}
 
 	// Check expiration (if set, must be in the future)
 	if c.Expiration != nil {
 		closeTime := ctx.Config.ParentCloseTime
 		if closeTime > *c.Expiration {
-			return tx.TecEXPIRED
+			return ter.TecEXPIRED
 		}
 	}
 
 	// Check reserve for issuer (ctx.Account) using the prior balance (before the
 	// actual fee was deducted), matching rippled's mPriorBalance comparison.
-	if result := ctx.CheckReserveWithFee(ctx.Account.OwnerCount + 1); result != tx.TesSUCCESS {
+	if result := ctx.CheckReserveWithFee(ctx.Account.OwnerCount + 1); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -200,9 +201,9 @@ func (c *CredentialCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	})
 	if err != nil {
 		if errors.Is(err, state.ErrDirFull) {
-			return tx.TecDIR_FULL
+			return ter.TecDIR_FULL
 		}
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	cred.IssuerNode = issuerDirResult.Page
 
@@ -214,9 +215,9 @@ func (c *CredentialCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		})
 		if err != nil {
 			if errors.Is(err, state.ErrDirFull) {
-				return tx.TecDIR_FULL
+				return ter.TecDIR_FULL
 			}
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		cred.SubjectNode = subjectDirResult.Page
 	}
@@ -224,16 +225,16 @@ func (c *CredentialCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Serialize the credential entry
 	credData, err := serializeCredentialEntry(cred)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Insert the credential
 	if err := ctx.View.Insert(credKeylet, credData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Increase issuer's owner count
 	ctx.Account.OwnerCount++
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/credential/credential_delete.go
+++ b/internal/tx/credential/credential_delete.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -82,7 +83,7 @@ func (c *CredentialDelete) Validate() error {
 	}
 	decoded, err := hex.DecodeString(c.CredentialType)
 	if err != nil {
-		return tx.Errorf(tx.TemMALFORMED, "CredentialType must be valid hex string")
+		return ter.Errorf(ter.TemMALFORMED, "CredentialType must be valid hex string")
 	}
 	if len(decoded) == 0 {
 		return ErrCredentialTypeEmpty
@@ -103,12 +104,12 @@ func (c *CredentialDelete) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled Credentials.cpp CredentialDelete::doApply()
-func (c *CredentialDelete) Apply(ctx *tx.ApplyContext) tx.Result {
+func (c *CredentialDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Check for invalid flags, gated behind fixInvalidTxFlags
 	// Reference: rippled Credentials.cpp:217-222
 	if ctx.Rules().Enabled(amendment.FeatureFixInvalidTxFlags) {
 		if c.GetFlags()&tx.TfUniversalMask != 0 {
-			return tx.TemINVALID_FLAG
+			return ter.TemINVALID_FLAG
 		}
 	}
 
@@ -120,13 +121,13 @@ func (c *CredentialDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	)
 
 	if c.CredentialType == "" {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	// Decode credential type from hex to bytes
 	credTypeBytes, err := hex.DecodeString(c.CredentialType)
 	if err != nil {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	// Default subject/issuer to Account if not specified
@@ -135,7 +136,7 @@ func (c *CredentialDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	if c.Subject != "" {
 		subjectID, err = state.DecodeAccountID(c.Subject)
 		if err != nil {
-			return tx.TecNO_TARGET
+			return ter.TecNO_TARGET
 		}
 	} else {
 		subjectID = ctx.AccountID
@@ -144,7 +145,7 @@ func (c *CredentialDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	if c.Issuer != "" {
 		issuerID, err = state.DecodeAccountID(c.Issuer)
 		if err != nil {
-			return tx.TecNO_TARGET
+			return ter.TecNO_TARGET
 		}
 	} else {
 		issuerID = ctx.AccountID
@@ -156,13 +157,13 @@ func (c *CredentialDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Preclaim check: verify credential exists
 	credData, err := ctx.View.Read(credKeylet)
 	if err != nil || credData == nil {
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	// Parse the credential entry
 	cred, err := ParseCredentialEntry(credData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Permission check: only subject or issuer can delete non-expired credentials
@@ -174,10 +175,10 @@ func (c *CredentialDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	if !isSubject && !isIssuer && !isExpired {
 		ctx.Log.Trace("credential delete: can't delete non-expired credential")
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
-	if result := DeleteSLE(ctx, credKeylet, cred); result != tx.TesSUCCESS {
+	if result := DeleteSLE(ctx, credKeylet, cred); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -187,5 +188,5 @@ func (c *CredentialDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.SyncSenderOwnerCount()
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/credential/credential_helpers.go
+++ b/internal/tx/credential/credential_helpers.go
@@ -8,6 +8,7 @@ import (
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -226,12 +227,12 @@ func CheckFields(ids []string, present bool, dupDetail string) error {
 		return nil
 	}
 	if len(ids) == 0 || len(ids) > 8 {
-		return tx.Errorf(tx.TemMALFORMED, "CredentialIDs array size is invalid")
+		return ter.Errorf(ter.TemMALFORMED, "CredentialIDs array size is invalid")
 	}
 	seen := make(map[string]bool, len(ids))
 	for _, id := range ids {
 		if seen[id] {
-			return tx.Errorf(tx.TemMALFORMED, "%s", dupDetail)
+			return ter.Errorf(ter.TemMALFORMED, "%s", dupDetail)
 		}
 		seen[id] = true
 	}
@@ -243,41 +244,41 @@ func CheckFields(ids []string, present bool, dupDetail string) error {
 // Subject, and be accepted, otherwise tecBAD_CREDENTIALS. Expiry is never
 // checked here — it is deferred to RemoveExpiredCredentials.
 // Reference: rippled CredentialHelpers.cpp credentials::valid()
-func ValidateCredentialIDs(ctx *tx.ApplyContext, credentialIDs []string) tx.Result {
+func ValidateCredentialIDs(ctx *tx.ApplyContext, credentialIDs []string) ter.Result {
 	return ValidCredentials(ctx.View, ctx.AccountID, credentialIDs)
 }
 
 // ValidCredentials is the view-based form of ValidateCredentialIDs, usable from
 // Preclaim where only a LedgerView (not an ApplyContext) is available.
-func ValidCredentials(view tx.LedgerView, subject [20]byte, credentialIDs []string) tx.Result {
+func ValidCredentials(view tx.LedgerView, subject [20]byte, credentialIDs []string) ter.Result {
 	for _, idHex := range credentialIDs {
 		credIDBytes, err := hex.DecodeString(idHex)
 		if err != nil || len(credIDBytes) != 32 {
-			return tx.TecBAD_CREDENTIALS
+			return ter.TecBAD_CREDENTIALS
 		}
 		var credID [32]byte
 		copy(credID[:], credIDBytes)
 
 		credData, err := view.Read(keylet.CredentialByID(credID))
 		if err != nil || credData == nil {
-			return tx.TecBAD_CREDENTIALS
+			return ter.TecBAD_CREDENTIALS
 		}
 
 		cred, err := ParseCredentialEntry(credData)
 		if err != nil {
-			return tx.TecBAD_CREDENTIALS
+			return ter.TecBAD_CREDENTIALS
 		}
 
 		if cred.Subject != subject {
-			return tx.TecBAD_CREDENTIALS
+			return ter.TecBAD_CREDENTIALS
 		}
 
 		if !cred.IsAccepted() {
-			return tx.TecBAD_CREDENTIALS
+			return ter.TecBAD_CREDENTIALS
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // RemoveExpiredCredentials deletes any expired credentials in credentialIDs
@@ -323,23 +324,23 @@ func RemoveExpiredCredentials(ctx *tx.ApplyContext, credentialIDs []string) bool
 // lsfDepositAuth set and src != dst, the deposit must be preauthorized by
 // dst, either by account or by the supplied credentials.
 // Reference: rippled CredentialHelpers.cpp verifyDepositPreauth()
-func VerifyDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, src, dst [20]byte, dstAccount *state.AccountRoot) tx.Result {
+func VerifyDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, src, dst [20]byte, dstAccount *state.AccountRoot) ter.Result {
 	credentialsPresent := len(credentialIDs) > 0
 
 	if credentialsPresent && RemoveExpiredCredentials(ctx, credentialIDs) {
-		return tx.TecEXPIRED
+		return ter.TecEXPIRED
 	}
 
 	if dstAccount != nil && (dstAccount.Flags&state.LsfDepositAuth) != 0 && src != dst {
 		if exists, _ := ctx.View.Exists(keylet.DepositPreauth(dst, src)); !exists {
 			if !credentialsPresent {
-				return tx.TecNO_PERMISSION
+				return ter.TecNO_PERMISSION
 			}
 			return authorizedDepositPreauth(ctx, credentialIDs, dst)
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // authorizedDepositPreauth checks whether the (Issuer, CredentialType) pairs
@@ -348,14 +349,14 @@ func VerifyDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, src, dst
 // credentials that passed preflight and preclaim, since credential IDs are
 // deduplicated there and all credentials share the sender as Subject.
 // Reference: rippled CredentialHelpers.cpp credentials::authorizedDepositPreauth()
-func authorizedDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, dst [20]byte) tx.Result {
+func authorizedDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, dst [20]byte) ter.Result {
 	pairs := make([]keylet.CredentialPair, 0, len(credentialIDs))
 	seen := make(map[string]bool, len(credentialIDs))
 
 	for _, idHex := range credentialIDs {
 		credIDBytes, err := hex.DecodeString(idHex)
 		if err != nil || len(credIDBytes) != 32 {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		var credID [32]byte
 		copy(credID[:], credIDBytes)
@@ -363,17 +364,17 @@ func authorizedDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, dst 
 		// Credential existence was already checked in preclaim.
 		credData, err := ctx.View.Read(keylet.CredentialByID(credID))
 		if err != nil || credData == nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		cred, err := ParseCredentialEntry(credData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		pairKey := hex.EncodeToString(cred.Issuer[:]) + ":" + hex.EncodeToString(cred.CredentialType)
 		if seen[pairKey] {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		seen[pairKey] = true
 
@@ -390,10 +391,10 @@ func authorizedDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, dst 
 	})
 
 	if exists, _ := ctx.View.Exists(keylet.DepositPreauthCredentials(dst, pairs)); !exists {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // DeleteSLE deletes a credential from the ledger, removing it from both the
@@ -404,38 +405,38 @@ func authorizedDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, dst 
 // resync ctx.Account from the view afterwards. A missing owner account yields
 // tecINTERNAL and a failed directory removal tefBAD_LEDGER, matching rippled.
 // Reference: rippled CredentialHelpers.cpp credentials::deleteSLE()
-func DeleteSLE(ctx *tx.ApplyContext, credKey keylet.Keylet, cred *CredentialEntry) tx.Result {
-	removeFromDir := func(account [20]byte, page uint64, isOwner bool) tx.Result {
+func DeleteSLE(ctx *tx.ApplyContext, credKey keylet.Keylet, cred *CredentialEntry) ter.Result {
+	removeFromDir := func(account [20]byte, page uint64, isOwner bool) ter.Result {
 		if exists, err := ctx.View.Exists(keylet.Account(account)); err != nil || !exists {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 		result, err := state.DirRemove(ctx.View, keylet.OwnerDir(account), page, credKey.Key, false)
 		if err != nil || result == nil || !result.Success {
-			return tx.TefBAD_LEDGER
+			return ter.TefBAD_LEDGER
 		}
 		if isOwner {
 			if err := tx.AdjustOwnerCount(ctx.View, account, -1); err != nil {
-				return tx.TefBAD_LEDGER
+				return ter.TefBAD_LEDGER
 			}
 		}
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// If not accepted, the issuer owns it; if accepted and subject == issuer,
 	// the issuer owns it.
 	issuerOwns := !cred.IsAccepted() || (cred.Subject == cred.Issuer)
-	if result := removeFromDir(cred.Issuer, cred.IssuerNode, issuerOwns); result != tx.TesSUCCESS {
+	if result := removeFromDir(cred.Issuer, cred.IssuerNode, issuerOwns); result != ter.TesSUCCESS {
 		return result
 	}
 
 	if cred.Subject != cred.Issuer {
-		if result := removeFromDir(cred.Subject, cred.SubjectNode, cred.IsAccepted()); result != tx.TesSUCCESS {
+		if result := removeFromDir(cred.Subject, cred.SubjectNode, cred.IsAccepted()); result != ter.TesSUCCESS {
 			return result
 		}
 	}
 
 	if err := ctx.View.Erase(credKey); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/delegate/delegate_set.go
+++ b/internal/tx/delegate/delegate_set.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -77,13 +78,13 @@ func (d *DelegateSet) Validate() error {
 	// Check permissions array size.
 	// Reference: rippled DelegateSet.cpp preflight() — permissions.size() > permissionMaxSize
 	if len(d.Permissions) > permissionMaxSize {
-		return tx.Errorf(tx.TemARRAY_TOO_LARGE, "permissions array exceeds maximum size of %d", permissionMaxSize)
+		return ter.Errorf(ter.TemARRAY_TOO_LARGE, "permissions array exceeds maximum size of %d", permissionMaxSize)
 	}
 
 	// Cannot authorize self.
 	// Reference: rippled DelegateSet.cpp preflight() — ctx.tx[sfAccount] == ctx.tx[sfAuthorize]
 	if d.Authorize != "" && d.GetCommon().Account == d.Authorize {
-		return tx.Errorf(tx.TemMALFORMED, "cannot delegate to self")
+		return ter.Errorf(ter.TemMALFORMED, "cannot delegate to self")
 	}
 
 	// Check for duplicate permission values.
@@ -95,7 +96,7 @@ func (d *DelegateSet) Validate() error {
 			continue
 		}
 		if seen[pv] {
-			return tx.Errorf(tx.TemMALFORMED, "duplicate permission value %q", pv)
+			return ter.Errorf(ter.TemMALFORMED, "duplicate permission value %q", pv)
 		}
 		seen[pv] = true
 	}
@@ -137,7 +138,7 @@ func (d *DelegateSet) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled DelegateSet.cpp preclaim() + doApply()
-func (d *DelegateSet) Apply(ctx *tx.ApplyContext) tx.Result {
+func (d *DelegateSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("delegate set apply",
 		"account", d.Account,
 		"authorize", d.Authorize,
@@ -148,10 +149,10 @@ func (d *DelegateSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled DelegateSet.cpp preclaim()
 	authorizeID, err := state.DecodeAccountID(d.Authorize)
 	if err != nil {
-		return tx.TecNO_TARGET
+		return ter.TecNO_TARGET
 	}
 	if exists, _ := ctx.View.Exists(keylet.Account(authorizeID)); !exists {
-		return tx.TecNO_TARGET
+		return ter.TecNO_TARGET
 	}
 
 	// Preclaim: check that all permissions are delegatable.
@@ -159,7 +160,7 @@ func (d *DelegateSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	permValues := d.permissionValues()
 	for _, pv := range permValues {
 		if !isDelegatable(pv) {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	}
 
@@ -176,7 +177,7 @@ func (d *DelegateSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Update the existing delegate with new permissions
 		newData, serErr := state.SerializeDelegate(ctx.AccountID, authorizeID, permValues, 0)
 		if serErr != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Preserve the existing OwnerNode by parsing old entry and re-serializing
@@ -184,35 +185,35 @@ func (d *DelegateSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		if parseErr == nil {
 			newData, serErr = state.SerializeDelegate(ctx.AccountID, authorizeID, permValues, existingEntry.OwnerNode)
 			if serErr != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 		}
 
 		if err := ctx.View.Update(delegateKey, newData); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Delegate SLE does not exist -- create new one
 	if len(permValues) == 0 {
 		// Nothing to create
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Check reserve against the prior balance (before the actual fee was
 	// deducted), allowing the account to dip into the reserve to pay fees.
-	if result := ctx.CheckReserveWithFee(ctx.Account.OwnerCount + 1); result != tx.TesSUCCESS {
+	if result := ctx.CheckReserveWithFee(ctx.Account.OwnerCount + 1); result != ter.TesSUCCESS {
 		return result
 	}
 
 	delegateData, serErr := state.SerializeDelegate(ctx.AccountID, authorizeID, permValues, 0)
 	if serErr != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if err := ctx.View.Insert(delegateKey, delegateData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Insert into owner directory
@@ -221,36 +222,36 @@ func (d *DelegateSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		dir.Owner = ctx.AccountID
 	})
 	if dirErr != nil {
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 
 	// Update OwnerNode on the delegate entry if page != 0
 	if dirResult.Page != 0 {
 		newData, serErr := state.SerializeDelegate(ctx.AccountID, authorizeID, permValues, dirResult.Page)
 		if serErr != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := ctx.View.Update(delegateKey, newData); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
 	ctx.Account.OwnerCount++
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // deleteDelegate removes an existing delegate entry from the ledger.
 // Reference: rippled DelegateSet.cpp deleteDelegate()
-func deleteDelegate(ctx *tx.ApplyContext, delegateKey keylet.Keylet, account [20]byte) tx.Result {
+func deleteDelegate(ctx *tx.ApplyContext, delegateKey keylet.Keylet, account [20]byte) ter.Result {
 	// Read the existing entry to get OwnerNode
 	existingData, err := ctx.View.Read(delegateKey)
 	if err != nil || existingData == nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	existingEntry, parseErr := state.ParseDelegate(existingData)
 	if parseErr != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	ownerDirKey := keylet.OwnerDir(account)
@@ -259,14 +260,14 @@ func deleteDelegate(ctx *tx.ApplyContext, delegateKey keylet.Keylet, account [20
 	// Erase the delegate entry
 	if err := ctx.View.Erase(delegateKey); err != nil {
 		ctx.Log.Error("delegate set: unable to delete delegate from owner")
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if ctx.Account.OwnerCount > 0 {
 		ctx.Account.OwnerCount--
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // permissionValues extracts the uint32 permission values from the transaction's

--- a/internal/tx/depositpreauth/depositpreauth.go
+++ b/internal/tx/depositpreauth/depositpreauth.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 const (
@@ -107,7 +108,7 @@ func (d *DepositPreauth) Validate() error {
 	// Exactly one of the 4 fields must be present
 	// Reference: rippled preflight() - authPresent + authCredPresent != 1
 	if authPresent+authCredPresent != 1 {
-		return tx.Errorf(tx.TemMALFORMED, "Invalid Authorize and Unauthorize field combination")
+		return ter.Errorf(ter.TemMALFORMED, "Invalid Authorize and Unauthorize field combination")
 	}
 
 	if authPresent > 0 {
@@ -120,16 +121,16 @@ func (d *DepositPreauth) Validate() error {
 		// Validate target account is not zero
 		targetID, err := state.DecodeAccountID(target)
 		if err != nil {
-			return tx.Errorf(tx.TemINVALID_ACCOUNT_ID, "Authorized or Unauthorized field invalid")
+			return ter.Errorf(ter.TemINVALID_ACCOUNT_ID, "Authorized or Unauthorized field invalid")
 		}
 		if targetID == [20]byte{} {
-			return tx.Errorf(tx.TemINVALID_ACCOUNT_ID, "Authorized or Unauthorized field zeroed")
+			return ter.Errorf(ter.TemINVALID_ACCOUNT_ID, "Authorized or Unauthorized field zeroed")
 		}
 
 		// Cannot preauthorize self (only checked for Authorize, not Unauthorize)
 		// Reference: rippled preflight() - optAuth && target == ctx.tx[sfAccount]
 		if hasAuth && target == d.Account {
-			return tx.Errorf(tx.TemCAN_NOT_PREAUTH_SELF, "Attempting to DepositPreauth self")
+			return ter.Errorf(ter.TemCAN_NOT_PREAUTH_SELF, "Attempting to DepositPreauth self")
 		}
 	} else {
 		// Credential-based preauth validation
@@ -152,10 +153,10 @@ func (d *DepositPreauth) Validate() error {
 // Reference: rippled credentials::checkArray()
 func checkCredentialArray(creds []CredentialWrapper) error {
 	if len(creds) == 0 {
-		return tx.Errorf(tx.TemARRAY_EMPTY, "Invalid credentials size: 0")
+		return ter.Errorf(ter.TemARRAY_EMPTY, "Invalid credentials size: 0")
 	}
 	if len(creds) > maxCredentialsArraySize {
-		return tx.Errorf(tx.TemARRAY_TOO_LARGE, "Invalid credentials size: %d", len(creds))
+		return ter.Errorf(ter.TemARRAY_TOO_LARGE, "Invalid credentials size: %d", len(creds))
 	}
 
 	// Check each credential and detect duplicates
@@ -166,19 +167,19 @@ func checkCredentialArray(creds []CredentialWrapper) error {
 		// Validate issuer
 		issuerID, err := state.DecodeAccountID(c.Issuer)
 		if err != nil || issuerID == ([20]byte{}) {
-			return tx.Errorf(tx.TemINVALID_ACCOUNT_ID, "Issuer account is invalid")
+			return ter.Errorf(ter.TemINVALID_ACCOUNT_ID, "Issuer account is invalid")
 		}
 
 		// Validate credential type (hex-encoded, 1-64 raw bytes)
 		credTypeBytes, err := hex.DecodeString(c.CredentialType)
 		if err != nil || len(credTypeBytes) == 0 || len(credTypeBytes) > maxCredentialTypeLength {
-			return tx.Errorf(tx.TemMALFORMED, "Invalid credentialType size")
+			return ter.Errorf(ter.TemMALFORMED, "Invalid credentialType size")
 		}
 
 		// Check for duplicates using sha512Half(issuer, credType)
 		hash := common.Sha512Half(issuerID[:], credTypeBytes)
 		if duplicates[hash] {
-			return tx.Errorf(tx.TemMALFORMED, "duplicates in credentials")
+			return ter.Errorf(ter.TemMALFORMED, "duplicates in credentials")
 		}
 		duplicates[hash] = true
 	}
@@ -260,7 +261,7 @@ func toKeyletPairs(pairs []sortedCredPair) []keylet.CredentialPair {
 
 // Combines preclaim checks and doApply logic.
 // Reference: rippled DepositPreauth::preclaim() + DepositPreauth::doApply()
-func (d *DepositPreauth) Apply(ctx *tx.ApplyContext) tx.Result {
+func (d *DepositPreauth) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("deposit preauth apply",
 		"account", d.Account,
 		"authorize", d.Authorize,
@@ -278,15 +279,15 @@ func (d *DepositPreauth) Apply(ctx *tx.ApplyContext) tx.Result {
 	} else if len(d.UnauthorizeCredentials) > 0 {
 		return d.applyUnauthorizeCredentials(ctx)
 	}
-	return tx.TemMALFORMED
+	return ter.TemMALFORMED
 }
 
 // applyAuthorize handles the Authorize case.
 // Reference: rippled DepositPreauth preclaim(sfAuthorize) + doApply(sfAuthorize)
-func (d *DepositPreauth) applyAuthorize(ctx *tx.ApplyContext) tx.Result {
+func (d *DepositPreauth) applyAuthorize(ctx *tx.ApplyContext) ter.Result {
 	authorizedID, err := state.DecodeAccountID(d.Authorize)
 	if err != nil {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	// --- Preclaim: verify target account exists ---
@@ -294,7 +295,7 @@ func (d *DepositPreauth) applyAuthorize(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Warn("deposit preauth authorize: target account does not exist",
 			"authorize", d.Authorize,
 		)
-		return tx.TecNO_TARGET
+		return ter.TecNO_TARGET
 	}
 
 	// --- Preclaim: verify preauth entry doesn't already exist ---
@@ -303,12 +304,12 @@ func (d *DepositPreauth) applyAuthorize(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Warn("deposit preauth authorize: preauth already exists",
 			"authorize", d.Authorize,
 		)
-		return tx.TecDUPLICATE
+		return ter.TecDUPLICATE
 	}
 
 	// Check reserve using the prior balance (before the actual fee was
 	// deducted), matching rippled's mPriorBalance comparison.
-	if result := ctx.CheckReserveWithFee(ctx.Account.OwnerCount + 1); result != tx.TesSUCCESS {
+	if result := ctx.CheckReserveWithFee(ctx.Account.OwnerCount + 1); result != ter.TesSUCCESS {
 		ctx.Log.Warn("deposit preauth authorize: insufficient reserve")
 		return result
 	}
@@ -317,12 +318,12 @@ func (d *DepositPreauth) applyAuthorize(ctx *tx.ApplyContext) tx.Result {
 	preauthData, err := state.SerializeDepositPreauth(ctx.AccountID, authorizedID)
 	if err != nil {
 		ctx.Log.Error("deposit preauth authorize: failed to serialize preauth entry", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if err := ctx.View.Insert(preauthKey, preauthData); err != nil {
 		ctx.Log.Error("deposit preauth authorize: failed to insert preauth entry", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// --- doApply: insert into owner directory ---
@@ -332,26 +333,26 @@ func (d *DepositPreauth) applyAuthorize(ctx *tx.ApplyContext) tx.Result {
 	})
 	if err != nil {
 		ctx.Log.Error("deposit preauth authorize: directory full", "error", err)
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 
 	if dirResult.Page != 0 {
 		if err := updateOwnerNode(ctx, preauthKey, dirResult.Page); err != nil {
 			ctx.Log.Error("deposit preauth authorize: failed to update owner node", "error", err)
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
 	ctx.Account.OwnerCount++
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // applyUnauthorize handles the Unauthorize case.
 // Reference: rippled DepositPreauth preclaim(sfUnauthorize) + doApply(sfUnauthorize)
-func (d *DepositPreauth) applyUnauthorize(ctx *tx.ApplyContext) tx.Result {
+func (d *DepositPreauth) applyUnauthorize(ctx *tx.ApplyContext) ter.Result {
 	unauthorizedID, err := state.DecodeAccountID(d.Unauthorize)
 	if err != nil {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	preauthKey := keylet.DepositPreauth(ctx.AccountID, unauthorizedID)
@@ -361,7 +362,7 @@ func (d *DepositPreauth) applyUnauthorize(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Warn("deposit preauth unauthorize: preauth entry does not exist",
 			"unauthorize", d.Unauthorize,
 		)
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	return removeFromLedger(ctx, preauthKey)
@@ -369,11 +370,11 @@ func (d *DepositPreauth) applyUnauthorize(ctx *tx.ApplyContext) tx.Result {
 
 // applyAuthorizeCredentials handles the AuthorizeCredentials case.
 // Reference: rippled DepositPreauth preclaim(sfAuthorizeCredentials) + doApply(sfAuthorizeCredentials)
-func (d *DepositPreauth) applyAuthorizeCredentials(ctx *tx.ApplyContext) tx.Result {
+func (d *DepositPreauth) applyAuthorizeCredentials(ctx *tx.ApplyContext) ter.Result {
 	// --- Preclaim: sort and validate credentials ---
 	sorted := makeSorted(d.AuthorizeCredentials)
 	if sorted == nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Verify each issuer account exists
@@ -382,7 +383,7 @@ func (d *DepositPreauth) applyAuthorizeCredentials(ctx *tx.ApplyContext) tx.Resu
 			ctx.Log.Warn("deposit preauth authorize credentials: issuer does not exist",
 				"issuer", fmt.Sprintf("%x", p.issuer),
 			)
-			return tx.TecNO_ISSUER
+			return ter.TecNO_ISSUER
 		}
 	}
 
@@ -390,12 +391,12 @@ func (d *DepositPreauth) applyAuthorizeCredentials(ctx *tx.ApplyContext) tx.Resu
 	preauthKey := keylet.DepositPreauthCredentials(ctx.AccountID, toKeyletPairs(sorted))
 	if exists, _ := ctx.View.Exists(preauthKey); exists {
 		ctx.Log.Warn("deposit preauth authorize credentials: preauth already exists")
-		return tx.TecDUPLICATE
+		return ter.TecDUPLICATE
 	}
 
 	// Check reserve using the prior balance (before the actual fee was
 	// deducted), matching rippled's mPriorBalance comparison.
-	if result := ctx.CheckReserveWithFee(ctx.Account.OwnerCount + 1); result != tx.TesSUCCESS {
+	if result := ctx.CheckReserveWithFee(ctx.Account.OwnerCount + 1); result != ter.TesSUCCESS {
 		ctx.Log.Warn("deposit preauth authorize credentials: insufficient reserve")
 		return result
 	}
@@ -406,7 +407,7 @@ func (d *DepositPreauth) applyAuthorizeCredentials(ctx *tx.ApplyContext) tx.Resu
 		addr, err := addresscodec.EncodeAccountIDToClassicAddress(p.issuer[:])
 		if err != nil {
 			ctx.Log.Error("deposit preauth authorize credentials: failed to encode issuer address", "error", err)
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		sleCreds[i] = state.DepositPreauthCredential{
 			Issuer:         addr,
@@ -417,12 +418,12 @@ func (d *DepositPreauth) applyAuthorizeCredentials(ctx *tx.ApplyContext) tx.Resu
 	preauthData, err := state.SerializeDepositPreauthCredentials(ctx.AccountID, sleCreds)
 	if err != nil {
 		ctx.Log.Error("deposit preauth authorize credentials: failed to serialize preauth entry", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if err := ctx.View.Insert(preauthKey, preauthData); err != nil {
 		ctx.Log.Error("deposit preauth authorize credentials: failed to insert preauth entry", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// --- doApply: insert into owner directory ---
@@ -432,26 +433,26 @@ func (d *DepositPreauth) applyAuthorizeCredentials(ctx *tx.ApplyContext) tx.Resu
 	})
 	if err != nil {
 		ctx.Log.Error("deposit preauth authorize credentials: directory full", "error", err)
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 
 	if dirResult.Page != 0 {
 		if err := updateOwnerNode(ctx, preauthKey, dirResult.Page); err != nil {
 			ctx.Log.Error("deposit preauth authorize credentials: failed to update owner node", "error", err)
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
 	ctx.Account.OwnerCount++
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // applyUnauthorizeCredentials handles the UnauthorizeCredentials case.
 // Reference: rippled DepositPreauth preclaim(sfUnauthorizeCredentials) + doApply(sfUnauthorizeCredentials)
-func (d *DepositPreauth) applyUnauthorizeCredentials(ctx *tx.ApplyContext) tx.Result {
+func (d *DepositPreauth) applyUnauthorizeCredentials(ctx *tx.ApplyContext) ter.Result {
 	sorted := makeSorted(d.UnauthorizeCredentials)
 	if sorted == nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	preauthKey := keylet.DepositPreauthCredentials(ctx.AccountID, toKeyletPairs(sorted))
@@ -459,7 +460,7 @@ func (d *DepositPreauth) applyUnauthorizeCredentials(ctx *tx.ApplyContext) tx.Re
 	// --- Preclaim: verify preauth entry exists ---
 	if exists, _ := ctx.View.Exists(preauthKey); !exists {
 		ctx.Log.Warn("deposit preauth unauthorize credentials: preauth entry does not exist")
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	return removeFromLedger(ctx, preauthKey)
@@ -469,12 +470,12 @@ func (d *DepositPreauth) applyUnauthorizeCredentials(ctx *tx.ApplyContext) tx.Re
 // Reads the entry to find OwnerNode, removes from owner directory,
 // adjusts owner count, and erases the entry.
 // Reference: rippled DepositPreauth::removeFromLedger()
-func removeFromLedger(ctx *tx.ApplyContext, preauthKey keylet.Keylet) tx.Result {
+func removeFromLedger(ctx *tx.ApplyContext, preauthKey keylet.Keylet) ter.Result {
 	// Read the preauth entry to get OwnerNode for directory removal
 	preauthData, err := ctx.View.Read(preauthKey)
 	if err != nil || preauthData == nil {
 		ctx.Log.Warn("deposit preauth remove: entry not found in ledger")
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	// Parse OwnerNode from the binary entry
@@ -489,20 +490,20 @@ func removeFromLedger(ctx *tx.ApplyContext, preauthKey keylet.Keylet) tx.Result 
 	res, err := state.DirRemove(ctx.View, ownerDirKey, ownerNode, preauthKey.Key, false)
 	if err != nil || !res.Success {
 		ctx.Log.Error("deposit preauth remove: failed to remove from owner directory", "error", err)
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 
 	// Erase the entry
 	if err := ctx.View.Erase(preauthKey); err != nil {
 		ctx.Log.Error("deposit preauth remove: failed to erase entry", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if ctx.Account.OwnerCount > 0 {
 		ctx.Account.OwnerCount--
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // updateOwnerNode reads a ledger entry, updates its OwnerNode field, and writes

--- a/internal/tx/did/constant.go
+++ b/internal/tx/did/constant.go
@@ -1,6 +1,6 @@
 package did
 
-import "github.com/LeJamon/go-xrpl/internal/tx"
+import "github.com/LeJamon/go-xrpl/internal/tx/ter"
 
 // DID field length constants
 // Reference: rippled Protocol.h
@@ -17,9 +17,9 @@ const (
 
 // DID validation errors
 var (
-	ErrDIDEmpty       = tx.Errorf(tx.TemEMPTY_DID, "DID transaction must have at least one non-empty field")
-	ErrDIDURITooLong  = tx.Errorf(tx.TemMALFORMED, "URI exceeds maximum length of 256 bytes")
-	ErrDIDDocTooLong  = tx.Errorf(tx.TemMALFORMED, "DIDDocument exceeds maximum length of 256 bytes")
-	ErrDIDDataTooLong = tx.Errorf(tx.TemMALFORMED, "Data exceeds maximum length of 256 bytes")
-	ErrDIDInvalidHex  = tx.Errorf(tx.TemMALFORMED, "field must be valid hex string")
+	ErrDIDEmpty       = ter.Errorf(ter.TemEMPTY_DID, "DID transaction must have at least one non-empty field")
+	ErrDIDURITooLong  = ter.Errorf(ter.TemMALFORMED, "URI exceeds maximum length of 256 bytes")
+	ErrDIDDocTooLong  = ter.Errorf(ter.TemMALFORMED, "DIDDocument exceeds maximum length of 256 bytes")
+	ErrDIDDataTooLong = ter.Errorf(ter.TemMALFORMED, "Data exceeds maximum length of 256 bytes")
+	ErrDIDInvalidHex  = ter.Errorf(ter.TemMALFORMED, "field must be valid hex string")
 )

--- a/internal/tx/did/did_delete.go
+++ b/internal/tx/did/did_delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -46,7 +47,7 @@ func (d *DIDDelete) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled DID.cpp DIDDelete::doApply
-func (d *DIDDelete) Apply(ctx *tx.ApplyContext) tx.Result {
+func (d *DIDDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("did delete apply",
 		"account", d.Account,
 	)
@@ -55,12 +56,12 @@ func (d *DIDDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	existingData, err := ctx.View.Read(didKey)
 	if err != nil || existingData == nil {
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	did, err := state.ParseDID(existingData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Remove from owner directory, using the page recorded in sfOwnerNode so a
@@ -71,12 +72,12 @@ func (d *DIDDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	if err := ctx.View.Erase(didKey); err != nil {
 		ctx.Log.Error("did delete: unable to delete DID from owner")
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if ctx.Account.OwnerCount > 0 {
 		ctx.Account.OwnerCount--
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/did/did_set.go
+++ b/internal/tx/did/did_set.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -108,7 +109,7 @@ func (d *DIDSet) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled DID.cpp DIDSet::doApply
-func (d *DIDSet) Apply(ctx *tx.ApplyContext) tx.Result {
+func (d *DIDSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("did set apply",
 		"account", d.Account,
 		"uri", d.URI,
@@ -120,7 +121,7 @@ func (d *DIDSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	if err == nil && existingData != nil {
 		did, err := state.ParseDID(existingData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Update fields based on what's provided in transaction
@@ -144,25 +145,25 @@ func (d *DIDSet) Apply(ctx *tx.ApplyContext) tx.Result {
 
 		// Check that at least one field remains after update
 		if did.URI == "" && did.DIDDocument == "" && did.Data == "" {
-			return tx.TecEMPTY_DID
+			return ter.TecEMPTY_DID
 		}
 
 		// Serialize and update the DID - modification tracked automatically by ApplyStateTable
 		updatedData, err := state.SerializeDID(did, d.Account)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		if err := ctx.View.Update(didKey, updatedData); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	reserve := ctx.AccountReserve(ctx.Account.OwnerCount + 1)
 	if ctx.Account.Balance < reserve {
-		return tx.TecINSUFFICIENT_RESERVE
+		return ter.TecINSUFFICIENT_RESERVE
 	}
 
 	did := &state.DIDData{
@@ -184,7 +185,7 @@ func (d *DIDSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled DID.cpp lines 163-169
 	if ctx.Rules().Enabled(amendment.FeatureFixEmptyDID) &&
 		did.URI == "" && did.DIDDocument == "" && did.Data == "" {
-		return tx.TecEMPTY_DID
+		return ter.TecEMPTY_DID
 	}
 
 	// Add to owner directory first so sfOwnerNode records the actual page.
@@ -194,21 +195,21 @@ func (d *DIDSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		dir.Owner = ctx.AccountID
 	})
 	if err != nil {
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 	did.OwnerNode = dirResult.Page
 
 	didData, err := state.SerializeDID(did, d.Account)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Insert the DID into the ledger
 	if err := ctx.View.Insert(didKey, didData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	ctx.Account.OwnerCount++
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/dir_remove.go
+++ b/internal/tx/dir_remove.go
@@ -2,6 +2,7 @@ package tx
 
 import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -10,10 +11,10 @@ import (
 // dirRemove during object teardown (escrow finish/cancel, channel close, check
 // cash) as a corrupt-ledger condition. keepRoot is passed through to
 // state.DirRemove; the teardown call sites use keepRoot=true.
-func DirRemoveOrBadLedger(view LedgerView, dir keylet.Keylet, page uint64, item [32]byte) Result {
+func DirRemoveOrBadLedger(view LedgerView, dir keylet.Keylet, page uint64, item [32]byte) ter.Result {
 	res, err := state.DirRemove(view, dir, page, item, true)
 	if err != nil || res == nil || !res.Success {
-		return TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/do_apply.go
+++ b/internal/tx/do_apply.go
@@ -337,7 +337,7 @@ func (e *Engine) invokeApplyInner(st *applyState) Result {
 		Config:           e.config,
 		TxHash:           st.txHash,
 		Metadata:         st.metadata,
-		Engine:           e,
+		InnerInvariants:  e,
 		SignedWithMaster: sigWithMaster,
 		Log:              e.logger,
 		Ctx:              st.ctx,
@@ -439,7 +439,7 @@ func (e *Engine) applyTecRecovery(st *applyState, result Result) Result {
 				Config:           e.config,
 				TxHash:           st.txHash,
 				Metadata:         st.metadata,
-				Engine:           e,
+				InnerInvariants:  e,
 				Log:              e.logger,
 				Ctx:              st.ctx,
 			}
@@ -789,7 +789,7 @@ func (e *Engine) runInvariantsOnTable(st *applyState, result Result, table *Appl
 //
 // A panic from CheckInvariants (e.g. AMM XRPLNumber overflow) is treated as a
 // violation, matching rippled's checkInvariantsHelper catch-all.
-func (e *Engine) CheckInnerInvariants(innerTx Transaction, result Result, innerTable *ApplyStateTable) (r Result) {
+func (e *Engine) CheckInnerInvariants(innerTx Transaction, result Result, innerTable LedgerView) (r Result) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			e.logger.Error("inner invariant check panic recovered, returning tecINVARIANT_FAILED",
@@ -798,11 +798,16 @@ func (e *Engine) CheckInnerInvariants(innerTx Transaction, result Result, innerT
 		}
 	}()
 
+	table, ok := innerTable.(*ApplyStateTable)
+	if !ok {
+		return TecINTERNAL
+	}
+
 	declaredFee := parseTxDeclaredFee(innerTx, innerFeeNone)
 	wrapped := wrapTxForInvariants(innerTx)
 	rules := e.rules()
 
-	if invariants.CheckInvariants(wrapped, invariants.Result(result), innerFeeNone, declaredFee, innerTable.CollectEntries(), innerTable, rules) == nil {
+	if invariants.CheckInvariants(wrapped, invariants.Result(result), innerFeeNone, declaredFee, table.CollectEntries(), table, rules) == nil {
 		return result
 	}
 

--- a/internal/tx/do_apply.go
+++ b/internal/tx/do_apply.go
@@ -8,6 +8,7 @@ import (
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx/invariants"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -50,7 +51,7 @@ func (st *applyState) sourceFeeCharged() uint64 {
 // doApply applies the transaction to the ledger
 // For tec results, only fee/sequence changes are applied; transaction effects are discarded.
 // Reference: rippled Transactor.cpp - tec results claim fee but don't apply effects
-func (e *Engine) doApply(ctx context.Context, tx Transaction, metadata *Metadata, txHash [32]byte) (Result, uint64) {
+func (e *Engine) doApply(ctx context.Context, tx Transaction, metadata *Metadata, txHash [32]byte) (ter.Result, uint64) {
 	common := tx.GetCommon()
 	accountID, _ := state.DecodeAccountID(common.Account)
 	accountKey := keylet.Account(accountID)
@@ -58,12 +59,12 @@ func (e *Engine) doApply(ctx context.Context, tx Transaction, metadata *Metadata
 	// Read sender account directly from view
 	accountData, err := e.view.Read(accountKey)
 	if err != nil {
-		return TefINTERNAL, 0
+		return ter.TefINTERNAL, 0
 	}
 
 	account, err := state.ParseAccountRoot(accountData)
 	if err != nil {
-		return TefINTERNAL, 0
+		return ter.TefINTERNAL, 0
 	}
 
 	fee := e.calculateFee(tx)
@@ -97,7 +98,7 @@ func (e *Engine) doApply(ctx context.Context, tx Transaction, metadata *Metadata
 
 	// payFee + consumeSeqProxy + AccountTxnID threading: apply pre-doApply()
 	// account mutations (rippled Transactor::apply()).
-	if result := e.applyPreApplyAccountChanges(st); result != TesSUCCESS {
+	if result := e.applyPreApplyAccountChanges(st); result != ter.TesSUCCESS {
 		return result, 0
 	}
 
@@ -106,7 +107,7 @@ func (e *Engine) doApply(ctx context.Context, tx Transaction, metadata *Metadata
 	// records st.chargedFee. On this success path preclaim's checkFee already
 	// guaranteed the delegate balance covers the full fee, so the clamp is a
 	// no-op and st.chargedFee == st.fee.
-	if result := e.payDelegatedFeeOnTable(st, table); result != TesSUCCESS {
+	if result := e.payDelegatedFeeOnTable(st, table); result != ter.TesSUCCESS {
 		return result, 0
 	}
 
@@ -115,7 +116,7 @@ func (e *Engine) doApply(ctx context.Context, tx Transaction, metadata *Metadata
 	// doApply() iterates the owner directory (e.g., AccountDelete), the
 	// consumed ticket is already gone.
 	if st.isTicket {
-		if result := e.consumeTicket(st, table); result != TesSUCCESS {
+		if result := e.consumeTicket(st, table); result != ter.TesSUCCESS {
 			return result, 0
 		}
 	}
@@ -145,7 +146,7 @@ func (e *Engine) doApply(ctx context.Context, tx Transaction, metadata *Metadata
 	//       result = tecOVERSIZE;
 	const oversizeMetaDataCap = 5200
 	if table.Size() > oversizeMetaDataCap {
-		result = TecOVERSIZE
+		result = ter.TecOVERSIZE
 	}
 
 	// For tec results, only apply fee/sequence changes, not transaction effects.
@@ -185,11 +186,11 @@ func (e *Engine) doApply(ctx context.Context, tx Transaction, metadata *Metadata
 	if !table.IsErased(accountKey) {
 		updatedData, err := state.SerializeAccountRoot(account)
 		if err != nil {
-			return TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
 
 		if err := table.Update(accountKey, updatedData); err != nil {
-			return TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
 	}
 
@@ -202,7 +203,7 @@ func (e *Engine) doApply(ctx context.Context, tx Transaction, metadata *Metadata
 	// Apply all tracked changes to the base view and generate metadata automatically
 	generatedMeta, err := table.Apply()
 	if err != nil {
-		return TefINTERNAL, 0
+		return ter.TefINTERNAL, 0
 	}
 
 	// Copy generated metadata to the output
@@ -216,7 +217,7 @@ func (e *Engine) doApply(ctx context.Context, tx Transaction, metadata *Metadata
 // pre-doApply account back into the ApplyStateTable. Mirrors the fee/seq
 // portion of rippled Transactor::apply() (payFee + consumeSeqProxy +
 // AccountTxnID block).
-func (e *Engine) applyPreApplyAccountChanges(st *applyState) Result {
+func (e *Engine) applyPreApplyAccountChanges(st *applyState) ter.Result {
 	// Reference: rippled Transactor::payFee + consumeSeqProxy in Transactor.cpp
 	if st.isDelegated {
 		// Delegated transactions: fee is charged to the delegate account, not the source.
@@ -252,12 +253,12 @@ func (e *Engine) applyPreApplyAccountChanges(st *applyState) Result {
 	// Without this, reads during Apply() would see the pre-fee balance.
 	preApplyData, preApplyErr := state.SerializeAccountRoot(st.account)
 	if preApplyErr != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := st.table.Update(st.accountKey, preApplyData); err != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // consumeTicket removes the ticket SLE from the owner directory and decrements
@@ -267,8 +268,8 @@ func (e *Engine) applyPreApplyAccountChanges(st *applyState) Result {
 // tec/invariant paths).
 // Reference: rippled Transactor::consumeSeqProxy + Transactor::ticketDelete
 // in Transactor.cpp.
-func (e *Engine) consumeTicket(st *applyState, table *ApplyStateTable) Result {
-	if r := e.eraseTicketEntry(st, table); r != TesSUCCESS {
+func (e *Engine) consumeTicket(st *applyState, table *ApplyStateTable) ter.Result {
+	if r := e.eraseTicketEntry(st, table); r != ter.TesSUCCESS {
 		return r
 	}
 	if st.account.OwnerCount > 0 {
@@ -279,12 +280,12 @@ func (e *Engine) consumeTicket(st *applyState, table *ApplyStateTable) Result {
 	}
 	preApplyData, preApplySerErr := state.SerializeAccountRoot(st.account)
 	if preApplySerErr != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := table.Update(st.accountKey, preApplyData); err != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // invokeApply dispatches to the per-tx-type Apply() implementation. Any panic
@@ -302,12 +303,12 @@ func (e *Engine) consumeTicket(st *applyState, table *ApplyStateTable) Result {
 // Returning tecINTERNAL here would diverge from rippled because tec* commits
 // fee+seq+meta to the ledger, producing a different account_hash on the same
 // adversarial input → consensus fork.
-func (e *Engine) invokeApply(st *applyState) (result Result) {
+func (e *Engine) invokeApply(st *applyState) (result ter.Result) {
 	defer func() {
 		if r := recover(); r != nil {
 			e.logger.Error("transaction Apply() panic recovered, returning tefEXCEPTION",
 				"txHash", fmt.Sprintf("%x", st.txHash), "panic", r)
-			result = TefEXCEPTION
+			result = ter.TefEXCEPTION
 		}
 	}()
 	return e.invokeApplyInner(st)
@@ -315,7 +316,7 @@ func (e *Engine) invokeApply(st *applyState) (result Result) {
 
 // invokeApplyInner is the body of invokeApply, separated so the panic-recovery
 // defer in invokeApply does not have to walk back through the dispatch.
-func (e *Engine) invokeApplyInner(st *applyState) Result {
+func (e *Engine) invokeApplyInner(st *applyState) ter.Result {
 	// Determine if the transaction was signed with the master key.
 	// Reference: rippled SetAccount.cpp sigWithMaster — compares
 	// calcAccountID(SigningPubKey) against the account ID.
@@ -346,7 +347,7 @@ func (e *Engine) invokeApplyInner(st *applyState) Result {
 	if appliable, ok := st.tx.(Appliable); ok {
 		return appliable.Apply(ctx)
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // isReapplyOnRetryTec reports whether a tec returned from doApply must still be
@@ -354,8 +355,8 @@ func (e *Engine) invokeApplyInner(st *applyState) Result {
 // rippled lists these four codes unconditionally in the reapply branch
 // (Transactor.cpp:1121-1124); the generic isTecClaimHardFail term — the part
 // that suppresses a tec under tapRETRY — never covers them.
-func isReapplyOnRetryTec(r Result) bool {
-	return r == TecOVERSIZE || r == TecKILLED || r == TecINCOMPLETE || r == TecEXPIRED
+func isReapplyOnRetryTec(r ter.Result) bool {
+	return r == ter.TecOVERSIZE || r == ter.TecKILLED || r == ter.TecINCOMPLETE || r == ter.TecEXPIRED
 }
 
 // applyTecRecovery implements the tec-result recovery path: discard the
@@ -365,11 +366,11 @@ func isReapplyOnRetryTec(r Result) bool {
 // Reference: rippled Transactor.cpp lines 1108-1216 — reset() + cleanup
 // helpers (removeUnfundedOffers, removeDeletedTrustLines,
 // removeExpiredNFTokenOffers).
-func (e *Engine) applyTecRecovery(st *applyState, result Result) Result {
+func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result {
 	// Collect keys-to-redelete from the to-be-discarded sandbox.
-	removedOfferKeys := collectErasedKeysOfType(st.table, "Offer", result == TecOVERSIZE || result == TecKILLED, 1000)
-	removedTrustLineKeys := collectErasedKeysOfType(st.table, "RippleState", result == TecINCOMPLETE, 512)
-	expiredNFTokenOfferKeys := collectErasedKeysOfType(st.table, "NFTokenOffer", result == TecEXPIRED, 256)
+	removedOfferKeys := collectErasedKeysOfType(st.table, "Offer", result == ter.TecOVERSIZE || result == ter.TecKILLED, 1000)
+	removedTrustLineKeys := collectErasedKeysOfType(st.table, "RippleState", result == ter.TecINCOMPLETE, 512)
+	expiredNFTokenOfferKeys := collectErasedKeysOfType(st.table, "NFTokenOffer", result == ter.TecEXPIRED, 256)
 
 	// Discard the transaction table — all doApply() side effects are lost.
 	// Reference: rippled Transactor.cpp — reset() discards the sandbox.
@@ -382,7 +383,7 @@ func (e *Engine) applyTecRecovery(st *applyState, result Result) Result {
 	// Consume ticket through tecTable for proper metadata (DeletedNode + directory changes)
 	// Reference: rippled Transactor.cpp — tec still consumes the ticket.
 	if st.isTicket {
-		if r := e.consumeTicketForRecovery(st, tecTable); r != TesSUCCESS {
+		if r := e.consumeTicketForRecovery(st, tecTable); r != ter.TesSUCCESS {
 			return r
 		}
 	}
@@ -401,15 +402,15 @@ func (e *Engine) applyTecRecovery(st *applyState, result Result) Result {
 	// Reference: rippled Transactor.cpp — restores original SLE on tec.
 	recoveredAccount, parseErr := state.ParseAccountRoot(st.originalAccountData)
 	if parseErr != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
-	if r := e.writeRecoveryAccount(st, tecTable, recoveredAccount); r != TesSUCCESS {
+	if r := e.writeRecoveryAccount(st, tecTable, recoveredAccount); r != ter.TesSUCCESS {
 		return r
 	}
 
 	// For delegated transactions, deduct the fee from the delegate's account on tec.
 	// Reference: rippled Transactor.cpp reset() lines 1011-1013, 1036
-	if r := e.payDelegatedFeeOnTable(st, tecTable); r != TesSUCCESS {
+	if r := e.payDelegatedFeeOnTable(st, tecTable); r != ter.TesSUCCESS {
 		return r
 	}
 
@@ -422,7 +423,7 @@ func (e *Engine) applyTecRecovery(st *applyState, result Result) Result {
 
 	// tecEXPIRED: re-delete expired NFTokenOffers and credentials.
 	// Reference: rippled Transactor.cpp lines 1203-1205: removeExpiredNFTokenOffers()
-	if result == TecEXPIRED {
+	if result == ter.TecEXPIRED {
 		// Re-delete NFTokenOffers through tecTable
 		for _, offerKey := range expiredNFTokenOfferKeys {
 			offerKL := keylet.Keylet{Key: offerKey}
@@ -464,7 +465,7 @@ func (e *Engine) applyTecRecovery(st *applyState, result Result) Result {
 	// Apply all tracked changes and generate proper metadata
 	generatedMeta, applyErr := tecTable.Apply()
 	if applyErr != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	st.metadata.AffectedNodes = generatedMeta.AffectedNodes
 
@@ -502,7 +503,7 @@ func collectErasedKeysOfType(table *ApplyStateTable, entryType string, enabled b
 // table. Differs from consumeTicket in that it does NOT mutate st.account or
 // write the account back — the recovery path rebuilds the account from
 // originalAccountData independently.
-func (e *Engine) consumeTicketForRecovery(st *applyState, tecTable *ApplyStateTable) Result {
+func (e *Engine) consumeTicketForRecovery(st *applyState, tecTable *ApplyStateTable) ter.Result {
 	return e.eraseTicketEntry(st, tecTable)
 }
 
@@ -510,7 +511,7 @@ func (e *Engine) consumeTicketForRecovery(st *applyState, tecTable *ApplyStateTa
 // it through the supplied table. It is the shared prologue for both
 // consumeTicket (success path) and consumeTicketForRecovery (tec/invariant
 // recovery path); the divergent account-mutation tail lives in the callers.
-func (e *Engine) eraseTicketEntry(st *applyState, table *ApplyStateTable) Result {
+func (e *Engine) eraseTicketEntry(st *applyState, table *ApplyStateTable) ter.Result {
 	ticketKey := keylet.Ticket(st.accountID, *st.common.TicketSequence)
 	ownerDirKey := keylet.OwnerDir(st.accountID)
 	// Read the ticket SLE to get its OwnerNode (directory page) for removal.
@@ -524,12 +525,12 @@ func (e *Engine) eraseTicketEntry(st *applyState, table *ApplyStateTable) Result
 	if res, err := state.DirRemove(table, ownerDirKey, ticketOwnerNode, ticketKey.Key, true); err != nil || !res.Success {
 		e.logger.Error("unable to delete Ticket from owner directory",
 			"ticketKey", fmt.Sprintf("%x", ticketKey.Key), "err", err)
-		return TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if err := table.Erase(ticketKey); err != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // removeDeletedTrustLines re-deletes the supplied AMM trust line keys through
@@ -611,7 +612,7 @@ func (e *Engine) removeUnfundedOffers(tecTable *ApplyStateTable, keys [][32]byte
 // mutations to the freshly-restored account and writes it through the recovery
 // table.
 // Reference: rippled Transactor.cpp reset() lines 998-1052.
-func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *ApplyStateTable, recoveredAccount *state.AccountRoot) Result {
+func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *ApplyStateTable, recoveredAccount *state.AccountRoot) ter.Result {
 	// For delegated transactions, fee is charged to the delegate, not the source.
 	// Reference: rippled Transactor.cpp reset() lines 1011-1013, 1036
 	if !st.isDelegated {
@@ -650,33 +651,33 @@ func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *ApplyStateTable,
 
 	updatedData, err := state.SerializeAccountRoot(recoveredAccount)
 	if err != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Update account through tecTable for proper metadata diff generation
 	if err := tecTable.Update(st.accountKey, updatedData); err != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // payDelegatedFeeOnTable deducts the fee from the delegate's account through
 // the supplied table. Used by both the tec-recovery and invariant-violation
 // recovery paths.
 // Reference: rippled Transactor.cpp reset() lines 1011-1013, 1036.
-func (e *Engine) payDelegatedFeeOnTable(st *applyState, table *ApplyStateTable) Result {
+func (e *Engine) payDelegatedFeeOnTable(st *applyState, table *ApplyStateTable) ter.Result {
 	if !st.isDelegated {
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	delegateID, _ := state.DecodeAccountID(st.common.Delegate)
 	delegateAccountKey := keylet.Account(delegateID)
 	delegateAccountData, delegateReadErr := e.view.Read(delegateAccountKey)
 	if delegateReadErr != nil || delegateAccountData == nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	delegateAccount, delegateParseErr := state.ParseAccountRoot(delegateAccountData)
 	if delegateParseErr != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	// On the recovery path the delegate is the fee payer, so the same reset()
 	// clamp applies: charge at most the delegate's balance, never underflow.
@@ -688,12 +689,12 @@ func (e *Engine) payDelegatedFeeOnTable(st *applyState, table *ApplyStateTable) 
 	delegateAccount.PreviousTxnLgrSeq = e.config.LedgerSequence
 	delegateData, delegateSerErr := state.SerializeAccountRoot(delegateAccount)
 	if delegateSerErr != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := table.Update(delegateAccountKey, delegateData); err != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // runInvariants checks invariants on the transaction's tracked entries. Returns
@@ -712,7 +713,7 @@ func (e *Engine) payDelegatedFeeOnTable(st *applyState, table *ApplyStateTable) 
 // return failInvariantCheck(result); }` — failInvariantCheck returns
 // tecINVARIANT_FAILED on the first pass (charges fee, retries on fee-only
 // state) and tefINVARIANT_FAILED on the second pass (no-op, no fee).
-func (e *Engine) runInvariants(st *applyState, result Result) (r Result, handled bool) {
+func (e *Engine) runInvariants(st *applyState, result ter.Result) (r ter.Result, handled bool) {
 	// Batch is checked per inner transaction, not on the combined outer delta.
 	// rippled runs each inner tx through its own apply() + checkInvariants on its
 	// own perTxBatchView (apply.cpp:189-207); the outer ttBATCH transactor's
@@ -724,7 +725,7 @@ func (e *Engine) runInvariants(st *applyState, result Result) (r Result, handled
 	// authoritative defense is CheckInnerInvariants, run per inner tx in the
 	// batch path.
 	if st.tx.TxType() == TypeBatch {
-		return Result(0), false
+		return ter.Result(0), false
 	}
 	return e.runInvariantsOnTable(st, result, st.table)
 }
@@ -736,7 +737,7 @@ func (e *Engine) runInvariants(st *applyState, result Result) (r Result, handled
 // whose finalize branches are result-aware. Returns (result, true) when a
 // violation has been handled (escalated via applyInvariantViolation) and
 // (zero, false) when the entries pass and the caller may commit `table`.
-func (e *Engine) runInvariantsOnTable(st *applyState, result Result, table *ApplyStateTable) (r Result, handled bool) {
+func (e *Engine) runInvariantsOnTable(st *applyState, result ter.Result, table *ApplyStateTable) (r ter.Result, handled bool) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			e.logger.Error("invariant check panic recovered, returning tecINVARIANT_FAILED",
@@ -758,7 +759,7 @@ func (e *Engine) runInvariantsOnTable(st *applyState, result Result, table *Appl
 		violation = e.invariantViolationHook(result, table)
 	}
 	if violation == nil {
-		return Result(0), false
+		return ter.Result(0), false
 	}
 	// Invariant violation: discard all doApply() side effects and apply only
 	// fee deduction + sequence increment, just like the tec recovery path.
@@ -789,18 +790,18 @@ func (e *Engine) runInvariantsOnTable(st *applyState, result Result, table *Appl
 //
 // A panic from CheckInvariants (e.g. AMM XRPLNumber overflow) is treated as a
 // violation, matching rippled's checkInvariantsHelper catch-all.
-func (e *Engine) CheckInnerInvariants(innerTx Transaction, result Result, innerTable LedgerView) (r Result) {
+func (e *Engine) CheckInnerInvariants(innerTx Transaction, result ter.Result, innerTable LedgerView) (r ter.Result) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			e.logger.Error("inner invariant check panic recovered, returning tecINVARIANT_FAILED",
 				"panic", rec)
-			r = TecINVARIANT_FAILED
+			r = ter.TecINVARIANT_FAILED
 		}
 	}()
 
 	table, ok := innerTable.(*ApplyStateTable)
 	if !ok {
-		return TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	declaredFee := parseTxDeclaredFee(innerTx, innerFeeNone)
@@ -815,10 +816,10 @@ func (e *Engine) CheckInnerInvariants(innerTx Transaction, result Result, innerT
 	// The inner tx carries no fee, so the reset state has an empty delta; a
 	// second violation there escalates to tefINVARIANT_FAILED.
 	feeOnly := NewApplyStateTable(e.view, [32]byte{}, e.config.LedgerSequence, rules)
-	if invariants.CheckInvariants(wrapped, invariants.Result(TecINVARIANT_FAILED), innerFeeNone, declaredFee, feeOnly.CollectEntries(), feeOnly, rules) != nil {
-		return TefINVARIANT_FAILED
+	if invariants.CheckInvariants(wrapped, invariants.Result(ter.TecINVARIANT_FAILED), innerFeeNone, declaredFee, feeOnly.CollectEntries(), feeOnly, rules) != nil {
+		return ter.TefINVARIANT_FAILED
 	}
-	return TecINVARIANT_FAILED
+	return ter.TecINVARIANT_FAILED
 }
 
 // innerFeeNone is the fee charged on a Batch inner transaction's delta. Inner
@@ -839,12 +840,12 @@ const innerFeeNone uint64 = 0
 // runInvariants (whose own defer has already fired) and crash the engine.
 //
 // Reference: rippled Transactor.cpp lines 1224-1238.
-func (e *Engine) applyInvariantViolation(st *applyState, txDeclaredFee uint64) (result Result) {
+func (e *Engine) applyInvariantViolation(st *applyState, txDeclaredFee uint64) (result ter.Result) {
 	defer func() {
 		if r := recover(); r != nil {
 			e.logger.Error("invariant recovery panic — escalating to tefINVARIANT_FAILED",
 				"txHash", fmt.Sprintf("%x", st.txHash), "panic", r)
-			result = TefINVARIANT_FAILED
+			result = ter.TefINVARIANT_FAILED
 		}
 	}()
 	// Don't call table.Apply() — discard all transaction effects.
@@ -853,7 +854,7 @@ func (e *Engine) applyInvariantViolation(st *applyState, txDeclaredFee uint64) (
 
 	// Consume ticket through invTecTable if needed.
 	if st.isTicket {
-		if r := e.consumeTicketForRecovery(st, invTecTable); r != TesSUCCESS {
+		if r := e.consumeTicketForRecovery(st, invTecTable); r != ter.TesSUCCESS {
 			return r
 		}
 	}
@@ -861,14 +862,14 @@ func (e *Engine) applyInvariantViolation(st *applyState, txDeclaredFee uint64) (
 	// Restore account to original state, then apply only fee/sequence.
 	invAccount, invErr := state.ParseAccountRoot(st.originalAccountData)
 	if invErr != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
-	if r := e.writeRecoveryAccount(st, invTecTable, invAccount); r != TesSUCCESS {
+	if r := e.writeRecoveryAccount(st, invTecTable, invAccount); r != ter.TesSUCCESS {
 		return r
 	}
 
 	// For delegated transactions, deduct the fee from the delegate.
-	if r := e.payDelegatedFeeOnTable(st, invTecTable); r != TesSUCCESS {
+	if r := e.payDelegatedFeeOnTable(st, invTecTable); r != ter.TesSUCCESS {
 		return r
 	}
 
@@ -879,19 +880,19 @@ func (e *Engine) applyInvariantViolation(st *applyState, txDeclaredFee uint64) (
 	invEntries2 := invTecTable.CollectEntries()
 	// Use the clamped charged fee here too — writeRecoveryAccount above may have
 	// reduced st.chargedFee to the payer's balance.
-	violation2 := invariants.CheckInvariants(wrapTxForInvariants(st.tx), invariants.Result(TecINVARIANT_FAILED), st.chargedFee, txDeclaredFee, invEntries2, invTecTable, e.rules())
+	violation2 := invariants.CheckInvariants(wrapTxForInvariants(st.tx), invariants.Result(ter.TecINVARIANT_FAILED), st.chargedFee, txDeclaredFee, invEntries2, invTecTable, e.rules())
 	if violation2 == nil && e.invariantViolationHook != nil {
-		violation2 = e.invariantViolationHook(TecINVARIANT_FAILED, invTecTable)
+		violation2 = e.invariantViolationHook(ter.TecINVARIANT_FAILED, invTecTable)
 	}
 	if violation2 != nil {
-		return TefINVARIANT_FAILED
+		return ter.TefINVARIANT_FAILED
 	}
 
 	generatedMeta, applyErr := invTecTable.Apply()
 	if applyErr != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	st.metadata.AffectedNodes = generatedMeta.AffectedNodes
 
-	return TecINVARIANT_FAILED
+	return ter.TecINVARIANT_FAILED
 }

--- a/internal/tx/do_apply_inner_invariants_test.go
+++ b/internal/tx/do_apply_inner_invariants_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -62,7 +63,7 @@ func TestCheckInnerInvariants_LegitimateCreatePasses(t *testing.T) {
 	}
 
 	innerTx := NewBaseTx(TypePayment, innerInvSender)
-	if got := e.CheckInnerInvariants(innerTx, TesSUCCESS, table); got != TesSUCCESS {
+	if got := e.CheckInnerInvariants(innerTx, ter.TesSUCCESS, table); got != ter.TesSUCCESS {
 		t.Fatalf("legitimate inner create: expected tesSUCCESS, got %s", got)
 	}
 }
@@ -90,11 +91,11 @@ func TestCheckInnerInvariants_XRPCreatedFails(t *testing.T) {
 	}
 
 	innerTx := NewBaseTx(TypePayment, innerInvSender)
-	got := e.CheckInnerInvariants(innerTx, TesSUCCESS, table)
-	if got == TesSUCCESS {
+	got := e.CheckInnerInvariants(innerTx, ter.TesSUCCESS, table)
+	if got == ter.TesSUCCESS {
 		t.Fatal("XRP-creating inner delta: expected invariant failure, got tesSUCCESS")
 	}
-	if got != TecINVARIANT_FAILED {
+	if got != ter.TecINVARIANT_FAILED {
 		t.Fatalf("XRP-creating inner delta: expected tecINVARIANT_FAILED, got %s", got)
 	}
 }
@@ -125,7 +126,7 @@ func TestCheckInnerInvariants_IllegalAccountCreatorFails(t *testing.T) {
 	}
 
 	innerTx := NewBaseTx(TypeAccountDelete, innerInvSender)
-	if got := e.CheckInnerInvariants(innerTx, TesSUCCESS, table); got != TecINVARIANT_FAILED {
+	if got := e.CheckInnerInvariants(innerTx, ter.TesSUCCESS, table); got != ter.TecINVARIANT_FAILED {
 		t.Fatalf("illegal inner account creator: expected tecINVARIANT_FAILED, got %s", got)
 	}
 }

--- a/internal/tx/engine.go
+++ b/internal/tx/engine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx/invariants"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
@@ -68,7 +69,7 @@ type Engine struct {
 	// invariantViolationHook, when non-nil, lets tests force an invariant
 	// violation for a given (result, table). Production always leaves it nil,
 	// so runInvariantsOnTable behaves exactly as the real checkers dictate.
-	invariantViolationHook func(result Result, table *ApplyStateTable) *invariants.InvariantViolation
+	invariantViolationHook func(result ter.Result, table *ApplyStateTable) *invariants.InvariantViolation
 }
 
 // ApplyFlags controls transaction application behavior during consensus.
@@ -285,7 +286,7 @@ type InvariantViolationValue = invariants.InvariantViolation
 // InvariantViolationHook is a test-only override that forces an invariant
 // violation for a given (result, table). It is consulted by the invariant pass
 // on both the tes and tec apply paths after the real checkers pass cleanly.
-type InvariantViolationHook = func(result Result, table *ApplyStateTable) *InvariantViolationValue
+type InvariantViolationHook = func(result ter.Result, table *ApplyStateTable) *InvariantViolationValue
 
 // SetInvariantViolationHookForTest installs a test-only hook that forces an
 // invariant violation, used to exercise the tec→tecINVARIANT_FAILED→
@@ -331,7 +332,7 @@ func (e *Engine) TxCount() uint32 {
 // validation) against the engine's rules and returns the TER. Used by
 // TxQ.Apply to reject structurally invalid submissions before they are
 // held in the queue, mirroring rippled's preflight at TxQ.cpp:743-745.
-func (e *Engine) Preflight(tx Transaction) Result {
+func (e *Engine) Preflight(tx Transaction) ter.Result {
 	return e.preflight(tx)
 }
 
@@ -339,7 +340,7 @@ func (e *Engine) Preflight(tx Transaction) Result {
 // and returns the TER. Used by TxQ's multiTxn path (TxQ.cpp:1167-1170)
 // which runs preclaim against a cloned view with adjusted AccountRoot
 // fields to detect terINSUF_FEE_B / terPRE_SEQ before queueing.
-func (e *Engine) Preclaim(tx Transaction, txHash [32]byte) Result {
+func (e *Engine) Preclaim(tx Transaction, txHash [32]byte) ter.Result {
 	return e.preclaim(tx, txHash)
 }
 

--- a/internal/tx/engine/apply.go
+++ b/internal/tx/engine/apply.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -286,7 +287,7 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx txcore.Transa
 	}
 
 	// Create ApplyStateTable to track changes
-	table := txcore.NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, rules)
+	table := applystate.NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, rules)
 
 	// Create a minimal ApplyContext for pseudo-transactions
 	ctx := &txcore.ApplyContext{
@@ -375,7 +376,7 @@ func (e *Engine) commitPreclaimTec(ctx context.Context, tx txcore.Transaction, t
 		ctx:                 ctx,
 	}
 
-	tecTable := txcore.NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, e.rules())
+	tecTable := applystate.NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, e.rules())
 
 	if st.isTicket {
 		if r := e.consumeTicketForRecovery(st, tecTable); r != ter.TesSUCCESS {

--- a/internal/tx/engine/apply.go
+++ b/internal/tx/engine/apply.go
@@ -1,4 +1,4 @@
-package tx
+package engine
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -17,16 +18,16 @@ import (
 // Reference: rippled passesLocalChecks() rejects pseudo-transactions submitted by users.
 //
 // Equivalent to ApplyWithContext(context.Background(), tx).
-func (e *Engine) Apply(tx Transaction) ApplyResult {
+func (e *Engine) Apply(tx txcore.Transaction) txcore.ApplyResult {
 	return e.ApplyWithContext(context.Background(), tx)
 }
 
-func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResult {
+func (e *Engine) ApplyWithContext(ctx context.Context, tx txcore.Transaction) txcore.ApplyResult {
 	// Reject pseudo-transactions — they cannot be submitted by users.
 	// Reference: rippled passesLocalChecks() in NetworkOPs.cpp
 	txType := tx.TxType()
 	if txType.IsPseudoTransaction() {
-		return ApplyResult{
+		return txcore.ApplyResult{
 			Result:  ter.TemINVALID,
 			Applied: false,
 			Message: "pseudo-transactions cannot be submitted",
@@ -48,7 +49,7 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 			"account", account,
 			"ter", result.String(),
 		)
-		return ApplyResult{
+		return txcore.ApplyResult{
 			Result:  result,
 			Applied: false,
 			Message: result.Message(),
@@ -56,9 +57,9 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 	}
 
 	// Step 2: Compute transaction hash (needed by preclaim for tefALREADY check)
-	txHash, err := computeTransactionHash(tx)
+	txHash, err := txcore.ComputeTransactionHash(tx)
 	if err != nil {
-		return ApplyResult{
+		return txcore.ApplyResult{
 			Result:  ter.TefINTERNAL,
 			Applied: false,
 			Message: fmt.Sprintf("failed to compute transaction hash: %v", err),
@@ -69,7 +70,7 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 	// (Transactor.cpp), the earliest point at which the id is known; the Go
 	// engine computes the id here, so the equivalent guard runs before preclaim.
 	if txHash == ([32]byte{}) {
-		return ApplyResult{
+		return txcore.ApplyResult{
 			Result:  ter.TemINVALID,
 			Applied: false,
 			Message: "transaction id may not be zero",
@@ -85,7 +86,7 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 			"txHash", hex.EncodeToString(txHash[:]),
 			"ter", result.String(),
 		)
-		return ApplyResult{
+		return txcore.ApplyResult{
 			Result:  result,
 			Applied: false,
 			Message: result.Message(),
@@ -100,8 +101,8 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 	// TapFAIL_HARD for a preclaim tec is handled at the commit branch below;
 	// the two flags are disjoint bits, so the order these gates run in is
 	// immaterial (at most one fires).
-	if result.IsTec() && (e.config.ApplyFlags&TapRETRY) != 0 {
-		return ApplyResult{
+	if result.IsTec() && (e.config.ApplyFlags&txcore.TapRETRY) != 0 {
+		return txcore.ApplyResult{
 			Result:  result,
 			Applied: false,
 			Message: result.Message(),
@@ -112,8 +113,8 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 	fee := e.calculateFee(tx)
 
 	// Step 5: Apply the transaction
-	metadata := &Metadata{
-		AffectedNodes:     make([]AffectedNode, 0),
+	metadata := &txcore.Metadata{
+		AffectedNodes:     make([]txcore.AffectedNode, 0),
 		TransactionResult: ter.TesSUCCESS,
 	}
 
@@ -127,8 +128,8 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 		// nothing — no fee charged, no sequence consumed, not applied. Reference:
 		// rippled Transactor.cpp:1114-1120 discards the context for any tec claim
 		// under tapFAIL_HARD before the reset()/commit logic runs.
-		if (e.config.ApplyFlags & TapFAIL_HARD) != 0 {
-			return ApplyResult{
+		if (e.config.ApplyFlags & txcore.TapFAIL_HARD) != 0 {
+			return txcore.ApplyResult{
 				Result:  result,
 				Applied: false,
 				Message: result.Message(),
@@ -147,7 +148,7 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 		// invariant-escalated code (tec/tefINVARIANT_FAILED) / tefINTERNAL when the
 		// fee-only delta fails its invariant pass or cannot be written.
 		if !committed.IsTec() {
-			return ApplyResult{
+			return txcore.ApplyResult{
 				Result:  committed,
 				Applied: false,
 				Message: committed.Message(),
@@ -167,14 +168,14 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 	// are NOT applied — they return Retry for the next pass.
 	// Reference: rippled Transactor.cpp operator() lines 1108-1216
 	applied := result.IsApplied()
-	if result.IsTec() && (e.config.ApplyFlags&TapFAIL_HARD) != 0 {
+	if result.IsTec() && (e.config.ApplyFlags&txcore.TapFAIL_HARD) != 0 {
 		// fail_hard: a tec from doApply was discarded (doApply returned fee 0
 		// without committing its recovery table), so it must not count as
 		// applied either. Reference: rippled Transactor.cpp:1114-1120 sets
 		// applied = false for any tec claim under tapFAIL_HARD.
 		applied = false
 	}
-	if result.IsTec() && (e.config.ApplyFlags&TapRETRY) != 0 && !isReapplyOnRetryTec(result) {
+	if result.IsTec() && (e.config.ApplyFlags&txcore.TapRETRY) != 0 && !isReapplyOnRetryTec(result) {
 		// Retry pass: a generic tec is NOT applied (no fee, no sequence) — it
 		// stays in the retry queue for a pass without TapRETRY. doApply already
 		// returned fee 0 without committing its recovery table for this case.
@@ -196,7 +197,7 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 		"fee", fee,
 	)
 
-	return ApplyResult{
+	return txcore.ApplyResult{
 		Result:   result,
 		Applied:  applied,
 		Fee:      fee,
@@ -211,11 +212,11 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx Transaction) ApplyResu
 // Reference: rippled Change.cpp — pseudo-txs are applied during consensus, not user submission.
 //
 // Equivalent to ApplyPseudoWithContext(context.Background(), tx).
-func (e *Engine) ApplyPseudo(tx Transaction) ApplyResult {
+func (e *Engine) ApplyPseudo(tx txcore.Transaction) txcore.ApplyResult {
 	return e.applyPseudoTransaction(context.Background(), tx)
 }
 
-func (e *Engine) ApplyPseudoWithContext(ctx context.Context, tx Transaction) ApplyResult {
+func (e *Engine) ApplyPseudoWithContext(ctx context.Context, tx txcore.Transaction) txcore.ApplyResult {
 	return e.applyPseudoTransaction(ctx, tx)
 }
 
@@ -226,7 +227,7 @@ func (e *Engine) ApplyPseudoWithContext(ctx context.Context, tx Transaction) App
 // - No signature
 // - No sequence number checks
 // Reference: rippled Change.cpp preflight/preclaim/doApply
-func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) ApplyResult {
+func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx txcore.Transaction) txcore.ApplyResult {
 	rules := e.rules()
 
 	// Preflight gates — mirror rippled Change::preflight (Change.cpp:36-80).
@@ -235,11 +236,11 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 	// computing the transaction hash so malformed inputs surface as a typed tem*
 	// result rather than a serialization-induced tefINTERNAL.
 	if gate := e.pseudoPreflight(tx, rules); !gate.IsSuccess() {
-		return ApplyResult{
+		return txcore.ApplyResult{
 			Result:   gate,
 			Applied:  false,
 			Fee:      0,
-			Metadata: &Metadata{TransactionResult: gate},
+			Metadata: &txcore.Metadata{TransactionResult: gate},
 			Message:  gate.Message(),
 		}
 	}
@@ -248,19 +249,19 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 	// Pseudo-transactions are only legal against a closed ledger; per-type field
 	// gating (e.g. XRPFees) runs through the PseudoPreclaim interface.
 	if gate := e.pseudoPreclaim(tx, rules); !gate.IsSuccess() {
-		return ApplyResult{
+		return txcore.ApplyResult{
 			Result:   gate,
 			Applied:  false,
 			Fee:      0,
-			Metadata: &Metadata{TransactionResult: gate},
+			Metadata: &txcore.Metadata{TransactionResult: gate},
 			Message:  gate.Message(),
 		}
 	}
 
 	// Compute transaction hash
-	txHash, err := computeTransactionHash(tx)
+	txHash, err := txcore.ComputeTransactionHash(tx)
 	if err != nil {
-		return ApplyResult{
+		return txcore.ApplyResult{
 			Result:  ter.TefINTERNAL,
 			Applied: false,
 			Message: fmt.Sprintf("failed to compute transaction hash: %v", err),
@@ -269,26 +270,26 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 
 	// A zero transaction id is never valid (rippled preflight0, Transactor.cpp).
 	if txHash == ([32]byte{}) {
-		return ApplyResult{
+		return txcore.ApplyResult{
 			Result:   ter.TemINVALID,
 			Applied:  false,
 			Fee:      0,
-			Metadata: &Metadata{TransactionResult: ter.TemINVALID},
+			Metadata: &txcore.Metadata{TransactionResult: ter.TemINVALID},
 			Message:  "transaction id may not be zero",
 		}
 	}
 
 	// Create metadata
-	metadata := &Metadata{
-		AffectedNodes:     make([]AffectedNode, 0),
+	metadata := &txcore.Metadata{
+		AffectedNodes:     make([]txcore.AffectedNode, 0),
 		TransactionResult: ter.TesSUCCESS,
 	}
 
 	// Create ApplyStateTable to track changes
-	table := NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, rules)
+	table := txcore.NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, rules)
 
 	// Create a minimal ApplyContext for pseudo-transactions
-	ctx := &ApplyContext{
+	ctx := &txcore.ApplyContext{
 		View:            table,
 		Account:         nil, // No account for pseudo-transactions
 		Config:          e.config,
@@ -301,7 +302,7 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 
 	// Apply the transaction
 	var result ter.Result
-	if appliable, ok := tx.(Appliable); ok {
+	if appliable, ok := tx.(txcore.Appliable); ok {
 		result = appliable.Apply(ctx)
 	} else {
 		result = ter.TesSUCCESS
@@ -313,7 +314,7 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 	if result.IsSuccess() {
 		generatedMeta, err := table.Apply()
 		if err != nil {
-			return ApplyResult{
+			return txcore.ApplyResult{
 				Result:   ter.TefINTERNAL,
 				Applied:  false,
 				Metadata: metadata,
@@ -328,7 +329,7 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 		metadata.TransactionIndex = e.txCount.Add(1) - 1
 	}
 
-	return ApplyResult{
+	return txcore.ApplyResult{
 		Result:   result,
 		Applied:  result.IsApplied(),
 		Fee:      0, // Pseudo-transactions have no fee
@@ -344,7 +345,7 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx Transaction) 
 // payDelegatedFeeOnTable) so the fee/seq commit semantics stay in lockstep.
 // Reference: rippled applySteps.cpp — likelyToClaimFee tec still enters
 // Transactor::operator() which calls reset(fee) before returning.
-func (e *Engine) commitPreclaimTec(ctx context.Context, tx Transaction, txHash [32]byte, fee uint64, origResult ter.Result, metadata *Metadata) (ter.Result, uint64) {
+func (e *Engine) commitPreclaimTec(ctx context.Context, tx txcore.Transaction, txHash [32]byte, fee uint64, origResult ter.Result, metadata *txcore.Metadata) (ter.Result, uint64) {
 	common := tx.GetCommon()
 	accountID, _ := state.DecodeAccountID(common.Account)
 	accountKey := keylet.Account(accountID)
@@ -374,7 +375,7 @@ func (e *Engine) commitPreclaimTec(ctx context.Context, tx Transaction, txHash [
 		ctx:                 ctx,
 	}
 
-	tecTable := NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, e.rules())
+	tecTable := txcore.NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, e.rules())
 
 	if st.isTicket {
 		if r := e.consumeTicketForRecovery(st, tecTable); r != ter.TesSUCCESS {

--- a/internal/tx/engine/block_processor.go
+++ b/internal/tx/engine/block_processor.go
@@ -1,4 +1,6 @@
-package tx
+package engine
+
+import txcore "github.com/LeJamon/go-xrpl/internal/tx"
 
 // BlockProcessor handles batch application of transactions to a ledger.
 // It wraps the Engine to provide higher-level functionality:
@@ -25,7 +27,7 @@ type BlockTxResult struct {
 	Hash [32]byte
 
 	// ApplyResult contains the engine's result
-	ApplyResult ApplyResult
+	ApplyResult txcore.ApplyResult
 
 	// TxWithMetaBlob is the combined VL-encoded tx + VL-encoded metadata
 	// This is what gets added to the transaction tree
@@ -48,14 +50,14 @@ func NewBlockProcessor(engine *Engine) *BlockProcessor {
 // - Calling the engine to apply the transaction
 // - Creating the tx+meta blob
 // The engine assigns TransactionIndex in metadata for applied transactions.
-func (bp *BlockProcessor) ApplyTransaction(transaction Transaction, txBlob []byte) (BlockTxResult, error) {
+func (bp *BlockProcessor) ApplyTransaction(transaction txcore.Transaction, txBlob []byte) (BlockTxResult, error) {
 	result := BlockTxResult{
 		Index:     bp.txIndex,
 		RawTxBlob: txBlob,
 	}
 
 	// Compute transaction hash
-	hash, err := computeTransactionHash(transaction)
+	hash, err := txcore.ComputeTransactionHash(transaction)
 	if err != nil {
 		return result, err
 	}
@@ -64,7 +66,7 @@ func (bp *BlockProcessor) ApplyTransaction(transaction Transaction, txBlob []byt
 	// Apply the transaction using the engine.
 	// Pseudo-transactions (Amendment, SetFee, UNLModify) use ApplyPseudo()
 	// since Apply() rejects them (matching rippled's passesLocalChecks).
-	var applyResult ApplyResult
+	var applyResult txcore.ApplyResult
 	if transaction.TxType().IsPseudoTransaction() {
 		applyResult = bp.engine.ApplyPseudo(transaction)
 	} else {
@@ -75,7 +77,7 @@ func (bp *BlockProcessor) ApplyTransaction(transaction Transaction, txBlob []byt
 	// Create the tx+meta blob for the transaction tree.
 	// The engine assigns TransactionIndex in metadata for applied transactions
 	// (matching rippled's txCount-based indexing), so we don't overwrite it here.
-	txWithMetaBlob, err := CreateTxWithMetaBlob(txBlob, applyResult.Metadata)
+	txWithMetaBlob, err := txcore.CreateTxWithMetaBlob(txBlob, applyResult.Metadata)
 	if err != nil {
 		return result, err
 	}
@@ -90,7 +92,7 @@ func (bp *BlockProcessor) ApplyTransaction(transaction Transaction, txBlob []byt
 // ParsedTx holds a parsed transaction along with its raw blob.
 type ParsedTx struct {
 	// Transaction is the parsed transaction
-	Transaction Transaction
+	Transaction txcore.Transaction
 
 	// RawBlob is the original binary blob
 	RawBlob []byte
@@ -99,7 +101,7 @@ type ParsedTx struct {
 // ParseAndPrepare parses a transaction blob and returns a ParsedTx ready for processing.
 // It also sets the raw bytes on the transaction for hash computation.
 func ParseAndPrepare(txBlob []byte) (*ParsedTx, error) {
-	transaction, err := ParseFromBinary(txBlob)
+	transaction, err := txcore.ParseFromBinary(txBlob)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tx/engine/checkfee_loadfeetrack_test.go
+++ b/internal/tx/engine/checkfee_loadfeetrack_test.go
@@ -1,18 +1,19 @@
-package tx
+package engine
 
 import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // newFeeTestTx builds a minimal AccountSet-typed transaction carrying the
 // given Fee (drops, decimal string). AccountSet has no custom base-fee
 // calculator, so preclaimBaseFee resolves to EngineConfig.BaseFee.
-func newFeeTestTx(fee string) Transaction {
-	t := NewBaseTx(TypeAccountSet, "rTestAccount")
+func newFeeTestTx(fee string) txcore.Transaction {
+	t := txcore.NewBaseTx(txcore.TypeAccountSet, "rTestAccount")
 	t.Fee = fee
 	return t
 }
@@ -44,7 +45,7 @@ func TestCheckFee_LoadFeeTrackScaling(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &Engine{config: EngineConfig{
+			e := &Engine{config: txcore.EngineConfig{
 				BaseFee:    baseFee,
 				OpenLedger: tt.openLedger,
 				FeeTrack:   tt.feeTrack,
@@ -72,7 +73,7 @@ func TestCheckFee_UnlimitedCarveOut(t *testing.T) {
 	tr.RaiseLocalFee() // second raise actually scales local up to 320
 
 	// Non-unlimited floor: 10*320/256 = 12 (truncated). fee=10 is short.
-	e := &Engine{config: EngineConfig{BaseFee: baseFee, OpenLedger: true, FeeTrack: tr}}
+	e := &Engine{config: txcore.EngineConfig{BaseFee: baseFee, OpenLedger: true, FeeTrack: tr}}
 	txn := newFeeTestTx("10")
 	if got := e.checkFee(txn, txn.GetCommon(), account); got != ter.TelINSUF_FEE_P {
 		t.Fatalf("checkFee(non-unlimited) = %v, want TelINSUF_FEE_P", got)
@@ -80,7 +81,7 @@ func TestCheckFee_UnlimitedCarveOut(t *testing.T) {
 
 	// Unlimited floor: carve-out drops feeFactor to remFee (256), so the
 	// floor is 10*256/256 = 10 and fee=10 now suffices.
-	eUnlimited := &Engine{config: EngineConfig{BaseFee: baseFee, OpenLedger: true, FeeTrack: tr, ApplyFlags: TapUNLIMITED}}
+	eUnlimited := &Engine{config: txcore.EngineConfig{BaseFee: baseFee, OpenLedger: true, FeeTrack: tr, ApplyFlags: txcore.TapUNLIMITED}}
 	if got := eUnlimited.checkFee(txn, txn.GetCommon(), account); got != ter.TesSUCCESS {
 		t.Fatalf("checkFee(unlimited) = %v, want TesSUCCESS", got)
 	}
@@ -113,7 +114,7 @@ func TestCheckFee_EnforceLoadFee(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &Engine{config: EngineConfig{
+			e := &Engine{config: txcore.EngineConfig{
 				BaseFee:        baseFee,
 				OpenLedger:     false,
 				EnforceLoadFee: tt.enforce,
@@ -148,7 +149,7 @@ func TestCheckFee_InsufficientBalance(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &Engine{config: EngineConfig{BaseFee: baseFee, OpenLedger: tt.openLedger}}
+			e := &Engine{config: txcore.EngineConfig{BaseFee: baseFee, OpenLedger: tt.openLedger}}
 			account := &state.AccountRoot{Balance: tt.balance}
 			// Fee of 100 drops exceeds both balances yet clears the open-ledger
 			// base-fee floor, so the balance branch is the one under test.

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -802,6 +802,11 @@ func (e *Engine) CheckInnerInvariants(innerTx txcore.Transaction, result ter.Res
 		}
 	}()
 
+	// innerTable is always the batch's *applystate.ApplyStateTable; the param is
+	// typed as the LedgerView interface only so the InnerInvariantChecker seam
+	// stays free of the applystate package. Recover the concrete table for
+	// CollectEntries. The !ok path cannot fire for any in-tree caller — it is
+	// defensive tecINTERNAL should that contract ever be violated.
 	table, ok := innerTable.(*applystate.ApplyStateTable)
 	if !ok {
 		return ter.TecINTERNAL

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -1,10 +1,12 @@
-package tx
+package engine
 
 import (
 	"context"
 	"fmt"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx/invariants"
@@ -17,8 +19,8 @@ import (
 // recovery paths, etc.). It mirrors what would be member fields on rippled's
 // Transactor instance during a single ::operator()() call.
 type applyState struct {
-	tx                  Transaction
-	common              *Common
+	tx                  txcore.Transaction
+	common              *txcore.Common
 	accountID           [20]byte
 	accountKey          keylet.Keylet
 	account             *state.AccountRoot
@@ -33,8 +35,8 @@ type applyState struct {
 	isDelegated bool
 	isTicket    bool
 	txHash      [32]byte
-	metadata    *Metadata
-	table       *ApplyStateTable
+	metadata    *txcore.Metadata
+	table       *txcore.ApplyStateTable
 	ctx         context.Context
 }
 
@@ -51,7 +53,7 @@ func (st *applyState) sourceFeeCharged() uint64 {
 // doApply applies the transaction to the ledger
 // For tec results, only fee/sequence changes are applied; transaction effects are discarded.
 // Reference: rippled Transactor.cpp - tec results claim fee but don't apply effects
-func (e *Engine) doApply(ctx context.Context, tx Transaction, metadata *Metadata, txHash [32]byte) (ter.Result, uint64) {
+func (e *Engine) doApply(ctx context.Context, tx txcore.Transaction, metadata *txcore.Metadata, txHash [32]byte) (ter.Result, uint64) {
 	common := tx.GetCommon()
 	accountID, _ := state.DecodeAccountID(common.Account)
 	accountKey := keylet.Account(accountID)
@@ -77,7 +79,7 @@ func (e *Engine) doApply(ctx context.Context, tx Transaction, metadata *Metadata
 	copy(originalAccountData, accountData)
 
 	// Create ApplyStateTable for transaction-specific changes
-	table := NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, e.rules())
+	table := txcore.NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, e.rules())
 
 	st := &applyState{
 		tx:                  tx,
@@ -160,7 +162,7 @@ func (e *Engine) doApply(ctx context.Context, tx Transaction, metadata *Metadata
 	//   if (isTecClaim(result) && (view().flags() & tapFAIL_HARD)) {
 	//       ctx_.discard(); applied = false; }
 	// This takes precedence over the retry handling and the hard-fail commit.
-	if result.IsTec() && (e.config.ApplyFlags&TapFAIL_HARD) != 0 {
+	if result.IsTec() && (e.config.ApplyFlags&txcore.TapFAIL_HARD) != 0 {
 		return result, 0
 	}
 
@@ -172,7 +174,7 @@ func (e *Engine) doApply(ctx context.Context, tx Transaction, metadata *Metadata
 	// the reapply branch; only the generic isTecClaimHardFail term is the one
 	// gated on !tapRETRY (applySteps.h:49-51). So those four fall through to
 	// applyTecRecovery here even under retry.
-	if result.IsTec() && (e.config.ApplyFlags&TapRETRY) != 0 && !isReapplyOnRetryTec(result) {
+	if result.IsTec() && (e.config.ApplyFlags&txcore.TapRETRY) != 0 && !isReapplyOnRetryTec(result) {
 		// Retry pass: discard all changes, don't commit fee/sequence.
 		// The transaction will be retried on the next pass without TapRETRY.
 		return result, 0
@@ -268,7 +270,7 @@ func (e *Engine) applyPreApplyAccountChanges(st *applyState) ter.Result {
 // tec/invariant paths).
 // Reference: rippled Transactor::consumeSeqProxy + Transactor::ticketDelete
 // in Transactor.cpp.
-func (e *Engine) consumeTicket(st *applyState, table *ApplyStateTable) ter.Result {
+func (e *Engine) consumeTicket(st *applyState, table *txcore.ApplyStateTable) ter.Result {
 	if r := e.eraseTicketEntry(st, table); r != ter.TesSUCCESS {
 		return r
 	}
@@ -330,7 +332,7 @@ func (e *Engine) invokeApplyInner(st *applyState) ter.Result {
 	}
 
 	// All transaction types implement Appliable
-	ctx := &ApplyContext{
+	ctx := &txcore.ApplyContext{
 		View:             st.table,
 		Account:          st.account,
 		AccountID:        st.accountID,
@@ -344,7 +346,7 @@ func (e *Engine) invokeApplyInner(st *applyState) ter.Result {
 		Ctx:              st.ctx,
 	}
 
-	if appliable, ok := st.tx.(Appliable); ok {
+	if appliable, ok := st.tx.(txcore.Appliable); ok {
 		return appliable.Apply(ctx)
 	}
 	return ter.TesSUCCESS
@@ -378,7 +380,7 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 	//
 	// Create a fresh ApplyStateTable to track tec-specific changes
 	// (fee, sequence, ticket consumption) for proper metadata generation.
-	tecTable := NewApplyStateTable(e.view, st.txHash, e.config.LedgerSequence, e.rules())
+	tecTable := txcore.NewApplyStateTable(e.view, st.txHash, e.config.LedgerSequence, e.rules())
 
 	// Consume ticket through tecTable for proper metadata (DeletedNode + directory changes)
 	// Reference: rippled Transactor.cpp — tec still consumes the ticket.
@@ -431,8 +433,8 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 		}
 
 		// Credential deletion via TecApplier
-		if tecApplier, ok := st.tx.(TecApplier); ok {
-			tecCtx := &ApplyContext{
+		if tecApplier, ok := st.tx.(txcore.TecApplier); ok {
+			tecCtx := &txcore.ApplyContext{
 				View:             tecTable,
 				Account:          recoveredAccount,
 				AccountID:        st.accountID,
@@ -476,13 +478,13 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 // keys whose entries are erased ledger entries of the given type. When
 // `enabled` is false, returns nil. Used by tec recovery to re-apply specific
 // deletions after the sandbox is discarded.
-func collectErasedKeysOfType(table *ApplyStateTable, entryType string, enabled bool, limit int) [][32]byte {
+func collectErasedKeysOfType(table *txcore.ApplyStateTable, entryType string, enabled bool, limit int) [][32]byte {
 	if !enabled {
 		return nil
 	}
 	var keys [][32]byte
 	for key, entry := range table.GetItems() {
-		if entry.Action != ActionErase {
+		if entry.Action != txcore.ActionErase {
 			continue
 		}
 		t := state.EntryType(entry.Original)
@@ -503,7 +505,7 @@ func collectErasedKeysOfType(table *ApplyStateTable, entryType string, enabled b
 // table. Differs from consumeTicket in that it does NOT mutate st.account or
 // write the account back — the recovery path rebuilds the account from
 // originalAccountData independently.
-func (e *Engine) consumeTicketForRecovery(st *applyState, tecTable *ApplyStateTable) ter.Result {
+func (e *Engine) consumeTicketForRecovery(st *applyState, tecTable *txcore.ApplyStateTable) ter.Result {
 	return e.eraseTicketEntry(st, tecTable)
 }
 
@@ -511,7 +513,7 @@ func (e *Engine) consumeTicketForRecovery(st *applyState, tecTable *ApplyStateTa
 // it through the supplied table. It is the shared prologue for both
 // consumeTicket (success path) and consumeTicketForRecovery (tec/invariant
 // recovery path); the divergent account-mutation tail lives in the callers.
-func (e *Engine) eraseTicketEntry(st *applyState, table *ApplyStateTable) ter.Result {
+func (e *Engine) eraseTicketEntry(st *applyState, table *txcore.ApplyStateTable) ter.Result {
 	ticketKey := keylet.Ticket(st.accountID, *st.common.TicketSequence)
 	ownerDirKey := keylet.OwnerDir(st.accountID)
 	// Read the ticket SLE to get its OwnerNode (directory page) for removal.
@@ -536,7 +538,7 @@ func (e *Engine) eraseTicketEntry(st *applyState, table *ApplyStateTable) ter.Re
 // removeDeletedTrustLines re-deletes the supplied AMM trust line keys through
 // the recovery table.
 // Reference: rippled View.cpp deleteAMMTrustLine + Transactor.cpp lines 1207-1209.
-func (e *Engine) removeDeletedTrustLines(tecTable *ApplyStateTable, keys [][32]byte, txHash [32]byte) {
+func (e *Engine) removeDeletedTrustLines(tecTable *txcore.ApplyStateTable, keys [][32]byte, txHash [32]byte) {
 	for _, lineKey := range keys {
 		lineKL := keylet.Keylet{Key: lineKey}
 		lineData, readErr := tecTable.Read(lineKL)
@@ -584,7 +586,7 @@ func (e *Engine) removeDeletedTrustLines(tecTable *ApplyStateTable, keys [][32]b
 // removeUnfundedOffers re-deletes the supplied offer keys through the recovery
 // table.
 // Reference: rippled Transactor.cpp lines 1198-1201: removeUnfundedOffers().
-func (e *Engine) removeUnfundedOffers(tecTable *ApplyStateTable, keys [][32]byte, txHash [32]byte) {
+func (e *Engine) removeUnfundedOffers(tecTable *txcore.ApplyStateTable, keys [][32]byte, txHash [32]byte) {
 	for _, offerKey := range keys {
 		offerKL := keylet.Keylet{Key: offerKey}
 		offerData, readErr := e.view.Read(offerKL)
@@ -612,7 +614,7 @@ func (e *Engine) removeUnfundedOffers(tecTable *ApplyStateTable, keys [][32]byte
 // mutations to the freshly-restored account and writes it through the recovery
 // table.
 // Reference: rippled Transactor.cpp reset() lines 998-1052.
-func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *ApplyStateTable, recoveredAccount *state.AccountRoot) ter.Result {
+func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *txcore.ApplyStateTable, recoveredAccount *state.AccountRoot) ter.Result {
 	// For delegated transactions, fee is charged to the delegate, not the source.
 	// Reference: rippled Transactor.cpp reset() lines 1011-1013, 1036
 	if !st.isDelegated {
@@ -665,7 +667,7 @@ func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *ApplyStateTable,
 // the supplied table. Used by both the tec-recovery and invariant-violation
 // recovery paths.
 // Reference: rippled Transactor.cpp reset() lines 1011-1013, 1036.
-func (e *Engine) payDelegatedFeeOnTable(st *applyState, table *ApplyStateTable) ter.Result {
+func (e *Engine) payDelegatedFeeOnTable(st *applyState, table *txcore.ApplyStateTable) ter.Result {
 	if !st.isDelegated {
 		return ter.TesSUCCESS
 	}
@@ -724,7 +726,7 @@ func (e *Engine) runInvariants(st *applyState, result ter.Result) (r ter.Result,
 	// accounts) — exactly the false positive issue #846 addresses. The
 	// authoritative defense is CheckInnerInvariants, run per inner tx in the
 	// batch path.
-	if st.tx.TxType() == TypeBatch {
+	if st.tx.TxType() == txcore.TypeBatch {
 		return ter.Result(0), false
 	}
 	return e.runInvariantsOnTable(st, result, st.table)
@@ -737,7 +739,7 @@ func (e *Engine) runInvariants(st *applyState, result ter.Result) (r ter.Result,
 // whose finalize branches are result-aware. Returns (result, true) when a
 // violation has been handled (escalated via applyInvariantViolation) and
 // (zero, false) when the entries pass and the caller may commit `table`.
-func (e *Engine) runInvariantsOnTable(st *applyState, result ter.Result, table *ApplyStateTable) (r ter.Result, handled bool) {
+func (e *Engine) runInvariantsOnTable(st *applyState, result ter.Result, table *txcore.ApplyStateTable) (r ter.Result, handled bool) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			e.logger.Error("invariant check panic recovered, returning tecINVARIANT_FAILED",
@@ -790,7 +792,7 @@ func (e *Engine) runInvariantsOnTable(st *applyState, result ter.Result, table *
 //
 // A panic from CheckInvariants (e.g. AMM XRPLNumber overflow) is treated as a
 // violation, matching rippled's checkInvariantsHelper catch-all.
-func (e *Engine) CheckInnerInvariants(innerTx Transaction, result ter.Result, innerTable LedgerView) (r ter.Result) {
+func (e *Engine) CheckInnerInvariants(innerTx txcore.Transaction, result ter.Result, innerTable txcore.LedgerView) (r ter.Result) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			e.logger.Error("inner invariant check panic recovered, returning tecINVARIANT_FAILED",
@@ -799,7 +801,7 @@ func (e *Engine) CheckInnerInvariants(innerTx Transaction, result ter.Result, in
 		}
 	}()
 
-	table, ok := innerTable.(*ApplyStateTable)
+	table, ok := innerTable.(*txcore.ApplyStateTable)
 	if !ok {
 		return ter.TecINTERNAL
 	}
@@ -815,7 +817,7 @@ func (e *Engine) CheckInnerInvariants(innerTx Transaction, result ter.Result, in
 	// First pass violated: rippled resets to a fee-only state and re-checks.
 	// The inner tx carries no fee, so the reset state has an empty delta; a
 	// second violation there escalates to tefINVARIANT_FAILED.
-	feeOnly := NewApplyStateTable(e.view, [32]byte{}, e.config.LedgerSequence, rules)
+	feeOnly := txcore.NewApplyStateTable(e.view, [32]byte{}, e.config.LedgerSequence, rules)
 	if invariants.CheckInvariants(wrapped, invariants.Result(ter.TecINVARIANT_FAILED), innerFeeNone, declaredFee, feeOnly.CollectEntries(), feeOnly, rules) != nil {
 		return ter.TefINVARIANT_FAILED
 	}
@@ -850,7 +852,7 @@ func (e *Engine) applyInvariantViolation(st *applyState, txDeclaredFee uint64) (
 	}()
 	// Don't call table.Apply() — discard all transaction effects.
 	// Create a fresh tecTable for fee-only changes.
-	invTecTable := NewApplyStateTable(e.view, st.txHash, e.config.LedgerSequence, e.rules())
+	invTecTable := txcore.NewApplyStateTable(e.view, st.txHash, e.config.LedgerSequence, e.rules())
 
 	// Consume ticket through invTecTable if needed.
 	if st.isTicket {

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -9,6 +9,7 @@ import (
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
 	"github.com/LeJamon/go-xrpl/internal/tx/invariants"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -36,7 +37,7 @@ type applyState struct {
 	isTicket    bool
 	txHash      [32]byte
 	metadata    *txcore.Metadata
-	table       *txcore.ApplyStateTable
+	table       *applystate.ApplyStateTable
 	ctx         context.Context
 }
 
@@ -79,7 +80,7 @@ func (e *Engine) doApply(ctx context.Context, tx txcore.Transaction, metadata *t
 	copy(originalAccountData, accountData)
 
 	// Create ApplyStateTable for transaction-specific changes
-	table := txcore.NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, e.rules())
+	table := applystate.NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, e.rules())
 
 	st := &applyState{
 		tx:                  tx,
@@ -270,7 +271,7 @@ func (e *Engine) applyPreApplyAccountChanges(st *applyState) ter.Result {
 // tec/invariant paths).
 // Reference: rippled Transactor::consumeSeqProxy + Transactor::ticketDelete
 // in Transactor.cpp.
-func (e *Engine) consumeTicket(st *applyState, table *txcore.ApplyStateTable) ter.Result {
+func (e *Engine) consumeTicket(st *applyState, table *applystate.ApplyStateTable) ter.Result {
 	if r := e.eraseTicketEntry(st, table); r != ter.TesSUCCESS {
 		return r
 	}
@@ -380,7 +381,7 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 	//
 	// Create a fresh ApplyStateTable to track tec-specific changes
 	// (fee, sequence, ticket consumption) for proper metadata generation.
-	tecTable := txcore.NewApplyStateTable(e.view, st.txHash, e.config.LedgerSequence, e.rules())
+	tecTable := applystate.NewApplyStateTable(e.view, st.txHash, e.config.LedgerSequence, e.rules())
 
 	// Consume ticket through tecTable for proper metadata (DeletedNode + directory changes)
 	// Reference: rippled Transactor.cpp — tec still consumes the ticket.
@@ -478,13 +479,13 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 // keys whose entries are erased ledger entries of the given type. When
 // `enabled` is false, returns nil. Used by tec recovery to re-apply specific
 // deletions after the sandbox is discarded.
-func collectErasedKeysOfType(table *txcore.ApplyStateTable, entryType string, enabled bool, limit int) [][32]byte {
+func collectErasedKeysOfType(table *applystate.ApplyStateTable, entryType string, enabled bool, limit int) [][32]byte {
 	if !enabled {
 		return nil
 	}
 	var keys [][32]byte
 	for key, entry := range table.GetItems() {
-		if entry.Action != txcore.ActionErase {
+		if entry.Action != applystate.ActionErase {
 			continue
 		}
 		t := state.EntryType(entry.Original)
@@ -505,7 +506,7 @@ func collectErasedKeysOfType(table *txcore.ApplyStateTable, entryType string, en
 // table. Differs from consumeTicket in that it does NOT mutate st.account or
 // write the account back — the recovery path rebuilds the account from
 // originalAccountData independently.
-func (e *Engine) consumeTicketForRecovery(st *applyState, tecTable *txcore.ApplyStateTable) ter.Result {
+func (e *Engine) consumeTicketForRecovery(st *applyState, tecTable *applystate.ApplyStateTable) ter.Result {
 	return e.eraseTicketEntry(st, tecTable)
 }
 
@@ -513,7 +514,7 @@ func (e *Engine) consumeTicketForRecovery(st *applyState, tecTable *txcore.Apply
 // it through the supplied table. It is the shared prologue for both
 // consumeTicket (success path) and consumeTicketForRecovery (tec/invariant
 // recovery path); the divergent account-mutation tail lives in the callers.
-func (e *Engine) eraseTicketEntry(st *applyState, table *txcore.ApplyStateTable) ter.Result {
+func (e *Engine) eraseTicketEntry(st *applyState, table *applystate.ApplyStateTable) ter.Result {
 	ticketKey := keylet.Ticket(st.accountID, *st.common.TicketSequence)
 	ownerDirKey := keylet.OwnerDir(st.accountID)
 	// Read the ticket SLE to get its OwnerNode (directory page) for removal.
@@ -538,7 +539,7 @@ func (e *Engine) eraseTicketEntry(st *applyState, table *txcore.ApplyStateTable)
 // removeDeletedTrustLines re-deletes the supplied AMM trust line keys through
 // the recovery table.
 // Reference: rippled View.cpp deleteAMMTrustLine + Transactor.cpp lines 1207-1209.
-func (e *Engine) removeDeletedTrustLines(tecTable *txcore.ApplyStateTable, keys [][32]byte, txHash [32]byte) {
+func (e *Engine) removeDeletedTrustLines(tecTable *applystate.ApplyStateTable, keys [][32]byte, txHash [32]byte) {
 	for _, lineKey := range keys {
 		lineKL := keylet.Keylet{Key: lineKey}
 		lineData, readErr := tecTable.Read(lineKL)
@@ -586,7 +587,7 @@ func (e *Engine) removeDeletedTrustLines(tecTable *txcore.ApplyStateTable, keys 
 // removeUnfundedOffers re-deletes the supplied offer keys through the recovery
 // table.
 // Reference: rippled Transactor.cpp lines 1198-1201: removeUnfundedOffers().
-func (e *Engine) removeUnfundedOffers(tecTable *txcore.ApplyStateTable, keys [][32]byte, txHash [32]byte) {
+func (e *Engine) removeUnfundedOffers(tecTable *applystate.ApplyStateTable, keys [][32]byte, txHash [32]byte) {
 	for _, offerKey := range keys {
 		offerKL := keylet.Keylet{Key: offerKey}
 		offerData, readErr := e.view.Read(offerKL)
@@ -614,7 +615,7 @@ func (e *Engine) removeUnfundedOffers(tecTable *txcore.ApplyStateTable, keys [][
 // mutations to the freshly-restored account and writes it through the recovery
 // table.
 // Reference: rippled Transactor.cpp reset() lines 998-1052.
-func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *txcore.ApplyStateTable, recoveredAccount *state.AccountRoot) ter.Result {
+func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *applystate.ApplyStateTable, recoveredAccount *state.AccountRoot) ter.Result {
 	// For delegated transactions, fee is charged to the delegate, not the source.
 	// Reference: rippled Transactor.cpp reset() lines 1011-1013, 1036
 	if !st.isDelegated {
@@ -667,7 +668,7 @@ func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *txcore.ApplyStat
 // the supplied table. Used by both the tec-recovery and invariant-violation
 // recovery paths.
 // Reference: rippled Transactor.cpp reset() lines 1011-1013, 1036.
-func (e *Engine) payDelegatedFeeOnTable(st *applyState, table *txcore.ApplyStateTable) ter.Result {
+func (e *Engine) payDelegatedFeeOnTable(st *applyState, table *applystate.ApplyStateTable) ter.Result {
 	if !st.isDelegated {
 		return ter.TesSUCCESS
 	}
@@ -739,7 +740,7 @@ func (e *Engine) runInvariants(st *applyState, result ter.Result) (r ter.Result,
 // whose finalize branches are result-aware. Returns (result, true) when a
 // violation has been handled (escalated via applyInvariantViolation) and
 // (zero, false) when the entries pass and the caller may commit `table`.
-func (e *Engine) runInvariantsOnTable(st *applyState, result ter.Result, table *txcore.ApplyStateTable) (r ter.Result, handled bool) {
+func (e *Engine) runInvariantsOnTable(st *applyState, result ter.Result, table *applystate.ApplyStateTable) (r ter.Result, handled bool) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			e.logger.Error("invariant check panic recovered, returning tecINVARIANT_FAILED",
@@ -801,7 +802,7 @@ func (e *Engine) CheckInnerInvariants(innerTx txcore.Transaction, result ter.Res
 		}
 	}()
 
-	table, ok := innerTable.(*txcore.ApplyStateTable)
+	table, ok := innerTable.(*applystate.ApplyStateTable)
 	if !ok {
 		return ter.TecINTERNAL
 	}
@@ -817,7 +818,7 @@ func (e *Engine) CheckInnerInvariants(innerTx txcore.Transaction, result ter.Res
 	// First pass violated: rippled resets to a fee-only state and re-checks.
 	// The inner tx carries no fee, so the reset state has an empty delta; a
 	// second violation there escalates to tefINVARIANT_FAILED.
-	feeOnly := txcore.NewApplyStateTable(e.view, [32]byte{}, e.config.LedgerSequence, rules)
+	feeOnly := applystate.NewApplyStateTable(e.view, [32]byte{}, e.config.LedgerSequence, rules)
 	if invariants.CheckInvariants(wrapped, invariants.Result(ter.TecINVARIANT_FAILED), innerFeeNone, declaredFee, feeOnly.CollectEntries(), feeOnly, rules) != nil {
 		return ter.TefINVARIANT_FAILED
 	}
@@ -852,7 +853,7 @@ func (e *Engine) applyInvariantViolation(st *applyState, txDeclaredFee uint64) (
 	}()
 	// Don't call table.Apply() — discard all transaction effects.
 	// Create a fresh tecTable for fee-only changes.
-	invTecTable := txcore.NewApplyStateTable(e.view, st.txHash, e.config.LedgerSequence, e.rules())
+	invTecTable := applystate.NewApplyStateTable(e.view, st.txHash, e.config.LedgerSequence, e.rules())
 
 	// Consume ticket through invTecTable if needed.
 	if st.isTicket {

--- a/internal/tx/engine/do_apply_inner_invariants_test.go
+++ b/internal/tx/engine/do_apply_inner_invariants_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -53,7 +54,7 @@ func TestCheckInnerInvariants_LegitimateCreatePasses(t *testing.T) {
 	base.data[senderKey.Key] = mustAccount(t, innerInvSender, 10_000, 1)
 
 	e := innerInvariantEngine(base)
-	table := txcore.NewApplyStateTable(base, [32]byte{}, 100, e.rules())
+	table := applystate.NewApplyStateTable(base, [32]byte{}, 100, e.rules())
 
 	// Inner Payment of 1_000 drops: debit sender, create recipient with 1_000.
 	if err := table.Update(senderKey, mustAccount(t, innerInvSender, 9_000, 2)); err != nil {
@@ -83,7 +84,7 @@ func TestCheckInnerInvariants_XRPCreatedFails(t *testing.T) {
 	base.data[senderKey.Key] = mustAccount(t, innerInvSender, 10_000, 1)
 
 	e := innerInvariantEngine(base)
-	table := txcore.NewApplyStateTable(base, [32]byte{}, 100, e.rules())
+	table := applystate.NewApplyStateTable(base, [32]byte{}, 100, e.rules())
 
 	// Create the recipient with 1_000 drops but DO NOT debit the sender — this
 	// is +1_000 drops of XRP from nothing.
@@ -115,7 +116,7 @@ func TestCheckInnerInvariants_IllegalAccountCreatorFails(t *testing.T) {
 	base.data[senderKey.Key] = mustAccount(t, innerInvSender, 10_000, 1)
 
 	e := innerInvariantEngine(base)
-	table := txcore.NewApplyStateTable(base, [32]byte{}, 100, e.rules())
+	table := applystate.NewApplyStateTable(base, [32]byte{}, 100, e.rules())
 
 	// A net-zero XRP delta (sender debited, recipient created) but under an
 	// AccountDelete inner type, which may NOT create an account root.

--- a/internal/tx/engine/do_apply_inner_invariants_test.go
+++ b/internal/tx/engine/do_apply_inner_invariants_test.go
@@ -1,10 +1,11 @@
-package tx
+package engine
 
 import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -12,7 +13,7 @@ import (
 // innerInvariantEngine builds a minimal engine over a mock base view for
 // exercising CheckInnerInvariants in isolation.
 func innerInvariantEngine(base *mockBaseView) *Engine {
-	return NewEngine(base, EngineConfig{
+	return NewEngine(base, txcore.EngineConfig{
 		LedgerSequence: 100,
 		Rules:          amendment.AllSupportedRules(),
 	})
@@ -52,7 +53,7 @@ func TestCheckInnerInvariants_LegitimateCreatePasses(t *testing.T) {
 	base.data[senderKey.Key] = mustAccount(t, innerInvSender, 10_000, 1)
 
 	e := innerInvariantEngine(base)
-	table := NewApplyStateTable(base, [32]byte{}, 100, e.rules())
+	table := txcore.NewApplyStateTable(base, [32]byte{}, 100, e.rules())
 
 	// Inner Payment of 1_000 drops: debit sender, create recipient with 1_000.
 	if err := table.Update(senderKey, mustAccount(t, innerInvSender, 9_000, 2)); err != nil {
@@ -62,7 +63,7 @@ func TestCheckInnerInvariants_LegitimateCreatePasses(t *testing.T) {
 		t.Fatalf("insert recipient: %v", err)
 	}
 
-	innerTx := NewBaseTx(TypePayment, innerInvSender)
+	innerTx := txcore.NewBaseTx(txcore.TypePayment, innerInvSender)
 	if got := e.CheckInnerInvariants(innerTx, ter.TesSUCCESS, table); got != ter.TesSUCCESS {
 		t.Fatalf("legitimate inner create: expected tesSUCCESS, got %s", got)
 	}
@@ -82,7 +83,7 @@ func TestCheckInnerInvariants_XRPCreatedFails(t *testing.T) {
 	base.data[senderKey.Key] = mustAccount(t, innerInvSender, 10_000, 1)
 
 	e := innerInvariantEngine(base)
-	table := NewApplyStateTable(base, [32]byte{}, 100, e.rules())
+	table := txcore.NewApplyStateTable(base, [32]byte{}, 100, e.rules())
 
 	// Create the recipient with 1_000 drops but DO NOT debit the sender — this
 	// is +1_000 drops of XRP from nothing.
@@ -90,7 +91,7 @@ func TestCheckInnerInvariants_XRPCreatedFails(t *testing.T) {
 		t.Fatalf("insert recipient: %v", err)
 	}
 
-	innerTx := NewBaseTx(TypePayment, innerInvSender)
+	innerTx := txcore.NewBaseTx(txcore.TypePayment, innerInvSender)
 	got := e.CheckInnerInvariants(innerTx, ter.TesSUCCESS, table)
 	if got == ter.TesSUCCESS {
 		t.Fatal("XRP-creating inner delta: expected invariant failure, got tesSUCCESS")
@@ -114,7 +115,7 @@ func TestCheckInnerInvariants_IllegalAccountCreatorFails(t *testing.T) {
 	base.data[senderKey.Key] = mustAccount(t, innerInvSender, 10_000, 1)
 
 	e := innerInvariantEngine(base)
-	table := NewApplyStateTable(base, [32]byte{}, 100, e.rules())
+	table := txcore.NewApplyStateTable(base, [32]byte{}, 100, e.rules())
 
 	// A net-zero XRP delta (sender debited, recipient created) but under an
 	// AccountDelete inner type, which may NOT create an account root.
@@ -125,7 +126,7 @@ func TestCheckInnerInvariants_IllegalAccountCreatorFails(t *testing.T) {
 		t.Fatalf("insert recipient: %v", err)
 	}
 
-	innerTx := NewBaseTx(TypeAccountDelete, innerInvSender)
+	innerTx := txcore.NewBaseTx(txcore.TypeAccountDelete, innerInvSender)
 	if got := e.CheckInnerInvariants(innerTx, ter.TesSUCCESS, table); got != ter.TecINVARIANT_FAILED {
 		t.Fatalf("illegal inner account creator: expected tecINVARIANT_FAILED, got %s", got)
 	}

--- a/internal/tx/engine/engine.go
+++ b/internal/tx/engine/engine.go
@@ -1,0 +1,182 @@
+package engine
+
+import (
+	"sync/atomic"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/invariants"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+)
+
+// Engine processes transactions against a ledger.
+//
+// Engine instances are NOT safe for concurrent Apply/ApplyPseudo calls. A
+// single Engine is meant to drive a single open ledger's transaction stream
+// in order (matching rippled's OpenView, which is also single-writer). The
+// only field that may be touched off-thread is txCount (read via TxCount,
+// reset via SetBaseTxCount), which is atomic to make those accessors safe
+// for observers — it is not a license to call Apply concurrently.
+type Engine struct {
+	// View provides access to ledger state
+	view txcore.LedgerView
+
+	// Config holds engine configuration
+	config txcore.EngineConfig
+
+	// logger is the scoped logger for the Tx partition.
+	// Always non-nil; falls back to xrpllog.Discard() when not configured.
+	logger xrpllog.Logger
+
+	// txCount tracks the number of applied transactions for TransactionIndex.
+	// Each applied transaction (tesSUCCESS or tec) gets the current count as
+	// its TransactionIndex, then the counter increments.
+	// Reference: rippled OpenView::txCount() = baseTxCount_ + txs_.size()
+	txCount atomic.Uint32
+
+	// invariantViolationHook, when non-nil, lets tests force an invariant
+	// violation for a given (result, table). Production always leaves it nil,
+	// so runInvariantsOnTable behaves exactly as the real checkers dictate.
+	invariantViolationHook func(result ter.Result, table *txcore.ApplyStateTable) *invariants.InvariantViolation
+}
+
+// rulesView wraps a LedgerView so Rules() reports a known rule set. The engine's
+// base view (e.g. a Ledger) returns nil from Rules(), but rippled's preclaim view
+// always carries the parent ledger's rules. Wrapping the view for the Preclaimer
+// dispatch keeps rules-gated reads (e.g. accountFunds' frozen-LP-token check)
+// working at the preclaim stage, matching the rules visible during apply.
+type rulesView struct {
+	txcore.LedgerView
+	rules *amendment.Rules
+}
+
+func (v rulesView) Rules() *amendment.Rules { return v.rules }
+
+// NewEngine creates a new transaction engine
+func NewEngine(view txcore.LedgerView, config txcore.EngineConfig) *Engine {
+	logger := config.Logger
+	if logger == nil {
+		logger = xrpllog.Discard()
+	}
+	return &Engine{
+		view:   view,
+		config: config,
+		logger: logger.Named(xrpllog.PartitionTx),
+	}
+}
+
+// InvariantViolationValue describes a detected invariant violation. Exported so
+// test hooks can construct one without importing the invariants package.
+type InvariantViolationValue = invariants.InvariantViolation
+
+// InvariantViolationHook is a test-only override that forces an invariant
+// violation for a given (result, table). It is consulted by the invariant pass
+// on both the tes and tec apply paths after the real checkers pass cleanly.
+type InvariantViolationHook = func(result ter.Result, table *txcore.ApplyStateTable) *InvariantViolationValue
+
+// SetInvariantViolationHookForTest installs a test-only hook that forces an
+// invariant violation, used to exercise the tec→tecINVARIANT_FAILED→
+// tefINVARIANT_FAILED escalation without crafting a state that trips a real
+// checker. Production never calls this, so the hook stays nil and the real
+// checkers alone decide.
+func (e *Engine) SetInvariantViolationHookForTest(hook InvariantViolationHook) {
+	e.invariantViolationHook = hook
+}
+
+// NewInvariantViolation builds an invariant violation value for tests that drive
+// SetInvariantViolationHookForTest, without exposing the invariants package to
+// test callers.
+func NewInvariantViolation(name, message string) *invariants.InvariantViolation {
+	return &invariants.InvariantViolation{Name: name, Message: message}
+}
+
+// rules returns the amendment rules for this engine. EngineConfig.Rules
+// MUST be set by the caller — typically from the parent ledger's
+// Amendments SLE via ledger.LoadAmendmentsFromLedger (production) or
+// amendment.AllSupportedRules / EmptyRules (tests / genesis).
+//
+// Mirrors rippled's `Rules() = delete` (include/xrpl/protocol/Rules.h:57)
+// where there is no default constructor — every Rules instance is
+// explicitly built from a ledger via makeRulesGivenLedger. A silent
+// fallback (whether AllSupportedRules or EmptyRules) desyncs the engine
+// from on-chain state: AllSupportedRules treats every amendment as
+// enabled even when not on the ledger (the #401/#418 wedge); EmptyRules
+// treats everything as disabled even when amendments ARE on the ledger
+// (which broke the soak in the opposite direction). Panicking forces
+// every call site to plumb the real rules.
+func (e *Engine) rules() *amendment.Rules {
+	return e.config.GetRules()
+}
+
+// TxCount returns the current transaction count (for batch baseTxCount).
+// Reference: rippled OpenView::txCount()
+func (e *Engine) TxCount() uint32 {
+	return e.txCount.Load()
+}
+
+// Preflight runs the preflight pipeline (syntax, signature, tx-type
+// validation) against the engine's rules and returns the TER. Used by
+// TxQ.Apply to reject structurally invalid submissions before they are
+// held in the queue, mirroring rippled's preflight at TxQ.cpp:743-745.
+func (e *Engine) Preflight(tx txcore.Transaction) ter.Result {
+	return e.preflight(tx)
+}
+
+// Preclaim runs the full preclaim pipeline against the engine's view
+// and returns the TER. Used by TxQ's multiTxn path (TxQ.cpp:1167-1170)
+// which runs preclaim against a cloned view with adjusted AccountRoot
+// fields to detect terINSUF_FEE_B / terPRE_SEQ before queueing.
+func (e *Engine) Preclaim(tx txcore.Transaction, txHash [32]byte) ter.Result {
+	return e.preclaim(tx, txHash)
+}
+
+// SetBaseTxCount sets the base transaction count for batch inner transactions.
+// Inner transactions start numbering from this value.
+// Reference: rippled OpenView::baseTxCount_ initialized from parent view
+func (e *Engine) SetBaseTxCount(count uint32) {
+	e.txCount.Store(count)
+}
+
+// adjustOwnerCountOnView modifies an account's OwnerCount on a LedgerView.
+// Used by the engine for tecOVERSIZE offer cleanup after the sandbox is discarded.
+// Reference: rippled removeUnfundedOffers() adjusts owner count on the base view.
+func adjustOwnerCountOnView(view txcore.LedgerView, account [20]byte, delta int, txHash [32]byte, ledgerSeq uint32) {
+	_ = txcore.AdjustOwnerCountWithTx(view, account, delta, txHash, ledgerSeq)
+}
+
+// deleteNFTokenOfferOnView deletes an NFTokenOffer from the ledger view,
+// removing it from owner directory, NFTBuys/NFTSells directory, and erasing the SLE.
+// Used for tecEXPIRED re-deletion of expired NFToken offers.
+// Reference: rippled NFTokenUtils.cpp deleteTokenOffer
+func deleteNFTokenOfferOnView(view txcore.LedgerView, offerKL keylet.Keylet, txHash [32]byte, ledgerSeq uint32) {
+	offerData, err := view.Read(offerKL)
+	if err != nil || offerData == nil {
+		return
+	}
+
+	offer, err := state.ParseNFTokenOffer(offerData)
+	if err != nil {
+		return
+	}
+
+	ownerDirKey := keylet.OwnerDir(offer.Owner)
+	state.DirRemove(view, ownerDirKey, offer.OwnerNode, offerKL.Key, false)
+
+	// Remove from NFTBuys or NFTSells directory
+	isSellOffer := offer.Flags&entry.LsfSellNFToken != 0
+	var tokenDirKey keylet.Keylet
+	if isSellOffer {
+		tokenDirKey = keylet.NFTSells(offer.NFTokenID)
+	} else {
+		tokenDirKey = keylet.NFTBuys(offer.NFTokenID)
+	}
+	state.DirRemove(view, tokenDirKey, offer.NFTokenOfferNode, offerKL.Key, false)
+
+	_ = view.Erase(offerKL)
+	adjustOwnerCountOnView(view, offer.Owner, -1, txHash, ledgerSeq)
+}

--- a/internal/tx/engine/engine.go
+++ b/internal/tx/engine/engine.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
 	"github.com/LeJamon/go-xrpl/internal/tx/invariants"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -42,7 +43,7 @@ type Engine struct {
 	// invariantViolationHook, when non-nil, lets tests force an invariant
 	// violation for a given (result, table). Production always leaves it nil,
 	// so runInvariantsOnTable behaves exactly as the real checkers dictate.
-	invariantViolationHook func(result ter.Result, table *txcore.ApplyStateTable) *invariants.InvariantViolation
+	invariantViolationHook func(result ter.Result, table *applystate.ApplyStateTable) *invariants.InvariantViolation
 }
 
 // rulesView wraps a LedgerView so Rules() reports a known rule set. The engine's
@@ -77,7 +78,7 @@ type InvariantViolationValue = invariants.InvariantViolation
 // InvariantViolationHook is a test-only override that forces an invariant
 // violation for a given (result, table). It is consulted by the invariant pass
 // on both the tes and tec apply paths after the real checkers pass cleanly.
-type InvariantViolationHook = func(result ter.Result, table *txcore.ApplyStateTable) *InvariantViolationValue
+type InvariantViolationHook = func(result ter.Result, table *applystate.ApplyStateTable) *InvariantViolationValue
 
 // SetInvariantViolationHookForTest installs a test-only hook that forces an
 // invariant violation, used to exercise the tec→tecINVARIANT_FAILED→

--- a/internal/tx/engine/engine_recovery_886_test.go
+++ b/internal/tx/engine/engine_recovery_886_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -279,7 +280,7 @@ func TestApply_PreclaimTec_InvariantViolation(t *testing.T) {
 	// violation yields tefINVARIANT_FAILED. Firing once exercises the
 	// tec→fee-only-claim escalation that the preclaim-tec commit must now run.
 	firstPass := true
-	e.SetInvariantViolationHookForTest(func(result ter.Result, table *txcore.ApplyStateTable) *InvariantViolationValue {
+	e.SetInvariantViolationHookForTest(func(result ter.Result, table *applystate.ApplyStateTable) *InvariantViolationValue {
 		if firstPass {
 			firstPass = false
 			return NewInvariantViolation("forced", "forced violation for test")

--- a/internal/tx/engine/engine_recovery_886_test.go
+++ b/internal/tx/engine/engine_recovery_886_test.go
@@ -1,4 +1,4 @@
-package tx
+package engine
 
 import (
 	"strconv"
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -34,8 +35,8 @@ func (r *recordingBaseView) AdjustDropsDestroyed(d drops.XRPAmount) {
 // recoveryEngine builds an engine over the supplied view configured for a
 // closed-ledger apply (OpenLedger=false) with signature verification skipped, so
 // a single-signed BaseTx reaches preclaim/commit without real crypto.
-func recoveryEngine(view LedgerView, flags ApplyFlags) *Engine {
-	return NewEngine(view, EngineConfig{
+func recoveryEngine(view txcore.LedgerView, flags txcore.ApplyFlags) *Engine {
+	return NewEngine(view, txcore.EngineConfig{
 		BaseFee:                   10,
 		LedgerSequence:            100,
 		Rules:                     amendment.AllSupportedRules(),
@@ -68,7 +69,7 @@ func fundRecoveryAccount(t *testing.T, view interface {
 	return k
 }
 
-func readRecoveryAccount(t *testing.T, view LedgerView, k keylet.Keylet) *state.AccountRoot {
+func readRecoveryAccount(t *testing.T, view txcore.LedgerView, k keylet.Keylet) *state.AccountRoot {
 	t.Helper()
 	data, err := view.Read(k)
 	if err != nil || data == nil {
@@ -84,8 +85,8 @@ func readRecoveryAccount(t *testing.T, view LedgerView, k keylet.Keylet) *state.
 // recoveryTx builds a closed-ledger-applicable single-signed AccountSet-shaped
 // BaseTx with an explicit fee and sequence. AccountSet is a no-op when it has no
 // fields, so it never reaches a per-type Apply that would itself fail.
-func recoveryTx(fee, seq uint32) *BaseTx {
-	tx := NewBaseTx(TypeAccountSet, recoveryTestAccount)
+func recoveryTx(fee, seq uint32) *txcore.BaseTx {
+	tx := txcore.NewBaseTx(txcore.TypeAccountSet, recoveryTestAccount)
 	tx.Common.Fee = strconv.FormatUint(uint64(fee), 10)
 	s := seq
 	tx.Common.Sequence = &s
@@ -104,7 +105,7 @@ func TestApply_TecInsuffFee_ClampsToBalance(t *testing.T) {
 	// ledger → checkFee returns tecINSUFF_FEE.
 	acctKey := fundRecoveryAccount(t, view, 5, 1)
 
-	e := recoveryEngine(view, TapNONE)
+	e := recoveryEngine(view, txcore.TapNONE)
 	res := e.Apply(recoveryTx(10, 1))
 
 	if res.Result != ter.TecINSUFF_FEE {
@@ -138,7 +139,7 @@ func TestApply_FailHard_TecNotApplied(t *testing.T) {
 	view := newRecordingBaseView()
 	acctKey := fundRecoveryAccount(t, view, 5, 1)
 
-	e := recoveryEngine(view, TapFAIL_HARD)
+	e := recoveryEngine(view, txcore.TapFAIL_HARD)
 	res := e.Apply(recoveryTx(10, 1))
 
 	if res.Result != ter.TecINSUFF_FEE {
@@ -163,11 +164,11 @@ func TestApply_FailHard_TecNotApplied(t *testing.T) {
 // code, used to drive the doApply tec branch (as opposed to the preclaim-tec
 // branch) for a specific code.
 type codeTecTx struct {
-	*BaseTx
+	*txcore.BaseTx
 	code ter.Result
 }
 
-func (t codeTecTx) Apply(*ApplyContext) ter.Result { return t.code }
+func (t codeTecTx) Apply(*txcore.ApplyContext) ter.Result { return t.code }
 
 // TestApply_FailHard_DoApplyTecNotApplied covers the second half of Item 2: a tec
 // that surfaces from doApply (not preclaim) must also be discarded under
@@ -177,7 +178,7 @@ func TestApply_FailHard_DoApplyTecNotApplied(t *testing.T) {
 	// Ample balance so preclaim passes and doApply runs to return its tec.
 	acctKey := fundRecoveryAccount(t, view, 1_000_000, 1)
 
-	e := recoveryEngine(view, TapFAIL_HARD)
+	e := recoveryEngine(view, txcore.TapFAIL_HARD)
 	txn := codeTecTx{BaseTx: recoveryTx(10, 1), code: ter.TecUNFUNDED_PAYMENT}
 	res := e.Apply(txn)
 
@@ -207,7 +208,7 @@ func TestApply_Retry_GenericTecNotApplied(t *testing.T) {
 	view := newRecordingBaseView()
 	acctKey := fundRecoveryAccount(t, view, 1_000_000, 1)
 
-	e := recoveryEngine(view, TapRETRY)
+	e := recoveryEngine(view, txcore.TapRETRY)
 	res := e.Apply(codeTecTx{BaseTx: recoveryTx(10, 1), code: ter.TecUNFUNDED_PAYMENT})
 
 	if res.Result != ter.TecUNFUNDED_PAYMENT {
@@ -235,7 +236,7 @@ func TestApply_Retry_WorkOnTecReapplied(t *testing.T) {
 	view := newRecordingBaseView()
 	acctKey := fundRecoveryAccount(t, view, 1_000_000, 1)
 
-	e := recoveryEngine(view, TapRETRY)
+	e := recoveryEngine(view, txcore.TapRETRY)
 	res := e.Apply(codeTecTx{BaseTx: recoveryTx(10, 1), code: ter.TecKILLED})
 
 	if res.Result != ter.TecKILLED {
@@ -271,14 +272,14 @@ func TestApply_PreclaimTec_InvariantViolation(t *testing.T) {
 	// a closed ledger to reach the preclaim-tec commit path.
 	fundRecoveryAccount(t, view, 5, 1)
 
-	e := recoveryEngine(view, TapNONE)
+	e := recoveryEngine(view, txcore.TapNONE)
 	// Force an invariant violation on the FIRST pass only. rippled's two-pass
 	// escalation (Transactor.cpp:1224-1238) resets to a fee-only state and
 	// re-checks: a clean second pass yields tecINVARIANT_FAILED, a second
 	// violation yields tefINVARIANT_FAILED. Firing once exercises the
 	// tec→fee-only-claim escalation that the preclaim-tec commit must now run.
 	firstPass := true
-	e.SetInvariantViolationHookForTest(func(result ter.Result, table *ApplyStateTable) *InvariantViolationValue {
+	e.SetInvariantViolationHookForTest(func(result ter.Result, table *txcore.ApplyStateTable) *InvariantViolationValue {
 		if firstPass {
 			firstPass = false
 			return NewInvariantViolation("forced", "forced violation for test")
@@ -302,7 +303,7 @@ func TestPreflight_InvalidSigningPubKey(t *testing.T) {
 
 	// SkipSignatureVerification=true is the standalone-RPC ingress mode that
 	// bypasses crypto verification; the key-type rejection must still fire.
-	e := recoveryEngine(view, TapNONE)
+	e := recoveryEngine(view, txcore.TapNONE)
 
 	tx := recoveryTx(10, 1)
 	// 0x99-prefixed 33-byte blob: a valid-length hex payload that is NOT a valid

--- a/internal/tx/engine/engine_reserve.go
+++ b/internal/tx/engine/engine_reserve.go
@@ -1,0 +1,31 @@
+package engine
+
+import "github.com/LeJamon/go-xrpl/internal/tx/ter"
+
+// The reserve calculations live on EngineConfig as the single source of truth.
+// Engine exposes the same helpers as thin delegations so callers on either side
+// share one implementation.
+
+// AccountReserve calculates the total reserve required for an account with the
+// given owner count.
+func (e *Engine) AccountReserve(ownerCount uint32) uint64 {
+	return e.config.AccountReserve(ownerCount)
+}
+
+// ReserveForNewObject calculates the reserve required for creating a new ledger
+// object (the first 2 objects are free).
+func (e *Engine) ReserveForNewObject(currentOwnerCount uint32) uint64 {
+	return e.config.ReserveForNewObject(currentOwnerCount)
+}
+
+// CanCreateNewObject reports whether the prior balance covers the reserve for a
+// new ledger object.
+func (e *Engine) CanCreateNewObject(priorBalance uint64, currentOwnerCount uint32) bool {
+	return e.config.CanCreateNewObject(priorBalance, currentOwnerCount)
+}
+
+// CheckReserveIncrease validates that an account can afford the reserve increase
+// for a new ledger object. Returns TecINSUFFICIENT_RESERVE if not enough funds.
+func (e *Engine) CheckReserveIncrease(priorBalance uint64, currentOwnerCount uint32) ter.Result {
+	return e.config.CheckReserveIncrease(priorBalance, currentOwnerCount)
+}

--- a/internal/tx/engine/fee.go
+++ b/internal/tx/engine/fee.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 )
 
 // calculateFee calculates the fee for a transaction
@@ -18,9 +19,9 @@ func (e *Engine) calculateFee(tx txcore.Transaction) uint64 {
 	}
 	// If no fee specified, use base fee (adjusted for multi-sig if applicable)
 	baseFee := e.config.BaseFee
-	if txcore.IsMultiSigned(tx) {
+	if sign.IsMultiSigned(tx) {
 		numSigners := len(common.Signers)
-		return txcore.CalculateMultiSigFee(baseFee, numSigners)
+		return sign.CalculateMultiSigFee(baseFee, numSigners)
 	}
 	return baseFee
 }

--- a/internal/tx/engine/fee.go
+++ b/internal/tx/engine/fee.go
@@ -1,10 +1,14 @@
-package tx
+package engine
 
-import "strconv"
+import (
+	"strconv"
+
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+)
 
 // calculateFee calculates the fee for a transaction
 // For multi-signed transactions, the minimum required fee is baseFee * (1 + numSigners)
-func (e *Engine) calculateFee(tx Transaction) uint64 {
+func (e *Engine) calculateFee(tx txcore.Transaction) uint64 {
 	common := tx.GetCommon()
 	if common.Fee != "" {
 		fee, err := strconv.ParseUint(common.Fee, 10, 64)
@@ -14,9 +18,9 @@ func (e *Engine) calculateFee(tx Transaction) uint64 {
 	}
 	// If no fee specified, use base fee (adjusted for multi-sig if applicable)
 	baseFee := e.config.BaseFee
-	if IsMultiSigned(tx) {
+	if txcore.IsMultiSigned(tx) {
 		numSigners := len(common.Signers)
-		return CalculateMultiSigFee(baseFee, numSigners)
+		return txcore.CalculateMultiSigFee(baseFee, numSigners)
 	}
 	return baseFee
 }
@@ -26,7 +30,7 @@ func (e *Engine) calculateFee(tx Transaction) uint64 {
 // If the transaction doesn't explicitly set a Fee field (e.g., the test env
 // auto-computes it), fallback is returned instead.
 // Reference: rippled InvariantCheck.cpp TransactionFeeCheck — tx.getFieldAmount(sfFee).xrp()
-func parseTxDeclaredFee(tx Transaction, fallback uint64) uint64 {
+func parseTxDeclaredFee(tx txcore.Transaction, fallback uint64) uint64 {
 	common := tx.GetCommon()
 	if common.Fee != "" {
 		if fee, err := strconv.ParseUint(common.Fee, 10, 64); err == nil {

--- a/internal/tx/engine/invariants_adapter.go
+++ b/internal/tx/engine/invariants_adapter.go
@@ -1,6 +1,7 @@
-package tx
+package engine
 
 import (
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/invariants"
 )
 
@@ -11,7 +12,7 @@ import (
 // Optional interfaces are implemented by delegating to the underlying transaction
 // and converting types where needed (e.g., tx.Asset -> invariants.Asset).
 type invariantsTxAdapter struct {
-	tx Transaction
+	tx txcore.Transaction
 }
 
 // --- invariants.Transaction interface ---
@@ -39,7 +40,7 @@ func (a *invariantsTxAdapter) Flatten() (map[string]any, error) {
 // interface; for others, the invariant check gates on TxType first.
 func (a *invariantsTxAdapter) ClawbackAmount() invariants.Amount {
 	type provider interface {
-		ClawbackAmount() Amount
+		ClawbackAmount() txcore.Amount
 	}
 	if p, ok := a.tx.(provider); ok {
 		return p.ClawbackAmount()
@@ -72,7 +73,7 @@ func (a *invariantsTxAdapter) GetDomainID() (*[32]byte, bool) {
 // GetAMMAsset implements invariants.AMMAssetProvider by converting tx.Asset to invariants.Asset.
 func (a *invariantsTxAdapter) GetAMMAsset() invariants.Asset {
 	type provider interface {
-		GetAMMAsset() Asset
+		GetAMMAsset() txcore.Asset
 	}
 	if p, ok := a.tx.(provider); ok {
 		asset := p.GetAMMAsset()
@@ -84,7 +85,7 @@ func (a *invariantsTxAdapter) GetAMMAsset() invariants.Asset {
 // GetAMMAsset2 implements invariants.AMMAssetProvider by converting tx.Asset to invariants.Asset.
 func (a *invariantsTxAdapter) GetAMMAsset2() invariants.Asset {
 	type provider interface {
-		GetAMMAsset2() Asset
+		GetAMMAsset2() txcore.Asset
 	}
 	if p, ok := a.tx.(provider); ok {
 		asset := p.GetAMMAsset2()
@@ -96,7 +97,7 @@ func (a *invariantsTxAdapter) GetAMMAsset2() invariants.Asset {
 // GetAmountAsset implements invariants.AMMCreateIssueProvider by converting tx.Asset to invariants.Asset.
 func (a *invariantsTxAdapter) GetAmountAsset() invariants.Asset {
 	type provider interface {
-		GetAmountAsset() Asset
+		GetAmountAsset() txcore.Asset
 	}
 	if p, ok := a.tx.(provider); ok {
 		asset := p.GetAmountAsset()
@@ -108,7 +109,7 @@ func (a *invariantsTxAdapter) GetAmountAsset() invariants.Asset {
 // GetAmount2Asset implements invariants.AMMCreateIssueProvider by converting tx.Asset to invariants.Asset.
 func (a *invariantsTxAdapter) GetAmount2Asset() invariants.Asset {
 	type provider interface {
-		GetAmount2Asset() Asset
+		GetAmount2Asset() txcore.Asset
 	}
 	if p, ok := a.tx.(provider); ok {
 		asset := p.GetAmount2Asset()
@@ -120,6 +121,6 @@ func (a *invariantsTxAdapter) GetAmount2Asset() invariants.Asset {
 // wrapTxForInvariants wraps a tx.Transaction as an invariants.Transaction.
 // The adapter implements all optional invariant interfaces by delegating to
 // the underlying transaction and converting types where needed.
-func wrapTxForInvariants(tx Transaction) invariants.Transaction {
+func wrapTxForInvariants(tx txcore.Transaction) invariants.Transaction {
 	return &invariantsTxAdapter{tx: tx}
 }

--- a/internal/tx/engine/mock_view_test.go
+++ b/internal/tx/engine/mock_view_test.go
@@ -1,0 +1,76 @@
+package engine
+
+import (
+	"bytes"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// mockBaseView implements tx.LedgerView for engine tests.
+type mockBaseView struct {
+	data map[[32]byte][]byte
+}
+
+func newMockBaseView() *mockBaseView {
+	return &mockBaseView{data: make(map[[32]byte][]byte)}
+}
+
+func (m *mockBaseView) Read(k keylet.Keylet) ([]byte, error) {
+	return m.data[k.Key], nil
+}
+
+func (m *mockBaseView) Exists(k keylet.Keylet) (bool, error) {
+	_, ok := m.data[k.Key]
+	return ok, nil
+}
+
+func (m *mockBaseView) Insert(k keylet.Keylet, data []byte) error {
+	m.data[k.Key] = data
+	return nil
+}
+
+func (m *mockBaseView) Update(k keylet.Keylet, data []byte) error {
+	m.data[k.Key] = data
+	return nil
+}
+
+func (m *mockBaseView) Erase(k keylet.Keylet) error {
+	delete(m.data, k.Key)
+	return nil
+}
+
+func (m *mockBaseView) AdjustDropsDestroyed(drops.XRPAmount) {}
+
+func (m *mockBaseView) TxExists([32]byte) bool { return false }
+
+func (m *mockBaseView) Rules() *amendment.Rules { return nil }
+
+func (m *mockBaseView) LedgerSeq() uint32 { return 0 }
+
+func (m *mockBaseView) ForEach(fn func(key [32]byte, data []byte) bool) error {
+	for k, v := range m.data {
+		if !fn(k, v) {
+			break
+		}
+	}
+	return nil
+}
+
+func (m *mockBaseView) Succ(key [32]byte) ([32]byte, []byte, bool, error) {
+	var best [32]byte
+	found := false
+	for k := range m.data {
+		if bytes.Compare(k[:], key[:]) > 0 {
+			if !found || bytes.Compare(k[:], best[:]) < 0 {
+				best = k
+				found = true
+			}
+		}
+	}
+	if found {
+		return best, m.data[best], true, nil
+	}
+	return [32]byte{}, nil, false, nil
+}

--- a/internal/tx/engine/preclaim.go
+++ b/internal/tx/engine/preclaim.go
@@ -1,9 +1,11 @@
-package tx
+package engine
 
 import (
 	"encoding/hex"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -16,7 +18,7 @@ import (
 //
 //	checkSeqProxy → checkPriorTxAndLastLedger → checkFee → checkPermission →
 //	checkSign (+ checkBatchSign) → tx-type preclaim.
-func (e *Engine) preclaim(tx Transaction, txHash [32]byte) ter.Result {
+func (e *Engine) preclaim(tx txcore.Transaction, txHash [32]byte) ter.Result {
 	common := tx.GetCommon()
 
 	// Resolve and parse the source account; this is shared by all subsequent steps.
@@ -46,7 +48,7 @@ func (e *Engine) preclaim(tx Transaction, txHash [32]byte) ter.Result {
 	// This checks that each BatchSigner is authorized to act as their account.
 	// This runs even when SkipSignatureVerification is true because it checks
 	// authorization (account existence, master key, regular key), not crypto.
-	if bsp, ok := tx.(BatchSignerProvider); ok {
+	if bsp, ok := tx.(txcore.BatchSignerProvider); ok {
 		if result := e.checkBatchSign(bsp.GetBatchSigners()); result != ter.TesSUCCESS {
 			return result
 		}
@@ -59,7 +61,7 @@ func (e *Engine) preclaim(tx Transaction, txHash [32]byte) ter.Result {
 	// PreclaimResult semantics.
 	// Reference: rippled applySteps.h — invoke_preclaim dispatches to
 	// the transaction type's static preclaim() method.
-	if preclaimer, ok := tx.(Preclaimer); ok {
+	if preclaimer, ok := tx.(txcore.Preclaimer); ok {
 		// Wrap the base view so Rules() reports the engine's rules: the base
 		// ledger returns nil, which would silently disable rules-gated reads
 		// (e.g. accountFunds' frozen-LP-token check) during preclaim.
@@ -74,13 +76,13 @@ func (e *Engine) preclaim(tx Transaction, txHash [32]byte) ter.Result {
 
 // preclaimLoadAccount decodes the source account and reads + parses its SLE.
 // Returns the decoded accountID, the parsed AccountRoot, and a TER result.
-func (e *Engine) preclaimLoadAccount(common *Common) ([20]byte, *state.AccountRoot, ter.Result) {
+func (e *Engine) preclaimLoadAccount(common *txcore.Common) ([20]byte, *state.AccountRoot, ter.Result) {
 	accountID, err := state.DecodeAccountID(common.Account)
 	if err != nil {
 		return [20]byte{}, nil, ter.TemBAD_SRC_ACCOUNT
 	}
 
-	account, err := ReadAccountRoot(e.view, accountID)
+	account, err := txcore.ReadAccountRoot(e.view, accountID)
 	if err != nil {
 		return accountID, nil, ter.TefINTERNAL
 	}
@@ -92,7 +94,7 @@ func (e *Engine) preclaimLoadAccount(common *Common) ([20]byte, *state.AccountRo
 
 // checkSeqProxy validates Sequence/TicketSequence against the account state.
 // Reference: rippled Transactor::checkSeqProxy in Transactor.cpp.
-func (e *Engine) checkSeqProxy(common *Common, accountID [20]byte, account *state.AccountRoot) ter.Result {
+func (e *Engine) checkSeqProxy(common *txcore.Common, accountID [20]byte, account *state.AccountRoot) ter.Result {
 	// Check for both Sequence (non-zero) and TicketSequence set → temSEQ_AND_TICKET
 	// Reference: rippled Transactor::checkSeqProxy in Transactor.cpp line 375
 	if common.Sequence != nil && *common.Sequence != 0 && common.TicketSequence != nil {
@@ -127,7 +129,7 @@ func (e *Engine) checkSeqProxy(common *Common, accountID [20]byte, account *stat
 // checkPriorTxAndLastLedger validates AccountTxnID, LastLedgerSequence, and
 // dedupes by transaction hash.
 // Reference: rippled Transactor::checkPriorTxAndLastLedger in Transactor.cpp.
-func (e *Engine) checkPriorTxAndLastLedger(common *Common, account *state.AccountRoot, txHash [32]byte) ter.Result {
+func (e *Engine) checkPriorTxAndLastLedger(common *txcore.Common, account *state.AccountRoot, txHash [32]byte) ter.Result {
 	// AccountTxnID check — if the transaction specifies an AccountTxnID, it must match
 	// the account's stored AccountTxnID (the hash of the last tx this account submitted).
 	if common.AccountTxnID != "" {
@@ -160,7 +162,7 @@ func (e *Engine) checkPriorTxAndLastLedger(common *Common, account *state.Accoun
 
 // checkFee enforces fee adequacy and that the fee payer (delegate or source)
 // can afford the fee. Reference: rippled Transactor::checkFee in Transactor.cpp.
-func (e *Engine) checkFee(tx Transaction, common *Common, account *state.AccountRoot) ter.Result {
+func (e *Engine) checkFee(tx txcore.Transaction, common *txcore.Common, account *state.AccountRoot) ter.Result {
 	// When a delegate is present, the fee is checked against the delegate's balance.
 	fee := e.calculateFee(tx)
 	baseFeeForTx := e.preclaimBaseFee(tx, common, account)
@@ -193,7 +195,7 @@ func (e *Engine) checkFee(tx Transaction, common *Common, account *state.Account
 		return ter.TesSUCCESS
 	}
 
-	if feeCalc, ok := tx.(BatchFeeCalculator); ok {
+	if feeCalc, ok := tx.(txcore.BatchFeeCalculator); ok {
 		batchMinFee := feeCalc.CalculateMinimumFee(e.config.BaseFee)
 		if fee < batchMinFee {
 			return ter.TelINSUF_FEE_P
@@ -228,7 +230,7 @@ func (e *Engine) checkFee(tx Transaction, common *Common, account *state.Account
 // insufficient-fee code. Reference: rippled Transactor::checkFee
 // Transactor.cpp:278-290.
 func (e *Engine) enforceFeeFloor(fee, baseFeeForTx uint64) ter.Result {
-	unlimited := e.config.ApplyFlags&TapUNLIMITED != 0
+	unlimited := e.config.ApplyFlags&txcore.TapUNLIMITED != 0
 	feeDue, scaleErr := feetrack.ScaleFeeLoad(baseFeeForTx, e.config.FeeTrack, unlimited)
 	if scaleErr != nil {
 		return ter.TelINSUF_FEE_P
@@ -243,21 +245,21 @@ func (e *Engine) enforceFeeFloor(fee, baseFeeForTx uint64) ter.Result {
 // applying multi-sign multipliers, custom calculators, and the SetRegularKey
 // free-password-change special case.
 // Reference: rippled applySteps.cpp calculateBaseFee() + SetRegularKey.cpp.
-func (e *Engine) preclaimBaseFee(tx Transaction, common *Common, account *state.AccountRoot) uint64 {
+func (e *Engine) preclaimBaseFee(tx txcore.Transaction, common *txcore.Common, account *state.AccountRoot) uint64 {
 	var baseFeeForTx uint64
-	if feeCalc, ok := tx.(CustomBaseFeeCalculator); ok {
+	if feeCalc, ok := tx.(txcore.CustomBaseFeeCalculator); ok {
 		baseFeeForTx = feeCalc.CalculateBaseFee(e.view, e.config)
 	} else {
 		baseFeeForTx = e.config.BaseFee
-		if IsMultiSigned(tx) {
-			baseFeeForTx = CalculateMultiSigFee(e.config.BaseFee, len(common.Signers))
+		if txcore.IsMultiSigned(tx) {
+			baseFeeForTx = txcore.CalculateMultiSigFee(e.config.BaseFee, len(common.Signers))
 		}
 	}
 	// SetRegularKey free password change: the base fee is waived when signed
 	// with the master key while lsfPasswordSpent is clear. The same predicate
 	// gates the lsfPasswordSpent flag in doApply, so the fee and the flag can
 	// never disagree. Reference: rippled SetRegularKey.cpp calculateBaseFee.
-	if tx.TxType() == TypeRegularKeySet && SetRegularKeyFeeWaived(e.config.SkipSignatureVerification, common, account) {
+	if tx.TxType() == txcore.TypeRegularKeySet && txcore.SetRegularKeyFeeWaived(e.config.SkipSignatureVerification, common, account) {
 		baseFeeForTx = 0
 	}
 	return baseFeeForTx
@@ -265,7 +267,7 @@ func (e *Engine) preclaimBaseFee(tx Transaction, common *Common, account *state.
 
 // feePayerBalance returns the balance of the account that will be charged the fee
 // (delegate when sfDelegate is present, otherwise the source account).
-func (e *Engine) feePayerBalance(common *Common, account *state.AccountRoot) (uint64, ter.Result) {
+func (e *Engine) feePayerBalance(common *txcore.Common, account *state.AccountRoot) (uint64, ter.Result) {
 	if common.Delegate == "" {
 		return account.Balance, ter.TesSUCCESS
 	}
@@ -273,7 +275,7 @@ func (e *Engine) feePayerBalance(common *Common, account *state.AccountRoot) (ui
 	if delegateErr != nil {
 		return 0, ter.TerNO_ACCOUNT
 	}
-	delegateAccount, readErr := ReadAccountRoot(e.view, delegateID)
+	delegateAccount, readErr := txcore.ReadAccountRoot(e.view, delegateID)
 	if readErr != nil {
 		// Real storage or parse failure, not a missing account.
 		return 0, ter.TefINTERNAL
@@ -288,7 +290,7 @@ func (e *Engine) feePayerBalance(common *Common, account *state.AccountRoot) (ui
 // grants permission for this transaction type.
 // Reference: rippled Transactor::checkPermission in Transactor.cpp lines 213-227
 // and DelegateUtils.cpp checkTxPermission().
-func (e *Engine) checkPermission(tx Transaction, common *Common, accountID [20]byte) ter.Result {
+func (e *Engine) checkPermission(tx txcore.Transaction, common *txcore.Common, accountID [20]byte) ter.Result {
 	if common.Delegate == "" {
 		return ter.TesSUCCESS
 	}
@@ -318,8 +320,8 @@ func (e *Engine) checkPermission(tx Transaction, common *Common, accountID [20]b
 // delegate. Reference: rippled line 602:
 //
 //	auto const idAccount = ctx.tx[~sfDelegate].value_or(ctx.tx[sfAccount]);
-func (e *Engine) checkSign(tx Transaction, common *Common) ter.Result {
-	if IsMultiSigned(tx) {
+func (e *Engine) checkSign(tx txcore.Transaction, common *txcore.Common) ter.Result {
+	if txcore.IsMultiSigned(tx) {
 		return e.checkMultiSign(common)
 	}
 	if common.SigningPubKey != "" {
@@ -331,7 +333,7 @@ func (e *Engine) checkSign(tx Transaction, common *Common) ter.Result {
 // checkMultiSign verifies the multi-sign signers against the idAccount's
 // SignerList and quorum.
 // Reference: rippled Transactor::checkMultiSign in Transactor.cpp lines 743-911.
-func (e *Engine) checkMultiSign(common *Common) ter.Result {
+func (e *Engine) checkMultiSign(common *txcore.Common) ter.Result {
 	// Multi-signed transaction: always check signer authorization and quorum.
 	// This runs regardless of SkipSignatureVerification because quorum and
 	// signer authorization (master key disabled, regular key, phantom accounts)
@@ -345,9 +347,9 @@ func (e *Engine) checkMultiSign(common *Common) ter.Result {
 		return ter.TefBAD_SIGNATURE
 	}
 	// Convert tx Signers to SignerInfo for checkBatchMultiSign
-	txSigners := make([]SignerInfo, len(common.Signers))
+	txSigners := make([]txcore.SignerInfo, len(common.Signers))
 	for i, sw := range common.Signers {
-		txSigners[i] = SignerInfo{
+		txSigners[i] = txcore.SignerInfo{
 			Account:       sw.Signer.Account,
 			SigningPubKey: sw.Signer.SigningPubKey,
 		}
@@ -358,7 +360,7 @@ func (e *Engine) checkMultiSign(common *Common) ter.Result {
 // checkSingleSign validates a single-signed transaction's signing key against
 // the idAccount's master/regular key configuration.
 // Reference: rippled Transactor::checkSingleSign in Transactor.cpp lines 682-740.
-func (e *Engine) checkSingleSign(common *Common) ter.Result {
+func (e *Engine) checkSingleSign(common *txcore.Common) ter.Result {
 	// Single-signed transaction: check signing key authorization.
 	// This runs regardless of SkipSignatureVerification because authorization
 	// (master key disabled, regular key) is a ledger-state check, not a
@@ -440,7 +442,7 @@ func (e *Engine) checkSingleSign(common *Common) ter.Result {
 // For single-sign signers (SigningPubKey non-empty): derives account from pubkey, checks authorization.
 // For multi-sign signers (SigningPubKey empty): checks signer list exists and quorum is met.
 // Reference: rippled Transactor::checkBatchSign in Transactor.cpp lines 635-679
-func (e *Engine) checkBatchSign(signers []BatchSignerInfo) ter.Result {
+func (e *Engine) checkBatchSign(signers []txcore.BatchSignerInfo) ter.Result {
 	for _, signer := range signers {
 		signerAccountID, err := state.DecodeAccountID(signer.Account)
 		if err != nil {
@@ -507,7 +509,7 @@ func (e *Engine) checkBatchSign(signers []BatchSignerInfo) ter.Result {
 // checkBatchMultiSign verifies a multi-sign batch signer's nested Signers against
 // the account's SignerList. This mirrors rippled's checkMultiSign.
 // Reference: rippled Transactor::checkMultiSign in Transactor.cpp lines 742-911
-func (e *Engine) checkBatchMultiSign(accountID [20]byte, txSigners []SignerInfo) ter.Result {
+func (e *Engine) checkBatchMultiSign(accountID [20]byte, txSigners []txcore.SignerInfo) ter.Result {
 	signerListKey := keylet.SignerList(accountID)
 	signerListData, err := e.view.Read(signerListKey)
 	if err != nil || signerListData == nil {
@@ -564,20 +566,16 @@ func (e *Engine) checkBatchMultiSign(accountID [20]byte, txSigners []SignerInfo)
 			return ter.TefINTERNAL
 		}
 
-		var acct signerAccountState
+		var acct txcore.SignerAccountState
 		if signerAccountData != nil {
 			signerAccountRoot, parseErr := state.ParseAccountRoot(signerAccountData)
 			if parseErr != nil {
 				return ter.TefINTERNAL
 			}
-			acct = signerAccountState{
-				found:      true,
-				flags:      signerAccountRoot.Flags,
-				regularKey: signerAccountRoot.RegularKey,
-			}
+			acct = txcore.NewSignerAccountState(true, signerAccountRoot.Flags, signerAccountRoot.RegularKey)
 		}
 
-		if r := authorizeMultiSigner(txSigner.Account, signingAcctIDFromPubKey, acct); r != ter.TesSUCCESS {
+		if r := txcore.AuthorizeMultiSigner(txSigner.Account, signingAcctIDFromPubKey, acct); r != ter.TesSUCCESS {
 			return r
 		}
 

--- a/internal/tx/engine/preclaim.go
+++ b/internal/tx/engine/preclaim.go
@@ -9,6 +9,7 @@ import (
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -251,8 +252,8 @@ func (e *Engine) preclaimBaseFee(tx txcore.Transaction, common *txcore.Common, a
 		baseFeeForTx = feeCalc.CalculateBaseFee(e.view, e.config)
 	} else {
 		baseFeeForTx = e.config.BaseFee
-		if txcore.IsMultiSigned(tx) {
-			baseFeeForTx = txcore.CalculateMultiSigFee(e.config.BaseFee, len(common.Signers))
+		if sign.IsMultiSigned(tx) {
+			baseFeeForTx = sign.CalculateMultiSigFee(e.config.BaseFee, len(common.Signers))
 		}
 	}
 	// SetRegularKey free password change: the base fee is waived when signed
@@ -321,7 +322,7 @@ func (e *Engine) checkPermission(tx txcore.Transaction, common *txcore.Common, a
 //
 //	auto const idAccount = ctx.tx[~sfDelegate].value_or(ctx.tx[sfAccount]);
 func (e *Engine) checkSign(tx txcore.Transaction, common *txcore.Common) ter.Result {
-	if txcore.IsMultiSigned(tx) {
+	if sign.IsMultiSigned(tx) {
 		return e.checkMultiSign(common)
 	}
 	if common.SigningPubKey != "" {
@@ -566,16 +567,16 @@ func (e *Engine) checkBatchMultiSign(accountID [20]byte, txSigners []txcore.Sign
 			return ter.TefINTERNAL
 		}
 
-		var acct txcore.SignerAccountState
+		var acct sign.SignerAccountState
 		if signerAccountData != nil {
 			signerAccountRoot, parseErr := state.ParseAccountRoot(signerAccountData)
 			if parseErr != nil {
 				return ter.TefINTERNAL
 			}
-			acct = txcore.NewSignerAccountState(true, signerAccountRoot.Flags, signerAccountRoot.RegularKey)
+			acct = sign.NewSignerAccountState(true, signerAccountRoot.Flags, signerAccountRoot.RegularKey)
 		}
 
-		if r := txcore.AuthorizeMultiSigner(txSigner.Account, signingAcctIDFromPubKey, acct); r != ter.TesSUCCESS {
+		if r := sign.AuthorizeMultiSigner(txSigner.Account, signingAcctIDFromPubKey, acct); r != ter.TesSUCCESS {
 			return r
 		}
 

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -1,4 +1,4 @@
-package tx
+package engine
 
 import (
 	"bytes"
@@ -8,6 +8,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
@@ -15,7 +16,7 @@ import (
 // Mirrors rippled Transactor::preflight() which composes preflight0/preflight1/preflight2
 // and the per-tx-type preflight. The blocks below are extracted helpers so this
 // top-level function reads as a high-level pipeline.
-func (e *Engine) preflight(tx Transaction) ter.Result {
+func (e *Engine) preflight(tx txcore.Transaction) ter.Result {
 	common := tx.GetCommon()
 
 	// preflight0: trivial common-field presence + amendment + flag checks.
@@ -47,7 +48,7 @@ func (e *Engine) preflight(tx Transaction) ter.Result {
 
 	// Rules-dependent preflight checks for tx types that need amendment-gated
 	// tem* validation alongside their rules-free Validate() body.
-	if rp, ok := tx.(RulesPreflighter); ok {
+	if rp, ok := tx.(txcore.RulesPreflighter); ok {
 		if err := rp.PreflightRules(e.rules()); err != nil {
 			return parseValidationError(err)
 		}
@@ -82,14 +83,14 @@ func (e *Engine) preflight(tx Transaction) ter.Result {
 // Reference: rippled Batch.cpp preflight() — `ripple::preflight(..., tapBATCH)`
 // per inner STTx; any failure → temINVALID_INNER_BATCH on the outer.
 type BatchOuter interface {
-	InnerTransactions() []Transaction
+	InnerTransactions() []txcore.Transaction
 }
 
 // Reference: rippled preflight(stx, tapBATCH) invoked from Batch.cpp:303.
 // Fee/signature/multi-sign/inner-flag rejections are skipped here because
 // inner txs have Fee=0, no signature, no multi-signers, and tfInnerBatchTxn
 // set; the corresponding presence checks live in Batch.Validate().
-func (e *Engine) preflightInner(innerTx Transaction) ter.Result {
+func (e *Engine) preflightInner(innerTx txcore.Transaction) ter.Result {
 	if result := e.preflightCommon(innerTx, innerTx.GetCommon()); result != ter.TesSUCCESS {
 		return result
 	}
@@ -101,14 +102,14 @@ func (e *Engine) preflightInner(innerTx Transaction) ter.Result {
 
 // Reference: rippled Transactor.cpp preflight0/early preflight1, plus the
 // outer-only tfInnerBatchTxn rejection on directly-submitted transactions.
-func (e *Engine) preflightCommonFields(tx Transaction, common *Common) ter.Result {
+func (e *Engine) preflightCommonFields(tx txcore.Transaction, common *txcore.Common) ter.Result {
 	if result := e.preflightCommon(tx, common); result != ter.TesSUCCESS {
 		return result
 	}
 
 	// tfInnerBatchTxn must never appear on a directly-submitted transaction.
 	// Reference: rippled Transactor.cpp preflight0().
-	if common.Flags != nil && *common.Flags&TfInnerBatchTxn != 0 {
+	if common.Flags != nil && *common.Flags&txcore.TfInnerBatchTxn != 0 {
 		return ter.TemINVALID_FLAG
 	}
 
@@ -118,7 +119,7 @@ func (e *Engine) preflightCommonFields(tx Transaction, common *Common) ter.Resul
 // Shared between outer (preflightCommonFields) and inner (preflightInner).
 // The tfInnerBatchTxn rejection lives only in the outer path because inner
 // txs are required to carry that flag.
-func (e *Engine) preflightCommon(tx Transaction, common *Common) ter.Result {
+func (e *Engine) preflightCommon(tx txcore.Transaction, common *txcore.Common) ter.Result {
 	if common.Account == "" {
 		return ter.TemBAD_SRC_ACCOUNT
 	}
@@ -144,7 +145,7 @@ func (e *Engine) preflightCommon(tx Transaction, common *Common) ter.Result {
 	// SkipSignatureVerification) must still bounce a malformed key here.
 	if common.SigningPubKey != "" {
 		spk, decErr := hex.DecodeString(common.SigningPubKey)
-		if decErr != nil || !IsValidPublicKey(spk) {
+		if decErr != nil || !txcore.IsValidPublicKey(spk) {
 			return ter.TemBAD_SIGNATURE
 		}
 	}
@@ -169,7 +170,7 @@ func (e *Engine) preflightCommon(tx Transaction, common *Common) ter.Result {
 
 // preflightSequence enforces the Sequence/TicketSequence/AccountTxnID rules
 // from rippled Transactor::preflight1() lines 142-153.
-func (e *Engine) preflightSequence(common *Common) ter.Result {
+func (e *Engine) preflightSequence(common *txcore.Common) ter.Result {
 	// Sequence must be present (unless using tickets)
 	if common.Sequence == nil && common.TicketSequence == nil {
 		return ter.TemBAD_SEQUENCE
@@ -190,14 +191,14 @@ func (e *Engine) preflightSequence(common *Common) ter.Result {
 // (sort, uniqueness, self-sign rejection) that runs regardless of
 // SkipSignatureVerification.
 // Reference: rippled STTx.cpp multiSignHelper() lines 468-485
-func (e *Engine) preflightMultiSignStructure(tx Transaction, common *Common) ter.Result {
-	if !IsMultiSigned(tx) {
+func (e *Engine) preflightMultiSignStructure(tx txcore.Transaction, common *txcore.Common) ter.Result {
+	if !txcore.IsMultiSigned(tx) {
 		return ter.TesSUCCESS
 	}
 	// The signer array must lie within the rules-gated bounds. An out-of-range
 	// array is "Invalid Signers array size" in rippled's multiSignHelper, which
 	// surfaces as temBAD_SIGNATURE at the verification call site.
-	if n := len(common.Signers); n < minMultiSigners || n > MaxMultiSigners(e.rules()) {
+	if n := len(common.Signers); n < txcore.MinMultiSigners || n > txcore.MaxMultiSigners(e.rules()) {
 		return ter.TemBAD_SIGNATURE
 	}
 	txAccountID, acctErr := state.DecodeAccountID(common.Account)
@@ -233,19 +234,19 @@ func (e *Engine) preflightMultiSignStructure(tx Transaction, common *Common) ter
 // array there surfaces as temBAD_SIGNATURE at the checkBatchSign call site. The
 // crypto verification of those signers lives in Batch.Validate(), which has no
 // rules access, so the rules-dependent size bound is enforced here in preflight.
-func (e *Engine) preflightBatchSignerStructure(tx Transaction) ter.Result {
-	bsp, ok := tx.(BatchSignerProvider)
+func (e *Engine) preflightBatchSignerStructure(tx txcore.Transaction) ter.Result {
+	bsp, ok := tx.(txcore.BatchSignerProvider)
 	if !ok {
 		return ter.TesSUCCESS
 	}
-	maxSigners := MaxMultiSigners(e.rules())
+	maxSigners := txcore.MaxMultiSigners(e.rules())
 	for _, signer := range bsp.GetBatchSigners() {
 		// A single-signed BatchSigner has no nested array; multi-sign is keyed
 		// off an empty SigningPubKey, matching Batch.verifyBatchSignatures.
 		if signer.SigningPubKey != "" {
 			continue
 		}
-		if n := len(signer.Signers); n < minMultiSigners || n > maxSigners {
+		if n := len(signer.Signers); n < txcore.MinMultiSigners || n > maxSigners {
 			return ter.TemBAD_SIGNATURE
 		}
 	}
@@ -255,7 +256,7 @@ func (e *Engine) preflightBatchSignerStructure(tx Transaction) ter.Result {
 // verifySignatures performs cryptographic signature verification (single or multi)
 // when SkipSignatureVerification is false. Authorization checks (master/regular
 // key) live in preclaim.
-func (e *Engine) verifySignatures(tx Transaction) ter.Result {
+func (e *Engine) verifySignatures(tx txcore.Transaction) ter.Result {
 	if e.config.SkipSignatureVerification {
 		return ter.TesSUCCESS
 	}
@@ -269,7 +270,7 @@ func (e *Engine) verifySignatures(tx Transaction) ter.Result {
 	// The structural/coverage checks on BatchSigners run unconditionally in Validate;
 	// only the cryptographic verification is gated here so it honours
 	// SkipSignatureVerification like every other signature.
-	if bsv, ok := tx.(BatchSignatureVerifier); ok {
+	if bsv, ok := tx.(txcore.BatchSignatureVerifier); ok {
 		if err := bsv.VerifyBatchSignatures(); err != nil {
 			return ter.TemBAD_SIGNATURE
 		}
@@ -280,17 +281,17 @@ func (e *Engine) verifySignatures(tx Transaction) ter.Result {
 // verifyOuterSignature performs the cryptographic single/multi-sign verification
 // of the transaction's own signature. Reference: rippled STTx::checkSingleSign /
 // checkMultiSign via preflight2's checkValidity.
-func (e *Engine) verifyOuterSignature(tx Transaction) ter.Result {
+func (e *Engine) verifyOuterSignature(tx txcore.Transaction) ter.Result {
 	// Full canonicality (low-S secp256k1) is required when RequireFullyCanonicalSig
 	// is enabled, or — independent of the amendment — when the transaction opts in
 	// via the tfFullyCanonicalSig flag.
 	// Reference: rippled apply.cpp:78-84 + STTx::checkSingleSign/checkMultiSign.
 	mustBeFullyCanonical := e.rules().RequireFullyCanonicalSigEnabled() ||
-		(tx.GetCommon().GetFlags()&TfFullyCanonicalSig) != 0
-	if IsMultiSigned(tx) {
+		(tx.GetCommon().GetFlags()&txcore.TfFullyCanonicalSig) != 0
+	if txcore.IsMultiSigned(tx) {
 		// Multi-signed transactions require signer list lookup
-		lookup := &engineSignerListLookup{view: e.view}
-		if err := VerifyMultiSignature(tx, lookup, mustBeFullyCanonical); err != nil {
+		lookup := &txcore.EngineSignerListLookup{View: e.view}
+		if err := txcore.VerifyMultiSignature(tx, lookup, mustBeFullyCanonical); err != nil {
 			// The typed signer-verification errors carry their own Result code
 			// (ErrNotMultiSigning, ErrBadQuorum, ErrBadSignature, ErrMasterDisabled,
 			// and ErrInternalLookup for a storage/parse failure); honour it.
@@ -298,9 +299,9 @@ func (e *Engine) verifyOuterSignature(tx Transaction) ter.Result {
 				return re.Code
 			}
 			// The malformed-signers sentinels are plain errors, all temBAD_SIGNATURE.
-			if errors.Is(err, ErrNoSigners) ||
-				errors.Is(err, ErrDuplicateSigner) ||
-				errors.Is(err, ErrSignersNotSorted) {
+			if errors.Is(err, txcore.ErrNoSigners) ||
+				errors.Is(err, txcore.ErrDuplicateSigner) ||
+				errors.Is(err, txcore.ErrSignersNotSorted) {
 				return ter.TemBAD_SIGNATURE
 			}
 			// Anything else (e.g. a wrapped serialization failure) is a bad sig.
@@ -314,7 +315,7 @@ func (e *Engine) verifyOuterSignature(tx Transaction) ter.Result {
 	// maps to temINVALID (Transactor.cpp:198-201) — NOT temBAD_SIGNATURE. The
 	// malformed-key-type case that does warrant temBAD_SIGNATURE is already
 	// caught unconditionally in preflight1 (preflightCommon).
-	if err := VerifySignature(tx, mustBeFullyCanonical); err != nil {
+	if err := txcore.VerifySignature(tx, mustBeFullyCanonical); err != nil {
 		return ter.TemINVALID
 	}
 	return ter.TesSUCCESS
@@ -334,11 +335,11 @@ func parseValidationError(err error) ter.Result {
 // validateNetworkID validates the NetworkID field according to rippled rules
 // - Legacy networks (ID <= 1024) cannot have NetworkID in transactions
 // - New networks (ID > 1024) require NetworkID and it must match
-func (e *Engine) validateNetworkID(common *Common) ter.Result {
+func (e *Engine) validateNetworkID(common *txcore.Common) ter.Result {
 	nodeNetworkID := e.config.NetworkID
 	txNetworkID := common.NetworkID
 
-	if nodeNetworkID <= LegacyNetworkIDThreshold {
+	if nodeNetworkID <= txcore.LegacyNetworkIDThreshold {
 		// Legacy networks cannot specify NetworkID in transactions
 		if txNetworkID != nil {
 			return ter.TelNETWORK_ID_MAKES_TX_NON_CANONICAL
@@ -357,7 +358,7 @@ func (e *Engine) validateNetworkID(common *Common) ter.Result {
 }
 
 // validateFee validates the Fee field
-func (e *Engine) validateFee(common *Common) ter.Result {
+func (e *Engine) validateFee(common *txcore.Common) ter.Result {
 	// sfFee is a required field on every transaction (rippled TxFormats.cpp:
 	// {sfFee, soeREQUIRED}); an STTx missing it fails template validation before
 	// preflight ever runs. The engine must not invent a fee the signer never
@@ -387,7 +388,7 @@ func (e *Engine) validateFee(common *Common) ter.Result {
 	// Fee cannot exceed maximum allowed fee
 	maxFee := e.config.MaxFee
 	if maxFee == 0 {
-		maxFee = DefaultMaxFee
+		maxFee = txcore.DefaultMaxFee
 	}
 	if fee > maxFee {
 		return ter.TemBAD_FEE
@@ -397,7 +398,7 @@ func (e *Engine) validateFee(common *Common) ter.Result {
 }
 
 // validateMemos validates the Memos array according to rippled rules
-func (e *Engine) validateMemos(common *Common) ter.Result {
+func (e *Engine) validateMemos(common *txcore.Common) ter.Result {
 	if len(common.Memos) == 0 {
 		return ter.TesSUCCESS
 	}
@@ -416,7 +417,7 @@ func (e *Engine) validateMemos(common *Common) ter.Result {
 				return ter.TemINVALID
 			}
 			// MemoType max size is 256 bytes (decoded)
-			if len(memoTypeBytes) > MaxMemoTypeSize {
+			if len(memoTypeBytes) > txcore.MaxMemoTypeSize {
 				return ter.TemINVALID
 			}
 			totalSize += len(memoTypeBytes)
@@ -435,7 +436,7 @@ func (e *Engine) validateMemos(common *Common) ter.Result {
 				return ter.TemINVALID
 			}
 			// MemoData max size is 1024 bytes (decoded)
-			if len(memoDataBytes) > MaxMemoDataSize {
+			if len(memoDataBytes) > txcore.MaxMemoDataSize {
 				return ter.TemINVALID
 			}
 			totalSize += len(memoDataBytes)
@@ -459,7 +460,7 @@ func (e *Engine) validateMemos(common *Common) ter.Result {
 	}
 
 	// Total memo size check
-	if totalSize > MaxMemoSize {
+	if totalSize > txcore.MaxMemoSize {
 		return ter.TemINVALID
 	}
 

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -9,6 +9,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
@@ -192,13 +193,13 @@ func (e *Engine) preflightSequence(common *txcore.Common) ter.Result {
 // SkipSignatureVerification.
 // Reference: rippled STTx.cpp multiSignHelper() lines 468-485
 func (e *Engine) preflightMultiSignStructure(tx txcore.Transaction, common *txcore.Common) ter.Result {
-	if !txcore.IsMultiSigned(tx) {
+	if !sign.IsMultiSigned(tx) {
 		return ter.TesSUCCESS
 	}
 	// The signer array must lie within the rules-gated bounds. An out-of-range
 	// array is "Invalid Signers array size" in rippled's multiSignHelper, which
 	// surfaces as temBAD_SIGNATURE at the verification call site.
-	if n := len(common.Signers); n < txcore.MinMultiSigners || n > txcore.MaxMultiSigners(e.rules()) {
+	if n := len(common.Signers); n < sign.MinMultiSigners || n > sign.MaxMultiSigners(e.rules()) {
 		return ter.TemBAD_SIGNATURE
 	}
 	txAccountID, acctErr := state.DecodeAccountID(common.Account)
@@ -239,14 +240,14 @@ func (e *Engine) preflightBatchSignerStructure(tx txcore.Transaction) ter.Result
 	if !ok {
 		return ter.TesSUCCESS
 	}
-	maxSigners := txcore.MaxMultiSigners(e.rules())
+	maxSigners := sign.MaxMultiSigners(e.rules())
 	for _, signer := range bsp.GetBatchSigners() {
 		// A single-signed BatchSigner has no nested array; multi-sign is keyed
 		// off an empty SigningPubKey, matching Batch.verifyBatchSignatures.
 		if signer.SigningPubKey != "" {
 			continue
 		}
-		if n := len(signer.Signers); n < txcore.MinMultiSigners || n > maxSigners {
+		if n := len(signer.Signers); n < sign.MinMultiSigners || n > maxSigners {
 			return ter.TemBAD_SIGNATURE
 		}
 	}
@@ -288,10 +289,10 @@ func (e *Engine) verifyOuterSignature(tx txcore.Transaction) ter.Result {
 	// Reference: rippled apply.cpp:78-84 + STTx::checkSingleSign/checkMultiSign.
 	mustBeFullyCanonical := e.rules().RequireFullyCanonicalSigEnabled() ||
 		(tx.GetCommon().GetFlags()&txcore.TfFullyCanonicalSig) != 0
-	if txcore.IsMultiSigned(tx) {
+	if sign.IsMultiSigned(tx) {
 		// Multi-signed transactions require signer list lookup
-		lookup := &txcore.EngineSignerListLookup{View: e.view}
-		if err := txcore.VerifyMultiSignature(tx, lookup, mustBeFullyCanonical); err != nil {
+		lookup := &sign.EngineSignerListLookup{View: e.view}
+		if err := sign.VerifyMultiSignature(tx, lookup, mustBeFullyCanonical); err != nil {
 			// The typed signer-verification errors carry their own Result code
 			// (ErrNotMultiSigning, ErrBadQuorum, ErrBadSignature, ErrMasterDisabled,
 			// and ErrInternalLookup for a storage/parse failure); honour it.
@@ -299,9 +300,9 @@ func (e *Engine) verifyOuterSignature(tx txcore.Transaction) ter.Result {
 				return re.Code
 			}
 			// The malformed-signers sentinels are plain errors, all temBAD_SIGNATURE.
-			if errors.Is(err, txcore.ErrNoSigners) ||
-				errors.Is(err, txcore.ErrDuplicateSigner) ||
-				errors.Is(err, txcore.ErrSignersNotSorted) {
+			if errors.Is(err, sign.ErrNoSigners) ||
+				errors.Is(err, sign.ErrDuplicateSigner) ||
+				errors.Is(err, sign.ErrSignersNotSorted) {
 				return ter.TemBAD_SIGNATURE
 			}
 			// Anything else (e.g. a wrapped serialization failure) is a bad sig.
@@ -315,7 +316,7 @@ func (e *Engine) verifyOuterSignature(tx txcore.Transaction) ter.Result {
 	// maps to temINVALID (Transactor.cpp:198-201) — NOT temBAD_SIGNATURE. The
 	// malformed-key-type case that does warrant temBAD_SIGNATURE is already
 	// caught unconditionally in preflight1 (preflightCommon).
-	if err := txcore.VerifySignature(tx, mustBeFullyCanonical); err != nil {
+	if err := sign.VerifySignature(tx, mustBeFullyCanonical); err != nil {
 		return ter.TemINVALID
 	}
 	return ter.TesSUCCESS

--- a/internal/tx/engine/pseudo_gates.go
+++ b/internal/tx/engine/pseudo_gates.go
@@ -1,7 +1,8 @@
-package tx
+package engine
 
 import (
 	"github.com/LeJamon/go-xrpl/amendment"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
@@ -19,13 +20,13 @@ type PseudoPreclaim interface {
 // tfInnerBatchTxn rejection (Transactor.cpp:46-51) and the NetworkID check
 // when sfNetworkID is present (Transactor.cpp:53-75).
 // Reference: rippled Change.cpp:36-80, Transactor.cpp:42-87.
-func (e *Engine) pseudoPreflight(tx Transaction, rules *amendment.Rules) ter.Result {
+func (e *Engine) pseudoPreflight(tx txcore.Transaction, rules *amendment.Rules) ter.Result {
 	common := tx.GetCommon()
 
 	// preflight0 inner-batch gate: a pseudo-tx with the tfInnerBatchTxn flag
 	// is structurally invalid because only the batch executor sets that flag.
 	// Reference: Transactor.cpp:46-51.
-	if common.Flags != nil && *common.Flags&TfInnerBatchTxn != 0 {
+	if common.Flags != nil && *common.Flags&txcore.TfInnerBatchTxn != 0 {
 		return ter.TemINVALID_FLAG
 	}
 
@@ -35,7 +36,7 @@ func (e *Engine) pseudoPreflight(tx Transaction, rules *amendment.Rules) ter.Res
 	// NetworkID on a pseudo-tx is always legal.
 	// Reference: Transactor.cpp:53-75.
 	if common.NetworkID != nil {
-		if e.config.NetworkID <= LegacyNetworkIDThreshold {
+		if e.config.NetworkID <= txcore.LegacyNetworkIDThreshold {
 			return ter.TelNETWORK_ID_MAKES_TX_NON_CANONICAL
 		}
 		if *common.NetworkID != e.config.NetworkID {
@@ -77,7 +78,7 @@ func (e *Engine) pseudoPreflight(tx Transaction, rules *amendment.Rules) ter.Res
 
 	// NegativeUNL amendment must be enabled for UNL_MODIFY pseudo-tx.
 	// Reference: Change.cpp:72-77.
-	if tx.TxType() == TypeUNLModify && (rules == nil || !rules.NegativeUNLEnabled()) {
+	if tx.TxType() == txcore.TypeUNLModify && (rules == nil || !rules.NegativeUNLEnabled()) {
 		return ter.TemDISABLED
 	}
 
@@ -90,17 +91,17 @@ func (e *Engine) pseudoPreflight(tx Transaction, rules *amendment.Rules) ter.Res
 // temUNKNOWN to mirror rippled's Change.cpp:137-139 — a new pseudo type added
 // without a PreclaimPseudo implementation must fail loudly, not silently.
 // Reference: Change.cpp:82-140.
-func (e *Engine) pseudoPreclaim(tx Transaction, rules *amendment.Rules) ter.Result {
+func (e *Engine) pseudoPreclaim(tx txcore.Transaction, rules *amendment.Rules) ter.Result {
 	if e.config.OpenLedger {
 		return ter.TemINVALID
 	}
 	switch tx.TxType() {
-	case TypeAmendment, TypeUNLModify:
+	case txcore.TypeAmendment, txcore.TypeUNLModify:
 		if p, ok := tx.(PseudoPreclaim); ok {
 			return p.PreclaimPseudo(rules)
 		}
 		return ter.TesSUCCESS
-	case TypeFee:
+	case txcore.TypeFee:
 		p, ok := tx.(PseudoPreclaim)
 		if !ok {
 			return ter.TemUNKNOWN

--- a/internal/tx/engine/reserve_test.go
+++ b/internal/tx/engine/reserve_test.go
@@ -1,9 +1,10 @@
-package tx
+package engine
 
 import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
@@ -53,7 +54,7 @@ func TestAccountReserve(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			engine := &Engine{
-				config: EngineConfig{
+				config: txcore.EngineConfig{
 					ReserveBase:      tt.reserveBase,
 					ReserveIncrement: tt.reserveIncrement,
 				},
@@ -86,11 +87,11 @@ func TestPriorBalanceExcludesDelegatedFee(t *testing.T) {
 	const fee = uint64(5000)
 	acct := &state.AccountRoot{Balance: balance}
 
-	normal := &ApplyContext{Account: acct, SourceFeeCharged: fee}
+	normal := &txcore.ApplyContext{Account: acct, SourceFeeCharged: fee}
 	if got := normal.PriorBalance(); got != balance+fee {
 		t.Fatalf("normal PriorBalance = %d, want %d", got, balance+fee)
 	}
-	delegated := &ApplyContext{Account: acct, SourceFeeCharged: 0}
+	delegated := &txcore.ApplyContext{Account: acct, SourceFeeCharged: 0}
 	if got := delegated.PriorBalance(); got != balance {
 		t.Fatalf("delegated PriorBalance = %d, want %d", got, balance)
 	}
@@ -106,15 +107,15 @@ func TestCheckReserveWithFeeDelegatedBoundary(t *testing.T) {
 	const reserveFor3 = reserveBase + 3*reserveIncrement // accountReserve(3) = 16 XRP
 	const fee = uint64(10)
 
-	cfg := EngineConfig{ReserveBase: reserveBase, ReserveIncrement: reserveIncrement}
+	cfg := txcore.EngineConfig{ReserveBase: reserveBase, ReserveIncrement: reserveIncrement}
 	acct := &state.AccountRoot{Balance: reserveFor3 - 1}
 
-	delegated := &ApplyContext{Account: acct, Config: cfg, SourceFeeCharged: 0}
+	delegated := &txcore.ApplyContext{Account: acct, Config: cfg, SourceFeeCharged: 0}
 	if got := delegated.CheckReserveWithFee(3); got != ter.TecINSUFFICIENT_RESERVE {
 		t.Fatalf("delegated boundary: got %v, want TecINSUFFICIENT_RESERVE", got)
 	}
 
-	normal := &ApplyContext{Account: acct, Config: cfg, SourceFeeCharged: fee}
+	normal := &txcore.ApplyContext{Account: acct, Config: cfg, SourceFeeCharged: fee}
 	if got := normal.CheckReserveWithFee(3); got != ter.TesSUCCESS {
 		t.Fatalf("normal boundary: got %v, want TesSUCCESS", got)
 	}
@@ -170,7 +171,7 @@ func TestReserveForNewObject(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			engine := &Engine{
-				config: EngineConfig{
+				config: txcore.EngineConfig{
 					ReserveBase:      tt.reserveBase,
 					ReserveIncrement: tt.reserveIncrement,
 				},
@@ -240,7 +241,7 @@ func TestCanCreateNewObject(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			engine := &Engine{
-				config: EngineConfig{
+				config: txcore.EngineConfig{
 					ReserveBase:      tt.reserveBase,
 					ReserveIncrement: tt.reserveIncrement,
 				},
@@ -302,7 +303,7 @@ func TestCheckReserveIncrease(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			engine := &Engine{
-				config: EngineConfig{
+				config: txcore.EngineConfig{
 					ReserveBase:      tt.reserveBase,
 					ReserveIncrement: tt.reserveIncrement,
 				},
@@ -324,7 +325,7 @@ func TestFreeTrustlines(t *testing.T) {
 	reserveIncrement := uint64(2000000) // 2 XRP
 
 	engine := &Engine{
-		config: EngineConfig{
+		config: txcore.EngineConfig{
 			ReserveBase:      baseReserve,
 			ReserveIncrement: reserveIncrement,
 		},
@@ -373,7 +374,7 @@ func TestFreeTrustlines(t *testing.T) {
 // Benchmark tests
 func BenchmarkAccountReserve(b *testing.B) {
 	engine := &Engine{
-		config: EngineConfig{
+		config: txcore.EngineConfig{
 			ReserveBase:      10000000,
 			ReserveIncrement: 2000000,
 		},
@@ -385,7 +386,7 @@ func BenchmarkAccountReserve(b *testing.B) {
 
 func BenchmarkReserveForNewObject(b *testing.B) {
 	engine := &Engine{
-		config: EngineConfig{
+		config: txcore.EngineConfig{
 			ReserveBase:      10000000,
 			ReserveIncrement: 2000000,
 		},

--- a/internal/tx/engine_config.go
+++ b/internal/tx/engine_config.go
@@ -2,18 +2,13 @@ package tx
 
 import (
 	"encoding/hex"
-	"sync/atomic"
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/crypto/common"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
-	"github.com/LeJamon/go-xrpl/internal/ledger/state"
-	"github.com/LeJamon/go-xrpl/internal/tx/invariants"
-	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
-	"github.com/LeJamon/go-xrpl/ledger/entry"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
@@ -40,37 +35,6 @@ const (
 	// QualityOne is the identity transfer rate (1e9). Alias for protocol.QualityOne.
 	QualityOne = protocol.QualityOne
 )
-
-// Engine processes transactions against a ledger.
-//
-// Engine instances are NOT safe for concurrent Apply/ApplyPseudo calls. A
-// single Engine is meant to drive a single open ledger's transaction stream
-// in order (matching rippled's OpenView, which is also single-writer). The
-// only field that may be touched off-thread is txCount (read via TxCount,
-// reset via SetBaseTxCount), which is atomic to make those accessors safe
-// for observers — it is not a license to call Apply concurrently.
-type Engine struct {
-	// View provides access to ledger state
-	view LedgerView
-
-	// Config holds engine configuration
-	config EngineConfig
-
-	// logger is the scoped logger for the Tx partition.
-	// Always non-nil; falls back to xrpllog.Discard() when not configured.
-	logger xrpllog.Logger
-
-	// txCount tracks the number of applied transactions for TransactionIndex.
-	// Each applied transaction (tesSUCCESS or tec) gets the current count as
-	// its TransactionIndex, then the counter increments.
-	// Reference: rippled OpenView::txCount() = baseTxCount_ + txs_.size()
-	txCount atomic.Uint32
-
-	// invariantViolationHook, when non-nil, lets tests force an invariant
-	// violation for a given (result, table). Production always leaves it nil,
-	// so runInvariantsOnTable behaves exactly as the real checkers dictate.
-	invariantViolationHook func(result ter.Result, table *ApplyStateTable) *invariants.InvariantViolation
-}
 
 // ApplyFlags controls transaction application behavior during consensus.
 // Reference: rippled ApplyView.h ApplyFlags enum
@@ -254,103 +218,6 @@ type LedgerView interface {
 	LedgerSeq() uint32
 }
 
-// rulesView wraps a LedgerView so Rules() reports a known rule set. The engine's
-// base view (e.g. a Ledger) returns nil from Rules(), but rippled's preclaim view
-// always carries the parent ledger's rules. Wrapping the view for the Preclaimer
-// dispatch keeps rules-gated reads (e.g. accountFunds' frozen-LP-token check)
-// working at the preclaim stage, matching the rules visible during apply.
-type rulesView struct {
-	LedgerView
-	rules *amendment.Rules
-}
-
-func (v rulesView) Rules() *amendment.Rules { return v.rules }
-
-// NewEngine creates a new transaction engine
-func NewEngine(view LedgerView, config EngineConfig) *Engine {
-	logger := config.Logger
-	if logger == nil {
-		logger = xrpllog.Discard()
-	}
-	return &Engine{
-		view:   view,
-		config: config,
-		logger: logger.Named(xrpllog.PartitionTx),
-	}
-}
-
-// InvariantViolationValue describes a detected invariant violation. Exported so
-// test hooks can construct one without importing the invariants package.
-type InvariantViolationValue = invariants.InvariantViolation
-
-// InvariantViolationHook is a test-only override that forces an invariant
-// violation for a given (result, table). It is consulted by the invariant pass
-// on both the tes and tec apply paths after the real checkers pass cleanly.
-type InvariantViolationHook = func(result ter.Result, table *ApplyStateTable) *InvariantViolationValue
-
-// SetInvariantViolationHookForTest installs a test-only hook that forces an
-// invariant violation, used to exercise the tec→tecINVARIANT_FAILED→
-// tefINVARIANT_FAILED escalation without crafting a state that trips a real
-// checker. Production never calls this, so the hook stays nil and the real
-// checkers alone decide.
-func (e *Engine) SetInvariantViolationHookForTest(hook InvariantViolationHook) {
-	e.invariantViolationHook = hook
-}
-
-// NewInvariantViolation builds an invariant violation value for tests that drive
-// SetInvariantViolationHookForTest, without exposing the invariants package to
-// test callers.
-func NewInvariantViolation(name, message string) *invariants.InvariantViolation {
-	return &invariants.InvariantViolation{Name: name, Message: message}
-}
-
-// rules returns the amendment rules for this engine. EngineConfig.Rules
-// MUST be set by the caller — typically from the parent ledger's
-// Amendments SLE via ledger.LoadAmendmentsFromLedger (production) or
-// amendment.AllSupportedRules / EmptyRules (tests / genesis).
-//
-// Mirrors rippled's `Rules() = delete` (include/xrpl/protocol/Rules.h:57)
-// where there is no default constructor — every Rules instance is
-// explicitly built from a ledger via makeRulesGivenLedger. A silent
-// fallback (whether AllSupportedRules or EmptyRules) desyncs the engine
-// from on-chain state: AllSupportedRules treats every amendment as
-// enabled even when not on the ledger (the #401/#418 wedge); EmptyRules
-// treats everything as disabled even when amendments ARE on the ledger
-// (which broke the soak in the opposite direction). Panicking forces
-// every call site to plumb the real rules.
-func (e *Engine) rules() *amendment.Rules {
-	return e.config.GetRules()
-}
-
-// TxCount returns the current transaction count (for batch baseTxCount).
-// Reference: rippled OpenView::txCount()
-func (e *Engine) TxCount() uint32 {
-	return e.txCount.Load()
-}
-
-// Preflight runs the preflight pipeline (syntax, signature, tx-type
-// validation) against the engine's rules and returns the TER. Used by
-// TxQ.Apply to reject structurally invalid submissions before they are
-// held in the queue, mirroring rippled's preflight at TxQ.cpp:743-745.
-func (e *Engine) Preflight(tx Transaction) ter.Result {
-	return e.preflight(tx)
-}
-
-// Preclaim runs the full preclaim pipeline against the engine's view
-// and returns the TER. Used by TxQ's multiTxn path (TxQ.cpp:1167-1170)
-// which runs preclaim against a cloned view with adjusted AccountRoot
-// fields to detect terINSUF_FEE_B / terPRE_SEQ before queueing.
-func (e *Engine) Preclaim(tx Transaction, txHash [32]byte) ter.Result {
-	return e.preclaim(tx, txHash)
-}
-
-// SetBaseTxCount sets the base transaction count for batch inner transactions.
-// Inner transactions start numbering from this value.
-// Reference: rippled OpenView::baseTxCount_ initialized from parent view
-func (e *Engine) SetBaseTxCount(count uint32) {
-	e.txCount.Store(count)
-}
-
 // ComputeTransactionHash computes the hash of a transaction.
 // The hash is SHA512Half of the "TXN\x00" prefix + serialized transaction.
 func ComputeTransactionHash(tx Transaction) ([32]byte, error) {
@@ -391,43 +258,4 @@ func computeTransactionHash(tx Transaction) ([32]byte, error) {
 
 	hash = common.Sha512Half(data)
 	return hash, nil
-}
-
-// adjustOwnerCountOnView modifies an account's OwnerCount on a LedgerView.
-// Used by the engine for tecOVERSIZE offer cleanup after the sandbox is discarded.
-// Reference: rippled removeUnfundedOffers() adjusts owner count on the base view.
-func adjustOwnerCountOnView(view LedgerView, account [20]byte, delta int, txHash [32]byte, ledgerSeq uint32) {
-	_ = AdjustOwnerCountWithTx(view, account, delta, txHash, ledgerSeq)
-}
-
-// deleteNFTokenOfferOnView deletes an NFTokenOffer from the ledger view,
-// removing it from owner directory, NFTBuys/NFTSells directory, and erasing the SLE.
-// Used for tecEXPIRED re-deletion of expired NFToken offers.
-// Reference: rippled NFTokenUtils.cpp deleteTokenOffer
-func deleteNFTokenOfferOnView(view LedgerView, offerKL keylet.Keylet, txHash [32]byte, ledgerSeq uint32) {
-	offerData, err := view.Read(offerKL)
-	if err != nil || offerData == nil {
-		return
-	}
-
-	offer, err := state.ParseNFTokenOffer(offerData)
-	if err != nil {
-		return
-	}
-
-	ownerDirKey := keylet.OwnerDir(offer.Owner)
-	state.DirRemove(view, ownerDirKey, offer.OwnerNode, offerKL.Key, false)
-
-	// Remove from NFTBuys or NFTSells directory
-	isSellOffer := offer.Flags&entry.LsfSellNFToken != 0
-	var tokenDirKey keylet.Keylet
-	if isSellOffer {
-		tokenDirKey = keylet.NFTSells(offer.NFTokenID)
-	} else {
-		tokenDirKey = keylet.NFTBuys(offer.NFTokenID)
-	}
-	state.DirRemove(view, tokenDirKey, offer.NFTokenOfferNode, offerKL.Key, false)
-
-	_ = view.Erase(offerKL)
-	adjustOwnerCountOnView(view, offer.Owner, -1, txHash, ledgerSeq)
 }

--- a/internal/tx/engine_recovery_886_test.go
+++ b/internal/tx/engine_recovery_886_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -106,7 +107,7 @@ func TestApply_TecInsuffFee_ClampsToBalance(t *testing.T) {
 	e := recoveryEngine(view, TapNONE)
 	res := e.Apply(recoveryTx(10, 1))
 
-	if res.Result != TecINSUFF_FEE {
+	if res.Result != ter.TecINSUFF_FEE {
 		t.Fatalf("result = %s, want tecINSUFF_FEE", res.Result)
 	}
 	if !res.Applied {
@@ -140,7 +141,7 @@ func TestApply_FailHard_TecNotApplied(t *testing.T) {
 	e := recoveryEngine(view, TapFAIL_HARD)
 	res := e.Apply(recoveryTx(10, 1))
 
-	if res.Result != TecINSUFF_FEE {
+	if res.Result != ter.TecINSUFF_FEE {
 		t.Fatalf("result = %s, want tecINSUFF_FEE (preserved under fail_hard)", res.Result)
 	}
 	if res.Applied {
@@ -163,10 +164,10 @@ func TestApply_FailHard_TecNotApplied(t *testing.T) {
 // branch) for a specific code.
 type codeTecTx struct {
 	*BaseTx
-	code Result
+	code ter.Result
 }
 
-func (t codeTecTx) Apply(*ApplyContext) Result { return t.code }
+func (t codeTecTx) Apply(*ApplyContext) ter.Result { return t.code }
 
 // TestApply_FailHard_DoApplyTecNotApplied covers the second half of Item 2: a tec
 // that surfaces from doApply (not preclaim) must also be discarded under
@@ -177,10 +178,10 @@ func TestApply_FailHard_DoApplyTecNotApplied(t *testing.T) {
 	acctKey := fundRecoveryAccount(t, view, 1_000_000, 1)
 
 	e := recoveryEngine(view, TapFAIL_HARD)
-	txn := codeTecTx{BaseTx: recoveryTx(10, 1), code: TecUNFUNDED_PAYMENT}
+	txn := codeTecTx{BaseTx: recoveryTx(10, 1), code: ter.TecUNFUNDED_PAYMENT}
 	res := e.Apply(txn)
 
-	if res.Result != TecUNFUNDED_PAYMENT {
+	if res.Result != ter.TecUNFUNDED_PAYMENT {
 		t.Fatalf("result = %s, want tecUNFUNDED_PAYMENT (preserved under fail_hard)", res.Result)
 	}
 	if res.Applied {
@@ -207,9 +208,9 @@ func TestApply_Retry_GenericTecNotApplied(t *testing.T) {
 	acctKey := fundRecoveryAccount(t, view, 1_000_000, 1)
 
 	e := recoveryEngine(view, TapRETRY)
-	res := e.Apply(codeTecTx{BaseTx: recoveryTx(10, 1), code: TecUNFUNDED_PAYMENT})
+	res := e.Apply(codeTecTx{BaseTx: recoveryTx(10, 1), code: ter.TecUNFUNDED_PAYMENT})
 
-	if res.Result != TecUNFUNDED_PAYMENT {
+	if res.Result != ter.TecUNFUNDED_PAYMENT {
 		t.Fatalf("result = %s, want tecUNFUNDED_PAYMENT", res.Result)
 	}
 	if res.Applied {
@@ -235,9 +236,9 @@ func TestApply_Retry_WorkOnTecReapplied(t *testing.T) {
 	acctKey := fundRecoveryAccount(t, view, 1_000_000, 1)
 
 	e := recoveryEngine(view, TapRETRY)
-	res := e.Apply(codeTecTx{BaseTx: recoveryTx(10, 1), code: TecKILLED})
+	res := e.Apply(codeTecTx{BaseTx: recoveryTx(10, 1), code: ter.TecKILLED})
 
-	if res.Result != TecKILLED {
+	if res.Result != ter.TecKILLED {
 		t.Fatalf("result = %s, want tecKILLED", res.Result)
 	}
 	if !res.Applied {
@@ -277,7 +278,7 @@ func TestApply_PreclaimTec_InvariantViolation(t *testing.T) {
 	// violation yields tefINVARIANT_FAILED. Firing once exercises the
 	// tec→fee-only-claim escalation that the preclaim-tec commit must now run.
 	firstPass := true
-	e.SetInvariantViolationHookForTest(func(result Result, table *ApplyStateTable) *InvariantViolationValue {
+	e.SetInvariantViolationHookForTest(func(result ter.Result, table *ApplyStateTable) *InvariantViolationValue {
 		if firstPass {
 			firstPass = false
 			return NewInvariantViolation("forced", "forced violation for test")
@@ -286,7 +287,7 @@ func TestApply_PreclaimTec_InvariantViolation(t *testing.T) {
 	})
 
 	res := e.Apply(recoveryTx(10, 1))
-	if res.Result != TecINVARIANT_FAILED {
+	if res.Result != ter.TecINVARIANT_FAILED {
 		t.Fatalf("result = %s, want tecINVARIANT_FAILED", res.Result)
 	}
 }
@@ -310,7 +311,7 @@ func TestPreflight_InvalidSigningPubKey(t *testing.T) {
 		"00000000000000000000000000000000000000000000000000000000000000"
 
 	res := e.Apply(tx)
-	if res.Result != TemBAD_SIGNATURE {
+	if res.Result != ter.TemBAD_SIGNATURE {
 		t.Fatalf("result = %s, want temBAD_SIGNATURE for invalid signing key type", res.Result)
 	}
 	if res.Applied {

--- a/internal/tx/escrow/escrow_cancel.go
+++ b/internal/tx/escrow/escrow_cancel.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -40,7 +41,7 @@ func (e *EscrowCancel) Validate() error {
 	// where the amendment rules are available.
 
 	if e.Owner == "" {
-		return tx.Errorf(tx.TemMALFORMED, "Owner is required")
+		return ter.Errorf(ter.TemMALFORMED, "Owner is required")
 	}
 
 	return nil
@@ -57,16 +58,16 @@ func (e *EscrowCancel) Flatten() (map[string]any, error) {
 // after the common preflight/preclaim steps. For a tx malformed in two ways this
 // can surface a different tem code than rippled; the result is tem-only (never
 // enters a ledger) so there is no consensus divergence.
-func (e *EscrowCancel) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
+func (e *EscrowCancel) Preclaim(_ tx.LedgerView, config tx.EngineConfig) ter.Result {
 	if config.GetRules().Enabled(amendment.FeatureFix1543) && (e.GetFlags()&tx.TfUniversalMask) != 0 {
-		return tx.TemINVALID_FLAG
+		return ter.TemINVALID_FLAG
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // Apply applies an EscrowCancel transaction
 // Reference: rippled Escrow.cpp EscrowCancel::preclaim() + doApply()
-func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) tx.Result {
+func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("escrow cancel apply",
 		"account", e.Account,
 		"owner", e.Owner,
@@ -77,7 +78,7 @@ func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	ownerID, err := state.DecodeAccountID(e.Owner)
 	if err != nil {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	// Find the escrow
@@ -88,14 +89,14 @@ func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 			"owner", e.Owner,
 			"offerSequence", e.OfferSequence,
 		)
-		return tx.TecNO_TARGET
+		return ter.TecNO_TARGET
 	}
 
 	// Parse escrow
 	escrowEntry, err := state.ParseEscrow(escrowData)
 	if err != nil {
 		ctx.Log.Error("escrow cancel: failed to parse escrow", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	isXRP := escrowEntry.IsXRP
@@ -105,11 +106,11 @@ func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 	if !isXRP && rules.Enabled(amendment.FeatureTokenEscrow) {
 		escrowAmount := reconstructAmountFromEscrow(escrowEntry)
 		if escrowAmount.IsMPT() {
-			if result := escrowCancelPreclaimMPT(ctx.View, escrowEntry.Account, escrowAmount); result != tx.TesSUCCESS {
+			if result := escrowCancelPreclaimMPT(ctx.View, escrowEntry.Account, escrowAmount); result != ter.TesSUCCESS {
 				return result
 			}
 		} else if escrowAmount.Issuer != "" {
-			if result := escrowCancelPreclaimIOU(ctx.View, escrowEntry.Account, escrowAmount); result != tx.TesSUCCESS {
+			if result := escrowCancelPreclaimIOU(ctx.View, escrowEntry.Account, escrowAmount); result != ter.TesSUCCESS {
 				return result
 			}
 		}
@@ -122,22 +123,22 @@ func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 	if rules.Enabled(amendment.FeatureFix1571) {
 		// fix1571: must have CancelAfter set, and close time must be past it
 		if escrowEntry.CancelAfter == 0 {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 		if closeTime <= escrowEntry.CancelAfter {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	} else {
 		// Pre-fix1571: same logic
 		if escrowEntry.CancelAfter == 0 || closeTime <= escrowEntry.CancelAfter {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	}
 
 	// Remove escrow from owner directory
 	// Reference: rippled Escrow.cpp doApply() lines 1333-1342
 	ownerDirKey := keylet.OwnerDir(escrowEntry.Account)
-	if result := tx.DirRemoveOrBadLedger(ctx.View, ownerDirKey, escrowEntry.OwnerNode, escrowKey.Key); result != tx.TesSUCCESS {
+	if result := tx.DirRemoveOrBadLedger(ctx.View, ownerDirKey, escrowEntry.OwnerNode, escrowKey.Key); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -145,7 +146,7 @@ func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled Escrow.cpp doApply() lines 1345-1356
 	if escrowEntry.HasDestNode {
 		destDirKey := keylet.OwnerDir(escrowEntry.DestinationID)
-		if result := tx.DirRemoveOrBadLedger(ctx.View, destDirKey, escrowEntry.DestinationNode, escrowKey.Key); result != tx.TesSUCCESS {
+		if result := tx.DirRemoveOrBadLedger(ctx.View, destDirKey, escrowEntry.DestinationNode, escrowKey.Key); result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -166,17 +167,17 @@ func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 			ownerData, err := ctx.View.Read(ownerKey)
 			if err != nil {
 				ctx.Log.Error("escrow cancel: failed to read owner account", "error", err)
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 
 			ownerAccount, err := state.ParseAccountRoot(ownerData)
 			if err != nil {
 				ctx.Log.Error("escrow cancel: failed to parse owner account", "error", err)
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 
 			ownerAccount.Balance += escrowEntry.Amount
-			if result := ctx.UpdateAccountRoot(ownerID, ownerAccount); result != tx.TesSUCCESS {
+			if result := ctx.UpdateAccountRoot(ownerID, ownerAccount); result != ter.TesSUCCESS {
 				return result
 			}
 		}
@@ -184,7 +185,7 @@ func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 		// IOU or MPT token escrow cancel
 		// Reference: rippled Escrow.cpp doApply() lines 1364-1398
 		if !rules.Enabled(amendment.FeatureTokenEscrow) {
-			return tx.TemDISABLED
+			return ter.TemDISABLED
 		}
 
 		escrowAmount := reconstructAmountFromEscrow(escrowEntry)
@@ -215,7 +216,7 @@ func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 				escrowEntry.Account,
 				false, // cancel scopes reserve+bump to the erased escrow SLE, not the creator
 				ctx.Config.ReserveBase, ctx.Config.ReserveIncrement,
-			); result != tx.TesSUCCESS {
+			); result != ter.TesSUCCESS {
 				return result
 			}
 		} else {
@@ -235,7 +236,7 @@ func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 				createAsset,
 				false, // cancel scopes reserve+bump to the erased escrow SLE, not the creator
 				ctx.Config.ReserveBase, ctx.Config.ReserveIncrement,
-			); result != tx.TesSUCCESS {
+			); result != ter.TesSUCCESS {
 				return result
 			}
 		}
@@ -246,7 +247,7 @@ func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 			issuerID, err := state.DecodeAccountID(escrowAmount.Issuer)
 			if err == nil {
 				issuerDirKey := keylet.OwnerDir(issuerID)
-				if result := tx.DirRemoveOrBadLedger(ctx.View, issuerDirKey, escrowEntry.IssuerNode, escrowKey.Key); result != tx.TesSUCCESS {
+				if result := tx.DirRemoveOrBadLedger(ctx.View, issuerDirKey, escrowEntry.IssuerNode, escrowKey.Key); result != ter.TesSUCCESS {
 					return result
 				}
 			}
@@ -261,10 +262,10 @@ func (e *EscrowCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled Escrow.cpp doApply() line 1405
 	if err := ctx.View.Erase(escrowKey); err != nil {
 		ctx.Log.Error("escrow cancel: failed to erase escrow", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // ownerReserveSnapshot returns the escrow owner's balance and owner count for the

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -10,6 +10,7 @@ import (
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -76,25 +77,25 @@ func (e *EscrowCreate) Validate() error {
 	// Reference: rippled Escrow.cpp preflight lines 130-148, escrowCreatePreflightHelper<Issue>
 	if e.Amount.IsNative() {
 		if e.Amount.IsZero() || e.Amount.IsNegative() {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "Amount must be positive")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
 		}
 	} else if !e.Amount.IsMPT() {
 		if e.Amount.Currency == "" || e.Amount.Currency == "XRP" {
-			return tx.Errorf(tx.TemBAD_CURRENCY, "cannot escrow XRP as IOU")
+			return ter.Errorf(ter.TemBAD_CURRENCY, "cannot escrow XRP as IOU")
 		}
 	}
 
 	// Must have at least one timeout value
 	// Reference: rippled Escrow.cpp:151-152
 	if e.CancelAfter == nil && e.FinishAfter == nil {
-		return tx.Errorf(tx.TemBAD_EXPIRATION, "must specify CancelAfter or FinishAfter")
+		return ter.Errorf(ter.TemBAD_EXPIRATION, "must specify CancelAfter or FinishAfter")
 	}
 
 	// If both times are specified, CancelAfter must be strictly after FinishAfter
 	// Reference: rippled Escrow.cpp:156-158
 	if e.CancelAfter != nil && e.FinishAfter != nil {
 		if *e.CancelAfter <= *e.FinishAfter {
-			return tx.Errorf(tx.TemBAD_EXPIRATION, "CancelAfter must be after FinishAfter")
+			return ter.Errorf(ter.TemBAD_EXPIRATION, "CancelAfter must be after FinishAfter")
 		}
 	}
 
@@ -105,10 +106,10 @@ func (e *EscrowCreate) Validate() error {
 	// Reference: rippled Escrow.cpp:170-190 condition deserialization
 	if e.Condition != nil {
 		if *e.Condition == "" {
-			return tx.Errorf(tx.TemMALFORMED, "empty condition")
+			return ter.Errorf(ter.TemMALFORMED, "empty condition")
 		}
 		if err := ValidateConditionFormat(*e.Condition); err != nil {
-			return tx.Errorf(tx.TemMALFORMED, "invalid condition")
+			return ter.Errorf(ter.TemMALFORMED, "invalid condition")
 		}
 	}
 
@@ -134,7 +135,7 @@ func (e *EscrowCreate) Flatten() (map[string]any, error) {
 // tecNO_PERMISSION on the final pass even though the initial apply succeeded.
 // Reference: rippled Escrow.cpp EscrowCreate::preclaim() lines 362-395 and
 // doApply() lines 457-489.
-func (e *EscrowCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Result {
+func (e *EscrowCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Result {
 	rules := config.GetRules()
 	closeTime := config.ParentCloseTime
 
@@ -147,7 +148,7 @@ func (e *EscrowCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.R
 	// the result is tem-only (never enters a ledger) so there is no consensus
 	// divergence.
 	if rules.Enabled(amendment.FeatureFix1543) && (e.GetFlags()&tx.TfUniversalMask) != 0 {
-		return tx.TemINVALID_FLAG
+		return ter.TemINVALID_FLAG
 	}
 
 	// Non-XRP preflight checks are all gated behind featureTokenEscrow: when it
@@ -159,9 +160,9 @@ func (e *EscrowCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.R
 	// Reference: rippled Escrow.cpp preflight lines 130-148, 88-119
 	if !e.Amount.IsNative() {
 		if !rules.Enabled(amendment.FeatureTokenEscrow) {
-			return tx.TemBAD_AMOUNT
+			return ter.TemBAD_AMOUNT
 		}
-		if result := escrowCreateNonXRPPreflight(rules, e.Amount); result != tx.TesSUCCESS {
+		if result := escrowCreateNonXRPPreflight(rules, e.Amount); result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -171,38 +172,38 @@ func (e *EscrowCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.R
 	// fix1571. Reference: rippled Escrow.cpp:160-167
 	if rules.Enabled(amendment.FeatureFix1571) {
 		if e.FinishAfter == nil && (e.Condition == nil || *e.Condition == "") {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 	}
 
 	accountID, err := state.DecodeAccountID(e.Account)
 	if err != nil {
-		return tx.TemBAD_SRC_ACCOUNT
+		return ter.TemBAD_SRC_ACCOUNT
 	}
 	destID, err := state.DecodeAccountID(e.Destination)
 	if err != nil {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	// Destination must exist and not be a pseudo-account.
 	// Reference: rippled Escrow.cpp:369-378
 	destAccount, result := readDestinationForEscrow(view, destID)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 	if destAccount.IsPseudoAccount() {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Non-XRP token preclaim helpers.
 	// Reference: rippled Escrow.cpp:380-393
 	if !e.Amount.IsNative() {
 		if e.Amount.IsMPT() {
-			if result := escrowCreatePreclaimMPT(view, rules, accountID, destID, e.Amount); result != tx.TesSUCCESS {
+			if result := escrowCreatePreclaimMPT(view, rules, accountID, destID, e.Amount); result != ter.TesSUCCESS {
 				return result
 			}
 		} else {
-			if result := escrowCreatePreclaimIOU(view, accountID, destID, e.Amount); result != tx.TesSUCCESS {
+			if result := escrowCreatePreclaimIOU(view, accountID, destID, e.Amount); result != ter.TesSUCCESS {
 				return result
 			}
 		}
@@ -213,37 +214,37 @@ func (e *EscrowCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.R
 	if rules.Enabled(amendment.FeatureFix1571) {
 		// fix1571: after() means strictly greater than
 		if e.CancelAfter != nil && closeTime > *e.CancelAfter {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 		if e.FinishAfter != nil && closeTime > *e.FinishAfter {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	} else {
 		// pre-fix1571: >= comparison
 		if e.CancelAfter != nil && closeTime >= *e.CancelAfter {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 		if e.FinishAfter != nil && closeTime >= *e.FinishAfter {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // readDestinationForEscrow reads and parses the destination AccountRoot from a
 // LedgerView, returning tecNO_DST if it is absent. Used by Preclaim where there
 // is no ApplyContext.
-func readDestinationForEscrow(view tx.LedgerView, destID [20]byte) (*state.AccountRoot, tx.Result) {
+func readDestinationForEscrow(view tx.LedgerView, destID [20]byte) (*state.AccountRoot, ter.Result) {
 	data, err := view.Read(keylet.Account(destID))
 	if err != nil || data == nil {
-		return nil, tx.TecNO_DST
+		return nil, ter.TecNO_DST
 	}
 	acct, err := state.ParseAccountRoot(data)
 	if err != nil {
-		return nil, tx.TefINTERNAL
+		return nil, ter.TefINTERNAL
 	}
-	return acct, tx.TesSUCCESS
+	return acct, ter.TesSUCCESS
 }
 
 // escrowCreateNonXRPPreflight runs the per-asset preflight validity checks for a
@@ -252,29 +253,29 @@ func readDestinationForEscrow(view tx.LedgerView, destID [20]byte) (*state.Accou
 // amounts require featureMPTokensV1 and must be positive and within range.
 // Reference: rippled Escrow.cpp escrowCreatePreflightHelper<Issue> lines 92-103
 // and escrowCreatePreflightHelper<MPTIssue> lines 106-119.
-func escrowCreateNonXRPPreflight(rules *amendment.Rules, amount tx.Amount) tx.Result {
+func escrowCreateNonXRPPreflight(rules *amendment.Rules, amount tx.Amount) ter.Result {
 	if amount.IsMPT() {
 		if !rules.Enabled(amendment.FeatureMPTokensV1) {
-			return tx.TemDISABLED
+			return ter.TemDISABLED
 		}
 		if amount.IsZero() || amount.IsNegative() {
-			return tx.TemBAD_AMOUNT
+			return ter.TemBAD_AMOUNT
 		}
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	if amount.IsZero() || amount.IsNegative() {
-		return tx.TemBAD_AMOUNT
+		return ter.TemBAD_AMOUNT
 	}
 	if amount.Currency == "" || amount.Currency == "XRP" {
-		return tx.TemBAD_CURRENCY
+		return ter.TemBAD_CURRENCY
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // Apply applies an EscrowCreate transaction
 // Reference: rippled Escrow.cpp EscrowCreate::doApply()
-func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
+func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("escrow create apply",
 		"account", e.Account,
 		"destination", e.Destination,
@@ -300,7 +301,7 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 			"balance", ctx.Account.Balance,
 			"reserve", reserve,
 		)
-		return tx.TecINSUFFICIENT_RESERVE
+		return ter.TecINSUFFICIENT_RESERVE
 	}
 
 	// For XRP escrows, also check that the sender can afford the amount
@@ -310,14 +311,14 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	if isNative {
 		drops := e.Amount.Drops()
 		if drops <= 0 {
-			return tx.TemINVALID
+			return ter.TemINVALID
 		}
 		if ctx.Account.Balance < reserve+uint64(drops) {
 			ctx.Log.Warn("escrow create: unfunded",
 				"balance", ctx.Account.Balance,
 				"needed", reserve+uint64(drops),
 			)
-			return tx.TecUNFUNDED
+			return ter.TecUNFUNDED
 		}
 	}
 
@@ -327,7 +328,7 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	// follows the reserve/unfunded checks.
 	// Reference: rippled Escrow.cpp:511-526
 	destAccount, destID, result := ctx.LookupDestination(e.Destination)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		ctx.Log.Warn("escrow create: destination lookup failed",
 			"destination", e.Destination,
 			"result", result,
@@ -341,14 +342,14 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Warn("escrow create: destination tag required",
 			"destination", e.Destination,
 		)
-		return tx.TecDST_TAG_NEEDED
+		return ter.TecDST_TAG_NEEDED
 	}
 
 	// DisallowXRP check (only when DepositAuth amendment is NOT enabled)
 	// Reference: rippled Escrow.cpp:523-525
 	if !rules.Enabled(amendment.FeatureDepositAuth) {
 		if (destAccount.Flags & state.LsfDisallowXRP) != 0 {
-			return tx.TecNO_TARGET
+			return ter.TecNO_TARGET
 		}
 	}
 
@@ -398,7 +399,7 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	})
 	if err != nil {
 		ctx.Log.Error("escrow create: owner directory full", "error", err)
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 	ownerNode := ownerResult.Page
 
@@ -416,7 +417,7 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		})
 		if derr != nil {
 			ctx.Log.Error("escrow create: destination directory full", "error", derr)
-			return tx.TecDIR_FULL
+			return ter.TecDIR_FULL
 		}
 		destNode = destResult.Page
 		hasDestNode = true
@@ -436,7 +437,7 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 			})
 			if ierr != nil {
 				ctx.Log.Error("escrow create: issuer directory full", "error", ierr)
-				return tx.TecDIR_FULL
+				return ter.TecDIR_FULL
 			}
 			issuerNode = issuerResult.Page
 			hasIssuerNode = true
@@ -447,13 +448,13 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		ownerNode, destNode, hasDestNode, issuerNode, hasIssuerNode)
 	if err != nil {
 		ctx.Log.Error("escrow create: failed to serialize escrow", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Insert escrow - creation tracked automatically by ApplyStateTable
 	if err := ctx.View.Insert(escrowKey, escrowData); err != nil {
 		ctx.Log.Error("escrow create: failed to insert escrow", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Deduct the escrow amount from the sender.
@@ -464,7 +465,7 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	} else if e.Amount.IsMPT() {
 		// MPT: lock via MPToken/MPTIssuance fields
 		// Reference: rippled View.cpp rippleLockEscrowMPT()
-		if lockResult := escrowLockMPT(ctx.View, accountID, e.Amount); lockResult != tx.TesSUCCESS {
+		if lockResult := escrowLockMPT(ctx.View, accountID, e.Amount); lockResult != ter.TesSUCCESS {
 			return lockResult
 		}
 	} else {
@@ -472,12 +473,12 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Reference: rippled escrowLockApplyHelper<Issue>
 		issuerID, issuerErr := state.DecodeAccountID(e.Amount.Issuer)
 		if issuerErr != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if issuerID == accountID {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
-		if lockResult := escrowLockIOU(ctx.View, accountID, issuerID, e.Amount); lockResult != tx.TesSUCCESS {
+		if lockResult := escrowLockIOU(ctx.View, accountID, issuerID, e.Amount); lockResult != ter.TesSUCCESS {
 			return lockResult
 		}
 	}
@@ -485,7 +486,7 @@ func (e *EscrowCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Increase owner count for the escrow creator
 	ctx.Account.OwnerCount++
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // serializeEscrow serializes an Escrow ledger entry.
@@ -591,6 +592,6 @@ func serializeEscrow(txn *EscrowCreate, ownerID, destID [20]byte, transferRate u
 // missing line means there is no balance to escrow (tecNO_LINE). A genuine view
 // read error is the corrupt-ledger case (tecINTERNAL).
 // Reference: rippled Escrow.cpp:408-431
-func escrowLockIOU(view tx.LedgerView, senderID, issuerID [20]byte, amount tx.Amount) tx.Result {
-	return rippleCreditEscrow(view, senderID, issuerID, amount, tx.TecINTERNAL, tx.TecNO_LINE)
+func escrowLockIOU(view tx.LedgerView, senderID, issuerID [20]byte, amount tx.Amount) ter.Result {
+	return rippleCreditEscrow(view, senderID, issuerID, amount, ter.TecINTERNAL, ter.TecNO_LINE)
 }

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -102,7 +103,7 @@ func (e *EscrowFinish) CalculateBaseFee(view tx.LedgerView, config tx.EngineConf
 		}
 	}
 
-	fee := tx.CalculateMultiSigFee(base, len(e.GetCommon().Signers))
+	fee := sign.CalculateMultiSigFee(base, len(e.GetCommon().Signers))
 
 	if e.Fulfillment != nil {
 		fulfillmentLen := len(*e.Fulfillment) / 2

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -57,7 +58,7 @@ func (e *EscrowFinish) Validate() error {
 	// where the amendment rules are available.
 
 	if e.Owner == "" {
-		return tx.Errorf(tx.TemMALFORMED, "Owner is required")
+		return ter.Errorf(ter.TemMALFORMED, "Owner is required")
 	}
 
 	// Both Condition and Fulfillment must be present or absent together
@@ -66,7 +67,7 @@ func (e *EscrowFinish) Validate() error {
 	hasCondition := e.Condition != nil
 	hasFulfillment := e.Fulfillment != nil
 	if hasCondition != hasFulfillment {
-		return tx.Errorf(tx.TemMALFORMED, "Condition and Fulfillment must be provided together")
+		return ter.Errorf(ter.TemMALFORMED, "Condition and Fulfillment must be provided together")
 	}
 
 	// Validate CredentialIDs field
@@ -121,11 +122,11 @@ func (e *EscrowFinish) CalculateBaseFee(view tx.LedgerView, config tx.EngineConf
 // after the common preflight/preclaim steps. For a tx malformed in two ways this
 // can surface a different tem code than rippled; the result is tem-only (never
 // enters a ledger) so there is no consensus divergence.
-func (e *EscrowFinish) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
+func (e *EscrowFinish) Preclaim(_ tx.LedgerView, config tx.EngineConfig) ter.Result {
 	if config.GetRules().Enabled(amendment.FeatureFix1543) && (e.GetFlags()&tx.TfUniversalMask) != 0 {
-		return tx.TemINVALID_FLAG
+		return ter.TemINVALID_FLAG
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // ApplyOnTec implements TecApplier. When tecEXPIRED is returned, this re-runs
@@ -139,7 +140,7 @@ func (e *EscrowFinish) ApplyOnTec(ctx *tx.ApplyContext) {
 
 // Apply applies an EscrowFinish transaction
 // Reference: rippled Escrow.cpp EscrowFinish::preclaim() + doApply()
-func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
+func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("escrow finish apply",
 		"account", e.Account,
 		"owner", e.Owner,
@@ -151,7 +152,7 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Amendment-gated check: CredentialIDs requires Credentials amendment
 	// Reference: rippled Escrow.cpp preflight() credential check
 	if len(e.CredentialIDs) > 0 && !rules.Enabled(amendment.FeatureCredentials) {
-		return tx.TemDISABLED
+		return ter.TemDISABLED
 	}
 
 	// --- Preclaim: credential validation (before time checks) ---
@@ -159,14 +160,14 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	// This must run before doApply's time checks because rippled's preclaim
 	// runs before doApply.
 	if len(e.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-		if result := credential.ValidateCredentialIDs(ctx, e.CredentialIDs); result != tx.TesSUCCESS {
+		if result := credential.ValidateCredentialIDs(ctx, e.CredentialIDs); result != ter.TesSUCCESS {
 			return result
 		}
 	}
 
 	ownerID, err := state.DecodeAccountID(e.Owner)
 	if err != nil {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	// Find the escrow
@@ -177,14 +178,14 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 			"owner", e.Owner,
 			"offerSequence", e.OfferSequence,
 		)
-		return tx.TecNO_TARGET
+		return ter.TecNO_TARGET
 	}
 
 	// Parse escrow
 	escrowEntry, err := state.ParseEscrow(escrowData)
 	if err != nil {
 		ctx.Log.Error("escrow finish: failed to parse escrow", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	isXRP := escrowEntry.IsXRP
@@ -194,11 +195,11 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	if !isXRP && rules.Enabled(amendment.FeatureTokenEscrow) {
 		escrowAmount := reconstructAmountFromEscrow(escrowEntry)
 		if escrowEntry.MPTIssuanceID != "" {
-			if result := escrowFinishPreclaimMPT(ctx.View, escrowEntry.DestinationID, escrowAmount); result != tx.TesSUCCESS {
+			if result := escrowFinishPreclaimMPT(ctx.View, escrowEntry.DestinationID, escrowAmount); result != ter.TesSUCCESS {
 				return result
 			}
 		} else if escrowAmount.Issuer != "" {
-			if result := escrowFinishPreclaimIOU(ctx.View, escrowEntry.DestinationID, escrowAmount); result != tx.TesSUCCESS {
+			if result := escrowFinishPreclaimIOU(ctx.View, escrowEntry.DestinationID, escrowAmount); result != ter.TesSUCCESS {
 				return result
 			}
 		}
@@ -211,19 +212,19 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	if rules.Enabled(amendment.FeatureFix1571) {
 		// fix1571: FinishAfter check — close time must be strictly after finish time
 		if escrowEntry.FinishAfter > 0 && closeTime <= escrowEntry.FinishAfter {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 		// fix1571: CancelAfter check — if past cancel time, finish not allowed
 		if escrowEntry.CancelAfter > 0 && closeTime > escrowEntry.CancelAfter {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	} else {
 		// Pre-fix1571: both use <= comparison (known bug in cancel check)
 		if escrowEntry.FinishAfter > 0 && closeTime <= escrowEntry.FinishAfter {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 		if escrowEntry.CancelAfter > 0 && closeTime <= escrowEntry.CancelAfter {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	}
 
@@ -242,25 +243,25 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Escrow has no condition — tx must NOT provide condition/fulfillment
 		if txCondition != "" || txFulfillment != "" {
 			ctx.Log.Warn("escrow finish: condition/fulfillment provided but escrow has no condition")
-			return tx.TecCRYPTOCONDITION_ERROR
+			return ter.TecCRYPTOCONDITION_ERROR
 		}
 	} else {
 		// Escrow has a condition — fulfillment is required (non-empty)
 		if txFulfillment == "" {
 			ctx.Log.Warn("escrow finish: fulfillment required but not provided")
-			return tx.TecCRYPTOCONDITION_ERROR
+			return ter.TecCRYPTOCONDITION_ERROR
 		}
 
 		// Condition in tx must match condition on escrow (case-insensitive hex comparison)
 		if !strings.EqualFold(txCondition, escrowEntry.Condition) {
 			ctx.Log.Warn("escrow finish: condition mismatch")
-			return tx.TecCRYPTOCONDITION_ERROR
+			return ter.TecCRYPTOCONDITION_ERROR
 		}
 
 		// Verify fulfillment matches condition
 		if err := validateCryptoCondition(txFulfillment, escrowEntry.Condition); err != nil {
 			ctx.Log.Debug("escrow finish: fulfillment verification failed", "error", err)
-			return tx.TecCRYPTOCONDITION_ERROR
+			return ter.TecCRYPTOCONDITION_ERROR
 		}
 		ctx.Log.Debug("escrow finish: fulfillment verified successfully")
 	}
@@ -280,11 +281,11 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 		// account, so this is tecNO_DST — not a parse-time tefINTERNAL.
 		// Reference: rippled Escrow.cpp:1105-1108
 		if err != nil || destData == nil {
-			return tx.TecNO_DST
+			return ter.TecNO_DST
 		}
 		destAccount, err = state.ParseAccountRoot(destData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
@@ -292,7 +293,7 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	// matching rippled; expired-credential removal happens inside.
 	// Reference: rippled Escrow.cpp doApply() — verifyDepositPreauth()
 	if rules.Enabled(amendment.FeatureDepositAuth) {
-		if result := credential.VerifyDepositPreauth(ctx, e.CredentialIDs, ctx.AccountID, escrowEntry.DestinationID, destAccount); result != tx.TesSUCCESS {
+		if result := credential.VerifyDepositPreauth(ctx, e.CredentialIDs, ctx.AccountID, escrowEntry.DestinationID, destAccount); result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -300,7 +301,7 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Remove escrow from owner directory
 	// Reference: rippled Escrow.cpp doApply() lines 1120-1129
 	ownerDirKey := keylet.OwnerDir(escrowEntry.Account)
-	if result := tx.DirRemoveOrBadLedger(ctx.View, ownerDirKey, escrowEntry.OwnerNode, escrowKey.Key); result != tx.TesSUCCESS {
+	if result := tx.DirRemoveOrBadLedger(ctx.View, ownerDirKey, escrowEntry.OwnerNode, escrowKey.Key); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -308,7 +309,7 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled Escrow.cpp doApply() lines 1132-1140
 	if escrowEntry.HasDestNode {
 		destDirKey := keylet.OwnerDir(escrowEntry.DestinationID)
-		if result := tx.DirRemoveOrBadLedger(ctx.View, destDirKey, escrowEntry.DestinationNode, escrowKey.Key); result != tx.TesSUCCESS {
+		if result := tx.DirRemoveOrBadLedger(ctx.View, destDirKey, escrowEntry.DestinationNode, escrowKey.Key); result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -320,7 +321,7 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 		destAccount.Balance += escrowEntry.Amount
 	} else {
 		if !rules.Enabled(amendment.FeatureTokenEscrow) {
-			return tx.TemDISABLED
+			return ter.TemDISABLED
 		}
 
 		escrowAmount := reconstructAmountFromEscrow(escrowEntry)
@@ -384,7 +385,7 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 				true, // finish bumps the destination account's OwnerCount
 				ctx.Config.ReserveBase,
 				ctx.Config.ReserveIncrement,
-			); result != tx.TesSUCCESS {
+			); result != ter.TesSUCCESS {
 				return result
 			}
 		} else {
@@ -403,7 +404,7 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 				true, // finish bumps the destination account's OwnerCount
 				ctx.Config.ReserveBase,
 				ctx.Config.ReserveIncrement,
-			); result != tx.TesSUCCESS {
+			); result != ter.TesSUCCESS {
 				return result
 			}
 		}
@@ -414,7 +415,7 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 			issuerID, issuerErr := state.DecodeAccountID(escrowAmount.Issuer)
 			if issuerErr == nil {
 				issuerDirKey := keylet.OwnerDir(issuerID)
-				if result := tx.DirRemoveOrBadLedger(ctx.View, issuerDirKey, escrowEntry.IssuerNode, escrowKey.Key); result != tx.TesSUCCESS {
+				if result := tx.DirRemoveOrBadLedger(ctx.View, issuerDirKey, escrowEntry.IssuerNode, escrowKey.Key); result != ter.TesSUCCESS {
 					return result
 				}
 			}
@@ -438,7 +439,7 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Write destination account back
 	// Reference: rippled Escrow.cpp doApply() line 1186: ctx_.view().update(sled);
 	if !destIsSelf {
-		if result := ctx.UpdateAccountRoot(escrowEntry.DestinationID, destAccount); result != tx.TesSUCCESS {
+		if result := ctx.UpdateAccountRoot(escrowEntry.DestinationID, destAccount); result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -447,14 +448,14 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled Escrow.cpp doApply() line 1194: ctx_.view().erase(slep);
 	if err := ctx.View.Erase(escrowKey); err != nil {
 		ctx.Log.Error("escrow finish: failed to erase escrow", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Decrement OwnerCount for escrow owner only.
 	// Reference: rippled Escrow.cpp doApply() lines 1188-1191
 	adjustOwnerCount(ctx, ownerID, -1)
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // adjustOwnerCount adjusts the OwnerCount of the given account by delta.

--- a/internal/tx/escrow/escrow_finish_nodst_test.go
+++ b/internal/tx/escrow/escrow_finish_nodst_test.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/LeJamon/go-xrpl/amendment"
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
-	"github.com/stretchr/testify/require"
 )
 
 // TestEscrowFinish_DeletedDestination_TecNO_DST verifies that finishing an
@@ -88,6 +90,6 @@ func TestEscrowFinish_DeletedDestination_TecNO_DST(t *testing.T) {
 	}
 
 	result := finish.Apply(ctx)
-	require.Equal(t, tx.TecNO_DST, result,
+	require.Equal(t, ter.TecNO_DST, result,
 		"finishing an escrow with a deleted destination must be tecNO_DST, not tefINTERNAL")
 }

--- a/internal/tx/escrow/token_helpers.go
+++ b/internal/tx/escrow/token_helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	entry "github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -23,36 +24,36 @@ const parityRate uint32 = 1_000_000_000
 
 // escrowCreatePreclaimIOU validates IOU escrow creation preconditions.
 // Reference: rippled Escrow.cpp escrowCreatePreclaimHelper<Issue> lines 204-279
-func escrowCreatePreclaimIOU(view tx.LedgerView, accountID, destID [20]byte, amount tx.Amount) tx.Result {
+func escrowCreatePreclaimIOU(view tx.LedgerView, accountID, destID [20]byte, amount tx.Amount) ter.Result {
 	issuerID, err := state.DecodeAccountID(amount.Issuer)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Issuer cannot create escrow of own tokens
 	if issuerID == accountID {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Issuer must exist and have lsfAllowTrustLineLocking
 	sleIssuer, err := tx.ReadAccountRoot(view, issuerID)
 	if err != nil || sleIssuer == nil {
-		return tx.TecNO_ISSUER
+		return ter.TecNO_ISSUER
 	}
 	if sleIssuer.Flags&state.LsfAllowTrustLineLocking == 0 {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Trust line must exist
 	trustLineKey := keylet.Line(accountID, issuerID, amount.Currency)
 	trustLineData, err := view.Read(trustLineKey)
 	if err != nil || trustLineData == nil {
-		return tx.TecNO_LINE
+		return ter.TecNO_LINE
 	}
 
 	rs, err := state.ParseRippleState(trustLineData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Balance direction validation
@@ -60,129 +61,129 @@ func escrowCreatePreclaimIOU(view tx.LedgerView, accountID, destID [20]byte, amo
 	// If balance is positive, issuer must have higher address than account
 	// If balance is negative, issuer must have lower address than account
 	if rs.Balance.Signum() > 0 && state.CompareAccountIDsForLine(issuerID, accountID) < 0 {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 	if rs.Balance.Signum() < 0 && state.CompareAccountIDsForLine(issuerID, accountID) > 0 {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// requireAuth for sender
-	if ter := requireAuthIOU(view, issuerID, accountID, amount.Currency); ter != tx.TesSUCCESS {
-		return ter
+	if tr := requireAuthIOU(view, issuerID, accountID, amount.Currency); tr != ter.TesSUCCESS {
+		return tr
 	}
 
 	// requireAuth for destination
-	if ter := requireAuthIOU(view, issuerID, destID, amount.Currency); ter != tx.TesSUCCESS {
-		return ter
+	if tr := requireAuthIOU(view, issuerID, destID, amount.Currency); tr != ter.TesSUCCESS {
+		return tr
 	}
 
 	// Freeze checks (global freeze + issuer-side individual freeze)
 	asset := tx.Asset{Currency: amount.Currency, Issuer: amount.Issuer}
 	if tx.IsFrozen(view, accountID, asset) {
-		return tx.TecFROZEN
+		return ter.TecFROZEN
 	}
 	if tx.IsFrozen(view, destID, asset) {
-		return tx.TecFROZEN
+		return ter.TecFROZEN
 	}
 
 	// Spendable amount check (ignore freeze since we already checked)
 	spendable := accountHoldsIOU(view, accountID, issuerID, amount.Currency)
 	if spendable.Signum() <= 0 {
-		return tx.TecINSUFFICIENT_FUNDS
+		return ter.TecINSUFFICIENT_FUNDS
 	}
 	if spendable.Compare(amount) < 0 {
-		return tx.TecINSUFFICIENT_FUNDS
+		return ter.TecINSUFFICIENT_FUNDS
 	}
 
 	// Precision loss check: if the spendable amount and escrow amount differ
 	// so much in magnitude that IOU addition loses the smaller value, reject.
 	// Reference: rippled Escrow.cpp line 275: if (!canAdd(spendableAmount, amount))
 	if !canAddIOUAmounts(spendable, amount) {
-		return tx.TecPRECISION_LOSS
+		return ter.TecPRECISION_LOSS
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // escrowCreatePreclaimMPT validates MPT escrow creation preconditions.
 // Reference: rippled Escrow.cpp escrowCreatePreclaimHelper<MPTIssue> lines 283-359
-func escrowCreatePreclaimMPT(view tx.LedgerView, rules *amendment.Rules, accountID, destID [20]byte, amount tx.Amount) tx.Result {
+func escrowCreatePreclaimMPT(view tx.LedgerView, rules *amendment.Rules, accountID, destID [20]byte, amount tx.Amount) ter.Result {
 	// FeatureMPTokensV1 must be enabled
 	if !rules.Enabled(amendment.FeatureMPTokensV1) {
-		return tx.TemDISABLED
+		return ter.TemDISABLED
 	}
 
 	// MPT amounts store the issuer in the MPTIssuanceID (last 20 bytes),
 	// not in Amount.Issuer which is empty for MPT.
 	issuerID, err := mptIssuerAccountID(amount.MPTIssuanceID())
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Issuer cannot create escrow
 	if issuerID == accountID {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// MPTIssuance must exist
 	issuanceKey, err := mptIssuanceKeyFromHex(amount.MPTIssuanceID())
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	issuanceData, err := view.Read(issuanceKey)
 	if err != nil || issuanceData == nil {
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	issuance, err := state.ParseMPTokenIssuance(issuanceData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Must have lsfMPTCanEscrow flag
 	if issuance.Flags&entry.LsfMPTCanEscrow == 0 {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Issuance issuer must match amount issuer
 	if issuance.Issuer != issuerID {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Sender must hold MPToken
 	tokenKey := keylet.MPToken(issuanceKey.Key, accountID)
 	exists, _ := view.Exists(tokenKey)
 	if !exists {
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	// requireAuth for sender (WeakAuth)
-	if ter := requireMPTAuthForEscrow(view, issuance.Flags, issuanceKey, accountID, issuerID); ter != tx.TesSUCCESS {
-		return ter
+	if tr := requireMPTAuthForEscrow(view, issuance.Flags, issuanceKey, accountID, issuerID); tr != ter.TesSUCCESS {
+		return tr
 	}
 
 	// requireAuth for destination (WeakAuth)
-	if ter := requireMPTAuthForEscrow(view, issuance.Flags, issuanceKey, destID, issuerID); ter != tx.TesSUCCESS {
-		return ter
+	if tr := requireMPTAuthForEscrow(view, issuance.Flags, issuanceKey, destID, issuerID); tr != ter.TesSUCCESS {
+		return tr
 	}
 
 	// Frozen checks (global lock on issuance or individual lock on token)
 	if isMPTFrozen(view, issuance.Flags, issuanceKey, accountID, issuerID) {
-		return tx.TecLOCKED
+		return ter.TecLOCKED
 	}
 	if isMPTFrozen(view, issuance.Flags, issuanceKey, destID, issuerID) {
-		return tx.TecLOCKED
+		return ter.TecLOCKED
 	}
 
 	// canTransfer check (holder-to-holder needs LsfMPTCanTransfer)
-	if ter := canTransferMPT(issuance, accountID, destID); ter != tx.TesSUCCESS {
-		return ter
+	if tr := canTransferMPT(issuance, accountID, destID); tr != ter.TesSUCCESS {
+		return tr
 	}
 
 	// Balance check (ignore freeze since we already checked)
 	spendable := accountHoldsMPT(view, issuanceKey, accountID)
 	if spendable <= 0 {
-		return tx.TecINSUFFICIENT_FUNDS
+		return ter.TecINSUFFICIENT_FUNDS
 	}
 
 	raw, ok := amount.MPTRaw()
@@ -191,142 +192,142 @@ func escrowCreatePreclaimMPT(view tx.LedgerView, rules *amendment.Rules, account
 		raw = amount.IOU().Mantissa()
 	}
 	if spendable < raw {
-		return tx.TecINSUFFICIENT_FUNDS
+		return ter.TecINSUFFICIENT_FUNDS
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // 2. EscrowFinish Preclaim Helpers
 
 // escrowFinishPreclaimIOU validates IOU escrow finish preconditions.
 // Reference: rippled Escrow.cpp lines 702-724
-func escrowFinishPreclaimIOU(view tx.LedgerView, destID [20]byte, amount tx.Amount) tx.Result {
+func escrowFinishPreclaimIOU(view tx.LedgerView, destID [20]byte, amount tx.Amount) ter.Result {
 	issuerID, err := state.DecodeAccountID(amount.Issuer)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// If dest == issuer, return tesSUCCESS
 	if issuerID == destID {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// requireAuth on destination
-	if ter := requireAuthIOU(view, issuerID, destID, amount.Currency); ter != tx.TesSUCCESS {
-		return ter
+	if tr := requireAuthIOU(view, issuerID, destID, amount.Currency); tr != ter.TesSUCCESS {
+		return tr
 	}
 
 	// Deep freeze check on destination
 	if tx.IsDeepFrozen(view, destID, issuerID, amount.Currency) {
-		return tx.TecFROZEN
+		return ter.TecFROZEN
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // escrowFinishPreclaimMPT validates MPT escrow finish preconditions.
 // Reference: rippled Escrow.cpp lines 726-758
-func escrowFinishPreclaimMPT(view tx.LedgerView, destID [20]byte, amount tx.Amount) tx.Result {
+func escrowFinishPreclaimMPT(view tx.LedgerView, destID [20]byte, amount tx.Amount) ter.Result {
 	// MPT amounts store the issuer in the MPTIssuanceID (last 20 bytes),
 	// not in Amount.Issuer which is empty for MPT.
 	issuerID, err := mptIssuerAccountID(amount.MPTIssuanceID())
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// If dest == issuer, return tesSUCCESS
 	if issuerID == destID {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// MPTIssuance must exist
 	issuanceKey, err := mptIssuanceKeyFromHex(amount.MPTIssuanceID())
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	issuanceData, err := view.Read(issuanceKey)
 	if err != nil || issuanceData == nil {
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	issuance, err := state.ParseMPTokenIssuance(issuanceData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// requireAuth on destination (WeakAuth)
-	if ter := requireMPTAuthForEscrow(view, issuance.Flags, issuanceKey, destID, issuerID); ter != tx.TesSUCCESS {
-		return ter
+	if tr := requireMPTAuthForEscrow(view, issuance.Flags, issuanceKey, destID, issuerID); tr != ter.TesSUCCESS {
+		return tr
 	}
 
 	// Frozen check on destination
 	if isMPTFrozen(view, issuance.Flags, issuanceKey, destID, issuerID) {
-		return tx.TecLOCKED
+		return ter.TecLOCKED
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // 3. EscrowCancel Preclaim Helpers
 
 // escrowCancelPreclaimIOU validates IOU escrow cancel preconditions.
 // Reference: rippled Escrow.cpp lines 1219-1237
-func escrowCancelPreclaimIOU(view tx.LedgerView, accountID [20]byte, amount tx.Amount) tx.Result {
+func escrowCancelPreclaimIOU(view tx.LedgerView, accountID [20]byte, amount tx.Amount) ter.Result {
 	issuerID, err := state.DecodeAccountID(amount.Issuer)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Issuer == account is an internal error
 	if issuerID == accountID {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	// requireAuth on account
-	if ter := requireAuthIOU(view, issuerID, accountID, amount.Currency); ter != tx.TesSUCCESS {
-		return ter
+	if tr := requireAuthIOU(view, issuerID, accountID, amount.Currency); tr != ter.TesSUCCESS {
+		return tr
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // escrowCancelPreclaimMPT validates MPT escrow cancel preconditions.
 // Reference: rippled Escrow.cpp lines 1239-1267
-func escrowCancelPreclaimMPT(view tx.LedgerView, accountID [20]byte, amount tx.Amount) tx.Result {
+func escrowCancelPreclaimMPT(view tx.LedgerView, accountID [20]byte, amount tx.Amount) ter.Result {
 	// MPT amounts store the issuer in the MPTIssuanceID (last 20 bytes),
 	// not in Amount.Issuer which is empty for MPT.
 	issuerID, err := mptIssuerAccountID(amount.MPTIssuanceID())
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Issuer == account is an internal error
 	if issuerID == accountID {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	// MPTIssuance must exist
 	issuanceKey, err := mptIssuanceKeyFromHex(amount.MPTIssuanceID())
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	issuanceData, err := view.Read(issuanceKey)
 	if err != nil || issuanceData == nil {
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	issuance, err := state.ParseMPTokenIssuance(issuanceData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// requireAuth on account (WeakAuth)
-	if ter := requireMPTAuthForEscrow(view, issuance.Flags, issuanceKey, accountID, issuerID); ter != tx.TesSUCCESS {
-		return ter
+	if tr := requireMPTAuthForEscrow(view, issuance.Flags, issuanceKey, accountID, issuerID); tr != ter.TesSUCCESS {
+		return tr
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // 4. Lock Helpers
@@ -334,25 +335,25 @@ func escrowCancelPreclaimMPT(view tx.LedgerView, accountID [20]byte, amount tx.A
 // escrowLockMPT locks MPT tokens by decreasing sender's MPTAmount and increasing
 // LockedAmount on both the MPToken and MPTIssuance.
 // Reference: rippled View.cpp rippleLockEscrowMPT() lines 2853-2947
-func escrowLockMPT(view tx.LedgerView, senderID [20]byte, amount tx.Amount) tx.Result {
+func escrowLockMPT(view tx.LedgerView, senderID [20]byte, amount tx.Amount) ter.Result {
 	issuanceKey, err := mptIssuanceKeyFromHex(amount.MPTIssuanceID())
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	issuanceData, err := view.Read(issuanceKey)
 	if err != nil || issuanceData == nil {
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	issuance, err := state.ParseMPTokenIssuance(issuanceData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	issuerID := issuance.Issuer
 	if issuerID == senderID {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	raw, ok := amount.MPTRaw()
@@ -365,17 +366,17 @@ func escrowLockMPT(view tx.LedgerView, senderID [20]byte, amount tx.Amount) tx.R
 	tokenKey := keylet.MPToken(issuanceKey.Key, senderID)
 	tokenData, err := view.Read(tokenKey)
 	if err != nil || tokenData == nil {
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	token, err := state.ParseMPToken(tokenData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Underflow check
 	if token.MPTAmount < pay {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	token.MPTAmount -= pay
 
@@ -385,17 +386,17 @@ func escrowLockMPT(view tx.LedgerView, senderID [20]byte, amount tx.Amount) tx.R
 		locked = *token.LockedAmount
 	}
 	if locked > ^uint64(0)-pay {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	newLocked := locked + pay
 	token.LockedAmount = &newLocked
 
 	updatedToken, err := state.SerializeMPToken(token)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := view.Update(tokenKey, updatedToken); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// 2. Update MPTIssuance: increase LockedAmount
@@ -404,20 +405,20 @@ func escrowLockMPT(view tx.LedgerView, senderID [20]byte, amount tx.Amount) tx.R
 		issuanceLocked = *issuance.LockedAmount
 	}
 	if issuanceLocked > ^uint64(0)-pay {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	newIssuanceLocked := issuanceLocked + pay
 	issuance.LockedAmount = &newIssuanceLocked
 
 	updatedIssuance, err := state.SerializeMPTokenIssuance(issuance)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := view.Update(issuanceKey, updatedIssuance); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // 5. Unlock Helpers
@@ -437,10 +438,10 @@ func escrowUnlockIOU(
 	createAsset bool,
 	bumpDestOwnerCount bool,
 	reserveBase, reserveIncrement uint64,
-) tx.Result {
+) ter.Result {
 	issuerID, err := state.DecodeAccountID(amount.Issuer)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	senderIsIssuer := issuerID == senderID
@@ -450,12 +451,12 @@ func escrowUnlockIOU(
 
 	// Sender should never be the issuer for a locked escrow
 	if senderIsIssuer {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	// If receiver is the issuer, nothing to credit (tokens return to issuer)
 	if receiverIsIssuer {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	trustLineKey := keylet.Line(receiverID, issuerID, amount.Currency)
@@ -473,22 +474,22 @@ func escrowUnlockIOU(
 		}
 		reserve := reserveBase + uint64(reserveOwnerCount+1)*reserveIncrement
 		if destBalance < reserve {
-			return tx.TecNO_LINE_INSUF_RESERVE
+			return ter.TecNO_LINE_INSUF_RESERVE
 		}
 
-		if ter := createTrustLineForEscrow(view, issuerID, receiverID, amount.Currency, destID, recvLow, bumpDestOwnerCount); ter != tx.TesSUCCESS {
-			return ter
+		if tr := createTrustLineForEscrow(view, issuerID, receiverID, amount.Currency, destID, recvLow, bumpDestOwnerCount); tr != ter.TesSUCCESS {
+			return tr
 		}
 		// Re-read after creation
 		trustLineData, err = view.Read(trustLineKey)
 		if err != nil || trustLineData == nil {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 		trustLineExists = true
 	}
 
 	if !trustLineExists && !receiverIsIssuer {
-		return tx.TecNO_LINE
+		return ter.TecNO_LINE
 	}
 
 	// Compute transfer fee
@@ -517,19 +518,19 @@ func escrowUnlockIOU(
 	// Validate the line limit if the receiver is not creating a new trust line
 	// (createAsset = false means receiver already submitted the finish tx)
 	if !createAsset {
-		if ter := checkTrustLineLimit(view, receiverID, issuerID, amount.Currency, finalAmt, issuerHigh); ter != tx.TesSUCCESS {
-			return ter
+		if tr := checkTrustLineLimit(view, receiverID, issuerID, amount.Currency, finalAmt, issuerHigh); tr != ter.TesSUCCESS {
+			return tr
 		}
 	}
 
 	// Credit the receiver via rippleCredit (issuer -> receiver)
 	if !receiverIsIssuer {
-		if ter := rippleCreditForEscrow(view, issuerID, receiverID, finalAmt); ter != tx.TesSUCCESS {
-			return ter
+		if tr := rippleCreditForEscrow(view, issuerID, receiverID, finalAmt); tr != ter.TesSUCCESS {
+			return tr
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // escrowUnlockMPT unlocks MPT tokens during EscrowFinish or EscrowCancel.
@@ -557,20 +558,20 @@ func escrowUnlockMPT(
 	destID [20]byte,
 	bumpDestOwnerCount bool,
 	reserveBase, reserveIncrement uint64,
-) tx.Result {
+) ter.Result {
 	issuanceKey, err := mptIssuanceKeyFromHex(mptHexID)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	issuanceData, err := view.Read(issuanceKey)
 	if err != nil || issuanceData == nil {
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	issuance, err := state.ParseMPTokenIssuance(issuanceData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	issuerID := issuance.Issuer
@@ -591,18 +592,18 @@ func escrowUnlockMPT(
 			}
 			reserve := reserveBase + uint64(reserveOwnerCount+1)*reserveIncrement
 			if destBalance < reserve {
-				return tx.TecINSUFFICIENT_RESERVE
+				return ter.TecINSUFFICIENT_RESERVE
 			}
 
-			if ter := createMPTokenForEscrow(view, issuanceKey, mptHexID, receiverID, destID, bumpDestOwnerCount); ter != tx.TesSUCCESS {
-				return ter
+			if tr := createMPTokenForEscrow(view, issuanceKey, mptHexID, receiverID, destID, bumpDestOwnerCount); tr != ter.TesSUCCESS {
+				return tr
 			}
 		}
 
 		// Re-check existence after potential creation
 		receiverExists, _ = view.Exists(receiverTokenKey)
 		if !receiverExists {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	}
 
@@ -613,11 +614,11 @@ func escrowUnlockMPT(
 	// 1. Decrease the Issuance LockedAmount by finalAmount
 	// Reference: rippled lines 2968-2997
 	if issuance.LockedAmount == nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	issuanceLocked := *issuance.LockedAmount
 	if issuanceLocked < finalAmount {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	newIssuanceLocked := issuanceLocked - finalAmount
 	if newIssuanceLocked == 0 {
@@ -631,7 +632,7 @@ func escrowUnlockMPT(
 		// Decrease OutstandingAmount by finalAmount (tokens are redeemed)
 		// Reference: rippled lines 3027-3044
 		if issuance.OutstandingAmount < finalAmount {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 		issuance.OutstandingAmount -= finalAmount
 	} else {
@@ -640,61 +641,61 @@ func escrowUnlockMPT(
 		receiverTokenKey := keylet.MPToken(issuanceKey.Key, receiverID)
 		receiverTokenData, err := view.Read(receiverTokenKey)
 		if err != nil || receiverTokenData == nil {
-			return tx.TecOBJECT_NOT_FOUND
+			return ter.TecOBJECT_NOT_FOUND
 		}
 
 		receiverToken, err := state.ParseMPToken(receiverTokenData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Overflow check
 		if receiverToken.MPTAmount > ^uint64(0)-finalAmount {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 		receiverToken.MPTAmount += finalAmount
 
 		updatedReceiverToken, err := state.SerializeMPToken(receiverToken)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := view.Update(receiverTokenKey, updatedReceiverToken); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
 	// Write back issuance (with updated LockedAmount and possibly OutstandingAmount)
 	updatedIssuance, err := state.SerializeMPTokenIssuance(issuance)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := view.Update(issuanceKey, updatedIssuance); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// 3. Decrease sender's MPToken LockedAmount by finalAmount
 	// Reference: rippled lines 3047-3092
 	if issuerID == senderID {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	senderTokenKey := keylet.MPToken(issuanceKey.Key, senderID)
 	senderTokenData, err := view.Read(senderTokenKey)
 	if err != nil || senderTokenData == nil {
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	senderToken, err := state.ParseMPToken(senderTokenData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if senderToken.LockedAmount == nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	senderLocked := *senderToken.LockedAmount
 	if senderLocked < finalAmount {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	newSenderLocked := senderLocked - finalAmount
 	if newSenderLocked == 0 {
@@ -705,13 +706,13 @@ func escrowUnlockMPT(
 
 	updatedSenderToken, err := state.SerializeMPToken(senderToken)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := view.Update(senderTokenKey, updatedSenderToken); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // 6. Shared Utilities
@@ -720,37 +721,37 @@ func escrowUnlockMPT(
 // is authorized on the trust line.
 // Reference: rippled View.cpp requireAuth(view, Issue, account) for IOU
 // Uses the default (legacy) auth type: trust line must exist if requireAuth is set.
-func requireAuthIOU(view tx.LedgerView, issuerID, accountID [20]byte, currency string) tx.Result {
+func requireAuthIOU(view tx.LedgerView, issuerID, accountID [20]byte, currency string) ter.Result {
 	// Issuer is always authorized for own currency
 	if issuerID == accountID {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Read issuer account. A missing issuer carries no auth requirement, matching
 	// rippled's `if (issuerAccount && requireAuth)` guard, so it passes.
 	issuerAccount, err := tx.ReadAccountRoot(view, issuerID)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if issuerAccount == nil {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// If issuer doesn't require auth, pass
 	if issuerAccount.Flags&state.LsfRequireAuth == 0 {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Issuer requires auth — check if the trust line exists and is authorized
 	trustLineKey := keylet.Line(accountID, issuerID, currency)
 	trustLineData, err := view.Read(trustLineKey)
 	if err != nil || trustLineData == nil {
-		return tx.TecNO_LINE
+		return ter.TecNO_LINE
 	}
 
 	rs, err := state.ParseRippleState(trustLineData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Check authorization flag based on account ordering
@@ -759,30 +760,30 @@ func requireAuthIOU(view tx.LedgerView, issuerID, accountID [20]byte, currency s
 	// When account < issuer: issuer is the HIGH account → check LsfHighAuth
 	if state.CompareAccountIDsForLine(accountID, issuerID) > 0 {
 		if rs.Flags&state.LsfLowAuth == 0 {
-			return tx.TecNO_AUTH
+			return ter.TecNO_AUTH
 		}
 	} else {
 		if rs.Flags&state.LsfHighAuth == 0 {
-			return tx.TecNO_AUTH
+			return ter.TecNO_AUTH
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // requireMPTAuthForEscrow checks MPT authorization for escrow operations.
 // Uses WeakAuth semantics: if account has no MPToken, pass (don't fail).
 // Only fail if lsfMPTRequireAuth is set AND MPToken exists but is not authorized.
 // Reference: rippled View.cpp requireAuth(view, MPTIssue, account, WeakAuth)
-func requireMPTAuthForEscrow(view tx.LedgerView, issuanceFlags uint32, issuanceKey keylet.Keylet, accountID, issuerID [20]byte) tx.Result {
+func requireMPTAuthForEscrow(view tx.LedgerView, issuanceFlags uint32, issuanceKey keylet.Keylet, accountID, issuerID [20]byte) ter.Result {
 	// Issuer is always authorized
 	if issuerID == accountID {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// If requireAuth is not set, pass
 	if issuanceFlags&entry.LsfMPTRequireAuth == 0 {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// WeakAuth: if MPToken doesn't exist, pass (destination may not hold yet)
@@ -790,20 +791,20 @@ func requireMPTAuthForEscrow(view tx.LedgerView, issuanceFlags uint32, issuanceK
 	tokenData, err := view.Read(tokenKey)
 	if err != nil || tokenData == nil {
 		// WeakAuth: no token is OK
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	token, err := state.ParseMPToken(tokenData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Token exists but is not authorized
 	if token.Flags&entry.LsfMPTAuthorized == 0 {
-		return tx.TecNO_AUTH
+		return ter.TecNO_AUTH
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // isMPTFrozen checks if an MPT is frozen for a given account.
@@ -838,17 +839,17 @@ func isMPTFrozen(view tx.LedgerView, issuanceFlags uint32, issuanceKey keylet.Ke
 // canTransferMPT checks if MPT can be transferred between two accounts.
 // If LsfMPTCanTransfer is not set, at least one party must be the issuer.
 // Reference: rippled View.cpp canTransfer(view, MPTIssue, from, to)
-func canTransferMPT(issuance *state.MPTokenIssuanceData, fromID, toID [20]byte) tx.Result {
+func canTransferMPT(issuance *state.MPTokenIssuanceData, fromID, toID [20]byte) ter.Result {
 	if issuance.Flags&entry.LsfMPTCanTransfer != 0 {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// If neither party is the issuer, cannot transfer
 	if fromID != issuance.Issuer && toID != issuance.Issuer {
-		return tx.TecNO_AUTH
+		return ter.TecNO_AUTH
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // getTransferRateForIssuer reads the transfer rate from an issuer's AccountRoot.
@@ -951,12 +952,12 @@ func createTrustLineForEscrow(
 	destID [20]byte,
 	recvLow bool,
 	bumpOwnerCount bool,
-) tx.Result {
+) ter.Result {
 	trustLineKey := keylet.Line(receiverID, issuerID, currency)
 
 	receiverStr, err := state.EncodeAccountID(receiverID)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// The account-being-set's (receiver's) noRipple is derived from its own
@@ -964,11 +965,11 @@ func createTrustLineForEscrow(
 	// Reference: rippled Escrow.cpp:862 (sleDest->getFlags() & lsfDefaultRipple) == 0.
 	receiverAcctData, err := view.Read(keylet.Account(receiverID))
 	if err != nil || receiverAcctData == nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	receiverAcct, err := state.ParseAccountRoot(receiverAcctData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	receiverNoRipple := receiverAcct.Flags&state.LsfDefaultRipple == 0
 
@@ -982,7 +983,7 @@ func createTrustLineForEscrow(
 		Balance:     state.NewIssuedAmountFromValue(0, state.MinExponent, currency, state.AccountOneAddress),
 		Limit:       tx.NewIssuedAmount(0, state.MinExponent, currency, receiverStr),
 	})
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -993,14 +994,14 @@ func createTrustLineForEscrow(
 		adjustOwnerCountViaView(view, destID, 1)
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // rippleCreditForEscrow credits IOU from issuer to receiver by modifying the
 // trust line balance. This is the unlock-side direction of rippleCreditEscrow.
 // Reference: rippled View.cpp rippleCredit(issuer, receiver, amount)
-func rippleCreditForEscrow(view tx.LedgerView, issuerID, receiverID [20]byte, amount tx.Amount) tx.Result {
-	return rippleCreditEscrow(view, issuerID, receiverID, amount, tx.TecNO_LINE, tx.TecNO_LINE)
+func rippleCreditForEscrow(view tx.LedgerView, issuerID, receiverID [20]byte, amount tx.Amount) ter.Result {
+	return rippleCreditEscrow(view, issuerID, receiverID, amount, ter.TecNO_LINE, ter.TecNO_LINE)
 }
 
 // rippleCreditEscrow moves an IOU amount from payerID to payeeID along their
@@ -1013,9 +1014,9 @@ func rippleCreditForEscrow(view tx.LedgerView, issuerID, receiverID [20]byte, am
 // the line is absent; the lock and unlock sites differ only in the read-error
 // mapping (tecINTERNAL vs tecNO_LINE), so each passes its own.
 // Reference: rippled View.cpp rippleCredit(sender, receiver, amount).
-func rippleCreditEscrow(view tx.LedgerView, payerID, payeeID [20]byte, amount tx.Amount, readErrResult, missingResult tx.Result) tx.Result {
+func rippleCreditEscrow(view tx.LedgerView, payerID, payeeID [20]byte, amount tx.Amount, readErrResult, missingResult ter.Result) ter.Result {
 	if amount.IsZero() {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	trustLineKey := keylet.Line(payerID, payeeID, amount.Currency)
@@ -1029,47 +1030,47 @@ func rippleCreditEscrow(view tx.LedgerView, payerID, payeeID [20]byte, amount tx
 
 	rs, err := state.ParseRippleState(trustLineData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	payerIsLow := state.CompareAccountIDsForLine(payerID, payeeID) < 0
 	if payerIsLow {
 		newBalance, err := rs.Balance.Sub(amount)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		rs.Balance = newBalance
 	} else {
 		newBalance, err := rs.Balance.Add(amount)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		rs.Balance = newBalance
 	}
 
 	updated, err := state.SerializeRippleState(rs)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := view.Update(trustLineKey, updated); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // checkTrustLineLimit verifies the trust line limit isn't exceeded by the unlock.
 // Reference: rippled Escrow.cpp lines 908-931
-func checkTrustLineLimit(view tx.LedgerView, receiverID, issuerID [20]byte, currency string, finalAmount tx.Amount, issuerHigh bool) tx.Result {
+func checkTrustLineLimit(view tx.LedgerView, receiverID, issuerID [20]byte, currency string, finalAmount tx.Amount, issuerHigh bool) ter.Result {
 	trustLineKey := keylet.Line(receiverID, issuerID, currency)
 	trustLineData, err := view.Read(trustLineKey)
 	if err != nil || trustLineData == nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	rs, err := state.ParseRippleState(trustLineData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// If the issuer is the high, then we use the low limit, otherwise the high limit
@@ -1089,15 +1090,15 @@ func checkTrustLineLimit(view tx.LedgerView, receiverID, issuerID [20]byte, curr
 
 	newBalance, err := lineBalance.Add(finalAmount)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// If the transfer would exceed the line limit, return tecLIMIT_EXCEEDED
 	if lineLimit.Compare(newBalance) < 0 {
-		return tx.TecLIMIT_EXCEEDED
+		return ter.TecLIMIT_EXCEEDED
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // divideAmountByRate computes amount * QUALITY_ONE / rate for IOU amounts.
@@ -1122,11 +1123,11 @@ func createMPTokenForEscrow(
 	holderID [20]byte,
 	destID [20]byte,
 	bumpOwnerCount bool,
-) tx.Result {
+) ter.Result {
 	// Decode MPT issuance ID to [24]byte
 	idBytes, err := hex.DecodeString(mptHexID)
 	if err != nil || len(idBytes) != 24 {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	var mptIssuanceID [24]byte
 	copy(mptIssuanceID[:], idBytes)
@@ -1147,16 +1148,16 @@ func createMPTokenForEscrow(
 		dir.Owner = holderID
 	})
 	if err != nil {
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 	tokenData.OwnerNode = dirResult.Page
 
 	data, err := state.SerializeMPToken(tokenData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := view.Insert(tokenKey, data); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// On the cancel path rippled bumps the soon-erased escrow SLE rather than a
@@ -1165,7 +1166,7 @@ func createMPTokenForEscrow(
 		adjustOwnerCountViaView(view, destID, 1)
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // Internal helpers

--- a/internal/tx/escrow/token_owner_count_test.go
+++ b/internal/tx/escrow/token_owner_count_test.go
@@ -3,13 +3,14 @@ package escrow
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/LeJamon/go-xrpl/amendment"
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
-	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
-	"github.com/stretchr/testify/require"
 )
 
 // mapView is a minimal map-backed tx.LedgerView for unit-testing the escrow
@@ -132,7 +133,7 @@ func TestEscrowTokenCreate_OwnerCountBumpGate(t *testing.T) {
 		issuanceKey, err := mptIssuanceKeyFromHex(mptHexID)
 		require.NoError(t, err)
 
-		require.Equal(t, tx.TesSUCCESS,
+		require.Equal(t, ter.TesSUCCESS,
 			createMPTokenForEscrow(v, issuanceKey, mptHexID, holder, holder, true))
 
 		require.Equal(t, uint32(6), ownerCountOf(t, v, holder),
@@ -147,7 +148,7 @@ func TestEscrowTokenCreate_OwnerCountBumpGate(t *testing.T) {
 		issuanceKey, err := mptIssuanceKeyFromHex(mptHexID)
 		require.NoError(t, err)
 
-		require.Equal(t, tx.TesSUCCESS,
+		require.Equal(t, ter.TesSUCCESS,
 			createMPTokenForEscrow(v, issuanceKey, mptHexID, holder, holder, false))
 
 		require.Equal(t, uint32(5), ownerCountOf(t, v, holder),
@@ -163,7 +164,7 @@ func TestEscrowTokenCreate_OwnerCountBumpGate(t *testing.T) {
 		vf := newMapView()
 		seedAccountForEscrow(t, vf, holder, 5)
 		seedAccountForEscrow(t, vf, issuer, 0)
-		require.Equal(t, tx.TesSUCCESS,
+		require.Equal(t, ter.TesSUCCESS,
 			createTrustLineForEscrow(vf, issuer, holder, "USD", holder, recvLow, true))
 		require.Equal(t, uint32(6), ownerCountOf(t, vf, holder),
 			"finish bumps the destination's OwnerCount for the new trust line")
@@ -172,7 +173,7 @@ func TestEscrowTokenCreate_OwnerCountBumpGate(t *testing.T) {
 		vc := newMapView()
 		seedAccountForEscrow(t, vc, holder, 5)
 		seedAccountForEscrow(t, vc, issuer, 0)
-		require.Equal(t, tx.TesSUCCESS,
+		require.Equal(t, ter.TesSUCCESS,
 			createTrustLineForEscrow(vc, issuer, holder, "USD", holder, recvLow, false))
 		require.Equal(t, uint32(5), ownerCountOf(t, vc, holder),
 			"cancel must not charge the creator's OwnerCount for the re-created trust line")

--- a/internal/tx/ledgerstatefix/ledger_state_fix.go
+++ b/internal/tx/ledgerstatefix/ledger_state_fix.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/nftoken"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -19,8 +20,8 @@ const (
 
 // LedgerStateFix errors
 var (
-	ErrLedgerFixInvalidType   = tx.Errorf(tx.TefINVALID_LEDGER_FIX_TYPE, "invalid LedgerFixType")
-	ErrLedgerFixOwnerRequired = tx.Errorf(tx.TemINVALID, "Owner is required for nfTokenPageLink fix")
+	ErrLedgerFixInvalidType   = ter.Errorf(ter.TefINVALID_LEDGER_FIX_TYPE, "invalid LedgerFixType")
+	ErrLedgerFixOwnerRequired = ter.Errorf(ter.TemINVALID, "Owner is required for nfTokenPageLink fix")
 )
 
 // LedgerStateFix is a system transaction to fix ledger state issues.
@@ -102,7 +103,7 @@ func (l *LedgerStateFix) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled LedgerStateFix.cpp preclaim() + doApply()
-func (l *LedgerStateFix) Apply(ctx *tx.ApplyContext) tx.Result {
+func (l *LedgerStateFix) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("ledger state fix apply",
 		"account", l.Account,
 		"fixType", l.LedgerFixType,
@@ -118,7 +119,7 @@ func (l *LedgerStateFix) Apply(ctx *tx.ApplyContext) tx.Result {
 			ctx.Log.Warn("ledger state fix: owner account decode failed",
 				"owner", l.Owner,
 			)
-			return tx.TecOBJECT_NOT_FOUND
+			return ter.TecOBJECT_NOT_FOUND
 		}
 		ownerAccountKey := keylet.Account(ownerID)
 		exists, existsErr := ctx.View.Exists(ownerAccountKey)
@@ -126,7 +127,7 @@ func (l *LedgerStateFix) Apply(ctx *tx.ApplyContext) tx.Result {
 			ctx.Log.Warn("ledger state fix: owner account does not exist",
 				"owner", l.Owner,
 			)
-			return tx.TecOBJECT_NOT_FOUND
+			return ter.TecOBJECT_NOT_FOUND
 		}
 
 		// doApply: repair NFToken directory links
@@ -135,17 +136,17 @@ func (l *LedgerStateFix) Apply(ctx *tx.ApplyContext) tx.Result {
 			ctx.Log.Warn("ledger state fix: no repairs needed",
 				"owner", l.Owner,
 			)
-			return tx.TecFAILED_PROCESSING
+			return ter.TecFAILED_PROCESSING
 		}
 		ctx.Log.Debug("ledger state fix: nftoken page links repaired",
 			"owner", l.Owner,
 		)
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 
 	default:
 		// preflight should have caught this
 		ctx.Log.Error("ledger state fix: unknown fix type", "fixType", l.LedgerFixType)
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 }
 

--- a/internal/tx/metadata.go
+++ b/internal/tx/metadata.go
@@ -7,12 +7,13 @@ import (
 	"strings"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // ApplyResult contains the result of applying a transaction
 type ApplyResult struct {
 	// Result is the transaction result code
-	Result Result
+	Result ter.Result
 
 	// Applied indicates if the transaction was applied to the ledger
 	Applied bool
@@ -36,7 +37,7 @@ type Metadata struct {
 	TransactionIndex uint32
 
 	// TransactionResult is the result code
-	TransactionResult Result
+	TransactionResult ter.Result
 
 	// DeliveredAmount is the actual amount delivered (for partial payments)
 	DeliveredAmount *Amount

--- a/internal/tx/mock_view_test.go
+++ b/internal/tx/mock_view_test.go
@@ -1,0 +1,76 @@
+package tx
+
+import (
+	"bytes"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// mockBaseView implements LedgerView for core tx tests.
+type mockBaseView struct {
+	data map[[32]byte][]byte
+}
+
+func newMockBaseView() *mockBaseView {
+	return &mockBaseView{data: make(map[[32]byte][]byte)}
+}
+
+func (m *mockBaseView) Read(k keylet.Keylet) ([]byte, error) {
+	return m.data[k.Key], nil
+}
+
+func (m *mockBaseView) Exists(k keylet.Keylet) (bool, error) {
+	_, ok := m.data[k.Key]
+	return ok, nil
+}
+
+func (m *mockBaseView) Insert(k keylet.Keylet, data []byte) error {
+	m.data[k.Key] = data
+	return nil
+}
+
+func (m *mockBaseView) Update(k keylet.Keylet, data []byte) error {
+	m.data[k.Key] = data
+	return nil
+}
+
+func (m *mockBaseView) Erase(k keylet.Keylet) error {
+	delete(m.data, k.Key)
+	return nil
+}
+
+func (m *mockBaseView) AdjustDropsDestroyed(drops.XRPAmount) {}
+
+func (m *mockBaseView) TxExists([32]byte) bool { return false }
+
+func (m *mockBaseView) Rules() *amendment.Rules { return nil }
+
+func (m *mockBaseView) LedgerSeq() uint32 { return 0 }
+
+func (m *mockBaseView) ForEach(fn func(key [32]byte, data []byte) bool) error {
+	for k, v := range m.data {
+		if !fn(k, v) {
+			break
+		}
+	}
+	return nil
+}
+
+func (m *mockBaseView) Succ(key [32]byte) ([32]byte, []byte, bool, error) {
+	var best [32]byte
+	found := false
+	for k := range m.data {
+		if bytes.Compare(k[:], key[:]) > 0 {
+			if !found || bytes.Compare(k[:], best[:]) < 0 {
+				best = k
+				found = true
+			}
+		}
+	}
+	if found {
+		return best, m.data[best], true, nil
+	}
+	return [32]byte{}, nil, false, nil
+}

--- a/internal/tx/mpt/mptoken_authorize.go
+++ b/internal/tx/mpt/mptoken_authorize.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -44,25 +45,25 @@ func (m *MPTokenAuthorize) Validate() error {
 	flags := m.GetFlags()
 
 	if flags&^tfMPTokenAuthorizeValidMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for MPTokenAuthorize")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for MPTokenAuthorize")
 	}
 
 	// MPTokenIssuanceID is required
 	if m.MPTokenIssuanceID == "" {
-		return tx.Errorf(tx.TemMALFORMED, "MPTokenIssuanceID is required")
+		return ter.Errorf(ter.TemMALFORMED, "MPTokenIssuanceID is required")
 	}
 
 	if len(m.MPTokenIssuanceID) != 48 {
-		return tx.Errorf(tx.TemMALFORMED, "MPTokenIssuanceID must be 48 hex characters")
+		return ter.Errorf(ter.TemMALFORMED, "MPTokenIssuanceID must be 48 hex characters")
 	}
 
 	if _, err := hex.DecodeString(m.MPTokenIssuanceID); err != nil {
-		return tx.Errorf(tx.TemMALFORMED, "MPTokenIssuanceID must be valid hex")
+		return ter.Errorf(ter.TemMALFORMED, "MPTokenIssuanceID must be valid hex")
 	}
 
 	// Holder cannot be the same as Account
 	if m.Holder != "" && m.Holder == m.Account {
-		return tx.Errorf(tx.TemMALFORMED, "Holder cannot be the same as Account")
+		return ter.Errorf(ter.TemMALFORMED, "Holder cannot be the same as Account")
 	}
 
 	return nil
@@ -83,7 +84,7 @@ func (m *MPTokenAuthorize) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled MPTokenAuthorize.cpp preclaim() + doApply() + View.cpp::authorizeMPToken()
-func (m *MPTokenAuthorize) Apply(ctx *tx.ApplyContext) tx.Result {
+func (m *MPTokenAuthorize) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("mptoken authorize apply",
 		"account", m.Account,
 		"issuanceID", m.MPTokenIssuanceID,
@@ -94,7 +95,7 @@ func (m *MPTokenAuthorize) Apply(ctx *tx.ApplyContext) tx.Result {
 	var mptID [24]byte
 	issuanceIDBytes, err := hex.DecodeString(m.MPTokenIssuanceID)
 	if err != nil || len(issuanceIDBytes) != 24 {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 	copy(mptID[:], issuanceIDBytes)
 
@@ -110,7 +111,7 @@ func (m *MPTokenAuthorize) Apply(ctx *tx.ApplyContext) tx.Result {
 }
 
 // applyHolderPath handles when a holder submits MPTokenAuthorize (no Holder field).
-func (m *MPTokenAuthorize) applyHolderPath(ctx *tx.ApplyContext, mptID [24]byte, issuanceKey keylet.Keylet, txFlags uint32) tx.Result {
+func (m *MPTokenAuthorize) applyHolderPath(ctx *tx.ApplyContext, mptID [24]byte, issuanceKey keylet.Keylet, txFlags uint32) ter.Result {
 	tokenKey := keylet.MPToken(issuanceKey.Key, ctx.AccountID)
 
 	if txFlags&MPTokenAuthorizeFlagUnauthorize != 0 {
@@ -122,18 +123,18 @@ func (m *MPTokenAuthorize) applyHolderPath(ctx *tx.ApplyContext, mptID [24]byte,
 }
 
 // holderUnauthorize handles a holder deleting their MPToken.
-func (m *MPTokenAuthorize) holderUnauthorize(ctx *tx.ApplyContext, tokenKey keylet.Keylet) tx.Result {
+func (m *MPTokenAuthorize) holderUnauthorize(ctx *tx.ApplyContext, tokenKey keylet.Keylet) ter.Result {
 	// MPToken must exist
 	tokenRaw, err := ctx.View.Read(tokenKey)
 	if err != nil || tokenRaw == nil {
 		ctx.Log.Warn("mptoken authorize: token not found for holder unauthorize")
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	token, err := state.ParseMPToken(tokenRaw)
 	if err != nil {
 		ctx.Log.Error("mptoken authorize: failed to parse token", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Cannot delete with non-zero balance
@@ -141,69 +142,69 @@ func (m *MPTokenAuthorize) holderUnauthorize(ctx *tx.ApplyContext, tokenKey keyl
 		ctx.Log.Warn("mptoken authorize: cannot delete token with balance",
 			"amount", token.MPTAmount,
 		)
-		return tx.TecHAS_OBLIGATIONS
+		return ter.TecHAS_OBLIGATIONS
 	}
 	if token.LockedAmount != nil && *token.LockedAmount != 0 {
 		ctx.Log.Warn("mptoken authorize: cannot delete token with locked amount",
 			"lockedAmount", *token.LockedAmount,
 		)
-		return tx.TecHAS_OBLIGATIONS
+		return ter.TecHAS_OBLIGATIONS
 	}
 
 	// With featureSingleAssetVault, a locked MPToken cannot be deleted.
 	// Reference: rippled MPTokenAuthorize.cpp:95-97
 	if ctx.Rules().Enabled(amendment.FeatureSingleAssetVault) &&
 		token.Flags&entry.LsfMPTLocked != 0 {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	ownerDirKey := keylet.OwnerDir(ctx.AccountID)
 	if res, err := state.DirRemove(ctx.View, ownerDirKey, token.OwnerNode, tokenKey.Key, false); err != nil || !res.Success {
 		ctx.Log.Error("mptoken authorize: failed to remove from owner directory", "error", err)
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	// Erase the MPToken
 	if err := ctx.View.Erase(tokenKey); err != nil {
 		ctx.Log.Error("mptoken authorize: failed to erase token", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if ctx.Account.OwnerCount > 0 {
 		ctx.Account.OwnerCount--
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // holderAuthorize handles a holder creating a new MPToken (opting in to hold).
-func (m *MPTokenAuthorize) holderAuthorize(ctx *tx.ApplyContext, mptID [24]byte, issuanceKey, tokenKey keylet.Keylet) tx.Result {
+func (m *MPTokenAuthorize) holderAuthorize(ctx *tx.ApplyContext, mptID [24]byte, issuanceKey, tokenKey keylet.Keylet) ter.Result {
 	// Issuance must exist
 	issuanceRaw, err := ctx.View.Read(issuanceKey)
 	if err != nil || issuanceRaw == nil {
 		ctx.Log.Warn("mptoken authorize: issuance not found",
 			"issuanceID", m.MPTokenIssuanceID,
 		)
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	issuance, err := state.ParseMPTokenIssuance(issuanceRaw)
 	if err != nil {
 		ctx.Log.Error("mptoken authorize: failed to parse issuance", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Issuer cannot hold own token
 	if issuance.Issuer == ctx.AccountID {
 		ctx.Log.Warn("mptoken authorize: issuer cannot hold own token")
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// MPToken must not already exist
 	exists, _ := ctx.View.Exists(tokenKey)
 	if exists {
 		ctx.Log.Warn("mptoken authorize: token already exists")
-		return tx.TecDUPLICATE
+		return ter.TecDUPLICATE
 	}
 
 	// Reserve check against the prior balance (before fee deduction).
@@ -215,7 +216,7 @@ func (m *MPTokenAuthorize) holderAuthorize(ctx *tx.ApplyContext, mptID [24]byte,
 			"priorBalance", ctx.PriorBalance(),
 			"reserve", reserveNeeded,
 		)
-		return tx.TecINSUFFICIENT_RESERVE
+		return ter.TecINSUFFICIENT_RESERVE
 	}
 
 	// Build MPToken entry
@@ -234,7 +235,7 @@ func (m *MPTokenAuthorize) holderAuthorize(ctx *tx.ApplyContext, mptID [24]byte,
 	})
 	if err != nil {
 		ctx.Log.Error("mptoken authorize: directory full", "error", err)
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 	tokenData.OwnerNode = dirResult.Page
 
@@ -242,23 +243,23 @@ func (m *MPTokenAuthorize) holderAuthorize(ctx *tx.ApplyContext, mptID [24]byte,
 	data, err := state.SerializeMPToken(tokenData)
 	if err != nil {
 		ctx.Log.Error("mptoken authorize: failed to serialize token", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Insert(tokenKey, data); err != nil {
 		ctx.Log.Error("mptoken authorize: failed to insert token", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	ctx.Account.OwnerCount++
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // applyIssuerPath handles when the issuer submits MPTokenAuthorize with Holder field.
-func (m *MPTokenAuthorize) applyIssuerPath(ctx *tx.ApplyContext, issuanceKey keylet.Keylet, txFlags uint32) tx.Result {
+func (m *MPTokenAuthorize) applyIssuerPath(ctx *tx.ApplyContext, issuanceKey keylet.Keylet, txFlags uint32) ter.Result {
 	// Decode holder account
 	holderID, err := state.DecodeAccountID(m.Holder)
 	if err != nil {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	// Holder account must exist
@@ -269,7 +270,7 @@ func (m *MPTokenAuthorize) applyIssuerPath(ctx *tx.ApplyContext, issuanceKey key
 		ctx.Log.Warn("mptoken authorize: holder account does not exist",
 			"holder", m.Holder,
 		)
-		return tx.TecNO_DST
+		return ter.TecNO_DST
 	}
 
 	// Issuance must exist
@@ -278,25 +279,25 @@ func (m *MPTokenAuthorize) applyIssuerPath(ctx *tx.ApplyContext, issuanceKey key
 		ctx.Log.Warn("mptoken authorize: issuance not found",
 			"issuanceID", m.MPTokenIssuanceID,
 		)
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	issuance, err := state.ParseMPTokenIssuance(issuanceRaw)
 	if err != nil {
 		ctx.Log.Error("mptoken authorize: failed to parse issuance", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Caller must be the issuer
 	if issuance.Issuer != ctx.AccountID {
 		ctx.Log.Warn("mptoken authorize: caller is not issuer")
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Issuance must have RequireAuth flag
 	if issuance.Flags&entry.LsfMPTRequireAuth == 0 {
 		ctx.Log.Warn("mptoken authorize: issuance does not require auth")
-		return tx.TecNO_AUTH
+		return ter.TecNO_AUTH
 	}
 
 	// Holder's MPToken must exist
@@ -306,13 +307,13 @@ func (m *MPTokenAuthorize) applyIssuerPath(ctx *tx.ApplyContext, issuanceKey key
 		ctx.Log.Warn("mptoken authorize: holder token not found",
 			"holder", m.Holder,
 		)
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	token, err := state.ParseMPToken(tokenRaw)
 	if err != nil {
 		ctx.Log.Error("mptoken authorize: failed to parse holder token", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Toggle authorization flag
@@ -326,12 +327,12 @@ func (m *MPTokenAuthorize) applyIssuerPath(ctx *tx.ApplyContext, issuanceKey key
 	updatedData, err := state.SerializeMPToken(token)
 	if err != nil {
 		ctx.Log.Error("mptoken authorize: failed to serialize token", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(tokenKey, updatedData); err != nil {
 		ctx.Log.Error("mptoken authorize: failed to update token", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/mpt/mptoken_issuance_create.go
+++ b/internal/tx/mpt/mptoken_issuance_create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -103,17 +104,17 @@ func (m *MPTokenIssuanceCreate) Validate() error {
 
 	flags := m.GetFlags()
 	if flags&^tfMPTokenIssuanceCreateValidMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for MPTokenIssuanceCreate")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for MPTokenIssuanceCreate")
 	}
 
 	// Validate TransferFee
 	if m.TransferFee != nil {
 		if *m.TransferFee > entry.MaxTransferFee {
-			return tx.Errorf(tx.TemBAD_TRANSFER_FEE, "TransferFee cannot exceed 50000")
+			return ter.Errorf(ter.TemBAD_TRANSFER_FEE, "TransferFee cannot exceed 50000")
 		}
 		// If a non-zero TransferFee is set, tfMPTCanTransfer must also be set
 		if *m.TransferFee > 0 && (flags&MPTokenIssuanceCreateFlagCanTransfer) == 0 {
-			return tx.Errorf(tx.TemMALFORMED, "TransferFee requires tfMPTCanTransfer flag")
+			return ter.Errorf(ter.TemMALFORMED, "TransferFee requires tfMPTCanTransfer flag")
 		}
 	}
 
@@ -124,7 +125,7 @@ func (m *MPTokenIssuanceCreate) Validate() error {
 		}
 		// Domain present implies that MPTokenIssuance is not public
 		if flags&MPTokenIssuanceCreateFlagRequireAuth == 0 {
-			return tx.Errorf(tx.TemMALFORMED, "DomainID requires tfMPTRequireAuth flag")
+			return ter.Errorf(ter.TemMALFORMED, "DomainID requires tfMPTRequireAuth flag")
 		}
 	}
 
@@ -132,20 +133,20 @@ func (m *MPTokenIssuanceCreate) Validate() error {
 	if m.MPTokenMetadata != nil {
 		metadataBytes, err := hex.DecodeString(*m.MPTokenMetadata)
 		if err != nil {
-			return tx.Errorf(tx.TemMALFORMED, "MPTokenMetadata must be valid hex")
+			return ter.Errorf(ter.TemMALFORMED, "MPTokenMetadata must be valid hex")
 		}
 		if len(metadataBytes) == 0 || len(metadataBytes) > entry.MaxMPTokenMetadataLength {
-			return tx.Errorf(tx.TemMALFORMED, "MPTokenMetadata length must be 1-1024 bytes")
+			return ter.Errorf(ter.TemMALFORMED, "MPTokenMetadata length must be 1-1024 bytes")
 		}
 	}
 
 	// Validate MaximumAmount
 	if m.MaximumAmount != nil {
 		if *m.MaximumAmount == 0 {
-			return tx.Errorf(tx.TemMALFORMED, "MaximumAmount cannot be zero")
+			return ter.Errorf(ter.TemMALFORMED, "MaximumAmount cannot be zero")
 		}
 		if *m.MaximumAmount > entry.MaxMPTokenAmount {
-			return tx.Errorf(tx.TemMALFORMED, "MaximumAmount exceeds maximum allowed")
+			return ter.Errorf(ter.TemMALFORMED, "MaximumAmount exceeds maximum allowed")
 		}
 	}
 
@@ -167,7 +168,7 @@ func (m *MPTokenIssuanceCreate) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled MPTokenIssuanceCreate.cpp doApply() / create()
-func (m *MPTokenIssuanceCreate) Apply(ctx *tx.ApplyContext) tx.Result {
+func (m *MPTokenIssuanceCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("mptoken issuance create apply",
 		"account", m.Account,
 		"assetScale", m.AssetScale,
@@ -176,7 +177,7 @@ func (m *MPTokenIssuanceCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	)
 
 	// Reserve check against the prior balance (before fee deduction).
-	if result := ctx.CheckReserveWithFee(ctx.Account.OwnerCount + 1); result != tx.TesSUCCESS {
+	if result := ctx.CheckReserveWithFee(ctx.Account.OwnerCount + 1); result != ter.TesSUCCESS {
 		ctx.Log.Warn("mptoken issuance create: insufficient reserve",
 			"priorBalance", ctx.PriorBalance(),
 			"reserve", ctx.AccountReserve(ctx.Account.OwnerCount+1),
@@ -221,7 +222,7 @@ func (m *MPTokenIssuanceCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	})
 	if err != nil {
 		ctx.Log.Error("mptoken issuance create: directory full", "error", err)
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 	issuanceData.OwnerNode = dirResult.Page
 
@@ -229,13 +230,13 @@ func (m *MPTokenIssuanceCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	data, err := state.SerializeMPTokenIssuance(issuanceData)
 	if err != nil {
 		ctx.Log.Error("mptoken issuance create: failed to serialize issuance", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Insert(issuanceKey, data); err != nil {
 		ctx.Log.Error("mptoken issuance create: failed to insert issuance", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	ctx.Account.OwnerCount++
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/mpt/mptoken_issuance_destroy.go
+++ b/internal/tx/mpt/mptoken_issuance_destroy.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -42,21 +43,21 @@ func (m *MPTokenIssuanceDestroy) Validate() error {
 
 	flags := m.GetFlags()
 	if flags&^tfMPTokenIssuanceDestroyValidMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for MPTokenIssuanceDestroy")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for MPTokenIssuanceDestroy")
 	}
 
 	// MPTokenIssuanceID is required and must be valid hex
 	if m.MPTokenIssuanceID == "" {
-		return tx.Errorf(tx.TemMALFORMED, "MPTokenIssuanceID is required")
+		return ter.Errorf(ter.TemMALFORMED, "MPTokenIssuanceID is required")
 	}
 
 	// MPTokenIssuanceID should be 48 hex characters (24 bytes / Hash192)
 	if len(m.MPTokenIssuanceID) != 48 {
-		return tx.Errorf(tx.TemMALFORMED, "MPTokenIssuanceID must be 48 hex characters")
+		return ter.Errorf(ter.TemMALFORMED, "MPTokenIssuanceID must be 48 hex characters")
 	}
 
 	if _, err := hex.DecodeString(m.MPTokenIssuanceID); err != nil {
-		return tx.Errorf(tx.TemMALFORMED, "MPTokenIssuanceID must be valid hex")
+		return ter.Errorf(ter.TemMALFORMED, "MPTokenIssuanceID must be valid hex")
 	}
 
 	return nil
@@ -71,7 +72,7 @@ func (m *MPTokenIssuanceDestroy) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled MPTokenIssuanceDestroy.cpp preclaim() + doApply()
-func (m *MPTokenIssuanceDestroy) Apply(ctx *tx.ApplyContext) tx.Result {
+func (m *MPTokenIssuanceDestroy) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("mptoken issuance destroy apply",
 		"account", m.Account,
 		"issuanceID", m.MPTokenIssuanceID,
@@ -81,7 +82,7 @@ func (m *MPTokenIssuanceDestroy) Apply(ctx *tx.ApplyContext) tx.Result {
 	var mptID [24]byte
 	issuanceIDBytes, err := hex.DecodeString(m.MPTokenIssuanceID)
 	if err != nil || len(issuanceIDBytes) != 24 {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 	copy(mptID[:], issuanceIDBytes)
 
@@ -92,20 +93,20 @@ func (m *MPTokenIssuanceDestroy) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Warn("mptoken issuance destroy: issuance not found",
 			"issuanceID", m.MPTokenIssuanceID,
 		)
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	// Parse issuance entry
 	issuance, err := state.ParseMPTokenIssuance(issuanceRaw)
 	if err != nil {
 		ctx.Log.Error("mptoken issuance destroy: failed to parse issuance", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Caller must be the issuer
 	if issuance.Issuer != ctx.AccountID {
 		ctx.Log.Warn("mptoken issuance destroy: caller is not issuer")
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Cannot destroy with outstanding balances
@@ -113,31 +114,31 @@ func (m *MPTokenIssuanceDestroy) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Warn("mptoken issuance destroy: has outstanding obligations",
 			"outstandingAmount", issuance.OutstandingAmount,
 		)
-		return tx.TecHAS_OBLIGATIONS
+		return ter.TecHAS_OBLIGATIONS
 	}
 	if issuance.LockedAmount != nil && *issuance.LockedAmount != 0 {
 		ctx.Log.Warn("mptoken issuance destroy: has locked obligations",
 			"lockedAmount", *issuance.LockedAmount,
 		)
-		return tx.TecHAS_OBLIGATIONS
+		return ter.TecHAS_OBLIGATIONS
 	}
 
 	// doApply: remove from owner directory
 	ownerDirKey := keylet.OwnerDir(ctx.AccountID)
 	if res, err := state.DirRemove(ctx.View, ownerDirKey, issuance.OwnerNode, issuanceKey.Key, false); err != nil || !res.Success {
 		ctx.Log.Error("mptoken issuance destroy: failed to remove from owner directory", "error", err)
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 
 	// Erase the issuance
 	if err := ctx.View.Erase(issuanceKey); err != nil {
 		ctx.Log.Error("mptoken issuance destroy: failed to erase issuance", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if ctx.Account.OwnerCount > 0 {
 		ctx.Account.OwnerCount--
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/mpt/mptoken_issuance_set.go
+++ b/internal/tx/mpt/mptoken_issuance_set.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -72,36 +73,36 @@ func (m *MPTokenIssuanceSet) Validate() error {
 	// DomainID and Holder cannot both be present
 	// Reference: rippled MPTokenIssuanceSet.cpp:40-41
 	if m.hasDomainID && m.Holder != "" {
-		return tx.Errorf(tx.TemMALFORMED, "cannot specify both DomainID and Holder")
+		return ter.Errorf(ter.TemMALFORMED, "cannot specify both DomainID and Holder")
 	}
 
 	flags := m.GetFlags()
 
 	if flags&^tfMPTokenIssuanceSetValidMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for MPTokenIssuanceSet")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for MPTokenIssuanceSet")
 	}
 
 	// Cannot set both tfMPTLock and tfMPTUnlock
 	if (flags&MPTokenIssuanceSetFlagLock) != 0 && (flags&MPTokenIssuanceSetFlagUnlock) != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "cannot set both tfMPTLock and tfMPTUnlock")
+		return ter.Errorf(ter.TemINVALID_FLAG, "cannot set both tfMPTLock and tfMPTUnlock")
 	}
 
 	// MPTokenIssuanceID is required
 	if m.MPTokenIssuanceID == "" {
-		return tx.Errorf(tx.TemMALFORMED, "MPTokenIssuanceID is required")
+		return ter.Errorf(ter.TemMALFORMED, "MPTokenIssuanceID is required")
 	}
 
 	if len(m.MPTokenIssuanceID) != 48 {
-		return tx.Errorf(tx.TemMALFORMED, "MPTokenIssuanceID must be 48 hex characters")
+		return ter.Errorf(ter.TemMALFORMED, "MPTokenIssuanceID must be 48 hex characters")
 	}
 
 	if _, err := hex.DecodeString(m.MPTokenIssuanceID); err != nil {
-		return tx.Errorf(tx.TemMALFORMED, "MPTokenIssuanceID must be valid hex")
+		return ter.Errorf(ter.TemMALFORMED, "MPTokenIssuanceID must be valid hex")
 	}
 
 	// Holder cannot be the same as Account
 	if m.Holder != "" && m.Holder == m.Account {
-		return tx.Errorf(tx.TemMALFORMED, "Holder cannot be the same as Account")
+		return ter.Errorf(ter.TemMALFORMED, "Holder cannot be the same as Account")
 	}
 
 	return nil
@@ -122,7 +123,7 @@ func (m *MPTokenIssuanceSet) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled MPTokenIssuanceSet.cpp preclaim() + doApply()
-func (m *MPTokenIssuanceSet) Apply(ctx *tx.ApplyContext) tx.Result {
+func (m *MPTokenIssuanceSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("mptoken issuance set apply",
 		"account", m.Account,
 		"issuanceID", m.MPTokenIssuanceID,
@@ -137,7 +138,7 @@ func (m *MPTokenIssuanceSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled MPTokenIssuanceSet.cpp:60-65
 	if rules.Enabled(amendment.FeatureSingleAssetVault) {
 		if txFlags == 0 && !m.hasDomainID {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 	}
 
@@ -145,7 +146,7 @@ func (m *MPTokenIssuanceSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	var mptID [24]byte
 	issuanceIDBytes, err := hex.DecodeString(m.MPTokenIssuanceID)
 	if err != nil || len(issuanceIDBytes) != 24 {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 	copy(mptID[:], issuanceIDBytes)
 
@@ -156,13 +157,13 @@ func (m *MPTokenIssuanceSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Warn("mptoken issuance set: issuance not found",
 			"issuanceID", m.MPTokenIssuanceID,
 		)
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	issuance, err := state.ParseMPTokenIssuance(issuanceRaw)
 	if err != nil {
 		ctx.Log.Error("mptoken issuance set: failed to parse issuance", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// CanLock check is conditional on featureSingleAssetVault.
@@ -172,17 +173,17 @@ func (m *MPTokenIssuanceSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	if issuance.Flags&entry.LsfMPTCanLock == 0 {
 		if !rules.Enabled(amendment.FeatureSingleAssetVault) {
 			ctx.Log.Warn("mptoken issuance set: issuance does not have CanLock capability")
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		} else if txFlags&MPTokenIssuanceSetFlagLock != 0 || txFlags&MPTokenIssuanceSetFlagUnlock != 0 {
 			ctx.Log.Warn("mptoken issuance set: issuance does not have CanLock capability")
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	}
 
 	// Caller must be the issuer
 	if issuance.Issuer != ctx.AccountID {
 		ctx.Log.Warn("mptoken issuance set: caller is not issuer")
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	if m.Holder != "" {
@@ -194,20 +195,20 @@ func (m *MPTokenIssuanceSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled MPTokenIssuanceSet.cpp:141-153
 	if m.hasDomainID {
 		if issuance.Flags&entry.LsfMPTRequireAuth == 0 {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 		if m.DomainID != nil && *m.DomainID != zeroHash256 {
 			// Non-zero domain: verify it exists
 			domainIDBytes, err := hex.DecodeString(*m.DomainID)
 			if err != nil || len(domainIDBytes) != 32 {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			var domainKey [32]byte
 			copy(domainKey[:], domainIDBytes)
 			domainKL := keylet.PermissionedDomainByID(domainKey)
 			exists, _ := ctx.View.Exists(domainKL)
 			if !exists {
-				return tx.TecOBJECT_NOT_FOUND
+				return ter.TecOBJECT_NOT_FOUND
 			}
 		}
 	}
@@ -220,10 +221,10 @@ func (m *MPTokenIssuanceSet) Apply(ctx *tx.ApplyContext) tx.Result {
 const zeroHash256 = "0000000000000000000000000000000000000000000000000000000000000000"
 
 // setHolderToken modifies a specific holder's MPToken (lock/unlock).
-func (m *MPTokenIssuanceSet) setHolderToken(ctx *tx.ApplyContext, issuanceKey keylet.Keylet, issuance *state.MPTokenIssuanceData, txFlags uint32) tx.Result {
+func (m *MPTokenIssuanceSet) setHolderToken(ctx *tx.ApplyContext, issuanceKey keylet.Keylet, issuance *state.MPTokenIssuanceData, txFlags uint32) ter.Result {
 	holderID, err := state.DecodeAccountID(m.Holder)
 	if err != nil {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	// Holder account must exist
@@ -234,7 +235,7 @@ func (m *MPTokenIssuanceSet) setHolderToken(ctx *tx.ApplyContext, issuanceKey ke
 		ctx.Log.Warn("mptoken issuance set: holder account does not exist",
 			"holder", m.Holder,
 		)
-		return tx.TecNO_DST
+		return ter.TecNO_DST
 	}
 
 	// MPToken must exist
@@ -244,13 +245,13 @@ func (m *MPTokenIssuanceSet) setHolderToken(ctx *tx.ApplyContext, issuanceKey ke
 		ctx.Log.Warn("mptoken issuance set: holder token not found",
 			"holder", m.Holder,
 		)
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 
 	token, err := state.ParseMPToken(tokenRaw)
 	if err != nil {
 		ctx.Log.Error("mptoken issuance set: failed to parse holder token", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Toggle lock/unlock on the token
@@ -264,19 +265,19 @@ func (m *MPTokenIssuanceSet) setHolderToken(ctx *tx.ApplyContext, issuanceKey ke
 	updatedData, err := state.SerializeMPToken(token)
 	if err != nil {
 		ctx.Log.Error("mptoken issuance set: failed to serialize holder token", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(tokenKey, updatedData); err != nil {
 		ctx.Log.Error("mptoken issuance set: failed to update holder token", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // setIssuance modifies the issuance itself (lock/unlock and DomainID).
 // Reference: rippled MPTokenIssuanceSet.cpp doApply()
-func (m *MPTokenIssuanceSet) setIssuance(ctx *tx.ApplyContext, issuanceKey keylet.Keylet, issuance *state.MPTokenIssuanceData, txFlags uint32) tx.Result {
+func (m *MPTokenIssuanceSet) setIssuance(ctx *tx.ApplyContext, issuanceKey keylet.Keylet, issuance *state.MPTokenIssuanceData, txFlags uint32) ter.Result {
 	// Toggle lock/unlock on the issuance
 	if txFlags&MPTokenIssuanceSetFlagLock != 0 {
 		issuance.Flags |= entry.LsfMPTLocked
@@ -299,12 +300,12 @@ func (m *MPTokenIssuanceSet) setIssuance(ctx *tx.ApplyContext, issuanceKey keyle
 	updatedData, err := state.SerializeMPTokenIssuance(issuance)
 	if err != nil {
 		ctx.Log.Error("mptoken issuance set: failed to serialize issuance", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(issuanceKey, updatedData); err != nil {
 		ctx.Log.Error("mptoken issuance set: failed to update issuance", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/nftoken/iou_helpers.go
+++ b/internal/tx/nftoken/iou_helpers.go
@@ -8,44 +8,45 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 // checkNFTTrustlineAuthorized checks if an account is authorized for an IOU currency.
 // Returns tesSUCCESS if authorized, or tecNO_LINE/tecNO_AUTH if not.
 // Reference: rippled NFTokenUtils.cpp checkTrustlineAuthorized
-func checkNFTTrustlineAuthorized(view tx.LedgerView, accountID [20]byte, currency string, issuerID [20]byte) tx.Result {
+func checkNFTTrustlineAuthorized(view tx.LedgerView, accountID [20]byte, currency string, issuerID [20]byte) ter.Result {
 	// Issuer is always authorized for their own currency
 	if accountID == issuerID {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Read issuer account to check RequireAuth flag
 	issuerKey := keylet.Account(issuerID)
 	issuerData, err := view.Read(issuerKey)
 	if err != nil || issuerData == nil {
-		return tx.TecNO_ISSUER
+		return ter.TecNO_ISSUER
 	}
 	issuerAccount, err := state.ParseAccountRoot(issuerData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// If issuer doesn't require auth, any account can hold this currency
 	if issuerAccount.Flags&state.LsfRequireAuth == 0 {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Issuer requires auth — check if the trust line exists and is authorized
 	trustLineKey := keylet.Line(accountID, issuerID, currency)
 	trustLineData, err := view.Read(trustLineKey)
 	if err != nil || trustLineData == nil {
-		return tx.TecNO_LINE
+		return ter.TecNO_LINE
 	}
 
 	rs, err := state.ParseRippleState(trustLineData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Check authorization flag based on account ordering
@@ -54,55 +55,55 @@ func checkNFTTrustlineAuthorized(view tx.LedgerView, accountID [20]byte, currenc
 	// When id < issuer: issuer is the HIGH account → check LsfHighAuth (issuer's auth flag)
 	if state.CompareAccountIDsForLine(accountID, issuerID) > 0 {
 		if rs.Flags&state.LsfLowAuth == 0 {
-			return tx.TecNO_AUTH
+			return ter.TecNO_AUTH
 		}
 	} else {
 		if rs.Flags&state.LsfHighAuth == 0 {
-			return tx.TecNO_AUTH
+			return ter.TecNO_AUTH
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // checkNFTTrustlineDeepFrozen checks if the trust line between account and
 // the asset issuer is deep-frozen. Returns tecFROZEN if either side has set
 // deep freeze. Gated behind featureDeepFreeze.
 // Reference: rippled NFTokenUtils.cpp nft::checkTrustlineDeepFrozen()
-func checkNFTTrustlineDeepFrozen(view tx.LedgerView, accountID [20]byte, currency string, issuerID [20]byte, rules *amendment.Rules) tx.Result {
+func checkNFTTrustlineDeepFrozen(view tx.LedgerView, accountID [20]byte, currency string, issuerID [20]byte, rules *amendment.Rules) ter.Result {
 	if rules == nil || !rules.DeepFreezeEnabled() {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	issuerKey := keylet.Account(issuerID)
 	issuerData, err := view.Read(issuerKey)
 	if err != nil || issuerData == nil {
-		return tx.TecNO_ISSUER
+		return ter.TecNO_ISSUER
 	}
 
 	// An account can not create a trustline to itself
 	if accountID == issuerID {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	trustLineKey := keylet.Line(accountID, issuerID, currency)
 	trustLineData, err := view.Read(trustLineKey)
 	if err != nil || trustLineData == nil {
 		// No trust line — not frozen
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	rs, err := state.ParseRippleState(trustLineData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Either side having deep freeze set blocks the operation
 	if (rs.Flags & (state.LsfLowDeepFreeze | state.LsfHighDeepFreeze)) != 0 {
-		return tx.TecFROZEN
+		return ter.TecFROZEN
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // offerIOUToAmount converts an NFTokenOfferData's IOU amount to a tx.Amount.
@@ -125,14 +126,14 @@ func offerIOUToAmount(offer *state.NFTokenOfferData) (tx.Amount, error) {
 //  3. third party: two trust line modifications with optional transfer rate
 //
 // Reference: rippled View.cpp accountSend → rippleSendIOU → rippleCreditIOU
-func accountSendIOU(view tx.LedgerView, from, to [20]byte, amount tx.Amount) tx.Result {
+func accountSendIOU(view tx.LedgerView, from, to [20]byte, amount tx.Amount) ter.Result {
 	if amount.IsZero() || from == to {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	issuerID, err := state.DecodeAccountID(amount.Issuer)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if from == issuerID || to == issuerID {
@@ -149,7 +150,7 @@ func accountSendIOU(view tx.LedgerView, from, to [20]byte, amount tx.Amount) tx.
 		rateAmount := state.NewIssuedAmountFromValue(int64(transferRate), -9, amount.Currency, amount.Issuer)
 		senderAmount := amount.Mul(rateAmount, false)
 		// Credit receiver the original amount
-		if r := rippleCreditIOU(view, issuerID, to, amount); r != tx.TesSUCCESS {
+		if r := rippleCreditIOU(view, issuerID, to, amount); r != ter.TesSUCCESS {
 			return r
 		}
 		// Debit sender the increased amount
@@ -157,7 +158,7 @@ func accountSendIOU(view tx.LedgerView, from, to [20]byte, amount tx.Amount) tx.
 	}
 
 	// No transfer rate — direct credit/debit
-	if r := rippleCreditIOU(view, issuerID, to, amount); r != tx.TesSUCCESS {
+	if r := rippleCreditIOU(view, issuerID, to, amount); r != ter.TesSUCCESS {
 		return r
 	}
 	return rippleCreditIOU(view, from, issuerID, amount)
@@ -166,14 +167,14 @@ func accountSendIOU(view tx.LedgerView, from, to [20]byte, amount tx.Amount) tx.
 // rippleCreditIOU modifies the trust line balance between two accounts.
 // If the trust line does not exist, it is auto-created (matching rippled's rippleCredit).
 // Reference: rippled Ledger/View.cpp rippleCredit
-func rippleCreditIOU(view tx.LedgerView, sender, receiver [20]byte, amount tx.Amount) tx.Result {
+func rippleCreditIOU(view tx.LedgerView, sender, receiver [20]byte, amount tx.Amount) ter.Result {
 	if amount.IsZero() {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	issuerID, err := state.DecodeAccountID(amount.Issuer)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Determine the two accounts for the trust line
@@ -197,7 +198,7 @@ func rippleCreditIOU(view tx.LedgerView, sender, receiver [20]byte, amount tx.Am
 
 	rs, err := state.ParseRippleState(trustLineData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Balance is stored from the low account's perspective (positive = low holds).
@@ -212,7 +213,7 @@ func rippleCreditIOU(view tx.LedgerView, sender, receiver [20]byte, amount tx.Am
 		newBalance, err = oldBalance.Add(amount)
 	}
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	rs.Balance = newBalance
 
@@ -223,22 +224,22 @@ func rippleCreditIOU(view tx.LedgerView, sender, receiver [20]byte, amount tx.Am
 	// reserve). Skipping this leaves stale lines and inflated owner counts —
 	// a permanent ledger-state divergence.
 	deleted, r := clearSenderReserveOnZero(view, rs, sender, receiver, senderIsLow, oldBalance, newBalance, trustLineKey)
-	if r != tx.TesSUCCESS {
+	if r != ter.TesSUCCESS {
 		return r
 	}
 	if deleted {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	updated, err := state.SerializeRippleState(rs)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := view.Update(trustLineKey, updated); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // clearSenderReserveOnZero applies the trust-line cleanup tail of rippled's
@@ -248,7 +249,7 @@ func rippleCreditIOU(view tx.LedgerView, sender, receiver [20]byte, amount tx.Am
 // the line when it is empty and the receiver carries no reserve. Returns whether
 // the line was deleted.
 // Reference: rippled View.cpp rippleCreditIOU.
-func clearSenderReserveOnZero(view tx.LedgerView, rs *state.RippleState, sender, receiver [20]byte, senderIsLow bool, oldBalance, newBalance tx.Amount, trustLineKey keylet.Keylet) (bool, tx.Result) {
+func clearSenderReserveOnZero(view tx.LedgerView, rs *state.RippleState, sender, receiver [20]byte, senderIsLow bool, oldBalance, newBalance tx.Amount, trustLineKey keylet.Keylet) (bool, ter.Result) {
 	// Express the before/after balance in the sender's terms (negate the stored
 	// low-perspective balance when the sender is the high account).
 	senderBefore, senderAfter := oldBalance, newBalance
@@ -257,7 +258,7 @@ func clearSenderReserveOnZero(view tx.LedgerView, rs *state.RippleState, sender,
 		senderAfter = senderAfter.Negate()
 	}
 	if senderBefore.Signum() <= 0 || senderAfter.Signum() > 0 {
-		return false, tx.TesSUCCESS
+		return false, ter.TesSUCCESS
 	}
 
 	senderReserve, senderNoRipple, senderFreeze := state.LsfHighReserve, state.LsfHighNoRipple, state.LsfHighFreeze
@@ -270,31 +271,31 @@ func clearSenderReserveOnZero(view tx.LedgerView, rs *state.RippleState, sender,
 	}
 
 	if rs.Flags&senderReserve == 0 || rs.Flags&senderFreeze != 0 {
-		return false, tx.TesSUCCESS
+		return false, ter.TesSUCCESS
 	}
 	if !senderLimit.IsZero() || senderQualityIn != 0 || senderQualityOut != 0 {
-		return false, tx.TesSUCCESS
+		return false, ter.TesSUCCESS
 	}
 
 	// The line's NoRipple flag for the sender must be the opposite of the
 	// sender account's DefaultRipple setting (rippled's XOR gate).
 	senderAcctData, errRead := view.Read(keylet.Account(sender))
 	if errRead != nil || senderAcctData == nil {
-		return false, tx.TefINTERNAL
+		return false, ter.TefINTERNAL
 	}
 	senderAcct, errParse := state.ParseAccountRoot(senderAcctData)
 	if errParse != nil {
-		return false, tx.TefINTERNAL
+		return false, ter.TefINTERNAL
 	}
 	if (rs.Flags&senderNoRipple != 0) == (senderAcct.Flags&state.LsfDefaultRipple != 0) {
-		return false, tx.TesSUCCESS
+		return false, ter.TesSUCCESS
 	}
 
 	adjustOwnerCountViaView(view, sender, -1)
 	rs.Flags &^= senderReserve
 
 	if !rs.Balance.IsZero() || rs.Flags&receiverReserve != 0 {
-		return false, tx.TesSUCCESS
+		return false, ter.TesSUCCESS
 	}
 
 	return true, trustDeleteLine(view, rs, sender, receiver, senderIsLow, trustLineKey)
@@ -302,7 +303,7 @@ func clearSenderReserveOnZero(view tx.LedgerView, rs *state.RippleState, sender,
 
 // trustDeleteLine removes an emptied trust line from both owner directories and
 // erases the SLE. Reference: rippled View.cpp trustDelete.
-func trustDeleteLine(view tx.LedgerView, rs *state.RippleState, sender, receiver [20]byte, senderIsLow bool, trustLineKey keylet.Keylet) tx.Result {
+func trustDeleteLine(view tx.LedgerView, rs *state.RippleState, sender, receiver [20]byte, senderIsLow bool, trustLineKey keylet.Keylet) ter.Result {
 	lowID, highID := receiver, sender
 	if senderIsLow {
 		lowID, highID = sender, receiver
@@ -315,30 +316,30 @@ func trustDeleteLine(view tx.LedgerView, rs *state.RippleState, sender, receiver
 	// transaction metadata diverges.
 	updated, err := state.SerializeRippleState(rs)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := view.Update(trustLineKey, updated); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	lowResult, err := state.DirRemove(view, keylet.OwnerDir(lowID), rs.LowNode, trustLineKey.Key, false)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if !lowResult.Success {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	highResult, err := state.DirRemove(view, keylet.OwnerDir(highID), rs.HighNode, trustLineKey.Key, false)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if !highResult.Success {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 	if err := view.Erase(trustLineKey); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // payIOU wraps accountSendIOU with post-hoc balance validation.
@@ -346,9 +347,9 @@ func trustDeleteLine(view tx.LedgerView, rs *state.RippleState, sender, receiver
 // neither party's balance went negative (which would indicate insufficient funds
 // to cover the IOU transfer rate).
 // Reference: rippled NFTokenAcceptOffer.cpp pay()
-func payIOU(ctx *tx.ApplyContext, from, to [20]byte, amount tx.Amount) tx.Result {
+func payIOU(ctx *tx.ApplyContext, from, to [20]byte, amount tx.Amount) ter.Result {
 	if amount.IsZero() {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	result := accountSendIOU(ctx.View, from, to, amount)
@@ -356,19 +357,19 @@ func payIOU(ctx *tx.ApplyContext, from, to [20]byte, amount tx.Amount) tx.Result
 	if !ctx.Rules().Enabled(amendment.FeatureFixNonFungibleTokensV1_2) {
 		return result
 	}
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 
 	// Post-hoc check: ensure neither party went negative after accounting for transfer rate
 	if accountIOUBalanceSignum(ctx.View, from, amount) < 0 {
-		return tx.TecINSUFFICIENT_FUNDS
+		return ter.TecINSUFFICIENT_FUNDS
 	}
 	if accountIOUBalanceSignum(ctx.View, to, amount) < 0 {
-		return tx.TecINSUFFICIENT_FUNDS
+		return ter.TecINSUFFICIENT_FUNDS
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // accountIOUBalanceSignum returns the signum of an account's IOU balance.
@@ -448,7 +449,7 @@ func accountHoldsIOU(view tx.LedgerView, accountID [20]byte, amount tx.Amount) t
 // Only the RECEIVER gets a reserve flag set and OwnerCount incremented.
 // NoRipple flags are set based on each account's DefaultRipple setting.
 // Reference: rippled Ledger/View.cpp rippleCredit → trustCreate
-func createTrustLineWithBalance(view tx.LedgerView, sender, receiver [20]byte, amount tx.Amount, trustLineKey keylet.Keylet) tx.Result {
+func createTrustLineWithBalance(view tx.LedgerView, sender, receiver [20]byte, amount tx.Amount, trustLineKey keylet.Keylet) ter.Result {
 	senderIsHigh := state.CompareAccountIDsForLine(sender, receiver) > 0
 
 	// Determine low/high accounts
@@ -463,11 +464,11 @@ func createTrustLineWithBalance(view tx.LedgerView, sender, receiver [20]byte, a
 
 	lowAccountStr, err := state.EncodeAccountID(lowAccountID)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	highAccountStr, err := state.EncodeAccountID(highAccountID)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Convention: positive balance = LOW account holds tokens
@@ -499,11 +500,11 @@ func createTrustLineWithBalance(view tx.LedgerView, sender, receiver [20]byte, a
 	// If an account does NOT have DefaultRipple, set NoRipple on that side.
 	receiverAcctData, err := view.Read(keylet.Account(receiver))
 	if err != nil || receiverAcctData == nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	receiverAcct, err := state.ParseAccountRoot(receiverAcctData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	receiverNoRipple := (receiverAcct.Flags & state.LsfDefaultRipple) == 0
 	if receiverNoRipple {
@@ -516,11 +517,11 @@ func createTrustLineWithBalance(view tx.LedgerView, sender, receiver [20]byte, a
 
 	senderAcctData, err := view.Read(keylet.Account(sender))
 	if err != nil || senderAcctData == nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	senderAcct, err := state.ParseAccountRoot(senderAcctData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	senderNoRipple := (senderAcct.Flags & state.LsfDefaultRipple) == 0
 	if senderNoRipple {
@@ -544,7 +545,7 @@ func createTrustLineWithBalance(view tx.LedgerView, sender, receiver [20]byte, a
 		dir.Owner = lowAccountID
 	})
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	rs.LowNode = lowDirResult.Page
 
@@ -554,52 +555,52 @@ func createTrustLineWithBalance(view tx.LedgerView, sender, receiver [20]byte, a
 		dir.Owner = highAccountID
 	})
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	rs.HighNode = highDirResult.Page
 
 	// Serialize and insert the trust line
 	trustLineData, err := state.SerializeRippleState(rs)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := view.Insert(trustLineKey, trustLineData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Only increment OwnerCount for the RECEIVER (matching rippled's trustCreate).
 	// The sender (IOU issuer) doesn't get a reserve for auto-created trust lines.
 	adjustOwnerCountViaView(view, receiver, 1)
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // checkIssuerTrustLineForAccept checks that the NFT issuer has a trust line for the
 // IOU currency. Used by NFTokenAcceptOffer doApply path — gated on fixEnforceNFTokenTrustline.
 // Reference: rippled NFTokenAcceptOffer.cpp doApply lines 373-377
-func checkIssuerTrustLineForAccept(ctx *tx.ApplyContext, nftIssuerID [20]byte, amount tx.Amount, nftFlags uint16) tx.Result {
+func checkIssuerTrustLineForAccept(ctx *tx.ApplyContext, nftIssuerID [20]byte, amount tx.Amount, nftFlags uint16) ter.Result {
 	if !ctx.Rules().Enabled(amendment.FeatureFixEnforceNFTokenTrustline) {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	if nftFlags&NFTokenFlagTrustLine != 0 {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	iouIssuerID, err := state.DecodeAccountID(amount.Issuer)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// NFT issuer == IOU issuer: issuer doesn't need trust line for own currency
 	if nftIssuerID == iouIssuerID {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	trustLineKey := keylet.Line(nftIssuerID, iouIssuerID, amount.Currency)
 	trustLineData, err := ctx.View.Read(trustLineKey)
 	if err != nil || trustLineData == nil {
-		return tx.TecNO_LINE
+		return ter.TecNO_LINE
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/nftoken/nftoken_accept.go
+++ b/internal/tx/nftoken/nftoken_accept.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -14,12 +15,12 @@ import (
 // checkBuyerReserve checks if the buyer has sufficient reserve after receiving
 // an NFToken. Only applies when fixNFTokenReserve amendment is enabled.
 // Reference: rippled NFTokenAcceptOffer.cpp transferNFToken() lines 457-474
-func checkBuyerReserve(ctx *tx.ApplyContext, buyerID [20]byte, pagesCreated int) tx.Result {
+func checkBuyerReserve(ctx *tx.ApplyContext, buyerID [20]byte, pagesCreated int) ter.Result {
 	if !ctx.Rules().Enabled(amendment.FeatureFixNFTokenReserve) {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	if pagesCreated <= 0 {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Read buyer's current state to check balance vs reserve
@@ -32,20 +33,20 @@ func checkBuyerReserve(ctx *tx.ApplyContext, buyerID [20]byte, pagesCreated int)
 		buyerKey := keylet.Account(buyerID)
 		buyerData, err := ctx.View.Read(buyerKey)
 		if err != nil || buyerData == nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		buyerAccount, err := state.ParseAccountRoot(buyerData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		buyerBalance = buyerAccount.Balance
 		buyerOwnerCount = buyerAccount.OwnerCount
 	}
 
 	if buyerBalance < ctx.AccountReserve(buyerOwnerCount) {
-		return tx.TecINSUFFICIENT_RESERVE
+		return ter.TecINSUFFICIENT_RESERVE
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // syncCtxOwnerCount re-reads the submitter's OwnerCount from the view and
@@ -78,7 +79,7 @@ func syncCtxOwnerCount(ctx *tx.ApplyContext) {
 // Reference: rippled NFTokenAcceptOffer.cpp doApply (brokered mode)
 func (n *NFTokenAcceptOffer) executeBrokeredMode(ctx *tx.ApplyContext, accountID [20]byte,
 	buyOffer, sellOffer *state.NFTokenOfferData, buyOfferKey, sellOfferKey keylet.Keylet,
-	buyOfferNegative, sellOfferNegative bool) tx.Result {
+	buyOfferNegative, sellOfferNegative bool) ter.Result {
 	sellerID := sellOffer.Owner
 	buyerID := buyOffer.Owner
 
@@ -90,10 +91,10 @@ func (n *NFTokenAcceptOffer) executeBrokeredMode(ctx *tx.ApplyContext, accountID
 	// only after both deletions succeed.
 	// Reference: rippled NFTokenAcceptOffer.cpp doApply() lines 527-539.
 	if err := deleteTokenOffer(ctx.View, buyOfferKey); err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	if err := deleteTokenOffer(ctx.View, sellOfferKey); err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	adjustOwnerCountViaView(ctx.View, buyerID, -1)
 	adjustOwnerCountViaView(ctx.View, sellerID, -1)
@@ -122,12 +123,12 @@ func (n *NFTokenAcceptOffer) executeBrokeredMode(ctx *tx.ApplyContext, accountID
 			// IOU brokered payment path
 			buyAmount, err := offerIOUToAmount(buyOffer)
 			if err != nil {
-				return tx.TecINTERNAL
+				return ter.TecINTERNAL
 			}
 
 			// Step 1: Pay broker fee
 			if n.NFTokenBrokerFee != nil && !brokerFeeIOU.IsZero() {
-				if r := payIOU(ctx, buyerID, accountID, brokerFeeIOU); r != tx.TesSUCCESS {
+				if r := payIOU(ctx, buyerID, accountID, brokerFeeIOU); r != ter.TesSUCCESS {
 					return r
 				}
 				buyAmount, _ = buyAmount.Sub(brokerFeeIOU)
@@ -137,12 +138,12 @@ func (n *NFTokenAcceptOffer) executeBrokeredMode(ctx *tx.ApplyContext, accountID
 			if transferFee != 0 && !buyAmount.IsZero() && sellerID != nftIssuerID && buyerID != nftIssuerID {
 				// Check issuer trust line (fixEnforceNFTokenTrustline)
 				nftFlags := getNFTFlagsFromID(sellOffer.NFTokenID)
-				if r := checkIssuerTrustLineForAccept(ctx, nftIssuerID, buyAmount, nftFlags); r != tx.TesSUCCESS {
+				if r := checkIssuerTrustLineForAccept(ctx, nftIssuerID, buyAmount, nftFlags); r != ter.TesSUCCESS {
 					return r
 				}
 				issuerCut := buyAmount.MulRatio(uint32(transferFee), transferFeeDivisor32, true)
 				if !issuerCut.IsZero() {
-					if r := payIOU(ctx, buyerID, nftIssuerID, issuerCut); r != tx.TesSUCCESS {
+					if r := payIOU(ctx, buyerID, nftIssuerID, issuerCut); r != ter.TesSUCCESS {
 						return r
 					}
 					buyAmount, _ = buyAmount.Sub(issuerCut)
@@ -151,7 +152,7 @@ func (n *NFTokenAcceptOffer) executeBrokeredMode(ctx *tx.ApplyContext, accountID
 
 			// Step 3: Pay seller remainder
 			if !buyAmount.IsZero() {
-				if r := payIOU(ctx, buyerID, sellerID, buyAmount); r != tx.TesSUCCESS {
+				if r := payIOU(ctx, buyerID, sellerID, buyAmount); r != ter.TesSUCCESS {
 					return r
 				}
 			}
@@ -166,16 +167,16 @@ func (n *NFTokenAcceptOffer) executeBrokeredMode(ctx *tx.ApplyContext, accountID
 			buyerKey := keylet.Account(buyerID)
 			buyerData, err := ctx.View.Read(buyerKey)
 			if err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			buyerAccount, err := state.ParseAccountRoot(buyerData)
 			if err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			buyerAccount.Balance -= amount
 			buyerUpdated, _ := state.SerializeAccountRoot(buyerAccount)
 			if err := ctx.View.Update(buyerKey, buyerUpdated); err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 
 			var issuerCut uint64
@@ -211,19 +212,19 @@ func (n *NFTokenAcceptOffer) executeBrokeredMode(ctx *tx.ApplyContext, accountID
 			sellerKey := keylet.Account(sellerID)
 			sellerData, err := ctx.View.Read(sellerKey)
 			if err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			sellerAccount, err := state.ParseAccountRoot(sellerData)
 			if err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			sellerAccount.Balance += amount
 			sellerUpdatedData, err := state.SerializeAccountRoot(sellerAccount)
 			if err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			if err := ctx.View.Update(sellerKey, sellerUpdatedData); err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 		}
 	}
@@ -232,7 +233,7 @@ func (n *NFTokenAcceptOffer) executeBrokeredMode(ctx *tx.ApplyContext, accountID
 	fixPageLinks := ctx.Rules().Enabled(amendment.FeatureFixNFTokenPageLinks)
 	fixDirV1 := ctx.Rules().Enabled(amendment.FeatureFixNFTokenDirV1)
 	xferResult := transferNFToken(sellerID, buyerID, sellOffer.NFTokenID, ctx.View, fixPageLinks, fixDirV1)
-	if xferResult.Result != tx.TesSUCCESS {
+	if xferResult.Result != ter.TesSUCCESS {
 		return xferResult.Result
 	}
 
@@ -241,24 +242,24 @@ func (n *NFTokenAcceptOffer) executeBrokeredMode(ctx *tx.ApplyContext, accountID
 	adjustOwnerCountViaView(ctx.View, buyerID, xferResult.ToPagesCreated)
 
 	// Check buyer reserve (fixNFTokenReserve)
-	if r := checkBuyerReserve(ctx, buyerID, xferResult.ToPagesCreated); r != tx.TesSUCCESS {
+	if r := checkBuyerReserve(ctx, buyerID, xferResult.ToPagesCreated); r != ter.TesSUCCESS {
 		return r
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // acceptNFTokenSellOfferDirect handles direct sell offer acceptance
 func (n *NFTokenAcceptOffer) acceptNFTokenSellOfferDirect(ctx *tx.ApplyContext, accountID [20]byte,
-	sellOffer *state.NFTokenOfferData, sellOfferKey keylet.Keylet) tx.Result {
+	sellOffer *state.NFTokenOfferData, sellOfferKey keylet.Keylet) ter.Result {
 	if sellOffer.HasDestination && sellOffer.Destination != accountID {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Verify seller owns the token
 	sellerID := sellOffer.Owner
 	if _, _, _, found := findToken(ctx.View, sellerID, sellOffer.NFTokenID); !found {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	transferFee := getNFTTransferFee(sellOffer.NFTokenID)
@@ -269,7 +270,7 @@ func (n *NFTokenAcceptOffer) acceptNFTokenSellOfferDirect(ctx *tx.ApplyContext, 
 	// Delete offer FIRST, matching rippled's doApply order; a failed deletion is
 	// tecINTERNAL. Offer data is already parsed into sellOffer.
 	if err := deleteTokenOffer(ctx.View, sellOfferKey); err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	adjustOwnerCountViaView(ctx.View, sellerID, -1)
 
@@ -277,19 +278,19 @@ func (n *NFTokenAcceptOffer) acceptNFTokenSellOfferDirect(ctx *tx.ApplyContext, 
 		// IOU payment path
 		sellAmount, err := offerIOUToAmount(sellOffer)
 		if err != nil {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 
 		// Calculate issuer cut for transfer fee
 		if transferFee != 0 && !sellAmount.IsZero() && sellerID != nftIssuerID && accountID != nftIssuerID {
 			// Check issuer trust line (fixEnforceNFTokenTrustline)
 			nftFlags := getNFTFlagsFromID(sellOffer.NFTokenID)
-			if r := checkIssuerTrustLineForAccept(ctx, nftIssuerID, sellAmount, nftFlags); r != tx.TesSUCCESS {
+			if r := checkIssuerTrustLineForAccept(ctx, nftIssuerID, sellAmount, nftFlags); r != ter.TesSUCCESS {
 				return r
 			}
 			issuerCut := sellAmount.MulRatio(uint32(transferFee), transferFeeDivisor32, true)
 			if !issuerCut.IsZero() {
-				if r := payIOU(ctx, accountID, nftIssuerID, issuerCut); r != tx.TesSUCCESS {
+				if r := payIOU(ctx, accountID, nftIssuerID, issuerCut); r != ter.TesSUCCESS {
 					return r
 				}
 				sellAmount, _ = sellAmount.Sub(issuerCut)
@@ -298,7 +299,7 @@ func (n *NFTokenAcceptOffer) acceptNFTokenSellOfferDirect(ctx *tx.ApplyContext, 
 
 		// Pay seller remainder
 		if !sellAmount.IsZero() {
-			if r := payIOU(ctx, accountID, sellerID, sellAmount); r != tx.TesSUCCESS {
+			if r := payIOU(ctx, accountID, sellerID, sellAmount); r != ter.TesSUCCESS {
 				return r
 			}
 		}
@@ -337,19 +338,19 @@ func (n *NFTokenAcceptOffer) acceptNFTokenSellOfferDirect(ctx *tx.ApplyContext, 
 		sellerKey := keylet.Account(sellerID)
 		sellerData, err := ctx.View.Read(sellerKey)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		sellerAccount, err := state.ParseAccountRoot(sellerData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		sellerAccount.Balance += amount
 		sellerUpdatedData, err := state.SerializeAccountRoot(sellerAccount)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := ctx.View.Update(sellerKey, sellerUpdatedData); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
@@ -357,7 +358,7 @@ func (n *NFTokenAcceptOffer) acceptNFTokenSellOfferDirect(ctx *tx.ApplyContext, 
 	fixPageLinks := ctx.Rules().Enabled(amendment.FeatureFixNFTokenPageLinks)
 	fixDirV1 := ctx.Rules().Enabled(amendment.FeatureFixNFTokenDirV1)
 	xferResult := transferNFToken(sellerID, accountID, sellOffer.NFTokenID, ctx.View, fixPageLinks, fixDirV1)
-	if xferResult.Result != tx.TesSUCCESS {
+	if xferResult.Result != ter.TesSUCCESS {
 		return xferResult.Result
 	}
 
@@ -366,23 +367,23 @@ func (n *NFTokenAcceptOffer) acceptNFTokenSellOfferDirect(ctx *tx.ApplyContext, 
 	ctx.Account.OwnerCount += uint32(xferResult.ToPagesCreated)
 
 	// Check buyer reserve (fixNFTokenReserve) — buyer is ctx.Account
-	if r := checkBuyerReserve(ctx, accountID, xferResult.ToPagesCreated); r != tx.TesSUCCESS {
+	if r := checkBuyerReserve(ctx, accountID, xferResult.ToPagesCreated); r != ter.TesSUCCESS {
 		return r
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // acceptNFTokenBuyOfferDirect handles direct buy offer acceptance
 func (n *NFTokenAcceptOffer) acceptNFTokenBuyOfferDirect(ctx *tx.ApplyContext, accountID [20]byte,
-	buyOffer *state.NFTokenOfferData, buyOfferKey keylet.Keylet) tx.Result {
+	buyOffer *state.NFTokenOfferData, buyOfferKey keylet.Keylet) ter.Result {
 	// Verify account owns the token
 	if _, _, _, found := findToken(ctx.View, accountID, buyOffer.NFTokenID); !found {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	if buyOffer.HasDestination && buyOffer.Destination != accountID {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	buyerID := buyOffer.Owner
@@ -394,7 +395,7 @@ func (n *NFTokenAcceptOffer) acceptNFTokenBuyOfferDirect(ctx *tx.ApplyContext, a
 	// Delete offer FIRST, matching rippled's doApply order; a failed deletion is
 	// tecINTERNAL. Offer data is already parsed into buyOffer.
 	if err := deleteTokenOffer(ctx.View, buyOfferKey); err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	adjustOwnerCountViaView(ctx.View, buyerID, -1)
 
@@ -402,19 +403,19 @@ func (n *NFTokenAcceptOffer) acceptNFTokenBuyOfferDirect(ctx *tx.ApplyContext, a
 		// IOU payment path: buyer pays seller via trust lines
 		buyAmount, err := offerIOUToAmount(buyOffer)
 		if err != nil {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 
 		// Calculate issuer cut for transfer fee
 		if transferFee != 0 && !buyAmount.IsZero() && accountID != nftIssuerID && buyerID != nftIssuerID {
 			// Check issuer trust line (fixEnforceNFTokenTrustline)
 			nftFlags := getNFTFlagsFromID(buyOffer.NFTokenID)
-			if r := checkIssuerTrustLineForAccept(ctx, nftIssuerID, buyAmount, nftFlags); r != tx.TesSUCCESS {
+			if r := checkIssuerTrustLineForAccept(ctx, nftIssuerID, buyAmount, nftFlags); r != ter.TesSUCCESS {
 				return r
 			}
 			issuerCut := buyAmount.MulRatio(uint32(transferFee), transferFeeDivisor32, true)
 			if !issuerCut.IsZero() {
-				if r := payIOU(ctx, buyerID, nftIssuerID, issuerCut); r != tx.TesSUCCESS {
+				if r := payIOU(ctx, buyerID, nftIssuerID, issuerCut); r != ter.TesSUCCESS {
 					return r
 				}
 				buyAmount, _ = buyAmount.Sub(issuerCut)
@@ -423,7 +424,7 @@ func (n *NFTokenAcceptOffer) acceptNFTokenBuyOfferDirect(ctx *tx.ApplyContext, a
 
 		// Pay seller remainder
 		if !buyAmount.IsZero() {
-			if r := payIOU(ctx, buyerID, accountID, buyAmount); r != tx.TesSUCCESS {
+			if r := payIOU(ctx, buyerID, accountID, buyAmount); r != ter.TesSUCCESS {
 				return r
 			}
 		}
@@ -439,16 +440,16 @@ func (n *NFTokenAcceptOffer) acceptNFTokenBuyOfferDirect(ctx *tx.ApplyContext, a
 		buyerKey := keylet.Account(buyerID)
 		buyerData, err := ctx.View.Read(buyerKey)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		buyerAccount, err := state.ParseAccountRoot(buyerData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		buyerAccount.Balance -= amount
 		buyerUpdated, _ := state.SerializeAccountRoot(buyerAccount)
 		if err := ctx.View.Update(buyerKey, buyerUpdated); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		var issuerCut uint64
@@ -481,7 +482,7 @@ func (n *NFTokenAcceptOffer) acceptNFTokenBuyOfferDirect(ctx *tx.ApplyContext, a
 	fixPageLinks := ctx.Rules().Enabled(amendment.FeatureFixNFTokenPageLinks)
 	fixDirV1 := ctx.Rules().Enabled(amendment.FeatureFixNFTokenDirV1)
 	xferResult := transferNFToken(accountID, buyerID, buyOffer.NFTokenID, ctx.View, fixPageLinks, fixDirV1)
-	if xferResult.Result != tx.TesSUCCESS {
+	if xferResult.Result != ter.TesSUCCESS {
 		return xferResult.Result
 	}
 
@@ -490,9 +491,9 @@ func (n *NFTokenAcceptOffer) acceptNFTokenBuyOfferDirect(ctx *tx.ApplyContext, a
 	adjustOwnerCountViaView(ctx.View, buyerID, xferResult.ToPagesCreated)
 
 	// Check buyer reserve (fixNFTokenReserve)
-	if r := checkBuyerReserve(ctx, buyerID, xferResult.ToPagesCreated); r != tx.TesSUCCESS {
+	if r := checkBuyerReserve(ctx, buyerID, xferResult.ToPagesCreated); r != ter.TesSUCCESS {
 		return r
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/nftoken/nftoken_accept_offer.go
+++ b/internal/tx/nftoken/nftoken_accept_offer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -43,32 +44,32 @@ func (n *NFTokenAcceptOffer) Validate() error {
 
 	// Check for invalid flags (no flags are valid for NFTokenAcceptOffer)
 	if n.GetFlags() != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "NFTokenAcceptOffer does not accept any flags")
+		return ter.Errorf(ter.TemINVALID_FLAG, "NFTokenAcceptOffer does not accept any flags")
 	}
 
 	// Must have at least one offer
 	if n.NFTokenSellOffer == "" && n.NFTokenBuyOffer == "" {
-		return tx.Errorf(tx.TemMALFORMED, "must specify NFTokenSellOffer or NFTokenBuyOffer")
+		return ter.Errorf(ter.TemMALFORMED, "must specify NFTokenSellOffer or NFTokenBuyOffer")
 	}
 
 	// BrokerFee only valid for brokered mode (both offers)
 	if n.NFTokenBrokerFee != nil {
 		if n.NFTokenSellOffer == "" || n.NFTokenBuyOffer == "" {
-			return tx.Errorf(tx.TemMALFORMED, "NFTokenBrokerFee requires both sell and buy offers")
+			return ter.Errorf(ter.TemMALFORMED, "NFTokenBrokerFee requires both sell and buy offers")
 		}
 		// BrokerFee must be positive (greater than zero)
 		// Reference: rippled NFTokenAcceptOffer.cpp:56 - if (*bf <= beast::zero)
 		if n.NFTokenBrokerFee.IsZero() {
-			return tx.Errorf(tx.TemMALFORMED, "NFTokenBrokerFee must be greater than zero")
+			return ter.Errorf(ter.TemMALFORMED, "NFTokenBrokerFee must be greater than zero")
 		}
 	}
 
 	// Validate offer IDs are valid hex strings (64 characters = 32 bytes)
 	if n.NFTokenSellOffer != "" && len(n.NFTokenSellOffer) != 64 {
-		return tx.Errorf(tx.TemMALFORMED, "invalid NFTokenSellOffer format")
+		return ter.Errorf(ter.TemMALFORMED, "invalid NFTokenSellOffer format")
 	}
 	if n.NFTokenBuyOffer != "" && len(n.NFTokenBuyOffer) != 64 {
-		return tx.Errorf(tx.TemMALFORMED, "invalid NFTokenBuyOffer format")
+		return ter.Errorf(ter.TemMALFORMED, "invalid NFTokenBuyOffer format")
 	}
 
 	return nil
@@ -99,7 +100,7 @@ func (n *NFTokenAcceptOffer) RequiredAmendments() [][32]byte {
 //  3. Buy offer checks (type, own offer, ownership, fund, auth)
 //  4. Sell offer checks (type, own offer, ownership, fund, auth)
 //  5. Transfer fee issuer checks
-func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
+func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("nftoken accept offer apply",
 		"account", n.Account,
 		"buyOffer", n.NFTokenBuyOffer,
@@ -122,7 +123,7 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	if n.NFTokenBuyOffer != "" {
 		buyOfferIDBytes, err := hex.DecodeString(n.NFTokenBuyOffer)
 		if err != nil || len(buyOfferIDBytes) != 32 {
-			return tx.TemINVALID
+			return ter.TemINVALID
 		}
 		var buyOfferKeyBytes [32]byte
 		copy(buyOfferKeyBytes[:], buyOfferIDBytes)
@@ -131,7 +132,7 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Zero offer ID check
 		var zeroID [32]byte
 		if buyOfferKeyBytes == zeroID {
-			return tx.TecOBJECT_NOT_FOUND
+			return ter.TecOBJECT_NOT_FOUND
 		}
 
 		buyOfferData, err := ctx.View.Read(buyOfferKey)
@@ -139,18 +140,18 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 			ctx.Log.Warn("nftoken accept offer: buy offer not found",
 				"buyOffer", n.NFTokenBuyOffer,
 			)
-			return tx.TecOBJECT_NOT_FOUND
+			return ter.TecOBJECT_NOT_FOUND
 		}
 		buyOffer, err = state.ParseNFTokenOffer(buyOfferData)
 		if err != nil {
 			ctx.Log.Error("nftoken accept offer: failed to parse buy offer", "error", err)
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Check expiration
 		if tx.HasExpiredField(buyOffer.Expiration, ctx.Config.ParentCloseTime) {
 			ctx.Log.Warn("nftoken accept offer: buy offer expired")
-			return tx.TecEXPIRED
+			return ter.TecEXPIRED
 		}
 
 		// The parser records the amount's sign (uint64 Amount cannot).
@@ -160,7 +161,7 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Reference: rippled NFTokenAcceptOffer.cpp checkOffer lines 80-87
 		if ctx.Rules().Enabled(amendment.FeatureFixNFTokenNegOffer) {
 			if buyOfferNegative {
-				return tx.TemBAD_OFFER
+				return ter.TemBAD_OFFER
 			}
 		}
 	}
@@ -168,7 +169,7 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	if n.NFTokenSellOffer != "" {
 		sellOfferIDBytes, err := hex.DecodeString(n.NFTokenSellOffer)
 		if err != nil || len(sellOfferIDBytes) != 32 {
-			return tx.TemINVALID
+			return ter.TemINVALID
 		}
 		var sellOfferKeyBytes [32]byte
 		copy(sellOfferKeyBytes[:], sellOfferIDBytes)
@@ -177,7 +178,7 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Zero offer ID check
 		var zeroID [32]byte
 		if sellOfferKeyBytes == zeroID {
-			return tx.TecOBJECT_NOT_FOUND
+			return ter.TecOBJECT_NOT_FOUND
 		}
 
 		sellOfferData, err := ctx.View.Read(sellOfferKey)
@@ -185,18 +186,18 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 			ctx.Log.Warn("nftoken accept offer: sell offer not found",
 				"sellOffer", n.NFTokenSellOffer,
 			)
-			return tx.TecOBJECT_NOT_FOUND
+			return ter.TecOBJECT_NOT_FOUND
 		}
 		sellOffer, err = state.ParseNFTokenOffer(sellOfferData)
 		if err != nil {
 			ctx.Log.Error("nftoken accept offer: failed to parse sell offer", "error", err)
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Check expiration
 		if tx.HasExpiredField(sellOffer.Expiration, ctx.Config.ParentCloseTime) {
 			ctx.Log.Warn("nftoken accept offer: sell offer expired")
-			return tx.TecEXPIRED
+			return ter.TecEXPIRED
 		}
 
 		// The parser records the amount's sign (uint64 Amount cannot).
@@ -206,7 +207,7 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Reference: rippled NFTokenAcceptOffer.cpp checkOffer lines 80-87
 		if ctx.Rules().Enabled(amendment.FeatureFixNFTokenNegOffer) {
 			if sellOfferNegative {
-				return tx.TemBAD_OFFER
+				return ter.TemBAD_OFFER
 			}
 		}
 	}
@@ -216,26 +217,26 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	if buyOffer != nil && sellOffer != nil {
 		// Token IDs must match
 		if buyOffer.NFTokenID != sellOffer.NFTokenID {
-			return tx.TecNFTOKEN_BUY_SELL_MISMATCH
+			return ter.TecNFTOKEN_BUY_SELL_MISMATCH
 		}
 
 		// Asset type must match
 		buyIsXRP := buyOffer.AmountIOU == nil
 		sellIsXRP := sellOffer.AmountIOU == nil
 		if buyIsXRP != sellIsXRP {
-			return tx.TecNFTOKEN_BUY_SELL_MISMATCH
+			return ter.TecNFTOKEN_BUY_SELL_MISMATCH
 		}
 		if !buyIsXRP && !sellIsXRP {
 			if buyOffer.AmountIOU.Currency != sellOffer.AmountIOU.Currency ||
 				buyOffer.AmountIOU.Issuer != sellOffer.AmountIOU.Issuer {
-				return tx.TecNFTOKEN_BUY_SELL_MISMATCH
+				return ter.TecNFTOKEN_BUY_SELL_MISMATCH
 			}
 		}
 
 		// Loop check (fixNonFungibleTokensV1_2)
 		if ctx.Rules().Enabled(amendment.FeatureFixNonFungibleTokensV1_2) {
 			if buyOffer.Owner == sellOffer.Owner {
-				return tx.TecCANT_ACCEPT_OWN_NFTOKEN_OFFER
+				return ter.TecCANT_ACCEPT_OWN_NFTOKEN_OFFER
 			}
 		}
 
@@ -247,19 +248,19 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		if !(buyOfferNegative || sellOfferNegative) {
 			if buyIsXRP {
 				if sellOffer.Amount > buyOffer.Amount {
-					return tx.TecINSUFFICIENT_PAYMENT
+					return ter.TecINSUFFICIENT_PAYMENT
 				}
 			} else {
 				buyAmount, err := offerIOUToAmount(buyOffer)
 				if err != nil {
-					return tx.TecINTERNAL
+					return ter.TecINTERNAL
 				}
 				sellAmount, err := offerIOUToAmount(sellOffer)
 				if err != nil {
-					return tx.TecINTERNAL
+					return ter.TecINTERNAL
 				}
 				if sellAmount.Compare(buyAmount) > 0 {
-					return tx.TecINSUFFICIENT_PAYMENT
+					return ter.TecINSUFFICIENT_PAYMENT
 				}
 			}
 		}
@@ -268,19 +269,19 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		if buyOffer.HasDestination {
 			if ctx.Rules().Enabled(amendment.FeatureFixNonFungibleTokensV1_2) {
 				if buyOffer.Destination != accountID {
-					return tx.TecNO_PERMISSION
+					return ter.TecNO_PERMISSION
 				}
 			} else if buyOffer.Destination != sellOffer.Owner && buyOffer.Destination != accountID {
-				return tx.TecNFTOKEN_BUY_SELL_MISMATCH
+				return ter.TecNFTOKEN_BUY_SELL_MISMATCH
 			}
 		}
 		if sellOffer.HasDestination {
 			if ctx.Rules().Enabled(amendment.FeatureFixNonFungibleTokensV1_2) {
 				if sellOffer.Destination != accountID {
-					return tx.TecNO_PERMISSION
+					return ter.TecNO_PERMISSION
 				}
 			} else if sellOffer.Destination != buyOffer.Owner && sellOffer.Destination != accountID {
-				return tx.TecNFTOKEN_BUY_SELL_MISMATCH
+				return ter.TecNFTOKEN_BUY_SELL_MISMATCH
 			}
 		}
 
@@ -288,33 +289,33 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		if n.NFTokenBrokerFee != nil && !(buyOfferNegative || sellOfferNegative) {
 			brokerFeeIsXRP := n.NFTokenBrokerFee.Currency == ""
 			if brokerFeeIsXRP != buyIsXRP {
-				return tx.TecNFTOKEN_BUY_SELL_MISMATCH
+				return ter.TecNFTOKEN_BUY_SELL_MISMATCH
 			}
 
 			if buyIsXRP {
 				brokerFee := uint64(n.NFTokenBrokerFee.Drops())
 				if brokerFee >= buyOffer.Amount {
-					return tx.TecINSUFFICIENT_PAYMENT
+					return ter.TecINSUFFICIENT_PAYMENT
 				}
 				if sellOffer.Amount > buyOffer.Amount-brokerFee {
-					return tx.TecINSUFFICIENT_PAYMENT
+					return ter.TecINSUFFICIENT_PAYMENT
 				}
 			} else {
 				brokerFeeIOU := *n.NFTokenBrokerFee
 				buyAmount, err := offerIOUToAmount(buyOffer)
 				if err != nil {
-					return tx.TecINTERNAL
+					return ter.TecINTERNAL
 				}
 				sellAmount, err := offerIOUToAmount(sellOffer)
 				if err != nil {
-					return tx.TecINTERNAL
+					return ter.TecINTERNAL
 				}
 				if brokerFeeIOU.Compare(buyAmount) >= 0 {
-					return tx.TecINSUFFICIENT_PAYMENT
+					return ter.TecINSUFFICIENT_PAYMENT
 				}
 				remainder, _ := buyAmount.Sub(brokerFeeIOU)
 				if sellAmount.Compare(remainder) > 0 {
-					return tx.TecINSUFFICIENT_PAYMENT
+					return ter.TecINSUFFICIENT_PAYMENT
 				}
 			}
 
@@ -322,11 +323,11 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 			if !n.NFTokenBrokerFee.IsNative() && ctx.Rules().Enabled(amendment.FeatureFixEnforceNFTokenTrustlineV2) {
 				brokerFeeIssuerID, err := state.DecodeAccountID(n.NFTokenBrokerFee.Issuer)
 				if err == nil {
-					if r := checkNFTTrustlineAuthorized(ctx.View, accountID, n.NFTokenBrokerFee.Currency, brokerFeeIssuerID); r != tx.TesSUCCESS {
+					if r := checkNFTTrustlineAuthorized(ctx.View, accountID, n.NFTokenBrokerFee.Currency, brokerFeeIssuerID); r != ter.TesSUCCESS {
 						return r
 					}
 					// Reference: rippled NFTokenAcceptOffer.cpp preclaim lines 176-182
-					if r := checkNFTTrustlineDeepFrozen(ctx.View, accountID, n.NFTokenBrokerFee.Currency, brokerFeeIssuerID, ctx.Rules()); r != tx.TesSUCCESS {
+					if r := checkNFTTrustlineDeepFrozen(ctx.View, accountID, n.NFTokenBrokerFee.Currency, brokerFeeIssuerID, ctx.Rules()); r != ter.TesSUCCESS {
 						return r
 					}
 				}
@@ -339,25 +340,25 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	if buyOffer != nil {
 		// Type check
 		if buyOffer.Flags&lsfSellNFToken != 0 {
-			return tx.TecNFTOKEN_OFFER_TYPE_MISMATCH
+			return ter.TecNFTOKEN_OFFER_TYPE_MISMATCH
 		}
 
 		// Cannot accept your own offer
 		if buyOffer.Owner == accountID {
-			return tx.TecCANT_ACCEPT_OWN_NFTOKEN_OFFER
+			return ter.TecCANT_ACCEPT_OWN_NFTOKEN_OFFER
 		}
 
 		// Ownership check (non-brokered only)
 		if sellOffer == nil {
 			if _, _, _, found := findToken(ctx.View, accountID, buyOffer.NFTokenID); !found {
-				return tx.TecNO_PERMISSION
+				return ter.TecNO_PERMISSION
 			}
 		}
 
 		// Destination check (non-brokered only)
 		if sellOffer == nil {
 			if buyOffer.HasDestination && buyOffer.Destination != accountID {
-				return tx.TecNO_PERMISSION
+				return ter.TecNO_PERMISSION
 			}
 		}
 
@@ -368,17 +369,17 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		if buyOffer.AmountIOU != nil {
 			buyAmount, err := offerIOUToAmount(buyOffer)
 			if err != nil {
-				return tx.TecINTERNAL
+				return ter.TecINTERNAL
 			}
 			if ctx.Rules().Enabled(amendment.FeatureFixNonFungibleTokensV1_2) {
 				funds := tx.AccountFunds(ctx.View, buyOffer.Owner, buyAmount, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
 				if funds.Compare(buyAmount) < 0 {
-					return tx.TecINSUFFICIENT_FUNDS
+					return ter.TecINSUFFICIENT_FUNDS
 				}
 			} else {
 				funds := accountHoldsIOU(ctx.View, buyOffer.Owner, buyAmount)
 				if funds.Compare(buyAmount) < 0 {
-					return tx.TecINSUFFICIENT_FUNDS
+					return ter.TecINSUFFICIENT_FUNDS
 				}
 			}
 		} else if !buyOfferNegative {
@@ -387,7 +388,7 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 			needed := tx.NewXRPAmount(int64(buyOffer.Amount))
 			funds := tx.AccountFunds(ctx.View, buyOffer.Owner, needed, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
 			if funds.Compare(needed) < 0 {
-				return tx.TecINSUFFICIENT_FUNDS
+				return ter.TecINSUFFICIENT_FUNDS
 			}
 		}
 
@@ -395,16 +396,16 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		if buyOffer.AmountIOU != nil && ctx.Rules().Enabled(amendment.FeatureFixEnforceNFTokenTrustlineV2) {
 			currency := buyOffer.AmountIOU.Currency
 			issuerID := buyOffer.AmountIOU.Issuer
-			if r := checkNFTTrustlineAuthorized(ctx.View, buyOffer.Owner, currency, issuerID); r != tx.TesSUCCESS {
+			if r := checkNFTTrustlineAuthorized(ctx.View, buyOffer.Owner, currency, issuerID); r != ter.TesSUCCESS {
 				return r
 			}
 			// Direct buy offer: seller (acceptor) must be authorized + deep freeze check
 			if sellOffer == nil {
-				if r := checkNFTTrustlineAuthorized(ctx.View, accountID, currency, issuerID); r != tx.TesSUCCESS {
+				if r := checkNFTTrustlineAuthorized(ctx.View, accountID, currency, issuerID); r != ter.TesSUCCESS {
 					return r
 				}
 				// Reference: rippled NFTokenAcceptOffer.cpp preclaim lines 255-261
-				if r := checkNFTTrustlineDeepFrozen(ctx.View, accountID, currency, issuerID, ctx.Rules()); r != tx.TesSUCCESS {
+				if r := checkNFTTrustlineDeepFrozen(ctx.View, accountID, currency, issuerID, ctx.Rules()); r != ter.TesSUCCESS {
 					return r
 				}
 			}
@@ -417,24 +418,24 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Type check
 		if sellOffer.Flags&lsfSellNFToken == 0 {
 			ctx.Log.Warn("nftoken accept offer: sell offer is actually a buy offer")
-			return tx.TecNFTOKEN_OFFER_TYPE_MISMATCH
+			return ter.TecNFTOKEN_OFFER_TYPE_MISMATCH
 		}
 
 		// Cannot accept your own offer
 		if sellOffer.Owner == accountID {
 			ctx.Log.Warn("nftoken accept offer: cannot accept own sell offer")
-			return tx.TecCANT_ACCEPT_OWN_NFTOKEN_OFFER
+			return ter.TecCANT_ACCEPT_OWN_NFTOKEN_OFFER
 		}
 
 		// Seller must own the token
 		if _, _, _, found := findToken(ctx.View, sellOffer.Owner, sellOffer.NFTokenID); !found {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 
 		// Destination check (non-brokered only)
 		if buyOffer == nil {
 			if sellOffer.HasDestination && sellOffer.Destination != accountID {
-				return tx.TecNO_PERMISSION
+				return ter.TecNO_PERMISSION
 			}
 		}
 
@@ -448,20 +449,20 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 			if !fixV1_2 {
 				sellAmount, err := offerIOUToAmount(sellOffer)
 				if err != nil {
-					return tx.TecINTERNAL
+					return ter.TecINTERNAL
 				}
 				funds := accountHoldsIOU(ctx.View, accountID, sellAmount)
 				if funds.Compare(sellAmount) < 0 {
-					return tx.TecINSUFFICIENT_FUNDS
+					return ter.TecINSUFFICIENT_FUNDS
 				}
 			} else if buyOffer == nil {
 				sellAmount, err := offerIOUToAmount(sellOffer)
 				if err != nil {
-					return tx.TecINTERNAL
+					return ter.TecINTERNAL
 				}
 				funds := tx.AccountFunds(ctx.View, accountID, sellAmount, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
 				if funds.Compare(sellAmount) < 0 {
-					return tx.TecINSUFFICIENT_FUNDS
+					return ter.TecINSUFFICIENT_FUNDS
 				}
 			}
 		} else if !sellOfferNegative {
@@ -473,7 +474,7 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 				needed := tx.NewXRPAmount(int64(sellOffer.Amount))
 				funds := tx.AccountFunds(ctx.View, accountID, needed, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
 				if funds.Compare(needed) < 0 {
-					return tx.TecINSUFFICIENT_FUNDS
+					return ter.TecINSUFFICIENT_FUNDS
 				}
 			}
 		}
@@ -482,11 +483,11 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		if sellOffer.AmountIOU != nil && ctx.Rules().Enabled(amendment.FeatureFixEnforceNFTokenTrustlineV2) {
 			currency := sellOffer.AmountIOU.Currency
 			issuerID := sellOffer.AmountIOU.Issuer
-			if r := checkNFTTrustlineAuthorized(ctx.View, sellOffer.Owner, currency, issuerID); r != tx.TesSUCCESS {
+			if r := checkNFTTrustlineAuthorized(ctx.View, sellOffer.Owner, currency, issuerID); r != ter.TesSUCCESS {
 				return r
 			}
 			if buyOffer == nil {
-				if r := checkNFTTrustlineAuthorized(ctx.View, accountID, currency, issuerID); r != tx.TesSUCCESS {
+				if r := checkNFTTrustlineAuthorized(ctx.View, accountID, currency, issuerID); r != ter.TesSUCCESS {
 					return r
 				}
 			}
@@ -497,7 +498,7 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		if sellOffer.AmountIOU != nil {
 			currency := sellOffer.AmountIOU.Currency
 			issuerID := sellOffer.AmountIOU.Issuer
-			if r := checkNFTTrustlineDeepFrozen(ctx.View, sellOffer.Owner, currency, issuerID, ctx.Rules()); r != tx.TesSUCCESS {
+			if r := checkNFTTrustlineDeepFrozen(ctx.View, sellOffer.Owner, currency, issuerID, ctx.Rules()); r != ter.TesSUCCESS {
 				return r
 			}
 		}
@@ -521,13 +522,13 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		if buyOffer != nil && buyOffer.AmountIOU != nil {
 			amt, err := offerIOUToAmount(buyOffer)
 			if err != nil {
-				return tx.TecINTERNAL
+				return ter.TecINTERNAL
 			}
 			offerAmount = &amt
 		} else if sellOffer != nil && sellOffer.AmountIOU != nil {
 			amt, err := offerIOUToAmount(sellOffer)
 			if err != nil {
-				return tx.TecINTERNAL
+				return ter.TecINTERNAL
 			}
 			offerAmount = &amt
 		}
@@ -542,7 +543,7 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 						trustLineKey := keylet.Line(nftMinterID, iouIssuerID, offerAmount.Currency)
 						trustLineData, _ := ctx.View.Read(trustLineKey)
 						if trustLineData == nil {
-							return tx.TecNO_LINE
+							return ter.TecNO_LINE
 						}
 					}
 				}
@@ -552,11 +553,11 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 			if ctx.Rules().Enabled(amendment.FeatureFixEnforceNFTokenTrustlineV2) {
 				iouIssuerID, err := state.DecodeAccountID(offerAmount.Issuer)
 				if err == nil {
-					if r := checkNFTTrustlineAuthorized(ctx.View, nftMinterID, offerAmount.Currency, iouIssuerID); r != tx.TesSUCCESS {
+					if r := checkNFTTrustlineAuthorized(ctx.View, nftMinterID, offerAmount.Currency, iouIssuerID); r != ter.TesSUCCESS {
 						return r
 					}
 					// Reference: rippled NFTokenAcceptOffer.cpp preclaim lines 387-390
-					if r := checkNFTTrustlineDeepFrozen(ctx.View, nftMinterID, offerAmount.Currency, iouIssuerID, ctx.Rules()); r != tx.TesSUCCESS {
+					if r := checkNFTTrustlineDeepFrozen(ctx.View, nftMinterID, offerAmount.Currency, iouIssuerID, ctx.Rules()); r != ter.TesSUCCESS {
 						return r
 					}
 				}
@@ -578,7 +579,7 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled NFTokenAcceptOffer.cpp pay() line 404
 	if sellOffer != nil {
 		if sellOfferNegative && !ctx.Rules().Enabled(amendment.FeatureFixNFTokenNegOffer) {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 		return n.acceptNFTokenSellOfferDirect(ctx, accountID, sellOffer, sellOfferKey)
 	}
@@ -586,10 +587,10 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Direct mode - buy offer only
 	if buyOffer != nil {
 		if buyOfferNegative && !ctx.Rules().Enabled(amendment.FeatureFixNFTokenNegOffer) {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 		return n.acceptNFTokenBuyOfferDirect(ctx, accountID, buyOffer, buyOfferKey)
 	}
 
-	return tx.TemINVALID
+	return ter.TemINVALID
 }

--- a/internal/tx/nftoken/nftoken_burn.go
+++ b/internal/tx/nftoken/nftoken_burn.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -39,11 +40,11 @@ func (n *NFTokenBurn) Validate() error {
 	}
 
 	if err := tx.CheckFlags(n.GetFlags(), tx.TfUniversalMask); err != nil {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid NFTokenBurn flags")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid NFTokenBurn flags")
 	}
 
 	if n.NFTokenID == "" {
-		return tx.Errorf(tx.TemMALFORMED, "NFTokenID is required")
+		return ter.Errorf(ter.TemMALFORMED, "NFTokenID is required")
 	}
 
 	return nil
@@ -58,7 +59,7 @@ func (n *NFTokenBurn) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled NFTokenBurn.cpp doApply
-func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
+func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("nftoken burn apply",
 		"account", n.Account,
 		"tokenID", n.NFTokenID,
@@ -69,7 +70,7 @@ func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Parse the token ID
 	tokenIDBytes, err := hex.DecodeString(n.NFTokenID)
 	if err != nil || len(tokenIDBytes) != 32 {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	var tokenID [32]byte
@@ -80,7 +81,7 @@ func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
 	if n.Owner != "" {
 		ownerID, err = state.DecodeAccountID(n.Owner)
 		if err != nil {
-			return tx.TemINVALID
+			return ter.TemINVALID
 		}
 	} else {
 		ownerID = accountID
@@ -91,7 +92,7 @@ func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Warn("nftoken burn: token not found",
 			"tokenID", n.NFTokenID,
 		)
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	// Verify burn authorization before any other preclaim check. The owner can
@@ -102,7 +103,7 @@ func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
 	if ownerID != accountID {
 		nftFlags := getNFTFlagsFromID(tokenID)
 		if nftFlags&NFTokenFlagBurnable == 0 {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 
 		issuerID := getNFTIssuer(tokenID)
@@ -110,17 +111,17 @@ func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
 			issuerKey := keylet.Account(issuerID)
 			issuerData, err := ctx.View.Read(issuerKey)
 			if err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			// A missing issuer account cannot designate a minter, so the burn
 			// proceeds; only an existing issuer's minter restriction applies.
 			if issuerData != nil {
 				issuerAccount, err := state.ParseAccountRoot(issuerData)
 				if err != nil {
-					return tx.TefINTERNAL
+					return ter.TefINTERNAL
 				}
 				if issuerAccount.NFTokenMinter != n.Account {
-					return tx.TecNO_PERMISSION
+					return ter.TecNO_PERMISSION
 				}
 			}
 		}
@@ -131,7 +132,7 @@ func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled NFTokenBurn.cpp preclaim — notTooManyOffers.
 	fixV1_2 := ctx.Rules().Enabled(amendment.FeatureFixNonFungibleTokensV1_2)
 	if !fixV1_2 {
-		if r := notTooManyOffers(ctx.View, tokenID); r != tx.TesSUCCESS {
+		if r := notTooManyOffers(ctx.View, tokenID); r != ter.TesSUCCESS {
 			return r
 		}
 	}
@@ -139,7 +140,7 @@ func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Remove the token using proper page management (handles merging)
 	fixPageLinks := ctx.Rules().Enabled(amendment.FeatureFixNFTokenPageLinks)
 	result, pagesRemoved := removeToken(ctx.View, ownerID, tokenID, fixPageLinks)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -147,14 +148,14 @@ func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
 		ownerKey := keylet.Account(ownerID)
 		ownerData, err := ctx.View.Read(ownerKey)
 		if err != nil || ownerData == nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		ownerAccount, err := state.ParseAccountRoot(ownerData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		ownerAccount.OwnerCount = clampedSub(ownerAccount.OwnerCount, pagesRemoved)
-		if result := ctx.UpdateAccountRoot(ownerID, ownerAccount); result != tx.TesSUCCESS {
+		if result := ctx.UpdateAccountRoot(ownerID, ownerAccount); result != ter.TesSUCCESS {
 			return result
 		}
 	} else {
@@ -188,11 +189,11 @@ func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Without fixNonFungibleTokensV1_2: delete ALL offers (no limit)
 		// notTooManyOffers was already checked above
 		r1, res := deleteNFTokenOffers(tokenID, true, maxInt, ctx.View, ctx.AccountID)
-		if res != tx.TesSUCCESS {
+		if res != ter.TesSUCCESS {
 			return res
 		}
 		r2, res := deleteNFTokenOffers(tokenID, false, maxInt, ctx.View, ctx.AccountID)
-		if res != tx.TesSUCCESS {
+		if res != ter.TesSUCCESS {
 			return res
 		}
 		selfDeleted = r1.SelfDeleted + r2.SelfDeleted
@@ -200,12 +201,12 @@ func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
 		// With fixNonFungibleTokensV1_2: delete up to 500 offers
 		// Prioritize sell offers (they're typically fewer)
 		r1, res := deleteNFTokenOffers(tokenID, true, maxDeletableTokenOfferEntries, ctx.View, ctx.AccountID)
-		if res != tx.TesSUCCESS {
+		if res != ter.TesSUCCESS {
 			return res
 		}
 		remaining := maxDeletableTokenOfferEntries - r1.TotalDeleted
 		r2, res := deleteNFTokenOffers(tokenID, false, remaining, ctx.View, ctx.AccountID)
-		if res != tx.TesSUCCESS {
+		if res != ter.TesSUCCESS {
 			return res
 		}
 		selfDeleted = r1.SelfDeleted + r2.SelfDeleted
@@ -215,5 +216,5 @@ func (n *NFTokenBurn) Apply(ctx *tx.ApplyContext) tx.Result {
 	// (view changes to ctx.Account are overwritten by the engine)
 	ctx.Account.OwnerCount = clampedSub(ctx.Account.OwnerCount, selfDeleted)
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/nftoken/nftoken_cancel_offer.go
+++ b/internal/tx/nftoken/nftoken_cancel_offer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -38,17 +39,17 @@ func (n *NFTokenCancelOffer) Validate() error {
 
 	// Check flags - no flags are valid for NFTokenCancelOffer
 	if n.GetFlags()&tfNFTokenCancelOfferMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for NFTokenCancelOffer")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for NFTokenCancelOffer")
 	}
 
 	// Must have at least one offer ID
 	if len(n.NFTokenOffers) == 0 {
-		return tx.Errorf(tx.TemMALFORMED, "NFTokenOffers is required")
+		return ter.Errorf(ter.TemMALFORMED, "NFTokenOffers is required")
 	}
 
 	// Cannot exceed maximum offer count
 	if len(n.NFTokenOffers) > maxTokenOfferCancelCount {
-		return tx.Errorf(tx.TemMALFORMED, "NFTokenOffers exceeds maximum count")
+		return ter.Errorf(ter.TemMALFORMED, "NFTokenOffers exceeds maximum count")
 	}
 
 	// Every offer ID must be a well-formed 256-bit hash. rippled's NFTokenOffers
@@ -58,12 +59,12 @@ func (n *NFTokenCancelOffer) Validate() error {
 	for _, offerID := range n.NFTokenOffers {
 		offerBytes, err := hex.DecodeString(offerID)
 		if err != nil || len(offerBytes) != 32 {
-			return tx.Errorf(tx.TemMALFORMED, "malformed offer ID in NFTokenOffers")
+			return ter.Errorf(ter.TemMALFORMED, "malformed offer ID in NFTokenOffers")
 		}
 		var key [32]byte
 		copy(key[:], offerBytes)
 		if seen[key] {
-			return tx.Errorf(tx.TemMALFORMED, "duplicate offer ID in NFTokenOffers")
+			return ter.Errorf(ter.TemMALFORMED, "duplicate offer ID in NFTokenOffers")
 		}
 		seen[key] = true
 	}
@@ -80,7 +81,7 @@ func (n *NFTokenCancelOffer) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled NFTokenCancelOffer.cpp preclaim + doApply
-func (n *NFTokenCancelOffer) Apply(ctx *tx.ApplyContext) tx.Result {
+func (n *NFTokenCancelOffer) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("nftoken cancel offer apply",
 		"account", n.Account,
 		"offerCount", len(n.NFTokenOffers),
@@ -110,12 +111,12 @@ func (n *NFTokenCancelOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Reference: rippled preclaim() line 75: if (offer->getType() != ltNFTOKEN_OFFER) return true;
 		entryType, err := state.GetLedgerEntryType(offerData)
 		if err != nil || entry.Type(entryType) != entry.TypeNFTokenOffer {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 
 		offer, err := state.ParseNFTokenOffer(offerData)
 		if err != nil {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 
 		// Anyone can cancel if expired
@@ -135,7 +136,7 @@ func (n *NFTokenCancelOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 
 		// No permission to cancel this offer
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// --- doApply: delete all offers ---
@@ -165,7 +166,7 @@ func (n *NFTokenCancelOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		// directory is corrupt) rather than leaving the offer in place while
 		// still decrementing OwnerCount.
 		if err := deleteTokenOffer(ctx.View, offerKey); err != nil {
-			return tx.TefBAD_LEDGER
+			return ter.TefBAD_LEDGER
 		}
 
 		if offer.Owner == accountID {
@@ -177,5 +178,5 @@ func (n *NFTokenCancelOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/nftoken/nftoken_create_offer.go
+++ b/internal/tx/nftoken/nftoken_create_offer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -71,11 +72,11 @@ func (n *NFTokenCreateOffer) Validate() error {
 	}
 
 	if n.GetFlags()&tfNFTokenCreateOfferMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid NFTokenCreateOffer flags")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid NFTokenCreateOffer flags")
 	}
 
 	if n.NFTokenID == "" {
-		return tx.Errorf(tx.TemMALFORMED, "NFTokenID is required")
+		return ter.Errorf(ter.TemMALFORMED, "NFTokenID is required")
 	}
 
 	// Parse NFToken flags from token ID to validate
@@ -95,23 +96,23 @@ func (n *NFTokenCreateOffer) Validate() error {
 	// Reference: rippled tokenOfferCreatePreflight lines 851-858
 	if !n.Amount.IsNative() {
 		if nftFlags&NFTokenFlagOnlyXRP != 0 {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "NFToken requires XRP only")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "NFToken requires XRP only")
 		}
 		if n.Amount.IsZero() {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "IOU amount cannot be zero")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "IOU amount cannot be zero")
 		}
 	}
 
 	// 3. Buy offer zero amount check
 	// Reference: rippled tokenOfferCreatePreflight lines 863-864
 	if !isSellOffer && n.Amount.IsZero() {
-		return tx.Errorf(tx.TemBAD_AMOUNT, "buy offer amount cannot be zero")
+		return ter.Errorf(ter.TemBAD_AMOUNT, "buy offer amount cannot be zero")
 	}
 
 	// 4. Expiration validation - expiration of 0 is invalid
 	// Reference: rippled tokenOfferCreatePreflight lines 866-867
 	if n.Expiration != nil && *n.Expiration == 0 {
-		return tx.Errorf(tx.TemBAD_EXPIRATION, "Expiration cannot be 0")
+		return ter.Errorf(ter.TemBAD_EXPIRATION, "Expiration cannot be 0")
 	}
 
 	// 5. Owner field checks
@@ -120,17 +121,17 @@ func (n *NFTokenCreateOffer) Validate() error {
 	// be present when selling (it's implicit)
 	if (n.Owner != "") == isSellOffer {
 		if !isSellOffer && n.Owner == "" {
-			return tx.Errorf(tx.TemMALFORMED, "Owner is required for buy offers")
+			return ter.Errorf(ter.TemMALFORMED, "Owner is required for buy offers")
 		}
 		if isSellOffer && n.Owner != "" {
-			return tx.Errorf(tx.TemMALFORMED, "Owner not allowed for sell offers")
+			return ter.Errorf(ter.TemMALFORMED, "Owner not allowed for sell offers")
 		}
 	}
 
 	// Owner cannot be the same as Account
 	// Reference: rippled tokenOfferCreatePreflight lines 874-875
 	if n.Owner != "" && n.Owner == n.Account {
-		return tx.Errorf(tx.TemMALFORMED, "Owner cannot be the same as Account")
+		return ter.Errorf(ter.TemMALFORMED, "Owner cannot be the same as Account")
 	}
 
 	// 6. Destination checks
@@ -138,7 +139,7 @@ func (n *NFTokenCreateOffer) Validate() error {
 	if n.Destination != "" {
 		// The destination can't be the account executing the transaction
 		if n.Destination == n.Account {
-			return tx.Errorf(tx.TemMALFORMED, "Destination cannot be the same as Account")
+			return ter.Errorf(ter.TemMALFORMED, "Destination cannot be the same as Account")
 		}
 	}
 
@@ -160,7 +161,7 @@ func (n *NFTokenCreateOffer) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled NFTokenCreateOffer.cpp doApply
-func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
+func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("nftoken create offer apply",
 		"account", n.Account,
 		"tokenID", n.NFTokenID,
@@ -173,7 +174,7 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Parse token ID
 	tokenIDBytes, err := hex.DecodeString(n.NFTokenID)
 	if err != nil || len(tokenIDBytes) != 32 {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	var tokenID [32]byte
@@ -182,7 +183,7 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Negative amount check — gated on fixNFTokenNegOffer
 	// Reference: rippled tokenOfferCreatePreflight line 847
 	if n.Amount.IsNegative() && ctx.Rules().Enabled(amendment.FeatureFixNFTokenNegOffer) {
-		return tx.TemBAD_AMOUNT
+		return ter.TemBAD_AMOUNT
 	}
 
 	// Destination on buy offers: pre-fixNFTokenNegOffer, any Destination on a
@@ -190,27 +191,27 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled tokenOfferCreatePreflight lines 877-892
 	isSellOffer := n.GetFlags()&NFTokenCreateOfferFlagSellNFToken != 0
 	if n.Destination != "" && !isSellOffer && !ctx.Rules().Enabled(amendment.FeatureFixNFTokenNegOffer) {
-		return tx.TemMALFORMED
+		return ter.TemMALFORMED
 	}
 
 	if tx.HasExpired(n.Expiration, ctx.Config.ParentCloseTime) {
 		ctx.Log.Warn("nftoken create offer: offer expired")
-		return tx.TecEXPIRED
+		return ter.TecEXPIRED
 	}
 
 	// Verify token ownership using findToken (proper page traversal)
 	if isSellOffer {
 		if _, _, _, found := findToken(ctx.View, accountID, tokenID); !found {
-			return tx.TecNO_ENTRY
+			return ter.TecNO_ENTRY
 		}
 	} else {
 		var ownerID [20]byte
 		ownerID, err = state.DecodeAccountID(n.Owner)
 		if err != nil {
-			return tx.TemINVALID
+			return ter.TemINVALID
 		}
 		if _, _, _, found := findToken(ctx.View, ownerID, tokenID); !found {
-			return tx.TecNO_ENTRY
+			return ter.TecNO_ENTRY
 		}
 	}
 
@@ -225,13 +226,13 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	if !n.Amount.IsNative() {
 		iouIssuerID, err := state.DecodeAccountID(n.Amount.Issuer)
 		if err != nil {
-			return tx.TemINVALID
+			return ter.TemINVALID
 		}
 
 		if nftFlags&NFTokenFlagTrustLine == 0 && getNFTTransferFee(tokenID) != 0 {
 			issuerExists, _ := ctx.View.Exists(keylet.Account(nftIssuerID))
 			if !issuerExists {
-				return tx.TecNO_ISSUER
+				return ter.TecNO_ISSUER
 			}
 
 			if ctx.Rules().Enabled(amendment.FeatureNFTokenMintOffer) {
@@ -239,21 +240,21 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 					trustLineKey := keylet.Line(nftIssuerID, iouIssuerID, n.Amount.Currency)
 					trustLineData, err := ctx.View.Read(trustLineKey)
 					if err != nil || trustLineData == nil {
-						return tx.TecNO_LINE
+						return ter.TecNO_LINE
 					}
 				}
 			} else {
 				trustLineKey := keylet.Line(nftIssuerID, iouIssuerID, n.Amount.Currency)
 				trustLineExists, _ := ctx.View.Exists(trustLineKey)
 				if !trustLineExists {
-					return tx.TecNO_LINE
+					return ter.TecNO_LINE
 				}
 			}
 
 			// NFT issuer frozen check
 			// Reference: rippled tokenOfferCreatePreclaim line 927-928
 			if tx.IsGlobalFrozen(ctx.View, n.Amount.Issuer) || tx.IsTrustlineFrozen(ctx.View, nftIssuerID, iouIssuerID, n.Amount.Currency) {
-				return tx.TecFROZEN
+				return ter.TecFROZEN
 			}
 		}
 	}
@@ -264,14 +265,14 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		issuerKey := keylet.Account(nftIssuerID)
 		issuerData, err := ctx.View.Read(issuerKey)
 		if err != nil {
-			return tx.TefNFTOKEN_IS_NOT_TRANSFERABLE
+			return ter.TefNFTOKEN_IS_NOT_TRANSFERABLE
 		}
 		issuerAccount, err := state.ParseAccountRoot(issuerData)
 		if err != nil {
-			return tx.TefNFTOKEN_IS_NOT_TRANSFERABLE
+			return ter.TefNFTOKEN_IS_NOT_TRANSFERABLE
 		}
 		if issuerAccount.NFTokenMinter != n.Account {
-			return tx.TefNFTOKEN_IS_NOT_TRANSFERABLE
+			return ter.TefNFTOKEN_IS_NOT_TRANSFERABLE
 		}
 	}
 
@@ -280,7 +281,7 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	if !n.Amount.IsNative() {
 		iouIssuerID, _ := state.DecodeAccountID(n.Amount.Issuer)
 		if tx.IsGlobalFrozen(ctx.View, n.Amount.Issuer) || tx.IsTrustlineFrozen(ctx.View, accountID, iouIssuerID, n.Amount.Currency) {
-			return tx.TecFROZEN
+			return ter.TecFROZEN
 		}
 	}
 
@@ -297,7 +298,7 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 			funds = accountHoldsIOU(ctx.View, accountID, n.Amount)
 		}
 		if funds.Signum() <= 0 {
-			return tx.TecUNFUNDED_OFFER
+			return ter.TecUNFUNDED_OFFER
 		}
 	}
 
@@ -305,12 +306,12 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled tokenOfferCreatePreclaim lines 970-988
 	if n.Destination != "" {
 		destAccount, _, result := ctx.LookupAccount(n.Destination)
-		if result != tx.TesSUCCESS {
+		if result != ter.TesSUCCESS {
 			return result
 		}
 		if ctx.Rules().Enabled(amendment.FeatureDisallowIncoming) {
 			if destAccount.Flags&state.LsfDisallowIncomingNFTokenOffer != 0 {
-				return tx.TecNO_PERMISSION
+				return ter.TecNO_PERMISSION
 			}
 		}
 	}
@@ -320,11 +321,11 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	if n.Owner != "" {
 		if ctx.Rules().Enabled(amendment.FeatureDisallowIncoming) {
 			ownerAccount, _, result := ctx.LookupAccount(n.Owner)
-			if result != tx.TesSUCCESS {
-				return tx.TecNO_TARGET
+			if result != ter.TesSUCCESS {
+				return ter.TecNO_TARGET
 			}
 			if ownerAccount.Flags&state.LsfDisallowIncomingNFTokenOffer != 0 {
-				return tx.TecNO_PERMISSION
+				return ter.TecNO_PERMISSION
 			}
 		}
 	}
@@ -333,7 +334,7 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled tokenOfferCreatePreclaim lines 1007-1018
 	if !n.Amount.IsNative() && ctx.Rules().Enabled(amendment.FeatureFixEnforceNFTokenTrustlineV2) {
 		iouIssuerID, _ := state.DecodeAccountID(n.Amount.Issuer)
-		if r := checkNFTTrustlineAuthorized(ctx.View, accountID, n.Amount.Currency, iouIssuerID); r != tx.TesSUCCESS {
+		if r := checkNFTTrustlineAuthorized(ctx.View, accountID, n.Amount.Currency, iouIssuerID); r != ter.TesSUCCESS {
 			return r
 		}
 	}
@@ -354,7 +355,7 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		dir.Owner = accountID
 	})
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	ownerNode := dirResult.Page
 
@@ -374,18 +375,18 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 		dir.NFTokenID = tokenID
 	})
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	offerNode := tokenDirResult.Page
 
 	// Serialize the offer with directory page numbers
 	offerData, err := serializeNFTokenOffer(n, accountID, tokenID, sequence, ownerNode, offerNode)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if err := ctx.View.Insert(offerKey, offerData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Increase owner count
@@ -396,8 +397,8 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) tx.Result {
 	mPriorBalance := ctx.PriorBalance()
 	reserve := ctx.AccountReserve(ctx.Account.OwnerCount)
 	if mPriorBalance < reserve {
-		return tx.TecINSUFFICIENT_RESERVE
+		return ter.TecINSUFFICIENT_RESERVE
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/nftoken/nftoken_mint.go
+++ b/internal/tx/nftoken/nftoken_mint.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -76,23 +77,23 @@ func (n *NFTokenMint) Validate() error {
 	// fixRemoveNFTokenAutoTrustLine is enabled, rejecting tfMutable when
 	// DynamicNFT is not enabled) are in Apply().
 	if n.GetFlags()&tfNFTokenMintOldMaskWithMutable != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid NFTokenMint flags")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid NFTokenMint flags")
 	}
 
 	// TransferFee must be <= maxTransferFee (50000 = 50%)
 	if n.TransferFee != nil {
 		if *n.TransferFee > maxTransferFee {
-			return tx.Errorf(tx.TemBAD_NFTOKEN_TRANSFER_FEE, "TransferFee cannot exceed 50000")
+			return ter.Errorf(ter.TemBAD_NFTOKEN_TRANSFER_FEE, "TransferFee cannot exceed 50000")
 		}
 		// If a non-zero TransferFee is set, tfTransferable must also be set
 		if *n.TransferFee > 0 && n.GetFlags()&NFTokenMintFlagTransferable == 0 {
-			return tx.Errorf(tx.TemMALFORMED, "non-zero TransferFee requires tfTransferable flag")
+			return ter.Errorf(ter.TemMALFORMED, "non-zero TransferFee requires tfTransferable flag")
 		}
 	}
 
 	// Issuer must not be the same as Account (if specified)
 	if n.Issuer != "" && n.Issuer == n.Account {
-		return tx.Errorf(tx.TemMALFORMED, "Issuer cannot be the same as Account")
+		return ter.Errorf(ter.TemMALFORMED, "Issuer cannot be the same as Account")
 	}
 
 	// URI validation: if the field is present, it must not be empty and must
@@ -104,10 +105,10 @@ func (n *NFTokenMint) Validate() error {
 	if n.HasField("URI") || n.URI != "" {
 		uriBytes := len(n.URI) / 2
 		if uriBytes == 0 {
-			return tx.Errorf(tx.TemMALFORMED, "URI cannot be empty")
+			return ter.Errorf(ter.TemMALFORMED, "URI cannot be empty")
 		}
 		if uriBytes > maxTokenURILength {
-			return tx.Errorf(tx.TemMALFORMED, "URI too long")
+			return ter.Errorf(ter.TemMALFORMED, "URI too long")
 		}
 	}
 
@@ -115,7 +116,7 @@ func (n *NFTokenMint) Validate() error {
 	// (This is NFTokenMintOffer support)
 	hasOfferFields := n.Amount != nil || n.Destination != "" || n.Expiration != nil
 	if hasOfferFields && n.Amount == nil {
-		return tx.Errorf(tx.TemMALFORMED, "Amount required when Destination or Expiration present")
+		return ter.Errorf(ter.TemMALFORMED, "Amount required when Destination or Expiration present")
 	}
 
 	// When Amount is present, validate the offer fields using the same logic as
@@ -133,24 +134,24 @@ func (n *NFTokenMint) Validate() error {
 
 			// If token has OnlyXRP flag, IOU offers are not allowed
 			if nftFlags&NFTokenFlagOnlyXRP != 0 {
-				return tx.Errorf(tx.TemBAD_AMOUNT, "NFToken requires XRP only")
+				return ter.Errorf(ter.TemBAD_AMOUNT, "NFToken requires XRP only")
 			}
 
 			// Zero IOU amount is not allowed
 			if n.Amount.IsZero() {
-				return tx.Errorf(tx.TemBAD_AMOUNT, "IOU amount cannot be zero")
+				return ter.Errorf(ter.TemBAD_AMOUNT, "IOU amount cannot be zero")
 			}
 		}
 
 		// Expiration of 0 is invalid
 		if n.Expiration != nil && *n.Expiration == 0 {
-			return tx.Errorf(tx.TemBAD_EXPIRATION, "Expiration cannot be 0")
+			return ter.Errorf(ter.TemBAD_EXPIRATION, "Expiration cannot be 0")
 		}
 
 		// Destination cannot be the same as the account creating the offer
 		// Reference: rippled tokenOfferCreatePreflight — "if (dest == acctID)"
 		if n.Destination != "" && n.Destination == n.Account {
-			return tx.Errorf(tx.TemMALFORMED, "Destination cannot be the same as Account")
+			return ter.Errorf(ter.TemMALFORMED, "Destination cannot be the same as Account")
 		}
 	}
 
@@ -185,7 +186,7 @@ func (n *NFTokenMint) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled NFTokenMint.cpp doApply
-func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
+func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("nftoken mint apply",
 		"account", n.Account,
 		"taxon", n.NFTokenTaxon,
@@ -199,17 +200,17 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 	if ctx.Rules().Enabled(amendment.FeatureFixRemoveNFTokenAutoTrustLine) {
 		if dynamicNFT {
 			if n.GetFlags()&tfNFTokenMintMaskWithMutable != 0 {
-				return tx.TemINVALID_FLAG
+				return ter.TemINVALID_FLAG
 			}
 		} else {
 			if n.GetFlags()&tfNFTokenMintMask != 0 {
-				return tx.TemINVALID_FLAG
+				return ter.TemINVALID_FLAG
 			}
 		}
 	} else {
 		if dynamicNFT {
 			if n.GetFlags()&tfNFTokenMintOldMaskWithMutable != 0 {
-				return tx.TemINVALID_FLAG
+				return ter.TemINVALID_FLAG
 			}
 		}
 		// else: use the old permissive mask (already checked in Validate)
@@ -234,18 +235,18 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 		var err error
 		issuerID, err = state.DecodeAccountID(n.Issuer)
 		if err != nil {
-			return tx.TemINVALID
+			return ter.TemINVALID
 		}
 
 		// Read issuer account for MintedNFTokens tracking
 		issuerKey = keylet.Account(issuerID)
 		issuerData, err := ctx.View.Read(issuerKey)
 		if err != nil || issuerData == nil {
-			return tx.TecNO_ISSUER
+			return ter.TecNO_ISSUER
 		}
 		issuerAccount, err = state.ParseAccountRoot(issuerData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Verify that Account is authorized to mint for this issuer
@@ -254,7 +255,7 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 			ctx.Log.Warn("nftoken mint: account not authorized to mint for issuer",
 				"issuer", n.Issuer,
 			)
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	} else {
 		issuerID = accountID
@@ -267,11 +268,11 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Negative amount check — gated by fixNFTokenNegOffer amendment
 		// Reference: rippled NFTokenUtils.cpp tokenOfferCreatePreflight line 847
 		if n.Amount.IsNegative() && ctx.Rules().Enabled(amendment.FeatureFixNFTokenNegOffer) {
-			return tx.TemBAD_AMOUNT
+			return ter.TemBAD_AMOUNT
 		}
 
 		if tx.HasExpired(n.Expiration, ctx.Config.ParentCloseTime) {
-			return tx.TecEXPIRED
+			return ter.TecEXPIRED
 		}
 
 		// Extract NFToken flags from transaction flags (lower 16 bits)
@@ -288,7 +289,7 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 		if !n.Amount.IsNative() {
 			iouIssuerID, err := state.DecodeAccountID(n.Amount.Issuer)
 			if err != nil {
-				return tx.TemINVALID
+				return ter.TemINVALID
 			}
 
 			// NFT issuer trust line check when transfer fee is set and no auto-trust-line flag
@@ -296,7 +297,7 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 			if nftFlags&NFTokenFlagTrustLine == 0 && transferFee > 0 {
 				issuerExists, _ := ctx.View.Exists(keylet.Account(issuerID))
 				if !issuerExists {
-					return tx.TecNO_ISSUER
+					return ter.TecNO_ISSUER
 				}
 
 				// With featureNFTokenMintOffer: skip trust line check when NFT issuer == IOU issuer
@@ -305,32 +306,32 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 						trustLineKey := keylet.Line(issuerID, iouIssuerID, n.Amount.Currency)
 						trustLineData, err := ctx.View.Read(trustLineKey)
 						if err != nil || trustLineData == nil {
-							return tx.TecNO_LINE
+							return ter.TecNO_LINE
 						}
 					}
 				} else {
 					trustLineKey := keylet.Line(issuerID, iouIssuerID, n.Amount.Currency)
 					exists, _ := ctx.View.Exists(trustLineKey)
 					if !exists {
-						return tx.TecNO_LINE
+						return ter.TecNO_LINE
 					}
 				}
 
 				if tx.IsGlobalFrozen(ctx.View, n.Amount.Issuer) || tx.IsTrustlineFrozen(ctx.View, issuerID, iouIssuerID, n.Amount.Currency) {
-					return tx.TecFROZEN
+					return ter.TecFROZEN
 				}
 			}
 
 			// Check if the minting account is frozen for this IOU
 			// Reference: rippled tokenOfferCreatePreclaim line 941
 			if tx.IsGlobalFrozen(ctx.View, n.Amount.Issuer) || tx.IsTrustlineFrozen(ctx.View, accountID, iouIssuerID, n.Amount.Currency) {
-				return tx.TecFROZEN
+				return ter.TecFROZEN
 			}
 
 			// Trust line authorization check (with fixEnforceNFTokenTrustlineV2)
 			// Reference: rippled tokenOfferCreatePreclaim lines 1007-1018
 			if ctx.Rules().Enabled(amendment.FeatureFixEnforceNFTokenTrustlineV2) {
-				if r := checkNFTTrustlineAuthorized(ctx.View, accountID, n.Amount.Currency, iouIssuerID); r != tx.TesSUCCESS {
+				if r := checkNFTTrustlineAuthorized(ctx.View, accountID, n.Amount.Currency, iouIssuerID); r != ter.TesSUCCESS {
 					return r
 				}
 			}
@@ -340,12 +341,12 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Reference: rippled tokenOfferCreatePreclaim lines 970-988
 		if n.Destination != "" {
 			destAccount, _, result := ctx.LookupAccount(n.Destination)
-			if result != tx.TesSUCCESS {
+			if result != ter.TesSUCCESS {
 				return result
 			}
 			if ctx.Rules().Enabled(amendment.FeatureDisallowIncoming) {
 				if destAccount.Flags&state.LsfDisallowIncomingNFTokenOffer != 0 {
-					return tx.TecNO_PERMISSION
+					return ter.TecNO_PERMISSION
 				}
 			}
 		}
@@ -361,7 +362,7 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 		tokenSeq = issuerAccount.MintedNFTokens
 		nextTokenSeq := tokenSeq + 1
 		if nextTokenSeq < tokenSeq {
-			return tx.TecMAX_SEQUENCE_REACHED
+			return ter.TecMAX_SEQUENCE_REACHED
 		}
 		issuerAccount.MintedNFTokens = nextTokenSeq
 	} else {
@@ -383,7 +384,7 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 		mintedNftCnt := issuerAccount.MintedNFTokens
 		issuerAccount.MintedNFTokens = mintedNftCnt + 1
 		if issuerAccount.MintedNFTokens == 0 {
-			return tx.TecMAX_SEQUENCE_REACHED
+			return ter.TecMAX_SEQUENCE_REACHED
 		}
 
 		// tokenSeq = FirstNFTokenSequence + MintedNFTokens (before increment)
@@ -391,7 +392,7 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 		tokenSeq = offset + mintedNftCnt
 
 		if tokenSeq+1 == 0 || tokenSeq < offset {
-			return tx.TecMAX_SEQUENCE_REACHED
+			return ter.TecMAX_SEQUENCE_REACHED
 		}
 	}
 
@@ -431,7 +432,7 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	fixDirV1 := ctx.Rules().Enabled(amendment.FeatureFixNFTokenDirV1)
 	insertResult := insertNFToken(accountID, newToken, ctx.View, fixDirV1)
-	if insertResult.Result != tx.TesSUCCESS {
+	if insertResult.Result != ter.TesSUCCESS {
 		ctx.Log.Error("nftoken mint: failed to insert token", "result", insertResult.Result)
 		return insertResult.Result
 	}
@@ -444,10 +445,10 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 	if n.Issuer != "" {
 		issuerUpdatedData, err := state.SerializeAccountRoot(issuerAccount)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := ctx.View.Update(issuerKey, issuerUpdatedData); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
@@ -456,7 +457,7 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 	if n.Amount != nil {
 		seqProxy := n.GetCommon().SeqProxy()
 		result := tokenOfferCreateApply(ctx, accountID, tokenID, n.Amount, n.Destination, n.Expiration, seqProxy, mPriorBalance)
-		if result != tx.TesSUCCESS {
+		if result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -469,9 +470,9 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) tx.Result {
 	if ctx.Account.OwnerCount > ownerCountBefore {
 		reserve := ctx.AccountReserve(ctx.Account.OwnerCount)
 		if mPriorBalance < reserve {
-			return tx.TecINSUFFICIENT_RESERVE
+			return ter.TecINSUFFICIENT_RESERVE
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/nftoken/nftoken_modify.go
+++ b/internal/tx/nftoken/nftoken_modify.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -47,13 +48,13 @@ func (n *NFTokenModify) Validate() error {
 	}
 
 	if n.NFTokenID == "" {
-		return tx.Errorf(tx.TemMALFORMED, "NFTokenID is required")
+		return ter.Errorf(ter.TemMALFORMED, "NFTokenID is required")
 	}
 
 	// Owner cannot be the same as Account
 	// Reference: rippled NFTokenModify.cpp:41 - if (auto owner = ctx.tx[~sfOwner]; owner == ctx.tx[sfAccount])
 	if n.Owner != "" && n.Owner == n.Account {
-		return tx.Errorf(tx.TemMALFORMED, "Owner cannot be the same as Account")
+		return ter.Errorf(ter.TemMALFORMED, "Owner cannot be the same as Account")
 	}
 
 	// URI validation: if present, must not be empty and not exceed maxTokenURILength
@@ -62,10 +63,10 @@ func (n *NFTokenModify) Validate() error {
 		// URI in transactions is hex-encoded, so actual byte length is len/2
 		uriBytes := len(n.URI) / 2
 		if uriBytes == 0 {
-			return tx.Errorf(tx.TemMALFORMED, "URI cannot be empty")
+			return ter.Errorf(ter.TemMALFORMED, "URI cannot be empty")
 		}
 		if uriBytes > maxTokenURILength {
-			return tx.Errorf(tx.TemMALFORMED, "URI too long")
+			return ter.Errorf(ter.TemMALFORMED, "URI too long")
 		}
 	}
 
@@ -82,7 +83,7 @@ func (n *NFTokenModify) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled NFTokenModify.cpp preclaim + doApply
-func (n *NFTokenModify) Apply(ctx *tx.ApplyContext) tx.Result {
+func (n *NFTokenModify) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("nftoken modify apply",
 		"account", n.Account,
 		"tokenID", n.NFTokenID,
@@ -93,7 +94,7 @@ func (n *NFTokenModify) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Parse the token ID
 	tokenIDBytes, err := hex.DecodeString(n.NFTokenID)
 	if err != nil || len(tokenIDBytes) != 32 {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 	var tokenID [32]byte
 	copy(tokenID[:], tokenIDBytes)
@@ -104,7 +105,7 @@ func (n *NFTokenModify) Apply(ctx *tx.ApplyContext) tx.Result {
 	if n.Owner != "" {
 		ownerID, err = state.DecodeAccountID(n.Owner)
 		if err != nil {
-			return tx.TemINVALID
+			return ter.TemINVALID
 		}
 	} else {
 		ownerID = accountID
@@ -115,12 +116,12 @@ func (n *NFTokenModify) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Verify the token exists
 	// Reference: rippled NFTokenModify.cpp preclaim:60
 	if _, _, _, found := findToken(ctx.View, ownerID, tokenID); !found {
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	// Reference: rippled NFTokenModify.cpp preclaim:64
 	if getNFTFlagsFromID(tokenID)&NFTokenFlagMutable == 0 {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Verify permissions: account must be the issuer or the issuer's authorized minter
@@ -130,14 +131,14 @@ func (n *NFTokenModify) Apply(ctx *tx.ApplyContext) tx.Result {
 		issuerKey := keylet.Account(issuerID)
 		issuerData, err := ctx.View.Read(issuerKey)
 		if err != nil || issuerData == nil {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 		issuerAccount, err := state.ParseAccountRoot(issuerData)
 		if err != nil {
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		}
 		if issuerAccount.NFTokenMinter != n.Account {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	}
 
@@ -147,7 +148,7 @@ func (n *NFTokenModify) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Locate the page containing the token
 	kl, page, locateErr := locatePage(ctx.View, ownerID, tokenID)
 	if locateErr != nil || page == nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	// Find the token in the page
@@ -159,7 +160,7 @@ func (n *NFTokenModify) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 	}
 	if tokenIdx == -1 {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
 	// Reference: rippled NFTokenModify.cpp doApply:88 — ctx_.tx[~sfURI]
@@ -176,11 +177,11 @@ func (n *NFTokenModify) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Serialize and update the page
 	pageBytes, err := serializeNFTokenPage(page)
 	if err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 	if err := ctx.View.Update(kl, pageBytes); err != nil {
-		return tx.TecINTERNAL
+		return ter.TecINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/nftoken/nftoken_offer.go
+++ b/internal/tx/nftoken/nftoken_offer.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -86,10 +87,10 @@ type deleteNFTokenOffersResult struct {
 // tefEXCEPTION. Offers missing from the directory are skipped, matching
 // rippled's null peek.
 // Reference: rippled NFTokenUtils.cpp removeTokenOffersWithLimit
-func deleteNFTokenOffers(tokenID [32]byte, sellOffers bool, limit int, view tx.LedgerView, selfAccountID [20]byte) (deleteNFTokenOffersResult, tx.Result) {
+func deleteNFTokenOffers(tokenID [32]byte, sellOffers bool, limit int, view tx.LedgerView, selfAccountID [20]byte) (deleteNFTokenOffersResult, ter.Result) {
 	result := deleteNFTokenOffersResult{}
 	if limit <= 0 {
-		return result, tx.TesSUCCESS
+		return result, ter.TesSUCCESS
 	}
 
 	var dirKey keylet.Keylet
@@ -103,7 +104,7 @@ func deleteNFTokenOffers(tokenID [32]byte, sellOffers bool, limit int, view tx.L
 	for {
 		pageData, err := view.Read(keylet.DirPage(dirKey.Key, pageIndex))
 		if err != nil {
-			return result, tx.TefEXCEPTION
+			return result, ter.TefEXCEPTION
 		}
 		if pageData == nil {
 			break
@@ -111,7 +112,7 @@ func deleteNFTokenOffers(tokenID [32]byte, sellOffers bool, limit int, view tx.L
 
 		page, err := state.ParseDirectoryNode(pageData)
 		if err != nil {
-			return result, tx.TefEXCEPTION
+			return result, ter.TefEXCEPTION
 		}
 
 		// Capture the next page before deleting: removing the last entry
@@ -123,7 +124,7 @@ func deleteNFTokenOffers(tokenID [32]byte, sellOffers bool, limit int, view tx.L
 
 			offerData, err := view.Read(offerKL)
 			if err != nil {
-				return result, tx.TefEXCEPTION
+				return result, ter.TefEXCEPTION
 			}
 			if offerData == nil {
 				continue
@@ -131,7 +132,7 @@ func deleteNFTokenOffers(tokenID [32]byte, sellOffers bool, limit int, view tx.L
 
 			offer, err := state.ParseNFTokenOffer(offerData)
 			if err != nil {
-				return result, tx.TefEXCEPTION
+				return result, ter.TefEXCEPTION
 			}
 
 			isSelf := offer.Owner == selfAccountID
@@ -146,7 +147,7 @@ func deleteNFTokenOffers(tokenID [32]byte, sellOffers bool, limit int, view tx.L
 
 			ownerDirKey := keylet.OwnerDir(offer.Owner)
 			if res, err := state.DirRemove(view, ownerDirKey, offer.OwnerNode, offerKL.Key, false); err != nil || !res.Success {
-				return result, tx.TefEXCEPTION
+				return result, ter.TefEXCEPTION
 			}
 
 			// Remove the offer from the NFT buy/sell offer directory we are
@@ -156,11 +157,11 @@ func deleteNFTokenOffers(tokenID [32]byte, sellOffers bool, limit int, view tx.L
 			// DeletedNode:DirectoryNode. Without this the page is left in state with
 			// stale Indexes, diverging both account_hash and transaction_hash.
 			if res, err := state.DirRemove(view, dirKey, offer.NFTokenOfferNode, offerKL.Key, false); err != nil || !res.Success {
-				return result, tx.TefEXCEPTION
+				return result, ter.TefEXCEPTION
 			}
 
 			if err := view.Erase(offerKL); err != nil {
-				return result, tx.TefEXCEPTION
+				return result, ter.TefEXCEPTION
 			}
 
 			result.TotalDeleted++
@@ -168,7 +169,7 @@ func deleteNFTokenOffers(tokenID [32]byte, sellOffers bool, limit int, view tx.L
 				result.SelfDeleted++
 			}
 			if result.TotalDeleted == limit {
-				return result, tx.TesSUCCESS
+				return result, ter.TesSUCCESS
 			}
 		}
 
@@ -177,13 +178,13 @@ func deleteNFTokenOffers(tokenID [32]byte, sellOffers bool, limit int, view tx.L
 		}
 	}
 
-	return result, tx.TesSUCCESS
+	return result, ter.TesSUCCESS
 }
 
 // notTooManyOffers checks whether the total number of buy + sell offers
 // for a token exceeds maxDeletableTokenOfferEntries.
 // Reference: rippled NFTokenUtils.cpp notTooManyOffers
-func notTooManyOffers(view tx.LedgerView, tokenID [32]byte) tx.Result {
+func notTooManyOffers(view tx.LedgerView, tokenID [32]byte) ter.Result {
 	totalOffers := 0
 
 	// Count buy offers
@@ -211,10 +212,10 @@ func notTooManyOffers(view tx.LedgerView, tokenID [32]byte) tx.Result {
 	}
 
 	if totalOffers > maxDeletableTokenOfferEntries {
-		return tx.TefTOO_BIG
+		return ter.TefTOO_BIG
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // adjustOwnerCountViaView adjusts an account's OwnerCount through the view.
@@ -235,12 +236,12 @@ func tokenOfferCreateApply(
 	expiration *uint32,
 	seqProxy uint32,
 	priorBalance uint64,
-) tx.Result {
+) ter.Result {
 	// Check reserve using priorBalance (balance before fee deduction)
 	// Reference: rippled NFTokenUtils.cpp tokenOfferCreateApply line 1037
 	reserve := ctx.AccountReserve(ctx.Account.OwnerCount + 1)
 	if priorBalance < reserve {
-		return tx.TecINSUFFICIENT_RESERVE
+		return ter.TecINSUFFICIENT_RESERVE
 	}
 
 	offerKey := keylet.NFTokenOffer(accountID, seqProxy)
@@ -250,7 +251,7 @@ func tokenOfferCreateApply(
 		dir.Owner = accountID
 	})
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	ownerNode := dirResult.Page
 
@@ -263,7 +264,7 @@ func tokenOfferCreateApply(
 		dir.NFTokenID = tokenID
 	})
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	offerNode := tokenDirResult.Page
 
@@ -276,14 +277,14 @@ func tokenOfferCreateApply(
 		destination, expiration,
 	)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if err := ctx.View.Insert(offerKey, offerData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	ctx.Account.OwnerCount++
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/nftoken/nftoken_offer_test.go
+++ b/internal/tx/nftoken/nftoken_offer_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
-	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -67,7 +67,7 @@ func TestDeleteNFTokenOffers_ReverseOrderWithinPage(t *testing.T) {
 	}
 
 	result, res := deleteNFTokenOffers(tokenID, true, 1, view, owner)
-	if res != tx.TesSUCCESS {
+	if res != ter.TesSUCCESS {
 		t.Fatalf("deleteNFTokenOffers result = %v, want tesSUCCESS", res)
 	}
 	if result.TotalDeleted != 1 || result.SelfDeleted != 1 {
@@ -97,7 +97,7 @@ func TestDeleteNFTokenOffers_CorruptOffer(t *testing.T) {
 	}
 
 	_, res := deleteNFTokenOffers(tokenID, true, maxDeletableTokenOfferEntries, view, owner)
-	if res != tx.TefEXCEPTION {
+	if res != ter.TefEXCEPTION {
 		t.Fatalf("deleteNFTokenOffers result = %v, want tefEXCEPTION", res)
 	}
 }
@@ -117,7 +117,7 @@ func TestDeleteNFTokenOffers_MissingOfferSkipped(t *testing.T) {
 	}
 
 	result, res := deleteNFTokenOffers(tokenID, true, maxDeletableTokenOfferEntries, view, owner)
-	if res != tx.TesSUCCESS {
+	if res != ter.TesSUCCESS {
 		t.Fatalf("deleteNFTokenOffers result = %v, want tesSUCCESS", res)
 	}
 	if result.TotalDeleted != 1 {

--- a/internal/tx/nftoken/nftoken_page.go
+++ b/internal/tx/nftoken/nftoken_page.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -85,7 +86,7 @@ func findToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte) (keylet.Key
 // ---------------------------------------------------------------------------
 
 type insertNFTokenResult struct {
-	Result       tx.Result
+	Result       ter.Result
 	PagesCreated int
 }
 
@@ -338,11 +339,11 @@ func splitPage(
 func insertNFToken(ownerID [20]byte, token state.NFTokenData, view tx.LedgerView, fixDirV1 bool) insertNFTokenResult {
 	pageKL, page, pagesCreated, err := getPageForToken(view, ownerID, token.NFTokenID, fixDirV1)
 	if err != nil {
-		return insertNFTokenResult{Result: tx.TefINTERNAL}
+		return insertNFTokenResult{Result: ter.TefINTERNAL}
 	}
 
 	if page == nil {
-		return insertNFTokenResult{Result: tx.TecNO_SUITABLE_NFTOKEN_PAGE}
+		return insertNFTokenResult{Result: ter.TecNO_SUITABLE_NFTOKEN_PAGE}
 	}
 
 	// Insert token in sorted position
@@ -351,14 +352,14 @@ func insertNFToken(ownerID [20]byte, token state.NFTokenData, view tx.LedgerView
 	// Serialize and update
 	pageBytes, err := serializeNFTokenPage(page)
 	if err != nil {
-		return insertNFTokenResult{Result: tx.TefINTERNAL}
+		return insertNFTokenResult{Result: ter.TefINTERNAL}
 	}
 
 	if err := view.Update(pageKL, pageBytes); err != nil {
-		return insertNFTokenResult{Result: tx.TefINTERNAL}
+		return insertNFTokenResult{Result: ter.TefINTERNAL}
 	}
 
-	return insertNFTokenResult{Result: tx.TesSUCCESS, PagesCreated: pagesCreated}
+	return insertNFTokenResult{Result: ter.TesSUCCESS, PagesCreated: pagesCreated}
 }
 
 // ---------------------------------------------------------------------------
@@ -371,30 +372,30 @@ func insertNFToken(ownerID [20]byte, token state.NFTokenData, view tx.LedgerView
 // link that cannot be read is a broken directory and yields tefEXCEPTION,
 // matching rippled's loadPage which throws (caught as tefEXCEPTION) rather than
 // treating it as "no neighbour".
-func loadAdjacentPage(view tx.LedgerView, pageType entry.Type, link [32]byte) (*state.NFTokenPageData, keylet.Keylet, tx.Result) {
+func loadAdjacentPage(view tx.LedgerView, pageType entry.Type, link [32]byte) (*state.NFTokenPageData, keylet.Keylet, ter.Result) {
 	var emptyHash [32]byte
 	if link == emptyHash {
-		return nil, keylet.Keylet{}, tx.TesSUCCESS
+		return nil, keylet.Keylet{}, ter.TesSUCCESS
 	}
 	kl := keylet.Keylet{Type: pageType, Key: link}
 	data, err := view.Read(kl)
 	if err != nil || data == nil {
-		return nil, kl, tx.TefEXCEPTION
+		return nil, kl, ter.TefEXCEPTION
 	}
 	page, err := state.ParseNFTokenPage(data)
 	if err != nil {
-		return nil, kl, tx.TefINTERNAL
+		return nil, kl, ter.TefINTERNAL
 	}
-	return page, kl, tx.TesSUCCESS
+	return page, kl, ter.TesSUCCESS
 }
 
-func removeToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte, fixPageLinks bool) (tx.Result, int) {
+func removeToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte, fixPageLinks bool) (ter.Result, int) {
 	kl, page, err := locatePage(view, owner, tokenID)
 	if err != nil {
-		return tx.TefINTERNAL, 0
+		return ter.TefINTERNAL, 0
 	}
 	if page == nil {
-		return tx.TecNO_ENTRY, 0
+		return ter.TecNO_ENTRY, 0
 	}
 
 	// Find and remove the token
@@ -407,18 +408,18 @@ func removeToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte, fixPageLi
 		}
 	}
 	if !found {
-		return tx.TecNO_ENTRY, 0
+		return ter.TecNO_ENTRY, 0
 	}
 
 	// Load prev and next pages. A set link to an unreadable page is a broken
 	// directory, not an absent neighbour.
 	var emptyHash [32]byte
 	prevPage, prevKL, r := loadAdjacentPage(view, kl.Type, page.PreviousPageMin)
-	if r != tx.TesSUCCESS {
+	if r != ter.TesSUCCESS {
 		return r, 0
 	}
 	nextPage, nextKL, r := loadAdjacentPage(view, kl.Type, page.NextPageMin)
-	if r != tx.TesSUCCESS {
+	if r != ter.TesSUCCESS {
 		return r, 0
 	}
 
@@ -428,16 +429,16 @@ func removeToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte, fixPageLi
 		// Page not empty — update it and try to consolidate
 		pageBytes, err := serializeNFTokenPage(page)
 		if err != nil {
-			return tx.TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
 		if err := view.Update(kl, pageBytes); err != nil {
-			return tx.TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
 
 		// Try merging with previous page
 		if prevPage != nil {
 			merged, res := doMergePages(view, prevKL, prevPage, kl, page)
-			if res != tx.TesSUCCESS {
+			if res != ter.TesSUCCESS {
 				return res, 0
 			}
 			if merged {
@@ -446,11 +447,11 @@ func removeToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte, fixPageLi
 				// Re-read kl for potential second merge.
 				klData, err := view.Read(kl)
 				if err != nil || klData == nil {
-					return tx.TefINTERNAL, 0
+					return ter.TefINTERNAL, 0
 				}
 				page, err = state.ParseNFTokenPage(klData)
 				if err != nil {
-					return tx.TefINTERNAL, 0
+					return ter.TefINTERNAL, 0
 				}
 			}
 		}
@@ -458,7 +459,7 @@ func removeToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte, fixPageLi
 		// Try merging with next page
 		if nextPage != nil {
 			merged, res := doMergePages(view, kl, page, nextKL, nextPage)
-			if res != tx.TesSUCCESS {
+			if res != ter.TesSUCCESS {
 				return res, 0
 			}
 			if merged {
@@ -466,7 +467,7 @@ func removeToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte, fixPageLi
 			}
 		}
 
-		return tx.TesSUCCESS, pagesRemoved
+		return ter.TesSUCCESS, pagesRemoved
 	}
 
 	// Page is empty
@@ -489,31 +490,31 @@ func removeToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte, fixPageLi
 			page.PreviousPageMin = prevPage.PreviousPageMin
 			// Fix link from prev's previous; that page must exist.
 			ppPage, ppKL, r := loadAdjacentPage(view, kl.Type, prevPage.PreviousPageMin)
-			if r != tx.TesSUCCESS {
+			if r != ter.TesSUCCESS {
 				return r, 0
 			}
 			ppPage.NextPageMin = kl.Key
 			ppBytes, err := serializeNFTokenPage(ppPage)
 			if err != nil {
-				return tx.TefINTERNAL, 0
+				return ter.TefINTERNAL, 0
 			}
 			if err := view.Update(ppKL, ppBytes); err != nil {
-				return tx.TefINTERNAL, 0
+				return ter.TefINTERNAL, 0
 			}
 		} else {
 			page.PreviousPageMin = emptyHash
 		}
 		pageBytes, err := serializeNFTokenPage(page)
 		if err != nil {
-			return tx.TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
 		if err := view.Update(kl, pageBytes); err != nil {
-			return tx.TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
 		if err := view.Erase(prevKL); err != nil {
-			return tx.TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
-		return tx.TesSUCCESS, 1
+		return ter.TesSUCCESS, 1
 	}
 
 	// Not the max page or no prev — unlink and remove
@@ -525,10 +526,10 @@ func removeToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte, fixPageLi
 		}
 		prevBytes, err := serializeNFTokenPage(prevPage)
 		if err != nil {
-			return tx.TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
 		if err := view.Update(prevKL, prevBytes); err != nil {
-			return tx.TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
 	}
 
@@ -540,15 +541,15 @@ func removeToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte, fixPageLi
 		}
 		nextBytes, err := serializeNFTokenPage(nextPage)
 		if err != nil {
-			return tx.TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
 		if err := view.Update(nextKL, nextBytes); err != nil {
-			return tx.TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
 	}
 
 	if err := view.Erase(kl); err != nil {
-		return tx.TefINTERNAL, 0
+		return ter.TefINTERNAL, 0
 	}
 	pagesRemoved = 1
 
@@ -557,22 +558,22 @@ func removeToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte, fixPageLi
 		// Re-read them since they were just updated.
 		prevData2, err := view.Read(prevKL)
 		if err != nil || prevData2 == nil {
-			return tx.TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
 		p1, err := state.ParseNFTokenPage(prevData2)
 		if err != nil {
-			return tx.TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
 		nextData2, err := view.Read(nextKL)
 		if err != nil || nextData2 == nil {
-			return tx.TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
 		p2, err := state.ParseNFTokenPage(nextData2)
 		if err != nil {
-			return tx.TefINTERNAL, 0
+			return ter.TefINTERNAL, 0
 		}
 		merged, res := doMergePages(view, prevKL, p1, nextKL, p2)
-		if res != tx.TesSUCCESS {
+		if res != ter.TesSUCCESS {
 			return res, 0
 		}
 		if merged {
@@ -580,7 +581,7 @@ func removeToken(view tx.LedgerView, owner [20]byte, tokenID [32]byte, fixPageLi
 		}
 	}
 
-	return tx.TesSUCCESS, pagesRemoved
+	return ter.TesSUCCESS, pagesRemoved
 }
 
 // doMergePages merges p1's tokens into p2 (p1 is lower, p2 is higher).
@@ -590,22 +591,22 @@ func doMergePages(
 	view tx.LedgerView,
 	p1KL keylet.Keylet, p1 *state.NFTokenPageData,
 	p2KL keylet.Keylet, p2 *state.NFTokenPageData,
-) (bool, tx.Result) {
+) (bool, ter.Result) {
 	// Reject inconsistent inputs before mutating state, matching rippled
 	// mergePages: the pages must be ordered (p1 below p2) and linked to each
 	// other. A violation is a corrupt directory, surfaced as tefEXCEPTION.
 	if bytes.Compare(p1KL.Key[:], p2KL.Key[:]) >= 0 {
-		return false, tx.TefEXCEPTION
+		return false, ter.TefEXCEPTION
 	}
 	if p1.NextPageMin != p2KL.Key {
-		return false, tx.TefEXCEPTION
+		return false, ter.TefEXCEPTION
 	}
 	if p2.PreviousPageMin != p1KL.Key {
-		return false, tx.TefEXCEPTION
+		return false, ter.TefEXCEPTION
 	}
 
 	if len(p1.NFTokens)+len(p2.NFTokens) > dirMaxTokensPerPage {
-		return false, tx.TesSUCCESS
+		return false, ter.TesSUCCESS
 	}
 
 	// Merge all tokens into p2 (higher page)
@@ -638,31 +639,31 @@ func doMergePages(
 
 		// Update p0's NextPageMin to point to p2; p0 must exist.
 		p0, p0KL, r := loadAdjacentPage(view, p1KL.Type, p1.PreviousPageMin)
-		if r != tx.TesSUCCESS {
+		if r != ter.TesSUCCESS {
 			return false, r
 		}
 		p0.NextPageMin = p2KL.Key
 		p0Bytes, err := serializeNFTokenPage(p0)
 		if err != nil {
-			return false, tx.TefINTERNAL
+			return false, ter.TefINTERNAL
 		}
 		if err := view.Update(p0KL, p0Bytes); err != nil {
-			return false, tx.TefINTERNAL
+			return false, ter.TefINTERNAL
 		}
 	}
 
 	p2Bytes, err := serializeNFTokenPage(p2)
 	if err != nil {
-		return false, tx.TefINTERNAL
+		return false, ter.TefINTERNAL
 	}
 	if err := view.Update(p2KL, p2Bytes); err != nil {
-		return false, tx.TefINTERNAL
+		return false, ter.TefINTERNAL
 	}
 	if err := view.Erase(p1KL); err != nil {
-		return false, tx.TefINTERNAL
+		return false, ter.TefINTERNAL
 	}
 
-	return true, tx.TesSUCCESS
+	return true, ter.TesSUCCESS
 }
 
 // ---------------------------------------------------------------------------
@@ -674,7 +675,7 @@ func doMergePages(
 // page changes for both sender and recipient so callers can properly adjust
 // OwnerCount (using ctx.Account for the submitter's account).
 type transferNFTokenResult struct {
-	Result           tx.Result
+	Result           ter.Result
 	FromPagesRemoved int
 	ToPagesCreated   int
 }
@@ -683,7 +684,7 @@ func transferNFToken(from, to [20]byte, tokenID [32]byte, view tx.LedgerView, fi
 	// Locate the sender's page holding the token and read its data in one lookup.
 	_, page, err := locatePage(view, from, tokenID)
 	if err != nil || page == nil {
-		return transferNFTokenResult{Result: tx.TefINTERNAL}
+		return transferNFTokenResult{Result: ter.TefINTERNAL}
 	}
 
 	var tokenData state.NFTokenData
@@ -696,24 +697,24 @@ func transferNFToken(from, to [20]byte, tokenID [32]byte, view tx.LedgerView, fi
 		}
 	}
 	if !found {
-		return transferNFTokenResult{Result: tx.TefINTERNAL}
+		return transferNFTokenResult{Result: ter.TefINTERNAL}
 	}
 
 	// Remove from sender using removeToken
 	result, pagesRemoved := removeToken(view, from, tokenID, fixPageLinks)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return transferNFTokenResult{Result: result}
 	}
 
 	// Insert into recipient
 	insertResult := insertNFToken(to, tokenData, view, fixDirV1)
-	if insertResult.Result != tx.TesSUCCESS {
+	if insertResult.Result != ter.TesSUCCESS {
 		return transferNFTokenResult{Result: insertResult.Result}
 	}
 
 	// Return page deltas — callers handle OwnerCount adjustments
 	return transferNFTokenResult{
-		Result:           tx.TesSUCCESS,
+		Result:           ter.TesSUCCESS,
 		FromPagesRemoved: pagesRemoved,
 		ToPagesCreated:   insertResult.PagesCreated,
 	}

--- a/internal/tx/nftoken/nftoken_page_test.go
+++ b/internal/tx/nftoken/nftoken_page_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
-	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -161,7 +161,7 @@ func TestPageSplitAndMergeThresholds(t *testing.T) {
 		id := generateNFTokenID(owner, 0, uint32(i), NFTokenFlagTransferable, 0)
 		ids = append(ids, id)
 		res := insertNFToken(owner, state.NFTokenData{NFTokenID: id}, view, true)
-		if res.Result != tx.TesSUCCESS {
+		if res.Result != ter.TesSUCCESS {
 			t.Fatalf("insert %d: result %v", i, res.Result)
 		}
 	}
@@ -175,7 +175,7 @@ func TestPageSplitAndMergeThresholds(t *testing.T) {
 	overflow := generateNFTokenID(owner, 0, uint32(dirMaxTokensPerPage), NFTokenFlagTransferable, 0)
 	ids = append(ids, overflow)
 	res := insertNFToken(owner, state.NFTokenData{NFTokenID: overflow}, view, true)
-	if res.Result != tx.TesSUCCESS {
+	if res.Result != ter.TesSUCCESS {
 		t.Fatalf("overflow insert: result %v", res.Result)
 	}
 	if res.PagesCreated != 1 {
@@ -196,7 +196,7 @@ func TestPageSplitAndMergeThresholds(t *testing.T) {
 	// Removing one token returns the total to 32; the two pages (combined size
 	// <= dirMaxTokensPerPage) must merge back into one.
 	result, removed := removeToken(view, owner, ids[0], true)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		t.Fatalf("removeToken: result %v", result)
 	}
 	if removed != 1 {

--- a/internal/tx/offer/offer_cancel.go
+++ b/internal/tx/offer/offer_cancel.go
@@ -4,6 +4,7 @@ package offer
 import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -35,11 +36,11 @@ func (o *OfferCancel) Validate() error {
 	}
 
 	if err := tx.CheckFlags(o.GetFlags(), tx.TfUniversalMask); err != nil {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags set")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags set")
 	}
 
 	if o.OfferSequence == 0 {
-		return tx.Errorf(tx.TemBAD_SEQUENCE, "OfferSequence is required and cannot be zero")
+		return ter.Errorf(ter.TemBAD_SEQUENCE, "OfferSequence is required and cannot be zero")
 	}
 
 	return nil
@@ -50,7 +51,7 @@ func (o *OfferCancel) Flatten() (map[string]any, error) {
 }
 
 // Reference: rippled CancelOffer.cpp preclaim() + doApply()
-func (o *OfferCancel) Apply(ctx *tx.ApplyContext) tx.Result {
+func (o *OfferCancel) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Preclaim: Account sequence must be strictly greater than OfferSequence
 	// Reference: rippled CancelOffer.cpp preclaim() lines 59-72
 	// Note: The engine has already incremented ctx.Account.Sequence by 1 for
@@ -63,7 +64,7 @@ func (o *OfferCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 		accountSeq-- // undo engine's pre-increment
 	}
 	if accountSeq <= o.OfferSequence {
-		return tx.TemBAD_SEQUENCE
+		return ter.TemBAD_SEQUENCE
 	}
 
 	// Find the offer
@@ -72,52 +73,52 @@ func (o *OfferCancel) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	exists, err := ctx.View.Exists(offerKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if !exists {
 		// Offer doesn't exist - this is OK (maybe already filled/cancelled)
 		// Reference: rippled CancelOffer.cpp lines 91-92
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Read the offer to get its details for metadata and directory removal
 	offerData, err := ctx.View.Read(offerKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	ledgerOffer, err := state.ParseLedgerOffer(offerData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Remove from owner directory (keepRoot = false since owner dir should persist)
 	ownerDirKey := keylet.OwnerDir(accountID)
 	ownerDirResult, err := state.DirRemove(ctx.View, ownerDirKey, ledgerOffer.OwnerNode, offerKey.Key, false)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if !ownerDirResult.Success {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 
 	// Remove from book directory (keepRoot = false - delete directory if empty)
 	bookDirKey := keylet.Keylet{Type: entry.TypeDirectoryNode, Key: ledgerOffer.BookDirectory}
 	bookDirResult, err := state.DirRemove(ctx.View, bookDirKey, ledgerOffer.BookNode, offerKey.Key, false)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if !bookDirResult.Success {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 
 	if err := ctx.View.Erase(offerKey); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if ctx.Account.OwnerCount > 0 {
 		ctx.Account.OwnerCount--
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/offer/offer_create_apply.go
+++ b/internal/tx/offer/offer_create_apply.go
@@ -5,6 +5,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -18,7 +19,7 @@ const lsfHybrid = entry.LsfHybrid
 // matching rippled where they precede doApply(). Apply performs offer crossing
 // and placement.
 // Reference: rippled CreateOffer.cpp doApply()
-func (o *OfferCreate) Apply(ctx *tx.ApplyContext) tx.Result {
+func (o *OfferCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("offer create apply",
 		"account", o.Account,
 		"takerPays", o.TakerPays,
@@ -41,7 +42,7 @@ func (o *OfferCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 //
 // For FoK offers that don't fully fill, we apply sbCancel instead of sb,
 // ensuring the cancellation happens but the crossing changes are discarded.
-func (o *OfferCreate) ApplyCreate(ctx *tx.ApplyContext) tx.Result {
+func (o *OfferCreate) ApplyCreate(ctx *tx.ApplyContext) ter.Result {
 	// Create TWO independent sandboxes from ctx.View
 	// Reference: rippled CreateOffer.cpp lines 938-941
 	sb := payment.NewPaymentSandbox(ctx.View)
@@ -70,7 +71,7 @@ func (o *OfferCreate) ApplyCreate(ctx *tx.ApplyContext) tx.Result {
 		// The account balance will be read from the sandbox after applying.
 	}
 	if err := activeSb.ApplyToView(ctx.View); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Re-read the account from the view to get the sandbox's changes.
@@ -103,7 +104,7 @@ func (o *OfferCreate) ApplyCreate(ctx *tx.ApplyContext) tx.Result {
 // Returns:
 //   - result: the transaction result code
 //   - applyMain: true to apply sb, false to apply sbCancel
-func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.PaymentSandbox) (tx.Result, bool) {
+func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.PaymentSandbox) (ter.Result, bool) {
 	rules := ctx.Rules()
 
 	flags := o.GetFlags()
@@ -128,9 +129,9 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 	// Reference: lines 623-636
 	if tx.HasExpired(o.Expiration, ctx.Config.ParentCloseTime) {
 		if rules.DepositPreauthEnabled() {
-			return tx.TecEXPIRED, false // Apply cancel sandbox for expired offers
+			return ter.TecEXPIRED, false // Apply cancel sandbox for expired offers
 		}
-		return tx.TesSUCCESS, true
+		return ter.TesSUCCESS, true
 	}
 
 	crossed := false
@@ -139,7 +140,7 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 	// source balance before its own fee was deducted.
 	mPriorBalance := ctx.PriorBalance()
 
-	if result == tx.TesSUCCESS {
+	if result == ter.TesSUCCESS {
 		outcome := o.takerCross(ctx, sb, sbCancel, saTakerPays, saTakerGets, uRate, bPassive, bSell, bFillOrKill)
 		if outcome.terminated {
 			return outcome.result, outcome.applyMain
@@ -152,10 +153,10 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 
 	// Sanity check: amounts should be positive
 	if isAmountZeroOrNegative(saTakerPays) || isAmountZeroOrNegative(saTakerGets) {
-		return tx.TefINTERNAL, false
+		return ter.TefINTERNAL, false
 	}
 
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result, false
 	}
 
@@ -164,18 +165,18 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 	// CRITICAL: For FoK, apply sbCancel to discard crossing changes
 	if bFillOrKill {
 		if rules.Enabled(amendment.FeatureFix1578) {
-			return tx.TecKILLED, false // Apply cancel sandbox
+			return ter.TecKILLED, false // Apply cancel sandbox
 		}
-		return tx.TesSUCCESS, false // Pre-amendment: still apply cancel sandbox
+		return ter.TesSUCCESS, false // Pre-amendment: still apply cancel sandbox
 	}
 
 	// Handle ImmediateOrCancel
 	// Reference: lines 799-809
 	if bImmediateOrCancel {
 		if !crossed && rules.Enabled(amendment.FeatureImmediateOfferKilled) {
-			return tx.TecKILLED, false // No crossing - apply cancel sandbox
+			return ter.TecKILLED, false // No crossing - apply cancel sandbox
 		}
-		return tx.TesSUCCESS, true // Crossing happened - apply main sandbox
+		return ter.TesSUCCESS, true // Crossing happened - apply main sandbox
 	}
 
 	// Reference: rippled CreateOffer.cpp lines 811-834
@@ -192,9 +193,9 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 	reserve := ctx.AccountReserve(ownerCount + 1)
 	if mPriorBalance < reserve {
 		if !crossed {
-			return tx.TecINSUF_RESERVE_OFFER, true
+			return ter.TecINSUF_RESERVE_OFFER, true
 		}
-		return tx.TesSUCCESS, true
+		return ter.TesSUCCESS, true
 	}
 
 	return o.placeRemainingOffer(ctx, sb, saTakerPays, saTakerGets, uRate, bPassive, bSell, bHybrid)
@@ -218,30 +219,30 @@ func peekOffer(view tx.LedgerView, accountID [20]byte, sequence uint32) *state.L
 
 // offerDeleteInView removes an offer from the given view without modifying account state.
 // This is used by the two-sandbox pattern to delete offers in both sandboxes.
-func offerDeleteInView(view tx.LedgerView, offer *state.LedgerOffer) tx.Result {
+func offerDeleteInView(view tx.LedgerView, offer *state.LedgerOffer) ter.Result {
 	accountID, err := state.DecodeAccountID(offer.Account)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	offerKey := keylet.Offer(accountID, offer.Sequence)
 
 	ownerDirKey := keylet.OwnerDir(accountID)
 	_, err = state.DirRemove(view, ownerDirKey, offer.OwnerNode, offerKey.Key, false)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	bookDirKey := keylet.Keylet{Type: entry.TypeDirectoryNode, Key: offer.BookDirectory}
 	_, err = state.DirRemove(view, bookDirKey, offer.BookNode, offerKey.Key, false)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if err := view.Erase(offerKey); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // adjustOwnerCountInView adjusts an account's OwnerCount directly through the view.
@@ -254,7 +255,7 @@ func adjustOwnerCountInView(view tx.LedgerView, accountID [20]byte, delta int) {
 
 // applyHybridInSandbox handles hybrid offer placement in a specific view/sandbox.
 // Reference: rippled CreateOffer.cpp applyHybrid() lines 528-573
-func applyHybridInSandbox(view tx.LedgerView, offer *state.LedgerOffer, offerKey keylet.Keylet, takerPays, takerGets tx.Amount) tx.Result {
+func applyHybridInSandbox(view tx.LedgerView, offer *state.LedgerOffer, offerKey keylet.Keylet, takerPays, takerGets tx.Amount) ter.Result {
 	offer.Flags |= lsfHybrid
 
 	// Also place in open book (without domain)
@@ -277,11 +278,11 @@ func applyHybridInSandbox(view tx.LedgerView, offer *state.LedgerOffer, offerKey
 		// No DomainID for open book
 	})
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	offer.AdditionalBookDirectory = openBookDirKey.Key
 	offer.AdditionalBookNode = bookDirResult.Page
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/offer/offer_create_cross.go
+++ b/internal/tx/offer/offer_create_cross.go
@@ -5,6 +5,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -12,20 +13,20 @@ import (
 // on the OfferCreate transaction. The cancellation must occur in BOTH
 // sandboxes so that orphan state never survives the FillOrKill decision.
 // Reference: rippled CreateOffer.cpp lines 608-621
-func (o *OfferCreate) processCancelRequest(ctx *tx.ApplyContext, sb, sbCancel *payment.PaymentSandbox) tx.Result {
+func (o *OfferCreate) processCancelRequest(ctx *tx.ApplyContext, sb, sbCancel *payment.PaymentSandbox) ter.Result {
 	if o.OfferSequence == nil {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	sleCancel := peekOffer(ctx.View, ctx.AccountID, *o.OfferSequence)
 	if sleCancel == nil {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	result := offerDeleteInView(sb, sleCancel)
 	// Delete in cancel sandbox (same operation)
 	_ = offerDeleteInView(sbCancel, sleCancel)
 
 	// Also update owner count (once, since we'll only apply one sandbox)
-	if result == tx.TesSUCCESS && ctx.Account.OwnerCount > 0 {
+	if result == ter.TesSUCCESS && ctx.Account.OwnerCount > 0 {
 		ctx.Account.OwnerCount--
 	}
 	return result
@@ -34,7 +35,7 @@ func (o *OfferCreate) processCancelRequest(ctx *tx.ApplyContext, sb, sbCancel *p
 // crossOutcome captures everything takerCross hands back to applyGuts.
 type crossOutcome struct {
 	terminated  bool
-	result      tx.Result
+	result      ter.Result
 	applyMain   bool
 	saTakerPays tx.Amount
 	saTakerGets tx.Amount
@@ -104,7 +105,7 @@ func (o *OfferCreate) takerCross(
 	saTakerPays, saTakerGets = applyTickSize(ctx.View, saTakerPays, saTakerGets, bSell, rules)
 	if isAmountZeroOrNegative(saTakerPays) || isAmountZeroOrNegative(saTakerGets) {
 		// Offer rounded to zero
-		return crossOutcome{terminated: true, result: tx.TesSUCCESS, applyMain: true}
+		return crossOutcome{terminated: true, result: ter.TesSUCCESS, applyMain: true}
 	}
 
 	// Recalculate rate after tick size
@@ -118,7 +119,7 @@ func (o *OfferCreate) takerCross(
 	// saTakerGets) at the top of flowCross. Reference: rippled CreateOffer.cpp
 	// flowCross lines 329-335.
 	if isAmountZeroOrNegative(tx.AccountFunds(sb, ctx.AccountID, saTakerGets, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)) {
-		return crossOutcome{terminated: true, result: tx.TecUNFUNDED_OFFER, applyMain: false}
+		return crossOutcome{terminated: true, result: ter.TecUNFUNDED_OFFER, applyMain: false}
 	}
 
 	// Perform offer crossing using the main sandbox (sb)
@@ -157,18 +158,18 @@ func (o *OfferCreate) takerCross(
 	// locally (tel: no fee, not relayed) rather than claiming a fee (tec).
 	// Defensive: the flow caps amounts at funds, so this never trips normally.
 	// Reference: rippled CreateOffer.cpp:728-729 (tecFAILED_PROCESSING && bOpenLedger).
-	if result == tx.TecFAILED_PROCESSING && ctx.Config.IsViewOpen() {
-		result = tx.TelFAILED_PROCESSING
+	if result == ter.TecFAILED_PROCESSING && ctx.Config.IsViewOpen() {
+		result = ter.TelFAILED_PROCESSING
 	}
 
 	// For offer crossing, tecPATH_DRY means no liquidity found to cross
 	// This is not an error - we just place the offer with original amounts
 	// Reference: rippled's flowCross always returns tesSUCCESS (CreateOffer.cpp line 509)
-	if result == tx.TecPATH_DRY {
-		result = tx.TesSUCCESS
+	if result == ter.TecPATH_DRY {
+		result = ter.TesSUCCESS
 	}
 
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		// Error during crossing - apply cancel sandbox
 		return crossOutcome{terminated: true, result: result, applyMain: false}
 	}
@@ -206,7 +207,7 @@ func (o *OfferCreate) takerCross(
 	// FlowCross creates a root sandbox, so we use ApplyToView with sb as the target
 	if crossResult.Sandbox != nil {
 		if err := crossResult.Sandbox.ApplyToView(sb); err != nil {
-			return crossOutcome{terminated: true, result: tx.TefINTERNAL, applyMain: false}
+			return crossOutcome{terminated: true, result: ter.TefINTERNAL, applyMain: false}
 		}
 	}
 
@@ -219,7 +220,7 @@ func (o *OfferCreate) takerCross(
 
 	if isAmountZeroOrNegative(takerInBalance) {
 		// Apply main sandbox with crossing results
-		return crossOutcome{terminated: true, result: tx.TesSUCCESS, applyMain: true}
+		return crossOutcome{terminated: true, result: ter.TesSUCCESS, applyMain: true}
 	}
 
 	// Reference: line 744-745
@@ -242,7 +243,7 @@ func (o *OfferCreate) takerCross(
 	// Reference: lines 766-767
 	return crossOutcome{
 		terminated:  false,
-		result:      tx.TesSUCCESS,
+		result:      ter.TesSUCCESS,
 		applyMain:   true,
 		saTakerPays: remainingPays,
 		saTakerGets: remainingGets,
@@ -277,14 +278,14 @@ func evaluatePostCrossTermination(
 		if !isAmountZeroOrNegative(remainingWithGross) {
 			// FoK not satisfied: TakerGets not fully consumed by GROSS amount.
 			if rules.Enabled(amendment.FeatureFix1578) {
-				return crossOutcome{terminated: true, result: tx.TecKILLED, applyMain: false}, true
+				return crossOutcome{terminated: true, result: ter.TecKILLED, applyMain: false}, true
 			}
-			return crossOutcome{terminated: true, result: tx.TesSUCCESS, applyMain: false}, true
+			return crossOutcome{terminated: true, result: ter.TesSUCCESS, applyMain: false}, true
 		}
 	}
 
 	if fullyCrossed {
-		return crossOutcome{terminated: true, result: tx.TesSUCCESS, applyMain: true}, true
+		return crossOutcome{terminated: true, result: ter.TesSUCCESS, applyMain: true}, true
 	}
 	return crossOutcome{}, false
 }

--- a/internal/tx/offer/offer_create_place.go
+++ b/internal/tx/offer/offer_create_place.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -19,7 +20,7 @@ func (o *OfferCreate) placeRemainingOffer(
 	saTakerPays, saTakerGets tx.Amount,
 	uRate uint64,
 	bPassive, bSell, bHybrid bool,
-) (tx.Result, bool) {
+) (ter.Result, bool) {
 	// Create the offer in the ledger (in main sandbox)
 	// Reference: lines 837-925
 	offerSequence := o.GetCommon().SeqProxy()
@@ -49,7 +50,7 @@ func (o *OfferCreate) placeRemainingOffer(
 		dir.Owner = ctx.AccountID
 	})
 	if err != nil {
-		return tx.TefINTERNAL, false
+		return ter.TefINTERNAL, false
 	}
 
 	// Reference: line 851
@@ -65,7 +66,7 @@ func (o *OfferCreate) placeRemainingOffer(
 		// Note: DomainID is stored on the offer itself, not the directory
 	})
 	if err != nil {
-		return tx.TefINTERNAL, false
+		return ter.TefINTERNAL, false
 	}
 
 	// Reference: lines 895-910
@@ -102,7 +103,7 @@ func (o *OfferCreate) placeRemainingOffer(
 	// Handle hybrid offers
 	// Reference: lines 912-919
 	if bHybrid {
-		if result := applyHybridInSandbox(sb, ledgerOffer, offerKey, saTakerPays, saTakerGets); result != tx.TesSUCCESS {
+		if result := applyHybridInSandbox(sb, ledgerOffer, offerKey, saTakerPays, saTakerGets); result != ter.TesSUCCESS {
 			return result, false
 		}
 	}
@@ -110,12 +111,12 @@ func (o *OfferCreate) placeRemainingOffer(
 	// Serialize and store the offer
 	offerData, err := state.SerializeLedgerOffer(ledgerOffer)
 	if err != nil {
-		return tx.TefINTERNAL, false
+		return ter.TefINTERNAL, false
 	}
 
 	if err := sb.Insert(offerKey, offerData); err != nil {
-		return tx.TefINTERNAL, false
+		return ter.TefINTERNAL, false
 	}
 
-	return tx.TesSUCCESS, true // Apply main sandbox
+	return ter.TesSUCCESS, true // Apply main sandbox
 }

--- a/internal/tx/offer/offer_create_validate.go
+++ b/internal/tx/offer/offer_create_validate.go
@@ -5,6 +5,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/permissioneddomain"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -20,7 +21,7 @@ func (o *OfferCreate) Validate() error {
 	// Reference: rippled CreateOffer.cpp preflight() lines 61-65
 	flags := o.GetFlags()
 	if flags&tfOfferCreateMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags set")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags set")
 	}
 
 	// IoC and FoK are mutually exclusive
@@ -28,23 +29,23 @@ func (o *OfferCreate) Validate() error {
 	bImmediateOrCancel := (flags & OfferCreateFlagImmediateOrCancel) != 0
 	bFillOrKill := (flags & OfferCreateFlagFillOrKill) != 0
 	if bImmediateOrCancel && bFillOrKill {
-		return tx.Errorf(tx.TemINVALID_FLAG, "cannot set both ImmediateOrCancel and FillOrKill")
+		return ter.Errorf(ter.TemINVALID_FLAG, "cannot set both ImmediateOrCancel and FillOrKill")
 	}
 
 	// tfHybrid requires DomainID (rules-independent check)
 	// Reference: lines 70-71
 	if (flags&tfHybrid != 0) && o.DomainID == nil {
-		return tx.Errorf(tx.TemINVALID_FLAG, "tfHybrid requires DomainID")
+		return ter.Errorf(ter.TemINVALID_FLAG, "tfHybrid requires DomainID")
 	}
 
 	// Reference: lines 82-88
 	if o.Expiration != nil && *o.Expiration == 0 {
-		return tx.Errorf(tx.TemBAD_EXPIRATION, "expiration cannot be zero")
+		return ter.Errorf(ter.TemBAD_EXPIRATION, "expiration cannot be zero")
 	}
 
 	// Reference: lines 90-95
 	if o.OfferSequence != nil && *o.OfferSequence == 0 {
-		return tx.Errorf(tx.TemBAD_SEQUENCE, "OfferSequence cannot be zero")
+		return ter.Errorf(ter.TemBAD_SEQUENCE, "OfferSequence cannot be zero")
 	}
 
 	// Validate amounts
@@ -53,27 +54,27 @@ func (o *OfferCreate) Validate() error {
 
 	// Check required amounts are present (unset Amount has no type info)
 	if !saTakerPays.IsNative() && saTakerPays.Currency == "" {
-		return tx.Errorf(tx.TemBAD_OFFER, "TakerPays is required")
+		return ter.Errorf(ter.TemBAD_OFFER, "TakerPays is required")
 	}
 	if !saTakerGets.IsNative() && saTakerGets.Currency == "" {
-		return tx.Errorf(tx.TemBAD_OFFER, "TakerGets is required")
+		return ter.Errorf(ter.TemBAD_OFFER, "TakerGets is required")
 	}
 
 	// Reference: lines 97-101
 	if !isLegalNetAmount(saTakerPays) || !isLegalNetAmount(saTakerGets) {
-		return tx.Errorf(tx.TemBAD_AMOUNT, "invalid amount")
+		return ter.Errorf(ter.TemBAD_AMOUNT, "invalid amount")
 	}
 
 	// Cannot exchange XRP for XRP
 	// Reference: lines 103-107
 	if saTakerPays.IsNative() && saTakerGets.IsNative() {
-		return tx.Errorf(tx.TemBAD_OFFER, "cannot exchange XRP for XRP")
+		return ter.Errorf(ter.TemBAD_OFFER, "cannot exchange XRP for XRP")
 	}
 
 	// Amounts must be positive
 	// Reference: lines 108-112
 	if isAmountZeroOrNegative(saTakerPays) || isAmountZeroOrNegative(saTakerGets) {
-		return tx.Errorf(tx.TemBAD_OFFER, "amounts must be positive")
+		return ter.Errorf(ter.TemBAD_OFFER, "amounts must be positive")
 	}
 
 	uPaysCurrency := saTakerPays.Currency
@@ -84,24 +85,24 @@ func (o *OfferCreate) Validate() error {
 	// Check for redundant offer (same currency and issuer)
 	// Reference: lines 120-124
 	if uPaysCurrency == uGetsCurrency && uPaysIssuerID == uGetsIssuerID {
-		return tx.Errorf(tx.TemREDUNDANT, "cannot create offer with same currency and issuer on both sides")
+		return ter.Errorf(ter.TemREDUNDANT, "cannot create offer with same currency and issuer on both sides")
 	}
 
 	// Check for bad currency (XRP as non-native currency code)
 	// Reference: lines 126-130
 	if !saTakerPays.IsNative() && uPaysCurrency == badCurrency() {
-		return tx.Errorf(tx.TemBAD_CURRENCY, "cannot use XRP as non-native currency code")
+		return ter.Errorf(ter.TemBAD_CURRENCY, "cannot use XRP as non-native currency code")
 	}
 	if !saTakerGets.IsNative() && uGetsCurrency == badCurrency() {
-		return tx.Errorf(tx.TemBAD_CURRENCY, "cannot use XRP as non-native currency code")
+		return ter.Errorf(ter.TemBAD_CURRENCY, "cannot use XRP as non-native currency code")
 	}
 
 	// Reference: lines 132-137
 	if saTakerPays.IsNative() != (uPaysIssuerID == "") {
-		return tx.Errorf(tx.TemBAD_ISSUER, "issuer mismatch for TakerPays")
+		return ter.Errorf(ter.TemBAD_ISSUER, "issuer mismatch for TakerPays")
 	}
 	if saTakerGets.IsNative() != (uGetsIssuerID == "") {
-		return tx.Errorf(tx.TemBAD_ISSUER, "issuer mismatch for TakerGets")
+		return ter.Errorf(ter.TemBAD_ISSUER, "issuer mismatch for TakerGets")
 	}
 
 	return nil
@@ -122,13 +123,13 @@ func (o *OfferCreate) PreflightRules(rules *amendment.Rules) error {
 	// Check if DomainID field is present without PermissionedDEX amendment
 	// Reference: rippled CreateOffer.cpp preflight() lines 49-51
 	if o.DomainID != nil && !rules.PermissionedDEXEnabled() {
-		return tx.Errorf(tx.TemDISABLED, "DomainID requires PermissionedDEX amendment")
+		return ter.Errorf(ter.TemDISABLED, "DomainID requires PermissionedDEX amendment")
 	}
 
 	// Reference: lines 67-68
 	flags := o.GetFlags()
 	if !rules.PermissionedDEXEnabled() && (flags&tfHybrid != 0) {
-		return tx.Errorf(tx.TemINVALID_FLAG, "tfHybrid requires PermissionedDEX amendment")
+		return ter.Errorf(ter.TemINVALID_FLAG, "tfHybrid requires PermissionedDEX amendment")
 	}
 
 	return nil
@@ -137,19 +138,19 @@ func (o *OfferCreate) PreflightRules(rules *amendment.Rules) error {
 // Preclaim validates the transaction against ledger state before application.
 // Runs through the engine's Preclaimer dispatch, before fee deduction.
 // Reference: rippled CreateOffer.cpp preclaim() lines 142-225
-func (o *OfferCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Result {
+func (o *OfferCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Result {
 	rules := config.GetRules()
 
 	accountID, err := state.DecodeAccountID(o.Account)
 	if err != nil {
-		return tx.TemBAD_SRC_ACCOUNT
+		return ter.TemBAD_SRC_ACCOUNT
 	}
 	account, readErr := tx.ReadAccountRoot(view, accountID)
 	if readErr != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if account == nil {
-		return tx.TerNO_ACCOUNT
+		return ter.TerNO_ACCOUNT
 	}
 
 	saTakerPays := o.TakerPays
@@ -161,12 +162,12 @@ func (o *OfferCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Re
 	// Reference: lines 165-170
 	if uPaysIssuerID != "" {
 		if tx.IsGlobalFrozen(view, uPaysIssuerID) {
-			return tx.TecFROZEN
+			return ter.TecFROZEN
 		}
 	}
 	if uGetsIssuerID != "" {
 		if tx.IsGlobalFrozen(view, uGetsIssuerID) {
-			return tx.TecFROZEN
+			return ter.TecFROZEN
 		}
 	}
 
@@ -176,7 +177,7 @@ func (o *OfferCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Re
 	// Partially-funded offers are allowed; only completely unfunded offers are rejected.
 	funds := tx.AccountFunds(view, accountID, saTakerGets, true, config.ReserveBase, config.ReserveIncrement)
 	if funds.Signum() <= 0 {
-		return tx.TecUNFUNDED_OFFER
+		return ter.TecUNFUNDED_OFFER
 	}
 
 	// Check cancel sequence is valid. rippled compares the *pre-transaction*
@@ -185,16 +186,16 @@ func (o *OfferCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Re
 	// here from the view) still holds the stored pre-transaction sequence.
 	if o.OfferSequence != nil {
 		if account.Sequence <= *o.OfferSequence {
-			return tx.TemBAD_SEQUENCE
+			return ter.TemBAD_SEQUENCE
 		}
 	}
 
 	// Reference: lines 189-200
 	if tx.HasExpired(o.Expiration, config.ParentCloseTime) {
 		if rules.DepositPreauthEnabled() {
-			return tx.TecEXPIRED
+			return ter.TecEXPIRED
 		}
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Check we can accept what the taker will pay us (for non-native)
@@ -202,10 +203,10 @@ func (o *OfferCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Re
 	if !saTakerPays.IsNative() {
 		paysIssuerID, err := state.DecodeAccountID(uPaysIssuerID)
 		if err != nil {
-			return tx.TecNO_ISSUER
+			return ter.TecNO_ISSUER
 		}
 		result := checkAcceptAsset(view, accountID, paysIssuerID, saTakerPays.Currency, rules)
-		if result != tx.TesSUCCESS {
+		if result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -214,26 +215,26 @@ func (o *OfferCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Re
 	// Reference: lines 217-222
 	if o.DomainID != nil {
 		if !accountInDomain(view, accountID, *o.DomainID, config.ParentCloseTime) {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // checkAcceptAsset validates that an account can receive an asset.
 // Reference: rippled CreateOffer.cpp checkAcceptAsset() lines 227-312
-func checkAcceptAsset(view tx.LedgerView, accountID, issuerID [20]byte, currency string, rules *amendment.Rules) tx.Result {
+func checkAcceptAsset(view tx.LedgerView, accountID, issuerID [20]byte, currency string, rules *amendment.Rules) ter.Result {
 	// Read issuer account
 	issuerAccount, err := tx.ReadAccountRoot(view, issuerID)
 	if err != nil || issuerAccount == nil {
-		return tx.TecNO_ISSUER
+		return ter.TecNO_ISSUER
 	}
 
 	// If account is the issuer, always allowed
 	// Reference: lines 254-256
 	if rules.DepositPreauthEnabled() && accountID == issuerID {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Reference: lines 258-282
@@ -241,12 +242,12 @@ func checkAcceptAsset(view tx.LedgerView, accountID, issuerID [20]byte, currency
 		trustLineKey := keylet.Line(accountID, issuerID, currency)
 		trustLineData, err := view.Read(trustLineKey)
 		if err != nil || trustLineData == nil {
-			return tx.TecNO_LINE
+			return ter.TecNO_LINE
 		}
 
 		rs, err := state.ParseRippleState(trustLineData)
 		if err != nil {
-			return tx.TecNO_LINE
+			return ter.TecNO_LINE
 		}
 
 		// Check authorization based on canonical ordering
@@ -259,14 +260,14 @@ func checkAcceptAsset(view tx.LedgerView, accountID, issuerID [20]byte, currency
 		}
 
 		if !isAuthorized {
-			return tx.TecNO_AUTH
+			return ter.TecNO_AUTH
 		}
 	}
 
 	// If account is issuer, always allowed (redundant check but matches rippled)
 	// Reference: lines 288-291
 	if accountID == issuerID {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Reference: lines 293-309
@@ -274,20 +275,20 @@ func checkAcceptAsset(view tx.LedgerView, accountID, issuerID [20]byte, currency
 	trustLineData, err := view.Read(trustLineKey)
 	if err != nil || trustLineData == nil {
 		// No trustline = OK (will be created if needed)
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	rs, err := state.ParseRippleState(trustLineData)
 	if err != nil {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	deepFrozen := (rs.Flags & (state.LsfLowDeepFreeze | state.LsfHighDeepFreeze)) != 0
 	if deepFrozen {
-		return tx.TecFROZEN
+		return ter.TecFROZEN
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // accountInDomain checks if an account is a member of a permissioned domain.

--- a/internal/tx/offer/offer_test.go
+++ b/internal/tx/offer/offer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // ptrUint32 returns a pointer to a uint32 value
@@ -569,8 +570,8 @@ func TestLedgerOfferFlags(t *testing.T) {
 // Validate() only checks required fields.
 func TestOfferExpirationValidation(t *testing.T) {
 	// Test that tecEXPIRED result code exists
-	if tx.TecEXPIRED != 148 {
-		t.Errorf("expected tx.TecEXPIRED=148, got %d", tx.TecEXPIRED)
+	if ter.TecEXPIRED != 148 {
+		t.Errorf("expected ter.TecEXPIRED=148, got %d", ter.TecEXPIRED)
 	}
 
 	// Valid offer with expiration passes Validate() (semantic checks are in Preflight)

--- a/internal/tx/oracle/helpers.go
+++ b/internal/tx/oracle/helpers.go
@@ -1,6 +1,6 @@
 package oracle
 
-import "github.com/LeJamon/go-xrpl/internal/tx"
+import "github.com/LeJamon/go-xrpl/internal/tx/ter"
 
 // pairKey returns the deduplication key for a base/quote token pair.
 func pairKey(base, quote string) string {
@@ -12,11 +12,11 @@ func pairKey(base, quote string) string {
 // whole byte. Returns a temMALFORMED error on violation.
 func validateHexFieldLen(name, value string, maxBytes int) error {
 	if len(value) == 0 {
-		return tx.Errorf(tx.TemMALFORMED, "%s cannot be empty", name)
+		return ter.Errorf(ter.TemMALFORMED, "%s cannot be empty", name)
 	}
 	byteLen := (len(value) + 1) / 2
 	if byteLen > maxBytes {
-		return tx.Errorf(tx.TemMALFORMED, "%s length must be between 1 and %d bytes", name, maxBytes)
+		return ter.Errorf(ter.TemMALFORMED, "%s length must be between 1 and %d bytes", name, maxBytes)
 	}
 	return nil
 }

--- a/internal/tx/oracle/oracle_delete.go
+++ b/internal/tx/oracle/oracle_delete.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -51,7 +52,7 @@ func (o *OracleDelete) RequiredAmendments() [][32]byte {
 // Apply applies an OracleDelete transaction to the ledger state.
 // Combines rippled's DeleteOracle::preclaim() and DeleteOracle::doApply().
 // Reference: rippled DeleteOracle.cpp
-func (o *OracleDelete) Apply(ctx *tx.ApplyContext) tx.Result {
+func (o *OracleDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("oracle delete apply",
 		"account", o.Account,
 		"oracleDocumentID", o.OracleDocumentID,
@@ -65,13 +66,13 @@ func (o *OracleDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Warn("oracle delete: oracle not found",
 			"oracleDocumentID", o.OracleDocumentID,
 		)
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	oracle, err := state.ParseOracle(oracleData)
 	if err != nil {
 		ctx.Log.Error("oracle delete: failed to parse oracle", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// --- doApply ---
@@ -83,12 +84,12 @@ func (o *OracleDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 // This is a shared helper used by both OracleDelete.Apply() and AccountDelete cascade.
 // If ownerCount is nil, the OwnerCount adjustment is skipped (account deletion case).
 // Reference: rippled DeleteOracle.cpp deleteOracle()
-func DeleteOracleFromView(view state.LedgerView, oracleKey keylet.Keylet, oracle *state.OracleData, accountID [20]byte, ownerCount *uint32) tx.Result {
+func DeleteOracleFromView(view state.LedgerView, oracleKey keylet.Keylet, oracle *state.OracleData, accountID [20]byte, ownerCount *uint32) ter.Result {
 	// DirRemove from owner directory
 	ownerDirKey := keylet.OwnerDir(accountID)
 	_, err := state.DirRemove(view, ownerDirKey, oracle.OwnerNode, oracleKey.Key, true)
 	if err != nil {
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 
 	// Adjust OwnerCount
@@ -104,8 +105,8 @@ func DeleteOracleFromView(view state.LedgerView, oracleKey keylet.Keylet, oracle
 
 	// Erase oracle SLE
 	if err := view.Erase(oracleKey); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/oracle/oracle_set.go
+++ b/internal/tx/oracle/oracle_set.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
@@ -81,12 +82,12 @@ func (o *OracleSet) Validate() error {
 
 	// PriceDataSeries must not be empty
 	if len(o.PriceDataSeries) == 0 {
-		return tx.Errorf(tx.TemARRAY_EMPTY, "PriceDataSeries is required")
+		return ter.Errorf(ter.TemARRAY_EMPTY, "PriceDataSeries is required")
 	}
 
 	// Max 10 price data entries
 	if len(o.PriceDataSeries) > MaxOracleDataSeries {
-		return tx.Errorf(tx.TemARRAY_TOO_LARGE, "cannot have more than %d PriceDataSeries entries", MaxOracleDataSeries)
+		return ter.Errorf(ter.TemARRAY_TOO_LARGE, "cannot have more than %d PriceDataSeries entries", MaxOracleDataSeries)
 	}
 
 	// Provider, URI and AssetClass are hex-encoded; an explicitly present field
@@ -115,17 +116,17 @@ func (o *OracleSet) Validate() error {
 
 		// BaseAsset and QuoteAsset must be different
 		if entry.BaseAsset == entry.QuoteAsset {
-			return tx.Errorf(tx.TemMALFORMED, "BaseAsset and QuoteAsset must be different")
+			return ter.Errorf(ter.TemMALFORMED, "BaseAsset and QuoteAsset must be different")
 		}
 
 		// Scale cannot exceed MaxPriceScale
 		if entry.Scale != nil && *entry.Scale > MaxPriceScale {
-			return tx.Errorf(tx.TemMALFORMED, "Scale cannot exceed %d", MaxPriceScale)
+			return ter.Errorf(ter.TemMALFORMED, "Scale cannot exceed %d", MaxPriceScale)
 		}
 
 		pairKey := entry.TokenPairKey()
 		if seenPairs[pairKey] {
-			return tx.Errorf(tx.TemMALFORMED, "duplicate token pair in PriceDataSeries")
+			return ter.Errorf(ter.TemMALFORMED, "duplicate token pair in PriceDataSeries")
 		}
 		seenPairs[pairKey] = true
 	}
@@ -175,7 +176,7 @@ type pairEntry struct {
 // Apply applies an OracleSet transaction to the ledger state.
 // Combines rippled's SetOracle::preclaim() and SetOracle::doApply().
 // Reference: rippled SetOracle.cpp
-func (o *OracleSet) Apply(ctx *tx.ApplyContext) tx.Result {
+func (o *OracleSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("oracle set apply",
 		"account", o.Account,
 		"oracleDocumentID", o.OracleDocumentID,
@@ -189,7 +190,7 @@ func (o *OracleSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	lastUpdateTime := uint64(o.LastUpdateTime)
 
 	if lastUpdateTime < uint64(protocol.RippleEpochUnix) {
-		return tx.TecINVALID_UPDATE_TIME
+		return ter.TecINVALID_UPDATE_TIME
 	}
 	lastUpdateTimeEpoch := lastUpdateTime - uint64(protocol.RippleEpochUnix)
 
@@ -201,7 +202,7 @@ func (o *OracleSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	if closeTime >= MaxLastUpdateTimeDelta {
 		if lastUpdateTimeEpoch < (closeTime-MaxLastUpdateTimeDelta) ||
 			lastUpdateTimeEpoch > (closeTime+MaxLastUpdateTimeDelta) {
-			return tx.TecINVALID_UPDATE_TIME
+			return ter.TecINVALID_UPDATE_TIME
 		}
 	}
 
@@ -219,19 +220,19 @@ func (o *OracleSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		entry := pd.PriceData
 
 		if entry.BaseAsset == entry.QuoteAsset {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 
 		key := entry.TokenPairKey()
 		if _, exists := pairs[key]; exists {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 		if _, exists := pairsDel[key]; exists {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 
 		if entry.Scale != nil && *entry.Scale > MaxPriceScale {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 
 		if entry.AssetPrice != nil {
@@ -244,7 +245,7 @@ func (o *OracleSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		} else if isUpdate {
 			pairsDel[key] = struct{}{}
 		} else {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 	}
 
@@ -257,20 +258,20 @@ func (o *OracleSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		var err error
 		existingOracle, err = state.ParseOracle(existingData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// LastUpdateTime must be more recent than existing
 		if o.LastUpdateTime <= existingOracle.LastUpdateTime {
-			return tx.TecINVALID_UPDATE_TIME
+			return ter.TecINVALID_UPDATE_TIME
 		}
 
 		// If field is present in tx, it must match existing value
 		if o.isFieldPresent("Provider") && o.Provider != existingOracle.Provider {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 		if o.isFieldPresent("AssetClass") && o.AssetClass != existingOracle.AssetClass {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 
 		// Merge existing pairs with tx pairs
@@ -291,7 +292,7 @@ func (o *OracleSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 
 		if len(pairsDel) > 0 {
-			return tx.TecTOKEN_PAIR_NOT_FOUND
+			return ter.TecTOKEN_PAIR_NOT_FOUND
 		}
 
 		oldCount := 1
@@ -307,10 +308,10 @@ func (o *OracleSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		// --- Create-specific preclaim ---
 		// Reference: rippled SetOracle.cpp preclaim lines 160-168
 		if !o.isFieldPresent("Provider") && o.Provider == "" {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 		if !o.isFieldPresent("AssetClass") && o.AssetClass == "" {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 
 		if len(pairs) > 5 {
@@ -324,18 +325,18 @@ func (o *OracleSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled SetOracle.cpp preclaim lines 170-181
 	if len(pairs) == 0 {
 		ctx.Log.Warn("oracle set: empty price data after merge")
-		return tx.TecARRAY_EMPTY
+		return ter.TecARRAY_EMPTY
 	}
 	if len(pairs) > MaxOracleDataSeries {
 		ctx.Log.Warn("oracle set: too many price data entries",
 			"count", len(pairs),
 		)
-		return tx.TecARRAY_TOO_LARGE
+		return ter.TecARRAY_TOO_LARGE
 	}
 
 	// Reserve check: use prior balance (before deducting the fee actually paid).
 	ownerCountAfter := uint32(int(ctx.Account.OwnerCount) + adjustReserve)
-	if res := ctx.CheckReserveWithFee(ownerCountAfter); res != tx.TesSUCCESS {
+	if res := ctx.CheckReserveWithFee(ownerCountAfter); res != ter.TesSUCCESS {
 		ctx.Log.Warn("oracle set: insufficient reserve",
 			"balance", ctx.PriorBalance(),
 			"reserve", ctx.AccountReserve(ownerCountAfter),
@@ -355,7 +356,7 @@ func (o *OracleSet) Apply(ctx *tx.ApplyContext) tx.Result {
 // doApplyUpdate applies an OracleSet update to an existing oracle.
 // Reference: rippled SetOracle.cpp doApply lines 223-280
 func (o *OracleSet) doApplyUpdate(ctx *tx.ApplyContext, oracleKey keylet.Keylet,
-	existingOracle *state.OracleData) tx.Result {
+	existingOracle *state.OracleData) ter.Result {
 	// Build ordered pairs map from existing PriceDataSeries.
 	// Existing pairs are stored WITHOUT price/scale (just base/quote).
 	type orderedPair struct {
@@ -445,20 +446,20 @@ func (o *OracleSet) doApplyUpdate(ctx *tx.ApplyContext, oracleKey keylet.Keylet,
 	data, err := state.SerializeOracle(existingOracle)
 	if err != nil {
 		ctx.Log.Error("oracle set update: failed to serialize oracle", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(oracleKey, data); err != nil {
 		ctx.Log.Error("oracle set update: failed to update oracle", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // doApplyCreate applies an OracleSet create for a new oracle.
 // Reference: rippled SetOracle.cpp doApply lines 282-327
 func (o *OracleSet) doApplyCreate(ctx *tx.ApplyContext, oracleKey keylet.Keylet,
-	pairs map[string]pairEntry) tx.Result {
+	pairs map[string]pairEntry) ter.Result {
 	rules := ctx.Rules()
 
 	// Build PriceDataSeries
@@ -527,7 +528,7 @@ func (o *OracleSet) doApplyCreate(ctx *tx.ApplyContext, oracleKey keylet.Keylet,
 	})
 	if err != nil {
 		ctx.Log.Error("oracle set create: directory full", "error", err)
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 	oracleData.OwnerNode = dirResult.Page
 
@@ -535,13 +536,13 @@ func (o *OracleSet) doApplyCreate(ctx *tx.ApplyContext, oracleKey keylet.Keylet,
 	data, err := state.SerializeOracle(oracleData)
 	if err != nil {
 		ctx.Log.Error("oracle set create: failed to serialize oracle", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Insert oracle SLE
 	if err := ctx.View.Insert(oracleKey, data); err != nil {
 		ctx.Log.Error("oracle set create: failed to insert oracle", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Adjust OwnerCount
@@ -551,5 +552,5 @@ func (o *OracleSet) doApplyCreate(ctx *tx.ApplyContext, oracleKey keylet.Keylet,
 	}
 	ctx.Account.OwnerCount += count
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/parse.go
+++ b/internal/tx/parse.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // ParseJSON parses a JSON transaction into the appropriate transaction type.
@@ -38,11 +39,11 @@ func ParseHash256NonZero(s string) ([32]byte, error) {
 	var h [32]byte
 	b, err := hex.DecodeString(s)
 	if err != nil || len(b) != 32 {
-		return h, Errorf(TemMALFORMED, "invalid 256-bit hash")
+		return h, ter.Errorf(ter.TemMALFORMED, "invalid 256-bit hash")
 	}
 	copy(h[:], b)
 	if h == [32]byte{} {
-		return h, Errorf(TemMALFORMED, "256-bit hash must be non-zero")
+		return h, ter.Errorf(ter.TemMALFORMED, "256-bit hash must be non-zero")
 	}
 	return h, nil
 }

--- a/internal/tx/paychan/constant.go
+++ b/internal/tx/paychan/constant.go
@@ -1,6 +1,6 @@
 package paychan
 
-import "github.com/LeJamon/go-xrpl/internal/tx"
+import "github.com/LeJamon/go-xrpl/internal/tx/ter"
 
 // Payment channel flags
 const (
@@ -18,14 +18,14 @@ const (
 
 // Payment channel errors
 var (
-	ErrPayChanAmountRequired    = tx.Errorf(tx.TemBAD_AMOUNT, "Amount is required")
-	ErrPayChanAmountNotXRP      = tx.Errorf(tx.TemBAD_AMOUNT, "payment channels can only hold XRP")
-	ErrPayChanAmountNotPositive = tx.Errorf(tx.TemBAD_AMOUNT, "Amount must be positive")
-	ErrPayChanPublicKeyRequired = tx.Errorf(tx.TemMALFORMED, "PublicKey is required")
-	ErrPayChanPublicKeyInvalid  = tx.Errorf(tx.TemMALFORMED, "PublicKey is not a valid public key")
-	ErrPayChanChannelRequired   = tx.Errorf(tx.TemMALFORMED, "Channel is required")
-	ErrPayChanBalanceGTAmount   = tx.Errorf(tx.TemBAD_AMOUNT, "Balance cannot exceed Amount")
-	ErrPayChanCloseAndRenew     = tx.Errorf(tx.TemMALFORMED, "cannot set both tfClose and tfRenew")
-	ErrPayChanSigNeedsKey       = tx.Errorf(tx.TemMALFORMED, "PublicKey is required with Signature")
-	ErrPayChanSigNeedsBalance   = tx.Errorf(tx.TemMALFORMED, "Balance is required with Signature")
+	ErrPayChanAmountRequired    = ter.Errorf(ter.TemBAD_AMOUNT, "Amount is required")
+	ErrPayChanAmountNotXRP      = ter.Errorf(ter.TemBAD_AMOUNT, "payment channels can only hold XRP")
+	ErrPayChanAmountNotPositive = ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
+	ErrPayChanPublicKeyRequired = ter.Errorf(ter.TemMALFORMED, "PublicKey is required")
+	ErrPayChanPublicKeyInvalid  = ter.Errorf(ter.TemMALFORMED, "PublicKey is not a valid public key")
+	ErrPayChanChannelRequired   = ter.Errorf(ter.TemMALFORMED, "Channel is required")
+	ErrPayChanBalanceGTAmount   = ter.Errorf(ter.TemBAD_AMOUNT, "Balance cannot exceed Amount")
+	ErrPayChanCloseAndRenew     = ter.Errorf(ter.TemMALFORMED, "cannot set both tfClose and tfRenew")
+	ErrPayChanSigNeedsKey       = ter.Errorf(ter.TemMALFORMED, "PublicKey is required with Signature")
+	ErrPayChanSigNeedsBalance   = ter.Errorf(ter.TemMALFORMED, "Balance is required with Signature")
 )

--- a/internal/tx/paychan/helpers.go
+++ b/internal/tx/paychan/helpers.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -67,17 +68,17 @@ func serializePayChannel(pcTx *PaymentChannelCreate, ownerID, destID [20]byte, a
 // closeChannel closes a payment channel: removes from directories, returns remaining funds
 // to owner, decrements OwnerCount, and erases the channel SLE.
 // Reference: rippled PayChan.cpp closeChannel() (lines 116-164)
-func closeChannel(ctx *tx.ApplyContext, channelKey keylet.Keylet, channel *state.PayChannelData) tx.Result {
+func closeChannel(ctx *tx.ApplyContext, channelKey keylet.Keylet, channel *state.PayChannelData) ter.Result {
 	// 1. Remove from owner directory
 	ownerDirKey := keylet.OwnerDir(channel.Account)
-	if result := tx.DirRemoveOrBadLedger(ctx.View, ownerDirKey, channel.OwnerNode, channelKey.Key); result != tx.TesSUCCESS {
+	if result := tx.DirRemoveOrBadLedger(ctx.View, ownerDirKey, channel.OwnerNode, channelKey.Key); result != ter.TesSUCCESS {
 		return result
 	}
 
 	// 2. Remove from destination directory (if fixPayChanRecipientOwnerDir was active when created)
 	if channel.HasDestNode {
 		destDirKey := keylet.OwnerDir(channel.DestinationID)
-		if result := tx.DirRemoveOrBadLedger(ctx.View, destDirKey, channel.DestinationNode, channelKey.Key); result != tx.TesSUCCESS {
+		if result := tx.DirRemoveOrBadLedger(ctx.View, destDirKey, channel.DestinationNode, channelKey.Key); result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -96,11 +97,11 @@ func closeChannel(ctx *tx.ApplyContext, channelKey keylet.Keylet, channel *state
 		ownerKey := keylet.Account(channel.Account)
 		ownerData, err := ctx.View.Read(ownerKey)
 		if err != nil || ownerData == nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		ownerAccount, err := state.ParseAccountRoot(ownerData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		ownerAccount.Balance += remaining
 		if ownerAccount.OwnerCount > 0 {
@@ -108,19 +109,19 @@ func closeChannel(ctx *tx.ApplyContext, channelKey keylet.Keylet, channel *state
 		}
 		ownerUpdated, err := state.SerializeAccountRoot(ownerAccount)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := ctx.View.Update(ownerKey, ownerUpdated); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
 	// 4. Erase channel
 	if err := ctx.View.Erase(channelKey); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // verifyClaimSignature verifies a payment channel claim signature.

--- a/internal/tx/paychan/paychan_test.go
+++ b/internal/tx/paychan/paychan_test.go
@@ -4,10 +4,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/LeJamon/go-xrpl/amendment"
-	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // Helper to create a valid hex public key (33 bytes compressed)
@@ -584,41 +586,41 @@ func TestPaymentChannelFlagGate(t *testing.T) {
 		pcc := &PaymentChannelCreate{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelCreate, "rIssuer")}
 		flags := strayFlag
 		pcc.Common.Flags = &flags
-		assert.Equal(t, tx.TemINVALID_FLAG, pcc.Preclaim(nil, cfg))
+		assert.Equal(t, ter.TemINVALID_FLAG, pcc.Preclaim(nil, cfg))
 	})
 
 	t.Run("create accepts universal flags", func(t *testing.T) {
 		pcc := &PaymentChannelCreate{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelCreate, "rIssuer")}
 		flags := tx.TfUniversal
 		pcc.Common.Flags = &flags
-		assert.Equal(t, tx.TesSUCCESS, pcc.Preclaim(nil, cfg))
+		assert.Equal(t, ter.TesSUCCESS, pcc.Preclaim(nil, cfg))
 	})
 
 	t.Run("fund rejects stray flag", func(t *testing.T) {
 		pcf := &PaymentChannelFund{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelFund, "rOwner")}
 		flags := strayFlag
 		pcf.Common.Flags = &flags
-		assert.Equal(t, tx.TemINVALID_FLAG, pcf.Preclaim(nil, cfg))
+		assert.Equal(t, ter.TemINVALID_FLAG, pcf.Preclaim(nil, cfg))
 	})
 
 	t.Run("fund accepts universal flags", func(t *testing.T) {
 		pcf := &PaymentChannelFund{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelFund, "rOwner")}
 		flags := tx.TfUniversal
 		pcf.Common.Flags = &flags
-		assert.Equal(t, tx.TesSUCCESS, pcf.Preclaim(nil, cfg))
+		assert.Equal(t, ter.TesSUCCESS, pcf.Preclaim(nil, cfg))
 	})
 
 	t.Run("claim rejects stray flag", func(t *testing.T) {
 		pcc := &PaymentChannelClaim{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelClaim, "rOwner")}
 		flags := strayFlag
 		pcc.Common.Flags = &flags
-		assert.Equal(t, tx.TemINVALID_FLAG, pcc.Preclaim(nil, cfg))
+		assert.Equal(t, ter.TemINVALID_FLAG, pcc.Preclaim(nil, cfg))
 	})
 
 	t.Run("claim accepts tfRenew", func(t *testing.T) {
 		pcc := &PaymentChannelClaim{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelClaim, "rOwner")}
 		pcc.SetRenew()
-		assert.Equal(t, tx.TesSUCCESS, pcc.Preclaim(nil, cfg))
+		assert.Equal(t, ter.TesSUCCESS, pcc.Preclaim(nil, cfg))
 	})
 }
 

--- a/internal/tx/paychan/payment_channel_claim.go
+++ b/internal/tx/paychan/payment_channel_claim.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -61,7 +62,7 @@ func (p *PaymentChannelClaim) Validate() error {
 	// Validate Channel is valid hex (256-bit hash)
 	channelBytes, err := hex.DecodeString(p.Channel)
 	if err != nil || len(channelBytes) != 32 {
-		return tx.Errorf(tx.TemMALFORMED, "Channel must be a valid 256-bit hash")
+		return ter.Errorf(ter.TemMALFORMED, "Channel must be a valid 256-bit hash")
 	}
 
 	// The tfPayChanClaimMask flag check is gated on fix1543 and runs in
@@ -77,22 +78,22 @@ func (p *PaymentChannelClaim) Validate() error {
 	// Validate Balance if present
 	if p.Balance != nil {
 		if !p.Balance.IsNative() {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "Balance must be XRP")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "Balance must be XRP")
 		}
 		balVal := p.Balance.Drops()
 		if balVal <= 0 {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "Balance must be positive")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "Balance must be positive")
 		}
 	}
 
 	// Validate Amount if present
 	if p.Amount != nil {
 		if !p.Amount.IsNative() {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "Amount must be XRP")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be XRP")
 		}
 		amtVal := p.Amount.Drops()
 		if amtVal <= 0 {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "Amount must be positive")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
 		}
 	}
 
@@ -133,7 +134,7 @@ func (p *PaymentChannelClaim) Validate() error {
 			authAmt = p.Amount.Drops()
 		}
 		if p.Balance.Drops() > authAmt {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "Balance exceeds authorized amount")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "Balance exceeds authorized amount")
 		}
 
 		// Validate PublicKey is valid hex with the type rippled's
@@ -147,7 +148,7 @@ func (p *PaymentChannelClaim) Validate() error {
 		// Verify the claim signature over the authorized amount.
 		// Reference: PayChan.cpp lines 469-473 serializePayChanAuthorization.
 		if !verifyClaimSignature(p.Channel, uint64(authAmt), p.PublicKey, p.Signature) {
-			return tx.Errorf(tx.TemBAD_SIGNATURE, "invalid claim signature")
+			return ter.Errorf(ter.TemBAD_SIGNATURE, "invalid claim signature")
 		}
 	}
 
@@ -170,12 +171,12 @@ func (p *PaymentChannelClaim) RequiredAmendments() [][32]byte {
 // steps. For a tx malformed in two ways this can surface a different tem code
 // than rippled; the result is tem-only (never enters a ledger) so there is no
 // consensus divergence.
-func (p *PaymentChannelClaim) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
+func (p *PaymentChannelClaim) Preclaim(_ tx.LedgerView, config tx.EngineConfig) ter.Result {
 	const tfPayChanClaimMask = ^(tfPayChanRenew | tfPayChanClose | tx.TfUniversal)
 	if config.GetRules().Enabled(amendment.FeatureFix1543) && (p.GetFlags()&tfPayChanClaimMask) != 0 {
-		return tx.TemINVALID_FLAG
+		return ter.TemINVALID_FLAG
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // SetClose sets the close flag
@@ -201,7 +202,7 @@ func (p *PaymentChannelClaim) IsRenew() bool {
 }
 
 // Reference: rippled PayChan.cpp PayChanClaim::preclaim() + doApply()
-func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
+func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("payment channel claim apply",
 		"account", p.Account,
 		"channel", p.Channel,
@@ -215,12 +216,12 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 	// --- Preclaim: credential checks ---
 	// Reference: rippled PayChan.cpp PayChanClaim::preflight() credential check
 	if len(p.CredentialIDs) > 0 && !rules.Enabled(amendment.FeatureCredentials) {
-		return tx.TemDISABLED
+		return ter.TemDISABLED
 	}
 
 	// Reference: rippled PayChan.cpp PayChanClaim::preclaim() credentials::valid()
 	if len(p.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {
-		if result := credential.ValidateCredentialIDs(ctx, p.CredentialIDs); result != tx.TesSUCCESS {
+		if result := credential.ValidateCredentialIDs(ctx, p.CredentialIDs); result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -228,7 +229,7 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Parse channel ID
 	channelID, err := hex.DecodeString(p.Channel)
 	if err != nil || len(channelID) != 32 {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	var channelKeyBytes [32]byte
@@ -241,14 +242,14 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Warn("payment channel claim: channel not found",
 			"channel", p.Channel,
 		)
-		return tx.TecNO_TARGET
+		return ter.TecNO_TARGET
 	}
 
 	// Parse channel
 	channel, err := state.ParsePayChannel(channelData)
 	if err != nil {
 		ctx.Log.Error("payment channel claim: failed to parse channel", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Auto-close on expiration
@@ -266,7 +267,7 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Permission check: must be owner or destination
 	if !isOwner && !isDest {
 		ctx.Log.Warn("payment channel claim: no permission, not owner or destination")
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Track whether the claim actually mutates the channel SLE. rippled only
@@ -282,7 +283,7 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Destination claiming without signature
 		// Reference: rippled PayChan.cpp doApply() line 529
 		if isDest && !isOwner && p.Signature == "" {
-			return tx.TemBAD_SIGNATURE
+			return ter.TemBAD_SIGNATURE
 		}
 
 		// The signature itself is verified in Validate(); here we only confirm
@@ -290,7 +291,7 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 		// ledger state. Reference: rippled PayChan.cpp doApply() lines 532-537.
 		if p.Signature != "" {
 			if !strings.EqualFold(p.PublicKey, channel.PublicKey) {
-				return tx.TemBAD_SIGNER
+				return ter.TemBAD_SIGNER
 			}
 		}
 
@@ -301,7 +302,7 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 				"claimBalance", claimBalance,
 				"channelAmount", channel.Amount,
 			)
-			return tx.TecUNFUNDED_PAYMENT
+			return ter.TecUNFUNDED_PAYMENT
 		}
 
 		// Must make progress (claim must be > current balance)
@@ -311,19 +312,19 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 				"claimBalance", claimBalance,
 				"channelBalance", channel.Balance,
 			)
-			return tx.TecUNFUNDED_PAYMENT
+			return ter.TecUNFUNDED_PAYMENT
 		}
 
 		// Read destination account
 		destKey := keylet.Account(channel.DestinationID)
 		destData, err := ctx.View.Read(destKey)
 		if err != nil || destData == nil {
-			return tx.TecNO_DST
+			return ter.TecNO_DST
 		}
 
 		destAccount, err := state.ParseAccountRoot(destData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// DisallowXRP check — bug compatibility, only when DepositAuth is NOT enabled
@@ -331,14 +332,14 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 		depositAuth := rules.Enabled(amendment.FeatureDepositAuth)
 		if !depositAuth && isOwner && !isDest {
 			if destAccount.Flags&state.LsfDisallowXRP != 0 {
-				return tx.TecNO_TARGET
+				return ter.TecNO_TARGET
 			}
 		}
 
 		// DepositAuth check — when DepositAuth IS enabled
 		// Reference: rippled PayChan.cpp doApply() lines 553-563
 		if depositAuth {
-			if result := credential.VerifyDepositPreauth(ctx, p.CredentialIDs, accountID, channel.DestinationID, destAccount); result != tx.TesSUCCESS {
+			if result := credential.VerifyDepositPreauth(ctx, p.CredentialIDs, accountID, channel.DestinationID, destAccount); result != ter.TesSUCCESS {
 				return result
 			}
 		}
@@ -354,10 +355,10 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 			destAccount.Balance += transferAmount
 			destUpdatedData, err := state.SerializeAccountRoot(destAccount)
 			if err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			if err := ctx.View.Update(destKey, destUpdatedData); err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 		}
 
@@ -370,7 +371,7 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 	flags := p.GetFlags()
 	if flags&PaymentChannelClaimFlagRenew != 0 {
 		if !isOwner {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 		// Clear expiration. rippled always calls view.update(slep) here but
 		// relies on its own no-op-modify drop (ApplyStateTable.cpp:156-157)
@@ -406,19 +407,19 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) tx.Result {
 	// channel untouched — no ModifiedNode, no PreviousTxnID bump — so the
 	// metadata carries only the submitter's AccountRoot (the fee).
 	if !channelChanged {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	updatedChannelData, err := state.SerializePayChannelFromData(channel)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if err := ctx.View.Update(channelKey, updatedChannelData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // ApplyOnTec implements TecApplier for PaymentChannelClaim.

--- a/internal/tx/paychan/payment_channel_create.go
+++ b/internal/tx/paychan/payment_channel_create.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -115,15 +116,15 @@ func (p *PaymentChannelCreate) RequiredAmendments() [][32]byte {
 // after the common preflight/preclaim steps. For a tx malformed in two ways this
 // can surface a different tem code than rippled; the result is tem-only (never
 // enters a ledger) so there is no consensus divergence.
-func (p *PaymentChannelCreate) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
+func (p *PaymentChannelCreate) Preclaim(_ tx.LedgerView, config tx.EngineConfig) ter.Result {
 	if config.GetRules().Enabled(amendment.FeatureFix1543) && (p.GetFlags()&tx.TfUniversalMask) != 0 {
-		return tx.TemINVALID_FLAG
+		return ter.TemINVALID_FLAG
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // Reference: rippled PayChan.cpp PayChanCreate::doApply()
-func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) tx.Result {
+func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("payment channel create apply",
 		"account", p.Account,
 		"destination", p.Destination,
@@ -142,20 +143,20 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 			"balance", ctx.Account.Balance,
 			"reserve", reserve,
 		)
-		return tx.TecINSUFFICIENT_RESERVE
+		return ter.TecINSUFFICIENT_RESERVE
 	}
 	if ctx.Account.Balance-reserve < amount {
 		ctx.Log.Warn("payment channel create: unfunded",
 			"balance", ctx.Account.Balance,
 			"needed", reserve+amount,
 		)
-		return tx.TecUNFUNDED
+		return ter.TecUNFUNDED
 	}
 
 	// Verify destination exists and is not a pseudo-account (AMM)
 	// Reference: rippled PayChan.cpp preclaim() lines 216-248
 	destAccount, destID, result := ctx.LookupDestination(p.Destination)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		ctx.Log.Warn("payment channel create: destination lookup failed",
 			"destination", p.Destination,
 			"result", result,
@@ -170,7 +171,7 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 			ctx.Log.Warn("payment channel create: destination disallows incoming pay channels",
 				"destination", p.Destination,
 			)
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	}
 
@@ -180,14 +181,14 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Warn("payment channel create: destination tag required",
 			"destination", p.Destination,
 		)
-		return tx.TecDST_TAG_NEEDED
+		return ter.TecDST_TAG_NEEDED
 	}
 
 	// DisallowXRP check (only when DepositAuth amendment is NOT enabled — bug compat)
 	// Reference: rippled PayChan.cpp preclaim() lsfDisallowXRP
 	if !ctx.Rules().Enabled(amendment.FeatureDepositAuth) {
 		if destAccount.Flags&state.LsfDisallowXRP != 0 {
-			return tx.TecNO_TARGET
+			return ter.TecNO_TARGET
 		}
 	}
 
@@ -197,7 +198,7 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 		if p.CancelAfter != nil {
 			closeTime := ctx.Config.ParentCloseTime
 			if closeTime > *p.CancelAfter {
-				return tx.TecEXPIRED
+				return ter.TecEXPIRED
 			}
 		}
 	}
@@ -210,13 +211,13 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	channelData, err := serializePayChannel(p, accountID, destID, amount)
 	if err != nil {
 		ctx.Log.Error("payment channel create: failed to serialize channel", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Insert channel
 	if err := ctx.View.Insert(channelKey, channelData); err != nil {
 		ctx.Log.Error("payment channel create: failed to insert channel", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// DirInsert into owner directory
@@ -227,13 +228,13 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	})
 	if err != nil {
 		ctx.Log.Error("payment channel create: owner directory full", "error", err)
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 
 	// Re-read and update channel with OwnerNode from DirInsert
 	channelSLE, err := state.ParsePayChannel(channelData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	channelSLE.OwnerNode = ownerResult.Page
 
@@ -245,7 +246,7 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 			dir.Owner = destID
 		})
 		if err != nil {
-			return tx.TecDIR_FULL
+			return ter.TecDIR_FULL
 		}
 		channelSLE.DestinationNode = destResult.Page
 		channelSLE.HasDestNode = true
@@ -254,15 +255,15 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Re-serialize with updated OwnerNode/DestinationNode
 	updatedData, err := state.SerializePayChannelFromData(channelSLE)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(channelKey, updatedData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Deduct amount from account and increment OwnerCount
 	ctx.Account.Balance -= amount
 	ctx.Account.OwnerCount++
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/paychan/payment_channel_fund.go
+++ b/internal/tx/paychan/payment_channel_fund.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -54,7 +55,7 @@ func (p *PaymentChannelFund) Validate() error {
 	// Validate Channel is valid hex (256-bit hash)
 	channelBytes, err := hex.DecodeString(p.Channel)
 	if err != nil || len(channelBytes) != 32 {
-		return tx.Errorf(tx.TemMALFORMED, "Channel must be a valid 256-bit hash")
+		return ter.Errorf(ter.TemMALFORMED, "Channel must be a valid 256-bit hash")
 	}
 
 	// Amount is required and must be XRP
@@ -89,15 +90,15 @@ func (p *PaymentChannelFund) RequiredAmendments() [][32]byte {
 // after the common preflight/preclaim steps. For a tx malformed in two ways this
 // can surface a different tem code than rippled; the result is tem-only (never
 // enters a ledger) so there is no consensus divergence.
-func (p *PaymentChannelFund) Preclaim(_ tx.LedgerView, config tx.EngineConfig) tx.Result {
+func (p *PaymentChannelFund) Preclaim(_ tx.LedgerView, config tx.EngineConfig) ter.Result {
 	if config.GetRules().Enabled(amendment.FeatureFix1543) && (p.GetFlags()&tx.TfUniversalMask) != 0 {
-		return tx.TemINVALID_FLAG
+		return ter.TemINVALID_FLAG
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // Reference: rippled PayChan.cpp PayChanFund::doApply()
-func (p *PaymentChannelFund) Apply(ctx *tx.ApplyContext) tx.Result {
+func (p *PaymentChannelFund) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("payment channel fund apply",
 		"account", p.Account,
 		"channel", p.Channel,
@@ -107,7 +108,7 @@ func (p *PaymentChannelFund) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Parse channel ID
 	channelID, err := hex.DecodeString(p.Channel)
 	if err != nil || len(channelID) != 32 {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	var channelKeyBytes [32]byte
@@ -120,14 +121,14 @@ func (p *PaymentChannelFund) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Warn("payment channel fund: channel not found",
 			"channel", p.Channel,
 		)
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	// Parse channel
 	channel, err := state.ParsePayChannel(channelData)
 	if err != nil {
 		ctx.Log.Error("payment channel fund: failed to parse channel", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Auto-close check: if CancelAfter or Expiration has passed
@@ -142,7 +143,7 @@ func (p *PaymentChannelFund) Apply(ctx *tx.ApplyContext) tx.Result {
 	accountID, _ := state.DecodeAccountID(p.Account)
 	if channel.Account != accountID {
 		ctx.Log.Warn("payment channel fund: sender is not channel owner")
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Handle Expiration extension
@@ -158,7 +159,7 @@ func (p *PaymentChannelFund) Apply(ctx *tx.ApplyContext) tx.Result {
 
 		// New expiration must be >= minExpiration
 		if *p.Expiration < minExpiration {
-			return tx.TemBAD_EXPIRATION
+			return ter.TemBAD_EXPIRATION
 		}
 
 		channel.Expiration = *p.Expiration
@@ -173,21 +174,21 @@ func (p *PaymentChannelFund) Apply(ctx *tx.ApplyContext) tx.Result {
 			"balance", ctx.Account.Balance,
 			"reserve", reserve,
 		)
-		return tx.TecINSUFFICIENT_RESERVE
+		return ter.TecINSUFFICIENT_RESERVE
 	}
 	if ctx.Account.Balance-reserve < amount {
 		ctx.Log.Warn("payment channel fund: unfunded",
 			"balance", ctx.Account.Balance,
 			"needed", reserve+amount,
 		)
-		return tx.TecUNFUNDED
+		return ter.TecUNFUNDED
 	}
 
 	// Destination must still exist
 	// Reference: rippled PayChan.cpp doApply() lines 389-390
 	destKey := keylet.Account(channel.DestinationID)
 	if exists, _ := ctx.View.Exists(destKey); !exists {
-		return tx.TecNO_DST
+		return ter.TecNO_DST
 	}
 
 	// Deduct from account and add to channel
@@ -198,13 +199,13 @@ func (p *PaymentChannelFund) Apply(ctx *tx.ApplyContext) tx.Result {
 	updatedChannelData, err := state.SerializePayChannelFromData(channel)
 	if err != nil {
 		ctx.Log.Error("payment channel fund: failed to serialize channel", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if err := ctx.View.Update(channelKey, updatedChannelData); err != nil {
 		ctx.Log.Error("payment channel fund: failed to update channel", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/payment/failed_processing.go
+++ b/internal/tx/payment/failed_processing.go
@@ -3,7 +3,7 @@ package payment
 import (
 	"errors"
 
-	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // errInsufficientFunds is the sentinel an XRP-movement primitive returns when
@@ -27,9 +27,9 @@ var errXRPBalanceOutOfRange = errors.New("xrp endpoint credit exceeds serializab
 // failedProcessingResult returns the FAILED_PROCESSING TER variant appropriate
 // for this sandbox's view openness, mirroring rippled View.cpp where the guard
 // returns view.open() ? telFAILED_PROCESSING : tecFAILED_PROCESSING.
-func (s *PaymentSandbox) failedProcessingResult() tx.Result {
+func (s *PaymentSandbox) failedProcessingResult() ter.Result {
 	if s.IsOpenLedger() {
-		return tx.TelFAILED_PROCESSING
+		return ter.TelFAILED_PROCESSING
 	}
-	return tx.TecFAILED_PROCESSING
+	return ter.TecFAILED_PROCESSING
 }

--- a/internal/tx/payment/failed_processing_test.go
+++ b/internal/tx/payment/failed_processing_test.go
@@ -3,7 +3,7 @@ package payment
 import (
 	"testing"
 
-	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // TestFailedProcessingResult_ViewOpenness verifies the FAILED_PROCESSING TER
@@ -13,13 +13,13 @@ func TestFailedProcessingResult_ViewOpenness(t *testing.T) {
 	view := newPaymentMockLedgerView()
 
 	closed := NewPaymentSandbox(view)
-	if got := closed.failedProcessingResult(); got != tx.TecFAILED_PROCESSING {
+	if got := closed.failedProcessingResult(); got != ter.TecFAILED_PROCESSING {
 		t.Fatalf("closed view: want tecFAILED_PROCESSING, got %s", got)
 	}
 
 	open := NewPaymentSandbox(view)
 	open.SetOpenLedger(true)
-	if got := open.failedProcessingResult(); got != tx.TelFAILED_PROCESSING {
+	if got := open.failedProcessingResult(); got != ter.TelFAILED_PROCESSING {
 		t.Fatalf("open view: want telFAILED_PROCESSING, got %s", got)
 	}
 
@@ -28,7 +28,7 @@ func TestFailedProcessingResult_ViewOpenness(t *testing.T) {
 	if !child.IsOpenLedger() {
 		t.Fatalf("child of open sandbox should report open ledger")
 	}
-	if got := child.failedProcessingResult(); got != tx.TelFAILED_PROCESSING {
+	if got := child.failedProcessingResult(); got != ter.TelFAILED_PROCESSING {
 		t.Fatalf("open child: want telFAILED_PROCESSING, got %s", got)
 	}
 }

--- a/internal/tx/payment/flow.go
+++ b/internal/tx/payment/flow.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -51,7 +52,7 @@ func Flow(
 			Out:             ZeroXRPEitherAmount(),
 			Sandbox:         nil,
 			RemovableOffers: nil,
-			Result:          tx.TecPATH_DRY,
+			Result:          ter.TecPATH_DRY,
 		}
 	}
 
@@ -129,7 +130,7 @@ func Flow(
 				Out:             ZeroXRPEitherAmount(),
 				Sandbox:         nil,
 				RemovableOffers: allOfrsToRm,
-				Result:          tx.TelFAILED_PROCESSING,
+				Result:          ter.TelFAILED_PROCESSING,
 			}
 		}
 		// activateNext: move next -> cur, optionally re-sorting by quality
@@ -335,7 +336,7 @@ func Flow(
 						Out:             totalOut,
 						Sandbox:         accumSandbox,
 						RemovableOffers: allOfrsToRm,
-						Result:          tx.TefINTERNAL,
+						Result:          ter.TefINTERNAL,
 					}
 				}
 			}
@@ -384,7 +385,7 @@ func Flow(
 	//     else if (actualOut == 0) → tecPATH_DRY (delivered nothing)
 	//   }
 	//   otherwise tesSUCCESS.
-	resultCode := tx.TesSUCCESS
+	resultCode := ter.TesSUCCESS
 
 	if cmp := totalOut.Compare(outReq); cmp != 0 {
 		if cmp > 0 {
@@ -397,14 +398,14 @@ func Flow(
 				Out:             ZeroXRPEitherAmount(),
 				Sandbox:         nil,
 				RemovableOffers: allOfrsToRm,
-				Result:          tx.TefEXCEPTION,
+				Result:          ter.TefEXCEPTION,
 			}
 		}
 		// cmp < 0: under-delivery.
 		if !partialPayment {
-			resultCode = tx.TecPATH_PARTIAL
+			resultCode = ter.TecPATH_PARTIAL
 		} else if totalOut.IsZero() {
-			resultCode = tx.TecPATH_DRY
+			resultCode = ter.TecPATH_DRY
 		}
 	}
 
@@ -575,7 +576,7 @@ type RippleCalculateResult struct {
 	ActualOut       EitherAmount
 	RemovableOffers map[[32]byte]bool
 	Sandbox         *PaymentSandbox
-	Result          tx.Result
+	Result          ter.Result
 }
 
 // RippleCalculate is the main entry point for path-based payments.
@@ -623,9 +624,9 @@ func RippleCalculate(
 	// Convert paths to strands
 	// opts: [0]=offerCrossing (false for payments), [1]=fix1781
 	strands, strandResult := ToStrands(sandbox, srcAccount, dstAccount, dstAmount, srcAmount, paths, addDefaultPath, false, rcOpts.fix1781)
-	if strandResult != tx.TesSUCCESS || len(strands) == 0 {
-		if strandResult == tx.TesSUCCESS {
-			strandResult = tx.TecPATH_DRY
+	if strandResult != ter.TesSUCCESS || len(strands) == 0 {
+		if strandResult == ter.TesSUCCESS {
+			strandResult = ter.TecPATH_DRY
 		}
 		return RippleCalculateResult{
 			ActualIn:  ZeroXRPEitherAmount(),
@@ -675,13 +676,13 @@ func RippleCalculate(
 	result := Flow(sandbox, strands, outReq, partialPayment, qualityLimit, sendMax, ammCtx, rcOpts.flowSortStrands)
 
 	// Apply flow sandbox changes back to the main sandbox
-	if result.Result == tx.TesSUCCESS || result.Result == tx.TecPATH_PARTIAL {
+	if result.Result == ter.TesSUCCESS || result.Result == ter.TecPATH_PARTIAL {
 		if result.Sandbox != nil {
 			if err := result.Sandbox.Apply(sandbox); err != nil {
 				return RippleCalculateResult{
 					ActualIn:  ZeroXRPEitherAmount(),
 					ActualOut: ZeroXRPEitherAmount(),
-					Result:    tx.TefINTERNAL,
+					Result:    ter.TefINTERNAL,
 				}
 			}
 		}

--- a/internal/tx/payment/flow_cross.go
+++ b/internal/tx/payment/flow_cross.go
@@ -3,6 +3,7 @@ package payment
 import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -56,7 +57,7 @@ type FlowCrossResult struct {
 	RemovableOffers map[[32]byte]bool
 
 	// Result is the transaction result code
-	Result tx.Result
+	Result ter.Result
 }
 
 // FlowCross executes offer crossing for an OfferCreate transaction.
@@ -193,7 +194,7 @@ func FlowCross(
 		params.Fix1781, // fix1781 - gate XRP endpoint loop detection
 	)
 
-	if strandResult != tx.TesSUCCESS || len(strands) == 0 {
+	if strandResult != ter.TesSUCCESS || len(strands) == 0 {
 		// No valid strands - no crossing possible
 		return FlowCrossResult{
 			TakerGot:        zeroCrossAmount(takerPays),
@@ -201,7 +202,7 @@ func FlowCross(
 			TakerPaidNet:    zeroCrossAmount(takerGets),
 			Sandbox:         sandbox,
 			RemovableOffers: nil,
-			Result:          tx.TecPATH_DRY,
+			Result:          ter.TecPATH_DRY,
 		}
 	}
 
@@ -245,7 +246,7 @@ func FlowCross(
 				TakerPaidNet:    ZeroXRPEitherAmount(),
 				Sandbox:         sandbox,
 				RemovableOffers: nil,
-				Result:          tx.TefINTERNAL,
+				Result:          ter.TefINTERNAL,
 			}
 		}
 	}

--- a/internal/tx/payment/flow_test.go
+++ b/internal/tx/payment/flow_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/binary"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
-	"github.com/stretchr/testify/require"
 )
 
 // Test Helpers - Mock LedgerView for testing
@@ -614,8 +616,8 @@ func TestDirectStepI_Basic(t *testing.T) {
 
 	// Check the step
 	result := step.Check(sandbox)
-	if result != tx.TesSUCCESS {
-		t.Errorf("expected tx.TesSUCCESS, got %d", result)
+	if result != ter.TesSUCCESS {
+		t.Errorf("expected ter.TesSUCCESS, got %d", result)
 	}
 }
 
@@ -648,7 +650,7 @@ func TestToStrands_WithPaths(t *testing.T) {
 
 	strands, result := ToStrands(sandbox, alice, bob, dstAmt, nil, paths, true, false, false)
 
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		t.Fatalf("unexpected result: %v", result)
 	}
 
@@ -718,8 +720,8 @@ func TestFlow_SingleStrand(t *testing.T) {
 
 	result := Flow(sandbox, strands, requestedOut, false, nil, nil, nil, false)
 
-	if result.Result != tx.TesSUCCESS {
-		t.Errorf("expected tx.TesSUCCESS, got %d", result.Result)
+	if result.Result != ter.TesSUCCESS {
+		t.Errorf("expected ter.TesSUCCESS, got %d", result.Result)
 	}
 	if result.Out.XRP != 10_000_000 {
 		t.Errorf("expected output=10M, got %d", result.Out.XRP)
@@ -768,7 +770,7 @@ func TestFlow_PartialPayment(t *testing.T) {
 
 	// With partial payment, any delivery (even partial) is success
 	// We just check that something was delivered
-	if result2.Out.XRP == 0 && result2.Result != tx.TecPATH_DRY {
+	if result2.Out.XRP == 0 && result2.Result != ter.TecPATH_DRY {
 		t.Errorf("expected some delivery with partial payment, got out=%d, result=%d", result2.Out.XRP, result2.Result)
 	}
 }
@@ -781,8 +783,8 @@ func TestFlow_EmptyStrands(t *testing.T) {
 
 	result := Flow(sandbox, []Strand{}, requestedOut, false, nil, nil, nil, false)
 
-	if result.Result != tx.TecPATH_DRY {
-		t.Errorf("expected tx.TecPATH_DRY for empty strands, got %d", result.Result)
+	if result.Result != ter.TecPATH_DRY {
+		t.Errorf("expected ter.TecPATH_DRY for empty strands, got %d", result.Result)
 	}
 }
 
@@ -844,12 +846,12 @@ func TestRippleCalculate_XRPPayment(t *testing.T) {
 		ledgerSeq, // Ledger sequence
 	)
 
-	if rc.Result != tx.TesSUCCESS && rc.Result != tx.TecPATH_DRY {
-		t.Errorf("expected tx.TesSUCCESS or tx.TecPATH_DRY, got %d", rc.Result)
+	if rc.Result != ter.TesSUCCESS && rc.Result != ter.TecPATH_DRY {
+		t.Errorf("expected ter.TesSUCCESS or ter.TecPATH_DRY, got %d", rc.Result)
 	}
 
 	// If successful, verify amounts
-	if rc.Result == tx.TesSUCCESS {
+	if rc.Result == ter.TesSUCCESS {
 		if rc.ActualOut.XRP != 10_000_000 {
 			t.Errorf("expected output=10M, got %d", rc.ActualOut.XRP)
 		}

--- a/internal/tx/payment/pathfinder/path_request.go
+++ b/internal/tx/payment/pathfinder/path_request.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -205,7 +206,7 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 
 		// If insufficient and we have a full-liquidity path, try adding it
 		if !pr.convertAll && len(fullLiquidityPath) > 0 &&
-			(calcResult != tx.TesSUCCESS || validateRC.ActualOut.Compare(payment.ToEitherAmount(effectiveDstAmount)) < 0) {
+			(calcResult != ter.TesSUCCESS || validateRC.ActualOut.Compare(payment.ToEitherAmount(effectiveDstAmount)) < 0) {
 			bestPaths = append(bestPaths, fullLiquidityPath)
 			calcResult = payment.RippleCalculate(
 				ledger,
@@ -220,7 +221,7 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 			).Result
 		}
 
-		if calcResult == tx.TesSUCCESS {
+		if calcResult == ter.TesSUCCESS {
 			// Re-run to get actual source and delivered amounts
 			finalRC := payment.RippleCalculate(
 				ledger,

--- a/internal/tx/payment/pathfinder/ranking.go
+++ b/internal/tx/payment/pathfinder/ranking.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // ComputePathRanks evaluates all discovered paths and ranks them by quality,
@@ -38,7 +39,7 @@ func (pf *Pathfinder) ComputePathRanks(maxPaths int) {
 
 	// Calculate remaining amount needed after default path
 	pf.remainingAmount = payment.ToEitherAmount(convertedAmount)
-	if defaultRC.Result == tx.TesSUCCESS {
+	if defaultRC.Result == ter.TesSUCCESS {
 		pf.remainingAmount = pf.remainingAmount.Sub(defaultRC.ActualOut)
 		if pf.remainingAmount.IsNegative() || pf.remainingAmount.IsZero() {
 			// Default path handles everything — no need for explicit paths
@@ -137,7 +138,7 @@ func (pf *Pathfinder) getPathLiquidity(path []payment.PathStep, minAmount tx.Amo
 		[32]byte{}, 0,
 	)
 
-	if rc.Result != tx.TesSUCCESS {
+	if rc.Result != ter.TesSUCCESS {
 		return payment.EitherAmount{}, 0, false
 	}
 
@@ -162,7 +163,7 @@ func (pf *Pathfinder) getPathLiquidity(path []payment.PathStep, minAmount tx.Amo
 				false,
 				[32]byte{}, 0,
 			)
-			if extraRC.Result == tx.TesSUCCESS {
+			if extraRC.Result == ter.TesSUCCESS {
 				totalLiquidity = totalLiquidity.Add(extraRC.ActualOut)
 			}
 		}

--- a/internal/tx/payment/payment.go
+++ b/internal/tx/payment/payment.go
@@ -6,6 +6,7 @@ import (
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
 	"github.com/LeJamon/go-xrpl/internal/tx/permissioneddomain"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // Payment transaction moves value from one account to another.
@@ -122,11 +123,11 @@ func (p *Payment) Validate() error {
 	}
 
 	if p.Destination == "" {
-		return tx.Errorf(tx.TemDST_NEEDED, "Destination is required")
+		return ter.Errorf(ter.TemDST_NEEDED, "Destination is required")
 	}
 
 	if p.Amount.IsZero() {
-		return tx.Errorf(tx.TemBAD_AMOUNT, "Amount is required")
+		return ter.Errorf(ter.TemBAD_AMOUNT, "Amount is required")
 	}
 
 	// Determine if this is an MPT direct payment
@@ -147,7 +148,7 @@ func (p *Payment) Validate() error {
 		// Only tfPartialPayment is allowed for MPT payments (beyond universal flags)
 		mptPaymentMask := ^(tx.TfUniversal | PaymentFlagPartialPayment)
 		if flags&mptPaymentMask != 0 {
-			return tx.Errorf(tx.TemINVALID_FLAG, "Invalid flags for MPT payment")
+			return ter.Errorf(ter.TemINVALID_FLAG, "Invalid flags for MPT payment")
 		}
 	}
 
@@ -159,7 +160,7 @@ func (p *Payment) Validate() error {
 	// MPT payments cannot have paths (sfPaths)
 	// Reference: rippled Payment.cpp:101-102
 	if mptDirect && hasPaths {
-		return tx.Errorf(tx.TemMALFORMED, "Paths not allowed for MPT payment")
+		return ter.Errorf(ter.TemMALFORMED, "Paths not allowed for MPT payment")
 	}
 
 	// MPT issue consistency check.
@@ -176,20 +177,20 @@ func (p *Payment) Validate() error {
 		// Wire-format MPT: SendMax must be same MPT or absent
 		if p.SendMax != nil && (!p.SendMax.IsMPT() ||
 			p.SendMax.MPTIssuanceID() != p.Amount.MPTIssuanceID()) {
-			return tx.Errorf(tx.TemMALFORMED, "Inconsistent MPT issues in Amount and SendMax")
+			return ter.Errorf(ter.TemMALFORMED, "Inconsistent MPT issues in Amount and SendMax")
 		}
 	} else if !mptDirect && srcAmount.IsMPT() {
 		// Non-MPT payment cannot have MPT SendMax
-		return tx.Errorf(tx.TemMALFORMED, "MPT SendMax not allowed for non-MPT payment")
+		return ter.Errorf(ter.TemMALFORMED, "MPT SendMax not allowed for non-MPT payment")
 	}
 
 	// Amount and SendMax must be positive (> 0)
 	// Reference: rippled Payment.cpp:142-153
 	if p.SendMax != nil && (p.SendMax.IsZero() || p.SendMax.IsNegative()) {
-		return tx.Errorf(tx.TemBAD_AMOUNT, "SendMax must be positive")
+		return ter.Errorf(ter.TemBAD_AMOUNT, "SendMax must be positive")
 	}
 	if p.Amount.IsNegative() {
-		return tx.Errorf(tx.TemBAD_AMOUNT, "Amount must be positive")
+		return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
 	}
 
 	// Reject "XRP" used as a non-native (IOU) currency code on either the
@@ -197,7 +198,7 @@ func (p *Payment) Validate() error {
 	// Reference: rippled Payment.cpp:154-158 — badCurrency() == srcAsset || dstAsset.
 	if (!srcAmount.IsNative() && !srcAmount.IsMPT() && srcAmount.Currency == tx.BadCurrency) ||
 		(!p.Amount.IsNative() && !p.Amount.IsMPT() && p.Amount.Currency == tx.BadCurrency) {
-		return tx.Errorf(tx.TemBAD_CURRENCY, "cannot use XRP as non-native currency code")
+		return ter.Errorf(ter.TemBAD_CURRENCY, "cannot use XRP as non-native currency code")
 	}
 
 	// Cannot send to self with same source/destination asset (temREDUNDANT)
@@ -213,43 +214,43 @@ func (p *Payment) Validate() error {
 		equalTokens = true // MPT direct: src and dst are same issuance
 	}
 	if p.Account == p.Destination && equalTokens && !hasPaths {
-		return tx.Errorf(tx.TemREDUNDANT, "cannot send to self without path")
+		return ter.Errorf(ter.TemREDUNDANT, "cannot send to self without path")
 	}
 
 	// XRP to XRP with SendMax is invalid (temBAD_SEND_XRP_MAX)
 	// Reference: rippled Payment.cpp:168-174
 	if xrpDirect && p.SendMax != nil {
-		return tx.Errorf(tx.TemBAD_SEND_XRP_MAX, "SendMax specified for XRP to XRP")
+		return ter.Errorf(ter.TemBAD_SEND_XRP_MAX, "SendMax specified for XRP to XRP")
 	}
 
 	// XRP/MPT with paths is invalid (temBAD_SEND_XRP_PATHS)
 	// Reference: rippled Payment.cpp:175-181
 	if (xrpDirect || mptDirect) && hasPaths {
-		return tx.Errorf(tx.TemBAD_SEND_XRP_PATHS, "Paths specified for XRP to XRP or MPT to MPT")
+		return ter.Errorf(ter.TemBAD_SEND_XRP_PATHS, "Paths specified for XRP to XRP or MPT to MPT")
 	}
 
 	// tfPartialPayment flag is invalid for XRP-to-XRP payments (temBAD_SEND_XRP_PARTIAL)
 	// Reference: rippled Payment.cpp:182-188
 	if xrpDirect && partialPaymentAllowed {
-		return tx.Errorf(tx.TemBAD_SEND_XRP_PARTIAL, "Partial payment specified for XRP to XRP")
+		return ter.Errorf(ter.TemBAD_SEND_XRP_PARTIAL, "Partial payment specified for XRP to XRP")
 	}
 
 	// tfLimitQuality flag is invalid for XRP/MPT direct payments (temBAD_SEND_XRP_LIMIT)
 	// Reference: rippled Payment.cpp:189-196
 	if (xrpDirect || mptDirect) && limitQuality {
-		return tx.Errorf(tx.TemBAD_SEND_XRP_LIMIT, "Limit quality specified for XRP to XRP or MPT to MPT")
+		return ter.Errorf(ter.TemBAD_SEND_XRP_LIMIT, "Limit quality specified for XRP to XRP or MPT to MPT")
 	}
 
 	// tfNoRippleDirect flag is invalid for XRP/MPT direct payments (temBAD_SEND_XRP_NO_DIRECT)
 	// Reference: rippled Payment.cpp:197-204
 	if (xrpDirect || mptDirect) && noRippleDirect {
-		return tx.Errorf(tx.TemBAD_SEND_XRP_NO_DIRECT, "No ripple direct specified for XRP to XRP or MPT to MPT")
+		return ter.Errorf(ter.TemBAD_SEND_XRP_NO_DIRECT, "No ripple direct specified for XRP to XRP or MPT to MPT")
 	}
 
 	// DeliverMin can only be used with tfPartialPayment flag (temBAD_AMOUNT)
 	// Reference: rippled Payment.cpp:206-214
 	if p.DeliverMin != nil && !partialPaymentAllowed {
-		return tx.Errorf(tx.TemBAD_AMOUNT, "DeliverMin requires tfPartialPayment flag")
+		return ter.Errorf(ter.TemBAD_AMOUNT, "DeliverMin requires tfPartialPayment flag")
 	}
 
 	// Validate DeliverMin if present
@@ -257,18 +258,18 @@ func (p *Payment) Validate() error {
 	if p.DeliverMin != nil {
 		// DeliverMin must be positive (not zero, not negative)
 		if p.DeliverMin.IsZero() || p.DeliverMin.IsNegative() {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "DeliverMin must be positive")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "DeliverMin must be positive")
 		}
 
 		// DeliverMin currency must match Amount currency
 		if p.DeliverMin.Currency != p.Amount.Currency || p.DeliverMin.Issuer != p.Amount.Issuer {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "DeliverMin currency must match Amount")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "DeliverMin currency must match Amount")
 		}
 
 		// DeliverMin cannot exceed Amount
 		// Reference: rippled Payment.cpp:232-238
 		if p.DeliverMin.Compare(p.Amount) > 0 {
-			return tx.Errorf(tx.TemBAD_AMOUNT, "DeliverMin cannot exceed Amount")
+			return ter.Errorf(ter.TemBAD_AMOUNT, "DeliverMin cannot exceed Amount")
 		}
 	}
 
@@ -317,25 +318,25 @@ func (p *Payment) validatePathElements() error {
 			// Path element with type zero is invalid
 			// Reference: rippled PaySteps.cpp:161 - if ((t & ~STPathElement::typeAll) || !t)
 			if elemType == 0 {
-				return tx.Errorf(tx.TemBAD_PATH, "Path element has no account, currency, or issuer")
+				return ter.Errorf(ter.TemBAD_PATH, "Path element has no account, currency, or issuer")
 			}
 
 			// Account element cannot also have currency or issuer
 			// Reference: rippled PaySteps.cpp:168-169
 			if hasAccount && (hasCurrency || hasIssuer) {
-				return tx.Errorf(tx.TemBAD_PATH, "Path element has account with currency or issuer")
+				return ter.Errorf(ter.TemBAD_PATH, "Path element has account with currency or issuer")
 			}
 
 			// XRP issuer is invalid (issuer must not be XRP pseudo-account)
 			// Reference: rippled PaySteps.cpp:171-172
 			if hasIssuer && (elem.Issuer == "rrrrrrrrrrrrrrrrrrrrrhoLvTp" || elem.Issuer == "" && hasCurrency && elem.Currency == "XRP") {
-				return tx.Errorf(tx.TemBAD_PATH, "Path element has XRP issuer")
+				return ter.Errorf(ter.TemBAD_PATH, "Path element has XRP issuer")
 			}
 
 			// XRP account in path is invalid (account must not be XRP pseudo-account)
 			// Reference: rippled PaySteps.cpp:174-175
 			if hasAccount && elem.Account == "rrrrrrrrrrrrrrrrrrrrrhoLvTp" {
-				return tx.Errorf(tx.TemBAD_PATH, "Path element has XRP account")
+				return ter.Errorf(ter.TemBAD_PATH, "Path element has XRP account")
 			}
 
 			// XRP currency with non-XRP issuer or vice versa is invalid
@@ -344,7 +345,7 @@ func (p *Payment) validatePathElements() error {
 				isXRPCurrency := elem.Currency == "XRP" || elem.Currency == ""
 				isXRPIssuer := elem.Issuer == "rrrrrrrrrrrrrrrrrrrrrhoLvTp" || elem.Issuer == ""
 				if isXRPCurrency != isXRPIssuer {
-					return tx.Errorf(tx.TemBAD_PATH, "XRP currency mismatch with issuer")
+					return ter.Errorf(ter.TemBAD_PATH, "XRP currency mismatch with issuer")
 				}
 			}
 		}
@@ -361,7 +362,7 @@ func (p *Payment) validatePathElements() error {
 // precedence: a payment that fails both credential and domain checks reports the
 // credential code.
 // Reference: rippled Payment.cpp:282-378
-func (p *Payment) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Result {
+func (p *Payment) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Result {
 	// Destination-existence branching for non-MPT payments. MPT direct
 	// payments resolve the destination inside Apply.
 	// Reference: rippled Payment.cpp:296-346
@@ -371,19 +372,19 @@ func (p *Payment) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Result
 			if !destExists {
 				// A non-native delivered amount cannot create the account.
 				if !p.Amount.IsNative() {
-					return tx.TecNO_DST
+					return ter.TecNO_DST
 				}
 				// A partial payment may not fund a new account on an open ledger.
 				if config.OpenLedger && (p.GetFlags()&PaymentFlagPartialPayment) != 0 {
-					return tx.TelNO_DST_PARTIAL
+					return ter.TelNO_DST_PARTIAL
 				}
 				// The delivered amount must cover the account reserve.
 				if uint64(p.Amount.Drops()) < config.ReserveBase {
-					return tx.TecNO_DST_INSUF_XRP
+					return ter.TecNO_DST_INSUF_XRP
 				}
 			} else if (destAccount.Flags&state.LsfRequireDestTag) != 0 && p.DestinationTag == nil {
 				// A newly-formed account is exempt — it has no way to set the flag.
-				return tx.TecDST_TAG_NEEDED
+				return ter.TecDST_TAG_NEEDED
 			}
 		}
 	}
@@ -395,11 +396,11 @@ func (p *Payment) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Result
 		ripple := len(p.Paths) > 0 || p.SendMax != nil || !p.Amount.IsNative()
 		if ripple {
 			if len(p.Paths) > MaxPathSize {
-				return tx.TelBAD_PATH_COUNT
+				return ter.TelBAD_PATH_COUNT
 			}
 			for _, path := range p.Paths {
 				if len(path) > MaxPathLength {
-					return tx.TelBAD_PATH_COUNT
+					return ter.TelBAD_PATH_COUNT
 				}
 			}
 		}
@@ -411,14 +412,14 @@ func (p *Payment) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Result
 	if len(p.CredentialIDs) > 0 || p.DomainID != nil {
 		senderID, err := state.DecodeAccountID(p.Account)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Credential validation precedes the domain check: each credential must
 		// exist, have the sender as its Subject, and be accepted. Expiry is not
 		// checked here (deferred to Apply).
 		// Reference: rippled Payment.cpp:362-365 / credentials::valid()
-		if result := credential.ValidCredentials(view, senderID, p.CredentialIDs); result != tx.TesSUCCESS {
+		if result := credential.ValidCredentials(view, senderID, p.CredentialIDs); result != ter.TesSUCCESS {
 			return result
 		}
 
@@ -428,23 +429,23 @@ func (p *Payment) Preclaim(view tx.LedgerView, config tx.EngineConfig) tx.Result
 		if p.DomainID != nil {
 			domainID, err := permissioneddomain.ParseDomainID(*p.DomainID)
 			if err != nil {
-				return tx.TemMALFORMED
+				return ter.TemMALFORMED
 			}
 			closeTime := config.ParentCloseTime
 			if !permissioneddomain.AccountInDomain(view, senderID, domainID, closeTime) {
-				return tx.TecNO_PERMISSION
+				return ter.TecNO_PERMISSION
 			}
 			destID, err := state.DecodeAccountID(p.Destination)
 			if err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			if !permissioneddomain.AccountInDomain(view, destID, domainID, closeTime) {
-				return tx.TecNO_PERMISSION
+				return ter.TecNO_PERMISSION
 			}
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 func (p *Payment) Flatten() (map[string]any, error) {
@@ -491,7 +492,7 @@ func (p *Payment) SetNoDirectRipple() {
 	p.SetFlags(flags)
 }
 
-func (p *Payment) Apply(ctx *tx.ApplyContext) tx.Result {
+func (p *Payment) Apply(ctx *tx.ApplyContext) ter.Result {
 	mptDirect := p.isMPTDirect()
 
 	ctx.Log.Trace("payment apply",

--- a/internal/tx/payment/payment_iou.go
+++ b/internal/tx/payment/payment_iou.go
@@ -6,6 +6,7 @@ import (
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
 	"github.com/LeJamon/go-xrpl/internal/tx/permissioneddomain"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -13,7 +14,7 @@ import (
 // cross-currency (ripple) payments: deposit-authorization / deposit-preauth.
 // The destination-tag and credential-validity checks run earlier, in Preclaim.
 // Reference: rippled Payment.cpp:429-465 (ripple == true).
-func (p *Payment) checkIOUDestPreamble(ctx *tx.ApplyContext, senderID, destID [20]byte, destAccount *state.AccountRoot) tx.Result {
+func (p *Payment) checkIOUDestPreamble(ctx *tx.ApplyContext, senderID, destID [20]byte, destAccount *state.AccountRoot) ter.Result {
 	depositAuth := ctx.Rules().Enabled(amendment.FeatureDepositAuth)
 	depositPreauth := ctx.Rules().Enabled(amendment.FeatureDepositPreauth)
 	reqDepositAuth := (destAccount.Flags&state.LsfDepositAuth) != 0 && depositAuth
@@ -23,42 +24,42 @@ func (p *Payment) checkIOUDestPreamble(ctx *tx.ApplyContext, senderID, destID [2
 	// the DepositPreauth amendment fixed.
 	// Reference: rippled Payment.cpp:440-441
 	if !depositPreauth && reqDepositAuth {
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// With DepositPreauth amendment: self-payments and preauthorized accounts
 	// are allowed. The check runs regardless of the destination's flags so
 	// that expired credentials are removed (tecEXPIRED).
 	if depositPreauth && depositAuth {
-		if result := credential.VerifyDepositPreauth(ctx, p.CredentialIDs, senderID, destID, destAccount); result != tx.TesSUCCESS {
+		if result := credential.VerifyDepositPreauth(ctx, p.CredentialIDs, senderID, destID, destAccount); result != ter.TesSUCCESS {
 			return result
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // applyIOUPayment applies an IOU (issued currency) or cross-currency payment.
 // This is called for any payment with paths, SendMax, or non-native Amount.
 // Reference: rippled/src/xrpld/app/tx/detail/Payment.cpp
-func (p *Payment) applyIOUPayment(ctx *tx.ApplyContext) tx.Result {
+func (p *Payment) applyIOUPayment(ctx *tx.ApplyContext) ter.Result {
 	// Validate the amount
 	if p.Amount.IsZero() {
-		return tx.TemBAD_AMOUNT
+		return ter.TemBAD_AMOUNT
 	}
 	if p.Amount.IsNegative() {
-		return tx.TemBAD_AMOUNT
+		return ter.TemBAD_AMOUNT
 	}
 
 	// Get account IDs
 	senderAccountID, err := state.DecodeAccountID(ctx.Account.Account)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	destAccountID, err := state.DecodeAccountID(p.Destination)
 	if err != nil {
-		return tx.TemDST_NEEDED
+		return ter.TemDST_NEEDED
 	}
 
 	// For cross-currency payments where Amount is XRP, we always need the flow engine
@@ -71,30 +72,30 @@ func (p *Payment) applyIOUPayment(ctx *tx.ApplyContext) tx.Result {
 
 	issuerAccountID, err := state.DecodeAccountID(p.Amount.Issuer)
 	if err != nil {
-		return tx.TemBAD_ISSUER
+		return ter.TemBAD_ISSUER
 	}
 
 	// Check destination exists (needed for DepositAuth check and destination flags)
 	destKey := keylet.Account(destAccountID)
 	destExists, err := ctx.View.Exists(destKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if !destExists {
-		return tx.TecNO_DST
+		return ter.TecNO_DST
 	}
 
 	// Get destination account to check flags
 	destData, err := ctx.View.Read(destKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	destAccount, err := state.ParseAccountRoot(destData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	if result := p.checkIOUDestPreamble(ctx, senderAccountID, destAccountID, destAccount); result != tx.TesSUCCESS {
+	if result := p.checkIOUDestPreamble(ctx, senderAccountID, destAccountID, destAccount); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -104,7 +105,7 @@ func (p *Payment) applyIOUPayment(ctx *tx.ApplyContext) tx.Result {
 // applyRipplePayment handles cross-currency payments where Amount is XRP but
 // the payment goes through the order book (has SendMax or paths).
 // Reference: rippled Payment.cpp doApply() when ripple=true
-func (p *Payment) applyRipplePayment(ctx *tx.ApplyContext, senderID, destID [20]byte) tx.Result {
+func (p *Payment) applyRipplePayment(ctx *tx.ApplyContext, senderID, destID [20]byte) ter.Result {
 	// This path only handles a native (XRP) delivered amount, so a missing
 	// destination can be funded by the payment. The normal engine flow gates
 	// these cases in Payment.Preclaim; this branch is also the authoritative
@@ -113,7 +114,7 @@ func (p *Payment) applyRipplePayment(ctx *tx.ApplyContext, senderID, destID [20]
 	destKey := keylet.Account(destID)
 	destExists, err := ctx.View.Exists(destKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if !destExists {
@@ -126,14 +127,14 @@ func (p *Payment) applyRipplePayment(ctx *tx.ApplyContext, senderID, destID [20]
 		// You cannot fund an account with a partial payment on an open ledger.
 		// Reference: rippled Payment.cpp:308-318
 		if ctx.Config.OpenLedger && partialPayment {
-			return tx.TelNO_DST_PARTIAL
+			return ter.TelNO_DST_PARTIAL
 		}
 
 		// Insufficient payment to meet the account reserve (accountReserve(0)).
 		// Reference: rippled Payment.cpp:319-331
 		amountDrops := uint64(p.Amount.Drops())
 		if amountDrops < ctx.AccountReserve(0) {
-			return tx.TecNO_DST_INSUF_XRP
+			return ter.TecNO_DST_INSUF_XRP
 		}
 
 		// Create the destination account before running the flow engine, which
@@ -156,10 +157,10 @@ func (p *Payment) applyRipplePayment(ctx *tx.ApplyContext, senderID, destID [20]
 		}
 		newAccountData, serErr := state.SerializeAccountRoot(newAccount)
 		if serErr != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if insErr := ctx.View.Insert(destKey, newAccountData); insErr != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// A freshly created account carries no flags, so destination-tag and
@@ -170,14 +171,14 @@ func (p *Payment) applyRipplePayment(ctx *tx.ApplyContext, senderID, destID [20]
 
 	destData, err := ctx.View.Read(destKey)
 	if err != nil || destData == nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	destAccount, err := state.ParseAccountRoot(destData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	if result := p.checkIOUDestPreamble(ctx, senderID, destID, destAccount); result != tx.TesSUCCESS {
+	if result := p.checkIOUDestPreamble(ctx, senderID, destID, destAccount); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -189,7 +190,7 @@ func (p *Payment) applyRipplePayment(ctx *tx.ApplyContext, senderID, destID [20]
 // applyIOUPaymentWithPaths handles IOU payments that require path finding using the Flow Engine.
 // This is the main entry point for cross-currency payments and payments with explicit paths.
 // Reference: rippled/src/xrpld/app/paths/RippleCalc.cpp
-func (p *Payment) applyIOUPaymentWithPaths(ctx *tx.ApplyContext, senderID, destID, issuerID [20]byte) tx.Result {
+func (p *Payment) applyIOUPaymentWithPaths(ctx *tx.ApplyContext, senderID, destID, issuerID [20]byte) ter.Result {
 	// Determine payment flags
 	flags := p.GetFlags()
 	partialPayment := (flags & PaymentFlagPartialPayment) != 0
@@ -243,18 +244,18 @@ func (p *Payment) applyIOUPaymentWithPaths(ctx *tx.ApplyContext, senderID, destI
 	// Because of its overhead, if RippleCalc fails with a retry code (ter*),
 	// claim a fee instead. Reference: rippled Payment.cpp:509-510
 	if result.IsTer() {
-		result = tx.TecPATH_DRY
+		result = ter.TecPATH_DRY
 	}
 
 	// Handle result
-	if result != tx.TesSUCCESS && result != tx.TecPATH_PARTIAL {
+	if result != ter.TesSUCCESS && result != ter.TecPATH_PARTIAL {
 		return result
 	}
 
 	// Apply sandbox changes back to the ledger view (through ApplyStateTable for tracking)
 	if sandbox != nil {
 		if err := sandbox.ApplyToView(ctx.View); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
@@ -274,7 +275,7 @@ func (p *Payment) applyIOUPaymentWithPaths(ctx *tx.ApplyContext, senderID, destI
 	if partialPayment && p.DeliverMin != nil {
 		deliverMin := ToEitherAmount(*p.DeliverMin)
 		if actualOut.Compare(deliverMin) < 0 {
-			return tx.TecPATH_PARTIAL
+			return ter.TecPATH_PARTIAL
 		}
 	}
 

--- a/internal/tx/payment/payment_mpt.go
+++ b/internal/tx/payment/payment_mpt.go
@@ -7,13 +7,14 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
 
 // applyMPTPayment applies an MPT direct payment.
 // Reference: rippled Payment.cpp doApply() mptDirect path + View.cpp rippleSendMPT/rippleCreditMPT
-func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) tx.Result {
+func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) ter.Result {
 	// Get the MPT issuance ID: prefer the legacy field, fall back to Amount's embedded ID
 	mptIDHex := p.MPTokenIssuanceID
 	if mptIDHex == "" {
@@ -23,7 +24,7 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) tx.Result {
 	// Parse MPTokenIssuanceID
 	issuanceIDBytes, err := hex.DecodeString(mptIDHex)
 	if err != nil || len(issuanceIDBytes) != 24 {
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 	var mptID [24]byte
 	copy(mptID[:], issuanceIDBytes)
@@ -32,11 +33,11 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) tx.Result {
 	issuanceKey := keylet.MPTIssuance(mptID)
 	issuanceRaw, err := ctx.View.Read(issuanceKey)
 	if err != nil || issuanceRaw == nil {
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 	issuance, err := state.ParseMPTokenIssuance(issuanceRaw)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	issuerID := issuance.Issuer
@@ -44,34 +45,34 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) tx.Result {
 	// Decode destination
 	destAccountID, err := state.DecodeAccountID(p.Destination)
 	if err != nil {
-		return tx.TemDST_NEEDED
+		return ter.TemDST_NEEDED
 	}
 
 	// Check destination exists
 	destKey := keylet.Account(destAccountID)
 	destData, err := ctx.View.Read(destKey)
 	if err != nil || destData == nil {
-		return tx.TecNO_DST
+		return ter.TecNO_DST
 	}
 	destAccount, err := state.ParseAccountRoot(destData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Check destination tag requirement
 	if (destAccount.Flags&state.LsfRequireDestTag) != 0 && p.DestinationTag == nil {
-		return tx.TecDST_TAG_NEEDED
+		return ter.TecDST_TAG_NEEDED
 	}
 
 	// requireAuth: check sender is authorized
 	// Reference: rippled View.cpp requireAuth() for MPTIssue + Payment.cpp:518-520
-	if res := requireMPTAuth(ctx, issuance, issuanceKey, ctx.AccountID, issuerID); res != tx.TesSUCCESS {
+	if res := requireMPTAuth(ctx, issuance, issuanceKey, ctx.AccountID, issuerID); res != ter.TesSUCCESS {
 		return res
 	}
 
 	// requireAuth: check destination is authorized
 	// Reference: rippled View.cpp requireAuth() for MPTIssue + Payment.cpp:522-524
-	if res := requireMPTAuth(ctx, issuance, issuanceKey, destAccountID, issuerID); res != tx.TesSUCCESS {
+	if res := requireMPTAuth(ctx, issuance, issuanceKey, destAccountID, issuerID); res != ter.TesSUCCESS {
 		return res
 	}
 
@@ -83,20 +84,20 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled Payment.cpp:526-529
 	if !senderIsIssuer && !destIsIssuer {
 		if issuance.Flags&entry.LsfMPTCanTransfer == 0 {
-			return tx.TecNO_AUTH
+			return ter.TecNO_AUTH
 		}
 	}
 
 	// Verify deposit preauth
 	// Reference: rippled Payment.cpp:531-539
-	if result := credential.VerifyDepositPreauth(ctx, p.CredentialIDs, ctx.AccountID, destAccountID, destAccount); result != tx.TesSUCCESS {
+	if result := credential.VerifyDepositPreauth(ctx, p.CredentialIDs, ctx.AccountID, destAccountID, destAccount); result != ter.TesSUCCESS {
 		return result
 	}
 
 	// Extract the payment amount as uint64
 	dstAmount := mptAmountToUint64(p.Amount)
 	if dstAmount == 0 {
-		return tx.TemBAD_AMOUNT
+		return ter.TemBAD_AMOUNT
 	}
 
 	// Compute transfer rate for holder-to-holder transfers
@@ -106,7 +107,7 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) tx.Result {
 	if !senderIsIssuer && !destIsIssuer {
 		// Check frozen (globally or individually locked)
 		if issuance.Flags&entry.LsfMPTLocked != 0 {
-			return tx.TecLOCKED
+			return ter.TecLOCKED
 		}
 		// Check individual locks on sender and destination
 		senderTokenKey := keylet.MPToken(issuanceKey.Key, ctx.AccountID)
@@ -114,7 +115,7 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) tx.Result {
 		if senderTokenRaw != nil {
 			senderToken, _ := state.ParseMPToken(senderTokenRaw)
 			if senderToken != nil && senderToken.Flags&entry.LsfMPTLocked != 0 {
-				return tx.TecLOCKED
+				return ter.TecLOCKED
 			}
 		}
 		destTokenKey := keylet.MPToken(issuanceKey.Key, destAccountID)
@@ -122,7 +123,7 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) tx.Result {
 		if destTokenRaw != nil {
 			destToken, _ := state.ParseMPToken(destTokenRaw)
 			if destToken != nil && destToken.Flags&entry.LsfMPTLocked != 0 {
-				return tx.TecLOCKED
+				return ter.TecLOCKED
 			}
 		}
 
@@ -153,20 +154,20 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) tx.Result {
 
 	// Check: source insufficient
 	if requiredMaxSourceAmount > maxSourceAmount {
-		return tx.TecPATH_PARTIAL
+		return ter.TecPATH_PARTIAL
 	}
 
 	// Check: DeliverMin not met
 	if p.DeliverMin != nil {
 		deliverMin := mptAmountToUint64(*p.DeliverMin)
 		if deliverMin > 0 && amountDeliver < deliverMin {
-			return tx.TecPATH_PARTIAL
+			return ter.TecPATH_PARTIAL
 		}
 	}
 
 	// Execute the actual transfer
 	// Reference: rippled Payment.cpp:582-595
-	var res tx.Result
+	var res ter.Result
 	if senderIsIssuer || destIsIssuer {
 		// Direct transfer (issuer involved, no transfer fee)
 		res = p.mptDirectTransfer(ctx, issuance, issuanceKey, amountDeliver, senderIsIssuer, destIsIssuer, destAccountID)
@@ -176,8 +177,8 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) tx.Result {
 	}
 
 	// Map error codes per rippled Payment.cpp:593-594
-	if res == tx.TecINSUFFICIENT_FUNDS || res == tx.TecPATH_DRY {
-		res = tx.TecPATH_PARTIAL
+	if res == ter.TecINSUFFICIENT_FUNDS || res == ter.TecPATH_DRY {
+		res = ter.TecPATH_PARTIAL
 	}
 
 	return res
@@ -186,7 +187,7 @@ func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) tx.Result {
 // mptDirectTransfer handles MPT payment where one party is the issuer.
 // No transfer fee applies. Handles MaximumAmount enforcement.
 func (p *Payment) mptDirectTransfer(ctx *tx.ApplyContext, issuance *state.MPTokenIssuanceData,
-	issuanceKey keylet.Keylet, amount uint64, senderIsIssuer, destIsIssuer bool, destAccountID [20]byte) tx.Result {
+	issuanceKey keylet.Keylet, amount uint64, senderIsIssuer, destIsIssuer bool, destAccountID [20]byte) ter.Result {
 	// If sender is issuer: check MaximumAmount
 	// Reference: rippled View.cpp rippleSendMPT() lines 2044-2055
 	if senderIsIssuer {
@@ -195,7 +196,7 @@ func (p *Payment) mptDirectTransfer(ctx *tx.ApplyContext, issuance *state.MPToke
 			maxAmount = *issuance.MaximumAmount
 		}
 		if amount > maxAmount || issuance.OutstandingAmount > maxAmount-amount {
-			return tx.TecPATH_DRY
+			return ter.TecPATH_DRY
 		}
 	}
 
@@ -206,68 +207,68 @@ func (p *Payment) mptDirectTransfer(ctx *tx.ApplyContext, issuance *state.MPToke
 		senderTokenKey := keylet.MPToken(issuanceKey.Key, ctx.AccountID)
 		senderTokenRaw, err := ctx.View.Read(senderTokenKey)
 		if err != nil || senderTokenRaw == nil {
-			return tx.TecNO_AUTH
+			return ter.TecNO_AUTH
 		}
 		senderToken, err := state.ParseMPToken(senderTokenRaw)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if senderToken.MPTAmount < amount {
-			return tx.TecINSUFFICIENT_FUNDS
+			return ter.TecINSUFFICIENT_FUNDS
 		}
 		senderToken.MPTAmount -= amount
 		updatedSenderToken, err := state.SerializeMPToken(senderToken)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := ctx.View.Update(senderTokenKey, updatedSenderToken); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
 	// rippleCreditMPT: receiver side
 	if destIsIssuer {
 		if issuance.OutstandingAmount < amount {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		issuance.OutstandingAmount -= amount
 	} else {
 		destTokenKey := keylet.MPToken(issuanceKey.Key, destAccountID)
 		destTokenRaw, err := ctx.View.Read(destTokenKey)
 		if err != nil || destTokenRaw == nil {
-			return tx.TecNO_AUTH
+			return ter.TecNO_AUTH
 		}
 		destToken, err := state.ParseMPToken(destTokenRaw)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		destToken.MPTAmount += amount
 		updatedDestToken, err := state.SerializeMPToken(destToken)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 		if err := ctx.View.Update(destTokenKey, updatedDestToken); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
 	// Update issuance
 	updatedIssuance, err := state.SerializeMPTokenIssuance(issuance)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(issuanceKey, updatedIssuance); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // mptTransitTransfer handles holder-to-holder MPT payment via transit through issuer.
 // Transfer fee is applied: sender pays amountDeliver * rate / QUALITY_ONE.
 // Reference: rippled View.cpp rippleSendMPT() lines 2068-2085
 func (p *Payment) mptTransitTransfer(ctx *tx.ApplyContext, issuance *state.MPTokenIssuanceData,
-	issuanceKey keylet.Keylet, amountDeliver, rate uint64, destAccountID [20]byte) tx.Result {
+	issuanceKey keylet.Keylet, amountDeliver, rate uint64, destAccountID [20]byte) ter.Result {
 	// Actual amount sender pays (includes transfer fee)
 	saActual := mptMultiply(amountDeliver, rate)
 
@@ -278,11 +279,11 @@ func (p *Payment) mptTransitTransfer(ctx *tx.ApplyContext, issuance *state.MPTok
 	destTokenKey := keylet.MPToken(issuanceKey.Key, destAccountID)
 	destTokenRaw, err := ctx.View.Read(destTokenKey)
 	if err != nil || destTokenRaw == nil {
-		return tx.TecNO_AUTH
+		return ter.TecNO_AUTH
 	}
 	destToken, err := state.ParseMPToken(destTokenRaw)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	destToken.MPTAmount += amountDeliver
 
@@ -291,14 +292,14 @@ func (p *Payment) mptTransitTransfer(ctx *tx.ApplyContext, issuance *state.MPTok
 	senderTokenKey := keylet.MPToken(issuanceKey.Key, ctx.AccountID)
 	senderTokenRaw, err := ctx.View.Read(senderTokenKey)
 	if err != nil || senderTokenRaw == nil {
-		return tx.TecNO_AUTH
+		return ter.TecNO_AUTH
 	}
 	senderToken, err := state.ParseMPToken(senderTokenRaw)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if senderToken.MPTAmount < saActual {
-		return tx.TecINSUFFICIENT_FUNDS
+		return ter.TecINSUFFICIENT_FUNDS
 	}
 	senderToken.MPTAmount -= saActual
 	issuance.OutstandingAmount -= saActual
@@ -308,29 +309,29 @@ func (p *Payment) mptTransitTransfer(ctx *tx.ApplyContext, issuance *state.MPTok
 	// Serialize and update all modified entries
 	updatedSenderToken, err := state.SerializeMPToken(senderToken)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(senderTokenKey, updatedSenderToken); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	updatedDestToken, err := state.SerializeMPToken(destToken)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(destTokenKey, updatedDestToken); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	updatedIssuance, err := state.SerializeMPTokenIssuance(issuance)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(issuanceKey, updatedIssuance); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 const (
@@ -418,10 +419,10 @@ func mptAmountToUint64(a tx.Amount) uint64 {
 // requireMPTAuth checks if an account is authorized for an MPToken issuance.
 // Reference: rippled View.cpp requireAuth() for MPTIssue (lines 2436-2519)
 func requireMPTAuth(ctx *tx.ApplyContext, issuance *state.MPTokenIssuanceData,
-	issuanceKey keylet.Keylet, accountID [20]byte, issuerID [20]byte) tx.Result {
+	issuanceKey keylet.Keylet, accountID [20]byte, issuerID [20]byte) ter.Result {
 	// Issuer is always authorized
 	if accountID == issuerID {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Read the MPToken for this account
@@ -444,7 +445,7 @@ func requireMPTAuth(ctx *tx.ApplyContext, issuance *state.MPTokenIssuanceData,
 				return res // No token → return domain result directly
 			}
 		}
-		return tx.TecNO_AUTH
+		return ter.TecNO_AUTH
 	}
 
 	// Check domain-based credential authorization
@@ -455,8 +456,8 @@ func requireMPTAuth(ctx *tx.ApplyContext, issuance *state.MPTokenIssuanceData,
 			var did [32]byte
 			copy(did[:], domainID)
 			res := validDomain(ctx, did, accountID)
-			if res == tx.TesSUCCESS {
-				return tx.TesSUCCESS // Authorized by credentials
+			if res == ter.TesSUCCESS {
+				return ter.TesSUCCESS // Authorized by credentials
 			}
 			if token == nil {
 				return res // No token and credentials invalid
@@ -468,24 +469,24 @@ func requireMPTAuth(ctx *tx.ApplyContext, issuance *state.MPTokenIssuanceData,
 	// Classic authorization check
 	if issuance.Flags&entry.LsfMPTRequireAuth != 0 {
 		if token == nil || token.Flags&entry.LsfMPTAuthorized == 0 {
-			return tx.TecNO_AUTH
+			return ter.TecNO_AUTH
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // validDomain checks if an account has valid credentials for a permissioned domain.
 // Reference: rippled CredentialHelpers.cpp credentials::validDomain()
-func validDomain(ctx *tx.ApplyContext, domainID [32]byte, account [20]byte) tx.Result {
+func validDomain(ctx *tx.ApplyContext, domainID [32]byte, account [20]byte) ter.Result {
 	domKey := keylet.PermissionedDomainByID(domainID)
 	domData, err := ctx.View.Read(domKey)
 	if err != nil || domData == nil {
-		return tx.TecOBJECT_NOT_FOUND
+		return ter.TecOBJECT_NOT_FOUND
 	}
 	pd, err := state.ParsePermissionedDomain(domData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	foundExpired := false
@@ -504,12 +505,12 @@ func validDomain(ctx *tx.ApplyContext, domainID [32]byte, account [20]byte) tx.R
 			continue
 		}
 		if cred.IsAccepted() {
-			return tx.TesSUCCESS
+			return ter.TesSUCCESS
 		}
 	}
 
 	if foundExpired {
-		return tx.TecEXPIRED
+		return ter.TecEXPIRED
 	}
-	return tx.TecNO_AUTH
+	return ter.TecNO_AUTH
 }

--- a/internal/tx/payment/payment_test.go
+++ b/internal/tx/payment/payment_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 func ptrUint32(v uint32) *uint32       { return &v }
@@ -1410,15 +1411,15 @@ func TestPaymentPathLimits(t *testing.T) {
 			// Preclaim on an open ledger enforces the limits.
 			openResult := payment.Preclaim(view, tx.EngineConfig{OpenLedger: true})
 			if tt.expectFail {
-				if openResult != tx.TelBAD_PATH_COUNT {
+				if openResult != ter.TelBAD_PATH_COUNT {
 					t.Errorf("open-ledger Preclaim: expected telBAD_PATH_COUNT, got %v", openResult)
 				}
-			} else if openResult != tx.TesSUCCESS {
+			} else if openResult != ter.TesSUCCESS {
 				t.Errorf("open-ledger Preclaim: expected tesSUCCESS, got %v", openResult)
 			}
 
 			// On a closed ledger the path-count check is skipped (tesSUCCESS).
-			if closedResult := payment.Preclaim(view, tx.EngineConfig{OpenLedger: false}); closedResult != tx.TesSUCCESS {
+			if closedResult := payment.Preclaim(view, tx.EngineConfig{OpenLedger: false}); closedResult != ter.TesSUCCESS {
 				t.Errorf("closed-ledger Preclaim: expected tesSUCCESS, got %v", closedResult)
 			}
 		})

--- a/internal/tx/payment/payment_xrp.go
+++ b/internal/tx/payment/payment_xrp.go
@@ -7,16 +7,17 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 // applyXRPPayment applies an XRP-to-XRP payment
 // Reference: rippled/src/xrpld/app/tx/detail/Payment.cpp doApply() for XRP direct payments
-func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) tx.Result {
+func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) ter.Result {
 	// Get the amount in drops
 	drops := p.Amount.Drops()
 	if drops <= 0 {
-		return tx.TemBAD_AMOUNT
+		return ter.TemBAD_AMOUNT
 	}
 	amountDrops := uint64(drops)
 
@@ -44,37 +45,37 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) tx.Result {
 	// Check sender has enough balance using PRE-FEE balance
 	// Reference: rippled Payment.cpp:619 - if (mPriorBalance < dstAmount.xrp() + mmm)
 	if priorBalance < amountDrops+mmm {
-		return tx.TecUNFUNDED_PAYMENT
+		return ter.TecUNFUNDED_PAYMENT
 	}
 
 	// Get destination account
 	destAccountID, err := state.DecodeAccountID(p.Destination)
 	if err != nil {
-		return tx.TemDST_NEEDED
+		return ter.TemDST_NEEDED
 	}
 	destKey := keylet.Account(destAccountID)
 
 	destExists, err := ctx.View.Exists(destKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if destExists {
 		// Destination exists - just credit the amount
 		destData, err := ctx.View.Read(destKey)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		destAccount, err := state.ParseAccountRoot(destData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Check for pseudo-account (AMM/Vault cannot receive direct payments).
 		// See rippled Payment.cpp:636-637: if (isPseudoAccount(sleDst)) return tecNO_PERMISSION.
 		if destAccount.IsPseudoAccount() {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 
 		// Check deposit authorization
@@ -86,7 +87,7 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) tx.Result {
 			dstReserve := ctx.Config.ReserveBase
 
 			if amountDrops > dstReserve || destAccount.Balance > dstReserve {
-				if result := credential.VerifyDepositPreauth(ctx, p.CredentialIDs, ctx.AccountID, destAccountID, destAccount); result != tx.TesSUCCESS {
+				if result := credential.VerifyDepositPreauth(ctx, p.CredentialIDs, ctx.AccountID, destAccountID, destAccount); result != ter.TesSUCCESS {
 					return result
 				}
 			}
@@ -111,21 +112,21 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) tx.Result {
 		// Update destination
 		updatedDestData, err := state.SerializeAccountRoot(destAccount)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Update tracked automatically by ApplyStateTable
 		if err := ctx.View.Update(destKey, updatedDestData); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Destination doesn't exist - need to create it
 	// Check minimum amount for account creation
 	if amountDrops < ctx.Config.ReserveBase {
-		return tx.TecNO_DST_INSUF_XRP
+		return ter.TecNO_DST_INSUF_XRP
 	}
 
 	// Create new account
@@ -153,13 +154,13 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) tx.Result {
 	// Serialize and insert new account
 	newAccountData, err := state.SerializeAccountRoot(newAccount)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Insert tracked automatically by ApplyStateTable
 	if err := ctx.View.Insert(destKey, newAccountData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
-	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/amm"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -790,11 +790,11 @@ func (s *BookStep) bookBaseKey() [32]byte {
 
 // Check validates the BookStep before use
 // Reference: rippled BookStep.cpp check() lines 1343-1380
-func (s *BookStep) Check(sb *PaymentSandbox) tx.Result {
+func (s *BookStep) Check(sb *PaymentSandbox) ter.Result {
 	// Check for same in/out issue - this is invalid
 	// Reference: rippled BookStep.cpp lines 1346-1351
 	if s.book.In.Currency == s.book.Out.Currency && s.book.In.Issuer == s.book.Out.Issuer {
-		return tx.TemBAD_PATH
+		return ter.TemBAD_PATH
 	}
 
 	// If previous step is a DirectStep, check NoRipple on the trust line
@@ -808,11 +808,11 @@ func (s *BookStep) Check(sb *PaymentSandbox) tx.Result {
 				sleLineKey := keylet.Line(prev, cur, s.book.In.Currency)
 				sleLineData, err := sb.Read(sleLineKey)
 				if err != nil || sleLineData == nil {
-					return tx.TerNO_LINE
+					return ter.TerNO_LINE
 				}
 				rs, parseErr := state.ParseRippleState(sleLineData)
 				if parseErr != nil {
-					return tx.TefINTERNAL
+					return ter.TefINTERNAL
 				}
 				// Check cur's NoRipple flag on the prev-cur trust line
 				curIsHigh := state.CompareAccountIDs(cur, prev) > 0
@@ -823,13 +823,13 @@ func (s *BookStep) Check(sb *PaymentSandbox) tx.Result {
 					noRippleFlag = state.LsfLowNoRipple
 				}
 				if rs.Flags&noRippleFlag != 0 {
-					return tx.TerNO_RIPPLE
+					return ter.TerNO_RIPPLE
 				}
 			}
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // LedgerReader is an interface for reading ledger entries.

--- a/internal/tx/payment/step_direct.go
+++ b/internal/tx/payment/step_direct.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -971,7 +972,7 @@ func (s *DirectStepI) DirectStepSrcAcct() *[20]byte {
 }
 
 // Check validates the DirectStepI before use
-func (s *DirectStepI) Check(sb *PaymentSandbox) tx.Result {
+func (s *DirectStepI) Check(sb *PaymentSandbox) ter.Result {
 	// Check freeze status — applies to BOTH payments and offer crossing.
 	// Skip for pure issue/redeem (single-step strand).
 	// Reference: rippled DirectStepI<TDerived>::check() lines 906-912
@@ -979,7 +980,7 @@ func (s *DirectStepI) Check(sb *PaymentSandbox) tx.Result {
 	//       checkFreeze(ctx.view, src_, dst_, currency_);
 	// This runs in the BASE class check(), before delegating to derived class.
 	if !(s.isFirst && s.isLast) {
-		if result := checkFreeze(sb, s.src, s.dst, s.currency); result != tx.TesSUCCESS {
+		if result := checkFreeze(sb, s.src, s.dst, s.currency); result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -988,22 +989,22 @@ func (s *DirectStepI) Check(sb *PaymentSandbox) tx.Result {
 	// Trust lines are created on demand during crossing via rippleCredit.
 	// Reference: rippled DirectIOfferCrossingStep::check() lines 462-470
 	if s.offerCrossing {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Check trust line exists
 	trustLineKey := keylet.Line(s.src, s.dst, s.currency)
 	data, err := sb.Read(trustLineKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if data == nil {
-		return tx.TerNO_LINE
+		return ter.TerNO_LINE
 	}
 
 	// Check authorization
 	// Reference: rippled DirectStep.cpp checkAuth()
-	if result := checkAuth(sb, s.src, s.dst, s.currency); result != tx.TesSUCCESS {
+	if result := checkAuth(sb, s.src, s.dst, s.currency); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -1015,7 +1016,7 @@ func (s *DirectStepI) Check(sb *PaymentSandbox) tx.Result {
 		if s.prevStep.BookStepBook() != nil {
 			rs, parseErr := state.ParseRippleState(data)
 			if parseErr != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			srcIsHigh := state.CompareAccountIDs(s.src, s.dst) > 0
 			var noRippleFlag uint32
@@ -1025,7 +1026,7 @@ func (s *DirectStepI) Check(sb *PaymentSandbox) tx.Result {
 				noRippleFlag = state.LsfLowNoRipple
 			}
 			if rs.Flags&noRippleFlag != 0 {
-				return tx.TerNO_RIPPLE
+				return ter.TerNO_RIPPLE
 			}
 		}
 	}
@@ -1056,13 +1057,13 @@ func (s *DirectStepI) Check(sb *PaymentSandbox) tx.Result {
 				}
 				negOwed := owed.Negate()
 				if negOwed.Compare(limit) >= 0 {
-					return tx.TecPATH_DRY
+					return ter.TecPATH_DRY
 				}
 			}
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // checkAuth checks if the trust line is properly authorized when RequireAuth is set.
@@ -1073,34 +1074,34 @@ func (s *DirectStepI) Check(sb *PaymentSandbox) tx.Result {
 //	(src > dst) ? lsfHighAuth : lsfLowAuth
 //
 // Auth is only checked when the balance is zero.
-func checkAuth(view *PaymentSandbox, src, dst [20]byte, currency string) tx.Result {
+func checkAuth(view *PaymentSandbox, src, dst [20]byte, currency string) ter.Result {
 	// Read source account to check RequireAuth
 	srcKey := keylet.Account(src)
 	srcData, err := view.Read(srcKey)
 	if err != nil || srcData == nil {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	srcAccount, err := state.ParseAccountRoot(srcData)
 	if err != nil {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Only check auth if source has RequireAuth
 	if (srcAccount.Flags & state.LsfRequireAuth) == 0 {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Get the trust line
 	trustLineKey := keylet.Line(src, dst, currency)
 	data, err := view.Read(trustLineKey)
 	if err != nil || data == nil {
-		return tx.TerNO_LINE
+		return ter.TerNO_LINE
 	}
 
 	rs, err := state.ParseRippleState(data)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Check the source's own auth flag
@@ -1117,17 +1118,17 @@ func checkAuth(view *PaymentSandbox, src, dst [20]byte, currency string) tx.Resu
 	// Only block if auth flag is NOT set AND balance is zero
 	// Reference: rippled DirectStep.cpp L422-430
 	if (rs.Flags&authFlag) == 0 && rs.Balance.Signum() == 0 {
-		return tx.TerNO_AUTH
+		return ter.TerNO_AUTH
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // checkFreeze checks if a trust line is frozen.
 // Reference: rippled StepChecks.h checkFreeze()
 // Returns terNO_LINE if frozen, tesSUCCESS otherwise.
 // Order matches rippled: global freeze → individual freeze → deep freeze.
-func checkFreeze(view *PaymentSandbox, src, dst [20]byte, currency string) tx.Result {
+func checkFreeze(view *PaymentSandbox, src, dst [20]byte, currency string) ter.Result {
 	// 1. Check global freeze on destination account
 	// Reference: rippled StepChecks.h:43-49
 	dstKey := keylet.Account(dst)
@@ -1135,7 +1136,7 @@ func checkFreeze(view *PaymentSandbox, src, dst [20]byte, currency string) tx.Re
 	if dstData != nil {
 		dstAccount, err := state.ParseAccountRoot(dstData)
 		if err == nil && (dstAccount.Flags&state.LsfGlobalFreeze) != 0 {
-			return tx.TerNO_LINE
+			return ter.TerNO_LINE
 		}
 	}
 
@@ -1146,12 +1147,12 @@ func checkFreeze(view *PaymentSandbox, src, dst [20]byte, currency string) tx.Re
 	data, err := view.Read(trustLineKey)
 	if err != nil || data == nil {
 		// No trust line — nothing to freeze-check
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	rs, err := state.ParseRippleState(data)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// 3. Check individual freeze
@@ -1161,18 +1162,18 @@ func checkFreeze(view *PaymentSandbox, src, dst [20]byte, currency string) tx.Re
 	srcIsLow := state.CompareAccountIDs(src, dst) < 0
 	if srcIsLow {
 		if (rs.Flags & state.LsfHighFreeze) != 0 {
-			return tx.TerNO_LINE
+			return ter.TerNO_LINE
 		}
 	} else {
 		if (rs.Flags & state.LsfLowFreeze) != 0 {
-			return tx.TerNO_LINE
+			return ter.TerNO_LINE
 		}
 	}
 
 	// 4. Check deep freeze — either side having deep freeze blocks the line
 	// Reference: rippled StepChecks.h:58-62
 	if (rs.Flags&state.LsfHighDeepFreeze) != 0 || (rs.Flags&state.LsfLowDeepFreeze) != 0 {
-		return tx.TerNO_LINE
+		return ter.TerNO_LINE
 	}
 
 	// 5. LP-token arm: a step toward an AMM pseudo-account (the LP-token issuer,
@@ -1183,20 +1184,20 @@ func checkFreeze(view *PaymentSandbox, src, dst [20]byte, currency string) tx.Re
 	if rules := view.Rules(); rules != nil && rules.Enabled(amendment.FeatureFixFrozenLPTokenTransfer) {
 		switch tx.LPTokenFrozenForIssuer(view, src, dst) {
 		case tx.LPTokenAMMUnresolvable:
-			return tx.TecINTERNAL
+			return ter.TecINTERNAL
 		case tx.LPTokenFrozen:
-			return tx.TerNO_LINE
+			return ter.TerNO_LINE
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // CheckWithPrevStep validates the DirectStepI with NoRipple checking against previous step.
 // Reference: rippled DirectStep.cpp make_DirectStepI() lines 918-923
-func (s *DirectStepI) CheckWithPrevStep(sb *PaymentSandbox, prevStep Step) tx.Result {
+func (s *DirectStepI) CheckWithPrevStep(sb *PaymentSandbox, prevStep Step) ter.Result {
 	// First do basic check
-	if result := s.Check(sb); result != tx.TesSUCCESS {
+	if result := s.Check(sb); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -1206,40 +1207,40 @@ func (s *DirectStepI) CheckWithPrevStep(sb *PaymentSandbox, prevStep Step) tx.Re
 		if prevDirectStep, ok := prevStep.(*DirectStepI); ok {
 			prevSrc := prevDirectStep.src
 			result := checkNoRipple(sb, prevSrc, s.src, s.dst, s.currency)
-			if result != tx.TesSUCCESS {
+			if result != ter.TesSUCCESS {
 				return result
 			}
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // checkNoRipple checks if the middle account (cur) has NoRipple set on both sides.
 // Reference: rippled StepChecks.h checkNoRipple()
-func checkNoRipple(view *PaymentSandbox, prev, cur, next [20]byte, currency string) tx.Result {
+func checkNoRipple(view *PaymentSandbox, prev, cur, next [20]byte, currency string) ter.Result {
 	// Fetch the ripple lines into and out of this node
 	sleInKey := keylet.Line(prev, cur, currency)
 	sleOutKey := keylet.Line(cur, next, currency)
 
 	sleInData, err := view.Read(sleInKey)
 	if err != nil || sleInData == nil {
-		return tx.TerNO_LINE
+		return ter.TerNO_LINE
 	}
 
 	sleOutData, err := view.Read(sleOutKey)
 	if err != nil || sleOutData == nil {
-		return tx.TerNO_LINE
+		return ter.TerNO_LINE
 	}
 
 	sleIn, err := state.ParseRippleState(sleInData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	sleOut, err := state.ParseRippleState(sleOutData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Check NoRipple flags
@@ -1263,10 +1264,10 @@ func checkNoRipple(view *PaymentSandbox, prev, cur, next [20]byte, currency stri
 
 	// If BOTH sides have NoRipple set, return terNO_RIPPLE
 	if noRippleIn && noRippleOut {
-		return tx.TerNO_RIPPLE
+		return ter.TerNO_RIPPLE
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // mulRatioAmount multiplies an Amount by num/den

--- a/internal/tx/payment/step_xrp.go
+++ b/internal/tx/payment/step_xrp.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -401,16 +402,16 @@ func (s *XRPEndpointStep) accountSend(sb *PaymentSandbox, amount int64) error {
 }
 
 // Check validates the XRPEndpointStep before use
-func (s *XRPEndpointStep) Check(sb *PaymentSandbox) tx.Result {
+func (s *XRPEndpointStep) Check(sb *PaymentSandbox) ter.Result {
 	// Check account exists
 	accountKey := keylet.Account(s.account)
 	exists, err := sb.Exists(accountKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if !exists {
-		return tx.TerNO_ACCOUNT
+		return ter.TerNO_ACCOUNT
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/payment/strand.go
+++ b/internal/tx/payment/strand.go
@@ -3,6 +3,7 @@ package payment
 import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // StrandContext tracks state during strand building for loop detection.
@@ -55,21 +56,21 @@ func NewStrandContext(view *PaymentSandbox, src, dst [20]byte) *StrandContext {
 // CheckDirectStepLoop checks and records a DirectStep for loops.
 // Returns temBAD_PATH_LOOP if a loop is detected.
 // Reference: rippled DirectStep.cpp make_DirectStepI() lines 949-955
-func (ctx *StrandContext) CheckDirectStepLoop(srcAcct, dstAcct [20]byte, currency string) tx.Result {
+func (ctx *StrandContext) CheckDirectStepLoop(srcAcct, dstAcct [20]byte, currency string) ter.Result {
 	srcIssue := Issue{Currency: currency, Issuer: srcAcct}
 	dstIssue := Issue{Currency: currency, Issuer: dstAcct}
 
 	// Check if source issue already seen as source (except for strand endpoints)
 	if srcAcct != ctx.StrandSrc && srcAcct != ctx.StrandDst {
 		if ctx.SeenDirectIssues[0][srcIssue] {
-			return tx.TemBAD_PATH_LOOP
+			return ter.TemBAD_PATH_LOOP
 		}
 	}
 
 	// Check if dest issue already seen as dest (except for strand endpoints)
 	if dstAcct != ctx.StrandSrc && dstAcct != ctx.StrandDst {
 		if ctx.SeenDirectIssues[1][dstIssue] {
-			return tx.TemBAD_PATH_LOOP
+			return ter.TemBAD_PATH_LOOP
 		}
 	}
 
@@ -77,39 +78,39 @@ func (ctx *StrandContext) CheckDirectStepLoop(srcAcct, dstAcct [20]byte, currenc
 	ctx.SeenDirectIssues[0][srcIssue] = true
 	ctx.SeenDirectIssues[1][dstIssue] = true
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // CheckBookStepLoop checks and records a BookStep for loops.
 // Returns temBAD_PATH_LOOP if a loop is detected.
 // Reference: rippled BookStep.cpp make_BookStepI() lines 1357-1372
-func (ctx *StrandContext) CheckBookStepLoop(bookOut Issue) tx.Result {
+func (ctx *StrandContext) CheckBookStepLoop(bookOut Issue) ter.Result {
 	// Cannot have multiple book steps with same output issue
 	if ctx.SeenBookOuts[bookOut] {
-		return tx.TemBAD_PATH_LOOP
+		return ter.TemBAD_PATH_LOOP
 	}
 
 	// Book output cannot match a direct step source issue
 	if ctx.SeenDirectIssues[0][bookOut] {
-		return tx.TemBAD_PATH_LOOP
+		return ter.TemBAD_PATH_LOOP
 	}
 
 	// Book output cannot match a direct step destination issue
 	if ctx.SeenDirectIssues[1][bookOut] {
-		return tx.TemBAD_PATH_LOOP
+		return ter.TemBAD_PATH_LOOP
 	}
 
 	ctx.SeenBookOuts[bookOut] = true
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // CheckXRPEndpointLoop checks XRP endpoint step for loops.
 // This check is gated on the fix1781 amendment. When fix1781 is not enabled,
 // the check is skipped entirely (pre-amendment behavior allows circular XRP paths).
 // Reference: rippled XRPEndpointStep.cpp lines 365-375
-func (ctx *StrandContext) CheckXRPEndpointLoop(isLast bool) tx.Result {
+func (ctx *StrandContext) CheckXRPEndpointLoop(isLast bool) ter.Result {
 	if !ctx.Fix1781 {
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	xrpIssue := Issue{Currency: "XRP", Issuer: [20]byte{}}
@@ -119,11 +120,11 @@ func (ctx *StrandContext) CheckXRPEndpointLoop(isLast bool) tx.Result {
 	}
 
 	if ctx.SeenDirectIssues[issuesIndex][xrpIssue] {
-		return tx.TemBAD_PATH_LOOP
+		return ter.TemBAD_PATH_LOOP
 	}
 
 	ctx.SeenDirectIssues[issuesIndex][xrpIssue] = true
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // newXRPEndpointStep creates an XRPEndpointStep appropriate for the context.
@@ -172,12 +173,12 @@ func ToStrands(
 	addDefaultPath bool,
 	offerCrossing bool,
 	fix1781 bool,
-) ([]Strand, tx.Result) {
+) ([]Strand, ter.Result) {
 	// Validate source and destination are not XRP pseudo-accounts
 	// Reference: rippled PaySteps.cpp:148-150
 	var xrpAccount [20]byte
 	if src == xrpAccount || dst == xrpAccount {
-		return nil, tx.TemBAD_PATH
+		return nil, ter.TemBAD_PATH
 	}
 
 	dstIssue := GetIssue(dstAmt)
@@ -199,12 +200,12 @@ func ToStrands(
 	}
 
 	var strands []Strand
-	var lastFailResult tx.Result = tx.TesSUCCESS
+	var lastFailResult ter.Result = ter.TesSUCCESS
 
 	// Add default path if requested
 	if addDefaultPath {
 		strand, result := ToStrandWithLoopCheck(view, src, dst, dstIssue, srcIssue, nil, true, offerCrossing, fix1781)
-		if result != tx.TesSUCCESS {
+		if result != ter.TesSUCCESS {
 			// For tem* errors, fail immediately
 			if isTemMalformed(result) || len(paths) == 0 {
 				return nil, result
@@ -215,13 +216,13 @@ func ToStrands(
 		}
 	} else if len(paths) == 0 {
 		// Reference: rippled PaySteps.cpp:532-537
-		return nil, tx.TemRIPPLE_EMPTY
+		return nil, ter.TemRIPPLE_EMPTY
 	}
 
 	// Convert each explicit path to a strand
 	for _, path := range paths {
 		strand, result := ToStrandWithLoopCheck(view, src, dst, dstIssue, srcIssue, path, false, offerCrossing, fix1781)
-		if result != tx.TesSUCCESS {
+		if result != ter.TesSUCCESS {
 			lastFailResult = result
 			// For tem* errors, fail immediately
 			if isTemMalformed(result) {
@@ -248,11 +249,11 @@ func ToStrands(
 		return nil, lastFailResult
 	}
 
-	return strands, tx.TesSUCCESS
+	return strands, ter.TesSUCCESS
 }
 
 // isTemMalformed returns true if the result is a tem* error code
-func isTemMalformed(result tx.Result) bool {
+func isTemMalformed(result ter.Result) bool {
 	code := result.String()
 	return len(code) >= 3 && code[:3] == "tem"
 }
@@ -268,7 +269,7 @@ func ToStrandWithLoopCheck(
 	isDefaultPath bool,
 	offerCrossing bool,
 	fix1781 bool,
-) (Strand, tx.Result) {
+) (Strand, ter.Result) {
 	// Create strand context for loop detection
 	ctx := NewStrandContext(view, src, dst)
 	ctx.StrandDeliver = dstIssue
@@ -282,11 +283,11 @@ func ToStrandWithLoopCheck(
 
 	// Use the context-aware strand builder
 	strand, result := ToStrandWithContext(ctx, src, dst, dstIssue, srcIssue, path, isDefaultPath)
-	if result != tx.TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return nil, result
 	}
 
-	return strand, tx.TesSUCCESS
+	return strand, ter.TesSUCCESS
 }
 
 // normNode is a normalized path element: a PathStep with the implicit source,
@@ -326,10 +327,10 @@ func ToStrandWithContext(
 	srcIssue *Issue,
 	path []PathStep,
 	isDefaultPath bool,
-) (Strand, tx.Result) {
+) (Strand, ter.Result) {
 	normPath := buildNormalizedPath(ctx, src, dst, dstIssue, srcIssue, path)
 	if len(normPath) < 2 {
-		return nil, tx.TemBAD_PATH
+		return nil, ter.TemBAD_PATH
 	}
 	return ctx.buildStrandSteps(src, dst, dstIssue, srcIssue, normPath)
 }
@@ -482,7 +483,7 @@ func (ctx *StrandContext) buildStrandSteps(
 	dstIssue Issue,
 	srcIssue *Issue,
 	normPath []normNode,
-) (Strand, tx.Result) {
+) (Strand, ter.Result) {
 	view := ctx.View
 
 	// Convert normalized path to steps with loop detection
@@ -516,25 +517,25 @@ func (ctx *StrandContext) buildStrandSteps(
 			if !curIssue.IsXRP() && curIssue.Issuer != cur.account && curIssue.Issuer != next.account {
 				// Insert implied DirectStep to curIssue.Issuer first
 				// Check for loop BEFORE creating step
-				if result := ctx.CheckDirectStepLoop(cur.account, curIssue.Issuer, curIssue.Currency); result != tx.TesSUCCESS {
+				if result := ctx.CheckDirectStepLoop(cur.account, curIssue.Issuer, curIssue.Currency); result != ter.TesSUCCESS {
 					return nil, result
 				}
 				directStep := ctx.newDirectStepI(cur.account, curIssue.Issuer, curIssue.Currency, prevStep, len(strand) == 0, false)
 				// Check NoRipple constraint
-				if result := ctx.checkDirectStep(directStep, view, prevStep); result != tx.TesSUCCESS {
+				if result := ctx.checkDirectStep(directStep, view, prevStep); result != ter.TesSUCCESS {
 					return nil, result
 				}
 				strand = append(strand, directStep)
 				prevStep = directStep
 
 				// Check for loop BEFORE creating step
-				if result := ctx.CheckDirectStepLoop(curIssue.Issuer, next.account, curIssue.Currency); result != tx.TesSUCCESS {
+				if result := ctx.CheckDirectStepLoop(curIssue.Issuer, next.account, curIssue.Currency); result != ter.TesSUCCESS {
 					return nil, result
 				}
 				// Now create step from curIssue.Issuer to next
 				directStep = ctx.newDirectStepI(curIssue.Issuer, next.account, curIssue.Currency, prevStep, false, isLast)
 				// Check NoRipple constraint
-				if result := ctx.checkDirectStep(directStep, view, prevStep); result != tx.TesSUCCESS {
+				if result := ctx.checkDirectStep(directStep, view, prevStep); result != ter.TesSUCCESS {
 					return nil, result
 				}
 				strand = append(strand, directStep)
@@ -545,7 +546,7 @@ func (ctx *StrandContext) buildStrandSteps(
 					// XRP endpoint step
 					if i == 0 {
 						// Check for XRP loop
-						if result := ctx.CheckXRPEndpointLoop(false); result != tx.TesSUCCESS {
+						if result := ctx.CheckXRPEndpointLoop(false); result != ter.TesSUCCESS {
 							return nil, result
 						}
 						step := ctx.newXRPEndpointStep(cur.account, false, true) // source, isFirst=true
@@ -554,7 +555,7 @@ func (ctx *StrandContext) buildStrandSteps(
 					}
 					if isLast {
 						// Check for XRP loop
-						if result := ctx.CheckXRPEndpointLoop(true); result != tx.TesSUCCESS {
+						if result := ctx.CheckXRPEndpointLoop(true); result != ter.TesSUCCESS {
 							return nil, result
 						}
 						step := ctx.newXRPEndpointStep(next.account, true, false) // destination, isFirst=false
@@ -562,12 +563,12 @@ func (ctx *StrandContext) buildStrandSteps(
 					}
 				} else {
 					// Check for loop BEFORE creating step
-					if result := ctx.CheckDirectStepLoop(cur.account, next.account, curIssue.Currency); result != tx.TesSUCCESS {
+					if result := ctx.CheckDirectStepLoop(cur.account, next.account, curIssue.Currency); result != ter.TesSUCCESS {
 						return nil, result
 					}
 					directStep := ctx.newDirectStepI(cur.account, next.account, curIssue.Currency, prevStep, len(strand) == 0, isLast)
 					// Check NoRipple constraint
-					if result := ctx.checkDirectStep(directStep, view, prevStep); result != tx.TesSUCCESS {
+					if result := ctx.checkDirectStep(directStep, view, prevStep); result != ter.TesSUCCESS {
 						return nil, result
 					}
 					strand = append(strand, directStep)
@@ -598,7 +599,7 @@ func (ctx *StrandContext) buildStrandSteps(
 			// and returns immediately. The book step is created in the next iteration.
 			if curIssue.IsXRP() && i == 0 {
 				// Check for XRP loop
-				if result := ctx.CheckXRPEndpointLoop(false); result != tx.TesSUCCESS {
+				if result := ctx.CheckXRPEndpointLoop(false); result != ter.TesSUCCESS {
 					return nil, result
 				}
 				xrpStep := ctx.newXRPEndpointStep(cur.account, false, true) // source, isFirst=true
@@ -613,12 +614,12 @@ func (ctx *StrandContext) buildStrandSteps(
 			} else if !curIssue.IsXRP() && curIssue.Issuer != cur.account {
 				// May need implied DirectStep first for IOU
 				// Check for loop BEFORE creating step
-				if result := ctx.CheckDirectStepLoop(cur.account, curIssue.Issuer, curIssue.Currency); result != tx.TesSUCCESS {
+				if result := ctx.CheckDirectStepLoop(cur.account, curIssue.Issuer, curIssue.Currency); result != ter.TesSUCCESS {
 					return nil, result
 				}
 				directStep := ctx.newDirectStepI(cur.account, curIssue.Issuer, curIssue.Currency, prevStep, len(strand) == 0, false)
 				// Check NoRipple constraint
-				if result := ctx.checkDirectStep(directStep, view, prevStep); result != tx.TesSUCCESS {
+				if result := ctx.checkDirectStep(directStep, view, prevStep); result != ter.TesSUCCESS {
 					return nil, result
 				}
 				strand = append(strand, directStep)
@@ -628,22 +629,22 @@ func (ctx *StrandContext) buildStrandSteps(
 			// Create book step for offer path elements
 			// Reference: rippled PaySteps.cpp toStep() creates BookStep
 			if curIssue.IsXRP() && outIssue.IsXRP() {
-				return nil, tx.TemBAD_PATH // Invalid: XRP to XRP book
+				return nil, ter.TemBAD_PATH // Invalid: XRP to XRP book
 			}
 			// Same in/out issue means an invalid book (book_.in == book_.out).
 			// Reference: rippled BookStep::check() line 1346: returns temBAD_PATH
 			if curIssue.Currency == outIssue.Currency && curIssue.Issuer == outIssue.Issuer {
-				return nil, tx.TemBAD_PATH
+				return nil, ter.TemBAD_PATH
 			}
 			// Check for book loop BEFORE creating step
-			if result := ctx.CheckBookStepLoop(outIssue); result != tx.TesSUCCESS {
+			if result := ctx.CheckBookStepLoop(outIssue); result != ter.TesSUCCESS {
 				return nil, result
 			}
 			bookStep := NewBookStep(curIssue, outIssue, src, dst, prevStep, false)
 			bookStep.defaultPath = ctx.IsDefaultPath
 			// Validate book step (noRipple, issuer existence, etc.)
 			// Reference: rippled BookStep.cpp make_BookStepHelper() calls check(ctx)
-			if result := bookStep.Check(view); result != tx.TesSUCCESS {
+			if result := bookStep.Check(view); result != ter.TesSUCCESS {
 				return nil, result
 			}
 			strand = append(strand, bookStep)
@@ -654,7 +655,7 @@ func (ctx *StrandContext) buildStrandSteps(
 			if curIssue.IsXRP() {
 				// XRP coming out of a book — need XRPEndpointStep for the recipient
 				// Check for XRP loop
-				if result := ctx.CheckXRPEndpointLoop(true); result != tx.TesSUCCESS {
+				if result := ctx.CheckXRPEndpointLoop(true); result != ter.TesSUCCESS {
 					return nil, result
 				}
 				step := ctx.newXRPEndpointStep(next.account, true, false) // destination, isFirst=false
@@ -662,12 +663,12 @@ func (ctx *StrandContext) buildStrandSteps(
 			} else if curIssue.Issuer != next.account {
 				// IOU: implied DirectStep from curIssue.Issuer to next account
 				// Check for loop BEFORE creating step
-				if result := ctx.CheckDirectStepLoop(curIssue.Issuer, next.account, curIssue.Currency); result != tx.TesSUCCESS {
+				if result := ctx.CheckDirectStepLoop(curIssue.Issuer, next.account, curIssue.Currency); result != ter.TesSUCCESS {
 					return nil, result
 				}
 				directStep := ctx.newDirectStepI(curIssue.Issuer, next.account, curIssue.Currency, prevStep, len(strand) == 0, isLast)
 				// Check NoRipple constraint
-				if result := ctx.checkDirectStep(directStep, view, prevStep); result != tx.TesSUCCESS {
+				if result := ctx.checkDirectStep(directStep, view, prevStep); result != ter.TesSUCCESS {
 					return nil, result
 				}
 				strand = append(strand, directStep)
@@ -694,22 +695,22 @@ func (ctx *StrandContext) buildStrandSteps(
 			// Reference: rippled PaySteps.cpp toStep() always creates BookStep,
 			// then check() validates it (returns temBAD_PATH for same in/out issue)
 			if curIssue.IsXRP() && outIssue.IsXRP() {
-				return nil, tx.TemBAD_PATH // Invalid: XRP to XRP book
+				return nil, ter.TemBAD_PATH // Invalid: XRP to XRP book
 			}
 			// Same in/out issue means an invalid book (book_.in == book_.out).
 			// Reference: rippled BookStep::check() line 1346: returns temBAD_PATH
 			if curIssue.Currency == outIssue.Currency && curIssue.Issuer == outIssue.Issuer {
-				return nil, tx.TemBAD_PATH
+				return nil, ter.TemBAD_PATH
 			}
 			// Check for book loop BEFORE creating step
-			if result := ctx.CheckBookStepLoop(outIssue); result != tx.TesSUCCESS {
+			if result := ctx.CheckBookStepLoop(outIssue); result != ter.TesSUCCESS {
 				return nil, result
 			}
 			bookStep := NewBookStep(curIssue, outIssue, src, dst, prevStep, false)
 			bookStep.defaultPath = ctx.IsDefaultPath
 			// Validate book step (noRipple, issuer existence, etc.)
 			// Reference: rippled BookStep.cpp make_BookStepHelper() calls check(ctx)
-			if result := bookStep.Check(view); result != tx.TesSUCCESS {
+			if result := bookStep.Check(view); result != ter.TesSUCCESS {
 				return nil, result
 			}
 			strand = append(strand, bookStep)
@@ -718,7 +719,7 @@ func (ctx *StrandContext) buildStrandSteps(
 		}
 	}
 
-	return strand, tx.TesSUCCESS
+	return strand, ter.TesSUCCESS
 }
 
 // accountFromPathElement extracts the account from a path element
@@ -828,16 +829,16 @@ func (ctx *StrandContext) newDirectStepI(src, dst [20]byte, currency string, pre
 // but STILL runs the freeze check (common base class checks).
 // Reference: rippled DirectStepI<TDerived>::check() runs checkFreeze before
 // delegating to DirectIOfferCrossingStep::check() which returns tesSUCCESS.
-func (ctx *StrandContext) checkDirectStep(step *DirectStepI, view *PaymentSandbox, prevStep Step) tx.Result {
+func (ctx *StrandContext) checkDirectStep(step *DirectStepI, view *PaymentSandbox, prevStep Step) ter.Result {
 	if ctx.OfferCrossing {
 		// Run common checks that apply to both payments and offer crossing.
 		// Reference: rippled DirectStepI<TDerived>::check() lines 906-912
 		if !(step.isFirst && step.isLast) {
-			if result := checkFreeze(view, step.src, step.dst, step.currency); result != tx.TesSUCCESS {
+			if result := checkFreeze(view, step.src, step.dst, step.currency); result != ter.TesSUCCESS {
 				return result
 			}
 		}
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	return step.CheckWithPrevStep(view, prevStep)
 }

--- a/internal/tx/payment/strand_flow.go
+++ b/internal/tx/payment/strand_flow.go
@@ -1,8 +1,6 @@
 package payment
 
-import (
-	tx "github.com/LeJamon/go-xrpl/internal/tx"
-)
+import "github.com/LeJamon/go-xrpl/internal/tx/ter"
 
 // flowError is the typed panic value used to abort strand execution when a step
 // fails to move funds. It mirrors rippled's FlowException, which BookStep throws
@@ -13,12 +11,12 @@ import (
 //
 // Reference: rippled Steps.h FlowException + StrandFlow.h flow() catch (lines 295-298).
 type flowError struct {
-	ter tx.Result
+	ter ter.Result
 }
 
 // throwFlowError panics with a flowError carrying the given TER. The TER is the
 // failed transfer's result code, matching rippled's Throw<FlowException>(dr).
-func throwFlowError(ter tx.Result) {
+func throwFlowError(ter ter.Result) {
 	panic(flowError{ter: ter})
 }
 
@@ -29,10 +27,10 @@ func throwFlowError(ter tx.Result) {
 // failure is an unexpected internal error and maps to tefINTERNAL, matching
 // rippled's Throw<FlowException>(tefINTERNAL) for unexpected state.
 func throwConsumeFailure(err error) {
-	if re, ok := tx.AsResultError(err); ok {
+	if re, ok := ter.AsResultError(err); ok {
 		throwFlowError(re.Code)
 	}
-	throwFlowError(tx.TefINTERNAL)
+	throwFlowError(ter.TefINTERNAL)
 }
 
 // strandOffersUsed sums the offers consumed by every step in the strand,

--- a/internal/tx/payment/strand_flow_test.go
+++ b/internal/tx/payment/strand_flow_test.go
@@ -3,8 +3,9 @@ package payment
 import (
 	"testing"
 
-	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // fakeStep is a minimal Step used to drive ExecuteStrand's panic/recover paths
@@ -92,7 +93,7 @@ func TestExecuteStrand_FlowErrorDiscardsPhantomTotals(t *testing.T) {
 		revFn: func(out EitherAmount) (EitherAmount, EitherAmount) {
 			// Simulate a step that has already computed (and would have cached)
 			// a non-zero output, then hits a failed consume mid-pass.
-			throwFlowError(tx.TefINTERNAL)
+			throwFlowError(ter.TefINTERNAL)
 			return out, out // unreachable
 		},
 	}
@@ -158,7 +159,7 @@ func TestExecuteStrand_FlowErrorReportsOffersUsed(t *testing.T) {
 	step := &fakeStep{
 		offersUsed: 4,
 		revFn: func(out EitherAmount) (EitherAmount, EitherAmount) {
-			throwFlowError(tx.TefINTERNAL)
+			throwFlowError(ter.TefINTERNAL)
 			return out, out
 		},
 	}
@@ -189,7 +190,7 @@ func TestFlow_DryStrandOffersConsideredReachesCap(t *testing.T) {
 	result := Flow(sandbox, strands, NewXRPEitherAmount(10_000_000), false, nil, nil, nil, true)
 
 	require.True(t, result.Out.IsZero(), "dry strand delivers nothing")
-	require.Equal(t, tx.TecPATH_PARTIAL, result.Result, "non-partial payment with no delivery is tecPATH_PARTIAL")
+	require.Equal(t, ter.TecPATH_PARTIAL, result.Result, "non-partial payment with no delivery is tecPATH_PARTIAL")
 }
 
 // TestFlow_MaxTriesFailedProcessing proves the curTry >= maxTries bail returns
@@ -211,7 +212,7 @@ func TestFlow_MaxTriesFailedProcessing(t *testing.T) {
 
 	result := Flow(sandbox, strands, NewXRPEitherAmount(10_000_000), true, nil, nil, nil, false)
 
-	require.Equal(t, tx.TelFAILED_PROCESSING, result.Result, "loop must bail with telFAILED_PROCESSING after maxTries")
+	require.Equal(t, ter.TelFAILED_PROCESSING, result.Result, "loop must bail with telFAILED_PROCESSING after maxTries")
 }
 
 // TestFlow_OverDeliveryTefException proves the actualOut > outReq guard returns
@@ -233,7 +234,7 @@ func TestFlow_OverDeliveryTefException(t *testing.T) {
 
 	result := Flow(sandbox, strands, NewXRPEitherAmount(10_000_000), false, nil, nil, nil, false)
 
-	require.Equal(t, tx.TefEXCEPTION, result.Result, "over-delivery must surface tefEXCEPTION")
+	require.Equal(t, ter.TefEXCEPTION, result.Result, "over-delivery must surface tefEXCEPTION")
 	require.True(t, result.Out.IsZero(), "tefEXCEPTION discards delivered output")
 	require.Nil(t, result.Sandbox, "tefEXCEPTION discards the sandbox")
 }

--- a/internal/tx/payment/types.go
+++ b/internal/tx/payment/types.go
@@ -3,6 +3,7 @@ package payment
 import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // DebtDirection indicates whether a step is issuing or redeeming currency
@@ -97,7 +98,7 @@ type FlowResult struct {
 	Out             EitherAmount
 	Sandbox         *PaymentSandbox
 	RemovableOffers map[[32]byte]bool
-	Result          tx.Result
+	Result          ter.Result
 }
 
 func GetIssue(amt tx.Amount) Issue {

--- a/internal/tx/permissioneddomain/constant.go
+++ b/internal/tx/permissioneddomain/constant.go
@@ -1,6 +1,6 @@
 package permissioneddomain
 
-import "github.com/LeJamon/go-xrpl/internal/tx"
+import "github.com/LeJamon/go-xrpl/internal/tx/ter"
 
 // Permissioned domain constants
 const (
@@ -10,13 +10,13 @@ const (
 
 // Permissioned domain errors
 var (
-	ErrPermDomainTooManyCredentials  = tx.Errorf(tx.TemARRAY_TOO_LARGE, "too many AcceptedCredentials")
-	ErrPermDomainEmptyCredentials    = tx.Errorf(tx.TemARRAY_EMPTY, "AcceptedCredentials cannot be empty")
-	ErrPermDomainDuplicateCredential = tx.Errorf(tx.TemMALFORMED, "duplicate credential in AcceptedCredentials")
-	ErrPermDomainEmptyCredType       = tx.Errorf(tx.TemMALFORMED, "CredentialType cannot be empty")
-	ErrPermDomainCredTypeTooLong     = tx.Errorf(tx.TemMALFORMED, "CredentialType exceeds maximum length")
-	ErrPermDomainNoIssuer            = tx.Errorf(tx.TemMALFORMED, "Issuer is required for each credential")
-	ErrPermDomainIDRequired          = tx.Errorf(tx.TemMALFORMED, "DomainID is required for delete")
+	ErrPermDomainTooManyCredentials  = ter.Errorf(ter.TemARRAY_TOO_LARGE, "too many AcceptedCredentials")
+	ErrPermDomainEmptyCredentials    = ter.Errorf(ter.TemARRAY_EMPTY, "AcceptedCredentials cannot be empty")
+	ErrPermDomainDuplicateCredential = ter.Errorf(ter.TemMALFORMED, "duplicate credential in AcceptedCredentials")
+	ErrPermDomainEmptyCredType       = ter.Errorf(ter.TemMALFORMED, "CredentialType cannot be empty")
+	ErrPermDomainCredTypeTooLong     = ter.Errorf(ter.TemMALFORMED, "CredentialType exceeds maximum length")
+	ErrPermDomainNoIssuer            = ter.Errorf(ter.TemMALFORMED, "Issuer is required for each credential")
+	ErrPermDomainIDRequired          = ter.Errorf(ter.TemMALFORMED, "DomainID is required for delete")
 )
 
 // AcceptedCredential defines an accepted credential type (wrapper for XRPL STArray format)

--- a/internal/tx/permissioneddomain/dex_helpers.go
+++ b/internal/tx/permissioneddomain/dex_helpers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -82,7 +83,7 @@ func ParseDomainID(hexStr string) ([32]byte, error) {
 	var domainID [32]byte
 	b, err := hex.DecodeString(hexStr)
 	if err != nil || len(b) != 32 {
-		return domainID, tx.Errorf(tx.TemMALFORMED, "DomainID must be a valid 256-bit hash")
+		return domainID, ter.Errorf(ter.TemMALFORMED, "DomainID must be a valid 256-bit hash")
 	}
 	copy(domainID[:], b)
 	return domainID, nil

--- a/internal/tx/permissioneddomain/permissioned_domain_delete.go
+++ b/internal/tx/permissioneddomain/permissioned_domain_delete.go
@@ -6,6 +6,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -65,7 +66,7 @@ func (p *PermissionedDomainDelete) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled PermissionedDomainDelete.cpp preclaim() + doApply()
-func (p *PermissionedDomainDelete) Apply(ctx *tx.ApplyContext) tx.Result {
+func (p *PermissionedDomainDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("permissioned domain delete apply",
 		"account", p.Account,
 		"domainID", p.DomainID,
@@ -73,7 +74,7 @@ func (p *PermissionedDomainDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	domainBytes, err := hex.DecodeString(p.DomainID)
 	if err != nil || len(domainBytes) != 32 {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 	var domainID [32]byte
 	copy(domainID[:], domainBytes)
@@ -86,20 +87,20 @@ func (p *PermissionedDomainDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Warn("permissioned domain delete: domain not found",
 			"domainID", p.DomainID,
 		)
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	existing, err := state.ParsePermissionedDomain(existingData)
 	if err != nil {
 		ctx.Log.Error("permissioned domain delete: failed to parse domain", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Preclaim: verify caller owns the domain
 	// Reference: rippled PermissionedDomainDelete.cpp preclaim() lines 57-61
 	if existing.Owner != ctx.AccountID {
 		ctx.Log.Warn("permissioned domain delete: caller is not owner")
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Remove from owner directory
@@ -107,17 +108,17 @@ func (p *PermissionedDomainDelete) Apply(ctx *tx.ApplyContext) tx.Result {
 	ownerDirKey := keylet.OwnerDir(ctx.AccountID)
 	if _, err := state.DirRemove(ctx.View, ownerDirKey, existing.OwnerNode, domainKeylet.Key, false); err != nil {
 		ctx.Log.Error("permissioned domain delete: failed to remove from directory", "error", err)
-		return tx.TefBAD_LEDGER
+		return ter.TefBAD_LEDGER
 	}
 
 	if err := ctx.View.Erase(domainKeylet); err != nil {
 		ctx.Log.Error("permissioned domain delete: failed to erase domain", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if ctx.Account.OwnerCount > 0 {
 		ctx.Account.OwnerCount--
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/permissioneddomain/permissioned_domain_set.go
+++ b/internal/tx/permissioneddomain/permissioned_domain_set.go
@@ -9,6 +9,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -77,7 +78,7 @@ func (p *PermissionedDomainSet) Validate() error {
 
 		credTypeBytes, err := hex.DecodeString(data.CredentialType)
 		if err != nil {
-			return tx.Errorf(tx.TemMALFORMED, "CredentialType must be valid hex string")
+			return ter.Errorf(ter.TemMALFORMED, "CredentialType must be valid hex string")
 		}
 		if len(credTypeBytes) == 0 {
 			return ErrPermDomainEmptyCredType
@@ -115,7 +116,7 @@ func (p *PermissionedDomainSet) RequiredAmendments() [][32]byte {
 }
 
 // Reference: rippled PermissionedDomainSet.cpp preclaim() + doApply()
-func (p *PermissionedDomainSet) Apply(ctx *tx.ApplyContext) tx.Result {
+func (p *PermissionedDomainSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("permissioned domain set apply",
 		"account", p.Account,
 		"domainID", p.DomainID,
@@ -127,14 +128,14 @@ func (p *PermissionedDomainSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	for _, cred := range p.AcceptedCredentials {
 		issuerID, err := state.DecodeAccountID(cred.Credential.Issuer)
 		if err != nil {
-			return tx.TemINVALID
+			return ter.TemINVALID
 		}
 		issuerData, err := ctx.View.Read(keylet.Account(issuerID))
 		if err != nil || issuerData == nil {
 			ctx.Log.Warn("permissioned domain set: issuer does not exist",
 				"issuer", cred.Credential.Issuer,
 			)
-			return tx.TecNO_ISSUER
+			return ter.TecNO_ISSUER
 		}
 	}
 
@@ -142,7 +143,7 @@ func (p *PermissionedDomainSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled PermissionedDomainSet.cpp makeSorted()
 	sorted, err := sortedCredentials(p.AcceptedCredentials)
 	if err != nil {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 
 	if p.DomainID != "" {
@@ -155,7 +156,7 @@ func (p *PermissionedDomainSet) Apply(ctx *tx.ApplyContext) tx.Result {
 }
 
 // applyCreate handles domain creation.
-func (p *PermissionedDomainSet) applyCreate(ctx *tx.ApplyContext, sorted []state.PermissionedDomainCredential) tx.Result {
+func (p *PermissionedDomainSet) applyCreate(ctx *tx.ApplyContext, sorted []state.PermissionedDomainCredential) ter.Result {
 	// Check reserve
 	// Reference: rippled PermissionedDomainSet.cpp doApply() lines 102-106
 	reserve := ctx.AccountReserve(ctx.Account.OwnerCount + 1)
@@ -164,7 +165,7 @@ func (p *PermissionedDomainSet) applyCreate(ctx *tx.ApplyContext, sorted []state
 			"balance", ctx.Account.Balance,
 			"reserve", reserve,
 		)
-		return tx.TecINSUFFICIENT_RESERVE
+		return ter.TecINSUFFICIENT_RESERVE
 	}
 
 	// Compute domain keylet from account + transaction sequence
@@ -182,12 +183,12 @@ func (p *PermissionedDomainSet) applyCreate(ctx *tx.ApplyContext, sorted []state
 	pdData, err := state.SerializePermissionedDomain(pd, p.Account)
 	if err != nil {
 		ctx.Log.Error("permissioned domain set: failed to serialize domain", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if err := ctx.View.Insert(domainKeylet, pdData); err != nil {
 		ctx.Log.Error("permissioned domain set: failed to insert domain", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Add to owner directory. The describe callback stamps sfOwner on a freshly
@@ -199,29 +200,29 @@ func (p *PermissionedDomainSet) applyCreate(ctx *tx.ApplyContext, sorted []state
 	})
 	if err != nil {
 		ctx.Log.Error("permissioned domain set: directory insert failed", "error", err)
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 
 	// Update OwnerNode in the stored entry
 	pd.OwnerNode = result.Page
 	pdData, err = state.SerializePermissionedDomain(pd, p.Account)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := ctx.View.Update(domainKeylet, pdData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	ctx.Account.OwnerCount++
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // applyUpdate handles domain update.
-func (p *PermissionedDomainSet) applyUpdate(ctx *tx.ApplyContext, sorted []state.PermissionedDomainCredential) tx.Result {
+func (p *PermissionedDomainSet) applyUpdate(ctx *tx.ApplyContext, sorted []state.PermissionedDomainCredential) ter.Result {
 	domainBytes, err := hex.DecodeString(p.DomainID)
 	if err != nil || len(domainBytes) != 32 {
-		return tx.TemINVALID
+		return ter.TemINVALID
 	}
 	var domainID [32]byte
 	copy(domainID[:], domainBytes)
@@ -232,20 +233,20 @@ func (p *PermissionedDomainSet) applyUpdate(ctx *tx.ApplyContext, sorted []state
 		ctx.Log.Warn("permissioned domain set: domain not found",
 			"domainID", p.DomainID,
 		)
-		return tx.TecNO_ENTRY
+		return ter.TecNO_ENTRY
 	}
 
 	existing, err := state.ParsePermissionedDomain(existingData)
 	if err != nil {
 		ctx.Log.Error("permissioned domain set: failed to parse domain", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Verify caller is the owner
 	// Reference: rippled PermissionedDomainSet.cpp preclaim() lines 88-95
 	if existing.Owner != ctx.AccountID {
 		ctx.Log.Warn("permissioned domain set: caller is not owner")
-		return tx.TecNO_PERMISSION
+		return ter.TecNO_PERMISSION
 	}
 
 	// Replace credentials
@@ -254,14 +255,14 @@ func (p *PermissionedDomainSet) applyUpdate(ctx *tx.ApplyContext, sorted []state
 	ownerAddress := p.Account
 	updatedData, err := state.SerializePermissionedDomain(existing, ownerAddress)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if err := ctx.View.Update(domainKeylet, updatedData); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // sortedCredentials converts AcceptedCredential slice to sorted PermissionedDomainCredential slice.

--- a/internal/tx/preclaim.go
+++ b/internal/tx/preclaim.go
@@ -7,6 +7,7 @@ import (
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -15,28 +16,28 @@ import (
 //
 //	checkSeqProxy → checkPriorTxAndLastLedger → checkFee → checkPermission →
 //	checkSign (+ checkBatchSign) → tx-type preclaim.
-func (e *Engine) preclaim(tx Transaction, txHash [32]byte) Result {
+func (e *Engine) preclaim(tx Transaction, txHash [32]byte) ter.Result {
 	common := tx.GetCommon()
 
 	// Resolve and parse the source account; this is shared by all subsequent steps.
 	accountID, account, result := e.preclaimLoadAccount(common)
-	if result != TesSUCCESS {
+	if result != ter.TesSUCCESS {
 		return result
 	}
 
-	if result := e.checkSeqProxy(common, accountID, account); result != TesSUCCESS {
+	if result := e.checkSeqProxy(common, accountID, account); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := e.checkPriorTxAndLastLedger(common, account, txHash); result != TesSUCCESS {
+	if result := e.checkPriorTxAndLastLedger(common, account, txHash); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := e.checkFee(tx, common, account); result != TesSUCCESS {
+	if result := e.checkFee(tx, common, account); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := e.checkPermission(tx, common, accountID); result != TesSUCCESS {
+	if result := e.checkPermission(tx, common, accountID); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := e.checkSign(tx, common); result != TesSUCCESS {
+	if result := e.checkSign(tx, common); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -46,7 +47,7 @@ func (e *Engine) preclaim(tx Transaction, txHash [32]byte) Result {
 	// This runs even when SkipSignatureVerification is true because it checks
 	// authorization (account existence, master key, regular key), not crypto.
 	if bsp, ok := tx.(BatchSignerProvider); ok {
-		if result := e.checkBatchSign(bsp.GetBatchSigners()); result != TesSUCCESS {
+		if result := e.checkBatchSign(bsp.GetBatchSigners()); result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -63,40 +64,40 @@ func (e *Engine) preclaim(tx Transaction, txHash [32]byte) Result {
 		// ledger returns nil, which would silently disable rules-gated reads
 		// (e.g. accountFunds' frozen-LP-token check) during preclaim.
 		preclaimView := rulesView{LedgerView: e.view, rules: e.config.GetRules()}
-		if result := preclaimer.Preclaim(preclaimView, e.config); result != TesSUCCESS {
+		if result := preclaimer.Preclaim(preclaimView, e.config); result != ter.TesSUCCESS {
 			return result
 		}
 	}
 
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // preclaimLoadAccount decodes the source account and reads + parses its SLE.
 // Returns the decoded accountID, the parsed AccountRoot, and a TER result.
-func (e *Engine) preclaimLoadAccount(common *Common) ([20]byte, *state.AccountRoot, Result) {
+func (e *Engine) preclaimLoadAccount(common *Common) ([20]byte, *state.AccountRoot, ter.Result) {
 	accountID, err := state.DecodeAccountID(common.Account)
 	if err != nil {
-		return [20]byte{}, nil, TemBAD_SRC_ACCOUNT
+		return [20]byte{}, nil, ter.TemBAD_SRC_ACCOUNT
 	}
 
 	account, err := ReadAccountRoot(e.view, accountID)
 	if err != nil {
-		return accountID, nil, TefINTERNAL
+		return accountID, nil, ter.TefINTERNAL
 	}
 	if account == nil {
-		return accountID, nil, TerNO_ACCOUNT
+		return accountID, nil, ter.TerNO_ACCOUNT
 	}
-	return accountID, account, TesSUCCESS
+	return accountID, account, ter.TesSUCCESS
 }
 
 // checkSeqProxy validates Sequence/TicketSequence against the account state.
 // Reference: rippled Transactor::checkSeqProxy in Transactor.cpp.
-func (e *Engine) checkSeqProxy(common *Common, accountID [20]byte, account *state.AccountRoot) Result {
+func (e *Engine) checkSeqProxy(common *Common, accountID [20]byte, account *state.AccountRoot) ter.Result {
 	// Check for both Sequence (non-zero) and TicketSequence set → temSEQ_AND_TICKET
 	// Reference: rippled Transactor::checkSeqProxy in Transactor.cpp line 375
 	if common.Sequence != nil && *common.Sequence != 0 && common.TicketSequence != nil {
 		if e.rules().Enabled(amendment.FeatureTicketBatch) {
-			return TemSEQ_AND_TICKET
+			return ter.TemSEQ_AND_TICKET
 		}
 	}
 
@@ -105,46 +106,46 @@ func (e *Engine) checkSeqProxy(common *Common, accountID [20]byte, account *stat
 		// Ticket-based transaction: validate the ticket exists
 		if *common.TicketSequence >= account.Sequence {
 			// Ticket hasn't been created yet
-			return TerPRE_TICKET
+			return ter.TerPRE_TICKET
 		}
 		ticketKey := keylet.Ticket(accountID, *common.TicketSequence)
 		ticketExists, ticketErr := e.view.Exists(ticketKey)
 		if ticketErr != nil || !ticketExists {
-			return TefNO_TICKET
+			return ter.TefNO_TICKET
 		}
 	} else if common.Sequence != nil {
 		if *common.Sequence < account.Sequence {
-			return TefPAST_SEQ
+			return ter.TefPAST_SEQ
 		}
 		if *common.Sequence > account.Sequence {
-			return TerPRE_SEQ
+			return ter.TerPRE_SEQ
 		}
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // checkPriorTxAndLastLedger validates AccountTxnID, LastLedgerSequence, and
 // dedupes by transaction hash.
 // Reference: rippled Transactor::checkPriorTxAndLastLedger in Transactor.cpp.
-func (e *Engine) checkPriorTxAndLastLedger(common *Common, account *state.AccountRoot, txHash [32]byte) Result {
+func (e *Engine) checkPriorTxAndLastLedger(common *Common, account *state.AccountRoot, txHash [32]byte) ter.Result {
 	// AccountTxnID check — if the transaction specifies an AccountTxnID, it must match
 	// the account's stored AccountTxnID (the hash of the last tx this account submitted).
 	if common.AccountTxnID != "" {
 		txAccountTxnID, decErr := hex.DecodeString(common.AccountTxnID)
 		if decErr != nil || len(txAccountTxnID) != 32 {
-			return TefWRONG_PRIOR
+			return ter.TefWRONG_PRIOR
 		}
 		var txPrior [32]byte
 		copy(txPrior[:], txAccountTxnID)
 		if txPrior != account.AccountTxnID {
-			return TefWRONG_PRIOR
+			return ter.TefWRONG_PRIOR
 		}
 	}
 
 	// LastLedgerSequence check
 	if common.LastLedgerSequence != nil {
 		if e.config.LedgerSequence > *common.LastLedgerSequence {
-			return TefMAX_LEDGER
+			return ter.TefMAX_LEDGER
 		}
 	}
 
@@ -152,14 +153,14 @@ func (e *Engine) checkPriorTxAndLastLedger(common *Common, account *state.Accoun
 	// view (already applied to this ledger), return tefALREADY.
 	// Reference: rippled Transactor::checkPriorTxAndLastLedger — ctx.view.txExists()
 	if e.view.TxExists(txHash) {
-		return TefALREADY
+		return ter.TefALREADY
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // checkFee enforces fee adequacy and that the fee payer (delegate or source)
 // can afford the fee. Reference: rippled Transactor::checkFee in Transactor.cpp.
-func (e *Engine) checkFee(tx Transaction, common *Common, account *state.AccountRoot) Result {
+func (e *Engine) checkFee(tx Transaction, common *Common, account *state.AccountRoot) ter.Result {
 	// When a delegate is present, the fee is checked against the delegate's balance.
 	fee := e.calculateFee(tx)
 	baseFeeForTx := e.preclaimBaseFee(tx, common, account)
@@ -180,7 +181,7 @@ func (e *Engine) checkFee(tx Transaction, common *Common, account *state.Account
 	if e.config.OpenLedger ||
 		(e.config.EnforceLoadFee && e.config.FeeTrack != nil &&
 			e.config.FeeTrack.GetLoadFactor() > feetrack.LoadBase) {
-		if r := e.enforceFeeFloor(fee, baseFeeForTx); r != TesSUCCESS {
+		if r := e.enforceFeeFloor(fee, baseFeeForTx); r != ter.TesSUCCESS {
 			return r
 		}
 	}
@@ -189,13 +190,13 @@ func (e *Engine) checkFee(tx Transaction, common *Common, account *state.Account
 	// Reference: rippled Transactor::checkFee line 292-293:
 	//   if (feePaid == beast::zero) return tesSUCCESS;
 	if fee == 0 {
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	if feeCalc, ok := tx.(BatchFeeCalculator); ok {
 		batchMinFee := feeCalc.CalculateMinimumFee(e.config.BaseFee)
 		if fee < batchMinFee {
-			return TelINSUF_FEE_P
+			return ter.TelINSUF_FEE_P
 		}
 	}
 
@@ -205,7 +206,7 @@ func (e *Engine) checkFee(tx Transaction, common *Common, account *state.Account
 	//       ? ctx.tx.getAccountID(sfDelegate)
 	//       : ctx.tx.getAccountID(sfAccount);
 	feePayerBalance, balResult := e.feePayerBalance(common, account)
-	if balResult != TesSUCCESS {
+	if balResult != ter.TesSUCCESS {
 		return balResult
 	}
 	if feePayerBalance < fee {
@@ -213,11 +214,11 @@ func (e *Engine) checkFee(tx Transaction, common *Common, account *state.Account
 		// ledger, a non-zero balance below the fee yields a deterministic
 		// claimed-fee result; otherwise the transaction is retryable.
 		if feePayerBalance > 0 && !e.config.OpenLedger {
-			return TecINSUFF_FEE
+			return ter.TecINSUFF_FEE
 		}
-		return TerINSUF_FEE_B
+		return ter.TerINSUF_FEE_B
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // enforceFeeFloor rejects a fee below the load-scaled minimum, mirroring
@@ -226,16 +227,16 @@ func (e *Engine) checkFee(tx Transaction, common *Common, account *state.Account
 // floor exceeds any payable fee, where rippled throws) resolves to the same
 // insufficient-fee code. Reference: rippled Transactor::checkFee
 // Transactor.cpp:278-290.
-func (e *Engine) enforceFeeFloor(fee, baseFeeForTx uint64) Result {
+func (e *Engine) enforceFeeFloor(fee, baseFeeForTx uint64) ter.Result {
 	unlimited := e.config.ApplyFlags&TapUNLIMITED != 0
 	feeDue, scaleErr := feetrack.ScaleFeeLoad(baseFeeForTx, e.config.FeeTrack, unlimited)
 	if scaleErr != nil {
-		return TelINSUF_FEE_P
+		return ter.TelINSUF_FEE_P
 	}
 	if fee < feeDue {
-		return TelINSUF_FEE_P
+		return ter.TelINSUF_FEE_P
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // preclaimBaseFee computes the minimum base fee for this transaction type,
@@ -264,50 +265,50 @@ func (e *Engine) preclaimBaseFee(tx Transaction, common *Common, account *state.
 
 // feePayerBalance returns the balance of the account that will be charged the fee
 // (delegate when sfDelegate is present, otherwise the source account).
-func (e *Engine) feePayerBalance(common *Common, account *state.AccountRoot) (uint64, Result) {
+func (e *Engine) feePayerBalance(common *Common, account *state.AccountRoot) (uint64, ter.Result) {
 	if common.Delegate == "" {
-		return account.Balance, TesSUCCESS
+		return account.Balance, ter.TesSUCCESS
 	}
 	delegateID, delegateErr := state.DecodeAccountID(common.Delegate)
 	if delegateErr != nil {
-		return 0, TerNO_ACCOUNT
+		return 0, ter.TerNO_ACCOUNT
 	}
 	delegateAccount, readErr := ReadAccountRoot(e.view, delegateID)
 	if readErr != nil {
 		// Real storage or parse failure, not a missing account.
-		return 0, TefINTERNAL
+		return 0, ter.TefINTERNAL
 	}
 	if delegateAccount == nil {
-		return 0, TerNO_ACCOUNT
+		return 0, ter.TerNO_ACCOUNT
 	}
-	return delegateAccount.Balance, TesSUCCESS
+	return delegateAccount.Balance, ter.TesSUCCESS
 }
 
 // checkPermission validates that, when sfDelegate is set, the delegate SLE
 // grants permission for this transaction type.
 // Reference: rippled Transactor::checkPermission in Transactor.cpp lines 213-227
 // and DelegateUtils.cpp checkTxPermission().
-func (e *Engine) checkPermission(tx Transaction, common *Common, accountID [20]byte) Result {
+func (e *Engine) checkPermission(tx Transaction, common *Common, accountID [20]byte) ter.Result {
 	if common.Delegate == "" {
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	delegateID, _ := state.DecodeAccountID(common.Delegate)
 	delegateKeylet := keylet.Delegate(accountID, delegateID)
 	delegateData, readErr := e.view.Read(delegateKeylet)
 	if readErr != nil || delegateData == nil {
-		return TecNO_DELEGATE_PERMISSION
+		return ter.TecNO_DELEGATE_PERMISSION
 	}
 	delegateEntry, parseErr := state.ParseDelegate(delegateData)
 	if parseErr != nil {
-		return TecNO_DELEGATE_PERMISSION
+		return ter.TecNO_DELEGATE_PERMISSION
 	}
 	// Check if the delegate SLE grants permission for this tx type.
 	// In rippled: permissionValue == tx.getTxnType() + 1
 	txTypeValue := uint32(tx.TxType())
 	if !delegateEntry.HasTxPermission(txTypeValue) {
-		return TecNO_DELEGATE_PERMISSION
+		return ter.TecNO_DELEGATE_PERMISSION
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // checkSign performs signature authorization for both single-signed and
@@ -317,20 +318,20 @@ func (e *Engine) checkPermission(tx Transaction, common *Common, accountID [20]b
 // delegate. Reference: rippled line 602:
 //
 //	auto const idAccount = ctx.tx[~sfDelegate].value_or(ctx.tx[sfAccount]);
-func (e *Engine) checkSign(tx Transaction, common *Common) Result {
+func (e *Engine) checkSign(tx Transaction, common *Common) ter.Result {
 	if IsMultiSigned(tx) {
 		return e.checkMultiSign(common)
 	}
 	if common.SigningPubKey != "" {
 		return e.checkSingleSign(common)
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // checkMultiSign verifies the multi-sign signers against the idAccount's
 // SignerList and quorum.
 // Reference: rippled Transactor::checkMultiSign in Transactor.cpp lines 743-911.
-func (e *Engine) checkMultiSign(common *Common) Result {
+func (e *Engine) checkMultiSign(common *Common) ter.Result {
 	// Multi-signed transaction: always check signer authorization and quorum.
 	// This runs regardless of SkipSignatureVerification because quorum and
 	// signer authorization (master key disabled, regular key, phantom accounts)
@@ -341,7 +342,7 @@ func (e *Engine) checkMultiSign(common *Common) Result {
 	}
 	idAccountID, idErr := state.DecodeAccountID(idAccount)
 	if idErr != nil {
-		return TefBAD_SIGNATURE
+		return ter.TefBAD_SIGNATURE
 	}
 	// Convert tx Signers to SignerInfo for checkBatchMultiSign
 	txSigners := make([]SignerInfo, len(common.Signers))
@@ -357,7 +358,7 @@ func (e *Engine) checkMultiSign(common *Common) Result {
 // checkSingleSign validates a single-signed transaction's signing key against
 // the idAccount's master/regular key configuration.
 // Reference: rippled Transactor::checkSingleSign in Transactor.cpp lines 682-740.
-func (e *Engine) checkSingleSign(common *Common) Result {
+func (e *Engine) checkSingleSign(common *Common) ter.Result {
 	// Single-signed transaction: check signing key authorization.
 	// This runs regardless of SkipSignatureVerification because authorization
 	// (master key disabled, regular key) is a ledger-state check, not a
@@ -365,7 +366,7 @@ func (e *Engine) checkSingleSign(common *Common) Result {
 	// Validate() and gated by SkipSignatureVerification.
 	signerAddress, addrErr := addresscodec.EncodeClassicAddressFromPublicKeyHex(common.SigningPubKey)
 	if addrErr != nil {
-		return TefBAD_AUTH
+		return ter.TefBAD_AUTH
 	}
 
 	// Determine the idAccount: delegate if present, else source account.
@@ -377,16 +378,16 @@ func (e *Engine) checkSingleSign(common *Common) Result {
 	// Read the idAccount's data for signature authorization check
 	idAccountID, idErr := state.DecodeAccountID(idAccount)
 	if idErr != nil {
-		return TefBAD_AUTH
+		return ter.TefBAD_AUTH
 	}
 	idAccountKey := keylet.Account(idAccountID)
 	idAccountData, idReadErr := e.view.Read(idAccountKey)
 	if idReadErr != nil || idAccountData == nil {
-		return TerNO_ACCOUNT
+		return ter.TerNO_ACCOUNT
 	}
 	idAccountRoot, idParseErr := state.ParseAccountRoot(idAccountData)
 	if idParseErr != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	isMasterDisabled := (idAccountRoot.Flags & state.LsfDisableMaster) != 0
@@ -398,18 +399,18 @@ func (e *Engine) checkSingleSign(common *Common) Result {
 		// Reference: rippled Transactor::checkSingleSign lines 691-713
 		if signerAddress == idAccountRoot.RegularKey {
 			// Signed with regular key — allowed
-			return TesSUCCESS
+			return ter.TesSUCCESS
 		}
 		if !isMasterDisabled && signerAddress == idAccount {
 			// Signed with enabled master key — allowed
-			return TesSUCCESS
+			return ter.TesSUCCESS
 		}
 		if isMasterDisabled && signerAddress == idAccount {
 			// Signed with disabled master key
-			return TefMASTER_DISABLED
+			return ter.TefMASTER_DISABLED
 		}
 		// Signed with an unauthorized key
-		return TefBAD_AUTH
+		return ter.TefBAD_AUTH
 	}
 
 	// Without fixMasterKeyAsRegularKey: check master key first.
@@ -419,37 +420,37 @@ func (e *Engine) checkSingleSign(common *Common) Result {
 	if signerAddress == idAccount {
 		// Signing with the master key. Continue if it is not disabled.
 		if isMasterDisabled {
-			return TefMASTER_DISABLED
+			return ter.TefMASTER_DISABLED
 		}
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	if signerAddress == idAccountRoot.RegularKey {
 		// Signing with the regular key. Continue.
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	if idAccountRoot.RegularKey != "" {
 		// Signing key does not match master or regular key.
-		return TefBAD_AUTH
+		return ter.TefBAD_AUTH
 	}
 	// No regular key on account and signing key does not match master key.
-	return TefBAD_AUTH_MASTER
+	return ter.TefBAD_AUTH_MASTER
 }
 
 // checkBatchSign verifies that each batch signer is authorized to sign for their account.
 // For single-sign signers (SigningPubKey non-empty): derives account from pubkey, checks authorization.
 // For multi-sign signers (SigningPubKey empty): checks signer list exists and quorum is met.
 // Reference: rippled Transactor::checkBatchSign in Transactor.cpp lines 635-679
-func (e *Engine) checkBatchSign(signers []BatchSignerInfo) Result {
+func (e *Engine) checkBatchSign(signers []BatchSignerInfo) ter.Result {
 	for _, signer := range signers {
 		signerAccountID, err := state.DecodeAccountID(signer.Account)
 		if err != nil {
-			return TefBAD_AUTH
+			return ter.TefBAD_AUTH
 		}
 
 		if signer.SigningPubKey == "" {
 			// Multi-sign batch signer: check nested Signers against the account's SignerList.
 			// Reference: rippled checkBatchSign -> checkMultiSign
-			if result := e.checkBatchMultiSign(signerAccountID, signer.Signers); result != TesSUCCESS {
+			if result := e.checkBatchMultiSign(signerAccountID, signer.Signers); result != ter.TesSUCCESS {
 				return result
 			}
 			continue
@@ -458,7 +459,7 @@ func (e *Engine) checkBatchSign(signers []BatchSignerInfo) Result {
 		// Single-sign batch signer: derive account from public key
 		signerAddress, addrErr := addresscodec.EncodeClassicAddressFromPublicKeyHex(signer.SigningPubKey)
 		if addrErr != nil {
-			return TefBAD_AUTH
+			return ter.TefBAD_AUTH
 		}
 
 		signerAccountKey := keylet.Account(signerAccountID)
@@ -466,14 +467,14 @@ func (e *Engine) checkBatchSign(signers []BatchSignerInfo) Result {
 		if readErr != nil {
 			// Real storage failure — view.read() cannot fail in rippled, so a
 			// genuine read error here is an internal fault, not a missing account.
-			return TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		if signerAccountData == nil {
 			// Account doesn't exist: only allowed if the signer pubkey derives to this account
 			// (phantom account pattern — the signer IS the account)
 			if signerAddress != signer.Account {
-				return TefBAD_AUTH
+				return ter.TefBAD_AUTH
 			}
 			// Phantom account — allowed
 			continue
@@ -481,7 +482,7 @@ func (e *Engine) checkBatchSign(signers []BatchSignerInfo) Result {
 
 		signerAccountRoot, parseErr := state.ParseAccountRoot(signerAccountData)
 		if parseErr != nil {
-			return TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Check authorization: master key, regular key, or disabled master
@@ -494,28 +495,28 @@ func (e *Engine) checkBatchSign(signers []BatchSignerInfo) Result {
 			// Signed with enabled master key — allowed
 		} else if isMasterDisabled && signerAddress == signer.Account {
 			// Signed with disabled master key
-			return TefMASTER_DISABLED
+			return ter.TefMASTER_DISABLED
 		} else {
 			// Signed with an unauthorized key
-			return TefBAD_AUTH
+			return ter.TefBAD_AUTH
 		}
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // checkBatchMultiSign verifies a multi-sign batch signer's nested Signers against
 // the account's SignerList. This mirrors rippled's checkMultiSign.
 // Reference: rippled Transactor::checkMultiSign in Transactor.cpp lines 742-911
-func (e *Engine) checkBatchMultiSign(accountID [20]byte, txSigners []SignerInfo) Result {
+func (e *Engine) checkBatchMultiSign(accountID [20]byte, txSigners []SignerInfo) ter.Result {
 	signerListKey := keylet.SignerList(accountID)
 	signerListData, err := e.view.Read(signerListKey)
 	if err != nil || signerListData == nil {
-		return TefNOT_MULTI_SIGNING
+		return ter.TefNOT_MULTI_SIGNING
 	}
 
 	signerList, parseErr := state.ParseSignerList(signerListData)
 	if parseErr != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Build a map from r-address to signer entry for O(1) lookup.
@@ -533,13 +534,13 @@ func (e *Engine) checkBatchMultiSign(accountID [20]byte, txSigners []SignerInfo)
 	for _, txSigner := range txSigners {
 		txSignerAccountID, decErr := state.DecodeAccountID(txSigner.Account)
 		if decErr != nil {
-			return TefBAD_SIGNATURE
+			return ter.TefBAD_SIGNATURE
 		}
 
 		// Look up the signer in the authorized signers map
 		authEntry, found := authorizedSigners[txSigner.Account]
 		if !found {
-			return TefBAD_SIGNATURE
+			return ter.TefBAD_SIGNATURE
 		}
 
 		// Derive account from the signer's public key
@@ -550,7 +551,7 @@ func (e *Engine) checkBatchMultiSign(accountID [20]byte, txSigners []SignerInfo)
 		} else {
 			addr, addrErr := addresscodec.EncodeClassicAddressFromPublicKeyHex(txSigner.SigningPubKey)
 			if addrErr != nil {
-				return TefBAD_SIGNATURE
+				return ter.TefBAD_SIGNATURE
 			}
 			signingAcctIDFromPubKey = addr
 		}
@@ -560,14 +561,14 @@ func (e *Engine) checkBatchMultiSign(accountID [20]byte, txSigners []SignerInfo)
 		if readErr != nil {
 			// Real storage failure — distinct from a missing account, which
 			// view.read() signals as nil data. Never fold it into the phantom branch.
-			return TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		var acct signerAccountState
 		if signerAccountData != nil {
 			signerAccountRoot, parseErr := state.ParseAccountRoot(signerAccountData)
 			if parseErr != nil {
-				return TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			acct = signerAccountState{
 				found:      true,
@@ -576,7 +577,7 @@ func (e *Engine) checkBatchMultiSign(accountID [20]byte, txSigners []SignerInfo)
 			}
 		}
 
-		if r := authorizeMultiSigner(txSigner.Account, signingAcctIDFromPubKey, acct); r != TesSUCCESS {
+		if r := authorizeMultiSigner(txSigner.Account, signingAcctIDFromPubKey, acct); r != ter.TesSUCCESS {
 			return r
 		}
 
@@ -586,8 +587,8 @@ func (e *Engine) checkBatchMultiSign(accountID [20]byte, txSigners []SignerInfo)
 
 	// Check quorum
 	if weightSum < signerList.SignerQuorum {
-		return TefBAD_QUORUM
+		return ter.TefBAD_QUORUM
 	}
 
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/preflight.go
+++ b/internal/tx/preflight.go
@@ -8,34 +8,35 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // preflight performs initial validation on the transaction.
 // Mirrors rippled Transactor::preflight() which composes preflight0/preflight1/preflight2
 // and the per-tx-type preflight. The blocks below are extracted helpers so this
 // top-level function reads as a high-level pipeline.
-func (e *Engine) preflight(tx Transaction) Result {
+func (e *Engine) preflight(tx Transaction) ter.Result {
 	common := tx.GetCommon()
 
 	// preflight0: trivial common-field presence + amendment + flag checks.
-	if result := e.preflightCommonFields(tx, common); result != TesSUCCESS {
+	if result := e.preflightCommonFields(tx, common); result != ter.TesSUCCESS {
 		return result
 	}
 
 	// preflight1 — fee, sequence, memos, structural multi-sign + signature checks.
-	if result := e.validateFee(common); result != TesSUCCESS {
+	if result := e.validateFee(common); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := e.preflightSequence(common); result != TesSUCCESS {
+	if result := e.preflightSequence(common); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := e.validateMemos(common); result != TesSUCCESS {
+	if result := e.validateMemos(common); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := e.preflightMultiSignStructure(tx, common); result != TesSUCCESS {
+	if result := e.preflightMultiSignStructure(tx, common); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := e.preflightBatchSignerStructure(tx); result != TesSUCCESS {
+	if result := e.preflightBatchSignerStructure(tx); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -57,7 +58,7 @@ func (e *Engine) preflight(tx Transaction) Result {
 	// is the final step of every tx's preflight(). A transaction that is both
 	// malformed and mis-signed therefore surfaces its type-specific tem* code,
 	// not the signature code.
-	if result := e.verifySignatures(tx); result != TesSUCCESS {
+	if result := e.verifySignatures(tx); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -65,15 +66,15 @@ func (e *Engine) preflight(tx Transaction) Result {
 	if outer, ok := tx.(BatchOuter); ok {
 		for _, inner := range outer.InnerTransactions() {
 			if inner == nil {
-				return TemINVALID_INNER_BATCH
+				return ter.TemINVALID_INNER_BATCH
 			}
-			if r := e.preflightInner(inner); r != TesSUCCESS {
-				return TemINVALID_INNER_BATCH
+			if r := e.preflightInner(inner); r != ter.TesSUCCESS {
+				return ter.TemINVALID_INNER_BATCH
 			}
 		}
 	}
 
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // BatchOuter is implemented by transaction types whose inner transactions
@@ -88,50 +89,50 @@ type BatchOuter interface {
 // Fee/signature/multi-sign/inner-flag rejections are skipped here because
 // inner txs have Fee=0, no signature, no multi-signers, and tfInnerBatchTxn
 // set; the corresponding presence checks live in Batch.Validate().
-func (e *Engine) preflightInner(innerTx Transaction) Result {
-	if result := e.preflightCommon(innerTx, innerTx.GetCommon()); result != TesSUCCESS {
+func (e *Engine) preflightInner(innerTx Transaction) ter.Result {
+	if result := e.preflightCommon(innerTx, innerTx.GetCommon()); result != ter.TesSUCCESS {
 		return result
 	}
 	if err := innerTx.Validate(); err != nil {
 		return parseValidationError(err)
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // Reference: rippled Transactor.cpp preflight0/early preflight1, plus the
 // outer-only tfInnerBatchTxn rejection on directly-submitted transactions.
-func (e *Engine) preflightCommonFields(tx Transaction, common *Common) Result {
-	if result := e.preflightCommon(tx, common); result != TesSUCCESS {
+func (e *Engine) preflightCommonFields(tx Transaction, common *Common) ter.Result {
+	if result := e.preflightCommon(tx, common); result != ter.TesSUCCESS {
 		return result
 	}
 
 	// tfInnerBatchTxn must never appear on a directly-submitted transaction.
 	// Reference: rippled Transactor.cpp preflight0().
 	if common.Flags != nil && *common.Flags&TfInnerBatchTxn != 0 {
-		return TemINVALID_FLAG
+		return ter.TemINVALID_FLAG
 	}
 
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // Shared between outer (preflightCommonFields) and inner (preflightInner).
 // The tfInnerBatchTxn rejection lives only in the outer path because inner
 // txs are required to carry that flag.
-func (e *Engine) preflightCommon(tx Transaction, common *Common) Result {
+func (e *Engine) preflightCommon(tx Transaction, common *Common) ter.Result {
 	if common.Account == "" {
-		return TemBAD_SRC_ACCOUNT
+		return ter.TemBAD_SRC_ACCOUNT
 	}
 	if common.TransactionType == "" {
-		return TemINVALID
+		return ter.TemINVALID
 	}
 
-	if result := e.validateNetworkID(common); result != TesSUCCESS {
+	if result := e.validateNetworkID(common); result != ter.TesSUCCESS {
 		return result
 	}
 
 	for _, featureID := range tx.RequiredAmendments() {
 		if !e.rules().Enabled(featureID) {
-			return TemDISABLED
+			return ter.TemDISABLED
 		}
 	}
 
@@ -144,86 +145,86 @@ func (e *Engine) preflightCommon(tx Transaction, common *Common) Result {
 	if common.SigningPubKey != "" {
 		spk, decErr := hex.DecodeString(common.SigningPubKey)
 		if decErr != nil || !IsValidPublicKey(spk) {
-			return TemBAD_SIGNATURE
+			return ter.TemBAD_SIGNATURE
 		}
 	}
 
 	// Reference: rippled Transactor.cpp preflight1() line 92.
 	if common.TicketSequence != nil && !e.rules().Enabled(amendment.FeatureTicketBatch) {
-		return TemMALFORMED
+		return ter.TemMALFORMED
 	}
 
 	// Reference: rippled Transactor.cpp preflight1() lines 101-108.
 	if common.Delegate != "" {
 		if !e.rules().Enabled(amendment.FeaturePermissionDelegation) {
-			return TemDISABLED
+			return ter.TemDISABLED
 		}
 		if common.Delegate == common.Account {
-			return TemBAD_SIGNER
+			return ter.TemBAD_SIGNER
 		}
 	}
 
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // preflightSequence enforces the Sequence/TicketSequence/AccountTxnID rules
 // from rippled Transactor::preflight1() lines 142-153.
-func (e *Engine) preflightSequence(common *Common) Result {
+func (e *Engine) preflightSequence(common *Common) ter.Result {
 	// Sequence must be present (unless using tickets)
 	if common.Sequence == nil && common.TicketSequence == nil {
-		return TemBAD_SEQUENCE
+		return ter.TemBAD_SEQUENCE
 	}
 
 	// TicketSequence + AccountTxnID is invalid
 	// Reference: rippled Transactor.cpp preflight1() line 153
 	if common.TicketSequence != nil && common.AccountTxnID != "" {
-		return TemINVALID
+		return ter.TemINVALID
 	}
 
 	// SourceTag validation - if present, it's already a uint32 via JSON parsing
 	// No additional validation needed as the type system ensures it's valid
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // preflightMultiSignStructure performs the structural multi-sign validation
 // (sort, uniqueness, self-sign rejection) that runs regardless of
 // SkipSignatureVerification.
 // Reference: rippled STTx.cpp multiSignHelper() lines 468-485
-func (e *Engine) preflightMultiSignStructure(tx Transaction, common *Common) Result {
+func (e *Engine) preflightMultiSignStructure(tx Transaction, common *Common) ter.Result {
 	if !IsMultiSigned(tx) {
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	// The signer array must lie within the rules-gated bounds. An out-of-range
 	// array is "Invalid Signers array size" in rippled's multiSignHelper, which
 	// surfaces as temBAD_SIGNATURE at the verification call site.
 	if n := len(common.Signers); n < minMultiSigners || n > MaxMultiSigners(e.rules()) {
-		return TemBAD_SIGNATURE
+		return ter.TemBAD_SIGNATURE
 	}
 	txAccountID, acctErr := state.DecodeAccountID(common.Account)
 	if acctErr != nil {
-		return TemBAD_SRC_ACCOUNT
+		return ter.TemBAD_SRC_ACCOUNT
 	}
 	var lastAccountID [20]byte // zero-initialized — less than any real ID
 	for _, sw := range common.Signers {
 		signerID, decErr := state.DecodeAccountID(sw.Signer.Account)
 		if decErr != nil {
-			return TemBAD_SIGNATURE
+			return ter.TemBAD_SIGNATURE
 		}
 		// The account owner may not multisign for themselves.
 		if signerID == txAccountID {
-			return TemBAD_SIGNATURE
+			return ter.TemBAD_SIGNATURE
 		}
 		// No duplicate signers allowed.
 		if signerID == lastAccountID {
-			return TemBAD_SIGNATURE
+			return ter.TemBAD_SIGNATURE
 		}
 		// Accounts must be in order by binary AccountID.
 		if bytes.Compare(lastAccountID[:], signerID[:]) > 0 {
-			return TemBAD_SIGNATURE
+			return ter.TemBAD_SIGNATURE
 		}
 		lastAccountID = signerID
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // preflightBatchSignerStructure enforces the rules-gated upper bound on each
@@ -232,10 +233,10 @@ func (e *Engine) preflightMultiSignStructure(tx Transaction, common *Common) Res
 // array there surfaces as temBAD_SIGNATURE at the checkBatchSign call site. The
 // crypto verification of those signers lives in Batch.Validate(), which has no
 // rules access, so the rules-dependent size bound is enforced here in preflight.
-func (e *Engine) preflightBatchSignerStructure(tx Transaction) Result {
+func (e *Engine) preflightBatchSignerStructure(tx Transaction) ter.Result {
 	bsp, ok := tx.(BatchSignerProvider)
 	if !ok {
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	maxSigners := MaxMultiSigners(e.rules())
 	for _, signer := range bsp.GetBatchSigners() {
@@ -245,22 +246,22 @@ func (e *Engine) preflightBatchSignerStructure(tx Transaction) Result {
 			continue
 		}
 		if n := len(signer.Signers); n < minMultiSigners || n > maxSigners {
-			return TemBAD_SIGNATURE
+			return ter.TemBAD_SIGNATURE
 		}
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // verifySignatures performs cryptographic signature verification (single or multi)
 // when SkipSignatureVerification is false. Authorization checks (master/regular
 // key) live in preclaim.
-func (e *Engine) verifySignatures(tx Transaction) Result {
+func (e *Engine) verifySignatures(tx Transaction) ter.Result {
 	if e.config.SkipSignatureVerification {
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	// Verify the outer single/multi-sign signature first, mirroring rippled's
 	// preflight2 (checkValidity) which precedes the batch-signer check.
-	if result := e.verifyOuterSignature(tx); result != TesSUCCESS {
+	if result := e.verifyOuterSignature(tx); result != ter.TesSUCCESS {
 		return result
 	}
 	// Batch-signer signatures are verified over the batch signing digest, the same
@@ -270,16 +271,16 @@ func (e *Engine) verifySignatures(tx Transaction) Result {
 	// SkipSignatureVerification like every other signature.
 	if bsv, ok := tx.(BatchSignatureVerifier); ok {
 		if err := bsv.VerifyBatchSignatures(); err != nil {
-			return TemBAD_SIGNATURE
+			return ter.TemBAD_SIGNATURE
 		}
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // verifyOuterSignature performs the cryptographic single/multi-sign verification
 // of the transaction's own signature. Reference: rippled STTx::checkSingleSign /
 // checkMultiSign via preflight2's checkValidity.
-func (e *Engine) verifyOuterSignature(tx Transaction) Result {
+func (e *Engine) verifyOuterSignature(tx Transaction) ter.Result {
 	// Full canonicality (low-S secp256k1) is required when RequireFullyCanonicalSig
 	// is enabled, or — independent of the amendment — when the transaction opts in
 	// via the tfFullyCanonicalSig flag.
@@ -293,19 +294,19 @@ func (e *Engine) verifyOuterSignature(tx Transaction) Result {
 			// The typed signer-verification errors carry their own Result code
 			// (ErrNotMultiSigning, ErrBadQuorum, ErrBadSignature, ErrMasterDisabled,
 			// and ErrInternalLookup for a storage/parse failure); honour it.
-			if re, ok := AsResultError(err); ok {
+			if re, ok := ter.AsResultError(err); ok {
 				return re.Code
 			}
 			// The malformed-signers sentinels are plain errors, all temBAD_SIGNATURE.
 			if errors.Is(err, ErrNoSigners) ||
 				errors.Is(err, ErrDuplicateSigner) ||
 				errors.Is(err, ErrSignersNotSorted) {
-				return TemBAD_SIGNATURE
+				return ter.TemBAD_SIGNATURE
 			}
 			// Anything else (e.g. a wrapped serialization failure) is a bad sig.
-			return TefBAD_SIGNATURE
+			return ter.TefBAD_SIGNATURE
 		}
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	// Single-signed transaction — verify cryptographic signature validity.
 	// The signing key authorization (master vs regular key) is checked in preclaim.
@@ -314,66 +315,66 @@ func (e *Engine) verifyOuterSignature(tx Transaction) Result {
 	// malformed-key-type case that does warrant temBAD_SIGNATURE is already
 	// caught unconditionally in preflight1 (preflightCommon).
 	if err := VerifySignature(tx, mustBeFullyCanonical); err != nil {
-		return TemINVALID
+		return ter.TemINVALID
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // parseValidationError maps a Validate() error to a TER result code.
 // Validators that need a specific code return *ResultError via tx.Errorf;
 // anything unstructured falls through to TemINVALID.
-func parseValidationError(err error) Result {
-	var re *ResultError
+func parseValidationError(err error) ter.Result {
+	var re *ter.ResultError
 	if errors.As(err, &re) {
 		return re.Code
 	}
-	return TemINVALID
+	return ter.TemINVALID
 }
 
 // validateNetworkID validates the NetworkID field according to rippled rules
 // - Legacy networks (ID <= 1024) cannot have NetworkID in transactions
 // - New networks (ID > 1024) require NetworkID and it must match
-func (e *Engine) validateNetworkID(common *Common) Result {
+func (e *Engine) validateNetworkID(common *Common) ter.Result {
 	nodeNetworkID := e.config.NetworkID
 	txNetworkID := common.NetworkID
 
 	if nodeNetworkID <= LegacyNetworkIDThreshold {
 		// Legacy networks cannot specify NetworkID in transactions
 		if txNetworkID != nil {
-			return TelNETWORK_ID_MAKES_TX_NON_CANONICAL
+			return ter.TelNETWORK_ID_MAKES_TX_NON_CANONICAL
 		}
 	} else {
 		// New networks require NetworkID to be present and match
 		if txNetworkID == nil {
-			return TelREQUIRES_NETWORK_ID
+			return ter.TelREQUIRES_NETWORK_ID
 		}
 		if *txNetworkID != nodeNetworkID {
-			return TelWRONG_NETWORK
+			return ter.TelWRONG_NETWORK
 		}
 	}
 
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // validateFee validates the Fee field
-func (e *Engine) validateFee(common *Common) Result {
+func (e *Engine) validateFee(common *Common) ter.Result {
 	// sfFee is a required field on every transaction (rippled TxFormats.cpp:
 	// {sfFee, soeREQUIRED}); an STTx missing it fails template validation before
 	// preflight ever runs. The engine must not invent a fee the signer never
 	// authorized, so an absent Fee is rejected here rather than defaulted.
 	if common.Fee == "" {
-		return TemBAD_FEE
+		return ter.TemBAD_FEE
 	}
 
 	// Parse fee as signed int first to detect negative values
 	feeInt, err := strconv.ParseInt(common.Fee, 10, 64)
 	if err != nil {
-		return TemBAD_FEE
+		return ter.TemBAD_FEE
 	}
 
 	// Fee cannot be negative
 	if feeInt < 0 {
-		return TemBAD_FEE
+		return ter.TemBAD_FEE
 	}
 
 	fee := uint64(feeInt)
@@ -389,16 +390,16 @@ func (e *Engine) validateFee(common *Common) Result {
 		maxFee = DefaultMaxFee
 	}
 	if fee > maxFee {
-		return TemBAD_FEE
+		return ter.TemBAD_FEE
 	}
 
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // validateMemos validates the Memos array according to rippled rules
-func (e *Engine) validateMemos(common *Common) Result {
+func (e *Engine) validateMemos(common *Common) ter.Result {
 	if len(common.Memos) == 0 {
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Calculate total serialized size of memos
@@ -412,17 +413,17 @@ func (e *Engine) validateMemos(common *Common) Result {
 			// MemoType must be a valid hex string
 			memoTypeBytes, err := hex.DecodeString(memo.MemoType)
 			if err != nil {
-				return TemINVALID
+				return ter.TemINVALID
 			}
 			// MemoType max size is 256 bytes (decoded)
 			if len(memoTypeBytes) > MaxMemoTypeSize {
-				return TemINVALID
+				return ter.TemINVALID
 			}
 			totalSize += len(memoTypeBytes)
 
 			// MemoType characters (when decoded) must be valid URL characters per RFC 3986
 			if !isValidURLBytes(memoTypeBytes) {
-				return TemINVALID
+				return ter.TemINVALID
 			}
 		}
 
@@ -431,11 +432,11 @@ func (e *Engine) validateMemos(common *Common) Result {
 			// MemoData must be a valid hex string
 			memoDataBytes, err := hex.DecodeString(memo.MemoData)
 			if err != nil {
-				return TemINVALID
+				return ter.TemINVALID
 			}
 			// MemoData max size is 1024 bytes (decoded)
 			if len(memoDataBytes) > MaxMemoDataSize {
-				return TemINVALID
+				return ter.TemINVALID
 			}
 			totalSize += len(memoDataBytes)
 			// Note: MemoData can contain any data, no character restrictions
@@ -446,23 +447,23 @@ func (e *Engine) validateMemos(common *Common) Result {
 			// MemoFormat must be a valid hex string
 			memoFormatBytes, err := hex.DecodeString(memo.MemoFormat)
 			if err != nil {
-				return TemINVALID
+				return ter.TemINVALID
 			}
 			totalSize += len(memoFormatBytes)
 
 			// MemoFormat characters (when decoded) must be valid URL characters per RFC 3986
 			if !isValidURLBytes(memoFormatBytes) {
-				return TemINVALID
+				return ter.TemINVALID
 			}
 		}
 	}
 
 	// Total memo size check
 	if totalSize > MaxMemoSize {
-		return TemINVALID
+		return ter.TemINVALID
 	}
 
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // isValidURLBytes checks if the bytes contain only characters allowed in URLs per RFC 3986

--- a/internal/tx/pseudo/enable_amendment.go
+++ b/internal/tx/pseudo/enable_amendment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -22,7 +23,7 @@ var fixTrustLinesToSelfIndexes = [...]string{
 }
 
 var (
-	ErrAmendmentMissing = tx.Errorf(tx.TemMALFORMED, "EnableAmendment missing amendment hash")
+	ErrAmendmentMissing = ter.Errorf(ter.TemMALFORMED, "EnableAmendment missing amendment hash")
 )
 
 // EnableAmendment is a pseudo-transaction that enables or tracks amendment voting.
@@ -70,12 +71,12 @@ func (e *EnableAmendment) IsPseudoTransaction() bool {
 }
 
 // Reference: rippled Change.cpp applyAmendment() lines 248-345
-func (e *EnableAmendment) Apply(ctx *tx.ApplyContext) tx.Result {
+func (e *EnableAmendment) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Reference: rippled line 251: uint256 amendment(ctx_.tx.getFieldH256(sfAmendment))
 	amendmentHash, err := parseAmendmentHash(e.Amendment)
 	if err != nil {
 		ctx.Log.Error("enable amendment: failed to parse amendment hash", "amendment", e.Amendment)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Get or create the Amendments SLE
@@ -90,7 +91,7 @@ func (e *EnableAmendment) Apply(ctx *tx.ApplyContext) tx.Result {
 	} else {
 		sle, err = ParseAmendmentsSLE(data)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
@@ -99,7 +100,7 @@ func (e *EnableAmendment) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Check if amendment is already enabled
 	// Reference: rippled lines 265-267
 	if sle.ContainsAmendment(amendmentHash) {
-		return tx.TefALREADY
+		return ter.TefALREADY
 	}
 
 	// Parse flags
@@ -112,7 +113,7 @@ func (e *EnableAmendment) Apply(ctx *tx.ApplyContext) tx.Result {
 	lostMajority := (flags & tfLostMajority) != 0
 
 	if gotMajority && lostMajority {
-		return tx.TemINVALID_FLAG
+		return ter.TemINVALID_FLAG
 	}
 
 	// Build new majorities list, filtering out the target amendment
@@ -124,7 +125,7 @@ func (e *EnableAmendment) Apply(ctx *tx.ApplyContext) tx.Result {
 		if entry.Amendment == amendmentHash {
 			if gotMajority {
 				// Already in majorities and we're trying to add again
-				return tx.TefALREADY
+				return ter.TefALREADY
 			}
 			found = true
 			// Don't copy this entry (it's being removed for lostMajority,
@@ -138,7 +139,7 @@ func (e *EnableAmendment) Apply(ctx *tx.ApplyContext) tx.Result {
 	// lostMajority but amendment wasn't in the majorities list
 	// Reference: rippled lines 300-301
 	if !found && lostMajority {
-		return tx.TefALREADY
+		return ter.TefALREADY
 	}
 
 	if found && lostMajority {
@@ -183,20 +184,20 @@ func (e *EnableAmendment) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	serialized, serErr := SerializeAmendmentsSLE(sle)
 	if serErr != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if isNew {
 		if insertErr := ctx.View.Insert(k, serialized); insertErr != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	} else {
 		if updateErr := ctx.View.Update(k, serialized); updateErr != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // activateTrustLinesToSelfFix removes the known trust-lines-to-self when the

--- a/internal/tx/pseudo/setfee.go
+++ b/internal/tx/pseudo/setfee.go
@@ -6,17 +6,18 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // SetFee errors matching rippled
 var (
-	ErrSetFeeBadSrcAccount = tx.Errorf(tx.TemBAD_SRC_ACCOUNT, "SetFee must have zero account")
-	ErrSetFeeBadFee        = tx.Errorf(tx.TemBAD_FEE, "SetFee must have zero fee")
-	ErrSetFeeBadSignature  = tx.Errorf(tx.TemBAD_SIGNATURE, "SetFee must not have signature")
-	ErrSetFeeBadSequence   = tx.Errorf(tx.TemBAD_SEQUENCE, "SetFee must have zero sequence")
-	ErrSetFeeMalformed     = tx.Errorf(tx.TemMALFORMED, "SetFee has invalid fields")
+	ErrSetFeeBadSrcAccount = ter.Errorf(ter.TemBAD_SRC_ACCOUNT, "SetFee must have zero account")
+	ErrSetFeeBadFee        = ter.Errorf(ter.TemBAD_FEE, "SetFee must have zero fee")
+	ErrSetFeeBadSignature  = ter.Errorf(ter.TemBAD_SIGNATURE, "SetFee must not have signature")
+	ErrSetFeeBadSequence   = ter.Errorf(ter.TemBAD_SEQUENCE, "SetFee must have zero sequence")
+	ErrSetFeeMalformed     = ter.Errorf(ter.TemMALFORMED, "SetFee has invalid fields")
 )
 
 // SetFee is a pseudo-transaction that updates network fee settings.
@@ -87,31 +88,31 @@ func (s *SetFee) Validate() error {
 // ReserveIncrementDrops triple is required and the legacy quad is forbidden;
 // without it, the legacy quad is required and the modern triple is forbidden.
 // Reference: rippled Change.cpp:93-133.
-func (s *SetFee) PreclaimPseudo(rules *amendment.Rules) tx.Result {
+func (s *SetFee) PreclaimPseudo(rules *amendment.Rules) ter.Result {
 	xrpFees := rules != nil && rules.XRPFeesEnabled()
 
 	if xrpFees {
 		if s.BaseFeeDrops == "" || s.ReserveBaseDrops == "" || s.ReserveIncrementDrops == "" {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 		if s.hasLegacyFields() {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 	} else {
 		if s.BaseFee == "" || s.ReferenceFeeUnits == nil || s.ReserveBase == nil || s.ReserveIncrement == nil {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 		// rippled returns temDISABLED — not temMALFORMED — when modern fields appear pre-XRPFees.
 		if s.hasModernFields() {
-			return tx.TemDISABLED
+			return ter.TemDISABLED
 		}
 	}
 
 	if _, err := s.parsedOrError(); err != nil {
-		return tx.TemMALFORMED
+		return ter.TemMALFORMED
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 func (s *SetFee) hasLegacyFields() bool {
@@ -190,7 +191,7 @@ func (s *SetFee) IsPseudoTransaction() bool {
 
 // This creates or updates the FeeSettings singleton entry.
 // Reference: rippled Change.cpp applyFee()
-func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
+func (s *SetFee) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Info("set fee apply",
 		"baseFeeDrops", s.BaseFeeDrops,
 		"reserveBaseDrops", s.ReserveBaseDrops,
@@ -206,14 +207,14 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 	// here on first access.
 	parsed, err := s.parsedOrError()
 	if err != nil {
-		return tx.TemMALFORMED
+		return ter.TemMALFORMED
 	}
 
 	feesKey := keylet.Fees()
 
 	exists, err := ctx.View.Exists(feesKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	var feeSettings *state.FeeSettings
@@ -221,12 +222,12 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 	if exists {
 		data, err := ctx.View.Read(feesKey)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		feeSettings, err = state.ParseFeeSettings(data)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	} else {
 		feeSettings = &state.FeeSettings{}
@@ -267,23 +268,23 @@ func (s *SetFee) Apply(ctx *tx.ApplyContext) tx.Result {
 	data, err := state.SerializeFeeSettings(feeSettings)
 	if err != nil {
 		ctx.Log.Error("set fee: failed to serialize fee settings", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Insert or update the FeeSettings entry
 	if exists {
 		if err := ctx.View.Update(feesKey, data); err != nil {
 			ctx.Log.Error("set fee: failed to update fee settings", "error", err)
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	} else {
 		if err := ctx.View.Insert(feesKey, data); err != nil {
 			ctx.Log.Error("set fee: failed to insert fee settings", "error", err)
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // parseDropsAmount parses a decimal drops amount string to uint64.

--- a/internal/tx/pseudo/unl_modify.go
+++ b/internal/tx/pseudo/unl_modify.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -47,23 +48,23 @@ func (u *UNLModify) IsPseudoTransaction() bool {
 }
 
 // Reference: rippled Change.cpp applyUNLModify() lines 388-512
-func (u *UNLModify) Apply(ctx *tx.ApplyContext) tx.Result {
+func (u *UNLModify) Apply(ctx *tx.ApplyContext) ter.Result {
 	// 1. Validate flag ledger
 	// Reference: rippled lines 390-395
 	if !isFlagLedger(ctx.Config.LedgerSequence) {
 		ctx.Log.Warn("unl modify: not a flag ledger",
 			"ledgerSequence", ctx.Config.LedgerSequence,
 		)
-		return tx.TefFAILURE
+		return ter.TefFAILURE
 	}
 
 	// 2. Validate required fields
 	// Reference: rippled lines 397-404
 	if u.UNLModifyDisabling == nil || *u.UNLModifyDisabling > 1 {
-		return tx.TefFAILURE
+		return ter.TefFAILURE
 	}
 	if u.LedgerSequence == nil || u.UNLModifyValidator == "" {
-		return tx.TefFAILURE
+		return ter.TefFAILURE
 	}
 
 	disabling := *u.UNLModifyDisabling == 1
@@ -77,18 +78,18 @@ func (u *UNLModify) Apply(ctx *tx.ApplyContext) tx.Result {
 	// 3. Verify LedgerSequence matches current ledger
 	// Reference: rippled lines 407-412
 	if seq != ctx.Config.LedgerSequence {
-		return tx.TefFAILURE
+		return ter.TefFAILURE
 	}
 
 	// 4. Parse and validate the validator public key
 	// Reference: rippled lines 414-419
 	validator, err := hex.DecodeString(u.UNLModifyValidator)
 	if err != nil || len(validator) == 0 {
-		return tx.TefFAILURE
+		return ter.TefFAILURE
 	}
 	// Validate public key type: ED25519 (0xED prefix, 33 bytes) or secp256k1 (0x02/0x03, 33 bytes)
 	if !isValidPublicKeyType(validator) {
-		return tx.TefFAILURE
+		return ter.TefFAILURE
 	}
 
 	// 5. Get or create the NegativeUNL SLE
@@ -104,7 +105,7 @@ func (u *UNLModify) Apply(ctx *tx.ApplyContext) tx.Result {
 	} else {
 		sle, err = ParseNegativeUNLSLE(data)
 		if err != nil {
-			return tx.TefFAILURE
+			return ter.TefFAILURE
 		}
 	}
 
@@ -118,17 +119,17 @@ func (u *UNLModify) Apply(ctx *tx.ApplyContext) tx.Result {
 
 		// Cannot have more than one ValidatorToDisable
 		if len(sle.ValidatorToDisable) > 0 {
-			return tx.TefFAILURE
+			return ter.TefFAILURE
 		}
 
 		// Cannot be the same as ValidatorToReEnable
 		if len(sle.ValidatorToReEnable) > 0 && bytes.Equal(sle.ValidatorToReEnable, validator) {
-			return tx.TefFAILURE
+			return ter.TefFAILURE
 		}
 
 		// Cannot already be in the disabled list
 		if found {
-			return tx.TefFAILURE
+			return ter.TefFAILURE
 		}
 
 		sle.ValidatorToDisable = validator
@@ -138,17 +139,17 @@ func (u *UNLModify) Apply(ctx *tx.ApplyContext) tx.Result {
 
 		// Cannot have more than one ValidatorToReEnable
 		if len(sle.ValidatorToReEnable) > 0 {
-			return tx.TefFAILURE
+			return ter.TefFAILURE
 		}
 
 		// Cannot be the same as ValidatorToDisable
 		if len(sle.ValidatorToDisable) > 0 && bytes.Equal(sle.ValidatorToDisable, validator) {
-			return tx.TefFAILURE
+			return ter.TefFAILURE
 		}
 
 		// Must be in the disabled list
 		if !found {
-			return tx.TefFAILURE
+			return ter.TefFAILURE
 		}
 
 		sle.ValidatorToReEnable = validator
@@ -158,20 +159,20 @@ func (u *UNLModify) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled line 510
 	serialized, serErr := SerializeNegativeUNLSLE(sle)
 	if serErr != nil {
-		return tx.TefFAILURE
+		return ter.TefFAILURE
 	}
 
 	if isNew {
 		if insertErr := ctx.View.Insert(k, serialized); insertErr != nil {
-			return tx.TefFAILURE
+			return ter.TefFAILURE
 		}
 	} else {
 		if updateErr := ctx.View.Update(k, serialized); updateErr != nil {
-			return tx.TefFAILURE
+			return ter.TefFAILURE
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // isFlagLedger returns true if the ledger sequence is a flag ledger (multiple of 256).

--- a/internal/tx/pseudo_gates.go
+++ b/internal/tx/pseudo_gates.go
@@ -2,6 +2,7 @@ package tx
 
 import (
 	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
@@ -9,7 +10,7 @@ import (
 // rule-aware preclaim gating beyond the generic open-ledger check.
 // Reference: rippled Change::preclaim per-tx-type switch (Change.cpp:93-139).
 type PseudoPreclaim interface {
-	PreclaimPseudo(rules *amendment.Rules) Result
+	PreclaimPseudo(rules *amendment.Rules) ter.Result
 }
 
 // pseudoPreflight enforces the gates that rippled's Change::preflight runs on
@@ -18,14 +19,14 @@ type PseudoPreclaim interface {
 // tfInnerBatchTxn rejection (Transactor.cpp:46-51) and the NetworkID check
 // when sfNetworkID is present (Transactor.cpp:53-75).
 // Reference: rippled Change.cpp:36-80, Transactor.cpp:42-87.
-func (e *Engine) pseudoPreflight(tx Transaction, rules *amendment.Rules) Result {
+func (e *Engine) pseudoPreflight(tx Transaction, rules *amendment.Rules) ter.Result {
 	common := tx.GetCommon()
 
 	// preflight0 inner-batch gate: a pseudo-tx with the tfInnerBatchTxn flag
 	// is structurally invalid because only the batch executor sets that flag.
 	// Reference: Transactor.cpp:46-51.
 	if common.Flags != nil && *common.Flags&TfInnerBatchTxn != 0 {
-		return TemINVALID_FLAG
+		return ter.TemINVALID_FLAG
 	}
 
 	// preflight0 NetworkID gate: rippled checks NetworkID for non-pseudo
@@ -35,10 +36,10 @@ func (e *Engine) pseudoPreflight(tx Transaction, rules *amendment.Rules) Result 
 	// Reference: Transactor.cpp:53-75.
 	if common.NetworkID != nil {
 		if e.config.NetworkID <= LegacyNetworkIDThreshold {
-			return TelNETWORK_ID_MAKES_TX_NON_CANONICAL
+			return ter.TelNETWORK_ID_MAKES_TX_NON_CANONICAL
 		}
 		if *common.NetworkID != e.config.NetworkID {
-			return TelWRONG_NETWORK
+			return ter.TelWRONG_NETWORK
 		}
 	}
 
@@ -48,7 +49,7 @@ func (e *Engine) pseudoPreflight(tx Transaction, rules *amendment.Rules) Result 
 	// protocol.ZeroAccount; anything else here is a caller bug.
 	// Reference: Change.cpp:43-48.
 	if common.Account != protocol.ZeroAccount {
-		return TemBAD_SRC_ACCOUNT
+		return ter.TemBAD_SRC_ACCOUNT
 	}
 
 	// Fee must decode to zero drops. Compare against the typed value rather
@@ -56,13 +57,13 @@ func (e *Engine) pseudoPreflight(tx Transaction, rules *amendment.Rules) Result 
 	// to the same beast::zero check rippled performs after parse.
 	// Reference: Change.cpp:50-56.
 	if !isZeroFee(common.Fee) {
-		return TemBAD_FEE
+		return ter.TemBAD_FEE
 	}
 
 	// No signing fields are permitted.
 	// Reference: Change.cpp:58-63.
 	if common.SigningPubKey != "" || common.TxnSignature != "" || len(common.Signers) > 0 {
-		return TemBAD_SIGNATURE
+		return ter.TemBAD_SIGNATURE
 	}
 
 	// Sequence must be zero. Rippled also rejects sfPreviousTxnID here, but
@@ -71,16 +72,16 @@ func (e *Engine) pseudoPreflight(tx Transaction, rules *amendment.Rules) Result 
 	// (Transactor::preflight1), so we do not gate on it here either.
 	// Reference: Change.cpp:65-69.
 	if common.Sequence != nil && *common.Sequence != 0 {
-		return TemBAD_SEQUENCE
+		return ter.TemBAD_SEQUENCE
 	}
 
 	// NegativeUNL amendment must be enabled for UNL_MODIFY pseudo-tx.
 	// Reference: Change.cpp:72-77.
 	if tx.TxType() == TypeUNLModify && (rules == nil || !rules.NegativeUNLEnabled()) {
-		return TemDISABLED
+		return ter.TemDISABLED
 	}
 
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // pseudoPreclaim enforces rippled Change::preclaim: pseudo-transactions are
@@ -89,24 +90,24 @@ func (e *Engine) pseudoPreflight(tx Transaction, rules *amendment.Rules) Result 
 // temUNKNOWN to mirror rippled's Change.cpp:137-139 — a new pseudo type added
 // without a PreclaimPseudo implementation must fail loudly, not silently.
 // Reference: Change.cpp:82-140.
-func (e *Engine) pseudoPreclaim(tx Transaction, rules *amendment.Rules) Result {
+func (e *Engine) pseudoPreclaim(tx Transaction, rules *amendment.Rules) ter.Result {
 	if e.config.OpenLedger {
-		return TemINVALID
+		return ter.TemINVALID
 	}
 	switch tx.TxType() {
 	case TypeAmendment, TypeUNLModify:
 		if p, ok := tx.(PseudoPreclaim); ok {
 			return p.PreclaimPseudo(rules)
 		}
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	case TypeFee:
 		p, ok := tx.(PseudoPreclaim)
 		if !ok {
-			return TemUNKNOWN
+			return ter.TemUNKNOWN
 		}
 		return p.PreclaimPseudo(rules)
 	default:
-		return TemUNKNOWN
+		return ter.TemUNKNOWN
 	}
 }
 

--- a/internal/tx/reserve.go
+++ b/internal/tx/reserve.go
@@ -1,5 +1,7 @@
 package tx
 
+import "github.com/LeJamon/go-xrpl/internal/tx/ter"
+
 // The reserve calculations live on EngineConfig as the single source of truth.
 // Both Engine and ApplyContext expose the same helpers as thin delegations so
 // callers on either side share one implementation.
@@ -34,11 +36,11 @@ func (c EngineConfig) CanCreateNewObject(priorBalance uint64, currentOwnerCount 
 
 // CheckReserveIncrease validates that an account can afford the reserve increase
 // for a new ledger object, returning TecINSUFFICIENT_RESERVE if not.
-func (c EngineConfig) CheckReserveIncrease(priorBalance uint64, currentOwnerCount uint32) Result {
+func (c EngineConfig) CheckReserveIncrease(priorBalance uint64, currentOwnerCount uint32) ter.Result {
 	if !c.CanCreateNewObject(priorBalance, currentOwnerCount) {
-		return TecINSUFFICIENT_RESERVE
+		return ter.TecINSUFFICIENT_RESERVE
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // AccountReserve calculates the total reserve required for an account with the
@@ -61,6 +63,6 @@ func (e *Engine) CanCreateNewObject(priorBalance uint64, currentOwnerCount uint3
 
 // CheckReserveIncrease validates that an account can afford the reserve increase
 // for a new ledger object. Returns TecINSUFFICIENT_RESERVE if not enough funds.
-func (e *Engine) CheckReserveIncrease(priorBalance uint64, currentOwnerCount uint32) Result {
+func (e *Engine) CheckReserveIncrease(priorBalance uint64, currentOwnerCount uint32) ter.Result {
 	return e.config.CheckReserveIncrease(priorBalance, currentOwnerCount)
 }

--- a/internal/tx/reserve.go
+++ b/internal/tx/reserve.go
@@ -42,27 +42,3 @@ func (c EngineConfig) CheckReserveIncrease(priorBalance uint64, currentOwnerCoun
 	}
 	return ter.TesSUCCESS
 }
-
-// AccountReserve calculates the total reserve required for an account with the
-// given owner count.
-func (e *Engine) AccountReserve(ownerCount uint32) uint64 {
-	return e.config.AccountReserve(ownerCount)
-}
-
-// ReserveForNewObject calculates the reserve required for creating a new ledger
-// object (the first 2 objects are free).
-func (e *Engine) ReserveForNewObject(currentOwnerCount uint32) uint64 {
-	return e.config.ReserveForNewObject(currentOwnerCount)
-}
-
-// CanCreateNewObject reports whether the prior balance covers the reserve for a
-// new ledger object.
-func (e *Engine) CanCreateNewObject(priorBalance uint64, currentOwnerCount uint32) bool {
-	return e.config.CanCreateNewObject(priorBalance, currentOwnerCount)
-}
-
-// CheckReserveIncrease validates that an account can afford the reserve increase
-// for a new ledger object. Returns TecINSUFFICIENT_RESERVE if not enough funds.
-func (e *Engine) CheckReserveIncrease(priorBalance uint64, currentOwnerCount uint32) ter.Result {
-	return e.config.CheckReserveIncrease(priorBalance, currentOwnerCount)
-}

--- a/internal/tx/reserve_test.go
+++ b/internal/tx/reserve_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // TestReserveCalculations tests reserve calculation logic.
@@ -109,12 +110,12 @@ func TestCheckReserveWithFeeDelegatedBoundary(t *testing.T) {
 	acct := &state.AccountRoot{Balance: reserveFor3 - 1}
 
 	delegated := &ApplyContext{Account: acct, Config: cfg, SourceFeeCharged: 0}
-	if got := delegated.CheckReserveWithFee(3); got != TecINSUFFICIENT_RESERVE {
+	if got := delegated.CheckReserveWithFee(3); got != ter.TecINSUFFICIENT_RESERVE {
 		t.Fatalf("delegated boundary: got %v, want TecINSUFFICIENT_RESERVE", got)
 	}
 
 	normal := &ApplyContext{Account: acct, Config: cfg, SourceFeeCharged: fee}
-	if got := normal.CheckReserveWithFee(3); got != TesSUCCESS {
+	if got := normal.CheckReserveWithFee(3); got != ter.TesSUCCESS {
 		t.Fatalf("normal boundary: got %v, want TesSUCCESS", got)
 	}
 }
@@ -262,7 +263,7 @@ func TestCheckReserveIncrease(t *testing.T) {
 		reserveIncrement uint64
 		priorBalance     uint64
 		currentOwners    uint32
-		expectedResult   Result
+		expectedResult   ter.Result
 	}{
 		{
 			name:             "first object - always succeeds",
@@ -270,7 +271,7 @@ func TestCheckReserveIncrease(t *testing.T) {
 			reserveIncrement: 2000000,
 			priorBalance:     1,
 			currentOwners:    0,
-			expectedResult:   TesSUCCESS,
+			expectedResult:   ter.TesSUCCESS,
 		},
 		{
 			name:             "second object - always succeeds",
@@ -278,7 +279,7 @@ func TestCheckReserveIncrease(t *testing.T) {
 			reserveIncrement: 2000000,
 			priorBalance:     1,
 			currentOwners:    1,
-			expectedResult:   TesSUCCESS,
+			expectedResult:   ter.TesSUCCESS,
 		},
 		{
 			name:             "third object - insufficient reserve",
@@ -286,7 +287,7 @@ func TestCheckReserveIncrease(t *testing.T) {
 			reserveIncrement: 2000000,
 			priorBalance:     15000000, // 15 XRP, need 16 XRP
 			currentOwners:    2,
-			expectedResult:   TecINSUFFICIENT_RESERVE,
+			expectedResult:   ter.TecINSUFFICIENT_RESERVE,
 		},
 		{
 			name:             "third object - sufficient reserve",
@@ -294,7 +295,7 @@ func TestCheckReserveIncrease(t *testing.T) {
 			reserveIncrement: 2000000,
 			priorBalance:     20000000, // 20 XRP
 			currentOwners:    2,
-			expectedResult:   TesSUCCESS,
+			expectedResult:   ter.TesSUCCESS,
 		},
 	}
 

--- a/internal/tx/result_failed_processing_test.go
+++ b/internal/tx/result_failed_processing_test.go
@@ -1,6 +1,10 @@
 package tx
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
 
 // TestTelFailedProcessing_LocalHoldClassification locks the submit-path
 // contract the open-ledger FAILED_PROCESSING guard relies on: a
@@ -14,7 +18,7 @@ import "testing"
 // submission is still held. tel is never applied, so it is held but neither
 // relayed nor charged — matching rippled NetworkOPs.cpp:1674-1689.
 func TestTelFailedProcessing_LocalHoldClassification(t *testing.T) {
-	r := TelFAILED_PROCESSING
+	r := ter.TelFAILED_PROCESSING
 
 	if r.IsApplied() {
 		t.Fatalf("telFAILED_PROCESSING must not be applied (no fee claimed, not relayed)")
@@ -28,7 +32,7 @@ func TestTelFailedProcessing_LocalHoldClassification(t *testing.T) {
 
 	// The closed-view variant is a tec: it claims a fee and is applied, the
 	// behaviour consensus apply must keep producing on the closed-view path.
-	c := TecFAILED_PROCESSING
+	c := ter.TecFAILED_PROCESSING
 	if !c.IsTec() || !c.IsApplied() {
 		t.Fatalf("tecFAILED_PROCESSING must claim a fee and be applied on the closed-view path")
 	}

--- a/internal/tx/serialize_deliveredamount_test.go
+++ b/internal/tx/serialize_deliveredamount_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // Regression for the mixed-network empty-tx-tree fork: binary metadata
@@ -21,7 +22,7 @@ func TestSerializeMetadata_DeliveredAmount(t *testing.T) {
 	t.Run("XRP", func(t *testing.T) {
 		amt := state.NewXRPAmountFromInt(1_000_000)
 		meta := &Metadata{
-			TransactionResult: TesSUCCESS,
+			TransactionResult: ter.TesSUCCESS,
 			TransactionIndex:  0,
 			AffectedNodes:     []AffectedNode{},
 			DeliveredAmount:   &amt,
@@ -45,7 +46,7 @@ func TestSerializeMetadata_DeliveredAmount(t *testing.T) {
 	t.Run("IOU", func(t *testing.T) {
 		amt := state.NewIssuedAmountFromValue(10, 0, "USD", "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh")
 		meta := &Metadata{
-			TransactionResult: TesSUCCESS,
+			TransactionResult: ter.TesSUCCESS,
 			TransactionIndex:  0,
 			AffectedNodes:     []AffectedNode{},
 			DeliveredAmount:   &amt,

--- a/internal/tx/sign/signature.go
+++ b/internal/tx/sign/signature.go
@@ -1,4 +1,4 @@
-package tx
+package sign
 
 import (
 	"bytes"
@@ -10,7 +10,10 @@ import (
 	"strings"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/crypto/ed25519"
 	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
@@ -97,7 +100,7 @@ var ErrInternalLookup = ter.Errorf(ter.TefINTERNAL, "internal error during signe
 
 // IsMultiSigned returns true if the transaction is multi-signed
 // A transaction is multi-signed if it has a Signers array and an empty SigningPubKey
-func IsMultiSigned(tx Transaction) bool {
+func IsMultiSigned(tx txcore.Transaction) bool {
 	common := tx.GetCommon()
 	return len(common.Signers) > 0 && common.SigningPubKey == ""
 }
@@ -109,7 +112,7 @@ func IsMultiSigned(tx Transaction) bool {
 // mustBeFullyCanonical requires secp256k1 signatures to be low-S. The caller
 // derives it from the RequireFullyCanonicalSig amendment and the per-tx
 // tfFullyCanonicalSig flag (rippled apply.cpp:78-84 + STTx::checkSingleSign).
-func VerifySignature(tx Transaction, mustBeFullyCanonical bool) error {
+func VerifySignature(tx txcore.Transaction, mustBeFullyCanonical bool) error {
 	common := tx.GetCommon()
 
 	// Check if this is a multi-signed transaction
@@ -160,7 +163,7 @@ func VerifySignature(tx Transaction, mustBeFullyCanonical bool) error {
 //
 // mustBeFullyCanonical requires each secp256k1 signer signature to be low-S
 // (see VerifySignature).
-func VerifyMultiSignature(tx Transaction, lookup SignerListLookup, mustBeFullyCanonical bool) error {
+func VerifyMultiSignature(tx txcore.Transaction, lookup SignerListLookup, mustBeFullyCanonical bool) error {
 	common := tx.GetCommon()
 
 	// Verify this is actually a multi-signed transaction
@@ -333,7 +336,7 @@ func copyMap(m map[string]any) map[string]any {
 }
 
 // getSigningPayload returns the binary data that should be signed
-func getSigningPayload(tx Transaction) (string, error) {
+func getSigningPayload(tx txcore.Transaction) (string, error) {
 	// Flatten the transaction to a map
 	txMap, err := tx.Flatten()
 	if err != nil {
@@ -388,7 +391,7 @@ func verifySignatureForKey(messageHex, pubKeyHex, signatureHex string, mustBeFul
 
 // SignTransaction signs a transaction with the given private key
 // Returns the signature as a hex string
-func SignTransaction(tx Transaction, privateKeyHex string) (string, error) {
+func SignTransaction(tx txcore.Transaction, privateKeyHex string) (string, error) {
 	// Get the signing payload
 	signingPayload, err := getSigningPayload(tx)
 	if err != nil {
@@ -449,7 +452,7 @@ func CalculateMultiSigFee(baseFee uint64, numSigners int) uint64 {
 // SignTransactionForMultiSign signs a transaction for multi-signing
 // Each signer signs a message that includes their account ID as a suffix
 // Returns the signature as a hex string
-func SignTransactionForMultiSign(tx Transaction, signerAccount string, privateKeyHex string) (string, error) {
+func SignTransactionForMultiSign(tx txcore.Transaction, signerAccount string, privateKeyHex string) (string, error) {
 	// Flatten the transaction to a map
 	txMap, err := tx.Flatten()
 	if err != nil {
@@ -509,7 +512,7 @@ func SignTransactionForMultiSign(tx Transaction, signerAccount string, privateKe
 // AddMultiSigner adds a signer to a transaction's Signers array
 // The signer should have already signed the transaction using SignTransactionForMultiSign
 // Signers are maintained in sorted order by binary AccountID, matching rippled.
-func AddMultiSigner(tx Transaction, account, publicKey, signature string) error {
+func AddMultiSigner(tx txcore.Transaction, account, publicKey, signature string) error {
 	common := tx.GetCommon()
 
 	// Clear single-signature fields if this is the first multi-signer
@@ -525,8 +528,8 @@ func AddMultiSigner(tx Transaction, account, publicKey, signature string) error 
 	}
 
 	// Create the new signer entry
-	newSigner := SignerWrapper{
-		Signer: Signer{
+	newSigner := txcore.SignerWrapper{
+		Signer: txcore.Signer{
 			Account:       account,
 			SigningPubKey: publicKey,
 			TxnSignature:  signature,
@@ -551,7 +554,7 @@ func AddMultiSigner(tx Transaction, account, publicKey, signature string) error 
 	}
 
 	// Insert at the correct position
-	common.Signers = append(common.Signers, SignerWrapper{})
+	common.Signers = append(common.Signers, txcore.SignerWrapper{})
 	copy(common.Signers[insertPos+1:], common.Signers[insertPos:])
 	common.Signers[insertPos] = newSigner
 

--- a/internal/tx/sign/signature_lookup_886_test.go
+++ b/internal/tx/sign/signature_lookup_886_test.go
@@ -1,8 +1,10 @@
-package tx
+package sign
 
 import (
 	"errors"
 	"testing"
+
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -31,7 +33,7 @@ func (s *stubSignerLookup) GetAccountInfo(account string) (uint32, string, error
 // consulted before the signature is verified, so a lookup error short-circuits
 // ahead of crypto. EncodeClassicAddressFromPublicKeyHex only hashes the bytes,
 // so any valid 33-byte key yields a deterministic address.
-func multiSignedTxForLookup(t *testing.T) (Transaction, string) {
+func multiSignedTxForLookup(t *testing.T) (txcore.Transaction, string) {
 	t.Helper()
 	const signerPub = "ED0000000000000000000000000000000000000000000000000000000000000001"
 	signerAddr, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(signerPub)
@@ -39,10 +41,10 @@ func multiSignedTxForLookup(t *testing.T) (Transaction, string) {
 		t.Fatalf("derive signer address: %v", err)
 	}
 
-	tx := NewBaseTx(TypeAccountSet, signerAddr)
+	tx := txcore.NewBaseTx(txcore.TypeAccountSet, signerAddr)
 	tx.Common.SigningPubKey = "" // multi-signed: empty top-level signing key
-	tx.Common.Signers = []SignerWrapper{
-		{Signer: Signer{
+	tx.Common.Signers = []txcore.SignerWrapper{
+		{Signer: txcore.Signer{
 			Account:       signerAddr,
 			SigningPubKey: signerPub,
 			TxnSignature:  "00", // bogus; never reached when lookup errors
@@ -133,10 +135,10 @@ func TestVerifyMultiSignature_RegularKeyStorageErrorIsInternal(t *testing.T) {
 		t.Fatal("test setup: signer account collided with pubkey-derived address")
 	}
 
-	tx := NewBaseTx(TypeAccountSet, signerAddr)
+	tx := txcore.NewBaseTx(txcore.TypeAccountSet, signerAddr)
 	tx.Common.SigningPubKey = ""
-	tx.Common.Signers = []SignerWrapper{
-		{Signer: Signer{Account: signerAddr, SigningPubKey: signerPub, TxnSignature: "00"}},
+	tx.Common.Signers = []txcore.SignerWrapper{
+		{Signer: txcore.Signer{Account: signerAddr, SigningPubKey: signerPub, TxnSignature: "00"}},
 	}
 
 	storageErr := errors.New("kvstore: disk read failed")

--- a/internal/tx/sign/signer_lookup.go
+++ b/internal/tx/sign/signer_lookup.go
@@ -1,9 +1,10 @@
-package tx
+package sign
 
 import (
 	"errors"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -74,7 +75,7 @@ func AuthorizeMultiSigner(signerAccount, derivedAccount string, acct SignerAccou
 
 // EngineSignerListLookup implements SignerListLookup using the engine's ledger view
 type EngineSignerListLookup struct {
-	View LedgerView
+	View txcore.LedgerView
 }
 
 // GetSignerList returns the signer list for an account

--- a/internal/tx/signature.go
+++ b/internal/tx/signature.go
@@ -22,7 +22,7 @@ import (
 // STTx::minMultiSigners / STTx::maxMultiSigners. The maximum is amendment-gated:
 // featureExpandedSignerList raises it from 8 to 32.
 const (
-	minMultiSigners    = 1
+	MinMultiSigners    = 1
 	maxSignersBase     = 8
 	maxSignersExpanded = 32
 )
@@ -282,17 +282,17 @@ func VerifyMultiSignature(tx Transaction, lookup SignerListLookup, mustBeFullyCa
 		// authorization decision then renders the phantom/master/regular-key
 		// verdict (rippled Transactor::checkMultiSign).
 		flags, regularKey, lookupErr := lookup.GetAccountInfo(txSignerAccount)
-		var acct signerAccountState
+		var acct SignerAccountState
 		switch {
 		case lookupErr == nil:
-			acct = signerAccountState{found: true, flags: flags, regularKey: regularKey}
+			acct = SignerAccountState{found: true, flags: flags, regularKey: regularKey}
 		case errors.Is(lookupErr, ErrAccountNotFound):
 			// Account absent — phantom branch (found stays false).
 		default:
 			// Real storage/parse failure — never silently allow the signer.
 			return ErrInternalLookup
 		}
-		switch authorizeMultiSigner(txSignerAccount, signingAcctIDFromPubKey, acct) {
+		switch AuthorizeMultiSigner(txSignerAccount, signingAcctIDFromPubKey, acct) {
 		case ter.TesSUCCESS:
 			// Authorized — continue to crypto verification.
 		case ter.TefMASTER_DISABLED:

--- a/internal/tx/signature.go
+++ b/internal/tx/signature.go
@@ -15,6 +15,7 @@ import (
 	"github.com/LeJamon/go-xrpl/crypto/ed25519"
 	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // Bounds on the size of a multi-signer array, mirroring rippled
@@ -49,16 +50,16 @@ var (
 // Multi-signature specific errors (matching rippled error codes)
 var (
 	// ErrNotMultiSigning is returned when the account has no signer list (tefNOT_MULTI_SIGNING)
-	ErrNotMultiSigning = Errorf(TefNOT_MULTI_SIGNING, "account is not configured for multi-signing")
+	ErrNotMultiSigning = ter.Errorf(ter.TefNOT_MULTI_SIGNING, "account is not configured for multi-signing")
 
 	// ErrBadQuorum is returned when signers fail to meet the quorum (tefBAD_QUORUM)
-	ErrBadQuorum = Errorf(TefBAD_QUORUM, "signers failed to meet quorum")
+	ErrBadQuorum = ter.Errorf(ter.TefBAD_QUORUM, "signers failed to meet quorum")
 
 	// ErrBadSignature is returned when a multi-sig signature is invalid (tefBAD_SIGNATURE)
-	ErrBadSignature = Errorf(TefBAD_SIGNATURE, "invalid signer or signature")
+	ErrBadSignature = ter.Errorf(ter.TefBAD_SIGNATURE, "invalid signer or signature")
 
 	// ErrMasterDisabled is returned when trying to sign with a disabled master key (tefMASTER_DISABLED)
-	ErrMasterDisabled = Errorf(TefMASTER_DISABLED, "master key is disabled for this signer")
+	ErrMasterDisabled = ter.Errorf(ter.TefMASTER_DISABLED, "master key is disabled for this signer")
 
 	// ErrNoSigners is returned when Signers array is empty
 	ErrNoSigners = errors.New("multi-signed transaction has no signers")
@@ -92,7 +93,7 @@ type SignerListLookup interface {
 // authorization so that VerifyMultiSignature can map it to tefINTERNAL. It is
 // distinct from ErrBadSignature (an unauthorized signer) and from the
 // not-found case, which is the legitimate phantom-account branch.
-var ErrInternalLookup = Errorf(TefINTERNAL, "internal error during signer lookup")
+var ErrInternalLookup = ter.Errorf(ter.TefINTERNAL, "internal error during signer lookup")
 
 // IsMultiSigned returns true if the transaction is multi-signed
 // A transaction is multi-signed if it has a Signers array and an empty SigningPubKey
@@ -292,9 +293,9 @@ func VerifyMultiSignature(tx Transaction, lookup SignerListLookup, mustBeFullyCa
 			return ErrInternalLookup
 		}
 		switch authorizeMultiSigner(txSignerAccount, signingAcctIDFromPubKey, acct) {
-		case TesSUCCESS:
+		case ter.TesSUCCESS:
 			// Authorized — continue to crypto verification.
-		case TefMASTER_DISABLED:
+		case ter.TefMASTER_DISABLED:
 			return ErrMasterDisabled
 		default:
 			return ErrBadSignature

--- a/internal/tx/signature_lookup_886_test.go
+++ b/internal/tx/signature_lookup_886_test.go
@@ -6,6 +6,7 @@ import (
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // stubSignerLookup is a SignerListLookup whose two methods are driven by
@@ -81,8 +82,8 @@ func TestVerifyMultiSignature_StorageErrorIsInternal(t *testing.T) {
 		t.Fatal("expected error on storage failure, got nil (signer was accepted)")
 	}
 
-	re, ok := AsResultError(err)
-	if !ok || re.Code != TefINTERNAL {
+	re, ok := ter.AsResultError(err)
+	if !ok || re.Code != ter.TefINTERNAL {
 		t.Fatalf("storage error must map to tefINTERNAL, got %v", err)
 	}
 	if errors.Is(err, ErrBadSignature) || errors.Is(err, ErrMasterDisabled) {
@@ -106,7 +107,7 @@ func TestVerifyMultiSignature_NotFoundTakesPhantomPath(t *testing.T) {
 	if err != ErrBadSignature {
 		t.Fatalf("phantom signer with bogus signature should yield ErrBadSignature, got %v", err)
 	}
-	if re, ok := AsResultError(err); ok && re.Code == TefINTERNAL {
+	if re, ok := ter.AsResultError(err); ok && re.Code == ter.TefINTERNAL {
 		t.Fatal("not-found must not be reported as tefINTERNAL")
 	}
 }
@@ -144,8 +145,8 @@ func TestVerifyMultiSignature_RegularKeyStorageErrorIsInternal(t *testing.T) {
 	})
 
 	verr := VerifyMultiSignature(tx, lookup, false)
-	re, ok := AsResultError(verr)
-	if !ok || re.Code != TefINTERNAL {
+	re, ok := ter.AsResultError(verr)
+	if !ok || re.Code != ter.TefINTERNAL {
 		t.Fatalf("regular-key storage error must map to tefINTERNAL, got %v", verr)
 	}
 }

--- a/internal/tx/signer_lookup.go
+++ b/internal/tx/signer_lookup.go
@@ -16,14 +16,21 @@ import (
 // the signer.
 var ErrAccountNotFound = errors.New("account not found")
 
-// signerAccountState is the resolved ledger state of a multi-sign signer's
+// SignerAccountState is the resolved ledger state of a multi-sign signer's
 // account, as consumed by the shared authorization decision. found=false marks
 // a phantom account (absent from the ledger); when found, flags and regularKey
 // carry the values needed for the master/regular-key decision.
-type signerAccountState struct {
+type SignerAccountState struct {
 	found      bool
 	flags      uint32
 	regularKey string
+}
+
+// NewSignerAccountState builds a resolved signer account state. found=false
+// marks a phantom account; otherwise flags and regularKey carry the values the
+// master/regular-key decision needs.
+func NewSignerAccountState(found bool, flags uint32, regularKey string) SignerAccountState {
+	return SignerAccountState{found: found, flags: flags, regularKey: regularKey}
 }
 
 // authorizeMultiSigner is the single source of truth for the multi-sign signer
@@ -50,7 +57,7 @@ type signerAccountState struct {
 // Sortedness/duplicate/quorum and crypto verification are the callers'
 // responsibility — this function only renders the per-signer authorization
 // verdict.
-func authorizeMultiSigner(signerAccount, derivedAccount string, acct signerAccountState) ter.Result {
+func AuthorizeMultiSigner(signerAccount, derivedAccount string, acct SignerAccountState) ter.Result {
 	if derivedAccount == signerAccount {
 		// Phantom or Master key. Phantoms (absent account) always pass.
 		if acct.found && acct.flags&state.LsfDisableMaster != 0 {
@@ -65,13 +72,13 @@ func authorizeMultiSigner(signerAccount, derivedAccount string, acct signerAccou
 	return ter.TesSUCCESS
 }
 
-// engineSignerListLookup implements SignerListLookup using the engine's ledger view
-type engineSignerListLookup struct {
-	view LedgerView
+// EngineSignerListLookup implements SignerListLookup using the engine's ledger view
+type EngineSignerListLookup struct {
+	View LedgerView
 }
 
 // GetSignerList returns the signer list for an account
-func (l *engineSignerListLookup) GetSignerList(account string) (*state.SignerListInfo, error) {
+func (l *EngineSignerListLookup) GetSignerList(account string) (*state.SignerListInfo, error) {
 	accountID, err := state.DecodeAccountID(account)
 	if err != nil {
 		return nil, err
@@ -79,7 +86,7 @@ func (l *engineSignerListLookup) GetSignerList(account string) (*state.SignerLis
 
 	// Look up the signer list (SignerListID is always 0 currently)
 	signerListKey := keylet.SignerList(accountID)
-	exists, err := l.view.Exists(signerListKey)
+	exists, err := l.View.Exists(signerListKey)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +95,7 @@ func (l *engineSignerListLookup) GetSignerList(account string) (*state.SignerLis
 	}
 
 	// Read and parse the signer list
-	signerListData, err := l.view.Read(signerListKey)
+	signerListData, err := l.View.Read(signerListKey)
 	if err != nil {
 		return nil, err
 	}
@@ -102,14 +109,14 @@ func (l *engineSignerListLookup) GetSignerList(account string) (*state.SignerLis
 }
 
 // GetAccountInfo returns account information needed for signer validation
-func (l *engineSignerListLookup) GetAccountInfo(account string) (flags uint32, regularKey string, err error) {
+func (l *EngineSignerListLookup) GetAccountInfo(account string) (flags uint32, regularKey string, err error) {
 	accountID, err := state.DecodeAccountID(account)
 	if err != nil {
 		return 0, "", err
 	}
 
 	accountKey := keylet.Account(accountID)
-	accountData, err := l.view.Read(accountKey)
+	accountData, err := l.View.Read(accountKey)
 	if err != nil {
 		return 0, "", err
 	}

--- a/internal/tx/signer_lookup.go
+++ b/internal/tx/signer_lookup.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -49,19 +50,19 @@ type signerAccountState struct {
 // Sortedness/duplicate/quorum and crypto verification are the callers'
 // responsibility — this function only renders the per-signer authorization
 // verdict.
-func authorizeMultiSigner(signerAccount, derivedAccount string, acct signerAccountState) Result {
+func authorizeMultiSigner(signerAccount, derivedAccount string, acct signerAccountState) ter.Result {
 	if derivedAccount == signerAccount {
 		// Phantom or Master key. Phantoms (absent account) always pass.
 		if acct.found && acct.flags&state.LsfDisableMaster != 0 {
-			return TefMASTER_DISABLED
+			return ter.TefMASTER_DISABLED
 		}
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	// Regular key: the account must exist and its RegularKey must match.
 	if !acct.found || acct.regularKey == "" || derivedAccount != acct.regularKey {
-		return TefBAD_SIGNATURE
+		return ter.TefBAD_SIGNATURE
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // engineSignerListLookup implements SignerListLookup using the engine's ledger view

--- a/internal/tx/signerlist/signer_list_set.go
+++ b/internal/tx/signerlist/signer_list_set.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -64,7 +65,7 @@ func (s *SignerListSet) Validate() error {
 	case s.SignerQuorum == 0 && !hasEntries:
 		return nil
 	default:
-		return tx.Errorf(tx.TemMALFORMED, "invalid signer set list format")
+		return ter.Errorf(ter.TemMALFORMED, "invalid signer set list format")
 	}
 }
 
@@ -74,19 +75,19 @@ func (s *SignerListSet) Validate() error {
 // when the amendment is enabled, and a reachable quorum. The check order matches
 // rippled so a transaction malformed in more than one way reports the same TER.
 // Reference: rippled SetSignerList.cpp:260-330 validateQuorumAndSignerEntries
-func (s *SignerListSet) validateQuorumAndSignerEntries(expandedSignerList bool) tx.Result {
+func (s *SignerListSet) validateQuorumAndSignerEntries(expandedSignerList bool) ter.Result {
 	maxEntries := 32
 	if !expandedSignerList {
 		maxEntries = 8
 	}
 	if len(s.SignerEntries) < 1 || len(s.SignerEntries) > maxEntries {
-		return tx.TemMALFORMED
+		return ter.TemMALFORMED
 	}
 
 	seen := make(map[string]bool, len(s.SignerEntries))
 	for _, e := range s.SignerEntries {
 		if seen[e.SignerEntry.Account] {
-			return tx.TemBAD_SIGNER
+			return ter.TemBAD_SIGNER
 		}
 		seen[e.SignerEntry.Account] = true
 	}
@@ -94,21 +95,21 @@ func (s *SignerListSet) validateQuorumAndSignerEntries(expandedSignerList bool) 
 	var totalWeight uint64
 	for _, e := range s.SignerEntries {
 		if e.SignerEntry.SignerWeight == 0 {
-			return tx.TemBAD_WEIGHT
+			return ter.TemBAD_WEIGHT
 		}
 		totalWeight += uint64(e.SignerEntry.SignerWeight)
 		if e.SignerEntry.Account == s.Account {
-			return tx.TemBAD_SIGNER
+			return ter.TemBAD_SIGNER
 		}
 		if e.SignerEntry.WalletLocator != "" && !expandedSignerList {
-			return tx.TemMALFORMED
+			return ter.TemMALFORMED
 		}
 	}
 
 	if totalWeight < uint64(s.SignerQuorum) {
-		return tx.TemBAD_QUORUM
+		return ter.TemBAD_QUORUM
 	}
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 func (s *SignerListSet) Flatten() (map[string]any, error) {
@@ -151,7 +152,7 @@ func (s *SetRegularKey) Validate() error {
 	}
 	// SetRegularKey has no type-specific flags.
 	if s.GetFlags()&tx.TfUniversalMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid flags for SetRegularKey")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for SetRegularKey")
 	}
 	return nil
 }
@@ -171,12 +172,12 @@ func (s *SetRegularKey) ClearKey() {
 }
 
 // Reference: rippled SetRegularKey.cpp preflight + doApply()
-func (s *SetRegularKey) Apply(ctx *tx.ApplyContext) tx.Result {
+func (s *SetRegularKey) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Amendment-gated preflight check: reject setting RegularKey to own account.
 	// Reference: rippled SetRegularKey.cpp preflight lines 66-71
 	if ctx.Rules().Enabled(amendment.FeatureFixMasterKeyAsRegularKey) {
 		if s.RegularKey != "" && s.RegularKey == s.Account {
-			return tx.TemBAD_REGKEY
+			return ter.TemBAD_REGKEY
 		}
 	}
 
@@ -187,7 +188,7 @@ func (s *SetRegularKey) Apply(ctx *tx.ApplyContext) tx.Result {
 		)
 		// Setting a regular key
 		if _, err := state.DecodeAccountID(s.RegularKey); err != nil {
-			return tx.TemINVALID
+			return ter.TemINVALID
 		}
 		ctx.Account.RegularKey = s.RegularKey
 	} else {
@@ -203,7 +204,7 @@ func (s *SetRegularKey) Apply(ctx *tx.ApplyContext) tx.Result {
 			hasSignerList, _ := ctx.View.Exists(signerListKey)
 			if !hasSignerList {
 				ctx.Log.Warn("set regular key: no alternative key available")
-				return tx.TecNO_ALTERNATIVE_KEY
+				return ter.TecNO_ALTERNATIVE_KEY
 			}
 		}
 		ctx.Account.RegularKey = ""
@@ -220,27 +221,27 @@ func (s *SetRegularKey) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Account.Flags |= state.LsfPasswordSpent
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // removeSignersFromLedger removes the existing signer list from the ledger,
 // adjusting the owner count based on whether lsfOneOwnerCount is set.
 // Reference: rippled SetSignerList.cpp removeSignersFromLedger()
-func removeSignersFromLedger(ctx *tx.ApplyContext, signerListKey, ownerDirKey keylet.Keylet) tx.Result {
+func removeSignersFromLedger(ctx *tx.ApplyContext, signerListKey, ownerDirKey keylet.Keylet) ter.Result {
 	exists, _ := ctx.View.Exists(signerListKey)
 	if !exists {
 		// If the signer list doesn't exist we've already succeeded in deleting it.
-		return tx.TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	// Read the existing signer list to determine the owner count adjustment.
 	signerListData, err := ctx.View.Read(signerListKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	signerList, err := state.ParseSignerList(signerListData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// There are two different ways that the OwnerCount could be managed.
@@ -270,10 +271,10 @@ func removeSignersFromLedger(ctx *tx.ApplyContext, signerListKey, ownerDirKey ke
 
 	// Erase the signer list.
 	if err := ctx.View.Erase(signerListKey); err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // signerCountBasedOwnerCountDelta computes the OwnerCount cost for a signer list
@@ -285,12 +286,12 @@ func signerCountBasedOwnerCountDelta(entryCount int) int {
 }
 
 // Reference: rippled SetSignerList.cpp preflight() + doApply(), replaceSignerList(), destroySignerList()
-func (s *SignerListSet) Apply(ctx *tx.ApplyContext) tx.Result {
+func (s *SignerListSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Check for invalid flags, gated behind fixInvalidTxFlags.
 	// Reference: rippled SetSignerList.cpp preflight() lines 86-91
 	if ctx.Rules().Enabled(amendment.FeatureFixInvalidTxFlags) {
 		if s.GetFlags()&tx.TfUniversalMask != 0 {
-			return tx.TemINVALID_FLAG
+			return ter.TemINVALID_FLAG
 		}
 	}
 
@@ -315,7 +316,7 @@ func (s *SignerListSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		hasRegularKey := ctx.Account.RegularKey != ""
 		if isMasterDisabled && !hasRegularKey {
 			ctx.Log.Warn("signer list set: no alternative key available")
-			return tx.TecNO_ALTERNATIVE_KEY
+			return ter.TecNO_ALTERNATIVE_KEY
 		}
 
 		return removeSignersFromLedger(ctx, signerListKey, ownerDirKey)
@@ -329,13 +330,13 @@ func (s *SignerListSet) Apply(ctx *tx.ApplyContext) tx.Result {
 	// runs here — which also covers batch inner transactions, since they reach
 	// Apply but not Preclaim.
 	expandedSignerList := ctx.Rules().Enabled(amendment.FeatureExpandedSignerList)
-	if r := s.validateQuorumAndSignerEntries(expandedSignerList); r != tx.TesSUCCESS {
+	if r := s.validateQuorumAndSignerEntries(expandedSignerList); r != ter.TesSUCCESS {
 		return r
 	}
 
 	// Preemptively remove any old signer list. May reduce the reserve,
 	// so this is done before checking the reserve.
-	if result := removeSignersFromLedger(ctx, signerListKey, ownerDirKey); result != tx.TesSUCCESS {
+	if result := removeSignersFromLedger(ctx, signerListKey, ownerDirKey); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -362,7 +363,7 @@ func (s *SignerListSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			"balance", priorBalance,
 			"reserve", newReserve,
 		)
-		return tx.TecINSUFFICIENT_RESERVE
+		return ter.TecINSUFFICIENT_RESERVE
 	}
 
 	// Build the signer entries for serialization.
@@ -392,22 +393,22 @@ func (s *SignerListSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		dir.Owner = ctx.AccountID
 	})
 	if err != nil {
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 
 	signerListData, err := state.SerializeSignerList(s.SignerQuorum, sleEntries, flags, expandedSignerList, dirResult.Page)
 	if err != nil {
 		ctx.Log.Error("signer list set: failed to serialize signer list", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	if err := ctx.View.Insert(signerListKey, signerListData); err != nil {
 		ctx.Log.Error("signer list set: failed to insert signer list", "error", err)
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Adjust owner count.
 	ctx.Account.OwnerCount += uint32(addedOwnerCount)
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/signerlist/signer_list_set_test.go
+++ b/internal/tx/signerlist/signer_list_set_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 const walletLocatorHex = "00000000000000000000000000000000000000000000000000000000DEADBEEF"
@@ -33,7 +33,7 @@ func TestValidateQuorumAndSignerEntries(t *testing.T) {
 		quorum   uint32
 		entries  []SignerEntry
 		expanded bool
-		want     tx.Result
+		want     ter.Result
 	}{
 		{
 			name: "valid two signers", account: "rAlice", quorum: 2, expanded: false,
@@ -41,20 +41,20 @@ func TestValidateQuorumAndSignerEntries(t *testing.T) {
 				{SignerEntry: SignerEntryData{Account: "rBob", SignerWeight: 1}},
 				{SignerEntry: SignerEntryData{Account: "rCarol", SignerWeight: 1}},
 			},
-			want: tx.TesSUCCESS,
+			want: ter.TesSUCCESS,
 		},
-		{name: "no entries", account: "rAlice", quorum: 1, entries: nil, expanded: false, want: tx.TemMALFORMED},
-		{name: "8 entries without amendment ok", account: "rAlice", quorum: 1, entries: entriesOfWeightOne(8), expanded: false, want: tx.TesSUCCESS},
-		{name: "9 entries without amendment", account: "rAlice", quorum: 1, entries: entriesOfWeightOne(9), expanded: false, want: tx.TemMALFORMED},
-		{name: "32 entries with amendment ok", account: "rAlice", quorum: 1, entries: entriesOfWeightOne(32), expanded: true, want: tx.TesSUCCESS},
-		{name: "33 entries with amendment", account: "rAlice", quorum: 1, entries: entriesOfWeightOne(33), expanded: true, want: tx.TemMALFORMED},
+		{name: "no entries", account: "rAlice", quorum: 1, entries: nil, expanded: false, want: ter.TemMALFORMED},
+		{name: "8 entries without amendment ok", account: "rAlice", quorum: 1, entries: entriesOfWeightOne(8), expanded: false, want: ter.TesSUCCESS},
+		{name: "9 entries without amendment", account: "rAlice", quorum: 1, entries: entriesOfWeightOne(9), expanded: false, want: ter.TemMALFORMED},
+		{name: "32 entries with amendment ok", account: "rAlice", quorum: 1, entries: entriesOfWeightOne(32), expanded: true, want: ter.TesSUCCESS},
+		{name: "33 entries with amendment", account: "rAlice", quorum: 1, entries: entriesOfWeightOne(33), expanded: true, want: ter.TemMALFORMED},
 		{
 			name: "duplicate signer", account: "rAlice", quorum: 2, expanded: false,
 			entries: []SignerEntry{
 				{SignerEntry: SignerEntryData{Account: "rBob", SignerWeight: 1}},
 				{SignerEntry: SignerEntryData{Account: "rBob", SignerWeight: 1}},
 			},
-			want: tx.TemBAD_SIGNER,
+			want: ter.TemBAD_SIGNER,
 		},
 		{
 			name: "self reference", account: "rAlice", quorum: 2, expanded: false,
@@ -62,7 +62,7 @@ func TestValidateQuorumAndSignerEntries(t *testing.T) {
 				{SignerEntry: SignerEntryData{Account: "rAlice", SignerWeight: 1}},
 				{SignerEntry: SignerEntryData{Account: "rBob", SignerWeight: 1}},
 			},
-			want: tx.TemBAD_SIGNER,
+			want: ter.TemBAD_SIGNER,
 		},
 		{
 			name: "zero weight", account: "rAlice", quorum: 2, expanded: false,
@@ -70,7 +70,7 @@ func TestValidateQuorumAndSignerEntries(t *testing.T) {
 				{SignerEntry: SignerEntryData{Account: "rBob", SignerWeight: 0}},
 				{SignerEntry: SignerEntryData{Account: "rCarol", SignerWeight: 2}},
 			},
-			want: tx.TemBAD_WEIGHT,
+			want: ter.TemBAD_WEIGHT,
 		},
 		{
 			name: "quorum unreachable", account: "rAlice", quorum: 5, expanded: false,
@@ -78,21 +78,21 @@ func TestValidateQuorumAndSignerEntries(t *testing.T) {
 				{SignerEntry: SignerEntryData{Account: "rBob", SignerWeight: 1}},
 				{SignerEntry: SignerEntryData{Account: "rCarol", SignerWeight: 1}},
 			},
-			want: tx.TemBAD_QUORUM,
+			want: ter.TemBAD_QUORUM,
 		},
 		{
 			name: "walletlocator without amendment", account: "rAlice", quorum: 1, expanded: false,
 			entries: []SignerEntry{
 				{SignerEntry: SignerEntryData{Account: "rBob", SignerWeight: 1, WalletLocator: walletLocatorHex}},
 			},
-			want: tx.TemMALFORMED,
+			want: ter.TemMALFORMED,
 		},
 		{
 			name: "walletlocator with amendment", account: "rAlice", quorum: 1, expanded: true,
 			entries: []SignerEntry{
 				{SignerEntry: SignerEntryData{Account: "rBob", SignerWeight: 1, WalletLocator: walletLocatorHex}},
 			},
-			want: tx.TesSUCCESS,
+			want: ter.TesSUCCESS,
 		},
 	}
 
@@ -115,7 +115,7 @@ func TestValidateQuorumAndSignerEntries_CheckOrder(t *testing.T) {
 	// wins, so the result is temMALFORMED rather than temBAD_WEIGHT.
 	overCap := entriesOfWeightOne(9)
 	overCap[0].SignerEntry.SignerWeight = 0
-	if got := newSLS("rAlice", 1, overCap).validateQuorumAndSignerEntries(false); got != tx.TemMALFORMED {
+	if got := newSLS("rAlice", 1, overCap).validateQuorumAndSignerEntries(false); got != ter.TemMALFORMED {
 		t.Errorf("cap precedes weight: got %v, want temMALFORMED", got)
 	}
 
@@ -125,7 +125,7 @@ func TestValidateQuorumAndSignerEntries_CheckOrder(t *testing.T) {
 		{SignerEntry: SignerEntryData{Account: "rBob", SignerWeight: 0}},
 		{SignerEntry: SignerEntryData{Account: "rBob", SignerWeight: 1}},
 	}
-	if got := newSLS("rAlice", 1, dupZero).validateQuorumAndSignerEntries(false); got != tx.TemBAD_SIGNER {
+	if got := newSLS("rAlice", 1, dupZero).validateQuorumAndSignerEntries(false); got != ter.TemBAD_SIGNER {
 		t.Errorf("duplicate precedes weight: got %v, want temBAD_SIGNER", got)
 	}
 }

--- a/internal/tx/template.go
+++ b/internal/tx/template.go
@@ -1,5 +1,7 @@
 package tx
 
+import "github.com/LeJamon/go-xrpl/internal/tx/ter"
+
 // fieldStyle is a templated field's presence requirement (rippled's SOEStyle).
 type fieldStyle uint8
 
@@ -434,7 +436,7 @@ func checkTemplate(txType Type, fields map[string]bool) error {
 		if _, ok := template[name]; ok {
 			continue
 		}
-		return Errorf(TemMALFORMED,
+		return ter.Errorf(ter.TemMALFORMED,
 			"field %q is not allowed for transaction type %s", name, txType)
 	}
 	return nil

--- a/internal/tx/template_test.go
+++ b/internal/tx/template_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // encodeTx encodes a field map into a binary transaction blob.
@@ -92,11 +93,11 @@ func TestParseFromBinary_DisallowedField(t *testing.T) {
 				t.Fatalf("expected parse to reject %s carrying %s, got nil error",
 					tc.txType, tc.disallowedKey)
 			}
-			re, ok := AsResultError(err)
+			re, ok := ter.AsResultError(err)
 			if !ok {
 				t.Fatalf("expected a ResultError, got %T: %v", err, err)
 			}
-			if re.Code != TemMALFORMED {
+			if re.Code != ter.TemMALFORMED {
 				t.Fatalf("expected TemMALFORMED, got %v: %v", re.Code, err)
 			}
 		})
@@ -200,7 +201,7 @@ func TestCheckTemplate_PseudoTransactions(t *testing.T) {
 		if err == nil {
 			t.Fatal("SetFee carrying Amount must be rejected")
 		}
-		if re, ok := AsResultError(err); !ok || re.Code != TemMALFORMED {
+		if re, ok := ter.AsResultError(err); !ok || re.Code != ter.TemMALFORMED {
 			t.Fatalf("expected TemMALFORMED, got: %v", err)
 		}
 	})

--- a/internal/tx/ter/result.go
+++ b/internal/tx/ter/result.go
@@ -1,4 +1,4 @@
-package tx
+package ter
 
 import (
 	"errors"

--- a/internal/tx/ter/result_test.go
+++ b/internal/tx/ter/result_test.go
@@ -1,4 +1,4 @@
-package tx
+package ter
 
 import (
 	"testing"

--- a/internal/tx/ticket/ticket_create.go
+++ b/internal/tx/ticket/ticket_create.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -48,7 +49,7 @@ func (t *TicketCreate) Validate() error {
 	// TicketCount must be between 1 and 250
 	// Reference: rippled CreateTicket.cpp:39-40
 	if t.TicketCount == 0 || t.TicketCount > 250 {
-		return tx.Errorf(tx.TemINVALID_COUNT, "TicketCount must be 1-250, got %d", t.TicketCount)
+		return ter.Errorf(ter.TemINVALID_COUNT, "TicketCount must be 1-250, got %d", t.TicketCount)
 	}
 
 	return nil
@@ -59,7 +60,7 @@ func (t *TicketCreate) Flatten() (map[string]any, error) {
 }
 
 // Reference: rippled CreateTicket.cpp preclaim() + doApply()
-func (t *TicketCreate) Apply(ctx *tx.ApplyContext) tx.Result {
+func (t *TicketCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("ticket create apply",
 		"account", t.Account,
 		"ticketCount", t.TicketCount,
@@ -89,7 +90,7 @@ func (t *TicketCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 			"currentCount", currentTicketCount,
 			"requestedCount", t.TicketCount,
 		)
-		return tx.TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 
 	// --- doApply checks ---
@@ -104,7 +105,7 @@ func (t *TicketCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 			"balance", priorBalance,
 			"reserve", reserve,
 		)
-		return tx.TecINSUFFICIENT_RESERVE
+		return ter.TecINSUFFICIENT_RESERVE
 	}
 
 	for i := uint32(0); i < t.TicketCount; i++ {
@@ -120,16 +121,16 @@ func (t *TicketCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 			dir.Owner = ctx.AccountID
 		})
 		if err != nil {
-			return tx.TecDIR_FULL
+			return ter.TecDIR_FULL
 		}
 
 		ticketData, err := state.SerializeTicket(ctx.AccountID, ticketSeq, dirResult.Page)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		if err := ctx.View.Insert(ticketKey, ticketData); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 	}
 
@@ -147,5 +148,5 @@ func (t *TicketCreate) Apply(ctx *tx.ApplyContext) tx.Result {
 	// Reference: rippled CreateTicket.cpp lines 142-144
 	ctx.Account.TicketCount += t.TicketCount
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // Common errors
@@ -14,7 +15,7 @@ var (
 	ErrInvalidAmount          = errors.New("invalid amount")
 	ErrInvalidDestination     = errors.New("invalid destination")
 	ErrInvalidAccount         = errors.New("invalid account")
-	ErrInvalidFlags           = Errorf(TemINVALID_FLAG, "invalid flags")
+	ErrInvalidFlags           = ter.Errorf(ter.TemINVALID_FLAG, "invalid flags")
 	ErrInvalidSequence        = errors.New("invalid sequence")
 )
 
@@ -47,7 +48,7 @@ type Transaction interface {
 // Appliable is implemented by transaction types that can apply themselves to ledger state.
 // This replaces the central switch statement in Engine.doApply().
 type Appliable interface {
-	Apply(ctx *ApplyContext) Result
+	Apply(ctx *ApplyContext) ter.Result
 }
 
 // RulesPreflighter is implemented by transaction types whose preflight has
@@ -68,7 +69,7 @@ type RulesPreflighter interface {
 // transaction to be retried on the next pass.
 // Reference: rippled applySteps.h — PreclaimResult.likelyToClaimFee
 type Preclaimer interface {
-	Preclaim(view LedgerView, config EngineConfig) Result
+	Preclaim(view LedgerView, config EngineConfig) ter.Result
 }
 
 // BadCurrency is the currency code that may not name a non-native (issued)
@@ -218,10 +219,10 @@ type Common struct {
 // directly, so the codes need to be typed for those paths.
 func (c *Common) Validate() error {
 	if c.Account == "" {
-		return Errorf(TemBAD_SRC_ACCOUNT, "Account is required")
+		return ter.Errorf(ter.TemBAD_SRC_ACCOUNT, "Account is required")
 	}
 	if c.TransactionType == "" {
-		return Errorf(TemINVALID, "TransactionType is required")
+		return ter.Errorf(ter.TemINVALID, "TransactionType is required")
 	}
 	return nil
 }

--- a/internal/tx/trust_create.go
+++ b/internal/tx/trust_create.go
@@ -2,6 +2,7 @@ package tx
 
 import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -46,7 +47,7 @@ type TrustCreateParams struct {
 // party). This is the one part of rippled's trustCreate left to the caller.
 //
 // Reference: rippled View.cpp trustCreate (lines 1329-1445).
-func TrustCreate(view LedgerView, p TrustCreateParams) Result {
+func TrustCreate(view LedgerView, p TrustCreateParams) ter.Result {
 	var lowAccountID, highAccountID [20]byte
 	if p.SrcHigh {
 		lowAccountID, highAccountID = p.Dst, p.Src
@@ -72,7 +73,7 @@ func TrustCreate(view LedgerView, p TrustCreateParams) Result {
 	}
 	peerLimitStr, err := state.EncodeAccountID(peerLimitIssuer)
 	if err != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	peerLimit := NewIssuedAmount(0, state.MinExponent, currency, peerLimitStr)
 
@@ -123,16 +124,16 @@ func TrustCreate(view LedgerView, p TrustCreateParams) Result {
 	}
 	peerData, err := view.Read(keylet.Account(peerID))
 	if err != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if peerData == nil {
 		// Matches rippled trustCreate: a missing peer account is tecNO_TARGET,
 		// not an internal error (View.cpp slePeer null branch).
-		return TecNO_TARGET
+		return ter.TecNO_TARGET
 	}
 	peerAcct, err := state.ParseAccountRoot(peerData)
 	if err != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if peerAcct.Flags&state.LsfDefaultRipple == 0 {
 		flags |= sideFlag(bSetHigh, state.LsfLowNoRipple, state.LsfHighNoRipple)
@@ -145,7 +146,7 @@ func TrustCreate(view LedgerView, p TrustCreateParams) Result {
 		dir.Owner = lowAccountID
 	})
 	if err != nil {
-		return TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 	rs.LowNode = lowDir.Page
 
@@ -154,19 +155,19 @@ func TrustCreate(view LedgerView, p TrustCreateParams) Result {
 		dir.Owner = highAccountID
 	})
 	if err != nil {
-		return TecDIR_FULL
+		return ter.TecDIR_FULL
 	}
 	rs.HighNode = highDir.Page
 
 	data, err := state.SerializeRippleState(rs)
 	if err != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 	if err := view.Insert(p.LineKey, data); err != nil {
-		return TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // sideFlag returns highFlag when bSetHigh is true, otherwise lowFlag.

--- a/internal/tx/trustset/trustset.go
+++ b/internal/tx/trustset/trustset.go
@@ -5,6 +5,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/amm"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
@@ -77,38 +78,38 @@ func (t *TrustSet) Validate() error {
 
 	// Check for invalid transaction flags
 	if txFlags&TrustSetFlagMask != 0 {
-		return tx.Errorf(tx.TemINVALID_FLAG, "invalid transaction flags")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid transaction flags")
 	}
 
 	// LimitAmount must be an issued currency, not XRP
 	if t.LimitAmount.IsNative() {
-		return tx.Errorf(tx.TemBAD_LIMIT, "cannot create trust line for XRP")
+		return ter.Errorf(ter.TemBAD_LIMIT, "cannot create trust line for XRP")
 	}
 
 	if t.LimitAmount.Currency == "" {
-		return tx.Errorf(tx.TemBAD_CURRENCY, "currency is required")
+		return ter.Errorf(ter.TemBAD_CURRENCY, "currency is required")
 	}
 
 	// Check for XRP currency code
 	if t.LimitAmount.Currency == "XRP" {
-		return tx.Errorf(tx.TemBAD_CURRENCY, "cannot use XRP as IOU currency")
+		return ter.Errorf(ter.TemBAD_CURRENCY, "cannot use XRP as IOU currency")
 	}
 
 	// Negative limit is not allowed
 	if t.LimitAmount.IsNegative() {
-		return tx.Errorf(tx.TemBAD_LIMIT, "negative credit limit")
+		return ter.Errorf(ter.TemBAD_LIMIT, "negative credit limit")
 	}
 
 	// Check if destination makes sense
 	// In rippled, preflight checks: if (!issuer || issuer == noAccount())
 	// noAccount() is ACCOUNT_ONE = rrrrrrrrrrrrrrrrrrrrBZbvji
 	if t.LimitAmount.Issuer == "" || t.LimitAmount.Issuer == "rrrrrrrrrrrrrrrrrrrrBZbvji" {
-		return tx.Errorf(tx.TemDST_NEEDED, "issuer is required")
+		return ter.Errorf(ter.TemDST_NEEDED, "issuer is required")
 	}
 
 	// Cannot create trust line to self
 	if t.LimitAmount.Issuer == t.Account {
-		return tx.Errorf(tx.TemDST_IS_SRC, "cannot create trust line to self")
+		return ter.Errorf(ter.TemDST_IS_SRC, "cannot create trust line to self")
 	}
 
 	return nil
@@ -179,7 +180,7 @@ func computeFreezeFlags(
 
 // Apply applies a TrustSet transaction to the ledger state.
 // Reference: rippled SetTrust.cpp doApply
-func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
+func (t *TrustSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("trust set apply",
 		"account", t.Account,
 		"currency", t.LimitAmount.Currency,
@@ -192,12 +193,12 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	// Cannot create trust line to self
 	if t.LimitAmount.Issuer == ctx.Account.Account {
-		return tx.TemDST_IS_SRC
+		return ter.TemDST_IS_SRC
 	}
 
 	issuerAccountID, err := state.DecodeAccountID(t.LimitAmount.Issuer)
 	if err != nil {
-		return tx.TemBAD_ISSUER
+		return ter.TemBAD_ISSUER
 	}
 	issuerKey := keylet.Account(issuerAccountID)
 
@@ -208,16 +209,16 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		ctx.Log.Warn("trust set: issuer account does not exist",
 			"issuer", t.LimitAmount.Issuer,
 		)
-		return tx.TecNO_DST
+		return ter.TecNO_DST
 	}
 	issuerAccount, err := state.ParseAccountRoot(issuerData)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	accountID, err := state.DecodeAccountID(ctx.Account.Account)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// Capture the initial owner count and compute the reserve once,
@@ -242,7 +243,7 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	trustLineExists, err := ctx.View.Exists(trustLineKey)
 	if err != nil {
-		return tx.TefINTERNAL
+		return ter.TefINTERNAL
 	}
 
 	// If the destination has opted to disallow incoming trustlines, honour that flag.
@@ -253,7 +254,7 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			if ctx.Rules().Enabled(amendment.FeatureFixDisallowIncomingV1) && trustLineExists {
 				// pass — existing trust lines are allowed
 			} else {
-				return tx.TecNO_PERMISSION
+				return ter.TecNO_PERMISSION
 			}
 		}
 	}
@@ -271,24 +272,24 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 				ammKey := keylet.AMMByID(issuerAccount.AMMID)
 				ammRawData, err := ctx.View.Read(ammKey)
 				if err != nil || ammRawData == nil {
-					return tx.TecINTERNAL
+					return ter.TecINTERNAL
 				}
 				ammData, err := amm.ParseAMMData(ammRawData)
 				if err != nil {
-					return tx.TecINTERNAL
+					return ter.TecINTERNAL
 				}
 				if amm.IsAMMEmpty(ammData) {
-					return tx.TecAMM_EMPTY
+					return ter.TecAMM_EMPTY
 				}
 				// Compute LP token currency from the AMM's asset pair
 				lptCurrency := amm.GenerateAMMLPTCurrency(ammData.Asset.Currency, ammData.Asset2.Currency)
 				if lptCurrency != t.LimitAmount.Currency {
-					return tx.TecNO_PERMISSION
+					return ter.TecNO_PERMISSION
 				}
 				// LP token trust line to non-empty AMM — allow creation
 			}
 		} else {
-			return tx.TecPSEUDO_ACCOUNT
+			return ter.TecPSEUDO_ACCOUNT
 		}
 	}
 
@@ -308,7 +309,7 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 
 	// Validate tfSetfAuth - requires issuer to have lsfRequireAuth set
 	if bSetAuth && (ctx.Account.Flags&state.LsfRequireAuth) == 0 {
-		return tx.TefNO_AUTH_REQUIRED
+		return ter.TefNO_AUTH_REQUIRED
 	}
 
 	bNoFreeze := (ctx.Account.Flags & state.LsfNoFreeze) != 0
@@ -319,13 +320,13 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Check #1: Cannot freeze if account has lsfNoFreeze set.
 		// Reference: rippled preclaim() lines 318-322
 		if bNoFreeze && (bSetFreeze || bSetDeepFreeze) {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 
 		// Check #2: Cannot set and clear freeze in same transaction.
 		// Reference: rippled preclaim() lines 326-332
 		if (bSetFreeze || bSetDeepFreeze) && (bClearFreeze || bClearDeepFreeze) {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 
 		// Check #3: Compute what the trust line flags WOULD be after applying,
@@ -335,12 +336,12 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		if trustLineExists {
 			trustLineData, readErr := ctx.View.Read(trustLineKey)
 			if readErr != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 			if trustLineData != nil {
 				rs, parseErr := state.ParseRippleState(trustLineData)
 				if parseErr != nil {
-					return tx.TefINTERNAL
+					return ter.TefINTERNAL
 				}
 				currentFlags = rs.Flags
 			}
@@ -362,13 +363,13 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		}
 
 		if deepFrozen && !frozen {
-			return tx.TecNO_PERMISSION
+			return ter.TecNO_PERMISSION
 		}
 	} else {
 		// Without featureDeepFreeze, deep freeze flags are invalid.
 		// Reference: rippled preflight() lines 87-95
 		if bSetDeepFreeze || bClearDeepFreeze {
-			return tx.TemINVALID_FLAG
+			return ter.TemINVALID_FLAG
 		}
 	}
 
@@ -394,7 +395,7 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Setting a non-existent line to defaults is redundant.
 		// Reference: rippled SetTrust.cpp lines 698-708
 		if limitAmount.IsZero() && !bSetAuth && (!bQualityIn || uQualityIn == 0) && (!bQualityOut || uQualityOut == 0) {
-			return tx.TecNO_LINE_REDUNDANT
+			return ter.TecNO_LINE_REDUNDANT
 		}
 
 		// Check account has reserve for new trust line
@@ -404,7 +405,7 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 				"balance", mPriorBalance,
 				"reserve", reserveCreate,
 			)
-			return tx.TecNO_LINE_INSUF_RESERVE
+			return ter.TecNO_LINE_INSUF_RESERVE
 		}
 
 		// Determine the LOW and HIGH account IDs
@@ -516,7 +517,7 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			dir.Owner = lowAccountID
 		})
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Add trust line to HIGH account's owner directory
@@ -525,7 +526,7 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			dir.Owner = highAccountID
 		})
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Set LowNode and HighNode on the RippleState (deletion hints)
@@ -534,11 +535,11 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 
 		trustLineData, err := state.SerializeRippleState(rs)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		if err := ctx.View.Insert(trustLineKey, trustLineData); err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		ctx.Account.OwnerCount++
@@ -546,12 +547,12 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 		// Modify existing trust line
 		trustLineData, err := ctx.View.Read(trustLineKey)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		rs, err := state.ParseRippleState(trustLineData)
 		if err != nil {
-			return tx.TefINTERNAL
+			return ter.TefINTERNAL
 		}
 
 		// Per rippled: saLimitAllow = saLimitAmount; saLimitAllow.setIssuer(account_);
@@ -590,7 +591,7 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			} else if ctx.Rules().Enabled(amendment.FeatureFix1578) {
 				// Cannot set noRipple on a negative balance.
 				// Reference: rippled SetTrust.cpp lines 582-584
-				return tx.TecNO_PERMISSION
+				return ter.TecNO_PERMISSION
 			}
 		} else if bClearNoRipple && !bSetNoRipple {
 			if bHigh {
@@ -718,15 +719,15 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			}
 			lowDirKey := keylet.OwnerDir(lowAccountID)
 			if res, err := state.DirRemove(ctx.View, lowDirKey, rs.LowNode, trustLineKey.Key, false); err != nil || !res.Success {
-				return tx.TefBAD_LEDGER
+				return ter.TefBAD_LEDGER
 			}
 			highDirKey := keylet.OwnerDir(highAccountID)
 			if res, err := state.DirRemove(ctx.View, highDirKey, rs.HighNode, trustLineKey.Key, false); err != nil || !res.Success {
-				return tx.TefBAD_LEDGER
+				return ter.TefBAD_LEDGER
 			}
 
 			if err := ctx.View.Erase(trustLineKey); err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 
 			// Decrement owner count for both sides that had reserve set
@@ -762,10 +763,10 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			if (bLowReserved && bHigh) || (bHighReserved && !bHigh) {
 				issuerUpdatedData, serErr := state.SerializeAccountRoot(issuerAccount)
 				if serErr != nil {
-					return tx.TefINTERNAL
+					return ter.TefINTERNAL
 				}
 				if err := ctx.View.Update(issuerKey, issuerUpdatedData); err != nil {
-					return tx.TefINTERNAL
+					return ter.TefINTERNAL
 				}
 			}
 		} else {
@@ -824,7 +825,7 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			// Check reserve increase affordability
 			// Reference: rippled SetTrust.cpp line 681: mPriorBalance < reserveCreate
 			if bReserveIncrease && mPriorBalance < reserveCreate {
-				return tx.TecINSUF_RESERVE_LINE
+				return ter.TecINSUF_RESERVE_LINE
 			}
 
 			// Write issuer account back if its OwnerCount changed
@@ -835,23 +836,23 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) tx.Result {
 			if issuerChanged {
 				issuerUpdatedData, serErr := state.SerializeAccountRoot(issuerAccount)
 				if serErr != nil {
-					return tx.TefINTERNAL
+					return ter.TefINTERNAL
 				}
 				if err := ctx.View.Update(issuerKey, issuerUpdatedData); err != nil {
-					return tx.TefINTERNAL
+					return ter.TefINTERNAL
 				}
 			}
 
 			updatedData, err := state.SerializeRippleState(rs)
 			if err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 
 			if err := ctx.View.Update(trustLineKey, updatedData); err != nil {
-				return tx.TefINTERNAL
+				return ter.TefINTERNAL
 			}
 		}
 	}
 
-	return tx.TesSUCCESS
+	return ter.TesSUCCESS
 }

--- a/internal/tx/utils.go
+++ b/internal/tx/utils.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
@@ -139,48 +140,48 @@ func IsFrozen(view LedgerView, accountID [20]byte, asset Asset) bool {
 // flag, and TesSUCCESS otherwise (including XRP, self-issued, or a missing issuer
 // account). Reference: rippled ledger/View.cpp requireAuth(view, Issue, account)
 // with AuthType::Legacy.
-func RequireAuth(view LedgerView, asset Asset, accountID [20]byte) Result {
+func RequireAuth(view LedgerView, asset Asset, accountID [20]byte) ter.Result {
 	if asset.Currency == "" || asset.Currency == "XRP" {
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	issuerID, err := state.DecodeAccountID(asset.Issuer)
 	if err != nil {
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	if accountID == issuerID {
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	trustLineData, _ := view.Read(keylet.Line(accountID, issuerID, asset.Currency))
 
 	issuerAccount, err := ReadAccountRoot(view, issuerID)
 	if err != nil || issuerAccount == nil {
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 	if (issuerAccount.Flags & state.LsfRequireAuth) == 0 {
-		return TesSUCCESS
+		return ter.TesSUCCESS
 	}
 
 	if trustLineData == nil {
-		return TecNO_LINE
+		return ter.TecNO_LINE
 	}
 	rs, err := state.ParseRippleState(trustLineData)
 	if err != nil {
-		return TecNO_AUTH
+		return ter.TecNO_AUTH
 	}
 
 	// (account > issuer) ? lsfLowAuth : lsfHighAuth
 	if state.CompareAccountIDsForLine(accountID, issuerID) > 0 {
 		if (rs.Flags & state.LsfLowAuth) == 0 {
-			return TecNO_AUTH
+			return ter.TecNO_AUTH
 		}
 	} else {
 		if (rs.Flags & state.LsfHighAuth) == 0 {
-			return TecNO_AUTH
+			return ter.TecNO_AUTH
 		}
 	}
-	return TesSUCCESS
+	return ter.TesSUCCESS
 }
 
 // TransferRateParity is the transfer-rate value (1e9) that means "no fee".

--- a/internal/tx/validate.go
+++ b/internal/tx/validate.go
@@ -1,11 +1,13 @@
 package tx
 
+import "github.com/LeJamon/go-xrpl/internal/tx/ter"
+
 // CheckFlags validates that no unsupported flags are set.
 // mask should be the bitwise complement of all valid flags (~(validFlag1 | validFlag2 | ...)).
 // If any bit in the mask is set in flags, returns temINVALID_FLAG.
 func CheckFlags(flags uint32, mask uint32) error {
 	if flags&mask != 0 {
-		return Errorf(TemINVALID_FLAG, "invalid flags")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags")
 	}
 	return nil
 }
@@ -14,7 +16,7 @@ func CheckFlags(flags uint32, mask uint32) error {
 // Use for transaction types that accept no flags at all.
 func CheckNoFlags(flags uint32) error {
 	if flags != 0 {
-		return Errorf(TemINVALID_FLAG, "invalid flags")
+		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags")
 	}
 	return nil
 }
@@ -22,7 +24,7 @@ func CheckNoFlags(flags uint32) error {
 // CheckDestNotSrc validates that destination is not the same as source account.
 func CheckDestNotSrc(account, destination string) error {
 	if account == destination {
-		return Errorf(TemDST_IS_SRC, "destination may not be source")
+		return ter.Errorf(ter.TemDST_IS_SRC, "destination may not be source")
 	}
 	return nil
 }
@@ -30,7 +32,7 @@ func CheckDestNotSrc(account, destination string) error {
 // CheckDestRequired validates that a destination field is present.
 func CheckDestRequired(destination string) error {
 	if destination == "" {
-		return Errorf(TemDST_NEEDED, "Destination is required")
+		return ter.Errorf(ter.TemDST_NEEDED, "Destination is required")
 	}
 	return nil
 }

--- a/internal/tx/vault/constant.go
+++ b/internal/tx/vault/constant.go
@@ -1,6 +1,6 @@
 package vault
 
-import "github.com/LeJamon/go-xrpl/internal/tx"
+import "github.com/LeJamon/go-xrpl/internal/tx/ter"
 
 // Vault constants
 const (
@@ -27,23 +27,23 @@ const (
 
 // Vault errors
 var (
-	ErrVaultIDRequired       = tx.Errorf(tx.TemMALFORMED, "VaultID is required")
-	ErrVaultIDZero           = tx.Errorf(tx.TemMALFORMED, "VaultID cannot be zero")
-	ErrVaultAssetRequired    = tx.Errorf(tx.TemMALFORMED, "Asset is required")
-	ErrVaultDataTooLong      = tx.Errorf(tx.TemMALFORMED, "Data exceeds maximum length")
-	ErrVaultDataEmpty        = tx.Errorf(tx.TemMALFORMED, "Data cannot be empty if present")
-	ErrVaultDomainIDZero     = tx.Errorf(tx.TemMALFORMED, "DomainID cannot be zero")
-	ErrVaultDomainNotPrivate = tx.Errorf(tx.TemMALFORMED, "DomainID only allowed on private vaults")
-	ErrVaultAmountNotPos     = tx.Errorf(tx.TemBAD_AMOUNT, "Amount must be positive")
-	ErrVaultHolderRequired   = tx.Errorf(tx.TemMALFORMED, "Holder is required")
-	ErrVaultHolderIsSelf     = tx.Errorf(tx.TemMALFORMED, "Holder cannot be same as issuer")
-	ErrVaultDestZero         = tx.Errorf(tx.TemMALFORMED, "Destination cannot be zero")
-	ErrVaultDestTagNoAccount = tx.Errorf(tx.TemMALFORMED, "DestinationTag without Destination")
-	ErrVaultNoFieldsToUpdate = tx.Errorf(tx.TemMALFORMED, "nothing to update")
-	ErrVaultAssetsMaxNeg     = tx.Errorf(tx.TemMALFORMED, "AssetsMaximum cannot be negative")
-	ErrVaultWithdrawalPolicy = tx.Errorf(tx.TemMALFORMED, "invalid withdrawal policy")
-	ErrVaultMetadataTooLong  = tx.Errorf(tx.TemMALFORMED, "MPTokenMetadata exceeds maximum length")
-	ErrVaultMetadataEmpty    = tx.Errorf(tx.TemMALFORMED, "MPTokenMetadata cannot be empty if present")
-	ErrVaultAmountXRP        = tx.Errorf(tx.TemMALFORMED, "cannot clawback XRP from vault")
-	ErrVaultAmountNotIssuer  = tx.Errorf(tx.TemMALFORMED, "only asset issuer can clawback")
+	ErrVaultIDRequired       = ter.Errorf(ter.TemMALFORMED, "VaultID is required")
+	ErrVaultIDZero           = ter.Errorf(ter.TemMALFORMED, "VaultID cannot be zero")
+	ErrVaultAssetRequired    = ter.Errorf(ter.TemMALFORMED, "Asset is required")
+	ErrVaultDataTooLong      = ter.Errorf(ter.TemMALFORMED, "Data exceeds maximum length")
+	ErrVaultDataEmpty        = ter.Errorf(ter.TemMALFORMED, "Data cannot be empty if present")
+	ErrVaultDomainIDZero     = ter.Errorf(ter.TemMALFORMED, "DomainID cannot be zero")
+	ErrVaultDomainNotPrivate = ter.Errorf(ter.TemMALFORMED, "DomainID only allowed on private vaults")
+	ErrVaultAmountNotPos     = ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
+	ErrVaultHolderRequired   = ter.Errorf(ter.TemMALFORMED, "Holder is required")
+	ErrVaultHolderIsSelf     = ter.Errorf(ter.TemMALFORMED, "Holder cannot be same as issuer")
+	ErrVaultDestZero         = ter.Errorf(ter.TemMALFORMED, "Destination cannot be zero")
+	ErrVaultDestTagNoAccount = ter.Errorf(ter.TemMALFORMED, "DestinationTag without Destination")
+	ErrVaultNoFieldsToUpdate = ter.Errorf(ter.TemMALFORMED, "nothing to update")
+	ErrVaultAssetsMaxNeg     = ter.Errorf(ter.TemMALFORMED, "AssetsMaximum cannot be negative")
+	ErrVaultWithdrawalPolicy = ter.Errorf(ter.TemMALFORMED, "invalid withdrawal policy")
+	ErrVaultMetadataTooLong  = ter.Errorf(ter.TemMALFORMED, "MPTokenMetadata exceeds maximum length")
+	ErrVaultMetadataEmpty    = ter.Errorf(ter.TemMALFORMED, "MPTokenMetadata cannot be empty if present")
+	ErrVaultAmountXRP        = ter.Errorf(ter.TemMALFORMED, "cannot clawback XRP from vault")
+	ErrVaultAmountNotIssuer  = ter.Errorf(ter.TemMALFORMED, "only asset issuer can clawback")
 )

--- a/internal/tx/vault/vault_clawback.go
+++ b/internal/tx/vault/vault_clawback.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 type VaultClawback struct {
@@ -50,7 +51,7 @@ func (v *VaultClawback) Validate() error {
 		if isZeroHash(v.VaultID) {
 			return ErrVaultIDZero
 		}
-		return tx.Errorf(tx.TemMALFORMED, "VaultID must be a valid 256-bit hash")
+		return ter.Errorf(ter.TemMALFORMED, "VaultID must be a valid 256-bit hash")
 	}
 
 	// Holder is required
@@ -91,7 +92,7 @@ func (v *VaultClawback) RequiredAmendments() [][32]byte {
 }
 
 // Apply is intentionally unimplemented. See VaultCreate.Apply.
-func (v *VaultClawback) Apply(ctx *tx.ApplyContext) tx.Result {
+func (v *VaultClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("vault clawback apply: not implemented", "account", v.Account)
-	return tx.TefINTERNAL
+	return ter.TefINTERNAL
 }

--- a/internal/tx/vault/vault_create.go
+++ b/internal/tx/vault/vault_create.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // VaultCreate creates a new vault.
@@ -86,7 +87,7 @@ func (v *VaultCreate) Validate() error {
 			if isZeroHash(v.DomainID) {
 				return ErrVaultDomainIDZero
 			}
-			return tx.Errorf(tx.TemMALFORMED, "DomainID must be a valid 256-bit hash")
+			return ter.Errorf(ter.TemMALFORMED, "DomainID must be a valid 256-bit hash")
 		}
 		// DomainID only allowed on private vaults
 		if v.Common.Flags == nil || (*v.Common.Flags&VaultFlagPrivate) == 0 {
@@ -129,9 +130,9 @@ func (v *VaultCreate) RequiredAmendments() [][32]byte {
 // engine rejects this transaction at preflight with temDISABLED and Apply is
 // unreachable. Returning a hard error that mutates no state guards against the
 // amendment being enabled before the real vault semantics are implemented.
-func (v *VaultCreate) Apply(ctx *tx.ApplyContext) tx.Result {
+func (v *VaultCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("vault create apply: not implemented", "account", v.Account)
-	return tx.TefINTERNAL
+	return ter.TefINTERNAL
 }
 
 // decodeBlob decodes a hex-encoded Blob field to its raw bytes.

--- a/internal/tx/vault/vault_delete.go
+++ b/internal/tx/vault/vault_delete.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // VaultDelete deletes a vault.
@@ -44,7 +45,7 @@ func (v *VaultDelete) Validate() error {
 		if isZeroHash(v.VaultID) {
 			return ErrVaultIDZero
 		}
-		return tx.Errorf(tx.TemMALFORMED, "VaultID must be a valid 256-bit hash")
+		return ter.Errorf(ter.TemMALFORMED, "VaultID must be a valid 256-bit hash")
 	}
 
 	return nil
@@ -59,7 +60,7 @@ func (v *VaultDelete) RequiredAmendments() [][32]byte {
 }
 
 // Apply is intentionally unimplemented. See VaultCreate.Apply.
-func (v *VaultDelete) Apply(ctx *tx.ApplyContext) tx.Result {
+func (v *VaultDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("vault delete apply: not implemented", "account", v.Account)
-	return tx.TefINTERNAL
+	return ter.TefINTERNAL
 }

--- a/internal/tx/vault/vault_deposit.go
+++ b/internal/tx/vault/vault_deposit.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // VaultDeposit deposits assets into a vault.
@@ -48,7 +49,7 @@ func (v *VaultDeposit) Validate() error {
 		if isZeroHash(v.VaultID) {
 			return ErrVaultIDZero
 		}
-		return tx.Errorf(tx.TemMALFORMED, "VaultID must be a valid 256-bit hash")
+		return ter.Errorf(ter.TemMALFORMED, "VaultID must be a valid 256-bit hash")
 	}
 
 	// Amount must be positive — rejects default, explicit zero, and negative.
@@ -68,7 +69,7 @@ func (v *VaultDeposit) RequiredAmendments() [][32]byte {
 }
 
 // Apply is intentionally unimplemented. See VaultCreate.Apply.
-func (v *VaultDeposit) Apply(ctx *tx.ApplyContext) tx.Result {
+func (v *VaultDeposit) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("vault deposit apply: not implemented", "account", v.Account)
-	return tx.TefINTERNAL
+	return ter.TefINTERNAL
 }

--- a/internal/tx/vault/vault_set.go
+++ b/internal/tx/vault/vault_set.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // VaultSet modifies a vault.
@@ -53,7 +54,7 @@ func (v *VaultSet) Validate() error {
 		if isZeroHash(v.VaultID) {
 			return ErrVaultIDZero
 		}
-		return tx.Errorf(tx.TemMALFORMED, "VaultID must be a valid 256-bit hash")
+		return ter.Errorf(ter.TemMALFORMED, "VaultID must be a valid 256-bit hash")
 	}
 
 	// Data is a Blob: present-but-empty and over-length (in decoded bytes)
@@ -93,7 +94,7 @@ func (v *VaultSet) RequiredAmendments() [][32]byte {
 }
 
 // Apply is intentionally unimplemented. See VaultCreate.Apply.
-func (v *VaultSet) Apply(ctx *tx.ApplyContext) tx.Result {
+func (v *VaultSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("vault set apply: not implemented", "account", v.Account)
-	return tx.TefINTERNAL
+	return ter.TefINTERNAL
 }

--- a/internal/tx/vault/vault_withdraw.go
+++ b/internal/tx/vault/vault_withdraw.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // VaultWithdraw withdraws assets from a vault.
@@ -55,7 +56,7 @@ func (v *VaultWithdraw) Validate() error {
 		if isZeroHash(v.VaultID) {
 			return ErrVaultIDZero
 		}
-		return tx.Errorf(tx.TemMALFORMED, "VaultID must be a valid 256-bit hash")
+		return ter.Errorf(ter.TemMALFORMED, "VaultID must be a valid 256-bit hash")
 	}
 
 	// Amount must be positive — rejects default, explicit zero, and negative.
@@ -85,7 +86,7 @@ func (v *VaultWithdraw) RequiredAmendments() [][32]byte {
 }
 
 // Apply is intentionally unimplemented. See VaultCreate.Apply.
-func (v *VaultWithdraw) Apply(ctx *tx.ApplyContext) tx.Result {
+func (v *VaultWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("vault withdraw apply: not implemented", "account", v.Account)
-	return tx.TefINTERNAL
+	return ter.TefINTERNAL
 }

--- a/internal/tx/xchain/xchain.go
+++ b/internal/tx/xchain/xchain.go
@@ -3,6 +3,7 @@ package xchain
 import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // XChainBridge identifies a cross-chain bridge
@@ -46,7 +47,7 @@ func (x *XChainCreateBridge) Validate() error {
 	}
 
 	if x.SignatureReward.IsZero() {
-		return tx.Errorf(tx.TemMALFORMED, "SignatureReward is required")
+		return ter.Errorf(ter.TemMALFORMED, "SignatureReward is required")
 	}
 
 	return nil
@@ -132,7 +133,7 @@ func (x *XChainCreateClaimID) Validate() error {
 	}
 
 	if x.OtherChainSource == "" {
-		return tx.Errorf(tx.TemMALFORMED, "OtherChainSource is required")
+		return ter.Errorf(ter.TemMALFORMED, "OtherChainSource is required")
 	}
 
 	return nil
@@ -183,7 +184,7 @@ func (x *XChainCommit) Validate() error {
 	}
 
 	if x.Amount.IsZero() {
-		return tx.Errorf(tx.TemBAD_AMOUNT, "Amount is required")
+		return ter.Errorf(ter.TemBAD_AMOUNT, "Amount is required")
 	}
 
 	return nil
@@ -238,11 +239,11 @@ func (x *XChainClaim) Validate() error {
 	}
 
 	if x.Destination == "" {
-		return tx.Errorf(tx.TemMALFORMED, "Destination is required")
+		return ter.Errorf(ter.TemMALFORMED, "Destination is required")
 	}
 
 	if x.Amount.IsZero() {
-		return tx.Errorf(tx.TemBAD_AMOUNT, "Amount is required")
+		return ter.Errorf(ter.TemBAD_AMOUNT, "Amount is required")
 	}
 
 	return nil
@@ -294,11 +295,11 @@ func (x *XChainAccountCreateCommit) Validate() error {
 	}
 
 	if x.Destination == "" {
-		return tx.Errorf(tx.TemMALFORMED, "Destination is required")
+		return ter.Errorf(ter.TemMALFORMED, "Destination is required")
 	}
 
 	if x.Amount.IsZero() {
-		return tx.Errorf(tx.TemBAD_AMOUNT, "Amount is required")
+		return ter.Errorf(ter.TemBAD_AMOUNT, "Amount is required")
 	}
 
 	return nil
@@ -366,23 +367,23 @@ func (x *XChainAddClaimAttestation) Validate() error {
 	}
 
 	if x.OtherChainSource == "" {
-		return tx.Errorf(tx.TemMALFORMED, "OtherChainSource is required")
+		return ter.Errorf(ter.TemMALFORMED, "OtherChainSource is required")
 	}
 
 	if x.AttestationRewardAccount == "" {
-		return tx.Errorf(tx.TemMALFORMED, "AttestationRewardAccount is required")
+		return ter.Errorf(ter.TemMALFORMED, "AttestationRewardAccount is required")
 	}
 
 	if x.AttestationSignerAccount == "" {
-		return tx.Errorf(tx.TemMALFORMED, "AttestationSignerAccount is required")
+		return ter.Errorf(ter.TemMALFORMED, "AttestationSignerAccount is required")
 	}
 
 	if x.PublicKey == "" {
-		return tx.Errorf(tx.TemMALFORMED, "PublicKey is required")
+		return ter.Errorf(ter.TemMALFORMED, "PublicKey is required")
 	}
 
 	if x.Signature == "" {
-		return tx.Errorf(tx.TemMALFORMED, "Signature is required")
+		return ter.Errorf(ter.TemMALFORMED, "Signature is required")
 	}
 
 	return nil
@@ -452,11 +453,11 @@ func (x *XChainAddAccountCreateAttestation) Validate() error {
 	}
 
 	if x.OtherChainSource == "" {
-		return tx.Errorf(tx.TemMALFORMED, "OtherChainSource is required")
+		return ter.Errorf(ter.TemMALFORMED, "OtherChainSource is required")
 	}
 
 	if x.Destination == "" {
-		return tx.Errorf(tx.TemMALFORMED, "Destination is required")
+		return ter.Errorf(ter.TemMALFORMED, "Destination is required")
 	}
 
 	return nil
@@ -476,42 +477,42 @@ func (x *XChainAddAccountCreateAttestation) RequiredAmendments() [][32]byte {
 // no state, guarding against the amendment being enabled before the real
 // cross-chain semantics are implemented.
 
-func (x *XChainCreateBridge) Apply(ctx *tx.ApplyContext) tx.Result {
+func (x *XChainCreateBridge) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("xchain create bridge apply: not implemented", "account", x.Account)
-	return tx.TefINTERNAL
+	return ter.TefINTERNAL
 }
 
-func (x *XChainModifyBridge) Apply(ctx *tx.ApplyContext) tx.Result {
+func (x *XChainModifyBridge) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("xchain modify bridge apply: not implemented", "account", x.Account)
-	return tx.TefINTERNAL
+	return ter.TefINTERNAL
 }
 
-func (x *XChainCreateClaimID) Apply(ctx *tx.ApplyContext) tx.Result {
+func (x *XChainCreateClaimID) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("xchain create claim id apply: not implemented", "account", x.Account)
-	return tx.TefINTERNAL
+	return ter.TefINTERNAL
 }
 
-func (x *XChainCommit) Apply(ctx *tx.ApplyContext) tx.Result {
+func (x *XChainCommit) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("xchain commit apply: not implemented", "account", x.Account)
-	return tx.TefINTERNAL
+	return ter.TefINTERNAL
 }
 
-func (x *XChainClaim) Apply(ctx *tx.ApplyContext) tx.Result {
+func (x *XChainClaim) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("xchain claim apply: not implemented", "account", x.Account)
-	return tx.TefINTERNAL
+	return ter.TefINTERNAL
 }
 
-func (x *XChainAccountCreateCommit) Apply(ctx *tx.ApplyContext) tx.Result {
+func (x *XChainAccountCreateCommit) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("xchain account create commit apply: not implemented", "account", x.Account)
-	return tx.TefINTERNAL
+	return ter.TefINTERNAL
 }
 
-func (x *XChainAddClaimAttestation) Apply(ctx *tx.ApplyContext) tx.Result {
+func (x *XChainAddClaimAttestation) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("xchain add claim attestation apply: not implemented", "account", x.Account)
-	return tx.TefINTERNAL
+	return ter.TefINTERNAL
 }
 
-func (x *XChainAddAccountCreateAttestation) Apply(ctx *tx.ApplyContext) tx.Result {
+func (x *XChainAddAccountCreateAttestation) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Log.Trace("xchain add account create attestation apply: not implemented", "account", x.Account)
-	return tx.TefINTERNAL
+	return ter.TefINTERNAL
 }

--- a/internal/txq/accept.go
+++ b/internal/txq/accept.go
@@ -2,6 +2,7 @@ package txq
 
 import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // AcceptContext provides the context needed to accept transactions into the open ledger.
@@ -14,7 +15,7 @@ type AcceptContext interface {
 
 	// ApplyTransaction attempts to apply a transaction to the open ledger.
 	// Returns the result and whether the transaction was applied.
-	ApplyTransaction(txn tx.Transaction) (tx.Result, bool)
+	ApplyTransaction(txn tx.Transaction) (ter.Result, bool)
 
 	// GetParentHash returns the parent ledger hash for deterministic ordering.
 	GetParentHash() [32]byte
@@ -221,11 +222,11 @@ func (q *TxQ) indexInByFee(c *Candidate) int {
 }
 
 // isTefFailure returns true if the result is a tef (fee claimed, not applied) failure.
-func isTefFailure(result tx.Result) bool {
+func isTefFailure(result ter.Result) bool {
 	return result <= -180 && result >= -199
 }
 
 // isTemMalformed returns true if the result is a tem (malformed) failure.
-func isTemMalformed(result tx.Result) bool {
+func isTemMalformed(result ter.Result) bool {
 	return result <= -200 && result >= -299
 }

--- a/internal/txq/admission_apply_test.go
+++ b/internal/txq/admission_apply_test.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // seqTx is a minimal sequence-based tx.Transaction for driving TxQ.Apply.
@@ -39,26 +41,26 @@ type stubApplyCtx struct {
 	ledgerSeq  uint32
 	flags      tx.ApplyFlags
 
-	preflight tx.Result
-	preclaim  tx.Result
-	applyRes  tx.Result
+	preflight ter.Result
+	preclaim  ter.Result
+	applyRes  ter.Result
 	applied   bool
 }
 
-func (c *stubApplyCtx) GetAccountSequence([20]byte) uint32            { return c.seq }
-func (c *stubApplyCtx) AccountExists([20]byte) bool                   { return c.exists }
-func (c *stubApplyCtx) TicketExists(_ [20]byte, t uint32) bool        { return c.tickets[t] }
-func (c *stubApplyCtx) GetAccountBalance([20]byte) uint64             { return c.balance }
-func (c *stubApplyCtx) GetAccountReserve(uint32) uint64               { return c.reserve }
-func (c *stubApplyCtx) GetBaseFee(tx.Transaction) uint64              { return c.baseFee }
-func (c *stubApplyCtx) GetTxInLedger() uint32                         { return c.txInLedger }
-func (c *stubApplyCtx) GetLedgerSequence() uint32                     { return c.ledgerSeq }
-func (c *stubApplyCtx) GetApplyFlags() tx.ApplyFlags                  { return c.flags }
-func (c *stubApplyCtx) PreflightTransaction(tx.Transaction) tx.Result { return c.preflight }
-func (c *stubApplyCtx) PreclaimTransaction(tx.Transaction, [20]byte, uint64, uint32) tx.Result {
+func (c *stubApplyCtx) GetAccountSequence([20]byte) uint32             { return c.seq }
+func (c *stubApplyCtx) AccountExists([20]byte) bool                    { return c.exists }
+func (c *stubApplyCtx) TicketExists(_ [20]byte, t uint32) bool         { return c.tickets[t] }
+func (c *stubApplyCtx) GetAccountBalance([20]byte) uint64              { return c.balance }
+func (c *stubApplyCtx) GetAccountReserve(uint32) uint64                { return c.reserve }
+func (c *stubApplyCtx) GetBaseFee(tx.Transaction) uint64               { return c.baseFee }
+func (c *stubApplyCtx) GetTxInLedger() uint32                          { return c.txInLedger }
+func (c *stubApplyCtx) GetLedgerSequence() uint32                      { return c.ledgerSeq }
+func (c *stubApplyCtx) GetApplyFlags() tx.ApplyFlags                   { return c.flags }
+func (c *stubApplyCtx) PreflightTransaction(tx.Transaction) ter.Result { return c.preflight }
+func (c *stubApplyCtx) PreclaimTransaction(tx.Transaction, [20]byte, uint64, uint32) ter.Result {
 	return c.preclaim
 }
-func (c *stubApplyCtx) ApplyTransaction(tx.Transaction) (tx.Result, bool) {
+func (c *stubApplyCtx) ApplyTransaction(tx.Transaction) (ter.Result, bool) {
 	return c.applyRes, c.applied
 }
 func (c *stubApplyCtx) NewSandbox() (SandboxContext, error) {
@@ -97,7 +99,7 @@ func TestApply_H2_ExpirationGap(t *testing.T) {
 	ctx := &stubApplyCtx{seq: 5, balance: 1_000_000_000, exists: true, baseFee: 10}
 	res := q.Apply(ctx, &seqTx{seq: 10, fee: "10"}, [32]byte{0xAA}, acct)
 
-	require.Equal(t, tx.TelCAN_NOT_QUEUE, res.Result)
+	require.Equal(t, ter.TelCAN_NOT_QUEUE, res.Result)
 	require.False(t, res.Queued)
 }
 
@@ -115,7 +117,7 @@ func TestApply_H2_TicketCreateHole(t *testing.T) {
 	ctx := &stubApplyCtx{seq: 5, balance: 1_000_000_000, exists: true, baseFee: 10}
 	res := q.Apply(ctx, &seqTx{seq: 6, fee: "10"}, [32]byte{0xBB}, acct)
 
-	require.Equal(t, tx.TelCAN_NOT_QUEUE, res.Result)
+	require.Equal(t, ter.TelCAN_NOT_QUEUE, res.Result)
 	require.False(t, res.Queued)
 }
 
@@ -137,7 +139,7 @@ func TestApply_H2_StalePredecessorGap(t *testing.T) {
 	ctx := &stubApplyCtx{seq: 5, balance: 1_000_000_000, exists: true, baseFee: 10}
 	res := q.Apply(ctx, &seqTx{seq: 6, fee: "10"}, [32]byte{0x1A}, acct)
 
-	require.Equal(t, tx.TelCAN_NOT_QUEUE, res.Result)
+	require.Equal(t, ter.TelCAN_NOT_QUEUE, res.Result)
 	require.False(t, res.Queued)
 }
 
@@ -146,11 +148,11 @@ func TestApply_H2_StalePredecessorGap(t *testing.T) {
 func TestApply_H1_PreflightRejects(t *testing.T) {
 	q := New(makeAdmissionConfig())
 	acct := [20]byte{9}
-	ctx := &stubApplyCtx{seq: 5, balance: 1_000_000_000, exists: true, baseFee: 10, preflight: tx.TemMALFORMED}
+	ctx := &stubApplyCtx{seq: 5, balance: 1_000_000_000, exists: true, baseFee: 10, preflight: ter.TemMALFORMED}
 
 	res := q.Apply(ctx, &seqTx{seq: 5, fee: "10"}, [32]byte{0xCC}, acct)
 
-	require.Equal(t, tx.TemMALFORMED, res.Result)
+	require.Equal(t, ter.TemMALFORMED, res.Result)
 	require.False(t, res.Queued)
 	require.False(t, res.Applied)
 }
@@ -165,12 +167,12 @@ func TestApply_H1_PreclaimRejectsFirstQueued(t *testing.T) {
 	acct := [20]byte{9}
 	ctx := &stubApplyCtx{
 		seq: 5, balance: 1_000_000_000, exists: true, baseFee: 10,
-		txInLedger: 100, preclaim: tx.TerINSUF_FEE_B,
+		txInLedger: 100, preclaim: ter.TerINSUF_FEE_B,
 	}
 
 	res := q.Apply(ctx, &seqTx{seq: 5, fee: "10"}, [32]byte{0xDD}, acct)
 
-	require.Equal(t, tx.TerINSUF_FEE_B, res.Result)
+	require.Equal(t, ter.TerINSUF_FEE_B, res.Result)
 	require.False(t, res.Queued)
 }
 
@@ -185,7 +187,7 @@ func TestApply_H1_PreclaimPassesQueues(t *testing.T) {
 
 	res := q.Apply(ctx, &seqTx{seq: 5, fee: "10"}, [32]byte{0xEE}, acct)
 
-	require.Equal(t, tx.TerQUEUED, res.Result)
+	require.Equal(t, ter.TerQUEUED, res.Result)
 	require.True(t, res.Queued)
 }
 
@@ -198,7 +200,7 @@ func TestApply_BadFeeRejected(t *testing.T) {
 
 	res := q.Apply(ctx, &seqTx{seq: 5, fee: "not-a-number"}, [32]byte{0xFF}, acct)
 
-	require.Equal(t, tx.TemBAD_FEE, res.Result)
+	require.Equal(t, ter.TemBAD_FEE, res.Result)
 	require.False(t, res.Queued)
 }
 

--- a/internal/txq/apply.go
+++ b/internal/txq/apply.go
@@ -9,13 +9,14 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/offer"
 	"github.com/LeJamon/go-xrpl/internal/tx/paychan"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/internal/tx/ticket"
 	"github.com/LeJamon/go-xrpl/internal/tx/xchain"
 )
 
 // ApplyResult represents the result of trying to apply or queue a transaction.
 type ApplyResult struct {
-	Result  tx.Result
+	Result  ter.Result
 	Applied bool
 	Queued  bool
 }
@@ -50,14 +51,14 @@ type ApplyContext interface {
 
 	// ApplyTransaction attempts to apply a transaction to the open ledger.
 	// Returns the result and whether the transaction was applied.
-	ApplyTransaction(txn tx.Transaction) (tx.Result, bool)
+	ApplyTransaction(txn tx.Transaction) (ter.Result, bool)
 
 	// PreflightTransaction runs the preflight pipeline (syntax, signature,
 	// tx-type validation) against the open view's rules, returning 0
 	// (tesSUCCESS) when the transaction is well-formed or the failing TER
 	// otherwise. Mirrors rippled running preflight on every submission
 	// before the apply-vs-queue decision (TxQ.cpp:743-745).
-	PreflightTransaction(txn tx.Transaction) tx.Result
+	PreflightTransaction(txn tx.Transaction) ter.Result
 
 	// PreclaimTransaction runs preclaim against a view whose account balance
 	// and sequence have been set to adjustedBalance/adjustedSeq. For the
@@ -65,7 +66,7 @@ type ApplyContext interface {
 	// for the single-tx paths they are the account's actual balance and
 	// sequence, so preclaim runs against the unmodified open view. Returns 0
 	// (tesSUCCESS) if preclaim passes, or the failing TER code.
-	PreclaimTransaction(txn tx.Transaction, account [20]byte, adjustedBalance uint64, adjustedSeq uint32) tx.Result
+	PreclaimTransaction(txn tx.Transaction, account [20]byte, adjustedBalance uint64, adjustedSeq uint32) ter.Result
 
 	// GetApplyFlags returns the engine ApplyFlags driving this
 	// submission. Implementations that don't carry flags (legacy test
@@ -89,7 +90,7 @@ type ApplyContext interface {
 type SandboxContext interface {
 	// ApplyTransaction applies txn to the sandbox view, returning the result
 	// and whether it was applied (same semantics as ApplyContext).
-	ApplyTransaction(txn tx.Transaction) (tx.Result, bool)
+	ApplyTransaction(txn tx.Transaction) (ter.Result, bool)
 
 	// Commit folds the sandbox's accumulated state back into the parent view.
 	Commit() error
@@ -109,21 +110,21 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 	// Compute fee level
 	common := txn.GetCommon()
 	if common == nil {
-		return ApplyResult{Result: tx.TefINTERNAL, Applied: false}
+		return ApplyResult{Result: ter.TefINTERNAL, Applied: false}
 	}
 
 	// Preflight every submission before deciding apply-vs-queue, so a
 	// structurally invalid or badly-signed transaction is rejected with its
 	// preflight TER instead of being silently held as terQUEUED.
 	// Reference: rippled TxQ.cpp:743-745.
-	if result := ctx.PreflightTransaction(txn); result != tx.TesSUCCESS {
+	if result := ctx.PreflightTransaction(txn); result != ter.TesSUCCESS {
 		return ApplyResult{Result: result, Applied: false}
 	}
 
 	baseFee := ctx.GetBaseFee(txn)
 	feePaid, err := strconv.ParseUint(common.Fee, 10, 64)
 	if err != nil {
-		return ApplyResult{Result: tx.TemBAD_FEE, Applied: false}
+		return ApplyResult{Result: ter.TemBAD_FEE, Applied: false}
 	}
 	feeLevel := ToFeeLevel(feePaid, baseFee)
 
@@ -137,7 +138,7 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 	} else if common.Sequence != nil {
 		seqProxy = NewSeqProxySequence(*common.Sequence)
 	} else {
-		return ApplyResult{Result: tx.TefINTERNAL, Applied: false}
+		return ApplyResult{Result: ter.TefINTERNAL, Applied: false}
 	}
 
 	var lastValid uint32
@@ -179,27 +180,27 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 	// rippled has no goxrpl counterpart — the field is metadata-only
 	// in this implementation and never lives on a submitted tx.
 	if common.AccountTxnID != "" {
-		return ApplyResult{Result: tx.TelCAN_NOT_QUEUE, Applied: false}
+		return ApplyResult{Result: ter.TelCAN_NOT_QUEUE, Applied: false}
 	}
 	if ctx.GetApplyFlags()&tx.TapFAIL_HARD != 0 {
-		return ApplyResult{Result: tx.TelCAN_NOT_QUEUE, Applied: false}
+		return ApplyResult{Result: ter.TelCAN_NOT_QUEUE, Applied: false}
 	}
 
 	if !ctx.AccountExists(account) {
-		return ApplyResult{Result: tx.TerNO_ACCOUNT, Applied: false}
+		return ApplyResult{Result: ter.TerNO_ACCOUNT, Applied: false}
 	}
 
 	if seqProxy.IsTicket {
 		if !ctx.TicketExists(account, seqProxy.Value) {
 			if seqProxy.Value < acctSeq {
-				return ApplyResult{Result: tx.TefNO_TICKET, Applied: false}
+				return ApplyResult{Result: ter.TefNO_TICKET, Applied: false}
 			}
-			return ApplyResult{Result: tx.TerPRE_TICKET, Applied: false}
+			return ApplyResult{Result: ter.TerPRE_TICKET, Applied: false}
 		}
 	}
 
 	if lastValid != 0 && lastValid < ledgerSeq+q.config.MinimumLastLedgerBuffer {
-		return ApplyResult{Result: tx.TelCAN_NOT_QUEUE, Applied: false}
+		return ApplyResult{Result: ter.TelCAN_NOT_QUEUE, Applied: false}
 	}
 
 	consequences := computeConsequences(txn, seqProxy)
@@ -224,12 +225,12 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 	// Reference: TxQ.cpp:832-856
 	if consequences.IsBlocker {
 		if acctTxCount > 1 {
-			return ApplyResult{Result: tx.TelCAN_NOT_QUEUE_BLOCKS, Applied: false}
+			return ApplyResult{Result: ter.TelCAN_NOT_QUEUE_BLOCKS, Applied: false}
 		}
 		if acctTxCount == 1 {
 			firstRelevant := aq.FirstRelevant(acctSeqProx)
 			if firstRelevant == nil || firstRelevant.SeqProxy != seqProxy {
-				return ApplyResult{Result: tx.TelCAN_NOT_QUEUE_BLOCKS, Applied: false}
+				return ApplyResult{Result: ter.TelCAN_NOT_QUEUE_BLOCKS, Applied: false}
 			}
 		}
 	}
@@ -258,7 +259,7 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		if acctTxCount == 1 && firstRelevant != nil &&
 			firstRelevant.Consequences.IsBlocker &&
 			firstRelevant.SeqProxy != seqProxy {
-			return ApplyResult{Result: tx.TelCAN_NOT_QUEUE_BLOCKED, Applied: false}
+			return ApplyResult{Result: ter.TelCAN_NOT_QUEUE_BLOCKED, Applied: false}
 		}
 
 		// Check replacement fee (requires higher fee to replace).
@@ -266,7 +267,7 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		if replacingCandidate != nil {
 			requiredRetryLevel := FeeLevel(mulDiv(uint64(replacingCandidate.FeeLevel), 100+uint64(q.config.RetrySequencePercent), 100))
 			if feeLevel <= requiredRetryLevel {
-				return ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FEE, Applied: false}
+				return ApplyResult{Result: ter.TelCAN_NOT_QUEUE_FEE, Applied: false}
 			}
 		}
 	}
@@ -289,16 +290,16 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		if !seqProxy.IsTicket {
 			if seqProxy.Value != acctSeq {
 				if seqProxy.Value < acctSeq {
-					return ApplyResult{Result: tx.TefPAST_SEQ, Applied: false}
+					return ApplyResult{Result: ter.TefPAST_SEQ, Applied: false}
 				}
-				return ApplyResult{Result: tx.TerPRE_SEQ, Applied: false}
+				return ApplyResult{Result: ter.TerPRE_SEQ, Applied: false}
 			}
 		}
 	} else {
 		// There are relevant queued transactions for this account.
 		// Reference: TxQ.cpp:959-1153
 		if !seqProxy.IsTicket && acctSeq > seqProxy.Value {
-			return ApplyResult{Result: tx.TefPAST_SEQ, Applied: false}
+			return ApplyResult{Result: ter.TefPAST_SEQ, Applied: false}
 		}
 
 		if acctTxCount > 1 || replacingCandidate == nil {
@@ -326,10 +327,10 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 				// The tx goes at the front of the queue.
 				// The first Sequence in the queue must match acctSeq.
 				if seqProxy.Value < acctSeq {
-					return ApplyResult{Result: tx.TefPAST_SEQ, Applied: false}
+					return ApplyResult{Result: ter.TefPAST_SEQ, Applied: false}
 				}
 				if seqProxy.Value > acctSeq {
-					return ApplyResult{Result: tx.TerPRE_SEQ, Applied: false}
+					return ApplyResult{Result: ter.TerPRE_SEQ, Applied: false}
 				}
 			} else if replacingCandidate == nil {
 				// The tx goes after existing entries: it must fill the first
@@ -338,7 +339,7 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 				// hole — is telCAN_NOT_QUEUE, never tefPAST_SEQ.
 				// Reference: TxQ.cpp:1031-1040 (nextQueuableSeqImpl == txSeqProx).
 				if q.getNextQueuableSeq(aq, acctSeq) != seqProxy.Value {
-					return ApplyResult{Result: tx.TelCAN_NOT_QUEUE, Applied: false}
+					return ApplyResult{Result: ter.TelCAN_NOT_QUEUE, Applied: false}
 				}
 			}
 		}
@@ -369,7 +370,7 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 			reserve := ctx.GetAccountReserve(0)
 			baseFeeVal := ctx.GetBaseFee(txn)
 			if totalFee >= balance || (reserve > 10*baseFeeVal && totalFee >= reserve) {
-				return ApplyResult{Result: tx.TelCAN_NOT_QUEUE_BALANCE, Applied: false}
+				return ApplyResult{Result: ter.TelCAN_NOT_QUEUE_BALANCE, Applied: false}
 			}
 
 			// Bump the preclaim view to reflect the in-flight chain
@@ -398,7 +399,7 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 	// rippled's likelyToClaimFee also guards the tec branch on !tapRETRY, but no
 	// TxQ.Apply caller sets tapRETRY (it is added only in the consensus apply-
 	// retry loop), so accepting every tec here is unconditionally correct.
-	if result := ctx.PreclaimTransaction(txn, account, preclaimBalance, preclaimSeq); result != tx.TesSUCCESS && !result.IsTec() {
+	if result := ctx.PreclaimTransaction(txn, account, preclaimBalance, preclaimSeq); result != ter.TesSUCCESS && !result.IsTec() {
 		return ApplyResult{Result: result, Applied: false}
 	}
 
@@ -449,7 +450,7 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 
 		if lowestOther == nil {
 			q.incTxQFull()
-			return ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
+			return ApplyResult{Result: ter.TelCAN_NOT_QUEUE_FULL, Applied: false}
 		}
 
 		endAccount := q.byAccount[lowestOther.Account]
@@ -492,7 +493,7 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 			}
 		} else {
 			q.incTxQFull()
-			return ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
+			return ApplyResult{Result: ter.TelCAN_NOT_QUEUE_FULL, Applied: false}
 		}
 	}
 
@@ -519,14 +520,14 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		feeLevel,
 		seqProxy,
 		lastValid,
-		tx.TesSUCCESS, // preflight ran and passed at the top of Apply
+		ter.TesSUCCESS,
 		consequences,
 	)
 
 	aq.Add(candidate)
 	q.insertByFee(candidate)
 
-	return ApplyResult{Result: tx.TerQUEUED, Queued: true}
+	return ApplyResult{Result: ter.TerQUEUED, Queued: true}
 }
 
 // tryClearAccountQueue attempts to clear all queued transactions for an account
@@ -603,7 +604,7 @@ func (q *TxQ) tryClearAccountQueue(
 		c.RetriesRemaining--
 		c.LastResult = result
 
-		if result == tx.TefNO_TICKET {
+		if result == ter.TefNO_TICKET {
 			// A ticketed tx that is both queued and already in the ledger can
 			// never succeed; treat it as cleared so the rest of the batch can
 			// proceed and the dead entry is erased (rippled TxQ.cpp:573-590).
@@ -665,13 +666,13 @@ func (q *TxQ) canBeHeld(aq *AccountQueue, replacingCandidate *Candidate, seqProx
 		nextSP, hasNext := q.upperBoundSeqProxy(aq, seqProxy)
 		if !hasNext || nextSP.IsTicket {
 			q.incTxQFull()
-			return true, ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
+			return true, ApplyResult{Result: ter.TelCAN_NOT_QUEUE_FULL, Applied: false}
 		}
 		// Real gap fill — allow it.
 		return false, ApplyResult{}
 	}
 	q.incTxQFull()
-	return true, ApplyResult{Result: tx.TelCAN_NOT_QUEUE_FULL, Applied: false}
+	return true, ApplyResult{Result: ter.TelCAN_NOT_QUEUE_FULL, Applied: false}
 }
 
 // upperBoundSeqProxy returns the smallest SeqProxy in aq strictly

--- a/internal/txq/candidate.go
+++ b/internal/txq/candidate.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // RetriesAllowed is the starting retry count for newly queued transactions.
@@ -49,9 +50,9 @@ type Candidate struct {
 	SeqProxy         SeqProxy
 	LastValid        uint32
 	RetriesRemaining int // starts at RetriesAllowed; drops to 0 before removal
-	LastResult       tx.Result
+	LastResult       ter.Result
 	// PreflightResult holds the result from the preflight check.
-	PreflightResult tx.Result
+	PreflightResult ter.Result
 	Consequences    TxConsequences
 }
 
@@ -81,7 +82,7 @@ func NewCandidate(
 	feeLevel FeeLevel,
 	seqProxy SeqProxy,
 	lastValid uint32,
-	preflightResult tx.Result,
+	preflightResult ter.Result,
 	consequences TxConsequences,
 ) *Candidate {
 	return &Candidate{

--- a/internal/txq/sandbox_test.go
+++ b/internal/txq/sandbox_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // mockTx is a minimal tx.Transaction used to drive tryClearAccountQueue in
@@ -21,14 +22,14 @@ func (m *mockTx) RequiredAmendments() [][32]byte   { return nil }
 // mockSandbox records what was applied and whether the batch was committed.
 type mockSandbox struct {
 	results map[*mockTx]struct {
-		res     tx.Result
+		res     ter.Result
 		applied bool
 	}
 	appliedTo []*mockTx
 	committed bool
 }
 
-func (s *mockSandbox) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
+func (s *mockSandbox) ApplyTransaction(txn tx.Transaction) (ter.Result, bool) {
 	mt := txn.(*mockTx)
 	s.appliedTo = append(s.appliedTo, mt)
 	r := s.results[mt]
@@ -56,11 +57,11 @@ func (c *mockClearCtx) GetAccountReserve(uint32) uint64    { return 0 }
 func (c *mockClearCtx) GetBaseFee(tx.Transaction) uint64   { return 10 }
 func (c *mockClearCtx) GetTxInLedger() uint32              { return 0 }
 func (c *mockClearCtx) GetLedgerSequence() uint32          { return 0 }
-func (c *mockClearCtx) ApplyTransaction(tx.Transaction) (tx.Result, bool) {
-	return tx.TefINTERNAL, false
+func (c *mockClearCtx) ApplyTransaction(tx.Transaction) (ter.Result, bool) {
+	return ter.TefINTERNAL, false
 }
-func (c *mockClearCtx) PreflightTransaction(tx.Transaction) tx.Result { return 0 }
-func (c *mockClearCtx) PreclaimTransaction(tx.Transaction, [20]byte, uint64, uint32) tx.Result {
+func (c *mockClearCtx) PreflightTransaction(tx.Transaction) ter.Result { return 0 }
+func (c *mockClearCtx) PreclaimTransaction(tx.Transaction, [20]byte, uint64, uint32) ter.Result {
 	return 0
 }
 func (c *mockClearCtx) GetApplyFlags() tx.ApplyFlags { return 0 }
@@ -96,19 +97,19 @@ func setupClearQueue() (*TxQ, *AccountQueue, *Candidate, *mockTx, [20]byte, SeqP
 
 func mkResults(entries ...struct {
 	tx      *mockTx
-	res     tx.Result
+	res     ter.Result
 	applied bool
 }) map[*mockTx]struct {
-	res     tx.Result
+	res     ter.Result
 	applied bool
 } {
 	m := make(map[*mockTx]struct {
-		res     tx.Result
+		res     ter.Result
 		applied bool
 	})
 	for _, e := range entries {
 		m[e.tx] = struct {
-			res     tx.Result
+			res     ter.Result
 			applied bool
 		}{e.res, e.applied}
 	}
@@ -123,9 +124,9 @@ func TestTryClearAccountQueue_RollbackOnPrecedingFailure(t *testing.T) {
 	sb := &mockSandbox{results: mkResults(
 		struct {
 			tx      *mockTx
-			res     tx.Result
+			res     ter.Result
 			applied bool
-		}{preceding.Txn.(*mockTx), tx.TelCAN_NOT_QUEUE, false},
+		}{preceding.Txn.(*mockTx), ter.TelCAN_NOT_QUEUE, false},
 	)}
 	ctx := &mockClearCtx{sandbox: sb}
 
@@ -154,14 +155,14 @@ func TestTryClearAccountQueue_RollbackOnNewTxFailure(t *testing.T) {
 	sb := &mockSandbox{results: mkResults(
 		struct {
 			tx      *mockTx
-			res     tx.Result
+			res     ter.Result
 			applied bool
-		}{preceding.Txn.(*mockTx), tx.TesSUCCESS, true},
+		}{preceding.Txn.(*mockTx), ter.TesSUCCESS, true},
 		struct {
 			tx      *mockTx
-			res     tx.Result
+			res     ter.Result
 			applied bool
-		}{newTx, tx.TelCAN_NOT_QUEUE, false},
+		}{newTx, ter.TelCAN_NOT_QUEUE, false},
 	)}
 	ctx := &mockClearCtx{sandbox: sb}
 
@@ -186,14 +187,14 @@ func TestTryClearAccountQueue_CommitOnFullSuccess(t *testing.T) {
 	sb := &mockSandbox{results: mkResults(
 		struct {
 			tx      *mockTx
-			res     tx.Result
+			res     ter.Result
 			applied bool
-		}{preceding.Txn.(*mockTx), tx.TesSUCCESS, true},
+		}{preceding.Txn.(*mockTx), ter.TesSUCCESS, true},
 		struct {
 			tx      *mockTx
-			res     tx.Result
+			res     ter.Result
 			applied bool
-		}{newTx, tx.TesSUCCESS, true},
+		}{newTx, ter.TesSUCCESS, true},
 	)}
 	ctx := &mockClearCtx{sandbox: sb}
 

--- a/internal/txq/txq.go
+++ b/internal/txq/txq.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
 // TxQ is the transaction queue (mempool) that holds transactions waiting to
@@ -301,13 +302,13 @@ type CandidateDetails struct {
 	SeqProxy         SeqProxy
 	LastValid        uint32
 	RetriesRemaining int
-	LastResult       tx.Result
+	LastResult       ter.Result
 	// HasLastResult mirrors rippled's std::optional<TER> lastResult: it is
 	// only set once a candidate has been re-applied at least once, so the
 	// ledger queue dump suppresses last_result for never-retried txs
 	// (LedgerToJson.cpp:308-309).
 	HasLastResult   bool
-	PreflightResult tx.Result
+	PreflightResult ter.Result
 	Fee             uint64
 	PotentialSpend  uint64
 	AuthChange      bool


### PR DESCRIPTION
## Summary

Splits the flat `internal/tx` package into a one-directional layer DAG, mirroring rippled's [#6227](https://github.com/XRPLF/rippled/pull/6227)/[#6228](https://github.com/XRPLF/rippled/pull/6228). A consumer that only needs a TER code no longer transitively pulls in the engine, the apply-state table, and signature/crypto.

Final DAG (one-directional; core never imports the layers above it):

```
engine ─► applystate ─► tx (core) ─► ter (leaf)
   │  │                   ▲
   │  └────► sign ────────┘
   └──────► ter
handlers ─► tx (+ applystate for Batch, + sign)
```

Landed as five reviewable commits:

- **Step 0 — `InnerInvariantChecker` seam.** The contract layer held a concrete `ApplyContext.Engine *Engine` purely so Batch could run the per-inner-tx invariant pass. (The issue described this field as dereferenced at zero sites; in the current tree `batch.go` genuinely calls `ctx.Engine.CheckInnerInvariants`.) Replaced with a narrow `InnerInvariantChecker` interface and widened the table param to `LedgerView` — the rippled-#6227 concrete→interface move — which severs the contract→orchestrator back-edge that blocked the engine split.
- **`tx/ter`** — `Result` + all 188 TER constants (leaf, imports nothing from tx). Full migration, no alias shim, so consumers import `ter` directly.
- **`tx/applystate`** — `ApplyStateTable`, metadata diff generation, entry/owner threading, field-metadata helpers.
- **`tx/sign`** — single/multi-sign verification, signing, `SignerListLookup` + engine-view adapter, signer-error sentinels.
- **`tx/engine`** — `Engine` + apply/preflight/preclaim/fee, tec+invariant recovery, block processor, pseudo gates.

`tx` (core) keeps the contract (`Transaction`, `Common`, `ApplyContext`, dispatch interfaces, registry), `EngineConfig`/`ApplyFlags`/`LedgerView`, the `Metadata` type with its serialization, and the shared handler-facing helpers. Core non-test LOC drops ~7.9k → ~4.1k.

### Notes for reviewers
- **Order is engine-before-applystate**, not the issue's applystate-first. With the engine files still in core, moving `ApplyStateTable` out creates a transient `core → applystate → core` cycle (applystate needs `tx.Metadata`/`tx.LedgerView`). Extracting the engine first removes core's only references to the table.
- **Metadata serialization stays in core**: `Metadata.MarshalJSON` is a method on the core `Metadata` type and shares `buildAffectedNodeInner` with the binary serializer, so it can't move without re-coupling.
- **Import aliases avoid two pervasive name collisions**: engine/sign import core as `txcore` (their tx-typed params are named `tx`); external callers import the engine package as `txengine` (their engine instances are named `engine`).

## Test plan
- [x] `just build-all` (CGO) — green
- [x] `go vet ./...` — clean
- [x] `just test` (full suite) — 136 packages, 0 failures
- [x] `just conformance --failing` — no failing suites (no new failures vs `origin/main`)
- [x] `just lint` (golangci-lint) — 0 issues

Fixes #916