### PR TITLE
fix: order FORBID gate before busy gate in RPC dispatch

### DIFF
--- a/internal/rpc/dispatch_gate_order_test.go
+++ b/internal/rpc/dispatch_gate_order_test.go
@@ -1,0 +1,127 @@
+package rpc
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// saturatedShedder returns a ClientLoadShedder whose in-flight count is one
+// over MaxJobQueueClients, the threshold RequireNotBusyClient sheds at.
+func saturatedShedder() *types.ClientLoadShedder {
+	s := types.NewClientLoadShedder()
+	for i := int64(0); i <= types.MaxJobQueueClients; i++ {
+		s.Begin()
+	}
+	return s
+}
+
+// TestDispatchGateOrder pins the gate sequence of the shared dispatch core
+// (used by BOTH the HTTP and WebSocket transports). rippled resolves a role-
+// layer FORBID (403) in ServerHandler::processRequest ahead of doCommand, while
+// the job-queue busy gate (rpcTOO_BUSY) lives inside fillHandler — so FORBID
+// precedes busy, busy precedes the unknown-command failure, and an invalid
+// api_version precedes both. A forbidden admin request under queue saturation
+// must therefore be denied 403, not rpcTOO_BUSY.
+func TestDispatchGateOrder(t *testing.T) {
+	reg := types.NewMethodRegistry()
+	reg.Register("stop", &stubHandler{role: types.RoleAdmin}) // admin-only
+	reg.Register("ping", &stubHandler{role: types.RoleGuest}) // open
+
+	cases := []struct {
+		name       string
+		method     string
+		apiVersion int
+		saturated  bool
+		wantErr    bool
+		wantCode   int
+	}{
+		{"forbidden admin while saturated → FORBIDDEN, not TOO_BUSY",
+			"stop", types.ApiVersion1, true, true, types.RpcFORBIDDEN},
+		{"forbidden admin while idle → FORBIDDEN",
+			"stop", types.ApiVersion1, false, true, types.RpcFORBIDDEN},
+		{"unknown method while saturated → TOO_BUSY (busy before unknown)",
+			"nope", types.ApiVersion1, true, true, types.RpcTOO_BUSY},
+		{"unknown method while idle → METHOD_NOT_FOUND",
+			"nope", types.ApiVersion1, false, true, types.RpcMETHOD_NOT_FOUND},
+		{"invalid api_version + forbidden admin → INVALID_API_VERSION (before FORBID)",
+			"stop", 99, false, true, types.RpcINVALID_API_VERSION},
+		{"invalid api_version + forbidden admin while saturated → INVALID_API_VERSION",
+			"stop", 99, true, true, types.RpcINVALID_API_VERSION},
+		{"open method while saturated → TOO_BUSY (busy still fires when not forbidden)",
+			"ping", types.ApiVersion1, true, true, types.RpcTOO_BUSY},
+		{"open method while idle → success",
+			"ping", types.ApiVersion1, false, false, 0},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			services := &types.ServiceContainer{}
+			if c.saturated {
+				services.ClientLoad = saturatedShedder()
+			}
+			ctx := &types.RpcContext{
+				ApiVersion: c.apiVersion,
+				Role:       types.RoleGuest, // non-admin caller
+				Services:   services,
+			}
+
+			result, rpcErr := dispatchMethod(reg, nil, services, ctx, c.method, nil, types.RpcErrorForbidden, rpcLog())
+
+			if !c.wantErr {
+				require.Nil(t, rpcErr)
+				assert.Equal(t, map[string]any{"ok": true}, result)
+				return
+			}
+			require.NotNil(t, rpcErr)
+			assert.Equal(t, c.wantCode, rpcErr.Code)
+		})
+	}
+}
+
+// TestHTTPForbiddenBeatsBusy pins the observable wire-shape divergence the
+// resequencing fixes: a forbidden admin request concurrent with a saturated
+// job queue returns HTTP 403 "Forbidden" (the role-layer short-circuit), not
+// the rpcTOO_BUSY 503 envelope. An unknown method under the same saturation
+// stays 503, confirming busy still precedes the unknown-command failure.
+func TestHTTPForbiddenBeatsBusy(t *testing.T) {
+	services := types.NewServiceContainer(nil)
+	srv := NewServer(time.Second, services)
+	srv.registry.Register("stop", &stubHandler{role: types.RoleAdmin})
+
+	for i := int64(0); i <= types.MaxJobQueueClients; i++ {
+		services.ClientLoad.Begin()
+	}
+
+	t.Run("forbidden admin request → 403, not 503", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"stop","params":[{}]}`))
+		// 192.0.2.1 (TEST-NET-1) is never localhost → RoleGuest, no admin
+		// fallback and not exempt from the shedder.
+		req.RemoteAddr = "192.0.2.1:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusForbidden, rr.Code,
+			"forbidden admin request under saturation must be 403, not 503; body: %s", rr.Body.String())
+		assert.Equal(t, "Forbidden", strings.TrimSpace(rr.Body.String()))
+		assert.NotContains(t, rr.Body.String(), "tooBusy")
+	})
+
+	t.Run("unknown method stays 503 tooBusy", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"nope","params":[{}]}`))
+		req.RemoteAddr = "192.0.2.1:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusServiceUnavailable, rr.Code,
+			"unknown method under saturation must stay 503; body: %s", rr.Body.String())
+		result := decodeEnvelope(t, rr.Body.Bytes())
+		assert.Equal(t, "tooBusy", result["error"])
+	})
+}

--- a/internal/rpc/dispatch_gate_order_test.go
+++ b/internal/rpc/dispatch_gate_order_test.go
@@ -28,11 +28,14 @@ func saturatedShedder() *types.ClientLoadShedder {
 // the job-queue busy gate (rpcTOO_BUSY) lives inside fillHandler — so FORBID
 // precedes busy, busy precedes the unknown-command failure, and an invalid
 // api_version precedes both. A forbidden admin request under queue saturation
-// must therefore be denied 403, not rpcTOO_BUSY.
+// must therefore be denied 403, not rpcTOO_BUSY. A known command whose handler
+// does not serve the requested (in-range) api_version resolves to unknown-
+// command — matching rippled's getHandler returning null — not invalid_API_version.
 func TestDispatchGateOrder(t *testing.T) {
 	reg := types.NewMethodRegistry()
-	reg.Register("stop", &stubHandler{role: types.RoleAdmin}) // admin-only
-	reg.Register("ping", &stubHandler{role: types.RoleGuest}) // open
+	reg.Register("stop", &stubHandler{role: types.RoleAdmin})                                      // admin-only
+	reg.Register("ping", &stubHandler{role: types.RoleGuest})                                      // open
+	reg.Register("v1only", &stubHandler{role: types.RoleGuest, apiVers: []int{types.ApiVersion1}}) // known, v1-only
 
 	cases := []struct {
 		name       string
@@ -58,6 +61,12 @@ func TestDispatchGateOrder(t *testing.T) {
 			"ping", types.ApiVersion1, true, true, types.RpcTOO_BUSY},
 		{"open method while idle → success",
 			"ping", types.ApiVersion1, false, false, 0},
+		{"known v1-only method at unsupported in-range version → METHOD_NOT_FOUND (not INVALID_API_VERSION)",
+			"v1only", types.ApiVersion2, false, true, types.RpcMETHOD_NOT_FOUND},
+		{"known v1-only method at unsupported version while saturated → TOO_BUSY (busy before unknown)",
+			"v1only", types.ApiVersion2, true, true, types.RpcTOO_BUSY},
+		{"known v1-only method at its supported version → success",
+			"v1only", types.ApiVersion1, false, false, 0},
 	}
 
 	for _, c := range cases {
@@ -124,4 +133,38 @@ func TestHTTPForbiddenBeatsBusy(t *testing.T) {
 		result := decodeEnvelope(t, rr.Body.Bytes())
 		assert.Equal(t, "tooBusy", result["error"])
 	})
+}
+
+// TestHTTPKnownMethodUnsupportedVersionIsUnknownCommand pins the wire shape for a
+// known but version-restricted command (like tx_history / ledger_header, both
+// registered for api_version 1 only) requested at an in-range but unsupported
+// version. rippled's getHandler returns null on a name match with no version-
+// range match (Handler.cpp:265-272) → rpcUNKNOWN_COMMAND; it never emits
+// invalid_API_version for an in-range version. The request must therefore render
+// identically to a genuinely unknown method (token unknownCmd), not as the 400
+// invalid_API_version bare token.
+func TestHTTPKnownMethodUnsupportedVersionIsUnknownCommand(t *testing.T) {
+	services := types.NewServiceContainer(nil)
+	srv := NewServer(time.Second, services)
+	srv.registry.Register("v1only", &stubHandler{role: types.RoleGuest, apiVers: []int{types.ApiVersion1}})
+
+	post := func(body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+		req.RemoteAddr = "192.0.2.1:1234" // never localhost → RoleGuest
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		return rr
+	}
+
+	unsupported := post(`{"method":"v1only","params":[{"api_version":2}]}`)
+	unknown := post(`{"method":"nope","params":[{"api_version":2}]}`)
+
+	require.NotEqual(t, http.StatusBadRequest, unsupported.Code,
+		"v1only@v2 must not take the 400 invalid_API_version path; body: %s", unsupported.Body.String())
+	assert.NotContains(t, unsupported.Body.String(), "invalid_API_version")
+	assert.Equal(t, unknown.Code, unsupported.Code,
+		"v1only@v2 status must match a genuinely unknown command")
+	assert.Equal(t, "unknownCmd", decodeEnvelope(t, unsupported.Body.Bytes())["error"],
+		"known method at an unsupported version must render as unknownCmd, not invalid_API_version")
+	assert.Equal(t, "unknownCmd", decodeEnvelope(t, unknown.Body.Bytes())["error"])
 }

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -619,11 +619,22 @@ func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types
 
 // dispatchMethod is the transport-agnostic dispatch core shared by the HTTP
 // (Server.executeMethod) and WebSocket (WebSocketServer.handleRPCMethod)
-// paths. It mirrors rippled's fillHandler gate order (RPCHandler.cpp:132-176):
-// busy → registry lookup → api-version → admin gate → conditionMet, then the
-// load gate → handle → load finalize. Hoisting it keeps the two transports
-// from drifting (the WS path previously skipped conditionMet). The only
-// transport-specific bit is the admin-gate error, supplied by adminGate.
+// paths. Hoisting it keeps the two transports from drifting (the WS path
+// previously skipped conditionMet). The only transport-specific bit is the
+// admin-gate error, supplied by adminGate.
+//
+// The gate order spans rippled's two layers: the role-layer FORBID short-
+// circuits in ServerHandler::processRequest *before* doCommand, while the
+// job-queue busy gate lives inside fillHandler. The effective sequence is:
+//
+//	api-version (400) → FORBID (403) → busy (rpcTOO_BUSY) → unknown-command →
+//	conditionMet → load gate → handle → load finalize
+//
+// FORBID therefore precedes busy: a forbidden admin request under queue
+// saturation is denied 403, not rpcTOO_BUSY. busy still precedes the
+// unknown-command failure, so an unknown method under saturation stays
+// rpcTOO_BUSY (an unknown method is never forbidden — its required role
+// resolves to GUEST, not ADMIN).
 func dispatchMethod(
 	registry *types.MethodRegistry,
 	tracker *loadtrack.Tracker,
@@ -634,32 +645,38 @@ func dispatchMethod(
 	adminGate func(string) *types.RpcError,
 	log xrpllog.Logger,
 ) (any, *types.RpcError) {
-	// rippled checks the job-queue busy gate first, before command lookup,
-	// the version check, the admin gate and conditionMet (RPCHandler.cpp:132-141).
-	if rpcErr := handlers.RequireNotBusyClient(ctx); rpcErr != nil {
-		return nil, rpcErr
-	}
-
+	// Resolve the handler without yet failing on an unknown method: the
+	// api-version and FORBID gates run ahead of the unknown-command failure,
+	// and the busy gate runs between them.
 	handler, exists := registry.Get(method)
-	if !exists {
-		return nil, types.RpcErrorMethodNotFound(method)
-	}
 
-	// rippled's getHandler resolves the command together with its api-version
-	// support, before the admin gate and conditionMet (RPCHandler.cpp:160-169).
+	// The api-version range is rejected regardless of the command; the
+	// per-handler support set is checked only when the command is known.
 	if rpcErr := validateApiVersion(ctx, handler); rpcErr != nil {
 		return nil, rpcErr
 	}
 
 	// Refuse an admin-only command for a non-admin caller. rippled decides this
-	// at the role layer (Role::FORBID) before the handler runs and charges
+	// at the role layer (Role::FORBID) before doCommand runs and charges
 	// feeMalformedRPC (ServerHandler.cpp:750-762, :482-486). The gate returns
 	// before the normal finalizeLoad site, so charge here; loadKindFor maps the
-	// forbidden error to the malformed bucket.
-	if handler.RequiredRole() == types.RoleAdmin && ctx.Role != types.RoleAdmin {
+	// forbidden error to the malformed bucket. An unknown method is not gated
+	// here — rippled's roleRequired yields GUEST for it, deferring to the
+	// busy-then-unknown-command path below.
+	if exists && handler.RequiredRole() == types.RoleAdmin && ctx.Role != types.RoleAdmin {
 		rpcErr := adminGate(method)
 		finalizeLoad(tracker, ctx, method, handler, rpcErr, log)
 		return nil, rpcErr
+	}
+
+	// The job-queue busy gate sheds after FORBID but before the unknown-command
+	// failure (RPCHandler.cpp:132-141, ahead of :143-164).
+	if rpcErr := handlers.RequireNotBusyClient(ctx); rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	if !exists {
+		return nil, types.RpcErrorMethodNotFound(method)
 	}
 
 	// Enforce the method's precondition, mirroring rippled's RPC::conditionMet
@@ -693,6 +710,11 @@ func betaEnabled(ctx *types.RpcContext) bool {
 // and the per-handler support set (Handler.cpp:257-263). A version above the
 // beta-gated maximum, or one the handler does not list, yields
 // invalid_API_version.
+//
+// The range check is handler-independent and so runs even for an unknown
+// command (handler nil), matching rippled rejecting an invalid api_version
+// ahead of command resolution; the per-handler support set is skipped when
+// there is no handler.
 func validateApiVersion(ctx *types.RpcContext, handler types.MethodHandler) *types.RpcError {
 	maxVersion := types.MaxSupportedApiVersion
 	if betaEnabled(ctx) {
@@ -700,6 +722,9 @@ func validateApiVersion(ctx *types.RpcContext, handler types.MethodHandler) *typ
 	}
 	if ctx.ApiVersion < types.ApiVersion1 || ctx.ApiVersion > maxVersion {
 		return types.RpcErrorInvalidApiVersion(strconv.Itoa(ctx.ApiVersion))
+	}
+	if handler == nil {
+		return nil
 	}
 	supportedVersions := handler.SupportedApiVersions()
 	if len(supportedVersions) > 0 && !slices.Contains(supportedVersions, ctx.ApiVersion) {

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -632,9 +632,10 @@ func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types
 //
 // FORBID therefore precedes busy: a forbidden admin request under queue
 // saturation is denied 403, not rpcTOO_BUSY. busy still precedes the
-// unknown-command failure, so an unknown method under saturation stays
-// rpcTOO_BUSY (an unknown method is never forbidden — its required role
-// resolves to GUEST, not ADMIN).
+// unknown-command failure, so an unresolved command under saturation stays
+// rpcTOO_BUSY (a command that does not resolve — unknown, or known but not
+// served at the requested api_version — is never forbidden; rippled's
+// roleRequired yields GUEST for it).
 func dispatchMethod(
 	registry *types.MethodRegistry,
 	tracker *loadtrack.Tracker,
@@ -645,25 +646,30 @@ func dispatchMethod(
 	adminGate func(string) *types.RpcError,
 	log xrpllog.Logger,
 ) (any, *types.RpcError) {
-	// Resolve the handler without yet failing on an unknown method: the
-	// api-version and FORBID gates run ahead of the unknown-command failure,
-	// and the busy gate runs between them.
+	// Resolve the handler without yet failing: the api-version and FORBID gates
+	// run ahead of the unknown-command failure, with the busy gate between them.
 	handler, exists := registry.Get(method)
 
-	// The api-version range is rejected regardless of the command; the
-	// per-handler support set is checked only when the command is known.
-	if rpcErr := validateApiVersion(ctx, handler); rpcErr != nil {
+	// The api_version range is handler-independent and rejected ahead of command
+	// resolution.
+	if rpcErr := validateApiVersion(ctx); rpcErr != nil {
 		return nil, rpcErr
 	}
+
+	// A known command whose handler does not serve the requested (in-range)
+	// api_version resolves to "unknown command", mirroring rippled's getHandler
+	// returning null on a name match with no version-range match
+	// (Handler.cpp:265-272) → rpcUNKNOWN_COMMAND, not invalid_API_version. Such a
+	// request is also not forbidden: rippled's roleRequired yields GUEST when the
+	// lookup misses, deferring to the busy-then-unknown-command path below.
+	resolved := exists && handlerSupportsVersion(handler, ctx.ApiVersion)
 
 	// Refuse an admin-only command for a non-admin caller. rippled decides this
 	// at the role layer (Role::FORBID) before doCommand runs and charges
 	// feeMalformedRPC (ServerHandler.cpp:750-762, :482-486). The gate returns
 	// before the normal finalizeLoad site, so charge here; loadKindFor maps the
-	// forbidden error to the malformed bucket. An unknown method is not gated
-	// here — rippled's roleRequired yields GUEST for it, deferring to the
-	// busy-then-unknown-command path below.
-	if exists && handler.RequiredRole() == types.RoleAdmin && ctx.Role != types.RoleAdmin {
+	// forbidden error to the malformed bucket.
+	if resolved && handler.RequiredRole() == types.RoleAdmin && ctx.Role != types.RoleAdmin {
 		rpcErr := adminGate(method)
 		finalizeLoad(tracker, ctx, method, handler, rpcErr, log)
 		return nil, rpcErr
@@ -675,7 +681,7 @@ func dispatchMethod(
 		return nil, rpcErr
 	}
 
-	if !exists {
+	if !resolved {
 		return nil, types.RpcErrorMethodNotFound(method)
 	}
 
@@ -705,17 +711,13 @@ func betaEnabled(ctx *types.RpcContext) bool {
 }
 
 // validateApiVersion enforces the accepted api_version range, mirroring
-// rippled's two checks: the dispatch-layer cap (getAPIVersionNumber rejecting
-// anything above apiBetaVersion when beta is off, ServerHandler.cpp:685-695),
-// and the per-handler support set (Handler.cpp:257-263). A version above the
-// beta-gated maximum, or one the handler does not list, yields
-// invalid_API_version.
-//
-// The range check is handler-independent and so runs even for an unknown
-// command (handler nil), matching rippled rejecting an invalid api_version
-// ahead of command resolution; the per-handler support set is skipped when
-// there is no handler.
-func validateApiVersion(ctx *types.RpcContext, handler types.MethodHandler) *types.RpcError {
+// rippled's dispatch-layer cap (getAPIVersionNumber rejecting anything above
+// apiBetaVersion when beta is off, ServerHandler.cpp:685-695). It is handler-
+// independent: a version outside the range yields invalid_API_version ahead of
+// command resolution, exactly as rippled rejects it before reaching a handler.
+// The narrower per-handler support set is enforced separately as part of
+// command resolution — see handlerSupportsVersion.
+func validateApiVersion(ctx *types.RpcContext) *types.RpcError {
 	maxVersion := types.MaxSupportedApiVersion
 	if betaEnabled(ctx) {
 		maxVersion = types.BetaApiVersion
@@ -723,14 +725,18 @@ func validateApiVersion(ctx *types.RpcContext, handler types.MethodHandler) *typ
 	if ctx.ApiVersion < types.ApiVersion1 || ctx.ApiVersion > maxVersion {
 		return types.RpcErrorInvalidApiVersion(strconv.Itoa(ctx.ApiVersion))
 	}
-	if handler == nil {
-		return nil
-	}
-	supportedVersions := handler.SupportedApiVersions()
-	if len(supportedVersions) > 0 && !slices.Contains(supportedVersions, ctx.ApiVersion) {
-		return types.RpcErrorInvalidApiVersion(strconv.Itoa(ctx.ApiVersion))
-	}
 	return nil
+}
+
+// handlerSupportsVersion reports whether the handler serves the requested
+// api_version; a handler listing no versions serves every in-range version.
+// rippled folds this per-handler range match into getHandler (Handler.cpp:265-
+// 272): a name match whose version falls outside the handler's range returns
+// null, which the caller treats as an unknown command — never as an invalid
+// api_version (that error is reserved for the out-of-range dispatch-layer cap).
+func handlerSupportsVersion(handler types.MethodHandler, version int) bool {
+	supportedVersions := handler.SupportedApiVersions()
+	return len(supportedVersions) == 0 || slices.Contains(supportedVersions, version)
 }
 
 // maxValidatedLedgerAge mirrors rippled's Tuning::maxValidatedLedgerAge


### PR DESCRIPTION
## Summary

- The shared `dispatchMethod` core (used by both the HTTP and WebSocket transports) checked the job-queue **busy gate before the role-layer FORBID gate** — the reverse of rippled. Under queue saturation a forbidden admin-only request returned `rpcTOO_BUSY` (HTTP 200/503 envelope) where rippled returns **403 "Forbidden"**.
- rippled resolves `Role::FORBID` in `ServerHandler::processRequest` ahead of `doCommand`, while the busy gate lives inside `fillHandler`. Resequenced the chain to the rippled-faithful order: **api-version (400) → FORBID (403) → busy (rpcTOO_BUSY) → unknown-command → conditionMet → load/handle**.
- Implementation: peek the handler without failing on an unknown method; run the handler-independent api-version range check (now nil-safe for the peek); gate FORBID before busy (only for **known** admin-only methods); keep busy ahead of the unknown-command failure.
- An unknown method under saturation still returns `rpcTOO_BUSY` — its required role resolves to GUEST (never FORBID), matching rippled's `roleRequired`. The optional 503-before-FORBID overload divergence noted in the issue is intentionally left out of scope (the target order keeps the load gate at the end).

## Test plan

- [x] `go test ./internal/rpc/...` — full package + subpackages pass
- [x] New `internal/rpc/dispatch_gate_order_test.go`:
  - forbidden admin **+ saturated** → `rpcFORBIDDEN` / HTTP **403** (not `rpcTOO_BUSY`)
  - unknown method **+ saturated** → stays `rpcTOO_BUSY` / HTTP **503** (busy-before-unknown guard)
  - invalid `api_version` **+ forbidden admin** → `invalid_API_version` (api-version before FORBID)
  - open method **+ saturated** → `rpcTOO_BUSY` (busy still fires when not forbidden)
- [x] Verified the new tests fail against the pre-fix order (return code 9 / 503) and pass after the fix
- [x] `go vet`, `gofmt`, `go build ./...` clean

Fixes #970