### PR TITLE
feat(sign): counterparty-signature machinery (sfCounterpartySignature)

### DIFF
--- a/internal/rpc/handlers/sign.go
+++ b/internal/rpc/handlers/sign.go
@@ -13,14 +13,15 @@ type SignMethod struct{}
 
 func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	var request struct {
-		TxJson     json.RawMessage `json:"tx_json"`
-		Secret     string          `json:"secret,omitempty"`
-		Seed       string          `json:"seed,omitempty"`
-		SeedHex    string          `json:"seed_hex,omitempty"`
-		Passphrase string          `json:"passphrase,omitempty"`
-		KeyType    string          `json:"key_type,omitempty"`
-		Offline    bool            `json:"offline,omitempty"`
-		BuildPath  bool            `json:"build_path,omitempty"`
+		TxJson          json.RawMessage `json:"tx_json"`
+		Secret          string          `json:"secret,omitempty"`
+		Seed            string          `json:"seed,omitempty"`
+		SeedHex         string          `json:"seed_hex,omitempty"`
+		Passphrase      string          `json:"passphrase,omitempty"`
+		KeyType         string          `json:"key_type,omitempty"`
+		Offline         bool            `json:"offline,omitempty"`
+		BuildPath       bool            `json:"build_path,omitempty"`
+		SignatureTarget string          `json:"signature_target,omitempty"`
 	}
 
 	if params != nil {
@@ -40,7 +41,7 @@ func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any,
 		SeedHex:    request.SeedHex,
 		Passphrase: request.Passphrase,
 		KeyType:    request.KeyType,
-	}, request.Offline, ctx.Unlimited, ctx.ApiVersion, params)
+	}, request.Offline, ctx.Unlimited, ctx.ApiVersion, params, request.SignatureTarget)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -20,13 +20,14 @@ type SignForMethod struct{}
 
 func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	var request struct {
-		Account    string          `json:"account"`
-		TxJson     json.RawMessage `json:"tx_json"`
-		Secret     string          `json:"secret,omitempty"`
-		Seed       string          `json:"seed,omitempty"`
-		SeedHex    string          `json:"seed_hex,omitempty"`
-		Passphrase string          `json:"passphrase,omitempty"`
-		KeyType    string          `json:"key_type,omitempty"`
+		Account         string          `json:"account"`
+		TxJson          json.RawMessage `json:"tx_json"`
+		Secret          string          `json:"secret,omitempty"`
+		Seed            string          `json:"seed,omitempty"`
+		SeedHex         string          `json:"seed_hex,omitempty"`
+		Passphrase      string          `json:"passphrase,omitempty"`
+		KeyType         string          `json:"key_type,omitempty"`
+		SignatureTarget string          `json:"signature_target,omitempty"`
 	}
 
 	if params != nil {
@@ -47,6 +48,13 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 
 	if len(request.TxJson) == 0 {
 		return nil, types.RpcErrorMissingField("tx_json")
+	}
+
+	// signature_target directs the multi-signer into a nested inner object.
+	// Only CounterpartySignature is a valid target; any other name is rejected
+	// with the field name as the message, matching rippled TransactionSign.cpp.
+	if request.SignatureTarget != "" && request.SignatureTarget != counterpartySignatureField {
+		return nil, types.RpcErrorInvalidParams(request.SignatureTarget)
 	}
 
 	// Parse credentials and derive keypair using the shared helper
@@ -79,12 +87,30 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		return nil, types.RpcErrorMissingField("Account")
 	}
 
-	// For multi-signing, SigningPubKey must be empty string
-	txMap["SigningPubKey"] = ""
+	// For multi-signing, the top-level SigningPubKey must be empty. With a
+	// signature_target the signature goes into a nested object, so an existing
+	// top-level SigningPubKey (the primary signer's) is preserved.
+	if request.SignatureTarget == "" {
+		txMap["SigningPubKey"] = ""
+	} else if _, ok := txMap["SigningPubKey"]; !ok {
+		txMap["SigningPubKey"] = ""
+	}
+
+	// sigContainer holds the Signers array the new signature is appended to:
+	// the transaction itself, or the nested CounterpartySignature object.
+	sigContainer := txMap
+	if request.SignatureTarget != "" {
+		nested, _ := txMap[request.SignatureTarget].(map[string]any)
+		if nested == nil {
+			nested = map[string]any{"SigningPubKey": ""}
+		}
+		txMap[request.SignatureTarget] = nested
+		sigContainer = nested
+	}
 
 	// Get existing signers array or create new one
 	var signers []map[string]any
-	if existingSigners, ok := txMap["Signers"].([]any); ok {
+	if existingSigners, ok := sigContainer["Signers"].([]any); ok {
 		for _, s := range existingSigners {
 			if signer, ok := s.(map[string]any); ok {
 				signers = append(signers, signer)
@@ -142,7 +168,7 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		return iAccount < jAccount
 	})
 
-	txMap["Signers"] = signers
+	sigContainer["Signers"] = signers
 
 	txBlob, err := binarycodec.Encode(txMap)
 	if err != nil {

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -17,6 +17,10 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 )
 
+// counterpartySignatureField is the only inner-object SField a signature_target
+// may name, matching rippled (the LoanSet sfCounterpartySignature).
+const counterpartySignatureField = "CounterpartySignature"
+
 // signCredentials holds the signing credential parameters common to both
 // the sign and submit RPC methods.
 type signCredentials struct {
@@ -154,7 +158,7 @@ type signResult struct {
 // read only when Fee is actually autofilled — rippled's checkFee returns
 // before inspecting them when Fee is present or offline. unlimited mirrors
 // rippled's isUnlimited(role) load-scaling carve-out.
-func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, txJSON json.RawMessage, creds signCredentials, offline bool, unlimited bool, apiVersion int, rawParams json.RawMessage) (*signResult, *types.RpcError) {
+func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, txJSON json.RawMessage, creds signCredentials, offline bool, unlimited bool, apiVersion int, rawParams json.RawMessage, signatureTarget string) (*signResult, *types.RpcError) {
 	// Check if ledger service is available (needed for auto-filling fields)
 	if !offline && (services == nil || services.Ledger == nil) {
 		return nil, types.RpcErrorInternal("Ledger service not available")
@@ -185,18 +189,42 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid tx_json: %v", err))
 	}
 
-	// A supplied Account must be a parseable address before anything else
-	// (rippled checkTxJsonFields → rpcSRC_ACT_MALFORMED), then match the
-	// signing key.
-	if txAccount, ok := txMap["Account"].(string); ok {
+	// signature_target directs the signature into a nested inner object instead
+	// of the top level. Only CounterpartySignature is a valid target; any other
+	// field name is rejected with the field name as the message, matching
+	// rippled TransactionSign.cpp.
+	if signatureTarget != "" && signatureTarget != counterpartySignatureField {
+		return nil, types.RpcErrorInvalidParams(signatureTarget)
+	}
+
+	// srcAddress is the account whose Sequence/Fee are autofilled and whose
+	// existence is checked. Without a target it is the signing key's account,
+	// which must match a supplied Account (rippled checkTxJsonFields →
+	// rpcSRC_ACT_MALFORMED, then acctMatchesPubKey). With a target the signature
+	// belongs to the counterparty, so account and secret need not correspond:
+	// the caller's Account (the primary signer) is the source and its ownership
+	// is not checked.
+	srcAddress := address
+	if signatureTarget == "" {
+		if txAccount, ok := txMap["Account"].(string); ok {
+			if !types.IsValidClassicAddress(txAccount) {
+				return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx_json.Account'.")
+			}
+			if txAccount != address {
+				return nil, types.RpcErrorInvalidParams("Account in tx_json does not match signing key")
+			}
+		} else {
+			txMap["Account"] = address
+		}
+	} else {
+		txAccount, ok := txMap["Account"].(string)
+		if !ok || txAccount == "" {
+			return nil, types.RpcErrorMissingField("tx_json.Account")
+		}
 		if !types.IsValidClassicAddress(txAccount) {
 			return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx_json.Account'.")
 		}
-		if txAccount != address {
-			return nil, types.RpcErrorInvalidParams("Account in tx_json does not match signing key")
-		}
-	} else {
-		txMap["Account"] = address
+		srcAddress = txAccount
 	}
 
 	// Fill in missing fields if not offline. Order matches rippled's
@@ -205,7 +233,7 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 	if !offline {
 		// The source account must exist in the current ledger, whether or
 		// not Sequence is supplied (rpcSRC_ACT_NOT_FOUND).
-		if _, err := services.Ledger.GetAccountInfo(ctx, address, "current"); err != nil {
+		if _, err := services.Ledger.GetAccountInfo(ctx, srcAddress, "current"); err != nil {
 			if errors.Is(err, svcerr.ErrAccountNotFound) {
 				return nil, types.RpcErrorSrcActNotFound("Source account not found.")
 			}
@@ -216,7 +244,7 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 		// TicketSequence supplies the sequence instead (Sequence = 0).
 		if _, ok := txMap["Sequence"]; !ok {
 			_, hasTicket := txMap["TicketSequence"]
-			seq, err := services.Ledger.GetAutofillSequence(address, hasTicket)
+			seq, err := services.Ledger.GetAutofillSequence(srcAddress, hasTicket)
 			if err != nil {
 				if errors.Is(err, svcerr.ErrAccountNotFound) {
 					return nil, types.RpcErrorSrcActNotFound("Source account not found.")
@@ -278,7 +306,13 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 		}
 	}
 
-	txMap["SigningPubKey"] = publicKey
+	// Without a target the signing key is the transaction's own key, placed at
+	// the top level. With a target the top-level SigningPubKey (the primary
+	// signer's) is left untouched so the counterparty covers the same signing
+	// payload; the counterparty's key goes into the nested object.
+	if signatureTarget == "" {
+		txMap["SigningPubKey"] = publicKey
+	}
 
 	txBytes, err := json.Marshal(txMap)
 	if err != nil {
@@ -290,15 +324,28 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Failed to parse transaction: %v", err))
 	}
 
-	txCommon := transaction.GetCommon()
-	txCommon.SigningPubKey = publicKey
+	if signatureTarget == "" {
+		transaction.GetCommon().SigningPubKey = publicKey
+	}
 
 	signature, err := sign.SignTransaction(transaction, privateKey)
 	if err != nil {
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to sign transaction: %v", err))
 	}
 
-	txMap["TxnSignature"] = signature
+	if signatureTarget == "" {
+		txMap["TxnSignature"] = signature
+	} else {
+		// Write SigningPubKey + TxnSignature into the nested target object,
+		// preserving any fields the caller already placed there.
+		targetObj, _ := txMap[signatureTarget].(map[string]any)
+		if targetObj == nil {
+			targetObj = map[string]any{}
+		}
+		targetObj["SigningPubKey"] = publicKey
+		targetObj["TxnSignature"] = signature
+		txMap[signatureTarget] = targetObj
+	}
 
 	txBlob, err := binarycodec.Encode(txMap)
 	if err != nil {

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -18,16 +18,17 @@ type SubmitMethod struct{}
 
 func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	var request struct {
-		TxBlob     string          `json:"tx_blob,omitempty"`
-		TxJson     json.RawMessage `json:"tx_json,omitempty"`
-		Secret     string          `json:"secret,omitempty"`
-		Seed       string          `json:"seed,omitempty"`
-		SeedHex    string          `json:"seed_hex,omitempty"`
-		Passphrase string          `json:"passphrase,omitempty"`
-		KeyType    string          `json:"key_type,omitempty"`
-		FailHard   bool            `json:"fail_hard,omitempty"`
-		Offline    bool            `json:"offline,omitempty"`
-		BuildPath  bool            `json:"build_path,omitempty"`
+		TxBlob          string          `json:"tx_blob,omitempty"`
+		TxJson          json.RawMessage `json:"tx_json,omitempty"`
+		Secret          string          `json:"secret,omitempty"`
+		Seed            string          `json:"seed,omitempty"`
+		SeedHex         string          `json:"seed_hex,omitempty"`
+		Passphrase      string          `json:"passphrase,omitempty"`
+		KeyType         string          `json:"key_type,omitempty"`
+		FailHard        bool            `json:"fail_hard,omitempty"`
+		Offline         bool            `json:"offline,omitempty"`
+		BuildPath       bool            `json:"build_path,omitempty"`
+		SignatureTarget string          `json:"signature_target,omitempty"`
 	}
 
 	if err := ParseParams(params, &request); err != nil {
@@ -72,7 +73,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 			SeedHex:    request.SeedHex,
 			Passphrase: request.Passphrase,
 			KeyType:    request.KeyType,
-		}, request.Offline, ctx.Unlimited, ctx.ApiVersion, params)
+		}, request.Offline, ctx.Unlimited, ctx.ApiVersion, params, request.SignatureTarget)
 		if rpcErr != nil {
 			return nil, rpcErr
 		}

--- a/internal/rpc/sign_counterparty_test.go
+++ b/internal/rpc/sign_counterparty_test.go
@@ -1,0 +1,202 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
+)
+
+// signOffline runs the sign handler in offline mode and returns the response map.
+func signOffline(t *testing.T, params json.RawMessage) map[string]any {
+	t.Helper()
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
+	result, rpcErr := handler.Handle(ctx, params)
+	require.Nil(t, rpcErr)
+	require.NotNil(t, result)
+	return result.(map[string]any)
+}
+
+// TestSign_SignatureTarget_HappyPath signs a transaction normally and then
+// attaches a counterparty signature via signature_target=CounterpartySignature.
+// The nested object is populated, the top-level signature is preserved, and both
+// signatures verify.
+func TestSign_SignatureTarget_HappyPath(t *testing.T) {
+	// Primary signs (masterpassphrase → rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh).
+	primary := signOffline(t, json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10",
+			"Sequence": 1
+		},
+		"passphrase": "masterpassphrase",
+		"offline": true
+	}`))
+	primaryTx := primary["tx_json"].(map[string]any)
+	require.NotEmpty(t, primaryTx["SigningPubKey"])
+	require.NotEmpty(t, primaryTx["TxnSignature"])
+	// Strip response-only aliases the codec cannot serialize on the re-sign.
+	delete(primaryTx, "hash")
+	delete(primaryTx, "DeliverMax")
+	primaryPubKey := primaryTx["SigningPubKey"].(string)
+
+	// Counterparty signs into the nested object with a different key.
+	req, err := json.Marshal(map[string]any{
+		"tx_json":          primaryTx,
+		"passphrase":       "counterparty phrase",
+		"offline":          true,
+		"signature_target": "CounterpartySignature",
+	})
+	require.NoError(t, err)
+	res := signOffline(t, req)
+
+	resTx := res["tx_json"].(map[string]any)
+	// Top-level primary signature is untouched.
+	assert.Equal(t, primaryPubKey, resTx["SigningPubKey"])
+	assert.Equal(t, primaryTx["TxnSignature"], resTx["TxnSignature"])
+
+	// The nested object carries the counterparty's key + signature.
+	cpObj, ok := resTx["CounterpartySignature"].(map[string]any)
+	require.True(t, ok, "response tx_json missing CounterpartySignature: %v", resTx)
+	assert.NotEmpty(t, cpObj["SigningPubKey"])
+	assert.NotEmpty(t, cpObj["TxnSignature"])
+	assert.NotEqual(t, primaryPubKey, cpObj["SigningPubKey"], "counterparty key must differ from primary")
+
+	// Reconstruct the transaction and verify both signatures.
+	blob := res["tx_blob"].(string)
+	decoded, err := binarycodec.Decode(blob)
+	require.NoError(t, err)
+	txBytes, err := json.Marshal(decoded)
+	require.NoError(t, err)
+	parsed, err := txcore.ParseJSON(txBytes)
+	require.NoError(t, err)
+
+	require.NoError(t, sign.VerifySignature(parsed, false), "top-level signature must verify")
+	cp := parsed.GetCommon().CounterpartySignature
+	require.NotNil(t, cp)
+	require.NoError(t, sign.VerifyCounterpartySignature(parsed, cp, nil, false), "counterparty signature must verify")
+}
+
+// TestSign_SignatureTarget_Invalid rejects a signature_target that does not name
+// the CounterpartySignature field, with rpcINVALID_PARAMS.
+func TestSign_SignatureTarget_Invalid(t *testing.T) {
+	handler := &handlers.SignMethod{}
+	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
+	params := json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10",
+			"Sequence": 1
+		},
+		"passphrase": "masterpassphrase",
+		"offline": true,
+		"signature_target": "NotAValidField"
+	}`)
+	_, err := handler.Handle(ctx, params)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+	assert.Contains(t, err.Message, "NotAValidField")
+}
+
+// TestSign_SignatureTarget_SkipsOwnershipCheck confirms that with a
+// signature_target the signing key need not correspond to tx_json.Account: a
+// counterparty key that derives to a different address does not raise the
+// "does not match" ownership error.
+func TestSign_SignatureTarget_SkipsOwnershipCheck(t *testing.T) {
+	res := signOffline(t, json.RawMessage(`{
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount": "1000000",
+			"Fee": "10",
+			"Sequence": 1
+		},
+		"passphrase": "counterparty phrase",
+		"offline": true,
+		"signature_target": "CounterpartySignature"
+	}`))
+	resTx := res["tx_json"].(map[string]any)
+	// The counterparty's key does not match Account, but signing succeeded and
+	// its signature was written into the nested object.
+	cpObj, ok := resTx["CounterpartySignature"].(map[string]any)
+	require.True(t, ok, "expected CounterpartySignature in %v", resTx)
+	assert.NotEmpty(t, cpObj["TxnSignature"])
+}
+
+// TestSignFor_SignatureTarget attaches a multi-signer into the nested
+// CounterpartySignature object via sign_for.
+func TestSignFor_SignatureTarget(t *testing.T) {
+	handler := &handlers.SignForMethod{}
+	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
+
+	// account is the signer; the tx Account is a different primary account.
+	params := json.RawMessage(`{
+		"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Amount": "1000000",
+			"Fee": "10",
+			"Sequence": 1
+		},
+		"passphrase": "masterpassphrase",
+		"signature_target": "CounterpartySignature"
+	}`)
+	result, rpcErr := handler.Handle(ctx, params)
+	require.Nil(t, rpcErr)
+	resTx := result.(map[string]any)["tx_json"].(map[string]any)
+
+	cpObj, ok := resTx["CounterpartySignature"].(map[string]any)
+	require.True(t, ok, "expected CounterpartySignature in %v", resTx)
+	switch signers := cpObj["Signers"].(type) {
+	case []map[string]any:
+		assert.Len(t, signers, 1)
+	case []any:
+		assert.Len(t, signers, 1)
+	default:
+		t.Fatalf("expected nested Signers array, got %T in %v", cpObj["Signers"], cpObj)
+	}
+	// The top-level tx must not have picked up a Signers array.
+	_, topHasSigners := resTx["Signers"]
+	assert.False(t, topHasSigners, "signer must go into the nested object, not the top level")
+}
+
+// TestSignFor_SignatureTarget_Invalid rejects an unknown signature_target.
+func TestSignFor_SignatureTarget_Invalid(t *testing.T) {
+	handler := &handlers.SignForMethod{}
+	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
+	params := json.RawMessage(`{
+		"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"tx_json": {
+			"TransactionType": "Payment",
+			"Account": "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Amount": "1000000",
+			"Fee": "10",
+			"Sequence": 1
+		},
+		"passphrase": "masterpassphrase",
+		"signature_target": "Memo"
+	}`)
+	_, err := handler.Handle(ctx, params)
+	require.NotNil(t, err)
+	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+	assert.Contains(t, err.Message, "Memo")
+}

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -124,6 +124,24 @@ func (b *Batch) InnerTransactions() []tx.Transaction {
 	return txns
 }
 
+// checkInnerSignatureFields rejects signature material on an inner batch object,
+// mirroring the checkSignatureFields lambda in rippled Batch::preflight: a
+// TxnSignature yields temBAD_SIGNATURE, a Signers array temBAD_SIGNER, and a
+// non-empty SigningPubKey temBAD_REGKEY. It is applied to every inner
+// transaction and to its nested CounterpartySignature.
+func checkInnerSignatureFields(signingPubKey, txnSignature string, hasSigners bool) error {
+	if txnSignature != "" {
+		return ErrBatchInnerHasTxnSignature
+	}
+	if hasSigners {
+		return ErrBatchInnerHasSigners
+	}
+	if signingPubKey != "" {
+		return ErrBatchInnerHasSigningPubKey
+	}
+	return nil
+}
+
 // validateInnerTransactions runs the per-inner checks and, as a side effect,
 // builds the set of inner-tx accounts other than the outer account — the
 // accounts that must each be covered by a BatchSigner.
@@ -160,14 +178,15 @@ func (b *Batch) validateInnerTransactions() (map[string]struct{}, error) {
 		if innerCommon.GetFlags()&tx.TfInnerBatchTxn == 0 {
 			return nil, ErrBatchInnerMissingFlag
 		}
-		if innerCommon.TxnSignature != "" {
-			return nil, ErrBatchInnerHasTxnSignature
+		if err := checkInnerSignatureFields(innerCommon.SigningPubKey, innerCommon.TxnSignature, len(innerCommon.Signers) > 0); err != nil {
+			return nil, err
 		}
-		if len(innerCommon.Signers) > 0 {
-			return nil, ErrBatchInnerHasSigners
-		}
-		if innerCommon.SigningPubKey != "" {
-			return nil, ErrBatchInnerHasSigningPubKey
+		// A CounterpartySignature is optional on an inner transaction and should
+		// not be present, but if it is it must not carry any signature material.
+		if cp := innerCommon.CounterpartySignature; cp != nil {
+			if err := checkInnerSignatureFields(cp.SigningPubKey, cp.TxnSignature, len(cp.Signers) > 0); err != nil {
+				return nil, err
+			}
 		}
 		if err := validateInnerFee(innerCommon.Fee); err != nil {
 			return nil, err

--- a/internal/tx/batch/counterparty_signature_test.go
+++ b/internal/tx/batch/counterparty_signature_test.go
@@ -1,0 +1,72 @@
+package batch
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+// batchWithInnerCounterparty builds a valid two-inner AllOrNothing batch whose
+// first inner transaction carries the given CounterpartySignature, so the
+// per-inner signature-field checks can be exercised.
+func batchWithInnerCounterparty(cp *tx.CounterpartySignature) *Batch {
+	b := NewBatch(testOuter)
+	inner := makeTestPayment()
+	inner.GetCommon().CounterpartySignature = cp
+	b.AddInnerTransaction(inner)
+	b.AddInnerTransaction(makeTestPayment())
+	flags := BatchFlagAllOrNothing
+	b.Common.Flags = &flags
+	return b
+}
+
+// TestBatchInnerCounterpartySignatureFields mirrors rippled Batch::preflight's
+// checkSignatureFields applied to an inner transaction's CounterpartySignature:
+// a TxnSignature is temBAD_SIGNATURE, a Signers array is temBAD_SIGNER, and a
+// non-empty SigningPubKey is temBAD_REGKEY.
+func TestBatchInnerCounterpartySignatureFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		cp      *tx.CounterpartySignature
+		wantErr error
+	}{
+		{
+			name:    "TxnSignature present",
+			cp:      &tx.CounterpartySignature{TxnSignature: "DEADBEEF"},
+			wantErr: ErrBatchInnerHasTxnSignature,
+		},
+		{
+			name: "Signers present",
+			cp: &tx.CounterpartySignature{Signers: []tx.SignerWrapper{
+				{Signer: tx.Signer{Account: testSigner1}},
+			}},
+			wantErr: ErrBatchInnerHasSigners,
+		},
+		{
+			name:    "SigningPubKey present",
+			cp:      &tx.CounterpartySignature{SigningPubKey: "ED0000000000000000000000000000000000000000000000000000000000000001"},
+			wantErr: ErrBatchInnerHasSigningPubKey,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := batchWithInnerCounterparty(tc.cp)
+			err := b.Validate()
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Validate() error = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestBatchInnerCounterpartyEmptyAllowed confirms that an inner transaction may
+// carry an empty CounterpartySignature (no signature material) without error —
+// only signature fields are rejected.
+func TestBatchInnerCounterpartyEmptyAllowed(t *testing.T) {
+	b := batchWithInnerCounterparty(&tx.CounterpartySignature{})
+	if err := b.Validate(); err != nil {
+		t.Fatalf("empty inner CounterpartySignature should be allowed, got %v", err)
+	}
+}

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -289,6 +289,17 @@ func (e *Engine) verifySignatures(tx txcore.Transaction) ter.Result {
 	if result := e.verifyOuterSignature(tx); result != ter.TesSUCCESS {
 		return result
 	}
+	// After the top-level signature passes, verify a nested
+	// sfCounterpartySignature if present, mirroring the counterparty arm of
+	// rippled STTx::checkSign. A failure is a bad signature (checkValidity's
+	// Validity::SigBad), which rippled maps to temINVALID.
+	if cp := tx.GetCommon().CounterpartySignature; cp != nil {
+		mustBeFullyCanonical := e.rules().RequireFullyCanonicalSigEnabled() ||
+			(tx.GetCommon().GetFlags()&txcore.TfFullyCanonicalSig) != 0
+		if err := sign.VerifyCounterpartySignature(tx, cp, e.rules(), mustBeFullyCanonical); err != nil {
+			return ter.TemINVALID
+		}
+	}
 	// Batch-signer signatures are verified over the batch signing digest, the same
 	// stage rippled runs STTx::checkBatchSign (always RequireFullyCanonicalSig::yes).
 	// The structural/coverage checks on BatchSigners run unconditionally in Validate;

--- a/internal/tx/sign/counterparty_signature_test.go
+++ b/internal/tx/sign/counterparty_signature_test.go
@@ -1,0 +1,279 @@
+package sign
+
+import (
+	"bytes"
+	"sort"
+	"strings"
+	"testing"
+
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/crypto/ed25519"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+// cpKeypair derives a deterministic ed25519 keypair + classic address from a
+// single seed byte, so counterparty-signature tests can build real signatures.
+func cpKeypair(t *testing.T, seed byte) (priv, pub, addr string) {
+	t.Helper()
+	entropy := make([]byte, addresscodec.FamilySeedLength)
+	for i := range entropy {
+		entropy[i] = seed
+	}
+	priv, pub, err := ed25519.ED25519().DeriveKeypair(entropy, false)
+	if err != nil {
+		t.Fatalf("derive keypair: %v", err)
+	}
+	addr, err = addresscodec.EncodeClassicAddressFromPublicKeyHex(pub)
+	if err != nil {
+		t.Fatalf("derive address: %v", err)
+	}
+	return priv, pub, addr
+}
+
+// primarySignedTx builds an AccountSet signed by its own account (the primary),
+// so a counterparty signature can be layered on top. The top-level SigningPubKey
+// is set before signing, so it is part of the data both the primary and the
+// counterparty cover.
+func primarySignedTx(t *testing.T) txcore.Transaction {
+	t.Helper()
+	pPriv, pPub, pAddr := cpKeypair(t, 0x11)
+	transaction := txcore.NewBaseTx(txcore.TypeAccountSet, pAddr)
+	seq := uint32(1)
+	transaction.Common.Sequence = &seq
+	transaction.Common.Fee = "10"
+	transaction.Common.SigningPubKey = pPub
+	sig, err := SignTransaction(transaction, pPriv)
+	if err != nil {
+		t.Fatalf("sign primary: %v", err)
+	}
+	transaction.Common.TxnSignature = sig
+	return transaction
+}
+
+// sortSigners orders signers by binary AccountID, as a well-formed multi-sign
+// array must be.
+func sortSigners(signers []txcore.SignerWrapper) {
+	sort.Slice(signers, func(i, j int) bool {
+		a, _ := state.DecodeAccountID(signers[i].Signer.Account)
+		b, _ := state.DecodeAccountID(signers[j].Signer.Account)
+		return bytes.Compare(a[:], b[:]) < 0
+	})
+}
+
+// TestCounterpartySignature_ExcludedFromSigningData pins the wire-level property
+// that the nested CounterpartySignature is not covered by the top-level
+// signature: the signing payload is byte-identical whether or not it is present.
+func TestCounterpartySignature_ExcludedFromSigningData(t *testing.T) {
+	transaction := primarySignedTx(t)
+
+	without, err := getSigningPayload(transaction)
+	if err != nil {
+		t.Fatalf("payload without counterparty: %v", err)
+	}
+
+	transaction.GetCommon().CounterpartySignature = &txcore.CounterpartySignature{
+		SigningPubKey: "ED0000000000000000000000000000000000000000000000000000000000000001",
+		TxnSignature:  "DEADBEEF",
+	}
+	with, err := getSigningPayload(transaction)
+	if err != nil {
+		t.Fatalf("payload with counterparty: %v", err)
+	}
+
+	if with != without {
+		t.Fatalf("CounterpartySignature must be excluded from signing data:\n with=%s\n without=%s", with, without)
+	}
+}
+
+// TestCounterpartySignature_WireRoundTrip confirms a transaction carrying a
+// single-signed CounterpartySignature survives encode → decode with the nested
+// signature fields intact.
+func TestCounterpartySignature_WireRoundTrip(t *testing.T) {
+	transaction := primarySignedTx(t)
+	_, cPub, _ := cpKeypair(t, 0x22)
+	cp, err := SignCounterparty(transaction, cPub, mustPrivFor(t, 0x22))
+	if err != nil {
+		t.Fatalf("sign counterparty: %v", err)
+	}
+	transaction.GetCommon().CounterpartySignature = cp
+
+	flat, err := transaction.Flatten()
+	if err != nil {
+		t.Fatalf("flatten: %v", err)
+	}
+	blob, err := binarycodec.Encode(flat)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := binarycodec.Decode(blob)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	obj, ok := decoded["CounterpartySignature"].(map[string]any)
+	if !ok {
+		t.Fatalf("decoded tx missing CounterpartySignature: %v", decoded)
+	}
+	if obj["SigningPubKey"] != cPub {
+		t.Fatalf("round-trip SigningPubKey = %v, want %s", obj["SigningPubKey"], cPub)
+	}
+	if obj["TxnSignature"] != cp.TxnSignature {
+		t.Fatalf("round-trip TxnSignature = %v, want %s", obj["TxnSignature"], cp.TxnSignature)
+	}
+}
+
+func mustPrivFor(t *testing.T, seed byte) string {
+	t.Helper()
+	priv, _, _ := cpKeypair(t, seed)
+	return priv
+}
+
+// TestCounterpartySignature_SingleSignValid verifies a correctly counterparty-
+// signed transaction passes.
+func TestCounterpartySignature_SingleSignValid(t *testing.T) {
+	transaction := primarySignedTx(t)
+	cPriv, cPub, _ := cpKeypair(t, 0x22)
+	cp, err := SignCounterparty(transaction, cPub, cPriv)
+	if err != nil {
+		t.Fatalf("sign counterparty: %v", err)
+	}
+	transaction.GetCommon().CounterpartySignature = cp
+
+	if err := VerifyCounterpartySignature(transaction, cp, nil, false); err != nil {
+		t.Fatalf("valid counterparty signature rejected: %v", err)
+	}
+}
+
+// TestCounterpartySignature_SingleSignWrongKey rejects a counterparty signature
+// whose SigningPubKey does not match the key that produced it, with the
+// "Counterparty: " prefix rippled uses.
+func TestCounterpartySignature_SingleSignWrongKey(t *testing.T) {
+	transaction := primarySignedTx(t)
+	cPriv, _, _ := cpKeypair(t, 0x22)
+	_, wrongPub, _ := cpKeypair(t, 0x33)
+
+	sig, err := SignTransaction(transaction, cPriv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	cp := &txcore.CounterpartySignature{SigningPubKey: wrongPub, TxnSignature: sig}
+
+	err = VerifyCounterpartySignature(transaction, cp, nil, false)
+	if err == nil {
+		t.Fatal("wrong-key counterparty signature was accepted")
+	}
+	if !strings.HasPrefix(err.Error(), counterpartyPrefix) {
+		t.Fatalf("error not prefixed %q: %v", counterpartyPrefix, err)
+	}
+}
+
+// TestCounterpartySignature_SingleAndMultiRejected rejects an object that
+// carries both a single signature and a Signers array (signed two ways).
+func TestCounterpartySignature_SingleAndMultiRejected(t *testing.T) {
+	transaction := primarySignedTx(t)
+	cPriv, cPub, _ := cpKeypair(t, 0x22)
+	sig, _ := SignTransaction(transaction, cPriv)
+	cp := &txcore.CounterpartySignature{
+		SigningPubKey: cPub,
+		TxnSignature:  sig,
+		Signers: []txcore.SignerWrapper{
+			{Signer: txcore.Signer{Account: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"}},
+		},
+	}
+	if err := VerifyCounterpartySignature(transaction, cp, nil, false); err == nil {
+		t.Fatal("counterparty signed two ways was accepted")
+	}
+}
+
+// TestCounterpartySignature_MultiSignValid verifies a multi-signed counterparty
+// object with two signers over the multi-signing payload.
+func TestCounterpartySignature_MultiSignValid(t *testing.T) {
+	transaction := primarySignedTx(t)
+
+	s1Priv, s1Pub, s1Addr := cpKeypair(t, 0x44)
+	s2Priv, s2Pub, s2Addr := cpKeypair(t, 0x55)
+	sig1, _ := SignTransactionForMultiSign(transaction, s1Addr, s1Priv)
+	sig2, _ := SignTransactionForMultiSign(transaction, s2Addr, s2Priv)
+
+	signers := []txcore.SignerWrapper{
+		{Signer: txcore.Signer{Account: s1Addr, SigningPubKey: s1Pub, TxnSignature: sig1}},
+		{Signer: txcore.Signer{Account: s2Addr, SigningPubKey: s2Pub, TxnSignature: sig2}},
+	}
+	sortSigners(signers)
+	cp := &txcore.CounterpartySignature{Signers: signers}
+
+	if err := VerifyCounterpartySignature(transaction, cp, nil, false); err != nil {
+		t.Fatalf("valid multi-signed counterparty rejected: %v", err)
+	}
+}
+
+// TestCounterpartySignature_MultiSignWrongKey rejects a multi-signed
+// counterparty object when a nested signature does not match its key.
+func TestCounterpartySignature_MultiSignWrongKey(t *testing.T) {
+	transaction := primarySignedTx(t)
+
+	s1Priv, _, s1Addr := cpKeypair(t, 0x44)
+	_, wrongPub, _ := cpKeypair(t, 0x66)
+	sig1, _ := SignTransactionForMultiSign(transaction, s1Addr, s1Priv)
+
+	cp := &txcore.CounterpartySignature{
+		Signers: []txcore.SignerWrapper{
+			{Signer: txcore.Signer{Account: s1Addr, SigningPubKey: wrongPub, TxnSignature: sig1}},
+		},
+	}
+	err := VerifyCounterpartySignature(transaction, cp, nil, false)
+	if err == nil {
+		t.Fatal("multi-signed counterparty with wrong key accepted")
+	}
+	if !strings.HasPrefix(err.Error(), counterpartyPrefix) {
+		t.Fatalf("error not prefixed %q: %v", counterpartyPrefix, err)
+	}
+}
+
+// TestCounterpartySignature_MultiSignUnsorted rejects nested signers that are
+// not sorted by AccountID.
+func TestCounterpartySignature_MultiSignUnsorted(t *testing.T) {
+	transaction := primarySignedTx(t)
+
+	s1Priv, s1Pub, s1Addr := cpKeypair(t, 0x44)
+	s2Priv, s2Pub, s2Addr := cpKeypair(t, 0x55)
+	sig1, _ := SignTransactionForMultiSign(transaction, s1Addr, s1Priv)
+	sig2, _ := SignTransactionForMultiSign(transaction, s2Addr, s2Priv)
+
+	signers := []txcore.SignerWrapper{
+		{Signer: txcore.Signer{Account: s1Addr, SigningPubKey: s1Pub, TxnSignature: sig1}},
+		{Signer: txcore.Signer{Account: s2Addr, SigningPubKey: s2Pub, TxnSignature: sig2}},
+	}
+	sortSigners(signers)
+	// Force descending order to break the sort invariant.
+	signers[0], signers[1] = signers[1], signers[0]
+	cp := &txcore.CounterpartySignature{Signers: signers}
+
+	if err := VerifyCounterpartySignature(transaction, cp, nil, false); err == nil {
+		t.Fatal("unsorted counterparty signers accepted")
+	}
+}
+
+// TestCounterpartySignature_MultiSignSelfSignAllowed confirms the counterparty
+// may sign for the transaction's own Account, unlike a top-level multi-sign
+// (rippled multiSignHelper with an unseated txnAccountID).
+func TestCounterpartySignature_MultiSignSelfSignAllowed(t *testing.T) {
+	transaction := primarySignedTx(t)
+	txAccount := transaction.GetCommon().Account
+
+	// Sign the multi-signing payload for the transaction's own account, using
+	// the primary key material (the account signing for itself).
+	priv := mustPrivFor(t, 0x11)
+	_, pub, _ := cpKeypair(t, 0x11)
+	sig, _ := SignTransactionForMultiSign(transaction, txAccount, priv)
+
+	cp := &txcore.CounterpartySignature{
+		Signers: []txcore.SignerWrapper{
+			{Signer: txcore.Signer{Account: txAccount, SigningPubKey: pub, TxnSignature: sig}},
+		},
+	}
+	if err := VerifyCounterpartySignature(transaction, cp, nil, false); err != nil {
+		t.Fatalf("counterparty self-sign should be allowed: %v", err)
+	}
+}

--- a/internal/tx/sign/signature.go
+++ b/internal/tx/sign/signature.go
@@ -328,6 +328,111 @@ func VerifyMultiSignature(tx txcore.Transaction, lookup SignerListLookup, mustBe
 	return nil
 }
 
+// counterpartyPrefix labels every error surfaced from the nested
+// CounterpartySignature check, matching rippled's "Counterparty: " prefix.
+const counterpartyPrefix = "Counterparty: "
+
+// VerifyCounterpartySignature cryptographically verifies the nested
+// sfCounterpartySignature object, mirroring rippled STTx::checkSign(sigObject).
+// It runs after the top-level signature passes and is crypto-only: no
+// signer-list or quorum authorization applies, because there is no counterparty
+// account on the ledger to authorize against — this is wire-format groundwork
+// for future multi-role transactions.
+//
+// A single-signed object (non-empty SigningPubKey) is verified against the same
+// signing payload the top-level single signer covers; a multi-signed object
+// (empty SigningPubKey + Signers) has each nested signer verified against the
+// multi-signing payload. Unlike a top-level multi-sign, the counterparty may
+// sign for the transaction's own Account. Every error is prefixed
+// "Counterparty: " to match rippled's messages.
+func VerifyCounterpartySignature(tx txcore.Transaction, cp *txcore.CounterpartySignature, rules *amendment.Rules, mustBeFullyCanonical bool) error {
+	if cp.SigningPubKey != "" {
+		return verifyCounterpartySingleSign(tx, cp, mustBeFullyCanonical)
+	}
+	return verifyCounterpartyMultiSign(tx, cp, rules, mustBeFullyCanonical)
+}
+
+// verifyCounterpartySingleSign verifies a single-signed counterparty object. A
+// nested Signers array alongside a SigningPubKey means the object is signed two
+// ways and is rejected. Reference: rippled singleSignHelper.
+func verifyCounterpartySingleSign(tx txcore.Transaction, cp *txcore.CounterpartySignature, mustBeFullyCanonical bool) error {
+	if len(cp.Signers) > 0 {
+		return errors.New(counterpartyPrefix + "Cannot both single- and multi-sign.")
+	}
+	payload, err := getSigningPayload(tx)
+	if err != nil {
+		return errors.New(counterpartyPrefix + "Invalid signature.")
+	}
+	if !verifySignatureForKey(payload, cp.SigningPubKey, cp.TxnSignature, mustBeFullyCanonical) {
+		return errors.New(counterpartyPrefix + "Invalid signature.")
+	}
+	return nil
+}
+
+// verifyCounterpartyMultiSign verifies a multi-signed counterparty object. Each
+// nested signer signs the transaction's multi-signing payload suffixed with its
+// own account ID; signers must be sorted by account ID with no duplicates. A
+// direct TxnSignature alongside the Signers array is rejected as signed two
+// ways. Reference: rippled multiSignHelper (txnAccountID unseated, so a signer
+// may equal the transaction Account).
+func verifyCounterpartyMultiSign(tx txcore.Transaction, cp *txcore.CounterpartySignature, rules *amendment.Rules, mustBeFullyCanonical bool) error {
+	// An empty SigningPubKey with no Signers is neither a single- nor a
+	// multi-signature (rippled multiSignHelper's !isFieldPresent(sfSigners) arm).
+	if len(cp.Signers) == 0 {
+		return errors.New(counterpartyPrefix + "Empty SigningPubKey.")
+	}
+	if cp.TxnSignature != "" {
+		return errors.New(counterpartyPrefix + "Cannot both single- and multi-sign.")
+	}
+	if len(cp.Signers) > MaxMultiSigners(rules) {
+		return errors.New(counterpartyPrefix + "Invalid Signers array size.")
+	}
+
+	txMap, err := tx.Flatten()
+	if err != nil {
+		return errors.New(counterpartyPrefix + "Invalid signature.")
+	}
+
+	var lastAccountID [20]byte
+	for _, sw := range cp.Signers {
+		signer := sw.Signer
+		accountID, decErr := state.DecodeAccountID(signer.Account)
+		if decErr != nil {
+			return fmt.Errorf("%sInvalid signature on account %s.", counterpartyPrefix, signer.Account)
+		}
+		if lastAccountID == accountID {
+			return errors.New(counterpartyPrefix + "Duplicate Signers not allowed.")
+		}
+		if bytes.Compare(lastAccountID[:], accountID[:]) > 0 {
+			return errors.New(counterpartyPrefix + "Unsorted Signers array.")
+		}
+		lastAccountID = accountID
+
+		payload, encErr := binarycodec.EncodeForMultisigning(copyMap(txMap), signer.Account)
+		if encErr != nil {
+			return fmt.Errorf("%sInvalid signature on account %s.", counterpartyPrefix, signer.Account)
+		}
+		if !verifySignatureForKey(payload, signer.SigningPubKey, signer.TxnSignature, mustBeFullyCanonical) {
+			return fmt.Errorf("%sInvalid signature on account %s.", counterpartyPrefix, signer.Account)
+		}
+	}
+	return nil
+}
+
+// SignCounterparty produces a single-signed CounterpartySignature over the
+// transaction's signing payload — the same payload the top-level signer covers
+// (rippled STTx::sign with a signatureTarget writes into the nested object).
+// The transaction must already carry the top-level SigningPubKey the primary
+// signer used, since that key is part of the signed data. pubKeyHex is the
+// counterparty's public key, placed in the returned object.
+func SignCounterparty(tx txcore.Transaction, pubKeyHex, privateKeyHex string) (*txcore.CounterpartySignature, error) {
+	sig, err := SignTransaction(tx, privateKeyHex)
+	if err != nil {
+		return nil, err
+	}
+	return &txcore.CounterpartySignature{SigningPubKey: pubKeyHex, TxnSignature: sig}, nil
+}
+
 // copyMap creates a shallow copy of a map to avoid modifying the original
 func copyMap(m map[string]any) map[string]any {
 	result := make(map[string]any, len(m))

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -176,6 +176,43 @@ type SignerWrapper struct {
 	Signer Signer `json:"Signer"`
 }
 
+// CounterpartySignature is the nested signature object (sfCounterpartySignature).
+// It lets a second party attach a signature to a transaction without being the
+// signing Account. It carries a single signature (SigningPubKey + TxnSignature)
+// or a multi-signature (empty SigningPubKey + Signers). The field is excluded
+// from the transaction's signing data (notSigning), so neither the top-level
+// signer nor the counterparty covers it.
+type CounterpartySignature struct {
+	SigningPubKey string          `json:"SigningPubKey,omitempty"`
+	TxnSignature  string          `json:"TxnSignature,omitempty"`
+	Signers       []SignerWrapper `json:"Signers,omitempty"`
+}
+
+// ToMap serializes the counterparty object for the binary codec. SigningPubKey
+// is always emitted — a single-signed object carries the signer's key and a
+// multi-signed object carries an empty key — so a decode/encode round-trip
+// reproduces the original wire bytes.
+func (cs *CounterpartySignature) ToMap() map[string]any {
+	m := map[string]any{"SigningPubKey": cs.SigningPubKey}
+	if cs.TxnSignature != "" {
+		m["TxnSignature"] = cs.TxnSignature
+	}
+	if len(cs.Signers) > 0 {
+		signers := make([]map[string]any, len(cs.Signers))
+		for i, sw := range cs.Signers {
+			signers[i] = map[string]any{
+				"Signer": map[string]any{
+					"Account":       sw.Signer.Account,
+					"SigningPubKey": sw.Signer.SigningPubKey,
+					"TxnSignature":  sw.Signer.TxnSignature,
+				},
+			}
+		}
+		m["Signers"] = signers
+	}
+	return m
+}
+
 // Common contains fields common to all transaction types
 type Common struct {
 	// Required fields
@@ -199,6 +236,11 @@ type Common struct {
 	SigningPubKey      string          `json:"SigningPubKey,omitempty"`
 	TicketSequence     *uint32         `json:"TicketSequence,omitempty"`
 	TxnSignature       string          `json:"TxnSignature,omitempty"`
+
+	// CounterpartySignature is a nested signature attached by a second party.
+	// It is excluded from the transaction's signing data and verified
+	// separately after the top-level signature.
+	CounterpartySignature *CounterpartySignature `json:"CounterpartySignature,omitempty"`
 
 	// Delegate is the account delegating permission to execute this transaction.
 	// When present, the fee is charged to the delegate and signature is verified
@@ -413,6 +455,9 @@ func (c *Common) ToMap() map[string]any {
 	}
 	if c.TxnSignature != "" {
 		m["TxnSignature"] = c.TxnSignature
+	}
+	if c.CounterpartySignature != nil {
+		m["CounterpartySignature"] = c.CounterpartySignature.ToMap()
 	}
 	if c.Delegate != "" {
 		m["Delegate"] = c.Delegate


### PR DESCRIPTION
## Summary

Implements the rippled 3.0.0 **counterparty-signature** machinery (v3.0.0 Phase B) in goXRPL: the `sfCounterpartySignature` inner object, generalized sign/verify that recurses into a nested signature object, the Batch nested-signature checks, and the `signature_target` signing-RPC parameter.

`sfCounterpartySignature` is wire-format + verification groundwork for future multi-role transactions (Lending). No currently activated transaction type uses it — in rippled 3.0.0 it appears only on `LoanSet` (gated by `featureLendingProtocol`), which goXRPL does not implement — but a 3.0.0 node must reject invalid counterparty signatures to avoid consensus divergence, so the verification and batch checks are wired in generically.

## Changes

- **Wire format** (`internal/tx/transaction.go`): `Common` gains a `CounterpartySignature` object (`SigningPubKey` / `TxnSignature` / `Signers`). It is excluded from the signing data (`notSigning`, already recognised by the codec from Phase A), so neither the top-level signer nor the counterparty covers it, and it round-trips through the binary codec.
- **Generalized verify** (`internal/tx/sign/signature.go`): `VerifyCounterpartySignature` mirrors rippled `STTx::checkSign(sigObject)` — single- or multi-sign over the *same* signing payload as the top level, crypto-only (no signer-list/quorum authorization, and a counterparty may sign for the transaction's own `Account`). Errors are prefixed `"Counterparty: "`. `SignCounterparty` builds a single-signed object.
- **Engine** (`internal/tx/engine/preflight.go`): after the top-level signature passes, `verifySignatures` verifies a present `CounterpartySignature`; a failure is `checkValidity`'s `SigBad` → `temINVALID`. Honours `SkipSignatureVerification`.
- **Batch** (`internal/tx/batch/batch.go`): the inner-tx signature-field checks are factored into `checkInnerSignatureFields` (TxnSignature → `temBAD_SIGNATURE`, Signers → `temBAD_SIGNER`, non-empty SigningPubKey → `temBAD_REGKEY`) and applied to each inner transaction **and** its nested `CounterpartySignature`, mirroring rippled `Batch::preflight`'s `checkSignatureFields` lambda.
- **RPC `signature_target`** (`sign_helper.go`, `sign.go`, `submit.go`, `sign_for.go`): names an inner-object SField; only `CounterpartySignature` is valid (otherwise `rpcINVALID_PARAMS` with the field name). When present, the signature (and `Signers` for `sign_for`) is written into the nested object, the account/secret ownership check is skipped, and the top-level `SigningPubKey` (the primary signer's) is preserved.

## Tests

- `internal/tx/sign/counterparty_signature_test.go`: byte-level proof that `CounterpartySignature` is excluded from the signing payload; encode/decode wire round-trip; single-sign valid / wrong-key; multi-sign valid / wrong-key / unsorted / self-sign-allowed; single-and-multi rejected.
- `internal/tx/batch/counterparty_signature_test.go`: inner-tx nested signature fields → the three `tem` codes; empty nested object allowed.
- `internal/rpc/sign_counterparty_test.go`: `signature_target` happy path (produces a nested object whose signature verifies end-to-end), invalid target, ownership-check skip, and `sign_for` into the nested `Signers` array.

## Verification

- `just build-all` clean.
- Full `just test`: only the pre-existing out-of-scope conformance suite fails; its leaf-failure set is **byte-identical to the baseline** (182: Vault 138, Batch 25, XChain 14, XChainSim 1, Delegate 4) — no new failures.
- `golangci-lint run --config .golangci.yml ./...`: 0 issues.
- `docsgen` (rpcmethods + registries): no drift (`signature_target` is a parameter, not a new method/tx/amendment).

## Deviations

- The Batch counterparty checks in rippled's own tests use `LoanSet` inner transactions (`featureLendingProtocol`), which goXRPL does not implement; the Go tests exercise the same machinery with generic inner transactions carrying a `CounterpartySignature`, since the check is type-agnostic.

References rippled PRs #5594, #5829, #5851.

Closes #276; part of #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)