### PR TITLE
feat: add consensus transaction censorship detector

### DIFF
--- a/internal/consensus/rcl/censorship.go
+++ b/internal/consensus/rcl/censorship.go
@@ -36,8 +36,8 @@ func (c *censorshipDetector) propose(proposed []consensus.TxID, seq uint32) {
 
 // check drops every tracked tx that made it into the accepted set, then
 // invokes pred for each remaining tx so it can warn about persistent
-// exclusion. pred returns true for entries to drop without warning (txs we
-// no longer vote for), false to keep tracking.
+// exclusion. pred returns true for entries to drop without warning, false
+// to keep tracking.
 func (c *censorshipDetector) check(accepted []consensus.TxID, pred func(id consensus.TxID, seq uint32) bool) {
 	acc := make(map[consensus.TxID]struct{}, len(accepted))
 	for _, id := range accepted {

--- a/internal/consensus/rcl/censorship.go
+++ b/internal/consensus/rcl/censorship.go
@@ -1,0 +1,60 @@
+package rcl
+
+import "github.com/LeJamon/go-xrpl/internal/consensus"
+
+// censorshipWarnInterval is the ledger cadence at which a tracked tx that
+// keeps being proposed but never included triggers a censorship warning.
+const censorshipWarnInterval = 15
+
+// censorshipDetector tracks the transactions this node proposes across
+// consensus rounds and warns when an eligible tx is persistently excluded
+// from ledgers. It is purely observational: it never affects the proposed
+// set, ledger content, or validations.
+//
+// Every entry point runs on the single consensus goroutine under Engine.mu,
+// so no internal locking is needed. The zero value is ready to use.
+type censorshipDetector struct {
+	// tracker maps a still-uncommitted proposed txid to the sequence of the
+	// ledger at which we began tracking it, so the wait grows across rounds.
+	tracker map[consensus.TxID]uint32
+}
+
+// propose records the txs proposed for the round building ledger seq. A tx
+// carried over from an earlier round keeps its original tracking seq; txs we
+// no longer propose are dropped.
+func (c *censorshipDetector) propose(proposed []consensus.TxID, seq uint32) {
+	next := make(map[consensus.TxID]uint32, len(proposed))
+	for _, id := range proposed {
+		if prev, ok := c.tracker[id]; ok {
+			next[id] = prev
+		} else {
+			next[id] = seq
+		}
+	}
+	c.tracker = next
+}
+
+// check drops every tracked tx that made it into the accepted set, then
+// invokes pred for each remaining tx so it can warn about persistent
+// exclusion. pred returns true for entries to drop without warning (txs we
+// no longer vote for), false to keep tracking.
+func (c *censorshipDetector) check(accepted []consensus.TxID, pred func(id consensus.TxID, seq uint32) bool) {
+	acc := make(map[consensus.TxID]struct{}, len(accepted))
+	for _, id := range accepted {
+		acc[id] = struct{}{}
+	}
+	for id, seq := range c.tracker {
+		if _, ok := acc[id]; ok {
+			delete(c.tracker, id)
+			continue
+		}
+		if pred(id, seq) {
+			delete(c.tracker, id)
+		}
+	}
+}
+
+// reset clears all tracking, e.g. after leaving proposing/observing mode.
+func (c *censorshipDetector) reset() {
+	c.tracker = nil
+}

--- a/internal/consensus/rcl/censorship_test.go
+++ b/internal/consensus/rcl/censorship_test.go
@@ -1,0 +1,124 @@
+package rcl
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+)
+
+func censorTxID(n int) consensus.TxID {
+	var id consensus.TxID
+	binary.BigEndian.PutUint32(id[:4], uint32(n))
+	return id
+}
+
+func censorTxIDs(ns []int) []consensus.TxID {
+	ids := make([]consensus.TxID, len(ns))
+	for i, n := range ns {
+		ids[i] = censorTxID(n)
+	}
+	return ids
+}
+
+func censorTxIDSet(ns []int) map[consensus.TxID]struct{} {
+	s := make(map[consensus.TxID]struct{}, len(ns))
+	for _, n := range ns {
+		s[censorTxID(n)] = struct{}{}
+	}
+	return s
+}
+
+// TestCensorshipDetector ports rippled's RCLCensorshipDetector_test: after a
+// propose/check round, every tx listed in remove is force-dropped, and every
+// tx listed in remain must still be tracked (so pred visits it and empties the
+// set).
+func TestCensorshipDetector(t *testing.T) {
+	var cdet censorshipDetector
+	round := 0
+
+	run := func(proposed, accepted, remain, remove []int) {
+		t.Helper()
+		round++
+		cdet.propose(censorTxIDs(proposed), uint32(round))
+
+		removeSet := censorTxIDSet(remove)
+		remainSet := censorTxIDSet(remain)
+		cdet.check(censorTxIDs(accepted), func(id consensus.TxID, _ uint32) bool {
+			if _, ok := removeSet[id]; ok {
+				return true
+			}
+			delete(remainSet, id)
+			return false
+		})
+		if len(remainSet) != 0 {
+			t.Fatalf("round %d: %d expected-remaining tx not tracked", round, len(remainSet))
+		}
+	}
+
+	//   proposed              accepted   remain        remove
+	run([]int{}, []int{}, []int{}, []int{})
+	run([]int{10, 11, 12, 13}, []int{11, 2}, []int{10, 13}, []int{})
+	run([]int{10, 13, 14, 15}, []int{14}, []int{10, 13, 15}, []int{})
+	run([]int{10, 13, 15, 16}, []int{15, 16}, []int{10, 13}, []int{})
+	run([]int{10, 13}, []int{17, 18}, []int{10, 13}, []int{})
+	run([]int{10, 19}, []int{}, []int{10, 19}, []int{})
+	run([]int{10, 19, 20}, []int{20}, []int{10}, []int{19})
+	run([]int{21}, []int{21}, []int{}, []int{})
+	run([]int{}, []int{22}, []int{}, []int{})
+	run([]int{23, 24, 25, 26}, []int{25, 27}, []int{23, 26}, []int{24})
+	run([]int{23, 26, 28}, []int{26, 28}, []int{23}, []int{})
+
+	for i := 0; i != 10; i++ {
+		run([]int{23}, []int{}, []int{23}, []int{})
+	}
+
+	run([]int{23, 29}, []int{29}, []int{23}, []int{})
+	run([]int{30, 31}, []int{31}, []int{30}, []int{})
+	run([]int{30}, []int{30}, []int{}, []int{})
+	run([]int{}, []int{}, []int{}, []int{})
+}
+
+// TestCensorshipDetectorSeqPreserved verifies a carried-over tx keeps its
+// original tracking seq across rounds — the property that lets the wait grow
+// so a persistently-excluded tx eventually crosses the warn interval.
+func TestCensorshipDetectorSeqPreserved(t *testing.T) {
+	var cdet censorshipDetector
+	x := censorTxID(42)
+
+	cdet.propose([]consensus.TxID{x}, 5)
+	cdet.propose([]consensus.TxID{x}, 6)
+	cdet.propose([]consensus.TxID{x}, 7)
+
+	var gotSeq uint32
+	var seen bool
+	cdet.check(nil, func(id consensus.TxID, seq uint32) bool {
+		if id == x {
+			gotSeq = seq
+			seen = true
+		}
+		return false
+	})
+	if !seen {
+		t.Fatal("tx not tracked after repeated proposes")
+	}
+	if gotSeq != 5 {
+		t.Fatalf("tracking seq = %d, want 5 (original round preserved)", gotSeq)
+	}
+}
+
+// TestCensorshipDetectorReset clears the tracker.
+func TestCensorshipDetectorReset(t *testing.T) {
+	var cdet censorshipDetector
+	cdet.propose(censorTxIDs([]int{1, 2, 3}), 10)
+	cdet.reset()
+
+	called := false
+	cdet.check(nil, func(consensus.TxID, uint32) bool {
+		called = true
+		return false
+	})
+	if called {
+		t.Fatal("pred invoked after reset; tracker not cleared")
+	}
+}

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -2232,7 +2232,7 @@ func (e *Engine) closeLedger() {
 	e.acquiredTxSets[txSet.ID()] = txSet
 
 	// Record the set we're proposing this round for censorship detection,
-	// unless we're acquiring the correct ledger (rippled's !wrongLCL gate).
+	// unless we're acquiring the correct ledger.
 	if e.prevLedger != nil && e.mode != consensus.ModeWrongLedger {
 		e.censorship.propose(txSet.TxIDs(), e.prevLedger.Seq()+1)
 	}

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -60,6 +60,11 @@ type Engine struct {
 	ourTxSet  consensus.TxSet
 	converged bool
 
+	// censorship tracks txs we propose but that never get included, warning
+	// on persistent exclusion. Observational only; touched solely from the
+	// consensus goroutine under e.mu.
+	censorship censorshipDetector
+
 	// proposalTracker owns the round-scoped peer-signal maps. Accessed only
 	// under e.mu (see ProposalTracker).
 	proposalTracker *ProposalTracker
@@ -1957,6 +1962,13 @@ func (e *Engine) setMode(newMode consensus.Mode) {
 	})
 
 	e.adaptor.OnModeChange(oldMode, newMode)
+
+	// Leaving proposing/observing resets censorship tracking: entries recorded
+	// under the old mode no longer reflect a set we keep proposing, so warning
+	// on them would be bogus (setMode already guarantees oldMode != newMode).
+	if oldMode == consensus.ModeProposing || oldMode == consensus.ModeObserving {
+		e.censorship.reset()
+	}
 }
 
 func (e *Engine) setPhase(newPhase consensus.Phase) {
@@ -2218,6 +2230,12 @@ func (e *Engine) closeLedger() {
 	// Our own tx set is immediately "acquired" so dispute wiring recognizes
 	// proposals referencing our position.
 	e.acquiredTxSets[txSet.ID()] = txSet
+
+	// Record the set we're proposing this round for censorship detection,
+	// unless we're acquiring the correct ledger (rippled's !wrongLCL gate).
+	if e.prevLedger != nil && e.mode != consensus.ModeWrongLedger {
+		e.censorship.propose(txSet.TxIDs(), e.prevLedger.Seq()+1)
+	}
 
 	// Raw now; rounding happens later via effCloseTime at acceptance.
 	closeTime := e.adaptor.Now()
@@ -3207,6 +3225,35 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 		"result", result.String(),
 		"mode", e.mode.String(),
 	)
+
+	// Censorship detection: reconcile the txs we've been proposing against the
+	// agreed set now that the LCL is built. Only meaningful with the correct
+	// LCL and full consensus (a timed-out round proves nothing about exclusion).
+	if e.state.HaveCorrectLCL && result == consensus.ResultSuccess {
+		accepted := txSet.TxIDs()
+		disputedNo := make(map[consensus.TxID]struct{})
+		for _, id := range e.disputeTracker.DisputedNoIDs() {
+			disputedNo[id] = struct{}{}
+		}
+		curr := newLedger.Seq()
+		e.censorship.check(accepted, func(id consensus.TxID, seq uint32) bool {
+			// Txs we ended up voting NO on aren't being censored — drop them.
+			if _, ok := disputedNo[id]; ok {
+				return true
+			}
+			if curr > seq && (curr-seq)%censorshipWarnInterval == 0 {
+				slog.Warn("potential censorship: eligible tx not yet included",
+					"t", "consensus",
+					"event", "censorship-warn",
+					"tx", fmt.Sprintf("%x", id[:8]),
+					"tracked_since_seq", seq,
+					"current_seq", curr,
+					"waited", curr-seq,
+				)
+			}
+			return false
+		})
+	}
 
 	e.eventBus.Publish(&consensus.ConsensusReachedEvent{
 		Round:     e.state.Round,

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -3227,20 +3227,17 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 	)
 
 	// Censorship detection: reconcile the txs we've been proposing against the
-	// agreed set now that the LCL is built. Only meaningful with the correct
+	// accepted set now that the LCL is built. Only meaningful with the correct
 	// LCL and full consensus (a timed-out round proves nothing about exclusion).
 	if e.state.HaveCorrectLCL && result == consensus.ResultSuccess {
 		accepted := txSet.TxIDs()
-		disputedNo := make(map[consensus.TxID]struct{})
-		for _, id := range e.disputeTracker.DisputedNoIDs() {
-			disputedNo[id] = struct{}{}
-		}
 		curr := newLedger.Seq()
 		e.censorship.check(accepted, func(id consensus.TxID, seq uint32) bool {
-			// Txs we ended up voting NO on aren't being censored — drop them.
-			if _, ok := disputedNo[id]; ok {
-				return true
-			}
+			// Reached only for txs we proposed that stayed out of the accepted
+			// set. Keep tracking them (never drop) so the wait accumulates as
+			// they get re-proposed from the pending pool each round; txs we
+			// genuinely stop proposing fall out via propose(), not here. Warn
+			// each time persistent exclusion crosses the interval.
 			if curr > seq && (curr-seq)%censorshipWarnInterval == 0 {
 				slog.Warn("potential censorship: eligible tx not yet included",
 					"t", "consensus",

--- a/internal/consensus/rcl/engine_censorship_test.go
+++ b/internal/consensus/rcl/engine_censorship_test.go
@@ -1,0 +1,64 @@
+package rcl
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+)
+
+// TestEngine_CensorshipWarnsOnPersistentExclusion drives the engine's accept
+// path and proves the detector actually fires. A tx we proposed and keep
+// tracking, that stays out of the accepted set — here because dispute
+// resolution forced us to vote NO on it as the network kept excluding it —
+// must warn once its exclusion crosses the interval.
+//
+// This is the exact case a predicate that dropped disputed-NO txs would
+// silence: every tx the predicate ever sees (tracked but not accepted) is one
+// we voted NO on, so dropping them disables the detector entirely. The captured
+// warn is the regression guard against re-introducing that drop.
+func TestEngine_CensorshipWarnsOnPersistentExclusion(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.opMode = consensus.OpModeFull
+	adaptor.validator = true
+
+	engine := NewEngine(adaptor, DefaultConfig())
+	engine.StartRound(consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}, true)
+	driveToEstablish(t, engine, adaptor)
+
+	// Our accepted position for this round holds no transactions, so the tx we
+	// track below is necessarily tracked-but-not-accepted at check time.
+	emptySet, err := adaptor.BuildTxSet(nil)
+	if err != nil {
+		t.Fatalf("BuildTxSet(nil): %v", err)
+	}
+
+	x := censorTxID(77)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	engine.mu.Lock()
+	curr := engine.prevLedger.Seq() + 1
+	engine.state.HaveCorrectLCL = true
+	engine.ourTxSet = emptySet
+	// x was first proposed exactly one interval ago and never included; we've
+	// since been forced to vote NO on it (why it isn't in our accepted set).
+	engine.censorship.propose([]consensus.TxID{x}, curr-censorshipWarnInterval)
+	engine.disputeTracker.CreateDispute(x, []byte{0xAA}, false)
+	engine.acceptLedger(consensus.ResultSuccess)
+	engine.mu.Unlock()
+
+	out := buf.String()
+	if !strings.Contains(out, "censorship-warn") {
+		t.Fatalf("expected a censorship warning for a tx excluded for %d ledgers; got:\n%s",
+			censorshipWarnInterval, out)
+	}
+	if !strings.Contains(out, "waited=15") {
+		t.Fatalf("censorship warning should report waited=%d; got:\n%s", censorshipWarnInterval, out)
+	}
+}

--- a/internal/consensus/rcl/proposals.go
+++ b/internal/consensus/rcl/proposals.go
@@ -332,20 +332,6 @@ func (dt *DisputeTracker) DisputedNoTxs() [][]byte {
 	return txs
 }
 
-// DisputedNoIDs returns the TxIDs of every dispute we currently vote NO on.
-func (dt *DisputeTracker) DisputedNoIDs() []consensus.TxID {
-	dt.mu.RLock()
-	defer dt.mu.RUnlock()
-
-	var ids []consensus.TxID
-	for id, d := range dt.disputes {
-		if !d.OurVote {
-			ids = append(ids, id)
-		}
-	}
-	return ids
-}
-
 // GetAll returns all disputed transactions.
 func (dt *DisputeTracker) GetAll() []*consensus.DisputedTx {
 	dt.mu.RLock()

--- a/internal/consensus/rcl/proposals.go
+++ b/internal/consensus/rcl/proposals.go
@@ -332,6 +332,20 @@ func (dt *DisputeTracker) DisputedNoTxs() [][]byte {
 	return txs
 }
 
+// DisputedNoIDs returns the TxIDs of every dispute we currently vote NO on.
+func (dt *DisputeTracker) DisputedNoIDs() []consensus.TxID {
+	dt.mu.RLock()
+	defer dt.mu.RUnlock()
+
+	var ids []consensus.TxID
+	for id, d := range dt.disputes {
+		if !d.OurVote {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
 // GetAll returns all disputed transactions.
 func (dt *DisputeTracker) GetAll() []*consensus.DisputedTx {
 	dt.mu.RLock()


### PR DESCRIPTION
## Summary

- Ports rippled's `RCLCensorshipDetector`: a log-only, observational tracker that flags eligible transactions this node keeps proposing but which never make it into a ledger. It never affects the proposed set, ledger content, or validations, so it cannot fork or wedge.
- New `censorshipDetector` (`internal/consensus/rcl/censorship.go`) with `propose`/`check`/`reset`, wired into the RCL engine:
  - **propose** — at ledger close (`closeLedger`), records our position with `seq = prevLedger.Seq()+1`, gated on not acquiring the correct ledger (rippled's `!wrongLCL`). Carried-over txs keep their original tracking seq so the wait grows across rounds.
  - **check** — after the LCL is built (`acceptLedger`), gated on `HaveCorrectLCL && ResultSuccess`. Drops txs in the agreed set and txs we voted NO on, and warns every `censorshipWarnInterval` (15) ledgers for anything still stuck.
  - **reset** — clears tracking when leaving proposing/observing mode (`setMode`).
- Added `DisputeTracker.DisputedNoIDs()` so the check can suppress no-longer-wanted txs by id without re-hashing blobs.

### Note on the "failed" predicate
rippled's `check` also suppresses warnings for txs that failed on apply (`retriableTxs`). In go-xrpl's build model the closing ledger only applies the agreed set plus disputed-NO txs, so agreed-set apply failures are already removed by the accepted-set intersection, and the only remaining case is disputed-NO txs — which the check already drops. This keeps the change self-contained in the `rcl` package with no signature churn across the `BuildLedger`/`AcceptConsensusResult` boundary.

## Test plan
- [x] `go test ./internal/consensus/rcl/... -run TestCensorship` — ports rippled's `RCLCensorshipDetector_test` corpus verbatim, plus seq-preservation and reset cases.
- [x] `go test ./internal/consensus/...` and `go test ./internal/testing/consensus/...` — full consensus + integration suites green.
- [x] `go vet ./internal/consensus/...` clean; `golangci-lint run --config .golangci.yml ./internal/consensus/rcl/...` — 0 issues.

Fixes #1199