### PR TITLE
fix: retain accessed validation sets past the seq expiry floor

### DIFF
--- a/config/validation_archive.go
+++ b/config/validation_archive.go
@@ -38,7 +38,9 @@ type ValidationArchiveConfig struct {
 	// InMemoryLedgers is the ExpireOld trigger. Every time a ledger is
 	// fully validated at seq S, the tracker drops validations for
 	// ledgers below (S - InMemoryLedgers) — which then stream into the
-	// archive via OnStale. Must be >= 1.
+	// archive via OnStale. Sets read or written within the last 10
+	// minutes (rippled's validationSET_EXPIRES) are held past the window
+	// and archived once cold. Must be >= 1.
 	InMemoryLedgers uint32 `toml:"in_memory_ledgers" mapstructure:"in_memory_ledgers"`
 }
 

--- a/config/validation_archive.go
+++ b/config/validation_archive.go
@@ -38,7 +38,7 @@ type ValidationArchiveConfig struct {
 	// InMemoryLedgers is the ExpireOld trigger. Every time a ledger is
 	// fully validated at seq S, the tracker drops validations for
 	// ledgers below (S - InMemoryLedgers) — which then stream into the
-	// archive via OnStale. Sets read or written within the last 10
+	// archive via OnStale. Sets created or read within the last 10
 	// minutes (rippled's validationSET_EXPIRES) are held past the window
 	// and archived once cold. Must be >= 1.
 	InMemoryLedgers uint32 `toml:"in_memory_ledgers" mapstructure:"in_memory_ledgers"`

--- a/internal/consensus/archive/archive.go
+++ b/internal/consensus/archive/archive.go
@@ -11,7 +11,9 @@
 // isCurrent() returned false — i.e. on time-window violations
 // (SignTime/SeenTime drifted outside the wall/local windows). go-xrpl
 // fires onStale only from ExpireOld(seq - inMemoryLedgers), which is
-// driven by ledger-seq retention from the fully-validated callback.
+// driven by ledger-seq retention from the fully-validated callback —
+// a per-ledger set accessed within validationSET_EXPIRES is held past
+// the window and archived on the first sweep after it goes cold.
 //
 // Practical consequence: time-stale validations that never reach a
 // fully-validated ledger (e.g. orphaned validations on losing forks)

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -303,7 +303,7 @@ func flushBroadcasts(pending []func()) {
 // validationSetExpires mirrors rippled's validationSET_EXPIRES. It is
 // both the SeqEnforcer reset window and the access-age retention floor
 // for per-ledger validation sets: ExpireOld keeps a set resident until
-// it has gone at least this long without a read or write touch.
+// at least this long has passed since it was created or last read.
 const validationSetExpires = 10 * time.Minute
 
 // defaultInMemoryLedgers bounds the tracker's retention with no archive

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -300,7 +300,10 @@ func flushBroadcasts(pending []func()) {
 	}
 }
 
-// SeqEnforcer reset window (validationSET_EXPIRES).
+// validationSetExpires mirrors rippled's validationSET_EXPIRES. It is
+// both the SeqEnforcer reset window and the access-age retention floor
+// for per-ledger validation sets: ExpireOld keeps a set resident until
+// it has gone at least this long without a read or write touch.
 const validationSetExpires = 10 * time.Minute
 
 // defaultInMemoryLedgers bounds the tracker's retention with no archive

--- a/internal/consensus/rcl/engine_archive_test.go
+++ b/internal/consensus/rcl/engine_archive_test.go
@@ -75,6 +75,9 @@ func TestEngine_SetArchive_PostStart(t *testing.T) {
 	if !engine.validationTracker.Add(v) {
 		t.Fatal("Add returned false; precondition broken")
 	}
+	// Jump the tracker clock past the access-age window so the seq
+	// floor can evict the just-touched set.
+	engine.validationTracker.SetNow(func() time.Time { return time.Now().Add(validationSetExpires + time.Second) })
 	engine.validationTracker.ExpireOld(200)
 
 	if arc.staleCount() != 1 {
@@ -116,6 +119,12 @@ func TestEngine_FullyValidated_TriggersExpireOldAndArchive(t *testing.T) {
 		t.Fatal("seed Add returned false")
 	}
 
+	// The seed set was just touched; move the tracker clock past the
+	// access-age window so the retention floor can evict it. The driving
+	// validations are signed at the same future instant to stay current.
+	future := now.Add(validationSetExpires + time.Second)
+	engine.validationTracker.SetNow(func() time.Time { return future })
+
 	// Drive two trusted validations at seq 300 so the tracker fires the
 	// fully-validated callback. Quorum=2.
 	for _, n := range []consensus.NodeID{{1}, {2}} {
@@ -123,7 +132,7 @@ func TestEngine_FullyValidated_TriggersExpireOldAndArchive(t *testing.T) {
 			LedgerSeq: 300,
 			LedgerID:  consensus.LedgerID{0xB},
 			NodeID:    n,
-			SignTime:  now,
+			SignTime:  future,
 			Full:      true,
 		}
 		engine.validationTracker.Add(v)
@@ -182,6 +191,9 @@ func TestEngine_SetArchive_NilDetaches(t *testing.T) {
 	if !engine.validationTracker.Add(v) {
 		t.Fatal("Add returned false; precondition broken")
 	}
+	// Jump the clock so the eviction really happens — otherwise the
+	// zero-stale assertion below would pass vacuously.
+	engine.validationTracker.SetNow(func() time.Time { return time.Now().Add(validationSetExpires + time.Second) })
 	engine.validationTracker.ExpireOld(200)
 
 	if got := arc.staleCount(); got != 0 {

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -35,9 +35,15 @@ func safeTrieCall(fn string, op func()) (panicked bool) {
 
 // ledgerValidations is one per-ledger validation set plus the
 // access-age bookkeeping ExpireOld needs. lastAccess holds unix-nanos
-// of the last read or write touch, stored atomically so query paths
-// holding only vt.mu.RLock can refresh it — the equivalent of rippled's
-// byLedger_.touch on every byLedger access.
+// of the set's creation or last read touch — writes into an existing
+// set do not refresh it, matching rippled's aged byLedger_ container,
+// which stamps on insert and touches on read only. Stored atomically
+// so query paths holding only vt.mu.RLock can refresh it. Aging
+// deliberately follows the tracker clock (adaptor.Now in production)
+// rather than rippled's monotonic steady_clock: touch and the
+// ExpireOld cutoff share that clock — consistent with the engine's
+// other validationSetExpires windows — so a close-offset adjustment
+// shifts retention by at most the adjustment.
 type ledgerValidations struct {
 	vals       map[consensus.NodeID]*consensus.Validation
 	lastAccess atomic.Int64
@@ -402,10 +408,10 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	ledgerVals, exists := vt.validations[validation.LedgerID]
 	if !exists {
 		ledgerVals = &ledgerValidations{vals: make(map[consensus.NodeID]*consensus.Validation)}
+		ledgerVals.touch(vt.now())
 		vt.validations[validation.LedgerID] = ledgerVals
 	}
 	ledgerVals.vals[resolvedID] = validation
-	ledgerVals.touch(vt.now())
 
 	// Steer the trie on trusted() alone — negUNL validators included —
 	// mirroring rippled's updateTrie precondition. negUNL exclusion lives
@@ -831,7 +837,7 @@ func (vt *ValidationTracker) FlushStale() {
 // onStale outside the mutex. Trie tips for dropped validators are also
 // removed so phantom branchSupport doesn't linger on stale ancestors.
 //
-// A set read or written within validationSetExpires is retained even
+// A set created or read within validationSetExpires is retained even
 // below the sequence floor — rippled's access-age expiry
 // (validationSET_EXPIRES with byLedger touch) — so hot ledgers stay
 // queryable for RPC and late peers. Memory stays bounded: Add rejects

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -3,6 +3,7 @@ package rcl
 import (
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
@@ -32,6 +33,20 @@ func safeTrieCall(fn string, op func()) (panicked bool) {
 	return false
 }
 
+// ledgerValidations is one per-ledger validation set plus the
+// access-age bookkeeping ExpireOld needs. lastAccess holds unix-nanos
+// of the last read or write touch, stored atomically so query paths
+// holding only vt.mu.RLock can refresh it — the equivalent of rippled's
+// byLedger_.touch on every byLedger access.
+type ledgerValidations struct {
+	vals       map[consensus.NodeID]*consensus.Validation
+	lastAccess atomic.Int64
+}
+
+func (lv *ledgerValidations) touch(now time.Time) {
+	lv.lastAccess.Store(now.UnixNano())
+}
+
 // ValidationTracker tracks validations and determines ledger finality.
 type ValidationTracker struct {
 	mu sync.RWMutex
@@ -46,7 +61,7 @@ type ValidationTracker struct {
 	now func() time.Time
 
 	// validations maps ledger ID to validations for that ledger
-	validations map[consensus.LedgerID]map[consensus.NodeID]*consensus.Validation
+	validations map[consensus.LedgerID]*ledgerValidations
 
 	// byNode maps node ID to their latest validation
 	byNode map[consensus.NodeID]*consensus.Validation
@@ -124,7 +139,7 @@ type ValidationTracker struct {
 func NewValidationTracker(quorum int, freshness time.Duration) *ValidationTracker {
 	return &ValidationTracker{
 		now:         time.Now,
-		validations: make(map[consensus.LedgerID]map[consensus.NodeID]*consensus.Validation),
+		validations: make(map[consensus.LedgerID]*ledgerValidations),
 		byNode:      make(map[consensus.NodeID]*consensus.Validation),
 		trusted:     make(map[consensus.NodeID]bool),
 		negUNL:      make(map[consensus.NodeID]bool),
@@ -386,10 +401,11 @@ func (vt *ValidationTracker) Add(validation *consensus.Validation) bool {
 	// Add to ledger validations
 	ledgerVals, exists := vt.validations[validation.LedgerID]
 	if !exists {
-		ledgerVals = make(map[consensus.NodeID]*consensus.Validation)
+		ledgerVals = &ledgerValidations{vals: make(map[consensus.NodeID]*consensus.Validation)}
 		vt.validations[validation.LedgerID] = ledgerVals
 	}
-	ledgerVals[resolvedID] = validation
+	ledgerVals.vals[resolvedID] = validation
+	ledgerVals.touch(vt.now())
 
 	// Steer the trie on trusted() alone — negUNL validators included —
 	// mirroring rippled's updateTrie precondition. negUNL exclusion lives
@@ -436,16 +452,16 @@ func (vt *ValidationTracker) checkFullValidationLocked(ledgerID consensus.Ledger
 		return ledgerID, 0, false
 	}
 	ledgerVals, exists := vt.validations[ledgerID]
-	if !exists || len(ledgerVals) == 0 {
+	if !exists || len(ledgerVals.vals) == 0 {
 		return ledgerID, 0, false
 	}
 
 	var sampleSeq uint32
-	for _, v := range ledgerVals {
+	for _, v := range ledgerVals.vals {
 		sampleSeq = v.LedgerSeq
 		break
 	}
-	trustedCount := vt.countTrustedExcludingNegUNLLocked(ledgerVals)
+	trustedCount := vt.countTrustedExcludingNegUNLLocked(ledgerVals.vals)
 
 	if trustedCount >= vt.quorum {
 		vt.fired[ledgerID] = struct{}{}
@@ -457,6 +473,8 @@ func (vt *ValidationTracker) checkFullValidationLocked(ledgerID consensus.Ledger
 // GetTrustedValidations returns trusted validations for a ledger. No
 // seq argument is needed: entries are keyed by ledger hash, which
 // uniquely determines the seq, so all entries under a ledgerID share it.
+// Reading a ledger's set refreshes its access age (rippled's
+// byLedger touch) so actively-queried ledgers survive ExpireOld.
 func (vt *ValidationTracker) GetTrustedValidations(ledgerID consensus.LedgerID) []*consensus.Validation {
 	vt.mu.RLock()
 	defer vt.mu.RUnlock()
@@ -465,9 +483,10 @@ func (vt *ValidationTracker) GetTrustedValidations(ledgerID consensus.LedgerID) 
 	if !exists {
 		return nil
 	}
+	ledgerVals.touch(vt.now())
 
 	var result []*consensus.Validation
-	for nodeID, v := range ledgerVals {
+	for nodeID, v := range ledgerVals.vals {
 		if vt.trusted[nodeID] {
 			result = append(result, v)
 		}
@@ -489,7 +508,8 @@ func (vt *ValidationTracker) GetTrustedValidationCount(ledgerID consensus.Ledger
 	if !exists {
 		return 0
 	}
-	return vt.countTrustedExcludingNegUNLLocked(ledgerVals)
+	ledgerVals.touch(vt.now())
+	return vt.countTrustedExcludingNegUNLLocked(ledgerVals.vals)
 }
 
 // countTrustedExcludingNegUNLLocked counts validators in ledgerVals
@@ -544,7 +564,8 @@ func (vt *ValidationTracker) GetTrustedSupport(ledgerID consensus.LedgerID) int 
 		if !exists {
 			return 0
 		}
-		return vt.countTrustedExcludingNegUNLLocked(ledgerVals)
+		ledgerVals.touch(vt.now())
+		return vt.countTrustedExcludingNegUNLLocked(ledgerVals.vals)
 	}
 	vt.checkAcquiredLocked()
 	return vt.branchSupportExcludingNegUNLLocked(lgr)
@@ -648,8 +669,9 @@ func (vt *ValidationTracker) ProposersValidated(ledgerID consensus.LedgerID) int
 	if !ok {
 		return 0
 	}
+	perLedger.touch(vt.now())
 	count := 0
-	for nodeID, v := range perLedger {
+	for nodeID, v := range perLedger.vals {
 		if !vt.trusted[nodeID] {
 			continue
 		}
@@ -808,22 +830,36 @@ func (vt *ValidationTracker) FlushStale() {
 // ExpireOld drops validations below minSeq from every index and fires
 // onStale outside the mutex. Trie tips for dropped validators are also
 // removed so phantom branchSupport doesn't linger on stale ancestors.
+//
+// A set read or written within validationSetExpires is retained even
+// below the sequence floor — rippled's access-age expiry
+// (validationSET_EXPIRES with byLedger touch) — so hot ledgers stay
+// queryable for RPC and late peers. Memory stays bounded: Add rejects
+// below the engine's minSeq gate, so a below-floor set cannot reheat
+// from the network, and it drops on the first ExpireOld after going
+// cold. The seq floor itself plays rippled's setSeqToKeep role of
+// protecting the recent (negative-UNL voting) window from expiry.
 func (vt *ValidationTracker) ExpireOld(minSeq uint32) {
 	vt.mu.Lock()
 
 	onStale := vt.onStale
 	var stale []*consensus.Validation
 
+	cutoff := vt.now().Add(-validationSetExpires).UnixNano()
+
 	for ledgerID, ledgerVals := range vt.validations {
 		var sample *consensus.Validation
-		for _, v := range ledgerVals {
+		for _, v := range ledgerVals.vals {
 			sample = v
 			break
 		}
 		if sample == nil || sample.LedgerSeq >= minSeq {
 			continue
 		}
-		for nodeID, v := range ledgerVals {
+		if ledgerVals.lastAccess.Load() > cutoff {
+			continue
+		}
+		for nodeID, v := range ledgerVals.vals {
 			stale = append(stale, v)
 			if latest, ok := vt.byNode[nodeID]; ok && latest == v {
 				delete(vt.byNode, nodeID)
@@ -863,7 +899,7 @@ func (vt *ValidationTracker) Flush() {
 	vt.mu.Lock()
 	defer vt.mu.Unlock()
 
-	vt.validations = make(map[consensus.LedgerID]map[consensus.NodeID]*consensus.Validation)
+	vt.validations = make(map[consensus.LedgerID]*ledgerValidations)
 	vt.byNode = make(map[consensus.NodeID]*consensus.Validation)
 	vt.fired = make(map[consensus.LedgerID]struct{})
 	vt.rebuildTrieLocked()

--- a/internal/consensus/rcl/validations_acquire_test.go
+++ b/internal/consensus/rcl/validations_acquire_test.go
@@ -263,6 +263,7 @@ func TestValidationTracker_ExpireOldUnparks(t *testing.T) {
 	vt.SetLedgerAncestryProvider(newMapAncestryProvider())
 
 	vt.Add(makeTrustedValidation(n1, abcd.ID(), abcd.Seq(), now))
+	now = now.Add(validationSetExpires + time.Second)
 	vt.ExpireOld(abcd.Seq() + 1)
 
 	if _, _, ok := vt.GetPreferred(0); ok {

--- a/internal/consensus/rcl/validations_helpers_test.go
+++ b/internal/consensus/rcl/validations_helpers_test.go
@@ -15,7 +15,7 @@ func (vt *ValidationTracker) GetValidationCount(ledgerID consensus.LedgerID) int
 	if !exists {
 		return 0
 	}
-	return len(ledgerVals)
+	return len(ledgerVals.vals)
 }
 
 // GetCurrentValidators returns nodes that have recently validated.
@@ -42,7 +42,7 @@ func (vt *ValidationTracker) Clear() {
 	vt.mu.Lock()
 	defer vt.mu.Unlock()
 
-	vt.validations = make(map[consensus.LedgerID]map[consensus.NodeID]*consensus.Validation)
+	vt.validations = make(map[consensus.LedgerID]*ledgerValidations)
 	vt.byNode = make(map[consensus.NodeID]*consensus.Validation)
 	vt.fired = make(map[consensus.LedgerID]struct{})
 	vt.rebuildTrieLocked()
@@ -65,7 +65,7 @@ func (vt *ValidationTracker) GetStats() ValidationStats {
 	trustedValidations := 0
 
 	for _, ledgerVals := range vt.validations {
-		for nodeID := range ledgerVals {
+		for nodeID := range ledgerVals.vals {
 			totalValidations++
 			if vt.trusted[nodeID] {
 				trustedValidations++

--- a/internal/consensus/rcl/validations_partial_test.go
+++ b/internal/consensus/rcl/validations_partial_test.go
@@ -193,9 +193,14 @@ func TestEngine_RetentionWithoutArchive(t *testing.T) {
 		t.Fatalf("precondition: seed validation not tracked (got %d)", got)
 	}
 
+	// Move the tracker clock past the access-age window so the seed set
+	// is cold when the retention floor sweeps it.
+	future := now.Add(validationSetExpires + time.Second)
+	engine.validationTracker.SetNow(func() time.Time { return future })
+
 	// Drive a quorum at seq 300 to fire the fully-validated callback.
 	for _, id := range []consensus.NodeID{{1}, {2}} {
-		v := &consensus.Validation{LedgerSeq: 300, LedgerID: consensus.LedgerID{0xB}, NodeID: id, SignTime: now, Full: true}
+		v := &consensus.Validation{LedgerSeq: 300, LedgerID: consensus.LedgerID{0xB}, NodeID: id, SignTime: future, Full: true}
 		engine.validationTracker.Add(v)
 	}
 

--- a/internal/consensus/rcl/validations_test.go
+++ b/internal/consensus/rcl/validations_test.go
@@ -652,6 +652,34 @@ func TestValidationTracker_ExpireOld_TouchOnReadExtends(t *testing.T) {
 	}
 }
 
+// A write into an existing set does not refresh its access age —
+// rippled's aged byLedger_ container stamps on insert and touches on
+// read only, so a below-floor set kept alive purely by late incoming
+// validations still expires once its creation/read age passes the
+// window.
+func TestValidationTracker_ExpireOld_WriteDoesNotExtend(t *testing.T) {
+	vt := NewValidationTracker(1, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	ledger := consensus.LedgerID{1}
+	vt.Add(&consensus.Validation{LedgerID: ledger, LedgerSeq: 100, NodeID: consensus.NodeID{0xA}, SignTime: now, Full: true})
+
+	// A second validator writes into the existing set just before the
+	// window closes.
+	now = now.Add(validationSetExpires - time.Second)
+	if !vt.Add(&consensus.Validation{LedgerID: ledger, LedgerSeq: 100, NodeID: consensus.NodeID{0xB}, SignTime: now, Full: true}) {
+		t.Fatal("precondition: second Add rejected")
+	}
+
+	// Past the creation age: the late write must not have refreshed it.
+	now = now.Add(2 * time.Second)
+	vt.ExpireOld(200)
+	if got := vt.GetValidationCount(ledger); got != 0 {
+		t.Fatalf("write-refreshed set survived: count=%d, want 0", got)
+	}
+}
+
 // TestValidationTracker_Flush mirrors rippled's Validations::flush()
 // (Validations.h:1103-1110, called on orderly shutdown at
 // Application.cpp:1612): all accumulated validation state is discarded

--- a/internal/consensus/rcl/validations_test.go
+++ b/internal/consensus/rcl/validations_test.go
@@ -520,6 +520,9 @@ func TestValidationTracker_ExpireOld_FiresOnStale(t *testing.T) {
 	var fired []*consensus.Validation
 	vt.SetOnStale(func(v *consensus.Validation) { fired = append(fired, v) })
 
+	// Sets are access-age guarded; jump the clock past
+	// validationSetExpires so the seq floor can evict.
+	vt.SetNow(func() time.Time { return time.Now().Add(validationSetExpires + time.Second) })
 	vt.ExpireOld(200)
 
 	if len(fired) != 2 {
@@ -550,6 +553,7 @@ func TestValidationTracker_ExpireOld_ClearsByNode(t *testing.T) {
 		t.Fatal("precondition: Add should have populated byNode")
 	}
 
+	vt.SetNow(func() time.Time { return time.Now().Add(validationSetExpires + time.Second) })
 	vt.ExpireOld(200)
 
 	if vt.GetLatestValidation(nodeA) != nil {
@@ -571,12 +575,80 @@ func TestValidationTracker_ExpireOld_OnStaleRunsOutsideLock(t *testing.T) {
 		close(done)
 	})
 
+	vt.SetNow(func() time.Time { return time.Now().Add(validationSetExpires + time.Second) })
 	vt.ExpireOld(200)
 
 	select {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("onStale callback deadlocked or never fired")
+	}
+}
+
+// A set below the seq floor but accessed within validationSetExpires
+// must survive ExpireOld — rippled's validationSET_EXPIRES access-age
+// window keeps recently-used ledgers queryable regardless of how far
+// back their sequence is.
+func TestValidationTracker_ExpireOld_RetainsRecentlyAccessed(t *testing.T) {
+	vt := NewValidationTracker(1, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	ledger := consensus.LedgerID{1}
+	vt.Add(&consensus.Validation{LedgerID: ledger, LedgerSeq: 100, NodeID: consensus.NodeID{0xA}, SignTime: now, Full: true})
+
+	var fired int
+	vt.SetOnStale(func(*consensus.Validation) { fired++ })
+
+	// Below the floor but touched moments ago: retained, no onStale.
+	vt.ExpireOld(200)
+	if got := vt.GetValidationCount(ledger); got != 1 {
+		t.Fatalf("hot set evicted: count=%d, want 1", got)
+	}
+	if fired != 0 {
+		t.Fatalf("onStale fired %d times for a hot set, want 0", fired)
+	}
+
+	// Once cold, the same floor evicts it.
+	now = now.Add(validationSetExpires + time.Second)
+	vt.ExpireOld(200)
+	if got := vt.GetValidationCount(ledger); got != 0 {
+		t.Fatalf("cold set survived: count=%d, want 0", got)
+	}
+	if fired != 1 {
+		t.Fatalf("onStale fired %d times for the cold eviction, want 1", fired)
+	}
+}
+
+// Reading a ledger's validations refreshes its access age — rippled's
+// byLedger touch — so an actively-queried set keeps surviving ExpireOld
+// while an unqueried sibling at the same seq expires.
+func TestValidationTracker_ExpireOld_TouchOnReadExtends(t *testing.T) {
+	vt := NewValidationTracker(1, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	hot := consensus.LedgerID{1}
+	cold := consensus.LedgerID{2}
+	vt.SetTrusted([]consensus.NodeID{{0xA}, {0xB}})
+	vt.Add(&consensus.Validation{LedgerID: hot, LedgerSeq: 100, NodeID: consensus.NodeID{0xA}, SignTime: now, Full: true})
+	vt.Add(&consensus.Validation{LedgerID: cold, LedgerSeq: 100, NodeID: consensus.NodeID{0xB}, SignTime: now, Full: true})
+
+	// Query the hot ledger just before the window closes on both sets.
+	now = now.Add(validationSetExpires - time.Second)
+	if got := len(vt.GetTrustedValidations(hot)); got != 1 {
+		t.Fatalf("precondition: hot ledger has %d trusted validations, want 1", got)
+	}
+
+	// Past the original window: the untouched set expires, the read
+	// refreshed the other.
+	now = now.Add(2 * time.Second)
+	vt.ExpireOld(200)
+	if got := vt.GetValidationCount(cold); got != 0 {
+		t.Fatalf("unqueried set survived: count=%d, want 0", got)
+	}
+	if got := vt.GetValidationCount(hot); got != 1 {
+		t.Fatalf("queried set evicted despite recent read: count=%d, want 1", got)
 	}
 }
 

--- a/internal/consensus/rcl/validations_trie_test.go
+++ b/internal/consensus/rcl/validations_trie_test.go
@@ -411,7 +411,9 @@ func TestValidationTracker_ExpireOldDropsTrieTip(t *testing.T) {
 		t.Fatalf("pre-expire branchSupport(ab): got %d, want 2", got)
 	}
 
-	// Expire validations below seq 4 — drops both tips.
+	// Expire validations below seq 4 — drops both tips. Jump the clock
+	// first so the access-age guard doesn't retain the sets.
+	now = now.Add(validationSetExpires + time.Second)
 	vt.ExpireOld(4)
 
 	// After expiry the trie must drop both tips. branchSupport on any

--- a/internal/testing/validationarchive/archive_test.go
+++ b/internal/testing/validationarchive/archive_test.go
@@ -71,6 +71,9 @@ func TestValidationArchive_StaleValidationWrittenOnPrune(t *testing.T) {
 		t.Fatal("Add returned false; precondition broken")
 	}
 
+	// Jump the tracker clock past the access-age retention window
+	// (rippled's validationSET_EXPIRES) so the seq floor can evict.
+	tracker.SetNow(func() time.Time { return time.Now().Add(10*time.Minute + time.Second) })
 	tracker.ExpireOld(200) // v becomes stale
 
 	if err := a.Flush(context.Background()); err != nil {
@@ -249,6 +252,13 @@ func TestValidationArchive_EngineDrivenFlow(t *testing.T) {
 		t.Fatal("seed Add returned false")
 	}
 
+	// The seed set was just touched; move the tracker clock past the
+	// access-age retention window (rippled's validationSET_EXPIRES) so
+	// the eviction sweep can drop it. The driving validations are signed
+	// at the same future instant to stay current.
+	future := time.Now().Add(10*time.Minute + time.Second)
+	tracker.SetNow(func() time.Time { return future })
+
 	// Drive quorum at seq 300: two trusted validations for the SAME
 	// ledger hash (mkValidation's hash varies by node, so we pin a
 	// deterministic LedgerID here and only swap NodeID).
@@ -257,6 +267,7 @@ func TestValidationArchive_EngineDrivenFlow(t *testing.T) {
 		v := mkValidation(300, n[0])
 		v.LedgerID = sharedLedger
 		v.NodeID = n
+		v.SignTime = future
 		if !tracker.Add(v) {
 			t.Fatalf("Add at seq=300 returned false for node %v", n)
 		}


### PR DESCRIPTION
## Summary
- `ExpireOld` dropped every per-ledger validation set below the sequence floor even if it had been written or queried seconds earlier — diverging from rippled, which expires `byLedger_`/`bySequence_` by **access age** (`validationSET_EXPIRES` = 10 min) and touches a set on every read (`Validations.h:559,774`), so recently-queried ledgers stay resident for RPC and late peers.
- Per-ledger sets now carry a last-access stamp (`atomic.Int64`, so `RLock` query paths can refresh it) touched on `Add` and on the by-ledger read paths (`GetTrustedValidations`, `GetTrustedValidationCount`, `ProposersValidated`, the `GetTrustedSupport` flat fallback). `ExpireOld` evicts a set only when it is both below the seq floor **and** cold — untouched for `validationSET_EXPIRES`.
- Retention model: every set stays resident ≥10 min after its last touch (rippled's availability guarantee), and the existing 256-ledger floor keeps playing rippled's `setSeqToKeep(seq-1, seq+FLAG_LEDGER_INTERVAL)` role of protecting the recent / negative-UNL voting window. Memory stays bounded: `Add` still rejects below the engine's minSeq gate, so a below-floor set cannot reheat from the network and drops on the first sweep after going cold. Archive semantics unchanged — `onStale` still fires exactly once per evicted validation, just deferred until a hot set cools.
- New tests pin the two behaviours: a hot below-floor set survives `ExpireOld` (and archives once cold), and a read touch extends a set's life while an unqueried sibling at the same seq expires.

## Test plan
- [x] `go test ./internal/consensus/...` — all green, including `-race` on `internal/consensus/rcl`
- [x] `go test ./internal/testing/validationarchive/...` — archive integration green
- [x] Core groups (`internal/ledger`, `internal/txq`, `internal/rpc`, `internal/peermanagement`, `config`) pass
- [x] `golangci-lint run --config .golangci.yml` on touched packages — 0 issues

Fixes #1191