### PR TITLE
feat(batch): reject Vault and Loan inner transaction types

### DIFF
--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -310,6 +310,78 @@ func TestPreflight(t *testing.T) {
 		xtesting.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
 	})
 
+	// A batch may not wrap a blocklisted inner transaction type (all Vault and
+	// Loan types). The rejection is unconditional and fires at preflight, before
+	// the inner's own amendment/flag/fee checks.
+	// Reference: rippled Batch::disabledTxTypes + Batch_test.cpp testLoan().
+	t.Run("temINVALID_INNER_BATCH - disabled inner type (VaultCreate)", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(MakeInnerVaultCreate(alice, seq+2)).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
+	})
+
+	// The blocklist check precedes the inner tfInnerBatchTxn-flag check: a
+	// blocklisted inner missing the flag is still temINVALID_INNER_BATCH, not
+	// temINVALID_FLAG.
+	t.Run("temINVALID_INNER_BATCH - disabled type precedes flag check", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+
+		badVault := MakeInnerVaultCreate(alice, seq+2)
+		badVault.GetCommon().Flags = nil // omit tfInnerBatchTxn
+
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(badVault).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
+	})
+
+	// The blocklist check precedes the inner zero-fee check: a blocklisted inner
+	// with a non-zero fee is still temINVALID_INNER_BATCH, not temBAD_FEE.
+	t.Run("temINVALID_INNER_BATCH - disabled type precedes fee check", func(t *testing.T) {
+		env := xtesting.NewTestEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+
+		badVault := MakeInnerVaultCreate(alice, seq+2)
+		badVault.Fee = fmt.Sprintf("%d", env.BaseFee())
+
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(badVault).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
+	})
+
 	// Reference: rippled Batch_test.cpp:410-501 (per-inner rejection cases).
 
 	t.Run("temBAD_FEE - inner fee non-zero", func(t *testing.T) {

--- a/internal/testing/batch/builder.go
+++ b/internal/testing/batch/builder.go
@@ -17,6 +17,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/check"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx/ticket"
+	"github.com/LeJamon/go-xrpl/internal/tx/vault"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -354,6 +355,18 @@ func MakeInnerPaymentXRPWithDelegate(from, to *testing.Account, xrp int64, seq u
 // MakeInnerPaymentXRP creates an inner Payment for an XRP amount in whole XRP units.
 func MakeInnerPaymentXRP(from, to *testing.Account, xrp int64, seq uint32) *payment.Payment {
 	return MakeInnerPayment(from, to, testing.XRP(xrp), seq)
+}
+
+// MakeInnerVaultCreate creates a well-formed inner VaultCreate. VaultCreate is on
+// the Batch inner-type blocklist, so a batch containing it is rejected with
+// temINVALID_INNER_BATCH regardless of the inner's other fields.
+func MakeInnerVaultCreate(account *testing.Account, seq uint32) *vault.VaultCreate {
+	v := vault.NewVaultCreate(account.Address, tx.Asset{Currency: "XRP"})
+	v.Fee = "0"
+	v.SigningPubKey = ""
+	v.SetSequence(seq)
+	v.SetFlags(tx.TfInnerBatchTxn)
+	return v
 }
 
 // NewBatchBuilderWithTicket creates a new BatchBuilder where the outer batch uses a TicketSequence.

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -86,6 +86,7 @@ var (
 	ErrBatchNilInnerTx            = ter.Errorf(ter.TemMALFORMED, "inner transaction cannot be nil")
 	ErrBatchDuplicateInnerTx      = ter.Errorf(ter.TemREDUNDANT, "duplicate inner transaction")
 	ErrBatchInnerIsBatch          = ter.Errorf(ter.TemINVALID, "inner transaction cannot itself be a Batch")
+	ErrBatchInnerDisabledType     = ter.Errorf(ter.TemINVALID_INNER_BATCH, "inner transaction type is not allowed in a batch")
 	ErrBatchInnerMissingFlag      = ter.Errorf(ter.TemINVALID_FLAG, "inner transaction missing tfInnerBatchTxn flag")
 	ErrBatchInnerHasTxnSignature  = ter.Errorf(ter.TemBAD_SIGNATURE, "inner transaction cannot include TxnSignature")
 	ErrBatchInnerHasSigners       = ter.Errorf(ter.TemBAD_SIGNER, "inner transaction cannot include Signers")
@@ -95,6 +96,29 @@ var (
 	ErrBatchInnerDupSeqOrTicket   = ter.Errorf(ter.TemREDUNDANT, "duplicate inner Sequence or TicketSequence for account")
 	ErrBatchInnerHashUncomputable = ter.Errorf(ter.TemINVALID, "failed to compute inner transaction hash")
 )
+
+// disabledInnerTxTypes are transaction types that may not appear as inner
+// transactions of a Batch. The check is unconditional — it is not gated on any
+// amendment — so a batch wrapping one of these is rejected at preflight
+// regardless of whether the wrapped feature is enabled.
+// Reference: rippled Batch::disabledTxTypes (Batch.h) / Batch::preflight.
+var disabledInnerTxTypes = map[tx.Type]struct{}{
+	tx.TypeVaultCreate:             {},
+	tx.TypeVaultSet:                {},
+	tx.TypeVaultDelete:             {},
+	tx.TypeVaultDeposit:            {},
+	tx.TypeVaultWithdraw:           {},
+	tx.TypeVaultClawback:           {},
+	tx.TypeLoanBrokerSet:           {},
+	tx.TypeLoanBrokerDelete:        {},
+	tx.TypeLoanBrokerCoverDeposit:  {},
+	tx.TypeLoanBrokerCoverWithdraw: {},
+	tx.TypeLoanBrokerCoverClawback: {},
+	tx.TypeLoanSet:                 {},
+	tx.TypeLoanDelete:              {},
+	tx.TypeLoanManage:              {},
+	tx.TypeLoanPay:                 {},
+}
 
 // NewBatch creates a new Batch transaction
 func NewBatch(account string) *Batch {
@@ -153,6 +177,10 @@ func (b *Batch) validateInnerTransactions() (map[string]struct{}, error) {
 
 		if inner.TxType() == tx.TypeBatch {
 			return nil, ErrBatchInnerIsBatch
+		}
+
+		if _, disabled := disabledInnerTxTypes[inner.TxType()]; disabled {
+			return nil, ErrBatchInnerDisabledType
 		}
 
 		innerCommon := inner.GetCommon()

--- a/internal/tx/types.go
+++ b/internal/tx/types.go
@@ -79,6 +79,16 @@ const (
 	TypeVaultClawback                = protocol.TxTypeVaultClawback
 	TypeBatch                        = protocol.TxTypeBatch
 
+	TypeLoanBrokerSet           = protocol.TxTypeLoanBrokerSet
+	TypeLoanBrokerDelete        = protocol.TxTypeLoanBrokerDelete
+	TypeLoanBrokerCoverDeposit  = protocol.TxTypeLoanBrokerCoverDeposit
+	TypeLoanBrokerCoverWithdraw = protocol.TxTypeLoanBrokerCoverWithdraw
+	TypeLoanBrokerCoverClawback = protocol.TxTypeLoanBrokerCoverClawback
+	TypeLoanSet                 = protocol.TxTypeLoanSet
+	TypeLoanDelete              = protocol.TxTypeLoanDelete
+	TypeLoanManage              = protocol.TxTypeLoanManage
+	TypeLoanPay                 = protocol.TxTypeLoanPay
+
 	TypeAmendment = protocol.TxTypeAmendment
 	TypeFee       = protocol.TxTypeFee
 	TypeUNLModify = protocol.TxTypeUNLModify

--- a/internal/tx/vault/vault_create.go
+++ b/internal/tx/vault/vault_create.go
@@ -13,7 +13,7 @@ type VaultCreate struct {
 	tx.BaseTx
 
 	// Asset is the asset the vault holds (required)
-	Asset tx.Asset `json:"Asset" xrpl:"Asset"`
+	Asset tx.Asset `json:"Asset" xrpl:"Asset,asset"`
 
 	// Data is arbitrary data (optional)
 	Data string `json:"Data,omitempty" xrpl:"Data,omitempty"`

--- a/protocol/transaction_type.go
+++ b/protocol/transaction_type.go
@@ -77,6 +77,18 @@ const (
 	TxTypeVaultClawback                TxType = 70 // ttVAULT_CLAWBACK
 	TxTypeBatch                        TxType = 71 // ttBATCH
 
+	// Lending protocol transaction types. go-xrpl registers no transactor for
+	// these yet; the codes exist so Batch can reject them as inner transactions.
+	TxTypeLoanBrokerSet           TxType = 74 // ttLOAN_BROKER_SET
+	TxTypeLoanBrokerDelete        TxType = 75 // ttLOAN_BROKER_DELETE
+	TxTypeLoanBrokerCoverDeposit  TxType = 76 // ttLOAN_BROKER_COVER_DEPOSIT
+	TxTypeLoanBrokerCoverWithdraw TxType = 77 // ttLOAN_BROKER_COVER_WITHDRAW
+	TxTypeLoanBrokerCoverClawback TxType = 78 // ttLOAN_BROKER_COVER_CLAWBACK
+	TxTypeLoanSet                 TxType = 80 // ttLOAN_SET
+	TxTypeLoanDelete              TxType = 81 // ttLOAN_DELETE
+	TxTypeLoanManage              TxType = 82 // ttLOAN_MANAGE
+	TxTypeLoanPay                 TxType = 84 // ttLOAN_PAY
+
 	// System-generated transaction types (pseudo-transactions).
 	TxTypeAmendment TxType = 100 // ttAMENDMENT
 	TxTypeFee       TxType = 101 // ttFEE
@@ -212,6 +224,24 @@ func (t TxType) String() string {
 		return "VaultClawback"
 	case TxTypeBatch:
 		return "Batch"
+	case TxTypeLoanBrokerSet:
+		return "LoanBrokerSet"
+	case TxTypeLoanBrokerDelete:
+		return "LoanBrokerDelete"
+	case TxTypeLoanBrokerCoverDeposit:
+		return "LoanBrokerCoverDeposit"
+	case TxTypeLoanBrokerCoverWithdraw:
+		return "LoanBrokerCoverWithdraw"
+	case TxTypeLoanBrokerCoverClawback:
+		return "LoanBrokerCoverClawback"
+	case TxTypeLoanSet:
+		return "LoanSet"
+	case TxTypeLoanDelete:
+		return "LoanDelete"
+	case TxTypeLoanManage:
+		return "LoanManage"
+	case TxTypeLoanPay:
+		return "LoanPay"
 	case TxTypeAmendment:
 		return "EnableAmendment"
 	case TxTypeFee:
@@ -288,6 +318,15 @@ var txTypeNameMap = map[string]TxType{
 	"VaultWithdraw":                     TxTypeVaultWithdraw,
 	"VaultClawback":                     TxTypeVaultClawback,
 	"Batch":                             TxTypeBatch,
+	"LoanBrokerSet":                     TxTypeLoanBrokerSet,
+	"LoanBrokerDelete":                  TxTypeLoanBrokerDelete,
+	"LoanBrokerCoverDeposit":            TxTypeLoanBrokerCoverDeposit,
+	"LoanBrokerCoverWithdraw":           TxTypeLoanBrokerCoverWithdraw,
+	"LoanBrokerCoverClawback":           TxTypeLoanBrokerCoverClawback,
+	"LoanSet":                           TxTypeLoanSet,
+	"LoanDelete":                        TxTypeLoanDelete,
+	"LoanManage":                        TxTypeLoanManage,
+	"LoanPay":                           TxTypeLoanPay,
 	"EnableAmendment":                   TxTypeAmendment,
 	"SetFee":                            TxTypeFee,
 	"UNLModify":                         TxTypeUNLModify,


### PR DESCRIPTION
## Summary

Ports the rippled 3.0.0 Batch inner-transaction type blocklist
([XRPLF/rippled#5270](https://github.com/XRPLF/rippled/pull/5270), commit
`138d6e751b`). rippled 3.0.0 rejects **every Vault and Loan transaction type**
as an inner transaction of a `Batch`, unconditionally at preflight, returning
`temINVALID_INNER_BATCH`.

The check is **not gated on any amendment** — a batch wrapping one of these
inner types is rejected whether or not the wrapped feature is enabled. This is
an ungated fork-risk behaviour: without it, a `Batch` carrying a Vault/Loan
inner would be classified differently than by a rippled 3.0.0 validator.

Part of #274 (re-audit comment, gap 3).

## The rippled change

`Batch::preflight` checks each inner transaction's type against the static
`Batch::disabledTxTypes` array (`Batch.h`), which contains all 6 Vault types
(`ttVAULT_CREATE`/`SET`/`DELETE`/`DEPOSIT`/`WITHDRAW`/`CLAWBACK`) and all 9 Loan
types (`ttLOAN_BROKER_SET`/`DELETE`/`COVER_DEPOSIT`/`COVER_WITHDRAW`/`COVER_CLAWBACK`,
`ttLOAN_SET`/`DELETE`/`MANAGE`/`PAY` — codes 74-78, 80-82, 84). A match returns
`temINVALID_INNER_BATCH`. The check sits **after** the inner-`Batch` rejection
(`temINVALID`) and **before** the per-inner `tfInnerBatchTxn` flag, signature,
fee, and sequence checks.

## Changes

- **`internal/tx/batch/batch.go`** — add the `disabledInnerTxTypes` blocklist
  (15 types) and enforce it in `validateInnerTransactions`, at the same
  precedence as rippled (after the inner-`Batch` check, before the flag/
  signature/fee/sequence checks). Returns `temINVALID_INNER_BATCH`.
- **`protocol/transaction_type.go`** / **`internal/tx/types.go`** — add the nine
  Loan transaction type codes (74-78, 80-82, 84) with their canonical names, so
  the blocklist can name them. No transactors are registered (these features are
  not implemented in go-xrpl); the codes exist only so `Batch` can reject them.
- **`internal/tx/vault/vault_create.go`** — fix the `Asset` field's
  serialization tag (`xrpl:"Asset"` → `xrpl:"Asset,asset"`, matching every AMM
  `Asset` field). Without it a programmatically constructed `VaultCreate` failed
  to serialize ("invalid issue object"), so a batch-wrapped `VaultCreate` failed
  the inner-hash step (`temINVALID`) before ever reaching the blocklist. This is
  a latent Vault-stub serialization bug that the blocklist path exposed.
- **Tests** (`internal/testing/batch/`) — a batch wrapping a `VaultCreate` fails
  `temINVALID_INNER_BATCH`, plus two precedence tests proving the blocklist
  fires before the inner flag check (would be `temINVALID_FLAG`) and before the
  inner zero-fee check (would be `temBAD_FEE`).

## Verification

- `just build-all` — clean.
- `just test-tx` — all green.
- `just test-integration` — the only failures are 3 pre-existing, out-of-scope
  `app/Vault` conformance tests (Vault `Apply` is a stub returning
  `tefINTERNAL`); confirmed identical on `origin/main`. `app/Vault` is listed in
  `scripts/conformance-out-of-scope.txt`.
- `golangci-lint run --config .golangci.yml` (CI config) on all changed
  packages — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)