### PR TITLE
fix: don't thread rebuilt order-book directory pages in metadata

### DIFF
--- a/internal/tx/applystate/apply_state_table.go
+++ b/internal/tx/applystate/apply_state_table.go
@@ -720,18 +720,23 @@ func (t *ApplyStateTable) buildCreatedNode(key [32]byte, data []byte) (tx.Affect
 // For a normal in-place modify the original node carries the reliable pointer:
 // the apply path peeks the SLE, so curNode and the original share it.
 //
-// For an erase+reinsert and for the conditional-threading directory types the
-// curNode can be a FRESH SLE with no prior pointer even though the pre-tx object
-// had one, so the original node is the WRONG source. An order-book directory
-// page emptied and rebuilt in the same tx — an account replacing the only offer
-// at a quality level removes it (page erased) then re-adds the new offer (page
-// recreated from scratch by state.DirInsert) — serializes no PreviousTxnID, so
-// rippled threads it to self with a zero prior pointer and emits none. There the
-// captured pre-thread value of Current (zero for the rebuilt page) is correct;
-// an in-place-modified page (e.g. an owner directory) keeps its pointer and
-// still emits it.
+// For an erase+reinsert, and for a DirectoryNode, the curNode can be a FRESH
+// SLE with no prior pointer even though the pre-tx object had one, so the
+// original node is the WRONG source. An order-book directory page emptied and
+// rebuilt in the same tx — an account replacing the only offer at a quality
+// level removes it (page erased) then re-adds the new offer (page recreated from
+// scratch by state.DirInsert) — serializes no PreviousTxnID, so rippled threads
+// it to self with a zero prior pointer and emits none. There the captured
+// pre-thread value of Current (zero for the rebuilt page) is correct; an
+// in-place-modified page (e.g. an owner directory) keeps its pointer and still
+// emits it. DirectoryNode is the only type with this erase→rebuild-flattened-to-
+// modify case AND a serializer that preserves PreviousTxnID round-trip, so its
+// Current is a faithful proxy for rippled's curNode field-presence gate. The
+// other conditional-threading types (Amendments/FeeSettings/NegativeUNL/AMM) are
+// only ever modified in place and several drop PreviousTxnID from Current, so
+// they must source the pointer from the original node.
 func (t *ApplyStateTable) modifiedNodePrevTxn(key [32]byte, entryType string, origEntry ledgerfields.Entry) (string, uint32) {
-	if e, ok := t.items[key]; ok && (e.reinserted || conditionalThreadingTypes[entryType]) {
+	if e, ok := t.items[key]; ok && (e.reinserted || entryType == "DirectoryNode") {
 		if !e.hasThreadPrev || e.threadPrevTxnID == ([32]byte{}) {
 			return "", 0
 		}

--- a/internal/tx/applystate/apply_state_table.go
+++ b/internal/tx/applystate/apply_state_table.go
@@ -712,20 +712,26 @@ func (t *ApplyStateTable) buildCreatedNode(key [32]byte, data []byte) (tx.Affect
 }
 
 // modifiedNodePrevTxn returns the node-level PreviousTxnID/PreviousTxnLgrSeq
-// for a ModifiedNode, mirroring rippled's threadItem (ApplyStateTable.cpp:
-// 552-581): the value is the threaded SLE's PreviousTxnID as it existed BEFORE
-// this tx threaded it (curNode's pre-thread value).
+// for a ModifiedNode. The emitted value is the threaded SLE's PreviousTxnID as
+// it existed BEFORE this tx threaded it (curNode's pre-thread value), omitted
+// when that value is zero — rippled only emits a pointer when the SLE actually
+// carried one (its threading gate is getFieldIndex(sfPreviousTxnID) != -1).
 //
-// For a normal in-place modify rippled peeks the SLE, so curNode carries the
-// original's PreviousTxnID — and goXRPL's serializers may drop it from Current
-// (re-added by threading), so the reliable source is the ORIGINAL node.
+// For a normal in-place modify the original node carries the reliable pointer:
+// the apply path peeks the SLE, so curNode and the original share it.
 //
-// For an erase+reinsert (e.g. a SignerListSet replace recreating the signer
-// list / owner directory) rippled's curNode is a fresh SLE with a zero
-// PreviousTxnID, so it emits no node-level PreviousTxnID. There goXRPL uses the
-// captured pre-thread value of Current (zero for a fresh SLE → omitted).
-func (t *ApplyStateTable) modifiedNodePrevTxn(key [32]byte, origEntry ledgerfields.Entry) (string, uint32) {
-	if e, ok := t.items[key]; ok && e.reinserted {
+// For an erase+reinsert and for the conditional-threading directory types the
+// curNode can be a FRESH SLE with no prior pointer even though the pre-tx object
+// had one, so the original node is the WRONG source. An order-book directory
+// page emptied and rebuilt in the same tx — an account replacing the only offer
+// at a quality level removes it (page erased) then re-adds the new offer (page
+// recreated from scratch by state.DirInsert) — serializes no PreviousTxnID, so
+// rippled threads it to self with a zero prior pointer and emits none. There the
+// captured pre-thread value of Current (zero for the rebuilt page) is correct;
+// an in-place-modified page (e.g. an owner directory) keeps its pointer and
+// still emits it.
+func (t *ApplyStateTable) modifiedNodePrevTxn(key [32]byte, entryType string, origEntry ledgerfields.Entry) (string, uint32) {
+	if e, ok := t.items[key]; ok && (e.reinserted || conditionalThreadingTypes[entryType]) {
 		if !e.hasThreadPrev || e.threadPrevTxnID == ([32]byte{}) {
 			return "", 0
 		}
@@ -775,7 +781,7 @@ func (t *ApplyStateTable) buildModifiedNode(key [32]byte, original, current []by
 			fixPreviousTxnID = t.rules.Enabled(amendment.FeatureFixPreviousTxnID)
 		}
 		if isThreadedType(entryType, fixPreviousTxnID) {
-			node.PreviousTxnID, node.PreviousTxnLgrSeq = t.modifiedNodePrevTxn(key, origEntry)
+			node.PreviousTxnID, node.PreviousTxnLgrSeq = t.modifiedNodePrevTxn(key, entryType, origEntry)
 		}
 		currEntry.EmitPreviousFields(origEntry, node.PreviousFields)
 		currEntry.EmitFinalFields(node.FinalFields)

--- a/internal/tx/applystate/dir_threading_test.go
+++ b/internal/tx/applystate/dir_threading_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -143,5 +144,72 @@ func TestDirInPlaceModify_KeepsPreviousTxnID(t *testing.T) {
 	want := hexUpper(priorTxn)
 	if node.prevTxnID != want {
 		t.Fatalf("in-place directory modify must emit the prior PreviousTxnID %s, got %q", want, node.prevTxnID)
+	}
+}
+
+// amendmentsBytes serializes an Amendments singleton SLE. priorTxn != zero sets
+// the stored PreviousTxnID — the field is added by applyThreading on the prior
+// tx and survives in state even though SerializeAmendmentsSLE never emits it. A
+// zero priorTxn mimics the field-less bytes that this tx's serializer produces.
+func amendmentsBytes(t *testing.T, amendments [][32]byte, priorTxn [32]byte, priorSeq uint32) []byte {
+	t.Helper()
+	hashes := make([]string, len(amendments))
+	for i, h := range amendments {
+		hashes[i] = hexUpper(h)
+	}
+	obj := map[string]any{
+		"LedgerEntryType": "Amendments",
+		"Flags":           uint32(0),
+		"Amendments":      hashes,
+	}
+	if priorTxn != ([32]byte{}) {
+		obj["PreviousTxnID"] = hexUpper(priorTxn)
+		obj["PreviousTxnLgrSeq"] = priorSeq
+	}
+	hexStr, err := binarycodec.Encode(obj)
+	if err != nil {
+		t.Fatalf("encode Amendments: %v", err)
+	}
+	b, err := hex.DecodeString(hexStr)
+	if err != nil {
+		t.Fatalf("decode Amendments hex: %v", err)
+	}
+	return b
+}
+
+// TestConditionalNonDirModify_KeepsPreviousTxnID guards against the #1006 fix
+// being applied too broadly. The threadPrevTxnID (Current-sourced) pointer path
+// is faithful only for DirectoryNode, whose serializer preserves PreviousTxnID
+// round-trip. The other conditional-threading types (Amendments here, also
+// NegativeUNL and AMM) DROP PreviousTxnID from Current, but they are only ever
+// modified in place — so the original node still carries the reliable pointer
+// and rippled emits it (its threading gate is field-presence on the in-place-
+// peeked SLE, which keeps the field). Routing these types through the field-less
+// Current would wrongly omit the node-level PreviousTxnID and fork
+// transaction_hash on every AMM / flag-ledger pseudo-tx modify.
+func TestConditionalNonDirModify_KeepsPreviousTxnID(t *testing.T) {
+	var amendKey [32]byte
+	for i := range amendKey {
+		amendKey[i] = byte(0x70 + i)
+	}
+	var amendA, amendB, priorTxn, thisTxn [32]byte
+	for i := range amendA {
+		amendA[i] = byte(0x01 + i)
+		amendB[i] = byte(0x80 + i)
+		priorTxn[i] = byte(0x42 + i)
+		thisTxn[i] = byte(0x52 + i)
+	}
+
+	orig := amendmentsBytes(t, [][32]byte{amendA}, priorTxn, 99226370)
+	// In-place modify: a second amendment is enabled; the serializer emits no
+	// PreviousTxnID (mirrors SerializeAmendmentsSLE), so Current is field-less.
+	cur := amendmentsBytes(t, [][32]byte{amendA, amendB}, [32]byte{}, 0)
+
+	meta := applyModify(t, amendKey, orig, cur, thisTxn, 99226371)
+	node := findAffected(t, meta, hexUpper(amendKey), "ModifiedNode")
+
+	want := hexUpper(priorTxn)
+	if node.prevTxnID != want {
+		t.Fatalf("in-place Amendments modify must emit the prior PreviousTxnID %s, got %q", want, node.prevTxnID)
 	}
 }

--- a/internal/tx/applystate/dir_threading_test.go
+++ b/internal/tx/applystate/dir_threading_test.go
@@ -1,0 +1,147 @@
+package applystate
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+type affectedView struct {
+	idx       string
+	nodeType  string
+	prevTxnID string
+}
+
+// findAffected returns the AffectedNode for the given ledger index (uppercase
+// hex) and node type, or fails the test.
+func findAffected(t *testing.T, nodes []affectedView, idx, nodeType string) affectedView {
+	t.Helper()
+	for _, n := range nodes {
+		if n.idx == idx && n.nodeType == nodeType {
+			return n
+		}
+	}
+	t.Fatalf("no %s for ledger index %s", nodeType, idx)
+	return affectedView{}
+}
+
+// hexUpper renders a 32-byte key as the uppercase hex the metadata uses.
+func hexUpper(k [32]byte) string { return strings.ToUpper(hex.EncodeToString(k[:])) }
+
+// bookDirBytes serializes an order-book directory page. priorTxn != zero sets
+// the page's stored PreviousTxnID (as a page carries once it has been threaded).
+func bookDirBytes(t *testing.T, root [32]byte, members [][32]byte, priorTxn [32]byte, priorSeq uint32) []byte {
+	t.Helper()
+	dir := &state.DirectoryNode{
+		RootIndex:         root,
+		Indexes:           members,
+		ExchangeRate:      0x5000000000000000,
+		TakerPaysCurrency: [20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 'C', 'N', 'Y', 0, 0, 0, 0, 0},
+		PreviousTxnID:     priorTxn,
+		PreviousTxnLgrSeq: priorSeq,
+	}
+	b, err := state.SerializeDirectoryNode(dir, true)
+	if err != nil {
+		t.Fatalf("SerializeDirectoryNode: %v", err)
+	}
+	return b
+}
+
+// applyModify runs a single in-place modify of bookKey from orig to cur bytes
+// through the full Apply() path (threading + metadata) and returns the
+// AffectedNodes flattened to {idx,type,prevTxnID}.
+func applyModify(t *testing.T, bookKey [32]byte, orig, cur []byte, txHash [32]byte, txSeq uint32) []affectedView {
+	t.Helper()
+	base := newMockBaseView()
+	base.data[bookKey] = orig
+
+	table := NewApplyStateTable(base, txHash, txSeq, amendment.AllSupportedRules())
+	if _, err := table.Read(keylet.Keylet{Key: bookKey}); err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if err := table.Update(keylet.Keylet{Key: bookKey}, cur); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	meta, err := table.Apply()
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	var out []affectedView
+	for _, an := range meta.AffectedNodes {
+		out = append(out, affectedView{
+			idx:       an.LedgerIndex,
+			nodeType:  an.NodeType,
+			prevTxnID: an.PreviousTxnID,
+		})
+	}
+	return out
+}
+
+// TestBookDirRebuild_NoNodeLevelPreviousTxnID reproduces issue #1006: an account
+// replacing the only offer at a quality level empties the order-book directory
+// page (page erased) and re-adds the new offer (page recreated from scratch by
+// state.DirInsert, carrying no PreviousTxnID). The flattened net effect reaching
+// the apply table is a plain modify of the page from its prior bytes (which
+// carried a pointer) to the rebuilt field-less bytes. rippled threads the
+// rebuilt page to self with a zero prior pointer and emits NO node-level
+// PreviousTxnID; goXRPL must match (it previously echoed the stale pointer,
+// +38 bytes, forking transaction_hash).
+func TestBookDirRebuild_NoNodeLevelPreviousTxnID(t *testing.T) {
+	var bookKey [32]byte
+	for i := range bookKey {
+		bookKey[i] = byte(0x10 + i)
+	}
+	var oldOffer, newOffer, priorTxn, thisTxn [32]byte
+	for i := range oldOffer {
+		oldOffer[i] = byte(0x20 + i)
+		newOffer[i] = byte(0x30 + i)
+		priorTxn[i] = byte(0x40 + i)
+		thisTxn[i] = byte(0x50 + i)
+	}
+
+	orig := bookDirBytes(t, bookKey, [][32]byte{oldOffer}, priorTxn, 99226370)
+	// Rebuilt page: fresh, no PreviousTxnID, holds the replacement offer.
+	rebuilt := bookDirBytes(t, bookKey, [][32]byte{newOffer}, [32]byte{}, 0)
+
+	meta := applyModify(t, bookKey, orig, rebuilt, thisTxn, 99226371)
+	node := findAffected(t, meta, hexUpper(bookKey), "ModifiedNode")
+
+	if node.prevTxnID != "" {
+		t.Fatalf("rebuilt book directory must not emit a node-level PreviousTxnID, got %q", node.prevTxnID)
+	}
+}
+
+// TestDirInPlaceModify_KeepsPreviousTxnID guards the converse: a directory page
+// modified in place (e.g. an owner directory gaining/losing an entry) keeps its
+// PreviousTxnID across the parse→serialize round-trip, so the node IS threaded
+// and the prior pointer IS emitted — exactly as rippled does for an in-place
+// peek+update.
+func TestDirInPlaceModify_KeepsPreviousTxnID(t *testing.T) {
+	var bookKey [32]byte
+	for i := range bookKey {
+		bookKey[i] = byte(0x11 + i)
+	}
+	var offerA, offerB, priorTxn, thisTxn [32]byte
+	for i := range offerA {
+		offerA[i] = byte(0x21 + i)
+		offerB[i] = byte(0x31 + i)
+		priorTxn[i] = byte(0x41 + i)
+		thisTxn[i] = byte(0x51 + i)
+	}
+
+	orig := bookDirBytes(t, bookKey, [][32]byte{offerA}, priorTxn, 99226370)
+	// In-place modify: an entry is added; the page keeps its stored pointer.
+	cur := bookDirBytes(t, bookKey, [][32]byte{offerA, offerB}, priorTxn, 99226370)
+
+	meta := applyModify(t, bookKey, orig, cur, thisTxn, 99226371)
+	node := findAffected(t, meta, hexUpper(bookKey), "ModifiedNode")
+
+	want := hexUpper(priorTxn)
+	if node.prevTxnID != want {
+		t.Fatalf("in-place directory modify must emit the prior PreviousTxnID %s, got %q", want, node.prevTxnID)
+	}
+}


### PR DESCRIPTION
## Summary

- During `replay-range` of mainnet ledger **99226371**, goXRPL emitted a node-level `PreviousTxnID`/`PreviousTxnLgrSeq` on a modified order-book `DirectoryNode` that mainnet does **not** — +38 bytes per affected page → forked `transaction_hash`.
- **Root cause:** the diverging transactions replace an offer at the same quality level. The order-book page is **emptied** (last offer removed → page erased) then **rebuilt** (new offer re-added → page recreated from scratch by `state.DirInsert`), so the rebuilt page carries no `PreviousTxnID`. rippled threads such a fresh page to self with a *zero* prior pointer and emits no node-level pointer — its gate is `getFieldIndex(sfPreviousTxnID) != -1` on the threaded SLE, **not** the entry type. goXRPL instead sourced the pointer from the *original* node for every non-reinserted modify, echoing the stale pre-tx pointer.
- **Fix:** for the conditional-threading directory types, source the node-level pointer from the threaded SLE's captured **pre-thread** `PreviousTxnID` (zero for a rebuilt page → omit; an in-place-modified owner directory keeps and emits its pointer), mirroring rippled's `curNode` field-presence gate. One-line call-site change + the `modifiedNodePrevTxn` condition.

## Verified against mainnet ground truth

Tx `39900413…` / ledger 99226371, queried against a full-history node:
- book dir `02BAAC…` `ModifiedNode` keys `[FinalFields, LedgerEntryType, LedgerIndex]` — **no** `PreviousTxnID` (the consumed + created offer both live in this book; the page is rebuilt).
- owner dir `47FAF5D1…` `ModifiedNode` **has** `PreviousTxnID` (modified in place) — unchanged by this fix.

## Test plan

- [x] New `internal/tx/applystate/dir_threading_test.go`: a rebuilt book page (field-less `Current`) emits no node-level `PreviousTxnID`; an in-place dir modify still emits the prior pointer. The first test fails without the fix (echoes the stale pointer) and passes with it.
- [x] `go test ./internal/tx/... ./internal/ledger/state/... ./internal/replaytool/...` — pass
- [x] `./internal/testing/{offer,payment,amm,escrow}` integration — pass
- [x] Full conformance suite — **per-suite diff vs `main` is empty** (zero regressions); offer / Directory / BookDirs / View suites stay at 100%.

Fixes #1006