### PR TITLE
fix: serialise pebble kvstore ops against Close to prevent use-after-close panic

### DIFF
--- a/storage/kvstore/kvstoretest/conformance.go
+++ b/storage/kvstore/kvstoretest/conformance.go
@@ -439,6 +439,19 @@ func testClosed(t *testing.T, store kvstore.KeyValueStore) {
 		t.Fatalf("closed-store iterator Error = %v, want ErrClosed", err)
 	}
 	it.Release()
+
+	// A batch obtained from a closed store must never commit against the
+	// closed backend; Write reports ErrClosed and nothing panics. Put's
+	// return is left unchecked because backends differ on when they surface
+	// the closed state (at buffer time vs. at Write) — Write is the contract.
+	b := store.NewBatch()
+	if b == nil {
+		t.Fatal("NewBatch on closed store returned nil")
+	}
+	_ = b.Put([]byte("k"), []byte("v"))
+	if err := b.Write(); !errors.Is(err, kvstore.ErrClosed) {
+		t.Fatalf("batch Write on closed store err = %v, want ErrClosed", err)
+	}
 }
 
 func insert(t *testing.T, store kvstore.KeyValueStore, kv map[string]string) {

--- a/storage/kvstore/pebble/pebble.go
+++ b/storage/kvstore/pebble/pebble.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"sync/atomic"
+	"sync"
 
 	"github.com/LeJamon/go-xrpl/storage/kvstore"
 	"github.com/cockroachdb/pebble"
@@ -14,9 +14,16 @@ import (
 )
 
 // Store is a thin wrapper around CockroachDB/Pebble that implements kvstore.KeyValueStore.
+//
+// mu serialises every operation against Close: an op holds RLock across both its
+// closed-check and the underlying s.db call, while Close takes the exclusive
+// lock. Pebble panics ("pebble: closed") on any op against a closed DB, so a
+// bare atomic flag — checked, then acted on — leaves a window where a racing
+// Close turns the panic loose. The RWMutex closes that window.
 type Store struct {
+	mu       sync.RWMutex
 	db       *pebble.DB
-	closed   atomic.Bool
+	closed   bool
 	readonly bool
 }
 
@@ -78,7 +85,9 @@ func New(path string, cache int, handles int, readonly bool) (*Store, error) {
 
 // Has returns true if the key exists in the store.
 func (s *Store) Has(key []byte) (bool, error) {
-	if s.closed.Load() {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
 		return false, kvstore.ErrClosed
 	}
 	_, closer, err := s.db.Get(key)
@@ -95,7 +104,9 @@ func (s *Store) Has(key []byte) (bool, error) {
 // Get retrieves the value for the given key.
 // Returns kvstore.ErrNotFound if the key does not exist.
 func (s *Store) Get(key []byte) ([]byte, error) {
-	if s.closed.Load() {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
 		return nil, kvstore.ErrClosed
 	}
 	val, closer, err := s.db.Get(key)
@@ -114,7 +125,9 @@ func (s *Store) Get(key []byte) ([]byte, error) {
 
 // Put stores the value for the given key.
 func (s *Store) Put(key []byte, value []byte) error {
-	if s.closed.Load() {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
 		return kvstore.ErrClosed
 	}
 	return s.db.Set(key, value, pebble.NoSync)
@@ -122,15 +135,24 @@ func (s *Store) Put(key []byte, value []byte) error {
 
 // Delete removes the value for the given key.
 func (s *Store) Delete(key []byte) error {
-	if s.closed.Load() {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
 		return kvstore.ErrClosed
 	}
 	return s.db.Delete(key, pebble.NoSync)
 }
 
-// NewBatch returns a new batch for accumulating writes.
+// NewBatch returns a new batch for accumulating writes. On a closed store it
+// returns a batch that reports ErrClosed rather than allocating one against
+// the closed DB; the returned batch also re-checks on Write.
 func (s *Store) NewBatch() kvstore.Batch {
-	return &batch{b: s.db.NewBatch()}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		return &errBatch{err: kvstore.ErrClosed}
+	}
+	return &batch{store: s, b: s.db.NewBatch()}
 }
 
 // NewIterator returns an iterator over key/value pairs with the given prefix,
@@ -138,7 +160,9 @@ func (s *Store) NewBatch() kvstore.Batch {
 // If the store is closed or the underlying iterator cannot be opened, the
 // returned iterator is empty and reports the failure via Error.
 func (s *Store) NewIterator(prefix []byte, start []byte) kvstore.Iterator {
-	if s.closed.Load() {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
 		return &errIterator{err: kvstore.ErrClosed}
 	}
 	opts := &pebble.IterOptions{}
@@ -196,7 +220,9 @@ func prefixUpperBound(prefix []byte) []byte {
 
 // Stat returns a string with database statistics.
 func (s *Store) Stat() (string, error) {
-	if s.closed.Load() {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
 		return "", kvstore.ErrClosed
 	}
 	if m := s.db.Metrics(); m != nil {
@@ -207,7 +233,9 @@ func (s *Store) Stat() (string, error) {
 
 // Compact compacts the database in the given key range.
 func (s *Store) Compact(start []byte, limit []byte) error {
-	if s.closed.Load() {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
 		return kvstore.ErrClosed
 	}
 	return s.db.Compact(start, limit, true)
@@ -217,7 +245,9 @@ func (s *Store) Compact(start []byte, limit []byte) error {
 // record to the WAL. Writes use pebble.NoSync, so this is the only point
 // at which acknowledged writes are guaranteed to survive a crash.
 func (s *Store) Sync() error {
-	if s.closed.Load() {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
 		return kvstore.ErrClosed
 	}
 	if s.readonly {
@@ -228,10 +258,17 @@ func (s *Store) Sync() error {
 
 // Close closes the database, flushing pending writes first. The underlying
 // handle is always closed, even if the flush fails.
+//
+// The exclusive lock is held across the whole close, so any in-flight op has
+// already released its RLock (and finished touching s.db) before the handle is
+// closed, and any op that arrives later observes closed == true.
 func (s *Store) Close() error {
-	if !s.closed.CompareAndSwap(false, true) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
 		return nil // already closed
 	}
+	s.closed = true
 	var flushErr error
 	if !s.readonly {
 		flushErr = s.db.Flush()
@@ -239,10 +276,13 @@ func (s *Store) Close() error {
 	return errors.Join(flushErr, s.db.Close())
 }
 
-// batch implements kvstore.Batch using a pebble.Batch.
+// batch implements kvstore.Batch using a pebble.Batch. Put/Delete/Reset only
+// touch the in-memory pebble.Batch buffer, so they are safe after Close; Write
+// commits against s.db and therefore re-checks the closed state under the lock.
 type batch struct {
-	b    *pebble.Batch
-	size int
+	store *Store
+	b     *pebble.Batch
+	size  int
 }
 
 // Put queues a key/value write.
@@ -262,6 +302,11 @@ func (b *batch) ValueSize() int {
 }
 
 func (b *batch) Write() error {
+	b.store.mu.RLock()
+	defer b.store.mu.RUnlock()
+	if b.store.closed {
+		return kvstore.ErrClosed
+	}
 	return b.b.Commit(pebble.NoSync)
 }
 
@@ -328,6 +373,19 @@ func (i *errIterator) Key() []byte   { return nil }
 func (i *errIterator) Value() []byte { return nil }
 func (i *errIterator) Error() error  { return i.err }
 func (i *errIterator) Release()      {}
+
+// errBatch is a no-op batch that reports a fixed error, returned by NewBatch
+// when the store is already closed so callers never buffer writes against a
+// closed DB.
+type errBatch struct {
+	err error
+}
+
+func (b *errBatch) Put(key []byte, value []byte) error { return b.err }
+func (b *errBatch) Delete(key []byte) error            { return b.err }
+func (b *errBatch) ValueSize() int                     { return 0 }
+func (b *errBatch) Write() error                       { return b.err }
+func (b *errBatch) Reset()                             {}
 
 // Ensure Store implements kvstore.KeyValueStore at compile time.
 var _ kvstore.KeyValueStore = (*Store)(nil)

--- a/storage/kvstore/pebble/pebble_test.go
+++ b/storage/kvstore/pebble/pebble_test.go
@@ -2,7 +2,11 @@ package pebble_test
 
 import (
 	"bytes"
+	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/storage/kvstore"
 	"github.com/LeJamon/go-xrpl/storage/kvstore/kvstoretest"
@@ -133,4 +137,86 @@ func TestStoreReadonly(t *testing.T) {
 		t.Fatalf("reopen after readonly close: %v", err)
 	}
 	_ = again.Close()
+}
+
+// TestConcurrentCloseNoPanic races every point operation against Close.
+// Pebble panics ("pebble: closed") on any op against a closed DB, so the old
+// check-then-act atomic guard let that panic escape once Close landed in the
+// window between the closed-check and the s.db call. Each op must instead be
+// serialised against Close by the RWMutex and return cleanly. Run under -race,
+// this also proves the closed flag and db handle are never touched
+// unsynchronised. Every op must return success, ErrClosed, or ErrNotFound —
+// never a panic.
+func TestConcurrentCloseNoPanic(t *testing.T) {
+	dir := t.TempDir()
+	store, err := pebble.New(dir, 0, 0, false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := store.Put([]byte("seed"), []byte("v")); err != nil {
+		t.Fatalf("seed Put: %v", err)
+	}
+
+	accept := func(op string, err error) {
+		if err == nil ||
+			errors.Is(err, kvstore.ErrClosed) ||
+			errors.Is(err, kvstore.ErrNotFound) {
+			return
+		}
+		t.Errorf("%s: unexpected error %v", op, err)
+	}
+
+	const workers = 16
+	var wg sync.WaitGroup
+	var panics atomic.Int64
+	start := make(chan struct{})
+
+	for i := range workers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panics.Add(1)
+					t.Errorf("worker %d panicked (use-after-close leaked through): %v", id, r)
+				}
+			}()
+			<-start
+			key := []byte{byte(id)}
+			for range 300 {
+				accept("Put", store.Put(key, []byte("v")))
+				_, gerr := store.Get(key)
+				accept("Get", gerr)
+				_, herr := store.Has([]byte("seed"))
+				accept("Has", herr)
+				accept("Delete", store.Delete(key))
+				b := store.NewBatch()
+				_ = b.Put(key, []byte("v"))
+				accept("Batch.Write", b.Write())
+				accept("Sync", store.Sync())
+				_, serr := store.Stat()
+				accept("Stat", serr)
+			}
+		}(i)
+	}
+
+	close(start)
+	// Let the workers get going so some ops land before Close and some after.
+	time.Sleep(time.Millisecond)
+	if err := store.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+	wg.Wait()
+
+	if n := panics.Load(); n != 0 {
+		t.Fatalf("%d worker(s) panicked on use-after-close", n)
+	}
+	// Close is idempotent.
+	if err := store.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+	// Every op is rejected once closed.
+	if _, err := store.Get([]byte("seed")); !errors.Is(err, kvstore.ErrClosed) {
+		t.Errorf("Get after close = %v, want ErrClosed", err)
+	}
 }


### PR DESCRIPTION
## Summary

- The pebble kvstore backend guarded its closed state with an `atomic.Bool`, but every op did a **check-then-act** — the `s.closed.Load()` check and the `s.db.*` call were separate steps. A concurrent `Close()` landing in that window makes pebble **panic** (`"pebble: closed"`) instead of the wrapper returning `kvstore.ErrClosed`.
- `NewBatch` was strictly worse: **unguarded entirely**, so `batch.Write()` committed against a closed DB even in **sequential** use-after-close, not just under a race.
- Fix mirrors the already-correct `memorydb` backend: replace `closed atomic.Bool` with `sync.RWMutex` + `closed bool`. Each op takes `RLock` across **both** its closed-check and the `s.db` call; `Close` takes the exclusive `Lock`. An op therefore either completes fully (before `Close`) or observes `closed` and returns a clean `ErrClosed` — never a panic, never a data race.
- `NewBatch` now returns a no-op `errBatch` (reports `ErrClosed`) on a closed store instead of allocating a batch against the closed DB, and `batch.Write` re-checks `closed` under the lock. `RLock` is uncontended except during an actual close, so hot-path cost is negligible.

## Test plan

- [x] `go test -race ./storage/kvstore/... ./storage/nodestore/...` — all pass (nodestore is the pebble consumer)
- [x] New `TestConcurrentCloseNoPanic` races every point op against `Close` under `-race`; every op returns success / `ErrClosed` / `ErrNotFound`, never a panic. **Verified non-vacuous**: reverting only `pebble.go` to the old atomic guard makes the test hang/panic (a pebble panic mid-`Commit` deadlocks the other workers).
- [x] Shared conformance suite (`kvstoretest`) extended to cover `NewBatch` on a closed store — now enforced for both `memorydb` and `pebble`.
- [x] `golangci-lint run --config .golangci.yml ./storage/kvstore/...` — 0 issues; `gofmt` clean.

Scope note: the fix guards the store's check-then-act sites (the issue's subject). An iterator handle that outlives `Close` mid-iteration is a distinct, pre-existing concern (pebble returns `"leaked iterators"` on `Close` in that case, same as direct pebble usage) and is intentionally left out of scope.

Fixes #1167