### PR TITLE
feat(consensus): park validations for unheld ledgers, replay once acquired

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1524,8 +1524,9 @@ func (a *Adaptor) preferredLCL(ledger consensus.Ledger, mode consensus.Operating
 			}
 			return ourLCL
 		}
-		// No-trie fallback over trusted-validation tips (rippled's acquiring_
-		// majority, Validations.h:858-879); already filtered to seq >= minSeq.
+		// No-trie fallback over trusted-validation tips (the acquiring_
+		// majority is handled inside GetPreferred); already filtered to
+		// seq >= minSeq.
 		if id, _, ok := h.PreferredFromValidations(minSeq); ok {
 			return id
 		}

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -107,6 +107,14 @@ type ValidationTracker struct {
 	// trieTips records each validator's current trie tip so a newer
 	// validation can remove the old before inserting the new.
 	trieTips map[consensus.NodeID]ledgertrie.Ledger
+
+	// acquiring parks trusted validations whose ledger isn't locally
+	// resolvable yet, keyed by (seq, id) → waiting validators — rippled's
+	// acquiring_ map. Entries drain via checkAcquiredLocked once the
+	// ledger is acquired, and expire with the validations that reference
+	// them (supersede, ExpireOld, trust rotation). nil when the trie is
+	// disabled.
+	acquiring map[acquiringKey]map[consensus.NodeID]struct{}
 }
 
 // NewValidationTracker creates a new validation tracker.
@@ -385,7 +393,11 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	// mirroring rippled's updateTrie precondition. negUNL exclusion lives
 	// on the quorum/support read paths, not on trie membership.
 	if vt.trusted[resolvedID] {
-		vt.updateTrieLocked(resolvedID, validation.LedgerID, preResolvedLedger)
+		var prior *acquiringKey
+		if hasExisting {
+			prior = &acquiringKey{seq: existing.LedgerSeq, id: existing.LedgerID}
+		}
+		vt.updateTrieLocked(resolvedID, validation, preResolvedLedger, prior)
 	}
 
 	// Capture the fire-tuple under the lock; the deferred dispatcher
@@ -559,38 +571,21 @@ func (vt *ValidationTracker) branchSupportExcludingNegUNLLocked(lgr ledgertrie.L
 }
 
 // GetPreferred returns the network-preferred ledger ID and sequence as
-// decided by the ancestry trie. ok is false when the trie is not wired or
-// empty, OR when it is blind to the majority: a trusted validation whose
-// ledger can't be locally resolved never enters the trie (updateTrieLocked
-// drops it), so on a consensus island the majority branch is invisible while
-// the trie prefers our own. rippled avoids this by acquiring the ledger
-// (acquireAsync) and re-inserting; until goXRPL acquisition lands, a trie
-// missing more fresh trusted tips than it holds is inconclusive and callers
-// fall back to the raw trusted-tip majority. largestIssued is the highest
-// sequence this node has validated; it seeds uncommitted support from earlier
-// seqs.
+// decided by the ancestry trie. Parked validations whose ledger has been
+// acquired since the last poll are replayed into the trie first, so the
+// trie decides unconditionally (rippled getPreferred via withTrie,
+// Validations.h:849-879). When the trie yields no tip at all, falls back
+// to the majority over still-acquiring ledgers; ok is false only when
+// the trie is unwired or both sources are empty. largestIssued is the
+// highest sequence this node has validated; it seeds uncommitted support
+// from earlier seqs.
 func (vt *ValidationTracker) GetPreferred(largestIssued uint32) (consensus.LedgerID, uint32, bool) {
-	vt.mu.RLock()
-	defer vt.mu.RUnlock()
+	vt.mu.Lock()
+	defer vt.mu.Unlock()
 	if vt.trie == nil {
 		return consensus.LedgerID{}, 0, false
 	}
-
-	placed, unplaced := 0, 0
-	for nodeID, v := range vt.byNode {
-		if !vt.trusted[nodeID] {
-			continue
-		}
-		tip, hasTip := vt.trieTips[nodeID]
-		if hasTip && tip.Seq() >= v.LedgerSeq {
-			placed++
-		} else {
-			unplaced++
-		}
-	}
-	if unplaced > placed {
-		return consensus.LedgerID{}, 0, false
-	}
+	vt.checkAcquiredLocked()
 
 	var (
 		tip ledgertrie.SpanTip
@@ -602,9 +597,31 @@ func (vt *ValidationTracker) GetPreferred(largestIssued uint32) (consensus.Ledge
 		return consensus.LedgerID{}, 0, false
 	}
 	if !ok {
-		return consensus.LedgerID{}, 0, false
+		return vt.acquiringMajorityLocked()
 	}
 	return tip.ID, tip.Seq, true
+}
+
+// acquiringMajorityLocked is GetPreferred's fallback when the trie holds
+// no tip: the still-acquiring ledger backed by the most trusted
+// validators, ties broken by greater ledger ID (Validations.h:857-878).
+// Caller must hold vt.mu.
+func (vt *ValidationTracker) acquiringMajorityLocked() (consensus.LedgerID, uint32, bool) {
+	var (
+		bestKey acquiringKey
+		bestN   int
+	)
+	for key, parked := range vt.acquiring {
+		n := len(parked)
+		if n > bestN || (n == bestN && lexLessLgrID(bestKey.id, key.id)) {
+			bestKey = key
+			bestN = n
+		}
+	}
+	if bestN == 0 {
+		return consensus.LedgerID{}, 0, false
+	}
+	return bestKey.id, bestKey.seq, true
 }
 
 // ProposersValidated returns the count of trusted validators whose
@@ -803,6 +820,7 @@ func (vt *ValidationTracker) ExpireOld(minSeq uint32) {
 			stale = append(stale, v)
 			if latest, ok := vt.byNode[nodeID]; ok && latest == v {
 				delete(vt.byNode, nodeID)
+				vt.unparkLocked(acquiringKey{seq: v.LedgerSeq, id: v.LedgerID}, nodeID)
 				if vt.trie != nil {
 					if prev, ok := vt.trieTips[nodeID]; ok {
 						safeTrieCall("Remove", func() {

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -112,8 +112,8 @@ type ValidationTracker struct {
 	// resolvable yet, keyed by (seq, id) → waiting validators — rippled's
 	// acquiring_ map. Entries drain via checkAcquiredLocked once the
 	// ledger is acquired, and expire with the validations that reference
-	// them (supersede, ExpireOld, trust rotation). nil when the trie is
-	// disabled.
+	// them (supersede, ExpireOld, FlushStale, trust rotation). nil when
+	// the trie is disabled.
 	acquiring map[acquiringKey]map[consensus.NodeID]struct{}
 }
 
@@ -661,7 +661,10 @@ func (vt *ValidationTracker) ProposersValidated(ledgerID consensus.LedgerID) int
 // getNodesAfter used by checkConsensus to return MovedOn. Like
 // getNodesAfter it reads the trie, so negUNL validators ARE counted here
 // (they steer just like any trusted validator); negUNL only adjusts the
-// quorum threshold, not this "have the peers moved on" signal.
+// quorum threshold, not this "have the peers moved on" signal. Unlike
+// rippled's withTrie, this read doesn't poll checkAcquired: parked
+// validations whose ledger was just acquired appear on the next
+// Add/GetPreferred poll, one sub-round later at most.
 func (vt *ValidationTracker) ProposersFinished(prev consensus.Ledger) int {
 	if prev == nil {
 		return 0
@@ -791,6 +794,7 @@ func (vt *ValidationTracker) FlushStale() {
 			continue
 		}
 		delete(vt.byNode, nodeID)
+		vt.unparkLocked(acquiringKey{seq: v.LedgerSeq, id: v.LedgerID}, nodeID)
 		if prev, ok := vt.trieTips[nodeID]; ok {
 			safeTrieCall("Remove", func() { vt.trie.Remove(prev, 1) })
 			delete(vt.trieTips, nodeID)

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -509,12 +509,12 @@ func (vt *ValidationTracker) countTrustedExcludingNegUNLLocked(
 
 // GetTrustedSupport returns the count of trusted-and-not-negUNL
 // validators committing to this ledger or any descendant — the
-// negUNL-excluded analogue of the trie's branchSupport, used by the
-// engine's quorum and peer-LCL gates. The trie itself now includes
-// negUNL validators (for GetPreferred steering), so the exclusion is
-// applied here in branchSupportExcludingNegUNLLocked rather than at
-// trie membership. Falls back to the flat trusted count when the trie
-// or ancestry is unavailable.
+// negUNL-excluded analogue of the trie's branchSupport. The trie itself
+// includes negUNL validators (for GetPreferred steering), so the
+// exclusion is applied here in branchSupportExcludingNegUNLLocked
+// rather than at trie membership. Polls checkAcquired before reading,
+// rippled's withTrie cadence. Falls back to the flat trusted count when
+// the trie or ancestry is unavailable.
 func (vt *ValidationTracker) GetTrustedSupport(ledgerID consensus.LedgerID) int {
 	// Snapshot pointers, drop the lock for ancestry resolution, then
 	// re-acquire for the cheap trie query.
@@ -532,8 +532,8 @@ func (vt *ValidationTracker) GetTrustedSupport(ledgerID consensus.LedgerID) int 
 		return vt.GetTrustedValidationCount(ledgerID)
 	}
 
-	vt.mu.RLock()
-	defer vt.mu.RUnlock()
+	vt.mu.Lock()
+	defer vt.mu.Unlock()
 	// Trie may have been swapped while we resolved ancestry.
 	if vt.trie != trie {
 		ledgerVals, exists := vt.validations[ledgerID]
@@ -542,6 +542,7 @@ func (vt *ValidationTracker) GetTrustedSupport(ledgerID consensus.LedgerID) int 
 		}
 		return vt.countTrustedExcludingNegUNLLocked(ledgerVals)
 	}
+	vt.checkAcquiredLocked()
 	return vt.branchSupportExcludingNegUNLLocked(lgr)
 }
 
@@ -661,10 +662,7 @@ func (vt *ValidationTracker) ProposersValidated(ledgerID consensus.LedgerID) int
 // getNodesAfter used by checkConsensus to return MovedOn. Like
 // getNodesAfter it reads the trie, so negUNL validators ARE counted here
 // (they steer just like any trusted validator); negUNL only adjusts the
-// quorum threshold, not this "have the peers moved on" signal. Unlike
-// rippled's withTrie, this read doesn't poll checkAcquired: parked
-// validations whose ledger was just acquired appear on the next
-// Add/GetPreferred poll, one sub-round later at most.
+// quorum threshold, not this "have the peers moved on" signal.
 func (vt *ValidationTracker) ProposersFinished(prev consensus.Ledger) int {
 	if prev == nil {
 		return 0
@@ -678,14 +676,15 @@ func (vt *ValidationTracker) ProposersFinished(prev consensus.Ledger) int {
 	vt.mu.RUnlock()
 	if trie != nil && ancestry != nil {
 		if lgr, ok := ancestry.LedgerByID(prev.ID()); ok {
-			vt.mu.RLock()
+			vt.mu.Lock()
 			current := vt.trie == trie
 			var branch, tip uint32
 			if current {
+				vt.checkAcquiredLocked()
 				branch = trie.BranchSupport(lgr)
 				tip = trie.TipSupport(lgr)
 			}
-			vt.mu.RUnlock()
+			vt.mu.Unlock()
 			if current {
 				if branch <= tip {
 					return 0

--- a/internal/consensus/rcl/validations_acquire_test.go
+++ b/internal/consensus/rcl/validations_acquire_test.go
@@ -11,8 +11,7 @@ import (
 // A trusted validation for an unresolvable ledger parks instead of
 // dropping: the node's previous tip keeps steering the trie, and once
 // the ledger is acquired the next GetPreferred poll replays the parked
-// validations and the trie flips — no new validation needed. The old
-// unplaced>placed guard would have returned ok=false while parked.
+// validations and the trie flips — no new validation needed.
 func TestValidationTracker_UnresolvableValidationParksThenReplays(t *testing.T) {
 	vt := NewValidationTracker(2, 5*time.Minute)
 	now := time.Now()
@@ -65,8 +64,7 @@ func TestValidationTracker_UnresolvableValidationParksThenReplays(t *testing.T) 
 }
 
 // The consensus-island shape: the trie decides even when the majority is
-// parked (guard removed), and flips to the majority branch once its
-// ledger is acquired.
+// parked, and flips to the majority branch once its ledger is acquired.
 func TestValidationTracker_TrieDecidesWithMajorityParked(t *testing.T) {
 	vt := NewValidationTracker(3, 5*time.Minute)
 	now := time.Now()
@@ -91,8 +89,8 @@ func TestValidationTracker_TrieDecidesWithMajorityParked(t *testing.T) {
 		vt.Add(makeTrustedValidation(n, abde.ID(), abde.Seq(), now))
 	}
 
-	// 3 trusted validations are parked vs 2 placed — the old guard
-	// returned ok=false here; the trie must decide with what it holds.
+	// 3 trusted validations parked vs 2 placed: the trie must decide
+	// with what it holds.
 	id, _, ok := vt.GetPreferred(0)
 	if !ok {
 		t.Fatal("GetPreferred must not go inconclusive while the majority is parked")

--- a/internal/consensus/rcl/validations_acquire_test.go
+++ b/internal/consensus/rcl/validations_acquire_test.go
@@ -1,0 +1,281 @@
+package rcl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrie"
+)
+
+// A trusted validation for an unresolvable ledger parks instead of
+// dropping: the node's previous tip keeps steering the trie, and once
+// the ledger is acquired the next GetPreferred poll replays the parked
+// validations and the trie flips — no new validation needed. The old
+// unplaced>placed guard would have returned ok=false while parked.
+func TestValidationTracker_UnresolvableValidationParksThenReplays(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abc := b.Build("abc")
+	abcd := b.Build("abcd")
+
+	provider := newMapAncestryProvider()
+	provider.add(abc)
+
+	n1 := consensus.NodeID{1}
+	n2 := consensus.NodeID{2}
+	vt.SetTrusted([]consensus.NodeID{n1, n2})
+	vt.SetLedgerAncestryProvider(provider)
+
+	if !vt.Add(makeTrustedValidation(n1, abc.ID(), abc.Seq(), now)) {
+		t.Fatal("Add(n1->abc) should succeed")
+	}
+	if !vt.Add(makeTrustedValidation(n2, abc.ID(), abc.Seq(), now)) {
+		t.Fatal("Add(n2->abc) should succeed")
+	}
+
+	// Both advance to abcd, which is not locally resolvable yet.
+	if !vt.Add(makeTrustedValidation(n1, abcd.ID(), abcd.Seq(), now)) {
+		t.Fatal("Add(n1->abcd) should succeed")
+	}
+	if !vt.Add(makeTrustedValidation(n2, abcd.ID(), abcd.Seq(), now)) {
+		t.Fatal("Add(n2->abcd) should succeed")
+	}
+
+	id, seq, ok := vt.GetPreferred(0)
+	if !ok {
+		t.Fatal("GetPreferred must stay conclusive while validations are parked")
+	}
+	if id != abc.ID() || seq != abc.Seq() {
+		t.Fatalf("GetPreferred while parked: got seq %d, want prior tip abc@%d", seq, abc.Seq())
+	}
+
+	// Acquisition lands; the next poll replays the parked validations.
+	provider.add(abcd)
+	id, seq, ok = vt.GetPreferred(0)
+	if !ok {
+		t.Fatal("GetPreferred after acquisition: no result")
+	}
+	if id != abcd.ID() || seq != abcd.Seq() {
+		t.Fatalf("GetPreferred after acquisition: got seq %d, want replayed abcd@%d", seq, abcd.Seq())
+	}
+}
+
+// The consensus-island shape: the trie decides even when the majority is
+// parked (guard removed), and flips to the majority branch once its
+// ledger is acquired.
+func TestValidationTracker_TrieDecidesWithMajorityParked(t *testing.T) {
+	vt := NewValidationTracker(3, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abc := b.Build("abc")   // island tip, locally held
+	abde := b.Build("abde") // majority tip, not held yet
+
+	provider := newMapAncestryProvider()
+	provider.add(abc)
+
+	island := []consensus.NodeID{{1}, {2}}
+	majority := []consensus.NodeID{{3}, {4}, {5}}
+	vt.SetTrusted(append(append([]consensus.NodeID{}, island...), majority...))
+	vt.SetLedgerAncestryProvider(provider)
+
+	for _, n := range island {
+		vt.Add(makeTrustedValidation(n, abc.ID(), abc.Seq(), now))
+	}
+	for _, n := range majority {
+		vt.Add(makeTrustedValidation(n, abde.ID(), abde.Seq(), now))
+	}
+
+	// 3 trusted validations are parked vs 2 placed — the old guard
+	// returned ok=false here; the trie must decide with what it holds.
+	id, _, ok := vt.GetPreferred(0)
+	if !ok {
+		t.Fatal("GetPreferred must not go inconclusive while the majority is parked")
+	}
+	if id != abc.ID() {
+		t.Fatalf("GetPreferred while majority parked: want the placed island tip abc")
+	}
+
+	// Majority ledger acquired: replay flips the trie, 3 beats 2.
+	provider.add(abde)
+	id, seq, ok := vt.GetPreferred(0)
+	if !ok {
+		t.Fatal("GetPreferred after majority acquisition: no result")
+	}
+	if id != abde.ID() || seq != abde.Seq() {
+		t.Fatalf("GetPreferred after majority acquisition: got seq %d, want abde@%d (3v2)", seq, abde.Seq())
+	}
+}
+
+// checkAcquired also polls on the Add path, mirroring rippled's
+// updateTrie: an unrelated resolvable validation replays parked entries.
+func TestValidationTracker_AddPollReplaysParked(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abc := b.Build("abc")
+	abcd := b.Build("abcd")
+
+	provider := newMapAncestryProvider()
+	provider.add(abc)
+
+	n1 := consensus.NodeID{1}
+	n2 := consensus.NodeID{2}
+	vt.SetTrusted([]consensus.NodeID{n1, n2})
+	vt.SetLedgerAncestryProvider(provider)
+
+	vt.Add(makeTrustedValidation(n1, abcd.ID(), abcd.Seq(), now))
+	provider.add(abcd)
+
+	// Resolvable but not replayed yet — GetTrustedSupport reads the trie
+	// without polling, so n1's tip is still absent.
+	if got := vt.GetTrustedSupport(abcd.ID()); got != 0 {
+		t.Fatalf("branch support before replay: got %d, want 0", got)
+	}
+
+	vt.Add(makeTrustedValidation(n2, abc.ID(), abc.Seq(), now))
+	if got := vt.GetTrustedSupport(abcd.ID()); got != 1 {
+		t.Fatalf("branch support after Add-path replay: got %d, want 1", got)
+	}
+}
+
+// With nothing placed at all, GetPreferred falls back to the majority
+// over still-acquiring ledgers: most parked validators first, ties to
+// the greater ledger ID.
+func TestValidationTracker_GetPreferred_AcquiringMajorityFallback(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abcx := b.Build("abcx")
+	abcy := b.Build("abcy")
+
+	vt.SetTrusted([]consensus.NodeID{{1}, {2}, {3}})
+	vt.SetLedgerAncestryProvider(newMapAncestryProvider())
+
+	vt.Add(makeTrustedValidation(consensus.NodeID{1}, abcx.ID(), abcx.Seq(), now))
+	vt.Add(makeTrustedValidation(consensus.NodeID{2}, abcx.ID(), abcx.Seq(), now))
+	vt.Add(makeTrustedValidation(consensus.NodeID{3}, abcy.ID(), abcy.Seq(), now))
+
+	id, seq, ok := vt.GetPreferred(0)
+	if !ok {
+		t.Fatal("acquiring-majority fallback: no result")
+	}
+	if id != abcx.ID() || seq != abcx.Seq() {
+		t.Fatalf("acquiring-majority fallback: want abcx (2 parked beats 1)")
+	}
+}
+
+func TestValidationTracker_GetPreferred_AcquiringTieBreaksOnGreaterID(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abcx := b.Build("abcx")
+	abcy := b.Build("abcy") // same seq, greater ID than abcx
+
+	vt.SetTrusted([]consensus.NodeID{{1}, {2}})
+	vt.SetLedgerAncestryProvider(newMapAncestryProvider())
+
+	vt.Add(makeTrustedValidation(consensus.NodeID{1}, abcx.ID(), abcx.Seq(), now))
+	vt.Add(makeTrustedValidation(consensus.NodeID{2}, abcy.ID(), abcy.Seq(), now))
+
+	id, _, ok := vt.GetPreferred(0)
+	if !ok {
+		t.Fatal("acquiring-majority tie: no result")
+	}
+	if id != abcy.ID() {
+		t.Fatalf("acquiring-majority tie: want the greater ledger ID abcy")
+	}
+}
+
+// A superseding validation removes the node from its prior parked entry,
+// so abandoned acquiring entries don't linger.
+func TestValidationTracker_SupersededValidationUnparks(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abcz := b.Build("abcz")   // greater ID: would win the tie-break if it lingered
+	abcwv := b.Build("abcwv") // higher seq, lesser ID at the fork byte
+
+	n1 := consensus.NodeID{1}
+	vt.SetTrusted([]consensus.NodeID{n1})
+	vt.SetLedgerAncestryProvider(newMapAncestryProvider())
+
+	vt.Add(makeTrustedValidation(n1, abcz.ID(), abcz.Seq(), now))
+	vt.Add(makeTrustedValidation(n1, abcwv.ID(), abcwv.Seq(), now))
+
+	id, seq, ok := vt.GetPreferred(0)
+	if !ok {
+		t.Fatal("fallback after supersede: no result")
+	}
+	if id != abcwv.ID() || seq != abcwv.Seq() {
+		t.Fatalf("fallback after supersede: got seq %d, want only the latest parked ledger abcwv@%d", seq, abcwv.Seq())
+	}
+}
+
+// ExpireOld drops parked entries with the validations that reference
+// them — acquiring_ never outlives its validations.
+func TestValidationTracker_ExpireOldUnparks(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abcd := b.Build("abcd")
+
+	n1 := consensus.NodeID{1}
+	vt.SetTrusted([]consensus.NodeID{n1})
+	vt.SetLedgerAncestryProvider(newMapAncestryProvider())
+
+	vt.Add(makeTrustedValidation(n1, abcd.ID(), abcd.Seq(), now))
+	vt.ExpireOld(abcd.Seq() + 1)
+
+	if _, _, ok := vt.GetPreferred(0); ok {
+		t.Fatal("expired parked validation must not feed the acquiring fallback")
+	}
+}
+
+// Trust rotation rebuilds the parked set from byNode: a de-trusted
+// node's parked entry drops, and re-trusting re-parks its latest
+// validation.
+func TestValidationTracker_TrustChangeReparksFromByNode(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abcd := b.Build("abcd")
+
+	n1 := consensus.NodeID{1}
+	n2 := consensus.NodeID{2}
+	vt.SetTrusted([]consensus.NodeID{n1, n2})
+	vt.SetLedgerAncestryProvider(newMapAncestryProvider())
+
+	vt.Add(makeTrustedValidation(n1, abcd.ID(), abcd.Seq(), now))
+
+	vt.SetTrusted([]consensus.NodeID{n2})
+	if _, _, ok := vt.GetPreferred(0); ok {
+		t.Fatal("de-trusted node's parked validation must not feed the acquiring fallback")
+	}
+
+	vt.SetTrusted([]consensus.NodeID{n1, n2})
+	id, _, ok := vt.GetPreferred(0)
+	if !ok {
+		t.Fatal("re-trusting must re-park the node's latest validation")
+	}
+	if id != abcd.ID() {
+		t.Fatalf("re-parked fallback: want abcd")
+	}
+}

--- a/internal/consensus/rcl/validations_acquire_test.go
+++ b/internal/consensus/rcl/validations_acquire_test.go
@@ -110,9 +110,11 @@ func TestValidationTracker_TrieDecidesWithMajorityParked(t *testing.T) {
 	}
 }
 
-// checkAcquired also polls on the Add path, mirroring rippled's
-// updateTrie: an unrelated resolvable validation replays parked entries.
-func TestValidationTracker_AddPollReplaysParked(t *testing.T) {
+// Trie reads poll checkAcquired like rippled's withTrie (Validations.h:
+// 483-491): a parked validation whose ledger has been acquired is
+// replayed by the read itself — no intervening Add or GetPreferred
+// (rippled testAcquireValidatedLedger, Validations_test.cpp:958-961).
+func TestValidationTracker_ReadPollReplaysParked(t *testing.T) {
 	vt := NewValidationTracker(2, 5*time.Minute)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
@@ -125,22 +127,45 @@ func TestValidationTracker_AddPollReplaysParked(t *testing.T) {
 	provider.add(abc)
 
 	n1 := consensus.NodeID{1}
-	n2 := consensus.NodeID{2}
-	vt.SetTrusted([]consensus.NodeID{n1, n2})
+	vt.SetTrusted([]consensus.NodeID{n1})
+	vt.SetLedgerAncestryProvider(provider)
+
+	vt.Add(makeTrustedValidation(n1, abc.ID(), abc.Seq(), now))
+	// Advance to abcd, not held: parks, tip stays abc.
+	vt.Add(makeTrustedValidation(n1, abcd.ID(), abcd.Seq(), now))
+
+	prev := &mockLedger{id: abc.ID(), seq: abc.Seq()}
+	if got := vt.ProposersFinished(prev); got != 0 {
+		t.Fatalf("ProposersFinished while parked: got %d, want 0", got)
+	}
+
+	provider.add(abcd)
+	if got := vt.ProposersFinished(prev); got != 1 {
+		t.Fatalf("ProposersFinished must replay parked validations: got %d, want 1", got)
+	}
+}
+
+// GetTrustedSupport's read also polls: an acquired-but-unreplayed parked
+// validation counts toward branch support with no intervening call.
+func TestValidationTracker_GetTrustedSupportPollReplaysParked(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abcd := b.Build("abcd")
+
+	provider := newMapAncestryProvider()
+
+	n1 := consensus.NodeID{1}
+	vt.SetTrusted([]consensus.NodeID{n1})
 	vt.SetLedgerAncestryProvider(provider)
 
 	vt.Add(makeTrustedValidation(n1, abcd.ID(), abcd.Seq(), now))
+
 	provider.add(abcd)
-
-	// Resolvable but not replayed yet — GetTrustedSupport reads the trie
-	// without polling, so n1's tip is still absent.
-	if got := vt.GetTrustedSupport(abcd.ID()); got != 0 {
-		t.Fatalf("branch support before replay: got %d, want 0", got)
-	}
-
-	vt.Add(makeTrustedValidation(n2, abc.ID(), abc.Seq(), now))
 	if got := vt.GetTrustedSupport(abcd.ID()); got != 1 {
-		t.Fatalf("branch support after Add-path replay: got %d, want 1", got)
+		t.Fatalf("GetTrustedSupport must replay parked validations: got %d, want 1", got)
 	}
 }
 

--- a/internal/consensus/rcl/validations_acquire_test.go
+++ b/internal/consensus/rcl/validations_acquire_test.go
@@ -247,6 +247,80 @@ func TestValidationTracker_ExpireOldUnparks(t *testing.T) {
 	}
 }
 
+// FlushStale drops parked entries with the flushed validation, mirroring
+// rippled's stale sweep (removeTrie erases acquiring_, Validations.h:
+// 363-372): a validator that goes silent while parked must stop feeding
+// the acquiring fallback, and must not be resurrected into the trie as a
+// phantom tip once its ledger is finally acquired.
+func TestValidationTracker_FlushStaleUnparks(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abcd := b.Build("abcd")
+
+	provider := newMapAncestryProvider()
+
+	n1 := consensus.NodeID{1}
+	vt.SetTrusted([]consensus.NodeID{n1})
+	vt.SetLedgerAncestryProvider(provider)
+
+	if !vt.Add(makeTrustedValidation(n1, abcd.ID(), abcd.Seq(), now)) {
+		t.Fatal("Add(n1->abcd) should succeed")
+	}
+
+	now = now.Add(validationCurrentEarly + time.Second)
+	vt.FlushStale()
+
+	if _, _, ok := vt.GetPreferred(0); ok {
+		t.Fatal("flushed-stale parked validation must not feed the acquiring fallback")
+	}
+
+	// The parked ledger is acquired after the flush: the dead node's
+	// validation must not replay.
+	provider.add(abcd)
+	if _, _, ok := vt.GetPreferred(0); ok {
+		t.Fatal("flushed-stale parked validation must not replay into the trie")
+	}
+	if got := vt.GetTrustedSupport(abcd.ID()); got != 0 {
+		t.Fatalf("phantom trie tip after flush+acquire: support %d, want 0", got)
+	}
+}
+
+// A validation parked while trusted must not replay once the node is
+// de-trusted, even after its ledger is acquired (rippled
+// Validations_test.cpp:1098-1124, "Trusted but not acquired ->
+// untrusted").
+func TestValidationTracker_DetrustedParkedValidationNotReplayed(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abcd := b.Build("abcd")
+
+	provider := newMapAncestryProvider()
+
+	n1 := consensus.NodeID{1}
+	vt.SetTrusted([]consensus.NodeID{n1})
+	vt.SetLedgerAncestryProvider(provider)
+
+	if !vt.Add(makeTrustedValidation(n1, abcd.ID(), abcd.Seq(), now)) {
+		t.Fatal("Add(n1->abcd) should succeed")
+	}
+
+	vt.SetTrusted([]consensus.NodeID{})
+	provider.add(abcd)
+
+	if _, _, ok := vt.GetPreferred(0); ok {
+		t.Fatal("de-trusted parked validation must not replay after acquisition")
+	}
+	if got := vt.GetTrustedSupport(abcd.ID()); got != 0 {
+		t.Fatalf("de-trusted parked validation counted as support: got %d, want 0", got)
+	}
+}
+
 // Trust rotation rebuilds the parked set from byNode: a de-trusted
 // node's parked entry drops, and re-trusting re-parks its latest
 // validation.

--- a/internal/consensus/rcl/validations_trie.go
+++ b/internal/consensus/rcl/validations_trie.go
@@ -12,6 +12,13 @@ type LedgerAncestryProvider interface {
 	LedgerByID(id consensus.LedgerID) (ledgertrie.Ledger, bool)
 }
 
+// acquiringKey identifies a ledger referenced by trusted validations but
+// not yet locally resolvable — the key of rippled's acquiring_ map.
+type acquiringKey struct {
+	seq uint32
+	id  consensus.LedgerID
+}
+
 // SetLedgerAncestryProvider installs a provider and enables the trie.
 // Passing nil disables the trie and reverts to flat-count support.
 // The trie is rebuilt from the current byNode / trusted / negUNL state.
@@ -23,6 +30,7 @@ func (vt *ValidationTracker) SetLedgerAncestryProvider(p LedgerAncestryProvider)
 		vt.ancestry = nil
 		vt.trie = nil
 		vt.trieTips = nil
+		vt.acquiring = nil
 		return
 	}
 	vt.ancestry = p
@@ -41,6 +49,7 @@ func (vt *ValidationTracker) rebuildTrieLocked() {
 	}
 	vt.trie = ledgertrie.New(genesisLedger{})
 	vt.trieTips = make(map[consensus.NodeID]ledgertrie.Ledger)
+	vt.acquiring = make(map[acquiringKey]map[consensus.NodeID]struct{})
 
 	for nodeID, v := range vt.byNode {
 		// Seed on trusted() alone — negUNL validators included, mirroring
@@ -51,36 +60,105 @@ func (vt *ValidationTracker) rebuildTrieLocked() {
 		}
 		lgr, ok := vt.ancestry.LedgerByID(v.LedgerID)
 		if !ok {
+			vt.parkLocked(acquiringKey{seq: v.LedgerSeq, id: v.LedgerID}, nodeID)
 			continue
 		}
-		safeTrieCall("Insert", func() { vt.trie.Insert(lgr, 1) })
-		vt.trieTips[nodeID] = lgr
+		vt.insertTipLocked(nodeID, lgr)
 	}
 }
 
-// updateTrieLocked replaces nodeID's previous trie tip (if any) with
-// newLedgerID's tip. Silent no-op if ancestry is unavailable.
+// updateTrieLocked places validation's ledger as nodeID's trie tip, or
+// parks the validation until the ledger is acquired (rippled updateTrie,
+// Validations.h:431-469). The node's previous tip keeps steering the trie
+// while its latest validation is parked. Silent no-op if the trie is
+// unavailable.
 //
 // preResolved is the ledger Add() walked outside vt.mu to avoid
 // serialising cold-LRU lookups; if nil or stale we resolve under lock.
+// prior is the (seq, id) of the node's superseded validation, cleared
+// from any parked entry first.
 //
 // Precondition: caller holds vt.mu (write) and has verified nodeID is
 // trusted. negUNL validators are intentionally inserted (they steer
 // GetPreferred); exclusion happens on the quorum/support read paths.
-func (vt *ValidationTracker) updateTrieLocked(nodeID consensus.NodeID, newLedgerID consensus.LedgerID, preResolved ledgertrie.Ledger) {
+func (vt *ValidationTracker) updateTrieLocked(nodeID consensus.NodeID, validation *consensus.Validation, preResolved ledgertrie.Ledger, prior *acquiringKey) {
 	if vt.trie == nil || vt.ancestry == nil {
 		return
 	}
 
+	if prior != nil {
+		vt.unparkLocked(*prior, nodeID)
+	}
+	vt.checkAcquiredLocked()
+
+	key := acquiringKey{seq: validation.LedgerSeq, id: validation.LedgerID}
+	if parked, ok := vt.acquiring[key]; ok {
+		parked[nodeID] = struct{}{}
+		return
+	}
+
 	lgr := preResolved
-	if lgr == nil || lgr.ID() != newLedgerID {
+	if lgr == nil || lgr.ID() != validation.LedgerID {
 		var ok bool
-		lgr, ok = vt.ancestry.LedgerByID(newLedgerID)
+		lgr, ok = vt.ancestry.LedgerByID(validation.LedgerID)
 		if !ok {
+			// Park until acquisition lands. The fetch itself is armed by
+			// the router on every trusted current validation
+			// (maybeAcquireFromValidation); replay happens on the next
+			// checkAcquiredLocked poll.
+			vt.parkLocked(key, nodeID)
 			return
 		}
 	}
+	vt.insertTipLocked(nodeID, lgr)
+}
 
+// checkAcquiredLocked replays parked validations whose ledger has become
+// locally resolvable into the trie (rippled checkAcquired). Polled from
+// updateTrieLocked on every trusted validation and from GetPreferred —
+// the same cadence as rippled's updateTrie / withTrie. Caller must hold
+// vt.mu (write).
+func (vt *ValidationTracker) checkAcquiredLocked() {
+	for key, nodes := range vt.acquiring {
+		lgr, ok := vt.ancestry.LedgerByID(key.id)
+		if !ok {
+			continue
+		}
+		for nodeID := range nodes {
+			vt.insertTipLocked(nodeID, lgr)
+		}
+		delete(vt.acquiring, key)
+	}
+}
+
+// parkLocked records nodeID as waiting on key's ledger acquisition.
+// Caller must hold vt.mu (write).
+func (vt *ValidationTracker) parkLocked(key acquiringKey, nodeID consensus.NodeID) {
+	parked, ok := vt.acquiring[key]
+	if !ok {
+		parked = make(map[consensus.NodeID]struct{})
+		vt.acquiring[key] = parked
+	}
+	parked[nodeID] = struct{}{}
+}
+
+// unparkLocked removes nodeID from key's parked set, dropping the entry
+// when it empties. No-op if the entry or node is absent. Caller must
+// hold vt.mu (write).
+func (vt *ValidationTracker) unparkLocked(key acquiringKey, nodeID consensus.NodeID) {
+	parked, ok := vt.acquiring[key]
+	if !ok {
+		return
+	}
+	delete(parked, nodeID)
+	if len(parked) == 0 {
+		delete(vt.acquiring, key)
+	}
+}
+
+// insertTipLocked replaces nodeID's previous trie tip (if any) with lgr.
+// Caller must hold vt.mu (write).
+func (vt *ValidationTracker) insertTipLocked(nodeID consensus.NodeID, lgr ledgertrie.Ledger) {
 	if prev, existed := vt.trieTips[nodeID]; existed {
 		safeTrieCall("Remove", func() { vt.trie.Remove(prev, 1) })
 	}

--- a/internal/consensus/rcl/validations_trie.go
+++ b/internal/consensus/rcl/validations_trie.go
@@ -115,8 +115,9 @@ func (vt *ValidationTracker) updateTrieLocked(nodeID consensus.NodeID, validatio
 
 // checkAcquiredLocked replays parked validations whose ledger has become
 // locally resolvable into the trie (rippled checkAcquired). Polled from
-// updateTrieLocked on every trusted validation and from GetPreferred.
-// Caller must hold vt.mu (write).
+// updateTrieLocked on every trusted validation and from every trie read
+// (GetPreferred, ProposersFinished, GetTrustedSupport) — rippled's
+// updateTrie / withTrie cadence. Caller must hold vt.mu (write).
 func (vt *ValidationTracker) checkAcquiredLocked() {
 	for key, nodes := range vt.acquiring {
 		lgr, ok := vt.ancestry.LedgerByID(key.id)

--- a/internal/consensus/rcl/validations_trie.go
+++ b/internal/consensus/rcl/validations_trie.go
@@ -115,9 +115,8 @@ func (vt *ValidationTracker) updateTrieLocked(nodeID consensus.NodeID, validatio
 
 // checkAcquiredLocked replays parked validations whose ledger has become
 // locally resolvable into the trie (rippled checkAcquired). Polled from
-// updateTrieLocked on every trusted validation and from GetPreferred —
-// the same cadence as rippled's updateTrie / withTrie. Caller must hold
-// vt.mu (write).
+// updateTrieLocked on every trusted validation and from GetPreferred.
+// Caller must hold vt.mu (write).
 func (vt *ValidationTracker) checkAcquiredLocked() {
 	for key, nodes := range vt.acquiring {
 		lgr, ok := vt.ancestry.LedgerByID(key.id)


### PR DESCRIPTION
## Summary

- **Park instead of drop**: a trusted validation whose ledger can't be resolved locally no longer vanishes from the ancestry trie — it is parked per `(seq, hash)` with a deduped validator set (rippled's `acquiring_`, `Validations.h:346`). The node's previous tip keeps steering the trie in the interim.
- **Replay on acquisition** (`checkAcquired`): parked validations are replayed into the trie once the ledger becomes resolvable, polled on every trusted-validation `Add` and every `GetPreferred` — the same cadence as rippled's `updateTrie`/`withTrie`. The fetch itself is armed by the existing router plumbing (`maybeAcquireFromValidation` fires on every trusted current validation, #1161), so no new acquisition driver is introduced.
- **Guard removed**: `GetPreferred` no longer returns inconclusive when `unplaced > placed`; the trie decides unconditionally, with rippled's acquiring-majority fallback (most parked trusted validators, ties to the greater ledger ID, `Validations.h:857-878`) when the trie holds no tip at all.
- **Bounded lifetime**: parked entries expire with the validations that reference them — cleared on supersede (`prior` handling), `ExpireOld`, and trust rotation (`rebuildTrieLocked` re-parks from `byNode`), mirroring rippled's `removeTrie`/`trustChanged`.

Island-heal flow: majority validations park → router arms the fetch → ledger adopted → next poll replays → trie flips to the majority branch. This restores rippled's exact preferred-ledger semantics under partial ledger knowledge.

## Test plan

- [x] 8 new tracker tests (`validations_acquire_test.go`): park-keeps-prior-tip, replay via `GetPreferred` poll, replay via `Add` poll, trie-decides-with-majority-parked (island shape, guard inversion) + flip-after-acquire, acquiring-majority fallback + greater-ID tie-break, unpark on supersede, unpark on `ExpireOld`, re-park on trust rotation
- [x] `go test ./internal/consensus/...` — all green (re-run after merging main)
- [x] `golangci-lint run --config .golangci.yml ./internal/consensus/...` — 0 issues
- [x] Conformance suite byte-identical to the pre-change baseline (1326 pass; fails only in known out-of-scope suites)

Fixes #1184