### PR TITLE
feat(number): runtime mantissa scale + faithful to_string (rippled 3.1.0, Phase A)

### DIFF
--- a/codec/binarycodec/types/number.go
+++ b/codec/binarycodec/types/number.go
@@ -27,6 +27,14 @@ var (
 	ErrNumberOverflow = errors.New("mantissa and exponent are too large")
 )
 
+// numberRangeLog is log10 of the normalized mantissa minimum. It drives
+// to_string's scientific-vs-decimal threshold and padding. STNumber serializes
+// and normalizes at the small scale (rangeLog 15) on the current chain; the
+// large scale (rangeLog 18) is threaded in when SingleAssetVault /
+// LendingProtocol activate (Number/codec Phase B). formatNumberText is faithful
+// for either value.
+const numberRangeLog = 15
+
 // numberRegex matches decimal/float/scientific number strings.
 // Pattern: optional sign, integer part, optional decimal, optional exponent
 var numberRegex = regexp.MustCompile(`^([-+]?)([0-9]+)(?:\.([0-9]+))?(?:[eE]([+-]?[0-9]+))?$`)
@@ -67,24 +75,8 @@ func (n *Number) ToJSON(p *serdes.BinaryParser, _ ...int) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	mantissa := bigMantissa.Int64()
 
-	// Special zero case
-	if mantissa == 0 && exponent == defaultZeroExp {
-		return "0", nil
-	}
-
-	if exponent == 0 {
-		return big.NewInt(mantissa).String(), nil
-	}
-
-	// Use scientific notation for very small/large exponents
-	if exponent < -25 || exponent > -5 {
-		return formatScientific(mantissa, exponent), nil
-	}
-
-	// Decimal rendering for -25 <= exp <= -5
-	return formatDecimal(mantissa, exponent), nil
+	return formatNumberText(bigMantissa, exponent, numberRangeLog), nil
 }
 
 // parseAndNormalize extracts mantissa, exponent from a string and normalizes them.
@@ -205,43 +197,57 @@ func normalize(mantissa *big.Int, exponent int32) (*big.Int, int32, error) {
 	return m, exponent, nil
 }
 
-// formatScientific formats mantissa and exponent as scientific notation string.
-func formatScientific(mantissa int64, exponent int32) string {
-	return strconv.FormatInt(mantissa, 10) + "e" + strconv.Itoa(int(exponent))
-}
+// formatNumberText renders a normalized (mantissa, exponent) as rippled's
+// to_string(Number) does, for a given rangeLog. It uses scientific notation
+// outside a threshold band and decimal within it; in the scientific branch the
+// mantissa's trailing zeros are shifted into the exponent (a live 3.1.0
+// formatting change), so e.g. 1000000000000000e-45 renders as 1e-30. The sign
+// is emitted separately.
+func formatNumberText(mantissa *big.Int, exponent int32, rangeLog int) string {
+	if mantissa.Sign() == 0 {
+		return "0"
+	}
+	negative := mantissa.Sign() < 0
+	m := new(big.Int).Abs(mantissa)
+	L := int32(rangeLog)
 
-// formatDecimal formats mantissa and exponent as a decimal string.
-func formatDecimal(mantissa int64, exponent int32) string {
-	isNegative := mantissa < 0
-	if isNegative {
-		mantissa = -mantissa
+	if exponent != 0 && (exponent < -(L+10) || exponent > -(L-10)) {
+		ten := big.NewInt(10)
+		q := new(big.Int)
+		r := new(big.Int)
+		for m.Sign() != 0 && exponent < maxExponent {
+			q.QuoRem(m, ten, r)
+			if r.Sign() != 0 {
+				break
+			}
+			m.Set(q)
+			exponent++
+		}
+		s := m.String() + "e" + strconv.Itoa(int(exponent))
+		if negative {
+			return "-" + s
+		}
+		return s
 	}
 
-	mantissaStr := big.NewInt(mantissa).String()
-
-	// Pad with zeros for proper decimal placement
-	const padPrefix = 27
-	const padSuffix = 23
-	rawValue := strings.Repeat("0", padPrefix) + mantissaStr + strings.Repeat("0", padSuffix)
-
-	offset := min(max(int(exponent)+43, 0), len(rawValue))
+	padPrefix := rangeLog + 12
+	padSuffix := rangeLog + 8
+	rawValue := strings.Repeat("0", padPrefix) + m.String() + strings.Repeat("0", padSuffix)
+	offset := int(exponent) + padPrefix + rangeLog + 1
 
 	integerPart := strings.TrimLeft(rawValue[:offset], "0")
 	if integerPart == "" {
 		integerPart = "0"
 	}
-
 	fractionPart := strings.TrimRight(rawValue[offset:], "0")
 
 	result := integerPart
 	if fractionPart != "" {
 		result += "." + fractionPart
 	}
-
-	if isNegative {
+	if negative {
 		result = "-" + result
 	}
-
 	return result
 }
 

--- a/codec/binarycodec/types/number_format_test.go
+++ b/codec/binarycodec/types/number_format_test.go
@@ -1,0 +1,75 @@
+package types
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec/serdes"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFormatNumberText ports rippled 3.1.0's to_string(Number) cases for both
+// mantissa scales (rangeLog 15 = small, 18 = large). Inputs are the normalized
+// (internal mantissa, exponent) values a Number holds after construction.
+func TestFormatNumberText(t *testing.T) {
+	t.Parallel()
+	bi := func(s string) *big.Int { v, _ := new(big.Int).SetString(s, 10); return v }
+
+	cases := []struct {
+		mantissa string
+		exponent int32
+		rangeLog int
+		want     string
+	}{
+		// The live 3.1.0 change: trailing zeros shift out of the scientific
+		// mantissa into the exponent, for both scales.
+		{"1000000000000000", -45, 15, "1e-30"},
+		{"-1000000000000000", -45, 15, "-1e-30"},
+		{"1000000000000000000", -48, 18, "1e-30"},
+
+		// Common cases (identical for both scales), given their small-scale
+		// normalized form.
+		{"2000000000000000", -35, 15, "2e-20"},
+		{"-2000000000000000", -35, 15, "-2e-20"},
+		{"2500000000000000", -13, 15, "250"},
+		{"2500000000000000", -17, 15, "0.025"},
+
+		// Small-scale limits.
+		{"1000000000000000", -32768, 15, "1e-32753"},
+		{"9999999999999999", 32768, 15, "9999999999999999e32768"},
+		{"-9999999999999999", 32768, 15, "-9999999999999999e32768"},
+
+		// Large-scale limits and int64-boundary values (internal mantissa may
+		// exceed int64, hence big.Int).
+		{"1000000000000000000", -32768, 18, "1e-32750"},
+		{"9223372036854775807", 32768, 18, "9223372036854775807e32768"},
+		{"-9223372036854775807", 32768, 18, "-9223372036854775807e32768"},
+		{"9999999999999999990", 0, 18, "9999999999999999990"},
+		{"9223372036854775810", 0, 18, "9223372036854775810"},
+	}
+	for _, tc := range cases {
+		got := formatNumberText(bi(tc.mantissa), tc.exponent, tc.rangeLog)
+		require.Equalf(t, tc.want, got, "formatNumberText(%s, %d, L=%d)", tc.mantissa, tc.exponent, tc.rangeLog)
+	}
+}
+
+// TestNumberToJSON_ScientificShift verifies the codec's decode path applies the
+// new scientific formatting end to end (encode → decode → JSON string).
+func TestNumberToJSON_ScientificShift(t *testing.T) {
+	t.Parallel()
+	n := &Number{}
+	for _, tc := range []struct{ in, want string }{
+		{"2e-20", "2e-20"},
+		{"-2e-20", "-2e-20"},
+		{"0.025", "0.025"},
+		{"250", "250"},
+		{"0", "0"},
+		{"2e20", "2e20"},
+	} {
+		b, err := n.FromJSON(tc.in)
+		require.NoError(t, err)
+		out, err := n.ToJSON(serdes.NewBinaryParser(b, nil))
+		require.NoError(t, err)
+		require.Equalf(t, tc.want, out, "round-trip %q", tc.in)
+	}
+}

--- a/internal/ledger/state/amount.go
+++ b/internal/ledger/state/amount.go
@@ -136,8 +136,8 @@ func (v *IOUAmountValue) normalizeRounded(mode RoundingMode) {
 	// Reference: IOUAmount.cpp lines 83-93
 	if GetNumberSwitchover() {
 		n := NewXRPLNumberRounded(v.mantissa, v.exponent, mode)
-		v.mantissa = n.mantissa
-		v.exponent = n.exponent
+		v.mantissa = n.Mantissa()
+		v.exponent = n.Exponent()
 		if v.exponent > MaxExponent {
 			panic("IOUAmount overflow")
 		}

--- a/internal/ledger/state/amount_round.go
+++ b/internal/ledger/state/amount_round.go
@@ -188,7 +188,7 @@ func canonicalizeDropsNoRound(amount uint64, offset int, strict bool) int64 {
 			return 0
 		}
 		guardNativeOffset(offset)
-		drops := XRPLNumber{mantissa: int64(amount), exponent: offset}.ToInt64WithMode(RoundToNearest)
+		drops := newXRPLNumberRaw(int64(amount), offset).ToInt64WithMode(RoundToNearest)
 		guardNativeDrops(drops)
 		return drops
 	}

--- a/internal/ledger/state/arithmetic_fuzz_test.go
+++ b/internal/ledger/state/arithmetic_fuzz_test.go
@@ -172,7 +172,7 @@ func orcMkNum(mantissa int64, exponent int) XRPLNumber {
 	return NewXRPLNumber(mantissa, exponent)
 }
 
-func orcStr(n XRPLNumber) string { return fmt.Sprintf("{%d,%d}", n.mantissa, n.exponent) }
+func orcStr(n XRPLNumber) string { return fmt.Sprintf("{%d,%d}", n.Mantissa(), n.Exponent()) }
 
 // orcRun reports whether fn panicked.
 func orcRun(fn func()) (panicked bool) {
@@ -191,8 +191,8 @@ func orcRun(fn func()) (panicked bool) {
 // decade).
 func orcWithin(t *testing.T, label string, got XRPLNumber, want *big.Rat, we, maxUlps int) {
 	t.Helper()
-	scale := max(got.exponent, we)
-	diff := new(big.Rat).Sub(orcValueRat(got.mantissa, got.exponent), want)
+	scale := max(got.Exponent(), we)
+	diff := new(big.Rat).Sub(orcValueRat(got.Mantissa(), got.Exponent()), want)
 	diff.Abs(diff)
 	ulp := new(big.Rat)
 	if scale >= 0 {
@@ -238,8 +238,8 @@ func FuzzXRPLNumberArithmetic(f *testing.F) {
 		b := orcMkNum(mB, orcExp(eB, -2048, 2048))
 		kind := op % 4
 
-		ra := orcValueRat(a.mantissa, a.exponent)
-		rb := orcValueRat(b.mantissa, b.exponent)
+		ra := orcValueRat(a.Mantissa(), a.Exponent())
+		rb := orcValueRat(b.Mantissa(), b.Exponent())
 		want := new(big.Rat)
 		switch kind {
 		case 0:
@@ -316,8 +316,8 @@ func FuzzXRPLNumberArithmetic(f *testing.F) {
 			}
 			orcWithin(t, label, got, want, we, maxUlps)
 		default:
-			if got.mantissa != wm || got.exponent != we {
-				t.Fatalf("%s = {%d,%d}, oracle {%d,%d}", label, got.mantissa, got.exponent, wm, we)
+			if got.Mantissa() != wm || got.Exponent() != we {
+				t.Fatalf("%s = {%d,%d}, oracle {%d,%d}", label, got.Mantissa(), got.Exponent(), wm, we)
 			}
 		}
 	})
@@ -356,7 +356,7 @@ func FuzzXRPLNumberProperties(f *testing.F) {
 		zero := xrplNumberZero()
 		one := NewXRPLNumberFromInt(1)
 
-		if !NewXRPLNumber(a.mantissa, a.exponent).Equal(a) {
+		if !NewXRPLNumber(a.Mantissa(), a.Exponent()).Equal(a) {
 			t.Fatalf("normalize not idempotent for %s", orcStr(a))
 		}
 		if !a.Negate().Negate().Equal(a) {
@@ -424,8 +424,8 @@ func orcCheckNormalize(t *testing.T, mantissa int64, exponent int) {
 			t.Fatalf("normalize(%d,%d): expected underflow to zero, got %s", mantissa, exponent, orcStr(n))
 		}
 	default:
-		if n.mantissa != wm || n.exponent != we {
-			t.Fatalf("normalize(%d,%d) = {%d,%d}, oracle {%d,%d}", mantissa, exponent, n.mantissa, n.exponent, wm, we)
+		if n.Mantissa() != wm || n.Exponent() != we {
+			t.Fatalf("normalize(%d,%d) = {%d,%d}, oracle {%d,%d}", mantissa, exponent, n.Mantissa(), n.Exponent(), wm, we)
 		}
 	}
 }
@@ -455,7 +455,7 @@ func FuzzXRPLNumberToInt64(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, mant int64, e int32) {
 		n := orcMkNum(mant, orcExp(e, -40, 2))
-		r := orcValueRat(n.mantissa, n.exponent)
+		r := orcValueRat(n.Mantissa(), n.Exponent())
 		for _, mode := range []RoundingMode{RoundToNearest, RoundTowardsZero, RoundDownward, RoundUpward} {
 			want := orcRoundRatToInt(r, mode)
 			if !want.IsInt64() {
@@ -518,8 +518,8 @@ func FuzzXRPLNumberRoot2(f *testing.F) {
 			return
 		}
 		sq := r.Mul(r)
-		ratN := orcValueRat(n.mantissa, n.exponent)
-		diff := new(big.Rat).Sub(orcValueRat(sq.mantissa, sq.exponent), ratN)
+		ratN := orcValueRat(n.Mantissa(), n.Exponent())
+		diff := new(big.Rat).Sub(orcValueRat(sq.Mantissa(), sq.Exponent()), ratN)
 		diff.Abs(diff)
 		tol := new(big.Rat).Mul(ratN, orcRelTol)
 		if diff.Cmp(tol) > 0 {
@@ -577,8 +577,8 @@ func FuzzIOUArithmetic(f *testing.F) {
 		a := NewIOUAmountValue(mA, expA)
 		b := NewIOUAmountValue(mB, expB)
 
-		ra := orcValueRat(a.mantissa, a.exponent)
-		rb := orcValueRat(b.mantissa, b.exponent)
+		ra := orcValueRat(a.Mantissa(), a.Exponent())
+		rb := orcValueRat(b.Mantissa(), b.Exponent())
 		want := new(big.Rat)
 		add := op%2 == 0
 		if add {
@@ -604,24 +604,24 @@ func FuzzIOUArithmetic(f *testing.F) {
 		switch {
 		case want.Sign() == 0: // exact cancellation -> canonical IOU zero
 			if !got.IsZero() {
-				t.Fatalf("IOU op add=%v: expected zero, got {%d,%d}", add, got.mantissa, got.exponent)
+				t.Fatalf("IOU op add=%v: expected zero, got {%d,%d}", add, got.Mantissa(), got.Exponent())
 			}
 		case overflow:
 			if !panicked {
 				t.Fatalf("IOU op add=%v on {%d,%d},{%d,%d}: expected overflow panic (oracle exp %d)",
-					add, a.mantissa, a.exponent, b.mantissa, b.exponent, we)
+					add, a.Mantissa(), a.Exponent(), b.Mantissa(), b.Exponent(), we)
 			}
 		case panicked:
 			t.Fatalf("IOU op add=%v on {%d,%d},{%d,%d}: unexpected panic (oracle {%d,%d})",
-				add, a.mantissa, a.exponent, b.mantissa, b.exponent, wm, we)
+				add, a.Mantissa(), a.Exponent(), b.Mantissa(), b.Exponent(), wm, we)
 		case underflow:
 			if !got.IsZero() {
-				t.Fatalf("IOU op add=%v: expected underflow to zero, got {%d,%d}", add, got.mantissa, got.exponent)
+				t.Fatalf("IOU op add=%v: expected underflow to zero, got {%d,%d}", add, got.Mantissa(), got.Exponent())
 			}
 		default:
-			if got.mantissa != wm || got.exponent != we {
+			if got.Mantissa() != wm || got.Exponent() != we {
 				t.Fatalf("IOU op add=%v on {%d,%d},{%d,%d} = {%d,%d}, oracle {%d,%d}",
-					add, a.mantissa, a.exponent, b.mantissa, b.exponent, got.mantissa, got.exponent, wm, we)
+					add, a.Mantissa(), a.Exponent(), b.Mantissa(), b.Exponent(), got.Mantissa(), got.Exponent(), wm, we)
 			}
 		}
 	})
@@ -668,6 +668,6 @@ func TestArithmeticBoundaries(t *testing.T) {
 		t.Fatal("IOU Mul overflow did not panic")
 	}
 	if got := lo.Mul(lo, false).IOU(); !got.IsZero() {
-		t.Fatalf("IOU Mul underflow = {%d,%d}, want zero", got.mantissa, got.exponent)
+		t.Fatalf("IOU Mul underflow = {%d,%d}, want zero", got.Mantissa(), got.Exponent())
 	}
 }

--- a/internal/ledger/state/number_asset.go
+++ b/internal/ledger/state/number_asset.go
@@ -1,0 +1,48 @@
+package state
+
+// Asset-aware Number rounding, ported from rippled 3.1.0's roundToAsset /
+// associateAsset (PRs #6156, #6259). These are the primitives the upcoming
+// SingleAssetVault / LendingProtocol transactors call on each sMD_NeedsAsset
+// NUMBER field (sfAssetsTotal, sfDebtTotal, ...) before it is written to an SLE
+// and serialized: the value is rounded to the precision of the vault's asset,
+// and a soeDEFAULT field that rounds to its default is dropped.
+//
+// Phase-B wiring point. The SLE-level associateAsset(SLE, asset) iterates the
+// ten NeedsAsset NUMBER fields on ltVAULT / Loan / LoanBroker entries, calls
+// AssociateAssetField on each present value, writes the rounded value back, and
+// removes the field when removeIfDefault is true and its template style is
+// soeDEFAULT. That SLE iteration (and the per-sfield sMD_NeedsAsset codec flag
+// it keys off) lands with the transactors; this file supplies the value-level
+// rounding and removal decision so they can be unit-tested independently.
+
+// RoundToAsset rounds the Number to the precision of the asset it represents, as
+// rippled's in-place roundToAsset(asset, Number) does — value = STAmount{asset,
+// value} read back as a Number — under round-to-nearest.
+//
+//   - integral assets (native XRP, MPT): the value counts indivisible units
+//     (drops / MPT units), so it is rounded to a whole number. Panics on int64
+//     overflow, matching rippled's Number::operator rep() throw.
+//   - IOU assets: the mantissa is snapped to the 16-significant-digit STAmount
+//     range [MinMantissa, MaxMantissa] (rippled cMinValue / cMaxValue).
+func (n XRPLNumber) RoundToAsset(integral bool) XRPLNumber {
+	if n.IsZero() {
+		return n
+	}
+	if integral {
+		v := n.ToInt64WithMode(RoundToNearest)
+		return NewXRPLNumberScaled(v, 0, n.scale, RoundToNearest)
+	}
+	m, e := n.NormalizeToRange(uint64(MinMantissa), uint64(MaxMantissa))
+	return NewXRPLNumberScaled(m, e, n.scale, RoundToNearest)
+}
+
+// AssociateAssetField applies the associateAsset semantics to one NUMBER field
+// value: it rounds the value to the asset's precision and reports whether a
+// soeDEFAULT-styled field must be removed because the rounded value equals its
+// (zero) default (rippled PR #6259). integral is Asset::integral() for the
+// vault's asset (true for native XRP and MPT, false for IOUs); soeDefault is
+// whether the field is soeDEFAULT in the entry's template.
+func AssociateAssetField(value XRPLNumber, integral, soeDefault bool) (rounded XRPLNumber, remove bool) {
+	rounded = value.RoundToAsset(integral)
+	return rounded, soeDefault && rounded.IsZero()
+}

--- a/internal/ledger/state/number_asset_test.go
+++ b/internal/ledger/state/number_asset_test.go
@@ -1,0 +1,91 @@
+package state
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMantissaScaleForRules(t *testing.T) {
+	t.Parallel()
+	// large when no rules, or when either amendment is enabled; small otherwise.
+	require.Equal(t, MantissaScaleLarge, MantissaScaleForRules(false, false, false))
+	require.Equal(t, MantissaScaleLarge, MantissaScaleForRules(true, true, false))
+	require.Equal(t, MantissaScaleLarge, MantissaScaleForRules(true, false, true))
+	require.Equal(t, MantissaScaleLarge, MantissaScaleForRules(true, true, true))
+	require.Equal(t, MantissaScaleSmall, MantissaScaleForRules(true, false, false))
+}
+
+func TestRoundToAsset_Integral(t *testing.T) {
+	t.Parallel()
+	// A fractional drops value rounds to the nearest whole unit.
+	require.Equal(t,
+		NewXRPLNumberScaled(8, 0, MantissaScaleLarge, RoundToNearest),
+		NewXRPLNumberScaled(75, -1, MantissaScaleLarge, RoundToNearest).RoundToAsset(true)) // 7.5 -> 8 (ties to even)
+	require.Equal(t,
+		NewXRPLNumberScaled(2, 0, MantissaScaleLarge, RoundToNearest),
+		NewXRPLNumberScaled(25, -1, MantissaScaleLarge, RoundToNearest).RoundToAsset(true)) // 2.5 -> 2 (ties to even)
+
+	// A large int64 value is preserved exactly at the large scale.
+	maxUnits := NewXRPLNumberScaled(math.MaxInt64, 0, MantissaScaleLarge, RoundToNearest)
+	require.Equal(t, int64(math.MaxInt64), maxUnits.RoundToAsset(true).ToInt64WithMode(RoundToNearest))
+
+	// A sub-unit value rounds to zero (would drop a soeDEFAULT field).
+	require.True(t, NewXRPLNumberScaled(4, -1, MantissaScaleLarge, RoundToNearest).RoundToAsset(true).IsZero()) // 0.4 -> 0
+}
+
+func TestRoundToAsset_IOU(t *testing.T) {
+	t.Parallel()
+	// An IOU value keeps its magnitude, reduced to 16 significant digits. The
+	// result is re-expressed at the Number's (large) scale, so compare by value.
+	v := NewXRPLNumberScaled(12345678901234567, -3, MantissaScaleLarge, RoundToNearest) // 17 sig digits
+	got := v.RoundToAsset(false)
+	want := NewXRPLNumberScaled(1234567890123457, -2, MantissaScaleLarge, RoundToNearest) // 16 sig digits, rounded
+	require.True(t, got.Equal(want), "got %s want %s", got, want)
+	require.False(t, got.Equal(v), "precision should have been reduced")
+
+	// Zero stays zero.
+	require.True(t, NewXRPLNumberScaled(0, 0, MantissaScaleLarge, RoundToNearest).RoundToAsset(false).IsZero())
+}
+
+func TestAssociateAssetField_Removal(t *testing.T) {
+	t.Parallel()
+	// Integral asset, sub-unit value, soeDEFAULT field -> removed.
+	_, remove := AssociateAssetField(NewXRPLNumberScaled(4, -1, MantissaScaleLarge, RoundToNearest), true, true)
+	require.True(t, remove)
+
+	// Same value but the field is not soeDEFAULT -> kept.
+	_, remove = AssociateAssetField(NewXRPLNumberScaled(4, -1, MantissaScaleLarge, RoundToNearest), true, false)
+	require.False(t, remove)
+
+	// Non-zero rounded value -> kept even when soeDEFAULT.
+	rounded, remove := AssociateAssetField(NewXRPLNumberScaled(15, -1, MantissaScaleLarge, RoundToNearest), true, true)
+	require.False(t, remove)
+	require.Equal(t, int64(2), rounded.ToInt64WithMode(RoundToNearest)) // 1.5 -> 2
+}
+
+func TestNormalizeToRange_IOUBounds(t *testing.T) {
+	t.Parallel()
+	// Snapping an over-precise value into the IOU mantissa range rounds to
+	// nearest and adjusts the exponent.
+	n := NewXRPLNumberScaled(99999999999999999, 0, MantissaScaleLarge, RoundToNearest) // 17 nines
+	m, e := n.NormalizeToRange(uint64(MinMantissa), uint64(MaxMantissa))
+	require.Equal(t, int64(1000000000000000), m)
+	require.Equal(t, 2, e)
+
+	// A value already within range is unchanged.
+	m, e = NewXRPLNumberScaled(1234567890123456, -6, MantissaScaleLarge, RoundToNearest).NormalizeToRange(uint64(MinMantissa), uint64(MaxMantissa))
+	require.Equal(t, int64(1234567890123456), m)
+	require.Equal(t, -6, e)
+}
+
+// TestToInt64_OverflowPanics mirrors rippled's Number::operator rep() throwing
+// on int64 overflow — the error surfaced as a TER by the tx engine's recover.
+func TestToInt64_OverflowPanics(t *testing.T) {
+	t.Parallel()
+	// 10^19 exceeds int64; scaling the mantissa up must panic.
+	require.Panics(t, func() {
+		NewXRPLNumberScaled(1, 19, MantissaScaleLarge, RoundToNearest).ToInt64WithMode(RoundToNearest)
+	})
+}

--- a/internal/ledger/state/xrpl_number.go
+++ b/internal/ledger/state/xrpl_number.go
@@ -1,73 +1,119 @@
 package state
 
 // XRPLNumber implements rippled's Number class with Guard-based precision.
-// Reference: rippled/src/libxrpl/basics/Number.cpp
 //
-// The Number class uses wider exponent range [-32768, 32768] than IOUAmount
+// The Number class uses a wider exponent range [-32768, 32768] than IOUAmount
 // [-96, 80] and employs a Guard mechanism that preserves digits discarded
-// during scale-down, enabling banker's rounding (round-half-to-even).
-// When fixUniversalNumber is enabled, IOUAmount arithmetic delegates here.
+// during scale-down, enabling banker's rounding (round-half-to-even). When
+// fixUniversalNumber is enabled, IOUAmount arithmetic delegates here.
 //
-// Panic contract: Add / Mul / Div / normalize / root2 / ToIOUAmountValue
-// panic on overflow, divide-by-zero, and NaN inputs — matching rippled's
-// `Throw<std::overflow_error>`. ParseIOUAmountBinary / ParseMPTAmountBinary
-// enforce codec-boundary bounds; arithmetic overflow during evaluation is
-// caught by recover() points in the tx engine and surfaced as a TER (the
-// node never crashes from a peer-fed amount overflow).
+// Mantissa scale. Since rippled 3.1.0 the normalized mantissa range is
+// runtime-selectable between two scales:
+//   - "small": mantissa in [10^15, 10^16-1], rangeLog 15 (the historical range,
+//     matching STAmount for IOUs).
+//   - "large": mantissa in [10^18, 10^19-1], rangeLog 18. This represents every
+//     int64 drops/MPT value exactly (maxRep = 2^63-1 lies inside the range).
+//
+// rippled selects the scale via a thread_local range_, installed for the whole
+// transaction (preflight, preclaim, calculateBaseFee, doApply): large when no
+// transaction rules are set, or when SingleAssetVault or LendingProtocol is
+// enabled; small otherwise. Its process-wide default (outside any transaction
+// context) is large.
+//
+// go-xrpl removed Number's global mutable state (see the switchover and rounding
+// mode below) to keep concurrent amount math race-free. Following the same
+// philosophy, the scale is not a mutable global: each XRPLNumber carries its own
+// scale, and the entry points that create Numbers from a transaction context
+// derive it from *amendment.Rules (see MantissaScaleForRules). Every current
+// arithmetic caller runs inside transaction processing without SingleAssetVault
+// or LendingProtocol, so they use the small scale — the only scale reachable on
+// v3.0.0 — via the unscaled constructors, which default to small. This is
+// exactly equivalent to rippled installing its small range for those steps.
+//
+// Because a normalized large-scale mantissa (up to 10^19-1) exceeds int64, the
+// internal representation is an unsigned mantissa plus a sign flag, matching
+// rippled. The external view (Mantissa/Exponent) collapses back to a signed
+// 63-bit mantissa.
+//
+// Panic contract: Add / Mul / Div / normalize / root2 / ToIOUAmountValue panic
+// on overflow, divide-by-zero, and NaN inputs — matching rippled's
+// Throw<std::overflow_error>. Arithmetic overflow during evaluation is caught by
+// recover() points in the tx engine and surfaced as a TER; the node never
+// crashes from a peer-fed amount overflow.
 
 import (
 	"math/big"
+	"math/bits"
+	"strconv"
+	"strings"
 	"sync/atomic"
 )
 
-// XRPLNumber constants matching rippled's Number.h
+// XRPLNumber exponent bounds and the zero sentinel exponent.
 const (
-	xrplNumMinMantissa int64 = 1_000_000_000_000_000 // 10^15
-	xrplNumMaxMantissa int64 = 9_999_999_999_999_999 // 10^16 - 1
-	xrplNumMinExponent       = -32768
-	xrplNumMaxExponent       = 32768
-	// Zero exponent for Number (different from IOUAmount's zeroExponent)
-	xrplNumZeroExponent = -2147483648 // math.MinInt32, matching Number{} default
+	xrplNumMinExponent = -32768
+	xrplNumMaxExponent = 32768
+	// xrplNumZeroExponent is Number{}'s exponent: std::numeric_limits<int>::lowest().
+	xrplNumZeroExponent = -2147483648
+	// xrplNumMaxRep is the largest signed 63-bit mantissa, std::int64_t max.
+	xrplNumMaxRep uint64 = 9223372036854775807
 )
+
+// MantissaScale selects the normalized mantissa range for an XRPLNumber.
+type MantissaScale int
+
+const (
+	// MantissaScaleSmall is the historical IOU range [10^15, 10^16-1]. It is the
+	// zero value, so the unscaled constructors default to it.
+	MantissaScaleSmall MantissaScale = iota
+	// MantissaScaleLarge is the [10^18, 10^19-1] range that represents every
+	// int64 value exactly, used under SingleAssetVault / LendingProtocol.
+	MantissaScaleLarge
+)
+
+// params returns the (min, max) normalized mantissa and the rangeLog (log10 of
+// min) for the scale.
+func (s MantissaScale) params() (minM, maxM uint64, rangeLog int) {
+	if s == MantissaScaleLarge {
+		return 1_000_000_000_000_000_000, 9_999_999_999_999_999_999, 18
+	}
+	return 1_000_000_000_000_000, 9_999_999_999_999_999, 15
+}
+
+// MantissaScaleForRules returns the mantissa scale rippled installs for a
+// transaction: large when no rules are in effect, or when SingleAssetVault or
+// LendingProtocol is enabled; small otherwise. Callers derive the booleans from
+// *amendment.Rules at the transaction boundary and thread the result explicitly,
+// rather than mutating a process-wide global.
+func MantissaScaleForRules(hasRules, singleAssetVault, lendingProtocol bool) MantissaScale {
+	if !hasRules || singleAssetVault || lendingProtocol {
+		return MantissaScaleLarge
+	}
+	return MantissaScaleSmall
+}
 
 // Package-level switchover flag, the Go equivalent of rippled's per-thread
 // getSTNumberSwitchover() / setSTNumberSwitchover() (LocalValue<bool>).
 //
-// Unlike the rounding mode, the switchover is written only by the single
-// transaction-apply goroutine (do_apply.go, from rules().Enabled(
-// fixUniversalNumber)) and is constant for the duration of a ledger, since
-// amendments do not flip mid-ledger. Concurrent readers are the RPC/path-find
-// goroutines, which only ever read it. An atomic.Bool therefore removes the
-// data race while preserving exact behavior: every reader observes the value
-// the apply goroutine established for the current ledger.
-//
-// The rounding mode, by contrast, is mutated mid-computation by both the apply
-// and RPC goroutines, so it cannot be a shared global — it is threaded
-// explicitly through the arithmetic call path (see RoundingMode below).
+// Unlike the mantissa scale and rounding mode, the switchover is written only by
+// the single transaction-apply goroutine (do_apply.go, from
+// rules().Enabled(fixUniversalNumber)) and is constant for the duration of a
+// ledger. An atomic.Bool removes the data race while preserving exact behavior:
+// every reader observes the value the apply goroutine established for the
+// current ledger.
 var numberSwitchoverEnabled atomic.Bool
 
 // SetNumberSwitchover enables or disables the XRPLNumber switchover.
-// When enabled, IOUAmount arithmetic uses Guard-based precision.
-func SetNumberSwitchover(enabled bool) {
-	numberSwitchoverEnabled.Store(enabled)
-}
+func SetNumberSwitchover(enabled bool) { numberSwitchoverEnabled.Store(enabled) }
 
 // GetNumberSwitchover returns whether the XRPLNumber switchover is enabled.
-func GetNumberSwitchover() bool {
-	return numberSwitchoverEnabled.Load()
-}
+func GetNumberSwitchover() bool { return numberSwitchoverEnabled.Load() }
 
-// RoundingMode controls how XRPLNumber rounds during normalization.
-// Reference: Number::rounding_mode in Number.h line 196.
-//
-// rippled stores the active mode in a thread_local (Number::mode_) and mutates
-// it via the NumberRoundModeGuard RAII helper. go-xrpl has no thread-local
-// storage and a live node performs amount arithmetic concurrently (apply vs.
-// RPC/path-find goroutines), so the mode is instead threaded explicitly as an
-// argument: every operation defaults to RoundToNearest, and the mode-sensitive
-// strict-rounding and AMM paths call the matching *Rounded variant with the
-// desired mode. This keeps the arithmetic race-free and deterministic without
-// any shared mutable rounding state.
+// RoundingMode controls how XRPLNumber rounds during normalization. rippled
+// stores the active mode in a thread_local (Number::mode_); go-xrpl threads it
+// explicitly so concurrent amount math is race-free and deterministic. Every
+// operation defaults to RoundToNearest; the mode-sensitive strict-rounding and
+// AMM paths call the matching *Rounded variant.
 type RoundingMode int
 
 const (
@@ -77,26 +123,25 @@ const (
 	RoundUpward                          // round towards positive infinity
 )
 
-// XRPLNumber represents a decimal floating-point number with Guard-based rounding.
-// Reference: rippled Number class in Number.h / Number.cpp
+// XRPLNumber is a decimal floating-point value with Guard-based rounding.
 type XRPLNumber struct {
-	mantissa int64
+	negative bool
+	mantissa uint64
 	exponent int
+	scale    MantissaScale
 }
 
-// xrplGuard preserves discarded digits during scale-down operations.
-// Uses BCD (Binary Coded Decimal) storage in a uint64 for 16 guard digits.
-// Reference: rippled Number::Guard class (Number.cpp lines 64-171)
+// xrplGuard preserves discarded digits during scale-down operations, using BCD
+// storage in a uint64 for 16 guard digits (rippled Number::Guard).
 type xrplGuard struct {
 	digits uint64 // 16 BCD guard digits
-	xbit   bool   // non-zero digit shifted off end
-	sbit   bool   // sign bit (true = negative)
+	xbit   bool   // a non-zero digit has been shifted off the end
+	sbit   bool   // sign of the guard digits (true = negative)
 }
 
 func (g *xrplGuard) setNegative() { g.sbit = true }
 
-// push adds a digit to the guard, shifting existing digits right.
-// Reference: Number.cpp lines 117-122
+// push adds a digit, shifting existing digits right.
 func (g *xrplGuard) push(d uint) {
 	g.xbit = g.xbit || (g.digits&0x000000000000000F) != 0
 	g.digits >>= 4
@@ -104,34 +149,25 @@ func (g *xrplGuard) push(d uint) {
 }
 
 // pop removes and returns the most significant guard digit.
-// Reference: Number.cpp lines 125-130
 func (g *xrplGuard) pop() uint {
 	d := uint((g.digits & 0xF000000000000000) >> 60)
 	g.digits <<= 4
 	return d
 }
 
-// round returns the rounding direction for the given mode.
-// Returns: 1 if round up, -1 if round down, 0 if exactly half.
-// Reference: Number.cpp lines 137-171
+// round returns the rounding direction: 1 up, -1 down, 0 exactly half.
 func (g *xrplGuard) round(mode RoundingMode) int {
 	if mode == RoundTowardsZero {
 		return -1
 	}
-
 	if mode == RoundDownward {
-		if g.sbit {
-			// Negative number, rounding down = more negative = round up magnitude
-			if g.digits > 0 || g.xbit {
-				return 1
-			}
+		if g.sbit && (g.digits > 0 || g.xbit) {
+			return 1
 		}
 		return -1
 	}
-
 	if mode == RoundUpward {
 		if g.sbit {
-			// Negative number, rounding up = less negative = round down magnitude
 			return -1
 		}
 		if g.digits > 0 || g.xbit {
@@ -139,166 +175,246 @@ func (g *xrplGuard) round(mode RoundingMode) int {
 		}
 		return -1
 	}
-
-	// to_nearest mode (default, banker's rounding)
+	// to_nearest (banker's rounding)
 	if g.digits > 0x5000000000000000 {
 		return 1
 	}
 	if g.digits < 0x5000000000000000 {
 		return -1
 	}
-	// Exactly 0x5000000000000000
 	if g.xbit {
 		return 1
 	}
 	return 0
 }
 
-// NewXRPLNumber creates a new XRPLNumber and normalizes it using banker's
-// rounding (RoundToNearest). Use NewXRPLNumberRounded to normalize under a
-// different mode.
-// Reference: Number::Number(rep mantissa, int exponent) in Number.h line 219-223
-func NewXRPLNumber(mantissa int64, exponent int) XRPLNumber {
-	return NewXRPLNumberRounded(mantissa, exponent, RoundToNearest)
+// externalToInternal converts a signed int64 mantissa to (sign, magnitude),
+// handling math.MinInt64 without overflow (rippled Number::externalToInternal).
+func externalToInternal(mantissa int64) (negative bool, m uint64) {
+	if mantissa >= 0 {
+		return false, uint64(mantissa)
+	}
+	if mantissa >= -9223372036854775807 { // -maxRep
+		return true, uint64(-mantissa)
+	}
+	// mantissa == math.MinInt64
+	return true, xrplNumMaxRep + 1
 }
 
+// NewXRPLNumber creates a small-scale Number normalized with banker's rounding.
+func NewXRPLNumber(mantissa int64, exponent int) XRPLNumber {
+	return newNumber(mantissa, exponent, MantissaScaleSmall, RoundToNearest)
+}
+
+// NewXRPLNumberRounded creates a small-scale Number normalized under mode.
 func NewXRPLNumberRounded(mantissa int64, exponent int, mode RoundingMode) XRPLNumber {
-	n := XRPLNumber{mantissa: mantissa, exponent: exponent}
+	return newNumber(mantissa, exponent, MantissaScaleSmall, mode)
+}
+
+// NewXRPLNumberScaled creates a Number in the given scale, normalized under mode.
+func NewXRPLNumberScaled(mantissa int64, exponent int, scale MantissaScale, mode RoundingMode) XRPLNumber {
+	return newNumber(mantissa, exponent, scale, mode)
+}
+
+// NewXRPLNumberFromInt creates a small-scale Number from a plain integer.
+func NewXRPLNumberFromInt(mantissa int64) XRPLNumber {
+	return newNumber(mantissa, 0, MantissaScaleSmall, RoundToNearest)
+}
+
+func newNumber(mantissa int64, exponent int, scale MantissaScale, mode RoundingMode) XRPLNumber {
+	neg, m := externalToInternal(mantissa)
+	n := XRPLNumber{negative: neg, mantissa: m, exponent: exponent, scale: scale}
 	n.normalize(mode)
 	return n
 }
 
-// NewXRPLNumberFromInt creates a Number from a plain integer.
-// Reference: Number::Number(rep mantissa) → Number{mantissa, 0}
-func NewXRPLNumberFromInt(mantissa int64) XRPLNumber {
-	return NewXRPLNumber(mantissa, 0)
+// newXRPLNumberRaw builds a Number from an external (mantissa, exponent) without
+// normalizing. Used where the caller needs the exact digits preserved before an
+// int64 conversion (canonicalizeDropsNoRound); the scale is irrelevant because
+// the only consumer, ToInt64WithMode, reads the external view.
+func newXRPLNumberRaw(mantissa int64, exponent int) XRPLNumber {
+	neg, m := externalToInternal(mantissa)
+	return XRPLNumber{negative: neg, mantissa: m, exponent: exponent}
 }
 
-// xrplNumberZero returns the zero Number.
+// intConst builds an integer Number in the receiver's scale (for the curve-fit
+// constants inside root2).
+func (n XRPLNumber) intConst(v int64) XRPLNumber {
+	return newNumber(v, 0, n.scale, RoundToNearest)
+}
+
+// oneVal returns 1 in the receiver's scale, already normalized.
+func (n XRPLNumber) oneVal() XRPLNumber {
+	minM, _, rangeLog := n.scale.params()
+	return XRPLNumber{mantissa: minM, exponent: -rangeLog, scale: n.scale}
+}
+
+// zero returns the canonical zero in the receiver's scale.
+func (n XRPLNumber) zero() XRPLNumber {
+	return XRPLNumber{mantissa: 0, exponent: xrplNumZeroExponent, scale: n.scale}
+}
+
+// xrplNumberZero returns a small-scale canonical zero.
 func xrplNumberZero() XRPLNumber {
 	return XRPLNumber{mantissa: 0, exponent: xrplNumZeroExponent}
 }
 
-// IsZero returns true if this number is zero.
-func (n XRPLNumber) IsZero() bool {
-	return n.mantissa == 0
-}
+// IsZero reports whether the number is zero.
+func (n XRPLNumber) IsZero() bool { return n.mantissa == 0 }
 
-// Equal returns true if two Numbers are identical.
+// Equal reports whether two Numbers have identical value. Matching rippled's
+// operator==, the scale is not part of identity.
 func (n XRPLNumber) Equal(other XRPLNumber) bool {
-	return n.mantissa == other.mantissa && n.exponent == other.exponent
+	return n.negative == other.negative && n.mantissa == other.mantissa && n.exponent == other.exponent
 }
 
-// Negate returns the negated number.
+// Negate returns the additive inverse.
 func (n XRPLNumber) Negate() XRPLNumber {
-	return XRPLNumber{mantissa: -n.mantissa, exponent: n.exponent}
+	if n.mantissa == 0 {
+		return n
+	}
+	n.negative = !n.negative
+	return n
 }
 
-// normalize adjusts mantissa and exponent to the proper range using Guard-based
-// rounding under mode.
-// Reference: Number.cpp lines 177-227
+// Mantissa returns the external (signed 63-bit) mantissa.
+func (n XRPLNumber) Mantissa() int64 {
+	m := n.mantissa
+	if m > xrplNumMaxRep {
+		m /= 10
+	}
+	if n.negative {
+		return -int64(m)
+	}
+	return int64(m)
+}
+
+// Exponent returns the external exponent, adjusted when the internal mantissa
+// exceeds the 63-bit range.
+func (n XRPLNumber) Exponent() int {
+	if n.mantissa > xrplNumMaxRep {
+		return n.exponent + 1
+	}
+	return n.exponent
+}
+
+// bringIntoRange restores a rounded mantissa to the normalized range or clamps
+// to zero on exponent underflow (rippled Guard::bringIntoRange).
+func bringIntoRange(negative *bool, m *uint64, e *int, minM uint64) {
+	if *m < minM {
+		*m *= 10
+		*e--
+	}
+	if *e < xrplNumMinExponent {
+		*negative = false
+		*m = 0
+		*e = xrplNumZeroExponent
+	}
+}
+
+// doRoundUp applies the guard's round-up decision and re-ranges (rippled
+// Guard::doRoundUp). It panics on exponent overflow.
+func (g *xrplGuard) doRoundUp(negative *bool, m *uint64, e *int, minM, maxM uint64, mode RoundingMode, loc string) {
+	if r := g.round(mode); r == 1 || (r == 0 && (*m&1) == 1) {
+		*m++
+		if *m > maxM || *m > xrplNumMaxRep {
+			*m /= 10
+			*e++
+		}
+	}
+	bringIntoRange(negative, m, e, minM)
+	if *e > xrplNumMaxExponent {
+		panic(loc)
+	}
+}
+
+// doRoundDown applies the guard's round-down decision and re-ranges (rippled
+// Guard::doRoundDown).
+func (g *xrplGuard) doRoundDown(negative *bool, m *uint64, e *int, minM uint64, mode RoundingMode) {
+	if r := g.round(mode); r == 1 || (r == 0 && (*m&1) == 1) {
+		*m--
+		if *m < minM {
+			*m *= 10
+			*e--
+		}
+	}
+	bringIntoRange(negative, m, e, minM)
+}
+
+// normalize brings the (uint64) mantissa into the scale's range with Guard
+// rounding under mode (rippled doNormalize for a 64-bit mantissa).
 func (n *XRPLNumber) normalize(mode RoundingMode) {
+	minM, maxM, _ := n.scale.params()
 	if n.mantissa == 0 {
-		*n = xrplNumberZero()
+		*n = n.zero()
 		return
 	}
+	m := n.mantissa
+	e := n.exponent
+	neg := n.negative
 
-	negative := n.mantissa < 0
-	var m uint64
-	if negative {
-		m = uint64(-n.mantissa)
-	} else {
-		m = uint64(n.mantissa)
-	}
-
-	// Scale up if mantissa is too small
-	for m < uint64(xrplNumMinMantissa) && n.exponent > xrplNumMinExponent {
+	for m < minM && e > xrplNumMinExponent {
 		m *= 10
-		n.exponent--
+		e--
 	}
-
-	// Scale down with guard if mantissa is too large
 	var g xrplGuard
-	if negative {
+	if neg {
 		g.setNegative()
 	}
-	for m > uint64(xrplNumMaxMantissa) {
-		if n.exponent >= xrplNumMaxExponent {
+	for m > maxM {
+		if e >= xrplNumMaxExponent {
 			panic("XRPLNumber::normalize overflow")
 		}
 		g.push(uint(m % 10))
 		m /= 10
-		n.exponent++
+		e++
 	}
-
-	n.mantissa = int64(m)
-
-	// Underflow to zero
-	if n.exponent < xrplNumMinExponent || n.mantissa < xrplNumMinMantissa {
-		*n = xrplNumberZero()
+	if e < xrplNumMinExponent || m < minM {
+		*n = n.zero()
 		return
 	}
-
-	// Apply guard rounding (round-half-to-even)
-	r := g.round(mode)
-	if r == 1 || (r == 0 && (n.mantissa&1) == 1) {
-		n.mantissa++
-		if n.mantissa > xrplNumMaxMantissa {
-			n.mantissa /= 10
-			n.exponent++
+	// Cut m down to fit int64 so rounding happens in that range; doRoundUp can
+	// grow the mantissa back up to maxM to fill the range.
+	if m > xrplNumMaxRep {
+		if e >= xrplNumMaxExponent {
+			panic("XRPLNumber::normalize overflow")
 		}
+		g.push(uint(m % 10))
+		m /= 10
+		e++
 	}
-
-	if n.exponent > xrplNumMaxExponent {
-		panic("XRPLNumber::normalize overflow")
-	}
-
-	if negative {
-		n.mantissa = -n.mantissa
-	}
+	g.doRoundUp(&neg, &m, &e, minM, maxM, mode, "XRPLNumber::normalize overflow")
+	n.negative = neg
+	n.mantissa = m
+	n.exponent = e
 }
 
-// Add returns the sum of two XRPLNumbers using banker's rounding.
-func (n XRPLNumber) Add(y XRPLNumber) XRPLNumber {
-	return n.AddRounded(y, RoundToNearest)
-}
+// Add returns n + y using banker's rounding.
+func (n XRPLNumber) Add(y XRPLNumber) XRPLNumber { return n.AddRounded(y, RoundToNearest) }
 
-// AddRounded returns the sum of two XRPLNumbers rounded under mode.
-// Reference: Number::operator+= in Number.cpp lines 229-345
+// AddRounded returns n + y rounded under mode (rippled operator+=).
 func (n XRPLNumber) AddRounded(y XRPLNumber, mode RoundingMode) XRPLNumber {
-	// Handle zero operands
 	if y.IsZero() {
 		return n
 	}
 	if n.IsZero() {
 		return y
 	}
-	// Exact cancellation
 	if n.Equal(y.Negate()) {
-		return xrplNumberZero()
+		return n.zero()
 	}
+	minM, maxM, _ := n.scale.params()
 
+	xn := n.negative
 	xm := n.mantissa
 	xe := n.exponent
-	xn := int64(1)
-	if xm < 0 {
-		xm = -xm
-		xn = -1
-	}
-
+	yn := y.negative
 	ym := y.mantissa
 	ye := y.exponent
-	yn := int64(1)
-	if ym < 0 {
-		ym = -ym
-		yn = -1
-	}
 
 	var g xrplGuard
-
-	// Align exponents by shifting the smaller-exponent operand's digits into guard
 	if xe < ye {
-		if xn == -1 {
+		if xn {
 			g.setNegative()
 		}
 		for xe < ye {
@@ -307,7 +423,7 @@ func (n XRPLNumber) AddRounded(y XRPLNumber, mode RoundingMode) XRPLNumber {
 			xe++
 		}
 	} else if xe > ye {
-		if yn == -1 {
+		if yn {
 			g.setNegative()
 		}
 		for xe > ye {
@@ -318,67 +434,45 @@ func (n XRPLNumber) AddRounded(y XRPLNumber, mode RoundingMode) XRPLNumber {
 	}
 
 	if xn == yn {
-		// Same sign: add magnitudes
-		xm += ym
-		if xm > xrplNumMaxMantissa {
-			g.push(uint(xm % 10))
-			xm /= 10
+		// Same sign: add magnitudes with a 128-bit intermediate.
+		lo, carry := bits.Add64(xm, ym, 0)
+		if carry != 0 || lo > maxM || lo > xrplNumMaxRep {
+			q, r := bits.Div64(carry, lo, 10) // carry <= 1 < 10
+			g.push(uint(r))
+			xm = q
 			xe++
+		} else {
+			xm = lo
 		}
-		r := g.round(mode)
-		if r == 1 || (r == 0 && (xm&1) == 1) {
-			xm++
-			if xm > xrplNumMaxMantissa {
-				xm /= 10
-				xe++
-			}
-		}
-		if xe > xrplNumMaxExponent {
-			panic("XRPLNumber::addition overflow")
-		}
+		g.doRoundUp(&xn, &xm, &xe, minM, maxM, mode, "XRPLNumber::addition overflow")
 	} else {
-		// Different sign: subtract magnitudes
+		// Different sign: subtract magnitudes.
 		if xm > ym {
-			xm = xm - ym
+			xm -= ym
 		} else {
 			xm = ym - xm
 			xe = ye
 			xn = yn
 		}
-		// Restore precision from guard digits
-		for xm < xrplNumMinMantissa {
-			xm *= 10
-			xm -= int64(g.pop())
+		for xm < minM && xm <= xrplNumMaxRep/10 {
+			xm = xm*10 - uint64(g.pop())
 			xe--
 		}
-		r := g.round(mode)
-		if r == 1 || (r == 0 && (xm&1) == 1) {
-			xm--
-			if xm < xrplNumMinMantissa {
-				xm *= 10
-				xe--
-			}
-		}
-		if xe < xrplNumMinExponent {
-			return xrplNumberZero()
-		}
+		g.doRoundDown(&xn, &xm, &xe, minM, mode)
 	}
 
-	return XRPLNumber{mantissa: xm * xn, exponent: xe}
+	r := XRPLNumber{negative: xn, mantissa: xm, exponent: xe, scale: n.scale}
+	r.normalize(mode)
+	return r
 }
 
 // Sub returns n - y.
-func (n XRPLNumber) Sub(y XRPLNumber) XRPLNumber {
-	return n.Add(y.Negate())
-}
+func (n XRPLNumber) Sub(y XRPLNumber) XRPLNumber { return n.Add(y.Negate()) }
 
-// Mul returns the product of two XRPLNumbers using banker's rounding.
-func (n XRPLNumber) Mul(y XRPLNumber) XRPLNumber {
-	return n.MulRounded(y, RoundToNearest)
-}
+// Mul returns n * y using banker's rounding.
+func (n XRPLNumber) Mul(y XRPLNumber) XRPLNumber { return n.MulRounded(y, RoundToNearest) }
 
-// MulRounded returns the product of two XRPLNumbers rounded under mode.
-// Reference: Number::operator*= in Number.cpp lines 375-445
+// MulRounded returns n * y rounded under mode (rippled operator*=).
 func (n XRPLNumber) MulRounded(y XRPLNumber, mode RoundingMode) XRPLNumber {
 	if n.IsZero() {
 		return n
@@ -386,73 +480,38 @@ func (n XRPLNumber) MulRounded(y XRPLNumber, mode RoundingMode) XRPLNumber {
 	if y.IsZero() {
 		return y
 	}
+	minM, maxM, _ := n.scale.params()
 
-	xm := n.mantissa
-	xe := n.exponent
-	xn := int64(1)
-	if xm < 0 {
-		xm = -xm
-		xn = -1
-	}
+	zn := n.negative != y.negative
+	ze := n.exponent + y.exponent
 
-	ym := y.mantissa
-	ye := y.exponent
-	yn := int64(1)
-	if ym < 0 {
-		ym = -ym
-		yn = -1
-	}
+	zm := new(big.Int).Mul(new(big.Int).SetUint64(n.mantissa), new(big.Int).SetUint64(y.mantissa))
+	bigMaxM := new(big.Int).SetUint64(maxM)
+	bigMaxRep := new(big.Int).SetUint64(xrplNumMaxRep)
+	ten := big.NewInt(10)
+	rem := new(big.Int)
 
-	// Use big.Int for multiplication (equivalent to uint128_t)
-	zm := new(big.Int).Mul(big.NewInt(xm), big.NewInt(ym))
-	ze := xe + ye
-	zn := xn * yn
-
-	// Scale down with guard
 	var g xrplGuard
-	if zn == -1 {
+	if zn {
 		g.setNegative()
 	}
-	bigMaxMant := big.NewInt(xrplNumMaxMantissa)
-	bigTen := big.NewInt(10)
-	bigRem := new(big.Int)
-	for zm.Cmp(bigMaxMant) > 0 {
-		zm.DivMod(zm, bigTen, bigRem)
-		g.push(uint(bigRem.Int64()))
+	for zm.Cmp(bigMaxM) > 0 || zm.Cmp(bigMaxRep) > 0 {
+		zm.DivMod(zm, ten, rem)
+		g.push(uint(rem.Uint64()))
 		ze++
 	}
+	xm := zm.Uint64()
+	g.doRoundUp(&zn, &xm, &ze, minM, maxM, mode, "XRPLNumber::multiplication overflow")
 
-	xm = zm.Int64()
-	xe = ze
-
-	// Apply guard rounding
-	r := g.round(mode)
-	if r == 1 || (r == 0 && (xm&1) == 1) {
-		xm++
-		if xm > xrplNumMaxMantissa {
-			xm /= 10
-			xe++
-		}
-	}
-
-	// Handle underflow/overflow
-	if xe < xrplNumMinExponent {
-		return xrplNumberZero()
-	}
-	if xe > xrplNumMaxExponent {
-		panic("XRPLNumber::multiplication overflow")
-	}
-
-	return XRPLNumber{mantissa: xm * zn, exponent: xe}
+	r := XRPLNumber{negative: zn, mantissa: xm, exponent: ze, scale: n.scale}
+	r.normalize(mode)
+	return r
 }
 
 // Div returns n / y using banker's rounding.
-func (n XRPLNumber) Div(y XRPLNumber) XRPLNumber {
-	return n.DivRounded(y, RoundToNearest)
-}
+func (n XRPLNumber) Div(y XRPLNumber) XRPLNumber { return n.DivRounded(y, RoundToNearest) }
 
-// DivRounded returns n / y rounded under mode.
-// Reference: Number::operator/= in Number.cpp lines 447-478
+// DivRounded returns n / y rounded under mode (rippled operator/=).
 func (n XRPLNumber) DivRounded(y XRPLNumber, mode RoundingMode) XRPLNumber {
 	if y.IsZero() {
 		panic("XRPLNumber: divide by zero")
@@ -460,129 +519,243 @@ func (n XRPLNumber) DivRounded(y XRPLNumber, mode RoundingMode) XRPLNumber {
 	if n.IsZero() {
 		return n
 	}
+	small := n.scale == MantissaScaleSmall
+	zn := n.negative != y.negative
 
-	np := int64(1)
-	nm := n.mantissa
-	ne := n.exponent
-	if nm < 0 {
-		nm = -nm
-		np = -1
+	// Shift by 10^17 (small) / 10^19 (large) gives the most precision without
+	// overflowing the 128-bit intermediate or the cast back.
+	var f *big.Int
+	if small {
+		f = new(big.Int).SetUint64(100_000_000_000_000_000)
+	} else {
+		f = new(big.Int).SetUint64(10_000_000_000_000_000_000)
+	}
+	dmu := new(big.Int).SetUint64(y.mantissa)
+	numerator := new(big.Int).Mul(new(big.Int).SetUint64(n.mantissa), f)
+
+	zm := new(big.Int)
+	remainder := new(big.Int)
+	zm.QuoRem(numerator, dmu, remainder)
+	ze := n.exponent - y.exponent
+	if small {
+		ze -= 17
+	} else {
+		ze -= 19
 	}
 
-	dp := int64(1)
-	dm := y.mantissa
-	de := y.exponent
-	if dm < 0 {
-		dm = -dm
-		dp = -1
+	if !small && remainder.Sign() != 0 {
+		// Fold three extra digits of precision (the correctionFactor) into the
+		// quotient before rounding, then divide back out via the exponent.
+		correction := new(big.Int).Mul(remainder, big.NewInt(1000))
+		correction.Quo(correction, dmu)
+		zm.Mul(zm, big.NewInt(1000))
+		zm.Add(zm, correction)
+		ze -= 3
 	}
 
-	// Scale by 10^17 for maximum precision without overflowing
-	// uint128_t equivalent: big.Int
-	f := new(big.Int).SetUint64(100_000_000_000_000_000) // 10^17
-	bigNm := new(big.Int).SetInt64(nm)
-	bigDm := new(big.Int).SetInt64(dm)
-	bigNm.Mul(bigNm, f)
-	quotient := new(big.Int).Div(bigNm, bigDm)
-
-	result := XRPLNumber{
-		mantissa: quotient.Int64() * np * dp,
-		exponent: ne - de - 17,
-	}
-	result.normalize(mode)
-	return result
+	return normalizeFromBig(zn, zm, ze, n.scale, mode)
 }
 
-// ToIOUAmountValue converts an XRPLNumber back to IOUAmountValue,
-// clamping the wider exponent range to IOUAmount's [-96, 80].
+// normalizeFromBig normalizes a big.Int mantissa (the Div intermediate can
+// exceed 64 bits) into an XRPLNumber (rippled doNormalize for uint128).
+func normalizeFromBig(negative bool, m *big.Int, e int, scale MantissaScale, mode RoundingMode) XRPLNumber {
+	z := XRPLNumber{scale: scale}
+	if m.Sign() == 0 {
+		return z.zero()
+	}
+	minM, maxM, _ := scale.params()
+	bigMinM := new(big.Int).SetUint64(minM)
+	bigMaxM := new(big.Int).SetUint64(maxM)
+	bigMaxRep := new(big.Int).SetUint64(xrplNumMaxRep)
+	ten := big.NewInt(10)
+	rem := new(big.Int)
+	mm := new(big.Int).Set(m)
+
+	for mm.Cmp(bigMinM) < 0 && e > xrplNumMinExponent {
+		mm.Mul(mm, ten)
+		e--
+	}
+	var g xrplGuard
+	if negative {
+		g.setNegative()
+	}
+	for mm.Cmp(bigMaxM) > 0 {
+		if e >= xrplNumMaxExponent {
+			panic("XRPLNumber::normalize overflow")
+		}
+		mm.DivMod(mm, ten, rem)
+		g.push(uint(rem.Uint64()))
+		e++
+	}
+	if e < xrplNumMinExponent || mm.Cmp(bigMinM) < 0 {
+		return z.zero()
+	}
+	if mm.Cmp(bigMaxRep) > 0 {
+		if e >= xrplNumMaxExponent {
+			panic("XRPLNumber::normalize overflow")
+		}
+		mm.DivMod(mm, ten, rem)
+		g.push(uint(rem.Uint64()))
+		e++
+	}
+	mu := mm.Uint64()
+	g.doRoundUp(&negative, &mu, &e, minM, maxM, mode, "XRPLNumber::normalize overflow")
+	return XRPLNumber{negative: negative, mantissa: mu, exponent: e, scale: scale}
+}
+
+// NormalizeToRange returns the value's mantissa and exponent renormalized to an
+// arbitrary [minMantissa, maxMantissa] range (rippled Number::normalizeToRange).
+// The returned mantissa is signed. It is used by STAmount's IOU conversion to
+// snap a Number into the IOU mantissa range.
+func (n XRPLNumber) NormalizeToRange(minMantissa, maxMantissa uint64) (mantissa int64, exponent int) {
+	neg := n.negative
+	m := n.mantissa
+	e := n.exponent
+	normalizeInRange(&neg, &m, &e, minMantissa, maxMantissa)
+	if neg {
+		return -int64(m), e
+	}
+	return int64(m), e
+}
+
+// normalizeInRange is doNormalize parameterized by an explicit mantissa range,
+// under the ambient (to_nearest) rounding used by normalizeToRange.
+func normalizeInRange(negative *bool, m *uint64, e *int, minM, maxM uint64) {
+	if *m == 0 {
+		*negative = false
+		*e = xrplNumZeroExponent
+		return
+	}
+	for *m < minM && *e > xrplNumMinExponent {
+		*m *= 10
+		*e--
+	}
+	var g xrplGuard
+	if *negative {
+		g.setNegative()
+	}
+	for *m > maxM {
+		if *e >= xrplNumMaxExponent {
+			panic("XRPLNumber::normalize overflow")
+		}
+		g.push(uint(*m % 10))
+		*m /= 10
+		*e++
+	}
+	if *e < xrplNumMinExponent || *m < minM {
+		*negative = false
+		*m = 0
+		*e = xrplNumZeroExponent
+		return
+	}
+	if *m > xrplNumMaxRep {
+		if *e >= xrplNumMaxExponent {
+			panic("XRPLNumber::normalize overflow")
+		}
+		g.push(uint(*m % 10))
+		*m /= 10
+		*e++
+	}
+	g.doRoundUp(negative, m, e, minM, maxM, RoundToNearest, "XRPLNumber::normalize overflow")
+}
+
+// ToIOUAmountValue converts to IOUAmountValue, clamping the wider exponent range
+// to IOUAmount's [-96, 80].
 func (n XRPLNumber) ToIOUAmountValue() IOUAmountValue {
 	if n.IsZero() {
 		return ZeroIOUValue()
 	}
-	if n.exponent > MaxExponent {
+	e := n.Exponent()
+	if e > MaxExponent {
 		panic("XRPLNumber→IOUAmountValue overflow")
 	}
-	if n.exponent < MinExponent {
+	if e < MinExponent {
 		return ZeroIOUValue()
 	}
-	return IOUAmountValue{mantissa: n.mantissa, exponent: n.exponent}
+	return IOUAmountValue{mantissa: n.Mantissa(), exponent: e}
 }
 
-// ToInt64WithMode converts this Number to an int64 using Guard-based rounding
-// under mode, matching rippled's Number::operator rep() (Number.cpp lines
-// 480-512).
+// ToInt64WithMode converts to int64 with Guard rounding under mode (rippled
+// Number::operator rep()). It panics on overflow.
 func (n XRPLNumber) ToInt64WithMode(mode RoundingMode) int64 {
-	drops := n.mantissa
-	offset := n.exponent
+	drops := n.Mantissa()
+	offset := n.Exponent()
 	var g xrplGuard
-
-	if drops != 0 {
-		if drops < 0 {
-			g.setNegative()
-			drops = -drops
+	if drops == 0 {
+		return 0
+	}
+	if drops < 0 {
+		g.setNegative()
+		drops = -drops
+	}
+	for offset < 0 {
+		g.push(uint(drops % 10))
+		drops /= 10
+		offset++
+	}
+	for offset > 0 {
+		if uint64(drops) > xrplNumMaxRep/10 {
+			panic("XRPLNumber::operator rep() overflow")
 		}
-		for offset < 0 {
-			g.push(uint(drops % 10))
-			drops /= 10
-			offset++
+		drops *= 10
+		offset--
+	}
+	if r := g.round(mode); r == 1 || (r == 0 && (drops&1) == 1) {
+		if uint64(drops) >= xrplNumMaxRep {
+			panic("XRPLNumber::operator rep() rounding overflow")
 		}
-		for offset > 0 {
-			drops *= 10
-			offset--
-		}
-
-		// Apply rounding with the specified mode
-		r := g.round(mode)
-
-		if r == 1 || (r == 0 && (drops&1) == 1) {
-			drops++
-		}
-		if g.sbit {
-			drops = -drops
-		}
+		drops++
+	}
+	if g.sbit {
+		drops = -drops
 	}
 	return drops
 }
 
-// root2 computes the square root of n using banker's rounding.
-func (n XRPLNumber) root2() XRPLNumber {
-	return n.root2Rounded(RoundToNearest)
+// shiftExponent returns the number with its exponent shifted by delta, keeping
+// the mantissa (rippled Number::shiftExponent).
+func (n XRPLNumber) shiftExponent(delta int) XRPLNumber {
+	newE := n.exponent + delta
+	if newE >= xrplNumMaxExponent {
+		panic("XRPLNumber::shiftExponent overflow")
+	}
+	if newE < xrplNumMinExponent {
+		return n.zero()
+	}
+	return XRPLNumber{negative: n.negative, mantissa: n.mantissa, exponent: newE, scale: n.scale}
 }
 
-// root2Rounded computes the square root of n using Newton-Raphson iteration,
-// rounding every intermediate operation under mode.
-// Reference: root2() in Number.cpp lines 700-736
+// root2 computes the square root using banker's rounding.
+func (n XRPLNumber) root2() XRPLNumber { return n.root2Rounded(RoundToNearest) }
+
+// root2Rounded computes the square root via Newton-Raphson iteration, rounding
+// every intermediate under mode (rippled root2).
 func (n XRPLNumber) root2Rounded(mode RoundingMode) XRPLNumber {
-	one := NewXRPLNumber(xrplNumMinMantissa, -15) // Number{1}
+	one := n.oneVal()
 	if n.Equal(one) {
 		return n
 	}
-	if n.mantissa < 0 {
+	if n.negative {
 		panic("XRPLNumber::root2 nan")
 	}
 	if n.IsZero() {
 		return n
 	}
 
-	// Scale f into range (0, 1) such that f's exponent is even
-	f := n
-	e := f.exponent + 16
+	_, _, rangeLog := n.scale.params()
+	e := n.exponent + rangeLog + 1
 	if e%2 != 0 {
 		e++
 	}
-	f = XRPLNumber{mantissa: f.mantissa, exponent: f.exponent - e}
-	f.normalize(mode)
+	f := n.shiftExponent(-e)
 
-	// Quadratic least squares curve fit: r = ((a2*f + a1)*f + a0) / D
-	// where D=105, a0=18, a1=144, a2=-60
-	a0 := NewXRPLNumberFromInt(18)
-	a1 := NewXRPLNumberFromInt(144)
-	a2 := NewXRPLNumberFromInt(-60)
-	D := NewXRPLNumberFromInt(105)
-	r := a2.MulRounded(f, mode).AddRounded(a1, mode).MulRounded(f, mode).AddRounded(a0, mode).DivRounded(D, mode)
+	a0 := n.intConst(18)
+	a1 := n.intConst(144)
+	a2 := n.intConst(-60)
+	den := n.intConst(105)
+	r := a2.MulRounded(f, mode).AddRounded(a1, mode).MulRounded(f, mode).AddRounded(a0, mode).DivRounded(den, mode)
 
-	// Newton-Raphson iteration: r = (r + f/r) / 2
-	two := NewXRPLNumberFromInt(2)
+	two := n.intConst(2)
 	var rm1, rm2 XRPLNumber
 	for {
 		rm2 = rm1
@@ -592,7 +765,69 @@ func (n XRPLNumber) root2Rounded(mode RoundingMode) XRPLNumber {
 			break
 		}
 	}
+	return r.shiftExponent(e / 2)
+}
 
-	// Return r * 10^(e/2) to reverse scaling
-	return XRPLNumber{mantissa: r.mantissa, exponent: r.exponent + e/2}
+// String renders the number as rippled's to_string(Number) does, using the
+// receiver's scale to choose thresholds and padding. This is the text form of
+// every NUMBER sfield in JSON.
+func (n XRPLNumber) String() string {
+	if n.mantissa == 0 {
+		return "0"
+	}
+	_, _, rangeLog := n.scale.params()
+	exponent := n.exponent
+	mantissa := n.mantissa
+
+	if exponent != 0 && (exponent < -(rangeLog+10) || exponent > -(rangeLog-10)) {
+		for mantissa != 0 && mantissa%10 == 0 && exponent < xrplNumMaxExponent {
+			mantissa /= 10
+			exponent++
+		}
+		var b strings.Builder
+		if n.negative {
+			b.WriteByte('-')
+		}
+		b.WriteString(strconv.FormatUint(mantissa, 10))
+		b.WriteByte('e')
+		b.WriteString(strconv.Itoa(exponent))
+		return b.String()
+	}
+
+	padPrefix := rangeLog + 12
+	padSuffix := rangeLog + 8
+	raw := strconv.FormatUint(mantissa, 10)
+	val := strings.Repeat("0", padPrefix) + raw + strings.Repeat("0", padSuffix)
+	offset := exponent + padPrefix + rangeLog + 1
+
+	preFrom, preTo := 0, offset
+	postFrom, postTo := offset, len(val)
+
+	if preTo-preFrom > padPrefix {
+		preFrom += padPrefix
+	}
+	for preFrom < preTo && val[preFrom] == '0' {
+		preFrom++
+	}
+	if postTo-postFrom > padSuffix {
+		postTo -= padSuffix
+	}
+	for postTo > postFrom && val[postTo-1] == '0' {
+		postTo--
+	}
+
+	var b strings.Builder
+	if n.negative {
+		b.WriteByte('-')
+	}
+	if preFrom == preTo {
+		b.WriteByte('0')
+	} else {
+		b.WriteString(val[preFrom:preTo])
+	}
+	if postTo != postFrom {
+		b.WriteByte('.')
+		b.WriteString(val[postFrom:postTo])
+	}
+	return b.String()
 }

--- a/internal/ledger/state/xrpl_number_scale_test.go
+++ b/internal/ledger/state/xrpl_number_scale_test.go
@@ -1,0 +1,212 @@
+package state
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests port rippled 3.1.0's Number_test.cpp coverage for the two mantissa
+// scales (small / large), exercising to_string, int64 conversion, rounding and
+// the range limits in both.
+
+// newNumberInternal builds a Number from its internal (sign, uint64 mantissa,
+// exponent) triple and normalizes under mode — rippled's Number{..., normalized}.
+func newNumberInternal(negative bool, mantissa uint64, exponent int, scale MantissaScale, mode RoundingMode) XRPLNumber {
+	n := XRPLNumber{negative: negative, mantissa: mantissa, exponent: exponent, scale: scale}
+	n.normalize(mode)
+	return n
+}
+
+// numberMin / numberMax / numberLowest mirror Number::min/max/lowest for a scale.
+func numberMin(scale MantissaScale) XRPLNumber {
+	minM, _, _ := scale.params()
+	return XRPLNumber{mantissa: minM, exponent: xrplNumMinExponent, scale: scale}
+}
+
+func numberMax(scale MantissaScale) XRPLNumber {
+	_, maxM, _ := scale.params()
+	if maxM > xrplNumMaxRep {
+		maxM = xrplNumMaxRep
+	}
+	return XRPLNumber{mantissa: maxM, exponent: xrplNumMaxExponent, scale: scale}
+}
+
+func numberLowest(scale MantissaScale) XRPLNumber {
+	n := numberMax(scale)
+	n.negative = true
+	return n
+}
+
+func TestXRPLNumber_ToString_CommonBothScales(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		mant int64
+		exp  int
+		want string
+	}{
+		{-2, 0, "-2"},
+		{0, 0, "0"},
+		{2, 0, "2"},
+		{25, -3, "0.025"},
+		{-25, -3, "-0.025"},
+		{25, 1, "250"},
+		{-25, 1, "-250"},
+		{2, 20, "2e20"},
+		{-2, -20, "-2e-20"},
+		// Threshold edges: decimal just inside, scientific just outside.
+		{2, -10, "0.0000000002"},
+		{2, -11, "2e-11"},
+		{-2, 10, "-20000000000"},
+		{-2, 11, "-2e11"},
+	}
+	for _, scale := range []MantissaScale{MantissaScaleSmall, MantissaScaleLarge} {
+		for _, tc := range cases {
+			got := NewXRPLNumberScaled(tc.mant, tc.exp, scale, RoundToNearest).String()
+			require.Equalf(t, tc.want, got, "scale=%d Number(%d,%d)", scale, tc.mant, tc.exp)
+		}
+	}
+}
+
+func TestXRPLNumber_ToString_SmallScale(t *testing.T) {
+	t.Parallel()
+	s := MantissaScaleSmall
+
+	require.Equal(t, "1e-32753", numberMin(s).String())
+	require.Equal(t, "9999999999999999e32768", numberMax(s).String())
+	require.Equal(t, "-9999999999999999e32768", numberLowest(s).String())
+
+	const maxMantissa = uint64(9999999999999999)
+	require.Equal(t, "9999999999999999",
+		newNumberInternal(false, maxMantissa*1000+999, -3, s, RoundTowardsZero).String())
+	require.Equal(t, "-9999999999999999",
+		newNumberInternal(true, maxMantissa*1000+999, -3, s, RoundTowardsZero).String())
+
+	require.Equal(t, "9223372036854775",
+		NewXRPLNumberScaled(math.MaxInt64, -3, s, RoundTowardsZero).String())
+	require.Equal(t, "-9223372036854775",
+		NewXRPLNumberScaled(math.MaxInt64, -3, s, RoundTowardsZero).Negate().String())
+
+	require.Equal(t, "-9223372036854775e3",
+		NewXRPLNumberScaled(math.MinInt64, 0, s, RoundTowardsZero).String())
+	require.Equal(t, "9223372036854775e3",
+		NewXRPLNumberScaled(math.MinInt64, 0, s, RoundTowardsZero).Negate().String())
+}
+
+func TestXRPLNumber_ToString_LargeScale(t *testing.T) {
+	t.Parallel()
+	l := MantissaScaleLarge
+
+	require.Equal(t, "1e-32750", numberMin(l).String())
+	require.Equal(t, "9223372036854775807e32768", numberMax(l).String())
+	require.Equal(t, "-9223372036854775807e32768", numberLowest(l).String())
+
+	const maxMantissa = uint64(9999999999999999999)
+	require.Equal(t, "9999999999999999990",
+		newNumberInternal(false, maxMantissa, 0, l, RoundTowardsZero).String())
+	require.Equal(t, "-9999999999999999990",
+		newNumberInternal(true, maxMantissa, 0, l, RoundTowardsZero).String())
+
+	require.Equal(t, "9223372036854775807",
+		NewXRPLNumberScaled(math.MaxInt64, 0, l, RoundTowardsZero).String())
+	require.Equal(t, "-9223372036854775807",
+		NewXRPLNumberScaled(math.MaxInt64, 0, l, RoundTowardsZero).Negate().String())
+
+	// |MinInt64| exceeds max, so it scales down; towards zero drops the 8.
+	require.Equal(t, "-9223372036854775800",
+		NewXRPLNumberScaled(math.MinInt64, 0, l, RoundTowardsZero).String())
+	require.Equal(t, "9223372036854775800",
+		NewXRPLNumberScaled(math.MinInt64, 0, l, RoundTowardsZero).Negate().String())
+
+	// int64max + 1 is exactly representable at large scale.
+	maxPlus1 := NewXRPLNumberScaled(math.MaxInt64, 0, l, RoundToNearest).Add(NewXRPLNumberScaled(1, 0, l, RoundToNearest))
+	require.Equal(t, "9223372036854775810", maxPlus1.String())
+	require.Equal(t, "-9223372036854775810", maxPlus1.Negate().String())
+}
+
+func TestXRPLNumber_ToInt64_Rounding(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		mant                    int64
+		exp                     int
+		nearest, zero, down, up int64
+	}{
+		{13, -1, 1, 1, 1, 2},
+		{23, -1, 2, 2, 2, 3},
+		{15, -1, 2, 1, 1, 2},
+		{25, -1, 2, 2, 2, 3},
+		{152, -2, 2, 1, 1, 2},
+		{252, -2, 3, 2, 2, 3},
+		{17, -1, 2, 1, 1, 2},
+		{27, -1, 3, 2, 2, 3},
+		{-13, -1, -1, -1, -2, -1},
+		{-23, -1, -2, -2, -3, -2},
+		{-15, -1, -2, -1, -2, -1},
+		{-25, -1, -2, -2, -3, -2},
+		{-152, -2, -2, -1, -2, -1},
+		{-252, -2, -3, -2, -3, -2},
+		{-17, -1, -2, -1, -2, -1},
+		{-27, -1, -3, -2, -3, -2},
+	}
+	for _, scale := range []MantissaScale{MantissaScaleSmall, MantissaScaleLarge} {
+		for _, tc := range cases {
+			n := NewXRPLNumberScaled(tc.mant, tc.exp, scale, RoundToNearest)
+			require.Equalf(t, tc.nearest, n.ToInt64WithMode(RoundToNearest), "nearest scale=%d %d,%d", scale, tc.mant, tc.exp)
+			require.Equalf(t, tc.zero, n.ToInt64WithMode(RoundTowardsZero), "zero scale=%d %d,%d", scale, tc.mant, tc.exp)
+			require.Equalf(t, tc.down, n.ToInt64WithMode(RoundDownward), "down scale=%d %d,%d", scale, tc.mant, tc.exp)
+			require.Equalf(t, tc.up, n.ToInt64WithMode(RoundUpward), "up scale=%d %d,%d", scale, tc.mant, tc.exp)
+		}
+	}
+}
+
+// TestXRPLNumber_Int64_ExactRepresentation checks the defining property of the
+// large scale: every int64 value round-trips exactly, while the small scale
+// truncates values above its 16-digit precision.
+func TestXRPLNumber_Int64_ExactRepresentation(t *testing.T) {
+	t.Parallel()
+
+	// Large scale: int64 max is inside the mantissa range, exponent stays <= 0.
+	maxInt64 := NewXRPLNumberScaled(math.MaxInt64, 0, MantissaScaleLarge, RoundToNearest)
+	require.LessOrEqual(t, maxInt64.Exponent(), 0)
+	require.Equal(t, int64(math.MaxInt64), maxInt64.ToInt64WithMode(RoundToNearest))
+
+	// Small scale: int64 max exceeds 16-digit precision, so it gains a positive
+	// exponent and cannot represent the low digits exactly.
+	maxInt64Small := NewXRPLNumberScaled(math.MaxInt64, 0, MantissaScaleSmall, RoundToNearest)
+	require.Greater(t, maxInt64Small.Exponent(), 0)
+
+	// maxMantissa()/10 property for the large scale (rippled testInt64).
+	const largeMax = uint64(9999999999999999999)
+	maxN := newNumberInternal(false, largeMax, 0, MantissaScaleLarge, RoundTowardsZero)
+	require.Equal(t, int64(largeMax/10), maxN.Mantissa())
+	require.Equal(t, 1, maxN.Exponent())
+	require.Equal(t, newNumberInternal(false, largeMax/10-1, 20, MantissaScaleLarge, RoundTowardsZero),
+		maxN.MulRounded(maxN, RoundTowardsZero))
+}
+
+// TestXRPLNumber_Limits verifies min/max round-trip through arithmetic identities.
+func TestXRPLNumber_Limits(t *testing.T) {
+	t.Parallel()
+	for _, scale := range []MantissaScale{MantissaScaleSmall, MantissaScaleLarge} {
+		one := NewXRPLNumberScaled(1, 0, scale, RoundToNearest)
+		mn := numberMin(scale)
+		mx := numberMax(scale)
+		// min * 1 == min, max * 1 == max (identity through Mul).
+		require.True(t, mn.MulRounded(one, RoundToNearest).Equal(mn), "min*1 scale=%d", scale)
+		require.True(t, mx.MulRounded(one, RoundToNearest).Equal(mx), "max*1 scale=%d", scale)
+		// lowest == -max.
+		require.True(t, numberLowest(scale).Equal(mx.Negate()), "lowest scale=%d", scale)
+	}
+}
+
+// TestXRPLNumber_Root2_BothScales checks sqrt on perfect squares in both scales.
+func TestXRPLNumber_Root2_BothScales(t *testing.T) {
+	t.Parallel()
+	for _, scale := range []MantissaScale{MantissaScaleSmall, MantissaScaleLarge} {
+		four := NewXRPLNumberScaled(4, 0, scale, RoundToNearest)
+		require.True(t, four.root2().Equal(NewXRPLNumberScaled(2, 0, scale, RoundToNearest)), "sqrt(4) scale=%d", scale)
+		nine := NewXRPLNumberScaled(9, 0, scale, RoundToNearest)
+		require.True(t, nine.root2().Equal(NewXRPLNumberScaled(3, 0, scale, RoundToNearest)), "sqrt(9) scale=%d", scale)
+	}
+}

--- a/internal/ledger/state/xrpl_number_test.go
+++ b/internal/ledger/state/xrpl_number_test.go
@@ -11,12 +11,10 @@ func TestXRPLGuard_PushPop(t *testing.T) {
 	t.Parallel()
 	var g xrplGuard
 
-	// Push digits 1, 2, 3 (most recent pushed = most significant)
 	g.push(1)
 	g.push(2)
 	g.push(3)
 
-	// Pop should return in LIFO order
 	require.Equal(t, uint(3), g.pop())
 	require.Equal(t, uint(2), g.pop())
 	require.Equal(t, uint(1), g.pop())
@@ -30,54 +28,18 @@ func TestXRPLGuard_Round(t *testing.T) {
 		setup func(*xrplGuard)
 		want  int
 	}{
-		{
-			name:  "empty guard rounds down",
-			setup: func(g *xrplGuard) {},
-			want:  -1,
-		},
-		{
-			name: "exactly half (5) rounds to even (0 = half)",
-			setup: func(g *xrplGuard) {
-				g.push(5)
-			},
-			want: 0,
-		},
-		{
-			name: "greater than half rounds up",
-			setup: func(g *xrplGuard) {
-				g.push(6)
-			},
-			want: 1,
-		},
-		{
-			name: "less than half rounds down",
-			setup: func(g *xrplGuard) {
-				g.push(4)
-			},
-			want: -1,
-		},
-		{
-			name: "exactly half with xbit rounds up",
-			setup: func(g *xrplGuard) {
-				// Push two digits to set xbit: push(3) then push(5)
-				// After push(3): digits=0x3000..., xbit=false
-				// After push(5): digits=0x5000...0003..., xbit from 3's lowest nibble
-				g.push(3) // this will be shifted off when we push 5
-				g.push(5)
-				// Now digits has 5 at top with 3 shifted down
-				// The 3 digit at position 2 means digits > 0x5000...
-				// Actually let's test xbit directly
-			},
-			want: 1,
-		},
+		{"empty guard rounds down", func(g *xrplGuard) {}, -1},
+		{"exactly half (5) rounds to even (0 = half)", func(g *xrplGuard) { g.push(5) }, 0},
+		{"greater than half rounds up", func(g *xrplGuard) { g.push(6) }, 1},
+		{"less than half rounds down", func(g *xrplGuard) { g.push(4) }, -1},
+		{"exactly half with xbit rounds up", func(g *xrplGuard) { g.push(3); g.push(5) }, 1},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var g xrplGuard
 			tt.setup(&g)
-			got := g.round(RoundToNearest)
-			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.want, g.round(RoundToNearest))
 		})
 	}
 }
@@ -92,48 +54,20 @@ func TestXRPLNumber_Normalize(t *testing.T) {
 		wantMant int64
 		wantExp  int
 	}{
-		{
-			name:     "zero",
-			mant:     0,
-			exp:      0,
-			wantMant: 0,
-			wantExp:  xrplNumZeroExponent,
-		},
-		{
-			name:     "small integer 7",
-			mant:     7,
-			exp:      0,
-			wantMant: 7000000000000000,
-			wantExp:  -15,
-		},
-		{
-			name:     "already normalized",
-			mant:     1500000000000000,
-			exp:      -15,
-			wantMant: 1500000000000000,
-			wantExp:  -15,
-		},
-		{
-			name:     "negative value",
-			mant:     -1234567890123456,
-			exp:      -16,
-			wantMant: -1234567890123456,
-			wantExp:  -16,
-		},
-		{
-			name:     "needs scale down with guard rounding",
-			mant:     99999999999999995,
-			exp:      -17,
-			wantMant: 1000000000000000,
-			wantExp:  -15, // 99999999999999995 / 10 = 9999999999999999 with guard 5 → rounds to even (odd mantissa) → 10000000000000000 → /10 → exp=-15
-		},
+		{"zero", 0, 0, 0, xrplNumZeroExponent},
+		{"small integer 7", 7, 0, 7000000000000000, -15},
+		{"already normalized", 1500000000000000, -15, 1500000000000000, -15},
+		{"negative value", -1234567890123456, -16, -1234567890123456, -16},
+		// 99999999999999995 / 10 = 9999999999999999 with guard 5 → ties to even
+		// (odd mantissa) → 10000000000000000 → /10 → exp -15.
+		{"needs scale down with guard rounding", 99999999999999995, -17, 1000000000000000, -15},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			n := NewXRPLNumber(tt.mant, tt.exp)
-			require.Equal(t, tt.wantMant, n.mantissa, "mantissa mismatch")
-			require.Equal(t, tt.wantExp, n.exponent, "exponent mismatch")
+			require.Equal(t, tt.wantMant, n.Mantissa(), "mantissa mismatch")
+			require.Equal(t, tt.wantExp, n.Exponent(), "exponent mismatch")
 		})
 	}
 }
@@ -141,63 +75,53 @@ func TestXRPLNumber_Normalize(t *testing.T) {
 // TestXRPLNumber_Add_SameSign verifies addition of same-sign numbers.
 func TestXRPLNumber_Add_SameSign(t *testing.T) {
 	t.Parallel()
-	// 1.5 + 1.5 = 3.0
 	a := NewXRPLNumber(1500000000000000, -15) // 1.5
 	b := NewXRPLNumber(1500000000000000, -15) // 1.5
 	result := a.Add(b)
-	require.Equal(t, int64(3000000000000000), result.mantissa)
-	require.Equal(t, -15, result.exponent)
+	require.Equal(t, int64(3000000000000000), result.Mantissa())
+	require.Equal(t, -15, result.Exponent())
 }
 
-// TestXRPLNumber_Add_DifferentSign_GuardRecovery tests the critical Guard digit
-// recovery during subtraction — the key feature missing from our old addIOUValues.
+// TestXRPLNumber_Add_DifferentSign_GuardRecovery tests Guard digit recovery
+// during subtraction: 1.0 - 0.9999999999999999 must not be zero.
 func TestXRPLNumber_Add_DifferentSign_GuardRecovery(t *testing.T) {
 	t.Parallel()
-	// 1.0 - 0.9999999999999999 should NOT be zero
 	a := NewXRPLNumber(1000000000000000, -15)  // 1.0
 	b := NewXRPLNumber(-9999999999999999, -16) // -0.9999999999999999
 	result := a.Add(b)
-	// Result should be 1e-16 = {1000000000000000, -31}
 	require.False(t, result.IsZero(), "result should not be zero")
-	require.Equal(t, int64(1000000000000000), result.mantissa)
-	require.Equal(t, -31, result.exponent)
+	require.Equal(t, int64(1000000000000000), result.Mantissa())
+	require.Equal(t, -31, result.Exponent())
 }
 
-// TestXRPLNumber_Add_CriticalCase tests the specific case that causes
-// TestOffer_CreateThenCross to fail: -1.0 + 0.0335
+// TestXRPLNumber_Add_CriticalCase tests -1.0 + 0.0335 (an offer-crossing case).
 func TestXRPLNumber_Add_CriticalCase(t *testing.T) {
 	t.Parallel()
-	// -1.0 + 0.0335 = -0.9665
 	a := NewXRPLNumber(-1000000000000000, -15)
 	b := NewXRPLNumber(3350000000000000, -17)
 	result := a.Add(b)
-	// With Guard precision, the result should differ from simple -0.9665
-	// The exact value depends on the guard digit recovery
-	t.Logf("Result: mantissa=%d, exponent=%d", result.mantissa, result.exponent)
 	require.False(t, result.IsZero())
-	require.True(t, result.mantissa < 0, "result should be negative")
+	require.True(t, result.Mantissa() < 0, "result should be negative")
 }
 
 // TestXRPLNumber_Mul verifies multiplication with Guard rounding.
 func TestXRPLNumber_Mul(t *testing.T) {
 	t.Parallel()
-	// 2.0 * 3.0 = 6.0
 	a := NewXRPLNumber(2000000000000000, -15) // 2.0
 	b := NewXRPLNumber(3000000000000000, -15) // 3.0
 	result := a.Mul(b)
-	require.Equal(t, int64(6000000000000000), result.mantissa)
-	require.Equal(t, -15, result.exponent)
+	require.Equal(t, int64(6000000000000000), result.Mantissa())
+	require.Equal(t, -15, result.Exponent())
 }
 
 // TestXRPLNumber_Div verifies division with 10^17 scaling.
 func TestXRPLNumber_Div(t *testing.T) {
 	t.Parallel()
-	// 6.0 / 2.0 = 3.0
 	a := NewXRPLNumber(6000000000000000, -15) // 6.0
 	b := NewXRPLNumber(2000000000000000, -15) // 2.0
 	result := a.Div(b)
-	require.Equal(t, int64(3000000000000000), result.mantissa)
-	require.Equal(t, -15, result.exponent)
+	require.Equal(t, int64(3000000000000000), result.Mantissa())
+	require.Equal(t, -15, result.Exponent())
 }
 
 // TestXRPLNumber_Div_ThirdPrecision tests 1/3 precision.
@@ -206,9 +130,8 @@ func TestXRPLNumber_Div_ThirdPrecision(t *testing.T) {
 	one := NewXRPLNumber(1000000000000000, -15)
 	three := NewXRPLNumber(3000000000000000, -15)
 	result := one.Div(three)
-	// 1/3 = 0.3333333333333333... → 3333333333333333 * 10^-16
-	require.Equal(t, int64(3333333333333333), result.mantissa)
-	require.Equal(t, -16, result.exponent)
+	require.Equal(t, int64(3333333333333333), result.Mantissa())
+	require.Equal(t, -16, result.Exponent())
 }
 
 // TestXRPLNumber_ExactCancellation verifies a + (-a) = 0.
@@ -231,36 +154,27 @@ func TestXRPLNumber_ToIOUAmountValue(t *testing.T) {
 // TestXRPLNumber_ToIOUAmountValue_Underflow verifies exponent underflow → zero.
 func TestXRPLNumber_ToIOUAmountValue_Underflow(t *testing.T) {
 	t.Parallel()
-	// Create a number with exponent below IOUAmount min (-96)
-	// We can't use NewXRPLNumber as it would normalize, so test the conversion
-	n := XRPLNumber{mantissa: 1000000000000000, exponent: -100}
+	// An un-normalized number with exponent below IOUAmount min (-96).
+	n := newXRPLNumberRaw(1000000000000000, -100)
 	iou := n.ToIOUAmountValue()
 	require.True(t, iou.IsZero())
 }
 
-// TestAddIOUValues_WithSwitchover tests that addIOUValues produces different
-// results with the switchover enabled vs disabled.
-// Mutates the package-level numberSwitchoverEnabled — must not run in parallel.
+// TestAddIOUValues_WithSwitchover tests that addIOUValues produces sensible
+// results with the switchover enabled vs disabled. Mutates the package-level
+// numberSwitchoverEnabled — must not run in parallel.
 func TestAddIOUValues_WithSwitchover(t *testing.T) {
 	a := IOUAmountValue{mantissa: -1000000000000000, exponent: -15} // -1.0
 	b := IOUAmountValue{mantissa: 3350000000000000, exponent: -17}  // 0.0335
 
-	// Without switchover (legacy)
 	SetNumberSwitchover(false)
 	resultOff := addIOUValues(a, b)
-	t.Logf("Switchover OFF: mantissa=%d, exponent=%d, value=%s",
-		resultOff.mantissa, resultOff.exponent, resultOff.String())
 
-	// With switchover (Guard-based)
 	SetNumberSwitchover(true)
 	resultOn := addIOUValues(a, b)
-	t.Logf("Switchover ON:  mantissa=%d, exponent=%d, value=%s",
-		resultOn.mantissa, resultOn.exponent, resultOn.String())
 
-	// Reset
 	SetNumberSwitchover(false)
 
-	// Both should be approximately -0.9665 but may differ in last digits
 	require.False(t, resultOff.IsZero())
 	require.False(t, resultOn.IsZero())
 }
@@ -268,12 +182,7 @@ func TestAddIOUValues_WithSwitchover(t *testing.T) {
 // TestMulRatio_RoomToGrow tests that roomToGrow captures fractional precision.
 func TestMulRatio_RoomToGrow(t *testing.T) {
 	t.Parallel()
-	// A transfer rate calculation that requires roomToGrow for precision:
-	// amount * 1005000000 / 1000000000 (1.005 transfer rate)
 	amt := NewIssuedAmountFromValue(3350000000000000, -17, "USD", "rTest") // 0.0335
 	result := amt.MulRatio(1005000000, 1000000000, false)
-	t.Logf("MulRatio result: mantissa=%d, exponent=%d, value=%s",
-		result.iou.Mantissa(), result.iou.Exponent(), result.Value())
-	// With roomToGrow, the result should have more precision than 0.033675
 	require.False(t, result.IsZero())
 }


### PR DESCRIPTION
## Summary

Phase A of #1245 — the Number/codec foundation for rippled 3.1.0 parity. Targets the `v3.0.0` integration branch. Implements rippled PRs **#6192** (mantissa-range expansion), **#6156** (`to_string`/STNumber text + associateAsset), and **#6259** (soeDEFAULT field removal).

### 1. Number 64-bit mantissa scale (#6192)

`XRPLNumber` gains a runtime-selectable mantissa range:

- **small** `[10^15, 10^16-1]` (rangeLog 15) — the historical IOU range.
- **large** `[10^18, 10^19-1]` (rangeLog 18) — represents every `int64` drops/MPT value exactly (`maxRep = 2^63-1` lies inside the range).

Because a normalized large mantissa (up to `10^19-1`) exceeds `int64`, the internal representation is now a **sign flag + unsigned mantissa + exponent + scale**, matching rippled; the external view (`Mantissa()`/`Exponent()`) collapses back to a signed 63-bit mantissa. `normalizeToRange`, the signed/unsigned constructors, and the `setMantissaScale` analog are all ported.

### 2. `to_string` / STNumber text (ungated) (#6156)

- Trailing zeros now shift out of the scientific mantissa into the exponent (`1000000000000000e-45` → `1e-30`); sign emitted separately.
- Scientific-vs-decimal threshold and padding derive from the active rangeLog `L`: scientific iff `exponent < -(L+10) || exponent > -(L-10)`; `pad_prefix = L+12`, `pad_suffix = L+8` (small reproduces the old `-25/-5`, `27/23`).
- Faithful for both scales in `XRPLNumber.String()` and the codec's `formatNumberText` (the JSON rendering of every NUMBER sfield).

### 3. `associateAsset` + asset rounding (#6156, #6259)

`RoundToAsset` (integral XRP/MPT via `int64` cast; IOU via `normalizeToRange(cMinValue, cMaxValue)`) and `AssociateAssetField`, which reports whether a soeDEFAULT NUMBER field whose rounded value equals its default must be removed (#6259). These are the value-level primitives the ten `sMD_NeedsAsset` NUMBER fields use.

### 4. STAmount / Number conversion primitives

`NormalizeToRange` (IOU snap) and `ToInt64WithMode`'s overflow panic (integral `int64` cast) provide the `fromNumber` building blocks.

## How the scale is threaded (design note)

rippled uses a process-wide `thread_local` range, installed for every tx step. go-xrpl previously removed Number's mutable global state (#740) to keep concurrent amount math race-free. Following the same philosophy, the scale is **not a mutable global**: each `XRPLNumber` carries its own scale, and `MantissaScaleForRules(hasRules, singleAssetVault, lendingProtocol)` derives it from `*amendment.Rules` at the transaction boundary (large iff no rules, or either amendment enabled). Every current arithmetic caller runs without SingleAssetVault/LendingProtocol, so they use the small scale — the only scale reachable on `v3.0.0` — via the unscaled constructors, exactly equivalent to rippled installing its small range for those steps.

## Scope / Phase B

The value-level foundation and its wiring points ship here. The SLE-level `associateAsset(SLE, asset)` iteration, the per-sfield `sMD_NeedsAsset` codec flag, the `tx.Amount` `fromNumber` wrapper, and the Vault ledgerfields (`int64` → NUMBER) land with the SingleAssetVault / LendingProtocol transactors.

## Verification

- `just build-all` — clean.
- Full `just test` — no non-conformance regressions; conformance failure set **identical** to the fresh `v3.0.0` baseline (178 == 178, 0 new, 0 fixed).
- Small-scale arithmetic proven byte-identical via the differential fuzz oracle (656k+ execs, 0 mismatches).
- Ported rippled 3.1.0 `Number_test.cpp` (`to_string`, int64 rounding, limits) for **both** scales.
- `golangci-lint run --config .golangci.yml ./...` — 0 issues.
- docsgen (`rpcmethods`, `registries`) — no drift.

Part of #1245 (Phase A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)