### PR TITLE
docs: clarify fetch-pack capped-tree comments

### DIFF
--- a/internal/consensus/adaptor/ledger_provider.go
+++ b/internal/consensus/adaptor/ledger_provider.go
@@ -173,10 +173,12 @@ func (p *LedgerProvider) GetReplayDelta(ledgerHash []byte) ([]byte, [][]byte, er
 }
 
 // fetchPackMaxObjects caps the SHAMap nodes a single fetch-pack reply carries.
-// go-xrpl packs a single ledger's FULL state+tx tree (it has no node-hash
-// store to let a receiver supply un-sent shared nodes — see
-// shamap.SHAMap.WalkFetchPackNodes), so the cap is sized to cover a moderate
-// ledger's tree in one pack while still bounding the reply.
+// Unlike rippled's have-diff, go-xrpl sends the want ledger's whole state+tx
+// tree — its acquisition SHAMap has no node-hash store to supply un-sent shared
+// nodes (see shamap.SHAMap.WalkFetchPackNodes). The cap bounds the reply: a
+// moderate ledger fits in one pack, while a large (mainnet-scale) tree is
+// truncated to a root-first connected prefix and the receiver completes the
+// remainder via ordinary node-by-hash requests.
 const fetchPackMaxObjects = 12288
 
 // MakeFetchPack builds a fetch-pack for the parent of the ledger named by

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -203,7 +203,8 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 			// Build a pack of the predecessor ledger's SHAMap nodes and
 			// reply (serveFetchPack), mirroring makeFetchPack. Offloaded
 			// to the serve-worker pool — building a pack snapshots the
-			// full state+tx tree and must not run on the event loop.
+			// state+tx tree (capped at fetchPackMaxObjects nodes) and
+			// must not run on the event loop.
 			o.submitServe(func() { o.serveFetchPack(evt.PeerID, gob) })
 			return
 		case message.ObjectTypeTransactions:
@@ -268,7 +269,7 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 // taken by serveDoTransactions and only charge a malformed hash there). A valid
 // request is charged feeHeavyBurdenPeer up front, mirroring rippled's
 // doFetchPack (PeerImp.cpp:2773): building a pack snapshots the want ledger's
-// full state+tx tree and walks up to fetchPackMaxObjects nodes — heavier than
+// state+tx tree and walks up to fetchPackMaxObjects nodes — heavier than
 // rippled's diff. go-xrpl builds the pack inline (no jtPACK job queue to bound),
 // so the send-queue back-pressure gate in handleGetObjectsMessage stands in for
 // rippled's isLoadedLocal / jtPACK busy guards (PeerImp.cpp:2758-2762).


### PR DESCRIPTION
## Summary

- Corrects the fetch-pack serve comments that claimed go-xrpl packs "a single ledger's **FULL** state+tx tree". A single fetch-pack reply is capped at `fetchPackMaxObjects` (12288) nodes, so at mainnet scale the pack is a root-first **connected prefix**, not the whole tree.
- `internal/consensus/adaptor/ledger_provider.go` — rewrites the `fetchPackMaxObjects` doc comment to describe the cap, the truncation-to-prefix behavior, and that the receiver completes the remainder via ordinary node-by-hash requests (graceful degradation).
- `internal/peermanagement/inbound_handlers.go` — fixes the two "full state+tx tree" phrasings at the serve-offload and `serveFetchPack` sites to reflect the cap.

This implements the issue's own suggested fix ("correct the misleading comments to describe the cap and prefix behavior accurately"). `shamap/fetchpack.go` already documents the prefix/truncation behavior accurately and is left unchanged. The longer-term enhancement (multi-pack continuation / have-diff) noted in the issue is an intentional, documented design tradeoff — go-xrpl's acquisition SHAMap has no node-hash store to supply un-sent shared nodes, so it sends the full capped tree rather than a diff — and is out of scope for this comment correction.

**Comment-only — no behavior change.**

## Test plan

- [x] `gofmt -l` clean on both files
- [x] `CGO_ENABLED=1 go build ./internal/consensus/adaptor/... ./internal/peermanagement/...` passes

Fixes #779