### PR TITLE
fix: preserve FirstLedgerSequence in LedgerHashes skip-list rewrite

### DIFF
--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -376,7 +376,7 @@ func (l *Ledger) HashOfSeq(seq uint32) ([32]byte, bool, error) {
 
 	// Rolling 256: this ledger's skip list holds hashes for seqs
 	// [lseq-len .. lseq-1], so hash(seq) sits at index len-diff.
-	hashes, _, err := readLedgerHashesSLE(l.stateMap, keylet.LedgerHashes().Key)
+	_, hashes, _, err := readLedgerHashesSLE(l.stateMap, keylet.LedgerHashes().Key)
 	if err != nil {
 		return [32]byte{}, false, err
 	}
@@ -391,7 +391,7 @@ func (l *Ledger) HashOfSeq(seq uint32) ([32]byte, bool, error) {
 	if seq&0xff != 0 {
 		return [32]byte{}, false, nil
 	}
-	histHashes, lastSeq, err := readLedgerHashesSLE(l.stateMap, keylet.LedgerHashesForSeq(seq).Key)
+	_, histHashes, lastSeq, err := readLedgerHashesSLE(l.stateMap, keylet.LedgerHashesForSeq(seq).Key)
 	if err != nil {
 		return [32]byte{}, false, err
 	}
@@ -761,7 +761,7 @@ func UpdateSkipListOnMap(stateMap *shamap.SHAMap, ledgerSeq uint32, parentHash [
 	// window holds at most 65536/256 = 256 entries.
 	if (prevIndex & 0xff) == 0 {
 		histKey := keylet.LedgerHashesForSeq(prevIndex)
-		hashes, lastSeq, err := readLedgerHashesSLE(stateMap, histKey.Key)
+		fields, hashes, lastSeq, err := readLedgerHashesSLE(stateMap, histKey.Key)
 		if err != nil {
 			return fmt.Errorf("read historical skip list: %w", err)
 		}
@@ -769,14 +769,14 @@ func UpdateSkipListOnMap(stateMap *shamap.SHAMap, ledgerSeq uint32, parentHash [
 			return fmt.Errorf("historical LedgerHashes (key %x): %w", histKey.Key, err)
 		}
 		hashes = append(hashes, parentHash)
-		if err := writeSkipList(stateMap, histKey.Key, hashes, prevIndex); err != nil {
+		if err := writeSkipList(stateMap, histKey.Key, fields, hashes, prevIndex); err != nil {
 			return fmt.Errorf("write historical skip list: %w", err)
 		}
 	}
 
 	// Operation 2: Rolling 256 skiplist (every ledger)
 	rollingKey := keylet.LedgerHashes()
-	hashes, lastSeq, err := readLedgerHashesSLE(stateMap, rollingKey.Key)
+	fields, hashes, lastSeq, err := readLedgerHashesSLE(stateMap, rollingKey.Key)
 	if err != nil {
 		return fmt.Errorf("read rolling skip list: %w", err)
 	}
@@ -788,7 +788,7 @@ func UpdateSkipListOnMap(stateMap *shamap.SHAMap, ledgerSeq uint32, parentHash [
 		hashes = hashes[1:]
 	}
 	hashes = append(hashes, parentHash)
-	if err := writeSkipList(stateMap, rollingKey.Key, hashes, prevIndex); err != nil {
+	if err := writeSkipList(stateMap, rollingKey.Key, fields, hashes, prevIndex); err != nil {
 		return fmt.Errorf("write rolling skip list: %w", err)
 	}
 
@@ -845,30 +845,32 @@ func assertHistoricalSkipListConsistent(hashes [][32]byte, lastSeq, prevIndex ui
 	return nil
 }
 
-// readLedgerHashesSLE returns (Hashes, LastLedgerSequence) for the
-// LedgerHashes SLE at key, or (nil, 0, nil) when absent.
-func readLedgerHashesSLE(stateMap *shamap.SHAMap, key [32]byte) ([][32]byte, uint32, error) {
+// readLedgerHashesSLE returns the decoded field map, Hashes, and
+// LastLedgerSequence for the LedgerHashes SLE at key, or (nil, nil, 0, nil)
+// when absent. The field map lets callers preserve every present field —
+// notably the optional FirstLedgerSequence — when rewriting the SLE.
+func readLedgerHashesSLE(stateMap *shamap.SHAMap, key [32]byte) (map[string]any, [][32]byte, uint32, error) {
 	item, found, err := stateMap.Get(key)
 	if err != nil {
-		return nil, 0, err
+		return nil, nil, 0, err
 	}
 	if !found {
-		return nil, 0, nil
+		return nil, nil, 0, nil
 	}
 	jsonObj, err := binarycodec.DecodeBytes(item.Data())
 	if err != nil {
-		return nil, 0, fmt.Errorf("decode LedgerHashes: %w", err)
+		return nil, nil, 0, fmt.Errorf("decode LedgerHashes: %w", err)
 	}
 
 	hashes, err := decodeHashesField(jsonObj)
 	if err != nil {
-		return nil, 0, err
+		return nil, nil, 0, err
 	}
 	lastSeq, err := decodeUint32Field(jsonObj, "LastLedgerSequence")
 	if err != nil {
-		return nil, 0, err
+		return nil, nil, 0, err
 	}
-	return hashes, lastSeq, nil
+	return jsonObj, hashes, lastSeq, nil
 }
 
 func decodeHashesField(jsonObj map[string]any) ([][32]byte, error) {
@@ -927,23 +929,37 @@ func decodeUint32Field(jsonObj map[string]any, name string) (uint32, error) {
 // Thin wrapper over readLedgerHashesSLE that drops the LastLedgerSequence
 // — kept for callers (SkipListHashes() exporter) that only need the vector.
 func readSkipListHashes(stateMap *shamap.SHAMap, key [32]byte) ([][32]byte, error) {
-	hashes, _, err := readLedgerHashesSLE(stateMap, key)
+	_, hashes, _, err := readLedgerHashesSLE(stateMap, key)
 	return hashes, err
 }
 
 // writeSkipList serializes a LedgerHashes SLE and writes it to the state map.
-func writeSkipList(stateMap *shamap.SHAMap, key [32]byte, hashes [][32]byte, lastSeq uint32) error {
+//
+// When fields is non-nil — the decoded map of an existing SLE — it updates
+// only Hashes and LastLedgerSequence and preserves every other present field,
+// mirroring rippled's in-place updateSkipList (Ledger.cpp:878-943). This keeps
+// the optional FirstLedgerSequence (and any future field) intact across the
+// per-close rewrite; rebuilding from a fixed field set would silently drop it
+// and shift the state-tree leaf, diverging account_hash.
+//
+// When fields is nil — no existing SLE — it creates a fresh entry. rippled's
+// updateSkipList likewise sets only Hashes and LastLedgerSequence on a newly
+// created SLE, so FirstLedgerSequence is intentionally absent here.
+func writeSkipList(stateMap *shamap.SHAMap, key [32]byte, fields map[string]any, hashes [][32]byte, lastSeq uint32) error {
 	hashHexes := make([]string, len(hashes))
 	for i, h := range hashes {
 		hashHexes[i] = fmt.Sprintf("%064X", h)
 	}
 
-	jsonObj := map[string]any{
-		"LedgerEntryType":    "LedgerHashes",
-		"Flags":              uint32(0),
-		"Hashes":             hashHexes,
-		"LastLedgerSequence": lastSeq,
+	jsonObj := fields
+	if jsonObj == nil {
+		jsonObj = map[string]any{
+			"LedgerEntryType": "LedgerHashes",
+			"Flags":           uint32(0),
+		}
 	}
+	jsonObj["Hashes"] = hashHexes
+	jsonObj["LastLedgerSequence"] = lastSeq
 
 	data, err := binarycodec.EncodeBytes(jsonObj)
 	if err != nil {

--- a/internal/ledger/ledger_skiplist_test.go
+++ b/internal/ledger/ledger_skiplist_test.go
@@ -177,7 +177,7 @@ func TestUpdateSkipListOnMap_RejectsCorruptedExistingSLE(t *testing.T) {
 		t.Fatalf("Snapshot: %v", err)
 	}
 	rollingKey := keylet.LedgerHashes()
-	existingHashes, existingLast, err := readLedgerHashesSLE(stateMap, rollingKey.Key)
+	existingFields, existingHashes, existingLast, err := readLedgerHashesSLE(stateMap, rollingKey.Key)
 	if err != nil {
 		t.Fatalf("readLedgerHashesSLE: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestUpdateSkipListOnMap_RejectsCorruptedExistingSLE(t *testing.T) {
 	ghost[0] = 0xDE
 	ghost[1] = 0xAD
 	corruptedHashes = append(corruptedHashes, ghost)
-	if err := writeSkipList(stateMap, rollingKey.Key, corruptedHashes, existingLast+1); err != nil {
+	if err := writeSkipList(stateMap, rollingKey.Key, existingFields, corruptedHashes, existingLast+1); err != nil {
 		t.Fatalf("writeSkipList (corrupting): %v", err)
 	}
 
@@ -196,4 +196,109 @@ func TestUpdateSkipListOnMap_RejectsCorruptedExistingSLE(t *testing.T) {
 		t.Fatalf("UpdateSkipListOnMap on corrupted SLE: want error, got nil")
 	}
 	t.Logf("got expected error: %v", err)
+}
+
+// walkToSeq advances a freshly created genesis ledger up to (and including)
+// the target sequence, returning the ledger at that seq.
+func walkToSeq(t *testing.T, target uint32) *Ledger {
+	t.Helper()
+	res, err := genesis.Create(genesis.DefaultConfig())
+	if err != nil {
+		t.Fatalf("genesis.Create: %v", err)
+	}
+	parent := FromGenesis(res.Header, res.StateMap, res.TxMap, drops.Fees{})
+	for parent.Sequence() < target {
+		closeTime := parent.CloseTime().Add(10 * time.Second)
+		child, err := NewOpen(parent, closeTime)
+		if err != nil {
+			t.Fatalf("NewOpen at seq %d: %v", parent.Sequence()+1, err)
+		}
+		if err := child.Close(closeTime, 0); err != nil {
+			t.Fatalf("Close at seq %d: %v", child.Sequence(), err)
+		}
+		parent = child
+	}
+	return parent
+}
+
+// TestUpdateSkipListOnMap_PreservesFirstLedgerSequence pins issue #1008: the
+// rolling LedgerHashes SLE is rewritten on every close, and that rewrite must
+// keep the optional FirstLedgerSequence the existing object carries. Mainnet's
+// rolling skip list has FirstLedgerSequence=2; dropping it on rewrite shortens
+// the SLE by 6 bytes, shifting its state-tree leaf and diverging account_hash.
+// rippled mutates the SLE in place (Ledger.cpp:878-943), preserving the field.
+func TestUpdateSkipListOnMap_PreservesFirstLedgerSequence(t *testing.T) {
+	// Parent at seq 5 → rolling SLE describes ledgers 1..4.
+	parent := walkToSeq(t, 5)
+
+	stateMap, err := parent.stateMap.Snapshot(true)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	rollingKey := keylet.LedgerHashes()
+
+	// Stamp FirstLedgerSequence=2 onto the existing rolling SLE, as a
+	// mainnet-seeded state map would carry it. Keep Hashes/LastLedgerSequence
+	// untouched so the next chain-advance assertion still holds.
+	const firstSeq = uint32(2)
+	fields, hashes, lastSeq, err := readLedgerHashesSLE(stateMap, rollingKey.Key)
+	if err != nil {
+		t.Fatalf("readLedgerHashesSLE: %v", err)
+	}
+	if fields == nil {
+		t.Fatalf("rolling LedgerHashes SLE absent at parent seq 5")
+	}
+	fields["FirstLedgerSequence"] = firstSeq
+	if err := writeSkipList(stateMap, rollingKey.Key, fields, hashes, lastSeq); err != nil {
+		t.Fatalf("writeSkipList (seeding FirstLedgerSequence): %v", err)
+	}
+
+	// Advance one ledger — the rewrite under test.
+	if err := UpdateSkipListOnMap(stateMap, parent.Sequence()+1, parent.Hash()); err != nil {
+		t.Fatalf("UpdateSkipListOnMap: %v", err)
+	}
+
+	// FirstLedgerSequence must survive, and the list must have advanced.
+	gotFields, gotHashes, gotLast, err := readLedgerHashesSLE(stateMap, rollingKey.Key)
+	if err != nil {
+		t.Fatalf("readLedgerHashesSLE after advance: %v", err)
+	}
+	gotFirst, err := decodeUint32Field(gotFields, "FirstLedgerSequence")
+	if err != nil {
+		t.Fatalf("decode FirstLedgerSequence: %v", err)
+	}
+	if _, ok := gotFields["FirstLedgerSequence"]; !ok {
+		t.Fatalf("FirstLedgerSequence dropped on rewrite (issue #1008)")
+	}
+	if gotFirst != firstSeq {
+		t.Errorf("FirstLedgerSequence = %d, want %d", gotFirst, firstSeq)
+	}
+	if want := parent.Sequence(); gotLast != want {
+		t.Errorf("LastLedgerSequence = %d, want %d", gotLast, want)
+	}
+	if want := len(hashes) + 1; len(gotHashes) != want {
+		t.Errorf("len(Hashes) = %d, want %d", len(gotHashes), want)
+	}
+	if gotHashes[len(gotHashes)-1] != parent.Hash() {
+		t.Errorf("last Hashes entry = %x, want parent hash %x", gotHashes[len(gotHashes)-1], parent.Hash())
+	}
+}
+
+// TestUpdateSkipListOnMap_CreatedSkipListHasNoFirstLedgerSequence pins the
+// other half of rippled parity: when updateSkipList creates the SLE from
+// scratch it sets only Hashes and LastLedgerSequence, so a node built from a
+// fresh genesis must not synthesize a FirstLedgerSequence the reference never
+// writes.
+func TestUpdateSkipListOnMap_CreatedSkipListHasNoFirstLedgerSequence(t *testing.T) {
+	child := walkToSeq(t, 5)
+	fields, _, _, err := readLedgerHashesSLE(child.stateMap, keylet.LedgerHashes().Key)
+	if err != nil {
+		t.Fatalf("readLedgerHashesSLE: %v", err)
+	}
+	if fields == nil {
+		t.Fatalf("rolling LedgerHashes SLE absent at seq 5")
+	}
+	if _, ok := fields["FirstLedgerSequence"]; ok {
+		t.Errorf("freshly created skip list has FirstLedgerSequence; rippled does not set it on creation")
+	}
 }


### PR DESCRIPTION
## Summary

- `writeSkipList` rebuilt the `LedgerHashes` SLE from a fixed four-field set on **every** close, silently dropping the existing object's optional `FirstLedgerSequence`. Mainnet's rolling skip list carries `FirstLedgerSequence = 2`, so the rewrite produced an SLE 6 bytes shorter than mainnet's → a different state-tree leaf → `account_hash` (and `ledger_hash`) divergence at every close (observed at replay-range ledger 99226371).
- Mirrors rippled's in-place `updateSkipList` (`Ledger.cpp:878-943`): `readLedgerHashesSLE` now returns the decoded field map, and `writeSkipList` updates only `Hashes` + `LastLedgerSequence` on that map, preserving every other present field. A freshly created skip list still sets only those two fields — rippled does not write `FirstLedgerSequence` on creation, so neither do we.
- This is the `account_hash` counterpart to the `transaction_hash` fix in #1006; with both, replay at 99226371 matches mainnet.

## Test plan

- [x] `just test-pkg ./internal/ledger/...` — full ledger suite passes
- [x] New `TestUpdateSkipListOnMap_PreservesFirstLedgerSequence` — seeds `FirstLedgerSequence=2`, advances one ledger, asserts the field survives the rewrite (fails before this change)
- [x] New `TestUpdateSkipListOnMap_CreatedSkipListHasNoFirstLedgerSequence` — pins rippled parity: a freshly created skip list has no `FirstLedgerSequence`
- [x] Existing skip-list / hash-of-seq / replaytool tests still pass; `gofmt`/`go vet` clean

Fixes #1008