### PR TITLE
fix: gate inbound validations on sign-time freshness before relay

### DIFF
--- a/internal/consensus/adaptor/converter.go
+++ b/internal/consensus/adaptor/converter.go
@@ -56,13 +56,15 @@ func ProposalToMessage(p *consensus.Proposal) *message.ProposeSet {
 }
 
 // ValidationFromMessage parses a decoded Validation message (containing an
-// XRPL-binary-encoded STValidation) into a consensus.Validation.
-func ValidationFromMessage(msg *message.Validation) (*consensus.Validation, error) {
+// XRPL-binary-encoded STValidation) into a consensus.Validation. seen
+// becomes the validation's SeenTime; pass the network-adjusted clock so
+// freshness checks compare it against the same clock they gate on.
+func ValidationFromMessage(msg *message.Validation, seen time.Time) (*consensus.Validation, error) {
 	v, err := parseSTValidation(msg.Validation)
 	if err != nil {
 		return nil, err
 	}
-	v.SeenTime = time.Now()
+	v.SeenTime = seen
 	return v, nil
 }
 

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/consensus/rcl"
 	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
@@ -212,6 +213,20 @@ func (r *Router) handleValidation(msg *peermanagement.InboundMessage) {
 		r.logger.Debug("dropping malformed validation",
 			"peer", msg.PeerID, "bad_field", badField)
 		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "validation-malformed-"+badField)
+		return
+	}
+
+	// Ingress freshness gate: charge and drop a stale or future-dated
+	// validation before suppression/relay, mirroring rippled's PeerImp
+	// isCurrent check right after deserialization. The tracker applies
+	// the same window for quorum/trie accounting, but by the time it
+	// runs the engine has already relayed the validation.
+	if !rcl.IsCurrent(r.adaptor.Now(), validation.SignTime, validation.SeenTime) {
+		r.logger.Debug("dropping non-current validation",
+			"peer", msg.PeerID,
+			"seq", validation.LedgerSeq,
+			"sign_time", validation.SignTime)
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "validation-not-current")
 		return
 	}
 

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -199,7 +199,7 @@ func (r *Router) handleValidation(msg *peermanagement.InboundMessage) {
 		return
 	}
 
-	validation, err := ValidationFromMessage(val)
+	validation, err := ValidationFromMessage(val, r.adaptor.Now())
 	if err != nil {
 		r.logger.Warn("failed to parse validation", "error", err, "peer", msg.PeerID)
 		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "validation-parse")

--- a/internal/consensus/adaptor/router_resolve_master_nodeid_test.go
+++ b/internal/consensus/adaptor/router_resolve_master_nodeid_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
-	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,7 +46,7 @@ func TestRouter_ResolveMasterNodeID_Validation_RewritesToMaster(t *testing.T) {
 	v := &consensus.Validation{
 		Full:      true,
 		LedgerSeq: 99,
-		SignTime:  time.Unix(protocol.RippleEpochUnix+12345, 0),
+		SignTime:  time.Now(),
 	}
 	for i := range v.LedgerID {
 		v.LedgerID[i] = byte(i + 1)
@@ -108,7 +107,7 @@ func TestRouter_ResolveMasterNodeID_Validation_NoMappingPreservesSigning(t *test
 	v := &consensus.Validation{
 		Full:      true,
 		LedgerSeq: 100,
-		SignTime:  time.Unix(protocol.RippleEpochUnix+12345, 0),
+		SignTime:  time.Now(),
 	}
 	for i := range v.LedgerID {
 		v.LedgerID[i] = byte(i + 1)

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -14,7 +14,6 @@ import (
 	testenv "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
-	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -157,7 +156,7 @@ func TestRouterDispatchesValidation(t *testing.T) {
 	testVal := &consensus.Validation{
 		Full:      true,
 		LedgerSeq: 42,
-		SignTime:  time.Unix(protocol.RippleEpochUnix+828618000, 0), // XRPL epoch + offset
+		SignTime:  time.Now(),
 		LoadFee:   0,
 	}
 	copy(testVal.LedgerID[:], []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32})

--- a/internal/consensus/adaptor/router_validation_freshness_test.go
+++ b/internal/consensus/adaptor/router_validation_freshness_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// buildValidationAt serializes a minimal well-formed validation with the
-// given sign-time into an inbound TMValidation frame from peerID.
 func buildValidationAt(t *testing.T, peerID peermanagement.PeerID, signTime time.Time) *peermanagement.InboundMessage {
 	t.Helper()
 	key := [33]byte{0x02, 0x77}

--- a/internal/consensus/adaptor/router_validation_freshness_test.go
+++ b/internal/consensus/adaptor/router_validation_freshness_test.go
@@ -1,0 +1,76 @@
+package adaptor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildValidationAt serializes a minimal well-formed validation with the
+// given sign-time into an inbound TMValidation frame from peerID.
+func buildValidationAt(t *testing.T, peerID peermanagement.PeerID, signTime time.Time) *peermanagement.InboundMessage {
+	t.Helper()
+	key := [33]byte{0x02, 0x77}
+	v := &consensus.Validation{
+		Full:      true,
+		LedgerSeq: 42,
+		SignTime:  signTime,
+	}
+	v.LedgerID = consensus.LedgerID{1}
+	v.NodeID = consensus.CalcNodeID(key)
+	v.SigningPubKey = key
+	v.Signature = make([]byte, 70)
+	return &peermanagement.InboundMessage{
+		PeerID:  peerID,
+		Type:    uint16(message.TypeValidation),
+		Payload: encodePayload(t, &message.Validation{Validation: SerializeSTValidation(v)}),
+	}
+}
+
+// TestRouter_ValidationFreshnessGate: a non-current validation (sign-time
+// outside the IsCurrent window) must be charged and dropped at ingress —
+// before dedup, relay, and the engine — mirroring rippled's PeerImp
+// isCurrent check in onMessage(TMValidation). A current one passes
+// through uncharged.
+func TestRouter_ValidationFreshnessGate(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		signTime  time.Time
+		delivered bool
+	}{
+		{"stale sign-time dropped", time.Now().Add(-10 * time.Minute), false},
+		{"future sign-time dropped", time.Now().Add(10 * time.Minute), false},
+		{"current sign-time delivered", time.Now(), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := &mockEngine{}
+			identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+			require.NoError(t, err)
+			rs := &badDataRecordingSender{}
+			a := New(Config{
+				LedgerService: newTestLedgerService(t),
+				Sender:        rs,
+				Identity:      identity,
+			})
+			router := NewRouter(engine, a, make(chan *peermanagement.InboundMessage, 1))
+
+			router.handleValidation(buildValidationAt(t, 7, tc.signTime))
+
+			if tc.delivered {
+				require.Len(t, engine.getValidations(), 1, "current validation must reach the engine")
+				assert.Empty(t, rs.getBadDataCalls(), "current validation must not be charged")
+				return
+			}
+			assert.Empty(t, engine.getValidations(), "non-current validation must be shed before the engine")
+			calls := rs.getBadDataCalls()
+			require.Len(t, calls, 1)
+			assert.Equal(t, uint64(7), calls[0].peerID)
+			assert.Equal(t, "validation-not-current", calls[0].reason)
+		})
+	}
+}

--- a/internal/consensus/adaptor/stvalidation_test.go
+++ b/internal/consensus/adaptor/stvalidation_test.go
@@ -291,13 +291,14 @@ func TestValidationFromMessage_Integration(t *testing.T) {
 	blob := SerializeSTValidation(orig)
 
 	msg := &message.Validation{Validation: blob}
-	parsed, err := ValidationFromMessage(msg)
+	seen := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	parsed, err := ValidationFromMessage(msg, seen)
 	require.NoError(t, err)
 
 	assert.Equal(t, orig.LedgerSeq, parsed.LedgerSeq)
 	assert.Equal(t, orig.LedgerID, parsed.LedgerID)
 	assert.Equal(t, orig.Full, parsed.Full)
-	assert.NotZero(t, parsed.SeenTime) // should be set by ValidationFromMessage
+	assert.Equal(t, seen, parsed.SeenTime)
 }
 
 func TestSignSerializeParseVerify_Roundtrip(t *testing.T) {

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -255,10 +255,6 @@ const (
 //
 // `now` is the network-adjusted time from the adaptor so the freshness
 // window honors the close-offset consensus has converged on.
-//
-// Exported for the router's ingress gate, which drops non-current
-// validations before suppression/relay (rippled PeerImp does the same
-// immediately after deserialization).
 func IsCurrent(now, signTime, seenTime time.Time) bool {
 	// Past bound on signTime (rippled uses EARLY=3m here, NOT WALL=5m):
 	// a validation signed more than EARLY in the past is stale —

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -238,7 +238,7 @@ const (
 	validationCurrentEarly = 3 * time.Minute
 )
 
-// isCurrent reports whether a validation's sign-time and seen-time are
+// IsCurrent reports whether a validation's sign-time and seen-time are
 // close enough to now to be considered "current" in rippled's sense.
 // Exact mirror of Validations.h:148-166 isCurrent:
 //
@@ -255,7 +255,11 @@ const (
 //
 // `now` is the network-adjusted time from the adaptor so the freshness
 // window honors the close-offset consensus has converged on.
-func isCurrent(now, signTime, seenTime time.Time) bool {
+//
+// Exported for the router's ingress gate, which drops non-current
+// validations before suppression/relay (rippled PeerImp does the same
+// immediately after deserialization).
+func IsCurrent(now, signTime, seenTime time.Time) bool {
 	// Past bound on signTime (rippled uses EARLY=3m here, NOT WALL=5m):
 	// a validation signed more than EARLY in the past is stale —
 	// interoperating peers already moved on.
@@ -353,7 +357,7 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	// raw time.Now so the check honors the network-adjusted close
 	// offset and doesn't reject our own just-signed validations on a
 	// clock-skewed node.
-	if !isCurrent(vt.now(), validation.SignTime, validation.SeenTime) {
+	if !IsCurrent(vt.now(), validation.SignTime, validation.SeenTime) {
 		return false
 	}
 
@@ -793,7 +797,7 @@ func (vt *ValidationTracker) FlushStale() {
 	defer vt.mu.Unlock()
 	now := vt.now()
 	for nodeID, v := range vt.byNode {
-		if isCurrent(now, v.SignTime, v.SeenTime) {
+		if IsCurrent(now, v.SignTime, v.SeenTime) {
 			continue
 		}
 		delete(vt.byNode, nodeID)

--- a/internal/consensus/rcl/validations_test.go
+++ b/internal/consensus/rcl/validations_test.go
@@ -460,7 +460,7 @@ func TestIsCurrent_WindowBoundaries(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := isCurrent(now, tc.signTime, tc.seenTime)
+			got := IsCurrent(now, tc.signTime, tc.seenTime)
 			if got != tc.want {
 				t.Fatalf("isCurrent: got %v, want %v", got, tc.want)
 			}


### PR DESCRIPTION
## Summary
- rippled's `PeerImp::onMessage(TMValidation)` runs `isCurrent` right after deserialization: a stale or future-dated validation is charged `feeUselessData` and dropped **before** suppression/relay. go-xrpl applied that window only inside the rcl `ValidationTracker` (quorum/trie accounting), which runs after the engine has already gossip-relayed the validation — so a stale-but-correctly-signed trusted validation was still amplified across the network.
- Export `rcl.IsCurrent` (the existing exact mirror of `Validations.h` `isCurrent`) and apply it in `handleValidation` ingress against the network-adjusted `adaptor.Now()`, in rippled's exact position: after parse/bounds, before the untrusted-drop policy and suppression — so every stale copy is charged, matching rippled's pre-suppression return. The delivering peer is charged via `IncPeerBadData("validation-not-current")`, the same surface used for the validator-list useless-data charge.
- New `TestRouter_ValidationFreshnessGate` covers stale-dropped+charged, future-dropped+charged, and current-delivered-uncharged. Two existing router tests used historic sign-times (year-2000 and a fixed 2026-04 epoch offset) that the gate now correctly rejects; freshened to `time.Now()`.

## Test plan
- [x] `go test ./internal/consensus/... -count=1` — all pass
- [x] `just test-core` (ledger / txq / rpc / consensus / peermanagement) — exit 0
- [x] `golangci-lint run --config .golangci.yml ./internal/consensus/...` — 0 issues

Fixes #1208