### PR TITLE
fix: raise OracleSet MaxPriceScale to 20 to match rippled

### DIFF
--- a/internal/testing/oracle/oracle_test.go
+++ b/internal/testing/oracle/oracle_test.go
@@ -765,10 +765,29 @@ func TestInvalidSet(t *testing.T) {
 		result := env.Submit(oracletest.OracleSet(owner, 1, lut).
 			ProviderHex(32).
 			AssetClassHex(8).
-			AddPrice("USD", "BTC", 740, 9). // scale 9 > max 8
+			AddPrice("USD", "BTC", 740, 21). // scale 21 > max 20
 			Fee(baseFee).
 			Build())
 		jtx.RequireTxFail(t, result, "temMALFORMED")
+	})
+
+	// -------------------------------------------------------------------------
+	// Scale == maxPriceScale (20) is accepted; mainnet applies Scale=10
+	// -------------------------------------------------------------------------
+	t.Run("ScaleAtMax", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		owner := jtx.NewAccount("owner")
+		env.Fund(owner)
+		env.Close()
+
+		lut := defaultLUT(env)
+		result := env.Submit(oracletest.OracleSet(owner, 1, lut).
+			ProviderHex(32).
+			AssetClassHex(8).
+			AddPrice("USD", "BTC", 740, 20).
+			Fee(baseFee).
+			Build())
+		jtx.RequireTxSuccess(t, result)
 	})
 
 	// -------------------------------------------------------------------------

--- a/internal/tx/oracle/constant.go
+++ b/internal/tx/oracle/constant.go
@@ -19,6 +19,5 @@ const (
 	MaxLastUpdateTimeDelta = 300
 
 	// MaxPriceScale is the maximum allowed scale value for price data
-	// Reference: rippled Oracle_test.cpp line 354 tests maxPriceScale + 1 = 9 fails
-	MaxPriceScale = 8
+	MaxPriceScale = 20
 )


### PR DESCRIPTION
## Summary

- `internal/tx/oracle/constant.go`: `MaxPriceScale` was `8`, so any `OracleSet` price entry with `Scale` in `9..20` was wrongly rejected `temMALFORMED`. rippled's `maxPriceScale` has been **20** since the Price Oracle feature (XLS-47d, #4789) was introduced and is **not** amendment-gated, so the cap is a hard protocol constant. Raised to `20`.
- The issue suggested `10`, but mainnet accepting `Scale=10` only proves the limit is `≥10`; the rippled-faithful value (`include/xrpl/protocol/Protocol.h`, and `SetOracle::preflight`'s unconditional `entry[~sfScale] > maxPriceScale`) is `20`. Capping at `10` would still diverge for `Scale` `11..20`.
- Updated the existing `TestInvalidSet/ScaleExceedsMax` case (`Scale=9` is now valid → `21`, i.e. `maxPriceScale + 1`, mirroring rippled `Oracle_test.cpp`) and added `TestInvalidSet/ScaleAtMax` asserting `Scale=20` applies `tesSUCCESS` (covers the real mainnet `Scale=10` case from ledger 99226372).

This resolves the `account_hash` / `transaction_hash` divergence at mainnet ledger 99226372, where the block's single `OracleSet` (7 of 8 entries at `Scale=10`) applied `tesSUCCESS` on mainnet but failed `temMALFORMED` in go-xrpl.

## Test plan

- [x] `go test ./internal/tx/oracle/...` — green
- [x] `go test ./internal/testing/oracle/...` — green (incl. `TestInvalidSet/ScaleExceedsMax` and new `TestInvalidSet/ScaleAtMax`)
- [x] `go vet ./internal/tx/oracle/...`, `gofmt` clean

Fixes #1010