### PR TITLE
fix: tolerate fat-reply / off-frontier shamap nodes

### DIFF
--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -242,7 +242,13 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 				"error", err.Error())
 			continue
 		}
-		if _, err := txMap.AddKnownNodeByID(parsedID, node.NodeData); err != nil {
+		res, err := txMap.AddKnownNodeByID(parsedID, node.NodeData)
+		if res == shamap.NodeReRequest {
+			// Ahead of its frontier: re-requested by the next getMissingNodes
+			// walk, not a poisoned reply.
+			continue
+		}
+		if res == shamap.NodeInvalid {
 			replyValid = false
 			r.logger.Debug("tx-set sync: node rejected",
 				"t", "consensus", "event", "txset-node-reject",

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -219,10 +219,10 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 	// storm of issue #413.
 	//
 	// replyValid stays true unless any non-root node fails parse or
-	// AddKnownNodeByID: a single bad non-root poisons the WHOLE reply.
-	// We MUST reflect this all-or-nothing reply outcome in per-peer
-	// non-progress accounting so a peer trickling junk alongside one
-	// good node can't keep its counter pinned at zero.
+	// AddKnownNodeByID. A provably-invalid non-root stops harvesting the
+	// rest of the reply (stop-on-first-bad) and flags the whole reply as
+	// non-progress, so a peer trickling junk alongside one good node can't
+	// keep its counter pinned at zero.
 	added := 0
 	replyValid := true
 	for _, node := range ld.Nodes {
@@ -255,8 +255,8 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 				"txset", fmt.Sprintf("%x", txSetID[:8]),
 				"node_id", fmt.Sprintf("%x", node.NodeID),
 				"node_data_len", len(node.NodeData),
-				"error", err.Error())
-			continue
+				"error", err)
+			break
 		}
 		added++
 		// Learn (submit + relay) the tx carried by this acquired leaf.

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -554,10 +554,8 @@ func (l *Ledger) GotTransactionNodes(nodes []message.LedgerNode) error {
 // number freshly attached. A node whose ancestor is still a hash-only stub
 // (NodeReRequest) is dropped without counting as a reject — the next
 // getMissingNodes walk re-requests the correct frontier and it returns on a
-// later reply, matching rippled's addKnownNode "attach-or-re-request". The
-// first genuinely invalid node stops harvesting the rest of the reply,
-// mirroring receiveNode's stop-on-first-bad (InboundLedger.cpp:920-927).
-// Caller holds l.mu.
+// later reply. The first genuinely invalid node stops harvesting the rest of
+// the reply. Caller holds l.mu.
 func (l *Ledger) applyKnownNodes(m *shamap.SHAMap, nodes []message.LedgerNode, label string) int {
 	added := 0
 	for _, node := range nodes {

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -579,13 +579,15 @@ func (l *Ledger) applyKnownNodes(m *shamap.SHAMap, nodes []message.LedgerNode, l
 		case shamap.NodeDuplicate, shamap.NodeReRequest:
 			// Already present, or ahead of its frontier: neither progress nor
 			// a reject. Re-requested by the next missing-node walk.
-		default: // NodeInvalid
+		default: // NodeInvalid, or any unrecognized result — reject conservatively.
 			l.rejectCount++
-			l.lastRejectErr = err.Error()
+			if err != nil {
+				l.lastRejectErr = err.Error()
+			}
 			l.logger.Debug("inbound ledger: "+label+" node rejected",
 				"node_id", fmt.Sprintf("%x", node.NodeID),
 				"node_data_len", len(node.NodeData),
-				"error", err.Error())
+				"error", err)
 			return added
 		}
 	}

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -484,35 +484,7 @@ func (l *Ledger) GotStateNodes(nodes []message.LedgerNode) error {
 	// drive placement by the peer-supplied NodeID via AddKnownNodeByID
 	// rather than the hash-search AddKnownNodeUnchecked, which silently
 	// drops nodes whose direct parent isn't loaded yet.
-	added := 0
-	for _, node := range nodes {
-		if len(node.NodeData) == 0 {
-			continue
-		}
-		parsedID, err := shamap.UnmarshalBinary(node.NodeID)
-		if err != nil {
-			l.logger.Debug("inbound ledger: malformed state node ID",
-				"node_id_len", len(node.NodeID),
-				"error", err.Error())
-			continue
-		}
-		if parsedID.IsRoot() {
-			continue
-		}
-		fresh, err := l.stateMap.AddKnownNodeByID(parsedID, node.NodeData)
-		if err != nil {
-			l.rejectCount++
-			l.lastRejectErr = err.Error()
-			l.logger.Debug("inbound ledger: state node rejected",
-				"node_id", fmt.Sprintf("%x", node.NodeID),
-				"node_data_len", len(node.NodeData),
-				"error", err.Error())
-			continue
-		}
-		if fresh {
-			added++
-		}
-	}
+	added := l.applyKnownNodes(l.stateMap, nodes, "state")
 
 	if added > 0 {
 		l.markProgressLocked()
@@ -557,35 +529,7 @@ func (l *Ledger) GotTransactionNodes(nodes []message.LedgerNode) error {
 		return fmt.Errorf("unexpected state %d for GotTransactionNodes", l.state)
 	}
 
-	added := 0
-	for _, node := range nodes {
-		if len(node.NodeData) == 0 {
-			continue
-		}
-		parsedID, err := shamap.UnmarshalBinary(node.NodeID)
-		if err != nil {
-			l.logger.Debug("inbound ledger: malformed tx node ID",
-				"node_id_len", len(node.NodeID),
-				"error", err.Error())
-			continue
-		}
-		if parsedID.IsRoot() {
-			continue
-		}
-		fresh, err := l.txMap.AddKnownNodeByID(parsedID, node.NodeData)
-		if err != nil {
-			l.rejectCount++
-			l.lastRejectErr = err.Error()
-			l.logger.Debug("inbound ledger: tx node rejected",
-				"node_id", fmt.Sprintf("%x", node.NodeID),
-				"node_data_len", len(node.NodeData),
-				"error", err.Error())
-			continue
-		}
-		if fresh {
-			added++
-		}
-	}
+	added := l.applyKnownNodes(l.txMap, nodes, "tx")
 
 	if added > 0 {
 		l.markProgressLocked()
@@ -604,6 +548,50 @@ func (l *Ledger) GotTransactionNodes(nodes []message.LedgerNode) error {
 	l.recomputeComplete()
 
 	return nil
+}
+
+// applyKnownNodes places peer-supplied tree nodes by NodeID, returning the
+// number freshly attached. A node whose ancestor is still a hash-only stub
+// (NodeReRequest) is dropped without counting as a reject — the next
+// getMissingNodes walk re-requests the correct frontier and it returns on a
+// later reply, matching rippled's addKnownNode "attach-or-re-request". The
+// first genuinely invalid node stops harvesting the rest of the reply,
+// mirroring receiveNode's stop-on-first-bad (InboundLedger.cpp:920-927).
+// Caller holds l.mu.
+func (l *Ledger) applyKnownNodes(m *shamap.SHAMap, nodes []message.LedgerNode, label string) int {
+	added := 0
+	for _, node := range nodes {
+		if len(node.NodeData) == 0 {
+			continue
+		}
+		parsedID, err := shamap.UnmarshalBinary(node.NodeID)
+		if err != nil {
+			l.logger.Debug("inbound ledger: malformed "+label+" node ID",
+				"node_id_len", len(node.NodeID),
+				"error", err.Error())
+			continue
+		}
+		if parsedID.IsRoot() {
+			continue
+		}
+		res, err := m.AddKnownNodeByID(parsedID, node.NodeData)
+		switch res {
+		case shamap.NodeUseful:
+			added++
+		case shamap.NodeDuplicate, shamap.NodeReRequest:
+			// Already present, or ahead of its frontier: neither progress nor
+			// a reject. Re-requested by the next missing-node walk.
+		default: // NodeInvalid
+			l.rejectCount++
+			l.lastRejectErr = err.Error()
+			l.logger.Debug("inbound ledger: "+label+" node rejected",
+				"node_id", fmt.Sprintf("%x", node.NodeID),
+				"node_data_len", len(node.NodeData),
+				"error", err.Error())
+			return added
+		}
+	}
+	return added
 }
 
 // recomputeComplete promotes the acquisition to StateComplete once both the
@@ -830,7 +818,7 @@ func fillFromLocal(m *shamap.SHAMap, fetch func(hash [32]byte) ([]byte, bool)) b
 			if !ok {
 				continue
 			}
-			if fresh, err := m.AddKnownNodeFromPrefix(missing[i].NodeID, data); err == nil && fresh {
+			if res, _ := m.AddKnownNodeFromPrefix(missing[i].NodeID, data); res == shamap.NodeUseful {
 				passAdded++
 			}
 		}

--- a/internal/ledger/inbound/inbound_attach_test.go
+++ b/internal/ledger/inbound/inbound_attach_test.go
@@ -1,0 +1,147 @@
+package inbound
+
+import (
+	"io"
+	"log/slog"
+	"sort"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+// buildDeepStateSource builds a multi-level state tree and returns its root
+// hash, serialized root, and wire nodes.
+func buildDeepStateSource(t *testing.T) ([32]byte, []byte, []shamap.WireNode) {
+	t.Helper()
+	source := shamap.New(shamap.TypeState)
+	for branch := range byte(4) {
+		for sub := range byte(4) {
+			for i := range byte(4) {
+				var key [32]byte
+				key[0] = (branch << 4) | sub
+				key[1] = i << 4
+				key[31] = 0xA5
+				if err := source.Put(key, []byte{branch, sub, i, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}); err != nil {
+					t.Fatalf("put: %v", err)
+				}
+			}
+		}
+	}
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("source hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("serialize root: %v", err)
+	}
+	wireNodes, err := source.WalkWireNodes()
+	if err != nil {
+		t.Fatalf("walk wire nodes: %v", err)
+	}
+	return rootHash, rootData, wireNodes
+}
+
+// Issue #1143: out-of-order fat-reply nodes (those arriving before their
+// ancestor stub is materialized) must NOT be counted as rejects. Delivered
+// deepest-first they re-request rather than flood the reject log, and the
+// acquisition still converges over a few passes.
+func TestGotStateNodes_OutOfOrderNotRejected(t *testing.T) {
+	t.Parallel()
+	rootHash, rootData, wireNodes := buildDeepStateSource(t)
+
+	hdr := header.LedgerHeader{LedgerIndex: 200, AccountHash: rootHash}
+	hdrBytes, ledgerHash := encodeHeader(hdr)
+	il := New(ledgerHash, 200, 9, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err := il.GotBase([]message.LedgerNode{{NodeData: hdrBytes}, {NodeData: rootData}}); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+
+	nodes := make([]message.LedgerNode, 0, len(wireNodes))
+	maxDepth := 0
+	for _, w := range wireNodes {
+		nid, err := shamap.UnmarshalBinary(w.NodeID)
+		if err != nil {
+			t.Fatalf("UnmarshalBinary: %v", err)
+		}
+		if nid.IsRoot() {
+			continue
+		}
+		if int(nid.Depth()) > maxDepth {
+			maxDepth = int(nid.Depth())
+		}
+		nodes = append(nodes, message.LedgerNode{NodeID: w.NodeID, NodeData: w.Data})
+	}
+	if maxDepth < 2 {
+		t.Fatalf("test setup too shallow: maxDepth=%d", maxDepth)
+	}
+	// Deepest-first: every non-frontier node is ahead of its parent stub.
+	sort.SliceStable(nodes, func(i, j int) bool {
+		a, _ := shamap.UnmarshalBinary(nodes[i].NodeID)
+		b, _ := shamap.UnmarshalBinary(nodes[j].NodeID)
+		return a.Depth() > b.Depth()
+	})
+
+	for round := 0; il.state != StateComplete; round++ {
+		if round > maxDepth+2 {
+			t.Fatalf("did not converge after %d passes (state=%d)", round, il.state)
+		}
+		if err := il.GotStateNodes(nodes); err != nil {
+			t.Fatalf("GotStateNodes pass %d: %v", round, err)
+		}
+		if il.rejectCount != 0 {
+			t.Fatalf("pass %d: ancestor-gap nodes counted as rejects: rejectCount=%d (%q)",
+				round, il.rejectCount, il.lastRejectErr)
+		}
+	}
+
+	gotHash, err := il.stateMap.Hash()
+	if err != nil {
+		t.Fatalf("dest hash: %v", err)
+	}
+	if gotHash != rootHash {
+		t.Errorf("reconstructed state hash mismatch: want %x got %x", rootHash[:8], gotHash[:8])
+	}
+}
+
+// Issue #1143: a genuinely invalid node stops the rest of the reply from being
+// harvested, mirroring rippled receiveNode's stop-on-first-bad. Three corrupt
+// nodes therefore tally exactly one reject, not three.
+func TestGotStateNodes_StopsOnFirstInvalid(t *testing.T) {
+	t.Parallel()
+	rootHash, rootData, wireNodes := buildDeepStateSource(t)
+
+	var d1 []shamap.WireNode
+	for _, w := range wireNodes {
+		nid, _ := shamap.UnmarshalBinary(w.NodeID)
+		if nid.Depth() == 1 {
+			d1 = append(d1, w)
+		}
+	}
+	if len(d1) < 3 {
+		t.Fatalf("need >=3 depth-1 nodes, got %d", len(d1))
+	}
+
+	hdr := header.LedgerHeader{LedgerIndex: 200, AccountHash: rootHash}
+	hdrBytes, ledgerHash := encodeHeader(hdr)
+	il := New(ledgerHash, 200, 9, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err := il.GotBase([]message.LedgerNode{{NodeData: hdrBytes}, {NodeData: rootData}}); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+
+	// Each node carries a sibling's data: the hash never matches the parent's
+	// stored child hash, so every entry is NodeInvalid.
+	bad := []message.LedgerNode{
+		{NodeID: d1[0].NodeID, NodeData: d1[1].Data},
+		{NodeID: d1[1].NodeID, NodeData: d1[2].Data},
+		{NodeID: d1[2].NodeID, NodeData: d1[0].Data},
+	}
+	if err := il.GotStateNodes(bad); err != nil {
+		t.Fatalf("GotStateNodes: %v", err)
+	}
+	if il.rejectCount != 1 {
+		t.Fatalf("stop-on-first-bad: want rejectCount=1, got %d", il.rejectCount)
+	}
+}

--- a/shamap/attach_outoforder_test.go
+++ b/shamap/attach_outoforder_test.go
@@ -1,0 +1,129 @@
+package shamap
+
+import (
+	"encoding/hex"
+	"sort"
+	"testing"
+)
+
+// TestAddKnownNodeByID_OutOfOrderConverges feeds a multi-level tree's wire
+// nodes deepest-first — the worst case for ancestor gaps — and asserts that
+// off-frontier nodes return NodeReRequest (never an error) and that the map
+// still converges to the source root. This is the regression for issue #1143:
+// fat-reply / off-frontier nodes must follow rippled's "attach-or-re-request"
+// instead of flooding the reject log with ErrParentNotInTree.
+func TestAddKnownNodeByID_OutOfOrderConverges(t *testing.T) {
+	source := New(TypeTransaction)
+
+	// Three keys sharing the first two bytes force a deep (depth>=3) chain;
+	// the spread keys give the tree breadth so gaps appear at several levels.
+	put := func(k [32]byte) {
+		if err := source.Put(k, []byte{0xCA, 0xFE, 0xBA, 0xBE, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+	for i := range 3 {
+		var k [32]byte
+		k[0], k[1], k[2] = 0xAA, 0xAA, byte(i)
+		put(k)
+	}
+	for i := range 240 {
+		var k [32]byte
+		k[0], k[1], k[2] = byte(i), byte(i*7+1), byte(i*13+2)
+		put(k)
+	}
+
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("source hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("SerializeRoot: %v", err)
+	}
+	wireNodes, err := source.WalkWireNodes()
+	if err != nil {
+		t.Fatalf("WalkWireNodes: %v", err)
+	}
+
+	type item struct {
+		id   NodeID
+		data []byte
+		key  string
+	}
+	var list []item
+	maxDepth := 0
+	for _, w := range wireNodes {
+		nid, err := UnmarshalBinary(w.NodeID)
+		if err != nil {
+			t.Fatalf("UnmarshalBinary: %v", err)
+		}
+		if nid.IsRoot() {
+			continue
+		}
+		if int(nid.Depth()) > maxDepth {
+			maxDepth = int(nid.Depth())
+		}
+		list = append(list, item{id: nid, data: w.Data, key: hex.EncodeToString(w.NodeID)})
+	}
+	if maxDepth < 3 {
+		t.Fatalf("test setup too shallow: maxDepth=%d, want >=3", maxDepth)
+	}
+	// Deepest-first: every node arrives before its parent — the worst case.
+	sort.SliceStable(list, func(i, j int) bool { return list[i].id.Depth() > list[j].id.Depth() })
+
+	dest := New(TypeTransaction)
+	if err := dest.StartSync(); err != nil {
+		t.Fatalf("StartSync: %v", err)
+	}
+	if err := dest.AddRootNode(rootHash, rootData); err != nil {
+		t.Fatalf("AddRootNode: %v", err)
+	}
+
+	placed := make(map[string]bool, len(list))
+	sawReRequest := false
+	for round := 0; len(placed) < len(list); round++ {
+		if round > maxDepth+1 {
+			t.Fatalf("did not converge: %d/%d placed after %d rounds", len(placed), len(list), round)
+		}
+		progressed := 0
+		for _, it := range list {
+			if placed[it.key] {
+				continue
+			}
+			res, err := dest.AddKnownNodeByID(it.id, it.data)
+			if err != nil {
+				t.Fatalf("out-of-order delivery must never error, got %v at depth=%d", err, it.id.Depth())
+			}
+			switch res {
+			case NodeUseful:
+				placed[it.key] = true
+				progressed++
+			case NodeDuplicate:
+				placed[it.key] = true
+			case NodeReRequest:
+				sawReRequest = true
+			default:
+				t.Fatalf("unexpected NodeInvalid at depth=%d", it.id.Depth())
+			}
+		}
+		if progressed == 0 {
+			t.Fatalf("stalled: %d/%d placed, no progress this round", len(placed), len(list))
+		}
+	}
+
+	if !sawReRequest {
+		t.Fatal("deepest-first delivery never exercised NodeReRequest")
+	}
+
+	if err := dest.FinishSync(); err != nil {
+		t.Fatalf("FinishSync: %v", err)
+	}
+	destHash, err := dest.Hash()
+	if err != nil {
+		t.Fatalf("dest hash: %v", err)
+	}
+	if destHash != rootHash {
+		t.Errorf("reconstructed root mismatch: want %x got %x", rootHash[:8], destHash[:8])
+	}
+}

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -19,9 +19,9 @@ var (
 )
 
 // AddNodeResult classifies the outcome of placing a peer-supplied node by
-// NodeID, mirroring rippled's SHAMapAddNode (SHAMapSync.cpp). It lets the
-// inbound caller tell a genuinely bad node from one that is simply ahead of
-// its frontier and should be re-requested rather than counted as a reject.
+// NodeID. It lets the inbound caller tell a genuinely bad node from one that
+// is simply ahead of its frontier and should be re-requested rather than
+// counted as a reject.
 type AddNodeResult int
 
 const (
@@ -38,8 +38,7 @@ const (
 	// NodeReRequest: the node is well-formed but an ancestor on its path is
 	// still a hash-only stub, so it cannot be hooked yet. Not an error: the
 	// next getMissingNodes walk re-requests the correct frontier and the node
-	// returns on a later reply. Mirrors rippled's descend()→nullptr with
-	// iNodeID != node returning useful() (re-requested by getMissingNodes).
+	// returns on a later reply.
 	NodeReRequest
 )
 
@@ -350,8 +349,8 @@ func (sm *SHAMap) AddKnownNodeFromPrefix(nodeID NodeID, data []byte) (AddNodeRes
 // by the peer-supplied SHAMap NodeID (path + depth). The node's computed
 // hash must match the parent's stored child hash at the target branch.
 //
-// Mirrors rippled's SHAMap::addKnownNode (SHAMapSync.cpp:578-673): descent
-// through the partial tree is driven by the NodeID, not by hash-searching.
+// Descent through the partial tree is driven by the NodeID, not by
+// hash-searching.
 //
 // Returns an AddNodeResult and, only for NodeInvalid, the underlying error:
 //   - NodeUseful, nil on a fresh attach
@@ -386,10 +385,9 @@ func (sm *SHAMap) AddKnownNodeByID(nodeID NodeID, data []byte) (AddNodeResult, e
 // hash against the parent's stored child hash. deserialize runs only once the
 // target slot is known to be empty, so a duplicate (slot already populated, or
 // a consolidated leaf mid-path) short-circuits without parsing the peer's
-// data. The AddNodeResult mirrors rippled's SHAMapAddNode (SHAMapSync.cpp):
-// reaching a hash-only ancestor before the target depth is NodeReRequest, not
-// an error, so off-frontier fat-reply nodes converge over re-requests instead
-// of flooding the reject log. Shared by AddKnownNodeByID and
+// data. Reaching a hash-only ancestor before the target depth is NodeReRequest,
+// not an error, so off-frontier fat-reply nodes converge over re-requests
+// instead of flooding the reject log. Shared by AddKnownNodeByID and
 // AddKnownNodeFromPrefix. Caller must hold the write lock and have validated
 // state and nodeID.
 func (sm *SHAMap) attachKnownNodeAt(nodeID NodeID, deserialize func() (Node, error)) (AddNodeResult, error) {
@@ -408,8 +406,7 @@ func (sm *SHAMap) attachKnownNodeAt(nodeID NodeID, deserialize func() (Node, err
 		child, childHash, isSet := parent.LoadChild(branch)
 		if !isSet {
 			// A materialized ancestor has no child here: the offered node is
-			// not part of this map (a node from another tree). rippled
-			// isEmptyBranch → SHAMapAddNode::invalid (SHAMapSync.cpp:601).
+			// not part of this map (a node from another tree).
 			return NodeInvalid, ErrEmptyBranchOnPath
 		}
 
@@ -422,7 +419,7 @@ func (sm *SHAMap) attachKnownNodeAt(nodeID NodeID, deserialize func() (Node, err
 				return NodeInvalid, fmt.Errorf("%w: %w", ErrInvalidNodeData, err)
 			}
 			// At leaf depth, an inner node is provably invalid — mark the
-			// map and bail (mirrors rippled SHAMapSync.cpp:632-638).
+			// map and bail.
 			if _, isInner := newNode.(*innerNode); isInner && targetDepth == MaxDepth {
 				sm.state = StateInvalid
 				return NodeInvalid, ErrUnexpectedNode
@@ -433,7 +430,6 @@ func (sm *SHAMap) attachKnownNodeAt(nodeID NodeID, deserialize func() (Node, err
 			if newNode.Hash() != childHash {
 				return NodeInvalid, ErrNodeHashMismatch
 			}
-			// rippled SHAMapSync.cpp:653 canonicalizeChild
 			parent.SetChildIfNil(branch, newNode)
 			return NodeUseful, nil
 		}
@@ -441,16 +437,13 @@ func (sm *SHAMap) attachKnownNodeAt(nodeID NodeID, deserialize func() (Node, err
 		if child == nil {
 			// Ancestor still a hash-only stub: cannot hook the node yet. The
 			// next getMissingNodes walk re-requests the correct frontier and
-			// it returns on a later reply (rippled descend()→nullptr with
-			// iNodeID != node → useful(), SHAMapSync.cpp:643-651).
+			// it returns on a later reply.
 			return NodeReRequest, nil
 		}
 		nextInner, ok := child.(*innerNode)
 		if !ok {
 			// A leaf encountered mid-path is the canonical content at this
 			// slot (SHAMap consolidates lone leaves above leafDepth).
-			// Rippled exits the !isInner() loop and returns duplicate
-			// (SHAMapSync.cpp:597, 671-672).
 			return NodeDuplicate, nil
 		}
 		parent = nextInner

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -18,6 +18,31 @@ var (
 	ErrParentNotInTree   = errors.New("parent node not yet loaded for path")
 )
 
+// AddNodeResult classifies the outcome of placing a peer-supplied node by
+// NodeID, mirroring rippled's SHAMapAddNode (SHAMapSync.cpp). It lets the
+// inbound caller tell a genuinely bad node from one that is simply ahead of
+// its frontier and should be re-requested rather than counted as a reject.
+type AddNodeResult int
+
+const (
+	// NodeInvalid: the node is provably wrong for this map — a hash mismatch,
+	// an inner node where only a leaf may live, or a path through a branch
+	// this map does not reference (a node from another tree). The caller
+	// should stop harvesting the rest of the reply.
+	NodeInvalid AddNodeResult = iota
+	// NodeUseful: a fresh node was attached at its slot.
+	NodeUseful
+	// NodeDuplicate: the slot was already populated, or the path consolidated
+	// into a mid-path leaf — nothing to do.
+	NodeDuplicate
+	// NodeReRequest: the node is well-formed but an ancestor on its path is
+	// still a hash-only stub, so it cannot be hooked yet. Not an error: the
+	// next getMissingNodes walk re-requests the correct frontier and the node
+	// returns on a later reply. Mirrors rippled's descend()→nullptr with
+	// iNodeID != node returning useful() (re-requested by getMissingNodes).
+	NodeReRequest
+)
+
 // SyncFilter is an interface for filtering which nodes should be fetched during sync.
 // This allows callers to avoid fetching nodes they already have locally.
 type SyncFilter interface {
@@ -302,18 +327,18 @@ func (sm *SHAMap) AddKnownNode(nodeHash [32]byte, data []byte) error {
 // parent's stored child hash at the target branch.
 //
 // Returns the same results as AddKnownNodeByID.
-func (sm *SHAMap) AddKnownNodeFromPrefix(nodeID NodeID, data []byte) (added bool, err error) {
+func (sm *SHAMap) AddKnownNodeFromPrefix(nodeID NodeID, data []byte) (AddNodeResult, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
 	if sm.state != StateSyncing {
-		return false, ErrSyncNotInProgress
+		return NodeInvalid, ErrSyncNotInProgress
 	}
 	if nodeID.IsRoot() {
-		return false, ErrUnexpectedNode
+		return NodeInvalid, ErrUnexpectedNode
 	}
 	if len(data) == 0 {
-		return false, ErrInvalidNodeData
+		return NodeInvalid, ErrInvalidNodeData
 	}
 
 	return sm.attachKnownNodeAt(nodeID, func() (Node, error) {
@@ -328,29 +353,27 @@ func (sm *SHAMap) AddKnownNodeFromPrefix(nodeID NodeID, data []byte) (added bool
 // Mirrors rippled's SHAMap::addKnownNode (SHAMapSync.cpp:578-673): descent
 // through the partial tree is driven by the NodeID, not by hash-searching.
 //
-// Returns:
-//   - added=true, nil on a fresh attach (rippled SHAMapAddNode::useful())
-//   - added=false, nil when the slot is already populated
-//     (duplicate, matching rippled's SHAMapAddNode::duplicate())
-//   - ErrEmptyBranchOnPath when descent hits an empty branch — peer sent
-//     a node we never asked for
-//   - ErrParentNotInTree when an intermediate ancestor on the path is
-//     still a hash-only stub — caller must acquire ancestors first
-//   - ErrNodeHashMismatch when the computed hash doesn't match what the
-//     parent expects at the target branch
-//   - ErrSyncNotInProgress / ErrInvalidNodeData on misuse
-func (sm *SHAMap) AddKnownNodeByID(nodeID NodeID, data []byte) (added bool, err error) {
+// Returns an AddNodeResult and, only for NodeInvalid, the underlying error:
+//   - NodeUseful, nil on a fresh attach
+//   - NodeDuplicate, nil when the slot is already populated or the path
+//     consolidated into a mid-path leaf
+//   - NodeReRequest, nil when an ancestor on the path is still a hash-only
+//     stub: not a reject, re-requested by the next getMissingNodes walk
+//   - NodeInvalid with ErrEmptyBranchOnPath (path into a branch this map does
+//     not reference), ErrNodeHashMismatch, ErrUnexpectedNode (inner where only
+//     a leaf may live), or ErrSyncNotInProgress / ErrInvalidNodeData on misuse
+func (sm *SHAMap) AddKnownNodeByID(nodeID NodeID, data []byte) (AddNodeResult, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
 	if sm.state != StateSyncing {
-		return false, ErrSyncNotInProgress
+		return NodeInvalid, ErrSyncNotInProgress
 	}
 	if nodeID.IsRoot() {
-		return false, ErrUnexpectedNode
+		return NodeInvalid, ErrUnexpectedNode
 	}
 	if len(data) == 0 {
-		return false, ErrInvalidNodeData
+		return NodeInvalid, ErrInvalidNodeData
 	}
 
 	return sm.attachKnownNodeAt(nodeID, func() (Node, error) {
@@ -359,18 +382,19 @@ func (sm *SHAMap) AddKnownNodeByID(nodeID NodeID, data []byte) (added bool, err 
 }
 
 // attachKnownNodeAt descends along nodeID's path and attaches the node
-// produced by deserialize at the target branch after verifying its hash
-// against the parent's stored child hash. deserialize runs only once the
-// target slot is known to be empty, so a duplicate (slot already
-// populated, or a consolidated leaf mid-path) short-circuits without
-// parsing the peer's data. added distinguishes a fresh attach from a
-// duplicate, mirroring rippled's SHAMapAddNode useful()/duplicate()
-// (SHAMapSync.cpp:653, 671-672). Shared by AddKnownNodeByID and
-// AddKnownNodeFromPrefix. Caller must hold the write lock and have
-// validated state and nodeID.
-func (sm *SHAMap) attachKnownNodeAt(nodeID NodeID, deserialize func() (Node, error)) (added bool, err error) {
+// produced by deserialize at the first hash-only slot, after verifying its
+// hash against the parent's stored child hash. deserialize runs only once the
+// target slot is known to be empty, so a duplicate (slot already populated, or
+// a consolidated leaf mid-path) short-circuits without parsing the peer's
+// data. The AddNodeResult mirrors rippled's SHAMapAddNode (SHAMapSync.cpp):
+// reaching a hash-only ancestor before the target depth is NodeReRequest, not
+// an error, so off-frontier fat-reply nodes converge over re-requests instead
+// of flooding the reject log. Shared by AddKnownNodeByID and
+// AddKnownNodeFromPrefix. Caller must hold the write lock and have validated
+// state and nodeID.
+func (sm *SHAMap) attachKnownNodeAt(nodeID NodeID, deserialize func() (Node, error)) (AddNodeResult, error) {
 	if sm.root == nil {
-		return false, ErrParentNotInTree
+		return NodeInvalid, ErrParentNotInTree
 	}
 
 	targetDepth := int(nodeID.Depth())
@@ -383,36 +407,43 @@ func (sm *SHAMap) attachKnownNodeAt(nodeID NodeID, deserialize func() (Node, err
 
 		child, childHash, isSet := parent.LoadChild(branch)
 		if !isSet {
-			return false, ErrEmptyBranchOnPath
+			// A materialized ancestor has no child here: the offered node is
+			// not part of this map (a node from another tree). rippled
+			// isEmptyBranch → SHAMapAddNode::invalid (SHAMapSync.cpp:601).
+			return NodeInvalid, ErrEmptyBranchOnPath
 		}
 
 		if curDepth+1 == targetDepth {
 			if child != nil {
-				return false, nil
+				return NodeDuplicate, nil
 			}
 			newNode, err := deserialize()
 			if err != nil {
-				return false, fmt.Errorf("%w: %w", ErrInvalidNodeData, err)
+				return NodeInvalid, fmt.Errorf("%w: %w", ErrInvalidNodeData, err)
 			}
 			// At leaf depth, an inner node is provably invalid — mark the
 			// map and bail (mirrors rippled SHAMapSync.cpp:632-638).
 			if _, isInner := newNode.(*innerNode); isInner && targetDepth == MaxDepth {
 				sm.state = StateInvalid
-				return false, ErrUnexpectedNode
+				return NodeInvalid, ErrUnexpectedNode
 			}
 			if err := newNode.UpdateHash(); err != nil {
-				return false, fmt.Errorf("failed to compute node hash: %w", err)
+				return NodeInvalid, fmt.Errorf("failed to compute node hash: %w", err)
 			}
 			if newNode.Hash() != childHash {
-				return false, ErrNodeHashMismatch
+				return NodeInvalid, ErrNodeHashMismatch
 			}
 			// rippled SHAMapSync.cpp:653 canonicalizeChild
 			parent.SetChildIfNil(branch, newNode)
-			return true, nil
+			return NodeUseful, nil
 		}
 
 		if child == nil {
-			return false, ErrParentNotInTree
+			// Ancestor still a hash-only stub: cannot hook the node yet. The
+			// next getMissingNodes walk re-requests the correct frontier and
+			// it returns on a later reply (rippled descend()→nullptr with
+			// iNodeID != node → useful(), SHAMapSync.cpp:643-651).
+			return NodeReRequest, nil
 		}
 		nextInner, ok := child.(*innerNode)
 		if !ok {
@@ -420,12 +451,12 @@ func (sm *SHAMap) attachKnownNodeAt(nodeID NodeID, deserialize func() (Node, err
 			// slot (SHAMap consolidates lone leaves above leafDepth).
 			// Rippled exits the !isInner() loop and returns duplicate
 			// (SHAMapSync.cpp:597, 671-672).
-			return false, nil
+			return NodeDuplicate, nil
 		}
 		parent = nextInner
 	}
 
-	return false, ErrUnexpectedNode
+	return NodeInvalid, ErrUnexpectedNode
 }
 
 // insertKnownNode inserts a node at the correct location in the tree.

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -25,17 +25,17 @@ var (
 type AddNodeResult int
 
 const (
-	// NodeInvalid: the node is provably wrong for this map — a hash mismatch,
-	// an inner node where only a leaf may live, or a path through a branch
-	// this map does not reference (a node from another tree). The caller
+	// NodeInvalid marks a node that is provably wrong for this map — a hash
+	// mismatch, an inner node where only a leaf may live, or a path through a
+	// branch this map does not reference (a node from another tree). The caller
 	// should stop harvesting the rest of the reply.
 	NodeInvalid AddNodeResult = iota
-	// NodeUseful: a fresh node was attached at its slot.
+	// NodeUseful means a fresh node was attached at its slot.
 	NodeUseful
-	// NodeDuplicate: the slot was already populated, or the path consolidated
-	// into a mid-path leaf — nothing to do.
+	// NodeDuplicate means the slot was already populated, or the path
+	// consolidated into a mid-path leaf — nothing to do.
 	NodeDuplicate
-	// NodeReRequest: the node is well-formed but an ancestor on its path is
+	// NodeReRequest marks a well-formed node whose ancestor on the path is
 	// still a hash-only stub, so it cannot be hooked yet. Not an error: the
 	// next getMissingNodes walk re-requests the correct frontier and the node
 	// returns on a later reply.

--- a/shamap/sync_test.go
+++ b/shamap/sync_test.go
@@ -537,7 +537,7 @@ func TestAddKnownNodeByID_SentinelErrors(t *testing.T) {
 		t.Fatal("test setup did not produce a depth>=2 node")
 	}
 
-	t.Run("ParentNotInTree", func(t *testing.T) {
+	t.Run("AncestorGapReRequests", func(t *testing.T) {
 		dest := New(TypeTransaction)
 		if err := dest.StartSync(); err != nil {
 			t.Fatalf("StartSync: %v", err)
@@ -545,10 +545,16 @@ func TestAddKnownNodeByID_SentinelErrors(t *testing.T) {
 		if err := dest.AddRootNode(rootHash, rootData); err != nil {
 			t.Fatalf("AddRootNode: %v", err)
 		}
+		// The deep node's parent is still a hash-only stub. rippled
+		// re-requests rather than rejecting (descend()→nullptr, iNodeID !=
+		// node → useful()), so this must be NodeReRequest, not an error.
 		nid, _ := UnmarshalBinary(deep.NodeID)
-		_, err = dest.AddKnownNodeByID(nid, deep.Data)
-		if !errors.Is(err, ErrParentNotInTree) {
-			t.Fatalf("want ErrParentNotInTree, got %v", err)
+		res, err := dest.AddKnownNodeByID(nid, deep.Data)
+		if err != nil {
+			t.Fatalf("ancestor gap: want nil error, got %v", err)
+		}
+		if res != NodeReRequest {
+			t.Fatalf("ancestor gap: want NodeReRequest, got %v", res)
 		}
 	})
 
@@ -636,21 +642,21 @@ func TestAddKnownNodeByID_SentinelErrors(t *testing.T) {
 			t.Skip("no depth-1 node available")
 		}
 		nid, _ := UnmarshalBinary(d1.NodeID)
-		added, err := dest.AddKnownNodeByID(nid, d1.Data)
+		res, err := dest.AddKnownNodeByID(nid, d1.Data)
 		if err != nil {
 			t.Fatalf("first AddKnownNodeByID: %v", err)
 		}
-		if !added {
-			t.Fatal("first AddKnownNodeByID: want added=true (useful)")
+		if res != NodeUseful {
+			t.Fatalf("first AddKnownNodeByID: want NodeUseful, got %v", res)
 		}
 		// Second call must be a no-op success (rippled SHAMap::addKnownNode
-		// returns SHAMapAddNode::duplicate(); we surface that as false, nil).
-		added, err = dest.AddKnownNodeByID(nid, d1.Data)
+		// returns SHAMapAddNode::duplicate()).
+		res, err = dest.AddKnownNodeByID(nid, d1.Data)
 		if err != nil {
 			t.Fatalf("duplicate AddKnownNodeByID: %v", err)
 		}
-		if added {
-			t.Fatal("duplicate AddKnownNodeByID: want added=false (duplicate)")
+		if res != NodeDuplicate {
+			t.Fatalf("duplicate AddKnownNodeByID: want NodeDuplicate, got %v", res)
 		}
 	})
 }
@@ -704,12 +710,12 @@ func TestAddKnownNodeByID_LeafMidPathReturnsDuplicate(t *testing.T) {
 	// leaf. The peer's data here is irrelevant — descent must short-
 	// circuit on the leaf and return nil.
 	deepNID := NodeID{depth: 2, id: k}
-	added, err := dest.AddKnownNodeByID(deepNID, []byte{0xFF})
+	res, err := dest.AddKnownNodeByID(deepNID, []byte{0xFF})
 	if err != nil {
 		t.Fatalf("leaf-mid-path: want nil (duplicate), got %v", err)
 	}
-	if added {
-		t.Fatal("leaf-mid-path: want added=false (duplicate)")
+	if res != NodeDuplicate {
+		t.Fatalf("leaf-mid-path: want NodeDuplicate, got %v", res)
 	}
 }
 
@@ -789,16 +795,16 @@ func TestAddKnownNodeFromPrefix_Direct(t *testing.T) {
 			if !ok {
 				t.Fatalf("no fetch-pack blob for missing hash %x", missing[i].Hash[:8])
 			}
-			added, err := dest.AddKnownNodeFromPrefix(missing[i].NodeID, data)
+			res, err := dest.AddKnownNodeFromPrefix(missing[i].NodeID, data)
 			if err != nil {
 				t.Fatalf("AddKnownNodeFromPrefix depth=%d: %v", missing[i].NodeID.Depth(), err)
 			}
-			if !added {
-				t.Fatalf("fresh attach depth=%d: want added=true", missing[i].NodeID.Depth())
+			if res != NodeUseful {
+				t.Fatalf("fresh attach depth=%d: want NodeUseful, got %v", missing[i].NodeID.Depth(), res)
 			}
-			added, err = dest.AddKnownNodeFromPrefix(missing[i].NodeID, data)
-			if err != nil || added {
-				t.Fatalf("duplicate: want (false, nil), got (%v, %v)", added, err)
+			res, err = dest.AddKnownNodeFromPrefix(missing[i].NodeID, data)
+			if err != nil || res != NodeDuplicate {
+				t.Fatalf("duplicate: want (NodeDuplicate, nil), got (%v, %v)", res, err)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- `shamap.attachKnownNodeAt` now mirrors rippled's `SHAMapAddNode` outcomes via a new `AddNodeResult` enum (`NodeUseful`/`NodeDuplicate`/`NodeReRequest`/`NodeInvalid`). A node whose ancestor on the path is still a hash-only stub returns **`NodeReRequest`** (not an error) instead of the old `ErrParentNotInTree` — matching rippled's `descend()→nullptr && iNodeID != node → useful()`. Off-frontier fat-reply nodes now converge over the next `getMissingNodes` walk rather than flooding the reject log.
- Genuine faults (hash mismatch, empty branch = node from another tree, provably-too-deep inner) stay `NodeInvalid`.
- Inbound acquisition (`GotStateNodes`/`GotTransactionNodes`, deduped into `applyKnownNodes`) no longer counts ancestor-gap nodes as rejects, and stops harvesting a reply on the first genuinely-invalid node — mirroring rippled's `receiveNode` stop-on-first-bad (`InboundLedger.cpp:920-927`).
- The consensus tx-set acquire path (`router_txset.go`) likewise no longer lets a gap node poison the whole reply.

This is the complementary shamap fix split out of #1140 (item 1 of #1136): an efficiency / rippled-parity change that removes the request amplification and `ErrEmptyBranchOnPath`/`ErrParentNotInTree` reject floods observed in the #1136 soak. It is **not** a wedge fix — acquisition already converged; this removes the wasted round-trips and log spam.

## Test plan

- [x] `go test ./shamap/... ./internal/ledger/... ./internal/consensus/...` — all pass
- [x] New `shamap.TestAddKnownNodeByID_OutOfOrderConverges`: deepest-first (worst-case) delivery of a deep tree never errors, exercises `NodeReRequest`, and converges to the source root.
- [x] New `inbound.TestGotStateNodes_OutOfOrderNotRejected`: out-of-order reply keeps `rejectCount == 0` across passes and still completes (criterion: progress accounting).
- [x] New `inbound.TestGotStateNodes_StopsOnFirstInvalid`: three corrupt nodes tally exactly one reject (stop-on-first-bad).
- [x] Updated `TestAddKnownNodeByID_SentinelErrors` / `_LeafMidPathReturnsDuplicate` / `TestAddKnownNodeFromPrefix_Direct` to the tri-state result; existing `repro_large_reconstruct` (pre-order one-pass) unchanged and green.
- [x] `go build ./...`, `go vet`, `gofmt`, `go test -race ./shamap/...` clean.

Fixes #1143