### PR TITLE
fix: keep present-zero directory links on collapse

### DIFF
--- a/internal/ledger/state/directory.go
+++ b/internal/ledger/state/directory.go
@@ -34,6 +34,19 @@ type DirectoryNode struct {
 	IndexNext     uint64     // Next page index (0 if none)
 	IndexPrevious uint64     // Previous page index (0 if none)
 
+	// indexNextSet / indexPreviousSet track whether the link fields are
+	// *present* on the page, independent of their value. rippled writes
+	// sfIndexNext / sfIndexPrevious via setFieldU64, which keeps a field present
+	// even at value 0: a directory that grew to several pages and then collapsed
+	// back to a single root carries zero-valued links, whereas a directory that
+	// was only ever one page omits them entirely. Tracking presence lets a
+	// collapsed root re-serialize IndexNext=0 / IndexPrevious=0 instead of
+	// dropping them. Dropping the zero links forked both the SLE (account_hash)
+	// and the ModifiedNode metadata, whose present-field set is parsed back from
+	// these same serialized bytes.
+	indexNextSet     bool
+	indexPreviousSet bool
+
 	// Owner directory specific
 	Owner [20]byte // Account that owns this directory (only for owner dirs)
 
@@ -59,6 +72,20 @@ type DirectoryNode struct {
 	// sfPreviousTxnID). Reference: ApplyStateTable.cpp:156-157.
 	PreviousTxnID     [32]byte
 	PreviousTxnLgrSeq uint32
+}
+
+// SetIndexNext sets the next-page link and marks it present, mirroring
+// rippled's setFieldU64(sfIndexNext): the field then serializes even at value 0.
+func (d *DirectoryNode) SetIndexNext(page uint64) {
+	d.IndexNext = page
+	d.indexNextSet = true
+}
+
+// SetIndexPrevious sets the previous-page link and marks it present, the
+// counterpart to SetIndexNext.
+func (d *DirectoryNode) SetIndexPrevious(page uint64) {
+	d.IndexPrevious = page
+	d.indexPreviousSet = true
 }
 
 // cMinValue is the minimum normalized mantissa value (10^15)
@@ -150,11 +177,14 @@ func SerializeDirectoryNode(dir *DirectoryNode, isBookDir bool) ([]byte, error) 
 	}
 	jsonObj["Indexes"] = indexes
 
-	// Add pagination fields if set
-	if dir.IndexNext != 0 {
+	// Emit the link fields when present or non-zero. A multi-page directory
+	// that collapses back to a single root keeps zero-valued links present (see
+	// DirectoryNode.indexNextSet); emitting only on non-zero would drop them and
+	// fork the ledger.
+	if dir.IndexNext != 0 || dir.indexNextSet {
 		jsonObj["IndexNext"] = formatUint64Hex(dir.IndexNext)
 	}
-	if dir.IndexPrevious != 0 {
+	if dir.IndexPrevious != 0 || dir.indexPreviousSet {
 		jsonObj["IndexPrevious"] = formatUint64Hex(dir.IndexPrevious)
 	}
 
@@ -225,9 +255,9 @@ func ParseDirectoryNode(data []byte) (*DirectoryNode, error) {
 		case stUInt64:
 			switch f.FieldCode {
 			case 1: // IndexNext
-				dir.IndexNext = f.UInt64()
+				dir.SetIndexNext(f.UInt64())
 			case 2: // IndexPrevious
-				dir.IndexPrevious = f.UInt64()
+				dir.SetIndexPrevious(f.UInt64())
 			case 6: // ExchangeRate
 				dir.ExchangeRate = f.UInt64()
 			}
@@ -462,19 +492,20 @@ func DirInsert(view LedgerView, dirKey keylet.Keylet, itemKey [32]byte, preserve
 	prevRoot := *root
 
 	// Update current node's IndexNext to point to new page
-	node.IndexNext = newPage
+	node.SetIndexNext(newPage)
 
 	// Update root's IndexPrevious to point to new page
-	root.IndexPrevious = newPage
+	root.SetIndexPrevious(newPage)
 
 	// Create new page
 	newPageNode := &DirectoryNode{
 		RootIndex: dirKey.Key,
 		Indexes:   [][32]byte{itemKey},
 	}
-	// Set IndexPrevious on new page (unless it's page 1)
+	// Set IndexPrevious on new page (unless it's page 1, whose previous is the
+	// root: rippled leaves that link absent to save space).
 	if newPage != 1 {
-		newPageNode.IndexPrevious = newPage - 1
+		newPageNode.SetIndexPrevious(newPage - 1)
 	}
 	// Copy book directory fields if applicable
 	if setupFunc != nil {
@@ -682,8 +713,8 @@ func DirRemove(view LedgerView, directory keylet.Keylet, page uint64, itemKey [3
 
 			if len(lastPage.Indexes) == 0 {
 				// Update root's linked list
-				node.IndexNext = rootPage
-				node.IndexPrevious = rootPage
+				node.SetIndexNext(rootPage)
+				node.SetIndexPrevious(rootPage)
 
 				// Track root modification
 				result.ModifiedNodes = append(result.ModifiedNodes, DirRemoveModifiedNode{
@@ -826,9 +857,9 @@ func DirRemove(view LedgerView, directory keylet.Keylet, page uint64, itemKey [3
 	}
 
 	// Unlink: prev.IndexNext = nextPage
-	prev.IndexNext = nextPage
+	prev.SetIndexNext(nextPage)
 	// Unlink: next.IndexPrevious = prevPage
-	next.IndexPrevious = prevPage
+	next.SetIndexPrevious(prevPage)
 
 	// Track prev modification
 	result.ModifiedNodes = append(result.ModifiedNodes, DirRemoveModifiedNode{
@@ -890,7 +921,7 @@ func DirRemove(view LedgerView, directory keylet.Keylet, page uint64, itemKey [3
 		}
 
 		// Update prev to point to root
-		prev.IndexNext = rootPage
+		prev.SetIndexNext(rootPage)
 		// Re-serialize prev
 		prevData, err := SerializeDirectoryNode(prev, prevIsBookDir)
 		if err != nil {
@@ -911,7 +942,7 @@ func DirRemove(view LedgerView, directory keylet.Keylet, page uint64, itemKey [3
 			return nil, err
 		}
 		rootPrev := *root
-		root.IndexPrevious = prevPage
+		root.SetIndexPrevious(prevPage)
 
 		result.ModifiedNodes = append(result.ModifiedNodes, DirRemoveModifiedNode{
 			Key:       rootKeylet.Key,

--- a/internal/ledger/state/directory_page_test.go
+++ b/internal/ledger/state/directory_page_test.go
@@ -91,20 +91,23 @@ func testDir() keylet.Keylet {
 
 // makePages inserts n empty, linked pages numbered [0, n-1] into the directory
 // rooted at dir. It is a direct port of rippled's Directory_test.cpp makePages
-// helper (src/test/ledger/Directory_test.cpp): each page's IndexNext points to
-// the next page (0 on the last), and IndexPrevious points to the previous page
-// (n-1 on the root, forming the circular back-link rippled uses).
+// helper (src/test/ledger/Directory_test.cpp): each page sets IndexNext (0 on
+// the last page) and IndexPrevious (n-1 on the root, forming the circular
+// back-link rippled uses). The links go through the setters so the zero-valued
+// ones stay present, exactly as rippled's setFieldU64 keeps them.
 func makePages(t *testing.T, v *stubView, dir keylet.Keylet, n uint64) {
 	t.Helper()
 	for i := range n {
 		node := &DirectoryNode{RootIndex: dir.Key}
-		if i+1 != n {
-			node.IndexNext = i + 1
+		if i+1 == n {
+			node.SetIndexNext(0)
+		} else {
+			node.SetIndexNext(i + 1)
 		}
 		if i == 0 {
-			node.IndexPrevious = n - 1
+			node.SetIndexPrevious(n - 1)
 		} else {
-			node.IndexPrevious = i - 1
+			node.SetIndexPrevious(i - 1)
 		}
 		data, err := SerializeDirectoryNode(node, false)
 		require.NoErrorf(t, err, "serialize page %d", i)

--- a/internal/ledger/state/directory_page_test.go
+++ b/internal/ledger/state/directory_page_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -427,6 +428,65 @@ func TestDirRemove_DrainsSoleNonRootPageResetsRootLinks(t *testing.T) {
 	assert.Equal(t, uint64(0), root.IndexNext, "root forward-link reset to itself")
 	assert.Equal(t, uint64(0), root.IndexPrevious,
 		"root back-link reset, not left dangling at the erased page")
+}
+
+// TestDirRemove_CollapsedRootKeepsPresentZeroLinks pins the fix for issue 983.
+// When a multi-page directory drains back to a single root page, rippled writes
+// the root's IndexNext / IndexPrevious to 0 with setFieldU64, keeping both links
+// *present* in the serialized SLE. go-xrpl previously dropped them because the
+// value was 0, forking the SLE bytes (account_hash) and — because the metadata
+// layer re-parses those bytes for its present-field set — the ModifiedNode
+// FinalFields (transaction_hash). A fresh single-page root, by contrast, never
+// has the links and must keep omitting them.
+func TestDirRemove_CollapsedRootKeepsPresentZeroLinks(t *testing.T) {
+	t.Parallel()
+
+	v := newStubView()
+	dir := testDir()
+
+	// A fresh single-page root must omit both links entirely (rippled's
+	// dirAdd never writes them — "save some space"): nothing has grown yet.
+	_, err := DirInsert(v, dir, itemKeyN(1), false, nil)
+	require.NoError(t, err)
+	freshData, ok := v.entries[keylet.DirPage(dir.Key, 0).Key]
+	require.True(t, ok)
+	freshFields, err := binarycodec.DecodeBytes(freshData)
+	require.NoError(t, err)
+	_, hasNext := freshFields["IndexNext"]
+	_, hasPrev := freshFields["IndexPrevious"]
+	assert.False(t, hasNext, "fresh single-page root must omit IndexNext")
+	assert.False(t, hasPrev, "fresh single-page root must omit IndexPrevious")
+
+	// Grow to two pages: entries 2..33 (33 total) overflow the root onto page 1.
+	for i := 2; i <= dirNodeMaxEntries+1; i++ {
+		_, err := DirInsert(v, dir, itemKeyN(i), false, nil)
+		require.NoErrorf(t, err, "insert %d", i)
+	}
+	require.True(t, v.hasPage(dir, 1), "precondition: page 1 exists")
+
+	// Drain page 1, collapsing the directory back to the root page.
+	res, err := DirRemove(v, dir, 1, v.page(t, dir, 1).Indexes[0], false)
+	require.NoError(t, err)
+	require.True(t, res.Success)
+	require.False(t, v.hasPage(dir, 1), "collapsed page must be erased")
+
+	rootData, ok := v.entries[keylet.DirPage(dir.Key, 0).Key]
+	require.True(t, ok, "root page must survive the collapse")
+
+	// account_hash level: the serialized SLE must carry both links at value 0.
+	fields, err := binarycodec.DecodeBytes(rootData)
+	require.NoError(t, err)
+	assert.Equal(t, "0", fields["IndexNext"], "collapsed root keeps IndexNext present at 0")
+	assert.Equal(t, "0", fields["IndexPrevious"], "collapsed root keeps IndexPrevious present at 0")
+
+	// Round-trip: parse recovers both as present, which is what drives the
+	// ModifiedNode FinalFields present-field set.
+	root, err := ParseDirectoryNode(rootData)
+	require.NoError(t, err)
+	assert.True(t, root.indexNextSet, "IndexNext present after collapse")
+	assert.True(t, root.indexPreviousSet, "IndexPrevious present after collapse")
+	assert.Equal(t, uint64(0), root.IndexNext)
+	assert.Equal(t, uint64(0), root.IndexPrevious)
 }
 
 // TestDirRemove_EmptyChainThreePages is a direct port of rippled's

--- a/internal/testing/env_directory.go
+++ b/internal/testing/env_directory.go
@@ -73,10 +73,16 @@ func (e *TestEnv) BumpDirectoryLastPage(acc *Account, targetPage uint64, adjustF
 	// Create new page at targetPage with the same entries
 	newPageKey := keylet.DirPage(dirRootKey.Key, targetPage)
 	newPage := &state.DirectoryNode{
-		RootIndex:     dirRootKey.Key,
-		Indexes:       indexes,
-		Owner:         root.Owner,
-		IndexPrevious: prevIndex,
+		RootIndex: dirRootKey.Key,
+		Indexes:   indexes,
+		Owner:     root.Owner,
+	}
+	// Mirror the original last page's link presence: rippled sets IndexPrevious
+	// via setFieldU64 only when non-zero (a page whose previous is the root
+	// leaves it absent), so guard the setter rather than force a present-at-0
+	// link.
+	if prevIndex != 0 {
+		newPage.SetIndexPrevious(prevIndex)
 	}
 	newPageData, err := state.SerializeDirectoryNode(newPage, false)
 	if err != nil {
@@ -87,10 +93,10 @@ func (e *TestEnv) BumpDirectoryLastPage(acc *Account, targetPage uint64, adjustF
 	}
 
 	// Update root's IndexPrevious to point to new page
-	root.IndexPrevious = targetPage
+	root.SetIndexPrevious(targetPage)
 	// If the previous page was root (prevIndex == 0), also update IndexNext
 	if prevIndex == 0 {
-		root.IndexNext = targetPage
+		root.SetIndexNext(targetPage)
 	}
 	rootData, err = state.SerializeDirectoryNode(root, false)
 	if err != nil {
@@ -111,7 +117,7 @@ func (e *TestEnv) BumpDirectoryLastPage(acc *Account, targetPage uint64, adjustF
 		if err != nil {
 			return fmt.Errorf("failed to parse previous page: %v", err)
 		}
-		prevPage.IndexNext = targetPage
+		prevPage.SetIndexNext(targetPage)
 		prevPageData, err = state.SerializeDirectoryNode(prevPage, false)
 		if err != nil {
 			return fmt.Errorf("failed to serialize previous page: %v", err)
@@ -230,7 +236,7 @@ func (e *TestEnv) ForceOwnerDirEmptyAnchorWithNext(acc *Account, nextPage uint64
 	}
 
 	root.Indexes = nil
-	root.IndexNext = nextPage
+	root.SetIndexNext(nextPage)
 
 	updated, err := state.SerializeDirectoryNode(root, false)
 	if err != nil {


### PR DESCRIPTION
## Summary

- When a multi-page owner/credential directory collapses back to a single root page, rippled writes the root's `IndexNext`/`IndexPrevious` to `0` via `setFieldU64`, keeping both links **present** in the serialized SLE. go-xrpl modelled them as plain `uint64` and serialized each only when non-zero, so a collapsed root **dropped** its zero links.
- This forked **both** `account_hash` (the SLE bytes differ) and `transaction_hash` (the `ModifiedNode` `FinalFields` metadata, whose present-field set is parsed back from those same bytes) on the transaction that triggers the collapse — observed live on a `CredentialDelete` in a confluence soak.
- Fix tracks link presence separately from value (`indexNextSet`/`indexPreviousSet`, set via new `SetIndexNext`/`SetIndexPrevious`), mirroring rippled's `setFieldU64` semantics across `ParseDirectoryNode`, `DirInsert`, and `DirRemove`. A collapsed root now re-serializes `IndexNext=0`/`IndexPrevious=0`; fresh single-page roots still omit them (matching rippled's "save some space" behaviour).
- The metadata layer needs no change — it derives its present-field bitmask from the serialized bytes, so fixing serialization fixes both hashes.

## Test plan

- [x] New regression test `TestDirRemove_CollapsedRootKeepsPresentZeroLinks` (in `internal/ledger/state`): grows a 2-page directory, drains the sole non-root page, and asserts the serialized root carries `IndexNext=0`/`IndexPrevious=0` at both the codec (`binarycodec.DecodeBytes`) and round-trip-presence levels; also asserts a fresh single-page root still omits them. Verified it **fails** on the pre-fix serializer and **passes** with the fix.
- [x] `go test ./internal/ledger/... ./internal/tx/...` — all green
- [x] `go test ./internal/testing/...` (integration) — all green
- [x] `go vet` + `gofmt` clean
- [x] Conformance summary **identical** to the pre-fix baseline (this fork manifests in live soaks, not the fixture corpus)

> Note: the issue's "downstream network stall" (inbound ledger acquisition wedging at "1 missing node" after a fork) is a separate state-sync concern and is intentionally out of scope here — this PR removes the fork that triggers that cascade.

Fixes #983