### PR TITLE
feat: add anti-self-equivocation floor after restart

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -248,6 +248,11 @@ type Adaptor struct {
 	// the trie-descent floor for preferredLCL. Zero for a non-validator.
 	lastIssuedValidationSeq atomic.Uint32
 
+	// maxDisallowedSeq is the highest ledger seq persisted before this
+	// process started; the engine never proposes or validates at or below
+	// it (anti-double-sign across restarts). Immutable after New.
+	maxDisallowedSeq uint32
+
 	// reqLedgerLast rate-limits per-hash broadcast TMGetLedger retries from
 	// the engine's checkLedger heartbeat (see RequestLedger).
 	reqLedgerMu   sync.Mutex
@@ -397,6 +402,17 @@ func New(cfg Config) *Adaptor {
 		feeVote.ReserveIncrement = defaults.ReserveIncrement
 	}
 
+	// A restarting validator may already have signed validations up to the
+	// persisted tip, so record it as the floor below which this node must
+	// never validate again. Non-validators never emit, so skip the read.
+	var maxDisallowedSeq uint32
+	if cfg.Identity != nil && cfg.LedgerService != nil {
+		maxDisallowedSeq = cfg.LedgerService.MaxPersistedLedgerSeq(context.Background())
+		if maxDisallowedSeq > 0 {
+			logger.Info("max persisted ledger floor for validations", "seq", maxDisallowedSeq)
+		}
+	}
+
 	// NegativeUNL voter: constructed only with both a local identity and UNL
 	// master keys (needed for the local-participation check and the emitted
 	// UNLModify tx). nil otherwise — GenerateNegativeUNLPseudoTx returns no votes.
@@ -423,6 +439,7 @@ func New(cfg Config) *Adaptor {
 		peerLCLs:          make(map[uint64]consensus.LedgerID),
 		reqLedgerLast:     make(map[consensus.LedgerID]time.Time),
 		announcedSets:     make(map[consensus.TxSetID]struct{}),
+		maxDisallowedSeq:  maxDisallowedSeq,
 		cookie:            cookie,
 		feeVote:           feeVote,
 		amendmentStances:  amendmentStances,
@@ -694,6 +711,12 @@ func (a *Adaptor) GetValidatedLedgerHash() consensus.LedgerID {
 		return consensus.LedgerID{}
 	}
 	return consensus.LedgerID(vl.Hash())
+}
+
+// GetMaxDisallowedLedgerSeq returns the boot-time anti-double-sign floor: the
+// highest ledger seq persisted before this process started, 0 when none.
+func (a *Adaptor) GetMaxDisallowedLedgerSeq() uint32 {
+	return a.maxDisallowedSeq
 }
 
 func (a *Adaptor) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, closeTime time.Time, closeTimeCorrect bool) (consensus.Ledger, error) {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -402,9 +402,7 @@ func New(cfg Config) *Adaptor {
 		feeVote.ReserveIncrement = defaults.ReserveIncrement
 	}
 
-	// A restarting validator may already have signed validations up to the
-	// persisted tip, so record it as the floor below which this node must
-	// never validate again. Non-validators never emit, so skip the read.
+	// Non-validators never emit, so skip the floor read (see maxDisallowedSeq).
 	var maxDisallowedSeq uint32
 	if cfg.Identity != nil && cfg.LedgerService != nil {
 		maxDisallowedSeq = cfg.LedgerService.MaxPersistedLedgerSeq(context.Background())
@@ -713,8 +711,6 @@ func (a *Adaptor) GetValidatedLedgerHash() consensus.LedgerID {
 	return consensus.LedgerID(vl.Hash())
 }
 
-// GetMaxDisallowedLedgerSeq returns the boot-time anti-double-sign floor: the
-// highest ledger seq persisted before this process started, 0 when none.
 func (a *Adaptor) GetMaxDisallowedLedgerSeq() uint32 {
 	return a.maxDisallowedSeq
 }

--- a/internal/consensus/adaptor/adaptor_test.go
+++ b/internal/consensus/adaptor/adaptor_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	"github.com/LeJamon/go-xrpl/storage/relationaldb"
+	sqlitedb "github.com/LeJamon/go-xrpl/storage/relationaldb/sqlite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -716,4 +718,50 @@ func TestOnConsensusReached_AutoPromote(t *testing.T) {
 		assert.Equal(t, consensus.OpModeConnected, a.GetOperatingMode(),
 			"a lower-seq preferred tip on a different chain is a switch — promotion must defer")
 	})
+}
+
+// TestNew_SeedsRestartValidationFloor pins the boot-time seeding of the
+// anti-double-sign floor (rippled setMaxDisallowedLedger,
+// Application.cpp:2170): a validator whose relational DB already holds
+// ledgers must record the max persisted seq at construction so the
+// engine never re-signs a pre-restart sequence. Non-validators skip the
+// read (rippled gates on validatorKeys_.keys).
+func TestNew_SeedsRestartValidationFloor(t *testing.T) {
+	ctx := context.Background()
+
+	rm, err := sqlitedb.NewRepositoryManager(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, rm.Open(ctx))
+	t.Cleanup(func() { _ = rm.Close(ctx) })
+
+	// Persist ledgers up to seq 742 as a prior run would have.
+	for _, seq := range []relationaldb.LedgerIndex{740, 742, 741} {
+		info := &relationaldb.LedgerInfo{Sequence: seq}
+		info.Hash[0] = byte(seq)
+		require.NoError(t, rm.Ledger().SaveValidatedLedger(ctx, info, true))
+	}
+
+	cfg := service.DefaultConfig()
+	cfg.Standalone = true
+	cfg.GenesisConfig = genesis.DefaultConfig()
+	cfg.RelationalDB = rm
+	svc, err := service.New(cfg)
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(742), svc.MaxPersistedLedgerSeq(ctx))
+
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+
+	a := New(Config{
+		LedgerService: svc,
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+	})
+	assert.Equal(t, uint32(742), a.GetMaxDisallowedLedgerSeq(),
+		"validator must seed the restart floor from the persisted tip")
+
+	observer := New(Config{LedgerService: svc})
+	assert.Equal(t, uint32(0), observer.GetMaxDisallowedLedgerSeq(),
+		"non-validators never emit, so the floor stays 0")
 }

--- a/internal/consensus/csf/engine_adaptor.go
+++ b/internal/consensus/csf/engine_adaptor.go
@@ -391,6 +391,12 @@ func (p *EnginePeer) GetValidatedLedgerHash() consensus.LedgerID {
 	return p.validated
 }
 
+// GetMaxDisallowedLedgerSeq: simulated peers have no persisted pre-boot
+// history, so the restart validation floor is always 0.
+func (p *EnginePeer) GetMaxDisallowedLedgerSeq() uint32 {
+	return 0
+}
+
 func (p *EnginePeer) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, closeTime time.Time, _ bool) (consensus.Ledger, error) {
 	l := buildSimLedger(parent.ID(), parent.Seq()+1, txSet.ID(), closeTime)
 	p.mu.Lock()

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -123,6 +123,13 @@ type LedgerProvider interface {
 	// validated ledger (trusted-validation quorum reached), or zero if none.
 	GetValidatedLedgerHash() LedgerID
 
+	// GetMaxDisallowedLedgerSeq returns the highest ledger sequence persisted
+	// before this process started, or 0 when none. A restarted validator may
+	// already have signed validations up to that tip, so it must never
+	// propose or validate at or below this floor (anti-self-equivocation
+	// across restarts). Immutable after startup.
+	GetMaxDisallowedLedgerSeq() uint32
+
 	BuildLedger(parent Ledger, txSet TxSet, closeTime time.Time, closeTimeCorrect bool) (Ledger, error)
 
 	ValidateLedger(ledger Ledger) error

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -501,7 +501,22 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 
 	// Determine mode. recovering forces switchedLedger for exactly one round
 	// even when we'd otherwise propose; the next round gets normal treatment.
+	// belowFloor holds a restarted validator in observing until the network
+	// passes the pre-restart persisted tip, so it can't re-sign a sequence it
+	// may already have validated (round.Seq is prevLedger.Seq()+1, making
+	// this rippled preStartRound's prevLgr.seq() >= maxDisallowedLedger).
+	belowFloor := round.Seq <= e.adaptor.GetMaxDisallowedLedgerSeq()
 	switch {
+	case belowFloor:
+		if proposing && e.adaptor.IsValidator() {
+			slog.Info("Observing: round at or below restart validation floor",
+				"t", "consensus",
+				"event", "restart-floor-observe",
+				"round_seq", round.Seq,
+				"floor", e.adaptor.GetMaxDisallowedLedgerSeq(),
+			)
+		}
+		e.setMode(consensus.ModeObserving)
 	case recovering && e.adaptor.IsValidator() && e.adaptor.GetOperatingMode() == consensus.OpModeFull:
 		e.setMode(consensus.ModeSwitchedLedger)
 	case proposing && e.adaptor.IsValidator() && e.adaptor.GetOperatingMode() == consensus.OpModeFull:
@@ -3083,6 +3098,7 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 		"compatible", compatible,
 		"can_validate_seq", canValidate,
 		"our_last_validated_seq", e.ourLastValidatedSeq,
+		"max_disallowed_seq", e.adaptor.GetMaxDisallowedLedgerSeq(),
 		"mode", e.mode.String(),
 		"decision", emitDecision(willEmit, isValidator, consensusFail, canValidate, compatible),
 	)
@@ -3319,12 +3335,16 @@ func (e *Engine) determineCloseTime() time.Time {
 }
 
 // peekCanValidateSeqLocked is the non-mutating SeqEnforcer predicate.
-// Caller holds e.mu read.
+// The restart floor never idle-expires: the pre-restart persisted tip stays
+// disallowed for the process lifetime. Caller holds e.mu read.
 func (e *Engine) peekCanValidateSeqLocked(seq uint32) bool {
 	floor := e.ourLastValidatedSeq
 	if !e.ourLastValidatedTime.IsZero() &&
 		e.adaptor.Now().Sub(e.ourLastValidatedTime) > validationSetExpires {
 		floor = 0
+	}
+	if d := e.adaptor.GetMaxDisallowedLedgerSeq(); floor < d {
+		floor = d
 	}
 	return seq > floor
 }
@@ -3338,7 +3358,7 @@ func (e *Engine) tryAdvanceValidatedSeqLocked(seq uint32) bool {
 		now.Sub(e.ourLastValidatedTime) > validationSetExpires {
 		e.ourLastValidatedSeq = 0
 	}
-	if seq <= e.ourLastValidatedSeq {
+	if seq <= e.ourLastValidatedSeq || seq <= e.adaptor.GetMaxDisallowedLedgerSeq() {
 		return false
 	}
 	e.ourLastValidatedSeq = seq

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -137,6 +137,10 @@ type mockAdaptor struct {
 	// sfValidatedHash gate path.
 	validatedLedgerHashOverride consensus.LedgerID
 
+	// Boot-time restart validation floor served by
+	// GetMaxDisallowedLedgerSeq. Zero by default (no persisted history).
+	maxDisallowedSeq uint32
+
 	// Amendment vote stance for the R5.3 test. Empty means no vote.
 	amendmentVote [][32]byte
 
@@ -225,6 +229,12 @@ func (a *mockAdaptor) UpdateRelaySlot(_ []byte, _ uint64, _ []uint64) {}
 // PeersThatHave returns nil — the rcl engine tests never query the
 // overlay's reverse index since they go through a mockAdaptor.
 func (a *mockAdaptor) PeersThatHave(_ [32]byte) []uint64 { return nil }
+
+func (a *mockAdaptor) GetMaxDisallowedLedgerSeq() uint32 {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.maxDisallowedSeq
+}
 
 func (a *mockAdaptor) GetValidatedLedgerHash() consensus.LedgerID {
 	// Test mock: no validated ledger tracking by default. Tests that
@@ -3109,6 +3119,152 @@ func TestSendValidation_SeqEnforcerExpiresAfterIdle(t *testing.T) {
 		t.Fatalf("post-reset floor not re-armed: a seq below the new "+
 			"floor (300) was wrongly accepted; want 2 emissions, got %d",
 			final)
+	}
+}
+
+// TestEngine_StartRound_RestartFloorForcesObserving pins the anti-
+// self-equivocation floor after restart (rippled preStartRound,
+// RCLConsensus.cpp:1006): a validator whose relational DB held ledgers
+// up to seq N before restart must not re-enter a validating mode for
+// any round at or below N — it may already have signed a conflicting
+// validation for those sequences. Rounds strictly above N (prevLedger
+// seq >= N) promote normally.
+func TestEngine_StartRound_RestartFloorForcesObserving(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+	adaptor.maxDisallowedSeq = 500
+
+	engine := NewEngine(adaptor, DefaultConfig())
+
+	// Round building seq 500 == floor → held in observing.
+	round := consensus.RoundID{Seq: 500, ParentHash: consensus.LedgerID{1}}
+	if err := engine.StartRound(round, true); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+	if engine.Mode() != consensus.ModeObserving {
+		t.Fatalf("round at the restart floor: want Observing, got %v", engine.Mode())
+	}
+
+	// Round building seq 501 (prevLedger seq 500 >= floor) → proposes.
+	round = consensus.RoundID{Seq: 501, ParentHash: consensus.LedgerID{2}}
+	if err := engine.StartRound(round, true); err != nil {
+		t.Fatalf("StartRound: %v", err)
+	}
+	if engine.Mode() != consensus.ModeProposing {
+		t.Fatalf("round above the restart floor: want Proposing, got %v", engine.Mode())
+	}
+}
+
+// TestSendValidation_RestartFloor_BlocksAtOrBelow pins the emission
+// side of the restart floor: go-xrpl emits validations regardless of
+// mode, so the SeqEnforcer must also refuse any seq at or below the
+// max ledger persisted before this process started, even when the
+// in-memory floor (ourLastValidatedSeq) is still 0.
+func TestSendValidation_RestartFloor_BlocksAtOrBelow(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+	adaptor.maxDisallowedSeq = 500
+
+	engine := NewEngine(adaptor, DefaultConfig())
+
+	ctx := t.Context()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer engine.Stop()
+
+	round := consensus.RoundID{Seq: 501, ParentHash: consensus.LedgerID{1}}
+	engine.StartRound(round, true)
+
+	adaptor.mu.Lock()
+	adaptor.validationsBroadcast = nil
+	adaptor.mu.Unlock()
+
+	// At and below the persisted tip → dropped (possible double-sign).
+	engine.mu.Lock()
+	engine.sendValidation(&mockLedger{id: consensus.LedgerID{0xA1}, seq: 500})
+	engine.sendValidation(&mockLedger{id: consensus.LedgerID{0xB2}, seq: 499})
+	engine.mu.Unlock()
+
+	adaptor.mu.RLock()
+	blocked := len(adaptor.validationsBroadcast)
+	adaptor.mu.RUnlock()
+	if blocked != 0 {
+		t.Fatalf("restart floor: emissions at seq <= 500 must be dropped, got %d", blocked)
+	}
+
+	// First seq above the persisted tip → emits.
+	engine.mu.Lock()
+	engine.sendValidation(&mockLedger{id: consensus.LedgerID{0xC3}, seq: 501})
+	engine.mu.Unlock()
+
+	adaptor.mu.RLock()
+	emitted := append([]*consensus.Validation(nil), adaptor.validationsBroadcast...)
+	adaptor.mu.RUnlock()
+	if len(emitted) != 1 || emitted[0].LedgerSeq != 501 {
+		t.Fatalf("restart floor: want exactly one emission at seq=501, got %d", len(emitted))
+	}
+}
+
+// TestSendValidation_RestartFloorSurvivesIdleExpiry pins the
+// difference between the two floors: the in-memory SeqEnforcer floor
+// resets after validationSetExpires of silence, but the boot-time
+// restart floor is rippled's maxDisallowedLedger_ — immutable for the
+// process lifetime. Without the clamp, a validator idle for 10+
+// minutes after restart could re-sign a pre-restart sequence.
+func TestSendValidation_RestartFloorSurvivesIdleExpiry(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.validator = true
+	adaptor.opMode = consensus.OpModeFull
+	adaptor.maxDisallowedSeq = 500
+
+	baseTime := time.Unix(1_700_000_000, 0).UTC()
+	adaptor.mu.Lock()
+	adaptor.now = baseTime
+	adaptor.mu.Unlock()
+
+	engine := NewEngine(adaptor, DefaultConfig())
+
+	ctx := t.Context()
+	if err := engine.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer engine.Stop()
+
+	round := consensus.RoundID{Seq: 501, ParentHash: consensus.LedgerID{1}}
+	engine.StartRound(round, true)
+
+	adaptor.mu.Lock()
+	adaptor.validationsBroadcast = nil
+	adaptor.mu.Unlock()
+
+	// Emit at 501, then go idle past the SeqEnforcer expiry.
+	engine.mu.Lock()
+	engine.sendValidation(&mockLedger{id: consensus.LedgerID{0xA1}, seq: 501})
+	engine.mu.Unlock()
+
+	adaptor.mu.Lock()
+	adaptor.now = baseTime.Add(validationSetExpires + time.Second)
+	adaptor.mu.Unlock()
+
+	// The idle reset drops ourLastValidatedSeq to 0, but the restart
+	// floor must still refuse a pre-restart sequence.
+	engine.mu.Lock()
+	engine.sendValidation(&mockLedger{id: consensus.LedgerID{0xB2}, seq: 400})
+	engine.mu.Unlock()
+
+	adaptor.mu.RLock()
+	emitted := append([]*consensus.Validation(nil), adaptor.validationsBroadcast...)
+	adaptor.mu.RUnlock()
+	if len(emitted) != 1 {
+		t.Fatalf("restart floor must survive the idle reset: seq=400 <= "+
+			"persisted tip 500 was wrongly emitted; want 1 emission, got %d",
+			len(emitted))
+	}
+	if emitted[0].LedgerSeq != 501 {
+		t.Fatalf("kept emission seq: want 501, got %d", emitted[0].LedgerSeq)
 	}
 }
 

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -137,8 +137,7 @@ type mockAdaptor struct {
 	// sfValidatedHash gate path.
 	validatedLedgerHashOverride consensus.LedgerID
 
-	// Boot-time restart validation floor served by
-	// GetMaxDisallowedLedgerSeq. Zero by default (no persisted history).
+	// Restart validation floor; zero = no persisted history.
 	maxDisallowedSeq uint32
 
 	// Amendment vote stance for the R5.3 test. Empty means no vote.

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -911,6 +911,23 @@ func (s *Service) GetClosedLedgerIndex() uint32 {
 	return s.closedLedger.Sequence()
 }
 
+// MaxPersistedLedgerSeq returns the highest ledger sequence in the relational
+// DB, or 0 when none is stored or no relational DB is configured.
+func (s *Service) MaxPersistedLedgerSeq(ctx context.Context) uint32 {
+	if s.relationalDB == nil || s.relationalDB.Ledger() == nil {
+		return 0
+	}
+	seq, err := s.relationalDB.Ledger().GetMaxLedgerSeq(ctx)
+	if err != nil {
+		s.logger.Warn("failed to read max persisted ledger seq", "err", err)
+		return 0
+	}
+	if seq == nil {
+		return 0
+	}
+	return uint32(*seq)
+}
+
 // ledgerHistoryRangeLocked returns the inclusive [min, max] span of in-memory
 // history, or ok=false when empty. Caller holds s.mu. NB: the span assumes
 // contiguity — purges/backward-fills can leave gaps, so callers reporting durable


### PR DESCRIPTION
## Summary
- Records the max persisted ledger seq at boot (rippled's `maxDisallowedLedger_`, `Application.cpp:2170` / `RCLConsensus.cpp:1006`) via a new `Service.MaxPersistedLedgerSeq`, seeded into the consensus adaptor only when the node has a validator identity — mirroring rippled's `validatorKeys_.keys` gate.
- Round start: a round building a seq at or below the floor is held in `ModeObserving` (`round.Seq <= floor` ⇔ rippled's `prevLgr.seq() >= getMaxDisallowedLedger()` gate), so a restarted validator can't propose for a sequence it may already have signed.
- Emission: go-xrpl intentionally emits validations regardless of mode, so the round-start gate alone is insufficient — the SeqEnforcer (`peekCanValidateSeqLocked` / `tryAdvanceValidatedSeqLocked`) also clamps to the floor. Unlike the in-memory `ourLastValidatedSeq`, the restart floor never idle-expires (`validationSetExpires` reset no longer opens a double-sign window after 10 idle minutes).

## Test plan
- [x] `go test ./internal/consensus/... ./internal/ledger/...` — all pass
- [x] New: `TestEngine_StartRound_RestartFloorForcesObserving`, `TestSendValidation_RestartFloor_BlocksAtOrBelow`, `TestSendValidation_RestartFloorSurvivesIdleExpiry`, `TestNew_SeedsRestartValidationFloor` — all proven to fail with the engine gates reverted
- [x] `go vet ./...`, `gofmt`, `golangci-lint run --config .golangci.yml` on touched packages — 0 issues

Fixes #1205