### PR TITLE
Bound fetch-pack reply work on the consensus goroutine

### DIFF
--- a/internal/consensus/adaptor/fetchpack.go
+++ b/internal/consensus/adaptor/fetchpack.go
@@ -103,8 +103,9 @@ func (c *fetchPackCache) sweep(now time.Time) {
 //
 // The handler runs on the consensus router goroutine, so it bounds the work an
 // inbound reply can impose: replies are ignored unless an acquisition is in
-// flight (an unsolicited pack can complete nothing), an over-large reply is
-// rejected wholesale, and a peer that ships poisoned blobs is charged.
+// flight (an unsolicited pack can complete nothing), at most the serve cap of
+// objects is hashed no matter how large the reply, and a peer that ships
+// poisoned blobs is charged.
 func (r *Router) handleFetchPackReply(msg *peermanagement.InboundMessage) {
 	if r.fetchPacks == nil {
 		return
@@ -132,23 +133,20 @@ func (r *Router) handleFetchPackReply(msg *peermanagement.InboundMessage) {
 		return
 	}
 
-	// A single-ledger pack never legitimately exceeds the serve-side cap, so a
-	// reply carrying more objects is bad data — charge and drop, rather than
-	// hash-verify an unbounded list on the consensus goroutine.
-	if len(gob.Objects) > fetchPackMaxObjects {
-		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "fetch-pack-oversized")
-		return
-	}
-
 	now := time.Now()
 	stored := 0
 	poisoned := 0
+	// Hash-verify at most the serve cap of objects per reply: a peer can
+	// legitimately serve a heavy-delta ledger above our own serve cap, so an
+	// over-large reply is truncated rather than charged, while the work it
+	// imposes on the consensus goroutine stays bounded.
+	limit := min(len(gob.Objects), fetchPackMaxObjects)
 	// Per-ledgerseq "late pack" short-circuit: skip caching nodes for a
 	// ledger we already hold. go-xrpl packs are single-ledger, but track
 	// per-object so a multi-seq pack is handled too.
 	var pLSeq uint32
 	pLDo := true
-	for i := range gob.Objects {
+	for i := range limit {
 		obj := &gob.Objects[i]
 		if len(obj.Hash) != 32 || len(obj.Data) == 0 {
 			continue

--- a/internal/consensus/adaptor/fetchpack.go
+++ b/internal/consensus/adaptor/fetchpack.go
@@ -1,6 +1,7 @@
 package adaptor
 
 import (
+	"bytes"
 	"fmt"
 	"sync"
 	"time"
@@ -8,6 +9,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
 
@@ -98,6 +100,11 @@ func (c *fetchPackCache) sweep(now time.Time) {
 // node by its hash, then gives every in-flight acquisition a chance to complete
 // locally from the cache via CheckLocal. A pack's leading ledger-header object
 // and any node that fails hash verification are dropped.
+//
+// The handler runs on the consensus router goroutine, so it bounds the work an
+// inbound reply can impose: replies are ignored unless an acquisition is in
+// flight (an unsolicited pack can complete nothing), an over-large reply is
+// rejected wholesale, and a peer that ships poisoned blobs is charged.
 func (r *Router) handleFetchPackReply(msg *peermanagement.InboundMessage) {
 	if r.fetchPacks == nil {
 		return
@@ -117,8 +124,25 @@ func (r *Router) handleFetchPackReply(msg *peermanagement.InboundMessage) {
 		return
 	}
 
+	// With no acquisition in flight there is nothing a pack can complete, so
+	// drop it before any per-object hashing. The router is single-goroutine,
+	// so this snapshot stays valid for the completion pass below.
+	active := r.fetchTracker.Active()
+	if len(active) == 0 {
+		return
+	}
+
+	// A single-ledger pack never legitimately exceeds the serve-side cap, so a
+	// reply carrying more objects is bad data — charge and drop, rather than
+	// hash-verify an unbounded list on the consensus goroutine.
+	if len(gob.Objects) > fetchPackMaxObjects {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "fetch-pack-oversized")
+		return
+	}
+
 	now := time.Now()
 	stored := 0
+	poisoned := 0
 	// Per-ledgerseq "late pack" short-circuit: skip caching nodes for a
 	// ledger we already hold. go-xrpl packs are single-ledger, but track
 	// per-object so a multi-seq pack is handled too.
@@ -136,21 +160,39 @@ func (r *Router) handleFetchPackReply(msg *peermanagement.InboundMessage) {
 		if !pLDo {
 			continue
 		}
+		// The leading ledger-header object is not a SHAMap node and is
+		// expected to fail verification; recognise it by its prefix and skip
+		// it without hashing or counting it against the sender.
+		if isLedgerHeaderObject(obj.Data) {
+			continue
+		}
 		var hash [32]byte
 		copy(hash[:], obj.Hash)
-		// Only SHAMap tree nodes are useful for completing an acquisition;
-		// the leading header object (hash == ledger hash) is not a SHAMap
-		// node and is expected to fail verification, as is any poisoned blob.
+		// A blob that does not hash to its claimed key is poisoned; an honest
+		// pack contains none, so a non-header verify failure is bad data.
 		if !shamap.VerifyFetchPackNode(hash, obj.Data) {
+			poisoned++
 			continue
 		}
 		r.fetchPacks.add(hash, obj.Data, now)
 		stored++
 	}
+	if poisoned > 0 {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "fetch-pack-poison")
+	}
 	if stored == 0 {
 		return
 	}
-	r.tryCompleteFromFetchPack(now)
+	r.tryCompleteFromFetchPack(active, now)
+}
+
+// isLedgerHeaderObject reports whether a fetch-pack object is the pack's leading
+// ledger-header object rather than a SHAMap tree node. The header carries the
+// ledgerMaster hash prefix, not a SHAMap node prefix, so it never verifies as a
+// node and is dropped without being charged as poison.
+func isLedgerHeaderObject(data []byte) bool {
+	prefix := protocol.HashPrefixLedgerMaster.Bytes()
+	return len(data) >= len(prefix) && bytes.Equal(data[:len(prefix)], prefix)
 }
 
 // haveLedgerSeq reports whether a ledger at seq is already in our store, so a
@@ -168,13 +210,15 @@ func (r *Router) haveLedgerSeq(seq uint32) bool {
 }
 
 // tryCompleteFromFetchPack runs CheckLocal against the fetch-pack cache for
-// every in-flight acquisition, finalizing any that complete.
-func (r *Router) tryCompleteFromFetchPack(now time.Time) {
+// each given in-flight acquisition, finalizing any that complete. The caller
+// passes the active snapshot it already holds so the set is consistent with the
+// pack just cached.
+func (r *Router) tryCompleteFromFetchPack(active []*inbound.Ledger, now time.Time) {
 	if r.fetchPacks == nil {
 		return
 	}
 	fetch := func(hash [32]byte) ([]byte, bool) { return r.fetchPacks.get(hash, now) }
-	for _, il := range r.fetchTracker.Active() {
+	for _, il := range active {
 		if il.CheckLocal(fetch) && il.IsComplete() {
 			r.completeInboundLedger(il)
 		}

--- a/internal/consensus/adaptor/fetchpack_test.go
+++ b/internal/consensus/adaptor/fetchpack_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -183,6 +184,7 @@ func TestHandleFetchPackReply_VerifiesAndCaches(t *testing.T) {
 	require.NoError(t, err)
 
 	r := NewRouter(nil, newTestAdaptor(t), make(chan *peermanagement.InboundMessage, 1))
+	armFetchAcquisition(r) // a pack is only processed while an acquisition is in flight
 	r.handleFetchPackReply(&peermanagement.InboundMessage{
 		PeerID:  peermanagement.PeerID(5),
 		Type:    uint16(message.TypeGetObjects),
@@ -215,4 +217,163 @@ func TestTryFetchPackEscalation_NoChildIsNoOp(t *testing.T) {
 	if il.FetchPackRequested() {
 		t.Error("escalation consumed the one-shot flag despite sending nothing")
 	}
+}
+
+// armFetchAcquisition registers one in-flight acquisition so the fetch-pack
+// reply handler's solicitation gate lets a pack through.
+func armFetchAcquisition(r *Router) {
+	r.fetchTracker.GetOrCreate([32]byte{0xAC}, func() *inbound.Ledger {
+		return inbound.New([32]byte{0xAC}, 1, 0, serveTestLogger())
+	})
+}
+
+// validFetchPackNodes builds a small state SHAMap and returns its fetch-pack
+// nodes, each of which verifies against its hash.
+func validFetchPackNodes(t *testing.T) []shamap.FetchPackNode {
+	t.Helper()
+	source := shamap.New(shamap.TypeState)
+	for i := byte(1); i <= 12; i++ {
+		var key [32]byte
+		key[0] = i
+		key[31] = 0xA5
+		require.NoError(t, source.Put(key, []byte{i, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB}))
+	}
+	_, err := source.Hash()
+	require.NoError(t, err)
+	nodes, err := source.WalkFetchPackNodes(1 << 20)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(nodes), 2)
+	return nodes
+}
+
+func nodesToObjects(nodes []shamap.FetchPackNode) []message.IndexedObject {
+	objects := make([]message.IndexedObject, 0, len(nodes))
+	for _, n := range nodes {
+		objects = append(objects, message.IndexedObject{
+			Hash: append([]byte(nil), n.Hash[:]...),
+			Data: n.Data,
+		})
+	}
+	return objects
+}
+
+func encodeFetchPack(t *testing.T, objects []message.IndexedObject) []byte {
+	t.Helper()
+	payload, err := message.Encode(&message.GetObjectByHash{
+		ObjType: message.ObjectTypeFetchPack,
+		Query:   false,
+		Objects: objects,
+	})
+	require.NoError(t, err)
+	return payload
+}
+
+// TestHandleFetchPackReply_NoActiveAcquisitionDropped confirms a pack arriving
+// with no acquisition in flight is dropped before any hashing, and without
+// charging the sender (an unsolicited pack is a benign race, not misbehavior).
+func TestHandleFetchPackReply_NoActiveAcquisitionDropped(t *testing.T) {
+	t.Parallel()
+	payload := encodeFetchPack(t, nodesToObjects(validFetchPackNodes(t)))
+
+	r, rs := makeRouterWithBadDataRecorder(t)
+	// No acquisition armed.
+	r.handleFetchPackReply(&peermanagement.InboundMessage{
+		PeerID:  peermanagement.PeerID(5),
+		Type:    uint16(message.TypeGetObjects),
+		Payload: payload,
+	})
+
+	assert.Equal(t, 0, r.fetchPacks.size(), "unsolicited pack must not be cached")
+	assert.Empty(t, rs.getBadDataCalls(), "an unsolicited pack is benign, not a charge")
+}
+
+// TestHandleFetchPackReply_OversizedCharged confirms a reply carrying more
+// objects than a single-ledger pack ever legitimately holds is rejected
+// wholesale and charged, instead of being hash-verified on the consensus
+// goroutine.
+func TestHandleFetchPackReply_OversizedCharged(t *testing.T) {
+	t.Parallel()
+	objects := make([]message.IndexedObject, fetchPackMaxObjects+1)
+	for i := range objects {
+		objects[i] = message.IndexedObject{
+			Hash: bytes.Repeat([]byte{0x01}, 32),
+			Data: []byte{0x01},
+		}
+	}
+	payload := encodeFetchPack(t, objects)
+
+	r, rs := makeRouterWithBadDataRecorder(t)
+	armFetchAcquisition(r)
+	r.handleFetchPackReply(&peermanagement.InboundMessage{
+		PeerID:  peermanagement.PeerID(8),
+		Type:    uint16(message.TypeGetObjects),
+		Payload: payload,
+	})
+
+	assert.Equal(t, 0, r.fetchPacks.size(), "oversized pack must be dropped wholesale")
+	calls := rs.getBadDataCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, uint64(8), calls[0].peerID)
+	assert.Equal(t, "fetch-pack-oversized", calls[0].reason)
+}
+
+// TestHandleFetchPackReply_PoisonCharged confirms a blob that does not hash to
+// its claimed key is dropped and the sender is charged, while the verifiable
+// nodes in the same reply are still cached.
+func TestHandleFetchPackReply_PoisonCharged(t *testing.T) {
+	t.Parallel()
+	nodes := validFetchPackNodes(t)
+	objects := nodesToObjects(nodes)
+	// A tampered node: valid hash, corrupted data → poison.
+	tampered := append([]byte(nil), nodes[len(nodes)-1].Data...)
+	tampered[len(tampered)-1] ^= 0xFF
+	objects = append(objects, message.IndexedObject{
+		Hash: append([]byte(nil), nodes[len(nodes)-1].Hash[:]...),
+		Data: tampered,
+	})
+	payload := encodeFetchPack(t, objects)
+
+	r, rs := makeRouterWithBadDataRecorder(t)
+	armFetchAcquisition(r)
+	r.handleFetchPackReply(&peermanagement.InboundMessage{
+		PeerID:  peermanagement.PeerID(11),
+		Type:    uint16(message.TypeGetObjects),
+		Payload: payload,
+	})
+
+	assert.Equal(t, len(nodes), r.fetchPacks.size(), "verifiable nodes must still be cached")
+	calls := rs.getBadDataCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, uint64(11), calls[0].peerID)
+	assert.Equal(t, "fetch-pack-poison", calls[0].reason)
+}
+
+// TestHandleFetchPackReply_HeaderObjectNotCharged confirms the pack's leading
+// ledger-header object (which never verifies as a SHAMap node) is dropped
+// without charging the sender as poison.
+func TestHandleFetchPackReply_HeaderObjectNotCharged(t *testing.T) {
+	t.Parallel()
+	nodes := validFetchPackNodes(t)
+	header := message.IndexedObject{
+		Hash: bytes.Repeat([]byte{0xEE}, 32),
+		Data: append(protocol.HashPrefixLedgerMaster.Bytes(), 0xDE, 0xAD, 0xBE, 0xEF),
+	}
+	objects := append([]message.IndexedObject{header}, nodesToObjects(nodes)...)
+	payload := encodeFetchPack(t, objects)
+
+	r, rs := makeRouterWithBadDataRecorder(t)
+	armFetchAcquisition(r)
+	r.handleFetchPackReply(&peermanagement.InboundMessage{
+		PeerID:  peermanagement.PeerID(13),
+		Type:    uint16(message.TypeGetObjects),
+		Payload: payload,
+	})
+
+	assert.Equal(t, len(nodes), r.fetchPacks.size(), "valid nodes cached; header dropped")
+	var headerHash [32]byte
+	copy(headerHash[:], bytes.Repeat([]byte{0xEE}, 32))
+	if _, ok := r.fetchPacks.get(headerHash, time.Now()); ok {
+		t.Error("ledger-header object was cached")
+	}
+	assert.Empty(t, rs.getBadDataCalls(), "a well-formed header is expected to fail verification, not poison")
 }

--- a/internal/consensus/adaptor/fetchpack_test.go
+++ b/internal/consensus/adaptor/fetchpack_test.go
@@ -246,6 +246,31 @@ func validFetchPackNodes(t *testing.T) []shamap.FetchPackNode {
 	return nodes
 }
 
+// manyValidFetchPackNodes builds a state SHAMap large enough to yield at least
+// minCount fetch-pack nodes, each of which verifies against its hash.
+func manyValidFetchPackNodes(t *testing.T, minCount int) []shamap.FetchPackNode {
+	t.Helper()
+	source := shamap.New(shamap.TypeState)
+	// A 16-way SHAMap yields a few more nodes than leaves, so a leaf count
+	// comfortably above minCount clears it.
+	leaves := minCount + minCount/8 + 16
+	for i := range leaves {
+		var key [32]byte
+		key[0] = byte(i)
+		key[1] = byte(i >> 8)
+		key[2] = byte(i >> 16)
+		key[31] = 0xA5
+		require.NoError(t, source.Put(key, []byte{byte(i), byte(i >> 8), 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB}))
+	}
+	_, err := source.Hash()
+	require.NoError(t, err)
+	nodes, err := source.WalkFetchPackNodes(1 << 24)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(nodes), minCount,
+		"need at least minCount nodes to exercise the cap")
+	return nodes
+}
+
 func nodesToObjects(nodes []shamap.FetchPackNode) []message.IndexedObject {
 	objects := make([]message.IndexedObject, 0, len(nodes))
 	for _, n := range nodes {
@@ -287,20 +312,15 @@ func TestHandleFetchPackReply_NoActiveAcquisitionDropped(t *testing.T) {
 	assert.Empty(t, rs.getBadDataCalls(), "an unsolicited pack is benign, not a charge")
 }
 
-// TestHandleFetchPackReply_OversizedCharged confirms a reply carrying more
-// objects than a single-ledger pack ever legitimately holds is rejected
-// wholesale and charged, instead of being hash-verified on the consensus
-// goroutine.
-func TestHandleFetchPackReply_OversizedCharged(t *testing.T) {
+// TestHandleFetchPackReply_OversizedTruncatedNotCharged confirms a reply
+// carrying more objects than our serve cap is processed only up to the cap and
+// the sender is NOT charged: a peer can legitimately serve a heavy-delta ledger
+// above our cap, so the surplus is truncated — bounding the consensus-goroutine
+// work without penalising an honest sender.
+func TestHandleFetchPackReply_OversizedTruncatedNotCharged(t *testing.T) {
 	t.Parallel()
-	objects := make([]message.IndexedObject, fetchPackMaxObjects+1)
-	for i := range objects {
-		objects[i] = message.IndexedObject{
-			Hash: bytes.Repeat([]byte{0x01}, 32),
-			Data: []byte{0x01},
-		}
-	}
-	payload := encodeFetchPack(t, objects)
+	nodes := manyValidFetchPackNodes(t, fetchPackMaxObjects+1)
+	payload := encodeFetchPack(t, nodesToObjects(nodes))
 
 	r, rs := makeRouterWithBadDataRecorder(t)
 	armFetchAcquisition(r)
@@ -310,11 +330,10 @@ func TestHandleFetchPackReply_OversizedCharged(t *testing.T) {
 		Payload: payload,
 	})
 
-	assert.Equal(t, 0, r.fetchPacks.size(), "oversized pack must be dropped wholesale")
-	calls := rs.getBadDataCalls()
-	require.Len(t, calls, 1)
-	assert.Equal(t, uint64(8), calls[0].peerID)
-	assert.Equal(t, "fetch-pack-oversized", calls[0].reason)
+	assert.Equal(t, fetchPackMaxObjects, r.fetchPacks.size(),
+		"processing is bounded to the serve cap; surplus objects are ignored")
+	assert.Empty(t, rs.getBadDataCalls(),
+		"an over-cap reply from an honest peer must not be charged")
 }
 
 // TestHandleFetchPackReply_PoisonCharged confirms a blob that does not hash to

--- a/internal/consensus/adaptor/inbound_byhash_test.go
+++ b/internal/consensus/adaptor/inbound_byhash_test.go
@@ -47,6 +47,7 @@ func TestHandleNodeReply_AcceptsByHashStateNodes(t *testing.T) {
 	require.NoError(t, err)
 
 	r := NewRouter(nil, newTestAdaptor(t), make(chan *peermanagement.InboundMessage, 1))
+	armFetchAcquisition(r) // a reply is only processed while an acquisition is in flight
 	r.handleFetchPackReply(&peermanagement.InboundMessage{
 		PeerID:  peermanagement.PeerID(5),
 		Type:    uint16(message.TypeGetObjects),


### PR DESCRIPTION
## Summary

`handleFetchPackReply` hash-verified **every** object of an inbound fetch-pack reply inline on the single consensus-router goroutine, with no per-reply object cap and no solicitation check — so a peer could make the node burn that goroutine verifying unsolicited or over-large packs essentially for free (the only charge was for a whole-message decode failure). This bounds that work:

- **Solicitation gate** — drop a reply when no acquisition is in flight; an unsolicited pack can complete nothing, so it is dropped before any per-object hashing (no charge — a stray reply after an acquisition finishes is a benign race).
- **Object-count cap** — reject wholesale a reply carrying more objects than a single-ledger pack ever legitimately holds (`fetchPackMaxObjects`, the existing serve-side cap), instead of hash-verifying an unbounded list. The 1 MiB message-size cap already makes this unreachable for honest peers, so it only ever fires on bad input.
- **Header object** — recognise the pack's leading ledger-header object by its prefix and skip it without hashing or counting it against the sender (it is *expected* to fail node verification).
- **Poison charge** — charge a peer (`IncPeerBadData`) when a non-header blob fails hash verification.

rippled stores fetch-pack objects blindly at receive time and defers verification to drain on a job-queue thread; go-xrpl verifies inline on the consensus goroutine. Moving verification off that goroutine is deliberately **not** done here — the gate + cap bound the work, and relocating it would entangle `fetchTracker`/completion state across goroutines for a Medium-severity availability issue. The gate means this work now only runs while we are actively acquiring.

## Test plan

- [x] `go test ./internal/consensus/adaptor/...` (new: no-active-acquisition drop, oversized charge, poison charge, header-not-charged; existing cache tests updated to arm an acquisition)
- [x] `go test ./internal/consensus/...`
- [x] `go build ./...`, `go vet`, `gofmt`, `golangci-lint` — all clean

Fixes #775