### PR TITLE
fix(conformance): apply non-TxQ user txns to an open view (AccountDelete balance-too-small)

### DIFF
--- a/internal/testing/conformance/runner.go
+++ b/internal/testing/conformance/runner.go
@@ -1006,8 +1006,16 @@ func (r *runner) setupEnv(cfg EnvConfig) {
 	// in execTx() so the fee adequacy check fires.
 	//
 	// TxQ suites need open-ledger mode so fee escalation triggers queuing.
+	//
+	// The view is still OPEN, though: rippled applies user txns to an OpenView
+	// in both Env::submit and consensus buildLedger, so view.open() is true on
+	// every apply path. SetViewOpen carries that open-view signal without the
+	// fee floor, so the open-view fee branch (terINSUF_FEE_B, not the closed-only
+	// tecINSUFF_FEE) and internal-failure variants match rippled across the
+	// initial apply and replay-on-close.
 	if !r.enableTxQ {
 		r.env.SetOpenLedger(false)
+		r.env.SetViewOpen(true)
 	}
 
 	// Register master account

--- a/internal/testing/conformance/runner.go
+++ b/internal/testing/conformance/runner.go
@@ -1007,12 +1007,9 @@ func (r *runner) setupEnv(cfg EnvConfig) {
 	//
 	// TxQ suites need open-ledger mode so fee escalation triggers queuing.
 	//
-	// The view is still OPEN, though: rippled applies user txns to an OpenView
-	// in both Env::submit and consensus buildLedger, so view.open() is true on
-	// every apply path. SetViewOpen carries that open-view signal without the
-	// fee floor, so the open-view fee branch (terINSUF_FEE_B, not the closed-only
-	// tecINSUFF_FEE) and internal-failure variants match rippled across the
-	// initial apply and replay-on-close.
+	// The view stays open even so: SetViewOpen keeps view.open() true without the
+	// fee floor, so the open-view fee branch (terINSUF_FEE_B, not closed-only
+	// tecINSUFF_FEE) matches rippled. See TestEnv.viewOpen.
 	if !r.enableTxQ {
 		r.env.SetOpenLedger(false)
 		r.env.SetViewOpen(true)

--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -85,14 +85,10 @@ type TestEnv struct {
 	// sufficient when the ledger is open."
 	openLedger bool
 
-	// viewOpen marks the apply view as open (rippled's view.open()) WITHOUT
-	// re-enabling the fee-adequacy floor that openLedger controls. rippled
-	// applies user transactions to an OpenView in both Env::submit and consensus
-	// buildLedger, so view.open() is true on every apply path. Conformance
-	// non-TxQ suites turn openLedger off (the fee floor) but still need the
-	// open-view fee branch (terINSUF_FEE_B vs the closed-only tecINSUFF_FEE)
-	// and the open-view internal-failure variants. Default false: normal tests
-	// already get an open view via openLedger=true.
+	// viewOpen marks the apply view as open (rippled's view.open()) WITHOUT the
+	// fee-adequacy floor that openLedger controls. Conformance non-TxQ suites turn
+	// openLedger off but still need the open-view fee branch (terINSUF_FEE_B vs the
+	// closed-only tecINSUFF_FEE) and its internal-failure variants.
 	viewOpen bool
 
 	// Optional state map family for backed SHAMaps (PebbleDB on disk).
@@ -350,10 +346,8 @@ func (e *TestEnv) SetOpenLedger(open bool) {
 	e.openLedger = open
 }
 
-// SetViewOpen marks the apply view as open without enabling the fee-adequacy
-// floor (see the viewOpen field). Conformance non-TxQ suites set this so the
-// open-view fee branch (terINSUF_FEE_B) and internal-failure variants match
-// rippled even while SetOpenLedger(false) keeps the fee floor off.
+// SetViewOpen marks the apply view as open without the fee-adequacy floor
+// (see the viewOpen field).
 func (e *TestEnv) SetViewOpen(open bool) {
 	e.viewOpen = open
 }

--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -85,6 +85,16 @@ type TestEnv struct {
 	// sufficient when the ledger is open."
 	openLedger bool
 
+	// viewOpen marks the apply view as open (rippled's view.open()) WITHOUT
+	// re-enabling the fee-adequacy floor that openLedger controls. rippled
+	// applies user transactions to an OpenView in both Env::submit and consensus
+	// buildLedger, so view.open() is true on every apply path. Conformance
+	// non-TxQ suites turn openLedger off (the fee floor) but still need the
+	// open-view fee branch (terINSUF_FEE_B vs the closed-only tecINSUFF_FEE)
+	// and the open-view internal-failure variants. Default false: normal tests
+	// already get an open view via openLedger=true.
+	viewOpen bool
+
 	// Optional state map family for backed SHAMaps (PebbleDB on disk).
 	// Only set when using NewTestEnvBacked() for heavy tests that would OOM otherwise.
 	// When nil, SHAMaps use unbacked mode (fast, full in-memory clones).
@@ -338,6 +348,14 @@ func NewTestEnvWithConfig(t testing.TB, cfg genesis.Config) *TestEnv {
 // When false, fee adequacy checks are skipped (matching rippled's closed-ledger behavior).
 func (e *TestEnv) SetOpenLedger(open bool) {
 	e.openLedger = open
+}
+
+// SetViewOpen marks the apply view as open without enabling the fee-adequacy
+// floor (see the viewOpen field). Conformance non-TxQ suites set this so the
+// open-view fee branch (terINSUF_FEE_B) and internal-failure variants match
+// rippled even while SetOpenLedger(false) keeps the fee floor off.
+func (e *TestEnv) SetViewOpen(open bool) {
+	e.viewOpen = open
 }
 
 // SetBypassTxQ temporarily bypasses TxQ routing. When true, Submit() goes

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -487,6 +487,7 @@ func (e *TestEnv) engineConfig(view *ledger.Ledger, opts engineConfigOpts) tx.En
 		NetworkID:                 e.networkID,
 		ParentHash:                view.ParentHash(),
 		OpenLedger:                opts.openLedger,
+		ViewOpen:                  e.viewOpen,
 		EnforceLoadFee:            opts.enforceLoadFee,
 		ApplyFlags:                opts.applyFlags,
 	}


### PR DESCRIPTION
## Summary

Fixes the in-scope conformance failure `app/AccountDelete/Balance_too_small_for_fee`.

## Root cause

This is a **harness modeling gap**, not a production bug — the engine's `checkFee` already mirrors rippled's `Transactor::checkFee` (Transactor.cpp:304-317) exactly, including the closed-view `tecINSUFF_FEE` vs open-view `terINSUF_FEE_B` split.

rippled's test framework applies user transactions to an `OpenView` in **both** `Env::submit` and consensus `buildLedger` (`OpenView accum(&*built)`), so `ctx.view.open() == true` on every apply path. The conformance harness, however, drove non-TxQ suites with a **closed** view. That is intentional for the fee-adequacy floor (it is disabled because fixture `tx_blob`s capture pre-autofill fees), but the single `OpenLedger` flag also gated the open-view fee branch. As a result:

1. **Step 5** — `AccountDelete` (Fee = 50 XRP, balance = 1 XRP): a closed view turned the `balance < feePaid` shortfall into the claimed-fee variant `tecINSUFF_FEE` instead of `terINSUF_FEE_B`.
2. The `ter*` result was tracked as retryable and replayed by the `replayOnClose` consensus simulation (`enableReplay = !isTxQSuite`); with the closed view it applied that `tecINSUFF_FEE` — charging the fee and advancing the sequence 4→5.
3. **Step 7** — the follow-up low-fee `AccountDelete` (Fee = 1 XRP, Sequence = 4) then failed `tefPAST_SEQ` instead of `telINSUF_FEE_P`.

## Fix

Decouple the two concerns that the `OpenLedger` flag conflated:

- keep the fee-adequacy floor **off** (`SetOpenLedger(false)`) so low-fee fixture blobs are not rejected, but
- mark the view **open** via a new `ViewOpen` signal (`SetViewOpen(true)`) for non-TxQ suites.

`ViewOpen` already exists on `EngineConfig` and feeds `IsViewOpen()` without touching the fee floor. `checkFee`'s balance branch and the open-view internal-failure TER variants now match rippled across the initial apply, the held-tx retry, and the consensus replay-on-close. TxQ suites are unaffected (the change is gated on `!enableTxQ`; they already get an open view via `EnforceLoadFee`).

Diff is 27 lines across 3 harness files; no production code changes.

## Verification

- `app/AccountDelete` suite: all green (`Balance_too_small_for_fee` now passes; Steps 5/7 return `terINSUF_FEE_B` / `telINSUF_FEE_P`).
- Full conformance: in-scope failures drop from **6 to 5**. Remaining in-scope failures are `AMM/Invalid_Deposit`, `AMM/AMM_Offer_Blocked_By_LOB`, and `TxQMetaInfo` ×3 — all **pre-existing**, confirmed by re-running the base (stashed) tree. No new regressions.
- jtx integration sanity (`escrow`, `offer`) pass — `offer` exercises the `offer_create_cross` `IsViewOpen()` consumer in jtx mode, confirming non-conformance tests are unaffected (`viewOpen` defaults false there).
- `gofmt` and `go vet` clean.