### PR TITLE
fix(consensus): high-throughput tx-set acquisition + overlay lane isolation

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -66,9 +66,9 @@ type NetworkSender interface {
 	// RequestTxSetMissingNodesFromPeer is the unicast variant of
 	// RequestTxSetMissingNodes: the request is sent only to the replying peer.
 	// The inbound acquire pipeline uses it so a progressing reply re-requests
-	// from the peer that just served (mirrors rippled trigger(peer)); the
-	// broadcast variant stays the timer's stalled-acquire fallback. nodeIDs may
-	// carry the 33-byte zero root ID to (re)fetch the root.
+	// from the peer that just served; the broadcast variant stays the timer's
+	// stalled-acquire fallback. nodeIDs may carry the 33-byte zero root ID to
+	// (re)fetch the root.
 	RequestTxSetMissingNodesFromPeer(id consensus.TxSetID, nodeIDs [][]byte, peerID uint64, indirect bool) error
 	RequestLedger(id consensus.LedgerID) error
 	RequestLedgerByHashAndSeq(hash [32]byte, seq uint32) error

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -63,6 +63,13 @@ type NetworkSender interface {
 	// query_type=qtINDIRECT; set it once the acquisition has timed out at
 	// least once (see RequestStateNodes).
 	RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool, indirect bool) error
+	// RequestTxSetMissingNodesFromPeer is the unicast variant of
+	// RequestTxSetMissingNodes: the request is sent only to the replying peer.
+	// The inbound acquire pipeline uses it so a progressing reply re-requests
+	// from the peer that just served (mirrors rippled trigger(peer)); the
+	// broadcast variant stays the timer's stalled-acquire fallback. nodeIDs may
+	// carry the 33-byte zero root ID to (re)fetch the root.
+	RequestTxSetMissingNodesFromPeer(id consensus.TxSetID, nodeIDs [][]byte, peerID uint64, indirect bool) error
 	RequestLedger(id consensus.LedgerID) error
 	RequestLedgerByHashAndSeq(hash [32]byte, seq uint32) error
 	RequestLedgerBaseFromPeer(peerID uint64, hash [32]byte, seq uint32) error
@@ -125,6 +132,9 @@ func (n *noopSender) RelayValidation(*consensus.Validation, uint64) error { retu
 func (n *noopSender) UpdateRelaySlot([]byte, uint64, []uint64)            {}
 func (n *noopSender) RequestTxSet(consensus.TxSetID) error                { return nil }
 func (n *noopSender) RequestTxSetMissingNodes(consensus.TxSetID, [][]byte, map[uint64]bool, bool) error {
+	return nil
+}
+func (n *noopSender) RequestTxSetMissingNodesFromPeer(consensus.TxSetID, [][]byte, uint64, bool) error {
 	return nil
 }
 func (n *noopSender) RequestLedger(consensus.LedgerID) error                         { return nil }
@@ -489,6 +499,10 @@ func (a *Adaptor) RequestTxSet(id consensus.TxSetID) error {
 
 func (a *Adaptor) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool, indirect bool) error {
 	return a.sender.RequestTxSetMissingNodes(id, nodeIDs, excluded, indirect)
+}
+
+func (a *Adaptor) RequestTxSetMissingNodesFromPeer(id consensus.TxSetID, nodeIDs [][]byte, peerID uint64, indirect bool) error {
+	return a.sender.RequestTxSetMissingNodesFromPeer(id, nodeIDs, peerID, indirect)
 }
 
 func (a *Adaptor) RequestLedger(id consensus.LedgerID) error {

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -45,7 +45,15 @@ type Router struct {
 	// handleMessage directly leave it nil, and a nil channel is simply
 	// never selected. Wired via SetTxInbox before Run.
 	txInbox <-chan *peermanagement.InboundMessage
-	logger  *slog.Logger
+	// acqInbox is the overlay's dedicated acquisition-reply lane
+	// (mtLEDGER_DATA and the replay-delta / proof-path responses). Run
+	// drains it PREFERENTIALLY, ahead of inbox/txInbox, so a reply this node
+	// explicitly requested (e.g. liBASE) is consumed before serve / propose
+	// / validation traffic and an inbound-ledger acquisition can't wedge in
+	// StateWantBase. nil when unset — a nil channel is never selected. Wired
+	// via SetAcqInbox before Run.
+	acqInbox <-chan *peermanagement.InboundMessage
+	logger   *slog.Logger
 
 	// Peer ledger tracking for catch-up detection
 	peersMu    sync.RWMutex
@@ -154,6 +162,20 @@ type Router struct {
 	// the gap, so a dropped relay frame is recoverable.
 	droppedTxJobs atomic.Uint64
 
+	// serveJobs is the bounded queue draining inbound mtGET_LEDGER serve work
+	// (handleGetLedger / serveTxSet, which builds the largest map — the
+	// 15k-tx tx-set — inline) off the Run message loop onto a small worker
+	// pool. Created and drained by startServeWorkers from Run; nil until
+	// then, in which case submitServeJob runs handleGetLedger inline (tests
+	// that drive handleMessage synchronously). Only written on the Run
+	// goroutine.
+	serveJobs chan *peermanagement.InboundMessage
+
+	// droppedServeJobs counts inbound get_ledger requests shed because the
+	// serve pool was saturated — the requesting peer retries elsewhere, so a
+	// dropped request is recoverable load-shedding.
+	droppedServeJobs atomic.Uint64
+
 	// acquisitionFamily backs new inbound acquisitions with the persistent node
 	// store (see SetAcquisitionFamily); nil leaves them unbacked. Set once at
 	// startup, before Run.
@@ -183,6 +205,18 @@ type Router struct {
 var txWorkerCount = max(4, runtime.GOMAXPROCS(0))
 
 const txQueueDepth = 1024
+
+// serveWorkerCount bounds the goroutines answering inbound mtGET_LEDGER
+// requests off the Run loop, and serveQueueDepth bounds the pending backlog
+// before submitServeJob sheds. Serving a request — especially building the
+// 15k-tx tx-set reply in serveTxSet — is CPU/IO-heavy and, run inline on Run,
+// stalls proposal / validation / acquisition-reply handling. The pool is
+// sized at half the cores (floored at 2): serving is a background courtesy to
+// peers, so it should not claim every core away from the apply strand and the
+// tx-prewarm pool. A shed request is recoverable (the peer retries elsewhere).
+var serveWorkerCount = max(2, runtime.GOMAXPROCS(0)/2)
+
+const serveQueueDepth = 256
 
 // messageDedupTTL is how long a proposal/validation hash is
 // remembered for duplicate-detection purposes. 30s comfortably covers a
@@ -233,6 +267,16 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, inbox <-chan *peermana
 // inbox-only behaviour tests rely on.
 func (r *Router) SetTxInbox(txInbox <-chan *peermanagement.InboundMessage) {
 	r.txInbox = txInbox
+}
+
+// SetAcqInbox installs the overlay's dedicated acquisition-reply lane. Run
+// drains it preferentially, so a reply this node requested (liBASE and the
+// replay-delta / proof-path responses) is consumed ahead of serve / propose
+// / validation traffic and an inbound-ledger acquisition can't wedge waiting
+// for a base it never receives. Safe to call before Run; leaving it unset
+// keeps acquisition replies flowing through the shared inbox as before.
+func (r *Router) SetAcqInbox(acqInbox <-chan *peermanagement.InboundMessage) {
+	r.acqInbox = acqInbox
 }
 
 // SetAcquisitionFamily installs the node-store family that backs new inbound
@@ -338,6 +382,7 @@ func (r *Router) HandlePeerDisconnect(peerID peermanagement.PeerID) {
 // acquisitions and fall back to the legacy mtGET_LEDGER path.
 func (r *Router) Run(ctx context.Context) {
 	r.startTxWorkers(ctx)
+	r.startServeWorkers(ctx)
 	ticker := time.NewTicker(inboundReplayDeltaTickInterval)
 	defer ticker.Stop()
 	for {
@@ -347,6 +392,19 @@ func (r *Router) Run(ctx context.Context) {
 		case msg, ok := <-r.inbox:
 			if !ok {
 				return
+			}
+			r.handleMessage(msg)
+		case msg, ok := <-r.acqInbox:
+			// Dedicated acquisition-reply lane (liBASE and the replay-delta /
+			// proof-path responses). Its own buffered lane keeps a flood on
+			// inbox from shedding it; drained as a CO-EQUAL select case so it
+			// neither starves nor is starved by consensus/tx traffic. An
+			// absolute-priority drain here would let a mtLEDGER_DATA flood
+			// starve proposal/validation handling and wedge consensus. nil
+			// when unwired/closed — a nil channel is never selected.
+			if !ok {
+				r.acqInbox = nil
+				continue
 			}
 			r.handleMessage(msg)
 		case msg, ok := <-r.txInbox:
@@ -409,6 +467,52 @@ func (r *Router) submitTxJob(msg *peermanagement.InboundMessage) {
 // because the worker pool was saturated.
 func (r *Router) DroppedTxJobs() uint64 {
 	return r.droppedTxJobs.Load()
+}
+
+// startServeWorkers builds the bounded get_ledger serve queue and launches
+// its drainers. Called once at the top of Run, before the message loop, so
+// the first dispatched request sees a live pool. Workers exit on ctx.Done.
+func (r *Router) startServeWorkers(ctx context.Context) {
+	r.serveJobs = make(chan *peermanagement.InboundMessage, serveQueueDepth)
+	jobs := r.serveJobs
+	for range serveWorkerCount {
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case msg := <-jobs:
+					r.handleGetLedger(msg)
+				}
+			}
+		}()
+	}
+}
+
+// submitServeJob hands an inbound get_ledger request to the serve pool, off
+// the Run message loop. When the pool isn't running (tests that drive
+// handleMessage synchronously without Run), it runs the handler inline to
+// preserve the synchronous contract. On a saturated queue it sheds the
+// request and bumps droppedServeJobs — the requesting peer retries elsewhere,
+// so a dropped serve is recoverable load-shedding.
+func (r *Router) submitServeJob(msg *peermanagement.InboundMessage) {
+	if r.serveJobs == nil {
+		r.handleGetLedger(msg)
+		return
+	}
+	select {
+	case r.serveJobs <- msg:
+	default:
+		r.droppedServeJobs.Add(1)
+		r.logger.Debug("inbound get_ledger dropped: serve pool saturated",
+			"t", "consensus", "event", "serve-shed", "peer", msg.PeerID)
+	}
+}
+
+// DroppedServeJobs returns the cumulative count of inbound get_ledger
+// requests shed because the serve pool was saturated.
+func (r *Router) DroppedServeJobs() uint64 {
+	return r.droppedServeJobs.Load()
 }
 
 // maintenanceTick runs out-of-band housekeeping: detect replay-delta

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -46,12 +46,12 @@ type Router struct {
 	// never selected. Wired via SetTxInbox before Run.
 	txInbox <-chan *peermanagement.InboundMessage
 	// acqInbox is the overlay's dedicated acquisition-reply lane
-	// (mtLEDGER_DATA and the replay-delta / proof-path responses). Run
-	// drains it PREFERENTIALLY, ahead of inbox/txInbox, so a reply this node
-	// explicitly requested (e.g. liBASE) is consumed before serve / propose
-	// / validation traffic and an inbound-ledger acquisition can't wedge in
-	// StateWantBase. nil when unset — a nil channel is never selected. Wired
-	// via SetAcqInbox before Run.
+	// (mtLEDGER_DATA and the replay-delta / proof-path responses). Its own
+	// buffered lane keeps a flood on inbox from shedding a reply this node
+	// explicitly requested; Run drains it as a co-equal select case — not
+	// absolute priority, which would let a mtLEDGER_DATA flood starve
+	// proposal/validation. nil when unset — a nil channel is never selected.
+	// Wired via SetAcqInbox before Run.
 	acqInbox <-chan *peermanagement.InboundMessage
 	logger   *slog.Logger
 
@@ -269,12 +269,9 @@ func (r *Router) SetTxInbox(txInbox <-chan *peermanagement.InboundMessage) {
 	r.txInbox = txInbox
 }
 
-// SetAcqInbox installs the overlay's dedicated acquisition-reply lane. Run
-// drains it preferentially, so a reply this node requested (liBASE and the
-// replay-delta / proof-path responses) is consumed ahead of serve / propose
-// / validation traffic and an inbound-ledger acquisition can't wedge waiting
-// for a base it never receives. Safe to call before Run; leaving it unset
-// keeps acquisition replies flowing through the shared inbox as before.
+// SetAcqInbox installs the overlay's dedicated acquisition-reply lane (see the
+// acqInbox field). Safe to call before Run; leaving it unset keeps acquisition
+// replies flowing through the shared inbox as before.
 func (r *Router) SetAcqInbox(acqInbox <-chan *peermanagement.InboundMessage) {
 	r.acqInbox = acqInbox
 }

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -33,7 +33,11 @@ func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
 	case message.TypeStatusChange:
 		r.handleStatusChange(msg)
 	case message.TypeGetLedger:
-		r.handleGetLedger(msg)
+		// Offload the serve to the bounded worker pool so building a large
+		// reply (notably the 15k-tx tx-set in serveTxSet) can't stall
+		// proposal / validation / acquisition-reply handling on this
+		// goroutine. Inline when the pool isn't running (synchronous tests).
+		r.submitServeJob(msg)
 	case message.TypeLedgerData:
 		r.handleLedgerData(msg)
 	case message.TypeGetObjects:

--- a/internal/consensus/adaptor/router_serve.go
+++ b/internal/consensus/adaptor/router_serve.go
@@ -76,9 +76,11 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 	}
 
 	// Load-shed ledger-BODY requests under load. The liTS_CANDIDATE branch
-	// above is intentionally exempt, because consensus liveness depends on
-	// tx-set acquisition always being served — so this gate runs only for
-	// liBASE / liAS_NODE / liTX_NODE.
+	// above is exempt from this isLoadedLocal gate — a tx-set serve that
+	// reaches the handler is answered — so this gate runs only for
+	// liBASE / liAS_NODE / liTX_NODE. (Under extreme load the bounded serve
+	// pool can still shed any get_ledger, tx-set included, before it reaches
+	// here; the requesting peer retries elsewhere.)
 	loadedLocal := false
 	if ft := svc.FeeTrack(); ft != nil {
 		loadedLocal = ft.IsLoadedLocal()

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -45,17 +45,16 @@ type txSetAcquireState struct {
 	dormant bool
 
 	// haveRoot latches once the real root node for this tx-set hash has been
-	// installed (mirrors rippled TransactionAcquire::mHaveRoot). A fresh
-	// shamap.New carries a non-nil but EMPTY root, which would let an empty
-	// tree "complete" with zero leaves; until haveRoot is set the acquire only
-	// requests the root and can never complete.
+	// installed. A fresh shamap.New carries a non-nil but EMPTY root, which
+	// would let an empty tree "complete" with zero leaves; until haveRoot is
+	// set the acquire only requests the root and can never complete.
 	haveRoot bool
 
 	// done latches a terminal acquire: completed (set built and fed to the
 	// engine) or given-up (dormant past MaxStallTicks). A data reply for a
 	// done acquire is dropped so a straggler can neither recreate a fresh empty
 	// map nor fan out re-requests; MarkTxSetStillNeeded clears it to revive a
-	// genuinely-needed set. Mirrors rippled's complete_/failed_ latches.
+	// genuinely-needed set.
 	done bool
 }
 
@@ -488,10 +487,10 @@ func (r *Router) markTxSetDone(txSetID consensus.TxSetID) {
 }
 
 // requestTxSetRoot (re)fetches the SHAMap root (the 33-byte zero node ID) of a
-// tx-set. It unicasts to the replying peer when known (mirrors rippled
-// trigger(peer) with !mHaveRoot), falling back to a broadcast when the origin
-// is unknown. Both paths skip Adaptor.RequestTxSet so onTxSetRequested
-// (MarkTxSetStillNeeded) does not reset the acquire's stall bookkeeping.
+// tx-set. It unicasts to the replying peer when known, falling back to a
+// broadcast when the origin is unknown. Both paths skip Adaptor.RequestTxSet so
+// onTxSetRequested (MarkTxSetStillNeeded) does not reset the acquire's stall
+// bookkeeping.
 func (r *Router) requestTxSetRoot(txSetID consensus.TxSetID, originPeer uint64, indirect bool) error {
 	rootID := [][]byte{make([]byte, shamap.NodeIDSize)}
 	if originPeer != 0 {
@@ -553,8 +552,7 @@ func (r *Router) fillTxSetFromLocalPool(txMap *shamap.SHAMap, missing []shamap.M
 // resets, and the request-spacing latch is dropped so the next timer tick or
 // data reply resumes from the retained partial map instead of waiting out the
 // TTL. haveRoot is preserved — a revived acquire keeps any root it already had.
-// A no-op if the router has no entry for txSetID. Mirrors rippled's stillNeed
-// reset path.
+// A no-op if the router has no entry for txSetID.
 func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
 	r.txSetAcquireMu.Lock()
 	defer r.txSetAcquireMu.Unlock()
@@ -595,6 +593,11 @@ func (r *Router) sweepStaleTxSetAcquireLocked() {
 // inbound path keeps lastRequest fresh while making progress, the MinInterval
 // gate keeps this timer out of an actively-progressing acquire and only fires
 // once responses stop arriving.
+//
+// A stalled tick re-requests by broadcast (filtered by the non-progress
+// exclusion set) rather than adding one targeted peer at a time: under the
+// high-throughput stalls this drives, fanning out to find any server fast
+// matters more than minimising duplicate requests.
 //
 // Runs on the Run() message-loop goroutine (same as handleTxSetData), so
 // reading state.txMap here never races the inbound path.

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -251,14 +251,15 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 		r.txSetAcquireMu.Unlock()
 	}
 
-	// A hash-bound map with no root is not valid and must never complete
-	// (mirrors mHaveRoot + isValid). Until the root arrives, only request it —
-	// do NOT descend non-root nodes, FinishSync, complete, or delete. The fetch
-	// goes to the replying peer (unicast); the timer broadcasts as fallback.
+	// A hash-bound map with no root is not valid and must never complete.
+	// Until the root arrives, only request it — do NOT descend non-root nodes,
+	// FinishSync, complete, or delete. This reply did not deliver the root, so
+	// it made no progress: re-request the root from the replying peer (RTT-
+	// paced), but do NOT refresh lastRequest — that leaves the stall timer free
+	// to escalate the root fetch to a broadcast and, past MaxStallTicks, give up.
 	if !haveRoot {
 		r.txSetAcquireMu.Lock()
 		indirect := state.timedOut
-		state.lastRequest = time.Now()
 		r.txSetAcquireMu.Unlock()
 		if err := r.requestTxSetRoot(txSetID, originPeer, indirect); err != nil {
 			r.logger.Info("tx-set sync: root request failed",
@@ -287,6 +288,7 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 	// progress: a duplicate re-send of fat nodes must not keep the pipeline
 	// firing.
 	added := 0
+	duplicates := 0
 	replyValid := true
 	for _, node := range ld.Nodes {
 		if isShamapRootNodeID(node.NodeID) {
@@ -322,7 +324,10 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			break
 		}
 		if res == shamap.NodeDuplicate {
-			// Slot already populated: nothing added, so not progress.
+			// Slot already populated: nothing added, so not fresh progress —
+			// but the node was valid. Track it so an all-duplicate reply isn't
+			// charged against the peer's non-progress counter below.
+			duplicates++
 			continue
 		}
 		added++
@@ -385,10 +390,14 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			// half-updated struct into the hot path.
 			knobs := r.txSetRetryKnobs
 			if !madeProgress {
-				// No progress: do NOT re-request inline — that would let a
-				// junk/empty-reply peer amplify into a broadcast storm. Just
-				// charge the peer and let the 250ms stall timer drive it.
-				if originPeer != 0 {
+				// No fresh attach: do NOT re-request inline — that would let a
+				// junk/empty-reply peer amplify into a broadcast storm; let the
+				// 250ms stall timer drive it. Charge the peer's non-progress
+				// counter EXCEPT on a valid all-duplicate reply, where the peer
+				// is cooperating but resending nodes we already hold — penalising
+				// it would wrongly exclude a useful peer.
+				validAllDuplicate := replyValid && duplicates > 0 && added == 0 && !rootAccepted
+				if originPeer != 0 && !validAllDuplicate {
 					state.peerNonProgress[originPeer]++
 				}
 				r.txSetAcquireMu.Unlock()
@@ -545,19 +554,25 @@ func (r *Router) fillTxSetFromLocalPool(txMap *shamap.SHAMap, missing []shamap.M
 	return filled
 }
 
-// MarkTxSetStillNeeded is the active re-arm hook fired every time
-// consensus re-asks for a tx-set via Adaptor.RequestTxSet. If an
-// in-flight acquisition for this set still exists, its terminal/stall state is
-// cleared: a done or dormant acquire wakes, the consecutive-no-progress counter
-// resets, and the request-spacing latch is dropped so the next timer tick or
-// data reply resumes from the retained partial map instead of waiting out the
-// TTL. haveRoot is preserved — a revived acquire keeps any root it already had.
-// A no-op if the router has no entry for txSetID.
+// MarkTxSetStillNeeded is the active re-arm hook fired every time consensus
+// re-asks for a tx-set via Adaptor.RequestTxSet. A DORMANT (retry-exhausted but
+// still viable) acquire wakes: the consecutive-no-progress counter resets and
+// the request-spacing latch is dropped so the next timer tick or data reply
+// resumes from the retained partial map instead of waiting out the TTL.
+// haveRoot is preserved — a revived acquire keeps any root it already had. A
+// terminal non-dormant acquire (a set already completed and fed to the engine,
+// or a stuck/inconsistent map) is left latched: reviving the former is a
+// redundant re-feed the engine dedups, and the latter would only re-stick. Only
+// a dormant acquire is revived, mirroring rippled's stillNeed clearing failed_
+// but never complete_. A no-op if the router has no entry for txSetID.
 func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
 	r.txSetAcquireMu.Lock()
 	defer r.txSetAcquireMu.Unlock()
 	state, ok := r.txSetAcquire[txSetID]
 	if !ok {
+		return
+	}
+	if state.done && !state.dormant {
 		return
 	}
 	state.done = false

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -19,13 +19,16 @@ type txSetAcquireState struct {
 	lastUpdate time.Time
 
 	// Retry bookkeeping. lastRequest is when we most recently broadcast a
-	// RequestTxSetMissingNodes; attempts counts those broadcasts so we can
-	// surface failure after a cap rather than spinning forever.
-	// peerNonProgress tracks consecutive TMLedgerData responses from a peer
-	// that failed to extend the SHAMap; peers at or over the per-peer
-	// threshold are skipped during the next broadcast.
+	// RequestTxSetMissingNodes. attempts is pure telemetry (the broadcast
+	// count surfaced in logs). stallTicks counts CONSECUTIVE no-progress
+	// timer ticks — the give-up signal — and is reset to 0 whenever an
+	// inbound reply makes progress. peerNonProgress tracks consecutive
+	// TMLedgerData responses from a peer that failed to extend the SHAMap;
+	// peers at or over the per-peer threshold are skipped during the next
+	// broadcast.
 	lastRequest     time.Time
 	attempts        int
+	stallTicks      int
 	peerNonProgress map[uint64]int
 
 	// timedOut latches once the stall timer (retryStalledTxSetAcquires) has
@@ -34,6 +37,26 @@ type txSetAcquireState struct {
 	// missing-nodes request (inbound or timer) is sent indirect
 	// (query_type=qtINDIRECT) so peers relay it on our behalf.
 	timedOut bool
+
+	// dormant latches once stallTicks reaches MaxStallTicks: the timer stops
+	// actively re-requesting, but the partial SHAMap is RETAINED so a later
+	// MarkTxSetStillNeeded resumes the acquire from where it left off. The TTL
+	// sweep still reclaims a truly-abandoned entry.
+	dormant bool
+
+	// haveRoot latches once the real root node for this tx-set hash has been
+	// installed (mirrors rippled TransactionAcquire::mHaveRoot). A fresh
+	// shamap.New carries a non-nil but EMPTY root, which would let an empty
+	// tree "complete" with zero leaves; until haveRoot is set the acquire only
+	// requests the root and can never complete.
+	haveRoot bool
+
+	// done latches a terminal acquire: completed (set built and fed to the
+	// engine) or given-up (dormant past MaxStallTicks). A data reply for a
+	// done acquire is dropped so a straggler can neither recreate a fresh empty
+	// map nor fan out re-requests; MarkTxSetStillNeeded clears it to revive a
+	// genuinely-needed set. Mirrors rippled's complete_/failed_ latches.
+	done bool
 }
 
 // 60s covers a consensus round (~15s) plus retries with margin while
@@ -41,27 +64,31 @@ type txSetAcquireState struct {
 const txSetAcquireTTL = 60 * time.Second
 
 // txSetRetryKnobs collects the tunable parameters of the tx-set acquire
-// retry loop, which is event-driven (one tick per inbound TMLedgerData).
+// retry loop. The inbound path pipelines a re-request on every
+// progressing reply (rate-limited by the RTT itself); the 250ms timer
+// drives stalled acquires and owns the give-up decision.
 //
-//   - MinInterval: minimum spacing between successive broadcasts for
-//     the same acquisition (250ms), so a chatty peer can't drive the
-//     cadence faster.
-//   - MaxAttempts: hard cap on broadcasts per acquisition (20) before
-//     the acquire gives up.
+//   - MinInterval: minimum spacing between successive TIMER broadcasts
+//     for the same acquisition (250ms). An actively-progressing acquire
+//     keeps lastRequest fresh, so the timer stays out of its way.
+//   - MaxStallTicks: consecutive no-progress timer ticks before an
+//     acquire goes dormant (20 ≈ 5s of continuous silence). Any
+//     progressing inbound reply resets the counter, so this only fires
+//     when a set is genuinely un-servable, not merely slow.
 //   - PeerNonProgressThreshold: consecutive non-progressing
 //     TMLedgerData replies from one peer before it is skipped on the
 //     next broadcast. 3 is small enough to react quickly to a truly
 //     stuck peer and large enough to ride out a transient empty reply.
 type txSetRetryKnobs struct {
 	MinInterval              time.Duration
-	MaxAttempts              int
+	MaxStallTicks            int
 	PeerNonProgressThreshold int
 }
 
 func defaultTxSetRetryKnobs() txSetRetryKnobs {
 	return txSetRetryKnobs{
 		MinInterval:              250 * time.Millisecond,
-		MaxAttempts:              20,
+		MaxStallTicks:            20,
 		PeerNonProgressThreshold: 3,
 	}
 }
@@ -166,6 +193,13 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 
 	r.txSetAcquireMu.Lock()
 	state, exists := r.txSetAcquire[txSetID]
+	if exists && state.done {
+		// Terminal acquire (completed or given-up): drop the straggler so it
+		// can neither recreate a fresh empty map nor fan out re-requests. Only
+		// MarkTxSetStillNeeded revives a genuinely-needed set.
+		r.txSetAcquireMu.Unlock()
+		return
+	}
 	if !exists {
 		txMap := shamap.New(shamap.TypeTransaction)
 		if err := txMap.StartSync(); err != nil {
@@ -186,6 +220,7 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 	state.lastUpdate = time.Now()
 	r.sweepStaleTxSetAcquireLocked()
 	txMap := state.txMap
+	haveRoot := state.haveRoot
 	r.txSetAcquireMu.Unlock()
 
 	// Root NodeID is 33 zero bytes. AddRootNode is idempotent
@@ -210,6 +245,33 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 		}
 		break
 	}
+	if rootAccepted && !haveRoot {
+		haveRoot = true
+		r.txSetAcquireMu.Lock()
+		state.haveRoot = true
+		r.txSetAcquireMu.Unlock()
+	}
+
+	// A hash-bound map with no root is not valid and must never complete
+	// (mirrors mHaveRoot + isValid). Until the root arrives, only request it —
+	// do NOT descend non-root nodes, FinishSync, complete, or delete. The fetch
+	// goes to the replying peer (unicast); the timer broadcasts as fallback.
+	if !haveRoot {
+		r.txSetAcquireMu.Lock()
+		indirect := state.timedOut
+		state.lastRequest = time.Now()
+		r.txSetAcquireMu.Unlock()
+		if err := r.requestTxSetRoot(txSetID, originPeer, indirect); err != nil {
+			r.logger.Info("tx-set sync: root request failed",
+				"t", "consensus", "event", "txset-reject",
+				"txset", fmt.Sprintf("%x", txSetID[:8]),
+				"error", err.Error())
+		}
+		r.logger.Debug("tx-set sync: awaiting root before completion",
+			"t", "consensus", "event", "txset-await-root",
+			"txset", fmt.Sprintf("%x", txSetID[:8]))
+		return
+	}
 
 	// Use NodeID-based placement: path-based descent works when the
 	// peer's response contains nodes deeper than our currently-loaded
@@ -222,7 +284,9 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 	// AddKnownNodeByID. A provably-invalid non-root stops harvesting the
 	// rest of the reply (stop-on-first-bad) and flags the whole reply as
 	// non-progress, so a peer trickling junk alongside one good node can't
-	// keep its counter pinned at zero.
+	// keep its counter pinned at zero. Only a fresh attach (NodeUseful) is
+	// progress: a duplicate re-send of fat nodes must not keep the pipeline
+	// firing.
 	added := 0
 	replyValid := true
 	for _, node := range ld.Nodes {
@@ -258,6 +322,10 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 				"error", err)
 			break
 		}
+		if res == shamap.NodeDuplicate {
+			// Slot already populated: nothing added, so not progress.
+			continue
+		}
 		added++
 		// Learn (submit + relay) the tx carried by this acquired leaf.
 		r.learnTxFromLeaf(originPeer, node.NodeData)
@@ -273,7 +341,11 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 		// the extra request for a tx we already relayed.
 		missing := txMap.GetMissingNodes(256, nil)
 		if len(missing) == 0 {
-			r.deleteTxSetAcquire(txSetID)
+			// Root present but the map is inconsistent: terminal. Latch done
+			// and KEEP the entry (TTL reclaims it); MarkTxSetStillNeeded can
+			// revive it. Deleting would let the next straggler recreate a fresh
+			// empty acquire.
+			r.markTxSetDone(txSetID)
 			r.logger.Info("tx-set sync: stuck",
 				"t", "consensus", "event", "txset-reject",
 				"txset", fmt.Sprintf("%x", txSetID[:8]),
@@ -304,51 +376,41 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 		}
 
 		if len(remaining) > 0 {
-			// Throttle retries, cap total attempts, and route around
-			// peers that have repeatedly failed to extend the SHAMap.
-			// Without these guards a non-progressing peer triggers 100+
-			// retries/sec until the 60s TTL sweep fires. A reply counts
-			// as progress only when it was non-empty AND every non-root
-			// node parsed and added cleanly. Any single bad non-root →
-			// invalid reply → not progress for the originating peer.
+			// A reply counts as progress only when it was non-empty AND
+			// every non-root node parsed and added cleanly. Any single bad
+			// non-root → invalid reply → not progress for the peer.
 			madeProgress := replyValid && (added > 0 || rootAccepted)
 			r.txSetAcquireMu.Lock()
 			// Knobs are read under txSetAcquireMu so a concurrent
 			// SetTxSetRetryKnobsForTest (test-only API) can't tear a
 			// half-updated struct into the hot path.
 			knobs := r.txSetRetryKnobs
-			if originPeer != 0 {
-				if madeProgress {
-					state.peerNonProgress[originPeer] = 0
-				} else {
+			if !madeProgress {
+				// No progress: do NOT re-request inline — that would let a
+				// junk/empty-reply peer amplify into a broadcast storm. Just
+				// charge the peer and let the 250ms stall timer drive it.
+				if originPeer != 0 {
 					state.peerNonProgress[originPeer]++
 				}
-			}
-			if !state.lastRequest.IsZero() && time.Since(state.lastRequest) < knobs.MinInterval {
 				r.txSetAcquireMu.Unlock()
-				r.logger.Debug("tx-set sync: retry throttled",
-					"t", "consensus", "event", "txset-retry-throttle",
+				r.logger.Debug("tx-set sync: no-progress reply, deferring to timer",
+					"t", "consensus", "event", "txset-retry-defer",
 					"txset", fmt.Sprintf("%x", txSetID[:8]),
 					"missing", len(remaining),
 				)
 				return
 			}
-			if state.attempts >= knobs.MaxAttempts {
-				attempts := state.attempts
-				delete(r.txSetAcquire, txSetID)
-				r.txSetAcquireMu.Unlock()
-				// Drop the entry rather than mark it permanently
-				// failed: if consensus is still proposing this set, the
-				// next inbound TMLedgerData should start a fresh acquire
-				// rather than be silently dropped for the TTL window.
-				r.logger.Info("tx-set sync: max attempts exceeded",
-					"t", "consensus", "event", "txset-reject",
-					"txset", fmt.Sprintf("%x", txSetID[:8]),
-					"attempts", attempts,
-					"missing", len(remaining),
-				)
-				return
+			// Progress: pipeline the next missing-nodes request IMMEDIATELY.
+			// The RTT itself rate-limits (one re-request per received reply),
+			// so there is no storm and no MinInterval gate is needed. A fresh
+			// lastRequest keeps the stall timer out of an actively-progressing
+			// acquire; reset stallTicks and un-dormant so a resumed acquire
+			// keeps pipelining. Give-up lives only on the timer.
+			if originPeer != 0 {
+				state.peerNonProgress[originPeer] = 0
 			}
+			state.dormant = false
+			state.stallTicks = 0
 			state.attempts++
 			state.lastRequest = time.Now()
 			excluded := buildExcludedPeers(state.peerNonProgress, knobs.PeerNonProgressThreshold)
@@ -367,7 +429,9 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 				"excluded_peers", len(excluded),
 				"indirect", indirect,
 			)
-			if reqErr := r.adaptor.RequestTxSetMissingNodes(txSetID, nodeIDs, excluded, indirect); reqErr != nil {
+			// Pipeline UNICAST to the replying peer (RTT rate-limits, no storm);
+			// the 250ms timer owns the broadcast fallback for silent peers.
+			if reqErr := r.requestTxSetMissingNodesUnicast(txSetID, nodeIDs, originPeer, excluded, indirect); reqErr != nil {
 				r.logger.Info("tx-set sync: missing-nodes request failed",
 					"t", "consensus", "event", "txset-reject",
 					"txset", fmt.Sprintf("%x", txSetID[:8]),
@@ -378,8 +442,10 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 		// fall through: tree complete via local fill
 	}
 
-	// Walk leaves into blobs, feed the engine, drop the acquire so dispute
-	// resolution flipping back to the same set starts fresh.
+	// Walk leaves into blobs, feed the engine, then latch the acquire done and
+	// KEEP it: stragglers for the finished set are dropped (see the top of
+	// handleTxSetData) rather than recreating a fresh empty acquire. The TTL
+	// sweep reclaims it.
 	blobs := make([][]byte, 0, added+1)
 	if err := txMap.ForEach(func(item *shamap.Item) bool {
 		blobs = append(blobs, item.Data())
@@ -388,7 +454,7 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 		r.deleteTxSetAcquire(txSetID)
 		return
 	}
-	r.deleteTxSetAcquire(txSetID)
+	r.markTxSetDone(txSetID)
 
 	r.logger.Info("received tx-set from peer",
 		"t", "consensus", "event", "txset-recv",
@@ -396,8 +462,6 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 		"node_count", len(ld.Nodes),
 		"tx_count", len(blobs))
 
-	// Duplicate response after a completed acquire — no root, ForEach
-	// yields 0 items, engine would fail with "tx set ID mismatch". Drop.
 	if len(blobs) == 0 {
 		return
 	}
@@ -409,6 +473,42 @@ func (r *Router) deleteTxSetAcquire(txSetID consensus.TxSetID) {
 	r.txSetAcquireMu.Lock()
 	delete(r.txSetAcquire, txSetID)
 	r.txSetAcquireMu.Unlock()
+}
+
+// markTxSetDone latches a tx-set acquire terminal (completed or given-up) and
+// KEEPS it, so later data replies are dropped rather than recreating a fresh
+// empty acquire. The TTL sweep reclaims it; MarkTxSetStillNeeded clears the
+// latch to revive a genuinely-needed set. No-op if the entry is gone.
+func (r *Router) markTxSetDone(txSetID consensus.TxSetID) {
+	r.txSetAcquireMu.Lock()
+	if state, ok := r.txSetAcquire[txSetID]; ok {
+		state.done = true
+	}
+	r.txSetAcquireMu.Unlock()
+}
+
+// requestTxSetRoot (re)fetches the SHAMap root (the 33-byte zero node ID) of a
+// tx-set. It unicasts to the replying peer when known (mirrors rippled
+// trigger(peer) with !mHaveRoot), falling back to a broadcast when the origin
+// is unknown. Both paths skip Adaptor.RequestTxSet so onTxSetRequested
+// (MarkTxSetStillNeeded) does not reset the acquire's stall bookkeeping.
+func (r *Router) requestTxSetRoot(txSetID consensus.TxSetID, originPeer uint64, indirect bool) error {
+	rootID := [][]byte{make([]byte, shamap.NodeIDSize)}
+	if originPeer != 0 {
+		return r.adaptor.RequestTxSetMissingNodesFromPeer(txSetID, rootID, originPeer, indirect)
+	}
+	return r.adaptor.RequestTxSetMissingNodes(txSetID, rootID, nil, indirect)
+}
+
+// requestTxSetMissingNodesUnicast pipelines the next missing-nodes request to
+// the single replying peer. It falls back to a filtered broadcast only when the
+// origin is unknown (peerID 0, e.g. tests); the excluded set applies solely to
+// that fallback, being irrelevant to a unicast.
+func (r *Router) requestTxSetMissingNodesUnicast(txSetID consensus.TxSetID, nodeIDs [][]byte, originPeer uint64, excluded map[uint64]bool, indirect bool) error {
+	if originPeer != 0 {
+		return r.adaptor.RequestTxSetMissingNodesFromPeer(txSetID, nodeIDs, originPeer, indirect)
+	}
+	return r.adaptor.RequestTxSetMissingNodes(txSetID, nodeIDs, excluded, indirect)
 }
 
 // submitTxSetToEngine feeds a completed tx-set's blobs to the engine. An
@@ -448,11 +548,13 @@ func (r *Router) fillTxSetFromLocalPool(txMap *shamap.SHAMap, missing []shamap.M
 
 // MarkTxSetStillNeeded is the active re-arm hook fired every time
 // consensus re-asks for a tx-set via Adaptor.RequestTxSet. If an
-// in-flight acquisition for this set still exists, attempts and
-// lastRequest are cleared so the next inbound TMLedgerData broadcasts
-// immediately instead of being throttled or silently dropped past the
-// max-attempts cap. A no-op if the router has no entry for txSetID
-// (e.g. first request, or already completed and swept).
+// in-flight acquisition for this set still exists, its terminal/stall state is
+// cleared: a done or dormant acquire wakes, the consecutive-no-progress counter
+// resets, and the request-spacing latch is dropped so the next timer tick or
+// data reply resumes from the retained partial map instead of waiting out the
+// TTL. haveRoot is preserved — a revived acquire keeps any root it already had.
+// A no-op if the router has no entry for txSetID. Mirrors rippled's stillNeed
+// reset path.
 func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
 	r.txSetAcquireMu.Lock()
 	defer r.txSetAcquireMu.Unlock()
@@ -460,6 +562,9 @@ func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
 	if !ok {
 		return
 	}
+	state.done = false
+	state.dormant = false
+	state.stallTicks = 0
 	state.attempts = 0
 	state.lastRequest = time.Time{}
 }
@@ -479,16 +584,17 @@ func (r *Router) sweepStaleTxSetAcquireLocked() {
 // in-flight tx-set acquisition whose inbound responses have gone quiet, and
 // sweeps entries past their TTL. It fires every 250ms.
 //
-// The inbound retry (handleTxSetData) only advances on an arriving
-// TMLedgerData. When a peer falls silent mid-acquire — or every reply is
-// throttled — nothing re-requests the remaining nodes, so the acquisition
-// stalls until the 60s TTL sweep; under load that drops the node into
-// wrongLedger and the mixed network below quorum. This timer is the missing
-// driver. It reuses the same throttle/attempt-cap/peer-exclusion knobs as
-// the inbound path so the two never compound into a request storm: because
-// the inbound path keeps lastRequest fresh while it is making progress, the
-// MinInterval gate keeps this timer out of an actively progressing acquire
-// and only fires it once responses stop arriving.
+// The inbound path (handleTxSetData) pipelines a re-request on every
+// progressing reply. When a peer falls silent mid-acquire nothing re-requests
+// the remaining nodes, so the acquisition would stall until the 60s TTL sweep;
+// under load that drops the node into wrongLedger and the mixed network below
+// quorum. This timer is the missing driver. Each firing on a stalled acquire
+// is a consecutive no-progress tick (stallTicks); past MaxStallTicks the
+// acquire goes dormant, RETAINING its partial map rather than deleting it, so
+// a later MarkTxSetStillNeeded / progressing reply can resume it. Because the
+// inbound path keeps lastRequest fresh while making progress, the MinInterval
+// gate keeps this timer out of an actively-progressing acquire and only fires
+// once responses stop arriving.
 //
 // Runs on the Run() message-loop goroutine (same as handleTxSetData), so
 // reading state.txMap here never races the inbound path.
@@ -514,6 +620,7 @@ func (r *Router) retryStalledTxSetAcquires() {
 	var kicks []txSetKick
 	var drops []txSetDrop
 	var completes []txSetComplete
+	var rootKicks []consensus.TxSetID
 
 	r.txSetAcquireMu.Lock()
 	r.sweepStaleTxSetAcquireLocked()
@@ -523,6 +630,30 @@ func (r *Router) retryStalledTxSetAcquires() {
 		// cadence window. An actively progressing acquire keeps
 		// lastRequest fresh and is skipped here.
 		if !state.lastRequest.IsZero() && now.Sub(state.lastRequest) < knobs.MinInterval {
+			continue
+		}
+		// A dormant acquire has given up actively re-requesting but keeps
+		// its partial map for a MarkTxSetStillNeeded resume; the TTL sweep
+		// reclaims it if it stays abandoned.
+		if state.dormant {
+			continue
+		}
+		if !state.haveRoot {
+			// Rootless acquire: its empty root exposes no missing nodes, so
+			// GetMissingNodes can't drive it. Re-request the root (broadcast
+			// fallback for a silent peer) with the same stall accounting as any
+			// stalled re-trigger.
+			state.stallTicks++
+			if state.stallTicks >= knobs.MaxStallTicks {
+				state.dormant = true
+				state.done = true
+				drops = append(drops, txSetDrop{id: id, attempts: state.attempts, missing: 0})
+				continue
+			}
+			state.attempts++
+			state.lastRequest = now
+			state.timedOut = true
+			rootKicks = append(rootKicks, id)
 			continue
 		}
 		missing := state.txMap.GetMissingNodes(256, nil)
@@ -549,8 +680,18 @@ func (r *Router) retryStalledTxSetAcquires() {
 			completes = append(completes, txSetComplete{id: id, txMap: state.txMap, filled: filled})
 			continue
 		}
-		if state.attempts >= knobs.MaxAttempts {
-			delete(r.txSetAcquire, id)
+		// A firing timer on a stalled acquire IS a consecutive no-progress
+		// tick — no inbound reply has reset stallTicks since the last one.
+		// Past MaxStallTicks the acquire goes dormant: it RETAINS its partial
+		// map (only the TTL sweep or an explicit resume reclaims it) instead
+		// of being deleted, so consensus re-asking picks up where it left off.
+		state.stallTicks++
+		if state.stallTicks >= knobs.MaxStallTicks {
+			// Give up: latch dormant AND done so stragglers are dropped, while
+			// KEEPING the partial map. Only MarkTxSetStillNeeded revives it; the
+			// TTL sweep reclaims it if it stays abandoned.
+			state.dormant = true
+			state.done = true
 			drops = append(drops, txSetDrop{id: id, attempts: state.attempts, missing: len(missing)})
 			continue
 		}
@@ -570,15 +711,30 @@ func (r *Router) retryStalledTxSetAcquires() {
 		r.finalizeLocalFilledTxSet(c.id, c.txMap, c.filled)
 	}
 	for _, d := range drops {
-		// Drop rather than mark failed: if consensus still needs the set,
-		// the next inbound TMLedgerData / MarkTxSetStillNeeded starts a
-		// fresh acquire (mirrors handleTxSetData's max-attempts handling).
-		r.logger.Info("tx-set sync: max attempts exceeded (timer)",
-			"t", "consensus", "event", "txset-reject",
+		// Dormant + done, not deleted: the partial map is retained so a later
+		// MarkTxSetStillNeeded resumes the acquire, and the TTL sweep reclaims
+		// it if it stays abandoned.
+		r.logger.Info("tx-set sync: stall limit reached, acquire dormant",
+			"t", "consensus", "event", "txset-dormant",
 			"txset", fmt.Sprintf("%x", d.id[:8]),
 			"attempts", d.attempts,
 			"missing", d.missing,
 		)
+	}
+	for _, id := range rootKicks {
+		r.logger.Info("tx-set sync: timer root re-request",
+			"t", "consensus", "event", "txset-timer-root",
+			"txset", fmt.Sprintf("%x", id[:8]),
+		)
+		// Broadcast the root fetch (post-stall → indirect). Uses the
+		// missing-nodes path, not RequestTxSet, so onTxSetRequested does not
+		// reset the stall accounting we just advanced.
+		if err := r.requestTxSetRoot(id, 0, true); err != nil {
+			r.logger.Info("tx-set sync: timer root request failed",
+				"t", "consensus", "event", "txset-reject",
+				"txset", fmt.Sprintf("%x", id[:8]),
+				"error", err.Error())
+		}
 	}
 	for _, k := range kicks {
 		r.logger.Info("tx-set sync: timer re-trigger",
@@ -612,7 +768,9 @@ func (r *Router) finalizeLocalFilledTxSet(txSetID consensus.TxSetID, txMap *sham
 		r.deleteTxSetAcquire(txSetID)
 		return
 	}
-	r.deleteTxSetAcquire(txSetID)
+	// Latch done + KEEP the entry so stragglers are dropped rather than
+	// recreating a fresh empty acquire; the TTL sweep reclaims it.
+	r.markTxSetDone(txSetID)
 	if len(blobs) == 0 {
 		return
 	}

--- a/internal/consensus/adaptor/router_txset_pipeline_test.go
+++ b/internal/consensus/adaptor/router_txset_pipeline_test.go
@@ -1,0 +1,265 @@
+package adaptor
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/require"
+)
+
+// newPipelineRouter is newRetryRouter plus a handle on the mockEngine so
+// the acquisition test can assert the completed set reached the engine.
+func newPipelineRouter(t *testing.T) (*Router, *retryRecordingSender, *mockEngine) {
+	t.Helper()
+	svc := newTestLedgerService(t)
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	rs := &retryRecordingSender{}
+	a := New(Config{
+		LedgerService: svc,
+		Sender:        rs,
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+	})
+	eng := &mockEngine{}
+	router := NewRouter(eng, a, make(chan *peermanagement.InboundMessage, 1))
+	return router, rs, eng
+}
+
+// buildLargeTxSet builds a tx-set of n distinct synthetic tx blobs and
+// returns its canonical ID plus a NodeID→wire-data index used to serve
+// missing-node requests back to the requestor (the server half of an
+// acquisition round-trip).
+func buildLargeTxSet(t *testing.T, n int) (consensus.TxSetID, map[string][]byte) {
+	t.Helper()
+	blobs := make([][]byte, n)
+	for i := range blobs {
+		b := make([]byte, 16)
+		binary.BigEndian.PutUint64(b[:8], uint64(i)+1)
+		binary.BigEndian.PutUint64(b[8:], uint64(i)*2654435761+0x9e3779b9)
+		blobs[i] = b
+	}
+	ts, err := NewTxSet(blobs)
+	require.NoError(t, err)
+	require.Equal(t, n, ts.Size(), "synthetic blobs must all be distinct")
+	wire, err := ts.shamap().WalkWireNodes()
+	require.NoError(t, err)
+	byID := make(map[string][]byte, len(wire))
+	for _, w := range wire {
+		byID[string(w.NodeID)] = w.Data
+	}
+	return ts.ID(), byID
+}
+
+// TestTxSetAcquire_PipelinesOnProgressAtRTT is the core throughput fix: a
+// large tx-set fetched in 256-node batches must re-request the next batch
+// IMMEDIATELY on each progressing reply (rate-limited only by the RTT), not
+// throttled to one request per MinInterval. It pins:
+//
+//	(a) each progressing batch pipelines exactly one more request, so the
+//	    acquire completes in ~#batches requests despite a huge MinInterval;
+//	(b) stallTicks stays 0 across a steadily-progressing acquire;
+//	(c) a retryStalledTxSetAcquires tick mid-acquire does NOT delete the
+//	    partial map (the timer skips an actively-progressing acquire).
+//
+// Mirrors rippled's TransactionAcquire::takeNodes → trigger(peer) on every
+// onLedgerData.
+func TestTxSetAcquire_PipelinesOnProgressAtRTT(t *testing.T) {
+	router, rs, eng := newPipelineRouter(t)
+
+	const leaves = 4000
+	txSetID, byID := buildLargeTxSet(t, leaves)
+	require.Greater(t, len(byID), 256, "fixture must need multiple 256-node batches")
+
+	// serveMissing returns a liTS_CANDIDATE reply carrying up to max of the
+	// requested node IDs, sourced from the canonical tx-set — the server
+	// half of an acquisition round-trip.
+	serveMissing := func(ids [][]byte, max int) *message.LedgerData {
+		if len(ids) > max {
+			ids = ids[:max]
+		}
+		nodes := make([]message.LedgerNode, 0, len(ids))
+		for _, id := range ids {
+			data, ok := byID[string(id)]
+			require.Truef(t, ok, "requested node %x must exist in the source tx-set", id)
+			nodes = append(nodes, message.LedgerNode{
+				NodeID:   append([]byte(nil), id...),
+				NodeData: append([]byte(nil), data...),
+			})
+		}
+		return &message.LedgerData{
+			InfoType:   message.LedgerInfoTsCandidate,
+			LedgerHash: txSetID[:],
+			Nodes:      nodes,
+		}
+	}
+
+	missingIDs := func() [][]byte {
+		router.txSetAcquireMu.Lock()
+		defer router.txSetAcquireMu.Unlock()
+		state, ok := router.txSetAcquire[txSetID]
+		if !ok {
+			return nil
+		}
+		return missingNodeIDs(state.txMap.GetMissingNodes(256, nil))
+	}
+
+	// stateSnapshot reads (stallTicks, tracked) under the lock.
+	stateSnapshot := func() (int, bool) {
+		router.txSetAcquireMu.Lock()
+		defer router.txSetAcquireMu.Unlock()
+		state, ok := router.txSetAcquire[txSetID]
+		if !ok {
+			return 0, false
+		}
+		return state.stallTicks, true
+	}
+
+	// doneSnapshot reports whether the acquire has completed. Completion now
+	// latches the entry done and RETAINS it (stragglers are dropped) rather
+	// than deleting it, so completion is observed via the done flag.
+	doneSnapshot := func() bool {
+		router.txSetAcquireMu.Lock()
+		defer router.txSetAcquireMu.Unlock()
+		state, ok := router.txSetAcquire[txSetID]
+		return ok && state.done
+	}
+
+	// MinInterval is deliberately HUGE: if the inbound path still consulted
+	// it, only the first batch would ever re-request and the acquire would
+	// never complete. The pipelining model ignores it for progressing
+	// replies. MaxStallTicks is small so any regression to timer-driven
+	// give-up would surface as a premature dormancy.
+	withRetryKnobs(router, time.Hour, 3, 1_000_000, func() {
+		// Batch 0: the root. A progressing root reply pipelines exactly one
+		// missing-nodes request immediately.
+		rootID := make([]byte, 33)
+		router.handleTxSetData(serveMissing([][]byte{rootID}, 256), 1)
+		require.Equal(t, 1, rs.calledN(),
+			"root reply must pipeline exactly one missing-nodes request")
+
+		requestsAtLastProgress := 1
+		firedMidTick := false
+		for step := 0; step < 10*leaves; step++ {
+			if doneSnapshot() { // acquire completed (retained as done)
+				break
+			}
+			ids := missingIDs()
+			require.NotEmpty(t, ids, "an incomplete tracked acquire must expose missing nodes")
+
+			// (b) A steadily-progressing acquire never accrues stall ticks.
+			st, tracked := stateSnapshot()
+			require.True(t, tracked)
+			require.Equalf(t, 0, st,
+				"stallTicks must stay 0 while the acquire is steadily progressing (step %d)", step)
+
+			// (c) A timer tick mid-acquire must NOT delete the partial map.
+			// lastRequest is fresh (< MinInterval) so the timer skips this
+			// actively-progressing acquire and the entry survives untouched.
+			if !firedMidTick && step == 2 {
+				before := rs.calledN()
+				router.retryStalledTxSetAcquires()
+				require.Equal(t, before, rs.calledN(),
+					"timer must skip an actively-progressing acquire (fresh lastRequest)")
+				stAfter, stillTracked := stateSnapshot()
+				require.True(t, stillTracked,
+					"the partial map must SURVIVE a retryStalledTxSetAcquires tick mid-acquire")
+				require.Equal(t, 0, stAfter,
+					"a skipped timer tick must not accrue stall ticks on a progressing acquire")
+				firedMidTick = true
+			}
+
+			prev := rs.calledN()
+			router.handleTxSetData(serveMissing(ids, 256), 1)
+
+			// (a) Each progressing batch pipelines exactly one more request
+			// IMMEDIATELY, unless it completed the tree (then no re-request).
+			if !doneSnapshot() {
+				require.Equal(t, prev+1, rs.calledN(),
+					"each progressing batch must pipeline exactly one more request (no throttle)")
+				requestsAtLastProgress = rs.calledN()
+			}
+		}
+
+		// Completed: entry retained (done-latched), engine fed the full set once.
+		require.True(t, doneSnapshot(), "acquire must complete (done-latched, entry retained)")
+		require.True(t, firedMidTick, "the mid-acquire timer tick must have fired")
+
+		eng.mu.Lock()
+		gotSets := append([]consensus.TxSetID(nil), eng.txSets...)
+		eng.mu.Unlock()
+		require.Len(t, gotSets, 1, "the completed tx-set must reach the engine exactly once")
+		require.Equal(t, txSetID, gotSets[0], "the completed set ID must match")
+
+		// The acquire completed in ~#batches pipelined requests — far more
+		// than the single request a MinInterval throttle would have allowed.
+		require.Greater(t, requestsAtLastProgress, 5,
+			"pipelining must issue one request per progressing batch, not throttle to one")
+	})
+}
+
+// TestTxSetAcquire_DormantRetainsMapAndResumes pins property (d): after
+// MaxStallTicks consecutive no-progress timer ticks the acquire goes dormant
+// but its partial map is RETAINED (not deleted), and a subsequent
+// MarkTxSetStillNeeded + progressing reply resumes it from that partial map.
+// Mirrors rippled keeping mMap across retries and stillNeed() re-arming.
+func TestTxSetAcquire_DormantRetainsMapAndResumes(t *testing.T) {
+	router, rs, _ := newPipelineRouter(t)
+	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
+
+	const maxStall = 3
+	withRetryKnobs(router, 0, maxStall, 1_000_000, func() {
+		// Progress reply creates the acquire (root only → incomplete) and
+		// pipelines one request.
+		router.handleTxSetData(ld, 1)
+		require.Equal(t, 1, rs.calledN())
+
+		// No inbound progress arrives; consecutive timer ticks accrue stall
+		// ticks until the acquire goes dormant at MaxStallTicks.
+		for range maxStall {
+			router.retryStalledTxSetAcquires()
+		}
+
+		router.txSetAcquireMu.Lock()
+		state, tracked := router.txSetAcquire[txSetID]
+		var dormant, resumable bool
+		if tracked {
+			dormant = state.dormant
+			// Root present, children still missing → a resumable partial map.
+			resumable = len(state.txMap.GetMissingNodes(256, nil)) > 0
+		}
+		router.txSetAcquireMu.Unlock()
+		require.True(t, tracked, "dormant acquire must be RETAINED, not deleted")
+		require.True(t, dormant, "acquire must be dormant after MaxStallTicks consecutive stall ticks")
+		require.True(t, resumable, "the partial SHAMap must be retained for resume")
+
+		// While dormant, further timer ticks must not re-request.
+		nAtDormant := rs.calledN()
+		router.retryStalledTxSetAcquires()
+		require.Equal(t, nAtDormant, rs.calledN(), "a dormant acquire must not re-request")
+
+		// Re-arm: consensus re-asks (MarkTxSetStillNeeded) AND a progressing
+		// reply arrives. Together they must wake the acquire and resume
+		// pipelining from the retained partial map.
+		router.MarkTxSetStillNeeded(txSetID)
+		router.handleTxSetData(ld, 1)
+		require.Greater(t, rs.calledN(), nAtDormant,
+			"a re-armed dormant acquire must resume requesting from its retained partial map")
+
+		router.txSetAcquireMu.Lock()
+		state, tracked = router.txSetAcquire[txSetID]
+		stillDormant := tracked && state.dormant
+		stall := 0
+		if tracked {
+			stall = state.stallTicks
+		}
+		router.txSetAcquireMu.Unlock()
+		require.True(t, tracked)
+		require.False(t, stillDormant, "resuming must clear the dormant latch")
+		require.Equal(t, 0, stall, "resuming must reset the stall counter")
+	})
+}

--- a/internal/consensus/adaptor/router_txset_retry_test.go
+++ b/internal/consensus/adaptor/router_txset_retry_test.go
@@ -13,10 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// retryRecordingSender captures the per-call peer-exclusion set passed
-// to RequestTxSetMissingNodes so tests can pin issue #420's throttle,
-// max-attempts, and de-prioritization behavior. Other NetworkSender
-// methods inherit from noopSender.
+// retryRecordingSender captures every tx-set missing-nodes request — the
+// broadcast RequestTxSetMissingNodes (timer path) AND the unicast
+// RequestTxSetMissingNodesFromPeer (inbound pipeline) — into a single ordered
+// slice so tests can pin throttle, give-up, de-prioritization, and the
+// unicast-inline / broadcast-timer split. peerID is 0 for a broadcast and the
+// target peer for a unicast; excluded is populated only on broadcasts. Other
+// NetworkSender methods inherit from noopSender.
 type retryRecordingSender struct {
 	noopSender
 	mu        sync.Mutex
@@ -29,6 +32,7 @@ type retryRecordedCall struct {
 	nodeIDs  [][]byte
 	excluded map[uint64]bool
 	indirect bool
+	peerID   uint64
 }
 
 func (s *retryRecordingSender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [][]byte, excluded map[uint64]bool, indirect bool) error {
@@ -45,6 +49,22 @@ func (s *retryRecordingSender) RequestTxSetMissingNodes(id consensus.TxSetID, no
 		nodeIDs:  copyIDs,
 		excluded: copyExcluded,
 		indirect: indirect,
+	})
+	return s.returnErr
+}
+
+func (s *retryRecordingSender) RequestTxSetMissingNodesFromPeer(id consensus.TxSetID, nodeIDs [][]byte, peerID uint64, indirect bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	copyIDs := make([][]byte, len(nodeIDs))
+	for i, n := range nodeIDs {
+		copyIDs[i] = append([]byte(nil), n...)
+	}
+	s.calls = append(s.calls, retryRecordedCall{
+		txSetID:  id,
+		nodeIDs:  copyIDs,
+		indirect: indirect,
+		peerID:   peerID,
 	})
 	return s.returnErr
 }
@@ -123,80 +143,83 @@ func emptyTxSetLedgerData(txSetID consensus.TxSetID) *message.LedgerData {
 	}
 }
 
-// withRetryKnobs overrides this router's issue-#420 retry knobs for
+// withRetryKnobs overrides this router's tx-set acquire retry knobs for
 // the duration of fn so tests run instantly instead of waiting for the
-// production 250 ms throttle window. Restores prior values on return.
-func withRetryKnobs(router *Router, minInterval time.Duration, maxAttempts, peerThreshold int, fn func()) {
+// production 250 ms cadence window. Restores prior values on return.
+func withRetryKnobs(router *Router, minInterval time.Duration, maxStallTicks, peerThreshold int, fn func()) {
 	prev := router.txSetRetryKnobs
 	router.SetTxSetRetryKnobsForTest(txSetRetryKnobs{
 		MinInterval:              minInterval,
-		MaxAttempts:              maxAttempts,
+		MaxStallTicks:            maxStallTicks,
 		PeerNonProgressThreshold: peerThreshold,
 	})
 	defer router.SetTxSetRetryKnobsForTest(prev)
 	fn()
 }
 
-// TestTxSetRetry_ThrottleSkipsRapidRetries pins the rate limiter
-// (issue #420 item 2a). A peer that replies twice in quick succession
-// must not produce two broadcasts — the second falls inside the
-// minimum-interval window and is dropped. Without the throttle, every
-// non-progressing TMLedgerData spawns an immediate re-broadcast,
-// driving the 100+ retries/sec storm captured in the issue.
-func TestTxSetRetry_ThrottleSkipsRapidRetries(t *testing.T) {
+// TestTxSetRetry_NoProgressReplyDefersToTimer pins the pipelining-model
+// anti-storm guard. A PROGRESSING reply re-requests immediately (RTT is
+// the rate limiter), but a NON-progress reply must NOT re-request inline —
+// otherwise a junk/empty-reply peer amplifies into a broadcast storm. The
+// 250ms stall timer, not the inbound path, drives re-requests once a peer
+// goes quiet.
+func TestTxSetRetry_NoProgressReplyDefersToTimer(t *testing.T) {
 	router, rs := newRetryRouter(t)
-	withRetryKnobs(router, time.Hour, 100, 100, func() {
-		ld, _ := rootOnlyTxSetLedgerData(t, 4)
+	withRetryKnobs(router, 0, 1_000_000, 1_000_000, func() {
+		ld, txSetID := rootOnlyTxSetLedgerData(t, 4)
 
+		// A progressing (root) reply pipelines exactly one request.
 		router.handleTxSetData(ld, 1)
 		require.Equal(t, 1, rs.calledN(),
-			"first reply must trigger exactly one missing-nodes broadcast")
+			"a progressing reply must pipeline exactly one missing-nodes request")
 
-		router.handleTxSetData(ld, 1)
+		// An empty reply makes no progress → must NOT re-request inline.
+		router.handleTxSetData(emptyTxSetLedgerData(txSetID), 1)
 		assert.Equal(t, 1, rs.calledN(),
-			"second reply inside the throttle window must NOT trigger another broadcast — "+
-				"issue #420: without this, every non-progressing reply re-broadcasts immediately")
+			"a non-progress reply must defer to the stall timer, not re-request inline")
 	})
 }
 
-// TestTxSetRetry_MaxAttemptsCapDropsAcquire pins the give-up condition
-// (issue #420 item 2b). After MaxAttempts broadcasts the acquisition
-// is dropped: the cap-hit reply does NOT broadcast and the entry is
-// deleted. A later reply for the same tx-set ID re-arms a fresh
-// acquire — mirrors rippled's stillNeed reset path
-// (TransactionAcquire.cpp:256-264) so consensus oscillating back to
-// the same set isn't silenced for the full TTL window.
-func TestTxSetRetry_MaxAttemptsCapDropsAcquire(t *testing.T) {
+// TestTxSetRetry_InboundProgressNeverGivesUp pins that the inbound path
+// has NO give-up cap: give-up now lives solely on the stall timer, keyed
+// on consecutive no-progress ticks. Many progressing replies in a row each
+// pipeline a fresh request and never delete the acquire nor accrue stall
+// ticks — the pre-pipelining inbound MaxAttempts delete-on-cap is gone.
+func TestTxSetRetry_InboundProgressNeverGivesUp(t *testing.T) {
 	router, rs := newRetryRouter(t)
-	const maxAttempts = 3
-	withRetryKnobs(router, 0, maxAttempts, 1_000_000, func() {
-		ld, _ := rootOnlyTxSetLedgerData(t, 4)
+	// MaxStallTicks deliberately small: if the inbound path fed stall
+	// telemetry it would trip and delete the acquire.
+	withRetryKnobs(router, 0, 3, 1_000_000, func() {
+		ld, txSetID := rootOnlyTxSetLedgerData(t, 4)
 
-		for i := range maxAttempts {
+		const replies = 25
+		for i := range replies {
 			router.handleTxSetData(ld, uint64(i+1))
 		}
-		require.Equal(t, maxAttempts, rs.calledN(),
-			"each of the first maxAttempts replies must broadcast")
+		require.Equal(t, replies, rs.calledN(),
+			"every progressing inbound reply must pipeline a request — no inbound give-up cap")
 
-		// Reply at the cap: hits the delete-on-cap branch — no broadcast.
-		router.handleTxSetData(ld, 99)
-		require.Equal(t, maxAttempts, rs.calledN(),
-			"reply that hits the cap must NOT broadcast (delete-on-cap)")
-
-		// Subsequent reply re-creates state and broadcasts a fresh attempt.
-		router.handleTxSetData(ld, 100)
-		assert.Equal(t, maxAttempts+1, rs.calledN(),
-			"after the entry was dropped, the next reply must start a fresh acquire "+
-				"and broadcast again — matches rippled's stillNeed re-arm path")
+		router.txSetAcquireMu.Lock()
+		state, tracked := router.txSetAcquire[txSetID]
+		stall, dormant := 0, false
+		if tracked {
+			stall, dormant = state.stallTicks, state.dormant
+		}
+		router.txSetAcquireMu.Unlock()
+		require.True(t, tracked, "a progressing acquire is never deleted by the inbound path")
+		assert.Equal(t, 0, stall, "progressing replies keep stallTicks pinned at 0")
+		assert.False(t, dormant, "a progressing acquire never goes dormant")
 	})
 }
 
 // TestTxSetRetry_DeprioritizesNonProgressingPeer pins per-peer
-// exclusion (issue #420 item 2c). A peer that returns
-// PeerNonProgressThreshold non-progressing replies in a row is
-// dropped from the next missing-nodes broadcast via the excluded
-// map. Non-progress matches rippled's takeNodes invalid() branch:
-// a reply that adds neither root nor non-root nodes.
+// exclusion. A peer that returns PeerNonProgressThreshold
+// non-progressing replies in a row is dropped from the next
+// missing-nodes broadcast via the excluded map. Under the pipelining
+// model, non-progress replies no longer re-request inline (they defer
+// to the timer), so the exclusion surfaces on the timer's re-request.
+// Non-progress matches rippled's takeNodes invalid() branch: a reply
+// that adds neither root nor non-root nodes.
 func TestTxSetRetry_DeprioritizesNonProgressingPeer(t *testing.T) {
 	router, rs := newRetryRouter(t)
 	const threshold = 2
@@ -205,24 +228,23 @@ func TestTxSetRetry_DeprioritizesNonProgressingPeer(t *testing.T) {
 		noProgressLD := emptyTxSetLedgerData(txSetID)
 		const badPeer = uint64(7)
 
-		// Setup: root-only reply creates state. Root-add counts as
-		// progress (TransactionAcquire.cpp:194-226 useful() branch),
-		// so the per-peer counter stays at 0.
+		// Root-only reply creates state and pipelines one request (root add
+		// counts as progress, so the per-peer counter stays at 0).
 		router.handleTxSetData(ld, badPeer)
 		require.Equal(t, 1, rs.calledN())
 		assert.Empty(t, rs.lastCall().excluded,
 			"first broadcast must carry no exclusions")
 
-		// Non-progress reply 1 — counter[badPeer] = 1 (< threshold).
+		// Two non-progress replies bump counter[badPeer] to threshold.
+		// Neither re-requests inline (deferred to the timer).
 		router.handleTxSetData(noProgressLD, badPeer)
-		require.Equal(t, 2, rs.calledN())
-		assert.Empty(t, rs.lastCall().excluded,
-			"counter below threshold must not yet exclude the peer")
+		router.handleTxSetData(noProgressLD, badPeer)
+		require.Equal(t, 1, rs.calledN(),
+			"non-progress replies must not re-request inline")
 
-		// Non-progress reply 2 — counter[badPeer] = 2 (== threshold) →
-		// the broadcast for this retry must exclude badPeer.
-		router.handleTxSetData(noProgressLD, badPeer)
-		require.Equal(t, 3, rs.calledN())
+		// The stall timer now re-requests and must route around badPeer.
+		router.retryStalledTxSetAcquires()
+		require.Equal(t, 2, rs.calledN(), "timer re-requests once the peer goes quiet")
 		require.NotNil(t, rs.lastCall().excluded)
 		assert.Truef(t, rs.lastCall().excluded[badPeer],
 			"peer %d should be excluded once non-progress count reaches threshold (%d)",
@@ -233,7 +255,8 @@ func TestTxSetRetry_DeprioritizesNonProgressingPeer(t *testing.T) {
 // TestTxSetRetry_ProgressResetsNonProgressCounter pins that a peer
 // reply that DOES extend the SHAMap resets that peer's non-progress
 // counter, so a transient stretch of empty replies doesn't permanently
-// banish a recovered peer.
+// banish a recovered peer. The exclusion decision is observed on the
+// timer's re-request (the inbound non-progress path no longer broadcasts).
 func TestTxSetRetry_ProgressResetsNonProgressCounter(t *testing.T) {
 	router, rs := newRetryRouter(t)
 	const threshold = 2
@@ -242,25 +265,27 @@ func TestTxSetRetry_ProgressResetsNonProgressCounter(t *testing.T) {
 		noProgressLD := emptyTxSetLedgerData(txSetID)
 		const peer = uint64(11)
 
-		// Setup: root reply creates state (counts as progress).
+		// Root reply creates state (progress).
 		router.handleTxSetData(ld, peer)
 		require.Equal(t, 1, rs.calledN())
 
 		// Non-progress reply — counter[peer] = 1.
 		router.handleTxSetData(noProgressLD, peer)
-		require.Equal(t, 2, rs.calledN())
 
 		// Progress reply: same root (ErrRootAlreadySet still counts as
-		// rootAccepted=true per takeNodes useful() semantics) — resets
-		// counter[peer] to 0.
+		// rootAccepted=true) — resets counter[peer] to 0 and pipelines
+		// another request.
 		router.handleTxSetData(ld, peer)
-		require.Equal(t, 3, rs.calledN())
+		require.Equal(t, 2, rs.calledN())
 
-		// One further non-progress reply — counter[peer] = 1 again,
-		// still < threshold=2, peer must NOT be excluded.
+		// One further non-progress reply — counter[peer] = 1 again (< threshold).
 		router.handleTxSetData(noProgressLD, peer)
-		last := rs.lastCall()
-		assert.Falsef(t, last.excluded[peer],
+
+		// The timer re-requests; peer must NOT be excluded (1 < 2), proving
+		// the intervening progress reply reset the counter.
+		router.retryStalledTxSetAcquires()
+		require.Equal(t, 3, rs.calledN())
+		assert.Falsef(t, rs.lastCall().excluded[peer],
 			"progress reset the non-progress counter; one further empty reply "+
 				"should not be enough to exclude the peer")
 	})
@@ -299,61 +324,70 @@ func TestTxSetRetry_BadNonRootInvalidatesWholeReply(t *testing.T) {
 		}
 		const badPeer = uint64(42)
 
-		// Reply 1: root accepted but junk non-root → replyValid=false →
-		// counter[badPeer] = 1 (< threshold).
+		// Reply 1: root accepted but junk non-root → replyValid=false → the
+		// whole reply is non-progress. State is created (root added) but no
+		// inline re-request; counter[badPeer] = 1.
 		router.handleTxSetData(rootPlusJunkLD, badPeer)
-		require.Equal(t, 1, rs.calledN())
-		assert.Empty(t, rs.lastCall().excluded,
-			"first such reply must broadcast without exclusions yet")
+		require.Equal(t, 0, rs.calledN(),
+			"a junk-non-root reply is non-progress → no inline re-request")
 
-		// Reply 2: same shape → counter[badPeer] = 2 (== threshold) →
-		// the next broadcast must exclude badPeer. Pre-M1 the rootAccepted
-		// branch alone would have reset the counter to 0 on each reply,
-		// so this peer would never have been excluded.
+		// Reply 2: same shape → counter[badPeer] = 2 (== threshold).
 		router.handleTxSetData(rootPlusJunkLD, badPeer)
-		require.Equal(t, 2, rs.calledN())
+		require.Equal(t, 0, rs.calledN())
+
+		// The stall timer now re-requests and must exclude badPeer: the junk
+		// non-root invalidated the whole reply, so the root-add alone did NOT
+		// keep the counter pinned at zero.
+		router.retryStalledTxSetAcquires()
+		require.Equal(t, 1, rs.calledN())
 		require.NotNil(t, rs.lastCall().excluded,
-			"second bad-non-root reply must trigger per-peer exclusion")
+			"timer re-request after two bad-non-root replies must exclude the peer")
 		assert.Truef(t, rs.lastCall().excluded[badPeer],
-			"peer %d should be excluded — junk non-root must invalidate the whole reply "+
-				"per rippled's takeNodes useful() (TransactionAcquire.cpp:217-220), "+
+			"peer %d should be excluded — junk non-root must invalidate the whole reply, "+
 				"NOT count as progress just because the root was accepted",
 			badPeer)
 	})
 }
 
-// TestTxSetRetry_StillNeededReArmsAtCap pins the stillNeed re-arm
-// path (M3 from PR #454 review). Once an in-flight acquisition hits
-// MaxAttempts, the next inbound reply would normally drop into the
-// delete-on-cap branch. If consensus actively re-asks via
-// Adaptor.RequestTxSet (rippled's stillNeed trigger,
-// InboundTransactions.cpp:107-114 → TransactionAcquire.cpp:256-264)
-// BEFORE that drop happens, attempts must be reset so the acquisition
-// keeps broadcasting instead of waiting on the 60s TTL sweep.
-func TestTxSetRetry_StillNeededReArmsAtCap(t *testing.T) {
+// TestTxSetRetry_StillNeededReArmsDormantAcquire pins the stillNeed
+// re-arm at the new give-up boundary. Once the stall timer drives an
+// acquire dormant (MaxStallTicks consecutive no-progress ticks), it stops
+// re-requesting but KEEPS its partial map. A consensus re-ask
+// (Adaptor.RequestTxSet → MarkTxSetStillNeeded) must clear the dormant
+// latch so the very next timer tick resumes requesting instead of waiting
+// out the 60s TTL — mirrors rippled's stillNeed reset.
+func TestTxSetRetry_StillNeededReArmsDormantAcquire(t *testing.T) {
 	router, rs := newRetryRouter(t)
-	const maxAttempts = 2
-	withRetryKnobs(router, 0, maxAttempts, 1_000_000, func() {
+	const maxStall = 2
+	withRetryKnobs(router, 0, maxStall, 1_000_000, func() {
 		ld, txSetID := rootOnlyTxSetLedgerData(t, 4)
 
-		// Drive attempts up to the cap.
-		for i := range maxAttempts {
-			router.handleTxSetData(ld, uint64(i+1))
+		// Progress reply creates the acquire and pipelines one request.
+		router.handleTxSetData(ld, 1)
+		require.Equal(t, 1, rs.calledN())
+
+		// Drive consecutive no-progress timer ticks to dormancy.
+		for range maxStall {
+			router.retryStalledTxSetAcquires()
 		}
-		require.Equal(t, maxAttempts, rs.calledN(),
-			"each of the first maxAttempts replies must broadcast")
+		router.txSetAcquireMu.Lock()
+		state, tracked := router.txSetAcquire[txSetID]
+		dormant := tracked && state.dormant
+		router.txSetAcquireMu.Unlock()
+		require.True(t, tracked, "dormant acquire keeps its partial map (not deleted)")
+		require.True(t, dormant, "acquire must be dormant after MaxStallTicks stall ticks")
 
-		// stillNeed: consensus re-asks for the same set. With the wiring
-		// in place, this resets attempts and lastRequest on the entry.
+		nAtDormant := rs.calledN()
+		// While dormant a further timer tick must not re-request.
+		router.retryStalledTxSetAcquires()
+		require.Equal(t, nAtDormant, rs.calledN(), "dormant acquire must not re-request")
+
+		// stillNeed re-arm via consensus re-ask, then a timer tick resumes.
 		require.NoError(t, router.adaptor.RequestTxSet(txSetID))
-
-		// Next reply: pre-M3 this would have hit the cap and deleted the
-		// entry (no broadcast). With M3, attempts is back at 0 so the
-		// broadcast fires.
-		router.handleTxSetData(ld, 99)
-		assert.Equal(t, maxAttempts+1, rs.calledN(),
-			"after stillNeed re-arm, the next reply must broadcast instead "+
-				"of being silenced by the max-attempts cap")
+		router.retryStalledTxSetAcquires()
+		assert.Greater(t, rs.calledN(), nAtDormant,
+			"after stillNeed re-arm the next timer tick must resume requesting "+
+				"instead of being silenced until the TTL sweep")
 	})
 }
 

--- a/internal/consensus/adaptor/router_txset_rootgate_test.go
+++ b/internal/consensus/adaptor/router_txset_rootgate_test.go
@@ -1,0 +1,158 @@
+package adaptor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/stretchr/testify/require"
+)
+
+// ldFromWire builds a liTS_CANDIDATE reply carrying the given SHAMap wire nodes.
+func ldFromWire(txSetID [32]byte, nodes []shamap.WireNode) *message.LedgerData {
+	lns := make([]message.LedgerNode, 0, len(nodes))
+	for _, w := range nodes {
+		lns = append(lns, message.LedgerNode{NodeID: w.NodeID, NodeData: w.Data})
+	}
+	return &message.LedgerData{
+		InfoType:   message.LedgerInfoTsCandidate,
+		LedgerHash: txSetID[:],
+		Nodes:      lns,
+	}
+}
+
+// TestTxSetAcquire_RootlessReplyDoesNotCompleteEmpty pins the root-gate fix: a
+// reply carrying only NON-root nodes for a set we're not yet tracking must NOT
+// complete-empty (the bug: a fresh shamap.New has an empty root, FinishSync on
+// it "succeeds" with zero leaves → a bogus tx_count=0 completion + delete →
+// recreate storm). Instead the acquire is created rootless, the root is
+// requested (unicast to the replying peer), and the entry is RETAINED. Then
+// delivering the root + nodes completes it normally with the right tx_count.
+func TestTxSetAcquire_RootlessReplyDoesNotCompleteEmpty(t *testing.T) {
+	router, rs, eng := newPipelineRouter(t)
+	withRetryKnobs(router, time.Hour, 1_000_000, 1_000_000, func() {
+		_, rawID, wireNodes := buildTxSetForTest(t, 8)
+		require.Greater(t, len(wireNodes), 1, "fixture must have non-root nodes")
+		txSetID := consensus.TxSetID(rawID)
+
+		// Feed ONLY the non-root nodes (a missing-nodes reply for a set with no
+		// live acquire) from peer 7.
+		router.handleTxSetData(ldFromWire(rawID, wireNodes[1:]), 7)
+
+		// No completion: the engine must not have been fed an empty set.
+		eng.mu.Lock()
+		fedAfterRootless := len(eng.txSets)
+		eng.mu.Unlock()
+		require.Zero(t, fedAfterRootless,
+			"a rootless reply must not complete-empty and feed the engine")
+
+		// Acquire retained, rootless, not done, and the root was requested once
+		// (unicast to the replying peer).
+		router.txSetAcquireMu.Lock()
+		state, tracked := router.txSetAcquire[txSetID]
+		var haveRoot, done bool
+		if tracked {
+			haveRoot, done = state.haveRoot, state.done
+		}
+		router.txSetAcquireMu.Unlock()
+		require.True(t, tracked, "the acquire must be retained, not deleted")
+		require.False(t, haveRoot, "no root installed from a non-root-only reply")
+		require.False(t, done, "a rootless acquire must not be latched done")
+		require.Equal(t, 1, rs.calledN(), "the root must be requested exactly once")
+		require.Equal(t, uint64(7), rs.lastCall().peerID,
+			"the root request must be unicast to the replying peer")
+
+		// Now deliver root + all nodes → completes normally with the right count.
+		router.handleTxSetData(ldFromWire(rawID, wireNodes), 7)
+
+		eng.mu.Lock()
+		gotSets := append([]consensus.TxSetID(nil), eng.txSets...)
+		eng.mu.Unlock()
+		require.Len(t, gotSets, 1, "delivering the root + nodes must complete the acquire")
+		require.Equal(t, txSetID, gotSets[0], "the completed set ID must match")
+
+		router.txSetAcquireMu.Lock()
+		state, tracked = router.txSetAcquire[txSetID]
+		doneAfter := tracked && state.done
+		router.txSetAcquireMu.Unlock()
+		require.True(t, tracked, "a completed acquire is retained (done), not deleted")
+		require.True(t, doneAfter, "a completed acquire is latched done")
+	})
+}
+
+// TestTxSetAcquire_StragglerAfterDoneIsDropped pins the done-latch anti-storm
+// guard: once an acquire completes it is retained as done, and any further
+// straggler reply for that set is DROPPED — no engine re-feed, no re-request,
+// no fresh acquire. This is the fix for the 860×/25ms recreate storm.
+func TestTxSetAcquire_StragglerAfterDoneIsDropped(t *testing.T) {
+	router, rs, eng := newPipelineRouter(t)
+	withRetryKnobs(router, time.Hour, 1_000_000, 1_000_000, func() {
+		_, rawID, wireNodes := buildTxSetForTest(t, 8)
+		txSetID := consensus.TxSetID(rawID)
+		completeLD := ldFromWire(rawID, wireNodes)
+
+		// Complete the acquire in one reply.
+		router.handleTxSetData(completeLD, 1)
+		eng.mu.Lock()
+		require.Len(t, eng.txSets, 1, "the set must complete and feed the engine once")
+		eng.mu.Unlock()
+
+		nAfterComplete := rs.calledN()
+		router.txSetAcquireMu.Lock()
+		state, tracked := router.txSetAcquire[txSetID]
+		done := tracked && state.done
+		router.txSetAcquireMu.Unlock()
+		require.True(t, tracked, "a completed acquire is retained as done")
+		require.True(t, done)
+
+		// A burst of straggler replies (both a full re-send and empty replies)
+		// for the finished set must all be dropped.
+		for range 50 {
+			router.handleTxSetData(completeLD, 2)
+			router.handleTxSetData(emptyTxSetLedgerData(txSetID), 3)
+		}
+		eng.mu.Lock()
+		require.Len(t, eng.txSets, 1, "stragglers must not re-feed the engine")
+		eng.mu.Unlock()
+		require.Equal(t, nAfterComplete, rs.calledN(),
+			"stragglers for a done acquire must not trigger re-requests")
+
+		// The entry is the same one (not recreated).
+		router.txSetAcquireMu.Lock()
+		state2, tracked2 := router.txSetAcquire[txSetID]
+		router.txSetAcquireMu.Unlock()
+		require.True(t, tracked2)
+		require.Same(t, state, state2, "no fresh acquire was created for the finished set")
+	})
+}
+
+// TestTxSetAcquire_DuplicateOnlyReplyDoesNotReRequest pins that only a fresh
+// attach (NodeUseful) counts as progress: a reply that re-sends nodes the map
+// already holds (all NodeDuplicate, no root) makes no progress and must NOT
+// pipeline a re-request — otherwise a peer replaying fat nodes keeps firing
+// requests (the 70f35035 regression).
+func TestTxSetAcquire_DuplicateOnlyReplyDoesNotReRequest(t *testing.T) {
+	router, rs, _ := newPipelineRouter(t)
+	withRetryKnobs(router, time.Hour, 1_000_000, 1_000_000, func() {
+		_, rawID, wireNodes := buildTxSetForTest(t, 16)
+		require.Greater(t, len(wireNodes), 2, "fixture must have a root and >=2 non-root nodes")
+		root := wireNodes[0]
+		firstNonRoot := wireNodes[1]
+
+		// Root reply → progress (installs the root) → pipelines one request.
+		router.handleTxSetData(ldFromWire(rawID, []shamap.WireNode{root}), 1)
+		require.Equal(t, 1, rs.calledN(), "a root reply pipelines one request")
+
+		// A reply carrying one fresh non-root node → progress → one more request.
+		router.handleTxSetData(ldFromWire(rawID, []shamap.WireNode{firstNonRoot}), 1)
+		require.Equal(t, 2, rs.calledN(), "a fresh non-root node pipelines one more request")
+
+		// Re-deliver the SAME non-root node (all NodeDuplicate, no root): nothing
+		// is added, so it is not progress and must NOT re-request.
+		router.handleTxSetData(ldFromWire(rawID, []shamap.WireNode{firstNonRoot}), 1)
+		require.Equal(t, 2, rs.calledN(),
+			"a duplicate-only reply makes no progress and must not re-request")
+	})
+}

--- a/internal/consensus/adaptor/router_txset_timer_test.go
+++ b/internal/consensus/adaptor/router_txset_timer_test.go
@@ -61,29 +61,35 @@ func TestTxSetAcquire_TimerRespectsMinInterval(t *testing.T) {
 	})
 }
 
-// Once the attempt cap is reached with no progress, the timer drops the
-// acquire instead of spinning forever (mirrors the inbound max-attempts path
-// and rippled's MAX_TIMEOUTS).
-func TestTxSetAcquire_TimerDropsAtMaxAttempts(t *testing.T) {
+// Once MaxStallTicks consecutive no-progress ticks elapse, the timer stops
+// re-requesting and marks the acquire dormant — but KEEPS its partial map,
+// unlike the pre-pipelining model which deleted it. The retained map lets a
+// consensus re-ask resume from where it left off; the TTL sweep reclaims a
+// truly-abandoned entry (rippled's TransactionAcquire keeps mMap across
+// retries and fails only after MAX_TIMEOUTS).
+func TestTxSetAcquire_TimerGoesDormantAtMaxStallTicks(t *testing.T) {
 	router, rs := newRetryRouter(t)
 	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
 
 	withRetryKnobs(router, 0, 3, 3, func() {
 		router.handleTxSetData(ld, 4)
-		// Drive ticks well past the cap; the acquire must be dropped and
-		// re-requests must stop.
+		// Drive ticks well past the stall cap; the acquire must go dormant
+		// (retained, not deleted) and re-requests must stop.
 		for range 10 {
 			router.maintenanceTick()
 		}
 		router.txSetAcquireMu.Lock()
-		_, stillTracked := router.txSetAcquire[txSetID]
+		state, stillTracked := router.txSetAcquire[txSetID]
+		dormant := stillTracked && state.dormant
 		router.txSetAcquireMu.Unlock()
-		require.False(t, stillTracked, "acquire must be dropped after exceeding MaxAttempts")
+		require.True(t, stillTracked,
+			"acquire must be RETAINED (partial map kept) after going dormant, not deleted")
+		require.True(t, dormant, "acquire must be dormant after MaxStallTicks stall ticks")
 
-		// No further re-requests once dropped.
+		// No further re-requests once dormant.
 		n := rs.calledN()
 		router.maintenanceTick()
-		require.Equal(t, n, rs.calledN(), "no re-requests after the acquire is dropped")
+		require.Equal(t, n, rs.calledN(), "no re-requests after the acquire goes dormant")
 	})
 }
 
@@ -113,35 +119,57 @@ func TestTxSetAcquire_TimerStaysOutWhileInboundFresh(t *testing.T) {
 	})
 }
 
-// A timer drop is revivable, not terminal: after the timer drops an acquire at
-// the attempt cap, a fresh inbound TMLedgerData for the same tx-set must
-// re-create the acquire and resume requesting — mirroring rippled's stillNeed
-// reset path (TransactionAcquire.cpp:256-264). Without this, consensus
-// oscillating back to a dropped set would wait out the 60s TTL.
-func TestTxSetAcquire_TimerDropIsRevivableByInbound(t *testing.T) {
+// A given-up acquire is terminal to stragglers but revivable by consensus:
+// after the timer drives it dormant (and latches it done), a straggler
+// TMLedgerData for the same tx-set is DROPPED — it must not revive the acquire
+// nor trigger a re-request (that recreate/re-request churn is what wedged the
+// network). Only a consensus re-ask (MarkTxSetStillNeeded) clears the latch,
+// after which the RETAINED partial map resumes — mirroring rippled's failed_
+// latch that only stillNeed() clears.
+func TestTxSetAcquire_GivenUpAcquireDropsStragglerRevivableByStillNeed(t *testing.T) {
 	router, rs := newRetryRouter(t)
 	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
 
 	withRetryKnobs(router, 0, 3, 3, func() {
-		// Create the acquire, then drive ticks past the cap to drop it.
+		// Create the acquire, then drive ticks past the stall cap to dormancy.
 		router.handleTxSetData(ld, 4)
 		for range 10 {
 			router.maintenanceTick()
 		}
 		router.txSetAcquireMu.Lock()
-		_, tracked := router.txSetAcquire[txSetID]
+		state, tracked := router.txSetAcquire[txSetID]
+		dormant := tracked && state.dormant
+		done := tracked && state.done
 		router.txSetAcquireMu.Unlock()
-		require.False(t, tracked, "acquire must be dropped by the timer after exceeding MaxAttempts")
+		require.True(t, tracked, "given-up acquire keeps its partial map (not deleted)")
+		require.True(t, dormant, "acquire must be dormant after exceeding MaxStallTicks")
+		require.True(t, done, "a given-up acquire is latched terminal so stragglers are dropped")
 
 		n := rs.calledN()
 
-		// A fresh inbound reply re-creates the acquire and broadcasts again.
+		// A straggler reply for the given-up set must be dropped: no revive, no
+		// re-request.
 		router.handleTxSetData(ld, 5)
-		require.Greater(t, rs.calledN(), n,
-			"a fresh inbound reply after a timer drop must re-create the acquire and resume requesting")
+		require.Equal(t, n, rs.calledN(),
+			"a straggler for a given-up acquire must be dropped, not re-request")
 		router.txSetAcquireMu.Lock()
-		_, tracked = router.txSetAcquire[txSetID]
+		state, tracked = router.txSetAcquire[txSetID]
+		stillDormant := tracked && state.dormant
 		router.txSetAcquireMu.Unlock()
-		require.True(t, tracked, "the acquire is tracked again after the reviving inbound reply")
+		require.True(t, tracked, "the acquire remains tracked after the dropped straggler")
+		require.True(t, stillDormant, "a straggler must not revive a given-up acquire")
+
+		// Consensus re-asks (stillNeed): the acquire wakes and the next timer
+		// tick resumes requesting from the retained partial map.
+		router.MarkTxSetStillNeeded(txSetID)
+		router.maintenanceTick()
+		require.Greater(t, rs.calledN(), n,
+			"after a stillNeed re-ask the acquire resumes from its retained map")
+		router.txSetAcquireMu.Lock()
+		state, tracked = router.txSetAcquire[txSetID]
+		revivedDormant := tracked && state.dormant
+		router.txSetAcquireMu.Unlock()
+		require.True(t, tracked, "the acquire remains tracked after revival")
+		require.False(t, revivedDormant, "stillNeed must clear the dormant latch")
 	})
 }

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -146,12 +146,9 @@ func (s *OverlaySender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [
 	return s.overlay.BroadcastExceptSet(skip, frame)
 }
 
-// RequestTxSetMissingNodesFromPeer is the unicast counterpart of
-// RequestTxSetMissingNodes: the request goes only to the single replying peer.
-// The inbound acquire pipeline uses it so a progressing reply re-requests from
-// the peer that just served (mirrors rippled trigger(peer)); the broadcast
-// variant stays the timer's stalled-acquire fallback. nodeIDs may carry the
-// 33-byte zero root ID to (re)fetch the root. indirect sets query_type=qtINDIRECT.
+// RequestTxSetMissingNodesFromPeer unicasts the missing-nodes request to the
+// single replying peer (see the NetworkSender interface doc). indirect sets
+// query_type=qtINDIRECT.
 func (s *OverlaySender) RequestTxSetMissingNodesFromPeer(id consensus.TxSetID, nodeIDs [][]byte, peerID uint64, indirect bool) error {
 	if len(nodeIDs) == 0 {
 		return fmt.Errorf("RequestTxSetMissingNodesFromPeer: nodeIDs must be non-empty")

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -146,6 +146,30 @@ func (s *OverlaySender) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs [
 	return s.overlay.BroadcastExceptSet(skip, frame)
 }
 
+// RequestTxSetMissingNodesFromPeer is the unicast counterpart of
+// RequestTxSetMissingNodes: the request goes only to the single replying peer.
+// The inbound acquire pipeline uses it so a progressing reply re-requests from
+// the peer that just served (mirrors rippled trigger(peer)); the broadcast
+// variant stays the timer's stalled-acquire fallback. nodeIDs may carry the
+// 33-byte zero root ID to (re)fetch the root. indirect sets query_type=qtINDIRECT.
+func (s *OverlaySender) RequestTxSetMissingNodesFromPeer(id consensus.TxSetID, nodeIDs [][]byte, peerID uint64, indirect bool) error {
+	if len(nodeIDs) == 0 {
+		return fmt.Errorf("RequestTxSetMissingNodesFromPeer: nodeIDs must be non-empty")
+	}
+	msg := &message.GetLedger{
+		InfoType:   message.LedgerInfoTsCandidate,
+		LedgerHash: id[:],
+		QueryDepth: 3,
+		NodeIDs:    nodeIDs,
+		QueryType:  indirectQueryType(indirect),
+	}
+	frame, err := encodeFrame(message.TypeGetLedger, msg)
+	if err != nil {
+		return fmt.Errorf("encode txset missing-nodes (unicast) request: %w", err)
+	}
+	return s.overlay.Send(peermanagement.PeerID(peerID), frame)
+}
+
 func (s *OverlaySender) BroadcastStatusChange(sc *message.StatusChange) error {
 	frame, err := encodeFrame(message.TypeStatusChange, sc)
 	if err != nil {

--- a/internal/consensus/adaptor/sender_cov_test.go
+++ b/internal/consensus/adaptor/sender_cov_test.go
@@ -78,6 +78,10 @@ func (f *snd_fakeOverlay) RequestTxSetMissingNodes(id consensus.TxSetID, nodeIDs
 	return nil
 }
 
+func (f *snd_fakeOverlay) RequestTxSetMissingNodesFromPeer(id consensus.TxSetID, nodeIDs [][]byte, peerID uint64, indirect bool) error {
+	return nil
+}
+
 func (f *snd_fakeOverlay) RequestLedger(id consensus.LedgerID) error {
 	return nil
 }

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -331,11 +331,13 @@ func NewFromConfig(
 	// proposing, so wrongLedger needs to demote opMode.
 	engine.Subscribe(modeManager)
 
-	// Consensus/acquisition frames arrive on overlay.Messages();
-	// transactions arrive on the separate overlay.TxMessages() lane so a
-	// tx flood can't starve them.
+	// Consensus frames arrive on overlay.Messages(); transactions arrive on
+	// the separate overlay.TxMessages() lane and acquisition replies on
+	// overlay.LedgerDataMessages(), so neither a tx flood nor a serve flood
+	// can starve a reply this node explicitly requested.
 	router := NewRouter(engine, adaptor, overlay.Messages())
 	router.SetTxInbox(overlay.TxMessages())
+	router.SetAcqInbox(overlay.LedgerDataMessages())
 	router.SetManifestCache(manifestCache, overlay)
 	router.SetMinimumOnlineFloor(floor)
 

--- a/internal/consensus/adaptor/txset.go
+++ b/internal/consensus/adaptor/txset.go
@@ -36,12 +36,13 @@ import (
 //
 // Aliasing. shamap() (package-internal) exposes the live backing map.
 // Add and Remove mutate it in place — there is no copy-on-write. The
-// only production caller (router.go serveTxSet) takes the pointer and
-// walks it synchronously, so the aliasing is dormant. A snapshot on
-// every round-trip would avoid it but requires O(1) SHAMap COW, which
-// the unbacked path here does not yet have (Snapshot does a deep
-// clone). The accessor stays unexported so the aliasing concern cannot
-// leak out of this package.
+// production caller (router.go serveTxSet, now driven by concurrent serve-pool
+// workers) only reads the pointer, and it walks a cached set that is never
+// mutated in place while served — SHAMap reads are themselves lock-protected —
+// so the aliasing stays dormant. A snapshot on every round-trip would avoid it
+// but requires O(1) SHAMap COW, which the unbacked path here does not yet have
+// (Snapshot does a deep clone). The accessor stays unexported so the aliasing
+// concern cannot leak out of this package.
 //
 // Concurrency. The backing *shamap.SHAMap is internally lock-protected,
 // but TxSetImpl maintains a shadow `count` field for O(1) Size(); the

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -23,10 +23,10 @@ const (
 
 	// DefaultLedgerDataBufferSize sizes the dedicated acquisition-reply
 	// lane (mtLEDGER_DATA and the replay-delta / proof-path responses). It
-	// is generous on purpose: the lane is drained preferentially so a reply
-	// this node explicitly requested is never shed behind a serve/propose
-	// flood on the shared messages channel. Overflow still sheds, but bumps
-	// droppedLedgerData so any residual loss is visible.
+	// is generous on purpose: its own lane keeps a reply this node explicitly
+	// requested from being shed behind a serve/propose flood on the shared
+	// messages channel. Overflow still sheds, but bumps droppedLedgerData so
+	// any residual loss is visible.
 	DefaultLedgerDataBufferSize = 1024
 
 	// DefaultMaxTransactions is the per-type in-flight ceiling

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -21,6 +21,14 @@ const (
 	DefaultMessageBufferSize = 256
 	DefaultSendBufferSize    = 64
 
+	// DefaultLedgerDataBufferSize sizes the dedicated acquisition-reply
+	// lane (mtLEDGER_DATA and the replay-delta / proof-path responses). It
+	// is generous on purpose: the lane is drained preferentially so a reply
+	// this node explicitly requested is never shed behind a serve/propose
+	// flood on the shared messages channel. Overflow still sheds, but bumps
+	// droppedLedgerData so any residual loss is visible.
+	DefaultLedgerDataBufferSize = 1024
+
 	// DefaultMaxTransactions is the per-type in-flight ceiling
 	// consulted at TMTransaction ingress before dispatching to the
 	// router. Matches rippled's [max_transactions] default.

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1290,15 +1290,16 @@ func (o *Overlay) DroppedTransactions() uint64 {
 
 // forwardLedgerData hands an acquisition reply to the dedicated ledgerData
 // lane. The lane is generously sized, so this sheds only under extreme
-// outstanding-request volume; a shed frame bumps droppedLedgerData (visible)
+// outstanding-request volume; a shed frame warns and bumps droppedLedgerData,
 // and the acquisition's own retry timer re-requests the missing nodes, so it
-// is recoverable.
+// is recoverable. Losing a reply this node explicitly requested is notable
+// (it can stall catch-up), so this warns rather than logs at debug.
 func (o *Overlay) forwardLedgerData(msg *InboundMessage) {
 	select {
 	case o.ledgerData <- msg:
 	default:
 		o.droppedLedgerData.Add(1)
-		slog.Debug("Ledger-data lane full", "t", "Overlay",
+		slog.Warn("Ledger-data lane full", "t", "Overlay",
 			"pending", len(o.ledgerData), "max", cap(o.ledgerData), "peer", msg.PeerID)
 	}
 }

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -120,6 +120,15 @@ type Overlay struct {
 	messages   chan *InboundMessage
 	txMessages chan *InboundMessage
 
+	// ledgerData carries acquisition replies (mtLEDGER_DATA and the
+	// replay-delta / proof-path responses) on their own lane, drained
+	// preferentially by the router so a serve/propose/validation flood on
+	// the shared messages channel can't shed a reply THIS node explicitly
+	// requested and wedge an inbound-ledger acquisition. Generously sized
+	// (DefaultLedgerDataBufferSize); on overflow the frame is still shed,
+	// but droppedLedgerData counts it so residual loss stays visible.
+	ledgerData chan *InboundMessage
+
 	// serveJobs carries heavy inbound serve work (fetch-pack, generic
 	// get-objects, tx back-fill) off the event-loop goroutine onto a
 	// bounded worker pool, so a single expensive serve can't stall ping
@@ -204,6 +213,11 @@ type Overlay struct {
 	// covering both wire frames and inner frames fanned out from a
 	// TMTransactions batch. Surfaced via server_info as jq_trans_overflow.
 	droppedTransactions atomic.Uint64
+
+	// droppedLedgerData counts acquisition replies shed because the
+	// ledgerData lane was full — visible evidence of residual loss on the
+	// preferentially-drained lane under extreme outstanding-request volume.
+	droppedLedgerData atomic.Uint64
 
 	// Transaction reduce-relay rolling-average metrics surfaced by the
 	// tx_reduce_relay RPC. Inbound tx-relay-related messages are
@@ -757,6 +771,7 @@ func New(opts ...Option) (*Overlay, error) {
 		events:          events,
 		messages:        make(chan *InboundMessage, messageBufferSize(cfg.MessageBufferSize)),
 		txMessages:      make(chan *InboundMessage, txLaneBufferSize(cfg.MaxTransactions)),
+		ledgerData:      make(chan *InboundMessage, DefaultLedgerDataBufferSize),
 		lifecycle:       make(chan Event, lifecycleBufferSize(&cfg)),
 		stopCh:          make(chan struct{}),
 		relayedIndex:    make(map[[32]byte]*relayedEntry),
@@ -1218,6 +1233,21 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		return
 	}
 
+	// Acquisition replies ride a dedicated, preferentially-drained lane so a
+	// serve/propose/validation flood on the shared messages channel can't
+	// shed a reply this node explicitly requested and wedge catch-up. The
+	// replay-delta / proof-path responses already passed their feature gate
+	// above.
+	switch msgType {
+	case message.TypeLedgerData, message.TypeReplayDeltaResponse, message.TypeProofPathResponse:
+		o.forwardLedgerData(&InboundMessage{
+			PeerID:  evt.PeerID,
+			Type:    evt.MessageType,
+			Payload: evt.Payload,
+		})
+		return
+	}
+
 	// Forward consensus/acquisition frames. On back-pressure (channel
 	// full), increment a visible counter rather than silently dropping —
 	// the warn log alone is easy to miss at production log levels.
@@ -1256,6 +1286,27 @@ func (o *Overlay) forwardTransaction(msg *InboundMessage) {
 // server_info as jq_trans_overflow.
 func (o *Overlay) DroppedTransactions() uint64 {
 	return o.droppedTransactions.Load()
+}
+
+// forwardLedgerData hands an acquisition reply to the dedicated ledgerData
+// lane. The lane is generously sized and drained preferentially, so this
+// sheds only under extreme outstanding-request volume; a shed frame bumps
+// droppedLedgerData (visible) and the acquisition's own retry timer
+// re-requests the missing nodes, so it is recoverable.
+func (o *Overlay) forwardLedgerData(msg *InboundMessage) {
+	select {
+	case o.ledgerData <- msg:
+	default:
+		o.droppedLedgerData.Add(1)
+		slog.Debug("Ledger-data lane full", "t", "Overlay",
+			"pending", len(o.ledgerData), "max", cap(o.ledgerData), "peer", msg.PeerID)
+	}
+}
+
+// DroppedLedgerData returns the cumulative count of acquisition replies
+// shed because the dedicated ledgerData lane was full.
+func (o *Overlay) DroppedLedgerData() uint64 {
+	return o.droppedLedgerData.Load()
 }
 
 // DroppedMessages returns the cumulative count of inbound messages the
@@ -1958,6 +2009,14 @@ func (o *Overlay) Messages() <-chan *InboundMessage {
 // consensus/acquisition traffic (issue #1103).
 func (o *Overlay) TxMessages() <-chan *InboundMessage {
 	return o.txMessages
+}
+
+// LedgerDataMessages returns the dedicated acquisition-reply lane
+// (mtLEDGER_DATA and the replay-delta / proof-path responses). The router
+// drains it preferentially so a reply this node requested is never shed
+// behind a serve/propose flood on the shared Messages channel.
+func (o *Overlay) LedgerDataMessages() <-chan *InboundMessage {
+	return o.ledgerData
 }
 
 // Identity returns the node's identity.

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -121,12 +121,12 @@ type Overlay struct {
 	txMessages chan *InboundMessage
 
 	// ledgerData carries acquisition replies (mtLEDGER_DATA and the
-	// replay-delta / proof-path responses) on their own lane, drained
-	// preferentially by the router so a serve/propose/validation flood on
-	// the shared messages channel can't shed a reply THIS node explicitly
-	// requested and wedge an inbound-ledger acquisition. Generously sized
-	// (DefaultLedgerDataBufferSize); on overflow the frame is still shed,
-	// but droppedLedgerData counts it so residual loss stays visible.
+	// replay-delta / proof-path responses) on their own lane so a
+	// serve/propose/validation flood on the shared messages channel can't
+	// shed a reply THIS node explicitly requested and wedge an inbound-ledger
+	// acquisition. Generously sized (DefaultLedgerDataBufferSize); on overflow
+	// the frame is still shed, but droppedLedgerData counts it so residual
+	// loss stays visible.
 	ledgerData chan *InboundMessage
 
 	// serveJobs carries heavy inbound serve work (fetch-pack, generic
@@ -215,8 +215,8 @@ type Overlay struct {
 	droppedTransactions atomic.Uint64
 
 	// droppedLedgerData counts acquisition replies shed because the
-	// ledgerData lane was full — visible evidence of residual loss on the
-	// preferentially-drained lane under extreme outstanding-request volume.
+	// ledgerData lane was full — evidence of residual loss on the dedicated
+	// lane under extreme outstanding-request volume.
 	droppedLedgerData atomic.Uint64
 
 	// Transaction reduce-relay rolling-average metrics surfaced by the
@@ -1233,7 +1233,7 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		return
 	}
 
-	// Acquisition replies ride a dedicated, preferentially-drained lane so a
+	// Acquisition replies ride a dedicated lane so a
 	// serve/propose/validation flood on the shared messages channel can't
 	// shed a reply this node explicitly requested and wedge catch-up. The
 	// replay-delta / proof-path responses already passed their feature gate
@@ -1289,10 +1289,10 @@ func (o *Overlay) DroppedTransactions() uint64 {
 }
 
 // forwardLedgerData hands an acquisition reply to the dedicated ledgerData
-// lane. The lane is generously sized and drained preferentially, so this
-// sheds only under extreme outstanding-request volume; a shed frame bumps
-// droppedLedgerData (visible) and the acquisition's own retry timer
-// re-requests the missing nodes, so it is recoverable.
+// lane. The lane is generously sized, so this sheds only under extreme
+// outstanding-request volume; a shed frame bumps droppedLedgerData (visible)
+// and the acquisition's own retry timer re-requests the missing nodes, so it
+// is recoverable.
 func (o *Overlay) forwardLedgerData(msg *InboundMessage) {
 	select {
 	case o.ledgerData <- msg:
@@ -2012,9 +2012,9 @@ func (o *Overlay) TxMessages() <-chan *InboundMessage {
 }
 
 // LedgerDataMessages returns the dedicated acquisition-reply lane
-// (mtLEDGER_DATA and the replay-delta / proof-path responses). The router
-// drains it preferentially so a reply this node requested is never shed
-// behind a serve/propose flood on the shared Messages channel.
+// (mtLEDGER_DATA and the replay-delta / proof-path responses). Its own lane
+// keeps a reply this node requested from being shed behind a serve/propose
+// flood on the shared Messages channel.
 func (o *Overlay) LedgerDataMessages() <-chan *InboundMessage {
 	return o.ledgerData
 }

--- a/internal/peermanagement/tx_ingress_test.go
+++ b/internal/peermanagement/tx_ingress_test.go
@@ -11,14 +11,15 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 )
 
-// newLaneTestOverlay builds a bare Overlay with just the two inbound
-// lanes wired, sized for ingress-routing tests. The zero-value cfg
-// leaves reduce-relay metrics off so onMessageReceived takes the plain
-// forward path.
-func newLaneTestOverlay(consensusCap, txCap int) *Overlay {
+// newLaneTestOverlay builds a bare Overlay with the three inbound lanes
+// wired, sized for ingress-routing tests. The zero-value cfg leaves
+// reduce-relay metrics off so onMessageReceived takes the plain forward
+// path.
+func newLaneTestOverlay(consensusCap, txCap, ledgerDataCap int) *Overlay {
 	return &Overlay{
 		messages:   make(chan *InboundMessage, consensusCap),
 		txMessages: make(chan *InboundMessage, txCap),
+		ledgerData: make(chan *InboundMessage, ledgerDataCap),
 	}
 }
 
@@ -30,7 +31,7 @@ func TestOverlay_TxLane_BoundedByCapacity(t *testing.T) {
 	const txCap = 4
 	const flooded = 64
 
-	o := newLaneTestOverlay(32, txCap)
+	o := newLaneTestOverlay(32, txCap, 8)
 
 	for range flooded {
 		o.onMessageReceived(Event{
@@ -56,14 +57,12 @@ func TestOverlay_TxLane_BoundedByCapacity(t *testing.T) {
 
 // TestOverlay_TxFlood_DoesNotStarveConsensusLane is the core #1103
 // regression: a transaction flood that saturates the tx lane must not
-// cause consensus/acquisition frames (mtLEDGER_DATA/mtPROPOSE/mtVALIDATION)
-// to be dropped. Before the lane split these shared a single 256-slot
-// channel with the 250-frame tx ceiling, leaving ~6 slots for everything
-// else; a tx flood filled it and the next ledger-data reply was dropped,
-// which got the node resource-disconnected by its rippled peer.
+// cause consensus frames (mtPROPOSE/mtVALIDATION) or acquisition replies
+// (mtLEDGER_DATA) to be dropped. Each rides its own lane, so a saturated
+// tx lane leaves both untouched.
 func TestOverlay_TxFlood_DoesNotStarveConsensusLane(t *testing.T) {
-	// Tiny tx lane, easily saturated; consensus lane has its own room.
-	o := newLaneTestOverlay(8, 2)
+	// Tiny tx lane, easily saturated; the other lanes have their own room.
+	o := newLaneTestOverlay(8, 2, 8)
 
 	// Saturate the tx lane well past capacity.
 	for range 1000 {
@@ -78,9 +77,8 @@ func TestOverlay_TxFlood_DoesNotStarveConsensusLane(t *testing.T) {
 	require.Greater(t, o.DroppedTransactions(), uint64(0),
 		"flood must have shed transactions")
 
-	// Now a consensus/acquisition frame must still get through.
+	// Proposals and validations still reach the consensus lane.
 	for _, mt := range []message.MessageType{
-		message.TypeLedgerData,
 		message.TypeProposeLedger,
 		message.TypeValidation,
 	} {
@@ -91,20 +89,61 @@ func TestOverlay_TxFlood_DoesNotStarveConsensusLane(t *testing.T) {
 			Payload:     []byte{0x00},
 		})
 	}
+	// Acquisition replies still reach their dedicated lane.
+	o.onMessageReceived(Event{
+		Type:        EventMessageReceived,
+		PeerID:      PeerID(1),
+		MessageType: uint16(message.TypeLedgerData),
+		Payload:     []byte{0x00},
+	})
 
-	assert.Equal(t, 3, len(o.messages),
-		"consensus/acquisition frames must reach the consensus lane despite the tx flood")
+	assert.Equal(t, 2, len(o.messages),
+		"proposals/validations must reach the consensus lane despite the tx flood")
+	assert.Equal(t, 1, len(o.ledgerData),
+		"acquisition replies must reach the dedicated lane despite the tx flood")
 	assert.Equal(t, uint64(0), o.DroppedMessages(),
 		"no consensus frame may be dropped while only the tx lane is saturated")
+	assert.Equal(t, uint64(0), o.DroppedLedgerData(),
+		"no acquisition reply may be dropped while only the tx lane is saturated")
 }
 
 // TestOverlay_NonTxUsesConsensusLane confirms the counters stay
-// class-specific: a non-tx frame that overflows the consensus lane bumps
-// droppedMessages and never touches droppedTransactions, so the
-// jq_trans_overflow signal isn't polluted by unrelated traffic. The tx
-// lane stays empty.
+// class-specific: a consensus frame (mtPROPOSE) that overflows the
+// consensus lane bumps droppedMessages and never touches
+// droppedTransactions or droppedLedgerData, so the jq_trans_overflow signal
+// isn't polluted by unrelated traffic. The tx and acquisition lanes stay
+// empty.
 func TestOverlay_NonTxUsesConsensusLane(t *testing.T) {
-	o := newLaneTestOverlay(1, 8)
+	o := newLaneTestOverlay(1, 8, 8)
+
+	for range 4 {
+		o.onMessageReceived(Event{
+			Type:        EventMessageReceived,
+			PeerID:      PeerID(1),
+			MessageType: uint16(message.TypeProposeLedger),
+			Payload:     []byte{0x00},
+		})
+	}
+
+	assert.Greater(t, o.DroppedMessages(), uint64(0),
+		"DroppedMessages must record consensus-lane overflow")
+	assert.Equal(t, uint64(0), o.DroppedTransactions(),
+		"DroppedTransactions must not move when only consensus frames overflow")
+	assert.Equal(t, uint64(0), o.DroppedLedgerData(),
+		"DroppedLedgerData must not move when only consensus frames overflow")
+	assert.Equal(t, 0, len(o.txMessages),
+		"consensus traffic must never reach the tx lane")
+	assert.Equal(t, 0, len(o.ledgerData),
+		"consensus traffic must never reach the acquisition lane")
+}
+
+// TestOverlay_AcquisitionRepliesUseDedicatedLane pins the fix: mtLEDGER_DATA
+// (a reply this node explicitly requested) rides its own lane, never the
+// shared consensus lane, and overflow there bumps only droppedLedgerData. A
+// serve/propose flood on the consensus lane therefore can't shed a requested
+// acquisition reply and wedge catch-up.
+func TestOverlay_AcquisitionRepliesUseDedicatedLane(t *testing.T) {
+	o := newLaneTestOverlay(8, 8, 1)
 
 	for range 4 {
 		o.onMessageReceived(Event{
@@ -115,12 +154,18 @@ func TestOverlay_NonTxUsesConsensusLane(t *testing.T) {
 		})
 	}
 
-	assert.Greater(t, o.DroppedMessages(), uint64(0),
-		"DroppedMessages must record consensus-lane overflow")
+	assert.Equal(t, 1, len(o.ledgerData),
+		"acquisition replies must ride the dedicated lane up to its capacity")
+	assert.Greater(t, o.DroppedLedgerData(), uint64(0),
+		"DroppedLedgerData must record dedicated-lane overflow")
+	assert.Equal(t, uint64(0), o.DroppedMessages(),
+		"acquisition-lane overflow must not touch the consensus-lane counter")
 	assert.Equal(t, uint64(0), o.DroppedTransactions(),
-		"DroppedTransactions must not move when only non-tx frames overflow")
+		"acquisition-lane overflow must not touch the tx-lane counter")
+	assert.Equal(t, 0, len(o.messages),
+		"acquisition replies must never reach the consensus lane")
 	assert.Equal(t, 0, len(o.txMessages),
-		"non-tx traffic must never reach the tx lane")
+		"acquisition replies must never reach the tx lane")
 }
 
 // TestOverlay_TxLane_BoundedGoroutines is the bounded-backpressure soak:
@@ -133,7 +178,7 @@ func TestOverlay_TxLane_BoundedGoroutines(t *testing.T) {
 	const flooded = 10_000
 	const writers = 16
 
-	o := newLaneTestOverlay(8, txCap)
+	o := newLaneTestOverlay(8, txCap, 8)
 
 	runtime.GC()
 	baseline := runtime.NumGoroutine()

--- a/internal/testing/p2p/two_overlay_test.go
+++ b/internal/testing/p2p/two_overlay_test.go
@@ -427,7 +427,9 @@ func TestTwoOverlay_ReplayDelta_RoundTrip(t *testing.T) {
 	require.NoError(t, sender.RequestReplayDelta(uint64(peerAOnB), hash),
 		"B must be able to send a replay-delta request to A")
 
-	// The response is delivered to B via its Messages() channel.
+	// The response rides B's dedicated acquisition-reply lane
+	// (LedgerDataMessages), where the overlay routes replay-delta /
+	// proof-path responses and mtLEDGER_DATA.
 	var resp *message.ReplayDeltaResponse
 	timer := time.NewTimer(3 * time.Second)
 	defer timer.Stop()
@@ -435,7 +437,7 @@ func TestTwoOverlay_ReplayDelta_RoundTrip(t *testing.T) {
 Loop:
 	for {
 		select {
-		case msg := <-b.Messages():
+		case msg := <-b.LedgerDataMessages():
 			if message.MessageType(msg.Type) != message.TypeReplayDeltaResponse {
 				continue
 			}
@@ -611,14 +613,15 @@ func TestTwoOverlay_ProofPath_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, b.Send(peerAOnB, frame))
 
-	// Read B.Messages() until the proof-path response lands.
+	// Read B's acquisition-reply lane (LedgerDataMessages) until the
+	// proof-path response lands.
 	var resp *message.ProofPathResponse
 	timer := time.NewTimer(3 * time.Second)
 	defer timer.Stop()
 Loop:
 	for {
 		select {
-		case msg := <-b.Messages():
+		case msg := <-b.LedgerDataMessages():
 			if message.MessageType(msg.Type) != message.TypeProofPathResponse {
 				continue
 			}


### PR DESCRIPTION
## Summary

Fixes the consensus **wedge under high tx/ledger load** (the throughput fork behind #1157). Under a mixed rippled+goxrpl network driven at high tx/block, validators forked and lost quorum. Root cause was **not** consensus math (the avalanche / `DisputedTx` port is faithful) — it was two throughput/saturation defects in the **peer/consensus acquisition path** that prevented goxrpl from reconstructing peers' proposed tx-sets, so it closed empty ledgers and stalled.

With these fixes, in a 3-rippled + 2-goxrpl soak goxrpl builds **byte-identical ledgers** to rippled and advances in lockstep past the point it previously wedged.

## Root cause

1. **Overlay reply shedding + inline serve.** A single 256-deep overlay message lane, drained by one Router goroutine that also served `mtGET_LEDGER` inline (building the large tx-set reply on the critical path), silently shed `mtLEDGER_DATA` replies this node had explicitly requested — wedging inbound-ledger acquisition in `StateWantBase`.

2. **Tx-set acquisition rootless-completion storm.** For a ~16k-node tx-set, the driver throttled every re-request to 250ms (~16s for a full set, longer than a round) and gave up after 20 broadcasts. Worse, it built a *fresh empty-rooted* SHAMap from any straggler reply, and `FinishSync` on a childless root wrongly "succeeded" → the set "completed" **empty** (`tx_count=0`), was deleted, and the next straggler recreated it — an 860×/25ms storm (all nodes rejected with `ErrEmptyBranchOnPath`). goxrpl could never rebuild a peer's tx-set, so consensus closed empty ledgers and stalled.

## Changes

**`perf(consensus): isolate acquisition replies and get_ledger serve from consensus`**
- Dedicated 1024-deep lane for acquisition replies (ledger-data / replay-delta / proof-path), drained co-equal with the consensus and tx lanes — neither shed under a serve/propose flood nor starving proposal/validation handling. Overflow bumps a visible `droppedLedgerData` counter.
- `mtGET_LEDGER` serve offloaded to a bounded worker pool (`max(2, GOMAXPROCS/2)`), mirroring the existing tx worker pool; inline when the pool isn't running (preserves the synchronous test contract).

**`fix(consensus): rippled-faithful tx-set acquisition for high tx/ledger`** — matches rippled's `TransactionAcquire`:
- **Pipeline** the next missing-nodes request on each progressing reply (RTT rate-limits), **unicast to the replying peer** (`trigger(peer)`); the 250ms timer owns the broadcast fallback for silent peers. Time out only on **consecutive no-progress** ticks, retaining the partial (unbacked) map.
- **Require the root before completing** (`mHaveRoot`/`isValid`): a rootless acquire only requests the root and can never complete empty.
- **Latch terminal acquires** (completed or given-up) and keep them; drop stragglers for a done set instead of recreating a fresh empty map. Count only genuinely new nodes (`NodeUseful`) as progress.

## Verification
- `just build`, `just vet` clean.
- `go test -race ./internal/consensus/... ./shamap/... ./internal/peermanagement/...` — all pass (new tests: dedicated acquisition lane; root-gate / done-latch / duplicate-not-progress; pipelining-at-RTT).
- **Conformance byte-identical to baseline** (networking/consensus-path only, no protocol behavior change).
- Live 3r2g soak: empty-branch storm eliminated (0 `tx_count=0` completions), goxrpl builds byte-identical ledgers to rippled in lockstep.

## Out of scope
A separate, deeper inbound-ledger **self-heal** issue remains (tracked as #1158): after goxrpl transiently falls onto a minority ledger, catch-up acquisition can't finalize because the backed-store completeness re-walk (`FinishSync`) reports a phantom missing node while the in-memory tree is complete. That is not addressed here and will be handled separately.