### PR TITLE
feat(invariants): per-tx privilege bitfield + ValidPseudoAccounts + NoModifiedUnmodifiableFields

### DIFF
--- a/amendment/registry.go
+++ b/amendment/registry.go
@@ -38,6 +38,7 @@ var (
 	FeaturePermissionedDEX               = registerFeature("PermissionedDEX", SupportedYes, VoteDefaultNo)
 	FeatureBatch                         = registerFeature("Batch", SupportedYes, VoteDefaultNo)
 	FeatureSingleAssetVault              = registerFeature("SingleAssetVault", SupportedNo, VoteDefaultNo)
+	FeatureLendingProtocol               = registerFeature("LendingProtocol", SupportedNo, VoteDefaultNo)
 	FeaturePermissionDelegation          = registerFeature("PermissionDelegation", SupportedNo, VoteDefaultNo)
 	FeatureFixPayChanCancelAfter         = registerFix("fixPayChanCancelAfter", SupportedYes, VoteDefaultNo)
 	FeatureFixInvalidTxFlags             = registerFix("fixInvalidTxFlags", SupportedYes, VoteDefaultNo)

--- a/docs/amendments.md
+++ b/docs/amendments.md
@@ -7,7 +7,7 @@ XRPL amendments known to this node, generated from the amendment registry
 amendment's behavior; **Default vote** is whether the node votes for it by
 default (operators override via the `[amendments]` config section).
 
-Total: 99 amendments.
+Total: 100 amendments.
 
 | Amendment | Supported | Default vote |
 |-----------|-----------|--------------|
@@ -37,6 +37,7 @@ Total: 99 amendments.
 | `HardenedValidations` | yes | yes |
 | `ImmediateOfferKilled` | yes | no |
 | `InvariantsV1_1` | no | no |
+| `LendingProtocol` | no | no |
 | `MPTokensV1` | yes | no |
 | `MultiSign` | yes | no |
 | `MultiSignReserve` | yes | yes |

--- a/internal/ledger/state/account_root.go
+++ b/internal/ledger/state/account_root.go
@@ -64,6 +64,8 @@ type AccountRoot struct {
 	WalletLocator        string   // Arbitrary hex data (deprecated)
 	TicketCount          uint32   // Number of outstanding tickets owned by this account
 	AMMID                [32]byte // Links AMM pseudo-account to its AMM ledger entry (sfAMMID, fieldCode 14)
+	VaultID              [32]byte // Links Vault pseudo-account to its Vault ledger entry (sfVaultID, fieldCode 35)
+	LoanBrokerID         [32]byte // Links LoanBroker pseudo-account to its LoanBroker ledger entry (sfLoanBrokerID, fieldCode 37)
 	PreviousTxnID        [32]byte
 	PreviousTxnLgrSeq    uint32
 }
@@ -76,12 +78,42 @@ func (a *AccountRoot) HasAMMID() bool {
 	return a != nil && a.AMMID != [32]byte{}
 }
 
+// HasVaultID reports whether the sfVaultID pseudo-account designator is present.
+func (a *AccountRoot) HasVaultID() bool {
+	return a != nil && a.VaultID != [32]byte{}
+}
+
+// HasLoanBrokerID reports whether the sfLoanBrokerID pseudo-account designator is present.
+func (a *AccountRoot) HasLoanBrokerID() bool {
+	return a != nil && a.LoanBrokerID != [32]byte{}
+}
+
+// PseudoAccountFieldCount returns how many pseudo-account designator fields
+// (sfAMMID, sfVaultID, sfLoanBrokerID) are present. rippled's ValidPseudoAccounts
+// invariant requires exactly one to be set. Reference: rippled sfields.macro —
+// fields flagged SField::sMD_PseudoAccount.
+func (a *AccountRoot) PseudoAccountFieldCount() int {
+	if a == nil {
+		return 0
+	}
+	n := 0
+	if a.HasAMMID() {
+		n++
+	}
+	if a.HasVaultID() {
+		n++
+	}
+	if a.HasLoanBrokerID() {
+		n++
+	}
+	return n
+}
+
 // IsPseudoAccount reports whether this AccountRoot is a pseudo-account, mirroring
-// rippled's isPseudoAccount (View.cpp:1138) which tests whether any of the
-// pseudo-account owner fields (sfAMMID, sfVaultID) is present. go-xrpl currently
-// surfaces only AMMID on AccountRoot; VaultID will land alongside featureSingleAssetVault.
+// rippled's isPseudoAccount (View.cpp) which tests whether any of the
+// pseudo-account owner fields (sfAMMID, sfVaultID, sfLoanBrokerID) is present.
 func (a *AccountRoot) IsPseudoAccount() bool {
-	return a.HasAMMID()
+	return a.PseudoAccountFieldCount() > 0
 }
 
 // Field type codes (exported for use by parent tx/ package)
@@ -125,6 +157,8 @@ const (
 	fieldCodeAccountTxnID         = 9  // Hash256 - last transaction ID
 	fieldCodeWalletLocator        = 7  // Hash256 - wallet locator (deprecated)
 	fieldCodeAMMID                = 14 // Hash256 - links AMM pseudo-account to AMM entry (sfAMMID)
+	fieldCodeVaultID              = 35 // Hash256 - links Vault pseudo-account to Vault entry (sfVaultID)
+	fieldCodeLoanBrokerID         = 37 // Hash256 - links LoanBroker pseudo-account to LoanBroker entry (sfLoanBrokerID)
 )
 
 // Ledger entry type code for AccountRoot (unexported)
@@ -241,6 +275,10 @@ func ParseAccountRoot(data []byte) (*AccountRoot, error) {
 				account.WalletLocator = hex.EncodeToString(f.Value)
 			case fieldCodeAMMID:
 				account.AMMID = f.Hash256()
+			case fieldCodeVaultID:
+				account.VaultID = f.Hash256()
+			case fieldCodeLoanBrokerID:
+				account.LoanBrokerID = f.Hash256()
 			}
 
 		case stUInt8:
@@ -340,6 +378,14 @@ func SerializeAccountRoot(account *AccountRoot) ([]byte, error) {
 	// Add AMMID if set (non-zero) — links AMM pseudo-account to AMM entry
 	if account.AMMID != zeroHash {
 		jsonObj["AMMID"] = strings.ToUpper(hex.EncodeToString(account.AMMID[:]))
+	}
+
+	// Add VaultID / LoanBrokerID if set (non-zero) — pseudo-account designators
+	if account.VaultID != zeroHash {
+		jsonObj["VaultID"] = strings.ToUpper(hex.EncodeToString(account.VaultID[:]))
+	}
+	if account.LoanBrokerID != zeroHash {
+		jsonObj["LoanBrokerID"] = strings.ToUpper(hex.EncodeToString(account.LoanBrokerID[:]))
 	}
 
 	// PreviousTxnID and PreviousTxnLgrSeq are soeREQUIRED on AccountRoot, so

--- a/internal/tx/invariants/basic.go
+++ b/internal/tx/invariants/basic.go
@@ -177,34 +177,33 @@ func checkAccountRootsNotDeleted(txType string, result Result, entries []Invaria
 			deletedCount++
 		}
 	}
-	if deletedCount == 0 {
+
+	// A successful mustDeleteAcct transaction (AccountDelete/AMMDelete/
+	// VaultDelete/LoanBrokerDelete) MUST delete exactly one account root.
+	if hasPrivilegeName(txType, mustDeleteAcct) && result == TesSUCCESS {
+		if deletedCount == 1 {
+			return nil
+		}
+		if deletedCount == 0 {
+			return &InvariantViolation{
+				Name:    "AccountRootsNotDeleted",
+				Message: fmt.Sprintf("%s succeeded without deleting an account", txType),
+			}
+		}
+		return &InvariantViolation{
+			Name:    "AccountRootsNotDeleted",
+			Message: fmt.Sprintf("%s succeeded but deleted multiple accounts (count=%d)", txType, deletedCount),
+		}
+	}
+
+	// A successful mayDeleteAcct transaction (AMMWithdraw/AMMClawback) MAY delete
+	// one account root when the total AMM LP Tokens balance goes to 0.
+	if hasPrivilegeName(txType, mayDeleteAcct) && result == TesSUCCESS && deletedCount == 1 {
 		return nil
 	}
 
-	if result == TesSUCCESS {
-		// A successful AccountDelete/AMMDelete/VaultDelete MUST delete exactly
-		// one account root. VaultDelete removes the vault's pseudo-account.
-		// Reference: rippled InvariantCheck.cpp:382-385.
-		switch txType {
-		case "AccountDelete", "AMMDelete", "VaultDelete":
-			if deletedCount == 1 {
-				return nil
-			}
-			return &InvariantViolation{
-				Name:    "AccountRootsNotDeleted",
-				Message: fmt.Sprintf("%s must delete exactly 1 AccountRoot, got %d", txType, deletedCount),
-			}
-		// A successful AMMWithdraw/AMMClawback MAY delete one account root
-		// (when total AMM LP Tokens balance goes to 0).
-		case "AMMWithdraw", "AMMClawback":
-			if deletedCount <= 1 {
-				return nil
-			}
-			return &InvariantViolation{
-				Name:    "AccountRootsNotDeleted",
-				Message: fmt.Sprintf("%s may delete at most 1 AccountRoot, got %d", txType, deletedCount),
-			}
-		}
+	if deletedCount == 0 {
+		return nil
 	}
 
 	return &InvariantViolation{
@@ -302,14 +301,9 @@ func checkValidNewAccountRoot(txType string, result Result, entries []InvariantE
 		}
 	}
 
-	// Only a successful transaction of a permitted type may create an
+	// Only a successful createAcct/createPseudoAcct transaction may create an
 	// AccountRoot.
-	permitted := false
-	switch txType {
-	case "Payment", "AMMCreate", "VaultCreate", "XChainAddClaimAttestation", "XChainAddAccountCreateAttestation":
-		permitted = result == TesSUCCESS
-	}
-	if !permitted {
+	if !(hasPrivilegeName(txType, createAcct|createPseudoAcct) && result == TesSUCCESS) {
 		return &InvariantViolation{
 			Name:    "ValidNewAccountRoot",
 			Message: fmt.Sprintf("account root created illegally by %s", txType),
@@ -324,19 +318,18 @@ func checkValidNewAccountRoot(txType string, result Result, entries []InvariantE
 		}
 	}
 
-	// A pseudo-account (AMMID or VaultID set) may only be created by
-	// AMMCreate or VaultCreate. The flag is gated on featureSingleAssetVault:
-	// before that amendment, sfVaultID does not exist as a serialized field
-	// and pseudo-account semantics are not enforced.
-	if pseudo && rules != nil && rules.Enabled(amendment.FeatureSingleAssetVault) {
-		if txType != "AMMCreate" && txType != "VaultCreate" {
-			return &InvariantViolation{
-				Name:    "ValidNewAccountRoot",
-				Message: fmt.Sprintf("pseudo-account created by a wrong transaction type %s", txType),
-			}
+	// A pseudo-account may only be created by a createPseudoAcct transaction.
+	// The pseudo-account semantics are gated on featureSingleAssetVault or
+	// featureLendingProtocol: before either amendment, the pseudo-account
+	// designator fields never appear and the checks do not run.
+	pseudo = pseudo && rules != nil &&
+		(rules.Enabled(amendment.FeatureSingleAssetVault) ||
+			rules.Enabled(amendment.FeatureLendingProtocol))
+	if pseudo && !hasPrivilegeName(txType, createPseudoAcct) {
+		return &InvariantViolation{
+			Name:    "ValidNewAccountRoot",
+			Message: fmt.Sprintf("pseudo-account created by a wrong transaction type %s", txType),
 		}
-	} else {
-		pseudo = false
 	}
 
 	var startingSeq uint32
@@ -394,8 +387,8 @@ func extractNewAccountRootFields(data []byte) (seq, flags uint32, pseudo, ok boo
 				seq = value
 				seqSeen = true
 			}
-		case 5: // Hash256 — sfAMMID (14) or sfVaultID (35) marks a pseudo-account
-			if f.FieldCode == 14 || f.FieldCode == 35 {
+		case 5: // Hash256 — sfAMMID (14), sfVaultID (35) or sfLoanBrokerID (37) marks a pseudo-account
+			if f.FieldCode == 14 || f.FieldCode == 35 || f.FieldCode == 37 {
 				for _, b := range f.Value {
 					if b != 0 {
 						pseudo = true

--- a/internal/tx/invariants/frozen.go
+++ b/internal/tx/invariants/frozen.go
@@ -388,10 +388,11 @@ func validateFrozenState(
 		return nil
 	}
 
-	// AMMClawback exception: if the trust line is NOT an AMM line, or if
-	// there's a global freeze, and the transaction is AMMClawback, allow it.
+	// overrideFreeze exception (AMMClawback): if the trust line is NOT an AMM
+	// line, or if there's a global freeze, an overrideFreeze transaction may
+	// move the funds.
 	// Reference: rippled lines 904-911
-	if (!isAMMLine || globalFreeze) && tx.TxType() == TypeAMMClawback {
+	if (!isAMMLine || globalFreeze) && hasPrivilege(tx.TxType(), overrideFreeze) {
 		return nil
 	}
 

--- a/internal/tx/invariants/invariants.go
+++ b/internal/tx/invariants/invariants.go
@@ -212,6 +212,12 @@ func CheckInvariants(tx Transaction, result Result, fee uint64, txDeclaredFee ui
 		func() *InvariantViolation {
 			return checkValidAMM(tx, result, entries, view, rules)
 		},
+		func() *InvariantViolation {
+			return checkValidPseudoAccounts(entries, rules)
+		},
+		func() *InvariantViolation {
+			return checkNoModifiedUnmodifiableFields(entries, rules)
+		},
 	}
 	for _, check := range checks {
 		if v := check(); v != nil {

--- a/internal/tx/invariants/mpt.go
+++ b/internal/tx/invariants/mpt.go
@@ -41,9 +41,9 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 	txType := tx.TxType()
 
 	if result == TesSUCCESS {
-		switch txType {
-		case TypeMPTokenIssuanceCreate, TypeVaultCreate:
-			// Must create exactly 1 issuance, delete 0.
+		// A createMPTIssuance transaction (MPTokenIssuanceCreate/VaultCreate)
+		// must create exactly 1 issuance and delete 0.
+		if hasPrivilege(txType, createMPTIssuance) {
 			if mptIssuancesCreated != 1 || mptIssuancesDeleted != 0 {
 				return &InvariantViolation{
 					Name:    "ValidMPTIssuance",
@@ -51,9 +51,11 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 				}
 			}
 			return nil
+		}
 
-		case TypeMPTokenIssuanceDestroy, TypeVaultDelete:
-			// Must delete exactly 1 issuance, create 0.
+		// A destroyMPTIssuance transaction (MPTokenIssuanceDestroy/VaultDelete)
+		// must delete exactly 1 issuance and create 0.
+		if hasPrivilege(txType, destroyMPTIssuance) {
 			if mptIssuancesCreated != 0 || mptIssuancesDeleted != 1 {
 				return &InvariantViolation{
 					Name:    "ValidMPTIssuance",
@@ -61,7 +63,9 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 				}
 			}
 			return nil
+		}
 
+		switch txType {
 		case TypeMPTokenAuthorize, TypeVaultDeposit:
 			// No issuance changes allowed.
 			if mptIssuancesCreated > 0 {

--- a/internal/tx/invariants/nftoken.go
+++ b/internal/tx/invariants/nftoken.go
@@ -126,8 +126,9 @@ func checkNFTokenCountTracking(txType string, result Result, entries []Invariant
 		}
 	}
 
-	// For non-mint/burn transactions, counts must not change.
-	if txType != "NFTokenMint" && txType != "NFTokenBurn" {
+	// Only a changeNFTCounts transaction (NFTokenMint/NFTokenBurn) may change
+	// the minted/burned counts.
+	if !hasPrivilegeName(txType, changeNFTCounts) {
 		if beforeMintedTotal != afterMintedTotal {
 			return &InvariantViolation{
 				Name:    "NFTokenCountTracking",

--- a/internal/tx/invariants/privileges.go
+++ b/internal/tx/invariants/privileges.go
@@ -1,0 +1,81 @@
+package invariants
+
+// privileges.go — per-transaction privilege bitfield.
+//
+// Each transaction type declares which privileged operations it is permitted to
+// perform. Invariant checks consult hasPrivilege instead of hardcoding
+// transaction-type lists, mirroring rippled's Privilege enum and the privileges
+// column of transactions.macro (tag 3.0.0). A transaction type absent from the
+// table carries noPriv, matching rippled's `default: return false` in
+// hasPrivilege (InvariantCheck.cpp).
+
+import "github.com/LeJamon/go-xrpl/protocol"
+
+// Privilege is a bitfield of operations a transaction type may perform.
+type Privilege uint16
+
+const (
+	noPriv             Privilege = 0x0000 // may perform none of the enumerated operations
+	createAcct         Privilege = 0x0001 // may create a new AccountRoot
+	createPseudoAcct   Privilege = 0x0002 // may create a pseudo-account (implies createAcct)
+	mustDeleteAcct     Privilege = 0x0004 // must delete an AccountRoot
+	mayDeleteAcct      Privilege = 0x0008 // may delete an AccountRoot
+	overrideFreeze     Privilege = 0x0010 // may override some freeze rules
+	changeNFTCounts    Privilege = 0x0020 // may mint or burn an NFT
+	createMPTIssuance  Privilege = 0x0040 // may create a new MPT issuance
+	destroyMPTIssuance Privilege = 0x0080 // may destroy an MPT issuance
+	mustAuthorizeMPT   Privilege = 0x0100 // must create or delete an MPToken (except by issuer)
+	mayAuthorizeMPT    Privilege = 0x0200 // may create or delete an MPToken (except by issuer)
+	mayDeleteMPT       Privilege = 0x0400 // may delete (not create) an MPToken
+	mustModifyVault    Privilege = 0x0800 // must modify, delete, or create a vault
+	mayModifyVault     Privilege = 0x1000 // may modify, delete, or create a vault
+)
+
+// txPrivileges maps each transaction type to its declared privilege bitfield,
+// transcribed from rippled's transactions.macro at tag 3.0.0. Transaction types
+// with noPriv are omitted (the zero value); hasPrivilege treats them, and any
+// deprecated/pseudo type, as privilege-less. The Loan* types (74-84) are keyed
+// by numeric tt code because go-xrpl does not yet name them (tracked in #1245).
+var txPrivileges = map[TxType]Privilege{
+	protocol.TxTypePayment:                      createAcct,
+	protocol.TxTypeAccountDelete:                mustDeleteAcct,
+	protocol.TxTypeNFTokenMint:                  changeNFTCounts,
+	protocol.TxTypeNFTokenBurn:                  changeNFTCounts,
+	protocol.TxTypeAMMClawback:                  mayDeleteAcct | overrideFreeze,
+	protocol.TxTypeAMMCreate:                    createPseudoAcct,
+	protocol.TxTypeAMMWithdraw:                  mayDeleteAcct,
+	protocol.TxTypeAMMDelete:                    mustDeleteAcct,
+	protocol.TxTypeXChainAddClaimAttestation:    createAcct,
+	protocol.TxTypeXChainAddAccountCreateAttest: createAcct,
+	protocol.TxTypeMPTokenIssuanceCreate:        createMPTIssuance,
+	protocol.TxTypeMPTokenIssuanceDestroy:       destroyMPTIssuance,
+	protocol.TxTypeMPTokenAuthorize:             mustAuthorizeMPT,
+	protocol.TxTypeVaultCreate:                  createPseudoAcct | createMPTIssuance | mustModifyVault,
+	protocol.TxTypeVaultSet:                     mustModifyVault,
+	protocol.TxTypeVaultDelete:                  mustDeleteAcct | destroyMPTIssuance | mustModifyVault,
+	protocol.TxTypeVaultDeposit:                 mayAuthorizeMPT | mustModifyVault,
+	protocol.TxTypeVaultWithdraw:                mayDeleteMPT | mayAuthorizeMPT | mustModifyVault,
+	protocol.TxTypeVaultClawback:                mayDeleteMPT | mustModifyVault,
+	TxType(74):                                  createPseudoAcct | mayAuthorizeMPT, // ttLOAN_BROKER_SET
+	TxType(75):                                  mustDeleteAcct | mayAuthorizeMPT,   // ttLOAN_BROKER_DELETE
+	TxType(77):                                  mayAuthorizeMPT,                    // ttLOAN_BROKER_COVER_WITHDRAW
+	TxType(80):                                  mayAuthorizeMPT | mustModifyVault,  // ttLOAN_SET
+	TxType(82):                                  mayModifyVault,                     // ttLOAN_MANAGE
+	TxType(84):                                  mayAuthorizeMPT | mustModifyVault,  // ttLOAN_PAY
+}
+
+// hasPrivilege reports whether the given transaction type holds priv.
+func hasPrivilege(txType TxType, priv Privilege) bool {
+	return txPrivileges[txType]&priv != 0
+}
+
+// hasPrivilegeName resolves a transaction type by its canonical name (as
+// produced by TxType.String()) and reports whether it holds priv. An unknown
+// name carries no privileges, matching rippled's hasPrivilege default.
+func hasPrivilegeName(name string, priv Privilege) bool {
+	t, ok := protocol.TxTypeFromName(name)
+	if !ok {
+		return false
+	}
+	return hasPrivilege(t, priv)
+}

--- a/internal/tx/invariants/privileges_test.go
+++ b/internal/tx/invariants/privileges_test.go
@@ -1,0 +1,63 @@
+package invariants
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/protocol"
+)
+
+// TestPrivilegeTable pins the transcription of transactions.macro's privileges
+// column (rippled tag 3.0.0). If a mapping drifts, the invariant checks that
+// consult hasPrivilege silently change behaviour, so lock the key entries down.
+func TestPrivilegeTable(t *testing.T) {
+	cases := []struct {
+		txType TxType
+		priv   Privilege
+	}{
+		{protocol.TxTypePayment, createAcct},
+		{protocol.TxTypeAccountDelete, mustDeleteAcct},
+		{protocol.TxTypeNFTokenMint, changeNFTCounts},
+		{protocol.TxTypeNFTokenBurn, changeNFTCounts},
+		{protocol.TxTypeAMMClawback, mayDeleteAcct | overrideFreeze},
+		{protocol.TxTypeAMMCreate, createPseudoAcct},
+		{protocol.TxTypeAMMWithdraw, mayDeleteAcct},
+		{protocol.TxTypeAMMDelete, mustDeleteAcct},
+		{protocol.TxTypeXChainAddClaimAttestation, createAcct},
+		{protocol.TxTypeXChainAddAccountCreateAttest, createAcct},
+		{protocol.TxTypeMPTokenIssuanceCreate, createMPTIssuance},
+		{protocol.TxTypeMPTokenIssuanceDestroy, destroyMPTIssuance},
+		{protocol.TxTypeMPTokenAuthorize, mustAuthorizeMPT},
+		{protocol.TxTypeVaultCreate, createPseudoAcct | createMPTIssuance | mustModifyVault},
+		{protocol.TxTypeVaultDelete, mustDeleteAcct | destroyMPTIssuance | mustModifyVault},
+		{protocol.TxTypeVaultDeposit, mayAuthorizeMPT | mustModifyVault},
+		{protocol.TxTypeVaultWithdraw, mayDeleteMPT | mayAuthorizeMPT | mustModifyVault},
+		{TxType(74), createPseudoAcct | mayAuthorizeMPT}, // ttLOAN_BROKER_SET
+		{TxType(75), mustDeleteAcct | mayAuthorizeMPT},   // ttLOAN_BROKER_DELETE
+	}
+	for _, c := range cases {
+		if got := txPrivileges[c.txType]; got != c.priv {
+			t.Errorf("txPrivileges[%d] = 0x%04x, want 0x%04x", c.txType, got, c.priv)
+		}
+		// Every set bit must be individually reported by hasPrivilege.
+		for bit := Privilege(1); bit != 0; bit <<= 1 {
+			if c.priv&bit != 0 && !hasPrivilege(c.txType, bit) {
+				t.Errorf("hasPrivilege(%d, 0x%04x) = false, want true", c.txType, bit)
+			}
+		}
+	}
+
+	// Transaction types with no declared privileges must report none.
+	for _, tt := range []TxType{
+		protocol.TxTypeOfferCreate,
+		protocol.TxTypeTrustSet,
+		protocol.TxTypeBatch,
+		protocol.TxTypeEscrowFinish,
+	} {
+		if txPrivileges[tt] != noPriv {
+			t.Errorf("txPrivileges[%d] = 0x%04x, want noPriv", tt, txPrivileges[tt])
+		}
+		if hasPrivilege(tt, mustDeleteAcct|createAcct|changeNFTCounts) {
+			t.Errorf("hasPrivilege(%d, ...) unexpectedly true", tt)
+		}
+	}
+}

--- a/internal/tx/invariants/pseudo_accounts.go
+++ b/internal/tx/invariants/pseudo_accounts.go
@@ -1,0 +1,94 @@
+package invariants
+
+import (
+	"fmt"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+)
+
+// ---------------------------------------------------------------------------
+// ValidPseudoAccounts
+// ---------------------------------------------------------------------------
+//
+// Reference: rippled InvariantCheck.cpp — ValidPseudoAccounts
+//
+// Pseudo-accounts (AMM, Vault, LoanBroker) have unique, consistent properties.
+// An AccountRoot is treated as a pseudo-account if it carries any designator
+// field (sfAMMID / sfVaultID / sfLoanBrokerID) OR has a zero Sequence — not all
+// pseudo-accounts have a zero sequence, but any account with a zero sequence had
+// better be a pseudo-account. Such an account must:
+//   1. Have exactly one designator field set.
+//   2. Not change its Sequence when modified.
+//   3. Have lsfDisableMaster, lsfDefaultRipple and lsfDepositAuth all set.
+//   4. Have no RegularKey.
+//
+// Enforcement is gated on featureSingleAssetVault; while disabled the check is
+// detection-only and never fails a transaction, matching rippled.
+
+func checkValidPseudoAccounts(entries []InvariantEntry, rules *amendment.Rules) *InvariantViolation {
+	if rules == nil || !rules.Enabled(amendment.FeatureSingleAssetVault) {
+		return nil
+	}
+
+	for _, e := range entries {
+		// Creation and modification are inspected; deletion is ignored.
+		if e.IsDelete || e.EntryType != "AccountRoot" || e.After == nil {
+			continue
+		}
+
+		after, err := state.ParseAccountRoot(e.After)
+		if err != nil {
+			return &InvariantViolation{
+				Name:    "ValidPseudoAccounts",
+				Message: fmt.Sprintf("could not parse AccountRoot SLE: %v", err),
+			}
+		}
+
+		if !after.IsPseudoAccount() && after.Sequence != 0 {
+			continue
+		}
+
+		if v := validatePseudoAccount(e.Before, after); v != nil {
+			return v
+		}
+	}
+	return nil
+}
+
+// validatePseudoAccount enforces the four pseudo-account invariants against a
+// modified/created AccountRoot. before is the prior image (nil on creation).
+func validatePseudoAccount(before []byte, after *state.AccountRoot) *InvariantViolation {
+	if n := after.PseudoAccountFieldCount(); n != 1 {
+		return &InvariantViolation{
+			Name:    "ValidPseudoAccounts",
+			Message: fmt.Sprintf("pseudo-account has %d pseudo-account fields set", n),
+		}
+	}
+
+	if before != nil {
+		if prev, err := state.ParseAccountRoot(before); err == nil && prev.Sequence != after.Sequence {
+			return &InvariantViolation{
+				Name:    "ValidPseudoAccounts",
+				Message: "pseudo-account sequence changed",
+			}
+		}
+	}
+
+	const expectedFlags = LsfDisableMaster | LsfDefaultRipple | LsfDepositAuth
+	if after.Flags&expectedFlags != expectedFlags {
+		return &InvariantViolation{
+			Name:    "ValidPseudoAccounts",
+			Message: "pseudo-account flags are not set",
+		}
+	}
+
+	if after.RegularKey != "" {
+		return &InvariantViolation{
+			Name:    "ValidPseudoAccounts",
+			Message: "pseudo-account has a regular key",
+		}
+	}
+
+	return nil
+}

--- a/internal/tx/invariants/pseudo_accounts_test.go
+++ b/internal/tx/invariants/pseudo_accounts_test.go
@@ -1,0 +1,143 @@
+package invariants
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+)
+
+const testPseudoAddr = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+
+// validPseudoAccount returns an AccountRoot that satisfies every
+// ValidPseudoAccounts rule: exactly one designator (VaultID), zero sequence and
+// the canonical pseudo-account flag mask.
+func validPseudoAccount() *state.AccountRoot {
+	return &state.AccountRoot{
+		Account:  testPseudoAddr,
+		Balance:  0,
+		Sequence: 0,
+		Flags:    LsfDisableMaster | LsfDefaultRipple | LsfDepositAuth,
+		VaultID:  [32]byte{1},
+	}
+}
+
+func rulesWithSingleAssetVaultOnly() *amendment.Rules {
+	return amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+}
+
+// TestValidPseudoAccounts_Valid: a well-formed pseudo-account (created or
+// modified) trips no invariant.
+func TestValidPseudoAccounts_Valid(t *testing.T) {
+	rules := rulesWithSingleAssetVaultOnly()
+	after := mustSerializeAccount(t, validPseudoAccount())
+
+	// Creation.
+	if v := checkValidPseudoAccounts([]InvariantEntry{{EntryType: "AccountRoot", After: after}}, rules); v != nil {
+		t.Fatalf("valid pseudo-account creation: unexpected violation %v", v)
+	}
+	// Idempotent modification (before == after).
+	if v := checkValidPseudoAccounts([]InvariantEntry{{EntryType: "AccountRoot", Before: after, After: after}}, rules); v != nil {
+		t.Fatalf("valid pseudo-account modification: unexpected violation %v", v)
+	}
+}
+
+// TestValidPseudoAccounts_Violations ports the mutation cases from rippled's
+// testValidPseudoAccounts (Invariants_test.cpp:1560-1640).
+func TestValidPseudoAccounts_Violations(t *testing.T) {
+	rules := rulesWithSingleAssetVaultOnly()
+	before := mustSerializeAccount(t, validPseudoAccount())
+
+	cases := []struct {
+		name    string
+		mutate  func(a *state.AccountRoot)
+		wantMsg string
+	}{
+		{
+			name:    "zero designator fields",
+			mutate:  func(a *state.AccountRoot) { a.VaultID = [32]byte{} }, // Sequence stays 0 → still looks pseudo
+			wantMsg: "0 pseudo-account fields set",
+		},
+		{
+			name:    "two designator fields",
+			mutate:  func(a *state.AccountRoot) { a.AMMID = [32]byte{2} },
+			wantMsg: "2 pseudo-account fields set",
+		},
+		{
+			name:    "sequence changed",
+			mutate:  func(a *state.AccountRoot) { a.Sequence = 12345 },
+			wantMsg: "sequence changed",
+		},
+		{
+			name:    "flags not set",
+			mutate:  func(a *state.AccountRoot) { a.Flags = LsfDisableMaster }, // missing DefaultRipple|DepositAuth
+			wantMsg: "flags are not set",
+		},
+		{
+			name:    "regular key present",
+			mutate:  func(a *state.AccountRoot) { a.RegularKey = testPseudoAddr },
+			wantMsg: "has a regular key",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			acct := validPseudoAccount()
+			tc.mutate(acct)
+			after := mustSerializeAccount(t, acct)
+			v := checkValidPseudoAccounts([]InvariantEntry{{EntryType: "AccountRoot", Before: before, After: after}}, rules)
+			if v == nil {
+				t.Fatalf("%s: expected violation", tc.name)
+			}
+			if !strings.Contains(v.Message, tc.wantMsg) {
+				t.Fatalf("%s: message %q does not contain %q", tc.name, v.Message, tc.wantMsg)
+			}
+		})
+	}
+}
+
+// TestValidPseudoAccounts_ZeroSequenceRegularAccount: a plain account whose
+// Sequence is set to 0 looks like a pseudo-account and must trip the check
+// (0 designator fields). Reference: Invariants_test.cpp:1627-1640.
+func TestValidPseudoAccounts_ZeroSequenceRegularAccount(t *testing.T) {
+	rules := rulesWithSingleAssetVaultOnly()
+	before := mustSerializeAccount(t, &state.AccountRoot{Account: testPseudoAddr, Balance: 1_000_000, Sequence: 7})
+	after := mustSerializeAccount(t, &state.AccountRoot{Account: testPseudoAddr, Balance: 1_000_000, Sequence: 0})
+	v := checkValidPseudoAccounts([]InvariantEntry{{EntryType: "AccountRoot", Before: before, After: after}}, rules)
+	if v == nil {
+		t.Fatal("expected violation for zero-sequence non-pseudo account")
+	}
+	if !strings.Contains(v.Message, "0 pseudo-account fields set") {
+		t.Fatalf("unexpected message %q", v.Message)
+	}
+}
+
+// TestValidPseudoAccounts_Gating: while featureSingleAssetVault is disabled the
+// check is detection-only and never fails a transaction.
+func TestValidPseudoAccounts_Gating(t *testing.T) {
+	before := mustSerializeAccount(t, validPseudoAccount())
+	broken := validPseudoAccount()
+	broken.VaultID = [32]byte{} // 0 designator fields, still zero-sequence
+	after := mustSerializeAccount(t, broken)
+
+	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: before, After: after}}
+
+	if v := checkValidPseudoAccounts(entries, amendment.NewRules(nil)); v != nil {
+		t.Fatalf("disabled amendment: unexpected violation %v", v)
+	}
+	if v := checkValidPseudoAccounts(entries, rulesWithSingleAssetVaultOnly()); v == nil {
+		t.Fatal("enabled amendment: expected violation")
+	}
+}
+
+// TestValidPseudoAccounts_IgnoresDeletion: deletions are not inspected.
+func TestValidPseudoAccounts_IgnoresDeletion(t *testing.T) {
+	broken := validPseudoAccount()
+	broken.VaultID = [32]byte{}
+	before := mustSerializeAccount(t, broken)
+	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: before, IsDelete: true}}
+	if v := checkValidPseudoAccounts(entries, rulesWithSingleAssetVaultOnly()); v != nil {
+		t.Fatalf("deletion: unexpected violation %v", v)
+	}
+}

--- a/internal/tx/invariants/unmodifiable.go
+++ b/internal/tx/invariants/unmodifiable.go
@@ -1,0 +1,76 @@
+package invariants
+
+import (
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+)
+
+// ---------------------------------------------------------------------------
+// NoModifiedUnmodifiableFields
+// ---------------------------------------------------------------------------
+//
+// Reference: rippled InvariantCheck.cpp — NoModifiedUnmodifiableFields
+//
+// Fields declared unmodifiable must not change when an existing object is
+// modified. Creation and deletion are ignored. Every ledger entry type shares
+// the default rule that sfLedgerEntryType and sfLedgerIndex are immutable;
+// Loan and LoanBroker entries additionally pin their structural fields, but
+// those entry types are not yet implemented (tracked in #1245) so only the
+// default rule can be exercised here.
+//
+// Enforcement is gated on featureLendingProtocol (the amendment under which the
+// check was introduced, even though it guards all entry types); while disabled
+// the check never fails a transaction, matching rippled.
+
+// sfLedgerIndex is a Hash256 field (code 6) that is not normally stored in an
+// SLE — its ledger key is the index. rippled still treats it as unmodifiable.
+const fieldCodeLedgerIndex = 6
+
+func checkNoModifiedUnmodifiableFields(entries []InvariantEntry, rules *amendment.Rules) *InvariantViolation {
+	if rules == nil || !rules.Enabled(amendment.FeatureLendingProtocol) {
+		return nil
+	}
+
+	for _, e := range entries {
+		// Only modifications are checked (before and after both present).
+		if e.IsDelete || e.Before == nil || e.After == nil {
+			continue
+		}
+
+		if state.EntryTypeCode(e.Before) != state.EntryTypeCode(e.After) ||
+			ledgerIndexChanged(e.Before, e.After) {
+			return &InvariantViolation{
+				Name:    "NoModifiedUnmodifiableFields",
+				Message: "changed an unmodifiable field",
+			}
+		}
+	}
+	return nil
+}
+
+// ledgerIndexChanged reports whether the sfLedgerIndex field appears, disappears,
+// or changes value between the two images, mirroring rippled's fieldChanged.
+func ledgerIndexChanged(before, after []byte) bool {
+	bPresent, bVal := findHash256Field(before, fieldCodeLedgerIndex)
+	aPresent, aVal := findHash256Field(after, fieldCodeLedgerIndex)
+	if bPresent != aPresent {
+		return true
+	}
+	return aPresent && bVal != aVal
+}
+
+// findHash256Field returns whether a Hash256 field with the given field code is
+// present in the serialized SLE and, if so, its value.
+func findHash256Field(data []byte, fieldCode int) (bool, [32]byte) {
+	var found bool
+	var val [32]byte
+	_ = state.WalkFields(data, func(f state.Field) error {
+		if f.TypeCode == state.FieldTypeHash256 && f.FieldCode == fieldCode {
+			found = true
+			val = f.Hash256()
+			return errStopWalk
+		}
+		return nil
+	})
+	return found, val
+}

--- a/internal/tx/invariants/unmodifiable_test.go
+++ b/internal/tx/invariants/unmodifiable_test.go
@@ -1,0 +1,108 @@
+package invariants
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+)
+
+func rulesWithLendingProtocol() *amendment.Rules {
+	return amendment.NewRules([][32]byte{amendment.FeatureLendingProtocol})
+}
+
+func encodeSLE(t *testing.T, m map[string]any) []byte {
+	t.Helper()
+	h, err := binarycodec.Encode(m)
+	if err != nil {
+		t.Fatalf("binarycodec.Encode: %v", err)
+	}
+	b, err := hex.DecodeString(h)
+	if err != nil {
+		t.Fatalf("hex.DecodeString: %v", err)
+	}
+	return b
+}
+
+func accountRootMap() map[string]any {
+	return map[string]any{
+		"LedgerEntryType":   "AccountRoot",
+		"Account":           testPseudoAddr,
+		"Balance":           "1000000",
+		"Sequence":          uint32(1),
+		"OwnerCount":        uint32(0),
+		"Flags":             uint32(0),
+		"PreviousTxnID":     strings.Repeat("0", 64),
+		"PreviousTxnLgrSeq": uint32(0),
+	}
+}
+
+// TestNoModifiedUnmodifiableFields_LedgerEntryType: changing the ledger entry
+// type of a modified object trips the invariant.
+// Reference: rippled Invariants_test.cpp:1902-1924.
+func TestNoModifiedUnmodifiableFields_LedgerEntryType(t *testing.T) {
+	before := mustSerializeAccount(t, &state.AccountRoot{Account: testPseudoAddr, Balance: 1_000_000, Sequence: 1})
+	// LedgerEntryType is always the first serialized field: header 0x11 followed
+	// by the 2-byte big-endian type code. Bump the low byte to forge a change.
+	after := append([]byte(nil), before...)
+	after[2]++
+
+	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: before, After: after}}
+	if v := checkNoModifiedUnmodifiableFields(entries, rulesWithLendingProtocol()); v == nil {
+		t.Fatal("expected violation for changed LedgerEntryType")
+	}
+}
+
+// TestNoModifiedUnmodifiableFields_LedgerIndex: adding an sfLedgerIndex field on
+// modification trips the invariant.
+// Reference: rippled Invariants_test.cpp:1905-1908.
+func TestNoModifiedUnmodifiableFields_LedgerIndex(t *testing.T) {
+	before := encodeSLE(t, accountRootMap())
+	afterMap := accountRootMap()
+	afterMap["LedgerIndex"] = strings.Repeat("0", 63) + "1"
+	after := encodeSLE(t, afterMap)
+
+	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: before, After: after}}
+	if v := checkNoModifiedUnmodifiableFields(entries, rulesWithLendingProtocol()); v == nil {
+		t.Fatal("expected violation for added LedgerIndex")
+	}
+}
+
+// TestNoModifiedUnmodifiableFields_NoChange: a modification that leaves the
+// entry type and index untouched is fine.
+func TestNoModifiedUnmodifiableFields_NoChange(t *testing.T) {
+	before := mustSerializeAccount(t, &state.AccountRoot{Account: testPseudoAddr, Balance: 1_000_000, Sequence: 1})
+	after := mustSerializeAccount(t, &state.AccountRoot{Account: testPseudoAddr, Balance: 999_990, Sequence: 2})
+	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: before, After: after}}
+	if v := checkNoModifiedUnmodifiableFields(entries, rulesWithLendingProtocol()); v != nil {
+		t.Fatalf("unexpected violation for ordinary modification: %v", v)
+	}
+}
+
+// TestNoModifiedUnmodifiableFields_IgnoresCreateDelete: creation and deletion
+// are not inspected.
+func TestNoModifiedUnmodifiableFields_IgnoresCreateDelete(t *testing.T) {
+	acct := mustSerializeAccount(t, &state.AccountRoot{Account: testPseudoAddr, Balance: 1_000_000, Sequence: 1})
+	rules := rulesWithLendingProtocol()
+	if v := checkNoModifiedUnmodifiableFields([]InvariantEntry{{EntryType: "AccountRoot", After: acct}}, rules); v != nil {
+		t.Fatalf("creation: unexpected violation %v", v)
+	}
+	if v := checkNoModifiedUnmodifiableFields([]InvariantEntry{{EntryType: "AccountRoot", Before: acct, IsDelete: true}}, rules); v != nil {
+		t.Fatalf("deletion: unexpected violation %v", v)
+	}
+}
+
+// TestNoModifiedUnmodifiableFields_Gating: while featureLendingProtocol is
+// disabled the check never fails a transaction.
+func TestNoModifiedUnmodifiableFields_Gating(t *testing.T) {
+	before := mustSerializeAccount(t, &state.AccountRoot{Account: testPseudoAddr, Balance: 1_000_000, Sequence: 1})
+	after := append([]byte(nil), before...)
+	after[2]++
+	entries := []InvariantEntry{{EntryType: "AccountRoot", Before: before, After: after}}
+	if v := checkNoModifiedUnmodifiableFields(entries, amendment.NewRules(nil)); v != nil {
+		t.Fatalf("disabled amendment: unexpected violation %v", v)
+	}
+}


### PR DESCRIPTION
## Summary

Ports rippled 3.0.0's invariant-system overhaul (gap 2 of the #274 re-audit). rippled restructured invariants around a per-transaction `Privilege` bitfield: every transaction type declares its privileges in `transactions.macro`, and the existing invariants enforce via `hasPrivilege()` instead of hardcoded transaction-type lists. This PR mirrors that in go-xrpl and adds the two new checks that run against objects **already present on mainnet** (AMM pseudo-accounts).

Rippled reference: [#5518](https://github.com/XRPLF/rippled/pull/5518), [#5270](https://github.com/XRPLF/rippled/pull/5270), [#5590](https://github.com/XRPLF/rippled/pull/5590). Tests ported from `src/test/app/Invariants_test.cpp` (`testValidPseudoAccounts`, `testNoModifiedUnmodifiableFields`).

## What changed

**Privilege bitfield** (`internal/tx/invariants/privileges.go`)
- `Privilege` enum + `txPrivileges` map keyed by `TxType`, transcribed 1:1 from `transactions.macro` at tag 3.0.0 (including the Loan/Vault types by tt code).
- `hasPrivilege(TxType, Privilege)` / `hasPrivilegeName(string, Privilege)`; types absent from the table carry `noPriv`, matching rippled's `default: return false`.

**Refactored dispatch** (behaviour-preserving — the privilege sets map exactly onto the existing registered-type lists):
- `AccountRootsNotDeleted` → `mustDeleteAcct` / `mayDeleteAcct` (also fixes the pre-existing `deletedCount==0` short-circuit so a `mustDeleteAcct` tx that deletes nothing now fails, matching rippled).
- `ValidNewAccountRoot` → `createAcct | createPseudoAcct`, pseudo guard → `createPseudoAcct`.
- `NFTokenCountTracking` → `changeNFTCounts`.
- `TransfersNotFrozen` → `overrideFreeze`.
- `ValidMPTIssuance` → `createMPTIssuance` / `destroyMPTIssuance` (create/destroy only; the authorize/set paths are left untouched to avoid changing behaviour for unimplemented Vault types).

**Two new checks** (wired into `CheckInvariants`)
- `ValidPseudoAccounts` (`pseudo_accounts.go`): a pseudo-account AccountRoot (any of sfAMMID/sfVaultID/sfLoanBrokerID set, or Sequence 0) must have exactly one designator field, an unchanged sequence, all of `lsfDisableMaster | lsfDefaultRipple | lsfDepositAuth`, and no RegularKey. Enforced under `featureSingleAssetVault`; detection-only while disabled.
- `NoModifiedUnmodifiableFields` (`unmodifiable.go`): `sfLedgerEntryType` and `sfLedgerIndex` are immutable on modification. Enforced under `featureLendingProtocol`; detection-only while disabled.

**Supporting changes**
- `state.AccountRoot`: added `VaultID` / `LoanBrokerID` pseudo-account designators (parse + serialize, gated non-zero) and `PseudoAccountFieldCount()`; `IsPseudoAccount()` now considers all three.
- Registered the `LendingProtocol` amendment (`SupportedNo`, `VoteDefaultNo`), matching `features.macro` — required as the enforcement gate for `NoModifiedUnmodifiableFields`.

## Deferred

`ValidLoanBroker`, `ValidLoan`, `ValidVault` and the Loan/LoanBroker-specific unmodifiable-field lists need the Lending/Vault ledger objects — tracked in **#1245**. Their transaction types are still present in the privilege table (by tt code) so the dispatch is complete when they land.

## Testing

- New unit tests: `privileges_test.go` (pins the transcription), `pseudo_accounts_test.go` (5 mutation cases + gating + zero-sequence + deletion), `unmodifiable_test.go` (type/index change + gating + create/delete ignore).
- `just build-all` and strict `golangci-lint run --config .golangci.yml ./...` clean.
- Full conformance suite unchanged vs. baseline: exactly the 182 pre-existing failures (Vault 138, Batch 25, XChain 14, XChainSim 1, Delegate 4) — **no new failures, no regressions**. The new checks are gated on currently-disabled amendments, so they are inert in the conformance run.

Part of #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)