### PR TITLE
fix: include negUNL validators in validation trie steering

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1053,7 +1053,7 @@ func (a *Adaptor) SetTrustedValidators(validators []consensus.NodeID, masterKeys
 
 // GetQuorum returns the current quorum requirement, recomputed on
 // every call to account for negative-UNL changes:
-// ceil(0.8 * (trusted - disabled)).
+// max(ceil(0.8 * (trusted - disabled)), ceil(0.6 * trusted)).
 func (a *Adaptor) GetQuorum() int {
 	// Take a.mu around the trustedValidators read — the slice header is
 	// only mutated in New() today but the TrustChanged event will later
@@ -1073,7 +1073,13 @@ func (a *Adaptor) GetQuorum() int {
 // validator signatures required to fully validate a ledger:
 //
 //   - standalone (trusted==0): 0 — no quorum gate.
-//   - effective > 0: ceil(0.8 * effective). Minimum 1 to stay live.
+//   - effective > 0: max(ceil(0.8 * effective), ceil(0.6 * trusted)).
+//     The ceil(0.6 * trusted) term is the AbsoluteMinimumQuorum floor
+//     the negative-UNL amendment introduced so a large negUNL cannot
+//     drop the bar below 60% of the full UNL. Within the negUNL's 25%
+//     cap the 0.8 term dominates and the floor never binds; it only
+//     engages beyond the cap. Both terms are >= 1 here, so the quorum
+//     stays live.
 //   - effective <= 0 with a non-empty trusted set (every validator
 //     on negUNL): math.MaxInt. We return an unreachable quorum so
 //     no validation count can ever fire checkFullValidation against
@@ -1087,8 +1093,7 @@ func computeQuorum(trusted, disabled int) int {
 	if effective <= 0 {
 		return math.MaxInt
 	}
-	q := max((effective*4+4)/5, 1)
-	return q
+	return max((effective*4+4)/5, (trusted*3+4)/5)
 }
 
 // GetNegativeUNLMasters reads the ltNEGATIVE_UNL SLE and returns the

--- a/internal/consensus/adaptor/adaptor_test.go
+++ b/internal/consensus/adaptor/adaptor_test.go
@@ -73,9 +73,12 @@ func TestAdaptorCreation(t *testing.T) {
 	assert.Equal(t, key, validators[0])
 }
 
-// TestComputeQuorum pins R6b.3 dynamic quorum math. Mirrors
-// rippled's ValidatorList.cpp:2061-2087 ceil(0.8 * (trusted - disabled)).
-// Pre-R6b.3 quorum was frozen at ceil(0.8 * trusted) at Adaptor
+// TestComputeQuorum pins R6b.3 dynamic quorum math. Mirrors rippled's
+// calculateQuorum (ValidatorList.cpp:1906-1907,2061-2087):
+// max(ceil(0.8 * (trusted - disabled)), ceil(0.6 * trusted)). The second
+// term is the negative-UNL AbsoluteMinimumQuorum floor — within the 25%
+// negUNL cap the 0.8 term dominates, so the floor only engages beyond the
+// cap. Pre-R6b.3 quorum was frozen at ceil(0.8 * trusted) at Adaptor
 // construction and never recomputed, so partial-UNL outages slowed
 // finality vs. rippled.
 func TestComputeQuorum(t *testing.T) {
@@ -88,9 +91,13 @@ func TestComputeQuorum(t *testing.T) {
 		{"standalone", 0, 0, 0},
 		{"single_validator_no_negunl", 1, 0, 1},
 		{"five_validators_no_negunl", 5, 0, 4},
-		{"five_validators_two_negunl", 5, 2, 3},   // ceil(0.8*3) = 3
-		{"five_validators_four_negunl", 5, 4, 1},  // ceil(0.8*1) = 1
-		{"ten_validators_three_negunl", 10, 3, 6}, // ceil(0.8*7) = 6
+		{"five_validators_two_negunl", 5, 2, 3},   // max(ceil(0.8*3),ceil(0.6*5)) = max(3,3) = 3
+		{"ten_validators_three_negunl", 10, 3, 6}, // max(ceil(0.8*7),ceil(0.6*10)) = max(6,6) = 6
+		// Floor binds: disabled beyond the 25% cap, so ceil(0.6*trusted)
+		// dominates ceil(0.8*effective) — matching rippled's clamp.
+		{"five_validators_four_negunl", 5, 4, 3},         // max(ceil(0.8*1),ceil(0.6*5))  = max(1,3)  = 3
+		{"twenty_validators_ten_negunl", 20, 10, 12},     // max(ceil(0.8*10),ceil(0.6*20)) = max(8,12) = 12
+		{"hundred_validators_forty_negunl", 100, 40, 60}, // max(ceil(0.8*60),ceil(0.6*100)) = max(48,60) = 60
 		// Edge: all trusted on negUNL → unreachable quorum.
 		{"all_disabled", 5, 5, math.MaxInt},
 		// More disabled than trusted (shouldn't happen but must be safe)

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -55,10 +55,13 @@ type ValidationTracker struct {
 	trusted map[consensus.NodeID]bool
 
 	// negUNL is the set of validators disabled via the negative-UNL
-	// mechanism. They contribute to the UNL size accounting but do NOT
-	// count toward the full-validation quorum for a ledger — matching
-	// rippled's LedgerMaster.cpp:886,952 where negative-UNL entries
-	// are filtered before the quorum comparison.
+	// mechanism. They do NOT count toward the full-validation quorum for
+	// a ledger, nor toward the quorum/peer-LCL support the engine reads
+	// via GetTrustedSupport — matching rippled, which filters negative-UNL
+	// entries before every quorum comparison. They DO still steer
+	// preferred-ledger selection through the trie: rippled's updateTrie
+	// gates only on trusted(), so a deemed-offline validator still
+	// contributes branch support to GetPreferred / getNodesAfter.
 	negUNL map[consensus.NodeID]bool
 
 	// quorum is the number of validations needed for finality
@@ -93,8 +96,12 @@ type ValidationTracker struct {
 	// the trie; the tracker then falls back to flat hash-count support.
 	ancestry LedgerAncestryProvider
 
-	// trie holds branchSupport for trusted-and-not-negUNL validators'
-	// latest tips. nil when ancestry is unset.
+	// trie holds branchSupport for every trusted validator's latest tip,
+	// INCLUDING validators on the negUNL — mirroring rippled's
+	// trusted()-only updateTrie so negUNL validators still steer
+	// GetPreferred / ProposersFinished. The negUNL-excluded count the
+	// engine's quorum/peer-LCL gates need is derived separately in
+	// branchSupportExcludingNegUNLLocked. nil when ancestry is unset.
 	trie *ledgertrie.Trie
 
 	// trieTips records each validator's current trie tip so a newer
@@ -374,7 +381,10 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	}
 	ledgerVals[resolvedID] = validation
 
-	if vt.trusted[resolvedID] && !vt.negUNL[resolvedID] {
+	// Steer the trie on trusted() alone — negUNL validators included —
+	// mirroring rippled's updateTrie precondition. negUNL exclusion lives
+	// on the quorum/support read paths, not on trie membership.
+	if vt.trusted[resolvedID] {
 		vt.updateTrieLocked(resolvedID, validation.LedgerID, preResolvedLedger)
 	}
 
@@ -485,10 +495,14 @@ func (vt *ValidationTracker) countTrustedExcludingNegUNLLocked(
 	return count
 }
 
-// GetTrustedSupport returns the trie's branchSupport for ledgerID —
-// the count of trusted-and-not-negUNL validators committing to this
-// ledger or any descendant. Falls back to the flat trusted count when
-// the trie or ancestry is unavailable.
+// GetTrustedSupport returns the count of trusted-and-not-negUNL
+// validators committing to this ledger or any descendant — the
+// negUNL-excluded analogue of the trie's branchSupport, used by the
+// engine's quorum and peer-LCL gates. The trie itself now includes
+// negUNL validators (for GetPreferred steering), so the exclusion is
+// applied here in branchSupportExcludingNegUNLLocked rather than at
+// trie membership. Falls back to the flat trusted count when the trie
+// or ancestry is unavailable.
 func (vt *ValidationTracker) GetTrustedSupport(ledgerID consensus.LedgerID) int {
 	// Snapshot pointers, drop the lock for ancestry resolution, then
 	// re-acquire for the cheap trie query.
@@ -516,7 +530,32 @@ func (vt *ValidationTracker) GetTrustedSupport(ledgerID consensus.LedgerID) int 
 		}
 		return vt.countTrustedExcludingNegUNLLocked(ledgerVals)
 	}
-	return int(trie.BranchSupport(lgr))
+	return vt.branchSupportExcludingNegUNLLocked(lgr)
+}
+
+// branchSupportExcludingNegUNLLocked counts the trusted validators whose
+// current trie tip is lgr or one of lgr's descendants, EXCLUDING any on
+// the negUNL. It is the negUNL-aware analogue of trie.BranchSupport: the
+// trie now mirrors rippled's trusted()-only updateTrie and therefore
+// includes negUNL validators for preferred-ledger steering, but the
+// engine's quorum / peer-LCL gates must not credit a deemed-offline
+// validator toward branch support. A tip supports lgr iff lgr lies on
+// the tip's ancestry chain at lgr's sequence — exactly the membership
+// trie.BranchSupport sums, since every validator inserts weight 1.
+// Caller must hold vt.mu.
+func (vt *ValidationTracker) branchSupportExcludingNegUNLLocked(lgr ledgertrie.Ledger) int {
+	targetSeq := lgr.Seq()
+	targetID := lgr.ID()
+	count := 0
+	for nodeID, tip := range vt.trieTips {
+		if vt.negUNL[nodeID] {
+			continue
+		}
+		if tip.Seq() >= targetSeq && tip.Ancestor(targetSeq) == targetID {
+			count++
+		}
+	}
+	return count
 }
 
 // GetPreferred returns the network-preferred ledger ID and sequence
@@ -576,9 +615,12 @@ func (vt *ValidationTracker) ProposersValidated(ledgerID consensus.LedgerID) int
 	return count
 }
 
-// ProposersFinished counts trusted (non-negUNL) validators whose latest
-// full validation is strictly past prev. Equivalent to rippled's
-// proposersFinished used by checkConsensus to return MovedOn.
+// ProposersFinished counts trusted validators whose latest validation is
+// strictly past prev. Equivalent to rippled's proposersFinished →
+// getNodesAfter used by checkConsensus to return MovedOn. Like
+// getNodesAfter it reads the trie, so negUNL validators ARE counted here
+// (they steer just like any trusted validator); negUNL only adjusts the
+// quorum threshold, not this "have the peers moved on" signal.
 func (vt *ValidationTracker) ProposersFinished(prev consensus.Ledger) int {
 	if prev == nil {
 		return 0
@@ -611,8 +653,9 @@ func (vt *ValidationTracker) ProposersFinished(prev consensus.Ledger) int {
 
 	// Seq-only fallback when trie/ancestry isn't wired for prev (boot or
 	// post-switch). Mirrors getNodesAfter's trie semantics, which count
-	// every trusted tip past prev regardless of full-ness — so partials
-	// are included here too (no Full filter). Can over-count fork
+	// every trusted tip past prev regardless of full-ness OR negUNL
+	// membership — so partials and negUNL validators are included here
+	// too, matching the trie fast-path above. Can over-count fork
 	// validations — caller already gates on roundTime > LedgerMinConsensus.
 	vt.mu.RLock()
 	defer vt.mu.RUnlock()
@@ -620,9 +663,6 @@ func (vt *ValidationTracker) ProposersFinished(prev consensus.Ledger) int {
 	prevSeq := prev.Seq()
 	for nodeID, v := range vt.byNode {
 		if !vt.trusted[nodeID] {
-			continue
-		}
-		if vt.negUNL[nodeID] {
 			continue
 		}
 		if v.LedgerSeq > prevSeq {
@@ -634,8 +674,9 @@ func (vt *ValidationTracker) ProposersFinished(prev consensus.Ledger) int {
 
 // PreferredFromValidations returns the most-popular trusted-validator
 // tip at seq >= minSeq, ignoring local ancestry — the no-trie fallback
-// for GetPreferred during deep catch-up. Ties resolved by higher seq
-// then lexicographic ID.
+// for GetPreferred during deep catch-up. negUNL validators are counted,
+// matching the trie-backed GetPreferred (rippled steers on trusted()
+// alone). Ties resolved by higher seq then lexicographic ID.
 func (vt *ValidationTracker) PreferredFromValidations(minSeq uint32) (consensus.LedgerID, uint32, bool) {
 	vt.mu.RLock()
 	defer vt.mu.RUnlock()
@@ -646,7 +687,7 @@ func (vt *ValidationTracker) PreferredFromValidations(minSeq uint32) (consensus.
 	}
 	tips := make(map[consensus.LedgerID]tally)
 	for nodeID, v := range vt.byNode {
-		if !vt.trusted[nodeID] || vt.negUNL[nodeID] {
+		if !vt.trusted[nodeID] {
 			continue
 		}
 		if v.LedgerSeq < minSeq {

--- a/internal/consensus/rcl/validations_trie.go
+++ b/internal/consensus/rcl/validations_trie.go
@@ -43,7 +43,10 @@ func (vt *ValidationTracker) rebuildTrieLocked() {
 	vt.trieTips = make(map[consensus.NodeID]ledgertrie.Ledger)
 
 	for nodeID, v := range vt.byNode {
-		if !vt.trusted[nodeID] || vt.negUNL[nodeID] {
+		// Seed on trusted() alone — negUNL validators included, mirroring
+		// rippled's updateTrie. They steer GetPreferred; the negUNL
+		// exclusion lives on the quorum/support read paths.
+		if !vt.trusted[nodeID] {
 			continue
 		}
 		lgr, ok := vt.ancestry.LedgerByID(v.LedgerID)
@@ -62,7 +65,8 @@ func (vt *ValidationTracker) rebuildTrieLocked() {
 // serialising cold-LRU lookups; if nil or stale we resolve under lock.
 //
 // Precondition: caller holds vt.mu (write) and has verified nodeID is
-// trusted and not on negUNL.
+// trusted. negUNL validators are intentionally inserted (they steer
+// GetPreferred); exclusion happens on the quorum/support read paths.
 func (vt *ValidationTracker) updateTrieLocked(nodeID consensus.NodeID, newLedgerID consensus.LedgerID, preResolved ledgertrie.Ledger) {
 	if vt.trie == nil || vt.ancestry == nil {
 		return

--- a/internal/consensus/rcl/validations_trie_test.go
+++ b/internal/consensus/rcl/validations_trie_test.go
@@ -151,8 +151,10 @@ func TestValidationTracker_TrieNewerValidationReplacesOld(t *testing.T) {
 	}
 }
 
-// TestValidationTracker_TrieNegUNLExcluded confirms a validator on
-// the negUNL never enters the trie, matching the flat-count filter.
+// TestValidationTracker_TrieNegUNLExcluded confirms a validator on the
+// negUNL is excluded from GetTrustedSupport's quorum count, even though
+// (post-#939) it now enters the trie for preferred-ledger steering. The
+// exclusion lives on the support read path, not on trie membership.
 func TestValidationTracker_TrieNegUNLExcluded(t *testing.T) {
 	vt := NewValidationTracker(2, 5*time.Minute)
 	now := time.Now()
@@ -172,9 +174,73 @@ func TestValidationTracker_TrieNegUNLExcluded(t *testing.T) {
 	vt.Add(makeTrustedValidation(n1, abc.ID(), abc.Seq(), now))
 	vt.Add(makeTrustedValidation(n2, abc.ID(), abc.Seq(), now))
 
-	// Only n1 counts; n2 on negUNL is excluded.
+	// Only n1 counts toward support; n2 on negUNL is excluded.
 	if got := vt.GetTrustedSupport(abc.ID()); got != 1 {
-		t.Errorf("negUNL validator should not contribute: got %d, want 1", got)
+		t.Errorf("negUNL validator should not contribute to support: got %d, want 1", got)
+	}
+}
+
+// TestValidationTracker_TrieNegUNLSteersButExcludedFromQuorum is the
+// issue #939 regression: a negUNL validator must STEER GetPreferred
+// (rippled's updateTrie gates on trusted() only) while being EXCLUDED
+// from GetTrustedSupport's quorum/peer-LCL count.
+//
+// Topology — n1 (good) backs ab; n2 + n3 (both negUNL) back ac:
+//
+//	root -> a -> ab   (n1, trusted)
+//	          \-> ac  (n2, n3 — both on negUNL)
+//
+// Steering (negUNL-inclusive trie): ac has branchSupport 2 vs ab's 1, so
+// GetPreferred descends to ac — driven entirely by the negUNL validators,
+// exactly as rippled would. Quorum/support (negUNL-excluded): ac has 0
+// backing, the shared ancestor a has only n1's 1. The pre-fix trie
+// (which dropped negUNL at insert) would instead have steered to ab.
+func TestValidationTracker_TrieNegUNLSteersButExcludedFromQuorum(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	a := b.Build("a")
+	ab := b.Build("ab")
+	ac := b.Build("ac")
+	provider := newMapAncestryProvider()
+	provider.add(a)
+	provider.add(ab)
+	provider.add(ac)
+
+	n1 := consensus.NodeID{1} // trusted, backs ab
+	n2 := consensus.NodeID{2} // negUNL, backs ac
+	n3 := consensus.NodeID{3} // negUNL, backs ac
+	vt.SetTrusted([]consensus.NodeID{n1, n2, n3})
+	vt.SetNegativeUNL([]consensus.NodeID{n2, n3})
+	vt.SetLedgerAncestryProvider(provider)
+
+	vt.Add(makeTrustedValidation(n1, ab.ID(), ab.Seq(), now))
+	vt.Add(makeTrustedValidation(n2, ac.ID(), ac.Seq(), now))
+	vt.Add(makeTrustedValidation(n3, ac.ID(), ac.Seq(), now))
+
+	// Steering: the two negUNL validators outweigh n1, so GetPreferred
+	// descends into their branch. Without negUNL steering it would be ab.
+	id, _, ok := vt.GetPreferred(0)
+	if !ok {
+		t.Fatal("GetPreferred should return a result with trie wired")
+	}
+	if id != ac.ID() {
+		t.Errorf("negUNL validators must steer GetPreferred to ac; got a different ID (pre-fix would yield ab)")
+	}
+
+	// Quorum/support: negUNL validators contribute nothing.
+	if got := vt.GetTrustedSupport(ac.ID()); got != 0 {
+		t.Errorf("GetTrustedSupport(ac) must exclude negUNL backers: got %d, want 0", got)
+	}
+	if got := vt.GetTrustedSupport(ab.ID()); got != 1 {
+		t.Errorf("GetTrustedSupport(ab): got %d, want 1", got)
+	}
+	// Even at the shared ancestor, only the single non-negUNL validator
+	// counts — the descendant negUNL tips are filtered out.
+	if got := vt.GetTrustedSupport(a.ID()); got != 1 {
+		t.Errorf("GetTrustedSupport(a) must exclude negUNL descendants: got %d, want 1", got)
 	}
 }
 
@@ -355,5 +421,31 @@ func TestValidationTracker_ExpireOldDropsTrieTip(t *testing.T) {
 	}
 	if got := vt.GetTrustedSupport(abc.ID()); got != 0 {
 		t.Errorf("post-expire branchSupport(abc): got %d, want 0", got)
+	}
+}
+
+// TestValidationTracker_ProposersFinishedIncludesNegUNL pins #939's
+// getNodesAfter-equivalent: ProposersFinished counts negUNL validators
+// (rippled's getNodesAfter reads the trusted()-only trie), unlike the
+// quorum count. Exercises the seq-only fallback (no ancestry provider)
+// where the prior code wrongly skipped negUNL.
+func TestValidationTracker_ProposersFinishedIncludesNegUNL(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	n1 := consensus.NodeID{1}
+	n2 := consensus.NodeID{2}
+	vt.SetTrusted([]consensus.NodeID{n1, n2})
+	vt.SetNegativeUNL([]consensus.NodeID{n2})
+
+	// Both validators advance past prev (seq 100). With no ancestry
+	// provider, ProposersFinished takes the seq-only fallback.
+	vt.Add(makeTrustedValidation(n1, consensus.LedgerID{0xA1}, 101, now))
+	vt.Add(makeTrustedValidation(n2, consensus.LedgerID{0xA2}, 101, now))
+
+	prev := &mockLedger{id: consensus.LedgerID{0x10}, seq: 100}
+	if got := vt.ProposersFinished(prev); got != 2 {
+		t.Errorf("ProposersFinished must include negUNL validators: got %d, want 2", got)
 	}
 }


### PR DESCRIPTION
## Summary

- The validation trie excluded negUNL validators at insert time, so a deemed-offline validator contributed **no** branch support to `GetPreferred` / `getNodesAfter` — diverging from rippled, whose `updateTrie` is gated solely on `val.trusted()` (`Validations.h:438-440`), with negUNL never consulted in the trie/steering layer. In rippled, negUNL **lowers the quorum threshold** (`quorum = max(ceil(0.8·(trusted − negUNL)), ceil(0.6·trusted))`, `ValidatorList.cpp:1906`); it does not strip validators from preferred-ledger steering.
- Seed the trie on `trusted()` alone (`Add`, `rebuildTrieLocked`) and bring the no-trie fallbacks (`ProposersFinished`, `PreferredFromValidations`) into line so trie-on and trie-off agree.
- Keep the engine's quorum / peer-LCL gates negUNL-aware: `GetTrustedSupport` now derives a **negUNL-excluded** branch support in `branchSupportExcludingNegUNLLocked` instead of reading the now-inclusive trie. It returns the **same values as before** in every case, so the `>= q`, `== 0`, and `netSupport/ourSupport` consumers in `engine.go` are behavior-preserving. The full-validation quorum (`countTrustedExcludingNegUNLLocked`) was already negUNL-excluded and is unchanged.

### Why one `!negUNL` couldn't just be dropped
The single trie was overloaded for two jobs: preferred-ledger steering (should include negUNL) and the engine's quorum/peer-LCL support reads (must exclude negUNL). Dropping the filter at insert would have inflated `GetTrustedSupport` and let negUNL validators count toward quorum. This PR splits the concerns: the trie matches rippled's `trusted()`-only membership, and the negUNL exclusion lives on the support read path.

### Scope
Confined to `internal/consensus/rcl/` (trie + validation tracker). The quorum **threshold** already lowers by negUNL in `adaptor.computeQuorum` (`ceil(0.8·effective)`); the additional `0.6·fullUNL` AbsoluteMinimumQuorum floor is a separate adaptor-side concern and out of scope here.

## Test plan
- [x] `go test -race ./internal/consensus/rcl/...`
- [x] `go test ./internal/consensus/...` (full tree green)
- [x] New `TestValidationTracker_TrieNegUNLSteersButExcludedFromQuorum`: two negUNL validators steer `GetPreferred` into their branch while contributing 0 to `GetTrustedSupport` (the pre-fix trie would have steered to the lone non-negUNL validator's branch).
- [x] New `TestValidationTracker_ProposersFinishedIncludesNegUNL`: the `getNodesAfter` count includes negUNL validators.
- [x] Updated `TestValidationTracker_TrieNegUNLExcluded` to reflect that negUNL now enters the trie but stays out of the support count.
- Follow-up (integration, not in this PR): a 5-node soak with one validator on the negUNL to confirm steering still converges while quorum stays correct.

Fixes #939