### PR TITLE
Fix AMM conformance: Offer_Blocked_By_LOB and Invalid_Deposit

### DIFF
--- a/internal/testing/amm/amm_bookstep_test.go
+++ b/internal/testing/amm/amm_bookstep_test.go
@@ -1063,7 +1063,7 @@ func TestAMMBookStep_FixChangeSpotPriceQuality(t *testing.T) {
 				poolIn := parsePool(tc.poolInStr, poolInIsXRP)
 				poolOut := parsePool(tc.poolOutStr, poolOutIsXRP)
 
-				takerPays, takerGets, ok := paymenttx.ChangeSpotPriceQuality(
+				takerPays, takerGets, ok, _ := paymenttx.ChangeSpotPriceQuality(
 					poolIn, poolOut, tc.quality, tc.fee, fixAMMv1_1, poolOutIsXRP,
 				)
 

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -193,27 +193,28 @@ func (e *TestEnv) closeWithReplay() {
 	}
 	e.clock.Advance(resolution)
 
-	// Collect ALL transactions to replay in submission order:
-	// setup txns first (fund, trust, reimbursement), then user txns (fixture),
-	// then held transactions from previous ledgers.
-	// Submission order preserves dependencies (e.g., TrustSet before Payment).
-	//
-	// Note: rippled applies all txns in canonical (SHAMap-salted) order via
-	// buildLedger(). We use submission order because go-xrpl's setup txns have
-	// different hashes than rippled's, making the canonical salt impossible to
-	// match. Submission order produces the correct closed-ledger state for
-	// most cases because the retry mechanism handles ordering-dependent failures.
-	var allTxns []tx.Transaction
-	allTxns = append(allTxns, e.openLedgerSetupTxns...)
-	allTxns = append(allTxns, e.openLedgerUserTxns...)
+	// Setup txns (fund, trust, reimbursement, the DefaultRipple AccountSet) are
+	// scaffolding the runner synthesizes and master-signs; their go-xrpl-specific
+	// hashes cannot reproduce rippled's canonical salt, so reordering them
+	// canonically only risks separating a flag-setting AccountSet from the
+	// TrustSet that depends on it (e.g. an issuer's DefaultRipple must precede a
+	// holder's TrustSet, or the new line keeps the issuer's NoRipple and blocks
+	// rippling). Keep setup in submission order — the natural dependency order —
+	// and canonically order only the fixture's user txns, whose blob hashes do
+	// match rippled. Setup hashes are still folded into the salt so the user
+	// order is identical to canonically ordering the combined set.
+	setupTxns := append([]tx.Transaction(nil), e.openLedgerSetupTxns...)
+	var userTxns []tx.Transaction
+	userTxns = append(userTxns, e.openLedgerUserTxns...)
 	for _, held := range e.heldTxns {
-		allTxns = append(allTxns, held...)
+		userTxns = append(userTxns, held...)
 	}
 
-	// Sort all transactions using SHAMap-salted canonical ordering.
-	// The salt is the SHAMap root hash of all transaction hashes,
-	// matching rippled's CanonicalTXSet (RCLConsensus.cpp onClose).
-	sortCanonicalSalted(allTxns)
+	sortCanonicalSalted(userTxns, setupTxns)
+
+	var allTxns []tx.Transaction
+	allTxns = append(allTxns, setupTxns...)
+	allTxns = append(allTxns, userTxns...)
 
 	// Clear held transactions -- they will be re-held if they still fail
 	e.heldTxns = nil

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -212,7 +212,7 @@ func (e *TestEnv) closeWithReplay() {
 
 	sortCanonicalSalted(userTxns, setupTxns)
 
-	var allTxns []tx.Transaction
+	allTxns := make([]tx.Transaction, 0, len(setupTxns)+len(userTxns))
 	allTxns = append(allTxns, setupTxns...)
 	allTxns = append(allTxns, userTxns...)
 

--- a/internal/tx/payment/amm_liquidity.go
+++ b/internal/tx/payment/amm_liquidity.go
@@ -163,12 +163,18 @@ func (l *AMMLiquidity) generateOffer(view *PaymentSandbox, poolIn, poolOut tx.Am
 	}
 
 	// Single-path with CLOB quality: match spot price to CLOB quality
-	offerIn, offerOut, ok := ChangeSpotPriceQuality(
+	offerIn, offerOut, ok, blocked := ChangeSpotPriceQuality(
 		poolIn, poolOut, *clobQuality, l.tradingFee,
 		l.fixAMMv1_1, l.issueOut.IsXRP(),
 	)
 	if ok {
 		return NewAMMOffer(l, offerIn, offerOut, poolIn, poolOut)
+	}
+
+	// Quality-worse case: rippled Throws, which the generic catch turns into
+	// nullopt with no maxOffer fallback. The AMM stays blocked by the LOB tip.
+	if blocked {
+		return nil
 	}
 
 	// ChangeSpotPriceQuality failed. In rippled this can be either:

--- a/internal/tx/payment/amm_swap.go
+++ b/internal/tx/payment/amm_swap.go
@@ -376,26 +376,35 @@ func SolveQuadraticEqSmallest(a, b, c tx.Amount) *tx.Amount {
 // ChangeSpotPriceQuality generates an AMM offer so that either the updated
 // Spot Price Quality (SPQ) equals the LOB quality, or the AMM offer quality
 // equals the LOB quality.
+//
+// When ok is false, blocked distinguishes the two failure modes that rippled
+// signals via different control flow: blocked=false is a plain calc failure
+// (rippled returns std::nullopt, allowing a maxOffer fallback), while
+// blocked=true means the generated offer's quality is worse than the LOB tip
+// (rippled Throws, which suppresses the AMM offer entirely). blocked is only
+// ever set on the pre-fixAMMv1_1 path; post-fix never throws.
 // Reference: rippled AMMHelpers.h changeSpotPriceQuality()
-func ChangeSpotPriceQuality(poolIn, poolOut tx.Amount, quality Quality, tfee uint16, fixAMMv1_1 bool, outIsXRP bool) (in, out tx.Amount, ok bool) {
+func ChangeSpotPriceQuality(poolIn, poolOut tx.Amount, quality Quality, tfee uint16, fixAMMv1_1 bool, outIsXRP bool) (in, out tx.Amount, ok, blocked bool) {
 	if !fixAMMv1_1 {
 		return changeSpotPriceQualityPreFix(poolIn, poolOut, quality, tfee)
 	}
 
 	// Post-fixAMMv1_1: start with the XRP side for better rounding
 	if outIsXRP {
-		return getAMMOfferStartWithTakerGets(poolIn, poolOut, quality, tfee)
+		in, out, ok = getAMMOfferStartWithTakerGets(poolIn, poolOut, quality, tfee)
+	} else {
+		in, out, ok = getAMMOfferStartWithTakerPays(poolIn, poolOut, quality, tfee)
 	}
-	return getAMMOfferStartWithTakerPays(poolIn, poolOut, quality, tfee)
+	return in, out, ok, false
 }
 
 // changeSpotPriceQualityPreFix is the pre-fixAMMv1_1 implementation.
 // Solves: i^2*(1-fee) + i*I*(2-fee) + I^2 - I*O/quality = 0
 // Reference: rippled AMMHelpers.h changeSpotPriceQuality() pre-amendment path
-func changeSpotPriceQualityPreFix(poolIn, poolOut tx.Amount, quality Quality, tfee uint16) (in, out tx.Amount, ok bool) {
+func changeSpotPriceQualityPreFix(poolIn, poolOut tx.Amount, quality Quality, tfee uint16) (in, out tx.Amount, ok, blocked bool) {
 	qRate := qualityToRate(quality)
 	if qRate.IsZero() {
-		return tx.Amount{}, tx.Amount{}, false
+		return tx.Amount{}, tx.Amount{}, false, false
 	}
 
 	// Convert to Number for uniform arithmetic
@@ -415,7 +424,7 @@ func changeSpotPriceQualityPreFix(poolIn, poolOut tx.Amount, quality Quality, tf
 	four := state.NewIssuedAmountFromValue(4e15, -15, "", "")
 	disc := ammSub(b.Mul(b, false), four.Mul(a, false).Mul(c, false))
 	if disc.Signum() < 0 {
-		return tx.Amount{}, tx.Amount{}, false
+		return tx.Amount{}, tx.Amount{}, false, false
 	}
 
 	sqrtDisc := disc.Sqrt()
@@ -424,13 +433,13 @@ func changeSpotPriceQualityPreFix(poolIn, poolOut tx.Amount, quality Quality, tf
 	nTakerPaysPropose := ammAdd(neg_b, sqrtDisc).Div(two.Mul(a, false), false)
 
 	if nTakerPaysPropose.Signum() <= 0 {
-		return tx.Amount{}, tx.Amount{}, false
+		return tx.Amount{}, tx.Amount{}, false, false
 	}
 
 	// Constraint: i <= O / q - I / f
 	constraint := ammSub(nPoolOut.Mul(qRate, false), nPoolIn.Div(f, false))
 	if constraint.Signum() <= 0 {
-		return tx.Amount{}, tx.Amount{}, false
+		return tx.Amount{}, tx.Amount{}, false, false
 	}
 	if nTakerPaysPropose.Compare(constraint) > 0 {
 		nTakerPaysPropose = constraint
@@ -440,15 +449,19 @@ func changeSpotPriceQualityPreFix(poolIn, poolOut tx.Amount, quality Quality, tf
 	takerPays := fromNumberRoundUp(nTakerPaysPropose, poolIn)
 	takerGets := SwapAssetIn(poolIn, poolOut, takerPays, tfee, false)
 
+	// If the generated offer quality is worse than the target and not within
+	// the relative-distance tolerance, rippled Throws rather than returning
+	// nullopt. The throw suppresses the AMM offer entirely (no maxOffer
+	// fallback), leaving the AMM blocked by the LOB tip.
 	offerQ := QualityFromAmounts(toEitherAmt(takerPays), toEitherAmt(takerGets))
 	if offerQ.WorseThan(quality) {
 		rd := RelativeDistance(offerQ, quality)
 		if rd >= 1e-7 {
-			return tx.Amount{}, tx.Amount{}, false
+			return tx.Amount{}, tx.Amount{}, false, true
 		}
 	}
 
-	return takerPays, takerGets, true
+	return takerPays, takerGets, true, false
 }
 
 // getAMMOfferStartWithTakerGets generates AMM offer starting with takerGets.

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -559,9 +559,16 @@ func (s *BookStep) forEachOffer(
 		}
 	}
 
-	// If no CLOB offers found, try the AMM alone.
+	// The bounded walk yielded no crossable tip. Either the book is empty, or its
+	// only funded offers sit beyond the taker's quality limit and the walk stopped
+	// before crossing any. rippled still seeds the AMM with the raw book tip's
+	// quality in the latter case (offers.step() is unbounded by the limit; only
+	// the cross is gated), which lets a low-quality LOB tip block an AMM that
+	// would otherwise produce its maximum offer. Probe the raw funded tip and seed
+	// the AMM with it; fall back to nil only when the book truly has no crossable
+	// offer.
 	if firstCLOB {
-		tryAMM(nil)
+		tryAMM(s.firstCrossableTipQuality(sb, ofrsToRm, visited))
 	}
 }
 

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -255,6 +255,81 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 	}
 }
 
+// firstCrossableTipQuality returns the quality of the first funded, crossable
+// offer in the book, walking quality order and skipping the offers rippled's
+// OfferStream::step grooms (missing SLE, expired, out-of-domain, deep-frozen,
+// zero, unfunded, tiny). Unlike getNextOfferSkipVisited it ignores the taker's
+// quality limit and mutates nothing. It reproduces the quality rippled seeds the
+// AMM with: tryAMM(offers.tip().quality()) offers the raw book tip to the AMM
+// regardless of the limit, and only the crossing is gated by the quality
+// threshold. Returns nil when the book holds no crossable offer.
+func (s *BookStep) firstCrossableTipQuality(sb *PaymentSandbox, ofrsToRm, visited map[[32]byte]bool) *Quality {
+	bookBase := s.bookBaseKey()
+	bookPrefix := bookBase[:24]
+	searchKey := bookBase
+	for {
+		foundKey, foundData, found, err := sb.Succ(searchKey)
+		if err != nil || !found {
+			return nil
+		}
+		if !bytes.Equal(foundKey[:24], bookPrefix) {
+			return nil
+		}
+		dir, err := state.ParseDirectoryNode(foundData)
+		if err != nil {
+			searchKey = foundKey
+			continue
+		}
+		rootKey := foundKey
+		for {
+			for _, idx := range dir.Indexes {
+				var offerKey [32]byte
+				copy(offerKey[:], idx[:])
+				if (ofrsToRm != nil && ofrsToRm[offerKey]) || (visited != nil && visited[offerKey]) {
+					continue
+				}
+				offerData, rerr := sb.Read(keylet.Keylet{Key: offerKey})
+				if rerr != nil || offerData == nil {
+					continue
+				}
+				offer, perr := state.ParseLedgerOffer(offerData)
+				if perr != nil {
+					continue
+				}
+				if s.offerExpired(offer) || s.offerOutOfDomain(sb, offer) {
+					continue
+				}
+				offerOwner, derr := state.DecodeAccountID(offer.Account)
+				if derr != nil {
+					continue
+				}
+				if offer.TakerGets.IsZero() ||
+					s.isDeepFrozen(sb, offerOwner, s.book.In.Currency, s.book.In.Issuer) {
+					continue
+				}
+				funds := s.getOfferFundedAmount(sb, offer)
+				if funds.IsZero() || s.shouldRmSmallIncreasedQOffer(sb, offer, funds) {
+					continue
+				}
+				q := s.offerQuality(offer)
+				return &q
+			}
+			if dir.IndexNext == 0 {
+				break
+			}
+			pageData, rerr := sb.Read(keylet.DirPage(rootKey, dir.IndexNext))
+			if rerr != nil || pageData == nil {
+				break
+			}
+			dir, rerr = state.ParseDirectoryNode(pageData)
+			if rerr != nil {
+				break
+			}
+		}
+		searchKey = foundKey
+	}
+}
+
 // isFoundPermGroomable reports whether a beyond-limit non-own offer is one that
 // rippled's OfferStream::step would perm-remove as a FOUND removal — i.e. it was
 // already removable in the pristine view before any crossing touched it. This is


### PR DESCRIPTION
Brings the `app/AMM` conformance suite to 100% by fixing the two remaining in-scope failures. They are independent root causes.

## AMM_Offer_Blocked_By_LOB (pre-fixAMMv1_1 path)

The fixture enables `fixAMMv1_2` but **not** `fixAMMv1_1`, exercising the pre-amendment "blocked by LOB" path. carol's offer was crossing the AMM when rippled leaves it blocked behind alice's low-quality LOB offer.

Two compounding bugs:

1. **`ChangeSpotPriceQuality` conflated rippled's two pre-amendment failure modes.** rippled's `changeSpotPriceQuality` pre-`fixAMMv1_1` either returns `nullopt` (calc failure → allows the `fixAMMv1_2` maxOffer fallback) or `Throw`s (the generated offer's quality is worse than the LOB tip → caught by the generic `catch` → `nullopt` with **no** maxOffer fallback → AMM blocked). go-xrpl returned a single `ok bool`, so the throw case fell into the maxOffer fallback and crossed. Added a `blocked` return; `generateOffer` now returns `nil` (no fallback) when blocked.

2. **The LOB tip never reached the AMM.** `getNextOfferSkipVisited(enforceQualityBound=true)` returns `nil` at a funded tip beyond the taker's quality limit, so `firstCLOB` stayed true and `tryAMM(nil)` produced a crossing maxOffer. rippled's `offers.step()` yields the raw funded tip regardless of the limit and seeds `tryAMM(offers.tip().quality())`; only `checkQualityThreshold` inside `execOffer` gates the cross. Added a read-only `firstCrossableTipQuality` probe so the end-of-walk `tryAMM` is seeded with the raw funded tip quality. The probe mutates nothing, so the tuned crossing/grooming walk is untouched.

## Invalid_Deposit (setup transaction ordering — not an AMM bug)

carol's USD→XRP offers never crossed the just-created AMM. Tracing showed `ToStrands` returning `terNO_RIPPLE`: the carol↔gateway USD trust line carried the gateway's NoRipple flag. `tx.TrustCreate` sets the peer (issuer) side's NoRipple when the peer lacks `lsfDefaultRipple` at creation time. The runner's `FundAmount` applies DefaultRipple as a **separate** AccountSet txn, and `closeWithReplay` canonically reordered all setup + user txns together — sometimes landing carol's TrustSet before the gateway's DefaultRipple AccountSet, so the line kept the issuer's NoRipple and blocked the strand.

The canonical close order of the *user* txns was already correct (AMMCreate sorted first); the divergence was upstream in the setup ledger. Setup txns are synthesized and master-signed by the runner, so their hashes cannot reproduce rippled's canonical salt; reordering them is meaningless and only risks breaking dependencies. They now keep submission order (their natural dependency order) while the fixture's user txns are still canonically ordered. Setup hashes remain folded into the salt, so the user ordering is byte-identical to before.

## Verification

- `app/AMM` 42/0, `app/AMMClawback` 12/0, `app/AMMExtended` 44/0 — all 100%.
- Full conformance in-scope: **1256 pass / 5 fail** (was 7). The 5 remaining are the pre-existing `AccountDelete`, `DepositAuth`, and `TxQMetaInfo`×3 failures — unrelated to this change.
- Setup-ordering-sensitive suites all 100%: `SetTrust` 14/14, `TrustAndBalance` 13/13, `Transaction_ordering` 3/3, `Path` 45/45, all `Offer*` 59/59.
- `internal/testing/offer`, `internal/testing/amm`, `internal/tx/{offer,payment,trustset}` all pass; `gofmt`/`go vet` clean.