### PR TITLE
Fix offer tick-size rounding for TickSize-15 issuers (#1224)

### DIFF
--- a/internal/tx/offer/offer_quality.go
+++ b/internal/tx/offer/offer_quality.go
@@ -11,12 +11,9 @@ import (
 
 // Quality constants
 const (
-	// maxTickSize is the sentinel meaning "no tick-size rounding": a 16-digit
-	// mantissa is kept intact. It matches rippled's Quality::maxTickSize (16),
-	// NOT the maximum valid TickSize field value (15). Using 15 here would make
-	// applyTickSize/roundToTickSize skip rounding for TickSize-15 issuers, so a
-	// placed sell offer keeps its submitted amount instead of the tick-rounded
-	// value (see #1224).
+	// maxTickSize is the "no rounding" sentinel (rippled Quality::maxTickSize),
+	// not the maximum valid TickSize field value (15): using 15 skips rounding
+	// for TickSize-15 issuers (#1224).
 	maxTickSize uint8 = 16
 )
 

--- a/internal/tx/offer/offer_quality.go
+++ b/internal/tx/offer/offer_quality.go
@@ -11,7 +11,13 @@ import (
 
 // Quality constants
 const (
-	maxTickSize uint8 = 15
+	// maxTickSize is the sentinel meaning "no tick-size rounding": a 16-digit
+	// mantissa is kept intact. It matches rippled's Quality::maxTickSize (16),
+	// NOT the maximum valid TickSize field value (15). Using 15 here would make
+	// applyTickSize/roundToTickSize skip rounding for TickSize-15 issuers, so a
+	// placed sell offer keeps its submitted amount instead of the tick-rounded
+	// value (see #1224).
+	maxTickSize uint8 = 16
 )
 
 // offerNativeDrops finalizes a muldiv-round magnitude as an XRP-drops Amount,

--- a/internal/tx/offer/ticksize_1224_test.go
+++ b/internal/tx/offer/ticksize_1224_test.go
@@ -9,7 +9,7 @@ import (
 
 // TestTickSize1224 reproduces ledger 99478516 idx46: a tfSell OfferCreate
 // TakerGets 900000 drops XRP, TakerPays 5000000 HADA (issuer TickSize 15).
-// Mainnet places TakerPays = 5000000.000000004; goXRPL currently places 5000000.
+// Mainnet places TakerPays = 5000000.000000004; pre-fix goXRPL placed 5000000.
 func TestTickSize1224(t *testing.T) {
 	const hada = "4841444100000000000000000000000000000000"
 	const issuer = "rsR5JSisuXsbipP6sGdKdz5agjxn8BhHUC"

--- a/internal/tx/offer/ticksize_1224_test.go
+++ b/internal/tx/offer/ticksize_1224_test.go
@@ -1,0 +1,33 @@
+package offer
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+// TestTickSize1224 reproduces ledger 99478516 idx46: a tfSell OfferCreate
+// TakerGets 900000 drops XRP, TakerPays 5000000 HADA (issuer TickSize 15).
+// Mainnet places TakerPays = 5000000.000000004; goXRPL currently places 5000000.
+func TestTickSize1224(t *testing.T) {
+	const hada = "4841444100000000000000000000000000000000"
+	const issuer = "rsR5JSisuXsbipP6sGdKdz5agjxn8BhHUC"
+
+	takerGets := tx.NewXRPAmount(900000)                                // XRP drops
+	takerPays := tx.NewIssuedAmount(5000000000000000, -9, hada, issuer) // 5000000
+
+	quality := state.CalculateQuality(takerGets, takerPays)
+	t.Logf("quality  mantissa=%d exp=%d", quality&0x00ffffffffffffff, int(quality>>56)-100)
+
+	rounded := roundToTickSize(quality, 15)
+	t.Logf("rounded  mantissa=%d exp=%d", rounded&0x00ffffffffffffff, int(rounded>>56)-100)
+
+	res := multiplyByQuality(takerGets, rounded, hada, issuer)
+	t.Logf("result   mantissa=%d exp=%d", res.Mantissa(), res.Exponent())
+
+	if res.Mantissa() != 5000000000000004 || res.Exponent() != -9 {
+		t.Errorf("TakerPays got mantissa=%d exp=%d, want 5000000000000004 exp=-9 (5000000.000000004)",
+			res.Mantissa(), res.Exponent())
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the systematic OfferCreate tick-size rounding divergence in #1224.

`maxTickSize` in `internal/tx/offer/offer_quality.go` was `15`, but it is the **"no rounding" sentinel** and must be **16** — matching rippled's `Quality::maxTickSize` (`Quality.h`). The maximum *valid* `TickSize` field value is 15, so for a TickSize-15 issuer both `applyTickSize` and `roundToTickSize` hit their `tickSize >= maxTickSize` guard and **silently skipped rounding**. A sell offer placed on a TickSize-15 book therefore kept its submitted amount instead of the tick-rounded value.

## Root cause walkthrough

Ledger **99478516 idx46** — `tfSell` OfferCreate, TakerGets 900000 drops XRP, TakerPays 5000000 HADA (issuer `rsR5JSis…`, TickSize 15). The offer doesn't cross, it's just placed:

| | quality mantissa | rounded mantissa | placed TakerPays |
|---|---|---|---|
| before fix | 5555555555555556 | 5555555555555556 *(unrounded)* | 5000000 |
| after fix / mainnet | 5555555555555556 | 555555555555556**0** | 5000000.000000004 |

rippled's `Quality::round(15)` bumps the rate mantissa up to a multiple of 10; `multiply(TakerGets, roundedRate)` then yields `5000000.000000004`. With `maxTickSize = 15` goXRPL never entered that path for TickSize-15 issuers.

## Verification

- **Byte-exact replay**: `replay-range --from 99478515 --to 99478516` with the fix → **0 divergences** (ledger/account/transaction hashes now match mainnet). Previously failed on hash mismatch.
- **Unit test** (`ticksize_1224_test.go`): placed TakerPays now `5000000.000000004`, mantissa rounds `…556 → …560`.
- `internal/tx/offer/...` and the `internal/testing/offer/...` conformance suite (incl. tick-size tests) pass — no regressions.

This is systematic (any offer placed on a TickSize-15 book), so it also clears the recurrence noted at ledger 99478797.

Closes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)
