### PR TITLE
fix: widen remote-fee median to parent ledger and full validations only

### DIFF
--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -1713,8 +1713,9 @@ func buildValidationEvent(e *consensus.ValidationReceivedEvent, manifests *manif
 	if v.Cookie != 0 {
 		ev.Cookie = strconv.FormatUint(v.Cookie, 10)
 	}
-	if v.LoadFee != 0 {
-		ev.LoadFee = v.LoadFee
+	if v.HasLoadFee() {
+		loadFee := v.LoadFee
+		ev.LoadFee = &loadFee
 	}
 	if v.ServerVersion != 0 {
 		ev.ServerVersion = strconv.FormatUint(v.ServerVersion, 10)

--- a/internal/cli/server_helpers_test.go
+++ b/internal/cli/server_helpers_test.go
@@ -274,6 +274,48 @@ func TestBuildValidationEvent_ServerVersionDecimal(t *testing.T) {
 	}
 }
 
+func TestBuildValidationEvent_LoadFeePresence(t *testing.T) {
+	explicitZero := &consensus.Validation{}
+	explicitZero.SetLoadFee(0)
+	tests := []struct {
+		name       string
+		validation *consensus.Validation
+		wantJSON   string
+	}{
+		{name: "absent", validation: &consensus.Validation{}},
+		{name: "explicit zero", validation: explicitZero, wantJSON: "0"},
+		{name: "legacy non-zero literal", validation: &consensus.Validation{LoadFee: 320}, wantJSON: "320"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event := buildValidationEvent(&consensus.ValidationReceivedEvent{Validation: test.validation}, nil, 0)
+			encoded, err := json.Marshal(event)
+			if err != nil {
+				t.Fatalf("marshal validation event: %v", err)
+			}
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(encoded, &fields); err != nil {
+				t.Fatalf("decode validation event: %v", err)
+			}
+
+			loadFee, present := fields["load_fee"]
+			if test.wantJSON == "" {
+				if event.LoadFee != nil || present {
+					t.Fatalf("load_fee must be omitted: event=%v json=%s", event.LoadFee, encoded)
+				}
+				return
+			}
+			if event.LoadFee == nil || !present {
+				t.Fatalf("load_fee missing: event=%v json=%s", event.LoadFee, encoded)
+			}
+			if got := string(loadFee); got != test.wantJSON {
+				t.Fatalf("load_fee JSON = %s; want %s", got, test.wantJSON)
+			}
+		})
+	}
+}
+
 func TestAcceptedLedgerView_Nil(t *testing.T) {
 	v := newAcceptedLedgerView(nil)
 	if v.Sequence() != 0 || v.Hash() != ([32]byte{}) || v.CloseTime() != 0 || v.IsValidated() {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1808,9 +1808,11 @@ func (a *Adaptor) OnLedgerFullyValidated(ledgerID consensus.LedgerID, seq uint32
 	)
 }
 
-// refreshRemoteFee takes the sfLoadFee of each trusted validation
-// (defaulting to LoadBase when the validator omitted the field) and
-// forwards the median to LoadFeeTrack.
+// refreshRemoteFee takes the sfLoadFee of each trusted, FULL validation
+// (defaulting to LoadBase when the validator omitted the field) across
+// both the validated ledger and its parent, and forwards the median to
+// LoadFeeTrack. Partial validations are excluded, and folding in the
+// parent widens the sample the same way rippled does.
 func (a *Adaptor) refreshRemoteFee(ledgerID consensus.LedgerID) {
 	if a.ledgerService == nil || a.validationHistorian == nil {
 		return
@@ -1819,14 +1821,28 @@ func (a *Adaptor) refreshRemoteFee(ledgerID consensus.LedgerID) {
 	if ft == nil {
 		return
 	}
-	vals := a.validationHistorian.GetTrustedValidations(ledgerID)
-	if len(vals) == 0 {
+	base := ft.GetLoadBase()
+
+	fees := a.collectValidationFees(ledgerID, base)
+	if l, err := a.ledgerService.GetLedgerByHash(ledgerID); err == nil && l != nil {
+		fees = append(fees, a.collectValidationFees(consensus.LedgerID(l.ParentHash()), base)...)
+	}
+	if len(fees) == 0 {
 		return
 	}
-	base := ft.GetLoadBase()
+	slices.Sort(fees)
+	ft.SetRemoteFee(fees[len(fees)/2])
+}
+
+// collectValidationFees returns the sfLoadFee (defaulting to base when
+// the validator omitted the field) of each trusted, FULL validation of
+// ledgerID. Trusted partials are dropped so only finality-bearing
+// validations feed the remote-fee median.
+func (a *Adaptor) collectValidationFees(ledgerID consensus.LedgerID, base uint32) []uint32 {
+	vals := a.validationHistorian.GetTrustedValidations(ledgerID)
 	fees := make([]uint32, 0, len(vals))
 	for _, v := range vals {
-		if v == nil {
+		if v == nil || !v.Full {
 			continue
 		}
 		fee := v.LoadFee
@@ -1835,11 +1851,7 @@ func (a *Adaptor) refreshRemoteFee(ledgerID consensus.LedgerID) {
 		}
 		fees = append(fees, fee)
 	}
-	if len(fees) == 0 {
-		return
-	}
-	slices.Sort(fees)
-	ft.SetRemoteFee(fees[len(fees)/2])
+	return fees
 }
 
 func (a *Adaptor) OnModeChange(oldMode, newMode consensus.Mode) {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1817,7 +1817,6 @@ func (a *Adaptor) OnLedgerFullyValidated(ledgerID consensus.LedgerID, seq uint32
 	)
 }
 
-// refreshRemoteFee updates the remote fee for a newly promoted validated tip.
 func (a *Adaptor) refreshRemoteFee(seq uint32, ledgerID, parentID consensus.LedgerID) {
 	if a.ledgerService == nil {
 		return

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -205,6 +205,11 @@ type Adaptor struct {
 	// wiring — GenerateNegativeUNLPseudoTx degrades to no vote.
 	validationHistorian consensus.ValidationHistorian
 
+	// remoteFeeMu serializes validated-ledger callbacks so a delayed older
+	// notification cannot overwrite the fee computed for a newer ledger.
+	remoteFeeMu  sync.Mutex
+	remoteFeeSeq uint32
+
 	txSetCache *TxSetCache
 
 	// Peer-reported last-closed ledger hashes, keyed by overlay peer ID.
@@ -493,7 +498,7 @@ func New(cfg Config) *Adaptor {
 		negUNLVoter = negativeunlvote.NewVoter(cfg.Identity.NodeID)
 	}
 
-	return &Adaptor{
+	a := &Adaptor{
 		ledgerService:     cfg.LedgerService,
 		sender:            sender,
 		identity:          cfg.Identity,
@@ -517,6 +522,12 @@ func New(cfg Config) *Adaptor {
 		relayValidations:  cfg.RelayValidations,
 		logger:            logger,
 	}
+	if a.ledgerService != nil {
+		a.ledgerService.SetOnValidatedLedger(func(seq uint32, hash, parentHash [32]byte) {
+			a.refreshRemoteFee(seq, consensus.LedgerID(hash), consensus.LedgerID(parentHash))
+		})
+	}
+	return a
 }
 
 // SetValidationHistorian wires per-ledger trusted-validation lookups into the
@@ -1795,58 +1806,62 @@ func (a *Adaptor) ancestorOf(ledger consensus.Ledger, targetSeq uint32) consensu
 
 // OnLedgerFullyValidated fires at trusted-validation quorum. It advances the
 // service's validated_ledger only if our stored ledger at that seq has the
-// matching hash (fork safety, keyed on the ledger not seq alone), then refreshes
-// LoadFeeTrack's remoteFee from the median sfLoadFee across trusted validations.
+// matching hash (fork safety, keyed on the ledger not seq alone).
 func (a *Adaptor) OnLedgerFullyValidated(ledgerID consensus.LedgerID, seq uint32) {
 	var hash [32]byte
 	copy(hash[:], ledgerID[:])
 	a.ledgerService.SetValidatedLedger(seq, hash)
-	a.refreshRemoteFee(ledgerID)
 	a.logger.Info("Ledger fully validated",
 		"seq", seq,
 		"hash", fmt.Sprintf("%x", hash[:8]),
 	)
 }
 
-// refreshRemoteFee takes the sfLoadFee of each trusted, FULL validation
-// (defaulting to LoadBase when the validator omitted the field) across
-// both the validated ledger and its parent, and forwards the median to
-// LoadFeeTrack. Partial validations are excluded, and folding in the
-// parent widens the sample the same way rippled does.
-func (a *Adaptor) refreshRemoteFee(ledgerID consensus.LedgerID) {
-	if a.ledgerService == nil || a.validationHistorian == nil {
+// refreshRemoteFee updates the remote fee for a newly promoted validated tip.
+func (a *Adaptor) refreshRemoteFee(seq uint32, ledgerID, parentID consensus.LedgerID) {
+	if a.ledgerService == nil {
 		return
 	}
+
+	a.mu.Lock()
+	historian := a.validationHistorian
+	a.mu.Unlock()
+
+	a.remoteFeeMu.Lock()
+	defer a.remoteFeeMu.Unlock()
+	if seq <= a.remoteFeeSeq {
+		return
+	}
+	if historian == nil {
+		return
+	}
+
 	ft := a.ledgerService.FeeTrack()
 	if ft == nil {
 		return
 	}
 	base := ft.GetLoadBase()
 
-	fees := a.collectValidationFees(ledgerID, base)
-	if l, err := a.ledgerService.GetLedgerByHash(ledgerID); err == nil && l != nil {
-		fees = append(fees, a.collectValidationFees(consensus.LedgerID(l.ParentHash()), base)...)
+	fees := collectValidationFees(historian, ledgerID, base)
+	fees = append(fees, collectValidationFees(historian, parentID, base)...)
+	fee := base
+	if len(fees) > 0 {
+		slices.Sort(fees)
+		fee = fees[len(fees)/2]
 	}
-	if len(fees) == 0 {
-		return
-	}
-	slices.Sort(fees)
-	ft.SetRemoteFee(fees[len(fees)/2])
+	ft.SetRemoteFee(fee)
+	a.remoteFeeSeq = seq
 }
 
-// collectValidationFees returns the sfLoadFee (defaulting to base when
-// the validator omitted the field) of each trusted, FULL validation of
-// ledgerID. Trusted partials are dropped so only finality-bearing
-// validations feed the remote-fee median.
-func (a *Adaptor) collectValidationFees(ledgerID consensus.LedgerID, base uint32) []uint32 {
-	vals := a.validationHistorian.GetTrustedValidations(ledgerID)
+func collectValidationFees(historian consensus.ValidationHistorian, ledgerID consensus.LedgerID, base uint32) []uint32 {
+	vals := historian.GetTrustedValidations(ledgerID)
 	fees := make([]uint32, 0, len(vals))
 	for _, v := range vals {
 		if v == nil || !v.Full {
 			continue
 		}
 		fee := v.LoadFee
-		if fee == 0 {
+		if !v.HasLoadFee() {
 			fee = base
 		}
 		fees = append(fees, fee)

--- a/internal/consensus/adaptor/refresh_remote_fee_test.go
+++ b/internal/consensus/adaptor/refresh_remote_fee_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
+	ledgerheader "github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/stretchr/testify/require"
 )
 
@@ -230,6 +231,103 @@ func TestRefreshRemoteFee_ValidationBeforePeerAdoption(t *testing.T) {
 	require.Equal(t, []consensus.LedgerID{targetID, parentID}, historian.lookupCalls())
 
 	a.OnLedgerFullyValidated(targetID, header.LedgerIndex)
+	require.Equal(t, []consensus.LedgerID{targetID, parentID}, historian.lookupCalls())
+}
+
+func TestRefreshRemoteFee_ValidationBeforeHeaderAdoption(t *testing.T) {
+	svc := adg_newNonStandaloneService(t)
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	a := New(Config{
+		LedgerService: svc,
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+	})
+	ft := svc.FeeTrack()
+	parent := svc.GetClosedLedger()
+	require.NotNil(t, parent)
+
+	closeTime := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	candidate, err := ledger.NewOpen(parent, closeTime)
+	require.NoError(t, err)
+	require.NoError(t, candidate.Close(closeTime, 0))
+	header := candidate.Header()
+	targetID := consensus.LedgerID(header.Hash)
+	parentID := consensus.LedgerID(header.ParentHash)
+	historian := &recordingFeeHistorian{stubHistorian: &stubHistorian{
+		byLedger: map[consensus.LedgerID][]*consensus.Validation{
+			targetID: {{LoadFee: 320, Full: true}},
+			parentID: {{LoadFee: 500, Full: true}, {LoadFee: 500, Full: true}},
+		},
+	}}
+	a.SetValidationHistorian(historian)
+
+	ft.SetRemoteFee(777)
+	a.OnLedgerFullyValidated(targetID, header.LedgerIndex)
+	require.Equal(t, uint32(777), ft.GetRemoteFee())
+	require.Empty(t, historian.lookupCalls())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.AdoptLedgerFromHeader(ledgerheader.AddRaw(header, true))
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("header adoption blocked while notifying the validated-ledger callback")
+	}
+
+	require.Equal(t, header.LedgerIndex, svc.GetValidatedLedgerIndex())
+	require.Equal(t, uint32(500), ft.GetRemoteFee())
+	require.Equal(t, []consensus.LedgerID{targetID, parentID}, historian.lookupCalls())
+}
+
+func TestRefreshRemoteFee_ValidationBeforeHeaderReAdoption(t *testing.T) {
+	svc := adg_newNonStandaloneService(t)
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	a := New(Config{
+		LedgerService: svc,
+		Identity:      identity,
+		Validators:    []consensus.NodeID{identity.NodeID},
+	})
+
+	_, first, _, _ := buildSuccessorAgainstParent(t, svc.GetClosedLedger())
+	firstHeader := first.Header()
+	require.NoError(t, svc.AdoptLedgerHeader(&firstHeader))
+
+	_, second, _, _ := buildSuccessorAgainstParent(t, svc.GetClosedLedger())
+	secondHeader := second.Header()
+	targetID := consensus.LedgerID(secondHeader.Hash)
+	parentID := consensus.LedgerID(secondHeader.ParentHash)
+	historian := &recordingFeeHistorian{stubHistorian: &stubHistorian{
+		byLedger: map[consensus.LedgerID][]*consensus.Validation{
+			targetID: {{LoadFee: 320, Full: true}},
+			parentID: {{LoadFee: 500, Full: true}, {LoadFee: 500, Full: true}},
+		},
+	}}
+	a.SetValidationHistorian(historian)
+
+	ft := svc.FeeTrack()
+	ft.SetRemoteFee(777)
+	a.OnLedgerFullyValidated(targetID, secondHeader.LedgerIndex)
+	require.Equal(t, uint32(777), ft.GetRemoteFee())
+	require.Empty(t, historian.lookupCalls())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.ReAdoptLedgerHeader(&secondHeader)
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("header re-adoption blocked while notifying the validated-ledger callback")
+	}
+
+	require.Equal(t, secondHeader.LedgerIndex, svc.GetValidatedLedgerIndex())
+	require.Equal(t, uint32(500), ft.GetRemoteFee())
 	require.Equal(t, []consensus.LedgerID{targetID, parentID}, historian.lookupCalls())
 }
 

--- a/internal/consensus/adaptor/refresh_remote_fee_test.go
+++ b/internal/consensus/adaptor/refresh_remote_fee_test.go
@@ -1,11 +1,35 @@
 package adaptor
 
 import (
+	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/stretchr/testify/require"
 )
+
+type recordingFeeHistorian struct {
+	*stubHistorian
+	mu    sync.Mutex
+	calls []consensus.LedgerID
+}
+
+func (h *recordingFeeHistorian) GetTrustedValidations(id consensus.LedgerID) []*consensus.Validation {
+	h.mu.Lock()
+	h.calls = append(h.calls, id)
+	h.mu.Unlock()
+	return h.stubHistorian.GetTrustedValidations(id)
+}
+
+func (h *recordingFeeHistorian) lookupCalls() []consensus.LedgerID {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]consensus.LedgerID(nil), h.calls...)
+}
 
 // TestRefreshRemoteFee_MedianOverTrustedValidations pins the
 // LedgerMaster.cpp:977-1006 port: collect LoadFee from trusted FULL
@@ -29,7 +53,7 @@ func TestRefreshRemoteFee_MedianOverTrustedValidations(t *testing.T) {
 		},
 	})
 
-	a.refreshRemoteFee(id)
+	a.refreshRemoteFee(1, id, consensus.LedgerID{})
 
 	// Sorted set: {256, 320, 500}; middle = 320.
 	if got := ft.GetRemoteFee(); got != 320 {
@@ -55,7 +79,7 @@ func TestRefreshRemoteFee_ExcludesPartialValidations(t *testing.T) {
 		},
 	})
 
-	a.refreshRemoteFee(id)
+	a.refreshRemoteFee(1, id, consensus.LedgerID{})
 
 	// Full-only set: {320, 400}; median index 1 = 400. Had the partial
 	// leaked, {10, 320, 400} would give median 320 — so 400 proves the
@@ -74,27 +98,34 @@ func TestRefreshRemoteFee_NoHistorian(t *testing.T) {
 		t.Fatal("FeeTrack must be non-nil")
 	}
 	before := ft.GetRemoteFee()
-	a.refreshRemoteFee(consensus.LedgerID{0xBB})
+	a.refreshRemoteFee(1, consensus.LedgerID{0xBB}, consensus.LedgerID{})
 	if got := ft.GetRemoteFee(); got != before {
 		t.Fatalf("RemoteFee changed without historian: before=%d after=%d", before, got)
 	}
 }
 
-// TestRefreshRemoteFee_EmptyValidations leaves the remote fee untouched
-// when the historian has no validations for the ledger — matches the
-// "no signal → no change" pattern (rippled also short-circuits when
-// fees is empty by falling through to base, but the median we'd compute
-// over a single base-only sample is meaningless).
+// TestRefreshRemoteFee_EmptyValidations resets the remote fee to LoadBase
+// through the normal validated-ledger promotion path when neither ledger has a
+// fee sample.
 func TestRefreshRemoteFee_EmptyValidations(t *testing.T) {
 	a := newTestAdaptor(t)
-	ft := a.ledgerService.FeeTrack()
+	svc := a.ledgerService
+	ft := svc.FeeTrack()
+	parent := svc.GetClosedLedger()
+	require.NotNil(t, parent)
+	seq, err := svc.AcceptConsensusResult(context.Background(), parent, nil, nil, time.Unix(1_700_000_000, 0), true)
+	require.NoError(t, err)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	require.Equal(t, seq, closed.Sequence())
+
 	ft.SetRemoteFee(777)
 	a.SetValidationHistorian(&stubHistorian{
 		byLedger: map[consensus.LedgerID][]*consensus.Validation{},
 	})
-	a.refreshRemoteFee(consensus.LedgerID{0xCC})
-	if got := ft.GetRemoteFee(); got != 777 {
-		t.Fatalf("RemoteFee mutated on empty validations: got %d, want 777", got)
+	a.OnLedgerFullyValidated(consensus.LedgerID(closed.Hash()), seq)
+	if got := ft.GetRemoteFee(); got != ft.GetLoadBase() {
+		t.Fatalf("RemoteFee = %d on empty validations; want LoadBase %d", got, ft.GetLoadBase())
 	}
 }
 
@@ -122,13 +153,131 @@ func TestRefreshRemoteFee_FoldsParentLedgerValidations(t *testing.T) {
 		},
 	})
 
-	a.refreshRemoteFee(id)
+	a.refreshRemoteFee(1, id, parentID)
 
 	// Union {320, 500, 500}; median index 1 = 500. The current ledger
 	// alone would yield 320, so 500 proves the parent was folded in.
 	if got := ft.GetRemoteFee(); got != 500 {
 		t.Fatalf("RemoteFee = %d; want 500 (parent validations folded in)", got)
 	}
+}
+
+func TestCollectValidationFees_DistinguishesExplicitZeroFromAbsent(t *testing.T) {
+	id := consensus.LedgerID{0xDD}
+	explicitZero := &consensus.Validation{Full: true}
+	explicitZero.SetLoadFee(0)
+	historian := &stubHistorian{
+		byLedger: map[consensus.LedgerID][]*consensus.Validation{
+			id: {
+				{Full: true},
+				explicitZero,
+			},
+		},
+	}
+
+	require.Equal(t, []uint32{feetrack.LoadBase, 0}, collectValidationFees(historian, id, feetrack.LoadBase))
+}
+
+func TestRefreshRemoteFee_ValidationBeforePeerAdoption(t *testing.T) {
+	a := newTestAdaptor(t)
+	svc := a.ledgerService
+	ft := svc.FeeTrack()
+	parent := svc.GetClosedLedger()
+	require.NotNil(t, parent)
+
+	closeTime := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	candidate, err := ledger.NewOpen(parent, closeTime)
+	require.NoError(t, err)
+	require.NoError(t, candidate.Close(closeTime, 0))
+	header := candidate.Header()
+	stateMap, err := candidate.StateMapSnapshot()
+	require.NoError(t, err)
+	txMap, err := candidate.TxMapSnapshot()
+	require.NoError(t, err)
+
+	targetID := consensus.LedgerID(header.Hash)
+	parentID := consensus.LedgerID(header.ParentHash)
+	historian := &recordingFeeHistorian{stubHistorian: &stubHistorian{
+		byLedger: map[consensus.LedgerID][]*consensus.Validation{
+			targetID: {{LoadFee: 320, Full: true}},
+			parentID: {{LoadFee: 500, Full: true}, {LoadFee: 500, Full: true}},
+		},
+	}}
+	a.SetValidationHistorian(historian)
+	svc.SetOnValidatedLedger(func(seq uint32, hash, parentHash [32]byte) {
+		svc.GetValidatedLedgerIndex()
+		a.refreshRemoteFee(seq, consensus.LedgerID(hash), consensus.LedgerID(parentHash))
+	})
+
+	ft.SetRemoteFee(777)
+	a.OnLedgerFullyValidated(targetID, header.LedgerIndex)
+	require.Equal(t, uint32(777), ft.GetRemoteFee())
+	require.Empty(t, historian.lookupCalls())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.AdoptLedgerWithState(context.Background(), &header, stateMap, txMap)
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("peer adoption blocked while notifying the validated-ledger callback")
+	}
+
+	require.Equal(t, header.LedgerIndex, svc.GetValidatedLedgerIndex())
+	require.Equal(t, uint32(500), ft.GetRemoteFee())
+	require.Equal(t, []consensus.LedgerID{targetID, parentID}, historian.lookupCalls())
+
+	a.OnLedgerFullyValidated(targetID, header.LedgerIndex)
+	require.Equal(t, []consensus.LedgerID{targetID, parentID}, historian.lookupCalls())
+}
+
+func TestRefreshRemoteFee_ValidationBeforeConsensusClose(t *testing.T) {
+	a := newTestAdaptor(t)
+	svc := a.ledgerService
+	ft := svc.FeeTrack()
+	parent := svc.GetClosedLedger()
+	require.NotNil(t, parent)
+	closeTime := time.Unix(1_700_000_000, 0)
+
+	probe := newTestLedgerService(t)
+	_, err := probe.AcceptConsensusResult(context.Background(), parent, nil, nil, closeTime, true)
+	require.NoError(t, err)
+	expected := probe.GetClosedLedger()
+	require.NotNil(t, expected)
+
+	targetID := consensus.LedgerID(expected.Hash())
+	parentID := consensus.LedgerID(expected.ParentHash())
+	historian := &recordingFeeHistorian{stubHistorian: &stubHistorian{
+		byLedger: map[consensus.LedgerID][]*consensus.Validation{
+			targetID: {{LoadFee: 320, Full: true}},
+			parentID: {{LoadFee: 500, Full: true}, {LoadFee: 500, Full: true}},
+		},
+	}}
+	a.SetValidationHistorian(historian)
+
+	ft.SetRemoteFee(777)
+	a.OnLedgerFullyValidated(targetID, expected.Sequence())
+	require.Equal(t, uint32(777), ft.GetRemoteFee())
+	require.Empty(t, historian.lookupCalls())
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := svc.AcceptConsensusResult(context.Background(), parent, nil, nil, closeTime, true)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("consensus close blocked while notifying the validated-ledger callback")
+	}
+
+	require.Equal(t, expected.Hash(), svc.GetClosedLedger().Hash())
+	require.Equal(t, expected.Sequence(), svc.GetValidatedLedgerIndex())
+	require.Equal(t, uint32(500), ft.GetRemoteFee())
+	require.Equal(t, []consensus.LedgerID{targetID, parentID}, historian.lookupCalls())
 }
 
 // TestGetLoadFee_MaxLocalCluster pins RCLConsensus.cpp:872 port: the

--- a/internal/consensus/adaptor/refresh_remote_fee_test.go
+++ b/internal/consensus/adaptor/refresh_remote_fee_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TestRefreshRemoteFee_MedianOverTrustedValidations pins the
-// LedgerMaster.cpp:977-1006 port: collect LoadFee from trusted
+// LedgerMaster.cpp:977-1006 port: collect LoadFee from trusted FULL
 // validations (substituting LoadBase for any that omitted the field),
 // sort, and forward the median to FeeTrack.SetRemoteFee.
 func TestRefreshRemoteFee_MedianOverTrustedValidations(t *testing.T) {
@@ -22,9 +22,9 @@ func TestRefreshRemoteFee_MedianOverTrustedValidations(t *testing.T) {
 	a.SetValidationHistorian(&stubHistorian{
 		byLedger: map[consensus.LedgerID][]*consensus.Validation{
 			id: {
-				{LoadFee: 320},
-				{LoadFee: 0}, // omitted → substituted with LoadBase=256
-				{LoadFee: 500},
+				{LoadFee: 320, Full: true},
+				{LoadFee: 0, Full: true}, // omitted → substituted with LoadBase=256
+				{LoadFee: 500, Full: true},
 			},
 		},
 	})
@@ -34,6 +34,34 @@ func TestRefreshRemoteFee_MedianOverTrustedValidations(t *testing.T) {
 	// Sorted set: {256, 320, 500}; middle = 320.
 	if got := ft.GetRemoteFee(); got != 320 {
 		t.Fatalf("RemoteFee = %d; want 320", got)
+	}
+}
+
+// TestRefreshRemoteFee_ExcludesPartialValidations pins the
+// Validations::fees() Full-only filter: trusted PARTIAL validations must
+// not leak into the median even though GetTrustedValidations returns them.
+func TestRefreshRemoteFee_ExcludesPartialValidations(t *testing.T) {
+	a := newTestAdaptor(t)
+	ft := a.ledgerService.FeeTrack()
+
+	id := consensus.LedgerID{0xAA}
+	a.SetValidationHistorian(&stubHistorian{
+		byLedger: map[consensus.LedgerID][]*consensus.Validation{
+			id: {
+				{LoadFee: 320, Full: true},
+				{LoadFee: 10, Full: false}, // partial → dropped
+				{LoadFee: 400, Full: true},
+			},
+		},
+	})
+
+	a.refreshRemoteFee(id)
+
+	// Full-only set: {320, 400}; median index 1 = 400. Had the partial
+	// leaked, {10, 320, 400} would give median 320 — so 400 proves the
+	// Full filter applied.
+	if got := ft.GetRemoteFee(); got != 400 {
+		t.Fatalf("RemoteFee = %d; want 400 (partial excluded)", got)
 	}
 }
 
@@ -67,6 +95,39 @@ func TestRefreshRemoteFee_EmptyValidations(t *testing.T) {
 	a.refreshRemoteFee(consensus.LedgerID{0xCC})
 	if got := ft.GetRemoteFee(); got != 777 {
 		t.Fatalf("RemoteFee mutated on empty validations: got %d, want 777", got)
+	}
+}
+
+// TestRefreshRemoteFee_FoldsParentLedgerValidations pins the
+// LedgerMaster.cpp:978-984 parent concatenation: the median is taken
+// over the union of the validated ledger's and its parent's trusted
+// full validations, not the current ledger alone.
+func TestRefreshRemoteFee_FoldsParentLedgerValidations(t *testing.T) {
+	a := newTestAdaptor(t)
+	svc := a.ledgerService
+	ft := svc.FeeTrack()
+
+	// A real ledger so refreshRemoteFee can resolve its parent hash.
+	l := svc.GetClosedLedger()
+	if l == nil {
+		t.Fatal("closed ledger must exist in the test service")
+	}
+	id := consensus.LedgerID(l.Hash())
+	parentID := consensus.LedgerID(l.ParentHash())
+
+	a.SetValidationHistorian(&stubHistorian{
+		byLedger: map[consensus.LedgerID][]*consensus.Validation{
+			id:       {{LoadFee: 320, Full: true}},
+			parentID: {{LoadFee: 500, Full: true}, {LoadFee: 500, Full: true}},
+		},
+	})
+
+	a.refreshRemoteFee(id)
+
+	// Union {320, 500, 500}; median index 1 = 500. The current ledger
+	// alone would yield 320, so 500 proves the parent was folded in.
+	if got := ft.GetRemoteFee(); got != 500 {
+		t.Fatalf("RemoteFee = %d; want 500 (parent validations folded in)", got)
 	}
 }
 

--- a/internal/consensus/adaptor/refresh_remote_fee_test.go
+++ b/internal/consensus/adaptor/refresh_remote_fee_test.go
@@ -62,9 +62,6 @@ func TestRefreshRemoteFee_MedianOverTrustedValidations(t *testing.T) {
 	}
 }
 
-// TestRefreshRemoteFee_ExcludesPartialValidations pins the
-// Validations::fees() Full-only filter: trusted PARTIAL validations must
-// not leak into the median even though GetTrustedValidations returns them.
 func TestRefreshRemoteFee_ExcludesPartialValidations(t *testing.T) {
 	a := newTestAdaptor(t)
 	ft := a.ledgerService.FeeTrack()
@@ -105,9 +102,6 @@ func TestRefreshRemoteFee_NoHistorian(t *testing.T) {
 	}
 }
 
-// TestRefreshRemoteFee_EmptyValidations resets the remote fee to LoadBase
-// through the normal validated-ledger promotion path when neither ledger has a
-// fee sample.
 func TestRefreshRemoteFee_EmptyValidations(t *testing.T) {
 	a := newTestAdaptor(t)
 	svc := a.ledgerService
@@ -139,7 +133,6 @@ func TestRefreshRemoteFee_FoldsParentLedgerValidations(t *testing.T) {
 	svc := a.ledgerService
 	ft := svc.FeeTrack()
 
-	// A real ledger so refreshRemoteFee can resolve its parent hash.
 	l := svc.GetClosedLedger()
 	if l == nil {
 		t.Fatal("closed ledger must exist in the test service")

--- a/internal/consensus/adaptor/stvalidation.go
+++ b/internal/consensus/adaptor/stvalidation.go
@@ -157,7 +157,7 @@ func parseSTValidation(data []byte) (*consensus.Validation, error) {
 			v.CloseTime = xrplEpochToTime(epoch)
 
 		case typeCode == typeUINT32 && fieldCode == fieldLoadFee:
-			v.LoadFee = binary.BigEndian.Uint32(fieldData)
+			v.SetLoadFee(binary.BigEndian.Uint32(fieldData))
 
 		case typeCode == typeUINT32 && fieldCode == fieldReserveBase:
 			v.ReserveBase = binary.BigEndian.Uint32(fieldData)
@@ -254,8 +254,8 @@ func parseSTValidation(data []byte) (*consensus.Validation, error) {
 // code, then ascending field code within each type).
 //
 // Outbound validations set both vfFullValidation and vfFullyCanonicalSig on
-// sfFlags. Optional supplementary fields (Cookie, LoadFee, ConsensusHash,
-// ServerVersion) are emitted only when non-zero.
+// sfFlags. Optional supplementary fields are emitted when present; fields
+// without explicit presence tracking use a non-zero value as their proxy.
 //
 // Exported so external packages (the validation archive) can reserialize
 // self-built validations whose Raw field is nil.
@@ -290,7 +290,7 @@ func SerializeSTValidation(v *consensus.Validation) []byte {
 	buf = binary.BigEndian.AppendUint32(buf, timeToXrplEpoch(v.SignTime))
 
 	// sfLoadFee (field 24) — optional
-	if v.LoadFee != 0 {
+	if v.HasLoadFee() {
 		buf = appendFieldHeader(buf, typeUINT32, fieldLoadFee)
 		buf = binary.BigEndian.AppendUint32(buf, v.LoadFee)
 	}

--- a/internal/consensus/adaptor/stvalidation_test.go
+++ b/internal/consensus/adaptor/stvalidation_test.go
@@ -51,7 +51,49 @@ func TestParseSTValidation_Roundtrip(t *testing.T) {
 	assert.Equal(t, orig.Signature, parsed.Signature)
 	assert.Equal(t, orig.Cookie, parsed.Cookie)
 	assert.Equal(t, orig.LoadFee, parsed.LoadFee)
+	assert.True(t, parsed.HasLoadFee())
 	assert.WithinDuration(t, orig.SignTime, parsed.SignTime, time.Second)
+}
+
+func TestSTValidation_LoadFeePresenceRoundTrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		configure   func(*consensus.Validation)
+		wantPresent bool
+		wantFee     uint32
+	}{
+		{
+			name: "absent",
+			configure: func(v *consensus.Validation) {
+				v.LoadFee = 0
+			},
+		},
+		{
+			name: "explicit zero",
+			configure: func(v *consensus.Validation) {
+				v.SetLoadFee(0)
+			},
+			wantPresent: true,
+		},
+		{
+			name:        "legacy non-zero literal",
+			configure:   func(*consensus.Validation) {},
+			wantPresent: true,
+			wantFee:     5000,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			validation := buildTestValidation()
+			test.configure(validation)
+
+			parsed, err := parseSTValidation(SerializeSTValidation(validation))
+			require.NoError(t, err)
+			assert.Equal(t, test.wantPresent, parsed.HasLoadFee())
+			assert.Equal(t, test.wantFee, parsed.LoadFee)
+		})
+	}
 }
 
 func TestParseSTValidation_PopulatesRaw(t *testing.T) {

--- a/internal/consensus/types.go
+++ b/internal/consensus/types.go
@@ -251,6 +251,9 @@ type Validation struct {
 
 	// LoadFee is the validator's current load-based fee.
 	LoadFee uint32
+	// loadFeePresent distinguishes an explicit sfLoadFee value of zero from an
+	// omitted field. Non-zero legacy struct literals are treated as present too.
+	loadFeePresent bool
 
 	// ConsensusHash is sfConsensusHash — the hash of the agreed-upon
 	// transaction set that produced the validated ledger. Rippled
@@ -326,6 +329,18 @@ type Validation struct {
 	// Used by the validation archive to persist the canonical blob
 	// without a parse → re-serialize round-trip.
 	Raw []byte
+}
+
+// SetLoadFee records sfLoadFee as present, including when fee is zero.
+func (v *Validation) SetLoadFee(fee uint32) {
+	v.LoadFee = fee
+	v.loadFeePresent = true
+}
+
+// HasLoadFee reports whether sfLoadFee was present on the wire or populated by
+// a legacy non-zero struct literal.
+func (v *Validation) HasLoadFee() bool {
+	return v != nil && (v.loadFeePresent || v.LoadFee != 0)
 }
 
 // ByzantineValidationError reports a validation that conflicts with one

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -161,20 +161,26 @@ func FromGenesis(
 	}
 }
 
-// NewFromHeader creates a closed/validated ledger from a deserialized header
-// and existing state/tx maps. Used during initial sync to adopt a peer's ledger.
+// NewFromHeader creates a closed ledger from a deserialized header and existing
+// state/tx maps. The header's Validated flag determines whether it is already
+// validated; peer wire headers omit that local state and remain closed until
+// quorum promotion.
 func NewFromHeader(
 	hdr header.LedgerHeader,
 	stateMap *shamap.SHAMap,
 	txMap *shamap.SHAMap,
 	fees drops.Fees,
 ) *Ledger {
+	state := StateClosed
+	if hdr.Validated {
+		state = StateValidated
+	}
 	return &Ledger{
 		stateMap: stateMap,
 		txMap:    txMap,
 		header:   hdr,
 		fees:     fees,
-		state:    StateValidated,
+		state:    state,
 	}
 }
 

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 )
 
+func TestNewFromHeaderHonorsValidatedFlag(t *testing.T) {
+	closed := NewFromHeader(header.LedgerHeader{}, nil, nil, drops.Fees{})
+	if closed.State() != StateClosed || closed.IsValidated() {
+		t.Fatalf("unvalidated header created state %s", closed.State())
+	}
+	if err := closed.SetValidated(); err != nil {
+		t.Fatalf("promote closed ledger: %v", err)
+	}
+	if !closed.IsValidated() || !closed.Header().Validated {
+		t.Fatal("SetValidated did not promote the ledger and header together")
+	}
+
+	validated := NewFromHeader(header.LedgerHeader{Validated: true}, nil, nil, drops.Fees{})
+	if validated.State() != StateValidated || !validated.IsValidated() {
+		t.Fatalf("validated header created state %s", validated.State())
+	}
+}
+
 // newParentAt builds a closed parent ledger with the requested
 // (seq, resolution, closeAgree) — synthesized from genesis and a
 // chain of no-op Close()s so we get valid hashes/maps for free.

--- a/internal/ledger/service/events.go
+++ b/internal/ledger/service/events.go
@@ -109,7 +109,6 @@ func (s *Service) validatedLedgerSeqLocked() uint32 {
 	return s.validatedLedger.Sequence()
 }
 
-// validatedLedgerNotificationLocked captures an advancement notification.
 // Caller must hold s.mu for writing and invoke notify only after unlocking.
 func (s *Service) validatedLedgerNotificationLocked(previousSeq uint32) validatedLedgerNotification {
 	if s.onValidatedLedger == nil || s.validatedLedger == nil || s.validatedLedger.Sequence() <= previousSeq {

--- a/internal/ledger/service/events.go
+++ b/internal/ledger/service/events.go
@@ -87,6 +87,54 @@ func (s *Service) SetOnPendingValidationStashed(handler func(seq uint32, hash [3
 	s.onPendingValidationStashed = handler
 }
 
+// SetOnValidatedLedger registers a handler invoked after the validated tip
+// advances and the service lock has been released. Pass nil to unwire.
+func (s *Service) SetOnValidatedLedger(handler func(seq uint32, hash, parentHash [32]byte)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onValidatedLedger = handler
+}
+
+type validatedLedgerNotification struct {
+	handler    func(seq uint32, hash, parentHash [32]byte)
+	seq        uint32
+	hash       [32]byte
+	parentHash [32]byte
+}
+
+func (s *Service) validatedLedgerSeqLocked() uint32 {
+	if s.validatedLedger == nil {
+		return 0
+	}
+	return s.validatedLedger.Sequence()
+}
+
+// validatedLedgerNotificationLocked captures an advancement notification.
+// Caller must hold s.mu for writing and invoke notify only after unlocking.
+func (s *Service) validatedLedgerNotificationLocked(previousSeq uint32) validatedLedgerNotification {
+	if s.onValidatedLedger == nil || s.validatedLedger == nil || s.validatedLedger.Sequence() <= previousSeq {
+		return validatedLedgerNotification{}
+	}
+	return validatedLedgerNotification{
+		handler:    s.onValidatedLedger,
+		seq:        s.validatedLedger.Sequence(),
+		hash:       s.validatedLedger.Hash(),
+		parentHash: s.validatedLedger.ParentHash(),
+	}
+}
+
+func (s *Service) unlockAndNotifyValidatedLedger(previousSeq uint32) {
+	notification := s.validatedLedgerNotificationLocked(previousSeq)
+	s.mu.Unlock()
+	notification.notify()
+}
+
+func (n validatedLedgerNotification) notify() {
+	if n.handler != nil {
+		n.handler(n.seq, n.hash, n.parentHash)
+	}
+}
+
 // SetEventHooks registers structured event hooks (richer than SetEventCallback).
 func (s *Service) SetEventHooks(hooks *EventHooks) {
 	s.mu.Lock()

--- a/internal/ledger/service/fix_mismatch_test.go
+++ b/internal/ledger/service/fix_mismatch_test.go
@@ -24,6 +24,7 @@ func makeStubLedger(t *testing.T, seq uint32, hash, parentHash [32]byte) *ledger
 		LedgerIndex: seq,
 		Hash:        hash,
 		ParentHash:  parentHash,
+		Validated:   true,
 	}
 	return ledger.NewFromHeader(hdr, stateMap, txMap, drops.Fees{})
 }
@@ -283,8 +284,8 @@ func TestAdoptLedgerWithState_FixMismatchValidatedLedgerInvalidationLogsError(t 
 
 	baseSeq := svc.GetClosedLedgerIndex() + 1
 
-	// Seed B at seq S+0; makeStubLedger's NewFromHeader already marks
-	// the ledger as validated (state=StateValidated). Adopt D at seq
+	// Seed B at seq S+0; makeStubLedger explicitly marks the header
+	// validated. Adopt D at seq
 	// S+1 whose parentHash does not equal B.Hash() — fixMismatch must
 	// purge B and log ERROR. The validatedLedger pointer must not
 	// silently flip.

--- a/internal/ledger/service/install_adopted_test.go
+++ b/internal/ledger/service/install_adopted_test.go
@@ -33,9 +33,6 @@ func TestInstallAdoptedLedgerLocked_ReturnCanonical(t *testing.T) {
 		if err != nil {
 			t.Fatalf("snapshot tx: %v", err)
 		}
-		// NewFromHeader yields StateValidated; NewOpenWithHeader yields
-		// StateOpen (IsValidated()==false) — the synthetic shape needed
-		// to exercise the precedence skip.
 		var parentHash, ledgerHash [32]byte
 		parentHash[0] = salt
 		ledgerHash[0] = salt
@@ -44,11 +41,9 @@ func TestInstallAdoptedLedgerLocked_ReturnCanonical(t *testing.T) {
 			LedgerIndex: seq,
 			ParentHash:  parentHash,
 			Hash:        ledgerHash,
+			Validated:   validated,
 		}
-		if validated {
-			return ledger.NewFromHeader(h, stateMap, txMap, drops.Fees{})
-		}
-		return ledger.NewOpenWithHeader(h, stateMap, txMap, drops.Fees{})
+		return ledger.NewFromHeader(h, stateMap, txMap, drops.Fees{})
 	}
 
 	seq := parentSeq + 5

--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -792,7 +792,8 @@ func (s *Service) NeedsInitialSync() bool {
 // have changed state).
 func (s *Service) AdoptLedgerHeader(h *header.LedgerHeader) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	previousValidatedSeq := s.validatedLedgerSeqLocked()
+	defer s.unlockAndNotifyValidatedLedger(previousValidatedSeq)
 
 	if !s.needsInitialSync {
 		return errors.New("not in initial sync mode")
@@ -819,10 +820,12 @@ func (s *Service) AdoptLedgerHeader(h *header.LedgerHeader) error {
 
 	adopted := ledger.NewFromHeader(*h, stateMap, txMap, drops.Fees{})
 
-	// Adopted becomes closedLedger and joins history but is NOT marked validated
-	// (no quorum yet); validatedLedger advances later via SetValidatedLedger.
 	// Source closedLedger from the install helper so validated-precedence holds.
-	s.closedLedger = s.installAdoptedLedgerLocked(h.LedgerIndex, adopted)
+	canonical := s.installAdoptedLedgerLocked(h.LedgerIndex, adopted)
+	s.closedLedger = canonical
+	if canonical == adopted {
+		s.drainPendingLedgerValidationLocked(h.LedgerIndex, adopted)
+	}
 
 	openLedger, err := ledger.NewOpen(s.closedLedger, time.Now())
 	if err != nil {
@@ -848,7 +851,8 @@ func (s *Service) AdoptLedgerHeader(h *header.LedgerHeader) error {
 // AdoptLedgerHeader but after needsInitialSync is cleared.
 func (s *Service) ReAdoptLedgerHeader(h *header.LedgerHeader) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	previousValidatedSeq := s.validatedLedgerSeqLocked()
+	defer s.unlockAndNotifyValidatedLedger(previousValidatedSeq)
 
 	if s.genesisLedger == nil {
 		return errors.New("no genesis ledger available")
@@ -880,9 +884,11 @@ func (s *Service) ReAdoptLedgerHeader(h *header.LedgerHeader) error {
 
 	adopted := ledger.NewFromHeader(*h, stateMap, txMap, drops.Fees{})
 
-	// Advance closedLedger to the peer's tip but NOT validatedLedger: "closed"
-	// is not "validated"; the quorum gate in SetValidatedLedger owns that.
-	s.closedLedger = s.installAdoptedLedgerLocked(h.LedgerIndex, adopted)
+	canonical := s.installAdoptedLedgerLocked(h.LedgerIndex, adopted)
+	s.closedLedger = canonical
+	if canonical == adopted {
+		s.drainPendingLedgerValidationLocked(h.LedgerIndex, adopted)
+	}
 
 	openLedger, err := ledger.NewOpen(s.closedLedger, time.Now())
 	if err != nil {

--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -399,7 +399,8 @@ func (s *Service) fixMismatchLocked(adopted *ledger.Ledger) {
 // ahead of the TxQ.
 func (s *Service) AcceptConsensusResult(ctx context.Context, parent *ledger.Ledger, txBlobs, disputedBlobs [][]byte, closeTime time.Time, closeTimeCorrect bool) (uint32, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	previousValidatedSeq := s.validatedLedgerSeqLocked()
+	defer s.unlockAndNotifyValidatedLedger(previousValidatedSeq)
 
 	if s.closedLedger == nil {
 		return 0, ErrNoClosedLedger
@@ -594,6 +595,7 @@ func (s *Service) AcceptConsensusResult(ctx context.Context, parent *ledger.Ledg
 // must NOT be flipped to validated.
 func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 	s.mu.Lock()
+	previousValidatedSeq := s.validatedLedgerSeqLocked()
 	l, ok := s.ledgerHistory[seq]
 	// rippled checkAccept is hash-keyed; our seq-keyed map splits into "no entry"
 	// or "different-hash" (same-height fork) — both stash and arm acquisition.
@@ -638,6 +640,7 @@ func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 	pool := s.localTxs
 	event := s.drainPendingValidationLocked(expectedHash)
 	callback := s.eventCallback
+	notification := s.validatedLedgerNotificationLocked(previousValidatedSeq)
 	s.mu.Unlock()
 
 	// Fold into the amendment table outside the lock (it has its own mutex).
@@ -650,6 +653,7 @@ func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 	if event != nil && callback != nil {
 		go callback(event)
 	}
+	notification.notify()
 }
 
 // SubmitHeldAdoptionResult describes the disposition of a candidate ledger. When
@@ -688,7 +692,8 @@ func (s *Service) SubmitHeldAdoption(ctx context.Context, h *header.LedgerHeader
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	previousValidatedSeq := s.validatedLedgerSeqLocked()
+	defer s.unlockAndNotifyValidatedLedger(previousValidatedSeq)
 
 	// Evict stale entries on every submission.
 	s.evictExpiredHeldAdoptionsLocked()
@@ -907,7 +912,8 @@ func (s *Service) ReAdoptLedgerHeader(h *header.LedgerHeader) error {
 // adopted ledger.
 func (s *Service) AdoptLedgerWithState(ctx context.Context, h *header.LedgerHeader, stateMap *shamap.SHAMap, txMap *shamap.SHAMap) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	previousValidatedSeq := s.validatedLedgerSeqLocked()
+	defer s.unlockAndNotifyValidatedLedger(previousValidatedSeq)
 	return s.adoptLedgerWithStateLocked(ctx, h, stateMap, txMap, 0)
 }
 

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -162,6 +162,9 @@ type Service struct {
 	// beyond closed (arms the inbound-ledger acquisition).
 	onPendingValidationStashed func(seq uint32, hash [32]byte)
 
+	// Invoked after the validated tip advances and after mu is released.
+	onValidatedLedger func(seq uint32, hash, parentHash [32]byte)
+
 	// heldAdoptions stashes out-of-order replay-delta adoptions (child seq
 	// before parent), keyed by the awaited parent seq so an adopt at N pops the
 	// child at N+1 and cascade-adopts it. Multi-level chains cascade via bounded
@@ -215,7 +218,7 @@ type Service struct {
 
 	// feeTrack is the local LoadFeeTrack mirror, always non-nil. Drivers:
 	//   - Raise/LowerLocalFee: per ledger close via tickLoadFeeLocked.
-	//   - SetRemoteFee: from OnLedgerFullyValidated, median of trusted LoadFees.
+	//   - SetRemoteFee: after validated-ledger promotion, median of trusted LoadFees.
 	//   - SetClusterFee: from the Overlay's TMCluster ingress.
 	feeTrack *feetrack.LoadFeeTrack
 

--- a/internal/rpc/events.go
+++ b/internal/rpc/events.go
@@ -64,7 +64,7 @@ type ValidationEvent struct {
 	Full                bool     `json:"full"`                     // Whether this is a full validation
 	LedgerHash          string   `json:"ledger_hash"`              // Hash of proposed ledger
 	LedgerIndex         string   `json:"ledger_index"`             // Index of proposed ledger (as string)
-	LoadFee             uint32   `json:"load_fee,omitempty"`       // Local load-scaled transaction cost
+	LoadFee             *uint32  `json:"load_fee,omitempty"`       // Local load-scaled transaction cost
 	MasterKey           string   `json:"master_key,omitempty"`     // Master public key — emitted only when the manifest cache resolves a master distinct from the signing key (NetworkOPs.cpp:2434-2438)
 	NetworkID           uint32   `json:"network_id,omitempty"`     // Network identifier (NetworkOPs.cpp:2423)
 	ReserveBase         uint64   `json:"reserve_base,omitempty"`   // Minimum reserve


### PR DESCRIPTION
## Summary
- `refreshRemoteFee` now mirrors rippled's `LedgerMaster`/`Validations::fees`: the remote load-fee median is taken over the **union** of the validated ledger's and its **parent** ledger's trusted validations, and restricted to **full** validations only.
- Previously it sampled the current ledger's hash alone and let trusted **partial** validations leak into the median, producing a smaller, differently-composed sample than rippled — diverging fee-escalation reporting (not ledger validity).
- Extracted `collectValidationFees` helper; parent hash is resolved via `GetLedgerByHash(ledgerID).ParentHash()`, degrading gracefully to the current-ledger sample when the ledger isn't in history.

## Test plan
- [x] `go test ./internal/consensus/adaptor/...` (full package green)
- [x] New `TestRefreshRemoteFee_ExcludesPartialValidations` — trusted partial dropped from the median
- [x] New `TestRefreshRemoteFee_FoldsParentLedgerValidations` — parent-ledger validations folded into the sample
- [x] Updated `TestRefreshRemoteFee_MedianOverTrustedValidations` for the full-only filter
- [x] `go vet` + `golangci-lint run --config .golangci.yml` clean

Fixes #1194