### PR TITLE
Gate GetLedger hash/seq-less serve on ltype==ltCLOSED

### DIFF
--- a/internal/consensus/adaptor/router_ledger_serve_ltype_test.go
+++ b/internal/consensus/adaptor/router_ledger_serve_ltype_test.go
@@ -1,6 +1,7 @@
 package adaptor
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
@@ -10,40 +11,62 @@ import (
 )
 
 // TestRouter_GetLedger_HashSeqlessGatesOnLtype pins rippled's
-// PeerImp::getLedger fallback: a GetLedger carrying neither a ledger_hash nor
-// a ledger_seq serves the closed ledger only when ltype == ltCLOSED. Any other
-// (or absent) ltype finds no ledger and serves nothing, rather than
-// unconditionally returning the closed ledger.
+// onMessage(TMGetLedger) + getLedger fallback. A GetLedger carrying neither a
+// ledger_hash nor a ledger_seq serves the closed ledger only when ltype ==
+// ltCLOSED; any other (or absent) ltype is a malformed "Invalid request" that
+// charges the peer and serves nothing. An ltype outside [ltACCEPTED, ltCLOSED]
+// is rejected as an invalid ledger type.
 func TestRouter_GetLedger_HashSeqlessGatesOnLtype(t *testing.T) {
-	send := func(t *testing.T, lt message.LedgerType) (*Router, []sentFrame) {
+	send := func(t *testing.T, req *message.GetLedger) (*Router, []badDataCall, []sentFrame) {
 		t.Helper()
 		r, rs := makeRouterWithQueryTypeRecorder(t)
-		req := &message.GetLedger{
-			InfoType: message.LedgerInfoBase,
-			LType:    lt,
-		}
 		r.handleMessage(&peermanagement.InboundMessage{
 			PeerID:  11,
 			Type:    uint16(message.TypeGetLedger),
 			Payload: encodePayload(t, req),
 		})
 		bd, sent := rs.snapshot()
-		require.Empty(t, bd, "a hash/seq-less liBASE request is well-formed; no bad-data charge")
-		return r, sent
+		return r, bd, sent
 	}
 
-	t.Run("absent ltype serves nothing", func(t *testing.T) {
-		_, sent := send(t, message.LedgerTypeAccepted)
-		assert.Empty(t, sent, "hash/seq-less request without ltCLOSED must not serve the closed ledger")
+	t.Run("absent ltype is invalid: charges bad data, serves nothing", func(t *testing.T) {
+		_, bd, sent := send(t, &message.GetLedger{
+			InfoType: message.LedgerInfoBase,
+			LType:    message.LedgerTypeAccepted,
+		})
+		require.Len(t, bd, 1, "a hash/seq-less request without ltCLOSED is malformed")
+		assert.Equal(t, uint64(11), bd[0].peerID)
+		assert.Equal(t, "get-ledger-invalid-request", bd[0].reason)
+		assert.Empty(t, sent, "malformed request must not serve the closed ledger")
 	})
 
-	t.Run("ltCURRENT serves nothing", func(t *testing.T) {
-		_, sent := send(t, message.LedgerTypeCurrent)
+	t.Run("ltCURRENT is invalid: charges bad data, serves nothing", func(t *testing.T) {
+		_, bd, sent := send(t, &message.GetLedger{
+			InfoType: message.LedgerInfoBase,
+			LType:    message.LedgerTypeCurrent,
+		})
+		require.Len(t, bd, 1)
+		assert.Equal(t, "get-ledger-invalid-request", bd[0].reason)
 		assert.Empty(t, sent, "hash/seq-less ltCURRENT must not serve the closed ledger")
 	})
 
+	t.Run("out-of-range ltype charges bad data, serves nothing", func(t *testing.T) {
+		_, bd, sent := send(t, &message.GetLedger{
+			InfoType:   message.LedgerInfoBase,
+			LedgerHash: bytes.Repeat([]byte{0xAB}, 32),
+			LType:      message.LedgerType(7),
+		})
+		require.Len(t, bd, 1, "an ltype outside [ltACCEPTED, ltCLOSED] is malformed")
+		assert.Equal(t, "get-ledger-invalid-ltype", bd[0].reason)
+		assert.Empty(t, sent, "malformed ltype must not serve anything")
+	})
+
 	t.Run("ltCLOSED serves the closed ledger", func(t *testing.T) {
-		r, sent := send(t, message.LedgerTypeClosed)
+		r, bd, sent := send(t, &message.GetLedger{
+			InfoType: message.LedgerInfoBase,
+			LType:    message.LedgerTypeClosed,
+		})
+		require.Empty(t, bd, "a hash/seq-less ltCLOSED request is well-formed")
 		require.Len(t, sent, 1, "ltCLOSED must serve the closed ledger")
 		assert.Equal(t, uint64(11), sent[0].peerID)
 

--- a/internal/consensus/adaptor/router_ledger_serve_ltype_test.go
+++ b/internal/consensus/adaptor/router_ledger_serve_ltype_test.go
@@ -1,0 +1,61 @@
+package adaptor
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRouter_GetLedger_HashSeqlessGatesOnLtype pins rippled's
+// PeerImp::getLedger fallback: a GetLedger carrying neither a ledger_hash nor
+// a ledger_seq serves the closed ledger only when ltype == ltCLOSED. Any other
+// (or absent) ltype finds no ledger and serves nothing, rather than
+// unconditionally returning the closed ledger.
+func TestRouter_GetLedger_HashSeqlessGatesOnLtype(t *testing.T) {
+	send := func(t *testing.T, lt message.LedgerType) (*Router, []sentFrame) {
+		t.Helper()
+		r, rs := makeRouterWithQueryTypeRecorder(t)
+		req := &message.GetLedger{
+			InfoType: message.LedgerInfoBase,
+			LType:    lt,
+		}
+		r.handleMessage(&peermanagement.InboundMessage{
+			PeerID:  11,
+			Type:    uint16(message.TypeGetLedger),
+			Payload: encodePayload(t, req),
+		})
+		bd, sent := rs.snapshot()
+		require.Empty(t, bd, "a hash/seq-less liBASE request is well-formed; no bad-data charge")
+		return r, sent
+	}
+
+	t.Run("absent ltype serves nothing", func(t *testing.T) {
+		_, sent := send(t, message.LedgerTypeAccepted)
+		assert.Empty(t, sent, "hash/seq-less request without ltCLOSED must not serve the closed ledger")
+	})
+
+	t.Run("ltCURRENT serves nothing", func(t *testing.T) {
+		_, sent := send(t, message.LedgerTypeCurrent)
+		assert.Empty(t, sent, "hash/seq-less ltCURRENT must not serve the closed ledger")
+	})
+
+	t.Run("ltCLOSED serves the closed ledger", func(t *testing.T) {
+		r, sent := send(t, message.LedgerTypeClosed)
+		require.Len(t, sent, 1, "ltCLOSED must serve the closed ledger")
+		assert.Equal(t, uint64(11), sent[0].peerID)
+
+		l := r.adaptor.LedgerService().GetClosedLedger()
+		require.NotNil(t, l)
+		hash := l.Hash()
+
+		_, decoded := decodeFrame(t, sent[0].frame)
+		ld, ok := decoded.(*message.LedgerData)
+		require.True(t, ok, "ltCLOSED serve must be a TMLedgerData")
+		assert.Equal(t, message.LedgerInfoBase, ld.InfoType)
+		assert.Equal(t, l.Sequence(), ld.LedgerSeq, "served seq must be the closed ledger's")
+		assert.Equal(t, hash[:], ld.LedgerHash, "served hash must be the closed ledger's")
+	})
+}

--- a/internal/consensus/adaptor/router_serve.go
+++ b/internal/consensus/adaptor/router_serve.go
@@ -56,6 +56,20 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 		return
 	}
 
+	// Reject a malformed lookup before touching the ledger service, the way
+	// rippled's onMessage(TMGetLedger) does: a non-candidate request that names
+	// neither a hash, a sequence, nor ltCLOSED has nothing to resolve, and an
+	// ltype outside [ltACCEPTED, ltCLOSED] is invalid. Both are bad data —
+	// charge the peer and drop without disconnecting.
+	if len(req.LedgerHash) != 32 && req.LedgerSeq == 0 && req.LType != message.LedgerTypeClosed {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "get-ledger-invalid-request")
+		return
+	}
+	if req.LType < message.LedgerTypeAccepted || req.LType > message.LedgerTypeClosed {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "get-ledger-invalid-ltype")
+		return
+	}
+
 	svc := r.adaptor.LedgerService()
 	if svc == nil {
 		return
@@ -83,10 +97,6 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 	} else if req.LedgerSeq > 0 {
 		l, err = svc.GetLedgerBySequence(req.LedgerSeq)
 	} else if req.LType == message.LedgerTypeClosed {
-		// A hash-less, seq-less request serves the closed ledger only when it
-		// explicitly asks for ltCLOSED; any other (or absent) ltype leaves
-		// l == nil and falls through to the miss path, matching rippled's
-		// null return for that case.
 		l = svc.GetClosedLedger()
 	}
 	if err != nil || l == nil {

--- a/internal/consensus/adaptor/router_serve.go
+++ b/internal/consensus/adaptor/router_serve.go
@@ -82,7 +82,11 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 		l, err = svc.GetLedgerByHash(hash)
 	} else if req.LedgerSeq > 0 {
 		l, err = svc.GetLedgerBySequence(req.LedgerSeq)
-	} else {
+	} else if req.LType == message.LedgerTypeClosed {
+		// A hash-less, seq-less request serves the closed ledger only when it
+		// explicitly asks for ltCLOSED; any other (or absent) ltype leaves
+		// l == nil and falls through to the miss path, matching rippled's
+		// null return for that case.
 		l = svc.GetClosedLedger()
 	}
 	if err != nil || l == nil {


### PR DESCRIPTION
## Summary

- An inbound `GetLedger` (`liBASE` / `liAS_NODE` / `liTX_NODE`) carrying **neither** a `ledger_hash` **nor** a `ledger_seq` unconditionally served go-xrpl's **closed ledger**. rippled (`PeerImp::getLedger`, oracle `1e89286a92`) serves the closed ledger only when `ltype == ltCLOSED`; for any other (or absent) `ltype` it finds no ledger and serves nothing.
- Gate the fallback on the already-modeled `req.LType`: a non-`ltCLOSED` hash/seq-less request now leaves `l == nil` and falls through to the existing miss path (relay/drop), matching rippled's null return. The `ltype == ltCLOSED` case still serves the closed ledger.
- Benign-direction parity fix (go-xrpl previously answered a request rippled would ignore — an extra serve, never a wrong ledger or a fork). Surfaced by the #976 (issue #969) finalize conformance review; pre-existing.

## Test plan

- [x] New `TestRouter_GetLedger_HashSeqlessGatesOnLtype` drives `handleGetLedger` end-to-end: absent `ltype` and `ltCURRENT` serve nothing; `ltCLOSED` serves the closed ledger (verified seq + hash).
- [x] `just test-pkg ./internal/consensus/adaptor/...` — full adaptor package green.
- [x] `go test ./internal/consensus/...` + `go build ./...` green.

Fixes #981