### PR TITLE
fix(paychan): run PaymentChannelCreate funds checks against the pre-fee balance

### DIFF
--- a/internal/testing/paychan/paychan_create_reserve_test.go
+++ b/internal/testing/paychan/paychan_create_reserve_test.go
@@ -9,9 +9,7 @@ import (
 // TestPaymentChannelCreateFundingBoundary pins PayChanCreate's reserve and
 // funding checks to the pre-fee balance. rippled runs them in preclaim against
 // the pre-fee ReadView (PayChan.cpp:209-213), so a base fee that straddles
-// reserve(OwnerCount+1) or reserve(OwnerCount+1)+amount must not flip the TER
-// (the issue #1147 class: a folded-preclaim native check reading the post-fee
-// balance).
+// reserve(OwnerCount+1) or reserve(OwnerCount+1)+amount must not flip the TER.
 func TestPaymentChannelCreateFundingBoundary(t *testing.T) {
 	const settleDelay = uint32(3600)
 

--- a/internal/testing/paychan/paychan_create_reserve_test.go
+++ b/internal/testing/paychan/paychan_create_reserve_test.go
@@ -48,6 +48,15 @@ func TestPaymentChannelCreateFundingBoundary(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 	})
 
+	t.Run("InsufficientReserve", func(t *testing.T) {
+		// Pre-fee balance is genuinely below reserve(1); the reserve check fires
+		// before the funding check, independent of amount.
+		result := create(t, drops(1), func(env *jtx.TestEnv) uint64 {
+			return env.ReserveBase() + env.ReserveIncrement() - uint64(xrp(1))
+		})
+		jtx.RequireTxClaimed(t, result, "tecINSUFFICIENT_RESERVE")
+	})
+
 	t.Run("Unfunded", func(t *testing.T) {
 		// Pre-fee balance is genuinely below reserve(1)+amount.
 		amount := xrp(10)

--- a/internal/testing/paychan/paychan_create_reserve_test.go
+++ b/internal/testing/paychan/paychan_create_reserve_test.go
@@ -1,0 +1,61 @@
+package paychan
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+)
+
+// TestPaymentChannelCreateFundingBoundary pins PayChanCreate's reserve and
+// funding checks to the pre-fee balance. rippled runs them in preclaim against
+// the pre-fee ReadView (PayChan.cpp:209-213), so a base fee that straddles
+// reserve(OwnerCount+1) or reserve(OwnerCount+1)+amount must not flip the TER
+// (the issue #1147 class: a folded-preclaim native check reading the post-fee
+// balance).
+func TestPaymentChannelCreateFundingBoundary(t *testing.T) {
+	const settleDelay = uint32(3600)
+
+	// create funds a normally-provisioned destination and a source funded to
+	// balanceFor(env), then has the source open a channel for amount drops.
+	create := func(t *testing.T, amount int64, balanceFor func(env *jtx.TestEnv) uint64) jtx.TxResult {
+		t.Helper()
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.FundAmount(bob, uint64(xrp(10000)))
+		env.Close()
+		env.FundAmount(alice, balanceFor(env))
+		env.Close()
+		return env.Submit(ChannelCreate(alice, bob, amount, settleDelay, alice.PublicKeyHex()).Build())
+	}
+
+	t.Run("FeeStraddlesFundingBoundary", func(t *testing.T) {
+		// Pre-fee balance clears reserve(1)+amount by 8 drops; the base fee would
+		// push the post-fee balance just under it. Reading the post-fee balance
+		// would return a spurious tecUNFUNDED — the bug.
+		amount := xrp(10)
+		result := create(t, amount, func(env *jtx.TestEnv) uint64 {
+			return env.ReserveBase() + env.ReserveIncrement() + uint64(amount) + 8
+		})
+		jtx.RequireTxSuccess(t, result)
+	})
+
+	t.Run("FeeStraddlesReserveBoundary", func(t *testing.T) {
+		// Pre-fee balance clears reserve(1) by 8 drops for a 1-drop channel; the
+		// base fee would push the post-fee balance under reserve(1), returning a
+		// spurious tecINSUFFICIENT_RESERVE.
+		result := create(t, drops(1), func(env *jtx.TestEnv) uint64 {
+			return env.ReserveBase() + env.ReserveIncrement() + 8
+		})
+		jtx.RequireTxSuccess(t, result)
+	})
+
+	t.Run("Unfunded", func(t *testing.T) {
+		// Pre-fee balance is genuinely below reserve(1)+amount.
+		amount := xrp(10)
+		result := create(t, amount, func(env *jtx.TestEnv) uint64 {
+			return env.ReserveBase() + env.ReserveIncrement() + uint64(amount) - uint64(xrp(1))
+		})
+		jtx.RequireTxClaimed(t, result, "tecUNFUNDED")
+	})
+}

--- a/internal/tx/paychan/payment_channel_create.go
+++ b/internal/tx/paychan/payment_channel_create.go
@@ -137,8 +137,7 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	// rippled runs these reserve/funding checks in preclaim against the pre-fee
 	// ReadView; goXRPL folds them into Apply, where ctx.View has the fee already
 	// deducted, so evaluate against the pre-fee PriorBalance. Otherwise a fee
-	// straddling reserve(OwnerCount+1)+amount flips the TER (the #1147 class).
-	// Reference: rippled PayChan.cpp preclaim() lines 209-213
+	// straddling reserve(OwnerCount+1)+amount flips the TER.
 	priorBalance := ctx.PriorBalance()
 	reserve := ctx.AccountReserve(ctx.Account.OwnerCount + 1)
 	if priorBalance < reserve {

--- a/internal/tx/paychan/payment_channel_create.go
+++ b/internal/tx/paychan/payment_channel_create.go
@@ -134,20 +134,23 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 
 	amount := uint64(p.Amount.Drops())
 
-	// Reserve and funding checks run before the destination checks, matching
-	// rippled's preclaim order.
-	// Reference: rippled PayChan.cpp preclaim() lines 204-214
+	// rippled runs these reserve/funding checks in preclaim against the pre-fee
+	// ReadView; goXRPL folds them into Apply, where ctx.View has the fee already
+	// deducted, so evaluate against the pre-fee PriorBalance. Otherwise a fee
+	// straddling reserve(OwnerCount+1)+amount flips the TER (the #1147 class).
+	// Reference: rippled PayChan.cpp preclaim() lines 209-213
+	priorBalance := ctx.PriorBalance()
 	reserve := ctx.AccountReserve(ctx.Account.OwnerCount + 1)
-	if ctx.Account.Balance < reserve {
+	if priorBalance < reserve {
 		ctx.Log.Warn("payment channel create: insufficient reserve",
-			"balance", ctx.Account.Balance,
+			"balance", priorBalance,
 			"reserve", reserve,
 		)
 		return ter.TecINSUFFICIENT_RESERVE
 	}
-	if ctx.Account.Balance-reserve < amount {
+	if priorBalance-reserve < amount {
 		ctx.Log.Warn("payment channel create: unfunded",
-			"balance", ctx.Account.Balance,
+			"balance", priorBalance,
 			"needed", reserve+amount,
 		)
 		return ter.TecUNFUNDED


### PR DESCRIPTION
## Summary

`PaymentChannelCreate` runs its **reserve** and **funding** checks in `Apply()` against the **fee-deducted** `ctx.Account.Balance`. rippled runs the corresponding checks in **preclaim**, against the **pre-fee** ReadView (`PayChan.cpp:209-213`). So a base fee that straddles `reserve(OwnerCount+1)` or `reserve(OwnerCount+1)+amount` flips the result — `tecINSUFFICIENT_RESERVE` / `tecUNFUNDED` instead of `tesSUCCESS` — and forks the transaction + ledger hash.

This is the same class as #1147 (the NFTokenCreateOffer buy-offer fix): a rippled-preclaim native funds check folded into goXRPL's `Apply()` reading the post-fee balance.

## Fix

Evaluate both checks against `ctx.PriorBalance()` (rippled's `mPriorBalance` — the source balance before its own fee was deducted). The `amount` deduction stays against the live balance, matching rippled's `doApply` (`PayChan.cpp:314`).

```
- if ctx.Account.Balance < reserve { ... tecINSUFFICIENT_RESERVE }
- if ctx.Account.Balance-reserve < amount { ... tecUNFUNDED }
+ priorBalance := ctx.PriorBalance()
+ if priorBalance < reserve { ... tecINSUFFICIENT_RESERVE }
+ if priorBalance-reserve < amount { ... tecUNFUNDED }
```

## Scope — siblings checked against rippled and NOT affected

While auditing this bug class I verified the two obvious neighbours against rippled and they are **correct as-is** — rippled itself runs their checks in `doApply` on the post-fee balance, which goXRPL already matches:

- **PaymentChannelFund** — rippled `doApply`, post-fee `(*sle)[sfBalance]` (`PayChan.cpp:390-398`).
- **EscrowCreate** — rippled `doApply`, post-fee `mSourceBalance` (`Escrow.cpp:501-508`).

rippled is deliberately inconsistent here (PayChanCreate pre-fee in preclaim; PayChanFund / EscrowCreate post-fee in doApply), so only `PaymentChannelCreate` diverges.

## Tests

`TestPaymentChannelCreateFundingBoundary` (3 sub-tests): a fee straddling the funding boundary → `tesSUCCESS` (regression guard), a fee straddling the reserve boundary → `tesSUCCESS`, and a genuinely-unfunded source → `tecUNFUNDED`. Both straddle guards are **proven non-vacuous** — they fail with `tecUNFUNDED` / `tecINSUFFICIENT_RESERVE` against the old post-fee code.

`just build` / `just vet` / `just lint` green; full `./internal/testing/paychan/...` and `./internal/tx/paychan/...` suites pass.