### PR TITLE
Relay GetLedger to a peer that has the ledger/tx-set

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -116,11 +116,11 @@ type NetworkSender interface {
 	// reaches these gates, so consensus liveness is not starved.
 	// Returns false for unknown peers.
 	ShouldShedLedgerRequest(peerID uint64, loadedLocal bool) bool
-	// PeerWithLedger returns a connected peer (other than exclude) that
-	// advertises ledger hash target, used to relay an unsatisfiable
-	// GetLedger to a peer that can serve it. ok is false when none
-	// qualifies. See Overlay.PeerWithLedger.
-	PeerWithLedger(target [32]byte, exclude uint64) (uint64, bool)
+	// PeerWithLedger returns a connected peer (other than exclude) that can
+	// serve ledger (target, seq) — by advertised hash or covering seq
+	// range — used to relay an unsatisfiable GetLedger to a peer that can
+	// serve it. ok is false when none qualifies. See Overlay.PeerWithLedger.
+	PeerWithLedger(target [32]byte, seq uint32, exclude uint64) (uint64, bool)
 	// PeerWithTxSet returns a connected peer (other than exclude) that
 	// advertised tx-set root target, used to relay an unsatisfiable
 	// liTS_CANDIDATE GetLedger. See Overlay.PeerWithTxSet.
@@ -155,7 +155,7 @@ func (n *noopSender) ReplayCapablePeersExcluding([]uint64, int) []uint64       {
 func (n *noopSender) IncPeerBadData(uint64, string)                            {}
 func (n *noopSender) PeersThatHave([32]byte) []uint64                          { return nil }
 func (n *noopSender) ShouldShedLedgerRequest(uint64, bool) bool                { return false }
-func (n *noopSender) PeerWithLedger([32]byte, uint64) (uint64, bool)           { return 0, false }
+func (n *noopSender) PeerWithLedger([32]byte, uint32, uint64) (uint64, bool)   { return 0, false }
 func (n *noopSender) PeerWithTxSet([32]byte, uint64) (uint64, bool)            { return 0, false }
 func (n *noopSender) NotePeerHasTxSet(uint64, [32]byte)                        {}
 
@@ -686,9 +686,9 @@ func (a *Adaptor) ShouldShedLedgerRequest(peerID uint64, loadedLocal bool) bool 
 }
 
 // PeerWithLedger delegates to NetworkSender; the Router uses it to relay an
-// unsatisfiable GetLedger to a peer that advertises the ledger.
-func (a *Adaptor) PeerWithLedger(target [32]byte, exclude uint64) (uint64, bool) {
-	return a.sender.PeerWithLedger(target, exclude)
+// unsatisfiable GetLedger to a peer that can serve the ledger.
+func (a *Adaptor) PeerWithLedger(target [32]byte, seq uint32, exclude uint64) (uint64, bool) {
+	return a.sender.PeerWithLedger(target, seq, exclude)
 }
 
 // PeerWithTxSet delegates to NetworkSender; the Router uses it to relay an

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -116,6 +116,18 @@ type NetworkSender interface {
 	// reaches these gates, so consensus liveness is not starved.
 	// Returns false for unknown peers.
 	ShouldShedLedgerRequest(peerID uint64, loadedLocal bool) bool
+	// PeerWithLedger returns a connected peer (other than exclude) that
+	// advertises ledger hash target, used to relay an unsatisfiable
+	// GetLedger to a peer that can serve it. ok is false when none
+	// qualifies. See Overlay.PeerWithLedger.
+	PeerWithLedger(target [32]byte, exclude uint64) (uint64, bool)
+	// PeerWithTxSet returns a connected peer (other than exclude) that
+	// advertised tx-set root target, used to relay an unsatisfiable
+	// liTS_CANDIDATE GetLedger. See Overlay.PeerWithTxSet.
+	PeerWithTxSet(target [32]byte, exclude uint64) (uint64, bool)
+	// NotePeerHasTxSet records that peerID advertised tx-set root hash
+	// via mtHAVE_TRANSACTION_SET{tsHAVE}, feeding PeerWithTxSet.
+	NotePeerHasTxSet(peerID uint64, hash [32]byte)
 }
 
 // noopSender is a no-op NetworkSender for standalone or test use.
@@ -143,6 +155,9 @@ func (n *noopSender) ReplayCapablePeersExcluding([]uint64, int) []uint64       {
 func (n *noopSender) IncPeerBadData(uint64, string)                            {}
 func (n *noopSender) PeersThatHave([32]byte) []uint64                          { return nil }
 func (n *noopSender) ShouldShedLedgerRequest(uint64, bool) bool                { return false }
+func (n *noopSender) PeerWithLedger([32]byte, uint64) (uint64, bool)           { return 0, false }
+func (n *noopSender) PeerWithTxSet([32]byte, uint64) (uint64, bool)            { return 0, false }
+func (n *noopSender) NotePeerHasTxSet(uint64, [32]byte)                        {}
 
 // Compile-time interface check.
 var _ consensus.Adaptor = (*Adaptor)(nil)
@@ -668,6 +683,26 @@ func (a *Adaptor) SendToPeer(peerID uint64, frame []byte) error {
 // through the adaptor rather than reaching into the overlay directly.
 func (a *Adaptor) ShouldShedLedgerRequest(peerID uint64, loadedLocal bool) bool {
 	return a.sender.ShouldShedLedgerRequest(peerID, loadedLocal)
+}
+
+// PeerWithLedger delegates to NetworkSender; the Router uses it to relay an
+// unsatisfiable GetLedger to a peer that advertises the ledger.
+func (a *Adaptor) PeerWithLedger(target [32]byte, exclude uint64) (uint64, bool) {
+	return a.sender.PeerWithLedger(target, exclude)
+}
+
+// PeerWithTxSet delegates to NetworkSender; the Router uses it to relay an
+// unsatisfiable liTS_CANDIDATE GetLedger to a peer that advertised the
+// tx-set.
+func (a *Adaptor) PeerWithTxSet(target [32]byte, exclude uint64) (uint64, bool) {
+	return a.sender.PeerWithTxSet(target, exclude)
+}
+
+// NotePeerHasTxSet delegates to NetworkSender; the Router calls it on
+// inbound mtHAVE_TRANSACTION_SET{tsHAVE} so PeerWithTxSet can later find
+// the advertising peer.
+func (a *Adaptor) NotePeerHasTxSet(peerID uint64, hash [32]byte) {
+	a.sender.NotePeerHasTxSet(peerID, hash)
 }
 
 // LedgerService returns the underlying ledger service for direct queries.

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -781,6 +781,15 @@ func (r *Router) handleLedgerData(msg *peermanagement.InboundMessage) {
 		return
 	}
 
+	// A reply carrying a request_cookie answers a GetLedger we relayed on
+	// another peer's behalf. Route it back to the original requester named
+	// by the cookie and do not consume it locally. Mirrors rippled
+	// onMessage(TMLedgerData).
+	if ld.RequestCookie != 0 {
+		r.routeRelayedLedgerData(ld, msg.PeerID)
+		return
+	}
+
 	var il *inbound.Ledger
 	if len(ld.LedgerHash) == 32 {
 		var h [32]byte

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -445,8 +445,9 @@ func (r *Router) handleHaveSet(msg *peermanagement.InboundMessage) {
 
 	switch status {
 	case message.TxSetStatusHave:
-		// Peer has a tx set we might need — if the engine is waiting for it,
-		// we could request the full set. For now, just log.
+		// Record the advertisement so an inbound GetLedger we can't satisfy
+		// can be relayed to this peer (rippled getPeerWithTree).
+		r.adaptor.NotePeerHasTxSet(uint64(msg.PeerID), [32]byte(txSetID))
 		r.logger.Debug("peer has txset", "txset", txSetID, "peer", msg.PeerID)
 	case message.TxSetStatusNeed:
 		// Peer needs a tx set we might have — check cache and respond.

--- a/internal/consensus/adaptor/router_relay.go
+++ b/internal/consensus/adaptor/router_relay.go
@@ -22,21 +22,28 @@ func (r *Router) maybeRelayGetLedger(from peermanagement.PeerID, req *message.Ge
 	if req.QueryType == nil || req.RequestCookie != 0 {
 		return false
 	}
-	// A peer is located only by the advertised ledger/tx-set hash carried in
-	// ledger_hash; a seq-only request can't be matched against the per-peer
-	// hints go-xrpl tracks.
-	if len(req.LedgerHash) != 32 {
-		return false
-	}
+
 	var target [32]byte
-	copy(target[:], req.LedgerHash)
+	hasHash := len(req.LedgerHash) == 32
+	if hasHash {
+		copy(target[:], req.LedgerHash)
+	}
 
 	var peer uint64
 	var ok bool
 	if req.InfoType == message.LedgerInfoTsCandidate {
+		// A tx-set is located only by its root hash.
+		if !hasHash {
+			return false
+		}
 		peer, ok = r.adaptor.PeerWithTxSet(target, uint64(from))
 	} else {
-		peer, ok = r.adaptor.PeerWithLedger(target, uint64(from))
+		// A ledger is located by advertised hash or a covering seq range
+		// (rippled getPeerWithLedger(hash, seq)); bail when we have neither.
+		if !hasHash && req.LedgerSeq == 0 {
+			return false
+		}
+		peer, ok = r.adaptor.PeerWithLedger(target, req.LedgerSeq, uint64(from))
 	}
 	if !ok {
 		return false

--- a/internal/consensus/adaptor/router_relay.go
+++ b/internal/consensus/adaptor/router_relay.go
@@ -1,0 +1,80 @@
+package adaptor
+
+import (
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+)
+
+// maybeRelayGetLedger forwards an unsatisfiable GetLedger to a peer that
+// advertises the requested ledger (liBASE / liAS_NODE / liTX_NODE) or
+// tx-set (liTS_CANDIDATE), mirroring rippled's getLedger / getTxSet relay.
+// It returns true when the request was relayed, in which case the caller
+// must stop processing it locally.
+//
+// Only an ORIGINAL, indirect request is relayed: query_type present AND
+// request_cookie absent — rippled's has_querytype() && !has_requestcookie()
+// predicate. A request that already carries a cookie has been relayed once
+// and is never relayed again (loop prevention); fan-out is capped at the
+// single best peer. The relayed frame is stamped with
+// request_cookie = our local id for the original requester so the eventual
+// TMLedgerData reply routes back through routeRelayedLedgerData.
+func (r *Router) maybeRelayGetLedger(from peermanagement.PeerID, req *message.GetLedger) bool {
+	if req.QueryType == nil || req.RequestCookie != 0 {
+		return false
+	}
+	// A peer is located only by the advertised ledger/tx-set hash carried in
+	// ledger_hash; a seq-only request can't be matched against the per-peer
+	// hints go-xrpl tracks.
+	if len(req.LedgerHash) != 32 {
+		return false
+	}
+	var target [32]byte
+	copy(target[:], req.LedgerHash)
+
+	var peer uint64
+	var ok bool
+	if req.InfoType == message.LedgerInfoTsCandidate {
+		peer, ok = r.adaptor.PeerWithTxSet(target, uint64(from))
+	} else {
+		peer, ok = r.adaptor.PeerWithLedger(target, uint64(from))
+	}
+	if !ok {
+		return false
+	}
+
+	relayed := *req
+	relayed.RequestCookie = uint64(from)
+	frame, err := encodeFrame(message.TypeGetLedger, &relayed)
+	if err != nil {
+		r.logger.Warn("failed to encode relayed get_ledger", "error", err)
+		return false
+	}
+	if err := r.adaptor.SendToPeer(peer, frame); err != nil {
+		r.logger.Debug("failed to relay get_ledger",
+			"error", err, "to", peer, "from", from)
+		return false
+	}
+	r.logger.Debug("relayed get_ledger to peer with data",
+		"from", from, "to", peer, "itype", req.InfoType)
+	return true
+}
+
+// routeRelayedLedgerData forwards a TMLedgerData carrying a request_cookie
+// back to the original requester named by the cookie, clearing the cookie
+// so the requester consumes the reply locally rather than re-relaying it.
+// Mirrors rippled onMessage(TMLedgerData)'s findPeerByShortID branch: an
+// unroutable cookie (the requester has since disconnected) is dropped.
+func (r *Router) routeRelayedLedgerData(ld *message.LedgerData, from peermanagement.PeerID) {
+	target := uint64(ld.RequestCookie)
+	out := *ld
+	out.RequestCookie = 0
+	frame, err := encodeFrame(message.TypeLedgerData, &out)
+	if err != nil {
+		r.logger.Warn("failed to encode relayed ledger_data", "error", err)
+		return
+	}
+	if err := r.adaptor.SendToPeer(target, frame); err != nil {
+		r.logger.Debug("unable to route ledger_data reply to original requester",
+			"error", err, "cookie", target, "from", from)
+	}
+}

--- a/internal/consensus/adaptor/router_relay.go
+++ b/internal/consensus/adaptor/router_relay.go
@@ -38,9 +38,11 @@ func (r *Router) maybeRelayGetLedger(from peermanagement.PeerID, req *message.Ge
 		}
 		peer, ok = r.adaptor.PeerWithTxSet(target, uint64(from))
 	} else {
-		// A ledger is located by advertised hash or a covering seq range
-		// (rippled getPeerWithLedger(hash, seq)); bail when we have neither.
-		if !hasHash && req.LedgerSeq == 0 {
+		// rippled relays a ledger request only from its has_ledgerhash()
+		// branch (getLedger, PeerImp.cpp:3165/3175); a seq-only miss is
+		// never relayed. Require a hash, then pass the seq as the secondary
+		// range filter exactly as getPeerWithLedger(hash, seq) does.
+		if !hasHash {
 			return false
 		}
 		peer, ok = r.adaptor.PeerWithLedger(target, req.LedgerSeq, uint64(from))
@@ -81,7 +83,7 @@ func (r *Router) routeRelayedLedgerData(ld *message.LedgerData, from peermanagem
 		return
 	}
 	if err := r.adaptor.SendToPeer(target, frame); err != nil {
-		r.logger.Debug("unable to route ledger_data reply to original requester",
+		r.logger.Info("unable to route ledger_data reply to original requester",
 			"error", err, "cookie", target, "from", from)
 	}
 }

--- a/internal/consensus/adaptor/router_relay_test.go
+++ b/internal/consensus/adaptor/router_relay_test.go
@@ -1,0 +1,283 @@
+package adaptor
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// relayRecorder is a NetworkSender that records SendToPeer / NotePeerHasTxSet
+// and serves configurable PeerWithLedger / PeerWithTxSet answers, so the
+// GetLedger relay path can be exercised without a real overlay.
+type relayRecorder struct {
+	noopSender
+	mu          sync.Mutex
+	sent        []sentFrame
+	noted       []notedTxSet
+	lastExclude uint64
+
+	ledgerPeer uint64
+	ledgerOK   bool
+	txsetPeer  uint64
+	txsetOK    bool
+}
+
+type notedTxSet struct {
+	peerID uint64
+	hash   [32]byte
+}
+
+func (s *relayRecorder) SendToPeer(peerID uint64, frame []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sent = append(s.sent, sentFrame{peerID: peerID, frame: append([]byte(nil), frame...)})
+	return nil
+}
+
+func (s *relayRecorder) PeerWithLedger(_ [32]byte, exclude uint64) (uint64, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastExclude = exclude
+	return s.ledgerPeer, s.ledgerOK
+}
+
+func (s *relayRecorder) PeerWithTxSet(_ [32]byte, exclude uint64) (uint64, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastExclude = exclude
+	return s.txsetPeer, s.txsetOK
+}
+
+func (s *relayRecorder) NotePeerHasTxSet(peerID uint64, hash [32]byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.noted = append(s.noted, notedTxSet{peerID: peerID, hash: hash})
+}
+
+func (s *relayRecorder) sentFrames() []sentFrame {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]sentFrame(nil), s.sent...)
+}
+
+func (s *relayRecorder) notedTxSets() []notedTxSet {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]notedTxSet(nil), s.noted...)
+}
+
+func (s *relayRecorder) excludeArg() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastExclude
+}
+
+func makeRouterWithRelayRecorder(t *testing.T) (*Router, *relayRecorder) {
+	t.Helper()
+	svc := newTestLedgerService(t)
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	rs := &relayRecorder{}
+	a := New(Config{
+		LedgerService: svc,
+		Sender:        rs,
+		Identity:      identity,
+	})
+	inbox := make(chan *peermanagement.InboundMessage, 8)
+	r := NewRouter(nil, a, inbox)
+	return r, rs
+}
+
+// TestRouter_GetLedger_RelayOnMiss_Ledger pins rippled's getLedger relay:
+// when a peer asks for a ledger we don't have and the request is an original
+// indirect one (query_type present, no cookie), forward it to a peer that
+// advertises the ledger — stamped with request_cookie = the requester's id —
+// rather than dropping it.
+func TestRouter_GetLedger_RelayOnMiss_Ledger(t *testing.T) {
+	r, rs := makeRouterWithRelayRecorder(t)
+	rs.ledgerPeer, rs.ledgerOK = 99, true
+
+	hash := bytes.Repeat([]byte{0xAB}, 32)
+	qt := message.QueryTypeIndirect
+	req := &message.GetLedger{
+		InfoType:   message.LedgerInfoBase,
+		LedgerHash: hash,
+		QueryType:  &qt,
+	}
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  42,
+		Type:    uint16(message.TypeGetLedger),
+		Payload: encodePayload(t, req),
+	})
+
+	sent := rs.sentFrames()
+	require.Len(t, sent, 1, "miss must relay exactly one frame")
+	assert.Equal(t, uint64(99), sent[0].peerID, "relayed to the peer that has the ledger")
+	assert.Equal(t, uint64(42), rs.excludeArg(), "selection must exclude the original requester")
+
+	msgType, decoded := decodeFrame(t, sent[0].frame)
+	require.Equal(t, message.TypeGetLedger, msgType)
+	relayed := decoded.(*message.GetLedger)
+	assert.Equal(t, uint64(42), relayed.RequestCookie, "cookie stamped with the requester id")
+	assert.Equal(t, hash, relayed.LedgerHash)
+	require.NotNil(t, relayed.QueryType)
+	assert.Equal(t, message.QueryTypeIndirect, *relayed.QueryType)
+}
+
+// TestRouter_GetLedger_RelayOnMiss_TxSet pins rippled's getTxSet relay for
+// liTS_CANDIDATE: a tx-set we don't have is forwarded to a peer that
+// advertised it (getPeerWithTree), cookie-stamped for reply routing.
+func TestRouter_GetLedger_RelayOnMiss_TxSet(t *testing.T) {
+	r, rs := makeRouterWithRelayRecorder(t)
+	rs.txsetPeer, rs.txsetOK = 7, true
+
+	hash := bytes.Repeat([]byte{0xCD}, 32)
+	qt := message.QueryTypeIndirect
+	req := &message.GetLedger{
+		InfoType:   message.LedgerInfoTsCandidate,
+		LedgerHash: hash,
+		QueryType:  &qt,
+	}
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  21,
+		Type:    uint16(message.TypeGetLedger),
+		Payload: encodePayload(t, req),
+	})
+
+	sent := rs.sentFrames()
+	require.Len(t, sent, 1)
+	assert.Equal(t, uint64(7), sent[0].peerID)
+	assert.Equal(t, uint64(21), rs.excludeArg())
+
+	_, decoded := decodeFrame(t, sent[0].frame)
+	relayed := decoded.(*message.GetLedger)
+	assert.Equal(t, uint64(21), relayed.RequestCookie)
+	assert.Equal(t, message.LedgerInfoTsCandidate, relayed.InfoType)
+}
+
+// TestRouter_GetLedger_NoRelayWhenCookieSet pins loop prevention: a request
+// that already carries a request_cookie has been relayed once and must never
+// be relayed again, even when query_type is present and we lack the tx-set.
+func TestRouter_GetLedger_NoRelayWhenCookieSet(t *testing.T) {
+	r, rs := makeRouterWithRelayRecorder(t)
+	rs.txsetPeer, rs.txsetOK = 7, true // would relay if the predicate allowed it
+
+	hash := bytes.Repeat([]byte{0xCD}, 32)
+	qt := message.QueryTypeIndirect
+	req := &message.GetLedger{
+		InfoType:      message.LedgerInfoTsCandidate,
+		LedgerHash:    hash,
+		QueryType:     &qt,
+		RequestCookie: 555, // already relayed by an upstream peer
+	}
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  21,
+		Type:    uint16(message.TypeGetLedger),
+		Payload: encodePayload(t, req),
+	})
+
+	assert.Empty(t, rs.sentFrames(), "a cookied request must not be relayed again")
+}
+
+// TestRouter_GetLedger_NoRelayWhenQueryTypeAbsent pins that a direct request
+// (no query_type) is never relayed — rippled relays only indirect requests.
+func TestRouter_GetLedger_NoRelayWhenQueryTypeAbsent(t *testing.T) {
+	r, rs := makeRouterWithRelayRecorder(t)
+	rs.txsetPeer, rs.txsetOK = 7, true
+
+	hash := bytes.Repeat([]byte{0xCD}, 32)
+	req := &message.GetLedger{
+		InfoType:   message.LedgerInfoTsCandidate,
+		LedgerHash: hash,
+	}
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  21,
+		Type:    uint16(message.TypeGetLedger),
+		Payload: encodePayload(t, req),
+	})
+
+	assert.Empty(t, rs.sentFrames(), "a request without query_type must not be relayed")
+}
+
+// TestRouter_GetLedger_NoRelayWhenNoCandidate pins the drop fallback: when no
+// peer advertises the requested data, the request is silently dropped.
+func TestRouter_GetLedger_NoRelayWhenNoCandidate(t *testing.T) {
+	r, rs := makeRouterWithRelayRecorder(t)
+	rs.txsetOK = false // no peer has it
+
+	hash := bytes.Repeat([]byte{0xCD}, 32)
+	qt := message.QueryTypeIndirect
+	req := &message.GetLedger{
+		InfoType:   message.LedgerInfoTsCandidate,
+		LedgerHash: hash,
+		QueryType:  &qt,
+	}
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  21,
+		Type:    uint16(message.TypeGetLedger),
+		Payload: encodePayload(t, req),
+	})
+
+	assert.Empty(t, rs.sentFrames(), "no candidate peer means the request is dropped")
+}
+
+// TestRouter_LedgerData_RoutedBackByCookie pins rippled's
+// onMessage(TMLedgerData) cookie branch: a reply carrying a request_cookie is
+// forwarded to the original requester named by the cookie, with the cookie
+// cleared, and is not consumed locally.
+func TestRouter_LedgerData_RoutedBackByCookie(t *testing.T) {
+	r, rs := makeRouterWithRelayRecorder(t)
+
+	hash := bytes.Repeat([]byte{0xEE}, 32)
+	ld := &message.LedgerData{
+		LedgerHash:    hash,
+		LedgerSeq:     12345,
+		InfoType:      message.LedgerInfoBase,
+		Nodes:         []message.LedgerNode{{NodeData: []byte{0x01, 0x02, 0x03}}},
+		RequestCookie: 77, // our local id for the original requester
+	}
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  5, // the peer that served the relayed request
+		Type:    uint16(message.TypeLedgerData),
+		Payload: encodePayload(t, ld),
+	})
+
+	sent := rs.sentFrames()
+	require.Len(t, sent, 1, "a cookied reply must be routed back exactly once")
+	assert.Equal(t, uint64(77), sent[0].peerID, "routed to the original requester (cookie holder)")
+
+	msgType, decoded := decodeFrame(t, sent[0].frame)
+	require.Equal(t, message.TypeLedgerData, msgType)
+	out := decoded.(*message.LedgerData)
+	assert.Equal(t, uint32(0), out.RequestCookie, "cookie cleared before forwarding")
+	assert.Equal(t, hash, out.LedgerHash)
+	require.Len(t, out.Nodes, 1)
+}
+
+// TestRouter_HaveSet_RecordsTxSetAdvertisement pins that an inbound
+// mtHAVE_TRANSACTION_SET{tsHAVE} records the (peer, tx-set) pair so a later
+// unsatisfiable GetLedger can be relayed to that peer.
+func TestRouter_HaveSet_RecordsTxSetAdvertisement(t *testing.T) {
+	r, rs := makeRouterWithRelayRecorder(t)
+
+	hash := bytes.Repeat([]byte{0x9A}, 32)
+	have := &message.HaveTransactionSet{
+		Status: message.TxSetStatusHave,
+		Hash:   hash,
+	}
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  88,
+		Type:    uint16(message.TypeHaveSet),
+		Payload: encodePayload(t, have),
+	})
+
+	noted := rs.notedTxSets()
+	require.Len(t, noted, 1, "a tsHAVE advertisement must be recorded")
+	assert.Equal(t, uint64(88), noted[0].peerID)
+	assert.Equal(t, [32]byte(hash), noted[0].hash)
+}

--- a/internal/consensus/adaptor/router_relay_test.go
+++ b/internal/consensus/adaptor/router_relay_test.go
@@ -129,12 +129,13 @@ func TestRouter_GetLedger_RelayOnMiss_Ledger(t *testing.T) {
 	assert.Equal(t, message.QueryTypeIndirect, *relayed.QueryType)
 }
 
-// TestRouter_GetLedger_RelayOnMiss_LedgerBySeq pins that a seq-only request
-// (no ledger_hash) we can't satisfy still relays — rippled
-// getPeerWithLedger(hash, seq) matches on the peer's covering seq range.
-func TestRouter_GetLedger_RelayOnMiss_LedgerBySeq(t *testing.T) {
+// TestRouter_GetLedger_NoRelayWhenSeqOnly pins rippled's getLedger: a relay
+// is attempted only from the has_ledgerhash() branch (PeerImp.cpp:3165/3175).
+// A seq-only request (no ledger_hash) that misses locally is dropped, never
+// relayed — even when a peer would cover the seq range.
+func TestRouter_GetLedger_NoRelayWhenSeqOnly(t *testing.T) {
 	r, rs := makeRouterWithRelayRecorder(t)
-	rs.ledgerPeer, rs.ledgerOK = 33, true
+	rs.ledgerPeer, rs.ledgerOK = 33, true // would relay if the predicate allowed it
 
 	qt := message.QueryTypeIndirect
 	req := &message.GetLedger{
@@ -148,13 +149,7 @@ func TestRouter_GetLedger_RelayOnMiss_LedgerBySeq(t *testing.T) {
 		Payload: encodePayload(t, req),
 	})
 
-	sent := rs.sentFrames()
-	require.Len(t, sent, 1, "seq-only miss must still relay")
-	assert.Equal(t, uint64(33), sent[0].peerID)
-	_, decoded := decodeFrame(t, sent[0].frame)
-	relayed := decoded.(*message.GetLedger)
-	assert.Equal(t, uint64(42), relayed.RequestCookie)
-	assert.Equal(t, uint32(4242), relayed.LedgerSeq)
+	assert.Empty(t, rs.sentFrames(), "a seq-only request must not be relayed")
 }
 
 // TestRouter_GetLedger_RelayOnMiss_TxSet pins rippled's getTxSet relay for

--- a/internal/consensus/adaptor/router_relay_test.go
+++ b/internal/consensus/adaptor/router_relay_test.go
@@ -39,7 +39,7 @@ func (s *relayRecorder) SendToPeer(peerID uint64, frame []byte) error {
 	return nil
 }
 
-func (s *relayRecorder) PeerWithLedger(_ [32]byte, exclude uint64) (uint64, bool) {
+func (s *relayRecorder) PeerWithLedger(_ [32]byte, _ uint32, exclude uint64) (uint64, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.lastExclude = exclude
@@ -127,6 +127,34 @@ func TestRouter_GetLedger_RelayOnMiss_Ledger(t *testing.T) {
 	assert.Equal(t, hash, relayed.LedgerHash)
 	require.NotNil(t, relayed.QueryType)
 	assert.Equal(t, message.QueryTypeIndirect, *relayed.QueryType)
+}
+
+// TestRouter_GetLedger_RelayOnMiss_LedgerBySeq pins that a seq-only request
+// (no ledger_hash) we can't satisfy still relays — rippled
+// getPeerWithLedger(hash, seq) matches on the peer's covering seq range.
+func TestRouter_GetLedger_RelayOnMiss_LedgerBySeq(t *testing.T) {
+	r, rs := makeRouterWithRelayRecorder(t)
+	rs.ledgerPeer, rs.ledgerOK = 33, true
+
+	qt := message.QueryTypeIndirect
+	req := &message.GetLedger{
+		InfoType:  message.LedgerInfoBase,
+		LedgerSeq: 4242,
+		QueryType: &qt,
+	}
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  42,
+		Type:    uint16(message.TypeGetLedger),
+		Payload: encodePayload(t, req),
+	})
+
+	sent := rs.sentFrames()
+	require.Len(t, sent, 1, "seq-only miss must still relay")
+	assert.Equal(t, uint64(33), sent[0].peerID)
+	_, decoded := decodeFrame(t, sent[0].frame)
+	relayed := decoded.(*message.GetLedger)
+	assert.Equal(t, uint64(42), relayed.RequestCookie)
+	assert.Equal(t, uint32(4242), relayed.LedgerSeq)
 }
 
 // TestRouter_GetLedger_RelayOnMiss_TxSet pins rippled's getTxSet relay for

--- a/internal/consensus/adaptor/router_serve.go
+++ b/internal/consensus/adaptor/router_serve.go
@@ -86,6 +86,10 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 		l = svc.GetClosedLedger()
 	}
 	if err != nil || l == nil {
+		// We don't have it — relay to a peer that advertises it, mirroring
+		// rippled's getLedger relay. Falls through to a silent drop when the
+		// request isn't relayable or no peer qualifies.
+		r.maybeRelayGetLedger(msg.PeerID, req)
 		return
 	}
 
@@ -209,6 +213,10 @@ func (r *Router) serveTxSet(peerID peermanagement.PeerID, req *message.GetLedger
 
 	ts, ok := r.adaptor.txSetCache.Get(txSetID)
 	if !ok {
+		// We don't have it — relay to a peer that advertised it (getTxSet).
+		if r.maybeRelayGetLedger(peerID, req) {
+			return
+		}
 		r.logger.Debug("peer requested tx-set we don't have",
 			"peer", peerID, "txset", fmt.Sprintf("%x", txSetID[:8]))
 		return

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -241,6 +241,28 @@ func (s *OverlaySender) ReplayCapablePeersExcluding(excluded []uint64, max int) 
 	return out
 }
 
+// PeerWithLedger forwards to Overlay.PeerWithLedger: selects a peer that
+// advertises ledger hash target (excluding `exclude`) to relay an
+// unsatisfiable GetLedger to.
+func (s *OverlaySender) PeerWithLedger(target [32]byte, exclude uint64) (uint64, bool) {
+	id, ok := s.overlay.PeerWithLedger(target, peermanagement.PeerID(exclude))
+	return uint64(id), ok
+}
+
+// PeerWithTxSet forwards to Overlay.PeerWithTxSet: selects a peer that
+// advertised tx-set root target (excluding `exclude`) to relay an
+// unsatisfiable liTS_CANDIDATE GetLedger to.
+func (s *OverlaySender) PeerWithTxSet(target [32]byte, exclude uint64) (uint64, bool) {
+	id, ok := s.overlay.PeerWithTxSet(target, peermanagement.PeerID(exclude))
+	return uint64(id), ok
+}
+
+// NotePeerHasTxSet forwards to Overlay.NotePeerHasTxSet, recording a
+// peer's tsHAVE tx-set advertisement for later relay selection.
+func (s *OverlaySender) NotePeerHasTxSet(peerID uint64, hash [32]byte) {
+	s.overlay.NotePeerHasTxSet(peermanagement.PeerID(peerID), hash)
+}
+
 // IncPeerBadData forwards to Overlay.IncPeerBadData. Called by the
 // consensus router via Adaptor.IncPeerBadData when it detects malformed
 // or invalid data from a peer (e.g., replay-delta verification

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -242,10 +242,10 @@ func (s *OverlaySender) ReplayCapablePeersExcluding(excluded []uint64, max int) 
 }
 
 // PeerWithLedger forwards to Overlay.PeerWithLedger: selects a peer that
-// advertises ledger hash target (excluding `exclude`) to relay an
+// can serve ledger (target, seq) (excluding `exclude`) to relay an
 // unsatisfiable GetLedger to.
-func (s *OverlaySender) PeerWithLedger(target [32]byte, exclude uint64) (uint64, bool) {
-	id, ok := s.overlay.PeerWithLedger(target, peermanagement.PeerID(exclude))
+func (s *OverlaySender) PeerWithLedger(target [32]byte, seq uint32, exclude uint64) (uint64, bool) {
+	id, ok := s.overlay.PeerWithLedger(target, seq, peermanagement.PeerID(exclude))
 	return uint64(id), ok
 }
 

--- a/internal/consensus/adaptor/sender_cov_test.go
+++ b/internal/consensus/adaptor/sender_cov_test.go
@@ -189,9 +189,9 @@ func (f *snd_fakeOverlay) ShouldShedLedgerRequest(peerID uint64, loadedLocal boo
 	return f.shedResult && peerID == f.shedResultPeerID
 }
 
-func (f *snd_fakeOverlay) PeerWithLedger([32]byte, uint64) (uint64, bool) { return 0, false }
-func (f *snd_fakeOverlay) PeerWithTxSet([32]byte, uint64) (uint64, bool)  { return 0, false }
-func (f *snd_fakeOverlay) NotePeerHasTxSet(uint64, [32]byte)              {}
+func (f *snd_fakeOverlay) PeerWithLedger([32]byte, uint32, uint64) (uint64, bool) { return 0, false }
+func (f *snd_fakeOverlay) PeerWithTxSet([32]byte, uint64) (uint64, bool)          { return 0, false }
+func (f *snd_fakeOverlay) NotePeerHasTxSet(uint64, [32]byte)                      {}
 
 func snd_newAdaptorWithFake(t *testing.T, fake *snd_fakeOverlay) *Adaptor {
 	t.Helper()

--- a/internal/consensus/adaptor/sender_cov_test.go
+++ b/internal/consensus/adaptor/sender_cov_test.go
@@ -189,6 +189,10 @@ func (f *snd_fakeOverlay) ShouldShedLedgerRequest(peerID uint64, loadedLocal boo
 	return f.shedResult && peerID == f.shedResultPeerID
 }
 
+func (f *snd_fakeOverlay) PeerWithLedger([32]byte, uint64) (uint64, bool) { return 0, false }
+func (f *snd_fakeOverlay) PeerWithTxSet([32]byte, uint64) (uint64, bool)  { return 0, false }
+func (f *snd_fakeOverlay) NotePeerHasTxSet(uint64, [32]byte)              {}
+
 func snd_newAdaptorWithFake(t *testing.T, fake *snd_fakeOverlay) *Adaptor {
 	t.Helper()
 	svc := newTestLedgerService(t)

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -290,20 +290,27 @@ func (o *Overlay) PeersWithClosedLedger(target [32]byte) []PeerID {
 	return matches
 }
 
-// PeerWithLedger picks a connected peer that advertises ledger hash
-// target (as its closed or previous ledger), excluding the peer with id
-// exclude, and returns (id, true). Returns (0, false) when no peer
-// qualifies. Mirrors rippled's getPeerWithLedger / PeerImp::hasLedger; it
-// is the GetLedger relay's "who can serve this ledger" selector.
+// PeerWithLedger picks a connected peer that can serve ledger (target,
+// seq), excluding the peer with id exclude, and returns (id, true).
+// Returns (0, false) when no peer qualifies. Mirrors rippled's
+// getPeerWithLedger / PeerImp::hasLedger: a peer qualifies when seq falls
+// within its advertised [first,last] range while it tracks the network
+// (converged), OR it advertises target as its closed or previous ledger.
+// seq == 0 disables the range arm; a zero target disables the hash arm.
 //
 // rippled additionally weights candidates by measured latency and a
 // random jitter (PeerImp::getScore) to spread load; go-xrpl picks the
 // lowest peer id deterministically, which is simpler and keeps the relay
-// path testable. Selection accuracy is bounded by the single closed/
-// previous-ledger hint go-xrpl tracks per peer — it does not model
-// rippled's full recent-ledger ring or min/max seq range.
-func (o *Overlay) PeerWithLedger(target [32]byte, exclude PeerID) (PeerID, bool) {
+// path testable. The hash arm is bounded by the single closed/previous
+// hint go-xrpl tracks per peer rather than rippled's full recent-ledger
+// ring.
+func (o *Overlay) PeerWithLedger(target [32]byte, seq uint32, exclude PeerID) (PeerID, bool) {
 	return o.bestPeer(exclude, func(p *Peer) bool {
+		if seq != 0 && p.Tracking() == PeerTrackingConverged {
+			if first, last := p.LedgerRange(); first != 0 && seq >= first && seq <= last {
+				return true
+			}
+		}
 		if closed, ok := p.ClosedLedger(); ok && closed == target {
 			return true
 		}

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	mrand "math/rand/v2"
 	"net"
 	"strings"
 	"sync"
@@ -295,27 +296,16 @@ func (o *Overlay) PeersWithClosedLedger(target [32]byte) []PeerID {
 // Returns (0, false) when no peer qualifies. Mirrors rippled's
 // getPeerWithLedger / PeerImp::hasLedger: a peer qualifies when seq falls
 // within its advertised [first,last] range while it tracks the network
-// (converged), OR it advertises target as its closed or previous ledger.
-// seq == 0 disables the range arm; a zero target disables the hash arm.
+// (converged), OR it advertised target among its recent ledgers (the
+// closed/previous hashes it announced via status changes). seq == 0
+// disables the range arm; a zero target disables the hash arm.
 //
-// rippled additionally weights candidates by measured latency and a
-// random jitter (PeerImp::getScore) to spread load; go-xrpl picks the
-// lowest peer id deterministically, which is simpler and keeps the relay
-// path testable. The hash arm is bounded by the single closed/previous
-// hint go-xrpl tracks per peer rather than rippled's full recent-ledger
-// ring.
+// Among qualifiers the winner is chosen by peerRelayScore (rippled
+// PeerImp::getScore): a latency-weighted random draw that spreads relay
+// load instead of always hitting the same peer.
 func (o *Overlay) PeerWithLedger(target [32]byte, seq uint32, exclude PeerID) (PeerID, bool) {
 	return o.bestPeer(exclude, func(p *Peer) bool {
-		if seq != 0 && p.Tracking() == PeerTrackingConverged {
-			if first, last := p.LedgerRange(); first != 0 && seq >= first && seq <= last {
-				return true
-			}
-		}
-		if closed, ok := p.ClosedLedger(); ok && closed == target {
-			return true
-		}
-		prev, ok := p.PreviousLedger()
-		return ok && prev == target
+		return p.HasLedger(target, seq)
 	})
 }
 
@@ -329,13 +319,14 @@ func (o *Overlay) PeerWithTxSet(target [32]byte, exclude PeerID) (PeerID, bool) 
 	})
 }
 
-// bestPeer returns the lowest-id connected peer (other than exclude) for
-// which want reports true.
+// bestPeer returns the highest-scoring connected peer (other than exclude)
+// for which want reports true, scoring each qualifier with peerRelayScore.
 func (o *Overlay) bestPeer(exclude PeerID, want func(*Peer) bool) (PeerID, bool) {
 	o.peersMu.RLock()
 	defer o.peersMu.RUnlock()
 
 	var best PeerID
+	var bestScore int
 	found := false
 	for id, peer := range o.peers {
 		if id == exclude || peer.State() != PeerStateConnected {
@@ -344,12 +335,35 @@ func (o *Overlay) bestPeer(exclude PeerID, want func(*Peer) bool) (PeerID, bool)
 		if !want(peer) {
 			continue
 		}
-		if !found || id < best {
+		score := peerRelayScore(peer)
+		if !found || score > bestScore {
 			best = id
+			bestScore = score
 			found = true
 		}
 	}
 	return best, found
+}
+
+// peerRelayScore mirrors rippled PeerImp::getScore(true): a random tie-break
+// plus a have-item bonus minus a latency penalty, picking a responsive peer
+// while spreading relay load. bestPeer only scores peers that already hold
+// the data, so the have-item term is constant across candidates and does not
+// affect the argmax — it is kept for a faithful port of the constants.
+func peerRelayScore(p *Peer) int {
+	const (
+		spRandomMax = 9999
+		spHaveItem  = 10000
+		spLatency   = 30
+		spNoLatency = 8000
+	)
+	score := mrand.IntN(spRandomMax+1) + spHaveItem
+	if lat, ok := p.Latency(); ok {
+		score -= int(lat.Milliseconds()) * spLatency
+	} else {
+		score -= spNoLatency
+	}
+	return score
 }
 
 // NotePeerHasTxSet records that the peer with id peerID advertised tx-set

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -290,6 +290,70 @@ func (o *Overlay) PeersWithClosedLedger(target [32]byte) []PeerID {
 	return matches
 }
 
+// PeerWithLedger picks a connected peer that advertises ledger hash
+// target (as its closed or previous ledger), excluding the peer with id
+// exclude, and returns (id, true). Returns (0, false) when no peer
+// qualifies. Mirrors rippled's getPeerWithLedger / PeerImp::hasLedger; it
+// is the GetLedger relay's "who can serve this ledger" selector.
+//
+// rippled additionally weights candidates by measured latency and a
+// random jitter (PeerImp::getScore) to spread load; go-xrpl picks the
+// lowest peer id deterministically, which is simpler and keeps the relay
+// path testable. Selection accuracy is bounded by the single closed/
+// previous-ledger hint go-xrpl tracks per peer — it does not model
+// rippled's full recent-ledger ring or min/max seq range.
+func (o *Overlay) PeerWithLedger(target [32]byte, exclude PeerID) (PeerID, bool) {
+	return o.bestPeer(exclude, func(p *Peer) bool {
+		if closed, ok := p.ClosedLedger(); ok && closed == target {
+			return true
+		}
+		prev, ok := p.PreviousLedger()
+		return ok && prev == target
+	})
+}
+
+// PeerWithTxSet picks a connected peer that advertised tx-set root target
+// (via mtHAVE_TRANSACTION_SET{tsHAVE}), excluding the peer with id
+// exclude. Mirrors rippled's getPeerWithTree / PeerImp::hasTxSet. See
+// PeerWithLedger for the selection-policy note.
+func (o *Overlay) PeerWithTxSet(target [32]byte, exclude PeerID) (PeerID, bool) {
+	return o.bestPeer(exclude, func(p *Peer) bool {
+		return p.HasTxSet(target)
+	})
+}
+
+// bestPeer returns the lowest-id connected peer (other than exclude) for
+// which want reports true.
+func (o *Overlay) bestPeer(exclude PeerID, want func(*Peer) bool) (PeerID, bool) {
+	o.peersMu.RLock()
+	defer o.peersMu.RUnlock()
+
+	var best PeerID
+	found := false
+	for id, peer := range o.peers {
+		if id == exclude || peer.State() != PeerStateConnected {
+			continue
+		}
+		if !want(peer) {
+			continue
+		}
+		if !found || id < best {
+			best = id
+			found = true
+		}
+	}
+	return best, found
+}
+
+// NotePeerHasTxSet records that the peer with id peerID advertised tx-set
+// root hash. No-op when the peer is unknown. Fed by the consensus router
+// on inbound mtHAVE_TRANSACTION_SET{tsHAVE}.
+func (o *Overlay) NotePeerHasTxSet(peerID PeerID, hash [32]byte) {
+	if peer, ok := o.getPeer(peerID); ok {
+		peer.AddTxSet(hash)
+	}
+}
+
 // SetLedgerHintProvider wires the hint source; nil suppresses headers.
 func (o *Overlay) SetLedgerHintProvider(fn func() (LedgerHints, bool)) {
 	o.providersMu.Lock()

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -159,6 +159,14 @@ type Peer struct {
 	// duplicates are ignored and the oldest entry is evicted past the cap.
 	recentTxSets [][32]byte
 
+	// recentLedgers is a bounded ring of ledger hashes the peer has
+	// advertised (closed or previous) via mtSTATUS_CHANGE. It backs the
+	// GetLedger relay's hash-arm "who has this ledger" lookup (HasLedger).
+	// Mirrors rippled PeerImp::recentLedgers_, a circular_buffer<uint256>{128}
+	// fed by addLedger: duplicates are ignored, the oldest entry is evicted
+	// past the cap, and the ring is never cleared (not even on LostSync).
+	recentLedgers [][32]byte
+
 	// protocolVersion: negotiated peer-protocol token (e.g. "XRPL/2.2").
 	// Mirrors rippled PeerImp::protocol_, surfaced via `protocol` in the
 	// peers RPC (PeerImp.cpp:419). Rippled constructs PeerImp only after
@@ -364,6 +372,7 @@ func (p *Peer) applyStatusChange(sc *message.StatusChange) message.NodeStatus {
 	if len(sc.LedgerHash) == 32 {
 		copy(p.closedLedger[:], sc.LedgerHash)
 		p.hasClosedLedger = true
+		p.addLedgerLocked(p.closedLedger)
 	} else {
 		p.hasClosedLedger = false
 		p.closedLedger = [32]byte{}
@@ -371,6 +380,7 @@ func (p *Peer) applyStatusChange(sc *message.StatusChange) message.NodeStatus {
 	if len(sc.LedgerHashPrevious) == 32 {
 		copy(p.previousLedger[:], sc.LedgerHashPrevious)
 		p.hasPreviousLedger = true
+		p.addLedgerLocked(p.previousLedger)
 	} else {
 		p.hasPreviousLedger = false
 		p.previousLedger = [32]byte{}
@@ -496,6 +506,45 @@ func (p *Peer) HasTxSet(hash [32]byte) bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return slices.Contains(p.recentTxSets, hash)
+}
+
+// maxRecentLedgers bounds recentLedgers, matching rippled's
+// circular_buffer<uint256>{128}.
+const maxRecentLedgers = 128
+
+// addLedgerLocked records a ledger hash the peer advertised via a status
+// change. Duplicates are ignored; the oldest entry is evicted past the cap.
+// Mirrors rippled PeerImp::addLedger. The caller must hold p.mu.
+func (p *Peer) addLedgerLocked(hash [32]byte) {
+	if slices.Contains(p.recentLedgers, hash) {
+		return
+	}
+	if len(p.recentLedgers) >= maxRecentLedgers {
+		p.recentLedgers = p.recentLedgers[1:]
+	}
+	p.recentLedgers = append(p.recentLedgers, hash)
+}
+
+// AddLedger records a ledger hash the peer advertised, taking p.mu. The live
+// path appends under the applyStatusChange lock via addLedgerLocked.
+func (p *Peer) AddLedger(hash [32]byte) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.addLedgerLocked(hash)
+}
+
+// HasLedger reports whether the peer can serve ledger (hash, seq), mirroring
+// rippled PeerImp::hasLedger: a converged peer whose advertised [first,last]
+// range covers seq qualifies, OR the peer advertised hash among its recent
+// ledgers. seq == 0 disables the range arm.
+func (p *Peer) HasLedger(hash [32]byte, seq uint32) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if seq != 0 && p.Tracking() == PeerTrackingConverged &&
+		p.firstLedgerSeq != 0 && seq >= p.firstLedgerSeq && seq <= p.lastLedgerSeq {
+		return true
+	}
+	return slices.Contains(p.recentLedgers, hash)
 }
 
 // LedgerRange returns the peer's advertised (min, max) ledger sequence,

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -150,6 +151,13 @@ type Peer struct {
 	previousLedger    [32]byte
 	hasClosedLedger   bool
 	hasPreviousLedger bool
+
+	// recentTxSets is a bounded ring of tx-set roots the peer has
+	// advertised via mtHAVE_TRANSACTION_SET{tsHAVE}. It backs the
+	// GetLedger relay's "who has this tx-set" lookup (HasTxSet). Mirrors
+	// rippled PeerImp::recentTxSets_, a circular_buffer<uint256>{128}:
+	// duplicates are ignored and the oldest entry is evicted past the cap.
+	recentTxSets [][32]byte
 
 	// protocolVersion: negotiated peer-protocol token (e.g. "XRPL/2.2").
 	// Mirrors rippled PeerImp::protocol_, surfaced via `protocol` in the
@@ -461,6 +469,33 @@ func (p *Peer) PreviousLedger() ([32]byte, bool) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.previousLedger, p.hasPreviousLedger
+}
+
+// maxRecentTxSets bounds recentTxSets, matching rippled's
+// circular_buffer<uint256>{128}.
+const maxRecentTxSets = 128
+
+// AddTxSet records that the peer advertised tx-set root hash (tsHAVE).
+// Duplicates are ignored; once the ring is full the oldest entry is
+// evicted. Mirrors rippled PeerImp::onMessage(TMHaveTransactionSet).
+func (p *Peer) AddTxSet(hash [32]byte) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if slices.Contains(p.recentTxSets, hash) {
+		return
+	}
+	if len(p.recentTxSets) >= maxRecentTxSets {
+		p.recentTxSets = p.recentTxSets[1:]
+	}
+	p.recentTxSets = append(p.recentTxSets, hash)
+}
+
+// HasTxSet reports whether the peer has advertised tx-set root hash.
+// Mirrors rippled PeerImp::hasTxSet.
+func (p *Peer) HasTxSet(hash [32]byte) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return slices.Contains(p.recentTxSets, hash)
 }
 
 // LedgerRange returns the peer's advertised (min, max) ledger sequence,

--- a/internal/peermanagement/relay_select_test.go
+++ b/internal/peermanagement/relay_select_test.go
@@ -1,0 +1,144 @@
+package peermanagement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newRelayTestPeer(id PeerID) *Peer {
+	return &Peer{id: id, state: PeerStateConnected}
+}
+
+func hash32(b byte) [32]byte {
+	var h [32]byte
+	for i := range h {
+		h[i] = b
+	}
+	return h
+}
+
+// TestPeer_TxSetRing pins the per-peer tx-set advertisement ring: HasTxSet
+// reflects AddTxSet, duplicates are ignored, and the ring evicts the oldest
+// entry once it exceeds maxRecentTxSets (mirrors rippled's
+// circular_buffer<uint256>{128}).
+func TestPeer_TxSetRing(t *testing.T) {
+	p := newRelayTestPeer(1)
+
+	a, b := hash32(0x01), hash32(0x02)
+	assert.False(t, p.HasTxSet(a))
+	p.AddTxSet(a)
+	p.AddTxSet(a) // duplicate ignored
+	p.AddTxSet(b)
+	assert.True(t, p.HasTxSet(a))
+	assert.True(t, p.HasTxSet(b))
+
+	p.mu.RLock()
+	require.Len(t, p.recentTxSets, 2, "duplicate must not grow the ring")
+	p.mu.RUnlock()
+
+	// Overflow the ring: the first-added entry (a) is evicted.
+	for i := range maxRecentTxSets {
+		p.AddTxSet(hash32(byte(0x80 + i)))
+	}
+	assert.False(t, p.HasTxSet(a), "oldest entry evicted past the cap")
+	p.mu.RLock()
+	require.Len(t, p.recentTxSets, maxRecentTxSets)
+	p.mu.RUnlock()
+}
+
+// TestOverlay_PeerWithLedger pins getPeerWithLedger selection: a connected
+// peer advertising the ledger as its closed OR previous hash is chosen, the
+// excluded peer is skipped, and ties resolve to the lowest peer id.
+func TestOverlay_PeerWithLedger(t *testing.T) {
+	target := hash32(0xAA)
+	o := &Overlay{peers: make(map[PeerID]*Peer)}
+
+	// p3 and p5 both advertise target as their closed ledger; p4 advertises
+	// it as its previous ledger; p9 advertises something else.
+	p3 := newRelayTestPeer(3)
+	p3.closedLedger, p3.hasClosedLedger = target, true
+	p5 := newRelayTestPeer(5)
+	p5.closedLedger, p5.hasClosedLedger = target, true
+	p4 := newRelayTestPeer(4)
+	p4.previousLedger, p4.hasPreviousLedger = target, true
+	p9 := newRelayTestPeer(9)
+	p9.closedLedger, p9.hasClosedLedger = hash32(0xBB), true
+	for _, p := range []*Peer{p3, p4, p5, p9} {
+		o.peers[p.id] = p
+	}
+
+	got, ok := o.PeerWithLedger(target, 0)
+	require.True(t, ok)
+	assert.Equal(t, PeerID(3), got, "lowest-id candidate selected")
+
+	got, ok = o.PeerWithLedger(target, 3)
+	require.True(t, ok)
+	assert.Equal(t, PeerID(4), got, "excluded peer skipped; previous-ledger match counts")
+
+	_, ok = o.PeerWithLedger(hash32(0xCC), 0)
+	assert.False(t, ok, "no peer advertises this ledger")
+}
+
+// TestOverlay_PeerWithLedger_SkipsDisconnected pins that a peer holding the
+// ledger but not in PeerStateConnected is not a relay target.
+func TestOverlay_PeerWithLedger_SkipsDisconnected(t *testing.T) {
+	target := hash32(0xAA)
+	o := &Overlay{peers: make(map[PeerID]*Peer)}
+
+	p := newRelayTestPeer(2)
+	p.state = PeerStateConnecting
+	p.closedLedger, p.hasClosedLedger = target, true
+	o.peers[p.id] = p
+
+	_, ok := o.PeerWithLedger(target, 0)
+	assert.False(t, ok, "a non-connected peer must not be selected")
+}
+
+// TestOverlay_PeerWithTxSet pins getPeerWithTree selection over the per-peer
+// tx-set advertisement ring, honouring the exclude argument.
+func TestOverlay_PeerWithTxSet(t *testing.T) {
+	root := hash32(0x77)
+	o := &Overlay{peers: make(map[PeerID]*Peer)}
+
+	p2 := newRelayTestPeer(2)
+	p2.AddTxSet(root)
+	p6 := newRelayTestPeer(6)
+	p6.AddTxSet(root)
+	p8 := newRelayTestPeer(8)
+	p8.AddTxSet(hash32(0x11))
+	for _, p := range []*Peer{p2, p6, p8} {
+		o.peers[p.id] = p
+	}
+
+	got, ok := o.PeerWithTxSet(root, 0)
+	require.True(t, ok)
+	assert.Equal(t, PeerID(2), got)
+
+	got, ok = o.PeerWithTxSet(root, 2)
+	require.True(t, ok)
+	assert.Equal(t, PeerID(6), got)
+
+	_, ok = o.PeerWithTxSet(hash32(0x22), 0)
+	assert.False(t, ok)
+}
+
+// TestOverlay_NotePeerHasTxSet pins that recording an advertisement reaches
+// the peer's ring and that an unknown peer id is a safe no-op.
+func TestOverlay_NotePeerHasTxSet(t *testing.T) {
+	root := hash32(0x77)
+	o := &Overlay{peers: make(map[PeerID]*Peer)}
+	p := newRelayTestPeer(1)
+	o.peers[p.id] = p
+
+	o.NotePeerHasTxSet(1, root)
+	assert.True(t, p.HasTxSet(root))
+
+	// Unknown peer: must not panic and must record nothing.
+	o.NotePeerHasTxSet(999, root)
+
+	got, ok := o.PeerWithTxSet(root, 0)
+	require.True(t, ok)
+	assert.Equal(t, PeerID(1), got)
+}

--- a/internal/peermanagement/relay_select_test.go
+++ b/internal/peermanagement/relay_select_test.go
@@ -69,16 +69,46 @@ func TestOverlay_PeerWithLedger(t *testing.T) {
 		o.peers[p.id] = p
 	}
 
-	got, ok := o.PeerWithLedger(target, 0)
+	got, ok := o.PeerWithLedger(target, 0, 0)
 	require.True(t, ok)
 	assert.Equal(t, PeerID(3), got, "lowest-id candidate selected")
 
-	got, ok = o.PeerWithLedger(target, 3)
+	got, ok = o.PeerWithLedger(target, 0, 3)
 	require.True(t, ok)
 	assert.Equal(t, PeerID(4), got, "excluded peer skipped; previous-ledger match counts")
 
-	_, ok = o.PeerWithLedger(hash32(0xCC), 0)
+	_, ok = o.PeerWithLedger(hash32(0xCC), 0, 0)
 	assert.False(t, ok, "no peer advertises this ledger")
+}
+
+// TestOverlay_PeerWithLedger_SeqRange pins the rippled hasLedger(hash, seq)
+// range arm: a converged peer whose advertised [first,last] range covers seq
+// qualifies even without a hash match; a diverged peer or out-of-range seq
+// does not.
+func TestOverlay_PeerWithLedger_SeqRange(t *testing.T) {
+	o := &Overlay{peers: make(map[PeerID]*Peer)}
+
+	// p2 converged, range [100,200] — covers seq 150.
+	p2 := newRelayTestPeer(2)
+	p2.firstLedgerSeq, p2.lastLedgerSeq = 100, 200
+	p2.setTracking(PeerTrackingConverged)
+	// p3 has the same range but is NOT converged — must be skipped.
+	p3 := newRelayTestPeer(3)
+	p3.firstLedgerSeq, p3.lastLedgerSeq = 100, 200
+	p3.setTracking(PeerTrackingDiverged)
+	for _, p := range []*Peer{p2, p3} {
+		o.peers[p.id] = p
+	}
+
+	got, ok := o.PeerWithLedger([32]byte{}, 150, 0)
+	require.True(t, ok, "converged peer covering the seq qualifies without a hash")
+	assert.Equal(t, PeerID(2), got)
+
+	_, ok = o.PeerWithLedger([32]byte{}, 250, 0)
+	assert.False(t, ok, "seq outside every advertised range")
+
+	_, ok = o.PeerWithLedger([32]byte{}, 150, 2)
+	assert.False(t, ok, "only the diverged peer remains after excluding p2")
 }
 
 // TestOverlay_PeerWithLedger_SkipsDisconnected pins that a peer holding the
@@ -92,7 +122,7 @@ func TestOverlay_PeerWithLedger_SkipsDisconnected(t *testing.T) {
 	p.closedLedger, p.hasClosedLedger = target, true
 	o.peers[p.id] = p
 
-	_, ok := o.PeerWithLedger(target, 0)
+	_, ok := o.PeerWithLedger(target, 0, 0)
 	assert.False(t, ok, "a non-connected peer must not be selected")
 }
 

--- a/internal/peermanagement/relay_select_test.go
+++ b/internal/peermanagement/relay_select_test.go
@@ -2,7 +2,9 @@ package peermanagement
 
 import (
 	"testing"
+	"time"
 
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -48,37 +50,116 @@ func TestPeer_TxSetRing(t *testing.T) {
 	p.mu.RUnlock()
 }
 
+// TestPeer_HasLedger pins rippled PeerImp::hasLedger: the hash arm matches a
+// ledger the peer advertised (recentLedgers ring), and the seq-range arm
+// qualifies only a converged peer whose advertised [first,last] covers seq.
+func TestPeer_HasLedger(t *testing.T) {
+	p := newRelayTestPeer(1)
+	h := hash32(0x42)
+
+	assert.False(t, p.HasLedger(h, 0), "nothing advertised yet")
+
+	// Hash arm via the ring.
+	p.AddLedger(h)
+	p.AddLedger(h) // duplicate ignored
+	assert.True(t, p.HasLedger(h, 0))
+	assert.False(t, p.HasLedger(hash32(0x43), 0), "different hash not matched")
+	p.mu.RLock()
+	require.Len(t, p.recentLedgers, 1, "duplicate must not grow the ring")
+	p.mu.RUnlock()
+
+	// Seq-range arm: only when converged and in range.
+	p.firstLedgerSeq, p.lastLedgerSeq = 100, 200
+	p.setTracking(PeerTrackingDiverged)
+	assert.False(t, p.HasLedger([32]byte{}, 150), "diverged peer fails the range arm")
+	p.setTracking(PeerTrackingConverged)
+	assert.True(t, p.HasLedger([32]byte{}, 150))
+	assert.False(t, p.HasLedger([32]byte{}, 250), "seq out of range")
+	assert.False(t, p.HasLedger([32]byte{}, 0), "seq 0 disables the range arm")
+}
+
+// TestPeer_StatusChangeFeedsLedgerRing pins that a status change advertising a
+// closed (and previous) ledger feeds the recentLedgers ring, and that a later
+// LostSync clears the single hints but never the ring — mirroring rippled
+// addLedger (PeerImp.cpp:1846/1857), which is never cleared.
+func TestPeer_StatusChangeFeedsLedgerRing(t *testing.T) {
+	p := newRelayTestPeer(1)
+	closed := hash32(0xC1)
+	prev := hash32(0xB1)
+
+	p.applyStatusChange(&message.StatusChange{
+		NewEvent:           message.NodeEventAcceptedLedger,
+		LedgerHash:         closed[:],
+		LedgerHashPrevious: prev[:],
+	})
+	assert.True(t, p.HasLedger(closed, 0), "closed ledger recorded in the ring")
+	assert.True(t, p.HasLedger(prev, 0), "previous ledger recorded in the ring")
+
+	// LostSync clears the closed/previous hints but must not clear the ring.
+	p.applyStatusChange(&message.StatusChange{NewEvent: message.NodeEventLostSync})
+	if _, ok := p.ClosedLedger(); ok {
+		t.Error("LostSync must clear the closed-ledger hint")
+	}
+	assert.True(t, p.HasLedger(closed, 0), "ring survives LostSync")
+}
+
 // TestOverlay_PeerWithLedger pins getPeerWithLedger selection: a connected
-// peer advertising the ledger as its closed OR previous hash is chosen, the
-// excluded peer is skipped, and ties resolve to the lowest peer id.
+// peer that advertised the ledger (via its recentLedgers ring) is chosen, a
+// peer advertising a different ledger is never chosen, and the excluded peer
+// is skipped.
 func TestOverlay_PeerWithLedger(t *testing.T) {
 	target := hash32(0xAA)
 	o := &Overlay{peers: make(map[PeerID]*Peer)}
 
-	// p3 and p5 both advertise target as their closed ledger; p4 advertises
-	// it as its previous ledger; p9 advertises something else.
+	// p3, p4, p5 advertised target among their recent ledgers; p9 advertised
+	// a different ledger.
 	p3 := newRelayTestPeer(3)
-	p3.closedLedger, p3.hasClosedLedger = target, true
-	p5 := newRelayTestPeer(5)
-	p5.closedLedger, p5.hasClosedLedger = target, true
+	p3.AddLedger(target)
 	p4 := newRelayTestPeer(4)
-	p4.previousLedger, p4.hasPreviousLedger = target, true
+	p4.AddLedger(target)
+	p5 := newRelayTestPeer(5)
+	p5.AddLedger(target)
 	p9 := newRelayTestPeer(9)
-	p9.closedLedger, p9.hasClosedLedger = hash32(0xBB), true
+	p9.AddLedger(hash32(0xBB))
 	for _, p := range []*Peer{p3, p4, p5, p9} {
 		o.peers[p.id] = p
 	}
 
 	got, ok := o.PeerWithLedger(target, 0, 0)
 	require.True(t, ok)
-	assert.Equal(t, PeerID(3), got, "lowest-id candidate selected")
+	assert.Contains(t, []PeerID{3, 4, 5}, got, "an advertiser is selected, never the non-advertiser p9")
 
 	got, ok = o.PeerWithLedger(target, 0, 3)
 	require.True(t, ok)
-	assert.Equal(t, PeerID(4), got, "excluded peer skipped; previous-ledger match counts")
+	assert.Contains(t, []PeerID{4, 5}, got, "excluded peer skipped")
 
 	_, ok = o.PeerWithLedger(hash32(0xCC), 0, 0)
 	assert.False(t, ok, "no peer advertises this ledger")
+}
+
+// TestOverlay_PeerWithLedger_PrefersLowerLatency pins the rippled getScore
+// weighting: among advertisers, the low-latency peer wins every draw despite
+// its higher id, because the latency gap dominates the random jitter.
+func TestOverlay_PeerWithLedger_PrefersLowerLatency(t *testing.T) {
+	target := hash32(0xAA)
+	o := &Overlay{peers: make(map[PeerID]*Peer)}
+
+	// fast has the higher id but a far lower latency; slow is the opposite.
+	fast := newRelayTestPeer(7)
+	fast.AddLedger(target)
+	fast.latency, fast.hasLatency = 1*time.Millisecond, true
+	slow := newRelayTestPeer(2)
+	slow.AddLedger(target)
+	slow.latency, slow.hasLatency = 600*time.Millisecond, true
+	o.peers[fast.id], o.peers[slow.id] = fast, slow
+
+	// The >333ms latency gap dominates the [0,9999] random jitter, so the
+	// low-latency peer wins every draw despite its higher id.
+	for range 50 {
+		got, ok := o.PeerWithLedger(target, 0, 0)
+		require.True(t, ok)
+		assert.Equal(t, PeerID(7), got)
+	}
 }
 
 // TestOverlay_PeerWithLedger_SeqRange pins the rippled hasLedger(hash, seq)
@@ -119,7 +200,7 @@ func TestOverlay_PeerWithLedger_SkipsDisconnected(t *testing.T) {
 
 	p := newRelayTestPeer(2)
 	p.state = PeerStateConnecting
-	p.closedLedger, p.hasClosedLedger = target, true
+	p.AddLedger(target)
 	o.peers[p.id] = p
 
 	_, ok := o.PeerWithLedger(target, 0, 0)
@@ -144,11 +225,11 @@ func TestOverlay_PeerWithTxSet(t *testing.T) {
 
 	got, ok := o.PeerWithTxSet(root, 0)
 	require.True(t, ok)
-	assert.Equal(t, PeerID(2), got)
+	assert.Contains(t, []PeerID{2, 6}, got, "an advertiser of root is selected, never p8")
 
 	got, ok = o.PeerWithTxSet(root, 2)
 	require.True(t, ok)
-	assert.Equal(t, PeerID(6), got)
+	assert.Equal(t, PeerID(6), got, "excluding p2 leaves p6 as the only advertiser")
 
 	_, ok = o.PeerWithTxSet(hash32(0x22), 0)
 	assert.False(t, ok)


### PR DESCRIPTION
## Summary

- go-xrpl was responder-only for `mtGET_LEDGER`: a request for a ledger or candidate tx-set we don't have was silently dropped. rippled instead **relays** the request to a peer that has it (`getPeerWithLedger` / `getPeerWithTree`). This implements item 3 deferred from #951 (PR #968).
- Adds a per-peer tx-set advertisement ring (`Peer.AddTxSet`/`HasTxSet`, cap 128, fed by inbound `mtHAVE_TRANSACTION_SET{tsHAVE}`) plus `Overlay.PeerWithLedger`/`PeerWithTxSet` selectors (exposed to the router via the `NetworkSender` interface), mirroring rippled's `recentTxSets_`/`hasLedger`/`hasTxSet`.
- On a serve miss for an **original indirect** request (`query_type` present, `request_cookie` absent), the router forwards the frame to the selected peer stamped with `request_cookie = requester id`. The inbound `TMLedgerData` path routes a cookied reply back to the original requester (clearing the cookie) instead of consuming it locally.
- **Loop prevention:** a request already carrying a cookie is never relayed again; fan-out is capped at the single best peer.

Selection note: rippled additionally weights candidates by measured latency and a random jitter (`getScore`) to spread load; go-xrpl picks the lowest peer id deterministically, which keeps the relay path testable. Setting `query_type` on our own *outbound* requests stays out of scope (the issue scopes the serve/relay side only).

## Test plan

- [x] `go test -race ./internal/consensus/adaptor/... ./internal/peermanagement/...`
- [x] New router tests: relay on miss (ledger + tx-set), no-relay when cookie already set / query_type absent / no candidate, reply routed back by cookie, tsHAVE recorded
- [x] New peermanagement tests: tx-set ring dedup/eviction, `PeerWithLedger` (closed/previous match, exclude, lowest-id, skip-disconnected), `PeerWithTxSet`, `NotePeerHasTxSet`
- [x] `go build ./...`, `go vet ./...`, `gofmt`, `golangci-lint` all clean

Fixes #969