### PR TITLE
fix: generate AMM offer at max quality behind worse LOB tip when crossing (#1018)

### DIFF
--- a/internal/testing/amm/issue1018_test.go
+++ b/internal/testing/amm/issue1018_test.go
@@ -1,0 +1,78 @@
+package amm_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/amm"
+	offerbuild "github.com/LeJamon/go-xrpl/internal/testing/offer"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+// TestIssue1018_AMMMarginalCrossBehindWorseLOB reproduces mainnet ledger 99226376.
+//
+// An XRP/NAUTi AMM pool (fee=0, XRP=10526371 drops, NAUTi=2089.989295377329)
+// sits behind resting CLOB offers whose quality (best ~0.00019888 NAUTi/XRP) is
+// WORSE than both the AMM spot price and the incoming offer's limit quality
+// (368.83 NAUTi / 1857611 drops ~0.00019855). The AMM is marginally better than
+// the limit, so a tiny sliver must cross the AMM while the worse LOB tip is left
+// untouched.
+//
+// Before the fix, forEachOffer's tryAMM passed the raw LOB tip quality to the AMM
+// offer generator, sizing the synthetic AMM offer down to the worse LOB tier so
+// it failed the taker's quality limit and nothing crossed. rippled passes nullopt
+// in this single-path case (BookOfferCrossingStep::qualityThreshold) so the AMM
+// generates its maximum offer, which the strand then limits to the taker quality.
+func TestIssue1018_AMMMarginalCrossBehindWorseLOB(t *testing.T) {
+	const cur = "NAU"
+	poolXRP := tx.NewXRPAmount(10526371)
+	poolNAU := tx.NewIssuedAmount(2089989295377329, -12, cur, "")
+
+	pool := [2]tx.Amount{poolXRP, poolNAU}
+	amm.TestAMM(t, &pool, 0, func(env *amm.AMMTestEnv, ammAcc *jtx.Account) {
+		// Resting CLOB offer selling XRP for NAUTi at a quality worse than the
+		// incoming offer's limit: best mainnet tier was 603360 drops for 120 NAUTi.
+		env.FundBob(30000, 0)
+		env.Trust(env.Bob, env.GW, cur, 100000)
+		env.Close()
+		env.PayIOU(env.GW, env.Bob, cur, 50000)
+		env.Close()
+		bobOffer := offerbuild.OfferCreate(env.Bob,
+			tx.NewIssuedAmount(120, 0, cur, env.GW.Address), // TakerPays = 120 NAUTi
+			tx.NewXRPAmount(603360),                         // TakerGets = 603360 drops XRP
+		).Build()
+		jtx.RequireTxSuccess(t, env.Submit(bobOffer))
+		env.Close()
+
+		xrpBefore := env.AMMPoolXRP(ammAcc)
+
+		// Carol sells 368.83 NAUTi, wants 1857611 drops XRP (Flags=0).
+		takerPays := tx.NewXRPAmount(1857611)
+		takerGets := tx.NewIssuedAmount(36883, -2, cur, env.GW.Address)
+		offerTx := offerbuild.OfferCreate(env.Carol, takerPays, takerGets).Build()
+		jtx.RequireTxSuccess(t, env.Submit(offerTx))
+		env.Close()
+
+		// The AMM must have crossed exactly the 147-drop sliver mainnet saw.
+		if consumed := int64(xrpBefore) - int64(env.AMMPoolXRP(ammAcc)); consumed != 147 {
+			t.Fatalf("AMM XRP consumed = %d drops, want 147 (offer crossed nothing => bug #1018)", consumed)
+		}
+
+		// Carol's remainder offer matches mainnet: TakerPays=1857464, TakerGets=368.8008130442811.
+		carolOffers := env.AccountOffers(env.Carol)
+		if len(carolOffers) != 1 {
+			t.Fatalf("Carol offers = %d, want 1", len(carolOffers))
+		}
+		if got := carolOffers[0].TakerPays.Value(); got != "1857464" {
+			t.Errorf("Carol remainder TakerPays = %s, want 1857464", got)
+		}
+		if got := carolOffers[0].TakerGets.Value(); got != "368.8008130442811" {
+			t.Errorf("Carol remainder TakerGets = %s, want 368.8008130442811", got)
+		}
+
+		// The worse LOB tip must be left fully untouched.
+		if n := env.OfferCount(env.Bob); n != 1 {
+			t.Errorf("Bob LOB offers = %d, want 1 (worse-quality tip must not cross)", n)
+		}
+	})
+}

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -308,7 +308,16 @@ func (s *BookStep) forEachOffer(
 		if s.domainID != nil {
 			return true
 		}
-		ammOffer := s.getAMMOffer(sb, lobQuality)
+		// For offer crossing, generate the AMM offer against the LOB tip quality
+		// or nil — passing nil when the taker's quality limit is better than the
+		// LOB tip lets the AMM produce its maximum offer instead of being capped
+		// to the lower-quality LOB tier (which would block an otherwise crossable
+		// AMM). Reference: rippled BookStep.cpp tryAMM lines 845-851.
+		qualityThreshold := lobQuality
+		if fixAMMv1_1Enabled(sb) && lobQuality != nil {
+			qualityThreshold = s.tipQualityThreshold(*lobQuality)
+		}
+		ammOffer := s.getAMMOffer(sb, qualityThreshold)
 		if ammOffer == nil {
 			return true
 		}


### PR DESCRIPTION
## Summary

- Fixes a mainnet replay divergence at ledger **99226376**: an `OfferCreate` that should partially cross an AMM pool was left fully unconsumed by go-xrpl while rippled crosses a ~147-drop sliver.
- Root cause is **not** the CLOB cross-eligibility logic the issue suspected. The counterparty (`rHMingK…`) is the **XRP/NAUTi AMM pseudo-account** (fee=0); the divergence is in single-path AMM offer generation during crossing.
- `forEachOffer`'s `tryAMM` passed the **raw LOB tip quality** to the AMM offer generator. When a resting CLOB offer exists whose quality is *worse* than the taker's limit (here `~0.00019888` vs limit `~0.00019855` NAUTi/XRP), the synthetic single-path AMM offer was sized down to the worse LOB tier, failing the taker's quality limit — so nothing crossed, even though the AMM spot price was crossable.
- rippled passes `nullopt` in this case (`BookOfferCrossingStep::qualityThreshold`, BookStep.cpp:845-851), letting the AMM produce its **maximum** offer, which the strand then limits to the taker quality. The helper (`tipQualityThreshold`) already existed in go-xrpl and was used by the quality-estimation path, but the actual consumption path skipped it.

The fix routes `lobQuality` through `tipQualityThreshold` (gated on `fixAMMv1_1`) in `tryAMM`, mirroring rippled exactly. One-spot change in `step_book.go`.

## Test plan

- [x] New regression test `TestIssue1018_AMMMarginalCrossBehindWorseLOB` reproduces the exact mainnet scenario (XRP/NAUTi AMM behind a worse-quality LOB tip) and asserts byte-exact behaviour: AMM consumes 147 drops, remainder offer `TakerPays=1857464` / `TakerGets=368.8008130442811`, worse LOB tip left untouched. Fails before the fix, passes after.
- [x] `go test ./internal/tx/payment/... ./internal/tx/offer/... ./internal/tx/amm/...` — green
- [x] `go test ./internal/testing/amm/... ./internal/testing/offer/... ./internal/testing/payment/... ./internal/testing/permissioneddex/...` — green
- [x] Offer conformance: 396/396 (100%); AMM conformance: 97/98 (the one failure, `Invalid_Deposit`, is pre-existing on `main` and unrelated to crossing)

Fixes #1018