### PR TITLE
fix(payment): don't pre-stamp PreviousTxnID in transferXRP (#1154)

### DIFF
--- a/internal/tx/payment/step_book_transfer.go
+++ b/internal/tx/payment/step_book_transfer.go
@@ -94,7 +94,7 @@ func (s *BookStep) transferFundsWithFee(sb *PaymentSandbox, from, to [20]byte, g
 // When from or to is the XRP pseudo-account (zero), that side is skipped.
 // The XRPEndpointStep handles the actual source/destination account balance changes.
 // Reference: rippled View.cpp accountSend() lines 1904-1939
-func (s *BookStep) transferXRP(sb *PaymentSandbox, from, to [20]byte, drops int64, txHash [32]byte, ledgerSeq uint32) error {
+func (s *BookStep) transferXRP(sb *PaymentSandbox, from, to [20]byte, drops int64, _ [32]byte, _ uint32) error {
 	var xrpAccount [20]byte
 	amount := tx.NewXRPAmount(drops)
 

--- a/internal/tx/payment/step_book_transfer.go
+++ b/internal/tx/payment/step_book_transfer.go
@@ -127,8 +127,13 @@ func (s *BookStep) transferXRP(sb *PaymentSandbox, from, to [20]byte, drops int6
 		sb.CreditHook(from, xrpAccount, amount, preCreditBalance)
 
 		fromAccount.Balance -= uint64(drops)
-		fromAccount.PreviousTxnID = txHash
-		fromAccount.PreviousTxnLgrSeq = ledgerSeq
+		// Do NOT stamp PreviousTxnID/PreviousTxnLgrSeq here: threading is the
+		// ApplyStateTable's job and runs after its no-op (Original == Current)
+		// check. A net-zero autobridge transfer (this account pays out one leg
+		// then receives the same drops back in another) would otherwise differ
+		// only in the bumped threading pointers, defeating that check and
+		// emitting a ghost ModifiedNode. rippled transferXRP only sets sfBalance;
+		// same fix as the sibling IOU paths (adjustTrustLineBalance, consumeOffer).
 
 		fromAccountData, err := state.SerializeAccountRoot(fromAccount)
 		if err != nil {
@@ -160,8 +165,8 @@ func (s *BookStep) transferXRP(sb *PaymentSandbox, from, to [20]byte, drops int6
 		sb.CreditHook(xrpAccount, to, amount, receiverPreBalance)
 
 		toAccount.Balance += uint64(drops)
-		toAccount.PreviousTxnID = txHash
-		toAccount.PreviousTxnLgrSeq = ledgerSeq
+		// No PreviousTxnID stamp — see the sender branch above; threading is
+		// deferred to the ApplyStateTable's post-no-op-check pass.
 
 		toAccountData, err := state.SerializeAccountRoot(toAccount)
 		if err != nil {

--- a/internal/tx/payment/step_book_transfer.go
+++ b/internal/tx/payment/step_book_transfer.go
@@ -127,13 +127,10 @@ func (s *BookStep) transferXRP(sb *PaymentSandbox, from, to [20]byte, drops int6
 		sb.CreditHook(from, xrpAccount, amount, preCreditBalance)
 
 		fromAccount.Balance -= uint64(drops)
-		// Do NOT stamp PreviousTxnID/PreviousTxnLgrSeq here: threading is the
-		// ApplyStateTable's job and runs after its no-op (Original == Current)
-		// check. A net-zero autobridge transfer (this account pays out one leg
-		// then receives the same drops back in another) would otherwise differ
-		// only in the bumped threading pointers, defeating that check and
-		// emitting a ghost ModifiedNode. rippled transferXRP only sets sfBalance;
-		// same fix as the sibling IOU paths (adjustTrustLineBalance, consumeOffer).
+		// Do NOT stamp PreviousTxnID/PreviousTxnLgrSeq here — the ApplyStateTable
+		// threads them after its no-op (Original == Current) check, which a net-zero
+		// autobridge pass-through would defeat (ghost ModifiedNode). Mirrors the
+		// IOU sibling paths.
 
 		fromAccountData, err := state.SerializeAccountRoot(fromAccount)
 		if err != nil {
@@ -165,8 +162,7 @@ func (s *BookStep) transferXRP(sb *PaymentSandbox, from, to [20]byte, drops int6
 		sb.CreditHook(xrpAccount, to, amount, receiverPreBalance)
 
 		toAccount.Balance += uint64(drops)
-		// No PreviousTxnID stamp — see the sender branch above; threading is
-		// deferred to the ApplyStateTable's post-no-op-check pass.
+		// No PreviousTxnID stamp — see the sender branch above.
 
 		toAccountData, err := state.SerializeAccountRoot(toAccount)
 		if err != nil {


### PR DESCRIPTION
Fixes #1154.

`transferXRP` stamped `PreviousTxnID`/`PreviousTxnLgrSeq` before serializing, so a net-zero XRP transfer differed from its pre-tx state only in the bumped threading pointers. In an autobridge the bridge-offer owner is the XRP sender in one leg and receiver in the other (pays out then receives back the same drops → Balance unchanged), so the stamp defeated the ApplyStateTable no-op guards (which in rippled run before threading) → ghost empty-diff ModifiedNode + bogus PreviousTxnID bump on the owner's account (ledger 99274667, RLUSD→USDC autobridge).

Remove the stamps; let `ApplyStateTable.threadItem` thread after the no-op check (rippled `transferXRP` only sets `sfBalance`). XRP analog of the dust IOU fix #1146; the IOU siblings were already fixed.

**Verified byte-exact:** replay 99272142→99274709 clean (99274667 now OK, no regression); payment/applystate/offer unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7BGJUPNfidYGoXg7r8F5K