### PR TITLE
fix: bow out of consensus when the validator list expires

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -243,6 +243,12 @@ type Adaptor struct {
 	// can broadcast mtHAVE_SET{tsHAVE} for it. nil-safe.
 	onTxSetBuilt func(consensus.TxSetID)
 
+	// unlBlocked reports the validator-list aggregator's UNL lock-down flag.
+	// Wired at startup when publisher lists are configured; nil (no
+	// publishers) means never blocked. Written once before the engine
+	// starts, then only read.
+	unlBlocked func() bool
+
 	// lastIssuedValidationSeq is the highest ledger seq this node has
 	// broadcast a validation for — rippled's localSeqEnforcer_.largest(),
 	// the trie-descent floor for preferredLCL. Zero for a non-validator.
@@ -1280,6 +1286,21 @@ func (a *Adaptor) IsStandalone() bool {
 		return false
 	}
 	return a.ledgerService.IsStandalone()
+}
+
+// SetUNLBlockedFunc wires the validator-list aggregator's lock-down flag
+// into the consensus bow-out gate. Must be called before the engine starts.
+func (a *Adaptor) SetUNLBlockedFunc(fn func() bool) {
+	a.unlBlocked = fn
+}
+
+// IsUNLBlocked reports the validator-list UNL lock-down. Always false when
+// no publisher lists are configured.
+func (a *Adaptor) IsUNLBlocked() bool {
+	if a.unlBlocked == nil {
+		return false
+	}
+	return a.unlBlocked()
 }
 
 func (a *Adaptor) Now() time.Time {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -249,6 +249,15 @@ type Adaptor struct {
 	// starts, then only read.
 	unlBlocked func() bool
 
+	// refreshUNL re-evaluates the aggregator's trust view against the live
+	// clock (promote rotations, latch/clear the lock-down flag). Wired to
+	// the aggregator's Tick so consensus can drive it once per round —
+	// rippled refreshes via updateTrusted at every ledger close, but
+	// goXRPL's standalone 30s ticker leaves the flag stale for several
+	// rounds after a list lapses. nil (no publishers) means no-op. Same
+	// write-once-before-start lifetime as unlBlocked.
+	refreshUNL func()
+
 	// lastIssuedValidationSeq is the highest ledger seq this node has
 	// broadcast a validation for — rippled's localSeqEnforcer_.largest(),
 	// the trie-descent floor for preferredLCL. Zero for a non-validator.
@@ -1301,6 +1310,25 @@ func (a *Adaptor) IsUNLBlocked() bool {
 		return false
 	}
 	return a.unlBlocked()
+}
+
+// SetUNLRefreshFunc wires the aggregator's per-round trust refresh. Must be
+// called before the engine starts.
+func (a *Adaptor) SetUNLRefreshFunc(fn func()) {
+	a.refreshUNL = fn
+}
+
+// RefreshUNLState drives a live re-evaluation of the aggregator's trust view
+// so the consensus bow-out sees an expired list the round it lapses rather
+// than waiting for the standalone refresh tick. No-op without publisher
+// lists. Safe under the engine lock: the aggregator's OnChange fan-out
+// reaches only the adaptor/static/trusted-votes mutexes, never back into the
+// engine, so the engine->aggregator lock order stays acyclic.
+func (a *Adaptor) RefreshUNLState() {
+	if a.refreshUNL == nil {
+		return
+	}
+	a.refreshUNL()
 }
 
 // IsAmendmentBlocked reports whether an unsupported amendment has activated.

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -369,8 +369,6 @@ func NewFromConfig(
 			return nil, fmt.Errorf("validator-list aggregator: %w", err)
 		}
 		router.SetValidatorListAggregator(vlAgg)
-		// Expired publisher lists make the engine voluntarily bow out
-		// of proposing/validating (rippled preStartRound parity).
 		adaptor.SetUNLBlockedFunc(vlAgg.IsUNLBlocked)
 		// On-disk publisher-list cache: accepted lists are persisted
 		// under <database_path>/validator-list/cache.<pubHex> after

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -369,6 +369,9 @@ func NewFromConfig(
 			return nil, fmt.Errorf("validator-list aggregator: %w", err)
 		}
 		router.SetValidatorListAggregator(vlAgg)
+		// Expired publisher lists make the engine voluntarily bow out
+		// of proposing/validating (rippled preStartRound parity).
+		adaptor.SetUNLBlockedFunc(vlAgg.IsUNLBlocked)
 		// On-disk publisher-list cache: accepted lists are persisted
 		// under <database_path>/validator-list/cache.<pubHex> after
 		// every successful apply, and hydrated on cold start so the

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -370,6 +370,7 @@ func NewFromConfig(
 		}
 		router.SetValidatorListAggregator(vlAgg)
 		adaptor.SetUNLBlockedFunc(vlAgg.IsUNLBlocked)
+		adaptor.SetUNLRefreshFunc(vlAgg.Tick)
 		// On-disk publisher-list cache: accepted lists are persisted
 		// under <database_path>/validator-list/cache.<pubHex> after
 		// every successful apply, and hydrated on cold start so the

--- a/internal/consensus/csf/engine_adaptor.go
+++ b/internal/consensus/csf/engine_adaptor.go
@@ -521,6 +521,7 @@ func (p *EnginePeer) GetNegativeUNL() []consensus.NodeID { return nil }
 func (p *EnginePeer) IsFeatureEnabled(string) bool                           { return true }
 func (p *EnginePeer) IsFeatureEnabledOnLedger(consensus.Ledger, string) bool { return true }
 func (p *EnginePeer) IsStandalone() bool                                     { return false }
+func (p *EnginePeer) IsUNLBlocked() bool                                     { return false }
 func (p *EnginePeer) GetCookie() uint64                                      { return uint64(p.id) + 1 }
 func (p *EnginePeer) GetServerVersion() uint64                               { return 0 }
 func (p *EnginePeer) GetLoadFee() uint32                                     { return 0 }

--- a/internal/consensus/csf/engine_adaptor.go
+++ b/internal/consensus/csf/engine_adaptor.go
@@ -524,6 +524,7 @@ func (p *EnginePeer) IsFeatureEnabled(string) bool                           { r
 func (p *EnginePeer) IsFeatureEnabledOnLedger(consensus.Ledger, string) bool { return true }
 func (p *EnginePeer) IsStandalone() bool                                     { return false }
 func (p *EnginePeer) IsUNLBlocked() bool                                     { return false }
+func (p *EnginePeer) RefreshUNLState()                                       {}
 func (p *EnginePeer) GetCookie() uint64                                      { return uint64(p.id) + 1 }
 func (p *EnginePeer) GetServerVersion() uint64                               { return 0 }
 func (p *EnginePeer) GetLoadFee() uint32                                     { return 0 }

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -213,6 +213,11 @@ type TrustOracle interface {
 	// IsStandalone reports whether the node runs in standalone (single-node) mode.
 	IsStandalone() bool
 
+	// IsUNLBlocked reports the validator-list lock-down: a configured
+	// publisher list expired or the trusted union went empty. Adaptors
+	// without publisher lists return false.
+	IsUNLBlocked() bool
+
 	// GetCookie returns the validator's per-boot sfCookie value.
 	GetCookie() uint64
 

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -223,6 +223,11 @@ type TrustOracle interface {
 	// without publisher lists return false.
 	IsUNLBlocked() bool
 
+	// RefreshUNLState re-evaluates the validator-list trust view against the
+	// live clock so IsUNLBlocked reflects an expired list this round. Called
+	// once per round-start; no-op for adaptors without publisher lists.
+	RefreshUNLState()
+
 	// GetCookie returns the validator's per-boot sfCookie value.
 	GetCookie() uint64
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -37,8 +37,12 @@ type Engine struct {
 	// GetLastCloseInfo reads (same RPC-hot-path rationale as modeAtomic).
 	// Written from acceptLedger under e.mu via storeLastCloseLocked.
 	lastCloseAtomic atomic.Pointer[lastCloseInfo]
-	state           *consensus.RoundState
-	prevLedger      consensus.Ledger
+	// bowedOut is the per-round voluntary bow-out: the configured validator
+	// list expired, so this round neither proposes nor validates. Snapshotted
+	// at round start (under e.mu); atomic for the lock-free IsValidating path.
+	bowedOut   atomic.Bool
+	state      *consensus.RoundState
+	prevLedger consensus.Ledger
 
 	// buildInProgress is set while acceptLedger applies the LCL off e.mu
 	// (rippled's jtACCEPT job window). While set, round-driving (timerEntry,
@@ -499,12 +503,30 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 	// Before the mode switch so it runs in every mode (preStartRound parity).
 	e.driveNegativeUNLNewValidatorsLocked()
 
+	// Voluntary bow-out: an expired validator list means our trust view is
+	// stale, so this round neither proposes nor validates (rippled
+	// preStartRound). Independent of sync state — a syncing validator must
+	// not emit partials on stale trust either. Skipped in standalone.
+	bowedOut := e.adaptor.IsValidator() && !e.adaptor.IsStandalone() &&
+		e.adaptor.IsUNLBlocked()
+	if bowedOut {
+		slog.Error("Voluntarily bowing out of consensus process because of an expired validator list",
+			"t", "consensus",
+			"event", "unl-expired-bow-out",
+			"seq", round.Seq,
+		)
+	}
+	e.bowedOut.Store(bowedOut)
+
+	validating := e.adaptor.IsValidator() &&
+		e.adaptor.GetOperatingMode() == consensus.OpModeFull && !bowedOut
+
 	// Determine mode. recovering forces switchedLedger for exactly one round
 	// even when we'd otherwise propose; the next round gets normal treatment.
 	switch {
-	case recovering && e.adaptor.IsValidator() && e.adaptor.GetOperatingMode() == consensus.OpModeFull:
+	case recovering && validating:
 		e.setMode(consensus.ModeSwitchedLedger)
-	case proposing && e.adaptor.IsValidator() && e.adaptor.GetOperatingMode() == consensus.OpModeFull:
+	case proposing && validating:
 		e.setMode(consensus.ModeProposing)
 	default:
 		e.setMode(consensus.ModeObserving)
@@ -1032,11 +1054,13 @@ func (e *Engine) IsProposing() bool {
 }
 
 // IsValidating reports whether the node is issuing validations this round:
-// a configured validator AND synced to OpModeFull. Lock-free reads, safe on
-// the server_info hot path under ledger.service.s.mu.
+// a configured validator, synced to OpModeFull, and not bowed out over an
+// expired validator list. Lock-free reads, safe on the server_info hot path
+// under ledger.service.s.mu.
 func (e *Engine) IsValidating() bool {
 	return e.adaptor.IsValidator() &&
-		e.adaptor.GetOperatingMode() == consensus.OpModeFull
+		e.adaptor.GetOperatingMode() == consensus.OpModeFull &&
+		!e.bowedOut.Load()
 }
 func (e *Engine) Timing() consensus.Timing {
 	return e.timing
@@ -3060,7 +3084,9 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 	// wrongLedger (the old behaviour) caused permanent quorum stalls (#451).
 	// ResultFail is a go-xrpl sentinel mapping to the MovedOn suppress class.
 	consensusFail := result == consensus.ResultMovedOn || result == consensus.ResultFail
-	isValidator := e.adaptor.IsValidator()
+	// bowedOut folds the round's UNL-expiry bow-out into the validating
+	// half of the gate (rippled's validating_ carries it the same way).
+	isValidator := e.adaptor.IsValidator() && !e.bowedOut.Load()
 	canValidate := e.peekCanValidateSeqLocked(newLedger.Seq())
 	// isCompatible suppresses emission when the build is on a side chain (not
 	// just ahead of validated on the same chain). Replaces the coarse

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -506,7 +506,7 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 	// Voluntary bow-out: an expired validator list means our trust view is
 	// stale, so this round neither proposes nor validates (rippled
 	// preStartRound). Independent of sync state — a syncing validator must
-	// not emit partials on stale trust either. Skipped in standalone.
+	// not emit partials on stale trust either.
 	bowedOut := e.adaptor.IsValidator() && !e.adaptor.IsStandalone() &&
 		e.adaptor.IsUNLBlocked()
 	if bowedOut {
@@ -3084,8 +3084,7 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 	// wrongLedger (the old behaviour) caused permanent quorum stalls (#451).
 	// ResultFail is a go-xrpl sentinel mapping to the MovedOn suppress class.
 	consensusFail := result == consensus.ResultMovedOn || result == consensus.ResultFail
-	// bowedOut folds the round's UNL-expiry bow-out into the validating
-	// half of the gate (rippled's validating_ carries it the same way).
+	// rippled's validating_ carries the bow-out into this gate the same way.
 	isValidator := e.adaptor.IsValidator() && !e.bowedOut.Load()
 	canValidate := e.peekCanValidateSeqLocked(newLedger.Seq())
 	// isCompatible suppresses emission when the build is on a side chain (not

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -538,6 +538,13 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 		e.prevCloseTime = e.state.CloseTimes.Self
 	}
 
+	// Refresh the trust view before reading it: rippled recomputes via
+	// updateTrusted at every ledger close, so an expired list bows the node
+	// out that round. goXRPL's aggregator otherwise only refreshes on its
+	// 30s tick, leaving the lock-down flag stale for several rounds after a
+	// list lapses. No-op without publisher lists.
+	e.adaptor.RefreshUNLState()
+
 	// Voluntary bow-out: an expired validator list means our trust view is
 	// stale, so this round neither proposes nor validates (rippled
 	// preStartRound). Independent of sync state — a syncing validator must
@@ -546,7 +553,7 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 	bowedOut := e.adaptor.IsValidator() && !e.adaptor.IsStandalone() &&
 		!e.adaptor.IsAmendmentBlocked() && e.adaptor.IsUNLBlocked()
 	if bowedOut {
-		slog.Error("Voluntarily bowing out of consensus process because of an expired validator list",
+		slog.Error("Voluntarily bowing out of consensus process because of an expired validator list.",
 			"t", "consensus",
 			"event", "unl-expired-bow-out",
 			"seq", round.Seq,

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -156,6 +156,10 @@ type mockAdaptor struct {
 	// OR-branch at RCLConsensus.cpp:352.
 	standalone bool
 
+	// unlBlocked toggles IsUNLBlocked() for the expired-validator-list
+	// bow-out tests.
+	unlBlocked bool
+
 	// proposableOverride lets a test pin a specific filtered set
 	// for GetProposableTxs to return, distinct from the raw pending
 	// pool, so closeLedger's wiring (proposing path uses the filtered
@@ -480,6 +484,12 @@ func (a *mockAdaptor) IsStandalone() bool {
 	return a.standalone
 }
 
+func (a *mockAdaptor) IsUNLBlocked() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.unlBlocked
+}
+
 func (a *mockAdaptor) GetCookie() uint64 {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
@@ -684,6 +694,79 @@ func TestEngine_StartRound_Observing(t *testing.T) {
 
 	if engine.Mode() != consensus.ModeObserving {
 		t.Errorf("Expected Observing mode, got %v", engine.Mode())
+	}
+}
+
+// TestEngine_StartRound_UNLExpiredBowsOut pins rippled preStartRound's
+// voluntary bow-out (RCLConsensus.cpp:1009-1021): a validator whose
+// configured validator list expired must neither propose nor validate.
+// The round drops to Observing, IsValidating reports false, and the
+// per-round bowedOut snapshot feeds the acceptLedger emission gate. Once
+// the list recovers, the next round re-evaluates and promotes back.
+func TestEngine_StartRound_UNLExpiredBowsOut(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+	adaptor.unlBlocked = true
+
+	engine := NewEngine(adaptor, DefaultConfig())
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	if err := engine.StartRound(round, true); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+
+	if mode := engine.Mode(); mode != consensus.ModeObserving {
+		t.Errorf("bowed-out round: want Observing, got %v", mode)
+	}
+	if engine.IsValidating() {
+		t.Error("bowed-out round: IsValidating must report false")
+	}
+	if !engine.bowedOut.Load() {
+		t.Error("bowedOut snapshot must be set for the emission gate")
+	}
+
+	adaptor.mu.Lock()
+	adaptor.unlBlocked = false
+	adaptor.mu.Unlock()
+
+	next := consensus.RoundID{Seq: 102, ParentHash: consensus.LedgerID{2}}
+	engine.mu.Lock()
+	engine.startRoundLocked(next, true, false)
+	engine.mu.Unlock()
+
+	if mode := engine.Mode(); mode != consensus.ModeProposing {
+		t.Errorf("recovered round: want Proposing, got %v", mode)
+	}
+	if !engine.IsValidating() {
+		t.Error("recovered round: IsValidating must report true")
+	}
+	if engine.bowedOut.Load() {
+		t.Error("recovered round: bowedOut snapshot must be cleared")
+	}
+}
+
+// TestEngine_StartRound_UNLExpiredStandaloneSkips: standalone skips the
+// bow-out check entirely, matching rippled's !standalone() gate.
+func TestEngine_StartRound_UNLExpiredStandaloneSkips(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+	adaptor.standalone = true
+	adaptor.unlBlocked = true
+
+	engine := NewEngine(adaptor, DefaultConfig())
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	if err := engine.StartRound(round, true); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+
+	if mode := engine.Mode(); mode != consensus.ModeProposing {
+		t.Errorf("standalone: want Proposing despite blocked list, got %v", mode)
+	}
+	if !engine.IsValidating() {
+		t.Error("standalone: IsValidating must report true")
 	}
 }
 

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -156,8 +156,6 @@ type mockAdaptor struct {
 	// OR-branch at RCLConsensus.cpp:352.
 	standalone bool
 
-	// unlBlocked toggles IsUNLBlocked() for the expired-validator-list
-	// bow-out tests.
 	unlBlocked bool
 
 	// proposableOverride lets a test pin a specific filtered set

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -159,6 +159,10 @@ type mockAdaptor struct {
 
 	unlBlocked bool
 
+	// onRefreshUNL, when set, runs on each RefreshUNLState call so a test
+	// can model the aggregator latching the lock-down flag at round start.
+	onRefreshUNL func()
+
 	// proposableOverride lets a test pin a specific filtered set
 	// for GetProposableTxs to return, distinct from the raw pending
 	// pool, so closeLedger's wiring (proposing path uses the filtered
@@ -495,6 +499,15 @@ func (a *mockAdaptor) IsUNLBlocked() bool {
 	return a.unlBlocked
 }
 
+func (a *mockAdaptor) RefreshUNLState() {
+	a.mu.RLock()
+	fn := a.onRefreshUNL
+	a.mu.RUnlock()
+	if fn != nil {
+		fn()
+	}
+}
+
 func (a *mockAdaptor) GetCookie() uint64 {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
@@ -772,6 +785,41 @@ func TestEngine_StartRound_UNLExpiredStandaloneSkips(t *testing.T) {
 	}
 	if !engine.IsValidating() {
 		t.Error("standalone: IsValidating must report true")
+	}
+}
+
+// TestEngine_StartRound_UNLRefreshLatchesBowOut pins the per-round trust
+// refresh (rippled updateTrusted at every ledger close): the lock-down flag
+// is clear entering the round, but RefreshUNLState — driven at round start —
+// latches it against the live clock, so the node bows out that same round
+// instead of waiting for the aggregator's standalone refresh tick.
+func TestEngine_StartRound_UNLRefreshLatchesBowOut(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+	// Flag starts clear; the aggregator latches it only when the round-start
+	// refresh re-evaluates the (now expired) list.
+	adaptor.onRefreshUNL = func() {
+		adaptor.mu.Lock()
+		adaptor.unlBlocked = true
+		adaptor.mu.Unlock()
+	}
+
+	engine := NewEngine(adaptor, DefaultConfig())
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	if err := engine.StartRound(round, true); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+
+	if mode := engine.Mode(); mode != consensus.ModeObserving {
+		t.Errorf("refresh-latched bow-out: want Observing, got %v", mode)
+	}
+	if engine.IsValidating() {
+		t.Error("refresh-latched bow-out: IsValidating must report false")
+	}
+	if !engine.bowedOut.Load() {
+		t.Error("refresh-latched bow-out: bowedOut snapshot must be set by the round-start refresh")
 	}
 }
 


### PR DESCRIPTION
## Summary
- A validator whose configured publisher lists expired kept proposing and validating on stale trust information. rippled's `preStartRound` deliberately withdraws (`validating_ = false`, "Voluntarily bowing out…") in this state; go-xrpl computed the signal (`Aggregator.IsUNLBlocked`, surfaced in RPC gating) but the consensus round-start never consulted it.
- Adds `IsUNLBlocked()` to the consensus `TrustOracle` interface, wired from the validator-list aggregator into the production adaptor at startup (nil / no publisher lists ⇒ never blocked, matching rippled's `count()` gate). The csf simulation adaptor returns false.
- `startRoundLocked` snapshots the bow-out per round: a blocked validator drops to observing (no proposals), the `acceptLedger` emission gate suppresses its validation for that round (rippled's `validating_` carries the bow-out the same way, independent of sync state), and `IsValidating`/`consensus_info` report the withdrawn state. Skipped in standalone, matching `!app_.config().standalone()`. The next round re-evaluates, so a recovered list promotes back automatically.

## Test plan
- [x] `go test ./internal/consensus/... ./internal/validator/...` — all pass, incl. new `TestEngine_StartRound_UNLExpiredBowsOut` (blocked ⇒ Observing + IsValidating false + emission-gate snapshot set; recovery ⇒ Proposing again) and `TestEngine_StartRound_UNLExpiredStandaloneSkips`
- [x] `go test ./internal/ledger/... ./internal/cli/... ./internal/rpc/... ./internal/txq/... ./internal/peermanagement/...`
- [x] `golangci-lint run --config .golangci.yml ./internal/consensus/... ./internal/validator/...` — 0 issues; `go vet ./...` clean

Fixes #1204