### PR TITLE
refactor: serialize DepositPreauth OwnerNode with real directory page

### DIFF
--- a/internal/ledger/state/signer_list.go
+++ b/internal/ledger/state/signer_list.go
@@ -194,7 +194,7 @@ func SerializeTicket(ownerID [20]byte, ticketSeq uint32, ownerNode uint64) ([]by
 }
 
 // SerializeDepositPreauth serializes a DepositPreauth ledger entry.
-func SerializeDepositPreauth(ownerID, authorizedID [20]byte) ([]byte, error) {
+func SerializeDepositPreauth(ownerID, authorizedID [20]byte, ownerNode uint64) ([]byte, error) {
 	ownerAddress, err := addresscodec.EncodeAccountIDToClassicAddress(ownerID[:])
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode owner address: %w", err)
@@ -209,7 +209,7 @@ func SerializeDepositPreauth(ownerID, authorizedID [20]byte) ([]byte, error) {
 		"LedgerEntryType": "DepositPreauth",
 		"Account":         ownerAddress,
 		"Authorize":       authorizedAddress,
-		"OwnerNode":       "0",
+		"OwnerNode":       strconv.FormatUint(ownerNode, 16),
 		"Flags":           uint32(0),
 	}
 
@@ -230,7 +230,7 @@ type DepositPreauthCredential struct {
 // SerializeDepositPreauthCredentials serializes a credential-based DepositPreauth ledger entry.
 // The credentials should already be sorted.
 // Reference: rippled DepositPreauth.cpp doApply() sfAuthorizeCredentials branch
-func SerializeDepositPreauthCredentials(ownerID [20]byte, credentials []DepositPreauthCredential) ([]byte, error) {
+func SerializeDepositPreauthCredentials(ownerID [20]byte, credentials []DepositPreauthCredential, ownerNode uint64) ([]byte, error) {
 	ownerAddress, err := addresscodec.EncodeAccountIDToClassicAddress(ownerID[:])
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode owner address: %w", err)
@@ -251,7 +251,7 @@ func SerializeDepositPreauthCredentials(ownerID [20]byte, credentials []DepositP
 		"LedgerEntryType":      "DepositPreauth",
 		"Account":              ownerAddress,
 		"AuthorizeCredentials": credArray,
-		"OwnerNode":            "0",
+		"OwnerNode":            strconv.FormatUint(ownerNode, 16),
 		"Flags":                uint32(0),
 	}
 

--- a/internal/tx/depositpreauth/depositpreauth.go
+++ b/internal/tx/depositpreauth/depositpreauth.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
-	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/crypto/common"
 	"github.com/LeJamon/go-xrpl/keylet"
 
@@ -314,19 +313,8 @@ func (d *DepositPreauth) applyAuthorize(ctx *tx.ApplyContext) ter.Result {
 		return result
 	}
 
-	// --- doApply: create and insert preauth entry ---
-	preauthData, err := state.SerializeDepositPreauth(ctx.AccountID, authorizedID)
-	if err != nil {
-		ctx.Log.Error("deposit preauth authorize: failed to serialize preauth entry", "error", err)
-		return ter.TefINTERNAL
-	}
-
-	if err := ctx.View.Insert(preauthKey, preauthData); err != nil {
-		ctx.Log.Error("deposit preauth authorize: failed to insert preauth entry", "error", err)
-		return ter.TefINTERNAL
-	}
-
-	// --- doApply: insert into owner directory ---
+	// --- doApply: insert into owner directory first so sfOwnerNode records
+	// the page the entry actually landed on ---
 	ownerDirKey := keylet.OwnerDir(ctx.AccountID)
 	dirResult, err := state.DirInsert(ctx.View, ownerDirKey, preauthKey.Key, false, func(dir *state.DirectoryNode) {
 		dir.Owner = ctx.AccountID
@@ -336,11 +324,16 @@ func (d *DepositPreauth) applyAuthorize(ctx *tx.ApplyContext) ter.Result {
 		return ter.TecDIR_FULL
 	}
 
-	if dirResult.Page != 0 {
-		if err := updateOwnerNode(ctx, preauthKey, dirResult.Page); err != nil {
-			ctx.Log.Error("deposit preauth authorize: failed to update owner node", "error", err)
-			return ter.TefINTERNAL
-		}
+	// --- doApply: create and insert preauth entry ---
+	preauthData, err := state.SerializeDepositPreauth(ctx.AccountID, authorizedID, dirResult.Page)
+	if err != nil {
+		ctx.Log.Error("deposit preauth authorize: failed to serialize preauth entry", "error", err)
+		return ter.TefINTERNAL
+	}
+
+	if err := ctx.View.Insert(preauthKey, preauthData); err != nil {
+		ctx.Log.Error("deposit preauth authorize: failed to insert preauth entry", "error", err)
+		return ter.TefINTERNAL
 	}
 
 	ctx.Account.OwnerCount++
@@ -401,6 +394,17 @@ func (d *DepositPreauth) applyAuthorizeCredentials(ctx *tx.ApplyContext) ter.Res
 		return result
 	}
 
+	// --- doApply: insert into owner directory first so sfOwnerNode records
+	// the page the entry actually landed on ---
+	ownerDirKey := keylet.OwnerDir(ctx.AccountID)
+	dirResult, err := state.DirInsert(ctx.View, ownerDirKey, preauthKey.Key, false, func(dir *state.DirectoryNode) {
+		dir.Owner = ctx.AccountID
+	})
+	if err != nil {
+		ctx.Log.Error("deposit preauth authorize credentials: directory full", "error", err)
+		return ter.TecDIR_FULL
+	}
+
 	// --- doApply: create and insert preauth entry with sorted credentials ---
 	sleCreds := make([]state.DepositPreauthCredential, len(sorted))
 	for i, p := range sorted {
@@ -415,7 +419,7 @@ func (d *DepositPreauth) applyAuthorizeCredentials(ctx *tx.ApplyContext) ter.Res
 		}
 	}
 
-	preauthData, err := state.SerializeDepositPreauthCredentials(ctx.AccountID, sleCreds)
+	preauthData, err := state.SerializeDepositPreauthCredentials(ctx.AccountID, sleCreds, dirResult.Page)
 	if err != nil {
 		ctx.Log.Error("deposit preauth authorize credentials: failed to serialize preauth entry", "error", err)
 		return ter.TefINTERNAL
@@ -424,23 +428,6 @@ func (d *DepositPreauth) applyAuthorizeCredentials(ctx *tx.ApplyContext) ter.Res
 	if err := ctx.View.Insert(preauthKey, preauthData); err != nil {
 		ctx.Log.Error("deposit preauth authorize credentials: failed to insert preauth entry", "error", err)
 		return ter.TefINTERNAL
-	}
-
-	// --- doApply: insert into owner directory ---
-	ownerDirKey := keylet.OwnerDir(ctx.AccountID)
-	dirResult, err := state.DirInsert(ctx.View, ownerDirKey, preauthKey.Key, false, func(dir *state.DirectoryNode) {
-		dir.Owner = ctx.AccountID
-	})
-	if err != nil {
-		ctx.Log.Error("deposit preauth authorize credentials: directory full", "error", err)
-		return ter.TecDIR_FULL
-	}
-
-	if dirResult.Page != 0 {
-		if err := updateOwnerNode(ctx, preauthKey, dirResult.Page); err != nil {
-			ctx.Log.Error("deposit preauth authorize credentials: failed to update owner node", "error", err)
-			return ter.TefINTERNAL
-		}
 	}
 
 	ctx.Account.OwnerCount++
@@ -504,32 +491,6 @@ func removeFromLedger(ctx *tx.ApplyContext, preauthKey keylet.Keylet) ter.Result
 	}
 
 	return ter.TesSUCCESS
-}
-
-// updateOwnerNode reads a ledger entry, updates its OwnerNode field, and writes
-// it back. This is needed because OwnerNode is set after dir insertion.
-func updateOwnerNode(ctx *tx.ApplyContext, k keylet.Keylet, page uint64) error {
-	data, err := ctx.View.Read(k)
-	if err != nil {
-		return err
-	}
-
-	jsonObj, err := binarycodec.Decode(hex.EncodeToString(data))
-	if err != nil {
-		return err
-	}
-	jsonObj["OwnerNode"] = fmt.Sprintf("%016X", page)
-
-	hexStr, err := binarycodec.Encode(jsonObj)
-	if err != nil {
-		return err
-	}
-	newData, err := hex.DecodeString(hexStr)
-	if err != nil {
-		return err
-	}
-
-	return ctx.View.Update(k, newData)
 }
 
 // boolToInt converts a bool to 0 or 1.

--- a/internal/tx/depositpreauth/depositpreauth.go
+++ b/internal/tx/depositpreauth/depositpreauth.go
@@ -313,8 +313,8 @@ func (d *DepositPreauth) applyAuthorize(ctx *tx.ApplyContext) ter.Result {
 		return result
 	}
 
-	// --- doApply: insert into owner directory first so sfOwnerNode records
-	// the page the entry actually landed on ---
+	// Insert into the owner directory first so OwnerNode records the page the
+	// entry actually landed on.
 	ownerDirKey := keylet.OwnerDir(ctx.AccountID)
 	dirResult, err := state.DirInsert(ctx.View, ownerDirKey, preauthKey.Key, false, func(dir *state.DirectoryNode) {
 		dir.Owner = ctx.AccountID
@@ -394,8 +394,8 @@ func (d *DepositPreauth) applyAuthorizeCredentials(ctx *tx.ApplyContext) ter.Res
 		return result
 	}
 
-	// --- doApply: insert into owner directory first so sfOwnerNode records
-	// the page the entry actually landed on ---
+	// Insert into the owner directory first so OwnerNode records the page the
+	// entry actually landed on.
 	ownerDirKey := keylet.OwnerDir(ctx.AccountID)
 	dirResult, err := state.DirInsert(ctx.View, ownerDirKey, preauthKey.Key, false, func(dir *state.DirectoryNode) {
 		dir.Owner = ctx.AccountID


### PR DESCRIPTION
## Summary

- `SerializeDepositPreauth` / `SerializeDepositPreauthCredentials` now take an `ownerNode uint64` parameter (matching `SerializeTicket`) and emit the real directory page instead of a hardcoded `"0"`.
- Both apply paths now insert into the owner directory **first**, then serialize with `dirResult.Page` and insert the SLE — mirroring rippled's `setFieldU64(sfOwnerNode, *page)` order and the SignerList/Ticket sibling pattern.
- Deletes `updateOwnerNode`, the decode → patch → re-encode round-trip previously run on every page > 0.

On-ledger bytes are unchanged at every page (`OwnerNode` is a hex `UInt64` field; `"0"`-then-patch and direct-serialize decode to the same value), so this is a maintainability change with no behavioural/state effect — it removes a latent forget-to-patch hazard and a wasteful extra decode/encode per write.

## Test plan
- [x] `go build ./internal/ledger/state/... ./internal/tx/depositpreauth/...`
- [x] `go test ./internal/testing/depositpreauth/... ./internal/ledger/state/...`
- [x] `go vet` + `gofmt` clean on the changed files
- [x] Verified byte-identical serialized output vs the old round-trip for pages `0 … 0xFFFFFFFFFFFFFFFF`

Fixes #990