### PR TITLE
fix: stop amendment-blocked node from proposing and validating

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1282,6 +1282,16 @@ func (a *Adaptor) IsStandalone() bool {
 	return a.ledgerService.IsStandalone()
 }
 
+// IsAmendmentBlocked reports whether an unsupported amendment has activated.
+// A blocked node must not propose or validate ledgers it can no longer build
+// correctly.
+func (a *Adaptor) IsAmendmentBlocked() bool {
+	if a.ledgerService == nil {
+		return false
+	}
+	return a.ledgerService.IsAmendmentBlocked()
+}
+
 func (a *Adaptor) Now() time.Time {
 	return time.Now().Add(time.Duration(a.closeOffsetNs.Load()))
 }
@@ -1378,6 +1388,11 @@ func (a *Adaptor) GetOperatingMode() consensus.OperatingMode {
 }
 
 func (a *Adaptor) SetOperatingMode(mode consensus.OperatingMode) {
+	// An amendment-blocked node is never more than connected: it cannot
+	// build correct ledgers, so it must not claim to be synced.
+	if mode > consensus.OpModeConnected && a.IsAmendmentBlocked() {
+		mode = consensus.OpModeConnected
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.operatingMode = mode

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1283,8 +1283,6 @@ func (a *Adaptor) IsStandalone() bool {
 }
 
 // IsAmendmentBlocked reports whether an unsupported amendment has activated.
-// A blocked node must not propose or validate ledgers it can no longer build
-// correctly.
 func (a *Adaptor) IsAmendmentBlocked() bool {
 	if a.ledgerService == nil {
 		return false

--- a/internal/consensus/adaptor/amendment_blocked_test.go
+++ b/internal/consensus/adaptor/amendment_blocked_test.go
@@ -1,0 +1,49 @@
+package adaptor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+)
+
+// TestSetOperatingMode_AmendmentBlockedCapsAtConnected pins the mode cap: an
+// amendment-blocked node must never report a mode above Connected, no matter
+// what transition the sync machinery requests.
+func TestSetOperatingMode_AmendmentBlockedCapsAtConnected(t *testing.T) {
+	tbl := amendment.NewAmendmentTable()
+	svc, err := service.New(service.Config{
+		Standalone:     true,
+		GenesisConfig:  genesis.DefaultConfig(),
+		AmendmentTable: tbl,
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	a := New(Config{LedgerService: svc})
+
+	a.SetOperatingMode(consensus.OpModeFull)
+	assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode())
+	assert.False(t, a.IsAmendmentBlocked())
+
+	// Activate an amendment this build does not support, then fold a
+	// validated ledger so the table latches blocked.
+	tbl.Enable([32]byte{0xde, 0xad, 0xbe, 0xef})
+	tbl.DoValidatedLedger(256, nil, nil)
+	require.True(t, a.IsAmendmentBlocked())
+
+	a.SetOperatingMode(consensus.OpModeFull)
+	assert.Equal(t, consensus.OpModeConnected, a.GetOperatingMode())
+
+	a.SetOperatingMode(consensus.OpModeTracking)
+	assert.Equal(t, consensus.OpModeConnected, a.GetOperatingMode())
+
+	// Transitions at or below Connected still pass through.
+	a.SetOperatingMode(consensus.OpModeDisconnected)
+	assert.Equal(t, consensus.OpModeDisconnected, a.GetOperatingMode())
+}

--- a/internal/consensus/csf/engine_adaptor.go
+++ b/internal/consensus/csf/engine_adaptor.go
@@ -485,6 +485,8 @@ func (p *EnginePeer) GetTx(id consensus.TxID) ([]byte, error) {
 
 func (p *EnginePeer) IsValidator() bool { return true }
 
+func (p *EnginePeer) IsAmendmentBlocked() bool { return false }
+
 func (p *EnginePeer) GetValidatorKey() (consensus.NodeID, error) { return p.nodeID, nil }
 
 func (p *EnginePeer) SignProposal(prop *consensus.Proposal) error {

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -164,6 +164,11 @@ type TxPool interface {
 type ValidatorIdentity interface {
 	IsValidator() bool
 
+	// IsAmendmentBlocked reports whether an unsupported amendment has
+	// activated. A blocked node can no longer build correct ledgers and
+	// must not propose or validate.
+	IsAmendmentBlocked() bool
+
 	GetValidatorKey() (NodeID, error)
 
 	SignProposal(proposal *Proposal) error

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -501,10 +501,15 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 
 	// Determine mode. recovering forces switchedLedger for exactly one round
 	// even when we'd otherwise propose; the next round gets normal treatment.
+	// An amendment-blocked node observes only: it can no longer build correct
+	// ledgers, so proposing or validating them would poison the network.
+	fullValidator := e.adaptor.IsValidator() &&
+		e.adaptor.GetOperatingMode() == consensus.OpModeFull &&
+		!e.adaptor.IsAmendmentBlocked()
 	switch {
-	case recovering && e.adaptor.IsValidator() && e.adaptor.GetOperatingMode() == consensus.OpModeFull:
+	case recovering && fullValidator:
 		e.setMode(consensus.ModeSwitchedLedger)
-	case proposing && e.adaptor.IsValidator() && e.adaptor.GetOperatingMode() == consensus.OpModeFull:
+	case proposing && fullValidator:
 		e.setMode(consensus.ModeProposing)
 	default:
 		e.setMode(consensus.ModeObserving)
@@ -1032,11 +1037,13 @@ func (e *Engine) IsProposing() bool {
 }
 
 // IsValidating reports whether the node is issuing validations this round:
-// a configured validator AND synced to OpModeFull. Lock-free reads, safe on
-// the server_info hot path under ledger.service.s.mu.
+// a configured validator, synced to OpModeFull, and not amendment-blocked.
+// Takes no engine lock, safe on the server_info hot path under
+// ledger.service.s.mu.
 func (e *Engine) IsValidating() bool {
 	return e.adaptor.IsValidator() &&
-		e.adaptor.GetOperatingMode() == consensus.OpModeFull
+		e.adaptor.GetOperatingMode() == consensus.OpModeFull &&
+		!e.adaptor.IsAmendmentBlocked()
 }
 func (e *Engine) Timing() consensus.Timing {
 	return e.timing
@@ -1322,6 +1329,13 @@ func (e *Engine) timerEntry() {
 	// OpModeConnected — no round closes, so auto-promote never fires.
 	if e.adaptor.GetOperatingMode() == consensus.OpModeDisconnected {
 		return
+	}
+
+	// An amendment-blocked node can no longer build correct ledgers: latch
+	// the operating mode down so it stops claiming to be synced.
+	if e.adaptor.GetOperatingMode() > consensus.OpModeConnected &&
+		e.adaptor.IsAmendmentBlocked() {
+		e.adaptor.SetOperatingMode(consensus.OpModeConnected)
 	}
 
 	// A peer-triggered accept may be applying the LCL off e.mu on another
@@ -3060,6 +3074,9 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 	// wrongLedger (the old behaviour) caused permanent quorum stalls (#451).
 	// ResultFail is a go-xrpl sentinel mapping to the MovedOn suppress class.
 	consensusFail := result == consensus.ResultMovedOn || result == consensus.ResultFail
+	// blocked kills emission entirely: an amendment-blocked node builds
+	// un-amended ledgers, and even a partial from it would misdirect peers.
+	blocked := e.adaptor.IsAmendmentBlocked()
 	isValidator := e.adaptor.IsValidator()
 	canValidate := e.peekCanValidateSeqLocked(newLedger.Seq())
 	// isCompatible suppresses emission when the build is on a side chain (not
@@ -3067,7 +3084,7 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 	// wrongLedger-mode gate that blocked the ahead-but-compatible case (#451)
 	// while still preventing side-chain emits (#401).
 	compatible := e.isBuildCompatibleWithValidatedLocked(newLedger)
-	willEmit := isValidator && !consensusFail && canValidate && compatible
+	willEmit := isValidator && !blocked && !consensusFail && canValidate && compatible
 
 	newLedgerID := newLedger.ID()
 	hashShort := fmt.Sprintf("%x", newLedgerID[:8])
@@ -3078,13 +3095,14 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 		"hash", hashShort,
 		"result", result.String(),
 		"is_validator", isValidator,
+		"amendment_blocked", blocked,
 		"consensus_fail", consensusFail,
 		"wrong_lcl", e.mode == consensus.ModeWrongLedger,
 		"compatible", compatible,
 		"can_validate_seq", canValidate,
 		"our_last_validated_seq", e.ourLastValidatedSeq,
 		"mode", e.mode.String(),
-		"decision", emitDecision(willEmit, isValidator, consensusFail, canValidate, compatible),
+		"decision", emitDecision(willEmit, isValidator, blocked, consensusFail, canValidate, compatible),
 	)
 
 	if willEmit {
@@ -3487,12 +3505,15 @@ func roundCloseTime(closeTime time.Time, resolution time.Duration) time.Time {
 
 // emitDecision labels which arm of the validation gate fired. wrongLedger
 // is intentionally NOT a skip reason (rippled emits a partial there, #451).
-func emitDecision(emit, isValidator, consensusFail, canValidate, compatible bool) string {
+func emitDecision(emit, isValidator, blocked, consensusFail, canValidate, compatible bool) string {
 	if emit {
 		return "emit"
 	}
 	if !isValidator {
 		return "skip:not-validator"
+	}
+	if blocked {
+		return "skip:amendment-blocked"
 	}
 	if consensusFail {
 		return "skip:consensus-fail"

--- a/internal/consensus/rcl/engine_amendment_blocked_test.go
+++ b/internal/consensus/rcl/engine_amendment_blocked_test.go
@@ -1,0 +1,93 @@
+package rcl
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+)
+
+// TestEngine_StartRound_AmendmentBlockedObserves pins the round-start gate:
+// an amendment-blocked validator can no longer build correct ledgers, so it
+// must enter rounds as an observer and report itself as not validating, even
+// when fully synced (rippled preStartRound: validating_ requires !isBlocked).
+func TestEngine_StartRound_AmendmentBlockedObserves(t *testing.T) {
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+	engine := NewEngine(adaptor, DefaultConfig())
+
+	engine.StartRound(round, true)
+	if mode := engine.Mode(); mode != consensus.ModeProposing {
+		t.Fatalf("unblocked full validator: want Proposing, got %v", mode)
+	}
+	if !engine.IsValidating() {
+		t.Fatal("unblocked full validator: IsValidating must be true")
+	}
+
+	adaptor.mu.Lock()
+	adaptor.amendmentBlocked = true
+	adaptor.mu.Unlock()
+
+	engine.StartRound(round, true)
+	if mode := engine.Mode(); mode != consensus.ModeObserving {
+		t.Fatalf("amendment-blocked validator: want Observing, got %v", mode)
+	}
+	if engine.IsValidating() {
+		t.Fatal("amendment-blocked validator: IsValidating must be false")
+	}
+}
+
+// TestEngine_AcceptLedger_AmendmentBlockedSuppressesValidation pins the
+// emission gate. The gate is intentionally mode-independent (observers emit
+// partials, #451), so the round-start demotion to Observing alone would NOT
+// stop a blocked node from signing validations for the wrong, un-amended
+// ledgers it builds — the blocked check must kill emission itself.
+func TestEngine_AcceptLedger_AmendmentBlockedSuppressesValidation(t *testing.T) {
+	run := func(t *testing.T, blocked bool) int {
+		t.Helper()
+		adaptor := newMockAdaptor()
+		adaptor.validator = true
+		adaptor.opMode = consensus.OpModeFull
+		adaptor.amendmentBlocked = blocked
+
+		engine := NewEngine(adaptor, DefaultConfig())
+		engine.StartRound(consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}, true)
+		driveToEstablish(t, engine, adaptor)
+
+		engine.mu.Lock()
+		engine.acceptLedger(consensus.ResultSuccess)
+		engine.mu.Unlock()
+
+		adaptor.mu.RLock()
+		defer adaptor.mu.RUnlock()
+		return len(adaptor.validationsBroadcast)
+	}
+
+	if got := run(t, false); got != 1 {
+		t.Fatalf("unblocked validator must emit one validation on accept, got %d", got)
+	}
+	if got := run(t, true); got != 0 {
+		t.Fatalf("amendment-blocked validator must emit no validation (not even a partial), got %d", got)
+	}
+}
+
+// TestEngine_TimerEntry_AmendmentBlockedDemotesToConnected pins the mode
+// latch: once blocked, the heartbeat drops the operating mode to Connected so
+// the node stops claiming to be synced (rippled setMode caps while blocked).
+func TestEngine_TimerEntry_AmendmentBlockedDemotesToConnected(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+	adaptor.amendmentBlocked = true
+
+	engine := NewEngine(adaptor, DefaultConfig())
+	engine.StartRound(consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}, true)
+
+	engine.timerEntry()
+
+	if got := adaptor.GetOperatingMode(); got != consensus.OpModeConnected {
+		t.Fatalf("blocked node after tick: want OpModeConnected, got %v", got)
+	}
+}

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -83,8 +83,9 @@ type mockAdaptor struct {
 	mu sync.RWMutex
 
 	// Mode
-	opMode    consensus.OperatingMode
-	validator bool
+	opMode           consensus.OperatingMode
+	validator        bool
+	amendmentBlocked bool
 
 	// Validator info
 	nodeID  consensus.NodeID
@@ -413,6 +414,12 @@ func (a *mockAdaptor) GetValidatorKey() (consensus.NodeID, error) {
 
 func (a *mockAdaptor) IsValidator() bool {
 	return a.validator
+}
+
+func (a *mockAdaptor) IsAmendmentBlocked() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.amendmentBlocked
 }
 
 func (a *mockAdaptor) IsTrusted(nodeID consensus.NodeID) bool {


### PR DESCRIPTION
## Summary
- An amendment-blocked go-xrpl validator kept proposing and validating: the proposing gate was purely `IsValidator() && OpModeFull` and nothing consulted `IsAmendmentBlocked()`, so at an amendment activation boundary a blocked validator keeps signing validations for the wrong (un-amended) ledgers it builds — fork/wedge risk in a mixed network.
- Mirrors rippled's two-pronged refusal: `preStartRound` gates `validating_` on `!isBlocked()` (RCLConsensus.cpp:1005-1007) and `setMode` caps the operating mode at CONNECTED while blocked (NetworkOPs.cpp:2557, 1839-1840).
- Changes: new `IsAmendmentBlocked()` on the consensus `ValidatorIdentity` seam (prod adaptor delegates to the ledger service, csf stub returns false); round-start mode switch demotes a blocked validator to observing; the validation emission gate kills emission entirely (the gate is intentionally mode-independent, so demotion alone would still leak partials); `IsValidating()` reports false; `SetOperatingMode` caps at Connected while blocked and the heartbeat latches a blocked FULL node down to Connected.

## Test plan
- [x] `go test ./internal/consensus/...` — new tests: blocked validator observes instead of proposing, emits no validation on accept (control emits one), heartbeat demotes to Connected, adaptor mode cap latches via a real blocked amendment table
- [x] `go vet ./...`, `golangci-lint run --config .golangci.yml` on changed packages — 0 issues
- [x] `go test ./internal/ledger/... ./internal/txq/... ./internal/rpc/... ./internal/peermanagement/...`

Fixes #1203