### PR TITLE
fix: verify open-ledger tx signatures off the apply strand

### DIFF
--- a/internal/ledger/openledger/openledger.go
+++ b/internal/ledger/openledger/openledger.go
@@ -415,14 +415,22 @@ func (o *OpenLedger) SubmitDetailed(ptx PendingTx, cfg ApplyConfig, queue *txq.T
 			out.Message = ter.TefALREADY.Message()
 			return false
 		}
-		parsed, err := tx.ParseFromBinary(ptx.Blob)
-		if err != nil {
-			out.Class = ResultFailure
-			out.Result = ter.TemMALFORMED
-			out.Message = ter.TemMALFORMED.Message()
-			return false
+		// Reuse the parse from ingress when present: it avoids re-decoding the
+		// blob under the apply mutex and carries any off-strand signature verdict
+		// (PrewarmSignature) through to the in-strand check. Fall back to parsing
+		// for PendingTx values built without ParsePendingTx.
+		parsed := ptx.Parsed
+		if parsed == nil {
+			p, err := tx.ParseFromBinary(ptx.Blob)
+			if err != nil {
+				out.Class = ResultFailure
+				out.Result = ter.TemMALFORMED
+				out.Message = ter.TemMALFORMED.Message()
+				return false
+			}
+			p.SetRawBytes(ptx.Blob)
+			parsed = p
 		}
-		parsed.SetRawBytes(ptx.Blob)
 
 		if queue != nil {
 			adapter := NewTxqAdapter(view, cfg)

--- a/internal/ledger/openledger/types.go
+++ b/internal/ledger/openledger/types.go
@@ -37,6 +37,13 @@ type PendingTx struct {
 	// Sequence. LocalTxs.Sweep uses this to switch between the seq-
 	// advance check and the ticket-burn check.
 	IsTicket bool
+	// Parsed is the decoded transaction produced while building this PendingTx.
+	// Ingress carries it through to SubmitDetailed so the apply path reuses this
+	// object instead of re-decoding the blob under the open-ledger apply mutex —
+	// and so any signature verdict prewarmed off-strand reaches the in-strand
+	// check. May be nil for PendingTx values built without ParsePendingTx (e.g.
+	// hand-constructed in tests), in which case SubmitDetailed re-parses.
+	Parsed tx.Transaction
 }
 
 // Result classifies the outcome of applying a single transaction in the
@@ -90,6 +97,7 @@ func ParsePendingTx(blob []byte) (PendingTx, error) {
 		LastLedgerSequence:    lastLedger,
 		HasLastLedgerSequence: hasLastLedger,
 		IsTicket:              common.TicketSequence != nil,
+		Parsed:                transaction,
 	}, nil
 }
 

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
 	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
 	"github.com/LeJamon/go-xrpl/internal/txq"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -950,6 +951,12 @@ func (s *Service) SubmitOpenLedgerTx(blob []byte, local bool) (openledger.Result
 	ptx, err := openledger.ParsePendingTx(blob)
 	if err != nil {
 		return openledger.ResultFailure, err
+	}
+	// Verify the signature off the open-ledger apply mutex so the dominant
+	// per-tx cost runs concurrently across ingress workers instead of serialising
+	// under modifyMu; the in-strand check then reuses the cached verdict (#1105).
+	if !cfg.SkipSignatureVerification {
+		txengine.PrewarmSignature(ptx.Parsed, cfg.Rules)
 	}
 	_, res := ov.Submit(ptx, cfg, queue)
 

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -104,6 +104,12 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 			CurrentLedger: s.openLedgerView.Current().Sequence(),
 		}, nil
 	}
+	// Verify the signature before SubmitDetailed acquires the apply mutex so the
+	// in-strand check reuses the cached verdict (#1105). Skipped in standalone
+	// mode, matching cfg.SkipSignatureVerification above.
+	if !cfg.SkipSignatureVerification {
+		txengine.PrewarmSignature(ptx.Parsed, cfg.Rules)
+	}
 
 	outcome := s.openLedgerView.SubmitDetailed(ptx, cfg, s.txQueue)
 

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -316,10 +316,55 @@ func (e *Engine) verifyOuterSignature(tx txcore.Transaction) ter.Result {
 	// maps to temINVALID (Transactor.cpp:198-201) — NOT temBAD_SIGNATURE. The
 	// malformed-key-type case that does warrant temBAD_SIGNATURE is already
 	// caught unconditionally in preflight1 (preflightCommon).
+	//
+	// A verdict cached off-strand (PrewarmSignature) means this same signature
+	// was already verified under the same rules, so the verify is skipped here to
+	// keep it off the open-ledger apply mutex (issue #1105). Only positive
+	// verdicts are cached, so a cold cache still runs the full verify below.
+	if tx.GetCommon().SignatureVerified() {
+		return ter.TesSUCCESS
+	}
 	if err := sign.VerifySignature(tx, mustBeFullyCanonical); err != nil {
 		return ter.TemINVALID
 	}
 	return ter.TesSUCCESS
+}
+
+// PrewarmSignature cryptographically verifies a single-signed transaction's
+// signature ahead of the open-ledger apply strand and caches a positive verdict
+// on the transaction, so the in-strand signature check skips the repeat verify.
+// This moves the dominant per-tx cost — ECDSA/EdDSA verification — off the
+// apply mutex onto the ingress workers, where it runs concurrently, mirroring
+// rippled caching SF_SIGGOOD in checkValidity before the apply strand (#1105).
+//
+// It never rejects and never caches a negative verdict: multi-signed, unsigned,
+// and bad-signature transactions leave the cache cold so the in-strand preflight
+// runs unchanged and reports the canonical, ordered result. Multi-signed
+// transactions stay on the in-strand path because go-xrpl interleaves their
+// crypto check with ledger-state signer-list authorization, which must observe
+// the apply view.
+//
+// rules supplies the parent ledger's amendment state so the canonicality
+// requirement matches the in-strand check; a nil rules honours only the per-tx
+// tfFullyCanonicalSig flag.
+func PrewarmSignature(txn txcore.Transaction, rules *amendment.Rules) {
+	if txn == nil {
+		return
+	}
+	common := txn.GetCommon()
+	if common == nil || common.SignatureVerified() {
+		return
+	}
+	// Only single-signed transactions are verified off-strand; an empty
+	// SigningPubKey marks a multi-signed or unsigned (inner-batch) transaction.
+	if common.SigningPubKey == "" {
+		return
+	}
+	mustBeFullyCanonical := (rules != nil && rules.RequireFullyCanonicalSigEnabled()) ||
+		(common.GetFlags()&txcore.TfFullyCanonicalSig) != 0
+	if sign.VerifySignature(txn, mustBeFullyCanonical) == nil {
+		common.MarkSignatureVerified()
+	}
 }
 
 // parseValidationError maps a Validate() error to a TER result code.

--- a/internal/tx/engine/prewarm_test.go
+++ b/internal/tx/engine/prewarm_test.go
@@ -1,0 +1,118 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/crypto/ed25519"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+// prewarmTestAccount is a real, decodable classic address used as the source
+// account. Signature verification checks only the cryptographic signature over
+// the signing payload — binding the signing key to the account is a preclaim
+// concern — so the account need not match the signing key.
+const prewarmTestAccount = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+// newSignedSingleSignTx builds a single-signed AccountSet-shaped BaseTx signed
+// with a fresh ed25519 key. ed25519 signatures are always canonical, so the
+// verdict is independent of the RequireFullyCanonicalSig rule.
+func newSignedSingleSignTx(t *testing.T) *txcore.BaseTx {
+	t.Helper()
+	priv, pub, err := ed25519.ED25519().DeriveKeypair([]byte("prewarm-issue-1105-seed"), false)
+	if err != nil {
+		t.Fatalf("DeriveKeypair: %v", err)
+	}
+	txn := txcore.NewBaseTx(txcore.TypeAccountSet, prewarmTestAccount)
+	txn.Common.Fee = "10"
+	seq := uint32(1)
+	txn.Common.Sequence = &seq
+	txn.Common.SigningPubKey = pub
+	sig, err := sign.SignTransaction(txn, priv)
+	if err != nil {
+		t.Fatalf("SignTransaction: %v", err)
+	}
+	txn.Common.TxnSignature = sig
+	return txn
+}
+
+func verifyingEngine(rules *amendment.Rules) *Engine {
+	return NewEngine(newMockBaseView(), txcore.EngineConfig{
+		Rules:                     rules,
+		SkipSignatureVerification: false,
+	})
+}
+
+// TestPrewarmSignature_SkipsRepeatVerify proves the off-strand verdict is
+// honoured: once PrewarmSignature has cached a positive verdict, the in-strand
+// signature check trusts it and does not re-verify — demonstrated by corrupting
+// the signature after prewarming and observing the check still passes.
+func TestPrewarmSignature_SkipsRepeatVerify(t *testing.T) {
+	rules := amendment.AllSupportedRules()
+	txn := newSignedSingleSignTx(t)
+
+	if txn.GetCommon().SignatureVerified() {
+		t.Fatal("a freshly built tx must not be marked verified")
+	}
+	PrewarmSignature(txn, rules)
+	if !txn.GetCommon().SignatureVerified() {
+		t.Fatal("PrewarmSignature must cache a positive verdict for a valid single-signed tx")
+	}
+
+	// Corrupt the signature; the cached verdict must short-circuit the verify.
+	txn.GetCommon().TxnSignature = "00"
+	if res := verifyingEngine(rules).verifySignatures(txn); res != ter.TesSUCCESS {
+		t.Fatalf("cached-good signature must skip re-verify; got %s", res)
+	}
+}
+
+// TestPrewarmSignature_ColdCacheStillVerifies is the control for the skip test:
+// the same corrupted signature WITHOUT a prewarmed verdict must be rejected by
+// the in-strand check, confirming the prior test's pass came from the cache.
+func TestPrewarmSignature_ColdCacheStillVerifies(t *testing.T) {
+	rules := amendment.AllSupportedRules()
+	txn := newSignedSingleSignTx(t)
+	txn.GetCommon().TxnSignature = "00"
+
+	if res := verifyingEngine(rules).verifySignatures(txn); res != ter.TemINVALID {
+		t.Fatalf("a cold cache must verify and reject a bad signature with temINVALID; got %s", res)
+	}
+}
+
+// TestPrewarmSignature_NoNegativeCache confirms a bad signature leaves the cache
+// cold, so the in-strand path reports the canonical, ordered result rather than
+// a spuriously cached pass.
+func TestPrewarmSignature_NoNegativeCache(t *testing.T) {
+	txn := newSignedSingleSignTx(t)
+	txn.GetCommon().TxnSignature = "00" // invalidate before prewarming
+
+	PrewarmSignature(txn, amendment.AllSupportedRules())
+	if txn.GetCommon().SignatureVerified() {
+		t.Fatal("PrewarmSignature must not cache a verdict for a bad signature")
+	}
+}
+
+// TestPrewarmSignature_SkipsMultiSignAndUnsigned confirms transactions with an
+// empty SigningPubKey (multi-signed or unsigned) are left for the in-strand
+// path, which interleaves the multi-sign crypto check with ledger-state
+// signer-list authorization.
+func TestPrewarmSignature_SkipsMultiSignAndUnsigned(t *testing.T) {
+	txn := txcore.NewBaseTx(txcore.TypeAccountSet, prewarmTestAccount)
+	txn.Common.Fee = "10"
+	seq := uint32(1)
+	txn.Common.Sequence = &seq
+	txn.Common.SigningPubKey = "" // multi-sign / unsigned marker
+
+	PrewarmSignature(txn, amendment.AllSupportedRules())
+	if txn.GetCommon().SignatureVerified() {
+		t.Fatal("PrewarmSignature must not pre-verify a transaction with no single-sign key")
+	}
+}
+
+// TestPrewarmSignature_NilTxn is a defensive guard: a nil transaction must be a
+// no-op rather than a panic.
+func TestPrewarmSignature_NilTxn(t *testing.T) {
+	PrewarmSignature(nil, amendment.AllSupportedRules())
+}

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -216,7 +216,10 @@ type Common struct {
 	// sigVerified records that this transaction's cryptographic signature has
 	// already been verified off the open-ledger apply strand, so the in-strand
 	// signature check can skip the repeat verify. It is never serialized and is
-	// meaningful only for one in-memory parsed transaction.
+	// meaningful only for one in-memory parsed transaction. No synchronization
+	// guards it: ingress writes the verdict (PrewarmSignature) and then submits
+	// on the same goroutine, so the write happens-before the in-strand read and
+	// before the parsed transaction is shared with any other goroutine.
 	sigVerified bool
 }
 

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -212,6 +212,12 @@ type Common struct {
 	// PresentFields tracks which fields were present in the original parsed data.
 	// This is used to distinguish between a field being absent vs explicitly set to empty.
 	PresentFields map[string]bool `json:"-"`
+
+	// sigVerified records that this transaction's cryptographic signature has
+	// already been verified off the open-ledger apply strand, so the in-strand
+	// signature check can skip the repeat verify. It is never serialized and is
+	// meaningful only for one in-memory parsed transaction.
+	sigVerified bool
 }
 
 // Validate validates the common fields. preflightCommonFields catches these
@@ -263,6 +269,18 @@ func (c *Common) GetFlags() uint32 {
 		return 0
 	}
 	return *c.Flags
+}
+
+// MarkSignatureVerified records that the transaction's cryptographic signature
+// has been verified, so a later in-strand check can skip re-verifying it.
+func (c *Common) MarkSignatureVerified() {
+	c.sigVerified = true
+}
+
+// SignatureVerified reports whether the transaction's signature was already
+// verified off-strand (see MarkSignatureVerified).
+func (c *Common) SignatureVerified() bool {
+	return c.sigVerified
 }
 
 // SetSequence sets the sequence number


### PR DESCRIPTION
## Summary

Open-ledger ingress (`OpenLedger.SubmitDetailed`) ran `ParseFromBinary` + signature verification + apply **all inside `modifyMu`**, so the dominant per-tx cost — ECDSA/EdDSA signature verification — was serialized to an effective apply concurrency of **1**, regardless of the four ingress workers. This is the throughput wall described in #1105 (the network runs live-but-degraded under load, ~15 validated tx/ledger).

This change mirrors rippled's `checkValidity`, which caches `SF_SIGGOOD` in the HashRouter **before** the open-ledger apply strand:

- **`engine.PrewarmSignature`** verifies a *single-signed* transaction's signature in the ingress worker (off the mutex) and caches a positive verdict on the parsed tx (`Common.sigVerified`). The four workers now verify signatures concurrently instead of one-at-a-time under `modifyMu`.
- The in-strand `verifyOuterSignature` (single-sign branch) consults the cache and **skips the repeat verify**.
- The parsed transaction is carried through `openledger.PendingTx.Parsed`, so the prewarmed object (and its verdict) reaches the apply path instead of being re-decoded under the lock — this also removes the previous redundant in-lock re-parse.

### Behaviour is preserved
- **Positive-only cache**: bad-signature, multi-signed, and unsigned txs leave the cache cold and run the in-strand preflight unchanged, so TER codes and their ordering are identical to before.
- **Multi-sign stays in-strand**: go-xrpl interleaves multi-sign crypto with view-dependent signer-list authorization, which must observe the apply view. Preclaim already re-validates all view-dependent authorization (signer-list membership, quorum, master/regular key), so only the view-independent crypto verify is hoisted.
- `mustBeFullyCanonical` is computed from the same `cfg.Rules` + tx flags in both the prewarm and the in-strand check, so a cached verdict is never trusted under a different canonicality requirement.

## Test plan
- [x] New white-box tests `internal/tx/engine/prewarm_test.go`: cached-good skips re-verify; cold-cache still verifies (control); no negative caching; multi-sign/unsigned deferred; nil-safe.
- [x] `-race`: `engine`, `txq`, `openledger`, `service`, `sign`, `consensus/adaptor`, `rpc`, and the `multisign`/`payment`/`batch`/`networkid`/`accountset` integration suites — all green.
- [x] `offer` integration suite passes (no behavioural change; the env submit path doesn't touch the prewarm).
- [x] Conformance suite: signature/offer/payment/path suites at 100% (no regression).
- [x] `go vet` + `gofmt` clean.

Fixes #1105