### PR TITLE
fix: log asynchronously so a slow output can't stall consensus

### DIFF
--- a/config/logging.go
+++ b/config/logging.go
@@ -77,6 +77,10 @@ func (c *LoggingConfig) Validate() error {
 func (c *LoggingConfig) ToLogConfig(debugLogfile string) (*xrpllog.Config, error) {
 	cfg := xrpllog.DefaultConfig()
 
+	// The live node logs asynchronously so a slow or blocked output never
+	// stalls a logging caller — notably the consensus strand under its lock.
+	cfg.Async = true
+
 	// Level
 	if c.Level != "" {
 		if level, ok := parseLevelString(c.Level); ok {

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -2949,7 +2949,7 @@ func (e *Engine) updateCloseTimePosition() {
 		ourPosCT = e.state.OurPosition.CloseTime.Unix() - protocol.RippleEpochUnix
 		ourPosSeq = e.state.OurPosition.Position
 	}
-	slog.Info("close-time avalanche",
+	slog.Debug("close-time avalanche",
 		"t", "consensus",
 		"event", "ct-avalanche",
 		"seq", e.state.Round.Seq,

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1243,8 +1243,10 @@ func (o *Overlay) forwardTransaction(msg *InboundMessage) {
 	select {
 	case o.txMessages <- msg:
 	default:
+		// Counted via droppedTransactions (jq_trans_overflow); log at Debug so a
+		// shed storm under load cannot itself flood the single log writer.
 		o.droppedTransactions.Add(1)
-		slog.Info("Transaction queue is full", "t", "Overlay",
+		slog.Debug("Transaction queue is full", "t", "Overlay",
 			"pending", len(o.txMessages), "max", cap(o.txMessages), "peer", msg.PeerID)
 	}
 }

--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -12,10 +12,9 @@
 // Behaviour mirrors rippled's LoadManager (LoadManager.cpp): warn at >=10s
 // without a heartbeat (repeated every reporting interval, with a full
 // goroutine stack dump on the first warning so the wedged loop is visible),
-// fatal log at >=90s, and process abort at >=600s. The slog handlers in use are
-// synchronous, so the abort record reaches the underlying writer before exit;
-// the abort path additionally fsyncs the stdout/stderr/file descriptors so those
-// final bytes survive os.Exit, which skips deferred Sync hooks. Only the
+// fatal log at >=90s, and process abort at >=600s. The abort path drains the
+// async log queue and fsyncs the stdout/stderr/file descriptors so the final
+// abort record survives os.Exit, which skips deferred Sync hooks. Only the
 // stall-detection half of LoadManager is reproduced here; the local-fee
 // raise/lower half already lives in internal/feetrack.
 package watchdog
@@ -132,9 +131,9 @@ func New(cfg Config, logger *slog.Logger) *Watchdog {
 		heartbeats: make(map[string]time.Time),
 	}
 	// exit terminates the process so an orchestrator can restart the wedged node
-	// — rippled's LogicError abort. The slog handlers are synchronous, so the
-	// abort record has already reached the writer; sync (called by check before
-	// exit) fsyncs the descriptors so those bytes survive os.Exit.
+	// — rippled's LogicError abort. sync (called by check before exit) drains the
+	// async log queue and fsyncs the descriptors so the abort record survives
+	// os.Exit, which under async logging would otherwise leave it still queued.
 	w.exit = func() { os.Exit(1) }
 	return w
 }
@@ -238,17 +237,16 @@ func (w *Watchdog) check(tick time.Duration) {
 	}
 }
 
-// syncLogDescriptors best-effort fsyncs the destinations the node's logs can
-// reach so the final abort record survives os.Exit, which does not flush
-// kernel-buffered file output. The slog handlers write synchronously, so by this
-// point the record is already in the writer; this only forces it to stable
-// storage. stdout/stderr cover the default and "stderr" config outputs;
-// xrpllog.Sync covers a file-backed [logging] output. All errors are ignored —
-// the process is aborting regardless.
+// syncLogDescriptors best-effort flushes the node's logs so the final abort
+// record survives os.Exit, which does not flush kernel-buffered output.
+// xrpllog.Sync runs first: it drains the async log queue into the destination
+// (and fsyncs a file-backed [logging] output). The stdout/stderr fsyncs then
+// cover the default and "stderr" config outputs. All errors are ignored — the
+// process is aborting regardless.
 func syncLogDescriptors() {
+	_ = xrpllog.Sync()
 	_ = os.Stderr.Sync()
 	_ = os.Stdout.Sync()
-	_ = xrpllog.Sync()
 }
 
 // allGoroutineStacks returns a dump of every goroutine's stack — the Go

--- a/log/asyncwriter.go
+++ b/log/asyncwriter.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"io"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -25,10 +26,12 @@ const asyncFlushTimeout = 2 * time.Second
 // A full queue drops and counts records — logging is best-effort, never a brake
 // on the hot path.
 type asyncWriter struct {
-	dst     io.Writer
-	queue   chan []byte
-	flushCh chan chan struct{}
-	dropped atomic.Uint64
+	dst       io.Writer
+	queue     chan []byte
+	flushCh   chan chan struct{}
+	done      chan struct{}
+	closeOnce sync.Once
+	dropped   atomic.Uint64
 }
 
 func newAsyncWriter(dst io.Writer, depth int) *asyncWriter {
@@ -39,6 +42,7 @@ func newAsyncWriter(dst io.Writer, depth int) *asyncWriter {
 		dst:     dst,
 		queue:   make(chan []byte, depth),
 		flushCh: make(chan chan struct{}),
+		done:    make(chan struct{}),
 	}
 	go w.drain()
 	return w
@@ -65,6 +69,9 @@ func (w *asyncWriter) drain() {
 		case ack := <-w.flushCh:
 			w.drainPending()
 			close(ack)
+		case <-w.done:
+			w.drainPending()
+			return
 		}
 	}
 }
@@ -94,6 +101,14 @@ func (w *asyncWriter) flush(timeout time.Duration) {
 	case <-ack:
 	case <-time.After(timeout):
 	}
+}
+
+// close stops the drain goroutine after writing everything currently queued.
+// The root logger is a process-lifetime singleton, so production never calls
+// this; it lets a writer created for a test or other transient scope shut its
+// goroutine down rather than leak it. Idempotent.
+func (w *asyncWriter) close() {
+	w.closeOnce.Do(func() { close(w.done) })
 }
 
 func (w *asyncWriter) DroppedRecords() uint64 {

--- a/log/asyncwriter.go
+++ b/log/asyncwriter.go
@@ -1,0 +1,115 @@
+package log
+
+import (
+	"io"
+	"sync/atomic"
+	"time"
+)
+
+// asyncQueueDepth bounds the records buffered ahead of a slow destination when
+// none is configured. At the few-thousand-records/s a node emits under load
+// this is roughly a second of headroom; past it records drop rather than block.
+const asyncQueueDepth = 4096
+
+// asyncFlushTimeout caps how long flush waits for the queue to clear on the
+// abort path. A wedged destination is the very failure this writer guards
+// against, so the bounded wait keeps an abort from hanging on a write that
+// never returns.
+const asyncFlushTimeout = 2 * time.Second
+
+// asyncWriter decouples record formatting from the underlying write(2). Records
+// are copied into a bounded queue drained by one background goroutine, so a slow
+// or blocked destination cannot park the caller. That matters most for the
+// consensus strand, which logs while holding its engine lock: a synchronous
+// write stalling there starves the ledger loop and trips the watchdog to fatal.
+// A full queue drops and counts records — logging is best-effort, never a brake
+// on the hot path.
+type asyncWriter struct {
+	dst     io.Writer
+	queue   chan []byte
+	flushCh chan chan struct{}
+	dropped atomic.Uint64
+}
+
+func newAsyncWriter(dst io.Writer, depth int) *asyncWriter {
+	if depth <= 0 {
+		depth = asyncQueueDepth
+	}
+	w := &asyncWriter{
+		dst:     dst,
+		queue:   make(chan []byte, depth),
+		flushCh: make(chan chan struct{}),
+	}
+	go w.drain()
+	return w
+}
+
+// Write copies p — slog reuses its buffer once Handle returns — and enqueues it
+// without blocking. A full queue drops the record and bumps the counter.
+func (w *asyncWriter) Write(p []byte) (int, error) {
+	b := make([]byte, len(p))
+	copy(b, p)
+	select {
+	case w.queue <- b:
+	default:
+		w.dropped.Add(1)
+	}
+	return len(p), nil
+}
+
+func (w *asyncWriter) drain() {
+	for {
+		select {
+		case b := <-w.queue:
+			_, _ = w.dst.Write(b)
+		case ack := <-w.flushCh:
+			w.drainPending()
+			close(ack)
+		}
+	}
+}
+
+func (w *asyncWriter) drainPending() {
+	for {
+		select {
+		case b := <-w.queue:
+			_, _ = w.dst.Write(b)
+		default:
+			return
+		}
+	}
+}
+
+// flush blocks until the drain goroutine has written everything queued at the
+// time of the call, or until timeout elapses. Used on the abort/Fatal path so
+// the final records reach the destination before os.Exit.
+func (w *asyncWriter) flush(timeout time.Duration) {
+	ack := make(chan struct{})
+	select {
+	case w.flushCh <- ack:
+	case <-time.After(timeout):
+		return
+	}
+	select {
+	case <-ack:
+	case <-time.After(timeout):
+	}
+}
+
+// DroppedRecords reports how many records were dropped on a full queue.
+func (w *asyncWriter) DroppedRecords() uint64 {
+	return w.dropped.Load()
+}
+
+// DroppedLogRecords returns the records the root logger dropped because its
+// async queue was full, or 0 when async logging is not enabled.
+func DroppedLogRecords() uint64 {
+	cfg := rootCfg.Load()
+	if cfg == nil {
+		return 0
+	}
+	if aw := cfg.asyncOut.Load(); aw != nil {
+		return aw.DroppedRecords()
+	}
+	return 0
+}

--- a/log/asyncwriter.go
+++ b/log/asyncwriter.go
@@ -45,7 +45,7 @@ func newAsyncWriter(dst io.Writer, depth int) *asyncWriter {
 }
 
 // Write copies p — slog reuses its buffer once Handle returns — and enqueues it
-// without blocking. A full queue drops the record and bumps the counter.
+// without blocking.
 func (w *asyncWriter) Write(p []byte) (int, error) {
 	b := make([]byte, len(p))
 	copy(b, p)
@@ -96,7 +96,6 @@ func (w *asyncWriter) flush(timeout time.Duration) {
 	}
 }
 
-// DroppedRecords reports how many records were dropped on a full queue.
 func (w *asyncWriter) DroppedRecords() uint64 {
 	return w.dropped.Load()
 }

--- a/log/asyncwriter_test.go
+++ b/log/asyncwriter_test.go
@@ -32,6 +32,7 @@ func (s *syncBuf) String() string {
 func TestAsyncWriter_FlushDeliversRecords(t *testing.T) {
 	dst := &syncBuf{}
 	w := newAsyncWriter(dst, 0)
+	t.Cleanup(w.close)
 
 	for _, s := range []string{"alpha\n", "bravo\n", "charlie\n"} {
 		if _, err := w.Write([]byte(s)); err != nil {
@@ -69,6 +70,7 @@ func (b *blockingWriter) Write(p []byte) (int, error) {
 func TestAsyncWriter_DropsWhenFull(t *testing.T) {
 	bw := &blockingWriter{entered: make(chan struct{}), release: make(chan struct{})}
 	w := newAsyncWriter(bw, 1) // queue depth 1
+	t.Cleanup(w.close)
 
 	// First record is dequeued by the drain goroutine, which then blocks in the
 	// destination's Write — leaving the depth-1 queue empty.
@@ -100,6 +102,7 @@ func TestNewHandler_Async(t *testing.T) {
 	if aw == nil {
 		t.Fatal("NewHandler did not install an async writer for Async config")
 	}
+	t.Cleanup(aw.close)
 	aw.flush(time.Second)
 
 	if !strings.Contains(dst.String(), "async-hello") {
@@ -116,6 +119,11 @@ func TestSync_FlushesAsyncQueue(t *testing.T) {
 	dst := &syncBuf{}
 	cfg := &Config{Level: LevelInfo, Format: "text", Output: dst, Async: true}
 	l := New(NewHandler(cfg), cfg)
+	t.Cleanup(func() {
+		if aw := cfg.asyncOut.Load(); aw != nil {
+			aw.close()
+		}
+	})
 	rootCfg.Store(cfg)
 
 	l.Error("abort-record")

--- a/log/asyncwriter_test.go
+++ b/log/asyncwriter_test.go
@@ -1,0 +1,128 @@
+package log
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncBuf is a concurrency-safe io.Writer so the drain goroutine and the test
+// goroutine never race on the underlying buffer.
+type syncBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuf) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// TestAsyncWriter_FlushDeliversRecords verifies queued records reach the
+// destination once flush drains the queue.
+func TestAsyncWriter_FlushDeliversRecords(t *testing.T) {
+	dst := &syncBuf{}
+	w := newAsyncWriter(dst, 0)
+
+	for _, s := range []string{"alpha\n", "bravo\n", "charlie\n"} {
+		if _, err := w.Write([]byte(s)); err != nil {
+			t.Fatalf("Write(%q): %v", s, err)
+		}
+	}
+	w.flush(time.Second)
+
+	got := dst.String()
+	for _, want := range []string{"alpha", "bravo", "charlie"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("flushed output missing %q: %q", want, got)
+		}
+	}
+	if d := w.DroppedRecords(); d != 0 {
+		t.Errorf("DroppedRecords() = %d, want 0", d)
+	}
+}
+
+// blockingWriter parks in Write until released, signalling entry so a test can
+// drive the drain goroutine into a known blocked state.
+type blockingWriter struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingWriter) Write(p []byte) (int, error) {
+	b.entered <- struct{}{}
+	<-b.release
+	return len(p), nil
+}
+
+// TestAsyncWriter_DropsWhenFull verifies that a blocked destination makes Write
+// shed records (counted, never blocking) rather than parking the caller.
+func TestAsyncWriter_DropsWhenFull(t *testing.T) {
+	bw := &blockingWriter{entered: make(chan struct{}), release: make(chan struct{})}
+	w := newAsyncWriter(bw, 1) // queue depth 1
+
+	// First record is dequeued by the drain goroutine, which then blocks in the
+	// destination's Write — leaving the depth-1 queue empty.
+	if _, err := w.Write([]byte("a")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	<-bw.entered
+
+	w.Write([]byte("b")) // fills the queue
+	w.Write([]byte("c")) // queue full → dropped
+	w.Write([]byte("d")) // dropped
+
+	if d := w.DroppedRecords(); d != 2 {
+		t.Errorf("DroppedRecords() = %d, want 2", d)
+	}
+	close(bw.release)
+}
+
+// TestNewHandler_Async verifies the async config path wires an async writer that
+// delivers records after a flush.
+func TestNewHandler_Async(t *testing.T) {
+	dst := &syncBuf{}
+	cfg := &Config{Level: LevelInfo, Format: "text", Output: dst, Async: true}
+	l := New(NewHandler(cfg), cfg)
+
+	l.Info("async-hello")
+
+	aw := cfg.asyncOut.Load()
+	if aw == nil {
+		t.Fatal("NewHandler did not install an async writer for Async config")
+	}
+	aw.flush(time.Second)
+
+	if !strings.Contains(dst.String(), "async-hello") {
+		t.Errorf("async record not delivered after flush: %q", dst.String())
+	}
+}
+
+// TestSync_FlushesAsyncQueue verifies the package Sync drains the async queue,
+// the guarantee the watchdog abort and Fatal paths depend on.
+func TestSync_FlushesAsyncQueue(t *testing.T) {
+	prev := rootCfg.Load()
+	t.Cleanup(func() { rootCfg.Store(prev) })
+
+	dst := &syncBuf{}
+	cfg := &Config{Level: LevelInfo, Format: "text", Output: dst, Async: true}
+	l := New(NewHandler(cfg), cfg)
+	rootCfg.Store(cfg)
+
+	l.Error("abort-record")
+	if err := Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if !strings.Contains(dst.String(), "abort-record") {
+		t.Errorf("Sync did not flush the async queue: %q", dst.String())
+	}
+}

--- a/log/filewriter.go
+++ b/log/filewriter.go
@@ -96,14 +96,19 @@ func Rotate() error {
 	return fw.Rotate()
 }
 
-// Sync flushes the root logger's file output to stable storage on a best-effort
-// basis, returning nil when logging is not file-backed (stdout/stderr writers
-// are flushed by syncing their own descriptors, not through here). It exists for
-// the abort path, where os.Exit skips deferred Close/Sync hooks.
+// Sync drains any async queue, then flushes the root logger's file output to
+// stable storage on a best-effort basis. It returns nil when logging is not
+// file-backed (stdout/stderr writers are flushed by syncing their own
+// descriptors, not through here), but the async drain still runs so buffered
+// records reach the destination. It exists for the abort path, where os.Exit
+// skips deferred Close/Sync hooks.
 func Sync() error {
 	cfg := rootCfg.Load()
 	if cfg == nil {
 		return nil
+	}
+	if aw := cfg.asyncOut.Load(); aw != nil {
+		aw.flush(asyncFlushTimeout)
 	}
 	fw, ok := cfg.Output.(*FileWriter)
 	if !ok {

--- a/log/handler.go
+++ b/log/handler.go
@@ -42,10 +42,25 @@ type Config struct {
 	// Omitted partitions use the global Level.
 	Partitions map[string]Level
 
+	// Async, when set, routes records through a bounded background queue
+	// (drop-on-full) instead of writing them on the calling goroutine, so a
+	// slow or blocked output can never stall a logging caller — in particular
+	// the consensus strand, which logs under its engine lock. Leave unset for
+	// tests and library use, where output must be synchronous and deterministic.
+	Async bool
+
+	// AsyncQueueDepth bounds the records buffered when Async is set.
+	// Zero uses asyncQueueDepth.
+	AsyncQueueDepth int
+
 	// dyn holds live LevelVars initialised by initDyn. Stored as
 	// atomic.Pointer so concurrent first-touches don't race on the
 	// pointer, and so Config itself remains copy-safe (no embedded mutex).
 	dyn atomic.Pointer[configDynamic]
+
+	// asyncOut holds the live async writer when Async is set, so Sync can drain
+	// it on the abort path. Set once by NewHandler.
+	asyncOut atomic.Pointer[asyncWriter]
 }
 
 // initDyn lazily initialises the dynamic state from the static Level fields.
@@ -135,6 +150,7 @@ func DefaultConfig() *Config {
 // Text format uses slog.NewTextHandler; JSON uses slog.NewJSONHandler.
 // NewHandler initialises cfg's dynamic LevelVars so that SetLevel /
 // SetPartitionLevel calls on the same *Config take effect immediately.
+// When cfg.Async is set the output is wrapped so writes never block the caller.
 func NewHandler(cfg *Config) slog.Handler {
 	if cfg == nil {
 		cfg = &Config{Level: LevelInfo, Format: "text", Output: os.Stdout}
@@ -142,6 +158,11 @@ func NewHandler(cfg *Config) slog.Handler {
 	out := cfg.Output
 	if out == nil {
 		out = os.Stdout
+	}
+	if cfg.Async {
+		aw := newAsyncWriter(out, cfg.AsyncQueueDepth)
+		cfg.asyncOut.Store(aw)
+		out = aw
 	}
 
 	d := cfg.initDyn() // ensure globalVar is live

--- a/log/logger.go
+++ b/log/logger.go
@@ -39,15 +39,15 @@ func (l *logger) Error(msg string, args ...any) {
 	l.inner.Error(msg, args...)
 }
 
-// Fatal emits an Error record then exits. The handlers in this package
-// (slog.NewTextHandler / slog.NewJSONHandler) are unbuffered, so the final
-// record reaches the underlying writer before exit. The os-level descriptor is
-// not fsynced here: defaultExit goes straight to os.Exit and will not run
-// deferred Sync hooks. Callers that need the file-backed output flushed to
-// stable storage before aborting should call Sync first (see the abort path in
-// internal/watchdog).
+// Fatal emits an Error record then exits. Sync runs before exit so the final
+// record reaches the destination even under async logging, where the record
+// would otherwise still be queued when defaultExit calls os.Exit (which skips
+// deferred Sync hooks). It does not fsync the os-level descriptor; callers that
+// need the file flushed to stable storage rely on Sync's file path or the
+// watchdog abort path's descriptor fsync.
 func (l *logger) Fatal(msg string, args ...any) {
 	l.inner.Error(msg, args...)
+	_ = Sync()
 	defaultExit()
 }
 


### PR DESCRIPTION
## Summary

- Synchronous logging through a single unbuffered slog handler let a log flood stall the consensus strand: its per-tick `Info` (emitted while holding the engine lock) parked on the writer's mutex behind a blocked `write(2)`, the ledger-loop heartbeat stopped, and the watchdog escalated to a **fatal abort** — a priority inversion where logging crashed the node.
- Add an async, bounded, drop-on-full writer (`log/asyncwriter.go`) wired in for the live node via `Config.Async` (set in `ToLogConfig`). No log call — least of all one under the engine lock — can now block on the destination; the failure mode becomes recoverable degradation, not a crash.
- The abort and `Fatal` paths drain the queue before `os.Exit` (`Sync` → async flush, then fd fsync) so the final record still survives. Tests construct `Config` directly without `Async`, so they stay synchronous and deterministic.
- Demote the two per-event flood emitters to `Debug` — consensus "close-time avalanche" (per establish tick, under the lock; rippled logs it at debug) and overlay "Transaction queue is full" (per shed tx, already counted via `jq_trans_overflow`) — so a storm can't itself saturate the single writer.

## Test plan

- [x] `go test -race ./log/...` — new async-writer tests (flush delivery, drop-on-full counting/non-blocking, `NewHandler` async path, `Sync` drains the queue)
- [x] `go build ./...` (CGO+OpenSSL)
- [x] `go vet` + `golangci-lint run` on all touched packages — 0 issues
- [x] `go test ./log/... ./config/... ./internal/watchdog/... ./internal/consensus/rcl/... ./internal/peermanagement/...` — all pass

Fixes #1135