### PR TITLE
fix: emit required PreviousTxnID/PreviousTxnLgrSeq in SerializeAccountRoot

### DIFF
--- a/internal/ledger/state/account_root.go
+++ b/internal/ledger/state/account_root.go
@@ -342,15 +342,11 @@ func SerializeAccountRoot(account *AccountRoot) ([]byte, error) {
 		jsonObj["AMMID"] = strings.ToUpper(hex.EncodeToString(account.AMMID[:]))
 	}
 
-	// Add PreviousTxnID if set (non-zero)
-	if account.PreviousTxnID != zeroHash {
-		jsonObj["PreviousTxnID"] = strings.ToUpper(hex.EncodeToString(account.PreviousTxnID[:]))
-	}
-
-	// Add PreviousTxnLgrSeq if set
-	if account.PreviousTxnLgrSeq > 0 {
-		jsonObj["PreviousTxnLgrSeq"] = account.PreviousTxnLgrSeq
-	}
+	// PreviousTxnID and PreviousTxnLgrSeq are soeREQUIRED on AccountRoot, so
+	// emit them unconditionally (a zero value round-trips), matching the genesis
+	// serializer and rippled's auto-initialised fields.
+	jsonObj["PreviousTxnID"] = strings.ToUpper(hex.EncodeToString(account.PreviousTxnID[:]))
+	jsonObj["PreviousTxnLgrSeq"] = account.PreviousTxnLgrSeq
 
 	// Add TickSize if set (non-zero)
 	if account.TickSize > 0 {


### PR DESCRIPTION
## Summary

- `state.SerializeAccountRoot` previously omitted `PreviousTxnID` / `PreviousTxnLgrSeq` when zero, while the genesis serializer (`genesis.SerializeAccountRoot`) emits them unconditionally. Both fields are `soeREQUIRED` on AccountRoot in rippled, so they are always present in a rippled-produced blob.
- This serializer now emits both fields unconditionally (a zero value round-trips through `ParseAccountRoot`), unifying the two serializers and removing the silent dependence on the apply pipeline's threading pass always re-stamping them before commit/hash.
- No observable behaviour change today — threading masks the divergence — but it closes a latent present-with-zero fork trap for any non-threaded serialize path. Part of the systematic SLE-serializer sweep (cf. #983, #729).

## Test plan

- [x] `just test-pkg ./internal/ledger/state/...` — passes (serialize/parse round-trip)
- [x] `go test ./internal/ledger/genesis/...` — passes
- [x] `go build ./internal/ledger/... ./internal/tx/... ./internal/statecompare/...`, `go vet`, `gofmt -l` — clean

Fixes #989