### PR TITLE
fix: erase dangling book-directory entries during payment walk

### DIFF
--- a/internal/tx/payment/step_book_counter_test.go
+++ b/internal/tx/payment/step_book_counter_test.go
@@ -104,3 +104,68 @@ func TestBookStep_OffersUsed_CountsEveryWalkedOffer(t *testing.T) {
 	require.Equal(t, uint32(expiredCount+unfundedCount), step.OffersUsed(),
 		"every offer the book walk advances past (expired + unfunded) must be counted exactly once")
 }
+
+// TestBookStep_ErasesDanglingDirectoryEntry proves the book walk removes a
+// dangling sfIndexes entry — a directory index whose offer SLE no longer exists
+// — from the book directory page in both the execution sandbox and the cancel
+// view, mirroring rippled's OfferStream::step. Before the fix the stale index
+// was skipped but left in place, diverging from rippled's defensive cleanup.
+func TestBookStep_ErasesDanglingDirectoryEntry(t *testing.T) {
+	var gw, owner [20]byte
+	copy(gw[:], []byte("gateway123456789012"))
+	copy(owner[:], []byte("owner1234567890123456")[:20])
+	gwStr := state.EncodeAccountIDSafe(gw)
+
+	view := newPaymentMockLedgerView()
+
+	inIssue := Issue{Currency: "USD", Issuer: gw}
+	outIssue := Issue{Currency: "XRP"}
+	var strandSrc, strandDst [20]byte
+	copy(strandSrc[:], []byte("src12345678901234567"))
+	copy(strandDst[:], []byte("dst12345678901234567"))
+
+	step := NewBookStep(inIssue, outIssue, strandSrc, strandDst, nil, false)
+	step.parentCloseTime = 1000
+
+	dirKey := step.bookBaseKey()
+	binary.BigEndian.PutUint64(dirKey[24:], 0x5500000000000000)
+
+	// A dangling index (no corresponding offer SLE) listed ahead of a real,
+	// existing offer so the walk encounters the stale entry first.
+	var dangling [32]byte
+	copy(dangling[:], []byte("dangling-offer-key-32-bytes-xxxx")[:32])
+	realKey := insertBookOffer(t, view, owner, gwStr, 1, 0, dirKey)
+
+	dirNode := &state.DirectoryNode{
+		RootIndex:         dirKey,
+		Indexes:           [][32]byte{dangling, realKey},
+		TakerPaysCurrency: keylet.CurrencyBytes("USD"),
+		TakerPaysIssuer:   gw,
+	}
+	dirData, err := state.SerializeDirectoryNode(dirNode, true)
+	require.NoError(t, err)
+	view.data[dirKey] = dirData
+
+	// Distinct cancel view (parent) and execution sandbox (child) so both erase
+	// paths are exercised, mirroring rippled's view_/cancelView_ split.
+	afView := NewPaymentSandbox(view)
+	sb := NewChildSandbox(afView)
+	sb.SetTransactionContext([32]byte{}, 1)
+
+	offer, offerKey, err := step.getNextOfferSkipVisited(sb, afView, make(map[[32]byte]bool), make(map[[32]byte]bool))
+	require.NoError(t, err)
+	require.NotNil(t, offer, "walk must skip the dangling entry and return the real offer")
+	require.Equal(t, realKey, offerKey)
+
+	// The dangling index must be erased from the directory page in both views,
+	// with the real offer's index retained.
+	for name, v := range map[string]*PaymentSandbox{"sb": sb, "afView": afView} {
+		pageData, err := v.Read(keylet.DirPage(dirKey, 0))
+		require.NoError(t, err)
+		require.NotNil(t, pageData, "%s: directory page must still exist", name)
+		page, err := state.ParseDirectoryNode(pageData)
+		require.NoError(t, err)
+		require.Equal(t, [][32]byte{realKey}, page.Indexes,
+			"%s: dangling index must be erased, real offer index retained", name)
+	}
+}

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -54,6 +54,7 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 
 		// Iterate root page + all subsequent pages via IndexNext chain
 		rootKey := foundKey
+		pageKey := keylet.DirPage(rootKey, 0)
 		for {
 			for _, idx := range dir.Indexes {
 				var offerKey [32]byte
@@ -83,6 +84,13 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 
 				offerData, err := sb.Read(keylet.Keylet{Key: offerKey})
 				if err != nil || offerData == nil {
+					// Dangling sfIndexes entry: the directory page references an
+					// offer SLE that no longer exists. Erase the stale index from
+					// the current page in both the execution sandbox and the cancel
+					// view, mirroring rippled's OfferStream::step removal of a
+					// directory item with no corresponding ledger entry.
+					s.eraseDanglingOffer(sb, pageKey, offerKey)
+					s.eraseDanglingOffer(afView, pageKey, offerKey)
 					continue
 				}
 
@@ -124,7 +132,7 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 			if dir.IndexNext == 0 {
 				break // No more pages at this quality
 			}
-			pageKey := keylet.DirPage(rootKey, dir.IndexNext)
+			pageKey = keylet.DirPage(rootKey, dir.IndexNext)
 			pageData, err := sb.Read(pageKey)
 			if err != nil || pageData == nil {
 				break
@@ -138,6 +146,44 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 		// All offers at this quality consumed — move to next quality
 		searchKey = foundKey
 	}
+}
+
+// eraseDanglingOffer removes a stale index from a book directory page whose
+// offer SLE no longer exists, mirroring rippled's OfferStream::erase. It
+// rewrites the page's sfIndexes in place rather than calling DirRemove, leaving
+// an emptied page intact: collapsing the page here would be a protocol-breaking
+// change. The page is re-read from the view on each call so successive erasures
+// on the same page compose.
+func (s *BookStep) eraseDanglingOffer(view *PaymentSandbox, pageKey keylet.Keylet, offerKey [32]byte) {
+	pageData, err := view.Read(pageKey)
+	if err != nil || pageData == nil {
+		return
+	}
+	page, err := state.ParseDirectoryNode(pageData)
+	if err != nil {
+		return
+	}
+
+	newIndexes := make([][32]byte, 0, len(page.Indexes))
+	found := false
+	for _, idx := range page.Indexes {
+		if idx == offerKey {
+			found = true
+			continue
+		}
+		newIndexes = append(newIndexes, idx)
+	}
+	if !found {
+		return
+	}
+	page.Indexes = newIndexes
+
+	isBookDir := page.TakerPaysCurrency != [20]byte{} || page.TakerGetsCurrency != [20]byte{}
+	data, err := state.SerializeDirectoryNode(page, isBookDir)
+	if err != nil {
+		return
+	}
+	_ = view.Update(pageKey, data)
 }
 
 // removeExpiredOffer removes an expired offer from the ledger.


### PR DESCRIPTION
## Summary
- The payment `BookStep` walk skipped book-directory indexes pointing at a missing offer SLE but left the dangling `sfIndexes` entry in the directory page — a divergence from rippled's `OfferStream::step`, which defensively erases such entries.
- `getNextOfferSkipVisited` now removes the stale index from the current book-directory page in **both** the execution sandbox and the cancel view (mirroring rippled's `erase(view_)` / `erase(cancelView_)`), rewriting `sfIndexes` in place rather than collapsing the page (collapsing would be a protocol-breaking change, per rippled's own note).
- Defensive-only: dangling directory entries do not arise in normal operation, so this is order-book consistency hardening with no behavioural change on well-formed ledgers.

## Test plan
- [x] `just test-pkg ./internal/tx/payment/...` — new `TestBookStep_ErasesDanglingDirectoryEntry` seeds a directory entry pointing at a non-existent offer SLE, walks the book, and asserts the entry is erased from both views while the real offer is retained.
- [x] `go test ./internal/tx/payment/... ./internal/tx/offer/... ./internal/testing/payment/... ./internal/testing/offer/...` — all pass.
- [x] `gofmt` clean, `go vet` clean.

Fixes #958