### PR TITLE
fix: restore zero-valued XRP-side book directory fields in replay reconstruction

### DIFF
--- a/internal/replaytool/replay_reconstruct.go
+++ b/internal/replaytool/replay_reconstruct.go
@@ -145,6 +145,7 @@ func applyAffectedNode(
 				obj["LedgerEntryType"] = let
 			}
 			fillRequiredDefaults(obj, entryType)
+			fillBookDirectoryDefaults(obj, entryType)
 			threadPreviousTxn(obj, entryType, txHash, ledgerSeq)
 			recordMembership(deltas, idx, entryType, obj, true)
 			if err := putEncoded(state, idx, obj); err != nil {

--- a/internal/replaytool/replay_reconstruct_defaults.go
+++ b/internal/replaytool/replay_reconstruct_defaults.go
@@ -74,7 +74,9 @@ type requiredField struct {
 //
 // DirectoryNode deliberately carries only Flags: its Indexes (sMD_Never) never
 // appears in metadata and is reconstructed from object membership instead (see
-// replay_reconstruct_dir.go); RootIndex (sMD_Always) is always already present.
+// replay_reconstruct_dir.go); RootIndex (sMD_Always) is always already present;
+// the soeOPTIONAL book fields a book directory drops are restored by
+// fillBookDirectoryDefaults.
 var requiredDefaults = map[string][]requiredField{
 	"AccountRoot": {
 		{Name: "Flags", Value: 0},
@@ -202,6 +204,41 @@ func fillRequiredDefaults(obj map[string]any, entryType string) {
 	for _, f := range requiredDefaults[entryType] {
 		if _, present := obj[f.Name]; !present {
 			obj[f.Name] = f.Value
+		}
+	}
+}
+
+// zeroHash160 is the JSON form binarycodec produces for an all-zero Hash160: the
+// XRP side of an order book, whose Currency and Issuer are both zero.
+const zeroHash160 = "0000000000000000000000000000000000000000"
+
+// bookDirectoryFields are the four Currency/Issuer fields a book DirectoryNode
+// serializes for both sides of the order book.
+var bookDirectoryFields = []string{
+	"TakerPaysCurrency",
+	"TakerPaysIssuer",
+	"TakerGetsCurrency",
+	"TakerGetsIssuer",
+}
+
+// fillBookDirectoryDefaults restores the all-zero XRP-side book fields rippled
+// drops from a created book directory's NewFields. These four fields are
+// soeOPTIONAL, so requiredDefaults cannot carry them, yet rippled still omits
+// whichever Currency/Issuer pair is all-zero (the XRP side of the book) because
+// isDefault() reports a zero Hash160 as default — while the real SLE always
+// serializes the full pair for both sides. A DirectoryNode is a book (not an
+// owner) directory iff it carries an ExchangeRate; owner directories never have
+// these fields and are left untouched.
+func fillBookDirectoryDefaults(obj map[string]any, entryType string) {
+	if entryType != "DirectoryNode" {
+		return
+	}
+	if _, isBook := obj["ExchangeRate"]; !isBook {
+		return
+	}
+	for _, name := range bookDirectoryFields {
+		if _, present := obj[name]; !present {
+			obj[name] = zeroHash160
 		}
 	}
 }

--- a/internal/replaytool/replay_reconstruct_test.go
+++ b/internal/replaytool/replay_reconstruct_test.go
@@ -470,6 +470,74 @@ func TestReconstructFromMeta_EscrowIssuerDir(t *testing.T) {
 	assertEntryBytes(t, corrected, issuerPage, wantIssuerDir, "issuer directory")
 }
 
+// TestReconstructFromMeta_CreatedBookDirectoryXRPSide is the issue's exact
+// scenario: a created order-book DirectoryNode whose taker pays in XRP, so its
+// TakerPaysCurrency/TakerPaysIssuer pair is all-zero. rippled drops that pair
+// from NewFields (a zero Hash160 reports isDefault() true), but the real SLE
+// always serializes both sides. The reconstruction must restore the zero pair so
+// the directory matches mainnet byte-for-byte and account_hash verifies.
+func TestReconstructFromMeta_CreatedBookDirectoryXRPSide(t *testing.T) {
+	bookRootHex := "00000000000000000000000000000000000000000000000000000000B0000001"
+	bookRoot := mustIndex(t, bookRootHex)
+	bookRootUpper := strings.ToUpper(bookRootHex)
+	offerKey := "00000000000000000000000000000000000000000000000000000000000000A1"
+
+	const exchangeRate = "5006519F6CF22000"
+	const getsCurrency = "0000000000000000000000005553440000000000" // USD
+	const getsIssuer = "0123456789ABCDEF0123456789ABCDEF01234567"
+
+	// The real book root SLE: both sides present, the XRP (pays) side all-zero,
+	// Indexes listing the offer, and the threaded PreviousTxn pair.
+	wantBook := encodeSLE(t, map[string]any{
+		"LedgerEntryType":   "DirectoryNode",
+		"Flags":             0,
+		"RootIndex":         bookRootUpper,
+		"ExchangeRate":      exchangeRate,
+		"TakerPaysCurrency": zeroHash160,
+		"TakerPaysIssuer":   zeroHash160,
+		"TakerGetsCurrency": getsCurrency,
+		"TakerGetsIssuer":   getsIssuer,
+		"Indexes":           []string{offerKey},
+		"PreviousTxnID":     testTxHashHex,
+		"PreviousTxnLgrSeq": testLedgerSeq,
+	})
+
+	// Metadata: the book directory and the offer are both created this ledger.
+	// NewFields carries only the non-zero (gets) side and ExchangeRate; the XRP
+	// (pays) side and Flags are dropped, and sfIndexes is sMD_Never so absent.
+	meta := encodeMeta(t,
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "DirectoryNode",
+			"LedgerIndex":     bookRootHex,
+			"NewFields": map[string]any{
+				"RootIndex":         bookRootUpper,
+				"ExchangeRate":      exchangeRate,
+				"TakerGetsCurrency": getsCurrency,
+				"TakerGetsIssuer":   getsIssuer,
+			},
+		}},
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "Offer",
+			"LedgerIndex":     offerKey,
+			"NewFields": map[string]any{
+				"Account":       testAccount,
+				"Sequence":      9,
+				"TakerPays":     "1000000",
+				"TakerGets":     map[string]any{"value": "10", "currency": "USD", "issuer": testAccount},
+				"BookDirectory": bookRootHex,
+				"BookNode":      "0",
+				"OwnerNode":     "0",
+			},
+		}},
+	)
+
+	corrected, err := reconstructFromMeta(putAll(t, nil), []metaTx{{Blob: meta, TxHash: mustIndex(t, testTxHashHex)}}, testLedgerSeq)
+	if err != nil {
+		t.Fatalf("reconstructFromMeta: %v", err)
+	}
+	assertEntryBytes(t, corrected, bookRoot, wantBook, "book directory")
+}
+
 func assertEntryBytes(t *testing.T, m *shamap.SHAMap, key [32]byte, want []byte, label string) {
 	t.Helper()
 	item, found, err := m.Get(key)


### PR DESCRIPTION
## Summary

- Follow-up to #1001 (PR #1003). Book `DirectoryNode` reconstruction still dropped the all-zero **XRP-side** `Taker*Currency`/`Taker*Issuer` pair, so reconstructed book directories diverged from mainnet and `reconstruction_verified` stayed `false`, leaving `--continue-on-divergence` unable to localize the real `account_hash` divergence.
- Root cause: a book root always serializes both sides of the order book, but rippled drops whichever `Currency`/`Issuer` pair is all-zero (the XRP side) from a `CreatedNode`'s `NewFields` because a zero `Hash160` reports `isDefault()` true. These four fields are `soeOPTIONAL`, so the existing `requiredDefaults` table cannot carry them.
- Fix: `fillBookDirectoryDefaults` re-adds the all-zero `TakerPays*`/`TakerGets*` fields for any created `DirectoryNode` carrying an `ExchangeRate` (the reliable book-vs-owner directory marker). Owner directories never have these fields and are left untouched. Modified book directories already keep them from the byte-exact pre-state, so only the created-node path needs the fix.

## Test plan

- [x] `go test ./internal/replaytool/` — all pass, including new `TestReconstructFromMeta_CreatedBookDirectoryXRPSide` (created XRP-side book root whose `TakerPays*` pair is dropped from `NewFields` must be restored byte-for-byte).
- [x] Verified the new test **fails** without the fix (reconstructed bytes omit the zero `TakerPaysCurrency`/`TakerPaysIssuer`) and **passes** with it.
- [x] `gofmt -l`, `go vet`, and full `go build ./...` clean.

Fixes #1004