### PR TITLE
fix(conformance): fee-vote reserve for NFTokenBurn/Dir fixtures; trim out-of-scope

### DIFF
--- a/internal/testing/conformance/runner.go
+++ b/internal/testing/conformance/runner.go
@@ -456,6 +456,18 @@ var feeVoteLookup = map[string]feeVoteConfig{
 	"ripple.app.PayChan/Account Delete":     {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 256},
 	"ripple.app.AMM/Auto Delete":            {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 257},
 	"ripple.app.AccountDelete/Resurrection": {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 256},
+	// The NFTokenBurn "Burn random" fixtures (replayed across five amendment
+	// variants) and NFTokenDir "NFToken consecutive packing" fund accounts with
+	// 10,000 XRP yet drive them past 400 owned objects — only affordable under
+	// the post-vote 10/2 XRP reserve, not the 200/50 the env block seeds at
+	// genesis. Accounts first cross the 196-object 200/50 ceiling around ledger
+	// 640, well after the seq-256 flag ledger, so the vote is already in effect.
+	"ripple.app.NFTokenBurnBaseUtil/Burn random":          {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 256},
+	"ripple.app.NFTokenBurnAllFeatures/Burn random":       {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 256},
+	"ripple.app.NFTokenBurnWOfixFungTokens/Burn random":   {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 256},
+	"ripple.app.NFTokenBurnWOFixNFTPageLinks/Burn random": {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 256},
+	"ripple.app.NFTokenBurnWOFixTokenRemint/Burn random":  {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 256},
+	"ripple.app.NFTokenDir/NFToken consecutive packing":   {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 256},
 }
 
 // txqTimeLeapLookup maps TxQ fixture test case names to the step indices

--- a/internal/testing/conformance/runner.go
+++ b/internal/testing/conformance/runner.go
@@ -456,12 +456,9 @@ var feeVoteLookup = map[string]feeVoteConfig{
 	"ripple.app.PayChan/Account Delete":     {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 256},
 	"ripple.app.AMM/Auto Delete":            {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 257},
 	"ripple.app.AccountDelete/Resurrection": {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 256},
-	// The NFTokenBurn "Burn random" fixtures (replayed across five amendment
-	// variants) and NFTokenDir "NFToken consecutive packing" fund accounts with
-	// 10,000 XRP yet drive them past 400 owned objects — only affordable under
-	// the post-vote 10/2 XRP reserve, not the 200/50 the env block seeds at
-	// genesis. Accounts first cross the 196-object 200/50 ceiling around ledger
-	// 640, well after the seq-256 flag ledger, so the vote is already in effect.
+	// These fixtures fund accounts with 10,000 XRP but exceed the object count
+	// affordable under the 200/50 XRP reserve the env seeds at genesis; they only
+	// pass once the seq-256 fee vote drops the reserve to 10/2.
 	"ripple.app.NFTokenBurnBaseUtil/Burn random":          {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 256},
 	"ripple.app.NFTokenBurnAllFeatures/Burn random":       {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 256},
 	"ripple.app.NFTokenBurnWOfixFungTokens/Burn random":   {BaseFee: 10, ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 256},

--- a/scripts/conformance-out-of-scope.txt
+++ b/scripts/conformance-out-of-scope.txt
@@ -5,23 +5,8 @@
 # To bring a suite into scope, remove or comment out the line.
 
 # Not implemented yet
-app/Vault
 app/Batch
-app/EscrowToken
+app/Delegate
+app/Vault
 app/XChain
 app/XChainSim
-app/Delegate
-app/Credentials
-
-# Partially implemented / known gaps
-app/NFTokenAuth
-app/NFTokenBurnAllFeatures
-app/NFTokenBurnBaseUtil
-app/NFTokenBurnWOfixFungTokens
-app/NFTokenBurnWOFixNFTPageLinks
-app/NFTokenBurnWOFixTokenRemint
-app/NFTokenDir
-app/Regression
-app/ThinBook
-app/Transaction_ordering
-ledger/BookDirs


### PR DESCRIPTION
## Summary

Two changes that bring the implemented NFToken conformance suites into scope and green:

1. **Fix the `Burn_random` / `NFToken consecutive packing` failures (6 tests) — a harness gap, not a protocol bug.**
2. **Trim `conformance-out-of-scope.txt`** to only the genuinely-unimplemented suites.

## Root cause (b)

The `NFTokenBurn*/Burn random` fixtures (5 amendment variants) and `NFTokenDir/NFToken consecutive packing` are recorded by rippled *after* its validator fee vote drops the reserve from the unit-test genesis seed (200 XRP base / 50 XRP increment, set in `jtx/impl/envconfig.cpp`) to the mainnet default (**10 XRP / 2 XRP**) at the seq-256 flag ledger.

go-xrpl's conformance runner does not implement fee voting — it replays this reduction only for fixtures hardcoded in `feeVoteLookup`. These NFToken fixtures were missing, so the runner kept 200/50 and **correctly** returned `tecINSUFFICIENT_RESERVE` once an account passed 196 owned objects. But the fixtures drive accounts to `ownerCount=424` funded with only 10,000 XRP — affordable only under 10/2 (needs 858 XRP) and impossible under 200/50 (needs 21,400 XRP). The 629 cascading `owner_count mismatch` errors all flowed from that one wrong-reserve rejection.

**Fix:** add the six failing testcases to `feeVoteLookup` with `{ReserveBase: 10_000_000, ReserveIncrement: 2_000_000, FlagLedgerSeq: 256}`, mirroring the existing PayChan/AMM/AccountDelete entries. Accounts first cross the 196-object 200/50 ceiling around ledger 640, well after the seq-256 flag ledger, so the vote is already in effect. **The NFTokenPage owner-count accounting and the offer reserve-check code are correct and unchanged.**

## Scope trim (a)

`conformance-out-of-scope.txt` previously hid the NFTokenAuth, NFTokenBurn\*, NFTokenDir, EscrowToken, Regression, Credentials, ThinBook, Transaction_ordering and BookDirs suites — all of which are implemented. Trimmed it to the genuinely-unimplemented set: **Batch, Delegate, Vault, XChain, XChainSim**. The fee-vote rationale now lives in a `runner.go` comment.

## Verification

- `NFTokenBurn*`: **24 pass / 0 fail**; `NFTokenDir`: **5 / 0** — all 6 previously-failing tests pass.
- Full conformance: **1315 pass / 200 fail** (was 1309 / 206 — exactly the 6 fixed). In-scope **1250 / 17 (98.6%)**.
- NFToken unit tests pass; `gofmt` / `go vet` clean; **no regressions** (every previously-green suite still green).

The remaining 17 in-scope failures (now honestly visible, pre-existing) are: AMM 2, NFTokenAuth 4, TxQMetaInfo 3, TxQPosNegFlows 2, EscrowToken 2, AccountDelete 1, DepositAuth 1, Regression 1, ledger/PaymentSandbox 1.