### PR TITLE
fix: stamp sfFirstLedgerSequence on NegativeUNL DisabledValidator

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1174,12 +1174,12 @@ func (a *Adaptor) disabledValidatorMasters() [][33]byte {
 		return nil
 	}
 	out := make([][33]byte, 0, len(sle.DisabledValidators))
-	for _, pubKey := range sle.DisabledValidators {
-		if len(pubKey) != 33 {
+	for _, dv := range sle.DisabledValidators {
+		if len(dv.PublicKey) != 33 {
 			continue
 		}
 		var master [33]byte
-		copy(master[:], pubKey)
+		copy(master[:], dv.PublicKey)
 		out = append(out, master)
 	}
 	return out

--- a/internal/consensus/adaptor/negative_unl_vote.go
+++ b/internal/consensus/adaptor/negative_unl_vote.go
@@ -139,11 +139,11 @@ func (a *Adaptor) negativeUNLState(l interface {
 	if n := len(parsed.DisabledValidators); n > 0 {
 		state.DisabledKeys = make([][33]byte, 0, n)
 		for _, v := range parsed.DisabledValidators {
-			if len(v) != 33 {
+			if len(v.PublicKey) != 33 {
 				continue
 			}
 			var k [33]byte
-			copy(k[:], v)
+			copy(k[:], v.PublicKey)
 			state.DisabledKeys = append(state.DisabledKeys, k)
 		}
 	}

--- a/internal/consensus/adaptor/negative_unl_vote_test.go
+++ b/internal/consensus/adaptor/negative_unl_vote_test.go
@@ -112,7 +112,10 @@ func TestNegativeUNLState_ParsesPopulatedSLE(t *testing.T) {
 	masterPending := make33Byte(0x03)
 
 	sle := &pseudo.NegativeUNLSLE{
-		DisabledValidators:  [][]byte{master1[:], master2[:]},
+		DisabledValidators: []pseudo.DisabledValidator{
+			{PublicKey: master1[:], FirstLedgerSequence: 256},
+			{PublicKey: master2[:], FirstLedgerSequence: 512},
+		},
 		ValidatorToReEnable: masterPending[:],
 	}
 	encoded, err := pseudo.SerializeNegativeUNLSLE(sle)

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -688,7 +688,7 @@ func (l *Ledger) UpdateNegativeUNL() error {
 	if hasToReEnable {
 		filtered := sle.DisabledValidators[:0]
 		for _, dv := range sle.DisabledValidators {
-			if bytes.Equal(dv, sle.ValidatorToReEnable) {
+			if bytes.Equal(dv.PublicKey, sle.ValidatorToReEnable) {
 				continue
 			}
 			filtered = append(filtered, dv)
@@ -696,13 +696,14 @@ func (l *Ledger) UpdateNegativeUNL() error {
 		sle.DisabledValidators = filtered
 	}
 
-	// Append ValidatorToDisable (if any) as a new DisabledValidators
-	// entry. Rippled also stamps the current ledger seq as
-	// sfFirstLedgerSequence; go-xrpl's NegativeUNLSLE today flattens
-	// DisabledValidators to a [][]byte of pubkeys — the sfFirstLedger
-	// stamping is a SLE serialization concern for a follow-up.
+	// Append ValidatorToDisable (if any) as a new DisabledValidators entry,
+	// stamping the flag-ledger sequence as sfFirstLedgerSequence (rippled
+	// Ledger.cpp:778-784).
 	if hasToDisable {
-		sle.DisabledValidators = append(sle.DisabledValidators, sle.ValidatorToDisable)
+		sle.DisabledValidators = append(sle.DisabledValidators, pseudo.DisabledValidator{
+			PublicKey:           sle.ValidatorToDisable,
+			FirstLedgerSequence: l.header.LedgerIndex,
+		})
 	}
 
 	// Clear the transition fields.

--- a/internal/ledger/negative_unl_test.go
+++ b/internal/ledger/negative_unl_test.go
@@ -1,0 +1,78 @@
+package ledger
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// TestUpdateNegativeUNL_StampsFlagLedgerSeq is the end-to-end parity check for
+// rippled's VerifyPubKeyAndSeq (NegativeUNL_test.cpp): materializing a pending
+// ValidatorToDisable on a flag ledger must produce a DisabledValidator entry
+// whose sfFirstLedgerSequence equals that ledger's own sequence, and must clear
+// the transition field (Ledger.cpp:783,792).
+func TestUpdateNegativeUNL_StampsFlagLedgerSeq(t *testing.T) {
+	res, err := genesis.Create(genesis.DefaultConfig())
+	if err != nil {
+		t.Fatalf("genesis.Create: %v", err)
+	}
+	parent := FromGenesis(res.Header, res.StateMap, res.TxMap, drops.Fees{})
+
+	l, err := NewOpen(parent, parent.CloseTime().Add(10*time.Second))
+	if err != nil {
+		t.Fatalf("NewOpen: %v", err)
+	}
+	// Pin the open ledger to a flag-ledger boundary (seq % 256 == 0); the
+	// stamped FirstLedgerSequence must equal this value.
+	const flagSeq = uint32(256)
+	l.header.LedgerIndex = flagSeq
+
+	validator := make([]byte, 33)
+	validator[0] = 0xED
+	for i := 1; i < 33; i++ {
+		validator[i] = 0x42
+	}
+
+	seed, err := pseudo.SerializeNegativeUNLSLE(&pseudo.NegativeUNLSLE{
+		ValidatorToDisable: validator,
+	})
+	if err != nil {
+		t.Fatalf("serialize seed SLE: %v", err)
+	}
+	key := keylet.NegativeUNL().Key
+	if err := l.stateMap.Put(key, seed); err != nil {
+		t.Fatalf("seed stateMap: %v", err)
+	}
+
+	if err := l.UpdateNegativeUNL(); err != nil {
+		t.Fatalf("UpdateNegativeUNL: %v", err)
+	}
+
+	item, ok, err := l.stateMap.Get(key)
+	if err != nil || !ok {
+		t.Fatalf("read back SLE: ok=%v err=%v", ok, err)
+	}
+	sle, err := pseudo.ParseNegativeUNLSLE(item.Data())
+	if err != nil {
+		t.Fatalf("parse SLE: %v", err)
+	}
+
+	if len(sle.DisabledValidators) != 1 {
+		t.Fatalf("DisabledValidators len = %d, want 1", len(sle.DisabledValidators))
+	}
+	dv := sle.DisabledValidators[0]
+	if !bytes.Equal(dv.PublicKey, validator) {
+		t.Errorf("PublicKey = %x, want %x", dv.PublicKey, validator)
+	}
+	if dv.FirstLedgerSequence != flagSeq {
+		t.Errorf("FirstLedgerSequence = %d, want %d", dv.FirstLedgerSequence, flagSeq)
+	}
+	if len(sle.ValidatorToDisable) != 0 {
+		t.Errorf("ValidatorToDisable not cleared: %x", sle.ValidatorToDisable)
+	}
+}

--- a/internal/testing/pseudotx/unl_modify_test.go
+++ b/internal/testing/pseudotx/unl_modify_test.go
@@ -263,7 +263,9 @@ func seedDisabledValidator(t *testing.T, env *jtx.TestEnv, validatorKeyHex strin
 	}
 
 	// Add the validator to the disabled list
-	sle.DisabledValidators = append(sle.DisabledValidators, validatorKey)
+	sle.DisabledValidators = append(sle.DisabledValidators, pseudo.DisabledValidator{
+		PublicKey: validatorKey,
+	})
 
 	serialized, serErr := pseudo.SerializeNegativeUNLSLE(sle)
 	require.NoError(t, serErr)

--- a/internal/tx/pseudo/negative_unl_sle.go
+++ b/internal/tx/pseudo/negative_unl_sle.go
@@ -9,14 +9,26 @@ import (
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 )
 
+// DisabledValidator is one entry of the NegativeUNL's sfDisabledValidators
+// array. Both PublicKey and FirstLedgerSequence are soeREQUIRED in the
+// sfDisabledValidator inner-object template, so both are always serialized.
+type DisabledValidator struct {
+	// PublicKey is the master public key of the disabled validator.
+	PublicKey []byte
+
+	// FirstLedgerSequence is the flag-ledger sequence at which the validator
+	// was added to the negative UNL.
+	FirstLedgerSequence uint32
+}
+
 // NegativeUNLSLE represents the parsed NegativeUNL ledger entry.
 // Reference: rippled SLE with type ltNEGATIVE_UNL (0x004e)
 // Fields: sfDisabledValidators (STArray), sfValidatorToDisable (Blob),
 //
 //	sfValidatorToReEnable (Blob)
 type NegativeUNLSLE struct {
-	// DisabledValidators is the list of currently disabled validator public keys.
-	DisabledValidators [][]byte
+	// DisabledValidators is the list of currently disabled validators.
+	DisabledValidators []DisabledValidator
 
 	// ValidatorToDisable is the validator scheduled for disabling (if any).
 	ValidatorToDisable []byte
@@ -39,7 +51,8 @@ func ParseNegativeUNLSLE(data []byte) (*NegativeUNLSLE, error) {
 
 	sle := &NegativeUNLSLE{}
 
-	// Parse sfDisabledValidators (STArray of objects with sfPublicKey)
+	// Parse sfDisabledValidators (STArray of objects with sfPublicKey +
+	// sfFirstLedgerSequence).
 	if validators, ok := jsonObj["DisabledValidators"]; ok {
 		arr, ok := validators.([]any)
 		if !ok {
@@ -58,12 +71,18 @@ func ParseNegativeUNLSLE(data []byte) (*NegativeUNLSLE, error) {
 			if !ok {
 				continue
 			}
-			if pubKey, ok := innerMap["PublicKey"].(string); ok {
-				b, err := hex.DecodeString(pubKey)
-				if err == nil {
-					sle.DisabledValidators = append(sle.DisabledValidators, b)
-				}
+			pubKey, ok := innerMap["PublicKey"].(string)
+			if !ok {
+				continue
 			}
+			b, err := hex.DecodeString(pubKey)
+			if err != nil {
+				continue
+			}
+			sle.DisabledValidators = append(sle.DisabledValidators, DisabledValidator{
+				PublicKey:           b,
+				FirstLedgerSequence: toUint32(innerMap["FirstLedgerSequence"]),
+			})
 		}
 	}
 
@@ -93,13 +112,15 @@ func SerializeNegativeUNLSLE(sle *NegativeUNLSLE) ([]byte, error) {
 		"Flags":           0,
 	}
 
-	// Add sfDisabledValidators (STArray)
+	// Add sfDisabledValidators (STArray). Both inner fields are soeREQUIRED,
+	// so FirstLedgerSequence is emitted unconditionally (even at 0).
 	if len(sle.DisabledValidators) > 0 {
 		arr := make([]any, len(sle.DisabledValidators))
-		for i, key := range sle.DisabledValidators {
+		for i, dv := range sle.DisabledValidators {
 			arr[i] = map[string]any{
 				"DisabledValidator": map[string]any{
-					"PublicKey": strings.ToUpper(hex.EncodeToString(key)),
+					"PublicKey":           strings.ToUpper(hex.EncodeToString(dv.PublicKey)),
+					"FirstLedgerSequence": dv.FirstLedgerSequence,
 				},
 			}
 		}
@@ -126,10 +147,29 @@ func SerializeNegativeUNLSLE(sle *NegativeUNLSLE) ([]byte, error) {
 
 // ContainsValidator checks if a validator key is in the disabled validators list.
 func (sle *NegativeUNLSLE) ContainsValidator(key []byte) bool {
-	for _, k := range sle.DisabledValidators {
-		if bytes.Equal(k, key) {
+	for _, dv := range sle.DisabledValidators {
+		if bytes.Equal(dv.PublicKey, key) {
 			return true
 		}
 	}
 	return false
+}
+
+// toUint32 coerces a decoded JSON value (binarycodec returns UInt32 fields as
+// uint32) into a uint32, tolerating the other numeric shapes a decoder may use.
+func toUint32(v any) uint32 {
+	switch n := v.(type) {
+	case uint32:
+		return n
+	case uint64:
+		return uint32(n)
+	case int:
+		return uint32(n)
+	case int64:
+		return uint32(n)
+	case float64:
+		return uint32(n)
+	default:
+		return 0
+	}
 }

--- a/internal/tx/pseudo/negative_unl_sle.go
+++ b/internal/tx/pseudo/negative_unl_sle.go
@@ -155,21 +155,9 @@ func (sle *NegativeUNLSLE) ContainsValidator(key []byte) bool {
 	return false
 }
 
-// toUint32 coerces a decoded JSON value (binarycodec returns UInt32 fields as
-// uint32) into a uint32, tolerating the other numeric shapes a decoder may use.
+// toUint32 returns v as a uint32. The binarycodec decodes UInt32 fields as
+// uint32; an absent or wrongly-typed value yields 0.
 func toUint32(v any) uint32 {
-	switch n := v.(type) {
-	case uint32:
-		return n
-	case uint64:
-		return uint32(n)
-	case int:
-		return uint32(n)
-	case int64:
-		return uint32(n)
-	case float64:
-		return uint32(n)
-	default:
-		return 0
-	}
+	n, _ := v.(uint32)
+	return n
 }

--- a/internal/tx/pseudo/negative_unl_sle_test.go
+++ b/internal/tx/pseudo/negative_unl_sle_test.go
@@ -1,0 +1,100 @@
+package pseudo
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+)
+
+func makeKey(b byte) []byte {
+	k := make([]byte, 33)
+	k[0] = 0xED
+	for i := 1; i < 33; i++ {
+		k[i] = b
+	}
+	return k
+}
+
+// TestNegativeUNL_FirstLedgerSequenceRoundTrips asserts each DisabledValidator
+// inner object carries sfFirstLedgerSequence through serialize → parse, and
+// that it is emitted even at its zero value (both inner fields are soeREQUIRED).
+func TestNegativeUNL_FirstLedgerSequenceRoundTrips(t *testing.T) {
+	key1 := makeKey(0x01)
+	key2 := makeKey(0x02)
+
+	sle := &NegativeUNLSLE{
+		DisabledValidators: []DisabledValidator{
+			{PublicKey: key1, FirstLedgerSequence: 256},
+			{PublicKey: key2, FirstLedgerSequence: 0},
+		},
+	}
+
+	data, err := SerializeNegativeUNLSLE(sle)
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+
+	parsed, err := ParseNegativeUNLSLE(data)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if len(parsed.DisabledValidators) != 2 {
+		t.Fatalf("DisabledValidators len = %d, want 2", len(parsed.DisabledValidators))
+	}
+	for i, want := range sle.DisabledValidators {
+		got := parsed.DisabledValidators[i]
+		if !bytes.Equal(got.PublicKey, want.PublicKey) {
+			t.Errorf("entry %d PublicKey mismatch", i)
+		}
+		if got.FirstLedgerSequence != want.FirstLedgerSequence {
+			t.Errorf("entry %d FirstLedgerSequence = %d, want %d", i, got.FirstLedgerSequence, want.FirstLedgerSequence)
+		}
+	}
+}
+
+// TestNegativeUNL_FirstLedgerSequenceSerializedPresent decodes the raw blob and
+// asserts sfFirstLedgerSequence is present in the inner object (it is
+// soeREQUIRED in rippled's sfDisabledValidator template). A zero value must
+// still be serialized, mirroring the present-with-zero SLE-fork class.
+func TestNegativeUNL_FirstLedgerSequenceSerializedPresent(t *testing.T) {
+	sle := &NegativeUNLSLE{
+		DisabledValidators: []DisabledValidator{
+			{PublicKey: makeKey(0x07), FirstLedgerSequence: 0},
+		},
+	}
+
+	data, err := SerializeNegativeUNLSLE(sle)
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+
+	fields, err := binarycodec.DecodeBytes(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	arr, ok := fields["DisabledValidators"].([]any)
+	if !ok || len(arr) != 1 {
+		t.Fatalf("DisabledValidators = %#v, want one-element array", fields["DisabledValidators"])
+	}
+	wrapper, ok := arr[0].(map[string]any)
+	if !ok {
+		t.Fatalf("entry type = %T, want map", arr[0])
+	}
+	inner, ok := wrapper["DisabledValidator"].(map[string]any)
+	if !ok {
+		t.Fatalf("DisabledValidator type = %T, want map", wrapper["DisabledValidator"])
+	}
+	if _, ok := inner["PublicKey"]; !ok {
+		t.Error("PublicKey must be present (soeREQUIRED)")
+	}
+	v, ok := inner["FirstLedgerSequence"]
+	if !ok {
+		t.Fatal("FirstLedgerSequence must be present even at 0 (soeREQUIRED)")
+	}
+	if toUint32(v) != 0 {
+		t.Errorf("FirstLedgerSequence = %v, want 0", v)
+	}
+}


### PR DESCRIPTION
## Summary

- The `NegativeUNL` SLE serialized each `sfDisabledValidator` inner object with **only** `sfPublicKey`, dropping `sfFirstLedgerSequence`. rippled marks **both** fields `soeREQUIRED`, so the serialized SLE diverged from rippled's — forking `account_hash` (and `transaction_hash`, since the metadata codec round-trips the blob) on any flag ledger that disables a validator. This is the missing-required-field variant of the present-with-zero SLE-fork class (cf. #983, #729).
- `NegativeUNLSLE.DisabledValidators` is now `[]DisabledValidator{PublicKey, FirstLedgerSequence}` instead of `[][]byte`. Parse reads both inner fields; serialize emits both unconditionally (`FirstLedgerSequence` even at 0, since it is required); `Ledger.UpdateNegativeUNL` stamps the flag-ledger sequence at the promotion site, matching `Ledger::updateNegativeUNL()`.
- Threaded the new shape through the consumers (`consensus/adaptor`, `ContainsValidator`, the UNLModify seed helper).

## Test plan

- [x] `just test-pkg ./internal/tx/pseudo/...` — new round-trip + present-at-zero golden tests pass
- [x] `just test-pkg ./internal/consensus/adaptor/...` and `./internal/testing/pseudotx/...`
- [x] `go test ./internal/ledger/`
- [x] `go vet` clean on touched packages; full `CGO_ENABLED=1 go build ./...` succeeds

Fixes #988