### PR TITLE
Gate AccountSet sigWithMaster on key type and multi-sign

### DIFF
--- a/internal/testing/accountset/accountset_test.go
+++ b/internal/testing/accountset/accountset_test.go
@@ -707,3 +707,50 @@ func TestAccountSet_DirIsEmpty_AnchorEmptyWithContinuation(t *testing.T) {
 		jtx.RequireTxFail(t, result, "tecOWNERS")
 	})
 }
+
+// =========================================================================
+// DisableMaster requires the master key — issue 734.
+// =========================================================================
+// asfDisableMaster may be set only by a transaction signed with the account's
+// own master key. A regular-key-signed or multi-signed AccountSet must be
+// rejected with tecNEED_MASTER_KEY, matching rippled SetAccount.cpp sigWithMaster.
+func TestAccountSet_DisableMaster_RequiresMasterKey(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	eric := jtx.NewAccount("eric")
+	bob := jtx.NewAccount("bob")
+	env.Fund(alice, eric, bob)
+	env.Close()
+
+	// Give alice both alternate signing methods so disabling the master key is
+	// otherwise permitted (no tecNO_ALTERNATIVE_KEY): a regular key and a signer
+	// list. This isolates the master-key requirement as the only gate under test.
+	env.SetRegularKey(alice, eric)
+	env.SetSignerList(alice, 1, []jtx.TestSigner{{Account: bob, Weight: 1}})
+	env.Close()
+
+	jtx.RequireFlagNotSet(t, env, alice, state.LsfDisableMaster)
+
+	// Multi-signed: an empty SigningPubKey is never the master key.
+	result := env.SubmitMultiSigned(
+		AccountSet(alice).SetFlag(accounttx.AccountSetFlagDisableMaster).Build(),
+		[]*jtx.Account{bob},
+	)
+	jtx.RequireTxFail(t, result, "tecNEED_MASTER_KEY")
+	jtx.RequireFlagNotSet(t, env, alice, state.LsfDisableMaster)
+
+	// Regular-key signed: a valid but non-master key.
+	result = env.SubmitSignedWith(
+		AccountSet(alice).SetFlag(accounttx.AccountSetFlagDisableMaster).Build(),
+		eric,
+	)
+	jtx.RequireTxFail(t, result, "tecNEED_MASTER_KEY")
+	jtx.RequireFlagNotSet(t, env, alice, state.LsfDisableMaster)
+
+	// Master-key signed: succeeds and sets lsfDisableMaster.
+	result = env.SubmitSigned(
+		AccountSet(alice).SetFlag(accounttx.AccountSetFlagDisableMaster).Build(),
+	)
+	jtx.RequireTxSuccess(t, result)
+	jtx.RequireFlagSet(t, env, alice, state.LsfDisableMaster)
+}

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -7,7 +7,6 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 
-	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
 	"github.com/LeJamon/go-xrpl/internal/tx/invariants"
@@ -320,17 +319,7 @@ func (e *Engine) invokeApply(st *applyState) (result ter.Result) {
 // invokeApplyInner is the body of invokeApply, separated so the panic-recovery
 // defer in invokeApply does not have to walk back through the dispatch.
 func (e *Engine) invokeApplyInner(st *applyState) ter.Result {
-	// Determine if the transaction was signed with the master key.
-	// Reference: rippled SetAccount.cpp sigWithMaster — compares
-	// calcAccountID(SigningPubKey) against the account ID.
-	// When signature verification is skipped (test mode), assume master key.
-	sigWithMaster := e.config.SkipSignatureVerification
-	if st.common.SigningPubKey != "" {
-		signerAddr, addrErr := addresscodec.EncodeClassicAddressFromPublicKeyHex(st.common.SigningPubKey)
-		if addrErr == nil {
-			sigWithMaster = signerAddr == st.common.Account
-		}
-	}
+	sigWithMaster := txcore.SignedWithMasterKey(e.config.SkipSignatureVerification, st.common)
 
 	// All transaction types implement Appliable
 	ctx := &txcore.ApplyContext{

--- a/internal/tx/setregularkey_fee.go
+++ b/internal/tx/setregularkey_fee.go
@@ -1,9 +1,6 @@
 package tx
 
 import (
-	"encoding/hex"
-
-	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 )
 
@@ -28,19 +25,5 @@ func SetRegularKeyFeeWaived(skipSigVerification bool, common *Common, account *s
 	if account.Flags&state.LsfPasswordSpent != 0 {
 		return false
 	}
-	if spk := common.SigningPubKey; spk != "" {
-		// Validate the public-key type before deriving an address, matching
-		// rippled's publicKeyType() guard — otherwise an arbitrary payload
-		// could hex-encode into a master-looking address.
-		spkBytes, decErr := hex.DecodeString(spk)
-		if decErr != nil || !IsValidPublicKey(spkBytes) {
-			return false
-		}
-		sigAddr, addrErr := addresscodec.EncodeClassicAddressFromPublicKey(spkBytes)
-		return addrErr == nil && sigAddr == common.Account
-	}
-	// No SigningPubKey: in standalone/test mode signature verification is
-	// skipped and a single-signed transaction is treated as master-signed. A
-	// multi-signed transaction (Signers present) is never master-signed.
-	return skipSigVerification && len(common.Signers) == 0
+	return SignedWithMasterKey(skipSigVerification, common)
 }

--- a/internal/tx/validate.go
+++ b/internal/tx/validate.go
@@ -1,6 +1,11 @@
 package tx
 
-import "github.com/LeJamon/go-xrpl/internal/tx/ter"
+import (
+	"encoding/hex"
+
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
 
 // CheckFlags validates that no unsupported flags are set.
 // mask should be the bitwise complement of all valid flags (~(validFlag1 | validFlag2 | ...)).
@@ -50,4 +55,31 @@ func IsValidPublicKey(key []byte) bool {
 		return false
 	}
 	return key[0] == 0xED || key[0] == 0x02 || key[0] == 0x03
+}
+
+// SignedWithMasterKey reports whether a transaction was signed with the sending
+// account's master key: SigningPubKey must hex-decode to a valid public key
+// whose derived account ID equals common.Account. A multi-signed transaction
+// (empty SigningPubKey, Signers present) is never master-signed; an unsigned
+// single-signed transaction is treated as master-signed only when signature
+// verification is skipped (standalone/test mode).
+//
+// This is the single source of truth for the "signed with master" question,
+// shared by the SetRegularKey fee waiver and AccountSet's master-key gates so
+// the two can never drift. It mirrors rippled's SetAccount.cpp sigWithMaster
+// lambda, which gates on publicKeyType() before deriving calcAccountID and
+// yields false for an empty SigningPubKey.
+func SignedWithMasterKey(skipSigVerification bool, common *Common) bool {
+	if common == nil {
+		return false
+	}
+	if spk := common.SigningPubKey; spk != "" {
+		spkBytes, decErr := hex.DecodeString(spk)
+		if decErr != nil || !IsValidPublicKey(spkBytes) {
+			return false
+		}
+		sigAddr, addrErr := addresscodec.EncodeClassicAddressFromPublicKey(spkBytes)
+		return addrErr == nil && sigAddr == common.Account
+	}
+	return skipSigVerification && len(common.Signers) == 0
 }

--- a/internal/tx/validate_test.go
+++ b/internal/tx/validate_test.go
@@ -1,0 +1,98 @@
+package tx
+
+import (
+	"testing"
+
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+)
+
+// TestSignedWithMasterKey pins the shared "signed with the master key" predicate
+// that gates AccountSet's asfDisableMaster / asfNoFreeze and the SetRegularKey
+// fee waiver. It must match rippled's SetAccount.cpp sigWithMaster: a valid
+// public-key type whose derived account ID equals the sender, and false for an
+// empty SigningPubKey unless it is an unsigned single-signed transaction in
+// skip-verify (standalone) mode.
+func TestSignedWithMasterKey(t *testing.T) {
+	// EncodeClassicAddressFromPublicKey only hashes the bytes, so any valid
+	// 33-byte key (0xED/0x02/0x03 prefix) yields a deterministic address.
+	const masterPub = "ED0000000000000000000000000000000000000000000000000000000000000001"
+	const otherPub = "ED0000000000000000000000000000000000000000000000000000000000000002"
+	// A 33-byte payload whose prefix byte (0x00) is not a valid public-key type:
+	// the length check passes but rippled's publicKeyType rejects it, so an
+	// arbitrary payload must never derive a master-looking match.
+	const badPrefixPub = "00" +
+		"0000000000000000000000000000000000000000000000000000000000000000"
+	// A 65-byte uncompressed secp256k1 key (0x04 prefix): rippled accepts only
+	// 33-byte keys.
+	const uncompressedPub = "04" +
+		"0000000000000000000000000000000000000000000000000000000000000000" +
+		"0000000000000000000000000000000000000000000000000000000000000000"
+
+	masterAddr, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(masterPub)
+	if err != nil {
+		t.Fatalf("derive master address: %v", err)
+	}
+
+	tests := []struct {
+		name                string
+		skipSigVerification bool
+		common              *Common
+		want                bool
+	}{
+		{
+			name:   "master-signed",
+			common: &Common{Account: masterAddr, SigningPubKey: masterPub},
+			want:   true,
+		},
+		{
+			name:   "signed with a non-master key",
+			common: &Common{Account: masterAddr, SigningPubKey: otherPub},
+			want:   false,
+		},
+		{
+			name:   "malformed SigningPubKey",
+			common: &Common{Account: masterAddr, SigningPubKey: "not-hex"},
+			want:   false,
+		},
+		{
+			name:   "valid length but invalid public-key type",
+			common: &Common{Account: masterAddr, SigningPubKey: badPrefixPub},
+			want:   false,
+		},
+		{
+			name:   "65-byte uncompressed key",
+			common: &Common{Account: masterAddr, SigningPubKey: uncompressedPub},
+			want:   false,
+		},
+		{
+			name:                "empty SigningPubKey, skip-verify, single-signed",
+			skipSigVerification: true,
+			common:              &Common{Account: masterAddr},
+			want:                true,
+		},
+		{
+			name:                "empty SigningPubKey, skip-verify, multi-signed",
+			skipSigVerification: true,
+			common:              &Common{Account: masterAddr, Signers: []SignerWrapper{{}}},
+			want:                false,
+		},
+		{
+			name:   "empty SigningPubKey without skip-verify",
+			common: &Common{Account: masterAddr},
+			want:   false,
+		},
+		{
+			name:   "nil common",
+			common: nil,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SignedWithMasterKey(tt.skipSigVerification, tt.common); got != tt.want {
+				t.Errorf("SignedWithMasterKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Issue #734: the engine re-derived "signed with the master key" a third way in `invokeApplyInner` (`internal/tx/engine/do_apply.go`), diverging from rippled's `SetAccount` `sigWithMaster`. It derived a classic address from any 33-byte `SigningPubKey` **without validating the key type**, and for an empty `SigningPubKey` (a multi-signed tx) it fell back to `SkipSignatureVerification` **with no `Signers` gate**. rippled gates on `publicKeyType()` before deriving the AccountID and is unconditionally `false` for an empty `SigningPubKey`.
- Effect (standalone/replay-sim only, masked on live consensus): a multi-signed AccountSet could wrongly set `lsfDisableMaster` / `lsfNoFreeze` instead of returning `tecNEED_MASTER_KEY`; a bad-prefix 33-byte key could spuriously match.
- Fix: extract a single shared `SignedWithMasterKey(skipSigVerification, common)` predicate in package `tx` (validate the public-key type via `IsValidPublicKey`, derive the address, and treat an empty `SigningPubKey` as master-signed only for an unsigned single-sign tx in skip-verify mode). The engine and the `SetRegularKey` fee waiver (`SetRegularKeyFeeWaived`) now both call it — retiring the last instance of the re-derivation pattern flagged in #732/#733.

## Test plan

- [x] `go test ./internal/tx/...` — full engine + tx tree green
- [x] New unit test `TestSignedWithMasterKey` (9 cases: master-signed, non-master key, malformed hex, bad-prefix 33-byte key, 65-byte uncompressed key, skip-verify single-sign, skip-verify multi-sign, no-skip empty key, nil)
- [x] New integration test `TestAccountSet_DisableMaster_RequiresMasterKey` — multi-signed and regular-key disable-master → `tecNEED_MASTER_KEY`; master-key disable-master → success
- [x] `internal/testing/{accountset,multisign,setregularkey}` suites green
- [x] `go vet` + `gofmt` clean
- [x] Conformance: 1309 pass / 206 fail — byte-identical to baseline (zero regression, git-stash diff)

Fixes #734