### PR TITLE
fix: walk owner directory for aggregation account RPCs

### DIFF
--- a/internal/ledger/service/account_query.go
+++ b/internal/ledger/service/account_query.go
@@ -1085,31 +1085,26 @@ func (s *Service) GetAccountCurrencies(ctx context.Context, account string, ledg
 	receiveCurrencies := make(map[string]bool)
 	sendCurrencies := make(map[string]bool)
 
-	targetLedger.ForEachCtx(ctx, func(key [32]byte, data []byte) bool {
-		if ctx.Err() != nil {
-			return false
+	dirKey := keylet.OwnerDir(accountID)
+	walkErr := state.DirForEach(targetLedger, dirKey, func(itemKey [32]byte) error {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		// Check if this is a RippleState entry (trust line)
-		if len(data) < 3 {
-			return true
+		data, err := targetLedger.Read(keylet.Keylet{Key: itemKey})
+		if err != nil || data == nil {
+			return nil
 		}
-
-		// Check LedgerEntryType field
-		if data[0] != 0x11 { // UInt16 type code 1, field code 1
-			return true
-		}
-		entryType := uint16(data[1])<<8 | uint16(data[2])
-		if entryType != 0x0072 { // RippleState type
-			return true
+		if state.EntryType(data) != "RippleState" {
+			return nil
 		}
 
-		// Parse the RippleState
 		rs, err := state.ParseRippleState(data)
 		if err != nil {
-			return true
+			return nil
 		}
 
-		// Check if this trust line involves our account
+		// Membership in the owner directory already implies ownership; the
+		// low/high check selects our side and defensively skips foreign lines.
 		lowID, _ := decodeAccountIDLocal(rs.LowLimit.Issuer)
 		highID, _ := decodeAccountIDLocal(rs.HighLimit.Issuer)
 
@@ -1120,7 +1115,7 @@ func (s *Service) GetAccountCurrencies(ctx context.Context, account string, ledg
 		} else if highID == accountID {
 			isLowAccount = false
 		} else {
-			return true // Not our account
+			return nil // Not our account
 		}
 
 		currency := rs.Balance.Currency
@@ -1180,10 +1175,10 @@ func (s *Service) GetAccountCurrencies(ctx context.Context, account string, ledg
 			}
 		}
 
-		return true
+		return nil
 	})
-	if err := ctx.Err(); err != nil {
-		return nil, err
+	if walkErr != nil {
+		return nil, walkErr
 	}
 
 	// Convert maps to sorted slices
@@ -1351,6 +1346,38 @@ type GatewayBalancesResult struct {
 	Validated      bool
 }
 
+// addEscrowLocked sums an Escrow entry's amount into the locked map keyed by
+// currency, mirroring rippled's GatewayBalances handling of escrow objects in
+// the owner directory. XRP escrows key on "XRP"; MPT escrows are skipped because
+// they carry no currency code to sum under.
+func addEscrowLocked(locked map[string]tx.Amount, data []byte) {
+	esc, err := state.ParseEscrow(data)
+	if err != nil {
+		return
+	}
+
+	var amount tx.Amount
+	var currency string
+	switch {
+	case esc.IsXRP:
+		amount = state.NewXRPAmountFromInt(int64(esc.Amount))
+		currency = "XRP"
+	case esc.IOUAmount != nil && !esc.IOUAmount.IsMPT():
+		amount = *esc.IOUAmount
+		currency = amount.Currency
+	default:
+		return
+	}
+
+	if existing, ok := locked[currency]; ok {
+		if sum, err := existing.Add(amount); err == nil {
+			locked[currency] = sum
+		}
+		return
+	}
+	locked[currency] = amount
+}
+
 // GetGatewayBalances retrieves obligations and balances for a gateway account
 func (s *Service) GetGatewayBalances(ctx context.Context, account string, hotWallets []string, ledgerIndex string) (*GatewayBalancesResult, error) {
 	if err := ctx.Err(); err != nil {
@@ -1400,29 +1427,31 @@ func (s *Service) GetGatewayBalances(ctx context.Context, account string, hotWal
 	hotBalances := make(map[string][]CurrencyBalance) // account -> balances
 	frozenBalances := make(map[string][]CurrencyBalance)
 	assets := make(map[string][]CurrencyBalance)
+	locked := make(map[string]tx.Amount) // currency -> total escrowed
 
-	// Iterate through all trust lines
-	targetLedger.ForEachCtx(ctx, func(key [32]byte, data []byte) bool {
-		if ctx.Err() != nil {
-			return false
+	// Walk the gateway's owner directory: trust lines and escrows only.
+	dirKey := keylet.OwnerDir(accountID)
+	walkErr := state.DirForEach(targetLedger, dirKey, func(itemKey [32]byte) error {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		// Check if this is a RippleState entry
-		if len(data) < 3 {
-			return true
-		}
-
-		if data[0] != 0x11 { // UInt16 type code 1, field code 1
-			return true
-		}
-		entryType := uint16(data[1])<<8 | uint16(data[2])
-		if entryType != 0x0072 { // RippleState type
-			return true
+		data, err := targetLedger.Read(keylet.Keylet{Key: itemKey})
+		if err != nil || data == nil {
+			return nil
 		}
 
-		// Parse the RippleState
+		entryType := state.EntryType(data)
+		if entryType == "Escrow" {
+			addEscrowLocked(locked, data)
+			return nil
+		}
+		if entryType != "RippleState" {
+			return nil
+		}
+
 		rs, err := state.ParseRippleState(data)
 		if err != nil {
-			return true
+			return nil
 		}
 
 		// Check if this trust line involves our account
@@ -1439,12 +1468,12 @@ func (s *Service) GetGatewayBalances(ctx context.Context, account string, hotWal
 			isLowAccount = false
 			peerID = lowID
 		} else {
-			return true // Not our account
+			return nil // Not our account
 		}
 
 		// Check if balance is zero
 		if rs.Balance.IsZero() {
-			return true
+			return nil
 		}
 
 		// Get the balance from the gateway's perspective.
@@ -1516,16 +1545,22 @@ func (s *Service) GetGatewayBalances(ctx context.Context, account string, hotWal
 			}
 		}
 
-		return true
+		return nil
 	})
-	if err := ctx.Err(); err != nil {
-		return nil, err
+	if walkErr != nil {
+		return nil, walkErr
 	}
 
 	// Convert obligations map to string values
 	obligationsStr := make(map[string]string)
 	for curr, amt := range obligations {
 		obligationsStr[curr] = amt.Value()
+	}
+
+	// Convert escrow totals to string values
+	lockedStr := make(map[string]string, len(locked))
+	for curr, amt := range locked {
+		lockedStr[curr] = amt.Value()
 	}
 
 	result := &GatewayBalancesResult{
@@ -1546,6 +1581,9 @@ func (s *Service) GetGatewayBalances(ctx context.Context, account string, hotWal
 	}
 	if len(assets) > 0 {
 		result.Assets = assets
+	}
+	if len(lockedStr) > 0 {
+		result.Locked = lockedStr
 	}
 
 	return result, nil
@@ -1576,6 +1614,10 @@ const (
 	tfSetNoRipple   uint32 = 0x00020000
 	tfClearNoRipple uint32 = 0x00040000
 )
+
+// errNoRippleLimitReached stops the owner-directory walk in GetNoRippleCheck once
+// limit problems have been collected, mirroring rippled's forEachItemAfter cap.
+var errNoRippleLimitReached = errors.New("noripple_check limit reached")
 
 // GetNoRippleCheck checks trust lines for proper NoRipple flag settings
 func (s *Service) GetNoRippleCheck(ctx context.Context, account string, role string, ledgerIndex string, limit uint32, transactions bool) (*NoRippleCheckResult, error) {
@@ -1659,37 +1701,33 @@ func (s *Service) GetNoRippleCheck(ctx context.Context, account string, role str
 		}
 	}
 
-	// Iterate through trust lines and check NoRipple settings
+	// Walk the account's owner directory and check NoRipple settings, capping the
+	// number of reported problems at limit (rippled's forEachItemAfter limit).
 	problemCount := uint32(0)
-	targetLedger.ForEachCtx(ctx, func(key [32]byte, entryData []byte) bool {
-		if ctx.Err() != nil {
-			return false
+	dirKey := keylet.OwnerDir(accountID)
+	walkErr := state.DirForEach(targetLedger, dirKey, func(itemKey [32]byte) error {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		// Check if we've reached the limit
 		if problemCount >= limit {
-			return false
+			return errNoRippleLimitReached
 		}
 
-		// Check if this is a RippleState entry
-		if len(entryData) < 3 {
-			return true
+		entryData, err := targetLedger.Read(keylet.Keylet{Key: itemKey})
+		if err != nil || entryData == nil {
+			return nil
+		}
+		if state.EntryType(entryData) != "RippleState" {
+			return nil
 		}
 
-		if entryData[0] != 0x11 { // UInt16 type code 1, field code 1
-			return true
-		}
-		entryType := uint16(entryData[1])<<8 | uint16(entryData[2])
-		if entryType != 0x0072 { // RippleState type
-			return true
-		}
-
-		// Parse the RippleState
 		rs, err := state.ParseRippleState(entryData)
 		if err != nil {
-			return true
+			return nil
 		}
 
-		// Check if this trust line involves our account
+		// Membership in the owner directory already implies ownership; the
+		// low/high check selects our side and defensively skips foreign lines.
 		lowID, _ := decodeAccountIDLocal(rs.LowLimit.Issuer)
 		highID, _ := decodeAccountIDLocal(rs.HighLimit.Issuer)
 
@@ -1703,7 +1741,7 @@ func (s *Service) GetNoRippleCheck(ctx context.Context, account string, role str
 			isLowAccount = false
 			peerAccount = rs.LowLimit.Issuer
 		} else {
-			return true // Not our account
+			return nil // Not our account
 		}
 
 		// Check NoRipple flag for this account's side
@@ -1764,10 +1802,10 @@ func (s *Service) GetNoRippleCheck(ctx context.Context, account string, role str
 			}
 		}
 
-		return true
+		return nil
 	})
-	if err := ctx.Err(); err != nil {
-		return nil, err
+	if walkErr != nil && !errors.Is(walkErr, errNoRippleLimitReached) {
+		return nil, walkErr
 	}
 
 	return &NoRippleCheckResult{

--- a/internal/ledger/service/account_query.go
+++ b/internal/ledger/service/account_query.go
@@ -1108,71 +1108,24 @@ func (s *Service) GetAccountCurrencies(ctx context.Context, account string, ledg
 		lowID, _ := decodeAccountIDLocal(rs.LowLimit.Issuer)
 		highID, _ := decodeAccountIDLocal(rs.HighLimit.Issuer)
 
-		var isLowAccount bool
-
+		// balance is from our perspective (rippled negates it for the high
+		// account); a currency is receivable while balance < our limit and
+		// sendable while -balance < the peer's limit.
+		var balance, ownLimit, peerLimit tx.Amount
 		if lowID == accountID {
-			isLowAccount = true
+			balance, ownLimit, peerLimit = rs.Balance, rs.LowLimit, rs.HighLimit
 		} else if highID == accountID {
-			isLowAccount = false
+			balance, ownLimit, peerLimit = rs.Balance.Negate(), rs.HighLimit, rs.LowLimit
 		} else {
-			return nil // Not our account
+			return nil // not our account
 		}
 
 		currency := rs.Balance.Currency
-
-		// Determine if account can receive and/or send this currency
-		// Based on the balance value and limits
-		if isLowAccount {
-			// We are low account
-			// Balance in RippleState: positive = low owes high (negative balance from our perspective)
-			// Our perspective balance: negative of rs.Balance
-			// receive: if our limit > 0 and balance < limit (there's room to receive)
-			// send: if our perspective balance > 0 (we hold some of this currency)
-
-			// Balance value: positive means low owes high
-			// From low's perspective: balance is negated
-			// If rs.Balance > 0, we owe peer (balance < 0 from our view)
-			// If rs.Balance < 0, peer owes us (balance > 0 from our view)
-
-			// Our limit is rs.LowLimit
-			// We can receive if: limit > balance from our perspective
-			// From our perspective: balance = -rs.Balance
-			// So we can receive if: limit > -rs.Balance
-			// i.e., limit + rs.Balance > 0
-
-			limit := rs.LowLimit
-			balance := rs.Balance.Negate() // Our perspective
-
-			// Can receive if limit > balance (more room to receive)
-			if limit.Signum() > 0 && limit.Compare(balance) > 0 {
-				receiveCurrencies[currency] = true
-			}
-
-			// Can send if balance > 0 (we have some to send)
-			if balance.Signum() > 0 {
-				sendCurrencies[currency] = true
-			}
-		} else {
-			// We are high account
-			// Balance value: positive means low owes high (we hold IOU from low's perspective)
-			// From high's perspective: balance = rs.Balance (same sign)
-
-			// Our limit is rs.HighLimit
-			// We can receive if: limit > balance
-			// We can send if balance > 0
-
-			limit := rs.HighLimit
-			balance := rs.Balance
-
-			// Can receive if limit > balance (more room to receive)
-			if limit.Signum() > 0 && limit.Compare(balance) > 0 {
-				receiveCurrencies[currency] = true
-			}
-
-			// Can send if balance > 0 (we have some to send)
-			if balance.Signum() > 0 {
-				sendCurrencies[currency] = true
-			}
+		if balance.Compare(ownLimit) < 0 {
+			receiveCurrencies[currency] = true
+		}
+		if balance.Negate().Compare(peerLimit) < 0 {
+			sendCurrencies[currency] = true
 		}
 
 		return nil
@@ -1180,6 +1133,11 @@ func (s *Service) GetAccountCurrencies(ctx context.Context, account string, ledg
 	if walkErr != nil {
 		return nil, walkErr
 	}
+
+	// A RippleState cannot legitimately carry the XRP currency code; drop the
+	// reserved sentinel from both sets, as rippled does.
+	delete(receiveCurrencies, "XRP")
+	delete(sendCurrencies, "XRP")
 
 	// Convert maps to sorted slices
 	receiveList := make([]string, 0, len(receiveCurrencies))
@@ -1346,8 +1304,9 @@ type GatewayBalancesResult struct {
 	Validated      bool
 }
 
-// addEscrowLocked sums an Escrow into locked, keyed by currency: XRP escrows key
-// on "XRP"; MPT escrows have no currency code to sum under and are skipped.
+// addEscrowLocked sums an Escrow into locked, keyed by currency. XRP escrows key
+// on "XRP" and IOU escrows on their currency code. MPT escrows are deliberately
+// skipped: they have no currency code to sum under, where rippled instead errors.
 func addEscrowLocked(locked map[string]tx.Amount, data []byte) {
 	esc, err := state.ParseEscrow(data)
 	if err != nil {
@@ -1358,6 +1317,9 @@ func addEscrowLocked(locked map[string]tx.Amount, data []byte) {
 	var currency string
 	switch {
 	case esc.IsXRP:
+		if esc.Amount > state.MaxNativeDrops {
+			return
+		}
 		amount = state.NewXRPAmountFromInt(int64(esc.Amount))
 		currency = "XRP"
 	case esc.IOUAmount != nil && !esc.IOUAmount.IsMPT():
@@ -1367,13 +1329,28 @@ func addEscrowLocked(locked map[string]tx.Amount, data []byte) {
 		return
 	}
 
-	if existing, ok := locked[currency]; ok {
-		if sum, err := existing.Add(amount); err == nil {
-			locked[currency] = sum
-		}
+	existing, ok := locked[currency]
+	if !ok {
+		locked[currency] = amount
 		return
 	}
-	locked[currency] = amount
+	locked[currency] = addLockedSaturating(existing, amount)
+}
+
+// addLockedSaturating returns existing+add, clamping to the largest representable
+// IOU amount on overflow rather than panicking — matching rippled, whose escrow
+// locked sum saturates to the maximum valid amount instead of failing.
+func addLockedSaturating(existing, add tx.Amount) (result tx.Amount) {
+	defer func() {
+		if recover() != nil {
+			result = state.NewIssuedAmountFromValue(state.MaxMantissa, state.MaxExponent, add.Currency, add.Issuer)
+		}
+	}()
+	sum, err := existing.Add(add)
+	if err != nil {
+		return existing
+	}
+	return sum
 }
 
 // GetGatewayBalances retrieves obligations and balances for a gateway account

--- a/internal/ledger/service/account_query.go
+++ b/internal/ledger/service/account_query.go
@@ -1346,10 +1346,8 @@ type GatewayBalancesResult struct {
 	Validated      bool
 }
 
-// addEscrowLocked sums an Escrow entry's amount into the locked map keyed by
-// currency, mirroring rippled's GatewayBalances handling of escrow objects in
-// the owner directory. XRP escrows key on "XRP"; MPT escrows are skipped because
-// they carry no currency code to sum under.
+// addEscrowLocked sums an Escrow into locked, keyed by currency: XRP escrows key
+// on "XRP"; MPT escrows have no currency code to sum under and are skipped.
 func addEscrowLocked(locked map[string]tx.Amount, data []byte) {
 	esc, err := state.ParseEscrow(data)
 	if err != nil {
@@ -1557,7 +1555,6 @@ func (s *Service) GetGatewayBalances(ctx context.Context, account string, hotWal
 		obligationsStr[curr] = amt.Value()
 	}
 
-	// Convert escrow totals to string values
 	lockedStr := make(map[string]string, len(locked))
 	for curr, amt := range locked {
 		lockedStr[curr] = amt.Value()
@@ -1616,7 +1613,7 @@ const (
 )
 
 // errNoRippleLimitReached stops the owner-directory walk in GetNoRippleCheck once
-// limit problems have been collected, mirroring rippled's forEachItemAfter cap.
+// limit problems have been collected.
 var errNoRippleLimitReached = errors.New("noripple_check limit reached")
 
 // GetNoRippleCheck checks trust lines for proper NoRipple flag settings
@@ -1702,7 +1699,7 @@ func (s *Service) GetNoRippleCheck(ctx context.Context, account string, role str
 	}
 
 	// Walk the account's owner directory and check NoRipple settings, capping the
-	// number of reported problems at limit (rippled's forEachItemAfter limit).
+	// number of reported problems at limit.
 	problemCount := uint32(0)
 	dirKey := keylet.OwnerDir(accountID)
 	walkErr := state.DirForEach(targetLedger, dirKey, func(itemKey [32]byte) error {

--- a/internal/ledger/service/account_query_test.go
+++ b/internal/ledger/service/account_query_test.go
@@ -2,11 +2,13 @@ package service
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"strings"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/codec/addresscodec"
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
@@ -46,8 +48,16 @@ func insertLineRaw(t *testing.T, svc *Service, lowAddr, highAddr, currency, rawB
 	if err != nil {
 		t.Fatalf("serialize ripple state: %v", err)
 	}
-	if err := svc.openLedger.Insert(keylet.Line(lowID, highID, currency), data); err != nil {
+	lineKey := keylet.Line(lowID, highID, currency)
+	if err := svc.openLedger.Insert(lineKey, data); err != nil {
 		t.Fatalf("insert ripple state: %v", err)
+	}
+	// A trust line lives in both endpoints' owner directories; mirror that so the
+	// owner-directory query path (gateway_balances, account_currencies, etc.) sees it.
+	for _, id := range [][20]byte{lowID, highID} {
+		if _, derr := state.DirInsert(svc.openLedger, keylet.OwnerDir(id), lineKey.Key, false, nil); derr != nil {
+			t.Fatalf("owner-dir insert: %v", derr)
+		}
 	}
 }
 
@@ -83,6 +93,44 @@ func insertPayChannelEntry(t *testing.T, svc *Service, srcAddr, dstAddr string, 
 	k := keylet.PayChannel(srcID, dstID, seq)
 	if err := svc.openLedger.Insert(k, data); err != nil {
 		t.Fatalf("insert pay channel: %v", err)
+	}
+	return k.Key
+}
+
+// insertXRPEscrow inserts an XRP Escrow owned by ownerAddr holding the given
+// drops, wiring it into both the ledger and the owner's directory so the
+// owner-directory query path observes it.
+func insertXRPEscrow(t *testing.T, svc *Service, ownerAddr, destAddr string, seq uint32, drops string) [32]byte {
+	t.Helper()
+	_, ownerBytes, err := addresscodec.DecodeClassicAddressToAccountID(ownerAddr)
+	if err != nil {
+		t.Fatalf("decode owner: %v", err)
+	}
+	var ownerID [20]byte
+	copy(ownerID[:], ownerBytes)
+
+	hexStr, err := binarycodec.Encode(map[string]any{
+		"LedgerEntryType": "Escrow",
+		"Account":         ownerAddr,
+		"Destination":     destAddr,
+		"Amount":          drops,
+		"OwnerNode":       "0",
+		"Flags":           uint32(0),
+	})
+	if err != nil {
+		t.Fatalf("encode escrow: %v", err)
+	}
+	data, err := hex.DecodeString(hexStr)
+	if err != nil {
+		t.Fatalf("decode escrow hex: %v", err)
+	}
+
+	k := keylet.Escrow(ownerID, seq)
+	if err := svc.openLedger.Insert(k, data); err != nil {
+		t.Fatalf("insert escrow: %v", err)
+	}
+	if _, derr := state.DirInsert(svc.openLedger, keylet.OwnerDir(ownerID), k.Key, false, nil); derr != nil {
+		t.Fatalf("owner-dir insert escrow: %v", derr)
 	}
 	return k.Key
 }
@@ -634,6 +682,59 @@ func TestGetGatewayBalances_Categories(t *testing.T) {
 			t.Fatalf("want error for invalid hot wallet, got nil")
 		}
 	})
+}
+
+func TestGetGatewayBalances_LockedEscrows(t *testing.T) {
+	svc := newOfferTestService(t)
+	gwAddr, _ := addressFromBytes(t, 0x10)
+	destAddr, _ := addressFromBytes(t, 0x40)
+	insertAccountRoot(t, svc, gwAddr, 1_000_000_000_000, 0)
+
+	// Two XRP escrows owned by the gateway lock 1.5 XRP total.
+	insertXRPEscrow(t, svc, gwAddr, destAddr, 1, "1000000")
+	insertXRPEscrow(t, svc, gwAddr, destAddr, 2, "500000")
+	// An ordinary obligation alongside the escrows must still be reported.
+	insertLineRaw(t, svc, gwAddr, destAddr, "USD", "-100", "0", "1000", 0)
+
+	res, err := svc.GetGatewayBalances(context.Background(), gwAddr, nil, "current")
+	if err != nil {
+		t.Fatalf("GetGatewayBalances: %v", err)
+	}
+	if got := res.Locked["XRP"]; got != "1500000" {
+		t.Errorf("locked XRP = %q, want 1500000", got)
+	}
+	if got := res.Obligations["USD"]; got != "100" {
+		t.Errorf("USD obligation = %q, want 100", got)
+	}
+}
+
+// TestGetAccountCurrencies_OwnerDirExcludesForeignLines proves the owner-directory
+// walk yields the same trust-line set the old whole-ledger scan would: it includes
+// the account's own lines and excludes a foreign line between third parties that a
+// scan would otherwise visit.
+func TestGetAccountCurrencies_OwnerDirExcludesForeignLines(t *testing.T) {
+	svc := newOfferTestService(t)
+	acct, _ := addressFromBytes(t, 0x10)
+	peer, _ := addressFromBytes(t, 0x40)
+	other1, _ := addressFromBytes(t, 0x80)
+	other2, _ := addressFromBytes(t, 0x90)
+	insertAccountRoot(t, svc, acct, 1_000_000_000, 0)
+
+	// Our line: acct is low; raw balance -10 means acct holds +10 → can send USD.
+	insertLineRaw(t, svc, acct, peer, "USD", "-10", "1000", "1000", 0)
+	// Foreign line present in the ledger but not in acct's owner directory.
+	insertLineRaw(t, svc, other1, other2, "EUR", "-10", "1000", "1000", 0)
+
+	res, err := svc.GetAccountCurrencies(context.Background(), acct, "current")
+	if err != nil {
+		t.Fatalf("GetAccountCurrencies: %v", err)
+	}
+	if !containsString(res.SendCurrencies, "USD") {
+		t.Errorf("send currencies %v should contain USD", res.SendCurrencies)
+	}
+	if containsString(res.SendCurrencies, "EUR") || containsString(res.ReceiveCurrencies, "EUR") {
+		t.Errorf("foreign EUR line must not surface: send=%v receive=%v", res.SendCurrencies, res.ReceiveCurrencies)
+	}
 }
 
 func TestGetNoRippleCheck_RolesAndProblems(t *testing.T) {

--- a/internal/ledger/service/account_query_test.go
+++ b/internal/ledger/service/account_query_test.go
@@ -737,6 +737,30 @@ func TestGetAccountCurrencies_OwnerDirExcludesForeignLines(t *testing.T) {
 	}
 }
 
+// TestGetAccountCurrencies_RippledLimitSemantics pins the receive/send membership
+// rules to rippled's: receivable iff balance < own limit (no own-limit>0 guard),
+// sendable iff -balance < the peer's limit. acct is low, holds +100 USD, but the
+// peer's limit (50) is below the holding, so USD is receivable but NOT sendable.
+func TestGetAccountCurrencies_RippledLimitSemantics(t *testing.T) {
+	svc := newOfferTestService(t)
+	acct, _ := addressFromBytes(t, 0x10)
+	peer, _ := addressFromBytes(t, 0x40)
+	insertAccountRoot(t, svc, acct, 1_000_000_000, 0)
+
+	insertLineRaw(t, svc, acct, peer, "USD", "-100", "1000", "50", 0)
+
+	res, err := svc.GetAccountCurrencies(context.Background(), acct, "current")
+	if err != nil {
+		t.Fatalf("GetAccountCurrencies: %v", err)
+	}
+	if !containsString(res.ReceiveCurrencies, "USD") {
+		t.Errorf("USD should be receivable (balance -100 < own limit 1000): %v", res.ReceiveCurrencies)
+	}
+	if containsString(res.SendCurrencies, "USD") {
+		t.Errorf("USD must not be sendable (-balance 100 >= peer limit 50): %v", res.SendCurrencies)
+	}
+}
+
 func TestGetNoRippleCheck_RolesAndProblems(t *testing.T) {
 	svc := newOfferTestService(t)
 	gwAddr, _ := addressFromBytes(t, 0x10)


### PR DESCRIPTION
## Summary

- `gateway_balances`, `account_currencies` and `noripple_check` no longer scan the entire ledger (`ForEachCtx`) and filter each `RippleState` by issuer. They walk the queried account's **owner directory** instead (`state.DirForEach` ≡ rippled `forEachItem`), so cost is O(owned objects) rather than O(ledger).
- `gateway_balances` now populates the previously-declared-but-unset `locked` map from **escrows** found in the owner directory, mirroring rippled's `ltESCROW` handling in `GatewayBalances.cpp` (XRP escrows key on `"XRP"`; MPT escrows are skipped as they carry no currency code to sum under).
- `noripple_check` caps reported problems at `limit` via a sentinel-stopped walk (mirrors rippled's `forEachItemAfter` limit), following the existing `errStopBookWalk` pattern in `offer_query.go`.

Because membership in the owner directory already implies ownership, the low/high issuer check becomes a defensive guard. No new ledger state — read-path only.

## Test plan

- [x] `just test-pkg ./internal/ledger/service/...` — existing `account_currencies` / `gateway_balances` / `noripple_check` service tests pass with the shared `insertLineRaw` helper updated to wire trust lines into both endpoints' owner directories.
- [x] Added `TestGetGatewayBalances_LockedEscrows` (escrow → `locked` summing) and `TestGetAccountCurrencies_OwnerDirExcludesForeignLines` (owner-dir walk includes owned lines, excludes a foreign third-party line a scan would visit).
- [x] `go build ./...`, `go vet`, `gofmt` clean; full `internal/ledger/...` and `internal/rpc/...` suites green.

Fixes #967