### PR TITLE
fix: detect equivocation at superseded validation seqs

### DIFF
--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -818,31 +818,28 @@ func (e *Engine) OnValidation(validation *consensus.Validation, originPeer uint6
 
 	trusted := e.adaptor.IsTrusted(validation.NodeID)
 
-	// Same-seq Byzantine detection: a trusted validator must not sign two
-	// ledgers (or re-sign differently) for one seq. On conflict, keep it out
-	// of quorum/trie but STILL relay it (peers should observe it too) and
-	// charge no one. The returned error only tells the router to skip the
-	// catch-up acquire — not to penalise the relaying peer.
+	// Feed the tracker — the gate that advances validated_ledger once a
+	// quorum of trusted FULL validations accumulates (partials steer the trie
+	// but don't count). Trust-gate to avoid a byNode entry per untrusted key.
+	//
+	// The tracker doubles as the Byzantine detector: a trusted validator
+	// must not sign two ledgers (or re-sign differently) for one seq, even
+	// a seq its tip has already superseded. On conflicting/multiple, the
+	// validation is kept out of quorum/trie but STILL relayed (peers should
+	// observe it too) and no one is charged. The returned error only tells
+	// the router to skip the catch-up acquire — not to penalise the
+	// relaying peer.
 	if trusted && e.validationTracker != nil {
-		if reason, conflict := validationConflict(
-			e.validationTracker.GetLatestValidation(validation.NodeID),
-			validation,
-		); conflict {
+		switch status := e.validationTracker.AddStatus(validation); status {
+		case ValStatusConflicting, ValStatusMultiple:
 			e.adaptor.RelayValidation(validation, originPeer)
-			return &consensus.ByzantineValidationError{NodeID: validation.NodeID, Reason: reason}
+			return &consensus.ByzantineValidationError{NodeID: validation.NodeID, Reason: status.String()}
 		}
 	}
 
 	// Store trusted-only: an untrusted key could grow the map unboundedly.
 	if trusted {
 		e.proposalTracker.SetValidation(validation)
-	}
-
-	// Feed the tracker — the gate that advances validated_ledger once a
-	// quorum of trusted FULL validations accumulates (partials steer the trie
-	// but don't count). Trust-gate to avoid a byNode entry per untrusted key.
-	if trusted && e.validationTracker != nil {
-		e.validationTracker.Add(validation)
 	}
 
 	e.eventBus.Publish(&consensus.ValidationReceivedEvent{
@@ -858,29 +855,6 @@ func (e *Engine) OnValidation(validation *consensus.Validation, originPeer uint6
 	}
 
 	return nil
-}
-
-// validationConflict classifies a new validation against the latest
-// tracked one for the same node. conflict=true only when they share a
-// seq but disagree: different ledger (or same ledger, different sign
-// time) → "conflicting"; same ledger+time, different cookie → "multiple".
-// nil prev, a different seq, or an identical resend is no conflict. Only
-// the latest seq per node is checked, so a conflict at an already-passed
-// seq is missed — harmless, it can't affect quorum.
-func validationConflict(prev, v *consensus.Validation) (string, bool) {
-	if prev == nil || prev.LedgerSeq != v.LedgerSeq {
-		return "", false
-	}
-	if prev.LedgerID != v.LedgerID {
-		return "conflicting", true
-	}
-	if !prev.SignTime.Equal(v.SignTime) {
-		return "conflicting", true
-	}
-	if prev.Cookie != v.Cookie {
-		return "multiple", true
-	}
-	return "", false
 }
 
 // OnTxSet handles receiving a transaction set we requested.

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -32,6 +32,73 @@ func safeTrieCall(fn string, op func()) (panicked bool) {
 	return false
 }
 
+// ValStatus classifies the outcome of AddStatus, mirroring rippled's
+// ValStatus (Validations.h:169-180).
+type ValStatus int
+
+const (
+	// ValStatusCurrent — added; counts toward quorum and steers the trie.
+	ValStatusCurrent ValStatus = iota
+	// ValStatusStale — outside the freshness window, below the sequence
+	// floor, or superseded by the node's tracked tip.
+	ValStatusStale
+	// ValStatusBadSeq — violates the increasing-seq requirement without
+	// double-sign evidence.
+	ValStatusBadSeq
+	// ValStatusMultiple — same seq and ledger signed with different
+	// cookies (likely two servers sharing a validator key).
+	ValStatusMultiple
+	// ValStatusConflicting — same seq signed for different ledgers, or
+	// re-signed with a different sign time.
+	ValStatusConflicting
+)
+
+func (s ValStatus) String() string {
+	switch s {
+	case ValStatusCurrent:
+		return "current"
+	case ValStatusStale:
+		return "stale"
+	case ValStatusBadSeq:
+		return "badSeq"
+	case ValStatusMultiple:
+		return "multiple"
+	case ValStatusConflicting:
+		return "conflicting"
+	default:
+		return "unknown"
+	}
+}
+
+// seqEnforcer tracks the largest validation seq a node issued within the
+// validationSetExpires window; the floor resets after that long idle. A
+// validation must exceed the floor to be considered monotonic.
+type seqEnforcer struct {
+	seq  uint32
+	when time.Time
+}
+
+// advance reports whether seq exceeds the non-expired floor, bumping the
+// floor when it does.
+func (s *seqEnforcer) advance(now time.Time, seq uint32) bool {
+	if now.Sub(s.when) > validationSetExpires {
+		s.seq = 0
+	}
+	if seq <= s.seq {
+		return false
+	}
+	s.seq = seq
+	s.when = now
+	return true
+}
+
+// seqValidations is one bySequence bucket: the validation each node
+// signed at a given seq, plus the last-access time driving expiry.
+type seqValidations struct {
+	touched time.Time
+	byNode  map[consensus.NodeID]*consensus.Validation
+}
+
 // ValidationTracker tracks validations and determines ledger finality.
 type ValidationTracker struct {
 	mu sync.RWMutex
@@ -50,6 +117,18 @@ type ValidationTracker struct {
 
 	// byNode maps node ID to their latest validation
 	byNode map[consensus.NodeID]*consensus.Validation
+
+	// bySequence tracks, per ledger seq, the validation each node signed
+	// at that seq — the evidence the Byzantine cross-check runs against
+	// when a node submits a non-monotonic seq, so equivocation is caught
+	// even at seqs the node has already superseded. Buckets age out after
+	// validationSetExpires without access (FlushStale sweep).
+	bySequence map[uint32]*seqValidations
+
+	// seqEnforcers holds the per-remote-node monotonic-seq floor with
+	// idle reset. Distinct from the engine's local enforcer, which gates
+	// what WE sign; these gate what each remote node may submit.
+	seqEnforcers map[consensus.NodeID]*seqEnforcer
 
 	// trusted is the set of trusted validators
 	trusted map[consensus.NodeID]bool
@@ -123,14 +202,16 @@ type ValidationTracker struct {
 // close-time offset.
 func NewValidationTracker(quorum int, freshness time.Duration) *ValidationTracker {
 	return &ValidationTracker{
-		now:         time.Now,
-		validations: make(map[consensus.LedgerID]map[consensus.NodeID]*consensus.Validation),
-		byNode:      make(map[consensus.NodeID]*consensus.Validation),
-		trusted:     make(map[consensus.NodeID]bool),
-		negUNL:      make(map[consensus.NodeID]bool),
-		quorum:      quorum,
-		freshness:   freshness,
-		fired:       make(map[consensus.LedgerID]struct{}),
+		now:          time.Now,
+		validations:  make(map[consensus.LedgerID]map[consensus.NodeID]*consensus.Validation),
+		byNode:       make(map[consensus.NodeID]*consensus.Validation),
+		bySequence:   make(map[uint32]*seqValidations),
+		seqEnforcers: make(map[consensus.NodeID]*seqEnforcer),
+		trusted:      make(map[consensus.NodeID]bool),
+		negUNL:       make(map[consensus.NodeID]bool),
+		quorum:       quorum,
+		freshness:    freshness,
+		fired:        make(map[consensus.LedgerID]struct{}),
 	}
 }
 
@@ -280,6 +361,14 @@ func isCurrent(now, signTime, seenTime time.Time) bool {
 
 // Add adds a validation to the tracker.
 // Returns true if this is a new validation (not duplicate).
+func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
+	return vt.AddStatus(validation) == ValStatusCurrent
+}
+
+// AddStatus adds a validation and classifies the outcome. Only
+// ValStatusCurrent validations enter the quorum/trie indexes; every
+// non-stale one is recorded in the by-seq evidence index first, so a
+// double-sign is detected even at a seq the node has already superseded.
 //
 // Inbound filters match rippled's Validations::add (Validations.h:
 // 623-707) and isCurrent:
@@ -293,6 +382,11 @@ func isCurrent(now, signTime, seenTime time.Time) bool {
 //     blinds every peer's preferred-ledger steering during recovery.
 //   - Stale or clock-skewed validations (outside the wall/local
 //     windows defined above) are rejected via isCurrent.
+//   - A non-monotonic seq (per-node enforcer floor, idle-reset after
+//     validationSetExpires) is rejected: as conflicting when the node
+//     already signed a different ledger — or the same ledger with a
+//     different sign time — at that seq, as multiple on a cookie
+//     mismatch, else as badSeq.
 //   - Validations with seq below minSeq are rejected. Once a ledger
 //     accepts, validations for seqs many rounds back are noise that
 //     can never retroactively become quorum; keeping them in memory
@@ -314,7 +408,7 @@ func isCurrent(now, signTime, seenTime time.Time) bool {
 //
 // Defer order is LIFO: vt.mu.Unlock runs first (released before the
 // callback), then the captured fire-tuple is dispatched.
-func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
+func (vt *ValidationTracker) AddStatus(validation *consensus.Validation) ValStatus {
 	var (
 		fireID     consensus.LedgerID
 		fireSeq    uint32
@@ -353,13 +447,9 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	// raw time.Now so the check honors the network-adjusted close
 	// offset and doesn't reject our own just-signed validations on a
 	// clock-skewed node.
-	if !isCurrent(vt.now(), validation.SignTime, validation.SeenTime) {
-		return false
-	}
-
-	// Reject far-stale validations below the sequence floor.
-	if vt.minSeq > 0 && validation.LedgerSeq < vt.minSeq {
-		return false
+	now := vt.now()
+	if !isCurrent(now, validation.SignTime, validation.SeenTime) {
+		return ValStatusStale
 	}
 
 	// validation.NodeID is already master-shaped on entry — the
@@ -370,13 +460,43 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	// happens at the wire seam, not here).
 	resolvedID := validation.NodeID
 
+	// Byzantine detector (Validations.h:637-681). Record the validation
+	// as by-seq evidence, then enforce monotonically increasing seqs per
+	// node. On a non-monotonic seq, classify against the entry already
+	// tracked at that exact seq — catching a double-sign even after the
+	// node's tip moved past it. Runs before the minSeq gate: rippled
+	// classifies anything inside the freshness window.
+	tracked := vt.trackBySequenceLocked(resolvedID, validation, now)
+	enf := vt.seqEnforcers[resolvedID]
+	if enf == nil {
+		enf = &seqEnforcer{}
+		vt.seqEnforcers[resolvedID] = enf
+	}
+	if !enf.advance(now, validation.LedgerSeq) {
+		if tracked.LedgerID != validation.LedgerID {
+			return ValStatusConflicting
+		}
+		if !tracked.SignTime.Equal(validation.SignTime) {
+			return ValStatusConflicting
+		}
+		if tracked.Cookie != validation.Cookie {
+			return ValStatusMultiple
+		}
+		return ValStatusBadSeq
+	}
+
+	// Reject far-stale validations below the sequence floor.
+	if vt.minSeq > 0 && validation.LedgerSeq < vt.minSeq {
+		return ValStatusStale
+	}
+
 	// Supersede a node's tip only with a strictly higher seq; a
 	// same-or-lower-seq re-sign is rejected so a stale or sideways
 	// ledger can't skew ProposersFinished / PreferredFromValidations.
 	existing, hasExisting := vt.byNode[resolvedID]
 	if hasExisting {
 		if validation.LedgerSeq <= existing.LedgerSeq {
-			return false
+			return ValStatusStale
 		}
 	}
 
@@ -406,7 +526,32 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	// invokes onFullyValidated after vt.mu.Unlock has run.
 	fireID, fireSeq, shouldFire = vt.checkFullValidationLocked(validation.LedgerID)
 	cb = vt.onFullyValidated
-	return true
+	return ValStatusCurrent
+}
+
+// trackBySequenceLocked records validation in the by-seq evidence index
+// and returns the entry tracked for (seq, node) — the prior validation
+// when one exists, else validation itself. A prior entry signed more
+// than validationCurrentWall before a newer one is disregarded and
+// replaced, so an ancient double-sign no longer reads as conflicting
+// (Validations.h:640-651). Caller must hold vt.mu.
+func (vt *ValidationTracker) trackBySequenceLocked(
+	nodeID consensus.NodeID,
+	validation *consensus.Validation,
+	now time.Time,
+) *consensus.Validation {
+	bucket := vt.bySequence[validation.LedgerSeq]
+	if bucket == nil {
+		bucket = &seqValidations{byNode: make(map[consensus.NodeID]*consensus.Validation)}
+		vt.bySequence[validation.LedgerSeq] = bucket
+	}
+	bucket.touched = now
+	tracked, ok := bucket.byNode[nodeID]
+	if !ok || validation.SignTime.Sub(tracked.SignTime) > validationCurrentWall {
+		bucket.byNode[nodeID] = validation
+		return validation
+	}
+	return tracked
 }
 
 // checkFullValidationLocked records that a ledger crossed the quorum
@@ -803,6 +948,20 @@ func (vt *ValidationTracker) FlushStale() {
 			delete(vt.trieTips, nodeID)
 		}
 	}
+
+	// Age out by-seq evidence and idle enforcer floors — rippled's
+	// beast::expire(bySequence_) sweep. An enforcer idle past the window
+	// would self-reset on next use, so deleting it is equivalent.
+	for seq, bucket := range vt.bySequence {
+		if now.Sub(bucket.touched) > validationSetExpires {
+			delete(vt.bySequence, seq)
+		}
+	}
+	for nodeID, enf := range vt.seqEnforcers {
+		if now.Sub(enf.when) > validationSetExpires {
+			delete(vt.seqEnforcers, nodeID)
+		}
+	}
 }
 
 // ExpireOld drops validations below minSeq from every index and fires
@@ -865,6 +1024,8 @@ func (vt *ValidationTracker) Flush() {
 
 	vt.validations = make(map[consensus.LedgerID]map[consensus.NodeID]*consensus.Validation)
 	vt.byNode = make(map[consensus.NodeID]*consensus.Validation)
+	vt.bySequence = make(map[uint32]*seqValidations)
+	vt.seqEnforcers = make(map[consensus.NodeID]*seqEnforcer)
 	vt.fired = make(map[consensus.LedgerID]struct{})
 	vt.rebuildTrieLocked()
 }

--- a/internal/consensus/rcl/validations_partial_test.go
+++ b/internal/consensus/rcl/validations_partial_test.go
@@ -102,6 +102,10 @@ func TestValidationTracker_AddStatus_Classification(t *testing.T) {
 		want  ValStatus
 	}{
 		{name: "first validation", v: mk(100, ledgerA, base, 1), want: ValStatusCurrent},
+		// Freshness gate (isCurrent) rejects a validation signed far in the
+		// past before any evidence or enforcer state is touched, so the row
+		// order around it is immaterial.
+		{name: "stale sign time", v: mk(105, ledgerA, base.Add(-time.Hour), 1), want: ValStatusStale},
 		{name: "identical resend", v: mk(100, ledgerA, base, 1), want: ValStatusBadSeq},
 		{name: "same seq different ledger", v: mk(100, ledgerB, base, 1), want: ValStatusConflicting},
 		{name: "same seq same ledger different signtime", v: mk(100, ledgerA, base.Add(time.Second), 1), want: ValStatusConflicting},
@@ -129,6 +133,61 @@ func TestValidationTracker_AddStatus_Classification(t *testing.T) {
 		if got := vt.AddStatus(tc.v); got != tc.want {
 			t.Errorf("%s: AddStatus = %v, want %v", tc.name, got, tc.want)
 		}
+	}
+}
+
+// TestValidationTracker_AddStatus_PartialDoubleSign checks the double-sign
+// detector on PARTIAL validations: classification runs before any Full-based
+// branch, so a partial equivocation is flagged just like a full one.
+func TestValidationTracker_AddStatus_PartialDoubleSign(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	vt := NewValidationTracker(10, 5*time.Minute)
+	vt.SetNow(func() time.Time { return base })
+
+	node := consensus.NodeID{0x7}
+	partial := func(seq uint32, ledger consensus.LedgerID) *consensus.Validation {
+		return &consensus.Validation{
+			LedgerSeq: seq, LedgerID: ledger, NodeID: node,
+			SignTime: base, Full: false,
+		}
+	}
+
+	if got := vt.AddStatus(partial(100, consensus.LedgerID{0xA})); got != ValStatusCurrent {
+		t.Fatalf("first partial: AddStatus = %v, want current", got)
+	}
+	if got := vt.AddStatus(partial(100, consensus.LedgerID{0xB})); got != ValStatusConflicting {
+		t.Errorf("partial same-seq different-ledger: AddStatus = %v, want conflicting", got)
+	}
+}
+
+// TestSeqEnforcer_IdleResetBoundary pins the monotonic-seq invariant and the
+// exact validationSetExpires idle-reset edge: at the boundary the floor still
+// holds; one tick past it the floor resets and re-admits a lower seq.
+func TestSeqEnforcer_IdleResetBoundary(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	var enf seqEnforcer
+
+	if !enf.advance(base, 1) {
+		t.Fatal("seq 1 must advance from an empty floor")
+	}
+	if !enf.advance(base, 10) {
+		t.Fatal("seq 10 must advance past floor 1")
+	}
+	if enf.advance(base, 5) {
+		t.Error("seq 5 must be rejected below floor 10")
+	}
+	if enf.advance(base, 9) {
+		t.Error("seq 9 must be rejected below floor 10")
+	}
+
+	// At exactly validationSetExpires the floor has NOT expired (strict >),
+	// so a lower seq is still rejected.
+	if enf.advance(base.Add(validationSetExpires), 1) {
+		t.Error("at exactly validationSetExpires the floor holds; seq 1 must be rejected")
+	}
+	// One tick past the window the floor resets to 0 and re-admits seq 1.
+	if !enf.advance(base.Add(validationSetExpires+time.Nanosecond), 1) {
+		t.Error("past validationSetExpires the floor resets; seq 1 must be re-admitted")
 	}
 }
 

--- a/internal/consensus/rcl/validations_partial_test.go
+++ b/internal/consensus/rcl/validations_partial_test.go
@@ -72,10 +72,17 @@ func TestValidationTracker_TrustedPartialSteersButNotQuorum(t *testing.T) {
 	}
 }
 
-// TestValidationConflict covers the A6 classification of same-seq
-// double-signs against the most recent tracked tip.
-func TestValidationConflict(t *testing.T) {
+// TestValidationTracker_AddStatus_Classification covers the A6
+// classification of double-signs. Non-monotonic seqs are cross-checked
+// against the validation tracked at that exact seq — not just the node's
+// latest tip — so equivocation is flagged even at superseded seqs. Steps
+// run in order against one tracker, sharing evidence and enforcer state.
+func TestValidationTracker_AddStatus_Classification(t *testing.T) {
 	base := time.Unix(1_700_000_000, 0)
+	now := base
+	vt := NewValidationTracker(10, 5*time.Minute)
+	vt.SetNow(func() time.Time { return now })
+
 	node := consensus.NodeID{0x9}
 	mk := func(seq uint32, ledger consensus.LedgerID, signTime time.Time, cookie uint64) *consensus.Validation {
 		return &consensus.Validation{
@@ -85,27 +92,43 @@ func TestValidationConflict(t *testing.T) {
 	}
 	ledgerA := consensus.LedgerID{0xA}
 	ledgerB := consensus.LedgerID{0xB}
+	ledgerC := consensus.LedgerID{0xC}
 
-	tests := []struct {
-		name       string
-		prev, next *consensus.Validation
-		wantReason string
-		wantConfl  bool
+	steps := []struct {
+		name  string
+		at    time.Duration // tracker clock offset from base
+		flush bool          // run the FlushStale heartbeat sweep first
+		v     *consensus.Validation
+		want  ValStatus
 	}{
-		{"nil prev", nil, mk(100, ledgerA, base, 0), "", false},
-		{"different seq", mk(100, ledgerA, base, 0), mk(101, ledgerB, base, 0), "", false},
-		{"identical resend", mk(100, ledgerA, base, 1), mk(100, ledgerA, base, 1), "", false},
-		{"same seq different ledger", mk(100, ledgerA, base, 0), mk(100, ledgerB, base, 0), "conflicting", true},
-		{"same seq same ledger different signtime", mk(100, ledgerA, base, 0), mk(100, ledgerA, base.Add(time.Second), 0), "conflicting", true},
-		{"same seq same ledger different cookie", mk(100, ledgerA, base, 1), mk(100, ledgerA, base, 2), "multiple", true},
+		{name: "first validation", v: mk(100, ledgerA, base, 1), want: ValStatusCurrent},
+		{name: "identical resend", v: mk(100, ledgerA, base, 1), want: ValStatusBadSeq},
+		{name: "same seq different ledger", v: mk(100, ledgerB, base, 1), want: ValStatusConflicting},
+		{name: "same seq same ledger different signtime", v: mk(100, ledgerA, base.Add(time.Second), 1), want: ValStatusConflicting},
+		{name: "same seq same ledger different cookie", v: mk(100, ledgerA, base, 2), want: ValStatusMultiple},
+		{name: "tip advances", v: mk(101, ledgerC, base, 1), want: ValStatusCurrent},
+		// The deep-detector case: the tip is at 101, yet the double-sign
+		// at the superseded seq 100 is still flagged.
+		{name: "conflict at superseded seq", v: mk(100, ledgerB, base, 1), want: ValStatusConflicting},
+		{name: "unseen lower seq", v: mk(99, ledgerB, base, 1), want: ValStatusBadSeq},
+		// Tracked evidence signed >validationCurrentWall before a newer
+		// submission is disregarded and replaced: the same (100, B) pair
+		// that was conflicting above degrades to badSeq.
+		{name: "stale evidence disregarded", at: 6 * time.Minute, v: mk(100, ledgerB, base.Add(6*time.Minute), 1), want: ValStatusBadSeq},
+		// After validationSetExpires idle the enforcer floor resets (and
+		// the heartbeat sweep drops the stale tip + aged evidence), so a
+		// node may legitimately re-validate a lower seq, e.g. after a
+		// network restart.
+		{name: "idle reset readmits lower seq", at: 17 * time.Minute, flush: true, v: mk(100, ledgerB, base.Add(17*time.Minute), 1), want: ValStatusCurrent},
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			reason, confl := validationConflict(tc.prev, tc.next)
-			if confl != tc.wantConfl || reason != tc.wantReason {
-				t.Errorf("validationConflict = (%q, %v), want (%q, %v)", reason, confl, tc.wantReason, tc.wantConfl)
-			}
-		})
+	for _, tc := range steps {
+		now = base.Add(tc.at)
+		if tc.flush {
+			vt.FlushStale()
+		}
+		if got := vt.AddStatus(tc.v); got != tc.want {
+			t.Errorf("%s: AddStatus = %v, want %v", tc.name, got, tc.want)
+		}
 	}
 }
 
@@ -163,6 +186,62 @@ func TestEngine_OnValidation_ConflictingDoubleSign(t *testing.T) {
 	}
 	if !relayedConflict {
 		t.Error("conflicting validation must still be relayed (rippled forwards Byzantine validations)")
+	}
+}
+
+// TestEngine_OnValidation_SupersededSeqDoubleSign pins the deep detector
+// end-to-end: equivocation at a seq the validator's tip has already
+// superseded is still flagged as Byzantine (the cross-check runs against
+// the by-seq evidence, not just the node's latest tip), kept out of
+// quorum/trie, and still relayed.
+func TestEngine_OnValidation_SupersededSeqDoubleSign(t *testing.T) {
+	adaptor := newMockAdaptor()
+	n := consensus.NodeID{0x9}
+	adaptor.setTrusted([]consensus.NodeID{n})
+	engine := NewEngine(adaptor, DefaultConfig())
+	if err := engine.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { engine.Stop() })
+
+	now := adaptor.Now()
+	v1 := &consensus.Validation{LedgerSeq: 100, LedgerID: consensus.LedgerID{0xA}, NodeID: n, SignTime: now, SeenTime: now, Full: true}
+	if err := engine.OnValidation(v1, 7); err != nil {
+		t.Fatalf("seq-100 validation rejected: %v", err)
+	}
+	v2 := &consensus.Validation{LedgerSeq: 101, LedgerID: consensus.LedgerID{0xC}, NodeID: n, SignTime: now, SeenTime: now, Full: true}
+	if err := engine.OnValidation(v2, 7); err != nil {
+		t.Fatalf("seq-101 validation rejected: %v", err)
+	}
+
+	// Double-sign at seq 100 — already superseded by the seq-101 tip.
+	v3 := &consensus.Validation{LedgerSeq: 100, LedgerID: consensus.LedgerID{0xB}, NodeID: n, SignTime: now, SeenTime: now, Full: true}
+	err := engine.OnValidation(v3, 7)
+	var bv *consensus.ByzantineValidationError
+	if !errors.As(err, &bv) {
+		t.Fatalf("expected *consensus.ByzantineValidationError, got %v", err)
+	}
+	if bv.Reason != "conflicting" {
+		t.Errorf("reason = %q, want conflicting", bv.Reason)
+	}
+
+	// The tip must stay at the seq-101 ledger.
+	if tip := engine.validationTracker.GetLatestValidation(n); tip == nil || tip.LedgerID != (consensus.LedgerID{0xC}) {
+		t.Errorf("tracked tip should remain the seq-101 ledger; got %+v", tip)
+	}
+
+	// Still relayed so peers observe the equivocation too.
+	adaptor.mu.RLock()
+	relayed := append([]*consensus.Validation(nil), adaptor.validationsRelayed...)
+	adaptor.mu.RUnlock()
+	var relayedConflict bool
+	for _, v := range relayed {
+		if v.LedgerID == (consensus.LedgerID{0xB}) {
+			relayedConflict = true
+		}
+	}
+	if !relayedConflict {
+		t.Error("superseded-seq double-sign must still be relayed")
 	}
 }
 


### PR DESCRIPTION
## Summary
- The Byzantine validation detector compared an incoming validation only against a node's **latest** tracked tip (`validationConflict` + `GetLatestValidation`), so a trusted validator double-signing at a seq it had already superseded was silently missed, and there was no `badSeq` rejection for plain non-monotonic seqs.
- Mirror rippled's `Validations::add` (Validations.h:637-681): `ValidationTracker.AddStatus` now records per-seq evidence (`bySequence`, aged out after `validationSetExpires` without access), runs a per-remote-node `seqEnforcer` with the 10-minute idle reset, and classifies against the entry tracked at that exact seq — `conflicting` (different ledger, or same ledger with a different sign time), `multiple` (different cookie), else `badSeq`. rippled's disregard rule is included: tracked evidence signed more than `validationCurrentWall` before a newer submission is replaced, degrading ancient double-signs to `badSeq`.
- The engine folds its previous two tracker interactions into one `AddStatus` call; `conflicting`/`multiple` still relay (peers must observe the equivocation too) and surface as `ByzantineValidationError` without charging the delivering peer. `Add() bool` remains as a thin wrapper, so existing callers and tests are unchanged. Evidence buckets and idle enforcer floors are pruned in the heartbeat-driven `FlushStale` and reset in `Flush`.

## Test plan
- [x] `go test -race ./internal/consensus/...`
- [x] `go test ./internal/testing/consensus/... ./internal/testing/validationarchive/...` (external `rcl` consumers)
- [x] `golangci-lint run --config .golangci.yml ./internal/consensus/...` (CI-strict) — 0 issues
- [x] New `TestValidationTracker_AddStatus_Classification` covers the full ValStatus matrix: superseded-seq conflict, unseen-lower-seq badSeq, stale-evidence disregard, and the 10-minute idle reset readmitting lower seqs
- [x] New `TestEngine_OnValidation_SupersededSeqDoubleSign` pins the end-to-end path: Byzantine error, tip unchanged, validation still relayed

Fixes #1190