### PR TITLE
fix: VL length encoder off-by-one at 12480 (< vs <=)

### DIFF
--- a/codec/binarycodec/serdes/binary_serializer.go
+++ b/codec/binarycodec/serdes/binary_serializer.go
@@ -63,7 +63,7 @@ func encodeVariableLength(length int) ([]byte, error) {
 	if length <= 192 {
 		return []byte{byte(length)}, nil
 	}
-	if length < 12480 {
+	if length <= 12480 {
 		length -= 193
 		b1 := byte((length >> 8) + 193)
 		b2 := byte((length & 0xFF))

--- a/codec/binarycodec/serdes/rippled_binary_format_test.go
+++ b/codec/binarycodec/serdes/rippled_binary_format_test.go
@@ -70,21 +70,20 @@ func TestVariableLengthEncoding(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "length 12479 (max two byte)",
+			name:        "length 12479",
 			length:      12479,
 			expectedHex: "f0fe",
 			expectError: false,
 		},
-		// Three byte encoding (12480-918744)
-		// Note: implementation uses 12480 as start of 3-byte encoding
 		{
-			name:        "length 12480 (min three byte)",
+			name:        "length 12480 (max two byte)",
 			length:      12480,
-			expectedHex: "f0ffff",
+			expectedHex: "f0ff",
 			expectError: false,
 		},
+		// Three byte encoding (12481-918744)
 		{
-			name:        "length 12481",
+			name:        "length 12481 (min three byte)",
 			length:      12481,
 			expectedHex: "f10000",
 			expectError: false,
@@ -237,6 +236,8 @@ func TestVariableLengthRoundtrip(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, length, decoded, "VL roundtrip failed for length %d", length)
+			assert.Equal(t, 0, parser.Remaining(),
+				"decoder must consume the entire prefix for length %d; leftover bytes mean the encoder emitted a prefix the decoder reads shorter", length)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- The variable-length prefix encoder in `codec/binarycodec/serdes/binary_serializer.go` used `<` instead of `<=` at the 12480 boundary, so a VL field of **exactly 12480 bytes** fell through to the three-byte branch and emitted a malformed `[F0 FF FF]`.
- `0xF0` (240) is a two-byte lead byte, so both rippled and go-xrpl's *own* decoder read `[F0 FF]` back as length 12480 and treat the trailing `0xFF` as value data — a hash/consensus divergence from rippled and an encoder↔decoder round-trip break. Changing `<` to `<=` makes 12480 emit the canonical two-byte `[F0 FF]`, converging with rippled (`Serializer::addEncoded`) and with the codebase's two already-correct sibling encoders (`internal/tx.EncodeVL`, `consensus/adaptor` router_dedup).
- Corrects the golden test that had enshrined the wrong output (`12480 -> "f0ffff"`, mislabeled "min three byte") and its stale boundary comments.
- Makes `TestVariableLengthRoundtrip` non-vacuous: it now asserts the decoder consumes the *entire* prefix, so the swallowed-trailing-byte corruption is actually caught (the old test only read the length value and silently ignored leftover bytes).

Divergence was confined to the single length 12480 — all other lengths (incl. 12481 and the `<= 918744` upper bound) already matched rippled.

## Test plan
- [x] `go test ./codec/binarycodec/...` — all pass
- [x] Reverted the encoder to the buggy `<` and confirmed **both** the golden test (`f0ffff` vs `f0ff`) and the strengthened round-trip test (leftover prefix byte at 12480) fail — proving the fix is real and the test is non-vacuous
- [x] `go vet` / `gofmt` clean on changed files

Fixes #1168