### PR TITLE
fix(consensus): surface worker-pool tx shedding in jq_trans_overflow (#1098 follow-up)

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -515,7 +515,20 @@ func runServer(cmd *cobra.Command, args []string) error {
 		services.PeerDisconnects = func() (uint64, uint64) {
 			return overlayRef.PeerDisconnects(), overlayRef.PeerDisconnectsResources()
 		}
-		services.JqTransOverflow = overlayRef.DroppedTransactions
+		// jq_trans_overflow folds the two sequential stages where a
+		// saturated inbound transaction is shed: the overlay ingress gate
+		// (max_transactions ceiling) and the consensus worker pool
+		// (Router.DroppedTxJobs). A frame is shed by at most one stage, so
+		// summing the disjoint counts reports the total without double-counting
+		// and mirrors rippled's single jq_trans_overflow counter.
+		routerRef := consensusComponents.Router
+		services.JqTransOverflow = func() uint64 {
+			n := overlayRef.DroppedTransactions()
+			if routerRef != nil {
+				n += routerRef.DroppedTxJobs()
+			}
+			return n
+		}
 		services.TxReduceRelayMetrics = func() types.TxReduceRelayMetrics {
 			s := overlayRef.TxMetricsSnapshot()
 			return types.TxReduceRelayMetrics{

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -148,11 +148,17 @@ type Router struct {
 
 // txWorkerCount bounds the goroutines draining inbound peer transactions off
 // the consensus Run loop, and txQueueDepth bounds the pending backlog before
-// submitTxJob sheds load. Mirrors rippled bounding inbound TMTransaction
-// behind its jtTRANSACTION job queue (with a MAX_TRANSACTIONS overflow drop)
-// rather than processing it on the read strand: under a tx flood the per-tx
-// submit+parse must not starve proposal / validation / ledger-acquisition
-// handling, which all share Run's single goroutine.
+// submitTxJob sheds load. This is the off-strand handoff, analogous to rippled
+// posting inbound TMTransaction to its jtTRANSACTION job queue rather than
+// processing it on the read strand: under a tx flood the per-tx submit+parse
+// must not starve proposal / validation / ledger-acquisition handling, which
+// all share Run's single goroutine. The single-frame max_transactions ceiling
+// is enforced upstream at the overlay ingress gate (which feeds
+// jq_trans_overflow); batch-fanned transactions reach this queue without
+// traversing that gate, so droppedTxJobs is their primary shed signal.
+// txQueueDepth is sized generously on purpose, and a frame shed here is
+// recoverable (the originating peer resends and reduce-relay re-delivers it via
+// other peers), so over-buffering costs little.
 const (
 	txWorkerCount = 4
 	txQueueDepth  = 1024

--- a/internal/consensus/adaptor/router_txpool_test.go
+++ b/internal/consensus/adaptor/router_txpool_test.go
@@ -1,0 +1,107 @@
+package adaptor
+
+import (
+	"encoding/hex"
+	"sync"
+	"testing"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	testenv "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSubmitTxJobShedsWhenPoolSaturated verifies that submitTxJob drops the
+// frame and bumps the shed counter when the worker-pool queue is full, rather
+// than blocking the consensus Run loop. Deterministic without goroutine timing:
+// a depth-1 queue is pre-filled and no worker drains it, so the non-blocking
+// send sheds on every call.
+func TestSubmitTxJobShedsWhenPoolSaturated(t *testing.T) {
+	r := NewRouter(&mockEngine{}, newTestAdaptor(t), make(chan *peermanagement.InboundMessage, 1))
+
+	// Install a full queue with no drainers so every submit sheds.
+	r.txJobs = make(chan *peermanagement.InboundMessage, 1)
+	r.txJobs <- &peermanagement.InboundMessage{}
+
+	require.Equal(t, uint64(0), r.DroppedTxJobs())
+
+	const sheds = 5
+	for range sheds {
+		r.submitTxJob(&peermanagement.InboundMessage{
+			PeerID: 7,
+			Tx:     &message.Transaction{RawTransaction: []byte{0x01}},
+		})
+	}
+
+	require.Equal(t, uint64(sheds), r.DroppedTxJobs())
+}
+
+// TestSubmitTxJobInlineFallback verifies that when the worker pool has not been
+// started (r.txJobs == nil, the contract for tests that drive dispatch
+// synchronously), submitTxJob runs handleTransaction inline on the calling
+// goroutine. The transaction is observable via HasTx immediately, with no
+// sleep — that absence of a sleep is the assertion that the path is synchronous.
+func TestSubmitTxJobInlineFallback(t *testing.T) {
+	a := newTestAdaptor(t)
+	r := NewRouter(&mockEngine{}, a, make(chan *peermanagement.InboundMessage, 1))
+	require.Nil(t, r.txJobs, "pool must be unstarted so submitTxJob takes the inline path")
+
+	// The open-ledger Submit path rejects un-parseable blobs, so the inbound
+	// tx must be a real signed Payment for HasTx to be true after dispatch.
+	env := testenv.NewTestEnv(t)
+	env.SetVerifySignatures(true)
+	master := testenv.MasterAccount()
+	alice := testenv.NewAccount("alice")
+	txn := payment.Pay(master, alice, 100_000_000).Sequence(1).Build()
+	env.SignWith(txn, master)
+	txMap, err := txn.Flatten()
+	require.NoError(t, err)
+	hexStr, err := binarycodec.Encode(txMap)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+	txHash, err := tx.ComputeTransactionHash(txn)
+	require.NoError(t, err)
+
+	r.submitTxJob(&peermanagement.InboundMessage{
+		PeerID: 3,
+		Tx:     &message.Transaction{RawTransaction: blob, Status: message.TxStatusNew},
+	})
+
+	require.True(t, a.HasTx(consensus.TxID(txHash)),
+		"inline path must apply the tx synchronously before submitTxJob returns")
+}
+
+// TestSubmitTxJobConcurrent exercises the real worker pool under concurrent
+// submits for the race detector: txWorkerCount workers drain a shared channel
+// while many goroutines submit at once. With fewer submits than txQueueDepth the
+// buffer absorbs them all, so nothing is shed and the result is deterministic;
+// `go test -race` is what makes this test meaningful — it verifies the
+// channel / atomic-counter / worker handoff is free of data races.
+func TestSubmitTxJobConcurrent(t *testing.T) {
+	r := NewRouter(&mockEngine{}, newTestAdaptor(t), make(chan *peermanagement.InboundMessage, 1))
+
+	// Workers exit when t.Context() is canceled at test cleanup, so they
+	// don't leak across tests.
+	r.startTxWorkers(t.Context())
+
+	const n = 500 // < txQueueDepth (1024): the buffer absorbs all, so 0 sheds
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			r.submitTxJob(&peermanagement.InboundMessage{
+				PeerID: 9,
+				Tx:     &message.Transaction{RawTransaction: []byte{0x01}},
+			})
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, uint64(0), r.DroppedTxJobs())
+}

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -253,14 +253,14 @@ type ServiceContainer struct {
 	// rippled's idle-state defaults.
 	TxQFeeMetrics func() TxQFeeMetrics
 
-	// JqTransOverflow returns the cumulative inbound TMTransaction
-	// frames the overlay refused at the router-dispatch boundary
-	// because the in-flight tx ceiling was already met. This is
-	// goxrpl's analog of rippled's OverlayImpl::getJqTransOverflow
-	// (bumped at PeerImp.cpp:1353 when
-	// `getJobCount(jtTRANSACTION) > MAX_TRANSACTIONS`) and drives
-	// server_info.jq_trans_overflow. Nil in standalone / RPC-only
-	// configurations (no overlay) — handler reads zero.
+	// JqTransOverflow returns the cumulative inbound transactions shed
+	// under saturation, summed across the two sequential drop stages: the
+	// overlay ingress gate (the in-flight tx ceiling) and the consensus
+	// worker pool. A frame is shed by at most one stage, so the sum does not
+	// double-count. This is goxrpl's analog of rippled's single
+	// jq_trans_overflow counter and drives server_info.jq_trans_overflow.
+	// Nil in standalone / RPC-only configurations (no overlay) — handler
+	// reads zero.
 	JqTransOverflow func() uint64
 
 	// PeerDisconnects returns cumulative peer-disconnect counters


### PR DESCRIPTION
Follow-up to #1098 (#1097) resolving the post-merge conformance-review findings. #1098 was merged before the review ran; this PR addresses the items it surfaced. No behavioural change to consensus/ledger logic — observability wiring, a comment fix, and regression tests.

## Findings addressed

**M1 — the worker-pool shed counter was unwired.** `Router.DroppedTxJobs()` (added in #1098) counts inbound transactions shed when the bounded worker pool is saturated, but had **zero callers** — invisible in production except an off-by-default `Debug` log, under exactly the tx-flood condition #1097 targets.

goXRPL already surfaces `jq_trans_overflow` in `server_info`/`server_state`, fed by the overlay ingress-gate counter (`Overlay.DroppedTransactions`, the `max_transactions` ceiling). The worker-pool shed is a **second, sequential** drop stage. rippled has a *single* `jq_trans_overflow` (bumped at `PeerImp.cpp:1349-1355` on `getJobCount(jtTRANSACTION) > MAX_TRANSACTIONS`), and the worker pool is its truer analog. So this folds `Router.DroppedTxJobs()` into the existing `JqTransOverflow` hook, summed with the overlay counter:

- A frame is shed by **at most one** stage (overlay gate drops *before* the message reaches the Router inbox), so the two counts are **disjoint** — summing does not double-count.
- No new JSON field (rippled has none); the wire shape stays a single decimal string.
- Batch-fanned (reduce-relay) inner txs bypass the overlay `max_transactions` gate, so for that path the worker-pool counter is the primary shed signal — folding it in also closes that coverage gap.

**M2 — no tests for the new concurrency code.** Adds `router_txpool_test.go` (same-package):
- `TestSubmitTxJobShedsWhenPoolSaturated` — load-shed accounting (deterministic: pre-filled depth-1 queue, no drainers).
- `TestSubmitTxJobInlineFallback` — the `txJobs == nil` inline path applies synchronously (asserted via `HasTx`, no sleep).
- `TestSubmitTxJobConcurrent` — concurrent submits + worker drain, meaningful under `-race`.

**N1 — misleading const comment.** The `txWorkerCount`/`txQueueDepth` doc implied the 1024 backlog tracked rippled's `MAX_TRANSACTIONS` (default 250). Clarified: the `max_transactions` ceiling is enforced upstream at the overlay ingress gate; this internal queue sits behind it (and is the shed point for batch-fanned txs that bypass that gate).

**N2 — parse.go error-wrap.** No change needed: the `fmt.Errorf("failed to parse transaction: %w", …)` wrap is an improvement and no caller depends on the unwrapped error string (verified — the one string-matching test keys off a different, unwrapped return path).

## Verification
- `go build` (full binary), `go vet`, `golangci-lint` — clean on the changed packages.
- `go test -race ./internal/consensus/adaptor/...` and `./internal/rpc/...` — green.
- Counter wiring: no test asserts an exact `jq_trans_overflow` value through the cli wiring (RPC tests stub the hook), so the change is safe.