### PR TITLE
fix: signal overlay listener readiness to de-flake TestTwoOverlay_*

### DIFF
--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -269,6 +269,15 @@ type Overlay struct {
 	listenerMu sync.RWMutex
 	listener   net.Listener
 
+	// listenerReady is closed once Run has finished its listener-bind
+	// phase — after startListener publishes o.listener, or immediately
+	// when no listener is configured. Callers that need to wait for the
+	// bind (integration tests wiring two overlays on an ephemeral port)
+	// block on ListenerReady() instead of polling ListenAddr() against a
+	// wall clock, which is racy under load.
+	listenerReady     chan struct{}
+	listenerReadyOnce sync.Once
+
 	// Lifecycle
 	// lifecycleMu guards ctx/cancel against the Run-write vs Stop-read
 	// race: Run is typically launched in its own goroutine and lazily
@@ -679,6 +688,23 @@ func (o *Overlay) ListenAddr() string {
 	return l.Addr().String()
 }
 
+// ListenerReady returns a channel that is closed once Run has finished
+// binding the listener (or determined none is configured). Waiting on it
+// is the race-free way to know ListenAddr() will report the resolved
+// ephemeral port — callers block on the event instead of polling.
+func (o *Overlay) ListenerReady() <-chan struct{} {
+	return o.listenerReady
+}
+
+// signalListenerReady closes listenerReady exactly once. Guarded against
+// overlays constructed directly (outside New), whose channel is nil.
+func (o *Overlay) signalListenerReady() {
+	if o.listenerReady == nil {
+		return
+	}
+	o.listenerReadyOnce.Do(func() { close(o.listenerReady) })
+}
+
 // messageBufferSize returns the inbound-message channel capacity,
 // falling back to DefaultMessageBufferSize when the configured value
 // is non-positive. A non-positive size would create an unbuffered
@@ -774,6 +800,7 @@ func New(opts ...Option) (*Overlay, error) {
 		ledgerData:      make(chan *InboundMessage, DefaultLedgerDataBufferSize),
 		lifecycle:       make(chan Event, lifecycleBufferSize(&cfg)),
 		stopCh:          make(chan struct{}),
+		listenerReady:   make(chan struct{}),
 		relayedIndex:    make(map[[32]byte]*relayedEntry),
 		clockForIndex:   time.Now,
 		inboundSem:      make(chan struct{}, inboundCap),
@@ -853,6 +880,9 @@ func (o *Overlay) Run(ctx context.Context) error {
 			return fmt.Errorf("listener error: %w", err)
 		}
 	}
+	// Unblock ListenerReady() waiters once the bind decision is made,
+	// whether a listener was started or none was configured.
+	o.signalListenerReady()
 
 	// Start resource manager (per-endpoint consumer table). The
 	// periodic-activity goroutine ages out inactive entries; the

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -271,10 +271,7 @@ type Overlay struct {
 
 	// listenerReady is closed once Run has finished its listener-bind
 	// phase — after startListener publishes o.listener, or immediately
-	// when no listener is configured. Callers that need to wait for the
-	// bind (integration tests wiring two overlays on an ephemeral port)
-	// block on ListenerReady() instead of polling ListenAddr() against a
-	// wall clock, which is racy under load.
+	// when no listener is configured.
 	listenerReady     chan struct{}
 	listenerReadyOnce sync.Once
 
@@ -688,16 +685,15 @@ func (o *Overlay) ListenAddr() string {
 	return l.Addr().String()
 }
 
-// ListenerReady returns a channel that is closed once Run has finished
-// binding the listener (or determined none is configured). Waiting on it
-// is the race-free way to know ListenAddr() will report the resolved
-// ephemeral port — callers block on the event instead of polling.
+// ListenerReady returns a channel closed once Run has finished binding
+// the listener (or determined none is configured), after which
+// ListenAddr reports the resolved ephemeral port.
 func (o *Overlay) ListenerReady() <-chan struct{} {
 	return o.listenerReady
 }
 
-// signalListenerReady closes listenerReady exactly once. Guarded against
-// overlays constructed directly (outside New), whose channel is nil.
+// signalListenerReady closes listenerReady, guarding overlays built
+// directly (outside New) whose channel is nil.
 func (o *Overlay) signalListenerReady() {
 	if o.listenerReady == nil {
 		return
@@ -880,8 +876,6 @@ func (o *Overlay) Run(ctx context.Context) error {
 			return fmt.Errorf("listener error: %w", err)
 		}
 	}
-	// Unblock ListenerReady() waiters once the bind decision is made,
-	// whether a listener was started or none was configured.
 	o.signalListenerReady()
 
 	// Start resource manager (per-endpoint consumer table). The

--- a/internal/testing/p2p/two_overlay_test.go
+++ b/internal/testing/p2p/two_overlay_test.go
@@ -219,6 +219,22 @@ func to32(b []byte) ([32]byte, bool) {
 	return out, true
 }
 
+const (
+	// overlayReadyTimeout bounds the wait for a freshly-started overlay to
+	// publish its listener. It is deliberately generous: the wait returns
+	// the instant the overlay signals readiness, so the ceiling only bites
+	// if the bind genuinely wedges — and under -race on a saturated CI
+	// runner a healthy bind can take well over a second.
+	overlayReadyTimeout = 30 * time.Second
+
+	// peerConnectTimeout bounds the wait for two overlays to complete the
+	// TLS+HTTP handshake and register each other as peers. Same rationale
+	// as overlayReadyTimeout: it returns immediately on success, so a large
+	// ceiling only guards against a real stall rather than slowing the
+	// happy path.
+	peerConnectTimeout = 30 * time.Second
+)
+
 // startOverlay spins up a single Overlay bound to localhost on an
 // ephemeral port. Returns the overlay and a cancel function.
 func startOverlay(t *testing.T) (*peermanagement.Overlay, context.CancelFunc) {
@@ -241,12 +257,15 @@ func startOverlay(t *testing.T) (*peermanagement.Overlay, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() { _ = o.Run(ctx) }()
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if o.ListenAddr() != "" {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
+	// Block on the overlay's readiness signal instead of racing a
+	// wall-clock poll. startListener does a real Listen syscall plus a
+	// TLS-certificate build before ListenAddr() reports non-empty; under
+	// -race on a loaded CI runner the background Run goroutine can be
+	// scheduling-starved past a tight deadline, which surfaced as a
+	// spurious "overlay listener never came up" suite failure.
+	select {
+	case <-o.ListenerReady():
+	case <-time.After(overlayReadyTimeout):
 	}
 	require.NotEmpty(t, o.ListenAddr(), "overlay listener never came up")
 	return o, cancel
@@ -285,7 +304,7 @@ func TestTwoOverlay_HandshakeAndConnect(t *testing.T) {
 
 	require.NoError(t, b.Connect(a.ListenAddr()),
 		"two overlays must complete the XRPL TLS+HTTP handshake against each other")
-	waitForPeers(t, a, b, 5*time.Second)
+	waitForPeers(t, a, b, peerConnectTimeout)
 
 	infosA := a.Peers()
 	infosB := b.Peers()
@@ -317,7 +336,7 @@ func TestTwoOverlay_PostHandshakeSendReceive(t *testing.T) {
 
 	require.NoError(t, b.Connect(a.ListenAddr()),
 		"two overlays must complete the XRPL TLS+HTTP handshake")
-	waitForPeers(t, a, b, 5*time.Second)
+	waitForPeers(t, a, b, peerConnectTimeout)
 
 	// Find the peer-id of B as seen by A (the inbound peer on A). We
 	// send from A -> B (A initiates the send, B's readLoop must
@@ -414,7 +433,7 @@ func TestTwoOverlay_ReplayDelta_RoundTrip(t *testing.T) {
 
 	require.NoError(t, b.Connect(a.ListenAddr()),
 		"two overlays must complete the XRPL TLS+HTTP handshake")
-	waitForPeers(t, a, b, 5*time.Second)
+	waitForPeers(t, a, b, peerConnectTimeout)
 
 	// B's view of A (outbound peer on B).
 	infosB := b.Peers()
@@ -481,7 +500,7 @@ func TestTwoOverlay_Squelch_RoundTrip(t *testing.T) {
 
 	require.NoError(t, b.Connect(a.ListenAddr()),
 		"two overlays must complete the XRPL TLS+HTTP handshake")
-	waitForPeers(t, a, b, 5*time.Second)
+	waitForPeers(t, a, b, peerConnectTimeout)
 
 	// Both overlays see exactly one peer.
 	infosA := a.Peers()
@@ -591,7 +610,7 @@ func TestTwoOverlay_ProofPath_RoundTrip(t *testing.T) {
 	a.LedgerSync().SetProvider(provider)
 
 	require.NoError(t, b.Connect(a.ListenAddr()))
-	waitForPeers(t, a, b, 5*time.Second)
+	waitForPeers(t, a, b, peerConnectTimeout)
 
 	infosB := b.Peers()
 	require.Len(t, infosB, 1)

--- a/internal/testing/p2p/two_overlay_test.go
+++ b/internal/testing/p2p/two_overlay_test.go
@@ -221,17 +221,14 @@ func to32(b []byte) ([32]byte, bool) {
 
 const (
 	// overlayReadyTimeout bounds the wait for a freshly-started overlay to
-	// publish its listener. It is deliberately generous: the wait returns
-	// the instant the overlay signals readiness, so the ceiling only bites
-	// if the bind genuinely wedges — and under -race on a saturated CI
-	// runner a healthy bind can take well over a second.
+	// publish its listener. The wait returns the instant readiness is
+	// signalled, so this generous ceiling only bites on a genuine wedge.
 	overlayReadyTimeout = 30 * time.Second
 
-	// peerConnectTimeout bounds the wait for two overlays to complete the
-	// TLS+HTTP handshake and register each other as peers. Same rationale
-	// as overlayReadyTimeout: it returns immediately on success, so a large
-	// ceiling only guards against a real stall rather than slowing the
-	// happy path.
+	// peerConnectTimeout bounds the wait for two overlays to finish the
+	// handshake and register each other. Same rationale as
+	// overlayReadyTimeout: it returns on success, so the ceiling only
+	// guards a real stall.
 	peerConnectTimeout = 30 * time.Second
 )
 
@@ -257,12 +254,9 @@ func startOverlay(t *testing.T) (*peermanagement.Overlay, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() { _ = o.Run(ctx) }()
 
-	// Block on the overlay's readiness signal instead of racing a
-	// wall-clock poll. startListener does a real Listen syscall plus a
-	// TLS-certificate build before ListenAddr() reports non-empty; under
-	// -race on a loaded CI runner the background Run goroutine can be
-	// scheduling-starved past a tight deadline, which surfaced as a
-	// spurious "overlay listener never came up" suite failure.
+	// Block on the readiness signal instead of a wall-clock poll: under
+	// -race on a loaded runner the Run goroutine can be starved past a
+	// tight deadline before ListenAddr() resolves.
 	select {
 	case <-o.ListenerReady():
 	case <-time.After(overlayReadyTimeout):


### PR DESCRIPTION
## Summary

- `TestTwoOverlay_*` flaked on CI (`Test (integration)` false-red) because the shared `startOverlay` helper polled a hard-coded **2s** wall-clock deadline for the listener bind. `startListener` does a real `Listen` syscall plus a TLS-cert build before `ListenAddr()` reports non-empty; under `-race` on a loaded runner the background `Run` goroutine can be scheduling-starved past 2s, tripping `two_overlay_test.go:251` — the failure rotates across siblings but always the same line.
- **Proper fix (issue's option 2):** expose `Overlay.ListenerReady()`, a `<-chan struct{}` closed once `Run` finishes its listener-bind phase (after `startListener` publishes `o.listener`, or immediately when no listener is configured). The test helper now blocks on that event instead of racing a wall clock. A generous 30s safety-net ceiling only bites if the bind genuinely wedges — the wait returns the instant readiness is signalled, so the happy path is unchanged.
- **Audit (issue asked to check `waitForPeers` and friends):** the sibling peer-connect budget moves from a tight `5s` to a shared `peerConnectTimeout` (30s), same load-dependent flake class, zero happy-path cost.
- Message-delivery latency assertions (PING/round-trip/squelch waits) are intentionally left untouched — they are post-connection behavioural bounds, not startup barriers.

## Test plan

- [x] `go test -race -count=5 -run '^TestTwoOverlay_' ./internal/testing/p2p/` — green
- [x] `go test -race ./internal/testing/p2p/ ./internal/peermanagement/` — green
- [x] `go build ./...` — clean
- [x] `golangci-lint run --config .golangci.yml ./internal/peermanagement/... ./internal/testing/p2p/...` — 0 issues

Fixes #1222