### PR TITLE
fix: mainnet-replay divergences (autonomous, rippled 2.6.2 parity)

### DIFF
--- a/internal/ledger/state/amount_round.go
+++ b/internal/ledger/state/amount_round.go
@@ -348,6 +348,71 @@ func MulRoundNative(v1, v2 Amount, roundUp bool) int64 {
 	return NativeRoundDrops(amount, offset, resultNegative, roundUp, addSlop, false)
 }
 
+// MulRoundNativeStrict multiplies two Amounts and returns the result as XRP
+// drops, taking the strict native canonicalize path of rippled's
+// mulRoundStrict (mulRoundImpl<canonicalizeRoundStrict, NumberRoundModeGuard>
+// with a native asset). It canonicalizes the un-truncated muldiv product
+// directly to drops via canonicalizeRoundStrict(native=true): when rounding
+// away from zero a true sub-drop remainder forces a round-up, unlike the IOU
+// MulRoundStrict which first collapses the product to a 16-digit mantissa and
+// discards that remainder.
+func MulRoundNativeStrict(v1, v2 Amount, roundUp bool) int64 {
+	if v1.IsZero() || v2.IsZero() {
+		return 0
+	}
+	if v1.IsNative() && v2.IsNative() {
+		return mulNativeNative(v1.Drops(), v2.Drops())
+	}
+	value1, offset1 := PrepareMulDivOperand(v1)
+	value2, offset2 := PrepareMulDivOperand(v2)
+	resultNegative := v1.IsNegative() != v2.IsNegative()
+	addSlop := resultNegative != roundUp
+
+	amount := MulMantissas(value1, value2, addSlop)
+	offset := offset1 + offset2 + 14
+	return NativeRoundDrops(amount, offset, resultNegative, roundUp, addSlop, true)
+}
+
+// DivRoundNativeStrict divides two Amounts and returns the result as XRP drops,
+// taking the native canonicalize path of rippled's divRoundStrict
+// (divRoundImpl<NumberRoundModeGuard> with a native asset). divRoundImpl always
+// uses the non-strict canonicalizeRound for the away-from-zero branch (only
+// mulRoundImpl is templated on the canonicalize function), so the round-up leg
+// matches the non-strict DivRoundNative; strictness only changes the toward-zero
+// leg, which truncates the un-truncated product to drops rather than rounding to
+// nearest. Like MulRoundNativeStrict it canonicalizes the raw product, not an
+// IOU-collapsed mantissa.
+func DivRoundNativeStrict(num, den Amount, roundUp bool) int64 {
+	if den.IsZero() {
+		panic("division by zero")
+	}
+	if num.IsZero() {
+		return 0
+	}
+	numVal, numOff := PrepareMulDivOperand(num)
+	denVal, denOff := PrepareMulDivOperand(den)
+	resultNegative := num.IsNegative() != den.IsNegative()
+	addSlop := resultNegative != roundUp
+
+	amount := DivMantissas(numVal, denVal, addSlop)
+	offset := numOff - denOff - 17
+	if addSlop {
+		drops := CanonicalizeDrops(int64(amount), offset)
+		if drops == 0 && roundUp && !resultNegative {
+			drops = 1
+		}
+		if resultNegative {
+			drops = -drops
+		}
+		return drops
+	}
+	drops := canonicalizeDropsNoRound(amount, offset, true)
+	if resultNegative {
+		drops = -drops
+	}
+	return drops
+}
+
 // mulNativeNative reproduces rippled's mulRoundImpl native×native fast path: the
 // product of the two drop values, guarded against a result exceeding cMaxNative
 // before the multiply. The bounds are sqrt(cMaxNative) and cMaxNative/2^32; an

--- a/internal/replaytool/replay.go
+++ b/internal/replaytool/replay.go
@@ -390,6 +390,7 @@ func (r *replayRunner) executeReplayVerbose(state *StateFixture, env *EnvFixture
 		ReserveBase:               uint64(fees.Reserve),
 		ReserveIncrement:          uint64(fees.Increment),
 		LedgerSequence:            env.LedgerIndex,
+		ParentCloseTime:           uint32(env.ParentCloseTime),
 		SkipSignatureVerification: true,
 		Standalone:                true,
 		Rules:                     rules,

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -647,6 +647,7 @@ func (r *replayRangeRunner) processBlock(
 		ReserveBase:               uint64(fees.Reserve),
 		ReserveIncrement:          uint64(fees.Increment),
 		LedgerSequence:            targetLedger,
+		ParentHash:                preSnapshot.LedgerHash,
 		ParentCloseTime:           uint32(preSnapshot.CloseTime),
 		SkipSignatureVerification: true,
 		Standalone:                true,

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -647,6 +647,7 @@ func (r *replayRangeRunner) processBlock(
 		ReserveBase:               uint64(fees.Reserve),
 		ReserveIncrement:          uint64(fees.Increment),
 		LedgerSequence:            targetLedger,
+		ParentCloseTime:           uint32(preSnapshot.CloseTime),
 		SkipSignatureVerification: true,
 		Standalone:                true,
 		Rules:                     rules,

--- a/internal/tx/account/account_delete.go
+++ b/internal/tx/account/account_delete.go
@@ -205,6 +205,11 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	sourceBalance := ctx.Account.Balance
 	destAccount.Balance += sourceBalance
 	ctx.Account.Balance -= sourceBalance
+	// Record the transferred balance as the delivered amount, matching rippled's
+	// ctx_.deliver(mSourceBalance) in DeleteAccount::doApply — it is emitted in
+	// the metadata (sfDeliveredAmount) for every successful AccountDelete.
+	xrpDelivered := tx.NewXRPAmount(int64(sourceBalance))
+	ctx.Metadata.DeliveredAmount = &xrpDelivered
 	if sourceBalance > 0 && (destAccount.Flags&state.LsfPasswordSpent) != 0 {
 		destAccount.Flags &^= state.LsfPasswordSpent
 	}

--- a/internal/tx/amm/amm_bid.go
+++ b/internal/tx/amm/amm_bid.go
@@ -365,6 +365,7 @@ func (a *AMMBid) Apply(ctx *tx.ApplyContext) ter.Result {
 	amm.AuctionSlot.DiscountedFee = discountedFee
 
 	if a.AuthAccounts != nil {
+		amm.AuctionSlot.AuthAccountsPresent = true
 		amm.AuctionSlot.AuthAccounts = make([][20]byte, 0, len(a.AuthAccounts))
 		for _, authAccountEntry := range a.AuthAccounts {
 			authAccountID, err := state.DecodeAccountID(authAccountEntry.AuthAccount.Account)
@@ -373,6 +374,7 @@ func (a *AMMBid) Apply(ctx *tx.ApplyContext) ter.Result {
 			}
 		}
 	} else {
+		amm.AuctionSlot.AuthAccountsPresent = false
 		amm.AuctionSlot.AuthAccounts = make([][20]byte, 0)
 	}
 

--- a/internal/tx/amm/amm_delete_account.go
+++ b/internal/tx/amm/amm_delete_account.go
@@ -328,7 +328,16 @@ func deleteAMMAccountIfEmpty(view tx.LedgerView, ammKey keylet.Keylet, ammAccoun
 		return ter.TesSUCCESS
 	}
 
-	// LP tokens are zero — try to delete the AMM account
+	// LP tokens are zero — try to delete the AMM account. First persist the AMM
+	// account's XRP-side balance change: a withdrawn XRP asset was debited from
+	// ammAccount.Balance (an in-memory struct) but not yet written, and
+	// DeleteAMMAccount re-reads the account from the view. Without this write the
+	// DeletedNode metadata records the pre-withdrawal balance instead of the
+	// drained balance, mirroring rippled which transfers the XRP out (draining the
+	// account) before deleting it.
+	if r := updateAMMAccountIfChanged(view, ammAccountKey, ammAccount); r != ter.TesSUCCESS {
+		return r
+	}
 	result := DeleteAMMAccount(view, asset, asset2)
 	if result != ter.TesSUCCESS && result != ter.TecINCOMPLETE {
 		return result

--- a/internal/tx/amm/amm_delete_account.go
+++ b/internal/tx/amm/amm_delete_account.go
@@ -83,6 +83,14 @@ func deleteAMMTrustLine(view tx.LedgerView, lineKey keylet.Keylet, rs *state.Rip
 		return ter.TerNO_AMM
 	}
 
+	// The reserve-holding side's flag must be present before the line is erased;
+	// an AMM pool line always carries at least the AMM side's reserve flag, so its
+	// total absence is an internal inconsistency. Mirrors rippled's tecINTERNAL
+	// guard. Reference: rippled View.cpp:2759-2761.
+	if rs.Flags&(state.LsfLowReserve|state.LsfHighReserve) == 0 {
+		return ter.TecINTERNAL
+	}
+
 	// rippled empties an AMM's pool lines during the withdrawal payout, where
 	// rippleCreditIOU drives the AMM (reserve) side to zero: it clears that
 	// side's reserve flag on the line and decrements the line owner's OwnerCount

--- a/internal/tx/amm/amm_delete_account.go
+++ b/internal/tx/amm/amm_delete_account.go
@@ -1,12 +1,34 @@
 package amm
 
 import (
+	"bytes"
+
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
+
+// updateAMMAccountIfChanged persists the AMM account only when its serialized
+// bytes actually differ from what the view already holds. An all-IOU withdraw
+// leaves the AMM account's own fields untouched (only its trust lines change);
+// rewriting it would promote it to a modified node, whereas rippled leaves it
+// as a bare threaded owner of the changed trust lines (no FinalFields). An
+// XRP-side withdraw does change its Balance, so it is still written.
+func updateAMMAccountIfChanged(view tx.LedgerView, ammAccountKey keylet.Keylet, ammAccount *state.AccountRoot) ter.Result {
+	ammAccountBytes, err := state.SerializeAccountRoot(ammAccount)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if cur, _ := view.Read(ammAccountKey); bytes.Equal(cur, ammAccountBytes) {
+		return ter.TesSUCCESS
+	}
+	if err := view.Update(ammAccountKey, ammAccountBytes); err != nil {
+		return ter.TefINTERNAL
+	}
+	return ter.TesSUCCESS
+}
 
 // maxDeletableAMMTrustLines is the maximum number of trust lines that can be
 // deleted in a single transaction when cleaning up an AMM account.
@@ -281,12 +303,8 @@ func deleteAMMAccountIfEmpty(view tx.LedgerView, ammKey keylet.Keylet, ammAccoun
 		if err := view.Update(ammKey, ammBytes); err != nil {
 			return ter.TefINTERNAL
 		}
-		ammAccountBytes, err := state.SerializeAccountRoot(ammAccount)
-		if err != nil {
-			return ter.TefINTERNAL
-		}
-		if err := view.Update(ammAccountKey, ammAccountBytes); err != nil {
-			return ter.TefINTERNAL
+		if r := updateAMMAccountIfChanged(view, ammAccountKey, ammAccount); r != ter.TesSUCCESS {
+			return r
 		}
 		return ter.TesSUCCESS
 	}
@@ -308,12 +326,8 @@ func deleteAMMAccountIfEmpty(view tx.LedgerView, ammKey keylet.Keylet, ammAccoun
 		if err := view.Update(ammKey, ammBytes); err != nil {
 			return ter.TefINTERNAL
 		}
-		ammAccountBytes, err := state.SerializeAccountRoot(ammAccount)
-		if err != nil {
-			return ter.TefINTERNAL
-		}
-		if err := view.Update(ammAccountKey, ammAccountBytes); err != nil {
-			return ter.TefINTERNAL
+		if r := updateAMMAccountIfChanged(view, ammAccountKey, ammAccount); r != ter.TesSUCCESS {
+			return r
 		}
 	}
 

--- a/internal/tx/amm/amm_delete_account.go
+++ b/internal/tx/amm/amm_delete_account.go
@@ -83,43 +83,62 @@ func deleteAMMTrustLine(view tx.LedgerView, lineKey keylet.Keylet, rs *state.Rip
 		return ter.TerNO_AMM
 	}
 
+	// rippled empties an AMM's pool lines during the withdrawal payout, where
+	// rippleCreditIOU drives the AMM (reserve) side to zero: it clears that
+	// side's reserve flag on the line and decrements the line owner's OwnerCount
+	// before trustDelete erases the line. Both mutations must be recorded
+	// in-place so the resulting DeletedNode metadata carries PreviousFields
+	// (line Flags 0x..020000 -> 0x..000000, owner OwnerCount n -> n-1). Mirror
+	// that here for each side holding a reserve, before the line is erased.
+	if rs.Flags&state.LsfLowReserve != 0 {
+		rs.Flags &^= state.LsfLowReserve
+		if err := decrementLineOwner(view, lowAccountID, lowAccount, ammLow); err != nil {
+			return ter.TecINTERNAL
+		}
+	}
+	if rs.Flags&state.LsfHighReserve != 0 {
+		rs.Flags &^= state.LsfHighReserve
+		if err := decrementLineOwner(view, highAccountID, highAccount, ammHigh); err != nil {
+			return ter.TecINTERNAL
+		}
+	}
+
+	// Persist the cleared reserve flag before erasing so the DeletedNode records
+	// the flag change as PreviousFields.
+	rsBytes, err := state.SerializeRippleState(rs)
+	if err != nil {
+		return ter.TecINTERNAL
+	}
+	if err := view.Update(lineKey, rsBytes); err != nil {
+		return ter.TecINTERNAL
+	}
+
 	if trustDelete(view, lineKey, lowAccountID, highAccountID, rs.LowNode, rs.HighNode) != nil {
 		return ter.TefBAD_LEDGER
 	}
 
-	// Decrement OwnerCount for each non-AMM side that has a reserve flag set.
-	// Unlike rippled — which deletes AMM pool lines during withdraw (so its
-	// deleteAMMTrustLine only ever runs on LP-holder lines where the non-AMM
-	// side carries the reserve) — goXRPL keeps the pool lines until the whole
-	// AMM account is deleted here. So this also runs on AMM-reserve-side pool
-	// lines, where the non-AMM (issuer) side has no reserve flag and must be
-	// skipped. Reference: rippled View.cpp deleteAMMTrustLine line 2759-2763.
-	if rs.Flags&state.LsfLowReserve != 0 && !ammLow {
-		if lowAccount.OwnerCount > 0 {
-			lowAccount.OwnerCount--
-		}
-		lowBytes, err := state.SerializeAccountRoot(lowAccount)
-		if err != nil {
-			return ter.TecINTERNAL
-		}
-		if err := view.Update(keylet.Account(lowAccountID), lowBytes); err != nil {
-			return ter.TecINTERNAL
-		}
-	}
-	if rs.Flags&state.LsfHighReserve != 0 && !ammHigh {
-		if highAccount.OwnerCount > 0 {
-			highAccount.OwnerCount--
-		}
-		highBytes, err := state.SerializeAccountRoot(highAccount)
-		if err != nil {
-			return ter.TecINTERNAL
-		}
-		if err := view.Update(keylet.Account(highAccountID), highBytes); err != nil {
-			return ter.TecINTERNAL
-		}
-	}
-
 	return ter.TesSUCCESS
+}
+
+// decrementLineOwner decrements the OwnerCount of a trust line's reserve-holding
+// side through the view, so the change is recorded as an in-place modification
+// before the line (and, for the AMM side, the AMM AccountRoot) is erased. For
+// the AMM side it routes through tx.AdjustOwnerCount, which re-reads the account
+// from the view each call so repeated decrements (one per pool line) compose to
+// the correct final OwnerCount and the AMM AccountRoot's later erase becomes a
+// DeletedNode carrying PreviousFields.OwnerCount.
+func decrementLineOwner(view tx.LedgerView, accountID [20]byte, account *state.AccountRoot, isAMM bool) error {
+	if isAMM {
+		return tx.AdjustOwnerCount(view, accountID, -1)
+	}
+	if account.OwnerCount > 0 {
+		account.OwnerCount--
+	}
+	bytes, err := state.SerializeAccountRoot(account)
+	if err != nil {
+		return err
+	}
+	return view.Update(keylet.Account(accountID), bytes)
 }
 
 // deleteAMMTrustLines iterates the AMM account's owner directory and deletes

--- a/internal/tx/amm/amm_deposit.go
+++ b/internal/tx/amm/amm_deposit.go
@@ -978,12 +978,12 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TefINTERNAL
 	}
 
-	ammAccountBytes, err := state.SerializeAccountRoot(ammAccount)
-	if err != nil {
-		return ter.TefINTERNAL
-	}
-	if err := ctx.View.Update(ammAccountKey, ammAccountBytes); err != nil {
-		return ter.TefINTERNAL
+	// Only persist the AMM account when it actually changed (an XRP-side deposit
+	// adjusts its Balance). For an all-IOU deposit the AMM account's own fields
+	// are untouched; rewriting it would promote it to a modified node, whereas
+	// rippled leaves it a bare threaded owner of the changed trust lines (#1038).
+	if r := updateAMMAccountIfChanged(ctx.View, ammAccountKey, ammAccount); r != ter.TesSUCCESS {
+		return r
 	}
 
 	accountKey := keylet.Account(accountID)

--- a/internal/tx/amm/serialize.go
+++ b/internal/tx/amm/serialize.go
@@ -106,6 +106,7 @@ func parseAMMData(data []byte) (*AMMData, error) {
 			slot.Price = price
 		}
 		if authArr, ok := auctionObj["AuthAccounts"].([]any); ok {
+			slot.AuthAccountsPresent = true
 			for _, authEntry := range authArr {
 				authMap, ok := authEntry.(map[string]any)
 				if !ok {
@@ -212,7 +213,7 @@ func serializeAMMData(amm *AMMData) ([]byte, error) {
 		if amm.AuctionSlot.DiscountedFee != 0 {
 			auctionSlot["DiscountedFee"] = amm.AuctionSlot.DiscountedFee
 		}
-		if len(amm.AuctionSlot.AuthAccounts) > 0 {
+		if amm.AuctionSlot.AuthAccountsPresent {
 			authAccounts := make([]any, 0, len(amm.AuctionSlot.AuthAccounts))
 			for _, authID := range amm.AuctionSlot.AuthAccounts {
 				authAcctAddr, err := state.EncodeAccountID(authID)

--- a/internal/tx/amm/trustline.go
+++ b/internal/tx/amm/trustline.go
@@ -514,16 +514,22 @@ func redeemIOUWithCleanup(view tx.LedgerView, holderID, ammAccountID [20]byte, a
 		rs.Balance.Currency, rs.Balance.Issuer)
 	rs.Flags = rsFlags
 
-	if bDelete {
-		return trustDeleteRippleState(view, trustLineKey, rs, holderID, ammAccountID, holderHigh)
-	}
-
+	// Persist the redeemed balance and cleared reserve flag before any deletion,
+	// so the metadata records the modification (FinalFields = balance 0 / flag
+	// cleared, PreviousFields = the pre-redeem state). rippled's redeemIOU updates
+	// the trust line and only then trustDelete's it; erasing without this update
+	// leaves a DeletedNode showing the pre-redeem balance and no PreviousFields,
+	// forking the transaction tree from rippled.
 	rsBytes, err := state.SerializeRippleState(rs)
 	if err != nil {
 		return ter.TefINTERNAL
 	}
 	if err := view.Update(trustLineKey, rsBytes); err != nil {
 		return ter.TefINTERNAL
+	}
+
+	if bDelete {
+		return trustDeleteRippleState(view, trustLineKey, rs, holderID, ammAccountID, holderHigh)
 	}
 
 	return ter.TesSUCCESS

--- a/internal/tx/amm/types.go
+++ b/internal/tx/amm/types.go
@@ -43,6 +43,12 @@ type AuctionSlotData struct {
 	Price         tx.Amount
 	DiscountedFee uint16 // Discounted trading fee for auction slot holder
 	AuthAccounts  [][20]byte
+	// AuthAccountsPresent records whether the optional sfAuthAccounts field is
+	// present on the slot (an empty array is present, not absent). rippled's
+	// AMMBid sets the field when the bid carries AuthAccounts and otherwise calls
+	// makeFieldAbsent, so present-empty and absent are distinct on-ledger states
+	// that must round-trip exactly.
+	AuthAccountsPresent bool
 }
 
 // AuthAccount is an authorized account for AMM slot trading

--- a/internal/tx/applystate/apply_state_table.go
+++ b/internal/tx/applystate/apply_state_table.go
@@ -412,7 +412,14 @@ func (t *ApplyStateTable) Apply() (*tx.Metadata, error) {
 	// carrying transactions that touched fresh owner accounts.
 	for key, owner := range t.threadOnlyOwners {
 		if entry, alreadyEmitted := t.items[key]; alreadyEmitted {
-			if entry.Action != ActionCache {
+			// Skip the bare emission only when the tracked item emits its own
+			// node. A no-op ActionModify (Original == Current) is dropped by the
+			// meta loop's bytes.Equal skip, so its bare threaded node must be
+			// emitted here — this is the order-dependent case from threadOwners
+			// where a later-keyed deleted/created child threads a force-marked
+			// payment destination (rippled's getForMod bare-node path).
+			noopModify := entry.Action == ActionModify && bytes.Equal(entry.Original, entry.Current)
+			if entry.Action != ActionCache && !noopModify {
 				continue
 			}
 		}
@@ -491,7 +498,7 @@ func (t *ApplyStateTable) applyThreading() {
 			}
 
 			// Thread owner accounts
-			t.threadOwners(w.entry.Current, entryType, fixCheckThreading)
+			t.threadOwners(w.key, w.entry.Current, entryType, fixCheckThreading)
 
 		case ActionModify:
 			// Skip threading when the apply code wrote back the same bytes
@@ -523,19 +530,21 @@ func (t *ApplyStateTable) applyThreading() {
 			if data == nil {
 				data = w.entry.Original
 			}
-			t.threadOwners(data, entryType, fixCheckThreading)
+			t.threadOwners(w.key, data, entryType, fixCheckThreading)
 		}
 	}
 }
 
 // threadOwners updates PreviousTxnID/PreviousTxnLgrSeq on owner accounts.
-// fixCheckThreading gates Check→Destination threading.
+// fixCheckThreading gates Check→Destination threading. sourceKey is the ledger
+// key of the created/deleted child whose owners are being threaded — it decides
+// the order-dependent FinalFields-vs-bare outcome described below.
 //
 // Owner SLEs the tx didn't otherwise mutate go into threadOnlyOwners
 // (NOT promoted to ActionModify), mirroring rippled's mods table at
 // ApplyStateTable.cpp:584-633 — the emitted AffectedNode is bare
 // (no FinalFields / PreviousFields).
-func (t *ApplyStateTable) threadOwners(data []byte, entryType string, fixCheckThreading bool) {
+func (t *ApplyStateTable) threadOwners(sourceKey [32]byte, data []byte, entryType string, fixCheckThreading bool) {
 	if data == nil {
 		return
 	}
@@ -552,6 +561,38 @@ func (t *ApplyStateTable) threadOwners(data []byte, entryType string, fixCheckTh
 			// Non-cache entry: thread fields flow into its own
 			// FinalFields/NewFields (rippled ApplyStateTable.cpp:614-615).
 			if entry.Action != ActionCache {
+				// A no-op ActionModify owner (Original == Current, e.g. a
+				// payment destination force-marked by view().update(sleDst)
+				// whose own fields never changed) is emitted as FinalFields or
+				// bare depending on rippled's std::map key ordering in the apply
+				// loop. rippled processes items_ in ascending key order: the skip
+				// of an unchanged modify (`*curNode == *origNode`,
+				// ApplyStateTable.cpp:156-157) and the threadOwners of a
+				// created/deleted child (line 168/241) both fire at their own
+				// key. If the child's key sorts before the owner's, the child
+				// threads the owner's in-items SLE first, so the owner is no
+				// longer a no-op when reached → emitted with FinalFields. If the
+				// owner's key sorts first, it is skipped while still a no-op, and
+				// the child later threads it via getForMod into the metadata as a
+				// bare node (threadItem alone). Replicate that ordering here: only
+				// thread into the owner's own FinalFields when sourceKey sorts
+				// before ownerKey; otherwise leave the no-op modify untouched (the
+				// meta loop's bytes.Equal skip drops it) and route the owner to
+				// threadOnlyOwners for a bare node.
+				if bytes.Equal(entry.Original, entry.Current) &&
+					bytes.Compare(sourceKey[:], ownerKey.Key[:]) > 0 {
+					oldPrev, oldPrevSeq, newData, changed := threadItem(entry.Current, t.txHash, t.txSeq)
+					if !changed {
+						continue
+					}
+					t.threadOnlyOwners[ownerKey.Key] = &ThreadedOwner{
+						EntryType:            state.EntryType(entry.Current),
+						OldPreviousTxnID:     oldPrev,
+						OldPreviousTxnLgrSeq: oldPrevSeq,
+						Updated:              newData,
+					}
+					continue
+				}
 				_, _, newData, changed := threadItem(entry.Current, t.txHash, t.txSeq)
 				if changed {
 					entry.Current = newData

--- a/internal/tx/applystate/apply_state_table.go
+++ b/internal/tx/applystate/apply_state_table.go
@@ -983,21 +983,32 @@ func (t *ApplyStateTable) buildDeletedNode(key [32]byte, original, current []byt
 
 // restoreDeletedNodePrevTxn forces a DeletedNode's FinalFields to carry the
 // entry's pre-tx PreviousTxnID/PreviousTxnLgrSeq (prevID/prevSeq, read from the
-// pre-tx Original). rippled never threads an erased node, so when an entry is
-// modified — threaded to the current tx — and then erased within the same tx
-// (e.g. a resting offer partially then fully consumed during crossing), the
-// erased entry's Current holds the current tx as PreviousTxnID. The correct
-// FinalFields value is the prior pointer, which is what mainnet reports.
+// pre-tx Original). rippled builds a deleted node's FinalFields from its
+// in-memory SLE (curNode), which always retains the stored sfPreviousTxnID
+// because it is never stripped on the delete path; both fields carry
+// sMD_DeleteFinal, so they are emitted with the node's last-modified pointer.
+//
+// goXRPL's equivalent of curNode is the Current blob. Two cases leave Current
+// without the correct pointer, both of which this restore corrects to the
+// stored value from Original:
+//   - An entry modified (threaded to the current tx) then erased within the
+//     same tx (e.g. a resting offer partially then fully consumed during
+//     crossing) holds the current tx as PreviousTxnID in Current — the correct
+//     FinalFields value is the prior pointer.
+//   - An entry whose serializer drops PreviousTxnID (e.g. NFTokenPage rebuilt
+//     during a page merge before deletion) holds no pointer in Current at all,
+//     so the field must be inserted, not just overwritten.
+//
+// In both cases prevID/prevSeq come from the pre-tx Original, which equals the
+// stored pointer rippled's curNode reports (an erased node is never re-threaded,
+// so its stored pointer is its last-modified value). When prevID is empty the
+// entry was never threaded (e.g. created and deleted), and nothing is stamped.
 func restoreDeletedNodePrevTxn(finalFields map[string]any, prevID string, prevSeq uint32) {
 	if prevID == "" {
 		return
 	}
-	if _, ok := finalFields["PreviousTxnID"]; ok {
-		finalFields["PreviousTxnID"] = prevID
-	}
-	if _, ok := finalFields["PreviousTxnLgrSeq"]; ok {
-		finalFields["PreviousTxnLgrSeq"] = prevSeq
-	}
+	finalFields["PreviousTxnID"] = prevID
+	finalFields["PreviousTxnLgrSeq"] = prevSeq
 }
 
 // fieldsEqual compares two field values

--- a/internal/tx/applystate/deleted_node_prevtxn_test.go
+++ b/internal/tx/applystate/deleted_node_prevtxn_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 )
 
@@ -79,6 +80,99 @@ func TestBuildDeletedNode_OfferPrevTxnFromOriginal(t *testing.T) {
 	}
 
 	gotSeq, _ := node.FinalFields["PreviousTxnLgrSeq"].(uint32)
+	if gotSeq != priorSeq {
+		t.Fatalf("DeletedNode FinalFields.PreviousTxnLgrSeq = %d, want %d (pre-tx Original)", gotSeq, priorSeq)
+	}
+}
+
+// nftokenPageBytes encodes an NFTokenPage blob. withPrevTxn controls whether
+// the stored threading pointer is present: the on-ledger page carries it, but
+// serializeNFTokenPage rebuilds a page WITHOUT it (the page is re-serialized
+// during a merge before being erased), so the deleted entry's Current is
+// threadless.
+func nftokenPageBytes(t *testing.T, tokens []string, prevTxn [32]byte, prevSeq uint32, withPrevTxn bool) []byte {
+	t.Helper()
+	nfTokens := make([]map[string]any, len(tokens))
+	for i, id := range tokens {
+		nfTokens[i] = map[string]any{
+			"NFToken": map[string]any{"NFTokenID": id},
+		}
+	}
+	obj := map[string]any{
+		"LedgerEntryType": "NFTokenPage",
+		"Flags":           uint32(0),
+		"NFTokens":        nfTokens,
+	}
+	if withPrevTxn {
+		obj["PreviousTxnID"] = strings.ToUpper(hex.EncodeToString(prevTxn[:]))
+		obj["PreviousTxnLgrSeq"] = prevSeq
+	}
+	hexStr, err := binarycodec.Encode(obj)
+	if err != nil {
+		t.Fatalf("encode NFTokenPage: %v", err)
+	}
+	b, err := hex.DecodeString(hexStr)
+	if err != nil {
+		t.Fatalf("decode NFTokenPage hex: %v", err)
+	}
+	return b
+}
+
+// TestBuildDeletedNode_NFTokenPagePrevTxnFromOriginal reproduces the divergence
+// at mainnet ledger 99226885 tx 6 (issue #1047): an NFToken leaves a page, the
+// page is re-serialized (serializeNFTokenPage drops PreviousTxnID) and then
+// merged into a sibling and erased within the same tx. The erased entry's
+// Current is therefore threadless — it carries no PreviousTxnID at all — while
+// its on-ledger Original still holds the page's last-modified pointer.
+//
+// rippled builds the DeletedNode's FinalFields from its in-memory SLE, which
+// retains sfPreviousTxnID (sMD_DeleteFinal), so mainnet reports the stored
+// pointer. buildDeletedNode must insert that pointer (from the pre-tx Original)
+// even though Current omits it.
+func TestBuildDeletedNode_NFTokenPagePrevTxnFromOriginal(t *testing.T) {
+	var priorTxn [32]byte
+	for i := range priorTxn {
+		priorTxn[i] = 0xC9
+	}
+	const priorSeq = uint32(99226875)
+
+	tokens := []string{
+		"001A2710E7EFE991D9F52CA949A75D4896F5B94D20E6472DAD8707510449F9C4",
+		"001A2710E7EFE991D9F52CA949A75D4896F5B94D20E6472DAD8707510449FAAA",
+	}
+
+	// Original: the live page, with its stored threading pointer.
+	origBytes := nftokenPageBytes(t, tokens, priorTxn, priorSeq, true)
+	// Current: the rebuilt, threadless page (serializeNFTokenPage output).
+	curBytes := nftokenPageBytes(t, tokens, priorTxn, priorSeq, false)
+
+	var key [32]byte
+	for i := range key {
+		key[i] = 0xF6
+	}
+
+	tbl := &ApplyStateTable{}
+	node, err := tbl.buildDeletedNode(key, origBytes, curBytes)
+	if err != nil {
+		t.Fatalf("buildDeletedNode: %v", err)
+	}
+	if node.FinalFields == nil {
+		t.Fatal("DeletedNode FinalFields is nil")
+	}
+
+	wantID := strings.ToUpper(hex.EncodeToString(priorTxn[:]))
+	gotID, ok := node.FinalFields["PreviousTxnID"].(string)
+	if !ok {
+		t.Fatalf("DeletedNode FinalFields.PreviousTxnID missing; want %s (pre-tx Original)", wantID)
+	}
+	if gotID != wantID {
+		t.Fatalf("DeletedNode FinalFields.PreviousTxnID = %q, want %q (pre-tx Original)", gotID, wantID)
+	}
+
+	gotSeq, ok := node.FinalFields["PreviousTxnLgrSeq"].(uint32)
+	if !ok {
+		t.Fatalf("DeletedNode FinalFields.PreviousTxnLgrSeq missing; want %d (pre-tx Original)", priorSeq)
+	}
 	if gotSeq != priorSeq {
 		t.Fatalf("DeletedNode FinalFields.PreviousTxnLgrSeq = %d, want %d (pre-tx Original)", gotSeq, priorSeq)
 	}

--- a/internal/tx/ledgerfields/decode_stream.go
+++ b/internal/tx/ledgerfields/decode_stream.go
@@ -404,9 +404,10 @@ func boolToInt(b bool) int {
 
 // decodeCurrencyCode mirrors codec/binarycodec/types/amount.go's
 // deserializeCurrencyCode without the strings.ToUpper(hex.EncodeToString(...))
-// double allocation. Returns "XRP" for the all-zero sentinel, the uppercased
-// 3-char ISO code when the 12/3/5-byte standard layout matches the IOU
-// charset, and the upper-hex 40-char form for any non-standard 20-byte code.
+// double allocation. Returns "XRP" for the all-zero sentinel, the 3-char ISO
+// code (preserving its original case — codes are case-sensitive and must
+// round-trip byte-for-byte) when the 12/3/5-byte standard layout matches the
+// IOU charset, and the upper-hex 40-char form for any non-standard 20-byte code.
 func decodeCurrencyCode(data []byte) (string, error) {
 	if len(data) != 20 {
 		return "", errors.New("ledgerfields: currency code must be 20 bytes")
@@ -448,9 +449,6 @@ func decodeCurrencyCode(data []byte) (string, error) {
 		ok := true
 		for i := range 3 {
 			b := data[12+i]
-			if b >= 'a' && b <= 'z' {
-				b -= 'a' - 'A'
-			}
 			iso[i] = b
 			if !isValidIOUCodeByte(b) {
 				ok = false
@@ -469,6 +467,8 @@ func isValidIOUCodeByte(b byte) bool {
 	case b >= '0' && b <= '9':
 		return true
 	case b >= 'A' && b <= 'Z':
+		return true
+	case b >= 'a' && b <= 'z':
 		return true
 	}
 	switch b {

--- a/internal/tx/nftoken/nftoken_accept.go
+++ b/internal/tx/nftoken/nftoken_accept.go
@@ -195,14 +195,21 @@ func (n *NFTokenAcceptOffer) executeBrokeredMode(ctx *tx.ApplyContext, accountID
 
 			// Pay issuer cut
 			if issuerCut > 0 {
-				issuerKey := keylet.Account(nftIssuerID)
-				issuerData, err := ctx.View.Read(issuerKey)
-				if err == nil {
-					issuerAccount, err := state.ParseAccountRoot(issuerData)
+				if nftIssuerID == accountID {
+					// Issuer is the broker/source: credit ctx.Account so the
+					// engine's authoritative write-back keeps it. Crediting the
+					// view here would be clobbered by ctx.Account's write-back.
+					ctx.Account.Balance += issuerCut
+				} else {
+					issuerKey := keylet.Account(nftIssuerID)
+					issuerData, err := ctx.View.Read(issuerKey)
 					if err == nil {
-						issuerAccount.Balance += issuerCut
-						issuerUpdatedData, _ := state.SerializeAccountRoot(issuerAccount)
-						ctx.View.Update(issuerKey, issuerUpdatedData)
+						issuerAccount, err := state.ParseAccountRoot(issuerData)
+						if err == nil {
+							issuerAccount.Balance += issuerCut
+							issuerUpdatedData, _ := state.SerializeAccountRoot(issuerAccount)
+							ctx.View.Update(issuerKey, issuerUpdatedData)
+						}
 					}
 				}
 				amount -= issuerCut

--- a/internal/tx/nftoken/nftoken_accept_offer.go
+++ b/internal/tx/nftoken/nftoken_accept_offer.go
@@ -42,9 +42,11 @@ func (n *NFTokenAcceptOffer) Validate() error {
 		return err
 	}
 
-	// Check for invalid flags (no flags are valid for NFTokenAcceptOffer)
-	if n.GetFlags() != 0 {
-		return ter.Errorf(ter.TemINVALID_FLAG, "NFTokenAcceptOffer does not accept any flags")
+	// NFTokenAcceptOffer defines no transaction-specific flags, but the universal
+	// flags (e.g. tfFullyCanonicalSig) are always permitted.
+	// Reference: rippled TxFlags.h tfNFTokenAcceptOfferMask = ~tfUniversal.
+	if n.GetFlags()&^tx.TfUniversal != 0 {
+		return ter.Errorf(ter.TemINVALID_FLAG, "NFTokenAcceptOffer: invalid flags")
 	}
 
 	// Must have at least one offer

--- a/internal/tx/nftoken/nftoken_serialize.go
+++ b/internal/tx/nftoken/nftoken_serialize.go
@@ -119,9 +119,12 @@ func serializeNFTokenOfferRaw(
 
 // serializeNFTokenOffer serializes an NFToken offer from an NFTokenCreateOffer transaction.
 func serializeNFTokenOffer(nftTx *NFTokenCreateOffer, ownerID [20]byte, tokenID [32]byte, sequence uint32, ownerNode uint64, offerNode uint64) ([]byte, error) {
+	// The NFTokenOffer ledger object only carries lsfSellNFToken; the rest of the
+	// transaction's flags (notably tfFullyCanonicalSig) must not leak into its
+	// sfFlags. rippled sets (*offer)[sfFlags] = isSell ? lsfSellNFToken : 0.
 	return serializeNFTokenOfferRaw(
 		ownerID, tokenID,
-		amountToCodecFormat(nftTx.Amount), nftTx.GetFlags(),
+		amountToCodecFormat(nftTx.Amount), nftTx.GetFlags()&NFTokenCreateOfferFlagSellNFToken,
 		ownerNode, offerNode,
 		nftTx.Destination, nftTx.Expiration,
 	)

--- a/internal/tx/offer/offer_create_apply.go
+++ b/internal/tx/offer/offer_create_apply.go
@@ -123,8 +123,11 @@ func (o *OfferCreate) applyGuts(ctx *tx.ApplyContext, sb, sbCancel *payment.Paym
 
 	// Process cancellation request if specified
 	// Reference: lines 608-621
-	// CRITICAL: Offer cancellation must happen in BOTH sandboxes
-	result := o.processCancelRequest(ctx, sb, sbCancel)
+	// The cancellation is applied to the main sandbox (sb) only; on a kill the
+	// cancel sandbox (sbCancel) is applied instead, discarding the cancellation
+	// — matching rippled, where offerDelete(sb, ...) and its owner-count
+	// adjustment both live in sb and are dropped with it on a kill.
+	result := o.processCancelRequest(ctx, sb)
 
 	// Reference: lines 623-636
 	if tx.HasExpired(o.Expiration, ctx.Config.ParentCloseTime) {

--- a/internal/tx/offer/offer_create_cross.go
+++ b/internal/tx/offer/offer_create_cross.go
@@ -53,7 +53,7 @@ func (o *OfferCreate) invokeFlowCross(
 	ctx *tx.ApplyContext,
 	sb *payment.PaymentSandbox,
 	saTakerPays, saTakerGets tx.Amount,
-	bPassive, bSell bool,
+	bPassive, bSell, bFillOrKill bool,
 ) payment.FlowCrossResult {
 	rules := ctx.Rules()
 	return payment.FlowCross(
@@ -64,14 +64,16 @@ func (o *OfferCreate) invokeFlowCross(
 		ctx.TxHash,
 		ctx.Config.LedgerSequence,
 		payment.FlowCrossParams{
-			Passive:                    bPassive, // For passive offers, only cross against strictly better quality
-			Sell:                       bSell,    // For sell offers, deliver MAX (sell all input regardless of output)
+			Passive:                    bPassive,    // For passive offers, only cross against strictly better quality
+			Sell:                       bSell,       // For sell offers, deliver MAX (sell all input regardless of output)
+			FillOrKill:                 bFillOrKill, // FillOrKill runs the flow with partialPayment disabled (rippled CreateOffer.cpp:411)
 			ParentCloseTime:            ctx.Config.ParentCloseTime,
 			ReserveBase:                ctx.Config.ReserveBase,
 			ReserveIncrement:           ctx.Config.ReserveIncrement,
 			FixReducedOffersV1:         rules.Enabled(amendment.FeatureFixReducedOffersV1),
 			FixReducedOffersV2:         rules.Enabled(amendment.FeatureFixReducedOffersV2),
 			FixRmSmallIncreasedQOffers: rules.Enabled(amendment.FeatureFixRmSmallIncreasedQOffers),
+			FixFillOrKill:              rules.Enabled(amendment.FeatureFixFillOrKill),
 			FlowSortStrands:            rules.Enabled(amendment.FeatureFlowSortStrands),
 			FixAMMv1_1:                 rules.Enabled(amendment.FeatureFixAMMv1_1),
 			FixAMMv1_2:                 rules.Enabled(amendment.FeatureFixAMMv1_2),
@@ -139,7 +141,7 @@ func (o *OfferCreate) takerCross(
 		"sell", bSell,
 	)
 
-	crossResult := o.invokeFlowCross(ctx, sb, saTakerPays, saTakerGets, bPassive, bSell)
+	crossResult := o.invokeFlowCross(ctx, sb, saTakerPays, saTakerGets, bPassive, bSell, bFillOrKill)
 
 	// Convert result amounts back.
 	// Reference: rippled CreateOffer.cpp flowCross() result handling
@@ -169,6 +171,28 @@ func (o *OfferCreate) takerCross(
 		result = ter.TesSUCCESS
 	}
 
+	// tecPATH_PARTIAL is only produced when the flow ran with partialPayment
+	// disabled, i.e. a FillOrKill offer that could not be fully crossed. rippled
+	// runs the same partialPayment=!FoK flow (CreateOffer.cpp:411); on a non-
+	// success engine result flowCross discards the partial crossing and reports
+	// the offer as completely uncrossed (afterCross = takerAmount, line 429), yet
+	// still erases the flow's removableOffers from both sandboxes (419-426).
+	// Mirror that: drop the partial crossing (sandbox was not applied in
+	// FlowCross), erase the groomed offers, and fall through with the original
+	// amounts so applyGuts reaches the FillOrKill kill (tecKILLED).
+	if result == ter.TecPATH_PARTIAL {
+		removeRemovableOffers(sb, sbCancel, crossResult.RemovableOffers, crossResult.PermRemovableOffers)
+		return crossOutcome{
+			terminated:  false,
+			result:      ter.TesSUCCESS,
+			applyMain:   true,
+			saTakerPays: saTakerPays,
+			saTakerGets: saTakerGets,
+			uRate:       uRate,
+			crossed:     false,
+		}
+	}
+
 	if result != ter.TesSUCCESS {
 		// Error during crossing - apply cancel sandbox
 		return crossOutcome{terminated: true, result: result, applyMain: false}
@@ -183,9 +207,9 @@ func (o *OfferCreate) takerCross(
 	// when applied) plus sbCancel keeps both sandboxes clean regardless of which
 	// one is ultimately applied.
 	if crossResult.Sandbox != nil {
-		removeRemovableOffers(crossResult.Sandbox, sbCancel, crossResult.RemovableOffers)
+		removeRemovableOffers(crossResult.Sandbox, sbCancel, crossResult.RemovableOffers, crossResult.PermRemovableOffers)
 	} else {
-		removeRemovableOffers(sb, sbCancel, crossResult.RemovableOffers)
+		removeRemovableOffers(sb, sbCancel, crossResult.RemovableOffers, crossResult.PermRemovableOffers)
 	}
 
 	// Check if account's funds were exhausted during crossing.
@@ -271,8 +295,10 @@ func evaluatePostCrossTermination(
 	// isn't fully consumed (because TakerPays was fully satisfied at a better rate).
 	// Reference: rippled CreateOffer.cpp: pre-amendment requires full TakerGets
 	// consumption for FoK; post-amendment relaxes non-sell FoK.
-	// Note: go-xrpl uses partialPayment=true for FlowCross (unlike rippled which
-	// passes partialPayment=!(txFlags & tfFillOrKill)), so FoK handling is manual.
+	// With partialPayment=!bFillOrKill threaded into the flow (matching rippled
+	// CreateOffer.cpp:411) an under-filled FoK now returns tecPATH_PARTIAL and is
+	// killed in takerCross before reaching here, so this remains only as the
+	// fully-crossed-but-gross-short safety net for the pre-fixFillOrKill era.
 	if fullyCrossed && bFillOrKill && !rules.Enabled(amendment.FeatureFixFillOrKill) {
 		remainingWithGross := subtractAmounts(saTakerGets, grossPaid)
 		if !isAmountZeroOrNegative(remainingWithGross) {
@@ -360,16 +386,23 @@ func computePostCrossAmounts(
 	return remainingGets, remainingPays
 }
 
-// removeRemovableOffers deletes the offers FlowCross marked for removal from
-// BOTH the main and cancel sandboxes. This guarantees orphan offers are
-// cleaned up regardless of which sandbox the FillOrKill decision applies.
+// removeRemovableOffers deletes the offers FlowCross groomed away. The full set
+// (offers the cross consumed to zero / drained / found stale) is erased from the
+// crossing sandbox so the applied book matches the post-cross state. Only the
+// perm subset — offers that were already unfunded/tiny/bad/frozen/expired/
+// self-crossed/unauthorized in the pristine view — is erased from the cancel
+// sandbox, mirroring rippled where flowCross erases result.removableOffers (the
+// perm-only set the engine returns) into both psb and psbCancel: a "became
+// unfunded/tiny" offer is deleted only in the crossing sandbox and is rolled
+// back when a FillOrKill/IoC kill applies the cancel sandbox.
 //
-// Reference: rippled CreateOffer.cpp lines 420-426
-func removeRemovableOffers(sb, sbCancel *payment.PaymentSandbox, removable map[[32]byte]bool) {
+// Reference: rippled CreateOffer.cpp lines 419-426; StrandFlow.h removableOffers.
+func removeRemovableOffers(sb, sbCancel *payment.PaymentSandbox, removable, permRemovable map[[32]byte]bool) {
 	for offerKey := range removable {
-		offerKeylet := keylet.Keylet{Key: offerKey}
-		removeOfferFromView(sb, offerKeylet)
-		removeOfferFromView(sbCancel, offerKeylet)
+		removeOfferFromView(sb, keylet.Keylet{Key: offerKey})
+	}
+	for offerKey := range permRemovable {
+		removeOfferFromView(sbCancel, keylet.Keylet{Key: offerKey})
 	}
 }
 

--- a/internal/tx/offer/offer_create_cross.go
+++ b/internal/tx/offer/offer_create_cross.go
@@ -10,10 +10,16 @@ import (
 )
 
 // processCancelRequest handles an OfferSequence cancellation that piggybacks
-// on the OfferCreate transaction. The cancellation must occur in BOTH
-// sandboxes so that orphan state never survives the FillOrKill decision.
-// Reference: rippled CreateOffer.cpp lines 608-621
-func (o *OfferCreate) processCancelRequest(ctx *tx.ApplyContext, sb, sbCancel *payment.PaymentSandbox) ter.Result {
+// on the OfferCreate transaction. The cancellation is applied to the main
+// sandbox (sb) ONLY, including its owner-count decrement, so that a tecKILLED
+// FillOrKill/ImmediateOrCancel decision — which applies the cancel sandbox
+// (sbCancel) instead of sb — discards the cancellation entirely, leaving only
+// the fee taken. rippled does the same: offerDelete(sb, ...) deletes the offer
+// and adjusts owner count within sb alone, and the whole sb is dropped on a
+// kill.
+// Reference: rippled CreateOffer.cpp lines 608-621; View.cpp offerDelete (the
+// adjustOwnerCount(-1) it performs lives in the same view).
+func (o *OfferCreate) processCancelRequest(ctx *tx.ApplyContext, sb *payment.PaymentSandbox) ter.Result {
 	if o.OfferSequence == nil {
 		return ter.TesSUCCESS
 	}
@@ -22,12 +28,8 @@ func (o *OfferCreate) processCancelRequest(ctx *tx.ApplyContext, sb, sbCancel *p
 		return ter.TesSUCCESS
 	}
 	result := offerDeleteInView(sb, sleCancel)
-	// Delete in cancel sandbox (same operation)
-	_ = offerDeleteInView(sbCancel, sleCancel)
-
-	// Also update owner count (once, since we'll only apply one sandbox)
-	if result == ter.TesSUCCESS && ctx.Account.OwnerCount > 0 {
-		ctx.Account.OwnerCount--
+	if result == ter.TesSUCCESS {
+		adjustOwnerCountInView(sb, ctx.AccountID, -1)
 	}
 	return result
 }

--- a/internal/tx/offer/offer_quality.go
+++ b/internal/tx/offer/offer_quality.go
@@ -251,42 +251,44 @@ func rateAmountFromQuality(quality uint64) tx.Amount {
 }
 
 // multiplyByQuality multiplies an amount by a quality rate, reproducing rippled's
-// multiply(amount, rate, asset): the exact product rounded to nearest (ties to
-// even), matching Number arithmetic under fixUniversalNumber. The result type is
-// determined by currency/issuer parameters.
+// multiply(amount, rate, asset). The result type is determined by currency/issuer
+// parameters.
 func multiplyByQuality(amount tx.Amount, quality uint64, currency, issuer string) tx.Amount {
+	native := currency == "" || currency == "XRP"
 	if quality == 0 || amount.IsZero() {
-		if currency == "" || currency == "XRP" {
+		if native {
 			return tx.NewXRPAmount(0)
 		}
 		return tx.NewIssuedAmount(0, -100, currency, issuer)
 	}
 
+	if native {
+		// rippled multiply() with a native result asset (post-fixUniversalNumber)
+		// rounds in two stages: the product is first rounded to a 16-significant-
+		// digit Number, then that Number is converted to drops. Reproducing it
+		// with a single exact round can round a tied-up product down at the 17th
+		// digit the opposite way (the placed offer's XRP leg ends up one drop
+		// high). Compute it as Number{amount} * Number{rate} → drops.
+		rate := rateAmountFromQuality(quality)
+		prod := state.NewXRPLNumber(amount.Mantissa(), amount.Exponent()).
+			Mul(state.NewXRPLNumber(rate.Mantissa(), rate.Exponent()))
+		return tx.NewXRPAmount(prod.ToInt64WithMode(state.RoundToNearest))
+	}
+
 	// Convert amount to big.Rat
-	var amtRat *big.Rat
-	if amount.IsNative() {
-		amtRat = new(big.Rat).SetInt64(amount.Drops())
-	} else {
-		mantissa := amount.Mantissa()
-		exponent := amount.Exponent()
-		amtRat = new(big.Rat).SetInt64(mantissa)
-		if exponent > 0 {
-			scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(exponent)), nil)
-			amtRat.Mul(amtRat, new(big.Rat).SetInt(scale))
-		} else if exponent < 0 {
-			scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(-exponent)), nil)
-			amtRat.Quo(amtRat, new(big.Rat).SetInt(scale))
-		}
+	mantissa := amount.Mantissa()
+	exponent := amount.Exponent()
+	amtRat := new(big.Rat).SetInt64(mantissa)
+	if exponent > 0 {
+		scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(exponent)), nil)
+		amtRat.Mul(amtRat, new(big.Rat).SetInt(scale))
+	} else if exponent < 0 {
+		scale := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(-exponent)), nil)
+		amtRat.Quo(amtRat, new(big.Rat).SetInt(scale))
 	}
 
 	rateRat := qualityToRate(quality)
 	result := new(big.Rat).Mul(amtRat, rateRat)
-
-	if currency == "" || currency == "XRP" {
-		// Round to nearest in exact integer arithmetic. float64 loses precision
-		// above 2^53 drops (~9M XRP), which would be a consensus divergence.
-		return tx.NewXRPAmount(ratRoundXRP(result))
-	}
 
 	return ratToIssuedAmount(result, currency, issuer)
 }
@@ -316,23 +318,6 @@ func divideByQuality(amount tx.Amount, quality uint64, currency, issuer string) 
 		return offerNativeDrops(mantissa, offset, resultNegative, false, false, false)
 	}
 	return state.FinalizeRoundIOU(mantissa, offset, resultNegative, false, currency, issuer, state.RoundToNearest, true)
-}
-
-// ratRoundXRP rounds a non-negative big.Rat drops value to the nearest integer,
-// ties to even, matching rippled's Number→XRPAmount conversion under
-// fixUniversalNumber. Exact integer arithmetic: float64 loses precision above 2^53
-// drops (~9M XRP), which would be a consensus divergence.
-func ratRoundXRP(r *big.Rat) int64 {
-	if r.Sign() <= 0 {
-		return 0
-	}
-	q := new(big.Int).Quo(r.Num(), r.Denom())
-	rem := new(big.Int).Mod(r.Num(), r.Denom())
-	twice := new(big.Int).Lsh(rem, 1)
-	if cmp := twice.Cmp(r.Denom()); cmp > 0 || (cmp == 0 && q.Bit(0) == 1) {
-		q.Add(q, big.NewInt(1))
-	}
-	return q.Int64()
 }
 
 // ratToIssuedAmount converts a big.Rat to an IOU Amount with the given currency and

--- a/internal/tx/payment/amm_liquidity.go
+++ b/internal/tx/payment/amm_liquidity.go
@@ -213,10 +213,17 @@ func (l *AMMLiquidity) safeMaxOffer(poolIn, poolOut tx.Amount) (result *AMMOffer
 // generateFibSeqOffer generates an offer sized by Fibonacci sequence.
 // Reference: rippled AMMLiquidity.cpp generateFibSeqOffer()
 func (l *AMMLiquidity) generateFibSeqOffer(poolIn, poolOut tx.Amount) (tx.Amount, tx.Amount, bool) {
-	// Initial offer: InitialFibSeqPct * initialPoolIn
-	// Use toNumber to handle XRP*IOU multiplication, then convert back
+	// Initial offer: InitialFibSeqPct * initialPoolIn.
+	// rippled computes the product under the ambient (round-to-nearest) mode and
+	// then converts to the input asset with Number::upward. For an XRP input that
+	// rounds the resulting drops UP (ceil); for an IOU input the upward mode is a
+	// no-op on the already-normalized Number. fromNumber would instead truncate
+	// the XRP drops, which under-sizes the whole Fibonacci offer chain and skews
+	// the offer quality.
+	// Reference: rippled AMMLiquidity.cpp generateFibSeqOffer() lines 64-67
+	//   toAmount<TIn>(getIssue(balances.in), InitialFibSeqPct * initialBalances_.in, Number::upward)
 	nInitPoolIn := toNumber(l.initialPoolIn)
-	curIn := fromNumber(nInitPoolIn.Mul(ammInitialFibSeqPct, true), l.initialPoolIn) // round up
+	curIn := fromNumberRoundUp(nInitPoolIn.Mul(ammInitialFibSeqPct, false), l.initialPoolIn)
 	curOut := SwapAssetIn(l.initialPoolIn, l.initialPoolOut, curIn, l.tradingFee, l.fixAMMv1_1)
 
 	if l.ammContext.CurIters() == 0 {

--- a/internal/tx/payment/amount.go
+++ b/internal/tx/payment/amount.go
@@ -133,35 +133,6 @@ func MulRatio(amt EitherAmount, num, den uint32, roundUp bool) EitherAmount {
 	return NewIOUEitherAmount(amt.IOU.MulRatio(num, den, roundUp))
 }
 
-// canonicalizeDropsFloor converts an IOU-style mantissa/exponent to XRP drops
-// using plain floor (truncation toward zero).
-// This matches rippled's STAmount::canonicalize() for native amounts when
-// canonicalizeRoundStrict is NOT called (i.e., when roundUp=false for positive values).
-// Reference: rippled STAmount.cpp canonicalize() lines 914-918:
-//
-//	while (mOffset < 0) { mValue /= 10; ++mOffset; }
-func canonicalizeDropsFloor(mantissa int64, exponent int) int64 {
-	if mantissa == 0 || exponent <= -20 {
-		return 0
-	}
-	value := mantissa
-	if value < 0 {
-		value = -value
-	}
-	for exponent > 0 {
-		value *= 10
-		exponent--
-	}
-	for exponent < 0 {
-		value /= 10
-		exponent++
-	}
-	if mantissa < 0 {
-		return -value
-	}
-	return value
-}
-
 // canonicalizeDropsRound converts an IOU-style mantissa/exponent to XRP drops
 // using round-to-nearest with ties going to even (banker's rounding).
 // This matches rippled's Number::operator rep() which is used by

--- a/internal/tx/payment/flow.go
+++ b/internal/tx/payment/flow.go
@@ -88,6 +88,20 @@ func Flow(
 
 	// Create the main sandbox that accumulates all changes
 	accumSandbox := NewChildSandbox(baseView)
+
+	// afBaseView is the "all funds" baseline used to tell a FOUND removal (an
+	// offer already unfunded/tiny before this flow ran) from a BECAME removal
+	// (an offer the flow's own crossing drained). It is a child of the pristine
+	// pre-flow baseView, taken ONCE and never mutated by the per-pass applies
+	// that accumulate into accumSandbox. rippled re-derives its cancelView_ from
+	// the per-pass accumulator, which makes a multi-pass crossing misread an
+	// offer this tx drained in an earlier pass as "found-unfunded": both the
+	// working view and the (accumulator-rooted) cancel view see the drained
+	// balance, so original_funds == ownerFunds and the became-removal is wrongly
+	// promoted to permToRemove and survives a FillOrKill kill. Anchoring the
+	// baseline to the pre-flow state keeps the found-vs-became test honest across
+	// passes, so a became-unfunded offer stays a conditional, rolled-back removal.
+	afBaseView := NewChildSandbox(baseView)
 	allOfrsToRm := make(map[[32]byte]bool)
 
 	// Initialize result accumulators
@@ -265,7 +279,7 @@ func Flow(
 
 			// Execute this strand with the potentially limited output.
 			// Reference: rippled StrandFlow.h line 694: flow(sb, *strand, remainingIn, limitRemainingOut, j)
-			result := ExecuteStrand(accumSandbox, *strand, remainingIn, limitRemainingOut)
+			result := ExecuteStrand(accumSandbox, *strand, remainingIn, limitRemainingOut, afBaseView)
 
 			// Collect offers to remove from ALL strands (even failed ones)
 			maps.Copy(iterOfrsToRm, result.OffsToRm)

--- a/internal/tx/payment/flow.go
+++ b/internal/tx/payment/flow.go
@@ -33,6 +33,7 @@ import (
 //   - limitQuality: Optional quality limit (nil means no limit)
 //   - sendMax: Optional maximum input amount
 //   - flowSortStrands: Whether the FlowSortStrands amendment is enabled
+//   - offerCrossing: Whether this is an offer-crossing flow (vs a payment)
 //
 // Returns: FlowResult with actual amounts and state changes
 func Flow(
@@ -44,6 +45,7 @@ func Flow(
 	sendMax *EitherAmount,
 	ammCtx *AMMContext,
 	flowSortStrands bool,
+	offerCrossing bool,
 ) FlowResult {
 	sortStrands := flowSortStrands
 	if len(strands) == 0 {
@@ -208,10 +210,19 @@ func Flow(
 				continue
 			}
 
-			// For offer crossing with quality limit (without FlowSortStrands),
-			// check strand quality upper bound
-			// Reference: rippled StrandFlow.h lines 688-692
-			if !sortStrands && limitQuality != nil {
+			// During offer crossing with a quality limit, skip any strand whose
+			// quality upper bound (the best the strand could deliver — the book
+			// tip or AMM) is worse than the taker's limit. This is the gate that
+			// prevents the strand's forEachOffer/OfferStream from ever running on
+			// a book whose tip is beyond the limit, so a beyond-limit found-
+			// unfunded tip is only groomed away when the strand actually executes
+			// (its upper bound meets the limit). rippled applies this on EVERY
+			// offer-crossing strand regardless of FlowSortStrands; the
+			// activateNext sort-filter above only fires for >1 strand, so this is
+			// the catch-all for the single-strand case.
+			// Reference: rippled StrandFlow.h lines 688-692 (if (offerCrossing &&
+			// limitQuality) { qualityUpperBound < limitQuality -> continue }).
+			if offerCrossing && limitQuality != nil {
 				strandQ := GetStrandQuality(*strand, accumSandbox)
 				if strandQ == nil || strandQ.WorseThan(*limitQuality) {
 					continue
@@ -672,8 +683,9 @@ func RippleCalculate(
 		qualityLimit = &q
 	}
 
-	// Execute flow with FlowSortStrands amendment flag
-	result := Flow(sandbox, strands, outReq, partialPayment, qualityLimit, sendMax, ammCtx, rcOpts.flowSortStrands)
+	// Execute flow with FlowSortStrands amendment flag. This is the payment
+	// (RippleCalculate) entry, never offer crossing.
+	result := Flow(sandbox, strands, outReq, partialPayment, qualityLimit, sendMax, ammCtx, rcOpts.flowSortStrands, false)
 
 	// Apply flow sandbox changes back to the main sandbox only on success.
 	// rippled's finishFlow (Flow.cpp) applies the flow sandbox solely on

--- a/internal/tx/payment/flow.go
+++ b/internal/tx/payment/flow.go
@@ -10,6 +10,29 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
+// flowOpts carries the offer-crossing FillOrKill context that only affects the
+// final result-code decision (rippled StrandFlow.h:827-893). Payments and
+// non-FillOrKill crossings leave these at their zero values.
+type flowOpts struct {
+	// fillOrKillEnabled mirrors rippled's fixFillOrKill amendment state.
+	fillOrKillEnabled bool
+	// offerCrossingSell is true when offerCrossing == OfferCrossing::sell.
+	offerCrossingSell bool
+}
+
+// FlowOption configures the FillOrKill termination behavior of Flow.
+type FlowOption func(*flowOpts)
+
+// WithFillOrKill threads the FillOrKill sell/amendment context into Flow so the
+// under-delivery termination matches rippled's flowCross. It is only meaningful
+// when Flow is called with partialPayment=false (a FillOrKill offer crossing).
+func WithFillOrKill(fillOrKillEnabled, offerCrossingSell bool) FlowOption {
+	return func(o *flowOpts) {
+		o.fillOrKillEnabled = fillOrKillEnabled
+		o.offerCrossingSell = offerCrossingSell
+	}
+}
+
 // Flow executes payment across multiple strands, selecting the best quality paths.
 //
 // The algorithm matches rippled's StrandFlow.h flow() function:
@@ -46,7 +69,12 @@ func Flow(
 	ammCtx *AMMContext,
 	flowSortStrands bool,
 	offerCrossing bool,
+	opts ...FlowOption,
 ) FlowResult {
+	var fo flowOpts
+	for _, opt := range opts {
+		opt(&fo)
+	}
 	sortStrands := flowSortStrands
 	if len(strands) == 0 {
 		return FlowResult{
@@ -389,12 +417,19 @@ func Flow(
 	}
 
 	// Determine final result code.
-	// Reference: rippled StrandFlow.h lines 840-873:
+	// Reference: rippled StrandFlow.h lines 840-895. The FillOrKill comment block
+	// there explains the offer-crossing nuance: under partialPayment=false an
+	// offer-crossing flow is a FillOrKill, and whether an under-delivery kills the
+	// offer depends on tfSell and the fixFillOrKill amendment.
 	//   if (actualOut != outReq) {
 	//     if (actualOut > outReq) → tefEXCEPTION (over-delivery; rounding bug)
-	//     if (!partialPayment)    → tecPATH_PARTIAL (couldn't deliver full amount)
-	//     else if (actualOut == 0) → tecPATH_DRY (delivered nothing)
+	//     if (!partialPayment && (!offerCrossing ||
+	//          (fixFillOrKill && offerCrossing != sell))) → tecPATH_PARTIAL
+	//     else if (actualOut == 0) → tecPATH_DRY
 	//   }
+	//   if (offerCrossing && !partialPayment &&
+	//        (!fixFillOrKill || offerCrossing == sell) && remainingIn != 0)
+	//     → tecPATH_PARTIAL  (FillOrKill: all input must be consumed)
 	//   otherwise tesSUCCESS.
 	resultCode := ter.TesSUCCESS
 
@@ -413,10 +448,28 @@ func Flow(
 			}
 		}
 		// cmp < 0: under-delivery.
-		if !partialPayment {
+		// Reference: rippled StrandFlow.h:853-873. For a non-FillOrKill payment
+		// (!offerCrossing) partialPayment is true here, so this collapses to the
+		// tecPATH_DRY branch. For a FillOrKill offer crossing (partialPayment
+		// false) this kills the offer with tecPATH_PARTIAL unless tfSell, whose
+		// "spend the whole TakerGets" rule is enforced by the remainingIn check
+		// below instead.
+		if !partialPayment &&
+			(!offerCrossing || (fo.fillOrKillEnabled && !fo.offerCrossingSell)) {
 			resultCode = ter.TecPATH_PARTIAL
-		} else if totalOut.IsZero() {
+		} else if partialPayment && totalOut.IsZero() {
 			resultCode = ter.TecPATH_DRY
+		}
+	}
+
+	// FillOrKill sell rule: when offer crossing with partialPayment disabled and
+	// either the fixFillOrKill amendment is off or this is a tfSell, the taker
+	// must consume the entire input (remainingIn == 0) or the offer is killed.
+	// Reference: rippled StrandFlow.h:875-893.
+	if resultCode == ter.TesSUCCESS && offerCrossing && !partialPayment &&
+		(!fo.fillOrKillEnabled || fo.offerCrossingSell) {
+		if remainingIn != nil && !remainingIn.IsZero() {
+			resultCode = ter.TecPATH_PARTIAL
 		}
 	}
 

--- a/internal/tx/payment/flow.go
+++ b/internal/tx/payment/flow.go
@@ -252,6 +252,12 @@ func Flow(
 				continue
 			}
 
+			// Clear AMM liquidity used flag before each strand attempt.
+			// Reference: rippled StrandFlow.h line 687: ammContext.clear()
+			if ammCtx != nil {
+				ammCtx.Clear()
+			}
+
 			// During offer crossing with a quality limit, skip any strand whose
 			// quality upper bound (the best the strand could deliver — the book
 			// tip or AMM) is worse than the taker's limit. This is the gate that
@@ -269,12 +275,6 @@ func Flow(
 				if strandQ == nil || strandQ.WorseThan(*limitQuality) {
 					continue
 				}
-			}
-
-			// Clear AMM liquidity used flag before each strand attempt.
-			// Reference: rippled StrandFlow.h line 687: ammContext.clear()
-			if ammCtx != nil {
-				ammCtx.Clear()
 			}
 
 			// Execute this strand with the potentially limited output.

--- a/internal/tx/payment/flow_cross.go
+++ b/internal/tx/payment/flow_cross.go
@@ -311,6 +311,10 @@ func configureStrandsForOfferCrossing(strands []Strand, qualityLimit *Quality, p
 				if bookStepCount == 1 {
 					bookStep.qualityLimit = qualityLimit
 				}
+				// crossLimit (rippled qualityThreshold_) is set on EVERY crossing
+				// step, including autobridge legs, and drives AMM-offer threshold
+				// selection in tipQualityThreshold.
+				bookStep.crossLimit = qualityLimit
 				bookStep.parentCloseTime = parentCloseTime
 				bookStep.fixReducedOffersV1 = fixReducedOffersV1
 				bookStep.fixReducedOffersV2 = fixReducedOffersV2

--- a/internal/tx/payment/flow_cross.go
+++ b/internal/tx/payment/flow_cross.go
@@ -17,6 +17,12 @@ type FlowCrossParams struct {
 	Passive bool
 	// Sell delivers the maximum (sell all input regardless of output).
 	Sell bool
+	// FillOrKill makes the flow run with partialPayment disabled, mirroring
+	// rippled flowCross which passes partialPayment=!(txFlags & tfFillOrKill).
+	// Under partialPayment=false an under-filled crossing returns
+	// tecPATH_PARTIAL and its (discarded) partial-walk grooming never reaches
+	// the applied sandbox, so a killed FillOrKill offer leaves only the fee.
+	FillOrKill bool
 
 	ParentCloseTime  uint32
 	ReserveBase      uint64
@@ -26,6 +32,7 @@ type FlowCrossParams struct {
 	FixReducedOffersV1         bool
 	FixReducedOffersV2         bool
 	FixRmSmallIncreasedQOffers bool
+	FixFillOrKill              bool
 	FlowSortStrands            bool
 	FixAMMv1_1                 bool
 	FixAMMv1_2                 bool
@@ -53,8 +60,21 @@ type FlowCrossResult struct {
 	// Sandbox contains the state changes from the crossing
 	Sandbox *PaymentSandbox
 
-	// RemovableOffers contains offer keys that should be removed
+	// RemovableOffers contains every offer key the crossing groomed away,
+	// including those that merely "became unfunded" or "became tiny" during the
+	// cross. These are erased from the crossing sandbox so the applied book
+	// matches the post-cross state.
 	RemovableOffers map[[32]byte]bool
+
+	// PermRemovableOffers is the subset of RemovableOffers that rippled records
+	// in FlowOfferStream::permToRemove — offers that were already unfunded, tiny,
+	// bad, frozen, out-of-domain, expired, self-crossed, or unauthorized in the
+	// PRISTINE view, independent of this crossing. Only this subset survives a
+	// discarded crossing (a FillOrKill/IoC kill that applies the cancel sandbox),
+	// matching rippled where flowCross erases result.removableOffers (= the perm
+	// set returned by the engine) into psbCancel. Reference: rippled StrandFlow.h
+	// removableOffers = ofrsToRmOnFail = union of strand permToRemove.
+	PermRemovableOffers map[[32]byte]bool
 
 	// Result is the transaction result code
 	Result ter.Result
@@ -231,14 +251,23 @@ func FlowCross(
 		setDomainOnBookSteps(strands, params.DomainID)
 	}
 
-	// Execute the flow
+	// Execute the flow.
 	// Reference: rippled flowCross passes partialPayment=!(txFlags & tfFillOrKill)
-	// For now, always allow partial (FoK is handled by caller)
-	result := Flow(sandbox, strands, deliver, true, &takerQuality, &sendMax, ammCtx, params.FlowSortStrands, true)
+	// (CreateOffer.cpp:411). With a FillOrKill offer partialPayment is false, so
+	// an under-filled crossing returns tecPATH_PARTIAL and its partial-walk
+	// grooming is discarded (see the apply gate below), leaving removableOffers
+	// out of the applied sandbox on a kill.
+	partialPayment := !params.FillOrKill
+	result := Flow(sandbox, strands, deliver, partialPayment, &takerQuality, &sendMax, ammCtx, params.FlowSortStrands, true,
+		WithFillOrKill(params.FixFillOrKill, params.Sell))
 
-	// Apply the flow sandbox changes to our root sandbox
-	// Reference: rippled CreateOffer.cpp line 711: psbFlow.apply(sb)
-	if result.Sandbox != nil {
+	// Apply the flow sandbox changes to our root sandbox only on success.
+	// Reference: rippled finishFlow (Flow.cpp:42-45) applies the flow sandbox
+	// solely on tesSUCCESS; a tecPATH_PARTIAL (only produced under
+	// partialPayment=false, i.e. a FillOrKill under-fill) discards the partial
+	// crossing — mirroring CreateOffer.cpp where flowCross then reports the offer
+	// as uncrossed. removableOffers is still returned so the caller can erase it.
+	if result.Result == ter.TesSUCCESS && result.Sandbox != nil {
 		if err := result.Sandbox.Apply(sandbox); err != nil {
 			return FlowCrossResult{
 				TakerGot:        ZeroXRPEitherAmount(),
@@ -273,13 +302,24 @@ func FlowCross(
 		}
 	}
 
+	// Collect the perm-removal subset from the executed strands' book steps.
+	// rippled's flow returns only this set as removableOffers (the rest were
+	// deleted in-band in the flow sandbox); we keep the full set for the crossing
+	// sandbox but expose the perm subset so a discarded crossing (FillOrKill/IoC
+	// kill) only re-erases offers rippled would.
+	permRemovable := make(map[[32]byte]bool)
+	for i := range strands {
+		strandPermRemovals(strands[i], permRemovable)
+	}
+
 	return FlowCrossResult{
-		TakerGot:        result.Out,
-		TakerPaid:       takerPaidGross,
-		TakerPaidNet:    takerPaidNet,
-		Sandbox:         sandbox,
-		RemovableOffers: result.RemovableOffers,
-		Result:          result.Result,
+		TakerGot:            result.Out,
+		TakerPaid:           takerPaidGross,
+		TakerPaidNet:        takerPaidNet,
+		Sandbox:             sandbox,
+		RemovableOffers:     result.RemovableOffers,
+		PermRemovableOffers: permRemovable,
+		Result:              result.Result,
 	}
 }
 

--- a/internal/tx/payment/flow_cross.go
+++ b/internal/tx/payment/flow_cross.go
@@ -234,7 +234,7 @@ func FlowCross(
 	// Execute the flow
 	// Reference: rippled flowCross passes partialPayment=!(txFlags & tfFillOrKill)
 	// For now, always allow partial (FoK is handled by caller)
-	result := Flow(sandbox, strands, deliver, true, &takerQuality, &sendMax, ammCtx, params.FlowSortStrands)
+	result := Flow(sandbox, strands, deliver, true, &takerQuality, &sendMax, ammCtx, params.FlowSortStrands, true)
 
 	// Apply the flow sandbox changes to our root sandbox
 	// Reference: rippled CreateOffer.cpp line 711: psbFlow.apply(sb)

--- a/internal/tx/payment/flow_test.go
+++ b/internal/tx/payment/flow_test.go
@@ -718,7 +718,7 @@ func TestFlow_SingleStrand(t *testing.T) {
 
 	requestedOut := NewXRPEitherAmount(10_000_000)
 
-	result := Flow(sandbox, strands, requestedOut, false, nil, nil, nil, false)
+	result := Flow(sandbox, strands, requestedOut, false, nil, nil, nil, false, false)
 
 	if result.Result != ter.TesSUCCESS {
 		t.Errorf("expected ter.TesSUCCESS, got %d", result.Result)
@@ -751,7 +751,7 @@ func TestFlow_PartialPayment(t *testing.T) {
 	requestedOut := NewXRPEitherAmount(100_000_000)
 
 	// Without partial payment flag - should fail or deliver less
-	result := Flow(sandbox, strands, requestedOut, false, nil, nil, nil, false)
+	result := Flow(sandbox, strands, requestedOut, false, nil, nil, nil, false, false)
 
 	// Should not deliver full amount
 	if result.Out.XRP >= 100_000_000 {
@@ -766,7 +766,7 @@ func TestFlow_PartialPayment(t *testing.T) {
 			NewXRPEndpointStep(bob, true),
 		},
 	}
-	result2 := Flow(sandbox2, strands2, requestedOut, true, nil, nil, nil, false)
+	result2 := Flow(sandbox2, strands2, requestedOut, true, nil, nil, nil, false, false)
 
 	// With partial payment, any delivery (even partial) is success
 	// We just check that something was delivered
@@ -781,7 +781,7 @@ func TestFlow_EmptyStrands(t *testing.T) {
 
 	requestedOut := NewXRPEitherAmount(10_000_000)
 
-	result := Flow(sandbox, []Strand{}, requestedOut, false, nil, nil, nil, false)
+	result := Flow(sandbox, []Strand{}, requestedOut, false, nil, nil, nil, false, false)
 
 	if result.Result != ter.TecPATH_DRY {
 		t.Errorf("expected ter.TecPATH_DRY for empty strands, got %d", result.Result)
@@ -809,7 +809,7 @@ func TestFlow_SendMaxLimit(t *testing.T) {
 	requestedOut := NewXRPEitherAmount(50_000_000)
 	sendMax := NewXRPEitherAmount(20_000_000) // Limit to 20 XRP
 
-	result := Flow(sandbox, strands, requestedOut, true, nil, &sendMax, nil, false)
+	result := Flow(sandbox, strands, requestedOut, true, nil, &sendMax, nil, false, false)
 
 	// Should be limited by sendMax
 	if result.In.XRP > 20_000_000 {

--- a/internal/tx/payment/flow_test.go
+++ b/internal/tx/payment/flow_test.go
@@ -682,7 +682,7 @@ func TestExecuteStrand_XRPPayment(t *testing.T) {
 	// Execute with 10 XRP requested output
 	requestedOut := NewXRPEitherAmount(10_000_000)
 
-	result := ExecuteStrand(sandbox, strand, nil, requestedOut)
+	result := ExecuteStrand(sandbox, strand, nil, requestedOut, nil)
 
 	if !result.Success {
 		t.Error("expected successful execution")

--- a/internal/tx/payment/flow_test.go
+++ b/internal/tx/payment/flow_test.go
@@ -460,13 +460,29 @@ func TestDirectStepI_QualityUpperBound_FixQualityUpperBoundGate(t *testing.T) {
 		"legacy quality (dstQIn/srcQOut) must be strictly smaller than post-fix quality")
 }
 
-// putCLOBTipQuality writes a synthetic order-book directory entry for the given
-// book at the given quality, so getCLOBTipQuality observes it as the tip offer.
-// The key is the book base with the quality encoded into bytes 24-31.
+// putCLOBTipQuality writes a synthetic order-book directory at the given quality
+// holding one offer index, so getCLOBTipQuality observes it as the tip offer.
+// The key is the book base with the quality encoded into bytes 24-31. The
+// directory must carry a real (non-empty) sfIndexes vector: getCLOBTipQuality
+// skips empty directory tiers exactly as rippled's BookTip::step does.
 func (m *paymentMockLedgerView) putCLOBTipQuality(step *BookStep, q Quality) {
 	key := step.bookBaseKey()
 	binary.BigEndian.PutUint64(key[24:], q.Value)
-	m.data[key] = []byte{0x01}
+	var offerIdx [32]byte
+	offerIdx[31] = 0x01
+	dir := &state.DirectoryNode{
+		RootIndex:         key,
+		Indexes:           [][32]byte{offerIdx},
+		TakerPaysCurrency: keylet.CurrencyBytes(step.book.In.Currency),
+		TakerPaysIssuer:   step.book.In.Issuer,
+		TakerGetsCurrency: keylet.CurrencyBytes(step.book.Out.Currency),
+		TakerGetsIssuer:   step.book.Out.Issuer,
+	}
+	dirData, err := state.SerializeDirectoryNode(dir, true)
+	if err != nil {
+		panic(err)
+	}
+	m.data[key] = dirData
 }
 
 // TestBookStep_QualityUpperBound_TransferFeeAdjusted proves that

--- a/internal/tx/payment/payment_iou.go
+++ b/internal/tx/payment/payment_iou.go
@@ -225,12 +225,29 @@ func (p *Payment) applyIOUPaymentWithPaths(ctx *tx.ApplyContext, senderID, destI
 			rcOpts = append(rcOpts, WithDomainID(&domainID))
 		}
 	}
+	// Derive the maximum source amount. When SendMax is absent, rippled does
+	// not leave it unset: getMaxSourceAmount() defaults it to the delivered
+	// Amount re-issued by the source account (for an IOU delivery). This
+	// becomes the flow engine's input bound, so the destination receives
+	// Amount/transferRate rather than the full Amount when the issuer charges
+	// a transfer fee. RippleCalc.cpp then only treats it as a sendMax when it
+	// is non-negative, or differs in currency/issuer from the source-issued
+	// delivery. Reference: rippled Payment.cpp:50-66, RippleCalc.cpp:88-96.
+	maxSourceAmount := p.getMaxSourceAmount(senderID)
+	var srcAmount *tx.Amount
+	srcIsSelfIssued := !maxSourceAmount.IsNative() && !maxSourceAmount.IsMPT() &&
+		maxSourceAmount.Currency == p.Amount.Currency &&
+		maxSourceAmount.Issuer == state.EncodeAccountIDSafe(senderID)
+	if maxSourceAmount.Signum() >= 0 || !srcIsSelfIssued {
+		srcAmount = &maxSourceAmount
+	}
+
 	rc := RippleCalculate(
 		ctx.View,
 		senderID,
 		destID,
 		p.Amount,
-		p.SendMax,
+		srcAmount,
 		p.Paths,
 		addDefaultPath,
 		partialPayment,
@@ -287,7 +304,14 @@ func (p *Payment) applyIOUPaymentWithPaths(ctx *tx.ApplyContext, senderID, destI
 	// Emitting it on full payments or on a tec result forks the transaction
 	// tree from rippled — observed as a mixed-network transaction_hash
 	// divergence (identical account_hash) at low seqs before amendments settle.
-	deliveredAmt := FromEitherAmount(actualOut)
+	//
+	// The delivered amount carries the requested Amount's issue (currency and
+	// issuer), taking only the value from the flow engine. This mirrors
+	// rippled's actualAmountOut = toSTAmount(flowOut.out, dstIssue), where
+	// dstIssue is the delivered Amount's issue. The flow engine's own output
+	// amount may carry a different (path-internal) issuer.
+	// Reference: rippled Flow.cpp:49,79.
+	deliveredAmt := deliveredWithDstIssue(actualOut, p.Amount)
 	if result == ter.TesSUCCESS && deliveredAmt.Compare(p.Amount) != 0 {
 		ctx.Metadata.DeliveredAmount = &deliveredAmt
 	}
@@ -295,6 +319,47 @@ func (p *Payment) applyIOUPaymentWithPaths(ctx *tx.ApplyContext, senderID, destI
 	// Offer deletions and trust line modifications tracked automatically by ApplyStateTable
 
 	return result
+}
+
+// getMaxSourceAmount returns the maximum amount the source will spend. When
+// SendMax is present it is used directly. Otherwise the bound defaults to the
+// delivered Amount: native XRP and MPT amounts are used as-is, while an IOU is
+// re-issued by the source account so the flow engine charges the issuer's
+// transfer fee against the delivery rather than grossing it onto the source.
+// Reference: rippled Payment.cpp getMaxSourceAmount() lines 50-66.
+func (p *Payment) getMaxSourceAmount(srcAccount [20]byte) tx.Amount {
+	if p.SendMax != nil {
+		return *p.SendMax
+	}
+	if p.Amount.IsNative() || p.Amount.IsMPT() {
+		return p.Amount
+	}
+	iou := p.Amount.IOU()
+	return state.NewIssuedAmountFromValue(
+		iou.Mantissa(),
+		iou.Exponent(),
+		p.Amount.Currency,
+		state.EncodeAccountIDSafe(srcAccount),
+	)
+}
+
+// deliveredWithDstIssue returns the flow engine's delivered amount carrying the
+// requested Amount's issue. Only the value comes from the flow output; the
+// currency and issuer are taken from dstAmount. This mirrors rippled's
+// actualAmountOut = toSTAmount(flowOut.out, dstIssue).
+// Reference: rippled Flow.cpp:49,79.
+func deliveredWithDstIssue(actualOut EitherAmount, dstAmount tx.Amount) tx.Amount {
+	out := FromEitherAmount(actualOut)
+	if out.IsNative() || dstAmount.IsNative() || dstAmount.IsMPT() {
+		return out
+	}
+	iou := out.IOU()
+	return state.NewIssuedAmountFromValue(
+		iou.Mantissa(),
+		iou.Exponent(),
+		dstAmount.Currency,
+		dstAmount.Issuer,
+	)
 }
 
 // ApplyOnTec implements TecApplier. When tecEXPIRED is returned, this re-runs

--- a/internal/tx/payment/payment_iou.go
+++ b/internal/tx/payment/payment_iou.go
@@ -197,6 +197,16 @@ func (p *Payment) applyRipplePayment(ctx *tx.ApplyContext, senderID, destID [20]
 		return result
 	}
 
+	// Force-mark the existing destination AccountRoot as touched, matching
+	// rippled's unconditional view().update(sleDst) for an existing ripple-payment
+	// destination (Payment.cpp:420-426) — applied for an XRP-delivered ripple
+	// payment too, not only the IOU-delivered path. The no-op modify is dropped
+	// when nothing rewrites the node (bytes unchanged); when owner-threading later
+	// rewrites its PreviousTxnID the node is emitted with FinalFields.
+	if err := ctx.View.Update(destKey, destData); err != nil {
+		return ter.TefINTERNAL
+	}
+
 	// Use the flow engine (issuerID is unused for XRP amount, pass zero)
 	var zeroID [20]byte
 	return p.applyIOUPaymentWithPaths(ctx, senderID, destID, zeroID)

--- a/internal/tx/payment/payment_iou.go
+++ b/internal/tx/payment/payment_iou.go
@@ -99,6 +99,21 @@ func (p *Payment) applyIOUPayment(ctx *tx.ApplyContext) ter.Result {
 		return result
 	}
 
+	// Mark the existing destination AccountRoot as intentionally touched, even
+	// when the delivered IOU never changes one of its own fields (the value
+	// lands on a RippleState trustline). rippled does this unconditionally for
+	// an existing destination of a ripple payment via view().update(sleDst)
+	// (Payment.cpp:420-426). The marking promotes the node to a modify so that,
+	// if owner-threading later rewrites its PreviousTxnID (e.g. it owns a
+	// trustline created or deleted by this payment, as when the destination is
+	// the issuer being redeemed to), the node is emitted as a ModifiedNode with
+	// FinalFields instead of a bare threaded node. When nothing rewrites it the
+	// no-op modify is dropped (bytes unchanged), matching rippled's
+	// `*curNode == *origNode` skip.
+	if err := ctx.View.Update(destKey, destData); err != nil {
+		return ter.TefINTERNAL
+	}
+
 	return p.applyIOUPaymentWithPaths(ctx, senderAccountID, destAccountID, issuerAccountID)
 }
 

--- a/internal/tx/payment/quality.go
+++ b/internal/tx/payment/quality.go
@@ -283,24 +283,17 @@ func (q Quality) CeilOutStrict(amtIn, amtOut EitherAmount, limit EitherAmount, r
 		inIssuer = amtIn.IOU.Issuer
 	}
 
-	resultIn := state.MulRoundStrict(limitAmt, qRate, inCurrency, inIssuer, roundUp)
-
 	var resultInEither EitherAmount
 	if amtIn.IsNative {
-		var drops int64
-		if roundUp {
-			// roundUp=true: rippled calls canonicalizeRoundStrict before STAmount construction.
-			// Reference: rippled mulRoundImpl - CanonicalizeFunc called when resultNegative != roundUp
-			drops = state.CanonicalizeDropsStrict(resultIn.Mantissa(), resultIn.Exponent(), roundUp)
-		} else {
-			// roundUp=false (positive values): rippled does NOT call canonicalizeRoundStrict.
-			// STAmount::canonicalize() for native applies plain floor (truncation):
-			//   while (mOffset < 0) { mValue /= 10; ++mOffset; }
-			// Reference: rippled STAmount.cpp canonicalize() lines 914-918
-			drops = canonicalizeDropsFloor(resultIn.Mantissa(), resultIn.Exponent())
-		}
-		resultInEither = NewXRPEitherAmount(drops)
+		// Native input asset: take the strict native canonicalize path of
+		// rippled's mulRoundStrict (mulRoundImpl<canonicalizeRoundStrict> with a
+		// native asset), which canonicalizes the un-truncated muldiv product to
+		// drops. Routing through the IOU MulRoundStrict first collapses the
+		// product to a 16-digit mantissa and discards any sub-drop remainder, so
+		// the subsequent drops canonicalize has nothing left to round up.
+		resultInEither = NewXRPEitherAmount(state.MulRoundNativeStrict(limitAmt, qRate, roundUp))
 	} else {
+		resultIn := state.MulRoundStrict(limitAmt, qRate, inCurrency, inIssuer, roundUp)
 		resultInEither = NewIOUEitherAmount(tx.NewIssuedAmount(
 			resultIn.Mantissa(), resultIn.Exponent(), inCurrency, inIssuer))
 	}
@@ -390,24 +383,16 @@ func (q Quality) CeilInStrict(amtIn, amtOut EitherAmount, limit EitherAmount, ro
 		outIssuer = amtOut.IOU.Issuer
 	}
 
-	resultOut := state.DivRoundStrict(limitAmt, qRate, outCurrency, outIssuer, roundUp)
-
 	var resultOutEither EitherAmount
 	if amtOut.IsNative {
-		var drops int64
-		if roundUp {
-			// roundUp=true: rippled calls canonicalizeRound before STAmount construction.
-			// Reference: rippled divRoundImpl - canonicalizeRound called when resultNegative != roundUp
-			drops = state.CanonicalizeDrops(resultOut.Mantissa(), resultOut.Exponent())
-		} else {
-			// roundUp=false (positive values): rippled does NOT call canonicalizeRound.
-			// STAmount::canonicalize() for native applies plain floor (truncation):
-			//   while (mOffset < 0) { mValue /= 10; ++mOffset; }
-			// Reference: rippled STAmount.cpp canonicalize() lines 914-918
-			drops = canonicalizeDropsFloor(resultOut.Mantissa(), resultOut.Exponent())
-		}
-		resultOutEither = NewXRPEitherAmount(drops)
+		// Native output asset: take the native canonicalize path of rippled's
+		// divRoundStrict (divRoundImpl<NumberRoundModeGuard> with a native asset),
+		// canonicalizing the un-truncated muldiv product to drops. Routing through
+		// the IOU DivRoundStrict first collapses the product to a 16-digit mantissa
+		// and discards any sub-drop remainder before the drops canonicalize.
+		resultOutEither = NewXRPEitherAmount(state.DivRoundNativeStrict(limitAmt, qRate, roundUp))
 	} else {
+		resultOut := state.DivRoundStrict(limitAmt, qRate, outCurrency, outIssuer, roundUp)
 		resultOutEither = NewIOUEitherAmount(tx.NewIssuedAmount(
 			resultOut.Mantissa(), resultOut.Exponent(), outCurrency, outIssuer))
 	}

--- a/internal/tx/payment/quality_function.go
+++ b/internal/tx/payment/quality_function.go
@@ -57,7 +57,7 @@ func NewCLOBLikeQualityFunction(q Quality) *QualityFunction {
 	}
 	// b = 1 / quality.rate()
 	one := numberOne()
-	b := one.Div(rate, false)
+	b := numberDiv(one, rate)
 
 	return &QualityFunction{
 		m:       numberZero(),
@@ -95,17 +95,16 @@ func NewAMMQualityFunction(poolGets, poolPays tx.Amount, tradingFee uint16) *Qua
 	} else {
 		feeNum := state.NewIssuedAmountFromValue(int64(tradingFee), 0, "", "")
 		scaleFactor := state.NewIssuedAmountFromValue(AuctionSlotFeeScaleFactor, 0, "", "")
-		feeFrac := feeNum.Div(scaleFactor, false) // tradingFee / 100000
-		cfee, _ = one.Sub(feeFrac)                // 1 - tradingFee/100000
+		feeFrac := numberDiv(feeNum, scaleFactor) // tradingFee / 100000
+		cfee = ammSub(one, feeFrac)               // 1 - tradingFee/100000
 	}
 
 	// m = -cfee / poolGets
 	cfeeNeg := cfee.Negate()
-	m := cfeeNeg.Div(nPoolGets, false)
+	m := numberDiv(cfeeNeg, nPoolGets)
 
 	// b = poolPays * cfee / poolGets
-	b := nPoolPays.Mul(cfee, false)
-	b = b.Div(nPoolGets, false)
+	b := numberDiv(numberMul(nPoolPays, cfee), nPoolGets)
 
 	return &QualityFunction{
 		m:       m,
@@ -124,11 +123,11 @@ func NewAMMQualityFunction(poolGets, poolPays tx.Amount, tradingFee uint16) *Qua
 // Reference: rippled QualityFunction.cpp combine()
 func (qf *QualityFunction) Combine(other QualityFunction) {
 	// m += b * other.m
-	bTimesOtherM := qf.b.Mul(other.m, false)
-	qf.m, _ = qf.m.Add(bTimesOtherM)
+	bTimesOtherM := numberMul(qf.b, other.m)
+	qf.m = ammAdd(qf.m, bTimesOtherM)
 
 	// b *= other.b
-	qf.b = qf.b.Mul(other.b, false)
+	qf.b = numberMul(qf.b, other.b)
 
 	// If m != 0, this is no longer a constant quality function
 	if qf.m.Signum() != 0 {
@@ -153,15 +152,15 @@ func (qf *QualityFunction) OutFromAvgQ(q Quality) *tx.Amount {
 		return nil
 	}
 
-	// Compute 1 / quality.rate() with round-up mode
-	// Reference: rippled uses saveNumberRoundMode(Number::rounding_mode::upward)
+	// rippled wraps the whole expression (1/quality.rate() - b) / m in
+	// Number::rounding_mode::upward, so every op — the reciprocal, the
+	// subtraction (a catastrophic cancellation) and the final divide — rounds
+	// upward in the unified Number space.
 	one := numberOne()
 	rate := q.Rate()
-	invRate := one.Div(rate, true) // round up
-
-	// out = (invRate - b) / m
-	numerator, _ := invRate.Sub(qf.b)
-	out := numerator.Div(qf.m, true) // round up
+	invRate := numberDivRounded(one, rate, state.RoundUpward)
+	numerator := ammSubRounded(invRate, qf.b, state.RoundUpward)
+	out := numberDivRounded(numerator, qf.m, state.RoundUpward)
 
 	if out.Signum() <= 0 {
 		return nil

--- a/internal/tx/payment/sandbox.go
+++ b/internal/tx/payment/sandbox.go
@@ -153,6 +153,18 @@ func NewChildSandbox(parent *PaymentSandbox) *PaymentSandbox {
 	}
 }
 
+// IterationBase returns the parent sandbox, which for a per-strand working
+// sandbox is the flow's accumulating view: the ledger state after all prior
+// flow iterations applied but before THIS strand pass's (possibly
+// over-extended) consumption. The trailing-offer groom uses it to tell an
+// offer whose owner was already drained by an earlier iteration (a genuine
+// became-unfunded that survives) from one the current over-walk merely
+// over-consumed (a spurious removal a limiting reset discards). Returns nil for
+// a root sandbox.
+func (s *PaymentSandbox) IterationBase() *PaymentSandbox {
+	return s.parent
+}
+
 // SetOpenLedger records whether this sandbox is applying against the open
 // ledger. It is set once from EngineConfig.IsViewOpen at the flow entry point
 // and propagated to child sandboxes. Mirrors rippled's view.open().

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -455,6 +455,13 @@ func (s *BookStep) forEachOffer(
 			if !tryAMM(&lobQ) {
 				break
 			}
+			// If the AMM (sized up to the LOB quality) already satisfied the
+			// remaining output, stop before crossing the CLOB tip — rippled's
+			// forEachOffer ends at remainingOut==0 and never reaches the next
+			// offer, so the tip must not be touched (threaded) by a zero cross.
+			if remainingZero() {
+				break
+			}
 		}
 
 		offerOwner, _ := state.DecodeAccountID(offer.Account)

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -490,27 +490,49 @@ func (s *BookStep) forEachOffer(
 	// Trailing-offer drain: rippled's forEachOffer do-while keeps stepping the
 	// book tip after the requested amount is satisfied, but ONLY when the last
 	// crossed tip was fully consumed (eachOffer returned true). In that case it
-	// runs offers.step() once more, which grooms — quality-blind — the contiguous
-	// run of found-unfunded / found-tiny offers immediately behind the satisfying
-	// tip (OfferStream::step permRmOffer, before any quality check), and
-	// limitSelfCrossQuality additionally removes the taker's own offers at or
-	// better than the limit. The walk stops at the first funded, non-own,
-	// non-groomable survivor: step() breaks there, execOffer's remainingOut==0 /
-	// checkQualityThreshold returns false, and the do-while breaks (the survivor
-	// is left untouched). goXRPL's main loop above instead stops as soon as the
-	// demand is met (remainingZero), so it never reaches those trailing offers;
-	// replay that single bounded step() here.
+	// runs offers.step() once more, which grooms the contiguous run of unfunded /
+	// tiny offers immediately behind the satisfying tip before execOffer's
+	// remainingOut==0 guard stops the walk. OfferStream::step grooms each such
+	// offer as it advances the tip:
+	//   - found-unfunded / found-tiny / expired → permRmOffer (perm removal)
+	//   - became-unfunded / became-tiny → deleted from the working view but NOT
+	//     permRmOffer (conditional)
+	// and limitSelfCrossQuality additionally removes the taker's own offers at or
+	// better than the limit on the funded tip the walk lands on. The walk stops at
+	// the first funded, non-own, non-groomable survivor. goXRPL's main loop above
+	// instead stops as soon as the demand is met (remainingZero), so it never
+	// reaches those trailing offers; replay that single bounded step() here.
+	//
+	// This grooming applies on EVERY strand, not just offer crossing —
+	// OfferStream::step removes the unfunded run behind a fully-consumed tip on
+	// payment strands too (e.g. a payment whose limiting BookStep is re-executed
+	// at exactly its tip's funded output). Only the self-cross clause (b) is
+	// offer-crossing-specific.
+	//
+	// The became-unfunded test (a) is taken against the iteration base — the flow
+	// view after all PRIOR iterations but before THIS pass's (possibly
+	// over-extended) consumption — not the working sandbox. An over-walk that
+	// fully consumes a tip drains its owner in sb, which would falsely mark every
+	// trailing offer of that owner unfunded; but a limiting reset discards that
+	// over-consumption, and rippled leaves those offers (issue #1029). Anchoring
+	// the test to the iteration base grooms only an offer whose owner an EARLIER
+	// iteration already drained (a genuine became-unfunded that the final cross
+	// also sees), and spares one this pass merely over-consumed.
 	//
 	// When demand is met by a PARTIAL fill of a still-funded tip, eachOffer
 	// returns offer.fully_consumed()==false, the do-while breaks WITHOUT another
 	// offers.step(), and trailing offers are never reached — so the drain must not
-	// fire (lastTipFullyConsumed gate). This is what spares a found-unfunded offer
-	// sitting behind such a partially-filled tip from being wrongly groomed.
+	// fire (lastTipFullyConsumed gate).
 	// Reference: rippled BookStep.cpp forEachOffer do-while 859-863, eachOffer
-	// 1041-1081 (rev) / 1252 (fwd); OfferStream.cpp step 234-404 (found-unfunded
-	// 314-341, found-tiny 343-404); limitSelfCrossQuality 404-459.
-	if consumed && s.lastTipFullyConsumed && remainingZero() && s.defaultPath &&
-		s.qualityLimit != nil && s.strandSrc == s.strandDst && currentQuality != nil {
+	// 1041-1081 (rev) / 1252 (fwd); OfferStream.cpp step 234-404 (found vs became
+	// unfunded 314-341, found vs became tiny 343-404); limitSelfCrossQuality.
+	selfCrossDrain := s.defaultPath && s.qualityLimit != nil &&
+		s.strandSrc == s.strandDst && currentQuality != nil
+	iterBase := sb.IterationBase()
+	if iterBase == nil {
+		iterBase = afView
+	}
+	if consumed && s.lastTipFullyConsumed && remainingZero() {
 		for s.offersUsed < s.maxOffersToConsume {
 			offer, offerKey, err := s.getNextOfferSkipVisited(sb, afView, ofrsToRm, visited, false)
 			if err != nil || offer == nil {
@@ -520,11 +542,9 @@ func (s *BookStep) forEachOffer(
 			if ownerErr != nil {
 				break
 			}
-			offerQ := s.offerQuality(offer)
 
-			// (a) any tip OfferStream::step grooms quality-blind, before execOffer
-			//     ever runs: found-unfunded or found-tiny, regardless of owner or
-			//     tier. Expired offers are removed inside getNextOfferSkipVisited
+			// (a) found-unfunded / found-tiny: a perm removal regardless of owner
+			//     or tier. Expired offers are removed inside getNextOfferSkipVisited
 			//     and never yielded here.
 			if s.isFoundPermGroomable(sb, afView, offer) {
 				ofrsToRm[offerKey] = true
@@ -532,24 +552,33 @@ func (s *BookStep) forEachOffer(
 				continue
 			}
 
-			// (b) own self-cross at or better than the limit on a FUNDED tip:
-			//     limitSelfCrossQuality removes it "even if no crossing occurs" and
-			//     execOffer returns true, so the do-while keeps stepping past it.
-			//     This is reached only on the funded survivor step() lands on, and
-			//     execOffer's `*ofrQ != offer.quality()` check (which runs before
-			//     limitSelfCrossQuality) restricts it to the locked tier: a funded
-			//     survivor at a different tier makes execOffer return false first,
-			//     breaking the do-while.
-			if offerOwner == s.strandSrc && offerQ.Value == currentQuality.Value &&
-				!offerQ.WorseThan(*s.qualityLimit) {
+			// (a') became-unfunded / became-tiny against the iteration base: groom
+			//     (conditional, not perm) only when an earlier iteration already
+			//     drained the owner, so the final cross sees it unfunded too. An
+			//     offer this pass merely over-consumed reads funded in iterBase and
+			//     is left for the funded-survivor break below.
+			if s.isBecameGroomableAgainst(iterBase, afView, offer) {
 				ofrsToRm[offerKey] = true
-				s.recordPermRm(offerKey)
 				continue
 			}
 
-			// (c) first funded, non-groomable survivor that is not a same-tier own
-			//     self-cross: step() breaks here and execOffer returns false (tier
-			//     change / remainingOut==0 / checkQualityThreshold). Leave it.
+			// (b) own self-cross at or better than the limit on a FUNDED tip:
+			//     limitSelfCrossQuality removes it "even if no crossing occurs" and
+			//     execOffer returns true, so the do-while keeps stepping past it.
+			//     Offer-crossing only; restricted to the locked tier.
+			if selfCrossDrain {
+				offerQ := s.offerQuality(offer)
+				if offerOwner == s.strandSrc && offerQ.Value == currentQuality.Value &&
+					!offerQ.WorseThan(*s.qualityLimit) {
+					ofrsToRm[offerKey] = true
+					s.recordPermRm(offerKey)
+					continue
+				}
+			}
+
+			// (c) first funded, non-groomable survivor: step() breaks here and
+			//     execOffer returns false (tier change / remainingOut==0 /
+			//     checkQualityThreshold). Leave it.
 			break
 		}
 	}

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -373,12 +373,12 @@ func (s *BookStep) forEachOffer(
 	// Main CLOB iteration with AMM interleaving.
 	// Reference: rippled BookStep.cpp forEachOffer lines 855-873.
 	firstCLOB := true
-	// consumed tracks whether any offer has been crossed in this pass. The
-	// quality-limit walk bound only applies before the first cross: rippled stops
-	// at a beyond-limit (or AMM-beaten) tip and crosses nothing, but after a cross
-	// its forEachOffer do-while keeps stepping — removing offers left unfunded by
-	// the cross — until the next *funded* tip fails the quality threshold. So a
-	// beyond-limit unfunded offer reached after a cross must still be removed.
+	// consumed tracks whether any offer has been crossed in this pass. Before the
+	// first cross the walk is bounded by the taker's quality limit; after a cross
+	// rippled's do-while keeps stepping, removing offers the cross left unfunded,
+	// until the next funded tip fails the quality threshold. The bound never stops
+	// the walk at a found-unfunded offer — only at a funded (crossable) one — so a
+	// reserve-locked own offer at a beyond-limit tip is still removed.
 	consumed := false
 	for s.offersUsed < s.maxOffersToConsume && !remainingZero() {
 		offer, offerKey, err := s.getNextOfferSkipVisited(sb, afView, ofrsToRm, visited, !consumed)
@@ -409,9 +409,25 @@ func (s *BookStep) forEachOffer(
 
 		// Pre-execOffer checks (OfferStream level)
 		// Reference: rippled OfferStream::step() reads ownerFunds from view_ (sb).
-		ownerFunds := s.getOfferFundedAmount(sb, offer)
-		if ownerFunds.IsZero() || offer.TakerGets.IsZero() {
+		if offer.TakerGets.IsZero() {
 			ofrsToRm[offerKey] = true
+			s.recordPermRm(offerKey)
+			continue
+		}
+		ownerFunds := s.getOfferFundedAmount(sb, offer)
+		if ownerFunds.IsZero() {
+			// Distinguish "found unfunded" from "became unfunded": if the
+			// owner's funds are still zero in the pristine afView, the offer was
+			// unfunded before any crossing modified the balance, so it is a
+			// permanent removal — kept even across a limiting-step reset. If the
+			// crossing drained the owner (funds nonzero in afView), it merely
+			// "became unfunded" and the removal stays conditional.
+			// Reference: rippled OfferStream::step() lines 314-341 (compares
+			// ownerFunds in view_ against cancelView_).
+			ofrsToRm[offerKey] = true
+			if s.getOfferFundedAmount(afView, offer).IsZero() {
+				s.recordPermRm(offerKey)
+			}
 			continue
 		}
 		if s.shouldRmSmallIncreasedQOffer(sb, offer, ownerFunds) {

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -125,6 +125,20 @@ type BookStep struct {
 	// Reference: rippled BookStep.cpp eachOffer lines 1041-1081.
 	lastTipFullyConsumed bool
 
+	// lastConsumedTipKey records the key of the last CLOB offer the callback fully
+	// consumed in the current pass; lastConsumedTipValid reports whether the field
+	// is set. rippled's forEachOffer do-while calls offers.step() after a
+	// fully-consumed tip, and BookTip::step deletes that previous tip from the view
+	// before advancing (BookTip.cpp:37-41). goXRPL consumes the tip in place —
+	// consumeOffer erases it only when its remainder reaches zero — so a funded-cap
+	// full take that drains the owner leaves a became-unfunded offer with a
+	// non-zero remainder in the book directory. The trailing-offer drain removes it,
+	// replicating that delete-on-advance, so the next flow iteration's strand-
+	// quality re-sort and book walk both advance past it instead of re-reading its
+	// stale (better) quality.
+	lastConsumedTipKey   [32]byte
+	lastConsumedTipValid bool
+
 	// offersUsed tracks offers consumed in last execution
 	offersUsed uint32
 
@@ -334,7 +348,7 @@ func (s *BookStep) forEachOffer(
 			}
 		}
 
-		return callback(offerExec{
+		res := callback(offerExec{
 			ofrIn:        ofrIn,
 			ofrOut:       ofrOut,
 			stpIn:        stpIn,
@@ -347,6 +361,18 @@ func (s *BookStep) forEachOffer(
 			ammOffer:     ammOffer,
 			clobOffer:    clobOffer,
 		})
+		// Track the CLOB offer the callback just fully consumed so the trailing
+		// drain can replicate BookTip::step's delete-on-advance for a became-
+		// unfunded full take whose remainder consumeOffer left in the book.
+		if !isAMM {
+			if s.lastTipFullyConsumed {
+				s.lastConsumedTipKey = clobKey
+				s.lastConsumedTipValid = true
+			} else {
+				s.lastConsumedTipValid = false
+			}
+		}
+		return res
 	}
 
 	// tryAMM attempts to process an AMM offer with an optional CLOB quality
@@ -533,6 +559,21 @@ func (s *BookStep) forEachOffer(
 		iterBase = afView
 	}
 	if consumed && s.lastTipFullyConsumed && remainingZero() {
+		// rippled's do-while calls offers.step() after a fully-consumed tip; that
+		// step()'s BookTip::step first deletes the just-consumed tip from the view
+		// (offerDelete of m_entry), then advances and grooms the run behind it.
+		// goXRPL's consumeOffer leaves a funded-cap full take in the book with a
+		// non-zero remainder (a became-unfunded tip), so delete it here first —
+		// otherwise the next flow iteration's strand re-sort and walk re-read its
+		// stale, better quality from the book directory. The deletion goes straight
+		// into the working sandbox (like consumeOffer's own erase and like
+		// BookTip::step's offerDelete on view_), NOT into ofrsToRm: it must follow
+		// the sandbox's reset/apply lifecycle so an over-extended reverse pass that
+		// a limiting-step reset discards rolls the deletion back too, and the
+		// re-executed final pass re-derives it.
+		if s.lastConsumedTipValid {
+			s.removeConsumedTipIfUnfunded(sb)
+		}
 		for s.offersUsed < s.maxOffersToConsume {
 			offer, offerKey, err := s.getNextOfferSkipVisited(sb, afView, ofrsToRm, visited, false)
 			if err != nil || offer == nil {
@@ -589,6 +630,40 @@ func (s *BookStep) forEachOffer(
 	}
 }
 
+// removeConsumedTipIfUnfunded deletes the just-fully-consumed CLOB tip from the
+// working sandbox when its funding cap drained the owner and consumeOffer left a
+// non-zero remainder in the book. This replicates rippled's BookTip::step, which
+// offerDeletes the previous tip from the view when the forEachOffer do-while
+// steps past a fully-consumed offer (BookTip.cpp:37-41). consumeOffer already
+// erases a tip whose remainder reached zero, so this only fires for a funded-cap
+// full take: in that case stpAmt.out is sourced from the owner's funds, so the
+// owner is drained and the remaining offer is became-unfunded. The delete goes
+// straight into the working sandbox (the same erase path consumeOffer uses for a
+// zero-remainder tip, and the same view offerDelete BookTip::step uses), so it
+// rides the sandbox's reset/apply lifecycle: a limiting-step reset rolls it back
+// with the rest of an over-extended pass, and the re-executed final pass re-runs
+// it. Reference: rippled BookTip.cpp:37-41 (offerDelete of m_entry on view_).
+func (s *BookStep) removeConsumedTipIfUnfunded(sb *PaymentSandbox) {
+	key := s.lastConsumedTipKey
+	offerData, err := sb.Read(keylet.Keylet{Key: key})
+	if err != nil || offerData == nil {
+		return
+	}
+	offer, err := state.ParseLedgerOffer(offerData)
+	if err != nil {
+		return
+	}
+	if !s.getOfferFundedAmount(sb, offer).IsZero() {
+		return
+	}
+	owner, err := state.DecodeAccountID(offer.Account)
+	if err != nil {
+		return
+	}
+	txHash, ledgerSeq := sb.GetTransactionContext()
+	_ = s.deleteOffer(sb, offer, owner, txHash, ledgerSeq)
+}
+
 // prevStepDebtDir returns the previous step's debt direction for the given
 // strand direction, defaulting to DebtDirectionIssues when this BookStep is the
 // first step in the strand (the strand source IS the issuer of the input
@@ -634,6 +709,7 @@ func (s *BookStep) Rev(
 	s.cache = nil
 	s.offersUsed = 0
 	s.lastTipFullyConsumed = false
+	s.lastConsumedTipValid = false
 	s.maxOffersToConsume = maxOffersToConsume(sb)
 
 	trIn := s.transferRateIn(sb, s.prevStepDebtDir(sb, StrandDirectionReverse))
@@ -738,6 +814,7 @@ func (s *BookStep) Fwd(
 	s.cache = nil
 	s.offersUsed = 0
 	s.lastTipFullyConsumed = false
+	s.lastConsumedTipValid = false
 	s.maxOffersToConsume = maxOffersToConsume(sb)
 
 	trIn := s.transferRateIn(sb, s.prevStepDebtDir(sb, StrandDirectionForward))

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -1039,20 +1039,66 @@ func (s *BookStep) ValidFwd(sb *PaymentSandbox, afView *PaymentSandbox, in Eithe
 }
 
 // getCLOBTipQuality gets the best quality from CLOB offers only.
+//
+// It mirrors rippled's BookTip::step, which advances past EMPTY book
+// directories: dirFirst returns false for a directory whose pages hold no
+// offer entries, and the BookTip loop then steps to the next quality tier
+// (BookTip.cpp:44-76). A stale, empty book directory therefore must not be
+// reported as the book tip — its quality is not a quality any offer can be
+// crossed at. Reading the first directory's quality unconditionally would
+// surface that phantom tier, which (e.g. on an autobridge leg whose first
+// directory is a left-over empty tier) makes the strand's quality upper bound
+// far better than any real liquidity and wrongly keeps the strand active.
 func (s *BookStep) getCLOBTipQuality(sb *PaymentSandbox) *Quality {
 	bookBase := s.bookBaseKey()
+	bookPrefix := bookBase[:24]
 
-	foundKey, _, found, err := sb.Succ(bookBase)
-	if err != nil || !found {
-		return nil
+	searchKey := bookBase
+	for {
+		foundKey, foundData, found, err := sb.Succ(searchKey)
+		if err != nil || !found {
+			return nil
+		}
+		if !bytes.Equal(foundKey[:24], bookPrefix) {
+			return nil
+		}
+
+		if s.bookDirHasEntries(sb, foundKey, foundData) {
+			q := QualityFromKey(foundKey)
+			return &q
+		}
+
+		// Empty directory tier — advance to the next quality, like
+		// BookTip::step's fall-through when dirFirst returns false.
+		searchKey = foundKey
 	}
+}
 
-	if !bytes.Equal(foundKey[:24], bookBase[:24]) {
-		return nil
+// bookDirHasEntries reports whether the book directory rooted at rootKey holds
+// at least one offer index across its page chain. Mirrors rippled's dirFirst,
+// which walks the page chain (sfIndexNext) and only succeeds when some page has
+// a non-empty sfIndexes vector. rootData is the already-read root page.
+func (s *BookStep) bookDirHasEntries(sb *PaymentSandbox, rootKey [32]byte, rootData []byte) bool {
+	dir, err := state.ParseDirectoryNode(rootData)
+	if err != nil {
+		return false
 	}
-
-	q := QualityFromKey(foundKey)
-	return &q
+	for {
+		if len(dir.Indexes) > 0 {
+			return true
+		}
+		if dir.IndexNext == 0 {
+			return false
+		}
+		pageData, err := sb.Read(keylet.DirPage(rootKey, dir.IndexNext))
+		if err != nil || pageData == nil {
+			return false
+		}
+		dir, err = state.ParseDirectoryNode(pageData)
+		if err != nil {
+			return false
+		}
+	}
 }
 
 // bookBaseKey computes the base key for this BookStep's order book.

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -332,8 +332,15 @@ func (s *BookStep) forEachOffer(
 	// Main CLOB iteration with AMM interleaving.
 	// Reference: rippled BookStep.cpp forEachOffer lines 855-873.
 	firstCLOB := true
+	// consumed tracks whether any offer has been crossed in this pass. The
+	// quality-limit walk bound only applies before the first cross: rippled stops
+	// at a beyond-limit (or AMM-beaten) tip and crosses nothing, but after a cross
+	// its forEachOffer do-while keeps stepping — removing offers left unfunded by
+	// the cross — until the next *funded* tip fails the quality threshold. So a
+	// beyond-limit unfunded offer reached after a cross must still be removed.
+	consumed := false
 	for s.offersUsed < s.maxOffersToConsume && !remainingZero() {
-		offer, offerKey, err := s.getNextOfferSkipVisited(sb, afView, ofrsToRm, visited)
+		offer, offerKey, err := s.getNextOfferSkipVisited(sb, afView, ofrsToRm, visited, !consumed)
 		if err != nil {
 			break
 		}
@@ -389,6 +396,7 @@ func (s *BookStep) forEachOffer(
 			nil, offer, offerKey) {
 			break
 		}
+		consumed = true
 	}
 
 	// If no CLOB offers found, try the AMM alone.

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -431,7 +431,20 @@ func (s *BookStep) forEachOffer(
 			continue
 		}
 		if s.shouldRmSmallIncreasedQOffer(sb, offer, ownerFunds) {
+			// Distinguish "found tiny" from "became tiny", mirroring the
+			// found-unfunded branch above and rippled OfferStream::step
+			// (OfferStream.cpp:378-401): a small-increased-quality offer is a
+			// permanent removal (propagated to removableOffers) only when the
+			// owner's funds are unchanged from the pristine afView — i.e. it was
+			// already this tiny before any crossing. If the crossing drained the
+			// owner so the offer only just became tiny, it is removed in-band from
+			// the working sandbox but stays a conditional removal: rippled does
+			// NOT permRmOffer it, so it must not survive into removableOffers and
+			// be re-erased on a FillOrKill kill.
 			ofrsToRm[offerKey] = true
+			if s.getOfferFundedAmount(afView, offer).Compare(ownerFunds) == 0 {
+				s.recordPermRm(offerKey)
+			}
 			continue
 		}
 

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -115,6 +115,16 @@ type BookStep struct {
 	// inactive indicates the step is dry (too many offers consumed)
 	inactive bool
 
+	// lastTipFullyConsumed records whether the last offer crossed in the current
+	// pass was fully consumed, i.e. whether rippled's eachOffer callback returned
+	// true for it (so the do-while runs offers.step() again, grooming trailing
+	// found-unfunded offers). The full-take branch always returns true; the
+	// partial-take branch (demand met mid-offer) returns offer.fully_consumed(),
+	// which is false for a still-funded tip — in that case rippled breaks without
+	// another offers.step(), so no trailing groom happens.
+	// Reference: rippled BookStep.cpp eachOffer lines 1041-1081.
+	lastTipFullyConsumed bool
+
 	// offersUsed tracks offers consumed in last execution
 	offersUsed uint32
 
@@ -477,40 +487,70 @@ func (s *BookStep) forEachOffer(
 		consumed = true
 	}
 
-	// Self-cross drain: rippled's forEachOffer do-while keeps stepping the book
-	// tip after the requested amount is satisfied. Each subsequent tip still runs
-	// limitSelfCrossQuality, which deletes the taker's own offers at this quality
-	// "even if no crossing occurs", and the loop only ends when a tip at a
-	// different quality (the locked ofrQ tier) or a genuinely crossable non-own
-	// offer is reached. goXRPL's loop above instead stops as soon as the demand is
-	// met (remainingZero), so when the satisfying tip is a non-own offer the own
-	// offers behind it at the same quality are never reached. Replay this tail
-	// here: step the remaining same-quality tip offers and perm-remove the taker's
-	// own ones, stopping at the first offer that is not such a removal — without
-	// consuming or removing anyone else (those removals are driven by the do-while
-	// callback/step, which we already mirror in the main loop above).
-	// Reference: rippled BookStep.cpp forEachOffer do-while 859-863 +
-	// limitSelfCrossQuality 404-459.
-	if consumed && remainingZero() && s.defaultPath && s.qualityLimit != nil &&
-		s.strandSrc == s.strandDst && currentQuality != nil {
+	// Trailing-offer drain: rippled's forEachOffer do-while keeps stepping the
+	// book tip after the requested amount is satisfied, but ONLY when the last
+	// crossed tip was fully consumed (eachOffer returned true). In that case it
+	// runs offers.step() once more, which grooms — quality-blind — the contiguous
+	// run of found-unfunded / found-tiny offers immediately behind the satisfying
+	// tip (OfferStream::step permRmOffer, before any quality check), and
+	// limitSelfCrossQuality additionally removes the taker's own offers at or
+	// better than the limit. The walk stops at the first funded, non-own,
+	// non-groomable survivor: step() breaks there, execOffer's remainingOut==0 /
+	// checkQualityThreshold returns false, and the do-while breaks (the survivor
+	// is left untouched). goXRPL's main loop above instead stops as soon as the
+	// demand is met (remainingZero), so it never reaches those trailing offers;
+	// replay that single bounded step() here.
+	//
+	// When demand is met by a PARTIAL fill of a still-funded tip, eachOffer
+	// returns offer.fully_consumed()==false, the do-while breaks WITHOUT another
+	// offers.step(), and trailing offers are never reached — so the drain must not
+	// fire (lastTipFullyConsumed gate). This is what spares a found-unfunded offer
+	// sitting behind such a partially-filled tip from being wrongly groomed.
+	// Reference: rippled BookStep.cpp forEachOffer do-while 859-863, eachOffer
+	// 1041-1081 (rev) / 1252 (fwd); OfferStream.cpp step 234-404 (found-unfunded
+	// 314-341, found-tiny 343-404); limitSelfCrossQuality 404-459.
+	if consumed && s.lastTipFullyConsumed && remainingZero() && s.defaultPath &&
+		s.qualityLimit != nil && s.strandSrc == s.strandDst && currentQuality != nil {
 		for s.offersUsed < s.maxOffersToConsume {
 			offer, offerKey, err := s.getNextOfferSkipVisited(sb, afView, ofrsToRm, visited, false)
 			if err != nil || offer == nil {
 				break
 			}
-			offerQ := s.offerQuality(offer)
-			// A different quality tier ends the walk, mirroring rippled's
-			// `*ofrQ != offer.quality()` guard once an offer has been attempted.
-			if offerQ.Value != currentQuality.Value {
-				break
-			}
 			offerOwner, ownerErr := state.DecodeAccountID(offer.Account)
-			if ownerErr != nil || offerQ.WorseThan(*s.qualityLimit) ||
-				offerOwner != s.strandSrc {
+			if ownerErr != nil {
 				break
 			}
-			ofrsToRm[offerKey] = true
-			s.recordPermRm(offerKey)
+			offerQ := s.offerQuality(offer)
+
+			// (a) any tip OfferStream::step grooms quality-blind, before execOffer
+			//     ever runs: found-unfunded or found-tiny, regardless of owner or
+			//     tier. Expired offers are removed inside getNextOfferSkipVisited
+			//     and never yielded here.
+			if s.isFoundPermGroomable(sb, afView, offer) {
+				ofrsToRm[offerKey] = true
+				s.recordPermRm(offerKey)
+				continue
+			}
+
+			// (b) own self-cross at or better than the limit on a FUNDED tip:
+			//     limitSelfCrossQuality removes it "even if no crossing occurs" and
+			//     execOffer returns true, so the do-while keeps stepping past it.
+			//     This is reached only on the funded survivor step() lands on, and
+			//     execOffer's `*ofrQ != offer.quality()` check (which runs before
+			//     limitSelfCrossQuality) restricts it to the locked tier: a funded
+			//     survivor at a different tier makes execOffer return false first,
+			//     breaking the do-while.
+			if offerOwner == s.strandSrc && offerQ.Value == currentQuality.Value &&
+				!offerQ.WorseThan(*s.qualityLimit) {
+				ofrsToRm[offerKey] = true
+				s.recordPermRm(offerKey)
+				continue
+			}
+
+			// (c) first funded, non-groomable survivor that is not a same-tier own
+			//     self-cross: step() breaks here and execOffer returns false (tier
+			//     change / remainingOut==0 / checkQualityThreshold). Leave it.
+			break
 		}
 	}
 
@@ -564,6 +604,7 @@ func (s *BookStep) Rev(
 ) (EitherAmount, EitherAmount) {
 	s.cache = nil
 	s.offersUsed = 0
+	s.lastTipFullyConsumed = false
 	s.maxOffersToConsume = maxOffersToConsume(sb)
 
 	trIn := s.transferRateIn(sb, s.prevStepDebtDir(sb, StrandDirectionReverse))
@@ -590,6 +631,10 @@ func (s *BookStep) Rev(
 					throwConsumeFailure(err)
 				}
 			}
+			// rippled's eachOffer returns true here unconditionally ("even if the
+			// payment is satisfied, we need to consume the offer"), so the do-while
+			// runs offers.step() again and grooms trailing offers.
+			s.lastTipFullyConsumed = true
 		} else {
 			// Partial take: limitStepOut
 			stpAdjOut := remainingOut
@@ -620,6 +665,11 @@ func (s *BookStep) Rev(
 					throwConsumeFailure(err)
 				}
 			}
+			// Demand met mid-offer: rippled returns offer.fully_consumed() here. A
+			// still-funded partially-filled tip is NOT fully consumed, so the
+			// do-while breaks without another offers.step() and trailing offers are
+			// never groomed.
+			s.lastTipFullyConsumed = s.tipFullyConsumed(e)
 		}
 
 		return true
@@ -658,6 +708,7 @@ func (s *BookStep) Fwd(
 	prevCache := s.cache
 	s.cache = nil
 	s.offersUsed = 0
+	s.lastTipFullyConsumed = false
 	s.maxOffersToConsume = maxOffersToConsume(sb)
 
 	trIn := s.transferRateIn(sb, s.prevStepDebtDir(sb, StrandDirectionForward))
@@ -671,6 +722,10 @@ func (s *BookStep) Fwd(
 	// Reference: rippled BookStep.cpp fwdImp callback lines 1175-1240.
 	fwdCallback := func(e offerExec) bool {
 		if e.stpIn.Compare(remainingIn) <= 0 {
+			// Full take: rippled sets processMore = true and eachOffer returns
+			// true, so the do-while runs offers.step() again and grooms trailing
+			// offers.
+			s.lastTipFullyConsumed = true
 			totalIn = totalIn.Add(e.stpIn)
 			totalOut = totalOut.Add(e.stpOut)
 
@@ -776,6 +831,10 @@ func (s *BookStep) Fwd(
 					throwConsumeFailure(err)
 				}
 			}
+			// Demand met mid-offer: rippled has processMore = false and returns
+			// offer.fully_consumed(), so a still-funded tip breaks the do-while
+			// without another offers.step() (no trailing groom).
+			s.lastTipFullyConsumed = s.tipFullyConsumed(e)
 		}
 
 		return true

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -198,6 +198,58 @@ type bookCache struct {
 	out EitherAmount
 }
 
+// amountMultiset accumulates the per-offer step amounts a BookStep consumes and
+// returns their sum in ascending magnitude order. It mirrors rippled's
+// boost::container::flat_multiset<TIn>/<TOut> in BookStep::revImp/fwdImp, whose
+// sum() helper folds the elements via std::accumulate over the sorted range
+// (BookStep.cpp:1002-1010). Because each STAmount add re-canonicalizes the
+// running total to a 16-significant-digit mantissa, the order in which the
+// per-offer amounts are added changes the final 1-ULP rounding: summing
+// smallest-first (rippled) can land on a different last digit than summing in
+// consumption order. Recomputing the total as the ascending sum on every take
+// reproduces rippled's result exactly.
+type amountMultiset struct {
+	elems []EitherAmount
+}
+
+// insert adds an amount to the multiset, keeping the slice sorted ascending so a
+// later sum() folds smallest-first. Duplicates are retained (multiset).
+func (m *amountMultiset) insert(a EitherAmount) {
+	i := 0
+	for i < len(m.elems) && m.elems[i].Compare(a) < 0 {
+		i++
+	}
+	m.elems = append(m.elems, EitherAmount{})
+	copy(m.elems[i+1:], m.elems[i:])
+	m.elems[i] = a
+}
+
+// erase removes one element equal to a, mirroring rippled's
+// savedOuts.erase(lastOut) (which erases the single iterator returned by the
+// matching insert). A no-op when no element matches.
+func (m *amountMultiset) erase(a EitherAmount) {
+	for i := range m.elems {
+		if m.elems[i].Compare(a) == 0 {
+			m.elems = append(m.elems[:i], m.elems[i+1:]...)
+			return
+		}
+	}
+}
+
+// sum folds the elements smallest-first, matching rippled's
+// std::accumulate(begin()+1, end(), *begin()) over the sorted flat_multiset.
+// zero is returned for an empty set (the currency-tagged zero the caller wants).
+func (m *amountMultiset) sum(zero EitherAmount) EitherAmount {
+	if len(m.elems) == 0 {
+		return zero
+	}
+	total := m.elems[0]
+	for _, e := range m.elems[1:] {
+		total = total.Add(e)
+	}
+	return total
+}
+
 // NewBookStep creates a new BookStep for order book consumption
 func NewBookStep(inIssue, outIssue Issue, strandSrc, strandDst [20]byte, prevStep Step, ownerPaysTransferFee bool) *BookStep {
 	return &BookStep{
@@ -718,13 +770,22 @@ func (s *BookStep) Rev(
 	totalIn, totalOut := s.zeroIn(), s.zeroOut()
 	remainingOut := out
 
+	// savedIns/savedOuts accumulate the per-offer step amounts and are summed
+	// smallest-first, matching rippled's flat_multiset<TIn>/<TOut> + sum() in
+	// revImp (BookStep.cpp:1026-1072). Re-summing in ascending order on each take
+	// reproduces rippled's 16-digit intermediate rounding, which differs from a
+	// running consumption-order accumulation.
+	var savedIns, savedOuts amountMultiset
+
 	// revImp callback: decide full vs partial take, consume, and update accumulators.
 	// Reference: rippled BookStep.cpp revImp callback lines 1056-1083.
 	revCallback := func(e offerExec) bool {
 		if e.stpOut.Compare(remainingOut) <= 0 {
 			// Full take
-			totalIn = totalIn.Add(e.stpIn)
-			totalOut = totalOut.Add(e.stpOut)
+			savedIns.insert(e.stpIn)
+			savedOuts.insert(e.stpOut)
+			totalIn = savedIns.sum(s.zeroIn())
+			totalOut = savedOuts.sum(s.zeroOut())
 			remainingOut = out.Sub(totalOut)
 
 			if e.isAMM {
@@ -757,7 +818,10 @@ func (s *BookStep) Rev(
 			ownerGivesAdj := MulRatio(stpAdjOut, e.ofrTrOut, QualityOne, false)
 			_ = ofrAdjOut
 
-			totalIn = totalIn.Add(stpAdjIn)
+			// rippled inserts stpAdjAmt.in into savedIns and sets result.in =
+			// sum(savedIns); result.out = out (BookStep.cpp:1069-1072).
+			savedIns.insert(stpAdjIn)
+			totalIn = savedIns.sum(s.zeroIn())
 			totalOut = out
 			remainingOut = s.zeroOut()
 
@@ -823,6 +887,12 @@ func (s *BookStep) Fwd(
 	totalIn, totalOut := s.zeroIn(), s.zeroOut()
 	remainingIn := in
 
+	// savedIns/savedOuts accumulate the per-offer step amounts and are summed
+	// smallest-first, matching rippled's flat_multiset<TIn>/<TOut> + sum() in
+	// fwdImp (BookStep.cpp:1172-1242). The ascending-order re-sum reproduces
+	// rippled's 16-digit intermediate rounding (see revImp).
+	var savedIns, savedOuts amountMultiset
+
 	// fwdImp callback: decide full vs partial take, reconcile against the reverse
 	// pass cache, consume, and update accumulators.
 	// Reference: rippled BookStep.cpp fwdImp callback lines 1175-1240.
@@ -832,12 +902,16 @@ func (s *BookStep) Fwd(
 			// true, so the do-while runs offers.step() again and grooms trailing
 			// offers.
 			s.lastTipFullyConsumed = true
-			totalIn = totalIn.Add(e.stpIn)
-			totalOut = totalOut.Add(e.stpOut)
+			savedIns.insert(e.stpIn)
+			lastOut := e.stpOut
+			savedOuts.insert(lastOut)
+			totalIn = savedIns.sum(s.zeroIn())
+			totalOut = savedOuts.sum(s.zeroOut())
 
 			// Forward > reverse cache check
 			if prevCache != nil && totalOut.Compare(prevCache.out) > 0 && totalIn.Compare(prevCache.in) <= 0 {
-				remainingCacheOut := prevCache.out.Sub(totalOut.Sub(e.stpOut))
+				savedOuts.erase(lastOut)
+				remainingCacheOut := prevCache.out.Sub(savedOuts.sum(s.zeroOut()))
 				adjOfrIn, adjOfrOut := e.ofrIn, e.ofrOut
 				adjStpOut := remainingCacheOut
 				if e.isAMM {
@@ -864,6 +938,9 @@ func (s *BookStep) Fwd(
 					remainingIn = s.zeroIn()
 					return true
 				}
+				// Reconciliation declined: rippled re-inserts the erased output
+				// (BookStep.cpp:1241) so the running totals stay consistent.
+				savedOuts.insert(lastOut)
 			}
 
 			remainingIn = in.Sub(totalIn)
@@ -893,12 +970,18 @@ func (s *BookStep) Fwd(
 			stpAdjOut := ofrAdjOut
 			ownerGivesAdj := MulRatio(ofrAdjOut, e.ofrTrOut, QualityOne, false)
 
-			totalOut = totalOut.Add(stpAdjOut)
+			// rippled inserts remainingIn into savedIns and stpAdjAmt.out into
+			// savedOuts, then sets result.out = sum(savedOuts); result.in = in
+			// (BookStep.cpp:1190-1193).
+			savedIns.insert(stpAdjIn)
+			savedOuts.insert(stpAdjOut)
+			totalOut = savedOuts.sum(s.zeroOut())
 			totalIn = in
 
 			// Forward > reverse cache check
 			if prevCache != nil && totalOut.Compare(prevCache.out) > 0 && totalIn.Compare(prevCache.in) <= 0 {
-				remainingCacheOut := prevCache.out.Sub(totalOut.Sub(stpAdjOut))
+				savedOuts.erase(stpAdjOut)
+				remainingCacheOut := prevCache.out.Sub(savedOuts.sum(s.zeroOut()))
 				revOfrIn, revOfrOut := e.ofrIn, e.ofrOut
 				revStpOut := remainingCacheOut
 				if e.isAMM {
@@ -925,6 +1008,9 @@ func (s *BookStep) Fwd(
 					remainingIn = s.zeroIn()
 					return true
 				}
+				// Reconciliation declined: rippled re-inserts the erased output
+				// (BookStep.cpp:1241).
+				savedOuts.insert(stpAdjOut)
 			}
 
 			remainingIn = s.zeroIn()

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -72,6 +72,15 @@ type BookStep struct {
 	// than the taker's quality.
 	qualityLimit *Quality
 
+	// crossLimit is the taker's offer-crossing quality threshold. rippled's
+	// BookOfferCrossingStep always carries qualityThreshold_ (from ctx.limitQuality)
+	// on EVERY crossing step — direct and autobridge legs alike — and uses it in
+	// qualityThreshold(lobQuality) to decide the AMM-offer generation threshold,
+	// independent of the default-path-gated per-offer quality bound (qualityLimit).
+	// Reference: rippled BookOfferCrossingStep::qualityThreshold_ and
+	// BookOfferCrossingStep::qualityThreshold().
+	crossLimit *Quality
+
 	// parentCloseTime is the parent ledger close time (Ripple epoch seconds)
 	// Used to check offer expiration during iteration
 	parentCloseTime uint32

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -547,6 +547,18 @@ func (s *BookStep) forEachOffer(
 			// remaining output, stop before crossing the CLOB tip — rippled's
 			// forEachOffer ends at remainingOut==0 and never reaches the next
 			// offer, so the tip must not be touched (threaded) by a zero cross.
+			//
+			// KNOWN NARROW DIVERGENCE (deferred): rippled's do-while still runs
+			// execOffer(offers.tip()) once after the AMM, and its
+			// limitSelfCrossQuality removes the taker's own self-crossed offer(s)
+			// (BookStep.cpp:756,855-863) before the remainingOut==0 callback stops
+			// the walk; the trailing-drain below (gated on a consumed CLOB tip) does
+			// not run here, so such self-crossed/groomable offers behind a
+			// demand-satisfying AMM are left on the book. A faithful fix applies the
+			// found/became/self-cross drain (clauses a/a'/b/c) starting at this tip,
+			// which restructures the trailing-drain gating and is unverifiable for
+			// byte-exactness without the nodestore replay seed; tracked with the
+			// #1027/#1029 seed-equipped follow-up rather than fixed speculatively.
 			if remainingZero() {
 				break
 			}

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -457,6 +457,43 @@ func (s *BookStep) forEachOffer(
 		consumed = true
 	}
 
+	// Self-cross drain: rippled's forEachOffer do-while keeps stepping the book
+	// tip after the requested amount is satisfied. Each subsequent tip still runs
+	// limitSelfCrossQuality, which deletes the taker's own offers at this quality
+	// "even if no crossing occurs", and the loop only ends when a tip at a
+	// different quality (the locked ofrQ tier) or a genuinely crossable non-own
+	// offer is reached. goXRPL's loop above instead stops as soon as the demand is
+	// met (remainingZero), so when the satisfying tip is a non-own offer the own
+	// offers behind it at the same quality are never reached. Replay this tail
+	// here: step the remaining same-quality tip offers and perm-remove the taker's
+	// own ones, stopping at the first offer that is not such a removal — without
+	// consuming or removing anyone else (those removals are driven by the do-while
+	// callback/step, which we already mirror in the main loop above).
+	// Reference: rippled BookStep.cpp forEachOffer do-while 859-863 +
+	// limitSelfCrossQuality 404-459.
+	if consumed && remainingZero() && s.defaultPath && s.qualityLimit != nil &&
+		s.strandSrc == s.strandDst && currentQuality != nil {
+		for s.offersUsed < s.maxOffersToConsume {
+			offer, offerKey, err := s.getNextOfferSkipVisited(sb, afView, ofrsToRm, visited, false)
+			if err != nil || offer == nil {
+				break
+			}
+			offerQ := s.offerQuality(offer)
+			// A different quality tier ends the walk, mirroring rippled's
+			// `*ofrQ != offer.quality()` guard once an offer has been attempted.
+			if offerQ.Value != currentQuality.Value {
+				break
+			}
+			offerOwner, ownerErr := state.DecodeAccountID(offer.Account)
+			if ownerErr != nil || offerQ.WorseThan(*s.qualityLimit) ||
+				offerOwner != s.strandSrc {
+				break
+			}
+			ofrsToRm[offerKey] = true
+			s.recordPermRm(offerKey)
+		}
+	}
+
 	// If no CLOB offers found, try the AMM alone.
 	if firstCLOB {
 		tryAMM(nil)

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -136,6 +136,36 @@ type BookStep struct {
 	// When enabled, throws tecINVARIANT_FAILED if the invariant is violated.
 	// Reference: rippled fixAMMOverflowOffer amendment
 	fixAMMOverflowOffer bool
+
+	// permRm records offers this step removed unconditionally — self-crossed
+	// (limitSelfCrossQuality), authorization-failed, expired, and domain-removed
+	// offers. rippled puts these in FlowOfferStream::permToRemove_, which is
+	// returned and unioned into the strand's ofrsToRm and survives "even if the
+	// strand is not applied" (OfferStream.h) — it is NEVER rolled back when a
+	// limiting step is reset and re-executed. The strand executor consults this
+	// to keep such removals when its limiting-step reset would otherwise discard
+	// an over-walk's removals (those discards target only "became unfunded"
+	// offers, which are NOT recorded here). It accumulates across re-executions
+	// within one strand build and is fresh per OfferCreate (strands are rebuilt).
+	// Reference: rippled OfferStream.h permToRemove_; BookStep.cpp limitSelfCrossQuality.
+	permRm map[[32]byte]bool
+}
+
+// recordPermRm marks an offer key as an unconditional ("perm") removal — the
+// rippled FlowOfferStream::permToRemove semantics. Lazily allocates the set.
+func (s *BookStep) recordPermRm(key [32]byte) {
+	if s.permRm == nil {
+		s.permRm = make(map[[32]byte]bool)
+	}
+	s.permRm[key] = true
+}
+
+// PermRemovals returns the offers this BookStep removed unconditionally during
+// its reverse/forward walks (self-cross, auth, expiry, domain). The strand
+// executor restores these into ofrsToRm after a limiting-step reset so they are
+// never discarded as spurious over-walk removals.
+func (s *BookStep) PermRemovals() map[[32]byte]bool {
+	return s.permRm
 }
 
 // bookCache holds cached values from the reverse pass
@@ -234,6 +264,7 @@ func (s *BookStep) forEachOffer(
 				if !offerQuality.WorseThan(*s.qualityLimit) &&
 					s.strandSrc == offerOwner && s.strandDst == offerOwner {
 					ofrsToRm[clobKey] = true
+					s.recordPermRm(clobKey)
 					if !offerAttempted {
 						currentQuality = nil
 					}
@@ -248,6 +279,7 @@ func (s *BookStep) forEachOffer(
 			if ownerErr == nil && offerOwner != s.book.In.Issuer {
 				if !s.isOfferOwnerAuthorized(afView, offerOwner, s.book.In.Issuer, s.book.In.Currency) {
 					ofrsToRm[clobKey] = true
+					s.recordPermRm(clobKey)
 					if !offerAttempted {
 						currentQuality = nil
 					}
@@ -370,6 +402,7 @@ func (s *BookStep) forEachOffer(
 			offerOwnerDF, _ := state.DecodeAccountID(offer.Account)
 			if s.isDeepFrozen(sb, offerOwnerDF, s.book.In.Currency, s.book.In.Issuer) {
 				ofrsToRm[offerKey] = true
+				s.recordPermRm(offerKey)
 				continue
 			}
 		}

--- a/internal/tx/payment/step_book_counter_test.go
+++ b/internal/tx/payment/step_book_counter_test.go
@@ -152,7 +152,7 @@ func TestBookStep_ErasesDanglingDirectoryEntry(t *testing.T) {
 	sb := NewChildSandbox(afView)
 	sb.SetTransactionContext([32]byte{}, 1)
 
-	offer, offerKey, err := step.getNextOfferSkipVisited(sb, afView, make(map[[32]byte]bool), make(map[[32]byte]bool))
+	offer, offerKey, err := step.getNextOfferSkipVisited(sb, afView, make(map[[32]byte]bool), make(map[[32]byte]bool), true)
 	require.NoError(t, err)
 	require.NotNil(t, offer, "walk must skip the dangling entry and return the real offer")
 	require.Equal(t, realKey, offerKey)

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -77,14 +77,22 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 				}
 
 				// In a beyond-limit directory the taker crosses nothing past its
-				// limit, and rippled does not step into a beyond-limit tip — so stop
-				// the walk here without counting or touching this offer, exactly as
-				// the directory bound did before. The sole exception is the taker's
-				// OWN offer on the default path (a self-cross): rippled removes a
-				// self-crossed own offer "even if no crossing occurs", so a
-				// reserve-locked own offer at a beyond-limit tip must still be reached
-				// and pruned (it falls through to the found-unfunded removal below).
-				// Reference: rippled BookStep.cpp limitSelfCrossQuality.
+				// limit. rippled's OfferStream::step still advances the book tip into
+				// such a directory and perm-removes any FOUND-unfunded (or expired)
+				// offer it walks over, regardless of quality; only execOffer's
+				// checkQualityThreshold stops the *crossing* at a FUNDED beyond-limit
+				// tip. So at a beyond-limit page we yield an offer only when it would
+				// be groomed by step() anyway — a found-unfunded one (zero funds in
+				// both the execution sandbox and the pristine afView) — and let
+				// forEachOffer's found-unfunded branch perm-remove it. The taker's OWN
+				// offer on the default path (a self-cross) is also yielded: rippled
+				// removes a self-crossed own offer "even if no crossing occurs". A
+				// FUNDED non-own beyond-limit offer still stops the walk here — exactly
+				// as rippled never steps past a funded beyond-limit tip — so an
+				// over-extended reverse pass can never reach and remove a deeper
+				// BECAME-unfunded offer behind it.
+				// Reference: rippled OfferStream.cpp step() lines 234-341 (found vs
+				// became unfunded) and BookStep.cpp checkQualityThreshold/do-while.
 				if pageBeyondLimit {
 					ownData, ownErr := sb.Read(keylet.Keylet{Key: offerKey})
 					isOwnOffer := false
@@ -96,7 +104,16 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 						}
 					}
 					if !isOwnOffer {
-						return nil, [32]byte{}, nil
+						foundUnfunded := false
+						if ownErr == nil && ownData != nil {
+							if probeOffer, pErr := state.ParseLedgerOffer(ownData); pErr == nil {
+								foundUnfunded = s.getOfferFundedAmount(sb, probeOffer).IsZero() &&
+									s.getOfferFundedAmount(afView, probeOffer).IsZero()
+							}
+						}
+						if !foundUnfunded {
+							return nil, [32]byte{}, nil
+						}
 					}
 				}
 

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -45,22 +45,13 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 			return nil, [32]byte{}, nil
 		}
 
-		// Bound the offer-crossing book walk by the taker's quality limit, but
-		// only before any offer has been crossed in this pass (enforceQualityBound).
-		// rippled's forEachOffer stops at the first beyond-limit (or AMM-beaten)
-		// tip and crosses nothing; but after a cross its do-while keeps calling
-		// offers.step(), which removes offers left unfunded/expired by the cross as
-		// it advances and only stops at the next *funded* tip that fails the quality
-		// threshold. So a beyond-limit unfunded offer reached after a cross must
-		// still be removed; stopping unconditionally here would leave it (e.g. a
-		// second offer of an owner the first cross drained). Only offer crossing
-		// sets qualityLimit (payments leave it nil and walk fully).
-		if enforceQualityBound && s.qualityLimit != nil {
-			pageQ := QualityFromKey(foundKey)
-			if pageQ.WorseThan(*s.qualityLimit) {
-				return nil, [32]byte{}, nil
-			}
-		}
+		// pageBeyondLimit: this directory's quality is worse than the taker's
+		// limit. selfCrossEligible: an offer-crossing default-path strand, where
+		// the taker is both the strand source and destination. See the per-offer
+		// check below for how the two bound the walk.
+		pageBeyondLimit := enforceQualityBound && s.qualityLimit != nil &&
+			QualityFromKey(foundKey).WorseThan(*s.qualityLimit)
+		selfCrossEligible := s.defaultPath && s.strandSrc == s.strandDst
 
 		// Iterate through all pages of this directory (root + linked pages)
 		dir, err := state.ParseDirectoryNode(foundData)
@@ -83,6 +74,30 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 				}
 				if visited != nil && visited[offerKey] {
 					continue
+				}
+
+				// In a beyond-limit directory the taker crosses nothing past its
+				// limit, and rippled does not step into a beyond-limit tip — so stop
+				// the walk here without counting or touching this offer, exactly as
+				// the directory bound did before. The sole exception is the taker's
+				// OWN offer on the default path (a self-cross): rippled removes a
+				// self-crossed own offer "even if no crossing occurs", so a
+				// reserve-locked own offer at a beyond-limit tip must still be reached
+				// and pruned (it falls through to the found-unfunded removal below).
+				// Reference: rippled BookStep.cpp limitSelfCrossQuality.
+				if pageBeyondLimit {
+					ownData, ownErr := sb.Read(keylet.Keylet{Key: offerKey})
+					isOwnOffer := false
+					if selfCrossEligible && ownErr == nil && ownData != nil {
+						if ownOffer, pErr := state.ParseLedgerOffer(ownData); pErr == nil {
+							if ownerID, derr := state.DecodeAccountID(ownOffer.Account); derr == nil && ownerID == s.strandSrc {
+								isOwnOffer = true
+							}
+						}
+					}
+					if !isOwnOffer {
+						return nil, [32]byte{}, nil
+					}
 				}
 
 				// Count this offer before the expiry/funding/removal checks,

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -78,21 +78,25 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 
 				// In a beyond-limit directory the taker crosses nothing past its
 				// limit. rippled's OfferStream::step still advances the book tip into
-				// such a directory and perm-removes any FOUND-unfunded (or expired)
-				// offer it walks over, regardless of quality; only execOffer's
-				// checkQualityThreshold stops the *crossing* at a FUNDED beyond-limit
-				// tip. So at a beyond-limit page we yield an offer only when it would
-				// be groomed by step() anyway — a found-unfunded one (zero funds in
-				// both the execution sandbox and the pristine afView) — and let
-				// forEachOffer's found-unfunded branch perm-remove it. The taker's OWN
+				// such a directory and perm-removes any offer it walks over that it
+				// would groom regardless of quality — a FOUND-unfunded offer, a
+				// FOUND-tiny offer (small/increased-quality, OfferStream.cpp:343-404),
+				// or an expired one — before execOffer's checkQualityThreshold ever
+				// applies the limit; that threshold only stops the *crossing* at a
+				// FUNDED, non-groomable beyond-limit tip. So at a beyond-limit page we
+				// yield an offer only when step() would groom it as a perm (FOUND)
+				// removal — zero funds, or a tiny-quality offer whose funds are
+				// unchanged from the pristine afView — and let forEachOffer's
+				// found-unfunded / found-tiny branch perm-remove it. The taker's OWN
 				// offer on the default path (a self-cross) is also yielded: rippled
 				// removes a self-crossed own offer "even if no crossing occurs". A
-				// FUNDED non-own beyond-limit offer still stops the walk here — exactly
-				// as rippled never steps past a funded beyond-limit tip — so an
-				// over-extended reverse pass can never reach and remove a deeper
-				// BECAME-unfunded offer behind it.
-				// Reference: rippled OfferStream.cpp step() lines 234-341 (found vs
-				// became unfunded) and BookStep.cpp checkQualityThreshold/do-while.
+				// FUNDED, non-groomable non-own beyond-limit offer (and any BECAME-
+				// unfunded/tiny one) still stops the walk here — exactly as rippled
+				// never crosses past a funded beyond-limit tip — so an over-extended
+				// reverse pass can never reach and remove a deeper BECAME-unfunded
+				// offer behind it.
+				// Reference: rippled OfferStream.cpp step() lines 314-404 (found vs
+				// became unfunded/tiny) and BookStep.cpp checkQualityThreshold/do-while.
 				if pageBeyondLimit {
 					ownData, ownErr := sb.Read(keylet.Keylet{Key: offerKey})
 					isOwnOffer := false
@@ -104,14 +108,13 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 						}
 					}
 					if !isOwnOffer {
-						foundUnfunded := false
+						groomable := false
 						if ownErr == nil && ownData != nil {
 							if probeOffer, pErr := state.ParseLedgerOffer(ownData); pErr == nil {
-								foundUnfunded = s.getOfferFundedAmount(sb, probeOffer).IsZero() &&
-									s.getOfferFundedAmount(afView, probeOffer).IsZero()
+								groomable = s.isFoundPermGroomable(sb, afView, probeOffer)
 							}
 						}
-						if !foundUnfunded {
+						if !groomable {
 							return nil, [32]byte{}, nil
 						}
 					}
@@ -215,6 +218,33 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 		// All offers at this quality consumed — move to next quality
 		searchKey = foundKey
 	}
+}
+
+// isFoundPermGroomable reports whether a beyond-limit non-own offer is one that
+// rippled's OfferStream::step would perm-remove as a FOUND removal — i.e. it was
+// already removable in the pristine view before any crossing touched it. This is
+// the set the beyond-limit walk may step past: rippled grooms it quality-blind,
+// ahead of the crossing quality threshold. Two cases qualify, both requiring the
+// owner's funds to be unchanged from the pristine afView (a FOUND, not a BECAME,
+// removal):
+//   - found-unfunded: zero funds in both the execution sandbox and afView, and
+//   - found-tiny: a small/increased-quality offer (shouldRmSmallIncreasedQOffer)
+//     whose funds are identical in the execution sandbox and afView.
+//
+// A funded, non-groomable offer — or one that only BECAME unfunded/tiny because
+// the crossing drained its owner — returns false and stops the walk, so a deeper
+// became-unfunded/tiny offer is never reached, exactly as rippled never crosses
+// past a funded beyond-limit tip.
+// Reference: rippled OfferStream.cpp step() lines 314-404.
+func (s *BookStep) isFoundPermGroomable(sb, afView *PaymentSandbox, offer *state.LedgerOffer) bool {
+	fundsSb := s.getOfferFundedAmount(sb, offer)
+	if fundsSb.IsZero() {
+		return s.getOfferFundedAmount(afView, offer).IsZero()
+	}
+	if s.shouldRmSmallIncreasedQOffer(sb, offer, fundsSb) {
+		return s.getOfferFundedAmount(afView, offer).Compare(fundsSb) == 0
+	}
+	return false
 }
 
 // eraseDanglingOffer removes a stale index from a book directory page whose

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -81,13 +81,13 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 				// such a directory and perm-removes any offer it walks over that it
 				// would groom regardless of quality — a FOUND-unfunded offer, a
 				// FOUND-tiny offer (small/increased-quality, OfferStream.cpp:343-404),
-				// or an expired one — before execOffer's checkQualityThreshold ever
-				// applies the limit; that threshold only stops the *crossing* at a
-				// FUNDED, non-groomable beyond-limit tip. So at a beyond-limit page we
-				// yield an offer only when step() would groom it as a perm (FOUND)
-				// removal — zero funds, or a tiny-quality offer whose funds are
-				// unchanged from the pristine afView — and let forEachOffer's
-				// found-unfunded / found-tiny branch perm-remove it. The taker's OWN
+				// an expired one, or a domain-removed one — before execOffer's
+				// checkQualityThreshold ever applies the limit; that threshold only
+				// stops the *crossing* at a FUNDED, non-groomable beyond-limit tip. So
+				// at a beyond-limit page we yield an offer only when step() would groom
+				// it — zero funds, a tiny-quality offer whose funds are unchanged from
+				// the pristine afView, an expired offer, or a domain-removed offer —
+				// and let forEachOffer / the expiry/domain branch remove it. The taker's OWN
 				// offer on the default path (a self-cross) is also yielded: rippled
 				// removes a self-crossed own offer "even if no crossing occurs". A
 				// FUNDED, non-groomable non-own beyond-limit offer (and any BECAME-
@@ -111,7 +111,9 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 						groomable := false
 						if ownErr == nil && ownData != nil {
 							if probeOffer, pErr := state.ParseLedgerOffer(ownData); pErr == nil {
-								groomable = s.isFoundPermGroomable(sb, afView, probeOffer)
+								groomable = s.isFoundPermGroomable(sb, afView, probeOffer) ||
+									s.offerExpired(probeOffer) ||
+									s.offerOutOfDomain(sb, probeOffer)
 							}
 						}
 						if !groomable {
@@ -151,28 +153,9 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 					continue
 				}
 
-				// Autobridge self-payment: in offer crossing, an offer whose owner
-				// is the strand destination and whose previous step is a BookStep
-				// (the XRP-bridge second leg) would deliver the destination its own
-				// asset — a self-payment that nets to zero, providing no real
-				// liquidity. rippled keeps it out of the consumed book (the offer is
-				// left untouched), falling back to the AMM/next offer; skip it here
-				// without removal so the same liquidity is consumed.
-				if s.offerCrossing {
-					if _, prevIsBook := s.prevStep.(*BookStep); prevIsBook {
-						if ownerID, derr := state.DecodeAccountID(offer.Account); derr == nil && ownerID == s.strandDst {
-							if visited != nil {
-								visited[offerKey] = true
-							}
-							continue
-						}
-					}
-				}
-
 				// Check offer expiration
 				// Reference: rippled OfferStream.cpp lines 256-265
-				if s.parentCloseTime > 0 && offer.Expiration > 0 &&
-					offer.Expiration <= s.parentCloseTime {
+				if s.offerExpired(offer) {
 					s.removeExpiredOffer(sb, offer, offerKey)
 					if ofrsToRm != nil {
 						ofrsToRm[offerKey] = true
@@ -188,13 +171,10 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 				// This applies to ALL payment streams, not just domain payments —
 				// hybrid offers in the open book must also be validated.
 				// Reference: rippled OfferStream.cpp lines 294-303
-				var zeroDomainID [32]byte
-				if offer.DomainID != zeroDomainID {
-					if !permissioneddomain.OfferInDomain(sb, offer, offer.DomainID, s.parentCloseTime) {
-						ofrsToRm[offerKey] = true
-						s.recordPermRm(offerKey)
-						continue
-					}
+				if s.offerOutOfDomain(sb, offer) {
+					ofrsToRm[offerKey] = true
+					s.recordPermRm(offerKey)
+					continue
 				}
 
 				return offer, offerKey, nil
@@ -245,6 +225,27 @@ func (s *BookStep) isFoundPermGroomable(sb, afView *PaymentSandbox, offer *state
 		return s.getOfferFundedAmount(afView, offer).Compare(fundsSb) == 0
 	}
 	return false
+}
+
+// offerExpired reports whether the offer's Expiration has passed the parent
+// ledger close time. rippled grooms an expired offer quality-blind, ahead of the
+// crossing quality threshold, so it is removed even at a beyond-limit tip.
+// Reference: rippled OfferStream.cpp lines 256-265.
+func (s *BookStep) offerExpired(offer *state.LedgerOffer) bool {
+	return s.parentCloseTime > 0 && offer.Expiration > 0 &&
+		offer.Expiration <= s.parentCloseTime
+}
+
+// offerOutOfDomain reports whether a domain/hybrid offer's owner has left the
+// offer's DomainID (or lost the gating credential), which rippled treats as
+// unfunded and grooms quality-blind, ahead of the crossing quality threshold.
+// Reference: rippled OfferStream.cpp lines 294-303.
+func (s *BookStep) offerOutOfDomain(sb *PaymentSandbox, offer *state.LedgerOffer) bool {
+	var zeroDomainID [32]byte
+	if offer.DomainID == zeroDomainID {
+		return false
+	}
+	return !permissioneddomain.OfferInDomain(sb, offer, offer.DomainID, s.parentCloseTime)
 }
 
 // isBecameGroomableAgainst reports whether the trailing offer is a BECAME

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -28,7 +28,7 @@ func (s *BookStep) stepOfferCounter() bool {
 // Uses Succ() for efficient O(log n) ordered traversal of book directories.
 // Follows IndexNext chains through multi-page directories at each quality level.
 // Reference: rippled OfferStream::step() + BookTip::step()
-func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSandbox, ofrsToRm map[[32]byte]bool, visited map[[32]byte]bool) (*state.LedgerOffer, [32]byte, error) {
+func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSandbox, ofrsToRm map[[32]byte]bool, visited map[[32]byte]bool, enforceQualityBound bool) (*state.LedgerOffer, [32]byte, error) {
 	bookBase := s.bookBaseKey()
 	bookPrefix := bookBase[:24]
 
@@ -45,13 +45,17 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 			return nil, [32]byte{}, nil
 		}
 
-		// Bound the offer-crossing book walk by the taker's quality limit.
-		// Book directory pages are quality-ordered, so once a page's quality is
-		// worse than the limit, this and every later page are beyond it. rippled's
-		// offer crossing never advances the BookTip past the threshold, so it never
-		// crosses — nor removes (expired/unfunded) — offers beyond the limit. Only
-		// offer crossing sets qualityLimit (payments leave it nil and walk fully).
-		if s.qualityLimit != nil {
+		// Bound the offer-crossing book walk by the taker's quality limit, but
+		// only before any offer has been crossed in this pass (enforceQualityBound).
+		// rippled's forEachOffer stops at the first beyond-limit (or AMM-beaten)
+		// tip and crosses nothing; but after a cross its do-while keeps calling
+		// offers.step(), which removes offers left unfunded/expired by the cross as
+		// it advances and only stops at the next *funded* tip that fails the quality
+		// threshold. So a beyond-limit unfunded offer reached after a cross must
+		// still be removed; stopping unconditionally here would leave it (e.g. a
+		// second offer of an owner the first cross drained). Only offer crossing
+		// sets qualityLimit (payments leave it nil and walk fully).
+		if enforceQualityBound && s.qualityLimit != nil {
 			pageQ := QualityFromKey(foundKey)
 			if pageQ.WorseThan(*s.qualityLimit) {
 				return nil, [32]byte{}, nil

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -247,6 +247,35 @@ func (s *BookStep) isFoundPermGroomable(sb, afView *PaymentSandbox, offer *state
 	return false
 }
 
+// isBecameGroomableAgainst reports whether the trailing offer is a BECAME
+// removal (unfunded or tiny) when its owner's funds are read from baseView — the
+// flow's iteration base, i.e. the state after all PRIOR iterations but before
+// the current strand pass's consumption — yet was funded before this whole flow
+// ran (pristine afView). This is rippled's OfferStream::step grooming a became-
+// unfunded/became-tiny offer the cross advances over: its owner was drained by
+// an earlier cross, so the offer is genuinely gone, but it is a conditional (not
+// perm) removal. Reading from baseView rather than the working sandbox is what
+// distinguishes a truly-drained owner from one the current over-walk merely
+// over-consumed (whose drain a limiting reset discards), matching the offers
+// rippled actually deletes. The found cases (unfunded/tiny in pristine afView
+// too) are handled separately by isFoundPermGroomable, so this returns false for
+// them to avoid double-classifying a perm removal as conditional.
+func (s *BookStep) isBecameGroomableAgainst(baseView, afView *PaymentSandbox, offer *state.LedgerOffer) bool {
+	fundsBase := s.getOfferFundedAmount(baseView, offer)
+	fundsAf := s.getOfferFundedAmount(afView, offer)
+	if fundsBase.IsZero() {
+		// Unfunded in the iteration base; a BECAME removal only if it was funded
+		// pre-flow (otherwise isFoundPermGroomable already handles the found case).
+		return !fundsAf.IsZero()
+	}
+	if s.shouldRmSmallIncreasedQOffer(baseView, offer, fundsBase) {
+		// Tiny in the iteration base; a BECAME-tiny removal only if its pre-flow
+		// funds differ (a found-tiny offer is the perm case handled elsewhere).
+		return fundsAf.Compare(fundsBase) != 0
+	}
+	return false
+}
+
 // tipFullyConsumed reports whether the offer just consumed by the callback is now
 // fully consumed, mirroring rippled's offer.fully_consumed() (no funds can flow
 // through it: remaining in or out <= 0). consumeOffer updates the CLOB offer's

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -142,6 +142,7 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 					if ofrsToRm != nil {
 						ofrsToRm[offerKey] = true
 					}
+					s.recordPermRm(offerKey)
 					continue
 				}
 
@@ -156,6 +157,7 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 				if offer.DomainID != zeroDomainID {
 					if !permissioneddomain.OfferInDomain(sb, offer, offer.DomainID, s.parentCloseTime) {
 						ofrsToRm[offerKey] = true
+						s.recordPermRm(offerKey)
 						continue
 					}
 				}

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -112,24 +112,6 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 					continue
 				}
 
-				// Autobridge self-payment: in offer crossing, an offer whose owner
-				// is the strand destination and whose previous step is a BookStep
-				// (the XRP-bridge second leg) would deliver the destination its own
-				// asset — a self-payment that nets to zero, providing no real
-				// liquidity. rippled keeps it out of the consumed book (the offer is
-				// left untouched), falling back to the AMM/next offer; skip it here
-				// without removal so the same liquidity is consumed.
-				if s.offerCrossing {
-					if _, prevIsBook := s.prevStep.(*BookStep); prevIsBook {
-						if ownerID, derr := state.DecodeAccountID(offer.Account); derr == nil && ownerID == s.strandDst {
-							if visited != nil {
-								visited[offerKey] = true
-							}
-							continue
-						}
-					}
-				}
-
 				// Check offer expiration
 				// Reference: rippled OfferStream.cpp lines 256-265
 				if s.parentCloseTime > 0 && offer.Expiration > 0 &&

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -99,6 +99,24 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 					continue
 				}
 
+				// Autobridge self-payment: in offer crossing, an offer whose owner
+				// is the strand destination and whose previous step is a BookStep
+				// (the XRP-bridge second leg) would deliver the destination its own
+				// asset — a self-payment that nets to zero, providing no real
+				// liquidity. rippled keeps it out of the consumed book (the offer is
+				// left untouched), falling back to the AMM/next offer; skip it here
+				// without removal so the same liquidity is consumed.
+				if s.offerCrossing {
+					if _, prevIsBook := s.prevStep.(*BookStep); prevIsBook {
+						if ownerID, derr := state.DecodeAccountID(offer.Account); derr == nil && ownerID == s.strandDst {
+							if visited != nil {
+								visited[offerKey] = true
+							}
+							continue
+						}
+					}
+				}
+
 				// Check offer expiration
 				// Reference: rippled OfferStream.cpp lines 256-265
 				if s.parentCloseTime > 0 && offer.Expiration > 0 &&

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -247,6 +247,23 @@ func (s *BookStep) isFoundPermGroomable(sb, afView *PaymentSandbox, offer *state
 	return false
 }
 
+// tipFullyConsumed reports whether the offer just consumed by the callback is now
+// fully consumed, mirroring rippled's offer.fully_consumed() (no funds can flow
+// through it: remaining in or out <= 0). consumeOffer updates the CLOB offer's
+// TakerPays/TakerGets in place, so this reads the post-consume amounts; AMM
+// offers track the flag directly. This is the partial-take return value of
+// rippled's eachOffer, which decides whether the do-while steps again to groom
+// trailing offers.
+// Reference: rippled Offer.h fully_consumed() / AMMOffer.h fully_consumed();
+// BookStep.cpp eachOffer return (rev line 1080, fwd line 1252).
+func (s *BookStep) tipFullyConsumed(e offerExec) bool {
+	if e.isAMM {
+		return e.ammOffer.FullyConsumed()
+	}
+	return s.offerTakerPays(e.clobOffer).IsZero() ||
+		s.offerTakerGets(e.clobOffer).IsZero()
+}
+
 // eraseDanglingOffer removes a stale index from a book directory page whose
 // offer SLE no longer exists, mirroring rippled's OfferStream::erase. It
 // rewrites the page's sfIndexes in place rather than calling DirRemove, leaving

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -406,6 +406,16 @@ func (s *BookStep) getOfferFundedAmount(sb *PaymentSandbox, offer *state.LedgerO
 
 	ownerBalance := s.getIOUBalance(sb, offerOwner, issuer, currency)
 
+	// Subtract deferred credits so self-cross round-trips net to zero, matching
+	// rippled accountHolds() which returns view.balanceHook(account, issuer, amount)
+	// for IOU exactly as the XRP branch above already does for XRP. Without this an
+	// offer owner that is also the strand destination (e.g. an autobridge self-cross)
+	// funds its offer from its full balance and over-delivers liquidity that rippled
+	// correctly nets to zero. Reference: rippled ledger/detail/View.cpp accountHolds().
+	if offerOwner != issuer {
+		ownerBalance = NewIOUEitherAmount(sb.BalanceHook(offerOwner, issuer, ownerBalance.IOU))
+	}
+
 	if ownerBalance.IsNegative() || ownerBalance.IsZero() {
 		if offerOwner == issuer {
 			return offerTakerGets

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -45,6 +45,19 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 			return nil, [32]byte{}, nil
 		}
 
+		// Bound the offer-crossing book walk by the taker's quality limit.
+		// Book directory pages are quality-ordered, so once a page's quality is
+		// worse than the limit, this and every later page are beyond it. rippled's
+		// offer crossing never advances the BookTip past the threshold, so it never
+		// crosses — nor removes (expired/unfunded) — offers beyond the limit. Only
+		// offer crossing sets qualityLimit (payments leave it nil and walk fully).
+		if s.qualityLimit != nil {
+			pageQ := QualityFromKey(foundKey)
+			if pageQ.WorseThan(*s.qualityLimit) {
+				return nil, [32]byte{}, nil
+			}
+		}
+
 		// Iterate through all pages of this directory (root + linked pages)
 		dir, err := state.ParseDirectoryNode(foundData)
 		if err != nil {

--- a/internal/tx/payment/step_book_quality.go
+++ b/internal/tx/payment/step_book_quality.go
@@ -148,12 +148,15 @@ func (s *BookStep) tipOfferQualityF(sb *PaymentSandbox) *QualityFunction {
 // Reference: rippled BookOfferCrossingStep::qualityThreshold() lines 479-486
 // Reference: rippled BookPaymentStep::qualityThreshold() line 305
 func (s *BookStep) tipQualityThreshold(lobQuality Quality) *Quality {
-	// For offer crossing with AMM in single-path mode:
-	// if qualityLimit is strictly better than lobQuality, return nil
-	// so AMM generates its max offer (limitOut handles the quality cap)
-	if s.qualityLimit != nil && s.ammLiquidity != nil &&
+	// rippled BookOfferCrossingStep::qualityThreshold(lobQuality): when the
+	// crossing step has a single-path AMM and the taker's crossing threshold is
+	// strictly better than the LOB tip, return nullopt so the AMM generates its
+	// max offer (limitOut then caps the quality). This uses qualityThreshold_,
+	// which is set on every crossing step — direct and autobridge legs — not the
+	// default-path-gated per-offer quality bound. Payments leave crossLimit nil.
+	if s.crossLimit != nil && s.ammLiquidity != nil &&
 		!s.ammLiquidity.ammContext.MultiPath() &&
-		s.qualityLimit.BetterThan(lobQuality) {
+		s.crossLimit.BetterThan(lobQuality) {
 		return nil
 	}
 	q := lobQuality

--- a/internal/tx/payment/step_direct.go
+++ b/internal/tx/payment/step_direct.go
@@ -318,11 +318,17 @@ func (s *DirectStepI) DebtDirection(sb *PaymentSandbox, dir StrandDirection) Deb
 
 // QualityUpperBound returns the worst-case quality for this step
 func (s *DirectStepI) QualityUpperBound(v *PaymentSandbox, prevStepDir DebtDirection) (*Quality, DebtDirection) {
-	// Offer crossing: quality is always 1.0 (identity rate)
-	// Reference: rippled DirectIOfferCrossingStep::quality() → Quality{STAmount::uRateOne}
+	// Offer crossing: the quality is the identity rate (1.0), but the returned
+	// debt direction must be this step's actual direction. rippled's
+	// DirectStepI::qualityUpperBound returns debtDirection(v, forward) for every
+	// variant — DirectIOfferCrossingStep overrides quality(), not qualityUpperBound
+	// or debtDirection. Returning Issues here drops the next step's input transfer
+	// rate from the composed QualityFunction used by limitOut, so a quality-limited
+	// AMM cross over a transfer-fee input is sized as if the fee were free and then
+	// rejected for landing just below the taker's limit.
 	if s.offerCrossing {
 		q := qualityOne
-		return &q, DebtDirectionIssues
+		return &q, s.DebtDirection(v, StrandDirectionForward)
 	}
 
 	srcDebtDir := s.DebtDirection(v, StrandDirectionForward)

--- a/internal/tx/payment/strand_flow.go
+++ b/internal/tx/payment/strand_flow.go
@@ -144,26 +144,10 @@ func ExecuteStrand(
 	for i := s - 1; i >= 0; i-- {
 		step := strand[i]
 
-		// Snapshot the offers-to-remove set before this step's (possibly
-		// over-extended) reverse walk. When this step turns out to be the
-		// limiting step it is reset and re-executed with a smaller output, which
-		// walks fewer offers; offers the discarded over-walk removed beyond the
-		// limited output must not persist (rippled does not remove offers a
-		// re-executed limiting step never reaches). restoreRmAfterReset() drops
-		// any removal this step's over-walk added, so only the re-execution's
-		// removals survive.
-		rmBefore := make(map[[32]byte]bool, len(ofrsToRm))
-		for k := range ofrsToRm {
-			rmBefore[k] = true
-		}
-		restoreRmAfterReset := func() {
-			for k := range ofrsToRm {
-				if !rmBefore[k] {
-					delete(ofrsToRm, k)
-				}
-			}
-		}
-
+		// Only the execution sandbox is reset on a limiting step; the offers-to-
+		// remove set accumulates monotonically across resets, matching rippled's
+		// flow() which re-emplaces sb/afView but never prunes the removal union
+		// (StrandFlow.h:152,184-185,698; BookStep.cpp revImp SetUnion at :1094).
 		actualIn, actualOut := step.Rev(sb, afView, ofrsToRm, stepOut)
 
 		// Check if output is zero → strand is dry
@@ -176,7 +160,6 @@ func ExecuteStrand(
 			// Reset sandbox and re-execute step 0 with Fwd(maxIn)
 			// Reference: rippled StrandFlow.h lines 148-178
 			sb.Reset()
-			restoreRmAfterReset()
 			limitingStep = 0
 
 			fwdIn, fwdOut := step.Fwd(sb, afView, ofrsToRm, *maxIn)
@@ -200,7 +183,6 @@ func ExecuteStrand(
 			// Reset BOTH sandboxes and re-execute ONLY this step
 			// Reference: rippled StrandFlow.h lines 180-217
 			sb.Reset()
-			restoreRmAfterReset()
 			limitingStep = i
 
 			// Re-execute with the limited output

--- a/internal/tx/payment/strand_flow.go
+++ b/internal/tx/payment/strand_flow.go
@@ -81,12 +81,16 @@ func strandPermRemovals(strand Strand, dst map[[32]byte]bool) {
 // (e.g., trust lines that increase reserves) that would poison earlier steps
 // if not reset.
 //
+// afBaseView is the pristine pre-flow baseline used for the found-vs-became
+// removal test (see the afView comment below); pass nil to fall back to baseView.
+//
 // Reference: rippled/src/xrpld/app/paths/detail/StrandFlow.h flow()
 func ExecuteStrand(
 	baseView *PaymentSandbox,
 	strand Strand,
 	maxIn *EitherAmount,
 	requestedOut EitherAmount,
+	afBaseView *PaymentSandbox,
 ) (result StrandResult) {
 	if len(strand) == 0 {
 		return StrandResult{
@@ -183,10 +187,17 @@ func ExecuteStrand(
 	// Reference: rippled StrandFlow.h line 130: size_t limitingStep = strand.size()
 	limitingStep := s
 	sb := NewChildSandbox(baseView)
-	// afView: "all funds" view — determines if offers are unfunded
-	// In rippled, this is a separate child of baseView that can be reset.
-	// We use baseView directly since we never modify it.
+	// afView: the "all funds" view that tells a FOUND removal (an offer already
+	// unfunded/tiny before the flow ran) from a BECAME removal (one this flow's
+	// crossing drained). The caller threads afBaseView — a child of the pristine
+	// pre-flow view that the per-pass applies never touch — so the found-vs-became
+	// test stays anchored to pre-flow funds across a multi-pass crossing. When no
+	// such baseline is supplied (unit tests, single-pass callers), afView falls
+	// back to baseView, which the strand never modifies.
 	afView := baseView
+	if afBaseView != nil {
+		afView = afBaseView
+	}
 	var limitStepOut EitherAmount
 
 	// === REVERSE PASS ===

--- a/internal/tx/payment/strand_flow.go
+++ b/internal/tx/payment/strand_flow.go
@@ -144,6 +144,26 @@ func ExecuteStrand(
 	for i := s - 1; i >= 0; i-- {
 		step := strand[i]
 
+		// Snapshot the offers-to-remove set before this step's (possibly
+		// over-extended) reverse walk. When this step turns out to be the
+		// limiting step it is reset and re-executed with a smaller output, which
+		// walks fewer offers; offers the discarded over-walk removed beyond the
+		// limited output must not persist (rippled does not remove offers a
+		// re-executed limiting step never reaches). restoreRmAfterReset() drops
+		// any removal this step's over-walk added, so only the re-execution's
+		// removals survive.
+		rmBefore := make(map[[32]byte]bool, len(ofrsToRm))
+		for k := range ofrsToRm {
+			rmBefore[k] = true
+		}
+		restoreRmAfterReset := func() {
+			for k := range ofrsToRm {
+				if !rmBefore[k] {
+					delete(ofrsToRm, k)
+				}
+			}
+		}
+
 		actualIn, actualOut := step.Rev(sb, afView, ofrsToRm, stepOut)
 
 		// Check if output is zero → strand is dry
@@ -156,6 +176,7 @@ func ExecuteStrand(
 			// Reset sandbox and re-execute step 0 with Fwd(maxIn)
 			// Reference: rippled StrandFlow.h lines 148-178
 			sb.Reset()
+			restoreRmAfterReset()
 			limitingStep = 0
 
 			fwdIn, fwdOut := step.Fwd(sb, afView, ofrsToRm, *maxIn)
@@ -179,6 +200,7 @@ func ExecuteStrand(
 			// Reset BOTH sandboxes and re-execute ONLY this step
 			// Reference: rippled StrandFlow.h lines 180-217
 			sb.Reset()
+			restoreRmAfterReset()
 			limitingStep = i
 
 			// Re-execute with the limited output

--- a/internal/tx/payment/strand_flow.go
+++ b/internal/tx/payment/strand_flow.go
@@ -47,6 +47,26 @@ func strandOffersUsed(strand Strand) uint32 {
 	return n
 }
 
+// strandPermRemovals unions every BookStep's unconditional ("perm") removals in
+// the strand. These are rippled's FlowOfferStream::permToRemove offers
+// (self-crossed, authorization-failed, expired, deep-frozen, domain-removed,
+// found-unfunded, and found-tiny). Only this perm subset propagates out of the
+// flow as removableOffers; "became unfunded" / "became tiny" offers are deleted
+// in-band from the working sandbox but are not returned for re-erasure on a
+// discarded (FillOrKill/IoC-kill) crossing. Reference: rippled OfferStream.h
+// permToRemove_; StrandFlow.h ofrsToRmOnFail = union of strand f.ofrsToRm.
+func strandPermRemovals(strand Strand, dst map[[32]byte]bool) {
+	for _, step := range strand {
+		bs, ok := step.(*BookStep)
+		if !ok {
+			continue
+		}
+		for k := range bs.PermRemovals() {
+			dst[k] = true
+		}
+	}
+}
+
 // ExecuteStrand executes a strand using the two-pass algorithm matching rippled's
 // StrandFlow.h flow() function.
 //

--- a/internal/tx/payment/strand_flow.go
+++ b/internal/tx/payment/strand_flow.go
@@ -141,17 +141,25 @@ func ExecuteStrand(
 	// Reference: rippled StrandFlow.h lines 138-221
 	stepOut := requestedOut
 
+	// deferredDiscard maps each offer a limiting step removed during its
+	// over-extended reverse walk to the strand index of that step. Whether the
+	// removal survives depends on what ultimately limited the strand:
+	//   - if a step closer to the input (lower index) limited further
+	//     (limitingStep < recorded index), the over-walk requested more output
+	//     than the input could buy, so those extra offers were never really
+	//     reached — their removals are spurious and stay discarded.
+	//   - otherwise the recording step is itself the final limiting step: the
+	//     offers were genuinely reached and their owners drained by the actual
+	//     cross, so rippled removes them — the removals must be restored.
+	deferredDiscard := make(map[[32]byte]int)
+
 	for i := s - 1; i >= 0; i-- {
 		step := strand[i]
 
 		// Snapshot the offers-to-remove set before this step's (possibly
-		// over-extended) reverse walk. When this step turns out to be the
-		// limiting step it is reset and re-executed with a smaller output, which
-		// walks fewer offers; offers the discarded over-walk removed beyond the
-		// limited output must not persist (rippled does not remove offers a
-		// re-executed limiting step never reaches). restoreRmAfterReset() drops
-		// any removal this step's over-walk added, so only the re-execution's
-		// removals survive.
+		// over-extended) reverse walk, so a limiting-step reset can drop the
+		// removals the over-walk added; see maxInCapped/deferredDiscard above for
+		// when those are later restored.
 		rmBefore := make(map[[32]byte]bool, len(ofrsToRm))
 		for k := range ofrsToRm {
 			rmBefore[k] = true
@@ -200,6 +208,11 @@ func ExecuteStrand(
 			// Reset BOTH sandboxes and re-execute ONLY this step
 			// Reference: rippled StrandFlow.h lines 180-217
 			sb.Reset()
+			for k := range ofrsToRm {
+				if !rmBefore[k] {
+					deferredDiscard[k] = i
+				}
+			}
 			restoreRmAfterReset()
 			limitingStep = i
 
@@ -227,6 +240,16 @@ func ExecuteStrand(
 		} else {
 			// Not limiting — continue to previous step
 			stepOut = actualIn
+		}
+	}
+
+	// Restore a deferred over-walk removal only when its recording step is the
+	// final limiting step (no lower-index step reduced the throughput further).
+	// If a step closer to the input limited more (limitingStep < idx), the cross
+	// never actually reached that offer, so the removal stays discarded.
+	for k, idx := range deferredDiscard {
+		if limitingStep >= idx {
+			ofrsToRm[k] = true
 		}
 	}
 

--- a/internal/tx/payment/strand_flow.go
+++ b/internal/tx/payment/strand_flow.go
@@ -98,6 +98,16 @@ func ExecuteStrand(
 			if _, ok := r.(flowError); !ok {
 				panic(r)
 			}
+			// Keep unconditional ("perm") removals even on a flow exception —
+			// rippled's permToRemove survives "even if the strand is not
+			// applied". Reference: rippled OfferStream.h permToRemove_.
+			for _, step := range strand {
+				if bs, ok := step.(*BookStep); ok {
+					for k := range bs.PermRemovals() {
+						ofrsToRm[k] = true
+					}
+				}
+			}
 			result = StrandResult{
 				Success:    false,
 				In:         ZeroXRPEitherAmount(),
@@ -110,11 +120,34 @@ func ExecuteStrand(
 		}
 	}()
 
+	// restorePermRemovals unions every BookStep's unconditional ("perm")
+	// removals back into ofrsToRm. These are rippled's FlowOfferStream
+	// permToRemove offers (self-crossed, authorization-failed, expired,
+	// deep-frozen, domain-removed) which survive "even if the strand is not
+	// applied" and are never rolled back by a limiting-step reset. A reset's
+	// over-walk discard (deferredDiscard) targets only "became unfunded"
+	// removals; calling this afterwards guarantees a perm removal a discarded
+	// over-walk produced is kept, matching rippled's monotonic permToRemove.
+	// Reference: rippled OfferStream.h permToRemove_; StrandFlow.h (ofrsToRm is
+	// passed by reference into every rev/fwd and never reset).
+	restorePermRemovals := func() {
+		for _, step := range strand {
+			bs, ok := step.(*BookStep)
+			if !ok {
+				continue
+			}
+			for k := range bs.PermRemovals() {
+				ofrsToRm[k] = true
+			}
+		}
+	}
+
 	// failStrand returns the failed-strand result rippled produces when it
 	// returns Result{strand, ofrsToRm}: success=false, zero in/out, the
 	// offers-to-remove preserved, and inactive. Used for dry strands and for
 	// the re-execution consistency guards below.
 	failStrand := func() StrandResult {
+		restorePermRemovals()
 		return StrandResult{
 			Success:    false,
 			In:         ZeroXRPEitherAmount(),
@@ -298,6 +331,8 @@ func ExecuteStrand(
 			inactive = true
 		}
 	}
+
+	restorePermRemovals()
 
 	return StrandResult{
 		Success:    true,

--- a/internal/tx/payment/strand_flow_test.go
+++ b/internal/tx/payment/strand_flow_test.go
@@ -98,7 +98,7 @@ func TestExecuteStrand_FlowErrorDiscardsPhantomTotals(t *testing.T) {
 		},
 	}
 
-	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000))
+	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000), nil)
 
 	require.False(t, result.Success, "strand must fail on flowError, not return phantom totals")
 	require.True(t, result.Out.IsZero(), "failed strand must report zero output")
@@ -121,7 +121,7 @@ func TestExecuteStrand_NonFlowErrorPanicPropagates(t *testing.T) {
 	}
 
 	require.PanicsWithValue(t, "genuine bug, not a flowError", func() {
-		ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000))
+		ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000), nil)
 	})
 }
 
@@ -142,7 +142,7 @@ func TestExecuteStrand_DryStrandReportsOffersUsed(t *testing.T) {
 		},
 	}
 
-	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000))
+	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000), nil)
 
 	require.False(t, result.Success, "dry strand must fail")
 	require.Equal(t, uint32(7), result.OffersUsed, "dry strand must report offers its steps consumed")
@@ -164,7 +164,7 @@ func TestExecuteStrand_FlowErrorReportsOffersUsed(t *testing.T) {
 		},
 	}
 
-	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000))
+	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000), nil)
 
 	require.False(t, result.Success, "flowError strand must fail")
 	require.Equal(t, uint32(4), result.OffersUsed, "flowError strand must report offers its steps consumed")
@@ -261,7 +261,7 @@ func TestExecuteStrand_FirstStepMaxInGuard(t *testing.T) {
 		},
 	}
 
-	result := ExecuteStrand(sandbox, Strand{step}, &maxIn, NewXRPEitherAmount(20_000_000))
+	result := ExecuteStrand(sandbox, Strand{step}, &maxIn, NewXRPEitherAmount(20_000_000), nil)
 
 	require.False(t, result.Success, "first-step maxIn mismatch must fail the strand")
 	require.True(t, result.Out.IsZero())
@@ -288,7 +288,7 @@ func TestExecuteStrand_LimitingStepGuard(t *testing.T) {
 		},
 	}
 
-	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000))
+	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000), nil)
 
 	require.False(t, result.Success, "limiting-step re-execution mismatch must fail the strand")
 	require.True(t, result.Out.IsZero())
@@ -321,7 +321,7 @@ func TestExecuteStrand_ForwardPassGuard(t *testing.T) {
 		},
 	}
 
-	result := ExecuteStrand(sandbox, Strand{step0, step1}, nil, NewXRPEitherAmount(10_000_000))
+	result := ExecuteStrand(sandbox, Strand{step0, step1}, nil, NewXRPEitherAmount(10_000_000), nil)
 
 	require.False(t, result.Success, "forward-pass re-execution mismatch must fail the strand")
 	require.True(t, result.Out.IsZero())

--- a/internal/tx/payment/strand_flow_test.go
+++ b/internal/tx/payment/strand_flow_test.go
@@ -187,7 +187,7 @@ func TestFlow_DryStrandOffersConsideredReachesCap(t *testing.T) {
 	strands := []Strand{{step}}
 
 	// FlowSortStrands enabled so offersConsidered >= maxOffersToConsider breaks.
-	result := Flow(sandbox, strands, NewXRPEitherAmount(10_000_000), false, nil, nil, nil, true)
+	result := Flow(sandbox, strands, NewXRPEitherAmount(10_000_000), false, nil, nil, nil, true, false)
 
 	require.True(t, result.Out.IsZero(), "dry strand delivers nothing")
 	require.Equal(t, ter.TecPATH_PARTIAL, result.Result, "non-partial payment with no delivery is tecPATH_PARTIAL")
@@ -210,7 +210,7 @@ func TestFlow_MaxTriesFailedProcessing(t *testing.T) {
 	}
 	strands := []Strand{{step}}
 
-	result := Flow(sandbox, strands, NewXRPEitherAmount(10_000_000), true, nil, nil, nil, false)
+	result := Flow(sandbox, strands, NewXRPEitherAmount(10_000_000), true, nil, nil, nil, false, false)
 
 	require.Equal(t, ter.TelFAILED_PROCESSING, result.Result, "loop must bail with telFAILED_PROCESSING after maxTries")
 }
@@ -232,7 +232,7 @@ func TestFlow_OverDeliveryTefException(t *testing.T) {
 	}
 	strands := []Strand{{step}}
 
-	result := Flow(sandbox, strands, NewXRPEitherAmount(10_000_000), false, nil, nil, nil, false)
+	result := Flow(sandbox, strands, NewXRPEitherAmount(10_000_000), false, nil, nil, nil, false, false)
 
 	require.Equal(t, ter.TefEXCEPTION, result.Result, "over-delivery must surface tefEXCEPTION")
 	require.True(t, result.Out.IsZero(), "tefEXCEPTION discards delivered output")

--- a/internal/tx/trustset/trustset.go
+++ b/internal/tx/trustset/trustset.go
@@ -621,6 +621,28 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) ter.Result {
 				return ter.TefBAD_LEDGER
 			}
 
+			// Clear the reserve flag(s) for the side(s) returning to default, matching
+			// rippled SetTrust (uFlagsOut &= ~lsfLowReserve / ~lsfHighReserve) — the
+			// owner-count decrement below already mirrors adjustOwnerCount(-1).
+			if bLowReserved {
+				rs.Flags &^= state.LsfLowReserve
+			}
+			if bHighReserved {
+				rs.Flags &^= state.LsfHighReserve
+			}
+
+			// Persist the trust line's field changes (limit/flags/quality) before
+			// erasing it, so the DeletedNode metadata carries them (FinalFields and
+			// PreviousFields). Matches rippled SetTrust, which sets the fields on the
+			// SLE before trustDelete().
+			modifiedData, serErr := state.SerializeRippleState(rs)
+			if serErr != nil {
+				return ter.TefINTERNAL
+			}
+			if err := ctx.View.Update(trustLineKey, modifiedData); err != nil {
+				return ter.TefINTERNAL
+			}
+
 			if err := ctx.View.Erase(trustLineKey); err != nil {
 				return ter.TefINTERNAL
 			}

--- a/internal/tx/utils.go
+++ b/internal/tx/utils.go
@@ -377,6 +377,16 @@ func LPTokenFrozenForIssuer(view LedgerView, accountID, issuerID [20]byte) LPTok
 	return LPTokenNotFrozen
 }
 
+// ownerCountReadHookView is the optional read-side owner-count hook a view may
+// implement. It mirrors rippled's virtual ReadView::ownerCountHook, which is a
+// no-op on the base view (returns the count unchanged) and is overridden by the
+// PaymentSandbox to return the maximum owner count seen so far during a payment.
+// This prevents an account from using reserve freed by objects it deleted
+// earlier in the same transaction.
+type ownerCountReadHookView interface {
+	OwnerCountHook(account [20]byte, count uint32) uint32
+}
+
 // XRPLiquid returns the amount of XRP an account can spend (balance minus reserve).
 // Reference: rippled ledger/View.cpp xrpLiquid()
 // ownerCountAdj allows adjusting the owner count (e.g., +1 to account for a pending new object).
@@ -386,8 +396,13 @@ func XRPLiquid(view LedgerView, accountID [20]byte, ownerCountAdj int64, reserve
 		return NewXRPAmount(0)
 	}
 
-	ownerCount := max(int64(account.OwnerCount)+ownerCountAdj, 0)
-	reserve := reserveBase + uint64(ownerCount)*reserveIncrement
+	ownerCount := account.OwnerCount
+	if h, ok := view.(ownerCountReadHookView); ok {
+		ownerCount = h.OwnerCountHook(accountID, ownerCount)
+	}
+
+	confinedOwnerCount := max(int64(ownerCount)+ownerCountAdj, 0)
+	reserve := reserveBase + uint64(confinedOwnerCount)*reserveIncrement
 	if account.Balance > reserve {
 		return NewXRPAmount(int64(account.Balance - reserve))
 	}


### PR DESCRIPTION
Fixes for mainnet-replay divergences (range 99226371–99236370), each verified byte-exact (ledger/account/transaction hash) against mainnet and grounded in **rippled 2.6.2** — including a rippled 2.6.2 standalone **1:1 oracle** of the exact intra-ledger state for the hardest case.

**Status:** ledgers **99226371–99226499** replay byte-for-byte (129 consecutive blocks) and counting.

| block | issue | commit | fix |
|---|---|---|---|
| 99226388 | #1024 | `0a6746a4` | TrustSet trust-line deletion: persist fields + clear lsfLowReserve before erase |
| 99226412 (tx 10) | #1025 | `2c5b587b` | Set ParentCloseTime in replay engine configs (AMM auction-slot fee + escrow/credential expiry) |
| 99226412 (tx 65–76) | #1027 | `e87cc2c6` | Apply BalanceHook to IOU offer funding (self-cross deferred-credit netting) |
| 99226412 (tx 64) | #1027 | `93098e0d` | Skip autobridge self-payment offers (owner==strandDst && prevStep is BookStep) in offer crossing |
| 99226414 (tx 8) | #1028 | `d2d4ebc2` | Bound offer-crossing book walk by the taker quality limit (stop at first beyond-limit page) |
| 99226431 (tx 76) | #1029 | `3b501c1c` | Discard a limiting step's over-walk offer removals on reset |
| 99226438 (tx 37/38) | #1030 | `f6f1dd1f` | QualityFunction uses Number arithmetic (rippled rounding) for AMM quality-limited swaps |
| 99226442 (tx 32) | #1031 | `fd0199a9` | Preserve case of lowercase 3-char currency codes in tx metadata |
| 99226449 (tx 33) | #1032 | `2e1a67e5` | DirectStepI.QualityUpperBound returns actual debt direction (offer-crossing AMM under-cross) |
| 99226455 (tx 69) | #1033 | `603714da` | AccountDelete records DeliveredAmount in metadata |
| 99226495 (tx 64) | #1034 | `cde324c5` | AMMWithdraw persists zeroed LP-token trust line before deleting (metadata) |

Closes #1024
Closes #1025
Closes #1027
Closes #1028
Closes #1029
Closes #1030
Closes #1031
Closes #1032
Closes #1033
Closes #1034



🤖 Generated with [Claude Code](https://claude.com/claude-code)







