### PR TITLE
fix: bound fetch-pack cache via sweep, accept new nodes like rippled (#778)

### DIFF
--- a/internal/consensus/adaptor/fetchpack.go
+++ b/internal/consensus/adaptor/fetchpack.go
@@ -12,21 +12,23 @@ import (
 )
 
 const (
-	// fetchPackCacheMaxSize bounds the fetch-pack node cache.
-	fetchPackCacheMaxSize = 65536
+	// fetchPackCacheTargetSize is the fetch-pack node cache's target entry
+	// count. It is a soft target, not a hard cap: new nodes are always
+	// accepted and sweep ages entries out faster once the cache grows past it.
+	fetchPackCacheTargetSize = 65536
 	// fetchPackCacheTTL bounds how long an inbound fetch-pack node lingers.
 	fetchPackCacheTTL = 45 * time.Second
 )
 
 // fetchPackCache holds inbound fetch-pack SHAMap nodes keyed by node hash,
 // briefly, so a stalled acquisition can complete locally via
-// inbound.Ledger.CheckLocal. Bounded by entry count and a TTL; the router
-// sweeps expired entries on its maintenance tick.
+// inbound.Ledger.CheckLocal. Bounded by sweep against a target size and a TTL;
+// the router sweeps it on every maintenance tick.
 type fetchPackCache struct {
-	mu      sync.Mutex
-	nodes   map[[32]byte]fetchPackEntry
-	maxSize int
-	ttl     time.Duration
+	mu         sync.Mutex
+	nodes      map[[32]byte]fetchPackEntry
+	targetSize int
+	ttl        time.Duration
 }
 
 type fetchPackEntry struct {
@@ -36,26 +38,22 @@ type fetchPackEntry struct {
 
 func newFetchPackCache() *fetchPackCache {
 	return &fetchPackCache{
-		nodes:   make(map[[32]byte]fetchPackEntry),
-		maxSize: fetchPackCacheMaxSize,
-		ttl:     fetchPackCacheTTL,
+		nodes:      make(map[[32]byte]fetchPackEntry),
+		targetSize: fetchPackCacheTargetSize,
+		ttl:        fetchPackCacheTTL,
 	}
 }
 
-// add stores a node blob keyed by its hash, stamping it with now. Once the
-// cache is full a new key is dropped to keep the add path lock-cheap — a
-// dropped node simply isn't available for local completion and the
-// acquisition falls back to the network. Refreshing an existing key is
-// always allowed.
+// add stores a node blob keyed by its hash, stamping it with now. A new node is
+// always accepted: the cache is bounded by sweep, not by refusing entries at
+// the door, so a fresh and immediately-useful node is never dropped while the
+// cache briefly sits over its target. Refreshing an existing key restamps it.
 func (c *fetchPackCache) add(hash [32]byte, data []byte, now time.Time) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if _, ok := c.nodes[hash]; !ok && len(c.nodes) >= c.maxSize {
-		return
-	}
 	c.nodes[hash] = fetchPackEntry{data: append([]byte(nil), data...), at: now}
 }
 
@@ -78,18 +76,34 @@ func (c *fetchPackCache) get(hash [32]byte, now time.Time) ([]byte, bool) {
 	return e.data, true
 }
 
-// sweep drops every entry older than the TTL.
+// sweep drops every entry older than the effective max age. Within the target
+// size that age is the full TTL; once the cache grows past the target the age
+// shrinks in proportion to the overflow, so an oversized cache is aged out more
+// aggressively. This is how rippled's TaggedCache bounds the fetch-pack cache —
+// it accepts every node and relies on the sweep, rather than evicting at insert.
 func (c *fetchPackCache) sweep(now time.Time) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	maxAge := c.effectiveMaxAge(len(c.nodes))
 	for h, e := range c.nodes {
-		if now.Sub(e.at) > c.ttl {
+		if now.Sub(e.at) > maxAge {
 			delete(c.nodes, h)
 		}
 	}
+}
+
+// effectiveMaxAge returns the eviction age for a cache holding size entries: the
+// full TTL within the target size, shrinking proportionally past it but never
+// below one second, matching rippled's TaggedCache::sweep.
+func (c *fetchPackCache) effectiveMaxAge(size int) time.Duration {
+	if c.targetSize <= 0 || size <= c.targetSize {
+		return c.ttl
+	}
+	age := c.ttl * time.Duration(c.targetSize) / time.Duration(size)
+	return max(age, time.Second)
 }
 
 // handleFetchPackReply consumes an inbound mtGET_OBJECTS reply carrying SHAMap

--- a/internal/consensus/adaptor/fetchpack_test.go
+++ b/internal/consensus/adaptor/fetchpack_test.go
@@ -54,22 +54,48 @@ func TestFetchPackCache_Sweep(t *testing.T) {
 	}
 }
 
-func TestFetchPackCache_CapDropsNewcomers(t *testing.T) {
+func TestFetchPackCache_AcceptsNewcomersOverTarget(t *testing.T) {
 	t.Parallel()
 	c := newFetchPackCache()
-	c.maxSize = 2
+	c.targetSize = 2
 	t0 := time.Unix(1000, 0)
 	c.add([32]byte{1}, []byte{1}, t0)
 	c.add([32]byte{2}, []byte{2}, t0)
-	c.add([32]byte{3}, []byte{3}, t0) // over cap → dropped
-	require.Equal(t, 2, c.size())
-	if _, ok := c.get([32]byte{3}, t0); ok {
-		t.Error("newcomer stored over the cap")
+	c.add([32]byte{3}, []byte{3}, t0) // over target → still accepted, like rippled
+	require.Equal(t, 3, c.size(), "a fresh node must be accepted even over the target size")
+	got, ok := c.get([32]byte{3}, t0)
+	require.True(t, ok, "newcomer over target was refused")
+	require.Equal(t, byte(3), got[0])
+}
+
+func TestFetchPackCache_SweepShrinksProportionallyOverTarget(t *testing.T) {
+	t.Parallel()
+	c := newFetchPackCache()
+	c.targetSize = 2
+	t0 := time.Unix(1000, 0)
+	// Four entries against a target of 2 → effective age = ttl*2/4 = ttl/2.
+	half := c.ttl / 2
+	c.add([32]byte{1}, []byte{1}, t0)                    // age at sweep = half+1s → evicted
+	c.add([32]byte{2}, []byte{2}, t0)                    // evicted
+	c.add([32]byte{3}, []byte{3}, t0.Add(2*time.Second)) // age = half-1s → kept
+	c.add([32]byte{4}, []byte{4}, t0.Add(2*time.Second)) // kept
+	c.sweep(t0.Add(half + time.Second))
+	require.Equal(t, 2, c.size(), "oversized cache must age out entries beyond the shrunk window")
+	if _, ok := c.get([32]byte{1}, t0.Add(half+time.Second)); ok {
+		t.Error("entry past the shrunk window was not swept")
 	}
-	// Refreshing an existing key stays allowed even at the cap.
-	c.add([32]byte{1}, []byte{0xAA}, t0)
-	got, _ := c.get([32]byte{1}, t0)
-	require.Equal(t, byte(0xAA), got[0], "refresh of an existing key was rejected at cap")
+	if _, ok := c.get([32]byte{3}, t0.Add(2*time.Second)); !ok {
+		t.Error("entry within the shrunk window was swept")
+	}
+}
+
+func TestFetchPackCache_EffectiveMaxAge(t *testing.T) {
+	t.Parallel()
+	c := newFetchPackCache()
+	require.Equal(t, c.ttl, c.effectiveMaxAge(0), "empty cache ages at the full TTL")
+	require.Equal(t, c.ttl, c.effectiveMaxAge(c.targetSize), "at target ages at the full TTL")
+	require.Equal(t, c.ttl/2, c.effectiveMaxAge(2*c.targetSize), "2x over target halves the age")
+	require.Equal(t, time.Second, c.effectiveMaxAge(100*c.targetSize), "far over target floors at 1s")
 }
 
 func TestFetchPackCache_NilReceiver(t *testing.T) {


### PR DESCRIPTION
## Summary

- The fetch-pack node cache (`internal/consensus/adaptor/fetchpack.go`) refused new nodes once it hit a hard 65536-entry cap, so a flood of cheaply-generated valid SHAMap nodes could lock out legitimate fetch-pack nodes until they aged out (~TTL). This is the divergence reported in #778.
- **The fix is *not* the issue's suggested "LRU evict-on-insert".** rippled's `fetch_packs_` is a `TaggedCache`, which is **not** an LRU and **never evicts at insert** — it accepts every node unconditionally and bounds the cache in its periodic `sweep`, shrinking the eviction age in proportion to the overflow (`when_expire = now - target_age*target_size/size`, floored at 1s). Implementing literal LRU eviction would itself diverge from rippled.
- This change mirrors rippled faithfully: `add()` always stores the newcomer; `sweep()` ages entries out at the full TTL while within the (now soft) target size and proportionally faster once over it. The hard cap is gone, so a fresh, immediately-useful node is never refused.
- `maxSize` → `targetSize` (and `fetchPackCacheMaxSize` → `fetchPackCacheTargetSize`) since the bound is now a soft target, not a refusal threshold.

The go-xrpl sweep runs every 100 ms (`maintenanceTick`), far more frequently than rippled's own sweep cadence, so the unbounded-grow window between sweeps is tiny and the proportional shrink keeps memory bounded.

## Test plan

- [x] `go test ./internal/consensus/adaptor/ -count=1` (full package green)
- [x] Updated `fetchpack_test.go`: replaced `TestFetchPackCache_CapDropsNewcomers` (which encoded the old drop-newcomer bug) with:
  - `TestFetchPackCache_AcceptsNewcomersOverTarget` — a newcomer over target is stored, not refused
  - `TestFetchPackCache_SweepShrinksProportionallyOverTarget` — an oversized cache ages out entries beyond the shrunk window
  - `TestFetchPackCache_EffectiveMaxAge` — full TTL within target, halved at 2× over, floored at 1s far over
- [x] `gofmt` / `go vet` clean

Fixes #778