### PR TITLE
fix: deleted node's FinalFields carry pre-tx PreviousTxnID, not crossing tx

### DIFF
--- a/internal/tx/applystate/apply_state_table.go
+++ b/internal/tx/applystate/apply_state_table.go
@@ -912,6 +912,7 @@ func (t *ApplyStateTable) buildDeletedNode(key [32]byte, original, current []byt
 		node.PreviousTxnID, node.PreviousTxnLgrSeq = origEntry.PreviousTxn()
 		currEntry.EmitDeletePreviousFields(origEntry, node.PreviousFields)
 		currEntry.EmitDeleteFinalFields(node.FinalFields)
+		restoreDeletedNodePrevTxn(node.FinalFields, node.PreviousTxnID, node.PreviousTxnLgrSeq)
 		if len(node.PreviousFields) == 0 {
 			node.PreviousFields = nil
 		}
@@ -967,6 +968,7 @@ func (t *ApplyStateTable) buildDeletedNode(key [32]byte, original, current []byt
 			node.FinalFields[name] = value
 		}
 	}
+	restoreDeletedNodePrevTxn(node.FinalFields, node.PreviousTxnID, node.PreviousTxnLgrSeq)
 
 	// Clean up empty maps
 	if len(node.PreviousFields) == 0 {
@@ -977,6 +979,25 @@ func (t *ApplyStateTable) buildDeletedNode(key [32]byte, original, current []byt
 	}
 
 	return node, nil
+}
+
+// restoreDeletedNodePrevTxn forces a DeletedNode's FinalFields to carry the
+// entry's pre-tx PreviousTxnID/PreviousTxnLgrSeq (prevID/prevSeq, read from the
+// pre-tx Original). rippled never threads an erased node, so when an entry is
+// modified — threaded to the current tx — and then erased within the same tx
+// (e.g. a resting offer partially then fully consumed during crossing), the
+// erased entry's Current holds the current tx as PreviousTxnID. The correct
+// FinalFields value is the prior pointer, which is what mainnet reports.
+func restoreDeletedNodePrevTxn(finalFields map[string]any, prevID string, prevSeq uint32) {
+	if prevID == "" {
+		return
+	}
+	if _, ok := finalFields["PreviousTxnID"]; ok {
+		finalFields["PreviousTxnID"] = prevID
+	}
+	if _, ok := finalFields["PreviousTxnLgrSeq"]; ok {
+		finalFields["PreviousTxnLgrSeq"] = prevSeq
+	}
 }
 
 // fieldsEqual compares two field values

--- a/internal/tx/applystate/deleted_node_prevtxn_test.go
+++ b/internal/tx/applystate/deleted_node_prevtxn_test.go
@@ -1,0 +1,85 @@
+package applystate
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+)
+
+// TestBuildDeletedNode_OfferPrevTxnFromOriginal reproduces the divergence at
+// mainnet ledger 99226383: a resting offer fully consumed during crossing is
+// threaded (PreviousTxnID set to the current tx) before being erased in the
+// same transaction. rippled never threads an erased node, so its DeletedNode
+// FinalFields carry the offer's PRIOR PreviousTxnID/PreviousTxnLgrSeq, not the
+// crossing tx. buildDeletedNode must source those fields from the pre-tx
+// Original rather than the threaded Current.
+func TestBuildDeletedNode_OfferPrevTxnFromOriginal(t *testing.T) {
+	var priorTxn, currentTxn [32]byte
+	for i := range priorTxn {
+		priorTxn[i] = 0xAB   // the offer's real last modification (ledger 99226378)
+		currentTxn[i] = 0xCD // the crossing tx that deletes it (ledger 99226383)
+	}
+	const priorSeq = uint32(99226378)
+	const currentSeq = uint32(99226383)
+
+	orig := &state.LedgerOffer{
+		Account:           "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+		Sequence:          96795764,
+		TakerPays:         state.NewXRPAmountFromInt(1_000_000_000),
+		TakerGets:         state.NewXRPAmountFromInt(2_000_000_000),
+		PreviousTxnID:     priorTxn,
+		PreviousTxnLgrSeq: priorSeq,
+	}
+	for i := range orig.BookDirectory {
+		orig.BookDirectory[i] = byte(i + 1)
+	}
+	origBytes, err := state.SerializeLedgerOffer(orig)
+	if err != nil {
+		t.Fatalf("SerializeLedgerOffer original: %v", err)
+	}
+
+	// Current is the state just before deletion: fully consumed (zeroed amounts)
+	// AND threaded to the crossing tx, exactly as it lands in the apply state
+	// table when an offer is partially then fully consumed across flow steps.
+	cur := *orig
+	cur.TakerPays = state.NewXRPAmountFromInt(0)
+	cur.TakerGets = state.NewXRPAmountFromInt(0)
+	cur.PreviousTxnID = currentTxn
+	cur.PreviousTxnLgrSeq = currentSeq
+	curBytes, err := state.SerializeLedgerOffer(&cur)
+	if err != nil {
+		t.Fatalf("SerializeLedgerOffer current: %v", err)
+	}
+
+	var key [32]byte
+	for i := range key {
+		key[i] = 0xBB
+	}
+
+	tbl := &ApplyStateTable{}
+	node, err := tbl.buildDeletedNode(key, origBytes, curBytes)
+	if err != nil {
+		t.Fatalf("buildDeletedNode: %v", err)
+	}
+	if node.FinalFields == nil {
+		t.Fatal("DeletedNode FinalFields is nil")
+	}
+
+	wantID := strings.ToUpper(hex.EncodeToString(priorTxn[:]))
+	threadedID := strings.ToUpper(hex.EncodeToString(currentTxn[:]))
+
+	gotID, _ := node.FinalFields["PreviousTxnID"].(string)
+	if gotID == threadedID {
+		t.Fatalf("DeletedNode FinalFields.PreviousTxnID reports the crossing tx (threaded Current); want the prior pointer %s", wantID)
+	}
+	if gotID != wantID {
+		t.Fatalf("DeletedNode FinalFields.PreviousTxnID = %q, want %q (pre-tx Original)", gotID, wantID)
+	}
+
+	gotSeq, _ := node.FinalFields["PreviousTxnLgrSeq"].(uint32)
+	if gotSeq != priorSeq {
+		t.Fatalf("DeletedNode FinalFields.PreviousTxnLgrSeq = %d, want %d (pre-tx Original)", gotSeq, priorSeq)
+	}
+}


### PR DESCRIPTION
## Summary

- A `DeletedNode` carries its `PreviousTxnID`/`PreviousTxnLgrSeq` inside `FinalFields` (sMD_DeleteFinal), not at the node level. `buildDeletedNode` built `FinalFields` from the entry's **Current** state.
- When a resting offer is partially then fully consumed during crossing, it is threaded (`PreviousTxnID` = current tx) on an earlier modify step and then erased in the **same** transaction, so `Current` holds the crossing tx as `PreviousTxnID`. rippled never threads an erased node, so its `DeletedNode` reports the offer's **prior** pointer.
- Fix: in `buildDeletedNode`, restore the `PreviousTxn*` pair in `FinalFields` from the pre-tx **Original** (both the typed `ledgerfields` path and the generic fallback). This is the rippled-faithful invariant for every deleted SLE type, and a no-op when the entry was not threaded mid-tx (`Current` == `Original`).
- Resolves the `transaction_hash` divergence at mainnet ledger **99226383** (`OfferCreate` `0d1c56ee…` deleting resting offer `800B039A…`, prior pointer `459587C5…` @ 99226378).

## Test plan

- [x] New unit test `TestBuildDeletedNode_OfferPrevTxnFromOriginal` reproduces the threaded-then-erased offer and asserts `FinalFields.PreviousTxnID`/`PreviousTxnLgrSeq` come from the prior pointer (confirmed FAIL before the fix, PASS after).
- [x] `internal/tx/applystate` parity tests (typed vs generic) still pass.
- [x] `go test ./internal/tx/...` and offer/payment/amm/check/escrow/nft/did/credential integration suites all green.
- [x] Conformance suite is byte-identical to baseline (no regressions); offer/flow/path suites at 100%.

Fixes #1022