### PR TITLE
feat: add ValidationTracker.Flush on shutdown

### DIFF
--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -469,6 +469,13 @@ func (e *Engine) Stop() error {
 	e.wg.Wait()
 	e.eventBus.Stop()
 
+	// Discard accumulated validation state on orderly shutdown, mirroring
+	// rippled's Validations::flush(). No archive interaction, so ordering
+	// relative to the archive close below is irrelevant.
+	if e.validationTracker != nil {
+		e.validationTracker.Flush()
+	}
+
 	if arc := e.loadArchive(); arc != nil {
 		// Bounded close — a stuck archive must not hang shutdown.
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -469,9 +469,8 @@ func (e *Engine) Stop() error {
 	e.wg.Wait()
 	e.eventBus.Stop()
 
-	// Discard accumulated validation state on orderly shutdown, mirroring
-	// rippled's Validations::flush(). No archive interaction, so ordering
-	// relative to the archive close below is irrelevant.
+	// Flush has no archive interaction, so its ordering relative to the
+	// archive close below is irrelevant.
 	if e.validationTracker != nil {
 		e.validationTracker.Flush()
 	}

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -826,3 +826,20 @@ func (vt *ValidationTracker) ExpireOld(minSeq uint32) {
 		onStale(v)
 	}
 }
+
+// Flush discards all accumulated validation state — the latest
+// validation per node, the per-ledger maps, the fully-validated firing
+// set, and the trie — while preserving configuration (trusted set,
+// negUNL, quorum, freshness, clock, callbacks, ancestry, and sequence
+// floor). Called on orderly shutdown and to reset for a clean
+// restart-in-process. It does not fire onStale: the state is dropped,
+// not archived.
+func (vt *ValidationTracker) Flush() {
+	vt.mu.Lock()
+	defer vt.mu.Unlock()
+
+	vt.validations = make(map[consensus.LedgerID]map[consensus.NodeID]*consensus.Validation)
+	vt.byNode = make(map[consensus.NodeID]*consensus.Validation)
+	vt.fired = make(map[consensus.LedgerID]struct{})
+	vt.rebuildTrieLocked()
+}

--- a/internal/consensus/rcl/validations_test.go
+++ b/internal/consensus/rcl/validations_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrie"
 )
 
 func TestValidationTracker_Add(t *testing.T) {
@@ -503,5 +504,65 @@ func TestValidationTracker_ExpireOld_OnStaleRunsOutsideLock(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("onStale callback deadlocked or never fired")
+	}
+}
+
+// TestValidationTracker_Flush mirrors rippled's Validations::flush()
+// (Validations.h:1103-1110, called on orderly shutdown at
+// Application.cpp:1612): all accumulated validation state is discarded
+// while configuration survives, so the tracker is reusable in-process.
+func TestValidationTracker_Flush(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abc := b.Build("abc")
+	provider := newMapAncestryProvider()
+	provider.add(abc)
+
+	n1 := consensus.NodeID{1}
+	n2 := consensus.NodeID{2}
+	vt.SetTrusted([]consensus.NodeID{n1, n2})
+	vt.SetLedgerAncestryProvider(provider)
+
+	vt.Add(makeTrustedValidation(n1, abc.ID(), abc.Seq(), now))
+	vt.Add(makeTrustedValidation(n2, abc.ID(), abc.Seq(), now))
+
+	// Sanity: state accumulated and the wired trie steers GetPreferred.
+	if got := vt.GetValidationCount(abc.ID()); got != 2 {
+		t.Fatalf("pre-flush: want 2 validations, got %d", got)
+	}
+	if vt.GetLatestValidation(n1) == nil {
+		t.Fatal("pre-flush: n1 latest validation missing")
+	}
+	if _, _, ok := vt.GetPreferred(0); !ok {
+		t.Fatal("pre-flush: GetPreferred should resolve with trie wired")
+	}
+
+	vt.Flush()
+
+	// Every accumulated index is cleared, including the trie.
+	if got := vt.GetValidationCount(abc.ID()); got != 0 {
+		t.Errorf("post-flush: want 0 validations, got %d", got)
+	}
+	if vt.GetLatestValidation(n1) != nil {
+		t.Error("post-flush: byNode not cleared")
+	}
+	if got := vt.GetTrustedSupport(abc.ID()); got != 0 {
+		t.Errorf("post-flush: want 0 trusted support, got %d", got)
+	}
+	if _, _, ok := vt.GetPreferred(0); ok {
+		t.Error("post-flush: trie not reset — GetPreferred still resolves")
+	}
+
+	// Configuration (trusted set, quorum, ancestry) survives: a fresh
+	// validation is accepted and re-steers GetPreferred.
+	if !vt.Add(makeTrustedValidation(n1, abc.ID(), abc.Seq(), now)) {
+		t.Fatal("post-flush: Add should accept a fresh validation")
+	}
+	vt.Add(makeTrustedValidation(n2, abc.ID(), abc.Seq(), now))
+	if _, _, ok := vt.GetPreferred(0); !ok {
+		t.Error("post-flush: GetPreferred should resolve again after re-adding")
 	}
 }


### PR DESCRIPTION
## Summary
- Add `ValidationTracker.Flush()` mirroring rippled's `Validations::flush()` (Validations.h:1103-1110): discards accumulated validation state — the latest validation per node (rippled's `current_`), the per-ledger maps, the fully-validated firing set, and the trie — while preserving configuration (trusted set, negUNL, quorum, freshness, clock, callbacks, ancestry, sequence floor). It does not fire `onStale`; the state is dropped, not archived, matching rippled.
- Wire it into `Engine.Stop()`, mirroring rippled's `mValidations.flush()` on orderly shutdown (Application.cpp:1612). Also gives a clean restart-in-process reset.

## Test plan
- [x] `just test-pkg ./internal/consensus/rcl/` — new `TestValidationTracker_Flush` asserts every index (byNode, per-ledger, trie) clears while trusted set / quorum / ancestry survive (a fresh validation is accepted and re-steers `GetPreferred`).
- [x] `go test ./internal/consensus/...` — full subsystem green (no regression from the `Stop()` wiring).
- [x] `go vet` + `gofmt` clean.

Fixes #1196