### PR TITLE
Converge divergent-ledger acquisition instead of fatal watchdog stall

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -129,6 +129,11 @@ type NetworkSender interface {
 	// range — used to relay an unsatisfiable GetLedger to a peer that can
 	// serve it. ok is false when none qualifies. See Overlay.PeerWithLedger.
 	PeerWithLedger(target [32]byte, seq uint32, exclude uint64) (uint64, bool)
+	// PeersWithLedger returns up to max connected peers (other than any id
+	// in excluded) that can serve ledger (target, seq), best-first. Used to
+	// broaden a stalled inbound acquisition's source set across several peers
+	// per no-progress timeout, mirroring InboundLedger::addPeers.
+	PeersWithLedger(target [32]byte, seq uint32, excluded []uint64, max int) []uint64
 	// PeerWithTxSet returns a connected peer (other than exclude) that
 	// advertised tx-set root target, used to relay an unsatisfiable
 	// liTS_CANDIDATE GetLedger. See Overlay.PeerWithTxSet.
@@ -164,6 +169,7 @@ func (n *noopSender) IncPeerBadData(uint64, string)                             
 func (n *noopSender) PeersThatHave([32]byte) []uint64                                { return nil }
 func (n *noopSender) ShouldShedLedgerRequest(uint64, bool) bool                      { return false }
 func (n *noopSender) PeerWithLedger([32]byte, uint32, uint64) (uint64, bool)         { return 0, false }
+func (n *noopSender) PeersWithLedger([32]byte, uint32, []uint64, int) []uint64       { return nil }
 func (n *noopSender) PeerWithTxSet([32]byte, uint64) (uint64, bool)                  { return 0, false }
 func (n *noopSender) NotePeerHasTxSet(uint64, [32]byte)                              {}
 
@@ -697,6 +703,12 @@ func (a *Adaptor) ShouldShedLedgerRequest(peerID uint64, loadedLocal bool) bool 
 // unsatisfiable GetLedger to a peer that can serve the ledger.
 func (a *Adaptor) PeerWithLedger(target [32]byte, seq uint32, exclude uint64) (uint64, bool) {
 	return a.sender.PeerWithLedger(target, seq, exclude)
+}
+
+// PeersWithLedger delegates to NetworkSender; the Router uses it to broaden a
+// stalled acquisition's source-peer set. See Overlay.PeersWithLedger.
+func (a *Adaptor) PeersWithLedger(target [32]byte, seq uint32, excluded []uint64, max int) []uint64 {
+	return a.sender.PeersWithLedger(target, seq, excluded, max)
 }
 
 // PeerWithTxSet delegates to NetworkSender; the Router uses it to relay an

--- a/internal/consensus/adaptor/fetchpack.go
+++ b/internal/consensus/adaptor/fetchpack.go
@@ -92,11 +92,12 @@ func (c *fetchPackCache) sweep(now time.Time) {
 	}
 }
 
-// handleFetchPackReply consumes an inbound mtGET_OBJECTS{otFETCH_PACK,
-// query=false}: cache each verified SHAMap node by its hash, then give every
-// in-flight acquisition a chance to complete locally from the cache. The
-// pack's leading ledger-header object and any node that fails hash
-// verification are dropped.
+// handleFetchPackReply consumes an inbound mtGET_OBJECTS reply carrying SHAMap
+// nodes — either an otFETCH_PACK bulk pack or the otSTATE_NODE/otTRANSACTION_NODE
+// nodes served for a by-hash acquisition escalation. It caches each verified
+// node by its hash, then gives every in-flight acquisition a chance to complete
+// locally from the cache via CheckLocal. A pack's leading ledger-header object
+// and any node that fails hash verification are dropped.
 func (r *Router) handleFetchPackReply(msg *peermanagement.InboundMessage) {
 	if r.fetchPacks == nil {
 		return
@@ -107,7 +108,12 @@ func (r *Router) handleFetchPackReply(msg *peermanagement.InboundMessage) {
 		return
 	}
 	gob, ok := decoded.(*message.GetObjectByHash)
-	if !ok || gob.Query || gob.ObjType != message.ObjectTypeFetchPack {
+	if !ok || gob.Query {
+		return
+	}
+	switch gob.ObjType {
+	case message.ObjectTypeFetchPack, message.ObjectTypeStateNode, message.ObjectTypeTransactionNode:
+	default:
 		return
 	}
 

--- a/internal/consensus/adaptor/inbound_broaden_target_test.go
+++ b/internal/consensus/adaptor/inbound_broaden_target_test.go
@@ -1,0 +1,111 @@
+package adaptor
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// peerTargetSender records the peer id of each legacy node-fetch and serves a
+// configurable PeersWithLedger answer, so the broaden (issue #985 M2) and
+// reply-targeting (M3) paths can be pinned. Other NetworkSender methods inherit
+// from noopSender.
+type peerTargetSender struct {
+	noopSender
+	mu         sync.Mutex
+	statePeers []uint64 // peer of each RequestStateNodes call, in order
+	broadenRet []uint64 // what PeersWithLedger returns
+	broadenEx  []uint64 // excluded set captured from the last PeersWithLedger call
+}
+
+func (s *peerTargetSender) RequestStateNodes(peerID uint64, _ [32]byte, _ [][]byte, _ bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.statePeers = append(s.statePeers, peerID)
+	return nil
+}
+
+func (s *peerTargetSender) RequestTransactionNodes(uint64, [32]byte, [][]byte, bool) error {
+	return nil
+}
+
+func (s *peerTargetSender) PeersWithLedger(_ [32]byte, _ uint32, excluded []uint64, _ int) []uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.broadenEx = append([]uint64(nil), excluded...)
+	return append([]uint64(nil), s.broadenRet...)
+}
+
+func (s *peerTargetSender) statePeerList() []uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]uint64(nil), s.statePeers...)
+}
+
+func (s *peerTargetSender) excludedSet() []uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]uint64(nil), s.broadenEx...)
+}
+
+func newPeerTargetRouter(t *testing.T, rs *peerTargetSender) (*Router, *service.Service) {
+	t.Helper()
+	svc := newTestLedgerService(t)
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	a := New(Config{
+		LedgerService: svc,
+		Sender:        rs,
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+	})
+	return NewRouter(&mockEngine{}, a, nil), svc
+}
+
+// TestBroadenAcquisitionPeers_AddsMultiple pins issue #985 M2: a no-progress
+// broaden adds every fresh peer PeersWithLedger returns (mirroring rippled's
+// peerCountAdd), excluding the acquisition's current set, instead of one.
+func TestBroadenAcquisitionPeers_AddsMultiple(t *testing.T) {
+	rs := &peerTargetSender{broadenRet: []uint64{8, 9, 10}}
+	router, _ := newPeerTargetRouter(t, rs)
+
+	il := inbound.New([32]byte{0xAB}, 42, 7, serveTestLogger())
+	router.broadenAcquisitionPeers(il)
+
+	assert.ElementsMatch(t, []uint64{7, 8, 9, 10}, il.Peers(),
+		"broaden must add all peers PeersWithLedger returned")
+	assert.Equal(t, []uint64{7}, rs.excludedSet(),
+		"the current source set must be excluded from selection")
+}
+
+// TestRequestMissingAcquisitionNodes_ReplyTargetsReplier pins issue #985 M3: on
+// a reply the re-request goes to just the replying peer (rippled trigger(peer)),
+// while the no-progress timeout path (target 0) fans out to the whole set.
+func TestRequestMissingAcquisitionNodes_ReplyTargetsReplier(t *testing.T) {
+	rs := &peerTargetSender{}
+	router, svc := newPeerTargetRouter(t, rs)
+
+	l := svc.GetClosedLedger()
+	require.NotNil(t, l)
+	il := inbound.New(l.Hash(), l.Sequence(), 7, serveTestLogger())
+	require.NoError(t, il.GotBase(router.buildLedgerBaseNodes(l)))
+	require.NotEmpty(t, il.NeedsMissingNodeIDs(), "acquisition must have outstanding state nodes")
+	il.AddPeer(8)
+	il.AddPeer(9)
+
+	// Reply path: target the replier only.
+	router.requestMissingAcquisitionNodes(il, 9)
+	assert.Equal(t, []uint64{9}, rs.statePeerList(),
+		"a reply must re-request from only the peer that answered")
+
+	// Timeout path: fan out to the whole broadened set.
+	rs.statePeers = nil
+	router.requestMissingAcquisitionNodes(il, 0)
+	assert.ElementsMatch(t, []uint64{7, 8, 9}, rs.statePeerList(),
+		"the no-progress path must fan out to every source peer")
+}

--- a/internal/consensus/adaptor/inbound_byhash_test.go
+++ b/internal/consensus/adaptor/inbound_byhash_test.go
@@ -1,0 +1,98 @@
+package adaptor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleNodeReply_AcceptsByHashStateNodes confirms the reply handler now
+// accepts the otSTATE_NODE nodes served for a by-hash acquisition escalation
+// (issue #985) and caches them, so CheckLocal can place them — the same
+// receiver path the bulk fetch-pack reply uses.
+func TestHandleNodeReply_AcceptsByHashStateNodes(t *testing.T) {
+	t.Parallel()
+	source := shamap.New(shamap.TypeState)
+	for i := byte(1); i <= 12; i++ {
+		var key [32]byte
+		key[0] = i
+		key[31] = 0xA5
+		require.NoError(t, source.Put(key, []byte{i, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB}))
+	}
+	_, err := source.Hash()
+	require.NoError(t, err)
+	valid, err := source.WalkFetchPackNodes(1 << 20)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(valid), 2)
+
+	objects := make([]message.IndexedObject, 0, len(valid))
+	for _, n := range valid {
+		objects = append(objects, message.IndexedObject{
+			Hash: append([]byte(nil), n.Hash[:]...),
+			Data: n.Data,
+		})
+	}
+	payload, err := message.Encode(&message.GetObjectByHash{
+		ObjType: message.ObjectTypeStateNode,
+		Query:   false,
+		Objects: objects,
+	})
+	require.NoError(t, err)
+
+	r := NewRouter(nil, newTestAdaptor(t), make(chan *peermanagement.InboundMessage, 1))
+	r.handleFetchPackReply(&peermanagement.InboundMessage{
+		PeerID:  peermanagement.PeerID(5),
+		Type:    uint16(message.TypeGetObjects),
+		Payload: payload,
+	})
+
+	assert.Equal(t, len(valid), r.fetchPacks.size(), "by-hash state-node reply nodes must be cached")
+	for _, n := range valid {
+		if _, ok := r.fetchPacks.get(n.Hash, time.Now()); !ok {
+			t.Errorf("by-hash node %x not cached", n.Hash[:8])
+		}
+	}
+}
+
+// TestFailInboundAcquisition_NotifiesEngineForConsensus pins issue #985 part C's
+// wiring: a consensus-driven acquisition that exhausts its retry budget is
+// reaped AND the engine is told, so a node pinned in wrongLedger can recover
+// instead of starving the ledger loop into a fatal watchdog abort.
+func TestFailInboundAcquisition_NotifiesEngineForConsensus(t *testing.T) {
+	t.Parallel()
+	eng := &mockEngine{}
+	r := NewRouter(eng, newTestAdaptor(t), make(chan *peermanagement.InboundMessage, 1))
+	hash := [32]byte{0xDE, 0xAD, 0xBE, 0xEF}
+	il := inbound.New(hash, 50, 7, serveTestLogger())
+	r.fetchTracker.Track(il)
+
+	r.failInboundAcquisition(il)
+
+	got := eng.getAcquireFailed()
+	require.Len(t, got, 1, "engine must be notified of the failed consensus acquisition")
+	assert.Equal(t, consensus.LedgerID(hash), got[0])
+	assert.Nil(t, r.fetchTracker.Find(hash), "failed acquisition must be removed from the tracker")
+}
+
+// TestFailInboundAcquisition_SkipsEngineForGeneric confirms an RPC-driven
+// (ReasonGeneric) acquisition failure does not disturb consensus.
+func TestFailInboundAcquisition_SkipsEngineForGeneric(t *testing.T) {
+	t.Parallel()
+	eng := &mockEngine{}
+	r := NewRouter(eng, newTestAdaptor(t), make(chan *peermanagement.InboundMessage, 1))
+	hash := [32]byte{0x0B, 0x0E}
+	il := inbound.NewGeneric(hash, 50, 7, serveTestLogger())
+	r.fetchTracker.Track(il)
+
+	r.failInboundAcquisition(il)
+
+	assert.Empty(t, eng.getAcquireFailed(), "a generic acquisition must not notify consensus")
+	assert.Nil(t, r.fetchTracker.Find(hash), "failed acquisition must be removed from the tracker")
+}

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -341,29 +341,21 @@ func (r *Router) maintenanceTick() {
 		r.startLedgerAcquisitionLegacy(entry.Seq, entry.Hash, entry.PeerID)
 	}
 
-	// Reap stuck legacy inbound ledgers. Without this a stalled acquisition
-	// blocks startLedgerAcquisitionLegacy from arming a new request for the
-	// SAME hash on the next statusChange — and blocks the replay-delta path
-	// too via isAcquiring's registry check.
-	for _, il := range r.fetchTracker.ActiveTimedOut() {
-		// Before giving up, try a fetch-pack: if we can name a child ledger
-		// of the stalled one, ask a peer for a bulk pack and grant one more
-		// timeout window for it to arrive and complete the acquisition
-		// locally (handleFetchPackReply → CheckLocal). Attempted at most once
-		// per acquisition; on the next timeout it reaps as before.
-		if r.tryFetchPackEscalation(il) {
-			continue
+	// Drive the timer-based retry loop over every in-flight legacy acquisition,
+	// porting rippled's TimeoutCounter/InboundLedger::onTimer. A no-progress
+	// interval escalates (broaden peers, re-request, fetch-pack, and once
+	// aggressive ask for the missing nodes by content hash); an exhausted retry
+	// budget fails the acquisition cleanly instead of re-arming the same stall
+	// forever. Reaping here also unblocks startLedgerAcquisitionLegacy and the
+	// replay-delta path, both of which refuse to arm while the hash is in flight.
+	now := time.Now()
+	for _, il := range r.fetchTracker.Active() {
+		switch il.OnTimer(now) {
+		case inbound.TimerFailed:
+			r.failInboundAcquisition(il)
+		case inbound.TimerEscalate:
+			r.escalateAcquisition(il, now)
 		}
-		r.logger.Warn("legacy inbound ledger acquisition timed out",
-			"seq", il.Seq(),
-			"hash", fmt.Sprintf("%x", il.Hash()),
-			"peer", il.PeerID(),
-		)
-		r.fetchTracker.Remove(il.Hash(), false)
-		// Do NOT re-issue from here: legacy has no retry partner, and
-		// the next statusChange from any peer will naturally arm a
-		// fresh acquisition via startLedgerAcquisition once the stuck
-		// reference is cleared.
 	}
 
 	// Expire stale fetch-pack nodes so the cache doesn't retain a stalled

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -993,8 +993,11 @@ func (r *Router) failInboundAcquisition(il *inbound.Ledger) {
 }
 
 // inboundByHashBatch bounds how many missing-node content hashes a single
-// by-hash escalation requests per tree.
-const inboundByHashBatch = 256
+// by-hash escalation requests per tree. By-hash is a targeted divergent-path
+// fallback, not a bulk-transfer path, so the set is kept small — matching
+// rippled's getNeededHashes cap of 4 per tree (InboundLedger::neededStateHashes/
+// neededTxHashes).
+const inboundByHashBatch = 4
 
 // requestAcquisitionNodesByHash performs the by-hash escalation rung: once the
 // acquisition has gone aggressive it asks the peer set for the missing

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
@@ -916,29 +917,138 @@ func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerD
 	return false
 }
 
-// requestMissingAcquisitionNodes asks the source peer for the outstanding
-// account-state and transaction tree nodes of the active acquisition,
-// requesting both trees in parallel. Each call is a no-op for a tree
-// already complete.
+// requestMissingAcquisitionNodes asks the acquisition's source peers for the
+// outstanding account-state and transaction tree nodes, requesting both trees
+// in parallel from every peer in the (possibly broadened) set. Each call is a
+// no-op for a tree already complete.
 //
 // Once the acquisition has timed out at least once we mark the requests
 // indirect (query_type=qtINDIRECT) so peers relay them on our behalf,
-// mirroring rippled's InboundLedger::trigger timeouts_ != 0 gate. go-xrpl
-// reaps a legacy acquisition on its first timeout, so its only post-timeout
-// life is the aggressive fetch-pack escalation window — exactly rippled's
-// "be more aggressive" branch — which FetchPackRequested reports.
+// mirroring rippled's InboundLedger::trigger timeouts_ != 0 gate.
 func (r *Router) requestMissingAcquisitionNodes(il *inbound.Ledger) {
-	indirect := il.FetchPackRequested()
-	if nodeIDs := il.NeedsMissingNodeIDs(); len(nodeIDs) > 0 {
-		if err := r.adaptor.RequestStateNodes(il.PeerID(), il.Hash(), nodeIDs, indirect); err != nil {
-			r.logger.Warn("inbound ledger: failed to request state nodes", "error", err)
+	indirect := il.Timeouts() > 0
+	stateIDs := il.NeedsMissingNodeIDs()
+	txIDs := il.NeedsMissingTxNodeIDs()
+	if len(stateIDs) == 0 && len(txIDs) == 0 {
+		return
+	}
+	hash := il.Hash()
+	for _, peerID := range il.Peers() {
+		if len(stateIDs) > 0 {
+			if err := r.adaptor.RequestStateNodes(peerID, hash, stateIDs, indirect); err != nil {
+				r.logger.Warn("inbound ledger: failed to request state nodes", "error", err)
+			}
+		}
+		if len(txIDs) > 0 {
+			if err := r.adaptor.RequestTransactionNodes(peerID, hash, txIDs, indirect); err != nil {
+				r.logger.Warn("inbound ledger: failed to request tx nodes", "error", err)
+			}
 		}
 	}
-	if nodeIDs := il.NeedsMissingTxNodeIDs(); len(nodeIDs) > 0 {
-		if err := r.adaptor.RequestTransactionNodes(il.PeerID(), il.Hash(), nodeIDs, indirect); err != nil {
-			r.logger.Warn("inbound ledger: failed to request tx nodes", "error", err)
+}
+
+// escalateAcquisition runs one no-progress escalation rung for a stalled
+// acquisition, mirroring rippled InboundLedger::onTimer's !wasProgress branch:
+// try to complete locally from the fetch-pack cache, broaden the source-peer
+// set, re-request the missing nodes (timer-driven, so a silent peer cannot
+// stall it), arm a one-shot fetch-pack, and once aggressive ask the peer set
+// for the missing nodes by content hash.
+func (r *Router) escalateAcquisition(il *inbound.Ledger, now time.Time) {
+	if il.CheckLocal(func(h [32]byte) ([]byte, bool) { return r.fetchPacks.get(h, now) }) && il.IsComplete() {
+		r.completeInboundLedger(il)
+		return
+	}
+	r.broadenAcquisitionPeers(il)
+	r.requestMissingAcquisitionNodes(il)
+	r.tryFetchPackEscalation(il)
+	r.requestAcquisitionNodesByHash(il)
+}
+
+// broadenAcquisitionPeers adds a fresh peer that reports the wanted ledger to a
+// stalled acquisition's source set, mirroring rippled InboundLedger::addPeers.
+// Without it a single silent source peer stalls the acquisition for its whole
+// budget; with it the re-requests fan out to peers that can actually answer.
+func (r *Router) broadenAcquisitionPeers(il *inbound.Ledger) {
+	if newPeer, ok := r.adaptor.PeerWithLedger(il.Hash(), il.Seq(), il.PeerID()); ok {
+		il.AddPeer(newPeer)
+	}
+}
+
+// failInboundAcquisition reaps an acquisition whose retry budget is exhausted.
+// For a consensus-driven acquisition it also tells the engine, so a node pinned
+// in wrongLedger on an unacquirable ledger can drop to a recoverable resync
+// rather than starving the ledger loop into a fatal watchdog abort (issue #985).
+func (r *Router) failInboundAcquisition(il *inbound.Ledger) {
+	hash := il.Hash()
+	reason := il.Reason()
+	r.logger.Warn("inbound ledger acquisition failed",
+		"seq", il.Seq(),
+		"hash", fmt.Sprintf("%x", hash[:8]),
+		"timeouts", il.Timeouts(),
+	)
+	r.fetchTracker.Remove(hash, false)
+	if reason == inbound.ReasonConsensus && r.engine != nil {
+		r.engine.OnLedgerAcquireFailed(consensus.LedgerID(hash))
+	}
+}
+
+// inboundByHashBatch bounds how many missing-node content hashes a single
+// by-hash escalation requests per tree.
+const inboundByHashBatch = 256
+
+// requestAcquisitionNodesByHash performs the by-hash escalation rung: once the
+// acquisition has gone aggressive it asks the peer set for the missing
+// state/tx nodes by content hash (TMGetObjectByHash), the unambiguous fallback
+// for a node on a divergent path that path-based requests cannot place. Replies
+// are served from peers' node stores and routed back through the fetch-pack
+// cache + CheckLocal placement.
+func (r *Router) requestAcquisitionNodesByHash(il *inbound.Ledger) {
+	state, tx := il.TakeByHashRequest(inboundByHashBatch)
+	if len(state) == 0 && len(tx) == 0 {
+		return
+	}
+	peers := il.Peers()
+	hash := il.Hash()
+	seq := il.Seq()
+	r.sendNodesByHash(peers, hash, seq, state, message.ObjectTypeStateNode)
+	r.sendNodesByHash(peers, hash, seq, tx, message.ObjectTypeTransactionNode)
+}
+
+// sendNodesByHash issues a TMGetObjectByHash query for the given node content
+// hashes to every peer in the set.
+func (r *Router) sendNodesByHash(peers []uint64, ledgerHash [32]byte, seq uint32, hashes [][32]byte, objType message.ObjectType) {
+	if len(hashes) == 0 || len(peers) == 0 {
+		return
+	}
+	objs := make([]message.IndexedObject, 0, len(hashes))
+	for i := range hashes {
+		h := hashes[i]
+		objs = append(objs, message.IndexedObject{Hash: h[:], LedgerSeq: seq})
+	}
+	req := &message.GetObjectByHash{
+		ObjType:    objType,
+		Query:      true,
+		Seq:        seq,
+		LedgerHash: ledgerHash[:],
+		Objects:    objs,
+	}
+	frame, err := encodeFrame(message.TypeGetObjects, req)
+	if err != nil {
+		r.logger.Debug("inbound ledger: encode by-hash request failed", "error", err)
+		return
+	}
+	for _, peerID := range peers {
+		if err := r.adaptor.SendToPeer(peerID, frame); err != nil {
+			r.logger.Debug("inbound ledger: by-hash request send failed", "peer", peerID, "error", err)
 		}
 	}
+	r.logger.Info("inbound ledger: requesting nodes by hash",
+		"seq", seq,
+		"hash", fmt.Sprintf("%x", ledgerHash[:4]),
+		"count", len(hashes),
+		"obj_type", objType,
+		"peers", len(peers),
+	)
 }
 
 // completeInboundLedger finalizes an InboundLedger acquisition and adopts the

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -814,7 +814,7 @@ func (r *Router) handleLedgerData(msg *peermanagement.InboundMessage) {
 	}
 
 	if il != nil {
-		if r.handleInboundLedgerData(il, ld) {
+		if r.handleInboundLedgerData(il, ld, uint64(msg.PeerID)) {
 			return
 		}
 		// If handleInboundLedgerData returned false (e.g. GotBase failed),
@@ -853,7 +853,7 @@ func (r *Router) handleLedgerData(msg *peermanagement.InboundMessage) {
 // handleInboundLedgerData feeds LedgerData to the given InboundLedger
 // acquisition (already matched by hash in handleLedgerData). Returns true if
 // the data was consumed by the acquisition.
-func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerData) bool {
+func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerData, peerID uint64) bool {
 	if il == nil {
 		return false
 	}
@@ -869,7 +869,7 @@ func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerD
 		}
 		if err := il.GotBase(ld.Nodes); err != nil {
 			r.logger.Warn("inbound ledger: GotBase failed, falling back", "error", err)
-			r.adaptor.IncPeerBadData(il.PeerID(), "ledger-data-base")
+			r.adaptor.IncPeerBadData(peerID, "ledger-data-base")
 			r.fetchTracker.Remove(il.Hash(), false)
 			return false
 		}
@@ -879,14 +879,15 @@ func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerD
 			return true
 		}
 
-		// Request the missing state and transaction nodes in parallel.
-		r.requestMissingAcquisitionNodes(il)
+		// Re-request the missing state and transaction nodes from the peer
+		// that answered, mirroring rippled trigger(peer) on a reply.
+		r.requestMissingAcquisitionNodes(il, peerID)
 		return true
 
 	case message.LedgerInfoAsNode:
 		if err := il.GotStateNodes(ld.Nodes); err != nil {
 			r.logger.Warn("inbound ledger: GotStateNodes failed", "error", err)
-			r.adaptor.IncPeerBadData(il.PeerID(), "ledger-data-state")
+			r.adaptor.IncPeerBadData(peerID, "ledger-data-state")
 			return true
 		}
 
@@ -895,13 +896,13 @@ func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerD
 			return true
 		}
 
-		r.requestMissingAcquisitionNodes(il)
+		r.requestMissingAcquisitionNodes(il, peerID)
 		return true
 
 	case message.LedgerInfoTxNode:
 		if err := il.GotTransactionNodes(ld.Nodes); err != nil {
 			r.logger.Warn("inbound ledger: GotTransactionNodes failed", "error", err)
-			r.adaptor.IncPeerBadData(il.PeerID(), "ledger-data-tx")
+			r.adaptor.IncPeerBadData(peerID, "ledger-data-tx")
 			return true
 		}
 
@@ -910,22 +911,25 @@ func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerD
 			return true
 		}
 
-		r.requestMissingAcquisitionNodes(il)
+		r.requestMissingAcquisitionNodes(il, peerID)
 		return true
 	}
 
 	return false
 }
 
-// requestMissingAcquisitionNodes asks the acquisition's source peers for the
-// outstanding account-state and transaction tree nodes, requesting both trees
-// in parallel from every peer in the (possibly broadened) set. Each call is a
+// requestMissingAcquisitionNodes asks for the acquisition's outstanding
+// account-state and transaction tree nodes, requesting both trees in parallel.
+// When target is non-zero (the reply path) the re-request goes to just that
+// peer — the one that answered — mirroring rippled's trigger(peer) on a reply;
+// when target is zero (the no-progress timeout path) it fans out to every peer
+// in the (possibly broadened) set, mirroring trigger(nullptr). Each call is a
 // no-op for a tree already complete.
 //
 // Once the acquisition has timed out at least once we mark the requests
 // indirect (query_type=qtINDIRECT) so peers relay them on our behalf,
 // mirroring rippled's InboundLedger::trigger timeouts_ != 0 gate.
-func (r *Router) requestMissingAcquisitionNodes(il *inbound.Ledger) {
+func (r *Router) requestMissingAcquisitionNodes(il *inbound.Ledger, target uint64) {
 	indirect := il.Timeouts() > 0
 	stateIDs := il.NeedsMissingNodeIDs()
 	txIDs := il.NeedsMissingTxNodeIDs()
@@ -933,7 +937,11 @@ func (r *Router) requestMissingAcquisitionNodes(il *inbound.Ledger) {
 		return
 	}
 	hash := il.Hash()
-	for _, peerID := range il.Peers() {
+	peers := il.Peers()
+	if target != 0 {
+		peers = []uint64{target}
+	}
+	for _, peerID := range peers {
 		if len(stateIDs) > 0 {
 			if err := r.adaptor.RequestStateNodes(peerID, hash, stateIDs, indirect); err != nil {
 				r.logger.Warn("inbound ledger: failed to request state nodes", "error", err)
@@ -959,18 +967,25 @@ func (r *Router) escalateAcquisition(il *inbound.Ledger, now time.Time) {
 		return
 	}
 	r.broadenAcquisitionPeers(il)
-	r.requestMissingAcquisitionNodes(il)
+	r.requestMissingAcquisitionNodes(il, 0)
 	r.tryFetchPackEscalation(il)
 	r.requestAcquisitionNodesByHash(il)
 }
 
-// broadenAcquisitionPeers adds a fresh peer that reports the wanted ledger to a
-// stalled acquisition's source set, mirroring rippled InboundLedger::addPeers.
-// Without it a single silent source peer stalls the acquisition for its whole
-// budget; with it the re-requests fan out to peers that can actually answer.
+// acquisitionPeerBroaden bounds how many fresh peers a single no-progress
+// escalation adds to a stalled acquisition's source set, mirroring rippled's
+// peerCountAdd (InboundLedger::addPeers).
+const acquisitionPeerBroaden = 3
+
+// broadenAcquisitionPeers adds up to acquisitionPeerBroaden fresh peers that
+// report the wanted ledger to a stalled acquisition's source set, mirroring
+// rippled InboundLedger::addPeers. Without it a single silent source peer
+// stalls the acquisition for its whole budget; with it the re-requests fan out
+// to several peers that can actually answer. AddPeer dedups against the set and
+// caps it, so an exhausted overlay or a full set simply adds fewer.
 func (r *Router) broadenAcquisitionPeers(il *inbound.Ledger) {
-	if newPeer, ok := r.adaptor.PeerWithLedger(il.Hash(), il.Seq(), il.PeerID()); ok {
-		il.AddPeer(newPeer)
+	for _, peerID := range r.adaptor.PeersWithLedger(il.Hash(), il.Seq(), il.Peers(), acquisitionPeerBroaden) {
+		il.AddPeer(peerID)
 	}
 }
 

--- a/internal/consensus/adaptor/router_catchup_querytype_test.go
+++ b/internal/consensus/adaptor/router_catchup_querytype_test.go
@@ -3,6 +3,7 @@ package adaptor
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
@@ -44,13 +45,11 @@ func (s *acqRecordingSender) stateIndirects() []bool {
 // TestRequestMissingAcquisitionNodes_QueryTypeEscalation pins issue #977's
 // requester-side escalation for the LEGACY inbound-ledger path: a fresh
 // acquisition fetches its outstanding state/tx nodes directly (query_type
-// absent, non-relayable), and once a fetch-pack escalation has been armed —
-// the acquisition's only post-timeout life, since go-xrpl reaps a legacy
-// acquisition on its first timeout — the requests go indirect
-// (query_type=qtINDIRECT) so peers relay them on our behalf. This is the
-// legacy-path analogue of rippled's InboundLedger::trigger timeouts_ != 0 gate
-// (InboundLedger.cpp:531); the symmetric tx-set path is covered by
-// TestTxSetRetry_QueryTypeEscalation.
+// absent, non-relayable), and once it has counted a no-progress timeout the
+// requests go indirect (query_type=qtINDIRECT) so peers relay them on our
+// behalf. This is the legacy-path analogue of rippled's InboundLedger::trigger
+// timeouts_ != 0 gate (InboundLedger.cpp:531); the symmetric tx-set path is
+// covered by TestTxSetRetry_QueryTypeEscalation.
 func TestRequestMissingAcquisitionNodes_QueryTypeEscalation(t *testing.T) {
 	svc := newTestLedgerService(t)
 	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
@@ -72,20 +71,21 @@ func TestRequestMissingAcquisitionNodes_QueryTypeEscalation(t *testing.T) {
 	require.NoError(t, il.GotBase(router.buildLedgerBaseNodes(l)))
 	require.NotEmpty(t, il.NeedsMissingNodeIDs(), "acquisition must have outstanding state nodes")
 
-	// First attempt, before any fetch-pack escalation → direct.
-	require.False(t, il.FetchPackRequested())
+	// First attempt, before any timeout → direct.
+	require.Equal(t, 0, il.Timeouts())
 	router.requestMissingAcquisitionNodes(il)
 	got := rs.stateIndirects()
 	require.Len(t, got, 1, "first attempt must issue one state-node request")
 	assert.False(t, got[0],
 		"first-attempt state-node request must NOT carry query_type (directly routed)")
 
-	// Arming the fetch-pack escalation latches the acquisition into the
-	// aggressive (relayable) mode, mirroring rippled's timeouts_ != 0 gate.
-	il.MarkFetchPackRequested()
+	// A no-progress timer fire counts a timeout, latching the acquisition into
+	// the aggressive (relayable) mode, mirroring rippled's timeouts_ != 0 gate.
+	require.Equal(t, inbound.TimerEscalate, il.OnTimer(time.Now().Add(time.Hour)))
+	require.Greater(t, il.Timeouts(), 0)
 	router.requestMissingAcquisitionNodes(il)
 	got = rs.stateIndirects()
-	require.Len(t, got, 2, "post-escalation attempt must issue a second state-node request")
+	require.Len(t, got, 2, "post-timeout attempt must issue a second state-node request")
 	assert.True(t, got[1],
-		"post-escalation state-node request must carry query_type=qtINDIRECT so peers relay it")
+		"post-timeout state-node request must carry query_type=qtINDIRECT so peers relay it")
 }

--- a/internal/consensus/adaptor/router_catchup_querytype_test.go
+++ b/internal/consensus/adaptor/router_catchup_querytype_test.go
@@ -73,7 +73,7 @@ func TestRequestMissingAcquisitionNodes_QueryTypeEscalation(t *testing.T) {
 
 	// First attempt, before any timeout → direct.
 	require.Equal(t, 0, il.Timeouts())
-	router.requestMissingAcquisitionNodes(il)
+	router.requestMissingAcquisitionNodes(il, 0)
 	got := rs.stateIndirects()
 	require.Len(t, got, 1, "first attempt must issue one state-node request")
 	assert.False(t, got[0],
@@ -83,7 +83,7 @@ func TestRequestMissingAcquisitionNodes_QueryTypeEscalation(t *testing.T) {
 	// the aggressive (relayable) mode, mirroring rippled's timeouts_ != 0 gate.
 	require.Equal(t, inbound.TimerEscalate, il.OnTimer(time.Now().Add(time.Hour)))
 	require.Greater(t, il.Timeouts(), 0)
-	router.requestMissingAcquisitionNodes(il)
+	router.requestMissingAcquisitionNodes(il, 0)
 	got = rs.stateIndirects()
 	require.Len(t, got, 2, "post-timeout attempt must issue a second state-node request")
 	assert.True(t, got[1],

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -21,11 +21,12 @@ import (
 
 // mockEngine records calls from the router for testing.
 type mockEngine struct {
-	mu          sync.Mutex
-	proposals   []*consensus.Proposal
-	validations []*consensus.Validation
-	txSets      []consensus.TxSetID
-	ledgers     []consensus.LedgerID
+	mu            sync.Mutex
+	proposals     []*consensus.Proposal
+	validations   []*consensus.Validation
+	txSets        []consensus.TxSetID
+	ledgers       []consensus.LedgerID
+	acquireFailed []consensus.LedgerID
 }
 
 func (m *mockEngine) Start(context.Context) error              { return nil }
@@ -47,10 +48,22 @@ func (m *mockEngine) OnLedger(id consensus.LedgerID, _ []byte) error {
 	return nil
 }
 
+func (m *mockEngine) OnLedgerAcquireFailed(id consensus.LedgerID) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.acquireFailed = append(m.acquireFailed, id)
+}
+
 func (m *mockEngine) getLedgers() []consensus.LedgerID {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return append([]consensus.LedgerID(nil), m.ledgers...)
+}
+
+func (m *mockEngine) getAcquireFailed() []consensus.LedgerID {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]consensus.LedgerID(nil), m.acquireFailed...)
 }
 
 func (m *mockEngine) OnProposal(p *consensus.Proposal, _ uint64) error {

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -251,6 +251,22 @@ func (s *OverlaySender) PeerWithLedger(target [32]byte, seq uint32, exclude uint
 	return uint64(id), ok
 }
 
+// PeersWithLedger forwards to Overlay.PeersWithLedger: selects up to max
+// peers that can serve ledger (target, seq), excluding `excluded`, to
+// broaden a stalled acquisition's source set.
+func (s *OverlaySender) PeersWithLedger(target [32]byte, seq uint32, excluded []uint64, max int) []uint64 {
+	ex := make([]peermanagement.PeerID, len(excluded))
+	for i, id := range excluded {
+		ex[i] = peermanagement.PeerID(id)
+	}
+	ids := s.overlay.PeersWithLedger(target, seq, ex, max)
+	out := make([]uint64, len(ids))
+	for i, id := range ids {
+		out[i] = uint64(id)
+	}
+	return out
+}
+
 // PeerWithTxSet forwards to Overlay.PeerWithTxSet: selects a peer that
 // advertised tx-set root target (excluding `exclude`) to relay an
 // unsatisfiable liTS_CANDIDATE GetLedger to.

--- a/internal/consensus/adaptor/sender_cov_test.go
+++ b/internal/consensus/adaptor/sender_cov_test.go
@@ -190,8 +190,11 @@ func (f *snd_fakeOverlay) ShouldShedLedgerRequest(peerID uint64, loadedLocal boo
 }
 
 func (f *snd_fakeOverlay) PeerWithLedger([32]byte, uint32, uint64) (uint64, bool) { return 0, false }
-func (f *snd_fakeOverlay) PeerWithTxSet([32]byte, uint64) (uint64, bool)          { return 0, false }
-func (f *snd_fakeOverlay) NotePeerHasTxSet(uint64, [32]byte)                      {}
+func (f *snd_fakeOverlay) PeersWithLedger([32]byte, uint32, []uint64, int) []uint64 {
+	return nil
+}
+func (f *snd_fakeOverlay) PeerWithTxSet([32]byte, uint64) (uint64, bool) { return 0, false }
+func (f *snd_fakeOverlay) NotePeerHasTxSet(uint64, [32]byte)             {}
 
 func snd_newAdaptorWithFake(t *testing.T, fake *snd_fakeOverlay) *Adaptor {
 	t.Helper()

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -39,6 +39,13 @@ type Engine interface {
 	// OnLedger handles receiving a ledger we were missing.
 	OnLedger(id LedgerID, ledger []byte) error
 
+	// OnLedgerAcquireFailed reports that an inbound acquisition of the given
+	// ledger failed cleanly after exhausting its retry budget. A node pinned in
+	// wrongLedger mode on an unacquirable ledger uses this to un-pin and, after
+	// repeated failures, drop to a degraded resync mode — so it keeps closing
+	// ledgers instead of starving the stall watchdog into a fatal os.Exit.
+	OnLedgerAcquireFailed(id LedgerID)
+
 	// State returns the current consensus state.
 	State() *RoundState
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -164,6 +164,18 @@ type Engine struct {
 	// while in ModeWrongLedger. Prevents spamming handleWrongLedger.
 	wrongLedgerID consensus.LedgerID
 
+	// wrongLedgerAcquireFailures counts how many times an inbound acquisition
+	// of wrongLedgerID has failed cleanly (retry budget exhausted). Once it
+	// reaches wrongLedgerAcquireMaxFailures the engine drops to a degraded
+	// resync rather than staying frozen on an unacquirable ledger.
+	wrongLedgerAcquireFailures int
+
+	// degradedResyncUntil, when in the future, suppresses re-pinning
+	// ModeWrongLedger after a degraded-resync drop so the node keeps closing
+	// ledgers (observer-mode advancement) — and feeding the stall watchdog's
+	// ledger heartbeat — while it retries acquisition (issue #985 part C).
+	degradedResyncUntil time.Time
+
 	// lastSignTime is the monotonic floor for emitted validation
 	// SignTime. If the adaptor clock regresses (NTP step, leap-second
 	// correction, VM pause/resume), sendValidation bumps SignTime to
@@ -1243,6 +1255,8 @@ func (e *Engine) OnLedger(id consensus.LedgerID, ledger []byte) error {
 			slog.Info("Acquired missing ledger, restarting round",
 				"seq", l.Seq(), "hash", fmt.Sprintf("%x", lID[:8]))
 			e.prevLedger = l
+			e.wrongLedgerID = consensus.LedgerID{}
+			e.wrongLedgerAcquireFailures = 0
 			if e.state != nil {
 				e.state.HaveCorrectLCL = true
 			}
@@ -2079,6 +2093,7 @@ func (e *Engine) handleWrongLedger(netLedgerID consensus.LedgerID, target consen
 		)
 		e.prevLedger = newLedger
 		e.wrongLedgerID = consensus.LedgerID{}
+		e.wrongLedgerAcquireFailures = 0
 		if e.state != nil {
 			e.state.HaveCorrectLCL = true
 		}
@@ -2090,7 +2105,22 @@ func (e *Engine) handleWrongLedger(netLedgerID consensus.LedgerID, target consen
 			e.adaptor.GetOperatingMode() == consensus.OpModeFull
 		e.startRoundLocked(nextRound, proposing, true)
 	} else {
-		// Not found — enter wrong ledger mode and request from peers
+		// Not found — request from peers. While inside the degraded-resync
+		// cooldown (a recent acquisition of this ledger exhausted its retry
+		// budget, issue #985 part C), stay in the current advancing mode rather
+		// than re-pinning ModeWrongLedger: a pinned node closes no ledgers, so
+		// it would starve the stall watchdog's ledger heartbeat into a fatal
+		// os.Exit. Observer-mode advancement keeps ledgers closing while we
+		// keep retrying acquisition.
+		e.adaptor.RequestLedger(netLedgerID)
+		if e.adaptor.Now().Before(e.degradedResyncUntil) {
+			slog.Info("Retrying network ledger in degraded resync",
+				"t", "consensus",
+				"event", "wrong-lcl-degraded-retry",
+				"hash", fmt.Sprintf("%x", netLedgerID[:8]),
+			)
+			return
+		}
 		slog.Info("Cannot acquire network ledger, entering wrongLedger mode",
 			"t", "consensus",
 			"event", "wrong-lcl",
@@ -2101,7 +2131,68 @@ func (e *Engine) handleWrongLedger(netLedgerID consensus.LedgerID, target consen
 		}
 		e.wrongLedgerID = netLedgerID
 		e.setMode(consensus.ModeWrongLedger)
-		e.adaptor.RequestLedger(netLedgerID)
+	}
+}
+
+// wrongLedgerAcquireMaxFailures bounds how many clean acquisition failures of
+// the pinned wrongLedger are tolerated before the engine drops to a degraded
+// resync, and degradedResyncCooldown is how long it then stays unpinned and
+// advancing before allowing a fresh wrongLedger pin.
+const (
+	wrongLedgerAcquireMaxFailures = 3
+	degradedResyncCooldown        = 20 * time.Second
+)
+
+// OnLedgerAcquireFailed reports that an inbound acquisition of id failed cleanly
+// after exhausting its retry budget. If the engine is pinned in wrongLedger
+// mode on id it must not stay frozen — a frozen wrongLedger closes no ledgers,
+// eventually tripping the stall watchdog into a fatal os.Exit. The first few
+// failures simply un-pin so checkLedger re-resolves the (possibly advanced)
+// network ledger and re-issues the acquisition with a fresh peer set / by-hash
+// escalation; persistent failure drops the node to a degraded observing/tracking
+// resync so ledger closes resume while recovery keeps being attempted.
+func (e *Engine) OnLedgerAcquireFailed(id consensus.LedgerID) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.mode != consensus.ModeWrongLedger || e.wrongLedgerID != id {
+		return
+	}
+
+	e.wrongLedgerAcquireFailures++
+	// Un-pin so the next checkLedger re-resolves and re-requests instead of
+	// returning early on the stale pin forever.
+	e.wrongLedgerID = consensus.LedgerID{}
+
+	if e.wrongLedgerAcquireFailures < wrongLedgerAcquireMaxFailures {
+		slog.Warn("wrongLedger acquisition failed; will re-attempt",
+			"t", "consensus",
+			"event", "wrong-lcl-retry",
+			"hash", fmt.Sprintf("%x", id[:8]),
+			"failures", e.wrongLedgerAcquireFailures,
+		)
+		return
+	}
+
+	// Persistent failure: the validated ledger is unacquirable from any peer.
+	// Drop to a degraded resync. ModeObserving lets rounds advance (observer-mode
+	// advancement), so ledger closes — and the watchdog ledger heartbeat — resume
+	// while checkLedger keeps retrying recovery each round; demote OpModeFull so
+	// we stop asserting we are fully synced.
+	slog.Warn("wrongLedger ledger unacquirable; dropping to degraded resync",
+		"t", "consensus",
+		"event", "wrong-lcl-degraded",
+		"hash", fmt.Sprintf("%x", id[:8]),
+		"failures", e.wrongLedgerAcquireFailures,
+	)
+	e.wrongLedgerAcquireFailures = 0
+	e.degradedResyncUntil = e.adaptor.Now().Add(degradedResyncCooldown)
+	if e.state != nil {
+		e.state.HaveCorrectLCL = false
+	}
+	e.setMode(consensus.ModeObserving)
+	if e.adaptor.GetOperatingMode() == consensus.OpModeFull {
+		e.adaptor.SetOperatingMode(consensus.OpModeTracking)
 	}
 }
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -173,7 +173,9 @@ type Engine struct {
 	// degradedResyncUntil, when in the future, suppresses re-pinning
 	// ModeWrongLedger after a degraded-resync drop so the node keeps closing
 	// ledgers (observer-mode advancement) — and feeding the stall watchdog's
-	// ledger heartbeat — while it retries acquisition (issue #985 part C).
+	// ledger heartbeat — while it retries acquisition (issue #985 part C). The
+	// suppression is engine-global: while the window is open every wrongLedger
+	// pin is skipped, not just one for the hash that degraded.
 	degradedResyncUntil time.Time
 
 	// lastSignTime is the monotonic floor for emitted validation
@@ -2146,10 +2148,11 @@ const (
 // OnLedgerAcquireFailed reports that an inbound acquisition of id failed cleanly
 // after exhausting its retry budget. If the engine is pinned in wrongLedger
 // mode on id it must not stay frozen — a frozen wrongLedger closes no ledgers,
-// eventually tripping the stall watchdog into a fatal os.Exit. The first few
-// failures simply un-pin so checkLedger re-resolves the (possibly advanced)
-// network ledger and re-issues the acquisition with a fresh peer set / by-hash
-// escalation; persistent failure drops the node to a degraded observing/tracking
+// eventually tripping the stall watchdog into a fatal os.Exit. Each failure
+// short of wrongLedgerAcquireMaxFailures simply un-pins so checkLedger
+// re-resolves the (possibly advanced) network ledger and re-issues the
+// acquisition with a fresh peer set / by-hash escalation; reaching that limit
+// drops the node to a degraded observing/tracking
 // resync so ledger closes resume while recovery keeps being attempted.
 func (e *Engine) OnLedgerAcquireFailed(id consensus.LedgerID) {
 	e.mu.Lock()

--- a/internal/consensus/rcl/engine_acquire_failed_test.go
+++ b/internal/consensus/rcl/engine_acquire_failed_test.go
@@ -1,0 +1,74 @@
+package rcl
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+)
+
+// TestEngine_OnLedgerAcquireFailed_UnpinsThenDegrades pins issue #985 part C:
+// repeated clean acquisition failures of the pinned wrongLedger first un-pin
+// (so checkLedger re-resolves and re-requests) and finally drop the node to a
+// degraded observing/tracking resync, so it keeps closing ledgers instead of
+// starving the stall watchdog into a fatal os.Exit.
+func TestEngine_OnLedgerAcquireFailed_UnpinsThenDegrades(t *testing.T) {
+	a := newMockAdaptor()
+	e := NewEngine(a, DefaultConfig())
+	id := consensus.LedgerID{0xAB}
+
+	// Each production failure is preceded by checkLedger re-pinning the target;
+	// mimic that round-trip. The first failures un-pin without degrading.
+	for i := 1; i < wrongLedgerAcquireMaxFailures; i++ {
+		e.mode = consensus.ModeWrongLedger
+		e.wrongLedgerID = id
+		e.OnLedgerAcquireFailed(id)
+
+		if e.mode != consensus.ModeWrongLedger {
+			t.Fatalf("failure %d must keep retrying in wrongLedger, got mode %v", i, e.mode)
+		}
+		if e.wrongLedgerID != (consensus.LedgerID{}) {
+			t.Fatalf("failure %d must clear the pin so checkLedger re-resolves and re-requests", i)
+		}
+	}
+
+	// The final failure drops to a degraded resync.
+	e.mode = consensus.ModeWrongLedger
+	e.wrongLedgerID = id
+	e.OnLedgerAcquireFailed(id)
+
+	if e.mode != consensus.ModeObserving {
+		t.Fatalf("persistent failure must drop to ModeObserving, got %v", e.mode)
+	}
+	if a.GetOperatingMode() != consensus.OpModeTracking {
+		t.Fatalf("persistent failure must demote OpModeFull→Tracking, got %v", a.GetOperatingMode())
+	}
+	if !e.adaptor.Now().Before(e.degradedResyncUntil) {
+		t.Fatal("degraded-resync cooldown must be armed so re-pinning is suppressed")
+	}
+	if e.wrongLedgerAcquireFailures != 0 {
+		t.Fatalf("the failure counter must reset on degrade, got %d", e.wrongLedgerAcquireFailures)
+	}
+}
+
+// TestEngine_OnLedgerAcquireFailed_IgnoredWhenNotPinned confirms the signal is a
+// no-op unless the engine is pinned in wrongLedger on exactly that ledger, so a
+// stale or unrelated acquisition failure can't disturb a healthy node.
+func TestEngine_OnLedgerAcquireFailed_IgnoredWhenNotPinned(t *testing.T) {
+	a := newMockAdaptor()
+	e := NewEngine(a, DefaultConfig())
+
+	// Not in wrongLedger mode.
+	e.mode = consensus.ModeObserving
+	e.OnLedgerAcquireFailed(consensus.LedgerID{0xAB})
+	if e.mode != consensus.ModeObserving || e.wrongLedgerAcquireFailures != 0 {
+		t.Fatal("a failure must be ignored when the engine is not pinned in wrongLedger")
+	}
+
+	// Pinned, but on a different ledger than the one that failed.
+	e.mode = consensus.ModeWrongLedger
+	e.wrongLedgerID = consensus.LedgerID{0x01}
+	e.OnLedgerAcquireFailed(consensus.LedgerID{0x02})
+	if e.wrongLedgerID != (consensus.LedgerID{0x01}) || e.wrongLedgerAcquireFailures != 0 {
+		t.Fatal("a failure for a different ledger must not disturb the current pin")
+	}
+}

--- a/internal/ledger/inbound/fetchpack_test.go
+++ b/internal/ledger/inbound/fetchpack_test.go
@@ -104,8 +104,8 @@ func TestCheckLocal_NoSourceNoProgress(t *testing.T) {
 	}
 }
 
-// TestFetchPackRequested_OneShot pins the one-shot escalation flag and its
-// deadline extension.
+// TestFetchPackRequested_OneShot pins the one-shot escalation flag so the
+// router escalates a stalled acquisition to a fetch-pack at most once.
 func TestFetchPackRequested_OneShot(t *testing.T) {
 	t.Parallel()
 	il := New([32]byte{1}, 5, 7, discardLogger())
@@ -115,10 +115,6 @@ func TestFetchPackRequested_OneShot(t *testing.T) {
 	il.MarkFetchPackRequested()
 	if !il.FetchPackRequested() {
 		t.Fatal("MarkFetchPackRequested was not recorded")
-	}
-	// Extending the deadline must clear a timed-out state at the moment of marking.
-	if il.IsTimedOut() {
-		t.Error("acquisition still reports timed-out immediately after deadline extension")
 	}
 }
 

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -7,6 +7,7 @@ package inbound
 import (
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
 	"time"
 
@@ -17,7 +18,27 @@ import (
 	"github.com/LeJamon/go-xrpl/shamap"
 )
 
-const acquisitionTimeout = 10 * time.Second
+// Acquisition retry-loop tuning, ported from rippled's InboundLedger
+// (InboundLedger.cpp:46-74). The loop fires on a timer rather than only on
+// peer replies, so a silent or dropped-reply peer cannot stall it: every
+// acquireTimerInterval the acquisition checks whether it made forward progress
+// since the last fire and, if not, counts a timeout and escalates.
+const (
+	// acquireTimerInterval is how often OnTimer evaluates progress
+	// (rippled ledgerAcquireTimeout).
+	acquireTimerInterval = 3 * time.Second
+	// ledgerTimeoutRetriesMax bounds no-progress timer fires before the
+	// acquisition fails cleanly (rippled ledgerTimeoutRetriesMax).
+	ledgerTimeoutRetriesMax = 6
+	// ledgerBecomeAggressiveThreshold is the no-progress timeout count past
+	// which the acquisition abandons path-based requests and asks every peer
+	// for the missing nodes by content hash (rippled
+	// ledgerBecomeAggressiveThreshold).
+	ledgerBecomeAggressiveThreshold = 4
+	// maxAcquisitionPeers caps the broadened source-peer set so a stalled
+	// acquisition fans its re-requests across peers without unbounded growth.
+	maxAcquisitionPeers = 8
+)
 
 // hardMaxReplyNodes is rippled's per-message cap on the nodes a peer may pack
 // into a single TMLedgerData reply (Tuning::hardMaxReplyNodes, Tuning.h:42).
@@ -63,6 +84,23 @@ const (
 	StateFailed                 // Unrecoverable error
 )
 
+// TimerAction tells the router what to do after an OnTimer evaluation,
+// mirroring the dispatch rippled's InboundLedger::onTimer performs inline.
+type TimerAction int
+
+const (
+	// TimerNone: the timer was not due yet, or the acquisition made progress
+	// this interval — nothing for the caller to do.
+	TimerNone TimerAction = iota
+	// TimerEscalate: a no-progress interval elapsed and the retry budget is
+	// not yet exhausted — broaden peers and re-request the missing nodes
+	// (and, once aggressive, escalate to a by-hash fetch).
+	TimerEscalate
+	// TimerFailed: the retry budget is exhausted — the acquisition is now
+	// StateFailed and the caller must reap it.
+	TimerFailed
+)
+
 // Ledger manages the acquisition of a single ledger from a peer.
 // It progresses through: WantBase → WantState → Complete. Like rippled's
 // InboundLedger, it fetches the account-state and transaction trees in
@@ -70,12 +108,13 @@ const (
 // both have been fully fetched (rippled InboundLedger.cpp:734,946).
 //
 // Field lock guarantees:
-//   - hash, seq, peerID, clock, logger are set at construction and never
-//     mutated thereafter; the accessors below (Hash, Seq, PeerID) read them
-//     without taking mu and are safe under concurrent State() callers.
-//   - header, stateMap, txMap, haveState, haveTx, state, err, created,
-//     fetchPackRequested are written under mu and must be read through
-//     accessors that take mu (State, IsTimedOut, GotBase, etc.).
+//   - hash, seq, logger are set at construction and never mutated thereafter;
+//     the accessors below (Hash, Seq) read them without taking mu and are safe
+//     under concurrent State() callers.
+//   - peers, header, stateMap, txMap, haveState, haveTx, state, err, the
+//     retry-loop fields, and fetchPackRequested are written under mu and must
+//     be read through accessors that take mu (State, PeerID, OnTimer, GotBase,
+//     etc.).
 type Ledger struct {
 	hash      [32]byte
 	seq       uint32
@@ -84,14 +123,28 @@ type Ledger struct {
 	txMap     *shamap.SHAMap // nil when the transaction tree is empty (TxHash zero)
 	haveState bool
 	haveTx    bool
-	peerID    uint64
+	peers     []uint64 // source peers, broadened on no-progress; peers[0] is the original
 	reason    Reason
 	state     State
 	err       error
-	created   time.Time
-	clock     Clock
 	mu        sync.Mutex
 	logger    *slog.Logger
+
+	// Retry-loop bookkeeping ported from rippled's TimeoutCounter. lastTimer
+	// is when OnTimer last evaluated; progress records a fresh node attach
+	// since then; timeouts counts no-progress intervals toward the failure
+	// budget; byHash latches eligibility for a by-hash escalation on the next
+	// aggressive request. All guarded by mu.
+	lastTimer time.Time
+	progress  bool
+	timeouts  int
+	byHash    bool
+
+	// Rejection diagnostics, surfaced on the no-progress tick so a stuck
+	// acquisition names which node it cannot place and why (the signal the
+	// swallowed Debug logs hid). Guarded by mu.
+	rejectCount   int
+	lastRejectErr string
 
 	// fetchPackRequested records that the router escalated this stalled
 	// acquisition to a fetch-pack (at most once). Guarded by mu.
@@ -102,13 +155,12 @@ type Ledger struct {
 // The acquisition reason defaults to ReasonConsensus.
 func New(hash [32]byte, seq uint32, peerID uint64, logger *slog.Logger) *Ledger {
 	return &Ledger{
-		hash:    hash,
-		seq:     seq,
-		peerID:  peerID,
-		state:   StateWantBase,
-		clock:   SystemClock,
-		created: SystemClock.Now(),
-		logger:  logger,
+		hash:      hash,
+		seq:       seq,
+		peers:     []uint64{peerID},
+		state:     StateWantBase,
+		lastTimer: SystemClock.Now(),
+		logger:    logger,
 	}
 }
 
@@ -125,13 +177,6 @@ func (l *Ledger) Reason() Reason {
 	return l.reason
 }
 
-// IsTimedOut returns true if the acquisition has been running too long.
-func (l *Ledger) IsTimedOut() bool {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	return l.state != StateComplete && l.state != StateFailed && l.clock.Now().Sub(l.created) > acquisitionTimeout
-}
-
 // State returns the current acquisition state.
 func (l *Ledger) State() State {
 	l.mu.Lock()
@@ -139,9 +184,148 @@ func (l *Ledger) State() State {
 	return l.state
 }
 
-// PeerID returns the peer we're fetching from.
+// PeerID returns the primary source peer (the one the acquisition started on).
 func (l *Ledger) PeerID() uint64 {
-	return l.peerID
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.peers) == 0 {
+		return 0
+	}
+	return l.peers[0]
+}
+
+// Peers returns a snapshot of the acquisition's current source-peer set.
+func (l *Ledger) Peers() []uint64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]uint64(nil), l.peers...)
+}
+
+// AddPeer adds peerID to the source set (capped at maxAcquisitionPeers),
+// mirroring rippled's InboundLedger::addPeers broadening a stalled
+// acquisition's peer set. Returns true if it was newly added.
+func (l *Ledger) AddPeer(peerID uint64) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.peers) >= maxAcquisitionPeers || slices.Contains(l.peers, peerID) {
+		return false
+	}
+	l.peers = append(l.peers, peerID)
+	return true
+}
+
+// Timeouts returns the number of no-progress timer intervals counted so far,
+// mirroring rippled's timeouts_. The router gates qtINDIRECT relaying on
+// timeouts > 0, matching InboundLedger::trigger.
+func (l *Ledger) Timeouts() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.timeouts
+}
+
+// OnTimer advances the acquisition's retry loop, mirroring rippled's
+// TimeoutCounter::invokeOnTimer + InboundLedger::onTimer. It is a no-op until
+// acquireTimerInterval has elapsed since the last fire, so it can be polled
+// from the router's maintenance tick. On a due fire it either records that
+// forward progress was made this interval (and keeps relying on the
+// reply-driven path) or counts a no-progress timeout; once the budget is
+// exhausted the acquisition transitions cleanly to StateFailed instead of
+// re-arming the same stall forever. The returned TimerAction tells the router
+// whether to reap (TimerFailed), escalate (TimerEscalate), or do nothing.
+func (l *Ledger) OnTimer(now time.Time) TimerAction {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.state == StateComplete || l.state == StateFailed {
+		return TimerNone
+	}
+	if now.Sub(l.lastTimer) < acquireTimerInterval {
+		return TimerNone
+	}
+	l.lastTimer = now
+
+	if l.progress {
+		// rippled onTimer(true): progress this interval — reset and keep going
+		// on the reply-driven path without escalating or counting a timeout.
+		l.progress = false
+		return TimerNone
+	}
+
+	l.timeouts++
+	if l.timeouts > ledgerTimeoutRetriesMax {
+		l.state = StateFailed
+		l.err = fmt.Errorf("inbound ledger %d: acquisition failed after %d timeouts (have_state=%t have_tx=%t last_reject=%q)",
+			l.seq, l.timeouts, l.haveState, l.haveTx, l.lastRejectErr)
+		l.logger.Warn("inbound ledger: acquisition failed, retry budget exhausted",
+			"seq", l.seq,
+			"hash", fmt.Sprintf("%x", l.hash[:8]),
+			"timeouts", l.timeouts,
+			"have_state", l.haveState,
+			"have_tx", l.haveTx,
+			"reject_count", l.rejectCount,
+			"last_reject", l.lastRejectErr,
+		)
+		return TimerFailed
+	}
+
+	// No progress, budget remains: arm a by-hash escalation and surface the
+	// diagnostic that the swallowed Debug-level rejections used to hide.
+	l.byHash = true
+	l.logger.Warn("inbound ledger: no acquisition progress",
+		"seq", l.seq,
+		"hash", fmt.Sprintf("%x", l.hash[:8]),
+		"timeouts", l.timeouts,
+		"have_state", l.haveState,
+		"have_tx", l.haveTx,
+		"reject_count", l.rejectCount,
+		"last_reject", l.lastRejectErr,
+	)
+	return TimerEscalate
+}
+
+// markProgressLocked records that a fresh node was attached this interval, so
+// the next OnTimer fire treats the acquisition as progressing rather than
+// timing out (rippled sets progress_ on a useful received node). Caller holds mu.
+func (l *Ledger) markProgressLocked() {
+	l.progress = true
+}
+
+// TakeByHashRequest returns the content hashes of up to max still-missing nodes
+// per outstanding tree once the acquisition has gone aggressive (more
+// no-progress timeouts than ledgerBecomeAggressiveThreshold), consuming the
+// by-hash latch. Mirrors rippled InboundLedger::trigger's getNeededHashes
+// branch, which past the aggressive threshold abandons path-based requests and
+// asks every peer for the missing nodes by content hash — unambiguous
+// placement for a node on a divergent path that path-based requests cannot
+// resolve. Returns nil sets when not yet aggressive.
+func (l *Ledger) TakeByHashRequest(max int) (state, tx [][32]byte) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if !l.byHash || l.timeouts <= ledgerBecomeAggressiveThreshold || l.state != StateWantState {
+		return nil, nil
+	}
+	l.byHash = false // consumed; re-armed by the next no-progress OnTimer
+	if !l.haveState && l.stateMap != nil {
+		state = neededHashes(l.stateMap, max)
+	}
+	if !l.haveTx && l.txMap != nil {
+		tx = neededHashes(l.txMap, max)
+	}
+	return state, tx
+}
+
+// neededHashes collects the content hashes of up to max missing nodes in m.
+func neededHashes(m *shamap.SHAMap, max int) [][32]byte {
+	missing := m.GetMissingNodes(max, nil)
+	if len(missing) == 0 {
+		return nil
+	}
+	out := make([][32]byte, 0, len(missing))
+	for i := range missing {
+		out = append(out, missing[i].Hash)
+	}
+	return out
 }
 
 // Seq returns the ledger sequence being acquired.
@@ -316,6 +500,8 @@ func (l *Ledger) GotStateNodes(nodes []message.LedgerNode) error {
 		}
 		fresh, err := l.stateMap.AddKnownNodeByID(parsedID, node.NodeData)
 		if err != nil {
+			l.rejectCount++
+			l.lastRejectErr = err.Error()
 			l.logger.Debug("inbound ledger: state node rejected",
 				"node_id", fmt.Sprintf("%x", node.NodeID),
 				"node_data_len", len(node.NodeData),
@@ -325,6 +511,10 @@ func (l *Ledger) GotStateNodes(nodes []message.LedgerNode) error {
 		if fresh {
 			added++
 		}
+	}
+
+	if added > 0 {
+		l.markProgressLocked()
 	}
 
 	complete := l.stateMap.IsComplete()
@@ -383,6 +573,8 @@ func (l *Ledger) GotTransactionNodes(nodes []message.LedgerNode) error {
 		}
 		fresh, err := l.txMap.AddKnownNodeByID(parsedID, node.NodeData)
 		if err != nil {
+			l.rejectCount++
+			l.lastRejectErr = err.Error()
 			l.logger.Debug("inbound ledger: tx node rejected",
 				"node_id", fmt.Sprintf("%x", node.NodeID),
 				"node_data_len", len(node.NodeData),
@@ -392,6 +584,10 @@ func (l *Ledger) GotTransactionNodes(nodes []message.LedgerNode) error {
 		if fresh {
 			added++
 		}
+	}
+
+	if added > 0 {
+		l.markProgressLocked()
 	}
 
 	l.logger.Info("inbound ledger: added tx nodes",
@@ -467,9 +663,8 @@ func missingNodeIDs(m *shamap.SHAMap) [][]byte {
 
 // Snapshot is a point-in-time view of an acquisition's progress, used by the
 // fetch_info RPC (mirrors the per-ledger fields rippled emits from
-// InboundLedger::getJson). The acquisition reaps on first timeout rather than
-// counting re-request cycles, so the timeouts field is always reported as zero,
-// and it fetches from a single source peer (Peers == 1 while in flight).
+// InboundLedger::getJson). Timeouts is the live no-progress retry count, and
+// Peers is the current broadened source-peer set size.
 type Snapshot struct {
 	Hash             [32]byte
 	Seq              uint32
@@ -478,7 +673,7 @@ type Snapshot struct {
 	HaveTransactions bool
 	Complete         bool
 	Failed           bool
-	TimedOut         bool
+	Timeouts         int
 	Peers            int
 	NeededState      [][32]byte // hashes of up to missingNodeBatch missing state nodes
 	NeededTx         [][32]byte // hashes of up to missingNodeBatch missing tx nodes
@@ -498,9 +693,8 @@ func (l *Ledger) Snapshot() Snapshot {
 		HaveTransactions: l.haveTx,
 		Complete:         l.state == StateComplete,
 		Failed:           l.state == StateFailed,
-		TimedOut: l.state != StateComplete && l.state != StateFailed &&
-			l.clock.Now().Sub(l.created) > acquisitionTimeout,
-		Peers: 1, // classic acquisition fetches from a single source peer (l.peerID)
+		Timeouts:         l.timeouts,
+		Peers:            len(l.peers),
 	}
 
 	if !l.haveState && l.stateMap != nil {
@@ -559,16 +753,15 @@ func (l *Ledger) FetchPackRequested() bool {
 	return l.fetchPackRequested
 }
 
-// MarkFetchPackRequested records that a fetch-pack was requested and grants
-// one more acquisitionTimeout window for the reply to arrive and complete the
-// acquisition locally via CheckLocal. Mirrors rippled arming an aggressive
-// fetch-pack fallback (LedgerMaster::getFetchPack) without immediately
-// abandoning the InboundLedger.
+// MarkFetchPackRequested records that a fetch-pack was requested for this
+// acquisition, so the router escalates at most once. The acquisition stays in
+// flight under its OnTimer retry budget while the reply arrives and completes
+// it locally via CheckLocal. Mirrors rippled arming an aggressive fetch-pack
+// fallback (LedgerMaster::getFetchPack) without abandoning the InboundLedger.
 func (l *Ledger) MarkFetchPackRequested() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.fetchPackRequested = true
-	l.created = l.clock.Now()
 }
 
 // CheckLocal attempts to complete the still-outstanding trees from a local
@@ -612,6 +805,7 @@ func (l *Ledger) CheckLocal(fetch func(hash [32]byte) ([]byte, bool)) bool {
 		}
 	}
 	if progressed {
+		l.markProgressLocked()
 		l.recomputeComplete()
 	}
 	return progressed

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -108,9 +108,9 @@ const (
 // both have been fully fetched (rippled InboundLedger.cpp:734,946).
 //
 // Field lock guarantees:
-//   - hash, seq, logger are set at construction and never mutated thereafter;
-//     the accessors below (Hash, Seq) read them without taking mu and are safe
-//     under concurrent State() callers.
+//   - hash, seq, reason, logger are set at construction and never mutated
+//     thereafter; the accessors below (Hash, Seq, Reason) read them without
+//     taking mu and are safe under concurrent State() callers.
 //   - peers, header, stateMap, txMap, haveState, haveTx, state, err, the
 //     retry-loop fields, and fetchPackRequested are written under mu and must
 //     be read through accessors that take mu (State, PeerID, OnTimer, GotBase,
@@ -134,7 +134,8 @@ type Ledger struct {
 	// is when OnTimer last evaluated; progress records a fresh node attach
 	// since then; timeouts counts no-progress intervals toward the failure
 	// budget; byHash latches eligibility for a by-hash escalation on the next
-	// aggressive request. All guarded by mu.
+	// aggressive request (false at construction — the first no-progress OnTimer
+	// sets it, well before the aggressive gate opens). All guarded by mu.
 	lastTimer time.Time
 	progress  bool
 	timeouts  int

--- a/internal/ledger/inbound/inbound_test.go
+++ b/internal/ledger/inbound/inbound_test.go
@@ -6,10 +6,8 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
-	"github.com/LeJamon/go-xrpl/internal/ledger/inbound/inboundtest"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
@@ -326,26 +324,5 @@ func TestGotBase_AdoptsSeqWhenZero(t *testing.T) {
 	}
 	if il.seq != 500 {
 		t.Fatalf("seq = %d, want 500 adopted from header", il.seq)
-	}
-}
-
-// TestLedger_IsTimedOut_InjectedClock drives the acquisition timeout off an
-// injected Clock so the elapsed-time branch is exercised without a wall-clock
-// wait — the determinism the classic Ledger lacked before clock injection.
-func TestLedger_IsTimedOut_InjectedClock(t *testing.T) {
-	var hash [32]byte
-	hash[0] = 0x42
-	il := New(hash, 7, 1, slog.New(slog.NewTextHandler(io.Discard, nil)))
-
-	fc := inboundtest.NewFakeClock(time.Unix(1_700_000_000, 0))
-	il.clock = fc
-	il.created = fc.Now()
-
-	if il.IsTimedOut() {
-		t.Fatal("fresh acquisition must not be timed out")
-	}
-	fc.Advance(acquisitionTimeout + time.Second)
-	if !il.IsTimedOut() {
-		t.Fatalf("acquisition must time out once the injected clock passes %s", acquisitionTimeout)
 	}
 }

--- a/internal/ledger/inbound/onloop_test.go
+++ b/internal/ledger/inbound/onloop_test.go
@@ -1,0 +1,178 @@
+package inbound
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+// incompleteStateAcquisition builds an acquisition seeded with a header + state
+// root for a tree with several branches, leaving it in StateWantState with
+// outstanding missing state nodes — the shape the retry loop operates on.
+func incompleteStateAcquisition(t *testing.T) *Ledger {
+	t.Helper()
+	source := shamap.New(shamap.TypeState)
+	for branch := range byte(8) {
+		for i := range byte(4) {
+			var key [32]byte
+			key[0] = (branch << 4) | i
+			key[31] = 0xA5
+			if err := source.Put(key, make([]byte, 12)); err != nil {
+				t.Fatalf("put: %v", err)
+			}
+		}
+	}
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("source hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("serialize root: %v", err)
+	}
+	hdrBytes, ledgerHash := encodeHeader(header.LedgerHeader{LedgerIndex: 100, AccountHash: rootHash})
+
+	il := New(ledgerHash, 100, 7, discardLogger())
+	if err := il.GotBase([]message.LedgerNode{{NodeData: hdrBytes}, {NodeData: rootData}}); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+	if il.State() != StateWantState {
+		t.Fatalf("acquisition state = %v, want StateWantState", il.State())
+	}
+	return il
+}
+
+// TestLedger_OnTimer_FailsCleanlyAfterBudget pins the core of issue #985: a
+// non-progressing acquisition escalates for ledgerTimeoutRetriesMax no-progress
+// intervals, then fails cleanly instead of re-arming the same stall forever.
+func TestLedger_OnTimer_FailsCleanlyAfterBudget(t *testing.T) {
+	t.Parallel()
+	il := New([32]byte{0xAB}, 42, 1, discardLogger())
+	il.state = StateWantState
+	base := time.Unix(1_700_000_000, 0)
+	il.lastTimer = base
+
+	for i := 1; i <= ledgerTimeoutRetriesMax; i++ {
+		now := base.Add(time.Duration(i) * acquireTimerInterval)
+		if got := il.OnTimer(now); got != TimerEscalate {
+			t.Fatalf("fire %d: got %v, want TimerEscalate", i, got)
+		}
+		if il.State() == StateFailed {
+			t.Fatalf("fire %d failed before the budget was exhausted", i)
+		}
+	}
+
+	final := base.Add(time.Duration(ledgerTimeoutRetriesMax+1) * acquireTimerInterval)
+	if got := il.OnTimer(final); got != TimerFailed {
+		t.Fatalf("budget fire: got %v, want TimerFailed", got)
+	}
+	if il.State() != StateFailed {
+		t.Fatalf("state = %v, want StateFailed", il.State())
+	}
+	if il.Err() == nil {
+		t.Fatal("a failed acquisition must carry a terminal error")
+	}
+}
+
+// TestLedger_OnTimer_ProgressDefersFailure confirms an interval that made
+// forward progress neither counts a timeout nor escalates, so a healthy
+// acquisition never fails (rippled onTimer(true)).
+func TestLedger_OnTimer_ProgressDefersFailure(t *testing.T) {
+	t.Parallel()
+	il := New([32]byte{0x01}, 7, 1, discardLogger())
+	il.state = StateWantState
+	base := time.Unix(1_700_000_000, 0)
+	il.lastTimer = base
+
+	for i := 1; i <= 5; i++ {
+		il.OnTimer(base.Add(time.Duration(i) * acquireTimerInterval))
+	}
+	if il.Timeouts() != 5 {
+		t.Fatalf("timeouts = %d, want 5 after five no-progress fires", il.Timeouts())
+	}
+
+	il.mu.Lock()
+	il.markProgressLocked()
+	il.mu.Unlock()
+	if got := il.OnTimer(base.Add(6 * acquireTimerInterval)); got != TimerNone {
+		t.Fatalf("progress fire: got %v, want TimerNone", got)
+	}
+	if il.Timeouts() != 5 {
+		t.Fatalf("a progressing interval must not count a timeout, got %d", il.Timeouts())
+	}
+}
+
+// TestLedger_OnTimer_NotDueIsNoop confirms OnTimer is a no-op before the timer
+// interval elapses, so polling it from the maintenance tick is cheap.
+func TestLedger_OnTimer_NotDueIsNoop(t *testing.T) {
+	t.Parallel()
+	il := New([32]byte{0x02}, 7, 1, discardLogger())
+	il.state = StateWantState
+	base := time.Unix(1_700_000_000, 0)
+	il.lastTimer = base
+	if got := il.OnTimer(base.Add(acquireTimerInterval / 2)); got != TimerNone {
+		t.Fatalf("sub-interval fire: got %v, want TimerNone", got)
+	}
+	if il.Timeouts() != 0 {
+		t.Fatalf("a not-due fire must not count a timeout, got %d", il.Timeouts())
+	}
+}
+
+// TestLedger_AddPeer_DedupsAndCaps pins the broadened source-peer set: the
+// original peer is the primary, duplicates are rejected, and the set is bounded.
+func TestLedger_AddPeer_DedupsAndCaps(t *testing.T) {
+	t.Parallel()
+	il := New([32]byte{}, 1, 7, discardLogger())
+	if il.PeerID() != 7 {
+		t.Fatalf("PeerID() = %d, want the original peer 7", il.PeerID())
+	}
+	if !il.AddPeer(8) {
+		t.Fatal("a fresh peer must be added")
+	}
+	if il.AddPeer(7) || il.AddPeer(8) {
+		t.Fatal("duplicate peers must not be added")
+	}
+	for i := 9; len(il.Peers()) < maxAcquisitionPeers; i++ {
+		il.AddPeer(uint64(i))
+	}
+	if il.AddPeer(9999) {
+		t.Fatal("the peer set must not grow past maxAcquisitionPeers")
+	}
+	if len(il.Peers()) != maxAcquisitionPeers {
+		t.Fatalf("peer set size = %d, want %d", len(il.Peers()), maxAcquisitionPeers)
+	}
+}
+
+// TestLedger_TakeByHashRequest_AggressiveGate confirms the by-hash escalation
+// only arms once the acquisition has gone aggressive, returns the outstanding
+// content hashes, and consumes the latch until the next no-progress tick.
+func TestLedger_TakeByHashRequest_AggressiveGate(t *testing.T) {
+	t.Parallel()
+	il := incompleteStateAcquisition(t)
+
+	// Armed (byHash) but not yet aggressive: no by-hash request.
+	il.mu.Lock()
+	il.byHash = true
+	il.timeouts = ledgerBecomeAggressiveThreshold
+	il.mu.Unlock()
+	if state, tx := il.TakeByHashRequest(16); state != nil || tx != nil {
+		t.Fatalf("by-hash must not arm at the threshold, got state=%d tx=%d", len(state), len(tx))
+	}
+
+	// Past the threshold: it returns the outstanding state hashes and consumes
+	// the latch so it fires once per no-progress interval.
+	il.mu.Lock()
+	il.byHash = true
+	il.timeouts = ledgerBecomeAggressiveThreshold + 1
+	il.mu.Unlock()
+	state, _ := il.TakeByHashRequest(16)
+	if len(state) == 0 {
+		t.Fatal("aggressive by-hash request must return outstanding state node hashes")
+	}
+	if again, _ := il.TakeByHashRequest(16); again != nil {
+		t.Fatal("the by-hash latch must be consumed until the next no-progress tick")
+	}
+}

--- a/internal/ledger/inbound/tracker.go
+++ b/internal/ledger/inbound/tracker.go
@@ -132,24 +132,6 @@ func (t *Tracker) Remove(hash [32]byte, complete bool) {
 	delete(t.active, hash)
 }
 
-// ActiveTimedOut returns the in-flight acquisitions that have exceeded the
-// acquisition timeout, for the router's maintenance reaper. The caller decides
-// recovery and finalizes each via Remove.
-func (t *Tracker) ActiveTimedOut() []*Ledger {
-	if t == nil {
-		return nil
-	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	var out []*Ledger
-	for _, l := range t.active {
-		if l.IsTimedOut() {
-			out = append(out, l)
-		}
-	}
-	return out
-}
-
 // Active returns every in-flight acquisition currently tracked. The router
 // iterates these to attempt local completion from the fetch-pack cache
 // (Ledger.CheckLocal), mirroring rippled's InboundLedgers::gotFetchPack which
@@ -210,10 +192,12 @@ func (t *Tracker) Info() map[string]any {
 		case snap.Complete:
 			t.completed[hash] = completedRecord{snap: snap, at: now}
 			delete(t.active, hash)
-		case snap.Failed || snap.TimedOut:
-			// A timed-out acquisition reports as failed for fetch_info (go-xrpl
-			// reaps on first timeout); mark it before retaining the snapshot so
-			// the failure entry mirrors rippled's still-in-mLedgers getJson.
+		case snap.Failed:
+			// Demote on the authoritative terminal state set by the router's
+			// OnTimer reaper, not a racing wall-clock: a read-only fetch_info
+			// must never reap an acquisition the router is still driving toward
+			// completion. Mark it before retaining the snapshot so the failure
+			// entry mirrors rippled's still-in-mLedgers getJson.
 			snap.Failed = true
 			t.failures[hash] = failureRecord{snap: snap, at: now}
 			delete(t.active, hash)
@@ -264,9 +248,9 @@ func AcquisitionJSON(snap Snapshot) map[string]any {
 	entry := map[string]any{
 		"hash":        fmt.Sprintf("%X", snap.Hash),
 		"have_header": snap.HaveHeader,
-		// go-xrpl reaps on the first timeout, so rippled's retry count is always
-		// zero; emit it for wire-shape parity with InboundLedger::getJson.
-		"timeouts": 0,
+		// Live no-progress retry count, mirroring InboundLedger::getJson's
+		// timeouts_ now that the acquisition runs a timer-driven retry loop.
+		"timeouts": snap.Timeouts,
 	}
 	switch {
 	case snap.Complete:
@@ -275,7 +259,7 @@ func AcquisitionJSON(snap Snapshot) map[string]any {
 		entry["failed"] = true
 	default:
 		// peers appears only while in flight, matching rippled's
-		// !complete_ && !failed_ gate. Classic acquisition uses one source peer.
+		// !complete_ && !failed_ gate: the broadened source-peer set size.
 		entry["peers"] = snap.Peers
 	}
 	if snap.HaveHeader {

--- a/internal/ledger/inbound/tracker_test.go
+++ b/internal/ledger/inbound/tracker_test.go
@@ -17,6 +17,16 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+// driveToFailure runs the acquisition's OnTimer retry loop past its budget so it
+// reaches StateFailed, the white-box stand-in for the router's reaper.
+func driveToFailure(il *Ledger) {
+	base := time.Unix(1_700_000_000, 0)
+	il.lastTimer = base
+	for i := 1; i <= ledgerTimeoutRetriesMax+1; i++ {
+		il.OnTimer(base.Add(time.Duration(i) * acquireTimerInterval))
+	}
+}
+
 // encodeHeader serializes a header for the wire and returns the hash a peer
 // answering GetLedger must produce. GotBase recomputes the hash from these exact
 // bytes and rejects a mismatch (mirroring rippled's takeHeader), so tests
@@ -224,7 +234,7 @@ func TestTracker_TimedOutDemotedToFailure(t *testing.T) {
 	var hash [32]byte
 	hash[0] = 0x11
 	il := New(hash, 500, 4, discardLogger())
-	il.created = time.Now().Add(-2 * acquisitionTimeout) // white-box: force timeout
+	driveToFailure(il) // white-box: exhaust the retry budget
 
 	tr := NewTracker()
 	tr.Track(il)
@@ -385,7 +395,7 @@ func TestTracker_FailedEntryCarriesRichShape(t *testing.T) {
 	if err := il.GotBase([]message.LedgerNode{{NodeData: hdr}, {NodeData: stateRoot}, {NodeData: txRoot}}); err != nil {
 		t.Fatalf("GotBase: %v", err)
 	}
-	il.created = time.Now().Add(-2 * acquisitionTimeout) // white-box: force timeout
+	driveToFailure(il) // white-box: exhaust the retry budget
 
 	tr := NewTracker()
 	tr.Track(il)

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -234,11 +234,11 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 	// Reply branch (query=false). Rippled adds the inbound objects to the
 	// fetch-pack cache at PeerImp.cpp:2547-2593. The acquisition state and
 	// the fetch-pack cache live in the consensus router, so forward the reply
-	// onto the overlay→router channel exactly as every other peer-originated
-	// reply (TMLedgerData, TMTransaction) is delivered. Both the bulk fetch-pack
-	// reply and the otSTATE_NODE/otTRANSACTION_NODE nodes served for a by-hash
-	// acquisition escalation (issue #985) carry SHAMap nodes the router caches;
-	// other reply types have no consumer and are dropped.
+	// onto the same overlay→router channel other peer-originated replies use.
+	// Both the bulk fetch-pack reply and the otSTATE_NODE/otTRANSACTION_NODE
+	// nodes served for a by-hash acquisition escalation (issue #985) carry
+	// SHAMap nodes the router caches; other reply types have no consumer and
+	// are dropped.
 	switch gob.ObjType {
 	case message.ObjectTypeFetchPack, message.ObjectTypeStateNode, message.ObjectTypeTransactionNode:
 		select {

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -235,9 +235,12 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 	// fetch-pack cache at PeerImp.cpp:2547-2593. The acquisition state and
 	// the fetch-pack cache live in the consensus router, so forward the reply
 	// onto the overlay→router channel exactly as every other peer-originated
-	// reply (TMLedgerData, TMTransaction) is delivered. Other reply types have
-	// no consumer and are dropped.
-	if gob.ObjType == message.ObjectTypeFetchPack {
+	// reply (TMLedgerData, TMTransaction) is delivered. Both the bulk fetch-pack
+	// reply and the otSTATE_NODE/otTRANSACTION_NODE nodes served for a by-hash
+	// acquisition escalation (issue #985) carry SHAMap nodes the router caches;
+	// other reply types have no consumer and are dropped.
+	switch gob.ObjType {
+	case message.ObjectTypeFetchPack, message.ObjectTypeStateNode, message.ObjectTypeTransactionNode:
 		select {
 		case o.messages <- &InboundMessage{
 			PeerID:  evt.PeerID,
@@ -246,7 +249,7 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 		}:
 		default:
 			o.droppedMessages.Add(1)
-			slog.Warn("TMGetObjects fetch-pack reply dropped: channel full",
+			slog.Warn("TMGetObjects node reply dropped: channel full",
 				"t", "Overlay", "peer", evt.PeerID)
 		}
 		return

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	mrand "math/rand/v2"
 	"net"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -307,6 +308,52 @@ func (o *Overlay) PeerWithLedger(target [32]byte, seq uint32, exclude PeerID) (P
 	return o.bestPeer(exclude, func(p *Peer) bool {
 		return p.HasLedger(target, seq)
 	})
+}
+
+// PeersWithLedger returns up to max connected peers that can serve ledger
+// (target, seq), excluding any id in excluded, ordered best-first by
+// peerRelayScore. Mirrors rippled InboundLedger::addPeers / PeerSet::addPeers,
+// which scores the overlay and accepts the top peers — broadening a stalled
+// acquisition's source set across several peers per timeout instead of one.
+// Returns nil when none qualifies.
+func (o *Overlay) PeersWithLedger(target [32]byte, seq uint32, excluded []PeerID, max int) []PeerID {
+	if max <= 0 {
+		return nil
+	}
+	skip := make(map[PeerID]struct{}, len(excluded))
+	for _, id := range excluded {
+		skip[id] = struct{}{}
+	}
+
+	o.peersMu.RLock()
+	defer o.peersMu.RUnlock()
+
+	type scoredPeer struct {
+		id    PeerID
+		score int
+	}
+	var cands []scoredPeer
+	for id, peer := range o.peers {
+		if _, ok := skip[id]; ok || peer.State() != PeerStateConnected {
+			continue
+		}
+		if !peer.HasLedger(target, seq) {
+			continue
+		}
+		cands = append(cands, scoredPeer{id: id, score: peerRelayScore(peer)})
+	}
+	if len(cands) == 0 {
+		return nil
+	}
+	slices.SortFunc(cands, func(a, b scoredPeer) int { return b.score - a.score })
+	if len(cands) > max {
+		cands = cands[:max]
+	}
+	out := make([]PeerID, len(cands))
+	for i := range cands {
+		out[i] = cands[i].id
+	}
+	return out
 }
 
 // PeerWithTxSet picks a connected peer that advertised tx-set root target

--- a/internal/peermanagement/relay_select_test.go
+++ b/internal/peermanagement/relay_select_test.go
@@ -137,6 +137,42 @@ func TestOverlay_PeerWithLedger(t *testing.T) {
 	assert.False(t, ok, "no peer advertises this ledger")
 }
 
+// TestOverlay_PeersWithLedger pins the multi-peer broaden selector
+// (InboundLedger::addPeers): up to max advertisers are returned, the excluded
+// set is skipped, non-advertisers are never chosen, and max<=0 / no-advertiser
+// both yield nil.
+func TestOverlay_PeersWithLedger(t *testing.T) {
+	target := hash32(0xAA)
+	o := &Overlay{peers: make(map[PeerID]*Peer)}
+
+	p3 := newRelayTestPeer(3)
+	p3.AddLedger(target)
+	p4 := newRelayTestPeer(4)
+	p4.AddLedger(target)
+	p5 := newRelayTestPeer(5)
+	p5.AddLedger(target)
+	p9 := newRelayTestPeer(9)
+	p9.AddLedger(hash32(0xBB))
+	for _, p := range []*Peer{p3, p4, p5, p9} {
+		o.peers[p.id] = p
+	}
+
+	got := o.PeersWithLedger(target, 0, nil, 2)
+	require.Len(t, got, 2, "capped at max")
+	for _, id := range got {
+		assert.Contains(t, []PeerID{3, 4, 5}, id, "only advertisers, never p9")
+	}
+
+	got = o.PeersWithLedger(target, 0, nil, 10)
+	assert.ElementsMatch(t, []PeerID{3, 4, 5}, got, "all advertisers when max exceeds the pool")
+
+	got = o.PeersWithLedger(target, 0, []PeerID{3, 4}, 10)
+	assert.Equal(t, []PeerID{5}, got, "excluded set skipped")
+
+	assert.Nil(t, o.PeersWithLedger(target, 0, nil, 0), "max<=0 yields nil")
+	assert.Nil(t, o.PeersWithLedger(hash32(0xCC), 0, nil, 5), "no advertiser yields nil")
+}
+
 // TestOverlay_PeerWithLedger_PrefersLowerLatency pins the rippled getScore
 // weighting: among advertisers, the low-latency peer wins every draw despite
 // its higher id, because the latency gap dominates the random jitter.


### PR DESCRIPTION
## Summary

Fixes the critical defect in #985: an inbound-ledger acquisition that diverges from our copy by a small subtree never converges and wedges the node into a fatal `os.Exit(1)`. The acquisition was **reply-driven with no progress or failure model** — a single un-acquirable SHAMap node re-requested the same node IDs every ~10s forever, made zero forward progress, swallowed the attach-rejection reason at Debug, and was eventually killed by the stall watchdog. With both go-xrpl validators dead the network loses quorum.

This ports rippled's `TimeoutCounter`/`InboundLedger` loop idiomatically (A+B+C — rippled implements A and B as one inseparable mechanism; C is go-xrpl-specific watchdog reconciliation):

- **A — timer-driven, progress-counted, bounded-failure loop.** `inbound.Ledger.OnTimer` fires every `acquireTimerInterval` (3s) regardless of replies, so a silent/dropped-reply peer can't stall it. A no-progress interval counts a timeout (rippled `progress_`/`timeouts_`), broadens the source-peer set (`addPeers`), and re-requests; the swallowed `AddKnownNodeByID` rejections now surface at Warn with the offending node + reason. After `ledgerTimeoutRetriesMax` (6) it transitions cleanly to `StateFailed` instead of re-arming the same stall. `fetch_info` now reports the real `timeouts` count (was hardcoded `0`).
- **B — by-hash escalation.** Past `ledgerBecomeAggressiveThreshold` (4) the acquisition asks its peer set for the missing nodes **by content hash** (`TMGetObjectByHash` `otSTATE_NODE`/`otTRANSACTION_NODE`) — the unambiguous fallback for a node on a divergent path that path-based `AddKnownNodeByID` can't place. Replies route through the existing fetch-pack cache + `CheckLocal` placement (the serve side already exists), so this reuses proven, rippled-interop receiver code.
- **C — watchdog reconciliation.** The `loop=ledger` watchdog aborts after 600s of no ledger close. A wrong-ledger node whose acquisition fails cleanly now un-pins (so `checkLedger` re-resolves and re-requests) and, after `wrongLedgerAcquireMaxFailures` (3), drops to a degraded `ModeObserving`/`OpModeTracking` resync so observer-mode advancement keeps ledgers closing — and the watchdog heartbeat alive — while recovery keeps being attempted. rippled has no such self-kill, so this realigns go-xrpl with its "fail cleanly and keep running" semantics.

Also retires the now-superseded wall-clock timeout path (`IsTimedOut`/`Snapshot.TimedOut`/`Tracker.ActiveTimedOut`/`acquisitionTimeout`/the `clock`+`created` fields), and fixes a race it would otherwise create where a read-only `fetch_info` could reap an acquisition the router is still driving (`Info()` now demotes on the authoritative `StateFailed` only).

## Test plan
- [x] New unit tests: `TestLedger_OnTimer_*` (fail-fast / progress / not-due), `TestLedger_AddPeer_DedupsAndCaps`, `TestLedger_TakeByHashRequest_AggressiveGate`, `TestHandleNodeReply_AcceptsByHashStateNodes`, `TestFailInboundAcquisition_{NotifiesEngineForConsensus,SkipsEngineForGeneric}`, `TestEngine_OnLedgerAcquireFailed_{UnpinsThenDegrades,IgnoredWhenNotPinned}`
- [x] `just build-all`, `just vet`, `just lint` (0 issues)
- [x] `just test-core` (ledger / txq / rpc / consensus / peermanagement) — all green
- [x] `just conformance` — no regressions (changes are confined to the consensus/peer acquisition paths, not tx/protocol)

Fixes #985