### PR TITLE
fix: HTTP admin-denial returns 403 "Forbidden" instead of 200 + noPermission

### DIFF
--- a/internal/rpc/admin_forbidden_test.go
+++ b/internal/rpc/admin_forbidden_test.go
@@ -1,0 +1,182 @@
+package rpc
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHTTPAdminDenialReturns403 pins the role-layer rejection of an admin-only
+// command for a non-admin caller on the HTTP single path: rippled answers
+// HTTPReply(403, "Forbidden") before the handler runs, not a 200 + JSON-RPC
+// result envelope (ServerHandler.cpp:750-757). An admin caller is unaffected.
+func TestHTTPAdminDenialReturns403(t *testing.T) {
+	srv := newHardeningServer(t, time.Second, "stop", &stubHandler{role: types.RoleAdmin})
+
+	t.Run("non-admin caller gets 403 Forbidden", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"stop","params":[{}]}`))
+		req.RemoteAddr = "203.0.113.5:1234" // non-local peer, no AdminNets → RoleGuest
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d\nbody: %s", rr.Code, rr.Body.String())
+		}
+		// rippled labels even this plain-text body application/json (M2).
+		if ct := rr.Header().Get("Content-Type"); ct != "application/json; charset=UTF-8" {
+			t.Fatalf("content-type = %q, want application/json; charset=UTF-8", ct)
+		}
+		if got := strings.TrimSpace(rr.Body.String()); got != "Forbidden" {
+			t.Fatalf("body = %q, want \"Forbidden\"", got)
+		}
+		// The denial must not ride the XRPL result envelope (the old 200 shape).
+		if strings.Contains(rr.Body.String(), "result") || strings.Contains(rr.Body.String(), "noPermission") {
+			t.Fatalf("admin denial leaked the result envelope: %s", rr.Body.String())
+		}
+	})
+
+	t.Run("admin caller is allowed", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"stop","params":[{}]}`))
+		req.RemoteAddr = "127.0.0.1:1234" // localhost fallback → RoleAdmin
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("admin caller: expected 200, got %d\nbody: %s", rr.Code, rr.Body.String())
+		}
+		if result := decodeEnvelope(t, rr.Body.Bytes()); result["status"] != "success" {
+			t.Fatalf("admin caller: status = %v, want success", result["status"])
+		}
+	})
+}
+
+// TestHTTPAdminDenialChargesFeeMalformed pins that a role-layer FORBID charges
+// the caller feeMalformedRPC (rippled ServerHandler.cpp:752), so admin-probing
+// is not a cheap probe. An admin (unlimited) caller bypasses the charge.
+func TestHTTPAdminDenialChargesFeeMalformed(t *testing.T) {
+	srv := newHardeningServer(t, time.Second, "stop", &stubHandler{role: types.RoleAdmin})
+	srv.loadTracker = loadtrack.New()
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"stop","params":[{}]}`))
+	req.RemoteAddr = "198.51.100.7:5555"
+	srv.ServeHTTP(httptest.NewRecorder(), req)
+
+	// The malformed bucket is 100; the reference bucket is 20. Allow for a hair
+	// of decay between the charge and this read, but confirm it is the malformed
+	// charge, not a cheaper one.
+	if got := srv.loadTracker.Balance("198.51.100.7"); got <= float64(loadtrack.ChargeReference) {
+		t.Fatalf("forbidden admin denial charged %v, want feeMalformedRPC (~%d)", got, loadtrack.ChargeMalformed)
+	}
+
+	// An admin caller is unlimited and accrues nothing.
+	req = httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"stop","params":[{}]}`))
+	req.RemoteAddr = "127.0.0.1:5555"
+	srv.ServeHTTP(httptest.NewRecorder(), req)
+	if got := srv.loadTracker.Balance("127.0.0.1"); got != 0 {
+		t.Fatalf("admin caller charged %v, want 0 (unlimited)", got)
+	}
+}
+
+// TestHTTPBatchAdminDenialForbidden pins the batch-element shape for a role-layer
+// FORBID: rippled echoes the element's own fields and attaches
+// make_json_error(forbidden, "Forbidden") (forbidden = -32605,
+// ServerHandler.cpp:758-760), rather than the XRPL result envelope. Sibling
+// elements are unaffected.
+func TestHTTPBatchAdminDenialForbidden(t *testing.T) {
+	srv := &Server{
+		registry: types.NewMethodRegistry(),
+		timeout:  time.Second,
+		services: types.NewServiceContainer(nil),
+	}
+	srv.registry.Register("stop", &stubHandler{role: types.RoleAdmin})
+	srv.registry.Register("ping", echoHandler())
+
+	body := `{"method":"batch","params":[
+		{"method":"stop","value":7},
+		{"method":"ping","value":1}
+	]}`
+	rr := postBatch(t, srv, body) // posts from 10.0.0.1 → RoleGuest
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d\nbody: %s", rr.Code, rr.Body.String())
+	}
+	var replies []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &replies); err != nil {
+		t.Fatalf("not a JSON array: %v\nbody: %s", err, rr.Body.String())
+	}
+	if len(replies) != 2 {
+		t.Fatalf("expected 2 replies, got %d", len(replies))
+	}
+
+	denied := replies[0]
+	if _, hasResult := denied["result"]; hasResult {
+		t.Fatalf("forbidden batch element must not carry a result envelope: %v", denied)
+	}
+	if denied["method"] != "stop" || denied["value"] != float64(7) {
+		t.Fatalf("forbidden element did not echo its own fields: %v", denied)
+	}
+	// make_json_error nests under "error"; rippled assigns the whole object to
+	// the element's "error" field, so the wire shape is double-nested.
+	errObj, ok := denied["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("forbidden element missing error object: %v", denied)
+	}
+	inner, ok := errObj["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("forbidden error not in make_json_error shape: %v", errObj)
+	}
+	if inner["code"] != float64(-32605) {
+		t.Fatalf("forbidden code = %v, want -32605", inner["code"])
+	}
+	if inner["message"] != "Forbidden" {
+		t.Fatalf("forbidden message = %v, want \"Forbidden\"", inner["message"])
+	}
+
+	okReply := replies[1]
+	result, ok := okReply["result"].(map[string]any)
+	if !ok || result["status"] != "success" {
+		t.Fatalf("guest sibling element should succeed in a result envelope: %v", okReply)
+	}
+}
+
+// TestWSAdminDenialForbidden confirms the WebSocket admin-denial against rippled:
+// requestRole → Role::FORBID → rpcError(rpcFORBIDDEN) (ServerHandler.cpp:482-486),
+// i.e. the "forbidden" token with code 3. A non-admin role is forced by
+// configuring AdminNets that exclude the loopback test peer, disabling the
+// localhost-admin fallback.
+func TestWSAdminDenialForbidden(t *testing.T) {
+	ws := NewWebSocketServer(2*time.Second, nil)
+	ws.methodRegistry.Register("stop", &stubHandler{role: types.RoleAdmin})
+
+	_, adminNet, _ := net.ParseCIDR("10.0.0.0/8")
+	pc := &PortContext{AdminNets: []net.IPNet{*adminNet}}
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws.ServeHTTP(w, r.WithContext(WithPortContext(r.Context(), pc)))
+	}))
+	defer httpSrv.Close()
+	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http")
+
+	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer c.Close()
+
+	require.NoError(t, c.WriteJSON(map[string]any{"command": "stop", "id": float64(1)}))
+	require.NoError(t, c.SetReadDeadline(time.Now().Add(2*time.Second)))
+	var resp map[string]any
+	require.NoError(t, c.ReadJSON(&resp))
+
+	assert.Equal(t, "error", resp["status"])
+	assert.Equal(t, "forbidden", resp["error"])
+	assert.Equal(t, float64(types.RpcFORBIDDEN), resp["error_code"])
+	assert.Equal(t, float64(1), resp["id"])
+}

--- a/internal/rpc/admin_forbidden_test.go
+++ b/internal/rpc/admin_forbidden_test.go
@@ -178,5 +178,8 @@ func TestWSAdminDenialForbidden(t *testing.T) {
 	assert.Equal(t, "error", resp["status"])
 	assert.Equal(t, "forbidden", resp["error"])
 	assert.Equal(t, float64(types.RpcFORBIDDEN), resp["error_code"])
+	// rpcFORBIDDEN's errorInfo message is "Bad credentials." (ErrorCodes.cpp:77),
+	// not rpcNO_PERMISSION's "You don't have permission for this command."
+	assert.Equal(t, "Bad credentials.", resp["error_message"])
 	assert.Equal(t, float64(1), resp["id"])
 }

--- a/internal/rpc/admin_forbidden_test.go
+++ b/internal/rpc/admin_forbidden_test.go
@@ -32,7 +32,7 @@ func TestHTTPAdminDenialReturns403(t *testing.T) {
 		if rr.Code != http.StatusForbidden {
 			t.Fatalf("expected 403, got %d\nbody: %s", rr.Code, rr.Body.String())
 		}
-		// rippled labels even this plain-text body application/json (M2).
+		// rippled labels even this plain-text body application/json.
 		if ct := rr.Header().Get("Content-Type"); ct != "application/json; charset=UTF-8" {
 			t.Fatalf("content-type = %q, want application/json; charset=UTF-8", ct)
 		}

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -333,6 +333,16 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// rippled rejects an admin-only command from a non-admin caller at the role
+	// layer: a FORBID role yields HTTPReply(403, "Forbidden") before the handler
+	// runs, not the JSON-RPC result envelope (ServerHandler.cpp:750-757). The
+	// feeMalformedRPC charge is applied in the shared dispatch core; here we only
+	// render the 403.
+	if rpcErr != nil && rpcErr.IsForbidden() {
+		writePlainHTTPError(w, http.StatusForbidden, "Forbidden")
+		return
+	}
+
 	requestObj := buildRequestEcho(method, params)
 
 	s.writeXrplResponseWithOptions(w, requestObj, result, rpcErr, loadWarningOpts(ctx))
@@ -463,6 +473,14 @@ func (s *Server) dispatchBatchElement(el json.RawMessage, baseCtx context.Contex
 		}
 	}
 
+	// rippled renders a batch element denied at the role layer as the echoed
+	// element plus a make_json_error(forbidden, "Forbidden") object — the
+	// malformed-element early-exit shape, not the XRPL result envelope
+	// (ServerHandler.cpp:758-760).
+	if rpcErr != nil && rpcErr.IsForbidden() {
+		return batchForbiddenElement(elem)
+	}
+
 	echo := make(map[string]any, len(elem)+1)
 	maps.Copy(echo, elem)
 	redactCredentials(echo)
@@ -475,6 +493,12 @@ func (s *Server) dispatchBatchElement(el json.RawMessage, baseCtx context.Contex
 // distinct from go-xrpl's XRPL-token error model and appears only inside the
 // batch malformed-element replies, to match rippled byte-for-byte.
 const rpcMethodNotFoundCode = -32601
+
+// forbiddenJSONRPCCode is the JSON-RPC error code rippled attaches to a batch
+// element refused at the role layer (ServerHandler.cpp:607, forbidden = -32605).
+// It is distinct from method_not_found and appears only inside batch
+// forbidden-element replies, matching rippled byte-for-byte.
+const forbiddenJSONRPCCode = -32605
 
 // makeBatchJSONError mirrors rippled's make_json_error (ServerHandler.cpp:594-603):
 // it returns {"error": {"code": code, "message": message}}. rippled assigns this
@@ -498,6 +522,18 @@ func batchMalformedElement(elem map[string]any, message string) map[string]any {
 	r := make(map[string]any, len(elem)+1)
 	maps.Copy(r, elem)
 	r["error"] = makeBatchJSONError(rpcMethodNotFoundCode, message)
+	return r
+}
+
+// batchForbiddenElement builds the reply for a batch element whose admin-only
+// command is refused for a non-admin caller. Like rippled's FORBID branch
+// (ServerHandler.cpp:758-760), the element's own fields are echoed at the top
+// level — unmasked, matching the other early-exit paths — with a forbidden
+// JSON-RPC error attached, rather than the XRPL result envelope.
+func batchForbiddenElement(elem map[string]any) map[string]any {
+	r := make(map[string]any, len(elem)+1)
+	maps.Copy(r, elem)
+	r["error"] = makeBatchJSONError(forbiddenJSONRPCCode, "Forbidden")
 	return r
 }
 
@@ -572,9 +608,13 @@ func redactCredentials(m map[string]any) {
 
 func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types.RpcContext) (any, *types.RpcError) {
 	rpcLog().Debug("rpc", "method", method, "client", ctx.ClientIP)
-	// The HTTP admin gate returns rpcNO_PERMISSION (rippled RPCHandler.cpp:166);
-	// the WS path passes RpcErrorForbidden instead (ServerHandler.cpp:482-486).
-	return dispatchMethod(s.registry, s.loadTracker, s.services, ctx, method, params, types.RpcErrorNoPermission, rpcLog())
+	// Both transports signal a forbidden admin-only command via RpcErrorForbidden.
+	// rippled resolves it at the role layer (Role::FORBID) ahead of the handler
+	// and renders it per transport — HTTP single 403 "Forbidden", batch
+	// make_json_error(forbidden), WS rpcError(rpcFORBIDDEN) (ServerHandler.cpp:482-486,
+	// 750-762). The writers special-case IsForbidden; in-handler permission
+	// denials keep returning rpcNO_PERMISSION on the normal result envelope.
+	return dispatchMethod(s.registry, s.loadTracker, s.services, ctx, method, params, types.RpcErrorForbidden, rpcLog())
 }
 
 // dispatchMethod is the transport-agnostic dispatch core shared by the HTTP
@@ -611,11 +651,15 @@ func dispatchMethod(
 		return nil, rpcErr
 	}
 
-	// Check role permissions — matches rippled RPCHandler.cpp line 166:
-	// if (handler->role_ == Role::ADMIN && context.role != Role::ADMIN)
-	//     return rpcNO_PERMISSION;
+	// Refuse an admin-only command for a non-admin caller. rippled decides this
+	// at the role layer (Role::FORBID) before the handler runs and charges
+	// feeMalformedRPC (ServerHandler.cpp:750-762, :482-486). The gate returns
+	// before the normal finalizeLoad site, so charge here; loadKindFor maps the
+	// forbidden error to the malformed bucket.
 	if handler.RequiredRole() == types.RoleAdmin && ctx.Role != types.RoleAdmin {
-		return nil, adminGate(method)
+		rpcErr := adminGate(method)
+		finalizeLoad(tracker, ctx, method, handler, rpcErr, log)
+		return nil, rpcErr
 	}
 
 	// Enforce the method's precondition, mirroring rippled's RPC::conditionMet
@@ -797,13 +841,14 @@ func finalizeLoad(tracker *loadtrack.Tracker, ctx *types.RpcContext, method stri
 }
 
 // loadKindFor returns the charge bucket to apply for one dispatch. A
-// malformed / unknown-method response is charged LoadMalformed so a
-// client cannot use bad input as a cheap probe (matches rippled's
-// feeMalformedRPC bump in RPCHandler.cpp / ServerHandler.cpp).
+// malformed / unknown-method response, and a role-layer FORBID, are charged
+// LoadMalformed so a client cannot use bad input or admin-probing as a cheap
+// probe (matches rippled's feeMalformedRPC bump in RPCHandler.cpp /
+// ServerHandler.cpp:752,:484).
 func loadKindFor(handler types.MethodHandler, rpcErr *types.RpcError) loadtrack.LoadKind {
 	if rpcErr != nil {
 		switch rpcErr.Code {
-		case types.RpcINVALID_PARAMS, types.RpcMETHOD_NOT_FOUND:
+		case types.RpcINVALID_PARAMS, types.RpcMETHOD_NOT_FOUND, types.RpcFORBIDDEN:
 			return loadtrack.LoadMalformed
 		case types.RpcINTERNAL:
 			return loadtrack.LoadException

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -59,6 +59,18 @@ func (e RpcError) IsInvalidApiVersion() bool {
 	return e.invalidApiVersion
 }
 
+// IsForbidden reports whether this error is the dispatch-layer admin-gate
+// denial (rpcFORBIDDEN): an admin-only command invoked by a non-admin caller.
+// rippled resolves it at the role layer (Role::FORBID) ahead of the handler and
+// renders it per transport — HTTP single → 403 "Forbidden"; batch element →
+// make_json_error(forbidden, "Forbidden"); WS → rpcError(rpcFORBIDDEN) in the
+// result envelope (ServerHandler.cpp:482-486, 750-762) — so the transport
+// writers special-case it. It is distinct from the in-handler rpcNO_PERMISSION
+// rejection, which rides the normal result envelope on every transport.
+func (e RpcError) IsForbidden() bool {
+	return e.Code == RpcFORBIDDEN
+}
+
 func (e RpcError) Error() string {
 	if e.Message != "" {
 		return e.Message

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -271,13 +271,15 @@ func RpcErrorNoPermission(method string) *RpcError {
 		"You don't have permission for this command.")
 }
 
-// RpcErrorForbidden matches rippled rpcFORBIDDEN (code 3, token "forbidden").
-// Used by the WebSocket pre-dispatch admin gate, mirroring rippled
+// RpcErrorForbidden matches rippled rpcFORBIDDEN (code 3, token "forbidden",
+// message "Bad credentials." per the ErrorCodes.cpp errorInfo table). Used by
+// the WebSocket pre-dispatch admin gate, mirroring rippled
 // ServerHandler.cpp:482-486 which writes rpcError(rpcFORBIDDEN) when
-// requestRole returns Role::FORBID for an admin-required command.
+// requestRole returns Role::FORBID for an admin-required command. (The HTTP
+// single and batch transports render their own literal "Forbidden" strings,
+// not this message.)
 func RpcErrorForbidden(method string) *RpcError {
-	return NewRpcError(RpcFORBIDDEN, "forbidden", "forbidden",
-		"You don't have permission for this command.")
+	return NewRpcError(RpcFORBIDDEN, "forbidden", "forbidden", "Bad credentials.")
 }
 
 // RpcErrorTooBusy returns the canonical rpcTOO_BUSY envelope. The


### PR DESCRIPTION
## Summary
- HTTP single-request admin-denial (non-admin → admin-only command) now returns **`403 "Forbidden"`** with `Content-Type: application/json; charset=UTF-8`, instead of a `200` + `{"result":{"error":"noPermission",...}}` envelope — matching rippled's role-layer `HTTPReply(403, "Forbidden")` (`ServerHandler.cpp:750-757`).
- HTTP **batch** admin-denial now renders the element as `make_json_error(forbidden, "Forbidden")` (`forbidden = -32605`) with the element's own fields echoed at the top level, not the XRPL result envelope (`ServerHandler.cpp:758-760`).
- The denial now **charges `feeMalformedRPC`** on both transports (routed through the existing `finalizeLoad`/`loadKindFor` machinery), mirroring `ServerHandler.cpp:752` / `:484`.
- Both transports now signal the dispatch admin gate via `RpcErrorForbidden`, aligning the **token** with rippled (`forbidden`, code 3 = `rpcFORBIDDEN`). In-handler `rpcNO_PERMISSION` rejections (e.g. the `subscribe`-with-`url` admin check) are deliberately unchanged — rippled keeps those on the normal result envelope.

### WS confirmation
The WebSocket path already returned the `forbidden` token (code 3), matching rippled's `rpcError(rpcFORBIDDEN)`; this PR only adds the `feeMalformedRPC` charge there. The top-level-vs-`result` envelope placement of WS errors is a pre-existing, systemic goXRPL shape that applies to *all* WS errors (not specific to forbidden), so it is left out of scope.

### Approach
Implemented the issue's **Option 1** (minimal, mirrors the existing `api_version` precedent): the dispatch core returns `RpcErrorForbidden`, and each transport writer special-cases `RpcError.IsForbidden()` — exactly analogous to how the unsupported-`api_version` rejection is rendered per transport.

## Test plan
- [x] `go test ./internal/rpc/...` (full package + `types`/`handlers`/`loadtrack`/`subscription`) — green
- [x] `go test -race ./internal/rpc/ -run 'AdminDenial|Forbidden|Batch|Dispatch|LoadTracker|WSAdmin'` — green
- [x] `go vet ./internal/rpc/...`, `gofmt`, `go build ./...` — clean
- New `internal/rpc/admin_forbidden_test.go` pins: HTTP single 403 + body + content-type (and admin caller still 200), `feeMalformedRPC` charge (admin bypasses), batch `make_json_error(forbidden, "Forbidden")` shape with a successful sibling element, and an end-to-end WS `forbidden`/code-3 confirmation.

Verified against the local rippled checkout at SHA `1e89286a92` (the SHA named in the issue).

Fixes #940