### PR TITLE
Stream statecompare state pack into the nodestore

### DIFF
--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -416,20 +416,16 @@ func loadInitialState(ctx context.Context, client *statecompare.Client, ledgerIn
 		return nil, nil, drops.Fees{}, fmt.Errorf("getting snapshot: %w", err)
 	}
 
-	// Get state entries
-	entries, err := client.GetStateEntries(ctx, ledgerIndex)
-	if err != nil {
-		return nil, nil, drops.Fees{}, fmt.Errorf("getting state entries: %w", err)
-	}
-
-	// Create state map
+	// Stream the state pack into the map so the whole pack and the full entry
+	// slice are never materialized in RAM at once.
 	stateMap := shamap.New(shamap.TypeState)
-
-	// Inject entries
-	for _, entry := range entries {
+	if err := client.StreamStateEntries(ctx, ledgerIndex, func(entry statecompare.StateEntry) error {
 		if err := stateMap.Put(entry.Index, entry.Data); err != nil {
-			return nil, nil, drops.Fees{}, fmt.Errorf("injecting entry: %w", err)
+			return fmt.Errorf("injecting entry: %w", err)
 		}
+		return nil
+	}); err != nil {
+		return nil, nil, drops.Fees{}, fmt.Errorf("getting state entries: %w", err)
 	}
 
 	// Verify the imported tree root against the known account_hash. The SHAMap

--- a/internal/replaytool/replay_state_source.go
+++ b/internal/replaytool/replay_state_source.go
@@ -94,8 +94,8 @@ func (s *nodestoreStateSource) Load(ctx context.Context, ledgerIndex uint32) (*s
 	}
 	s.opened = append(s.opened, base)
 
-	stateMap, err := buildOrOpenLazyState(ctx, base, s.overlay, snapshot.AccountHash, func() ([]statecompare.StateEntry, error) {
-		return s.client.GetStateEntries(ctx, ledgerIndex)
+	stateMap, err := buildOrOpenLazyState(ctx, base, s.overlay, snapshot.AccountHash, func(fn func(statecompare.StateEntry) error) error {
+		return s.client.StreamStateEntries(ctx, ledgerIndex, fn)
 	})
 	if err != nil {
 		return nil, nil, drops.Fees{}, err
@@ -122,14 +122,17 @@ func (s *nodestoreStateSource) Close() error {
 // buildOrOpenLazyState returns a state SHAMap whose backing is a shared
 // read-only base plus a writable overlay. If the base already holds the root
 // node for accountHash it is opened lazily with no rebuild; otherwise the tree
-// is built once from loadEntries, flushed into the base, verified against
-// accountHash, and then re-opened over the base+overlay so replay mutations
-// land only in the overlay.
+// is built once by streaming entries from streamEntries, flushed into the base,
+// verified against accountHash, and then re-opened over the base+overlay so
+// replay mutations land only in the overlay.
+//
+// streamEntries delivers each entry through a callback rather than returning a
+// slice, so a multi-gigabyte checkpoint is never held in the heap at once.
 func buildOrOpenLazyState(
 	ctx context.Context,
 	base, overlay shamap.Family,
 	accountHash [32]byte,
-	loadEntries func() ([]statecompare.StateEntry, error),
+	streamEntries func(func(statecompare.StateEntry) error) error,
 ) (*shamap.SHAMap, error) {
 	// Warm path: the root node is content-addressed by accountHash, so its
 	// presence means the derived store was built and the root commitment
@@ -142,11 +145,7 @@ func buildOrOpenLazyState(
 		return shamap.NewFromRootHash(shamap.TypeState, accountHash, shamap.NewOverlayFamily(base, overlay))
 	}
 
-	// Cold path: build the derived nodestore once from the raw state entries.
-	entries, err := loadEntries()
-	if err != nil {
-		return nil, fmt.Errorf("getting state entries: %w", err)
-	}
+	// Cold path: build the derived nodestore once, streaming the raw entries.
 	buildMap, err := shamap.NewBacked(shamap.TypeState, base)
 	if err != nil {
 		return nil, fmt.Errorf("creating build map: %w", err)
@@ -156,15 +155,18 @@ func buildOrOpenLazyState(
 	// holding it all in the heap at once: released subtrees are re-fetched
 	// from the base on demand.
 	const flushChunk = 100_000
-	for i, entry := range entries {
+	n := 0
+	if err := streamEntries(func(entry statecompare.StateEntry) error {
 		if err := buildMap.Put(entry.Index, entry.Data); err != nil {
-			return nil, fmt.Errorf("injecting entry: %w", err)
+			return fmt.Errorf("injecting entry: %w", err)
 		}
-		if (i+1)%flushChunk == 0 {
-			if err := flushToFamily(ctx, buildMap, base); err != nil {
-				return nil, err
-			}
+		n++
+		if n%flushChunk == 0 {
+			return flushToFamily(ctx, buildMap, base)
 		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("getting state entries: %w", err)
 	}
 	if err := flushToFamily(ctx, buildMap, base); err != nil {
 		return nil, err

--- a/internal/replaytool/replay_state_source_test.go
+++ b/internal/replaytool/replay_state_source_test.go
@@ -35,6 +35,19 @@ func syntheticEntries(t *testing.T, n int) ([]statecompare.StateEntry, [32]byte)
 	return entries, root
 }
 
+// streamAll adapts a fixed slice of entries into the streaming callback
+// buildOrOpenLazyState consumes.
+func streamAll(entries []statecompare.StateEntry) func(func(statecompare.StateEntry) error) error {
+	return func(fn func(statecompare.StateEntry) error) error {
+		for _, e := range entries {
+			if err := fn(e); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
 func TestBuildOrOpenLazyState_ColdBuildThenLazyRead(t *testing.T) {
 	ctx := context.Background()
 	entries, accountHash := syntheticEntries(t, 250)
@@ -43,15 +56,15 @@ func TestBuildOrOpenLazyState_ColdBuildThenLazyRead(t *testing.T) {
 	overlay := shamap.NewMemoryNodeStoreFamily()
 
 	loads := 0
-	state, err := buildOrOpenLazyState(ctx, base, overlay, accountHash, func() ([]statecompare.StateEntry, error) {
+	state, err := buildOrOpenLazyState(ctx, base, overlay, accountHash, func(fn func(statecompare.StateEntry) error) error {
 		loads++
-		return entries, nil
+		return streamAll(entries)(fn)
 	})
 	if err != nil {
 		t.Fatalf("cold build: %v", err)
 	}
 	if loads != 1 {
-		t.Fatalf("expected 1 entry load on cold build, got %d", loads)
+		t.Fatalf("expected 1 entry stream on cold build, got %d", loads)
 	}
 
 	root, err := state.Hash()
@@ -78,18 +91,16 @@ func TestBuildOrOpenLazyState_WarmOpenSkipsRebuild(t *testing.T) {
 	base := shamap.NewMemoryNodeStoreFamily()
 	overlay := shamap.NewMemoryNodeStoreFamily()
 
-	if _, err := buildOrOpenLazyState(ctx, base, overlay, accountHash, func() ([]statecompare.StateEntry, error) {
-		return entries, nil
-	}); err != nil {
+	if _, err := buildOrOpenLazyState(ctx, base, overlay, accountHash, streamAll(entries)); err != nil {
 		t.Fatalf("cold build: %v", err)
 	}
 
-	// A second open over the now-populated base must not rebuild: loadEntries
+	// A second open over the now-populated base must not rebuild: streamEntries
 	// failing the test if called proves the open path is "open the nodestore".
 	overlay2 := shamap.NewMemoryNodeStoreFamily()
-	state, err := buildOrOpenLazyState(ctx, base, overlay2, accountHash, func() ([]statecompare.StateEntry, error) {
-		t.Fatalf("loadEntries called on warm open")
-		return nil, nil
+	state, err := buildOrOpenLazyState(ctx, base, overlay2, accountHash, func(func(statecompare.StateEntry) error) error {
+		t.Fatalf("streamEntries called on warm open")
+		return nil
 	})
 	if err != nil {
 		t.Fatalf("warm open: %v", err)
@@ -111,9 +122,7 @@ func TestBuildOrOpenLazyState_VerifyGate(t *testing.T) {
 	// must fail rather than hand back an unverified seed.
 	wrong := accountHash
 	wrong[0] ^= 0xFF
-	if _, err := buildOrOpenLazyState(ctx, base, overlay, wrong, func() ([]statecompare.StateEntry, error) {
-		return entries, nil
-	}); err == nil {
+	if _, err := buildOrOpenLazyState(ctx, base, overlay, wrong, streamAll(entries)); err == nil {
 		t.Fatal("expected account_hash mismatch error, got nil")
 	}
 }

--- a/internal/statecompare/blobstore.go
+++ b/internal/statecompare/blobstore.go
@@ -23,6 +23,10 @@ import (
 // dev/test, and S3/MinIO for production cross-pod blob sharing.
 type blobStore interface {
 	get(ctx context.Context, key string) ([]byte, error)
+	// getReader returns the object as a stream so a large pack is consumed
+	// incrementally rather than buffered whole. The caller owns the reader and
+	// must Close it.
+	getReader(ctx context.Context, key string) (io.ReadCloser, error)
 }
 
 // BlobStoreConfig selects and configures the blob backend. Field defaults and
@@ -96,6 +100,18 @@ func (l *localBlobStore) get(_ context.Context, key string) ([]byte, error) {
 	return data, nil
 }
 
+func (l *localBlobStore) getReader(_ context.Context, key string) (io.ReadCloser, error) {
+	path := filepath.Join(l.root, filepath.FromSlash(key))
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("blob %q: %w", key, ErrNotFound)
+		}
+		return nil, fmt.Errorf("reading blob %q: %w", key, err)
+	}
+	return f, nil
+}
+
 // s3BlobStore fetches packs from S3/MinIO over plain HTTP, signing each GET
 // with AWS Signature Version 4. Path-style addressing (the MinIO default) is
 // used: the object URL is <endpoint>/<bucket>/<key>.
@@ -145,6 +161,19 @@ func newS3BlobStore(cfg BlobStoreConfig) (*s3BlobStore, error) {
 const emptyPayloadSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 func (s *s3BlobStore) get(ctx context.Context, key string) ([]byte, error) {
+	r, err := s.getReader(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading blob %q: %w", key, err)
+	}
+	return data, nil
+}
+
+func (s *s3BlobStore) getReader(ctx context.Context, key string) (io.ReadCloser, error) {
 	reqURL := *s.endpoint
 	reqURL.Path = "/" + s.bucket + "/" + key
 
@@ -159,19 +188,16 @@ func (s *s3BlobStore) get(ctx context.Context, key string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fetching blob %q: %w", key, err)
 	}
-	defer resp.Body.Close()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		data, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("reading blob %q: %w", key, err)
-		}
-		return data, nil
+		return resp.Body, nil
 	case http.StatusNotFound:
+		resp.Body.Close()
 		return nil, fmt.Errorf("blob %q: %w", key, ErrNotFound)
 	default:
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		resp.Body.Close()
 		return nil, fmt.Errorf("fetching blob %q: status %s: %s", key, resp.Status, strings.TrimSpace(string(body)))
 	}
 }

--- a/internal/statecompare/blobstore_test.go
+++ b/internal/statecompare/blobstore_test.go
@@ -111,6 +111,43 @@ func TestLocalBlobStoreGet(t *testing.T) {
 	}
 }
 
+func TestLocalBlobStoreGetReader(t *testing.T) {
+	root := t.TempDir()
+	store := &localBlobStore{root: root}
+
+	entries := []StateEntry{{Index: idx(0x01), Data: []byte("x")}, {Index: idx(0x02), Data: []byte("yz")}}
+	blob := packState(7, entries)
+	key := "state/ckpt-7.pack"
+	if err := os.MkdirAll(filepath.Join(root, "state"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(key)), blob, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := store.getReader(context.Background(), key)
+	if err != nil {
+		t.Fatalf("getReader: %v", err)
+	}
+	defer r.Close()
+
+	got := 0
+	seq, _, err := unpackStateStream(r, func([32]byte, []byte) error {
+		got++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unpackStateStream: %v", err)
+	}
+	if seq != 7 || got != len(entries) {
+		t.Errorf("seq=%d entries=%d, want seq=7 entries=%d", seq, got, len(entries))
+	}
+
+	if _, err := store.getReader(context.Background(), "state/missing.pack"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("missing key err = %v, want ErrNotFound", err)
+	}
+}
+
 // TestSignV4GoldenVector verifies the SigV4 signer against the documented AWS
 // "GET Object" example, which fixes the expected signature for a known
 // request. Matching it proves the canonical request, string-to-sign and
@@ -188,6 +225,60 @@ func TestS3BlobStoreGet(t *testing.T) {
 	}
 
 	if _, err := store.get(context.Background(), "ledger/missing.pack"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("missing key err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestS3BlobStoreGetReader(t *testing.T) {
+	entries := []StateEntry{{Index: idx(0x01), Data: []byte("x")}, {Index: idx(0xaa), Data: []byte("abc")}}
+	blob := packState(99250000, entries)
+	const wantPath = "/xrpl-replay/state/ckpt-99250000.pack"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "AWS4-HMAC-SHA256 ") {
+			t.Errorf("missing/bad Authorization header: %q", r.Header.Get("Authorization"))
+		}
+		switch r.URL.Path {
+		case wantPath:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(blob)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	store, err := newS3BlobStore(BlobStoreConfig{
+		Backend:     "s3",
+		EndpointURL: srv.URL,
+		AccessKey:   "ak",
+		SecretKey:   "sk",
+		Bucket:      "xrpl-replay",
+		Region:      "us-east-1",
+	})
+	if err != nil {
+		t.Fatalf("newS3BlobStore: %v", err)
+	}
+
+	r, err := store.getReader(context.Background(), "state/ckpt-99250000.pack")
+	if err != nil {
+		t.Fatalf("getReader: %v", err)
+	}
+	defer r.Close()
+
+	got := 0
+	seq, _, err := unpackStateStream(r, func([32]byte, []byte) error {
+		got++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unpackStateStream: %v", err)
+	}
+	if seq != 99250000 || got != len(entries) {
+		t.Errorf("seq=%d entries=%d, want seq=99250000 entries=%d", seq, got, len(entries))
+	}
+
+	if _, err := store.getReader(context.Background(), "state/missing.pack"); !errors.Is(err, ErrNotFound) {
 		t.Errorf("missing key err = %v, want ErrNotFound", err)
 	}
 }

--- a/internal/statecompare/client.go
+++ b/internal/statecompare/client.go
@@ -251,6 +251,41 @@ func (c *Client) GetStateEntries(ctx context.Context, seq uint32) ([]StateEntry,
 	return entries, nil
 }
 
+// StreamStateEntries decodes a checkpoint's STATE pack on the fly, invoking fn
+// for each SLE as it is read from the blob store. Unlike GetStateEntries it
+// never materializes the whole pack or the full entry slice, so seeding a
+// multi-gigabyte mainnet checkpoint stays within a bounded memory footprint.
+// seq must be a checkpoint ledger; a non-checkpoint seq returns ErrNotFound.
+func (c *Client) StreamStateEntries(ctx context.Context, seq uint32, fn func(StateEntry) error) error {
+	var blobKey string
+	err := c.db.QueryRowContext(ctx,
+		`SELECT blob_key FROM checkpoints WHERE seq = $1`, seq,
+	).Scan(&blobKey)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("checkpoint %d: %w", seq, ErrNotFound)
+	}
+	if err != nil {
+		return fmt.Errorf("querying checkpoint %d: %w", seq, err)
+	}
+
+	r, err := c.blobs.getReader(ctx, blobKey)
+	if err != nil {
+		return fmt.Errorf("fetching state pack %q: %w", blobKey, err)
+	}
+	defer r.Close()
+
+	packSeq, _, err := unpackStateStream(r, func(index [32]byte, data []byte) error {
+		return fn(StateEntry{Index: index, Data: data})
+	})
+	if err != nil {
+		return fmt.Errorf("decoding state pack %q: %w", blobKey, err)
+	}
+	if packSeq != uint64(seq) {
+		return fmt.Errorf("state pack %q is for checkpoint %d, want %d", blobKey, packSeq, seq)
+	}
+	return nil
+}
+
 // GetTransactions retrieves the transactions of a ledger by seeking into its
 // batch pack at the manifest-recorded offset.
 func (c *Client) GetTransactions(ctx context.Context, seq uint32) ([]Transaction, error) {

--- a/internal/statecompare/pack.go
+++ b/internal/statecompare/pack.go
@@ -1,9 +1,11 @@
 package statecompare
 
 import (
+	"bufio"
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 )
 
 // XSCP is the deterministic, length-prefixed binary format the
@@ -105,6 +107,49 @@ func unpackState(blob []byte) (uint64, []StateEntry, error) {
 		entries = append(entries, e)
 	}
 	return seq, entries, nil
+}
+
+// unpackStateStream decodes a STATE pack from r, invoking fn for each SLE as it
+// is read so peak memory stays O(one entry) regardless of state size. A STATE
+// pack is strictly sequential, so it decodes from a stream without ever holding
+// the whole pack or the full entry slice in memory. It returns the checkpoint
+// seq and entry count from the header.
+func unpackStateStream(r io.Reader, fn func(index [32]byte, data []byte) error) (uint64, uint32, error) {
+	br := bufio.NewReaderSize(r, 1<<20)
+
+	var head [packHeaderLen]byte
+	if _, err := io.ReadFull(br, head[:]); err != nil {
+		return 0, 0, fmt.Errorf("%w: truncated header", errPack)
+	}
+	if _, err := checkHeader(head[:], kindState); err != nil {
+		return 0, 0, err
+	}
+
+	var meta [12]byte // u64 seq + u32 count
+	if _, err := io.ReadFull(br, meta[:]); err != nil {
+		return 0, 0, fmt.Errorf("%w: truncated state header", errPack)
+	}
+	seq := binary.BigEndian.Uint64(meta[:8])
+	count := binary.BigEndian.Uint32(meta[8:])
+
+	var index [32]byte
+	var lenBuf [4]byte
+	for range count {
+		if _, err := io.ReadFull(br, index[:]); err != nil {
+			return 0, 0, fmt.Errorf("%w: truncated state index", errPack)
+		}
+		if _, err := io.ReadFull(br, lenBuf[:]); err != nil {
+			return 0, 0, fmt.Errorf("%w: truncated data length", errPack)
+		}
+		data := make([]byte, binary.BigEndian.Uint32(lenBuf[:]))
+		if _, err := io.ReadFull(br, data); err != nil {
+			return 0, 0, fmt.Errorf("%w: truncated data", errPack)
+		}
+		if err := fn(index, data); err != nil {
+			return 0, 0, err
+		}
+	}
+	return seq, count, nil
 }
 
 // readOneLedger decodes the ledger record starting at off and returns the

--- a/internal/statecompare/pack_test.go
+++ b/internal/statecompare/pack_test.go
@@ -97,6 +97,118 @@ func TestStatePackGoldenBytes(t *testing.T) {
 	}
 }
 
+func TestUnpackStateStreamRoundtrip(t *testing.T) {
+	entries := []StateEntry{
+		{Index: idx(0x01), Data: []byte("hello")},
+		{Index: idx(0x02), Data: []byte{}},
+		{Index: idx(0xff), Data: []byte{0x00, 0x01, 0x02}},
+	}
+	blob := packState(99250000, entries)
+
+	var got []StateEntry
+	seq, count, err := unpackStateStream(bytes.NewReader(blob), func(index [32]byte, data []byte) error {
+		got = append(got, StateEntry{Index: index, Data: append([]byte(nil), data...)})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unpackStateStream: %v", err)
+	}
+	if seq != 99250000 {
+		t.Errorf("seq = %d, want 99250000", seq)
+	}
+	if count != uint32(len(entries)) {
+		t.Errorf("count = %d, want %d", count, len(entries))
+	}
+	if len(got) != len(entries) {
+		t.Fatalf("got %d entries, want %d", len(got), len(entries))
+	}
+	for i, e := range entries {
+		if got[i].Index != e.Index {
+			t.Errorf("entry %d index = %x, want %x", i, got[i].Index, e.Index)
+		}
+		if !bytes.Equal(got[i].Data, e.Data) {
+			t.Errorf("entry %d data = %x, want %x", i, got[i].Data, e.Data)
+		}
+	}
+}
+
+// TestUnpackStateStreamMatchesBuffered cross-checks the streaming decoder
+// against the buffered one over the same pack, so the two paths cannot drift.
+func TestUnpackStateStreamMatchesBuffered(t *testing.T) {
+	entries := []StateEntry{
+		{Index: idx(0x10), Data: []byte("abcdefghijkl")},
+		{Index: idx(0x20), Data: bytes.Repeat([]byte{0x7e}, 300)},
+	}
+	blob := packState(42, entries)
+
+	wantSeq, want, err := unpackState(blob)
+	if err != nil {
+		t.Fatalf("unpackState: %v", err)
+	}
+
+	var got []StateEntry
+	gotSeq, _, err := unpackStateStream(bytes.NewReader(blob), func(index [32]byte, data []byte) error {
+		got = append(got, StateEntry{Index: index, Data: append([]byte(nil), data...)})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unpackStateStream: %v", err)
+	}
+	if gotSeq != wantSeq {
+		t.Errorf("stream seq = %d, want %d", gotSeq, wantSeq)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("stream got %d entries, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Index != want[i].Index || !bytes.Equal(got[i].Data, want[i].Data) {
+			t.Errorf("entry %d mismatch between stream and buffered decode", i)
+		}
+	}
+}
+
+func TestUnpackStateStreamRejectsBadMagicAndKind(t *testing.T) {
+	if _, _, err := unpackStateStream(bytes.NewReader([]byte("NOTAPACK"+"\x00\x00\x00\x00")), nil); !errors.Is(err, errPack) {
+		t.Errorf("bad magic: err = %v, want errPack", err)
+	}
+	lblob, _ := packLedgerBatch(1, nil)
+	if _, _, err := unpackStateStream(bytes.NewReader(lblob), nil); !errors.Is(err, errPack) {
+		t.Errorf("kind mismatch: err = %v, want errPack", err)
+	}
+}
+
+func TestUnpackStateStreamRejectsTruncated(t *testing.T) {
+	blob := packState(1, []StateEntry{{Index: idx(0x01), Data: []byte("abcdef")}})
+	noop := func([32]byte, []byte) error { return nil }
+	if _, _, err := unpackStateStream(bytes.NewReader(blob[:len(blob)-3]), noop); !errors.Is(err, errPack) {
+		t.Errorf("truncated data: err = %v, want errPack", err)
+	}
+	if _, _, err := unpackStateStream(bytes.NewReader(blob[:8]), noop); !errors.Is(err, errPack) {
+		t.Errorf("truncated header: err = %v, want errPack", err)
+	}
+}
+
+// TestUnpackStateStreamPropagatesCallbackError verifies a callback failure stops
+// the decode and surfaces unchanged (not wrapped as a pack error).
+func TestUnpackStateStreamPropagatesCallbackError(t *testing.T) {
+	blob := packState(1, []StateEntry{
+		{Index: idx(0x01), Data: []byte("a")},
+		{Index: idx(0x02), Data: []byte("b")},
+	})
+	sentinel := errors.New("boom")
+	calls := 0
+	_, _, err := unpackStateStream(bytes.NewReader(blob), func([32]byte, []byte) error {
+		calls++
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err = %v, want sentinel", err)
+	}
+	if calls != 1 {
+		t.Errorf("callback called %d times, want 1 (decode should stop on error)", calls)
+	}
+}
+
 func TestLedgerBatchRoundtripAndOffsets(t *testing.T) {
 	ledgers := []ledgerBlob{
 		{seq: 1000, headerBlob: []byte("H0"), txs: []txRecord{


### PR DESCRIPTION
## Summary

- `replay-range`'s seed loader buffered the **entire** checkpoint state pack into RAM (`io.ReadAll`) and decoded every SLE into one slice before injecting it, so a large mainnet checkpoint (~5.3 GB / ~18M objects) OOMed or surfaced `unexpected EOF` on an 8 GiB host — even with `--nodestore-dir`, which only bounds the *tree*, not the *load*.
- Adds the symmetric streaming counterpart to the producer-side fix (xrpl-state-compare#7, context #986):
  - `blobstore.go` — `getReader` returns the object as a stream (S3 hands back `resp.Body`, local opens the file); `s3BlobStore.get` now delegates to it.
  - `pack.go` — `unpackStateStream` decodes a STATE pack from an `io.Reader` with O(one entry) memory.
  - `client.go` — `StreamStateEntries` looks up `blob_key`, opens `getReader`, and drives `unpackStateStream`.
  - Both seed-load consumers (`loadInitialState` in-memory path and `buildOrOpenLazyState` nodestore-lazy cold build) inject each entry as it arrives, so peak RSS is independent of state size.
- Buffered `GetStateEntries` / `unpackState` are kept for tests and small ledgers. `GetTransactions` is unchanged (it already seeks to a single ledger via `blob_offset`).

The seed `account_hash` verify-gate before replay is unchanged.

## Test plan

- [x] `go test ./internal/statecompare/... ./internal/replaytool/...` (pass)
- [x] `go vet` + `golangci-lint run` on both packages (0 issues)
- New tests: `unpackStateStream` round-trip + cross-check against the buffered decoder + truncation/bad-magic/callback-error cases; `getReader` end-to-end stream-decode for both local and S3 backends; existing `buildOrOpenLazyState` tests migrated to the streaming callback.

Fixes #995