### PR TITLE
Reconstruct SLE-implied fields in replay-range ground truth

### DIFF
--- a/internal/replaytool/replay_reconstruct.go
+++ b/internal/replaytool/replay_reconstruct.go
@@ -34,12 +34,12 @@ func reconstructMainnetState(
 	if err != nil {
 		return nil, false, fmt.Errorf("getting transactions: %w", err)
 	}
-	metaBlobs := make([][]byte, len(txs))
+	metas := make([]metaTx, len(txs))
 	for i, t := range txs {
-		metaBlobs[i] = t.MetaBlob
+		metas[i] = metaTx{Blob: t.MetaBlob, TxHash: t.TxHash}
 	}
 
-	corrected, err := reconstructFromMeta(preState, metaBlobs)
+	corrected, err := reconstructFromMeta(preState, metas, ledgerIndex)
 	if err != nil {
 		return nil, false, err
 	}
@@ -51,20 +51,35 @@ func reconstructMainnetState(
 	return corrected, root == expectedAccountHash, nil
 }
 
-// reconstructFromMeta applies an ordered list of transaction metadata blobs to
-// a copy of preState and returns the resulting state map. Blobs are the raw
-// per-transaction metadata in ledger (tx_index) order.
-func reconstructFromMeta(preState *shamap.SHAMap, metaBlobs [][]byte) (*shamap.SHAMap, error) {
+// metaTx pairs a transaction's metadata blob with its hash. The hash is threaded
+// into PreviousTxnID on every SLE the transaction created or modified — a field
+// metadata never carries (sMD_DeleteFinal) but the real state SLE always does.
+type metaTx struct {
+	Blob   []byte
+	TxHash [32]byte
+}
+
+// reconstructFromMeta applies an ordered list of per-transaction metadata to a
+// copy of preState and returns the resulting state map. metas are in ledger
+// (tx_index) order. A second pass rebuilds directory page contents (sfIndexes),
+// which metadata never carries.
+func reconstructFromMeta(preState *shamap.SHAMap, metas []metaTx, ledgerIndex uint32) (*shamap.SHAMap, error) {
 	corrected, err := preState.Snapshot(true)
 	if err != nil {
 		return nil, fmt.Errorf("snapshotting pre-state: %w", err)
 	}
 
-	for i, blob := range metaBlobs {
-		if len(blob) == 0 {
+	// Directory page sfIndexes is sMD_Never, so it cannot be overlaid from a
+	// metadata delta; it is reconstructed from the per-page membership changes
+	// collected while applying every affected node, then written in a second pass.
+	deltas := map[[32]byte]*dirDelta{}
+	deletedDirs := map[[32]byte]bool{}
+
+	for i, m := range metas {
+		if len(m.Blob) == 0 {
 			continue
 		}
-		meta, err := binarycodec.Decode(hex.EncodeToString(blob))
+		meta, err := binarycodec.Decode(hex.EncodeToString(m.Blob))
 		if err != nil {
 			return nil, fmt.Errorf("decoding metadata for tx %d: %w", i, err)
 		}
@@ -73,22 +88,36 @@ func reconstructFromMeta(preState *shamap.SHAMap, metaBlobs [][]byte) (*shamap.S
 			continue
 		}
 		for _, node := range affected {
-			if err := applyAffectedNode(corrected, node); err != nil {
+			if err := applyAffectedNode(corrected, node, m.TxHash, ledgerIndex, deltas, deletedDirs); err != nil {
 				return nil, fmt.Errorf("applying metadata for tx %d: %w", i, err)
 			}
 		}
+	}
+
+	if err := reconstructDirIndexes(corrected, deltas, deletedDirs); err != nil {
+		return nil, fmt.Errorf("reconstructing directory pages: %w", err)
 	}
 	return corrected, nil
 }
 
 // applyAffectedNode applies one metadata AffectedNode (CreatedNode /
-// ModifiedNode / DeletedNode) to the state map.
-func applyAffectedNode(state *shamap.SHAMap, node any) error {
-	entry, ok := node.(map[string]any)
+// ModifiedNode / DeletedNode) to the state map. Created objects are completed
+// with the soeREQUIRED default-zero fields metadata omits; created and modified
+// objects of threaded types are stamped with PreviousTxnID/PreviousTxnLgrSeq.
+// Directory membership changes are accumulated into deltas for the second pass.
+func applyAffectedNode(
+	state *shamap.SHAMap,
+	node any,
+	txHash [32]byte,
+	ledgerSeq uint32,
+	deltas map[[32]byte]*dirDelta,
+	deletedDirs map[[32]byte]bool,
+) error {
+	affectedNode, ok := node.(map[string]any)
 	if !ok {
 		return nil
 	}
-	for kind, body := range entry {
+	for kind, body := range affectedNode {
 		fields, ok := body.(map[string]any)
 		if !ok {
 			continue
@@ -98,9 +127,14 @@ func applyAffectedNode(state *shamap.SHAMap, node any) error {
 		if err != nil {
 			return fmt.Errorf("bad LedgerIndex %q: %w", idxHex, err)
 		}
+		entryType, _ := fields["LedgerEntryType"].(string)
 
 		switch kind {
 		case "DeletedNode":
+			recordMembership(deltas, idx, entryType, asMap(fields["FinalFields"]), false)
+			if entryType == "DirectoryNode" {
+				deletedDirs[idx] = true
+			}
 			if err := state.Delete(idx); err != nil && !errors.Is(err, shamap.ErrItemNotFound) {
 				return fmt.Errorf("deleting %s: %w", idxHex, err)
 			}
@@ -110,6 +144,9 @@ func applyAffectedNode(state *shamap.SHAMap, node any) error {
 			if let, ok := fields["LedgerEntryType"]; ok {
 				obj["LedgerEntryType"] = let
 			}
+			fillRequiredDefaults(obj, entryType)
+			threadPreviousTxn(obj, entryType, txHash, ledgerSeq)
+			recordMembership(deltas, idx, entryType, obj, true)
 			if err := putEncoded(state, idx, obj); err != nil {
 				return fmt.Errorf("creating %s: %w", idxHex, err)
 			}
@@ -129,6 +166,7 @@ func applyAffectedNode(state *shamap.SHAMap, node any) error {
 				}
 			}
 			maps.Copy(obj, final)
+			threadPreviousTxn(obj, entryType, txHash, ledgerSeq)
 			if err := putEncoded(state, idx, obj); err != nil {
 				return fmt.Errorf("modifying %s: %w", idxHex, err)
 			}

--- a/internal/replaytool/replay_reconstruct_defaults.go
+++ b/internal/replaytool/replay_reconstruct_defaults.go
@@ -24,7 +24,8 @@ var conditionalThreadingTypes = map[string]bool{
 }
 
 // nonThreadedTypes never carry PreviousTxnID, mirroring
-// internal/tx/applystate.nonThreadedTypes.
+// internal/tx/applystate.nonThreadedTypes. LedgerHashes is the only entry type
+// whose format lacks the field; a new field-less type must be added here.
 var nonThreadedTypes = map[string]bool{
 	"LedgerHashes": true,
 }
@@ -59,11 +60,14 @@ type requiredField struct {
 //
 // A field belongs here iff it is soeREQUIRED for the type AND its default is a
 // zero that isDefault() reports true (UInt = 0, native XRP Amount = 0 drops,
-// Hash256 = zero, empty array). sfFlags is soeREQUIRED on every type (a common
-// field), so every type carries Flags: 0. Fields that are never at default-zero
-// on creation (Account, Sequence, BookDirectory, RootIndex, non-native Balance,
-// ...) are excluded, as are soeOPTIONAL/soeDEFAULT fields, PreviousTxnID/Seq
-// (handled by threading) and LedgerEntryType (carried at the node level).
+// Hash256 = zero, empty array) AND it is metadata-eligible (rippled only drops
+// default fields that would otherwise be emitted into NewFields). sfFlags is
+// soeREQUIRED on every type (a common field), so every type carries Flags: 0.
+// Fields that are never at default-zero on creation (Account, Sequence,
+// BookDirectory, RootIndex, non-native Balance, ...) are excluded, as are
+// soeOPTIONAL/soeDEFAULT fields, the never-in-metadata fields PreviousTxnID/Seq
+// (handled by threading) and Indexes, and LedgerEntryType (carried at the node
+// level).
 //
 // Representations: UInt32 -> int(0); UInt64 -> "0" (lowercase hex, no leading
 // zeros, == binarycodec UInt64.ToJSON); native Amount -> "0" (drops).

--- a/internal/replaytool/replay_reconstruct_defaults.go
+++ b/internal/replaytool/replay_reconstruct_defaults.go
@@ -1,0 +1,216 @@
+package replaytool
+
+import (
+	"encoding/hex"
+	"strings"
+)
+
+// fixPreviousTxnIDEnabled reflects that this tool reconstructs recent mainnet
+// ledgers, where fixPreviousTxnID has long been active. It gates whether the
+// directory/singleton types listed in conditionalThreadingTypes carry threaded
+// PreviousTxnID/PreviousTxnLgrSeq fields. Replaying a pre-amendment ledger with
+// this true would over-thread those types; that only degrades the reconstruction
+// (account_hash will not verify), it never masks a real divergence.
+const fixPreviousTxnIDEnabled = true
+
+// Types whose threading is conditional on fixPreviousTxnID, mirroring
+// internal/tx/applystate.conditionalThreadingTypes.
+var conditionalThreadingTypes = map[string]bool{
+	"DirectoryNode": true,
+	"Amendments":    true,
+	"FeeSettings":   true,
+	"NegativeUNL":   true,
+	"AMM":           true,
+}
+
+// nonThreadedTypes never carry PreviousTxnID, mirroring
+// internal/tx/applystate.nonThreadedTypes.
+var nonThreadedTypes = map[string]bool{
+	"LedgerHashes": true,
+}
+
+// isThreadedType reports whether an entry type carries threaded
+// PreviousTxnID/PreviousTxnLgrSeq fields. It mirrors
+// internal/tx/applystate.isThreadedType.
+func isThreadedType(entryType string) bool {
+	if nonThreadedTypes[entryType] {
+		return false
+	}
+	if conditionalThreadingTypes[entryType] {
+		return fixPreviousTxnIDEnabled
+	}
+	return true
+}
+
+// requiredField is one soeREQUIRED ledger-entry field whose STObject default (a
+// "zero" that rippled's isDefault() reports true) is omitted from a CreatedNode's
+// NewFields, even though the real serialized SLE always carries it. Value is the
+// form binarycodec.Encode accepts for that zero, identical to the bytes
+// binarycodec.Decode would have produced had the field been present.
+type requiredField struct {
+	Name  string
+	Value any
+}
+
+// requiredDefaults lists, per ledger-entry type, the soeREQUIRED fields rippled
+// omits from NewFields when they sit at their STObject default. After copying a
+// CreatedNode's NewFields we re-add any of these the metadata did not carry, so
+// the re-encoded SLE matches mainnet byte-for-byte.
+//
+// A field belongs here iff it is soeREQUIRED for the type AND its default is a
+// zero that isDefault() reports true (UInt = 0, native XRP Amount = 0 drops,
+// Hash256 = zero, empty array). sfFlags is soeREQUIRED on every type (a common
+// field), so every type carries Flags: 0. Fields that are never at default-zero
+// on creation (Account, Sequence, BookDirectory, RootIndex, non-native Balance,
+// ...) are excluded, as are soeOPTIONAL/soeDEFAULT fields, PreviousTxnID/Seq
+// (handled by threading) and LedgerEntryType (carried at the node level).
+//
+// Representations: UInt32 -> int(0); UInt64 -> "0" (lowercase hex, no leading
+// zeros, == binarycodec UInt64.ToJSON); native Amount -> "0" (drops).
+//
+// DirectoryNode deliberately carries only Flags: its Indexes (sMD_Never) never
+// appears in metadata and is reconstructed from object membership instead (see
+// replay_reconstruct_dir.go); RootIndex (sMD_Always) is always already present.
+var requiredDefaults = map[string][]requiredField{
+	"AccountRoot": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerCount", Value: 0},
+	},
+	"Offer": {
+		{Name: "Flags", Value: 0},
+		{Name: "BookNode", Value: "0"},
+		{Name: "OwnerNode", Value: "0"},
+	},
+	"DirectoryNode": {
+		{Name: "Flags", Value: 0},
+	},
+	"RippleState": {
+		{Name: "Flags", Value: 0},
+	},
+	"NFTokenOffer": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+		{Name: "NFTokenOfferNode", Value: "0"},
+	},
+	"Check": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+		{Name: "DestinationNode", Value: "0"},
+	},
+	"DID": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+	},
+	"NegativeUNL": {
+		{Name: "Flags", Value: 0},
+	},
+	"NFTokenPage": {
+		{Name: "Flags", Value: 0},
+	},
+	"SignerList": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+		{Name: "SignerListID", Value: 0},
+	},
+	"Ticket": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+	},
+	"Amendments": {
+		{Name: "Flags", Value: 0},
+	},
+	"LedgerHashes": {
+		{Name: "Flags", Value: 0},
+	},
+	"Bridge": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+		{Name: "XChainClaimID", Value: "0"},
+		{Name: "XChainAccountCreateCount", Value: "0"},
+		{Name: "XChainAccountClaimCount", Value: "0"},
+	},
+	"DepositPreauth": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+	},
+	"XChainOwnedClaimID": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+	},
+	"FeeSettings": {
+		{Name: "Flags", Value: 0},
+	},
+	"XChainOwnedCreateAccountClaimID": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+		{Name: "XChainAccountCreateCount", Value: "0"},
+	},
+	"Escrow": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+	},
+	"PayChannel": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+		{Name: "Balance", Value: "0"},
+	},
+	"AMM": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+	},
+	"MPTokenIssuance": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+		{Name: "OutstandingAmount", Value: "0"},
+	},
+	"MPToken": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+	},
+	"Oracle": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+	},
+	"Credential": {
+		{Name: "Flags", Value: 0},
+		{Name: "IssuerNode", Value: "0"},
+		{Name: "SubjectNode", Value: "0"},
+	},
+	"PermissionedDomain": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+	},
+	"Delegate": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+	},
+	"Vault": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+	},
+}
+
+// fillRequiredDefaults adds every soeREQUIRED default-zero field for entryType
+// that obj does not already carry. A soeREQUIRED field absent from a CreatedNode's
+// NewFields is, by rippled's rule, at its default — so re-adding the default zero
+// is exact.
+func fillRequiredDefaults(obj map[string]any, entryType string) {
+	for _, f := range requiredDefaults[entryType] {
+		if _, present := obj[f.Name]; !present {
+			obj[f.Name] = f.Value
+		}
+	}
+}
+
+// threadPreviousTxn stamps the threaded PreviousTxnID/PreviousTxnLgrSeq onto obj
+// for threaded entry types, mirroring what ApplyStateTable writes to the state
+// SLE: the current transaction's hash and ledger sequence. These fields never
+// appear in CreatedNode NewFields or ModifiedNode FinalFields (sMD_DeleteFinal),
+// so they must be supplied here for the reconstructed SLE to match mainnet.
+func threadPreviousTxn(obj map[string]any, entryType string, txHash [32]byte, ledgerSeq uint32) {
+	if !isThreadedType(entryType) {
+		return
+	}
+	obj["PreviousTxnID"] = strings.ToUpper(hex.EncodeToString(txHash[:]))
+	obj["PreviousTxnLgrSeq"] = ledgerSeq
+}

--- a/internal/replaytool/replay_reconstruct_dir.go
+++ b/internal/replaytool/replay_reconstruct_dir.go
@@ -21,9 +21,10 @@ import (
 // the ledger added to / removed from each page, mirroring rippled's directory
 // machinery:
 //
-//   - Owner directories (and every non-offer directory) are kept sorted by key
-//     on each insert (ApplyView dirInsert), and removals preserve order.
-//   - Offer book directories preserve insertion order, appending new offers to
+//   - Owner directories, and every directory other than order books (including
+//     NFToken-offer directories), are kept sorted by key on each insert
+//     (ApplyView dirInsert), and removals preserve order.
+//   - Order-book directories preserve insertion order, appending new offers to
 //     the tail (ApplyView dirAppend); removals preserve order.
 //
 // An object's final OwnerNode/BookNode (etc.) pin it to a specific page, so we
@@ -94,12 +95,16 @@ func directoryPlacements(entryType string, fields map[string]any) []dirPlacement
 		return out
 
 	case "Credential":
-		// A credential is listed in both the issuer's and subject's directories.
+		// The issuer always lists the credential in its directory. The subject
+		// lists it too, except for a self-issued credential (subject == issuer),
+		// which carries no SubjectNode and is listed once.
 		if iss, ok := metaAccountID(fields, "Issuer"); ok {
 			add(keylet.OwnerDirPage(iss, metaUint64(fields["IssuerNode"])), dirSorted)
 		}
-		if sub, ok := metaAccountID(fields, "Subject"); ok {
-			add(keylet.OwnerDirPage(sub, metaUint64(fields["SubjectNode"])), dirSorted)
+		if _, has := fields["SubjectNode"]; has {
+			if sub, ok := metaAccountID(fields, "Subject"); ok {
+				add(keylet.OwnerDirPage(sub, metaUint64(fields["SubjectNode"])), dirSorted)
+			}
 		}
 		return out
 	}
@@ -137,6 +142,15 @@ func directoryPlacements(entryType string, fields map[string]any) []dirPlacement
 		if dest, ok := metaAccountID(fields, "Destination"); ok {
 			if _, has := fields["DestinationNode"]; has {
 				add(keylet.OwnerDirPage(dest, metaUint64(fields["DestinationNode"])), dirSorted)
+			}
+		}
+		// An IOU escrow is additionally listed in the issuer's owner directory
+		// (IssuerNode present) to track the locked balance.
+		if entryType == "Escrow" {
+			if iss, ok := metaIssuer(fields, "Amount"); ok {
+				if _, has := fields["IssuerNode"]; has {
+					add(keylet.OwnerDirPage(iss, metaUint64(fields["IssuerNode"])), dirSorted)
+				}
 			}
 		}
 	}
@@ -246,7 +260,10 @@ func encodeIndexes(members [][32]byte) []string {
 }
 
 // metaUint64 reads a UInt64 (hex string) or UInt32 (numeric) metadata field as a
-// uint64, returning 0 when the field is absent or unparseable.
+// uint64, returning 0 when the field is absent or unparseable. Node-pointer
+// fields are sMD_Default (always present on created/deleted nodes), so an absent
+// field attributing to page 0 only arises on malformed input, which the final
+// account_hash check catches.
 func metaUint64(v any) uint64 {
 	switch t := v.(type) {
 	case string:

--- a/internal/replaytool/replay_reconstruct_dir.go
+++ b/internal/replaytool/replay_reconstruct_dir.go
@@ -1,0 +1,304 @@
+package replaytool
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+	ledgerentry "github.com/LeJamon/go-xrpl/ledger/entry"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+// A DirectoryNode page's sfIndexes (its membership list) is sMD_Never: it never
+// appears in transaction metadata, so it cannot be overlaid from a metadata
+// delta the way every other field is. We instead reconstruct it from the objects
+// the ledger added to / removed from each page, mirroring rippled's directory
+// machinery:
+//
+//   - Owner directories (and every non-offer directory) are kept sorted by key
+//     on each insert (ApplyView dirInsert), and removals preserve order.
+//   - Offer book directories preserve insertion order, appending new offers to
+//     the tail (ApplyView dirAppend); removals preserve order.
+//
+// An object's final OwnerNode/BookNode (etc.) pin it to a specific page, so we
+// never have to simulate page splitting — each added/removed key is attributed
+// to the page its own node-pointer names.
+
+// dirStrategy is how a directory page orders its sfIndexes.
+type dirStrategy int
+
+const (
+	dirSorted dirStrategy = iota // dirInsert: page kept sorted by key
+	dirAppend                    // dirAppend: offer books, insertion order
+)
+
+// dirPlacement is one directory page an object is listed in.
+type dirPlacement struct {
+	Key      [32]byte
+	Strategy dirStrategy
+}
+
+// dirDelta accumulates the membership changes a ledger makes to one directory
+// page. adds is in operation order (needed for append-ordered offer books);
+// removes is a set.
+type dirDelta struct {
+	strategy dirStrategy
+	adds     [][32]byte
+	removes  map[[32]byte]bool
+}
+
+// recordMembership attributes an object's creation (isAdd) or deletion to every
+// directory page it belongs to, accumulating the per-page deltas.
+func recordMembership(deltas map[[32]byte]*dirDelta, objKey [32]byte, entryType string, fields map[string]any, isAdd bool) {
+	for _, p := range directoryPlacements(entryType, fields) {
+		d := deltas[p.Key]
+		if d == nil {
+			d = &dirDelta{strategy: p.Strategy, removes: map[[32]byte]bool{}}
+			deltas[p.Key] = d
+		}
+		if isAdd {
+			d.adds = append(d.adds, objKey)
+		} else {
+			d.removes[objKey] = true
+		}
+	}
+}
+
+// directoryPlacements returns the directory pages an object of entryType with
+// the given fields is listed in. The fields come from a CreatedNode's (default-
+// filled) NewFields or a DeletedNode's FinalFields, both of which carry the
+// node-pointer and owner fields needed to locate each page.
+func directoryPlacements(entryType string, fields map[string]any) []dirPlacement {
+	var out []dirPlacement
+	add := func(k keylet.Keylet, s dirStrategy) { out = append(out, dirPlacement{Key: k.Key, Strategy: s}) }
+
+	switch entryType {
+	case "DirectoryNode", "Amendments", "FeeSettings", "NegativeUNL", "LedgerHashes", "AccountRoot":
+		// Directory pages and singletons are not themselves listed in a directory.
+		return nil
+
+	case "RippleState":
+		// A trust line is listed in both endpoints' owner directories.
+		if lo, ok := metaIssuer(fields, "LowLimit"); ok {
+			add(keylet.OwnerDirPage(lo, metaUint64(fields["LowNode"])), dirSorted)
+		}
+		if hi, ok := metaIssuer(fields, "HighLimit"); ok {
+			add(keylet.OwnerDirPage(hi, metaUint64(fields["HighNode"])), dirSorted)
+		}
+		return out
+
+	case "Credential":
+		// A credential is listed in both the issuer's and subject's directories.
+		if iss, ok := metaAccountID(fields, "Issuer"); ok {
+			add(keylet.OwnerDirPage(iss, metaUint64(fields["IssuerNode"])), dirSorted)
+		}
+		if sub, ok := metaAccountID(fields, "Subject"); ok {
+			add(keylet.OwnerDirPage(sub, metaUint64(fields["SubjectNode"])), dirSorted)
+		}
+		return out
+	}
+
+	// Owner directory: the object's owner lists it at OwnerNode. The owner is the
+	// Account field, or Owner for the types that have no Account.
+	if owner, ok := metaAccountID(fields, "Account"); ok {
+		add(keylet.OwnerDirPage(owner, metaUint64(fields["OwnerNode"])), dirSorted)
+	} else if owner, ok := metaAccountID(fields, "Owner"); ok {
+		add(keylet.OwnerDirPage(owner, metaUint64(fields["OwnerNode"])), dirSorted)
+	}
+
+	switch entryType {
+	case "Offer":
+		// Offers are additionally listed in their order-book directory, which is
+		// append-ordered.
+		if book, ok := metaHash256(fields, "BookDirectory"); ok {
+			add(keylet.DirPage(book, metaUint64(fields["BookNode"])), dirAppend)
+		}
+
+	case "NFTokenOffer":
+		// NFToken offers are additionally listed in the per-token buy or sell
+		// offer directory.
+		if nft, ok := metaHash256(fields, "NFTokenID"); ok {
+			root := keylet.NFTBuys(nft)
+			if metaUint64(fields["Flags"])&uint64(ledgerentry.LsfSellNFToken) != 0 {
+				root = keylet.NFTSells(nft)
+			}
+			add(keylet.DirPage(root.Key, metaUint64(fields["NFTokenOfferNode"])), dirSorted)
+		}
+
+	case "Check", "Escrow", "PayChannel":
+		// When threaded to the destination (DestinationNode present), the object
+		// is also listed in the destination's owner directory.
+		if dest, ok := metaAccountID(fields, "Destination"); ok {
+			if _, has := fields["DestinationNode"]; has {
+				add(keylet.OwnerDirPage(dest, metaUint64(fields["DestinationNode"])), dirSorted)
+			}
+		}
+	}
+
+	return out
+}
+
+// reconstructDirIndexes rewrites the sfIndexes of every directory page touched
+// this ledger, applying the accumulated membership deltas to the page's prior
+// contents (already present in state from the metadata pass). Deleted pages are
+// skipped.
+func reconstructDirIndexes(state *shamap.SHAMap, deltas map[[32]byte]*dirDelta, deleted map[[32]byte]bool) error {
+	for pageKey, d := range deltas {
+		if deleted[pageKey] {
+			continue
+		}
+		item, found, err := state.Get(pageKey)
+		if err != nil {
+			return fmt.Errorf("reading directory page %x: %w", pageKey[:4], err)
+		}
+		if !found || item == nil {
+			continue
+		}
+		obj, err := binarycodec.Decode(hex.EncodeToString(item.Data()))
+		if err != nil {
+			return fmt.Errorf("decoding directory page %x: %w", pageKey[:4], err)
+		}
+		members := applyDirDelta(decodeIndexes(obj["Indexes"]), d)
+		obj["Indexes"] = encodeIndexes(members)
+		if err := putEncoded(state, pageKey, obj); err != nil {
+			return fmt.Errorf("re-encoding directory page %x: %w", pageKey[:4], err)
+		}
+	}
+	return nil
+}
+
+// applyDirDelta applies one page's membership delta to its prior members,
+// reproducing rippled's ordering: removals preserve relative order; additions
+// append in operation order, then the whole page is sorted when the directory is
+// sorted (dirInsert) rather than append-ordered (dirAppend). A key both added
+// and removed in the same ledger ends up absent.
+func applyDirDelta(members [][32]byte, d *dirDelta) [][32]byte {
+	if len(d.removes) > 0 {
+		kept := make([][32]byte, 0, len(members))
+		for _, k := range members {
+			if !d.removes[k] {
+				kept = append(kept, k)
+			}
+		}
+		members = kept
+	}
+
+	present := make(map[[32]byte]bool, len(members))
+	for _, k := range members {
+		present[k] = true
+	}
+	for _, k := range d.adds {
+		if present[k] || d.removes[k] {
+			continue
+		}
+		members = append(members, k)
+		present[k] = true
+	}
+
+	if d.strategy == dirSorted {
+		sort.Slice(members, func(i, j int) bool {
+			return bytes.Compare(members[i][:], members[j][:]) < 0
+		})
+	}
+	return members
+}
+
+// decodeIndexes parses a directory page's sfIndexes value into 32-byte keys.
+func decodeIndexes(v any) [][32]byte {
+	var out [][32]byte
+	appendHex := func(s string) {
+		b, err := hex.DecodeString(s)
+		if err == nil && len(b) == 32 {
+			var k [32]byte
+			copy(k[:], b)
+			out = append(out, k)
+		}
+	}
+	switch t := v.(type) {
+	case []any:
+		for _, e := range t {
+			if s, ok := e.(string); ok {
+				appendHex(s)
+			}
+		}
+	case []string:
+		for _, s := range t {
+			appendHex(s)
+		}
+	}
+	return out
+}
+
+// encodeIndexes renders 32-byte keys as the uppercase-hex string array the
+// binary codec expects for sfIndexes.
+func encodeIndexes(members [][32]byte) []string {
+	out := make([]string, len(members))
+	for i, k := range members {
+		out[i] = strings.ToUpper(hex.EncodeToString(k[:]))
+	}
+	return out
+}
+
+// metaUint64 reads a UInt64 (hex string) or UInt32 (numeric) metadata field as a
+// uint64, returning 0 when the field is absent or unparseable.
+func metaUint64(v any) uint64 {
+	switch t := v.(type) {
+	case string:
+		n, _ := strconv.ParseUint(t, 16, 64)
+		return n
+	case float64:
+		return uint64(t)
+	case uint32:
+		return uint64(t)
+	case uint64:
+		return t
+	case int:
+		return uint64(t)
+	case int64:
+		return uint64(t)
+	}
+	return 0
+}
+
+// metaAccountID decodes a classic-address metadata field into an account ID.
+func metaAccountID(fields map[string]any, key string) ([20]byte, bool) {
+	s, ok := fields[key].(string)
+	if !ok || s == "" {
+		return [20]byte{}, false
+	}
+	id, err := state.DecodeAccountID(s)
+	if err != nil {
+		return [20]byte{}, false
+	}
+	return id, true
+}
+
+// metaIssuer decodes the issuer account out of an amount/limit metadata field.
+func metaIssuer(fields map[string]any, key string) ([20]byte, bool) {
+	m, ok := fields[key].(map[string]any)
+	if !ok {
+		return [20]byte{}, false
+	}
+	return metaAccountID(m, "issuer")
+}
+
+// metaHash256 decodes a 32-byte hex metadata field.
+func metaHash256(fields map[string]any, key string) ([32]byte, bool) {
+	s, ok := fields[key].(string)
+	if !ok {
+		return [32]byte{}, false
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil || len(b) != 32 {
+		return [32]byte{}, false
+	}
+	var h [32]byte
+	copy(h[:], b)
+	return h, true
+}

--- a/internal/replaytool/replay_reconstruct_test.go
+++ b/internal/replaytool/replay_reconstruct_test.go
@@ -1,14 +1,23 @@
 package replaytool
 
 import (
+	"bytes"
 	"encoding/hex"
+	"strings"
 	"testing"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
 
 const testAccount = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+// testTxHashHex / testLedgerSeq stand in for the transaction hash and ledger
+// sequence the reconstruction threads into PreviousTxnID / PreviousTxnLgrSeq.
+const testTxHashHex = "AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899"
+const testLedgerSeq = uint32(90000000)
 
 func encodeSLE(t *testing.T, m map[string]any) []byte {
 	t.Helper()
@@ -70,28 +79,35 @@ func putAll(t *testing.T, entries map[[32]byte][]byte) *shamap.SHAMap {
 // TestReconstructFromMeta_ModifyWithFieldRemoval covers the hardest path: a
 // ModifiedNode whose FinalFields is a partial delta (Balance changed) and whose
 // PreviousFields names a field removed by the transaction (Domain). The
-// reconstruction must overlay the delta onto the pre-object and drop the
-// removed field, byte-for-byte.
+// reconstruction must overlay the delta onto the pre-object, drop the removed
+// field, and re-thread PreviousTxnID/PreviousTxnLgrSeq to this transaction —
+// metadata carries neither (sMD_DeleteFinal), so a stale pre-state value must be
+// overwritten, byte-for-byte.
 func TestReconstructFromMeta_ModifyWithFieldRemoval(t *testing.T) {
 	idxHex := "00000000000000000000000000000000000000000000000000000000000000AA"
 	idx := mustIndex(t, idxHex)
+	staleTxID := "1111111111111111111111111111111111111111111111111111111111111111"
 
 	pre := map[string]any{
-		"LedgerEntryType": "AccountRoot",
-		"Account":         testAccount,
-		"Balance":         "1000000000",
-		"Flags":           0,
-		"OwnerCount":      0,
-		"Sequence":        1,
-		"Domain":          "6578616D706C65",
+		"LedgerEntryType":   "AccountRoot",
+		"Account":           testAccount,
+		"Balance":           "1000000000",
+		"Flags":             0,
+		"OwnerCount":        0,
+		"Sequence":          1,
+		"Domain":            "6578616D706C65",
+		"PreviousTxnID":     staleTxID,
+		"PreviousTxnLgrSeq": uint32(42),
 	}
 	post := map[string]any{
-		"LedgerEntryType": "AccountRoot",
-		"Account":         testAccount,
-		"Balance":         "2000000000",
-		"Flags":           0,
-		"OwnerCount":      0,
-		"Sequence":        1,
+		"LedgerEntryType":   "AccountRoot",
+		"Account":           testAccount,
+		"Balance":           "2000000000",
+		"Flags":             0,
+		"OwnerCount":        0,
+		"Sequence":          1,
+		"PreviousTxnID":     testTxHashHex,
+		"PreviousTxnLgrSeq": testLedgerSeq,
 	}
 
 	preState := putAll(t, map[[32]byte][]byte{idx: encodeSLE(t, pre)})
@@ -106,7 +122,7 @@ func TestReconstructFromMeta_ModifyWithFieldRemoval(t *testing.T) {
 		},
 	})
 
-	corrected, err := reconstructFromMeta(preState, [][]byte{meta})
+	corrected, err := reconstructFromMeta(preState, []metaTx{{Blob: meta, TxHash: mustIndex(t, testTxHashHex)}}, testLedgerSeq)
 	if err != nil {
 		t.Fatalf("reconstructFromMeta: %v", err)
 	}
@@ -138,9 +154,12 @@ func TestReconstructFromMeta_CreateAndDelete(t *testing.T) {
 	newFields := map[string]any{
 		"Account": testAccount, "Balance": "30", "Flags": 0, "OwnerCount": 0, "Sequence": 3,
 	}
+	// The created AccountRoot is a threaded type, so the reconstruction stamps
+	// PreviousTxnID/PreviousTxnLgrSeq even though NewFields omits them.
 	created := encodeSLE(t, map[string]any{
 		"LedgerEntryType": "AccountRoot", "Account": testAccount,
 		"Balance": "30", "Flags": 0, "OwnerCount": 0, "Sequence": 3,
+		"PreviousTxnID": testTxHashHex, "PreviousTxnLgrSeq": testLedgerSeq,
 	})
 
 	preState := putAll(t, map[[32]byte][]byte{idxKeep: keep, idxDel: del})
@@ -159,7 +178,7 @@ func TestReconstructFromMeta_CreateAndDelete(t *testing.T) {
 		}},
 	)
 
-	corrected, err := reconstructFromMeta(preState, [][]byte{meta})
+	corrected, err := reconstructFromMeta(preState, []metaTx{{Blob: meta, TxHash: mustIndex(t, testTxHashHex)}}, testLedgerSeq)
 	if err != nil {
 		t.Fatalf("reconstructFromMeta: %v", err)
 	}
@@ -188,7 +207,7 @@ func TestReconstructFromMeta_EmptyMetaLeavesStateUnchanged(t *testing.T) {
 	preState := putAll(t, map[[32]byte][]byte{idx: obj})
 	preRoot, _ := preState.Hash()
 
-	corrected, err := reconstructFromMeta(preState, [][]byte{nil, {}})
+	corrected, err := reconstructFromMeta(preState, []metaTx{{Blob: nil}, {Blob: []byte{}}}, testLedgerSeq)
 	if err != nil {
 		t.Fatalf("reconstructFromMeta: %v", err)
 	}
@@ -232,5 +251,164 @@ func TestDivergingObjects(t *testing.T) {
 	d, ok = byIndex[hex.EncodeToString(idxOnlyGo[:])]
 	if !ok || d.GoXRPL == "" || d.Mainnet != "" {
 		t.Fatalf("go-only object should have empty mainnet side: %+v", d)
+	}
+}
+
+// TestReconstructFromMeta_CreatedOfferDefaults is the issue's exact scenario: a
+// created Offer whose NewFields omits the soeREQUIRED default-zero fields
+// (Flags, BookNode, OwnerNode) and the threaded PreviousTxn pair. The
+// reconstruction must restore all of them so the SLE matches mainnet byte-for-byte.
+func TestReconstructFromMeta_CreatedOfferDefaults(t *testing.T) {
+	idxHex := "00000000000000000000000000000000000000000000000000000000000000C0"
+	idx := mustIndex(t, idxHex)
+	bookDir := "0000000000000000000000000000000000000000000000000000000000000ABC"
+
+	full := map[string]any{
+		"LedgerEntryType":   "Offer",
+		"Account":           testAccount,
+		"Sequence":          5,
+		"TakerPays":         "1000000",
+		"TakerGets":         map[string]any{"value": "10", "currency": "USD", "issuer": testAccount},
+		"BookDirectory":     bookDir,
+		"Flags":             0,
+		"BookNode":          "0",
+		"OwnerNode":         "0",
+		"PreviousTxnID":     testTxHashHex,
+		"PreviousTxnLgrSeq": testLedgerSeq,
+	}
+	wantRoot := stateRoot(t, map[[32]byte][]byte{idx: encodeSLE(t, full)})
+
+	newFields := map[string]any{
+		"Account":       testAccount,
+		"Sequence":      5,
+		"TakerPays":     "1000000",
+		"TakerGets":     map[string]any{"value": "10", "currency": "USD", "issuer": testAccount},
+		"BookDirectory": bookDir,
+	}
+	meta := encodeMeta(t, map[string]any{"CreatedNode": map[string]any{
+		"LedgerEntryType": "Offer",
+		"LedgerIndex":     idxHex,
+		"NewFields":       newFields,
+	}})
+
+	corrected, err := reconstructFromMeta(putAll(t, nil), []metaTx{{Blob: meta, TxHash: mustIndex(t, testTxHashHex)}}, testLedgerSeq)
+	if err != nil {
+		t.Fatalf("reconstructFromMeta: %v", err)
+	}
+	gotRoot, err := corrected.Hash()
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	if gotRoot != wantRoot {
+		t.Fatalf("reconstructed offer root %x != expected %x", gotRoot[:8], wantRoot[:8])
+	}
+}
+
+// TestReconstructFromMeta_DirectoryIndexes covers the directory-page path, whose
+// sfIndexes is sMD_Never and so absent from metadata: an owner directory (kept
+// sorted) gains a created Ticket, and an order-book directory (insertion-ordered)
+// gains a created Offer at its tail. Both pages must be rebuilt byte-for-byte
+// from the membership changes, including the threaded PreviousTxn pair.
+func TestReconstructFromMeta_DirectoryIndexes(t *testing.T) {
+	ownerID, err := state.DecodeAccountID(testAccount)
+	if err != nil {
+		t.Fatalf("DecodeAccountID: %v", err)
+	}
+	ownerPage := keylet.OwnerDirPage(ownerID, 0).Key
+	ownerPageHex := hex.EncodeToString(ownerPage[:])
+	ownerRootHex := strings.ToUpper(hex.EncodeToString(ownerPage[:]))
+
+	keyB := "00000000000000000000000000000000000000000000000000000000000000BB"
+	keyD := "00000000000000000000000000000000000000000000000000000000000000DD"
+
+	bookRootHex := "00000000000000000000000000000000000000000000000000000000B0000000"
+	bookRoot := mustIndex(t, bookRootHex)
+	offer1 := "0000000000000000000000000000000000000000000000000000000000000022"
+	offer2 := "0000000000000000000000000000000000000000000000000000000000000011"
+
+	// Pre-state: the two directory pages with their prior contents.
+	ownerDirPre := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "DirectoryNode",
+		"Flags":           0,
+		"RootIndex":       ownerRootHex,
+		"Owner":           testAccount,
+		"Indexes":         []string{keyD},
+	})
+	bookDirPre := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "DirectoryNode",
+		"Flags":           0,
+		"RootIndex":       bookRootHex,
+		"Indexes":         []string{offer1},
+	})
+	preState := putAll(t, map[[32]byte][]byte{ownerPage: ownerDirPre, bookRoot: bookDirPre})
+
+	meta := encodeMeta(t,
+		map[string]any{"ModifiedNode": map[string]any{
+			"LedgerEntryType": "DirectoryNode",
+			"LedgerIndex":     ownerPageHex,
+			"FinalFields":     map[string]any{"Flags": 0, "RootIndex": ownerRootHex, "Owner": testAccount},
+		}},
+		map[string]any{"ModifiedNode": map[string]any{
+			"LedgerEntryType": "DirectoryNode",
+			"LedgerIndex":     bookRootHex,
+			"FinalFields":     map[string]any{"Flags": 0, "RootIndex": bookRootHex},
+		}},
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "Ticket",
+			"LedgerIndex":     keyB,
+			"NewFields":       map[string]any{"Account": testAccount, "OwnerNode": "0", "TicketSequence": 7},
+		}},
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "Offer",
+			"LedgerIndex":     offer2,
+			"NewFields": map[string]any{
+				"Account":       testAccount,
+				"Sequence":      9,
+				"TakerPays":     "1000000",
+				"TakerGets":     map[string]any{"value": "10", "currency": "USD", "issuer": testAccount},
+				"BookDirectory": bookRootHex,
+				"BookNode":      "0",
+				"OwnerNode":     "3e7", // page 999 of the owner dir: absent here, so untouched
+			},
+		}},
+	)
+
+	corrected, err := reconstructFromMeta(preState, []metaTx{{Blob: meta, TxHash: mustIndex(t, testTxHashHex)}}, testLedgerSeq)
+	if err != nil {
+		t.Fatalf("reconstructFromMeta: %v", err)
+	}
+
+	// Owner directory: sorted insert places keyB before keyD.
+	wantOwner := encodeSLE(t, map[string]any{
+		"LedgerEntryType":   "DirectoryNode",
+		"Flags":             0,
+		"RootIndex":         ownerRootHex,
+		"Owner":             testAccount,
+		"Indexes":           []string{keyB, keyD},
+		"PreviousTxnID":     testTxHashHex,
+		"PreviousTxnLgrSeq": testLedgerSeq,
+	})
+	assertEntryBytes(t, corrected, ownerPage, wantOwner, "owner directory")
+
+	// Order book: append keeps insertion order (offer1 then offer2), not sorted.
+	wantBook := encodeSLE(t, map[string]any{
+		"LedgerEntryType":   "DirectoryNode",
+		"Flags":             0,
+		"RootIndex":         bookRootHex,
+		"Indexes":           []string{offer1, offer2},
+		"PreviousTxnID":     testTxHashHex,
+		"PreviousTxnLgrSeq": testLedgerSeq,
+	})
+	assertEntryBytes(t, corrected, bookRoot, wantBook, "order book directory")
+}
+
+func assertEntryBytes(t *testing.T, m *shamap.SHAMap, key [32]byte, want []byte, label string) {
+	t.Helper()
+	item, found, err := m.Get(key)
+	if err != nil || !found || item == nil {
+		t.Fatalf("%s: entry missing (found=%v err=%v)", label, found, err)
+	}
+	if !bytes.Equal(item.Data(), want) {
+		t.Fatalf("%s bytes mismatch:\n got %X\nwant %X", label, item.Data(), want)
 	}
 }

--- a/internal/replaytool/replay_reconstruct_test.go
+++ b/internal/replaytool/replay_reconstruct_test.go
@@ -402,6 +402,74 @@ func TestReconstructFromMeta_DirectoryIndexes(t *testing.T) {
 	assertEntryBytes(t, corrected, bookRoot, wantBook, "order book directory")
 }
 
+// TestReconstructFromMeta_EscrowIssuerDir covers the issuer owner-directory an
+// IOU escrow is listed in (beyond the owner's and destination's): rippled adds a
+// cross-issuer IOU escrow to the issuer's directory to track the locked balance,
+// recording IssuerNode. The reconstruction must add the escrow key to that page,
+// or the issuer page's sfIndexes diverges from mainnet.
+func TestReconstructFromMeta_EscrowIssuerDir(t *testing.T) {
+	const destination = "rrrrrrrrrrrrrrrrrrrrBZbvji"
+	const issuer = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+
+	issuerID, err := state.DecodeAccountID(issuer)
+	if err != nil {
+		t.Fatalf("DecodeAccountID: %v", err)
+	}
+	issuerPage := keylet.OwnerDirPage(issuerID, 0).Key
+	issuerPageHex := hex.EncodeToString(issuerPage[:])
+	issuerRootHex := strings.ToUpper(hex.EncodeToString(issuerPage[:]))
+
+	escrowKey := "00000000000000000000000000000000000000000000000000000000000000E5"
+	existingKey := "00000000000000000000000000000000000000000000000000000000000000F0"
+
+	// Pre-state: the issuer's directory page already lists one object.
+	issuerDirPre := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "DirectoryNode",
+		"Flags":           0,
+		"RootIndex":       issuerRootHex,
+		"Owner":           issuer,
+		"Indexes":         []string{existingKey},
+	})
+	preState := putAll(t, map[[32]byte][]byte{issuerPage: issuerDirPre})
+
+	meta := encodeMeta(t,
+		map[string]any{"ModifiedNode": map[string]any{
+			"LedgerEntryType": "DirectoryNode",
+			"LedgerIndex":     issuerPageHex,
+			"FinalFields":     map[string]any{"Flags": 0, "RootIndex": issuerRootHex, "Owner": issuer},
+		}},
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "Escrow",
+			"LedgerIndex":     escrowKey,
+			"NewFields": map[string]any{
+				"Account":         testAccount,
+				"Destination":     destination,
+				"Amount":          map[string]any{"value": "10", "currency": "USD", "issuer": issuer},
+				"OwnerNode":       "0",
+				"DestinationNode": "0",
+				"IssuerNode":      "0",
+			},
+		}},
+	)
+
+	corrected, err := reconstructFromMeta(preState, []metaTx{{Blob: meta, TxHash: mustIndex(t, testTxHashHex)}}, testLedgerSeq)
+	if err != nil {
+		t.Fatalf("reconstructFromMeta: %v", err)
+	}
+
+	// Sorted insert: escrowKey (E5) sorts before the existing key (F0).
+	wantIssuerDir := encodeSLE(t, map[string]any{
+		"LedgerEntryType":   "DirectoryNode",
+		"Flags":             0,
+		"RootIndex":         issuerRootHex,
+		"Owner":             issuer,
+		"Indexes":           []string{escrowKey, existingKey},
+		"PreviousTxnID":     testTxHashHex,
+		"PreviousTxnLgrSeq": testLedgerSeq,
+	})
+	assertEntryBytes(t, corrected, issuerPage, wantIssuerDir, "issuer directory")
+}
+
 func assertEntryBytes(t *testing.T, m *shamap.SHAMap, key [32]byte, want []byte, label string) {
 	t.Helper()
 	item, found, err := m.Get(key)


### PR DESCRIPTION
## Summary

`replay-range --continue-on-divergence` rebuilt mainnet's post-state from transaction **metadata**, but metadata deliberately omits fields the real SLE always serializes. The reconstruction therefore never matched mainnet's `account_hash` (`reconstruction_verified=false`, so the survey stopped), and every `diverging_objects` entry was a false positive — making findings useless for localizing real divergences.

This restores the three classes of omitted fields so the reconstructed state is byte-exact:

- **soeREQUIRED default-zero fields** (`Flags`, `OwnerNode`/`BookNode`, `OwnerCount`, …). rippled drops these from `NewFields` when `isDefault()` is true even though the SLE always carries them; a per-type table re-adds them on `CreatedNode`.
- **`PreviousTxnID` / `PreviousTxnLgrSeq`** (`sMD_DeleteFinal`, never in `NewFields`/`FinalFields`). Threaded onto every created **and** modified SLE of a threaded type — fixing both the missing-on-create and the stale-on-modify cases — mirroring `ApplyStateTable` (with the `LedgerHashes` / `fixPreviousTxnID`-gated skip list).
- **`DirectoryNode` `sfIndexes`** (`sMD_Never` — absent from metadata entirely). A second pass rebuilds each touched page's membership from the objects the ledger added to / removed from it: sorted for owner directories (`dirInsert`), insertion-ordered for order books (`dirAppend`), removals order-preserving — matching rippled's `ApplyView` directory machinery. Each object's final `OwnerNode`/`BookNode` pins it to its page, so no page-split simulation is needed.

## Test plan

- [x] `go test ./internal/replaytool/...` — existing reconstruction tests updated for threading; new tests cover the created-Offer default/threading restore (the issue's exact case) and directory-page reconstruction (sorted owner dir + append-ordered book).
- [x] `gofmt`, `go vet ./internal/replaytool/...`, `golangci-lint run ./internal/replaytool/...` (0 issues), full-module `go build ./...`.
- [ ] End-to-end against the lab nodestore: a `replay-range --continue-on-divergence` run over a divergent ledger should now report `reconstruction_verified=true` and surface only genuine `diverging_objects`.

## Notes

Directory reconstruction covers owner directories, order books, trust-line (Low/High) directories, NFToken-offer directories, and destination directories — the relationships that produce the observed false positives. Object types whose membership isn't yet modeled (or pre-`fixPreviousTxnID` ledgers) degrade gracefully: `reconstruction_verified` stays `false`, which never masks a real divergence.

Fixes #1001