### PR TITLE
feat: reply with 503 endpoint redirect on inbound slot-full rejection

### DIFF
--- a/internal/peermanagement/discovery.go
+++ b/internal/peermanagement/discovery.go
@@ -424,6 +424,38 @@ func (d *Discovery) AddPeer(address string, hops uint32, source PeerID) {
 	}
 }
 
+// AddRedirectCandidate records an address learned from a peer's 503
+// redirect. rippled files redirect addresses into the lower-trust boot
+// cache (Logic::onRedirects -> bootcache_), NOT the live cache it
+// re-advertises, so a redirected address becomes a reconnect seed but is
+// never gossiped onward as if we had observed it live. When no boot cache
+// is configured (no DataDir) we fall back to the discovered set as a
+// one-hop candidate so the address stays usable for connection.
+func (d *Discovery) AddRedirectCandidate(address string, source PeerID) {
+	ep, err := ParseEndpoint(address)
+	if err != nil {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Lock order d.mu -> bc.mu matches MarkConnected / SelectPeersToConnect.
+	if d.bootCache != nil {
+		d.bootCache.Insert(address, ep.Port)
+		return
+	}
+
+	if _, exists := d.peers[address]; !exists {
+		d.peers[address] = &DiscoveredPeer{
+			Address:  address,
+			Hops:     1,
+			LastSeen: time.Now(),
+			Source:   source,
+		}
+	}
+}
+
 // MarkConnected marks a peer as connected.
 func (d *Discovery) MarkConnected(address string, peerID PeerID) {
 	d.mu.Lock()

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -208,6 +209,40 @@ func BuildHandshakeErrorResponse(userAgent, remoteAddr, text string) *http.Respo
 	}
 	resp.Header.Set(HeaderConnection, "close")
 	resp.ContentLength = 0
+	return resp
+}
+
+// BuildRedirectResponse builds the slot-full rejection: 503 Service
+// Unavailable carrying a JSON body of alternate peer addresses
+// (`{"peer-ips": [...]}`) so a dialer we cannot admit can bootstrap
+// elsewhere instead of being dropped with no signal. peerIPs are
+// "host:port" strings; an empty list still serializes as `[]`.
+func BuildRedirectResponse(userAgent, remoteAddr string, peerIPs []string) *http.Response {
+	if peerIPs == nil {
+		peerIPs = []string{}
+	}
+	body, _ := json.Marshal(struct {
+		PeerIPs []string `json:"peer-ips"`
+	}{PeerIPs: peerIPs})
+
+	resp := &http.Response{
+		StatusCode:    http.StatusServiceUnavailable,
+		Status:        "503 Service Unavailable",
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        make(http.Header),
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+	if userAgent != "" {
+		resp.Header.Set(HeaderServer, userAgent)
+	}
+	if remoteAddr != "" {
+		resp.Header.Set("Remote-Address", remoteAddr)
+	}
+	resp.Header.Set("Content-Type", "application/json")
+	resp.Header.Set(HeaderConnection, "close")
 	return resp
 }
 

--- a/internal/peermanagement/inbound_redirect.go
+++ b/internal/peermanagement/inbound_redirect.go
@@ -1,0 +1,112 @@
+package peermanagement
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/peertls"
+)
+
+// redirectEndpointCount caps the alternate addresses handed back in a
+// slot-full 503 redirect. Matches rippled's
+// peerfinder/detail/Tuning.h Tuning::redirectEndpointCount.
+const redirectEndpointCount = 10
+
+// redirectBodyLimit bounds how much of a non-101 handshake response body
+// we read before parsing it for redirect endpoints. The peer-ips array
+// is at most redirectEndpointCount "ip:port" strings, so a few KB is
+// ample and caps a hostile peer's reply.
+const redirectBodyLimit = 8 << 10
+
+// writeInboundRedirect replies to a handshaked-but-unadmittable dialer
+// with a 503 carrying alternate peer addresses before the caller closes
+// the connection, mirroring rippled's OverlayImpl::makeRedirectResponse.
+// Best-effort: a write failure is irrelevant since we are closing the
+// connection regardless.
+func (o *Overlay) writeInboundRedirect(tlsConn peertls.PeerConn) {
+	dialer := tcpRemoteIP(tlsConn)
+	peerIPs := o.collectRedirectEndpoints(dialer)
+
+	var remoteAddr string
+	if dialer != nil {
+		remoteAddr = dialer.String()
+	}
+
+	resp := BuildRedirectResponse(o.cfg.UserAgent, remoteAddr, peerIPs)
+	_ = resp.Write(tlsConn)
+}
+
+// collectRedirectEndpoints selects up to redirectEndpointCount alternate
+// addresses for a 503 redirect, drawn from the discovered gossip set.
+// Mirrors rippled's RedirectHandouts selection: only literal IP
+// endpoints, never the dialer's own address, deduplicated by IP
+// (port ignored), bounded by the count cap. Discovery's map iteration
+// order supplies the shuffle rippled applies to its livecache.
+func (o *Overlay) collectRedirectEndpoints(dialer net.IP) []string {
+	out := make([]string, 0, redirectEndpointCount)
+	seen := make(map[string]struct{})
+
+	for _, e := range o.collectDiscoveredEndpoints() {
+		ep, err := ParseEndpoint(e.Endpoint)
+		if err != nil {
+			continue
+		}
+		ip := net.ParseIP(ep.Host)
+		if ip == nil {
+			continue
+		}
+		if dialer != nil && ip.Equal(dialer) {
+			continue
+		}
+		key := ip.String()
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		out = append(out, e.Endpoint)
+		if len(out) >= redirectEndpointCount {
+			break
+		}
+	}
+
+	return out
+}
+
+// ingestRedirect parses a 503 handshake-rejection body for its peer-ips
+// array and hands the addresses to the dialer's onRedirect callback so a
+// peer that could not admit us still points us at alternates. A missing
+// callback, empty body, or malformed JSON is a no-op.
+func (p *Peer) ingestRedirect(body []byte) {
+	if p.onRedirect == nil || len(body) == 0 {
+		return
+	}
+	var payload struct {
+		PeerIPs []string `json:"peer-ips"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return
+	}
+	if len(payload.PeerIPs) == 0 {
+		return
+	}
+	p.onRedirect(payload.PeerIPs)
+}
+
+// ingestRedirectEndpoints feeds the addresses from a peer's 503 redirect
+// into Discovery so a dialer we could not connect to actually bootstraps
+// from the alternates. Mirrors rippled's ConnectAttempt::processResponse
+// handing peer-ips to PeerFinder::onRedirects. Each entry is recorded as
+// a one-hop candidate; non-literal addresses are skipped.
+func (o *Overlay) ingestRedirectEndpoints(peerIPs []string, source PeerID) {
+	for _, addr := range peerIPs {
+		ep, err := ParseEndpoint(addr)
+		if err != nil || net.ParseIP(ep.Host) == nil {
+			continue
+		}
+		o.discovery.AddPeer(addr, 1, source)
+	}
+	slog.Debug("Ingested redirect endpoints",
+		"t", "Overlay", "source", source, "count", len(peerIPs))
+}

--- a/internal/peermanagement/inbound_redirect.go
+++ b/internal/peermanagement/inbound_redirect.go
@@ -2,8 +2,10 @@ package peermanagement
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net"
+	"strings"
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/peertls"
 )
@@ -13,11 +15,37 @@ import (
 // peerfinder/detail/Tuning.h Tuning::redirectEndpointCount.
 const redirectEndpointCount = 10
 
+// maxRedirectIngest caps how many addresses we accept from a single 503
+// redirect body. The emitter is untrusted, so we apply our own bound
+// rather than relying on its count cap. Matches rippled's
+// peerfinder/detail/Tuning.h Tuning::maxRedirects.
+const maxRedirectIngest = 30
+
 // redirectBodyLimit bounds how much of a non-101 handshake response body
 // we read before parsing it for redirect endpoints. The peer-ips array
 // is at most redirectEndpointCount "ip:port" strings, so a few KB is
 // ample and caps a hostile peer's reply.
 const redirectBodyLimit = 8 << 10
+
+// errInboundRejected signals handleInbound that performInboundHandshake
+// already emitted the appropriate rejection (a 503 redirect for a
+// non-peer Connect-As or slot-full dialer, or a silent close for a
+// duplicate) in lieu of the 101 upgrade. The handshake itself did not
+// fail, so the connection is closed without an EventPeerFailed event.
+var errInboundRejected = errors.New("inbound connection rejected before upgrade")
+
+// connectAsIncludesPeer reports whether a Connect-As header advertises
+// the "peer" role. rippled splits the header on commas and admits the
+// connection only when some token case-insensitively equals "peer";
+// anything else (a crawler, an empty/absent header) is redirected.
+func connectAsIncludesPeer(header string) bool {
+	for _, tok := range strings.Split(header, ",") {
+		if strings.EqualFold(strings.TrimSpace(tok), "peer") {
+			return true
+		}
+	}
+	return false
+}
 
 // writeInboundRedirect replies to a handshaked-but-unadmittable dialer
 // with a 503 carrying alternate peer addresses before the caller closes
@@ -41,8 +69,9 @@ func (o *Overlay) writeInboundRedirect(tlsConn peertls.PeerConn) {
 // addresses for a 503 redirect, drawn from the discovered gossip set.
 // Mirrors rippled's RedirectHandouts selection: only literal IP
 // endpoints, never the dialer's own address, deduplicated by IP
-// (port ignored), bounded by the count cap. Discovery's map iteration
-// order supplies the shuffle rippled applies to its livecache.
+// (port ignored), bounded by the count cap. Selection order follows
+// Go's randomized map iteration rather than rippled's explicit livecache
+// shuffle; both yield a non-deterministic subset.
 func (o *Overlay) collectRedirectEndpoints(dialer net.IP) []string {
 	out := make([]string, 0, redirectEndpointCount)
 	seen := make(map[string]struct{})
@@ -94,19 +123,27 @@ func (p *Peer) ingestRedirect(body []byte) {
 	p.onRedirect(payload.PeerIPs)
 }
 
-// ingestRedirectEndpoints feeds the addresses from a peer's 503 redirect
-// into Discovery so a dialer we could not connect to actually bootstraps
-// from the alternates. Mirrors rippled's ConnectAttempt::processResponse
-// handing peer-ips to PeerFinder::onRedirects. Each entry is recorded as
-// a one-hop candidate; non-literal addresses are skipped.
+// ingestRedirectEndpoints files the addresses from a peer's 503 redirect
+// as reconnect candidates so a dialer we could not connect to still
+// bootstraps from the alternates. Mirrors rippled's
+// ConnectAttempt::processResponse handing peer-ips to
+// PeerFinder::onRedirects, which records them in the lower-trust boot
+// cache (capped at Tuning::maxRedirects) rather than the live gossip set
+// it re-advertises. The emitter is untrusted, so entries are bounded by
+// maxRedirectIngest and non-literal addresses are skipped.
 func (o *Overlay) ingestRedirectEndpoints(peerIPs []string, source PeerID) {
+	accepted := 0
 	for _, addr := range peerIPs {
+		if accepted >= maxRedirectIngest {
+			break
+		}
 		ep, err := ParseEndpoint(addr)
 		if err != nil || net.ParseIP(ep.Host) == nil {
 			continue
 		}
-		o.discovery.AddPeer(addr, 1, source)
+		o.discovery.AddRedirectCandidate(addr, source)
+		accepted++
 	}
 	slog.Debug("Ingested redirect endpoints",
-		"t", "Overlay", "source", source, "count", len(peerIPs))
+		"t", "Overlay", "source", source, "count", accepted)
 }

--- a/internal/peermanagement/inbound_redirect_test.go
+++ b/internal/peermanagement/inbound_redirect_test.go
@@ -119,6 +119,72 @@ func TestIngestRedirectEndpoints(t *testing.T) {
 	}
 }
 
+// TestConnectAsIncludesPeer mirrors rippled's onHandoff Connect-As gate:
+// admit only when some comma-token case-insensitively equals "peer".
+func TestConnectAsIncludesPeer(t *testing.T) {
+	for header, want := range map[string]bool{
+		"peer":          true,
+		"Peer":          true,
+		"PEER":          true,
+		" peer ":        true,
+		"crawler,peer":  true,
+		"peer, crawler": true,
+		"":              false,
+		"crawler":       false,
+		"peerish":       false,
+	} {
+		assert.Equalf(t, want, connectAsIncludesPeer(header), "Connect-As %q", header)
+	}
+}
+
+// An untrusted emitter cannot make us record more than maxRedirectIngest
+// addresses from a single 503 body, matching rippled's Tuning::maxRedirects.
+func TestIngestRedirectEndpoints_Cap(t *testing.T) {
+	o := &Overlay{discovery: &Discovery{peers: make(map[string]*DiscoveredPeer)}}
+	addrs := make([]string, 0, maxRedirectIngest+10)
+	for i := 0; i < maxRedirectIngest+10; i++ {
+		addrs = append(addrs, net.JoinHostPort(
+			net.IPv4(10, 0, byte(i/256), byte(i%256)).String(), "51235"))
+	}
+	o.ingestRedirectEndpoints(addrs, PeerID(1))
+
+	o.discovery.mu.RLock()
+	defer o.discovery.mu.RUnlock()
+	assert.Len(t, o.discovery.peers, maxRedirectIngest)
+}
+
+// A redirect address is filed in the lower-trust boot cache, not the live
+// gossip set we re-advertise — matching rippled's onRedirects -> bootcache_.
+func TestAddRedirectCandidate_BootCacheRouting(t *testing.T) {
+	d := &Discovery{
+		peers:     make(map[string]*DiscoveredPeer),
+		bootCache: NewBootCache(t.TempDir()),
+	}
+	d.AddRedirectCandidate("192.0.2.20:51235", PeerID(3))
+
+	d.mu.RLock()
+	assert.Empty(t, d.peers, "redirect must not enter the gossip set when a boot cache exists")
+	d.mu.RUnlock()
+
+	eps := d.bootCache.GetEndpoints(10)
+	require.Len(t, eps, 1)
+	assert.Equal(t, "192.0.2.20:51235", eps[0].Address)
+}
+
+// Without a boot cache (no DataDir) a redirect falls back to the discovered
+// set as a one-hop candidate so it stays usable for connection.
+func TestAddRedirectCandidate_FallbackWhenNoBootCache(t *testing.T) {
+	d := &Discovery{peers: make(map[string]*DiscoveredPeer)}
+	d.AddRedirectCandidate("192.0.2.21:51235", PeerID(4))
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	p, ok := d.peers["192.0.2.21:51235"]
+	require.True(t, ok)
+	assert.Equal(t, uint32(1), p.Hops)
+	assert.Equal(t, PeerID(4), p.Source)
+}
+
 // TestPeerIngestRedirect verifies the dialer-side parse of a 503 body
 // invokes onRedirect with the peer-ips, and is a safe no-op otherwise.
 func TestPeerIngestRedirect(t *testing.T) {

--- a/internal/peermanagement/inbound_redirect_test.go
+++ b/internal/peermanagement/inbound_redirect_test.go
@@ -1,0 +1,152 @@
+package peermanagement
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// redirectBody decodes a 503 redirect response body into its peer-ips.
+func redirectBody(t *testing.T, resp *http.Response) []string {
+	t.Helper()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var payload struct {
+		PeerIPs []string `json:"peer-ips"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	return payload.PeerIPs
+}
+
+// TestBuildRedirectResponse verifies the slot-full 503 carries the
+// rippled-shaped headers and a peer-ips JSON body. Mirrors rippled's
+// OverlayImpl::makeRedirectResponse.
+func TestBuildRedirectResponse(t *testing.T) {
+	ips := []string{"192.0.2.1:51235", "203.0.113.5:51235"}
+	resp := BuildRedirectResponse("go-xrpl/test", "198.51.100.9", ips)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, "go-xrpl/test", resp.Header.Get(HeaderServer))
+	assert.Equal(t, "198.51.100.9", resp.Header.Get("Remote-Address"))
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "close", resp.Header.Get(HeaderConnection))
+
+	assert.Equal(t, ips, redirectBody(t, resp))
+}
+
+// An empty redirect set still serializes as [] (not null), matching
+// rippled's Json::arrayValue default.
+func TestBuildRedirectResponse_EmptyList(t *testing.T) {
+	resp := BuildRedirectResponse("", "", nil)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get(HeaderServer))
+	assert.Empty(t, resp.Header.Get("Remote-Address"))
+	assert.Equal(t, []string{}, redirectBody(t, resp))
+}
+
+// TestCollectRedirectEndpoints mirrors rippled's RedirectHandouts
+// selection: the dialer's own address is excluded, addresses are
+// deduplicated by IP (port ignored), and the list is capped at
+// redirectEndpointCount.
+func TestCollectRedirectEndpoints(t *testing.T) {
+	o := &Overlay{discovery: &Discovery{peers: make(map[string]*DiscoveredPeer)}}
+
+	dialer := net.ParseIP("192.0.2.50")
+
+	// The dialer's own address — must never be handed back to it.
+	o.discovery.AddPeer("192.0.2.50:51235", 1, 0)
+	// Two entries sharing an IP — only one survives the IP dedup.
+	o.discovery.AddPeer("203.0.113.7:51235", 1, 0)
+	o.discovery.AddPeer("203.0.113.7:3000", 1, 0)
+	// A non-IP entry is not redirectable.
+	o.discovery.AddPeer("example.com:51235", 1, 0)
+	o.discovery.AddPeer("198.51.100.1:51235", 1, 0)
+
+	got := o.collectRedirectEndpoints(dialer)
+
+	seenIP := make(map[string]struct{})
+	for _, addr := range got {
+		ep, err := ParseEndpoint(addr)
+		require.NoError(t, err)
+		ip := net.ParseIP(ep.Host)
+		require.NotNil(t, ip, "redirect must only contain literal IPs")
+		require.False(t, ip.Equal(dialer), "must not redirect dialer to itself")
+		_, dup := seenIP[ip.String()]
+		require.False(t, dup, "must not repeat an IP")
+		seenIP[ip.String()] = struct{}{}
+	}
+	// 203.0.113.7 (deduped) + 198.51.100.1 — example.com and the dialer
+	// are filtered out.
+	assert.Len(t, got, 2)
+}
+
+func TestCollectRedirectEndpoints_Cap(t *testing.T) {
+	o := &Overlay{discovery: &Discovery{peers: make(map[string]*DiscoveredPeer)}}
+	for i := 0; i < redirectEndpointCount+5; i++ {
+		o.discovery.AddPeer(net.JoinHostPort(
+			net.IPv4(203, 0, 113, byte(i+1)).String(), "51235"), 1, 0)
+	}
+	assert.Len(t, o.collectRedirectEndpoints(nil), redirectEndpointCount)
+}
+
+// TestIngestRedirectEndpoints verifies a dialer feeds a peer's redirect
+// addresses into Discovery as one-hop candidates, skipping non-literals.
+func TestIngestRedirectEndpoints(t *testing.T) {
+	o := &Overlay{discovery: &Discovery{peers: make(map[string]*DiscoveredPeer)}}
+
+	o.ingestRedirectEndpoints([]string{
+		"192.0.2.10:51235",
+		"example.com:51235", // hostname → skipped
+		"garbage",           // unparseable → skipped
+		"203.0.113.5:51235",
+	}, PeerID(7))
+
+	o.discovery.mu.RLock()
+	defer o.discovery.mu.RUnlock()
+	require.Len(t, o.discovery.peers, 2)
+	for _, addr := range []string{"192.0.2.10:51235", "203.0.113.5:51235"} {
+		p, ok := o.discovery.peers[addr]
+		require.True(t, ok, "expected %s ingested", addr)
+		assert.Equal(t, uint32(1), p.Hops)
+		assert.Equal(t, PeerID(7), p.Source)
+	}
+}
+
+// TestPeerIngestRedirect verifies the dialer-side parse of a 503 body
+// invokes onRedirect with the peer-ips, and is a safe no-op otherwise.
+func TestPeerIngestRedirect(t *testing.T) {
+	t.Run("valid body invokes callback", func(t *testing.T) {
+		var got []string
+		p := &Peer{onRedirect: func(ips []string) { got = ips }}
+		p.ingestRedirect([]byte(`{"peer-ips":["192.0.2.1:51235","203.0.113.5:51235"]}`))
+		assert.Equal(t, []string{"192.0.2.1:51235", "203.0.113.5:51235"}, got)
+	})
+
+	t.Run("nil callback does not panic", func(t *testing.T) {
+		p := &Peer{}
+		assert.NotPanics(t, func() {
+			p.ingestRedirect([]byte(`{"peer-ips":["192.0.2.1:51235"]}`))
+		})
+	})
+
+	for name, body := range map[string]string{
+		"empty body":       "",
+		"malformed json":   "{not json",
+		"empty peer-ips":   `{"peer-ips":[]}`,
+		"missing peer-ips": `{"other":1}`,
+	} {
+		t.Run(name+" is a no-op", func(t *testing.T) {
+			called := false
+			p := &Peer{onRedirect: func([]string) { called = true }}
+			p.ingestRedirect([]byte(body))
+			assert.False(t, called)
+		})
+	}
+}

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1577,6 +1577,9 @@ func (o *Overlay) Connect(addr string) error {
 	peer := NewPeer(peerID, endpoint, false, o.identity, o.events)
 	peer.SetDroppedEventsCounter(&o.droppedEvents)
 	peer.handshakeCfg = o.handshakeConfigFor()
+	peer.onRedirect = func(peerIPs []string) {
+		o.ingestRedirectEndpoints(peerIPs, peerID)
+	}
 
 	ctx, cancel := context.WithTimeout(baseCtx, o.cfg.ConnectTimeout)
 	defer cancel()

--- a/internal/peermanagement/overlay_inbound.go
+++ b/internal/peermanagement/overlay_inbound.go
@@ -150,8 +150,14 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 	}
 
 	if err := o.performInboundHandshake(ctx, peer, tlsConn); err != nil {
-		slog.Info("Inbound handshake failed", "t", "Overlay", "remote", remoteAddr, "err", err)
 		conn.Close()
+		// Admission rejections (non-peer Connect-As, slot-full, duplicate)
+		// already emitted their response in lieu of the 101 upgrade and are
+		// not handshake failures, so they raise no lifecycle event.
+		if errors.Is(err, errInboundRejected) {
+			return
+		}
+		slog.Info("Inbound handshake failed", "t", "Overlay", "remote", remoteAddr, "err", err)
 		o.dispatchLifecycle(Event{
 			Type:     EventPeerFailed,
 			PeerID:   peerID,
@@ -159,18 +165,6 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 			Inbound:  true,
 			Error:    err,
 		})
-		return
-	}
-
-	if o.isConnectedTo(endpoint) {
-		conn.Close()
-		return
-	}
-
-	if !o.hasInboundSlot(peer) {
-		slog.Info("Inbound rejected: no slots", "t", "Overlay", "remote", remoteAddr)
-		o.writeInboundRedirect(tlsConn)
-		conn.Close()
 		return
 	}
 
@@ -215,6 +209,18 @@ func (o *Overlay) performInboundHandshake(ctx context.Context, peer *Peer, tlsCo
 		return NewHandshakeError(peer.Endpoint(), "read_request", err)
 	}
 	req.Body.Close()
+
+	// A dialer that does not advertise the "peer" role (a crawler or a
+	// misdirected client) is handed alternates and closed rather than
+	// upgraded. rippled gates this in onHandoff before the rest of the
+	// handshake.
+	if !connectAsIncludesPeer(req.Header.Get(HeaderConnectAs)) {
+		slog.Info("Inbound rejected: non-peer Connect-As",
+			"t", "Overlay", "remote", peer.Endpoint().Host,
+			"connect-as", req.Header.Get(HeaderConnectAs))
+		o.writeInboundRedirect(tlsConn)
+		return errInboundRejected
+	}
 
 	// Server-Domain runs first in the verify chain.
 	if _, err := ValidateServerDomain(req.Header); err != nil {
@@ -279,6 +285,23 @@ func (o *Overlay) performInboundHandshake(ctx context.Context, peer *Peer, tlsCo
 	peer.capabilities = caps
 	peer.protocolVersion = protocol
 	peer.mu.Unlock()
+
+	// Decide admission before sending the 101 upgrade, mirroring rippled's
+	// onHandoff: a duplicate or slot-full dialer gets a rejection in lieu
+	// of the upgrade, never both on the same stream. The slot check needs
+	// the verified public key (set above) so reserved/cluster peers still
+	// bypass the inbound cap.
+	if o.isConnectedTo(peer.Endpoint()) {
+		slog.Info("Inbound rejected: already connected",
+			"t", "Overlay", "remote", peer.Endpoint().Host)
+		return errInboundRejected
+	}
+	if !o.hasInboundSlot(peer) {
+		slog.Info("Inbound rejected: no slots",
+			"t", "Overlay", "remote", peer.Endpoint().Host)
+		o.writeInboundRedirect(tlsConn)
+		return errInboundRejected
+	}
 
 	resp := BuildHandshakeResponse(o.identity, sharedValue, hsCfg, protocol)
 	addAddressHeaders(resp.Header, hsCfg, peerRemote)

--- a/internal/peermanagement/overlay_inbound.go
+++ b/internal/peermanagement/overlay_inbound.go
@@ -169,6 +169,7 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 
 	if !o.hasInboundSlot(peer) {
 		slog.Info("Inbound rejected: no slots", "t", "Overlay", "remote", remoteAddr)
+		o.writeInboundRedirect(tlsConn)
 		conn.Close()
 		return
 	}

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -76,6 +77,13 @@ type Peer struct {
 	bufReader    *bufio.Reader
 	state        PeerState
 	handshakeCfg HandshakeConfig
+
+	// onRedirect receives the alternate addresses from a 503 handshake
+	// rejection (rippled's makeRedirectResponse peer-ips) so the dialer
+	// can bootstrap elsewhere. Wired by Overlay.Connect before the
+	// handshake runs and read only on that synchronous path, so it needs
+	// no lock. nil for inbound peers and in tests.
+	onRedirect func([]string)
 
 	send   chan []byte
 	events chan<- Event
@@ -578,12 +586,14 @@ func (p *Peer) performHandshake(ctx context.Context, tlsConn peertls.PeerConn) e
 	}
 
 	if resp.StatusCode != http.StatusSwitchingProtocols {
-		body := make([]byte, 1024)
-		n, _ := resp.Body.Read(body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, redirectBodyLimit))
 		resp.Body.Close()
+		if resp.StatusCode == http.StatusServiceUnavailable {
+			p.ingestRedirect(body)
+		}
 		return NewHandshakeError(p.endpoint, "verify",
 			fmt.Errorf("%w: got status %d, headers: %v, body: %s",
-				ErrInvalidHandshake, resp.StatusCode, resp.Header, string(body[:n])))
+				ErrInvalidHandshake, resp.StatusCode, resp.Header, string(body)))
 	}
 	resp.Body.Close()
 


### PR DESCRIPTION
## Summary
- On a handshaked inbound peer with no admission slot, reply with an HTTP **503** carrying alternate peer addresses (`{"peer-ips": [...]}`) before closing, instead of a bare TCP close. Mirrors rippled's `OverlayImpl::makeRedirectResponse`.
- Redirect endpoints are drawn from the discovered gossip set, exclude the dialer's own address, are deduplicated by IP (port ignored), and capped at 10 (rippled `Tuning::redirectEndpointCount`), mirroring `RedirectHandouts`.
- On the **dialer** side, a 503 with `peer-ips` now feeds those addresses into discovery as one-hop candidates so a redirected dialer actually bootstraps — mirrors `ConnectAttempt::processResponse`.

## Test plan
- [x] `go test ./internal/peermanagement/...` — new `TestBuildRedirectResponse`, `TestCollectRedirectEndpoints(_Cap)`, `TestIngestRedirectEndpoints`, `TestPeerIngestRedirect` plus full suite pass
- [x] `go build ./...` and `go vet ./internal/peermanagement/...` clean

Fixes #947