### PR TITLE
fix: compare OracleSet Provider/AssetClass by bytes, not hex case

### DIFF
--- a/internal/ledger/state/oracle_entry.go
+++ b/internal/ledger/state/oracle_entry.go
@@ -3,6 +3,7 @@ package state
 import (
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
@@ -140,10 +141,14 @@ func parseOraclePriceDataSeries(content []byte) ([]OraclePriceData, error) {
 }
 
 // parseCurrencyBytes converts 20 binary currency bytes to a string.
-// XRP = all zeros. Standard 3-letter ISO codes are at bytes 12-14.
+// XRP = all zeros. Standard 3-letter ISO codes are at bytes 12-14. A
+// non-standard 160-bit code renders as upper-case hex, matching the binary
+// codec's decodeCurrencyCode so the same currency yields an identical string
+// whether it reaches us via tx decode or SLE parse — token-pair keys must
+// compare equal across both paths.
 func parseCurrencyBytes(b []byte) string {
 	if len(b) != 20 {
-		return hex.EncodeToString(b)
+		return strings.ToUpper(hex.EncodeToString(b))
 	}
 
 	// Check if all zeros (XRP)
@@ -178,7 +183,7 @@ func parseCurrencyBytes(b []byte) string {
 		return string(b[12:15])
 	}
 
-	return hex.EncodeToString(b)
+	return strings.ToUpper(hex.EncodeToString(b))
 }
 
 // SerializeOracle serializes an Oracle ledger entry to binary format.

--- a/internal/testing/oracle/oracle_test.go
+++ b/internal/testing/oracle/oracle_test.go
@@ -1258,6 +1258,51 @@ func TestUpdate(t *testing.T) {
 	})
 
 	// -------------------------------------------------------------------------
+	// A token pair using a non-standard 160-bit hex currency must match its
+	// stored counterpart on update. The tx-decode path renders such a currency
+	// as upper-case hex while the SLE parse renders the same bytes; the pair key
+	// must compare equal across both paths, so an update of an existing pair
+	// updates it in place rather than appending a duplicate. Regression for the
+	// currency-side of #1011 (rippled keys pairs on the raw Currency value).
+	// -------------------------------------------------------------------------
+	t.Run("HexCurrencyPairUpdateInPlace", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		owner := jtx.NewAccount("owner")
+		env.Fund(owner)
+		env.Close()
+
+		const hexCurrency = "0158415500000000C1F76FF6ECB0BAC600000000"
+
+		lut := defaultLUT(env)
+		result := env.Submit(oracletest.OracleSet(owner, 1, lut).
+			Provider("70726F7669646572").
+			AssetClass("63757272656E6379").
+			AddPrice(hexCurrency, "USD", 740, 1).
+			Fee(baseFee).
+			Build())
+		jtx.RequireTxSuccess(t, result)
+
+		// Update the price of the same hex-currency pair.
+		lut2 := lut + 1
+		result = env.Submit(oracletest.OracleSet(owner, 1, lut2).
+			AddPrice(hexCurrency, "USD", 741, 1).
+			Fee(baseFee).
+			Build())
+		jtx.RequireTxSuccess(t, result)
+
+		// The existing pair must be updated in place — exactly one entry, with
+		// the new price — not duplicated under a case-mismatched key.
+		data, err := env.LedgerEntry(keylet.Oracle(owner.ID, 1))
+		require.NoError(t, err)
+		oracle, err := state.ParseOracle(data)
+		require.NoError(t, err)
+		require.Len(t, oracle.PriceDataSeries, 1)
+		require.Equal(t, "USD", oracle.PriceDataSeries[0].QuoteAsset)
+		require.True(t, oracle.PriceDataSeries[0].HasPrice)
+		require.Equal(t, uint64(741), oracle.PriceDataSeries[0].AssetPrice)
+	})
+
+	// -------------------------------------------------------------------------
 	// Add new pairs, non-included pair resets — rippled lines 619-625
 	// -------------------------------------------------------------------------
 	t.Run("AddNewPairs", func(t *testing.T) {

--- a/internal/testing/oracle/oracle_test.go
+++ b/internal/testing/oracle/oracle_test.go
@@ -1222,6 +1222,42 @@ func TestUpdate(t *testing.T) {
 	})
 
 	// -------------------------------------------------------------------------
+	// Provider/AssetClass that differ only in hex case must still match the
+	// immutable stored values on update. The tx-decode path yields upper-case
+	// hex while the stored SLE re-parses to lower-case hex; the bytes are
+	// identical, so the immutability check must not reject. Regression for #1011.
+	// -------------------------------------------------------------------------
+	t.Run("ProviderAssetClassHexCaseInsensitive", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		owner := jtx.NewAccount("owner")
+		env.Fund(owner)
+		env.Close()
+
+		// Create with upper-case hex Provider/AssetClass.
+		lut := defaultLUT(env)
+		result := env.Submit(oracletest.OracleSet(owner, 1, lut).
+			Provider("70726F7669646572").   // "provider"
+			AssetClass("63757272656E6379"). // "currency"
+			AddPrice("XRP", "USD", 740, 1).
+			Fee(baseFee).
+			Build())
+		jtx.RequireTxSuccess(t, result)
+		require.True(t, oracleExists(t, env, owner, 1))
+
+		// Update re-supplies the same Provider/AssetClass in the original
+		// upper-case hex; the stored values are lower-case but byte-identical,
+		// so the update must succeed.
+		lut2 := lut + 1
+		result = env.Submit(oracletest.OracleSet(owner, 1, lut2).
+			Provider("70726F7669646572").
+			AssetClass("63757272656E6379").
+			AddPrice("XRP", "USD", 741, 1).
+			Fee(baseFee).
+			Build())
+		jtx.RequireTxSuccess(t, result)
+	})
+
+	// -------------------------------------------------------------------------
 	// Add new pairs, non-included pair resets — rippled lines 619-625
 	// -------------------------------------------------------------------------
 	t.Run("AddNewPairs", func(t *testing.T) {

--- a/internal/testing/oracle/oracle_test.go
+++ b/internal/testing/oracle/oracle_test.go
@@ -1282,7 +1282,6 @@ func TestUpdate(t *testing.T) {
 			Build())
 		jtx.RequireTxSuccess(t, result)
 
-		// Update the price of the same hex-currency pair.
 		lut2 := lut + 1
 		result = env.Submit(oracletest.OracleSet(owner, 1, lut2).
 			AddPrice(hexCurrency, "USD", 741, 1).

--- a/internal/tx/oracle/oracle_set.go
+++ b/internal/tx/oracle/oracle_set.go
@@ -402,8 +402,7 @@ func (o *OracleSet) doApplyUpdate(ctx *tx.ApplyContext, oracleKey keylet.Keylet,
 		}
 	}
 
-	// Build updated PriceDataSeries (map iteration = sorted by key in Go maps... but Go maps are NOT ordered)
-	// In rippled, std::map sorts by key. We need sorted order.
+	// Emit the pairs in token-pair key order, matching rippled's std::map.
 	keys := make([]string, 0, len(orderedPairs))
 	for k := range orderedPairs {
 		keys = append(keys, k)

--- a/internal/tx/oracle/oracle_set.go
+++ b/internal/tx/oracle/oracle_set.go
@@ -2,6 +2,7 @@ package oracle
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -266,11 +267,14 @@ func (o *OracleSet) Apply(ctx *tx.ApplyContext) ter.Result {
 			return ter.TecINVALID_UPDATE_TIME
 		}
 
-		// If field is present in tx, it must match existing value
-		if o.isFieldPresent("Provider") && o.Provider != existingOracle.Provider {
+		// If field is present in tx, it must match the existing value. Both are
+		// hex-encoded Blob bytes; the tx-decode and SLE-parse paths can differ in
+		// hex case for identical bytes, so compare case-insensitively to mirror
+		// rippled comparing the raw Blob.
+		if o.isFieldPresent("Provider") && !strings.EqualFold(o.Provider, existingOracle.Provider) {
 			return ter.TemMALFORMED
 		}
-		if o.isFieldPresent("AssetClass") && o.AssetClass != existingOracle.AssetClass {
+		if o.isFieldPresent("AssetClass") && !strings.EqualFold(o.AssetClass, existingOracle.AssetClass) {
 			return ter.TemMALFORMED
 		}
 


### PR DESCRIPTION
## Summary

- `OracleSet`'s update-path immutability check compared the hex-encoded `Provider` and `AssetClass` fields as **case-sensitive strings**. The tx-decode path emits upper-case hex (`63757272656E6379`) while the stored SLE re-parses to lower-case hex (`63757272656e6379`) via `hex.EncodeToString` in `state.ParseOracle`. The bytes are identical, so an update re-supplying the same values was wrongly rejected as `temMALFORMED`.
- Compare the two fields case-insensitively with `strings.EqualFold`, which for hex strings is equivalent to comparing the raw `Blob` bytes — matching rippled's behaviour.
- This is the second of two bugs that block mainnet ledger **99226372** (the first, `MaxPriceScale`, is #1010); both are required for that ledger to apply `tesSUCCESS`.

## Test plan

- [x] Added `TestUpdate/ProviderAssetClassHexCaseInsensitive` regression: create with upper-case hex `Provider`/`AssetClass`, then update re-supplying the same upper-case hex (stored lower-case, byte-identical) must succeed. Verified it fails with `temMALFORMED` before the fix and passes after.
- [x] `go test ./internal/tx/oracle/... ./internal/testing/oracle/...` — green (includes the existing Provider/AssetClass *mismatch* failure cases).

Fixes #1011