### PR TITLE
Add LedgerTrie JSON introspection for preferred-ledger debugging

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -1712,9 +1712,8 @@ func (a *Adaptor) preferredLCL(ledger consensus.Ledger, mode consensus.Operating
 	}
 
 	if h := a.validationHistorian; h != nil {
-		// Dump the trie's support state before selecting; this is the primary
-		// handle for diagnosing why a given branch was preferred. Built only
-		// when debug logging is on, mirroring rippled's lazy ValidationTrie log.
+		// Dump the trie's support state to diagnose why a branch was preferred.
+		// Debug-gated because building it walks and marshals the whole trie.
 		if a.logger.Enabled(context.Background(), slog.LevelDebug) {
 			if trie := h.GetJsonTrie(); trie != nil {
 				if raw, err := json.Marshal(trie); err == nil {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -1711,6 +1712,16 @@ func (a *Adaptor) preferredLCL(ledger consensus.Ledger, mode consensus.Operating
 	}
 
 	if h := a.validationHistorian; h != nil {
+		// Dump the trie's support state before selecting; this is the primary
+		// handle for diagnosing why a given branch was preferred. Built only
+		// when debug logging is on, mirroring rippled's lazy ValidationTrie log.
+		if a.logger.Enabled(context.Background(), slog.LevelDebug) {
+			if trie := h.GetJsonTrie(); trie != nil {
+				if raw, err := json.Marshal(trie); err == nil {
+					a.logger.Debug("ValidationTrie", "trie", string(raw))
+				}
+			}
+		}
 		if id, seq, ok := h.GetPreferred(a.lastIssuedValidationSeq.Load()); ok {
 			id, seq = a.resolvePreferredVsCurrent(id, seq, ledger)
 			if seq >= minSeq {

--- a/internal/consensus/adaptor/negative_unl_vote_test.go
+++ b/internal/consensus/adaptor/negative_unl_vote_test.go
@@ -61,6 +61,8 @@ func (s *stubHistorian) PreferredFromValidations(minSeq uint32) (consensus.Ledge
 	return s.preferredID, s.preferredSeq, s.preferredOK
 }
 
+func (s *stubHistorian) GetJsonTrie() map[string]any { return nil }
+
 func TestAdaptor_NegativeUNL_NilVoterReturnsNil(t *testing.T) {
 	// Adaptor constructed without master keys → voter is nil.
 	a := newTestAdaptor(t)

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -60,6 +60,11 @@ type ValidationHistorian interface {
 	GetTrustedValidations(ledgerID LedgerID) []*Validation
 	GetPreferred(largestIssued uint32) (LedgerID, uint32, bool)
 	PreferredFromValidations(minSeq uint32) (LedgerID, uint32, bool)
+
+	// GetJsonTrie returns a JSON-serializable snapshot of the ancestry trie's
+	// support state for debugging preferred-ledger divergence, or nil when the
+	// trie is disabled.
+	GetJsonTrie() map[string]any
 }
 
 // WireableAdaptor is an optional extension engine wires after constructing its

--- a/internal/consensus/ledgertrie/json.go
+++ b/internal/consensus/ledgertrie/json.go
@@ -7,8 +7,7 @@ import (
 
 // GetJson returns a JSON-serializable snapshot of the trie's support state:
 // the compressed ancestry trie under "trie" and a per-sequence tip-count map
-// under "seq_support". It is the primary observability handle for diagnosing
-// preferred-ledger divergence — why GetPreferred picked a given branch.
+// under "seq_support".
 func (t *Trie) GetJson() map[string]any {
 	seqSupport := make(map[string]uint32, len(t.seqSupport))
 	for seq, sup := range t.seqSupport {
@@ -22,7 +21,7 @@ func (t *Trie) GetJson() map[string]any {
 
 // getJSON recursively serializes n and its descendants. The "span" string is
 // the tip ID followed by the half-open [start,end) interval, matching rippled's
-// Span stream format.
+// wire format.
 func (n *node) getJSON() map[string]any {
 	tip := n.s.tip()
 	startID := n.s.startID()

--- a/internal/consensus/ledgertrie/json.go
+++ b/internal/consensus/ledgertrie/json.go
@@ -1,0 +1,44 @@
+package ledgertrie
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// GetJson returns a JSON-serializable snapshot of the trie's support state:
+// the compressed ancestry trie under "trie" and a per-sequence tip-count map
+// under "seq_support". It is the primary observability handle for diagnosing
+// preferred-ledger divergence — why GetPreferred picked a given branch.
+func (t *Trie) GetJson() map[string]any {
+	seqSupport := make(map[string]uint32, len(t.seqSupport))
+	for seq, sup := range t.seqSupport {
+		seqSupport[strconv.FormatUint(uint64(seq), 10)] = sup
+	}
+	return map[string]any{
+		"trie":        t.root.getJSON(),
+		"seq_support": seqSupport,
+	}
+}
+
+// getJSON recursively serializes n and its descendants. The "span" string is
+// the tip ID followed by the half-open [start,end) interval, matching rippled's
+// Span stream format.
+func (n *node) getJSON() map[string]any {
+	tip := n.s.tip()
+	startID := n.s.startID()
+	res := map[string]any{
+		"span":          fmt.Sprintf("%X[%d,%d)", tip.ID[:], n.s.start, n.s.end),
+		"startID":       fmt.Sprintf("%X", startID[:]),
+		"seq":           tip.Seq,
+		"tipSupport":    n.tipSupport,
+		"branchSupport": n.branchSupport,
+	}
+	if len(n.children) > 0 {
+		children := make([]any, len(n.children))
+		for i, c := range n.children {
+			children[i] = c.getJSON()
+		}
+		res["children"] = children
+	}
+	return res
+}

--- a/internal/consensus/ledgertrie/json_test.go
+++ b/internal/consensus/ledgertrie/json_test.go
@@ -1,0 +1,101 @@
+package ledgertrie
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+)
+
+func hexID(id consensus.LedgerID) string { return fmt.Sprintf("%X", id[:]) }
+
+func TestTrie_GetJson_Empty(t *testing.T) {
+	tr, _ := newTestTrie()
+
+	js := tr.GetJson()
+	if _, err := json.Marshal(js); err != nil {
+		t.Fatalf("GetJson output not JSON-marshalable: %v", err)
+	}
+
+	seqSupport, ok := js["seq_support"].(map[string]uint32)
+	if !ok {
+		t.Fatalf("seq_support: got %T, want map[string]uint32", js["seq_support"])
+	}
+	if len(seqSupport) != 0 {
+		t.Errorf("empty trie seq_support = %v, want {}", seqSupport)
+	}
+
+	root, ok := js["trie"].(map[string]any)
+	if !ok {
+		t.Fatalf("trie: got %T, want map[string]any", js["trie"])
+	}
+	if root["seq"].(uint32) != 0 || root["tipSupport"].(uint32) != 0 || root["branchSupport"].(uint32) != 0 {
+		t.Errorf("empty root = %v, want seq0/tip0/branch0", root)
+	}
+	if want := hexID(consensus.LedgerID{}) + "[0,1)"; root["span"] != want {
+		t.Errorf("genesis span = %q, want %q", root["span"], want)
+	}
+	if _, has := root["children"]; has {
+		t.Errorf("empty root must omit children key, got %v", root["children"])
+	}
+}
+
+func TestTrie_GetJson_Structure(t *testing.T) {
+	tr, b := newTestTrie()
+	a := b.Build("a")
+	abc := b.Build("abc")
+	abcd := b.Build("abcd")
+	tr.Insert(abc, 1)
+	tr.Insert(abcd, 1)
+
+	js := tr.GetJson()
+
+	// Marshalable: this is how the adaptor emits the ValidationTrie log.
+	if _, err := json.Marshal(js); err != nil {
+		t.Fatalf("GetJson output not JSON-marshalable: %v", err)
+	}
+
+	seqSupport := js["seq_support"].(map[string]uint32)
+	if len(seqSupport) != 2 || seqSupport["3"] != 1 || seqSupport["4"] != 1 {
+		t.Errorf("seq_support = %v, want {3:1, 4:1}", seqSupport)
+	}
+
+	root := js["trie"].(map[string]any)
+	if root["seq"].(uint32) != 0 || root["tipSupport"].(uint32) != 0 || root["branchSupport"].(uint32) != 2 {
+		t.Errorf("root = %v, want seq0/tip0/branch2", root)
+	}
+
+	rootChildren := root["children"].([]any)
+	if len(rootChildren) != 1 {
+		t.Fatalf("root children = %d, want 1", len(rootChildren))
+	}
+
+	// abc node covers the compressed span [1,4): startID is the ledger at
+	// seq 1 ('a'), the tip id is abc, and it still carries abcd's branch.
+	abcNode := rootChildren[0].(map[string]any)
+	if abcNode["seq"].(uint32) != 3 || abcNode["tipSupport"].(uint32) != 1 || abcNode["branchSupport"].(uint32) != 2 {
+		t.Errorf("abc node = %v, want seq3/tip1/branch2", abcNode)
+	}
+	if want := hexID(abc.ID()) + "[1,4)"; abcNode["span"] != want {
+		t.Errorf("abc span = %q, want %q", abcNode["span"], want)
+	}
+	if want := hexID(a.ID()); abcNode["startID"] != want {
+		t.Errorf("abc startID = %q, want %q (ledger at seq 1)", abcNode["startID"], want)
+	}
+
+	abcChildren := abcNode["children"].([]any)
+	if len(abcChildren) != 1 {
+		t.Fatalf("abc children = %d, want 1", len(abcChildren))
+	}
+	abcdNode := abcChildren[0].(map[string]any)
+	if abcdNode["seq"].(uint32) != 4 || abcdNode["tipSupport"].(uint32) != 1 || abcdNode["branchSupport"].(uint32) != 1 {
+		t.Errorf("abcd node = %v, want seq4/tip1/branch1", abcdNode)
+	}
+	if want := hexID(abcd.ID()) + "[4,5)"; abcdNode["span"] != want {
+		t.Errorf("abcd span = %q, want %q", abcdNode["span"], want)
+	}
+	if _, has := abcdNode["children"]; has {
+		t.Errorf("abcd leaf must omit children key, got %v", abcdNode["children"])
+	}
+}

--- a/internal/consensus/rcl/validations_trie.go
+++ b/internal/consensus/rcl/validations_trie.go
@@ -167,9 +167,9 @@ func (vt *ValidationTracker) insertTipLocked(nodeID consensus.NodeID, lgr ledger
 }
 
 // GetJsonTrie returns a JSON-serializable snapshot of the ancestry trie's
-// support state for diagnosing preferred-ledger divergence, mirroring rippled's
-// Validations::getJsonTrie. Returns nil when the trie is disabled (no ancestry
-// provider wired) or a serialization panic is trapped. Guarded by vt.mu.
+// support state for diagnosing preferred-ledger divergence. Returns nil when
+// the trie is disabled (no ancestry provider wired) or a serialization panic
+// is trapped. Guarded by vt.mu.
 func (vt *ValidationTracker) GetJsonTrie() map[string]any {
 	vt.mu.RLock()
 	defer vt.mu.RUnlock()

--- a/internal/consensus/rcl/validations_trie.go
+++ b/internal/consensus/rcl/validations_trie.go
@@ -166,6 +166,23 @@ func (vt *ValidationTracker) insertTipLocked(nodeID consensus.NodeID, lgr ledger
 	vt.trieTips[nodeID] = lgr
 }
 
+// GetJsonTrie returns a JSON-serializable snapshot of the ancestry trie's
+// support state for diagnosing preferred-ledger divergence, mirroring rippled's
+// Validations::getJsonTrie. Returns nil when the trie is disabled (no ancestry
+// provider wired) or a serialization panic is trapped. Guarded by vt.mu.
+func (vt *ValidationTracker) GetJsonTrie() map[string]any {
+	vt.mu.RLock()
+	defer vt.mu.RUnlock()
+	if vt.trie == nil {
+		return nil
+	}
+	var res map[string]any
+	if safeTrieCall("GetJson", func() { res = vt.trie.GetJson() }) {
+		return nil
+	}
+	return res
+}
+
 // genesisLedger is the trie's root placeholder. The trie only reads
 // Ancestor(0) and Seq()==0 from it.
 type genesisLedger struct{}

--- a/internal/consensus/rcl/validations_trie_test.go
+++ b/internal/consensus/rcl/validations_trie_test.go
@@ -1,6 +1,7 @@
 package rcl
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -449,5 +450,43 @@ func TestValidationTracker_ProposersFinishedIncludesNegUNL(t *testing.T) {
 	prev := &mockLedger{id: consensus.LedgerID{0x10}, seq: 100}
 	if got := vt.ProposersFinished(prev); got != 2 {
 		t.Errorf("ProposersFinished must include negUNL validators: got %d, want 2", got)
+	}
+}
+
+// TestValidationTracker_GetJsonTrie verifies the debug introspection dump:
+// nil while the trie is disabled, and a marshalable support snapshot once an
+// ancestry provider is wired and a trusted validation is inserted.
+func TestValidationTracker_GetJsonTrie(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+
+	if js := vt.GetJsonTrie(); js != nil {
+		t.Fatalf("GetJsonTrie with no ancestry provider must be nil, got %v", js)
+	}
+
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	b := ledgertrie.NewTestLedgerBuilder()
+	abc := b.Build("abc")
+	provider := newMapAncestryProvider()
+	provider.add(abc)
+
+	n1 := consensus.NodeID{1}
+	vt.SetTrusted([]consensus.NodeID{n1})
+	vt.SetLedgerAncestryProvider(provider)
+	if !vt.Add(makeTrustedValidation(n1, abc.ID(), abc.Seq(), now)) {
+		t.Fatal("Add(n1->abc) should succeed")
+	}
+
+	js := vt.GetJsonTrie()
+	if js == nil {
+		t.Fatal("GetJsonTrie with a wired trie must be non-nil")
+	}
+	if _, err := json.Marshal(js); err != nil {
+		t.Fatalf("GetJsonTrie output not JSON-marshalable: %v", err)
+	}
+	seqSupport, ok := js["seq_support"].(map[string]uint32)
+	if !ok || seqSupport["3"] != 1 {
+		t.Errorf("seq_support = %v, want 3:1", js["seq_support"])
 	}
 }


### PR DESCRIPTION
## Summary
- Add `Trie.GetJson()` (with a recursive `*node` helper) to `internal/consensus/ledgertrie`, serializing the compressed ancestry trie as a nested `{span, startID, seq, tipSupport, branchSupport, children}` tree plus a `seq_support` map — mirroring rippled's `LedgerTrie::getJson` field-for-field.
- Surface it through `ValidationTracker.GetJsonTrie()` (guarded by `vt.mu`, panic-trapped via `safeTrieCall`), extending the `consensus.ValidationHistorian` interface — the analog of rippled's `Validations::getJsonTrie`.
- Emit it lazily from the adaptor's `preferredLCL` selection (built only when debug logging is enabled), the go-xrpl equivalent of rippled's `ValidationTrie` debug line in `NetworkOPs::checkLastClosedLedger`.

This gives operators the primary observability handle for diagnosing validator-split / preferred-ledger-divergence incidents — why `GetPreferred` picked a given branch.

Field names and the `<tipID>[start,end)` span format match rippled so trie dumps cross-reference directly.

## Test plan
- [x] `go test ./internal/consensus/ledgertrie/... ./internal/consensus/rcl/... ./internal/consensus/adaptor/...` — new `GetJson` (empty + nested structure) and `GetJsonTrie` (disabled → nil, wired → snapshot) tests pass
- [x] `go test ./internal/consensus/...` — full consensus tree green
- [x] `go build ./...` — full module builds
- [x] `golangci-lint run --config .golangci.yml` — 0 issues on changed packages

Fixes #1200