### PR TITLE
consensus: expose GetCurrentNodeIDs live-validator set

### DIFF
--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -3303,9 +3303,8 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 			// just-accepted ledger still count.
 			e.validationTracker.SetMinSeq(newLedger.Seq() - 128)
 		}
-		// Gather the live-participation set where rippled feeds
-		// getCurrentNodeIDs() into updateTrusted. Rippled's quorum ignores that
-		// set, so surface it for partial-outage visibility, not for quorum.
+		// rippled feeds getCurrentNodeIDs() into updateTrusted, but its quorum
+		// ignores the set — surface it for partial-outage visibility, not quorum.
 		slog.Debug("live validator participation",
 			"current", len(e.validationTracker.GetCurrentNodeIDs()),
 			"quorum", e.adaptor.GetQuorum(),

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -3303,6 +3303,13 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 			// just-accepted ledger still count.
 			e.validationTracker.SetMinSeq(newLedger.Seq() - 128)
 		}
+		// Gather the live-participation set where rippled feeds
+		// getCurrentNodeIDs() into updateTrusted. Rippled's quorum ignores that
+		// set, so surface it for partial-outage visibility, not for quorum.
+		slog.Debug("live validator participation",
+			"current", len(e.validationTracker.GetCurrentNodeIDs()),
+			"quorum", e.adaptor.GetQuorum(),
+			"ledger_seq", newLedger.Seq())
 	}
 
 	// Track round time for convergePercent calculation

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -954,6 +954,29 @@ func (vt *ValidationTracker) GetLatestValidation(nodeID consensus.NodeID) *conse
 	return vt.byNode[nodeID]
 }
 
+// GetCurrentNodeIDs returns the node IDs of every validator whose latest
+// tracked validation still passes the IsCurrent freshness gate — the set
+// observed actively validating right now, partial or full, trusted or not.
+// The gate matches Add()'s admission check, so a node appears iff its most
+// recent validation is neither stale nor clock-skewed against the
+// network-adjusted clock. Enumeration only; FlushStale does the paired
+// eviction that rippled folds into its current() sweep. Mirrors rippled's
+// Validations::getCurrentNodeIDs — the live-participation set gathered when
+// the engine refreshes the trusted set and quorum each round.
+func (vt *ValidationTracker) GetCurrentNodeIDs() []consensus.NodeID {
+	vt.mu.RLock()
+	defer vt.mu.RUnlock()
+
+	now := vt.now()
+	ids := make([]consensus.NodeID, 0, len(vt.byNode))
+	for nodeID, v := range vt.byNode {
+		if IsCurrent(now, v.SignTime, v.SeenTime) {
+			ids = append(ids, nodeID)
+		}
+	}
+	return ids
+}
+
 // FlushStale drops non-current validations from the steering indexes (byNode
 // + trie tips), mirroring rippled's current() sweep inside withTrie
 // (Validations.h:509-533): a silent validator must stop steering

--- a/internal/consensus/rcl/validations_helpers_test.go
+++ b/internal/consensus/rcl/validations_helpers_test.go
@@ -18,25 +18,6 @@ func (vt *ValidationTracker) GetValidationCount(ledgerID consensus.LedgerID) int
 	return len(ledgerVals.vals)
 }
 
-// GetCurrentValidators returns nodes that have recently validated.
-// Uses the injected clock (vt.now) so tests and production share the
-// same network-adjusted time source that Add() uses for its isCurrent
-// check — keeps "recent" consistent across both reads and writes.
-func (vt *ValidationTracker) GetCurrentValidators() []consensus.NodeID {
-	vt.mu.RLock()
-	defer vt.mu.RUnlock()
-
-	cutoff := vt.now().Add(-vt.freshness)
-	var result []consensus.NodeID
-
-	for nodeID, v := range vt.byNode {
-		if v.SignTime.After(cutoff) {
-			result = append(result, nodeID)
-		}
-	}
-	return result
-}
-
 // Clear removes all tracked validations.
 func (vt *ValidationTracker) Clear() {
 	vt.mu.Lock()

--- a/internal/consensus/rcl/validations_test.go
+++ b/internal/consensus/rcl/validations_test.go
@@ -739,3 +739,60 @@ func TestValidationTracker_Flush(t *testing.T) {
 		t.Error("post-flush: GetPreferred should resolve again after re-adding")
 	}
 }
+
+// TestValidationTracker_GetCurrentNodeIDs pins issue #1193: the live
+// participation set enumerates every byNode entry still passing IsCurrent —
+// trusted or not, partial or full — excludes entries whose latest validation
+// has aged out, and does not mutate the tracker (FlushStale owns eviction).
+func TestValidationTracker_GetCurrentNodeIDs(t *testing.T) {
+	vt := NewValidationTracker(2, 5*time.Minute)
+	t0 := time.Now()
+	vt.SetNow(func() time.Time { return t0 })
+
+	ledger := consensus.LedgerID{9}
+	const seq = uint32(100)
+	n1 := consensus.NodeID{1} // trusted, full, stays fresh
+	n2 := consensus.NodeID{2} // trusted, full, ages out before the read
+	n3 := consensus.NodeID{3} // untrusted, fresh — still enumerated
+	n4 := consensus.NodeID{4} // trusted, partial, fresh — still enumerated
+
+	vt.SetTrusted([]consensus.NodeID{n1, n2, n4})
+
+	// n2 signs at t0; it falls outside the isCurrent window once time moves.
+	if !vt.Add(makeTrustedValidation(n2, ledger, seq, t0)) {
+		t.Fatal("n2 validation should be accepted while current")
+	}
+
+	// Advance past the early bound so n2's t0 signature is now stale, then
+	// add the remaining validators against the new clock.
+	t1 := t0.Add(validationCurrentEarly + time.Minute)
+	vt.SetNow(func() time.Time { return t1 })
+
+	if !vt.Add(makeTrustedValidation(n1, ledger, seq, t1)) {
+		t.Fatal("n1 validation should be accepted at t1")
+	}
+	if !vt.Add(makeTrustedValidation(n3, ledger, seq, t1)) {
+		t.Fatal("n3 (untrusted) validation should still be tracked")
+	}
+	partial := makeTrustedValidation(n4, ledger, seq, t1)
+	partial.Full = false
+	if !vt.Add(partial) {
+		t.Fatal("n4 partial validation should be accepted at t1")
+	}
+
+	got := vt.GetCurrentNodeIDs()
+	want := map[consensus.NodeID]bool{n1: true, n3: true, n4: true}
+	if len(got) != len(want) {
+		t.Fatalf("GetCurrentNodeIDs: want %d live nodes, got %d (%v)", len(want), len(got), got)
+	}
+	for _, id := range got {
+		if !want[id] {
+			t.Errorf("GetCurrentNodeIDs returned %v; n2 is stale and must be excluded", id)
+		}
+	}
+
+	// Enumeration must not evict the stale entry — that is FlushStale's job.
+	if vt.GetLatestValidation(n2) == nil {
+		t.Error("GetCurrentNodeIDs must not mutate byNode (n2 was evicted)")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `ValidationTracker.GetCurrentNodeIDs()` — enumerates every validator whose latest tracked validation still passes the `IsCurrent` freshness gate (partial or full, trusted or not). Mirrors rippled's `Validations::getCurrentNodeIDs`; enumeration only, `FlushStale` owns the paired eviction rippled folds into its `current()` sweep.
- Gather the live set at the per-accept trust/quorum refresh — the point where rippled feeds `getCurrentNodeIDs()` into `updateTrusted` — and log it for partial-outage visibility.
- Remove the dead, redundant test-only `GetCurrentValidators()` helper, which used a weaker `SignTime > now-freshness` cutoff instead of the full `isCurrent` gate.

### Faithfulness note
In the referenced rippled snapshot, `updateTrusted` threads the seen set into `calculateQuorum` as `seenSize`, but the body never reads it — the quorum is purely `max(ceil(0.8·effectiveUnl), ceil(0.6·unl))`. So the live set does **not** change the quorum in rippled, and this PR does not change it in go-xrpl either. The substantive gap closed is the missing exported enumeration method; the wiring mirrors rippled's call structure and surfaces the set for operational visibility rather than inventing a quorum effect rippled does not have.

## Test plan
- [x] `just test-pkg ./internal/consensus/rcl/...` (full package green)
- [x] New `TestValidationTracker_GetCurrentNodeIDs`: fresh trusted/untrusted/partial included, aged-out entry excluded, getter does not mutate `byNode`
- [x] `go vet` + `golangci-lint run --config .golangci.yml ./internal/consensus/rcl/...` (0 issues)
- [x] `go build ./...`

Fixes #1193