### PR TITLE
fix: align payment flow offer counter and apply gate with rippled

### DIFF
--- a/internal/tx/payment/flow.go
+++ b/internal/tx/payment/flow.go
@@ -674,8 +674,14 @@ func RippleCalculate(
 	// Execute flow with FlowSortStrands amendment flag
 	result := Flow(sandbox, strands, outReq, partialPayment, qualityLimit, sendMax, ammCtx, rcOpts.flowSortStrands)
 
-	// Apply flow sandbox changes back to the main sandbox
-	if result.Result == tx.TesSUCCESS || result.Result == tx.TecPATH_PARTIAL {
+	// Apply flow sandbox changes back to the main sandbox only on success.
+	// rippled's finishFlow (Flow.cpp) applies the flow sandbox solely on
+	// tesSUCCESS; on tecPATH_PARTIAL (returned only when partial payment is not
+	// allowed) it keeps the result code and discards the sandbox, so no partial
+	// liquidity is committed. Applying it here would fold partial offer
+	// consumption and grooming into the view for a payment that ultimately
+	// fails — a state divergence from rippled.
+	if result.Result == tx.TesSUCCESS {
 		if result.Sandbox != nil {
 			if err := result.Sandbox.Apply(sandbox); err != nil {
 				return RippleCalculateResult{

--- a/internal/tx/payment/payment_iou.go
+++ b/internal/tx/payment/payment_iou.go
@@ -278,15 +278,16 @@ func (p *Payment) applyIOUPaymentWithPaths(ctx *tx.ApplyContext, senderID, destI
 		}
 	}
 
-	// Record delivered amount in metadata only when it differs from the
-	// requested Amount. rippled sets sfDeliveredAmount only when
-	// actualAmountOut != dstAmount (Payment.cpp:495); a full delivery omits
-	// it. Emitting it unconditionally forks the transaction tree from rippled
-	// on full (non-partial) IOU payments — observed as a mixed-network
-	// transaction_hash divergence (identical account_hash) at low seqs before
-	// amendments settle.
+	// Record delivered amount in metadata only on a successful delivery whose
+	// amount differs from the requested Amount. rippled sets sfDeliveredAmount
+	// only when result == tesSUCCESS && actualAmountOut != dstAmount
+	// (Payment.cpp:495); a full delivery omits it, and a non-success result
+	// (e.g. tecPATH_PARTIAL when partial payment is disallowed) never sets it.
+	// Emitting it on full payments or on a tec result forks the transaction
+	// tree from rippled — observed as a mixed-network transaction_hash
+	// divergence (identical account_hash) at low seqs before amendments settle.
 	deliveredAmt := FromEitherAmount(actualOut)
-	if deliveredAmt.Compare(p.Amount) != 0 {
+	if result == tx.TesSUCCESS && deliveredAmt.Compare(p.Amount) != 0 {
 		ctx.Metadata.DeliveredAmount = &deliveredAmt
 	}
 

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -225,7 +225,6 @@ func (s *BookStep) forEachOffer(
 				if !offerQuality.WorseThan(*s.qualityLimit) &&
 					s.strandSrc == offerOwner && s.strandDst == offerOwner {
 					ofrsToRm[clobKey] = true
-					s.offersUsed++
 					if !offerAttempted {
 						currentQuality = nil
 					}
@@ -240,7 +239,6 @@ func (s *BookStep) forEachOffer(
 			if ownerErr == nil && offerOwner != s.book.In.Issuer {
 				if !s.isOfferOwnerAuthorized(afView, offerOwner, s.book.In.Issuer, s.book.In.Currency) {
 					ofrsToRm[clobKey] = true
-					s.offersUsed++
 					if !offerAttempted {
 						currentQuality = nil
 					}
@@ -333,7 +331,12 @@ func (s *BookStep) forEachOffer(
 		if offer == nil {
 			break
 		}
-		visited[offerKey] = true
+
+		// These offers were already counted (and marked visited) by
+		// getNextOfferSkipVisited when it advanced to them, so the removals
+		// below must not double-count. In rippled the deep-frozen, unfunded and
+		// small-increased-quality checks live inside OfferStream::step, after
+		// counter_.step() has already counted the offer.
 
 		// Deep freeze check on the input (TakerPays) side.
 		// Deep-frozen offers are permanently removed from the order book.
@@ -342,7 +345,6 @@ func (s *BookStep) forEachOffer(
 			offerOwnerDF, _ := state.DecodeAccountID(offer.Account)
 			if s.isDeepFrozen(sb, offerOwnerDF, s.book.In.Currency, s.book.In.Issuer) {
 				ofrsToRm[offerKey] = true
-				s.offersUsed++
 				continue
 			}
 		}
@@ -352,12 +354,10 @@ func (s *BookStep) forEachOffer(
 		ownerFunds := s.getOfferFundedAmount(sb, offer)
 		if ownerFunds.IsZero() || offer.TakerGets.IsZero() {
 			ofrsToRm[offerKey] = true
-			s.offersUsed++
 			continue
 		}
 		if s.shouldRmSmallIncreasedQOffer(sb, offer, ownerFunds) {
 			ofrsToRm[offerKey] = true
-			s.offersUsed++
 			continue
 		}
 
@@ -490,7 +490,6 @@ func (s *BookStep) Rev(
 			}
 		}
 
-		s.offersUsed++
 		return true
 	}
 
@@ -570,7 +569,6 @@ func (s *BookStep) Fwd(
 						}
 					}
 					remainingIn = s.zeroIn()
-					s.offersUsed++
 					return true
 				}
 			}
@@ -632,7 +630,6 @@ func (s *BookStep) Fwd(
 						}
 					}
 					remainingIn = s.zeroIn()
-					s.offersUsed++
 					return true
 				}
 			}
@@ -649,7 +646,6 @@ func (s *BookStep) Fwd(
 			}
 		}
 
-		s.offersUsed++
 		return true
 	}
 

--- a/internal/tx/payment/step_book_counter_test.go
+++ b/internal/tx/payment/step_book_counter_test.go
@@ -1,0 +1,106 @@
+package payment
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+// insertBookOffer writes a single offer SLE into the mock view and returns its key.
+// The offer sells XRP (TakerGets) for USD (TakerPays); the Out side is XRP so the
+// funding check reads the owner's XRP balance/reserve.
+func insertBookOffer(t *testing.T, view *paymentMockLedgerView, owner [20]byte, gwStr string, seq, expiration uint32, bookDir [32]byte) [32]byte {
+	t.Helper()
+	offer := &state.LedgerOffer{
+		Account:       state.EncodeAccountIDSafe(owner),
+		Sequence:      seq,
+		TakerPays:     tx.NewIssuedAmountFromFloat64(100, "USD", gwStr),
+		TakerGets:     tx.NewXRPAmount(100_000_000),
+		BookDirectory: bookDir,
+		Expiration:    expiration,
+	}
+	data, err := state.SerializeLedgerOffer(offer)
+	require.NoError(t, err)
+	key := keylet.Offer(owner, seq).Key
+	view.data[key] = data
+	return key
+}
+
+// TestBookStep_OffersUsed_CountsEveryWalkedOffer proves the unified step counter
+// counts every CLOB offer the book walk advances past — expired offers removed
+// inside getNextOfferSkipVisited and unfunded offers removed in the consumption
+// loop — exactly once, mirroring rippled's OfferStream::step where counter_.step()
+// runs before the expiry/funding/removal checks.
+//
+// Before the fix, expired/missing/domain-removed offers were skipped without
+// being counted (under-count), so offersUsed reported only the unfunded offers.
+//
+// Reference: rippled OfferStream.cpp step() counter_.step() placement (line 245),
+// before the expiry (256), unfunded (315) and removal checks.
+func TestBookStep_OffersUsed_CountsEveryWalkedOffer(t *testing.T) {
+	var gw, owner [20]byte
+	copy(gw[:], []byte("gateway123456789012"))
+	copy(owner[:], []byte("owner1234567890123456")[:20])
+	gwStr := state.EncodeAccountIDSafe(gw)
+
+	view := newPaymentMockLedgerView()
+	// Owner holds less XRP than the base reserve, so every offer that reaches the
+	// funding check is unfunded on the XRP (TakerGets) side.
+	view.createAccount(owner, 5_000_000, 0)
+
+	inIssue := Issue{Currency: "USD", Issuer: gw}
+	outIssue := Issue{Currency: "XRP"}
+	var strandSrc, strandDst [20]byte
+	copy(strandSrc[:], []byte("src12345678901234567"))
+	copy(strandDst[:], []byte("dst12345678901234567"))
+
+	step := NewBookStep(inIssue, outIssue, strandSrc, strandDst, nil, false)
+	step.parentCloseTime = 1000
+
+	// Single book directory at one quality level holding all offers.
+	dirKey := step.bookBaseKey()
+	binary.BigEndian.PutUint64(dirKey[24:], 0x5500000000000000)
+
+	const expiredCount = 3
+	const unfundedCount = 3
+	var indexes [][32]byte
+	seq := uint32(1)
+	// Expired offers: Expiration <= parentCloseTime, removed during the walk.
+	for range expiredCount {
+		indexes = append(indexes, insertBookOffer(t, view, owner, gwStr, seq, step.parentCloseTime-1, dirKey))
+		seq++
+	}
+	// Unfunded offers: no expiration, removed by the funding check in the loop.
+	for range unfundedCount {
+		indexes = append(indexes, insertBookOffer(t, view, owner, gwStr, seq, 0, dirKey))
+		seq++
+	}
+
+	dirNode := &state.DirectoryNode{
+		RootIndex:         dirKey,
+		Indexes:           indexes,
+		TakerPaysCurrency: keylet.CurrencyBytes("USD"),
+		TakerPaysIssuer:   gw,
+	}
+	dirData, err := state.SerializeDirectoryNode(dirNode, true)
+	require.NoError(t, err)
+	view.data[dirKey] = dirData
+
+	sandbox := NewPaymentSandbox(view)
+	sandbox.SetTransactionContext([32]byte{}, 1)
+
+	// Request a large output. No offer is funded, so nothing is consumed; the walk
+	// removes every offer and exhausts the book.
+	out := NewXRPEitherAmount(1_000_000_000)
+	ofrsToRm := make(map[[32]byte]bool)
+	gotIn, gotOut := step.Rev(sandbox, sandbox, ofrsToRm, out)
+
+	require.True(t, gotOut.IsZero(), "no funded liquidity, so output must be zero")
+	require.True(t, gotIn.IsZero(), "no funded liquidity, so input must be zero")
+	require.Equal(t, uint32(expiredCount+unfundedCount), step.OffersUsed(),
+		"every offer the book walk advances past (expired + unfunded) must be counted exactly once")
+}

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -165,10 +165,6 @@ func (s *BookStep) removeExpiredOffer(sb *PaymentSandbox, offer *state.LedgerOff
 	s.adjustOwnerCount(sb, ownerID, -1, txHash, ledgerSeq)
 }
 
-// isOfferFunded checks if an offer has sufficient funding
-// isOfferOwnerAuthorized checks if the offer owner is authorized to hold currency
-// from the issuer. Returns true if authorized or if no auth is required.
-// Reference: BookStep.cpp lines 760-790
 // isOfferOwnerAuthorized checks if the offer owner is authorized to hold currency
 // from the issuer. Returns true if authorized or if no auth is required.
 // Reference: BookStep.cpp lines 760-790

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -9,6 +9,21 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
+// stepOfferCounter counts a single offer the book walk has advanced to and
+// reports whether the walk may continue. It mirrors rippled's
+// TOfferStreamBase::StepCounter::step(): once the per-execution limit is
+// reached it returns false, leaving the offer uncounted and untouched — exactly
+// as counter_.step() returning false ends OfferStream::step. The synthetic AMM
+// offer is generated outside this walk, so it never flows through here and is
+// never counted toward offersUsed.
+func (s *BookStep) stepOfferCounter() bool {
+	if s.offersUsed >= s.maxOffersToConsume {
+		return false
+	}
+	s.offersUsed++
+	return true
+}
+
 // getNextOfferSkipVisited returns the next offer at the best quality, skipping offers in ofrsToRm and visited.
 // Uses Succ() for efficient O(log n) ordered traversal of book directories.
 // Follows IndexNext chains through multi-page directories at each quality level.
@@ -50,6 +65,20 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 				}
 				if visited != nil && visited[offerKey] {
 					continue
+				}
+
+				// Count this offer before the expiry/funding/removal checks,
+				// mirroring rippled's OfferStream::step where counter_.step()
+				// runs before those checks. When the limit is reached, stop the
+				// walk without counting or touching this offer. Mark it visited
+				// so every offer the walk advances to is counted exactly once —
+				// even one skipped just below as expired, missing or
+				// domain-removed — and is never re-counted on a later walk.
+				if !s.stepOfferCounter() {
+					return nil, [32]byte{}, nil
+				}
+				if visited != nil {
+					visited[offerKey] = true
 				}
 
 				offerData, err := sb.Read(keylet.Keylet{Key: offerKey})


### PR DESCRIPTION
## Summary

Resolves the two pre-existing payment-engine flow divergences from rippled surfaced in the #921 review.

**1. `offersUsed` / `offersConsidered` counter (consensus-relevant).** The per-step offer counter is now incremented at a single site — `stepOfferCounter()` called inside `getNextOfferSkipVisited` before the expiry/funding/removal checks — mirroring rippled's `OfferStream::step` (`counter_.step()` at `OfferStream.cpp:245`, before the missing/expired/unfunded/deep-frozen/domain/rmSmallQ checks). This fixes both reported directions:
  - **1a (over-count):** the synthetic AMM offer is generated outside the book walk and so is never counted (previously the rev/fwd callbacks incremented unconditionally, including for AMM).
  - **1b (under-count):** expired / missing / domain-removed offers skipped inside the walk are now counted exactly once (previously they were `continue`d without counting).

  The scattered `s.offersUsed++` sites (self-cross, auth, deep-frozen, unfunded, small-increased-quality, rev/fwd callbacks) are removed; the single counter also gates the walk — including removals — at `maxOffersToConsume`, matching rippled's `counter_.step()`-returns-false behaviour.

**2. `RippleCalculate` apply gate.** `flow.go` now applies the flow sandbox only on `tesSUCCESS`, matching rippled's `finishFlow` (`Flow.cpp:42-43`). On `tecPATH_PARTIAL` rippled keeps the result code and discards the sandbox; the previous `|| tecPATH_PARTIAL` gate folded partial offer consumption/grooming into the view for a payment that ultimately fails. Investigation confirmed the engine already discards the per-tx table on a `tec` result (`do_apply.go` → `applyTecRecovery`), so the broad gate was dead in practice — this tightens the contract to remove the latent risk. Aligned the adjacent `sfDeliveredAmount` write in `payment_iou.go` to rippled's `result == tesSUCCESS && actualAmountOut != dstAmount` (`Payment.cpp:495`), which the prior code omitted the `tesSUCCESS` half of.

## Test plan

- [x] New unit test `TestBookStep_OffersUsed_CountsEveryWalkedOffer` builds a CLOB book mixing expired + unfunded offers and asserts `OffersUsed()` counts every walked offer exactly once. Verified discriminating: reports `3` on the original code (expired under-counted), `6` with the fix.
- [x] `just test-pkg ./internal/tx/payment/...` (incl. pathfinder) — pass
- [x] `internal/testing/offer/...`, `internal/testing/amm/...`, `internal/testing/permissioneddex/...`, `internal/testing/payment/...` — pass
- [x] `internal/tx/offer/...`, `internal/tx/check/...`, `internal/testing/check/...` — pass
- [x] `go vet` + `gofmt` clean on changed files

Fixes #930