### PR TITLE
fix: carry decoded tx through TMTransactions batch fanout

### DIFF
--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -350,17 +350,23 @@ func validateValidationBounds(v *consensus.Validation) (string, bool) {
 }
 
 func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) {
-	decoded, err := message.Decode(message.TypeTransaction, msg.Payload)
-	if err != nil {
-		r.logger.Warn("failed to decode transaction", "error", err, "peer", msg.PeerID)
-		return
-	}
-	txMsg, ok := decoded.(*message.Transaction)
-	if !ok {
-		r.logger.Warn("decoded transaction has unexpected type",
-			"peer", msg.PeerID,
-			"got", fmt.Sprintf("%T", decoded))
-		return
+	// Frames fanned out from a TMTransactions batch arrive already
+	// decoded in Tx; only wire-sourced frames need decoding from Payload.
+	txMsg := msg.Tx
+	if txMsg == nil {
+		decoded, err := message.Decode(message.TypeTransaction, msg.Payload)
+		if err != nil {
+			r.logger.Warn("failed to decode transaction", "error", err, "peer", msg.PeerID)
+			return
+		}
+		var ok bool
+		txMsg, ok = decoded.(*message.Transaction)
+		if !ok {
+			r.logger.Warn("decoded transaction has unexpected type",
+				"peer", msg.PeerID,
+				"got", fmt.Sprintf("%T", decoded))
+			return
+		}
 	}
 
 	blob := TransactionFromMessage(txMsg)

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -228,6 +228,52 @@ func TestRouterDispatchesTransaction(t *testing.T) {
 	assert.True(t, a.HasTx(consensus.TxID(txHash)))
 }
 
+// TestRouterDispatchesPreDecodedTransaction covers the path taken by
+// frames fanned out from a TMTransactions batch: the transaction arrives
+// already decoded in InboundMessage.Tx with a nil Payload, so the router
+// must accept it without re-decoding. Companion to
+// TestRouterDispatchesTransaction (the wire/Payload path).
+func TestRouterDispatchesPreDecodedTransaction(t *testing.T) {
+	engine := &mockEngine{}
+	a := newTestAdaptor(t)
+	inbox := make(chan *peermanagement.InboundMessage, 10)
+
+	router := NewRouter(engine, a, inbox)
+
+	ctx := t.Context()
+	go router.Run(ctx)
+
+	env := testenv.NewTestEnv(t)
+	env.SetVerifySignatures(true)
+	master := testenv.MasterAccount()
+	alice := testenv.NewAccount("alice")
+	txn := payment.Pay(master, alice, 100_000_000).Sequence(1).Build()
+	env.SignWith(txn, master)
+	txMap, err := txn.Flatten()
+	require.NoError(t, err)
+	hexStr, err := binarycodec.Encode(txMap)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+	txHash, err := tx.ComputeTransactionHash(txn)
+	require.NoError(t, err)
+
+	inbox <- &peermanagement.InboundMessage{
+		PeerID: 3,
+		Type:   uint16(message.TypeTransaction),
+		Tx: &message.Transaction{
+			RawTransaction:   blob,
+			Status:           message.TxStatusNew,
+			ReceiveTimestamp: uint64(time.Now().UnixNano()),
+		},
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	assert.True(t, a.HasTx(consensus.TxID(txHash)),
+		"router must accept a pre-decoded (batch-fanned) transaction")
+}
+
 func TestRouterIgnoresUnknownMessages(t *testing.T) {
 	engine := &mockEngine{}
 	adaptor := newTestAdaptor(t)

--- a/internal/peermanagement/events.go
+++ b/internal/peermanagement/events.go
@@ -4,6 +4,8 @@ package peermanagement
 import (
 	"fmt"
 	"net"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 )
 
 // PeerID is a unique identifier for a connected peer.
@@ -134,4 +136,10 @@ type InboundMessage struct {
 
 	// Payload is the raw message payload.
 	Payload []byte
+
+	// Tx carries an already-decoded transaction for inner frames fanned
+	// out from a TMTransactions batch, so the consumer can skip decoding
+	// Payload. It is nil for messages read off the wire, whose decoded
+	// form lives in Payload.
+	Tx *message.Transaction
 }

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -591,14 +591,14 @@ func (o *Overlay) serveGetObjects(peerID PeerID, req *message.GetObjectByHash) {
 // list of TMTransaction frames). Mirrors rippled
 // PeerImp::onMessage(TMTransactions) at PeerImp.cpp:2667-2688.
 //
-// Each inner TMTransaction is re-emitted onto o.messages so
-// router.handleTransaction processes it identically to an unbundled
-// TMTransaction frame. This matches rippled's pattern of calling
-// handleTransaction(inner, eraseTxQueue=false, batch=true) for each
-// child — the only behavioural difference rippled draws between
-// batched and unbatched is the eraseTxQueue path on a duplicate hit,
-// which go-xrpl doesn't implement (no tx-reduce-relay outbound queue
-// to erase from).
+// Each inner TMTransaction is fanned out onto o.messages carrying its
+// already-decoded form so router.handleTransaction processes it
+// identically to an unbundled TMTransaction frame. Like rippled, which
+// hands the decoded inner straight to handleTransaction, we never
+// re-serialize: the decode happened once when the batch was parsed.
+// The only behavioural difference rippled draws between batched and
+// unbatched is the eraseTxQueue path on a duplicate hit, which go-xrpl
+// doesn't implement (no tx-reduce-relay outbound queue to erase from).
 func (o *Overlay) handleTransactionsBatchMessage(evt Event) {
 	if !o.cfg.EnableTxReduceRelay || !o.PeerSupports(evt.PeerID, FeatureTxReduceRelay) {
 		slog.Debug("TMTransactions batch without negotiated tx-reduce-relay; dropping",
@@ -620,26 +620,16 @@ func (o *Overlay) handleTransactionsBatchMessage(evt Event) {
 	// rippled addTxMetrics(m->transactions_size()) at PeerImp.cpp:2680.
 	o.txm.addMissingTx(uint64(len(batch.Transactions)))
 
-	// Re-emit each inner TMTransaction as a standalone wire-encoded
-	// inbound message so the router's handleTransaction path picks
-	// it up. Encoding the inner protobuf is the cheapest path —
-	// alternatively we could expose a router entrypoint that takes
-	// a pre-decoded *message.Transaction, but the channel-based
-	// dispatch is the established pattern for every other peer
-	// message and keeps the relay-timing fix in one place.
+	// Fan out each inner TMTransaction onto o.messages so the router's
+	// handleTransaction path picks it up. The decoded transaction rides
+	// along in Tx, so the router need not re-serialize and re-parse it —
+	// the batch decode above already produced the decoded form.
 	for i := range batch.Transactions {
-		inner := &batch.Transactions[i]
-		encoded, encErr := message.Encode(inner)
-		if encErr != nil {
-			slog.Debug("TMTransactions inner encode failed",
-				"t", "Overlay", "peer", evt.PeerID, "idx", i, "err", encErr)
-			continue
-		}
 		select {
 		case o.messages <- &InboundMessage{
-			PeerID:  evt.PeerID,
-			Type:    uint16(message.TypeTransaction),
-			Payload: encoded,
+			PeerID: evt.PeerID,
+			Type:   uint16(message.TypeTransaction),
+			Tx:     &batch.Transactions[i],
 		}:
 		default:
 			o.droppedMessages.Add(1)

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -354,6 +354,63 @@ func TestHandleTransactionsBatchMessage_GatedOnFeatureNegotiation(t *testing.T) 
 	}
 }
 
+// TestHandleTransactionsBatchMessage_FansOutDecodedTx pins the negotiated
+// batch path: each inner TMTransaction is fanned out carrying its
+// already-decoded form (InboundMessage.Tx) with no re-serialization,
+// mirroring rippled handing the decoded inner straight to
+// handleTransaction (PeerImp.cpp:2682-2687). Payload stays nil so the
+// router skips a redundant decode.
+func TestHandleTransactionsBatchMessage_FansOutDecodedTx(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	o := &Overlay{
+		cfg:      Config{EnableTxReduceRelay: true},
+		peers:    make(map[PeerID]*Peer),
+		events:   make(chan Event, 8),
+		messages: make(chan *InboundMessage, 8),
+		cluster:  cluster.New(),
+	}
+
+	endpoint := Endpoint{Host: "127.0.0.1", Port: 51235}
+	peer := NewPeer(PeerID(34), endpoint, false, id, make(chan Event, 1))
+	caps := NewPeerCapabilities()
+	caps.Features.Enable(FeatureTxReduceRelay)
+	peer.capabilities = caps
+	o.peers[peer.ID()] = peer
+
+	inners := []message.Transaction{
+		{RawTransaction: []byte{0x12, 0x00, 0x01}, Status: message.TxStatusCurrent},
+		{RawTransaction: []byte{0x12, 0x00, 0x02}, Status: message.TxStatusCurrent},
+	}
+	payload, err := message.Encode(&message.Transactions{Transactions: inners})
+	require.NoError(t, err)
+
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeTransactions),
+		Payload:     payload,
+	})
+
+	for i := range inners {
+		select {
+		case got := <-o.messages:
+			require.NotNil(t, got)
+			assert.Equal(t, uint16(message.TypeTransaction), got.Type)
+			assert.Nil(t, got.Payload,
+				"fanned-out frame must carry the decoded tx, not re-encoded bytes")
+			require.NotNil(t, got.Tx,
+				"fanned-out frame must carry the decoded transaction")
+			assert.Equal(t, inners[i].RawTransaction, got.Tx.RawTransaction)
+		case <-time.After(time.Second):
+			t.Fatalf("expected fanout for inner %d", i)
+		}
+	}
+
+	assert.Zero(t, peer.BadDataCount(),
+		"negotiated batch must not charge bad-data")
+}
+
 // TestHandleGetObjectsMessage_DropsReplyWithoutOutstandingRequest pins
 // the rippled reply-branch behavior at PeerImp.cpp:2540-2594: an
 // inbound query=false frame is parsed but go-xrpl has no fetch-pack


### PR DESCRIPTION
## Summary

Resolves #781 — the per-inner-tx re-encode in `handleTransactionsBatchMessage`, the issue's "one genuine smell."

- `handleTransactionsBatchMessage` re-encoded every inner transaction via `message.Encode(inner)` **on the shared overlay event-loop goroutine**, then the router (`handleTransaction`) decoded those bytes straight back into a `*message.Transaction` — a wasteful encode→decode round-trip per inner tx.
- rippled does **not** do this: `PeerImp::onMessage(TMTransactions)` (PeerImp.cpp:2682-2687) hands the already-decoded inner protobuf directly to `handleTransaction`, never re-serializing.
- Fix: carry the decoded transaction through a new optional `InboundMessage.Tx` field. The batch handler sets `Tx: &batch.Transactions[i]` (no encode); the router uses `msg.Tx` when present and falls back to decoding `Payload` for wire-sourced frames. This removes the per-item serialization from the event loop and restores rippled parity. The remaining fanout loop only performs non-blocking channel sends.

### Why not the issue's suggested count cap?

The issue suggested bounding the batch by an explicit item count. I deliberately did **not** add one: rippled's inbound `onMessage(TMTransactions)` loops **uncapped**, so a cap would be a behavioral divergence. The actual cost the issue flags is the re-encode (not the iteration count); eliminating it makes the loop strictly lighter than rippled's per-item `handleTransaction`, so the event-loop concern is resolved without diverging. The cluster and have-transactions loops are left as-is — their trust / opt-in gates make them acceptable, exactly as the issue states.

## Test plan

- [x] `go test ./internal/peermanagement/...` — added `TestHandleTransactionsBatchMessage_FansOutDecodedTx` (negotiated batch fans out decoded `Tx`, `Payload` nil, no bad-data charge)
- [x] `go test ./internal/consensus/adaptor/...` — added `TestRouterDispatchesPreDecodedTransaction` (router accepts a pre-decoded `Tx` frame end-to-end)
- [x] Existing `TestHandleTransactionsBatchMessage_GatedOnFeatureNegotiation` and `TestRouterDispatchesTransaction` (wire path) still pass
- [x] `go build ./...`, `go vet ./internal/peermanagement/... ./internal/consensus/adaptor/...`, `gofmt` clean

Fixes #781