### PR TITLE
fix(amm): round-trip PreviousTxnID so no-op AMM modifications are pruned (#1125)

### DIFF
--- a/internal/tx/amm/serialize.go
+++ b/internal/tx/amm/serialize.go
@@ -178,12 +178,7 @@ func serializeAMMData(amm *AMMData) ([]byte, error) {
 		jsonObj["TradingFee"] = amm.TradingFee
 	}
 
-	// PreviousTxnID / PreviousTxnLgrSeq thread modification history. Emit them only
-	// when the AMM has been threaded before (a freshly created AMM has neither
-	// until the apply layer stamps it), so a no-op modification round-trips
-	// byte-identically and the apply layer's unchanged-entry guard prunes it —
-	// rippled writes no ModifiedNode and bumps no PreviousTxnID when nothing
-	// changed (ApplyStateTable.cpp:154-157).
+	// soeOPTIONAL: emit only once the apply layer has threaded the AMM (see AMMData docs).
 	if amm.PreviousTxnID != "" {
 		jsonObj["PreviousTxnID"] = amm.PreviousTxnID
 		jsonObj["PreviousTxnLgrSeq"] = amm.PreviousTxnLgrSeq

--- a/internal/tx/amm/serialize.go
+++ b/internal/tx/amm/serialize.go
@@ -58,6 +58,13 @@ func parseAMMData(data []byte) (*AMMData, error) {
 		amm.OwnerNode, _ = parseHexUint64(ownerNodeStr)
 	}
 
+	// PreviousTxnID / PreviousTxnLgrSeq (threading pointers) — preserve them so a
+	// no-op modification re-serializes byte-identically (see AMMData docs).
+	if prevTxnID, ok := fields["PreviousTxnID"].(string); ok {
+		amm.PreviousTxnID = prevTxnID
+	}
+	amm.PreviousTxnLgrSeq = getFieldUint32(fields, "PreviousTxnLgrSeq")
+
 	// LPTokenBalance (Amount object)
 	if lptObj, ok := fields["LPTokenBalance"].(map[string]any); ok {
 		bal, err := amountMapToAmount(lptObj)
@@ -169,6 +176,17 @@ func serializeAMMData(amm *AMMData) ([]byte, error) {
 	// state. Emitting TradingFee:0 forks account_hash.
 	if amm.TradingFee != 0 {
 		jsonObj["TradingFee"] = amm.TradingFee
+	}
+
+	// PreviousTxnID / PreviousTxnLgrSeq thread modification history. Emit them only
+	// when the AMM has been threaded before (a freshly created AMM has neither
+	// until the apply layer stamps it), so a no-op modification round-trips
+	// byte-identically and the apply layer's unchanged-entry guard prunes it —
+	// rippled writes no ModifiedNode and bumps no PreviousTxnID when nothing
+	// changed (ApplyStateTable.cpp:154-157).
+	if amm.PreviousTxnID != "" {
+		jsonObj["PreviousTxnID"] = amm.PreviousTxnID
+		jsonObj["PreviousTxnLgrSeq"] = amm.PreviousTxnLgrSeq
 	}
 
 	// VoteSlots (STArray of VoteEntry objects)

--- a/internal/tx/amm/serialize_soe_test.go
+++ b/internal/tx/amm/serialize_soe_test.go
@@ -1,6 +1,7 @@
 package amm
 
 import (
+	"strings"
 	"testing"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
@@ -128,6 +129,67 @@ func TestSerializeAMM_RoundTrip(t *testing.T) {
 		if voteEntryHasTradingFee(t, fields) != (fee != 0) {
 			t.Errorf("fee=%d: VoteEntry.TradingFee presence wrong after round trip", fee)
 		}
+	}
+}
+
+// TestSerializeAMM_PreviousTxnRoundTrip asserts the soeOPTIONAL threading
+// pointers are omitted on an un-threaded AMM and round-trip faithfully once set,
+// so a no-op modification re-serializes with PreviousTxnID intact and the apply
+// layer's unchanged-entry guard prunes it instead of writing a ghost ModifiedNode.
+func TestSerializeAMM_PreviousTxnRoundTrip(t *testing.T) {
+	// Un-threaded: both soeOPTIONAL pointers absent.
+	data, err := serializeAMMData(buildTestAMM(t, 500))
+	if err != nil {
+		t.Fatalf("serialize (un-threaded): %v", err)
+	}
+	f := decodeFieldsBytes(t, data)
+	if _, ok := f["PreviousTxnID"]; ok {
+		t.Error("PreviousTxnID must be absent on an un-threaded AMM (soeOPTIONAL)")
+	}
+	if _, ok := f["PreviousTxnLgrSeq"]; ok {
+		t.Error("PreviousTxnLgrSeq must be absent on an un-threaded AMM (soeOPTIONAL)")
+	}
+
+	// Threaded: both present, correct, and stable across serialize → parse → serialize.
+	const prevTxnID = "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+	const prevLgrSeq = uint32(98948137)
+	amm := buildTestAMM(t, 500)
+	amm.PreviousTxnID = prevTxnID
+	amm.PreviousTxnLgrSeq = prevLgrSeq
+
+	data2, err := serializeAMMData(amm)
+	if err != nil {
+		t.Fatalf("serialize (threaded): %v", err)
+	}
+	f2 := decodeFieldsBytes(t, data2)
+	if got, ok := f2["PreviousTxnID"].(string); !ok || !strings.EqualFold(got, prevTxnID) {
+		t.Errorf("serialized PreviousTxnID = %v, want %s", f2["PreviousTxnID"], prevTxnID)
+	}
+	if got := toUint64(f2["PreviousTxnLgrSeq"]); got != uint64(prevLgrSeq) {
+		t.Errorf("serialized PreviousTxnLgrSeq = %d, want %d", got, prevLgrSeq)
+	}
+
+	parsed, err := ParseAMMData(data2)
+	if err != nil {
+		t.Fatalf("parse (threaded): %v", err)
+	}
+	if !strings.EqualFold(parsed.PreviousTxnID, prevTxnID) {
+		t.Errorf("round-trip PreviousTxnID = %s, want %s", parsed.PreviousTxnID, prevTxnID)
+	}
+	if parsed.PreviousTxnLgrSeq != prevLgrSeq {
+		t.Errorf("round-trip PreviousTxnLgrSeq = %d, want %d", parsed.PreviousTxnLgrSeq, prevLgrSeq)
+	}
+
+	data3, err := serializeAMMData(parsed)
+	if err != nil {
+		t.Fatalf("re-serialize (threaded): %v", err)
+	}
+	f3 := decodeFieldsBytes(t, data3)
+	if _, ok := f3["PreviousTxnID"]; !ok {
+		t.Error("PreviousTxnID must remain present after round trip")
+	}
+	if _, ok := f3["PreviousTxnLgrSeq"]; !ok {
+		t.Error("PreviousTxnLgrSeq must remain present after round trip")
 	}
 }
 

--- a/internal/tx/amm/types.go
+++ b/internal/tx/amm/types.go
@@ -27,6 +27,15 @@ type AMMData struct {
 	VoteSlots []VoteSlotData
 	// AuctionSlot contains the current auction slot state (optional)
 	AuctionSlot *AuctionSlotData
+	// PreviousTxnID / PreviousTxnLgrSeq thread the AMM SLE's modification history.
+	// They must round-trip through parse/serialize so that a no-op modification
+	// (e.g. an idempotent re-vote that re-submits the same TradingFee) produces a
+	// byte-identical SLE, letting the apply layer's unchanged-entry guard prune it
+	// — matching rippled, which emits no ModifiedNode and threads no PreviousTxnID
+	// when nothing changed (ApplyStateTable.cpp:154-157). Empty/zero when the AMM
+	// has never been threaded (freshly created); omitted on serialize in that case.
+	PreviousTxnID     string
+	PreviousTxnLgrSeq uint32
 }
 
 // VoteSlotData holds a single vote slot entry.

--- a/internal/tx/amm/types.go
+++ b/internal/tx/amm/types.go
@@ -27,13 +27,10 @@ type AMMData struct {
 	VoteSlots []VoteSlotData
 	// AuctionSlot contains the current auction slot state (optional)
 	AuctionSlot *AuctionSlotData
-	// PreviousTxnID / PreviousTxnLgrSeq thread the AMM SLE's modification history.
-	// They must round-trip through parse/serialize so that a no-op modification
-	// (e.g. an idempotent re-vote that re-submits the same TradingFee) produces a
-	// byte-identical SLE, letting the apply layer's unchanged-entry guard prune it
-	// — matching rippled, which emits no ModifiedNode and threads no PreviousTxnID
-	// when nothing changed (ApplyStateTable.cpp:154-157). Empty/zero when the AMM
-	// has never been threaded (freshly created); omitted on serialize in that case.
+	// PreviousTxnID / PreviousTxnLgrSeq must round-trip through parse/serialize so a no-op
+	// modification (e.g. an idempotent re-vote) re-serializes byte-identically and the apply
+	// layer's unchanged-entry guard prunes it (ApplyStateTable.cpp:154-157). soeOPTIONAL:
+	// empty/zero until the apply layer threads the AMM, and omitted from serialization until then.
 	PreviousTxnID     string
 	PreviousTxnLgrSeq uint32
 }


### PR DESCRIPTION
Fixes #1125.

An idempotent `AMMVote` re-vote (voter re-submits the same `TradingFee` it already holds, as the AMM's only vote slot) recomputes a byte-identical AMM SLE. rippled emits no `ModifiedNode` and threads no `PreviousTxnID` for an unchanged modify — `ApplyStateTable::apply` skips a `taaMODIFY` whose `*curNode == *origNode` (`ApplyStateTable.cpp:154-157`). goXRPL already mirrors that guard (`internal/tx/applystate/apply_state_table.go:372-376`, `:503-513`, `bytes.Equal(entry.Original, entry.Current)`), but it failed for AMM because the AMM serializer dropped `PreviousTxnID`/`PreviousTxnLgrSeq` — so the re-serialized `entry.Current` never matched `entry.Original`, the guard never fired, and goXRPL emitted a spurious empty-diff `ModifiedNode` and bumped the AMM's `PreviousTxnID` (forking the ledger hash at 99250127).

This round-trips the two threading fields in `AMMData` / `parseAMMData` / `serializeAMMData`, emitting them only when non-zero so the AMMCreate path (no `PreviousTxnID` until the apply layer stamps it) is unaffected. Every other SLE type already round-trips these fields; same class as the NegativeUNL fix (#1092).

**Verified byte-exact:** mainnet replay 99250000→99254205 clean — ledger 99250127 (the divergence) now OK; AMM unit tests (`internal/tx/amm`, `internal/testing/amm`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7BGJUPNfidYGoXg7r8F5K