### PR TITLE
Speed up replay-range: profiling hook + Tier-1 hot-path & nodestore cache fixes (#1084)

### DIFF
--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -54,7 +54,7 @@ func newMetricsRegistry() *prometheus.Registry {
 }
 
 // startMetricsServer serves Prometheus metrics at /metrics on addr. It
-// mirrors startPProfServer: a standalone auxiliary HTTP server enabled
+// mirrors observability.StartPProf: a standalone auxiliary HTTP server enabled
 // out-of-band (via the GOXRPL_METRICS env var) and never mounted on the
 // public JSON-RPC ports, keeping scrape traffic and internal telemetry off
 // the client-facing API surface.

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -111,7 +111,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 	// Set GOXRPL_PPROF=:6060 (or any addr:port) to enable pprof. Off by default.
 	if addr := os.Getenv("GOXRPL_PPROF"); addr != "" {
 		go func() {
-			if err := startPProfServer(addr); err != nil {
+			if err := observability.StartPProf(addr); err != nil {
 				serverLog.Warn("pprof server failed", "addr", addr, "err", err)
 			}
 		}()

--- a/internal/observability/pprof.go
+++ b/internal/observability/pprof.go
@@ -1,4 +1,4 @@
-package cli
+package observability
 
 import (
 	"net/http"
@@ -7,13 +7,17 @@ import (
 	"time"
 )
 
-// Mutex + block profile rates are tuned to keep overhead bounded:
+// StartPProf runs a pprof HTTP server on addr, blocking until it returns, and
+// is shared by the long-running commands (server, replay-range) so profiles can
+// be captured without each re-implementing the wiring. Run it in its own
+// goroutine.
+//
+// Mutex and block profile rates are tuned to keep overhead bounded:
 //   - MutexProfileFraction=100 samples 1-in-100 contention events; fraction=1
 //     can dominate cost on hot locks without adding ranking precision.
-//   - BlockProfileRate=1_000_000 ns samples blocks of ~1ms or longer; rate=1
-//     captures every channel/sync block — orders of magnitude more samples
-//     than needed to identify off-CPU hotspots.
-func startPProfServer(addr string) error {
+//   - BlockProfileRate=1_000_000 ns samples blocks of ~1ms or longer, enough to
+//     surface off-CPU (DB / blob-store) wait without flooding the profile.
+func StartPProf(addr string) error {
 	runtime.SetMutexProfileFraction(100)
 	runtime.SetBlockProfileRate(1_000_000)
 

--- a/internal/replaytool/replay.go
+++ b/internal/replaytool/replay.go
@@ -104,6 +104,7 @@ type TxApplyInfo struct {
 	DecodedTx  map[string]any
 	Metadata   *tx.Metadata
 	Error      string
+	RawBlob    []byte `json:"-"`
 }
 
 // ReplayResult contains the results of the replay
@@ -399,8 +400,9 @@ func (r *replayRunner) executeReplayVerbose(state *StateFixture, env *EnvFixture
 	engine := txengine.NewEngine(openLedger, engineConfig)
 	blockProcessor := txengine.NewBlockProcessor(engine)
 
-	// The full per-tx decode feeds only verbose/decoded output and the JSON
-	// result/dump artifacts; it is not needed for the apply path itself.
+	// The full per-tx decode feeds verbose/decoded output and the JSON result
+	// artifact; the apply path never needs it, and the on-failure dump backfills
+	// it on demand from the retained blob.
 	wantTxDetail := r.verbose || r.dumpState || r.showDecoded || r.outputResult != ""
 	for _, txEntry := range txs.Transactions {
 		txInfo := TxApplyInfo{
@@ -665,6 +667,7 @@ func (r *replayRunner) dumpDebugInfo(result *ReplayResult, preState *StateFixtur
 	fmt.Fprintf(r.out, "State diff: +%d added, ~%d modified, -%d removed\n", added, modified, removed)
 
 	txResultsFile := filepath.Join(dir, "tx_results.json")
+	materializeDecoded(result.TxResults)
 	if err := writeJSONFile(txResultsFile, result.TxResults); err != nil {
 		fmt.Fprintf(r.out, "ERROR: Failed to write tx_results.json: %v\n", err)
 	} else {
@@ -682,14 +685,40 @@ func decodeEntryData(hexData string) map[string]any {
 	return decoded
 }
 
+// decodeEntryBytes decodes an already-binary blob directly, skipping the hex
+// round-trip decodeEntryData would impose.
+func decodeEntryBytes(blob []byte) map[string]any {
+	decoded, err := binarycodec.DecodeBytes(blob)
+	if err != nil {
+		return nil
+	}
+	return decoded
+}
+
+// materializeDecoded fills DecodedTx for any result still missing it, decoding
+// from the retained raw blob. The apply path leaves DecodedTx nil on the hot
+// success path (the ledger hashes never read it); the on-failure debug dump
+// calls this so tx_results.json is complete even on a run that did not request
+// per-tx detail up front.
+func materializeDecoded(results []TxApplyInfo) {
+	for i := range results {
+		if results[i].DecodedTx == nil && len(results[i].RawBlob) > 0 {
+			results[i].DecodedTx = decodeEntryBytes(results[i].RawBlob)
+		}
+	}
+}
+
 // fillTxDisplay populates txInfo's display/diagnostic fields. TxType and Account
 // are read straight from the already-parsed transaction, so the hot path never
 // decodes the blob a second time (the engine's ParseAndPrepare already decoded
 // it). The full DecodedTx map — read only by verbose output and the on-failure
-// debug dump / findings, never by the three ledger hashes — is materialized
-// lazily: when wantDetail is set, or when parsed is nil (a parse failure, where
-// a best-effort decode is the only way to label the tx for the dump).
+// debug dump, never by the three ledger hashes — is materialized lazily: when
+// wantDetail is set, or when parsed is nil (a parse failure, where a best-effort
+// decode is the only way to label the tx). The raw blob is retained so a dump
+// triggered by a late failure can still materialize DecodedTx on demand (see
+// materializeDecoded) without the hot path paying for the decode.
 func fillTxDisplay(txInfo *TxApplyInfo, blob []byte, parsed tx.Transaction, wantDetail bool) {
+	txInfo.RawBlob = blob
 	if parsed != nil {
 		c := parsed.GetCommon()
 		txInfo.TxType = c.TransactionType
@@ -698,7 +727,7 @@ func fillTxDisplay(txInfo *TxApplyInfo, blob []byte, parsed tx.Transaction, want
 			return
 		}
 	}
-	decoded := decodeEntryData(hex.EncodeToString(blob))
+	decoded := decodeEntryBytes(blob)
 	if decoded == nil {
 		return
 	}

--- a/internal/replaytool/replay.go
+++ b/internal/replaytool/replay.go
@@ -399,6 +399,9 @@ func (r *replayRunner) executeReplayVerbose(state *StateFixture, env *EnvFixture
 	engine := txengine.NewEngine(openLedger, engineConfig)
 	blockProcessor := txengine.NewBlockProcessor(engine)
 
+	// The full per-tx decode feeds only verbose/decoded output and the JSON
+	// result/dump artifacts; it is not needed for the apply path itself.
+	wantTxDetail := r.verbose || r.dumpState || r.showDecoded || r.outputResult != ""
 	for _, txEntry := range txs.Transactions {
 		txInfo := TxApplyInfo{
 			Index: txEntry.Index,
@@ -415,27 +418,18 @@ func (r *replayRunner) executeReplayVerbose(state *StateFixture, env *EnvFixture
 			continue
 		}
 
-		// Decode transaction for display
-		txInfo.DecodedTx = decodeEntryData(txEntry.TxBlob)
-		if txInfo.DecodedTx != nil {
-			if txType, ok := txInfo.DecodedTx["TransactionType"].(string); ok {
-				txInfo.TxType = txType
-			}
-			if account, ok := txInfo.DecodedTx["Account"].(string); ok {
-				txInfo.Account = account
-			}
-		}
-
 		// Parse and prepare the transaction
 		parsedTx, err := txengine.ParseAndPrepare(txBlob)
 		if err != nil {
 			txInfo.Error = fmt.Sprintf("failed to parse: %v", err)
 			txInfo.Applied = false
+			fillTxDisplay(&txInfo, txBlob, nil, wantTxDetail)
 			result.TxResults = append(result.TxResults, txInfo)
 			result.Errors = append(result.Errors, fmt.Sprintf("tx %d: %s", txEntry.Index, txInfo.Error))
 			result.Success = false
 			continue
 		}
+		fillTxDisplay(&txInfo, txBlob, parsedTx.Transaction, wantTxDetail)
 
 		// Apply the transaction using the BlockProcessor
 		// This handles: applying, setting transaction index, creating tx+meta blob
@@ -686,6 +680,37 @@ func decodeEntryData(hexData string) map[string]any {
 		return nil
 	}
 	return decoded
+}
+
+// fillTxDisplay populates txInfo's display/diagnostic fields. TxType and Account
+// are read straight from the already-parsed transaction, so the hot path never
+// decodes the blob a second time (the engine's ParseAndPrepare already decoded
+// it). The full DecodedTx map — read only by verbose output and the on-failure
+// debug dump / findings, never by the three ledger hashes — is materialized
+// lazily: when wantDetail is set, or when parsed is nil (a parse failure, where
+// a best-effort decode is the only way to label the tx for the dump).
+func fillTxDisplay(txInfo *TxApplyInfo, blob []byte, parsed tx.Transaction, wantDetail bool) {
+	if parsed != nil {
+		c := parsed.GetCommon()
+		txInfo.TxType = c.TransactionType
+		txInfo.Account = c.Account
+		if !wantDetail {
+			return
+		}
+	}
+	decoded := decodeEntryData(hex.EncodeToString(blob))
+	if decoded == nil {
+		return
+	}
+	txInfo.DecodedTx = decoded
+	if parsed == nil {
+		if t, ok := decoded["TransactionType"].(string); ok {
+			txInfo.TxType = t
+		}
+		if a, ok := decoded["Account"].(string); ok {
+			txInfo.Account = a
+		}
+	}
 }
 
 // buildRulesFromAmendments creates amendment rules from a list of amendment names or IDs.

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -682,9 +682,9 @@ func (r *replayRangeRunner) processBlock(
 	engine := txengine.NewEngine(openLedger, engineConfig)
 	blockProcessor := txengine.NewBlockProcessor(engine)
 
-	// Apply transactions. The full per-tx decode is only needed for verbose
-	// output or the on-failure debug dump; the three ledger hashes never read
-	// it, so the hot success path skips it.
+	// Apply transactions. The hot success path skips the full per-tx decode: the
+	// three ledger hashes never read it, verbose output gates it, and the
+	// on-failure dump materializes it on demand from the retained blob.
 	wantTxDetail := r.verbose || r.dumpDir != ""
 	for _, txEntry := range txs {
 		txInfo := TxApplyInfo{
@@ -822,6 +822,7 @@ func hexStateMap(stateMap *shamap.SHAMap) map[string]string {
 // writeTxResults writes the per-transaction apply results for a block.
 func (r *replayRangeRunner) writeTxResults(dir string, result *BlockResult) {
 	txResultsFile := filepath.Join(dir, "tx_results.json")
+	materializeDecoded(result.TxResults)
 	if err := writeJSONFile(txResultsFile, result.TxResults); err != nil {
 		fmt.Fprintf(r.out, "  ERROR: Failed to write tx_results.json: %v\n", err)
 		return

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/observability"
 	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
 
 	"github.com/spf13/cobra"
@@ -41,6 +43,9 @@ type replayRangeRunner struct {
 	checkpointInterval   uint32
 	resumeFrom           uint32
 	nodestoreDir         string
+	baseCacheMB          int
+	overlayCacheMB       int
+	gogc                 int
 	continueOnDivergence bool
 	findingsOut          string
 	goxrplCommit         string
@@ -118,6 +123,9 @@ Example:
 	cmd.Flags().Uint32Var(&r.checkpointInterval, "checkpoint-interval", 10000, "Write a checkpoint every N ledgers (requires --checkpoint-dir)")
 	cmd.Flags().Uint32Var(&r.resumeFrom, "resume-from", 0, "Resume from the checkpoint at this ledger seq (requires --checkpoint-dir)")
 	cmd.Flags().StringVar(&r.nodestoreDir, "nodestore-dir", "", "Node-local directory for the lazy pebble nodestore (shared read-only checkpoint base + per-run overlay). When set, seed state is held lazily instead of fully in RAM.")
+	cmd.Flags().IntVar(&r.baseCacheMB, "base-cache-mb", 1024, "Pebble block-cache size (MiB) for the shared read-only nodestore base (only used with --nodestore-dir)")
+	cmd.Flags().IntVar(&r.overlayCacheMB, "overlay-cache-mb", 256, "Pebble block-cache size (MiB) for the per-run nodestore overlay (only used with --nodestore-dir)")
+	cmd.Flags().IntVar(&r.gogc, "gogc", 0, "If >0, set GOGC for this run, raising the GC trigger to cut collection frequency on the default in-memory state path (which keeps the whole tree live). 0 leaves Go's default.")
 	cmd.Flags().BoolVar(&r.continueOnDivergence, "continue-on-divergence", false, "On a hash mismatch, record a finding and reset to mainnet ground truth, then continue (survey all divergences) instead of stopping")
 	cmd.Flags().StringVar(&r.findingsOut, "findings-out", "", "Path to the findings JSONL file (default <dump-dir>/findings.jsonl or ./debug/findings.jsonl); used with --continue-on-divergence")
 	cmd.Flags().StringVar(&r.goxrplCommit, "goxrpl-commit", "", "Commit/image tag recorded in findings (default: VCS revision from build info)")
@@ -168,6 +176,23 @@ func (r *replayRangeRunner) run() error {
 	ctx := context.Background()
 	startTime := time.Now()
 
+	// Opt-in profiling: GOXRPL_PPROF=:6060 exposes pprof for this run so the
+	// CPU-vs-IO split of a replay can be measured. Off by default.
+	if addr := os.Getenv("GOXRPL_PPROF"); addr != "" {
+		go func() {
+			if err := observability.StartPProf(addr); err != nil {
+				fmt.Fprintf(r.out, "      WARNING: pprof server failed on %s: %v\n", addr, err)
+			}
+		}()
+		fmt.Fprintf(r.out, "pprof enabled on %s\n", addr)
+	}
+
+	// The default in-memory state path keeps the whole tree live for the run, so
+	// a higher GC trigger trades RAM for fewer full marks of a mostly-static set.
+	if r.gogc > 0 {
+		debug.SetGCPercent(r.gogc)
+	}
+
 	fmt.Fprintln(r.out, "================================================================================")
 	fmt.Fprintln(r.out, "                    XRPL Continuous State Replay")
 	fmt.Fprintln(r.out, "================================================================================")
@@ -195,7 +220,7 @@ func (r *replayRangeRunner) run() error {
 	}
 	fmt.Fprintf(r.out, "      All %d ledgers present in database\n", r.to-startLedger+1)
 
-	source, err := newStateSource(client, r.nodestoreDir)
+	source, err := newStateSource(client, r.nodestoreDir, r.baseCacheMB, r.overlayCacheMB)
 	if err != nil {
 		return fmt.Errorf("initializing state source: %w", err)
 	}
@@ -657,32 +682,26 @@ func (r *replayRangeRunner) processBlock(
 	engine := txengine.NewEngine(openLedger, engineConfig)
 	blockProcessor := txengine.NewBlockProcessor(engine)
 
-	// Apply transactions
+	// Apply transactions. The full per-tx decode is only needed for verbose
+	// output or the on-failure debug dump; the three ledger hashes never read
+	// it, so the hot success path skips it.
+	wantTxDetail := r.verbose || r.dumpDir != ""
 	for _, txEntry := range txs {
 		txInfo := TxApplyInfo{
 			Index: txEntry.TxIndex,
 			Hash:  hex.EncodeToString(txEntry.TxHash[:]),
 		}
 
-		// Decode for display
-		txInfo.DecodedTx = decodeEntryData(hex.EncodeToString(txEntry.TxBlob))
-		if txInfo.DecodedTx != nil {
-			if txType, ok := txInfo.DecodedTx["TransactionType"].(string); ok {
-				txInfo.TxType = txType
-			}
-			if account, ok := txInfo.DecodedTx["Account"].(string); ok {
-				txInfo.Account = account
-			}
-		}
-
 		// Parse transaction
 		parsedTx, err := txengine.ParseAndPrepare(txEntry.TxBlob)
 		if err != nil {
 			txInfo.Error = fmt.Sprintf("failed to parse: %v", err)
+			fillTxDisplay(&txInfo, txEntry.TxBlob, nil, wantTxDetail)
 			result.TxResults = append(result.TxResults, txInfo)
 			result.Errors = append(result.Errors, fmt.Sprintf("tx %d: %s", txEntry.TxIndex, txInfo.Error))
 			continue
 		}
+		fillTxDisplay(&txInfo, txEntry.TxBlob, parsedTx.Transaction, wantTxDetail)
 
 		// Apply transaction
 		blockTxResult, err := blockProcessor.ApplyTransaction(parsedTx.Transaction, parsedTx.RawBlob)

--- a/internal/replaytool/replay_state_source.go
+++ b/internal/replaytool/replay_state_source.go
@@ -42,22 +42,26 @@ func (s *memoryStateSource) Close() error { return nil }
 // and a fresh per-run overlay captures the segment's mutations so the base
 // stays pristine and shareable.
 type nodestoreStateSource struct {
-	client     *statecompare.Client
-	dir        string
-	overlay    *shamap.NodeStoreFamily
-	overlayDir string
-	opened     []*shamap.NodeStoreFamily
+	client         *statecompare.Client
+	dir            string
+	baseCacheMB    int
+	overlayCacheMB int
+	overlay        *shamap.NodeStoreFamily
+	overlayDir     string
+	opened         []*shamap.NodeStoreFamily
 }
 
-// baseCacheMB / overlayCacheMB bound the resident node cache for the base and
-// overlay pebble stores. The base is read-heavy (the whole checkpoint); the
-// overlay only sees a segment's mutations.
+// baseNodeCacheItems / overlayNodeCacheItems size the positive node LRU (a count
+// of decoded entries, independent of the Pebble block-cache MiB budget). The
+// base is read-heavy (the whole checkpoint) so it warrants a far larger working
+// set than the overlay, which only sees a segment's mutations. Both are generous
+// but bounded so a long run does not grow the heap without limit.
 const (
-	baseCacheMB    = 1024
-	overlayCacheMB = 256
+	baseNodeCacheItems    = 262144
+	overlayNodeCacheItems = 65536
 )
 
-func newNodestoreStateSource(client *statecompare.Client, dir string) (*nodestoreStateSource, error) {
+func newNodestoreStateSource(client *statecompare.Client, dir string, baseCacheMB, overlayCacheMB int) (*nodestoreStateSource, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("creating nodestore dir: %w", err)
 	}
@@ -67,17 +71,19 @@ func newNodestoreStateSource(client *statecompare.Client, dir string) (*nodestor
 	if err != nil {
 		return nil, fmt.Errorf("creating overlay dir: %w", err)
 	}
-	overlay, err := shamap.NewPebbleNodeStoreFamily(overlayDir, overlayCacheMB)
+	overlay, err := shamap.NewPebbleNodeStoreFamily(overlayDir, overlayCacheMB, overlayNodeCacheItems)
 	if err != nil {
 		os.RemoveAll(overlayDir)
 		return nil, fmt.Errorf("opening overlay nodestore: %w", err)
 	}
 	return &nodestoreStateSource{
-		client:     client,
-		dir:        dir,
-		overlay:    overlay,
-		overlayDir: overlayDir,
-		opened:     []*shamap.NodeStoreFamily{overlay},
+		client:         client,
+		dir:            dir,
+		baseCacheMB:    baseCacheMB,
+		overlayCacheMB: overlayCacheMB,
+		overlay:        overlay,
+		overlayDir:     overlayDir,
+		opened:         []*shamap.NodeStoreFamily{overlay},
 	}, nil
 }
 
@@ -88,7 +94,7 @@ func (s *nodestoreStateSource) Load(ctx context.Context, ledgerIndex uint32) (*s
 	}
 
 	basePath := filepath.Join(s.dir, fmt.Sprintf("ckpt-%d", ledgerIndex))
-	base, err := shamap.NewPebbleNodeStoreFamily(basePath, baseCacheMB)
+	base, err := shamap.NewPebbleNodeStoreFamily(basePath, s.baseCacheMB, baseNodeCacheItems)
 	if err != nil {
 		return nil, nil, drops.Fees{}, fmt.Errorf("opening base nodestore %s: %w", basePath, err)
 	}
@@ -203,10 +209,12 @@ func flushToFamily(ctx context.Context, m *shamap.SHAMap, fam shamap.Family) err
 }
 
 // newStateSource returns the nodestore-lazy source when dir is set, otherwise
-// the in-memory source.
-func newStateSource(client *statecompare.Client, nodestoreDir string) (StateSource, error) {
+// the in-memory source. baseCacheMB / overlayCacheMB size the Pebble block
+// caches of the nodestore base and overlay; they are ignored by the in-memory
+// source.
+func newStateSource(client *statecompare.Client, nodestoreDir string, baseCacheMB, overlayCacheMB int) (StateSource, error) {
 	if nodestoreDir == "" {
 		return &memoryStateSource{client: client}, nil
 	}
-	return newNodestoreStateSource(client, nodestoreDir)
+	return newNodestoreStateSource(client, nodestoreDir, baseCacheMB, overlayCacheMB)
 }

--- a/internal/replaytool/replay_txdisplay_test.go
+++ b/internal/replaytool/replay_txdisplay_test.go
@@ -1,0 +1,82 @@
+package replaytool
+
+import (
+	"encoding/hex"
+	"testing"
+
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
+)
+
+// A real serialized transaction blob (SigningPubKey + signature + Account
+// present) used to exercise fillTxDisplay's three paths.
+const sampleTxBlobHex = "1200192400000001202A0000000068400000000000000A73210330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD02074473045022100858210F05EA58ACCAD60DA2EB7D505EF56016E0D323698D4819199358809120D022007B68AF69934E1E1DD12CC2A9E5D0F9696D5BDFA8CAA50CA29A36B9AA26C2F0A8114B5F762798A53D543A014CAF8B297CFF8F2F937E8"
+
+// TestFillTxDisplay locks the contract that matters for hash-safety: the
+// display fields fillTxDisplay derives from the parsed transaction must equal
+// what a full decode of the same blob produces, and the expensive DecodedTx map
+// must only be materialized when a consumer asks for it (or on a parse failure,
+// where a best-effort decode is the only labeling option).
+func TestFillTxDisplay(t *testing.T) {
+	blob, err := hex.DecodeString(sampleTxBlobHex)
+	if err != nil {
+		t.Fatalf("decoding sample blob: %v", err)
+	}
+	parsed, err := txengine.ParseAndPrepare(blob)
+	if err != nil {
+		t.Fatalf("parsing sample blob: %v", err)
+	}
+	common := parsed.Transaction.GetCommon()
+	decoded := decodeEntryData(sampleTxBlobHex)
+	if decoded == nil {
+		t.Fatal("sample blob did not decode")
+	}
+
+	// The parse-sourced fields must match the decode-sourced fields exactly;
+	// otherwise switching the hot path to GetCommon would change displayed/
+	// recorded values.
+	if common.TransactionType != decoded["TransactionType"] {
+		t.Fatalf("parse vs decode TransactionType mismatch: %q != %v", common.TransactionType, decoded["TransactionType"])
+	}
+	if common.Account != decoded["Account"] {
+		t.Fatalf("parse vs decode Account mismatch: %q != %v", common.Account, decoded["Account"])
+	}
+
+	t.Run("hot path skips the decode", func(t *testing.T) {
+		var info TxApplyInfo
+		fillTxDisplay(&info, blob, parsed.Transaction, false)
+		if info.TxType != common.TransactionType {
+			t.Errorf("TxType = %q, want %q", info.TxType, common.TransactionType)
+		}
+		if info.Account != common.Account {
+			t.Errorf("Account = %q, want %q", info.Account, common.Account)
+		}
+		if info.DecodedTx != nil {
+			t.Errorf("DecodedTx populated on hot path; should be lazy")
+		}
+	})
+
+	t.Run("detail path materializes the decode", func(t *testing.T) {
+		var info TxApplyInfo
+		fillTxDisplay(&info, blob, parsed.Transaction, true)
+		if info.DecodedTx == nil {
+			t.Errorf("DecodedTx nil when detail requested")
+		}
+		if info.TxType != common.TransactionType {
+			t.Errorf("TxType = %q, want %q", info.TxType, common.TransactionType)
+		}
+	})
+
+	t.Run("parse failure still labels the tx", func(t *testing.T) {
+		var info TxApplyInfo
+		fillTxDisplay(&info, blob, nil, false)
+		if info.DecodedTx == nil {
+			t.Errorf("expected best-effort decode on parse failure")
+		}
+		if info.TxType != common.TransactionType {
+			t.Errorf("TxType = %q, want %q", info.TxType, common.TransactionType)
+		}
+		if info.Account != common.Account {
+			t.Errorf("Account = %q, want %q", info.Account, common.Account)
+		}
+	})
+}

--- a/internal/replaytool/replay_txdisplay_test.go
+++ b/internal/replaytool/replay_txdisplay_test.go
@@ -53,6 +53,31 @@ func TestFillTxDisplay(t *testing.T) {
 		if info.DecodedTx != nil {
 			t.Errorf("DecodedTx populated on hot path; should be lazy")
 		}
+		if len(info.RawBlob) == 0 {
+			t.Errorf("RawBlob not retained on hot path; a late-failure dump could not recover DecodedTx")
+		}
+	})
+
+	// A divergence dump can fire even on a run that skipped per-tx detail (no
+	// --dump-dir / -v). materializeDecoded must backfill DecodedTx from the
+	// retained blob so tx_results.json is never silently missing it.
+	t.Run("dump materializes the decode on demand", func(t *testing.T) {
+		var info TxApplyInfo
+		fillTxDisplay(&info, blob, parsed.Transaction, false)
+		if info.DecodedTx != nil {
+			t.Fatal("precondition: DecodedTx should be nil before materialize")
+		}
+		results := []TxApplyInfo{info}
+		materializeDecoded(results)
+		if results[0].DecodedTx == nil {
+			t.Fatal("materializeDecoded did not backfill DecodedTx")
+		}
+		if results[0].DecodedTx["TransactionType"] != decoded["TransactionType"] {
+			t.Errorf("backfilled TransactionType = %v, want %v", results[0].DecodedTx["TransactionType"], decoded["TransactionType"])
+		}
+		if results[0].DecodedTx["Account"] != decoded["Account"] {
+			t.Errorf("backfilled Account = %v, want %v", results[0].DecodedTx["Account"], decoded["Account"])
+		}
 	})
 
 	t.Run("detail path materializes the decode", func(t *testing.T) {

--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -269,7 +269,7 @@ func NewTestEnvBacked(t testing.TB) *TestEnv {
 // Must be called before any transactions are submitted.
 func (e *TestEnv) enablePebbleBacking(t testing.TB) {
 	t.Helper()
-	stateFamily, err := shamap.NewPebbleNodeStoreFamily(t.TempDir(), 200000)
+	stateFamily, err := shamap.NewPebbleNodeStoreFamily(t.TempDir(), 256, 200000)
 	if err != nil {
 		t.Fatalf("Failed to create state family: %v", err)
 	}

--- a/shamap/nodestore_family.go
+++ b/shamap/nodestore_family.go
@@ -39,15 +39,24 @@ func NewMemoryNodeStoreFamily() *NodeStoreFamily {
 }
 
 // NewPebbleNodeStoreFamily creates a Family backed by PebbleDB on disk.
-// Data persists to disk; the LRU cache bounds RAM usage. For production.
-func NewPebbleNodeStoreFamily(path string, cacheSize int) (*NodeStoreFamily, error) {
-	store, err := kvpebble.New(path, cacheSize*1024*1024, 500, false)
+// Data persists to disk; the caches bound RAM usage. For production.
+//
+// The two cache budgets are independent units and must be passed separately:
+//   - blockCacheMB sizes Pebble's block cache (decompressed SSTable blocks) in
+//     MiB, avoiding disk reads.
+//   - nodeCacheItems caps the positive LRU of decoded nodes as a COUNT of
+//     entries (not bytes), avoiding the Pebble lookup + deserialize on a hit.
+//
+// They were previously a single argument fed to both, so a "1024 MiB" intent
+// silently produced a 1024-entry node LRU over a multi-million-node tree.
+func NewPebbleNodeStoreFamily(path string, blockCacheMB, nodeCacheItems int) (*NodeStoreFamily, error) {
+	store, err := kvpebble.New(path, blockCacheMB*1024*1024, 500, false)
 	if err != nil {
 		return nil, err
 	}
 
 	dbConfig := &nodestore.DatabaseConfig{
-		CacheSize:            cacheSize,
+		CacheSize:            nodeCacheItems,
 		CacheTTL:             time.Hour,
 		NegativeCacheTTL:     5 * time.Minute,
 		NegativeCacheMaxSize: 100000,

--- a/shamap/nodestore_family.go
+++ b/shamap/nodestore_family.go
@@ -46,9 +46,6 @@ func NewMemoryNodeStoreFamily() *NodeStoreFamily {
 //     MiB, avoiding disk reads.
 //   - nodeCacheItems caps the positive LRU of decoded nodes as a COUNT of
 //     entries (not bytes), avoiding the Pebble lookup + deserialize on a hit.
-//
-// They were previously a single argument fed to both, so a "1024 MiB" intent
-// silently produced a 1024-entry node LRU over a multi-million-node tree.
 func NewPebbleNodeStoreFamily(path string, blockCacheMB, nodeCacheItems int) (*NodeStoreFamily, error) {
 	store, err := kvpebble.New(path, blockCacheMB*1024*1024, 500, false)
 	if err != nil {


### PR DESCRIPTION
Implements **Step 0 (profiling enablement) + Tier 1 (quick wins)** from #1084 — the low-risk, do-regardless-of-profile work. Prefetch (Tier 2) and range sharding (Tier 3) remain tracked in the issue as profile-gated / higher-effort follow-on phases.

**Hash-safety:** the replay tool exists to verify hash-exact conformance, so the bar for every change here is byte-identical output — same `ledger_hash` / `account_hash` / `transaction_hash` and per-tx TER. None of the changed code feeds those hashes; see verification below.

## What's in this PR

**Step 0 — profiling for `replay-range`**
- pprof was wired only into the `server` command. Moved the hook from `internal/cli` (which `replaytool` can't import without a cycle) into `internal/observability.StartPProf`, and call it from `replayRangeRunner.run()` gated on the same `GOXRPL_PPROF` env var. `server.go`/`metrics.go` now reference the shared helper.
- Capture a profile of a representative slice:
  ```
  GOXRPL_PPROF=:6060 ./tmp/main replay-range --from N --to N+1000 [--nodestore-dir ...]
  go tool pprof -http=: 'http://localhost:6060/debug/pprof/profile?seconds=60'   # CPU
  go tool pprof -http=: 'http://localhost:6060/debug/pprof/block'               # off-CPU I/O wait
  ```

**1.1 — drop the redundant per-tx decode** (`replay_range.go`, `replay.go`)
- Each tx blob was binary-decoded twice: once purely for display (`decodeEntryData`) and again in `ParseAndPrepare`. New `fillTxDisplay` helper sources `TxType`/`Account` from the already-parsed transaction (`GetCommon()`), and materializes the full `DecodedTx` map only when a consumer is configured (verbose / `--dump-dir` / `replay`'s `-o`/`--dump`/`-d`), or on a parse failure (best-effort decode to still label the tx for the dump). `buildFinding` only needs `TxType`, which is always set — so `--continue-on-divergence` surveys keep full findings without the per-tx decode.

**1.3 — fix the nodestore LRU cache-unit bug** (`shamap/nodestore_family.go`)
- `NewPebbleNodeStoreFamily(path, cacheSize)` fed one argument into two different units: Pebble's block cache in **MiB** and the node LRU as an **item count**. So the replay base passed `1024` → a **1024-entry** node LRU over a ~14M-node tree, while `internal/testing/env.go` passed `200000` intending items (→ a nonsensical 200 GB block-cache request). Split into explicit `blockCacheMB` + `nodeCacheItems`; updated all three callers. Replay now gets a 256k/64k-entry base/overlay node cache.

**1.4 — cache + GC knobs**
- `--base-cache-mb` / `--overlay-cache-mb` (Pebble block cache for the nodestore base/overlay; defaults 1024/256 preserve current behavior) and `--gogc` (raise the GC trigger on the default in-memory state path, which keeps the whole tree live). 

## Intentionally scoped out

Issue item **1.2** proposed also gating the per-tx hex hash, `Metadata` retention, and the `TxResults` append. The expensive part of 1.2 (the `DecodedTx` decode) is handled by the lazy gate above; the rest are pointer copies / small slice appends with negligible CPU, and gating them would empty the default `./debug` failure dump for blocks that diverge without `--dump-dir`. Left as-is to preserve the divergence-hunting workflow. Tier 2/3 deferred per the issue.

## Verification

- `go build ./...` (CGO) clean; `go vet` + `gofmt` clean.
- `go test ./internal/replaytool/... ./shamap/... ./internal/observability/... ./internal/cli/...` — pass.
- Pebble-backed offer tests (`internal/testing/offer -run CrossingLimits`, which use `NewTestEnvBacked`) pass — exercise the new node-cache signature at runtime.
- New `TestFillTxDisplay` locks the hash-safety contract: the parse-sourced `TxType`/`Account` equal a full decode of the same blob, and `DecodedTx` is only materialized when requested / on parse failure.
- Binary builds; `replay-range --help` shows the new flags with correct defaults.

Hash-safety argument: `DecodedTx`/`TxType`/`Account`/`Metadata` are read only by display, the failure dump, and findings — the three hashes come from `AddTransactionWithMeta`/`Apply`/`Close`, which never read `txInfo`. The node cache is content-addressed, so capacity only trades a RAM hit for a deserialize. pprof and GOGC are pure observation / GC timing.

Closes nothing — #1084 stays open to track Tier 2/3.
