### PR TITLE
fix: pin flag-ledger validation window for the negative-UNL vote

### DIFF
--- a/internal/consensus/adaptor/negative_unl_vote.go
+++ b/internal/consensus/adaptor/negative_unl_vote.go
@@ -183,18 +183,23 @@ func (a *Adaptor) buildNegativeUNLScoreTable(
 	},
 	historian consensus.ValidationHistorian,
 ) (map[consensus.NodeID]uint32, bool) {
+	// Pin the window this vote scans so a concurrent ExpireOld can't drop its
+	// low end. rippled keeps [seq-1, seq+interval) for the forward window
+	// against its time-based expiry; go-xrpl expires by sequence, so we also
+	// widen the pin down over the ancestors we read, and pin before the
+	// skip-list check so it holds on a round we can't vote. seq = prevSeq + 1;
+	// the low end saturates to avoid underflow at the first flag ledger.
+	upcoming := prev.Sequence() + 1
+	var keepLow uint32
+	if upcoming >= 1+protocol.FlagLedgerInterval {
+		keepLow = upcoming - 1 - protocol.FlagLedgerInterval
+	}
+	historian.SetSeqToKeep(keepLow, upcoming+protocol.FlagLedgerInterval)
+
 	ancestors, err := prev.SkipListHashes()
 	if err != nil || uint32(len(ancestors)) < protocol.FlagLedgerInterval {
 		return nil, false
 	}
-
-	// Pin the window we are about to scan so a concurrent ExpireOld can't drop
-	// its low end. rippled sets [seq-1, seq+interval) to keep the *forward*
-	// window alive against its time-based expiry; go-xrpl expires by sequence,
-	// so the exposure is the low end of the window this vote reads — we widen
-	// the pin down to cover it. seq = prevSeq + 1 is the upcoming ledger.
-	upcoming := prev.Sequence() + 1
-	historian.SetSeqToKeep(upcoming-1-protocol.FlagLedgerInterval, upcoming+protocol.FlagLedgerInterval)
 
 	n := uint32(len(ancestors))
 	window := protocol.FlagLedgerInterval

--- a/internal/consensus/adaptor/negative_unl_vote.go
+++ b/internal/consensus/adaptor/negative_unl_vote.go
@@ -178,6 +178,7 @@ func (a *Adaptor) negativeUNLState(l interface {
 // table (NodeIDs that have since left the UNL) is harmless.
 func (a *Adaptor) buildNegativeUNLScoreTable(
 	prev interface {
+		Sequence() uint32
 		SkipListHashes() ([][32]byte, error)
 	},
 	historian consensus.ValidationHistorian,
@@ -186,6 +187,14 @@ func (a *Adaptor) buildNegativeUNLScoreTable(
 	if err != nil || uint32(len(ancestors)) < protocol.FlagLedgerInterval {
 		return nil, false
 	}
+
+	// Pin the window we are about to scan so a concurrent ExpireOld can't drop
+	// its low end. rippled sets [seq-1, seq+interval) to keep the *forward*
+	// window alive against its time-based expiry; go-xrpl expires by sequence,
+	// so the exposure is the low end of the window this vote reads — we widen
+	// the pin down to cover it. seq = prevSeq + 1 is the upcoming ledger.
+	upcoming := prev.Sequence() + 1
+	historian.SetSeqToKeep(upcoming-1-protocol.FlagLedgerInterval, upcoming+protocol.FlagLedgerInterval)
 
 	n := uint32(len(ancestors))
 	window := protocol.FlagLedgerInterval

--- a/internal/consensus/adaptor/negative_unl_vote_test.go
+++ b/internal/consensus/adaptor/negative_unl_vote_test.go
@@ -30,8 +30,13 @@ func (s *stubLedgerReader) Read(k keylet.Keylet) ([]byte, error) {
 // stubSkipListProvider satisfies the narrow interface
 // buildNegativeUNLScoreTable consumes.
 type stubSkipListProvider struct {
+	seq    uint32
 	hashes [][32]byte
 	err    error
+}
+
+func (s *stubSkipListProvider) Sequence() uint32 {
+	return s.seq
 }
 
 func (s *stubSkipListProvider) SkipListHashes() ([][32]byte, error) {
@@ -47,6 +52,11 @@ type stubHistorian struct {
 	preferredID  consensus.LedgerID
 	preferredSeq uint32
 	preferredOK  bool
+
+	// keepLow/keepHigh record the last SetSeqToKeep call so tests can
+	// assert the negative-UNL vote pins its scan window before reading.
+	keepLow  uint32
+	keepHigh uint32
 }
 
 func (s *stubHistorian) GetTrustedValidations(id consensus.LedgerID) []*consensus.Validation {
@@ -59,6 +69,10 @@ func (s *stubHistorian) GetPreferred(largestIssued uint32) (consensus.LedgerID, 
 
 func (s *stubHistorian) PreferredFromValidations(minSeq uint32) (consensus.LedgerID, uint32, bool) {
 	return s.preferredID, s.preferredSeq, s.preferredOK
+}
+
+func (s *stubHistorian) SetSeqToKeep(low, high uint32) {
+	s.keepLow, s.keepHigh = low, high
 }
 
 func TestAdaptor_NegativeUNL_NilVoterReturnsNil(t *testing.T) {
@@ -175,7 +189,7 @@ func TestBuildScoreTable_DoesNotGateOnLocalParticipation(t *testing.T) {
 	}
 
 	scoreTable, ok := a.buildNegativeUNLScoreTable(
-		&stubSkipListProvider{hashes: ancestors},
+		&stubSkipListProvider{seq: 2 * protocol.FlagLedgerInterval, hashes: ancestors},
 		&stubHistorian{byLedger: byLedger},
 	)
 	require.True(t, ok, "a full skip-list must build a table regardless of local participation")
@@ -207,15 +221,24 @@ func TestBuildScoreTable_TalliesAcrossAncestors(t *testing.T) {
 		byLedger[consensus.LedgerID(h)] = vals
 	}
 
+	const prevSeq = 2 * protocol.FlagLedgerInterval // a flag ledger
+	hist := &stubHistorian{byLedger: byLedger}
 	scoreTable, ok := a.buildNegativeUNLScoreTable(
-		&stubSkipListProvider{hashes: ancestors},
-		&stubHistorian{byLedger: byLedger},
+		&stubSkipListProvider{seq: prevSeq, hashes: ancestors},
+		hist,
 	)
 	require.True(t, ok, "a full skip-list of FlagLedgerInterval ancestors builds the table")
 	require.NotNil(t, scoreTable)
 
 	assert.Equal(t, protocol.FlagLedgerInterval, scoreTable[myID], "local validator scored on every ancestor")
 	assert.Equal(t, uint32(50), scoreTable[offline], "offline validator scored only on first 50 ancestors")
+
+	// The vote must pin the scan window before reading so a concurrent
+	// ExpireOld can't prune its low end. Window is [prevSeq-interval,
+	// prevSeq+1+interval) with upcoming = prevSeq+1.
+	upcoming := prevSeq + 1
+	assert.Equal(t, upcoming-1-protocol.FlagLedgerInterval, hist.keepLow, "keep-range low pins the oldest scanned ledger")
+	assert.Equal(t, upcoming+protocol.FlagLedgerInterval, hist.keepHigh, "keep-range high mirrors rippled's forward window")
 }
 
 // TestAdaptor_OnUNLChange_NoVoterIsNoOp covers the no-master-keys

--- a/internal/consensus/adaptor/negative_unl_vote_test.go
+++ b/internal/consensus/adaptor/negative_unl_vote_test.go
@@ -241,6 +241,27 @@ func TestBuildScoreTable_TalliesAcrossAncestors(t *testing.T) {
 	assert.Equal(t, upcoming+protocol.FlagLedgerInterval, hist.keepHigh, "keep-range high mirrors rippled's forward window")
 }
 
+// At the first flag ledger the parent seq is below FlagLedgerInterval, so the
+// pin's widened low end would underflow uint32; it must saturate to 0 (keeping
+// the whole window) rather than wrap and self-clear. The pin is also set
+// before the skip-list length check, so an incomplete skip-list that can't
+// build a table still records the keep-range — as rippled does, calling
+// setSeqToKeep before its ancestor-count gate.
+func TestBuildScoreTable_PinLowSaturatesAtFirstFlagLedger(t *testing.T) {
+	a := newTestAdaptor(t)
+	hist := &stubHistorian{}
+
+	const prevSeq = protocol.FlagLedgerInterval - 1 // parent of the first flag ledger
+	_, ok := a.buildNegativeUNLScoreTable(
+		&stubSkipListProvider{seq: prevSeq}, // empty skip-list → no table
+		hist,
+	)
+	require.False(t, ok, "an incomplete skip-list cannot build a table")
+
+	assert.Equal(t, uint32(0), hist.keepLow, "pin low saturates to 0, not a uint32 underflow")
+	assert.Equal(t, prevSeq+1+protocol.FlagLedgerInterval, hist.keepHigh, "pin high is still upcoming+interval")
+}
+
 // TestAdaptor_OnUNLChange_NoVoterIsNoOp covers the no-master-keys
 // adaptor: OnUNLChange must be safe to call (a no-op) when the
 // NegativeUNL voter was never constructed. Mirrors rippled's

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -60,6 +60,10 @@ type ValidationHistorian interface {
 	GetTrustedValidations(ledgerID LedgerID) []*Validation
 	GetPreferred(largestIssued uint32) (LedgerID, uint32, bool)
 	PreferredFromValidations(minSeq uint32) (LedgerID, uint32, bool)
+	// SetSeqToKeep pins the validation range [low, high) against expiry so
+	// the negative-UNL vote's flag-ledger scan window survives a
+	// fast-advancing retention floor.
+	SetSeqToKeep(low, high uint32)
 }
 
 // WireableAdaptor is an optional extension engine wires after constructing its

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -182,6 +182,15 @@ type ValidationTracker struct {
 	// Caller (the engine) advances minSeq as ledgers accept.
 	minSeq uint32
 
+	// keepLow, keepHigh pin the sequence range [keepLow, keepHigh) against
+	// ExpireOld: validations in it survive even below the retention floor and
+	// past their access age. The negative-UNL vote sets it via SetSeqToKeep so
+	// a fast-advancing tip (whose floor is anchored at the validated tip, not
+	// the flag ledger) can't prune the flag-ledger scan window mid-vote.
+	// keepLow == keepHigh disables the pin. Mirrors rippled's toKeep_.
+	keepLow  uint32
+	keepHigh uint32
+
 	// callbacks
 	onFullyValidated func(ledgerID consensus.LedgerID, ledgerSeq uint32)
 
@@ -270,6 +279,24 @@ func (vt *ValidationTracker) SetQuorum(quorum int) {
 	vt.mu.Lock()
 	defer vt.mu.Unlock()
 	vt.quorum = quorum
+}
+
+// SetSeqToKeep pins validations in [low, high) so ExpireOld will not drop
+// them, even once the retention floor advances past them. The negative-UNL
+// vote calls this before scanning the flag-ledger window so a fast-advancing
+// tip can't prune its low end mid-scan. Unlike the seq floor — which is
+// anchored at the validated tip — the pin is anchored at the flag ledger, so
+// it holds regardless of how far the tip has raced ahead or how small the
+// configured retention is. Mirrors rippled's setSeqToKeep; a range with
+// high <= low clears the pin.
+func (vt *ValidationTracker) SetSeqToKeep(low, high uint32) {
+	vt.mu.Lock()
+	defer vt.mu.Unlock()
+	if high <= low {
+		vt.keepLow, vt.keepHigh = 0, 0
+		return
+	}
+	vt.keepLow, vt.keepHigh = low, high
 }
 
 // SetNegativeUNL replaces the current negative-UNL set. Validators on
@@ -1002,8 +1029,9 @@ func (vt *ValidationTracker) FlushStale() {
 // queryable for RPC and late peers. Memory stays bounded: Add rejects
 // below the engine's minSeq gate, so a below-floor set cannot reheat
 // from the network, and it drops on the first ExpireOld after going
-// cold. The seq floor itself plays rippled's setSeqToKeep role of
-// protecting the recent (negative-UNL voting) window from expiry.
+// cold. The seq floor coarsely protects the recent (negative-UNL voting)
+// window, but is anchored at the validated tip; SetSeqToKeep pins the exact
+// flag-ledger window so a fast-advancing tip can't outrun the vote's read.
 func (vt *ValidationTracker) ExpireOld(minSeq uint32) {
 	vt.mu.Lock()
 
@@ -1019,6 +1047,10 @@ func (vt *ValidationTracker) ExpireOld(minSeq uint32) {
 			break
 		}
 		if sample == nil || sample.LedgerSeq >= minSeq {
+			continue
+		}
+		if vt.keepLow < vt.keepHigh &&
+			sample.LedgerSeq >= vt.keepLow && sample.LedgerSeq < vt.keepHigh {
 			continue
 		}
 		if ledgerVals.lastAccess.Load() > cutoff {

--- a/internal/consensus/rcl/validations_test.go
+++ b/internal/consensus/rcl/validations_test.go
@@ -620,6 +620,43 @@ func TestValidationTracker_ExpireOld_RetainsRecentlyAccessed(t *testing.T) {
 	}
 }
 
+// SetSeqToKeep pins a sequence range so ExpireOld retains it even when a set
+// is BOTH below the floor and past its access age — the negative-UNL vote
+// relies on this to keep its flag-ledger scan window alive against a
+// fast-advancing tip. The pin is selective (sequences below its low still
+// evict) and clearing it restores normal expiry.
+func TestValidationTracker_ExpireOld_HonorsSeqToKeep(t *testing.T) {
+	vt := NewValidationTracker(1, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	ledgerKeep := consensus.LedgerID{0x10}
+	ledgerDrop := consensus.LedgerID{0x20}
+	vt.Add(&consensus.Validation{LedgerID: ledgerKeep, LedgerSeq: 100, NodeID: consensus.NodeID{0xA}, SignTime: now, Full: true})
+	vt.Add(&consensus.Validation{LedgerID: ledgerDrop, LedgerSeq: 50, NodeID: consensus.NodeID{0xB}, SignTime: now, Full: true})
+
+	// Both are below the floor and cold; only the pinned range must survive.
+	now = now.Add(validationSetExpires + time.Second)
+	vt.SetSeqToKeep(100, 400)
+	vt.ExpireOld(200)
+
+	if got := vt.GetValidationCount(ledgerKeep); got != 1 {
+		t.Fatalf("pinned set evicted: count=%d, want 1", got)
+	}
+	if got := vt.GetValidationCount(ledgerDrop); got != 0 {
+		t.Fatalf("set below the pin survived: count=%d, want 0", got)
+	}
+
+	// Clearing the pin lets the floor evict the once-pinned set. Advance the
+	// clock again so the GetValidationCount touches above go cold.
+	now = now.Add(validationSetExpires + time.Second)
+	vt.SetSeqToKeep(0, 0)
+	vt.ExpireOld(200)
+	if got := vt.GetValidationCount(ledgerKeep); got != 0 {
+		t.Fatalf("unpinned set survived: count=%d, want 0", got)
+	}
+}
+
 // Reading a ledger's validations refreshes its access age — rippled's
 // byLedger touch — so an actively-queried set keeps surviving ExpireOld
 // while an unqueried sibling at the same seq expires.

--- a/internal/consensus/rcl/validations_test.go
+++ b/internal/consensus/rcl/validations_test.go
@@ -657,6 +657,33 @@ func TestValidationTracker_ExpireOld_HonorsSeqToKeep(t *testing.T) {
 	}
 }
 
+// The keep-range high bound is exclusive: a set whose seq equals keepHigh is
+// not pinned and still evicts once below the floor and cold, while a set at
+// keepLow (inclusive) survives. Mirrors rippled setSeqToKeep(C-1, C) dropping
+// the set at C (Validations_test.cpp).
+func TestValidationTracker_ExpireOld_SeqToKeepHighExclusive(t *testing.T) {
+	vt := NewValidationTracker(1, 5*time.Minute)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+
+	atLow := consensus.LedgerID{0x10}  // seq 100 == keepLow  → kept (inclusive)
+	atHigh := consensus.LedgerID{0x20} // seq 150 == keepHigh → dropped (exclusive)
+	vt.Add(&consensus.Validation{LedgerID: atLow, LedgerSeq: 100, NodeID: consensus.NodeID{0xA}, SignTime: now, Full: true})
+	vt.Add(&consensus.Validation{LedgerID: atHigh, LedgerSeq: 150, NodeID: consensus.NodeID{0xB}, SignTime: now, Full: true})
+
+	// Both below the floor and cold; the pin's boundaries decide who survives.
+	now = now.Add(validationSetExpires + time.Second)
+	vt.SetSeqToKeep(100, 150)
+	vt.ExpireOld(200)
+
+	if got := vt.GetValidationCount(atLow); got != 1 {
+		t.Fatalf("keepLow boundary evicted (should be inclusive): count=%d, want 1", got)
+	}
+	if got := vt.GetValidationCount(atHigh); got != 0 {
+		t.Fatalf("keepHigh boundary survived (should be exclusive): count=%d, want 0", got)
+	}
+}
+
 // Reading a ledger's validations refreshes its access age — rippled's
 // byLedger touch — so an actively-queried set keeps surviving ExpireOld
 // while an unqueried sibling at the same seq expires.


### PR DESCRIPTION
## Summary

- rippled's `NegativeUNLVote::buildScoreTable` calls `setSeqToKeep(seq-1, seq+FLAG_LEDGER_INTERVAL)` before scanning the last 256 ledgers' validations, so its (time-based) expiry can't drop the scan window mid-vote (`Validations.h:715`, `NegativeUNLVote.cpp:176`).
- go-xrpl had no equivalent: it leaned on the seq-floor retention driving `ExpireOld`. That floor is **anchored at the validated tip, not the flag ledger** (and can be shrunk below 256 via `InMemoryLedgers`), so a fast-advancing tip could prune the low end of the window before the vote reads it — the gap reported in #1195.
- Adds `ValidationTracker.SetSeqToKeep(low, high)` (mirrors rippled's `toKeep_`), honored by `ExpireOld`, and calls it from `buildNegativeUNLScoreTable` to pin the exact window the vote is about to scan. Because go-xrpl expires by **sequence** (not wall-clock), the pin's low bound is widened down to `upcoming-1-FlagLedgerInterval` to cover the window this vote reads, rather than only rippled's forward window.

The pin is a sliding, self-clearing window (re-set every flag ledger, `high <= low` disables it), so retention stays bounded.

## Test plan

- [x] `go test ./internal/consensus/...` (all green)
- [x] `internal/consensus/rcl`: `TestValidationTracker_ExpireOld_HonorsSeqToKeep` — a pinned set survives `ExpireOld` even when below the floor **and** cold; the pin is selective and clears cleanly.
- [x] `internal/consensus/adaptor`: `TestBuildScoreTable_TalliesAcrossAncestors` asserts the vote pins `[prevSeq-interval, prevSeq+1+interval)` before scanning.
- [x] `golangci-lint run --config .golangci.yml` on changed packages — 0 issues.

Fixes #1195