### PR TITLE
fix: order OracleSet PriceDataSeries by Currency bytes

### DIFF
--- a/internal/testing/oracle/oracle_test.go
+++ b/internal/testing/oracle/oracle_test.go
@@ -53,6 +53,21 @@ func oracleQuoteAssets(t *testing.T, env *jtx.TestEnv, owner *jtx.Account, docID
 	return assets
 }
 
+// oraclePairs reads the oracle SLE and returns each PriceData entry as a
+// "BASE/QUOTE" string in on-ledger array order.
+func oraclePairs(t *testing.T, env *jtx.TestEnv, owner *jtx.Account, docID uint32) []string {
+	t.Helper()
+	data, err := env.LedgerEntry(keylet.Oracle(owner.ID, docID))
+	require.NoError(t, err)
+	oracle, err := state.ParseOracle(data)
+	require.NoError(t, err)
+	pairs := make([]string, len(oracle.PriceDataSeries))
+	for i, pd := range oracle.PriceDataSeries {
+		pairs[i] = pd.BaseAsset + "/" + pd.QuoteAsset
+	}
+	return pairs
+}
+
 // oracleExists checks if an oracle ledger entry exists.
 func oracleExists(t *testing.T, env *jtx.TestEnv, owner *jtx.Account, docID uint32) bool {
 	t.Helper()
@@ -1577,6 +1592,60 @@ func TestUpdate(t *testing.T) {
 
 		after := oracleQuoteAssets(t, env, owner, 1)
 		require.Equal(t, before, after)
+	})
+
+	// The always-sorted update path must order by canonical Currency bytes, where
+	// XRP is the all-zero currency and sorts before any token. Ordering by the
+	// asset strings instead places XRP-based pairs ("XRP" = 0x585250…) last.
+	t.Run("UpdateOrdersByCurrencyXRPFirst", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		owner := jtx.NewAccount("owner")
+		env.Fund(owner)
+		env.Close()
+
+		lut := defaultLUT(env)
+		result := env.Submit(oracletest.OracleSet(owner, 1, lut).
+			ProviderHex(32).
+			AssetClassHex(8).
+			AddPrice("USD", "EUR", 1, 0).
+			AddPrice("USD", "GBP", 1, 0).
+			AddPrice("XRP", "USD", 1, 0).
+			AddPrice("XRP", "EUR", 1, 0).
+			Fee(baseFee).
+			Build())
+		jtx.RequireTxSuccess(t, result)
+
+		lut2 := lut + 1
+		result = env.Submit(oracletest.OracleSet(owner, 1, lut2).
+			AddPrice("XRP", "USD", 2, 0).
+			Fee(baseFee).
+			Build())
+		jtx.RequireTxSuccess(t, result)
+
+		require.Equal(t, []string{
+			"XRP/EUR", "XRP/USD", "USD/EUR", "USD/GBP",
+		}, oraclePairs(t, env, owner, 1))
+	})
+
+	// With fixPriceOracleOrder enabled, the create path sorts the same way.
+	t.Run("CreateOrdersByCurrencyXRPFirst", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		env.EnableFeature("fixPriceOracleOrder")
+		owner := jtx.NewAccount("owner")
+		env.Fund(owner)
+		env.Close()
+
+		lut := defaultLUT(env)
+		result := env.Submit(oracletest.OracleSet(owner, 1, lut).
+			ProviderHex(32).
+			AssetClassHex(8).
+			AddPrice("USD", "EUR", 1, 0).
+			AddPrice("XRP", "USD", 1, 0).
+			Fee(baseFee).
+			Build())
+		jtx.RequireTxSuccess(t, result)
+
+		require.Equal(t, []string{"XRP/USD", "USD/EUR"}, oraclePairs(t, env, owner, 1))
 	})
 }
 

--- a/internal/tx/oracle/helpers.go
+++ b/internal/tx/oracle/helpers.go
@@ -22,15 +22,21 @@ func currencyOrderKey(base, quote string) string {
 	return string(b[:]) + string(q[:])
 }
 
-// currencyCode converts an oracle asset string — as produced by the binary codec
-// and the SLE parser ("XRP", a 3-letter ISO code, or a 40-char hex code) — into
-// its canonical 20-byte Currency. XRP is the all-zero code; a 3-letter code fills
-// bytes 12-14; a 40-char hex code is decoded verbatim.
+// currencyCode converts an oracle asset string into its canonical 20-byte
+// Currency, covering every form the two producers emit: the binary codec (tx
+// decode) yields "XRP", the noCurrency sentinel "1", a 3-letter ISO code, or a
+// 40-char hex code; the SLE parser yields "XRP", a 3-letter code, or 40-char hex
+// (it renders noCurrency as hex). XRP is the all-zero code; noCurrency is
+// 0x00…01; a 3-letter code fills bytes 12-14; a 40-char hex code is decoded
+// verbatim. Both noCurrency spellings ("1" and its hex form) must yield the same
+// bytes so the emit order matches rippled, which keys on the raw Currency.
 func currencyCode(asset string) [20]byte {
 	var c [20]byte
 	switch {
 	case asset == "XRP":
 		// all-zero code
+	case asset == "1":
+		c[19] = 0x01 // noCurrency sentinel
 	case len(asset) == 40:
 		if b, err := hex.DecodeString(asset); err == nil {
 			copy(c[:], b)

--- a/internal/tx/oracle/helpers.go
+++ b/internal/tx/oracle/helpers.go
@@ -1,10 +1,44 @@
 package oracle
 
-import "github.com/LeJamon/go-xrpl/internal/tx/ter"
+import (
+	"encoding/hex"
+
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
 
 // pairKey returns the deduplication key for a base/quote token pair.
 func pairKey(base, quote string) string {
 	return base + "/" + quote
+}
+
+// currencyOrderKey returns a sort key that orders a base/quote token pair by its
+// canonical 20-byte Currency codes (base first, then quote), matching rippled's
+// std::map<std::pair<Currency, Currency>>. XRP is the all-zero currency, so
+// XRP-based pairs sort before any token pair; sorting the asset strings directly
+// would instead place XRP ("XRP" = 0x585250…) after the tokens.
+func currencyOrderKey(base, quote string) string {
+	b := currencyCode(base)
+	q := currencyCode(quote)
+	return string(b[:]) + string(q[:])
+}
+
+// currencyCode converts an oracle asset string — as produced by the binary codec
+// and the SLE parser ("XRP", a 3-letter ISO code, or a 40-char hex code) — into
+// its canonical 20-byte Currency. XRP is the all-zero code; a 3-letter code fills
+// bytes 12-14; a 40-char hex code is decoded verbatim.
+func currencyCode(asset string) [20]byte {
+	var c [20]byte
+	switch {
+	case asset == "XRP":
+		// all-zero code
+	case len(asset) == 40:
+		if b, err := hex.DecodeString(asset); err == nil {
+			copy(c[:], b)
+		}
+	case len(asset) == 3:
+		copy(c[12:], asset)
+	}
+	return c
 }
 
 // validateHexFieldLen checks that a hex-encoded field value is non-empty and

--- a/internal/tx/oracle/helpers_test.go
+++ b/internal/tx/oracle/helpers_test.go
@@ -1,0 +1,40 @@
+package oracle
+
+import "testing"
+
+func TestCurrencyCodeForms(t *testing.T) {
+	usd := [20]byte{}
+	copy(usd[12:], "USD")
+
+	tests := []struct {
+		name  string
+		asset string
+		want  [20]byte
+	}{
+		{"xrp", "XRP", [20]byte{}},
+		{"noCurrency sentinel", "1", [20]byte{19: 0x01}},
+		{"noCurrency hex", "0000000000000000000000000000000000000001", [20]byte{19: 0x01}},
+		{"iso", "USD", usd},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := currencyCode(tt.asset); got != tt.want {
+				t.Fatalf("currencyCode(%q) = %x, want %x", tt.asset, got, tt.want)
+			}
+		})
+	}
+}
+
+// The binary codec renders the noCurrency code as "1" while the SLE parser
+// renders the same bytes as 40-char hex; both must reduce to the same Currency,
+// and that Currency (0x00…01) must sort after XRP (all-zero) — matching rippled's
+// std::pair<Currency,Currency> byte order. The pre-fix code had no "1" case, so
+// it collapsed the sentinel onto the all-zero code and tied it with XRP.
+func TestCurrencyOrderKeyNoCurrencyAfterXRP(t *testing.T) {
+	if currencyCode("1") != currencyCode("0000000000000000000000000000000000000001") {
+		t.Fatal(`currencyCode("1") must equal its 40-char hex form`)
+	}
+	if !(currencyOrderKey("XRP", "USD") < currencyOrderKey("1", "USD")) {
+		t.Fatal("XRP must order before the noCurrency sentinel")
+	}
+}

--- a/internal/tx/oracle/oracle_set.go
+++ b/internal/tx/oracle/oracle_set.go
@@ -402,12 +402,17 @@ func (o *OracleSet) doApplyUpdate(ctx *tx.ApplyContext, oracleKey keylet.Keylet,
 		}
 	}
 
-	// Emit the pairs in token-pair key order, matching rippled's std::map.
+	// Emit the pairs ordered by canonical Currency bytes (base, then quote),
+	// matching rippled's std::map<std::pair<Currency, Currency>>.
 	keys := make([]string, 0, len(orderedPairs))
 	for k := range orderedPairs {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	sort.Slice(keys, func(i, j int) bool {
+		a, b := orderedPairs[keys[i]], orderedPairs[keys[j]]
+		return currencyOrderKey(a.baseAsset, a.quoteAsset) <
+			currencyOrderKey(b.baseAsset, b.quoteAsset)
+	})
 
 	updatedSeries := make([]state.OraclePriceData, 0, len(orderedPairs))
 	for _, k := range keys {
@@ -487,12 +492,18 @@ func (o *OracleSet) doApplyCreate(ctx *tx.ApplyContext, oracleKey keylet.Keylet,
 			series = append(series, spd)
 		}
 	} else {
-		// With fixPriceOracleOrder: sort by (BaseAsset, QuoteAsset) key
+		// With fixPriceOracleOrder: emit ordered by canonical Currency bytes
+		// (base, then quote), matching rippled's std::map<std::pair<Currency,
+		// Currency>>.
 		keys := make([]string, 0, len(pairs))
 		for k := range pairs {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		sort.Slice(keys, func(i, j int) bool {
+			a, b := pairs[keys[i]], pairs[keys[j]]
+			return currencyOrderKey(a.baseAsset, a.quoteAsset) <
+				currencyOrderKey(b.baseAsset, b.quoteAsset)
+		})
 
 		for _, k := range keys {
 			p := pairs[k]


### PR DESCRIPTION
## Summary

- On an `OracleSet` apply, goXRPL sorted the merged `PriceDataSeries` by the `"base/quote"` asset-string key, in which **XRP is the literal `"XRP"`** (`0x585250…`) and so sorts *after* token currencies. rippled orders by `std::map<std::pair<Currency, Currency>>`, where **XRP is the all-zero currency** (`0x0000…`) and sorts *first*. Same entries, different order → divergent `Oracle` SLE → `account_hash`/`transaction_hash` fork at ledger **99226380**.
- Fix sorts by the canonical 20-byte `Currency` codes via a shared `currencyOrderKey` helper (`"XRP"` → 20 zero bytes, 3-letter ISO → bytes 12-14, 40-char hex → decoded verbatim).
- Applied to **both** apply sites that had the bug: the always-sorted update path (`doApplyUpdate`) and the `fixPriceOracleOrder`-gated create path (`doApplyCreate`). rippled's `tokenPairKey` returns `std::pair<Currency, Currency>` in both; the create-sorted branch is latent today (`fixPriceOracleOrder` is not yet enabled on mainnet) but had the identical bug.

## Test plan

- [x] `go test ./internal/tx/oracle/... ./internal/testing/oracle/...` — green
- [x] New `TestUpdate/UpdateOrdersByCurrencyXRPFirst` and `TestUpdate/CreateOrdersByCurrencyXRPFirst` assert XRP-based pairs sort first; verified they **fail** on the pre-fix string sort (XRP last) and **pass** with the fix
- [x] `./scripts/conformance-summary.sh Oracle` — 7/7 pass, no regressions
- [x] `go vet` / `gofmt` clean; `CGO_ENABLED=0 go build ./...` clean

Fixes #1020