### PR TITLE
refactor(testing): harden jtx framework — defer amendment toggles, dedup, validate names

### DIFF
--- a/internal/testing/account.go
+++ b/internal/testing/account.go
@@ -66,33 +66,31 @@ func NewAccountWithAddress(name string, address string) *Account {
 	}
 }
 
-// NewAccountWithKeyType creates a new test account with the specified key type.
-// Supported key types: "secp256k1" and "ed25519".
-func NewAccountWithKeyType(name string, keyType string) *Account {
-	// Generate seed from name using SHA512-Half (first 16 bytes of SHA512)
-	hash := sha512.Sum512([]byte(name))
-	seed := hash[:16] // Use first 16 bytes as seed
-
+// newAccountFromSeedBytes derives a deterministic Account from raw seed bytes
+// using the algorithm named by keyType. It backs NewAccountWithKeyType and
+// NewAccountFromPassphraseWithKeyType, which differ only in how the seed is
+// produced.
+func newAccountFromSeedBytes(name string, seed []byte, keyType string) *Account {
 	var privKeyHex, pubKeyHex string
 	var err error
-
 	switch keyType {
 	case KeyTypeEd25519:
-		algo := ed25519.ED25519()
-		privKeyHex, pubKeyHex, err = algo.DeriveKeypair(seed, false)
-		if err != nil {
-			panic("failed to derive ed25519 keypair for account " + name + ": " + err.Error())
-		}
+		privKeyHex, pubKeyHex, err = ed25519.ED25519().DeriveKeypair(seed, false)
 	case KeyTypeSecp256k1:
-		algo := secp256k1.SECP256K1()
-		privKeyHex, pubKeyHex, err = algo.DeriveKeypair(seed, false)
-		if err != nil {
-			panic("failed to derive secp256k1 keypair for account " + name + ": " + err.Error())
-		}
+		privKeyHex, pubKeyHex, err = secp256k1.SECP256K1().DeriveKeypair(seed, false)
 	default:
 		panic("unsupported key type: " + keyType + " (must be 'secp256k1' or 'ed25519')")
 	}
+	if err != nil {
+		panic("failed to derive " + keyType + " keypair for account " + name + ": " + err.Error())
+	}
+	return buildAccount(name, seed, keyType, privKeyHex, pubKeyHex)
+}
 
+// buildAccount finalizes an Account from a derived keypair: it strips the
+// private-key prefix, decodes the public key, and derives the classic address
+// and account ID.
+func buildAccount(name string, seed []byte, keyType, privKeyHex, pubKeyHex string) *Account {
 	// Decode private key (remove the leading prefix if present)
 	privKey, err := hex.DecodeString(privKeyHex)
 	if err != nil {
@@ -135,6 +133,14 @@ func NewAccountWithKeyType(name string, keyType string) *Account {
 	}
 }
 
+// NewAccountWithKeyType creates a new test account with the specified key type.
+// Supported key types: "secp256k1" and "ed25519".
+func NewAccountWithKeyType(name string, keyType string) *Account {
+	// Generate seed from name using SHA512-Half (first 16 bytes of SHA512)
+	hash := sha512.Sum512([]byte(name))
+	return newAccountFromSeedBytes(name, hash[:16], keyType)
+}
+
 // MasterAccount returns the well-known master account derived from "masterpassphrase".
 // This is the genesis account that holds all XRP initially.
 // Address: rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh
@@ -154,67 +160,7 @@ func NewAccountFromPassphrase(name, passphrase string) *Account {
 func NewAccountFromPassphraseWithKeyType(name, passphrase, keyType string) *Account {
 	// Generate seed from passphrase using SHA512-Half
 	hash := sha512.Sum512([]byte(passphrase))
-	seed := hash[:16] // Use first 16 bytes as seed
-
-	var privKeyHex, pubKeyHex string
-	var err error
-
-	switch keyType {
-	case KeyTypeEd25519:
-		algo := ed25519.ED25519()
-		privKeyHex, pubKeyHex, err = algo.DeriveKeypair(seed, false)
-		if err != nil {
-			panic("failed to derive ed25519 keypair from passphrase: " + err.Error())
-		}
-	case KeyTypeSecp256k1:
-		algo := secp256k1.SECP256K1()
-		privKeyHex, pubKeyHex, err = algo.DeriveKeypair(seed, false)
-		if err != nil {
-			panic("failed to derive secp256k1 keypair from passphrase: " + err.Error())
-		}
-	default:
-		panic("unsupported key type: " + keyType + " (must be 'secp256k1' or 'ed25519')")
-	}
-
-	// Decode private key (remove the leading prefix if present)
-	privKey, err := hex.DecodeString(privKeyHex)
-	if err != nil {
-		panic("failed to decode private key: " + err.Error())
-	}
-	if len(privKey) == 33 {
-		privKey = privKey[1:]
-	}
-
-	// Decode public key
-	pubKey, err := hex.DecodeString(pubKeyHex)
-	if err != nil {
-		panic("failed to decode public key: " + err.Error())
-	}
-
-	// Generate classic address from public key
-	address, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(pubKeyHex)
-	if err != nil {
-		panic("failed to generate address: " + err.Error())
-	}
-
-	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(address)
-	if err != nil {
-		panic("failed to decode account ID: " + err.Error())
-	}
-
-	var accountID [20]byte
-	copy(accountID[:], accountIDBytes)
-
-	return &Account{
-		Name:       name,
-		KeyType:    keyType,
-		Seed:       seed,
-		Address:    address,
-		PublicKey:  pubKey,
-		PrivateKey: privKey,
-		ID:         accountID,
-		Sequence:   1, // Default starting sequence
-	}
+	return newAccountFromSeedBytes(name, hash[:16], keyType)
 }
 
 // PublicKeyHex returns the public key as a hex string (uppercase).
@@ -274,56 +220,16 @@ func NewAccountFromSeed(name, base58Seed string) *Account {
 		panic("failed to decode base58 seed: " + err.Error())
 	}
 
-	// Determine key type from algorithm
-	keyType := KeyTypeSecp256k1
 	privKeyHex, pubKeyHex, err := algo.DeriveKeypair(seedBytes, false)
 	if err != nil {
 		panic("failed to derive keypair from seed: " + err.Error())
 	}
 
-	// Check if this is ed25519 by looking at the public key prefix
-	pubKeyBytes, _ := hex.DecodeString(pubKeyHex)
-	if len(pubKeyBytes) > 0 && pubKeyBytes[0] == 0xED {
+	// Determine key type from the derived public key prefix (0xED → ed25519).
+	keyType := KeyTypeSecp256k1
+	if pubKeyBytes, _ := hex.DecodeString(pubKeyHex); len(pubKeyBytes) > 0 && pubKeyBytes[0] == 0xED {
 		keyType = KeyTypeEd25519
 	}
 
-	// Decode private key (remove the leading prefix if present)
-	privKey, err := hex.DecodeString(privKeyHex)
-	if err != nil {
-		panic("failed to decode private key: " + err.Error())
-	}
-	if len(privKey) == 33 {
-		privKey = privKey[1:]
-	}
-
-	// Decode public key
-	pubKey, err := hex.DecodeString(pubKeyHex)
-	if err != nil {
-		panic("failed to decode public key: " + err.Error())
-	}
-
-	// Generate classic address from public key
-	address, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(pubKeyHex)
-	if err != nil {
-		panic("failed to generate address: " + err.Error())
-	}
-
-	_, accountIDBytes, err := addresscodec.DecodeClassicAddressToAccountID(address)
-	if err != nil {
-		panic("failed to decode account ID: " + err.Error())
-	}
-
-	var accountID [20]byte
-	copy(accountID[:], accountIDBytes)
-
-	return &Account{
-		Name:       name,
-		KeyType:    keyType,
-		Seed:       seedBytes,
-		Address:    address,
-		PublicKey:  pubKey,
-		PrivateKey: privKey,
-		ID:         accountID,
-		Sequence:   1,
-	}
+	return buildAccount(name, seedBytes, keyType, privKeyHex, pubKeyHex)
 }

--- a/internal/testing/accountdelete/accountdelete_test.go
+++ b/internal/testing/accountdelete/accountdelete_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
 	acctx "github.com/LeJamon/go-xrpl/internal/tx/account"
 	"github.com/LeJamon/go-xrpl/keylet"
-	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -344,22 +343,6 @@ func TestAccountDelete_RegularKey(t *testing.T) {
 	jtx.RequireAccountNotExists(t, env, becky)
 }
 
-func rippleTime(env *jtx.TestEnv) uint32 {
-	return uint32(env.Now().Unix() - protocol.RippleEpochUnix)
-}
-
-// closeToParentCloseTime closes one ledger so that the new open ledger's
-// parent close time lands exactly on target (Ripple epoch seconds).
-func closeToParentCloseTime(t *testing.T, env *jtx.TestEnv, target uint32) {
-	t.Helper()
-	resolution := time.Duration(env.Ledger().CloseTimeResolution()) * time.Second
-	targetTime := time.Unix(int64(target)+protocol.RippleEpochUnix, 0).UTC()
-	env.SetTime(targetTime.Add(-resolution))
-	env.Close()
-	got := uint32(env.Ledger().ParentCloseTime().Unix() - protocol.RippleEpochUnix)
-	require.Equal(t, target, got, "parent close time must land exactly on target")
-}
-
 // TestAccountDelete_CredentialExpiry verifies rippled's credential expiry
 // semantics for AccountDelete: credentials::valid() in preclaim never checks
 // expiry; only removeExpired inside verifyDepositPreauth does, with a strict
@@ -382,7 +365,7 @@ func TestAccountDelete_CredentialExpiry(t *testing.T) {
 		env.Fund(alice, carol, john)
 		env.Close()
 
-		expiration := rippleTime(env) + 20
+		expiration := env.NowRipple() + 20
 		jtx.RequireTxSuccess(t, env.Submit(
 			credential.CredentialCreate(carol, john, credType).Expiration(expiration).Build()))
 		env.Close()
@@ -416,7 +399,7 @@ func TestAccountDelete_CredentialExpiry(t *testing.T) {
 		env.Close()
 
 		// Far enough out to stay in the future across the 256-ledger advance.
-		expiration := rippleTime(env) + 20000
+		expiration := env.NowRipple() + 20000
 		jtx.RequireTxSuccess(t, env.Submit(
 			credential.CredentialCreate(carol, john, credType).Expiration(expiration).Build()))
 		env.Close()
@@ -436,7 +419,7 @@ func TestAccountDelete_CredentialExpiry(t *testing.T) {
 		env.Close()
 
 		env.IncLedgerSeqForAccDel(john)
-		closeToParentCloseTime(t, env, expiration)
+		env.CloseToParentCloseTime(expiration)
 
 		d := newAccountDelete(john, alice)
 		d.CredentialIDs = []string{credIdx}

--- a/internal/testing/amm/amm_clawback_test.go
+++ b/internal/testing/amm/amm_clawback_test.go
@@ -263,6 +263,7 @@ func TestAMMClawback_FeatureDisabled(t *testing.T) {
 
 	// Disable the AMMClawback amendment
 	env.DisableFeature("AMMClawback")
+	env.Close()
 
 	// When featureAMMClawback is not enabled, AMMClawback is disabled.
 	clawbackTx := amm.AMMClawback(env.GW, env.Alice.Address, env.USD, amm.XRP()).Build()

--- a/internal/testing/amm/amm_deposit_test.go
+++ b/internal/testing/amm/amm_deposit_test.go
@@ -511,6 +511,7 @@ func TestAMMDepositWithFrozenAssets(t *testing.T) {
 	t.Run("SingleAsset_NonFrozen_WithoutAMMClawback", func(t *testing.T) {
 		env := setupFrozenAMM(t)
 		env.DisableFeature("AMMClawback")
+		env.Close()
 
 		depositTx := amm.AMMDeposit(env.Alice, amm.XRP(), env.USD).
 			Amount(amm.XRPAmount(100)).

--- a/internal/testing/amm/amm_enabled_test.go
+++ b/internal/testing/amm/amm_enabled_test.go
@@ -18,8 +18,9 @@ func TestEnabled(t *testing.T) {
 		env.FundWithIOUs(30000, 0)
 		env.Close()
 
-		// Disable AMM amendment
+		// Disable AMM amendment (deferred — Close to apply it before submitting).
 		env.DisableFeature("AMM")
+		env.Close()
 
 		// AMMCreate should fail
 		createTx := amm.AMMCreate(env.Alice, amm.XRPAmount(10000), amm.IOUAmount(env.GW, "USD", 10000)).Build()
@@ -92,8 +93,9 @@ func TestFixUniversalNumberDisabled(t *testing.T) {
 	env.FundWithIOUs(30000, 0)
 	env.Close()
 
-	// Disable fixUniversalNumber (AMM requires both AMM and fixUniversalNumber)
+	// Disable fixUniversalNumber (AMM requires both AMM and fixUniversalNumber).
 	env.DisableFeature("fixUniversalNumber")
+	env.Close()
 
 	// AMMCreate should fail
 	createTx := amm.AMMCreate(env.Alice, amm.XRPAmount(10000), amm.IOUAmount(env.GW, "USD", 10000)).Build()
@@ -110,8 +112,9 @@ func TestAMMClawbackEnabled(t *testing.T) {
 		env.FundWithIOUs(30000, 0)
 		env.Close()
 
-		// Disable AMMClawback amendment
+		// Disable AMMClawback amendment (deferred — Close to apply it).
 		env.DisableFeature("AMMClawback")
+		env.Close()
 
 		// AMMClawback requires: AMM, fixUniversalNumber, and AMMClawback
 		clawbackTx := amm.AMMClawback(env.GW, env.Alice.Address, env.USD, amm.XRP()).Build()

--- a/internal/testing/assertions.go
+++ b/internal/testing/assertions.go
@@ -13,7 +13,7 @@ import (
 
 // RequireBalance asserts that an account has the expected XRP balance in drops.
 // This is a convenience wrapper around require.Equal for balance checks.
-func RequireBalance(t *testing.T, env *TestEnv, acc *Account, expected uint64) {
+func RequireBalance(t testing.TB, env *TestEnv, acc *Account, expected uint64) {
 	t.Helper()
 	actual := env.Balance(acc)
 	require.Equal(t, expected, actual,
@@ -23,28 +23,14 @@ func RequireBalance(t *testing.T, env *TestEnv, acc *Account, expected uint64) {
 
 // RequireBalanceXRP asserts that an account has the expected XRP balance.
 // The expected amount is in whole XRP units (e.g., 100 XRP, not drops).
-func RequireBalanceXRP(t *testing.T, env *TestEnv, acc *Account, expectedXRP int64) {
+func RequireBalanceXRP(t testing.TB, env *TestEnv, acc *Account, expectedXRP int64) {
 	t.Helper()
 	expected := uint64(XRP(expectedXRP))
 	RequireBalance(t, env, acc, expected)
 }
 
-// RequireBalanceApprox asserts that an account balance is within a tolerance of the expected value.
-// This is useful when fees or other small adjustments affect the exact balance.
-func RequireBalanceApprox(t *testing.T, env *TestEnv, acc *Account, expected uint64, tolerance uint64) {
-	t.Helper()
-	actual := env.Balance(acc)
-	diff := int64(actual) - int64(expected)
-	if diff < 0 {
-		diff = -diff
-	}
-	require.LessOrEqual(t, uint64(diff), tolerance,
-		"Account %s balance mismatch: expected %d +/- %d drops, got %d drops (diff: %d)",
-		acc.Name, expected, tolerance, actual, diff)
-}
-
 // RequireTxSuccess asserts that a transaction result indicates success.
-func RequireTxSuccess(t *testing.T, result TxResult) {
+func RequireTxSuccess(t testing.TB, result TxResult) {
 	t.Helper()
 	require.True(t, result.Success,
 		"Expected transaction success, got %s: %s", result.Code, result.Message)
@@ -53,7 +39,7 @@ func RequireTxSuccess(t *testing.T, result TxResult) {
 }
 
 // RequireTxFail asserts that a transaction result indicates failure with a specific code.
-func RequireTxFail(t *testing.T, result TxResult, expectedCode string) {
+func RequireTxFail(t testing.TB, result TxResult, expectedCode string) {
 	t.Helper()
 	require.False(t, result.Success,
 		"Expected transaction failure with code %s, but transaction succeeded", expectedCode)
@@ -63,7 +49,7 @@ func RequireTxFail(t *testing.T, result TxResult, expectedCode string) {
 
 // RequireTxClaimed asserts that a transaction had its fee claimed but wasn't applied.
 // This corresponds to "tec" result codes.
-func RequireTxClaimed(t *testing.T, result TxResult, expectedCode string) {
+func RequireTxClaimed(t testing.TB, result TxResult, expectedCode string) {
 	t.Helper()
 	require.True(t, result.IsClaimed(),
 		"Expected claimed transaction with code %s, got %s", expectedCode, result.Code)
@@ -72,21 +58,21 @@ func RequireTxClaimed(t *testing.T, result TxResult, expectedCode string) {
 }
 
 // RequireAccountExists asserts that an account exists in the ledger.
-func RequireAccountExists(t *testing.T, env *TestEnv, acc *Account) {
+func RequireAccountExists(t testing.TB, env *TestEnv, acc *Account) {
 	t.Helper()
 	require.True(t, env.Exists(acc),
 		"Expected account %s to exist, but it does not", acc.Name)
 }
 
 // RequireAccountNotExists asserts that an account does not exist in the ledger.
-func RequireAccountNotExists(t *testing.T, env *TestEnv, acc *Account) {
+func RequireAccountNotExists(t testing.TB, env *TestEnv, acc *Account) {
 	t.Helper()
 	require.False(t, env.Exists(acc),
 		"Expected account %s to not exist, but it does", acc.Name)
 }
 
 // RequireSequence asserts that an account has the expected sequence number.
-func RequireSequence(t *testing.T, env *TestEnv, acc *Account, expected uint32) {
+func RequireSequence(t testing.TB, env *TestEnv, acc *Account, expected uint32) {
 	t.Helper()
 	actual := env.Seq(acc)
 	require.Equal(t, expected, actual,
@@ -94,32 +80,12 @@ func RequireSequence(t *testing.T, env *TestEnv, acc *Account, expected uint32) 
 }
 
 // RequireOwnerCount asserts that an account has the expected owner count.
-func RequireOwnerCount(t *testing.T, env *TestEnv, acc *Account, expected uint32) {
+func RequireOwnerCount(t testing.TB, env *TestEnv, acc *Account, expected uint32) {
 	t.Helper()
 	info := env.AccountInfo(acc)
 	require.NotNil(t, info, "Account %s does not exist", acc.Name)
 	require.Equal(t, expected, info.OwnerCount,
 		"Account %s owner count mismatch: expected %d, got %d", acc.Name, expected, info.OwnerCount)
-}
-
-// AssertBalanceChange runs a function and asserts the expected balance change.
-// The change can be positive (increase) or negative (decrease).
-func AssertBalanceChange(t *testing.T, env *TestEnv, acc *Account, expectedChange int64, fn func()) {
-	t.Helper()
-	before := env.Balance(acc)
-	fn()
-	after := env.Balance(acc)
-
-	actualChange := int64(after) - int64(before)
-	require.Equal(t, expectedChange, actualChange,
-		"Account %s balance change mismatch: expected %d drops change, got %d drops change (before: %d, after: %d)",
-		acc.Name, expectedChange, actualChange, before, after)
-}
-
-// AssertNoBalanceChange runs a function and asserts the balance stays the same.
-func AssertNoBalanceChange(t *testing.T, env *TestEnv, acc *Account, fn func()) {
-	t.Helper()
-	AssertBalanceChange(t, env, acc, 0, fn)
 }
 
 // TxResultCode is a type alias for transaction result codes for better documentation.
@@ -264,20 +230,13 @@ func ResultCodeCategory(code string) string {
 	}
 }
 
-// FormatBalance formats a balance in drops as a human-readable string.
-// For example, 1000000000 drops becomes "1000.000000 XRP".
-func FormatBalance(drops uint64) string {
-	xrp := float64(drops) / float64(DropsPerXRP)
-	return fmt.Sprintf("%.6f XRP (%d drops)", xrp, drops)
-}
-
 // requireOwnedEntries asserts that an account's owner directory holds the
 // expected number of entries of the given ledger entry type. The owner
 // directory mixes object types (trust lines, offers, escrows, ...), so
 // counting filters by type; for trust lines both the low and high side
 // directories reference the shared RippleState entry, so each line the
 // account participates in is counted exactly once.
-func requireOwnedEntries(t *testing.T, env *TestEnv, acc *Account, entryType uint16, label string, expected uint32) {
+func requireOwnedEntries(t testing.TB, env *TestEnv, acc *Account, entryType uint16, label string, expected uint32) {
 	t.Helper()
 	info := env.AccountInfo(acc)
 	if info == nil {
@@ -312,20 +271,20 @@ func requireOwnedEntries(t *testing.T, env *TestEnv, acc *Account, entryType uin
 
 // RequireLines asserts that an account has the expected number of trust lines.
 // This counts RippleState entries in the account's owner directory.
-func RequireLines(t *testing.T, env *TestEnv, acc *Account, expected uint32) {
+func RequireLines(t testing.TB, env *TestEnv, acc *Account, expected uint32) {
 	t.Helper()
 	requireOwnedEntries(t, env, acc, uint16(entry.TypeRippleState), "trust line", expected)
 }
 
 // RequireOffers asserts that an account has the expected number of offers.
 // This counts Offer entries in the account's owner directory.
-func RequireOffers(t *testing.T, env *TestEnv, acc *Account, expected uint32) {
+func RequireOffers(t testing.TB, env *TestEnv, acc *Account, expected uint32) {
 	t.Helper()
 	requireOwnedEntries(t, env, acc, uint16(entry.TypeOffer), "offer", expected)
 }
 
 // RequireFlags asserts that an account has the expected flags set.
-func RequireFlags(t *testing.T, env *TestEnv, acc *Account, expectedFlags uint32) {
+func RequireFlags(t testing.TB, env *TestEnv, acc *Account, expectedFlags uint32) {
 	t.Helper()
 	info := env.AccountInfo(acc)
 	require.NotNil(t, info, "Account %s does not exist", acc.Name)
@@ -335,7 +294,7 @@ func RequireFlags(t *testing.T, env *TestEnv, acc *Account, expectedFlags uint32
 }
 
 // RequireFlagSet asserts that a specific flag is set on an account.
-func RequireFlagSet(t *testing.T, env *TestEnv, acc *Account, flag uint32) {
+func RequireFlagSet(t testing.TB, env *TestEnv, acc *Account, flag uint32) {
 	t.Helper()
 	info := env.AccountInfo(acc)
 	require.NotNil(t, info, "Account %s does not exist", acc.Name)
@@ -345,19 +304,13 @@ func RequireFlagSet(t *testing.T, env *TestEnv, acc *Account, flag uint32) {
 }
 
 // RequireFlagNotSet asserts that a specific flag is NOT set on an account.
-func RequireFlagNotSet(t *testing.T, env *TestEnv, acc *Account, flag uint32) {
+func RequireFlagNotSet(t testing.TB, env *TestEnv, acc *Account, flag uint32) {
 	t.Helper()
 	info := env.AccountInfo(acc)
 	require.NotNil(t, info, "Account %s does not exist", acc.Name)
 	require.True(t, (info.Flags&flag) == 0,
 		"Account %s expected flag 0x%x to NOT be set, but flags are 0x%x",
 		acc.Name, flag, info.Flags)
-}
-
-// XRPMinusFee calculates expected XRP balance after paying fees.
-// amount is in drops, fee defaults to env's base fee.
-func XRPMinusFee(env *TestEnv, amountXRP int64) uint64 {
-	return uint64(XRP(amountXRP)) - env.BaseFee()
 }
 
 // XRPMinusFees calculates expected XRP balance after paying multiple fees.
@@ -368,7 +321,7 @@ func XRPMinusFees(env *TestEnv, amountXRP int64, numFees int) uint64 {
 // RequireIOUBalance asserts that an account has the expected IOU balance.
 // The balance is from the holder's perspective.
 // Reference: rippled's require(env.balance(alice, USD) == USD(100))
-func RequireIOUBalance(t *testing.T, env *TestEnv, holder, issuer *Account, currency string, expected float64) {
+func RequireIOUBalance(t testing.TB, env *TestEnv, holder, issuer *Account, currency string, expected float64) {
 	t.Helper()
 	actual := env.BalanceIOU(holder, currency, issuer)
 	require.InDelta(t, expected, actual, 1e-10,
@@ -377,7 +330,7 @@ func RequireIOUBalance(t *testing.T, env *TestEnv, holder, issuer *Account, curr
 }
 
 // RequireIOUBalanceApprox asserts that an account IOU balance is within a tolerance of the expected value.
-func RequireIOUBalanceApprox(t *testing.T, env *TestEnv, holder, issuer *Account, currency string, expected, tolerance float64) {
+func RequireIOUBalanceApprox(t testing.TB, env *TestEnv, holder, issuer *Account, currency string, expected, tolerance float64) {
 	t.Helper()
 	actual := env.BalanceIOU(holder, currency, issuer)
 	diff := math.Abs(actual - expected)
@@ -387,14 +340,14 @@ func RequireIOUBalanceApprox(t *testing.T, env *TestEnv, holder, issuer *Account
 }
 
 // RequireLedgerEntryExists asserts that a ledger entry exists at the given keylet.
-func RequireLedgerEntryExists(t *testing.T, env *TestEnv, key keylet.Keylet) {
+func RequireLedgerEntryExists(t testing.TB, env *TestEnv, key keylet.Keylet) {
 	t.Helper()
 	require.True(t, env.LedgerEntryExists(key),
 		"Expected ledger entry to exist at keylet %v", key)
 }
 
 // RequireLedgerEntryNotExists asserts that a ledger entry does NOT exist at the given keylet.
-func RequireLedgerEntryNotExists(t *testing.T, env *TestEnv, key keylet.Keylet) {
+func RequireLedgerEntryNotExists(t testing.TB, env *TestEnv, key keylet.Keylet) {
 	t.Helper()
 	require.False(t, env.LedgerEntryExists(key),
 		"Expected ledger entry to NOT exist at keylet %v", key)
@@ -403,7 +356,7 @@ func RequireLedgerEntryNotExists(t *testing.T, env *TestEnv, key keylet.Keylet) 
 // RequireTicketCount asserts that an account has the expected number of tickets.
 // This iterates the owner directory and counts entries of type Ticket (0x0054),
 // matching rippled's owner_count<ltTICKET> behavior.
-func RequireTicketCount(t *testing.T, env *TestEnv, acc *Account, expected uint32) {
+func RequireTicketCount(t testing.TB, env *TestEnv, acc *Account, expected uint32) {
 	t.Helper()
 	dirKey := keylet.OwnerDir(acc.ID)
 	var count uint32
@@ -432,7 +385,7 @@ func RequireTicketCount(t *testing.T, env *TestEnv, acc *Account, expected uint3
 
 // RequireSignerListCount asserts that an account has the expected number of signer lists.
 // On the XRPL, an account can have at most one signer list, so expected is 0 or 1.
-func RequireSignerListCount(t *testing.T, env *TestEnv, acc *Account, expected uint32) {
+func RequireSignerListCount(t testing.TB, env *TestEnv, acc *Account, expected uint32) {
 	t.Helper()
 	key := keylet.SignerList(acc.ID)
 	exists := env.LedgerEntryExists(key)
@@ -446,7 +399,7 @@ func RequireSignerListCount(t *testing.T, env *TestEnv, acc *Account, expected u
 }
 
 // RequireTrustLineExists asserts that a trust line exists between two accounts for a currency.
-func RequireTrustLineExists(t *testing.T, env *TestEnv, acc1, acc2 *Account, currency string) {
+func RequireTrustLineExists(t testing.TB, env *TestEnv, acc1, acc2 *Account, currency string) {
 	t.Helper()
 	require.True(t, env.TrustLineExists(acc1, acc2, currency),
 		"Expected trust line to exist between %s and %s for %s",
@@ -454,7 +407,7 @@ func RequireTrustLineExists(t *testing.T, env *TestEnv, acc1, acc2 *Account, cur
 }
 
 // RequireTrustLineNotExists asserts that a trust line does NOT exist between two accounts for a currency.
-func RequireTrustLineNotExists(t *testing.T, env *TestEnv, acc1, acc2 *Account, currency string) {
+func RequireTrustLineNotExists(t testing.TB, env *TestEnv, acc1, acc2 *Account, currency string) {
 	t.Helper()
 	require.False(t, env.TrustLineExists(acc1, acc2, currency),
 		"Expected no trust line between %s and %s for %s",
@@ -463,7 +416,7 @@ func RequireTrustLineNotExists(t *testing.T, env *TestEnv, acc1, acc2 *Account, 
 
 // RequireMintedCount asserts that an account has the expected number of minted NFTokens.
 // Reference: rippled's mintedCount() test helper.
-func RequireMintedCount(t *testing.T, env *TestEnv, acc *Account, expected uint32) {
+func RequireMintedCount(t testing.TB, env *TestEnv, acc *Account, expected uint32) {
 	t.Helper()
 	actual := env.MintedCount(acc)
 	require.Equal(t, expected, actual,
@@ -473,7 +426,7 @@ func RequireMintedCount(t *testing.T, env *TestEnv, acc *Account, expected uint3
 
 // RequireBurnedCount asserts that an account has the expected number of burned NFTokens.
 // Reference: rippled's burnedCount() test helper.
-func RequireBurnedCount(t *testing.T, env *TestEnv, acc *Account, expected uint32) {
+func RequireBurnedCount(t testing.TB, env *TestEnv, acc *Account, expected uint32) {
 	t.Helper()
 	actual := env.BurnedCount(acc)
 	require.Equal(t, expected, actual,

--- a/internal/testing/clock.go
+++ b/internal/testing/clock.go
@@ -19,13 +19,6 @@ func NewManualClock() *ManualClock {
 	}
 }
 
-// NewManualClockAt creates a new ManualClock set to the specified time.
-func NewManualClockAt(t time.Time) *ManualClock {
-	return &ManualClock{
-		current: t,
-	}
-}
-
 // Now returns the current time on the clock.
 func (c *ManualClock) Now() time.Time {
 	c.mu.RLock()

--- a/internal/testing/conformance/runner.go
+++ b/internal/testing/conformance/runner.go
@@ -704,7 +704,7 @@ func RunFixture(t *testing.T, fixturePath string) {
 		case "env_reset":
 			r.execEnvReset(i, step)
 		case "enable_amendment":
-			r.env.EnableFeature(step.Amendment)
+			r.env.EnableFeatureNow(step.Amendment)
 		case "modify_state":
 			r.execModifyState(i, step)
 		default:
@@ -814,7 +814,7 @@ func (r *runner) replaySteps(steps []Step, isContinuation bool) {
 			// During replay, the txns were already applied by Close().
 			// Nothing to do here.
 		case "enable_amendment":
-			r.env.EnableFeature(step.Amendment)
+			r.env.EnableFeatureNow(step.Amendment)
 		case "modify_state":
 			r.execModifyState(i, step)
 		case "env_reset":
@@ -1816,24 +1816,14 @@ func (r *runner) shouldAutoFund(steps []Step) bool {
 //
 // For Credential and similar transaction types, auxiliary accounts (Subject,
 // Issuer, Destination) are also funded when they need to exist for preclaim
-// checks. However, accounts that have explicit fund steps in the fixture are
-// NOT auto-funded as auxiliary accounts — the fixture intends to fund them
-// at a specific time and amount.
+// checks. Auxiliary accounts a fixture deliberately leaves uncreated — detected
+// via an expected tecNO_TARGET/tecNO_ISSUER on the first tx that references them
+// (see findSkipAuxAddresses) — are excluded from auto-funding.
 //
 // Initial funding amounts are derived from the first post_state entry for
 // each account when possible. This is critical for reserve-sensitive tests
 // where the exact balance determines the TER code.
 func (r *runner) autoFundAccounts(steps []Step) {
-	// Build a map of addresses that have explicit fund steps.
-	// These addresses should not be auto-funded as auxiliary accounts because the
-	// fixture deliberately controls when they are created.
-	explicitFundAddrs := make(map[string]bool) // addresses with explicit fund steps
-	for _, s := range steps {
-		if s.Op == "fund" && s.Address != "" {
-			explicitFundAddrs[s.Address] = true
-		}
-	}
-
 	// Derive the initial funding amount for each account from the first
 	// post_state entry. For applied tx results (tesSUCCESS/tec*), the
 	// post_state balance = initial_balance - fees_consumed. By analyzing

--- a/internal/testing/credential/credential_delete_audit_test.go
+++ b/internal/testing/credential/credential_delete_audit_test.go
@@ -73,10 +73,10 @@ func TestCredentialAccept_ExpiredRemovesFromBothDirectories(t *testing.T) {
 	env.Fund(issuer, subject)
 	env.Close()
 
-	credKey := credentialKeylet(subject, issuer, credType)
+	credKey := jtx.CredentialKeylet(subject, issuer, credType)
 
 	// Issuer creates a credential for subject with a short expiration.
-	now := rippleTime(env)
+	now := env.NowRipple()
 	r := env.Submit(credential.CredentialCreate(issuer, subject, credType).
 		Expiration(now + 20).Build())
 	jtx.RequireTxSuccess(t, r)
@@ -91,7 +91,7 @@ func TestCredentialAccept_ExpiredRemovesFromBothDirectories(t *testing.T) {
 	require.Equal(t, uint32(0), env.OwnerCount(subject), "subject does not own un-accepted credential")
 
 	// Advance time past expiry, then attempt to accept.
-	for rippleTime(env) <= now+20 {
+	for env.NowRipple() <= now+20 {
 		env.Close()
 	}
 
@@ -122,7 +122,7 @@ func TestCredentialDelete_ViaDeleteSLE_AcceptedBySubject(t *testing.T) {
 	env.Fund(issuer, subject)
 	env.Close()
 
-	credKey := credentialKeylet(subject, issuer, credType)
+	credKey := jtx.CredentialKeylet(subject, issuer, credType)
 
 	r := env.Submit(credential.CredentialCreate(issuer, subject, credType).Build())
 	jtx.RequireTxSuccess(t, r)
@@ -164,7 +164,7 @@ func TestCredentialDelete_ViaDeleteSLE_UnacceptedByIssuer(t *testing.T) {
 	env.Fund(issuer, subject)
 	env.Close()
 
-	credKey := credentialKeylet(subject, issuer, credType)
+	credKey := jtx.CredentialKeylet(subject, issuer, credType)
 
 	r := env.Submit(credential.CredentialCreate(issuer, subject, credType).Build())
 	jtx.RequireTxSuccess(t, r)

--- a/internal/testing/credential/credential_test.go
+++ b/internal/testing/credential/credential_test.go
@@ -14,23 +14,11 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/credential"
 	acctx "github.com/LeJamon/go-xrpl/internal/tx/account"
 	credtx "github.com/LeJamon/go-xrpl/internal/tx/credential"
-	"github.com/LeJamon/go-xrpl/keylet"
-	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // xrpAccount is the XRPL zero account address (20 bytes of zero).
 // This matches rippled's xrpAccount() / noAccount().
 const xrpAccount = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
-
-// credentialKeylet computes the keylet for a credential given subject, issuer, and raw credential type.
-func credentialKeylet(subject, issuer *jtx.Account, credType string) keylet.Keylet {
-	return keylet.Credential(subject.ID, issuer.ID, []byte(credType))
-}
-
-// rippleTime returns the current Ripple epoch time from the test environment.
-func rippleTime(env *jtx.TestEnv) uint32 {
-	return uint32(env.Now().Unix() - protocol.RippleEpochUnix)
-}
 
 // TestSuccessful tests the basic credential lifecycle: create, accept, delete.
 // Reference: rippled Credentials_test.cpp testSuccessful
@@ -45,7 +33,7 @@ func TestSuccessful(t *testing.T) {
 	env.Fund(issuer, subject)
 	env.Close()
 
-	credKey := credentialKeylet(subject, issuer, credType)
+	credKey := jtx.CredentialKeylet(subject, issuer, credType)
 
 	// Test: Create credential for subject
 	t.Run("CreateForSubject", func(t *testing.T) {
@@ -129,7 +117,7 @@ func TestCreateForSelf(t *testing.T) {
 	env.Fund(issuer)
 	env.Close()
 
-	credKey := credentialKeylet(issuer, issuer, credType)
+	credKey := jtx.CredentialKeylet(issuer, issuer, credType)
 
 	// Test: Create credential for self (issuer == subject)
 	t.Run("CreateForSelf", func(t *testing.T) {
@@ -187,7 +175,7 @@ func TestCredentialsDelete(t *testing.T) {
 	t.Run("DeleteByOther", func(t *testing.T) {
 		ct := "delother"
 		// Create credential with near-future expiration
-		now := rippleTime(env)
+		now := env.NowRipple()
 		tx := credential.CredentialCreate(issuer, subject, ct).
 			Expiration(now + 20).Build()
 		result := env.Submit(tx)
@@ -210,7 +198,7 @@ func TestCredentialsDelete(t *testing.T) {
 		env.Close()
 
 		// Verify credential deleted and owner counts reset
-		credKey := credentialKeylet(subject, issuer, ct)
+		credKey := jtx.CredentialKeylet(subject, issuer, ct)
 		if env.LedgerEntryExists(credKey) {
 			t.Error("Expected credential to be deleted")
 		}
@@ -239,7 +227,7 @@ func TestCredentialsDelete(t *testing.T) {
 		}
 		env.Close()
 
-		credKey := credentialKeylet(subject, issuer, ct)
+		credKey := jtx.CredentialKeylet(subject, issuer, ct)
 		if env.LedgerEntryExists(credKey) {
 			t.Error("Expected credential to be deleted")
 		}
@@ -268,7 +256,7 @@ func TestCredentialsDelete(t *testing.T) {
 		}
 		env.Close()
 
-		credKey := credentialKeylet(subject, issuer, ct)
+		credKey := jtx.CredentialKeylet(subject, issuer, ct)
 		if env.LedgerEntryExists(credKey) {
 			t.Error("Expected credential to be deleted")
 		}
@@ -304,7 +292,7 @@ func TestCredentialsDelete(t *testing.T) {
 		env.Close()
 
 		// Credential should be cleaned up by cascade delete
-		credKey := credentialKeylet(subject, issuer, ct)
+		credKey := jtx.CredentialKeylet(subject, issuer, ct)
 		if env.LedgerEntryExists(credKey) {
 			t.Error("Expected credential to be deleted when issuer account is deleted")
 		}
@@ -346,7 +334,7 @@ func TestCredentialsDelete(t *testing.T) {
 		}
 		env.Close()
 
-		credKey := credentialKeylet(subject, issuer, ct)
+		credKey := jtx.CredentialKeylet(subject, issuer, ct)
 		if env.LedgerEntryExists(credKey) {
 			t.Error("Expected credential to be deleted when issuer account is deleted")
 		}
@@ -381,7 +369,7 @@ func TestCredentialsDelete(t *testing.T) {
 		}
 		env.Close()
 
-		credKey := credentialKeylet(subject, issuer, ct)
+		credKey := jtx.CredentialKeylet(subject, issuer, ct)
 		if env.LedgerEntryExists(credKey) {
 			t.Error("Expected credential to be deleted when subject account is deleted")
 		}
@@ -423,7 +411,7 @@ func TestCredentialsDelete(t *testing.T) {
 		}
 		env.Close()
 
-		credKey := credentialKeylet(subject, issuer, ct)
+		credKey := jtx.CredentialKeylet(subject, issuer, ct)
 		if env.LedgerEntryExists(credKey) {
 			t.Error("Expected credential to be deleted when subject account is deleted")
 		}
@@ -539,7 +527,7 @@ func TestCreateFailed(t *testing.T) {
 
 	// Reference: rippled "Credentials fail, expiration in the past."
 	t.Run("ExpirationInPast", func(t *testing.T) {
-		now := rippleTime(env)
+		now := env.NowRipple()
 		tx := credential.CredentialCreate(issuer, subject, credType).
 			Expiration(now - 1).Build()
 		result := env.Submit(tx)
@@ -581,7 +569,7 @@ func TestCreateFailed(t *testing.T) {
 		env.Close()
 
 		// Verify credential still present after failed duplicate attempt
-		credKey := credentialKeylet(subject, issuer, credType)
+		credKey := jtx.CredentialKeylet(subject, issuer, credType)
 		if !env.LedgerEntryExists(credKey) {
 			t.Error("Expected credential to still exist after failed duplicate create")
 		}
@@ -726,7 +714,7 @@ func TestAcceptFailed(t *testing.T) {
 		env.Close()
 
 		// Verify credential still present after failed re-accept
-		credKey := credentialKeylet(subject, issuer, credType)
+		credKey := jtx.CredentialKeylet(subject, issuer, credType)
 		if !env.LedgerEntryExists(credKey) {
 			t.Error("Expected credential to still exist after failed re-accept")
 		}
@@ -745,7 +733,7 @@ func TestAcceptFailed(t *testing.T) {
 		// Create credential with expiration at current time.
 		// In rippled, setting expiration to parentCloseTime and then closing one ledger
 		// makes the credential expired on the next operation.
-		now := rippleTime(env)
+		now := env.NowRipple()
 		tx := credential.CredentialCreate(issuer, subject, credType2).
 			Expiration(now).Build()
 		result := env.Submit(tx)
@@ -764,7 +752,7 @@ func TestAcceptFailed(t *testing.T) {
 		env.Close()
 
 		// Verify that expired credentials were auto-deleted
-		credKey := credentialKeylet(subject, issuer, credType2)
+		credKey := jtx.CredentialKeylet(subject, issuer, credType2)
 		if env.LedgerEntryExists(credKey) {
 			t.Error("Expected expired credential to be auto-deleted on failed accept")
 		}
@@ -807,7 +795,7 @@ func TestAcceptFailed(t *testing.T) {
 		env.Close()
 
 		// Credential should have been cleaned up when issuer was deleted
-		credKey := credentialKeylet(subject, issuer, ct)
+		credKey := jtx.CredentialKeylet(subject, issuer, ct)
 		if env.LedgerEntryExists(credKey) {
 			t.Error("Expected credential to not exist after issuer account deletion")
 		}
@@ -852,7 +840,7 @@ func TestAcceptReserve(t *testing.T) {
 	env.Close()
 
 	// Verify credential still present after failed accept
-	credKey := credentialKeylet(subject, issuer, credType)
+	credKey := jtx.CredentialKeylet(subject, issuer, credType)
 	if !env.LedgerEntryExists(credKey) {
 		t.Error("Expected credential to still exist after failed accept")
 	}
@@ -950,7 +938,7 @@ func TestDeleteFailed(t *testing.T) {
 		env.Close()
 
 		// Verify credential still present after failed delete
-		credKey := credentialKeylet(subject, issuer, credType2)
+		credKey := jtx.CredentialKeylet(subject, issuer, credType2)
 		if !env.LedgerEntryExists(credKey) {
 			t.Error("Expected credential to still exist after failed delete by other")
 		}
@@ -964,7 +952,7 @@ func TestDeleteFailed(t *testing.T) {
 	// Reference: rippled "CredentialsDelete fail, time not expired yet."
 	// Credential has an expiration but it hasn't passed yet — other can't delete.
 	t.Run("TimeNotExpiredYet", func(t *testing.T) {
-		now := rippleTime(env)
+		now := env.NowRipple()
 		// Create credential with expiration far in the future
 		tx := credential.CredentialCreate(issuer, subject, credType).
 			Expiration(now + 1000).Build()
@@ -983,7 +971,7 @@ func TestDeleteFailed(t *testing.T) {
 		env.Close()
 
 		// Verify credential still present
-		credKey := credentialKeylet(subject, issuer, credType)
+		credKey := jtx.CredentialKeylet(subject, issuer, credType)
 		if !env.LedgerEntryExists(credKey) {
 			t.Error("Expected credential to still exist (not yet expired)")
 		}
@@ -1053,7 +1041,7 @@ func TestDeleteBySubject(t *testing.T) {
 	env.Close()
 
 	// Verify credential gone and owner counts zero
-	credKey := credentialKeylet(subject, issuer, credType)
+	credKey := jtx.CredentialKeylet(subject, issuer, credType)
 	if env.LedgerEntryExists(credKey) {
 		t.Error("Expected credential to be deleted")
 	}
@@ -1094,7 +1082,7 @@ func TestDeleteByIssuer(t *testing.T) {
 	env.Close()
 
 	// Verify credential gone and owner counts zero
-	credKey := credentialKeylet(subject, issuer, credType)
+	credKey := jtx.CredentialKeylet(subject, issuer, credType)
 	if env.LedgerEntryExists(credKey) {
 		t.Error("Expected credential to be deleted")
 	}
@@ -1163,6 +1151,7 @@ func TestEnabled(t *testing.T) {
 
 	// Disable the Credentials amendment
 	env.DisableFeature("Credentials")
+	env.Close()
 
 	// Without the featureCredentials amendment, all credential transactions should fail
 	t.Run("CreateDisabled", func(t *testing.T) {

--- a/internal/testing/depositpreauth/depositpreauth_test.go
+++ b/internal/testing/depositpreauth/depositpreauth_test.go
@@ -16,23 +16,11 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/depositpreauth"
 	paymentPkg "github.com/LeJamon/go-xrpl/internal/tx/payment"
-	"github.com/LeJamon/go-xrpl/keylet"
-	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/stretchr/testify/require"
 )
 
 // xrpAccount is the XRPL zero account address (20 bytes of zero).
 const xrpAccount = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
-
-// rippleTime returns the current Ripple epoch time from the test environment.
-func rippleTime(env *jtx.TestEnv) uint32 {
-	return uint32(env.Now().Unix() - protocol.RippleEpochUnix)
-}
-
-// credentialKeylet computes the keylet for a credential.
-func credentialKeylet(subject, issuer *jtx.Account, credType string) keylet.Keylet {
-	return keylet.Credential(subject.ID, issuer.ID, []byte(credType))
-}
 
 // --------------------------------------------------------------------------
 // testEnable
@@ -1058,7 +1046,7 @@ func TestDepositPreauth_ExpiredCreds(t *testing.T) {
 		env.Close()
 
 		// Issuer creates credential for alice with expiration (current time + 60s).
-		now := rippleTime(env)
+		now := env.NowRipple()
 		expiration := now + 60
 		result := env.Submit(
 			credential.CredentialCreate(issuer, alice, credType).
@@ -1074,7 +1062,7 @@ func TestDepositPreauth_ExpiredCreds(t *testing.T) {
 		env.Close()
 
 		// Issuer creates non-expiring credential for alice (expiration far in the future).
-		now = rippleTime(env)
+		now = env.NowRipple()
 		result = env.Submit(
 			credential.CredentialCreate(issuer, alice, credType2).
 				Expiration(now + 1000).
@@ -1124,12 +1112,12 @@ func TestDepositPreauth_ExpiredCreds(t *testing.T) {
 		env.Close()
 
 		// Expired credential should be deleted.
-		credKey := credentialKeylet(alice, issuer, credType)
+		credKey := jtx.CredentialKeylet(alice, issuer, credType)
 		require.False(t, env.LedgerEntryExists(credKey),
 			"expired credential should be deleted from ledger")
 
 		// Non-expired credential should still be present.
-		credKey2 := credentialKeylet(alice, issuer, credType2)
+		credKey2 := jtx.CredentialKeylet(alice, issuer, credType2)
 		require.True(t, env.LedgerEntryExists(credKey2),
 			"non-expired credential should still exist")
 
@@ -1137,7 +1125,7 @@ func TestDepositPreauth_ExpiredCreds(t *testing.T) {
 		jtx.RequireOwnerCount(t, env, alice, 1) // only credType2 remains
 
 		// Additional test: issuer creates credential for gw with short expiration.
-		now = rippleTime(env)
+		now = env.NowRipple()
 		result = env.Submit(
 			credential.CredentialCreate(issuer, gw, credType).
 				Expiration(now + 40).
@@ -1170,7 +1158,7 @@ func TestDepositPreauth_ExpiredCreds(t *testing.T) {
 		env.Close()
 
 		// Expired credential should be deleted.
-		gwCredKey := credentialKeylet(gw, issuer, credType)
+		gwCredKey := jtx.CredentialKeylet(gw, issuer, credType)
 		require.False(t, env.LedgerEntryExists(gwCredKey))
 		jtx.RequireOwnerCount(t, env, issuer, 0)
 		jtx.RequireOwnerCount(t, env, gw, 0)
@@ -1189,7 +1177,7 @@ func TestDepositPreauth_ExpiredCreds(t *testing.T) {
 		env.Close()
 
 		// Issuer creates credential for zelda with short expiration.
-		now := rippleTime(env)
+		now := env.NowRipple()
 		result := env.Submit(
 			credential.CredentialCreate(issuer, zelda, credType).
 				Expiration(now + 50).
@@ -1244,7 +1232,7 @@ func TestDepositPreauth_ExpiredCreds(t *testing.T) {
 		_ = credIdx
 
 		// Verify expired credentials were deleted.
-		zeldaCredKey := credentialKeylet(zelda, issuer, credType)
+		zeldaCredKey := jtx.CredentialKeylet(zelda, issuer, credType)
 		// After the escrow finish attempt with expired creds, the credential should be deleted.
 		// Since we can't fully test escrow here, at least verify the credential still exists
 		// (it will be deleted when a transaction attempts to use it after expiration).

--- a/internal/testing/depositpreauth/verify_deposit_preauth_test.go
+++ b/internal/testing/depositpreauth/verify_deposit_preauth_test.go
@@ -37,7 +37,7 @@ func TestDepositAuth_ExpiredCredentialsReserveExemption(t *testing.T) {
 	env.Close()
 
 	// Issuer creates a soon-to-expire credential for alice; alice accepts.
-	expiration := rippleTime(env) + 50
+	expiration := env.NowRipple() + 50
 	result := env.Submit(
 		credential.CredentialCreate(issuer, alice, credType).
 			Expiration(expiration).
@@ -50,7 +50,7 @@ func TestDepositAuth_ExpiredCredentialsReserveExemption(t *testing.T) {
 	env.Close()
 
 	credIdx := dp.CredentialIndex(alice, issuer, credType)
-	credKey := credentialKeylet(alice, issuer, credType)
+	credKey := jtx.CredentialKeylet(alice, issuer, credType)
 
 	// Bring bob's XRP balance down to exactly the base reserve.
 	// bob does NOT have lsfDepositAuth set.
@@ -128,7 +128,7 @@ func TestPayment_ExpiredCredentialsNoDepositAuthDestination(t *testing.T) {
 	env.Close()
 
 	// Issuer creates a soon-to-expire credential for alice; alice accepts.
-	expiration := rippleTime(env) + 50
+	expiration := env.NowRipple() + 50
 	result = env.Submit(
 		credential.CredentialCreate(issuer, alice, credType).
 			Expiration(expiration).
@@ -141,7 +141,7 @@ func TestPayment_ExpiredCredentialsNoDepositAuthDestination(t *testing.T) {
 	env.Close()
 
 	credIdx := dp.CredentialIndex(alice, issuer, credType)
-	credKey := credentialKeylet(alice, issuer, credType)
+	credKey := jtx.CredentialKeylet(alice, issuer, credType)
 
 	// Let the credential expire.
 	env.AdvanceTime(60 * time.Second)
@@ -190,7 +190,7 @@ func TestMPTPayment_CanTransferCheckedBeforeDepositPreauth(t *testing.T) {
 	mptAlice.Pay(alice, bob, 100)
 
 	// Issuer creates a soon-to-expire credential for bob; bob accepts.
-	expiration := rippleTime(env) + 50
+	expiration := env.NowRipple() + 50
 	result := env.Submit(
 		credential.CredentialCreate(issuer, bob, credType).
 			Expiration(expiration).
@@ -203,7 +203,7 @@ func TestMPTPayment_CanTransferCheckedBeforeDepositPreauth(t *testing.T) {
 	env.Close()
 
 	credIdx := dp.CredentialIndex(bob, issuer, credType)
-	credKey := credentialKeylet(bob, issuer, credType)
+	credKey := jtx.CredentialKeylet(bob, issuer, credType)
 
 	// Let the credential expire.
 	env.AdvanceTime(60 * time.Second)

--- a/internal/testing/doc.go
+++ b/internal/testing/doc.go
@@ -19,19 +19,13 @@
 //
 //	    alice := testing.NewAccount("alice")
 //	    bob := testing.NewAccount("bob")
-//
 //	    env.Fund(alice, bob)
 //	    env.Close()
 //
-//	    // Alice sends 100 XRP to Bob
-//	    payment := builders.Pay(
-//	        &builders.Account{Address: alice.Address},
-//	        &builders.Account{Address: bob.Address},
-//	        testing.XRP(100),
-//	    ).Build()
-//
-//	    result := env.Submit(payment)
-//	    testing.RequireTxSuccess(t, result)
+//	    // Alice sends 100 XRP to Bob. Submit auto-fills the fee and sequence.
+//	    pay := payment.NewPayment(alice.Address, bob.Address,
+//	        tx.NewXRPAmount(testing.XRP(100)))
+//	    testing.RequireTxSuccess(t, env.Submit(pay))
 //	}
 //
 // # TestEnv
@@ -71,24 +65,22 @@
 //	testing.EUR(gateway, 50.00)   // 50 EUR from gateway
 //	testing.IssuedCurrency(gateway, "JPY", 1000.0)  // Custom currency
 //
-// # Transaction Builders
+// # Submitting Transactions
 //
-// The builders package provides fluent interfaces for constructing transactions:
+// Build a transaction with its package constructor, set any optional fields, and
+// pass it to env.Submit. Submit auto-fills the fee and sequence when unset:
 //
-//	// Payment
-//	builders.Pay(from, to, amount).Fee(10).Build()
+//	pay := payment.NewPayment(alice.Address, bob.Address, tx.NewXRPAmount(testing.XRP(100)))
+//	env.Submit(pay)
 //
-//	// Trust line
-//	builders.TrustUSD(account, issuer, "1000000").Build()
+//	ts := trustset.NewTrustSet(alice.Address, gateway.IOU("USD", 1000))
+//	env.Submit(ts)
 //
-//	// Offer
-//	builders.OfferCreate(account, takerPays, takerGets).Passive().Build()
+// TestEnv also exposes convenience helpers for common setup:
 //
-//	// Escrow
-//	builders.EscrowCreate(from, to, amount).
-//	    FinishTime(time.Now().Add(24 * time.Hour)).
-//	    Condition(builders.TestCondition1).
-//	    Build()
+//	env.Trust(alice, gateway.IOU("USD", 1000)) // create a trust line
+//	env.PayIOU(alice, bob, gateway, "USD", 50) // send issued currency
+//	env.CreateOffer(alice, takerGets, takerPays)
 //
 // # Assertions
 //

--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -20,10 +20,8 @@ import (
 // It provides a simplified interface for creating accounts, funding them,
 // submitting transactions, and verifying results.
 type TestEnv struct {
-	// t is the active testing.TB used for Helper / Fatalf / Cleanup.
-	// Captured at construction; use WithT to retarget at a subtest's *testing.T
-	// so that failures attribute to the running subtest rather than the parent.
-	// testing.TB is an interface so both *testing.T and *testing.B work.
+	// t is the active testing.TB used for Helper / Fatalf / Cleanup, captured at
+	// construction. testing.TB is an interface so both *testing.T and *testing.B work.
 	t        testing.TB
 	ledger   *ledger.Ledger
 	clock    *ManualClock
@@ -58,12 +56,17 @@ type TestEnv struct {
 	// Reference: rippled's FeatureBitset in test/jtx/Env.h
 	rulesBuilder *amendment.RulesBuilder
 
-	// pendingAmendments stores amendment names that take effect on next Close().
-	// Matches rippled where enableFeature/disableFeature require close() for
-	// changes to take effect.
+	// pendingAmendments / pendingEnable / pendingDisable stage amendment changes
+	// that take effect on the next Close(), matching rippled where
+	// enableFeature/disableFeature require close() for changes to take effect.
+	// pendingAmendments (set by SetAmendments) REPLACES the whole rule set;
+	// pendingEnable/pendingDisable (set by EnableFeature/DisableFeature) are
+	// deltas applied on top of the current set. All are validated at call time.
 	// Reference: rippled Env.cpp: "Env::close() must be called for feature
 	// enable to take place."
 	pendingAmendments []string
+	pendingEnable     []string
+	pendingDisable    []string
 
 	// NetworkID for engine configuration (0 = mainnet default, >1024 requires NetworkID in txns)
 	networkID uint32
@@ -261,14 +264,6 @@ func NewTestEnvBacked(t testing.TB) *TestEnv {
 	return env
 }
 
-// NewTestEnvWithConfigBacked creates a test environment with custom config and PebbleDB backing.
-func NewTestEnvWithConfigBacked(t testing.TB, cfg genesis.Config) *TestEnv {
-	t.Helper()
-	env := NewTestEnvWithConfig(t, cfg)
-	env.enablePebbleBacking(t)
-	return env
-}
-
 // enablePebbleBacking enables PebbleDB-backed SHAMaps on the environment.
 // Must be called before any transactions are submitted.
 func (e *TestEnv) enablePebbleBacking(t testing.TB) {
@@ -445,13 +440,4 @@ func (e *TestEnv) syncFeeSettings() {
 // the transaction set. Cleared after use.
 func (e *TestEnv) SetNextCloseSalt(salt [32]byte) {
 	e.nextCloseSalt = &salt
-}
-
-// WithT retargets the env at the given testing.TB. Use this from a subtest
-// so that env-driven Helper / Fatalf calls attribute failures to the subtest
-// rather than the parent test captured at construction.
-func (e *TestEnv) WithT(t testing.TB) *TestEnv {
-	t.Helper()
-	e.t = t
-	return e
 }

--- a/internal/testing/env_flags.go
+++ b/internal/testing/env_flags.go
@@ -7,92 +7,64 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/offer"
 )
 
+// setAccountFlag submits an AccountSet that sets flag on acc, failing the test
+// if it is not applied. clearAccountFlag is the mirror that clears flag. These
+// back the named EnableX/DisableX helpers below, which differ only by the flag.
+func (e *TestEnv) setAccountFlag(acc *Account, flag uint32) {
+	e.t.Helper()
+	e.submitAccountFlag(acc, &flag, nil)
+}
+
+func (e *TestEnv) clearAccountFlag(acc *Account, flag uint32) {
+	e.t.Helper()
+	e.submitAccountFlag(acc, nil, &flag)
+}
+
+func (e *TestEnv) submitAccountFlag(acc *Account, setFlag, clearFlag *uint32) {
+	e.t.Helper()
+	as := account.NewAccountSet(acc.Address)
+	as.SetFlag = setFlag
+	as.ClearFlag = clearFlag
+	as.Fee = formatUint64(e.baseFee)
+	seq := e.Seq(acc)
+	as.Sequence = &seq
+	if result := e.Submit(as); !result.Success {
+		e.t.Fatalf("AccountSet flag change for %s failed: %s", acc.Name, result.Code)
+	}
+}
+
 // EnableDepositAuth enables the DepositAuth flag on an account.
 // When enabled, the account can only receive payments from preauthorized accounts.
 func (e *TestEnv) EnableDepositAuth(acc *Account) {
 	e.t.Helper()
-
-	accountSet := account.NewAccountSet(acc.Address)
-	accountSet.EnableDepositAuth()
-	accountSet.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	accountSet.Sequence = &seq
-
-	result := e.Submit(accountSet)
-	if !result.Success {
-		e.t.Fatalf("Failed to enable DepositAuth for account %s: %s", acc.Name, result.Code)
-	}
+	e.setAccountFlag(acc, account.AccountSetFlagDepositAuth)
 }
 
 // DisableDepositAuth disables the DepositAuth flag on an account.
 func (e *TestEnv) DisableDepositAuth(acc *Account) {
 	e.t.Helper()
-
-	accountSet := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagDepositAuth
-	accountSet.ClearFlag = &flag
-	accountSet.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	accountSet.Sequence = &seq
-
-	result := e.Submit(accountSet)
-	if !result.Success {
-		e.t.Fatalf("Failed to disable DepositAuth for account %s: %s", acc.Name, result.Code)
-	}
+	e.clearAccountFlag(acc, account.AccountSetFlagDepositAuth)
 }
 
 // EnableGlobalFreeze enables the GlobalFreeze flag on an account.
 // When enabled, all trust lines for this account's issued currencies are frozen.
 func (e *TestEnv) EnableGlobalFreeze(acc *Account) {
 	e.t.Helper()
-
-	accountSet := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagGlobalFreeze
-	accountSet.SetFlag = &flag
-	accountSet.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	accountSet.Sequence = &seq
-
-	result := e.Submit(accountSet)
-	if !result.Success {
-		e.t.Fatalf("Failed to enable GlobalFreeze for account %s: %s", acc.Name, result.Code)
-	}
+	e.setAccountFlag(acc, account.AccountSetFlagGlobalFreeze)
 }
 
 // DisableGlobalFreeze disables the GlobalFreeze flag on an account.
 // Note: Cannot be cleared if NoFreeze is set.
 func (e *TestEnv) DisableGlobalFreeze(acc *Account) {
 	e.t.Helper()
-
-	accountSet := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagGlobalFreeze
-	accountSet.ClearFlag = &flag
-	accountSet.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	accountSet.Sequence = &seq
-
-	result := e.Submit(accountSet)
-	if !result.Success {
-		e.t.Fatalf("Failed to disable GlobalFreeze for account %s: %s", acc.Name, result.Code)
-	}
+	e.clearAccountFlag(acc, account.AccountSetFlagGlobalFreeze)
 }
 
 // EnableNoFreeze enables the NoFreeze flag on an account.
 // Once set, this flag cannot be cleared. It prevents the account from freezing trust lines.
 func (e *TestEnv) EnableNoFreeze(acc *Account) {
 	e.t.Helper()
-
-	accountSet := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagNoFreeze
-	accountSet.SetFlag = &flag
-	accountSet.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	accountSet.Sequence = &seq
-
-	result := e.Submit(accountSet)
-	if !result.Success {
-		e.t.Fatalf("Failed to enable NoFreeze for account %s: %s", acc.Name, result.Code)
-	}
+	e.setAccountFlag(acc, account.AccountSetFlagNoFreeze)
 }
 
 // SetTransferRate sets the transfer rate for an account.
@@ -117,70 +89,26 @@ func (e *TestEnv) SetTransferRate(acc *Account, rate uint32) {
 // When enabled, trust lines to this account require authorization.
 func (e *TestEnv) EnableRequireAuth(acc *Account) {
 	e.t.Helper()
-
-	accountSet := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagRequireAuth
-	accountSet.SetFlag = &flag
-	accountSet.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	accountSet.Sequence = &seq
-
-	result := e.Submit(accountSet)
-	if !result.Success {
-		e.t.Fatalf("Failed to enable RequireAuth for account %s: %s", acc.Name, result.Code)
-	}
+	e.setAccountFlag(acc, account.AccountSetFlagRequireAuth)
 }
 
 // DisableRequireAuth disables the RequireAuth flag on an account.
 func (e *TestEnv) DisableRequireAuth(acc *Account) {
 	e.t.Helper()
-
-	accountSet := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagRequireAuth
-	accountSet.ClearFlag = &flag
-	accountSet.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	accountSet.Sequence = &seq
-
-	result := e.Submit(accountSet)
-	if !result.Success {
-		e.t.Fatalf("Failed to disable RequireAuth for account %s: %s", acc.Name, result.Code)
-	}
+	e.clearAccountFlag(acc, account.AccountSetFlagRequireAuth)
 }
 
 // EnableRequireDest enables the RequireDest flag on an account.
 // When enabled, the account requires a destination tag on incoming payments.
 func (e *TestEnv) EnableRequireDest(acc *Account) {
 	e.t.Helper()
-
-	accountSet := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagRequireDest
-	accountSet.SetFlag = &flag
-	accountSet.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	accountSet.Sequence = &seq
-
-	result := e.Submit(accountSet)
-	if !result.Success {
-		e.t.Fatalf("Failed to enable RequireDest for account %s: %s", acc.Name, result.Code)
-	}
+	e.setAccountFlag(acc, account.AccountSetFlagRequireDest)
 }
 
 // DisableRequireDest disables the RequireDest flag on an account.
 func (e *TestEnv) DisableRequireDest(acc *Account) {
 	e.t.Helper()
-
-	accountSet := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagRequireDest
-	accountSet.ClearFlag = &flag
-	accountSet.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	accountSet.Sequence = &seq
-
-	result := e.Submit(accountSet)
-	if !result.Success {
-		e.t.Fatalf("Failed to disable RequireDest for account %s: %s", acc.Name, result.Code)
-	}
+	e.clearAccountFlag(acc, account.AccountSetFlagRequireDest)
 }
 
 // EnableDisallowXRP enables the DisallowXRP flag on an account.
@@ -188,18 +116,7 @@ func (e *TestEnv) DisableRequireDest(acc *Account) {
 // transactor, so XRP payments to such an account still succeed.
 func (e *TestEnv) EnableDisallowXRP(acc *Account) {
 	e.t.Helper()
-
-	accountSet := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagDisallowXRP
-	accountSet.SetFlag = &flag
-	accountSet.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	accountSet.Sequence = &seq
-
-	result := e.Submit(accountSet)
-	if !result.Success {
-		e.t.Fatalf("Failed to enable DisallowXRP for account %s: %s", acc.Name, result.Code)
-	}
+	e.setAccountFlag(acc, account.AccountSetFlagDisallowXRP)
 }
 
 // Preauthorize allows owner to preauthorize authorized for deposits.
@@ -267,18 +184,7 @@ func (e *TestEnv) CreatePassiveOffer(acc *Account, takerGets, takerPays tx.Amoun
 // The account must have a regular key or signer list set first.
 func (e *TestEnv) DisableMasterKey(acc *Account) {
 	e.t.Helper()
-
-	accountSet := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagDisableMaster
-	accountSet.SetFlag = &flag
-	accountSet.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	accountSet.Sequence = &seq
-
-	result := e.Submit(accountSet)
-	if !result.Success {
-		e.t.Fatalf("Failed to disable master key for %s: %s", acc.Name, result.Code)
-	}
+	e.setAccountFlag(acc, account.AccountSetFlagDisableMaster)
 }
 
 // Noop submits a no-op AccountSet to bump an account's sequence number.

--- a/internal/testing/env_funding.go
+++ b/internal/testing/env_funding.go
@@ -6,13 +6,38 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 )
 
-// Fund funds the specified accounts from the master account.
-// Each account receives the specified amount or a default of 1000 XRP.
+// Fund funds the specified accounts from the master account with 1000 XRP each.
+// Use FundAmount to fund a specific amount.
 func (e *TestEnv) Fund(accounts ...*Account) {
 	e.t.Helper()
 
 	for _, acc := range accounts {
 		e.FundAmount(acc, uint64(XRP(1000)))
+	}
+}
+
+// masterPayment sends amount drops of XRP from the master account to acc,
+// failing the test if it is not applied. When sign is true the payment is signed
+// with the master key (matching rippled's funded-account setup); callers that
+// only need a balance top-up pass sign=false. what labels failures.
+func (e *TestEnv) masterPayment(acc *Account, amount uint64, sign bool, what string) {
+	e.t.Helper()
+	master := e.accounts["master"]
+	if master == nil {
+		e.t.Fatal("Master account not found")
+	}
+	seq := e.Seq(master)
+	p := payment.NewPayment(master.Address, acc.Address, tx.NewXRPAmount(int64(amount)))
+	p.Fee = formatUint64(e.baseFee)
+	p.Sequence = &seq
+	if e.networkID > 1024 {
+		p.NetworkID = &e.networkID
+	}
+	if sign && master.PublicKey != nil {
+		e.SignWith(p, master)
+	}
+	if result := e.Submit(p); !result.Success {
+		e.t.Fatalf("%s for %s failed: %s", what, acc.Name, result.Code)
 	}
 }
 
@@ -26,34 +51,9 @@ func (e *TestEnv) FundAmount(acc *Account, amount uint64) {
 	// Register account
 	e.accounts[acc.Name] = acc
 
-	// Create a payment from master to the new account
-	master := e.accounts["master"]
-	if master == nil {
-		e.t.Fatal("Master account not found")
-	}
-
 	// Fund with extra to cover the AccountSet fee (for enabling DefaultRipple)
-	// This ensures the account ends up with the requested amount.
-	totalFunding := amount + e.baseFee
-
-	// Create payment transaction
-	seq := e.Seq(master)
-	p := payment.NewPayment(master.Address, acc.Address, tx.NewXRPAmount(int64(totalFunding)))
-	p.Fee = formatUint64(e.baseFee)
-	p.Sequence = &seq
-	if e.networkID > 1024 {
-		p.NetworkID = &e.networkID
-	}
-
-	if master.PublicKey != nil {
-		e.SignWith(p, master)
-	}
-
-	// Submit the payment
-	result := e.Submit(p)
-	if !result.Success {
-		e.t.Fatalf("Failed to fund account %s: %s", acc.Name, result.Code)
-	}
+	// so the account ends up with the requested amount.
+	e.masterPayment(acc, amount+e.baseFee, true, "fund account")
 
 	// Enable DefaultRipple on the account (matching rippled's test environment)
 	// This allows trust lines to be properly deleted when limits are set to 0.
@@ -66,24 +66,8 @@ func (e *TestEnv) FundAmount(acc *Account, amount uint64) {
 // register the account or enable DefaultRipple.
 func (e *TestEnv) Pay(acc *Account, drops uint64) {
 	e.t.Helper()
-
-	master := e.accounts["master"]
-	if master == nil {
-		e.t.Fatal("Master account not found")
-	}
-
-	seq := e.Seq(master)
-	p := payment.NewPayment(master.Address, acc.Address, tx.NewXRPAmount(int64(drops)))
-	p.Fee = formatUint64(e.baseFee)
-	p.Sequence = &seq
-	if e.networkID > 1024 {
-		p.NetworkID = &e.networkID
-	}
-
-	result := e.Submit(p)
-	if !result.Success {
-		e.t.Fatalf("Failed to pay %d drops to %s: %s", drops, acc.Name, result.Code)
-	}
+	// Unlike FundAmount this is a bare top-up: no DefaultRipple, no signature.
+	e.masterPayment(acc, drops, false, "pay")
 }
 
 // enableDefaultRipple enables the DefaultRipple flag on an account.
@@ -122,28 +106,6 @@ func (e *TestEnv) FundNoRipple(accounts ...*Account) {
 // FundAmountNoRipple funds an account with a specific amount but does NOT enable DefaultRipple.
 func (e *TestEnv) FundAmountNoRipple(acc *Account, amount uint64) {
 	e.t.Helper()
-
 	e.accounts[acc.Name] = acc
-
-	master := e.accounts["master"]
-	if master == nil {
-		e.t.Fatal("Master account not found")
-	}
-
-	seq := e.Seq(master)
-	pay := payment.NewPayment(master.Address, acc.Address, tx.NewXRPAmount(int64(amount)))
-	pay.Fee = formatUint64(e.baseFee)
-	pay.Sequence = &seq
-	if e.networkID > 1024 {
-		pay.NetworkID = &e.networkID
-	}
-
-	if master.PublicKey != nil {
-		e.SignWith(pay, master)
-	}
-
-	result := e.Submit(pay)
-	if !result.Success {
-		e.t.Fatalf("Failed to fund account %s (no ripple): %s", acc.Name, result.Code)
-	}
+	e.masterPayment(acc, amount, true, "fund account (no ripple)")
 }

--- a/internal/testing/env_pseudo.go
+++ b/internal/testing/env_pseudo.go
@@ -6,22 +6,45 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 )
 
-// EnableFeature enables an amendment by name for subsequent transactions.
-// Matches rippled's Env::enableFeature() in test/jtx/impl/Env.cpp: the
-// amendment is staged into the rules builder and only takes effect after the
-// next Close() — call e.Close() before submitting transactions that depend on
-// the new amendment.
+// EnableFeature stages an amendment to be enabled on the next Close(), matching
+// rippled's Env::enableFeature() (test/jtx/impl/Env.cpp), which requires close()
+// for the change to take effect — call e.Close() before submitting transactions
+// that depend on the amendment. An unknown amendment name fails the test
+// immediately rather than being silently dropped.
 func (e *TestEnv) EnableFeature(name string) {
 	e.t.Helper()
-	e.rulesBuilder.EnableByName(name)
+	e.requireKnownAmendment(name)
+	e.pendingEnable = append(e.pendingEnable, name)
 }
 
-// DisableFeature disables an amendment by name for subsequent transactions.
-// See EnableFeature for the Close()-required semantic.
+// DisableFeature stages an amendment to be disabled on the next Close().
+// See EnableFeature for the Close()-required semantic and name validation.
 // Reference: rippled's Env::disableFeature() in test/jtx/impl/Env.cpp.
 func (e *TestEnv) DisableFeature(name string) {
 	e.t.Helper()
-	e.rulesBuilder.DisableByName(name)
+	e.requireKnownAmendment(name)
+	e.pendingDisable = append(e.pendingDisable, name)
+}
+
+// EnableFeatureNow enables an amendment and applies it immediately, without
+// waiting for a Close(). It exists for the conformance runner, whose recorded
+// enable_amendment fixture steps expect the amendment to be active for the very
+// next transaction in the same ledger. Ordinary tests should use EnableFeature,
+// which defers to the next Close() like rippled's Env::enableFeature.
+func (e *TestEnv) EnableFeatureNow(name string) {
+	e.t.Helper()
+	e.requireKnownAmendment(name)
+	e.rulesBuilder.EnableByName(name)
+}
+
+// requireKnownAmendment fails the test if name is not a registered amendment.
+// Used by EnableFeature/DisableFeature/SetAmendments so a typo'd amendment name
+// surfaces loudly instead of silently running the test against the wrong rules.
+func (e *TestEnv) requireKnownAmendment(name string) {
+	e.t.Helper()
+	if amendment.GetFeatureByName(name) == nil {
+		e.t.Fatalf("unknown amendment name %q", name)
+	}
 }
 
 // SetVerifySignatures enables or disables signature verification in the engine.
@@ -37,20 +60,29 @@ func (e *TestEnv) SetNetworkID(id uint32) {
 	e.networkID = id
 }
 
-// FeatureEnabled returns true if the named amendment is currently enabled.
+// FeatureEnabled returns true if the named amendment will be enabled once the
+// staged toggles take effect at the next Close(). Reading it right after
+// EnableFeature/DisableFeature therefore reflects the staged change, even though
+// the engine rules themselves only switch at Close.
 // Reference: rippled's Env::enabled() in test/jtx/Env.h
 func (e *TestEnv) FeatureEnabled(name string) bool {
 	f := amendment.GetFeatureByName(name)
 	if f == nil {
 		return false
 	}
-	rules := e.rulesBuilder.Build()
-	return rules.Enabled(f.ID)
+	return e.pendingRulesBuilder().Build().Enabled(f.ID)
 }
 
 // Now returns the current time on the test clock.
 func (e *TestEnv) Now() time.Time {
 	return e.clock.Now()
+}
+
+// NowRipple returns the current test-clock time as seconds since the Ripple
+// epoch (the uint32 form used by on-ledger time fields such as Expiration,
+// FinishAfter and CancelAfter).
+func (e *TestEnv) NowRipple() uint32 {
+	return toRippleTime(e.clock.Now())
 }
 
 // AdvanceTime advances the test clock by the specified duration.

--- a/internal/testing/env_queries.go
+++ b/internal/testing/env_queries.go
@@ -18,7 +18,6 @@ func (e *TestEnv) Balance(acc *Account) uint64 {
 	exists, err := e.ledger.Exists(accountKey)
 	if err != nil {
 		e.t.Fatalf("Failed to check account existence: %v", err)
-		return 0
 	}
 	if !exists {
 		return 0 // Account doesn't exist
@@ -28,14 +27,12 @@ func (e *TestEnv) Balance(acc *Account) uint64 {
 	data, err := e.ledger.Read(accountKey)
 	if err != nil {
 		e.t.Fatalf("Failed to read account: %v", err)
-		return 0
 	}
 
 	// Parse account root to get balance
 	accountRoot, err := state.ParseAccountRootFromBytes(data)
 	if err != nil {
 		e.t.Fatalf("Failed to parse account data: %v", err)
-		return 0
 	}
 
 	return accountRoot.Balance
@@ -54,7 +51,6 @@ func (e *TestEnv) IOUBalance(holder, issuer *Account, currency string) *state.Am
 	exists, err := e.ledger.Exists(lineKey)
 	if err != nil {
 		e.t.Fatalf("Failed to check trust line existence: %v", err)
-		return nil
 	}
 	if !exists {
 		// No trust line = zero balance
@@ -66,14 +62,12 @@ func (e *TestEnv) IOUBalance(holder, issuer *Account, currency string) *state.Am
 	data, err := e.ledger.Read(lineKey)
 	if err != nil {
 		e.t.Fatalf("Failed to read trust line: %v", err)
-		return nil
 	}
 
 	// Parse RippleState
 	rs, err := state.ParseRippleState(data)
 	if err != nil {
 		e.t.Fatalf("Failed to parse trust line: %v", err)
-		return nil
 	}
 
 	// Determine if holder is low or high account
@@ -115,7 +109,6 @@ func (e *TestEnv) Exists(acc *Account) bool {
 	exists, err := e.ledger.Exists(accountKey)
 	if err != nil {
 		e.t.Fatalf("Failed to check account existence: %v", err)
-		return false
 	}
 	return exists
 }
@@ -128,7 +121,6 @@ func (e *TestEnv) TrustLineExists(acc1, acc2 *Account, currency string) bool {
 	exists, err := e.ledger.Exists(lineKey)
 	if err != nil {
 		e.t.Fatalf("Failed to check trust line existence: %v", err)
-		return false
 	}
 	return exists
 }
@@ -188,8 +180,7 @@ func (e *TestEnv) HasNoRipple(account, counterparty *Account, currency string) b
 
 // Seq returns the current sequence number for an account.
 // It fatals if the account does not exist, matching rippled's Env which throws
-// when querying a non-existent account. Use SeqOrDefault for auto-fill paths
-// where the account may not exist yet.
+// when querying a non-existent account.
 func (e *TestEnv) Seq(acc *Account) uint32 {
 	e.t.Helper()
 
@@ -200,58 +191,21 @@ func (e *TestEnv) Seq(acc *Account) uint32 {
 	exists, err := e.ledger.Exists(accountKey)
 	if err != nil {
 		e.t.Fatalf("Failed to check account existence: %v", err)
-		return 0
 	}
 	if !exists {
 		e.t.Fatalf("Seq: account %s does not exist", acc.Name)
-		return 0 // unreachable
 	}
 
 	// Read account data
 	data, err := e.ledger.Read(accountKey)
 	if err != nil {
 		e.t.Fatalf("Failed to read account: %v", err)
-		return 0
 	}
 
 	// Parse account root to get sequence
 	accountRoot, err := state.ParseAccountRootFromBytes(data)
 	if err != nil {
 		e.t.Fatalf("Failed to parse account data: %v", err)
-		return 0
-	}
-
-	return accountRoot.Sequence
-}
-
-// SeqOrDefault returns the current sequence number for an account, or 1 if
-// the account does not exist. This is useful for auto-fill paths where the
-// account may not have been created yet (e.g., the Payment that creates it
-// is the one being submitted).
-func (e *TestEnv) SeqOrDefault(acc *Account) uint32 {
-	e.t.Helper()
-
-	accountKey := keylet.Account(acc.ID)
-
-	exists, err := e.ledger.Exists(accountKey)
-	if err != nil {
-		e.t.Fatalf("Failed to check account existence: %v", err)
-		return 1
-	}
-	if !exists {
-		return 1 // Default sequence for new accounts
-	}
-
-	data, err := e.ledger.Read(accountKey)
-	if err != nil {
-		e.t.Fatalf("Failed to read account: %v", err)
-		return 1
-	}
-
-	accountRoot, err := state.ParseAccountRootFromBytes(data)
-	if err != nil {
-		e.t.Fatalf("Failed to parse account data: %v", err)
-		return 1
 	}
 
 	return accountRoot.Sequence
@@ -276,14 +230,15 @@ func (e *TestEnv) LedgerSeq() uint32 {
 	return e.ledger.Sequence()
 }
 
-// GetAccount returns a registered account by name.
-func (e *TestEnv) GetAccount(name string) *Account {
-	return e.accounts[name]
-}
-
 // MasterAccount returns the master account for the test environment.
 func (e *TestEnv) MasterAccount() *Account {
 	return e.accounts["master"]
+}
+
+// CredentialKeylet returns the keylet for the credential identified by subject,
+// issuer and credential type. Shared by the suites that build credential SLEs.
+func CredentialKeylet(subject, issuer *Account, credType string) keylet.Keylet {
+	return keylet.Credential(subject.ID, issuer.ID, []byte(credType))
 }
 
 // AccountInfo returns detailed account information.
@@ -446,7 +401,6 @@ func (e *TestEnv) OwnerCount(acc *Account) uint32 {
 	info := e.AccountInfo(acc)
 	if info == nil {
 		e.t.Fatalf("OwnerCount: account %s does not exist", acc.Name)
-		return 0
 	}
 	return info.OwnerCount
 }
@@ -457,7 +411,6 @@ func (e *TestEnv) LedgerEntryExists(key keylet.Keylet) bool {
 	exists, err := e.ledger.Exists(key)
 	if err != nil {
 		e.t.Fatalf("Failed to check ledger entry existence: %v", err)
-		return false
 	}
 	return exists
 }
@@ -517,7 +470,8 @@ func (e *TestEnv) GetTxQ() *txq.TxQ {
 	return e.txQueue
 }
 
-// TxQMetrics returns the current TxQ metrics. Panics if TxQ is not configured.
+// TxQMetrics returns the current TxQ metrics. Fatals the test if TxQ is not
+// configured.
 // Reference: rippled TxQ::getMetrics(*env.current())
 func (e *TestEnv) TxQMetrics() txq.Metrics {
 	if e.txQueue == nil {

--- a/internal/testing/env_signing.go
+++ b/internal/testing/env_signing.go
@@ -8,7 +8,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/keylet"
-	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // WithSeq sets the sequence number on a transaction manually.
@@ -86,14 +85,12 @@ func (e *TestEnv) SubmitSigned(transaction any) TxResult {
 	txn, ok := transaction.(tx.Transaction)
 	if !ok {
 		e.t.Fatalf("Transaction does not implement tx.Transaction interface")
-		return TxResult{Code: "temINVALID", Success: false, Message: "Invalid transaction type"}
 	}
 
 	// Look up the account by address
 	acc := e.findAccountByAddress(txn.GetCommon().Account)
 	if acc == nil {
 		e.t.Fatalf("SubmitSigned: account %s not registered in test env", txn.GetCommon().Account)
-		return TxResult{Code: "terNO_ACCOUNT", Success: false, Message: "Account not found"}
 	}
 
 	// Auto-fill BEFORE signing, since sequence/fee are part of the signed payload.
@@ -111,7 +108,6 @@ func (e *TestEnv) SubmitSignedWith(transaction any, signer *Account) TxResult {
 	txn, ok := transaction.(tx.Transaction)
 	if !ok {
 		e.t.Fatalf("Transaction does not implement tx.Transaction interface")
-		return TxResult{Code: "temINVALID", Success: false, Message: "Invalid transaction type"}
 	}
 
 	// Auto-fill BEFORE signing, since sequence/fee are part of the signed payload.
@@ -130,7 +126,6 @@ func (e *TestEnv) SubmitMultiSigned(transaction any, signers []*Account) TxResul
 	txn, ok := transaction.(tx.Transaction)
 	if !ok {
 		e.t.Fatalf("Transaction does not implement tx.Transaction interface")
-		return TxResult{Code: "temINVALID", Success: false, Message: "Invalid transaction type"}
 	}
 
 	// Auto-fill BEFORE signing, since sequence/fee are part of the signed payload.
@@ -179,7 +174,6 @@ func (e *TestEnv) autoFillForSigning(txn tx.Transaction) {
 		_, accountID, err := addresscodec.DecodeClassicAddressToAccountID(common.Account)
 		if err != nil {
 			e.t.Fatalf("autoFillForSigning: failed to decode account address: %v", err)
-			return
 		}
 
 		var id [20]byte
@@ -189,13 +183,11 @@ func (e *TestEnv) autoFillForSigning(txn tx.Transaction) {
 		data, err := e.ledger.Read(accountKey)
 		if err != nil || data == nil {
 			e.t.Fatalf("autoFillForSigning: failed to read account: %v", err)
-			return
 		}
 
 		accountRoot, err := state.ParseAccountRootFromBytes(data)
 		if err != nil {
 			e.t.Fatalf("autoFillForSigning: failed to parse account root: %v", err)
-			return
 		}
 
 		seq := accountRoot.Sequence
@@ -208,32 +200,41 @@ func (e *TestEnv) autoFillForSigning(txn tx.Transaction) {
 	}
 }
 
-// submitWithSigVerification is the internal submit path with signature verification enabled.
-// Callers must auto-fill and sign BEFORE calling this.
+// submitWithSigVerification is the internal submit path with signature
+// verification enabled. Callers must auto-fill and sign BEFORE calling this.
+//
+// It mirrors applyDirect: it seeds and bumps the per-ledger transaction counters
+// (txInLedger / closingTxTotal / fee levels) and derives ParentCloseTime from
+// the ledger header, so a test mixing Submit and SubmitSigned in one close
+// window gets consistent metadata.TransactionIndex and TxQ fee metrics.
 func (e *TestEnv) submitWithSigVerification(txn tx.Transaction) TxResult {
 	e.t.Helper()
 
-	parentCloseTime := uint32(e.clock.Now().Unix() - protocol.RippleEpochUnix)
-	engineConfig := tx.EngineConfig{
-		BaseFee:                   e.baseFee,
-		ReserveBase:               e.reserveBase,
-		ReserveIncrement:          e.reserveIncrement,
-		LedgerSequence:            e.ledger.Sequence(),
-		SkipSignatureVerification: false, // Verify signatures
-		Rules:                     e.rulesBuilder.Build(),
-		ParentCloseTime:           parentCloseTime,
-		NetworkID:                 e.networkID,
-		ParentHash:                e.ledger.ParentHash(),
-		OpenLedger:                e.openLedger,
-	}
+	engineConfig := e.engineConfig(e.ledger, engineConfigOpts{
+		openLedger:       e.openLedger,
+		feeTrack:         true,
+		verifySignatures: true,
+	})
 
 	engine := tx.NewEngine(e.ledger, engineConfig)
+	// Seed txCount so metadata.TransactionIndex matches rippled — see applyDirect.
+	engine.SetBaseTxCount(e.txInLedger)
 	applyResult := engine.Apply(txn)
 
+	if applyResult.Result.IsApplied() {
+		e.txInLedger++
+		e.closingTxTotal++
+		e.recordTxFeeLevel(txn)
+		if counter, ok := txn.(innerTxCounter); ok {
+			e.closingTxTotal += uint32(counter.InnerTxCount())
+		}
+	}
+
 	return TxResult{
-		Code:    applyResult.Result.String(),
-		Success: applyResult.Result.IsSuccess(),
-		Message: applyResult.Message,
+		Code:     applyResult.Result.String(),
+		Success:  applyResult.Result.IsSuccess(),
+		Message:  applyResult.Message,
+		Metadata: applyResult.Metadata,
 	}
 }
 

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -27,15 +27,26 @@ import (
 // rippled's standalone consensus simulation (BuildLedger.cpp).
 func (e *TestEnv) Close() {
 	e.t.Helper()
+	e.close(false)
+}
 
-	// Apply any pending amendment changes from SetAmendments().
-	// Matches rippled where enableFeature/disableFeature require close()
-	// for changes to take effect.
+// close closes the current ledger, advances to a fresh open ledger, and runs
+// the TxQ drain. timeLeap simulates a slow consensus round: it is forwarded to
+// ProcessClosedLedger (driving txnsExpected back toward the minimum) and
+// suppresses the replay-on-close branch (which only ever runs for plain Close).
+func (e *TestEnv) close(timeLeap bool) {
+	e.t.Helper()
+
+	// Apply any pending amendment changes from EnableFeature/DisableFeature/
+	// SetAmendments(). Matches rippled where feature toggles require close()
+	// for the rules to take effect.
 	// Reference: rippled Env.cpp: "Env::close() must be called for feature
 	// enable to take place."
 	e.applyPendingAmendments()
 
-	if e.replayOnClose {
+	// Replay-on-close consensus simulation only applies to plain Close(); the
+	// time-leap path never rebuilds the ledger from its parent.
+	if !timeLeap && e.replayOnClose {
 		e.closeWithReplay()
 		return
 	}
@@ -95,7 +106,7 @@ func (e *TestEnv) Close() {
 			ledgerSeq: e.ledger.Sequence(),
 			feeLevels: feeLevels,
 		}
-		e.txQueue.ProcessClosedLedger(closedCtx, false)
+		e.txQueue.ProcessClosedLedger(closedCtx, timeLeap)
 	}
 
 	// Track the closed ledger as the last closed ledger.
@@ -140,68 +151,20 @@ func (e *TestEnv) Close() {
 // Reference: rippled TxQ::FeeMetrics::update timeLeap handling
 func (e *TestEnv) CloseWithTimeLeap() {
 	e.t.Helper()
+	e.close(true)
+}
 
-	// Apply any pending amendment changes (same as Close).
-	e.applyPendingAmendments()
-
-	closingTxCount := e.closingTxTotal
-	// Round closeTime up to next resolution boundary, matching rippled.
+// CloseToParentCloseTime closes one ledger so that the new open ledger's parent
+// close time lands exactly on target (Ripple epoch seconds), failing the test
+// otherwise. Used by expiry tests that need ParentCloseTime at a precise value.
+func (e *TestEnv) CloseToParentCloseTime(target uint32) {
+	e.t.Helper()
 	resolution := time.Duration(e.ledger.CloseTimeResolution()) * time.Second
-	if resolution == 0 {
-		resolution = 10 * time.Second
-	}
-	e.clock.Advance(resolution)
-
-	if err := e.ledger.Close(e.clock.Now(), 0); err != nil {
-		e.t.Fatalf("Failed to close ledger: %v", err)
-	}
-	if err := e.ledger.SetValidated(); err != nil {
-		e.t.Fatalf("Failed to validate ledger: %v", err)
-	}
-
-	// Re-sync clock to the actual close time from the closed ledger.
-	// Matches rippled's timeKeeper().set(closed()->info().closeTime).
-	e.clock.Set(e.ledger.CloseTime())
-
-	if h, err := e.ledger.StateMapHash(); err == nil {
-		e.ledgerRootHashes[e.ledger.Sequence()] = h
-	}
-	if e.stateFamily != nil {
-		e.stateFamily.Sweep()
-	}
-
-	// Process with timeLeap=true to reset metrics
-	if e.txQueue != nil {
-		feeLevels := e.closingFeeLevels
-		if len(feeLevels) == 0 && closingTxCount > 0 {
-			feeLevels = make([]txq.FeeLevel, closingTxCount)
-			for i := range feeLevels {
-				feeLevels[i] = txq.FeeLevel(txq.BaseLevel)
-			}
-		}
-		closedCtx := &testClosedLedgerContext{
-			ledgerSeq: e.ledger.Sequence(),
-			feeLevels: feeLevels,
-		}
-		e.txQueue.ProcessClosedLedger(closedCtx, true) // timeLeap = true
-	}
-
-	e.lastClosedLedger = e.ledger
-	newLedger, err := ledger.NewOpen(e.ledger, e.clock.Now())
-	if err != nil {
-		e.t.Fatalf("Failed to create new ledger: %v", err)
-	}
-	e.ledger = newLedger
-	e.currentSeq++
-	e.openLedgerSetupTxns = nil
-	e.openLedgerUserTxns = nil
-	e.txInLedger = 0
-	e.closingTxTotal = 0
-	e.closingFeeLevels = nil
-
-	if e.txQueue != nil {
-		e.drainQueue()
-		e.retryAllHeldViaTxQ()
+	targetTime := time.Unix(int64(target)+protocol.RippleEpochUnix, 0).UTC()
+	e.SetTime(targetTime.Add(-resolution))
+	e.Close()
+	if got := toRippleTime(e.ledger.ParentCloseTime()); got != target {
+		e.t.Fatalf("CloseToParentCloseTime: parent close time landed on %d, want %d", got, target)
 	}
 }
 
@@ -325,21 +288,46 @@ func (e *TestEnv) closeWithReplay() {
 	}
 }
 
-// applyPendingAmendments applies any deferred amendment changes from
-// SetAmendments(). Called at the start of Close() and CloseWithTimeLeap().
-// Matches rippled where enableFeature/disableFeature modify config().features
-// but the rules are only rebuilt when the ledger is closed.
+// pendingRulesBuilder returns a RulesBuilder reflecting the current rules with
+// all staged amendment changes applied: SetAmendments (whole-set replace) first,
+// then the EnableFeature/DisableFeature deltas layered on top. It does NOT mutate
+// the env — applyPendingAmendments installs the result at Close, while
+// FeatureEnabled queries it without committing.
+func (e *TestEnv) pendingRulesBuilder() *amendment.RulesBuilder {
+	b := amendment.NewRulesBuilder()
+	if len(e.pendingAmendments) > 0 {
+		for _, name := range e.pendingAmendments {
+			b.EnableByName(name)
+		}
+	} else {
+		for _, id := range e.rulesBuilder.Build().GetEnabled() {
+			b.Enable(id)
+		}
+	}
+	for _, name := range e.pendingEnable {
+		b.EnableByName(name)
+	}
+	for _, name := range e.pendingDisable {
+		b.DisableByName(name)
+	}
+	return b
+}
+
+// applyPendingAmendments installs the amendment changes staged by SetAmendments
+// (whole-set replace) and EnableFeature/DisableFeature (deltas). Called at the
+// start of every close(). Matches rippled where enableFeature/disableFeature
+// modify config().features but the rules are only rebuilt when the ledger is
+// closed.
 // Reference: rippled Env.cpp: "Env::close() must be called for feature
 // enable to take place."
 func (e *TestEnv) applyPendingAmendments() {
-	if len(e.pendingAmendments) == 0 {
+	if len(e.pendingAmendments) == 0 && len(e.pendingEnable) == 0 && len(e.pendingDisable) == 0 {
 		return
 	}
-	e.rulesBuilder = amendment.NewRulesBuilder()
-	for _, name := range e.pendingAmendments {
-		e.rulesBuilder.EnableByName(name)
-	}
+	e.rulesBuilder = e.pendingRulesBuilder()
 	e.pendingAmendments = nil
+	e.pendingEnable = nil
+	e.pendingDisable = nil
 }
 
 // applyWithRetry applies a set of transactions with multi-pass retry logic,
@@ -387,15 +375,6 @@ func (e *TestEnv) applyWithRetry(txns []tx.Transaction, maxRetryPasses, maxTotal
 	return remaining
 }
 
-// CloseAt closes ledgers until the ledger reaches the target sequence.
-// If already at or past target, does nothing.
-func (e *TestEnv) CloseAt(targetSeq uint32) {
-	e.t.Helper()
-	for e.ledger.Sequence() < targetSeq {
-		e.Close()
-	}
-}
-
 // Submit submits a transaction to the current open ledger.
 // If the transaction doesn't have a sequence number set, it will be auto-filled
 // from the account's current sequence in the ledger.
@@ -411,7 +390,6 @@ func (e *TestEnv) Submit(transaction any) TxResult {
 	txn, ok := transaction.(tx.Transaction)
 	if !ok {
 		e.t.Fatalf("Transaction does not implement tx.Transaction interface")
-		return TxResult{Code: "temINVALID", Success: false, Message: "Invalid transaction type"}
 	}
 
 	// Auto-fill the fee if not set. rippled requires sfFee on every STTx
@@ -428,7 +406,6 @@ func (e *TestEnv) Submit(transaction any) TxResult {
 		_, accountID, err := addresscodec.DecodeClassicAddressToAccountID(common.Account)
 		if err != nil {
 			e.t.Fatalf("Failed to decode account address: %v", err)
-			return TxResult{Code: "temINVALID", Success: false, Message: "Invalid account address"}
 		}
 
 		var id [20]byte
@@ -438,13 +415,11 @@ func (e *TestEnv) Submit(transaction any) TxResult {
 		data, err := e.ledger.Read(accountKey)
 		if err != nil || data == nil {
 			e.t.Fatalf("Failed to read account for sequence auto-fill: %v", err)
-			return TxResult{Code: "terNO_ACCOUNT", Success: false, Message: "Account not found"}
 		}
 
 		accountRoot, err := state.ParseAccountRootFromBytes(data)
 		if err != nil {
 			e.t.Fatalf("Failed to parse account root: %v", err)
-			return TxResult{Code: "temINVALID", Success: false, Message: "Failed to parse account"}
 		}
 
 		seq := accountRoot.Sequence
@@ -464,30 +439,71 @@ func (e *TestEnv) Submit(transaction any) TxResult {
 	return e.applyDirect(txn)
 }
 
+// toRippleTime converts a wall-clock time to seconds since the Ripple epoch,
+// the form EngineConfig.ParentCloseTime and on-ledger time fields expect.
+func toRippleTime(t time.Time) uint32 {
+	return uint32(t.Unix() - protocol.RippleEpochUnix)
+}
+
+// engineConfigOpts captures the per-call-site differences in engine setup. The
+// shared fields (fees, reserves, rules, network, signature verification, parent
+// hash) are filled by engineConfig; only these vary across the direct-apply,
+// replay, TxQ-apply, accept, preflight, pseudo and signed-submit paths.
+type engineConfigOpts struct {
+	// parentCloseFromClock derives ParentCloseTime from the manual clock rather
+	// than the ledger header. The direct-apply and replay paths use the header
+	// so the initial apply and replay-on-close agree; the TxQ/preflight/pseudo/
+	// signed paths use the clock.
+	parentCloseFromClock bool
+	openLedger           bool
+	feeTrack             bool
+	enforceLoadFee       bool
+	applyFlags           tx.ApplyFlags
+	// verifySignatures forces signature verification even when the env runs in
+	// the default no-verify mode (used by the SubmitSigned/MultiSigned paths).
+	verifySignatures bool
+}
+
+// engineConfig builds the EngineConfig for applying a transaction against view,
+// filling the fields shared by every apply path and taking the deliberate
+// differences from opts. Centralizing construction keeps those differences
+// explicit and stops accidental drift between the call sites.
+func (e *TestEnv) engineConfig(view *ledger.Ledger, opts engineConfigOpts) tx.EngineConfig {
+	parentCloseTime := toRippleTime(view.ParentCloseTime())
+	if opts.parentCloseFromClock {
+		parentCloseTime = e.NowRipple()
+	}
+	cfg := tx.EngineConfig{
+		BaseFee:                   e.baseFee,
+		ReserveBase:               e.reserveBase,
+		ReserveIncrement:          e.reserveIncrement,
+		LedgerSequence:            view.Sequence(),
+		SkipSignatureVerification: !(e.VerifySignatures || opts.verifySignatures),
+		Rules:                     e.rulesBuilder.Build(),
+		ParentCloseTime:           parentCloseTime,
+		NetworkID:                 e.networkID,
+		ParentHash:                view.ParentHash(),
+		OpenLedger:                opts.openLedger,
+		EnforceLoadFee:            opts.enforceLoadFee,
+		ApplyFlags:                opts.applyFlags,
+	}
+	if opts.feeTrack {
+		cfg.FeeTrack = e.feeTrack
+	}
+	return cfg
+}
+
 // applyDirect applies a transaction directly without TxQ routing.
 // This is the original Submit path.
 func (e *TestEnv) applyDirect(txn tx.Transaction) TxResult {
 	e.t.Helper()
 
-	// Use the ledger's stored ParentCloseTime, not the clock.
-	// This matches rippled where parentCloseTime is derived from the
-	// parent ledger's closeTime (OpenView.cpp line 106), not from the
-	// network time. Using the ledger header ensures consistency between
-	// initial apply and replay-on-close.
-	parentCloseTime := uint32(e.ledger.ParentCloseTime().Unix() - protocol.RippleEpochUnix)
-	engineConfig := tx.EngineConfig{
-		BaseFee:                   e.baseFee,
-		ReserveBase:               e.reserveBase,
-		ReserveIncrement:          e.reserveIncrement,
-		LedgerSequence:            e.ledger.Sequence(),
-		SkipSignatureVerification: !e.VerifySignatures,
-		Rules:                     e.rulesBuilder.Build(),
-		ParentCloseTime:           parentCloseTime,
-		NetworkID:                 e.networkID,
-		ParentHash:                e.ledger.ParentHash(),
-		OpenLedger:                e.openLedger,
-		FeeTrack:                  e.feeTrack,
-	}
+	// Header-based ParentCloseTime (not the clock) keeps the initial apply and
+	// replay-on-close in agreement; see engineConfig.
+	engineConfig := e.engineConfig(e.ledger, engineConfigOpts{
+		openLedger: e.openLedger,
+		feeTrack:   true,
+	})
 
 	engine := tx.NewEngine(e.ledger, engineConfig)
 	// Seed the engine's txCount from the env's tx-in-ledger counter so
@@ -575,7 +591,6 @@ func (e *TestEnv) submitViaTxQ(txn tx.Transaction) TxResult {
 	_, acctBytes, err := addresscodec.DecodeClassicAddressToAccountID(accountAddr)
 	if err != nil {
 		e.t.Fatalf("submitViaTxQ: failed to decode account: %v", err)
-		return TxResult{Code: "temINVALID", Success: false}
 	}
 	copy(accountID[:], acctBytes)
 
@@ -834,25 +849,13 @@ func (e *TestEnv) drainQueue() {
 // are not applied (matching rippled's retry pass behavior).
 // Returns the result code and whether the transaction was actually applied.
 func (e *TestEnv) applyForReplay(txn tx.Transaction, certainRetry bool) (tx.Result, bool) {
-	// Use the ledger's stored ParentCloseTime, matching applyDirect().
-	// Both paths use the ledger header so time-dependent checks produce
-	// the same result during initial apply and during replay.
-	parentCloseTime := uint32(e.ledger.ParentCloseTime().Unix() - protocol.RippleEpochUnix)
-	engineConfig := tx.EngineConfig{
-		BaseFee:                   e.baseFee,
-		ReserveBase:               e.reserveBase,
-		ReserveIncrement:          e.reserveIncrement,
-		LedgerSequence:            e.ledger.Sequence(),
-		SkipSignatureVerification: !e.VerifySignatures,
-		Rules:                     e.rulesBuilder.Build(),
-		ParentCloseTime:           parentCloseTime,
-		NetworkID:                 e.networkID,
-		ParentHash:                e.ledger.ParentHash(),
-		OpenLedger:                e.openLedger,
-	}
+	// Header-based ParentCloseTime matches applyDirect so time-dependent checks
+	// produce the same result during initial apply and during replay.
+	opts := engineConfigOpts{openLedger: e.openLedger}
 	if certainRetry {
-		engineConfig.ApplyFlags = tx.TapRETRY
+		opts.applyFlags = tx.TapRETRY
 	}
+	engineConfig := e.engineConfig(e.ledger, opts)
 
 	engine := tx.NewEngine(e.ledger, engineConfig)
 	// Seed the engine's txCount from the env's tx-in-ledger counter so
@@ -1241,37 +1244,46 @@ func (c *testTxQApplyContext) GetAccountReserve(ownerCount uint32) uint64 {
 	return c.env.reserveBase + uint64(ownerCount)*c.env.reserveIncrement
 }
 
+// isFreeRegularKeySet reports whether txn is a SetRegularKey that qualifies for
+// the free password change: signed with the account's master key while
+// lsfPasswordSpent is clear. rippled charges a zero base fee in that case.
+// Reference: rippled SetRegularKey.cpp calculateBaseFee.
+func (e *TestEnv) isFreeRegularKeySet(txn tx.Transaction) bool {
+	if txn.TxType() != tx.TypeRegularKeySet {
+		return false
+	}
+	common := txn.GetCommon()
+	if common == nil || common.SigningPubKey == "" {
+		return false
+	}
+	sigAddr, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(common.SigningPubKey)
+	if err != nil || sigAddr != common.Account {
+		return false // not signed with the master key
+	}
+	acctID, err := state.DecodeAccountID(common.Account)
+	if err != nil {
+		return false
+	}
+	data, err := e.ledger.Read(keylet.Account(acctID))
+	if err != nil || data == nil {
+		return false
+	}
+	accountRoot, err := state.ParseAccountRootFromBytes(data)
+	if err != nil {
+		return false
+	}
+	return accountRoot.Flags&state.LsfPasswordSpent == 0
+}
+
 func (c *testTxQApplyContext) GetBaseFee(txn tx.Transaction) uint64 {
 	// For batch transactions, the base fee includes extra signers and inner
 	// txns. Reference: rippled calculateBaseFee() in Transactor.cpp.
 	if calc, ok := txn.(baseFeeCalculator); ok {
 		return calc.CalculateMinimumFee(c.env.baseFee)
 	}
-
-	// SetRegularKey free password change: baseFee = 0 when signed with master
-	// key and lsfPasswordSpent is not set.
-	// Reference: rippled SetRegularKey.cpp calculateBaseFee
-	if txn.TxType() == tx.TypeRegularKeySet {
-		common := txn.GetCommon()
-		if common != nil && common.SigningPubKey != "" {
-			sigAddr, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(common.SigningPubKey)
-			if err == nil && sigAddr == common.Account {
-				// Signed with master key. Check if lsfPasswordSpent is set.
-				acctID, acctErr := state.DecodeAccountID(common.Account)
-				if acctErr == nil {
-					accountKey := keylet.Account(acctID)
-					data, readErr := c.env.ledger.Read(accountKey)
-					if readErr == nil && data != nil {
-						accountRoot, parseErr := state.ParseAccountRootFromBytes(data)
-						if parseErr == nil && accountRoot.Flags&state.LsfPasswordSpent == 0 {
-							return 0
-						}
-					}
-				}
-			}
-		}
+	if c.env.isFreeRegularKeySet(txn) {
+		return 0
 	}
-
 	return c.env.baseFee
 }
 
@@ -1284,7 +1296,6 @@ func (c *testTxQApplyContext) GetLedgerSequence() uint32 {
 }
 
 func (c *testTxQApplyContext) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
-	parentCloseTime := uint32(c.env.clock.Now().Unix() - protocol.RippleEpochUnix)
 	// Transactions applied through the TxQ must NOT check open-ledger fee
 	// adequacy. In rippled, TxQ::tryDirectApply calls ripple::apply() with
 	// tapNONE flags (NOT tapOPEN_LEDGER). The TxQ's own fee-level check is
@@ -1294,20 +1305,11 @@ func (c *testTxQApplyContext) ApplyTransaction(txn tx.Transaction) (tx.Result, b
 	//   TxQ::tryDirectApply (uses same flags as NetworkOPs),
 	//   TxQ::tryClearAccountQueueUpThruTx (uses stored MaybeTx flags)
 	view := c.applyView()
-	engineConfig := tx.EngineConfig{
-		BaseFee:                   c.env.baseFee,
-		ReserveBase:               c.env.reserveBase,
-		ReserveIncrement:          c.env.reserveIncrement,
-		LedgerSequence:            view.Sequence(),
-		SkipSignatureVerification: !c.env.VerifySignatures,
-		Rules:                     c.env.rulesBuilder.Build(),
-		ParentCloseTime:           parentCloseTime,
-		NetworkID:                 c.env.networkID,
-		ParentHash:                view.ParentHash(),
-		OpenLedger:                false,
-		FeeTrack:                  c.env.feeTrack,
-		EnforceLoadFee:            true,
-	}
+	engineConfig := c.env.engineConfig(view, engineConfigOpts{
+		parentCloseFromClock: true,
+		feeTrack:             true,
+		enforceLoadFee:       true,
+	})
 
 	engine := tx.NewEngine(view, engineConfig)
 	applyResult := engine.Apply(txn)
@@ -1375,19 +1377,10 @@ func (c *testTxQApplyContext) PreflightTransaction(txn tx.Transaction) tx.Result
 	// Mirror the engine config used by ApplyTransaction so TxQ admission
 	// preflight (rippled TxQ.cpp:743-745) matches the direct-apply path.
 	view := c.applyView()
-	parentCloseTime := uint32(c.env.clock.Now().Unix() - protocol.RippleEpochUnix)
-	engineConfig := tx.EngineConfig{
-		BaseFee:                   c.env.baseFee,
-		ReserveBase:               c.env.reserveBase,
-		ReserveIncrement:          c.env.reserveIncrement,
-		LedgerSequence:            view.Sequence(),
-		SkipSignatureVerification: !c.env.VerifySignatures,
-		Rules:                     c.env.rulesBuilder.Build(),
-		ParentCloseTime:           parentCloseTime,
-		NetworkID:                 c.env.networkID,
-		ParentHash:                view.ParentHash(),
-		FeeTrack:                  c.env.feeTrack,
-	}
+	engineConfig := c.env.engineConfig(view, engineConfigOpts{
+		parentCloseFromClock: true,
+		feeTrack:             true,
+	})
 	return tx.NewEngine(view, engineConfig).Preflight(txn)
 }
 
@@ -1445,27 +1438,17 @@ func (c *testTxQAcceptContext) GetAccountSequence(account [20]byte) uint32 {
 }
 
 func (c *testTxQAcceptContext) ApplyTransaction(txn tx.Transaction) (tx.Result, bool) {
-	parentCloseTime := uint32(c.env.clock.Now().Unix() - protocol.RippleEpochUnix)
 	// TxQ accept (drain on close) applies queued transactions with tapNONE
 	// flags in rippled — NOT tapOPEN_LEDGER. This prevents the engine's
 	// fee adequacy check from rejecting fee=0 transactions that were
 	// already validated by the TxQ's fee-level mechanism.
 	// Reference: rippled TxQ::accept calls MaybeTx::apply with stored
 	//   flags (which have tapRETRY cleared but NOT tapOPEN_LEDGER set)
-	engineConfig := tx.EngineConfig{
-		BaseFee:                   c.env.baseFee,
-		ReserveBase:               c.env.reserveBase,
-		ReserveIncrement:          c.env.reserveIncrement,
-		LedgerSequence:            c.env.ledger.Sequence(),
-		SkipSignatureVerification: !c.env.VerifySignatures,
-		Rules:                     c.env.rulesBuilder.Build(),
-		ParentCloseTime:           parentCloseTime,
-		NetworkID:                 c.env.networkID,
-		ParentHash:                c.env.ledger.ParentHash(),
-		OpenLedger:                false,
-		FeeTrack:                  c.env.feeTrack,
-		EnforceLoadFee:            true,
-	}
+	engineConfig := c.env.engineConfig(c.env.ledger, engineConfigOpts{
+		parentCloseFromClock: true,
+		feeTrack:             true,
+		enforceLoadFee:       true,
+	})
 
 	engine := tx.NewEngine(c.env.ledger, engineConfig)
 	applyResult := engine.Apply(txn)
@@ -1507,21 +1490,8 @@ func (e *TestEnv) recordTxFeeLevel(txn tx.Transaction) {
 
 	// SetRegularKey free password change: baseFee = 0 when signed with master key.
 	// Reference: rippled SetRegularKey.cpp calculateBaseFee + TxQ.cpp getFeeLevelPaid
-	if txn.TxType() == tx.TypeRegularKeySet && common.SigningPubKey != "" {
-		sigAddr, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(common.SigningPubKey)
-		if err == nil && sigAddr == common.Account {
-			acctID, acctErr := state.DecodeAccountID(common.Account)
-			if acctErr == nil {
-				accountKey := keylet.Account(acctID)
-				data, readErr := e.ledger.Read(accountKey)
-				if readErr == nil && data != nil {
-					accountRoot, parseErr := state.ParseAccountRootFromBytes(data)
-					if parseErr == nil && accountRoot.Flags&state.LsfPasswordSpent == 0 {
-						baseFee = 0
-					}
-				}
-			}
-		}
+	if e.isFreeRegularKeySet(txn) {
+		baseFee = 0
 	}
 
 	feeLevel := txq.ToFeeLevel(feePaid, baseFee)
@@ -1564,11 +1534,6 @@ func (e *TestEnv) EnableOpenLedgerReplay() {
 	}
 }
 
-// IsReplayEnabled returns whether open-ledger replay is enabled.
-func (e *TestEnv) IsReplayEnabled() bool {
-	return e.replayOnClose
-}
-
 // SetInSetupMode controls whether subsequent transactions are tagged as
 // setup (fund/trust) or user (fixture) for replay purposes. Setup
 // transactions are replayed first in submission order; user transactions
@@ -1588,22 +1553,9 @@ func (e *TestEnv) SubmitPseudo(transaction any) TxResult {
 	txn, ok := transaction.(tx.Transaction)
 	if !ok {
 		e.t.Fatalf("Transaction does not implement tx.Transaction interface")
-		return TxResult{Code: "temINVALID", Success: false, Message: "Invalid transaction type"}
 	}
 
-	parentCloseTime := uint32(e.clock.Now().Unix() - protocol.RippleEpochUnix)
-	engineConfig := tx.EngineConfig{
-		BaseFee:                   e.baseFee,
-		ReserveBase:               e.reserveBase,
-		ReserveIncrement:          e.reserveIncrement,
-		LedgerSequence:            e.ledger.Sequence(),
-		SkipSignatureVerification: !e.VerifySignatures,
-		Rules:                     e.rulesBuilder.Build(),
-		ParentCloseTime:           parentCloseTime,
-		NetworkID:                 e.networkID,
-		ParentHash:                e.ledger.ParentHash(),
-		OpenLedger:                false,
-	}
+	engineConfig := e.engineConfig(e.ledger, engineConfigOpts{parentCloseFromClock: true})
 
 	engine := tx.NewEngine(e.ledger, engineConfig)
 	applyResult := engine.ApplyPseudo(txn)

--- a/internal/testing/env_trust.go
+++ b/internal/testing/env_trust.go
@@ -37,121 +37,49 @@ func (e *TestEnv) Trust(acc *Account, amount tx.Amount) {
 // EnableDisallowIncomingCheck enables the DisallowIncomingCheck flag on an account.
 func (e *TestEnv) EnableDisallowIncomingCheck(acc *Account) {
 	e.t.Helper()
-	as := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagDisallowIncomingCheck
-	as.SetFlag = &flag
-	as.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	as.Sequence = &seq
-	result := e.Submit(as)
-	if !result.Success {
-		e.t.Fatalf("Failed to enable DisallowIncomingCheck for %s: %s", acc.Name, result.Code)
-	}
+	e.setAccountFlag(acc, account.AccountSetFlagDisallowIncomingCheck)
 }
 
 // DisableDisallowIncomingCheck disables the DisallowIncomingCheck flag on an account.
 func (e *TestEnv) DisableDisallowIncomingCheck(acc *Account) {
 	e.t.Helper()
-	as := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagDisallowIncomingCheck
-	as.ClearFlag = &flag
-	as.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	as.Sequence = &seq
-	result := e.Submit(as)
-	if !result.Success {
-		e.t.Fatalf("Failed to disable DisallowIncomingCheck for %s: %s", acc.Name, result.Code)
-	}
+	e.clearAccountFlag(acc, account.AccountSetFlagDisallowIncomingCheck)
 }
 
 // EnableDisallowIncomingPayChan enables the DisallowIncomingPayChan flag on an account.
 func (e *TestEnv) EnableDisallowIncomingPayChan(acc *Account) {
 	e.t.Helper()
-	as := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagDisallowIncomingPayChan
-	as.SetFlag = &flag
-	as.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	as.Sequence = &seq
-	result := e.Submit(as)
-	if !result.Success {
-		e.t.Fatalf("Failed to enable DisallowIncomingPayChan for %s: %s", acc.Name, result.Code)
-	}
+	e.setAccountFlag(acc, account.AccountSetFlagDisallowIncomingPayChan)
 }
 
 // DisableDisallowIncomingPayChan disables the DisallowIncomingPayChan flag on an account.
 func (e *TestEnv) DisableDisallowIncomingPayChan(acc *Account) {
 	e.t.Helper()
-	as := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagDisallowIncomingPayChan
-	as.ClearFlag = &flag
-	as.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	as.Sequence = &seq
-	result := e.Submit(as)
-	if !result.Success {
-		e.t.Fatalf("Failed to disable DisallowIncomingPayChan for %s: %s", acc.Name, result.Code)
-	}
+	e.clearAccountFlag(acc, account.AccountSetFlagDisallowIncomingPayChan)
 }
 
 // EnableDisallowIncomingNFTokenOffer enables the DisallowIncomingNFTokenOffer flag on an account.
 func (e *TestEnv) EnableDisallowIncomingNFTokenOffer(acc *Account) {
 	e.t.Helper()
-	as := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagDisallowIncomingNFTokenOffer
-	as.SetFlag = &flag
-	as.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	as.Sequence = &seq
-	result := e.Submit(as)
-	if !result.Success {
-		e.t.Fatalf("Failed to enable DisallowIncomingNFTokenOffer for %s: %s", acc.Name, result.Code)
-	}
+	e.setAccountFlag(acc, account.AccountSetFlagDisallowIncomingNFTokenOffer)
 }
 
 // DisableDisallowIncomingNFTokenOffer disables the DisallowIncomingNFTokenOffer flag on an account.
 func (e *TestEnv) DisableDisallowIncomingNFTokenOffer(acc *Account) {
 	e.t.Helper()
-	as := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagDisallowIncomingNFTokenOffer
-	as.ClearFlag = &flag
-	as.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	as.Sequence = &seq
-	result := e.Submit(as)
-	if !result.Success {
-		e.t.Fatalf("Failed to disable DisallowIncomingNFTokenOffer for %s: %s", acc.Name, result.Code)
-	}
+	e.clearAccountFlag(acc, account.AccountSetFlagDisallowIncomingNFTokenOffer)
 }
 
 // EnableDisallowIncomingTrustline enables the DisallowIncomingTrustline flag on an account.
 func (e *TestEnv) EnableDisallowIncomingTrustline(acc *Account) {
 	e.t.Helper()
-	as := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagDisallowIncomingTrustline
-	as.SetFlag = &flag
-	as.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	as.Sequence = &seq
-	result := e.Submit(as)
-	if !result.Success {
-		e.t.Fatalf("Failed to enable DisallowIncomingTrustline for %s: %s", acc.Name, result.Code)
-	}
+	e.setAccountFlag(acc, account.AccountSetFlagDisallowIncomingTrustline)
 }
 
 // DisableDisallowIncomingTrustline disables the DisallowIncomingTrustline flag on an account.
 func (e *TestEnv) DisableDisallowIncomingTrustline(acc *Account) {
 	e.t.Helper()
-	as := account.NewAccountSet(acc.Address)
-	flag := account.AccountSetFlagDisallowIncomingTrustline
-	as.ClearFlag = &flag
-	as.Fee = formatUint64(e.baseFee)
-	seq := e.Seq(acc)
-	as.Sequence = &seq
-	result := e.Submit(as)
-	if !result.Success {
-		e.t.Fatalf("Failed to disable DisallowIncomingTrustline for %s: %s", acc.Name, result.Code)
-	}
+	e.clearAccountFlag(acc, account.AccountSetFlagDisallowIncomingTrustline)
 }
 
 // FreezeTrustLine freezes a specific trust line (issuer-side freeze).
@@ -435,10 +363,15 @@ func (e *TestEnv) SetDelegate(owner, authorized *Account, permissions []string) 
 
 // SetAmendments replaces the current amendment set with exactly the named amendments.
 // Changes are deferred until the next Close(), matching rippled where
-// enableFeature/disableFeature require close() to take effect.
+// enableFeature/disableFeature require close() to take effect. Each name must be
+// a known amendment; an unknown name fails the test immediately.
 // Reference: rippled Env.cpp: "Env::close() must be called for feature
 // enable to take place."
 func (e *TestEnv) SetAmendments(names []string) {
+	e.t.Helper()
+	for _, name := range names {
+		e.requireKnownAmendment(name)
+	}
 	e.pendingAmendments = names
 }
 
@@ -450,24 +383,5 @@ func (e *TestEnv) SetAmendments(names []string) {
 // so it participates in canonical sort salt and survives replay-on-close.
 func (e *TestEnv) ReimburseWithPayment(acc *Account) {
 	e.t.Helper()
-	master := e.accounts["master"]
-	if master == nil {
-		e.t.Fatal("ReimburseWithPayment: master account not found")
-	}
-
-	seq := e.Seq(master)
-	p := payment.NewPayment(master.Address, acc.Address, tx.NewXRPAmount(int64(e.baseFee)))
-	p.Fee = formatUint64(e.baseFee)
-	p.Sequence = &seq
-	if e.networkID > 1024 {
-		p.NetworkID = &e.networkID
-	}
-	if master.PublicKey != nil {
-		e.SignWith(p, master)
-	}
-
-	result := e.Submit(p)
-	if !result.Success {
-		e.t.Fatalf("ReimburseWithPayment: failed for %s: %s", acc.Name, result.Code)
-	}
+	e.masterPayment(acc, e.baseFee, true, "reimburse")
 }

--- a/internal/testing/escrow/escrow_test.go
+++ b/internal/testing/escrow/escrow_test.go
@@ -354,6 +354,7 @@ func TestEscrow_DisallowXRP(t *testing.T) {
 		// Reference: rippled lines 266-275
 		env := jtx.NewTestEnv(t)
 		env.DisableFeature("DepositAuth")
+		env.Close()
 
 		bob := jtx.NewAccount("bob")
 		george := jtx.NewAccount("george")

--- a/internal/testing/escrow/token_escrow_mpt_test.go
+++ b/internal/testing/escrow/token_escrow_mpt_test.go
@@ -167,6 +167,7 @@ func TestMPTEscrow_CreatePreflight(t *testing.T) {
 		env := jtx.NewTestEnv(t)
 		env.EnableFeature("TokenEscrow")
 		env.DisableFeature("MPTokensV1")
+		env.Close()
 
 		alice := jtx.NewAccount("alice")
 		bob := jtx.NewAccount("bob")

--- a/internal/testing/escrow/token_escrow_test.go
+++ b/internal/testing/escrow/token_escrow_test.go
@@ -146,6 +146,7 @@ func TestIOUEscrow_Enablement(t *testing.T) {
 
 		// Disable TokenEscrow for the escrow create attempt
 		env.DisableFeature("TokenEscrow")
+		env.Close()
 
 		// Create IOU escrow: should fail with temBAD_AMOUNT
 		result = env.Submit(

--- a/internal/testing/mpt/mpt_test.go
+++ b/internal/testing/mpt/mpt_test.go
@@ -21,6 +21,7 @@ func TestMPT_CreateValidation(t *testing.T) {
 		// If the MPT amendment is not enabled, you should not be able to create MPTokenIssuances
 		env := jtx.NewTestEnv(t)
 		env.DisableFeature("MPTokensV1")
+		env.Close()
 		alice := jtx.NewAccount("alice")
 		env.Fund(alice)
 
@@ -224,6 +225,7 @@ func TestMPT_DestroyValidation(t *testing.T) {
 		// Reference: rippled lines 244-254
 		env := jtx.NewTestEnv(t)
 		env.DisableFeature("MPTokensV1")
+		env.Close()
 		alice := jtx.NewAccount("alice")
 		env.Fund(alice)
 
@@ -239,6 +241,7 @@ func TestMPT_DestroyValidation(t *testing.T) {
 
 		// Enable feature and test invalid flag
 		env.EnableFeature("MPTokensV1")
+		env.Close()
 
 		mptAlice.Destroy(mpt.DestroyOpts{
 			ID:    id,
@@ -312,6 +315,7 @@ func TestMPT_AuthorizeValidation(t *testing.T) {
 		// Reference: rippled lines 313-321
 		env := jtx.NewTestEnv(t)
 		env.DisableFeature("MPTokensV1")
+		env.Close()
 		alice := jtx.NewAccount("alice")
 		bob := jtx.NewAccount("bob")
 		env.Fund(alice)
@@ -682,6 +686,7 @@ func TestMPT_SetValidation(t *testing.T) {
 		// Reference: rippled lines 570-658
 		env := jtx.NewTestEnv(t)
 		env.DisableFeature("MPTokensV1")
+		env.Close()
 		alice := jtx.NewAccount("alice")
 		bob := jtx.NewAccount("bob")
 		env.Fund(alice)
@@ -698,6 +703,7 @@ func TestMPT_SetValidation(t *testing.T) {
 
 		// Enable feature
 		env.EnableFeature("MPTokensV1")
+		env.Close()
 
 		mptAlice.Create(mpt.CreateOpts{OwnerCount: mpt.PtrUint32(1), HolderCount: mpt.PtrUint32(0)})
 		mptAlice.Authorize(mpt.AuthorizeOpts{Account: bob, HolderCount: mpt.PtrUint32(1)})
@@ -901,6 +907,7 @@ func TestMPT_Payment(t *testing.T) {
 		// Reference: rippled lines 928-937
 		env := jtx.NewTestEnv(t)
 		env.DisableFeature("MPTokensV1")
+		env.Close()
 		alice := jtx.NewAccount("alice")
 		bob := jtx.NewAccount("bob")
 		env.FundAmount(alice, uint64(jtx.XRP(1_000)))
@@ -1441,6 +1448,7 @@ func TestMPT_ClawbackValidation(t *testing.T) {
 		// Reference: rippled lines 2360-2380
 		env := jtx.NewTestEnv(t)
 		env.DisableFeature("MPTokensV1")
+		env.Close()
 		alice := jtx.NewAccount("alice")
 		bob := jtx.NewAccount("bob")
 		env.FundAmount(alice, uint64(jtx.XRP(1_000)))

--- a/internal/testing/nft/nftoken_test.go
+++ b/internal/testing/nft/nftoken_test.go
@@ -163,6 +163,7 @@ func TestEnabled(t *testing.T) {
 		// Disable NFT amendments
 		env.DisableFeature("NonFungibleTokensV1")
 		env.DisableFeature("NonFungibleTokensV1_1")
+		env.Close()
 
 		// Verify initial counts
 		jtx.RequireOwnerCount(t, env, alice, 0)

--- a/internal/testing/oracle/oracle_test.go
+++ b/internal/testing/oracle/oracle_test.go
@@ -1496,6 +1496,7 @@ func TestAmendment(t *testing.T) {
 		env.Close()
 
 		env.DisableFeature("PriceOracle")
+		env.Close()
 
 		lut := defaultLUT(env)
 		result := env.Submit(oracletest.OracleSet(owner, 1, lut).
@@ -1517,6 +1518,7 @@ func TestAmendment(t *testing.T) {
 		env.Close()
 
 		env.DisableFeature("PriceOracle")
+		env.Close()
 
 		result := env.Submit(oracletest.OracleDelete(owner, 1).
 			Fee(baseFee).

--- a/internal/testing/paychan/paychan_test.go
+++ b/internal/testing/paychan/paychan_test.go
@@ -1979,6 +1979,7 @@ func TestEnabled(t *testing.T) {
 		env.Close()
 
 		env.DisableFeature("PayChan")
+		env.Close()
 
 		submitExpect(t, env, ChannelCreate(alice, bob, xrp(1000), 100, alice.PublicKeyHex()).Build(), "temDISABLED")
 
@@ -2008,18 +2009,6 @@ func submitExpect(t *testing.T, env *jtx.TestEnv, txn tx.Transaction, expectedCo
 	result := env.Submit(txn)
 	require.Equal(t, expectedCode, result.Code,
 		fmt.Sprintf("expected %s but got %s", expectedCode, result.Code))
-}
-
-// closeToParentCloseTime closes one ledger so that the new open ledger's
-// parent close time lands exactly on target (Ripple epoch seconds).
-func closeToParentCloseTime(t *testing.T, env *jtx.TestEnv, target uint32) {
-	t.Helper()
-	resolution := time.Duration(env.Ledger().CloseTimeResolution()) * time.Second
-	targetTime := time.Unix(int64(target)+protocol.RippleEpochUnix, 0).UTC()
-	env.SetTime(targetTime.Add(-resolution))
-	env.Close()
-	got := uint32(env.Ledger().ParentCloseTime().Unix() - protocol.RippleEpochUnix)
-	require.Equal(t, target, got, "parent close time must land exactly on target")
 }
 
 // TestPayChan_CredentialExpirySemantics verifies rippled's credential expiry
@@ -2071,7 +2060,7 @@ func TestPayChan_CredentialExpirySemantics(t *testing.T) {
 
 	// At ParentCloseTime == Expiration the credential is still valid:
 	// removeExpired uses strict ">", so the claim succeeds.
-	closeToParentCloseTime(t, env, expiration)
+	env.CloseToParentCloseTime(expiration)
 	delta := xrp(500)
 	jtx.RequireTxSuccess(t, env.Submit(ChannelClaim(alice, chanIDHex).
 		Balance(delta).Amount(delta).

--- a/internal/testing/payment/depositauth_test.go
+++ b/internal/testing/payment/depositauth_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/depositpreauth"
 	paymentPkg "github.com/LeJamon/go-xrpl/internal/tx/payment"
-	"github.com/LeJamon/go-xrpl/keylet"
-	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -821,16 +819,6 @@ func TestDepositPreauth_Credentials(t *testing.T) {
 	t.Log("DepositPreauth credentials test passed")
 }
 
-// rippleTime returns the current Ripple epoch time from the test environment.
-func rippleTime(env *xrplgoTesting.TestEnv) uint32 {
-	return uint32(env.Now().Unix() - protocol.RippleEpochUnix)
-}
-
-// credentialKeylet computes the keylet for a credential given subject, issuer, and raw credential type.
-func credentialKeylet(subject, issuer *xrplgoTesting.Account, credType string) keylet.Keylet {
-	return keylet.Credential(subject.ID, issuer.ID, []byte(credType))
-}
-
 // TestDepositPreauth_ExpiredCredentials tests DepositPreauth with expired credentials.
 // From rippled: DepositPreauth_test::testExpiredCreds
 // When a payment is attempted with expired credentials, the transaction should
@@ -852,7 +840,7 @@ func TestDepositPreauth_ExpiredCredentials(t *testing.T) {
 	env.Close()
 
 	// issuer creates credential for alice with short expiration (current time + 60s).
-	now := rippleTime(env)
+	now := env.NowRipple()
 	expiration := now + 60
 	result := env.Submit(
 		credential.CredentialCreate(issuer, alice, credType).
@@ -868,7 +856,7 @@ func TestDepositPreauth_ExpiredCredentials(t *testing.T) {
 	env.Close()
 
 	// issuer creates a second credential for alice with long expiration.
-	now = rippleTime(env)
+	now = env.NowRipple()
 	result = env.Submit(
 		credential.CredentialCreate(issuer, alice, credType2).
 			Expiration(now + 1000).
@@ -920,12 +908,12 @@ func TestDepositPreauth_ExpiredCredentials(t *testing.T) {
 	env.Close()
 
 	// Expired credential (credType) should be deleted from the ledger.
-	credKey := credentialKeylet(alice, issuer, credType)
+	credKey := xrplgoTesting.CredentialKeylet(alice, issuer, credType)
 	require.False(t, env.LedgerEntryExists(credKey),
 		"expired credential should be deleted from ledger")
 
 	// Non-expired credential (credType2) should still be present.
-	credKey2 := credentialKeylet(alice, issuer, credType2)
+	credKey2 := xrplgoTesting.CredentialKeylet(alice, issuer, credType2)
 	require.True(t, env.LedgerEntryExists(credKey2),
 		"non-expired credential should still exist")
 

--- a/internal/testing/permissioneddex/permissioned_dex_test.go
+++ b/internal/testing/permissioneddex/permissioned_dex_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 	"github.com/LeJamon/go-xrpl/keylet"
-	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // requireResult asserts the transaction result matches the expected code.
@@ -40,11 +39,6 @@ func xrpUsdEurPath(gw *jtx.Account) [][]payment.PathStep {
 		{Currency: "USD", Issuer: gw.Address},
 		{Currency: "EUR", Issuer: gw.Address},
 	}}
-}
-
-// rippleTimeNow returns the current ledger time as Ripple epoch seconds.
-func rippleTimeNow(env *jtx.TestEnv) uint32 {
-	return uint32(env.Now().Unix() - protocol.RippleEpochUnix)
 }
 
 // badDomain is a nonexistent domain ID (hex).
@@ -150,7 +144,7 @@ func TestPermissionedDEX_OfferCreate(t *testing.T) {
 		env.Close()
 
 		// Issue credential with 20s expiry
-		expiration := rippleTimeNow(env) + 20
+		expiration := env.NowRipple() + 20
 		result := env.Submit(
 			cred.CredentialCreate(dex.DomainOwner, devin, dex.CredType).
 				Expiration(expiration).Build(),
@@ -773,7 +767,7 @@ func TestPermissionedDEX_BookStep(t *testing.T) {
 		// (no Close between them), matching rippled's testBookStep behavior where
 		// both are applied before env.close() so only 2 closes happen before the
 		// first payment instead of 3 (which would exceed the 20s expiration).
-		expiration := rippleTimeNow(env) + 20
+		expiration := env.NowRipple() + 20
 		result := env.Submit(
 			cred.CredentialCreate(dex.DomainOwner, devin, dex.CredType).
 				Expiration(expiration).Build(),

--- a/internal/testing/result.go
+++ b/internal/testing/result.go
@@ -22,24 +22,6 @@ type TxResult struct {
 // tesSUCCESS is the result code for a successful transaction.
 const tesSUCCESS = "tesSUCCESS"
 
-// ResultSuccess returns a successful transaction result.
-func ResultSuccess() TxResult {
-	return TxResult{
-		Code:    tesSUCCESS,
-		Success: true,
-		Message: "The transaction was applied.",
-	}
-}
-
-// ResultWithCode creates a TxResult with the specified code.
-func ResultWithCode(code string, success bool, message string) TxResult {
-	return TxResult{
-		Code:    code,
-		Success: success,
-		Message: message,
-	}
-}
-
 // IsSuccess returns true if the result code indicates success.
 func (r TxResult) IsSuccess() bool {
 	return r.Code == tesSUCCESS

--- a/internal/testing/testing_test.go
+++ b/internal/testing/testing_test.go
@@ -96,16 +96,9 @@ func TestManualClock(t *testing.T) {
 	assert.Equal(t, newTime, clock.Now())
 }
 
-func TestManualClockAt(t *testing.T) {
-	startTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	clock := NewManualClockAt(startTime)
-
-	assert.Equal(t, startTime, clock.Now())
-}
-
 func TestTxResult(t *testing.T) {
 	// Success
-	success := ResultSuccess()
+	success := TxResult{Code: "tesSUCCESS", Success: true}
 	assert.True(t, success.IsSuccess())
 	assert.False(t, success.IsClaimed())
 	assert.False(t, success.IsRetry())
@@ -113,23 +106,23 @@ func TestTxResult(t *testing.T) {
 	assert.False(t, success.IsFailed())
 
 	// Claimed (tec)
-	claimed := ResultWithCode("tecUNFUNDED_PAYMENT", false, "insufficient funds")
+	claimed := TxResult{Code: "tecUNFUNDED_PAYMENT"}
 	assert.False(t, claimed.IsSuccess())
 	assert.True(t, claimed.IsClaimed())
 	assert.False(t, claimed.IsRetry())
 
 	// Retry (ter)
-	retry := ResultWithCode("terPRE_SEQ", false, "pre-sequence")
+	retry := TxResult{Code: "terPRE_SEQ"}
 	assert.False(t, retry.IsSuccess())
 	assert.True(t, retry.IsRetry())
 
 	// Malformed (tem)
-	malformed := ResultWithCode("temMALFORMED", false, "malformed")
+	malformed := TxResult{Code: "temMALFORMED"}
 	assert.False(t, malformed.IsSuccess())
 	assert.True(t, malformed.IsMalformed())
 
 	// Failed (tef)
-	failed := ResultWithCode("tefPAST_SEQ", false, "past sequence")
+	failed := TxResult{Code: "tefPAST_SEQ"}
 	assert.False(t, failed.IsSuccess())
 	assert.True(t, failed.IsFailed())
 }
@@ -142,15 +135,6 @@ func TestResultCodeCategory(t *testing.T) {
 	assert.Equal(t, "malformed", ResultCodeCategory("temMALFORMED"))
 	assert.Equal(t, "unknown", ResultCodeCategory("xyz"))
 	assert.Equal(t, "unknown", ResultCodeCategory("ab"))
-}
-
-func TestFormatBalance(t *testing.T) {
-	formatted := FormatBalance(1_000_000)
-	assert.Contains(t, formatted, "1.000000 XRP")
-	assert.Contains(t, formatted, "1000000 drops")
-
-	formatted2 := FormatBalance(100_500_000)
-	assert.Contains(t, formatted2, "100.500000 XRP")
 }
 
 func TestIssuedCurrencyHelpers(t *testing.T) {

--- a/internal/testing/ticket/ticket_test.go
+++ b/internal/testing/ticket/ticket_test.go
@@ -44,6 +44,7 @@ func noop(acc *jtx.Account) *account.AccountSet {
 func TestTicket_FeatureNotEnabled(t *testing.T) {
 	env := jtx.NewTestEnv(t)
 	env.DisableFeature("TicketBatch")
+	env.Close()
 	master := env.MasterAccount()
 
 	// ticket::create(master, 1) → temDISABLED

--- a/scripts/conformance-summary.sh
+++ b/scripts/conformance-summary.sh
@@ -74,8 +74,35 @@ SUITE_DATA=$(mktemp)
 trap 'rm -f "$TMPFILE" "$RESULTS" "$SUITE_DATA" "$OOS_FILE"' EXIT
 
 echo "Running conformance tests (timeout=${TIMEOUT})..."
+# Capture the exit status and BOTH streams (stderr carries build errors and
+# panics). The previous `2>&1 > file` order sent stderr to the terminal, not
+# the file, so compile failures escaped the result accounting below.
+GO_TEST_EXIT=0
 go test -count=1 ./internal/testing/conformance/... \
-    $RUN_PATTERN -timeout "$TIMEOUT" -v 2>&1 > "$TMPFILE" || true
+    $RUN_PATTERN -timeout "$TIMEOUT" -v > "$TMPFILE" 2>&1 || GO_TEST_EXIT=$?
+
+# fail_loud prints a red banner plus the tail of the captured output and aborts
+# non-zero. Used whenever the run ended abnormally (build failure, panic,
+# timeout, wholesale skip): in those cases the PASS/FAIL tallies below are taken
+# over a silently truncated denominator and must not be presented as the suite.
+fail_loud() {
+    echo ""
+    echo "${C_RED}${C_BOLD}=========================================${C_RESET}"
+    echo "${C_RED}${C_BOLD} CONFORMANCE RUN FAILED: $1${C_RESET}"
+    echo "${C_RED}${C_BOLD}=========================================${C_RESET}"
+    echo "${C_DIM}--- last 30 lines of test output ---${C_RESET}"
+    tail -n 30 "$TMPFILE"
+    exit 1
+}
+
+# A build failure, panic, or timeout truncates results without any PASS/FAIL
+# bookkeeping — detect the markers go test emits in those cases.
+if grep -qE 'build failed|cannot find package|\[setup failed\]' "$TMPFILE"; then
+    fail_loud "package failed to build"
+fi
+if grep -qE 'test timed out|test (binary|process|executable) killed|^panic: ' "$TMPFILE"; then
+    fail_loud "test run panicked or timed out (results truncated)"
+fi
 
 # Extract only subtest PASS/FAIL lines
 grep 'TestConformance/' "$TMPFILE" | grep -E 'PASS:|FAIL:' > "$RESULTS" || true
@@ -83,6 +110,25 @@ grep 'TestConformance/' "$TMPFILE" | grep -E 'PASS:|FAIL:' > "$RESULTS" || true
 TOTAL_PASS=$(grep -c 'PASS:' "$RESULTS" || true)
 TOTAL_FAIL=$(grep -c 'FAIL:' "$RESULTS" || true)
 TOTAL=$((TOTAL_PASS + TOTAL_FAIL))
+TOTAL_SKIP=$(grep -c -- '--- SKIP:' "$TMPFILE" || true)
+
+# Zero PASS/FAIL results means the run produced no data at all (missing/empty
+# fixtures, a wholesale t.Skip, or an early abort). Don't print an empty,
+# misleadingly-green summary. A run that is legitimately all-skips is reported,
+# not failed; anything else aborts loudly.
+if [[ "$TOTAL" -eq 0 ]]; then
+    if [[ "$TOTAL_SKIP" -gt 0 ]]; then
+        echo "${C_YELLOW}All conformance tests were skipped (${TOTAL_SKIP} skipped, 0 run).${C_RESET}"
+        exit 0
+    fi
+    fail_loud "produced zero PASS/FAIL results (go test exit ${GO_TEST_EXIT})"
+fi
+
+# A non-zero exit with no failing subtests recorded means the process died for a
+# reason the PASS/FAIL counters can't see (e.g. a late panic between subtests).
+if [[ "$GO_TEST_EXIT" -ne 0 && "$TOTAL_FAIL" -eq 0 ]]; then
+    fail_loud "go test exited ${GO_TEST_EXIT} with no failing subtests recorded"
+fi
 
 # Build per-suite data: "suite pass fail total rate"
 awk '{
@@ -128,6 +174,9 @@ if [[ "$TOTAL" -gt 0 ]]; then
     PCT=$(echo "scale=1; $TOTAL_PASS * 100 / $TOTAL" | bc 2>/dev/null || echo "?")
     printf " Total:    %4d pass / %4d fail / %4d  (%s%%)\n" \
         "$TOTAL_PASS" "$TOTAL_FAIL" "$TOTAL" "$PCT"
+fi
+if [[ "$TOTAL_SKIP" -gt 0 ]]; then
+    printf " ${C_YELLOW}Skipped:  %4d${C_RESET}\n" "$TOTAL_SKIP"
 fi
 if [[ "$IN_SCOPE_TOTAL" -gt 0 ]]; then
     IN_PCT=$(echo "scale=1; $IN_SCOPE_PASS * 100 / $IN_SCOPE_TOTAL" | bc 2>/dev/null || echo "?")


### PR DESCRIPTION
## Summary
Resolves the #902 audit of the jtx-style test framework, across three areas.

**Correctness**
- `scripts/conformance-summary.sh` now captures `go test`'s exit status and fails loudly on build failure / panic / timeout / zero-result runs (previously these produced an empty-but-green summary), and reports the skip count.
- `EnableFeature` / `DisableFeature` / `SetAmendments` validate amendment names (`t.Fatalf` on unknown — no more silent no-op) and **defer to the next `Close()`**, matching rippled's `Env::enableFeature` semantics; `FeatureEnabled` reflects staged toggles.
- `submitWithSigVerification` seeds and bumps the per-ledger tx counters (header-based `ParentCloseTime`, `FeeTrack`) so `metadata.TransactionIndex` and TxQ metrics match the `Submit` path.
- Removed the dead `explicitFundAddrs` map in the conformance runner.

**Deduplication (~500 lines)**
- Single `engineConfig` builder for all six apply paths.
- Merged `Close()` / `CloseWithTimeLeap()` into one `close(timeLeap)`.
- Collapsed the ~20 AccountSet flag helpers onto `setAccountFlag`/`clearAccountFlag`, the three account constructors onto `newAccountFromSeedBytes`/`buildAccount`, the SetRegularKey free-fee check, and the master→account payment boilerplate.
- Added `NowRipple` / `CredentialKeylet` / `CloseToParentCloseTime` and migrated the per-suite copies.

**Idiomatic**
- Removed dead helpers, dropped unreachable `return`s after `t.Fatalf`, switched assertions to `testing.TB`, rewrote `doc.go` around the real API.

Notes:
- Deferring amendment toggles required inserting `Close()` in the suites that toggle-then-submit; the conformance runner uses a new `EnableFeatureNow` to preserve immediate replay semantics for recorded `enable_amendment` steps.
- Kept `RequireLines` rather than deleting it — finding #3's "it's wrong" rationale no longer applies (it already counts RippleState entries correctly on `main`), and it's the natural peer of the actively-used `RequireOffers`.

## Test plan
- [x] `go test ./internal/testing/...` — fully green (0 failures)
- [x] Conformance pass/fail **identical to `main`** (204 pre-existing out-of-scope Vault/XChain/Batch failures; the 4 `enable_amendment` fixtures that regressed under deferral are fixed via `EnableFeatureNow`)
- [x] External jtx consumers pass (`internal/consensus/adaptor`, `internal/ledger/{localtxs,openledger,service}`)
- [x] `go vet` + `gofmt` clean across all consumer packages

Fixes #902