### PR TITLE
fix: back inbound ledger acquisition with the node store

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -480,6 +480,14 @@ func runServer(cmd *cobra.Command, args []string) error {
 				}
 				return node.Data, true
 			})
+
+			// Back inbound ledger acquisitions with the persistent node store so a
+			// forked or catching-up node satisfies the shared majority of a
+			// state/tx tree from local storage and only fetches the genuinely-
+			// missing nodes from peers (issue #1158).
+			if router := consensusComponents.Router; router != nil {
+				router.SetAcquisitionFamily(shamap.NewNodeStoreFamily(db))
+			}
 		}
 
 		// LoadFeeTrack ingress + outbound self-load advertisement.

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -417,12 +417,9 @@ func runServer(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("create consensus components: %w", compErr)
 		}
 
-		// Back inbound ledger acquisitions with the persistent node store so a
-		// forked or catching-up node satisfies the shared majority of a
-		// state/tx tree from local storage and only fetches the genuinely-
-		// missing nodes from peers (issue #1158). Wired before Start launches
-		// the router loop, so the family is published before any acquisition
-		// can read it.
+		// Back inbound acquisitions with the node store before Start launches the
+		// router loop, so the family is published before any acquisition reads it
+		// (issue #1158).
 		if db != nil {
 			if router := consensusComponents.Router; router != nil {
 				router.SetAcquisitionFamily(shamap.NewNodeStoreFamily(db))

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -417,6 +417,18 @@ func runServer(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("create consensus components: %w", compErr)
 		}
 
+		// Back inbound ledger acquisitions with the persistent node store so a
+		// forked or catching-up node satisfies the shared majority of a
+		// state/tx tree from local storage and only fetches the genuinely-
+		// missing nodes from peers (issue #1158). Wired before Start launches
+		// the router loop, so the family is published before any acquisition
+		// can read it.
+		if db != nil {
+			if router := consensusComponents.Router; router != nil {
+				router.SetAcquisitionFamily(shamap.NewNodeStoreFamily(db))
+			}
+		}
+
 		if err := consensusComponents.Start(); err != nil {
 			return fmt.Errorf("start consensus components: %w", err)
 		}
@@ -480,14 +492,6 @@ func runServer(cmd *cobra.Command, args []string) error {
 				}
 				return node.Data, true
 			})
-
-			// Back inbound ledger acquisitions with the persistent node store so a
-			// forked or catching-up node satisfies the shared majority of a
-			// state/tx tree from local storage and only fetches the genuinely-
-			// missing nodes from peers (issue #1158).
-			if router := consensusComponents.Router; router != nil {
-				router.SetAcquisitionFamily(shamap.NewNodeStoreFamily(db))
-			}
 		}
 
 		// LoadFeeTrack ingress + outbound self-load advertisement.

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	validatorlist "github.com/LeJamon/go-xrpl/internal/validator/list"
+	"github.com/LeJamon/go-xrpl/shamap"
 )
 
 // inboundReplayDeltaTickInterval drives the periodic check for
@@ -152,6 +153,11 @@ type Router struct {
 	// was saturated — the originating peer resends and reduce-relay covers
 	// the gap, so a dropped relay frame is recoverable.
 	droppedTxJobs atomic.Uint64
+
+	// acquisitionFamily backs new inbound acquisitions with the persistent node
+	// store (see SetAcquisitionFamily); nil leaves them unbacked. Set once at
+	// startup, before Run.
+	acquisitionFamily shamap.Family
 }
 
 // txWorkerCount bounds the goroutines draining inbound peer transactions off
@@ -227,6 +233,25 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, inbox <-chan *peermana
 // inbox-only behaviour tests rely on.
 func (r *Router) SetTxInbox(txInbox <-chan *peermanagement.InboundMessage) {
 	r.txInbox = txInbox
+}
+
+// SetAcquisitionFamily installs the node-store family that backs new inbound
+// ledger acquisitions, so a forked or catching-up node satisfies the shared
+// majority of a state/tx tree from its local store and only fetches the
+// genuinely-missing nodes from peers (issue #1158). A nil family leaves
+// acquisitions unbacked, preserving the fetch-everything path for storeless
+// deployments. Call before Run.
+func (r *Router) SetAcquisitionFamily(family shamap.Family) {
+	r.acquisitionFamily = family
+}
+
+// acquisitionOpts returns the inbound.Option set applied to every new
+// acquisition — currently just the node-store backing when one is wired.
+func (r *Router) acquisitionOpts() []inbound.Option {
+	if r.acquisitionFamily == nil {
+		return nil
+	}
+	return []inbound.Option{inbound.WithFamily(r.acquisitionFamily)}
 }
 
 // SetMinimumOnlineFloor installs the online-delete retention floor. Once set,

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -221,7 +221,7 @@ func (r *Router) startLedgerAcquisitionLegacy(seq uint32, hash [32]byte, peerID 
 	}
 
 	_, created := r.fetchTracker.GetOrCreate(hash, func() *inbound.Ledger {
-		return inbound.New(hash, seq, peerID, r.logger)
+		return inbound.New(hash, seq, peerID, r.logger, r.acquisitionOpts()...)
 	})
 	if !created {
 		// Already acquiring this hash (consensus or a prior arm).
@@ -342,7 +342,7 @@ func (r *Router) startGenericAcquisition(hash [32]byte, seq uint32) (map[string]
 	}
 
 	il, created := r.fetchTracker.GetOrCreate(hash, func() *inbound.Ledger {
-		return inbound.NewGeneric(hash, seq, peerID, r.logger)
+		return inbound.NewGeneric(hash, seq, peerID, r.logger, r.acquisitionOpts()...)
 	})
 	if created {
 		r.logger.Info("starting ledger acquisition (generic, ledger_request)",

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -130,6 +130,11 @@ type Ledger struct {
 	mu        sync.Mutex
 	logger    *slog.Logger
 
+	// family backs the acquisition SHAMaps with the persistent node store when
+	// set, so getMissingNodes only reports nodes not already held locally. nil
+	// leaves the maps unbacked. Set once at construction, never mutated after.
+	family shamap.Family
+
 	// Retry-loop bookkeeping ported from rippled's TimeoutCounter. lastTimer
 	// is when OnTimer last evaluated; progress records a fresh node attach
 	// since then; timeouts counts no-progress intervals toward the failure
@@ -152,10 +157,26 @@ type Ledger struct {
 	fetchPackRequested bool
 }
 
+// Option configures an acquisition at construction.
+type Option func(*Ledger)
+
+// WithFamily backs the acquisition's state and transaction SHAMaps with the
+// node-store family, so nodes already present locally (the shared majority of
+// the tree after a fork or during forward catch-up) are satisfied from the
+// store and only the genuinely-missing ones are fetched from peers. A nil
+// family is ignored, leaving the maps unbacked.
+func WithFamily(family shamap.Family) Option {
+	return func(l *Ledger) {
+		if family != nil {
+			l.family = family
+		}
+	}
+}
+
 // New creates a new InboundLedger acquisition for the given ledger hash.
 // The acquisition reason defaults to ReasonConsensus.
-func New(hash [32]byte, seq uint32, peerID uint64, logger *slog.Logger) *Ledger {
-	return &Ledger{
+func New(hash [32]byte, seq uint32, peerID uint64, logger *slog.Logger, opts ...Option) *Ledger {
+	l := &Ledger{
 		hash:      hash,
 		seq:       seq,
 		peers:     []uint64{peerID},
@@ -163,14 +184,29 @@ func New(hash [32]byte, seq uint32, peerID uint64, logger *slog.Logger) *Ledger 
 		lastTimer: SystemClock.Now(),
 		logger:    logger,
 	}
+	for _, opt := range opts {
+		opt(l)
+	}
+	return l
 }
 
 // NewGeneric creates an RPC-driven (ReasonGeneric) acquisition: on completion
 // the ledger is persisted for querying but not adopted into the active chain.
-func NewGeneric(hash [32]byte, seq uint32, peerID uint64, logger *slog.Logger) *Ledger {
-	l := New(hash, seq, peerID, logger)
+func NewGeneric(hash [32]byte, seq uint32, peerID uint64, logger *slog.Logger, opts ...Option) *Ledger {
+	l := New(hash, seq, peerID, logger, opts...)
 	l.reason = ReasonGeneric
 	return l
+}
+
+// newSyncMap builds an acquisition SHAMap, backed by the node-store family when
+// one is wired so a forked or catching-up node satisfies the shared majority of
+// the tree from its local store instead of re-fetching it from peers. Without a
+// family the map is unbacked and every node must come over the wire.
+func (l *Ledger) newSyncMap(t shamap.Type) (*shamap.SHAMap, error) {
+	if l.family != nil {
+		return shamap.NewBacked(t, l.family)
+	}
+	return shamap.New(t), nil
 }
 
 // Reason returns why this acquisition was started.
@@ -409,7 +445,12 @@ func (l *Ledger) GotBase(nodes []message.LedgerNode) error {
 	)
 
 	// Create state SHAMap and add the root node
-	sm := shamap.New(shamap.TypeState)
+	sm, err := l.newSyncMap(shamap.TypeState)
+	if err != nil {
+		l.state = StateFailed
+		l.err = fmt.Errorf("create state map: %w", err)
+		return l.err
+	}
 
 	if err := sm.AddRootNode(h.AccountHash, nodes[1].NodeData); err != nil {
 		l.state = StateFailed
@@ -426,7 +467,12 @@ func (l *Ledger) GotBase(nodes []message.LedgerNode) error {
 	if h.TxHash == ([32]byte{}) {
 		l.haveTx = true
 	} else {
-		tm := shamap.New(shamap.TypeTransaction)
+		tm, terr := l.newSyncMap(shamap.TypeTransaction)
+		if terr != nil {
+			l.state = StateFailed
+			l.err = fmt.Errorf("create tx map: %w", terr)
+			return l.err
+		}
 		if len(nodes) >= 3 && len(nodes[2].NodeData) > 0 {
 			if err := tm.AddRootNode(h.TxHash, nodes[2].NodeData); err != nil {
 				l.state = StateFailed

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -199,9 +199,7 @@ func NewGeneric(hash [32]byte, seq uint32, peerID uint64, logger *slog.Logger, o
 }
 
 // newSyncMap builds an acquisition SHAMap, backed by the node-store family when
-// one is wired so a forked or catching-up node satisfies the shared majority of
-// the tree from its local store instead of re-fetching it from peers. Without a
-// family the map is unbacked and every node must come over the wire.
+// one is wired (see WithFamily) and unbacked otherwise.
 func (l *Ledger) newSyncMap(t shamap.Type) (*shamap.SHAMap, error) {
 	if l.family != nil {
 		return shamap.NewBacked(t, l.family)

--- a/internal/ledger/inbound/inbound_backed_test.go
+++ b/internal/ledger/inbound/inbound_backed_test.go
@@ -1,0 +1,177 @@
+package inbound
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+// buildBackedTestState builds a multi-level state SHAMap from a fixed base set
+// plus `extra` items placed under an otherwise-unused top branch. Two trees
+// built with different `extra` share byte-identical base subtrees (only the
+// added branch and the root re-hash), modeling a fork: canonical and divergent
+// ledgers share the bulk of state, differing only in the touched accounts.
+func buildBackedTestState(t *testing.T, extra int) (sm *shamap.SHAMap, rootHash [32]byte, rootData []byte) {
+	t.Helper()
+	sm = shamap.New(shamap.TypeState)
+	put := func(k0, k1, k2 byte) {
+		var key [32]byte
+		key[0] = k0
+		key[1] = k1
+		key[2] = k2
+		key[31] = 0xA5
+		if err := sm.Put(key, []byte{k0, k1, k2, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99}); err != nil {
+			t.Fatalf("put: %v", err)
+		}
+	}
+	// Base set shared by every tree: four top branches, multi-level.
+	for a := range byte(4) {
+		for b := range byte(4) {
+			for c := range byte(4) {
+				put((a<<4)|b, c<<4, 0)
+			}
+		}
+	}
+	// Fork delta: brand-new subtree under top branch 0xE, untouched by the base.
+	for i := range extra {
+		put(0xE0, byte(i)<<4, 0)
+	}
+
+	var err error
+	if rootHash, err = sm.Hash(); err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	if rootData, err = sm.SerializeRoot(); err != nil {
+		t.Fatalf("serialize root: %v", err)
+	}
+	return sm, rootHash, rootData
+}
+
+// seedFamilyFrom stores every node of sm into a fresh in-memory node-store
+// family, modeling the nodes a node already holds in its local store.
+func seedFamilyFrom(t *testing.T, sm *shamap.SHAMap) *shamap.NodeStoreFamily {
+	t.Helper()
+	family := shamap.NewMemoryNodeStoreFamily()
+	nodes, err := sm.WalkFetchPackNodes(1 << 20)
+	if err != nil {
+		t.Fatalf("walk fetch-pack nodes: %v", err)
+	}
+	entries := make([]shamap.FlushEntry, 0, len(nodes))
+	for _, n := range nodes {
+		entries = append(entries, shamap.FlushEntry{Hash: n.Hash, Data: n.Data})
+	}
+	if err := family.StoreBatch(context.Background(), entries); err != nil {
+		t.Fatalf("store batch: %v", err)
+	}
+	return family
+}
+
+func toLedgerNodes(wire []shamap.WireNode) []message.LedgerNode {
+	out := make([]message.LedgerNode, 0, len(wire))
+	for _, w := range wire {
+		out = append(out, message.LedgerNode{NodeID: w.NodeID, NodeData: w.Data})
+	}
+	return out
+}
+
+// TestGotBase_BackedCompletesEntirelyFromStore proves a node-store-backed
+// acquisition self-heals with zero peer fetches when the whole canonical tree
+// is already in the local store — rippled's tryDB (InboundLedger.cpp:340).
+func TestGotBase_BackedCompletesEntirelyFromStore(t *testing.T) {
+	t.Parallel()
+	source, rootHash, rootData := buildBackedTestState(t, 0)
+	family := seedFamilyFrom(t, source)
+
+	hdrBytes, ledgerHash := encodeHeader(header.LedgerHeader{LedgerIndex: 100, AccountHash: rootHash})
+	il := New(ledgerHash, 100, 7, discardLogger(), WithFamily(family))
+	if err := il.GotBase([]message.LedgerNode{{NodeData: hdrBytes}, {NodeData: rootData}}); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+
+	if !il.IsComplete() {
+		t.Fatalf("backed acquisition with the whole tree in the store must complete in GotBase; state=%d", il.State())
+	}
+	if ids := il.NeedsMissingNodeIDs(); ids != nil {
+		t.Fatalf("expected no missing nodes to request, got %d", len(ids))
+	}
+}
+
+// TestGotBase_ColdStoreMatchesUnbacked proves no regression for forward
+// catch-up of a brand-new ledger: a backed acquisition over an empty store
+// reports the same missing set as an unbacked one, so it still fetches the tree
+// over the wire when the store can't help.
+func TestGotBase_ColdStoreMatchesUnbacked(t *testing.T) {
+	t.Parallel()
+	_, rootHash, rootData := buildBackedTestState(t, 0)
+	hdrBytes, ledgerHash := encodeHeader(header.LedgerHeader{LedgerIndex: 100, AccountHash: rootHash})
+	base := []message.LedgerNode{{NodeData: hdrBytes}, {NodeData: rootData}}
+
+	unbacked := New(ledgerHash, 100, 7, discardLogger())
+	if err := unbacked.GotBase(base); err != nil {
+		t.Fatalf("unbacked GotBase: %v", err)
+	}
+	backedCold := New(ledgerHash, 100, 7, discardLogger(), WithFamily(shamap.NewMemoryNodeStoreFamily()))
+	if err := backedCold.GotBase(base); err != nil {
+		t.Fatalf("backed-cold GotBase: %v", err)
+	}
+
+	want := len(unbacked.stateMap.GetMissingNodes(0, nil))
+	got := len(backedCold.stateMap.GetMissingNodes(0, nil))
+	if want == 0 {
+		t.Fatal("test setup: unbacked map should have missing nodes after GotBase")
+	}
+	if got != want {
+		t.Fatalf("backed map over an empty store must report the same missing set as unbacked: got %d want %d", got, want)
+	}
+}
+
+// TestGotBase_BackedFetchesOnlyForkDelta is the core fork self-heal case: the
+// shared pre-fork state is in the local store; the canonical post-fork tree adds
+// a touched subtree. A backed acquisition only needs the fork delta from peers
+// (far fewer nodes than the whole tree), and completes once the peer supplies it.
+func TestGotBase_BackedFetchesOnlyForkDelta(t *testing.T) {
+	t.Parallel()
+	// Pre-fork (shared) state already in our local store.
+	shared, _, _ := buildBackedTestState(t, 0)
+	family := seedFamilyFrom(t, shared)
+
+	// Canonical post-fork state: shared base plus a touched (new) subtree.
+	canonical, canonRoot, canonRootData := buildBackedTestState(t, 2)
+	hdrBytes, ledgerHash := encodeHeader(header.LedgerHeader{LedgerIndex: 101, AccountHash: canonRoot})
+	base := []message.LedgerNode{{NodeData: hdrBytes}, {NodeData: canonRootData}}
+
+	il := New(ledgerHash, 101, 7, discardLogger(), WithFamily(family))
+	if err := il.GotBase(base); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+
+	backedMissing := len(il.stateMap.GetMissingNodes(0, nil))
+	if backedMissing == 0 {
+		t.Fatal("expected a non-empty fork delta to fetch from peers")
+	}
+
+	unbacked := New(ledgerHash, 101, 7, discardLogger())
+	if err := unbacked.GotBase(base); err != nil {
+		t.Fatalf("unbacked GotBase: %v", err)
+	}
+	unbackedMissing := len(unbacked.stateMap.GetMissingNodes(0, nil))
+	if backedMissing >= unbackedMissing {
+		t.Fatalf("backed acquisition must request fewer nodes than unbacked: backed=%d unbacked=%d", backedMissing, unbackedMissing)
+	}
+
+	// The peer supplies the canonical tree; store-resident nodes are duplicates,
+	// the fork delta attaches, and the acquisition completes.
+	wire, err := canonical.WalkWireNodes()
+	if err != nil {
+		t.Fatalf("walk wire nodes: %v", err)
+	}
+	if err := il.GotStateNodes(toLedgerNodes(wire)); err != nil {
+		t.Fatalf("GotStateNodes: %v", err)
+	}
+	if !il.IsComplete() {
+		t.Fatalf("acquisition should complete after the peer supplies the fork delta; state=%d", il.State())
+	}
+}


### PR DESCRIPTION
## Summary

- A forked validator could not **self-heal** for large state trees. Inbound acquisition (`inbound.GotBase`) built its account-state and transaction `SHAMap`s **unbacked** (`shamap.New`), so `getMissingNodes` re-requested *every* node over the wire — including the ~99% the node already held locally (shared pre-fork state). For large forked trees this exceeds the fixed retry budget and stalls at `still have 1 missing nodes` / `retry budget exhausted` (`have_state=false`), pinning the node forever.
- **Fix:** back the acquisition maps with the node-store family, mirroring rippled's `InboundLedger` (its `stateMap_`/`txMap_` are constructed with the node `family`, `backed_ = true`, and `tryDB` drains the persistent store). Shared nodes are now satisfied from the local store via the existing `loadFromStore`/`descend` lazy-load path, so only the genuinely-missing **fork delta** is fetched from peers — and a node whose store already holds the whole canonical tree completes in `GotBase` with **zero** peer fetches.
- Wiring: `inbound.New`/`NewGeneric` gain a backward-compatible `WithFamily` option; the router exposes `SetAcquisitionFamily`, wired in `server.go` with `shamap.NewNodeStoreFamily(db)` only when a node store is configured. A nil family leaves acquisitions unbacked, preserving behaviour for storeless/standalone deployments.

Confirmed against rippled: go-xrpl's retry budget (6), aggressive threshold (4), and by-hash cap (4 hashes, all peers) **already match** rippled — the *only* divergence was the unbacked map, so no budget/by-hash knob is changed.

## Test plan

- [x] `go test ./internal/ledger/inbound/... ./internal/consensus/adaptor/...` (pass)
- [x] New `internal/ledger/inbound/inbound_backed_test.go`:
  - backed acquisition with the whole tree in the store completes in `GotBase` with no nodes to request (rippled `tryDB`);
  - backed acquisition over an empty store reports the **same** missing set as unbacked (no regression for cold forward catch-up);
  - backed acquisition over a seeded store requests **only** the fork delta (`< unbacked`), then completes once the peer supplies it.
- [x] `go build ./...`, `go vet ./...` (affected pkgs), `golangci-lint run --config .golangci.yml` on affected packages → 0 issues.

Fixes #1158