### PR TITLE
refactor: collapse Replayer's parallel in-flight registries

### DIFF
--- a/internal/ledger/inbound/inflight_registry.go
+++ b/internal/ledger/inbound/inflight_registry.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2024-2026. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package inbound
+
+import (
+	"maps"
+	"sync"
+)
+
+// inFlightItem is the minimal behaviour an acquisition must expose for
+// the registry to enforce its per-peer cap. Both *ReplayDelta and
+// *SkipListAcquire satisfy it; everything else the registry needs is
+// type-agnostic, hash-keyed map bookkeeping.
+type inFlightItem interface {
+	PeerID() uint64
+}
+
+// inFlightRegistry is a concurrency-safe set of in-flight acquisitions
+// keyed by ledger hash, enforcing a global cap and a per-peer cap on
+// admission. The replay-delta and skip-list paths each own one: keeping
+// them separate makes the per-hash dedup precise (the same hash can be
+// both a replay-delta target and a skip-list target) and stops a deep
+// delta backlog from starving short-lived proof-path fetches. The caps
+// are sized identically but accounted independently.
+type inFlightRegistry[T inFlightItem] struct {
+	mu          sync.Mutex
+	items       map[[32]byte]T
+	maxInFlight int
+	maxPerPeer  int
+}
+
+// newInFlightRegistry returns an empty registry with the given caps.
+func newInFlightRegistry[T inFlightItem](maxInFlight, maxPerPeer int) *inFlightRegistry[T] {
+	return &inFlightRegistry[T]{
+		items:       make(map[[32]byte]T),
+		maxInFlight: maxInFlight,
+		maxPerPeer:  maxPerPeer,
+	}
+}
+
+// add registers a new acquisition for hash, enforcing in order: dedup
+// (ErrAcquisitionExists), the global cap (ErrCapacityFull), and the
+// per-peer cap against peerID (ErrPerPeerCapacityFull). factory is
+// invoked only once every check passes, so a rejected admission never
+// constructs an acquisition. The whole sequence runs under the lock so
+// concurrent callers observe a consistent count. Returns the zero value
+// of T and the sentinel error on rejection.
+func (r *inFlightRegistry[T]) add(hash [32]byte, peerID uint64, factory func() T) (T, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var zero T
+	if _, exists := r.items[hash]; exists {
+		return zero, ErrAcquisitionExists
+	}
+	if len(r.items) >= r.maxInFlight {
+		return zero, ErrCapacityFull
+	}
+
+	perPeer := 0
+	for _, it := range r.items {
+		if it.PeerID() == peerID {
+			perPeer++
+		}
+	}
+	if perPeer >= r.maxPerPeer {
+		return zero, ErrPerPeerCapacityFull
+	}
+
+	item := factory()
+	r.items[hash] = item
+	return item, nil
+}
+
+// get returns the acquisition registered under hash, if any.
+func (r *inFlightRegistry[T]) get(hash [32]byte) (T, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	it, ok := r.items[hash]
+	return it, ok
+}
+
+// remove drops the acquisition for hash. No-op on an unknown hash, so
+// callers can call it unconditionally at the end of a handle path.
+func (r *inFlightRegistry[T]) remove(hash [32]byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.items, hash)
+}
+
+// has reports whether hash is currently registered.
+func (r *inFlightRegistry[T]) has(hash [32]byte) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.items[hash]
+	return ok
+}
+
+// count returns the number of in-flight acquisitions.
+func (r *inFlightRegistry[T]) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.items)
+}
+
+// drain empties the registry and returns the number of entries removed,
+// so a shutdown caller has an observable "N still pending" count.
+func (r *inFlightRegistry[T]) drain() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := len(r.items)
+	r.items = make(map[[32]byte]T)
+	return n
+}
+
+// snapshot returns a freshly-allocated copy of the hash→item map. The
+// item values are shared, so callers must use the items' own
+// concurrency-safe methods; the registry lock is released before the
+// caller iterates the result.
+func (r *inFlightRegistry[T]) snapshot() map[[32]byte]T {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return maps.Clone(r.items)
+}

--- a/internal/ledger/inbound/inflight_registry.go
+++ b/internal/ledger/inbound/inflight_registry.go
@@ -74,7 +74,6 @@ func (r *inFlightRegistry[T]) add(hash [32]byte, peerID uint64, factory func() T
 	return item, nil
 }
 
-// get returns the acquisition registered under hash, if any.
 func (r *inFlightRegistry[T]) get(hash [32]byte) (T, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -90,7 +89,6 @@ func (r *inFlightRegistry[T]) remove(hash [32]byte) {
 	delete(r.items, hash)
 }
 
-// has reports whether hash is currently registered.
 func (r *inFlightRegistry[T]) has(hash [32]byte) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -98,7 +96,6 @@ func (r *inFlightRegistry[T]) has(hash [32]byte) bool {
 	return ok
 }
 
-// count returns the number of in-flight acquisitions.
 func (r *inFlightRegistry[T]) count() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/ledger/inbound/replay_delta_test.go
+++ b/internal/ledger/inbound/replay_delta_test.go
@@ -350,7 +350,7 @@ func TestInboundReplayDelta_SubTaskRetryLoop(t *testing.T) {
 	// a further retry from the router (SubTaskTimedOut filter in the
 	// replayer skips exhausted entries).
 	r := NewReplayer(nil, nil, 1)
-	r.inFlight[rd.Hash()] = rd
+	r.delta.items[rd.Hash()] = rd
 	assert.Empty(t, r.SubTaskTimedOut(),
 		"exhausted acquisition must not appear in SubTaskTimedOut")
 }

--- a/internal/ledger/inbound/replayer.go
+++ b/internal/ledger/inbound/replayer.go
@@ -68,21 +68,24 @@ type TimedOutEntry struct {
 }
 
 // Replayer coordinates concurrent *ReplayDelta and *SkipListAcquire
-// acquisitions under a shared cap. Transport-agnostic; the caller
-// issues the wire request via its own NetworkSender. Mirrors
-// rippled's LedgerReplayer.
+// acquisitions, each backed by its own inFlightRegistry. Transport-
+// agnostic; the caller issues the wire request via its own
+// NetworkSender. Mirrors rippled's LedgerReplayer.
 //
-// Skip-list and replay-delta share the cap but use separate maps so
-// the per-hash dedup is precise — the same hash can legitimately be
-// both a skip-list target (its 256-entry ancestor vector) and a
-// replay-delta target (its tx-set).
+// Skip-list and replay-delta size their caps identically but account
+// them separately so the per-hash dedup is precise — the same hash can
+// legitimately be both a skip-list target (its 256-entry ancestor
+// vector) and a replay-delta target (its tx-set).
 type Replayer struct {
-	mu           sync.Mutex
-	inFlight     map[[32]byte]*ReplayDelta
-	inFlightSkip map[[32]byte]*SkipListAcquire
-	logger       *slog.Logger
-	clock        Clock
-	maxInFlight  int
+	delta *inFlightRegistry[*ReplayDelta]
+	skip  *inFlightRegistry[*SkipListAcquire]
+
+	logger *slog.Logger
+
+	// clockMu guards only the swappable clock handed to newly-armed
+	// acquisitions; the registries carry their own locks.
+	clockMu sync.Mutex
+	clock   Clock
 }
 
 // NewReplayer returns a Replayer configured with the given concurrency
@@ -100,11 +103,10 @@ func NewReplayer(logger *slog.Logger, clock Clock, maxInFlight int) *Replayer {
 		maxInFlight = DefaultMaxInFlightReplays
 	}
 	return &Replayer{
-		inFlight:     make(map[[32]byte]*ReplayDelta),
-		inFlightSkip: make(map[[32]byte]*SkipListAcquire),
-		logger:       logger,
-		clock:        clock,
-		maxInFlight:  maxInFlight,
+		delta:  newInFlightRegistry[*ReplayDelta](maxInFlight, MaxPerPeerReplays),
+		skip:   newInFlightRegistry[*SkipListAcquire](maxInFlight, MaxPerPeerReplays),
+		logger: logger,
+		clock:  clock,
 	}
 }
 
@@ -116,9 +118,17 @@ func (r *Replayer) SetClock(c Clock) {
 	if c == nil {
 		c = SystemClock
 	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.clockMu.Lock()
+	defer r.clockMu.Unlock()
 	r.clock = c
+}
+
+// currentClock returns the clock a newly-armed acquisition should
+// capture. Read under clockMu so a concurrent SetClock is race-free.
+func (r *Replayer) currentClock() Clock {
+	r.clockMu.Lock()
+	defer r.clockMu.Unlock()
+	return r.clock
 }
 
 // Acquire arms a new *ReplayDelta for the ledger identified by hash,
@@ -135,32 +145,9 @@ func (r *Replayer) SetClock(c Clock) {
 // the slot. HandleResponse later resolves the response back to this
 // acquisition via its ledger hash.
 func (r *Replayer) Acquire(hash [32]byte, peerID uint64, parent *ledger.Ledger) (*ReplayDelta, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if _, exists := r.inFlight[hash]; exists {
-		return nil, ErrAcquisitionExists
-	}
-	if len(r.inFlight) >= r.maxInFlight {
-		return nil, ErrCapacityFull
-	}
-
-	// R5.14 per-peer cap. Count how many in-flight acquisitions are
-	// currently targeting peerID; if >= MaxPerPeerReplays the caller
-	// must pick a different peer via ReplayCapablePeersExcluding.
-	perPeer := 0
-	for _, rd := range r.inFlight {
-		if rd.PeerID() == peerID {
-			perPeer++
-		}
-	}
-	if perPeer >= MaxPerPeerReplays {
-		return nil, ErrPerPeerCapacityFull
-	}
-
-	rd := NewReplayDeltaWithClock(hash, peerID, parent, r.logger, r.clock)
-	r.inFlight[hash] = rd
-	return rd, nil
+	return r.delta.add(hash, peerID, func() *ReplayDelta {
+		return NewReplayDeltaWithClock(hash, peerID, parent, r.logger, r.currentClock())
+	})
 }
 
 // HandleResponse routes resp to the matching in-flight acquisition
@@ -187,10 +174,7 @@ func (r *Replayer) HandleResponse(resp *message.ReplayDeltaResponse) (*ReplayDel
 		return nil, ErrNoMatchingAcquisition
 	}
 
-	r.mu.Lock()
-	rd, exists := r.inFlight[hash]
-	r.mu.Unlock()
-
+	rd, exists := r.delta.get(hash)
 	if !exists {
 		return nil, ErrNoMatchingAcquisition
 	}
@@ -206,9 +190,7 @@ func (r *Replayer) HandleResponse(resp *message.ReplayDeltaResponse) (*ReplayDel
 // abandonment. No-op on unknown hash so callers can call it
 // unconditionally at the end of a handle-response path.
 func (r *Replayer) Complete(hash [32]byte) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	delete(r.inFlight, hash)
+	r.delta.remove(hash)
 }
 
 // Abandon is a synonym for Complete. Kept as a separate call for
@@ -225,20 +207,15 @@ func (r *Replayer) Abandon(hash [32]byte) {
 // pending at shutdown" count, and so subsequent calls to Acquire
 // from late-arriving traffic don't spuriously grow the map post-stop.
 //
-// Implementation: we simply clear the map. ReplayDelta instances are
-// single-struct values (no goroutines of their own); the router's
-// Run() goroutine owns the message loop that was feeding them, so
-// once the context cancels the router stops and nothing will try to
-// advance these acquisitions further. Callers that need a softer
-// handoff (e.g., "log each outstanding replay at stop") can iterate
-// the slice returned by InFlight() before calling Stop.
+// Implementation: we simply clear both registries. ReplayDelta and
+// SkipListAcquire instances are single-struct values (no goroutines of
+// their own); the router's Run() goroutine owns the message loop that
+// was feeding them, so once the context cancels the router stops and
+// nothing will try to advance these acquisitions further. Callers that
+// need a softer handoff (e.g., "log each outstanding replay at stop")
+// can iterate the slice returned by InFlight() before calling Stop.
 func (r *Replayer) Stop() int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	n := len(r.inFlight) + len(r.inFlightSkip)
-	r.inFlight = make(map[[32]byte]*ReplayDelta)
-	r.inFlightSkip = make(map[[32]byte]*SkipListAcquire)
-	return n
+	return r.delta.drain() + r.skip.drain()
 }
 
 // InFlight returns a snapshot of hashes currently being acquired.
@@ -247,16 +224,15 @@ func (r *Replayer) Stop() int {
 // parent is nil (shouldn't happen in production) sort to the front as
 // seq 0.
 func (r *Replayer) InFlight() [][32]byte {
-	r.mu.Lock()
+	snap := r.delta.snapshot()
 	type entry struct {
 		hash [32]byte
 		seq  uint32
 	}
-	entries := make([]entry, 0, len(r.inFlight))
-	for h, rd := range r.inFlight {
+	entries := make([]entry, 0, len(snap))
+	for h, rd := range snap {
 		entries = append(entries, entry{hash: h, seq: rd.Seq()})
 	}
-	r.mu.Unlock()
 
 	sort.Slice(entries, func(i, j int) bool { return entries[i].seq < entries[j].seq })
 	out := make([][32]byte, len(entries))
@@ -272,11 +248,8 @@ func (r *Replayer) InFlight() [][32]byte {
 // Seq + PeerID. Returning TimedOutEntry (rather than bare hashes)
 // removes a round-trip to fetch Seq/PeerID after the slot is freed.
 func (r *Replayer) TimedOut() []TimedOutEntry {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	var out []TimedOutEntry
-	for h, rd := range r.inFlight {
+	for h, rd := range r.delta.snapshot() {
 		if rd.IsTimedOut() {
 			out = append(out, TimedOutEntry{
 				Hash:   h,
@@ -297,11 +270,8 @@ func (r *Replayer) TimedOut() []TimedOutEntry {
 // and re-issuing the wire request. Separated from TimedOut so the
 // router handles rotation vs. abandon distinctly.
 func (r *Replayer) SubTaskTimedOut() []*ReplayDelta {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	var out []*ReplayDelta
-	for _, rd := range r.inFlight {
+	for _, rd := range r.delta.snapshot() {
 		if rd.IsSubTaskTimedOut() && !rd.IsTimedOut() && !rd.RetriesExhausted() {
 			out = append(out, rd)
 		}
@@ -313,19 +283,14 @@ func (r *Replayer) SubTaskTimedOut() []*ReplayDelta {
 
 // Count returns the current number of in-flight acquisitions.
 func (r *Replayer) Count() int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return len(r.inFlight)
+	return r.delta.count()
 }
 
 // Has reports whether the given hash is currently in flight. Useful
 // for callers that want to cheap-skip a duplicate Acquire without
 // incurring the ErrAcquisitionExists round-trip.
 func (r *Replayer) Has(hash [32]byte) bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	_, ok := r.inFlight[hash]
-	return ok
+	return r.delta.has(hash)
 }
 
 // AcquireSkipList arms a new *SkipListAcquire for targetHash's
@@ -335,29 +300,9 @@ func (r *Replayer) Has(hash [32]byte) bool {
 // otherwise mirror Acquire (ErrAcquisitionExists / ErrCapacityFull /
 // ErrPerPeerCapacityFull).
 func (r *Replayer) AcquireSkipList(targetHash, stateHash [32]byte, peerID uint64) (*SkipListAcquire, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if _, exists := r.inFlightSkip[targetHash]; exists {
-		return nil, ErrAcquisitionExists
-	}
-	if len(r.inFlightSkip) >= r.maxInFlight {
-		return nil, ErrCapacityFull
-	}
-
-	perPeer := 0
-	for _, sa := range r.inFlightSkip {
-		if sa.PeerID() == peerID {
-			perPeer++
-		}
-	}
-	if perPeer >= MaxPerPeerReplays {
-		return nil, ErrPerPeerCapacityFull
-	}
-
-	sa := NewSkipListAcquireWithClock(targetHash, stateHash, peerID, r.logger, r.clock)
-	r.inFlightSkip[targetHash] = sa
-	return sa, nil
+	return r.skip.add(targetHash, peerID, func() *SkipListAcquire {
+		return NewSkipListAcquireWithClock(targetHash, stateHash, peerID, r.logger, r.currentClock())
+	})
 }
 
 // HandleSkipListResponse routes resp to the matching in-flight
@@ -373,10 +318,7 @@ func (r *Replayer) HandleSkipListResponse(resp *message.ProofPathResponse) (*Ski
 		return nil, ErrNoMatchingAcquisition
 	}
 
-	r.mu.Lock()
-	sa, exists := r.inFlightSkip[hash]
-	r.mu.Unlock()
-
+	sa, exists := r.skip.get(hash)
 	if !exists {
 		return nil, ErrNoMatchingAcquisition
 	}
@@ -390,9 +332,7 @@ func (r *Replayer) HandleSkipListResponse(resp *message.ProofPathResponse) (*Ski
 // CompleteSkipList removes the skip-list acquisition for targetHash
 // from in-flight.
 func (r *Replayer) CompleteSkipList(targetHash [32]byte) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	delete(r.inFlightSkip, targetHash)
+	r.skip.remove(targetHash)
 }
 
 // AbandonSkipList is a caller-side synonym for CompleteSkipList,
@@ -402,28 +342,20 @@ func (r *Replayer) AbandonSkipList(targetHash [32]byte) {
 }
 
 func (r *Replayer) HasSkipList(targetHash [32]byte) bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	_, ok := r.inFlightSkip[targetHash]
-	return ok
+	return r.skip.has(targetHash)
 }
 
 // SkipListCount returns the number of in-flight skip-list
 // acquisitions. Separate counter from Count (replay-delta).
 func (r *Replayer) SkipListCount() int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return len(r.inFlightSkip)
+	return r.skip.count()
 }
 
 // SkipListTimedOut returns target hashes of every in-flight skip-list
 // acquisition whose outer budget has expired. Counterpart to TimedOut.
 func (r *Replayer) SkipListTimedOut() [][32]byte {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	var out [][32]byte
-	for h, sa := range r.inFlightSkip {
+	for h, sa := range r.skip.snapshot() {
 		if sa.IsTimedOut() {
 			out = append(out, h)
 		}

--- a/internal/ledger/inbound/replayer_test.go
+++ b/internal/ledger/inbound/replayer_test.go
@@ -177,9 +177,7 @@ func TestReplayer_HandleResponse_RoutesByHash(t *testing.T) {
 	assert.Equal(t, StateComplete, rd.State())
 
 	// The untouched acquisition must still be in StateWantBase.
-	rep.mu.Lock()
-	otherRD := rep.inFlight[otherHash]
-	rep.mu.Unlock()
+	otherRD, _ := rep.delta.get(otherHash)
 	require.NotNil(t, otherRD)
 	assert.Equal(t, StateWantBase, otherRD.State())
 


### PR DESCRIPTION
## Summary

- The `Replayer` carried two ~90%-identical method families over two maps (`inFlight`/`*ReplayDelta` and `inFlightSkip`/`*SkipListAcquire`), differing only in map name, constructor, and response type.
- Extracted a generic, self-locking `inFlightRegistry[T]` (constraint: `PeerID() uint64`) that owns the hash-keyed map plus the global and per-peer admission caps. The `Replayer` now holds one registry per acquisition type (`delta`, `skip`); its public methods delegate to them.
- The swappable clock moved behind a dedicated `clockMu` so the registries each carry only their own lock; all exported method signatures are unchanged.

## Behaviour preservation (live delta path)

- Registries are accounted **separately** with identical caps — a deep delta backlog still can't starve proof-path fetches.
- Admission ordering is preserved: dedup (`ErrAcquisitionExists`) → global cap (`ErrCapacityFull`) → per-peer cap (`ErrPerPeerCapacityFull`), all atomic under the registry's lock; the acquisition is constructed only after every check passes.
- `HandleResponse`/`HandleSkipListResponse`, `Complete`/`Abandon`, `TimedOut`/`SubTaskTimedOut`/`SkipListTimedOut`, `Count`/`Has`, and `Stop` keep their exact contracts.

## Test plan

- [x] `go test -race -count=1 ./internal/ledger/inbound/` (replayer_test.go green, incl. the concurrent-acquire race guard)
- [x] `go test -race -count=1 ./internal/consensus/adaptor/` (live router caller)
- [x] `go build ./...`, `go vet`, `golangci-lint run ./internal/ledger/inbound/...` (0 issues), `gofmt` clean

Fixes #933