### PR TITLE
Fix held-tx fee semantics in conformance replay (app/DepositAuth)

### DIFF
--- a/internal/testing/conformance/runner.go
+++ b/internal/testing/conformance/runner.go
@@ -1456,13 +1456,17 @@ func (r *runner) retryHeldTxs() {
 }
 
 // retryQueuedTxs retries TxQ-queued transactions on ledger close.
-// In rippled, TxQ::accept() processes queued ter* transactions during
-// close. Retries that still return ter* stay queued; tec results charge
-// the fee; tef/tem results are dropped.
+// In rippled, TxQ::accept() processes queued ter* transactions against the
+// fresh open ledger, so a payer that cannot cover the fee yields the retryable
+// terINSUF_FEE_B (stays queued, no fee charged) rather than the closed-ledger
+// tecINSUFF_FEE that would claim its remaining balance. Retries that still
+// return ter* stay queued; tec results charge the fee; tef/tem results dropped.
 func (r *runner) retryQueuedTxs() {
 	if len(r.pendingQueued) == 0 {
 		return
 	}
+	r.env.SetOpenLedger(true)
+	defer r.env.SetOpenLedger(false)
 	remaining := r.pendingQueued[:0]
 	for _, txn := range r.pendingQueued {
 		result := r.env.Submit(txn)

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -203,11 +203,41 @@ func (e *TestEnv) closeWithReplay() {
 	// different hashes than rippled's, making the canonical salt impossible to
 	// match. Submission order produces the correct closed-ledger state for
 	// most cases because the retry mechanism handles ordering-dependent failures.
-	var allTxns []tx.Transaction
-	allTxns = append(allTxns, e.openLedgerSetupTxns...)
-	allTxns = append(allTxns, e.openLedgerUserTxns...)
+	//
+	// heldHashes marks transactions carried over from a previous ledger as
+	// held. rippled retries held transactions against the OPEN ledger
+	// (LedgerMaster::applyHeldTransactions), so their fee-adequacy is judged
+	// with view.open()==true: a payer that cannot cover the fee yields the
+	// retryable terINSUF_FEE_B (no fee charged) and stays held, never the
+	// closed-ledger tecINSUFF_FEE that would claim its remaining balance.
+	heldHashes := make(map[[32]byte]bool)
 	for _, held := range e.heldTxns {
-		allTxns = append(allTxns, held...)
+		for _, txn := range held {
+			h, _ := tx.ComputeTransactionHash(txn)
+			heldHashes[h] = true
+		}
+	}
+
+	// Collect the transactions to replay, de-duplicating by hash: a retryable
+	// txn is tracked in both openLedgerUserTxns and heldTxns, and the runner's
+	// queue retries re-submit the same object across ledgers. Applying the same
+	// txn twice in one ledger is never valid (the second hits tefPAST_SEQ).
+	seen := make(map[[32]byte]bool)
+	var allTxns []tx.Transaction
+	addAll := func(list []tx.Transaction) {
+		for _, txn := range list {
+			h, _ := tx.ComputeTransactionHash(txn)
+			if seen[h] {
+				continue
+			}
+			seen[h] = true
+			allTxns = append(allTxns, txn)
+		}
+	}
+	addAll(e.openLedgerSetupTxns)
+	addAll(e.openLedgerUserTxns)
+	for _, held := range e.heldTxns {
+		addAll(held)
 	}
 
 	// Sort all transactions using SHAMap-salted canonical ordering.
@@ -236,7 +266,7 @@ func (e *TestEnv) closeWithReplay() {
 
 	// Apply all transactions with retry passes.
 	// Setup and user txns are in a single list in submission order.
-	remaining := e.applyWithRetry(allTxns, maxRetryPasses, maxTotalPasses)
+	remaining := e.applyWithRetry(allTxns, heldHashes, maxRetryPasses, maxTotalPasses)
 
 	// Any remaining transactions that still failed go back into the held
 	// map for retry in the next ledger.
@@ -342,7 +372,7 @@ func (e *TestEnv) applyPendingAmendments() {
 // final pass (certainRetry=false), TapRETRY is cleared so tec results
 // ARE applied (fee consumed, sequence advanced).
 // Reference: rippled BuildLedger.cpp lines 98-178
-func (e *TestEnv) applyWithRetry(txns []tx.Transaction, maxRetryPasses, maxTotalPasses int) []tx.Transaction {
+func (e *TestEnv) applyWithRetry(txns []tx.Transaction, heldHashes map[[32]byte]bool, maxRetryPasses, maxTotalPasses int) []tx.Transaction {
 	remaining := txns
 	certainRetry := true
 
@@ -351,7 +381,8 @@ func (e *TestEnv) applyWithRetry(txns []tx.Transaction, maxRetryPasses, maxTotal
 		changes := 0
 
 		for _, txn := range remaining {
-			result, applied := e.applyForReplay(txn, certainRetry)
+			h, _ := tx.ComputeTransactionHash(txn)
+			result, applied := e.applyForReplay(txn, certainRetry, heldHashes[h])
 
 			switch {
 			case applied:
@@ -849,12 +880,14 @@ func (e *TestEnv) drainQueue() {
 
 // applyForReplay applies a single transaction during the replay-on-close
 // process. When certainRetry is true, TapRETRY is set so that tec results
-// are not applied (matching rippled's retry pass behavior).
+// are not applied (matching rippled's retry pass behavior). When held is true
+// the txn was carried over from a prior ledger; rippled retries held txns on
+// the open ledger, so its fee-adequacy is judged with view.open()==true.
 // Returns the result code and whether the transaction was actually applied.
-func (e *TestEnv) applyForReplay(txn tx.Transaction, certainRetry bool) (ter.Result, bool) {
+func (e *TestEnv) applyForReplay(txn tx.Transaction, certainRetry, held bool) (ter.Result, bool) {
 	// Header-based ParentCloseTime matches applyDirect so time-dependent checks
 	// produce the same result during initial apply and during replay.
-	opts := engineConfigOpts{openLedger: e.openLedger}
+	opts := engineConfigOpts{openLedger: e.openLedger || held}
 	if certainRetry {
 		opts.applyFlags = tx.TapRETRY
 	}


### PR DESCRIPTION
## Problem

`app/DepositAuth/Pay_XRP` failed conformance: the recipient (bob) ended a close step with **9 drops instead of 10** (off by exactly one drop), which cascaded into a later XRP payment wrongly returning `tecNO_PERMISSION` instead of `tesSUCCESS`.

## Root cause

The scenario holds an `AccountSet` (clearing deposit-auth) that returns `terINSUF_FEE_B` because bob's balance is 0; small payments then slowly fund bob until he can afford the fee, at which point the held tx applies and clears deposit-auth so a large payment can land.

The conformance harness lost the funding drop in two places, both because **held/queued transactions were replayed against the closed consensus view** (`view.open()==false`):

1. `closeWithReplay` collected held transactions into the closed-ledger replay set. After the canonical sort placed the funding `Payment` before the held `AccountSet`, bob's balance became non-zero and `checkFee` flipped `terINSUF_FEE_B` → **`tecINSUFF_FEE`** (closed ledger, non-zero balance below fee), claiming bob's remaining balance and consuming his sequence.
2. The runner's `retryQueuedTxs` re-submitted the held tx via the direct apply path (also closed view), hitting the same `tecINSUFF_FEE` charge.

rippled never does this: held/queued transactions are retried against the **open ledger** (`LedgerMaster::applyHeldTransactions`, `TxQ::accept`), where a payer that cannot cover the fee yields the retryable `terINSUF_FEE_B` (no fee charged) and the transaction stays held until it is affordable.

This is why the earlier "wrap `retryQueuedTxs` with `SetOpenLedger(true)`" attempt was a no-op in isolation — site (1) drained the drop first, so fixing only (2) changed nothing. Both sites must use open-ledger fee semantics.

## Fix (test harness only)

- `closeWithReplay` marks carried-over (held) transactions and applies them with open-ledger fee semantics, matching rippled's `applyHeldTransactions`. It also de-duplicates the replay set by tx hash — a retryable txn is tracked in both `openLedgerUserTxns` and `heldTxns` and re-submitted by the queue retry across ledgers; applying the same txn twice in one ledger is never valid (the second hits `tefPAST_SEQ`).
- `retryQueuedTxs` replays queued transactions against the open ledger so the same fee semantics apply on the runner-driven retry path.

No protocol/engine code changed; `tecINSUFF_FEE` vs `terINSUF_FEE_B` in `preclaim` already matches rippled `Transactor::checkFee`.

## Verification

- `app/DepositAuth`: **4/4** (was 3/4; `Pay_XRP` now passes — bob reaches 10 drops, held `AccountSet` applies, deposit-auth clears, final payment succeeds).
- Full in-scope conformance: zero regressions. A stash-based baseline diff confirms the only remaining in-scope failures (`AccountDelete/Balance_too_small_for_fee`, `AMM/Invalid_Deposit`, `AMM/AMM_Offer_Blocked_By_LOB`, `TxQMetaInfo` ×3) are pre-existing and byte-identical before/after this change.
- `internal/testing/{payment,escrow,offer}` integration suites pass; `gofmt`/`go vet` clean.