### PR TITLE
feat: track listed-untrusted validations and honor relay_validations

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -243,6 +244,19 @@ type Adaptor struct {
 	// can broadcast mtHAVE_SET{tsHAVE} for it. nil-safe.
 	onTxSetBuilt func(consensus.TxSetID)
 
+	// relayValidations is the operator's [relay_validations] stance.
+	// Immutable after New — read without a.mu.
+	relayValidations RelayValidationsPolicy
+
+	// listedFn resolves validator-list membership (Aggregator.IsListed).
+	// nil when no publisher trust is configured — nothing is listed.
+	listedFn func(consensus.NodeID) bool
+
+	// onTrustChanged fires after every SetTrustedValidators swap (outside
+	// a.mu) so the engine can promote stored validations at trust-change
+	// time. nil-safe.
+	onTrustChanged func()
+
 	// lastIssuedValidationSeq is the highest ledger seq this node has
 	// broadcast a validation for — rippled's localSeqEnforcer_.largest(),
 	// the trie-descent floor for preferredLCL. Zero for a non-validator.
@@ -292,6 +306,39 @@ func defaultFeeVote() FeeVoteStance {
 	}
 }
 
+// RelayValidationsPolicy mirrors rippled's RELAY_UNTRUSTED_VALIDATIONS
+// tri-state, set by the [relay_validations] config key: forward verified
+// current validations from outside the UNL (default), forward trusted only,
+// or drop untrusted before signature verification.
+type RelayValidationsPolicy int
+
+const (
+	// RelayValidationsAll relays untrusted validations too — rippled's
+	// default (RELAY_UNTRUSTED_VALIDATIONS = 1). The zero value, so bare
+	// Config{} adaptors get the network-friendly default.
+	RelayValidationsAll RelayValidationsPolicy = iota
+	// RelayValidationsTrusted verifies and processes untrusted validations
+	// but relays only trusted ones (rippled 0).
+	RelayValidationsTrusted
+	// RelayValidationsDropUntrusted drops untrusted validations at the
+	// router before signature verification (rippled -1).
+	RelayValidationsDropUntrusted
+)
+
+// ParseRelayValidationsPolicy maps the [relay_validations] config string
+// (case-insensitive; "" = default "all") to its policy. Unknown values are
+// rejected by config validation upstream; fall back to the default here.
+func ParseRelayValidationsPolicy(s string) RelayValidationsPolicy {
+	switch strings.ToLower(s) {
+	case "trusted":
+		return RelayValidationsTrusted
+	case "drop_untrusted":
+		return RelayValidationsDropUntrusted
+	default:
+		return RelayValidationsAll
+	}
+}
+
 type Config struct {
 	LedgerService *service.Service
 	Sender        NetworkSender
@@ -312,6 +359,9 @@ type Config struct {
 	// abstain, upvoted → up) over registry defaults. Shared with the ledger
 	// service, which folds validated flag ledgers in via DoValidatedLedger.
 	AmendmentTable *amendment.AmendmentTable
+	// RelayValidations is the operator's [relay_validations] stance; the
+	// zero value relays untrusted validations (rippled's default).
+	RelayValidations RelayValidationsPolicy
 }
 
 // generateCookie returns a non-zero random 64-bit cookie. On a read error it
@@ -443,6 +493,7 @@ func New(cfg Config) *Adaptor {
 		amendmentStances:  amendmentStances,
 		amendmentTable:    cfg.AmendmentTable,
 		trustedVotes:      trustedVotes,
+		relayValidations:  cfg.RelayValidations,
 		logger:            logger,
 	}
 }
@@ -976,6 +1027,44 @@ func (a *Adaptor) IsTrusted(node consensus.NodeID) bool {
 	return ok
 }
 
+// SetListedLookup installs the validator-list membership resolver
+// (Aggregator.IsListed). Wired once at startup when publisher trust is
+// configured; nil (the default) means nothing is listed.
+func (a *Adaptor) SetListedLookup(fn func(consensus.NodeID) bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.listedFn = fn
+}
+
+// IsListed implements consensus.ListedOracle: whether node appears in at
+// least one live publisher list without (necessarily) being trusted.
+func (a *Adaptor) IsListed(node consensus.NodeID) bool {
+	a.mu.Lock()
+	fn := a.listedFn
+	a.mu.Unlock()
+	return fn != nil && fn(node)
+}
+
+// RelayUntrustedValidations implements consensus.ValidationRelayPolicy:
+// true under the default [relay_validations] "all" stance.
+func (a *Adaptor) RelayUntrustedValidations() bool {
+	return a.relayValidations == RelayValidationsAll
+}
+
+// DropUntrustedValidations reports the "drop_untrusted" stance; the router
+// then sheds untrusted validations before signature verification.
+func (a *Adaptor) DropUntrustedValidations() bool {
+	return a.relayValidations == RelayValidationsDropUntrusted
+}
+
+// OnTrustChanged implements consensus.TrustChangeNotifier: fn runs after
+// every SetTrustedValidators swap, outside a.mu.
+func (a *Adaptor) OnTrustChanged(fn func()) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.onTrustChanged = fn
+}
+
 func (a *Adaptor) GetTrustedValidators() []consensus.NodeID {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -1017,6 +1106,7 @@ func (a *Adaptor) SetTrustedValidators(validators []consensus.NodeID, masterKeys
 	a.trustedValidators = vCopy
 	a.trustedSet = newSet
 	a.trustedMasterKeys = mkCopy
+	onTrustChanged := a.onTrustChanged
 	a.mu.Unlock()
 
 	// trustedVotes is assigned once in New and never reassigned, so the
@@ -1024,6 +1114,11 @@ func (a *Adaptor) SetTrustedValidators(validators []consensus.NodeID, masterKeys
 	// releasing a.mu to avoid lock nesting.
 	if a.trustedVotes != nil {
 		a.trustedVotes.TrustChanged(vCopy)
+	}
+	// Outside a.mu: the engine's trust refresh reads back through
+	// GetTrustedValidators / GetQuorum, which re-lock it.
+	if onTrustChanged != nil {
+		onTrustChanged()
 	}
 }
 

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -1,8 +1,10 @@
 package adaptor
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
@@ -213,6 +215,14 @@ func (r *Router) handleValidation(msg *peermanagement.InboundMessage) {
 		return
 	}
 
+	// Operator opt-out ([relay_validations] = drop_untrusted): shed
+	// validations signed outside our UNL here, before the engine spends
+	// CPU verifying the signature. rippled's PeerImp does the same under
+	// RELAY_UNTRUSTED_VALIDATIONS == -1.
+	if r.adaptor.DropUntrustedValidations() && !r.adaptor.IsTrusted(validation.NodeID) {
+		return
+	}
+
 	originPeer := uint64(msg.PeerID)
 
 	// Observe-before-engine for consistent duplicate accounting. Hash
@@ -247,15 +257,20 @@ func (r *Router) handleValidation(msg *peermanagement.InboundMessage) {
 		// A same-seq double-sign (conflicting/multiple) is Byzantine
 		// behaviour, but the validation is well-formed and correctly
 		// signed and the engine has already relayed it. Like rippled
-		// (handleNewValidation logs at error level and forwards; no
-		// Resource::Charge), log it loudly and do NOT charge the delivering
-		// peer — it is an innocent relay.
+		// (handleNewValidation logs trusted offenders at error, untrusted
+		// at info, and forwards; no Resource::Charge), log it and do NOT
+		// charge the delivering peer — it is an innocent relay.
 		var bv *consensus.ByzantineValidationError
 		if errors.As(err, &bv) {
-			r.logger.Error("byzantine validation detected",
+			level := slog.LevelError
+			if !bv.Trusted {
+				level = slog.LevelInfo
+			}
+			r.logger.Log(context.Background(), level, "byzantine validation detected",
 				"t", "consensus",
 				"event", "byzantine-validation",
 				"reason", bv.Reason,
+				"trusted", bv.Trusted,
 				"peer", msg.PeerID)
 			return
 		}

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -278,7 +278,8 @@ func NewFromConfig(
 		AmendmentTable: ledgerSvc.AmendmentTable(),
 		// The operator's [voting] stanza. Zero values mean unset —
 		// New() substitutes the network defaults.
-		FeeVote: feeVoteFromConfig(appCfg.Voting),
+		FeeVote:          feeVoteFromConfig(appCfg.Voting),
+		RelayValidations: ParseRelayValidationsPolicy(appCfg.RelayValidations),
 	})
 
 	modeManager := NewModeManager(adaptor)
@@ -369,6 +370,10 @@ func NewFromConfig(
 			return nil, fmt.Errorf("validator-list aggregator: %w", err)
 		}
 		router.SetValidatorListAggregator(vlAgg)
+		// Listed-but-untrusted signers (published below the trust
+		// threshold) get their validations stored by the engine so a later
+		// trust change promotes what was already seen.
+		adaptor.SetListedLookup(vlAgg.IsListed)
 		// On-disk publisher-list cache: accepted lists are persisted
 		// under <database_path>/validator-list/cache.<pubHex> after
 		// every successful apply, and hydrated on cold start so the

--- a/internal/consensus/adaptor/untrusted_validations_test.go
+++ b/internal/consensus/adaptor/untrusted_validations_test.go
@@ -1,0 +1,128 @@
+package adaptor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRelayValidationsPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want RelayValidationsPolicy
+	}{
+		{"", RelayValidationsAll},
+		{"all", RelayValidationsAll},
+		{"ALL", RelayValidationsAll},
+		{"trusted", RelayValidationsTrusted},
+		{"Trusted", RelayValidationsTrusted},
+		{"drop_untrusted", RelayValidationsDropUntrusted},
+		{"Drop_Untrusted", RelayValidationsDropUntrusted},
+		// Unknown values are rejected upstream by config validation;
+		// the parser itself falls back to the rippled default.
+		{"garbage", RelayValidationsAll},
+	} {
+		if got := ParseRelayValidationsPolicy(tc.in); got != tc.want {
+			t.Errorf("ParseRelayValidationsPolicy(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestAdaptor_RelayValidationsPolicyAccessors pins the policy → accessor
+// mapping the engine (relay gate) and router (pre-verify drop) read.
+func TestAdaptor_RelayValidationsPolicyAccessors(t *testing.T) {
+	for _, tc := range []struct {
+		policy    RelayValidationsPolicy
+		wantRelay bool
+		wantDrop  bool
+	}{
+		{RelayValidationsAll, true, false},
+		{RelayValidationsTrusted, false, false},
+		{RelayValidationsDropUntrusted, false, true},
+	} {
+		a := New(Config{RelayValidations: tc.policy})
+		assert.Equal(t, tc.wantRelay, a.RelayUntrustedValidations(), "policy %v relay", tc.policy)
+		assert.Equal(t, tc.wantDrop, a.DropUntrustedValidations(), "policy %v drop", tc.policy)
+	}
+}
+
+// TestAdaptor_IsListed: nothing is listed until a lookup is wired; then the
+// adaptor defers to it (Aggregator.IsListed in production).
+func TestAdaptor_IsListed(t *testing.T) {
+	a := New(Config{})
+	listed := consensus.NodeID{0x11}
+
+	assert.False(t, a.IsListed(listed), "no lookup wired")
+
+	a.SetListedLookup(func(n consensus.NodeID) bool { return n == listed })
+	assert.True(t, a.IsListed(listed))
+	assert.False(t, a.IsListed(consensus.NodeID{0x22}))
+}
+
+// TestAdaptor_SetTrustedValidatorsFiresTrustChange: every UNL swap invokes
+// the registered trust-change callback (the engine's tracker refresh) after
+// the new set is visible through GetTrustedValidators.
+func TestAdaptor_SetTrustedValidatorsFiresTrustChange(t *testing.T) {
+	a := New(Config{})
+	n := consensus.NodeID{0x33}
+
+	var sawTrusted bool
+	fired := 0
+	a.OnTrustChanged(func() {
+		fired++
+		sawTrusted = a.IsTrusted(n)
+	})
+
+	a.SetTrustedValidators([]consensus.NodeID{n}, [][33]byte{{1}})
+	require.Equal(t, 1, fired, "callback must fire once per swap")
+	assert.True(t, sawTrusted, "callback must observe the post-swap trusted set")
+
+	a.SetTrustedValidators(nil, nil)
+	assert.Equal(t, 2, fired)
+}
+
+// TestRouter_DropUntrustedValidations: under [relay_validations] =
+// drop_untrusted the router sheds validations signed outside the UNL before
+// the engine (and its signature verification) ever sees them — rippled's
+// PeerImp pre-verify drop under RELAY_UNTRUSTED_VALIDATIONS == -1.
+// TestRouterDispatchesValidation covers the default-policy positive path
+// for the same untrusted payload.
+func TestRouter_DropUntrustedValidations(t *testing.T) {
+	engine := &mockEngine{}
+	a := newTestAdaptor(t)
+	a.relayValidations = RelayValidationsDropUntrusted
+
+	router := NewRouter(engine, a, make(chan *peermanagement.InboundMessage))
+
+	build := func(node consensus.NodeID, signingKey [33]byte) *peermanagement.InboundMessage {
+		v := &consensus.Validation{
+			Full:      true,
+			LedgerSeq: 42,
+			NodeID:    node,
+			SignTime:  time.Now(),
+		}
+		v.LedgerID = consensus.LedgerID{1}
+		v.SigningPubKey = signingKey
+		v.Signature = make([]byte, 70)
+		return &peermanagement.InboundMessage{
+			PeerID:  2,
+			Type:    uint16(message.TypeValidation),
+			Payload: encodePayload(t, &message.Validation{Validation: SerializeSTValidation(v)}),
+		}
+	}
+
+	// Untrusted signer → dropped pre-engine.
+	untrustedKey := [33]byte{0x02, 0x99}
+	router.handleValidation(build(consensus.CalcNodeID(untrustedKey), untrustedKey))
+	assert.Empty(t, engine.getValidations(), "untrusted validation must be shed before the engine")
+
+	// Trusted signer (the adaptor's own identity) still passes through.
+	identityKey := [33]byte(a.identity.SigningPubKey())
+	router.handleValidation(build(a.identity.NodeID, identityKey))
+	require.Len(t, engine.getValidations(), 1, "trusted validation must reach the engine")
+}

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -69,6 +69,33 @@ type WireableAdaptor interface {
 	SetValidationHistorian(h ValidationHistorian)
 }
 
+// ListedOracle is an optional TrustOracle extension reporting validator-list
+// membership: a listed validator is published by at least one configured list
+// publisher but not (necessarily) in the UNL. The engine stores validations
+// from listed signers so a later trust change promotes the ones already seen
+// instead of waiting for a fresh validation. Absent → nothing is listed.
+type ListedOracle interface {
+	IsListed(node NodeID) bool
+}
+
+// ValidationRelayPolicy is an optional Adaptor extension exposing the
+// operator's [relay_validations] stance. Absent → only trusted validations
+// are relayed.
+type ValidationRelayPolicy interface {
+	// RelayUntrustedValidations reports whether verified, current validations
+	// signed by validators outside the UNL are forwarded to peers, so nodes
+	// with a different UNL that do trust the signer still receive them.
+	RelayUntrustedValidations() bool
+}
+
+// TrustChangeNotifier is an optional Adaptor extension: implementers invoke
+// the registered callback after every runtime UNL mutation so the engine can
+// promote stored validations from newly-trusted validators immediately rather
+// than at the next accepted ledger.
+type TrustChangeNotifier interface {
+	OnTrustChanged(fn func())
+}
+
 // Adaptor is composed of the narrower per-subsystem interfaces below; depend
 // on the narrowest one that satisfies your needs.
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -26,6 +26,13 @@ type Engine struct {
 	adaptor  consensus.Adaptor
 	eventBus *consensus.EventBus
 
+	// listedOracle / relayPolicy are the adaptor's optional untrusted-
+	// validation extensions, resolved once at construction. Nil when the
+	// adaptor doesn't implement them: nothing is listed, only trusted
+	// validations relay.
+	listedOracle consensus.ListedOracle
+	relayPolicy  consensus.ValidationRelayPolicy
+
 	// Current state
 	mode  consensus.Mode
 	phase consensus.Phase
@@ -343,6 +350,8 @@ func NewEngine(adaptor consensus.Adaptor, config Config) *Engine {
 	if e.now == nil {
 		e.now = time.Now
 	}
+	e.listedOracle, _ = adaptor.(consensus.ListedOracle)
+	e.relayPolicy, _ = adaptor.(consensus.ValidationRelayPolicy)
 	e.modeAtomic.Store(int32(e.mode))
 	return e
 }
@@ -404,6 +413,23 @@ func (e *Engine) SetStallPing(ping func()) {
 	e.stallPing.Store(&ping)
 }
 
+// refreshTrustedSet re-syncs the validation tracker's trusted set and quorum
+// after a runtime UNL change (rippled trustChanged): the trie rebuild inside
+// SetTrusted promotes stored validations from newly-trusted validators into
+// branch support immediately, and quorum reads pick up the new set on the
+// next check. Runs on the trust-change caller's goroutine; takes e.mu only
+// briefly to snapshot the tracker, so it must not be called while holding it.
+func (e *Engine) refreshTrustedSet() {
+	e.mu.RLock()
+	vt := e.validationTracker
+	e.mu.RUnlock()
+	if vt == nil {
+		return
+	}
+	vt.SetTrusted(e.adaptor.GetTrustedValidators())
+	vt.SetQuorum(e.adaptor.GetQuorum())
+}
+
 func (e *Engine) Start(ctx context.Context) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -423,6 +449,13 @@ func (e *Engine) Start(ctx context.Context) error {
 	e.validationTracker.SetTrusted(e.adaptor.GetTrustedValidators())
 	if wired, ok := e.adaptor.(consensus.WireableAdaptor); ok {
 		wired.SetValidationHistorian(e.validationTracker)
+	}
+	// Promote stored validations the moment the UNL mutates (rippled
+	// trustChanged) instead of at the next accepted ledger — a stalled node
+	// may never accept, and the whole point of a runtime trust grant is to
+	// count what the newly-trusted validator already signed.
+	if notifier, ok := e.adaptor.(consensus.TrustChangeNotifier); ok {
+		notifier.OnTrustChanged(e.refreshTrustedSet)
 	}
 	if e.ledgerAncestry != nil {
 		e.validationTracker.SetLedgerAncestryProvider(e.ledgerAncestry)
@@ -818,30 +851,49 @@ func (e *Engine) OnValidation(validation *consensus.Validation, originPeer uint6
 
 	trusted := e.adaptor.IsTrusted(validation.NodeID)
 
-	// Same-seq Byzantine detection: a trusted validator must not sign two
+	// Track listed-but-untrusted signers too: a validator published by a
+	// configured list publisher but below the trust threshold gets its
+	// validations stored (untrusted — quorum and trie filter on the trusted
+	// set at read time), so a later trust change promotes what was already
+	// seen instead of waiting one validation interval for a fresh one.
+	// Publisher lists bound the key space, so this can't grow unboundedly.
+	tracked := trusted
+	if !tracked && e.listedOracle != nil {
+		tracked = e.listedOracle.IsListed(validation.NodeID)
+	}
+
+	// Operator [relay_validations] stance: "all" (the default, matching
+	// rippled) also forwards verified, current validations signed outside
+	// our UNL, so peers with a different UNL that do trust the signer still
+	// receive them.
+	relay := trusted || (e.relayPolicy != nil && e.relayPolicy.RelayUntrustedValidations())
+
+	// Same-seq Byzantine detection: a tracked validator must not sign two
 	// ledgers (or re-sign differently) for one seq. On conflict, keep it out
 	// of quorum/trie but STILL relay it (peers should observe it too) and
 	// charge no one. The returned error only tells the router to skip the
 	// catch-up acquire — not to penalise the relaying peer.
-	if trusted && e.validationTracker != nil {
+	if tracked && e.validationTracker != nil {
 		if reason, conflict := validationConflict(
 			e.validationTracker.GetLatestValidation(validation.NodeID),
 			validation,
 		); conflict {
-			e.adaptor.RelayValidation(validation, originPeer)
-			return &consensus.ByzantineValidationError{NodeID: validation.NodeID, Reason: reason}
+			if relay {
+				e.adaptor.RelayValidation(validation, originPeer)
+			}
+			return &consensus.ByzantineValidationError{NodeID: validation.NodeID, Reason: reason, Trusted: trusted}
 		}
 	}
 
-	// Store trusted-only: an untrusted key could grow the map unboundedly.
+	// Round-scoped bookkeeping stays trusted-only.
 	if trusted {
 		e.proposalTracker.SetValidation(validation)
 	}
 
 	// Feed the tracker — the gate that advances validated_ledger once a
 	// quorum of trusted FULL validations accumulates (partials steer the trie
-	// but don't count). Trust-gate to avoid a byNode entry per untrusted key.
-	if trusted && e.validationTracker != nil {
+	// but don't count). Untrusted keys must be listed to get a byNode entry.
+	if tracked && e.validationTracker != nil {
 		e.validationTracker.Add(validation)
 	}
 
@@ -851,9 +903,7 @@ func (e *Engine) OnValidation(validation *consensus.Validation, originPeer uint6
 		Timestamp:  e.adaptor.Now(),
 	})
 
-	// Relay trusted validations (excluding origin); drop untrusted for the
-	// same spam reason as OnProposal.
-	if trusted {
+	if relay {
 		e.adaptor.RelayValidation(validation, originPeer)
 	}
 

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -92,6 +92,17 @@ type mockAdaptor struct {
 	trusted map[consensus.NodeID]bool
 	quorum  int
 
+	// listed backs the optional ListedOracle; nil/empty = nothing listed.
+	listed map[consensus.NodeID]bool
+
+	// relayUntrusted backs the optional ValidationRelayPolicy. Defaults
+	// false so pre-existing tests keep trusted-only relay semantics.
+	relayUntrusted bool
+
+	// trustChanged is the engine's TrustChangeNotifier callback, captured
+	// at Start; tests fire it via notifyTrustChanged.
+	trustChanged func()
+
 	// Data stores
 	ledgers map[consensus.LedgerID]consensus.Ledger
 	txSets  map[consensus.TxSetID]consensus.TxSet
@@ -613,6 +624,48 @@ func (a *mockAdaptor) setTrusted(nodes []consensus.NodeID) {
 	a.trusted = make(map[consensus.NodeID]bool)
 	for _, n := range nodes {
 		a.trusted[n] = true
+	}
+}
+
+func (a *mockAdaptor) setListed(nodes []consensus.NodeID) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.listed = make(map[consensus.NodeID]bool)
+	for _, n := range nodes {
+		a.listed[n] = true
+	}
+}
+
+// IsListed implements the optional consensus.ListedOracle.
+func (a *mockAdaptor) IsListed(nodeID consensus.NodeID) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.listed[nodeID]
+}
+
+// RelayUntrustedValidations implements the optional
+// consensus.ValidationRelayPolicy.
+func (a *mockAdaptor) RelayUntrustedValidations() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.relayUntrusted
+}
+
+// OnTrustChanged implements the optional consensus.TrustChangeNotifier.
+func (a *mockAdaptor) OnTrustChanged(fn func()) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.trustChanged = fn
+}
+
+// notifyTrustChanged fires the engine's registered trust-change callback,
+// standing in for the production SetTrustedValidators tail.
+func (a *mockAdaptor) notifyTrustChanged() {
+	a.mu.RLock()
+	fn := a.trustChanged
+	a.mu.RUnlock()
+	if fn != nil {
+		fn()
 	}
 }
 

--- a/internal/consensus/rcl/engine_untrusted_validations_test.go
+++ b/internal/consensus/rcl/engine_untrusted_validations_test.go
@@ -1,0 +1,154 @@
+package rcl
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+)
+
+// startedEngine builds and starts an engine over adaptor, registering
+// cleanup. Tests drive it via OnValidation directly.
+func startedEngine(t *testing.T, adaptor *mockAdaptor) *Engine {
+	t.Helper()
+	engine := NewEngine(adaptor, DefaultConfig())
+	if err := engine.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { engine.Stop() })
+	return engine
+}
+
+func (a *mockAdaptor) relayedValidations() []*consensus.Validation {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return append([]*consensus.Validation(nil), a.validationsRelayed...)
+}
+
+// TestEngine_OnValidation_ListedUntrustedStoredAndPromoted pins the #1192
+// contract end-to-end: a validation from a listed-but-untrusted signer is
+// stored (byNode tip present) without counting toward quorum, and a
+// subsequent trust change — delivered through the TrustChangeNotifier hook,
+// not an accepted ledger — promotes the already-stored validation into the
+// trusted count, mirroring rippled's trustChanged.
+func TestEngine_OnValidation_ListedUntrustedStoredAndPromoted(t *testing.T) {
+	adaptor := newMockAdaptor()
+	nL := consensus.NodeID{0x11}
+	adaptor.setListed([]consensus.NodeID{nL})
+	engine := startedEngine(t, adaptor)
+
+	now := adaptor.Now()
+	ledgerA := consensus.LedgerID{0xA}
+	v := &consensus.Validation{LedgerSeq: 200, LedgerID: ledgerA, NodeID: nL, SignTime: now, SeenTime: now, Full: true}
+	if err := engine.OnValidation(v, 3); err != nil {
+		t.Fatalf("listed-untrusted validation rejected: %v", err)
+	}
+
+	// Stored but untrusted: tip tracked, quorum count zero, no relay under
+	// the default (mock) trusted-only relay policy.
+	if tip := engine.validationTracker.GetLatestValidation(nL); tip == nil || tip.LedgerID != ledgerA {
+		t.Fatalf("listed-untrusted validation must be stored; got %+v", tip)
+	}
+	if got := engine.validationTracker.GetTrustedValidationCount(ledgerA); got != 0 {
+		t.Errorf("untrusted validation must not count toward quorum: got %d, want 0", got)
+	}
+	if relayed := adaptor.relayedValidations(); len(relayed) != 0 {
+		t.Errorf("untrusted validation must not relay under trusted-only policy: %d relayed", len(relayed))
+	}
+
+	// Promote: the validator enters the UNL and the adaptor fires the
+	// trust-change hook the engine registered at Start.
+	adaptor.setTrusted([]consensus.NodeID{nL})
+	adaptor.notifyTrustChanged()
+
+	if got := engine.validationTracker.GetTrustedValidationCount(ledgerA); got != 1 {
+		t.Errorf("stored validation must count after trust promotion: got %d, want 1", got)
+	}
+}
+
+// TestEngine_OnValidation_UnlistedUntrustedNotStored: without a listing, an
+// untrusted signer gets no byNode entry — the unbounded-growth guard stays.
+func TestEngine_OnValidation_UnlistedUntrustedNotStored(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.relayUntrusted = true // storage must not piggyback on the relay stance
+	nU := consensus.NodeID{0x22}
+	engine := startedEngine(t, adaptor)
+
+	now := adaptor.Now()
+	v := &consensus.Validation{LedgerSeq: 200, LedgerID: consensus.LedgerID{0xA}, NodeID: nU, SignTime: now, SeenTime: now, Full: true}
+	if err := engine.OnValidation(v, 3); err != nil {
+		t.Fatalf("unlisted validation errored: %v", err)
+	}
+	if tip := engine.validationTracker.GetLatestValidation(nU); tip != nil {
+		t.Errorf("unlisted-untrusted validation must not be stored; got %+v", tip)
+	}
+}
+
+// TestEngine_OnValidation_RelayUntrustedPolicy pins the #1206 contract: with
+// the [relay_validations]=all stance an untrusted (even unlisted) verified
+// validation is forwarded — rippled's RELAY_UNTRUSTED_VALIDATIONS=1 default —
+// while the trusted-only stance keeps the old drop.
+func TestEngine_OnValidation_RelayUntrustedPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		relayUntrusted bool
+		wantRelayed    int
+	}{
+		{"all relays untrusted", true, 1},
+		{"trusted-only drops untrusted", false, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			adaptor := newMockAdaptor()
+			adaptor.relayUntrusted = tc.relayUntrusted
+			engine := startedEngine(t, adaptor)
+
+			now := adaptor.Now()
+			v := &consensus.Validation{LedgerSeq: 200, LedgerID: consensus.LedgerID{0xA}, NodeID: consensus.NodeID{0x22}, SignTime: now, SeenTime: now, Full: true}
+			if err := engine.OnValidation(v, 3); err != nil {
+				t.Fatalf("OnValidation: %v", err)
+			}
+			if got := len(adaptor.relayedValidations()); got != tc.wantRelayed {
+				t.Errorf("relayed = %d, want %d", got, tc.wantRelayed)
+			}
+		})
+	}
+}
+
+// TestEngine_OnValidation_ListedUntrustedDoubleSign: same-seq double-signs
+// from listed-but-untrusted validators are detected against their stored tip
+// and surfaced with Trusted=false so the router logs at info, not error.
+// Under the relay-all stance the conflicting validation still forwards.
+func TestEngine_OnValidation_ListedUntrustedDoubleSign(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.relayUntrusted = true
+	nL := consensus.NodeID{0x11}
+	adaptor.setListed([]consensus.NodeID{nL})
+	engine := startedEngine(t, adaptor)
+
+	now := adaptor.Now()
+	v1 := &consensus.Validation{LedgerSeq: 100, LedgerID: consensus.LedgerID{0xA}, NodeID: nL, SignTime: now, SeenTime: now, Full: true}
+	if err := engine.OnValidation(v1, 7); err != nil {
+		t.Fatalf("first validation rejected: %v", err)
+	}
+
+	v2 := &consensus.Validation{LedgerSeq: 100, LedgerID: consensus.LedgerID{0xB}, NodeID: nL, SignTime: now, SeenTime: now, Full: true}
+	err := engine.OnValidation(v2, 7)
+	var bv *consensus.ByzantineValidationError
+	if !errors.As(err, &bv) {
+		t.Fatalf("expected *consensus.ByzantineValidationError, got %v", err)
+	}
+	if bv.Trusted {
+		t.Errorf("Trusted = true for an untrusted double-signer")
+	}
+
+	var relayedConflict bool
+	for _, v := range adaptor.relayedValidations() {
+		if v.LedgerID == (consensus.LedgerID{0xB}) {
+			relayedConflict = true
+		}
+	}
+	if !relayedConflict {
+		t.Errorf("conflicting untrusted validation must still relay under the all stance")
+	}
+}

--- a/internal/consensus/types.go
+++ b/internal/consensus/types.go
@@ -342,6 +342,10 @@ type ByzantineValidationError struct {
 	// different sign time) or "multiple" (same ledger and sign time but a
 	// different cookie — probably accidental misconfiguration).
 	Reason string
+	// Trusted reports whether the double-signing validator is in our UNL;
+	// the router logs trusted offenders at error and listed-but-untrusted
+	// ones at info, mirroring rippled's journal-level split.
+	Trusted bool
 }
 
 func (e *ByzantineValidationError) Error() string {

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
@@ -254,6 +255,15 @@ type Aggregator struct {
 	// when a publisher list update doesn't move any validator into or
 	// out of the union.
 	lastEmitted [][33]byte
+
+	// listed is the NodeID snapshot of every validator carried by at
+	// least one live publisher list (count >= 1 — rippled's "listed", as
+	// opposed to "trusted" at count >= threshold). Refreshed on every
+	// count recompute and published via atomic pointer: IsListed serves
+	// the consensus validation path, which runs under the engine's lock
+	// while the OnChange → SetTrustedValidators → engine trust-refresh
+	// chain runs under a.mu — reading a.mu here would be an ABBA deadlock.
+	listed atomic.Pointer[map[consensus.NodeID]struct{}]
 
 	// unlBlocked mirrors rippled's NetworkOPs unlBlocked_ (NetworkOPs.cpp:750):
 	// the sticky UNL lock-down. Maintained under a.mu by recomputeAndEmitLocked;
@@ -1094,7 +1104,9 @@ func (a *Aggregator) handleRevocation(pubKey PublisherKey) {
 
 // computeValidatorCountsLocked counts, per validator master key, how many
 // publishers with a live (available, effective, unexpired) list carry
-// it. Caller must hold a.mu and filters by threshold afterwards.
+// it. Caller must hold a.mu and filters by threshold afterwards. As a
+// side effect the listed-NodeID snapshot is republished, so IsListed
+// tracks every count recompute (ingest, Tick, trusted-set reads).
 func (a *Aggregator) computeValidatorCountsLocked(now time.Time) map[[33]byte]int {
 	counts := make(map[[33]byte]int, 64)
 	for _, s := range a.state {
@@ -1118,7 +1130,25 @@ func (a *Aggregator) computeValidatorCountsLocked(now time.Time) map[[33]byte]in
 			counts[k]++
 		}
 	}
+	listed := make(map[consensus.NodeID]struct{}, len(counts))
+	for k := range counts {
+		listed[consensus.CalcNodeID(k)] = struct{}{}
+	}
+	a.listed.Store(&listed)
 	return counts
+}
+
+// IsListed reports whether node's master key appears in at least one live
+// publisher list — rippled's ValidatorList::listed, one tier below trusted.
+// Lock-free (atomic snapshot) so the consensus validation path can query it
+// without ordering against a.mu.
+func (a *Aggregator) IsListed(node consensus.NodeID) bool {
+	listed := a.listed.Load()
+	if listed == nil {
+		return false
+	}
+	_, ok := (*listed)[node]
+	return ok
 }
 
 // recomputeAndEmitLocked walks the per-publisher state, computes the

--- a/internal/validator/list/listed_test.go
+++ b/internal/validator/list/listed_test.go
@@ -1,0 +1,60 @@
+package list
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+)
+
+// TestAggregator_IsListed pins the listed-vs-trusted split: a validator
+// carried by one live publisher list is listed the moment counts recompute,
+// even while it stays below the trust threshold, and delists once the
+// carrying publisher stops contributing.
+func TestAggregator_IsListed(t *testing.T) {
+	pk1 := PublisherKey{1}
+	pk2 := PublisherKey{2}
+	k1 := [33]byte{9}
+	nid := consensus.CalcNodeID(k1)
+	now := time.Unix(1000, 0)
+
+	a := &Aggregator{
+		publishers: map[PublisherKey]struct{}{pk1: {}, pk2: {}},
+		state: map[PublisherKey]*PublisherState{
+			pk1: {MasterKey: pk1, Status: StatusUnavailable},
+			pk2: {MasterKey: pk2, Status: StatusUnavailable},
+		},
+		threshold: 2,
+		clock:     func() time.Time { return now },
+	}
+
+	if a.IsListed(nid) {
+		t.Fatal("nothing is listed before any count recompute")
+	}
+
+	// One live publisher carries k1: below the threshold of 2 (untrusted)
+	// but listed.
+	s := a.state[pk1]
+	s.Status = StatusAvailable
+	s.Validators = [][33]byte{k1}
+	s.Expiration = now.Add(time.Hour)
+	a.Tick()
+
+	if !a.IsListed(nid) {
+		t.Fatal("validator carried by a live publisher list must be listed")
+	}
+	if nodes, _ := a.TrustedValidators(); len(nodes) != 0 {
+		t.Fatalf("one listing below threshold 2 must not be trusted; got %d", len(nodes))
+	}
+	if a.IsListed(consensus.NodeID{0x77}) {
+		t.Fatal("unknown validator must not be listed")
+	}
+
+	// The carrying list expires → the validator delists on the next
+	// recompute.
+	s.Expiration = now.Add(-time.Minute)
+	a.Tick()
+	if a.IsListed(nid) {
+		t.Fatal("validator must delist once its only carrying list expires")
+	}
+}


### PR DESCRIPTION
## Summary
- **Storage + trust promotion (#1192):** the engine now stores validations from listed-but-untrusted signers (rippled `handleNewValidation` stores any trusted-or-listed signer, keyed by the manifest-resolved master ID). The tracker's quorum and trie already filter on the trusted set at read time, so a runtime UNL change promotes what was already seen — delivered immediately through a new `TrustChangeNotifier` hook (`SetTrustedValidators` → engine tracker refresh), mirroring rippled's `trustChanged` instead of waiting for the next accepted ledger. `Aggregator.IsListed` (lock-free atomic snapshot, refreshed on every count recompute) bounds the stored key space to the published lists.
- **Untrusted-validation relay (#1206):** the already-parsed-but-unwired `[relay_validations]` config knob now drives behavior: `all` (default, rippled's `RELAY_UNTRUSTED_VALIDATIONS = 1`) relays verified current validations from outside the UNL; `trusted` keeps trusted-only relay; `drop_untrusted` sheds untrusted validations at the router before signature verification (rippled's `-1` PeerImp pre-verify drop).
- Same-seq double-sign detection now also covers listed-untrusted signers; `ByzantineValidationError` carries `Trusted` so the router logs trusted offenders at error and untrusted at info, matching rippled's journal-level split. Byzantine validations still forward under the relay policy.

## Test plan
- [x] `go test ./internal/consensus/... ./internal/validator/... ./config/...` — all green
- [x] New tests: listed-untrusted stored + promoted on trust change, unlisted-untrusted not stored, relay policy matrix (engine relay gate + router pre-verify drop + trusted passthrough), listed-untrusted double-sign, `Aggregator.IsListed` listed-vs-trusted split, `SetTrustedValidators` trust-change callback, policy parsing/accessors
- [x] `go build ./...`, `go vet`, `golangci-lint run --config .golangci.yml ./...` (strict CI config) — 0 issues

Fixes #1192
Fixes #1206