### PR TITLE
fix: give disputed we-voted-NO txs first crack at the next open ledger

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -766,7 +766,7 @@ func (a *Adaptor) GetMaxDisallowedLedgerSeq() uint32 {
 	return a.maxDisallowedSeq
 }
 
-func (a *Adaptor) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, closeTime time.Time, closeTimeCorrect bool) (consensus.Ledger, error) {
+func (a *Adaptor) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, closeTime time.Time, closeTimeCorrect bool, disputedTxs [][]byte) (consensus.Ledger, error) {
 	// Unwrap the parent for the service. Critical for chain switching: the
 	// parent may differ from the service's closedLedger after wrong-ledger detection.
 	var parentLedger *ledger.Ledger
@@ -775,7 +775,7 @@ func (a *Adaptor) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, cl
 	}
 	// context.TODO: BuildLedger's interface has no context, so persistence
 	// here can't be cancelled by the engine (#185).
-	seq, err := a.ledgerService.AcceptConsensusResult(context.TODO(), parentLedger, txSet.Txs(), closeTime, closeTimeCorrect)
+	seq, err := a.ledgerService.AcceptConsensusResult(context.TODO(), parentLedger, txSet.Txs(), disputedTxs, closeTime, closeTimeCorrect)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/consensus/adaptor/adaptor_methods_cov_test.go
+++ b/internal/consensus/adaptor/adaptor_methods_cov_test.go
@@ -63,7 +63,7 @@ func TestAdg_BuildLedger(t *testing.T) {
 	txSet, err := a.BuildTxSet(nil)
 	require.NoError(t, err)
 
-	built, err := a.BuildLedger(lcl, txSet, time.Now(), true)
+	built, err := a.BuildLedger(lcl, txSet, time.Now(), true, nil)
 	require.NoError(t, err)
 	require.NotNil(t, built)
 	assert.Equal(t, lcl.Seq()+1, built.Seq())

--- a/internal/consensus/csf/engine_adaptor.go
+++ b/internal/consensus/csf/engine_adaptor.go
@@ -397,7 +397,7 @@ func (p *EnginePeer) GetMaxDisallowedLedgerSeq() uint32 {
 	return 0
 }
 
-func (p *EnginePeer) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, closeTime time.Time, _ bool) (consensus.Ledger, error) {
+func (p *EnginePeer) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, closeTime time.Time, _ bool, _ [][]byte) (consensus.Ledger, error) {
 	l := buildSimLedger(parent.ID(), parent.Seq()+1, txSet.ID(), closeTime)
 	p.mu.Lock()
 	p.ledgers[l.id] = l

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -159,9 +159,7 @@ type LedgerProvider interface {
 
 	// BuildLedger closes a ledger from the agreed tx set on parent.
 	// disputedTxs are the raw blobs of the round's disputed txs we voted NO
-	// on; they are replayed into the next open ledger ahead of the queue —
-	// first crack goes to txs proposed by trusted validators but excluded
-	// from the consensus set.
+	// on; they are replayed into the next open ledger ahead of the queue.
 	BuildLedger(parent Ledger, txSet TxSet, closeTime time.Time, closeTimeCorrect bool, disputedTxs [][]byte) (Ledger, error)
 
 	ValidateLedger(ledger Ledger) error

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -157,7 +157,12 @@ type LedgerProvider interface {
 	// across restarts). Immutable after startup.
 	GetMaxDisallowedLedgerSeq() uint32
 
-	BuildLedger(parent Ledger, txSet TxSet, closeTime time.Time, closeTimeCorrect bool) (Ledger, error)
+	// BuildLedger closes a ledger from the agreed tx set on parent.
+	// disputedTxs are the raw blobs of the round's disputed txs we voted NO
+	// on; they are replayed into the next open ledger ahead of the queue —
+	// first crack goes to txs proposed by trusted validators but excluded
+	// from the consensus set.
+	BuildLedger(parent Ledger, txSet TxSet, closeTime time.Time, closeTimeCorrect bool, disputedTxs [][]byte) (Ledger, error)
 
 	ValidateLedger(ledger Ledger) error
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -3158,11 +3158,12 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 	// goroutine parks its round-driving until the commit tail runs.
 	prevLedger := e.prevLedger
 	closeTimeCorrect := e.closeTime.haveConsensus
+	disputedNoTxs := e.disputeTracker.DisputedNoTxs()
 	e.buildInProgress = true
 	e.setPhase(consensus.PhaseAccepted)
 
 	e.mu.Unlock()
-	newLedger, err := e.adaptor.BuildLedger(prevLedger, txSet, closeTime, closeTimeCorrect)
+	newLedger, err := e.adaptor.BuildLedger(prevLedger, txSet, closeTime, closeTimeCorrect, disputedNoTxs)
 	if err == nil {
 		if err = e.adaptor.ValidateLedger(newLedger); err == nil {
 			err = e.adaptor.StoreLedger(newLedger)

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -294,7 +294,7 @@ func (a *mockAdaptor) GetLastClosedLedger() (consensus.Ledger, error) {
 	return a.lastLCL, nil
 }
 
-func (a *mockAdaptor) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, closeTime time.Time, _ bool) (consensus.Ledger, error) {
+func (a *mockAdaptor) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, closeTime time.Time, _ bool, _ [][]byte) (consensus.Ledger, error) {
 	a.mu.RLock()
 	hook := a.buildLedgerHook
 	a.mu.RUnlock()

--- a/internal/consensus/rcl/proposals.go
+++ b/internal/consensus/rcl/proposals.go
@@ -318,8 +318,7 @@ func (dt *DisputeTracker) Has(txID consensus.TxID) bool {
 }
 
 // DisputedNoTxs returns the raw blobs of every dispute we currently vote NO
-// on — txs peers proposed that end up excluded from the consensus set. The
-// accept path replays them into the next open ledger ahead of the queue.
+// on — txs peers proposed that end up excluded from the consensus set.
 func (dt *DisputeTracker) DisputedNoTxs() [][]byte {
 	dt.mu.RLock()
 	defer dt.mu.RUnlock()

--- a/internal/consensus/rcl/proposals.go
+++ b/internal/consensus/rcl/proposals.go
@@ -317,6 +317,22 @@ func (dt *DisputeTracker) Has(txID consensus.TxID) bool {
 	return ok
 }
 
+// DisputedNoTxs returns the raw blobs of every dispute we currently vote NO
+// on — txs peers proposed that end up excluded from the consensus set. The
+// accept path replays them into the next open ledger ahead of the queue.
+func (dt *DisputeTracker) DisputedNoTxs() [][]byte {
+	dt.mu.RLock()
+	defer dt.mu.RUnlock()
+
+	var txs [][]byte
+	for _, d := range dt.disputes {
+		if !d.OurVote {
+			txs = append(txs, d.Tx)
+		}
+	}
+	return txs
+}
+
 // GetAll returns all disputed transactions.
 func (dt *DisputeTracker) GetAll() []*consensus.DisputedTx {
 	dt.mu.RLock()

--- a/internal/ledger/service/close_flags_test.go
+++ b/internal/ledger/service/close_flags_test.go
@@ -59,7 +59,7 @@ func closeAndGetHeader(t *testing.T, closeTimeCorrect bool) header.LedgerHeader 
 	require.NotNil(t, parent)
 	closeTime := time.Unix(1700000000, 0)
 
-	_, err = svc.AcceptConsensusResult(context.TODO(), parent, nil, closeTime, closeTimeCorrect)
+	_, err = svc.AcceptConsensusResult(context.TODO(), parent, nil, nil, closeTime, closeTimeCorrect)
 	require.NoError(t, err)
 
 	svc.mu.RLock()

--- a/internal/ledger/service/empty_set_txroot_test.go
+++ b/internal/ledger/service/empty_set_txroot_test.go
@@ -27,7 +27,7 @@ func TestAcceptConsensusResult_EmptySetClosesWithZeroTxRoot(t *testing.T) {
 	parent := svc.GetClosedLedger()
 	require.NotNil(t, parent)
 
-	_, err = svc.AcceptConsensusResult(context.TODO(), parent, nil, time.Unix(1700000000, 0), true)
+	_, err = svc.AcceptConsensusResult(context.TODO(), parent, nil, nil, time.Unix(1700000000, 0), true)
 	require.NoError(t, err)
 
 	svc.mu.RLock()

--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -447,11 +447,9 @@ func (s *Service) AcceptConsensusResult(ctx context.Context, parent *ledger.Ledg
 		return 0, err
 	}
 
-	// Merge the disputed we-voted-NO txs into the retriable set so they are
-	// replayed into the new open ledger ahead of the TxQ. Pseudo-txs can't
-	// succeed in a later ledger; malformed blobs are dropped. The merged set
-	// is re-sorted with the agreed set's SHAMap root as salt, matching the
-	// canonical order rippled's retriable set applies in.
+	// Pseudo-txs can't succeed in a later ledger; malformed blobs are
+	// dropped. The merged set is re-sorted with the agreed set's SHAMap root
+	// as salt, matching the canonical order rippled's retriable set applies in.
 	if len(disputedBlobs) > 0 {
 		seen := make(map[[32]byte]struct{}, len(retriableTxs))
 		for _, ptx := range retriableTxs {

--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -208,7 +208,11 @@ func (s *Service) advanceToNewOpenLedgerLocked(closedSeq uint32, closedLedgerHas
 	s.processClosedLedgerLocked()
 
 	// LCL transition: replay the prior view's txs via Accept, retries-first for
-	// the build pass's retry set (a harmless superset of rippled's disputed set).
+	// retriableTxs (disputed we-voted-NO txs plus the build pass's leftovers).
+	// rippled gates retries-first on disputes alone, but its retry loop drains
+	// the shared retriable set during the current-view replay either way;
+	// ApplyTxs never re-applies pre-existing retries, so the first pass must
+	// run whenever the set is non-empty or the leftovers would be dropped.
 	s.acceptOpenLedgerViewLocked(closedSeq, retriableTxs, len(retriableTxs) > 0)
 
 	ledgerInfo := &LedgerInfo{
@@ -390,7 +394,10 @@ func (s *Service) fixMismatchLocked(adopted *ledger.Ledger) {
 // doesn't require standalone, and does NOT auto-validate (the validation tracker
 // does). parent is the ledger to build on; when consensus switches chains it may
 // differ from s.closedLedger, and the service resets state accordingly.
-func (s *Service) AcceptConsensusResult(ctx context.Context, parent *ledger.Ledger, txBlobs [][]byte, closeTime time.Time, closeTimeCorrect bool) (uint32, error) {
+// disputedBlobs are the round's disputed txs we voted NO on (peer-proposed,
+// excluded from the agreed set); they get first crack at the new open ledger,
+// ahead of the TxQ.
+func (s *Service) AcceptConsensusResult(ctx context.Context, parent *ledger.Ledger, txBlobs, disputedBlobs [][]byte, closeTime time.Time, closeTimeCorrect bool) (uint32, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -438,6 +445,37 @@ func (s *Service) AcceptConsensusResult(ctx context.Context, parent *ledger.Ledg
 	retriableTxs, err := s.buildClosedLedgerLocked(pending, closeTime, false)
 	if err != nil {
 		return 0, err
+	}
+
+	// Merge the disputed we-voted-NO txs into the retriable set so they are
+	// replayed into the new open ledger ahead of the TxQ. Pseudo-txs can't
+	// succeed in a later ledger; malformed blobs are dropped. The merged set
+	// is re-sorted with the agreed set's SHAMap root as salt, matching the
+	// canonical order rippled's retriable set applies in.
+	if len(disputedBlobs) > 0 {
+		seen := make(map[[32]byte]struct{}, len(retriableTxs))
+		for _, ptx := range retriableTxs {
+			seen[ptx.Hash] = struct{}{}
+		}
+		added := false
+		for _, blob := range disputedBlobs {
+			ptx, perr := parsePendingTx(blob)
+			if perr != nil {
+				continue
+			}
+			if ptx.Parsed.TxType().IsPseudoTransaction() {
+				continue
+			}
+			if _, dup := seen[ptx.Hash]; dup {
+				continue
+			}
+			seen[ptx.Hash] = struct{}{}
+			retriableTxs = append(retriableTxs, ptx)
+			added = true
+		}
+		if added {
+			canonicalSort(retriableTxs, computeSalt(pending))
+		}
 	}
 
 	// pending is now in canonical order for the round-summary log.

--- a/internal/ledger/service/negative_unl_close_test.go
+++ b/internal/ledger/service/negative_unl_close_test.go
@@ -80,7 +80,7 @@ func TestAcceptConsensusResult_FlagLedgerAppliesNegativeUNL(t *testing.T) {
 	// Build the flag ledger (seq 256) through the consensus path with an EMPTY
 	// tx set — the sub-path that skipped the transition before this fix.
 	closeTime = closeTime.Add(2 * time.Second)
-	seq, err := svc.AcceptConsensusResult(context.TODO(), open255, nil, closeTime, true)
+	seq, err := svc.AcceptConsensusResult(context.TODO(), open255, nil, nil, closeTime, true)
 	if err != nil {
 		t.Fatalf("flag-ledger consensus close: %v", err)
 	}

--- a/internal/ledger/service/pending_ledger_validation_test.go
+++ b/internal/ledger/service/pending_ledger_validation_test.go
@@ -456,7 +456,7 @@ func TestAcceptConsensusResult_EventCallbackFiresAfterValidationFirstRace(t *tes
 	probeSvc, err := New(DefaultConfig())
 	require.NoError(t, err)
 	require.NoError(t, probeSvc.Start())
-	_, err = probeSvc.AcceptConsensusResult(context.TODO(), parentReal, nil, closeTime, true)
+	_, err = probeSvc.AcceptConsensusResult(context.TODO(), parentReal, nil, nil, closeTime, true)
 	require.NoError(t, err)
 
 	probeSvc.mu.RLock()
@@ -476,7 +476,7 @@ func TestAcceptConsensusResult_EventCallbackFiresAfterValidationFirstRace(t *tes
 	// Close the consensus ledger. F4 drain sees the matching-hash,
 	// non-expired stash and promotes validatedLedger. eventCallback MUST
 	// fire inline because no later SetValidatedLedger will arrive.
-	closedSeq, err := svc.AcceptConsensusResult(context.TODO(), parentReal, nil, closeTime, true)
+	closedSeq, err := svc.AcceptConsensusResult(context.TODO(), parentReal, nil, nil, closeTime, true)
 	require.NoError(t, err)
 	require.Equal(t, expectedSeq, closedSeq)
 

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -552,10 +552,10 @@ func (s *Service) tickLoadFeeLocked() {
 }
 
 // acceptOpenLedgerViewLocked invokes OpenLedger.Accept on the LCL transition to
-// s.closedLedger. No-op pre-Start. buildRetries are the build pass's retry-state
-// txs, replayed first; anyDisputes is the retriesFirst flag. closedSeq is for log
-// context only. Caller must hold s.mu.
-func (s *Service) acceptOpenLedgerViewLocked(closedSeq uint32, buildRetries []openledger.PendingTx, anyDisputes bool) {
+// s.closedLedger. No-op pre-Start. retriableTxs are the disputed we-voted-NO txs
+// plus the build pass's retry-state txs, replayed first; anyDisputes is the
+// retriesFirst flag. closedSeq is for log context only. Caller must hold s.mu.
+func (s *Service) acceptOpenLedgerViewLocked(closedSeq uint32, retriableTxs []openledger.PendingTx, anyDisputes bool) {
 	if s.openLedgerView == nil {
 		return
 	}
@@ -589,8 +589,8 @@ func (s *Service) acceptOpenLedgerViewLocked(closedSeq uint32, buildRetries []op
 	if s.localTxs != nil {
 		locals = s.localTxs.GetTxSet()
 	}
-	// Seed retries with the build-pass leftovers; Accept drains then re-fills it.
-	retries := append([]openledger.PendingTx(nil), buildRetries...)
+	// Seed retries with the disputed/build-pass set; Accept drains then re-fills it.
+	retries := append([]openledger.PendingTx(nil), retriableTxs...)
 	relay := s.txRelay
 	relayCB := func(_ [32]byte, blob []byte) {
 		if relay != nil {

--- a/internal/ledger/service/service_openledger_test.go
+++ b/internal/ledger/service/service_openledger_test.go
@@ -4,15 +4,18 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"strings"
 	"testing"
 	"time"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	consensuscommon "github.com/LeJamon/go-xrpl/internal/consensus/common"
 	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	testenv "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
 )
 
 // buildSignedPaymentBlob constructs a signed Payment binary blob from sender
@@ -137,7 +140,7 @@ func TestService_AcceptConsensusResult_RebuildsOpenView(t *testing.T) {
 	if parent == nil {
 		t.Fatal("GetClosedLedger nil before AcceptConsensusResult")
 	}
-	if _, err := svc.AcceptConsensusResult(context.TODO(), parent, nil, time.Now(), true); err != nil {
+	if _, err := svc.AcceptConsensusResult(context.TODO(), parent, nil, nil, time.Now(), true); err != nil {
 		t.Fatalf("AcceptConsensusResult: %v", err)
 	}
 
@@ -175,7 +178,7 @@ func TestService_AcceptConsensusResult_IncludedTxsNotDuplicated(t *testing.T) {
 	if parent == nil {
 		t.Fatal("GetClosedLedger nil before AcceptConsensusResult")
 	}
-	if _, err := svc.AcceptConsensusResult(context.TODO(), parent, [][]byte{blob1}, time.Now(), true); err != nil {
+	if _, err := svc.AcceptConsensusResult(context.TODO(), parent, [][]byte{blob1}, nil, time.Now(), true); err != nil {
 		t.Fatalf("AcceptConsensusResult: %v", err)
 	}
 
@@ -188,6 +191,77 @@ func TestService_AcceptConsensusResult_IncludedTxsNotDuplicated(t *testing.T) {
 	}
 	if svc.OpenLedgerHasTx(hash1) {
 		t.Errorf("post-Accept open view still contains tx1 (already in closed ledger)")
+	}
+	if got := svc.OpenLedgerTxs(); len(got) != 0 {
+		t.Errorf("post-Accept OpenLedgerTxs len = %d, want 0", len(got))
+	}
+}
+
+// TestService_AcceptConsensusResult_DisputedTxsFirstCrack verifies that a
+// disputed tx we voted NO on — peer-proposed, never in our open ledger —
+// is replayed into the fresh open view on the LCL transition, not into the
+// closed ledger.
+func TestService_AcceptConsensusResult_DisputedTxsFirstCrack(t *testing.T) {
+	svc := newServiceForOpenLedgerTest(t)
+
+	env := testenv.NewTestEnv(t)
+	master := testenv.MasterAccount()
+	alice := testenv.NewAccount("alice")
+
+	disputedBlob, disputedHash := buildSignedPaymentBlob(t, env, master, alice, 50_000_000, 1)
+
+	parent := svc.GetClosedLedger()
+	if parent == nil {
+		t.Fatal("GetClosedLedger nil before AcceptConsensusResult")
+	}
+	if _, err := svc.AcceptConsensusResult(context.TODO(), parent, nil, [][]byte{disputedBlob}, time.Now(), true); err != nil {
+		t.Fatalf("AcceptConsensusResult: %v", err)
+	}
+
+	closed := svc.GetClosedLedger()
+	if closed == nil {
+		t.Fatal("GetClosedLedger nil after AcceptConsensusResult")
+	}
+	if closed.TxExists(disputedHash) {
+		t.Errorf("disputed tx landed in the closed ledger; must only reach the open view")
+	}
+	if !svc.OpenLedgerHasTx(disputedHash) {
+		t.Errorf("post-Accept open view missing the disputed we-voted-NO tx")
+	}
+}
+
+// TestService_AcceptConsensusResult_DisputedPseudoTxSkipped verifies that a
+// disputed pseudo-tx is dropped from the replay: a pseudo-tx rejected by
+// consensus cannot be successfully applied in a later ledger.
+func TestService_AcceptConsensusResult_DisputedPseudoTxSkipped(t *testing.T) {
+	svc := newServiceForOpenLedgerTest(t)
+
+	ledgerSeq := uint32(2)
+	pseudoBlob, err := consensuscommon.BuildPseudoTx(tx.TypeAmendment, func(base tx.BaseTx) tx.Transaction {
+		return &pseudo.EnableAmendment{
+			BaseTx:         base,
+			Amendment:      strings.Repeat("AB", 32),
+			LedgerSequence: &ledgerSeq,
+		}
+	})
+	if err != nil {
+		t.Fatalf("BuildPseudoTx: %v", err)
+	}
+	pseudoTx, err := openledger.ParsePendingTx(pseudoBlob)
+	if err != nil {
+		t.Fatalf("ParsePendingTx: %v", err)
+	}
+
+	parent := svc.GetClosedLedger()
+	if parent == nil {
+		t.Fatal("GetClosedLedger nil before AcceptConsensusResult")
+	}
+	if _, err := svc.AcceptConsensusResult(context.TODO(), parent, nil, [][]byte{pseudoBlob}, time.Now(), true); err != nil {
+		t.Fatalf("AcceptConsensusResult: %v", err)
+	}
+
+	if svc.OpenLedgerHasTx(pseudoTx.Hash) {
+		t.Errorf("post-Accept open view contains a disputed pseudo-tx; pseudo-txs must be skipped")
 	}
 	if got := svc.OpenLedgerTxs(); len(got) != 0 {
 		t.Errorf("post-Accept OpenLedgerTxs len = %d, want 0", len(got))

--- a/internal/ledger/service/service_skiplist_test.go
+++ b/internal/ledger/service/service_skiplist_test.go
@@ -84,7 +84,7 @@ func TestService_AcceptConsensusResult_LedgerHashesInvariants(t *testing.T) {
 			t.Fatalf("closedLedger nil after %d closes", i)
 		}
 		closeTime = closeTime.Add(2 * time.Second)
-		seq, err := svc.AcceptConsensusResult(context.TODO(), parent, nil, closeTime, true)
+		seq, err := svc.AcceptConsensusResult(context.TODO(), parent, nil, nil, closeTime, true)
 		if err != nil {
 			t.Fatalf("AcceptConsensusResult at iter %d: %v", i, err)
 		}
@@ -154,7 +154,7 @@ func TestService_AcceptConsensusResult_RebuildSameSeq_NoSkipListLeak(t *testing.
 	for i := range 5 {
 		closeTime = closeTime.Add(2 * time.Second)
 		parent := svc.GetClosedLedger()
-		if _, err := svc.AcceptConsensusResult(context.TODO(), parent, nil, closeTime, true); err != nil {
+		if _, err := svc.AcceptConsensusResult(context.TODO(), parent, nil, nil, closeTime, true); err != nil {
 			t.Fatalf("warm-up close %d: %v", i, err)
 		}
 	}
@@ -165,7 +165,7 @@ func TestService_AcceptConsensusResult_RebuildSameSeq_NoSkipListLeak(t *testing.
 	parentSeq := parent.Sequence()
 
 	closeTime = closeTime.Add(2 * time.Second)
-	if _, err := svc.AcceptConsensusResult(context.TODO(), parent, nil, closeTime, true); err != nil {
+	if _, err := svc.AcceptConsensusResult(context.TODO(), parent, nil, nil, closeTime, true); err != nil {
 		t.Fatalf("first build: %v", err)
 	}
 
@@ -173,7 +173,7 @@ func TestService_AcceptConsensusResult_RebuildSameSeq_NoSkipListLeak(t *testing.
 	// parent again. This resets s.closedLedger to parent and rebuilds
 	// the open ledger.
 	closeTime = closeTime.Add(2 * time.Second)
-	if _, err := svc.AcceptConsensusResult(context.TODO(), parent, nil, closeTime, true); err != nil {
+	if _, err := svc.AcceptConsensusResult(context.TODO(), parent, nil, nil, closeTime, true); err != nil {
 		t.Fatalf("second build (chain switch): %v", err)
 	}
 
@@ -234,7 +234,7 @@ func TestService_AcceptConsensusResult_SiblingForkSwitchesChain(t *testing.T) {
 	for i := range 5 {
 		closeTime = closeTime.Add(2 * time.Second)
 		for _, svc := range []*Service{alt, canonical} {
-			if _, err := svc.AcceptConsensusResult(context.TODO(), svc.GetClosedLedger(), nil, closeTime, true); err != nil {
+			if _, err := svc.AcceptConsensusResult(context.TODO(), svc.GetClosedLedger(), nil, nil, closeTime, true); err != nil {
 				t.Fatalf("warm-up close iter %d: %v", i, err)
 			}
 		}
@@ -250,10 +250,10 @@ func TestService_AcceptConsensusResult_SiblingForkSwitchesChain(t *testing.T) {
 	// they produce sibling hashes at the same seq.
 	altCloseTime := closeTime.Add(2 * time.Second)
 	canonCloseTime := closeTime.Add(7 * time.Second)
-	if _, err := alt.AcceptConsensusResult(context.TODO(), altSync, nil, altCloseTime, true); err != nil {
+	if _, err := alt.AcceptConsensusResult(context.TODO(), altSync, nil, nil, altCloseTime, true); err != nil {
 		t.Fatalf("alt fork build: %v", err)
 	}
-	if _, err := canonical.AcceptConsensusResult(context.TODO(), canonSync, nil, canonCloseTime, true); err != nil {
+	if _, err := canonical.AcceptConsensusResult(context.TODO(), canonSync, nil, nil, canonCloseTime, true); err != nil {
 		t.Fatalf("canonical fork build: %v", err)
 	}
 	altTip := alt.GetClosedLedger()
@@ -270,7 +270,7 @@ func TestService_AcceptConsensusResult_SiblingForkSwitchesChain(t *testing.T) {
 	// chain-switch check (seq matches), and alt's openLedger stayed
 	// pinned to the alt-built state.
 	nextCloseTime := altCloseTime.Add(2 * time.Second)
-	if _, err := alt.AcceptConsensusResult(context.TODO(), canonTip, nil, nextCloseTime, true); err != nil {
+	if _, err := alt.AcceptConsensusResult(context.TODO(), canonTip, nil, nil, nextCloseTime, true); err != nil {
 		t.Fatalf("alt rebuild on canonical parent: %v", err)
 	}
 

--- a/internal/testing/consensus/openledger_convergence_test.go
+++ b/internal/testing/consensus/openledger_convergence_test.go
@@ -120,7 +120,7 @@ func fundAccountsAndClose(
 	if parent == nil {
 		t.Fatal("GetClosedLedger nil before AcceptConsensusResult")
 	}
-	if _, err := svc.AcceptConsensusResult(context.TODO(), parent, fundingBlobs, time.Now(), true); err != nil {
+	if _, err := svc.AcceptConsensusResult(context.TODO(), parent, fundingBlobs, nil, time.Now(), true); err != nil {
 		t.Fatalf("AcceptConsensusResult: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- rippled's `doAccept` inserts every disputed tx we voted NO on (non-pseudo) into the retriable set so it is applied into the fresh open ledger ahead of the TxQ — "first crack ... goes to transactions proposed by a validator we trust but not included in the consensus set". go-xrpl only replayed the build pass's retry leftovers, so peer-proposed disputed-NO txs never got that ordering priority.
- Thread the round's disputed-NO tx blobs from the consensus engine (`DisputeTracker.DisputedNoTxs`, snapshotted under the engine lock) through `Adaptor.BuildLedger` into `AcceptConsensusResult`, which merges them into the retriable set: malformed blobs and pseudo-txs are dropped (a pseudo-tx rejected by consensus can't succeed in a later ledger), duplicates deduped by hash, and the merged set is re-sorted with the agreed set's SHAMap root as salt — the canonical order rippled's `CanonicalTXSet` applies in.
- Corrects the comment that called the build retry set a "harmless superset of rippled's disputed set": the retries-first pass must run whenever the set is non-empty because `ApplyTxs` never re-applies pre-existing retries (rippled's retry loop drains the shared set during the current-view replay either way).

## Test plan
- [x] `go test ./internal/ledger/service/... ./internal/consensus/... ./internal/testing/consensus/...` — all green
- [x] New `TestService_AcceptConsensusResult_DisputedTxsFirstCrack` — a disputed we-voted-NO tx never submitted locally lands in the fresh open view, not the closed ledger
- [x] New `TestService_AcceptConsensusResult_DisputedPseudoTxSkipped` — a disputed pseudo-tx is dropped from the replay
- [x] `golangci-lint run --config .golangci.yml ./...` — 0 issues

Fixes #1198