### PR TITLE
fix(nftoken): run buy-offer native funds check against pre-fee balance (#1147)

### DIFF
--- a/internal/testing/nft/nftoken_test.go
+++ b/internal/testing/nft/nftoken_test.go
@@ -3247,6 +3247,58 @@ func TestBuyerReserve(t *testing.T) {
 }
 
 // ===========================================================================
+// TestNFTokenCreateBuyOfferReserve
+// Reference: rippled NFToken_test.cpp testFixNFTokenBuyerReserve
+// ===========================================================================
+
+// TestNFTokenCreateBuyOfferReserve pins the native buy-offer funds check to the
+// pre-fee balance: a base fee that straddles reserve(OwnerCount) must yield
+// tecINSUFFICIENT_RESERVE, not a spurious tecUNFUNDED_OFFER (issue #1147).
+func TestNFTokenCreateBuyOfferReserve(t *testing.T) {
+	// buyOffer funds a fresh buyer to balanceFor(env), then has it create a
+	// native buy offer against a transferable NFT owned by alice.
+	buyOffer := func(t *testing.T, balanceFor func(env *jtx.TestEnv) uint64) jtx.TxResult {
+		t.Helper()
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice)
+		env.Close()
+
+		nftID := nft.GetNextNFTokenID(env, alice, 0, nftoken.NFTokenFlagTransferable, 0)
+		jtx.RequireTxSuccess(t, env.Submit(nft.NFTokenMint(alice, 0).Transferable().Build()))
+		env.Close()
+
+		env.FundAmount(bob, balanceFor(env))
+		env.Close()
+
+		return env.Submit(nft.NFTokenCreateBuyOffer(bob, nftID, tx.NewXRPAmount(1), alice).Build())
+	}
+
+	t.Run("FeeStraddlesReserveBoundary", func(t *testing.T) {
+		// Pre-fee balance clears reserve(0) by 8 drops, so the funds check passes
+		// and the offer falls through to the reserve check (which needs
+		// reserve(1)). Evaluating the post-fee balance would short-circuit to
+		// tecUNFUNDED_OFFER — the bug.
+		result := buyOffer(t, func(env *jtx.TestEnv) uint64 { return env.ReserveBase() + 8 })
+		jtx.RequireTxClaimed(t, result, "tecINSUFFICIENT_RESERVE")
+	})
+
+	t.Run("AtBaseReserveUnfunded", func(t *testing.T) {
+		// Pre-fee balance equals reserve(0): genuinely no liquidity.
+		result := buyOffer(t, func(env *jtx.TestEnv) uint64 { return env.ReserveBase() })
+		jtx.RequireTxClaimed(t, result, "tecUNFUNDED_OFFER")
+	})
+
+	t.Run("SufficientReserve", func(t *testing.T) {
+		result := buyOffer(t, func(env *jtx.TestEnv) uint64 {
+			return env.ReserveBase() + env.ReserveIncrement() + env.BaseFee()
+		})
+		jtx.RequireTxSuccess(t, result)
+	})
+}
+
+// ===========================================================================
 // testFixAutoTrustLine
 // Reference: rippled NFToken_test.cpp testUnaskedForAutoTrustline
 // ===========================================================================

--- a/internal/tx/nftoken/nftoken_create_offer.go
+++ b/internal/tx/nftoken/nftoken_create_offer.go
@@ -285,10 +285,9 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) ter.Result {
 		}
 	}
 
-	// 4. Fund check for buy offers (both XRP and IOU). rippled rejects a buy
-	// offer whose creator has no available funds, regardless of nativeness:
-	// accountFunds().signum() <= 0 → tecUNFUNDED_OFFER (post-fixNonFungibleTokensV1_2),
-	// accountHolds().signum() <= 0 otherwise.
+	// 4. Fund check for buy offers. rippled's preclaim rejects a creator with no
+	// available funds → tecUNFUNDED_OFFER: accountFunds().signum() <= 0
+	// (post-fixNonFungibleTokensV1_2) or accountHolds().signum() <= 0 otherwise.
 	// Reference: rippled tokenOfferCreatePreclaim lines 947-967.
 	if !isSellOffer {
 		if n.Amount.IsNative() {
@@ -402,15 +401,12 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TefINTERNAL
 	}
 
-	// Increase owner count
 	ctx.Account.OwnerCount++
 
-	// Check reserve against mPriorBalance — the source balance before its own
-	// fee was deducted — so the offer can dip into the reserve to pay the fee.
-	mPriorBalance := ctx.PriorBalance()
-	reserve := ctx.AccountReserve(ctx.Account.OwnerCount)
-	if mPriorBalance < reserve {
-		return ter.TecINSUFFICIENT_RESERVE
+	// The offer adds an owned object; charge its reserve against the pre-fee
+	// balance so the source can still dip into the reserve to pay the fee.
+	if r := ctx.CheckReserveWithFee(ctx.Account.OwnerCount); r != ter.TesSUCCESS {
+		return r
 	}
 
 	return ter.TesSUCCESS

--- a/internal/tx/nftoken/nftoken_create_offer.go
+++ b/internal/tx/nftoken/nftoken_create_offer.go
@@ -291,14 +291,29 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) ter.Result {
 	// accountHolds().signum() <= 0 otherwise.
 	// Reference: rippled tokenOfferCreatePreclaim lines 947-967.
 	if !isSellOffer {
-		var funds tx.Amount
-		if n.Amount.IsNative() || ctx.Rules().Enabled(amendment.FeatureFixNonFungibleTokensV1_2) {
-			funds = tx.AccountFunds(ctx.View, accountID, n.Amount, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
+		if n.Amount.IsNative() {
+			// rippled runs this native funds check in tokenOfferCreatePreclaim, on
+			// the pre-fee ReadView. goXRPL folds it into Apply, where ctx.View has
+			// already had the fee deducted, so evaluate native liquidity against
+			// the pre-fee PriorBalance — exactly as the reserve check below does.
+			// Otherwise a fee that straddles reserve(OwnerCount) flips the result
+			// from tecINSUFFICIENT_RESERVE to tecUNFUNDED_OFFER (ledger 99272734:
+			// PriorBalance 7000008 vs post-fee 6999996 against reserve 7000000).
+			// AccountFunds(native).signum()<=0 is exactly balance<=reserve.
+			// Reference: rippled tokenOfferCreatePreclaim lines 947-967.
+			if ctx.PriorBalance() <= ctx.AccountReserve(ctx.Account.OwnerCount) {
+				return ter.TecUNFUNDED_OFFER
+			}
 		} else {
-			funds = accountHoldsIOU(ctx.View, accountID, n.Amount)
-		}
-		if funds.Signum() <= 0 {
-			return ter.TecUNFUNDED_OFFER
+			var funds tx.Amount
+			if ctx.Rules().Enabled(amendment.FeatureFixNonFungibleTokensV1_2) {
+				funds = tx.AccountFunds(ctx.View, accountID, n.Amount, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
+			} else {
+				funds = accountHoldsIOU(ctx.View, accountID, n.Amount)
+			}
+			if funds.Signum() <= 0 {
+				return ter.TecUNFUNDED_OFFER
+			}
 		}
 	}
 

--- a/internal/tx/nftoken/nftoken_create_offer.go
+++ b/internal/tx/nftoken/nftoken_create_offer.go
@@ -292,15 +292,13 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Reference: rippled tokenOfferCreatePreclaim lines 947-967.
 	if !isSellOffer {
 		if n.Amount.IsNative() {
-			// rippled runs this native funds check in tokenOfferCreatePreclaim, on
-			// the pre-fee ReadView. goXRPL folds it into Apply, where ctx.View has
-			// already had the fee deducted, so evaluate native liquidity against
-			// the pre-fee PriorBalance — exactly as the reserve check below does.
-			// Otherwise a fee that straddles reserve(OwnerCount) flips the result
-			// from tecINSUFFICIENT_RESERVE to tecUNFUNDED_OFFER (ledger 99272734:
-			// PriorBalance 7000008 vs post-fee 6999996 against reserve 7000000).
-			// AccountFunds(native).signum()<=0 is exactly balance<=reserve.
-			// Reference: rippled tokenOfferCreatePreclaim lines 947-967.
+			// rippled runs this native funds check in preclaim against the
+			// pre-fee ReadView; goXRPL folds it into Apply, where the fee is
+			// already deducted, so check the pre-fee PriorBalance (like the
+			// reserve check below). A fee straddling reserve(OwnerCount) would
+			// otherwise flip tecINSUFFICIENT_RESERVE into a spurious
+			// tecUNFUNDED_OFFER. AccountFunds(native).signum()<=0 is exactly
+			// balance<=reserve.
 			if ctx.PriorBalance() <= ctx.AccountReserve(ctx.Account.OwnerCount) {
 				return ter.TecUNFUNDED_OFFER
 			}


### PR DESCRIPTION
Fixes #1147.

NFTokenCreateOffer's buy-offer funds check (rippled runs it in `tokenOfferCreatePreclaim` on the pre-fee ReadView) is folded into goXRPL's `Apply()`, where `ctx.View` is already fee-deducted. For a native buy offer it read the post-fee balance, so a fee that straddles `reserve(OwnerCount)` wrongly returned `tecUNFUNDED_OFFER` instead of reaching the apply-phase reserve check that returns `tecINSUFFICIENT_RESERVE` (ledger 99272734: PriorBalance 7000008, post-fee 6999996, reserve(30) 7000000).

Evaluate the native funds check against the pre-fee `PriorBalance` — as the reserve check below already does. IOU path unchanged.

**Verified byte-exact:** replay from ckpt-99272142 with 99272734 now OK (tecINSUFFICIENT_RESERVE matching mainnet); nftoken unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7BGJUPNfidYGoXg7r8F5K