### PR TITLE
fix: re-share replayed peer proposals after a ledger switch

### DIFF
--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -1677,7 +1677,6 @@ func (e *Engine) handleWrongLedger(netLedgerID consensus.LedgerID, target consen
 			}
 		}
 
-		// Re-share replayed positions to peers on the switched-to ledger.
 		for _, p := range relay {
 			e.adaptor.RelayProposal(p, 0)
 		}

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -554,9 +554,15 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 
 	// Replay buffered proposals for this round's prevLedger.
 	if e.prevLedger != nil {
-		closeTimes, replayed := e.proposalTracker.Replay(e.prevLedger.ID(), e.adaptor.IsTrusted)
+		closeTimes, replayed, relay := e.proposalTracker.Replay(e.prevLedger.ID(), e.adaptor.IsTrusted)
 		for _, ct := range closeTimes {
 			e.state.CloseTimes.Peers[ct]++
+		}
+
+		// Re-share replayed positions so peers that missed a proposal on this
+		// prevLedger get re-fed it from us during the recovery window.
+		for _, p := range relay {
+			e.adaptor.RelayProposal(p, 0)
 		}
 
 		// Peer pressure: if a majority of prior proposers already closed,
@@ -1664,11 +1670,16 @@ func (e *Engine) handleWrongLedger(netLedgerID consensus.LedgerID, target consen
 
 		// Replay proposals for the new ledger; close-time votes only if a
 		// round state exists.
-		closeTimes, _ := e.proposalTracker.Replay(netLedgerID, e.adaptor.IsTrusted)
+		closeTimes, _, relay := e.proposalTracker.Replay(netLedgerID, e.adaptor.IsTrusted)
 		if e.state != nil {
 			for _, ct := range closeTimes {
 				e.state.CloseTimes.Peers[ct]++
 			}
+		}
+
+		// Re-share replayed positions to peers on the switched-to ledger.
+		for _, p := range relay {
+			e.adaptor.RelayProposal(p, 0)
 		}
 	}
 

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -922,6 +922,61 @@ func TestEngine_OnProposal_Untrusted(t *testing.T) {
 	}
 }
 
+// TestEngine_StartRound_ResharesReplayedProposals pins issue #1188: after a
+// ledger switch / round start, buffered peer proposals for the new prevLedger
+// are re-shared to peers (rippled playbackProposals + adaptor_.share), not just
+// stored. Without the re-share, a peer that missed a proposal would not be
+// re-fed it on the recovery path.
+func TestEngine_StartRound_ResharesReplayedProposals(t *testing.T) {
+	prev := &mockLedger{id: consensus.LedgerID{0x11}, seq: 100}
+	adaptor := newMockAdaptor()
+	adaptor.lastLCL = prev
+	adaptor.ledgers[prev.ID()] = prev
+	peer := consensus.NodeID{2}
+	adaptor.setTrusted([]consensus.NodeID{peer})
+
+	engine := NewEngine(adaptor, DefaultConfig())
+
+	// Buffer a peer proposal between rounds (accepted phase): OnProposal only
+	// buffers it, it does not relay yet.
+	proposal := &consensus.Proposal{
+		Round:          consensus.RoundID{Seq: 101, ParentHash: prev.ID()},
+		NodeID:         peer,
+		Position:       0,
+		TxSet:          consensus.TxSetID{1},
+		CloseTime:      time.Now(),
+		PreviousLedger: prev.ID(),
+		Timestamp:      time.Now(),
+	}
+	if err := engine.OnProposal(proposal, 0); err != nil {
+		t.Fatalf("OnProposal (buffer): %v", err)
+	}
+	adaptor.mu.RLock()
+	preRelay := len(adaptor.proposalsRelayed)
+	adaptor.mu.RUnlock()
+	if preRelay != 0 {
+		t.Fatalf("between-round proposal must be buffered not relayed; got %d relays", preRelay)
+	}
+
+	// Enter the round whose prevLedger matches the buffered proposal.
+	engine.mu.Lock()
+	engine.prevLedger = prev
+	engine.mu.Unlock()
+	round := consensus.RoundID{Seq: 101, ParentHash: prev.ID()}
+	if err := engine.StartRound(round, false); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+
+	adaptor.mu.RLock()
+	defer adaptor.mu.RUnlock()
+	if len(adaptor.proposalsRelayed) != 1 {
+		t.Fatalf("replayed proposal not re-shared: got %d relays, want 1", len(adaptor.proposalsRelayed))
+	}
+	if adaptor.proposalsRelayed[0].NodeID != peer {
+		t.Errorf("re-shared wrong proposal: NodeID = %x, want %x", adaptor.proposalsRelayed[0].NodeID, peer)
+	}
+}
+
 func TestEngine_OnValidation(t *testing.T) {
 	adaptor := newMockAdaptor()
 	adaptor.setTrusted([]consensus.NodeID{{2}})

--- a/internal/consensus/rcl/proposal_tracker.go
+++ b/internal/consensus/rcl/proposal_tracker.go
@@ -61,12 +61,15 @@ func (pt *ProposalTracker) All() map[consensus.NodeID]*consensus.Proposal {
 	return pt.proposals
 }
 
-// Store records a proposal as its node's position when newer (higher ProposeSeq).
-func (pt *ProposalTracker) Store(p *consensus.Proposal) {
+// Store records a proposal as its node's position when newer (higher
+// ProposeSeq), reporting whether it updated the stored position.
+func (pt *ProposalTracker) Store(p *consensus.Proposal) bool {
 	existing, exists := pt.proposals[p.NodeID]
 	if !exists || p.Position > existing.Position {
 		pt.proposals[p.NodeID] = p
+		return true
 	}
+	return false
 }
 
 func (pt *ProposalTracker) CountTrusted(trusted func(consensus.NodeID) bool) int {
@@ -161,15 +164,19 @@ func (pt *ProposalTracker) LatestFresh(trusted func(consensus.NodeID) bool, now 
 
 // Replay upserts buffered proposals for prevID into current-round positions
 // (monotonic) and returns the close-time votes to record — one per Position==0
-// trusted proposal — plus the count of trusted proposals replayed.
-func (pt *ProposalTracker) Replay(prevID consensus.LedgerID, trusted func(consensus.NodeID) bool) (closeTimes []time.Time, trustedReplayed int) {
+// trusted proposal — the count of trusted proposals replayed, and the proposals
+// whose position was (re-)stored, so the caller can re-share them to peers that
+// missed them on this ledger.
+func (pt *ProposalTracker) Replay(prevID consensus.LedgerID, trusted func(consensus.NodeID) bool) (closeTimes []time.Time, trustedReplayed int, relay []*consensus.Proposal) {
 	for nodeID, positions := range pt.recentProposals {
 		for _, p := range positions {
 			if p.PreviousLedger != prevID {
 				continue
 			}
 			isTrusted := trusted(nodeID)
-			pt.Store(p)
+			if pt.Store(p) {
+				relay = append(relay, p)
+			}
 			if p.Position == 0 && isTrusted {
 				closeTimes = append(closeTimes, p.CloseTime)
 			}
@@ -178,7 +185,7 @@ func (pt *ProposalTracker) Replay(prevID consensus.LedgerID, trusted func(consen
 			}
 		}
 	}
-	return closeTimes, trustedReplayed
+	return closeTimes, trustedReplayed, relay
 }
 
 func (pt *ProposalTracker) SetValidation(v *consensus.Validation) {

--- a/internal/consensus/rcl/proposal_tracker_test.go
+++ b/internal/consensus/rcl/proposal_tracker_test.go
@@ -286,11 +286,15 @@ func TestProposalTracker_Replay(t *testing.T) {
 	pt.BufferRecent(&consensus.Proposal{NodeID: nodeA, Position: 1, PreviousLedger: target, CloseTime: ct})
 	pt.BufferRecent(&consensus.Proposal{NodeID: nodeB, Position: 0, PreviousLedger: other, CloseTime: ct})
 
-	closeTimes, trustedReplayed := pt.Replay(target, alwaysTrusted)
+	closeTimes, trustedReplayed, relay := pt.Replay(target, alwaysTrusted)
 
 	// nodeA contributes two proposals (Position 0 and 1) for the target.
 	if trustedReplayed != 2 {
 		t.Errorf("trustedReplayed = %d, want 2", trustedReplayed)
+	}
+	// Both stored positions are returned so the caller can re-share them.
+	if len(relay) != 2 {
+		t.Errorf("relay = %d proposals, want 2", len(relay))
 	}
 	// Only the Position==0 proposal yields a close-time vote.
 	if len(closeTimes) != 1 || !closeTimes[0].Equal(ct) {
@@ -302,6 +306,25 @@ func TestProposalTracker_Replay(t *testing.T) {
 	}
 	if _, ok := pt.proposals[nodeB]; ok {
 		t.Error("nodeB (different prev ledger) should not have been replayed")
+	}
+}
+
+// TestProposalTracker_ReplayReshareOnlyStored verifies Replay returns only the
+// proposals whose position it actually (re-)stored: a stale buffered position
+// that loses to an existing higher one is not re-shared, mirroring rippled
+// sharing only when peerProposalInternal accepts the position.
+func TestProposalTracker_ReplayReshareOnlyStored(t *testing.T) {
+	pt := NewProposalTracker()
+	target := consensus.LedgerID{9}
+	node := consensus.NodeID{1}
+
+	// Current position already ahead of the buffered one.
+	pt.Store(&consensus.Proposal{NodeID: node, Position: 5, PreviousLedger: target})
+	pt.BufferRecent(&consensus.Proposal{NodeID: node, Position: 2, PreviousLedger: target})
+
+	_, _, relay := pt.Replay(target, alwaysTrusted)
+	if len(relay) != 0 {
+		t.Errorf("stale replay re-shared %d proposals, want 0", len(relay))
 	}
 }
 


### PR DESCRIPTION
## Summary
- After a round start / ledger switch, `ProposalTracker.Replay` only **stored** buffered peer proposals for the new `prevLedger`; it never re-relayed them, so peers that missed a proposal were not re-fed it during the recovery window (issue #1188).
- Mirror rippled's `playbackProposals` + `adaptor_.share`: `Store` now reports whether it updated a node's position, `Replay` returns the (re-)stored positions, and both engine call sites (`startRoundLocked`, `handleWrongLedger`) re-relay each via `adaptor.RelayProposal(p, 0)`.
- Faithful to rippled's "share only when `peerProposalInternal` accepts the position" — stale replays that lose to an existing higher position are not re-shared.

## Test plan
- [x] `go test ./internal/consensus/...` — all green
- [x] New unit coverage: `TestProposalTracker_ReplayReshareOnlyStored` (gate: only Store-accepted positions are returned) + updated `TestProposalTracker_Replay`
- [x] New end-to-end coverage: `TestEngine_StartRound_ResharesReplayedProposals` (buffer between rounds → start round → proposal re-relayed to peers)
- [x] `golangci-lint run --config .golangci.yml ./internal/consensus/rcl/` — 0 issues; `gofmt` clean

Fixes #1188