### PR TITLE
fix(offer): commit an in-ledger tecKILLED when a crossing over-delivers

### DIFF
--- a/internal/tx/offer/offer_create_cross.go
+++ b/internal/tx/offer/offer_create_cross.go
@@ -195,19 +195,16 @@ func (o *OfferCreate) takerCross(
 		}
 	}
 
-	// A flow over-delivery aborts the engine with tefEXCEPTION and discards its
-	// sandbox (the over-deliver guard returns no state; FlowCross only applies the
-	// sandbox on tesSUCCESS). During offer crossing this is NOT a transaction
-	// failure: rippled's flowCross swallows every non-tesSUCCESS flow result,
-	// leaving the offer unchanged (afterCross = takerAmount) and returning
-	// tesSUCCESS, so the discarded crossing simply yields nothing. Mirror that —
-	// erase the groomed offers, drop the crossing, and fall through uncrossed
-	// (crossed=false) so applyGuts reaches the ImmediateOrCancel / FillOrKill kill
-	// (tecKILLED) or, for a plain offer, places the original amounts. Surfacing the
-	// engine's tefEXCEPTION as the transaction result instead would wrongly discard
-	// the whole tx (no fee, not in ledger) rather than commit an in-ledger tecKILLED.
-	// Reference: rippled CreateOffer.cpp:428-430 (isTesSuccess gate -> offer
-	// unchanged), Flow.cpp:42-45 (sandbox applied only on tesSUCCESS).
+	// A flow over-delivery returns tefEXCEPTION with its sandbox discarded (the
+	// over-deliver guard returns no state; FlowCross applies the sandbox only on
+	// tesSUCCESS). During crossing this is not a tx failure: rippled's flowCross
+	// swallows every non-tesSUCCESS flow result, leaving the offer unchanged
+	// (afterCross = takerAmount) and returning tesSUCCESS (CreateOffer.cpp:428-430;
+	// Flow.cpp:42-45). Mirror that — erase the groomed offers, drop the crossing,
+	// and fall through uncrossed (crossed=false) so applyGuts reaches the
+	// ImmediateOrCancel / FillOrKill kill (tecKILLED) or places a plain offer's
+	// original amounts — an in-ledger result, not the whole-tx discard the raw
+	// engine tefEXCEPTION would produce.
 	if result == ter.TefEXCEPTION {
 		removeRemovableOffers(sb, sbCancel, crossResult.RemovableOffers, crossResult.PermRemovableOffers)
 		return crossOutcome{

--- a/internal/tx/offer/offer_create_cross.go
+++ b/internal/tx/offer/offer_create_cross.go
@@ -195,6 +195,32 @@ func (o *OfferCreate) takerCross(
 		}
 	}
 
+	// A flow over-delivery aborts the engine with tefEXCEPTION and discards its
+	// sandbox (the over-deliver guard returns no state; FlowCross only applies the
+	// sandbox on tesSUCCESS). During offer crossing this is NOT a transaction
+	// failure: rippled's flowCross swallows every non-tesSUCCESS flow result,
+	// leaving the offer unchanged (afterCross = takerAmount) and returning
+	// tesSUCCESS, so the discarded crossing simply yields nothing. Mirror that —
+	// erase the groomed offers, drop the crossing, and fall through uncrossed
+	// (crossed=false) so applyGuts reaches the ImmediateOrCancel / FillOrKill kill
+	// (tecKILLED) or, for a plain offer, places the original amounts. Surfacing the
+	// engine's tefEXCEPTION as the transaction result instead would wrongly discard
+	// the whole tx (no fee, not in ledger) rather than commit an in-ledger tecKILLED.
+	// Reference: rippled CreateOffer.cpp:428-430 (isTesSuccess gate -> offer
+	// unchanged), Flow.cpp:42-45 (sandbox applied only on tesSUCCESS).
+	if result == ter.TefEXCEPTION {
+		removeRemovableOffers(sb, sbCancel, crossResult.RemovableOffers, crossResult.PermRemovableOffers)
+		return crossOutcome{
+			terminated:  false,
+			result:      ter.TesSUCCESS,
+			applyMain:   true,
+			saTakerPays: saTakerPays,
+			saTakerGets: saTakerGets,
+			uRate:       uRate,
+			crossed:     false,
+		}
+	}
+
 	if result != ter.TesSUCCESS {
 		// Error during crossing - apply cancel sandbox
 		return crossOutcome{terminated: true, result: result, applyMain: false}


### PR DESCRIPTION
## Summary

An IoC `OfferCreate` whose crossing fills the full request and then adds a sub-ULP dust slice **over-delivers by 1 ULP**, tripping the flow's over-deliver guard (`tefEXCEPTION`, sandbox discarded). `takerCross` surfaced that engine result as the transaction result, discarding the whole tx (no fee, not in ledger) — mainnet instead commits an in-ledger `tecKILLED`.

rippled's `flowCross` swallows every non-`tesSUCCESS` flow result: the offer is left unchanged (`afterCross = takerAmount`) and it returns `tesSUCCESS`, so the crossing yields nothing and the ImmediateOrCancel branch emits `tecKILLED`. This mirrors that for the over-deliver `tefEXCEPTION` in `takerCross`, exactly like the existing `tecPATH_DRY` / `tecPATH_PARTIAL` handling.

## Verification

- Byte-exact replay of mainnet ledger **99334433** (tx `4510F528…`, Index 16 → `tecKILLED`, 1 node) and downstream **99334434-99334438**.
- `go test ./internal/tx/...` (28 packages) + `go vet` green.

Closes #1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)