### PR TITLE
fix: cache per-ledger ApplyConfig off the per-tx submit path

### DIFF
--- a/internal/ledger/service/apply_config_cache_test.go
+++ b/internal/ledger/service/apply_config_cache_test.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
+)
+
+// applyConfigForTest exercises applyConfigLocked under the read lock its
+// contract requires, failing the test on the only error it can return
+// (no closed ledger).
+func (s *Service) applyConfigForTest(t *testing.T) openledger.ApplyConfig {
+	t.Helper()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	cfg, err := s.applyConfigLocked()
+	if err != nil {
+		t.Fatalf("applyConfigLocked: %v", err)
+	}
+	return cfg
+}
+
+// TestApplyConfigCache_HitWithinLedger pins the #1094 fix: while the closed
+// ledger is unchanged, applyConfigLocked must reuse the same amendment
+// Rules instead of re-reading the Amendments SLE and allocating a fresh
+// rule set on every call (the per-transaction hot path that starved
+// consensus under load).
+func TestApplyConfigCache_HitWithinLedger(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Failed to start service: %v", err)
+	}
+
+	first := svc.applyConfigForTest(t)
+	if first.Rules == nil {
+		t.Fatal("expected non-nil Rules")
+	}
+	second := svc.applyConfigForTest(t)
+
+	if first.Rules != second.Rules {
+		t.Error("expected memoised Rules pointer within a ledger; a fresh allocation means the rule set was rebuilt per call")
+	}
+}
+
+// TestApplyConfigCache_InvalidatedOnClose verifies the cache keys on the
+// closed ledger: once it advances, applyConfigLocked rebuilds the config
+// (fresh Rules pointer) and reports the new ledger sequence rather than
+// serving a stale cached value.
+func TestApplyConfigCache_InvalidatedOnClose(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Failed to start service: %v", err)
+	}
+
+	before := svc.applyConfigForTest(t)
+	if _, err := svc.AcceptLedger(context.TODO()); err != nil {
+		t.Fatalf("Failed to accept ledger: %v", err)
+	}
+	after := svc.applyConfigForTest(t)
+
+	if before.Rules == after.Rules {
+		t.Error("expected Rules to be rebuilt after the closed ledger advanced")
+	}
+	if after.LedgerSequence <= before.LedgerSequence {
+		t.Errorf("expected LedgerSequence to advance after close: before=%d after=%d",
+			before.LedgerSequence, after.LedgerSequence)
+	}
+}
+
+// TestApplyConfigCache_ConcurrentReads exercises the cache under concurrent
+// readers (the SubmitOpenLedgerTx ingress pattern: many goroutines holding
+// only s.mu.RLock) so `go test -race` covers the dedicated cache mutex.
+func TestApplyConfigCache_ConcurrentReads(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Failed to start service: %v", err)
+	}
+
+	const (
+		goroutines = 32
+		iterations = 100
+	)
+	errCh := make(chan error, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				svc.mu.RLock()
+				_, e := svc.applyConfigLocked()
+				svc.mu.RUnlock()
+				if e != nil {
+					errCh <- e
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	if e := <-errCh; e != nil {
+		t.Fatalf("applyConfigLocked under concurrent reads: %v", e)
+	}
+}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -322,6 +322,22 @@ type Service struct {
 	// progress. Carried via an atomic pointer so it can be installed after
 	// construction without taking s.mu; nil disables it.
 	stallPing atomic.Pointer[func()]
+
+	// configCacheMu guards the memoised open-ledger ApplyConfig below. The
+	// config is a pure function of closedLedger (fees, amendment rules,
+	// sequence, parent close time) plus stable Service fields, so it is
+	// rebuilt only when closedLedger advances and otherwise served from
+	// cache — keeping the per-transaction ingress path off an O(amendments)
+	// store-read + binary-parse + Rules allocation on every submit.
+	//
+	// A dedicated mutex (not s.mu) lets concurrent SubmitOpenLedgerTx
+	// callers, which hold only s.mu.RLock, populate the cache without a
+	// write lock. Lock order is always s.mu → configCacheMu: the cache is
+	// consulted only from applyConfigLocked, whose caller already holds
+	// s.mu, which keeps closedLedger stable while the cache is keyed on it.
+	configCacheMu     sync.Mutex
+	configCacheLedger *ledger.Ledger
+	configCache       openledger.ApplyConfig
 }
 
 // SubmittedTxEvent carries the inputs the WebSocket transactions_proposed
@@ -834,24 +850,45 @@ func (s *Service) acceptOpenLedgerViewLocked(closedSeq uint32, buildRetries []op
 	}
 }
 
-// applyConfigLocked builds an openledger.ApplyConfig from the current
-// closed ledger's fees. Caller must hold s.mu (read lock is sufficient).
+// applyConfigLocked returns the openledger.ApplyConfig for the current
+// closed ledger. The config is memoised per closed ledger (see the
+// configCache fields): it is rebuilt only when closedLedger advances and
+// otherwise returned from cache, so the per-transaction ingress path does
+// not re-read and re-parse the Amendments SLE and re-allocate the Rules
+// set on every submit. The returned value is a copy; callers may mutate
+// per-submission fields (e.g. ApplyFlags) without affecting the cache.
+// Caller must hold s.mu (read lock is sufficient).
 func (s *Service) applyConfigLocked() (openledger.ApplyConfig, error) {
-	if s.closedLedger == nil {
+	closed := s.closedLedger
+	if closed == nil {
 		return openledger.ApplyConfig{}, ErrNoClosedLedger
 	}
-	baseFee, reserveBase, reserveIncrement := readFeesFromLedger(s.closedLedger)
-	return openledger.ApplyConfig{
+
+	s.configCacheMu.Lock()
+	defer s.configCacheMu.Unlock()
+	// Pointer identity is a sufficient key: closed ledgers are immutable and
+	// each close installs a fresh *ledger.Ledger. The cache retains the
+	// ledger it was built from, so that object stays alive and its address
+	// cannot be reused for a different ledger while it remains the key.
+	if s.configCacheLedger == closed {
+		return s.configCache, nil
+	}
+
+	baseFee, reserveBase, reserveIncrement := readFeesFromLedger(closed)
+	cfg := openledger.ApplyConfig{
 		BaseFee:          baseFee,
 		ReserveBase:      reserveBase,
 		ReserveIncrement: reserveIncrement,
-		LedgerSequence:   s.closedLedger.Sequence() + 1,
+		LedgerSequence:   closed.Sequence() + 1,
 		NetworkID:        s.config.NetworkID,
-		ParentCloseTime:  parentCloseTimeRippleEpoch(s.closedLedger),
+		ParentCloseTime:  parentCloseTimeRippleEpoch(closed),
 		Logger:           s.config.Logger,
-		Rules:            rulesFromLedger(s.closedLedger, s.logger),
+		Rules:            rulesFromLedger(closed, s.logger),
 		FeeTrack:         s.feeTrack,
-	}, nil
+	}
+	s.configCache = cfg
+	s.configCacheLedger = closed
+	return cfg, nil
 }
 
 // rulesFromLedger derives the amendment.Rules in effect for `parent`'s


### PR DESCRIPTION
## Summary

- `SubmitOpenLedgerTx` called `applyConfigLocked` on **every** inbound transaction, which re-read and re-parsed the on-ledger `Amendments` SLE and allocated a fresh `amendment.Rules` set per tx — on the single consensus `Router` goroutine. Under sustained ingress (~3–4k tx/s) this CPU-starved consensus, froze `validated_seq`, and wedged a mixed network below quorum.
- The `openledger.ApplyConfig` (fees, amendment rules, ledger sequence, parent close time) is a pure function of the closed ledger, which only advances at ledger close. This memoises it: `applyConfigLocked` now rebuilds the config only when `s.closedLedger` advances and otherwise serves a cached copy.
- The cache is keyed on the closed-ledger pointer (closed ledgers are immutable; each close installs a fresh `*ledger.Ledger`, and the cache retains the ledger it was built from so the address can't be reused while it remains the key). It is guarded by a dedicated mutex so the `RLock`-only ingress path populates it without taking the `s.mu` write lock; a cache miss is single-flighted, so even a post-close thundering herd rebuilds once. No apply semantics change.

## Test plan

- [x] `just test-pkg './internal/ledger/service/... -run TestApplyConfigCache -race -v'` — new white-box tests: cache hit within a ledger (same `Rules` pointer), rebuild + sequence advance after close, and concurrent-reader race coverage
- [x] `just test-pkg ./internal/ledger/service/...` — full service package
- [x] `just test-core` — ledger / txq / rpc / consensus / peermanagement all green
- [x] `just build-all` && `just vet`

Fixes #1094