### PR TITLE
feat(rpc): salvage still-relevant ledger_entry + delivered_amount parity from retired v3.0.0 branch

### DIFF
--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -414,34 +414,42 @@ func decodeTxBlob(data []byte) (StoredTransaction, error) {
 	return st, nil
 }
 
-// InjectDeliveredAmount adds DeliveredAmount to metadata for Payment transactions.
-// If meta has a "DeliveredAmount" field already, it is left as-is.
-// If meta has a "delivered_amount" field, it is promoted to "DeliveredAmount".
-// Otherwise, for Payment transactions, the Amount field from the transaction
-// is used as a fallback for "DeliveredAmount".
-// Non-Payment transactions and nil meta are no-ops.
+// InjectDeliveredAmount adds the synthetic snake_case "delivered_amount" field
+// to a transaction's metadata, matching rippled's RPC::insertDeliveredAmount.
+// It is emitted only for a successful Payment, CheckCash, or AccountDelete
+// (rippled's canHaveDeliveredAmount: those three types plus tesSUCCESS; CheckCash
+// also requires fix1623, which is enabled on every ledger go-xrpl serves). The
+// value is the real serialized sfDeliveredAmount metadata field when present,
+// otherwise the transaction's Amount (rippled's ledger-index / close-time gate
+// always holds for served ledgers), otherwise the literal "unavailable". The
+// real PascalCase "DeliveredAmount" metadata field is left untouched — only the
+// synthetic snake_case field is written. nil meta is a no-op.
 func InjectDeliveredAmount(txJSON map[string]any, meta map[string]any) {
-	txType, _ := txJSON["TransactionType"].(string)
-	if txType != "Payment" {
-		return
-	}
 	if meta == nil {
 		return
 	}
 
-	// If DeliveredAmount already present in metadata, use it
-	if _, ok := meta["DeliveredAmount"]; ok {
+	switch txType, _ := txJSON["TransactionType"].(string); txType {
+	case "Payment", "CheckCash", "AccountDelete":
+	default:
+		return
+	}
+	if result, _ := meta["TransactionResult"].(string); result != "tesSUCCESS" {
 		return
 	}
 
-	// If delivered_amount is present, promote to DeliveredAmount
-	if da, ok := meta["delivered_amount"]; ok {
-		meta["DeliveredAmount"] = da
+	// Idempotent: a caller may already carry the real delivered amount under the
+	// snake_case key (e.g. a partial-payment value); keep it rather than
+	// clobbering it with the full Amount fallback.
+	if _, ok := meta["delivered_amount"]; ok {
 		return
 	}
 
-	// Fallback: use Amount from transaction as DeliveredAmount
-	if amount, ok := txJSON["Amount"]; ok {
-		meta["DeliveredAmount"] = amount
+	if da, ok := meta["DeliveredAmount"]; ok {
+		meta["delivered_amount"] = da
+	} else if amount, ok := txJSON["Amount"]; ok {
+		meta["delivered_amount"] = amount
+	} else {
+		meta["delivered_amount"] = "unavailable"
 	}
 }

--- a/internal/rpc/handlers/ledger_entry.go
+++ b/internal/rpc/handlers/ledger_entry.go
@@ -75,19 +75,27 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// account_root: string (account address) — rippled only accepts address, no hex fallback
+	// account / account_root: string (account address) — rippled only accepts an
+	// address, no hex fallback. `account` is rippled's canonical AccountRoot
+	// selector (the ledger_entries.macro rpcName); `account_root` is the
+	// appended alias. Both resolve to keylet::account.
 	if !keySet {
-		if raw, ok := rawParams["account_root"]; ok {
+		for _, field := range []string{"account", "account_root"} {
+			raw, ok := rawParams[field]
+			if !ok {
+				continue
+			}
 			var addr string
 			if err := json.Unmarshal(raw, &addr); err != nil {
-				return nil, types.RpcErrorInvalidParams("Invalid account_root")
+				return nil, types.RpcErrorInvalidParams("Invalid " + field)
 			}
 			accountID, err := decodeAccountID(addr)
 			if err != nil {
-				return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid account_root address: %v", err))
+				return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid %s address: %v", field, err))
 			}
 			entryKey = keylet.Account(accountID).Key
 			keySet = true
+			break
 		}
 	}
 
@@ -188,6 +196,31 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	if !keySet {
 		if raw, ok := rawParams["escrow"]; ok {
 			entryKey, rpcErr = parseEscrowKeylet(raw)
+			if rpcErr != nil {
+				return nil, rpcErr
+			}
+			keySet = true
+		}
+	}
+
+	// loan / loan_broker: string (hex ID). rippled's parseLoan/parseLoanBroker
+	// resolve a keylet from an object form (loan_broker_id+loan_seq / owner+seq),
+	// but fall back to a direct hex-index lookup when the param is not an object.
+	// go-xrpl has no lending subsystem (no keylet::loan), so only that hex-index
+	// form is supported — the same pragmatic handling as bridge/xchain.
+	if !keySet {
+		if raw, ok := rawParams["loan"]; ok {
+			entryKey, rpcErr = parseHex256(raw, "loan")
+			if rpcErr != nil {
+				return nil, rpcErr
+			}
+			keySet = true
+		}
+	}
+
+	if !keySet {
+		if raw, ok := rawParams["loan_broker"]; ok {
+			entryKey, rpcErr = parseHex256(raw, "loan_broker")
 			if rpcErr != nil {
 				return nil, rpcErr
 			}

--- a/internal/rpc/helpers_test.go
+++ b/internal/rpc/helpers_test.go
@@ -9,11 +9,14 @@ import (
 )
 
 // InjectDeliveredAmount Tests
-// Based on rippled src/test/rpc/DeliveredAmount_test.cpp
+// Based on rippled src/test/rpc/DeliveredAmount_test.cpp and the
+// RPC::insertDeliveredAmount / getDeliveredAmount logic in DeliveredAmount.cpp.
+// The synthetic field is snake_case "delivered_amount"; the real serialized
+// metadata field is PascalCase "DeliveredAmount" and is never altered.
 
-// TestDeliveredAmountNonPaymentSkipped verifies that non-Payment transactions
-// are skipped entirely (no DeliveredAmount is added to meta).
-func TestDeliveredAmountNonPaymentSkipped(t *testing.T) {
+// TestDeliveredAmountIneligibleTypeSkipped verifies that transaction types
+// outside {Payment, CheckCash, AccountDelete} get no delivered_amount.
+func TestDeliveredAmountIneligibleTypeSkipped(t *testing.T) {
 	tests := []struct {
 		name   string
 		txType string
@@ -30,290 +33,187 @@ func TestDeliveredAmountNonPaymentSkipped(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			txJSON := map[string]any{
+			txJSON := map[string]interface{}{
 				"TransactionType": tc.txType,
 				"Amount":          "1000000",
 			}
-			meta := map[string]any{
+			meta := map[string]interface{}{
 				"TransactionResult": "tesSUCCESS",
 			}
 
 			handlers.InjectDeliveredAmount(txJSON, meta)
 
-			_, hasDeliveredAmount := meta["DeliveredAmount"]
-			assert.False(t, hasDeliveredAmount,
-				"Non-Payment tx type %q should not get DeliveredAmount", tc.txType)
+			_, has := meta["delivered_amount"]
+			assert.False(t, has,
+				"ineligible tx type %q should not get delivered_amount", tc.txType)
 		})
 	}
 }
 
-// TestDeliveredAmountExistingDeliveredAmountNotOverridden verifies that if
-// DeliveredAmount is already present in meta, it is not overridden.
-func TestDeliveredAmountExistingDeliveredAmountNotOverridden(t *testing.T) {
-	t.Run("XRP drops DeliveredAmount preserved", func(t *testing.T) {
-		txJSON := map[string]any{
-			"TransactionType": "Payment",
-			"Amount":          "5000000",
-		}
-		meta := map[string]any{
+// TestDeliveredAmountEligibleTypes verifies the three eligible types each get a
+// delivered_amount (here via the Amount fallback). AccountDelete carries no
+// Amount field, so it falls through to "unavailable".
+func TestDeliveredAmountEligibleTypes(t *testing.T) {
+	t.Run("Payment", func(t *testing.T) {
+		meta := map[string]interface{}{"TransactionResult": "tesSUCCESS"}
+		handlers.InjectDeliveredAmount(
+			map[string]interface{}{"TransactionType": "Payment", "Amount": "1000000"}, meta)
+		assert.Equal(t, "1000000", meta["delivered_amount"])
+	})
+
+	t.Run("CheckCash", func(t *testing.T) {
+		meta := map[string]interface{}{"TransactionResult": "tesSUCCESS"}
+		handlers.InjectDeliveredAmount(
+			map[string]interface{}{"TransactionType": "CheckCash", "Amount": "2000000"}, meta)
+		assert.Equal(t, "2000000", meta["delivered_amount"])
+	})
+
+	t.Run("AccountDelete with no Amount falls back to unavailable", func(t *testing.T) {
+		meta := map[string]interface{}{"TransactionResult": "tesSUCCESS"}
+		handlers.InjectDeliveredAmount(
+			map[string]interface{}{"TransactionType": "AccountDelete"}, meta)
+		assert.Equal(t, "unavailable", meta["delivered_amount"])
+	})
+}
+
+// TestDeliveredAmountFailedTxSkipped verifies that a non-tesSUCCESS result
+// produces no delivered_amount.
+func TestDeliveredAmountFailedTxSkipped(t *testing.T) {
+	for _, res := range []string{"tecUNFUNDED_PAYMENT", "tecPATH_PARTIAL", "tefPAST_SEQ"} {
+		t.Run(res, func(t *testing.T) {
+			meta := map[string]interface{}{"TransactionResult": res}
+			handlers.InjectDeliveredAmount(
+				map[string]interface{}{"TransactionType": "Payment", "Amount": "1000000"}, meta)
+			_, has := meta["delivered_amount"]
+			assert.False(t, has, "failed tx (%s) must not get delivered_amount", res)
+		})
+	}
+}
+
+// TestDeliveredAmountFromRealField verifies that the real (PascalCase)
+// DeliveredAmount metadata field is copied to the synthetic snake_case
+// delivered_amount and left in place (the partial-payment case).
+func TestDeliveredAmountFromRealField(t *testing.T) {
+	t.Run("XRP drops", func(t *testing.T) {
+		txJSON := map[string]interface{}{"TransactionType": "Payment", "Amount": "5000000"}
+		meta := map[string]interface{}{
 			"TransactionResult": "tesSUCCESS",
 			"DeliveredAmount":   "3000000",
 		}
 
 		handlers.InjectDeliveredAmount(txJSON, meta)
 
+		assert.Equal(t, "3000000", meta["delivered_amount"],
+			"delivered_amount should come from the real DeliveredAmount field, not Amount")
 		assert.Equal(t, "3000000", meta["DeliveredAmount"],
-			"Existing DeliveredAmount should not be overridden")
+			"the real DeliveredAmount field must be left untouched")
 	})
 
-	t.Run("IOU DeliveredAmount preserved", func(t *testing.T) {
-		iouAmount := map[string]any{
+	t.Run("IOU", func(t *testing.T) {
+		iou := map[string]interface{}{
 			"value":    "100",
 			"currency": "USD",
 			"issuer":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 		}
-		txJSON := map[string]any{
+		txJSON := map[string]interface{}{
 			"TransactionType": "Payment",
-			"Amount": map[string]any{
+			"Amount": map[string]interface{}{
 				"value":    "500",
 				"currency": "USD",
 				"issuer":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			},
 		}
-		meta := map[string]any{
+		meta := map[string]interface{}{
 			"TransactionResult": "tesSUCCESS",
-			"DeliveredAmount":   iouAmount,
+			"DeliveredAmount":   iou,
 		}
 
 		handlers.InjectDeliveredAmount(txJSON, meta)
 
-		delivered := meta["DeliveredAmount"].(map[string]any)
-		assert.Equal(t, "100", delivered["value"],
-			"Existing IOU DeliveredAmount should not be overridden")
+		delivered := meta["delivered_amount"].(map[string]interface{})
+		assert.Equal(t, "100", delivered["value"])
 	})
 }
 
-// TestDeliveredAmountPromotedFromDeliveredAmountField verifies that
-// delivered_amount (lowercase, from meta) is promoted to DeliveredAmount.
-func TestDeliveredAmountPromotedFromDeliveredAmountField(t *testing.T) {
-	t.Run("XRP drops promoted", func(t *testing.T) {
-		txJSON := map[string]any{
-			"TransactionType": "Payment",
-			"Amount":          "5000000",
-		}
-		meta := map[string]any{
-			"TransactionResult": "tesSUCCESS",
-			"delivered_amount":  "2000000",
-		}
+// TestDeliveredAmountFallbackToAmount verifies that with no real DeliveredAmount
+// field, the tx Amount is used (the full-delivery case; the ledger-index /
+// close-time gate always holds for ledgers go-xrpl serves).
+func TestDeliveredAmountFallbackToAmount(t *testing.T) {
+	t.Run("XRP drops", func(t *testing.T) {
+		txJSON := map[string]interface{}{"TransactionType": "Payment", "Amount": "50000000"}
+		meta := map[string]interface{}{"TransactionResult": "tesSUCCESS"}
 
 		handlers.InjectDeliveredAmount(txJSON, meta)
 
-		assert.Equal(t, "2000000", meta["DeliveredAmount"],
-			"delivered_amount should be promoted to DeliveredAmount")
-		// delivered_amount should still be present (not removed)
-		assert.Equal(t, "2000000", meta["delivered_amount"],
-			"delivered_amount should remain in meta")
+		assert.Equal(t, "50000000", meta["delivered_amount"])
+		_, hasReal := meta["DeliveredAmount"]
+		assert.False(t, hasReal, "the synthetic fallback must not invent a PascalCase field")
 	})
 
-	t.Run("IOU promoted", func(t *testing.T) {
-		iouDA := map[string]any{
-			"value":    "75.5",
-			"currency": "EUR",
-			"issuer":   "rPyfep3gcLzkosKC9XiE77Y8LJUBS1test",
+	t.Run("IOU", func(t *testing.T) {
+		iou := map[string]interface{}{
+			"value":    "250.75",
+			"currency": "USD",
+			"issuer":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 		}
-		txJSON := map[string]any{
-			"TransactionType": "Payment",
-			"Amount": map[string]any{
-				"value":    "100",
-				"currency": "EUR",
-				"issuer":   "rPyfep3gcLzkosKC9XiE77Y8LJUBS1test",
-			},
-		}
-		meta := map[string]any{
-			"TransactionResult": "tesSUCCESS",
-			"delivered_amount":  iouDA,
-		}
+		txJSON := map[string]interface{}{"TransactionType": "Payment", "Amount": iou}
+		meta := map[string]interface{}{"TransactionResult": "tesSUCCESS"}
 
 		handlers.InjectDeliveredAmount(txJSON, meta)
 
-		delivered := meta["DeliveredAmount"].(map[string]any)
-		assert.Equal(t, "75.5", delivered["value"],
-			"IOU delivered_amount should be promoted to DeliveredAmount")
-	})
-
-	t.Run("delivered_amount takes precedence over Amount fallback", func(t *testing.T) {
-		txJSON := map[string]any{
-			"TransactionType": "Payment",
-			"Amount":          "9999999",
-		}
-		meta := map[string]any{
-			"TransactionResult": "tesSUCCESS",
-			"delivered_amount":  "1234567",
-		}
-
-		handlers.InjectDeliveredAmount(txJSON, meta)
-
-		assert.Equal(t, "1234567", meta["DeliveredAmount"],
-			"delivered_amount should take precedence over Amount fallback")
+		delivered := meta["delivered_amount"].(map[string]interface{})
+		assert.Equal(t, "250.75", delivered["value"])
+		assert.Equal(t, "USD", delivered["currency"])
+		assert.Equal(t, "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh", delivered["issuer"])
 	})
 }
 
-// TestDeliveredAmountFallbackToAmountXRP verifies that when no DeliveredAmount
-// or delivered_amount exists in meta, the Amount field from the tx is used.
-func TestDeliveredAmountFallbackToAmountXRP(t *testing.T) {
-	txJSON := map[string]any{
-		"TransactionType": "Payment",
-		"Amount":          "50000000",
-	}
-	meta := map[string]any{
+// TestDeliveredAmountUnavailable verifies that an eligible, successful tx with
+// neither a real DeliveredAmount field nor an Amount field yields the literal
+// "unavailable".
+func TestDeliveredAmountUnavailable(t *testing.T) {
+	txJSON := map[string]interface{}{"TransactionType": "Payment"} // no Amount
+	meta := map[string]interface{}{"TransactionResult": "tesSUCCESS"}
+
+	handlers.InjectDeliveredAmount(txJSON, meta)
+
+	assert.Equal(t, "unavailable", meta["delivered_amount"])
+}
+
+// TestDeliveredAmountIdempotent verifies that a pre-existing snake_case
+// delivered_amount (e.g. the engine's metadata carrying a real partial-payment
+// value) is preserved rather than clobbered by the Amount fallback.
+func TestDeliveredAmountIdempotent(t *testing.T) {
+	txJSON := map[string]interface{}{"TransactionType": "Payment", "Amount": "9999999"}
+	meta := map[string]interface{}{
 		"TransactionResult": "tesSUCCESS",
+		"delivered_amount":  "1234567",
 	}
 
 	handlers.InjectDeliveredAmount(txJSON, meta)
 
-	assert.Equal(t, "50000000", meta["DeliveredAmount"],
-		"Amount field (XRP drops string) should be used as fallback DeliveredAmount")
-}
-
-// TestDeliveredAmountFallbackToAmountIOU verifies fallback to Amount for IOU.
-func TestDeliveredAmountFallbackToAmountIOU(t *testing.T) {
-	iouAmount := map[string]any{
-		"value":    "250.75",
-		"currency": "USD",
-		"issuer":   "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-	}
-	txJSON := map[string]any{
-		"TransactionType": "Payment",
-		"Amount":          iouAmount,
-	}
-	meta := map[string]any{
-		"TransactionResult": "tesSUCCESS",
-	}
-
-	handlers.InjectDeliveredAmount(txJSON, meta)
-
-	delivered := meta["DeliveredAmount"].(map[string]any)
-	assert.Equal(t, "250.75", delivered["value"],
-		"Amount IOU value should be used as fallback DeliveredAmount")
-	assert.Equal(t, "USD", delivered["currency"])
-	assert.Equal(t, "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh", delivered["issuer"])
+	assert.Equal(t, "1234567", meta["delivered_amount"],
+		"an existing delivered_amount must not be overwritten by the Amount fallback")
 }
 
 // TestDeliveredAmountNilMeta verifies that nil meta does not panic.
 func TestDeliveredAmountNilMeta(t *testing.T) {
-	txJSON := map[string]any{
-		"TransactionType": "Payment",
-		"Amount":          "1000000",
-	}
-
-	// Should not panic
+	txJSON := map[string]interface{}{"TransactionType": "Payment", "Amount": "1000000"}
 	require.NotPanics(t, func() {
 		handlers.InjectDeliveredAmount(txJSON, nil)
 	})
 }
 
-// TestDeliveredAmountEmptyMeta verifies that empty meta does not panic
-// and correctly adds DeliveredAmount from Amount fallback.
-func TestDeliveredAmountEmptyMeta(t *testing.T) {
-	txJSON := map[string]any{
-		"TransactionType": "Payment",
-		"Amount":          "1000000",
-	}
-	meta := map[string]any{}
-
-	require.NotPanics(t, func() {
-		handlers.InjectDeliveredAmount(txJSON, meta)
-	})
-
-	assert.Equal(t, "1000000", meta["DeliveredAmount"],
-		"Empty meta should get DeliveredAmount from Amount fallback")
-}
-
-// TestDeliveredAmountNoAmountField verifies behavior when Payment has no Amount.
-func TestDeliveredAmountNoAmountField(t *testing.T) {
-	txJSON := map[string]any{
-		"TransactionType": "Payment",
-		// No Amount field
-	}
-	meta := map[string]any{
-		"TransactionResult": "tesSUCCESS",
-	}
-
-	require.NotPanics(t, func() {
-		handlers.InjectDeliveredAmount(txJSON, meta)
-	})
-
-	_, hasDeliveredAmount := meta["DeliveredAmount"]
-	assert.False(t, hasDeliveredAmount,
-		"No DeliveredAmount should be set when Amount is missing from tx")
-}
-
 // TestDeliveredAmountMissingTransactionType verifies that a tx with no
-// TransactionType field is treated as non-Payment (skipped).
+// TransactionType is treated as ineligible.
 func TestDeliveredAmountMissingTransactionType(t *testing.T) {
-	txJSON := map[string]any{
-		"Amount": "1000000",
-		// No TransactionType field
-	}
-	meta := map[string]any{
-		"TransactionResult": "tesSUCCESS",
-	}
+	txJSON := map[string]interface{}{"Amount": "1000000"} // no TransactionType
+	meta := map[string]interface{}{"TransactionResult": "tesSUCCESS"}
 
 	handlers.InjectDeliveredAmount(txJSON, meta)
 
-	_, hasDeliveredAmount := meta["DeliveredAmount"]
-	assert.False(t, hasDeliveredAmount,
-		"Missing TransactionType should result in no DeliveredAmount")
-}
-
-// TestDeliveredAmountPriorityOrder verifies the full priority chain:
-// 1. Existing DeliveredAmount in meta -> keep it
-// 2. delivered_amount in meta -> promote to DeliveredAmount
-// 3. Amount in tx -> use as fallback
-func TestDeliveredAmountPriorityOrder(t *testing.T) {
-	t.Run("DeliveredAmount wins over delivered_amount and Amount", func(t *testing.T) {
-		txJSON := map[string]any{
-			"TransactionType": "Payment",
-			"Amount":          "9999",
-		}
-		meta := map[string]any{
-			"DeliveredAmount":  "1111",
-			"delivered_amount": "2222",
-		}
-
-		handlers.InjectDeliveredAmount(txJSON, meta)
-
-		assert.Equal(t, "1111", meta["DeliveredAmount"],
-			"Existing DeliveredAmount should win")
-	})
-
-	t.Run("delivered_amount wins over Amount", func(t *testing.T) {
-		txJSON := map[string]any{
-			"TransactionType": "Payment",
-			"Amount":          "9999",
-		}
-		meta := map[string]any{
-			"delivered_amount": "2222",
-		}
-
-		handlers.InjectDeliveredAmount(txJSON, meta)
-
-		assert.Equal(t, "2222", meta["DeliveredAmount"],
-			"delivered_amount should win over Amount fallback")
-	})
-
-	t.Run("Amount used as last resort", func(t *testing.T) {
-		txJSON := map[string]any{
-			"TransactionType": "Payment",
-			"Amount":          "9999",
-		}
-		meta := map[string]any{}
-
-		handlers.InjectDeliveredAmount(txJSON, meta)
-
-		assert.Equal(t, "9999", meta["DeliveredAmount"],
-			"Amount should be used as last resort")
-	})
+	_, has := meta["delivered_amount"]
+	assert.False(t, has, "missing TransactionType should yield no delivered_amount")
 }
 
 // FormatLedgerHash Tests

--- a/internal/rpc/ledger_entry_test.go
+++ b/internal/rpc/ledger_entry_test.go
@@ -3031,3 +3031,96 @@ func TestLedgerEntryAMMHexFallback(t *testing.T) {
 		assert.Contains(t, rpcErr.Message, "asset and asset2 required")
 	})
 }
+
+// TestLedgerEntryAccountSelector covers rippled's canonical AccountRoot
+// selector `account` (the ledger_entries.macro rpcName; `account_root` is the
+// appended alias). Both parse an address to keylet::account and must resolve to
+// the same key.
+func TestLedgerEntryAccountSelector(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	services := newLedgerEntryTestServices(mock)
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+	addr := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+	t.Run("account selector succeeds", func(t *testing.T) {
+		params := map[string]any{"account": addr, "ledger_index": "validated"}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		result, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+	})
+
+	t.Run("account and account_root resolve to the same key", func(t *testing.T) {
+		canonical, err := json.Marshal(map[string]any{"account": addr, "ledger_index": "validated"})
+		require.NoError(t, err)
+		alias, err := json.Marshal(map[string]any{"account_root": addr, "ledger_index": "validated"})
+		require.NoError(t, err)
+
+		rc, e1 := method.Handle(ctx, canonical)
+		ra, e2 := method.Handle(ctx, alias)
+		require.Nil(t, e1)
+		require.Nil(t, e2)
+		require.Equal(t, rc.(map[string]any)["index"], ra.(map[string]any)["index"])
+	})
+
+	t.Run("account with malformed address is rejected", func(t *testing.T) {
+		params := map[string]any{"account": "not-an-address", "ledger_index": "validated"}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(ctx, paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Contains(t, rpcErr.Message, "Invalid account")
+	})
+}
+
+// TestLedgerEntryLoanSelectors covers the rippled 3.0.0 `loan`/`loan_broker`
+// selectors. rippled's parseLoan/parseLoanBroker fall back to a direct
+// hex-index lookup when the param is not an object; go-xrpl has no lending
+// subsystem, so it supports only that hex form (like bridge/xchain). Each field
+// must be recognized and resolve to a lookup rather than being rejected as an
+// unknown option.
+func TestLedgerEntryLoanSelectors(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	services := newLedgerEntryTestServices(mock)
+
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+	index := "A33EC6BB85FB5674074C4A3A43373BB17645308F3EAE1933E3E35252162B217D"
+
+	for _, field := range []string{"loan", "loan_broker"} {
+		t.Run(field+" by hex string", func(t *testing.T) {
+			params := map[string]any{field: index, "ledger_index": "validated"}
+			paramsJSON, err := json.Marshal(params)
+			require.NoError(t, err)
+
+			result, rpcErr := method.Handle(ctx, paramsJSON)
+			require.Nil(t, rpcErr)
+			require.NotNil(t, result)
+		})
+
+		t.Run(field+" invalid hex", func(t *testing.T) {
+			params := map[string]any{field: "TOOSHORT", "ledger_index": "validated"}
+			paramsJSON, err := json.Marshal(params)
+			require.NoError(t, err)
+
+			_, rpcErr := method.Handle(ctx, paramsJSON)
+			require.NotNil(t, rpcErr)
+			assert.Contains(t, rpcErr.Message, "Invalid "+field)
+		})
+	}
+}


### PR DESCRIPTION
Salvages the still-relevant RPC parity fixes from the retired v3.0.0 integration branch (merged as PRs #727/#728), reimplemented against current `main`/`v3.0.0`. Each old-branch commit was verified against rippled 3.0.0 (`ledger_entries.macro`, `LedgerEntry.cpp`, `DeliveredAmount.cpp`); superseded pieces were dropped rather than duplicated.

Part of #274; salvages the still-relevant work from PRs #727/#728.

## Ported

### `account` ledger_entry selector — old-branch `fe3536a3`
rippled 3.0.0's dispatch keys AccountRoot by its macro rpcName `account` (`ledger_entries.macro:148`); `account_root` is only the appended alias (`LedgerEntry.cpp` aliases block). The Go handler resolved only `account_root`, so `{"account": "<addr>"}` was rejected as `unknownOption` while rippled resolves it. Both now share one block that parses an address to `keylet::account`. Not present on `main` or in the sibling ledger_entry PR (#1259).

### `loan` / `loan_broker` ledger_entry selectors — old-branch `5bc97d71` (partial)
rippled's `parseLoan`/`parseLoanBroker` resolve a keylet from an object form but fall back to a direct hex-index lookup when the param is not an object (`if (!params.isObject()) return parseObjectID(...)`). go-xrpl has no lending subsystem (no `keylet::loan`), so it supports exactly that hex-index form — identical to the existing `bridge`/`xchain` handling — making both fields resolve to a lookup instead of `unknownOption`. Not present on `main` or #1259.

### snake_case `delivered_amount` in the shared metadata helper — old-branch `2d8a0925` (helper only)
`InjectDeliveredAmount` wrote a synthetic PascalCase `DeliveredAmount`; rippled's `RPC::insertDeliveredAmount` emits snake_case `delivered_amount` (`DeliveredAmount.cpp:150,157`), while PascalCase is only the real serialized `sfDeliveredAmount` metadata field. Ported rippled's `canHaveDeliveredAmount` gating (successful Payment / CheckCash / AccountDelete), the real-field → tx `Amount` → `"unavailable"` fallback chain, and idempotency, leaving the real PascalCase field untouched. Fixes the `tx`, `account_tx`, `ledger`, and `transaction_entry` handlers that share the helper.

## Skipped (superseded)

- **`sfSignerListID` on the SignerList SLE** (old-branch `78bb7a39`): current `main` already emits `SignerListID: 0` in `SerializeSignerList`, and the parse side defaults to 0 (rippled hardcodes `DEFAULT_SIGNER_LIST_ID`), so the round-trip is already correct. The commit's test also depends on the `fixIncludeKeyletFields` scaffolding that lives in the sibling PR #1254.
- **`nft_offer` selector** (old-branch `5bc97d71`): already added by #1259 (`nft_offer` canonical + `nftoken_offer` alias) — not duplicated here.
- **`entryNotFound` default-message + `errors.go` bareToken doc cleanup** (old-branch `5bc97d71`): #1259 already implements `rpcENTRY_NOT_FOUND` (98) with the `"Entry not found."` default and the identical `TestEntryNotFoundDefaultMessage`.
- **`simulate.go` / `toMetaMap` normalization** (part of old-branch `2d8a0925`): current `main`'s simulate handler does not use the shared helper; #1259 owns the simulate `delivered_amount` path via `enrichSimulateMeta`.

## Validation

- `just build-all`: clean
- `just test`: all packages `ok`; the only failing suite is `internal/testing/conformance`, whose failure set is byte-identical to the provided baseline (0 new, 0 regressed)
- Conformance diff vs baseline: 0 new failures, 0 regressions
- Strict lint (`golangci-lint run --config .golangci.yml ./...`): 0 issues
- `docsgen/rpcmethods` + `docsgen/registries`: no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)