### PR TITLE
fix(invariants): don't treat an "XRP"-at-bytes-12-14 IOU as native XRP

### DIFF
--- a/internal/tx/invariants/binary_helpers.go
+++ b/internal/tx/invariants/binary_helpers.go
@@ -4,54 +4,45 @@ import (
 	"fmt"
 )
 
-// isXRPCurrency returns true if the given currency string represents XRP.
-// XRP is the all-zero 160-bit currency, which the state amount parser may render
-// as the empty string, the literal "XRP", or a 3-byte run of NUL bytes (the
-// standard-code path reading an all-zero currency); it may also arrive as a
-// 40-char hex string of all zeros. Besides the all-zero (native) currency, only
-// the exact 3-char ISO "XRP" bad-currency (bytes 12-14 "XRP", every other byte
-// zero) counts as XRP — a non-zero prefix (e.g. "Wellgistics XRP") is a valid IOU.
-func isXRPCurrency(curr string) bool {
+// badCurrencyBytes is rippled's badCurrency() (UintTypes.cpp:132-137): the
+// forbidden 3-char ISO "XRP" code — bytes 12-14 "XRP", every other byte zero.
+var badCurrencyBytes = [20]byte{12: 'X', 13: 'R', 14: 'P'}
+
+// isNativeXRPCurrency returns true if the currency string renders the all-zero
+// 160-bit (native XRP) currency: the empty string (a missing or native-form
+// field), the literal "XRP", a run of NUL bytes, or all-zero hex. A currency
+// whose bytes merely contain "XRP" beside non-zero bytes (e.g. "Wellgistics
+// XRP") is a valid IOU, as is badCurrency.
+func isNativeXRPCurrency(curr string) bool {
 	if len(curr) == 0 || curr == "XRP" {
 		return true
 	}
-	// All-NUL bytes (e.g. the 3-byte standard-code form of the zero currency).
 	if isAllZeroBytes(curr) {
 		return true
 	}
-	// Hex-encoded currency: 40 hex chars = 20 bytes
 	if len(curr) == 40 {
 		b, err := hexDecode20(curr)
 		if err != nil {
 			return false
 		}
-		// All zeros = XRP
-		allZero := true
-		for _, bb := range b {
-			if bb != 0 {
-				allZero = false
-				break
-			}
-		}
-		if allZero {
-			return true
-		}
-		// rippled badCurrency() (UintTypes.cpp:132-137): bytes 12-14 "XRP" with
-		// every other byte zero; "XRP" beside non-zero bytes is a valid IOU.
-		if b[12] == 'X' && b[13] == 'R' && b[14] == 'P' {
-			restZero := true
-			for i := 0; i < 20; i++ {
-				if (i < 12 || i > 14) && b[i] != 0 {
-					restZero = false
-					break
-				}
-			}
-			if restZero {
-				return true
-			}
-		}
+		return b == [20]byte{}
 	}
 	return false
+}
+
+// isBadCurrency returns true iff the currency string is the hex rendering of
+// badCurrencyBytes — the only form the canonical codec produces for it
+// (to_string refuses the ISO "XRP" representation, so it never arrives as a
+// 3-char string).
+func isBadCurrency(curr string) bool {
+	if len(curr) != 40 {
+		return false
+	}
+	b, err := hexDecode20(curr)
+	if err != nil {
+		return false
+	}
+	return b == badCurrencyBytes
 }
 
 // isAllZeroBytes reports whether s is non-empty and every byte is NUL.

--- a/internal/tx/invariants/binary_helpers.go
+++ b/internal/tx/invariants/binary_helpers.go
@@ -8,7 +8,9 @@ import (
 // XRP is the all-zero 160-bit currency, which the state amount parser may render
 // as the empty string, the literal "XRP", or a 3-byte run of NUL bytes (the
 // standard-code path reading an all-zero currency); it may also arrive as a
-// 40-char hex string of zeros or with "XRP" at bytes 12-14.
+// 40-char hex string of all zeros. Besides the all-zero (native) currency, only
+// the exact 3-char ISO "XRP" bad-currency (bytes 12-14 "XRP", every other byte
+// zero) counts as XRP — a non-zero prefix (e.g. "Wellgistics XRP") is a valid IOU.
 func isXRPCurrency(curr string) bool {
 	if len(curr) == 0 || curr == "XRP" {
 		return true
@@ -34,9 +36,25 @@ func isXRPCurrency(curr string) bool {
 		if allZero {
 			return true
 		}
-		// Check "XRP" at bytes 12-14
+		// The 3-char ISO "XRP" code — bytes 12-14 "XRP" with EVERY OTHER byte zero —
+		// is a forbidden bad-currency, treated as XRP here. But a non-standard
+		// currency whose bytes 12-14 merely spell "XRP" with a non-zero prefix (e.g.
+		// "Wellgistics XRP", 57656C6C67697374696373205852500000000000) is a VALID
+		// IOU. Requiring the rest to be zero keeps NoXRPTrustLines aligned with
+		// rippled's isXRP (currency == beast::zero) for real trust lines; the old
+		// unconditional bytes-12-14 check wrongly flagged such IOUs
+		// (tecINVARIANT_FAILED vs mainnet tesSUCCESS, ledger 99342512).
 		if b[12] == 'X' && b[13] == 'R' && b[14] == 'P' {
-			return true
+			restZero := true
+			for i := 0; i < 20; i++ {
+				if (i < 12 || i > 14) && b[i] != 0 {
+					restZero = false
+					break
+				}
+			}
+			if restZero {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/tx/invariants/binary_helpers.go
+++ b/internal/tx/invariants/binary_helpers.go
@@ -36,14 +36,8 @@ func isXRPCurrency(curr string) bool {
 		if allZero {
 			return true
 		}
-		// The 3-char ISO "XRP" code — bytes 12-14 "XRP" with EVERY OTHER byte zero —
-		// is a forbidden bad-currency, treated as XRP here. But a non-standard
-		// currency whose bytes 12-14 merely spell "XRP" with a non-zero prefix (e.g.
-		// "Wellgistics XRP", 57656C6C67697374696373205852500000000000) is a VALID
-		// IOU. Requiring the rest to be zero keeps NoXRPTrustLines aligned with
-		// rippled's isXRP (currency == beast::zero) for real trust lines; the old
-		// unconditional bytes-12-14 check wrongly flagged such IOUs
-		// (tecINVARIANT_FAILED vs mainnet tesSUCCESS, ledger 99342512).
+		// rippled badCurrency() (UintTypes.cpp:132-137): bytes 12-14 "XRP" with
+		// every other byte zero; "XRP" beside non-zero bytes is a valid IOU.
 		if b[12] == 'X' && b[13] == 'R' && b[14] == 'P' {
 			restZero := true
 			for i := 0; i < 20; i++ {

--- a/internal/tx/invariants/binary_helpers_test.go
+++ b/internal/tx/invariants/binary_helpers_test.go
@@ -1,0 +1,36 @@
+package invariants
+
+import "testing"
+
+// TestIsXRPCurrency pins the exact badCurrency boundary: only the all-zero
+// (native) currency and rippled's badCurrency() — bytes 12-14 "XRP", every
+// other byte zero (UintTypes.cpp:132-137) — count as XRP. A currency whose
+// bytes 12-14 merely spell "XRP" beside non-zero bytes is a valid IOU
+// (mainnet "Wellgistics XRP", ledger 99342512).
+func TestIsXRPCurrency(t *testing.T) {
+	tests := []struct {
+		name string
+		curr string
+		want bool
+	}{
+		{"empty string", "", true},
+		{"literal XRP", "XRP", true},
+		{"three NUL bytes", "\x00\x00\x00", true},
+		{"all-zero hex", "0000000000000000000000000000000000000000", true},
+		{"badCurrency hex", "0000000000000000000000005852500000000000", true},
+		{"Wellgistics XRP mainnet IOU", "57656C6C67697374696373205852500000000000", false},
+		{"Wellgistics XRP lowercase hex", "57656c6c67697374696373205852500000000000", false},
+		{"XRP at 12-14 with non-zero suffix", "0000000000000000000000005852500000000001", false},
+		{"XRP at 12-14 with non-zero prefix byte", "0100000000000000000000005852500000000000", false},
+		{"noCurrency sentinel", "1", false},
+		{"ISO USD", "USD", false},
+		{"40 chars but invalid hex", "ZZ00000000000000000000005852500000000000", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isXRPCurrency(tt.curr); got != tt.want {
+				t.Errorf("isXRPCurrency(%q) = %v, want %v", tt.curr, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tx/invariants/binary_helpers_test.go
+++ b/internal/tx/invariants/binary_helpers_test.go
@@ -1,13 +1,18 @@
 package invariants
 
-import "testing"
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
 
-// TestIsXRPCurrency pins the exact badCurrency boundary: only the all-zero
-// (native) currency and rippled's badCurrency() — bytes 12-14 "XRP", every
-// other byte zero (UintTypes.cpp:132-137) — count as XRP. A currency whose
-// bytes 12-14 merely spell "XRP" beside non-zero bytes is a valid IOU
-// (mainnet "Wellgistics XRP", ledger 99342512).
-func TestIsXRPCurrency(t *testing.T) {
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+)
+
+// TestIsNativeXRPCurrency pins the renderings of the all-zero (native XRP)
+// currency and rejects look-alikes: badCurrency, and any code whose bytes
+// 12-14 merely spell "XRP" beside non-zero bytes (mainnet "Wellgistics XRP",
+// ledger 99342512).
+func TestIsNativeXRPCurrency(t *testing.T) {
 	tests := []struct {
 		name string
 		curr string
@@ -17,20 +22,114 @@ func TestIsXRPCurrency(t *testing.T) {
 		{"literal XRP", "XRP", true},
 		{"three NUL bytes", "\x00\x00\x00", true},
 		{"all-zero hex", "0000000000000000000000000000000000000000", true},
+		{"badCurrency hex", "0000000000000000000000005852500000000000", false},
+		{"Wellgistics XRP mainnet IOU", "57656C6C67697374696373205852500000000000", false},
+		{"Wellgistics XRP lowercase hex", "57656c6c67697374696373205852500000000000", false},
+		{"single non-zero byte", "0000000000000000000000000000000000000001", false},
+		{"noCurrency sentinel", "1", false},
+		{"ISO USD", "USD", false},
+		{"40 chars but invalid hex", "ZZ00000000000000000000000000000000000000", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNativeXRPCurrency(tt.curr); got != tt.want {
+				t.Errorf("isNativeXRPCurrency(%q) = %v, want %v", tt.curr, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsBadCurrency pins rippled's badCurrency() boundary (UintTypes.cpp:132-137):
+// exactly bytes 12-14 "XRP" with every other byte zero, hex form only.
+func TestIsBadCurrency(t *testing.T) {
+	tests := []struct {
+		name string
+		curr string
+		want bool
+	}{
 		{"badCurrency hex", "0000000000000000000000005852500000000000", true},
+		{"all-zero hex", "0000000000000000000000000000000000000000", false},
+		{"literal XRP", "XRP", false},
+		{"empty string", "", false},
 		{"Wellgistics XRP mainnet IOU", "57656C6C67697374696373205852500000000000", false},
 		{"Wellgistics XRP lowercase hex", "57656c6c67697374696373205852500000000000", false},
 		{"XRP at 12-14 with non-zero suffix", "0000000000000000000000005852500000000001", false},
 		{"XRP at 12-14 with non-zero prefix byte", "0100000000000000000000005852500000000000", false},
-		{"noCurrency sentinel", "1", false},
-		{"ISO USD", "USD", false},
 		{"40 chars but invalid hex", "ZZ00000000000000000000005852500000000000", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isXRPCurrency(tt.curr); got != tt.want {
-				t.Errorf("isXRPCurrency(%q) = %v, want %v", tt.curr, got, tt.want)
+			if got := isBadCurrency(tt.curr); got != tt.want {
+				t.Errorf("isBadCurrency(%q) = %v, want %v", tt.curr, got, tt.want)
 			}
 		})
+	}
+}
+
+// encodeTrustLine builds a canonical RippleState blob whose LowLimit currency
+// is the standard-form "ABC" (unique in the blob, so tests can patch its 3
+// currency bytes in place).
+func encodeTrustLine(t *testing.T) []byte {
+	t.Helper()
+	const balanceIssuer = "rrrrrrrrrrrrrrrrrrrrBZbvji"
+	const owner = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+
+	jsonObj := map[string]any{
+		"LedgerEntryType": "RippleState",
+		"Flags":           uint32(0),
+		"Balance": map[string]any{
+			"currency": "USD",
+			"issuer":   balanceIssuer,
+			"value":    "0",
+		},
+		"LowLimit": map[string]any{
+			"currency": "ABC",
+			"issuer":   owner,
+			"value":    "10",
+		},
+		"HighLimit": map[string]any{
+			"currency": "USD",
+			"issuer":   balanceIssuer,
+			"value":    "20",
+		},
+	}
+	hexStr, err := binarycodec.Encode(jsonObj)
+	if err != nil {
+		t.Fatalf("binarycodec.Encode: %v", err)
+	}
+	blob, err := hex.DecodeString(hexStr)
+	if err != nil {
+		t.Fatalf("hex.DecodeString: %v", err)
+	}
+	return blob
+}
+
+// TestNoXRPTrustLines_BadCurrencyBoundary mirrors rippled's NoXRPTrustLines
+// predicate (InvariantCheck.cpp:591-593, issue() == xrpIssue()): a zero-currency
+// limit fires, a badCurrency limit does not. rippled pins the firing side in
+// Invariants_test.cpp testNoXRPTrustLine.
+func TestNoXRPTrustLines_BadCurrencyBoundary(t *testing.T) {
+	good := encodeTrustLine(t)
+	if v := checkNoXRPTrustLines([]InvariantEntry{{EntryType: "RippleState", After: good}}); v != nil {
+		t.Fatalf("IOU trust line: unexpected violation %v", v)
+	}
+
+	idx := bytes.Index(good, []byte("ABC"))
+	if idx < 0 {
+		t.Fatal("ABC currency marker not found in encoded RippleState")
+	}
+
+	badCur := make([]byte, len(good))
+	copy(badCur, good)
+	copy(badCur[idx:idx+3], "XRP")
+	if v := checkNoXRPTrustLines([]InvariantEntry{{EntryType: "RippleState", After: badCur}}); v != nil {
+		t.Fatalf("badCurrency limit must not fire NoXRPTrustLines: %v", v)
+	}
+
+	zeroCur := make([]byte, len(good))
+	copy(zeroCur, good)
+	copy(zeroCur[idx:idx+3], []byte{0, 0, 0})
+	if v := checkNoXRPTrustLines([]InvariantEntry{{EntryType: "RippleState", After: zeroCur}}); v == nil {
+		t.Fatal("expected violation: trust line limit with the zero (XRP) currency")
 	}
 }

--- a/internal/tx/invariants/offers.go
+++ b/internal/tx/invariants/offers.go
@@ -127,12 +127,10 @@ func checkEscrowAmount(data []byte) *InvariantViolation {
 		}
 		return nil
 	}
-	// IOU escrow — must be strictly positive and must not use the sentinel "bad"
-	// currency code ("XRP" as an IOU currency). The canonical codec renders the
-	// forbidden standard-form "XRP" slot as full hex, so the currency may arrive
-	// either as the literal "XRP" or as hex with "XRP" at bytes 12-14;
-	// isXRPCurrency detects both. Mirrors rippled InvariantCheck.cpp:286-292 /
-	// Issue.h badCurrency().
+	// IOU escrow — must be strictly positive and must not use badCurrency
+	// (rippled InvariantCheck.cpp:286-292). A zero-currency IOU is an illegal
+	// encoding rippled rejects at deserialization (STAmount.cpp:183-184), so it
+	// is flagged too.
 	if esc.IOUAmount != nil {
 		if esc.IOUAmount.Signum() <= 0 {
 			return &InvariantViolation{
@@ -140,7 +138,7 @@ func checkEscrowAmount(data []byte) *InvariantViolation {
 				Message: "Escrow IOU amount is not positive",
 			}
 		}
-		if isXRPCurrency(esc.IOUAmount.Currency) {
+		if isBadCurrency(esc.IOUAmount.Currency) || isNativeXRPCurrency(esc.IOUAmount.Currency) {
 			return &InvariantViolation{
 				Name:    "NoZeroEscrow",
 				Message: "Escrow IOU amount uses the bad (XRP) currency code",

--- a/internal/tx/invariants/trustlines.go
+++ b/internal/tx/invariants/trustlines.go
@@ -32,7 +32,10 @@ func checkNoXRPTrustLines(entries []InvariantEntry) *InvariantViolation {
 				Message: fmt.Sprintf("could not parse RippleState SLE: %v", err),
 			}
 		}
-		if isXRPCurrency(rs.LowLimit.Currency) || isXRPCurrency(rs.HighLimit.Currency) {
+		// rippled fires only on issue() == xrpIssue() — the all-zero currency; a
+		// badCurrency limit does not trip this invariant (it is rejected at
+		// TrustSet preflight with temBAD_CURRENCY and never reaches a ledger).
+		if isNativeXRPCurrency(rs.LowLimit.Currency) || isNativeXRPCurrency(rs.HighLimit.Currency) {
 			return &InvariantViolation{
 				Name:    "NoXRPTrustLines",
 				Message: "RippleState entry uses XRP as currency (trust lines must use IOU currencies)",


### PR DESCRIPTION
## Summary

`isXRPCurrency` flagged any 40-hex currency with "XRP" at bytes 12-14 as native XRP, so the `NoXRPTrustLines` invariant wrongly tripped on a `TrustSet` creating a trust line for the valid non-standard IOU **"Wellgistics XRP"** — `tecINVARIANT_FAILED` where mainnet returns `tesSUCCESS`.

rippled's `isXRP` is `currency == beast::zero`. The bytes-12-14 "XRP" check now also requires every other byte to be zero (the exact ISO "XRP" bad-currency), so a non-zero prefix is treated as the valid IOU it is. The ISO-code case stays flagged, leaving the escrow bad-currency invariant intact.

## Verification

- Byte-exact replay of mainnet ledger **99342512** (TrustSet `29670A03…`, Index 20 → tesSUCCESS) and downstream **99342513-99342518**.
- `go test ./internal/tx/...` (28 packages) + `go vet` green.

Closes #1178

🤖 Generated with [Claude Code](https://claude.com/claude-code)