### PR TITLE
fix(amm): clear reserve flag only on the AMM side in deleteAMMTrustLine (#1141)

### DIFF
--- a/internal/testing/amm/amm_delete_reserve_flag_test.go
+++ b/internal/testing/amm/amm_delete_reserve_flag_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
-	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/amm"
 	"github.com/LeJamon/go-xrpl/internal/testing/metadata"
 	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
@@ -12,17 +11,15 @@ import (
 	coreAmm "github.com/LeJamon/go-xrpl/internal/tx/amm"
 )
 
-// TestAMMTeardownPreservesHolderReserveFlag is a regression test for #1141: on a
-// full AMM teardown, deleteAMMTrustLine must clear a trust-line reserve flag only
-// on the AMM side. The LP-token line carries its reserve flag on the non-AMM
-// (holder) side; clearing it forks the ledger hash via a spurious
-// PreviousFields.Flags on that DeletedNode while mainnet leaves the flag intact.
+// TestAMMTeardownPreservesHolderReserveFlag is a regression test for #1141:
+// deleteAMMTrustLine must clear a trust-line reserve flag only on the AMM side.
+// The LP-token line holds its reserve on the non-AMM (holder) side; clearing it
+// forks the ledger hash with a spurious PreviousFields.Flags on that DeletedNode.
 //
-// A non-zero limit on the holder's LP-token line keeps the reserve from being
-// released during the LP-token burn — rippled (rippleCreditIOU) only collapses a
-// default line (limit == 0) — so the flag survives to deleteAMMTrustLine where
-// the fix applies. Without it the burn clears the reserve first and the gated
-// branch is never exercised.
+// The non-zero limit on the holder's LP-token line is load-bearing: it stops the
+// LP-token burn from releasing the reserve (rippled collapses only a default,
+// limit==0 line), so the flag survives to deleteAMMTrustLine. Without it the test
+// is vacuous — the burn clears the flag before the gated branch runs.
 func TestAMMTeardownPreservesHolderReserveFlag(t *testing.T) {
 	env := amm.NewAMMTestEnv(t)
 	env.FundWithIOUs(30000, 0)
@@ -51,15 +48,31 @@ func TestAMMTeardownPreservesHolderReserveFlag(t *testing.T) {
 		t.Fatal("AMM should be deleted after WithdrawAll")
 	}
 
-	lpLine := findDeletedRippleState(t, result, lptCurrency)
+	deletedLine := func(currency string) *tx.AffectedNode {
+		for _, n := range metadata.FindNodes(result.Metadata, "DeletedNode", "RippleState") {
+			if bal, ok := n.FinalFields["Balance"].(map[string]any); ok {
+				if cur, _ := bal["currency"].(string); cur == currency {
+					return n
+				}
+			}
+		}
+		return nil
+	}
+
+	lpLine := deletedLine(lptCurrency)
 	if lpLine == nil {
 		t.Fatal("no DeletedNode RippleState for the LP-token line")
 	}
 
-	holderReserve := holderReserveBit(lpLine, ammAcc.Address)
-	finalFlags := metadata.ToUint32(metadata.GetFinalField(lpLine, "Flags"))
-	if finalFlags&holderReserve == 0 {
-		t.Errorf("holder reserve flag (0x%X) was cleared on the LP-token line: FinalFields.Flags=0x%X", holderReserve, finalFlags)
+	// The holder is the non-AMM side; its reserve flag must remain set.
+	holderReserve := uint32(state.LsfLowReserve)
+	if low, _ := lpLine.FinalFields["LowLimit"].(map[string]any); low != nil {
+		if iss, _ := low["issuer"].(string); iss == ammAcc.Address {
+			holderReserve = state.LsfHighReserve
+		}
+	}
+	if flags := metadata.ToUint32(metadata.GetFinalField(lpLine, "Flags")); flags&holderReserve == 0 {
+		t.Errorf("holder reserve flag (0x%X) cleared on the LP-token line: FinalFields.Flags=0x%X", holderReserve, flags)
 	}
 	if lpLine.PreviousFields != nil {
 		if v, ok := lpLine.PreviousFields["Flags"]; ok {
@@ -67,40 +80,13 @@ func TestAMMTeardownPreservesHolderReserveFlag(t *testing.T) {
 		}
 	}
 
-	// Contrast: the AMM-side pool line (USD) does release its reserve — the gated
-	// branch the fix keeps clearing.
-	usdLine := findDeletedRippleState(t, result, "USD")
+	// Complementary case: the AMM-side pool line (USD) does release its reserve —
+	// the gated branch the fix keeps clearing.
+	usdLine := deletedLine("USD")
 	if usdLine == nil {
 		t.Fatal("no DeletedNode RippleState for the USD pool line")
 	}
-	usdFinal := metadata.ToUint32(metadata.GetFinalField(usdLine, "Flags"))
-	if usdFinal&(state.LsfLowReserve|state.LsfHighReserve) != 0 {
-		t.Errorf("AMM-side reserve flag not cleared on the USD pool line: FinalFields.Flags=0x%X", usdFinal)
+	if flags := metadata.ToUint32(metadata.GetFinalField(usdLine, "Flags")); flags&(state.LsfLowReserve|state.LsfHighReserve) != 0 {
+		t.Errorf("AMM-side reserve flag not cleared on the USD pool line: FinalFields.Flags=0x%X", flags)
 	}
-}
-
-// findDeletedRippleState returns the DeletedNode RippleState whose Balance is in
-// the given currency, or nil.
-func findDeletedRippleState(t *testing.T, result jtx.TxResult, currency string) *tx.AffectedNode {
-	t.Helper()
-	for _, n := range metadata.FindNodes(result.Metadata, "DeletedNode", "RippleState") {
-		bal, ok := n.FinalFields["Balance"].(map[string]any)
-		if !ok {
-			continue
-		}
-		if cur, _ := bal["currency"].(string); cur == currency {
-			return n
-		}
-	}
-	return nil
-}
-
-// holderReserveBit returns the reserve flag of a trust line's non-AMM side,
-// given the AMM account address.
-func holderReserveBit(node *tx.AffectedNode, ammAddr string) uint32 {
-	low, _ := node.FinalFields["LowLimit"].(map[string]any)
-	if lowIssuer, _ := low["issuer"].(string); lowIssuer == ammAddr {
-		return state.LsfHighReserve
-	}
-	return state.LsfLowReserve
 }

--- a/internal/testing/amm/amm_delete_reserve_flag_test.go
+++ b/internal/testing/amm/amm_delete_reserve_flag_test.go
@@ -1,0 +1,106 @@
+package amm_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/amm"
+	"github.com/LeJamon/go-xrpl/internal/testing/metadata"
+	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	coreAmm "github.com/LeJamon/go-xrpl/internal/tx/amm"
+)
+
+// TestAMMTeardownPreservesHolderReserveFlag is a regression test for #1141: on a
+// full AMM teardown, deleteAMMTrustLine must clear a trust-line reserve flag only
+// on the AMM side. The LP-token line carries its reserve flag on the non-AMM
+// (holder) side; clearing it forks the ledger hash via a spurious
+// PreviousFields.Flags on that DeletedNode while mainnet leaves the flag intact.
+//
+// A non-zero limit on the holder's LP-token line keeps the reserve from being
+// released during the LP-token burn — rippled (rippleCreditIOU) only collapses a
+// default line (limit == 0) — so the flag survives to deleteAMMTrustLine where
+// the fix applies. Without it the burn clears the reserve first and the gated
+// branch is never exercised.
+func TestAMMTeardownPreservesHolderReserveFlag(t *testing.T) {
+	env := amm.NewAMMTestEnv(t)
+	env.FundWithIOUs(30000, 0)
+	env.Close()
+
+	if r := env.Submit(amm.AMMCreate(env.Alice, amm.XRPAmount(10000), amm.IOUAmount(env.GW, "USD", 10000)).Build()); !r.Success {
+		t.Fatalf("AMMCreate: %s - %s", r.Code, r.Message)
+	}
+	env.Close()
+
+	ammAcc := env.ReadAMMAccount(amm.XRP(), env.USD)
+	lptCurrency := coreAmm.GenerateAMMLPTCurrency("XRP", "USD")
+
+	limit := tx.NewIssuedAmountFromFloat64(1_000_000_000, lptCurrency, ammAcc.Address)
+	if r := env.Submit(trustset.TrustSet(env.Alice, limit).Build()); !r.Success {
+		t.Fatalf("TrustSet LP limit: %s - %s", r.Code, r.Message)
+	}
+	env.Close()
+
+	// Redeem all LP tokens; this deletes the AMM account and its trust lines.
+	result := env.Submit(amm.AMMWithdraw(env.Alice, amm.XRP(), env.USD).WithdrawAll().Build())
+	if !result.Success {
+		t.Fatalf("WithdrawAll: %s - %s", result.Code, result.Message)
+	}
+	if env.ReadAMMData(amm.XRP(), env.USD) != nil {
+		t.Fatal("AMM should be deleted after WithdrawAll")
+	}
+
+	lpLine := findDeletedRippleState(t, result, lptCurrency)
+	if lpLine == nil {
+		t.Fatal("no DeletedNode RippleState for the LP-token line")
+	}
+
+	holderReserve := holderReserveBit(lpLine, ammAcc.Address)
+	finalFlags := metadata.ToUint32(metadata.GetFinalField(lpLine, "Flags"))
+	if finalFlags&holderReserve == 0 {
+		t.Errorf("holder reserve flag (0x%X) was cleared on the LP-token line: FinalFields.Flags=0x%X", holderReserve, finalFlags)
+	}
+	if lpLine.PreviousFields != nil {
+		if v, ok := lpLine.PreviousFields["Flags"]; ok {
+			t.Errorf("spurious PreviousFields.Flags=%v on the LP-token line DeletedNode", v)
+		}
+	}
+
+	// Contrast: the AMM-side pool line (USD) does release its reserve — the gated
+	// branch the fix keeps clearing.
+	usdLine := findDeletedRippleState(t, result, "USD")
+	if usdLine == nil {
+		t.Fatal("no DeletedNode RippleState for the USD pool line")
+	}
+	usdFinal := metadata.ToUint32(metadata.GetFinalField(usdLine, "Flags"))
+	if usdFinal&(state.LsfLowReserve|state.LsfHighReserve) != 0 {
+		t.Errorf("AMM-side reserve flag not cleared on the USD pool line: FinalFields.Flags=0x%X", usdFinal)
+	}
+}
+
+// findDeletedRippleState returns the DeletedNode RippleState whose Balance is in
+// the given currency, or nil.
+func findDeletedRippleState(t *testing.T, result jtx.TxResult, currency string) *tx.AffectedNode {
+	t.Helper()
+	for _, n := range metadata.FindNodes(result.Metadata, "DeletedNode", "RippleState") {
+		bal, ok := n.FinalFields["Balance"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if cur, _ := bal["currency"].(string); cur == currency {
+			return n
+		}
+	}
+	return nil
+}
+
+// holderReserveBit returns the reserve flag of a trust line's non-AMM side,
+// given the AMM account address.
+func holderReserveBit(node *tx.AffectedNode, ammAddr string) uint32 {
+	low, _ := node.FinalFields["LowLimit"].(map[string]any)
+	if lowIssuer, _ := low["issuer"].(string); lowIssuer == ammAddr {
+		return state.LsfHighReserve
+	}
+	return state.LsfLowReserve
+}

--- a/internal/testing/amm/amm_delete_reserve_flag_test.go
+++ b/internal/testing/amm/amm_delete_reserve_flag_test.go
@@ -65,7 +65,7 @@ func TestAMMTeardownPreservesHolderReserveFlag(t *testing.T) {
 	}
 
 	// The holder is the non-AMM side; its reserve flag must remain set.
-	holderReserve := uint32(state.LsfLowReserve)
+	holderReserve := state.LsfLowReserve
 	if low, _ := lpLine.FinalFields["LowLimit"].(map[string]any); low != nil {
 		if iss, _ := low["issuer"].(string); iss == ammAcc.Address {
 			holderReserve = state.LsfHighReserve

--- a/internal/tx/amm/amm_delete_account.go
+++ b/internal/tx/amm/amm_delete_account.go
@@ -91,9 +91,9 @@ func deleteAMMTrustLine(view tx.LedgerView, lineKey keylet.Keylet, rs *state.Rip
 		return ter.TecINTERNAL
 	}
 
-	// Clear the reserve flag only on the AMM side — rippled clears it during the
-	// payout credit, never here, and leaves the non-AMM (holder) side's flag
-	// (e.g. the LP-token line) set.
+	// Clear the reserve flag only on the AMM side, reproducing rippled: it
+	// releases the AMM side's reserve during the payout credit and leaves the
+	// non-AMM (holder) side's flag set (e.g. on the LP-token line).
 	if rs.Flags&state.LsfLowReserve != 0 {
 		if ammLow {
 			rs.Flags &^= state.LsfLowReserve

--- a/internal/tx/amm/amm_delete_account.go
+++ b/internal/tx/amm/amm_delete_account.go
@@ -91,14 +91,9 @@ func deleteAMMTrustLine(view tx.LedgerView, lineKey keylet.Keylet, rs *state.Rip
 		return ter.TecINTERNAL
 	}
 
-	// Clear the reserve flag ONLY on the AMM side, and decrement each reserve-
-	// holding side's OwnerCount. rippled releases the AMM side's reserve as the
-	// pool line is emptied (rippleCreditIOU drives the AMM side to zero), so the
-	// line's DeletedNode records that flag change; but it never clears the
-	// non-AMM (holder) side's flag — e.g. on the LP-token line the holder keeps
-	// lsfLowReserve. Clearing the holder-side flag here was an overreach that
-	// forked the ledger hash on a full AMM teardown (a spurious Flags change on
-	// the LP-token line's DeletedNode).
+	// Clear the reserve flag only on the AMM side — rippled clears it during the
+	// payout credit, never here, and leaves the non-AMM (holder) side's flag
+	// (e.g. the LP-token line) set.
 	if rs.Flags&state.LsfLowReserve != 0 {
 		if ammLow {
 			rs.Flags &^= state.LsfLowReserve

--- a/internal/tx/amm/amm_delete_account.go
+++ b/internal/tx/amm/amm_delete_account.go
@@ -91,21 +91,26 @@ func deleteAMMTrustLine(view tx.LedgerView, lineKey keylet.Keylet, rs *state.Rip
 		return ter.TecINTERNAL
 	}
 
-	// rippled empties an AMM's pool lines during the withdrawal payout, where
-	// rippleCreditIOU drives the AMM (reserve) side to zero: it clears that
-	// side's reserve flag on the line and decrements the line owner's OwnerCount
-	// before trustDelete erases the line. Both mutations must be recorded
-	// in-place so the resulting DeletedNode metadata carries PreviousFields
-	// (line Flags 0x..020000 -> 0x..000000, owner OwnerCount n -> n-1). Mirror
-	// that here for each side holding a reserve, before the line is erased.
+	// Clear the reserve flag ONLY on the AMM side, and decrement each reserve-
+	// holding side's OwnerCount. rippled releases the AMM side's reserve as the
+	// pool line is emptied (rippleCreditIOU drives the AMM side to zero), so the
+	// line's DeletedNode records that flag change; but it never clears the
+	// non-AMM (holder) side's flag — e.g. on the LP-token line the holder keeps
+	// lsfLowReserve. Clearing the holder-side flag here was an overreach that
+	// forked the ledger hash on a full AMM teardown (a spurious Flags change on
+	// the LP-token line's DeletedNode).
 	if rs.Flags&state.LsfLowReserve != 0 {
-		rs.Flags &^= state.LsfLowReserve
+		if ammLow {
+			rs.Flags &^= state.LsfLowReserve
+		}
 		if err := decrementLineOwner(view, lowAccountID, lowAccount, ammLow); err != nil {
 			return ter.TecINTERNAL
 		}
 	}
 	if rs.Flags&state.LsfHighReserve != 0 {
-		rs.Flags &^= state.LsfHighReserve
+		if ammHigh {
+			rs.Flags &^= state.LsfHighReserve
+		}
 		if err := decrementLineOwner(view, highAccountID, highAccount, ammHigh); err != nil {
 			return ter.TecINTERNAL
 		}


### PR DESCRIPTION
Fixes #1141.

A full AMM teardown (`AMMWithdraw` of the last LP tokens) forked the ledger hash at 99266883: `deleteAMMTrustLine` cleared the reserve flag on the non-AMM (holder) side of the LP-token line and recorded a spurious `PreviousFields.Flags`. rippled clears only the AMM side's reserve and leaves the holder side intact (`View.cpp:2718-2766`).

Gate the flag-clearing on the AMM side; the per-reserve-side OwnerCount decrement and pool-line handling are unchanged.

**Verified byte-exact:** replay 99261370→99272142 clean (99266883 now OK); amm/testing-amm/state unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7BGJUPNfidYGoXg7r8F5K