### PR TITLE
fix: reject same-seq validation re-signs to match rippled (#1197)

### DIFF
--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -289,10 +289,8 @@ func isCurrent(now, signTime, seenTime time.Time) bool {
 //     accepts, validations for seqs many rounds back are noise that
 //     can never retroactively become quorum; keeping them in memory
 //     wastes work on every checkFullValidation pass.
-//   - Per-node supersede rule: a node's tracked tip is replaced only
-//     by a strictly newer validation — a higher seq, or a same-seq
-//     re-sign of the same ledger with a later sign time (rippled's
-//     signTime tie-break). Regressing-seq re-signs are rejected.
+//   - Per-node newer-seq-only rule: a node's tip is superseded only by
+//     a strictly higher seq; a same-or-lower seq is rejected.
 //
 // onFullyValidated is fired OUTSIDE vt.mu so the callback may call
 // back into the tracker (e.g. ExpireOld) or take other locks that
@@ -364,21 +362,13 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	// happens at the wire seam, not here).
 	resolvedID := validation.NodeID
 
-	// Supersede a node's tip only with a strictly newer validation.
-	// A regressing seq is rejected here: go-xrpl has no SeqEnforcer to
-	// catch it downstream, and pulling byNode back to a stale ledger
-	// would skew ProposersFinished / PreferredFromValidations. For a
-	// same-seq re-sign of the same ledger, the later sign time wins,
-	// matching rippled's current_ signTime supersede; a same-seq
-	// validation for a different ledger is an equivocation we drop.
+	// Supersede a node's tip only with a strictly higher seq. go-xrpl
+	// has no SeqEnforcer; a same-or-lower-seq re-sign is rejected so a
+	// stale or sideways ledger can't skew ProposersFinished /
+	// PreferredFromValidations.
 	existing, hasExisting := vt.byNode[resolvedID]
 	if hasExisting {
-		if validation.LedgerSeq < existing.LedgerSeq {
-			return false
-		}
-		if validation.LedgerSeq == existing.LedgerSeq &&
-			(validation.LedgerID != existing.LedgerID ||
-				!validation.SignTime.After(existing.SignTime)) {
+		if validation.LedgerSeq <= existing.LedgerSeq {
 			return false
 		}
 	}

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -370,10 +370,9 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	// happens at the wire seam, not here).
 	resolvedID := validation.NodeID
 
-	// Supersede a node's tip only with a strictly higher seq. go-xrpl
-	// has no SeqEnforcer; a same-or-lower-seq re-sign is rejected so a
-	// stale or sideways ledger can't skew ProposersFinished /
-	// PreferredFromValidations.
+	// Supersede a node's tip only with a strictly higher seq; a
+	// same-or-lower-seq re-sign is rejected so a stale or sideways
+	// ledger can't skew ProposersFinished / PreferredFromValidations.
 	existing, hasExisting := vt.byNode[resolvedID]
 	if hasExisting {
 		if validation.LedgerSeq <= existing.LedgerSeq {
@@ -455,12 +454,9 @@ func (vt *ValidationTracker) checkFullValidationLocked(ledgerID consensus.Ledger
 	return ledgerID, 0, false
 }
 
-// GetTrustedValidations returns trusted validations for a ledger.
-//
-// Unlike rippled's getTrustedForLedger(ledgerID, seq), which also
-// filters v.seq() == seq, no seq argument is needed here: this map is
-// keyed by ledger hash, and a ledger hash uniquely determines its seq,
-// so every entry under a given ledgerID already shares that seq.
+// GetTrustedValidations returns trusted validations for a ledger. No
+// seq argument is needed: entries are keyed by ledger hash, which
+// uniquely determines the seq, so all entries under a ledgerID share it.
 func (vt *ValidationTracker) GetTrustedValidations(ledgerID consensus.LedgerID) []*consensus.Validation {
 	vt.mu.RLock()
 	defer vt.mu.RUnlock()

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -289,8 +289,10 @@ func isCurrent(now, signTime, seenTime time.Time) bool {
 //     accepts, validations for seqs many rounds back are noise that
 //     can never retroactively become quorum; keeping them in memory
 //     wastes work on every checkFullValidation pass.
-//   - Per-node newer-seq-only rule: a node's latest validation
-//     supersedes any earlier one.
+//   - Per-node supersede rule: a node's tracked tip is replaced only
+//     by a strictly newer validation — a higher seq, or a same-seq
+//     re-sign of the same ledger with a later sign time (rippled's
+//     signTime tie-break). Regressing-seq re-signs are rejected.
 //
 // onFullyValidated is fired OUTSIDE vt.mu so the callback may call
 // back into the tracker (e.g. ExpireOld) or take other locks that
@@ -362,11 +364,22 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	// happens at the wire seam, not here).
 	resolvedID := validation.NodeID
 
-	// Check if this is a newer validation from this node
+	// Supersede a node's tip only with a strictly newer validation.
+	// A regressing seq is rejected here: go-xrpl has no SeqEnforcer to
+	// catch it downstream, and pulling byNode back to a stale ledger
+	// would skew ProposersFinished / PreferredFromValidations. For a
+	// same-seq re-sign of the same ledger, the later sign time wins,
+	// matching rippled's current_ signTime supersede; a same-seq
+	// validation for a different ledger is an equivocation we drop.
 	existing, hasExisting := vt.byNode[resolvedID]
 	if hasExisting {
-		if validation.LedgerSeq <= existing.LedgerSeq {
-			return false // Not newer, ignore
+		if validation.LedgerSeq < existing.LedgerSeq {
+			return false
+		}
+		if validation.LedgerSeq == existing.LedgerSeq &&
+			(validation.LedgerID != existing.LedgerID ||
+				!validation.SignTime.After(existing.SignTime)) {
+			return false
 		}
 	}
 
@@ -441,6 +454,11 @@ func (vt *ValidationTracker) checkFullValidationLocked(ledgerID consensus.Ledger
 }
 
 // GetTrustedValidations returns trusted validations for a ledger.
+//
+// Unlike rippled's getTrustedForLedger(ledgerID, seq), which also
+// filters v.seq() == seq, no seq argument is needed here: this map is
+// keyed by ledger hash, and a ledger hash uniquely determines its seq,
+// so every entry under a given ledgerID already shares that seq.
 func (vt *ValidationTracker) GetTrustedValidations(ledgerID consensus.LedgerID) []*consensus.Validation {
 	vt.mu.RLock()
 	defer vt.mu.RUnlock()

--- a/internal/consensus/rcl/validations_test.go
+++ b/internal/consensus/rcl/validations_test.go
@@ -191,13 +191,15 @@ func TestValidationTracker_NewerValidation(t *testing.T) {
 	}
 }
 
-// TestValidationTracker_SameSeqResignSupersede pins the signTime
-// tie-break for a same-seq re-sign, matching rippled's current_
-// replacement (Validations.h:690 — replace only when the new sign time
-// is strictly later). go-xrpl has no SeqEnforcer, so the by-node tip
-// still rejects a regressing seq and refuses to promote a same-seq
-// validation for a conflicting ledger.
-func TestValidationTracker_SameSeqResignSupersede(t *testing.T) {
+// TestValidationTracker_SameSeqResignRejected pins that a same-seq
+// re-sign never supersedes a node's tip. rippled leaves current_
+// untouched here: within the SeqEnforcer window a re-sign for the same
+// seq returns badSeq (same ledger) or conflicting (different ledger),
+// and the signTime tie-break only ever runs for a strictly higher seq
+// (Validations_test.cpp:285, :305-307, :344-353). go-xrpl has no
+// SeqEnforcer, so the by-node guard enforces the same outcome with a
+// strictly-higher-seq supersede rule.
+func TestValidationTracker_SameSeqResignRejected(t *testing.T) {
 	vt := NewValidationTracker(2, 5*time.Minute)
 
 	base := time.Unix(1_600_000_000, 0).UTC()
@@ -218,36 +220,22 @@ func TestValidationTracker_SameSeqResignSupersede(t *testing.T) {
 		t.Fatal("initial validation should be added")
 	}
 
-	// Same seq, same ledger, later sign time: supersedes.
-	later := base.Add(2 * time.Second)
-	if !vt.Add(&consensus.Validation{
-		LedgerID:  ledgerX,
-		LedgerSeq: 100,
-		NodeID:    node,
-		SignTime:  later,
-		Full:      true,
-	}) {
-		t.Error("same-seq re-sign with a later sign time should supersede")
-	}
-	if got := vt.GetLatestValidation(node); got == nil || !got.SignTime.Equal(later) {
-		t.Errorf("tip should reflect the later re-sign, got %+v", got)
-	}
-
-	// Same seq, same ledger, equal/earlier sign time: rejected, tip kept.
+	// Same seq, same ledger, later sign time: rejected, tip unchanged
+	// (rippled returns badSeq — no signTime supersede for the same seq).
 	if vt.Add(&consensus.Validation{
 		LedgerID:  ledgerX,
 		LedgerSeq: 100,
 		NodeID:    node,
-		SignTime:  base,
+		SignTime:  base.Add(2 * time.Second),
 		Full:      true,
 	}) {
-		t.Error("same-seq re-sign with an earlier sign time should be rejected")
+		t.Error("same-seq re-sign should not supersede the tip")
 	}
-	if got := vt.GetLatestValidation(node); got == nil || !got.SignTime.Equal(later) {
-		t.Errorf("tip should be unchanged after a stale re-sign, got %+v", got)
+	if got := vt.GetLatestValidation(node); got == nil || !got.SignTime.Equal(base) {
+		t.Errorf("tip should be unchanged after a same-seq re-sign, got %+v", got)
 	}
 
-	// Same seq, different ledger, even later sign time: equivocation, dropped.
+	// Same seq, different ledger: equivocation, dropped (rippled conflicting).
 	if vt.Add(&consensus.Validation{
 		LedgerID:  ledgerY,
 		LedgerSeq: 100,
@@ -255,10 +243,24 @@ func TestValidationTracker_SameSeqResignSupersede(t *testing.T) {
 		SignTime:  base.Add(4 * time.Second),
 		Full:      true,
 	}) {
-		t.Error("same-seq validation for a conflicting ledger should not be promoted")
+		t.Error("same-seq validation for a conflicting ledger should be dropped")
 	}
 	if got := vt.GetLatestValidation(node); got == nil || got.LedgerID != ledgerX {
 		t.Errorf("tip should still be ledgerX after equivocation, got %+v", got)
+	}
+
+	// A strictly higher seq still supersedes.
+	if !vt.Add(&consensus.Validation{
+		LedgerID:  ledgerY,
+		LedgerSeq: 101,
+		NodeID:    node,
+		SignTime:  base.Add(6 * time.Second),
+		Full:      true,
+	}) {
+		t.Error("a strictly higher seq should supersede")
+	}
+	if got := vt.GetLatestValidation(node); got == nil || got.LedgerID != ledgerY {
+		t.Errorf("tip should advance to ledgerY at the higher seq, got %+v", got)
 	}
 }
 

--- a/internal/consensus/rcl/validations_test.go
+++ b/internal/consensus/rcl/validations_test.go
@@ -191,6 +191,77 @@ func TestValidationTracker_NewerValidation(t *testing.T) {
 	}
 }
 
+// TestValidationTracker_SameSeqResignSupersede pins the signTime
+// tie-break for a same-seq re-sign, matching rippled's current_
+// replacement (Validations.h:690 — replace only when the new sign time
+// is strictly later). go-xrpl has no SeqEnforcer, so the by-node tip
+// still rejects a regressing seq and refuses to promote a same-seq
+// validation for a conflicting ledger.
+func TestValidationTracker_SameSeqResignSupersede(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+
+	base := time.Unix(1_600_000_000, 0).UTC()
+	vt.SetNow(func() time.Time { return base })
+
+	node := consensus.NodeID{7}
+	ledgerX := consensus.LedgerID{0xAA}
+	ledgerY := consensus.LedgerID{0xBB}
+
+	// Initial validation for ledgerX at seq 100.
+	if !vt.Add(&consensus.Validation{
+		LedgerID:  ledgerX,
+		LedgerSeq: 100,
+		NodeID:    node,
+		SignTime:  base,
+		Full:      true,
+	}) {
+		t.Fatal("initial validation should be added")
+	}
+
+	// Same seq, same ledger, later sign time: supersedes.
+	later := base.Add(2 * time.Second)
+	if !vt.Add(&consensus.Validation{
+		LedgerID:  ledgerX,
+		LedgerSeq: 100,
+		NodeID:    node,
+		SignTime:  later,
+		Full:      true,
+	}) {
+		t.Error("same-seq re-sign with a later sign time should supersede")
+	}
+	if got := vt.GetLatestValidation(node); got == nil || !got.SignTime.Equal(later) {
+		t.Errorf("tip should reflect the later re-sign, got %+v", got)
+	}
+
+	// Same seq, same ledger, equal/earlier sign time: rejected, tip kept.
+	if vt.Add(&consensus.Validation{
+		LedgerID:  ledgerX,
+		LedgerSeq: 100,
+		NodeID:    node,
+		SignTime:  base,
+		Full:      true,
+	}) {
+		t.Error("same-seq re-sign with an earlier sign time should be rejected")
+	}
+	if got := vt.GetLatestValidation(node); got == nil || !got.SignTime.Equal(later) {
+		t.Errorf("tip should be unchanged after a stale re-sign, got %+v", got)
+	}
+
+	// Same seq, different ledger, even later sign time: equivocation, dropped.
+	if vt.Add(&consensus.Validation{
+		LedgerID:  ledgerY,
+		LedgerSeq: 100,
+		NodeID:    node,
+		SignTime:  base.Add(4 * time.Second),
+		Full:      true,
+	}) {
+		t.Error("same-seq validation for a conflicting ledger should not be promoted")
+	}
+	if got := vt.GetLatestValidation(node); got == nil || got.LedgerID != ledgerX {
+		t.Errorf("tip should still be ledgerX after equivocation, got %+v", got)
+	}
+}
+
 // TestValidationTracker_NegativeUNL_ExcludedFromQuorum pins the negUNL
 // filter's quorum behavior. A validator on the negative-UNL is trusted
 // for message acceptance (its Full validation is stored) but EXCLUDED


### PR DESCRIPTION
## Summary
Closes #1197 (both edge cases — the issue rates them **cosmetic**), reconciled to match rippled.

- **byNode supersede:** a node's tip is superseded only by a strictly **higher seq**; a same-or-lower-seq re-sign is rejected. This matches rippled: a same-seq re-sign is gated by the `SeqEnforcer` and returns `conflicting`/`badSeq` (never supersedes) within the 10-min expiry window — the signTime tie-break at `Validations.h:690` only ever runs for a strictly higher seq (see `Validations_test.cpp:285`, `:305-307`, `:344-353`). An earlier revision of this PR switched to a same-seq signTime supersede; that **diverged** from rippled and has been reverted (commit `0169a123`).
- **GetTrustedValidations:** documents why no `seq` filter is needed — entries are keyed by ledger hash, which uniquely determines the seq, so entries under a `ledgerID` are seq-homogeneous (rippled's `getTrustedForLedger(id, seq)` adds a filter that would be redundant here).
- **Net behavioral change vs `main`: none.** The byNode logic is now byte-identical to `main`; this PR adds a regression test + docs and merges `main` to clear a stale base (the branch predated the parking/Flush work on `validations.go`).

## Test plan
- [x] `TestValidationTracker_SameSeqResignRejected` — non-vacuous (fails if the supersede branch is reintroduced); asserts same-seq re-signs and conflicting-ledger equivocations are rejected and a strictly higher seq still supersedes.
- [x] `go build ./...`, `go vet ./internal/consensus/...`, `golangci-lint --config .golangci.yml ./internal/consensus/rcl/...` (0 issues), full `rcl` package tests green — before and after merging `origin/main`.

Fixes #1197
