### PR TITLE
fix: guard queryAccountTxsPage marker against Limit==0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,9 @@ jobs:
   # paths silently forks account_hash / transaction_hash. `int` is 64-bit on the
   # amd64 matrix, so an overflow like `len(x) > math.MaxUint32` only fails to
   # compile on a 32-bit target. This compiles the whole module for linux/386
-  # (CGO off → peertls uses its !cgo stub) and is fast. Runtime 386 tests run in
-  # the nightly workflow.
+  # (CGO off → peertls uses its !cgo stub), then exercises the SQLite pagination
+  # boundaries whose correctness depends on runtime int width. Broader runtime
+  # 386 tests run in the nightly workflow.
   build-386:
     name: Build (linux/386 — word-size guard)
     runs-on: ubuntu-latest
@@ -97,6 +98,7 @@ jobs:
         with:
           cgo: "false"
       - run: go build ./...
+      - run: go test -count=1 -timeout 5m ./storage/relationaldb/sqlite/...
 
   test:
     name: Test (${{ matrix.group }})

--- a/storage/relationaldb/postgres/account_repository.go
+++ b/storage/relationaldb/postgres/account_repository.go
@@ -190,10 +190,12 @@ func (r *AccountTransactionRepository) queryAccountTxsPage(ctx context.Context, 
 	if len(transactions) > int(options.Limit) {
 		// Remove the extra transaction and set marker
 		transactions = transactions[:options.Limit]
-		lastTx := transactions[len(transactions)-1]
-		result.Marker = &relationaldb.AccountTxMarker{
-			LedgerSeq: lastTx.LedgerSeq,
-			TxnSeq:    lastTx.TxnSeq,
+		if len(transactions) > 0 {
+			lastTx := transactions[len(transactions)-1]
+			result.Marker = &relationaldb.AccountTxMarker{
+				LedgerSeq: lastTx.LedgerSeq,
+				TxnSeq:    lastTx.TxnSeq,
+			}
 		}
 	}
 

--- a/storage/relationaldb/postgres/account_repository.go
+++ b/storage/relationaldb/postgres/account_repository.go
@@ -188,7 +188,6 @@ func (r *AccountTransactionRepository) queryAccountTxsPage(ctx context.Context, 
 
 	// Check if there are more results
 	if len(transactions) > int(options.Limit) {
-		// Remove the extra transaction and set marker
 		transactions = transactions[:options.Limit]
 		if len(transactions) > 0 {
 			lastTx := transactions[len(transactions)-1]

--- a/storage/relationaldb/postgres/account_repository.go
+++ b/storage/relationaldb/postgres/account_repository.go
@@ -164,7 +164,7 @@ func (r *AccountTransactionRepository) queryAccountTxsPage(ctx context.Context, 
 	query += " ORDER BY at.ledger_seq " + orderDir + ", at.txn_seq " + orderDir
 
 	// Fetch one extra to determine if there are more results
-	args = append(args, options.Limit+1)
+	args = append(args, int64(options.Limit)+1)
 	query += fmt.Sprintf(" LIMIT $%d", len(args))
 
 	rows, err := r.getExecutor().QueryContext(ctx, query, args...)
@@ -187,8 +187,8 @@ func (r *AccountTransactionRepository) queryAccountTxsPage(ctx context.Context, 
 	}
 
 	// Check if there are more results
-	if len(transactions) > int(options.Limit) {
-		transactions = transactions[:options.Limit]
+	if uint64(len(transactions)) > uint64(options.Limit) {
+		transactions = transactions[:len(transactions)-1]
 		if len(transactions) > 0 {
 			lastTx := transactions[len(transactions)-1]
 			result.Marker = &relationaldb.AccountTxMarker{

--- a/storage/relationaldb/postgres/postgres_test.go
+++ b/storage/relationaldb/postgres/postgres_test.go
@@ -412,6 +412,42 @@ func TestPostgresAccountTransactionPagination(t *testing.T) {
 	}
 }
 
+func TestPostgresAccountTransactionPaginationZeroLimit(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+
+	var accountID relationaldb.AccountID
+	accountID[0] = 0x01
+
+	tx := &relationaldb.TransactionInfo{
+		LedgerSeq: 1,
+		TxnSeq:    1,
+		Status:    "validated",
+		RawTxn:    []byte("raw"),
+	}
+	tx.Hash[0] = 0x01
+	if err := rm.Transaction().SaveTransaction(ctx, tx); err != nil {
+		t.Fatal(err)
+	}
+	if err := rm.AccountTransaction().SaveAccountTransaction(ctx, accountID, tx); err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := rm.AccountTransaction().GetOldestAccountTxsPage(ctx, relationaldb.AccountTxPageOptions{
+		Account: accountID,
+		Limit:   0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Transactions) != 0 {
+		t.Fatalf("expected 0 txs, got %d", len(page.Transactions))
+	}
+	if page.Marker != nil {
+		t.Fatal("expected no marker for zero limit")
+	}
+}
+
 func TestPostgresWithTransaction(t *testing.T) {
 	rm := setupTestDB(t)
 	ctx := context.Background()

--- a/storage/relationaldb/postgres/postgres_test.go
+++ b/storage/relationaldb/postgres/postgres_test.go
@@ -11,6 +11,7 @@ package postgres
 
 import (
 	"context"
+	"math"
 	"os"
 	"testing"
 	"time"
@@ -409,6 +410,20 @@ func TestPostgresAccountTransactionPagination(t *testing.T) {
 	}
 	if page3.Marker != nil {
 		t.Fatal("expected no marker on last page")
+	}
+
+	maxLimitPage, err := rm.AccountTransaction().GetOldestAccountTxsPage(ctx, relationaldb.AccountTxPageOptions{
+		Account: accountID,
+		Limit:   math.MaxUint32,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(maxLimitPage.Transactions) != 5 {
+		t.Fatalf("expected 5 txs with maximum limit, got %d", len(maxLimitPage.Transactions))
+	}
+	if maxLimitPage.Marker != nil {
+		t.Fatal("expected no marker with maximum limit")
 	}
 }
 

--- a/storage/relationaldb/sqlite/account_repository.go
+++ b/storage/relationaldb/sqlite/account_repository.go
@@ -182,10 +182,12 @@ func (r *AccountTransactionRepository) queryAccountTxsPage(ctx context.Context, 
 
 	if len(transactions) > int(options.Limit) {
 		transactions = transactions[:options.Limit]
-		lastTx := transactions[len(transactions)-1]
-		result.Marker = &relationaldb.AccountTxMarker{
-			LedgerSeq: lastTx.LedgerSeq,
-			TxnSeq:    lastTx.TxnSeq,
+		if len(transactions) > 0 {
+			lastTx := transactions[len(transactions)-1]
+			result.Marker = &relationaldb.AccountTxMarker{
+				LedgerSeq: lastTx.LedgerSeq,
+				TxnSeq:    lastTx.TxnSeq,
+			}
 		}
 	}
 

--- a/storage/relationaldb/sqlite/account_repository.go
+++ b/storage/relationaldb/sqlite/account_repository.go
@@ -145,7 +145,7 @@ func (r *AccountTransactionRepository) queryAccountTxsPage(ctx context.Context, 
 	query += " ORDER BY at.ledger_seq " + orderDir + ", at.txn_seq " + orderDir
 
 	// Fetch one extra to check for more results
-	limit := options.Limit + 1
+	limit := int64(options.Limit) + 1
 	query += " LIMIT ?"
 	args = append(args, limit)
 
@@ -180,8 +180,8 @@ func (r *AccountTransactionRepository) queryAccountTxsPage(ctx context.Context, 
 		Limit: options.Limit,
 	}
 
-	if len(transactions) > int(options.Limit) {
-		transactions = transactions[:options.Limit]
+	if uint64(len(transactions)) > uint64(options.Limit) {
+		transactions = transactions[:len(transactions)-1]
 		if len(transactions) > 0 {
 			lastTx := transactions[len(transactions)-1]
 			result.Marker = &relationaldb.AccountTxMarker{

--- a/storage/relationaldb/sqlite/sqlite_test.go
+++ b/storage/relationaldb/sqlite/sqlite_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -526,6 +527,20 @@ func TestAccountTransactionPagination(t *testing.T) {
 	}
 	if page3.Marker != nil {
 		t.Fatal("expected no marker on last page")
+	}
+
+	maxLimitPage, err := rm.AccountTransaction().GetOldestAccountTxsPage(ctx, relationaldb.AccountTxPageOptions{
+		Account: accountID,
+		Limit:   math.MaxUint32,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(maxLimitPage.Transactions) != 5 {
+		t.Fatalf("expected 5 txs with maximum limit, got %d", len(maxLimitPage.Transactions))
+	}
+	if maxLimitPage.Marker != nil {
+		t.Fatal("expected no marker with maximum limit")
 	}
 }
 

--- a/storage/relationaldb/sqlite/sqlite_test.go
+++ b/storage/relationaldb/sqlite/sqlite_test.go
@@ -529,6 +529,42 @@ func TestAccountTransactionPagination(t *testing.T) {
 	}
 }
 
+func TestAccountTransactionPaginationZeroLimit(t *testing.T) {
+	rm := setupTestDB(t)
+	ctx := context.Background()
+
+	var accountID relationaldb.AccountID
+	accountID[0] = 0x01
+
+	tx := &relationaldb.TransactionInfo{
+		LedgerSeq: 1,
+		TxnSeq:    1,
+		Status:    "validated",
+		RawTxn:    []byte("raw"),
+	}
+	tx.Hash[0] = 0x01
+	if err := rm.Transaction().SaveTransaction(ctx, tx); err != nil {
+		t.Fatal(err)
+	}
+	if err := rm.AccountTransaction().SaveAccountTransaction(ctx, accountID, tx); err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := rm.AccountTransaction().GetOldestAccountTxsPage(ctx, relationaldb.AccountTxPageOptions{
+		Account: accountID,
+		Limit:   0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Transactions) != 0 {
+		t.Fatalf("expected 0 txs, got %d", len(page.Transactions))
+	}
+	if page.Marker != nil {
+		t.Fatal("expected no marker for zero limit")
+	}
+}
+
 func TestWithTransaction(t *testing.T) {
 	rm := setupTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- `queryAccountTxsPage` in both the sqlite and postgres account repositories over-fetches one row for marker pagination; with `Limit == 0` the SQL fetches up to 1 row, the `len > Limit` guard passes, the slice is truncated to empty, and `transactions[len-1]` panics with `index out of range [-1]`.
- Only set the pagination marker when the truncated page is non-empty, so `Limit == 0` returns an empty page with no marker instead of panicking. Latent today (the only production caller clamps the limit first), but the guard belongs at the repository layer.
- Adds zero-limit regression tests to both backends; the sqlite test reproduces the exact `index out of range [-1]` panic on pre-fix code.

## Test plan
- [x] `go test ./storage/relationaldb/...`
- [x] `go test -tags postgres ./storage/relationaldb/postgres/` (compiles; skips without `XRPLD_TEST_POSTGRES_DSN`)
- [x] Verified `TestAccountTransactionPaginationZeroLimit` panics on `origin/main` code and passes with the fix
- [x] `golangci-lint run --config .golangci.yml --build-tags postgres ./storage/relationaldb/...` — 0 issues

Fixes #1171