### PR TITLE
Reject out-of-range MPT amounts on binary decode (GHSA-j5cw-qr86-mmv7)

### DIFF
--- a/internal/ledger/state/mpt_amount_binary_test.go
+++ b/internal/ledger/state/mpt_amount_binary_test.go
@@ -1,0 +1,63 @@
+package state
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// mptAmountBlob builds a 33-byte MPT amount: 1-byte header, 8-byte big-endian
+// magnitude, 24-byte issuance ID (left zero). header 0x60 = positive MPT,
+// 0x20 = negative MPT.
+func mptAmountBlob(header byte, magnitude uint64) []byte {
+	b := make([]byte, 33)
+	b[0] = header
+	binary.BigEndian.PutUint64(b[1:9], magnitude)
+	return b
+}
+
+// TestParseMPTAmountBinary_RejectsOverMaxInt64 guards GHSA-j5cw-qr86-mmv7: an
+// MPT magnitude >= 2^63 must be rejected, not silently wrapped through
+// num.Int64() into a negative value. rippled bounds MPT amounts at
+// maxMPTokenAmount = 2^63-1.
+func TestParseMPTAmountBinary_RejectsOverMaxInt64(t *testing.T) {
+	cases := []struct {
+		name      string
+		header    byte
+		magnitude uint64
+		wantErr   bool
+		wantRaw   int64
+	}{
+		// Exact advisory reproducer: magnitude 2^63 wraps to -2^63.
+		{"positive_two_pow_63", 0x60, 1 << 63, true, 0},
+		{"positive_max_uint64", 0x60, math.MaxUint64, true, 0},
+		{"negative_two_pow_63", 0x20, 1 << 63, true, 0},
+		{"positive_max_int64_ok", 0x60, math.MaxInt64, false, math.MaxInt64},
+		{"positive_small_ok", 0x60, 1234567890, false, 1234567890},
+		{"negative_small_ok", 0x20, 1234567890, false, -1234567890},
+		{"zero_ok", 0x60, 0, false, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			amt, err := ParseMPTAmountBinary(mptAmountBlob(tc.header, tc.magnitude))
+			if tc.wantErr {
+				if err == nil {
+					raw, _ := amt.MPTRaw()
+					t.Fatalf("expected out-of-range error for magnitude %d, got mptRaw=%d", tc.magnitude, raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			raw, ok := amt.MPTRaw()
+			if !ok {
+				t.Fatal("expected MPTRaw to be set")
+			}
+			if raw != tc.wantRaw {
+				t.Errorf("MPTRaw = %d, want %d", raw, tc.wantRaw)
+			}
+		})
+	}
+}

--- a/internal/ledger/state/ripple_state.go
+++ b/internal/ledger/state/ripple_state.go
@@ -257,6 +257,14 @@ func ParseMPTAmountBinary(data []byte) (Amount, error) {
 	shifted := new(big.Int).Lsh(msbBig, 32)
 	num := new(big.Int).Or(shifted, lsbBig)
 
+	// An MPT magnitude must fit in int64 (max 2^63-1). num.Int64() wraps
+	// two's-complement for magnitudes >= 2^63, silently decoding an
+	// out-of-range positive amount as a large negative one, so reject before
+	// converting.
+	if num.BitLen() > 63 {
+		return Amount{}, fmt.Errorf("MPT amount out of range: %s", num.String())
+	}
+
 	value := num.Int64()
 	if !positive {
 		value = -value

--- a/internal/tx/ledgerfields/decode_stream.go
+++ b/internal/tx/ledgerfields/decode_stream.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"math"
 	"strconv"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
@@ -479,10 +480,12 @@ func isValidIOUCodeByte(b byte) bool {
 	return false
 }
 
-// readMPTAmount decodes a 33-byte MPToken Amount inline. verifyMPTValue
-// constrains |value| ≤ 2^63-1, so the 8-byte mantissa fits in a uint64 and
-// no big.Int math is required. The returned map shape matches the codec's
-// deserializeMPTAmount: {value, mpt_issuance_id}.
+// readMPTAmount decodes a 33-byte MPToken Amount inline. An MPT magnitude
+// must fit in int64 (max 2^63-1); a larger mantissa is rejected so an
+// out-of-range value can never surface as a bogus decimal string. The 8-byte
+// mantissa therefore fits in a uint64 and no big.Int math is required. The
+// returned map shape matches the codec's deserializeMPTAmount:
+// {value, mpt_issuance_id}.
 func (r *streamReader) readMPTAmount() (map[string]any, error) {
 	if r.pos+33 > len(r.data) {
 		return nil, errors.New("ledgerfields: out of bounds reading MPT Amount")
@@ -492,6 +495,9 @@ func (r *streamReader) readMPTAmount() (map[string]any, error) {
 
 	positive := data[0]&0x40 != 0
 	mant := binary.BigEndian.Uint64(data[1:9])
+	if mant > math.MaxInt64 {
+		return nil, errors.New("ledgerfields: MPT amount exceeds max int64")
+	}
 
 	var value string
 	if positive {

--- a/internal/tx/ledgerfields/mpt_amount_overflow_test.go
+++ b/internal/tx/ledgerfields/mpt_amount_overflow_test.go
@@ -1,0 +1,57 @@
+package ledgerfields
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// mptStreamBlob builds a 33-byte MPT amount: 1-byte header, 8-byte big-endian
+// magnitude, 24-byte issuance ID (left zero). header 0x60 = positive MPT,
+// 0x20 = negative MPT.
+func mptStreamBlob(header byte, magnitude uint64) []byte {
+	b := make([]byte, 33)
+	b[0] = header
+	binary.BigEndian.PutUint64(b[1:9], magnitude)
+	return b
+}
+
+// TestReadMPTAmount_RejectsOverMaxInt64 guards GHSA-j5cw-qr86-mmv7 on the
+// inline streaming decoder: an MPT mantissa >= 2^63 must error rather than
+// surface as a bogus decimal string. rippled bounds MPT amounts at
+// maxMPTokenAmount = 2^63-1.
+func TestReadMPTAmount_RejectsOverMaxInt64(t *testing.T) {
+	cases := []struct {
+		name      string
+		header    byte
+		magnitude uint64
+		wantErr   bool
+		wantValue string
+	}{
+		{"positive_two_pow_63", 0x60, 1 << 63, true, ""},
+		{"positive_max_uint64", 0x60, math.MaxUint64, true, ""},
+		{"negative_two_pow_63", 0x20, 1 << 63, true, ""},
+		{"positive_max_int64_ok", 0x60, math.MaxInt64, false, "9223372036854775807"},
+		{"positive_small_ok", 0x60, 1234567890, false, "1234567890"},
+		{"negative_small_ok", 0x20, 1234567890, false, "-1234567890"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sr := newStreamReader(mptStreamBlob(tc.header, tc.magnitude))
+			got, err := sr.readMPTAmount()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected out-of-range error for magnitude %d, got %#v", tc.magnitude, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got["value"] != tc.wantValue {
+				t.Errorf("value = %v, want %s", got["value"], tc.wantValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes security advisory **GHSA-j5cw-qr86-mmv7** — positive MPT amounts ≥ 2^63 were silently decoded as negative on the binary-decode path.

`ParseMPTAmountBinary` (`internal/ledger/state/ripple_state.go`) converted the 8-byte MPT magnitude to `int64` via `num.Int64()` without first checking the magnitude fits. For any magnitude ≥ 2^63, `num.Int64()` wraps two's-complement into a large negative value and the function returned it **with no error** — a positive over-range amount silently became negative.

The streaming `readMPTAmount` (`internal/tx/ledgerfields/decode_stream.go`) had the same gap: it formatted the raw `uint64` mantissa without bounding it, and its comment claimed a `verifyMPTValue` constraint that was never actually applied.

The public binary codec (`codec/binarycodec/types/amount.go` → `deserializeMPTValue`) already had the correct `num.BitLen() > 63` guard, so the internal parsers were inconsistent with it — and with rippled.

## Fix

Both decoders now reject magnitudes ≥ 2^63:
- `ParseMPTAmountBinary`: `num.BitLen() > 63` check before `num.Int64()`.
- `readMPTAmount`: `mant > math.MaxInt64` check; comment corrected to describe the enforced bound.

This matches rippled's `maxMPTokenAmount = 0x7FFFFFFFFFFFFFFF` (2^63−1, `include/xrpl/protocol/Protocol.h:120`) and the existing public-codec guard. Without it, go-xrpl could interpret an over-range MPT escrow entry differently from rippled (ledger-state divergence), and `ParseEscrow` would store a negative `MPTAmount`.

## Reachability addressed

- `ParseEscrow` → `ParseMPTAmountBinary` for 33-byte `sfAmount` fields (now errors instead of storing a negative amount).
- The streaming ledgerfields decoder no longer surfaces over-limit MPT amounts as large decimal strings.

## Tests

New table-driven regression tests at both sites covering the advisory reproducer (magnitude 2^63 → previously `-2^63`), `MaxUint64`, the negative-sign variant, and the in-range boundary (`MaxInt64`, small positive/negative, zero). Both fail against the pre-fix code.

## Verification

- `go build ./...`, `go vet`, `gofmt` clean.
- New tests + `internal/ledger/state`, `internal/tx/ledgerfields`, and downstream `internal/testing/escrow` / `internal/testing/mpt` suites all green.
- A 4-hunter adversarial completeness sweep (ledger-state, ledgerfields, codec, repo-wide) found **no** other binary decoders with this int64-wrap bug class, confirming these two sites are the complete set.