### PR TITLE
Bound peer-discovery ingest against TMEndpoints flooding

### DIFF
--- a/internal/peermanagement/discovery.go
+++ b/internal/peermanagement/discovery.go
@@ -19,6 +19,13 @@ const (
 	CacheEntryTTL          = 7 * 24 * time.Hour
 	MaxHops                = 3
 	DefaultReservationFile = "peer_reservations.json"
+
+	// MaxDiscoveredPeers caps the peer-discovery set. AddPeer evicts the
+	// least-recently-seen non-connected, non-fixed entry before exceeding
+	// it, so gossiped endpoint announcements cannot grow d.peers without
+	// bound (issue #1170). Sized well above any real network's reachable
+	// peer count; the live connection set and fixed peers are never evicted.
+	MaxDiscoveredPeers = 8192
 )
 
 // CachedEndpoint represents a cached peer endpoint.
@@ -416,12 +423,40 @@ func (d *Discovery) AddPeer(address string, hops uint32, source PeerID) {
 		return
 	}
 
+	if len(d.peers) >= MaxDiscoveredPeers && !d.evictOldestLocked() {
+		// At the ceiling with every entry a live or fixed peer we must
+		// keep — refuse the new gossiped address rather than grow unbounded.
+		return
+	}
+
 	d.peers[address] = &DiscoveredPeer{
 		Address:  address,
 		Hops:     hops,
 		LastSeen: time.Now(),
 		Source:   source,
 	}
+}
+
+// evictOldestLocked removes the least-recently-seen discardable entry to
+// make room under MaxDiscoveredPeers, returning false when every entry is
+// a connected or fixed peer that must be retained. Caller holds d.mu.
+func (d *Discovery) evictOldestLocked() bool {
+	var victim string
+	var oldest time.Time
+	for addr, p := range d.peers {
+		if p.Connected || d.fixedPeers[addr] {
+			continue
+		}
+		if victim == "" || p.LastSeen.Before(oldest) {
+			victim = addr
+			oldest = p.LastSeen
+		}
+	}
+	if victim == "" {
+		return false
+	}
+	delete(d.peers, victim)
+	return true
 }
 
 // AddRedirectCandidate records an address learned from a peer's 503

--- a/internal/peermanagement/discovery.go
+++ b/internal/peermanagement/discovery.go
@@ -1,6 +1,7 @@
 package peermanagement
 
 import (
+	"container/list"
 	"context"
 	"encoding/json"
 	"math/rand/v2"
@@ -327,6 +328,9 @@ type DiscoveredPeer struct {
 	Connected bool
 	PeerID    PeerID
 	Source    PeerID
+
+	// Position in Discovery.lru; guarded by Discovery.mu.
+	lruEntry *list.Element
 }
 
 // Discovery manages peer discovery and connection maintenance.
@@ -335,7 +339,11 @@ type Discovery struct {
 
 	cfg Config
 
-	peers       map[string]*DiscoveredPeer
+	peers map[string]*DiscoveredPeer
+	// lru orders d.peers by last-seen recency (front = most recent) so
+	// eviction at MaxDiscoveredPeers pops from the stale end instead of
+	// scanning the whole map. Every peers insert/delete updates it.
+	lru         list.List
 	connected   map[PeerID]*DiscoveredPeer
 	fixedPeers  map[string]bool
 	bootCache   *BootCache
@@ -420,6 +428,7 @@ func (d *Discovery) AddPeer(address string, hops uint32, source PeerID) {
 			existing.Source = source
 		}
 		existing.LastSeen = time.Now()
+		d.lru.MoveToFront(existing.lruEntry)
 		return
 	}
 
@@ -429,34 +438,35 @@ func (d *Discovery) AddPeer(address string, hops uint32, source PeerID) {
 		return
 	}
 
-	d.peers[address] = &DiscoveredPeer{
+	d.insertPeerLocked(&DiscoveredPeer{
 		Address:  address,
 		Hops:     hops,
 		LastSeen: time.Now(),
 		Source:   source,
-	}
+	})
+}
+
+// insertPeerLocked adds p to the peer map and the recency list as the
+// most recently seen entry. Caller holds d.mu.
+func (d *Discovery) insertPeerLocked(p *DiscoveredPeer) {
+	p.lruEntry = d.lru.PushFront(p)
+	d.peers[p.Address] = p
 }
 
 // evictOldestLocked removes the least-recently-seen discardable entry to
 // make room under MaxDiscoveredPeers, returning false when every entry is
 // a connected or fixed peer that must be retained. Caller holds d.mu.
 func (d *Discovery) evictOldestLocked() bool {
-	var victim string
-	var oldest time.Time
-	for addr, p := range d.peers {
-		if p.Connected || d.fixedPeers[addr] {
+	for e := d.lru.Back(); e != nil; e = e.Prev() {
+		p := e.Value.(*DiscoveredPeer)
+		if p.Connected || d.fixedPeers[p.Address] {
 			continue
 		}
-		if victim == "" || p.LastSeen.Before(oldest) {
-			victim = addr
-			oldest = p.LastSeen
-		}
+		d.lru.Remove(e)
+		delete(d.peers, p.Address)
+		return true
 	}
-	if victim == "" {
-		return false
-	}
-	delete(d.peers, victim)
-	return true
+	return false
 }
 
 // AddRedirectCandidate records an address learned from a peer's 503
@@ -482,12 +492,12 @@ func (d *Discovery) AddRedirectCandidate(address string, source PeerID) {
 	}
 
 	if _, exists := d.peers[address]; !exists {
-		d.peers[address] = &DiscoveredPeer{
+		d.insertPeerLocked(&DiscoveredPeer{
 			Address:  address,
 			Hops:     1,
 			LastSeen: time.Now(),
 			Source:   source,
-		}
+		})
 	}
 }
 
@@ -499,7 +509,7 @@ func (d *Discovery) MarkConnected(address string, peerID PeerID) {
 	peer, exists := d.peers[address]
 	if !exists {
 		peer = &DiscoveredPeer{Address: address, LastSeen: time.Now()}
-		d.peers[address] = peer
+		d.insertPeerLocked(peer)
 	}
 
 	peer.Connected = true
@@ -689,6 +699,7 @@ func (d *Discovery) prune() {
 	cutoff := time.Now().Add(-1 * time.Hour)
 	for addr, peer := range d.peers {
 		if !peer.Connected && peer.LastSeen.Before(cutoff) {
+			d.lru.Remove(peer.lruEntry)
 			delete(d.peers, addr)
 		}
 	}

--- a/internal/peermanagement/discovery_test.go
+++ b/internal/peermanagement/discovery_test.go
@@ -1,6 +1,7 @@
 package peermanagement
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -698,5 +699,65 @@ func TestDiscoverySyncConnectedHosts_SkipsMalformedAddress(t *testing.T) {
 	defer d.mu.RUnlock()
 	if d.peers["badly-formed-no-port"].Connected {
 		t.Error("malformed address must not be marked connected")
+	}
+}
+
+// TestAddPeerCapEvictsOldest pins issue #1170: once d.peers reaches
+// MaxDiscoveredPeers, a new gossiped address evicts the least-recently-seen
+// non-connected, non-fixed entry instead of growing the map without bound.
+// The live connection and the fixed peer must survive the eviction.
+func TestAddPeerCapEvictsOldest(t *testing.T) {
+	cfg := &Config{
+		MaxPeers:    50,
+		MaxInbound:  25,
+		MaxOutbound: 25,
+		FixedPeers:  []string{"fixed:51235"},
+	}
+	d := NewDiscovery(cfg, make(chan Event, 1))
+
+	// A connected peer and a stale fixed peer that must never be evicted.
+	d.MarkConnected("connected:51235", PeerID(1))
+	d.AddPeer("fixed:51235", 1, PeerID(2))
+
+	// Fill the map exactly to the ceiling with non-connected gossip entries.
+	for i := 0; len(d.peers) < MaxDiscoveredPeers; i++ {
+		d.AddPeer(fmt.Sprintf("gossip-%d:51235", i), 1, PeerID(3))
+	}
+
+	d.mu.RLock()
+	filled := len(d.peers)
+	d.mu.RUnlock()
+	if filled != MaxDiscoveredPeers {
+		t.Fatalf("setup: len(d.peers) = %d, want %d", filled, MaxDiscoveredPeers)
+	}
+
+	// Make one gossip entry the clear least-recently-seen victim, and mark
+	// the connected/fixed entries even staler to prove they are exempt.
+	stale := time.Now().Add(-24 * time.Hour)
+	d.mu.Lock()
+	d.peers["gossip-0:51235"].LastSeen = stale
+	d.peers["connected:51235"].LastSeen = stale.Add(-time.Hour)
+	d.peers["fixed:51235"].LastSeen = stale.Add(-time.Hour)
+	d.mu.Unlock()
+
+	// One more distinct address forces exactly one eviction.
+	d.AddPeer("fresh:51235", 1, PeerID(4))
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if len(d.peers) != MaxDiscoveredPeers {
+		t.Errorf("len(d.peers) = %d, want %d after over-cap insert", len(d.peers), MaxDiscoveredPeers)
+	}
+	if _, ok := d.peers["gossip-0:51235"]; ok {
+		t.Error("least-recently-seen gossip entry should have been evicted")
+	}
+	if _, ok := d.peers["fresh:51235"]; !ok {
+		t.Error("new address should have been inserted after eviction")
+	}
+	if _, ok := d.peers["connected:51235"]; !ok {
+		t.Error("connected peer must never be evicted")
+	}
+	if _, ok := d.peers["fixed:51235"]; !ok {
+		t.Error("fixed peer must never be evicted")
 	}
 }

--- a/internal/peermanagement/discovery_test.go
+++ b/internal/peermanagement/discovery_test.go
@@ -705,7 +705,9 @@ func TestDiscoverySyncConnectedHosts_SkipsMalformedAddress(t *testing.T) {
 // TestAddPeerCapEvictsOldest pins issue #1170: once d.peers reaches
 // MaxDiscoveredPeers, a new gossiped address evicts the least-recently-seen
 // non-connected, non-fixed entry instead of growing the map without bound.
-// The live connection and the fixed peer must survive the eviction.
+// The live connection and the fixed peer sit at the stale end of the
+// recency order and must survive the eviction; a re-announced gossip entry
+// is refreshed to the recent end and must survive too.
 func TestAddPeerCapEvictsOldest(t *testing.T) {
 	cfg := &Config{
 		MaxPeers:    50,
@@ -715,7 +717,8 @@ func TestAddPeerCapEvictsOldest(t *testing.T) {
 	}
 	d := NewDiscovery(cfg, make(chan Event, 1))
 
-	// A connected peer and a stale fixed peer that must never be evicted.
+	// Inserted first, so both sit at the least-recently-seen end where a
+	// naive eviction would pick them.
 	d.MarkConnected("connected:51235", PeerID(1))
 	d.AddPeer("fixed:51235", 1, PeerID(2))
 
@@ -731,14 +734,9 @@ func TestAddPeerCapEvictsOldest(t *testing.T) {
 		t.Fatalf("setup: len(d.peers) = %d, want %d", filled, MaxDiscoveredPeers)
 	}
 
-	// Make one gossip entry the clear least-recently-seen victim, and mark
-	// the connected/fixed entries even staler to prove they are exempt.
-	stale := time.Now().Add(-24 * time.Hour)
-	d.mu.Lock()
-	d.peers["gossip-0:51235"].LastSeen = stale
-	d.peers["connected:51235"].LastSeen = stale.Add(-time.Hour)
-	d.peers["fixed:51235"].LastSeen = stale.Add(-time.Hour)
-	d.mu.Unlock()
+	// Re-announcing gossip-0 refreshes its recency, leaving gossip-1 as
+	// the least-recently-seen discardable entry.
+	d.AddPeer("gossip-0:51235", 1, PeerID(3))
 
 	// One more distinct address forces exactly one eviction.
 	d.AddPeer("fresh:51235", 1, PeerID(4))
@@ -748,8 +746,11 @@ func TestAddPeerCapEvictsOldest(t *testing.T) {
 	if len(d.peers) != MaxDiscoveredPeers {
 		t.Errorf("len(d.peers) = %d, want %d after over-cap insert", len(d.peers), MaxDiscoveredPeers)
 	}
-	if _, ok := d.peers["gossip-0:51235"]; ok {
+	if _, ok := d.peers["gossip-1:51235"]; ok {
 		t.Error("least-recently-seen gossip entry should have been evicted")
+	}
+	if _, ok := d.peers["gossip-0:51235"]; !ok {
+		t.Error("re-announced gossip entry should have been refreshed, not evicted")
 	}
 	if _, ok := d.peers["fresh:51235"]; !ok {
 		t.Error("new address should have been inserted after eviction")

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -6,6 +6,7 @@ package peermanagement
 
 import (
 	"log/slog"
+	"math/rand/v2"
 	"net"
 	"strconv"
 	"time"
@@ -381,6 +382,14 @@ func (o *Overlay) handleHaveTransactionsMessage(evt Event) {
 // rejected wholesale and the peer charged for useless data.
 const endpointsIngestMaxEntries = 1024
 
+// endpointsIngestSampleMax bounds how many addresses a single accepted
+// TMEndpoints frame may contribute to Discovery. Mirrors rippled's
+// PeerFinder numberOfEndpointsMax (Tuning.h:116, Logic.h:792-796): a
+// larger accepted set is shuffled and truncated to this many before
+// ingest, so one frame cannot enqueue an unbounded address batch even
+// while staying under the 1024 wholesale-reject bound.
+const endpointsIngestSampleMax = 64
+
 // handleEndpointsMessage processes mtENDPOINTS from a peer and feeds the
 // advertised addresses into Discovery, the gossip half of overlay peer
 // discovery. Mirrors rippled PeerImp::onMessage(TMEndpoints) at
@@ -397,6 +406,13 @@ const endpointsIngestMaxEntries = 1024
 // self-reported host is untrustworthy, so we overwrite it with the
 // socket's observed remote IP (keeping the advertised port), matching
 // rippled's remote_address_.at_port(result->port()).
+//
+// The surviving set is then bounded like rippled's PeerFinder before it
+// reaches Discovery: sampled down to numberOfEndpointsMax (64), gated by
+// the per-peer secondsPerMessage rate-limit (one accepted frame per
+// window), and clipped to our discovery horizon (hops<=MaxHops). Without
+// these an announced address stream would grow d.peers without bound
+// (issue #1170).
 func (o *Overlay) handleEndpointsMessage(evt Event) {
 	peer, exists := o.getPeer(evt.PeerID)
 	if !exists {
@@ -429,6 +445,11 @@ func (o *Overlay) handleEndpointsMessage(evt Event) {
 	}
 
 	remoteIP := peer.RemoteIP()
+	type ingestEndpoint struct {
+		address string
+		hops    uint32
+	}
+	accepted := make([]ingestEndpoint, 0, len(eps.EndpointsV2))
 	for _, tm := range eps.EndpointsV2 {
 		parsed, parseErr := ParseEndpoint(tm.Endpoint)
 		if parseErr != nil || net.ParseIP(parsed.Host) == nil {
@@ -450,7 +471,40 @@ func (o *Overlay) handleEndpointsMessage(evt Event) {
 			address = Endpoint{Host: remoteIP, Port: parsed.Port}.String()
 		}
 
-		o.discovery.AddPeer(address, tm.Hops, evt.PeerID)
+		accepted = append(accepted, ingestEndpoint{address: address, hops: tm.Hops})
+	}
+
+	// rippled hands the parsed set to PeerFinder only when at least one
+	// entry survived (PeerImp.cpp:1249); an all-malformed frame never
+	// touches the rate-limit window.
+	if len(accepted) == 0 {
+		return
+	}
+
+	// Sample down to numberOfEndpointsMax before ingest so an oversized
+	// (but sub-1024) frame cannot enqueue its whole batch.
+	if len(accepted) > endpointsIngestSampleMax {
+		rand.Shuffle(len(accepted), func(i, j int) {
+			accepted[i], accepted[j] = accepted[j], accepted[i]
+		})
+		accepted = accepted[:endpointsIngestSampleMax]
+	}
+
+	// Per-peer inbound rate-limit: one accepted frame per window. A frame
+	// arriving inside the window is dropped silently (no charge), matching
+	// rippled's whenAcceptEndpoints gate.
+	if !peer.acceptEndpoints() {
+		return
+	}
+
+	for _, e := range accepted {
+		// Drop endpoints beyond our discovery horizon rather than storing
+		// addresses SelectPeersToConnect would never dial; mirrors
+		// rippled's hops>maxHops preprocess drop.
+		if e.hops > MaxHops {
+			continue
+		}
+		o.discovery.AddPeer(e.address, e.hops, evt.PeerID)
 	}
 }
 

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -1,6 +1,7 @@
 package peermanagement
 
 import (
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -781,4 +782,91 @@ func TestHandleEndpoints_RejectsNonIPHost(t *testing.T) {
 	defer o.discovery.mu.RUnlock()
 	require.Len(t, o.discovery.peers, 1)
 	assert.Contains(t, o.discovery.peers, "10.0.0.9:51235")
+}
+
+// TestHandleEndpoints_RateLimitsPerPeer pins issue #1170: after a peer's
+// TMEndpoints frame is accepted, a second frame arriving inside the
+// secondsPerMessage window is dropped silently (no charge, no ingest),
+// mirroring rippled's whenAcceptEndpoints gate. Once the window elapses
+// the peer is served again.
+func TestHandleEndpoints_RateLimitsPerPeer(t *testing.T) {
+	o, peer := newEndpointsTestOverlay(t, PeerID(18))
+
+	send := func(addr string) {
+		o.onMessageReceived(Event{
+			PeerID:      peer.ID(),
+			MessageType: uint16(message.TypeEndpoints),
+			Payload:     encodeEndpoints(t, 2, []message.Endpointv2{{Endpoint: addr, Hops: 1}}),
+		})
+	}
+
+	send("10.0.0.1:51235")
+	send("10.0.0.2:51235") // inside the window → silently dropped
+
+	o.discovery.mu.RLock()
+	require.Len(t, o.discovery.peers, 1, "second frame inside the window must not ingest")
+	assert.Contains(t, o.discovery.peers, "10.0.0.1:51235")
+	o.discovery.mu.RUnlock()
+	assert.Zero(t, peer.BadDataCount(), "rate-limited frame must not be charged")
+
+	// Simulate the window elapsing, then a fresh frame is accepted again.
+	peer.acceptEndpointsMu.Lock()
+	peer.whenAcceptEndpoints = time.Now().Add(-time.Second)
+	peer.acceptEndpointsMu.Unlock()
+
+	send("10.0.0.2:51235")
+	o.discovery.mu.RLock()
+	defer o.discovery.mu.RUnlock()
+	require.Len(t, o.discovery.peers, 2, "frame after the window must ingest")
+	assert.Contains(t, o.discovery.peers, "10.0.0.2:51235")
+}
+
+// TestHandleEndpoints_SamplesOversizedFrame pins issue #1170: a frame
+// carrying more than numberOfEndpointsMax valid entries (but under the
+// 1024 wholesale-reject bound) is sampled down before ingest, so a single
+// accepted frame contributes at most endpointsIngestSampleMax addresses.
+func TestHandleEndpoints_SamplesOversizedFrame(t *testing.T) {
+	o, peer := newEndpointsTestOverlay(t, PeerID(19))
+
+	const n = endpointsIngestSampleMax * 3
+	eps := make([]message.Endpointv2, n)
+	for i := range eps {
+		eps[i] = message.Endpointv2{Endpoint: fmt.Sprintf("10.%d.%d.1:51235", i/256, i%256), Hops: 1}
+	}
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeEndpoints),
+		Payload:     encodeEndpoints(t, 2, eps),
+	})
+
+	o.discovery.mu.RLock()
+	defer o.discovery.mu.RUnlock()
+	assert.Len(t, o.discovery.peers, endpointsIngestSampleMax,
+		"accepted frame must be sampled down to numberOfEndpointsMax")
+	assert.Zero(t, peer.BadDataCount(), "well-formed oversized-but-sub-1024 frame is not charged")
+}
+
+// TestHandleEndpoints_DropsBeyondHorizon pins issue #1170: an entry whose
+// hop count exceeds our discovery horizon (MaxHops) is dropped at ingest
+// without a charge, while a sibling within the horizon is still ingested.
+// Mirrors rippled's hops>maxHops preprocess drop.
+func TestHandleEndpoints_DropsBeyondHorizon(t *testing.T) {
+	o, peer := newEndpointsTestOverlay(t, PeerID(20))
+
+	payload := encodeEndpoints(t, 2, []message.Endpointv2{
+		{Endpoint: "10.0.0.1:51235", Hops: MaxHops},
+		{Endpoint: "10.0.0.2:51235", Hops: MaxHops + 1},
+	})
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeEndpoints),
+		Payload:     payload,
+	})
+
+	o.discovery.mu.RLock()
+	defer o.discovery.mu.RUnlock()
+	require.Len(t, o.discovery.peers, 1)
+	assert.Contains(t, o.discovery.peers, "10.0.0.1:51235", "hops within horizon must ingest")
+	assert.NotContains(t, o.discovery.peers, "10.0.0.2:51235", "hops beyond horizon must be dropped")
+	assert.Zero(t, peer.BadDataCount(), "over-horizon hop count is dropped, not charged")
 }

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -129,6 +129,15 @@ type Peer struct {
 
 	tracking atomic.Int32
 
+	// whenAcceptEndpoints is the earliest instant this peer may have
+	// another inbound TMEndpoints frame accepted. Enforces the per-peer
+	// endpoint rate-limit (rippled PeerFinder secondsPerMessage): a frame
+	// arriving inside the window is dropped silently so a single peer
+	// cannot stream endpoint announcements unbounded. Guarded by
+	// acceptEndpointsMu.
+	acceptEndpointsMu   sync.Mutex
+	whenAcceptEndpoints time.Time
+
 	// Consecutive ErrSendBufferFull count; close at sendqIntervals.
 	// PeerImp.cpp:705-708 "Large send queue".
 	largeSendQ atomic.Uint32
@@ -408,6 +417,23 @@ func (p *Peer) Tracking() PeerTracking {
 
 func (p *Peer) setTracking(t PeerTracking) {
 	p.tracking.Store(int32(t))
+}
+
+// acceptEndpoints reports whether an inbound TMEndpoints frame from this
+// peer may be processed now, arming the next window when it may. Mirrors
+// rippled's per-slot whenAcceptEndpoints gate (PeerFinder secondsPerMessage):
+// a frame arriving inside the window is rejected so one peer cannot stream
+// endpoint announcements unbounded. Returns false as a silent drop (no
+// charge), matching rippled.
+func (p *Peer) acceptEndpoints() bool {
+	now := time.Now()
+	p.acceptEndpointsMu.Lock()
+	defer p.acceptEndpointsMu.Unlock()
+	if now.Before(p.whenAcceptEndpoints) {
+		return false
+	}
+	p.whenAcceptEndpoints = now.Add(endpointsBroadcastInterval)
+	return true
 }
 
 // CheckTracking mirrors rippled PeerImp::checkTracking (PeerImp.cpp:1986-2005).


### PR DESCRIPTION
## Summary

Closes the peer-discovery memory-exhaustion DoS from #1170. The inbound `TMEndpoints` path stored every announced `IP:port` verbatim and retained it for an hour, with only the 1024 wholesale-reject guard — go-xrpl was missing three of rippled's four inbound PeerFinder defenses, so a single `Converged` peer could stream valid endpoints and grow `d.peers` without bound.

This adds the missing bounds, mirroring rippled's PeerFinder:

- **Per-message sampling** — an accepted frame is shuffled and truncated to `numberOfEndpointsMax` (64) before ingest (`endpointsIngestSampleMax`), so one frame can't enqueue its whole sub-1024 batch.
- **Per-peer inbound rate-limit** — ingest is gated behind rippled's `secondsPerMessage` (151s) window via a new `Peer.acceptEndpoints()` / `whenAcceptEndpoints`; a frame inside the window is dropped silently (no charge), matching rippled's `whenAcceptEndpoints` gate.
- **Hop-horizon drop** — entries with `hops > MaxHops` are dropped at ingest rather than stored (they'd never be dialed by `SelectPeersToConnect` anyway), mirroring rippled's `hops > maxHops` preprocess drop.
- **Absolute ceiling on `d.peers`** — `MaxDiscoveredPeers` (8192) with least-recently-seen eviction that never touches connected or fixed peers, as a cross-peer backstop against many-peer amplification.

Ingest order matches rippled: parse + charge malformed → skip if none survived → sample to 64 → rate-limit (arms the window) → drop over-horizon hops → `AddPeer`.

## Test plan

- [x] `just test-pkg ./internal/peermanagement/...` (with `-race`) — all pass
- [x] New tests: rate-limit (accept → silent drop inside window → accept after window), oversized-frame sampling to 64, over-horizon hop drop, and `AddPeer` cap eviction keeping connected/fixed peers
- [x] `gofmt` clean; strict `.golangci.yml` lint reports 0 issues
- [x] Existing endpoint-handler tests unchanged (hops ≤ MaxHops, single-frame)

Fixes #1170