### PR TITLE
fix: seed prevRoundTime to the idle interval on the first round

### DIFF
--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -108,6 +108,11 @@ type Engine struct {
 	prevRoundTime  time.Duration
 	roundStartTime time.Time
 
+	// firstRound seeds prevRoundTime to the idle interval on the first round
+	// after boot, so round 1's convergePercent divisor and close gates divide
+	// by the idle interval instead of zero (rippled firstRound_).
+	firstRound bool
+
 	// lastConvergePercent retains convergePercent() from the last
 	// phaseEstablish tick (reset at round start) so consensus_info reports a
 	// meaningful value between rounds. The live convergePercent() still
@@ -330,6 +335,7 @@ func NewEngine(adaptor consensus.Adaptor, config Config) *Engine {
 		parms:           consensus.DefaultConsensusParms(),
 		now:             config.Clock,
 		manualTick:      config.ManualTick,
+		firstRound:      true,
 	}
 	if e.now == nil {
 		e.now = time.Now
@@ -496,6 +502,15 @@ func (e *Engine) StartRound(round consensus.RoundID, proposing bool) error {
 // the new round's tx-set isn't coherent yet and a stale emission would
 // poison convergence.
 func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering bool) error {
+	// On the first round after boot there is no prior round to measure, so
+	// seed prevRoundTime to the idle interval — otherwise convergePercent
+	// would divide by the 5s floor and the openTime/2 close gate by zero,
+	// escalating avalanche state ~3x faster than rippled in round 1.
+	if e.firstRound {
+		e.prevRoundTime = e.timing.LedgerIdleInterval
+		e.firstRound = false
+	}
+
 	// Before the mode switch so it runs in every mode (preStartRound parity).
 	e.driveNegativeUNLNewValidatorsLocked()
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -108,9 +108,6 @@ type Engine struct {
 	prevRoundTime  time.Duration
 	roundStartTime time.Time
 
-	// firstRound seeds prevRoundTime to the idle interval on the first round
-	// after boot, so round 1's convergePercent divisor and close gates divide
-	// by the idle interval instead of zero (rippled firstRound_).
 	firstRound bool
 
 	// lastConvergePercent retains convergePercent() from the last
@@ -502,10 +499,9 @@ func (e *Engine) StartRound(round consensus.RoundID, proposing bool) error {
 // the new round's tx-set isn't coherent yet and a stale emission would
 // poison convergence.
 func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering bool) error {
-	// On the first round after boot there is no prior round to measure, so
-	// seed prevRoundTime to the idle interval — otherwise convergePercent
-	// would divide by the 5s floor and the openTime/2 close gate by zero,
-	// escalating avalanche state ~3x faster than rippled in round 1.
+	// First round after boot has no prior round to measure; seed prevRoundTime
+	// to the idle interval so round-1 convergePercent uses the 15s divisor, not
+	// the 5s floor (else avalanche state escalates ~3x faster than rippled).
 	if e.firstRound {
 		e.prevRoundTime = e.timing.LedgerIdleInterval
 		e.firstRound = false

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -687,6 +687,47 @@ func TestEngine_StartRound_Observing(t *testing.T) {
 	}
 }
 
+// TestEngine_FirstRoundSeedsPrevRoundTime pins rippled's firstRound_ seeding
+// (Consensus.h:658-664): the first round after boot has no prior round to
+// measure, so prevRoundTime is seeded to the idle interval. Without the seed,
+// round-1 convergePercent divides by the 5s floor instead of 15s, escalating
+// avalanche state ~3x faster than a rippled node in the same round.
+func TestEngine_FirstRoundSeedsPrevRoundTime(t *testing.T) {
+	adaptor := newMockAdaptor()
+	config := DefaultConfig()
+
+	now := time.Unix(1000, 0)
+	config.Clock = func() time.Time { return now }
+
+	engine := NewEngine(adaptor, config)
+
+	if !engine.firstRound {
+		t.Fatal("fresh engine should have firstRound=true")
+	}
+	if engine.prevRoundTime != 0 {
+		t.Fatalf("fresh engine prevRoundTime = %v, want 0", engine.prevRoundTime)
+	}
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	if err := engine.StartRound(round, false); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+
+	if engine.firstRound {
+		t.Error("firstRound should be cleared after the first round")
+	}
+	if got, want := engine.prevRoundTime, config.Timing.LedgerIdleInterval; got != want {
+		t.Errorf("prevRoundTime after first round = %v, want idle interval %v", got, want)
+	}
+
+	// convergePercent must divide by the seeded idle interval (15s), not the
+	// 5s avMinConsensusTime floor: 3s elapsed → 20%, not 60%.
+	now = now.Add(3 * time.Second)
+	if got := engine.convergePercent(); got != 20 {
+		t.Errorf("round-1 convergePercent = %d, want 20 (15s divisor, not the 5s floor)", got)
+	}
+}
+
 // TestEngine_StartRound_DrivesOnUNLChange pins the wiring that
 // mirrors rippled's NetworkOPs.cpp:2081-2102 → RCLConsensus.cpp:1041-1043
 // pairing: at the head of every consensus round, the engine computes the


### PR DESCRIPTION
## Summary
- Seed `prevRoundTime` to the idle interval (`LedgerIdleInterval`, 15s) on the first consensus round after boot, mirroring rippled's `firstRound_` seeding (`Consensus.h:658-664`).
- On round 1 there is no prior round to measure. Previously `prevRoundTime` stayed at its zero value until the first `accept`, so `convergePercent` divided by the 5s `avMinConsensusTime` floor instead of 15s (avalanche state / close-time avalanche ran ~3x faster than a rippled node in the same round), and the `openTime < prevRoundTime/2` close gate was trivially false.
- One-round-only effect; a new `firstRound` flag clears after the first round so the accept path takes over as before.

## Test plan
- [x] `go test ./internal/consensus/rcl/` — new `TestEngine_FirstRoundSeedsPrevRoundTime` asserts the seed and that round-1 `convergePercent` uses the 15s divisor (3s elapsed → 20%, not 60%).
- [x] `go test ./internal/consensus/...` — full consensus suite (incl. csf simulation) green, no regressions.

Fixes #1187