### PR TITLE
fix(smartescrow): persist update_data mutation on tecWASM_REJECTED (#719)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,10 @@ jobs:
       - name: Build libwasmi
         run: ./internal/wasm/wasmi/build.sh
       # The WASM engine is gated behind the `wasmi` tag; assert its gas costs
-      # match rippled's smart-escrow branch (fib=1137) byte-for-byte.
-      - run: go test -tags wasmi -count=1 -timeout 15m ./internal/wasm/...
+      # match rippled's smart-escrow branch (fib=1137) byte-for-byte, and run the
+      # SmartEscrow EscrowFinish end-to-end tests (also `cgo && wasmi`-gated) so
+      # the engine accept/reject + gas + Data write-back paths are exercised in CI.
+      - run: go test -tags wasmi -count=1 -timeout 15m ./internal/wasm/... ./internal/tx/escrow/... ./internal/testing/escrow/...
 
   consensus-smoke:
     name: Consensus smoke (2 rippled + 1 goxrpl)

--- a/internal/testing/escrow/smartescrow_test.go
+++ b/internal/testing/escrow/smartescrow_test.go
@@ -151,10 +151,29 @@ func TestSmartEscrow_AcceptWithDataMutation(t *testing.T) {
 		Fee(2_000_000).
 		BuildEscrowFinish()
 	ef.ComputationAllowance = &allowance
-	require.Equal(t, "tesSUCCESS", env.Submit(ef).Code)
+	res := env.Submit(ef)
+	require.Equal(t, "tesSUCCESS", res.Code)
 	env.Close()
 
 	require.False(t, env.LedgerEntryExists(keylet.Escrow(alice.ID, seq)), "escrow must be deleted on a successful finish")
+
+	// The deleted escrow's metadata must still carry the finish function's
+	// update_data write: runSmartEscrow writes Data into the escrow SLE before the
+	// success-path erase, so the escrow's DeletedNode FinalFields records it.
+	require.NotNil(t, res.Metadata, "successful finish must produce metadata")
+	var finalData string
+	var found bool
+	for _, n := range res.Metadata.AffectedNodes {
+		if n.NodeType == "DeletedNode" && n.LedgerEntryType == "Escrow" {
+			v, ok := n.FinalFields["Data"].(string)
+			require.True(t, ok, "deleted escrow FinalFields must include Data")
+			finalData, found = v, true
+			break
+		}
+	}
+	require.True(t, found, "successful finish must emit a DeletedNode for the escrow")
+	require.True(t, strings.EqualFold(updateDataValueHex, finalData),
+		"deleted escrow FinalFields.Data must hold the finish function's write, got %q", finalData)
 }
 
 // TestSmartEscrow_FinishRejects: a finish function returning 0 rejects the

--- a/internal/testing/escrow/smartescrow_test.go
+++ b/internal/testing/escrow/smartescrow_test.go
@@ -5,11 +5,14 @@
 package escrow_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
+	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,10 +57,104 @@ func runComputationalEscrow(t *testing.T, finishFunctionHex string) string {
 	return env.Submit(ef).Code
 }
 
+// Finish functions that call update_data("smartescrow-data") (16 bytes) and then
+// return — one rejecting (0), one accepting (1). Compiled with wat2wasm from:
+//
+//	(module
+//	  (import "host" "update_data" (func $u (param i32 i32) (result i32)))
+//	  (memory (export "memory") 1)
+//	  (data (i32.const 0) "smartescrow-data")
+//	  (func (export "finish") (result i32)
+//	    (drop (call $u (i32.const 0) (i32.const 16)))
+//	    (i32.const N)))
+const (
+	finishUpdateDataReject = "0061736d01000000010b0260027f7f017f6000017f02140104686f73740b7570646174655f646174610000030201010503010001071302066d656d6f727902000666696e69736800010a0d010b004100411010001a41000b0b16010041000b10736d617274657363726f772d64617461"
+	finishUpdateDataAccept = "0061736d01000000010b0260027f7f017f6000017f02140104686f73740b7570646174655f646174610000030201010503010001071302066d656d6f727902000666696e69736800010a0d010b004100411010001a41010b0b16010041000b10736d617274657363726f772d64617461"
+	// hex of the bytes the finish functions write via update_data.
+	updateDataValueHex = "736d617274657363726f772d64617461"
+)
+
 // TestSmartEscrow_FinishAccepts: a finish function returning 1 lets the escrow
 // finish.
 func TestSmartEscrow_FinishAccepts(t *testing.T) {
 	require.Equal(t, "tesSUCCESS", runComputationalEscrow(t, finishReturns1))
+}
+
+// TestSmartEscrow_RejectPersistsData: a finish function that mutates the escrow's
+// Data via update_data and then rejects (returns 0) yields tecWASM_REJECTED, and
+// the escrow survives carrying the new Data. The in-doApply Data write rides in
+// the discarded sandbox, so this only holds if the write is re-applied after the
+// sandbox is reset. Reference: rippled Transactor.cpp modifyWasmDataFields.
+func TestSmartEscrow_RejectPersistsData(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SmartEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	seq := env.Seq(alice)
+	ec := escrow.EscrowCreate(alice, bob, xrp(1000)).
+		CancelTime(env.Now().Add(1000 * time.Second)).
+		Fee(baseFee * 150).
+		BuildEscrowCreate()
+	ff := finishUpdateDataReject
+	ec.FinishFunction = &ff
+	jtx.RequireTxSuccess(t, env.Submit(ec))
+	env.Close()
+
+	allowance := uint32(1_000_000)
+	ef := escrow.EscrowFinish(bob, alice, seq).
+		Fee(2_000_000).
+		BuildEscrowFinish()
+	ef.ComputationAllowance = &allowance
+	require.Equal(t, "tecWASM_REJECTED", env.Submit(ef).Code)
+	env.Close()
+
+	// The escrow must survive the rejected finish, now carrying the mutated Data.
+	escrowKey := keylet.Escrow(alice.ID, seq)
+	require.True(t, env.LedgerEntryExists(escrowKey), "escrow must survive tecWASM_REJECTED")
+	raw, err := env.LedgerEntry(escrowKey)
+	require.NoError(t, err)
+	decoded, err := binarycodec.DecodeBytes(raw)
+	require.NoError(t, err)
+	data, ok := decoded["Data"].(string)
+	require.True(t, ok, "escrow Data field must be present after update_data")
+	require.True(t, strings.EqualFold(updateDataValueHex, data), "escrow Data must hold the finish function's write, got %q", data)
+}
+
+// TestSmartEscrow_AcceptWithDataMutation: update_data followed by an accepting
+// finish still succeeds and deletes the escrow (the Data write is moot once the
+// escrow is erased), confirming the Data path does not disturb the success flow.
+func TestSmartEscrow_AcceptWithDataMutation(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("SmartEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	fund5000(env, alice, bob)
+	env.Close()
+
+	seq := env.Seq(alice)
+	ec := escrow.EscrowCreate(alice, bob, xrp(1000)).
+		CancelTime(env.Now().Add(1000 * time.Second)).
+		Fee(baseFee * 150).
+		BuildEscrowCreate()
+	ff := finishUpdateDataAccept
+	ec.FinishFunction = &ff
+	jtx.RequireTxSuccess(t, env.Submit(ec))
+	env.Close()
+
+	allowance := uint32(1_000_000)
+	ef := escrow.EscrowFinish(bob, alice, seq).
+		Fee(2_000_000).
+		BuildEscrowFinish()
+	ef.ComputationAllowance = &allowance
+	require.Equal(t, "tesSUCCESS", env.Submit(ef).Code)
+	env.Close()
+
+	require.False(t, env.LedgerEntryExists(keylet.Escrow(alice.ID, seq)), "escrow must be deleted on a successful finish")
 }
 
 // TestSmartEscrow_FinishRejects: a finish function returning 0 rejects the

--- a/internal/tx/do_apply.go
+++ b/internal/tx/do_apply.go
@@ -438,6 +438,28 @@ func (e *Engine) applyTecRecovery(st *applyState, result Result) Result {
 		}
 	}
 
+	// tecWASM_REJECTED: a SmartEscrow finish function that mutated the escrow's
+	// Data via update_data persists that mutation even though the finish was
+	// rejected. The sandbox carrying the in-doApply sfData write is discarded, so
+	// re-apply it through tecTable on the surviving escrow.
+	// Reference: rippled Transactor.cpp lines 1377-1381 modifyWasmDataFields.
+	if result == TecWASM_REJECTED {
+		if applier, ok := st.tx.(WasmDataApplier); ok {
+			tecCtx := &ApplyContext{
+				View:      tecTable,
+				Account:   recoveredAccount,
+				AccountID: st.accountID,
+				Config:    e.config,
+				TxHash:    st.txHash,
+				Metadata:  st.metadata,
+				Engine:    e,
+				Log:       e.logger,
+				Ctx:       st.ctx,
+			}
+			applier.ApplyWasmDataOnTec(tecCtx)
+		}
+	}
+
 	// Apply all tracked changes and generate proper metadata
 	generatedMeta, applyErr := tecTable.Apply()
 	if applyErr != nil {

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -38,6 +38,12 @@ type EscrowFinish struct {
 	// ComputationAllowance is the gas budget for the escrow's FinishFunction
 	// (SmartEscrow). Required when finishing an escrow that has a FinishFunction.
 	ComputationAllowance *uint32 `json:"ComputationAllowance,omitempty" xrpl:"ComputationAllowance,omitempty"`
+
+	// wasmData/wasmDataSet capture a SmartEscrow finish function's update_data
+	// mutation during Apply so it can be re-applied to the surviving escrow on
+	// tecWASM_REJECTED, after the tx sandbox is discarded. Not serialized.
+	wasmData    []byte
+	wasmDataSet bool
 }
 
 func NewEscrowFinish(account, owner string, offerSequence uint32) *EscrowFinish {
@@ -141,6 +147,31 @@ func (e *EscrowFinish) CalculateBaseFee(view tx.LedgerView, config tx.EngineConf
 func (e *EscrowFinish) ApplyOnTec(ctx *tx.ApplyContext) tx.Result {
 	removeExpiredCredentials(ctx, e.CredentialIDs)
 	return tx.TecEXPIRED
+}
+
+// ApplyWasmDataOnTec implements tx.WasmDataApplier. On tecWASM_REJECTED, it
+// persists the finish function's update_data mutation to the escrow that
+// survived the rejected finish, re-applying the Data write that the discarded
+// sandbox carried. A no-op when the finish function did not mutate Data.
+// Reference: rippled Transactor.cpp modifyWasmDataFields.
+func (e *EscrowFinish) ApplyWasmDataOnTec(ctx *tx.ApplyContext) {
+	if !e.wasmDataSet {
+		return
+	}
+	ownerID, err := state.DecodeAccountID(e.Owner)
+	if err != nil {
+		return
+	}
+	escrowKey := keylet.Escrow(ownerID, e.OfferSequence)
+	escrowData, err := ctx.View.Read(escrowKey)
+	if err != nil || escrowData == nil {
+		return
+	}
+	newEscrow, err := setEscrowData(escrowData, e.wasmData)
+	if err != nil {
+		return
+	}
+	_ = ctx.View.Update(escrowKey, newEscrow)
 }
 
 // Apply applies an EscrowFinish transaction

--- a/internal/tx/escrow/smartescrow.go
+++ b/internal/tx/escrow/smartescrow.go
@@ -147,9 +147,10 @@ func runSmartEscrow(ctx *tx.ApplyContext, e *EscrowFinish, escrowData []byte) tx
 	}
 
 	view := &escrowView{ctx: ctx, txBytes: e.GetRawBytes(), escrowBytes: escrowData}
+	h := host.New(view)
 	engine := wasm.New()
 	defer engine.Close()
-	res, runErr := engine.Run(wasmBytes, "finish", nil, host.New(view), int64(*e.ComputationAllowance))
+	res, runErr := engine.Run(wasmBytes, "finish", nil, h, int64(*e.ComputationAllowance))
 	if runErr != nil {
 		ctx.Log.Debug("escrow finish: wasm execution failed", "error", runErr)
 		return tx.TecFAILED_PROCESSING
@@ -168,10 +169,47 @@ func runSmartEscrow(ctx *tx.ApplyContext, e *EscrowFinish, escrowData []byte) tx
 		ctx.Metadata.GasUsed = &gasUsed
 	}
 
+	// If the finish function mutated the escrow's Data via update_data, write it
+	// to the escrow SLE before testing the result — matching rippled, which writes
+	// sfData regardless of the verdict. On a successful finish the new Data rides
+	// into the escrow's DeletedNode; on tecWASM_REJECTED the escrow survives, so
+	// the write is re-applied after the sandbox is discarded (ApplyWasmDataOnTec).
+	// Reference: rippled EscrowFinish.cpp:424-433.
+	if data := h.Data(); len(data) > 0 {
+		if len(data) > maxWasmDataLength {
+			return tx.TecINTERNAL
+		}
+		newEscrow, err := setEscrowData(escrowData, data)
+		if err != nil {
+			return tx.TefINTERNAL
+		}
+		ownerID, err := state.DecodeAccountID(e.Owner)
+		if err != nil {
+			return tx.TefINTERNAL
+		}
+		if err := ctx.View.Update(keylet.Escrow(ownerID, e.OfferSequence), newEscrow); err != nil {
+			return tx.TefINTERNAL
+		}
+		e.wasmData = data
+		e.wasmDataSet = true
+	}
+
 	if res.Result <= 0 {
 		return tx.TecWASM_REJECTED
 	}
 	return tx.TesSUCCESS
+}
+
+// setEscrowData returns the escrow ledger object reserialized with its Data
+// field set to data. The escrow SLE is round-tripped through the binary codec
+// because state.EscrowData does not model the Data field.
+func setEscrowData(escrowData, data []byte) ([]byte, error) {
+	m, err := binarycodec.DecodeBytes(escrowData)
+	if err != nil {
+		return nil, err
+	}
+	m["Data"] = hex.EncodeToString(data)
+	return binarycodec.EncodeBytes(m)
 }
 
 // escrowFinishFunctionHex extracts the FinishFunction (hex string) from a

--- a/internal/tx/escrow/smartescrow.go
+++ b/internal/tx/escrow/smartescrow.go
@@ -190,8 +190,13 @@ func runSmartEscrow(ctx *tx.ApplyContext, e *EscrowFinish, escrowData []byte) tx
 		if err := ctx.View.Update(keylet.Escrow(ownerID, e.OfferSequence), newEscrow); err != nil {
 			return tx.TefINTERNAL
 		}
-		e.wasmData = data
-		e.wasmDataSet = true
+		// Capture for tec re-apply only on the reject path; a successful finish
+		// carries the sandbox write into the escrow's deletion, so
+		// ApplyWasmDataOnTec is never invoked.
+		if res.Result <= 0 {
+			e.wasmData = data
+			e.wasmDataSet = true
+		}
 	}
 
 	if res.Result <= 0 {

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -73,6 +73,15 @@ type TecApplier interface {
 	ApplyOnTec(ctx *ApplyContext) Result
 }
 
+// WasmDataApplier is implemented by transaction types whose SmartEscrow finish
+// function may mutate a ledger object's Data field and have that mutation persist
+// even when the finish is rejected. On tecWASM_REJECTED the tx sandbox is
+// discarded, so the Data write-back is re-applied through the recovery view.
+// Reference: rippled Transactor.cpp modifyWasmDataFields (tecWASM_REJECTED path)
+type WasmDataApplier interface {
+	ApplyWasmDataOnTec(ctx *ApplyContext)
+}
+
 // BatchFeeCalculator is implemented by transaction types that need custom minimum fee calculation.
 // Used by Batch transactions which require a higher fee based on inner tx count and signers.
 type BatchFeeCalculator interface {

--- a/justfile
+++ b/justfile
@@ -57,9 +57,9 @@ test-core:
 test-libs:
     go test ./codec/... ./crypto/... ./shamap/... ./storage/... ./keylet/... ./ledger/... ./amendment/... ./drops/... ./protocol/... ./config/...
 
-# WASM engine parity tests (cgo + libwasmi, behind the `wasmi` tag).
+# WASM engine parity tests + SmartEscrow end-to-end (cgo + libwasmi, `wasmi` tag).
 test-wasm: wasmi-build
-    go test -tags wasmi -count=1 ./internal/wasm/...
+    go test -tags wasmi -count=1 ./internal/wasm/... ./internal/tx/escrow/... ./internal/testing/escrow/...
 
 # Test a single package: `just test-pkg ./internal/peermanagement/...`
 test-pkg pkg:


### PR DESCRIPTION
## Summary

Fixes #719 (the Data write-back half) — a real ledger-state divergence from rippled on the SmartEscrow `wasm` branch.

A SmartEscrow finish function can mutate the escrow's `Data` field via the `update_data` host function. rippled writes `sfData` into the escrow SLE in `doApply` and, on **`tecWASM_REJECTED`**, re-applies it to the *surviving* escrow after the tx sandbox is discarded (`Transactor::modifyWasmDataFields`) — so the escrow persists carrying the new Data. goXRPL discarded the mutation entirely: `update_data("X")` then `finish → 0` left the escrow with its **old** Data while rippled kept `X`. That is a divergent close.

## Changes

- **`runSmartEscrow`** writes the mutated `Data` into the escrow SLE *before* the result check (mirrors `EscrowFinish.cpp:424-433`), so a successful finish carries the new Data into the escrow's `DeletedNode` FinalFields, and a rejected finish leaves it staged in the (to-be-discarded) sandbox.
- New **`WasmDataApplier`** optional interface, dispatched from the engine's tec-recovery on `tecWASM_REJECTED`, re-applies the Data to the surviving escrow through the recovery view — the idiomatic Go mirror of `modifyWasmDataFields`. A plain reject (no `update_data`) is a no-op.
- `setEscrowData` round-trips the escrow through the binary codec, since the hand-written `state.EscrowData` does not model `sfData`.

## #705 CI gap (folded in)

The SmartEscrow EscrowFinish end-to-end tests are `cgo && wasmi`-gated, but the wasmi CI job and `just test-wasm` only globbed `./internal/wasm/...`, so the engine accept/reject + gas + Data paths ran in **zero** CI jobs. Extended both to also run `./internal/tx/escrow/...` and `./internal/testing/escrow/...`.

## Tests

- `TestSmartEscrow_RejectPersistsData` — `update_data` then reject → `tecWASM_REJECTED`, escrow **survives carrying the new Data** (the regression that was failing before this fix).
- `TestSmartEscrow_AcceptWithDataMutation` — `update_data` then accept → `tesSUCCESS`, escrow deleted.
- Conformance in-scope unchanged vs the `wasm` baseline (1098 pass / 43 fail); `app/Escrow` 100%. Full `internal/tx` (non-wasmi) and `internal/wasm` (wasmi) suites green.

## Scope note

This resolves #719's Data write-back (its lead/title item; the `get_nft`/`FindNFTURI` half already landed on `wasm`). Part of #64 / PR #708.