### PR TITLE
fix: stop stamping PreviousTxnID in owner-count adjustments

### DIFF
--- a/internal/testing/offer/payment_netzero_owner_meta_test.go
+++ b/internal/testing/offer/payment_netzero_owner_meta_test.go
@@ -1,0 +1,123 @@
+package offer
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPayment_NetZeroOwnerCount_EmitsBareThreadedNode pins the issue #1180 fix:
+// a payment that fully consumes an offer (owner count -1) while auto-creating a
+// trust line for the same owner to receive the proceeds (owner count +1) leaves
+// the owner's AccountRoot byte-identical. rippled emits that owner as a bare
+// threaded ModifiedNode — old PreviousTxnID/PreviousTxnLgrSeq only, no
+// FinalFields, no PreviousFields (mainnet ledger 99358634, tx index 75).
+//
+// goXRPL diverged because the owner-count helpers stamped
+// PreviousTxnID/PreviousTxnLgrSeq on the AccountRoot mid-apply, so the
+// bytes.Equal(Original, Current) no-op guards in the ApplyStateTable misfired
+// and attached a spurious FinalFields block. Threading is the ApplyStateTable's
+// job at metadata time; rippled's adjustOwnerCount (View.cpp) only touches
+// OwnerCount.
+func TestPayment_NetZeroOwnerCount_EmitsBareThreadedNode(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+
+	gw := jtx.NewAccount("gateway")
+	// "mm990" hashes to account key 000B614F… — low enough that the deleted
+	// offer and created trust line keys deterministically sort after it (the
+	// ordering the bare-node emission requires; asserted below).
+	mm := jtx.NewAccount("mm990")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+
+	env.FundAmount(gw, uint64(jtx.XRP(100000)))
+	env.FundAmount(mm, uint64(jtx.XRP(100000)))
+	env.FundAmount(alice, uint64(jtx.XRP(100000)))
+	env.FundAmount(bob, uint64(jtx.XRP(100000)))
+	env.Close()
+
+	// mm deliberately holds NO USD trust line: crossing its offer auto-creates
+	// one to receive the USD proceeds (+1) while the fully-consumed offer is
+	// deleted (-1) — a net-zero OwnerCount change with no other AccountRoot
+	// field touched.
+	env.Trust(mm, jtx.EUR(gw, 1_000_000))
+	env.Trust(alice, jtx.USD(gw, 1_000_000))
+	env.Trust(bob, jtx.EUR(gw, 1_000_000))
+	env.Close()
+
+	jtx.RequireTxSuccess(t, env.Submit(payment.PayIssued(gw, mm, jtx.EUR(gw, 1000)).Build()))
+	jtx.RequireTxSuccess(t, env.Submit(payment.PayIssued(gw, alice, jtx.USD(gw, 1000)).Build()))
+	env.Close()
+
+	// mm gives EUR, receives USD.
+	mmOfferSeq := env.Seq(mm)
+	jtx.RequireTxSuccess(t, env.Submit(OfferCreate(mm, jtx.USD(gw, 100), jtx.EUR(gw, 100)).Build()))
+	env.Close()
+
+	mmAcctKL := keylet.Account(mm.ID)
+	offerKey := keylet.Offer(mm.ID, mmOfferSeq).Key
+	lineKey := keylet.Line(mm.ID, gw.ID, "USD").Key
+
+	// The bare-vs-FinalFields outcome for a no-op owner follows rippled's
+	// ascending-key apply order: the owner is emitted bare only when every
+	// mutated child sorts after the owner's account key. Pin the shape that
+	// diverged on mainnet.
+	require.Positive(t, bytes.Compare(offerKey[:], mmAcctKL.Key[:]),
+		"precondition: deleted offer key must sort after mm's account key")
+	require.Positive(t, bytes.Compare(lineKey[:], mmAcctKL.Key[:]),
+		"precondition: created trust line key must sort after mm's account key")
+
+	beforeData, err := env.LedgerEntry(mmAcctKL)
+	require.NoError(t, err)
+	before, err := state.ParseAccountRoot(beforeData)
+	require.NoError(t, err)
+
+	// alice pays bob 100 EUR funded by 100 USD through the book, consuming
+	// mm's offer exactly and entirely.
+	pay := env.Submit(payment.PayIssued(alice, bob, jtx.EUR(gw, 100)).SendMax(jtx.USD(gw, 100)).Build())
+	jtx.RequireTxSuccess(t, pay)
+
+	// Sanity: the offer was fully consumed and deleted, the USD line was
+	// created, and mm's AccountRoot is a true no-op (OwnerCount unchanged).
+	require.Nil(t, GetOffer(env, mm, mmOfferSeq), "mm's offer should be fully consumed and deleted")
+	jtx.RequireIOUBalance(t, env, mm, gw, "USD", 100)
+	jtx.RequireIOUBalance(t, env, mm, gw, "EUR", 900)
+	jtx.RequireIOUBalance(t, env, bob, gw, "EUR", 100)
+
+	afterData, err := env.LedgerEntry(mmAcctKL)
+	require.NoError(t, err)
+	after, err := state.ParseAccountRoot(afterData)
+	require.NoError(t, err)
+	require.Equal(t, before.OwnerCount, after.OwnerCount, "premise: OwnerCount nets to zero")
+	require.NotEqual(t, before.PreviousTxnID, after.PreviousTxnID,
+		"mm's AccountRoot must still be re-threaded to the payment in ledger state")
+
+	require.NotNil(t, pay.Metadata, "payment has nil Metadata")
+	mmAcctIndex := strings.ToUpper(hex.EncodeToString(mmAcctKL.Key[:]))
+	found := false
+	for i := range pay.Metadata.AffectedNodes {
+		n := &pay.Metadata.AffectedNodes[i]
+		if !strings.EqualFold(n.LedgerIndex, mmAcctIndex) {
+			continue
+		}
+		require.False(t, found, "mm's AccountRoot appears more than once in AffectedNodes")
+		found = true
+		require.Equal(t, "ModifiedNode", n.NodeType)
+		require.Empty(t, n.FinalFields,
+			"net-zero owner AccountRoot must be emitted bare (threading only), got spurious FinalFields")
+		require.Empty(t, n.PreviousFields,
+			"net-zero owner AccountRoot must not carry PreviousFields")
+		require.Equal(t, strings.ToUpper(hex.EncodeToString(before.PreviousTxnID[:])), n.PreviousTxnID,
+			"bare node must carry the pre-payment PreviousTxnID")
+		require.Equal(t, before.PreviousTxnLgrSeq, n.PreviousTxnLgrSeq,
+			"bare node must carry the pre-payment PreviousTxnLgrSeq")
+	}
+	require.True(t, found, "mm's AccountRoot must appear as a bare threaded ModifiedNode")
+}

--- a/internal/testing/offer/payment_netzero_owner_meta_test.go
+++ b/internal/testing/offer/payment_netzero_owner_meta_test.go
@@ -20,12 +20,10 @@ import (
 // threaded ModifiedNode — old PreviousTxnID/PreviousTxnLgrSeq only, no
 // FinalFields, no PreviousFields (mainnet ledger 99358634, tx index 75).
 //
-// goXRPL diverged because the owner-count helpers stamped
-// PreviousTxnID/PreviousTxnLgrSeq on the AccountRoot mid-apply, so the
-// bytes.Equal(Original, Current) no-op guards in the ApplyStateTable misfired
-// and attached a spurious FinalFields block. Threading is the ApplyStateTable's
-// job at metadata time; rippled's adjustOwnerCount (View.cpp) only touches
-// OwnerCount.
+// Guards against mid-apply PreviousTxnID stamping in the owner-count helpers,
+// which would defeat the ApplyStateTable's no-op guard and attach a spurious
+// FinalFields block: threading belongs to the ApplyStateTable at metadata time
+// (rippled View.cpp adjustOwnerCount only touches OwnerCount).
 func TestPayment_NetZeroOwnerCount_EmitsBareThreadedNode(t *testing.T) {
 	env := jtx.NewTestEnv(t)
 
@@ -84,8 +82,6 @@ func TestPayment_NetZeroOwnerCount_EmitsBareThreadedNode(t *testing.T) {
 	pay := env.Submit(payment.PayIssued(alice, bob, jtx.EUR(gw, 100)).SendMax(jtx.USD(gw, 100)).Build())
 	jtx.RequireTxSuccess(t, pay)
 
-	// Sanity: the offer was fully consumed and deleted, the USD line was
-	// created, and mm's AccountRoot is a true no-op (OwnerCount unchanged).
 	require.Nil(t, GetOffer(env, mm, mmOfferSeq), "mm's offer should be fully consumed and deleted")
 	jtx.RequireIOUBalance(t, env, mm, gw, "USD", 100)
 	jtx.RequireIOUBalance(t, env, mm, gw, "EUR", 900)

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -385,7 +385,7 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 	// Reference: rippled Transactor.cpp lines 1207-1209: removeDeletedTrustLines()
 	//   which calls deleteAMMTrustLine() for each collected trust line key.
 	if len(removedTrustLineKeys) > 0 {
-		e.removeDeletedTrustLines(tecTable, removedTrustLineKeys, st.txHash)
+		e.removeDeletedTrustLines(tecTable, removedTrustLineKeys)
 	}
 
 	// Restore account to original state, then apply only fee/sequence.
@@ -410,7 +410,7 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 	// These offers were deleted in the (now discarded) sandbox.
 	// Reference: rippled Transactor.cpp lines 1198-1201: removeUnfundedOffers()
 	if len(removedOfferKeys) > 0 {
-		e.removeUnfundedOffers(tecTable, removedOfferKeys, st.txHash)
+		e.removeUnfundedOffers(tecTable, removedOfferKeys)
 	}
 
 	// tecEXPIRED: re-delete expired NFTokenOffers and credentials.
@@ -419,7 +419,7 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 		// Re-delete NFTokenOffers through tecTable
 		for _, offerKey := range expiredNFTokenOfferKeys {
 			offerKL := keylet.Keylet{Key: offerKey}
-			deleteNFTokenOfferOnView(tecTable, offerKL, st.txHash, e.config.LedgerSequence)
+			deleteNFTokenOfferOnView(tecTable, offerKL)
 		}
 
 		// Credential deletion via TecApplier
@@ -528,7 +528,7 @@ func (e *Engine) eraseTicketEntry(st *applyState, table *applystate.ApplyStateTa
 // removeDeletedTrustLines re-deletes the supplied AMM trust line keys through
 // the recovery table.
 // Reference: rippled View.cpp deleteAMMTrustLine + Transactor.cpp lines 1207-1209.
-func (e *Engine) removeDeletedTrustLines(tecTable *applystate.ApplyStateTable, keys [][32]byte, txHash [32]byte) {
+func (e *Engine) removeDeletedTrustLines(tecTable *applystate.ApplyStateTable, keys [][32]byte) {
 	for _, lineKey := range keys {
 		lineKL := keylet.Keylet{Key: lineKey}
 		lineData, readErr := tecTable.Read(lineKL)
@@ -564,10 +564,10 @@ func (e *Engine) removeDeletedTrustLines(tecTable *applystate.ApplyStateTable, k
 			ammLow := lowAcct.AMMID != zeroHash
 			ammHigh := highAcct.AMMID != zeroHash
 			if rs.Flags&state.LsfLowReserve != 0 && !ammLow {
-				adjustOwnerCountOnView(tecTable, lowID, -1, txHash, e.config.LedgerSequence)
+				adjustOwnerCountOnView(tecTable, lowID, -1)
 			}
 			if rs.Flags&state.LsfHighReserve != 0 && !ammHigh {
-				adjustOwnerCountOnView(tecTable, highID, -1, txHash, e.config.LedgerSequence)
+				adjustOwnerCountOnView(tecTable, highID, -1)
 			}
 		}
 	}
@@ -576,7 +576,7 @@ func (e *Engine) removeDeletedTrustLines(tecTable *applystate.ApplyStateTable, k
 // removeUnfundedOffers re-deletes the supplied offer keys through the recovery
 // table.
 // Reference: rippled Transactor.cpp lines 1198-1201: removeUnfundedOffers().
-func (e *Engine) removeUnfundedOffers(tecTable *applystate.ApplyStateTable, keys [][32]byte, txHash [32]byte) {
+func (e *Engine) removeUnfundedOffers(tecTable *applystate.ApplyStateTable, keys [][32]byte) {
 	for _, offerKey := range keys {
 		offerKL := keylet.Keylet{Key: offerKey}
 		offerData, readErr := e.view.Read(offerKL)
@@ -596,7 +596,7 @@ func (e *Engine) removeUnfundedOffers(tecTable *applystate.ApplyStateTable, keys
 		bookDirKey := keylet.Keylet{Type: 100, Key: offerObj.BookDirectory}
 		state.DirRemove(tecTable, bookDirKey, offerObj.BookNode, offerKey, false)
 		_ = tecTable.Erase(offerKL)
-		adjustOwnerCountOnView(tecTable, ownerID, -1, txHash, e.config.LedgerSequence)
+		adjustOwnerCountOnView(tecTable, ownerID, -1)
 	}
 }
 

--- a/internal/tx/engine/engine.go
+++ b/internal/tx/engine/engine.go
@@ -146,15 +146,15 @@ func (e *Engine) SetBaseTxCount(count uint32) {
 // adjustOwnerCountOnView modifies an account's OwnerCount on a LedgerView.
 // Used by the engine for tecOVERSIZE offer cleanup after the sandbox is discarded.
 // Reference: rippled removeUnfundedOffers() adjusts owner count on the base view.
-func adjustOwnerCountOnView(view txcore.LedgerView, account [20]byte, delta int, txHash [32]byte, ledgerSeq uint32) {
-	_ = txcore.AdjustOwnerCountWithTx(view, account, delta, txHash, ledgerSeq)
+func adjustOwnerCountOnView(view txcore.LedgerView, account [20]byte, delta int) {
+	_ = txcore.AdjustOwnerCount(view, account, delta)
 }
 
 // deleteNFTokenOfferOnView deletes an NFTokenOffer from the ledger view,
 // removing it from owner directory, NFTBuys/NFTSells directory, and erasing the SLE.
 // Used for tecEXPIRED re-deletion of expired NFToken offers.
 // Reference: rippled NFTokenUtils.cpp deleteTokenOffer
-func deleteNFTokenOfferOnView(view txcore.LedgerView, offerKL keylet.Keylet, txHash [32]byte, ledgerSeq uint32) {
+func deleteNFTokenOfferOnView(view txcore.LedgerView, offerKL keylet.Keylet) {
 	offerData, err := view.Read(offerKL)
 	if err != nil || offerData == nil {
 		return
@@ -179,5 +179,5 @@ func deleteNFTokenOfferOnView(view txcore.LedgerView, offerKL keylet.Keylet, txH
 	state.DirRemove(view, tokenDirKey, offer.NFTokenOfferNode, offerKL.Key, false)
 
 	_ = view.Erase(offerKL)
-	adjustOwnerCountOnView(view, offer.Owner, -1, txHash, ledgerSeq)
+	adjustOwnerCountOnView(view, offer.Owner, -1)
 }

--- a/internal/tx/owner_count.go
+++ b/internal/tx/owner_count.go
@@ -55,32 +55,3 @@ func AdjustOwnerCount(view LedgerView, accountID [20]byte, delta int) error {
 
 	return view.Update(accountKey, updated)
 }
-
-// AdjustOwnerCountWithTx adjusts an account's OwnerCount by delta and updates
-// PreviousTxnID and PreviousTxnLgrSeq fields on the account.
-// Saturates to math.MaxUint32 on overflow and clamps to 0 on underflow.
-// Returns an error if the account cannot be read or serialized.
-// If the account does not exist, returns nil.
-func AdjustOwnerCountWithTx(view LedgerView, accountID [20]byte, delta int, txHash [32]byte, ledgerSeq uint32) error {
-	accountKey := keylet.Account(accountID)
-	data, err := view.Read(accountKey)
-	if err != nil || data == nil {
-		return nil // Account doesn't exist (may have been deleted)
-	}
-
-	account, err := state.ParseAccountRoot(data)
-	if err != nil {
-		return fmt.Errorf("failed to parse account root: %w", err)
-	}
-
-	account.OwnerCount = confineOwnerCount(account.OwnerCount, delta)
-	account.PreviousTxnID = txHash
-	account.PreviousTxnLgrSeq = ledgerSeq
-
-	updated, err := state.SerializeAccountRoot(account)
-	if err != nil {
-		return fmt.Errorf("failed to serialize account root: %w", err)
-	}
-
-	return view.Update(accountKey, updated)
-}

--- a/internal/tx/payment/flow.go
+++ b/internal/tx/payment/flow.go
@@ -613,8 +613,6 @@ func offerDeleteInSandbox(sb *PaymentSandbox, offerKey [32]byte) {
 		return
 	}
 
-	txHash, ledgerSeq := sb.GetTransactionContext()
-
 	// Remove from owner directory
 	ownerDirKey := keylet.OwnerDir(ownerID)
 	state.DirRemove(sb, ownerDirKey, offer.OwnerNode, offerKey, false)
@@ -627,13 +625,13 @@ func offerDeleteInSandbox(sb *PaymentSandbox, offerKey [32]byte) {
 	sb.Erase(offerKL)
 
 	// Decrement owner count
-	adjustOwnerCountInSandbox(sb, ownerID, -1, txHash, ledgerSeq)
+	adjustOwnerCountInSandbox(sb, ownerID, -1)
 }
 
 // adjustOwnerCountInSandbox modifies an account's OwnerCount by delta in a PaymentSandbox.
 // Records the change via AdjustOwnerCount hook so OwnerCountHook returns the maximum.
 // This is a standalone version used by offerDeleteInSandbox.
-func adjustOwnerCountInSandbox(sb *PaymentSandbox, account [20]byte, delta int, txHash [32]byte, ledgerSeq uint32) {
+func adjustOwnerCountInSandbox(sb *PaymentSandbox, account [20]byte, delta int) {
 	// Read current owner count and record via hook before modifying.
 	accountKey := keylet.Account(account)
 	data, err := sb.Read(accountKey)
@@ -644,7 +642,7 @@ func adjustOwnerCountInSandbox(sb *PaymentSandbox, account [20]byte, delta int, 
 			sb.AdjustOwnerCount(account, curOC, uint32(newOC))
 		}
 	}
-	_ = tx.AdjustOwnerCountWithTx(sb, account, delta, txHash, ledgerSeq)
+	_ = tx.AdjustOwnerCount(sb, account, delta)
 }
 
 // RippleCalculateResult bundles the outputs of a RippleCalculate run.

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -602,8 +602,7 @@ func (s *BookStep) removeConsumedTipIfUnfunded(sb *PaymentSandbox) {
 	if err != nil {
 		return
 	}
-	txHash, ledgerSeq := sb.GetTransactionContext()
-	_ = s.deleteOffer(sb, offer, owner, txHash, ledgerSeq)
+	_ = s.deleteOffer(sb, offer, owner)
 }
 
 // prevStepDebtDir returns the previous step's debt direction for the given

--- a/internal/tx/payment/step_book_consume.go
+++ b/internal/tx/payment/step_book_consume.go
@@ -46,8 +46,6 @@ func (s *BookStep) consumeOffer(sb *PaymentSandbox, offer *state.LedgerOffer, co
 		return err
 	}
 
-	txHash, ledgerSeq := sb.GetTransactionContext()
-
 	grossIn := consumedInGross
 	netIn := consumedInNet
 
@@ -95,7 +93,7 @@ func (s *BookStep) consumeOffer(sb *PaymentSandbox, offer *state.LedgerOffer, co
 		if err := sb.Update(offerKey, offerData); err != nil {
 			return err
 		}
-		if err := s.deleteOffer(sb, offer, offerOwner, txHash, ledgerSeq); err != nil {
+		if err := s.deleteOffer(sb, offer, offerOwner); err != nil {
 			return err
 		}
 	} else {
@@ -135,7 +133,7 @@ func (s *BookStep) zeroIn() EitherAmount {
 }
 
 // deleteOffer properly deletes an offer from the ledger.
-func (s *BookStep) deleteOffer(sb *PaymentSandbox, offer *state.LedgerOffer, owner [20]byte, txHash [32]byte, ledgerSeq uint32) error {
+func (s *BookStep) deleteOffer(sb *PaymentSandbox, offer *state.LedgerOffer, owner [20]byte) error {
 	offerKey := keylet.Offer(owner, offer.Sequence)
 
 	ownerDirKey := keylet.OwnerDir(owner)
@@ -154,7 +152,7 @@ func (s *BookStep) deleteOffer(sb *PaymentSandbox, offer *state.LedgerOffer, own
 		s.applyDirRemoveResult(sb, bookResult)
 	}
 
-	if err := s.adjustOwnerCount(sb, owner, -1, txHash, ledgerSeq); err != nil {
+	if err := s.adjustOwnerCount(sb, owner, -1); err != nil {
 		return err
 	}
 

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -424,8 +424,7 @@ func (s *BookStep) groomUnfundedOffer(sb, afView *PaymentSandbox, offer *state.L
 // removableOffers set. Reference: rippled OfferStream.cpp 333-340 (became
 // unfunded: deleted from view_ but not added to permToRemove_).
 func (s *BookStep) dropBecameOffer(sb *PaymentSandbox, offer *state.LedgerOffer, owner [20]byte) {
-	txHash, ledgerSeq := sb.GetTransactionContext()
-	_ = s.deleteOffer(sb, offer, owner, txHash, ledgerSeq)
+	_ = s.deleteOffer(sb, offer, owner)
 }
 
 // tipFullyConsumed reports whether the offer just consumed by the callback is now
@@ -491,8 +490,6 @@ func (s *BookStep) removeExpiredOffer(sb *PaymentSandbox, offer *state.LedgerOff
 		return
 	}
 
-	txHash, ledgerSeq := sb.GetTransactionContext()
-
 	// Remove from owner directory
 	ownerDirKey := keylet.OwnerDir(ownerID)
 	state.DirRemove(sb, ownerDirKey, offer.OwnerNode, offerKey, false)
@@ -505,7 +502,7 @@ func (s *BookStep) removeExpiredOffer(sb *PaymentSandbox, offer *state.LedgerOff
 	sb.Erase(keylet.Keylet{Key: offerKey})
 
 	// Decrement owner count
-	s.adjustOwnerCount(sb, ownerID, -1, txHash, ledgerSeq)
+	s.adjustOwnerCount(sb, ownerID, -1)
 }
 
 // isOfferOwnerAuthorized checks if the offer owner is authorized to hold currency

--- a/internal/tx/payment/step_book_transfer.go
+++ b/internal/tx/payment/step_book_transfer.go
@@ -11,8 +11,11 @@ import (
 // adjustOwnerCount adjusts the OwnerCount on an account.
 // Also records the change via AdjustOwnerCount for the PaymentSandbox's
 // OwnerCountHook, which returns the maximum count seen.
+// It must not touch PreviousTxnID/PreviousTxnLgrSeq: threading is the
+// ApplyStateTable's job at metadata time, and a mid-apply stamp defeats the
+// no-op guards for an owner whose count nets back to its original value.
 // Reference: rippled View.cpp adjustOwnerCount() calls adjustOwnerCountHook()
-func (s *BookStep) adjustOwnerCount(sb *PaymentSandbox, account [20]byte, delta int, txHash [32]byte, ledgerSeq uint32) error {
+func (s *BookStep) adjustOwnerCount(sb *PaymentSandbox, account [20]byte, delta int) error {
 	// Read the current owner count BEFORE modifying so we can record it.
 	accountKey := keylet.Account(account)
 	data, err := sb.Read(accountKey)
@@ -30,7 +33,7 @@ func (s *BookStep) adjustOwnerCount(sb *PaymentSandbox, account [20]byte, delta 
 	sb.AdjustOwnerCount(account, curOC, uint32(newOC))
 
 	// Perform the actual modification.
-	return tx.AdjustOwnerCountWithTx(sb, account, delta, txHash, ledgerSeq)
+	return tx.AdjustOwnerCount(sb, account, delta)
 }
 
 // transferFunds transfers an amount between two accounts.


### PR DESCRIPTION
## Summary
- Root cause of the ledger 99358634 metadata-only replay divergence: `AdjustOwnerCountWithTx` stamped `PreviousTxnID`/`PreviousTxnLgrSeq` on the owner's AccountRoot **mid-apply**, while rippled's `adjustOwnerCount` (View.cpp:1029-1045) only touches `OwnerCount` — threading is exclusively the ApplyStateTable's job at metadata time.
- For an owner whose count nets back to its original value (offer fully consumed −1 while a trust line is auto-created for the proceeds +1), the stamp was the only byte difference between `Original` and `Current`, defeating the `bytes.Equal` no-op guards in `threadOwners`/the meta loop and attaching a spurious `FinalFields` block where rippled emits the node bare. The stamp was invisible in state (threading sets the same final values), which is why only the transaction hash forked.
- Fix: the payment book-step, flow, and engine tec-cleanup owner-count helpers now call plain `AdjustOwnerCount`; `AdjustOwnerCountWithTx` is removed. All call sites are coupled to a child SLE erase, so `ApplyStateTable.threadOwners` already threads the owner at metadata time — same final state, correct bare/FinalFields routing.
- Regression test reproduces the exact mainnet shape (spurious `FinalFields{Account, Balance, Flags, OwnerCount, Sequence}`, no `PreviousFields`, node-level old `PreviousTxnID`) and pins the bare emission plus the state re-threading. Same bug class as #1081 (offer-side mid-apply stamp).

## Test plan
- [x] `go test ./internal/testing/offer/ -run TestPayment_NetZeroOwnerCount_EmitsBareThreadedNode` — red before the fix (spurious FinalFields), green after
- [x] `go test ./internal/tx/... ./internal/testing/...` — pass (only pre-existing out-of-scope conformance failures)
- [x] Full conformance stash-diff: in-scope 1260 pass / 0 fail on both baseline and fix; the 182 out-of-scope failing-test sets are byte-identical
- [x] `golangci-lint run --config .golangci.yml` on touched packages — 0 issues

Fixes #1180