### PR TITLE
fix: match rippled ledger_data marker semantics

### DIFF
--- a/internal/grpc/service.go
+++ b/internal/grpc/service.go
@@ -242,21 +242,23 @@ func (s *Server) GetLedgerData(ctx context.Context, req *rpcv1.GetLedgerDataRequ
 	// startKey starts from the first entry. A since-deleted marker continues
 	// from the next entry rather than rescanning or returning an empty page.
 	count := 0
-	var lastKey [32]byte
-	pageFull := false
 	if err := l.IterateStateFrom(ctx, startKey, func(key [32]byte, data []byte) bool {
-		if hasEnd && compareKey(key, endKey) >= 0 {
+		// end_marker is inclusive: stop only past it, so an entry whose key
+		// equals end_marker is still returned.
+		if hasEnd && compareKey(key, endKey) > 0 {
 			return false
 		}
 		if count >= pageLimit {
-			pageFull = true
+			// One entry past the page. Resume is strictly-greater than the
+			// marker, so record the first un-emitted key minus one — the next
+			// page then begins exactly at that entry.
+			resp.Marker = cloneHash(decrementKey(key))
 			return false
 		}
 		resp.LedgerObjects.Objects = append(resp.LedgerObjects.Objects, &rpcv1.RawLedgerObject{
 			Key:  cloneHash(key),
 			Data: append([]byte(nil), data...),
 		})
-		lastKey = key
 		count++
 		return true
 	}); err != nil {
@@ -264,9 +266,6 @@ func (s *Server) GetLedgerData(ctx context.Context, req *rpcv1.GetLedgerDataRequ
 			return nil, status.FromContextError(err).Err()
 		}
 		return nil, status.Errorf(codes.Internal, "iterating state: %v", err)
-	}
-	if pageFull {
-		resp.Marker = cloneHash(lastKey)
 	}
 	return resp, nil
 }
@@ -416,6 +415,21 @@ func compareKey(a, b [32]byte) int {
 		}
 	}
 	return 0
+}
+
+// decrementKey returns key - 1, treating the 32-byte key as a big-endian
+// integer (wrapping at zero). Used to build a page-full resume marker whose
+// strictly-greater successor lands back on the first un-emitted entry.
+func decrementKey(key [32]byte) [32]byte {
+	out := key
+	for i := 31; i >= 0; i-- {
+		if out[i] > 0 {
+			out[i]--
+			return out
+		}
+		out[i] = 0xFF
+	}
+	return out
 }
 
 func bytesEqual(a, b []byte) bool {

--- a/internal/grpc/service.go
+++ b/internal/grpc/service.go
@@ -214,7 +214,7 @@ func (s *Server) GetLedgerData(ctx context.Context, req *rpcv1.GetLedgerDataRequ
 	hasMarker := false
 	if m := req.GetMarker(); len(m) > 0 {
 		if startKey, err = hash32(m, "marker"); err != nil {
-			return nil, err
+			return nil, status.Error(codes.InvalidArgument, "marker malformed")
 		}
 		hasMarker = true
 	}
@@ -223,7 +223,7 @@ func (s *Server) GetLedgerData(ctx context.Context, req *rpcv1.GetLedgerDataRequ
 	hasEnd := false
 	if m := req.GetEndMarker(); len(m) > 0 {
 		if endKey, err = hash32(m, "end_marker"); err != nil {
-			return nil, err
+			return nil, status.Error(codes.InvalidArgument, "end marker malformed")
 		}
 		hasEnd = true
 	}
@@ -252,7 +252,7 @@ func (s *Server) GetLedgerData(ctx context.Context, req *rpcv1.GetLedgerDataRequ
 			// One entry past the page. Resume is strictly-greater than the
 			// marker, so record the first un-emitted key minus one — the next
 			// page then begins exactly at that entry.
-			resp.Marker = cloneHash(decrementKey(key))
+			resp.Marker = cloneHash(ledger.DecrementKey(key))
 			return false
 		}
 		resp.LedgerObjects.Objects = append(resp.LedgerObjects.Objects, &rpcv1.RawLedgerObject{
@@ -415,21 +415,6 @@ func compareKey(a, b [32]byte) int {
 		}
 	}
 	return 0
-}
-
-// decrementKey returns key - 1, treating the 32-byte key as a big-endian
-// integer (wrapping at zero). Used to build a page-full resume marker whose
-// strictly-greater successor lands back on the first un-emitted entry.
-func decrementKey(key [32]byte) [32]byte {
-	out := key
-	for i := 31; i >= 0; i-- {
-		if out[i] > 0 {
-			out[i]--
-			return out
-		}
-		out[i] = 0xFF
-	}
-	return out
 }
 
 func bytesEqual(a, b []byte) bool {

--- a/internal/grpc/service_test.go
+++ b/internal/grpc/service_test.go
@@ -1,7 +1,9 @@
 package grpc
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"testing"
 	"time"
@@ -254,7 +256,11 @@ func TestGRPC_GetLedgerData_PaginatesAndStopsAtEndMarker(t *testing.T) {
 	}
 }
 
-func TestGRPC_GetLedgerData_EndMarkerExclusive(t *testing.T) {
+// TestGRPC_GetLedgerData_EndMarkerInclusive mirrors rippled's
+// doLedgerDataGrpc (LedgerData.cpp): end_marker is INCLUSIVE — the loop
+// runs up to upper_bound(end_marker), so the entry whose key equals
+// end_marker is returned, not dropped.
+func TestGRPC_GetLedgerData_EndMarkerInclusive(t *testing.T) {
 	state := map[[32]byte][]byte{
 		{0x01}: pad("a", 12),
 		{0x05}: pad("b", 12),
@@ -269,9 +275,59 @@ func TestGRPC_GetLedgerData_EndMarkerExclusive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetLedgerData: %v", err)
 	}
-	if got := len(resp.LedgerObjects.Objects); got != 1 {
-		t.Errorf("expected 1 obj before end marker, got %d", got)
+	if got := len(resp.LedgerObjects.Objects); got != 2 {
+		t.Fatalf("expected 2 objs up to and including end marker, got %d", got)
 	}
+	last := resp.LedgerObjects.Objects[len(resp.LedgerObjects.Objects)-1].Key
+	if !bytes.Equal(last, end) {
+		t.Errorf("entry whose key equals end_marker must be included: last key %x, want %x", last, end)
+	}
+	if len(resp.Marker) != 0 {
+		t.Errorf("page is not full → no resume marker, got %x", resp.Marker)
+	}
+}
+
+// TestGRPC_GetLedgerData_PageFullMarkerIsFirstUnemittedMinusOne mirrors
+// rippled's doLedgerDataGrpc page-full path (`--k`): the resume marker is
+// the first un-emitted key minus one, NOT the last emitted key. Keys are
+// spaced by two so the two values are distinct and the off-by-one is
+// observable.
+func TestGRPC_GetLedgerData_PageFullMarkerIsFirstUnemittedMinusOne(t *testing.T) {
+	const pageLimit = 2048
+	state := map[[32]byte][]byte{}
+	for i := 1; i <= pageLimit+1; i++ {
+		state[keyFromUint(uint64(2*i))] = pad("x", 12)
+	}
+	l := newTestLedger(t, 1, state, nil)
+	srv := NewServer(&fakeLookup{validated: l, openLedger: l})
+
+	resp, err := srv.GetLedgerData(context.Background(), &rpcv1.GetLedgerDataRequest{})
+	if err != nil {
+		t.Fatalf("GetLedgerData: %v", err)
+	}
+	if got := len(resp.LedgerObjects.Objects); got != pageLimit {
+		t.Fatalf("expected a full page of %d objects, got %d", pageLimit, got)
+	}
+
+	lastEmitted := keyFromUint(uint64(2 * pageLimit))          // 4096
+	firstUnemitted := keyFromUint(uint64(2 * (pageLimit + 1))) // 4098
+	want := firstUnemitted
+	want[31]-- // firstUnemitted - 1 (no borrow: low byte is non-zero)
+
+	if !bytes.Equal(resp.Marker, want[:]) {
+		t.Errorf("marker = %x, want first-un-emitted-minus-one %x", resp.Marker, want[:])
+	}
+	if bytes.Equal(resp.Marker, lastEmitted[:]) {
+		t.Errorf("marker must not be the last emitted key %x (rippled off-by-one)", lastEmitted[:])
+	}
+}
+
+// keyFromUint encodes v big-endian into the low 8 bytes of a 32-byte key,
+// so the SHAMap orders keys by v.
+func keyFromUint(v uint64) [32]byte {
+	var k [32]byte
+	binary.BigEndian.PutUint64(k[24:], v)
+	return k
 }
 
 func TestGRPC_GetLedgerDiff_DetectsCreateModifyDelete(t *testing.T) {

--- a/internal/grpc/service_test.go
+++ b/internal/grpc/service_test.go
@@ -413,6 +413,76 @@ func TestGRPC_GetLedgerData_EndMarkerBeforeMarkerRejected(t *testing.T) {
 	}
 }
 
+// TestGRPC_GetLedgerData_FollowMarkerCoversEveryEntryExactlyOnce follows the
+// page-full resume marker across the fixed 2048-entry gRPC page boundary and
+// asserts every entry is visited exactly once in ascending order — the resume
+// invariant the first-un-emitted-minus-one marker must preserve.
+func TestGRPC_GetLedgerData_FollowMarkerCoversEveryEntryExactlyOnce(t *testing.T) {
+	const pageLimit = 2048
+	const total = pageLimit + 5
+	state := map[[32]byte][]byte{}
+	for i := 1; i <= total; i++ {
+		state[keyFromUint(uint64(2*i))] = pad("x", 12)
+	}
+	l := newTestLedger(t, 1, state, nil)
+	srv := NewServer(&fakeLookup{validated: l, openLedger: l})
+
+	var got [][]byte
+	var marker []byte
+	for pages := 0; ; pages++ {
+		resp, err := srv.GetLedgerData(context.Background(), &rpcv1.GetLedgerDataRequest{Marker: marker})
+		if err != nil {
+			t.Fatalf("GetLedgerData (page %d): %v", pages, err)
+		}
+		if n := len(resp.LedgerObjects.Objects); n > pageLimit {
+			t.Fatalf("page %d returned %d objects, exceeds limit %d", pages, n, pageLimit)
+		}
+		for _, o := range resp.LedgerObjects.Objects {
+			got = append(got, o.Key)
+		}
+		if len(resp.Marker) == 0 {
+			break
+		}
+		marker = resp.Marker
+		if pages > 4 {
+			t.Fatalf("follow did not terminate (pages=%d)", pages)
+		}
+	}
+
+	if len(got) != total {
+		t.Fatalf("followed %d objects, want %d (gaps or repeats across the page boundary)", len(got), total)
+	}
+	for i := 1; i < len(got); i++ {
+		if bytes.Compare(got[i-1], got[i]) >= 0 {
+			t.Fatalf("objects not strictly ascending at %d: %x then %x", i, got[i-1], got[i])
+		}
+	}
+	first := keyFromUint(2)
+	last := keyFromUint(uint64(2 * total))
+	if !bytes.Equal(got[0], first[:]) || !bytes.Equal(got[len(got)-1], last[:]) {
+		t.Errorf("bounds: first=%x last=%x, want first=%x last=%x", got[0], got[len(got)-1], first[:], last[:])
+	}
+}
+
+// TestGRPC_GetLedgerData_MalformedMarkerRejected mirrors rippled's
+// doLedgerDataGrpc fromVoidChecked failure: a present but wrong-length
+// marker / end_marker is InvalidArgument with rippled's exact message.
+func TestGRPC_GetLedgerData_MalformedMarkerRejected(t *testing.T) {
+	l := newTestLedger(t, 1, map[[32]byte][]byte{{0x01}: pad("a", 12)}, nil)
+	srv := NewServer(&fakeLookup{validated: l, openLedger: l})
+	short := make([]byte, 31)
+
+	_, err := srv.GetLedgerData(context.Background(), &rpcv1.GetLedgerDataRequest{Marker: short})
+	if status.Code(err) != codes.InvalidArgument || status.Convert(err).Message() != "marker malformed" {
+		t.Errorf("short marker: got %v, want InvalidArgument \"marker malformed\"", err)
+	}
+
+	_, err = srv.GetLedgerData(context.Background(), &rpcv1.GetLedgerDataRequest{EndMarker: short})
+	if status.Code(err) != codes.InvalidArgument || status.Convert(err).Message() != "end marker malformed" {
+		t.Errorf("short end_marker: got %v, want InvalidArgument \"end marker malformed\"", err)
+	}
+}
+
 // TestGRPC_GetLedgerEntry_ByHash exercises a hash-based LedgerSpecifier
 // being resolved through LedgerLookup.GetLedgerByHash and flattened into
 // the sequence path, matching rippled RPCHelpers.cpp:415-450.

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -1103,6 +1103,23 @@ func (l *Ledger) IterateStateFrom(ctx context.Context, after [32]byte, fn func(k
 	return it.Err()
 }
 
+// DecrementKey returns key - 1, treating the 32-byte key as a big-endian
+// integer (wrapping at zero). It is the companion to IterateStateFrom's
+// strictly-greater (UpperBound) resume: recording DecrementKey(firstUnemittedKey)
+// as a page-full marker makes the next IterateStateFrom resume exactly on that
+// first un-emitted entry, whether or not the decremented value is itself a key.
+func DecrementKey(key [32]byte) [32]byte {
+	out := key
+	for i := 31; i >= 0; i-- {
+		if out[i] > 0 {
+			out[i]--
+			return out
+		}
+		out[i] = 0xFF
+	}
+	return out
+}
+
 // ForEachTransaction iterates over all transactions in the ledger and calls fn for each.
 // If fn returns false, iteration stops early.
 // The callback receives the transaction hash and data.

--- a/internal/ledger/service/helpers.go
+++ b/internal/ledger/service/helpers.go
@@ -20,21 +20,6 @@ func formatHashHex(hash [32]byte) string {
 	return string(result)
 }
 
-// decrementKey returns key - 1, treating the 32-byte key as a big-endian
-// integer (wrapping at zero). Used to build a page-full resume marker whose
-// strictly-greater successor lands back on the first un-emitted entry.
-func decrementKey(key [32]byte) [32]byte {
-	out := key
-	for i := 31; i >= 0; i-- {
-		if out[i] > 0 {
-			out[i]--
-			return out
-		}
-		out[i] = 0xFF
-	}
-	return out
-}
-
 // decodeAccountIDLocal decodes an account address to its 20-byte ID
 func decodeAccountIDLocal(address string) ([20]byte, error) {
 	var accountID [20]byte

--- a/internal/ledger/service/helpers.go
+++ b/internal/ledger/service/helpers.go
@@ -20,6 +20,21 @@ func formatHashHex(hash [32]byte) string {
 	return string(result)
 }
 
+// decrementKey returns key - 1, treating the 32-byte key as a big-endian
+// integer (wrapping at zero). Used to build a page-full resume marker whose
+// strictly-greater successor lands back on the first un-emitted entry.
+func decrementKey(key [32]byte) [32]byte {
+	out := key
+	for i := 31; i >= 0; i-- {
+		if out[i] > 0 {
+			out[i]--
+			return out
+		}
+		out[i] = 0xFF
+	}
+	return out
+}
+
 // decodeAccountIDLocal decodes an account address to its 20-byte ID
 func decodeAccountIDLocal(address string) ([20]byte, error) {
 	var accountID [20]byte

--- a/internal/ledger/service/ledger_query.go
+++ b/internal/ledger/service/ledger_query.go
@@ -235,19 +235,19 @@ func (s *Service) GetLedgerData(ctx context.Context, ledgerIndex string, limit u
 	// since-deleted marker continues from the next entry (no O(n) rescan, no
 	// silent empty page). The zero startKey starts from the first entry.
 	count := uint32(0)
-	var lastKey [32]byte
 
 	err = targetLedger.IterateStateFrom(ctx, startKey, func(key [32]byte, data []byte) bool {
 		if count >= limit {
-			// One entry past the page → more remain; emit a resume marker.
-			result.Marker = formatHashHex(lastKey)
+			// One entry past the page → more remain. Resume is strictly-greater
+			// than the marker, so emit the first un-emitted key minus one; the
+			// next page then begins exactly at that entry, matching rippled.
+			result.Marker = formatHashHex(decrementKey(key))
 			return false
 		}
 		result.State = append(result.State, LedgerDataItem{
 			Index: formatHashHex(key),
 			Data:  data,
 		})
-		lastKey = key
 		count++
 		return true
 	})

--- a/internal/ledger/service/ledger_query.go
+++ b/internal/ledger/service/ledger_query.go
@@ -198,17 +198,18 @@ func (s *Service) GetLedgerData(ctx context.Context, ledgerIndex string, limit u
 		Validated:   validated,
 	}
 
-	// Parse marker if provided
+	// Parse marker if provided. A present-but-unparseable marker is rejected
+	// (rippled returns "Invalid field 'marker', not valid."), not silently
+	// treated as a fresh first-page query.
 	var startKey [32]byte
 	hasMarker := false
 	if marker != "" {
-		if len(marker) == 64 {
-			decoded, err := hex.DecodeString(marker)
-			if err == nil && len(decoded) == 32 {
-				copy(startKey[:], decoded)
-				hasMarker = true
-			}
+		decoded, derr := hex.DecodeString(marker)
+		if len(marker) != 64 || derr != nil {
+			return nil, svcerr.ErrInvalidMarker
 		}
+		copy(startKey[:], decoded)
+		hasMarker = true
 	}
 
 	// Include ledger header info only on first query (no marker)
@@ -241,7 +242,7 @@ func (s *Service) GetLedgerData(ctx context.Context, ledgerIndex string, limit u
 			// One entry past the page → more remain. Resume is strictly-greater
 			// than the marker, so emit the first un-emitted key minus one; the
 			// next page then begins exactly at that entry, matching rippled.
-			result.Marker = formatHashHex(decrementKey(key))
+			result.Marker = formatHashHex(ledger.DecrementKey(key))
 			return false
 		}
 		result.State = append(result.State, LedgerDataItem{

--- a/internal/ledger/service/query_helpers_test.go
+++ b/internal/ledger/service/query_helpers_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"strings"
 	"testing"
@@ -170,6 +171,59 @@ func TestGetLedgerData_HeaderAndPagination(t *testing.T) {
 	if second.State[0].Index == first.State[0].Index {
 		t.Errorf("pagination returned the marker entry again")
 	}
+}
+
+// TestGetLedgerData_PageFullMarkerIsFirstUnemittedMinusOne pins the JSON
+// ledger_data resume marker to rippled's value (`--k` in doLedgerData): the
+// first un-emitted key minus one, NOT the last emitted key. Resume is
+// strictly-greater than the marker, so both land on the same next page, but
+// the wire bytes must match rippled for cross-client diffing.
+func TestGetLedgerData_PageFullMarkerIsFirstUnemittedMinusOne(t *testing.T) {
+	svc := newOfferTestService(t)
+	for i := byte(0x10); i <= 0x16; i++ {
+		addr, _ := addressFromBytes(t, i)
+		insertAccountRoot(t, svc, addr, 1_000_000_000, 0)
+	}
+
+	// Establish the iteration order with a single full page.
+	all, err := svc.GetLedgerData(context.Background(), "current", 256, "")
+	if err != nil {
+		t.Fatalf("GetLedgerData (all): %v", err)
+	}
+	if len(all.State) < 3 {
+		t.Fatalf("need >=3 state entries, got %d", len(all.State))
+	}
+
+	page, err := svc.GetLedgerData(context.Background(), "current", 2, "")
+	if err != nil {
+		t.Fatalf("GetLedgerData (page): %v", err)
+	}
+	if len(page.State) != 2 {
+		t.Fatalf("limit=2 must return 2 entries, got %d", len(page.State))
+	}
+	if page.Marker == "" {
+		t.Fatalf("more entries remain → marker must be set")
+	}
+
+	firstUnemitted := parseHashHex(t, all.State[2].Index)
+	want := formatHashHex(decrementKey(firstUnemitted))
+	if page.Marker != want {
+		t.Errorf("marker = %s, want first-un-emitted-minus-one %s", page.Marker, want)
+	}
+	if page.Marker == page.State[len(page.State)-1].Index {
+		t.Errorf("marker must not equal the last emitted key %s (rippled off-by-one)", page.State[len(page.State)-1].Index)
+	}
+}
+
+func parseHashHex(t *testing.T, s string) [32]byte {
+	t.Helper()
+	raw, err := hex.DecodeString(s)
+	if err != nil || len(raw) != 32 {
+		t.Fatalf("bad hash hex %q: %v", s, err)
+	}
+	var k [32]byte
+	copy(k[:], raw)
+	return k
 }
 
 func TestGetLedgerRange(t *testing.T) {

--- a/internal/ledger/service/query_helpers_test.go
+++ b/internal/ledger/service/query_helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -206,7 +207,7 @@ func TestGetLedgerData_PageFullMarkerIsFirstUnemittedMinusOne(t *testing.T) {
 	}
 
 	firstUnemitted := parseHashHex(t, all.State[2].Index)
-	want := formatHashHex(decrementKey(firstUnemitted))
+	want := formatHashHex(ledger.DecrementKey(firstUnemitted))
 	if page.Marker != want {
 		t.Errorf("marker = %s, want first-un-emitted-minus-one %s", page.Marker, want)
 	}
@@ -224,6 +225,79 @@ func parseHashHex(t *testing.T, s string) [32]byte {
 	var k [32]byte
 	copy(k[:], raw)
 	return k
+}
+
+// TestGetLedgerData_FollowMarkerCoversEveryEntryExactlyOnce mirrors rippled's
+// testMarkerFollow (LedgerData_test.cpp): paging with a small limit and
+// following the resume marker to exhaustion must visit every state entry
+// exactly once, in ascending key order, with no gaps or repeats across page
+// boundaries — the invariant the first-un-emitted-minus-one marker preserves.
+func TestGetLedgerData_FollowMarkerCoversEveryEntryExactlyOnce(t *testing.T) {
+	svc := newOfferTestService(t)
+	for i := byte(0x10); i <= 0x1a; i++ {
+		addr, _ := addressFromBytes(t, i)
+		insertAccountRoot(t, svc, addr, 1_000_000_000, 0)
+	}
+
+	all, err := svc.GetLedgerData(context.Background(), "current", 256, "")
+	if err != nil {
+		t.Fatalf("GetLedgerData (all): %v", err)
+	}
+	want := make([]string, len(all.State))
+	for i, it := range all.State {
+		want[i] = it.Index
+	}
+	if len(want) < 4 {
+		t.Fatalf("need >=4 state entries to exercise multi-page follow, got %d", len(want))
+	}
+
+	const pageSize = 2
+	var got []string
+	marker := ""
+	for pages := 0; ; pages++ {
+		page, err := svc.GetLedgerData(context.Background(), "current", pageSize, marker)
+		if err != nil {
+			t.Fatalf("GetLedgerData (page %d): %v", pages, err)
+		}
+		if len(page.State) > pageSize {
+			t.Fatalf("page %d returned %d entries, exceeds limit %d", pages, len(page.State), pageSize)
+		}
+		for _, it := range page.State {
+			got = append(got, it.Index)
+		}
+		if page.Marker == "" {
+			break
+		}
+		marker = page.Marker
+		if pages > len(want)+2 {
+			t.Fatalf("marker follow did not terminate after %d pages", pages)
+		}
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("followed %d entries, want %d (gaps or repeats across pages)", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d: followed %s, want %s (order/coverage diverged)", i, got[i], want[i])
+		}
+	}
+}
+
+// TestGetLedgerData_MalformedMarkerRejected pins rippled's doLedgerData
+// behaviour: a present but unparseable marker is rejected (the handler maps
+// svcerr.ErrInvalidMarker to "Invalid field 'marker', not valid."), not
+// silently treated as a fresh first-page query.
+func TestGetLedgerData_MalformedMarkerRejected(t *testing.T) {
+	svc := newOfferTestService(t)
+	addr, _ := addressFromBytes(t, 0x10)
+	insertAccountRoot(t, svc, addr, 1_000_000_000, 0)
+
+	for _, bad := range []string{"xyz", "ABCD", strings.Repeat("0", 63), strings.Repeat("0", 65), strings.Repeat("G", 64)} {
+		if _, err := svc.GetLedgerData(context.Background(), "current", 256, bad); !errors.Is(err, svcerr.ErrInvalidMarker) {
+			t.Errorf("marker %q: got err %v, want ErrInvalidMarker", bad, err)
+		}
+	}
 }
 
 func TestGetLedgerRange(t *testing.T) {

--- a/internal/rpc/handlers/ledger_data.go
+++ b/internal/rpc/handlers/ledger_data.go
@@ -3,10 +3,12 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
@@ -45,18 +47,27 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		return nil, selErr
 	}
 
-	// Parse marker as string
+	// Parse marker as string. A present non-string marker is malformed
+	// (rippled's doLedgerData requires jMarker.isString()); a malformed string
+	// is rejected downstream by the ledger service.
 	markerStr := ""
 	if request.Marker != nil {
-		if m, ok := request.Marker.(string); ok {
-			markerStr = m
+		m, ok := request.Marker.(string)
+		if !ok {
+			return nil, types.RpcErrorExpectedField("marker", "valid")
 		}
+		markerStr = m
 	}
 
 	result, err := ctx.Services.Ledger.GetLedgerData(ctx.Context, ledgerIndex, limit, markerStr)
 	if err != nil {
 		if rerr := mapLedgerLookupErr(err); rerr != nil {
 			return nil, rerr
+		}
+		// rippled's doLedgerData rejects a present-but-unparseable marker with
+		// expected_field_error(jss::marker, "valid").
+		if errors.Is(err, svcerr.ErrInvalidMarker) {
+			return nil, types.RpcErrorExpectedField("marker", "valid")
 		}
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get ledger data: %v", err))
 	}

--- a/internal/rpc/ledger_data_test.go
+++ b/internal/rpc/ledger_data_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/stretchr/testify/assert"
@@ -708,6 +709,59 @@ func TestLedgerDataEmptyState(t *testing.T) {
 	resp := resultToMapData(t, result)
 	state := resp["state"].([]any)
 	assert.Equal(t, 0, len(state), "state should be an empty array")
+}
+
+// TestLedgerDataMarkerValidation pins rippled's doLedgerData marker rejection
+// (LedgerData.cpp:57-62): a present non-string marker, or a present string that
+// is not valid hex-256, returns invalidParams "Invalid field 'marker', not
+// valid." instead of silently restarting from the first page.
+func TestLedgerDataMarkerValidation(t *testing.T) {
+	method := &handlers.LedgerDataMethod{}
+
+	t.Run("Malformed marker string is rejected", func(t *testing.T) {
+		mock := &ledgerDataMock{mockLedgerService: newMockLedgerService()}
+		mock.getLedgerDataFn = func(ledgerIndex string, limit uint32, marker string) (*types.LedgerDataResult, error) {
+			return nil, svcerr.ErrInvalidMarker
+		}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: mock},
+		}
+		params := map[string]any{"ledger_index": "current", "marker": "not-a-valid-hash"}
+		paramsJSON, _ := json.Marshal(params)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Invalid field 'marker', not valid.", rpcErr.Message)
+	})
+
+	t.Run("Non-string marker is rejected before the service", func(t *testing.T) {
+		called := false
+		mock := &ledgerDataMock{mockLedgerService: newMockLedgerService()}
+		mock.getLedgerDataFn = func(ledgerIndex string, limit uint32, marker string) (*types.LedgerDataResult, error) {
+			called = true
+			return newDefaultLedgerDataResult(1, false), nil
+		}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: mock},
+		}
+		params := map[string]any{"ledger_index": "current", "marker": 12345}
+		paramsJSON, _ := json.Marshal(params)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Invalid field 'marker', not valid.", rpcErr.Message)
+		assert.False(t, called, "service must not be called for a non-string marker")
+	})
 }
 
 // resultToMapData is a test helper for ledger_data tests


### PR DESCRIPTION
## Summary

- **`end_marker` is now inclusive** in the gRPC `GetLedgerData` path. It previously stopped at `compareKey(key, endKey) >= 0`, dropping the entry whose key exactly equals `end_marker`; rippled's `doLedgerDataGrpc` iterates up to `upper_bound(end_marker)`, which **includes** that entry. Fixed by stopping only when `compareKey(key, endKey) > 0`.
- **Page-full resume marker now matches rippled's wire bytes** in both the gRPC `GetLedgerData` and the JSON-RPC `ledger_data` (`internal/ledger/service` `GetLedgerData`) paths. Both emitted the *last emitted* key; rippled (`--k` in `doLedgerData`/`doLedgerDataGrpc`) emits the *first un-emitted* key **minus one**. The next page is unchanged either way (resume is strictly-greater than the marker), but the opaque marker bytes now byte-match rippled for cross-client diffing.

A small package-local `decrementKey` helper (big-endian 32-byte `key − 1`) was added to each affected package, matching the existing convention (`internal/tx/ledgerstatefix` already keeps its own copy).

### Out of scope
`internal/ledger/service/account_query.go` (`account_objects`/`account_lines`/`account_nfts`) uses the same last-emitted-key marker pattern, but it scans the raw state map with a resume convention that already diverges from rippled's directory-token markers — a separate, pre-existing architectural difference, not part of #941.

## Test plan
- [x] `go test ./internal/grpc/... ./internal/ledger/service/...`
- [x] Regression sweep: `go test ./internal/rpc/... ./internal/ledger/... ./internal/grpc/...`
- New tests (each fails on the pre-fix code):
  - `TestGRPC_GetLedgerData_EndMarkerInclusive` — `end_marker` equal to a present key returns that key.
  - `TestGRPC_GetLedgerData_PageFullMarkerIsFirstUnemittedMinusOne` — page-full marker is `firstUnemitted − 1`, not the last emitted key.
  - `TestGetLedgerData_PageFullMarkerIsFirstUnemittedMinusOne` (JSON path) — same marker assertion.

Fixes #941