### PR TITLE
Fix #1118's 99243845 regression: re-root the strand afView on the running sandbox (rippled StrandFlow.h:135)

### DIFF
--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -467,8 +467,16 @@ func (s *BookStep) forEachOffer(
 	// until the next funded tip fails the quality threshold. The bound never stops
 	// the walk at a found-unfunded offer — only at a funded (crossable) one — so a
 	// reserve-locked own offer at a beyond-limit tip is still removed.
+	// rippled's do-while: `do { if(!execOffer(tip)) break; } while(step())`. The
+	// loop is NOT bounded by remaining-amount at the top; instead each step()
+	// (getNextOfferSkipVisited) grooms the unfunded/became/tiny run it advances
+	// over, and the callback returns false once the demand is met (remainingZero
+	// at entry) or a partial fill leaves a still-funded tip. So after the take
+	// that meets demand, the loop runs one more getNextOfferSkipVisited — which
+	// grooms the trailing run in the SAME (committed) pass — before the next
+	// callback returns false and breaks. Reference: BookStep.cpp:855-865.
 	consumed := false
-	for s.offersUsed < s.maxOffersToConsume && !remainingZero() {
+	for s.offersUsed < s.maxOffersToConsume {
 		offer, offerKey, err := s.getNextOfferSkipVisited(sb, afView, ofrsToRm, visited, !consumed)
 		if err != nil {
 			break
@@ -551,78 +559,14 @@ func (s *BookStep) forEachOffer(
 		}
 	}
 
-	// Trailing-offer drain: rippled's forEachOffer do-while keeps stepping the
-	// book tip after the requested amount is satisfied, but ONLY when the last
-	// crossed tip was fully consumed (eachOffer returned true). That extra
-	// offers.step() first deletes the just-consumed tip from the working view
-	// (BookTip::step), then grooms the contiguous run of unfunded/tiny offers
-	// behind it before execOffer's remainingOut==0 guard stops the walk. goXRPL's
-	// main loop stops as soon as the demand is met (remainingZero), so it never
-	// reaches those trailing offers; replay that bounded step() here.
-	//
-	// removeConsumedTipIfUnfunded deletes the just-consumed funded-cap tip, and
-	// drainTrailingOffers advances through the run — getNextOfferSkipVisited's
-	// single funded rule grooms each found/became unfunded or tiny offer it steps
-	// over (perm or working-sandbox drop), and the self-cross clause removes the
-	// taker's own offers at the tier — stopping at the first funded survivor.
-	//
-	// When demand is met by a PARTIAL fill of a still-funded tip, eachOffer
-	// returns offer.fully_consumed()==false, the do-while breaks WITHOUT another
-	// offers.step(), and trailing offers are never reached — so the drain must not
-	// fire (lastTipFullyConsumed gate).
-	// Reference: rippled BookStep.cpp forEachOffer do-while 859-863; OfferStream.cpp
-	// step 234-404; limitSelfCrossQuality.
-	if consumed && s.lastTipFullyConsumed && remainingZero() {
-		if s.lastConsumedTipValid {
-			s.removeConsumedTipIfUnfunded(sb)
-		}
-		s.drainTrailingOffers(sb, afView, ofrsToRm, visited, currentQuality)
-	}
+	// The trailing groom is no longer a separate gated drain: the do-while above
+	// runs one more getNextOfferSkipVisited after the demand-meeting take, which
+	// grooms the trailing unfunded/became/tiny run in this (committed) pass before
+	// the next callback returns false — matching rippled's `while(offers.step())`.
 
 	// If no CLOB offers found, try the AMM alone.
 	if firstCLOB {
 		tryAMM(nil)
-	}
-}
-
-// drainTrailingOffers replays rippled's forEachOffer do-while after the requested
-// amount has been satisfied: it keeps stepping the book tip, letting
-// getNextOfferSkipVisited groom the contiguous run of unfunded/tiny offers the
-// crossing left behind (its single funded rule), and removing the taker's own
-// self-crossed offers at or better than the limit on the locked tier (rippled's
-// limitSelfCrossQuality, which removes them "even if no crossing occurs"), until
-// the first funded, non-own survivor — where rippled's execOffer stops on
-// remainingOut==0.
-// Reference: rippled BookStep.cpp do-while 855-863; limitSelfCrossQuality 443-457.
-func (s *BookStep) drainTrailingOffers(
-	sb, afView *PaymentSandbox,
-	ofrsToRm, visited map[[32]byte]bool,
-	currentQuality *Quality,
-) {
-	selfCrossDrain := s.defaultPath && s.qualityLimit != nil &&
-		s.strandSrc == s.strandDst && currentQuality != nil
-	for s.offersUsed < s.maxOffersToConsume {
-		offer, offerKey, err := s.getNextOfferSkipVisited(sb, afView, ofrsToRm, visited, false)
-		if err != nil || offer == nil {
-			break
-		}
-		// getNextOfferSkipVisited already groomed every found/became unfunded or
-		// tiny offer it stepped over, so what it yields is a funded survivor or the
-		// taker's own offer. Remove an own self-cross offer at or better than the
-		// limit on the locked tier and keep stepping; otherwise stop at the funded,
-		// non-own survivor (rippled's execOffer break on remainingOut==0).
-		if selfCrossDrain {
-			if offerOwner, err := state.DecodeAccountID(offer.Account); err == nil &&
-				offerOwner == s.strandSrc {
-				offerQ := s.offerQuality(offer)
-				if offerQ.Value == currentQuality.Value && !offerQ.WorseThan(*s.qualityLimit) {
-					ofrsToRm[offerKey] = true
-					s.recordPermRm(offerKey)
-					continue
-				}
-			}
-		}
-		break
 	}
 }
 
@@ -724,6 +668,11 @@ func (s *BookStep) Rev(
 	// revImp callback: decide full vs partial take, consume, and update accumulators.
 	// Reference: rippled BookStep.cpp revImp callback lines 1056-1083.
 	revCallback := func(e offerExec) bool {
+		// rippled eachOffer: if (remainingOut <= 0) return false — demand already
+		// met, so the do-while breaks (the prior take's step already groomed the run).
+		if remainingOut.IsZero() {
+			return false
+		}
 		if e.stpOut.Compare(remainingOut) <= 0 {
 			// Full take
 			savedIns.insert(e.stpIn)
@@ -785,7 +734,11 @@ func (s *BookStep) Rev(
 			s.lastTipFullyConsumed = s.tipFullyConsumed(e)
 		}
 
-		return true
+		// rippled eachOffer return: a full take always returns true ("even if the
+		// payment is satisfied, we need to consume the offer"), so the do-while
+		// steps once more and grooms the trailing run; a partial fill returns
+		// offer.fully_consumed(). lastTipFullyConsumed carries exactly that value.
+		return s.lastTipFullyConsumed
 	}
 
 	s.forEachOffer(sb, afView, ofrsToRm, trIn, trOut,
@@ -841,6 +794,11 @@ func (s *BookStep) Fwd(
 	// pass cache, consume, and update accumulators.
 	// Reference: rippled BookStep.cpp fwdImp callback lines 1175-1240.
 	fwdCallback := func(e offerExec) bool {
+		// rippled fwd eachOffer: once the input is exhausted, break the do-while
+		// (the prior take's step already groomed the trailing run).
+		if remainingIn.IsZero() {
+			return false
+		}
 		if e.stpIn.Compare(remainingIn) <= 0 {
 			// Full take: rippled sets processMore = true and eachOffer returns
 			// true, so the do-while runs offers.step() again and grooms trailing
@@ -973,7 +931,10 @@ func (s *BookStep) Fwd(
 			s.lastTipFullyConsumed = s.tipFullyConsumed(e)
 		}
 
-		return true
+		// rippled fwd eachOffer return: processMore || offer.fully_consumed(). A
+		// full take continues (lastTipFullyConsumed true → another step grooms the
+		// trailing run); a partial fill returns offer.fully_consumed().
+		return s.lastTipFullyConsumed
 	}
 
 	s.forEachOffer(sb, afView, ofrsToRm, trIn, trOut,

--- a/internal/tx/payment/strand_flow.go
+++ b/internal/tx/payment/strand_flow.go
@@ -187,17 +187,19 @@ func ExecuteStrand(
 	// Reference: rippled StrandFlow.h line 130: size_t limitingStep = strand.size()
 	limitingStep := s
 	sb := NewChildSandbox(baseView)
-	// afView: the "all funds" view that tells a FOUND removal (an offer already
-	// unfunded/tiny before the flow ran) from a BECAME removal (one this flow's
-	// crossing drained). The caller threads afBaseView — a child of the pristine
-	// pre-flow view that the per-pass applies never touch — so the found-vs-became
-	// test stays anchored to pre-flow funds across a multi-pass crossing. When no
-	// such baseline is supplied (unit tests, single-pass callers), afView falls
-	// back to baseView, which the strand never modifies.
-	afView := baseView
-	if afBaseView != nil {
-		afView = afBaseView
-	}
+	// afView ("all funds" view) is a fresh child of the RUNNING sandbox, exactly
+	// like rippled's afView(&baseView) (StrandFlow.h:135), where baseView is the
+	// running multi-strand sandbox. It therefore reflects every prior committed
+	// iteration (best-strand applies AND the per-iteration offerDeletes), so an
+	// offer whose owner a PRIOR iteration drained reads unfunded here too. The
+	// found-vs-became test then classifies it FOUND-unfunded and promotes it to a
+	// perm removal that the multi-strand loop offerDeletes from the running view —
+	// matching rippled. Anchoring afView to a pristine pre-flow baseline instead
+	// kept such an offer classified BECAME (a discardable working-sandbox delete)
+	// and left it in the book across a multi-iteration crossing (the 99243845
+	// beyond-limit drained-maker offer that #1118 regressed).
+	_ = afBaseView
+	afView := NewChildSandbox(baseView)
 	var limitStepOut EitherAmount
 
 	// === REVERSE PASS ===
@@ -248,8 +250,11 @@ func ExecuteStrand(
 		} else if !step.EqualOut(actualOut, stepOut) {
 			// Limiting step found — actualOut < requested stepOut
 			// Reset BOTH sandboxes and re-execute ONLY this step
-			// Reference: rippled StrandFlow.h lines 180-217
+			// Reference: rippled StrandFlow.h lines 180-217. rippled resets BOTH sb
+			// (184) AND afView (185) on this branch (unlike the maxIn branch, which
+			// resets only sb at 152), so afView is re-rooted on the running sandbox.
 			sb.Reset()
+			afView.Reset()
 			limitingStep = i
 
 			// Re-execute with the limited output


### PR DESCRIPTION
## Summary

PR #1118 unified offer-crossing grooming and fixed the same-quality-sibling case (ledger **99248432**, #1114), but it **regressed ledger 99243845** — a ledger that is byte-exact on un-patched `main`. This PR fixes that regression with a faithful port of rippled's flow algorithm, keeping #1118's 99248432 fix intact.

## Root cause — one divergence from rippled's `StrandFlow.h`

A mechanical side-by-side of rippled's flow loop against goXRPL's surfaced exactly one substantive divergence: the **`afView`** — the "all funds" baseline that distinguishes a **FOUND** removal (an offer already unfunded before the flow ran → permanent removal) from a **BECAME** removal (one this flow drained → discardable working-sandbox delete).

- **rippled** creates a fresh `afView(&baseView)` at the start of *each* per-strand flow (`StrandFlow.h:135`), where `baseView` is the **running** multi-strand sandbox. So `afView` reflects every prior committed iteration (best-strand applies + the per-iteration `offerDelete`s at 807-815).
- **goXRPL** pinned `afView` to a child of the **pristine pre-flow** view, created once before the loop and never updated.

### Why that regressed 99243845

In the OfferCreate at 99243845, maker `rJVfiW` is drained across several *earlier* flow iterations. By a later iteration its beyond-limit offer `82E23BDC` is unfunded:
- With rippled's running-sandbox `afView`, `82E23BDC` reads unfunded there too → classified **FOUND-unfunded** → a perm removal the loop `offerDelete`s from the running view → **committed** (mainnet deletes it).
- With the pinned pristine `afView`, `rJVfiW` still reads funded → `82E23BDC` stays **BECAME** → a discardable delete the limiting-step reset rolled back → **left in the book** (31 vs 33 affected nodes).

The same-quality-sibling case (99248432) is unaffected because those siblings are drained in the **same** iteration — they stay BECAME and are committed via the best-strand sandbox. One re-rooted view, not two special-cased paths — which is exactly why the single change fixes both.

## The fix

Port rippled's two lines into `ExecuteStrand`:
- `afView := NewChildSandbox(baseView)` — a fresh child of the running sandbox (`StrandFlow.h:135`)
- reset `afView` on the `!equalOut` limiting branch (`StrandFlow.h:185`), which the `maxIn` branch (152) deliberately does not

## Commits

- `3b28dd1d` — restructure `forEachOffer` to rippled's literal do-while (`BookStep.cpp:855-865`): drop the top `!remainingZero()` gate, return rippled's `eachOffer` value from the callbacks, remove the gated `drainTrailingOffers`. A faithful loop port / cleanup (not the bug fix on its own).
- `818d8354` — **the afView re-root fix** (~17 lines in `strand_flow.go`). This is what resolves the regression.

## Verification (byte-exact mainnet replay vs rippled 2.6.2)

- **Range 2** (99236370→99250000): **13630 / 13630, 0 divergences** — both 99243845 ✅ and 99248432 ✅, frontier advanced past 99248432.
- **Range 1** (99226370→99236370): **10000 / 10000, 0 divergences** — #1027/#1029 family clean.
- **Unit tests**: `internal/tx/payment`, `internal/testing/offer` (incl. `TestOffer_DrainedMakerSiblingsGroomed`, the 99248432 lock-in), `internal/testing/amm` — all green.

## References

rippled 2.6.2: `src/xrpld/app/paths/detail/StrandFlow.h:135` (afView rooting), `:184-185` (limiting reset of both sb and afView), `:797`+`:807-815` (per-iteration best-apply + offerDelete to the running sandbox); `OfferStream.cpp:315-340` (FOUND vs BECAME). goXRPL: `internal/tx/payment/strand_flow.go` (ExecuteStrand), `flow.go` (multi-strand loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7BGJUPNfidYGoXg7r8F5K