### PR TITLE
feat(rpc): rippled 3.0.0 RPC parity — pseudo_account, simulate meta, ledger_entry error codes

### DIFF
--- a/internal/rpc/account_info_pseudo_test.go
+++ b/internal/rpc/account_info_pseudo_test.go
@@ -1,0 +1,105 @@
+package rpc
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccountInfoPseudoAccount verifies the rippled 3.0.0 pseudo_account block:
+// an account root carrying a pseudo-account designator (AMMID / VaultID /
+// LoanBrokerID) surfaces result.pseudo_account.type (the field name minus
+// "ID"); a normal account omits it entirely.
+// Reference: rippled AccountInfo.cpp:153-173 (PR #5270).
+func TestAccountInfoPseudoAccount(t *testing.T) {
+	mock := newMockLedgerService()
+	services := newTestServices(mock)
+
+	method := &handlers.AccountInfoMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	validAccount := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	designatorHash := "AE0A97F385FFE42E3096BB352C7A2AA5B0E82C90D80E4DFD0EAABD5B2E4B6E1F"
+
+	// buildRaw serializes an AccountRoot with an optional designator field via
+	// the binary codec, matching what the service supplies in RawData.
+	buildRaw := func(designator string) []byte {
+		obj := map[string]any{
+			"LedgerEntryType": "AccountRoot",
+			"Account":         validAccount,
+			"Balance":         "100000000000",
+			"Flags":           uint32(0),
+			"OwnerCount":      uint32(0),
+			"Sequence":        uint32(1),
+		}
+		if designator != "" {
+			obj[designator] = designatorHash
+		}
+		encoded, err := binarycodec.Encode(obj)
+		require.NoError(t, err)
+		raw, err := hex.DecodeString(encoded)
+		require.NoError(t, err)
+		return raw
+	}
+
+	tests := []struct {
+		name         string
+		designator   string
+		expectedType string // "" means pseudo_account must be absent
+	}{
+		{"AMM pseudo-account", "AMMID", "AMM"},
+		{"Vault pseudo-account", "VaultID", "Vault"},
+		{"LoanBroker pseudo-account", "LoanBrokerID", "LoanBroker"},
+		{"normal account", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock.accountInfo = &types.AccountInfo{
+				Account:     validAccount,
+				Balance:     "100000000000",
+				Sequence:    1,
+				LedgerIndex: 2,
+				LedgerHash:  "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652",
+				Validated:   true,
+				RawData:     buildRaw(tc.designator),
+			}
+			mock.accountInfoErr = nil
+
+			paramsJSON, err := json.Marshal(map[string]any{"account": validAccount})
+			require.NoError(t, err)
+
+			result, rpcErr := method.Handle(ctx, paramsJSON)
+			require.Nil(t, rpcErr)
+			require.NotNil(t, result)
+
+			resp := result.(map[string]any)
+			if tc.expectedType == "" {
+				assert.NotContains(t, resp, "pseudo_account",
+					"normal account must not carry pseudo_account")
+				return
+			}
+
+			pseudo, ok := resp["pseudo_account"].(map[string]any)
+			require.True(t, ok, "pseudo_account should be present and an object")
+			assert.Equal(t, tc.expectedType, pseudo["type"])
+
+			// The designator hash stays in account_data, not under pseudo_account.
+			accountData := resp["account_data"].(map[string]any)
+			assert.Equal(t, designatorHash, accountData[tc.designator])
+			assert.NotContains(t, pseudo, tc.designator)
+		})
+	}
+}

--- a/internal/rpc/handlers/account_info.go
+++ b/internal/rpc/handlers/account_info.go
@@ -143,6 +143,7 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		"account_data":  accountData,
 		"account_flags": accountFlags,
 	}
+	addPseudoAccount(response, accountData)
 	fillLedgerFields(response, ledgerIndex, info.LedgerHash, info.LedgerIndex, info.Validated)
 
 	// Add queue data if requested (only for current/open ledger — validated above)
@@ -167,6 +168,24 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	}
 
 	return response, nil
+}
+
+// pseudoAccountFields are the AccountRoot designator fields, in the SOTemplate
+// order rippled iterates (getPseudoAccountFields). A pseudo-account carries
+// exactly one; the RPC reports its type by stripping the trailing "ID".
+var pseudoAccountFields = [...]string{"AMMID", "VaultID", "LoanBrokerID"}
+
+// addPseudoAccount sets response["pseudo_account"] = {"type": <name>} when the
+// account root carries a pseudo-account designator, matching rippled
+// doAccountInfo. The designator's own hash stays in account_data; only the
+// derived type name (field name minus "ID") is surfaced here.
+func addPseudoAccount(response, accountData map[string]any) {
+	for _, field := range pseudoAccountFields {
+		if _, present := accountData[field]; present {
+			response["pseudo_account"] = map[string]any{"type": strings.TrimSuffix(field, "ID")}
+			return
+		}
+	}
 }
 
 // buildAccountData constructs account_data from the full SLE binary.

--- a/internal/rpc/handlers/ledger_entry.go
+++ b/internal/rpc/handlers/ledger_entry.go
@@ -30,26 +30,36 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	}
 
 	// ledger_hash takes precedence over ledger_index, matching rippled's
-	// RPC::lookupLedger.
+	// RPC::ledgerFromRequest. A JSON null in either field is treated as absent
+	// (rippled's isNull() / isConvertibleTo checks), a present non-string
+	// ledger_hash is ledgerHashNotString, and an unparseable ledger_index is
+	// ledgerIndexMalformed.
 	ledgerIndex := "validated"
-	if lh, ok := rawParams["ledger_hash"]; ok {
+	if lh, ok := rawParams["ledger_hash"]; ok && !isJSONNull(lh) {
 		var lhStr string
 		if err := json.Unmarshal(lh, &lhStr); err != nil {
-			return nil, types.RpcErrorExpectedField("ledger_hash", "string")
+			return nil, types.RpcErrorInvalidParams("ledgerHashNotString")
 		}
 		if raw, err := hex.DecodeString(lhStr); err != nil || len(raw) != 32 {
 			return nil, types.RpcErrorInvalidParams("ledgerHashMalformed")
 		}
 		ledgerIndex = lhStr
-	} else if li, ok := rawParams["ledger_index"]; ok {
-		var liStr string
-		if err := json.Unmarshal(li, &liStr); err == nil {
+	} else if li, ok := rawParams["ledger_index"]; ok && !isJSONNull(li) {
+		tok := strings.TrimSpace(string(li))
+		if len(tok) > 0 && tok[0] == '"' {
+			var liStr string
+			if err := json.Unmarshal(li, &liStr); err != nil {
+				return nil, types.RpcErrorInvalidParams("ledgerIndexMalformed")
+			}
 			ledgerIndex = liStr
 		} else {
+			// A numeric ledger_index must be an integral, in-range uint32;
+			// objects/arrays/booleans/non-integral doubles are malformed.
 			var liNum uint32
-			if err := json.Unmarshal(li, &liNum); err == nil {
-				ledgerIndex = strings.TrimSpace(string(li))
+			if err := json.Unmarshal(li, &liNum); err != nil {
+				return nil, types.RpcErrorInvalidParams("ledgerIndexMalformed")
 			}
+			ledgerIndex = tok
 		}
 	}
 
@@ -235,7 +245,19 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// nftoken_offer: string (hex ID)
+	// nft_offer: string (hex ID) — rippled's canonical selector key
+	// (ledger_entries.macro rpcName). nftoken_offer is a go-xrpl alias.
+	if !keySet {
+		if raw, ok := rawParams["nft_offer"]; ok {
+			entryKey, rpcErr = parseHex256(raw, "nft_offer")
+			if rpcErr != nil {
+				return nil, rpcErr
+			}
+			keySet = true
+		}
+	}
+
+	// nftoken_offer: string (hex ID) — go-xrpl alias for nft_offer
 	if !keySet {
 		if raw, ok := rawParams["nftoken_offer"]; ok {
 			entryKey, rpcErr = parseHex256(raw, "nftoken_offer")
@@ -379,15 +401,32 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, types.RpcErrorUnknownOption("")
 	}
 
+	// The type the matched filter selects (rippled's per-filter expectedType).
+	// "" means the `index` alias (ltANY), which accepts any entry type.
+	expectedType := expectedLedgerEntryType(rawParams)
+
 	result, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, entryKey, ledgerIndex)
 	if err != nil {
 		if errors.Is(err, svcerr.ErrLedgerEntryNotFound) {
-			return nil, types.RpcErrorEntryNotFound("Requested ledger entry not found.")
+			return nil, types.RpcErrorEntryNotFound("")
 		}
 		if errors.Is(err, svcerr.ErrLedgerNotFound) {
 			return nil, types.RpcErrorLgrNotFound("ledgerNotFound")
 		}
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get ledger entry: %v", err))
+	}
+
+	// Decode the entry once — needed for the type check (in both output modes)
+	// and for the JSON node body.
+	decoded, decodeErr := decodeLedgerEntryNode(result.Node)
+
+	// unexpectedLedgerType: the entry found at the requested index must match
+	// the filter's type (rippled LedgerEntry.cpp:853-856). The `index` alias
+	// opts out via expectedType == "".
+	if expectedType != "" && decodeErr == nil {
+		if actual, _ := decoded["LedgerEntryType"].(string); actual != "" && actual != expectedType {
+			return nil, types.RpcErrorUnexpectedLedgerType()
+		}
 	}
 
 	response := map[string]any{
@@ -399,20 +438,80 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 
 	if binary {
 		response["node_binary"] = result.NodeBinary
+	} else if decodeErr == nil {
+		decoded["index"] = strings.ToUpper(result.Index)
+		response["node"] = decoded
 	} else {
-		// Decode to JSON
-		hexData := hex.EncodeToString(result.Node)
-		decoded, err := binarycodec.Decode(hexData)
-		if err != nil {
-			// Fallback to hex string
-			response["node"] = strings.ToUpper(hexData)
-		} else {
-			decoded["index"] = strings.ToUpper(result.Index)
-			response["node"] = decoded
-		}
+		response["node"] = strings.ToUpper(hex.EncodeToString(result.Node))
 	}
 
 	return response, nil
+}
+
+// decodeLedgerEntryNode decodes an SLE to its JSON object form. Production
+// nodes are binary (binarycodec); the test path supplies JSON directly, so a
+// JSON fallback keeps both working. Returns an error only when neither decodes.
+func decodeLedgerEntryNode(node []byte) (map[string]any, error) {
+	if decoded, err := binarycodec.Decode(hex.EncodeToString(node)); err == nil {
+		return decoded, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(node, &m); err == nil {
+		return m, nil
+	}
+	return nil, errors.New("ledger_entry: undecodable node")
+}
+
+// ledgerEntryFilterTypes maps each ledger_entry filter key to the
+// LedgerEntryType name it selects, in the handler's resolution priority order.
+// It mirrors rippled's per-filter expectedType (LedgerEntry.cpp dispatch
+// table). `index` is absent: it is the ltANY alias and skips the type check.
+var ledgerEntryFilterTypes = []struct {
+	key      string
+	typeName string
+}{
+	{"account_root", "AccountRoot"},
+	{"amm", "AMM"},
+	{"bridge", "Bridge"},
+	{"check", "Check"},
+	{"credential", "Credential"},
+	{"delegate", "Delegate"},
+	{"deposit_preauth", "DepositPreauth"},
+	{"did", "DID"},
+	{"directory", "DirectoryNode"},
+	{"escrow", "Escrow"},
+	{"mpt_issuance", "MPTokenIssuance"},
+	{"mptoken", "MPToken"},
+	{"nft_page", "NFTokenPage"},
+	{"nft_offer", "NFTokenOffer"},
+	{"nftoken_offer", "NFTokenOffer"},
+	{"offer", "Offer"},
+	{"oracle", "Oracle"},
+	{"payment_channel", "PayChannel"},
+	{"permissioned_domain", "PermissionedDomain"},
+	{"ripple_state", "RippleState"},
+	{"state", "RippleState"},
+	{"signer_list", "SignerList"},
+	{"ticket", "Ticket"},
+	{"vault", "Vault"},
+	{"xchain_owned_claim_id", "XChainOwnedClaimID"},
+	{"xchain_owned_create_account_claim_id", "XChainOwnedCreateAccountClaimID"},
+}
+
+// expectedLedgerEntryType returns the LedgerEntryType the matched filter
+// selects, or "" for the `index` alias (which accepts any type) and when no
+// typed filter is present. The `index` key is checked first because it has
+// resolution priority in the handler.
+func expectedLedgerEntryType(rawParams map[string]json.RawMessage) string {
+	if _, ok := rawParams["index"]; ok {
+		return ""
+	}
+	for _, f := range ledgerEntryFilterTypes {
+		if _, ok := rawParams[f.key]; ok {
+			return f.typeName
+		}
+	}
+	return ""
 }
 
 // decodeAccountID decodes a base58 account address to a 20-byte account ID

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -254,10 +254,16 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 
 	// rippled emits "meta" (JSON) when binary=false and "meta_blob" (hex)
 	// when binary=true. Always emit when Metadata is present, mirroring
-	// rippled's `if (result.metadata)` guard (Simulate.cpp:264-276).
+	// rippled's `if (result.metadata)` guard (Simulate.cpp:264-276). The
+	// synthetic fields (delivered_amount / nftoken_id / nftoken_ids / offer_id /
+	// mpt_issuance_id) are a JSON-meta-only enrichment; meta_blob carries only
+	// the raw serialized metadata (Simulate.cpp:277-288).
 	if result.Metadata != nil {
 		if binaryOutput {
 			response["meta_blob"] = strings.ToUpper(hex.EncodeToString(result.Metadata.Blob))
+		} else if metaMap := metadataToMap(result.Metadata.JSON); metaMap != nil {
+			enrichSimulateMeta(metaMap, txJsonMap)
+			response["meta"] = metaMap
 		} else {
 			response["meta"] = result.Metadata.JSON
 		}

--- a/internal/rpc/handlers/synthetic_meta.go
+++ b/internal/rpc/handlers/synthetic_meta.go
@@ -1,0 +1,292 @@
+package handlers
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// metadataToMap renders simulation metadata as a mutable JSON object so
+// synthetic fields can be injected. The production adapter supplies a typed
+// *tx.Metadata (marshalled here via its MarshalJSON); a value that is already a
+// map is returned as-is. Returns nil when the metadata cannot be rendered.
+func metadataToMap(meta any) map[string]any {
+	if m, ok := meta.(map[string]any); ok {
+		return m
+	}
+	b, err := json.Marshal(meta)
+	if err != nil {
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil
+	}
+	return m
+}
+
+// enrichSimulateMeta injects rippled's synthetic transaction-metadata fields
+// (delivered_amount, nftoken_id / nftoken_ids, offer_id, mpt_issuance_id) into
+// a simulated transaction's `meta` JSON, matching what tx / account_tx report
+// for validated transactions. All of these require tesSUCCESS and are computed
+// from the metadata's AffectedNodes, so a failed simulation is a no-op.
+// Reference: rippled Simulate.cpp:277-288 (insertDeliveredAmount /
+// insertNFTSyntheticInJson / insertMPTokenIssuanceID).
+func enrichSimulateMeta(meta, txJSON map[string]any) {
+	if meta == nil {
+		return
+	}
+	if result, _ := meta["TransactionResult"].(string); result != "tesSUCCESS" {
+		return
+	}
+	txType, _ := txJSON["TransactionType"].(string)
+
+	insertSimulateDeliveredAmount(meta, txJSON, txType)
+	insertNFTSynthetic(meta, txJSON, txType)
+	insertMPTokenIssuanceID(meta, txJSON, txType)
+}
+
+// insertSimulateDeliveredAmount mirrors rippled insertDeliveredAmount /
+// getDeliveredAmount for a simulated (current open ledger) transaction. Only
+// Payment / CheckCash / AccountDelete carry a delivered amount. If the engine
+// already recorded one it is kept; otherwise the transaction's Amount is used
+// (a simulation always runs against a recent-enough ledger for the fix1623
+// fallback), falling back to "unavailable" when there is no Amount.
+func insertSimulateDeliveredAmount(meta, txJSON map[string]any, txType string) {
+	switch txType {
+	case "Payment", "CheckCash", "AccountDelete":
+	default:
+		return
+	}
+	if _, ok := meta["delivered_amount"]; ok {
+		return
+	}
+	if amount, ok := txJSON["Amount"]; ok {
+		meta["delivered_amount"] = amount
+	} else {
+		meta["delivered_amount"] = "unavailable"
+	}
+}
+
+// insertNFTSynthetic mirrors rippled insertNFTSyntheticInJson: nftoken_id /
+// nftoken_ids for mint / accept-offer / cancel-offer, and offer_id for a
+// create-offer (or a mint that also lists the token via an Amount).
+func insertNFTSynthetic(meta, txJSON map[string]any, txType string) {
+	nodes := affectedNodes(meta)
+
+	switch txType {
+	case "NFTokenMint":
+		if id, ok := nftokenIDFromPage(nodes); ok {
+			meta["nftoken_id"] = id
+		}
+	case "NFTokenAcceptOffer":
+		if ids := nftokenIDsFromDeletedOffers(nodes); len(ids) > 0 {
+			meta["nftoken_id"] = ids[0]
+		}
+	case "NFTokenCancelOffer":
+		ids := nftokenIDsFromDeletedOffers(nodes)
+		arr := make([]any, len(ids))
+		for i, id := range ids {
+			arr[i] = id
+		}
+		meta["nftoken_ids"] = arr
+	}
+
+	if txType == "NFTokenCreateOffer" || (txType == "NFTokenMint" && hasKey(txJSON, "Amount")) {
+		if id, ok := offerIDFromCreatedOffer(nodes); ok {
+			meta["offer_id"] = id
+		}
+	}
+}
+
+// insertMPTokenIssuanceID mirrors rippled insertMPTokenIssuanceID: the id of
+// the MPTokenIssuance created by an MPTokenIssuanceCreate, derived from the
+// created issuance's Sequence and Issuer (makeMptID).
+func insertMPTokenIssuanceID(meta, txJSON map[string]any, txType string) {
+	if txType != "MPTokenIssuanceCreate" {
+		return
+	}
+	for _, n := range affectedNodes(meta) {
+		action, inner := nodeParts(n)
+		if action != "CreatedNode" || nodeType(inner) != "MPTokenIssuance" {
+			continue
+		}
+		nf, _ := inner["NewFields"].(map[string]any)
+		seq, ok := jsonUint32(nf["Sequence"])
+		if !ok {
+			continue
+		}
+		issuer, _ := nf["Issuer"].(string)
+		accountID, err := decodeAccountID(issuer)
+		if err != nil {
+			continue
+		}
+		mptID := keylet.MakeMPTID(seq, accountID)
+		meta["mpt_issuance_id"] = strings.ToUpper(hex.EncodeToString(mptID[:]))
+		return
+	}
+}
+
+// nftokenIDFromPage extracts the newly minted NFTokenID by diffing the final
+// against the previous NFTokenIDs across all affected NFTokenPage nodes
+// (rippled getNFTokenIDFromPage). The added token is the single element present
+// in the final set but not the previous one.
+func nftokenIDFromPage(nodes []any) (string, bool) {
+	var prevIDs, finalIDs []string
+	for _, n := range nodes {
+		action, inner := nodeParts(n)
+		if nodeType(inner) != "NFTokenPage" {
+			continue
+		}
+		switch action {
+		case "CreatedNode":
+			nf, _ := inner["NewFields"].(map[string]any)
+			finalIDs = append(finalIDs, nftokenIDsInFields(nf)...)
+		case "ModifiedNode":
+			prev, _ := inner["PreviousFields"].(map[string]any)
+			// A page whose NFTokens did not change (only page-link fields did)
+			// carries no NFTokens in PreviousFields and must be skipped.
+			if _, has := prev["NFTokens"]; !has {
+				continue
+			}
+			prevIDs = append(prevIDs, nftokenIDsInFields(prev)...)
+			fin, _ := inner["FinalFields"].(map[string]any)
+			finalIDs = append(finalIDs, nftokenIDsInFields(fin)...)
+		}
+	}
+
+	// NFTs are added one at a time, so the final set is exactly one longer.
+	if len(finalIDs) != len(prevIDs)+1 {
+		return "", false
+	}
+	for i := range finalIDs {
+		if i >= len(prevIDs) || finalIDs[i] != prevIDs[i] {
+			return finalIDs[i], true
+		}
+	}
+	return "", false
+}
+
+// nftokenIDsFromDeletedOffers collects the NFTokenIDs of every deleted
+// NFTokenOffer, sorted and de-duplicated (rippled getNFTokenIDFromDeletedOffer).
+func nftokenIDsFromDeletedOffers(nodes []any) []string {
+	var ids []string
+	for _, n := range nodes {
+		action, inner := nodeParts(n)
+		if action != "DeletedNode" || nodeType(inner) != "NFTokenOffer" {
+			continue
+		}
+		ff, _ := inner["FinalFields"].(map[string]any)
+		if id, _ := ff["NFTokenID"].(string); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return dedupSorted(ids)
+}
+
+// offerIDFromCreatedOffer returns the ledger index of the first created
+// NFTokenOffer (rippled getOfferIDFromCreatedOffer).
+func offerIDFromCreatedOffer(nodes []any) (string, bool) {
+	for _, n := range nodes {
+		action, inner := nodeParts(n)
+		if action != "CreatedNode" || nodeType(inner) != "NFTokenOffer" {
+			continue
+		}
+		if id, _ := inner["LedgerIndex"].(string); id != "" {
+			return id, true
+		}
+	}
+	return "", false
+}
+
+// affectedNodes returns the AffectedNodes array of a metadata JSON map.
+func affectedNodes(meta map[string]any) []any {
+	nodes, _ := meta["AffectedNodes"].([]any)
+	return nodes
+}
+
+// nodeParts returns the node action (CreatedNode / ModifiedNode / DeletedNode)
+// and its inner object for one AffectedNodes element.
+func nodeParts(n any) (string, map[string]any) {
+	m, ok := n.(map[string]any)
+	if !ok {
+		return "", nil
+	}
+	for _, action := range [...]string{"CreatedNode", "ModifiedNode", "DeletedNode"} {
+		if inner, ok := m[action].(map[string]any); ok {
+			return action, inner
+		}
+	}
+	return "", nil
+}
+
+// nodeType returns an affected node's LedgerEntryType.
+func nodeType(inner map[string]any) string {
+	t, _ := inner["LedgerEntryType"].(string)
+	return t
+}
+
+// nftokenIDsInFields extracts the NFTokenIDs from a fields object's NFTokens
+// array (each element is {"NFToken": {"NFTokenID": ...}}).
+func nftokenIDsInFields(fields map[string]any) []string {
+	arr, ok := fields["NFTokens"].([]any)
+	if !ok {
+		return nil
+	}
+	ids := make([]string, 0, len(arr))
+	for _, el := range arr {
+		wrapper, ok := el.(map[string]any)
+		if !ok {
+			continue
+		}
+		token, ok := wrapper["NFToken"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if id, _ := token["NFTokenID"].(string); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// jsonUint32 coerces a JSON-decoded numeric value to a uint32.
+func jsonUint32(v any) (uint32, bool) {
+	switch n := v.(type) {
+	case float64:
+		if n >= 0 && n <= 4294967295 {
+			return uint32(n), true
+		}
+	case uint32:
+		return n, true
+	case json.Number:
+		if i, err := n.Int64(); err == nil && i >= 0 && i <= 4294967295 {
+			return uint32(i), true
+		}
+	}
+	return 0, false
+}
+
+// hasKey reports whether a JSON object carries a non-null value for key.
+func hasKey(m map[string]any, key string) bool {
+	v, ok := m[key]
+	return ok && v != nil
+}
+
+// dedupSorted removes adjacent duplicates from a sorted slice in place.
+func dedupSorted(s []string) []string {
+	if len(s) < 2 {
+		return s
+	}
+	out := s[:1]
+	for _, v := range s[1:] {
+		if v != out[len(out)-1] {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/internal/rpc/handlers/synthetic_meta_test.go
+++ b/internal/rpc/handlers/synthetic_meta_test.go
@@ -1,0 +1,170 @@
+package handlers
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nftPageNode builds an NFTokenPage affected node with the given NFTokenIDs in
+// the named fields object (NewFields / FinalFields / PreviousFields).
+func nftPageNode(action, fieldsKey string, ids ...string) map[string]any {
+	tokens := make([]any, len(ids))
+	for i, id := range ids {
+		tokens[i] = map[string]any{"NFToken": map[string]any{"NFTokenID": id}}
+	}
+	return map[string]any{
+		action: map[string]any{
+			"LedgerEntryType": "NFTokenPage",
+			fieldsKey:         map[string]any{"NFTokens": tokens},
+		},
+	}
+}
+
+func deletedOfferNode(nftokenID string) map[string]any {
+	return map[string]any{
+		"DeletedNode": map[string]any{
+			"LedgerEntryType": "NFTokenOffer",
+			"FinalFields":     map[string]any{"NFTokenID": nftokenID},
+		},
+	}
+}
+
+func TestEnrichSimulateMeta_DeliveredAmount(t *testing.T) {
+	t.Run("payment without engine amount falls back to tx Amount", func(t *testing.T) {
+		meta := map[string]any{"TransactionResult": "tesSUCCESS", "AffectedNodes": []any{}}
+		enrichSimulateMeta(meta, map[string]any{"TransactionType": "Payment", "Amount": "100"})
+		assert.Equal(t, "100", meta["delivered_amount"])
+	})
+
+	t.Run("engine-recorded delivered_amount is preserved", func(t *testing.T) {
+		meta := map[string]any{"TransactionResult": "tesSUCCESS", "delivered_amount": "50", "AffectedNodes": []any{}}
+		enrichSimulateMeta(meta, map[string]any{"TransactionType": "Payment", "Amount": "100"})
+		assert.Equal(t, "50", meta["delivered_amount"])
+	})
+
+	t.Run("non-payment gets no delivered_amount", func(t *testing.T) {
+		meta := map[string]any{"TransactionResult": "tesSUCCESS", "AffectedNodes": []any{}}
+		enrichSimulateMeta(meta, map[string]any{"TransactionType": "AccountSet"})
+		assert.NotContains(t, meta, "delivered_amount")
+	})
+
+	t.Run("failed transaction is a no-op", func(t *testing.T) {
+		meta := map[string]any{"TransactionResult": "tecUNFUNDED_PAYMENT", "AffectedNodes": []any{}}
+		enrichSimulateMeta(meta, map[string]any{"TransactionType": "Payment", "Amount": "100"})
+		assert.NotContains(t, meta, "delivered_amount")
+	})
+}
+
+func TestEnrichSimulateMeta_NFTokenMint(t *testing.T) {
+	idA := "000800001234567890ABCDEF1234567890ABCDEF1234567890ABCDEF00000001"
+	idB := "000800001234567890ABCDEF1234567890ABCDEF1234567890ABCDEF00000002"
+
+	t.Run("modified page reveals the added token", func(t *testing.T) {
+		meta := map[string]any{
+			"TransactionResult": "tesSUCCESS",
+			"AffectedNodes": []any{
+				map[string]any{"ModifiedNode": map[string]any{
+					"LedgerEntryType": "NFTokenPage",
+					"PreviousFields":  map[string]any{"NFTokens": []any{map[string]any{"NFToken": map[string]any{"NFTokenID": idA}}}},
+					"FinalFields": map[string]any{"NFTokens": []any{
+						map[string]any{"NFToken": map[string]any{"NFTokenID": idA}},
+						map[string]any{"NFToken": map[string]any{"NFTokenID": idB}},
+					}},
+				}},
+			},
+		}
+		enrichSimulateMeta(meta, map[string]any{"TransactionType": "NFTokenMint"})
+		assert.Equal(t, idB, meta["nftoken_id"])
+	})
+
+	t.Run("created page (first token) reveals the added token", func(t *testing.T) {
+		meta := map[string]any{
+			"TransactionResult": "tesSUCCESS",
+			"AffectedNodes":     []any{nftPageNode("CreatedNode", "NewFields", idB)},
+		}
+		enrichSimulateMeta(meta, map[string]any{"TransactionType": "NFTokenMint"})
+		assert.Equal(t, idB, meta["nftoken_id"])
+	})
+
+	t.Run("mint that lists the token also emits offer_id", func(t *testing.T) {
+		offerIndex := "AAAA0000000000000000000000000000000000000000000000000000000000FF"
+		meta := map[string]any{
+			"TransactionResult": "tesSUCCESS",
+			"AffectedNodes": []any{
+				nftPageNode("CreatedNode", "NewFields", idB),
+				map[string]any{"CreatedNode": map[string]any{
+					"LedgerEntryType": "NFTokenOffer",
+					"LedgerIndex":     offerIndex,
+				}},
+			},
+		}
+		enrichSimulateMeta(meta, map[string]any{"TransactionType": "NFTokenMint", "Amount": "10"})
+		assert.Equal(t, idB, meta["nftoken_id"])
+		assert.Equal(t, offerIndex, meta["offer_id"])
+	})
+}
+
+func TestEnrichSimulateMeta_NFTokenOffers(t *testing.T) {
+	idA := "000800001234567890ABCDEF1234567890ABCDEF1234567890ABCDEF0000000A"
+	idB := "000800001234567890ABCDEF1234567890ABCDEF1234567890ABCDEF0000000B"
+
+	t.Run("accept-offer emits scalar nftoken_id", func(t *testing.T) {
+		meta := map[string]any{
+			"TransactionResult": "tesSUCCESS",
+			"AffectedNodes":     []any{deletedOfferNode(idA)},
+		}
+		enrichSimulateMeta(meta, map[string]any{"TransactionType": "NFTokenAcceptOffer"})
+		assert.Equal(t, idA, meta["nftoken_id"])
+	})
+
+	t.Run("cancel-offer emits sorted, de-duplicated nftoken_ids array", func(t *testing.T) {
+		meta := map[string]any{
+			"TransactionResult": "tesSUCCESS",
+			"AffectedNodes":     []any{deletedOfferNode(idB), deletedOfferNode(idA), deletedOfferNode(idB)},
+		}
+		enrichSimulateMeta(meta, map[string]any{"TransactionType": "NFTokenCancelOffer"})
+		assert.Equal(t, []any{idA, idB}, meta["nftoken_ids"])
+	})
+
+	t.Run("create-offer emits offer_id from the created offer", func(t *testing.T) {
+		offerIndex := "BBBB0000000000000000000000000000000000000000000000000000000000FF"
+		meta := map[string]any{
+			"TransactionResult": "tesSUCCESS",
+			"AffectedNodes": []any{
+				map[string]any{"CreatedNode": map[string]any{
+					"LedgerEntryType": "NFTokenOffer",
+					"LedgerIndex":     offerIndex,
+				}},
+			},
+		}
+		enrichSimulateMeta(meta, map[string]any{"TransactionType": "NFTokenCreateOffer"})
+		assert.Equal(t, offerIndex, meta["offer_id"])
+	})
+}
+
+func TestEnrichSimulateMeta_MPTokenIssuanceID(t *testing.T) {
+	issuer := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	seq := uint32(42)
+
+	accountID, err := decodeAccountID(issuer)
+	require.NoError(t, err)
+	mptID := keylet.MakeMPTID(seq, accountID)
+	want := strings.ToUpper(hex.EncodeToString(mptID[:]))
+
+	meta := map[string]any{
+		"TransactionResult": "tesSUCCESS",
+		"AffectedNodes": []any{
+			map[string]any{"CreatedNode": map[string]any{
+				"LedgerEntryType": "MPTokenIssuance",
+				"NewFields":       map[string]any{"Sequence": float64(seq), "Issuer": issuer},
+			}},
+		},
+	}
+	enrichSimulateMeta(meta, map[string]any{"TransactionType": "MPTokenIssuanceCreate"})
+	assert.Equal(t, want, meta["mpt_issuance_id"])
+}

--- a/internal/rpc/handlers/vault_info.go
+++ b/internal/rpc/handlers/vault_info.go
@@ -74,7 +74,7 @@ func (m *VaultInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		if rerr := mapLedgerLookupErr(err); rerr != nil {
 			return nil, rerr
 		}
-		return nil, types.RpcErrorEntryNotFound("Vault not found")
+		return nil, types.RpcErrorEntryNotFoundBare("Vault not found")
 	}
 
 	vaultDecoded, decodeErr := binarycodec.Decode(hex.EncodeToString(vaultEntry.Node))

--- a/internal/rpc/ledger_entry_test.go
+++ b/internal/rpc/ledger_entry_test.go
@@ -46,12 +46,16 @@ func (m *mockLedgerEntryService) GetLedgerEntry(_ context.Context, entryKey [32]
 	if m.ledgerEntryResult != nil {
 		return m.ledgerEntryResult, nil
 	}
-	// Default result
+	// Default result. The node deliberately omits LedgerEntryType so the naive
+	// "any key returns this node" stub does not spuriously trip the 3.0.0
+	// unexpectedLedgerType check in tests that only exercise key derivation.
+	// Type-match behaviour is covered by dedicated tests that set an explicit
+	// LedgerEntryType.
 	return &types.LedgerEntryResult{
 		Index:       hex.EncodeToString(entryKey[:]),
 		LedgerIndex: m.validatedLedgerIndex,
 		LedgerHash:  [32]byte{0x4B, 0xC5, 0x0C, 0x9B, 0x0D, 0x85, 0x15, 0xD3, 0xEA, 0xAE, 0x1E, 0x74, 0xB2, 0x9A, 0x95, 0x80, 0x43, 0x46, 0xC4, 0x91, 0xEE, 0x1A, 0x95, 0xBF, 0x25, 0xE4, 0xAA, 0xB8, 0x54, 0xA6, 0xA6, 0x52},
-		Node:        []byte(`{"LedgerEntryType": "AccountRoot", "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"}`),
+		Node:        []byte(`{"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"}`),
 		Validated:   true,
 	}, nil
 }
@@ -1277,8 +1281,9 @@ func TestLedgerEntryNotFoundErrorCode(t *testing.T) {
 
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
-	assert.Equal(t, -1, rpcErr.Code, "Entry not found returns rippled's bare entryNotFound token (code -1)")
-	assert.Contains(t, rpcErr.Message, "not found")
+	assert.Equal(t, types.RpcENTRY_NOT_FOUND, rpcErr.Code, "ledger_entry returns rpcENTRY_NOT_FOUND (98) in rippled 3.0.0")
+	assert.Equal(t, "entryNotFound", rpcErr.ErrorString)
+	assert.Equal(t, "Entry not found.", rpcErr.Message)
 }
 
 // AccountRoot Entry Tests
@@ -2089,13 +2094,11 @@ func TestLedgerEntryUnexpectedType(t *testing.T) {
 		Services:   services,
 	}
 
-	// Test requesting an entry using the wrong type
-	// e.g., using an AccountRoot index when requesting a check
-	t.Run("Entry type mismatch should succeed with index lookup", func(t *testing.T) {
-		// When using direct index lookup, it returns whatever entry is at that index
-		// regardless of what type was expected
-		accountRootIndex := "9CE54C3B934E473A995B477E92EC229F99CED5B62BF4D2ACE4DC42719103AE2F"
+	accountRootIndex := "9CE54C3B934E473A995B477E92EC229F99CED5B62BF4D2ACE4DC42719103AE2F"
 
+	// A typed selector whose key resolves to a different entry type returns
+	// rpcUNEXPECTED_LEDGER_TYPE (rippled 3.0.0 LedgerEntry.cpp:853-856).
+	t.Run("typed selector on mismatched entry returns unexpectedLedgerType", func(t *testing.T) {
 		mock.ledgerEntryResult = &types.LedgerEntryResult{
 			Index:       accountRootIndex,
 			LedgerIndex: 3,
@@ -2105,7 +2108,7 @@ func TestLedgerEntryUnexpectedType(t *testing.T) {
 		}
 		mock.ledgerEntryErr = nil
 
-		// Using check field but providing an AccountRoot index
+		// The `check` selector expects a Check, but the entry is an AccountRoot.
 		params := map[string]any{
 			"check":        accountRootIndex,
 			"ledger_index": "validated",
@@ -2115,9 +2118,34 @@ func TestLedgerEntryUnexpectedType(t *testing.T) {
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 
-		// Current implementation does direct index lookup, so it returns the entry
-		require.Nil(t, rpcErr, "Direct index lookup should succeed")
-		require.NotNil(t, result, "Expected result")
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr, "Expected unexpectedLedgerType error")
+		assert.Equal(t, types.RpcUNEXPECTED_LEDGER_TYPE, rpcErr.Code)
+		assert.Equal(t, "unexpectedLedgerType", rpcErr.ErrorString)
+		assert.Equal(t, "Unexpected ledger type.", rpcErr.Message)
+	})
+
+	// The `index` alias (ltANY) accepts any entry type — no type check.
+	t.Run("index selector accepts any entry type", func(t *testing.T) {
+		mock.ledgerEntryResult = &types.LedgerEntryResult{
+			Index:       accountRootIndex,
+			LedgerIndex: 3,
+			LedgerHash:  [32]byte{0x4B, 0xC5, 0x0C, 0x9B},
+			Node:        []byte(`{"LedgerEntryType": "AccountRoot", "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"}`),
+			Validated:   true,
+		}
+		mock.ledgerEntryErr = nil
+
+		params := map[string]any{
+			"index":        accountRootIndex,
+			"ledger_index": "validated",
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr, "index lookup must not type-check")
+		require.NotNil(t, result)
 	})
 }
 
@@ -2435,11 +2463,13 @@ func TestLedgerEntryHexValidation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if !tc.expectError {
+				// This case exercises hex validation only; the node is left
+				// type-agnostic so it does not trip the unexpectedLedgerType check.
 				mock.ledgerEntryResult = &types.LedgerEntryResult{
 					Index:       tc.paramValue,
 					LedgerIndex: 2,
 					LedgerHash:  [32]byte{0x4B, 0xC5, 0x0C, 0x9B},
-					Node:        []byte(`{"LedgerEntryType": "AccountRoot"}`),
+					Node:        []byte(`{"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"}`),
 					Validated:   true,
 				}
 				mock.ledgerEntryErr = nil

--- a/internal/rpc/ledger_entry_validation_test.go
+++ b/internal/rpc/ledger_entry_validation_test.go
@@ -1,0 +1,150 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLedgerEntryLedgerSelectorValidation covers the rippled 3.0.0
+// ledgerFromRequest drift: null ledger_hash / ledger_index are treated as
+// absent, a non-string ledger_hash is ledgerHashNotString, and an unparseable
+// ledger_index is ledgerIndexMalformed (all invalidParams, code 31).
+func TestLedgerEntryLedgerSelectorValidation(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	services := newLedgerEntryTestServices(mock)
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	validIndex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
+
+	tests := []struct {
+		name       string
+		params     map[string]any
+		expectErr  bool
+		expectMsg  string
+		expectCode int
+	}{
+		{
+			name:       "non-string ledger_hash is ledgerHashNotString",
+			params:     map[string]any{"index": validIndex, "ledger_hash": 12345},
+			expectErr:  true,
+			expectMsg:  "ledgerHashNotString",
+			expectCode: types.RpcINVALID_PARAMS,
+		},
+		{
+			name:       "bad-hex ledger_hash is ledgerHashMalformed",
+			params:     map[string]any{"index": validIndex, "ledger_hash": "not-hex"},
+			expectErr:  true,
+			expectMsg:  "ledgerHashMalformed",
+			expectCode: types.RpcINVALID_PARAMS,
+		},
+		{
+			name:      "null ledger_hash is treated as absent",
+			params:    map[string]any{"index": validIndex, "ledger_hash": nil},
+			expectErr: false,
+		},
+		{
+			name:       "object ledger_index is ledgerIndexMalformed",
+			params:     map[string]any{"index": validIndex, "ledger_index": map[string]any{"x": 1}},
+			expectErr:  true,
+			expectMsg:  "ledgerIndexMalformed",
+			expectCode: types.RpcINVALID_PARAMS,
+		},
+		{
+			name:       "non-integral ledger_index is ledgerIndexMalformed",
+			params:     map[string]any{"index": validIndex, "ledger_index": 2.5},
+			expectErr:  true,
+			expectMsg:  "ledgerIndexMalformed",
+			expectCode: types.RpcINVALID_PARAMS,
+		},
+		{
+			name:      "null ledger_index is treated as absent",
+			params:    map[string]any{"index": validIndex, "ledger_index": nil},
+			expectErr: false,
+		},
+		{
+			name:      "string ledger_index keyword still works",
+			params:    map[string]any{"index": validIndex, "ledger_index": "validated"},
+			expectErr: false,
+		},
+		{
+			name:      "integer ledger_index still works",
+			params:    map[string]any{"index": validIndex, "ledger_index": 2},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock.ledgerEntryResult = nil
+			mock.ledgerEntryErr = nil
+
+			paramsJSON, err := json.Marshal(tc.params)
+			require.NoError(t, err)
+
+			result, rpcErr := method.Handle(ctx, paramsJSON)
+			if tc.expectErr {
+				assert.Nil(t, result)
+				require.NotNil(t, rpcErr)
+				assert.Equal(t, tc.expectCode, rpcErr.Code)
+				assert.Equal(t, tc.expectMsg, rpcErr.Message)
+			} else {
+				require.Nil(t, rpcErr, "unexpected error: %v", rpcErr)
+				require.NotNil(t, result)
+			}
+		})
+	}
+}
+
+// TestLedgerEntryNFTOfferAlias verifies the canonical rippled `nft_offer`
+// selector and the go-xrpl `nftoken_offer` alias both resolve to a lookup and
+// pass the type check for an NFTokenOffer entry.
+func TestLedgerEntryNFTOfferAlias(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	services := newLedgerEntryTestServices(mock)
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	offerIndex := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
+
+	for _, key := range []string{"nft_offer", "nftoken_offer"} {
+		t.Run(key, func(t *testing.T) {
+			mock.ledgerEntryResult = &types.LedgerEntryResult{
+				Index:       offerIndex,
+				LedgerIndex: 2,
+				LedgerHash:  [32]byte{0x4B, 0xC5, 0x0C, 0x9B},
+				Node:        []byte(`{"LedgerEntryType": "NFTokenOffer", "Amount": "1"}`),
+				Validated:   true,
+			}
+			mock.ledgerEntryErr = nil
+
+			paramsJSON, err := json.Marshal(map[string]any{
+				key:            offerIndex,
+				"ledger_index": "validated",
+			})
+			require.NoError(t, err)
+
+			result, rpcErr := method.Handle(ctx, paramsJSON)
+			require.Nil(t, rpcErr, "%s should resolve to a lookup", key)
+			require.NotNil(t, result)
+		})
+	}
+}

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -1178,6 +1178,55 @@ func TestSimulateMethod_UnknownField(t *testing.T) {
 }
 
 // TestSimulateMethod_MissingRequiredField mirrors rippled
+// TestSimulateMethod_MetaSyntheticFields verifies the rippled 3.0.0 synthetic
+// metadata enrichment (Simulate.cpp:277-288): a simulated Payment's meta gains
+// a delivered_amount derived from the transaction Amount when the engine did
+// not record one. Mirrors Simulate_test.cpp testSuccessfulTransactionAdditionalMetadata.
+func TestSimulateMethod_MetaSyntheticFields(t *testing.T) {
+	method := &handlers.SimulateMethod{}
+	mock := newMockLedgerServiceSimulate()
+	mock.simulateResult = &types.SubmitResult{
+		EngineResult:     "tesSUCCESS",
+		EngineResultCode: 0,
+		Applied:          false,
+		CurrentLedger:    3,
+		Metadata: &types.SubmitMetadata{
+			JSON: map[string]any{
+				"AffectedNodes":     []any{},
+				"TransactionIndex":  uint32(0),
+				"TransactionResult": "tesSUCCESS",
+			},
+			Blob: []byte{0xAB},
+		},
+	}
+
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+		Services:   newSimulateTestServices(mock),
+	}
+	params := map[string]any{
+		"tx_json": map[string]any{
+			"TransactionType": "Payment",
+			"Account":         validAccountAddress,
+			"Destination":     "r4bbzCamAis69rNoRdSaMSmPb1kDUHXcAL",
+			"Amount":          "100",
+		},
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	result, rpcErr := method.Handle(ctx, paramsJSON)
+	require.Nil(t, rpcErr)
+	resp := result.(map[string]any)
+
+	meta, ok := resp["meta"].(map[string]any)
+	require.True(t, ok, "meta must be a JSON object")
+	assert.Equal(t, "100", meta["delivered_amount"],
+		"a Payment's simulated meta must carry delivered_amount")
+}
+
 // Simulate_test.cpp:300-312. A Payment without Destination must surface
 // as `error: "invalidTransaction"` + `error_exception: <reason>`, the
 // envelope rippled emits when STTx construction throws

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -29,9 +29,9 @@ type RpcError struct {
 
 	// bareToken marks errors rippled emits as a lone `error` token via a direct
 	// jvResult[jss::error] = "..." assignment (e.g. VaultInfo.cpp:101,
-	// LedgerEntry.cpp:1044, TransactionEntry.cpp:71) rather than RPC::inject_error.
-	// rippled's bare path writes neither error_code nor error_message, so the
-	// wire emitters omit both when this is set.
+	// TransactionEntry.cpp:71) rather than RPC::inject_error. rippled's bare path
+	// writes neither error_code nor error_message, so the wire emitters omit both
+	// when this is set.
 	bareToken bool
 
 	// invalidApiVersion marks the unsupported-api_version rejection, which
@@ -213,6 +213,10 @@ const (
 	RpcBAD_CREDENTIALS       = 95 // deposit_authorized + credentials
 	RpcTX_SIGNED             = 96 // Simulate
 	RpcDOMAIN_MALFORMED      = 97 // Pathfinding
+
+	// ledger_entry (rippled 3.0.0, PR #5237)
+	RpcENTRY_NOT_FOUND        = 98
+	RpcUNEXPECTED_LEDGER_TYPE = 99
 )
 
 // go-xrpl-specific error codes for conditions rippled does not assign an
@@ -509,13 +513,36 @@ func RpcErrorOracleMalformed() *RpcError {
 	return NewRpcError(RpcORACLE_MALFORMED, "oracleMalformed", "oracleMalformed", "Oracle request is malformed.")
 }
 
-// RpcErrorEntryNotFound returns the error rippled emits for a missing ledger
-// entry (LedgerEntry.cpp:1044, VaultInfo.cpp:101): a bare "entryNotFound"
-// token with no numeric code, so the code is rpcUNKNOWN (-1).
+// RpcErrorEntryNotFound returns rippled's rpcENTRY_NOT_FOUND (code 98, token
+// "entryNotFound"). rippled 3.0.0 promoted the ledger_entry handler's missing
+// entry from a bare token to RPC::make_error(rpcENTRY_NOT_FOUND)
+// (LedgerEntry.cpp:838,850; ErrorCodes.cpp:121), so it now carries the numeric
+// code and an error_message. An empty message defaults to rippled's canonical
+// "Entry not found." string. The bare-token form survives as
+// RpcErrorEntryNotFoundBare for the handlers rippled left unchanged.
 func RpcErrorEntryNotFound(message string) *RpcError {
+	if message == "" {
+		message = "Entry not found."
+	}
+	return NewRpcError(RpcENTRY_NOT_FOUND, "entryNotFound", "entryNotFound", message)
+}
+
+// RpcErrorEntryNotFoundBare returns the bare "entryNotFound" token (no numeric
+// code or error_message) that rippled still emits via a direct
+// jvResult[jss::error] assignment in handlers not covered by the 3.0.0
+// ledger_entry refactor (VaultInfo.cpp:101), so the code is rpcUNKNOWN (-1).
+func RpcErrorEntryNotFoundBare(message string) *RpcError {
 	e := NewRpcError(RpcUNKNOWN, "entryNotFound", "entryNotFound", message)
 	e.bareToken = true
 	return e
+}
+
+// RpcErrorUnexpectedLedgerType returns rippled's rpcUNEXPECTED_LEDGER_TYPE
+// (code 99, token "unexpectedLedgerType"), emitted by the 3.0.0 ledger_entry
+// handler when the object found does not match the type implied by the request
+// selector (LedgerEntry.cpp:853-856; ErrorCodes.cpp:122).
+func RpcErrorUnexpectedLedgerType() *RpcError {
+	return NewRpcError(RpcUNEXPECTED_LEDGER_TYPE, "unexpectedLedgerType", "unexpectedLedgerType", "Unexpected ledger type.")
 }
 
 // RpcErrorTransactionNotFound returns the error rippled's transaction_entry

--- a/internal/rpc/types/errors_test.go
+++ b/internal/rpc/types/errors_test.go
@@ -82,6 +82,8 @@ var rippledEnum = []struct {
 	{"RpcBAD_CREDENTIALS", RpcBAD_CREDENTIALS, 95},
 	{"RpcTX_SIGNED", RpcTX_SIGNED, 96},
 	{"RpcDOMAIN_MALFORMED", RpcDOMAIN_MALFORMED, 97},
+	{"RpcENTRY_NOT_FOUND", RpcENTRY_NOT_FOUND, 98},
+	{"RpcUNEXPECTED_LEDGER_TYPE", RpcUNEXPECTED_LEDGER_TYPE, 99},
 }
 
 func TestErrorCodesMatchRippledEnum(t *testing.T) {
@@ -167,7 +169,9 @@ func TestErrorConstructorsTokenCodePairs(t *testing.T) {
 		{RpcErrorSrcActMalformed("x"), "srcActMalformed", 65},
 		{RpcErrorNotImpl(), "notImpl", 74},
 		{RpcErrorOracleMalformed(), "oracleMalformed", 94},
-		{RpcErrorEntryNotFound("x"), "entryNotFound", RpcUNKNOWN},
+		{RpcErrorEntryNotFound("x"), "entryNotFound", RpcENTRY_NOT_FOUND},
+		{RpcErrorEntryNotFoundBare("x"), "entryNotFound", RpcUNKNOWN},
+		{RpcErrorUnexpectedLedgerType(), "unexpectedLedgerType", RpcUNEXPECTED_LEDGER_TYPE},
 		{RpcErrorTransactionNotFound("x"), "transactionNotFound", RpcUNKNOWN},
 		{RpcErrorNotStandalone("x"), "notStandAlone", RpcUNKNOWN},
 		{RpcErrorUnknownOption("x"), "unknownOption", RpcUNKNOWN},
@@ -194,12 +198,12 @@ func TestErrorConstructorsTokenCodePairs(t *testing.T) {
 }
 
 // Bare-token errors mirror rippled handlers that set jvResult[jss::error]
-// directly (e.g. VaultInfo.cpp:101, LedgerEntry.cpp:1044,
-// TransactionEntry.cpp:71): only `error` is wired, never error_code or
-// error_message. Errors built through inject_error keep all three fields.
+// directly (e.g. VaultInfo.cpp:101, TransactionEntry.cpp:71): only `error` is
+// wired, never error_code or error_message. Errors built through inject_error
+// keep all three fields.
 func TestBareTokenErrors(t *testing.T) {
 	bare := []*RpcError{
-		RpcErrorEntryNotFound("x"),
+		RpcErrorEntryNotFoundBare("x"),
 		RpcErrorTransactionNotFound("x"),
 		RpcErrorUnknownOption("x"),
 		RpcErrorFieldNotFoundTransaction(),
@@ -218,11 +222,26 @@ func TestBareTokenErrors(t *testing.T) {
 		RpcErrorLgrNotFound("x"),
 		RpcErrorInternal("x"),
 		RpcErrorActNotFound("x"),
+		// rippled 3.0.0 promoted these ledger_entry paths to inject_error.
+		RpcErrorEntryNotFound("x"),
+		RpcErrorUnexpectedLedgerType(),
 	}
 	for _, e := range notBare {
 		if e.IsBareToken() {
 			t.Errorf("%q must not be a bare token", e.ErrorString)
 		}
+	}
+}
+
+// RpcErrorEntryNotFound defaults an empty message to rippled's canonical
+// "Entry not found." string (ErrorCodes.cpp:121); RpcErrorEntryNotFoundBare
+// carries whatever the handler passes.
+func TestEntryNotFoundDefaultMessage(t *testing.T) {
+	if got := RpcErrorEntryNotFound("").Message; got != "Entry not found." {
+		t.Errorf("default message = %q, want %q", got, "Entry not found.")
+	}
+	if got := RpcErrorEntryNotFound("custom").Message; got != "custom" {
+		t.Errorf("explicit message = %q, want %q", got, "custom")
 	}
 }
 


### PR DESCRIPTION
Part of #274 / #279 (v3.0.0 Phase E — RPC surface). Non-consensus, client-compat.

Cites rippled 3.0.0 PRs: **#5270** (pseudo_account), **#5754** (simulate metadata), **#5237** (ledger_entry rewrite).

## What changed

### 1. `account_info` — `pseudo_account` (rippled AccountInfo.cpp:153-173, PR #5270)
When the account root carries a pseudo-account designator (`sfAMMID` / `sfVaultID` / `sfLoanBrokerID`), the response now includes `result.pseudo_account = {"type": "AMM"|"Vault"|"LoanBroker"}` (the field name minus its trailing `ID`, first-match in that order). The type is derived from the decoded `account_data`, and `binarycodec.Decode` already surfaces all three designators, so AMM/Vault/LoanBroker all work today (no dependency on `state.AccountRoot` parsing `VaultID`/`LoanBrokerID`, which lands with PR #1255). The designator hash itself stays in `account_data`.

### 2. `simulate` — synthetic metadata (rippled Simulate.cpp:277-288, PR #5754)
The simulated `meta` JSON is now enriched with the same synthetic fields `tx`/`account_tx` report for validated transactions, computed from the metadata's `AffectedNodes`:
- `delivered_amount` (Payment / CheckCash / AccountDelete)
- `nftoken_id` (NFTokenMint, NFTokenAcceptOffer) / `nftoken_ids` (NFTokenCancelOffer)
- `offer_id` (NFTokenCreateOffer, or NFTokenMint that lists via an Amount)
- `mpt_issuance_id` (MPTokenIssuanceCreate)

All four require `tesSUCCESS` and are a JSON-`meta`-only enrichment — `meta_blob` (binary mode) carries the raw serialized metadata unchanged, matching rippled. New helper file `internal/rpc/handlers/synthetic_meta.go`.

**Overlaps #483** (now CLOSED): that issue covered `simulate` Sequence/Fee autofill and `meta`/`meta_blob`, which already landed. This PR builds on it, adding only the synthetic-field enrichment.

### 3. `ledger_entry` audit (rippled LedgerEntry.cpp, PR #5237)
- New error codes `rpcENTRY_NOT_FOUND=98` (`entryNotFound`, "Entry not found.", 400) and `rpcUNEXPECTED_LEDGER_TYPE=99` (`unexpectedLedgerType`, "Unexpected ledger type.", 400), wired into the enum + constructor tests.
- Missing entries now return the numeric `entryNotFound` (98) instead of the bare token. `vault_info` keeps the bare token rippled left unchanged (VaultInfo.cpp:101 → `RpcErrorEntryNotFoundBare`).
- `unexpectedLedgerType` (99) when the entry found at the requested index does not match the filter's expected `LedgerEntryType`; the `index` alias (ltANY) opts out.
- Added rippled's canonical `nft_offer` selector (`nftoken_offer` kept as a go-xrpl alias).
- RPCHelpers `ledgerFromRequest` drift: null `ledger_hash`/`ledger_index` treated as absent; non-string `ledger_hash` → `ledgerHashNotString`; unparseable/non-integral `ledger_index` → `ledgerIndexMalformed`.

## Overlap with PR #727 (`origin/v3.0.0`)
The older `origin/v3.0.0` branch (merged PR #727, based on a much earlier main) already implemented the two new error codes, the `nft_offer`/`loan`/`loan_broker` selectors, and a snake_case `delivered_amount` sweep. This PR was written against current `main` and **deliberately aligns error codes / tokens / messages / constructor names** with #727 (`RpcErrorEntryNotFound` = code 98; `RpcErrorEntryNotFoundBare` = bare; `RpcErrorUnexpectedLedgerType` = code 99) so reconciliation is trivial. Two intentional differences: #727 refactored `ledger_entry` into a `ledgerEntrySelectors()` table whereas this targets current main's sequential resolver (same behaviour), and this PR **defers `loan`/`loan_broker` lookups to #1245** per the task scope (only `nft_offer` is added).

## Left unaudited (conscious scope)
- **Per-filter malformed-token normalization** — rippled's 3.0.0 rewrite emits custom tokens (`malformedOwner`, `malformedSeq`, `malformedAddress`, …) all at `error_code = rpcINVALID_PARAMS (31)`. go-xrpl already returns code 31 for these; only the token string and message text differ. Renaming across ~30 selectors is a large, low-signal surface (clients key on the numeric code) and would churn many existing tests, so it is deferred. Prioritized per the task: new error codes + `unexpectedLedgerType` + RPCHelpers drift first.
- **`loan`/`loan_broker` selectors** — deferred to #1245 (need a lending subsystem for the object form).

## Verification
- `just build-all`: clean.
- `just test`: all packages pass except the pre-existing `internal/testing/conformance` failures. Conformance diff vs baseline: **182 failures, 0 new, 0 fixed** (RPC-only changes don't touch the ledger-replay path).
- `golangci-lint run --config .golangci.yml ./...`: 0 issues.
- New tests: `account_info` pseudo_account (AMM/Vault/LoanBroker + absent for normal accounts); `enrichSimulateMeta` unit coverage for every synthetic field + an end-to-end `delivered_amount` simulate; `ledger_entry` entryNotFound (98), unexpectedLedgerType (99), `nft_offer`/`nftoken_offer` aliasing, and ledger_hash/ledger_index validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
