### PR TITLE
feat: reject inbound proposals signed with our own validator key

### DIFF
--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -762,6 +762,20 @@ func (e *Engine) OnProposal(proposal *consensus.Proposal, originPeer uint64) err
 		return nil
 	}
 
+	// A trusted proposal signed with our own validator key means a duplicate-key
+	// misconfiguration (two nodes sharing our key) or our own proposal routed
+	// back to us. Drop it and log loudly — absorbing it double-counts our position.
+	if e.adaptor.IsValidator() {
+		if ourKey, err := e.adaptor.GetValidatorKey(); err == nil && proposal.NodeID == ourKey {
+			slog.Error("dropping proposal signed with our own validator key",
+				"t", "consensus",
+				"event", "self-key-proposal",
+				"peer", originPeer,
+				"node", fmt.Sprintf("%x", proposal.NodeID[:6]))
+			return nil
+		}
+	}
+
 	// Buffer for future playback, even between rounds.
 	e.proposalTracker.BufferRecent(proposal)
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -755,16 +755,12 @@ func (e *Engine) OnProposal(proposal *consensus.Proposal, originPeer uint64) err
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Drop untrusted proposals: buffering them would let throwaway keypairs
-	// grow the tracker unboundedly and feed phantom proposers into
-	// convergence counts.
-	if !e.adaptor.IsTrusted(proposal.NodeID) {
-		return nil
-	}
-
-	// A trusted proposal signed with our own validator key means a duplicate-key
+	// A proposal carrying our own validator identity — a duplicate-key
 	// misconfiguration (two nodes sharing our key) or our own proposal routed
-	// back to us. Drop it and log loudly — absorbing it double-counts our position.
+	// back to us — must not be absorbed as a foreign position; that double-counts
+	// our vote. Checked before the trust gate because we don't list our own key
+	// in our trusted set, so an unrecognised self-keyed proposal would otherwise
+	// be dropped just below as "untrusted", losing the misconfiguration signal.
 	if e.adaptor.IsValidator() {
 		if ourKey, err := e.adaptor.GetValidatorKey(); err == nil && proposal.NodeID == ourKey {
 			slog.Error("dropping proposal signed with our own validator key",
@@ -774,6 +770,13 @@ func (e *Engine) OnProposal(proposal *consensus.Proposal, originPeer uint64) err
 				"node", fmt.Sprintf("%x", proposal.NodeID[:6]))
 			return nil
 		}
+	}
+
+	// Drop untrusted proposals: buffering them would let throwaway keypairs
+	// grow the tracker unboundedly and feed phantom proposers into
+	// convergence counts.
+	if !e.adaptor.IsTrusted(proposal.NodeID) {
+		return nil
 	}
 
 	// Buffer for future playback, even between rounds.

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -1163,6 +1163,69 @@ func TestEngine_OnProposal_Untrusted(t *testing.T) {
 	}
 }
 
+// TestEngine_OnProposal_SelfKey pins issue #1210: a trusted proposal signed
+// with our own validator key — a duplicate-key misconfiguration or our own
+// proposal routed back to us — is dropped and not relayed, rather than absorbed
+// as a foreign position that would double-count our own vote. A proposal from a
+// different trusted validator is still accepted, so the drop is specific to the
+// self-key guard.
+func TestEngine_OnProposal_SelfKey(t *testing.T) {
+	adaptor := newMockAdaptor()
+	ourKey, err := adaptor.GetValidatorKey()
+	if err != nil {
+		t.Fatalf("GetValidatorKey: %v", err)
+	}
+	adaptor.setTrusted([]consensus.NodeID{ourKey, {2}})
+
+	config := DefaultConfig()
+	engine := NewEngine(adaptor, config)
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	engine.StartRound(round, true)
+
+	// A proposal carrying our own validator key is dropped.
+	selfProposal := &consensus.Proposal{
+		Round:          round,
+		NodeID:         ourKey,
+		Position:       0,
+		TxSet:          consensus.TxSetID{1},
+		CloseTime:      time.Now(),
+		PreviousLedger: consensus.LedgerID{1},
+		Timestamp:      time.Now(),
+	}
+	if err := engine.OnProposal(selfProposal, 0); err != nil {
+		t.Fatalf("OnProposal(self) returned error: %v", err)
+	}
+
+	adaptor.mu.RLock()
+	relayed := len(adaptor.proposalsRelayed)
+	adaptor.mu.RUnlock()
+	if relayed != 0 {
+		t.Errorf("self-key proposal relayed %d times, want 0", relayed)
+	}
+	if got := engine.proposalTracker.Count(); got != 0 {
+		t.Errorf("self-key proposal stored %d positions, want 0", got)
+	}
+
+	// A proposal from a different trusted validator is still accepted, proving
+	// the drop is specific to the self-key guard, not the round setup.
+	peerProposal := &consensus.Proposal{
+		Round:          round,
+		NodeID:         consensus.NodeID{2},
+		Position:       0,
+		TxSet:          consensus.TxSetID{1},
+		CloseTime:      time.Now(),
+		PreviousLedger: consensus.LedgerID{1},
+		Timestamp:      time.Now(),
+	}
+	if err := engine.OnProposal(peerProposal, 0); err != nil {
+		t.Fatalf("OnProposal(peer) returned error: %v", err)
+	}
+	if got := engine.proposalTracker.Count(); got != 1 {
+		t.Errorf("trusted peer proposal stored %d positions, want 1", got)
+	}
+}
+
 // TestEngine_StartRound_ResharesReplayedProposals pins issue #1188: after a
 // ledger switch / round start, buffered peer proposals for the new prevLedger
 // are re-shared to peers (rippled playbackProposals + adaptor_.share), not just

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -1226,6 +1226,63 @@ func TestEngine_OnProposal_SelfKey(t *testing.T) {
 	}
 }
 
+// TestEngine_OnProposal_SelfKey_UntrustedStillGuarded pins the reachability half
+// of issue #1210. Unlike rippled — which lists its own key in its trusted set —
+// go-xrpl never self-lists, so the self-key guard runs before the trust gate.
+// A proposal carrying our own validator key is therefore still recognised,
+// dropped, and logged as a misconfiguration even when our key is absent from the
+// trusted set; without the pre-gate placement the trust gate would drop it
+// silently as "untrusted" and the operator would lose the duplicate-key signal.
+func TestEngine_OnProposal_SelfKey_UntrustedStillGuarded(t *testing.T) {
+	adaptor := newMockAdaptor()
+	ourKey, err := adaptor.GetValidatorKey()
+	if err != nil {
+		t.Fatalf("GetValidatorKey: %v", err)
+	}
+	// Our own key is deliberately NOT in the trusted set.
+	adaptor.setTrusted([]consensus.NodeID{{2}})
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	config := DefaultConfig()
+	engine := NewEngine(adaptor, config)
+
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	engine.StartRound(round, true)
+
+	selfProposal := &consensus.Proposal{
+		Round:          round,
+		NodeID:         ourKey,
+		Position:       0,
+		TxSet:          consensus.TxSetID{1},
+		CloseTime:      time.Now(),
+		PreviousLedger: consensus.LedgerID{1},
+		Timestamp:      time.Now(),
+	}
+	if err := engine.OnProposal(selfProposal, 0); err != nil {
+		t.Fatalf("OnProposal(self) returned error: %v", err)
+	}
+
+	// The guard must have fired before the trust gate: with our key untrusted,
+	// a post-gate guard would never run and nothing would be logged.
+	if !strings.Contains(buf.String(), "self-key-proposal") {
+		t.Errorf("expected the self-key guard to log and drop before the trust gate; got log %q", buf.String())
+	}
+
+	adaptor.mu.RLock()
+	relayed := len(adaptor.proposalsRelayed)
+	adaptor.mu.RUnlock()
+	if relayed != 0 {
+		t.Errorf("self-key proposal relayed %d times, want 0", relayed)
+	}
+	if got := engine.proposalTracker.Count(); got != 0 {
+		t.Errorf("self-key proposal stored %d positions, want 0", got)
+	}
+}
+
 // TestEngine_StartRound_ResharesReplayedProposals pins issue #1188: after a
 // ledger switch / round start, buffered peer proposals for the new prevLedger
 // are re-shared to peers (rippled playbackProposals + adaptor_.share), not just


### PR DESCRIPTION
## Summary
- `OnProposal` now drops (and does not relay) a trusted proposal whose master-derived `NodeID` matches our own validator key, before it is buffered, stored, or relayed — mirroring rippled's `processTrustedProposal` self-key guard (`NetworkOPs.cpp`).
- Such a proposal means either a duplicate-key misconfiguration (two nodes running the same validator key) or our own proposal routed back to us via a third peer; absorbing it double-counts our own position. It is now surfaced with a loud `ERROR` log for operators.
- A single `NodeID` comparison covers both of rippled's arms (signing + master key) because the consensus router already substitutes the master key before quorum lookups reach `OnProposal`.

## Test plan
- [x] `go test ./internal/consensus/...` (all green)
- [x] New `TestEngine_OnProposal_SelfKey`: a proposal carrying our own key is dropped (not relayed, not stored), while a proposal from a different trusted validator is still accepted — proving the drop is specific to the self-key guard.
- [x] `golangci-lint run --config .golangci.yml ./internal/consensus/rcl/...` (0 issues)

Fixes #1210