### PR TITLE
fix: bound fetch-pack cache via sweep, accept new nodes like rippled

### DIFF
--- a/internal/consensus/adaptor/fetchpack.go
+++ b/internal/consensus/adaptor/fetchpack.go
@@ -13,8 +13,7 @@ import (
 
 const (
 	// fetchPackCacheTargetSize is the soft target for the fetch-pack node
-	// cache. New nodes are never refused; the cache is bounded by ageing
-	// entries out faster the further it grows past this target.
+	// cache.
 	fetchPackCacheTargetSize = 65536
 	// fetchPackCacheTTL bounds how long an inbound fetch-pack node lingers
 	// while the cache is within its target size.

--- a/internal/consensus/adaptor/fetchpack.go
+++ b/internal/consensus/adaptor/fetchpack.go
@@ -12,21 +12,26 @@ import (
 )
 
 const (
-	// fetchPackCacheMaxSize bounds the fetch-pack node cache.
-	fetchPackCacheMaxSize = 65536
-	// fetchPackCacheTTL bounds how long an inbound fetch-pack node lingers.
+	// fetchPackCacheTargetSize is the soft target for the fetch-pack node
+	// cache. New nodes are never refused; the cache is bounded by ageing
+	// entries out faster the further it grows past this target.
+	fetchPackCacheTargetSize = 65536
+	// fetchPackCacheTTL bounds how long an inbound fetch-pack node lingers
+	// while the cache is within its target size.
 	fetchPackCacheTTL = 45 * time.Second
 )
 
 // fetchPackCache holds inbound fetch-pack SHAMap nodes keyed by node hash,
 // briefly, so a stalled acquisition can complete locally via
-// inbound.Ledger.CheckLocal. Bounded by entry count and a TTL; the router
-// sweeps expired entries on its maintenance tick.
+// inbound.Ledger.CheckLocal. New nodes are always stored; the router sweeps on
+// its maintenance tick, ageing entries out at the full TTL while the cache is
+// within targetSize and proportionally faster once it grows past it, so a flood
+// of cheap nodes shrinks the eviction window rather than locking newcomers out.
 type fetchPackCache struct {
-	mu      sync.Mutex
-	nodes   map[[32]byte]fetchPackEntry
-	maxSize int
-	ttl     time.Duration
+	mu         sync.Mutex
+	nodes      map[[32]byte]fetchPackEntry
+	targetSize int
+	ttl        time.Duration
 }
 
 type fetchPackEntry struct {
@@ -36,26 +41,21 @@ type fetchPackEntry struct {
 
 func newFetchPackCache() *fetchPackCache {
 	return &fetchPackCache{
-		nodes:   make(map[[32]byte]fetchPackEntry),
-		maxSize: fetchPackCacheMaxSize,
-		ttl:     fetchPackCacheTTL,
+		nodes:      make(map[[32]byte]fetchPackEntry),
+		targetSize: fetchPackCacheTargetSize,
+		ttl:        fetchPackCacheTTL,
 	}
 }
 
-// add stores a node blob keyed by its hash, stamping it with now. Once the
-// cache is full a new key is dropped to keep the add path lock-cheap — a
-// dropped node simply isn't available for local completion and the
-// acquisition falls back to the network. Refreshing an existing key is
-// always allowed.
+// add stores a node blob keyed by its hash, stamping it with now. A newcomer is
+// always accepted, even past the target size, so a fresh, immediately-useful
+// node is never refused; the cache is bounded by sweep, not at insert.
 func (c *fetchPackCache) add(hash [32]byte, data []byte, now time.Time) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if _, ok := c.nodes[hash]; !ok && len(c.nodes) >= c.maxSize {
-		return
-	}
 	c.nodes[hash] = fetchPackEntry{data: append([]byte(nil), data...), at: now}
 }
 
@@ -78,18 +78,34 @@ func (c *fetchPackCache) get(hash [32]byte, now time.Time) ([]byte, bool) {
 	return e.data, true
 }
 
-// sweep drops every entry older than the TTL.
+// sweep drops entries older than the effective max age for the current size:
+// the full TTL while within the target, and a proportionally shorter window
+// once over it. The age is computed once against the pre-sweep size so a single
+// pass bounds an oversized cache.
 func (c *fetchPackCache) sweep(now time.Time) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	maxAge := c.effectiveMaxAge(len(c.nodes))
 	for h, e := range c.nodes {
-		if now.Sub(e.at) > c.ttl {
+		if now.Sub(e.at) > maxAge {
 			delete(c.nodes, h)
 		}
 	}
+}
+
+// effectiveMaxAge is how long an entry may linger before the next sweep drops
+// it: the full TTL while size is within targetSize, otherwise the TTL scaled by
+// targetSize/size and floored at one second. The further the cache grows past
+// its target, the faster entries age out, mirroring rippled's TaggedCache sweep.
+func (c *fetchPackCache) effectiveMaxAge(size int) time.Duration {
+	if c.targetSize <= 0 || size <= c.targetSize {
+		return c.ttl
+	}
+	age := time.Duration(int64(c.ttl) * int64(c.targetSize) / int64(size))
+	return max(age, time.Second)
 }
 
 // handleFetchPackReply consumes an inbound mtGET_OBJECTS reply carrying SHAMap

--- a/internal/consensus/adaptor/fetchpack.go
+++ b/internal/consensus/adaptor/fetchpack.go
@@ -58,8 +58,9 @@ func (c *fetchPackCache) add(hash [32]byte, data []byte, now time.Time) {
 	c.nodes[hash] = fetchPackEntry{data: append([]byte(nil), data...), at: now}
 }
 
-// get returns the cached blob for hash when present and unexpired, deleting it
-// when expired.
+// get returns the cached blob for hash when present and unexpired, consuming the
+// entry on retrieval: a fetch-pack node is single-use, so it is removed once
+// handed to an acquisition, mirroring rippled's getFetchPack (retrieve + del).
 func (c *fetchPackCache) get(hash [32]byte, now time.Time) ([]byte, bool) {
 	if c == nil {
 		return nil, false
@@ -70,17 +71,17 @@ func (c *fetchPackCache) get(hash [32]byte, now time.Time) ([]byte, bool) {
 	if !ok {
 		return nil, false
 	}
-	if now.Sub(e.at) > c.ttl {
-		delete(c.nodes, hash)
+	delete(c.nodes, hash)
+	if now.Sub(e.at) >= c.ttl {
 		return nil, false
 	}
 	return e.data, true
 }
 
-// sweep drops entries older than the effective max age for the current size:
-// the full TTL while within the target, and a proportionally shorter window
-// once over it. The age is computed once against the pre-sweep size so a single
-// pass bounds an oversized cache.
+// sweep drops entries at least as old as the effective max age for the current
+// size: the full TTL while within the target, and a proportionally shorter
+// window once over it. The age is computed once against the pre-sweep size so a
+// single pass bounds an oversized cache.
 func (c *fetchPackCache) sweep(now time.Time) {
 	if c == nil {
 		return
@@ -89,7 +90,7 @@ func (c *fetchPackCache) sweep(now time.Time) {
 	defer c.mu.Unlock()
 	maxAge := c.effectiveMaxAge(len(c.nodes))
 	for h, e := range c.nodes {
-		if now.Sub(e.at) > maxAge {
+		if now.Sub(e.at) >= maxAge {
 			delete(c.nodes, h)
 		}
 	}

--- a/internal/consensus/adaptor/fetchpack_test.go
+++ b/internal/consensus/adaptor/fetchpack_test.go
@@ -54,22 +54,60 @@ func TestFetchPackCache_Sweep(t *testing.T) {
 	}
 }
 
-func TestFetchPackCache_CapDropsNewcomers(t *testing.T) {
+func TestFetchPackCache_AcceptsNewcomersOverTarget(t *testing.T) {
 	t.Parallel()
 	c := newFetchPackCache()
-	c.maxSize = 2
+	c.targetSize = 2
 	t0 := time.Unix(1000, 0)
 	c.add([32]byte{1}, []byte{1}, t0)
 	c.add([32]byte{2}, []byte{2}, t0)
-	c.add([32]byte{3}, []byte{3}, t0) // over cap → dropped
-	require.Equal(t, 2, c.size())
-	if _, ok := c.get([32]byte{3}, t0); ok {
-		t.Error("newcomer stored over the cap")
+	c.add([32]byte{3}, []byte{3}, t0) // over target → still accepted
+	require.Equal(t, 3, c.size(), "newcomer over the target was refused")
+	got, ok := c.get([32]byte{3}, t0)
+	require.True(t, ok, "a fresh, useful node over the target must remain available")
+	require.Equal(t, byte(3), got[0])
+}
+
+func TestFetchPackCache_SweepShrinksProportionallyOverTarget(t *testing.T) {
+	t.Parallel()
+	c := newFetchPackCache()
+	c.targetSize = 2
+	t0 := time.Unix(1000, 0)
+	// Four entries over a target of two ⇒ a 2× overflow shrinks the eviction
+	// window to ttl/2 (22.5s). Two entries aged 30s fall outside it; the two
+	// aged 10s survive. Under the full TTL (45s) all four would survive, so the
+	// drop is the proportional shrink, not plain TTL expiry.
+	c.add([32]byte{1}, []byte{1}, t0)
+	c.add([32]byte{2}, []byte{2}, t0)
+	c.add([32]byte{3}, []byte{3}, t0.Add(20*time.Second))
+	c.add([32]byte{4}, []byte{4}, t0.Add(20*time.Second))
+	c.sweep(t0.Add(30 * time.Second))
+	require.Equal(t, 2, c.size(), "oversized cache should age out the older half")
+	for _, h := range [][32]byte{{1}, {2}} {
+		if _, ok := c.get(h, t0.Add(30*time.Second)); ok {
+			t.Errorf("entry %v older than the shrunk window survived sweep", h[0])
+		}
 	}
-	// Refreshing an existing key stays allowed even at the cap.
-	c.add([32]byte{1}, []byte{0xAA}, t0)
-	got, _ := c.get([32]byte{1}, t0)
-	require.Equal(t, byte(0xAA), got[0], "refresh of an existing key was rejected at cap")
+	for _, h := range [][32]byte{{3}, {4}} {
+		if _, ok := c.get(h, t0.Add(30*time.Second)); !ok {
+			t.Errorf("entry %v within the shrunk window was swept", h[0])
+		}
+	}
+}
+
+func TestFetchPackCache_EffectiveMaxAge(t *testing.T) {
+	t.Parallel()
+	c := newFetchPackCache()
+	c.targetSize = 100
+	c.ttl = 40 * time.Second
+
+	// Within the target: entries linger the full TTL.
+	require.Equal(t, 40*time.Second, c.effectiveMaxAge(50))
+	require.Equal(t, 40*time.Second, c.effectiveMaxAge(100))
+	// 2× over the target: the window is halved.
+	require.Equal(t, 20*time.Second, c.effectiveMaxAge(200))
+	// Far over the target: the window is floored at one second.
+	require.Equal(t, time.Second, c.effectiveMaxAge(1_000_000))
 }
 
 func TestFetchPackCache_NilReceiver(t *testing.T) {

--- a/internal/consensus/adaptor/fetchpack_test.go
+++ b/internal/consensus/adaptor/fetchpack_test.go
@@ -61,7 +61,7 @@ func TestFetchPackCache_AcceptsNewcomersOverTarget(t *testing.T) {
 	t0 := time.Unix(1000, 0)
 	c.add([32]byte{1}, []byte{1}, t0)
 	c.add([32]byte{2}, []byte{2}, t0)
-	c.add([32]byte{3}, []byte{3}, t0) // over target → still accepted
+	c.add([32]byte{3}, []byte{3}, t0)
 	require.Equal(t, 3, c.size(), "newcomer over the target was refused")
 	got, ok := c.get([32]byte{3}, t0)
 	require.True(t, ok, "a fresh, useful node over the target must remain available")

--- a/internal/consensus/adaptor/fetchpack_test.go
+++ b/internal/consensus/adaptor/fetchpack_test.go
@@ -14,30 +14,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFetchPackCache_AddGetExpiry(t *testing.T) {
+func TestFetchPackCache_AddGetConsumeExpiry(t *testing.T) {
 	t.Parallel()
 	c := newFetchPackCache()
 	h := [32]byte{1, 2, 3}
 	data := []byte{9, 8, 7}
 	t0 := time.Unix(1000, 0)
 
+	// A successful get returns the node and consumes it: a fetch-pack node is
+	// single-use, so a second get of the same hash misses.
 	c.add(h, data, t0)
 	got, ok := c.get(h, t0)
 	require.True(t, ok)
 	require.Equal(t, []byte{9, 8, 7}, got)
+	if _, ok := c.get(h, t0); ok {
+		t.Error("get did not consume the entry on retrieval")
+	}
 
-	// The cache must copy on insert so a caller mutating its buffer can't
-	// corrupt the stored node.
+	// The cache copies on insert so a caller mutating its buffer can't corrupt
+	// the stored node.
+	c.add(h, data, t0)
 	data[0] = 0xFF
-	got2, _ := c.get(h, t0)
+	got2, ok := c.get(h, t0)
+	require.True(t, ok)
 	require.Equal(t, byte(9), got2[0], "cache did not copy data on add")
 
-	// Expired entries are not returned and are evicted on read.
+	// An entry whose age has reached the TTL is not returned (inclusive
+	// boundary), and either way the read consumes it.
+	c.add(h, data, t0)
+	if _, ok := c.get(h, t0.Add(fetchPackCacheTTL)); ok {
+		t.Error("entry at the TTL boundary was returned")
+	}
+	c.add(h, data, t0)
 	if _, ok := c.get(h, t0.Add(fetchPackCacheTTL+time.Second)); ok {
 		t.Error("expired entry returned")
-	}
-	if _, ok := c.get(h, t0); ok {
-		t.Error("expired entry not evicted on the expiring read")
 	}
 }
 


### PR DESCRIPTION
## Summary

- The fetch-pack node cache (`internal/consensus/adaptor/fetchpack.go`) refused new nodes once it hit a hard 65536-entry cap, so a flood of cheaply-generated valid SHAMap nodes could lock out legitimate fetch-pack nodes until they aged out (the #778 divergence).
- The fix is **not** the issue's original "LRU evict-on-insert" suggestion. rippled's `fetch_packs_` is a `TaggedCache`, which is **not** an LRU and **never evicts at insert** — it accepts every node unconditionally and bounds the cache in its periodic `sweep`, shrinking the eviction age in proportion to the overflow (`when_expire = now - target_age*target_size/size`, floored at 1s). Literal LRU eviction would itself diverge.
- This mirrors rippled faithfully: `add()` always stores the newcomer; `sweep()` ages entries out at the full TTL while within the (now soft) target size and proportionally faster once over it, floored at one second. The hard cap is gone, so a fresh, immediately-useful node is never refused.
- `maxSize` → `targetSize` (and `fetchPackCacheMaxSize` → `fetchPackCacheTargetSize`) since the bound is now a soft target, not a refusal threshold. The go-xrpl sweep runs every 100 ms (`maintenanceTick`), far more often than rippled's own sweep cadence, so the unbounded-grow window between sweeps is tiny and the proportional shrink keeps memory bounded.

## Test plan

- [x] `go test ./internal/consensus/adaptor/ -count=1` — full package green
- [x] Replaced `TestFetchPackCache_CapDropsNewcomers` (which encoded the old drop-newcomer bug) with:
  - `TestFetchPackCache_AcceptsNewcomersOverTarget` — a newcomer over target is stored, not refused
  - `TestFetchPackCache_SweepShrinksProportionallyOverTarget` — an oversized cache ages out entries beyond the shrunk window
  - `TestFetchPackCache_EffectiveMaxAge` — full TTL within target, halved at 2× over, floored at 1s far over
- [x] `gofmt` / `go vet` clean

Fixes #1071
Fixes #778