### PR TITLE
fix(engine): retryable insufficient-fee on any open view, not just open ledger

### DIFF
--- a/internal/tx/engine/checkfee_loadfeetrack_test.go
+++ b/internal/tx/engine/checkfee_loadfeetrack_test.go
@@ -128,14 +128,11 @@ func TestCheckFee_EnforceLoadFee(t *testing.T) {
 	}
 }
 
-// TestCheckFee_InsufficientBalance verifies the balance-below-fee branch of
-// checkFee, mirroring rippled Transactor::checkFee: the deterministic
-// tecINSUFF_FEE fires only when the balance is non-zero AND the view is closed
-// (!ctx.view.open()); a zero balance or any open view stays retryable as
-// terINSUF_FEE_B. The view is open whenever IsViewOpen() is true — the direct
-// open-ledger path (OpenLedger), the TxQ apply/accept paths (EnforceLoadFee),
-// or the open-ledger submit / held-tx replay path (ViewOpen) — not just
-// OpenLedger.
+// TestCheckFee_InsufficientBalance covers the balance-below-fee branch:
+// deterministic tecINSUFF_FEE only when balance>0 AND the view is closed, else
+// the retryable terINSUF_FEE_B. The view counts as open for OpenLedger, the TxQ
+// paths (EnforceLoadFee), or the open-ledger submit path (ViewOpen) — not just
+// OpenLedger. Reference: rippled Transactor::checkFee.
 func TestCheckFee_InsufficientBalance(t *testing.T) {
 	const baseFee = 10
 

--- a/internal/tx/engine/checkfee_loadfeetrack_test.go
+++ b/internal/tx/engine/checkfee_loadfeetrack_test.go
@@ -129,33 +129,45 @@ func TestCheckFee_EnforceLoadFee(t *testing.T) {
 }
 
 // TestCheckFee_InsufficientBalance verifies the balance-below-fee branch of
-// checkFee, mirroring rippled Transactor::checkFee lines 304-316: on a closed
-// ledger a non-zero balance below the fee is a deterministic tecINSUFF_FEE,
-// while a zero balance (or any open-ledger case) stays retryable as
-// terINSUF_FEE_B.
+// checkFee, mirroring rippled Transactor::checkFee: the deterministic
+// tecINSUFF_FEE fires only when the balance is non-zero AND the view is closed
+// (!ctx.view.open()); a zero balance or any open view stays retryable as
+// terINSUF_FEE_B. The view is open whenever IsViewOpen() is true — the direct
+// open-ledger path (OpenLedger), the TxQ apply/accept paths (EnforceLoadFee),
+// or the open-ledger submit / held-tx replay path (ViewOpen) — not just
+// OpenLedger.
 func TestCheckFee_InsufficientBalance(t *testing.T) {
 	const baseFee = 10
 
 	tests := []struct {
-		name       string
-		balance    uint64
-		openLedger bool
-		want       ter.Result
+		name           string
+		balance        uint64
+		openLedger     bool
+		enforceLoadFee bool
+		viewOpen       bool
+		want           ter.Result
 	}{
 		{name: "closed ledger, non-zero balance below fee", balance: 50, openLedger: false, want: ter.TecINSUFF_FEE},
 		{name: "closed ledger, zero balance", balance: 0, openLedger: false, want: ter.TerINSUF_FEE_B},
 		{name: "open ledger, non-zero balance below fee", balance: 50, openLedger: true, want: ter.TerINSUF_FEE_B},
 		{name: "open ledger, zero balance", balance: 0, openLedger: true, want: ter.TerINSUF_FEE_B},
+		{name: "open view via EnforceLoadFee (TxQ apply/accept), non-zero balance below fee", balance: 50, enforceLoadFee: true, want: ter.TerINSUF_FEE_B},
+		{name: "open view via ViewOpen (open-ledger submit), non-zero balance below fee", balance: 50, viewOpen: true, want: ter.TerINSUF_FEE_B},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &Engine{config: txcore.EngineConfig{BaseFee: baseFee, OpenLedger: tt.openLedger}}
+			e := &Engine{config: txcore.EngineConfig{
+				BaseFee:        baseFee,
+				OpenLedger:     tt.openLedger,
+				EnforceLoadFee: tt.enforceLoadFee,
+				ViewOpen:       tt.viewOpen,
+			}}
 			account := &state.AccountRoot{Balance: tt.balance}
 			// Fee of 100 drops exceeds both balances yet clears the open-ledger
 			// base-fee floor, so the balance branch is the one under test.
 			txn := newFeeTestTx("100")
 			if got := e.checkFee(txn, txn.GetCommon(), account); got != tt.want {
-				t.Errorf("checkFee(balance=%d, open=%v) = %v, want %v", tt.balance, tt.openLedger, got, tt.want)
+				t.Errorf("checkFee(balance=%d, viewOpen=%v) = %v, want %v", tt.balance, e.config.IsViewOpen(), got, tt.want)
 			}
 		})
 	}

--- a/internal/tx/engine/preclaim.go
+++ b/internal/tx/engine/preclaim.go
@@ -213,10 +213,11 @@ func (e *Engine) checkFee(tx txcore.Transaction, common *txcore.Common, account 
 		return balResult
 	}
 	if feePayerBalance < fee {
-		// Reference: rippled Transactor::checkFee lines 304-316. On a closed
-		// ledger, a non-zero balance below the fee yields a deterministic
-		// claimed-fee result; otherwise the transaction is retryable.
-		if feePayerBalance > 0 && !e.config.OpenLedger {
+		// Reference: rippled Transactor::checkFee lines 304-316. Only a closed
+		// ledger with a non-zero balance below the fee yields a deterministic
+		// claimed-fee result; on any open view (open ledger, queued retry, or
+		// load-fee enforcement — rippled's ctx.view.open()) it is retryable.
+		if feePayerBalance > 0 && !e.config.IsViewOpen() {
 			return ter.TecINSUFF_FEE
 		}
 		return ter.TerINSUF_FEE_B


### PR DESCRIPTION
## Summary

`engine/preclaim.go` returned the **closed-ledger** claimed-fee result (`tecINSUFF_FEE`) for a positive-balance-below-fee transaction whenever the strict `OpenLedger` flag was unset — but a **queued-transaction retry** or **load-fee-enforcement** pass is still an *open view*.

rippled gates this purely on `ctx.view.open()`:
```cpp
// Transactor.cpp:310
if ((balance > beast::zero) && !ctx.view.open())
    return tecINSUFF_FEE;   // closed ledger
return terINSUF_FEE_B;      // open view → retryable
```

go-xrpl's `OpenLedger` flag is narrower than rippled's `view.open()`. The fix uses the existing `EngineConfig.IsViewOpen()` (`OpenLedger || EnforceLoadFee || ViewOpen`), which is the faithful mapping — so the transaction is retryable (`terINSUF_FEE_B`) in any open view instead of deterministically claimed.

## Effect

Fixes the two in-scope `TxQPosNegFlows` conformance failures:
- `fail_in_preclaim` (got `tecINSUFF_FEE`, want `terINSUF_FEE_B`)
- `unexpected_balance_change` (downstream of the same gate)

## Verification

- `TxQPosNegFlows`: **17 pass / 0 fail** (was 15/2).
- Full conformance: **no regressions** — in-scope 1133 pass / 8 fail (was 1131/10); every other suite identical.
- `internal/tx/engine/...` and `internal/txq/...` unit tests pass; gofmt/vet clean.

One-line change to the fee gate; comment updated to cite `ctx.view.open()`.