### PR TITLE
refactor: hoist FlagLedgerInterval/IsFlagLedger into protocol package

### DIFF
--- a/internal/consensus/adaptor/negative_unl_vote.go
+++ b/internal/consensus/adaptor/negative_unl_vote.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/consensus/negativeunlvote"
 	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // GenerateNegativeUNLPseudoTx produces the UNLModify pseudo-tx blobs
@@ -182,12 +183,12 @@ func (a *Adaptor) buildNegativeUNLScoreTable(
 	historian consensus.ValidationHistorian,
 ) (map[consensus.NodeID]uint32, bool) {
 	ancestors, err := prev.SkipListHashes()
-	if err != nil || uint32(len(ancestors)) < consensus.FlagLedgerInterval {
+	if err != nil || uint32(len(ancestors)) < protocol.FlagLedgerInterval {
 		return nil, false
 	}
 
 	n := uint32(len(ancestors))
-	window := consensus.FlagLedgerInterval
+	window := protocol.FlagLedgerInterval
 	scoreTable := make(map[consensus.NodeID]uint32)
 	for i := range window {
 		ledgerHash := ancestors[n-1-i]

--- a/internal/consensus/adaptor/negative_unl_vote_test.go
+++ b/internal/consensus/adaptor/negative_unl_vote_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/consensus/negativeunlvote"
 	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -154,7 +155,7 @@ func TestBuildScoreTable_RejectsShortSkipList(t *testing.T) {
 func TestBuildScoreTable_DoesNotGateOnLocalParticipation(t *testing.T) {
 	a := newTestAdaptor(t)
 
-	ancestors := make([][32]byte, consensus.FlagLedgerInterval)
+	ancestors := make([][32]byte, protocol.FlagLedgerInterval)
 	for i := range ancestors {
 		ancestors[i] = [32]byte{byte(i), 0xAB}
 	}
@@ -186,7 +187,7 @@ func TestBuildScoreTable_DoesNotGateOnLocalParticipation(t *testing.T) {
 func TestBuildScoreTable_TalliesAcrossAncestors(t *testing.T) {
 	a := newTestAdaptor(t)
 
-	ancestors := make([][32]byte, consensus.FlagLedgerInterval)
+	ancestors := make([][32]byte, protocol.FlagLedgerInterval)
 	for i := range ancestors {
 		ancestors[i] = [32]byte{byte(i >> 8), byte(i), 0xCD}
 	}
@@ -213,7 +214,7 @@ func TestBuildScoreTable_TalliesAcrossAncestors(t *testing.T) {
 	require.True(t, ok, "a full skip-list of FlagLedgerInterval ancestors builds the table")
 	require.NotNil(t, scoreTable)
 
-	assert.Equal(t, consensus.FlagLedgerInterval, scoreTable[myID], "local validator scored on every ancestor")
+	assert.Equal(t, protocol.FlagLedgerInterval, scoreTable[myID], "local validator scored on every ancestor")
 	assert.Equal(t, uint32(50), scoreTable[offline], "offline validator scored only on first 50 ancestors")
 }
 

--- a/internal/consensus/ledger_timing.go
+++ b/internal/consensus/ledger_timing.go
@@ -14,25 +14,6 @@ const increaseLedgerTimeResolutionEvery uint32 = 8
 // decreaseLedgerTimeResolutionEvery: every N disagreeing rounds, step to a coarser bin.
 const decreaseLedgerTimeResolutionEvery uint32 = 1
 
-// FlagLedgerInterval is the period (in ledgers) on which validators vote on
-// amendments and fee/reserve changes. Matches rippled FLAG_LEDGER_INTERVAL
-// (Ledger.h:426).
-const FlagLedgerInterval uint32 = 256
-
-// IsFlagLedger reports whether the ledger at seq is a flag ledger — where fee
-// and amendment vote results take effect: seq % FlagLedgerInterval == 0.
-// Matches rippled isFlagLedger (Ledger.cpp:957).
-func IsFlagLedger(seq uint32) bool {
-	return seq%FlagLedgerInterval == 0
-}
-
-// IsVotingLedger reports whether the validation for the ledger at seq carries
-// fee- and amendment-vote fields — the ledger before a flag ledger:
-// (seq+1) % FlagLedgerInterval == 0. Matches rippled isVotingLedger (Ledger.cpp:950).
-func IsVotingLedger(seq uint32) bool {
-	return (seq+1)%FlagLedgerInterval == 0
-}
-
 // GetNextLedgerTimeResolution returns the close-time resolution (seconds) for
 // newLedgerSeq, given the parent's resolution and whether the prior round
 // agreed. Widening (on disagreement) lets clock-skewed peers round to the same

--- a/internal/consensus/negativeunlvote/vote.go
+++ b/internal/consensus/negativeunlvote/vote.go
@@ -16,6 +16,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/consensus/common"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // ErrLocalCountExceedsWindow signals the local node's validation count
@@ -24,21 +25,17 @@ import (
 var ErrLocalCountExceedsWindow = errors.New("negativeunlvote: local validation count exceeds flag-ledger window")
 
 const (
-	// scoring window in ledgers; duplicates consensus.FlagLedgerInterval as
-	// a uint32 so the thresholds below are compile-time constants
-	flagLedgerInterval uint32 = 256
-
 	// below this score a validator is unreliable → ToDisable candidate
-	LowWaterMark uint32 = flagLedgerInterval * 50 / 100
+	LowWaterMark uint32 = protocol.FlagLedgerInterval * 50 / 100
 
 	// above this score a disabled validator → ToReEnable candidate
-	HighWaterMark uint32 = flagLedgerInterval * 80 / 100
+	HighWaterMark uint32 = protocol.FlagLedgerInterval * 80 / 100
 
 	// minimum local validations to trust our own view; below it, abstain
-	MinLocalValsToVote uint32 = flagLedgerInterval * 90 / 100
+	MinLocalValsToVote uint32 = protocol.FlagLedgerInterval * 90 / 100
 
 	// ledgers a freshly-added validator is exempt from ToDisable voting
-	NewValidatorDisableSkip uint32 = flagLedgerInterval * 2
+	NewValidatorDisableSkip uint32 = protocol.FlagLedgerInterval * 2
 
 	// max fraction of the UNL that may be on the NegativeUNL at once
 	MaxListedFraction float64 = 0.25
@@ -177,8 +174,8 @@ func (v *Voter) DoVoting(
 	if myCount <= MinLocalValsToVote {
 		return nil, nil
 	}
-	if myCount > flagLedgerInterval {
-		return nil, fmt.Errorf("%w: %d > %d", ErrLocalCountExceedsWindow, myCount, flagLedgerInterval)
+	if myCount > protocol.FlagLedgerInterval {
+		return nil, fmt.Errorf("%w: %d > %d", ErrLocalCountExceedsWindow, myCount, protocol.FlagLedgerInterval)
 	}
 
 	// effective negUNL for the upcoming flag ledger (current ± pending)

--- a/internal/consensus/negativeunlvote/vote_test.go
+++ b/internal/consensus/negativeunlvote/vote_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,17 +47,6 @@ func fullScoreTable(myID consensus.NodeID, keys [][33]byte) map[consensus.NodeID
 		st[nid] = HighWaterMark + 1
 	}
 	return st
-}
-
-// TestFlagLedgerIntervalMatchesConsensus guards against drift between
-// this package's compile-time flagLedgerInterval constant (duplicated so
-// the watermark thresholds can be evaluated at compile time) and the
-// canonical consensus.FlagLedgerInterval.
-func TestFlagLedgerIntervalMatchesConsensus(t *testing.T) {
-	if flagLedgerInterval != consensus.FlagLedgerInterval {
-		t.Fatalf("flagLedgerInterval (%d) drifted from consensus.FlagLedgerInterval (%d)",
-			flagLedgerInterval, consensus.FlagLedgerInterval)
-	}
 }
 
 func TestDoVoting_RefusesWhenLocalParticipationLow(t *testing.T) {
@@ -544,7 +534,7 @@ func TestDoVoting_LocalCountAboveWindow(t *testing.T) {
 	unl := [][33]byte{myKey, weak}
 
 	scoreTable := map[consensus.NodeID]uint32{
-		v.myID:            flagLedgerInterval + 1,
+		v.myID:            protocol.FlagLedgerInterval + 1,
 		keyToNodeID(weak): LowWaterMark - 1,
 	}
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1880,12 +1880,12 @@ func (e *Engine) closeLedger() {
 	if e.prevLedger != nil && (e.mode == consensus.ModeProposing || e.adaptor.IsStandalone()) {
 		prev := e.prevLedger
 		switch {
-		case consensus.IsFlagLedger(prev.Seq()):
+		case protocol.IsFlagLedger(prev.Seq()):
 			parentVals := e.parentValidations(prev.ParentID())
 			if extra := e.adaptor.GenerateFlagLedgerPseudoTxs(prev, parentVals); len(extra) > 0 {
 				txs = append(txs, extra...)
 			}
-		case consensus.IsVotingLedger(prev.Seq()) && e.adaptor.IsFeatureEnabledOnLedger(prev, "NegativeUNL"):
+		case protocol.IsVotingLedger(prev.Seq()) && e.adaptor.IsFeatureEnabledOnLedger(prev, "NegativeUNL"):
 			if extra := e.adaptor.GenerateNegativeUNLPseudoTx(prev); len(extra) > 0 {
 				txs = append(txs, extra...)
 			}
@@ -3103,7 +3103,7 @@ func (e *Engine) sendValidation(ledger consensus.Ledger) {
 		}
 		validation.Cookie = cookie
 
-		if consensus.IsVotingLedger(ledger.Seq()) {
+		if protocol.IsVotingLedger(ledger.Seq()) {
 			serverVersion := e.adaptor.GetServerVersion()
 			if serverVersion == 0 {
 				slog.Warn("sendValidation: serverVersion is zero on voting ledger under HardenedValidations — adaptor must advertise a build tag; emitting without serverVersion")
@@ -3114,7 +3114,7 @@ func (e *Engine) sendValidation(ledger consensus.Ledger) {
 
 	// Fee + amendment votes only on voting (flag) ledgers; emitting every
 	// ledger inflates bandwidth ~256× and confuses peer aggregators.
-	if consensus.IsVotingLedger(ledger.Seq()) {
+	if protocol.IsVotingLedger(ledger.Seq()) {
 		// Fee vote: AMOUNT triple under post-XRPFees rules, legacy UINT triple
 		// otherwise (never both). Zero = no vote, serializer omits.
 		if fv := e.adaptor.GetFeeVote(); fv.BaseFee != 0 || fv.ReserveBase != 0 || fv.ReserveIncrement != 0 {

--- a/internal/ledger/inbound/replay_delta.go
+++ b/internal/ledger/inbound/replay_delta.go
@@ -608,12 +608,10 @@ func (r *ReplayDelta) Apply(engineCfg tx.EngineConfig) (*ledger.Ledger, error) {
 
 	// R6b.1: on a flag ledger with featureNegativeUNL, apply pending
 	// ValidatorToDisable / ValidatorToReEnable transitions BEFORE
-	// applying any txs. Mirrors rippled BuildLedger.cpp:50-53. Without
-	// this, every 256th ledger's replay-delta produces a wrong
-	// AccountHash on networks with featureNegativeUNL and falls back
-	// to legacy catchup. seq%256==0 is rippled's isFlagLedger check
-	// (Ledger.cpp:946-958).
-	if child.Sequence()%256 == 0 && engineCfg.Rules != nil && engineCfg.Rules.Enabled(amendment.FeatureNegativeUNL) {
+	// applying any txs. Without this, every flag ledger's replay-delta
+	// produces a wrong AccountHash on networks with featureNegativeUNL
+	// and falls back to legacy catchup.
+	if protocol.IsFlagLedger(child.Sequence()) && engineCfg.Rules != nil && engineCfg.Rules.Enabled(amendment.FeatureNegativeUNL) {
 		if err := child.UpdateNegativeUNL(); err != nil {
 			return nil, fmt.Errorf("flag-ledger updateNegativeUNL: %w", err)
 		}

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -567,7 +567,7 @@ func (l *Ledger) Close(closeTime time.Time, closeFlags uint8) error {
 }
 
 // UpdateNegativeUNL applies pending ValidatorToDisable / ValidatorToReEnable
-// transitions on the NegativeUNL SLE during flag-ledger (seq%256==0) processing,
+// transitions on the NegativeUNL SLE during flag-ledger processing,
 // before any transactions are applied. No-op on any other ledger or when neither
 // transition field is set. Caller must NOT hold l.mu — it acquires it internally.
 func (l *Ledger) UpdateNegativeUNL() error {

--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/skiplist"
+	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
 
@@ -131,10 +132,10 @@ func (s *Service) AcceptLedgerAt(ctx context.Context, explicitCloseTime time.Tim
 // the result as s.openLedger, returning the txs left in retry state. Shared by
 // the standalone and consensus close paths. Caller must hold s.mu.
 // applyFlagLedgerNegativeUNL applies the pending NegativeUNL transition on a
-// flag ledger (seq%256==0) when featureNegativeUNL is enabled; skipping it on
-// the local close path forks account_hash from the network. Caller must hold s.mu.
+// flag ledger when featureNegativeUNL is enabled; skipping it on the local
+// close path forks account_hash from the network. Caller must hold s.mu.
 func (s *Service) applyFlagLedgerNegativeUNL(l *ledger.Ledger) error {
-	if l.Sequence()%256 != 0 {
+	if !protocol.IsFlagLedger(l.Sequence()) {
 		return nil
 	}
 	rules := rulesFromLedger(s.closedLedger, s.logger)

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -666,16 +666,16 @@ func (r *replayRangeRunner) processBlock(
 		return nil, nil, fmt.Errorf("loading amendments: %w", err)
 	}
 
-	// Flag-ledger NegativeUNL transition: on a flag ledger (seq % 256 == 0) with
+	// Flag-ledger NegativeUNL transition: on a flag ledger with
 	// featureNegativeUNL enabled, apply the pending ValidatorToDisable /
 	// ValidatorToReEnable transitions to the NegativeUNL entry BEFORE creating the
 	// tx-apply engine and applying txs, mirroring rippled BuildLedger.cpp:48-53
 	// (updateNegativeUNL runs on the freshly-built ledger before the OpenView
-	// tx-apply accum) and the catchup path (inbound/replay_delta.go:616-620). A
+	// tx-apply accum) and the catchup path in inbound/replay_delta.go. A
 	// UNLModify pseudo-tx sets the pending transition at one flag ledger; the next
-	// flag ledger moves it into DisabledValidators. Without this the 256th ledger
-	// after a UNLModify forks account_hash even though every transaction matches.
-	if targetLedger%256 == 0 && rules != nil && rules.Enabled(amendment.FeatureNegativeUNL) {
+	// flag ledger moves it into DisabledValidators. Without this the next flag
+	// ledger after a UNLModify forks account_hash even though every transaction matches.
+	if protocol.IsFlagLedger(targetLedger) && rules != nil && rules.Enabled(amendment.FeatureNegativeUNL) {
 		if err := openLedger.UpdateNegativeUNL(); err != nil {
 			return nil, nil, fmt.Errorf("flag-ledger updateNegativeUNL: %w", err)
 		}

--- a/internal/testing/pseudotx/unl_modify_test.go
+++ b/internal/testing/pseudotx/unl_modify_test.go
@@ -52,7 +52,7 @@ func TestUNLModify_NotFlagLedger(t *testing.T) {
 
 	// Default ledger sequence is typically 2 or 3 (not a flag ledger = multiple of 256)
 	seq := env.Ledger().Sequence()
-	require.NotEqual(t, uint32(0), seq%256, "Test setup: ledger should not be on a flag ledger")
+	require.False(t, protocol.IsFlagLedger(seq), "Test setup: ledger should not be on a flag ledger")
 
 	u := newUNLModify(1, seq, validatorKey1)
 	result := env.SubmitPseudo(u)

--- a/internal/testing/pseudotx/unl_modify_test.go
+++ b/internal/testing/pseudotx/unl_modify_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -235,10 +236,10 @@ func TestUNLModify_AlreadyHasToReEnable(t *testing.T) {
 	jtx.RequireTxFail(t, result, "tefFAILURE")
 }
 
-// advanceToFlagLedger advances the test environment to a flag ledger (seq % 256 == 0).
+// advanceToFlagLedger advances the test environment to a flag ledger.
 func advanceToFlagLedger(t *testing.T, env *jtx.TestEnv) {
 	t.Helper()
-	for env.Ledger().Sequence()%256 != 0 {
+	for !protocol.IsFlagLedger(env.Ledger().Sequence()) {
 		env.Close()
 	}
 }

--- a/internal/tx/pseudo/unl_modify.go
+++ b/internal/tx/pseudo/unl_modify.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // UNLModify is a pseudo-transaction that modifies the Negative UNL.
@@ -51,7 +52,7 @@ func (u *UNLModify) IsPseudoTransaction() bool {
 func (u *UNLModify) Apply(ctx *tx.ApplyContext) ter.Result {
 	// 1. Validate flag ledger
 	// Reference: rippled lines 390-395
-	if !isFlagLedger(ctx.Config.LedgerSequence) {
+	if !protocol.IsFlagLedger(ctx.Config.LedgerSequence) {
 		ctx.Log.Warn("unl modify: not a flag ledger",
 			"ledgerSequence", ctx.Config.LedgerSequence,
 		)
@@ -173,12 +174,6 @@ func (u *UNLModify) Apply(ctx *tx.ApplyContext) ter.Result {
 	}
 
 	return ter.TesSUCCESS
-}
-
-// isFlagLedger returns true if the ledger sequence is a flag ledger (multiple of 256).
-// Reference: rippled isFlagLedger()
-func isFlagLedger(seq uint32) bool {
-	return seq%256 == 0
 }
 
 // isValidPublicKeyType validates that the byte slice is a valid public key.

--- a/protocol/flag_ledger.go
+++ b/protocol/flag_ledger.go
@@ -1,0 +1,19 @@
+package protocol
+
+// FlagLedgerInterval is the period (in ledgers) on which validators vote on
+// amendments and fee/reserve changes. Matches rippled FLAG_LEDGER_INTERVAL.
+const FlagLedgerInterval uint32 = 256
+
+// IsFlagLedger reports whether the ledger at seq is a flag ledger — where fee
+// and amendment vote results take effect: seq % FlagLedgerInterval == 0.
+// Matches rippled isFlagLedger.
+func IsFlagLedger(seq uint32) bool {
+	return seq%FlagLedgerInterval == 0
+}
+
+// IsVotingLedger reports whether the validation for the ledger at seq carries
+// fee- and amendment-vote fields — the ledger before a flag ledger:
+// (seq+1) % FlagLedgerInterval == 0. Matches rippled isVotingLedger.
+func IsVotingLedger(seq uint32) bool {
+	return (seq+1)%FlagLedgerInterval == 0
+}

--- a/protocol/flag_ledger.go
+++ b/protocol/flag_ledger.go
@@ -1,19 +1,18 @@
 package protocol
 
 // FlagLedgerInterval is the period (in ledgers) on which validators vote on
-// amendments and fee/reserve changes. Matches rippled FLAG_LEDGER_INTERVAL.
+// amendments and fee/reserve changes.
 const FlagLedgerInterval uint32 = 256
 
 // IsFlagLedger reports whether the ledger at seq is a flag ledger — where fee
 // and amendment vote results take effect: seq % FlagLedgerInterval == 0.
-// Matches rippled isFlagLedger.
 func IsFlagLedger(seq uint32) bool {
 	return seq%FlagLedgerInterval == 0
 }
 
 // IsVotingLedger reports whether the validation for the ledger at seq carries
 // fee- and amendment-vote fields — the ledger before a flag ledger:
-// (seq+1) % FlagLedgerInterval == 0. Matches rippled isVotingLedger.
+// (seq+1) % FlagLedgerInterval == 0.
 func IsVotingLedger(seq uint32) bool {
 	return (seq+1)%FlagLedgerInterval == 0
 }


### PR DESCRIPTION
## Summary

- Move `FlagLedgerInterval`, `IsFlagLedger`, and `IsVotingLedger` out of `internal/consensus` into the dependency-free **`protocol/`** package, giving the flag-ledger predicate (`seq % 256 == 0`) and its interval constant a single source of truth.
- This resolves the import-cycle constraint that forced the ledger layer to reinline `% 256`: `internal/consensus` imports `internal/ledger`, so `internal/ledger`/`internal/tx/pseudo` could not import `consensus.IsFlagLedger`. `protocol/` imports no internal packages, so every layer can share it. It is also the conceptually correct home — rippled keeps `FLAG_LEDGER_INTERVAL` / `isFlagLedger` in the ledger/protocol layer, not the consensus engine.
- Converge every ad-hoc `% 256` flag-ledger check onto `protocol.IsFlagLedger` / `protocol.FlagLedgerInterval`:
  - `internal/ledger/service/lifecycle.go`, `internal/ledger/inbound/replay_delta.go`, `internal/replaytool/replay_range.go`
  - delete the duplicate local `isFlagLedger` helper (`internal/tx/pseudo/unl_modify.go`)
  - delete the duplicate `flagLedgerInterval` const (`internal/consensus/negativeunlvote`) and derive its watermarks from `protocol.FlagLedgerInterval`
  - update the consensus callers (`rcl/engine.go`, `adaptor/negative_unl_vote.go`) and the now-obsolete drift test
- `IsVotingLedger` (`(seq+1)%256==0`) kept distinct from `IsFlagLedger` (`seq%256==0`).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet` (touched packages) — clean
- [x] `golangci-lint` (v2.11.3, default + `.golangci-warnings.yml`) — 0 issues
- [x] `go test` for all touched packages incl. flag-ledger-sensitive paths (negativeunlvote, adaptor, rcl, ledger/service, tx/pseudo, testing/pseudotx) — all pass
- [x] **Conformance byte-identical** — pure refactor verified by comparing against the pre-refactor baseline on the same checkout: in-scope **1256 pass / 5 fail (99.6%)**, total 1322/187, **per-suite identical**.

Fixes #1111