### PR TITLE
fix: drop premature offer PreviousTxnID stamp on partial consume

### DIFF
--- a/internal/testing/offer/offer_prevtxn_stamp_test.go
+++ b/internal/testing/offer/offer_prevtxn_stamp_test.go
@@ -1,0 +1,111 @@
+package offer
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOffer_PartialConsumeRoundsBack_NoGhostModifiedNode pins the issue #1081
+// fix: when a crossing draws a tiny amount out of a near-maximum 1:1 offer, the
+// offer's recomputed TakerPays/TakerGets round back to byte-identical values, so
+// the resting offer must be left completely untouched — no ModifiedNode at all.
+//
+// The mainnet account_hash fork at ledger 99238379 (tx #57) happened because
+// consumeOffer's partial-consume branch stamped PreviousTxnID/PreviousTxnLgrSeq
+// on the offer before serializing. When the consumed amount is far below the
+// 16-significant-digit IOU precision of the offer's amounts (here ~1e96), the
+// recomputed amounts are byte-identical to the originals, so the stamp was the
+// ONLY difference between the original and current SLE — defeating the
+// bytes.Equal(Original, Current) skip in the meta loop and emitting a ghost
+// ModifiedNode (one extra node vs rippled). Threading is the ApplyStateTable's
+// job and runs only after that changed-check, mirroring rippled:
+//
+//	rippled/src/xrpld/app/tx/detail/Offer.h:120-122 (consume() only subtracts)
+//	rippled/src/xrpld/ledger/detail/ApplyStateTable.cpp:156 (skip when *cur==*orig)
+//
+// Existing offer/payment suites did not catch this — the divergence only appears
+// when a partial consume rounds back byte-identical, which needs an offer at
+// near-maximum magnitude. This test constructs exactly that case.
+func TestOffer_PartialConsumeRoundsBack_NoGhostModifiedNode(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	gw := jtx.NewAccount("gateway")
+	mm := jtx.NewAccount("marketmaker")
+	taker := jtx.NewAccount("taker")
+
+	env.FundAmount(gw, uint64(jtx.XRP(100000)))
+	env.FundAmount(mm, uint64(jtx.XRP(100000)))
+	env.FundAmount(taker, uint64(jtx.XRP(100000)))
+	env.Close()
+
+	// Trust lines: both parties hold USD and EUR issued by gw.
+	env.Trust(mm, jtx.USD(gw, 2_000_000))
+	env.Trust(mm, jtx.EUR(gw, 2_000_000))
+	env.Trust(taker, jtx.USD(gw, 2_000_000))
+	env.Trust(taker, jtx.EUR(gw, 2_000_000))
+	env.Close()
+
+	// mm holds USD to deliver; taker holds EUR to pay with.
+	jtx.RequireTxSuccess(t, env.Submit(payment.PayIssued(gw, mm, jtx.USD(gw, 1_000_000)).Build()))
+	jtx.RequireTxSuccess(t, env.Submit(payment.PayIssued(gw, taker, jtx.EUR(gw, 1_000_000)).Build()))
+	env.Close()
+
+	// Near-maximum 1:1 offer: mm gives USD, receives EUR, both at 9999999999999999e80.
+	// The maximum-magnitude amounts make any normal-sized fill round back to the
+	// same 16-significant-digit value.
+	maxUSD := jtx.IssuedCurrencyFromMantissa(gw, "USD", 9999999999999999, 80)
+	maxEUR := jtx.IssuedCurrencyFromMantissa(gw, "EUR", 9999999999999999, 80)
+
+	mmOfferSeq := env.Seq(mm)
+	jtx.RequireTxSuccess(t, env.Submit(OfferCreate(mm, maxEUR, maxUSD).Build()))
+	env.Close()
+
+	// taker crosses, taking 100 USD for 100 EUR — a tiny slice of the huge offer.
+	cross := env.Submit(OfferCreate(taker, jtx.USD(gw, 100), jtx.EUR(gw, 100)).Build())
+	jtx.RequireTxSuccess(t, cross)
+
+	// Sanity: the crossing really executed against mm's offer (otherwise the
+	// no-ghost-node assertion below would pass vacuously).
+	jtx.RequireIOUBalance(t, env, taker, gw, "USD", 100)
+	jtx.RequireIOUBalance(t, env, taker, gw, "EUR", 999_900)
+	jtx.RequireIOUBalance(t, env, mm, gw, "USD", 999_900)
+	jtx.RequireIOUBalance(t, env, mm, gw, "EUR", 100)
+
+	require.NotNil(t, cross.Metadata, "crossing OfferCreate has nil Metadata")
+
+	// mm's offer rounded back byte-identical, so it must NOT appear in the
+	// crossing's AffectedNodes at all — not as a ModifiedNode, not as anything.
+	mmOfferKey := keylet.Offer(mm.ID, mmOfferSeq).Key
+	mmOfferIndex := strings.ToUpper(hex.EncodeToString(mmOfferKey[:]))
+	offerMods := 0
+	mmOfferTouched := false
+	for _, n := range cross.Metadata.AffectedNodes {
+		if n.LedgerEntryType == "Offer" && n.NodeType == "ModifiedNode" {
+			offerMods++
+		}
+		if strings.EqualFold(n.LedgerIndex, mmOfferIndex) {
+			mmOfferTouched = true
+		}
+	}
+
+	require.Equal(t, 0, offerMods,
+		"partial consume that rounds back byte-identical emitted %d ghost Offer ModifiedNode(s); "+
+			"expected 0 (matches rippled ApplyStateTable.cpp:156)", offerMods)
+	require.False(t, mmOfferTouched,
+		"mm's resting offer (%s) appeared in AffectedNodes; a round-back-identical consume must leave it untouched",
+		mmOfferIndex)
+
+	// The offer is still in the ledger with its amounts unchanged.
+	resting := GetOffer(env, mm, mmOfferSeq)
+	require.NotNil(t, resting, "mm's resting offer should still exist")
+	require.True(t, amountsEqual(resting.TakerGets, maxUSD),
+		"mm offer TakerGets changed: got %v, want %v", resting.TakerGets, maxUSD)
+	require.True(t, amountsEqual(resting.TakerPays, maxEUR),
+		"mm offer TakerPays changed: got %v, want %v", resting.TakerPays, maxEUR)
+}

--- a/internal/tx/payment/step_book_consume.go
+++ b/internal/tx/payment/step_book_consume.go
@@ -99,12 +99,13 @@ func (s *BookStep) consumeOffer(sb *PaymentSandbox, offer *state.LedgerOffer, co
 			return err
 		}
 	} else {
-		// Partially consumed — just update the offer amounts.
-		// Do NOT check remaining funding here. Rippled's consume() does not
-		// check funding; the OfferStream handles unfunded detection on the
-		// next step() call.
-		offer.PreviousTxnID = txHash
-		offer.PreviousTxnLgrSeq = ledgerSeq
+		// Partially consumed — just update the offer amounts. Do NOT stamp
+		// PreviousTxnID here: threading is the ApplyStateTable's job and runs
+		// only after the node-changed check, so an offer whose recomputed
+		// amounts round back to byte-identical values is correctly left
+		// untouched instead of emitting a ghost ModifiedNode.
+		// Do NOT check remaining funding here either; the OfferStream handles
+		// unfunded detection on the next step() call.
 		offerData, err := state.SerializeLedgerOffer(offer)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary
- `consumeOffer`'s partial-consume branch stamped `PreviousTxnID`/`PreviousTxnLgrSeq` on the offer before serializing it back to the sandbox. When a crossing draws from a near-infinite offer whose recomputed `TakerGets`/`TakerPays` round back to byte-identical values, that stamp was the **only** byte difference between the offer's original and modified serialization — defeating `ApplyStateTable`'s `Original == Current` skip and emitting a ghost `ModifiedNode` (5 affected nodes vs mainnet's 4), forking `account_hash` at ledger **99238379** (tx#57).
- Removed the stamp. Threading is `ApplyStateTable`'s job and runs only after the node-changed check, so an offer whose amounts round back identical is correctly left untouched, matching rippled (`Offer::consume()` only subtracts; `threadItem` runs after `*curNode == *origNode`).
- Normal partial consumes are unaffected: when `TakerGets`/`TakerPays` actually change, `Original != Current` via the amount change, so the node is still threaded and emitted with the correct old node-level `PreviousTxnID` read from the original. The fully-consumed (delete) branch was never stamped and is unchanged.

## Test plan
- [x] `go test ./internal/tx/payment/... ./internal/tx/offer/... ./internal/testing/payment/... ./internal/testing/offer/...` — all green (incl. the full 128s offer suite)
- [x] Conformance unchanged vs clean `main`: in-scope 1132 pass / 9 fail (99.2%), total 1310 pass / 205 fail — byte-identical baseline, zero regression

Fixes #1081