### PR TITLE
fix: redact password in relationaldb Config.String for raw DSNs

### DIFF
--- a/storage/relationaldb/config.go
+++ b/storage/relationaldb/config.go
@@ -242,9 +242,6 @@ func (c *Config) String() string {
 // survives URL re-encoding unescaped.
 const redactedPassword = "xxxxx"
 
-// redactDSN masks any password embedded in a connection string: URL userinfo
-// (postgres://user:pass@host), a password query parameter, or key/value form
-// (password=...).
 func redactDSN(dsn string) string {
 	if strings.Contains(dsn, "://") {
 		return redactURLDSN(dsn)

--- a/storage/relationaldb/config.go
+++ b/storage/relationaldb/config.go
@@ -3,6 +3,7 @@ package relationaldb
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 	"time"
 )
 
@@ -230,12 +231,36 @@ func (c *Config) WithConnectionString(connStr string) *Config {
 
 // String returns a string representation of the config (with password redacted)
 func (c *Config) String() string {
-	clone := c.Clone()
-	if clone.Password != "" {
-		clone.Password = "***"
-	}
-
-	connStr, _ := clone.BuildConnectionString()
+	connStr, _ := c.BuildConnectionString()
 	return fmt.Sprintf("Config{Driver: %s, Host: %s, Port: %d, Database: %s, Connection: %s}",
-		clone.Driver, clone.Host, clone.Port, clone.Database, connStr)
+		c.Driver, c.Host, c.Port, c.Database, redactDSN(connStr))
+}
+
+// redactedPassword matches the placeholder net/url's URL.Redacted() uses; it
+// survives URL re-encoding unescaped.
+const redactedPassword = "xxxxx"
+
+var dsnPasswordRE = regexp.MustCompile(`(?i)(password\s*=\s*)(?:'[^']*'|[^\s&]+)`)
+
+// redactDSN masks any password embedded in a connection string: URL userinfo
+// (postgres://user:pass@host), a password query parameter, or key/value form
+// (password=...).
+func redactDSN(dsn string) string {
+	if u, err := url.Parse(dsn); err == nil && u.IsAbs() {
+		redacted := false
+		if _, ok := u.User.Password(); ok {
+			u.User = url.UserPassword(u.User.Username(), redactedPassword)
+			redacted = true
+		}
+		if q := u.Query(); q.Has("password") {
+			q.Set("password", redactedPassword)
+			u.RawQuery = q.Encode()
+			redacted = true
+		}
+		if redacted {
+			return u.String()
+		}
+		return dsn
+	}
+	return dsnPasswordRE.ReplaceAllString(dsn, "${1}"+redactedPassword)
 }

--- a/storage/relationaldb/config.go
+++ b/storage/relationaldb/config.go
@@ -3,8 +3,10 @@ package relationaldb
 import (
 	"fmt"
 	"net/url"
-	"regexp"
+	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 // Config contains database configuration settings
@@ -240,27 +242,139 @@ func (c *Config) String() string {
 // survives URL re-encoding unescaped.
 const redactedPassword = "xxxxx"
 
-var dsnPasswordRE = regexp.MustCompile(`(?i)(password\s*=\s*)(?:'[^']*'|[^\s&]+)`)
-
 // redactDSN masks any password embedded in a connection string: URL userinfo
 // (postgres://user:pass@host), a password query parameter, or key/value form
 // (password=...).
 func redactDSN(dsn string) string {
-	if u, err := url.Parse(dsn); err == nil && u.IsAbs() {
-		redacted := false
-		if _, ok := u.User.Password(); ok {
-			u.User = url.UserPassword(u.User.Username(), redactedPassword)
+	if strings.Contains(dsn, "://") {
+		return redactURLDSN(dsn)
+	}
+	return redactKeywordDSN(dsn)
+}
+
+func redactURLDSN(dsn string) string {
+	u, err := url.Parse(dsn)
+	if err != nil || !u.IsAbs() {
+		return redactedPassword
+	}
+
+	redacted := false
+	if _, ok := u.User.Password(); ok {
+		u.User = url.UserPassword(u.User.Username(), redactedPassword)
+		redacted = true
+	}
+
+	if u.RawQuery != "" {
+		query, err := url.ParseQuery(u.RawQuery)
+		if err != nil {
+			return redactedPassword
+		}
+		queryRedacted := false
+		for key := range query {
+			if strings.EqualFold(key, "password") {
+				query.Set(key, redactedPassword)
+				queryRedacted = true
+			}
+		}
+		if queryRedacted {
+			u.RawQuery = query.Encode()
 			redacted = true
 		}
-		if q := u.Query(); q.Has("password") {
-			q.Set("password", redactedPassword)
-			u.RawQuery = q.Encode()
+	}
+
+	if redacted {
+		return u.String()
+	}
+	return dsn
+}
+
+func redactKeywordDSN(dsn string) string {
+	var result strings.Builder
+	last := 0
+	redacted := false
+	for pos := 0; pos < len(dsn); {
+		pos = skipDSNSpace(dsn, pos)
+		keyStart := pos
+		for pos < len(dsn) {
+			r, size := utf8.DecodeRuneInString(dsn[pos:])
+			if unicode.IsSpace(r) || r == '=' {
+				break
+			}
+			pos += size
+		}
+		keyEnd := pos
+		pos = skipDSNSpace(dsn, pos)
+		if pos >= len(dsn) {
+			break
+		}
+		if dsn[pos] != '=' {
+			continue
+		}
+		pos++
+		pos = skipDSNSpace(dsn, pos)
+		valueStart := pos
+		pos = scanDSNValue(dsn, pos)
+		if strings.EqualFold(dsn[keyStart:keyEnd], "password") {
+			if !redacted {
+				result.Grow(len(dsn))
+			}
+			result.WriteString(dsn[last:valueStart])
+			result.WriteString(redactedPassword)
+			last = pos
 			redacted = true
 		}
-		if redacted {
-			return u.String()
-		}
+	}
+
+	if !redacted {
 		return dsn
 	}
-	return dsnPasswordRE.ReplaceAllString(dsn, "${1}"+redactedPassword)
+	result.WriteString(dsn[last:])
+	return result.String()
+}
+
+func skipDSNSpace(dsn string, pos int) int {
+	for pos < len(dsn) {
+		r, size := utf8.DecodeRuneInString(dsn[pos:])
+		if !unicode.IsSpace(r) {
+			break
+		}
+		pos += size
+	}
+	return pos
+}
+
+func scanDSNValue(dsn string, pos int) int {
+	if pos >= len(dsn) {
+		return pos
+	}
+
+	if dsn[pos] == '\'' {
+		pos++
+		for pos < len(dsn) {
+			r, size := utf8.DecodeRuneInString(dsn[pos:])
+			pos += size
+			if r == '\\' && pos < len(dsn) {
+				_, size = utf8.DecodeRuneInString(dsn[pos:])
+				pos += size
+				continue
+			}
+			if r == '\'' {
+				break
+			}
+		}
+		return pos
+	}
+
+	for pos < len(dsn) {
+		r, size := utf8.DecodeRuneInString(dsn[pos:])
+		if unicode.IsSpace(r) {
+			break
+		}
+		pos += size
+		if r == '\\' && pos < len(dsn) {
+			_, size = utf8.DecodeRuneInString(dsn[pos:])
+			pos += size
+		}
+	}
+	return pos
 }

--- a/storage/relationaldb/config_test.go
+++ b/storage/relationaldb/config_test.go
@@ -1,0 +1,83 @@
+package relationaldb
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactDSN(t *testing.T) {
+	tests := []struct {
+		name string
+		dsn  string
+		want string
+	}{
+		{
+			name: "url userinfo password",
+			dsn:  "postgres://xrpl:s3cr3t@dbhost:5432/xrpl?sslmode=require",
+			want: "postgres://xrpl:xxxxx@dbhost:5432/xrpl?sslmode=require",
+		},
+		{
+			name: "url without password unchanged",
+			dsn:  "postgres://xrpl@dbhost/xrpl?sslmode=require",
+			want: "postgres://xrpl@dbhost/xrpl?sslmode=require",
+		},
+		{
+			name: "url password query parameter",
+			dsn:  "postgres://dbhost/xrpl?password=s3cr3t&sslmode=require",
+			want: "postgres://dbhost/xrpl?password=xxxxx&sslmode=require",
+		},
+		{
+			name: "key/value password",
+			dsn:  "host=dbhost user=xrpl password=s3cr3t dbname=xrpl",
+			want: "host=dbhost user=xrpl password=xxxxx dbname=xrpl",
+		},
+		{
+			name: "key/value quoted password",
+			dsn:  "host=dbhost password='se cr et' dbname=xrpl",
+			want: "host=dbhost password=xxxxx dbname=xrpl",
+		},
+		{
+			name: "sqlite dsn unchanged",
+			dsn:  "xrpl.db?foreign_keys=1&journal_mode=WAL",
+			want: "xrpl.db?foreign_keys=1&journal_mode=WAL",
+		},
+		{
+			name: "empty",
+			dsn:  "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redactDSN(tt.dsn); got != tt.want {
+				t.Errorf("redactDSN(%q) = %q, want %q", tt.dsn, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigStringRedactsPassword(t *testing.T) {
+	t.Run("connection string DSN", func(t *testing.T) {
+		cfg := NewConfig().WithConnectionString("postgres://xrpl:s3cr3t@dbhost/xrpl?sslmode=require")
+		s := cfg.String()
+		if strings.Contains(s, "s3cr3t") {
+			t.Errorf("String() leaked DSN password: %s", s)
+		}
+		if !strings.Contains(s, "xxxxx") {
+			t.Errorf("String() missing redaction marker: %s", s)
+		}
+	})
+
+	t.Run("password field", func(t *testing.T) {
+		cfg := NewConfig()
+		cfg.Password = "s3cr3t"
+		s := cfg.String()
+		if strings.Contains(s, "s3cr3t") {
+			t.Errorf("String() leaked password field: %s", s)
+		}
+		if !strings.Contains(s, "xxxxx") {
+			t.Errorf("String() missing redaction marker: %s", s)
+		}
+	})
+}

--- a/storage/relationaldb/config_test.go
+++ b/storage/relationaldb/config_test.go
@@ -27,6 +27,16 @@ func TestRedactDSN(t *testing.T) {
 			want: "postgres://dbhost/xrpl?password=xxxxx&sslmode=require",
 		},
 		{
+			name: "url userinfo with malformed path escape",
+			dsn:  "postgres://xrpl:s3cr3t@dbhost/%ZZ",
+			want: "xxxxx",
+		},
+		{
+			name: "url password query parameter with malformed escape",
+			dsn:  "postgres://dbhost/xrpl?password=s3cr3t%ZZ&sslmode=require",
+			want: "xxxxx",
+		},
+		{
 			name: "key/value password",
 			dsn:  "host=dbhost user=xrpl password=s3cr3t dbname=xrpl",
 			want: "host=dbhost user=xrpl password=xxxxx dbname=xrpl",
@@ -35,6 +45,36 @@ func TestRedactDSN(t *testing.T) {
 			name: "key/value quoted password",
 			dsn:  "host=dbhost password='se cr et' dbname=xrpl",
 			want: "host=dbhost password=xxxxx dbname=xrpl",
+		},
+		{
+			name: "key/value password with ampersand",
+			dsn:  "host=dbhost password=abc&def dbname=xrpl",
+			want: "host=dbhost password=xxxxx dbname=xrpl",
+		},
+		{
+			name: "key/value password with escaped spaces",
+			dsn:  `host=dbhost password=se\ cr\ et dbname=xrpl`,
+			want: "host=dbhost password=xxxxx dbname=xrpl",
+		},
+		{
+			name: "key/value quoted password with escaped quote",
+			dsn:  `host=dbhost password='it\'s secret' dbname=xrpl`,
+			want: "host=dbhost password=xxxxx dbname=xrpl",
+		},
+		{
+			name: "key/value unterminated quoted password",
+			dsn:  "host=dbhost password='se cr et",
+			want: "host=dbhost password=xxxxx",
+		},
+		{
+			name: "key/value unicode whitespace",
+			dsn:  "host=dbhost password\u00a0=\u00a0s3cr3t dbname=xrpl",
+			want: "host=dbhost password\u00a0=\u00a0xxxxx dbname=xrpl",
+		},
+		{
+			name: "password text in another value unchanged",
+			dsn:  "user=password=s3cr3t host=dbhost",
+			want: "user=password=s3cr3t host=dbhost",
 		},
 		{
 			name: "sqlite dsn unchanged",


### PR DESCRIPTION
## Summary
- `Config.String()` masked only the `Password` field, but `BuildConnectionString()` short-circuits and returns `ConnectionString` verbatim when it is set — so a DSN like `postgres://user:secret@host/db` had its embedded password rendered in cleartext, despite the method documenting the password as redacted.
- Redaction now applies to the **rendered** connection string via a `redactDSN` helper, covering all three places a password can live in a DSN: URL userinfo, a `password` query parameter, and libpq key/value form (`password=...`), so both build paths are safe.
- The placeholder is `xxxxx`, matching `net/url`'s `URL.Redacted()` convention (it survives URL re-encoding; `***` would render as `%2A%2A%2A`).

## Test plan
- [x] `go test ./storage/relationaldb/...` — new table-driven `TestRedactDSN` plus `TestConfigStringRedactsPassword` covering both the `ConnectionString` path and the built-postgres path
- [x] `go vet`, `gofmt`, and strict-config `golangci-lint run --config .golangci.yml ./storage/relationaldb/...` all clean

Fixes #1172