### PR TITLE
fix: unify offer-crossing grooming onto rippled's single live-funded rule (#1114)

### DIFF
--- a/internal/testing/amm/amm_bookstep_test.go
+++ b/internal/testing/amm/amm_bookstep_test.go
@@ -2927,6 +2927,10 @@ func TestAMMBookStep_DirectToDirectPath(t *testing.T) {
 	if ammBBUX < 320 || ammBBUX > 321 {
 		t.Errorf("AMM B_BUX: got %f, want ~320.02", ammBBUX)
 	}
+	// rippled testDirectToDirectPath (AMMExtended_test.cpp:1305-1325): cam's
+	// self-crossed passive offer is removed; only cam's new offer rests on the
+	// book, with the unfilled remainder (~20.02 B_BUX / ~20.02 A_BUX).
+	offerbuild.RequireOfferCount(t, env.TestEnv, cam, 1)
 }
 
 // TestAMMBookStep_RequireAuth tests require auth with AMM paths.

--- a/internal/testing/offer/offer_grooming_test.go
+++ b/internal/testing/offer/offer_grooming_test.go
@@ -1,0 +1,83 @@
+package offer
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOffer_DrainedMakerSiblingsGroomed reproduces the mainnet divergence at
+// ledger 99248432 (issue #1114): a maker has several same-quality offers, the
+// crossing consumes the first up to the maker's funded cap — draining the maker
+// and leaving a non-zero remainder — and that exactly satisfies the taker's
+// demand, so the walk stops before reaching the siblings.
+//
+// rippled's OfferStream::step reads the maker's funds live from the working view,
+// so each same-quality sibling it steps over reads became-unfunded and is groomed
+// off the book on the same pass. goXRPL previously anchored the trailing-drain
+// became test to the iteration base, which still showed the maker funded this
+// pass, and left the siblings behind. With the single funded rule now applied to
+// every stepped-over offer against the live sandbox, the siblings are groomed and
+// the maker ends with zero offers.
+//
+// Reference: rippled OfferStream.cpp step() 306-340 (live ownerFunds, found vs
+// became unfunded); BookStep.cpp forEachOffer do-while 855-865.
+func TestOffer_DrainedMakerSiblingsGroomed(t *testing.T) {
+	for _, fs := range offerFeatureSets {
+		t.Run(fs.name, func(t *testing.T) {
+			env := newEnvWithFeatures(t, fs.disabled)
+
+			gw := jtx.NewAccount("gateway")
+			maker := jtx.NewAccount("maker")
+			taker := jtx.NewAccount("taker")
+
+			USD := func(amount float64) tx.Amount { return jtx.USD(gw, amount) }
+
+			env.FundAmount(gw, uint64(jtx.XRP(10000)))
+			env.FundAmount(maker, uint64(jtx.XRP(10000)))
+			env.FundAmount(taker, uint64(jtx.XRP(10000)))
+			env.Close()
+
+			env.Trust(maker, USD(1000))
+			env.Trust(taker, USD(1000))
+
+			// The maker holds exactly 100 USD — enough to fund only one offer's
+			// funded cap. The taker pays the maker XRP for that USD.
+			jtx.RequireTxSuccess(t, env.Submit(payment.PayIssued(gw, maker, USD(100)).Build()))
+			env.Close()
+
+			// Three same-quality (1 USD : 1 XRP) offers, each selling 150 USD. Every
+			// offer's funded cap is the maker's 100 USD balance, so crossing the first
+			// drains the maker and leaves a 50 USD remainder on it (a funded-cap full
+			// take, not an exact consume).
+			const nSiblings = 3
+			for range nSiblings {
+				jtx.RequireTxSuccess(t, env.Submit(
+					OfferCreate(maker, jtx.XRPTxAmountFromXRP(150), USD(150)).Build()))
+			}
+			env.Close()
+			require.Equal(t, uint32(nSiblings), CountOffers(env, maker),
+				"maker should start with all sibling offers on the book")
+
+			// The taker buys exactly 100 USD for 100 XRP — satisfied in full by the
+			// first offer's funded-cap take, which drains the maker before the walk
+			// reaches the siblings.
+			jtx.RequireTxSuccess(t, env.Submit(
+				OfferCreate(taker, USD(100), jtx.XRPTxAmountFromXRP(100)).Build()))
+			env.Close()
+
+			// Every sibling read became-unfunded from the live sandbox and was
+			// groomed: the maker ends with no offers. Before the fix two siblings
+			// were left on the book.
+			require.Equal(t, uint32(0), CountOffers(env, maker),
+				"all same-quality siblings of the drained maker must be groomed")
+			// The taker's demand was met in full, so its offer crossed completely and
+			// left nothing on the book.
+			require.Equal(t, uint32(0), CountOffers(env, taker),
+				"the taker's offer should fully cross and not rest on the book")
+		})
+	}
+}

--- a/internal/tx/payment/flow.go
+++ b/internal/tx/payment/flow.go
@@ -153,17 +153,6 @@ func Flow(
 	// the strand still owes output — the engine couldn't converge in time.
 	// Reference: rippled StrandFlow.h lines 643-650.
 	var curTry uint32
-	// anyStrandApplied records whether any iteration committed a crossing (applied
-	// a best strand's sandbox). "Became unfunded"/"became tiny" removals are only
-	// real once some cross has actually drained an owner; before any cross commits,
-	// a strand that reads an offer unfunded did so only via its own discardable
-	// over-walk (e.g. a tfPassive taker whose sole strand — an autobridge leg — is
-	// rejected by limitQuality). rippled keeps such became-unfunded deletes in the
-	// per-strand sandbox and only the best strand's are committed (best->sb.apply),
-	// so gate the best strand's conditional removals on a committed crossing here.
-	// Perm removals (rippled permToRemove) are unaffected and always applied.
-	// Reference: rippled StrandFlow.h flow()/OfferStream::step.
-	var anyStrandApplied bool
 	for {
 		// Mirror rippled's while-guard: continue only while remainingOut > 0 and
 		// (no sendMax or remainingIn > 0). A non-positive remainingOut (zero OR
@@ -258,11 +247,6 @@ func Flow(
 			out     EitherAmount
 			sandbox *PaymentSandbox
 			quality Quality
-			// condOfrsToRm is this strand's CONDITIONAL (became-unfunded/tiny)
-			// removal set. Only the best strand's sandbox is applied (rippled
-			// best->sb.apply), so only its conditional removals reach the ledger;
-			// non-best strands' became-unfunded reads live in discarded sandboxes.
-			condOfrsToRm map[[32]byte]bool
 		}
 		var best *bestStrand
 		var markInactiveOnUse int = -1
@@ -302,19 +286,15 @@ func Flow(
 			// Reference: rippled StrandFlow.h line 694: flow(sb, *strand, remainingIn, limitRemainingOut, j)
 			result := ExecuteStrand(accumSandbox, *strand, remainingIn, limitRemainingOut, afBaseView)
 
-			// Split the strand's removals: perm (rippled permToRemove, deleted even
-			// when the strand fails) into iterOfrsToRm; the remaining conditional
-			// (became unfunded/tiny) into a per-strand set carried on bestStrand,
-			// so only the applied strand's conditional removals reach the ledger.
+			// Every removal a BookStep now reports is a perm removal (rippled's
+			// permToRemove_), deleted from both views regardless of TER. A
+			// became-unfunded/tiny offer is no longer split out here: it is a plain
+			// working-sandbox delete that reaches the ledger only through the applied
+			// strand's best.sandbox.Apply below, exactly as rippled's best->sb.apply,
+			// so a non-best or no-cross strand's drained-owner reads never erase it.
 			strandPerm := make(map[[32]byte]bool)
 			strandPermRemovals(*strand, strandPerm)
 			maps.Copy(iterOfrsToRm, strandPerm)
-			strandCond := make(map[[32]byte]bool)
-			for k := range result.OffsToRm {
-				if !strandPerm[k] {
-					strandCond[k] = true
-				}
-			}
 
 			// Track total offers considered across ALL strands
 			offersConsidered += result.OffersUsed
@@ -343,11 +323,10 @@ func Flow(
 					next = append(next, strand)
 				}
 				best = &bestStrand{
-					in:           result.In,
-					out:          result.Out,
-					sandbox:      result.Sandbox,
-					quality:      q,
-					condOfrsToRm: strandCond,
+					in:      result.In,
+					out:     result.Out,
+					sandbox: result.Sandbox,
+					quality: q,
 				}
 				// Push remaining strands to next
 				for ri := strandIndex + 1; ri < len(cur); ri++ {
@@ -377,11 +356,10 @@ func Flow(
 					markInactiveOnUse = -1
 				}
 				best = &bestStrand{
-					in:           result.In,
-					out:          result.Out,
-					sandbox:      result.Sandbox,
-					quality:      q,
-					condOfrsToRm: strandCond,
+					in:      result.In,
+					out:     result.Out,
+					sandbox: result.Sandbox,
+					quality: q,
 				}
 			}
 		}
@@ -427,24 +405,11 @@ func Flow(
 					}
 				}
 			}
-			// A crossing committed this iteration: from here on, became-unfunded
-			// grooming reflects real drains, so the conditional removals are real.
-			anyStrandApplied = true
 			// Update AMM iteration counter
 			// Reference: rippled StrandFlow.h line 798: ammContext.update()
 			if ammCtx != nil {
 				ammCtx.Update()
 			}
-		}
-
-		// Fold the applied (best) strand's conditional ("became unfunded"/"became
-		// tiny") removals into the deletion set, once a crossing has committed.
-		// rippled reaches the ledger only through best->sb.apply, so a non-best or
-		// no-cross strand's became-unfunded reads — discardable over-walk phantoms
-		// (e.g. a tfPassive taker whose only strand, an autobridge leg, is rejected
-		// by limitQuality) — never erase the offer. Perm removals are unaffected.
-		if anyStrandApplied && best != nil && best.condOfrsToRm != nil {
-			maps.Copy(iterOfrsToRm, best.condOfrsToRm)
 		}
 
 		// Delete removable offers from the accumulating sandbox

--- a/internal/tx/payment/flow.go
+++ b/internal/tx/payment/flow.go
@@ -89,19 +89,6 @@ func Flow(
 	// Create the main sandbox that accumulates all changes
 	accumSandbox := NewChildSandbox(baseView)
 
-	// afBaseView is the "all funds" baseline used to tell a FOUND removal (an
-	// offer already unfunded/tiny before this flow ran) from a BECAME removal
-	// (an offer the flow's own crossing drained). It is a child of the pristine
-	// pre-flow baseView, taken ONCE and never mutated by the per-pass applies
-	// that accumulate into accumSandbox. rippled re-derives its cancelView_ from
-	// the per-pass accumulator, which makes a multi-pass crossing misread an
-	// offer this tx drained in an earlier pass as "found-unfunded": both the
-	// working view and the (accumulator-rooted) cancel view see the drained
-	// balance, so original_funds == ownerFunds and the became-removal is wrongly
-	// promoted to permToRemove and survives a FillOrKill kill. Anchoring the
-	// baseline to the pre-flow state keeps the found-vs-became test honest across
-	// passes, so a became-unfunded offer stays a conditional, rolled-back removal.
-	afBaseView := NewChildSandbox(baseView)
 	allOfrsToRm := make(map[[32]byte]bool)
 
 	// Initialize result accumulators
@@ -284,7 +271,7 @@ func Flow(
 
 			// Execute this strand with the potentially limited output.
 			// Reference: rippled StrandFlow.h line 694: flow(sb, *strand, remainingIn, limitRemainingOut, j)
-			result := ExecuteStrand(accumSandbox, *strand, remainingIn, limitRemainingOut, afBaseView)
+			result := ExecuteStrand(accumSandbox, *strand, remainingIn, limitRemainingOut)
 
 			// Every removal a BookStep now reports is a perm removal (rippled's
 			// permToRemove_), deleted from both views regardless of TER. A

--- a/internal/tx/payment/flow_test.go
+++ b/internal/tx/payment/flow_test.go
@@ -698,7 +698,7 @@ func TestExecuteStrand_XRPPayment(t *testing.T) {
 	// Execute with 10 XRP requested output
 	requestedOut := NewXRPEitherAmount(10_000_000)
 
-	result := ExecuteStrand(sandbox, strand, nil, requestedOut, nil)
+	result := ExecuteStrand(sandbox, strand, nil, requestedOut)
 
 	if !result.Success {
 		t.Error("expected successful execution")

--- a/internal/tx/payment/sandbox.go
+++ b/internal/tx/payment/sandbox.go
@@ -153,18 +153,6 @@ func NewChildSandbox(parent *PaymentSandbox) *PaymentSandbox {
 	}
 }
 
-// IterationBase returns the parent sandbox, which for a per-strand working
-// sandbox is the flow's accumulating view: the ledger state after all prior
-// flow iterations applied but before THIS strand pass's (possibly
-// over-extended) consumption. The trailing-offer groom uses it to tell an
-// offer whose owner was already drained by an earlier iteration (a genuine
-// became-unfunded that survives) from one the current over-walk merely
-// over-consumed (a spurious removal a limiting reset discards). Returns nil for
-// a root sandbox.
-func (s *PaymentSandbox) IterationBase() *PaymentSandbox {
-	return s.parent
-}
-
 // SetOpenLedger records whether this sandbox is applying against the open
 // ledger. It is set once from EngineConfig.IsViewOpen at the flow entry point
 // and propagated to child sandboxes. Mirrors rippled's view.open().

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -559,11 +559,6 @@ func (s *BookStep) forEachOffer(
 		}
 	}
 
-	// The trailing groom is no longer a separate gated drain: the do-while above
-	// runs one more getNextOfferSkipVisited after the demand-meeting take, which
-	// grooms the trailing unfunded/became/tiny run in this (committed) pass before
-	// the next callback returns false — matching rippled's `while(offers.step())`.
-
 	// If no CLOB offers found, try the AMM alone.
 	if firstCLOB {
 		tryAMM(nil)

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -467,8 +467,16 @@ func (s *BookStep) forEachOffer(
 	// until the next funded tip fails the quality threshold. The bound never stops
 	// the walk at a found-unfunded offer — only at a funded (crossable) one — so a
 	// reserve-locked own offer at a beyond-limit tip is still removed.
+	// rippled's do-while: `do { if(!execOffer(tip)) break; } while(step())`. The
+	// loop is NOT bounded by remaining-amount at the top; instead each step()
+	// (getNextOfferSkipVisited) grooms the unfunded/became/tiny run it advances
+	// over, and the callback returns false once the demand is met (remainingZero
+	// at entry) or a partial fill leaves a still-funded tip. So after the take
+	// that meets demand, the loop runs one more getNextOfferSkipVisited — which
+	// grooms the trailing run in the SAME (committed) pass — before the next
+	// callback returns false and breaks. Reference: BookStep.cpp:855-865.
 	consumed := false
-	for s.offersUsed < s.maxOffersToConsume && !remainingZero() {
+	for s.offersUsed < s.maxOffersToConsume {
 		offer, offerKey, err := s.getNextOfferSkipVisited(sb, afView, ofrsToRm, visited, !consumed)
 		if err != nil {
 			break
@@ -551,78 +559,14 @@ func (s *BookStep) forEachOffer(
 		}
 	}
 
-	// Trailing-offer drain: rippled's forEachOffer do-while keeps stepping the
-	// book tip after the requested amount is satisfied, but ONLY when the last
-	// crossed tip was fully consumed (eachOffer returned true). That extra
-	// offers.step() first deletes the just-consumed tip from the working view
-	// (BookTip::step), then grooms the contiguous run of unfunded/tiny offers
-	// behind it before execOffer's remainingOut==0 guard stops the walk. goXRPL's
-	// main loop stops as soon as the demand is met (remainingZero), so it never
-	// reaches those trailing offers; replay that bounded step() here.
-	//
-	// removeConsumedTipIfUnfunded deletes the just-consumed funded-cap tip, and
-	// drainTrailingOffers advances through the run — getNextOfferSkipVisited's
-	// single funded rule grooms each found/became unfunded or tiny offer it steps
-	// over (perm or working-sandbox drop), and the self-cross clause removes the
-	// taker's own offers at the tier — stopping at the first funded survivor.
-	//
-	// When demand is met by a PARTIAL fill of a still-funded tip, eachOffer
-	// returns offer.fully_consumed()==false, the do-while breaks WITHOUT another
-	// offers.step(), and trailing offers are never reached — so the drain must not
-	// fire (lastTipFullyConsumed gate).
-	// Reference: rippled BookStep.cpp forEachOffer do-while 859-863; OfferStream.cpp
-	// step 234-404; limitSelfCrossQuality.
-	if consumed && s.lastTipFullyConsumed && remainingZero() {
-		if s.lastConsumedTipValid {
-			s.removeConsumedTipIfUnfunded(sb)
-		}
-		s.drainTrailingOffers(sb, afView, ofrsToRm, visited, currentQuality)
-	}
+	// The trailing groom is no longer a separate gated drain: the do-while above
+	// runs one more getNextOfferSkipVisited after the demand-meeting take, which
+	// grooms the trailing unfunded/became/tiny run in this (committed) pass before
+	// the next callback returns false — matching rippled's `while(offers.step())`.
 
 	// If no CLOB offers found, try the AMM alone.
 	if firstCLOB {
 		tryAMM(nil)
-	}
-}
-
-// drainTrailingOffers replays rippled's forEachOffer do-while after the requested
-// amount has been satisfied: it keeps stepping the book tip, letting
-// getNextOfferSkipVisited groom the contiguous run of unfunded/tiny offers the
-// crossing left behind (its single funded rule), and removing the taker's own
-// self-crossed offers at or better than the limit on the locked tier (rippled's
-// limitSelfCrossQuality, which removes them "even if no crossing occurs"), until
-// the first funded, non-own survivor — where rippled's execOffer stops on
-// remainingOut==0.
-// Reference: rippled BookStep.cpp do-while 855-863; limitSelfCrossQuality 443-457.
-func (s *BookStep) drainTrailingOffers(
-	sb, afView *PaymentSandbox,
-	ofrsToRm, visited map[[32]byte]bool,
-	currentQuality *Quality,
-) {
-	selfCrossDrain := s.defaultPath && s.qualityLimit != nil &&
-		s.strandSrc == s.strandDst && currentQuality != nil
-	for s.offersUsed < s.maxOffersToConsume {
-		offer, offerKey, err := s.getNextOfferSkipVisited(sb, afView, ofrsToRm, visited, false)
-		if err != nil || offer == nil {
-			break
-		}
-		// getNextOfferSkipVisited already groomed every found/became unfunded or
-		// tiny offer it stepped over, so what it yields is a funded survivor or the
-		// taker's own offer. Remove an own self-cross offer at or better than the
-		// limit on the locked tier and keep stepping; otherwise stop at the funded,
-		// non-own survivor (rippled's execOffer break on remainingOut==0).
-		if selfCrossDrain {
-			if offerOwner, err := state.DecodeAccountID(offer.Account); err == nil &&
-				offerOwner == s.strandSrc {
-				offerQ := s.offerQuality(offer)
-				if offerQ.Value == currentQuality.Value && !offerQ.WorseThan(*s.qualityLimit) {
-					ofrsToRm[offerKey] = true
-					s.recordPermRm(offerKey)
-					continue
-				}
-			}
-		}
-		break
 	}
 }
 
@@ -724,6 +668,11 @@ func (s *BookStep) Rev(
 	// revImp callback: decide full vs partial take, consume, and update accumulators.
 	// Reference: rippled BookStep.cpp revImp callback lines 1056-1083.
 	revCallback := func(e offerExec) bool {
+		// rippled eachOffer: if (remainingOut <= 0) return false — demand already
+		// met, so the do-while breaks (the prior take's step already groomed the run).
+		if remainingOut.IsZero() {
+			return false
+		}
 		if e.stpOut.Compare(remainingOut) <= 0 {
 			// Full take
 			savedIns.insert(e.stpIn)
@@ -785,7 +734,11 @@ func (s *BookStep) Rev(
 			s.lastTipFullyConsumed = s.tipFullyConsumed(e)
 		}
 
-		return true
+		// rippled eachOffer return: a full take always returns true ("even if the
+		// payment is satisfied, we need to consume the offer"), so the do-while
+		// steps once more and grooms the trailing run; a partial fill returns
+		// offer.fully_consumed(). lastTipFullyConsumed carries exactly that value.
+		return s.lastTipFullyConsumed
 	}
 
 	s.forEachOffer(sb, afView, ofrsToRm, trIn, trOut,
@@ -841,6 +794,11 @@ func (s *BookStep) Fwd(
 	// pass cache, consume, and update accumulators.
 	// Reference: rippled BookStep.cpp fwdImp callback lines 1175-1240.
 	fwdCallback := func(e offerExec) bool {
+		// rippled fwd eachOffer: once the input is exhausted, break the do-while
+		// (the prior take's step already groomed the trailing run).
+		if remainingIn.IsZero() {
+			return false
+		}
 		if e.stpIn.Compare(remainingIn) <= 0 {
 			// Full take: rippled sets processMore = true and eachOffer returns
 			// true, so the do-while runs offers.step() again and grooms trailing
@@ -973,7 +931,10 @@ func (s *BookStep) Fwd(
 			s.lastTipFullyConsumed = s.tipFullyConsumed(e)
 		}
 
-		return true
+		// rippled fwd eachOffer return: processMore || offer.fully_consumed(). A
+		// full take continues (lastTipFullyConsumed true → another step grooms the
+		// trailing run); a partial fill returns offer.fully_consumed().
+		return s.lastTipFullyConsumed
 	}
 
 	s.forEachOffer(sb, afView, ofrsToRm, trIn, trOut,

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -477,64 +477,11 @@ func (s *BookStep) forEachOffer(
 			break
 		}
 
-		// These offers were already counted (and marked visited) by
-		// getNextOfferSkipVisited when it advanced to them, so the removals
-		// below must not double-count. In rippled the deep-frozen, unfunded and
-		// small-increased-quality checks live inside OfferStream::step, after
-		// counter_.step() has already counted the offer.
-
-		// Deep freeze check on the input (TakerPays) side.
-		// Deep-frozen offers are permanently removed from the order book.
-		// Reference: rippled OfferStream.cpp lines 280-292
-		{
-			offerOwnerDF, _ := state.DecodeAccountID(offer.Account)
-			if s.isDeepFrozen(sb, offerOwnerDF, s.book.In.Currency, s.book.In.Issuer) {
-				ofrsToRm[offerKey] = true
-				s.recordPermRm(offerKey)
-				continue
-			}
-		}
-
-		// Pre-execOffer checks (OfferStream level)
-		// Reference: rippled OfferStream::step() reads ownerFunds from view_ (sb).
-		if offer.TakerGets.IsZero() {
-			ofrsToRm[offerKey] = true
-			s.recordPermRm(offerKey)
-			continue
-		}
-		ownerFunds := s.getOfferFundedAmount(sb, offer)
-		if ownerFunds.IsZero() {
-			// Distinguish "found unfunded" from "became unfunded": if the
-			// owner's funds are still zero in the pristine afView, the offer was
-			// unfunded before any crossing modified the balance, so it is a
-			// permanent removal — kept even across a limiting-step reset. If the
-			// crossing drained the owner (funds nonzero in afView), it merely
-			// "became unfunded" and the removal stays conditional.
-			// Reference: rippled OfferStream::step() lines 314-341 (compares
-			// ownerFunds in view_ against cancelView_).
-			ofrsToRm[offerKey] = true
-			if s.getOfferFundedAmount(afView, offer).IsZero() {
-				s.recordPermRm(offerKey)
-			}
-			continue
-		}
-		if s.shouldRmSmallIncreasedQOffer(sb, offer, ownerFunds) {
-			// Distinguish "found tiny" from "became tiny", mirroring the
-			// found-unfunded branch above and rippled OfferStream::step
-			// (OfferStream.cpp:378-401): a small-increased-quality offer is a
-			// permanent removal (propagated to removableOffers) only when the
-			// owner's funds are unchanged from the pristine afView — i.e. it was
-			// already this tiny before any crossing. If the crossing drained the
-			// owner so the offer only just became tiny, it is removed in-band from
-			// the working sandbox but stays a conditional removal: rippled does
-			// NOT permRmOffer it, so it must not survive into removableOffers and
-			// be re-erased on a FillOrKill kill.
-			ofrsToRm[offerKey] = true
-			if s.getOfferFundedAmount(afView, offer).Compare(ownerFunds) == 0 {
-				s.recordPermRm(offerKey)
-			}
-			continue
-		}
+		// getNextOfferSkipVisited applied the single funded/groom rule as it
+		// stepped onto this offer (deep-frozen, zero-amount, found/became unfunded
+		// or tiny — rippled's OfferStream::step), so every offer it yields is
+		// funded and crossable, or the taker's own offer that execOffer's
+		// self-cross check removes. No funded check is repeated here.
 
 		// On the first funded CLOB offer, try the AMM with the LOB quality.
 		if firstCLOB {
@@ -545,20 +492,22 @@ func (s *BookStep) forEachOffer(
 			}
 			// If the AMM (sized up to the LOB quality) already satisfied the
 			// remaining output, stop before crossing the CLOB tip — rippled's
-			// forEachOffer ends at remainingOut==0 and never reaches the next
-			// offer, so the tip must not be touched (threaded) by a zero cross.
+			// forEachOffer ends at remainingOut==0 and never reaches the next offer,
+			// so the tip must not be touched by a zero cross.
 			//
-			// KNOWN NARROW DIVERGENCE (deferred): rippled's do-while still runs
-			// execOffer(offers.tip()) once after the AMM, and its
-			// limitSelfCrossQuality removes the taker's own self-crossed offer(s)
-			// (BookStep.cpp:756,855-863) before the remainingOut==0 callback stops
-			// the walk; the trailing-drain below (gated on a consumed CLOB tip) does
-			// not run here, so such self-crossed/groomable offers behind a
-			// demand-satisfying AMM are left on the book. A faithful fix applies the
-			// found/became/self-cross drain (clauses a/a'/b/c) starting at this tip,
-			// which restructures the trailing-drain gating and is unverifiable for
-			// byte-exactness without the nodestore replay seed; tracked with the
-			// #1027/#1029 seed-equipped follow-up rather than fixed speculatively.
+			// The self-crossed run behind a demand-satisfying AMM is NOT drained
+			// here: when the AMM offer's quality differs from the LOB tip (the
+			// changeSpotPriceQuality case), rippled's do-while breaks on the
+			// same-quality gate (ofrQ != offer.quality()) BEFORE limitSelfCrossQuality
+			// runs, so rippled leaves the self-cross too — removing it only on a later
+			// flow iteration whose AMM offer is suppressed (spot-price gate) and whose
+			// quality then matches. goXRPL's main loop reproduces that gate and removes
+			// the self-cross on that later iteration as well (verified against rippled
+			// testDirectToDirectPath, AMM B=320.02 with cam's offer1 removed). Draining
+			// the self-cross here unconditionally would instead break the gate and let
+			// the next iteration re-consume the AMM unbounded by any LOB tip, draining
+			// the pool past the taker's limit (B=309) — a divergence, not a fix.
+			// Reference: rippled BookStep.cpp forEachOffer do-while 855-863.
 			if remainingZero() {
 				break
 			}
@@ -604,118 +553,76 @@ func (s *BookStep) forEachOffer(
 
 	// Trailing-offer drain: rippled's forEachOffer do-while keeps stepping the
 	// book tip after the requested amount is satisfied, but ONLY when the last
-	// crossed tip was fully consumed (eachOffer returned true). In that case it
-	// runs offers.step() once more, which grooms the contiguous run of unfunded /
-	// tiny offers immediately behind the satisfying tip before execOffer's
-	// remainingOut==0 guard stops the walk. OfferStream::step grooms each such
-	// offer as it advances the tip:
-	//   - found-unfunded / found-tiny / expired → permRmOffer (perm removal)
-	//   - became-unfunded / became-tiny → deleted from the working view but NOT
-	//     permRmOffer (conditional)
-	// and limitSelfCrossQuality additionally removes the taker's own offers at or
-	// better than the limit on the funded tip the walk lands on. The walk stops at
-	// the first funded, non-own, non-groomable survivor. goXRPL's main loop above
-	// instead stops as soon as the demand is met (remainingZero), so it never
-	// reaches those trailing offers; replay that single bounded step() here.
+	// crossed tip was fully consumed (eachOffer returned true). That extra
+	// offers.step() first deletes the just-consumed tip from the working view
+	// (BookTip::step), then grooms the contiguous run of unfunded/tiny offers
+	// behind it before execOffer's remainingOut==0 guard stops the walk. goXRPL's
+	// main loop stops as soon as the demand is met (remainingZero), so it never
+	// reaches those trailing offers; replay that bounded step() here.
 	//
-	// This grooming applies on EVERY strand, not just offer crossing —
-	// OfferStream::step removes the unfunded run behind a fully-consumed tip on
-	// payment strands too (e.g. a payment whose limiting BookStep is re-executed
-	// at exactly its tip's funded output). Only the self-cross clause (b) is
-	// offer-crossing-specific.
-	//
-	// The became-unfunded test (a) is taken against the iteration base — the flow
-	// view after all PRIOR iterations but before THIS pass's (possibly
-	// over-extended) consumption — not the working sandbox. An over-walk that
-	// fully consumes a tip drains its owner in sb, which would falsely mark every
-	// trailing offer of that owner unfunded; but a limiting reset discards that
-	// over-consumption, and rippled leaves those offers (issue #1029). Anchoring
-	// the test to the iteration base grooms only an offer whose owner an EARLIER
-	// iteration already drained (a genuine became-unfunded that the final cross
-	// also sees), and spares one this pass merely over-consumed.
+	// removeConsumedTipIfUnfunded deletes the just-consumed funded-cap tip, and
+	// drainTrailingOffers advances through the run — getNextOfferSkipVisited's
+	// single funded rule grooms each found/became unfunded or tiny offer it steps
+	// over (perm or working-sandbox drop), and the self-cross clause removes the
+	// taker's own offers at the tier — stopping at the first funded survivor.
 	//
 	// When demand is met by a PARTIAL fill of a still-funded tip, eachOffer
 	// returns offer.fully_consumed()==false, the do-while breaks WITHOUT another
 	// offers.step(), and trailing offers are never reached — so the drain must not
 	// fire (lastTipFullyConsumed gate).
-	// Reference: rippled BookStep.cpp forEachOffer do-while 859-863, eachOffer
-	// 1041-1081 (rev) / 1252 (fwd); OfferStream.cpp step 234-404 (found vs became
-	// unfunded 314-341, found vs became tiny 343-404); limitSelfCrossQuality.
-	selfCrossDrain := s.defaultPath && s.qualityLimit != nil &&
-		s.strandSrc == s.strandDst && currentQuality != nil
-	iterBase := sb.IterationBase()
-	if iterBase == nil {
-		iterBase = afView
-	}
+	// Reference: rippled BookStep.cpp forEachOffer do-while 859-863; OfferStream.cpp
+	// step 234-404; limitSelfCrossQuality.
 	if consumed && s.lastTipFullyConsumed && remainingZero() {
-		// rippled's do-while calls offers.step() after a fully-consumed tip; that
-		// step()'s BookTip::step first deletes the just-consumed tip from the view
-		// (offerDelete of m_entry), then advances and grooms the run behind it.
-		// goXRPL's consumeOffer leaves a funded-cap full take in the book with a
-		// non-zero remainder (a became-unfunded tip), so delete it here first —
-		// otherwise the next flow iteration's strand re-sort and walk re-read its
-		// stale, better quality from the book directory. The deletion goes straight
-		// into the working sandbox (like consumeOffer's own erase and like
-		// BookTip::step's offerDelete on view_), NOT into ofrsToRm: it must follow
-		// the sandbox's reset/apply lifecycle so an over-extended reverse pass that
-		// a limiting-step reset discards rolls the deletion back too, and the
-		// re-executed final pass re-derives it.
 		if s.lastConsumedTipValid {
 			s.removeConsumedTipIfUnfunded(sb)
 		}
-		for s.offersUsed < s.maxOffersToConsume {
-			offer, offerKey, err := s.getNextOfferSkipVisited(sb, afView, ofrsToRm, visited, false)
-			if err != nil || offer == nil {
-				break
-			}
-			offerOwner, ownerErr := state.DecodeAccountID(offer.Account)
-			if ownerErr != nil {
-				break
-			}
-
-			// (a) found-unfunded / found-tiny: a perm removal regardless of owner
-			//     or tier. Expired offers are removed inside getNextOfferSkipVisited
-			//     and never yielded here.
-			if s.isFoundPermGroomable(sb, afView, offer) {
-				ofrsToRm[offerKey] = true
-				s.recordPermRm(offerKey)
-				continue
-			}
-
-			// (a') became-unfunded / became-tiny against the iteration base: groom
-			//     (conditional, not perm) only when an earlier iteration already
-			//     drained the owner, so the final cross sees it unfunded too. An
-			//     offer this pass merely over-consumed reads funded in iterBase and
-			//     is left for the funded-survivor break below.
-			if s.isBecameGroomableAgainst(iterBase, afView, offer) {
-				ofrsToRm[offerKey] = true
-				continue
-			}
-
-			// (b) own self-cross at or better than the limit on a FUNDED tip:
-			//     limitSelfCrossQuality removes it "even if no crossing occurs" and
-			//     execOffer returns true, so the do-while keeps stepping past it.
-			//     Offer-crossing only; restricted to the locked tier.
-			if selfCrossDrain {
-				offerQ := s.offerQuality(offer)
-				if offerOwner == s.strandSrc && offerQ.Value == currentQuality.Value &&
-					!offerQ.WorseThan(*s.qualityLimit) {
-					ofrsToRm[offerKey] = true
-					s.recordPermRm(offerKey)
-					continue
-				}
-			}
-
-			// (c) first funded, non-groomable survivor: step() breaks here and
-			//     execOffer returns false (tier change / remainingOut==0 /
-			//     checkQualityThreshold). Leave it.
-			break
-		}
+		s.drainTrailingOffers(sb, afView, ofrsToRm, visited, currentQuality)
 	}
 
 	// If no CLOB offers found, try the AMM alone.
 	if firstCLOB {
 		tryAMM(nil)
+	}
+}
+
+// drainTrailingOffers replays rippled's forEachOffer do-while after the requested
+// amount has been satisfied: it keeps stepping the book tip, letting
+// getNextOfferSkipVisited groom the contiguous run of unfunded/tiny offers the
+// crossing left behind (its single funded rule), and removing the taker's own
+// self-crossed offers at or better than the limit on the locked tier (rippled's
+// limitSelfCrossQuality, which removes them "even if no crossing occurs"), until
+// the first funded, non-own survivor — where rippled's execOffer stops on
+// remainingOut==0.
+// Reference: rippled BookStep.cpp do-while 855-863; limitSelfCrossQuality 443-457.
+func (s *BookStep) drainTrailingOffers(
+	sb, afView *PaymentSandbox,
+	ofrsToRm, visited map[[32]byte]bool,
+	currentQuality *Quality,
+) {
+	selfCrossDrain := s.defaultPath && s.qualityLimit != nil &&
+		s.strandSrc == s.strandDst && currentQuality != nil
+	for s.offersUsed < s.maxOffersToConsume {
+		offer, offerKey, err := s.getNextOfferSkipVisited(sb, afView, ofrsToRm, visited, false)
+		if err != nil || offer == nil {
+			break
+		}
+		// getNextOfferSkipVisited already groomed every found/became unfunded or
+		// tiny offer it stepped over, so what it yields is a funded survivor or the
+		// taker's own offer. Remove an own self-cross offer at or better than the
+		// limit on the locked tier and keep stepping; otherwise stop at the funded,
+		// non-own survivor (rippled's execOffer break on remainingOut==0).
+		if selfCrossDrain {
+			if offerOwner, err := state.DecodeAccountID(offer.Account); err == nil &&
+				offerOwner == s.strandSrc {
+				offerQ := s.offerQuality(offer)
+				if offerQ.Value == currentQuality.Value && !offerQ.WorseThan(*s.qualityLimit) {
+					ofrsToRm[offerKey] = true
+					s.recordPermRm(offerKey)
+					continue
+				}
+			}
+		}
+		break
 	}
 }
 

--- a/internal/tx/payment/step_book_counter_test.go
+++ b/internal/tx/payment/step_book_counter_test.go
@@ -117,6 +117,10 @@ func TestBookStep_ErasesDanglingDirectoryEntry(t *testing.T) {
 	gwStr := state.EncodeAccountIDSafe(gw)
 
 	view := newPaymentMockLedgerView()
+	// Fund the owner above the reserve so the real offer is a funded survivor the
+	// walk yields — getNextOfferSkipVisited now applies the funded/groom rule and
+	// would otherwise groom an unfunded owner's offer, leaving nothing to return.
+	view.createAccount(owner, 1_000_000_000, 1)
 
 	inIssue := Issue{Currency: "USD", Issuer: gw}
 	outIssue := Issue{Currency: "XRP"}

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -206,6 +206,32 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 					continue
 				}
 
+				// The single funded/groom rule, applied to every offer the walk
+				// steps onto and read from the live working sandbox — rippled's
+				// OfferStream::step. A deep-frozen or zero-amount offer is a
+				// permanent removal; an unfunded or tiny/increased-quality offer is
+				// classified FOUND (still unfunded/tiny in the pristine afView →
+				// permanent, survives a limiting-step reset) or BECAME (this flow's
+				// crossing drained the owner → a plain working-sandbox delete that
+				// rides the sandbox reset/apply lifecycle, never the permanent
+				// removableOffers set). Only a funded, non-groomable offer is
+				// yielded for crossing, so the main loop and trailing drain no
+				// longer repeat any funded check.
+				// Reference: rippled OfferStream.cpp step() lines 271-404.
+				offerOwner, ownerErr := state.DecodeAccountID(offer.Account)
+				if ownerErr != nil {
+					continue
+				}
+				if offer.TakerGets.IsZero() ||
+					s.isDeepFrozen(sb, offerOwner, s.book.In.Currency, s.book.In.Issuer) {
+					ofrsToRm[offerKey] = true
+					s.recordPermRm(offerKey)
+					continue
+				}
+				if s.groomUnfundedOffer(sb, afView, offer, offerKey, offerOwner, ofrsToRm) {
+					continue
+				}
+
 				return offer, offerKey, nil
 			}
 
@@ -277,33 +303,54 @@ func (s *BookStep) offerOutOfDomain(sb *PaymentSandbox, offer *state.LedgerOffer
 	return !permissioneddomain.OfferInDomain(sb, offer, offer.DomainID, s.parentCloseTime)
 }
 
-// isBecameGroomableAgainst reports whether the trailing offer is a BECAME
-// removal (unfunded or tiny) when its owner's funds are read from baseView — the
-// flow's iteration base, i.e. the state after all PRIOR iterations but before
-// the current strand pass's consumption — yet was funded before this whole flow
-// ran (pristine afView). This is rippled's OfferStream::step grooming a became-
-// unfunded/became-tiny offer the cross advances over: its owner was drained by
-// an earlier cross, so the offer is genuinely gone, but it is a conditional (not
-// perm) removal. Reading from baseView rather than the working sandbox is what
-// distinguishes a truly-drained owner from one the current over-walk merely
-// over-consumed (whose drain a limiting reset discards), matching the offers
-// rippled actually deletes. The found cases (unfunded/tiny in pristine afView
-// too) are handled separately by isFoundPermGroomable, so this returns false for
-// them to avoid double-classifying a perm removal as conditional.
-func (s *BookStep) isBecameGroomableAgainst(baseView, afView *PaymentSandbox, offer *state.LedgerOffer) bool {
-	fundsBase := s.getOfferFundedAmount(baseView, offer)
-	fundsAf := s.getOfferFundedAmount(afView, offer)
-	if fundsBase.IsZero() {
-		// Unfunded in the iteration base; a BECAME removal only if it was funded
-		// pre-flow (otherwise isFoundPermGroomable already handles the found case).
-		return !fundsAf.IsZero()
+// groomUnfundedOffer applies rippled's single OfferStream::step funds rule to an
+// offer the book walk has advanced onto, reading the owner's funds from the live
+// working sandbox. It removes the offer and reports true when the owner is
+// unfunded or holds only a tiny/increased-quality residue, classifying the
+// removal by one comparison against the pristine afView:
+//   - FOUND (also unfunded/tiny in afView → this flow did not touch the owner):
+//     a permanent removal recorded in ofrsToRm/permRm, which survives a
+//     limiting-step reset and is erased from both views regardless of TER.
+//   - BECAME (funded in afView → this flow's crossing drained the owner): a plain
+//     working-sandbox delete via dropBecameOffer, which rides the sandbox
+//     reset/apply lifecycle — rolled back with an over-extended pass and applied
+//     only when the crossing commits, never the permanent removableOffers set.
+//
+// A funded, non-groomable offer is left untouched and reports false.
+// Reference: rippled OfferStream.cpp step() lines 314-341 (unfunded) and 378-404
+// (tiny); found-vs-became is the cancelView_ comparison at lines 328 / 388.
+func (s *BookStep) groomUnfundedOffer(sb, afView *PaymentSandbox, offer *state.LedgerOffer, offerKey [32]byte, owner [20]byte, ofrsToRm map[[32]byte]bool) bool {
+	funds := s.getOfferFundedAmount(sb, offer)
+	if funds.IsZero() {
+		if s.getOfferFundedAmount(afView, offer).IsZero() {
+			ofrsToRm[offerKey] = true
+			s.recordPermRm(offerKey)
+		} else {
+			s.dropBecameOffer(sb, offer, owner)
+		}
+		return true
 	}
-	if s.shouldRmSmallIncreasedQOffer(baseView, offer, fundsBase) {
-		// Tiny in the iteration base; a BECAME-tiny removal only if its pre-flow
-		// funds differ (a found-tiny offer is the perm case handled elsewhere).
-		return fundsAf.Compare(fundsBase) != 0
+	if s.shouldRmSmallIncreasedQOffer(sb, offer, funds) {
+		if s.getOfferFundedAmount(afView, offer).Compare(funds) == 0 {
+			ofrsToRm[offerKey] = true
+			s.recordPermRm(offerKey)
+		} else {
+			s.dropBecameOffer(sb, offer, owner)
+		}
+		return true
 	}
 	return false
+}
+
+// dropBecameOffer deletes a BECAME-unfunded/tiny offer straight from the working
+// sandbox — the same erase path consumeOffer uses for a zero-remainder tip and
+// the view offerDelete rippled's BookTip::step performs on advance — so the
+// removal follows the sandbox reset/apply lifecycle rather than the permanent
+// removableOffers set. Reference: rippled OfferStream.cpp 333-340 (became
+// unfunded: deleted from view_ but not added to permToRemove_).
+func (s *BookStep) dropBecameOffer(sb *PaymentSandbox, offer *state.LedgerOffer, owner [20]byte) {
+	txHash, ledgerSeq := sb.GetTransactionContext()
+	_ = s.deleteOffer(sb, offer, owner, txHash, ledgerSeq)
 }
 
 // tipFullyConsumed reports whether the offer just consumed by the callback is now

--- a/internal/tx/payment/strand_flow.go
+++ b/internal/tx/payment/strand_flow.go
@@ -187,17 +187,19 @@ func ExecuteStrand(
 	// Reference: rippled StrandFlow.h line 130: size_t limitingStep = strand.size()
 	limitingStep := s
 	sb := NewChildSandbox(baseView)
-	// afView: the "all funds" view that tells a FOUND removal (an offer already
-	// unfunded/tiny before the flow ran) from a BECAME removal (one this flow's
-	// crossing drained). The caller threads afBaseView — a child of the pristine
-	// pre-flow view that the per-pass applies never touch — so the found-vs-became
-	// test stays anchored to pre-flow funds across a multi-pass crossing. When no
-	// such baseline is supplied (unit tests, single-pass callers), afView falls
-	// back to baseView, which the strand never modifies.
-	afView := baseView
-	if afBaseView != nil {
-		afView = afBaseView
-	}
+	// afView ("all funds" view) is a fresh child of the RUNNING sandbox, exactly
+	// like rippled's afView(&baseView) (StrandFlow.h:135), where baseView is the
+	// running multi-strand sandbox. It therefore reflects every prior committed
+	// iteration (best-strand applies AND the per-iteration offerDeletes), so an
+	// offer whose owner a PRIOR iteration drained reads unfunded here too. The
+	// found-vs-became test then classifies it FOUND-unfunded and promotes it to a
+	// perm removal that the multi-strand loop offerDeletes from the running view —
+	// matching rippled. Anchoring afView to a pristine pre-flow baseline instead
+	// kept such an offer classified BECAME (a discardable working-sandbox delete)
+	// and left it in the book across a multi-iteration crossing (the 99243845
+	// beyond-limit drained-maker offer that #1118 regressed).
+	_ = afBaseView
+	afView := NewChildSandbox(baseView)
 	var limitStepOut EitherAmount
 
 	// === REVERSE PASS ===
@@ -248,8 +250,11 @@ func ExecuteStrand(
 		} else if !step.EqualOut(actualOut, stepOut) {
 			// Limiting step found — actualOut < requested stepOut
 			// Reset BOTH sandboxes and re-execute ONLY this step
-			// Reference: rippled StrandFlow.h lines 180-217
+			// Reference: rippled StrandFlow.h lines 180-217. rippled resets BOTH sb
+			// (184) AND afView (185) on this branch (unlike the maxIn branch, which
+			// resets only sb at 152), so afView is re-rooted on the running sandbox.
 			sb.Reset()
+			afView.Reset()
 			limitingStep = i
 
 			// Re-execute with the limited output

--- a/internal/tx/payment/strand_flow.go
+++ b/internal/tx/payment/strand_flow.go
@@ -147,13 +147,13 @@ func ExecuteStrand(
 	// restorePermRemovals unions every BookStep's unconditional ("perm")
 	// removals back into ofrsToRm. These are rippled's FlowOfferStream
 	// permToRemove offers (self-crossed, authorization-failed, expired,
-	// deep-frozen, domain-removed) which survive "even if the strand is not
-	// applied" and are never rolled back by a limiting-step reset. A reset's
-	// over-walk discard (deferredDiscard) targets only "became unfunded"
-	// removals; calling this afterwards guarantees a perm removal a discarded
-	// over-walk produced is kept, matching rippled's monotonic permToRemove.
-	// Reference: rippled OfferStream.h permToRemove_; StrandFlow.h (ofrsToRm is
-	// passed by reference into every rev/fwd and never reset).
+	// deep-frozen, domain-removed, found-unfunded, found-tiny) which survive "even
+	// if the strand is not applied" and are never rolled back by a limiting-step
+	// reset. It guarantees ofrsToRm carries the full perm set on the failure and
+	// success exits even though the per-step writes already accumulate it, matching
+	// rippled's monotonic permToRemove. Reference: rippled OfferStream.h
+	// permToRemove_; StrandFlow.h (ofrsToRm is passed by reference into every
+	// rev/fwd and never reset).
 	restorePermRemovals := func() {
 		for _, step := range strand {
 			bs, ok := step.(*BookStep)
@@ -205,36 +205,15 @@ func ExecuteStrand(
 	// Reference: rippled StrandFlow.h lines 138-221
 	stepOut := requestedOut
 
-	// deferredDiscard maps each offer a limiting step removed during its
-	// over-extended reverse walk to the strand index of that step. Whether the
-	// removal survives depends on what ultimately limited the strand:
-	//   - if a step closer to the input (lower index) limited further
-	//     (limitingStep < recorded index), the over-walk requested more output
-	//     than the input could buy, so those extra offers were never really
-	//     reached — their removals are spurious and stay discarded.
-	//   - otherwise the recording step is itself the final limiting step: the
-	//     offers were genuinely reached and their owners drained by the actual
-	//     cross, so rippled removes them — the removals must be restored.
-	deferredDiscard := make(map[[32]byte]int)
-
+	// ofrsToRm now holds only perm removals (rippled's permToRemove_): every offer
+	// the grooming rule adds here is paired with recordPermRm, while a BECAME
+	// removal is a working-sandbox delete that the sb.Reset() below rolls back on a
+	// limiting step. So, like rippled's monotonic permToRemove_, this set is never
+	// discarded on a reset — a perm removal an over-walk produced is genuinely
+	// removable (already unfunded/tiny in the pristine view) and survives even when
+	// the strand is reset or fails. Reference: rippled OfferStream.h permToRemove_.
 	for i := s - 1; i >= 0; i-- {
 		step := strand[i]
-
-		// Snapshot the offers-to-remove set before this step's (possibly
-		// over-extended) reverse walk, so a limiting-step reset can drop the
-		// removals the over-walk added; see maxInCapped/deferredDiscard above for
-		// when those are later restored.
-		rmBefore := make(map[[32]byte]bool, len(ofrsToRm))
-		for k := range ofrsToRm {
-			rmBefore[k] = true
-		}
-		restoreRmAfterReset := func() {
-			for k := range ofrsToRm {
-				if !rmBefore[k] {
-					delete(ofrsToRm, k)
-				}
-			}
-		}
 
 		actualIn, actualOut := step.Rev(sb, afView, ofrsToRm, stepOut)
 
@@ -248,7 +227,6 @@ func ExecuteStrand(
 			// Reset sandbox and re-execute step 0 with Fwd(maxIn)
 			// Reference: rippled StrandFlow.h lines 148-178
 			sb.Reset()
-			restoreRmAfterReset()
 			limitingStep = 0
 
 			fwdIn, fwdOut := step.Fwd(sb, afView, ofrsToRm, *maxIn)
@@ -272,12 +250,6 @@ func ExecuteStrand(
 			// Reset BOTH sandboxes and re-execute ONLY this step
 			// Reference: rippled StrandFlow.h lines 180-217
 			sb.Reset()
-			for k := range ofrsToRm {
-				if !rmBefore[k] {
-					deferredDiscard[k] = i
-				}
-			}
-			restoreRmAfterReset()
 			limitingStep = i
 
 			// Re-execute with the limited output
@@ -304,16 +276,6 @@ func ExecuteStrand(
 		} else {
 			// Not limiting — continue to previous step
 			stepOut = actualIn
-		}
-	}
-
-	// Restore a deferred over-walk removal only when its recording step is the
-	// final limiting step (no lower-index step reduced the throughput further).
-	// If a step closer to the input limited more (limitingStep < idx), the cross
-	// never actually reached that offer, so the removal stays discarded.
-	for k, idx := range deferredDiscard {
-		if limitingStep >= idx {
-			ofrsToRm[k] = true
 		}
 	}
 

--- a/internal/tx/payment/strand_flow.go
+++ b/internal/tx/payment/strand_flow.go
@@ -81,16 +81,12 @@ func strandPermRemovals(strand Strand, dst map[[32]byte]bool) {
 // (e.g., trust lines that increase reserves) that would poison earlier steps
 // if not reset.
 //
-// afBaseView is the pristine pre-flow baseline used for the found-vs-became
-// removal test (see the afView comment below); pass nil to fall back to baseView.
-//
 // Reference: rippled/src/xrpld/app/paths/detail/StrandFlow.h flow()
 func ExecuteStrand(
 	baseView *PaymentSandbox,
 	strand Strand,
 	maxIn *EitherAmount,
 	requestedOut EitherAmount,
-	afBaseView *PaymentSandbox,
 ) (result StrandResult) {
 	if len(strand) == 0 {
 		return StrandResult{
@@ -198,7 +194,6 @@ func ExecuteStrand(
 	// kept such an offer classified BECAME (a discardable working-sandbox delete)
 	// and left it in the book across a multi-iteration crossing (the 99243845
 	// beyond-limit drained-maker offer that #1118 regressed).
-	_ = afBaseView
 	afView := NewChildSandbox(baseView)
 	var limitStepOut EitherAmount
 

--- a/internal/tx/payment/strand_flow_test.go
+++ b/internal/tx/payment/strand_flow_test.go
@@ -98,7 +98,7 @@ func TestExecuteStrand_FlowErrorDiscardsPhantomTotals(t *testing.T) {
 		},
 	}
 
-	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000), nil)
+	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000))
 
 	require.False(t, result.Success, "strand must fail on flowError, not return phantom totals")
 	require.True(t, result.Out.IsZero(), "failed strand must report zero output")
@@ -121,7 +121,7 @@ func TestExecuteStrand_NonFlowErrorPanicPropagates(t *testing.T) {
 	}
 
 	require.PanicsWithValue(t, "genuine bug, not a flowError", func() {
-		ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000), nil)
+		ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000))
 	})
 }
 
@@ -142,7 +142,7 @@ func TestExecuteStrand_DryStrandReportsOffersUsed(t *testing.T) {
 		},
 	}
 
-	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000), nil)
+	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000))
 
 	require.False(t, result.Success, "dry strand must fail")
 	require.Equal(t, uint32(7), result.OffersUsed, "dry strand must report offers its steps consumed")
@@ -164,7 +164,7 @@ func TestExecuteStrand_FlowErrorReportsOffersUsed(t *testing.T) {
 		},
 	}
 
-	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000), nil)
+	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000))
 
 	require.False(t, result.Success, "flowError strand must fail")
 	require.Equal(t, uint32(4), result.OffersUsed, "flowError strand must report offers its steps consumed")
@@ -261,7 +261,7 @@ func TestExecuteStrand_FirstStepMaxInGuard(t *testing.T) {
 		},
 	}
 
-	result := ExecuteStrand(sandbox, Strand{step}, &maxIn, NewXRPEitherAmount(20_000_000), nil)
+	result := ExecuteStrand(sandbox, Strand{step}, &maxIn, NewXRPEitherAmount(20_000_000))
 
 	require.False(t, result.Success, "first-step maxIn mismatch must fail the strand")
 	require.True(t, result.Out.IsZero())
@@ -288,7 +288,7 @@ func TestExecuteStrand_LimitingStepGuard(t *testing.T) {
 		},
 	}
 
-	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000), nil)
+	result := ExecuteStrand(sandbox, Strand{step}, nil, NewXRPEitherAmount(10_000_000))
 
 	require.False(t, result.Success, "limiting-step re-execution mismatch must fail the strand")
 	require.True(t, result.Out.IsZero())
@@ -321,7 +321,7 @@ func TestExecuteStrand_ForwardPassGuard(t *testing.T) {
 		},
 	}
 
-	result := ExecuteStrand(sandbox, Strand{step0, step1}, nil, NewXRPEitherAmount(10_000_000), nil)
+	result := ExecuteStrand(sandbox, Strand{step0, step1}, nil, NewXRPEitherAmount(10_000_000))
 
 	require.False(t, result.Success, "forward-pass re-execution mismatch must fail the strand")
 	require.True(t, result.Out.IsZero())


### PR DESCRIPTION
## Summary

goXRPL split rippled's single `OfferStream::step` grooming rule into **four** view-anchored funded checks (main-loop, per-advance, trailing-drain `iterBase`, beyond-limit). Every new book topology surfaced another seam — #1075, #1076, #1083, #1089, and a fresh mainnet divergence at **ledger 99248432**, where a maker's same-quality siblings, drained by the current pass's funded cap *after* demand was met, were left on the book.

This adopts rippled's single-rule shape (issue #1114 §6):

- **One funded check per stepped-over offer**, moved into the advance (`getNextOfferSkipVisited`), read from the **live** working sandbox. FOUND (still unfunded/tiny in the pristine `afView`) → permanent removal (`ofrsToRm` + `recordPermRm`); BECAME (this flow drained the owner) → a plain working-sandbox `deleteOffer` that rides the reset/apply lifecycle (applied on commit, discarded on a limiting reset), exactly like rippled's working-view `offerDelete` — never the durable `removableOffers` set.
- `ofrsToRm` is therefore **purely the perm set** (rippled's `permToRemove_`), so the `iterBase` anchor (`isBecameGroomableAgainst`, `PaymentSandbox.IterationBase`) and the conditional-removal machinery (`strand_flow` `deferredDiscard`/`rmBefore`/`restoreRmAfterReset`, `flow` `condOfrsToRm`/`strandCond`) become dead and are removed.
- The trailing drain collapses to advancing the (now self-grooming) walk plus the self-cross removal; the main loop just crosses funded survivors.

Net **−150 LOC** in `internal/tx/payment`, with no new conformance regressions.

The firstCLOB AMM-satisfies-demand corner is intentionally left as a plain `break`: when the AMM offer's quality differs from the LOB tip, rippled's same-quality gate (`ofrQ != offer.quality()`) also defers the self-cross removal to a later flow iteration — which goXRPL already reproduces. Verified against rippled `testDirectToDirectPath` (AMM `B_BUX=320.02` with the self-cross offer removed); the test now asserts rippled's `expectOffers(cam, 1)` too. Unconditionally draining there instead re-consumes the AMM unbounded past the taker's limit, so it stays gated off.

## Test plan

- [x] `just test-pkg ./internal/tx/payment/...` — unit suite
- [x] `just test-pkg ./internal/testing/offer/...` — full crossing scenarios (self-cross, FillOrKill, unfunded pruning, crossing limits)
- [x] `just test-pkg ./internal/testing/amm/...` — incl. `TestAMMBookStep_DirectToDirectPath` with the added rippled offer-count assertion
- [x] `just test-pkg ./internal/testing/payment/...`
- [x] `just conformance Offer` → 396/396; `AMM` 96/98 (2 failures pre-exist on `main`, identical)
- [x] `just lint` → 0 issues
- [x] New `TestOffer_DrainedMakerSiblingsGroomed` reproduces 99248432: **fails on the prior code** (two siblings left on the book), passes here
- [ ] Mainnet byte-exact replay of ledger 99248432 (needs the seed-cache lab) — remaining confirmation step

Fixes #1114