### PR TITLE
fix(check): reject non-Check CheckID with tecNO_ENTRY (CashCheck/CancelCheck)

### DIFF
--- a/internal/testing/regression/regression_test.go
+++ b/internal/testing/regression/regression_test.go
@@ -101,14 +101,13 @@ func TestRegression_InvalidTxObjectIDType(t *testing.T) {
 	aliceKey := keylet.Account(alice.AccountID())
 	aliceIndex := hex.EncodeToString(aliceKey.Key[:])
 
-	// Try to cash a "check" using alice's account index.
-	// Rippled: tecNO_ENTRY (object is not a check)
-	// Go engine: tecNO_PERMISSION (fails an earlier check)
-	// Reference: rippled Regression_test.cpp:274-277
+	// Cash a "check" at alice's account index. The object there is an
+	// AccountRoot, not a Check, so it is rejected with tecNO_ENTRY.
+	// Reference: rippled Regression_test.cpp:274-276
 	result := env.Submit(
 		check.CheckCashAmount(alice, aliceIndex, tx.NewXRPAmount(100_000_000)).Build(),
 	)
-	jtx.RequireTxClaimed(t, result, "tecNO_PERMISSION")
+	jtx.RequireTxClaimed(t, result, "tecNO_ENTRY")
 }
 
 // TestRegression_FeeEscalation tests that the fee escalation mechanism works.

--- a/internal/tx/check/check_cancel.go
+++ b/internal/tx/check/check_cancel.go
@@ -82,9 +82,8 @@ func (c *CheckCancel) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TecNO_ENTRY
 	}
 
-	// The CheckID must reference a Check. rippled reads through the typed
-	// keylet::check, which returns tecNO_ENTRY when the index holds any other
-	// object type; an untyped read here must reject non-Check entries the same way.
+	// View.Read is untyped, so reject a CheckID that resolves to a non-Check
+	// object, matching rippled's tecNO_ENTRY.
 	if state.EntryType(checkData) != "Check" {
 		return ter.TecNO_ENTRY
 	}

--- a/internal/tx/check/check_cancel.go
+++ b/internal/tx/check/check_cancel.go
@@ -82,6 +82,13 @@ func (c *CheckCancel) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TecNO_ENTRY
 	}
 
+	// The CheckID must reference a Check. rippled reads through the typed
+	// keylet::check, which returns tecNO_ENTRY when the index holds any other
+	// object type; an untyped read here must reject non-Check entries the same way.
+	if state.EntryType(checkData) != "Check" {
+		return ter.TecNO_ENTRY
+	}
+
 	// Parse check
 	check, err := state.ParseCheck(checkData)
 	if err != nil {

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -131,6 +131,13 @@ func (c *CheckCash) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TecNO_ENTRY
 	}
 
+	// The CheckID must reference a Check. rippled reads through the typed
+	// keylet::check, which returns tecNO_ENTRY when the index holds any other
+	// object type; an untyped read here must reject non-Check entries the same way.
+	if state.EntryType(checkData) != "Check" {
+		return ter.TecNO_ENTRY
+	}
+
 	// Parse check
 	check, err := state.ParseCheck(checkData)
 	if err != nil {

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -131,9 +131,8 @@ func (c *CheckCash) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TecNO_ENTRY
 	}
 
-	// The CheckID must reference a Check. rippled reads through the typed
-	// keylet::check, which returns tecNO_ENTRY when the index holds any other
-	// object type; an untyped read here must reject non-Check entries the same way.
+	// View.Read is untyped, so reject a CheckID that resolves to a non-Check
+	// object, matching rippled's tecNO_ENTRY.
 	if state.EntryType(checkData) != "Check" {
 		return ter.TecNO_ENTRY
 	}


### PR DESCRIPTION
## Summary

`CheckCash` and `CheckCancel` read the `CheckID` by **raw ledger index** without verifying the entry type:

```go
checkKey := keylet.Keylet{Key: checkKeyBytes} // no Type
checkData, err := ctx.View.Read(checkKey)
if err != nil || checkData == nil { return ter.TecNO_ENTRY }
check, err := state.ParseCheck(checkData)     // mis-parses a non-Check entry
```

So a `CheckID` that points at an existing **non-Check** object (e.g. an `AccountRoot` index) was read and parsed as if it were a Check, producing `tecNO_PERMISSION` (the destination check on garbage fields) instead of `tecNO_ENTRY`.

rippled reads through the **typed** `keylet::check`, which returns `tecNO_ENTRY` for any other object type:
```cpp
auto const sleCheck = ctx.view.read(keylet::check(ctx.tx[sfCheckID]));  // CashCheck.cpp:85, CancelCheck.cpp:55
if (!sleCheck) ... return tecNO_ENTRY;
```

Fix: after the read, reject entries whose type is not `Check` with `tecNO_ENTRY`, matching rippled.

## Effect

Fixes the in-scope conformance case `Regression/Invalid_Transaction_Object_ID_Type` (got `tecNO_PERMISSION`, want `tecNO_ENTRY`). `CheckCancel` shared the identical latent bug (no conformance case exercises it, but it diverges from rippled the same way) and is fixed for parity.

## Verification

- `Regression`: **7 pass / 0 fail** (was 6/1) — `Invalid_Transaction_Object_ID_Type` now passes.
- `internal/tx/check/...`, `internal/testing/check/...`, and the conformance `Check` suite all pass; gofmt/vet clean.

Two-line guard per handler.