### PR TITLE
fix: offload inbound tx off the consensus message loop

### DIFF
--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
@@ -131,7 +132,31 @@ type Router struct {
 	// guarantee implicitly because online-delete physically removed the data.
 	// Nil when online-delete is off, leaving acquisition/serving unrestricted.
 	floor MinimumOnlineFloor
+
+	// txJobs is the bounded queue draining inbound peer transactions off the
+	// Run message loop, mirroring rippled's jtTRANSACTION job queue. Created
+	// and drained by startTxWorkers from Run; nil until then, in which case
+	// submitTxJob runs the handler inline (tests that drive handleMessage
+	// synchronously). Only written on the Run goroutine.
+	txJobs chan *peermanagement.InboundMessage
+
+	// droppedTxJobs counts inbound transactions shed because the worker pool
+	// was saturated — the originating peer resends and reduce-relay covers
+	// the gap, so a dropped relay frame is recoverable.
+	droppedTxJobs atomic.Uint64
 }
+
+// txWorkerCount bounds the goroutines draining inbound peer transactions off
+// the consensus Run loop, and txQueueDepth bounds the pending backlog before
+// submitTxJob sheds load. Mirrors rippled bounding inbound TMTransaction
+// behind its jtTRANSACTION job queue (with a MAX_TRANSACTIONS overflow drop)
+// rather than processing it on the read strand: under a tx flood the per-tx
+// submit+parse must not starve proposal / validation / ledger-acquisition
+// handling, which all share Run's single goroutine.
+const (
+	txWorkerCount = 4
+	txQueueDepth  = 1024
+)
 
 // messageDedupTTL is how long a proposal/validation hash is
 // remembered for duplicate-detection purposes. 30s comfortably covers a
@@ -258,6 +283,7 @@ func (r *Router) HandlePeerDisconnect(peerID peermanagement.PeerID) {
 // also runs in this loop to time out stuck inbound replay-delta
 // acquisitions and fall back to the legacy mtGET_LEDGER path.
 func (r *Router) Run(ctx context.Context) {
+	r.startTxWorkers(ctx)
 	ticker := time.NewTicker(inboundReplayDeltaTickInterval)
 	defer ticker.Stop()
 	for {
@@ -273,6 +299,53 @@ func (r *Router) Run(ctx context.Context) {
 			r.maintenanceTick()
 		}
 	}
+}
+
+// startTxWorkers builds the bounded inbound-transaction queue and launches its
+// drainers. Called once at the top of Run, before the message loop, so the
+// first dispatched transaction sees a live pool. Workers exit on ctx.Done.
+func (r *Router) startTxWorkers(ctx context.Context) {
+	r.txJobs = make(chan *peermanagement.InboundMessage, txQueueDepth)
+	jobs := r.txJobs
+	for range txWorkerCount {
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case msg := <-jobs:
+					r.handleTransaction(msg)
+				}
+			}
+		}()
+	}
+}
+
+// submitTxJob hands an inbound transaction to the worker pool, off the Run
+// message loop. When the pool isn't running (tests that drive handleMessage
+// synchronously without Run), it runs the handler inline to preserve the
+// synchronous contract. On a saturated queue it sheds the frame and bumps
+// droppedTxJobs — the originating peer resends and reduce-relay means other
+// peers relay it too, so a dropped relay frame is recoverable. Mirrors
+// rippled's "Transaction queue is full" overflow drop.
+func (r *Router) submitTxJob(msg *peermanagement.InboundMessage) {
+	if r.txJobs == nil {
+		r.handleTransaction(msg)
+		return
+	}
+	select {
+	case r.txJobs <- msg:
+	default:
+		r.droppedTxJobs.Add(1)
+		r.logger.Debug("inbound tx dropped: worker pool saturated",
+			"t", "consensus", "event", "tx-shed", "peer", msg.PeerID)
+	}
+}
+
+// DroppedTxJobs returns the cumulative count of inbound transactions shed
+// because the worker pool was saturated.
+func (r *Router) DroppedTxJobs() uint64 {
+	return r.droppedTxJobs.Load()
 }
 
 // maintenanceTick runs out-of-band housekeeping: detect replay-delta

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -22,7 +22,12 @@ func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
 	case message.TypeValidation:
 		r.handleValidation(msg)
 	case message.TypeTransaction:
-		r.handleTransaction(msg)
+		// Offload to the bounded worker pool so a transaction flood can't
+		// starve proposal / validation / ledger-acquisition handling, which
+		// share this goroutine. Mirrors rippled dispatching inbound
+		// TMTransaction onto its jtTRANSACTION job queue rather than handling
+		// it on the read strand.
+		r.submitTxJob(msg)
 	case message.TypeHaveSet:
 		r.handleHaveSet(msg)
 	case message.TypeStatusChange:
@@ -380,7 +385,9 @@ func (r *Router) handleTransaction(msg *peermanagement.InboundMessage) {
 	// Peer-relay path — the originating peer manages its own resends,
 	// so we don't pin the blob in our LocalTxs held pool.
 	res, err := r.adaptor.SubmitPendingTx(blob, false)
-	r.logger.Info("inbound tx accepted into pending pool",
+	// Debug, not Info: at thousands of tx/s an unconditional Info write here
+	// is a per-transaction blocking syscall on the submit hot path.
+	r.logger.Debug("inbound tx accepted into pending pool",
 		"t", "consensus",
 		"event", "tx-inbound",
 		"peer", msg.PeerID,

--- a/internal/tx/parse.go
+++ b/internal/tx/parse.go
@@ -50,11 +50,10 @@ func ParseHash256NonZero(s string) ([32]byte, error) {
 
 // ParseFromBinary parses a binary transaction blob into a Transaction
 func ParseFromBinary(blob []byte) (Transaction, error) {
-	// Convert binary to hex string for the codec
-	hexStr := hex.EncodeToString(blob)
-
-	// Decode binary to JSON map
-	jsonMap, err := binarycodec.Decode(hexStr)
+	// Decode the canonical binary directly; the blob is already bytes, so
+	// going through a hex string round-trip would only churn allocations on
+	// this per-transaction hot path.
+	jsonMap, err := binarycodec.DecodeBytes(blob)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode binary transaction: %w", err)
 	}
@@ -66,16 +65,17 @@ func ParseFromBinary(blob []byte) (Transaction, error) {
 		presentFields[key] = true
 	}
 
+	typeName, _ := jsonMap["TransactionType"].(string)
+	txType, knownType := TypeFromName(typeName)
+
 	// Reject any codec-known field that is not allowed for this transaction
 	// type before the transaction can be applied, mirroring rippled's STTx
 	// template application. Without this a tx carrying a field disallowed for
 	// its type would be silently applied while rippled rejects it at
 	// deserialization, forking the ledger.
-	if typeName, ok := jsonMap["TransactionType"].(string); ok {
-		if txType, ok := TypeFromName(typeName); ok {
-			if err := checkTemplate(txType, presentFields); err != nil {
-				return nil, err
-			}
+	if knownType {
+		if err := checkTemplate(txType, presentFields); err != nil {
+			return nil, err
 		}
 	}
 
@@ -85,17 +85,32 @@ func ParseFromBinary(blob []byte) (Transaction, error) {
 		return nil, fmt.Errorf("failed to marshal decoded transaction: %w", err)
 	}
 
-	tx, err := ParseJSON(jsonBytes)
-	if err != nil {
-		return nil, err
+	// The TransactionType is already known from the decoded map, so build the
+	// concrete transaction and unmarshal in one pass, skipping the redundant
+	// TransactionType re-parse FromJSON performs. Unknown or unregistered
+	// types fall back to the generic ParseJSON path (yielding a BaseTx).
+	var parsed Transaction
+	if knownType {
+		if t, nerr := NewFromType(txType); nerr == nil {
+			if err := json.Unmarshal(jsonBytes, t); err != nil {
+				return nil, fmt.Errorf("failed to parse transaction: %w", err)
+			}
+			parsed = t
+		}
+	}
+	if parsed == nil {
+		parsed, err = ParseJSON(jsonBytes)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	tx.GetCommon().SetPresentFields(presentFields)
+	parsed.GetCommon().SetPresentFields(presentFields)
 
 	// Preserve the original serialized bytes so that downstream consumers
 	// (e.g. sortCanonicalSalted) can use them for hash/SHAMap computation
 	// without re-encoding, ensuring byte-exact fidelity with the source.
-	tx.SetRawBytes(blob)
+	parsed.SetRawBytes(blob)
 
-	return tx, nil
+	return parsed, nil
 }


### PR DESCRIPTION
## Summary

Follow-up to #1094 (fixed by #1096). #1096 removed the per-tx `amendment.Rules` rebuild, but the network still wedged under a tx flood because the cost simply relocated: inbound peer transactions are submitted, parsed, and logged **inline on the single `Router.Run` goroutine**, which also drives proposals, validations, and ledger acquisition. At a few thousand tx/s that goroutine saturates and consensus can't make progress, dropping the node below quorum.

This addresses the three per-tx-hot-path fixes the issue suggested:

- **Offload `handleTransaction` to a bounded worker pool with load-shedding** (`router.go`, `router_dispatch.go`). `TypeTransaction` is dispatched via `submitTxJob` to a 4-worker / depth-1024 queue; proposals, validations, and acquisition stay on `Run`. On a saturated queue the frame is shed (the origin peer resends and reduce-relay covers it). This mirrors rippled routing inbound `TMTransaction` through its bounded `jtTRANSACTION` job queue (with a `MAX_TRANSACTIONS` overflow drop) rather than handling it on the read strand. When the pool isn't running (unit tests that drive `handleMessage` synchronously), `submitTxJob` runs inline, matching the existing overlay `serveJobs`/`submitServe` pattern.
- **Demote the per-tx `Info` log to `Debug`** (`router_dispatch.go:~388`). It was an unconditional, blocking `slog`→`syscall.write` for every inbound tx on the submit path.
- **Trim `ParseFromBinary` round-trips** (`tx/parse.go`). Decode the blob directly with `binarycodec.DecodeBytes` instead of a `blob → hex → blob` round-trip, and skip `FromJSON`'s redundant `TransactionType` re-parse since the type is already known from the decoded map. The resulting transaction struct is byte-identical to before (both paths do `NewFromType` + a single `json.Unmarshal` into a fresh struct).

The co-occurring inbound-ledger **state-acquisition livelock** the issue flagged ("still have 1 missing nodes") is intentionally left for its own issue, as the author suggested.

> Note: the actual network-wedge resolution can only be confirmed with the `xrpl-confluence` `soak-throughput-15k` harness (mixed 3 rippled + 2 go-xrpl). Locally this PR is verified for correctness and zero behavioral regression only.

## Test plan

- [x] `go test -race ./internal/consensus/adaptor/` — passes (no data races on the new pool; the inline-fallback keeps synchronous `handleMessage` tests green)
- [x] `go test ./internal/tx/... ./codec/binarycodec/... ./internal/ledger/openledger/... ./internal/ledger/service/...` — all pass
- [x] `go test ./internal/consensus/...` — all pass
- [x] Conformance unchanged vs `origin/main`: **in-scope 1132 pass / 9 fail (99.2%)** on both the clean tree and this branch — zero regression
- [x] `gofmt` clean, `go vet` clean, `golangci-lint run` on changed packages — 0 issues

Fixes #1097