### PR TITLE
fix: ledger_data marker validation for degenerate inputs

### DIFF
--- a/internal/rpc/handlers/ledger_data.go
+++ b/internal/rpc/handlers/ledger_data.go
@@ -19,10 +19,10 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	// Parse parameters
 	var request struct {
 		types.LedgerSpecifier
-		Binary bool   `json:"binary,omitempty"`
-		Limit  uint32 `json:"limit,omitempty"`
-		Marker any    `json:"marker,omitempty"`
-		Type   string `json:"type,omitempty"`
+		Binary bool            `json:"binary,omitempty"`
+		Limit  uint32          `json:"limit,omitempty"`
+		Marker json.RawMessage `json:"marker,omitempty"`
+		Type   string          `json:"type,omitempty"`
 	}
 
 	if err := ParseParams(params, &request); err != nil {
@@ -48,15 +48,18 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 	}
 
 	// Validate a present marker up front, mirroring rippled's doLedgerData which
-	// runs key.parseHex before touching the view: a present non-string marker,
-	// or a present string parseHex rejects, is "not valid". parseHex accepts the
-	// literal "0" as the all-zero key and otherwise requires exactly 64 hex
-	// chars; the empty string fails its length check. An absent marker is a
-	// fresh first-page query, signalled to the service by the empty sentinel.
+	// runs key.parseHex before touching the view: a present non-string marker
+	// (including JSON null), or a present string parseHex rejects, is "not
+	// valid". parseHex accepts the literal "0" as the all-zero key and otherwise
+	// requires exactly 64 hex chars; the empty string fails its length check. An
+	// absent marker is a fresh first-page query, signalled to the service by the
+	// empty sentinel. Marker stays raw JSON so a present null — which decodes to
+	// a nil any, indistinguishable from an absent marker — is still rejected, as
+	// rippled's isMember + isString checks do.
 	markerStr := ""
 	if request.Marker != nil {
-		m, ok := request.Marker.(string)
-		if !ok {
+		var m string
+		if err := json.Unmarshal(request.Marker, &m); err != nil {
 			return nil, types.RpcErrorExpectedField("marker", "valid")
 		}
 		switch m {

--- a/internal/rpc/handlers/ledger_data.go
+++ b/internal/rpc/handlers/ledger_data.go
@@ -47,16 +47,29 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		return nil, selErr
 	}
 
-	// Parse marker as string. A present non-string marker is malformed
-	// (rippled's doLedgerData requires jMarker.isString()); a malformed string
-	// is rejected downstream by the ledger service.
+	// Validate a present marker up front, mirroring rippled's doLedgerData which
+	// runs key.parseHex before touching the view: a present non-string marker,
+	// or a present string parseHex rejects, is "not valid". parseHex accepts the
+	// literal "0" as the all-zero key and otherwise requires exactly 64 hex
+	// chars; the empty string fails its length check. An absent marker is a
+	// fresh first-page query, signalled to the service by the empty sentinel.
 	markerStr := ""
 	if request.Marker != nil {
 		m, ok := request.Marker.(string)
 		if !ok {
 			return nil, types.RpcErrorExpectedField("marker", "valid")
 		}
-		markerStr = m
+		switch m {
+		case "":
+			return nil, types.RpcErrorExpectedField("marker", "valid")
+		case "0":
+			// The all-zero key: iterate from the first entry but, being a
+			// present marker, omit the base-ledger header. Normalize to the
+			// canonical 64-char form the service already parses to that key.
+			markerStr = strings.Repeat("0", 64)
+		default:
+			markerStr = m
+		}
 	}
 
 	result, err := ctx.Services.Ledger.GetLedgerData(ctx.Context, ledgerIndex, limit, markerStr)

--- a/internal/rpc/ledger_data_test.go
+++ b/internal/rpc/ledger_data_test.go
@@ -763,6 +763,32 @@ func TestLedgerDataMarkerValidation(t *testing.T) {
 		assert.False(t, called, "service must not be called for a non-string marker")
 	})
 
+	// A present JSON null is isMember==true but isString()==false in rippled, so
+	// it is rejected — not conflated with an absent marker (a fresh first page).
+	t.Run("Present null marker is rejected before the service", func(t *testing.T) {
+		called := false
+		mock := &ledgerDataMock{mockLedgerService: newMockLedgerService()}
+		mock.getLedgerDataFn = func(ledgerIndex string, limit uint32, marker string) (*types.LedgerDataResult, error) {
+			called = true
+			return newDefaultLedgerDataResult(1, false), nil
+		}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: mock},
+		}
+		params := map[string]any{"ledger_index": "current", "marker": nil}
+		paramsJSON, _ := json.Marshal(params)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Invalid field 'marker', not valid.", rpcErr.Message)
+		assert.False(t, called, "service must not be called for a present null marker")
+	})
+
 	// A present empty-string marker is parseHex("") → badLength in rippled, not
 	// the absent-marker case. It must be rejected, not silently restart paging.
 	t.Run("Empty-string marker is rejected before the service", func(t *testing.T) {

--- a/internal/rpc/ledger_data_test.go
+++ b/internal/rpc/ledger_data_test.go
@@ -762,6 +762,68 @@ func TestLedgerDataMarkerValidation(t *testing.T) {
 		assert.Equal(t, "Invalid field 'marker', not valid.", rpcErr.Message)
 		assert.False(t, called, "service must not be called for a non-string marker")
 	})
+
+	// A present empty-string marker is parseHex("") → badLength in rippled, not
+	// the absent-marker case. It must be rejected, not silently restart paging.
+	t.Run("Empty-string marker is rejected before the service", func(t *testing.T) {
+		called := false
+		mock := &ledgerDataMock{mockLedgerService: newMockLedgerService()}
+		mock.getLedgerDataFn = func(ledgerIndex string, limit uint32, marker string) (*types.LedgerDataResult, error) {
+			called = true
+			return newDefaultLedgerDataResult(1, false), nil
+		}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: mock},
+		}
+		params := map[string]any{"ledger_index": "current", "marker": ""}
+		paramsJSON, _ := json.Marshal(params)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Invalid field 'marker', not valid.", rpcErr.Message)
+		assert.False(t, called, "service must not be called for a present empty marker")
+	})
+
+	// rippled's parseHex special-cases "0" as the all-zero key: paging starts at
+	// the first entry, but because a marker is present the base-ledger header is
+	// omitted. The handler normalizes "0" to its canonical 64-char form.
+	t.Run("Marker '0' is the all-zero key and omits the ledger header", func(t *testing.T) {
+		var forwarded string
+		called := false
+		mock := &ledgerDataMock{mockLedgerService: newMockLedgerService()}
+		mock.getLedgerDataFn = func(ledgerIndex string, limit uint32, marker string) (*types.LedgerDataResult, error) {
+			called = true
+			forwarded = marker
+			// A present marker → service returns no ledger header.
+			return newDefaultLedgerDataResult(2, false), nil
+		}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleGuest,
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: mock},
+		}
+		params := map[string]any{"ledger_index": "current", "marker": "0"}
+		paramsJSON, _ := json.Marshal(params)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr, "marker '0' must be accepted, got: %v", rpcErr)
+		require.NotNil(t, result)
+		assert.True(t, called, "service must be called for marker '0'")
+		assert.Equal(t, strings.Repeat("0", 64), forwarded,
+			"marker '0' must be normalized to the canonical all-zero key")
+
+		resp := resultToMapData(t, result)
+		_, hasHeader := resp["ledger"]
+		assert.False(t, hasHeader, "a present marker must omit the base-ledger header")
+		state := resp["state"].([]any)
+		assert.Equal(t, 2, len(state))
+	})
 }
 
 // resultToMapData is a test helper for ledger_data tests


### PR DESCRIPTION
## Summary

- `ledger_data` rejected the literal marker `"0"` and silently accepted a present empty-string marker `""` as "no marker" — both diverged from rippled's `doLedgerData`, which validates the marker via `key.parseHex` before touching the view.
- Validate the marker up front in the handler (no service signature change):
  - `marker: ""` (present) → `invalidParams` `"Invalid field 'marker', not valid."` (was: first page **with** base-ledger header).
  - `marker: "0"` → accepted as the all-zero key: first page, header **omitted** (was: rejected). Normalized to its canonical 64-char form, which the service already parses to the zero key.
- Other markers (absent, non-string, non-64-hex) are unchanged.

## Test plan

- [x] `just test-pkg ./internal/rpc/...` — full rpc suite green, incl. new `TestLedgerDataMarkerValidation` subtests for `""` and `"0"`.
- [x] `just test-pkg ./internal/ledger/service/...` — service unchanged, green.
- [x] `go vet ./internal/rpc/...`, `gofmt` clean.

Fixes #971