### PR TITLE
fix: stop replay double-updating the LedgerHashes skip list

### DIFF
--- a/internal/replaytool/replay.go
+++ b/internal/replaytool/replay.go
@@ -307,7 +307,7 @@ func (r *replayRunner) executeReplayVerbose(state *StateFixture, env *EnvFixture
 	fmt.Fprintln(r.out, "--- Execution ---")
 
 	// Step 1: Create state map and inject pre-state
-	fmt.Fprintf(r.out, "[1/6] Injecting %d pre-state entries...\n", len(state.Entries))
+	fmt.Fprintf(r.out, "[1/5] Injecting %d pre-state entries...\n", len(state.Entries))
 
 	stateMap := shamap.New(shamap.TypeState)
 
@@ -341,11 +341,11 @@ func (r *replayRunner) executeReplayVerbose(state *StateFixture, env *EnvFixture
 	fmt.Fprintf(r.out, "      Pre-state hash: %s\n", hex.EncodeToString(preStateHash[:]))
 
 	// Step 2: Create transaction map
-	fmt.Fprintln(r.out, "[2/6] Creating transaction map...")
+	fmt.Fprintln(r.out, "[2/5] Creating transaction map...")
 	txMap := shamap.New(shamap.TypeTransaction)
 
 	// Step 3: Parse environment
-	fmt.Fprintln(r.out, "[3/6] Setting up ledger environment...")
+	fmt.Fprintln(r.out, "[3/5] Setting up ledger environment...")
 	totalCoins, err := parseDrops(env.TotalCoins)
 	if err != nil {
 		return nil, nil, fmt.Errorf("parsing total_coins: %w", err)
@@ -380,7 +380,7 @@ func (r *replayRunner) executeReplayVerbose(state *StateFixture, env *EnvFixture
 	fmt.Fprintf(r.out, "      Total coins:     %d drops\n", totalCoins)
 
 	// Step 4: Apply transactions
-	fmt.Fprintf(r.out, "[4/6] Applying %d transactions...\n", len(txs.Transactions))
+	fmt.Fprintf(r.out, "[4/5] Applying %d transactions...\n", len(txs.Transactions))
 
 	// Build amendment rules from the amendments list in the fixture
 	rules := buildRulesFromAmendments(env.Amendments)
@@ -483,17 +483,10 @@ func (r *replayRunner) executeReplayVerbose(state *StateFixture, env *EnvFixture
 		}
 	}
 
-	// Step 5: Update skip list (LedgerHashes entry)
-	fmt.Fprintln(r.out, "[5/6] Updating skip list (LedgerHashes)...")
-	if err := updateSkipList(openLedger, parentHash, env.LedgerIndex); err != nil {
-		fmt.Fprintf(r.out, "      WARNING: Failed to update skip list: %v\n", err)
-		// Don't fail - this is not critical for basic replay testing
-	} else {
-		fmt.Fprintf(r.out, "      Updated LedgerHashes with parent hash, LastLedgerSequence=%d\n", env.LedgerIndex-1)
-	}
-
-	// Step 6: Close the ledger
-	fmt.Fprintln(r.out, "[6/6] Closing ledger...")
+	// Step 5: Close the ledger. Close() updates the LedgerHashes skip lists
+	// from the header's ParentHash before sealing state, so there is no
+	// separate skip-list pass — running one would double-append the hash.
+	fmt.Fprintln(r.out, "[5/5] Closing ledger...")
 	if err := openLedger.Close(closeTime, env.CloseFlags); err != nil {
 		return nil, nil, fmt.Errorf("closing ledger: %w", err)
 	}
@@ -771,132 +764,6 @@ func writeResultJSON(path string, result *ReplayResult) error {
 	}
 
 	return os.WriteFile(path, data, 0o644)
-}
-
-// updateSkipList updates the LedgerHashes entries (skip lists) with the parent hash.
-// This mirrors rippled's Ledger::updateSkipList() function.
-// There are TWO skip lists:
-//  1. "Every 256th ledger" skip list: Updated only when (prevIndex & 0xff) == 0,
-//     using keylet::skip(prevIndex). Records a hash of every 256th ledger.
-//  2. "Rolling 256" skip list: Always updated, using keylet::skip().
-//     Maintains a rolling window of the most recent 256 ledger hashes.
-func updateSkipList(l *ledger.Ledger, parentHash [32]byte, currentSeq uint32) error {
-	if currentSeq == 0 {
-		// Genesis ledger has no parent
-		return nil
-	}
-
-	prevIndex := currentSeq - 1
-
-	// 1. Update record of every 256th ledger (only when prevIndex is a multiple of 256)
-	if (prevIndex & 0xff) == 0 {
-		k := keylet.LedgerHashesForSeq(prevIndex)
-		if err := updateOrCreateSkipListEntry(l, k, parentHash, prevIndex, false); err != nil {
-			return fmt.Errorf("updating every-256th skip list: %w", err)
-		}
-	}
-
-	// 2. Update record of past 256 ledgers (always)
-	k := keylet.LedgerHashes()
-	if err := updateOrCreateSkipListEntry(l, k, parentHash, prevIndex, true); err != nil {
-		return fmt.Errorf("updating rolling-256 skip list: %w", err)
-	}
-
-	return nil
-}
-
-// updateOrCreateSkipListEntry updates or creates a skip list entry.
-// If rolling is true, it removes the oldest hash when at 256 hashes (rolling window).
-// If rolling is false, it just appends (for the every-256th ledger skip list).
-func updateOrCreateSkipListEntry(l *ledger.Ledger, k keylet.Keylet, parentHash [32]byte, prevIndex uint32, rolling bool) error {
-	// Read the existing entry. Ledger.Read reports an absent key as (nil, nil),
-	// so a missing entry is detected by data == nil — not by a non-nil error.
-	data, err := l.Read(k)
-	if err != nil {
-		return fmt.Errorf("reading LedgerHashes: %w", err)
-	}
-	if data == nil {
-		// Entry doesn't exist - create a new one
-		return createSkipListEntry(l, k, parentHash, prevIndex)
-	}
-
-	// Decode the binary data
-	decoded, err := binarycodec.Decode(hex.EncodeToString(data))
-	if err != nil {
-		return fmt.Errorf("decoding LedgerHashes: %w", err)
-	}
-
-	// Get the current hashes array
-	var hashes []string
-	if hashesRaw, ok := decoded["Hashes"]; ok {
-		switch arr := hashesRaw.(type) {
-		case []string:
-			// Binary codec returns []string directly
-			hashes = make([]string, len(arr))
-			copy(hashes, arr)
-		case []any:
-			// Handle []any case (e.g., from JSON unmarshaling)
-			hashes = make([]string, 0, len(arr))
-			for _, h := range arr {
-				if hashStr, ok := h.(string); ok {
-					hashes = append(hashes, hashStr)
-				}
-			}
-		}
-	}
-
-	// If rolling and we have 256 hashes, remove the oldest (first)
-	if rolling && len(hashes) >= 256 {
-		hashes = hashes[1:]
-	}
-
-	// Add the new parent hash (uppercase hex)
-	hashes = append(hashes, strings.ToUpper(hex.EncodeToString(parentHash[:])))
-
-	// Update the decoded map
-	decoded["Hashes"] = hashes
-	decoded["LastLedgerSequence"] = prevIndex
-
-	// Encode back to binary
-	encoded, err := binarycodec.Encode(decoded)
-	if err != nil {
-		return fmt.Errorf("encoding LedgerHashes: %w", err)
-	}
-
-	// Decode hex to bytes
-	newData, err := hex.DecodeString(encoded)
-	if err != nil {
-		return fmt.Errorf("decoding encoded hex: %w", err)
-	}
-
-	// Update the entry
-	return l.Update(k, newData)
-}
-
-// createSkipListEntry creates a new LedgerHashes entry when one doesn't exist.
-func createSkipListEntry(l *ledger.Ledger, k keylet.Keylet, parentHash [32]byte, prevIndex uint32) error {
-	// Create a new LedgerHashes entry
-	entry := map[string]any{
-		"LedgerEntryType":    "LedgerHashes",
-		"Flags":              uint32(0),
-		"Hashes":             []string{strings.ToUpper(hex.EncodeToString(parentHash[:]))},
-		"LastLedgerSequence": prevIndex,
-	}
-
-	// Encode to binary
-	encoded, err := binarycodec.Encode(entry)
-	if err != nil {
-		return fmt.Errorf("encoding new LedgerHashes: %w", err)
-	}
-
-	// Decode hex to bytes
-	data, err := hex.DecodeString(encoded)
-	if err != nil {
-		return fmt.Errorf("decoding encoded hex: %w", err)
-	}
-
-	// Insert the new entry
-	return l.Insert(k, data)
 }
 
 // extractFeesFromState reads the fee schedule from the FeeSettings entry in a

--- a/internal/replaytool/replay_helpers_test.go
+++ b/internal/replaytool/replay_helpers_test.go
@@ -9,13 +9,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
-	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
-	"github.com/LeJamon/go-xrpl/drops"
-	"github.com/LeJamon/go-xrpl/internal/ledger"
-	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
-	"github.com/LeJamon/go-xrpl/keylet"
-	"github.com/LeJamon/go-xrpl/shamap"
 )
 
 // feeSettingsIndexHex is keylet::fees() — the singleton FeeSettings key the
@@ -215,59 +209,5 @@ func TestLoadFixtures(t *testing.T) {
 	}
 	if _, _, _, _, err := loadFixtures(dir); err == nil {
 		t.Error("expected error when a fixture file is missing")
-	}
-}
-
-// newReplayTestLedger builds a minimal open ledger suitable for exercising the
-// skip-list mutators, mirroring replay.go's NewOpenWithHeader construction.
-func newReplayTestLedger(t *testing.T, seq uint32) *ledger.Ledger {
-	t.Helper()
-	stateMap := shamap.New(shamap.TypeState)
-	txMap := shamap.New(shamap.TypeTransaction)
-	hdr := header.LedgerHeader{
-		LedgerIndex: seq,
-		CloseTime:   time.Unix(0, 0).UTC(),
-	}
-	fees := drops.Fees{Base: 10, Reserve: 10_000_000, Increment: 2_000_000}
-	return ledger.NewOpenWithHeader(hdr, stateMap, txMap, fees)
-}
-
-func TestUpdateSkipList(t *testing.T) {
-	l := newReplayTestLedger(t, 2)
-
-	// Genesis (seq 0) has no parent: a complete no-op.
-	if err := updateSkipList(l, [32]byte{0x01}, 0); err != nil {
-		t.Fatalf("genesis skip list: %v", err)
-	}
-
-	// seq 1: prevIndex 0 is a multiple of 256, so BOTH the every-256th and the
-	// rolling skip lists are created.
-	if err := updateSkipList(l, [32]byte{0xAA}, 1); err != nil {
-		t.Fatalf("seq 1 skip list: %v", err)
-	}
-	// seq 2: prevIndex 1 only touches the rolling list, exercising the
-	// read-decode-append-update path of updateOrCreateSkipListEntry.
-	if err := updateSkipList(l, [32]byte{0xBB}, 2); err != nil {
-		t.Fatalf("seq 2 skip list: %v", err)
-	}
-
-	// The rolling LedgerHashes entry must now record two parent hashes.
-	data, err := l.Read(keylet.LedgerHashes())
-	if err != nil {
-		t.Fatalf("reading rolling skip list: %v", err)
-	}
-	decoded, err := binarycodec.Decode(hex.EncodeToString(data))
-	if err != nil {
-		t.Fatalf("decoding rolling skip list: %v", err)
-	}
-	hashes, ok := decoded["Hashes"].([]string)
-	if !ok {
-		t.Fatalf("Hashes is %T, want []string", decoded["Hashes"])
-	}
-	if len(hashes) != 2 {
-		t.Fatalf("rolling skip list has %d hashes, want 2", len(hashes))
-	}
-	if decoded["LastLedgerSequence"].(uint32) != 1 {
-		t.Errorf("LastLedgerSequence = %v, want 1", decoded["LastLedgerSequence"])
 	}
 }

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -710,15 +710,9 @@ func (r *replayRangeRunner) processBlock(
 		}
 	}
 
-	// Update skip list
-	if err := updateSkipList(openLedger, preSnapshot.LedgerHash, targetLedger); err != nil {
-		// Log but don't fail
-		if r.verbose {
-			fmt.Fprintf(r.out, "      WARNING: Failed to update skip list: %v\n", err)
-		}
-	}
-
-	// Close ledger
+	// Close ledger. Close() updates the LedgerHashes skip lists from the
+	// header's ParentHash as its first step, so no separate skip-list pass is
+	// needed here — doing one would double-append the parent hash.
 	if err := openLedger.Close(closeTime, postSnapshot.CloseFlags); err != nil {
 		return nil, nil, fmt.Errorf("closing ledger: %w", err)
 	}

--- a/internal/replaytool/replay_skiplist_test.go
+++ b/internal/replaytool/replay_skiplist_test.go
@@ -1,0 +1,192 @@
+package replaytool
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+// TestReplayClose_CheckpointSeedBoundary closes the first block of a replay
+// range whose state is seeded from a checkpoint — a parent ledger's fully
+// closed state, loaded straight into a fresh open ledger via NewOpenWithHeader,
+// exactly as the replay tooling does. Close() owns the LedgerHashes skip-list
+// update, so closing this block must advance the rolling list by exactly one
+// entry (the parent hash), not abort.
+//
+// Regression for issue #997: replay used to run its own updateSkipList pass
+// before Close(), double-appending the parent hash. The second append (inside
+// Close) then saw LastLedgerSequence already at prevIndex and tripped the
+// issue #470 consistency assertion, wedging the range at its first block.
+func TestReplayClose_CheckpointSeedBoundary(t *testing.T) {
+	parent := walkGenesisTo(t, 6)
+
+	// Seed the replay from the parent's closed state, mirroring the checkpoint
+	// loader: a fresh open ledger built from the snapshot via NewOpenWithHeader
+	// (not NewOpen), then closed.
+	seed, err := parent.StateMapSnapshot()
+	if err != nil {
+		t.Fatalf("StateMapSnapshot: %v", err)
+	}
+	block := parent.Sequence() + 1
+	hdr := seedBlockHeader(parent)
+	open := ledger.NewOpenWithHeader(hdr, seed, shamap.New(shamap.TypeTransaction), drops.Fees{})
+
+	if err := open.Close(hdr.CloseTime, 0); err != nil {
+		t.Fatalf("closing first replayed block %d after checkpoint seed: %v", block, err)
+	}
+
+	// The rolling LedgerHashes must have advanced by exactly one append: the
+	// parent hash, stamped at LastLedgerSequence = parent.seq (= block-1).
+	lastSeq, hashes := decodeRollingLedgerHashes(t, open)
+	if want := block - 1; lastSeq != want {
+		t.Errorf("LastLedgerSequence = %d, want %d", lastSeq, want)
+	}
+	if want := int(block - 1); len(hashes) != want {
+		t.Errorf("len(Hashes) = %d, want %d (single append, no duplicate)", len(hashes), want)
+	}
+
+	parentHash := parent.Hash()
+	if got := hashes[len(hashes)-1]; got != parentHash {
+		t.Errorf("last Hashes entry = %x, want parent hash %x", got, parentHash)
+	}
+	// Direct guard against the double-append: the parent hash appears once.
+	count := 0
+	for _, h := range hashes {
+		if h == parentHash {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("parent hash appears %d times in rolling skip list, want 1", count)
+	}
+}
+
+// TestReplayClose_DoubleSkipListUpdateRejected reproduces the exact failure
+// from issue #997: running a skip-list update before Close() (as the replay
+// tooling used to) double-appends the parent hash, so Close()'s own update
+// finds LastLedgerSequence already at prevIndex and aborts. This pins why the
+// pre-Close pass had to be removed — Close() must be the sole updater.
+func TestReplayClose_DoubleSkipListUpdateRejected(t *testing.T) {
+	parent := walkGenesisTo(t, 6)
+
+	seed, err := parent.StateMapSnapshot()
+	if err != nil {
+		t.Fatalf("StateMapSnapshot: %v", err)
+	}
+	hdr := seedBlockHeader(parent)
+
+	// Simulate the removed pre-Close skip-list pass: one update advances the
+	// seed's rolling list to LastLedgerSequence = prevIndex.
+	if err := ledger.UpdateSkipListOnMap(seed, hdr.LedgerIndex, hdr.ParentHash); err != nil {
+		t.Fatalf("first (pre-Close) skip-list update: %v", err)
+	}
+
+	// Close() runs the update a second time and must reject the now-ahead state.
+	open := ledger.NewOpenWithHeader(hdr, seed, shamap.New(shamap.TypeTransaction), drops.Fees{})
+	if err := open.Close(hdr.CloseTime, 0); err == nil {
+		t.Fatal("Close after a double skip-list update: want error, got nil")
+	} else {
+		t.Logf("got expected error: %v", err)
+	}
+}
+
+// walkGenesisTo builds a genesis ledger and advances it to sequence target via
+// the consensus construction (NewOpen + Close), returning the closed parent.
+// Its rolling LedgerHashes SLE is then populated (LastLedgerSequence =
+// target-1, target-1 hashes), as a real checkpoint seed would be.
+func walkGenesisTo(t *testing.T, target uint32) *ledger.Ledger {
+	t.Helper()
+	res, err := genesis.Create(genesis.DefaultConfig())
+	if err != nil {
+		t.Fatalf("genesis.Create: %v", err)
+	}
+	parent := ledger.FromGenesis(res.Header, res.StateMap, res.TxMap, drops.Fees{})
+	for parent.Sequence() < target {
+		closeTime := parent.CloseTime().Add(10 * time.Second)
+		child, err := ledger.NewOpen(parent, closeTime)
+		if err != nil {
+			t.Fatalf("NewOpen at seq %d: %v", parent.Sequence()+1, err)
+		}
+		if err := child.Close(closeTime, 0); err != nil {
+			t.Fatalf("Close at seq %d: %v", child.Sequence(), err)
+		}
+		parent = child
+	}
+	return parent
+}
+
+// seedBlockHeader builds the header for the first replayed block on top of
+// parent, mirroring replay_range's NewOpenWithHeader construction.
+func seedBlockHeader(parent *ledger.Ledger) header.LedgerHeader {
+	return header.LedgerHeader{
+		LedgerIndex:         parent.Sequence() + 1,
+		ParentHash:          parent.Hash(),
+		ParentCloseTime:     parent.CloseTime(),
+		CloseTime:           parent.CloseTime().Add(10 * time.Second),
+		CloseTimeResolution: parent.CloseTimeResolution(),
+		Drops:               parent.TotalDrops(),
+	}
+}
+
+// decodeRollingLedgerHashes reads the rolling-256 LedgerHashes SLE from l and
+// returns its (LastLedgerSequence, Hashes). Returns (0, nil) when absent.
+func decodeRollingLedgerHashes(t *testing.T, l *ledger.Ledger) (uint32, [][32]byte) {
+	t.Helper()
+	raw, err := l.Read(keylet.LedgerHashes())
+	if err != nil {
+		t.Fatalf("read LedgerHashes SLE: %v", err)
+	}
+	if raw == nil {
+		return 0, nil
+	}
+	decoded, err := binarycodec.DecodeBytes(raw)
+	if err != nil {
+		t.Fatalf("decode LedgerHashes SLE: %v", err)
+	}
+
+	var lastSeq uint32
+	switch v := decoded["LastLedgerSequence"].(type) {
+	case uint32:
+		lastSeq = v
+	case int:
+		lastSeq = uint32(v)
+	case int64:
+		lastSeq = uint32(v)
+	case uint64:
+		lastSeq = uint32(v)
+	default:
+		t.Fatalf("LastLedgerSequence type %T", decoded["LastLedgerSequence"])
+	}
+
+	var rawHashes []string
+	switch v := decoded["Hashes"].(type) {
+	case []string:
+		rawHashes = v
+	case []any:
+		for _, h := range v {
+			rawHashes = append(rawHashes, h.(string))
+		}
+	default:
+		t.Fatalf("Hashes type %T", decoded["Hashes"])
+	}
+
+	hashes := make([][32]byte, 0, len(rawHashes))
+	for _, h := range rawHashes {
+		b, err := hex.DecodeString(h)
+		if err != nil {
+			t.Fatalf("decode hash %q: %v", h, err)
+		}
+		var arr [32]byte
+		copy(arr[:], b)
+		hashes = append(hashes, arr)
+	}
+	return lastSeq, hashes
+}


### PR DESCRIPTION
## Summary

- `replay-range` aborted at the first block after a checkpoint seed with `failed to update skip list: ... existing LastLedgerSequence=N, want N-1`. The root cause is a **double-update**, not a seed off-by-one: the replay tools ran their own `updateSkipList` pass over the open ledger immediately before `Close()`, and `Close()` already updates the `LedgerHashes` skip lists from the header's `ParentHash` as its first step. The parent hash was appended twice, so `Close()`'s update saw the rolling list already at `LastLedgerSequence = prevIndex` and tripped the issue #470 consistency assertion.
- A byte-exact mainnet seed for ledger `M` correctly stores `LastLedgerSequence = M-1` (rippled `Ledger::updateSkipList` stamps `prevIndex = seq-1`); the `M`-valued reading in the report is the result of the redundant pre-`Close` append, which the reproduction test confirms (same rolling-skiplist key `B4979…`, same `existing=N, want N-1` message).
- Remove the redundant pre-`Close` pass from both the single-ledger (`replay.go`) and range (`replay_range.go`) paths, and delete the now-dead local skip-list helpers (`updateSkipList` / `updateOrCreateSkipListEntry` / `createSkipListEntry`). `Close()` → `UpdateSkipListOnMap` is now the sole updater, which also restores the #470 consistency guard for replay (the old pass swallowed its error).

## Test plan
- [x] `go test ./internal/replaytool/... ./internal/ledger/...`
- [x] New `TestReplayClose_CheckpointSeedBoundary` — a checkpoint-seeded block (`NewOpenWithHeader` from a closed-ledger snapshot) closes cleanly and advances the rolling skip list by exactly one append.
- [x] New `TestReplayClose_DoubleSkipListUpdateRejected` — reproduces the exact #997 failure: a pre-`Close` skip-list update makes `Close()` abort.
- [x] `go build ./...`, `go vet ./internal/replaytool/...`, `gofmt`

Fixes #997