### PR TITLE
fix: propagate IOU/MPT amount parse errors in ledger-entry parsers

### DIFF
--- a/internal/ledger/state/escrow_entry.go
+++ b/internal/ledger/state/escrow_entry.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"encoding/hex"
+	"fmt"
 )
 
 // EscrowData represents an Escrow ledger entry
@@ -75,17 +76,21 @@ func ParseEscrow(data []byte) (*EscrowData, error) {
 			// width discrimination, so len(Value) is the reliable selector.
 			switch len(f.Value) {
 			case 48: // IOU
-				if amt, err := ParseIOUAmountBinary(f.Value); err == nil {
-					escrow.IOUAmount = &amt
+				amt, err := ParseIOUAmountBinary(f.Value)
+				if err != nil {
+					return fmt.Errorf("Escrow IOU amount parse failed: %w", err)
 				}
+				escrow.IOUAmount = &amt
 			case 33: // MPT
-				if mptAmt, err := ParseMPTAmountBinary(f.Value); err == nil {
-					escrow.IOUAmount = &mptAmt
-					if raw, ok := mptAmt.MPTRaw(); ok {
-						escrow.MPTAmount = &raw
-					}
-					escrow.MPTIssuanceID = mptAmt.MPTIssuanceID()
+				mptAmt, err := ParseMPTAmountBinary(f.Value)
+				if err != nil {
+					return fmt.Errorf("Escrow MPT amount parse failed: %w", err)
 				}
+				escrow.IOUAmount = &mptAmt
+				if raw, ok := mptAmt.MPTRaw(); ok {
+					escrow.MPTAmount = &raw
+				}
+				escrow.MPTIssuanceID = mptAmt.MPTIssuanceID()
 			case 8: // XRP
 				escrow.Amount = xrpDrops(f.Value)
 				escrow.IsXRP = true

--- a/internal/ledger/state/nftoken_page.go
+++ b/internal/ledger/state/nftoken_page.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"encoding/hex"
+	"fmt"
 )
 
 // NFTokenPageData represents an NFToken page ledger entry
@@ -133,14 +134,16 @@ func ParseNFTokenOffer(data []byte) (*NFTokenOfferData, error) {
 				offer.Negative = (raw&0x4000000000000000) == 0 && value != 0
 			case 48: // IOU
 				offer.Negative = raw&0x4000000000000000 == 0 && raw&0x3FFFFFFFFFFFFFFF != 0
-				if iouAmount, err := ParseIOUAmountBinary(f.Value); err == nil {
-					var issuerID [20]byte
-					copy(issuerID[:], f.Value[28:48])
-					offer.AmountIOU = &NFTIOUAmount{
-						Currency: iouAmount.Currency,
-						Issuer:   issuerID,
-						Value:    iouAmount.IOU().String(),
-					}
+				iouAmount, err := ParseIOUAmountBinary(f.Value)
+				if err != nil {
+					return fmt.Errorf("NFTokenOffer IOU amount parse failed: %w", err)
+				}
+				var issuerID [20]byte
+				copy(issuerID[:], f.Value[28:48])
+				offer.AmountIOU = &NFTIOUAmount{
+					Currency: iouAmount.Currency,
+					Issuer:   issuerID,
+					Value:    iouAmount.IOU().String(),
 				}
 			}
 

--- a/internal/ledger/state/offer_entry.go
+++ b/internal/ledger/state/offer_entry.go
@@ -151,7 +151,7 @@ func parseLedgerOffer(data []byte) (*LedgerOffer, error) {
 			case 8: // XRP
 				amt = NewXRPAmountFromInt(int64(xrpDrops(f.Value)))
 			default:
-				return nil
+				return fmt.Errorf("Offer amount (field %d) unexpected width %d", f.FieldCode, len(f.Value))
 			}
 			switch f.FieldCode {
 			case 4: // TakerPays

--- a/internal/ledger/state/offer_entry.go
+++ b/internal/ledger/state/offer_entry.go
@@ -145,7 +145,7 @@ func parseLedgerOffer(data []byte) (*LedgerOffer, error) {
 			case 48: // IOU
 				a, err := ParseIOUAmountBinary(f.Value)
 				if err != nil {
-					return nil
+					return fmt.Errorf("Offer IOU amount (field %d) parse failed: %w", f.FieldCode, err)
 				}
 				amt = a
 			case 8: // XRP


### PR DESCRIPTION
## Summary
- `ParseEscrow`, `parseLedgerOffer`, and `ParseNFTokenOffer` in `internal/ledger/state` discarded errors from `ParseIOUAmountBinary`/`ParseMPTAmountBinary`, leaving amount fields at zero/nil and silently accepting malformed entries — a ledger-divergence risk (rippled rejects such entries) and a nil-dereference hazard on the unset amount pointers.
- All three now propagate the parse error via `fmt.Errorf(... %w ...)`, matching the existing `ParseCheck` and `ParseRippleState` handling.
- No behavior change for valid ledger data (`ParseIOUAmountBinary` only errors on out-of-range mantissa/exponent); the new errors surface only on malformed input.

## Test plan
- [x] `go build ./internal/ledger/state/` + `go vet ./internal/ledger/state/`
- [x] `go test ./internal/ledger/... ./internal/replaytool/...`
- [x] `go test ./internal/testing/escrow/... ./internal/testing/offer/... ./internal/testing/nft/...` (full offer suite green)

Fixes #1079