### PR TITLE
Drop to degraded resync on a stuck wrongLedger pin

### DIFF
--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -125,12 +125,9 @@ type Engine struct {
 	// degraded resync rather than freezing.
 	wrongLedgerAcquireFailures int
 
-	// wrongLedgerSince is when we last entered ModeWrongLedger; zero when not
-	// pinned. It measures continuous time stuck regardless of how often the
-	// target hash churns, arming a watchdog that drops to a degraded resync
-	// even when no acquisition reports a clean failure (a livelocked
-	// acquisition) or the clean failures land on a stale target the hatch no
-	// longer recognises (the network advancing past us).
+	// wrongLedgerSince is when we last entered ModeWrongLedger (zero when not
+	// pinned); it measures continuous time stuck regardless of target-hash
+	// churn, arming the wrongLedgerStuckTimeout watchdog.
 	wrongLedgerSince time.Time
 
 	// degradedResyncUntil, when in the future, suppresses re-pinning
@@ -1364,12 +1361,9 @@ func (e *Engine) checkAndStartRoundInner() {
 	e.startRoundLocked(round, proposing, false)
 }
 
-// checkStuckWrongLedger drops to a degraded resync when pinned in
-// ModeWrongLedger continuously past wrongLedgerStuckTimeout, backing the
-// clean-failure hatch which can't arm under a livelock or moving target. Run
-// every tick regardless of phase: a pin taken while phase==PhaseAccepted
-// (acceptLedger's preferred-LCL jump) advances no rounds, so checkLedger never
-// runs. Caller must hold e.mu.
+// checkStuckWrongLedger drops to a degraded resync once pinned in
+// ModeWrongLedger past wrongLedgerStuckTimeout, backing the clean-failure hatch
+// which can't arm under a livelock or moving target. Caller must hold e.mu.
 func (e *Engine) checkStuckWrongLedger() {
 	if e.mode == consensus.ModeWrongLedger && !e.wrongLedgerSince.IsZero() &&
 		e.adaptor.Now().Sub(e.wrongLedgerSince) > wrongLedgerStuckTimeout {
@@ -1657,18 +1651,13 @@ const (
 	wrongLedgerAcquireMaxFailures = 3
 	degradedResyncCooldown        = 20 * time.Second
 
-	// wrongLedgerStuckTimeout is the watchdog bound on continuous time pinned
-	// in ModeWrongLedger. The clean-failure hatch can fail to arm: an inbound
-	// acquisition can livelock (it keeps attaching frontier nodes, so it never
-	// times out, but never completes), and when the network advances past us
-	// each clean failure lands on a stale target the hatch no longer matches,
-	// so wrongLedgerAcquireFailures never climbs. Either way the node closes no
-	// ledgers and wedges forever. Past this bound the watchdog drops to a
-	// degraded resync regardless, so closes resume and recovery continues. Set
-	// above the clean-failure budget (~wrongLedgerAcquireMaxFailures full
-	// acquire cycles) so it only backstops a genuinely stuck node, and well
-	// under the fatal stall watchdog (90s default) so degraded resync engages
-	// before the node aborts.
+	// wrongLedgerStuckTimeout bounds continuous time pinned in ModeWrongLedger.
+	// The clean-failure hatch can fail to arm — a livelocked acquisition never
+	// times out, and a target moving as the network advances leaves each clean
+	// failure on a stale id the hatch ignores — so without this bound the node
+	// wedges forever. Set above the clean-failure budget (only backstop a
+	// genuinely stuck node) and under the 90s fatal stall watchdog (so degraded
+	// resync engages before the node aborts).
 	wrongLedgerStuckTimeout = 60 * time.Second
 )
 
@@ -1704,10 +1693,10 @@ func (e *Engine) OnLedgerAcquireFailed(id consensus.LedgerID) {
 }
 
 // dropToDegradedResync demotes a node that cannot acquire its wrongLedger
-// target to a degraded resync: ModeObserving keeps rounds (and the stall
-// watchdog heartbeat) advancing while checkLedger retries, so closes resume
-// and the network recovers. Reached both from the clean-failure hatch at its
-// limit and from the stuck-acquisition watchdog. Caller must hold e.mu.
+// target: ModeObserving keeps rounds (and the stall watchdog heartbeat)
+// advancing while checkLedger retries, so closes resume. Reached from both the
+// clean-failure hatch (at its limit) and the stuck-acquisition watchdog. Caller
+// must hold e.mu.
 func (e *Engine) dropToDegradedResync(reason string) {
 	slog.Warn("wrongLedger ledger unacquirable; dropping to degraded resync",
 		"t", "consensus",
@@ -1740,9 +1729,8 @@ func (e *Engine) setMode(newMode consensus.Mode) {
 	// old or new — fine for the snapshot.
 	e.modeAtomic.Store(int32(newMode))
 
-	// Stamp the continuous-wrongLedger clock on entry and clear it on exit, so
-	// the watchdog measures uninterrupted time pinned even as the target hash
-	// churns (re-pins to a fresh hash keep the same mode, so this runs once).
+	// Stamp wrongLedgerSince on entry to ModeWrongLedger, clear on exit. A re-pin
+	// stays in the same mode, so the stamp survives a churning target.
 	switch {
 	case newMode == consensus.ModeWrongLedger && oldMode != consensus.ModeWrongLedger:
 		e.wrongLedgerSince = e.adaptor.Now()

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -125,6 +125,14 @@ type Engine struct {
 	// degraded resync rather than freezing.
 	wrongLedgerAcquireFailures int
 
+	// wrongLedgerSince is when we last entered ModeWrongLedger; zero when not
+	// pinned. It measures continuous time stuck regardless of how often the
+	// target hash churns, arming a watchdog that drops to a degraded resync
+	// even when no acquisition reports a clean failure (a livelocked
+	// acquisition) or the clean failures land on a stale target the hatch no
+	// longer recognises (the network advancing past us).
+	wrongLedgerSince time.Time
+
 	// degradedResyncUntil, when in the future, suppresses re-pinning
 	// ModeWrongLedger so the node keeps closing ledgers (observer-mode
 	// advancement) while it retries acquisition. Engine-global: every
@@ -1355,6 +1363,17 @@ func (e *Engine) checkAndStartRoundInner() {
 // checkLedger compares prevLedger against the network-preferred ledger
 // and calls handleWrongLedger on a mismatch.
 func (e *Engine) checkLedger() {
+	// Defense in depth against a wedged wrongLedger pin. The clean-failure
+	// hatch (OnLedgerAcquireFailed) can never arm under a livelocked
+	// acquisition or a target that keeps moving, so back it with a wall-clock
+	// bound on continuous time pinned: past it, drop to a degraded resync
+	// regardless so the node resumes closing ledgers.
+	if e.mode == consensus.ModeWrongLedger && !e.wrongLedgerSince.IsZero() &&
+		e.adaptor.Now().Sub(e.wrongLedgerSince) > wrongLedgerStuckTimeout {
+		e.dropToDegradedResync("stuck-watchdog")
+		return
+	}
+
 	if e.prevLedger == nil {
 		return
 	}
@@ -1631,6 +1650,20 @@ func (e *Engine) handleWrongLedger(netLedgerID consensus.LedgerID, target consen
 const (
 	wrongLedgerAcquireMaxFailures = 3
 	degradedResyncCooldown        = 20 * time.Second
+
+	// wrongLedgerStuckTimeout is the watchdog bound on continuous time pinned
+	// in ModeWrongLedger. The clean-failure hatch can fail to arm: an inbound
+	// acquisition can livelock (it keeps attaching frontier nodes, so it never
+	// times out, but never completes), and when the network advances past us
+	// each clean failure lands on a stale target the hatch no longer matches,
+	// so wrongLedgerAcquireFailures never climbs. Either way the node closes no
+	// ledgers and wedges forever. Past this bound the watchdog drops to a
+	// degraded resync regardless, so closes resume and recovery continues. Set
+	// above the clean-failure budget (~wrongLedgerAcquireMaxFailures full
+	// acquire cycles) so it only backstops a genuinely stuck node, and well
+	// under the fatal stall watchdog (90s default) so degraded resync engages
+	// before the node aborts.
+	wrongLedgerStuckTimeout = 60 * time.Second
 )
 
 // OnLedgerAcquireFailed reports a clean acquisition failure for id. If
@@ -1660,16 +1693,24 @@ func (e *Engine) OnLedgerAcquireFailed(id consensus.LedgerID) {
 		return
 	}
 
-	// Persistent failure: validated ledger unacquirable. Drop to a degraded
-	// resync — ModeObserving keeps rounds (and the watchdog heartbeat)
-	// advancing while checkLedger retries; demote OpModeFull.
+	// Persistent clean failure: validated ledger unacquirable.
+	e.dropToDegradedResync("acquire-max-failures")
+}
+
+// dropToDegradedResync demotes a node that cannot acquire its wrongLedger
+// target to a degraded resync: ModeObserving keeps rounds (and the stall
+// watchdog heartbeat) advancing while checkLedger retries, so closes resume
+// and the network recovers. Reached both from the clean-failure hatch at its
+// limit and from the stuck-acquisition watchdog. Caller must hold e.mu.
+func (e *Engine) dropToDegradedResync(reason string) {
 	slog.Warn("wrongLedger ledger unacquirable; dropping to degraded resync",
 		"t", "consensus",
 		"event", "wrong-lcl-degraded",
-		"hash", fmt.Sprintf("%x", id[:8]),
-		"failures", e.wrongLedgerAcquireFailures,
+		"reason", reason,
 	)
 	e.wrongLedgerAcquireFailures = 0
+	// Un-pin so the next checkLedger re-resolves and re-requests.
+	e.wrongLedgerID = consensus.LedgerID{}
 	e.degradedResyncUntil = e.adaptor.Now().Add(degradedResyncCooldown)
 	if e.state != nil {
 		e.state.HaveCorrectLCL = false
@@ -1692,6 +1733,16 @@ func (e *Engine) setMode(newMode consensus.Mode) {
 	// the e.mu-held write above; an int32 store can't tear, so a reader sees
 	// old or new — fine for the snapshot.
 	e.modeAtomic.Store(int32(newMode))
+
+	// Stamp the continuous-wrongLedger clock on entry and clear it on exit, so
+	// the watchdog measures uninterrupted time pinned even as the target hash
+	// churns (re-pins to a fresh hash keep the same mode, so this runs once).
+	switch {
+	case newMode == consensus.ModeWrongLedger && oldMode != consensus.ModeWrongLedger:
+		e.wrongLedgerSince = e.adaptor.Now()
+	case newMode != consensus.ModeWrongLedger:
+		e.wrongLedgerSince = time.Time{}
+	}
 
 	e.eventBus.Publish(&consensus.ModeChangedEvent{
 		OldMode:   oldMode,

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1299,6 +1299,10 @@ func (e *Engine) timerEntry() {
 		return
 	}
 
+	// Runs every tick regardless of phase: a WrongLedger pin taken at
+	// PhaseAccepted advances no rounds, so the checkLedger path below never runs.
+	e.checkStuckWrongLedger()
+
 	// checkLedger runs in every non-disconnected mode — the Syncing/Tracking
 	// → Full recovery path; gating on Full would wedge us after a wrongLedger
 	// demotion.
@@ -1360,20 +1364,22 @@ func (e *Engine) checkAndStartRoundInner() {
 	e.startRoundLocked(round, proposing, false)
 }
 
-// checkLedger compares prevLedger against the network-preferred ledger
-// and calls handleWrongLedger on a mismatch.
-func (e *Engine) checkLedger() {
-	// Defense in depth against a wedged wrongLedger pin. The clean-failure
-	// hatch (OnLedgerAcquireFailed) can never arm under a livelocked
-	// acquisition or a target that keeps moving, so back it with a wall-clock
-	// bound on continuous time pinned: past it, drop to a degraded resync
-	// regardless so the node resumes closing ledgers.
+// checkStuckWrongLedger drops to a degraded resync when pinned in
+// ModeWrongLedger continuously past wrongLedgerStuckTimeout, backing the
+// clean-failure hatch which can't arm under a livelock or moving target. Run
+// every tick regardless of phase: a pin taken while phase==PhaseAccepted
+// (acceptLedger's preferred-LCL jump) advances no rounds, so checkLedger never
+// runs. Caller must hold e.mu.
+func (e *Engine) checkStuckWrongLedger() {
 	if e.mode == consensus.ModeWrongLedger && !e.wrongLedgerSince.IsZero() &&
 		e.adaptor.Now().Sub(e.wrongLedgerSince) > wrongLedgerStuckTimeout {
 		e.dropToDegradedResync("stuck-watchdog")
-		return
 	}
+}
 
+// checkLedger compares prevLedger against the network-preferred ledger
+// and calls handleWrongLedger on a mismatch.
+func (e *Engine) checkLedger() {
 	if e.prevLedger == nil {
 		return
 	}

--- a/internal/consensus/rcl/engine_stuck_watchdog_test.go
+++ b/internal/consensus/rcl/engine_stuck_watchdog_test.go
@@ -55,10 +55,9 @@ func TestEngine_WrongLedgerStuckWatchdog_DropsToDegradedResync(t *testing.T) {
 	e.setMode(consensus.ModeWrongLedger)
 	e.wrongLedgerID = consensus.LedgerID{0x01}
 
-	// Before the timeout the watchdog must not fire. prevLedger is nil, so
-	// checkLedger returns right after the watchdog gate — isolating it.
+	// Before the timeout the watchdog must not fire.
 	a.now = start.Add(wrongLedgerStuckTimeout - time.Second)
-	e.checkLedger()
+	e.checkStuckWrongLedger()
 	if e.mode != consensus.ModeWrongLedger {
 		t.Fatalf("watchdog fired early at %v, mode=%v", a.now.Sub(start), e.mode)
 	}
@@ -73,7 +72,7 @@ func TestEngine_WrongLedgerStuckWatchdog_DropsToDegradedResync(t *testing.T) {
 
 	// Past the timeout the watchdog drops to a degraded resync so closes resume.
 	a.now = start.Add(wrongLedgerStuckTimeout + time.Second)
-	e.checkLedger()
+	e.checkStuckWrongLedger()
 
 	if e.mode != consensus.ModeObserving {
 		t.Fatalf("stuck watchdog must drop to ModeObserving, got %v", e.mode)
@@ -89,5 +88,31 @@ func TestEngine_WrongLedgerStuckWatchdog_DropsToDegradedResync(t *testing.T) {
 	}
 	if !e.wrongLedgerSince.IsZero() {
 		t.Fatal("leaving ModeWrongLedger must clear the watchdog clock")
+	}
+}
+
+// TestEngine_WrongLedgerStuckWatchdog_FiresAtPhaseAccepted covers the
+// phase==PhaseAccepted pin: acceptLedger's preferred-LCL jump can pin
+// ModeWrongLedger while the phase is still Accepted, a state that advances no
+// rounds and never calls checkLedger. The watchdog runs every tick from
+// timerEntry regardless of phase, so the pin is still bounded; the mode drop
+// then lets the next checkAndStartRoundInner restart a round.
+func TestEngine_WrongLedgerStuckWatchdog_FiresAtPhaseAccepted(t *testing.T) {
+	a := newMockAdaptor()
+	e := NewEngine(a, DefaultConfig())
+
+	start := a.now
+	e.setMode(consensus.ModeWrongLedger)
+	e.wrongLedgerID = consensus.LedgerID{0x01}
+	e.phase = consensus.PhaseAccepted
+
+	a.now = start.Add(wrongLedgerStuckTimeout + time.Second)
+	e.checkStuckWrongLedger()
+
+	if e.mode != consensus.ModeObserving {
+		t.Fatalf("watchdog must drop to ModeObserving even at PhaseAccepted, got %v", e.mode)
+	}
+	if e.phase != consensus.PhaseAccepted {
+		t.Fatalf("watchdog drops the mode only; the round restart advances the phase, got %v", e.phase)
 	}
 }

--- a/internal/consensus/rcl/engine_stuck_watchdog_test.go
+++ b/internal/consensus/rcl/engine_stuck_watchdog_test.go
@@ -1,0 +1,93 @@
+package rcl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+)
+
+// TestEngine_SetMode_StampsWrongLedgerSince checks the watchdog clock is set on
+// entry to ModeWrongLedger, preserved while pinned (re-pins keep the same mode,
+// so the continuous-time measurement survives a churning target), and cleared
+// on exit.
+func TestEngine_SetMode_StampsWrongLedgerSince(t *testing.T) {
+	a := newMockAdaptor()
+	e := NewEngine(a, DefaultConfig())
+
+	e.setMode(consensus.ModeObserving)
+	if !e.wrongLedgerSince.IsZero() {
+		t.Fatal("wrongLedgerSince must be zero outside ModeWrongLedger")
+	}
+
+	entered := a.now
+	e.setMode(consensus.ModeWrongLedger)
+	if !e.wrongLedgerSince.Equal(entered) {
+		t.Fatalf("entering ModeWrongLedger must stamp wrongLedgerSince=%v, got %v", entered, e.wrongLedgerSince)
+	}
+
+	// A re-pin to a fresh target stays in ModeWrongLedger, so setMode is a
+	// no-op and the original stamp is preserved — the watchdog measures
+	// continuous time pinned, not time-on-this-hash.
+	a.now = entered.Add(30 * time.Second)
+	e.setMode(consensus.ModeWrongLedger)
+	if !e.wrongLedgerSince.Equal(entered) {
+		t.Fatalf("re-pin must preserve the original stamp %v, got %v", entered, e.wrongLedgerSince)
+	}
+
+	e.setMode(consensus.ModeObserving)
+	if !e.wrongLedgerSince.IsZero() {
+		t.Fatal("leaving ModeWrongLedger must clear wrongLedgerSince")
+	}
+}
+
+// TestEngine_WrongLedgerStuckWatchdog_DropsToDegradedResync pins issue #1136:
+// a node pinned in wrongLedger whose acquisition never reports a clean failure
+// — because it livelocks, or because the network advances and each clean
+// failure lands on a stale target the hatch no longer matches — would close no
+// ledgers forever. The wall-clock watchdog drops it to a degraded resync once
+// it has been pinned past wrongLedgerStuckTimeout, regardless.
+func TestEngine_WrongLedgerStuckWatchdog_DropsToDegradedResync(t *testing.T) {
+	a := newMockAdaptor()
+	e := NewEngine(a, DefaultConfig())
+
+	start := a.now
+	e.setMode(consensus.ModeWrongLedger)
+	e.wrongLedgerID = consensus.LedgerID{0x01}
+
+	// Before the timeout the watchdog must not fire. prevLedger is nil, so
+	// checkLedger returns right after the watchdog gate — isolating it.
+	a.now = start.Add(wrongLedgerStuckTimeout - time.Second)
+	e.checkLedger()
+	if e.mode != consensus.ModeWrongLedger {
+		t.Fatalf("watchdog fired early at %v, mode=%v", a.now.Sub(start), e.mode)
+	}
+
+	// Model the wedge: the target keeps moving and the only failures reported
+	// land on stale ledgers, so the clean-failure hatch never arms.
+	e.wrongLedgerID = consensus.LedgerID{0x02}
+	e.OnLedgerAcquireFailed(consensus.LedgerID{0x01}) // stale → no-op
+	if e.wrongLedgerAcquireFailures != 0 {
+		t.Fatalf("stale-target failure must not arm the hatch, got %d", e.wrongLedgerAcquireFailures)
+	}
+
+	// Past the timeout the watchdog drops to a degraded resync so closes resume.
+	a.now = start.Add(wrongLedgerStuckTimeout + time.Second)
+	e.checkLedger()
+
+	if e.mode != consensus.ModeObserving {
+		t.Fatalf("stuck watchdog must drop to ModeObserving, got %v", e.mode)
+	}
+	if a.GetOperatingMode() != consensus.OpModeTracking {
+		t.Fatalf("stuck watchdog must demote OpModeFull→Tracking, got %v", a.GetOperatingMode())
+	}
+	if !a.Now().Before(e.degradedResyncUntil) {
+		t.Fatal("degraded-resync cooldown must be armed so re-pinning is suppressed")
+	}
+	if e.wrongLedgerID != (consensus.LedgerID{}) {
+		t.Fatal("watchdog must un-pin so checkLedger re-resolves after the cooldown")
+	}
+	if !e.wrongLedgerSince.IsZero() {
+		t.Fatal("leaving ModeWrongLedger must clear the watchdog clock")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the permanent consensus wedge in #1136: a diverged node pinned in `ModeWrongLedger` never re-syncs because the degraded-resync recovery hatch never arms.

- `OnLedgerAcquireFailed` (the hatch) only fires on a **clean** acquisition failure, guarded by `wrongLedgerID == id`. It can't arm in the two real cases that wedge the node:
  - **Livelocked acquisition** — the inbound state-tree acquisition keeps attaching frontier nodes every interval (`progress` stays set, `timeouts` stays at 0), so it *never completes and never times out* → no clean failure is ever reported. (The "still have **1** missing nodes" signature is a `FinishSync` probe artifact — it caps the count at 1, so it means "incomplete", not "one residual".)
  - **Moving target** — as the network advances, `handleWrongLedger` re-pins `wrongLedgerID` to each new hash. Old acquisitions do eventually fail clean, but on a **stale** id, so the hatch's `wrongLedgerID != id` guard no-ops them and `wrongLedgerAcquireFailures` stays at 0 (exactly the observed "retry counter stayed at 0").
- In both cases the node closes no ledgers until the fatal 90s stall watchdog aborts it.

This adds the defense-in-depth the issue asks for (item 2): a wall-clock bound (`wrongLedgerStuckTimeout = 60s`) on **continuous** time pinned in `ModeWrongLedger`, measured independently of which hash is pinned or whether any acquisition reports failure. Past the bound, `checkLedger` drops to a degraded resync (`ModeObserving` + cooldown, demote `OpModeFull→Tracking`) so closes resume and recovery continues. The bound sits above the clean-failure budget (~`3 × ledgerTimeoutRetriesMax` cycles, so it only backstops a genuinely stuck node) and well under the fatal stall watchdog (90s default), so degraded resync engages before the node aborts.

Implementation:
- `wrongLedgerSince` stamped on entry to `ModeWrongLedger` in `setMode` (preserved across same-mode re-pins, cleared on exit) so the watchdog measures continuous time stuck.
- Extracted the terminal degraded-resync drop into a shared `dropToDegradedResync(reason)`, used by both the existing clean-failure hatch and the new watchdog.

### Scope note

This is item (2) from the issue. Item (1) — liberalising `shamap.attachKnownNodeAt` to accept fat-reply / off-frontier nodes the way rippled's `addKnownNode` does (return a re-request signal on an ancestor gap instead of hard-rejecting with `ErrEmptyBranchOnPath`) — would cut the rejection floods and let acquisitions converge faster, but it does **not** resolve the wedge (the acquisition still completes-or-not independently of the hatch arming) and is a riskier shared-shamap contract change. Deliberately left out of this PR; the watchdog makes recovery robust regardless of (1).

## Test plan

- [x] `go test ./internal/consensus/rcl/` — new `engine_stuck_watchdog_test.go` covers: `setMode` stamps/preserves/clears `wrongLedgerSince`; the watchdog does **not** fire before the timeout; and it drops to degraded resync after the timeout even when the only reported failures land on a stale (moving) target.
- [x] `go test ./internal/consensus/...` — full consensus tree green, including the existing `OnLedgerAcquireFailed` tests (the `dropToDegradedResync` refactor preserves behaviour).
- [x] `go vet ./internal/consensus/...` and `go test -race ./internal/consensus/rcl/` clean.

Fixes #1136