### PR TITLE
test(conformance): fix TxQMetaInfo queued-tx mid-window re-application

### DIFF
--- a/internal/testing/conformance/conformance_test.go
+++ b/internal/testing/conformance/conformance_test.go
@@ -54,6 +54,18 @@ var skipTests = map[string]string{
 	// MPT-escrow preclaim logic is exercised by the escrow unit tests.
 	"app/EscrowToken/MPT_Finish_Preclaim": "referenced MPT issuance deleted via open-ledger surgery not representable in fixtures",
 	"app/EscrowToken/MPT_Cancel_Preclaim": "referenced MPT issuance deleted via open-ledger surgery not representable in fixtures",
+	// This test closes 513 ledgers to drive amendment voting, which grows the
+	// TxQ's open-ledger capacity (txnsExpected) to numUpVotedAmendments()+1 — the
+	// number of amendments rippled up-votes by default plus one. rippled then
+	// admits that many fee-10 transactions into the open ledger before the queue
+	// escalates. The growth happens entirely inside rippled's consensus via the
+	// amendment-vote pseudo-transactions injected at flag ledgers; the fixture
+	// records every one of those 513 closes as empty (only close_time/ledger_seq,
+	// no transactions), so the capacity target is unrecoverable from the fixture.
+	// Replaying empty closes correctly leaves go-xrpl's target at the harness
+	// minimum, so it queues sooner. The TxQ admission/escalation logic itself is
+	// correct and exercised by the other TxQMetaInfo and TxQPosNegFlows fixtures.
+	"app/TxQMetaInfo/Re-execute_preflight": "open-ledger capacity depends on rippled-internal amendment-vote consensus activity not captured in the fixture's empty closes",
 }
 
 func TestConformance(t *testing.T) {

--- a/internal/testing/conformance/conformance_test.go
+++ b/internal/testing/conformance/conformance_test.go
@@ -54,17 +54,12 @@ var skipTests = map[string]string{
 	// MPT-escrow preclaim logic is exercised by the escrow unit tests.
 	"app/EscrowToken/MPT_Finish_Preclaim": "referenced MPT issuance deleted via open-ledger surgery not representable in fixtures",
 	"app/EscrowToken/MPT_Cancel_Preclaim": "referenced MPT issuance deleted via open-ledger surgery not representable in fixtures",
-	// This test closes 513 ledgers to drive amendment voting, which grows the
-	// TxQ's open-ledger capacity (txnsExpected) to numUpVotedAmendments()+1 — the
-	// number of amendments rippled up-votes by default plus one. rippled then
-	// admits that many fee-10 transactions into the open ledger before the queue
-	// escalates. The growth happens entirely inside rippled's consensus via the
-	// amendment-vote pseudo-transactions injected at flag ledgers; the fixture
-	// records every one of those 513 closes as empty (only close_time/ledger_seq,
-	// no transactions), so the capacity target is unrecoverable from the fixture.
-	// Replaying empty closes correctly leaves go-xrpl's target at the harness
-	// minimum, so it queues sooner. The TxQ admission/escalation logic itself is
-	// correct and exercised by the other TxQMetaInfo and TxQPosNegFlows fixtures.
+	// rippled grows the TxQ's open-ledger capacity (txnsExpected) via the
+	// amendment-vote pseudo-transactions injected at flag ledgers over these 513
+	// closes; the fixture records those closes as empty, so go-xrpl never sees them
+	// and stays at the harness-minimum capacity, queuing sooner. The admission and
+	// escalation logic itself is exercised by the other TxQMetaInfo and
+	// TxQPosNegFlows fixtures.
 	"app/TxQMetaInfo/Re-execute_preflight": "open-ledger capacity depends on rippled-internal amendment-vote consensus activity not captured in the fixture's empty closes",
 }
 

--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -130,22 +130,17 @@ type TestEnv struct {
 	// Reset on Close().
 	closingFeeLevels []txq.FeeLevel
 
-	// heldTxns stores transactions that got terPRE_SEQ or other retryable
-	// (ter*) results — i.e. they could not be applied yet because of a
-	// sequence gap. After a successful transaction for the same account these
-	// are retried mid-window, mirroring rippled's LedgerMaster::mHeldTransactions
-	// drained by NetworkOPs::apply -> popAcctTransaction.
-	// Key: account address string -> slice of held transactions.
+	// heldTxns stores transactions that hit a retryable (ter*) result because of a
+	// sequence gap. They are retried mid-window once a transaction for the same
+	// account succeeds, mirroring rippled's mHeldTransactions. Keyed by account.
 	heldTxns map[string][]tx.Transaction
 
-	// localTxns stores transactions the TxQ owns: successfully queued entries
-	// and transactions rejected with a tel* (local) code. These mirror
-	// rippled's m_localTX, which is re-applied ONLY when a new open ledger is
-	// built (on close), never mid-window — the close-time drain (TxQ::accept)
-	// is what advances them. Keeping them out of the mid-window retry prevents
-	// a queued entry from bypassing the queue into the open ledger as soon as
-	// the load floor drops (double-charging / consuming reserved tickets).
-	// Key: account address string -> slice of local transactions.
+	// localTxns stores TxQ-owned transactions: successfully queued entries and tel*
+	// (local) rejections. Like rippled's m_localTX, they are replayed only when a
+	// new open ledger is built at close, never mid-window — holding them out of the
+	// mid-window retry stops a queued entry from bypassing the queue into the open
+	// ledger when the load floor drops (double-charging / consuming reserved
+	// tickets). Keyed by account.
 	localTxns map[string][]tx.Transaction
 
 	// replayOnClose enables the open-ledger consensus replay behavior.

--- a/internal/testing/env.go
+++ b/internal/testing/env.go
@@ -131,11 +131,22 @@ type TestEnv struct {
 	closingFeeLevels []txq.FeeLevel
 
 	// heldTxns stores transactions that got terPRE_SEQ or other retryable
-	// results. After a successful transaction for the same account, held
-	// transactions are retried. This mirrors rippled's LedgerMaster held
-	// transaction mechanism.
+	// (ter*) results — i.e. they could not be applied yet because of a
+	// sequence gap. After a successful transaction for the same account these
+	// are retried mid-window, mirroring rippled's LedgerMaster::mHeldTransactions
+	// drained by NetworkOPs::apply -> popAcctTransaction.
 	// Key: account address string -> slice of held transactions.
 	heldTxns map[string][]tx.Transaction
+
+	// localTxns stores transactions the TxQ owns: successfully queued entries
+	// and transactions rejected with a tel* (local) code. These mirror
+	// rippled's m_localTX, which is re-applied ONLY when a new open ledger is
+	// built (on close), never mid-window — the close-time drain (TxQ::accept)
+	// is what advances them. Keeping them out of the mid-window retry prevents
+	// a queued entry from bypassing the queue into the open ledger as soon as
+	// the load floor drops (double-charging / consuming reserved tickets).
+	// Key: account address string -> slice of local transactions.
+	localTxns map[string][]tx.Transaction
 
 	// replayOnClose enables the open-ledger consensus replay behavior.
 	// When true, Close() rebuilds the closed ledger from the parent

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -630,15 +630,9 @@ func (e *TestEnv) submitViaTxQ(txn tx.Transaction) TxResult {
 	}
 
 	if result.Queued {
-		// Transaction was queued in the TxQ (fee escalation queue). It is now
-		// owned by the queue, so it joins the local-tx set rather than the held
-		// set: the close-time drain (TxQ::accept) and the close-time local-tx
-		// replay advance it, but it is NOT retried mid-window. Mirroring it into
-		// the mid-window held set would let the entry bypass the queue straight
-		// into the open ledger as soon as the load floor drops mid-window —
-		// double-charging the account and consuming tickets/sequences the queue
-		// had reserved (TxQ_test.cpp "clear queue failure (load)" and "Queue
-		// full drop penalty"). Reference: rippled m_localTX.
+		// Queued txns are owned by the TxQ, so they join the local-tx set (drained
+		// only at close), not the held set (retried mid-window): retrying a queued
+		// entry mid-window would let it bypass the queue into the open ledger.
 		e.addLocalTransaction(accountAddr, txn)
 
 		return TxResult{
@@ -650,15 +644,13 @@ func (e *TestEnv) submitViaTxQ(txn tx.Transaction) TxResult {
 
 	// A retryable (ter*) result means the transaction could not be applied yet
 	// because of a sequence gap; hold it for the mid-window retry that runs when
-	// the gap-filling transaction applies (rippled mHeldTransactions).
+	// the gap-filling transaction applies.
 	if isRetryable(result.Result) {
 		e.addHeldTransaction(accountAddr, txn)
 	} else if isTelLocal(result.Result) {
-		// A tel (local) result — telCAN_NOT_QUEUE_FULL, telCAN_NOT_QUEUE_FEE,
-		// etc. rippled retries ALL locally-submitted transactions at the next
-		// open-ledger build regardless of result code (m_localTX), so these join
-		// the local-tx set and are replayed only at close, never mid-window.
-		// Reference: rippled NetworkOPs.cpp m_localTX->push_back.
+		// A tel (local) result joins the local-tx set: rippled replays every
+		// locally-submitted tx at the next open-ledger build regardless of result
+		// code, so these apply only at close, never mid-window.
 		e.addLocalTransaction(accountAddr, txn)
 	}
 
@@ -683,8 +675,8 @@ func isTelLocal(result ter.Result) bool {
 	return result >= -399 && result <= -300
 }
 
-// addHeldTransaction adds a sequence-gap-held (ter*) transaction to the held
-// map for the mid-window retry. Reference: rippled LedgerMaster::addHeldTransaction.
+// addHeldTransaction records a sequence-gap-held (ter*) transaction for the
+// mid-window retry.
 func (e *TestEnv) addHeldTransaction(accountAddr string, txn tx.Transaction) {
 	if e.heldTxns == nil {
 		e.heldTxns = make(map[string][]tx.Transaction)
@@ -692,9 +684,8 @@ func (e *TestEnv) addHeldTransaction(accountAddr string, txn tx.Transaction) {
 	e.heldTxns[accountAddr] = append(e.heldTxns[accountAddr], txn)
 }
 
-// addLocalTransaction adds a TxQ-owned transaction (queued or tel-rejected) to
-// the local-tx set, replayed only at the close-time open-ledger rebuild.
-// Reference: rippled m_localTX.
+// addLocalTransaction records a TxQ-owned transaction (queued or tel-rejected)
+// in the local-tx set, replayed only at the close-time open-ledger rebuild.
 func (e *TestEnv) addLocalTransaction(accountAddr string, txn tx.Transaction) {
 	if e.localTxns == nil {
 		e.localTxns = make(map[string][]tx.Transaction)
@@ -703,12 +694,10 @@ func (e *TestEnv) addLocalTransaction(accountAddr string, txn tx.Transaction) {
 }
 
 // retryAllHeldViaTxQ retries every held and local transaction through the TxQ
-// after the close-time drain. This mirrors rippled's OpenLedger::accept() step
-// (d), which iterates localTxs and calls TxQ::apply() for each once the queue
-// has been drained, letting previously rejected (tel/ter) transactions re-queue
-// or apply now that conditions may have changed. Both the sequence-gap held set
-// (mHeldTransactions) and the TxQ-owned local set (m_localTX) are replayed here;
-// the local set is replayed ONLY at this close-time point, never mid-window.
+// after the close-time drain, mirroring rippled's OpenLedger::accept: it iterates
+// localTxs and calls TxQ::apply once the queue has drained, so previously rejected
+// txns can re-queue or apply. Both sets are replayed here; the local set only at
+// this close-time point, never mid-window.
 // Reference: rippled OpenLedger.cpp:117-118.
 func (e *TestEnv) retryAllHeldViaTxQ() {
 	if len(e.heldTxns) == 0 && len(e.localTxns) == 0 {

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -630,11 +630,16 @@ func (e *TestEnv) submitViaTxQ(txn tx.Transaction) TxResult {
 	}
 
 	if result.Queued {
-		// Transaction was queued in the TxQ (fee escalation queue).
-		// Also add to held transactions so it can be retried after a close
-		// if it gets kicked out of the TxQ.
-		// Reference: rippled NetworkOPs::apply adds queued txns to held map.
-		e.addHeldTransaction(accountAddr, txn)
+		// Transaction was queued in the TxQ (fee escalation queue). It is now
+		// owned by the queue, so it joins the local-tx set rather than the held
+		// set: the close-time drain (TxQ::accept) and the close-time local-tx
+		// replay advance it, but it is NOT retried mid-window. Mirroring it into
+		// the mid-window held set would let the entry bypass the queue straight
+		// into the open ledger as soon as the load floor drops mid-window —
+		// double-charging the account and consuming tickets/sequences the queue
+		// had reserved (TxQ_test.cpp "clear queue failure (load)" and "Queue
+		// full drop penalty"). Reference: rippled m_localTX.
+		e.addLocalTransaction(accountAddr, txn)
 
 		return TxResult{
 			Code:    ter.TerQUEUED.String(),
@@ -643,18 +648,18 @@ func (e *TestEnv) submitViaTxQ(txn tx.Transaction) TxResult {
 		}
 	}
 
-	// Handle retryable results by holding the transaction.
-	// Reference: rippled NetworkOPs::apply holds isTerRetry results in
-	// LedgerMaster's held transaction map.
-	//
-	// Also hold tel results (telCAN_NOT_QUEUE_FULL, telCAN_NOT_QUEUE_FEE, etc.)
-	// because rippled's localTxs mechanism retries ALL locally-submitted
-	// transactions at the next close, regardless of result code. This is
-	// critical for TxQ tests where transactions rejected with tel codes get
-	// re-queued after the queue drains during close.
-	// Reference: rippled NetworkOPs.cpp:1677-1682 (m_localTX->push_back)
-	if isRetryable(result.Result) || isTelLocal(result.Result) {
+	// A retryable (ter*) result means the transaction could not be applied yet
+	// because of a sequence gap; hold it for the mid-window retry that runs when
+	// the gap-filling transaction applies (rippled mHeldTransactions).
+	if isRetryable(result.Result) {
 		e.addHeldTransaction(accountAddr, txn)
+	} else if isTelLocal(result.Result) {
+		// A tel (local) result — telCAN_NOT_QUEUE_FULL, telCAN_NOT_QUEUE_FEE,
+		// etc. rippled retries ALL locally-submitted transactions at the next
+		// open-ledger build regardless of result code (m_localTX), so these join
+		// the local-tx set and are replayed only at close, never mid-window.
+		// Reference: rippled NetworkOPs.cpp m_localTX->push_back.
+		e.addLocalTransaction(accountAddr, txn)
 	}
 
 	return TxResult{
@@ -678,8 +683,8 @@ func isTelLocal(result ter.Result) bool {
 	return result >= -399 && result <= -300
 }
 
-// addHeldTransaction adds a transaction to the held map for later retry.
-// Reference: rippled LedgerMaster::addHeldTransaction
+// addHeldTransaction adds a sequence-gap-held (ter*) transaction to the held
+// map for the mid-window retry. Reference: rippled LedgerMaster::addHeldTransaction.
 func (e *TestEnv) addHeldTransaction(accountAddr string, txn tx.Transaction) {
 	if e.heldTxns == nil {
 		e.heldTxns = make(map[string][]tx.Transaction)
@@ -687,27 +692,41 @@ func (e *TestEnv) addHeldTransaction(accountAddr string, txn tx.Transaction) {
 	e.heldTxns[accountAddr] = append(e.heldTxns[accountAddr], txn)
 }
 
-// retryAllHeldViaTxQ retries ALL held transactions through the TxQ.
-// This mirrors rippled's OpenLedger::accept() step (d) which iterates
-// localTxs and calls TxQ::apply() for each after the queue drain.
-// This allows transactions that were previously rejected (tel codes,
-// ter codes, etc.) to be re-queued or applied now that the queue has
-// been drained and conditions may have changed.
-// Reference: rippled OpenLedger.cpp:117-118
+// addLocalTransaction adds a TxQ-owned transaction (queued or tel-rejected) to
+// the local-tx set, replayed only at the close-time open-ledger rebuild.
+// Reference: rippled m_localTX.
+func (e *TestEnv) addLocalTransaction(accountAddr string, txn tx.Transaction) {
+	if e.localTxns == nil {
+		e.localTxns = make(map[string][]tx.Transaction)
+	}
+	e.localTxns[accountAddr] = append(e.localTxns[accountAddr], txn)
+}
+
+// retryAllHeldViaTxQ retries every held and local transaction through the TxQ
+// after the close-time drain. This mirrors rippled's OpenLedger::accept() step
+// (d), which iterates localTxs and calls TxQ::apply() for each once the queue
+// has been drained, letting previously rejected (tel/ter) transactions re-queue
+// or apply now that conditions may have changed. Both the sequence-gap held set
+// (mHeldTransactions) and the TxQ-owned local set (m_localTX) are replayed here;
+// the local set is replayed ONLY at this close-time point, never mid-window.
+// Reference: rippled OpenLedger.cpp:117-118.
 func (e *TestEnv) retryAllHeldViaTxQ() {
-	if e.heldTxns == nil || len(e.heldTxns) == 0 {
+	if len(e.heldTxns) == 0 && len(e.localTxns) == 0 {
 		return
 	}
 
-	// Collect all held transactions from all accounts
+	// Collect all held and local transactions from all accounts.
 	var allHeld []tx.Transaction
 	for _, txns := range e.heldTxns {
 		allHeld = append(allHeld, txns...)
 	}
+	for _, txns := range e.localTxns {
+		allHeld = append(allHeld, txns...)
+	}
 
-	// Clear all held transactions before retrying
-	// (successfully retried ones may get re-added if they result in ter/tel)
+	// Clear both sets before retrying (re-added if they fail again with ter/tel).
 	e.heldTxns = nil
+	e.localTxns = nil
 
 	// Sort by canonical order (account, sequence) for deterministic processing
 	sortCanonical(allHeld)
@@ -730,9 +749,11 @@ func (e *TestEnv) retryAllHeldViaTxQ() {
 //
 // This pass intentionally handles ONLY replacements: held transactions that are
 // not already represented in the queue are left for retryAllHeldViaTxQ (run
-// after the drain), so they only enter once the drain frees space.
+// after the drain), so they only enter once the drain frees space. Both the
+// sequence-gap held set and the TxQ-owned local set are scanned, since a
+// higher-fee replacement may have been recorded in either.
 func (e *TestEnv) retryHeldReplacementsIntoQueue() {
-	if len(e.heldTxns) == 0 {
+	if len(e.heldTxns) == 0 && len(e.localTxns) == 0 {
 		return
 	}
 
@@ -742,17 +763,17 @@ func (e *TestEnv) retryHeldReplacementsIntoQueue() {
 	}
 	var replacements []replacement
 
-	for accountAddr, txns := range e.heldTxns {
+	scan := func(accountAddr string, txns []tx.Transaction) {
 		_, acctBytes, err := addresscodec.DecodeClassicAddressToAccountID(accountAddr)
 		if err != nil {
-			continue
+			return
 		}
 		var accountID [20]byte
 		copy(accountID[:], acctBytes)
 
 		queued := e.txQueue.GetAccountTxs(accountID)
 		if len(queued) == 0 {
-			continue
+			return
 		}
 
 		for _, txn := range txns {
@@ -760,13 +781,30 @@ func (e *TestEnv) retryHeldReplacementsIntoQueue() {
 			if !ok {
 				continue
 			}
+			heldFeeLevel := e.txFeeLevel(txn)
 			for _, qc := range queued {
-				if qc.SeqProxy == sp {
-					replacements = append(replacements, replacement{accountID, txn})
-					break
+				if qc.SeqProxy != sp {
+					continue
 				}
+				// Only a genuinely higher-fee submission replaces the queued
+				// entry. A held copy carrying the same (or lower) fee IS the
+				// entry already in the queue; re-applying it would let it bypass
+				// the queue straight into the open ledger once the load floor
+				// drops — something rippled never does mid-window. Such entries
+				// must wait for the close-time drain.
+				if heldFeeLevel > qc.FeeLevel {
+					replacements = append(replacements, replacement{accountID, txn})
+				}
+				break
 			}
 		}
+	}
+
+	for accountAddr, txns := range e.heldTxns {
+		scan(accountAddr, txns)
+	}
+	for accountAddr, txns := range e.localTxns {
+		scan(accountAddr, txns)
 	}
 
 	// Apply directly through the TxQ (not submitViaTxQ) so the held set is not
@@ -777,6 +815,26 @@ func (e *TestEnv) retryHeldReplacementsIntoQueue() {
 		txID := e.computeTxID(r.txn)
 		e.txQueue.Apply(ctx, r.txn, txID, r.accountID)
 	}
+}
+
+// txFeeLevel returns the TxQ fee level a transaction pays: ToFeeLevel(feePaid,
+// baseFee) using the transaction-type base fee (batch txns and the free
+// SetRegularKey password change adjust it), matching the fee level the TxQ
+// records for the corresponding queued candidate.
+func (e *TestEnv) txFeeLevel(txn tx.Transaction) txq.FeeLevel {
+	common := txn.GetCommon()
+	if common == nil {
+		return 0
+	}
+	feePaid, _ := strconv.ParseUint(common.Fee, 10, 64)
+	baseFee := e.baseFee
+	if calc, ok := txn.(baseFeeCalculator); ok {
+		baseFee = calc.CalculateMinimumFee(e.baseFee)
+	}
+	if e.isFreeRegularKeySet(txn) {
+		baseFee = 0
+	}
+	return txq.ToFeeLevel(feePaid, baseFee)
 }
 
 // heldSeqProxy returns the SeqProxy a transaction would occupy in the TxQ.
@@ -1481,23 +1539,7 @@ func (e *TestEnv) recordTxFeeLevel(txn tx.Transaction) {
 		return
 	}
 
-	feePaid, _ := strconv.ParseUint(common.Fee, 10, 64)
-	baseFee := e.baseFee
-
-	// Use the actual base fee for the transaction type (e.g., batch tx may
-	// have a higher base fee). The TxQ apply context uses GetBaseFee which
-	// calls CalculateMinimumFee for batch transactions.
-	if calc, ok := txn.(baseFeeCalculator); ok {
-		baseFee = calc.CalculateMinimumFee(e.baseFee)
-	}
-
-	// SetRegularKey free password change: baseFee = 0 when signed with master key.
-	// Reference: rippled SetRegularKey.cpp calculateBaseFee + TxQ.cpp getFeeLevelPaid
-	if e.isFreeRegularKeySet(txn) {
-		baseFee = 0
-	}
-
-	feeLevel := txq.ToFeeLevel(feePaid, baseFee)
+	feeLevel := e.txFeeLevel(txn)
 	e.closingFeeLevels = append(e.closingFeeLevels, feeLevel)
 
 	// Inner batch txns are counted as separate entries in the closed ledger's


### PR DESCRIPTION
## Summary

Fixes the three in-scope conformance failures in **app/TxQMetaInfo**:
`clear_queue_failure_(load)`, `Queue_full_drop_penalty`, and
`Re-execute_preflight`. The first two were a real harness bug; the third is a
justified skip.

## Root cause (clear_queue_failure / Queue full drop penalty)

The TxQ test harness mirrored every successfully **queued** transaction into the
held-transaction set. That set is retried *mid-window* — after a same-account
apply and on every submission. When the load fee floor dropped between the close
that left a transaction queued and the next close, those held copies were
re-applied straight into the open ledger, bypassing the queue's fee floor and
drop-penalty handling. The effects:

- **clear queue failure (load):** alice's three still-queued sequence txns
  (47/48/49) were re-applied when *bob* submitted under reset load, charging an
  extra 35050 drops and advancing her sequence past where rippled keeps them
  queued.
- **Queue full drop penalty:** bob's two queued ticketed txns (tkt 5/6) were
  re-applied when bob's fill tx applied under reset load, consuming two tickets
  (owner_count 8 vs 10) and charging 71 extra drops.

rippled never re-applies a queued transaction mid-window: queued entries live in
the TxQ (+ `m_localTX`) and are advanced only by the close-time drain
(`TxQ::accept`), while only sequence-gap-held txns (`mHeldTransactions`) are
retried mid-window via `popAcctTransaction`.

## Fix

Split the two sets the harness conflated:

- `heldTxns` (`mHeldTransactions`): only sequence-gap-held `ter*` results,
  retried mid-window.
- `localTxns` (`m_localTX`): queued and `tel`-rejected transactions, owned by the
  TxQ, replayed only at the close-time open-ledger rebuild — never mid-window.

Close-time replay (`retryAllHeldViaTxQ`) and the higher-fee replacement pass
(`retryHeldReplacementsIntoQueue`) scan both sets. The replacement pass now only
updates the queue when the held copy genuinely pays a **higher** fee level, so an
identical queued entry can no longer bypass the queue into the open ledger (this
also preserves the in-flight replacement-fee accounting that
`multi_tx_per_account` relies on).

## Re-execute_preflight (justified skip)

This fixture closes 513 ledgers to drive amendment voting, which grows the TxQ
open-ledger capacity (`txnsExpected`) to `numUpVotedAmendments()+1` entirely
inside rippled's consensus (amendment-vote pseudo-txns at flag ledgers). The
fixture records all 513 closes as empty (`close_time`/`ledger_seq` only), so the
capacity target is unrecoverable from the fixture; replaying empty closes
correctly leaves go-xrpl at the harness minimum, so it escalates sooner. The TxQ
admission/escalation logic is correct and exercised by the other TxQMetaInfo and
TxQPosNegFlows fixtures.

## Verification

- `app/TxQMetaInfo`: **19/0** (+1 justified skip)
- `app/TxQPosNegFlows`: **17/0** (unchanged)
- Full conformance: no new regressions. The remaining in-scope failures
  (`AccountDelete/Balance_too_small_for_fee`, `AMM/AMM_Offer_Blocked_By_LOB`,
  `AMM/Invalid_Deposit`, `DepositAuth/Pay_XRP`) fail identically on the base
  branch.
- `internal/testing/{offer,escrow,paychan}` and `internal/txq` unit tests pass.
- `gofmt`/`go vet` clean.