### PR TITLE
fix: emit SWITCHED_LEDGER/LOST_SYNC status changes to peers

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -189,6 +189,12 @@ type Adaptor struct {
 	// Atomic ns so the Now() hot path avoids lock contention.
 	closeOffsetNs atomic.Int64
 
+	// consensusMode mirrors the engine's live consensus mode (stored by
+	// OnModeChange, which the engine serializes with the phase callbacks);
+	// broadcastStatus reads it to substitute LOST_SYNC while building on
+	// the wrong LCL.
+	consensusMode atomic.Int32
+
 	// consensusPhaseCh serializes consensus-phase notifications to the ledger
 	// service's OnConsensusPhase hook: a single dispatcher goroutine drains it
 	// in order (preventing out-of-order delivery). Enqueue is non-blocking, so
@@ -1776,10 +1782,19 @@ func (a *Adaptor) refreshRemoteFee(ledgerID consensus.LedgerID) {
 }
 
 func (a *Adaptor) OnModeChange(oldMode, newMode consensus.Mode) {
+	a.consensusMode.Store(int32(newMode))
 	a.logger.Info("Consensus mode changed",
 		"from", oldMode.String(),
 		"to", newMode.String(),
 	)
+
+	// The engine pins in wrongLedger without running rounds, so no
+	// phase-driven status would go out; tell peers directly that our
+	// advertised LCL is stale (rippled keeps re-sending LOST_SYNC each
+	// wrong-LCL round instead).
+	if newMode == consensus.ModeWrongLedger {
+		a.broadcastStatus(message.NodeEventLostSync)
+	}
 }
 
 // NeedsInitialSync returns true if the node hasn't yet adopted a ledger from peers.
@@ -1805,6 +1820,10 @@ func (a *Adaptor) AdoptLedgerFromHeader(headerData []byte) error {
 	// Transition to Tracking mode — the router manages the Full transition
 	// once we verify our LCL matches the network.
 	a.SetOperatingMode(consensus.OpModeTracking)
+
+	// Tell peers about the jump so their tallies replace whatever LCL they
+	// last recorded for us.
+	a.broadcastSwitchedLedger(h.LedgerIndex, h.Hash[:], h.ParentHash[:])
 
 	a.logger.Info("Adopted peer ledger",
 		"seq", h.LedgerIndex,
@@ -1832,11 +1851,45 @@ func (a *Adaptor) OnPhaseChange(oldPhase, newPhase consensus.Phase) {
 	a.emitConsensusPhase(newPhase.String())
 }
 
-// broadcastStatus sends a TMStatusChange message to all peers.
+// OnLedgerSwitched tells peers we abandoned our previous LCL for ledger,
+// mirroring rippled's switchLastClosedLedger broadcast.
+func (a *Adaptor) OnLedgerSwitched(ledger consensus.Ledger) {
+	if ledger == nil {
+		return
+	}
+	id := ledger.ID()
+	parent := ledger.ParentID()
+	a.broadcastSwitchedLedger(ledger.Seq(), id[:], parent[:])
+}
+
+// broadcastSwitchedLedger sends a SWITCHED_LEDGER status change carrying the
+// adopted ledger's identity. No status or validated-range fields: receivers
+// inherit the prior status, and the jump says nothing about served history.
+func (a *Adaptor) broadcastSwitchedLedger(seq uint32, hash, parentHash []byte) {
+	sc := &message.StatusChange{
+		NewEvent:           message.NodeEventSwitchedLedger,
+		LedgerSeq:          seq,
+		LedgerHash:         hash,
+		LedgerHashPrevious: parentHash,
+		NetworkTime:        uint64(time.Now().Unix() - protocol.RippleEpochUnix),
+	}
+	if err := a.sender.BroadcastStatusChange(sc); err != nil {
+		a.logger.Warn("failed to broadcast status change", "error", err)
+	}
+}
+
+// broadcastStatus sends a TMStatusChange message to all peers. While the
+// engine is building on the wrong LCL the given event is replaced with
+// LOST_SYNC, mirroring rippled notify()'s haveCorrectLCL substitution, so
+// peers stop counting our advertised ledger.
 func (a *Adaptor) broadcastStatus(event message.NodeEvent) {
 	l := a.ledgerService.GetClosedLedger()
 	if l == nil {
 		return
+	}
+
+	if consensus.Mode(a.consensusMode.Load()) == consensus.ModeWrongLedger {
+		event = message.NodeEventLostSync
 	}
 
 	hash := l.Hash()

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1790,8 +1790,7 @@ func (a *Adaptor) OnModeChange(oldMode, newMode consensus.Mode) {
 
 	// The engine pins in wrongLedger without running rounds, so no
 	// phase-driven status would go out; tell peers directly that our
-	// advertised LCL is stale (rippled keeps re-sending LOST_SYNC each
-	// wrong-LCL round instead).
+	// advertised LCL is stale.
 	if newMode == consensus.ModeWrongLedger {
 		a.broadcastStatus(message.NodeEventLostSync)
 	}
@@ -1851,8 +1850,7 @@ func (a *Adaptor) OnPhaseChange(oldPhase, newPhase consensus.Phase) {
 	a.emitConsensusPhase(newPhase.String())
 }
 
-// OnLedgerSwitched tells peers we abandoned our previous LCL for ledger,
-// mirroring rippled's switchLastClosedLedger broadcast.
+// OnLedgerSwitched tells peers we abandoned our previous LCL for ledger.
 func (a *Adaptor) OnLedgerSwitched(ledger consensus.Ledger) {
 	if ledger == nil {
 		return
@@ -1880,8 +1878,7 @@ func (a *Adaptor) broadcastSwitchedLedger(seq uint32, hash, parentHash []byte) {
 
 // broadcastStatus sends a TMStatusChange message to all peers. While the
 // engine is building on the wrong LCL the given event is replaced with
-// LOST_SYNC, mirroring rippled notify()'s haveCorrectLCL substitution, so
-// peers stop counting our advertised ledger.
+// LOST_SYNC, so peers stop counting our advertised ledger.
 func (a *Adaptor) broadcastStatus(event message.NodeEvent) {
 	l := a.ledgerService.GetClosedLedger()
 	if l == nil {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1860,6 +1860,12 @@ func (a *Adaptor) OnLedgerSwitched(ledger consensus.Ledger) {
 	a.broadcastSwitchedLedger(ledger.Seq(), id[:], parent[:])
 }
 
+// networkTime is the current time-adjusted clock as ripple-epoch seconds, for
+// the TMStatusChange networktime field.
+func (a *Adaptor) networkTime() uint64 {
+	return uint64(a.Now().Unix() - protocol.RippleEpochUnix)
+}
+
 // broadcastSwitchedLedger sends a SWITCHED_LEDGER status change carrying the
 // adopted ledger's identity. No status or validated-range fields: receivers
 // inherit the prior status, and the jump says nothing about served history.
@@ -1869,7 +1875,7 @@ func (a *Adaptor) broadcastSwitchedLedger(seq uint32, hash, parentHash []byte) {
 		LedgerSeq:          seq,
 		LedgerHash:         hash,
 		LedgerHashPrevious: parentHash,
-		NetworkTime:        uint64(time.Now().Unix() - protocol.RippleEpochUnix),
+		NetworkTime:        a.networkTime(),
 	}
 	if err := a.sender.BroadcastStatusChange(sc); err != nil {
 		a.logger.Warn("failed to broadcast status change", "error", err)
@@ -1878,7 +1884,9 @@ func (a *Adaptor) broadcastSwitchedLedger(seq uint32, hash, parentHash []byte) {
 
 // broadcastStatus sends a TMStatusChange message to all peers. While the
 // engine is building on the wrong LCL the given event is replaced with
-// LOST_SYNC, so peers stop counting our advertised ledger.
+// LOST_SYNC, so peers stop counting our advertised ledger. No newstatus is
+// set: peers inherit the status they last recorded for us, and the advertised
+// [first, last] is the range we durably serve (0/0 when none).
 func (a *Adaptor) broadcastStatus(event message.NodeEvent) {
 	l := a.ledgerService.GetClosedLedger()
 	if l == nil {
@@ -1892,24 +1900,17 @@ func (a *Adaptor) broadcastStatus(event message.NodeEvent) {
 	hash := l.Hash()
 	parentHash := l.ParentHash()
 
-	status := message.NodeStatusConnected
-	if a.IsValidator() {
-		status = message.NodeStatusValidating
+	var firstSeq, lastSeq uint32
+	if first, last, ok := a.ledgerService.AdvertisableLedgerRange(); ok {
+		firstSeq, lastSeq = first, last
 	}
 
-	// NetworkTime is XRPL epoch seconds on the wire, not microseconds.
-	networkTime := uint64(time.Now().Unix() - protocol.RippleEpochUnix)
-
-	firstSeq := uint32(2) // genesis sequence
-	lastSeq := l.Sequence()
-
 	sc := &message.StatusChange{
-		NewStatus:          status,
 		NewEvent:           event,
 		LedgerSeq:          l.Sequence(),
 		LedgerHash:         hash[:],
 		LedgerHashPrevious: parentHash[:],
-		NetworkTime:        networkTime,
+		NetworkTime:        a.networkTime(),
 		FirstSeq:           &firstSeq,
 		LastSeq:            &lastSeq,
 	}

--- a/internal/consensus/adaptor/status_change_test.go
+++ b/internal/consensus/adaptor/status_change_test.go
@@ -1,0 +1,120 @@
+package adaptor
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scRecordingSender records broadcast status changes; any other
+// NetworkSender method panics via the nil embedded interface.
+type scRecordingSender struct {
+	NetworkSender
+	mu  sync.Mutex
+	scs []*message.StatusChange
+}
+
+func (s *scRecordingSender) BroadcastStatusChange(sc *message.StatusChange) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.scs = append(s.scs, sc)
+	return nil
+}
+
+func (s *scRecordingSender) events() []message.NodeEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]message.NodeEvent, len(s.scs))
+	for i, sc := range s.scs {
+		out[i] = sc.NewEvent
+	}
+	return out
+}
+
+// Issue #1207: while the engine builds on the wrong LCL, phase-driven status
+// changes must carry LOST_SYNC instead of CLOSING/ACCEPTED_LEDGER, and
+// entering wrongLedger itself announces LOST_SYNC (the engine pins without
+// running rounds, so no phase-driven status would go out).
+func TestStatusChange_WrongLedgerSubstitutesLostSync(t *testing.T) {
+	sender := &scRecordingSender{}
+	svc := newTestLedgerService(t)
+	a := New(Config{LedgerService: svc, Sender: sender})
+
+	_, err := svc.AcceptLedger(context.TODO())
+	require.NoError(t, err)
+
+	a.OnModeChange(consensus.ModeObserving, consensus.ModeWrongLedger)
+	a.OnPhaseChange(consensus.PhaseOpen, consensus.PhaseEstablish)
+	a.OnPhaseChange(consensus.PhaseEstablish, consensus.PhaseAccepted)
+
+	require.Equal(t, []message.NodeEvent{
+		message.NodeEventLostSync, // wrongLedger entry
+		message.NodeEventLostSync, // substituted for CLOSING_LEDGER
+		message.NodeEventLostSync, // substituted for ACCEPTED_LEDGER
+	}, sender.events())
+
+	// Recovery restores the normal events.
+	a.OnModeChange(consensus.ModeWrongLedger, consensus.ModeObserving)
+	a.OnPhaseChange(consensus.PhaseOpen, consensus.PhaseEstablish)
+	a.OnPhaseChange(consensus.PhaseEstablish, consensus.PhaseAccepted)
+
+	events := sender.events()
+	require.Len(t, events, 5)
+	assert.Equal(t, message.NodeEventClosingLedger, events[3])
+	assert.Equal(t, message.NodeEventAcceptedLedger, events[4])
+}
+
+// The SWITCHED_LEDGER broadcast carries the adopted ledger's identity and,
+// like rippled's switchLastClosedLedger message, no status or validated-range
+// fields.
+func TestStatusChange_OnLedgerSwitchedPayload(t *testing.T) {
+	sender := &scRecordingSender{}
+	svc := newTestLedgerService(t)
+	a := New(Config{LedgerService: svc, Sender: sender})
+
+	l := stubLedger{id: consensus.LedgerID{0xAA}, seq: 42, parentID: consensus.LedgerID{0xBB}}
+	a.OnLedgerSwitched(l)
+
+	sender.mu.Lock()
+	defer sender.mu.Unlock()
+	require.Len(t, sender.scs, 1)
+	sc := sender.scs[0]
+	assert.Equal(t, message.NodeEventSwitchedLedger, sc.NewEvent)
+	assert.Equal(t, uint32(42), sc.LedgerSeq)
+	assert.Equal(t, l.id[:], sc.LedgerHash)
+	assert.Equal(t, l.parentID[:], sc.LedgerHashPrevious)
+	assert.Equal(t, message.NodeStatus(0), sc.NewStatus)
+	assert.Nil(t, sc.FirstSeq)
+	assert.Nil(t, sc.LastSeq)
+	assert.NotZero(t, sc.NetworkTime)
+}
+
+// Adopting a peer's ledger during initial sync is an LCL jump and must be
+// announced to peers.
+func TestStatusChange_AdoptLedgerFromHeaderAnnouncesSwitch(t *testing.T) {
+	svc := adg_newNonStandaloneService(t)
+	sender := &scRecordingSender{}
+	a := New(Config{LedgerService: svc, Sender: sender})
+
+	cl := svc.GetClosedLedger()
+	require.NotNil(t, cl)
+	h := cl.Header()
+	raw := header.AddRaw(h, true)
+
+	require.NoError(t, a.AdoptLedgerFromHeader(raw))
+
+	sender.mu.Lock()
+	defer sender.mu.Unlock()
+	require.Len(t, sender.scs, 1)
+	sc := sender.scs[0]
+	assert.Equal(t, message.NodeEventSwitchedLedger, sc.NewEvent)
+	assert.Equal(t, h.LedgerIndex, sc.LedgerSeq)
+	assert.Equal(t, h.Hash[:], sc.LedgerHash)
+	assert.Equal(t, h.ParentHash[:], sc.LedgerHashPrevious)
+}

--- a/internal/consensus/adaptor/status_change_test.go
+++ b/internal/consensus/adaptor/status_change_test.go
@@ -118,3 +118,37 @@ func TestStatusChange_AdoptLedgerFromHeaderAnnouncesSwitch(t *testing.T) {
 	assert.Equal(t, h.Hash[:], sc.LedgerHash)
 	assert.Equal(t, h.ParentHash[:], sc.LedgerHashPrevious)
 }
+
+// A phase-driven status change omits new_status (peers inherit their last
+// record, as rippled's notify() sends none) and advertises the range we
+// durably serve — clamped up to the online-delete floor, not genesis..tip.
+func TestStatusChange_OmitsNewStatusAdvertisesServedRange(t *testing.T) {
+	sender := &scRecordingSender{}
+	svc := newTestLedgerService(t)
+	a := New(Config{LedgerService: svc, Sender: sender})
+
+	for range 3 {
+		_, err := svc.AcceptLedger(context.TODO())
+		require.NoError(t, err)
+	}
+	_, maxSeq, ok := svc.AvailableLedgerRange()
+	require.True(t, ok)
+	require.Greater(t, maxSeq, uint32(2))
+	// Only the tip is durably served: the advertised range must start at the
+	// floor, proving it is not the old hard-coded genesis lower bound.
+	svc.SetMinimumOnlineFunc(func() uint32 { return maxSeq })
+
+	a.OnPhaseChange(consensus.PhaseOpen, consensus.PhaseEstablish)
+
+	sender.mu.Lock()
+	defer sender.mu.Unlock()
+	require.Len(t, sender.scs, 1)
+	sc := sender.scs[0]
+	assert.Equal(t, message.NodeEventClosingLedger, sc.NewEvent)
+	assert.Equal(t, message.NodeStatus(0), sc.NewStatus)
+	require.NotNil(t, sc.FirstSeq)
+	require.NotNil(t, sc.LastSeq)
+	assert.Equal(t, maxSeq, *sc.FirstSeq)
+	assert.Equal(t, maxSeq, *sc.LastSeq)
+	assert.NotZero(t, sc.NetworkTime)
+}

--- a/internal/consensus/csf/engine_adaptor.go
+++ b/internal/consensus/csf/engine_adaptor.go
@@ -581,6 +581,7 @@ func (p *EnginePeer) OnLedgerFullyValidated(ledgerID consensus.LedgerID, seq uin
 
 func (p *EnginePeer) OnModeChange(consensus.Mode, consensus.Mode)    {}
 func (p *EnginePeer) OnPhaseChange(consensus.Phase, consensus.Phase) {}
+func (p *EnginePeer) OnLedgerSwitched(consensus.Ledger)              {}
 
 // helpers
 

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -309,6 +309,11 @@ type StatusEvents interface {
 	OnModeChange(oldMode, newMode Mode)
 
 	OnPhaseChange(oldPhase, newPhase Phase)
+
+	// OnLedgerSwitched fires when the engine abandons its previous LCL and
+	// adopts ledger (wrong-ledger recovery), so peers can be told the jump
+	// via a SWITCHED_LEDGER status change.
+	OnLedgerSwitched(ledger Ledger)
 }
 
 // Adaptor is the full seam between the consensus engine and the node; new code

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -555,6 +555,12 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 	// Before the mode switch so it runs in every mode (preStartRound parity).
 	e.driveNegativeUNLNewValidatorsLocked()
 
+	// A recovery restart means we just jumped to a different LCL — tell peers
+	// via SWITCHED_LEDGER so their tallies drop our abandoned ledger.
+	if recovering && e.prevLedger != nil {
+		e.adaptor.OnLedgerSwitched(e.prevLedger)
+	}
+
 	// Carry our own observed close time across rounds. The first round seeds
 	// from the seed ledger; afterwards we take the self close time of the round
 	// that just ended, read from e.state before it is replaced below (this runs

--- a/internal/consensus/rcl/engine_onledger_test.go
+++ b/internal/consensus/rcl/engine_onledger_test.go
@@ -86,6 +86,30 @@ func TestEngine_OnLedger_StopsAtChainBreak(t *testing.T) {
 	}
 }
 
+// Issue #1207: adopting a different LCL must fire OnLedgerSwitched so peers
+// are told the jump (SWITCHED_LEDGER) and drop our abandoned ledger from
+// their tallies.
+func TestEngine_OnLedger_AnnouncesSwitchedLedger(t *testing.T) {
+	a := newMockAdaptor()
+	e := NewEngine(a, DefaultConfig())
+	initial := a.ledgers[consensus.LedgerID{1}]
+	a.StoreLedger(chainLedger(101, 101, 1))
+	e.prevLedger = initial
+	e.mode = consensus.ModeWrongLedger
+
+	if err := e.OnLedger(consensus.LedgerID{101}, nil); err != nil {
+		t.Fatalf("OnLedger: %v", err)
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.switchedLedgers) != 1 {
+		t.Fatalf("OnLedgerSwitched calls = %d, want 1", len(a.switchedLedgers))
+	}
+	if got := a.switchedLedgers[0].Seq(); got != 101 {
+		t.Fatalf("switched ledger seq = %d, want 101", got)
+	}
+}
+
 func TestEngine_OnLedger_StopsAtGap(t *testing.T) {
 	a := newMockAdaptor()
 	e := NewEngine(a, DefaultConfig())

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -123,6 +123,7 @@ type mockAdaptor struct {
 	ledgersRequested     []consensus.LedgerID
 	modeChanges          []consensus.Mode
 	phaseChanges         []consensus.Phase
+	switchedLedgers      []consensus.Ledger
 
 	// Time
 	now time.Time
@@ -616,6 +617,12 @@ func (a *mockAdaptor) OnPhaseChange(oldPhase, newPhase consensus.Phase) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.phaseChanges = append(a.phaseChanges, newPhase)
+}
+
+func (a *mockAdaptor) OnLedgerSwitched(ledger consensus.Ledger) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.switchedLedgers = append(a.switchedLedgers, ledger)
 }
 
 func (a *mockAdaptor) setTrusted(nodes []consensus.NodeID) {

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -954,6 +954,33 @@ func (s *Service) AvailableLedgerRange() (min, max uint32, ok bool) {
 	return s.ledgerHistoryRangeLocked()
 }
 
+// advertisableLedgerRangeLocked returns the held [first, last] span clamped up
+// to the online-delete retention floor, so we never advertise ledgers we won't
+// serve. ok is false when nothing durable remains. Caller holds s.mu.
+func (s *Service) advertisableLedgerRangeLocked() (first, last uint32, ok bool) {
+	minSeq, maxSeq, have := s.ledgerHistoryRangeLocked()
+	if !have {
+		return 0, 0, false
+	}
+	if s.minimumOnlineFunc != nil {
+		if floor := s.minimumOnlineFunc(); floor > minSeq {
+			minSeq = floor
+		}
+	}
+	if minSeq > maxSeq {
+		return 0, 0, false
+	}
+	return minSeq, maxSeq, true
+}
+
+// AdvertisableLedgerRange is the locking wrapper over
+// advertisableLedgerRangeLocked, read by the peer status-change broadcast.
+func (s *Service) AdvertisableLedgerRange() (first, last uint32, ok bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.advertisableLedgerRangeLocked()
+}
+
 // GetValidatedLedgerIndex returns the highest validated ledger index
 func (s *Service) GetValidatedLedgerIndex() uint32 {
 	s.mu.RLock()
@@ -1074,21 +1101,10 @@ func (s *Service) GetServerInfo() ServerInfo {
 		info.ValidatedLedgerCloseTime = rippleEpochSeconds(s.validatedLedger.CloseTime())
 	}
 
-	if minSeq, maxSeq, ok := s.ledgerHistoryRangeLocked(); ok {
-		// Clamp the lower bound up to the online-delete floor: the in-memory
-		// window can outlast the node store after a rotation. complete_ledgers
-		// must report durable availability.
-		if s.minimumOnlineFunc != nil {
-			if floor := s.minimumOnlineFunc(); floor > minSeq {
-				minSeq = floor
-			}
-		}
-		switch {
-		case minSeq > maxSeq:
-			// The whole window sits below the floor — nothing durable to advertise.
-		case minSeq == maxSeq:
+	if minSeq, maxSeq, ok := s.advertisableLedgerRangeLocked(); ok {
+		if minSeq == maxSeq {
 			info.CompleteLedgers = strconv.FormatUint(uint64(minSeq), 10)
-		default:
+		} else {
 			info.CompleteLedgers = formatRange(minSeq, maxSeq)
 		}
 	}


### PR DESCRIPTION
## Summary
- rippled broadcasts a TMStatusChange on four node events; go-xrpl only ever emitted `CLOSING_LEDGER`/`ACCEPTED_LEDGER`, so peers' `checkLastClosedLedger` tallies and tracking classification kept counting an abandoned or stale LCL (#1207).
- The engine now fires a new `StatusEvents.OnLedgerSwitched` callback when a recovery round adopts a different LCL (`handleWrongLedger` found-path and `OnLedger`, which also covers catch-up completion) — the adaptor broadcasts `SWITCHED_LEDGER` carrying the adopted ledger's seq/hash/parent, with no status or validated-range fields, mirroring rippled's `switchLastClosedLedger` message. Initial peer-ledger adoption (`AdoptLedgerFromHeader`) announces the same way.
- `broadcastStatus` now substitutes `LOST_SYNC` for the phase-driven event while the consensus mode is `wrongLedger`, mirroring `RCLConsensus::Adaptor::notify()`'s `haveCorrectLCL` handling. Since go-xrpl pins in `ModeWrongLedger` without running rounds (where rippled keeps notifying `LOST_SYNC` each wrong-LCL round), entering the mode announces `LOST_SYNC` directly so peers clear our advertised LCL promptly.

## Test plan
- [x] `go test ./internal/consensus/... -count=1` — green
- [x] `just test-core` (ledger/txq/rpc/consensus/peermanagement) — green
- [x] `go test ./internal/testing/...` — only pre-existing out-of-scope Vault/XChain conformance failures (identical on main)
- [x] `golangci-lint run --config .golangci.yml ./internal/consensus/...` — 0 issues
- New tests: LOST_SYNC substitution + wrongLedger-entry announcement, SWITCHED_LEDGER payload (no status/range fields), initial-adoption announcement, engine recovery-round `OnLedgerSwitched` firing

Fixes #1207