### PR TITLE
Reject MPT amount uint64 overflow in integralAmount (GHSA-xv89-94jf-8vx2)

### DIFF
--- a/internal/ledger/state/amount_json.go
+++ b/internal/ledger/state/amount_json.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/bits"
 	"regexp"
 	"strconv"
 	"strings"
@@ -305,10 +306,11 @@ func integralAmount(parts amountNumberParts, maxValue uint64, rangeMsg string) (
 	}
 	value := parts.mantissa
 	for i := 0; i < parts.exponent; i++ {
-		if value > maxValue {
+		hi, lo := bits.Mul64(value, 10)
+		if hi != 0 || lo > maxValue {
 			return 0, errors.New(rangeMsg)
 		}
-		value *= 10
+		value = lo
 	}
 	if value > maxValue {
 		return 0, errors.New(rangeMsg)

--- a/internal/ledger/state/amount_json_test.go
+++ b/internal/ledger/state/amount_json_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 )
 
@@ -230,4 +231,64 @@ func TestAmountFromJSON_MPT(t *testing.T) {
 			}
 		})
 	}
+}
+
+// GHSA-xv89-94jf-8vx2: scaling the mantissa by a positive exponent must not
+// wrap uint64 and slip past the range guard. maxMPTAmount (math.MaxInt64,
+// ~9.22e18) sits above the uint64 wrap threshold (2^64/10 ~ 1.84e18), so a
+// mantissa in that window times ten overflows; the result must be rejected as
+// out of range, never silently truncated to a small valid-looking value.
+func TestAmountFromJSON_MPTOverflow(t *testing.T) {
+	mpt := func(value string) string {
+		return `{"mpt_issuance_id":"` + testMPTID + `","value":"` + value + `"}`
+	}
+
+	t.Run("rejects", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			value string
+		}{
+			// Advisory exploit: 1844674407370955162 * 10 = 18446744073709551620,
+			// which wraps to 4 mod 2^64 and used to be returned as a valid amount.
+			{"exploit wraps to small value", "1844674407370955162e1"},
+			// Single multiply with a non-zero high word.
+			{"wrap high word set", "2000000000000000000e1"},
+			// Two multiplies; the wrap happens on the second iteration.
+			{"wrap on second exponent step", "184467440737095517e2"},
+			// In range for the mantissa, but the true product exceeds the max
+			// without wrapping — the post-multiply guard must still reject it.
+			{"over range without wrap", "922337203685477581e1"},
+		}
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				if _, err := AmountFromJSON(json.RawMessage(mpt(tt.value))); err == nil {
+					t.Fatalf("AmountFromJSON(%s): want out-of-range error", tt.value)
+				}
+			})
+		}
+	})
+
+	t.Run("accepts", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			value string
+			want  int64
+		}{
+			{"exact max", "9223372036854775807", math.MaxInt64},
+			// 922337203685477580 * 10 = 9223372036854775800 <= max: still valid.
+			{"near max via exponent", "922337203685477580e1", 9223372036854775800},
+		}
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				amt, err := AmountFromJSON(json.RawMessage(mpt(tt.value)))
+				if err != nil {
+					t.Fatalf("AmountFromJSON(%s): %v", tt.value, err)
+				}
+				raw, ok := amt.MPTRaw()
+				if !ok || raw != tt.want {
+					t.Fatalf("AmountFromJSON(%s) = %d/%v, want %d", tt.value, raw, ok, tt.want)
+				}
+			})
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Fixes security advisory **GHSA-xv89-94jf-8vx2** — a `uint64` multiplication overflow in `integralAmount` lets a crafted MPT amount bypass the range check, returning a tiny valid-looking value instead of an error. Reachable from untrusted `ripple_path_find` input.

`integralAmount` (`internal/ledger/state/amount_json.go`) scaled an MPT mantissa by a positive exponent with a bare `value *= 10` loop. The range guard ran **before** the multiply, but for MPT amounts the maximum valid value (`maxMPTAmount = math.MaxInt64`, ~9.22e18) is larger than the `uint64` overflow threshold (`2^64 / 10` ≈ 1.84e18). A mantissa in `[1844674407370955162, maxMPTAmount]` passes the pre-multiply guard, wraps `uint64` to a tiny value, and that wrapped value also passes the post-loop guard — so `AmountFromJSON` returns a wildly wrong MPT amount with no error.

Example: `"1844674407370955162e1"` → `1844674407370955162 * 10 = 18446744073709551620`, which is `4 mod 2^64`. The old code returned `4` instead of rejecting an out-of-range amount.

The native (XRP) path was never vulnerable: `maxNativeAmount = 1e17` is below the wrap threshold, so the pre-multiply guard always fires before `value *= 10` can wrap. The IOU path does not call `integralAmount`.

## Reachability

`AmountFromJSON` is called with untrusted caller input at:
- `internal/rpc/handlers/ripple_path_find.go` — `DestinationAmount`, `SendMax`
- `internal/rpc/path_find_session.go` — `DestinationAmount`, `SendMax`

## Fix

Replace the loop's multiply with a carry-detecting `bits.Mul64`, rejecting any step whose product overflows `uint64` or exceeds the maximum:

```go
for i := 0; i < parts.exponent; i++ {
    hi, lo := bits.Mul64(value, 10)
    if hi != 0 || lo > maxValue {
        return 0, errors.New(rangeMsg)
    }
    value = lo
}
if value > maxValue {
    return 0, errors.New(rangeMsg)
}
```

The post-loop `value > maxValue` check is retained — it is the sole guard for the `exponent == 0` case (the loop body never runs).

## Rippled conformance

rippled rejects out-of-range MPT amounts: `STAmount::canonicalize` constructs `MPTAmount{Number(...)}`, whose `Number::operator rep()` throws `std::overflow_error` when `drops > int64::max/10`, and `amountFromJsonNoThrow` maps that to `invalidParams`. `MPToken_test.cpp:1614` / `:2494` assert `to_string(maxMPTokenAmount + 1)` yields `invalidParams`. Returning the out-of-range error here is the correct, conformant behaviour.

## Tests

New `TestAmountFromJSON_MPTOverflow` covering: the advisory exploit (`1844674407370955162e1`), a single-multiply wrap with a non-zero high word, a multi-step wrap that overflows on the second exponent iteration, a non-wrapping over-range value (post-loop guard), and the valid boundaries (`maxMPTAmount` at `exp=0`, and `922337203685477580e1` = `9223372036854775800`). The three wrap cases fail against the pre-fix code.

## Verification

- An exhaustive comparison of the `bits.Mul64` implementation against true `big.Int` math across every boundary mantissa/exponent/sign for both MPT and native showed an **identical** accept/reject set — **0 mismatches**, byte-identical values on valid inputs.
- `go build ./...`, `go vet`, `gofmt` clean.
- `internal/ledger/state`, `internal/rpc/...`, `internal/tx/...`, `codec/...` suites all green; conformance `app/MPToken` 100% with amount-sensitive suites (Path, Offer, AMM, Oracle, Payment) unaffected.

## Scope note

A repo-wide sweep also surfaced the binary-decode `int64`-wrap in `ParseMPTAmountBinary`, but that is a distinct advisory (**GHSA-j5cw-qr86-mmv7**) already addressed by #1093, so it is intentionally left out of this change.
