### PR TITLE
fix(paychan,nftoken): run two more preclaim funds checks pre-fee (#1149)

### DIFF
--- a/internal/tx/nftoken/nftoken_accept_offer.go
+++ b/internal/tx/nftoken/nftoken_accept_offer.go
@@ -474,8 +474,19 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) ter.Result {
 			fixV1_2 := ctx.Rules().Enabled(amendment.FeatureFixNonFungibleTokensV1_2)
 			if !fixV1_2 || buyOffer == nil {
 				needed := tx.NewXRPAmount(int64(sellOffer.Amount))
-				funds := tx.AccountFunds(ctx.View, accountID, needed, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
-				if funds.Compare(needed) < 0 {
+				// rippled checks the submitter's native funds in preclaim, on the
+				// PRE-fee balance; goXRPL runs this in Apply where ctx.View is
+				// post-fee, so compute liquidity from PriorBalance — a fee straddling
+				// reserve(OwnerCount) would otherwise flip tecINSUFFICIENT_FUNDS.
+				// accountID is the submitter (ctx.AccountID = ctx.Account). Mirrors
+				// AccountFunds(native): max(0, balance-reserve) < needed.
+				// Reference: rippled NFTokenAcceptOffer.cpp preclaim 316-322.
+				reserve := ctx.AccountReserve(ctx.Account.OwnerCount)
+				var liquid uint64
+				if pb := ctx.PriorBalance(); pb > reserve {
+					liquid = pb - reserve
+				}
+				if liquid < uint64(needed.Drops()) {
 					return ter.TecINSUFFICIENT_FUNDS
 				}
 			}

--- a/internal/tx/nftoken/nftoken_accept_offer.go
+++ b/internal/tx/nftoken/nftoken_accept_offer.go
@@ -474,13 +474,9 @@ func (n *NFTokenAcceptOffer) Apply(ctx *tx.ApplyContext) ter.Result {
 			fixV1_2 := ctx.Rules().Enabled(amendment.FeatureFixNonFungibleTokensV1_2)
 			if !fixV1_2 || buyOffer == nil {
 				needed := tx.NewXRPAmount(int64(sellOffer.Amount))
-				// rippled checks the submitter's native funds in preclaim, on the
-				// PRE-fee balance; goXRPL runs this in Apply where ctx.View is
-				// post-fee, so compute liquidity from PriorBalance — a fee straddling
-				// reserve(OwnerCount) would otherwise flip tecINSUFFICIENT_FUNDS.
-				// accountID is the submitter (ctx.AccountID = ctx.Account). Mirrors
-				// AccountFunds(native): max(0, balance-reserve) < needed.
-				// Reference: rippled NFTokenAcceptOffer.cpp preclaim 316-322.
+				// rippled checks the submitter's native funds in preclaim on the
+				// PRE-fee balance; goXRPL folds this into Apply (post-fee), so use
+				// PriorBalance, else a fee straddling reserve(OwnerCount) flips the TER.
 				reserve := ctx.AccountReserve(ctx.Account.OwnerCount)
 				var liquid uint64
 				if pb := ctx.PriorBalance(); pb > reserve {

--- a/internal/tx/paychan/payment_channel_create.go
+++ b/internal/tx/paychan/payment_channel_create.go
@@ -135,19 +135,23 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	amount := uint64(p.Amount.Drops())
 
 	// Reserve and funding checks run before the destination checks, matching
-	// rippled's preclaim order.
-	// Reference: rippled PayChan.cpp preclaim() lines 204-214
+	// rippled's preclaim order. rippled reads the PRE-fee balance there
+	// ((*sle)[sfBalance] in preclaim), so use ctx.PriorBalance(): the engine
+	// charges the fee before Apply, leaving ctx.Account.Balance post-fee, and a
+	// fee straddling reserve(OwnerCount+1) would otherwise flip the TER.
+	// Reference: rippled PayChan.cpp preclaim() lines 204-214.
+	priorBalance := ctx.PriorBalance()
 	reserve := ctx.AccountReserve(ctx.Account.OwnerCount + 1)
-	if ctx.Account.Balance < reserve {
+	if priorBalance < reserve {
 		ctx.Log.Warn("payment channel create: insufficient reserve",
-			"balance", ctx.Account.Balance,
+			"balance", priorBalance,
 			"reserve", reserve,
 		)
 		return ter.TecINSUFFICIENT_RESERVE
 	}
-	if ctx.Account.Balance-reserve < amount {
+	if priorBalance-reserve < amount {
 		ctx.Log.Warn("payment channel create: unfunded",
-			"balance", ctx.Account.Balance,
+			"balance", priorBalance,
 			"needed", reserve+amount,
 		)
 		return ter.TecUNFUNDED

--- a/internal/tx/paychan/payment_channel_create.go
+++ b/internal/tx/paychan/payment_channel_create.go
@@ -135,10 +135,8 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	amount := uint64(p.Amount.Drops())
 
 	// Reserve and funding checks run before the destination checks, matching
-	// rippled's preclaim order. rippled reads the PRE-fee balance there
-	// ((*sle)[sfBalance] in preclaim), so use ctx.PriorBalance(): the engine
-	// charges the fee before Apply, leaving ctx.Account.Balance post-fee, and a
-	// fee straddling reserve(OwnerCount+1) would otherwise flip the TER.
+	// rippled's preclaim order, which reads the PRE-fee balance — so use
+	// PriorBalance, else a fee straddling reserve(OwnerCount+1) flips the TER.
 	// Reference: rippled PayChan.cpp preclaim() lines 204-214.
 	priorBalance := ctx.PriorBalance()
 	reserve := ctx.AccountReserve(ctx.Account.OwnerCount + 1)


### PR DESCRIPTION
Fixes #1149. Follow-up audit to #1148.

Two more tx types run a rippled-preclaim native funds/reserve check in `Apply()` against the post-fee balance; a fee straddling the reserve flips the TER vs rippled (which checks pre-fee in preclaim).

- **PaymentChannelCreate** (`payment_channel_create.go:141,148`): `ctx.Account.Balance` → `ctx.PriorBalance()` (rippled `PayChan.cpp` preclaim reads pre-fee `(*sle)[sfBalance]` vs `reserve(OwnerCount+1)`). Was a **consensus divergence** (both sides claim the fee).
- **NFTokenAcceptOffer** (`nftoken_accept_offer.go:477`): native direct-accept funds check → pre-fee `max(0, PriorBalance−reserve) < needed` (rippled checks `accountFunds(ctx.tx[sfAccount])` in preclaim).

Audit cleared all other tx types (Escrow/PayChanFund/DID/PermissionedDomain reserve checks are themselves post-fee in rippled, already matched).

**Verified:** tx/paychan, tx/nftoken, testing/nft, testing/paychan tests pass; replay 99272142→99274666 byte-exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7BGJUPNfidYGoXg7r8F5K