### PR TITLE
fix: walk owner directory for account_lines/offers/channels

### DIFF
--- a/internal/ledger/service/account_owner_dir_test.go
+++ b/internal/ledger/service/account_owner_dir_test.go
@@ -308,3 +308,128 @@ func TestAccountDirMarkers_Invalid(t *testing.T) {
 		})
 	}
 }
+
+// ownerDirSpansMultiplePages reports whether id's owner directory chains to more
+// than one page (a non-zero IndexNext on the root), so a test can assert it
+// genuinely exercises the cross-page walk rather than the single-page fast path.
+func ownerDirSpansMultiplePages(t *testing.T, svc *Service, id [20]byte) bool {
+	t.Helper()
+	root := keylet.OwnerDir(id).Key
+	data, err := svc.openLedger.Read(keylet.Keylet{Key: root})
+	if err != nil || data == nil {
+		t.Fatalf("read owner dir root: %v", err)
+	}
+	node, err := state.ParseDirectoryNode(data)
+	if err != nil {
+		t.Fatalf("parse owner dir root: %v", err)
+	}
+	return node.IndexNext != 0
+}
+
+// TestAccountOffers_MarkerPaginationAcrossDirPages walks more offers than fit on
+// a single owner-directory page (which holds 32 entries) and asserts the full
+// set comes back exactly once with at least one marker landing on a non-zero
+// owner-node page. That exercises both the IndexNext page traversal and the
+// hintPage jump in ownerDirAfter, not just the single-page path the smaller
+// pagination tests cover.
+func TestAccountOffers_MarkerPaginationAcrossDirPages(t *testing.T) {
+	svc := newOfferTestService(t)
+	issuerAddr, _ := addressFromBytes(t, 0x10)
+	ownerAddr, ownerID := addressFromBytes(t, 0x20)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 0)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+
+	const total = 50
+	for seq := uint32(1); seq <= total; seq++ {
+		insertOffer(t, svc, ownerAddr, seq,
+			state.NewIssuedAmountFromFloat64(float64(seq), "USD", issuerAddr),
+			tx.NewXRPAmount(10_000_000),
+		)
+	}
+	if !ownerDirSpansMultiplePages(t, svc, ownerID) {
+		t.Fatalf("owner directory must span >1 page for %d offers", total)
+	}
+
+	seen := map[uint32]bool{}
+	crossedPage := false
+	marker := ""
+	for page := range total + 5 {
+		res, err := svc.GetAccountOffers(context.Background(), ownerAddr, "current", 20, marker)
+		if err != nil {
+			t.Fatalf("page %d: %v", page, err)
+		}
+		for _, o := range res.Offers {
+			if seen[o.Seq] {
+				t.Fatalf("page %d: duplicate offer seq %d", page, o.Seq)
+			}
+			seen[o.Seq] = true
+		}
+		if res.Marker == "" {
+			break
+		}
+		assertDirMarker(t, res.Marker)
+		if _, pageStr, _ := strings.Cut(res.Marker, ","); pageStr != "0" {
+			crossedPage = true
+		}
+		marker = res.Marker
+	}
+	if len(seen) != total {
+		t.Fatalf("pagination returned %d distinct offers, want %d", len(seen), total)
+	}
+	if !crossedPage {
+		t.Fatal("expected a marker on a non-zero owner-dir page (cross-page resume)")
+	}
+}
+
+// TestAccountChannels_ShortFilteredPageKeepsMarker pins the per-entry limit
+// charging #938 introduced: ownerDirAfter spends the limit on every directory
+// entry visited, not on every entry kept. With limit=1 and a destination filter
+// that excludes the first owner-dir entry, the first page comes back empty yet
+// still carries a marker (the budget was spent on the filtered entry), and the
+// next page returns the matching channel. Mirrors rippled forEachItemAfter,
+// whose lambda counts every visited entry regardless of the filter.
+func TestAccountChannels_ShortFilteredPageKeepsMarker(t *testing.T) {
+	svc := newOfferTestService(t)
+	srcAddr, srcID := addressFromBytes(t, 0x10)
+	dAddr, _ := addressFromBytes(t, 0x40)
+	eAddr, _ := addressFromBytes(t, 0x50)
+	insertAccountRoot(t, svc, srcAddr, 1_000_000_000_000, 0)
+
+	k1 := insertPayChannelEntry(t, svc, srcAddr, dAddr, 1, nil)
+	k2 := insertPayChannelEntry(t, svc, srcAddr, eAddr, 2, nil)
+	keyToDst := map[[32]byte]string{k1: dAddr, k2: eAddr}
+
+	order := ownerDirOrder(t, svc, srcID)
+	if len(order) != 2 {
+		t.Fatalf("want 2 owner-dir entries, got %d", len(order))
+	}
+	// Filter on the destination of the second owner-dir entry, so the first entry
+	// visited is filtered out and the page must come back short.
+	target := keyToDst[order[1]]
+
+	page1, err := svc.GetAccountChannels(context.Background(), srcAddr, target, "current", 1, "")
+	if err != nil {
+		t.Fatalf("page1: %v", err)
+	}
+	if len(page1.Channels) != 0 {
+		t.Fatalf("page1 must be empty (first entry filtered out), got %d", len(page1.Channels))
+	}
+	if page1.Marker == "" {
+		t.Fatal("page1 must carry a marker: the limit is charged per entry visited, not per kept")
+	}
+	assertDirMarker(t, page1.Marker)
+
+	page2, err := svc.GetAccountChannels(context.Background(), srcAddr, target, "current", 1, page1.Marker)
+	if err != nil {
+		t.Fatalf("page2: %v", err)
+	}
+	if len(page2.Channels) != 1 {
+		t.Fatalf("page2 must return the matching channel, got %d", len(page2.Channels))
+	}
+	if page2.Channels[0].DestinationAccount != target {
+		t.Fatalf("page2 destination = %s, want %s", page2.Channels[0].DestinationAccount, target)
+	}
+	if page2.Marker != "" {
+		t.Fatalf("page2 must be the final page (no marker), got %q", page2.Marker)
+	}
+}

--- a/internal/ledger/service/account_owner_dir_test.go
+++ b/internal/ledger/service/account_owner_dir_test.go
@@ -1,0 +1,310 @@
+package service
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// assertDirMarker checks that a non-empty account_lines/offers/channels marker is
+// "<64-hex entryKey>,<decimal ownerNode>" — the rippled forEachItemAfter shape.
+func assertDirMarker(t *testing.T, marker string) {
+	t.Helper()
+	keyStr, pageStr, found := strings.Cut(marker, ",")
+	if !found {
+		t.Fatalf("marker %q is missing the ',' separator", marker)
+	}
+	if len(keyStr) != 64 {
+		t.Fatalf("marker key half %q is not 64 hex chars", keyStr)
+	}
+	if _, err := hex.DecodeString(keyStr); err != nil {
+		t.Fatalf("marker key half %q is not hex: %v", keyStr, err)
+	}
+	if _, err := strconv.ParseUint(pageStr, 10, 64); err != nil {
+		t.Fatalf("marker page half %q is not a uint64: %v", pageStr, err)
+	}
+}
+
+// ownerDirOrder returns the keys in an account's owner directory in walk order.
+func ownerDirOrder(t *testing.T, svc *Service, id [20]byte) [][32]byte {
+	t.Helper()
+	var keys [][32]byte
+	if err := state.DirForEach(svc.openLedger, keylet.OwnerDir(id), func(k [32]byte) error {
+		keys = append(keys, k)
+		return nil
+	}); err != nil {
+		t.Fatalf("walk owner dir: %v", err)
+	}
+	return keys
+}
+
+// TestAccountOffers_ExcludesIssuerOnlyOffer pins the headline correctness
+// property of #938: an offer owned by B that merely *mentions* A (as the issuer
+// of the IOU it sells) must not appear in A's results. Walking A's owner
+// directory never reaches B's offer, where the old whole-ledger byte-scan did.
+func TestAccountOffers_ExcludesIssuerOnlyOffer(t *testing.T) {
+	svc := newOfferTestService(t)
+	issuerAddr, issuerID := addressFromBytes(t, 0x10) // A, the IOU issuer
+	ownerAddr, _ := addressFromBytes(t, 0x20)         // B, the offer owner
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 0)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+
+	// B offers to buy A's USD with XRP — A's account ID is embedded as issuer.
+	insertOffer(t, svc, ownerAddr, 1,
+		state.NewIssuedAmountFromFloat64(100, "USD", issuerAddr),
+		tx.NewXRPAmount(10_000_000),
+	)
+
+	// A owns nothing.
+	aOffers, err := svc.GetAccountOffers(context.Background(), issuerAddr, "current", 0, "")
+	if err != nil {
+		t.Fatalf("GetAccountOffers(A): %v", err)
+	}
+	if len(aOffers.Offers) != 0 {
+		t.Fatalf("A must not see B's offer (issuer-only mention), got %d", len(aOffers.Offers))
+	}
+
+	// account_objects for A must also be empty (no owner-dir entries).
+	aObjects, err := svc.GetAccountObjects(context.Background(), issuerAddr, "current", "", 0, "")
+	if err != nil {
+		t.Fatalf("GetAccountObjects(A): %v", err)
+	}
+	if len(aObjects.AccountObjects) != 0 {
+		t.Fatalf("A's account_objects must be empty, got %d", len(aObjects.AccountObjects))
+	}
+
+	// B genuinely owns the offer.
+	bOffers, err := svc.GetAccountOffers(context.Background(), ownerAddr, "current", 0, "")
+	if err != nil {
+		t.Fatalf("GetAccountOffers(B): %v", err)
+	}
+	if len(bOffers.Offers) != 1 {
+		t.Fatalf("B must own exactly 1 offer, got %d", len(bOffers.Offers))
+	}
+	_ = issuerID
+}
+
+// TestAccountChannels_ExcludesDestinationChannel: a payment channel lives in both
+// the source and destination owner directories, but account_channels reports only
+// channels the account is the *source* of. Querying the destination must return
+// nothing even though the channel sits in its owner directory.
+func TestAccountChannels_ExcludesDestinationChannel(t *testing.T) {
+	svc := newOfferTestService(t)
+	srcAddr, _ := addressFromBytes(t, 0x10)
+	dstAddr, _ := addressFromBytes(t, 0x40)
+	insertAccountRoot(t, svc, srcAddr, 1_000_000_000_000, 0)
+	insertAccountRoot(t, svc, dstAddr, 1_000_000_000_000, 0)
+
+	insertPayChannelEntry(t, svc, srcAddr, dstAddr, 1, nil)
+
+	src, err := svc.GetAccountChannels(context.Background(), srcAddr, "", "current", 0, "")
+	if err != nil {
+		t.Fatalf("GetAccountChannels(src): %v", err)
+	}
+	if len(src.Channels) != 1 {
+		t.Fatalf("source must report 1 channel, got %d", len(src.Channels))
+	}
+
+	dst, err := svc.GetAccountChannels(context.Background(), dstAddr, "", "current", 0, "")
+	if err != nil {
+		t.Fatalf("GetAccountChannels(dst): %v", err)
+	}
+	if len(dst.Channels) != 0 {
+		t.Fatalf("destination must report 0 channels (not source-owned), got %d", len(dst.Channels))
+	}
+}
+
+// TestAccountLines_OrderMatchesOwnerDir verifies the lines come back in
+// owner-directory order, not SHAMap-key order.
+func TestAccountLines_OrderMatchesOwnerDir(t *testing.T) {
+	svc := newOfferTestService(t)
+	aAddr, aID := addressFromBytes(t, 0x10)
+	bAddr, _ := addressFromBytes(t, 0x40)
+	cAddr, _ := addressFromBytes(t, 0x50)
+	dAddr, _ := addressFromBytes(t, 0x60)
+	insertAccountRoot(t, svc, aAddr, 1_000_000_000_000, 0)
+	insertLineRaw(t, svc, aAddr, bAddr, "USD", "0", "100", "100", 0)
+	insertLineRaw(t, svc, aAddr, cAddr, "EUR", "0", "100", "100", 0)
+	insertLineRaw(t, svc, aAddr, dAddr, "GBP", "0", "100", "100", 0)
+
+	res, err := svc.GetAccountLines(context.Background(), aAddr, "current", "", 0, "")
+	if err != nil {
+		t.Fatalf("GetAccountLines: %v", err)
+	}
+	if len(res.Lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(res.Lines))
+	}
+
+	// Expected order: map each owner-dir key to its line currency.
+	wantOrder := make([]string, 0, 3)
+	for _, k := range ownerDirOrder(t, svc, aID) {
+		data, rerr := svc.openLedger.Read(keylet.Keylet{Key: k})
+		if rerr != nil || data == nil {
+			t.Fatalf("read owner-dir entry: %v", rerr)
+		}
+		rs, perr := state.ParseRippleState(data)
+		if perr != nil {
+			t.Fatalf("parse ripple state: %v", perr)
+		}
+		wantOrder = append(wantOrder, rs.Balance.Currency)
+	}
+	for i, ln := range res.Lines {
+		if ln.Currency != wantOrder[i] {
+			t.Fatalf("line %d currency = %s, want %s (owner-dir order %v)", i, ln.Currency, wantOrder[i], wantOrder)
+		}
+	}
+}
+
+// TestAccountLines_MarkerPagination walks every line one page at a time and
+// asserts the full set is returned exactly once, the marker is rippled-shaped,
+// and the final page carries no marker.
+func TestAccountLines_MarkerPagination(t *testing.T) {
+	svc := newOfferTestService(t)
+	aAddr, _ := addressFromBytes(t, 0x10)
+	bAddr, _ := addressFromBytes(t, 0x40)
+	cAddr, _ := addressFromBytes(t, 0x50)
+	dAddr, _ := addressFromBytes(t, 0x60)
+	insertAccountRoot(t, svc, aAddr, 1_000_000_000_000, 0)
+	insertLineRaw(t, svc, aAddr, bAddr, "USD", "0", "100", "100", 0)
+	insertLineRaw(t, svc, aAddr, cAddr, "EUR", "0", "100", "100", 0)
+	insertLineRaw(t, svc, aAddr, dAddr, "GBP", "0", "100", "100", 0)
+
+	seen := map[string]bool{}
+	marker := ""
+	for page := range 10 {
+		res, err := svc.GetAccountLines(context.Background(), aAddr, "current", "", 1, marker)
+		if err != nil {
+			t.Fatalf("page %d: %v", page, err)
+		}
+		if len(res.Lines) != 1 {
+			t.Fatalf("page %d: expected 1 line, got %d", page, len(res.Lines))
+		}
+		peer := res.Lines[0].Account
+		if seen[peer] {
+			t.Fatalf("page %d: duplicate line for %s", page, peer)
+		}
+		seen[peer] = true
+
+		if res.Marker == "" {
+			break
+		}
+		assertDirMarker(t, res.Marker)
+		marker = res.Marker
+	}
+	if len(seen) != 3 {
+		t.Fatalf("pagination returned %d distinct lines, want 3", len(seen))
+	}
+}
+
+// TestAccountOffers_MarkerPagination mirrors the lines pagination walk for offers.
+func TestAccountOffers_MarkerPagination(t *testing.T) {
+	svc := newOfferTestService(t)
+	issuerAddr, _ := addressFromBytes(t, 0x10)
+	ownerAddr, _ := addressFromBytes(t, 0x20)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 0)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+	for seq := uint32(1); seq <= 3; seq++ {
+		insertOffer(t, svc, ownerAddr, seq,
+			state.NewIssuedAmountFromFloat64(float64(100*seq), "USD", issuerAddr),
+			tx.NewXRPAmount(10_000_000),
+		)
+	}
+
+	seen := map[uint32]bool{}
+	marker := ""
+	for page := range 10 {
+		res, err := svc.GetAccountOffers(context.Background(), ownerAddr, "current", 1, marker)
+		if err != nil {
+			t.Fatalf("page %d: %v", page, err)
+		}
+		if len(res.Offers) != 1 {
+			t.Fatalf("page %d: expected 1 offer, got %d", page, len(res.Offers))
+		}
+		if seen[res.Offers[0].Seq] {
+			t.Fatalf("page %d: duplicate offer seq %d", page, res.Offers[0].Seq)
+		}
+		seen[res.Offers[0].Seq] = true
+		if res.Marker == "" {
+			break
+		}
+		assertDirMarker(t, res.Marker)
+		marker = res.Marker
+	}
+	if len(seen) != 3 {
+		t.Fatalf("pagination returned %d distinct offers, want 3", len(seen))
+	}
+}
+
+// TestAccountChannels_MarkerPagination mirrors the pagination walk for channels.
+func TestAccountChannels_MarkerPagination(t *testing.T) {
+	svc := newOfferTestService(t)
+	srcAddr, _ := addressFromBytes(t, 0x10)
+	insertAccountRoot(t, svc, srcAddr, 1_000_000_000_000, 0)
+	dsts := []byte{0x40, 0x50, 0x60}
+	for i, seed := range dsts {
+		dstAddr, _ := addressFromBytes(t, seed)
+		insertPayChannelEntry(t, svc, srcAddr, dstAddr, uint32(i+1), nil)
+	}
+
+	seen := map[string]bool{}
+	marker := ""
+	for page := range 10 {
+		res, err := svc.GetAccountChannels(context.Background(), srcAddr, "", "current", 1, marker)
+		if err != nil {
+			t.Fatalf("page %d: %v", page, err)
+		}
+		if len(res.Channels) != 1 {
+			t.Fatalf("page %d: expected 1 channel, got %d", page, len(res.Channels))
+		}
+		id := res.Channels[0].ChannelID
+		if seen[id] {
+			t.Fatalf("page %d: duplicate channel %s", page, id)
+		}
+		seen[id] = true
+		if res.Marker == "" {
+			break
+		}
+		assertDirMarker(t, res.Marker)
+		marker = res.Marker
+	}
+	if len(seen) != 3 {
+		t.Fatalf("pagination returned %d distinct channels, want 3", len(seen))
+	}
+}
+
+// TestAccountDirMarkers_Invalid covers the malformed and stale marker tiers for
+// the owner-directory RPCs: both must surface as ErrInvalidMarker.
+func TestAccountDirMarkers_Invalid(t *testing.T) {
+	svc := newOfferTestService(t)
+	aAddr, _ := addressFromBytes(t, 0x10)
+	bAddr, _ := addressFromBytes(t, 0x40)
+	insertAccountRoot(t, svc, aAddr, 1_000_000_000_000, 0)
+	insertLineRaw(t, svc, aAddr, bAddr, "USD", "0", "100", "100", 0)
+
+	cases := []struct {
+		name   string
+		marker string
+	}{
+		{"no separator", "deadbeef"},
+		{"bad hex key", strings.Repeat("z", 64) + ",0"},
+		{"short key", "ABCD,0"},
+		{"bad page", strings.Repeat("AB", 32) + ",notanumber"},
+		{"key not in dir", strings.Repeat("AB", 32) + ",0"},
+	}
+	for _, tc := range cases {
+		t.Run("lines/"+tc.name, func(t *testing.T) {
+			_, err := svc.GetAccountLines(context.Background(), aAddr, "current", "", 0, tc.marker)
+			if !errors.Is(err, svcerr.ErrInvalidMarker) {
+				t.Fatalf("marker %q: want ErrInvalidMarker, got %v", tc.marker, err)
+			}
+		})
+	}
+}

--- a/internal/ledger/service/account_owner_dir_test.go
+++ b/internal/ledger/service/account_owner_dir_test.go
@@ -298,6 +298,7 @@ func TestAccountDirMarkers_Invalid(t *testing.T) {
 		{"short key", "ABCD,0"},
 		{"bad page", strings.Repeat("AB", 32) + ",notanumber"},
 		{"key not in dir", strings.Repeat("AB", 32) + ",0"},
+		{"zero-shorthand key", "0,0"},
 	}
 	for _, tc := range cases {
 		t.Run("lines/"+tc.name, func(t *testing.T) {
@@ -431,5 +432,83 @@ func TestAccountChannels_ShortFilteredPageKeepsMarker(t *testing.T) {
 	}
 	if page2.Marker != "" {
 		t.Fatalf("page2 must be the final page (no marker), got %q", page2.Marker)
+	}
+}
+
+// TestAccountOffers_MarkerIgnoresTrailingSegment pins that a marker with an
+// extra trailing ",<junk>" segment resumes exactly as the clean marker would.
+// rippled reads the hint as the second comma-delimited field and ignores the
+// rest (std::getline), so the marker parser must do the same.
+func TestAccountOffers_MarkerIgnoresTrailingSegment(t *testing.T) {
+	svc := newOfferTestService(t)
+	issuerAddr, _ := addressFromBytes(t, 0x10)
+	ownerAddr, _ := addressFromBytes(t, 0x20)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 0)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+	for seq := uint32(1); seq <= 2; seq++ {
+		insertOffer(t, svc, ownerAddr, seq,
+			state.NewIssuedAmountFromFloat64(float64(seq), "USD", issuerAddr),
+			tx.NewXRPAmount(10_000_000),
+		)
+	}
+
+	page1, err := svc.GetAccountOffers(context.Background(), ownerAddr, "current", 1, "")
+	if err != nil {
+		t.Fatalf("page1: %v", err)
+	}
+	if page1.Marker == "" {
+		t.Fatal("page1 must carry a marker")
+	}
+
+	clean, err := svc.GetAccountOffers(context.Background(), ownerAddr, "current", 1, page1.Marker)
+	if err != nil {
+		t.Fatalf("clean resume: %v", err)
+	}
+	dirty, err := svc.GetAccountOffers(context.Background(), ownerAddr, "current", 1, page1.Marker+",999")
+	if err != nil {
+		t.Fatalf("dirty resume (trailing segment must be ignored): %v", err)
+	}
+	if len(clean.Offers) != 1 || len(dirty.Offers) != 1 {
+		t.Fatalf("expected 1 offer per resumed page, got clean=%d dirty=%d", len(clean.Offers), len(dirty.Offers))
+	}
+	if dirty.Offers[0].Seq != clean.Offers[0].Seq {
+		t.Fatalf("dirty marker resumed to seq %d, clean to %d", dirty.Offers[0].Seq, clean.Offers[0].Seq)
+	}
+}
+
+// TestAccountOffers_PhantomDirEntryDoesNotConsumeLimit pins that a directory
+// entry whose backing object is missing is skipped without charging the limit
+// (rippled's null-SLE traversal). With one phantom entry and one real offer at
+// limit=1, the real offer comes back on a single page with no marker — the
+// phantom neither consumes the slot nor becomes a marker.
+func TestAccountOffers_PhantomDirEntryDoesNotConsumeLimit(t *testing.T) {
+	svc := newOfferTestService(t)
+	issuerAddr, _ := addressFromBytes(t, 0x10)
+	ownerAddr, ownerID := addressFromBytes(t, 0x20)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000_000, 0)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000_000, 0)
+
+	insertOffer(t, svc, ownerAddr, 1,
+		state.NewIssuedAmountFromFloat64(100, "USD", issuerAddr),
+		tx.NewXRPAmount(10_000_000),
+	)
+	// Link a key with no backing ledger object into the owner directory.
+	var phantom [32]byte
+	for i := range phantom {
+		phantom[i] = 0xEE
+	}
+	if _, derr := state.DirInsert(svc.openLedger, keylet.OwnerDir(ownerID), phantom, false, nil); derr != nil {
+		t.Fatalf("owner dir insert (phantom): %v", derr)
+	}
+
+	res, err := svc.GetAccountOffers(context.Background(), ownerAddr, "current", 1, "")
+	if err != nil {
+		t.Fatalf("GetAccountOffers: %v", err)
+	}
+	if len(res.Offers) != 1 {
+		t.Fatalf("expected 1 real offer (phantom skipped), got %d", len(res.Offers))
+	}
+	if res.Marker != "" {
+		t.Fatalf("phantom must not produce a marker, got %q", res.Marker)
 	}
 }

--- a/internal/ledger/service/account_query.go
+++ b/internal/ledger/service/account_query.go
@@ -65,7 +65,6 @@ func parseDirMarker(marker string) (afterKey [32]byte, page uint64, present bool
 	return key, p, true, nil
 }
 
-// formatDirMarker renders the "<entryKey>,<ownerNode>" resume marker.
 func formatDirMarker(key [32]byte, page uint64) string {
 	return formatHashHex(key) + "," + strconv.FormatUint(page, 10)
 }

--- a/internal/ledger/service/account_query.go
+++ b/internal/ledger/service/account_query.go
@@ -50,14 +50,17 @@ func parseDirMarker(marker string) (afterKey [32]byte, page uint64, present bool
 	if marker == "" {
 		return afterKey, 0, false, nil
 	}
-	keyStr, pageStr, found := strings.Cut(marker, ",")
+	keyStr, rest, found := strings.Cut(marker, ",")
 	if !found {
 		return afterKey, 0, false, svcerr.ErrInvalidMarker
 	}
-	key, ok := markerUint256(keyStr)
-	if !ok {
+	var key [32]byte
+	if derr := decodeHex32Into(keyStr, &key); derr != nil {
 		return afterKey, 0, false, svcerr.ErrInvalidMarker
 	}
+	// rippled reads the hint as the second comma-delimited field and ignores any
+	// trailing content (std::getline up to the next ','); mirror that.
+	pageStr, _, _ := strings.Cut(rest, ",")
 	p, perr := strconv.ParseUint(pageStr, 10, 64)
 	if perr != nil {
 		return afterKey, 0, false, svcerr.ErrInvalidMarker
@@ -785,19 +788,22 @@ func ownerDirAfter(
 				}
 				continue
 			}
+			data, rerr := l.Read(keylet.Keylet{Key: key})
+			if rerr != nil {
+				return "", found, rerr
+			}
+			if data == nil {
+				// A directory entry with no backing object is skipped without
+				// charging the limit, mirroring rippled's null-SLE traversal.
+				continue
+			}
 			if count >= limit {
 				// A further entry exists beyond the page limit.
 				hasMore = true
 				break
 			}
-			data, rerr := l.Read(keylet.Keylet{Key: key})
-			if rerr != nil {
-				return "", found, rerr
-			}
 			count++
-			if data != nil {
-				visit(key, data)
-			}
+			visit(key, data)
 			if count == limit {
 				markerKey = key
 				markerPage = page

--- a/internal/ledger/service/account_query.go
+++ b/internal/ledger/service/account_query.go
@@ -41,20 +41,33 @@ type AccountInfoResult struct {
 	Index             [32]byte // SLE key (keylet hash)
 }
 
-// parseQueryMarker decodes a paginated-query resume marker. The marker is the
-// 64-char-hex ledger-state key of the last entry returned on the previous page;
-// the scan resumes at the first key strictly greater than it. An empty marker
-// means "start from the beginning"; a malformed one yields svcerr.ErrInvalidMarker.
-func parseQueryMarker(marker string) (key [32]byte, present bool, err error) {
+// parseDirMarker decodes the resume marker shared by account_lines,
+// account_offers and account_channels: "<entryKey>,<ownerNode>" — the ledger key
+// of the last entry returned plus the owner-directory page it sat on (the resume
+// hint). Mirrors rippled's forEachItemAfter marker. An empty marker means "start
+// from the beginning"; a malformed one yields svcerr.ErrInvalidMarker.
+func parseDirMarker(marker string) (afterKey [32]byte, page uint64, present bool, err error) {
 	if marker == "" {
-		return key, false, nil
+		return afterKey, 0, false, nil
 	}
-	raw, decErr := hex.DecodeString(marker)
-	if decErr != nil || len(raw) != 32 {
-		return key, false, svcerr.ErrInvalidMarker
+	keyStr, pageStr, found := strings.Cut(marker, ",")
+	if !found {
+		return afterKey, 0, false, svcerr.ErrInvalidMarker
 	}
-	copy(key[:], raw)
-	return key, true, nil
+	key, ok := markerUint256(keyStr)
+	if !ok {
+		return afterKey, 0, false, svcerr.ErrInvalidMarker
+	}
+	p, perr := strconv.ParseUint(pageStr, 10, 64)
+	if perr != nil {
+		return afterKey, 0, false, svcerr.ErrInvalidMarker
+	}
+	return key, p, true, nil
+}
+
+// formatDirMarker renders the "<entryKey>,<ownerNode>" resume marker.
+func formatDirMarker(key [32]byte, page uint64) string {
+	return formatHashHex(key) + "," + strconv.FormatUint(page, 10)
 }
 
 // GetAccountInfo retrieves account information from the ledger
@@ -169,7 +182,7 @@ func (s *Service) GetAccountLines(ctx context.Context, account string, ledgerInd
 		return nil, err
 	}
 
-	markerKey, hasMarker, err := parseQueryMarker(marker)
+	afterKey, hintPage, hasMarker, err := parseDirMarker(marker)
 	if err != nil {
 		return nil, err
 	}
@@ -200,46 +213,23 @@ func (s *Service) GetAccountLines(ctx context.Context, account string, ledgerInd
 		limit = 200
 	}
 
-	// Collect trust lines by iterating through ledger entries
 	var lines []TrustLine
-	var lastKey [32]byte
-	truncated := false
-
-	targetLedger.ForEachCtx(ctx, func(key [32]byte, data []byte) bool {
-		if ctx.Err() != nil {
-			return false
+	visit := func(_ [32]byte, data []byte) {
+		if state.EntryType(data) != "RippleState" {
+			return
 		}
-		if hasMarker && bytes.Compare(key[:], markerKey[:]) <= 0 {
-			return true
+		rs, perr := state.ParseRippleState(data)
+		if perr != nil {
+			return
 		}
 
-		// Check if this is a RippleState entry (trust line)
-		if len(data) < 3 {
-			return true
-		}
-
-		// Check LedgerEntryType field
-		if data[0] != 0x11 { // UInt16 type code 1, field code 1
-			return true
-		}
-		entryType := uint16(data[1])<<8 | uint16(data[2])
-		if entryType != 0x0072 { // RippleState type
-			return true
-		}
-
-		// Parse the RippleState
-		rs, err := state.ParseRippleState(data)
-		if err != nil {
-			return true
-		}
-
-		// Check if this trust line involves our account
+		// Determine which side of the line the account sits on. Owner-directory
+		// membership guarantees one side matches; the default guard is defensive.
 		lowID, _ := decodeAccountIDLocal(rs.LowLimit.Issuer)
 		highID, _ := decodeAccountIDLocal(rs.HighLimit.Issuer)
 
 		var isLowAccount bool
 		var peerAccount string
-
 		if lowID == accountID {
 			isLowAccount = true
 			peerAccount = rs.HighLimit.Issuer
@@ -247,34 +237,25 @@ func (s *Service) GetAccountLines(ctx context.Context, account string, ledgerInd
 			isLowAccount = false
 			peerAccount = rs.LowLimit.Issuer
 		} else {
-			return true // Not our account
+			return
 		}
 
 		// Filter by peer if specified
 		if hasPeer {
 			peerAccountID, _ := decodeAccountIDLocal(peerAccount)
 			if peerAccountID != peerID {
-				return true
+				return
 			}
 		}
 
-		if uint32(len(lines)) >= limit {
-			truncated = true
-			return false
-		}
-
-		// Build trust line response
 		line := TrustLine{
 			Account:  peerAccount,
 			Currency: rs.Balance.Currency,
 		}
 
-		// Calculate balance from perspective of our account
-		// Positive balance means peer owes us, negative means we owe peer
+		// Calculate balance from perspective of our account.
+		// Positive balance means peer owes us, negative means we owe peer.
 		if isLowAccount {
-			// We are low account
-			// Balance is positive if low owes high (we owe them) -> negative for us
-			// Balance is negative if high owes low (they owe us) -> positive for us
 			line.Balance = rs.Balance.Negate().Value()
 			line.Limit = rs.LowLimit.Value()
 			line.LimitPeer = rs.HighLimit.Value()
@@ -287,7 +268,6 @@ func (s *Service) GetAccountLines(ctx context.Context, account string, ledgerInd
 			line.QualityIn = rs.LowQualityIn
 			line.QualityOut = rs.LowQualityOut
 		} else {
-			// We are high account
 			line.Balance = rs.Balance.Value()
 			line.Limit = rs.HighLimit.Value()
 			line.LimitPeer = rs.LowLimit.Value()
@@ -302,24 +282,24 @@ func (s *Service) GetAccountLines(ctx context.Context, account string, ledgerInd
 		}
 
 		lines = append(lines, line)
-		lastKey = key
-		return true
-	})
-	if err := ctx.Err(); err != nil {
-		return nil, err
 	}
 
-	result := &AccountLinesResult{
+	markerStr, found, err := ownerDirAfter(ctx, targetLedger, accountID, limit, afterKey, hintPage, hasMarker, visit)
+	if err != nil {
+		return nil, err
+	}
+	if hasMarker && !found {
+		return nil, svcerr.ErrInvalidMarker
+	}
+
+	return &AccountLinesResult{
 		Account:     account,
 		Lines:       lines,
 		LedgerIndex: targetLedger.Sequence(),
 		LedgerHash:  targetLedger.Hash(),
 		Validated:   validated,
-	}
-	if truncated {
-		result.Marker = formatHashHex(lastKey)
-	}
-	return result, nil
+		Marker:      markerStr,
+	}, nil
 }
 
 // AccountOffer represents an offer from account_offers RPC
@@ -356,7 +336,7 @@ func (s *Service) GetAccountOffers(ctx context.Context, account string, ledgerIn
 		return nil, err
 	}
 
-	markerKey, hasMarker, err := parseQueryMarker(marker)
+	afterKey, hintPage, hasMarker, err := parseDirMarker(marker)
 	if err != nil {
 		return nil, err
 	}
@@ -374,51 +354,16 @@ func (s *Service) GetAccountOffers(ctx context.Context, account string, ledgerIn
 		limit = 200
 	}
 
-	// Collect offers by iterating through ledger entries
 	var offers []AccountOffer
-	var lastKey [32]byte
-	truncated := false
-
-	targetLedger.ForEachCtx(ctx, func(key [32]byte, data []byte) bool {
-		if ctx.Err() != nil {
-			return false
+	visit := func(_ [32]byte, data []byte) {
+		if state.EntryType(data) != "Offer" {
+			return
 		}
-		if hasMarker && bytes.Compare(key[:], markerKey[:]) <= 0 {
-			return true
+		offer, perr := state.ParseLedgerOffer(data)
+		if perr != nil {
+			return
 		}
 
-		// Check if this is an Offer entry
-		if len(data) < 3 {
-			return true
-		}
-
-		// Check LedgerEntryType field
-		if data[0] != 0x11 { // UInt16 type code 1, field code 1
-			return true
-		}
-		entryType := uint16(data[1])<<8 | uint16(data[2])
-		if entryType != 0x006F { // Offer type
-			return true
-		}
-
-		// Parse the Offer
-		offer, err := state.ParseLedgerOffer(data)
-		if err != nil {
-			return true
-		}
-
-		// Check if this offer belongs to our account
-		offerAccountID, _ := decodeAccountIDLocal(offer.Account)
-		if offerAccountID != accountID {
-			return true
-		}
-
-		if uint32(len(offers)) >= limit {
-			truncated = true
-			return false
-		}
-
-		// Build offer response
 		accountOffer := AccountOffer{
 			Flags: offer.Flags,
 			Seq:   offer.Sequence,
@@ -446,7 +391,6 @@ func (s *Service) GetAccountOffers(ctx context.Context, account string, ledgerIn
 			}
 		}
 
-		// Calculate quality
 		accountOffer.Quality = qualityFromBookDir(offer.BookDirectory)
 
 		if offer.Expiration > 0 {
@@ -454,24 +398,24 @@ func (s *Service) GetAccountOffers(ctx context.Context, account string, ledgerIn
 		}
 
 		offers = append(offers, accountOffer)
-		lastKey = key
-		return true
-	})
-	if err := ctx.Err(); err != nil {
-		return nil, err
 	}
 
-	result := &AccountOffersResult{
+	markerStr, found, err := ownerDirAfter(ctx, targetLedger, accountID, limit, afterKey, hintPage, hasMarker, visit)
+	if err != nil {
+		return nil, err
+	}
+	if hasMarker && !found {
+		return nil, svcerr.ErrInvalidMarker
+	}
+
+	return &AccountOffersResult{
 		Account:     account,
 		Offers:      offers,
 		LedgerIndex: targetLedger.Sequence(),
 		LedgerHash:  targetLedger.Hash(),
 		Validated:   validated,
-	}
-	if truncated {
-		result.Marker = formatHashHex(lastKey)
-	}
-	return result, nil
+		Marker:      markerStr,
+	}, nil
 }
 
 // AccountObjectsResult contains account objects
@@ -771,6 +715,111 @@ func indexOfHash(entries [][32]byte, key [32]byte) int {
 	return -1
 }
 
+// ownerDirAfter walks accountID's owner directory in directory order and invokes
+// visit for each entry, resuming strictly after afterKey when hasMarker. It
+// mirrors rippled's forEachItemAfter plus the pagination shared by account_lines,
+// account_offers and account_channels: it jumps to hintPage first (falling back
+// to a scan from the root if afterKey is not there), and charges limit per
+// directory entry visited rather than per entry kept — so a filtered page can
+// come back short but still carry a marker. It returns the "<entryKey>,<ownerNode>"
+// resume marker when an entry beyond the limit exists, and found=false when a
+// non-empty resume marker could not be located (reported by callers as an
+// invalid marker).
+func ownerDirAfter(
+	ctx context.Context,
+	l *ledger.Ledger,
+	accountID [20]byte,
+	limit uint32,
+	afterKey [32]byte,
+	hintPage uint64,
+	hasMarker bool,
+	visit func(key [32]byte, data []byte),
+) (marker string, found bool, err error) {
+	root := keylet.OwnerDir(accountID).Key
+
+	readPage := func(page uint64) (*state.DirectoryNode, error) {
+		key := root
+		if page != 0 {
+			key = keylet.DirPage(root, page).Key
+		}
+		data, rerr := l.Read(keylet.Keylet{Key: key})
+		if rerr != nil || data == nil {
+			return nil, rerr
+		}
+		return state.ParseDirectoryNode(data)
+	}
+
+	// Resolve the starting page. When resuming, prefer the hint page if it still
+	// holds afterKey; otherwise scan from the root and skip to afterKey.
+	page := uint64(0)
+	found = !hasMarker
+	if hasMarker && hintPage != 0 {
+		hp, herr := readPage(hintPage)
+		if herr != nil {
+			return "", false, herr
+		}
+		if hp != nil && indexOfHash(hp.Indexes, afterKey) >= 0 {
+			page = hintPage
+		}
+	}
+
+	var count uint32
+	var markerKey [32]byte
+	var markerPage uint64
+	hasMore := false
+
+	for {
+		if cerr := ctx.Err(); cerr != nil {
+			return "", found, cerr
+		}
+		node, perr := readPage(page)
+		if perr != nil {
+			return "", found, perr
+		}
+		if node == nil {
+			break
+		}
+		for _, key := range node.Indexes {
+			if !found {
+				if key == afterKey {
+					found = true
+				}
+				continue
+			}
+			if count >= limit {
+				// A further entry exists beyond the page limit.
+				hasMore = true
+				break
+			}
+			data, rerr := l.Read(keylet.Keylet{Key: key})
+			if rerr != nil {
+				return "", found, rerr
+			}
+			count++
+			if data != nil {
+				visit(key, data)
+			}
+			if count == limit {
+				markerKey = key
+				markerPage = page
+			}
+		}
+		if hasMore {
+			break
+		}
+		next := node.IndexNext
+		if next == 0 {
+			break
+		}
+		page = next
+	}
+
+	if hasMore {
+		marker = formatDirMarker(markerKey, markerPage)
+	}
+	return marker, found, nil
+}
+
 // OwnerInfoResult groups an account's owner-directory offers and trust lines.
 type OwnerInfoResult struct {
 	Offers      []AccountObjectItem
@@ -889,7 +938,7 @@ func (s *Service) GetAccountChannels(ctx context.Context, account string, destin
 		return nil, err
 	}
 
-	markerKey, hasMarker, err := parseQueryMarker(marker)
+	afterKey, hintPage, hasMarker, err := parseDirMarker(marker)
 	if err != nil {
 		return nil, err
 	}
@@ -930,55 +979,27 @@ func (s *Service) GetAccountChannels(ctx context.Context, account string, destin
 		limit = 256
 	}
 
-	// Collect payment channels by iterating through ledger entries
 	var channels []AccountChannel
-	var lastKey [32]byte
-	truncated := false
-
-	targetLedger.ForEachCtx(ctx, func(key [32]byte, data []byte) bool {
-		if ctx.Err() != nil {
-			return false
+	visit := func(key [32]byte, data []byte) {
+		if state.EntryType(data) != "PayChannel" {
+			return
 		}
-		if hasMarker && bytes.Compare(key[:], markerKey[:]) <= 0 {
-			return true
+		payChan, perr := state.ParsePayChannel(data)
+		if perr != nil {
+			return
 		}
 
-		// Check if this is a PayChannel entry
-		if len(data) < 3 {
-			return true
-		}
-
-		// Check LedgerEntryType field
-		if data[0] != 0x11 { // UInt16 type code 1, field code 1
-			return true
-		}
-		entryType := uint16(data[1])<<8 | uint16(data[2])
-		if entryType != 0x0078 { // PayChannel type
-			return true
-		}
-
-		// Parse the PayChannel
-		payChan, err := state.ParsePayChannel(data)
-		if err != nil {
-			return true
-		}
-
-		// Check if this channel belongs to our account (as source)
+		// A channel sits in both the source and destination owner directories;
+		// account_channels only reports channels the account is the source of.
 		if payChan.Account != accountID {
-			return true
+			return
 		}
 
 		// Filter by destination account if specified
 		if hasDestFilter && payChan.DestinationID != destID {
-			return true
+			return
 		}
 
-		if uint32(len(channels)) >= limit {
-			truncated = true
-			return false
-		}
-
-		// Build channel response
 		srcAddr, _ := addresscodec.EncodeAccountIDToClassicAddress(payChan.Account[:])
 		destAddr, _ := addresscodec.EncodeAccountIDToClassicAddress(payChan.DestinationID[:])
 
@@ -995,8 +1016,8 @@ func (s *Service) GetAccountChannels(ctx context.Context, account string, destin
 		if payChan.PublicKey != "" {
 			channel.PublicKeyHex = payChan.PublicKey
 			// Convert hex to base58 for public_key field
-			pkBytes, err := hex.DecodeString(payChan.PublicKey)
-			if err == nil && len(pkBytes) > 0 {
+			pkBytes, derr := hex.DecodeString(payChan.PublicKey)
+			if derr == nil && len(pkBytes) > 0 {
 				if encoded, encErr := addresscodec.EncodeNodePublicKey(pkBytes); encErr == nil {
 					channel.PublicKey = encoded
 				}
@@ -1020,24 +1041,24 @@ func (s *Service) GetAccountChannels(ctx context.Context, account string, destin
 		}
 
 		channels = append(channels, channel)
-		lastKey = key
-		return true
-	})
-	if err := ctx.Err(); err != nil {
-		return nil, err
 	}
 
-	result := &AccountChannelsResult{
+	markerStr, found, err := ownerDirAfter(ctx, targetLedger, accountID, limit, afterKey, hintPage, hasMarker, visit)
+	if err != nil {
+		return nil, err
+	}
+	if hasMarker && !found {
+		return nil, svcerr.ErrInvalidMarker
+	}
+
+	return &AccountChannelsResult{
 		Account:     account,
 		Channels:    channels,
 		LedgerIndex: targetLedger.Sequence(),
 		LedgerHash:  targetLedger.Hash(),
 		Validated:   validated,
-	}
-	if truncated {
-		result.Marker = formatHashHex(lastKey)
-	}
-	return result, nil
+		Marker:      markerStr,
+	}, nil
 }
 
 // AccountCurrenciesResult contains the result of account_currencies RPC

--- a/internal/ledger/service/account_query_test.go
+++ b/internal/ledger/service/account_query_test.go
@@ -46,8 +46,16 @@ func insertLineRaw(t *testing.T, svc *Service, lowAddr, highAddr, currency, rawB
 	if err != nil {
 		t.Fatalf("serialize ripple state: %v", err)
 	}
-	if err := svc.openLedger.Insert(keylet.Line(lowID, highID, currency), data); err != nil {
+	lineKey := keylet.Line(lowID, highID, currency)
+	if err := svc.openLedger.Insert(lineKey, data); err != nil {
 		t.Fatalf("insert ripple state: %v", err)
+	}
+	// A trust line is linked into both parties' owner directories, which is what
+	// account_lines / account_objects walk.
+	for _, id := range [][20]byte{lowID, highID} {
+		if _, derr := state.DirInsert(svc.openLedger, keylet.OwnerDir(id), lineKey.Key, false, nil); derr != nil {
+			t.Fatalf("owner dir insert: %v", derr)
+		}
 	}
 }
 
@@ -83,6 +91,13 @@ func insertPayChannelEntry(t *testing.T, svc *Service, srcAddr, dstAddr string, 
 	k := keylet.PayChannel(srcID, dstID, seq)
 	if err := svc.openLedger.Insert(k, data); err != nil {
 		t.Fatalf("insert pay channel: %v", err)
+	}
+	// A payment channel is linked into both the source and destination owner
+	// directories; account_channels walks the source's.
+	for _, id := range [][20]byte{srcID, dstID} {
+		if _, derr := state.DirInsert(svc.openLedger, keylet.OwnerDir(id), k.Key, false, nil); derr != nil {
+			t.Fatalf("owner dir insert: %v", derr)
+		}
 	}
 	return k.Key
 }


### PR DESCRIPTION
## Summary

- `account_lines`, `account_offers` and `account_channels` enumerated their results by **scanning the entire ledger** and emitting single-hash (64-hex) markers, diverging from rippled on marker shape, page cadence under filters, ordering and cost. (`account_objects` was already migrated to the owner-directory walk; this finishes the family.)
- Port rippled's `forEachItemAfter` traversal into a shared `ownerDirAfter` helper: walk the account's **owner directory** in directory order, resolve each key to its SLE, and charge the `limit` per **directory entry visited** (not per entry kept) — so a peer/`ignore_default`-filtered page can legitimately come back short and still carry a marker, exactly as rippled does.
- Markers are now rippled-shaped `<entryKey>,<ownerNode>` and resume correctly across pages (hint-page jump with a root-scan fallback; an unlocatable marker key surfaces as `temINVALID`-style invalid-marker).
- Removed the now-unused single-hash `parseQueryMarker`.

## Acceptance criteria (issue #938)

- ✅ `account_lines` / `_offers` / `_channels` return only owner-directory objects — no object that merely *mentions* the account (e.g. an Offer owned by B that sells an IOU issued by A no longer appears for A; a PayChannel where the account is the *destination* is not reported as one of its channels).
- ✅ Result ordering matches owner-directory order, not SHAMap-key order.
- ✅ Markers are `<entryKey>,<ownerNode>`-shaped and resume correctly across pages.
- ✅ Page yields/markers count scanned directory entries (rippled's `forEachItemAfter` semantics), so peer / `ignore_default` filters keep the handler's post-filter rippled-faithful.

## Test plan

- [x] `go test ./internal/ledger/service/...` (incl. new `account_owner_dir_test.go`: issuer-only offer exclusion, destination-channel exclusion, owner-dir ordering, marker round-trip pagination, malformed/stale markers)
- [x] `go test ./internal/rpc/... ./internal/grpc/...`
- [x] `go test ./internal/testing/{rpcenv,payment,nft,offer}/...`
- [x] `CGO_ENABLED=0 go build ./...`, `go vet`, `gofmt`, `-race` on the account suite

Fixes #938