### PR TITLE
consensus: use our own observed close time when the previous close was incorrect

### DIFF
--- a/internal/consensus/adaptor/ledger_wrapper.go
+++ b/internal/consensus/adaptor/ledger_wrapper.go
@@ -45,7 +45,6 @@ func (w *LedgerWrapper) CloseAgree() bool {
 	return h.GetCloseAgree()
 }
 
-// ParentCloseTime returns the close time of this ledger's parent.
 func (w *LedgerWrapper) ParentCloseTime() time.Time {
 	return w.ledger.ParentCloseTime()
 }

--- a/internal/consensus/adaptor/ledger_wrapper.go
+++ b/internal/consensus/adaptor/ledger_wrapper.go
@@ -38,6 +38,18 @@ func (w *LedgerWrapper) CloseTime() time.Time {
 	return w.ledger.CloseTime()
 }
 
+// CloseAgree reports whether this ledger's close time was reached by
+// consensus (false when it was defaulted to parentClose+1s).
+func (w *LedgerWrapper) CloseAgree() bool {
+	h := w.ledger.Header()
+	return h.GetCloseAgree()
+}
+
+// ParentCloseTime returns the close time of this ledger's parent.
+func (w *LedgerWrapper) ParentCloseTime() time.Time {
+	return w.ledger.ParentCloseTime()
+}
+
 func (w *LedgerWrapper) TxSetID() consensus.TxSetID {
 	return w.txSetID
 }

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -122,10 +122,10 @@ type Engine struct {
 	// peer pressure.
 	prevProposers int
 
-	// prevCloseTime is our own observed close time carried across rounds
-	// (rippled's prevCloseTime_ / rawCloseTimes_.self). shouldCloseLedger
-	// measures idle time from it, instead of the previous ledger's stored
-	// close time, when that close can't be trusted — see lastCloseBaseline.
+	// prevCloseTime is our own observed close time carried across rounds.
+	// shouldCloseLedger measures idle time from it, instead of the previous
+	// ledger's stored close time, when that close can't be trusted — see
+	// lastCloseBaseline.
 	prevCloseTime time.Time
 
 	// wrongLedgerID is the ledger we're acquiring in ModeWrongLedger;
@@ -505,10 +505,10 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 	// Before the mode switch so it runs in every mode (preStartRound parity).
 	e.driveNegativeUNLNewValidatorsLocked()
 
-	// Carry our own observed close time across rounds (rippled prevCloseTime_).
-	// The first round seeds from the seed ledger; afterwards we take the self
-	// close time of the round that just ended, read from e.state before it is
-	// replaced below (this runs for every round-start path).
+	// Carry our own observed close time across rounds. The first round seeds
+	// from the seed ledger; afterwards we take the self close time of the round
+	// that just ended, read from e.state before it is replaced below (this runs
+	// for every round-start path).
 	if e.state == nil {
 		if e.prevLedger != nil {
 			e.prevCloseTime = e.prevLedger.CloseTime()
@@ -1917,8 +1917,7 @@ type closeAgreementReporter interface {
 // lastCloseBaseline returns the reference close time the idle/close timers
 // measure from. When the previous close was reached by consensus it's the
 // previous ledger's stored close time; otherwise it's our own observed close
-// carried across rounds (prevCloseTime) — matching rippled's
-// previousCloseCorrect branch in phaseOpen.
+// carried across rounds (prevCloseTime).
 func (e *Engine) lastCloseBaseline() time.Time {
 	if e.previousCloseCorrect() {
 		return e.prevLedger.CloseTime()

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -122,6 +122,12 @@ type Engine struct {
 	// peer pressure.
 	prevProposers int
 
+	// prevCloseTime is our own observed close time carried across rounds
+	// (rippled's prevCloseTime_ / rawCloseTimes_.self). shouldCloseLedger
+	// measures idle time from it, instead of the previous ledger's stored
+	// close time, when that close can't be trusted — see lastCloseBaseline.
+	prevCloseTime time.Time
+
 	// wrongLedgerID is the ledger we're acquiring in ModeWrongLedger;
 	// prevents spamming handleWrongLedger.
 	wrongLedgerID consensus.LedgerID
@@ -498,6 +504,18 @@ func (e *Engine) StartRound(round consensus.RoundID, proposing bool) error {
 func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering bool) error {
 	// Before the mode switch so it runs in every mode (preStartRound parity).
 	e.driveNegativeUNLNewValidatorsLocked()
+
+	// Carry our own observed close time across rounds (rippled prevCloseTime_).
+	// The first round seeds from the seed ledger; afterwards we take the self
+	// close time of the round that just ended, read from e.state before it is
+	// replaced below (this runs for every round-start path).
+	if e.state == nil {
+		if e.prevLedger != nil {
+			e.prevCloseTime = e.prevLedger.CloseTime()
+		}
+	} else {
+		e.prevCloseTime = e.state.CloseTimes.Self
+	}
 
 	// Determine mode. recovering forces switchedLedger for exactly one round
 	// even when we'd otherwise propose; the next round gets normal treatment.
@@ -1865,7 +1883,7 @@ func (e *Engine) shouldCloseLedger() bool {
 		return false
 	}
 	openTime := e.now().Sub(e.state.StartTime)
-	timeSincePrevClose := e.adaptor.Now().Sub(e.prevLedger.CloseTime())
+	timeSincePrevClose := e.adaptor.Now().Sub(e.lastCloseBaseline())
 
 	if e.closeTimesOutOfBounds(timeSincePrevClose) {
 		return true
@@ -1886,6 +1904,43 @@ func (e *Engine) shouldCloseLedger() bool {
 	e.traceCloseMiss(openTime, proposersClosed, proposersValidated)
 
 	return e.closeOnTimers(openTime, timeSincePrevClose)
+}
+
+// closeAgreementReporter is optionally implemented by a prevLedger that can
+// report whether its close time was reached by consensus. Ledgers that don't
+// (simulation/test ledgers) are treated as having agreed — the normal case.
+type closeAgreementReporter interface {
+	CloseAgree() bool
+	ParentCloseTime() time.Time
+}
+
+// lastCloseBaseline returns the reference close time the idle/close timers
+// measure from. When the previous close was reached by consensus it's the
+// previous ledger's stored close time; otherwise it's our own observed close
+// carried across rounds (prevCloseTime) — matching rippled's
+// previousCloseCorrect branch in phaseOpen.
+func (e *Engine) lastCloseBaseline() time.Time {
+	if e.previousCloseCorrect() {
+		return e.prevLedger.CloseTime()
+	}
+	return e.prevCloseTime
+}
+
+// previousCloseCorrect reports whether the previous ledger's stored close
+// time can be trusted: we're not on the wrong ledger, its close time was
+// agreed, and it isn't the defaulted parentClose+1s.
+func (e *Engine) previousCloseCorrect() bool {
+	if e.mode == consensus.ModeWrongLedger {
+		return false
+	}
+	rep, ok := e.prevLedger.(closeAgreementReporter)
+	if !ok {
+		return true
+	}
+	if !rep.CloseAgree() {
+		return false
+	}
+	return !e.prevLedger.CloseTime().Equal(rep.ParentCloseTime().Add(time.Second))
 }
 
 // closeTimesOutOfBounds reports close times so unreasonable we should

--- a/internal/consensus/rcl/engine_close_baseline_test.go
+++ b/internal/consensus/rcl/engine_close_baseline_test.go
@@ -1,0 +1,95 @@
+package rcl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+)
+
+// reporterLedger is a mockLedger that also reports close-time agreement,
+// satisfying closeAgreementReporter so lastCloseBaseline can consult it.
+type reporterLedger struct {
+	*mockLedger
+	closeAgree      bool
+	parentCloseTime time.Time
+}
+
+func (l *reporterLedger) CloseAgree() bool           { return l.closeAgree }
+func (l *reporterLedger) ParentCloseTime() time.Time { return l.parentCloseTime }
+
+// TestEngine_LastCloseBaseline mirrors rippled's previousCloseCorrect branch
+// (Consensus.h phaseOpen): the idle timer measures from the previous ledger's
+// stored close time only when that close was reached by consensus; otherwise
+// it measures from our own observed close (prevCloseTime).
+func TestEngine_LastCloseBaseline(t *testing.T) {
+	ledgerClose := time.Unix(1_000_000, 0).UTC()
+	observed := time.Unix(1_234_567, 0).UTC()
+
+	reporter := func(agree bool, parentClose time.Time) *reporterLedger {
+		return &reporterLedger{
+			mockLedger:      &mockLedger{id: consensus.LedgerID{9}, seq: 500, closeTime: ledgerClose},
+			closeAgree:      agree,
+			parentCloseTime: parentClose,
+		}
+	}
+	nonDefaultParent := ledgerClose.Add(-10 * time.Second) // parentClose+1s != ledgerClose
+	defaultParent := ledgerClose.Add(-time.Second)         // parentClose+1s == ledgerClose
+
+	tests := []struct {
+		name     string
+		prev     consensus.Ledger
+		mode     consensus.Mode
+		wantBase time.Time
+	}{
+		{"agreed close uses ledger close", reporter(true, nonDefaultParent), consensus.ModeObserving, ledgerClose},
+		{"wrong ledger uses observed close", reporter(true, nonDefaultParent), consensus.ModeWrongLedger, observed},
+		{"no close agreement uses observed close", reporter(false, nonDefaultParent), consensus.ModeObserving, observed},
+		{"defaulted parentClose+1s uses observed close", reporter(true, defaultParent), consensus.ModeObserving, observed},
+		{"non-reporter ledger falls back to ledger close", &mockLedger{id: consensus.LedgerID{7}, seq: 500, closeTime: ledgerClose}, consensus.ModeObserving, ledgerClose},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := NewEngine(newMockAdaptor(), DefaultConfig())
+			e.prevLedger = tt.prev
+			e.mode = tt.mode
+			e.prevCloseTime = observed
+
+			if got := e.lastCloseBaseline(); !got.Equal(tt.wantBase) {
+				t.Fatalf("lastCloseBaseline() = %v, want %v", got, tt.wantBase)
+			}
+		})
+	}
+}
+
+// TestEngine_PrevCloseTime_SeededAcrossRounds checks the cross-round carry of
+// our own observed close time (rippled prevCloseTime_): seeded from the seed
+// ledger on the first round, then from the self close time of the round that
+// just ended.
+func TestEngine_PrevCloseTime_SeededAcrossRounds(t *testing.T) {
+	e := NewEngine(newMockAdaptor(), DefaultConfig())
+
+	seedClose := time.Unix(1_000_000, 0).UTC()
+	e.prevLedger = &mockLedger{id: consensus.LedgerID{1}, seq: 100, closeTime: seedClose}
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	if err := e.StartRound(round, false); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+	if !e.prevCloseTime.Equal(seedClose) {
+		t.Fatalf("first round: prevCloseTime = %v, want seed ledger close %v", e.prevCloseTime, seedClose)
+	}
+
+	// Simulate closing our own ledger this round.
+	selfClose := time.Unix(1_000_050, 0).UTC()
+	e.state.CloseTimes.Self = selfClose
+
+	round2 := consensus.RoundID{Seq: 102, ParentHash: consensus.LedgerID{1}}
+	if err := e.StartRound(round2, false); err != nil {
+		t.Fatalf("StartRound (round 2): %v", err)
+	}
+	if !e.prevCloseTime.Equal(selfClose) {
+		t.Fatalf("second round: prevCloseTime = %v, want our observed close %v", e.prevCloseTime, selfClose)
+	}
+}


### PR DESCRIPTION
## Summary
- rippled's `phaseOpen` measures idle time (`sinceClose`) from its own observed close time (`prevCloseTime_`), not the previous ledger's stored close time, whenever that close can't be trusted — `mode == wrongLedger`, `!closeAgree`, or a defaulted `parentClose + 1s` (Consensus.h:1181-1210). go-xrpl's `shouldCloseLedger` always measured from `prevLedger.CloseTime()`, so after a degraded round the two nodes could decide to close an idle ledger at different elapsed times (a close-cadence/liveness divergence, not a divergence in the agreed close time).
- Carry our own observed close time across rounds as `Engine.prevCloseTime`, seeded exactly like rippled: first round from the seed ledger's close time, subsequent rounds from `state.CloseTimes.Self` (rippled's `rawCloseTimes_.self`), captured at the top of `startRoundLocked` before `e.state` is replaced.
- `shouldCloseLedger` now measures from `lastCloseBaseline()`, which returns `prevLedger.CloseTime()` when `previousCloseCorrect()` holds and `prevCloseTime` otherwise — a direct port of rippled's `previousCloseCorrect` branch.
- Close-agreement details are read through a small optional `closeAgreementReporter` interface implemented by the production `LedgerWrapper` (`CloseAgree` / `ParentCloseTime`). Ledgers that don't implement it (the deterministic csf simulation ledger, test mocks) are treated as close-correct — i.e. the current behaviour — so nothing changes under normal operation.

## Behaviour
- Normal operation (`closeAgree == true`, non-defaulted close, right ledger): `previousCloseCorrect` is true and the baseline is `prevLedger.CloseTime()`, identical to before.
- The new branch only activates in the degraded conditions the issue describes.

## Test plan
- [x] `go test ./internal/consensus/...` — all green, including the csf consensus simulation (unaffected, as expected).
- [x] New `internal/consensus/rcl/engine_close_baseline_test.go`: table-driven coverage of all `lastCloseBaseline` branches (agreed / wrong-ledger / no-agreement / defaulted parentClose+1s / non-reporter fallback) plus cross-round `prevCloseTime` seeding.
- [x] `go build ./...`, `go vet`, `gofmt`, and the strict `.golangci.yml` lint config — all clean.
- Conformance is orthogonal: this change only affects the live close-cadence decision, not tx application, ledger state, meta, or serialization (the paths conformance fixtures replay).

Fixes #1186