### PR TITLE
perf(replaytool): profile replay-range (#1084 Step 0) + skip per-fetch re-hash + --shards

### DIFF
--- a/internal/replaytool/replay_findings.go
+++ b/internal/replaytool/replay_findings.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	rtdebug "runtime/debug"
+	"sync"
 )
 
 // findingSchema versions the findings record so the lab can evolve the format.
@@ -59,7 +60,11 @@ type findingTx struct {
 
 // findingsWriter appends Findings to a file as JSON Lines (one record per
 // line), so a long-running survey streams findings without buffering them all.
+// Write is mutex-guarded so a sharded run can share one writer across worker
+// goroutines: a finding can exceed the OS atomic-append size, so concurrent
+// O_APPEND writes are serialized to keep records from interleaving.
 type findingsWriter struct {
+	mu  sync.Mutex
 	f   *os.File
 	enc *json.Encoder
 }
@@ -73,6 +78,8 @@ func newFindingsWriter(path string) (*findingsWriter, error) {
 }
 
 func (w *findingsWriter) Write(finding *Finding) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.enc.Encode(finding)
 }
 

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -49,6 +49,7 @@ type replayRangeRunner struct {
 	continueOnDivergence bool
 	findingsOut          string
 	goxrplCommit         string
+	shards               int
 }
 
 // newReplayRangeCmd builds the `replay-range` command and its flags.
@@ -129,6 +130,7 @@ Example:
 	cmd.Flags().BoolVar(&r.continueOnDivergence, "continue-on-divergence", false, "On a hash mismatch, record a finding and reset to mainnet ground truth, then continue (survey all divergences) instead of stopping")
 	cmd.Flags().StringVar(&r.findingsOut, "findings-out", "", "Path to the findings JSONL file (default <dump-dir>/findings.jsonl or ./debug/findings.jsonl); used with --continue-on-divergence")
 	cmd.Flags().StringVar(&r.goxrplCommit, "goxrpl-commit", "", "Commit/image tag recorded in findings (default: VCS revision from build info)")
+	cmd.Flags().IntVar(&r.shards, "shards", 1, "Replay the range as N parallel segments, each on its own goroutine, DB client, and nodestore overlay (survey throughput multiplier). Every segment boundary must be an independently seedable ledger (a checkpoint seq), since each segment loads and account-hash-verifies its own seed. 1 = serial (default).")
 
 	// MarkFlagRequired only errors if the flag does not exist — a construction
 	// bug, so fail fast rather than ignoring the error.
@@ -165,28 +167,16 @@ func (r *replayRangeRunner) run() error {
 	if r.from >= r.to {
 		return fmt.Errorf("--from must be less than --to")
 	}
-
-	// Effective starting point. With --resume-from we seed from an on-disk
-	// checkpoint at that seq instead of loading the full state at --from.
-	startLedger := r.from
-	if r.resumeFrom > 0 {
-		if r.checkpointDir == "" {
-			return fmt.Errorf("--resume-from requires --checkpoint-dir")
-		}
-		if r.resumeFrom <= r.from || r.resumeFrom >= r.to {
-			return fmt.Errorf("--resume-from must be within (%d, %d)", r.from, r.to)
-		}
-		if _, err := os.Stat(checkpointPath(r.checkpointDir, r.resumeFrom)); err != nil {
-			return fmt.Errorf("no checkpoint for ledger %d in %s; --resume-from must equal a ledger seq checkpointed in a prior run (a multiple of --checkpoint-interval)", r.resumeFrom, r.checkpointDir)
-		}
-		startLedger = r.resumeFrom
+	if r.shards < 1 {
+		return fmt.Errorf("--shards must be >= 1")
 	}
 
 	ctx := context.Background()
-	startTime := time.Now()
 
 	// Opt-in profiling: GOXRPL_PPROF=:6060 exposes pprof for this run so the
-	// CPU-vs-IO split of a replay can be measured. Off by default.
+	// CPU-vs-IO split of a replay can be measured. Off by default. The pprof
+	// server and GOGC are process-global, so they are set once here rather than
+	// per shard.
 	if addr := os.Getenv("GOXRPL_PPROF"); addr != "" {
 		go func() {
 			if err := observability.StartPProf(addr); err != nil {
@@ -202,6 +192,62 @@ func (r *replayRangeRunner) run() error {
 		debug.SetGCPercent(r.gogc)
 	}
 
+	if r.shards > 1 {
+		return r.runSharded(ctx)
+	}
+
+	// Findings, when enabled, are opened once and (in the sharded path) shared
+	// across workers — the writer is safe for concurrent use.
+	var findings *findingsWriter
+	if r.continueOnDivergence {
+		f, err := newFindingsWriter(r.findingsPath())
+		if err != nil {
+			return fmt.Errorf("opening findings file: %w", err)
+		}
+		findings = f
+		defer findings.Close()
+	}
+
+	stats, err := r.replaySegment(ctx, findings)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(r.out)
+	r.printRangeSummary(stats)
+
+	if stats.FailedAtBlock > 0 {
+		// The failure is already reported in the loop; only the exit code is left.
+		return cmdexit.ErrReported
+	}
+	return nil
+}
+
+// replaySegment runs the continuous-replay loop over [r.from, r.to] (or from
+// --resume-from) with its own DB client and state source, returning the
+// segment's stats. It prints its own header and per-block progress to r.out;
+// the caller owns the run summary so the sharded path can aggregate across
+// segments. The findings writer, when non-nil, is shared across shards.
+// Process-global setup (pprof, GOGC) is the caller's responsibility.
+func (r *replayRangeRunner) replaySegment(ctx context.Context, findings *findingsWriter) (*RangeReplayStats, error) {
+	// Effective starting point. With --resume-from we seed from an on-disk
+	// checkpoint at that seq instead of loading the full state at --from.
+	startLedger := r.from
+	if r.resumeFrom > 0 {
+		if r.checkpointDir == "" {
+			return nil, fmt.Errorf("--resume-from requires --checkpoint-dir")
+		}
+		if r.resumeFrom <= r.from || r.resumeFrom >= r.to {
+			return nil, fmt.Errorf("--resume-from must be within (%d, %d)", r.from, r.to)
+		}
+		if _, err := os.Stat(checkpointPath(r.checkpointDir, r.resumeFrom)); err != nil {
+			return nil, fmt.Errorf("no checkpoint for ledger %d in %s; --resume-from must equal a ledger seq checkpointed in a prior run (a multiple of --checkpoint-interval)", r.resumeFrom, r.checkpointDir)
+		}
+		startLedger = r.resumeFrom
+	}
+
+	startTime := time.Now()
+
 	fmt.Fprintln(r.out, "================================================================================")
 	fmt.Fprintln(r.out, "                    XRPL Continuous State Replay")
 	fmt.Fprintln(r.out, "================================================================================")
@@ -213,7 +259,7 @@ func (r *replayRangeRunner) run() error {
 	fmt.Fprintln(r.out, "[1/3] Connecting to database...")
 	client, err := statecompare.NewClientFromEnv()
 	if err != nil {
-		return fmt.Errorf("connecting to database: %w", err)
+		return nil, fmt.Errorf("connecting to database: %w", err)
 	}
 	defer client.Close()
 	fmt.Fprintln(r.out, "      Connected to PostgreSQL")
@@ -222,27 +268,18 @@ func (r *replayRangeRunner) run() error {
 	fmt.Fprintln(r.out, "[2/3] Validating ledger range...")
 	valid, missingLedger, err := client.ValidateRange(ctx, startLedger, r.to)
 	if err != nil {
-		return fmt.Errorf("validating range: %w", err)
+		return nil, fmt.Errorf("validating range: %w", err)
 	}
 	if !valid {
-		return fmt.Errorf("ledger %d not found in database; run 'python main.py sync-range %d %d' first", missingLedger, startLedger, r.to)
+		return nil, fmt.Errorf("ledger %d not found in database; run 'python main.py sync-range %d %d' first", missingLedger, startLedger, r.to)
 	}
 	fmt.Fprintf(r.out, "      All %d ledgers present in database\n", r.to-startLedger+1)
 
 	source, err := newStateSource(client, r.nodestoreDir, r.baseCacheMB, r.overlayCacheMB)
 	if err != nil {
-		return fmt.Errorf("initializing state source: %w", err)
+		return nil, fmt.Errorf("initializing state source: %w", err)
 	}
 	defer source.Close()
-
-	var findings *findingsWriter
-	if r.continueOnDivergence {
-		findings, err = newFindingsWriter(r.findingsPath())
-		if err != nil {
-			return fmt.Errorf("opening findings file: %w", err)
-		}
-		defer findings.Close()
-	}
 
 	var stateMap *shamap.SHAMap
 	var preSnapshot *statecompare.LedgerSnapshot
@@ -253,13 +290,13 @@ func (r *replayRangeRunner) run() error {
 		fmt.Fprintf(r.out, "[3/3] Resuming from checkpoint at ledger %d...\n", startLedger)
 		stateMap, preSnapshot, fees, err = resumeFromCheckpoint(ctx, client, r.checkpointDir, startLedger)
 		if err != nil {
-			return fmt.Errorf("resuming from checkpoint: %w", err)
+			return nil, fmt.Errorf("resuming from checkpoint: %w", err)
 		}
 	} else {
 		fmt.Fprintf(r.out, "[3/3] Loading initial state at ledger %d...\n", startLedger)
 		stateMap, preSnapshot, fees, err = source.Load(ctx, startLedger)
 		if err != nil {
-			return fmt.Errorf("loading initial state: %w", err)
+			return nil, fmt.Errorf("loading initial state: %w", err)
 		}
 	}
 
@@ -358,16 +395,7 @@ func (r *replayRangeRunner) run() error {
 	}
 
 	stats.TotalDuration = time.Since(startTime)
-
-	// Print summary
-	fmt.Fprintln(r.out)
-	r.printRangeSummary(stats)
-
-	if stats.FailedAtBlock > 0 {
-		// The failure is already reported above; only the exit code is left.
-		return cmdexit.ErrReported
-	}
-	return nil
+	return stats, nil
 }
 
 // maybeCheckpoint writes a checkpoint when checkpointing is enabled and the

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -150,6 +150,15 @@ type RangeReplayStats struct {
 	TotalDuration     time.Duration
 	FailedAtBlock     uint32
 	FailureReason     string
+
+	// Per-phase wall-clock accumulated across every processed block, so each
+	// run self-reports its bottleneck without a profiler (issue #1084 Step 0):
+	//   - FetchDuration:    the two Postgres round-trips (snapshot + txs)
+	//   - ApplyDuration:    rule/fee setup + per-tx parse and engine apply
+	//   - FinalizeDuration: Close (rehash) + the three root hashes + snapshot
+	FetchDuration    time.Duration
+	ApplyDuration    time.Duration
+	FinalizeDuration time.Duration
 }
 
 func (r *replayRangeRunner) run() error {
@@ -281,6 +290,9 @@ func (r *replayRangeRunner) run() error {
 		blockDuration := time.Since(blockStart)
 		stats.BlocksProcessed++
 		stats.TotalTransactions += result.TxCount
+		stats.FetchDuration += result.FetchDur
+		stats.ApplyDuration += result.ApplyDur
+		stats.FinalizeDuration += result.FinalizeDur
 
 		// Check hashes
 		if !result.Success {
@@ -432,6 +444,12 @@ type BlockResult struct {
 	PostSnapshot            *statecompare.LedgerSnapshot
 	TxResults               []TxApplyInfo
 	Errors                  []string
+
+	// Per-phase wall-clock for this block (fetch / apply / finalize), summed
+	// into RangeReplayStats so printRangeSummary can report the bottleneck.
+	FetchDur    time.Duration
+	ApplyDur    time.Duration
+	FinalizeDur time.Duration
 }
 
 func loadInitialState(ctx context.Context, client *statecompare.Client, ledgerIndex uint32) (*shamap.SHAMap, *statecompare.LedgerSnapshot, drops.Fees, error) {
@@ -618,6 +636,10 @@ func (r *replayRangeRunner) processBlock(
 		Errors:    make([]string, 0),
 	}
 
+	// Phase 1 (fetch): the two synchronous Postgres round-trips, plus the
+	// ~1-in-1000 cold-pack blob download that GetTransactions triggers.
+	fetchStart := time.Now()
+
 	// Get expected values for this ledger
 	postSnapshot, err := client.GetSnapshot(ctx, targetLedger)
 	if err != nil {
@@ -635,6 +657,12 @@ func (r *replayRangeRunner) processBlock(
 		return nil, nil, fmt.Errorf("getting transactions: %w", err)
 	}
 	result.TxCount = len(txs)
+	result.FetchDur = time.Since(fetchStart)
+
+	// Phase 2 (apply): amendment-rule/fee setup, then per-tx parse and engine
+	// apply. State-node reads from the lazy nodestore happen here, during the
+	// SHAMap descents inside each Apply.
+	applyStart := time.Now()
 
 	// Create transaction map
 	txMap := shamap.New(shamap.TypeTransaction)
@@ -745,6 +773,11 @@ func (r *replayRangeRunner) processBlock(
 			fmt.Fprintf(r.out, "        [%d] %-20s %-12s\n", txEntry.TxIndex, txInfo.TxType, txInfo.Result)
 		}
 	}
+	result.ApplyDur = time.Since(applyStart)
+
+	// Phase 3 (finalize): Close (incremental rehash of the touched nodes), the
+	// three root hashes, and the COW state snapshot handed to the next block.
+	finalizeStart := time.Now()
 
 	// Close ledger. Close() updates the LedgerHashes skip lists from the
 	// header's ParentHash as its first step, so no separate skip-list pass is
@@ -771,6 +804,7 @@ func (r *replayRangeRunner) processBlock(
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting state snapshot: %w", err)
 	}
+	result.FinalizeDur = time.Since(finalizeStart)
 
 	return result, newStateMap, nil
 }
@@ -912,6 +946,20 @@ func (r *replayRangeRunner) printRangeSummary(stats *RangeReplayStats) {
 	fmt.Fprintf(r.out, "Total time:          %v\n", stats.TotalDuration.Round(time.Millisecond))
 	if stats.TotalDuration.Seconds() > 0 {
 		fmt.Fprintf(r.out, "Average speed:       %.1f blocks/sec\n", float64(stats.BlocksProcessed)/stats.TotalDuration.Seconds())
+	}
+
+	// Per-phase breakdown: report each phase's share of measured in-block time
+	// so every run self-reports where it spends its time (issue #1084 Step 0).
+	// The percentages are of fetch+apply+finalize, not TotalDuration, which
+	// also covers seed load, checkpointing, and per-block bookkeeping.
+	phaseTotal := stats.FetchDuration + stats.ApplyDuration + stats.FinalizeDuration
+	if phaseTotal > 0 {
+		pct := func(d time.Duration) float64 { return 100 * float64(d) / float64(phaseTotal) }
+		fmt.Fprintln(r.out, "--------------------------------------------------------------------------------")
+		fmt.Fprintf(r.out, "Phase breakdown (in-block, %% of fetch+apply+finalize):\n")
+		fmt.Fprintf(r.out, "  fetch    (db snapshot+txs):   %10v  %5.1f%%\n", stats.FetchDuration.Round(time.Millisecond), pct(stats.FetchDuration))
+		fmt.Fprintf(r.out, "  apply    (parse+engine):      %10v  %5.1f%%\n", stats.ApplyDuration.Round(time.Millisecond), pct(stats.ApplyDuration))
+		fmt.Fprintf(r.out, "  finalize (close+hash+snap):   %10v  %5.1f%%\n", stats.FinalizeDuration.Round(time.Millisecond), pct(stats.FinalizeDuration))
 	}
 	fmt.Fprintln(r.out, "================================================================================")
 }

--- a/internal/replaytool/replay_shards.go
+++ b/internal/replaytool/replay_shards.go
@@ -1,0 +1,236 @@
+package replaytool
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/cmdexit"
+)
+
+// ledgerSegment is one shard's half-open replay span: it seeds at `from` and
+// replays (from, to]. Contiguous segments share boundaries — one shard's `to`
+// is the next shard's `from` — so the whole range is covered without gaps or
+// overlap.
+type ledgerSegment struct {
+	from uint32
+	to   uint32
+}
+
+// partitionRange splits [from, to] into `shards` contiguous segments of as-equal
+// length as possible. The boundaries are the seeds each shard loads, so they
+// must be independently seedable ledgers (checkpoint seqs) — partitioning only
+// decides where to cut, not whether the cut is seedable; an unseedable boundary
+// fails that shard at seed-load time. Shards are capped at the block count so no
+// segment is empty.
+func partitionRange(from, to uint32, shards int) []ledgerSegment {
+	if shards < 1 {
+		shards = 1
+	}
+	total := to - from
+	if total == 0 {
+		return []ledgerSegment{{from: from, to: to}}
+	}
+	if uint32(shards) > total {
+		shards = int(total)
+	}
+
+	segs := make([]ledgerSegment, 0, shards)
+	base := total / uint32(shards)
+	rem := total % uint32(shards)
+	b := from
+	for k := 0; k < shards; k++ {
+		n := base
+		if uint32(k) < rem {
+			n++ // spread the remainder over the first `rem` shards
+		}
+		next := b + n
+		segs = append(segs, ledgerSegment{from: b, to: next})
+		b = next
+	}
+	return segs
+}
+
+// aggregateStats sums per-shard stats into one combined record. TotalDuration is
+// left zero for the caller to set to the overall wall-clock (the shards overlap
+// in time, so summing their durations would be meaningless). The earliest
+// failing block across shards wins, mirroring a serial run stopping at the first
+// failure.
+func aggregateStats(parts []*RangeReplayStats) *RangeReplayStats {
+	agg := &RangeReplayStats{}
+	for _, p := range parts {
+		if p == nil {
+			continue
+		}
+		agg.BlocksProcessed += p.BlocksProcessed
+		agg.BlocksSuccessful += p.BlocksSuccessful
+		agg.TotalTransactions += p.TotalTransactions
+		agg.Divergences += p.Divergences
+		agg.FetchDuration += p.FetchDuration
+		agg.ApplyDuration += p.ApplyDuration
+		agg.FinalizeDuration += p.FinalizeDuration
+		if p.FailedAtBlock > 0 && (agg.FailedAtBlock == 0 || p.FailedAtBlock < agg.FailedAtBlock) {
+			agg.FailedAtBlock = p.FailedAtBlock
+			agg.FailureReason = p.FailureReason
+		}
+	}
+	return agg
+}
+
+// runSegmentsConcurrently runs fn for every segment on its own goroutine and
+// collects each result by index, so callers never share a slot. fn must be
+// safe to run concurrently — its per-shard state is private, and any shared
+// sinks (findings writer, output) are concurrency-safe.
+func runSegmentsConcurrently(
+	ctx context.Context,
+	segs []ledgerSegment,
+	fn func(ctx context.Context, shard int, seg ledgerSegment) (*RangeReplayStats, error),
+) ([]*RangeReplayStats, []error) {
+	stats := make([]*RangeReplayStats, len(segs))
+	errs := make([]error, len(segs))
+
+	var wg sync.WaitGroup
+	for i, seg := range segs {
+		wg.Add(1)
+		go func(i int, seg ledgerSegment) {
+			defer wg.Done()
+			stats[i], errs[i] = fn(ctx, i, seg)
+		}(i, seg)
+	}
+	wg.Wait()
+	return stats, errs
+}
+
+// shardWriter funnels one shard's output into a shared sink, prefixing each
+// complete line with the shard tag and holding the shared mutex across the whole
+// write so concurrent shards never interleave mid-line. Partial lines are
+// buffered per shard until their newline arrives.
+type shardWriter struct {
+	mu     *sync.Mutex // shared across shards: serializes writes to w
+	w      io.Writer
+	prefix string
+	buf    []byte // partial line for this shard only (guarded by mu)
+}
+
+func (s *shardWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.buf = append(s.buf, p...)
+	for {
+		i := bytes.IndexByte(s.buf, '\n')
+		if i < 0 {
+			break
+		}
+		if _, err := io.WriteString(s.w, s.prefix); err != nil {
+			return 0, err
+		}
+		if _, err := s.w.Write(s.buf[:i+1]); err != nil {
+			return 0, err
+		}
+		s.buf = s.buf[i+1:]
+	}
+	return len(p), nil
+}
+
+// runSharded replays [from, to] as `shards` parallel segments. Each segment runs
+// its own serial replay (own DB client and nodestore overlay) seeded from and
+// account-hash-verified at its boundary, so the segments are independent; the
+// only cross-block carry — the state SHAMap — is reproduced from each segment's
+// verified seed. Stats are aggregated and findings are merged into one writer.
+//
+// Sharding requires per-segment seeds, so checkpoint/resume (a serial-run
+// feature) is rejected here.
+func (r *replayRangeRunner) runSharded(ctx context.Context) error {
+	if r.resumeFrom > 0 {
+		return fmt.Errorf("--resume-from is not supported with --shards (each shard seeds from its own segment boundary)")
+	}
+	if r.checkpointDir != "" {
+		return fmt.Errorf("--checkpoint-dir is not supported with --shards")
+	}
+
+	segs := partitionRange(r.from, r.to, r.shards)
+
+	fmt.Fprintln(r.out, "================================================================================")
+	fmt.Fprintln(r.out, "                XRPL Continuous State Replay (sharded)")
+	fmt.Fprintln(r.out, "================================================================================")
+	fmt.Fprintf(r.out, "Range:   %d -> %d (%d blocks) split into %d shard(s):\n", r.from, r.to, r.to-r.from, len(segs))
+	for k, s := range segs {
+		fmt.Fprintf(r.out, "  shard %d: %d -> %d (%d blocks)\n", k, s.from, s.to, s.to-s.from)
+	}
+	fmt.Fprintln(r.out)
+	fmt.Fprintln(r.out, "Each shard loads and account-hash-verifies its own seed; a boundary that is")
+	fmt.Fprintln(r.out, "not an independently seedable ledger fails that shard, not the others.")
+	fmt.Fprintln(r.out)
+
+	// One findings writer, shared across shards (Write is mutex-guarded).
+	var findings *findingsWriter
+	if r.continueOnDivergence {
+		f, err := newFindingsWriter(r.findingsPath())
+		if err != nil {
+			return fmt.Errorf("opening findings file: %w", err)
+		}
+		findings = f
+		defer findings.Close()
+	}
+
+	var outMu sync.Mutex
+	start := time.Now()
+
+	statsList, errs := runSegmentsConcurrently(ctx, segs, func(ctx context.Context, shard int, seg ledgerSegment) (*RangeReplayStats, error) {
+		worker := *r // copy flags; each shard is otherwise independent
+		worker.from = seg.from
+		worker.to = seg.to
+		worker.shards = 1
+		worker.out = &shardWriter{mu: &outMu, w: r.out, prefix: fmt.Sprintf("[s%d] ", shard)}
+		return worker.replaySegment(ctx, findings)
+	})
+
+	agg := aggregateStats(statsList)
+	agg.TotalDuration = time.Since(start)
+
+	fmt.Fprintln(r.out)
+	r.printShardedSummary(segs, statsList, errs, agg)
+
+	failed := false
+	for i, err := range errs {
+		if err != nil {
+			failed = true
+			fmt.Fprintf(r.out, "shard %d (%d->%d) error: %v\n", i, segs[i].from, segs[i].to, err)
+		}
+	}
+	if failed || agg.FailedAtBlock > 0 {
+		return cmdexit.ErrReported
+	}
+	return nil
+}
+
+// printShardedSummary reports each shard's outcome, then the aggregate totals and
+// per-phase breakdown via the shared summary printer.
+func (r *replayRangeRunner) printShardedSummary(segs []ledgerSegment, statsList []*RangeReplayStats, errs []error, agg *RangeReplayStats) {
+	fmt.Fprintln(r.out, "================================================================================")
+	fmt.Fprintln(r.out, "Per-shard results:")
+	for i, seg := range segs {
+		switch {
+		case errs[i] != nil:
+			fmt.Fprintf(r.out, "  shard %d %d->%d: ERROR\n", i, seg.from, seg.to)
+		case statsList[i] == nil:
+			fmt.Fprintf(r.out, "  shard %d %d->%d: no result\n", i, seg.from, seg.to)
+		default:
+			s := statsList[i]
+			status := "ok"
+			if s.FailedAtBlock > 0 {
+				status = fmt.Sprintf("FAILED@%d", s.FailedAtBlock)
+			} else if s.Divergences > 0 {
+				status = fmt.Sprintf("%d divergence(s)", s.Divergences)
+			}
+			fmt.Fprintf(r.out, "  shard %d %d->%d: %d/%d blocks ok, %s, %v\n",
+				i, seg.from, seg.to, s.BlocksSuccessful, s.BlocksProcessed, status,
+				s.TotalDuration.Round(time.Millisecond))
+		}
+	}
+	r.printRangeSummary(agg)
+}

--- a/internal/replaytool/replay_shards_test.go
+++ b/internal/replaytool/replay_shards_test.go
@@ -1,0 +1,141 @@
+package replaytool
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPartitionRange(t *testing.T) {
+	cases := []struct {
+		name           string
+		from, to       uint32
+		shards         int
+		wantSegs       int
+		wantBoundaries []uint32 // from, b1, ..., to
+	}{
+		{"single shard", 100, 200, 1, 1, []uint32{100, 200}},
+		{"even split", 100, 200, 4, 4, []uint32{100, 125, 150, 175, 200}},
+		{"remainder spread to front", 0, 10, 3, 3, []uint32{0, 4, 7, 10}},
+		{"more shards than blocks caps", 100, 103, 8, 3, []uint32{100, 101, 102, 103}},
+		{"zero shards treated as one", 5, 9, 0, 1, []uint32{5, 9}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			segs := partitionRange(c.from, c.to, c.shards)
+			if len(segs) != c.wantSegs {
+				t.Fatalf("got %d segments, want %d: %+v", len(segs), c.wantSegs, segs)
+			}
+
+			// Contiguous, gap-free, covers the whole range, no empty segments.
+			if segs[0].from != c.from {
+				t.Errorf("first segment starts at %d, want %d", segs[0].from, c.from)
+			}
+			if segs[len(segs)-1].to != c.to {
+				t.Errorf("last segment ends at %d, want %d", segs[len(segs)-1].to, c.to)
+			}
+			var covered uint32
+			for k, s := range segs {
+				if s.to <= s.from {
+					t.Errorf("segment %d is empty: %d->%d", k, s.from, s.to)
+				}
+				if k > 0 && s.from != segs[k-1].to {
+					t.Errorf("gap/overlap at %d: prev.to=%d this.from=%d", k, segs[k-1].to, s.from)
+				}
+				covered += s.to - s.from
+			}
+			if covered != c.to-c.from {
+				t.Errorf("covered %d blocks, want %d", covered, c.to-c.from)
+			}
+
+			if c.wantBoundaries != nil {
+				got := []uint32{segs[0].from}
+				for _, s := range segs {
+					got = append(got, s.to)
+				}
+				if fmt.Sprint(got) != fmt.Sprint(c.wantBoundaries) {
+					t.Errorf("boundaries %v, want %v", got, c.wantBoundaries)
+				}
+			}
+		})
+	}
+}
+
+func TestAggregateStats(t *testing.T) {
+	parts := []*RangeReplayStats{
+		{BlocksProcessed: 10, BlocksSuccessful: 10, TotalTransactions: 100, FetchDuration: time.Second, ApplyDuration: 10 * time.Second, FinalizeDuration: time.Second},
+		nil, // a shard that produced no stats must be skipped, not panic
+		{BlocksProcessed: 5, BlocksSuccessful: 4, TotalTransactions: 40, Divergences: 1, FailedAtBlock: 207, FailureReason: "hash mismatch", FetchDuration: time.Second, ApplyDuration: 5 * time.Second},
+		{BlocksProcessed: 3, BlocksSuccessful: 2, FailedAtBlock: 150, FailureReason: "earlier"},
+	}
+	agg := aggregateStats(parts)
+
+	if agg.BlocksProcessed != 18 || agg.BlocksSuccessful != 16 || agg.TotalTransactions != 140 {
+		t.Errorf("count aggregation wrong: %+v", agg)
+	}
+	if agg.Divergences != 1 {
+		t.Errorf("divergences = %d, want 1", agg.Divergences)
+	}
+	if agg.FetchDuration != 2*time.Second || agg.ApplyDuration != 15*time.Second || agg.FinalizeDuration != time.Second {
+		t.Errorf("phase durations wrong: fetch=%v apply=%v finalize=%v", agg.FetchDuration, agg.ApplyDuration, agg.FinalizeDuration)
+	}
+	// Earliest failing block across shards wins.
+	if agg.FailedAtBlock != 150 || agg.FailureReason != "earlier" {
+		t.Errorf("failure aggregation: got %d/%q, want 150/earlier", agg.FailedAtBlock, agg.FailureReason)
+	}
+}
+
+// TestRunSegmentsConcurrently checks every segment's result lands at its own
+// index and shared sinks stay uncorrupted under concurrency. Run under -race.
+func TestRunSegmentsConcurrently(t *testing.T) {
+	segs := partitionRange(0, 4000, 8)
+
+	var sinkMu sync.Mutex
+	var sink bytes.Buffer
+	const linesPerShard = 50
+
+	stats, errs := runSegmentsConcurrently(context.Background(), segs,
+		func(_ context.Context, shard int, seg ledgerSegment) (*RangeReplayStats, error) {
+			w := &shardWriter{mu: &sinkMu, w: &sink, prefix: fmt.Sprintf("[s%d] ", shard)}
+			for i := 0; i < linesPerShard; i++ {
+				fmt.Fprintf(w, "block %d of shard %d\n", i, shard)
+			}
+			// Encode the shard index into the stats so we can verify ordering.
+			return &RangeReplayStats{BlocksProcessed: shard, TotalTransactions: int(seg.to - seg.from)}, nil
+		})
+
+	if len(stats) != len(segs) {
+		t.Fatalf("got %d stats, want %d", len(stats), len(segs))
+	}
+	for i := range segs {
+		if errs[i] != nil {
+			t.Errorf("shard %d unexpected error: %v", i, errs[i])
+		}
+		if stats[i] == nil || stats[i].BlocksProcessed != i {
+			t.Errorf("shard %d result landed at wrong index: %+v", i, stats[i])
+		}
+	}
+
+	// Every emitted line must be intact and correctly tagged — no interleaving.
+	lines := strings.Split(strings.TrimRight(sink.String(), "\n"), "\n")
+	if len(lines) != len(segs)*linesPerShard {
+		t.Fatalf("got %d lines, want %d", len(lines), len(segs)*linesPerShard)
+	}
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "[s") {
+			t.Fatalf("line missing shard prefix: %q", line)
+		}
+		var ls, li, lsh int
+		if _, err := fmt.Sscanf(line, "[s%d] block %d of shard %d", &ls, &li, &lsh); err != nil {
+			t.Fatalf("malformed/interleaved line %q: %v", line, err)
+		}
+		if ls != lsh {
+			t.Fatalf("prefix shard %d != body shard %d in %q", ls, lsh, line)
+		}
+	}
+}

--- a/shamap/deserialize_withhash_test.go
+++ b/shamap/deserialize_withhash_test.go
@@ -1,0 +1,139 @@
+package shamap
+
+import (
+	"bytes"
+	"testing"
+)
+
+// serializedNode is a prefix-format node blob paired with its true SHAMap hash,
+// as it would be stored in (and fetched from) the content-addressed nodestore.
+type serializedNode struct {
+	name string
+	data []byte
+	hash [32]byte
+}
+
+// buildSerializedNodes produces one prefix-format blob per node type, mirroring
+// what a lazy descent fetches from the store.
+func buildSerializedNodes(t testing.TB) []serializedNode {
+	t.Helper()
+
+	mkData := func(seed byte, n int) []byte {
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = seed + byte(i)
+		}
+		return b
+	}
+
+	// Inner node with a few populated branches.
+	inner := newInnerNode()
+	for i := 0; i < BranchFactor; i += 5 {
+		var h [32]byte
+		for j := range h {
+			h[j] = byte(i*7 + j + 1)
+		}
+		inner.hashes[i] = h
+		inner.isBranch |= 1 << uint(i)
+	}
+	if err := inner.UpdateHash(); err != nil {
+		t.Fatalf("inner UpdateHash: %v", err)
+	}
+
+	stateLeaf, err := newAccountStateLeafNode(NewItem([32]byte{0xAB, 0x01, 0x02}, mkData(0x10, 96)))
+	if err != nil {
+		t.Fatalf("account state leaf: %v", err)
+	}
+	txLeaf, err := newTransactionLeafNode(NewItem([32]byte{0xCD}, mkData(0x20, 80)))
+	if err != nil {
+		t.Fatalf("tx leaf: %v", err)
+	}
+	txMetaLeaf, err := newTransactionWithMetaLeafNode(NewItem([32]byte{0xEF, 0x09}, mkData(0x30, 160)))
+	if err != nil {
+		t.Fatalf("tx+meta leaf: %v", err)
+	}
+
+	var out []serializedNode
+	for _, c := range []struct {
+		name string
+		node Node
+	}{
+		{"inner", inner},
+		{"account_state_leaf", stateLeaf},
+		{"transaction_leaf", txLeaf},
+		{"transaction_with_meta_leaf", txMetaLeaf},
+	} {
+		data, err := c.node.SerializeWithPrefix()
+		if err != nil {
+			t.Fatalf("%s SerializeWithPrefix: %v", c.name, err)
+		}
+		out = append(out, serializedNode{name: c.name, data: data, hash: c.node.Hash()})
+	}
+	return out
+}
+
+// TestDeserializeFromPrefixWithHashMatchesRecompute proves the fast path is
+// byte-for-byte equivalent to the recomputing path: installing the known
+// content-addressed hash yields the same node hash and the same re-serialized
+// bytes as recomputing it. This is the safety contract behind skipping the
+// per-descent re-hash (issue #1084).
+func TestDeserializeFromPrefixWithHashMatchesRecompute(t *testing.T) {
+	for _, sn := range buildSerializedNodes(t) {
+		t.Run(sn.name, func(t *testing.T) {
+			recomputed, err := DeserializeFromPrefix(sn.data)
+			if err != nil {
+				t.Fatalf("DeserializeFromPrefix: %v", err)
+			}
+			if recomputed.Hash() != sn.hash {
+				t.Fatalf("recompute hash %x != true hash %x", recomputed.Hash(), sn.hash)
+			}
+
+			withHash, err := DeserializeFromPrefixWithHash(sn.data, sn.hash)
+			if err != nil {
+				t.Fatalf("DeserializeFromPrefixWithHash: %v", err)
+			}
+			if withHash.Hash() != recomputed.Hash() {
+				t.Fatalf("withHash hash %x != recompute hash %x", withHash.Hash(), recomputed.Hash())
+			}
+
+			// A loaded node must be clean, and must re-serialize to the exact
+			// bytes it was decoded from (the content is untouched by the hash
+			// shortcut).
+			if withHash.IsDirty() {
+				t.Fatal("withHash node marked dirty")
+			}
+			reser, err := withHash.SerializeWithPrefix()
+			if err != nil {
+				t.Fatalf("re-SerializeWithPrefix: %v", err)
+			}
+			if !bytes.Equal(reser, sn.data) {
+				t.Fatalf("re-serialized bytes differ from original")
+			}
+		})
+	}
+}
+
+func benchmarkDeserialize(b *testing.B, withHash bool) {
+	nodes := buildSerializedNodes(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sn := nodes[i%len(nodes)]
+		var err error
+		if withHash {
+			_, err = DeserializeFromPrefixWithHash(sn.data, sn.hash)
+		} else {
+			_, err = DeserializeFromPrefix(sn.data)
+		}
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkDeserializeFromPrefix is the recomputing baseline.
+func BenchmarkDeserializeFromPrefix(b *testing.B) { benchmarkDeserialize(b, false) }
+
+// BenchmarkDeserializeFromPrefixWithHash is the descent fast path; compare its
+// allocs/op and B/op against the baseline to see the per-fetch saving.
+func BenchmarkDeserializeFromPrefixWithHash(b *testing.B) { benchmarkDeserialize(b, true) }

--- a/shamap/leaf.go
+++ b/shamap/leaf.go
@@ -90,6 +90,26 @@ func newLeafNode(kind leafKind, item *Item) (*leafNode, error) {
 	return n, nil
 }
 
+// newLeafNodeWithHash builds a leaf whose hash is already known — the
+// content-addressed key it was fetched by — and installs it directly instead
+// of re-hashing the item (a SHA-512Half over the full, possibly large, leaf
+// data on every lazy descent). The node is marked clean: it came from the store.
+func newLeafNodeWithHash(kind leafKind, item *Item, h [32]byte) (*leafNode, error) {
+	if item == nil {
+		return nil, ErrNilItem
+	}
+	if len(item.Data()) < 12 {
+		return nil, ErrItemTooSmall
+	}
+	n := &leafNode{
+		item: item,
+		kind: kind,
+	}
+	n.hash = h
+	n.SetDirty(false)
+	return n, nil
+}
+
 // newAccountStateLeafNode creates a new account state leaf node.
 func newAccountStateLeafNode(item *Item) (*leafNode, error) {
 	return newLeafNode(leafAccountState, item)

--- a/shamap/shamap.go
+++ b/shamap/shamap.go
@@ -143,8 +143,9 @@ func NewFromRootHash(mapType Type, rootHash [32]byte, family Family) (*SHAMap, e
 		return nil, fmt.Errorf("root node %x not found in store", rootHash[:8])
 	}
 
-	// Deserialize — creates innerNode with hashes set, children nil
-	node, err := DeserializeFromPrefix(data)
+	// Deserialize — creates innerNode with hashes set, children nil. The root
+	// hash is known (the fetch key), so install it without recomputing.
+	node, err := DeserializeFromPrefixWithHash(data, rootHash)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deserialize root node: %w", err)
 	}
@@ -200,8 +201,10 @@ func (sm *SHAMap) descendCtx(ctx context.Context, inner *innerNode, branch int) 
 		return nil, fmt.Errorf("child node %x not found in store", hash[:8])
 	}
 
-	// Fresh deserialised copy — not shared across SHAMap instances.
-	node, err := DeserializeFromPrefix(data)
+	// Fresh deserialised copy — not shared across SHAMap instances. The hash is
+	// already known (it is the fetch key), so install it directly instead of
+	// re-hashing every descended node.
+	node, err := DeserializeFromPrefixWithHash(data, hash)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deserialize child node: %w", err)
 	}

--- a/shamap/store.go
+++ b/shamap/store.go
@@ -23,6 +23,21 @@ type NodeBatch struct {
 // Inner nodes are created with hashes set but children nil (lazy loading).
 // All deserialized nodes are marked as not dirty.
 func DeserializeFromPrefix(data []byte) (Node, error) {
+	return deserializeFromPrefix(data, nil)
+}
+
+// DeserializeFromPrefixWithHash is DeserializeFromPrefix for the common case
+// where the node's hash is already known: the content-addressed key it was
+// fetched by. Because the store is content-addressed, recomputing the hash from
+// the bytes reproduces that key by construction — so the recompute (a
+// SHA-512Half plus the serialization buffer it needs, per node) is pure waste
+// on every lazy descent. Installing the known hash directly is the dominant
+// per-fetch CPU/alloc saving on the replay hot path (issue #1084).
+func DeserializeFromPrefixWithHash(data []byte, knownHash [32]byte) (Node, error) {
+	return deserializeFromPrefix(data, &knownHash)
+}
+
+func deserializeFromPrefix(data []byte, knownHash *[32]byte) (Node, error) {
 	if len(data) < 4 {
 		return nil, fmt.Errorf("data too short for prefix: %d bytes", len(data))
 	}
@@ -32,13 +47,13 @@ func DeserializeFromPrefix(data []byte) (Node, error) {
 
 	switch prefix {
 	case protocol.HashPrefixInnerNode:
-		return parseInnerNodeFromPrefix(data)
+		return parseInnerNodeFromPrefix(data, knownHash)
 	case protocol.HashPrefixLeafNode:
-		return parseAccountStateLeafFromPrefix(data)
+		return parseAccountStateLeafFromPrefix(data, knownHash)
 	case protocol.HashPrefixTransactionID:
-		return parseTransactionLeafFromPrefix(data)
+		return parseTransactionLeafFromPrefix(data, knownHash)
 	case protocol.HashPrefixTxNode:
-		return parseTransactionWithMetaLeafFromPrefix(data)
+		return parseTransactionWithMetaLeafFromPrefix(data, knownHash)
 	default:
 		return nil, fmt.Errorf("unknown hash prefix: %x", prefix)
 	}
@@ -47,7 +62,7 @@ func DeserializeFromPrefix(data []byte) (Node, error) {
 // parseInnerNodeFromPrefix deserializes an inner node from prefix format.
 // Format: [4-byte prefix][16 x 32-byte child hashes] = 516 bytes
 // Children are hash-only (pointers nil) — they are loaded lazily.
-func parseInnerNodeFromPrefix(data []byte) (*innerNode, error) {
+func parseInnerNodeFromPrefix(data []byte, knownHash *[32]byte) (*innerNode, error) {
 	const expectedSize = 4 + BranchFactor*32 // 4 + 512 = 516
 	if len(data) != expectedSize {
 		return nil, fmt.Errorf("invalid inner node prefix data size: expected %d, got %d", expectedSize, len(data))
@@ -70,17 +85,36 @@ func parseInnerNodeFromPrefix(data []byte) (*innerNode, error) {
 		}
 	}
 
-	// Compute the node's own hash
-	if err := node.UpdateHash(); err != nil {
+	// Install the node's own hash. When it is already known (the fetch key),
+	// use it directly; otherwise recompute it from the child hashes.
+	if knownHash != nil {
+		node.hash = *knownHash
+	} else if err := node.UpdateHash(); err != nil {
 		return nil, fmt.Errorf("failed to update inner node hash: %w", err)
 	}
 
 	return node, nil
 }
 
+// buildLeaf constructs a leaf from an already-parsed item. When the node hash
+// is known (the fetch key) it is installed directly, skipping the per-descent
+// re-hash; otherwise it is computed. Either way the leaf is marked clean, as it
+// came from the store.
+func buildLeaf(kind leafKind, item *Item, knownHash *[32]byte) (*leafNode, error) {
+	if knownHash != nil {
+		return newLeafNodeWithHash(kind, item, *knownHash)
+	}
+	node, err := newLeafNode(kind, item)
+	if err != nil {
+		return nil, err
+	}
+	node.SetDirty(false)
+	return node, nil
+}
+
 // parseAccountStateLeafFromPrefix deserializes an account state leaf from prefix format.
 // Format: [4-byte prefix][state_data][32-byte key]
-func parseAccountStateLeafFromPrefix(data []byte) (*leafNode, error) {
+func parseAccountStateLeafFromPrefix(data []byte, knownHash *[32]byte) (*leafNode, error) {
 	if len(data) < 4+32 {
 		return nil, fmt.Errorf("account state prefix data too short: %d bytes", len(data))
 	}
@@ -98,37 +132,35 @@ func parseAccountStateLeafFromPrefix(data []byte) (*leafNode, error) {
 	stateData := nodeData[:keyStart]
 	item := NewItem(key, stateData)
 
-	node, err := newAccountStateLeafNode(item)
-	if err != nil {
-		return nil, err
-	}
-	node.SetDirty(false)
-	return node, nil
+	return buildLeaf(leafAccountState, item, knownHash)
 }
 
 // parseTransactionLeafFromPrefix deserializes a transaction leaf from prefix format.
 // Format: [4-byte prefix][tx_data]
-func parseTransactionLeafFromPrefix(data []byte) (*leafNode, error) {
+func parseTransactionLeafFromPrefix(data []byte, knownHash *[32]byte) (*leafNode, error) {
 	if len(data) <= 4 {
 		return nil, fmt.Errorf("transaction prefix data too short: %d bytes", len(data))
 	}
 
 	txData := data[4:]
 
-	key := common.Sha512Half(protocol.HashPrefixTransactionID[:], txData)
+	// A tx-no-meta leaf's node hash equals its transaction id —
+	// Sha512Half(prefix, txData) — which is also the item key, so reuse the
+	// known hash for both when present and skip recomputing it.
+	var key [32]byte
+	if knownHash != nil {
+		key = *knownHash
+	} else {
+		key = common.Sha512Half(protocol.HashPrefixTransactionID[:], txData)
+	}
 	item := NewItem(key, txData)
 
-	node, err := newTransactionLeafNode(item)
-	if err != nil {
-		return nil, err
-	}
-	node.SetDirty(false)
-	return node, nil
+	return buildLeaf(leafTransaction, item, knownHash)
 }
 
 // parseTransactionWithMetaLeafFromPrefix deserializes a tx+meta leaf from prefix format.
 // Format: [4-byte prefix][tx+meta_data][32-byte key]
-func parseTransactionWithMetaLeafFromPrefix(data []byte) (*leafNode, error) {
+func parseTransactionWithMetaLeafFromPrefix(data []byte, knownHash *[32]byte) (*leafNode, error) {
 	if len(data) < 4+32 {
 		return nil, fmt.Errorf("transaction+meta prefix data too short: %d bytes", len(data))
 	}
@@ -142,10 +174,5 @@ func parseTransactionWithMetaLeafFromPrefix(data []byte) (*leafNode, error) {
 	txData := nodeData[:keyStart]
 	item := NewItem(key, txData)
 
-	node, err := newTransactionWithMetaLeafNode(item)
-	if err != nil {
-		return nil, err
-	}
-	node.SetDirty(false)
-	return node, nil
+	return buildLeaf(leafTransactionWithMeta, item, knownHash)
 }


### PR DESCRIPTION
Profiles `replay-range` (#1084 Step 0), then acts on what the profile shows. Three commits:

### 1. Per-phase timing (`fc51c8e`)
`replay-range` now prints a fetch/apply/finalize breakdown in its summary, so every run self-reports its bottleneck without a profiler.

Measured over a 200-block mainnet range (`--nodestore-dir`, byte-exact):

| Phase | Per-block | Share |
|-------|-----------|-------|
| fetch (Postgres) | ~16 ms | **0.9%** |
| **apply** | ~1.75 s | **97.5%** |
| finalize | ~29 ms | **1.6%** |

A live pprof CPU profile agrees: only **12–19% on-CPU** (~80% blocked on `pread`), hot path `Engine.doApply → SHAMap.descendCtx → NodeStoreFamily.Fetch → pebble.DB.Get`. So replay is apply-bound on state-node reads, **not** Postgres/blobstore I/O — Tier-2 (query coalescing/prefetch) targets the 0.9% and is not worth it on this path.

### 2. Skip the redundant re-hash on every node fetch (`3c581088`)
The profile showed SHA-512/256 and GC are a large share of the on-CPU apply cost. Cause: every lazy descent fetches a node from the content-addressed nodestore **by its hash**, then `DeserializeFromPrefix` recomputes that same hash from the bytes — a SHA-512Half plus a serialization buffer — on every node, every descent. Since the store is content-addressed, the recomputed hash is by construction the fetch key, so it's pure waste.

`DeserializeFromPrefixWithHash` installs the known hash directly (used by `descendCtx` and `NewFromRootHash`).

Microbenchmark (avg over the four node types): **2852 → 755 ns/op, 808 → 500 B/op, 9 → 3 allocs/op**. An equivalence test proves the fast path yields the same hash and re-serializes to identical bytes; verified byte-identical over a 30-block mainnet replay.

### 3. `--shards N` — replay a range as N parallel segments (`177dcd8e`, Tier 3)
The loop is serial only because each block's post-state seeds the next; the sole cross-block carry is the state SHAMap, which a segment reproduces from its own account-hash-verified seed (rules/fees are re-derived per block). `--shards N` partitions `[from,to]` into N contiguous segments, each on its own goroutine with its own DB client, nodestore overlay, and shard-tagged output; stats aggregate and findings merge into one (now mutex-guarded) writer. `run()` is refactored to share `replaySegment` with the sharded path, so **shards=1 is unchanged**.

`partitionRange`, `aggregateStats`, and the concurrent fan-out are unit-tested (the fan-out + shared-writer interleaving under `-race`); shards=1 verified byte-identical over a 15-block replay.

## Verification
- `gofmt`/`go vet`/`go build ./...` clean; `shamap` and `replaytool` suites pass; shard helpers pass under `-race`.
- Byte-identical replays confirmed for the timing change (200 blocks), the re-hash skip (30 blocks), and shards=1 (15 blocks) — all three hashes matched mainnet throughout.

## Verification gap (host-limited)
All runs were on a 3-core / 8 GB box also running another replay, so absolute per-block time is inflated and **the speedups are demonstrated as correctness + microbenchmark, not end-to-end wall-clock**. Multi-shard end-to-end (N segments over distinct checkpoint bases) needs a host with more cores/RAM and a checkpoint base per segment; the design mirrors running N disjoint `replay-range` processes, now in one process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
