### PR TITLE
fix: run RPC overload (gateLoad) gate before FORBID

### DIFF
--- a/internal/rpc/overload_gate_test.go
+++ b/internal/rpc/overload_gate_test.go
@@ -1,0 +1,221 @@
+package rpc
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pushOverDropThreshold charges key until the tracker reports it is over the
+// per-IP drop threshold, so a single subsequent request is admission-rejected
+// deterministically rather than after a probabilistic number of heavy calls.
+func pushOverDropThreshold(t *testing.T, tr *loadtrack.Tracker, key string) {
+	t.Helper()
+	for range 1000 {
+		if tr.OverDropThreshold(key) {
+			return
+		}
+		tr.Charge(key, loadtrack.LoadHeavy)
+	}
+	t.Fatalf("could not push %s over DropThreshold", key)
+}
+
+// TestHTTPOverloadBeforeForbid pins issue #975: a forbidden admin command from a
+// caller already over its per-IP budget is rejected at the overload-admission
+// layer (503 "Server is overloaded"), ahead of the role-layer FORBID (403),
+// matching rippled's usage.disconnect() running before the FORBID short-circuit
+// (ServerHandler.cpp:735 ahead of :750).
+func TestHTTPOverloadBeforeForbid(t *testing.T) {
+	srv := newHardeningServer(t, time.Second, "stop", &stubHandler{role: types.RoleAdmin})
+	srv.loadTracker = loadtrack.New()
+	pushOverDropThreshold(t, srv.loadTracker, "203.0.113.5")
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"stop","params":[{}]}`))
+	req.RemoteAddr = "203.0.113.5:1234" // non-local peer, no AdminNets → RoleGuest
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d\nbody: %s", rr.Code, rr.Body.String())
+	}
+	// rippled labels even this plain-text body application/json.
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json; charset=UTF-8" {
+		t.Fatalf("content-type = %q, want application/json; charset=UTF-8", ct)
+	}
+	if got := strings.TrimSpace(rr.Body.String()); got != "Server is overloaded" {
+		t.Fatalf("body = %q, want \"Server is overloaded\"", got)
+	}
+	// It must be the overload denial, not the 403 FORBID (which would win if the
+	// gate order were wrong) nor the result envelope.
+	if strings.Contains(rr.Body.String(), "Forbidden") || strings.Contains(rr.Body.String(), "result") {
+		t.Fatalf("overload denial leaked a FORBID/result shape: %s", rr.Body.String())
+	}
+}
+
+// TestHTTPOverloadOpenMethod confirms the overload gate still fires for an
+// ordinary (non-forbidden) method, so moving it ahead of FORBID did not narrow
+// it to only the admin path.
+func TestHTTPOverloadOpenMethod(t *testing.T) {
+	srv := newHardeningServer(t, time.Second, "ping", echoHandler())
+	srv.loadTracker = loadtrack.New()
+	pushOverDropThreshold(t, srv.loadTracker, "198.51.100.7")
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"ping","params":[{}]}`))
+	req.RemoteAddr = "198.51.100.7:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d\nbody: %s", rr.Code, rr.Body.String())
+	}
+	if got := strings.TrimSpace(rr.Body.String()); got != "Server is overloaded" {
+		t.Fatalf("body = %q, want \"Server is overloaded\"", got)
+	}
+}
+
+// TestHTTPOverloadAdminUnlimitedBypass confirms an admin (unlimited) caller
+// bypasses gateLoad entirely even when its key is over the threshold, matching
+// rippled's isUnlimited() taking the newUnlimitedEndpoint branch that never
+// disconnects.
+func TestHTTPOverloadAdminUnlimitedBypass(t *testing.T) {
+	srv := newHardeningServer(t, time.Second, "stop", &stubHandler{role: types.RoleAdmin})
+	srv.loadTracker = loadtrack.New()
+	pushOverDropThreshold(t, srv.loadTracker, "127.0.0.1")
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"stop","params":[{}]}`))
+	req.RemoteAddr = "127.0.0.1:1234" // localhost fallback → RoleAdmin → Unlimited
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("admin caller: expected 200, got %d\nbody: %s", rr.Code, rr.Body.String())
+	}
+	if result := decodeEnvelope(t, rr.Body.Bytes()); result["status"] != "success" {
+		t.Fatalf("admin caller: status = %v, want success", result["status"])
+	}
+}
+
+// TestHTTPApiVersionPrecedesOverload pins that the api_version check (400) still
+// runs ahead of the overload gate, mirroring getAPIVersionNumber preceding
+// usage.disconnect() (ServerHandler.cpp:685 ahead of :735): an over-budget caller
+// supplying an out-of-range api_version gets invalid_API_version, not 503.
+func TestHTTPApiVersionPrecedesOverload(t *testing.T) {
+	srv := newHardeningServer(t, time.Second, "ping", echoHandler())
+	srv.loadTracker = loadtrack.New()
+	pushOverDropThreshold(t, srv.loadTracker, "198.51.100.7")
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"ping","params":[{"api_version":99}]}`))
+	req.RemoteAddr = "198.51.100.7:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 (api-version before overload), got %d\nbody: %s", rr.Code, rr.Body.String())
+	}
+	if got := strings.TrimSpace(rr.Body.String()); got != types.InvalidApiVersionToken {
+		t.Fatalf("body = %q, want %q", got, types.InvalidApiVersionToken)
+	}
+}
+
+// TestHTTPBatchOverloadElement pins the batch-element shape for the overload gate:
+// rippled echoes the element's own fields and attaches
+// make_json_error(server_overloaded, "Server is overloaded") (server_overloaded =
+// -32604, ServerHandler.cpp:742-746), ahead of FORBID. So a batch from an
+// over-budget caller renders the overload object for BOTH a forbidden admin
+// element and an ordinary element — never the forbidden (-32605) object.
+func TestHTTPBatchOverloadElement(t *testing.T) {
+	srv := &Server{
+		registry:    types.NewMethodRegistry(),
+		timeout:     time.Second,
+		services:    types.NewServiceContainer(nil),
+		loadTracker: loadtrack.New(),
+	}
+	srv.registry.Register("stop", &stubHandler{role: types.RoleAdmin})
+	srv.registry.Register("ping", echoHandler())
+	pushOverDropThreshold(t, srv.loadTracker, "10.0.0.1") // postBatch posts from 10.0.0.1
+
+	body := `{"method":"batch","params":[
+		{"method":"stop","value":7},
+		{"method":"ping","value":1}
+	]}`
+	rr := postBatch(t, srv, body)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d\nbody: %s", rr.Code, rr.Body.String())
+	}
+	var replies []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &replies); err != nil {
+		t.Fatalf("not a JSON array: %v\nbody: %s", err, rr.Body.String())
+	}
+	if len(replies) != 2 {
+		t.Fatalf("expected 2 replies, got %d", len(replies))
+	}
+
+	for i, want := range []float64{7, 1} {
+		el := replies[i]
+		if _, hasResult := el["result"]; hasResult {
+			t.Fatalf("element %d must not carry a result envelope: %v", i, el)
+		}
+		if el["value"] != want {
+			t.Fatalf("element %d did not echo its own fields: %v", i, el)
+		}
+		errObj, ok := el["error"].(map[string]any)
+		if !ok {
+			t.Fatalf("element %d missing error object: %v", i, el)
+		}
+		inner, ok := errObj["error"].(map[string]any)
+		if !ok {
+			t.Fatalf("element %d error not in make_json_error shape: %v", i, errObj)
+		}
+		if inner["code"] != float64(-32604) {
+			t.Fatalf("element %d code = %v, want -32604 (server_overloaded)", i, inner["code"])
+		}
+		if inner["message"] != "Server is overloaded" {
+			t.Fatalf("element %d message = %v, want \"Server is overloaded\"", i, inner["message"])
+		}
+	}
+}
+
+// TestWSOverloadBeforeForbid confirms the WebSocket ordering: an over-budget caller
+// invoking a forbidden admin command is rejected by the overload gate ahead of
+// FORBID, surfacing rippled's WS overload code rpcSLOW_DOWN (slowDown, 10) rather
+// than the forbidden token. A non-admin role is forced by AdminNets that exclude
+// the loopback peer, disabling the localhost-admin fallback.
+func TestWSOverloadBeforeForbid(t *testing.T) {
+	ws := NewWebSocketServer(2*time.Second, nil)
+	ws.methodRegistry.Register("stop", &stubHandler{role: types.RoleAdmin})
+	ws.loadTracker = loadtrack.New()
+	pushOverDropThreshold(t, ws.loadTracker, "127.0.0.1")
+
+	_, adminNet, _ := net.ParseCIDR("10.0.0.0/8")
+	pc := &PortContext{AdminNets: []net.IPNet{*adminNet}}
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws.ServeHTTP(w, r.WithContext(WithPortContext(r.Context(), pc)))
+	}))
+	defer httpSrv.Close()
+	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http")
+
+	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer c.Close()
+
+	require.NoError(t, c.WriteJSON(map[string]any{"command": "stop", "id": float64(1)}))
+	require.NoError(t, c.SetReadDeadline(time.Now().Add(2*time.Second)))
+	var resp map[string]any
+	require.NoError(t, c.ReadJSON(&resp))
+
+	assert.Equal(t, "error", resp["status"])
+	assert.Equal(t, "slowDown", resp["error"], "overload must precede FORBID on the WS path")
+	assert.Equal(t, float64(types.RpcSLOW_DOWN), resp["error_code"])
+	assert.Equal(t, float64(1), resp["id"])
+}

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -333,6 +333,16 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// rippled rejects a caller already over its per-IP resource budget at the
+	// overload-admission layer, ahead of FORBID: a positive usage.disconnect()
+	// yields HTTPReply(503, "Server is overloaded") — a 503 whose body is the
+	// bare string, not the JSON-RPC result envelope (ServerHandler.cpp:735-740).
+	// This precedes the FORBID render below, matching rippled's order.
+	if rpcErr != nil && rpcErr.IsOverloaded() {
+		writePlainHTTPError(w, http.StatusServiceUnavailable, "Server is overloaded")
+		return
+	}
+
 	// rippled rejects an admin-only command from a non-admin caller at the role
 	// layer: a FORBID role yields HTTPReply(403, "Forbidden") before the handler
 	// runs, not the JSON-RPC result envelope (ServerHandler.cpp:750-757). The
@@ -473,6 +483,15 @@ func (s *Server) dispatchBatchElement(el json.RawMessage, baseCtx context.Contex
 		}
 	}
 
+	// rippled rejects a batch element whose caller is over its per-IP budget at
+	// the overload-admission layer, ahead of FORBID: the echoed element plus
+	// make_json_error(server_overloaded, "Server is overloaded")
+	// (ServerHandler.cpp:735-746). Like the single path, this precedes the FORBID
+	// branch below.
+	if rpcErr != nil && rpcErr.IsOverloaded() {
+		return batchOverloadedElement(elem)
+	}
+
 	// rippled renders a batch element denied at the role layer as the echoed
 	// element plus a make_json_error(forbidden, "Forbidden") object — the
 	// malformed-element early-exit shape, not the XRPL result envelope
@@ -499,6 +518,12 @@ const rpcMethodNotFoundCode = -32601
 // It is distinct from method_not_found and appears only inside batch
 // forbidden-element replies, matching rippled byte-for-byte.
 const forbiddenJSONRPCCode = -32605
+
+// serverOverloadedJSONRPCCode is the JSON-RPC error code rippled attaches to a
+// batch element whose caller is over its per-IP resource budget
+// (ServerHandler.cpp:606, server_overloaded = -32604). It appears only inside
+// batch overload-element replies, matching rippled byte-for-byte.
+const serverOverloadedJSONRPCCode = -32604
 
 // makeBatchJSONError mirrors rippled's make_json_error (ServerHandler.cpp:594-603):
 // it returns {"error": {"code": code, "message": message}}. rippled assigns this
@@ -534,6 +559,18 @@ func batchForbiddenElement(elem map[string]any) map[string]any {
 	r := make(map[string]any, len(elem)+1)
 	maps.Copy(r, elem)
 	r["error"] = makeBatchJSONError(forbiddenJSONRPCCode, "Forbidden")
+	return r
+}
+
+// batchOverloadedElement builds the reply for a batch element whose caller is
+// over its per-IP resource budget. Like rippled's overload branch
+// (ServerHandler.cpp:742-746), the element's own fields are echoed at the top
+// level — unmasked, matching the other early-exit paths — with a
+// server_overloaded JSON-RPC error attached, rather than the XRPL result envelope.
+func batchOverloadedElement(elem map[string]any) map[string]any {
+	r := make(map[string]any, len(elem)+1)
+	maps.Copy(r, elem)
+	r["error"] = makeBatchJSONError(serverOverloadedJSONRPCCode, "Server is overloaded")
 	return r
 }
 
@@ -623,19 +660,22 @@ func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types
 // previously skipped conditionMet). The only transport-specific bit is the
 // admin-gate error, supplied by adminGate.
 //
-// The gate order spans rippled's two layers: the role-layer FORBID short-
-// circuits in ServerHandler::processRequest *before* doCommand, while the
-// job-queue busy gate lives inside fillHandler. The effective sequence is:
+// The gate order spans rippled's two layers: the per-IP overload check and the
+// role-layer FORBID short-circuit both fire in ServerHandler::processRequest
+// *before* doCommand, while the job-queue busy gate lives inside fillHandler.
+// The effective sequence is:
 //
-//	api-version (400) → FORBID (403) → busy (rpcTOO_BUSY) → unknown-command →
-//	conditionMet → load gate → handle → load finalize
+//	api-version (400) → overload (503) → FORBID (403) → busy (rpcTOO_BUSY) →
+//	unknown-command → conditionMet → handle → load finalize
 //
-// FORBID therefore precedes busy: a forbidden admin request under queue
-// saturation is denied 403, not rpcTOO_BUSY. busy still precedes the
-// unknown-command failure, so an unresolved command under saturation stays
-// rpcTOO_BUSY (a command that does not resolve — unknown, or known but not
-// served at the requested api_version — is never forbidden; rippled's
-// roleRequired yields GUEST for it).
+// The overload admission (usage.disconnect()) precedes FORBID: a forbidden admin
+// request from a caller already over its per-IP budget is denied 503 "Server is
+// overloaded", not 403 (ServerHandler.cpp:735 ahead of :750). FORBID in turn
+// precedes busy: a forbidden admin request under queue saturation is denied 403,
+// not rpcTOO_BUSY. busy still precedes the unknown-command failure, so an
+// unresolved command under saturation stays rpcTOO_BUSY (a command that does not
+// resolve — unknown, or known but not served at the requested api_version — is
+// never forbidden; rippled's roleRequired yields GUEST for it).
 func dispatchMethod(
 	registry *types.MethodRegistry,
 	tracker *loadtrack.Tracker,
@@ -664,6 +704,16 @@ func dispatchMethod(
 	// lookup misses, deferring to the busy-then-unknown-command path below.
 	resolved := exists && handlerSupportsVersion(handler, ctx.ApiVersion)
 
+	// The per-IP resource-overload admission check runs before FORBID and busy,
+	// mirroring usage.disconnect() consulted ahead of doCommand and the FORBID
+	// short-circuit (ServerHandler.cpp:735 ahead of :750). A caller already over
+	// its budget is denied here (503 "Server is overloaded") regardless of whether
+	// the command is forbidden, unknown, or saturated. Admin / unlimited callers
+	// no-op (matching isUnlimited taking the newUnlimitedEndpoint branch).
+	if rpcErr := gateLoad(tracker, ctx, method, log); rpcErr != nil {
+		return nil, rpcErr
+	}
+
 	// Refuse an admin-only command for a non-admin caller. rippled decides this
 	// at the role layer (Role::FORBID) before doCommand runs and charges
 	// feeMalformedRPC (ServerHandler.cpp:750-762, :482-486). The gate returns
@@ -691,9 +741,6 @@ func dispatchMethod(
 		return nil, rpcErr
 	}
 
-	if err := gateLoad(tracker, ctx, method, log); err != nil {
-		return nil, err
-	}
 	if services != nil && services.ClientLoad != nil {
 		services.ClientLoad.Begin()
 		defer services.ClientLoad.End()
@@ -828,10 +875,13 @@ func notSyncedError(apiVersion, v1Code int, v1Token, v1Message string) *types.Rp
 		"Not synced to the network.")
 }
 
-// gateLoad is the pre-dispatch admission check. It does NOT charge the
-// caller; it only rejects when the (decayed) balance is already at or
-// above DropThreshold. Mirrors rippled ServerHandler.cpp:735 where
-// usage.disconnect() is consulted *before* doCommand runs.
+// gateLoad is the pre-dispatch overload admission check, run ahead of the FORBID
+// and busy gates. It does NOT charge the caller; it only rejects when the
+// (decayed) balance is already at or above DropThreshold. Mirrors rippled
+// ServerHandler.cpp:735 where usage.disconnect() is consulted *before* the FORBID
+// short-circuit and doCommand, returning without charging feeMalformedRPC. The
+// rejection carries the overloaded flag so the transport writers render rippled's
+// 503 "Server is overloaded" (single) / make_json_error(server_overloaded) (batch).
 //
 // Admin / identified callers bypass tracking entirely, matching rippled
 // isUnlimited() (Role.cpp:124-128).
@@ -842,7 +892,7 @@ func gateLoad(tracker *loadtrack.Tracker, ctx *types.RpcContext, method string, 
 	if tracker.OverDropThreshold(ctx.ClientIP) {
 		log.Warn("rpc dropped: client over load threshold",
 			"client", ctx.ClientIP, "method", method, "balance", tracker.Balance(ctx.ClientIP))
-		return types.RpcErrorSlowDown("Slow down. Server is too busy for this client.")
+		return types.RpcErrorOverloaded()
 	}
 	return nil
 }
@@ -968,9 +1018,12 @@ func (s *Server) writeXrplResponseWithOptions(w http.ResponseWriter, request any
 	// is the only honest signal.
 	//
 	// rpcTOO_BUSY maps to HTTP 503, matching rippled ErrorCodes.cpp:114
-	// (`{rpcTOO_BUSY, "tooBusy", ..., 503}`). All other errors ride on
-	// 200 OK; XRPL clients parse result.error, not the HTTP status.
-	if rpcErr != nil && rpcErr.Code == types.RpcTOO_BUSY {
+	// (`{rpcTOO_BUSY, "tooBusy", ..., 503}`). The per-IP overload rejection is
+	// also a 503 (ServerHandler.cpp:739); the HTTP-single POST path renders its
+	// bare-string body earlier, so this branch only covers the GET extension,
+	// which keeps the result envelope. All other errors ride on 200 OK; XRPL
+	// clients parse result.error, not the HTTP status.
+	if rpcErr != nil && (rpcErr.Code == types.RpcTOO_BUSY || rpcErr.IsOverloaded()) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	} else {
 		w.WriteHeader(http.StatusOK)

--- a/internal/rpc/server_hardening_test.go
+++ b/internal/rpc/server_hardening_test.go
@@ -298,22 +298,32 @@ type heavyStub struct{ stubHandler }
 
 func (heavyStub) LoadKind() loadtrack.LoadKind { return loadtrack.LoadHeavy }
 
+// Once the per-IP balance crosses DropThreshold, the overload-admission gate
+// (gateLoad) rejects with rippled's canonical HTTP 503 "Server is overloaded"
+// bare-string body (ServerHandler.cpp:739), not the slowDown result envelope.
 func TestLoadTracker_RejectsAfterDropThreshold(t *testing.T) {
 	srv := newHardeningServer(t, time.Second, "path_find", &heavyStub{stubHandler{}})
 	srv.loadTracker = loadtrack.New()
 
-	var lastResult map[string]any
+	var lastBody string
 	for range 12 {
 		req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"path_find","params":[{}]}`))
 		req.RemoteAddr = "198.51.100.7:5555"
 		rr := httptest.NewRecorder()
 		srv.ServeHTTP(rr, req)
-		lastResult = decodeEnvelope(t, rr.Body.Bytes())
-		if lastResult["error"] == "slowDown" {
+		lastBody = rr.Body.String()
+		if rr.Code == http.StatusServiceUnavailable {
+			if got := strings.TrimSpace(rr.Body.String()); got != "Server is overloaded" {
+				t.Fatalf("503 body = %q, want \"Server is overloaded\"", got)
+			}
+			// The denial must not ride the result envelope (the old slowDown-on-200 shape).
+			if strings.Contains(rr.Body.String(), "result") || strings.Contains(rr.Body.String(), "slowDown") {
+				t.Fatalf("overload denial leaked the result envelope: %s", rr.Body.String())
+			}
 			return
 		}
 	}
-	t.Fatalf("never received slowDown after 12 heavy invocations; last result %v", lastResult)
+	t.Fatalf("never received HTTP 503 after 12 heavy invocations; last body %s", lastBody)
 }
 
 func TestLoadTracker_AdminBypassesCharge(t *testing.T) {

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -42,6 +42,15 @@ type RpcError struct {
 	// `error` token. Transport writers special-case this flag so go-xrpl mirrors
 	// each path exactly without disturbing the table-driven error model.
 	invalidApiVersion bool
+
+	// overloaded marks the per-IP resource-overload admission rejection, which
+	// rippled emits before doCommand (usage.disconnect(), ServerHandler.cpp:735)
+	// with a shape that differs per transport: HTTP single is a bare-string 503
+	// "Server is overloaded", each batch element is a make_json_error JSON-RPC
+	// object (server_overloaded = -32604), and WS carries the rpcSLOW_DOWN
+	// envelope. Transport writers special-case this flag the same way they do
+	// invalidApiVersion / forbidden.
+	overloaded bool
 }
 
 // IsBareToken reports whether this error mirrors a rippled bare-token response
@@ -69,6 +78,18 @@ func (e RpcError) IsInvalidApiVersion() bool {
 // rejection, which rides the normal result envelope on every transport.
 func (e RpcError) IsForbidden() bool {
 	return e.Code == RpcFORBIDDEN
+}
+
+// IsOverloaded reports whether this error is the per-IP resource-overload
+// admission rejection. rippled consults usage.disconnect() in
+// ServerHandler::processRequest ahead of the FORBID gate and doCommand
+// (ServerHandler.cpp:735), rendering it per transport — HTTP single → 503
+// "Server is overloaded"; batch element → make_json_error(server_overloaded,
+// "Server is overloaded"); WS → rpcError(rpcSLOW_DOWN) — so the transport
+// writers special-case it. It is distinct from the post-dispatch warning:"load"
+// path, which rides the normal result envelope.
+func (e RpcError) IsOverloaded() bool {
+	return e.overloaded
 }
 
 func (e RpcError) Error() string {
@@ -292,6 +313,18 @@ func RpcErrorTooBusy() *RpcError {
 
 func RpcErrorSlowDown(message string) *RpcError {
 	return NewRpcError(RpcSLOW_DOWN, "slowDown", "slowDown", message)
+}
+
+// RpcErrorOverloaded is the per-IP resource-overload admission rejection
+// consulted before doCommand (rippled usage.disconnect(), ServerHandler.cpp:735).
+// It carries rpcSLOW_DOWN with rippled's canonical slowDown message so the WS /
+// result-envelope path renders rippled's WS overload code, and sets the
+// overloaded flag so the HTTP single (503 "Server is overloaded") and batch
+// (make_json_error(server_overloaded, ...)) writers can special-case it.
+func RpcErrorOverloaded() *RpcError {
+	e := RpcErrorSlowDown("You are placing too much load on the server.")
+	e.overloaded = true
+	return e
 }
 
 // RpcErrorNotStandalone mirrors rippled's ledger_accept handler


### PR DESCRIPTION
## Summary

- `dispatchMethod` ran the per-IP resource/overload admission check (`gateLoad`) at the **end** of the gate chain, after the role-layer FORBID gate. rippled consults `usage.disconnect()` in `ServerHandler::processRequest` **before** FORBID and `doCommand`, so a forbidden admin request from a caller already over its per-IP budget returned **403 "Forbidden"** in goXRPL where rippled returns **503 "Server is overloaded"**.
- Move `gateLoad` ahead of FORBID and busy in the shared dispatch core, so the fix lands on HTTP single, batch, and WS at once. New effective order: `api-version (400) → overload (503) → FORBID (403) → busy (rpcTOO_BUSY) → unknown-command → conditionMet`.
- Render the rejection in rippled's canonical wire shape (facet 2): HTTP single → bare-string **503 "Server is overloaded"** (`ServerHandler.cpp:739`); batch element → `make_json_error(server_overloaded /* -32604 */, "Server is overloaded")` (`:744`); WS → the `rpcSLOW_DOWN` frame (rippled's WS overload code). The overload denial returns before `finalizeLoad`, so it does **not** charge `feeMalformedRPC`, and the `Unlimited`/admin carve-out is preserved.

Fixing the ordering alone would only trade the 403 divergence for a 200-`slowDown` divergence, so the canonical 503 wire shape is part of the fix (the issue's facet 2). WS keeps delivering an error frame rather than closing the session (rippled closes it but does not deliver the error) — left out of scope as a more invasive change; the ordering fix still applies there.

Split off from #970 (PR #973), which resequenced the busy gate ahead of FORBID and deliberately deferred this overload-ordering item.

## Test plan

- [x] `go test ./internal/rpc/...` — all green
- [x] New `internal/rpc/overload_gate_test.go` (green under `-race`): overload-before-FORBID on HTTP single / batch / WS, overload still fires for an open method, admin/unlimited bypass, and api-version (400) still precedes overload
- [x] Updated `TestLoadTracker_RejectsAfterDropThreshold` to assert the 503 bare body
- [x] `go vet` + `gofmt` clean; `cli` / `grpc` / `cmd` build clean

Fixes #975