### PR TITLE
fix: run open-ledger preflight once and scale the tx worker pool

### DIFF
--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -167,10 +168,15 @@ type Router struct {
 // txQueueDepth is sized generously on purpose, and a frame shed here is
 // recoverable (the originating peer resends and reduce-relay re-delivers it via
 // other peers), so over-buffering costs little.
-const (
-	txWorkerCount = 4
-	txQueueDepth  = 1024
-)
+//
+// Each worker's job — decode, parse, and the ECDSA/EdDSA signature prewarm in
+// SubmitPendingTx — is CPU-bound and runs concurrently with the serialized
+// apply strand, so the pool scales with the available cores (floored at the
+// historical 4) to keep that strand fed; a single fixed worker count throttled
+// the prewarm throughput well below the apply rate on multi-core validators.
+var txWorkerCount = max(4, runtime.GOMAXPROCS(0))
+
+const txQueueDepth = 1024
 
 // messageDedupTTL is how long a proposal/validation hash is
 // remembered for duplicate-detection purposes. 30s comfortably covers a

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -21,14 +21,11 @@ func (e *Engine) preflight(tx txcore.Transaction) ter.Result {
 	common := tx.GetCommon()
 	rules := e.rules()
 
-	// Structural preflight (preflight0/1 + the per-type Validate and rules-gated
-	// checks) is independent of ledger state, so it is run once and memoised on
-	// the transaction. The open-ledger apply strand preflights a submission in
-	// TxQ.Apply and then again in Engine.Apply under modifyMu; this skip collapses
-	// that to a single structural pass. The rules pointer keys the verdict so a
-	// later ledger (rebuilt rules) recomputes. Signature verification is left
-	// out of the memo and always runs below, so a multi-signed transaction's
-	// view-dependent signer-list check is never cached.
+	// Structural preflight is ledger-state-independent, so its verdict is
+	// memoised on the transaction and a re-preflight under the same rules skips
+	// the repeat (see Common.preflightedRules). Signature verification stays out
+	// of the memo and always runs below, so a multi-signed tx's view-dependent
+	// signer-list check is never cached.
 	if !common.PreflightVerified(rules) {
 		if result := e.preflightStructure(tx, common); result != ter.TesSUCCESS {
 			return result

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -19,13 +19,59 @@ import (
 // top-level function reads as a high-level pipeline.
 func (e *Engine) preflight(tx txcore.Transaction) ter.Result {
 	common := tx.GetCommon()
+	rules := e.rules()
 
+	// Structural preflight (preflight0/1 + the per-type Validate and rules-gated
+	// checks) is independent of ledger state, so it is run once and memoised on
+	// the transaction. The open-ledger apply strand preflights a submission in
+	// TxQ.Apply and then again in Engine.Apply under modifyMu; this skip collapses
+	// that to a single structural pass. The rules pointer keys the verdict so a
+	// later ledger (rebuilt rules) recomputes. Signature verification is left
+	// out of the memo and always runs below, so a multi-signed transaction's
+	// view-dependent signer-list check is never cached.
+	if !common.PreflightVerified(rules) {
+		if result := e.preflightStructure(tx, common); result != ter.TesSUCCESS {
+			return result
+		}
+		common.MarkPreflightVerified(rules)
+	}
+
+	// preflight2 — cryptographic signature verification runs LAST, after the
+	// type-specific checks, mirroring rippled where preflight2()'s checkValidity
+	// is the final step of every tx's preflight(). A transaction that is both
+	// malformed and mis-signed therefore surfaces its type-specific tem* code,
+	// not the signature code.
+	if result := e.verifySignatures(tx); result != ter.TesSUCCESS {
+		return result
+	}
+
+	// Reference: rippled Batch.cpp:303-312.
+	if outer, ok := tx.(BatchOuter); ok {
+		for _, inner := range outer.InnerTransactions() {
+			if inner == nil {
+				return ter.TemINVALID_INNER_BATCH
+			}
+			if r := e.preflightInner(inner); r != ter.TesSUCCESS {
+				return ter.TemINVALID_INNER_BATCH
+			}
+		}
+	}
+
+	return ter.TesSUCCESS
+}
+
+// preflightStructure runs the ledger-state-independent preflight checks
+// (preflight0/1 minus signature verification, plus the per-type Validate and
+// rules-gated checks). It is a pure function of the transaction fields and the
+// active rules, which is what makes its verdict safe to memoise (see
+// Common.PreflightVerified).
+func (e *Engine) preflightStructure(tx txcore.Transaction, common *txcore.Common) ter.Result {
 	// preflight0: trivial common-field presence + amendment + flag checks.
 	if result := e.preflightCommonFields(tx, common); result != ter.TesSUCCESS {
 		return result
 	}
 
-	// preflight1 — fee, sequence, memos, structural multi-sign + signature checks.
+	// preflight1 — fee, sequence, memos, structural multi-sign checks.
 	if result := e.validateFee(common); result != ter.TesSUCCESS {
 		return result
 	}
@@ -52,27 +98,6 @@ func (e *Engine) preflight(tx txcore.Transaction) ter.Result {
 	if rp, ok := tx.(txcore.RulesPreflighter); ok {
 		if err := rp.PreflightRules(e.rules()); err != nil {
 			return parseValidationError(err)
-		}
-	}
-
-	// preflight2 — cryptographic signature verification runs LAST, after the
-	// type-specific checks, mirroring rippled where preflight2()'s checkValidity
-	// is the final step of every tx's preflight(). A transaction that is both
-	// malformed and mis-signed therefore surfaces its type-specific tem* code,
-	// not the signature code.
-	if result := e.verifySignatures(tx); result != ter.TesSUCCESS {
-		return result
-	}
-
-	// Reference: rippled Batch.cpp:303-312.
-	if outer, ok := tx.(BatchOuter); ok {
-		for _, inner := range outer.InnerTransactions() {
-			if inner == nil {
-				return ter.TemINVALID_INNER_BATCH
-			}
-			if r := e.preflightInner(inner); r != ter.TesSUCCESS {
-				return ter.TemINVALID_INNER_BATCH
-			}
 		}
 	}
 

--- a/internal/tx/engine/preflight_dedup_test.go
+++ b/internal/tx/engine/preflight_dedup_test.go
@@ -1,0 +1,128 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+// newDedupTx builds a structurally valid, unsigned AccountSet-shaped BaseTx.
+// The dedup tests run with SkipSignatureVerification so the signature step is a
+// no-op and the structural-verdict cache is exercised in isolation.
+func newDedupTx() *txcore.BaseTx {
+	txn := txcore.NewBaseTx(txcore.TypeAccountSet, prewarmTestAccount)
+	txn.Common.Fee = "10"
+	seq := uint32(1)
+	txn.Common.Sequence = &seq
+	return txn
+}
+
+func dedupEngine(rules *amendment.Rules) *Engine {
+	return NewEngine(newMockBaseView(), txcore.EngineConfig{
+		BaseFee:                   10,
+		LedgerSequence:            100,
+		Rules:                     rules,
+		SkipSignatureVerification: true,
+	})
+}
+
+// TestPreflight_SkipsRepeatStructural proves the structural verdict is memoised:
+// once preflight succeeds under a set of rules, a second preflight of the same
+// parsed transaction under those same rules skips the structural pass — shown by
+// corrupting a structural field afterwards and observing the check still passes.
+// This is the open-ledger apply strand's double preflight (TxQ.Apply then
+// Engine.Apply) collapsing to a single structural pass (#1153).
+func TestPreflight_SkipsRepeatStructural(t *testing.T) {
+	rules := amendment.AllSupportedRules()
+	txn := newDedupTx()
+	eng := dedupEngine(rules)
+
+	if txn.GetCommon().PreflightVerified(rules) {
+		t.Fatal("a freshly built tx must not be preflight-verified")
+	}
+	if res := eng.preflight(txn); res != ter.TesSUCCESS {
+		t.Fatalf("first preflight must pass; got %s", res)
+	}
+	if !txn.GetCommon().PreflightVerified(rules) {
+		t.Fatal("a successful preflight must cache the structural verdict")
+	}
+
+	// Corrupt a structural field; the cached verdict must short-circuit the
+	// structural pass so the second preflight still passes.
+	txn.GetCommon().Sequence = nil
+	txn.GetCommon().TicketSequence = nil
+	if res := eng.preflight(txn); res != ter.TesSUCCESS {
+		t.Fatalf("cached structural verdict must skip the repeat; got %s", res)
+	}
+}
+
+// TestPreflight_ColdCacheRunsStructural is the control: the same corruption with
+// no cached verdict must be rejected, confirming the skip above came from the
+// cache and not from the field being ignored.
+func TestPreflight_ColdCacheRunsStructural(t *testing.T) {
+	rules := amendment.AllSupportedRules()
+	txn := newDedupTx()
+	txn.Common.Sequence = nil
+	txn.Common.TicketSequence = nil
+
+	if res := dedupEngine(rules).preflight(txn); res != ter.TemBAD_SEQUENCE {
+		t.Fatalf("a cold cache must run structural and reject the bad sequence; got %s", res)
+	}
+}
+
+// TestPreflight_DifferentRulesRecomputes proves the verdict is keyed on the
+// rules pointer: a re-preflight under a distinct rules pointer (a later ledger
+// rebuilds its rules) must not trust a verdict cached under the prior pointer,
+// even when the two rule sets are semantically identical. This keeps a queued
+// transaction re-applied on a later ledger from skipping a structural check that
+// an amendment change could have altered.
+func TestPreflight_DifferentRulesRecomputes(t *testing.T) {
+	rulesA := amendment.AllSupportedRules()
+	txn := newDedupTx()
+	if res := dedupEngine(rulesA).preflight(txn); res != ter.TesSUCCESS {
+		t.Fatalf("first preflight must pass; got %s", res)
+	}
+
+	txn.GetCommon().Sequence = nil
+	txn.GetCommon().TicketSequence = nil
+
+	rulesB := amendment.AllSupportedRules() // same rule set, distinct pointer
+	if txn.GetCommon().PreflightVerified(rulesB) {
+		t.Fatal("a verdict cached under rulesA must not be honoured for rulesB")
+	}
+	if res := dedupEngine(rulesB).preflight(txn); res != ter.TemBAD_SEQUENCE {
+		t.Fatalf("a new ledger (rebuilt rules) must recompute structural; got %s", res)
+	}
+}
+
+// TestPreflight_DoesNotCacheSignature is the correctness guard that separates
+// this change from a naive whole-verdict cache: signature verification is left
+// out of the memo and always runs, so a cached structural verdict never masks a
+// corrupted signature (and a multi-signed tx's view-dependent signer-list check
+// is never skipped).
+func TestPreflight_DoesNotCacheSignature(t *testing.T) {
+	rules := amendment.AllSupportedRules()
+	txn := newSignedSingleSignTx(t)
+	eng := NewEngine(newMockBaseView(), txcore.EngineConfig{
+		BaseFee:                   10,
+		LedgerSequence:            100,
+		Rules:                     rules,
+		SkipSignatureVerification: false,
+	})
+
+	if res := eng.preflight(txn); res != ter.TesSUCCESS {
+		t.Fatalf("first preflight of a validly signed tx must pass; got %s", res)
+	}
+	if !txn.GetCommon().PreflightVerified(rules) {
+		t.Fatal("structural verdict must be cached after a successful preflight")
+	}
+
+	// Corrupt only the signature. Structural is cached, but the signature is not,
+	// so the second preflight must re-verify and reject.
+	txn.GetCommon().TxnSignature = "00"
+	if res := eng.preflight(txn); res != ter.TemINVALID {
+		t.Fatalf("signature must never be cached; a corrupt sig must be re-rejected, got %s", res)
+	}
+}

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -230,6 +230,19 @@ type Common struct {
 	// under the strand without re-hashing.
 	cachedTxID [32]byte
 	txIDCached bool
+
+	// preflightedRules records the amendment rules under which this
+	// transaction's structural preflight last succeeded. Structural preflight
+	// (everything except the view-dependent signature check) is a pure function
+	// of the transaction fields and the active rules, so when the engine
+	// re-preflights the same parsed transaction under the identical rules — as
+	// the open-ledger apply strand does, preflighting once in TxQ.Apply and
+	// again in Engine.Apply under modifyMu — the second run skips the repeat.
+	// The rules pointer keys the verdict: a later ledger rebuilds rules, so a
+	// pointer mismatch forces a recompute and the verdict never outlives an
+	// amendment change. Same single-goroutine, unsynchronised contract as
+	// cachedTxID.
+	preflightedRules *amendment.Rules
 }
 
 // Validate validates the common fields. preflightCommonFields catches these
@@ -295,6 +308,19 @@ func (c *Common) MarkSignatureVerified() {
 // verified off-strand (see MarkSignatureVerified).
 func (c *Common) SignatureVerified() bool {
 	return c.sigVerified
+}
+
+// PreflightVerified reports whether this transaction's structural preflight
+// already succeeded under the given rules (see preflightedRules). A nil rules
+// never matches, so the cache is a no-op on paths that do not supply rules.
+func (c *Common) PreflightVerified(rules *amendment.Rules) bool {
+	return c.preflightedRules != nil && c.preflightedRules == rules
+}
+
+// MarkPreflightVerified records that the structural preflight succeeded under
+// the given rules so a later in-strand preflight can skip the repeat.
+func (c *Common) MarkPreflightVerified(rules *amendment.Rules) {
+	c.preflightedRules = rules
 }
 
 // SetSequence sets the sequence number


### PR DESCRIPTION
## Summary

Follow-up to #1137. PR #1139 fixed the **hash** half (tx-id memoization); this PR closes the two remaining items, both of which were keeping the open-ledger **apply strand** (the serialized critical section under `OpenLedger.modifyMu`) as the throughput floor.

- **Preflight ran twice per tx under `modifyMu`.** `TxQ.Apply` preflights every submission (to reject malformed txs with their `tem*` code instead of silently queuing them — this must stay), and `Engine.Apply` then preflighted it *again*. The full structural validation ran twice in the serialized section. Now the **structural** preflight verdict is memoised on the transaction, keyed by the `*amendment.Rules` pointer, so the second pass under the same rules skips it — mirroring the off-strand id/signature caching of #1139/#1105.
  - **Signature verification is deliberately excluded from the memo and always runs.** It is the only view-dependent step (multi-sign signer-list lookup reads the ledger view), so leaving it out keeps the cache view-independent and composes with #1105's separate single-sign cache. A later ledger rebuilds its rules, so the rules-pointer key forces a recompute there — a queued tx re-applied on a later ledger never skips a check an amendment change could have altered.
  - Result-code ordering is preserved exactly (structural → signature → inner-batch), so this is behavior-preserving.
- **`txWorkerCount` was still 4.** Each inbound-tx worker's job — decode, parse, and the ECDSA/EdDSA signature prewarm in `SubmitPendingTx` — is CPU-bound and runs concurrently with the apply strand. It now scales with `runtime.GOMAXPROCS(0)`, floored at the historical 4, so the prewarm throughput is no longer capped below the apply rate on multi-core validators.

As #1137's analysis notes, the irreducible residue under `modifyMu` (preclaim + apply + metadata + view mutation, plus the in-strand multi-sign verify) remains; this raises/parallelizes the floor rather than removing it.

## Test plan
- [x] `go test ./internal/tx/... ./internal/txq/... ./internal/ledger/openledger/... ./internal/consensus/adaptor/...` — pass
- [x] `go test ./internal/testing/... ./internal/ledger/... ./internal/consensus/...` — pass (the only failures are the pre-existing out-of-scope `XChainCreateBridge` conformance baseline)
- [x] `TestConformance` failure set is **byte-identical** with and without this change (183/183) — zero conformance delta
- [x] New `internal/tx/engine/preflight_dedup_test.go`: proves the structural skip, the cold-cache control, rules-pointer recompute, and that the signature is never cached
- [x] `golangci-lint run --config .golangci.yml` on changed packages — 0 issues

Fixes #1153