### PR TITLE
fix(ledger): apply flag-ledger NegativeUNL transition on the live close path

### DIFF
--- a/internal/ledger/service/negative_unl_close_coverage_test.go
+++ b/internal/ledger/service/negative_unl_close_coverage_test.go
@@ -1,0 +1,147 @@
+package service_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	testenv "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// negUNLValidator is a deterministic ed25519-prefixed validator public key used
+// to seed a pending ValidatorToDisable across the flag-ledger coverage tests.
+func negUNLValidator() []byte {
+	v := make([]byte, 33)
+	v[0] = 0xED
+	for i := 1; i < 33; i++ {
+		v[i] = 0x42
+	}
+	return v
+}
+
+// driveStandaloneToFlagParent advances a fresh standalone service to the flag
+// ledger's parent: it closes ledgers until the open ledger is seq 256 (the
+// first flag ledger), with seq 255 carrying a pending ValidatorToDisable on its
+// NegativeUNL SLE — the state a UNLModify pseudo-tx on the prior flag ledger
+// would have left. The returned service is poised so that the next close (256)
+// is the flag-ledger close under test.
+func driveStandaloneToFlagParent(t *testing.T) (*service.Service, []byte) {
+	t.Helper()
+
+	svc, err := service.New(service.DefaultConfig())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	for i := 0; svc.GetOpenLedger().Sequence() < 255; i++ {
+		if i > 300 {
+			t.Fatalf("drove %d ledgers without reaching open seq 255 (at %d)",
+				i, svc.GetOpenLedger().Sequence())
+		}
+		closeLedger(t, svc)
+	}
+	if got := svc.GetOpenLedger().Sequence(); got != 255 {
+		t.Fatalf("open seq before SLE injection = %d, want 255", got)
+	}
+
+	validator := negUNLValidator()
+	seed, err := pseudo.SerializeNegativeUNLSLE(&pseudo.NegativeUNLSLE{ValidatorToDisable: validator})
+	if err != nil {
+		t.Fatalf("serialize NegativeUNL seed: %v", err)
+	}
+	if err := svc.GetOpenLedger().Insert(keylet.NegativeUNL(), seed); err != nil {
+		t.Fatalf("insert NegativeUNL SLE into open 255: %v", err)
+	}
+
+	// Close 255 (carries the pending transition forward) and open 256.
+	closeLedger(t, svc)
+	if got := svc.GetOpenLedger().Sequence(); got != 256 {
+		t.Fatalf("open seq after closing 255 = %d, want 256", got)
+	}
+	return svc, validator
+}
+
+// assertFlagLedgerTransitioned checks the flag ledger (the latest closed ledger,
+// expected seq 256) materialised the NegativeUNL transition: ValidatorToDisable
+// moved into DisabledValidators with FirstLedgerSequence stamped to the flag
+// ledger, and the transition field cleared.
+func assertFlagLedgerTransitioned(t *testing.T, svc *service.Service, validator []byte) {
+	t.Helper()
+
+	closed := svc.GetClosedLedger()
+	if got := closed.Sequence(); got != 256 {
+		t.Fatalf("closed seq = %d, want 256", got)
+	}
+	raw, err := closed.Read(keylet.NegativeUNL())
+	if err != nil {
+		t.Fatalf("read NegativeUNL SLE from flag ledger: %v", err)
+	}
+	if raw == nil {
+		t.Fatal("NegativeUNL SLE missing from flag ledger")
+	}
+	sle, err := pseudo.ParseNegativeUNLSLE(raw)
+	if err != nil {
+		t.Fatalf("parse NegativeUNL SLE: %v", err)
+	}
+	if len(sle.DisabledValidators) != 1 {
+		t.Fatalf("DisabledValidators len = %d, want 1 — flag-ledger transition not applied (issue #1091)",
+			len(sle.DisabledValidators))
+	}
+	if dv := sle.DisabledValidators[0]; !bytes.Equal(dv.PublicKey, validator) {
+		t.Errorf("DisabledValidators[0].PublicKey = %x, want %x", dv.PublicKey, validator)
+	} else if dv.FirstLedgerSequence != 256 {
+		t.Errorf("FirstLedgerSequence = %d, want 256", dv.FirstLedgerSequence)
+	}
+	if len(sle.ValidatorToDisable) != 0 {
+		t.Errorf("ValidatorToDisable not cleared on flag ledger: %x", sle.ValidatorToDisable)
+	}
+}
+
+// TestAcceptLedger_StandaloneFlagLedgerAppliesNegativeUNL covers the standalone
+// AcceptLedger close path (issue #1091): with no pending transactions the close
+// skips buildClosedLedgerLocked and must still apply the flag-ledger NegativeUNL
+// transition via the else branch on the open ledger. Complements the consensus
+// empty-tx-set regression in TestAcceptConsensusResult_FlagLedgerAppliesNegativeUNL.
+func TestAcceptLedger_StandaloneFlagLedgerAppliesNegativeUNL(t *testing.T) {
+	svc, validator := driveStandaloneToFlagParent(t)
+
+	// Empty pending set: AcceptLedger takes the else branch on s.openLedger.
+	closeLedger(t, svc)
+
+	assertFlagLedgerTransitioned(t, svc, validator)
+}
+
+// TestAcceptLedger_FlagLedgerWithTxAppliesNegativeUNL covers the
+// buildClosedLedgerLocked path: a flag-ledger close carrying a transaction must
+// apply the NegativeUNL transition on the fresh ledger before the transaction,
+// not only on the empty-tx-set close paths. A real payment makes the pending set
+// non-empty so AcceptLedger rebuilds through buildClosedLedgerLocked.
+func TestAcceptLedger_FlagLedgerWithTxAppliesNegativeUNL(t *testing.T) {
+	svc, validator := driveStandaloneToFlagParent(t)
+
+	env := testenv.NewTestEnv(t)
+	env.SetVerifySignatures(true)
+	master := testenv.MasterAccount()
+	alice := testenv.NewAccount("alice")
+
+	masterSeq := accountSeq(t, svc, master.Address)
+	mustApply(t, svc, signedBlob(t, env,
+		payment.Pay(master, alice, 100_000_000).Sequence(masterSeq).Build(), master))
+
+	// Pending set is non-empty: AcceptLedger routes through buildClosedLedgerLocked.
+	closeLedger(t, svc)
+
+	assertFlagLedgerTransitioned(t, svc, validator)
+
+	// The carried transaction must also have applied in the flag-ledger build.
+	if _, err := svc.GetAccountInfo(context.Background(), alice.Address, "current"); err != nil {
+		t.Errorf("alice account not created by the flag-ledger payment: %v", err)
+	}
+}

--- a/internal/ledger/service/negative_unl_close_test.go
+++ b/internal/ledger/service/negative_unl_close_test.go
@@ -1,12 +1,12 @@
-package service
+package service_test
 
 import (
-	"bytes"
 	"context"
 	"testing"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -25,9 +25,9 @@ import (
 // a pending ValidatorToDisable seeded on the parent and asserts the transition
 // materialised.
 func TestAcceptConsensusResult_FlagLedgerAppliesNegativeUNL(t *testing.T) {
-	cfg := DefaultConfig()
+	cfg := service.DefaultConfig()
 	cfg.Standalone = false
-	svc, err := New(cfg)
+	svc, err := service.New(cfg)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -54,11 +54,7 @@ func TestAcceptConsensusResult_FlagLedgerAppliesNegativeUNL(t *testing.T) {
 
 	// Hand-build seq 255 carrying a pending ValidatorToDisable, as a UNLModify
 	// pseudo-tx on the prior flag ledger would have left it.
-	validator := make([]byte, 33)
-	validator[0] = 0xED
-	for i := 1; i < 33; i++ {
-		validator[i] = 0x42
-	}
+	validator := negUNLValidator()
 	seed, err := pseudo.SerializeNegativeUNLSLE(&pseudo.NegativeUNLSLE{
 		ValidatorToDisable: validator,
 	})
@@ -92,30 +88,5 @@ func TestAcceptConsensusResult_FlagLedgerAppliesNegativeUNL(t *testing.T) {
 		t.Fatalf("flag-ledger seq = %d, want 256", seq)
 	}
 
-	closed := svc.GetClosedLedger()
-	raw, err := closed.Read(keylet.NegativeUNL())
-	if err != nil {
-		t.Fatalf("read NegativeUNL SLE from flag ledger: %v", err)
-	}
-	if raw == nil {
-		t.Fatal("NegativeUNL SLE missing from flag ledger")
-	}
-	sle, err := pseudo.ParseNegativeUNLSLE(raw)
-	if err != nil {
-		t.Fatalf("parse NegativeUNL SLE: %v", err)
-	}
-
-	if len(sle.DisabledValidators) != 1 {
-		t.Fatalf("DisabledValidators len = %d, want 1 — flag-ledger transition not applied (issue #1091)", len(sle.DisabledValidators))
-	}
-	dv := sle.DisabledValidators[0]
-	if !bytes.Equal(dv.PublicKey, validator) {
-		t.Errorf("DisabledValidators[0].PublicKey = %x, want %x", dv.PublicKey, validator)
-	}
-	if dv.FirstLedgerSequence != 256 {
-		t.Errorf("FirstLedgerSequence = %d, want 256", dv.FirstLedgerSequence)
-	}
-	if len(sle.ValidatorToDisable) != 0 {
-		t.Errorf("ValidatorToDisable not cleared on flag ledger: %x", sle.ValidatorToDisable)
-	}
+	assertFlagLedgerTransitioned(t, svc, validator)
 }

--- a/internal/ledger/service/negative_unl_close_test.go
+++ b/internal/ledger/service/negative_unl_close_test.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// TestAcceptConsensusResult_FlagLedgerAppliesNegativeUNL is the regression test
+// for issue #1091: the live consensus close path must apply the flag-ledger
+// NegativeUNL transition (move sfValidatorToDisable into sfDisabledValidators,
+// clear the transition field) just like the catchup/replay path, or a
+// locally-built flag ledger computes a different account_hash than the rest of
+// the network and forks.
+//
+// The empty-consensus-tx-set close is the gap: AcceptConsensusResult skips
+// buildClosedLedgerLocked when the agreed tx set is empty, yet rippled applies
+// the transition on every flag ledger (seq % 256 == 0) regardless of whether it
+// carries transactions. This drives a flag-ledger close through that path with
+// a pending ValidatorToDisable seeded on the parent and asserts the transition
+// materialised.
+func TestAcceptConsensusResult_FlagLedgerAppliesNegativeUNL(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Standalone = false
+	svc, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	closeTime := time.Unix(1700000000, 0)
+
+	// Build a chain from genesis up to seq 254 so the next ledger (256, built
+	// below) is the first flag ledger.
+	parent := svc.GetClosedLedger()
+	for parent.Sequence() < 254 {
+		closeTime = closeTime.Add(2 * time.Second)
+		open, err := ledger.NewOpen(parent, closeTime)
+		if err != nil {
+			t.Fatalf("NewOpen %d: %v", parent.Sequence()+1, err)
+		}
+		if err := open.Close(closeTime, 0); err != nil {
+			t.Fatalf("Close %d: %v", open.Sequence(), err)
+		}
+		parent = open
+	}
+
+	// Hand-build seq 255 carrying a pending ValidatorToDisable, as a UNLModify
+	// pseudo-tx on the prior flag ledger would have left it.
+	validator := make([]byte, 33)
+	validator[0] = 0xED
+	for i := 1; i < 33; i++ {
+		validator[i] = 0x42
+	}
+	seed, err := pseudo.SerializeNegativeUNLSLE(&pseudo.NegativeUNLSLE{
+		ValidatorToDisable: validator,
+	})
+	if err != nil {
+		t.Fatalf("serialize NegativeUNL seed: %v", err)
+	}
+
+	closeTime = closeTime.Add(2 * time.Second)
+	open255, err := ledger.NewOpen(parent, closeTime)
+	if err != nil {
+		t.Fatalf("NewOpen 255: %v", err)
+	}
+	if err := open255.Insert(keylet.NegativeUNL(), seed); err != nil {
+		t.Fatalf("insert NegativeUNL SLE: %v", err)
+	}
+	if err := open255.Close(closeTime, 0); err != nil {
+		t.Fatalf("Close 255: %v", err)
+	}
+	if open255.Sequence() != 255 {
+		t.Fatalf("hand-built parent seq = %d, want 255", open255.Sequence())
+	}
+
+	// Build the flag ledger (seq 256) through the consensus path with an EMPTY
+	// tx set — the sub-path that skipped the transition before this fix.
+	closeTime = closeTime.Add(2 * time.Second)
+	seq, err := svc.AcceptConsensusResult(context.TODO(), open255, nil, closeTime, true)
+	if err != nil {
+		t.Fatalf("flag-ledger consensus close: %v", err)
+	}
+	if seq != 256 {
+		t.Fatalf("flag-ledger seq = %d, want 256", seq)
+	}
+
+	closed := svc.GetClosedLedger()
+	raw, err := closed.Read(keylet.NegativeUNL())
+	if err != nil {
+		t.Fatalf("read NegativeUNL SLE from flag ledger: %v", err)
+	}
+	if raw == nil {
+		t.Fatal("NegativeUNL SLE missing from flag ledger")
+	}
+	sle, err := pseudo.ParseNegativeUNLSLE(raw)
+	if err != nil {
+		t.Fatalf("parse NegativeUNL SLE: %v", err)
+	}
+
+	if len(sle.DisabledValidators) != 1 {
+		t.Fatalf("DisabledValidators len = %d, want 1 — flag-ledger transition not applied (issue #1091)", len(sle.DisabledValidators))
+	}
+	dv := sle.DisabledValidators[0]
+	if !bytes.Equal(dv.PublicKey, validator) {
+		t.Errorf("DisabledValidators[0].PublicKey = %x, want %x", dv.PublicKey, validator)
+	}
+	if dv.FirstLedgerSequence != 256 {
+		t.Errorf("FirstLedgerSequence = %d, want 256", dv.FirstLedgerSequence)
+	}
+	if len(sle.ValidatorToDisable) != 0 {
+		t.Errorf("ValidatorToDisable not cleared on flag ledger: %x", sle.ValidatorToDisable)
+	}
+}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1312,15 +1312,12 @@ func (s *Service) AcceptLedgerAt(ctx context.Context, explicitCloseTime time.Tim
 	return closedSeq, nil
 }
 
-// applyFlagLedgerNegativeUNL applies the pending NegativeUNL transition
-// (move ValidatorToDisable into DisabledValidators, drop ValidatorToReEnable,
-// clear the transition fields) to l when l is a flag ledger (seq % 256 == 0)
-// and featureNegativeUNL is enabled on the parent rule set. rippled does this
-// on every flag-ledger build before applying transactions, and the
-// catchup/replay-delta path mirrors it; omitting it on the local close path
-// makes a locally-built flag ledger compute a different account_hash than the
-// rest of the network 256 ledgers after any UNLModify set a pending
-// transition, forking the chain. Caller must hold s.mu.
+// applyFlagLedgerNegativeUNL applies the pending NegativeUNL transition on a
+// flag ledger (seq % 256 == 0) when featureNegativeUNL is enabled on the parent
+// rules. Skipping it on the local close path makes a locally-built flag ledger
+// compute a different account_hash than the rest of the network 256 ledgers
+// after a UNLModify queues a transition, forking the chain. Caller must hold
+// s.mu.
 func (s *Service) applyFlagLedgerNegativeUNL(l *ledger.Ledger) error {
 	if l.Sequence()%256 != 0 {
 		return nil
@@ -1352,8 +1349,8 @@ func (s *Service) buildClosedLedgerLocked(pending []pendingTx, closeTime time.Ti
 		return nil, fmt.Errorf("failed to create fresh ledger for close: %w", err)
 	}
 
-	// On a flag ledger, apply the pending NegativeUNL transition before any
-	// transactions, matching rippled's BuildLedger ordering.
+	// On a flag ledger the NegativeUNL transition must be applied before any
+	// transactions.
 	if err := s.applyFlagLedgerNegativeUNL(freshLedger); err != nil {
 		return nil, err
 	}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1222,6 +1222,12 @@ func (s *Service) AcceptLedgerAt(ctx context.Context, explicitCloseTime time.Tim
 			return 0, err
 		}
 		retriableTxs = built
+	} else {
+		// No pending txs to rebuild through buildClosedLedgerLocked, but a
+		// flag-ledger close must still apply the pending NegativeUNL transition.
+		if err := s.applyFlagLedgerNegativeUNL(s.openLedger); err != nil {
+			return 0, err
+		}
 	}
 
 	// Reset pending transactions
@@ -1306,6 +1312,29 @@ func (s *Service) AcceptLedgerAt(ctx context.Context, explicitCloseTime time.Tim
 	return closedSeq, nil
 }
 
+// applyFlagLedgerNegativeUNL applies the pending NegativeUNL transition
+// (move ValidatorToDisable into DisabledValidators, drop ValidatorToReEnable,
+// clear the transition fields) to l when l is a flag ledger (seq % 256 == 0)
+// and featureNegativeUNL is enabled on the parent rule set. rippled does this
+// on every flag-ledger build before applying transactions, and the
+// catchup/replay-delta path mirrors it; omitting it on the local close path
+// makes a locally-built flag ledger compute a different account_hash than the
+// rest of the network 256 ledgers after any UNLModify set a pending
+// transition, forking the chain. Caller must hold s.mu.
+func (s *Service) applyFlagLedgerNegativeUNL(l *ledger.Ledger) error {
+	if l.Sequence()%256 != 0 {
+		return nil
+	}
+	rules := rulesFromLedger(s.closedLedger, s.logger)
+	if rules == nil || !rules.Enabled(amendment.FeatureNegativeUNL) {
+		return nil
+	}
+	if err := l.UpdateNegativeUNL(); err != nil {
+		return fmt.Errorf("flag-ledger updateNegativeUNL: %w", err)
+	}
+	return nil
+}
+
 // buildClosedLedgerLocked canonically sorts pending, re-applies it onto a
 // fresh ledger built from s.closedLedger, hoists every committed tx into
 // s.txIndex, and installs the result as s.openLedger. It returns the txs
@@ -1321,6 +1350,12 @@ func (s *Service) buildClosedLedgerLocked(pending []pendingTx, closeTime time.Ti
 	freshLedger, err := ledger.NewOpen(s.closedLedger, closeTime)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create fresh ledger for close: %w", err)
+	}
+
+	// On a flag ledger, apply the pending NegativeUNL transition before any
+	// transactions, matching rippled's BuildLedger ordering.
+	if err := s.applyFlagLedgerNegativeUNL(freshLedger); err != nil {
+		return nil, err
 	}
 
 	baseFee, reserveBase, reserveIncrement := readFeesFromLedger(s.closedLedger)
@@ -2021,6 +2056,12 @@ func (s *Service) AcceptConsensusResult(ctx context.Context, parent *ledger.Ledg
 		canonicalTxHashes = make([]string, 0, len(pending))
 		for _, ptx := range pending {
 			canonicalTxHashes = append(canonicalTxHashes, fmt.Sprintf("%x", ptx.Hash[:8]))
+		}
+	} else {
+		// Empty consensus tx set: buildClosedLedgerLocked is skipped, but a
+		// flag-ledger close must still apply the pending NegativeUNL transition.
+		if err := s.applyFlagLedgerNegativeUNL(s.openLedger); err != nil {
+			return 0, err
 		}
 	}
 


### PR DESCRIPTION
## Summary
- The live close path (`AcceptConsensusResult` / `AcceptLedgerAt` → `Close`) never applied the flag-ledger NegativeUNL transition, unlike the catchup/replay-delta path. A locally-built flag ledger (`seq % 256 == 0`) therefore computed a different `account_hash` than the rest of the network 256 ledgers after any UNLModify set a pending transition — a consensus fork.
- Added a shared `applyFlagLedgerNegativeUNL` helper and invoke it on every close sub-path: before transactions in `buildClosedLedgerLocked` (the tx path, matching rippled's `BuildLedger` ordering vs. UNLModify pseudo-txs) and before `Close` in the **empty-tx-set** branches of both the consensus and standalone paths. The empty-tx-set consensus close was the real gap — `buildClosedLedgerLocked` is skipped when the agreed tx set is empty, yet rippled applies the transition on every flag ledger regardless of whether it carries transactions.

## Test plan
- [x] New regression test `TestAcceptConsensusResult_FlagLedgerAppliesNegativeUNL` drives a flag-ledger (seq 256) close through the empty consensus tx set with a seeded pending `ValidatorToDisable`; asserts the entry moves into `DisabledValidators` with `FirstLedgerSequence == 256` and the transition field is cleared. Verified it **fails** without the fix and passes with it.
- [x] `go test ./internal/ledger/... ./internal/consensus/... ./internal/testing/pseudotx/...` — all green.
- [x] Conformance unchanged vs. baseline: in-scope 1131 pass / 10 fail / 1141 (99.1%) both with and without the fix — zero regressions.
- [x] `gofmt` / `go vet` clean.

Fixes #1091