### PR TITLE
fix: reject malformed Vector256 payloads in state.Field.Vector256()

### DIFF
--- a/internal/ledger/state/directory.go
+++ b/internal/ledger/state/directory.go
@@ -295,7 +295,11 @@ func ParseDirectoryNode(data []byte) (*DirectoryNode, error) {
 
 		case stVector256:
 			if f.FieldCode == 1 { // Indexes
-				dir.Indexes = f.Vector256()
+				idx, err := f.Vector256()
+				if err != nil {
+					return err
+				}
+				dir.Indexes = idx
 			}
 		}
 		return nil

--- a/internal/ledger/state/field_value.go
+++ b/internal/ledger/state/field_value.go
@@ -1,6 +1,9 @@
 package state
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"fmt"
+)
 
 // Typed accessors for a Field decoded by WalkFields. WalkFields has already
 // delimited Value by the field's serialized type, so each accessor reads a
@@ -87,14 +90,18 @@ func (f Field) AccountID() (id [20]byte, ok bool) {
 }
 
 // Vector256 splits a Vector256 payload into its constituent 32-byte hashes.
-func (f Field) Vector256() [][32]byte {
+// A payload whose length is not a multiple of 32 is malformed and rejected,
+// matching the public binary codec and the streaming ledgerfields decoder.
+func (f Field) Vector256() ([][32]byte, error) {
 	p := f.VLBytes()
-	n := len(p) / 32
-	out := make([][32]byte, n)
+	if len(p)%32 != 0 {
+		return nil, fmt.Errorf("bad serialization for STVector256: %d", len(p))
+	}
+	out := make([][32]byte, len(p)/32)
 	for i := range out {
 		copy(out[i][:], p[i*32:])
 	}
-	return out
+	return out, nil
 }
 
 // xrpDrops decodes the drops carried by an 8-byte native Amount value, masking

--- a/internal/ledger/state/issue1078_test.go
+++ b/internal/ledger/state/issue1078_test.go
@@ -1,0 +1,34 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// indexesField builds a serialized DirectoryNode Indexes field (Vector256,
+// type 19 field 1) carrying payloadLen raw bytes behind the XRPL single-byte
+// length prefix. payloadLen must be <= 192 so the prefix stays one byte.
+func indexesField(payloadLen int) []byte {
+	b := []byte{0x01, 0x13, byte(payloadLen)} // field header + 1-byte VL length
+	return append(b, make([]byte, payloadLen)...)
+}
+
+// TestParseDirectoryNode_RejectsMalformedIndexes pins issue 1078: a DirectoryNode
+// whose Indexes Vector256 payload length is not a multiple of 32 must be rejected,
+// matching the public binary codec and the streaming ledgerfields decoder, rather
+// than silently dropping the trailing bytes and misreading directory membership.
+func TestParseDirectoryNode_RejectsMalformedIndexes(t *testing.T) {
+	t.Parallel()
+
+	// 33 bytes: one whole hash plus a stray trailing byte.
+	_, err := ParseDirectoryNode(indexesField(33))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad serialization for STVector256")
+
+	// 32 bytes: a single well-formed hash still parses cleanly.
+	dir, err := ParseDirectoryNode(indexesField(32))
+	require.NoError(t, err)
+	require.Len(t, dir.Indexes, 1)
+}


### PR DESCRIPTION
## Summary

- `internal/ledger/state.Field.Vector256()` split its payload with integer division (`len(p) / 32`), silently discarding trailing bytes when the length was not a multiple of 32. It now returns an error for a malformed length, matching `codec/binarycodec/types/vector256.go` and `internal/tx/ledgerfields/decode_stream.go`, which both already reject the same input.
- `ParseDirectoryNode` propagates the error instead of storing a truncated `Indexes` slice. Previously a malformed `DirectoryNode` parsed cleanly but with fewer entries than the blob encoded, so a parse → re-serialise round-trip changed the byte representation and diverged the ledger hash.

## Test plan

- [x] `just test-pkg ./internal/ledger/state/...` — new `TestParseDirectoryNode_RejectsMalformedIndexes` (33-byte payload rejected, 32-byte payload still parses) plus the existing suite pass
- [x] `go vet ./internal/ledger/...` clean
- [x] `go build ./...` and directory consumers (`./internal/ledger/...`, `./internal/tx/offer/...`, `./internal/replaytool/...`) green

Fixes #1078