### PR TITLE
fix: round tick-size offer quality to nearest

### DIFF
--- a/internal/testing/offer/offer_ticksize_quality_test.go
+++ b/internal/testing/offer/offer_ticksize_quality_test.go
@@ -1,0 +1,60 @@
+package offer
+
+import (
+	"encoding/binary"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/accountset"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOffer_TickSizeQuality_Issue1012 pins the book-directory quality an offer
+// receives when a tick size applies. rippled rounds the tick-adjusted side with
+// plain multiply()/divide() — round to nearest — so the resulting quality matches
+// Quality::round(). goXRPL previously rounded that side away from zero, producing a
+// quality one ULP off and keying the offer into a different BookDirectory.
+//
+// Replays mainnet ledger 99226373's OfferCreate c1d3b833…: a passive
+// XRP↔RLUSD offer, TakerPays 971829440 drops, TakerGets 2854.83644, against an
+// issuer with TickSize 7. Mainnet stored TakerGets 2854.835624261196 and
+// ExchangeRate 5a0c180ee6b8b000; the away-from-zero rounding yielded
+// 2854.835624261197 / 5a0c180ee6b8afff.
+func TestOffer_TickSizeQuality_Issue1012(t *testing.T) {
+	const (
+		wantExchangeRate uint64 = 0x5a0c180ee6b8b000
+		wantTakerGets           = "2854.835624261196"
+	)
+
+	env := newEnvWithFeatures(t, nil)
+
+	gw := jtx.NewAccount("gateway")
+	alice := jtx.NewAccount("alice")
+	env.FundAmount(gw, uint64(jtx.XRP(100000)))
+	env.FundAmount(alice, uint64(jtx.XRP(100000)))
+	env.Close()
+
+	jtx.RequireTxSuccess(t, env.Submit(accountset.AccountSet(gw).TickSize(7).Build()))
+
+	env.Trust(alice, jtx.USD(gw, 1000000))
+	jtx.RequireTxSuccess(t, env.Submit(payment.PayIssued(gw, alice, jtx.USD(gw, 1000000)).Build()))
+	env.Close()
+
+	// TakerGets = 2854.83644 USD (== mantissa 2854836440000000e-12), TakerPays = XRP drops.
+	takerGets := tx.NewIssuedAmount(2854836440000000, -12, "USD", gw.Address)
+	takerPays := tx.NewXRPAmount(971829440)
+
+	seq := env.Seq(alice)
+	jtx.RequireTxSuccess(t, env.Submit(OfferCreate(alice, takerPays, takerGets).Passive().Build()))
+	env.Close()
+
+	offer := GetOffer(env, alice, seq)
+	require.NotNil(t, offer, "offer should be placed")
+
+	gotRate := binary.BigEndian.Uint64(offer.BookDirectory[24:32])
+	require.Equalf(t, wantExchangeRate, gotRate,
+		"book-directory ExchangeRate: got %016x want %016x", gotRate, wantExchangeRate)
+	require.Equal(t, wantTakerGets, offer.TakerGets.Value(), "tick-rounded TakerGets")
+}

--- a/internal/tx/offer/offer_quality.go
+++ b/internal/tx/offer/offer_quality.go
@@ -241,9 +241,19 @@ func qualityToRate(quality uint64) *big.Rat {
 	return rat
 }
 
-// multiplyByQuality multiplies an amount by a quality rate.
-// Reference: rippled uses mulRound to multiply amount by quality rate.
-// The result type is determined by currency/issuer parameters.
+// rateAmountFromQuality decodes a quality code (exponent<<56 | mantissa) into the
+// IOU rate Amount rippled's Quality::rate() yields: an issue-less value carrying the
+// rate magnitude. Used as the divisor/multiplicand for tick-size amount rounding.
+func rateAmountFromQuality(quality uint64) tx.Amount {
+	mantissa := int64(quality & 0x00ffffffffffffff)
+	exponent := int(quality>>56) - 100
+	return tx.NewIssuedAmount(mantissa, exponent, "", "")
+}
+
+// multiplyByQuality multiplies an amount by a quality rate, reproducing rippled's
+// multiply(amount, rate, asset): the exact product rounded to nearest (ties to
+// even), matching Number arithmetic under fixUniversalNumber. The result type is
+// determined by currency/issuer parameters.
 func multiplyByQuality(amount tx.Amount, quality uint64, currency, issuer string) tx.Amount {
 	if quality == 0 || amount.IsZero() {
 		if currency == "" || currency == "XRP" {
@@ -278,71 +288,57 @@ func multiplyByQuality(amount tx.Amount, quality uint64, currency, issuer string
 		return tx.NewXRPAmount(ratRoundXRP(result))
 	}
 
-	return ratToIssuedAmount(result, currency, issuer, true)
+	return ratToIssuedAmount(result, currency, issuer)
 }
 
-// divideByQuality divides an amount by a quality rate.
-// Reference: rippled uses divRound to divide amount by quality rate.
+// divideByQuality divides an amount by a quality rate, reproducing rippled's
+// divide(amount, rate, asset): muldiv(amount, 10^17, rate) + 5 canonicalized to
+// nearest (ties to even). This is the same core GetRate uses, so the offer's
+// tick-rounded amount and the quality recomputed from it stay consistent.
 // The result type is determined by currency/issuer parameters.
 func divideByQuality(amount tx.Amount, quality uint64, currency, issuer string) tx.Amount {
-	if quality == 0 {
-		// Division by zero - return zero
-		if currency == "" || currency == "XRP" {
+	native := currency == "" || currency == "XRP"
+	if quality == 0 || amount.IsZero() {
+		if native {
 			return tx.NewXRPAmount(0)
 		}
 		return tx.NewIssuedAmount(0, -100, currency, issuer)
 	}
 
-	if amount.IsZero() {
-		if currency == "" || currency == "XRP" {
-			return tx.NewXRPAmount(0)
-		}
-		return tx.NewIssuedAmount(0, -100, currency, issuer)
+	rate := rateAmountFromQuality(quality)
+	numVal, numOff := state.PrepareMulDivOperand(amount)
+	denVal, denOff := state.PrepareMulDivOperand(rate)
+	resultNegative := amount.IsNegative() != rate.IsNegative()
+
+	mantissa := state.DivMantissas(numVal, denVal, false) + 5
+	offset := numOff - denOff - 17
+	if native {
+		return offerNativeDrops(mantissa, offset, resultNegative, false, false, false)
 	}
-
-	// Convert amount to big.Rat
-	var amtRat *big.Rat
-	if amount.IsNative() {
-		amtRat = new(big.Rat).SetInt64(amount.Drops())
-	} else {
-		mantissa := amount.Mantissa()
-		exponent := amount.Exponent()
-		amtRat = new(big.Rat).SetInt64(mantissa)
-		if exponent > 0 {
-			scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(exponent)), nil)
-			amtRat.Mul(amtRat, new(big.Rat).SetInt(scale))
-		} else if exponent < 0 {
-			scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(-exponent)), nil)
-			amtRat.Quo(amtRat, new(big.Rat).SetInt(scale))
-		}
-	}
-
-	rateRat := qualityToRate(quality)
-	result := new(big.Rat).Quo(amtRat, rateRat)
-
-	if currency == "" || currency == "XRP" {
-		// Round to nearest in exact integer arithmetic; float64 loses precision
-		// above 2^53 drops (~9M XRP), which would be a consensus divergence.
-		return tx.NewXRPAmount(ratRoundXRP(result))
-	}
-
-	return ratToIssuedAmount(result, currency, issuer, true)
+	return state.FinalizeRoundIOU(mantissa, offset, resultNegative, false, currency, issuer, state.RoundToNearest, true)
 }
 
-// ratRoundXRP rounds a non-negative big.Rat drops value to the nearest integer
-// (half rounds up), matching the previous float64 "f + 0.5" behavior without its
-// precision loss for amounts above 2^53.
+// ratRoundXRP rounds a non-negative big.Rat drops value to the nearest integer,
+// ties to even, matching rippled's Number→XRPAmount conversion under
+// fixUniversalNumber. Exact integer arithmetic: float64 loses precision above 2^53
+// drops (~9M XRP), which would be a consensus divergence.
 func ratRoundXRP(r *big.Rat) int64 {
 	if r.Sign() <= 0 {
 		return 0
 	}
-	sum := new(big.Rat).Add(r, big.NewRat(1, 2))
-	return new(big.Int).Quo(sum.Num(), sum.Denom()).Int64()
+	q := new(big.Int).Quo(r.Num(), r.Denom())
+	rem := new(big.Int).Mod(r.Num(), r.Denom())
+	twice := new(big.Int).Lsh(rem, 1)
+	if cmp := twice.Cmp(r.Denom()); cmp > 0 || (cmp == 0 && q.Bit(0) == 1) {
+		q.Add(q, big.NewInt(1))
+	}
+	return q.Int64()
 }
 
-// ratToIssuedAmount converts a big.Rat to an IOU Amount with the given currency and issuer.
-// The roundUp parameter controls rounding direction.
-func ratToIssuedAmount(rat *big.Rat, currency, issuer string, roundUp bool) tx.Amount {
+// ratToIssuedAmount converts a big.Rat to an IOU Amount with the given currency and
+// issuer, rounding the mantissa to nearest (ties to even) — the rounding rippled's
+// multiply()/divide() apply through Number under fixUniversalNumber.
+func ratToIssuedAmount(rat *big.Rat, currency, issuer string) tx.Amount {
 	if rat.Sign() == 0 {
 		return tx.NewIssuedAmount(0, -100, currency, issuer)
 	}
@@ -385,8 +381,14 @@ func ratToIssuedAmount(rat *big.Rat, currency, issuer string, roundUp bool) tx.A
 	intPart := new(big.Int).Quo(scaled.Num(), scaled.Denom())
 	remainder := new(big.Int).Mod(scaled.Num(), scaled.Denom())
 
-	if roundUp && remainder.Sign() != 0 {
+	// Round half to even on the discarded fraction.
+	twice := new(big.Int).Lsh(remainder, 1)
+	if cmp := twice.Cmp(scaled.Denom()); cmp > 0 || (cmp == 0 && intPart.Bit(0) == 1) {
 		intPart.Add(intPart, big.NewInt(1))
+		if intPart.Cmp(maxMant) >= 0 {
+			intPart.Quo(intPart, big.NewInt(10))
+			exponent++
+		}
 	}
 
 	mantissa := intPart.Int64()


### PR DESCRIPTION
## Summary

- Offer placement under a tick size rounded the adjusted `TakerGets`/`TakerPays` **away from zero**, producing a book-directory quality one ULP off from rippled. The offer then keyed into a different `BookDirectory` (created a new one instead of joining the existing one), forking `account_hash`/`transaction_hash` on replay.
- Rewrote the tick-size amount rounding to match rippled's plain `multiply()`/`divide()` — **round to nearest, ties to even** (the `Number` arithmetic used under `fixUniversalNumber`): `divideByQuality` now uses the same `muldiv(...)+5` core `GetRate` uses, and `multiplyByQuality` rounds the exact product half-to-even.

## Root cause

For the diverging offer (mainnet ledger 99226373, OfferCreate `c1d3b833…`, a **passive** XRP↔RLUSD offer against an issuer with `TickSize 7`), rippled rounds the tick-adjusted `TakerGets` via `divide()` to `2854.835624261196`, giving `getRate = 5a0c180ee6b8b000`. go-xrpl rounded it up to `2854.835624261197`, giving `5a0c180ee6b8afff` — one ULP lower — so the offer landed in a new directory rather than the existing `…b8b000` one.

The basic `GetRate`/`divideIOU` rounding was already correct; the divergence was in `applyTickSize`'s helper rounding (`roundUp`/half-up), not in `GetRate` as the issue first supposed.

## Test plan

- [x] New regression `TestOffer_TickSizeQuality_Issue1012` replays the exact ledger-99226373 amounts and asserts the stored `ExchangeRate = 5a0c180ee6b8b000` and `TakerGets = 2854.835624261196` (both match mainnet).
- [x] `just test-pkg ./internal/tx/offer/...` and `./internal/testing/offer/...` green (incl. existing `TestOffer_TickSize`).
- [x] `./internal/tx/...`, `./internal/testing/payment/...`, `./internal/testing/amm/...` green — no regressions.
- [x] `gofmt`/`go vet` clean.

Fixes #1012