### PR TITLE
fix: memoize transaction id to drop redundant in-strand re-hashing

### DIFF
--- a/internal/tx/engine_config.go
+++ b/internal/tx/engine_config.go
@@ -229,11 +229,7 @@ func ComputeTransactionHash(tx Transaction) ([32]byte, error) {
 func computeTransactionHash(tx Transaction) ([32]byte, error) {
 	c := tx.GetCommon()
 
-	// Fast path: when the raw signed bytes are present the id is a pure
-	// function of them, unchanged until SetRawBytes replaces them. It is
-	// memoised on first computation and reused thereafter, so the open-ledger
-	// apply strand reads the precomputed id instead of re-hashing the blob.
-	// Mirrors rippled's STTx::tid_.
+	// Fast path: id is memoised from the raw signed bytes (see cachedTxID).
 	if rawBytes := tx.GetRawBytes(); len(rawBytes) > 0 {
 		if c != nil && c.txIDCached {
 			return c.cachedTxID, nil
@@ -246,8 +242,7 @@ func computeTransactionHash(tx Transaction) ([32]byte, error) {
 		return hash, nil
 	}
 
-	// No raw bytes: serialize from current field state via Flatten and hash.
-	// This blob is rebuilt each call, so it is not memoised.
+	// No raw bytes: rebuilt from current field state each call, so not memoised.
 	txMap, err := tx.Flatten()
 	if err != nil {
 		return [32]byte{}, err
@@ -263,8 +258,7 @@ func computeTransactionHash(tx Transaction) ([32]byte, error) {
 	return hashWithTxnPrefix(txBytes), nil
 }
 
-// hashWithTxnPrefix returns SHA512Half of the transactionID prefix
-// ("TXN\x00" = 0x54584E00) concatenated with txBytes.
+// hashWithTxnPrefix returns SHA512Half of the "TXN\x00" prefix + txBytes.
 func hashWithTxnPrefix(txBytes []byte) [32]byte {
 	prefix := []byte{0x54, 0x58, 0x4E, 0x00} //nolint:prealloc // static 4-byte composite literal followed by a single append
 	return common.Sha512Half(append(prefix, txBytes...))

--- a/internal/tx/engine_config.go
+++ b/internal/tx/engine_config.go
@@ -227,35 +227,45 @@ func ComputeTransactionHash(tx Transaction) ([32]byte, error) {
 // computeTransactionHash computes the hash of a transaction
 // The hash is SHA512Half of the "TXN\x00" prefix + serialized transaction
 func computeTransactionHash(tx Transaction) ([32]byte, error) {
-	var hash [32]byte
-	var txBytes []byte
+	c := tx.GetCommon()
 
-	// Use raw bytes if available (from parsing), otherwise re-serialize
+	// Fast path: when the raw signed bytes are present the id is a pure
+	// function of them, unchanged until SetRawBytes replaces them. It is
+	// memoised on first computation and reused thereafter, so the open-ledger
+	// apply strand reads the precomputed id instead of re-hashing the blob.
+	// Mirrors rippled's STTx::tid_.
 	if rawBytes := tx.GetRawBytes(); len(rawBytes) > 0 {
-		txBytes = rawBytes
-	} else {
-		// Serialize the transaction using Flatten
-		txMap, err := tx.Flatten()
-		if err != nil {
-			return hash, err
+		if c != nil && c.txIDCached {
+			return c.cachedTxID, nil
 		}
-
-		// Encode to binary using the binary codec
-		hexStr, err := binarycodec.Encode(txMap)
-		if err != nil {
-			return hash, err
+		hash := hashWithTxnPrefix(rawBytes)
+		if c != nil {
+			c.cachedTxID = hash
+			c.txIDCached = true
 		}
-
-		txBytes, err = hex.DecodeString(hexStr)
-		if err != nil {
-			return hash, err
-		}
+		return hash, nil
 	}
 
-	// Prefix is "TXN\x00" = 0x54584E00
-	prefix := []byte{0x54, 0x58, 0x4E, 0x00} //nolint:prealloc // prealloc: static 4-byte composite literal followed by a single append
-	data := append(prefix, txBytes...)
+	// No raw bytes: serialize from current field state via Flatten and hash.
+	// This blob is rebuilt each call, so it is not memoised.
+	txMap, err := tx.Flatten()
+	if err != nil {
+		return [32]byte{}, err
+	}
+	hexStr, err := binarycodec.Encode(txMap)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	txBytes, err := hex.DecodeString(hexStr)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return hashWithTxnPrefix(txBytes), nil
+}
 
-	hash = common.Sha512Half(data)
-	return hash, nil
+// hashWithTxnPrefix returns SHA512Half of the transactionID prefix
+// ("TXN\x00" = 0x54584E00) concatenated with txBytes.
+func hashWithTxnPrefix(txBytes []byte) [32]byte {
+	prefix := []byte{0x54, 0x58, 0x4E, 0x00} //nolint:prealloc // static 4-byte composite literal followed by a single append
+	return common.Sha512Half(append(prefix, txBytes...))
 }

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -222,15 +222,12 @@ type Common struct {
 	// before the parsed transaction is shared with any other goroutine.
 	sigVerified bool
 
-	// cachedTxID memoises this transaction's id — SHA512Half of the
-	// transactionID prefix concatenated with RawBytes — mirroring rippled's
-	// STTx::tid_, which is computed once at construction. The id is a pure
-	// function of RawBytes, so the cache stays valid until SetRawBytes
-	// replaces them (which clears it). Carries the same single-goroutine,
-	// unsynchronised contract as sigVerified: the apply path reuses one parsed
-	// transaction across preflight/preclaim/apply, so the id is computed once
-	// (off the open-ledger apply strand at ingress) and read under the strand
-	// without re-hashing the blob.
+	// cachedTxID memoises this transaction's id. The id is a pure function of
+	// RawBytes, so the cache stays valid until SetRawBytes replaces them (which
+	// clears it). Carries the same single-goroutine, unsynchronised contract as
+	// sigVerified: the apply path reuses one parsed transaction across
+	// preflight/preclaim/apply, so the id is computed once at ingress and read
+	// under the strand without re-hashing.
 	cachedTxID [32]byte
 	txIDCached bool
 }

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -221,6 +221,18 @@ type Common struct {
 	// on the same goroutine, so the write happens-before the in-strand read and
 	// before the parsed transaction is shared with any other goroutine.
 	sigVerified bool
+
+	// cachedTxID memoises this transaction's id — SHA512Half of the
+	// transactionID prefix concatenated with RawBytes — mirroring rippled's
+	// STTx::tid_, which is computed once at construction. The id is a pure
+	// function of RawBytes, so the cache stays valid until SetRawBytes
+	// replaces them (which clears it). Carries the same single-goroutine,
+	// unsynchronised contract as sigVerified: the apply path reuses one parsed
+	// transaction across preflight/preclaim/apply, so the id is computed once
+	// (off the open-ledger apply strand at ingress) and read under the strand
+	// without re-hashing the blob.
+	cachedTxID [32]byte
+	txIDCached bool
 }
 
 // Validate validates the common fields. preflightCommonFields catches these
@@ -256,9 +268,11 @@ func (c *Common) GetRawBytes() []byte {
 	return c.RawBytes
 }
 
-// SetRawBytes stores the original serialized bytes
+// SetRawBytes stores the original serialized bytes, invalidating any memoised
+// transaction id since the id is derived from these bytes.
 func (c *Common) SetRawBytes(data []byte) {
 	c.RawBytes = data
+	c.txIDCached = false
 }
 
 // SetFlags sets the flags field

--- a/internal/tx/txid_cache_test.go
+++ b/internal/tx/txid_cache_test.go
@@ -1,0 +1,127 @@
+package tx
+
+import "testing"
+
+// TestComputeTransactionHash_MemoizesRawBytes pins the txid memoisation: once
+// the raw signed bytes are present the id is computed once and reused, so the
+// repeated under-lock ComputeTransactionHash calls on the apply strand become
+// O(1) cache hits instead of re-hashing the blob (issue #1137).
+func TestComputeTransactionHash_MemoizesRawBytes(t *testing.T) {
+	blob := encodeTx(t, baseCommon("AccountSet"))
+
+	txn, err := ParseFromBinary(blob)
+	if err != nil {
+		t.Fatalf("ParseFromBinary: %v", err)
+	}
+
+	c := txn.GetCommon()
+	if c.txIDCached {
+		t.Fatalf("txid must not be cached before the first ComputeTransactionHash")
+	}
+
+	h1, err := ComputeTransactionHash(txn)
+	if err != nil {
+		t.Fatalf("ComputeTransactionHash: %v", err)
+	}
+
+	// The cached value is the canonical txid: SHA512Half(TXN-prefix || blob).
+	if want := hashWithTxnPrefix(blob); h1 != want {
+		t.Fatalf("txid = %x, want %x", h1, want)
+	}
+	if !c.txIDCached || c.cachedTxID != h1 {
+		t.Fatalf("first compute must memoise the txid (cached=%v, value=%x, want %x)",
+			c.txIDCached, c.cachedTxID, h1)
+	}
+
+	// A second compute on the same object — the open-ledger apply strand reusing
+	// the parsed tx — returns the identical id without re-hashing.
+	h2, err := ComputeTransactionHash(txn)
+	if err != nil {
+		t.Fatalf("ComputeTransactionHash (2nd): %v", err)
+	}
+	if h2 != h1 {
+		t.Fatalf("memoised txid diverged: %x != %x", h2, h1)
+	}
+}
+
+// TestComputeTransactionHash_SetRawBytesInvalidates guards the invalidation
+// contract: the id tracks the current raw bytes, so SetRawBytes must drop a
+// stale cache rather than return the previous transaction's id.
+func TestComputeTransactionHash_SetRawBytesInvalidates(t *testing.T) {
+	blob1 := encodeTx(t, baseCommon("AccountSet"))
+
+	fields2 := baseCommon("AccountSet")
+	fields2["Sequence"] = uint32(2)
+	blob2 := encodeTx(t, fields2)
+
+	txn, err := ParseFromBinary(blob1)
+	if err != nil {
+		t.Fatalf("ParseFromBinary: %v", err)
+	}
+
+	h1, err := ComputeTransactionHash(txn)
+	if err != nil {
+		t.Fatalf("ComputeTransactionHash(blob1): %v", err)
+	}
+
+	// Different bytes must yield a different id once the cache is invalidated.
+	txn.SetRawBytes(blob2)
+	if txn.GetCommon().txIDCached {
+		t.Fatalf("SetRawBytes must invalidate the memoised txid")
+	}
+	h2, err := ComputeTransactionHash(txn)
+	if err != nil {
+		t.Fatalf("ComputeTransactionHash(blob2): %v", err)
+	}
+	if h2 == h1 {
+		t.Fatalf("txid did not change after SetRawBytes: still %x", h1)
+	}
+	if want := hashWithTxnPrefix(blob2); h2 != want {
+		t.Fatalf("post-invalidation txid = %x, want %x", h2, want)
+	}
+
+	// Restoring the original bytes recomputes the original id, not a stale h2.
+	txn.SetRawBytes(blob1)
+	h3, err := ComputeTransactionHash(txn)
+	if err != nil {
+		t.Fatalf("ComputeTransactionHash(blob1 restored): %v", err)
+	}
+	if h3 != h1 {
+		t.Fatalf("restored txid = %x, want original %x", h3, h1)
+	}
+}
+
+// TestComputeTransactionHash_FlattenPathUnmemoised verifies the no-raw-bytes
+// fallback still hashes from current field state — and must NOT memoise, since
+// without raw bytes the blob is rebuilt from mutable fields each call (the
+// Flatten branch must survive the memoisation refactor unchanged).
+func TestComputeTransactionHash_FlattenPathUnmemoised(t *testing.T) {
+	blob := encodeTx(t, baseCommon("AccountSet"))
+
+	txn, err := ParseFromBinary(blob)
+	if err != nil {
+		t.Fatalf("ParseFromBinary: %v", err)
+	}
+
+	// Drop the raw bytes: ComputeTransactionHash must fall back to Flatten,
+	// producing a stable non-zero id with nothing memoised.
+	txn.SetRawBytes(nil)
+	h1, err := ComputeTransactionHash(txn)
+	if err != nil {
+		t.Fatalf("ComputeTransactionHash(flatten): %v", err)
+	}
+	if h1 == ([32]byte{}) {
+		t.Fatalf("flatten-path txid must not be zero")
+	}
+	if txn.GetCommon().txIDCached {
+		t.Fatalf("the Flatten path must not memoise (no raw bytes to key on)")
+	}
+
+	h2, err := ComputeTransactionHash(txn)
+	if err != nil {
+		t.Fatalf("ComputeTransactionHash(flatten 2nd): %v", err)
+	}
+	if h2 != h1 {
+		t.Fatalf("flatten-path txid not deterministic: %x != %x", h2, h1)
+	}
+}


### PR DESCRIPTION
## Summary

Extends #1105. The per-tx apply closure runs under `OpenLedger.modifyMu`, whose contract forbids "long computation" — yet `ComputeTransactionHash` re-hashed the full signed blob on every call, so the apply strand computed each tx's id **twice** under the lock (in `BlockProcessor` and again in the engine), *despite* the id already having been computed off-strand at ingress (`ptx.Hash`).

rippled avoids this by caching the id once on `STTx` (`tid_`, computed at construction). Because the **same parsed transaction object** flows through go-xrpl's entire apply path (the `ptx.Parsed` reuse landed by #1105), memoizing the id on that object mirrors rippled exactly and drives the under-`modifyMu` hash computations to **zero** on the ingress path (the off-strand compute in `ParsePendingTx` becomes the one-and-only computation; `BlockProcessor` and the engine read the cache).

### What changed
- `internal/tx/transaction.go` — `Common` gains an unexported `cachedTxID`/`txIDCached` pair (same single-goroutine, unsynchronized contract as the existing `sigVerified` field from #1105). `SetRawBytes` clears it.
- `internal/tx/engine_config.go` — `computeTransactionHash` returns the memoized id when raw bytes are present (computing + caching on first call); the no-raw-bytes `Flatten` fallback is left unmemoized and unchanged.

### Why it's safe
When raw bytes are present, the id is already a pure function of those bytes (`computeTransactionHash` ignored field state on that path), and `SetRawBytes` is the only thing that mutates them — so caching keyed on `SetRawBytes` invalidation is identical to recomputing. Confirmed: **in-scope conformance is byte-identical at 1260/0** (all failing suites are out-of-scope: Batch/Delegate/Vault/XChain/XChainSim).

### Scope note (double-preflight / allocations)
The issue also lists the double preflight and per-tx engine allocations. The double-preflight actually **mirrors rippled** (`TxQ.cpp:743` `pfresult` + `tryDirectApply`→`ripple::apply` at `:1719` both preflight), and its dominant cost — signature verification — is already moved off-strand by #1105's `PrewarmSignature`; the residual structural re-validation is cheap, and reordering/removing it risks conformance TER-ordering diffs for marginal gain. Reusing the per-tx `Engine`/`ApplyStateTable` is a larger refactor (each open-ledger `Submit` runs against a fresh `Modify` snapshot). Both are intentionally left out of this focused, behavior-preserving fix; the genuine rippled divergence — the redundant re-hashing — is resolved here.

## Test plan
- [x] New unit tests (`internal/tx/txid_cache_test.go`): memoization correctness, `SetRawBytes` invalidation, and the un-memoized `Flatten` fallback — pass under `-race`.
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./internal/tx/` (0 issues)
- [x] `./internal/tx/...`, `./internal/ledger/openledger/...`, `./internal/txq/...` suites pass
- [x] Conformance: in-scope **1260 pass / 0 fail** (byte-identical)

Fixes #1137