### PR TITLE
feat(engine): v3.1 preclaim reorder + Batch signing amendments

### DIFF
--- a/amendment/registry.go
+++ b/amendment/registry.go
@@ -28,6 +28,7 @@ var (
 // above — there is no separate init() write-back, so cross-package callers
 // observing FeatureXxx never see a zero ID.
 var (
+	FeatureFixBatchInnerSigs             = registerFix("fixBatchInnerSigs", SupportedNo, VoteDefaultNo)
 	FeatureFixDirectoryLimit             = registerFix("fixDirectoryLimit", SupportedYes, VoteDefaultNo)
 	FeatureFixIncludeKeyletFields        = registerFix("fixIncludeKeyletFields", SupportedYes, VoteDefaultNo)
 	FeatureFixDelegateV1_1               = registerFix("fixDelegateV1_1", SupportedNo, VoteDefaultNo)
@@ -39,7 +40,7 @@ var (
 	FeatureFixEnforceNFTokenTrustlineV2  = registerFix("fixEnforceNFTokenTrustlineV2", SupportedYes, VoteDefaultNo)
 	FeatureFixAMMv1_3                    = registerFix("fixAMMv1_3", SupportedYes, VoteDefaultNo)
 	FeaturePermissionedDEX               = registerFeature("PermissionedDEX", SupportedYes, VoteDefaultNo)
-	FeatureBatch                         = registerFeature("Batch", SupportedYes, VoteDefaultNo)
+	FeatureBatch                         = registerFeature("Batch", SupportedNo, VoteDefaultNo)
 	FeatureLendingProtocol               = registerFeature("LendingProtocol", SupportedNo, VoteDefaultNo)
 	FeatureSingleAssetVault              = registerFeature("SingleAssetVault", SupportedNo, VoteDefaultNo)
 	FeaturePermissionDelegation          = registerFeature("PermissionDelegation", SupportedNo, VoteDefaultNo)

--- a/docs/amendments.md
+++ b/docs/amendments.md
@@ -7,13 +7,13 @@ XRPL amendments known to this node, generated from the amendment registry
 amendment's behavior; **Default vote** is whether the node votes for it by
 default (operators override via the `[amendments]` config section).
 
-Total: 103 amendments.
+Total: 104 amendments.
 
 | Amendment | Supported | Default vote |
 |-----------|-----------|--------------|
 | `AMM` | yes | no |
 | `AMMClawback` | yes | no |
-| `Batch` | yes | no |
+| `Batch` | no | no |
 | `CheckCashMakesTrustLine` | yes | no |
 | `Checks` | yes | yes |
 | `Clawback` | yes | no |
@@ -78,6 +78,7 @@ Total: 103 amendments.
 | `fixAMMv1_2` | yes | no |
 | `fixAMMv1_3` | yes | no |
 | `fixAmendmentMajorityCalc` | yes | yes |
+| `fixBatchInnerSigs` | no | no |
 | `fixCheckThreading` | yes | yes |
 | `fixDelegateV1_1` | no | no |
 | `fixDirectoryLimit` | yes | no |

--- a/docs/amendments.md
+++ b/docs/amendments.md
@@ -7,7 +7,7 @@ XRPL amendments known to this node, generated from the amendment registry
 amendment's behavior; **Default vote** is whether the node votes for it by
 default (operators override via the `[amendments]` config section).
 
-Total: 104 amendments.
+Total: 105 amendments.
 
 | Amendment | Supported | Default vote |
 |-----------|-----------|--------------|

--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -18,6 +18,18 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/txq"
 )
 
+// newBatchEnv builds a test environment with the Batch amendment active.
+// Batch is Supported::no upstream (rippled 3.1.1 withdrew support pending
+// fixBatchInnerSigs), so the all-supported preset no longer activates it and
+// every Batch test must opt in. EnableFeatureNow enables it from genesis,
+// matching the behaviour these tests relied on when the preset carried Batch.
+func newBatchEnv(t *testing.T) *xtesting.TestEnv {
+	t.Helper()
+	env := xtesting.NewTestEnv(t)
+	env.EnableFeatureNow("Batch")
+	return env
+}
+
 // =============================================================================
 // Test 1: testEnable
 // Reference: rippled Batch_test.cpp testEnable()
@@ -25,7 +37,7 @@ import (
 
 func TestEnabled(t *testing.T) {
 	t.Run("batch enabled", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -47,7 +59,6 @@ func TestEnabled(t *testing.T) {
 
 	t.Run("batch disabled", func(t *testing.T) {
 		env := xtesting.NewTestEnv(t)
-		env.DisableFeature("Batch")
 
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -67,29 +78,47 @@ func TestEnabled(t *testing.T) {
 	})
 
 	t.Run("tfInnerBatchTxn on non-batch tx - feature enabled", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
 		env.Close()
 
-		// A regular payment with tfInnerBatchTxn should fail
-		// Reference: rippled returns telENV_RPC_FAILED (checkValidity)
-		// Our implementation returns temINVALID_FLAG from engine validation
+		// A directly-submitted inner-flagged transaction (no signature) reaches
+		// the engine and fails with temINVALID_FLAG. Reference: rippled
+		// checkValidity short-circuits it to Valid before fixBatchInnerSigs, so
+		// it reaches the engine (Batch_test.cpp doTestInnerSubmitRPC).
 		p := MakeInnerPayment(alice, bob, xtesting.XRP(1), env.Seq(alice))
 		p.Fee = fmt.Sprintf("%d", env.BaseFee())
 		p.SigningPubKey = "" // inner batch format, but submitted directly
 
 		result := env.Submit(p)
-		// Should fail - the exact code may be temINVALID_FLAG or telENV_RPC_FAILED
-		require.False(t, result.Success,
-			"Payment with tfInnerBatchTxn flag should not succeed when submitted directly")
+		xtesting.RequireTxFail(t, result, "temINVALID_FLAG")
+	})
+
+	t.Run("tfInnerBatchTxn on non-batch tx - fixBatchInnerSigs enabled", func(t *testing.T) {
+		env := newBatchEnv(t)
+		env.EnableFeatureNow("fixBatchInnerSigs")
+
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		// With fixBatchInnerSigs an inner-flagged transaction never has a valid
+		// signature, so it is rejected as invalid rather than reaching the
+		// engine. Reference: rippled apply.cpp checkValidity (PR #6069).
+		p := MakeInnerPayment(alice, bob, xtesting.XRP(1), env.Seq(alice))
+		p.Fee = fmt.Sprintf("%d", env.BaseFee())
+		p.SigningPubKey = ""
+
+		result := env.Submit(p)
+		xtesting.RequireTxFail(t, result, "temINVALID")
 	})
 
 	t.Run("tfInnerBatchTxn on non-batch tx - feature disabled", func(t *testing.T) {
 		env := xtesting.NewTestEnv(t)
-		env.DisableFeature("Batch")
 
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -113,7 +142,7 @@ func TestEnabled(t *testing.T) {
 
 func TestPreflight(t *testing.T) {
 	t.Run("temBAD_FEE - negative fee", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -133,7 +162,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temINVALID_FLAG - invalid batch flags", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -152,7 +181,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temINVALID_FLAG - too many mode flags", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -172,7 +201,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temARRAY_EMPTY - no transactions", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		env.Fund(alice)
 		env.Close()
@@ -188,7 +217,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temARRAY_EMPTY - only 1 transaction", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -206,7 +235,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temARRAY_TOO_LARGE - more than 8 transactions", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -225,7 +254,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temREDUNDANT - duplicate batch signer", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -245,7 +274,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temBAD_SIGNER - signer is outer account", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -264,7 +293,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temARRAY_TOO_LARGE - too many signers", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		env.Fund(alice)
 		env.Close()
@@ -286,7 +315,7 @@ func TestPreflight(t *testing.T) {
 
 	// Reference: rippled Batch_test.cpp:398-406.
 	t.Run("temINVALID_INNER_BATCH - malformed inner tx", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -315,7 +344,7 @@ func TestPreflight(t *testing.T) {
 	// the inner's own amendment/flag/fee checks.
 	// Reference: rippled Batch::disabledTxTypes + Batch_test.cpp testLoan().
 	t.Run("temINVALID_INNER_BATCH - disabled inner type (VaultCreate)", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -337,7 +366,7 @@ func TestPreflight(t *testing.T) {
 	// blocklisted inner missing the flag is still temINVALID_INNER_BATCH, not
 	// temINVALID_FLAG.
 	t.Run("temINVALID_INNER_BATCH - disabled type precedes flag check", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -361,7 +390,7 @@ func TestPreflight(t *testing.T) {
 	// The blocklist check precedes the inner zero-fee check: a blocklisted inner
 	// with a non-zero fee is still temINVALID_INNER_BATCH, not temBAD_FEE.
 	t.Run("temINVALID_INNER_BATCH - disabled type precedes fee check", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -385,7 +414,7 @@ func TestPreflight(t *testing.T) {
 	// Reference: rippled Batch_test.cpp:410-501 (per-inner rejection cases).
 
 	t.Run("temBAD_FEE - inner fee non-zero", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -406,7 +435,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temSEQ_AND_TICKET - inner has both Sequence and TicketSequence", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -428,7 +457,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temSEQ_AND_TICKET - inner has neither Sequence nor TicketSequence", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -448,7 +477,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temBAD_SIGNATURE - inner has TxnSignature", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -469,7 +498,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temBAD_SIGNER - inner has Signers", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -492,7 +521,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temBAD_REGKEY - inner has SigningPubKey", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -513,7 +542,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temINVALID - inner is itself a Batch", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -537,7 +566,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temINVALID_FLAG - inner missing tfInnerBatchTxn", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -559,7 +588,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temREDUNDANT - duplicate inner transactions", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -578,7 +607,7 @@ func TestPreflight(t *testing.T) {
 	})
 
 	t.Run("temREDUNDANT - duplicate sequence per account under tfAllOrNothing", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -603,7 +632,7 @@ func TestPreflight(t *testing.T) {
 			batchtx.BatchFlagUntilFailure,
 			batchtx.BatchFlagIndependent,
 		} {
-			env := xtesting.NewTestEnv(t)
+			env := newBatchEnv(t)
 			alice := xtesting.NewAccount("alice")
 			bob := xtesting.NewAccount("bob")
 			env.Fund(alice, bob)
@@ -647,7 +676,7 @@ func TestCalculateBaseFee(t *testing.T) {
 	})
 
 	t.Run("calculateBaseFee from env", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		// Default base fee is 10
 		require.Equal(t, uint64(40), CalcBatchFeeFromEnv(env, 0, 2))
 		require.Equal(t, uint64(50), CalcBatchFeeFromEnv(env, 1, 2))
@@ -661,7 +690,7 @@ func TestCalculateBaseFee(t *testing.T) {
 
 func TestAllOrNothing(t *testing.T) {
 	t.Run("all succeed", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -690,7 +719,7 @@ func TestAllOrNothing(t *testing.T) {
 	})
 
 	t.Run("tec failure - all rolled back", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -720,7 +749,7 @@ func TestAllOrNothing(t *testing.T) {
 	})
 
 	t.Run("tef failure - all rolled back", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -761,7 +790,7 @@ func TestAllOrNothing(t *testing.T) {
 
 func TestOnlyOne(t *testing.T) {
 	t.Run("all transactions fail", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -792,7 +821,7 @@ func TestOnlyOne(t *testing.T) {
 	})
 
 	t.Run("first fails then succeeds - stops after success", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -822,7 +851,7 @@ func TestOnlyOne(t *testing.T) {
 	})
 
 	t.Run("succeeds first - stops immediately", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -859,7 +888,7 @@ func TestOnlyOne(t *testing.T) {
 
 func TestUntilFailure(t *testing.T) {
 	t.Run("first transaction fails - stops immediately", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -890,7 +919,7 @@ func TestUntilFailure(t *testing.T) {
 	})
 
 	t.Run("all transactions succeed", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -921,7 +950,7 @@ func TestUntilFailure(t *testing.T) {
 	})
 
 	t.Run("tec error in middle - stops at failure", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -959,7 +988,7 @@ func TestUntilFailure(t *testing.T) {
 
 func TestIndependent(t *testing.T) {
 	t.Run("multiple transactions fail - all execute", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -990,7 +1019,7 @@ func TestIndependent(t *testing.T) {
 	})
 
 	t.Run("tec error in middle - continues executing", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -1027,7 +1056,7 @@ func TestIndependent(t *testing.T) {
 // =============================================================================
 
 func TestAccountActivation(t *testing.T) {
-	env := xtesting.NewTestEnv(t)
+	env := newBatchEnv(t)
 	alice := xtesting.NewAccount("alice")
 	bob := xtesting.NewAccount("bob")
 	env.FundAmount(alice, uint64(xtesting.XRP(10000))) // rippled funds with XRP(10000)
@@ -1070,7 +1099,7 @@ func TestAccountActivation(t *testing.T) {
 // outer delta (createdCount=2) and wrongly returned tecINVARIANT_FAILED.
 // Reference: rippled apply.cpp:189-207, InvariantCheck.cpp:964-967.
 func TestActivateTwoAccounts(t *testing.T) {
-	env := xtesting.NewTestEnv(t)
+	env := newBatchEnv(t)
 	alice := xtesting.NewAccount("alice")
 	bob := xtesting.NewAccount("bob")
 	carol := xtesting.NewAccount("carol")
@@ -1113,7 +1142,7 @@ func TestActivateTwoAccounts(t *testing.T) {
 // =============================================================================
 
 func TestAccountSet(t *testing.T) {
-	env := xtesting.NewTestEnv(t)
+	env := newBatchEnv(t)
 	alice := xtesting.NewAccount("alice")
 	bob := xtesting.NewAccount("bob")
 	env.Fund(alice, bob)
@@ -1158,7 +1187,7 @@ func TestAccountSet(t *testing.T) {
 
 func TestBadSequence(t *testing.T) {
 	t.Run("past sequence - inner tx with past seq", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -1186,7 +1215,7 @@ func TestBadSequence(t *testing.T) {
 	})
 
 	t.Run("future sequence - inner tx with far future seq", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -1214,7 +1243,7 @@ func TestBadSequence(t *testing.T) {
 	})
 
 	t.Run("same sequence as outer - inner tx uses outer's seq", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -1249,7 +1278,7 @@ func TestBadSequence(t *testing.T) {
 
 func TestBadOuterFee(t *testing.T) {
 	t.Run("insufficient fee without signers", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -1268,7 +1297,7 @@ func TestBadOuterFee(t *testing.T) {
 	})
 
 	t.Run("insufficient fee with batch signers", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -1302,7 +1331,7 @@ func TestBatchDelegate(t *testing.T) {
 		// Inner tx[0] is a payment from alice to bob with Delegate=bob.
 		// Inner tx[1] is a regular payment from alice to bob.
 		// Reference: rippled Batch_test.cpp testBatchDelegate() - "delegated non atomic inner"
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.EnableFeature("PermissionDelegation")
 
 		alice := xtesting.NewAccount("alice")
@@ -1347,7 +1376,7 @@ func TestBatchDelegate(t *testing.T) {
 		// Bob delegates "Payment" permission to carol.
 		// Carol submits batch: inner tx[0] is payment bob->alice with Delegate=carol, inner tx[1] is payment alice->bob.
 		// Reference: rippled Batch_test.cpp testBatchDelegate() - "delegated atomic inner"
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.EnableFeature("PermissionDelegation")
 
 		alice := xtesting.NewAccount("alice")
@@ -1408,7 +1437,7 @@ func TestTickets(t *testing.T) {
 	t.Run("tickets outer", func(t *testing.T) {
 		// Outer batch uses a ticket; inner transactions use regular sequences.
 		// Reference: rippled Batch_test.cpp testTickets() - "tickets outer"
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -1450,7 +1479,7 @@ func TestTickets(t *testing.T) {
 	t.Run("tickets inner", func(t *testing.T) {
 		// Outer batch uses regular sequence; inner transactions use tickets.
 		// Reference: rippled Batch_test.cpp testTickets() - "tickets inner"
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -1492,7 +1521,7 @@ func TestTickets(t *testing.T) {
 	t.Run("tickets outer inner", func(t *testing.T) {
 		// Outer batch uses a ticket; one inner tx uses a ticket, the other uses a sequence.
 		// Reference: rippled Batch_test.cpp testTickets() - "tickets outer inner"
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -1545,7 +1574,7 @@ func TestTicketsOpenLedger(t *testing.T) {
 		// The batch is applied first (canonical order), consuming the ticket
 		// used by the inner tx. The noop that also uses that ticket is
 		// overwritten.
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.EnableOpenLedgerReplay()
 
 		alice := xtesting.NewAccount("alice")
@@ -1591,7 +1620,7 @@ func TestTicketsOpenLedger(t *testing.T) {
 
 	t.Run("after batch txn with same ticket", func(t *testing.T) {
 		// Reference: rippled testTicketsOpenLedger() "After Batch Txn w/ same ticket"
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.EnableOpenLedgerReplay()
 
 		alice := xtesting.NewAccount("alice")
@@ -1647,6 +1676,7 @@ func TestBatchTxQueue(t *testing.T) {
 		// "only outer batch transactions are counter towards the queue size"
 		cfg := makeSmallQueueConfig(2)
 		env := xtesting.NewTestEnvWithTxQ(t, cfg)
+		env.EnableFeatureNow("Batch")
 
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -1710,6 +1740,7 @@ func TestBatchTxQueue(t *testing.T) {
 		// "inner batch transactions are counter towards the ledger tx count"
 		cfg := makeSmallQueueConfig(2)
 		env := xtesting.NewTestEnvWithTxQ(t, cfg)
+		env.EnableFeatureNow("Batch")
 
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -1832,7 +1863,7 @@ func TestSequenceOpenLedger(t *testing.T) {
 		// A noop at aliceSeq+2 gets terPRE_SEQ. Then a batch with carol as
 		// outer submitter and alice as inner signer advances alice's seq.
 		// After close: batch succeeds, noop retried in next ledger.
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.EnableOpenLedgerReplay()
 
 		alice := xtesting.NewAccount("alice")
@@ -1892,7 +1923,7 @@ func TestSequenceOpenLedger(t *testing.T) {
 		// A noop at aliceSeq+1 gets terPRE_SEQ. Then a batch with alice as
 		// outer submitter has inner payments consuming aliceSeq+1 and aliceSeq+2.
 		// After close: batch wins (canonical order), noop overwritten.
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.EnableOpenLedgerReplay()
 
 		alice := xtesting.NewAccount("alice")
@@ -1943,7 +1974,7 @@ func TestSequenceOpenLedger(t *testing.T) {
 		// Reference: rippled testSequenceOpenLedger() "After Batch Txn w/ same sequence"
 		// Batch submitted first, then noop at aliceSeq+1.
 		// After close: batch wins (applied first), noop at same seq overwritten.
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.EnableOpenLedgerReplay()
 
 		alice := xtesting.NewAccount("alice")
@@ -1994,7 +2025,7 @@ func TestSequenceOpenLedger(t *testing.T) {
 		// Reference: rippled testSequenceOpenLedger() "Outer Batch terPRE_SEQ"
 		// Batch outer has a future sequence (carolSeq+1) -> terPRE_SEQ.
 		// A noop advances carol's seq. After close: batch succeeds.
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.EnableOpenLedgerReplay()
 
 		alice := xtesting.NewAccount("alice")
@@ -2066,7 +2097,7 @@ func TestObjectsOpenLedger(t *testing.T) {
 		// In our Go code, the batch inner txns are applied immediately, so
 		// the CheckCash may succeed or fail depending on submission order.
 		// After replay-on-close, the final state is the same.
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.EnableOpenLedgerReplay()
 
 		alice := xtesting.NewAccount("alice")
@@ -2127,7 +2158,7 @@ func TestObjectsOpenLedger(t *testing.T) {
 		// CheckCreate submitted before the batch. The batch's inner CheckCash
 		// consumes the check. The standalone CheckCreate runs first in the
 		// open view.
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.EnableOpenLedgerReplay()
 
 		alice := xtesting.NewAccount("alice")
@@ -2181,7 +2212,7 @@ func TestObjectsOpenLedger(t *testing.T) {
 		// Batch creates a check (inner), then standalone CheckCash tries to cash it.
 		// In rippled, the CheckCash gets tecNO_ENTRY because batch inner txns
 		// are deferred. During replay, batch applies first, then CheckCash succeeds.
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.EnableOpenLedgerReplay()
 
 		alice := xtesting.NewAccount("alice")
@@ -2251,7 +2282,7 @@ func TestOpenLedger(t *testing.T) {
 	// In our implementation, since inner batch txns are applied immediately,
 	// bob's payment at bobSeq+1 may or may not get terPRE_SEQ depending on
 	// whether the batch has already been applied. We verify final state.
-	env := xtesting.NewTestEnv(t)
+	env := newBatchEnv(t)
 	env.EnableOpenLedgerReplay()
 
 	alice := xtesting.NewAccount("alice")
@@ -2336,7 +2367,7 @@ func TestOpenLedger(t *testing.T) {
 
 func TestBadRawTxn(t *testing.T) {
 	t.Run("nil inner transaction", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -2372,7 +2403,7 @@ func TestPreclaim(t *testing.T) {
 	// Tests checkSign.checkSingleSign, checkBatchSign.checkMultiSign, and checkBatchSign.checkSingleSign.
 	// Uses a shared environment because state accumulates (signer lists, regular keys, disabled masters).
 
-	env := xtesting.NewTestEnv(t)
+	env := newBatchEnv(t)
 
 	alice := xtesting.NewAccount("alice")
 	bob := xtesting.NewAccount("bob")
@@ -2651,7 +2682,7 @@ func TestPreclaim(t *testing.T) {
 func TestAccountDelete(t *testing.T) {
 	t.Run("tfIndependent - account delete success", func(t *testing.T) {
 		// Reference: rippled Batch_test.cpp testAccountDelete() - tfIndependent success
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -2689,7 +2720,7 @@ func TestAccountDelete(t *testing.T) {
 
 	t.Run("tfIndependent - account delete fails", func(t *testing.T) {
 		// Reference: rippled Batch_test.cpp testAccountDelete() - tfIndependent fails
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -2729,7 +2760,7 @@ func TestAccountDelete(t *testing.T) {
 
 	t.Run("tfAllOrNothing - account delete fails", func(t *testing.T) {
 		// Reference: rippled Batch_test.cpp testAccountDelete() - tfAllOrNothing fails
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -2773,7 +2804,7 @@ func TestObjectCreateSequence(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		// Create a CheckCreate from bob to alice, then CheckCash from alice, all in a batch.
 		// Reference: rippled Batch_test.cpp testObjectCreateSequence() - success
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -2836,7 +2867,7 @@ func TestObjectCreateSequence(t *testing.T) {
 		// Alice enables asfRequireDest, so CheckCreate to alice fails with tecDST_TAG_NEEDED.
 		// In Independent mode, CheckCash then fails with tecNO_ENTRY.
 		// Reference: rippled Batch_test.cpp testObjectCreateSequence() - failure
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -2905,7 +2936,7 @@ func TestObjectCreateSequence(t *testing.T) {
 func TestObjectCreateTicket(t *testing.T) {
 	// Create tickets inside a batch, then use a ticket for CheckCreate, then CheckCash.
 	// Reference: rippled Batch_test.cpp testObjectCreateTicket()
-	env := xtesting.NewTestEnv(t)
+	env := newBatchEnv(t)
 
 	alice := xtesting.NewAccount("alice")
 	bob := xtesting.NewAccount("bob")
@@ -2984,7 +3015,7 @@ func TestObjectCreate3rdParty(t *testing.T) {
 	// bob creates a check for alice, alice cashes it.
 	// batch::sig(alice, bob) provides authorization.
 
-	env := xtesting.NewTestEnv(t)
+	env := newBatchEnv(t)
 
 	alice := xtesting.NewAccount("alice")
 	bob := xtesting.NewAccount("bob")
@@ -3052,7 +3083,7 @@ func TestObjectCreate3rdParty(t *testing.T) {
 
 func TestBatchCalculateBaseFee(t *testing.T) {
 	t.Run("too many txns returns error fee", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -3074,7 +3105,7 @@ func TestBatchCalculateBaseFee(t *testing.T) {
 	})
 
 	t.Run("too many signers returns error fee", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		env.Fund(alice)
 		env.Close()
@@ -3097,7 +3128,7 @@ func TestBatchCalculateBaseFee(t *testing.T) {
 	})
 
 	t.Run("valid batch fee calculation", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -3129,7 +3160,7 @@ func TestBatchSigningVectors(t *testing.T) {
 	// temBAD_SIGNER: bob's inner makes bob a required signer, but no BatchSigners
 	// are provided at all, so the required set is never emptied (Batch.cpp:448-453).
 	t.Run("temBAD_SIGNER - foreign inner with no batch signers", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -3149,7 +3180,7 @@ func TestBatchSigningVectors(t *testing.T) {
 	// temBAD_SIGNER: a presented signer is not required because both inner txns
 	// belong to the outer account, so requiredSigners is empty (Batch.cpp:530-541).
 	t.Run("temBAD_SIGNER - stray signer, no inner requires it", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -3170,7 +3201,7 @@ func TestBatchSigningVectors(t *testing.T) {
 	// temBAD_SIGNER: bob's inner requires bob, but the presented signer is carol
 	// (Batch.cpp:543-552).
 	t.Run("temBAD_SIGNER - wrong signer for required inner account", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		carol := xtesting.NewAccount("carol")
@@ -3192,7 +3223,7 @@ func TestBatchSigningVectors(t *testing.T) {
 	// temBAD_SIGNER: a required inner account (carol) is left uncovered after all
 	// presented signers are consumed (Batch.cpp:581-592).
 	t.Run("temBAD_SIGNER - required inner account uncovered", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		carol := xtesting.NewAccount("carol")
@@ -3220,7 +3251,7 @@ func TestBatchSigningVectors(t *testing.T) {
 	// alice). This mirrors rippled, where checkBatchSign rejects in preflight before
 	// the preclaim authorization check is reached.
 	t.Run("temBAD_SIGNATURE - signature key mismatched to signing pubkey", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.VerifySignatures = true
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -3242,7 +3273,7 @@ func TestBatchSigningVectors(t *testing.T) {
 	// temBAD_SIGNATURE: bob is the required signer with his own public key but a
 	// corrupted signature that does not verify over the batch digest.
 	t.Run("temBAD_SIGNATURE - garbage signature", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.VerifySignatures = true
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -3264,7 +3295,7 @@ func TestBatchSigningVectors(t *testing.T) {
 	// tesSUCCESS: a single required signer (bob) signs the batch digest with his
 	// master key — a valid single-signed BatchSigner.
 	t.Run("tesSUCCESS - valid single-signed batch signer", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -3286,7 +3317,7 @@ func TestBatchSigningVectors(t *testing.T) {
 	// verification enabled so bob's BatchTxnSignature is checked cryptographically
 	// over the batch digest, exercising the engine's batch single-sign crypto path.
 	t.Run("tesSUCCESS - valid single-signed batch signer (verified)", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.VerifySignatures = true
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -3309,7 +3340,7 @@ func TestBatchSigningVectors(t *testing.T) {
 	// BatchSigner (carol + dave on bob's signer list) — a valid multi-signed
 	// BatchSigner.
 	t.Run("tesSUCCESS - valid multi-signed batch signer", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		carol := xtesting.NewAccount("carol")
@@ -3340,7 +3371,7 @@ func TestBatchSigningVectors(t *testing.T) {
 	// cryptographically over the digest-plus-accountID message, exercising the
 	// engine's batch multi-sign crypto path end-to-end.
 	t.Run("tesSUCCESS - valid multi-signed batch signer (verified)", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		carol := xtesting.NewAccount("carol")
@@ -3372,7 +3403,7 @@ func TestBatchSigningVectors(t *testing.T) {
 	// tesSUCCESS: a single-account batch (both inners from the outer account)
 	// needs no BatchSigners at all.
 	t.Run("tesSUCCESS - single-account batch needs no signers", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
 		env.Fund(alice, bob)
@@ -3423,7 +3454,7 @@ func TestBatchSignerArrayBound(t *testing.T) {
 	// Amendment enabled (mainnet): the bound is 32. 33 nested signers is rejected
 	// in preflight before any SignerList lookup.
 	t.Run("ExpandedSignerList enabled - 33 nested signers rejected", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		require.True(t, env.FeatureEnabled("ExpandedSignerList"))
 		alice := xtesting.NewAccount("alice")
 		bob := xtesting.NewAccount("bob")
@@ -3441,7 +3472,7 @@ func TestBatchSignerArrayBound(t *testing.T) {
 	// Amendment disabled: the bound drops to 8. 9 nested signers is rejected in
 	// preflight regardless of the SignerList.
 	t.Run("ExpandedSignerList disabled - 9 nested signers rejected", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.DisableFeature("ExpandedSignerList")
 		env.Close()
 		require.False(t, env.FeatureEnabled("ExpandedSignerList"))
@@ -3462,7 +3493,7 @@ func TestBatchSignerArrayBound(t *testing.T) {
 	// Amendment disabled: 8 nested signers is exactly the bound and passes the
 	// full pipeline when bob authorizes all eight with a met quorum.
 	t.Run("ExpandedSignerList disabled - 8 nested signers accepted", func(t *testing.T) {
-		env := xtesting.NewTestEnv(t)
+		env := newBatchEnv(t)
 		env.DisableFeature("ExpandedSignerList")
 		env.Close()
 		require.False(t, env.FeatureEnabled("ExpandedSignerList"))

--- a/internal/tx/engine/preclaim.go
+++ b/internal/tx/engine/preclaim.go
@@ -15,10 +15,13 @@ import (
 )
 
 // preclaim validates the transaction against the current ledger state.
-// Mirrors rippled's Transactor::operator()() pre-application pipeline:
+// Mirrors rippled's invoke_preclaim pipeline (applySteps.cpp, PR #6192):
 //
-//	checkSeqProxy → checkPriorTxAndLastLedger → checkFee → checkPermission →
-//	checkSign (+ checkBatchSign) → tx-type preclaim.
+//	checkSeqProxy → checkPriorTxAndLastLedger → checkSign (+ checkBatchSign) →
+//	checkFee → checkPermission → tx-type preclaim.
+//
+// The signature stage precedes the fee and permission checks so that no
+// fee-charging TER is ever returned before the signature has been verified.
 func (e *Engine) preclaim(tx txcore.Transaction, txHash [32]byte) ter.Result {
 	common := tx.GetCommon()
 
@@ -34,28 +37,36 @@ func (e *Engine) preclaim(tx txcore.Transaction, txHash [32]byte) ter.Result {
 	if result := e.checkPriorTxAndLastLedger(common, account, txHash); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := e.checkFee(tx, common, account); result != ter.TesSUCCESS {
-		return result
-	}
-	if result := e.checkPermission(tx, common, accountID); result != ter.TesSUCCESS {
-		return result
-	}
+
+	// The signature is verified before the fee and permission checks so that a
+	// transaction that fails both signature verification and a fee/permission
+	// check reports the signature failure. No fee-charging TER (terINSUF_FEE_B,
+	// tecNO_DELEGATE_PERMISSION, ...) may precede the signature check, which
+	// would risk charging a fee on an unauthorized transaction.
+	// Reference: rippled applySteps.cpp invoke_preclaim (PR #6192).
 	if result := e.checkSign(tx, common); result != ter.TesSUCCESS {
 		return result
 	}
-
-	// Step 6: checkBatchSign — batch signer authorization
-	// Reference: rippled Batch::checkSign -> Transactor::checkBatchSign
-	// This checks that each BatchSigner is authorized to act as their account.
-	// This runs even when SkipSignatureVerification is true because it checks
-	// authorization (account existence, master key, regular key), not crypto.
+	// checkBatchSign is part of the signature stage (rippled Batch::checkSign =
+	// Transactor::checkSign + Transactor::checkBatchSign), so it moves ahead of
+	// checkFee together with checkSign. It verifies each BatchSigner is
+	// authorized to act as their account and runs even under
+	// SkipSignatureVerification because it checks authorization (account
+	// existence, master/regular key), not crypto.
 	if bsp, ok := tx.(txcore.BatchSignerProvider); ok {
 		if result := e.checkBatchSign(bsp.GetBatchSigners()); result != ter.TesSUCCESS {
 			return result
 		}
 	}
 
-	// Step 7: Transaction-specific preclaim checks.
+	if result := e.checkFee(tx, common, account); result != ter.TesSUCCESS {
+		return result
+	}
+	if result := e.checkPermission(tx, common, accountID); result != ter.TesSUCCESS {
+		return result
+	}
+
+	// Transaction-specific preclaim checks.
 	// These run after all common preclaim checks and are subject to the
 	// TapRETRY gate in Apply(). tec results from preclaim are NOT applied
 	// when TapRETRY is set (likelyToClaimFee = false), matching rippled's

--- a/internal/tx/engine/preclaim_precedence_test.go
+++ b/internal/tx/engine/preclaim_precedence_test.go
@@ -1,0 +1,157 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// Genesis keypair: the master-passphrase public key derives to this address, so
+// signing with it is authorized only while the account's master key is enabled.
+const (
+	precedenceGenesisAddr   = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	precedenceGenesisPubKey = "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020"
+	// A second, unrelated account used as the transaction source.
+	precedenceSourceAddr = "rMRxj8jED6ZCjtjgFxB4cz1MGVNtYqCEyS"
+)
+
+// precedenceEngine builds an engine over a mock view with all supported
+// amendments enabled and an open ledger (so the fee floor is active).
+func precedenceEngine(t *testing.T, accounts map[string]*state.AccountRoot) *Engine {
+	t.Helper()
+	base := newMockBaseView()
+	for addr, root := range accounts {
+		id, err := state.DecodeAccountID(addr)
+		if err != nil {
+			t.Fatalf("decode %s: %v", addr, err)
+		}
+		data, err := state.SerializeAccountRoot(root)
+		if err != nil {
+			t.Fatalf("serialize %s: %v", addr, err)
+		}
+		base.data[keylet.Account(id).Key] = data
+	}
+	return NewEngine(base, txcore.EngineConfig{
+		BaseFee:        10,
+		OpenLedger:     true,
+		LedgerSequence: 100,
+		Rules:          amendment.AllSupportedRules(),
+	})
+}
+
+func u32(v uint32) *uint32 { return &v }
+
+// TestPreclaimPrecedence_SignBeforeFee pins the invoke_preclaim ordering change
+// (rippled PR #6192): the signature check runs before the fee check, so a
+// transaction that fails BOTH signature verification and the fee check surfaces
+// the signature failure — never a fee-charging TER. Reference: rippled
+// applySteps.cpp invoke_preclaim.
+func TestPreclaimPrecedence_SignBeforeFee(t *testing.T) {
+	// masterDisabled + zero balance: checkSign yields tefMASTER_DISABLED and
+	// checkFee yields terINSUF_FEE_B. The reorder must return the signature code.
+	makeTx := func() *txcore.BaseTx {
+		tx := txcore.NewBaseTx(txcore.TypeAccountSet, precedenceGenesisAddr)
+		tx.Fee = "100"
+		tx.Sequence = u32(5)
+		tx.SigningPubKey = precedenceGenesisPubKey
+		return tx
+	}
+
+	t.Run("bad sign + insufficient fee returns sign error", func(t *testing.T) {
+		e := precedenceEngine(t, map[string]*state.AccountRoot{
+			precedenceGenesisAddr: {
+				Account:  precedenceGenesisAddr,
+				Balance:  0, // below the 100-drop fee
+				Sequence: 5,
+				Flags:    state.LsfDisableMaster, // master signing not allowed
+			},
+		})
+		if got := e.preclaim(makeTx(), [32]byte{}); got != ter.TefMASTER_DISABLED {
+			t.Fatalf("combined sign+fee failure = %v, want TefMASTER_DISABLED", got)
+		}
+	})
+
+	t.Run("fee check still fires when signature is authorized", func(t *testing.T) {
+		// Master enabled → checkSign passes; zero balance → checkFee fails.
+		e := precedenceEngine(t, map[string]*state.AccountRoot{
+			precedenceGenesisAddr: {
+				Account:  precedenceGenesisAddr,
+				Balance:  0,
+				Sequence: 5,
+			},
+		})
+		if got := e.preclaim(makeTx(), [32]byte{}); got != ter.TerINSUF_FEE_B {
+			t.Fatalf("fee-only failure = %v, want TerINSUF_FEE_B", got)
+		}
+	})
+
+	t.Run("sign check still fires when fee is affordable", func(t *testing.T) {
+		// Master disabled → checkSign fails; ample balance → checkFee passes.
+		e := precedenceEngine(t, map[string]*state.AccountRoot{
+			precedenceGenesisAddr: {
+				Account:  precedenceGenesisAddr,
+				Balance:  1_000_000,
+				Sequence: 5,
+				Flags:    state.LsfDisableMaster,
+			},
+		})
+		if got := e.preclaim(makeTx(), [32]byte{}); got != ter.TefMASTER_DISABLED {
+			t.Fatalf("sign-only failure = %v, want TefMASTER_DISABLED", got)
+		}
+	})
+}
+
+// TestPreclaimPrecedence_SignBeforePermission pins the same reorder for the
+// delegate permission check (go-xrpl's checkPermission, PR #1257): a
+// delegated transaction that fails both signature verification and the delegate
+// permission check surfaces the signature failure, not tecNO_DELEGATE_PERMISSION.
+func TestPreclaimPrecedence_SignBeforePermission(t *testing.T) {
+	// Source delegates to the genesis account. No Delegate SLE exists, so
+	// checkPermission yields tecNO_DELEGATE_PERMISSION. Signature is verified
+	// against the delegate (genesis); disabling its master key makes checkSign
+	// yield tefMASTER_DISABLED. The delegate funds the fee, so checkFee passes.
+	makeTx := func() *txcore.BaseTx {
+		tx := txcore.NewBaseTx(txcore.TypeAccountSet, precedenceSourceAddr)
+		tx.Fee = "10"
+		tx.Sequence = u32(5)
+		tx.SigningPubKey = precedenceGenesisPubKey
+		tx.Delegate = precedenceGenesisAddr
+		return tx
+	}
+	source := &state.AccountRoot{Account: precedenceSourceAddr, Balance: 1_000_000, Sequence: 5}
+
+	t.Run("bad sign + no delegate permission returns sign error", func(t *testing.T) {
+		e := precedenceEngine(t, map[string]*state.AccountRoot{
+			precedenceSourceAddr: source,
+			precedenceGenesisAddr: {
+				Account:  precedenceGenesisAddr,
+				Balance:  1_000_000,
+				Sequence: 1,
+				Flags:    state.LsfDisableMaster,
+			},
+		})
+		if got := e.preclaim(makeTx(), [32]byte{}); got != ter.TefMASTER_DISABLED {
+			t.Fatalf("combined sign+permission failure = %v, want TefMASTER_DISABLED", got)
+		}
+	})
+
+	t.Run("permission check still fires when signature is authorized", func(t *testing.T) {
+		// Delegate master enabled → checkSign passes; missing Delegate SLE →
+		// checkPermission fails.
+		e := precedenceEngine(t, map[string]*state.AccountRoot{
+			precedenceSourceAddr: source,
+			precedenceGenesisAddr: {
+				Account:  precedenceGenesisAddr,
+				Balance:  1_000_000,
+				Sequence: 1,
+			},
+		})
+		if got := e.preclaim(makeTx(), [32]byte{}); got != ter.TecNO_DELEGATE_PERMISSION {
+			t.Fatalf("permission-only failure = %v, want TecNO_DELEGATE_PERMISSION", got)
+		}
+	})
+}

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -131,13 +131,39 @@ func (e *Engine) preflightCommonFields(tx txcore.Transaction, common *txcore.Com
 		return result
 	}
 
-	// tfInnerBatchTxn must never appear on a directly-submitted transaction.
-	// Reference: rippled Transactor.cpp preflight0().
-	if common.Flags != nil && *common.Flags&txcore.TfInnerBatchTxn != 0 {
-		return ter.TemINVALID_FLAG
+	if result := e.preflightInnerBatchFlag(common); result != ter.TesSUCCESS {
+		return result
 	}
 
 	return ter.TesSUCCESS
+}
+
+// preflightInnerBatchFlag rejects a directly-submitted transaction that carries
+// tfInnerBatchTxn. That flag is only ever set by the Batch transactor on the
+// inner transactions it applies (which flow through preflightInner, not here),
+// so on a top-level submission it is always illegitimate.
+//
+// The rejection code mirrors rippled across the two amendment gates:
+//   - Batch disabled: the flag itself is undefined → temINVALID_FLAG
+//     (rippled Transactor::preflight1, unchanged by fixBatchInnerSigs).
+//   - Batch enabled: such a transaction still has no valid signature (its
+//     SigningPubKey is empty). With fixBatchInnerSigs it is rejected as a bad
+//     signature before reaching the engine (rippled apply.cpp checkValidity
+//     falls through to checkSign → SigBad → temINVALID). Before the fix it
+//     reached the transaction engine and failed with temINVALID_FLAG. Either
+//     way it can never apply.
+func (e *Engine) preflightInnerBatchFlag(common *txcore.Common) ter.Result {
+	if common.Flags == nil || *common.Flags&txcore.TfInnerBatchTxn == 0 {
+		return ter.TesSUCCESS
+	}
+	rules := e.rules()
+	if !rules.Enabled(amendment.FeatureBatch) {
+		return ter.TemINVALID_FLAG
+	}
+	if rules.Enabled(amendment.FeatureFixBatchInnerSigs) {
+		return ter.TemINVALID
+	}
+	return ter.TemINVALID_FLAG
 }
 
 // Shared between outer (preflightCommonFields) and inner (preflightInner).

--- a/internal/tx/engine/preflight_inner_batch_test.go
+++ b/internal/tx/engine/preflight_inner_batch_test.go
@@ -1,0 +1,78 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+// batchRules builds a rules set from the all-supported preset with the named
+// amendments additionally enabled. Batch and fixBatchInnerSigs are Supported::no
+// upstream, so they are absent from the preset and must be enabled explicitly.
+func batchRules(names ...string) *amendment.Rules {
+	b := amendment.NewRulesBuilder().FromPreset(amendment.PresetAllSupported)
+	for _, n := range names {
+		b.EnableByName(n)
+	}
+	return b.Build()
+}
+
+func innerFlaggedTx() *txcore.Common {
+	tx := txcore.NewBaseTx(txcore.TypePayment, precedenceSourceAddr)
+	flags := txcore.TfInnerBatchTxn
+	tx.Flags = &flags
+	return tx.GetCommon()
+}
+
+// TestPreflightInnerBatchFlag exercises the tfInnerBatchTxn rejection on a
+// directly-submitted transaction across the Batch and fixBatchInnerSigs gates,
+// mirroring rippled's Transactor::preflight1 (temINVALID_FLAG when Batch is
+// disabled) and apply.cpp checkValidity (fixBatchInnerSigs, PR #6069).
+func TestPreflightInnerBatchFlag(t *testing.T) {
+	tests := []struct {
+		name  string
+		rules *amendment.Rules
+		want  ter.Result
+	}{
+		{
+			// The flag is undefined without Batch → invalid flag.
+			name:  "batch disabled",
+			rules: batchRules(),
+			want:  ter.TemINVALID_FLAG,
+		},
+		{
+			// Pre-fix: the transaction reached the engine and failed with
+			// temINVALID_FLAG (checkValidity short-circuited it to Valid).
+			name:  "batch enabled, fix disabled",
+			rules: batchRules("Batch"),
+			want:  ter.TemINVALID_FLAG,
+		},
+		{
+			// Post-fix: an inner-flagged transaction never has a valid
+			// signature, so it is rejected as invalid before applying.
+			name:  "batch enabled, fix enabled",
+			rules: batchRules("Batch", "fixBatchInnerSigs"),
+			want:  ter.TemINVALID,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := NewEngine(newMockBaseView(), txcore.EngineConfig{Rules: tt.rules})
+			if got := e.preflightInnerBatchFlag(innerFlaggedTx()); got != tt.want {
+				t.Fatalf("preflightInnerBatchFlag = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPreflightInnerBatchFlag_AbsentFlag confirms an ordinary transaction (no
+// tfInnerBatchTxn) is unaffected by the gate regardless of the amendments.
+func TestPreflightInnerBatchFlag_AbsentFlag(t *testing.T) {
+	tx := txcore.NewBaseTx(txcore.TypePayment, precedenceSourceAddr)
+	e := NewEngine(newMockBaseView(), txcore.EngineConfig{Rules: batchRules("Batch", "fixBatchInnerSigs")})
+	if got := e.preflightInnerBatchFlag(tx.GetCommon()); got != ter.TesSUCCESS {
+		t.Fatalf("preflightInnerBatchFlag(no flag) = %v, want TesSUCCESS", got)
+	}
+}


### PR DESCRIPTION
Brings the transaction engine to rippled **3.1.0/3.1.1** parity for the signature-precedence and batch-inner-signature changes. Targets the `v3.0.0` integration branch.

Part of #1245 (Phase B); closes #1246.

## Changes

### 1. Preclaim reorder — rippled PR #6192 (ungated TER-precedence change)
`invoke_preclaim` reorders the signature check ahead of the fee and permission checks so that a fee-charging TER is never returned before the signature has been verified (rationale: never risk charging a fee on an unauthorized transaction).

- `internal/tx/engine/preclaim.go`: `checkSign` (+ `checkBatchSign`, which rippled folds into `Batch::checkSign`) now runs **before** `checkFee` and `checkPermission`.
- New order: `checkSeqProxy → checkPriorTxAndLastLedger → checkSign → checkBatchSign → checkFee → checkPermission → tx-type preclaim`.
- Externally observable: a transaction that fails **both** signature verification and a fee/permission check now returns the signature error (e.g. `tefMASTER_DISABLED`) instead of `terINSUF_FEE_B` / `tecNO_DELEGATE_PERMISSION`. The go-xrpl delegate-permission machinery (from #1257) lives in `checkPermission`, which now runs after `checkSign`.

### 2. fixBatchInnerSigs — rippled PR #6069
- **Amendment registered** `Supported::no` / `DefaultNo`. It was introduced `Supported::yes` in 3.1.0, then **withdrawn to `Supported::no` in rippled 3.1.1 (PR #6402)** pending a fix, which is the up-to-date state mirrored here.
- **Gated behaviour**: a directly-submitted / relayed transaction carrying `tfInnerBatchTxn` (which has no valid signature — empty `SigningPubKey`) is gated in `internal/tx/engine/preflight.go` (`preflightInnerBatchFlag`): `temINVALID_FLAG` without Batch, and `temINVALID` once `fixBatchInnerSigs` activates (mirroring rippled `apply.cpp checkValidity` falling through to `checkSign → SigBad → temINVALID`; before the fix it reached the engine and failed with `temINVALID_FLAG`).
- **Companion preflight2 change (ungated)**: rippled's sig-skip condition flips from `(tfInnerBatchTxn && !featureBatch)` to `(tfInnerBatchTxn && featureBatch)`. go-xrpl already routes genuine inner transactions through `preflightInner` (skips signature verification) and applies them via `applyInnerTransaction`, so the inner-tx sig-skip is architecturally scoped to the Batch-enabled path; the outer/directly-submitted gate above carries the observable half of the flip.

> Note: go-xrpl has a **single-stage** validity architecture (the engine preflight is the ingress validity path) rather than rippled's two-stage `checkValidity` (ingress) + `preflight2` (apply). The only outside-engine `tfInnerBatchTxn` handling is the relay filter in `openledger.go`, which already matches rippled's `NetworkOPs` (PR #6069's edit there was a no-op parenthesization).

### 3. Batch support withdrawal — issue #1246, rippled 3.1.1 PR #6402
- `FeatureBatch` flipped `Supported::yes → Supported::no` (`DefaultNo` unchanged).
- The all-supported test preset no longer activates Batch, so the Batch integration suite opts in via `EnableFeatureNow("Batch")` (new `newBatchEnv` helper). The Batch **conformance** fixtures gate amendments per-fixture and are unaffected — verified below.

### Docs
Regenerated `docs/amendments.md` for the two registry changes (total 103 → 104).

## Tests
- `internal/tx/engine/preclaim_precedence_test.go`: pins both reorder orders — bad-sig + insufficient-fee → sig error; bad-sig + no-delegate-permission → sig error; plus fee-only and permission-only controls.
- `internal/tx/engine/preflight_inner_batch_test.go`: the `(Batch × fixBatchInnerSigs)` matrix (disabled → `temINVALID_FLAG`, enabled/pre-fix → `temINVALID_FLAG`, enabled/post-fix → `temINVALID`).
- `internal/testing/batch/batch_test.go`: tightened the directly-submitted inner-flagged case to assert `temINVALID_FLAG` and added a `fixBatchInnerSigs`-enabled case asserting `temINVALID`; all Batch tests force-enable the amendment.

## Verification
- `just build-all` clean.
- Full `just test` — all packages pass; the only failures are the pre-existing out-of-scope conformance suites (Vault/Batch/XChain/Delegate).
- **Conformance diff vs the v3.0.0 baseline: byte-identical** (1019 normalized detail lines, 178 leaf failures = 178, zero new / zero fixed). The Batch conformance suite is 25 fail = 25 fail with identical error messages, confirming the per-fixture amendment gating is unaffected.
- `golangci-lint run --config .golangci.yml ./...` → 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)