### PR TITLE
fix: guard online_delete prune against resurrected live nodes (#1166)

### DIFF
--- a/storage/nodestore/kvstore_database.go
+++ b/storage/nodestore/kvstore_database.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -38,6 +39,11 @@ func DefaultDatabaseConfig() *DatabaseConfig {
 
 // KVDatabaseImpl wraps a kvstore.KeyValueStore to implement the Database interface.
 type KVDatabaseImpl struct {
+	// pruneMu serialises online-delete pruning against writers. Writers take
+	// the read side; DeleteBefore's flush takes the write side so its
+	// re-read-then-delete of each key is atomic w.r.t. a concurrent Store —
+	// otherwise a key re-created live during a prune could be erased.
+	pruneMu       sync.RWMutex
 	store         kvstore.KeyValueStore
 	cache         *Cache
 	negativeCache *NegativeCache
@@ -101,11 +107,13 @@ func (d *KVDatabaseImpl) Store(ctx context.Context, node *Node) error {
 	}
 
 	encoded := encodeNodeData(node)
-	if err := d.store.Put(node.Hash[:], encoded); err != nil {
-		releaseEncodeBuf(encoded)
+	d.pruneMu.RLock()
+	err := d.store.Put(node.Hash[:], encoded)
+	d.pruneMu.RUnlock()
+	releaseEncodeBuf(encoded)
+	if err != nil {
 		return fmt.Errorf("store failed: %w", err)
 	}
-	releaseEncodeBuf(encoded)
 
 	atomic.AddUint64(&d.stats.writes, 1)
 	atomic.AddUint64(&d.stats.writeBytes, uint64(len(node.Data)))
@@ -195,7 +203,10 @@ func (d *KVDatabaseImpl) StoreBatch(ctx context.Context, nodes []*Node) error {
 			return fmt.Errorf("store batch failed: %w", err)
 		}
 	}
-	if err := batch.Write(); err != nil {
+	d.pruneMu.RLock()
+	err := batch.Write()
+	d.pruneMu.RUnlock()
+	if err != nil {
 		return fmt.Errorf("store batch commit failed: %w", err)
 	}
 

--- a/storage/nodestore/prune.go
+++ b/storage/nodestore/prune.go
@@ -58,16 +58,32 @@ func (d *KVDatabaseImpl) DeleteBefore(ctx context.Context, boundary uint32, batc
 		if len(pending) == 0 {
 			return nil
 		}
+
+		// Keys were queued from the iterator's frozen snapshot, but a snapshot
+		// copy below the boundary may have been re-created live at seq >=
+		// boundary during the scan window. Re-read each key's current value
+		// under the write lock and delete only keys still below the boundary,
+		// so a resurrected node is never erased.
+		d.pruneMu.Lock()
 		batch := d.store.NewBatch()
+		deletedKeys := make([][]byte, 0, len(pending))
 		for _, k := range pending {
+			if cur, err := d.store.Get(k); err == nil &&
+				len(cur) >= nodeEncodingHeaderSize &&
+				binary.BigEndian.Uint32(cur[1:5]) >= boundary {
+				continue
+			}
 			if err := batch.Delete(k); err != nil {
+				d.pruneMu.Unlock()
 				return fmt.Errorf("delete-before batch: %w", err)
 			}
+			deletedKeys = append(deletedKeys, k)
 		}
 		if err := batch.Write(); err != nil {
+			d.pruneMu.Unlock()
 			return fmt.Errorf("delete-before commit: %w", err)
 		}
-		for _, k := range pending {
+		for _, k := range deletedKeys {
 			var h Hash256
 			copy(h[:], k)
 			if d.cache != nil {
@@ -77,7 +93,9 @@ func (d *KVDatabaseImpl) DeleteBefore(ctx context.Context, boundary uint32, batc
 				d.negativeCache.MarkMissing(h)
 			}
 		}
-		deleted += uint64(len(pending))
+		d.pruneMu.Unlock()
+
+		deleted += uint64(len(deletedKeys))
 		pending = pending[:0]
 		return nil
 	}

--- a/storage/nodestore/prune_test.go
+++ b/storage/nodestore/prune_test.go
@@ -2,11 +2,31 @@ package nodestore
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/storage/kvstore"
 	"github.com/LeJamon/go-xrpl/storage/kvstore/memorydb"
 )
+
+// resurrectOnIterate wraps a store and fires a one-shot callback immediately
+// after the prune iterator has snapshotted the keyspace, before the flush runs.
+// It reproduces the online-delete race: a key present below the boundary in the
+// frozen snapshot is re-created live (at seq >= boundary) during the scan window.
+type resurrectOnIterate struct {
+	*memorydb.MemDatabase
+	once sync.Once
+	fn   func()
+}
+
+func (r *resurrectOnIterate) NewIterator(prefix, start []byte) kvstore.Iterator {
+	it := r.MemDatabase.NewIterator(prefix, start)
+	if r.fn != nil {
+		r.once.Do(r.fn)
+	}
+	return it
+}
 
 // storeNodeAt persists a node carrying an explicit ledger sequence so the
 // prune scanner can classify it. The key is derived from the data plus seq so
@@ -142,6 +162,45 @@ func TestDeleteBefore_EvictsPositiveCache(t *testing.T) {
 	}
 	if present(t, db, h) {
 		t.Fatal("pruned node must not be fetchable after cache eviction")
+	}
+}
+
+func TestDeleteBefore_ResurrectedDuringScanSurvives(t *testing.T) {
+	// A key whose snapshot copy is below the boundary is re-created live at
+	// seq >= boundary after the prune iterator snapshots but before the flush
+	// (e.g. AccountDelete then re-funding the same deterministic keylet). The
+	// flush must observe the live value and leave the resurrected node alone.
+	store := &resurrectOnIterate{MemDatabase: memorydb.New()}
+	db := NewKVDatabase(store, "mem", 1000, time.Hour)
+	defer db.Close()
+
+	data := Blob("resurrected-account-state")
+	h := ComputeHash256(data)
+	writeAt := func(seq uint32) {
+		node := &Node{Type: NodeAccount, Hash: h, Data: data, LedgerSeq: seq}
+		if err := db.Store(context.Background(), node); err != nil {
+			t.Fatalf("Store(seq=%d): %v", seq, err)
+		}
+	}
+
+	// Snapshot copy: a superseded (below-boundary) sequence.
+	writeAt(3)
+	// Live resurrection at a retained sequence, injected after the snapshot.
+	store.fn = func() { writeAt(50) }
+
+	if _, err := db.DeleteBefore(context.Background(), 40, 0); err != nil {
+		t.Fatalf("DeleteBefore: %v", err)
+	}
+	if !present(t, db, h) {
+		t.Fatal("node re-created live during the scan window must not be pruned")
+	}
+	// The live value must also be intact, not a stale below-boundary copy.
+	n, err := db.Fetch(context.Background(), h)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if n == nil || n.LedgerSeq != 50 {
+		t.Fatalf("resurrected node LedgerSeq = %v, want 50", n)
 	}
 }
 


### PR DESCRIPTION
## Summary

`online_delete` pruning (`storage/nodestore/prune.go`) queued keys from a **frozen iterator snapshot** and then `batch.Delete`-ed them **unconditionally** against the **live** DB, with **no lock** against concurrent `Store`/`StoreBatch`. A ledger-entry index that is below the boundary in the snapshot but **re-created live** during the scan window — e.g. `AccountDelete` followed by re-funding the same deterministic keylet — had its now-live node erased, silently corrupting state (missing node / potential fork).

This implements the issue's suggested fix (option 1):

- Add a `pruneMu sync.RWMutex` to `KVDatabaseImpl`.
- `Store` / `StoreBatch` take the **read** side around their store mutation, preserving existing write-write concurrency.
- The prune `flush` takes the **write** side, then **re-reads each key's current value** and deletes only keys whose live `LedgerSeq` is still `< boundary`. The re-read and delete are atomic w.r.t. writers, so a resurrected node is never removed. Cache eviction is restricted to keys actually deleted (a survivor is never `MarkMissing`-ed).

Rotation stays off the consensus / ledger-accept critical path — writers only block for the duration of a single batch flush, and only during the (infrequent) rotation.

## Test plan

- [x] New `TestDeleteBefore_ResurrectedDuringScanSurvives` — a `resurrectOnIterate` store re-creates the key at `seq >= boundary` immediately after the iterator snapshots but before the flush. Proven non-vacuous: **fails** on the pre-fix flush (node erased), **passes** on the fix.
- [x] `go test -race ./storage/... ./internal/ledger/shamapstore/...` — all green
- [x] `go build ./...`, `go vet ./storage/nodestore/`, `gofmt`, `golangci-lint run --config .golangci.yml ./storage/nodestore/...` (0 issues)

Fixes #1166