### PR TITLE
feat: validate GetLedger query_type for rippled parity

### DIFF
--- a/internal/consensus/adaptor/ledger_provider.go
+++ b/internal/consensus/adaptor/ledger_provider.go
@@ -46,12 +46,13 @@ var _ peermanagement.LedgerProvider = (*LedgerProvider)(nil)
 
 // LedgerProvider implements peermanagement.LedgerProvider on top of the
 // go-xrpl ledger service. It answers the LedgerReplay protocol paths
-// (mtREPLAY_DELTA_REQ / mtPROOF_PATH_REQ) for the overlay; the legacy
-// mtGET_LEDGER(LedgerInfoBase) path is NOT routed through this provider —
-// the consensus router's handleGetLedger (router.go) answers those requests
-// directly from the ledger service. The adapter exists so peermanagement
-// can reach the ledger service without importing internal/ledger, which is
-// forbidden by the layering boundary between the two packages.
+// (mtREPLAY_DELTA_REQ / mtPROOF_PATH_REQ) and fetch-pack serving for the
+// overlay. The mtGET_LEDGER path is NOT routed through this provider — the
+// consensus router's handleGetLedger (router_serve.go) answers those
+// requests directly from the ledger service. The adapter exists so
+// peermanagement can reach the ledger service without importing
+// internal/ledger, which is forbidden by the layering boundary between the
+// two packages.
 type LedgerProvider struct {
 	svc   ledgerLookup
 	floor MinimumOnlineFloor
@@ -85,8 +86,8 @@ func (p *LedgerProvider) belowFloor(seq uint32) bool {
 
 // GetLedgerHeader returns the serialized header for a ledger identified by
 // hash (preferred) or, when no hash is supplied, by sequence. Returns
-// (nil, nil) when the ledger is unknown — handleGetLedger interprets a nil
-// node as "skip" and emits an empty response.
+// (nil, nil) when the ledger is unknown or below the online-delete floor; a
+// nil node means "no data to serve".
 func (p *LedgerProvider) GetLedgerHeader(hash []byte, seq uint32) ([]byte, error) {
 	l := p.lookupLedger(hash, seq)
 	if l == nil || p.belowFloor(l.Sequence()) {

--- a/internal/consensus/adaptor/router_querytype_test.go
+++ b/internal/consensus/adaptor/router_querytype_test.go
@@ -1,0 +1,143 @@
+package adaptor
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// querytypeRecorder records both IncPeerBadData and SendToPeer so the
+// query_type validation test can assert that a present-but-invalid query_type
+// charges the peer and serves nothing, while a valid (qtINDIRECT) or absent
+// one serves normally. badDataCall and sentFrame are shared with the other
+// router tests in this package.
+type querytypeRecorder struct {
+	recordingSender
+	qmu     sync.Mutex
+	badData []badDataCall
+	sent    []sentFrame
+}
+
+func (s *querytypeRecorder) IncPeerBadData(peerID uint64, reason string) {
+	s.qmu.Lock()
+	defer s.qmu.Unlock()
+	s.badData = append(s.badData, badDataCall{peerID: peerID, reason: reason})
+}
+
+func (s *querytypeRecorder) SendToPeer(peerID uint64, frame []byte) error {
+	s.qmu.Lock()
+	defer s.qmu.Unlock()
+	s.sent = append(s.sent, sentFrame{peerID: peerID, frame: append([]byte(nil), frame...)})
+	return nil
+}
+
+func (s *querytypeRecorder) snapshot() ([]badDataCall, []sentFrame) {
+	s.qmu.Lock()
+	defer s.qmu.Unlock()
+	return append([]badDataCall(nil), s.badData...), append([]sentFrame(nil), s.sent...)
+}
+
+func makeRouterWithQueryTypeRecorder(t *testing.T) (*Router, *querytypeRecorder) {
+	t.Helper()
+	svc := newTestLedgerService(t)
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	rs := &querytypeRecorder{recordingSender: recordingSender{peerSupportsReplay: true}}
+	a := New(Config{
+		LedgerService: svc,
+		Sender:        rs,
+		Identity:      identity,
+	})
+	inbox := make(chan *peermanagement.InboundMessage, 8)
+	r := NewRouter(nil, a, inbox)
+	return r, rs
+}
+
+// TestRouter_GetLedger_QueryTypeValidation pins rippled's
+// onMessage(TMGetLedger) query_type rule: qtINDIRECT is the only valid value.
+// A present-but-different value is invalid data — charge the peer and drop the
+// request without disconnecting; an absent or qtINDIRECT value is served. The
+// tx-set is served via a cached liTS_CANDIDATE request because that path is
+// exempt from load-shedding, so the positive cases are deterministic.
+func TestRouter_GetLedger_QueryTypeValidation(t *testing.T) {
+	blobs := [][]byte{
+		bytes.Repeat([]byte{0x11}, 16),
+		bytes.Repeat([]byte{0x55}, 16),
+	}
+
+	t.Run("invalid query_type charges peer and serves nothing", func(t *testing.T) {
+		r, rs := makeRouterWithQueryTypeRecorder(t)
+		ts, err := r.adaptor.BuildTxSet(blobs)
+		require.NoError(t, err)
+		id := ts.ID()
+
+		invalid := message.LedgerQueryType(7)
+		req := &message.GetLedger{
+			InfoType:   message.LedgerInfoTsCandidate,
+			LedgerHash: id[:],
+			QueryType:  &invalid,
+		}
+		r.handleMessage(&peermanagement.InboundMessage{
+			PeerID:  42,
+			Type:    uint16(message.TypeGetLedger),
+			Payload: encodePayload(t, req),
+		})
+
+		bd, sent := rs.snapshot()
+		require.Len(t, bd, 1, "invalid query_type must charge bad data exactly once")
+		assert.Equal(t, uint64(42), bd[0].peerID)
+		assert.Equal(t, "get-ledger-bad-querytype", bd[0].reason)
+		assert.Empty(t, sent, "invalid query_type must not serve a response")
+	})
+
+	t.Run("qtINDIRECT serves normally", func(t *testing.T) {
+		r, rs := makeRouterWithQueryTypeRecorder(t)
+		ts, err := r.adaptor.BuildTxSet(blobs)
+		require.NoError(t, err)
+		id := ts.ID()
+
+		valid := message.QueryTypeIndirect
+		req := &message.GetLedger{
+			InfoType:   message.LedgerInfoTsCandidate,
+			LedgerHash: id[:],
+			QueryType:  &valid,
+		}
+		r.handleMessage(&peermanagement.InboundMessage{
+			PeerID:  7,
+			Type:    uint16(message.TypeGetLedger),
+			Payload: encodePayload(t, req),
+		})
+
+		bd, sent := rs.snapshot()
+		assert.Empty(t, bd, "qtINDIRECT must not charge bad data")
+		require.Len(t, sent, 1, "qtINDIRECT must serve the cached tx-set")
+		assert.Equal(t, uint64(7), sent[0].peerID)
+	})
+
+	t.Run("absent query_type serves normally", func(t *testing.T) {
+		r, rs := makeRouterWithQueryTypeRecorder(t)
+		ts, err := r.adaptor.BuildTxSet(blobs)
+		require.NoError(t, err)
+		id := ts.ID()
+
+		req := &message.GetLedger{
+			InfoType:   message.LedgerInfoTsCandidate,
+			LedgerHash: id[:],
+		}
+		r.handleMessage(&peermanagement.InboundMessage{
+			PeerID:  9,
+			Type:    uint16(message.TypeGetLedger),
+			Payload: encodePayload(t, req),
+		})
+
+		bd, sent := rs.snapshot()
+		assert.Empty(t, bd, "absent query_type must not charge bad data")
+		require.Len(t, sent, 1, "absent query_type must serve the cached tx-set")
+		assert.Equal(t, uint64(9), sent[0].peerID)
+	})
+}

--- a/internal/consensus/adaptor/router_serve.go
+++ b/internal/consensus/adaptor/router_serve.go
@@ -22,6 +22,17 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 		return
 	}
 
+	// qtINDIRECT is the only valid query_type. A present-but-different
+	// value is invalid data: charge the peer and drop the request without
+	// disconnecting, mirroring rippled's onMessage(TMGetLedger). Absence of
+	// the field (the common case) is always accepted.
+	if req.QueryType != nil && *req.QueryType != message.QueryTypeIndirect {
+		r.logger.Debug("get_ledger rejected: invalid query_type",
+			"peer", msg.PeerID, "query_type", int32(*req.QueryType))
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "get-ledger-bad-querytype")
+		return
+	}
+
 	r.logger.Debug("peer requests ledger",
 		"peer", msg.PeerID,
 		"itype", req.InfoType,

--- a/internal/peermanagement/ledgersync.go
+++ b/internal/peermanagement/ledgersync.go
@@ -161,14 +161,6 @@ type LedgerSyncHandler struct {
 	// Pending requests
 	requests map[uint64]*LedgerRequest
 
-	// Request callbacks. mtREPLAY_DELTA_RESPONSE and mtPROOF_PATH_RESPONSE
-	// are intentionally NOT dispatched to callbacks here — orchestration
-	// (state machine, hash verification, adoption) lives in the consensus
-	// router, which reads those responses via the overlay's Messages()
-	// channel. Dispatching them twice would race the inbound-acquisition
-	// state. See the comment on HandleMessage below.
-	onLedgerData func(ctx context.Context, peerID PeerID, data *message.LedgerData)
-
 	// Data provider for responding to requests
 	provider LedgerProvider
 
@@ -200,13 +192,6 @@ func NewLedgerSyncHandler(events chan<- Event) *LedgerSyncHandler {
 		requests: make(map[uint64]*LedgerRequest),
 		events:   events,
 	}
-}
-
-// SetLedgerDataCallback sets the callback for incoming ledger data.
-func (h *LedgerSyncHandler) SetLedgerDataCallback(fn func(ctx context.Context, peerID PeerID, data *message.LedgerData)) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.onLedgerData = fn
 }
 
 // SetProvider sets the ledger data provider for responding to requests.
@@ -251,107 +236,22 @@ func (h *LedgerSyncHandler) SetPeerLedgerHintLookup(fn func(target [32]byte) []P
 	h.peerHintLookup = fn
 }
 
-// HandleMessage handles a ledger sync message.
+// HandleMessage handles a ledger sync request the overlay dispatches to this
+// handler: mtPROOF_PATH_REQ and mtREPLAY_DELTA_REQ.
 //
-// mtREPLAY_DELTA_RESPONSE intentionally has no arm here: orchestration of an
-// outbound replay-delta acquisition (state machine, hash verification,
-// adoption) lives in the consensus router, which receives the response via
-// the overlay's Messages() channel. Delivering the response twice — once to
-// the router, once to this handler — would create competing consumers and a
-// race on the inbound-acquisition state.
+// mtGET_LEDGER serving and the mtLEDGER_DATA / mtREPLAY_DELTA_RESPONSE /
+// mtPROOF_PATH_RESPONSE replies have no arm here: serving and orchestration
+// (state machine, hash verification, adoption) live in the consensus router,
+// which receives those frames via the overlay's Messages() channel. Handling
+// them here too would create competing consumers and a race on the
+// inbound-acquisition state.
 func (h *LedgerSyncHandler) HandleMessage(ctx context.Context, peerID PeerID, msg message.Message) error {
 	switch m := msg.(type) {
-	case *message.GetLedger:
-		return h.handleGetLedger(ctx, peerID, m)
-	case *message.LedgerData:
-		return h.handleLedgerData(ctx, peerID, m)
 	case *message.ProofPathRequest:
 		return h.handleProofPathRequest(ctx, peerID, m)
 	case *message.ReplayDeltaRequest:
 		return h.handleReplayDeltaRequest(ctx, peerID, m)
 	}
-	return nil
-}
-
-// handleGetLedger handles incoming ledger data requests.
-func (h *LedgerSyncHandler) handleGetLedger(ctx context.Context, peerID PeerID, req *message.GetLedger) error {
-	h.mu.RLock()
-	provider := h.provider
-	h.mu.RUnlock()
-
-	if provider == nil {
-		// No provider, can't respond
-		return nil
-	}
-
-	// Build response. Echo the request's info type, as rippled does
-	// (ledgerData.set_type(itype)), so the reply identifies which map it
-	// answers.
-	response := &message.LedgerData{
-		LedgerSeq:  req.LedgerSeq,
-		LedgerHash: req.LedgerHash,
-		InfoType:   req.InfoType,
-	}
-
-	// Dispatch on the ledger info type (rippled's itype), the field the
-	// codec actually carries on the wire. liBASE returns the header;
-	// liAS_NODE/liTX_NODE return the requested state/transaction nodes.
-	switch req.InfoType {
-	case message.LedgerInfoBase:
-		header, err := provider.GetLedgerHeader(req.LedgerHash, req.LedgerSeq)
-		if err == nil && header != nil {
-			response.Nodes = append(response.Nodes, message.LedgerNode{NodeData: header})
-		}
-	case message.LedgerInfoAsNode:
-		for _, nodeID := range req.NodeIDs {
-			node, err := provider.GetAccountStateNode(req.LedgerHash, nodeID)
-			if err == nil && node != nil {
-				response.Nodes = append(response.Nodes, message.LedgerNode{NodeData: node, NodeID: nodeID})
-			}
-		}
-	case message.LedgerInfoTxNode:
-		for _, nodeID := range req.NodeIDs {
-			node, err := provider.GetTransactionNode(req.LedgerHash, nodeID)
-			if err == nil && node != nil {
-				response.Nodes = append(response.Nodes, message.LedgerNode{NodeData: node, NodeID: nodeID})
-			}
-		}
-	}
-
-	// Send response via events channel. We ship the fully-framed wire
-	// message (6-byte header + protobuf body) so Overlay.onLedgerResponse
-	// can hand it straight to the peer's send queue without having to
-	// know the message type. Matches the handlePing round-trip in
-	// overlay.go which also writes through BuildWireMessage.
-	if h.events != nil && len(response.Nodes) > 0 {
-		encoded, err := message.Encode(response)
-		if err != nil {
-			return nil
-		}
-		frame, err := message.BuildWireMessage(message.TypeLedgerData, encoded)
-		if err != nil {
-			return nil
-		}
-		h.events <- Event{
-			Type:    EventLedgerResponse,
-			PeerID:  peerID,
-			Payload: frame,
-		}
-	}
-
-	return nil
-}
-
-// handleLedgerData handles incoming ledger data responses.
-func (h *LedgerSyncHandler) handleLedgerData(ctx context.Context, peerID PeerID, data *message.LedgerData) error {
-	h.mu.RLock()
-	callback := h.onLedgerData
-	h.mu.RUnlock()
-
-	if callback != nil {
-		callback(ctx, peerID, data)
-	}
-
 	return nil
 }
 
@@ -376,7 +276,7 @@ func (h *LedgerSyncHandler) handleLedgerData(ctx context.Context, peerID PeerID,
 //
 // The encoded response is pushed onto the events channel as
 // EventLedgerResponse so the overlay can ship it to the requesting peer
-// (mirrors handleGetLedger and handleReplayDeltaRequest).
+// (mirrors handleReplayDeltaRequest).
 func (h *LedgerSyncHandler) handleProofPathRequest(_ context.Context, peerID PeerID, req *message.ProofPathRequest) error {
 	// Validate up-front: independent of any configured provider, matching
 	// rippled's ordering at LedgerReplayMsgHandler.cpp:46-54.
@@ -396,8 +296,7 @@ func (h *LedgerSyncHandler) handleProofPathRequest(_ context.Context, peerID Pee
 	h.mu.RUnlock()
 
 	if provider == nil {
-		// No provider wired: silently drop (matches handleGetLedger and
-		// handleReplayDeltaRequest).
+		// No provider wired: silently drop (matches handleReplayDeltaRequest).
 		return nil
 	}
 
@@ -502,7 +401,7 @@ func (h *LedgerSyncHandler) sendProofPathResponse(peerID PeerID, resp *message.P
 //
 // The encoded response is pushed onto the events channel as
 // EventLedgerResponse so the overlay can ship it to the requesting peer
-// (mirrors handleGetLedger).
+// (mirrors handleProofPathRequest).
 func (h *LedgerSyncHandler) handleReplayDeltaRequest(_ context.Context, peerID PeerID, req *message.ReplayDeltaRequest) error {
 	// Validate ledger_hash length first — this check is independent of any
 	// configured provider, matching the rippled ordering.
@@ -519,7 +418,7 @@ func (h *LedgerSyncHandler) handleReplayDeltaRequest(_ context.Context, peerID P
 	h.mu.RUnlock()
 
 	if provider == nil {
-		// No provider wired: silently drop (matches handleGetLedger).
+		// No provider wired: silently drop (matches handleProofPathRequest).
 		return nil
 	}
 

--- a/internal/peermanagement/message/messages.go
+++ b/internal/peermanagement/message/messages.go
@@ -172,13 +172,14 @@ type LedgerNode struct {
 
 // GetLedger requests ledger data.
 type GetLedger struct {
-	InfoType      LedgerInfoType `json:"itype"`
-	LType         LedgerType     `json:"ltype,omitempty"`
-	LedgerHash    []byte         `json:"ledger_hash,omitempty"`
-	LedgerSeq     uint32         `json:"ledger_seq,omitempty"`
-	NodeIDs       [][]byte       `json:"node_ids,omitempty"`
-	RequestCookie uint64         `json:"request_cookie,omitempty"`
-	QueryDepth    uint32         `json:"query_depth,omitempty"`
+	InfoType      LedgerInfoType   `json:"itype"`
+	LType         LedgerType       `json:"ltype,omitempty"`
+	LedgerHash    []byte           `json:"ledger_hash,omitempty"`
+	LedgerSeq     uint32           `json:"ledger_seq,omitempty"`
+	NodeIDs       [][]byte         `json:"node_ids,omitempty"`
+	RequestCookie uint64           `json:"request_cookie,omitempty"`
+	QueryType     *LedgerQueryType `json:"query_type,omitempty"`
+	QueryDepth    uint32           `json:"query_depth,omitempty"`
 }
 
 func (g *GetLedger) Type() MessageType { return TypeGetLedger }

--- a/internal/peermanagement/message/serialize_proto.go
+++ b/internal/peermanagement/message/serialize_proto.go
@@ -190,7 +190,7 @@ var codecs = map[MessageType]msgCodec{
 			}
 			itype := proto.TMLedgerInfoType(m.InfoType)
 			ltype := proto.TMLedgerType(m.LType)
-			return &proto.TMGetLedger{
+			out := &proto.TMGetLedger{
 				Itype:         &itype,
 				Ltype:         &ltype,
 				LedgerHash:    m.LedgerHash,
@@ -198,11 +198,16 @@ var codecs = map[MessageType]msgCodec{
 				NodeIds:       m.NodeIDs,
 				RequestCookie: m.RequestCookie,
 				QueryDepth:    m.QueryDepth,
-			}, nil
+			}
+			if m.QueryType != nil {
+				qt := proto.TMQueryType(*m.QueryType)
+				out.QueryType = &qt
+			}
+			return out, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
 			p := pmsg.(*proto.TMGetLedger)
-			return &GetLedger{
+			g := &GetLedger{
 				InfoType:      LedgerInfoType(p.GetItype()),
 				LType:         LedgerType(p.GetLtype()),
 				LedgerHash:    p.GetLedgerHash(),
@@ -210,7 +215,12 @@ var codecs = map[MessageType]msgCodec{
 				NodeIDs:       p.GetNodeIds(),
 				RequestCookie: p.GetRequestCookie(),
 				QueryDepth:    p.GetQueryDepth(),
-			}, nil
+			}
+			if p.QueryType != nil {
+				qt := LedgerQueryType(*p.QueryType)
+				g.QueryType = &qt
+			}
+			return g, nil
 		},
 	},
 	TypeLedgerData: {

--- a/internal/peermanagement/message/serialize_test.go
+++ b/internal/peermanagement/message/serialize_test.go
@@ -265,6 +265,7 @@ func TestHaveTransactionsRoundtrip(t *testing.T) {
 }
 
 func TestGetLedgerRoundtrip(t *testing.T) {
+	qt := QueryTypeIndirect
 	original := &GetLedger{
 		InfoType:      LedgerInfoBase,
 		LType:         LedgerTypeAccepted,
@@ -272,6 +273,7 @@ func TestGetLedgerRoundtrip(t *testing.T) {
 		LedgerSeq:     500000,
 		NodeIDs:       [][]byte{bytes.Repeat([]byte{0x99}, 32)},
 		RequestCookie: 12345,
+		QueryType:     &qt,
 		QueryDepth:    3,
 	}
 
@@ -300,9 +302,51 @@ func TestGetLedgerRoundtrip(t *testing.T) {
 	if decoded.RequestCookie != original.RequestCookie {
 		t.Errorf("RequestCookie = %d, want %d", decoded.RequestCookie, original.RequestCookie)
 	}
+	if decoded.QueryType == nil || *decoded.QueryType != *original.QueryType {
+		t.Errorf("QueryType = %v, want %d", decoded.QueryType, *original.QueryType)
+	}
 	if decoded.QueryDepth != original.QueryDepth {
 		t.Errorf("QueryDepth = %d, want %d", decoded.QueryDepth, original.QueryDepth)
 	}
+}
+
+// TestGetLedgerQueryTypePresence pins that query_type presence survives the
+// wire round-trip: an absent field decodes to nil (so the serve path treats
+// it as "accept"), while a present non-qtINDIRECT value is preserved as a
+// distinct non-nil value the serve path can reject.
+func TestGetLedgerQueryTypePresence(t *testing.T) {
+	t.Run("absent stays nil", func(t *testing.T) {
+		encoded, err := Encode(&GetLedger{InfoType: LedgerInfoBase})
+		if err != nil {
+			t.Fatalf("Encode error: %v", err)
+		}
+		decoded, err := Decode(TypeGetLedger, encoded)
+		if err != nil {
+			t.Fatalf("Decode error: %v", err)
+		}
+		if qt := decoded.(*GetLedger).QueryType; qt != nil {
+			t.Errorf("QueryType = %d, want nil (absent)", *qt)
+		}
+	})
+
+	t.Run("present non-indirect preserved", func(t *testing.T) {
+		invalid := LedgerQueryType(7)
+		encoded, err := Encode(&GetLedger{InfoType: LedgerInfoBase, QueryType: &invalid})
+		if err != nil {
+			t.Fatalf("Encode error: %v", err)
+		}
+		decoded, err := Decode(TypeGetLedger, encoded)
+		if err != nil {
+			t.Fatalf("Decode error: %v", err)
+		}
+		qt := decoded.(*GetLedger).QueryType
+		if qt == nil {
+			t.Fatal("QueryType = nil, want present")
+		}
+		if *qt != invalid {
+			t.Errorf("QueryType = %d, want %d", *qt, invalid)
+		}
+	})
 }
 
 func TestLedgerDataRoundtrip(t *testing.T) {

--- a/internal/peermanagement/message/types.go
+++ b/internal/peermanagement/message/types.go
@@ -136,6 +136,17 @@ const (
 	LedgerInfoTsCandidate LedgerInfoType = 3
 )
 
+// LedgerQueryType represents the GetLedger query routing mode. qtINDIRECT
+// is the only defined value; a present query_type that is anything else is
+// rejected as invalid data. The field is modelled as a pointer on GetLedger
+// so absence (the common case) is distinguishable from an explicit
+// qtINDIRECT, matching rippled's has_querytype() presence check.
+type LedgerQueryType int32
+
+const (
+	QueryTypeIndirect LedgerQueryType = 0
+)
+
 // LedgerType represents types of ledgers.
 type LedgerType int32
 


### PR DESCRIPTION
## Summary

- **Adds `query_type` validation (item 1)** to the live `mtGET_LEDGER` serve path (`router_serve.go::handleGetLedger`): a `query_type` that is **present and not `qtINDIRECT`** is charged invalid-data (`IncPeerBadData`) and the request is dropped **without disconnecting**, mirroring rippled's `PeerImp::onMessage(TMGetLedger)`. An absent field (the common case) or an explicit `qtINDIRECT` is served as before.
- **Restores `query_type` presence** on `message.GetLedger` (dropped in #943) as a presence-aware pointer field, so the codec carries proto field 7 and the serve path can distinguish *absent* from an *explicit value*.
- **Removes the dead, never-wired** `LedgerSyncHandler.handleGetLedger` / `handleLedgerData` and their unreachable `HandleMessage` arms (plus the `onLedgerData` / `SetLedgerDataCallback` plumbing). Nothing dispatches to them — the live serve path is the consensus router — so this clears the redundant second copy that prompted the issue and prevents it from being revived into a double-serve.

### Scope note (issue premise was partly outdated)

The issue assumed inbound `TMGetLedger` is unserved and pointed at the peermanagement `handleGetLedger`. In the current tree, `TMGetLedger` frames already flow `overlay → o.messages → router_dispatch → handleGetLedger`, and the router **already serves `liTS_CANDIDATE`** (item 2) from the tx-set cache with query-depth + reply caps. So:

- **Item 1 (query_type validation)** — genuinely missing → fixed here.
- **Item 2 (`liTS_CANDIDATE` serving)** — already implemented in the router; covered by `TestRouter_GetLedger_TsCandidate_ServesCachedTxSet`. This PR adds an explicit parity assertion that a valid/absent `query_type` still serves it.
- **Item 3 (request relay)** — genuinely missing, needs a new peer-scoring relay subsystem (`getPeerWithLedger`/`getPeerWithTree` equivalents); deferred to its own follow-up issue, as the issue itself sanctioned.

## Test plan

- [x] `go test ./internal/peermanagement/... ./internal/consensus/...` (incl. new `TestRouter_GetLedger_QueryTypeValidation` and extended `TestGetLedgerRoundtrip` / `TestGetLedgerQueryTypePresence`)
- [x] `go test ./internal/testing/p2p/...`
- [x] `go vet` + `golangci-lint run` on changed packages — 0 issues
- [x] `go build ./...`

Oracle: rippled @ `1e89286a92`.

Fixes #951