### PR TITLE
fix: split inbound peer-message channel into consensus and tx lanes

### DIFF
--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -159,10 +159,11 @@ type Router struct {
 // posting inbound TMTransaction to its jtTRANSACTION job queue rather than
 // processing it on the read strand: under a tx flood the per-tx submit+parse
 // must not starve proposal / validation / ledger-acquisition handling, which
-// all share Run's single goroutine. The single-frame max_transactions ceiling
-// is enforced upstream at the overlay ingress gate (which feeds
-// jq_trans_overflow); batch-fanned transactions reach this queue without
-// traversing that gate, so droppedTxJobs is their primary shed signal.
+// all share Run's single goroutine. The MaxTransactions ceiling is enforced
+// upstream on the dedicated overlay tx lane for both wire and batch-fanned
+// frames (forwardTransaction sheds and counts droppedTransactions, surfaced
+// as jq_trans_overflow); droppedTxJobs here is the second, worker-pool-stage
+// shed signal common to both.
 // txQueueDepth is sized generously on purpose, and a frame shed here is
 // recoverable (the originating peer resends and reduce-relay re-delivers it via
 // other peers), so over-buffering costs little.

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -36,6 +36,13 @@ type Router struct {
 	engine  consensus.Engine
 	adaptor *Adaptor
 	inbox   <-chan *peermanagement.InboundMessage
+	// txInbox is the overlay's dedicated transaction lane. Run drains it
+	// alongside inbox and hands each frame to the worker pool, so a tx
+	// flood on this lane can't starve consensus/acquisition frames
+	// arriving on inbox (issue #1103). nil when unset — tests that drive
+	// handleMessage directly leave it nil, and a nil channel is simply
+	// never selected. Wired via SetTxInbox before Run.
+	txInbox <-chan *peermanagement.InboundMessage
 	logger  *slog.Logger
 
 	// Peer ledger tracking for catch-up detection
@@ -206,6 +213,15 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, inbox <-chan *peermana
 	return r
 }
 
+// SetTxInbox installs the overlay's dedicated transaction lane. Run selects
+// it alongside the consensus inbox, so transactions and consensus/acquisition
+// traffic no longer share a single bounded buffer that a tx flood could
+// saturate (issue #1103). Safe to call before Run; leaving it unset keeps the
+// inbox-only behaviour tests rely on.
+func (r *Router) SetTxInbox(txInbox <-chan *peermanagement.InboundMessage) {
+	r.txInbox = txInbox
+}
+
 // SetMinimumOnlineFloor installs the online-delete retention floor. Once set,
 // the router refuses to acquire or serve ledgers below it. A nil floor leaves
 // both paths unrestricted, so the disabled / standalone case is unchanged.
@@ -301,6 +317,15 @@ func (r *Router) Run(ctx context.Context) {
 				return
 			}
 			r.handleMessage(msg)
+		case msg, ok := <-r.txInbox:
+			if !ok {
+				// Lane closed (or never wired): stop selecting it so we
+				// don't busy-spin on a closed channel. The consensus
+				// inbox / ctx.Done drive shutdown.
+				r.txInbox = nil
+				continue
+			}
+			r.submitTxJob(msg)
 		case <-ticker.C:
 			r.maintenanceTick()
 		}

--- a/internal/consensus/adaptor/router_txpool_test.go
+++ b/internal/consensus/adaptor/router_txpool_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"sync"
 	"testing"
+	"time"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
@@ -14,6 +15,27 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/stretchr/testify/require"
 )
+
+// signedPaymentFrame builds a real signed master→alice Payment and
+// returns its wire blob plus the expected transaction hash. The
+// open-ledger Submit path rejects un-parseable blobs, so a tx must be a
+// genuine signed Payment for HasTx to report true after dispatch.
+func signedPaymentFrame(t *testing.T, env *testenv.TestEnv, seq uint32) ([]byte, consensus.TxID) {
+	t.Helper()
+	master := testenv.MasterAccount()
+	alice := testenv.NewAccount("alice")
+	txn := payment.Pay(master, alice, 100_000_000).Sequence(seq).Build()
+	env.SignWith(txn, master)
+	txMap, err := txn.Flatten()
+	require.NoError(t, err)
+	hexStr, err := binarycodec.Encode(txMap)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+	txHash, err := tx.ComputeTransactionHash(txn)
+	require.NoError(t, err)
+	return blob, consensus.TxID(txHash)
+}
 
 // TestSubmitTxJobShedsWhenPoolSaturated verifies that submitTxJob drops the
 // frame and bumps the shed counter when the worker-pool queue is full, rather
@@ -50,30 +72,46 @@ func TestSubmitTxJobInlineFallback(t *testing.T) {
 	r := NewRouter(&mockEngine{}, a, make(chan *peermanagement.InboundMessage, 1))
 	require.Nil(t, r.txJobs, "pool must be unstarted so submitTxJob takes the inline path")
 
-	// The open-ledger Submit path rejects un-parseable blobs, so the inbound
-	// tx must be a real signed Payment for HasTx to be true after dispatch.
 	env := testenv.NewTestEnv(t)
 	env.SetVerifySignatures(true)
-	master := testenv.MasterAccount()
-	alice := testenv.NewAccount("alice")
-	txn := payment.Pay(master, alice, 100_000_000).Sequence(1).Build()
-	env.SignWith(txn, master)
-	txMap, err := txn.Flatten()
-	require.NoError(t, err)
-	hexStr, err := binarycodec.Encode(txMap)
-	require.NoError(t, err)
-	blob, err := hex.DecodeString(hexStr)
-	require.NoError(t, err)
-	txHash, err := tx.ComputeTransactionHash(txn)
-	require.NoError(t, err)
+	blob, txID := signedPaymentFrame(t, env, 1)
 
 	r.submitTxJob(&peermanagement.InboundMessage{
 		PeerID: 3,
 		Tx:     &message.Transaction{RawTransaction: blob, Status: message.TxStatusNew},
 	})
 
-	require.True(t, a.HasTx(consensus.TxID(txHash)),
+	require.True(t, a.HasTx(txID),
 		"inline path must apply the tx synchronously before submitTxJob returns")
+}
+
+// TestRunDrainsTxLane verifies the end-to-end #1103 path on the consensus
+// side: a transaction pushed onto the dedicated tx lane (SetTxInbox) is
+// drained by Run, handed to the worker pool, and applied — independent of
+// the consensus inbox, which here is nil and never selected.
+func TestRunDrainsTxLane(t *testing.T) {
+	a := newTestAdaptor(t)
+	// nil consensus inbox: that select case is never ready, so Run is
+	// driven solely by the tx lane and the maintenance ticker.
+	r := NewRouter(&mockEngine{}, a, nil)
+
+	txLane := make(chan *peermanagement.InboundMessage, 4)
+	r.SetTxInbox(txLane)
+
+	go r.Run(t.Context())
+
+	env := testenv.NewTestEnv(t)
+	env.SetVerifySignatures(true)
+	blob, txID := signedPaymentFrame(t, env, 1)
+
+	txLane <- &peermanagement.InboundMessage{
+		PeerID: 3,
+		Tx:     &message.Transaction{RawTransaction: blob, Status: message.TxStatusNew},
+	}
+
+	require.Eventually(t, func() bool { return a.HasTx(txID) },
+		2*time.Second, 5*time.Millisecond,
+		"Run must drain the tx lane and apply the transaction")
 }
 
 // TestSubmitTxJobConcurrent exercises the real worker pool under concurrent

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -331,8 +331,11 @@ func NewFromConfig(
 	// proposing, so wrongLedger needs to demote opMode.
 	engine.Subscribe(modeManager)
 
-	// Create the router
+	// Create the router. Consensus/acquisition frames arrive on
+	// overlay.Messages(); transactions arrive on the separate
+	// overlay.TxMessages() lane so a tx flood can't starve them.
 	router := NewRouter(engine, adaptor, overlay.Messages())
+	router.SetTxInbox(overlay.TxMessages())
 	router.SetManifestCache(manifestCache, overlay)
 	router.SetMinimumOnlineFloor(floor)
 

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -331,9 +331,9 @@ func NewFromConfig(
 	// proposing, so wrongLedger needs to demote opMode.
 	engine.Subscribe(modeManager)
 
-	// Create the router. Consensus/acquisition frames arrive on
-	// overlay.Messages(); transactions arrive on the separate
-	// overlay.TxMessages() lane so a tx flood can't starve them.
+	// Consensus/acquisition frames arrive on overlay.Messages();
+	// transactions arrive on the separate overlay.TxMessages() lane so a
+	// tx flood can't starve them.
 	router := NewRouter(engine, adaptor, overlay.Messages())
 	router.SetTxInbox(overlay.TxMessages())
 	router.SetManifestCache(manifestCache, overlay)

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -67,11 +67,12 @@ type Config struct {
 	EventBufferSize   int
 	MessageBufferSize int
 
-	// MaxTransactions caps the per-type in-flight TMTransaction frames
-	// the overlay will hand to the router before refusing new ones and
-	// bumping droppedTransactions. The analog of [max_transactions] in
-	// rippled.cfg. Non-positive disables the gate (channel-saturation
-	// drop remains the defensive backstop).
+	// MaxTransactions sizes the overlay's dedicated inbound
+	// TMTransaction lane. Inbound tx frames past this ceiling are shed
+	// (bumping droppedTransactions); the separate lane keeps a tx flood
+	// from crowding consensus/acquisition traffic. The analog of
+	// [max_transactions] in rippled.cfg. Non-positive falls back to
+	// DefaultMaxTransactions — the lane is always bounded.
 	MaxTransactions int
 
 	// Features — advertised via X-Protocol-Ctl during handshake so
@@ -347,9 +348,9 @@ func WithMessageBufferSize(size int) Option {
 	}
 }
 
-// WithMaxTransactions sets the in-flight TMTransaction ceiling at the
-// overlay → router boundary. Non-positive disables the gate.
-// Default 250.
+// WithMaxTransactions sets the capacity of the overlay's dedicated
+// inbound TMTransaction lane. Non-positive falls back to the default
+// (250).
 func WithMaxTransactions(n int) Option {
 	return func(c *Config) {
 		c.MaxTransactions = n

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -592,9 +592,10 @@ func (o *Overlay) serveGetObjects(peerID PeerID, req *message.GetObjectByHash) {
 // list of TMTransaction frames). Mirrors rippled
 // PeerImp::onMessage(TMTransactions) at PeerImp.cpp:2667-2688.
 //
-// Each inner TMTransaction is fanned out onto o.messages carrying its
-// already-decoded form so router.handleTransaction processes it
-// identically to an unbundled TMTransaction frame. Like rippled, which
+// Each inner TMTransaction is fanned out onto the tx lane
+// (o.txMessages) carrying its already-decoded form so
+// router.handleTransaction processes it identically to an unbundled
+// TMTransaction frame. Like rippled, which
 // hands the decoded inner straight to handleTransaction, we never
 // re-serialize: the decode happened once when the batch was parsed.
 // The only behavioural difference rippled draws between batched and
@@ -621,21 +622,17 @@ func (o *Overlay) handleTransactionsBatchMessage(evt Event) {
 	// rippled addTxMetrics(m->transactions_size()) at PeerImp.cpp:2680.
 	o.txm.addMissingTx(uint64(len(batch.Transactions)))
 
-	// Fan out each inner TMTransaction onto o.messages so the router's
+	// Fan out each inner TMTransaction onto the tx lane so the router's
 	// handleTransaction path picks it up. The decoded transaction rides
 	// along in Tx, so the router need not re-serialize and re-parse it —
-	// the batch decode above already produced the decoded form.
+	// the batch decode above already produced the decoded form. The lane
+	// is shared with the wire path, so batch frames are subject to the
+	// same MaxTransactions ceiling and jq_trans_overflow accounting.
 	for i := range batch.Transactions {
-		select {
-		case o.messages <- &InboundMessage{
+		o.forwardTransaction(&InboundMessage{
 			PeerID: evt.PeerID,
 			Type:   uint16(message.TypeTransaction),
 			Tx:     &batch.Transactions[i],
-		}:
-		default:
-			o.droppedMessages.Add(1)
-			slog.Warn("TMTransactions batch fanout dropped: channel full",
-				"t", "Overlay", "peer", evt.PeerID, "idx", i)
-		}
+		})
 	}
 }

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -413,6 +413,62 @@ func TestHandleTransactionsBatchMessage_FansOutDecodedTx(t *testing.T) {
 		"negotiated batch must not charge bad-data")
 }
 
+// TestHandleTransactionsBatchMessage_OverflowShedsToTxCounter pins the
+// #1103 batch-overflow accounting: when the tx lane is saturated, inner
+// frames fanned out from a TMTransactions batch are shed to
+// droppedTransactions (jq_trans_overflow) rather than the consensus-lane
+// droppedMessages, and never consume the consensus lane. Mirrors rippled
+// routing batched txs through the same MAX_TRANSACTIONS / jqTransOverflow
+// gate as single ones (PeerImp.cpp:2682-2687 → 1349-1355).
+func TestHandleTransactionsBatchMessage_OverflowShedsToTxCounter(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	const txCap = 2
+	o := &Overlay{
+		cfg:        Config{EnableTxReduceRelay: true},
+		peers:      make(map[PeerID]*Peer),
+		events:     make(chan Event, 8),
+		messages:   make(chan *InboundMessage, 8),
+		txMessages: make(chan *InboundMessage, txCap),
+		cluster:    cluster.New(),
+	}
+
+	endpoint := Endpoint{Host: "127.0.0.1", Port: 51235}
+	peer := NewPeer(PeerID(35), endpoint, false, id, make(chan Event, 1))
+	caps := NewPeerCapabilities()
+	caps.Features.Enable(FeatureTxReduceRelay)
+	peer.capabilities = caps
+	o.peers[peer.ID()] = peer
+
+	// More inners than the tx lane holds; the lane is never drained, so the
+	// overflow has nowhere to go but the shed branch.
+	inners := []message.Transaction{
+		{RawTransaction: []byte{0x12, 0x00, 0x01}, Status: message.TxStatusCurrent},
+		{RawTransaction: []byte{0x12, 0x00, 0x02}, Status: message.TxStatusCurrent},
+		{RawTransaction: []byte{0x12, 0x00, 0x03}, Status: message.TxStatusCurrent},
+		{RawTransaction: []byte{0x12, 0x00, 0x04}, Status: message.TxStatusCurrent},
+		{RawTransaction: []byte{0x12, 0x00, 0x05}, Status: message.TxStatusCurrent},
+	}
+	payload, err := message.Encode(&message.Transactions{Transactions: inners})
+	require.NoError(t, err)
+
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeTransactions),
+		Payload:     payload,
+	})
+
+	assert.Equal(t, txCap, len(o.txMessages),
+		"tx lane must fill to capacity with fanned-out inner frames")
+	assert.Equal(t, uint64(len(inners)-txCap), o.DroppedTransactions(),
+		"batch overflow must shed to droppedTransactions (jq_trans_overflow)")
+	assert.Equal(t, uint64(0), o.DroppedMessages(),
+		"batch overflow must not bump the consensus-lane counter")
+	assert.Equal(t, 0, len(o.messages),
+		"a transaction batch must never consume the consensus lane")
+}
+
 // TestHandleGetObjectsMessage_DropsReplyWithoutOutstandingRequest pins
 // the rippled reply-branch behavior at PeerImp.cpp:2540-2594: an
 // inbound query=false frame is parsed but go-xrpl has no fetch-pack

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -316,11 +316,12 @@ func TestHandleTransactionsBatchMessage_GatedOnFeatureNegotiation(t *testing.T) 
 	require.NoError(t, err)
 
 	o := &Overlay{
-		cfg:      Config{EnableTxReduceRelay: false},
-		peers:    make(map[PeerID]*Peer),
-		events:   make(chan Event, 8),
-		messages: make(chan *InboundMessage, 8),
-		cluster:  cluster.New(),
+		cfg:        Config{EnableTxReduceRelay: false},
+		peers:      make(map[PeerID]*Peer),
+		events:     make(chan Event, 8),
+		messages:   make(chan *InboundMessage, 8),
+		txMessages: make(chan *InboundMessage, 8),
+		cluster:    cluster.New(),
 	}
 
 	endpoint := Endpoint{Host: "127.0.0.1", Port: 51235}
@@ -345,10 +346,10 @@ func TestHandleTransactionsBatchMessage_GatedOnFeatureNegotiation(t *testing.T) 
 	assert.NotZero(t, peer.BadDataCount(),
 		"TMTransactions batch without tx-reduce-relay must charge bad-data")
 
-	// And no inner frame should have been fanned out to the messages
-	// channel — the whole batch is dropped before the fanout loop.
+	// And no inner frame should have been fanned out to the tx lane —
+	// the whole batch is dropped before the fanout loop.
 	select {
-	case got := <-o.messages:
+	case got := <-o.txMessages:
 		t.Fatalf("expected no fanout, got %v", got)
 	case <-time.After(10 * time.Millisecond):
 	}
@@ -365,11 +366,12 @@ func TestHandleTransactionsBatchMessage_FansOutDecodedTx(t *testing.T) {
 	require.NoError(t, err)
 
 	o := &Overlay{
-		cfg:      Config{EnableTxReduceRelay: true},
-		peers:    make(map[PeerID]*Peer),
-		events:   make(chan Event, 8),
-		messages: make(chan *InboundMessage, 8),
-		cluster:  cluster.New(),
+		cfg:        Config{EnableTxReduceRelay: true},
+		peers:      make(map[PeerID]*Peer),
+		events:     make(chan Event, 8),
+		messages:   make(chan *InboundMessage, 8),
+		txMessages: make(chan *InboundMessage, 8),
+		cluster:    cluster.New(),
 	}
 
 	endpoint := Endpoint{Host: "127.0.0.1", Port: 51235}
@@ -394,7 +396,7 @@ func TestHandleTransactionsBatchMessage_FansOutDecodedTx(t *testing.T) {
 
 	for i := range inners {
 		select {
-		case got := <-o.messages:
+		case got := <-o.txMessages:
 			require.NotNil(t, got)
 			assert.Equal(t, uint16(message.TypeTransaction), got.Type)
 			assert.Nil(t, got.Payload,

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -107,7 +107,18 @@ type Overlay struct {
 	// out a disconnect. Both are drained by the single eventLoop goroutine.
 	events    chan Event
 	lifecycle chan Event
-	messages  chan *InboundMessage
+
+	// messages carries consensus- and ledger-acquisition-relevant peer
+	// frames (proposals, validations, ledger data, status changes,
+	// manifests, validator lists, replay/proof-path replies) to the
+	// router. txMessages carries inbound TMTransaction frames on a
+	// separate lane. Splitting the two means a transaction flood that
+	// saturates txMessages can no longer crowd consensus/acquisition
+	// traffic out of a single shared buffer and get the node
+	// resource-disconnected for dropping mtLEDGER_DATA/mtPROPOSE/
+	// mtVALIDATION (issue #1103).
+	messages   chan *InboundMessage
+	txMessages chan *InboundMessage
 
 	// serveJobs carries heavy inbound serve work (fetch-pack, generic
 	// get-objects, tx back-fill) off the event-loop goroutine onto a
@@ -118,11 +129,6 @@ type Overlay struct {
 	// rippled offloading these to its job queue (jtPACK et al.) rather than
 	// running them on the peer read strand.
 	serveJobs chan func()
-
-	// maxTransactions caches cfg.MaxTransactions, the per-type
-	// in-flight TMTransaction ceiling consulted at the overlay → router
-	// boundary. Non-positive disables the gate.
-	maxTransactions int
 
 	// Peer lifecycle callbacks wired by higher layers (e.g., consensus
 	// router) that need to clean up per-peer state on disconnect. Fired
@@ -186,16 +192,17 @@ type Overlay struct {
 	localNodeIdentity []byte
 
 	// droppedMessages counts how many times the non-blocking send to
-	// the messages channel hit its default branch (downstream consumer
-	// slow). Exposed via DroppedMessages() so server_info / telemetry
-	// can surface back-pressure to operators. Without this counter a
-	// slow consumer silently loses events with only a debug-level log.
+	// the consensus messages channel hit its default branch (downstream
+	// consumer slow). Exposed via DroppedMessages() so server_info /
+	// telemetry can surface back-pressure to operators. Without this
+	// counter a slow consumer silently loses events with only a
+	// debug-level log.
 	droppedMessages atomic.Uint64
 
-	// droppedTransactions counts inbound TMTransaction frames refused
-	// by the MaxTransactions gate in onMessageReceived; the
-	// channel-saturation drop is the backstop when the gate is
-	// disabled. Surfaced via server_info as jq_trans_overflow.
+	// droppedTransactions counts inbound TMTransaction frames shed
+	// because the txMessages lane was at its MaxTransactions ceiling,
+	// covering both wire frames and inner frames fanned out from a
+	// TMTransactions batch. Surfaced via server_info as jq_trans_overflow.
 	droppedTransactions atomic.Uint64
 
 	// Transaction reduce-relay rolling-average metrics surfaced by the
@@ -670,6 +677,19 @@ func messageBufferSize(configured int) int {
 	return configured
 }
 
+// txLaneBufferSize returns the inbound-transaction channel capacity. It
+// equals the MaxTransactions ceiling so a full lane is exactly that
+// ceiling and frames past it are shed, falling back to
+// DefaultMaxTransactions when the configured value is non-positive.
+// Keeping transactions on their own lane stops a tx flood from
+// crowding consensus/acquisition frames out of the messages channel.
+func txLaneBufferSize(configured int) int {
+	if configured <= 0 {
+		return DefaultMaxTransactions
+	}
+	return configured
+}
+
 // eventBufferSize returns the lossy events-channel capacity, falling back
 // to DefaultEventBufferSize when the configured value is non-positive.
 func eventBufferSize(configured int) int {
@@ -736,9 +756,9 @@ func New(opts ...Option) (*Overlay, error) {
 		peers:           make(map[PeerID]*Peer),
 		events:          events,
 		messages:        make(chan *InboundMessage, messageBufferSize(cfg.MessageBufferSize)),
+		txMessages:      make(chan *InboundMessage, txLaneBufferSize(cfg.MaxTransactions)),
 		lifecycle:       make(chan Event, lifecycleBufferSize(&cfg)),
 		stopCh:          make(chan struct{}),
-		maxTransactions: cfg.MaxTransactions,
 		relayedIndex:    make(map[[32]byte]*relayedEntry),
 		clockForIndex:   time.Now,
 		inboundSem:      make(chan struct{}, inboundCap),
@@ -1158,10 +1178,10 @@ func (o *Overlay) onMessageReceived(evt Event) {
 
 	// mtREPLAY_DELTA_RESPONSE / mtPROOF_PATH_RESPONSE that pass the
 	// feature gate above reach the consensus router via the overlay's
-	// Messages() channel — like every other peer-originated reply
-	// (mtLEDGER_DATA, mtTRANSACTION, mtVALIDATION). The router owns
-	// the verification + adoption state and is the only place that
-	// can drive it.
+	// Messages() channel — like every other peer-originated consensus
+	// frame (mtLEDGER_DATA, mtPROPOSE, mtVALIDATION). Transactions ride
+	// the separate TxMessages() lane. The router owns the verification +
+	// adoption state and is the only place that can drive it.
 
 	// Transport-level messages with no consensus-router impact are
 	// handled inline here and NOT forwarded to o.messages.
@@ -1185,20 +1205,22 @@ func (o *Overlay) onMessageReceived(evt Event) {
 
 	slog.Debug("Message received", "t", "Overlay", "type", msgType.String(), "peer", evt.PeerID, "size", len(evt.Payload))
 
-	// Per-type ingress gate: refuse before the channel send so non-tx
-	// traffic keeps flowing when the dispatch pipeline is
-	// tx-saturated. Channel-saturation branch below is the backstop
-	// when the gate is disabled.
-	if msgType == message.TypeTransaction && o.maxTransactions > 0 && len(o.messages) >= o.maxTransactions {
-		o.droppedTransactions.Add(1)
-		slog.Info("Transaction queue is full", "t", "Overlay",
-			"pending", len(o.messages), "max", o.maxTransactions, "peer", evt.PeerID)
+	// Transactions ride a dedicated lane so a tx flood can't crowd
+	// consensus/acquisition frames out of the messages channel and get
+	// us resource-disconnected for dropping mtLEDGER_DATA/mtPROPOSE/
+	// mtVALIDATION (issue #1103).
+	if msgType == message.TypeTransaction {
+		o.forwardTransaction(&InboundMessage{
+			PeerID:  evt.PeerID,
+			Type:    evt.MessageType,
+			Payload: evt.Payload,
+		})
 		return
 	}
 
-	// Forward to external consumers. On back-pressure (channel full),
-	// increment a visible counter rather than silently dropping — the
-	// warn log alone is easy to miss at production log levels.
+	// Forward consensus/acquisition frames. On back-pressure (channel
+	// full), increment a visible counter rather than silently dropping —
+	// the warn log alone is easy to miss at production log levels.
 	select {
 	case o.messages <- &InboundMessage{
 		PeerID:  evt.PeerID,
@@ -1207,10 +1229,23 @@ func (o *Overlay) onMessageReceived(evt Event) {
 	}:
 	default:
 		o.droppedMessages.Add(1)
-		if msgType == message.TypeTransaction {
-			o.droppedTransactions.Add(1)
-		}
 		slog.Warn("Message dropped: channel full", "t", "Overlay", "type", msgType.String())
+	}
+}
+
+// forwardTransaction hands an inbound TMTransaction frame to the tx
+// lane. A full lane means the MaxTransactions ceiling is reached, so the
+// frame is shed and counted (surfaced as jq_trans_overflow). The
+// originating peer resends and reduce-relay re-delivers via other peers,
+// so a shed frame is recoverable. Shared by the wire path
+// (onMessageReceived) and the TMTransactions batch fanout.
+func (o *Overlay) forwardTransaction(msg *InboundMessage) {
+	select {
+	case o.txMessages <- msg:
+	default:
+		o.droppedTransactions.Add(1)
+		slog.Info("Transaction queue is full", "t", "Overlay",
+			"pending", len(o.txMessages), "max", cap(o.txMessages), "peer", msg.PeerID)
 	}
 }
 
@@ -1910,9 +1945,17 @@ func (o *Overlay) PeerCount() int {
 	return len(o.peers)
 }
 
-// Messages returns a channel for receiving inbound messages.
+// Messages returns the channel of inbound consensus- and
+// ledger-acquisition-relevant frames (everything except transactions).
 func (o *Overlay) Messages() <-chan *InboundMessage {
 	return o.messages
+}
+
+// TxMessages returns the channel of inbound TMTransaction frames. It is
+// drained separately from Messages so a transaction flood can't starve
+// consensus/acquisition traffic (issue #1103).
+func (o *Overlay) TxMessages() <-chan *InboundMessage {
+	return o.txMessages
 }
 
 // Identity returns the node's identity.

--- a/internal/peermanagement/tx_ingress_test.go
+++ b/internal/peermanagement/tx_ingress_test.go
@@ -11,25 +11,26 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 )
 
-// TestOverlay_TxIngress_RippledGate pins the rippled-shape
-// jq_trans_overflow trigger: when the in-flight TMTransaction count
-// (proxied by messages-channel depth) already meets the configured
-// MaxTransactions ceiling, the next TMTransaction frame is refused
-// BEFORE the channel send and droppedTransactions increments.
-// Mirrors PeerImp.cpp:1349-1355 where
-// `getJobCount(jtTRANSACTION) > config().MAX_TRANSACTIONS` causes
-// rippled to bump jqTransOverflow_ and skip dispatching the job.
-func TestOverlay_TxIngress_RippledGate(t *testing.T) {
-	const maxTx = 4
+// newLaneTestOverlay builds a bare Overlay with just the two inbound
+// lanes wired, sized for ingress-routing tests. The zero-value cfg
+// leaves reduce-relay metrics off so onMessageReceived takes the plain
+// forward path.
+func newLaneTestOverlay(consensusCap, txCap int) *Overlay {
+	return &Overlay{
+		messages:   make(chan *InboundMessage, consensusCap),
+		txMessages: make(chan *InboundMessage, txCap),
+	}
+}
+
+// TestOverlay_TxLane_BoundedByCapacity pins the tx-lane ceiling: inbound
+// TMTransaction frames land on txMessages until it is full, then excess
+// frames are shed and counted in droppedTransactions (the jq_trans_overflow
+// signal). A full tx lane is exactly the MaxTransactions ceiling.
+func TestOverlay_TxLane_BoundedByCapacity(t *testing.T) {
+	const txCap = 4
 	const flooded = 64
 
-	// Channel cap is intentionally larger than maxTx so the ceiling
-	// gate fires before any hard channel-saturation drop — matching
-	// the production case where MessageBufferSize > MaxTransactions.
-	o := &Overlay{
-		messages:        make(chan *InboundMessage, 32),
-		maxTransactions: maxTx,
-	}
+	o := newLaneTestOverlay(32, txCap)
 
 	for range flooded {
 		o.onMessageReceived(Event{
@@ -40,92 +41,72 @@ func TestOverlay_TxIngress_RippledGate(t *testing.T) {
 		})
 	}
 
-	// First `maxTx` sends land in the channel; the rest are refused
-	// at the rippled-faithful ingress gate.
-	wantDropped := uint64(flooded - maxTx)
-	assert.Equal(t, wantDropped, o.DroppedTransactions(),
-		"DroppedTransactions must count refusals at the MaxTransactions ceiling")
-	assert.Equal(t, maxTx, len(o.messages),
-		"messages channel must hold exactly MaxTransactions accepted frames")
+	assert.Equal(t, txCap, len(o.txMessages),
+		"tx lane must hold exactly its capacity of accepted frames")
+	assert.Equal(t, uint64(flooded-txCap), o.DroppedTransactions(),
+		"DroppedTransactions must count frames shed past the tx-lane ceiling")
 
-	// The aggregate droppedMessages counter does NOT move for ceiling
-	// refusals — only hard channel-saturation drops bump it, matching
-	// the field invariant that droppedMessages tracks send-side failures.
+	// The consensus lane is a different buffer and must be untouched by a
+	// pure transaction flood — that is the whole point of issue #1103.
+	assert.Equal(t, 0, len(o.messages),
+		"transaction flood must not consume the consensus lane")
 	assert.Equal(t, uint64(0), o.DroppedMessages(),
-		"DroppedMessages must not move when refusals happen at the per-type gate")
+		"DroppedMessages must not move for transaction-lane shedding")
 }
 
-// TestOverlay_TxIngress_ChannelSaturationBackstop verifies that when
-// the rippled-faithful gate is disabled (maxTransactions <= 0), the
-// channel-saturation drop branch still records refused TMTransaction
-// frames. This is the defensive backstop: even without an explicit
-// ceiling, a slow consumer cannot silently lose tx-ingress signal.
-func TestOverlay_TxIngress_ChannelSaturationBackstop(t *testing.T) {
-	const capacity = 4
-	const flooded = 64
+// TestOverlay_TxFlood_DoesNotStarveConsensusLane is the core #1103
+// regression: a transaction flood that saturates the tx lane must not
+// cause consensus/acquisition frames (mtLEDGER_DATA/mtPROPOSE/mtVALIDATION)
+// to be dropped. Before the lane split these shared a single 256-slot
+// channel with the 250-frame tx ceiling, leaving ~6 slots for everything
+// else; a tx flood filled it and the next ledger-data reply was dropped,
+// which got the node resource-disconnected by its rippled peer.
+func TestOverlay_TxFlood_DoesNotStarveConsensusLane(t *testing.T) {
+	// Tiny tx lane, easily saturated; consensus lane has its own room.
+	o := newLaneTestOverlay(8, 2)
 
-	o := &Overlay{
-		messages: make(chan *InboundMessage, capacity),
-		// maxTransactions intentionally zero — gate disabled.
-	}
-
-	for range flooded {
+	// Saturate the tx lane well past capacity.
+	for range 1000 {
 		o.onMessageReceived(Event{
 			Type:        EventMessageReceived,
 			PeerID:      PeerID(1),
 			MessageType: uint16(message.TypeTransaction),
-			Payload:     []byte{0xde, 0xad, 0xbe, 0xef},
+			Payload:     []byte{0x01},
 		})
 	}
+	require.Equal(t, 2, len(o.txMessages), "tx lane must be saturated")
+	require.Greater(t, o.DroppedTransactions(), uint64(0),
+		"flood must have shed transactions")
 
-	wantDropped := uint64(flooded - capacity)
-	assert.Equal(t, wantDropped, o.DroppedTransactions(),
-		"DroppedTransactions must count channel-full drops when ceiling gate is disabled")
-	assert.Equal(t, wantDropped, o.DroppedMessages(),
-		"DroppedMessages aggregate must equal the type-specific count when only tx frames overflow")
-}
-
-// TestOverlay_TxIngress_OnlyTxCounterMovesForTx confirms the
-// droppedTransactions counter is TMTransaction-specific: dropping a
-// non-tx frame bumps droppedMessages but leaves droppedTransactions
-// untouched. Without this discrimination the jq_trans_overflow signal
-// would conflate transaction backpressure with unrelated traffic
-// (ledger_data, validations, etc.) and confuse operators.
-func TestOverlay_TxIngress_OnlyTxCounterMovesForTx(t *testing.T) {
-	o := &Overlay{
-		messages: make(chan *InboundMessage, 1),
-	}
-
-	nonTxType := uint16(message.TypeLedgerData)
-	// Fill the channel with a non-tx frame, then overflow with another.
-	for range 4 {
+	// Now a consensus/acquisition frame must still get through.
+	for _, mt := range []message.MessageType{
+		message.TypeLedgerData,
+		message.TypeProposeLedger,
+		message.TypeValidation,
+	} {
 		o.onMessageReceived(Event{
 			Type:        EventMessageReceived,
 			PeerID:      PeerID(1),
-			MessageType: nonTxType,
+			MessageType: uint16(mt),
 			Payload:     []byte{0x00},
 		})
 	}
 
-	assert.Equal(t, uint64(0), o.DroppedTransactions(),
-		"DroppedTransactions must not move when only non-tx frames overflow")
-	assert.Greater(t, o.DroppedMessages(), uint64(0),
-		"DroppedMessages aggregate must still record the non-tx drops")
+	assert.Equal(t, 3, len(o.messages),
+		"consensus/acquisition frames must reach the consensus lane despite the tx flood")
+	assert.Equal(t, uint64(0), o.DroppedMessages(),
+		"no consensus frame may be dropped while only the tx lane is saturated")
 }
 
-// TestOverlay_TxIngress_NonTxBypassesGate confirms the
-// rippled-faithful gate is per-type: non-TMTransaction frames are
-// never refused at the ceiling, matching PeerImp.cpp where the
-// jq_trans_overflow check is inside `onMessage(TMTransaction)` and
-// other handlers (proposal, validation, ledger_data) ignore it.
-func TestOverlay_TxIngress_NonTxBypassesGate(t *testing.T) {
-	o := &Overlay{
-		messages:        make(chan *InboundMessage, 32),
-		maxTransactions: 2,
-	}
+// TestOverlay_NonTxUsesConsensusLane confirms the counters stay
+// class-specific: a non-tx frame that overflows the consensus lane bumps
+// droppedMessages and never touches droppedTransactions, so the
+// jq_trans_overflow signal isn't polluted by unrelated traffic. The tx
+// lane stays empty.
+func TestOverlay_NonTxUsesConsensusLane(t *testing.T) {
+	o := newLaneTestOverlay(1, 8)
 
-	// Saturate the channel above maxTransactions with NON-tx frames.
-	for range 16 {
+	for range 4 {
 		o.onMessageReceived(Event{
 			Type:        EventMessageReceived,
 			PeerID:      PeerID(1),
@@ -133,29 +114,27 @@ func TestOverlay_TxIngress_NonTxBypassesGate(t *testing.T) {
 			Payload:     []byte{0x00},
 		})
 	}
-	require.Equal(t, 16, len(o.messages),
-		"non-tx frames must not trip the per-type ceiling")
+
+	assert.Greater(t, o.DroppedMessages(), uint64(0),
+		"DroppedMessages must record consensus-lane overflow")
 	assert.Equal(t, uint64(0), o.DroppedTransactions(),
-		"non-tx traffic must not bump the TMTransaction counter")
+		"DroppedTransactions must not move when only non-tx frames overflow")
+	assert.Equal(t, 0, len(o.txMessages),
+		"non-tx traffic must never reach the tx lane")
 }
 
-// TestOverlay_TxIngress_BoundedGoroutines is the bounded-backpressure
-// soak: flood thousands of TMTransaction frames at a tiny channel and
-// confirm no goroutine fans out per-message. The single-writer ingest
-// path is the structural bound on memory growth — if a future change
-// fans out per-frame, the goroutine count would scale with the flood
-// size and this test would fail.
-func TestOverlay_TxIngress_BoundedGoroutines(t *testing.T) {
-	const capacity = 8
+// TestOverlay_TxLane_BoundedGoroutines is the bounded-backpressure soak:
+// flood thousands of TMTransaction frames at a tiny tx lane and confirm no
+// goroutine fans out per-message. The single-writer ingest path is the
+// structural bound on memory growth — a future per-frame fan-out would
+// scale the goroutine count with the flood size and fail this test.
+func TestOverlay_TxLane_BoundedGoroutines(t *testing.T) {
+	const txCap = 8
 	const flooded = 10_000
 	const writers = 16
 
-	o := &Overlay{
-		messages:        make(chan *InboundMessage, capacity),
-		maxTransactions: capacity, // exercise the rippled-faithful gate
-	}
+	o := newLaneTestOverlay(8, txCap)
 
-	// Settle the runtime before sampling baseline goroutines.
 	runtime.GC()
 	baseline := runtime.NumGoroutine()
 
@@ -177,20 +156,12 @@ func TestOverlay_TxIngress_BoundedGoroutines(t *testing.T) {
 	wg.Wait()
 	runtime.GC()
 
-	// After the flood, in-flight goroutines must not have ballooned in
-	// proportion to message count. Allow generous slack to absorb the
-	// runtime's bookkeeping goroutines on loaded CI runners; the
-	// assertion fails only on per-message fan-out (which would push
-	// the delta into the thousands).
 	delta := runtime.NumGoroutine() - baseline
 	assert.LessOrEqual(t, delta, writers+64,
 		"per-message goroutine fan-out detected: delta=%d, baseline=%d", delta, baseline)
 
-	// Sanity: counter advanced. Exact value isn't deterministic under
-	// concurrent producers (consumer never runs, but writes are
-	// non-blocking), so just assert progress.
 	require.Greater(t, o.DroppedTransactions(), uint64(0),
-		"flood must have triggered at least one TMTransaction refusal")
+		"flood must have triggered at least one transaction shed")
 }
 
 // TestMessageBufferSize_NonPositiveFallback pins the helper's
@@ -211,5 +182,26 @@ func TestMessageBufferSize_NonPositiveFallback(t *testing.T) {
 	for _, tc := range cases {
 		assert.Equal(t, tc.want, messageBufferSize(tc.in),
 			"messageBufferSize(%d)", tc.in)
+	}
+}
+
+// TestTxLaneBufferSize_NonPositiveFallback pins the tx-lane helper's
+// non-positive → DefaultMaxTransactions contract, mirroring the
+// consensus-lane helper. A non-positive cfg.MaxTransactions must still
+// yield a buffered lane so the non-blocking send doesn't degrade into a
+// drop-every-transaction path.
+func TestTxLaneBufferSize_NonPositiveFallback(t *testing.T) {
+	cases := []struct {
+		in   int
+		want int
+	}{
+		{0, DefaultMaxTransactions},
+		{-1, DefaultMaxTransactions},
+		{100, 100},
+		{1000, 1000},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, txLaneBufferSize(tc.in),
+			"txLaneBufferSize(%d)", tc.in)
 	}
 }


### PR DESCRIPTION
## Summary
- Inbound peer frames all shared one bounded channel (`o.messages`, cap `DefaultMessageBufferSize=256`) with a tx ingress gate at `MaxTransactions=250`, leaving only ~6 slots for consensus/acquisition traffic. Under a transaction flood the channel saturated and the indiscriminate channel-full `default` branch dropped **every** class — including `mtLEDGER_DATA`/`mtPROPOSE`/`mtVALIDATION` — stalling state acquisition until the rippled peer resource-disconnected the node and wedged consensus (most visible on a 1r+1g, quorum-2/2 soak).
- Route transactions onto a **dedicated `txMessages` lane** (sized to the `MaxTransactions` ceiling) drained separately by the consensus router's existing worker pool, so a tx flood can no longer crowd consensus/acquisition frames out of their own buffer. This replaces the old shared-channel gate; batch-fanned inner transactions use the same lane and `jq_trans_overflow` accounting.
- Mirrors rippled's structure more closely: distinct message classes go to distinct queues (`jtTRANSACTION` vs proposal/validation/inbound-ledger) rather than sharing one bounded inbound channel.

### Changes
- `peermanagement/overlay.go`: new `txMessages` channel + `forwardTransaction` helper (non-blocking send, sheds+counts `droppedTransactions` on full); `messages` now carries only consensus/acquisition frames; new `TxMessages()` accessor; removed the dead `maxTransactions` gate + struct field; `txLaneBufferSize` helper.
- `peermanagement/inbound_handlers.go`: TMTransactions batch fanout routes inner txs to the tx lane.
- `consensus/adaptor/router.go` + `startup.go`: `SetTxInbox` setter; `Run` selects the tx lane alongside the consensus inbox and hands frames to the worker pool. A nil/unset lane is never selected (no behavior change for tests).
- `jq_trans_overflow` (`cli/server.go`) accounting unchanged and still non-double-counting (overlay tx-lane shed + worker-pool shed are disjoint stages).

## Test plan
- [x] `go test -race ./internal/peermanagement/ ./internal/consensus/adaptor/`
- [x] Rewrote `tx_ingress_test.go` around the lanes, incl. the core regression: a tx flood saturating the tx lane must **not** drop consensus/acquisition frames (`TestOverlay_TxFlood_DoesNotStarveConsensusLane`); added `TestRunDrainsTxLane` end-to-end.
- [x] `go test ./internal/consensus/... ./internal/rpc/... ./internal/ledger/... ./internal/txq/...`
- [x] `go build ./...`, `gofmt`, `golangci-lint run` (0 issues)
- Note: protocol-conformance suite is orthogonal (it exercises tx/ledger vectors, not the peer overlay inbound path). Full wedge resolution is only observable via an `xrpl-confluence` 1r+1g soak.

Fixes #1103