### PR TITLE
Set query_type=qtINDIRECT on retried GetLedger acquisitions

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -73,14 +73,22 @@ type NetworkSender interface {
 	// that should be skipped during this broadcast — populated by the
 	// router with peers that have repeatedly returned non-progressing
 	// TMLedgerData replies for this acquisition. A nil or empty map is
-	// the unrestricted case.
-	RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error
+	// the unrestricted case. indirect sets query_type=qtINDIRECT so peers
+	// relay the request on our behalf — set once the acquisition has timed
+	// out at least once (see RequestStateNodes).
+	RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool, indirect bool) error
 	RequestLedger(id consensus.LedgerID) error
 	RequestLedgerByHashAndSeq(hash [32]byte, seq uint32) error
 	RequestLedgerBaseFromPeer(peerID uint64, hash [32]byte, seq uint32) error
 	RequestReplayDelta(peerID uint64, hash [32]byte) error
-	RequestStateNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error
-	RequestTransactionNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error
+	// RequestStateNodes / RequestTransactionNodes fetch outstanding
+	// account-state / transaction SHAMap nodes of an in-flight acquisition.
+	// indirect sets query_type=qtINDIRECT, marking the request relayable by
+	// intermediary peers; it must be false on the first attempt and true
+	// once the acquisition has timed out at least once, mirroring rippled's
+	// InboundLedger::trigger timeouts_ != 0 gate.
+	RequestStateNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte, indirect bool) error
+	RequestTransactionNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte, indirect bool) error
 	SendToPeer(peerID uint64, frame []byte) error
 	// PeerSupportsReplay reports whether the peer identified by peerID
 	// advertised the ledger-replay feature during handshake. Used by
@@ -128,21 +136,21 @@ func (n *noopSender) RelayProposal(*consensus.Proposal, uint64) error     { retu
 func (n *noopSender) RelayValidation(*consensus.Validation, uint64) error { return nil }
 func (n *noopSender) UpdateRelaySlot([]byte, uint64, []uint64)            {}
 func (n *noopSender) RequestTxSet(consensus.TxSetID) error                { return nil }
-func (n *noopSender) RequestTxSetMissingNodes(consensus.TxSetID, [][]byte, map[uint64]bool) error {
+func (n *noopSender) RequestTxSetMissingNodes(consensus.TxSetID, [][]byte, map[uint64]bool, bool) error {
 	return nil
 }
-func (n *noopSender) RequestLedger(consensus.LedgerID) error                   { return nil }
-func (n *noopSender) RequestLedgerByHashAndSeq([32]byte, uint32) error         { return nil }
-func (n *noopSender) RequestLedgerBaseFromPeer(uint64, [32]byte, uint32) error { return nil }
-func (n *noopSender) RequestReplayDelta(uint64, [32]byte) error                { return nil }
-func (n *noopSender) RequestStateNodes(uint64, [32]byte, [][]byte) error       { return nil }
-func (n *noopSender) RequestTransactionNodes(uint64, [32]byte, [][]byte) error { return nil }
-func (n *noopSender) SendToPeer(uint64, []byte) error                          { return nil }
-func (n *noopSender) PeerSupportsReplay(uint64) bool                           { return false }
-func (n *noopSender) ReplayCapablePeersExcluding([]uint64, int) []uint64       { return nil }
-func (n *noopSender) IncPeerBadData(uint64, string)                            {}
-func (n *noopSender) PeersThatHave([32]byte) []uint64                          { return nil }
-func (n *noopSender) ShouldShedLedgerRequest(uint64, bool) bool                { return false }
+func (n *noopSender) RequestLedger(consensus.LedgerID) error                         { return nil }
+func (n *noopSender) RequestLedgerByHashAndSeq([32]byte, uint32) error               { return nil }
+func (n *noopSender) RequestLedgerBaseFromPeer(uint64, [32]byte, uint32) error       { return nil }
+func (n *noopSender) RequestReplayDelta(uint64, [32]byte) error                      { return nil }
+func (n *noopSender) RequestStateNodes(uint64, [32]byte, [][]byte, bool) error       { return nil }
+func (n *noopSender) RequestTransactionNodes(uint64, [32]byte, [][]byte, bool) error { return nil }
+func (n *noopSender) SendToPeer(uint64, []byte) error                                { return nil }
+func (n *noopSender) PeerSupportsReplay(uint64) bool                                 { return false }
+func (n *noopSender) ReplayCapablePeersExcluding([]uint64, int) []uint64             { return nil }
+func (n *noopSender) IncPeerBadData(uint64, string)                                  {}
+func (n *noopSender) PeersThatHave([32]byte) []uint64                                { return nil }
+func (n *noopSender) ShouldShedLedgerRequest(uint64, bool) bool                      { return false }
 
 // Compile-time interface check.
 var _ consensus.Adaptor = (*Adaptor)(nil)
@@ -568,8 +576,8 @@ func (a *Adaptor) RequestTxSet(id consensus.TxSetID) error {
 	return a.sender.RequestTxSet(id)
 }
 
-func (a *Adaptor) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error {
-	return a.sender.RequestTxSetMissingNodes(id, nodeIDs, excluded)
+func (a *Adaptor) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool, indirect bool) error {
+	return a.sender.RequestTxSetMissingNodes(id, nodeIDs, excluded, indirect)
 }
 
 func (a *Adaptor) RequestLedger(id consensus.LedgerID) error {
@@ -590,12 +598,12 @@ func (a *Adaptor) RequestReplayDelta(peerID uint64, hash [32]byte) error {
 	return a.sender.RequestReplayDelta(peerID, hash)
 }
 
-func (a *Adaptor) RequestStateNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error {
-	return a.sender.RequestStateNodes(peerID, ledgerHash, nodeIDs)
+func (a *Adaptor) RequestStateNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte, indirect bool) error {
+	return a.sender.RequestStateNodes(peerID, ledgerHash, nodeIDs, indirect)
 }
 
-func (a *Adaptor) RequestTransactionNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error {
-	return a.sender.RequestTransactionNodes(peerID, ledgerHash, nodeIDs)
+func (a *Adaptor) RequestTransactionNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte, indirect bool) error {
+	return a.sender.RequestTransactionNodes(peerID, ledgerHash, nodeIDs, indirect)
 }
 
 // EngineConfigForReplay returns the shared (non-per-ledger)

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -911,14 +911,22 @@ func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerD
 // account-state and transaction tree nodes of the active acquisition,
 // requesting both trees in parallel. Each call is a no-op for a tree
 // already complete.
+//
+// Once the acquisition has timed out at least once we mark the requests
+// indirect (query_type=qtINDIRECT) so peers relay them on our behalf,
+// mirroring rippled's InboundLedger::trigger timeouts_ != 0 gate. go-xrpl
+// reaps a legacy acquisition on its first timeout, so its only post-timeout
+// life is the aggressive fetch-pack escalation window — exactly rippled's
+// "be more aggressive" branch — which FetchPackRequested reports.
 func (r *Router) requestMissingAcquisitionNodes(il *inbound.Ledger) {
+	indirect := il.FetchPackRequested()
 	if nodeIDs := il.NeedsMissingNodeIDs(); len(nodeIDs) > 0 {
-		if err := r.adaptor.RequestStateNodes(il.PeerID(), il.Hash(), nodeIDs); err != nil {
+		if err := r.adaptor.RequestStateNodes(il.PeerID(), il.Hash(), nodeIDs, indirect); err != nil {
 			r.logger.Warn("inbound ledger: failed to request state nodes", "error", err)
 		}
 	}
 	if nodeIDs := il.NeedsMissingTxNodeIDs(); len(nodeIDs) > 0 {
-		if err := r.adaptor.RequestTransactionNodes(il.PeerID(), il.Hash(), nodeIDs); err != nil {
+		if err := r.adaptor.RequestTransactionNodes(il.PeerID(), il.Hash(), nodeIDs, indirect); err != nil {
 			r.logger.Warn("inbound ledger: failed to request tx nodes", "error", err)
 		}
 	}

--- a/internal/consensus/adaptor/router_catchup_querytype_test.go
+++ b/internal/consensus/adaptor/router_catchup_querytype_test.go
@@ -1,0 +1,91 @@
+package adaptor
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// acqRecordingSender captures the indirect flag passed to the legacy
+// inbound-ledger node-fetch builders (RequestStateNodes / RequestTransactionNodes)
+// so the requester-side query_type escalation can be pinned. Other
+// NetworkSender methods inherit from noopSender.
+type acqRecordingSender struct {
+	noopSender
+	mu       sync.Mutex
+	stateInd []bool
+	txInd    []bool
+}
+
+func (s *acqRecordingSender) RequestStateNodes(_ uint64, _ [32]byte, _ [][]byte, indirect bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stateInd = append(s.stateInd, indirect)
+	return nil
+}
+
+func (s *acqRecordingSender) RequestTransactionNodes(_ uint64, _ [32]byte, _ [][]byte, indirect bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.txInd = append(s.txInd, indirect)
+	return nil
+}
+
+func (s *acqRecordingSender) stateIndirects() []bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]bool(nil), s.stateInd...)
+}
+
+// TestRequestMissingAcquisitionNodes_QueryTypeEscalation pins issue #977's
+// requester-side escalation for the LEGACY inbound-ledger path: a fresh
+// acquisition fetches its outstanding state/tx nodes directly (query_type
+// absent, non-relayable), and once a fetch-pack escalation has been armed —
+// the acquisition's only post-timeout life, since go-xrpl reaps a legacy
+// acquisition on its first timeout — the requests go indirect
+// (query_type=qtINDIRECT) so peers relay them on our behalf. This is the
+// legacy-path analogue of rippled's InboundLedger::trigger timeouts_ != 0 gate
+// (InboundLedger.cpp:531); the symmetric tx-set path is covered by
+// TestTxSetRetry_QueryTypeEscalation.
+func TestRequestMissingAcquisitionNodes_QueryTypeEscalation(t *testing.T) {
+	svc := newTestLedgerService(t)
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	rs := &acqRecordingSender{}
+	a := New(Config{
+		LedgerService: svc,
+		Sender:        rs,
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+	})
+	router := NewRouter(&mockEngine{}, a, nil)
+
+	// Serve the closed ledger's base (header + state root) into a fresh
+	// acquisition so it has outstanding state nodes but an incomplete tree.
+	l := svc.GetClosedLedger()
+	require.NotNil(t, l)
+	il := inbound.New(l.Hash(), l.Sequence(), 7, serveTestLogger())
+	require.NoError(t, il.GotBase(router.buildLedgerBaseNodes(l)))
+	require.NotEmpty(t, il.NeedsMissingNodeIDs(), "acquisition must have outstanding state nodes")
+
+	// First attempt, before any fetch-pack escalation → direct.
+	require.False(t, il.FetchPackRequested())
+	router.requestMissingAcquisitionNodes(il)
+	got := rs.stateIndirects()
+	require.Len(t, got, 1, "first attempt must issue one state-node request")
+	assert.False(t, got[0],
+		"first-attempt state-node request must NOT carry query_type (directly routed)")
+
+	// Arming the fetch-pack escalation latches the acquisition into the
+	// aggressive (relayable) mode, mirroring rippled's timeouts_ != 0 gate.
+	il.MarkFetchPackRequested()
+	router.requestMissingAcquisitionNodes(il)
+	got = rs.stateIndirects()
+	require.Len(t, got, 2, "post-escalation attempt must issue a second state-node request")
+	assert.True(t, got[1],
+		"post-escalation state-node request must carry query_type=qtINDIRECT so peers relay it")
+}

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -27,6 +27,13 @@ type txSetAcquireState struct {
 	lastRequest     time.Time
 	attempts        int
 	peerNonProgress map[uint64]int
+
+	// timedOut latches once the stall timer (retryStalledTxSetAcquires) has
+	// re-triggered this acquisition — go-xrpl's analogue of rippled's
+	// TransactionAcquire timeouts_ != 0. Once set, every subsequent
+	// missing-nodes request (inbound or timer) is sent indirect
+	// (query_type=qtINDIRECT) so peers relay it on our behalf.
+	timedOut bool
 }
 
 // 60s covers a consensus round (~15s) plus retries with margin while
@@ -340,6 +347,7 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			state.lastRequest = time.Now()
 			excluded := buildExcludedPeers(state.peerNonProgress, knobs.PeerNonProgressThreshold)
 			attempts := state.attempts
+			indirect := state.timedOut
 			r.txSetAcquireMu.Unlock()
 
 			nodeIDs := missingNodeIDs(remaining)
@@ -351,8 +359,9 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 				"missing", len(remaining),
 				"attempts", attempts,
 				"excluded_peers", len(excluded),
+				"indirect", indirect,
 			)
-			if reqErr := r.adaptor.RequestTxSetMissingNodes(txSetID, nodeIDs, excluded); reqErr != nil {
+			if reqErr := r.adaptor.RequestTxSetMissingNodes(txSetID, nodeIDs, excluded, indirect); reqErr != nil {
 				r.logger.Info("tx-set sync: missing-nodes request failed",
 					"t", "consensus", "event", "txset-reject",
 					"txset", fmt.Sprintf("%x", txSetID[:8]),
@@ -541,6 +550,10 @@ func (r *Router) retryStalledTxSetAcquires() {
 		}
 		state.attempts++
 		state.lastRequest = now
+		// The timer firing IS the stall signal: latch timedOut so this and
+		// every later request for the set escalates to an indirect (relayable)
+		// fetch, mirroring rippled's TransactionAcquire timeouts_ != 0 gate.
+		state.timedOut = true
 		excluded := buildExcludedPeers(state.peerNonProgress, knobs.PeerNonProgressThreshold)
 		nodeIDs := missingNodeIDs(missing)
 		kicks = append(kicks, txSetKick{id: id, nodeIDs: nodeIDs, excluded: excluded, attempts: state.attempts, missing: len(missing)})
@@ -569,7 +582,8 @@ func (r *Router) retryStalledTxSetAcquires() {
 			"attempts", k.attempts,
 			"excluded_peers", len(k.excluded),
 		)
-		if err := r.adaptor.RequestTxSetMissingNodes(k.id, k.nodeIDs, k.excluded); err != nil {
+		// Timer re-triggers are always post-stall, so always indirect.
+		if err := r.adaptor.RequestTxSetMissingNodes(k.id, k.nodeIDs, k.excluded, true); err != nil {
 			r.logger.Info("tx-set sync: timer missing-nodes request failed",
 				"t", "consensus", "event", "txset-reject",
 				"txset", fmt.Sprintf("%x", k.id[:8]),

--- a/internal/consensus/adaptor/router_txset_retry_test.go
+++ b/internal/consensus/adaptor/router_txset_retry_test.go
@@ -28,9 +28,10 @@ type retryRecordedCall struct {
 	txSetID  consensus.TxSetID
 	nodeIDs  [][]byte
 	excluded map[uint64]bool
+	indirect bool
 }
 
-func (s *retryRecordingSender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error {
+func (s *retryRecordingSender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool, indirect bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	copyExcluded := map[uint64]bool{}
@@ -43,6 +44,7 @@ func (s *retryRecordingSender) RequestTxSetMissingNodes(id consensus.TxSetID, no
 		txSetID:  id,
 		nodeIDs:  copyIDs,
 		excluded: copyExcluded,
+		indirect: indirect,
 	})
 	return s.returnErr
 }
@@ -60,6 +62,12 @@ func (s *retryRecordingSender) lastCall() retryRecordedCall {
 		return retryRecordedCall{}
 	}
 	return s.calls[len(s.calls)-1]
+}
+
+func (s *retryRecordingSender) callAt(i int) retryRecordedCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls[i]
 }
 
 // newRetryRouter wires a Router whose NetworkSender records every
@@ -365,4 +373,43 @@ func TestTxSetRetry_StillNeededNoOpOnUnknownTxSet(t *testing.T) {
 	_, exists := router.txSetAcquire[unknownID]
 	router.txSetAcquireMu.Unlock()
 	assert.False(t, exists, "MarkTxSetStillNeeded must not allocate state for unknown tx-sets")
+}
+
+// TestTxSetRetry_QueryTypeEscalation pins issue #977's requester-side
+// escalation for tx-set acquisition: the first (inbound-driven)
+// missing-nodes request is direct (query_type absent, non-relayable),
+// while requests issued after the stall timer fires carry indirect=true
+// (query_type=qtINDIRECT) so peers relay them on our behalf. Once the
+// acquisition has timed out, the latch holds: later inbound-driven
+// requests stay indirect too — mirroring rippled's TransactionAcquire
+// timeouts_ != 0 gate (TransactionAcquire.cpp:133,164), which is a
+// per-acquisition latch, not a per-request flag.
+func TestTxSetRetry_QueryTypeEscalation(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	// MinInterval=0 so neither the inbound throttle nor the timer skip
+	// fires; high attempt cap so nothing is dropped mid-test.
+	withRetryKnobs(router, 0, 1_000_000, 1_000_000, func() {
+		ld, _ := rootOnlyTxSetLedgerData(t, 4)
+
+		// First attempt is inbound-driven, before any timeout → direct.
+		router.handleTxSetData(ld, 1)
+		require.Equal(t, 1, rs.calledN(), "first reply must broadcast once")
+		assert.False(t, rs.callAt(0).indirect,
+			"first-attempt request must NOT carry query_type (directly routed)")
+
+		// The stall timer firing IS the timeout signal → indirect, and it
+		// latches the acquisition into the aggressive (relayable) mode.
+		router.retryStalledTxSetAcquires()
+		require.Equal(t, 2, rs.calledN(), "stall timer must re-request missing nodes")
+		assert.True(t, rs.callAt(1).indirect,
+			"timer re-trigger is post-stall, so its request must carry query_type=qtINDIRECT")
+
+		// Latch: a further inbound-driven request after the timeout stays
+		// indirect (rippled re-triggers with query_type set on every reply
+		// once timeouts_ != 0, not just on the timeout itself).
+		router.handleTxSetData(ld, 1)
+		require.Equal(t, 3, rs.calledN())
+		assert.True(t, rs.callAt(2).indirect,
+			"after the acquisition has timed out once, subsequent requests stay indirect (latch)")
+	})
 }

--- a/internal/consensus/adaptor/router_txset_wire_test.go
+++ b/internal/consensus/adaptor/router_txset_wire_test.go
@@ -367,3 +367,59 @@ func TestRequestTxSet_WireFormat(t *testing.T) {
 		"SHAMap node ID is 32 bytes path + 1 byte depth = 33 bytes "+
 			"(SHAMapNodeID::getRawString)")
 }
+
+// TestGetLedger_IndirectQueryType_Wire pins issue #977's wire contract:
+// the acquisition GetLedger builders (RequestStateNodes,
+// RequestTransactionNodes, RequestTxSetMissingNodes) all funnel their
+// query_type through indirectQueryType. A false arg must leave the field
+// absent — the non-relayable first attempt; a true arg must set
+// qtINDIRECT — the relayable retry a peer will forward on our behalf
+// (rippled has_querytype()). The field must survive the encode/decode
+// round-trip onto the wire.
+func TestGetLedger_IndirectQueryType_Wire(t *testing.T) {
+	require.Nil(t, indirectQueryType(false),
+		"a directly-routed first attempt must leave query_type absent")
+	qt := indirectQueryType(true)
+	require.NotNil(t, qt)
+	require.Equal(t, message.QueryTypeIndirect, *qt)
+
+	cases := []struct {
+		name     string
+		infoType message.LedgerInfoType
+		indirect bool
+		wantSet  bool
+	}{
+		{"state-nodes first attempt", message.LedgerInfoAsNode, false, false},
+		{"state-nodes retry", message.LedgerInfoAsNode, true, true},
+		{"tx-nodes retry", message.LedgerInfoTxNode, true, true},
+		{"txset missing-nodes retry", message.LedgerInfoTsCandidate, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Same construction the OverlaySender builders use, threaded
+			// through the shared indirectQueryType helper.
+			msg := &message.GetLedger{
+				InfoType:   tc.infoType,
+				LedgerHash: make([]byte, 32),
+				NodeIDs:    [][]byte{make([]byte, 33)},
+				QueryDepth: 2,
+				QueryType:  indirectQueryType(tc.indirect),
+			}
+			frame, err := encodeFrame(message.TypeGetLedger, msg)
+			require.NoError(t, err)
+
+			_, decoded := decodeFrame(t, frame)
+			got, ok := decoded.(*message.GetLedger)
+			require.True(t, ok)
+
+			if tc.wantSet {
+				require.NotNil(t, got.QueryType,
+					"retry request must carry query_type so peers relay it")
+				assert.Equal(t, message.QueryTypeIndirect, *got.QueryType)
+			} else {
+				assert.Nil(t, got.QueryType,
+					"first-attempt request must NOT carry query_type")
+			}
+		})
+	}
+}

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -119,8 +119,9 @@ func (s *OverlaySender) RequestTxSet(id consensus.TxSetID) error {
 // excluded carries peer IDs to skip (router-supplied list of peers that
 // have repeatedly returned non-progressing TMLedgerData replies for this
 // acquisition); a nil or empty map falls through to a plain broadcast.
-// Issue #420.
-func (s *OverlaySender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error {
+// When indirect is set, query_type=qtINDIRECT marks the request relayable
+// by intermediary peers (see indirectQueryType). Issue #420.
+func (s *OverlaySender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool, indirect bool) error {
 	if len(nodeIDs) == 0 {
 		return fmt.Errorf("RequestTxSetMissingNodes: nodeIDs must be non-empty")
 	}
@@ -129,6 +130,7 @@ func (s *OverlaySender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [
 		LedgerHash: id[:],
 		QueryDepth: 3,
 		NodeIDs:    nodeIDs,
+		QueryType:  indirectQueryType(indirect),
 	}
 	frame, err := encodeFrame(message.TypeGetLedger, msg)
 	if err != nil {
@@ -280,12 +282,14 @@ func (s *OverlaySender) RequestReplayDelta(peerID uint64, hash [32]byte) error {
 }
 
 // RequestStateNodes sends a GetLedger request for account state SHAMap nodes.
-func (s *OverlaySender) RequestStateNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error {
+// indirect sets query_type=qtINDIRECT (see indirectQueryType).
+func (s *OverlaySender) RequestStateNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte, indirect bool) error {
 	msg := &message.GetLedger{
 		InfoType:   message.LedgerInfoAsNode,
 		LedgerHash: ledgerHash[:],
 		NodeIDs:    nodeIDs,
 		QueryDepth: 2, // Return fat nodes (node + 2 levels of descendants)
+		QueryType:  indirectQueryType(indirect),
 	}
 	frame, err := encodeFrame(message.TypeGetLedger, msg)
 	if err != nil {
@@ -295,19 +299,35 @@ func (s *OverlaySender) RequestStateNodes(peerID uint64, ledgerHash [32]byte, no
 }
 
 // RequestTransactionNodes sends a GetLedger request for transaction SHAMap
-// nodes.
-func (s *OverlaySender) RequestTransactionNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error {
+// nodes. indirect sets query_type=qtINDIRECT (see indirectQueryType).
+func (s *OverlaySender) RequestTransactionNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte, indirect bool) error {
 	msg := &message.GetLedger{
 		InfoType:   message.LedgerInfoTxNode,
 		LedgerHash: ledgerHash[:],
 		NodeIDs:    nodeIDs,
 		QueryDepth: 2, // Return fat nodes (node + 2 levels of descendants)
+		QueryType:  indirectQueryType(indirect),
 	}
 	frame, err := encodeFrame(message.TypeGetLedger, msg)
 	if err != nil {
 		return fmt.Errorf("encode get_ledger (tx nodes): %w", err)
 	}
 	return s.overlay.Send(peermanagement.PeerID(peerID), frame)
+}
+
+// indirectQueryType returns the GetLedger query_type for an acquisition
+// request: a presence-aware pointer to qtINDIRECT when indirect is set, nil
+// otherwise. A relayer only forwards GetLedger requests that carry a
+// query_type, so setting it lets peers fetch on our behalf. Mirrors rippled's
+// InboundLedger::trigger / TransactionAcquire::trigger, which escalate to
+// qtINDIRECT once an acquisition has timed out at least once (timeouts_ != 0)
+// rather than on the first, directly-routed attempt.
+func indirectQueryType(indirect bool) *message.LedgerQueryType {
+	if !indirect {
+		return nil
+	}
+	qt := message.QueryTypeIndirect
+	return &qt
 }
 
 // encodeFrame serializes a message and wraps it with the wire protocol header.

--- a/internal/consensus/adaptor/sender_cov_test.go
+++ b/internal/consensus/adaptor/sender_cov_test.go
@@ -74,7 +74,7 @@ func (f *snd_fakeOverlay) RequestTxSet(id consensus.TxSetID) error {
 	return nil
 }
 
-func (f *snd_fakeOverlay) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool) error {
+func (f *snd_fakeOverlay) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool, indirect bool) error {
 	return nil
 }
 
@@ -109,7 +109,7 @@ func (f *snd_fakeOverlay) RequestReplayDelta(peerID uint64, hash [32]byte) error
 	return nil
 }
 
-func (f *snd_fakeOverlay) RequestStateNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error {
+func (f *snd_fakeOverlay) RequestStateNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte, indirect bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.sends == nil {
@@ -119,7 +119,7 @@ func (f *snd_fakeOverlay) RequestStateNodes(peerID uint64, ledgerHash [32]byte, 
 	return nil
 }
 
-func (f *snd_fakeOverlay) RequestTransactionNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte) error {
+func (f *snd_fakeOverlay) RequestTransactionNodes(peerID uint64, ledgerHash [32]byte, nodeIDs [][]byte, indirect bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.sends == nil {
@@ -238,7 +238,7 @@ func TestSndAdaptor_RequestTxSetMissingNodes(t *testing.T) {
 	a := snd_newAdaptorWithFake(t, fake)
 	id := consensus.TxSetID{0xAB}
 	nodeIDs := [][]byte{make([]byte, 33)}
-	err := a.RequestTxSetMissingNodes(id, nodeIDs, nil)
+	err := a.RequestTxSetMissingNodes(id, nodeIDs, nil, false)
 	assert.NoError(t, err)
 }
 
@@ -255,7 +255,7 @@ func TestSndAdaptor_RequestStateNodes(t *testing.T) {
 	fake := &snd_fakeOverlay{}
 	a := snd_newAdaptorWithFake(t, fake)
 	var hash [32]byte
-	err := a.RequestStateNodes(99, hash, [][]byte{make([]byte, 33)})
+	err := a.RequestStateNodes(99, hash, [][]byte{make([]byte, 33)}, false)
 	assert.NoError(t, err)
 	require.Len(t, fake.sends[99], 1)
 }
@@ -264,7 +264,7 @@ func TestSndAdaptor_RequestTransactionNodes(t *testing.T) {
 	fake := &snd_fakeOverlay{}
 	a := snd_newAdaptorWithFake(t, fake)
 	var hash [32]byte
-	err := a.RequestTransactionNodes(77, hash, [][]byte{make([]byte, 33)})
+	err := a.RequestTransactionNodes(77, hash, [][]byte{make([]byte, 33)}, false)
 	assert.NoError(t, err)
 	require.Len(t, fake.sends[77], 1)
 }
@@ -387,13 +387,13 @@ func TestSndOverlaySender_RequestTxSet_NoPeers(t *testing.T) {
 func TestSndOverlaySender_RequestTxSetMissingNodes_NoPeers(t *testing.T) {
 	s := snd_newOverlaySender(t)
 	nodeIDs := [][]byte{make([]byte, 33)}
-	err := s.RequestTxSetMissingNodes(consensus.TxSetID{0x01}, nodeIDs, nil)
+	err := s.RequestTxSetMissingNodes(consensus.TxSetID{0x01}, nodeIDs, nil, false)
 	assert.NoError(t, err)
 }
 
 func TestSndOverlaySender_RequestTxSetMissingNodes_EmptyNodeIDs(t *testing.T) {
 	s := snd_newOverlaySender(t)
-	err := s.RequestTxSetMissingNodes(consensus.TxSetID{0x01}, nil, nil)
+	err := s.RequestTxSetMissingNodes(consensus.TxSetID{0x01}, nil, nil, false)
 	assert.Error(t, err)
 }
 
@@ -401,7 +401,7 @@ func TestSndOverlaySender_RequestTxSetMissingNodes_WithExcluded_NoPeers(t *testi
 	s := snd_newOverlaySender(t)
 	nodeIDs := [][]byte{make([]byte, 33)}
 	excluded := map[uint64]bool{1: true, 2: true}
-	err := s.RequestTxSetMissingNodes(consensus.TxSetID{0x01}, nodeIDs, excluded)
+	err := s.RequestTxSetMissingNodes(consensus.TxSetID{0x01}, nodeIDs, excluded, false)
 	assert.NoError(t, err)
 }
 
@@ -482,13 +482,13 @@ func TestSndOverlaySender_RequestReplayDelta_UnknownPeer(t *testing.T) {
 func TestSndOverlaySender_RequestStateNodes_UnknownPeer(t *testing.T) {
 	s := snd_newOverlaySender(t)
 	var hash [32]byte
-	err := s.RequestStateNodes(999, hash, [][]byte{make([]byte, 33)})
+	err := s.RequestStateNodes(999, hash, [][]byte{make([]byte, 33)}, false)
 	assert.ErrorIs(t, err, peermanagement.ErrPeerNotFound)
 }
 
 func TestSndOverlaySender_RequestTransactionNodes_UnknownPeer(t *testing.T) {
 	s := snd_newOverlaySender(t)
 	var hash [32]byte
-	err := s.RequestTransactionNodes(999, hash, [][]byte{make([]byte, 33)})
+	err := s.RequestTransactionNodes(999, hash, [][]byte{make([]byte, 33)}, false)
 	assert.ErrorIs(t, err, peermanagement.ErrPeerNotFound)
 }


### PR DESCRIPTION
## Summary

Requester-side complement of the GetLedger relayer landed in #976. Our **outbound** `GetLedger` acquisition requests left `query_type` nil, so peers never relayed our catch-up requests on our behalf — a relayer only forwards a request that carries `query_type` (rippled `has_querytype()`).

- Threads an `indirect bool` through the acquisition `GetLedger` builders (`RequestStateNodes`, `RequestTransactionNodes`, `RequestTxSetMissingNodes`) via a shared `indirectQueryType` helper that emits a presence-aware `query_type=qtINDIRECT` pointer.
- Sets it on the **retry / aggressive** path only — never the first attempt — mirroring rippled's `InboundLedger::trigger` and `TransactionAcquire::trigger` `timeouts_ != 0` gate.
  - **tx-set acquisition**: a `timedOut` latch flips the first time the stall timer (`retryStalledTxSetAcquires`) re-triggers; that request and every later one for the set (inbound or timer) is then relayable — matching rippled's per-acquisition latch (`TransactionAcquire.cpp:133,164`).
  - **legacy inbound-ledger node walk**: escalates in the fetch-pack aggressive window (`FetchPackRequested`), which is go-xrpl's analogue of rippled's "be more aggressive" branch in the same `timeouts_ != 0` block. go-xrpl reaps a legacy acquisition on its first timeout, so that window is its only post-timeout `GetLedger` life.
- First-attempt / consensus-driven broadcasts (`RequestTxSet`, `RequestLedger`, `RequestLedgerBaseFromPeer`) stay direct.

Oracle: rippled `1e89286a92` (sibling `../rippled`).

## Test plan

- [x] `TestTxSetRetry_QueryTypeEscalation` — first inbound request is direct; the stall-timer re-trigger is `qtINDIRECT`; a later inbound request stays indirect (latch).
- [x] `TestGetLedger_IndirectQueryType_Wire` — `query_type` is absent on first attempt and survives the encode/decode round-trip as `qtINDIRECT` on retry, across the liAS_NODE / liTX_NODE / liTS_CANDIDATE shapes.
- [x] `go test -race ./internal/consensus/adaptor/... ./internal/ledger/inbound/...`, `./internal/consensus/rcl/...`
- [x] `gofmt`, `go vet`, full `CGO_ENABLED=1 go build ./...`, `golangci-lint` (0 issues) all clean.

Fixes #977