### PR TITLE
feat: add human-readable LedgerTrie dump

### DIFF
--- a/internal/consensus/ledgertrie/dump.go
+++ b/internal/consensus/ledgertrie/dump.go
@@ -1,0 +1,63 @@
+package ledgertrie
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// String renders the span as "<tipID>[start,end)", where tipID is the
+// uppercase hex of the span tip's ledger ID.
+func (s span) String() string {
+	tip := s.tip()
+	return fmt.Sprintf("%X[%d,%d)", tip.ID[:], s.start, s.end)
+}
+
+// String renders the node as "<span>(T:tipSupport,B:branchSupport)".
+func (n *node) String() string {
+	return fmt.Sprintf("%s(T:%d,B:%d)", n.s.String(), n.tipSupport, n.branchSupport)
+}
+
+// Dump writes an indented ASCII rendering of the trie to w, one node per
+// line as "<tipID>[start,end)(T:tipSupport,B:branchSupport)", each child
+// indented beneath its parent. Intended for interactive debugging.
+func (t *Trie) Dump(w io.Writer) error {
+	return dumpNode(w, t.root, 0)
+}
+
+// String returns the trie's ASCII dump, satisfying fmt.Stringer.
+func (t *Trie) String() string {
+	var b strings.Builder
+	_ = t.Dump(&b)
+	return b.String()
+}
+
+// dumpNode prints curr and its subtree. offset is the column at which the
+// "|-" marker is right-aligned; the root prints at offset 0 with no marker,
+// and each child indents to offset + len(line) + 3 past its parent.
+func dumpNode(w io.Writer, curr *node, offset int) error {
+	if curr == nil {
+		return nil
+	}
+	if offset > 2 {
+		if _, err := io.WriteString(w, strings.Repeat(" ", offset-2)); err != nil {
+			return err
+		}
+	}
+	if offset > 0 {
+		if _, err := io.WriteString(w, "|-"); err != nil {
+			return err
+		}
+	}
+	line := curr.String()
+	if _, err := io.WriteString(w, line+"\n"); err != nil {
+		return err
+	}
+	childOffset := offset + 1 + len(line) + 2
+	for _, child := range curr.children {
+		if err := dumpNode(w, child, childOffset); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/consensus/ledgertrie/dump.go
+++ b/internal/consensus/ledgertrie/dump.go
@@ -6,14 +6,11 @@ import (
 	"strings"
 )
 
-// String renders the span as "<tipID>[start,end)", where tipID is the
-// uppercase hex of the span tip's ledger ID.
 func (s span) String() string {
 	tip := s.tip()
 	return fmt.Sprintf("%X[%d,%d)", tip.ID[:], s.start, s.end)
 }
 
-// String renders the node as "<span>(T:tipSupport,B:branchSupport)".
 func (n *node) String() string {
 	return fmt.Sprintf("%s(T:%d,B:%d)", n.s.String(), n.tipSupport, n.branchSupport)
 }

--- a/internal/consensus/ledgertrie/dump_test.go
+++ b/internal/consensus/ledgertrie/dump_test.go
@@ -1,0 +1,65 @@
+package ledgertrie
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// zeros is the 64-char hex rendering of the all-zero genesis ledger ID.
+var zeros = strings.Repeat("0", 64)
+
+func sp(n int) string { return strings.Repeat(" ", n) }
+
+func TestTrie_DumpEmpty(t *testing.T) {
+	trie, _ := newTestTrie()
+
+	want := zeros + "[0,1)(T:0,B:0)\n"
+	if got := trie.String(); got != want {
+		t.Errorf("empty trie dump:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestTrie_DumpSingleBranch(t *testing.T) {
+	trie, b := newTestTrie()
+	trie.Insert(b.Build("abc"), 1)
+
+	root := zeros + "[0,1)(T:0,B:1)"
+	child := "616263" + strings.Repeat("0", 58) + "[1,4)(T:1,B:1)"
+	want := root + "\n" + sp(len(root)+1) + "|-" + child + "\n"
+
+	var buf bytes.Buffer
+	if err := trie.Dump(&buf); err != nil {
+		t.Fatalf("Dump: %v", err)
+	}
+	if got := buf.String(); got != want {
+		t.Errorf("single-branch dump mismatch:\n got %q\nwant %q", got, want)
+	}
+	if s := trie.String(); s != want {
+		t.Errorf("String() must equal Dump():\n got %q\nwant %q", s, want)
+	}
+}
+
+func TestTrie_DumpFork(t *testing.T) {
+	trie, b := newTestTrie()
+	trie.Insert(b.Build("abcd"), 1)
+	trie.Insert(b.Build("abce"), 1)
+
+	root := zeros + "[0,1)(T:0,B:2)"
+	// Shared "abc" prefix node, tip is the seq-3 ancestor of abcd.
+	child := "616263" + strings.Repeat("0", 58) + "[1,4)(T:0,B:2)"
+	abcd := "61626364" + strings.Repeat("0", 56) + "[4,5)(T:1,B:1)"
+	abce := "61626365" + strings.Repeat("0", 56) + "[4,5)(T:1,B:1)"
+
+	childIndent := len(root) + 1
+	// Grandchild offset = childOffset + len(child) + 3; indent = offset - 2.
+	grandIndent := (len(root) + 3) + len(child) + 1
+	want := root + "\n" +
+		sp(childIndent) + "|-" + child + "\n" +
+		sp(grandIndent) + "|-" + abcd + "\n" +
+		sp(grandIndent) + "|-" + abce + "\n"
+
+	if got := trie.String(); got != want {
+		t.Errorf("fork dump mismatch:\n got %q\nwant %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Trie.Dump(io.Writer)` and `Trie.String()` to `internal/consensus/ledgertrie`, rendering the ancestry trie as an indented ASCII tree of `id[start,end)(T:tipSupport,B:branchSupport)` nodes — the Go equivalent of rippled's `LedgerTrie::dump`/`dumpImpl` (LedgerTrie.h:790).
- `span`/`node` gain `String()` (`fmt.Stringer`) mirroring rippled's two-level `operator<<`; tip IDs render as uppercase hex, matching the codebase's existing ID-dump convention.
- Indentation reproduces rippled's `dumpImpl` offset recurrence exactly (child column = parent offset + node width + 3).

## Test plan
- [x] `go test ./internal/consensus/ledgertrie/...` — new `dump_test.go` asserts exact output for empty, single-branch, and forked tries
- [x] `go test ./internal/consensus/rcl/...` — dependent package unaffected by the new `Stringer` methods
- [x] `go vet` + `golangci-lint run --config .golangci.yml` clean

Fixes #1201