### PR TITLE
feat(rpc): object-form loan/loan_broker ledger_entry selectors (3.1.0)

### DIFF
--- a/internal/rpc/handlers/ledger_entry.go
+++ b/internal/rpc/handlers/ledger_entry.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
@@ -213,14 +215,10 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
-	// loan / loan_broker: string (hex ID). rippled's parseLoan/parseLoanBroker
-	// resolve a keylet from an object form (loan_broker_id+loan_seq / owner+seq),
-	// but fall back to a direct hex-index lookup when the param is not an object.
-	// go-xrpl has no lending subsystem (no keylet::loan), so only that hex-index
-	// form is supported — the same pragmatic handling as bridge/xchain.
+	// loan: string (hex object index) or { loan_broker_id, loan_seq }
 	if !keySet {
 		if raw, ok := rawParams["loan"]; ok {
-			entryKey, rpcErr = parseHex256(raw, "loan")
+			entryKey, rpcErr = parseLoanKeylet(raw)
 			if rpcErr != nil {
 				return nil, rpcErr
 			}
@@ -228,9 +226,10 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		}
 	}
 
+	// loan_broker: string (hex object index) or { owner, seq }
 	if !keySet {
 		if raw, ok := rawParams["loan_broker"]; ok {
-			entryKey, rpcErr = parseHex256(raw, "loan_broker")
+			entryKey, rpcErr = parseLoanBrokerKeylet(raw)
 			if rpcErr != nil {
 				return nil, rpcErr
 			}
@@ -513,6 +512,8 @@ var ledgerEntryFilterTypes = []struct {
 	{"did", "DID"},
 	{"directory", "DirectoryNode"},
 	{"escrow", "Escrow"},
+	{"loan", "Loan"},
+	{"loan_broker", "LoanBroker"},
 	{"mpt_issuance", "MPTokenIssuance"},
 	{"mptoken", "MPToken"},
 	{"nft_page", "NFTokenPage"},
@@ -782,6 +783,128 @@ func parseEscrowKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
 		return [32]byte{}, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid escrow owner: %v", err))
 	}
 	return keylet.Escrow(accountID, req.Seq).Key, nil
+}
+
+// parseLoanKeylet parses a loan specifier: a hex object index or
+// { loan_broker_id, loan_seq }, mirroring rippled LedgerEntry.cpp parseLoan().
+func parseLoanKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
+	obj, ok := asJSONObject(raw)
+	if !ok {
+		return parseSelectorHexID(raw, "loan")
+	}
+	brokerID, rpcErr := requiredHash256Field(obj, "loan_broker_id", "malformedBroker")
+	if rpcErr != nil {
+		return [32]byte{}, rpcErr
+	}
+	loanSeq, rpcErr := requiredUInt32Field(obj, "loan_seq", "malformedSeq")
+	if rpcErr != nil {
+		return [32]byte{}, rpcErr
+	}
+	return keylet.Loan(brokerID, loanSeq).Key, nil
+}
+
+// parseLoanBrokerKeylet parses a loan_broker specifier: a hex object index or
+// { owner, seq }, mirroring rippled LedgerEntry.cpp parseLoanBroker().
+func parseLoanBrokerKeylet(raw json.RawMessage) ([32]byte, *types.RpcError) {
+	obj, ok := asJSONObject(raw)
+	if !ok {
+		return parseSelectorHexID(raw, "loan_broker")
+	}
+	owner, rpcErr := requiredAccountIDField(obj, "owner", "malformedOwner")
+	if rpcErr != nil {
+		return [32]byte{}, rpcErr
+	}
+	seq, rpcErr := requiredUInt32Field(obj, "seq", "malformedSeq")
+	if rpcErr != nil {
+		return [32]byte{}, rpcErr
+	}
+	return keylet.LoanBroker(owner, seq).Key, nil
+}
+
+// asJSONObject reports whether raw is a JSON object and, if so, unmarshals it.
+// It mirrors rippled's params.isObject() branch: only objects take the field
+// path; strings/arrays/numbers/null fall through to the hex-index form.
+func asJSONObject(raw json.RawMessage) (map[string]json.RawMessage, bool) {
+	if trimmed := bytes.TrimSpace(raw); len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil, false
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, false
+	}
+	return obj, true
+}
+
+// parseSelectorHexID resolves a non-object selector as a 64-char hex object
+// index, mirroring rippled's parseObjectID: an unparseable value yields the
+// "malformedRequest" token with an expected-hex-string message.
+func parseSelectorHexID(raw json.RawMessage, field string) ([32]byte, *types.RpcError) {
+	if key, ok := tryParseHex256(raw); ok {
+		return key, nil
+	}
+	return [32]byte{}, types.RpcErrorMalformedField("malformedRequest", field, "hex string")
+}
+
+// isJSONFieldAbsent reports whether a required subfield is missing or explicitly
+// null, which rippled treats identically.
+func isJSONFieldAbsent(obj map[string]json.RawMessage, field string) bool {
+	raw, ok := obj[field]
+	return !ok || bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+}
+
+// requiredHash256Field mirrors rippled requiredUInt256: a required 64-char hex
+// field. Absent → malformedRequest; present but unparseable → field token.
+func requiredHash256Field(obj map[string]json.RawMessage, field, token string) ([32]byte, *types.RpcError) {
+	if isJSONFieldAbsent(obj, field) {
+		return [32]byte{}, types.RpcErrorMalformedRequestMissingField(field)
+	}
+	if key, ok := tryParseHex256(obj[field]); ok {
+		return key, nil
+	}
+	return [32]byte{}, types.RpcErrorMalformedField(token, field, "Hash256")
+}
+
+// requiredAccountIDField mirrors rippled requiredAccountID: a required, non-zero
+// base58 account. Absent → malformedRequest; present but unparseable → token.
+func requiredAccountIDField(obj map[string]json.RawMessage, field, token string) ([20]byte, *types.RpcError) {
+	if isJSONFieldAbsent(obj, field) {
+		return [20]byte{}, types.RpcErrorMalformedRequestMissingField(field)
+	}
+	var s string
+	if err := json.Unmarshal(obj[field], &s); err == nil {
+		if id, err := decodeAccountID(s); err == nil && id != [20]byte{} {
+			return id, nil
+		}
+	}
+	return [20]byte{}, types.RpcErrorMalformedField(token, field, "AccountID")
+}
+
+// requiredUInt32Field mirrors rippled requiredUInt32: a required uint32 accepted
+// as a non-negative JSON integer that fits 32 bits, or a numeric string.
+func requiredUInt32Field(obj map[string]json.RawMessage, field, token string) (uint32, *types.RpcError) {
+	if isJSONFieldAbsent(obj, field) {
+		return 0, types.RpcErrorMalformedRequestMissingField(field)
+	}
+	if v, ok := parseUInt32(obj[field]); ok {
+		return v, nil
+	}
+	return 0, types.RpcErrorMalformedField(token, field, "number")
+}
+
+// parseUInt32 accepts a JSON number (non-negative, fits uint32) or a numeric
+// string, rejecting fractional, negative, out-of-range, and non-numeric values.
+func parseUInt32(raw json.RawMessage) (uint32, bool) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		n, err := strconv.ParseUint(s, 10, 32)
+		return uint32(n), err == nil
+	}
+	var num json.Number
+	if err := json.Unmarshal(raw, &num); err == nil {
+		n, err := strconv.ParseUint(num.String(), 10, 32)
+		return uint32(n), err == nil
+	}
+	return 0, false
 }
 
 // parseMPTokenKeylet parses an mptoken specifier: string (hex) or { mpt_issuance_id, account }

--- a/internal/rpc/ledger_entry_test.go
+++ b/internal/rpc/ledger_entry_test.go
@@ -7,9 +7,11 @@ import (
 	"strings"
 	"testing"
 
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,6 +21,7 @@ type mockLedgerEntryService struct {
 	mockLedgerService
 	ledgerEntryResult *types.LedgerEntryResult
 	ledgerEntryErr    error
+	lastRequestedKey  [32]byte
 }
 
 func newMockLedgerEntryService() *mockLedgerEntryService {
@@ -40,6 +43,7 @@ func newMockLedgerEntryService() *mockLedgerEntryService {
 }
 
 func (m *mockLedgerEntryService) GetLedgerEntry(_ context.Context, entryKey [32]byte, ledgerIndex string) (*types.LedgerEntryResult, error) {
+	m.lastRequestedKey = entryKey
 	if m.ledgerEntryErr != nil {
 		return nil, m.ledgerEntryErr
 	}
@@ -1504,6 +1508,230 @@ func TestLedgerEntryEscrow(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Loan / LoanBroker Entry Tests
+
+// TestLedgerEntryLoan covers the object-form loan selector
+// { loan_broker_id, loan_seq }, its hex-index equivalent, and the malformed
+// field responses (including the 3.1.0 malformedBroker token).
+func TestLedgerEntryLoan(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	services := newLedgerEntryTestServices(mock)
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	brokerIDHex := "5233D68B4D44388F98559DE42903767803EFA7C1F8D01413FC16EE6B01403D6D"
+	var brokerID [32]byte
+	decoded, err := hex.DecodeString(brokerIDHex)
+	require.NoError(t, err)
+	copy(brokerID[:], decoded)
+	const loanSeq = uint32(7)
+	expectedKey := keylet.Loan(brokerID, loanSeq).Key
+	expectedKeyHex := hex.EncodeToString(expectedKey[:])
+
+	t.Run("object form resolves to keylet.Loan and returns the node", func(t *testing.T) {
+		mock.ledgerEntryResult = &types.LedgerEntryResult{
+			Index:       expectedKeyHex,
+			LedgerIndex: 4,
+			LedgerHash:  [32]byte{0x4B, 0xC5},
+			Node:        []byte(`{"LedgerEntryType": "Loan", "Sequence": 7}`),
+			Validated:   true,
+		}
+		params := map[string]any{
+			"loan": map[string]any{
+				"loan_broker_id": brokerIDHex,
+				"loan_seq":       loanSeq,
+			},
+			"ledger_index": "validated",
+		}
+		result, rpcErr := handleLedgerEntry(t, method, ctx, params)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+		assert.Equal(t, expectedKey, mock.lastRequestedKey)
+	})
+
+	t.Run("hex form resolves to the same key as the object form", func(t *testing.T) {
+		mock.ledgerEntryResult = &types.LedgerEntryResult{
+			Index:     expectedKeyHex,
+			Node:      []byte(`{"LedgerEntryType": "Loan"}`),
+			Validated: true,
+		}
+		params := map[string]any{"loan": expectedKeyHex, "ledger_index": "validated"}
+		_, rpcErr := handleLedgerEntry(t, method, ctx, params)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedKey, mock.lastRequestedKey,
+			"hex and object forms must resolve to the same key")
+	})
+
+	malformedCases := []struct {
+		name    string
+		loan    map[string]any
+		token   string
+		message string
+	}{
+		{
+			name:    "loan_broker_id not hex yields malformedBroker",
+			loan:    map[string]any{"loan_broker_id": "not-a-hash", "loan_seq": loanSeq},
+			token:   "malformedBroker",
+			message: "Invalid field 'loan_broker_id', not Hash256.",
+		},
+		{
+			name:    "loan_broker_id missing yields malformedRequest",
+			loan:    map[string]any{"loan_seq": loanSeq},
+			token:   "malformedRequest",
+			message: "Missing field 'loan_broker_id'.",
+		},
+		{
+			name:    "loan_seq non-numeric yields malformedSeq",
+			loan:    map[string]any{"loan_broker_id": brokerIDHex, "loan_seq": "abc"},
+			token:   "malformedSeq",
+			message: "Invalid field 'loan_seq', not number.",
+		},
+		{
+			name:    "loan_seq negative yields malformedSeq",
+			loan:    map[string]any{"loan_broker_id": brokerIDHex, "loan_seq": -1},
+			token:   "malformedSeq",
+			message: "Invalid field 'loan_seq', not number.",
+		},
+		{
+			name:    "loan_seq missing yields malformedRequest",
+			loan:    map[string]any{"loan_broker_id": brokerIDHex},
+			token:   "malformedRequest",
+			message: "Missing field 'loan_seq'.",
+		},
+	}
+	for _, tc := range malformedCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock.ledgerEntryResult = nil
+			params := map[string]any{"loan": tc.loan, "ledger_index": "validated"}
+			result, rpcErr := handleLedgerEntry(t, method, ctx, params)
+			assert.Nil(t, result)
+			require.NotNil(t, rpcErr)
+			assert.Equal(t, tc.token, rpcErr.ErrorString)
+			assert.Equal(t, tc.message, rpcErr.Message)
+			assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		})
+	}
+
+	t.Run("non-object non-hex loan yields malformedRequest", func(t *testing.T) {
+		mock.ledgerEntryResult = nil
+		params := map[string]any{"loan": "not-hex", "ledger_index": "validated"}
+		result, rpcErr := handleLedgerEntry(t, method, ctx, params)
+		assert.Nil(t, result)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, "malformedRequest", rpcErr.ErrorString)
+		assert.Equal(t, "Invalid field 'loan', not hex string.", rpcErr.Message)
+	})
+}
+
+// TestLedgerEntryLoanBroker covers the object-form loan_broker selector
+// { owner, seq }, its hex-index equivalent, and the malformed field responses.
+func TestLedgerEntryLoanBroker(t *testing.T) {
+	mock := newMockLedgerEntryService()
+	services := newLedgerEntryTestServices(mock)
+	method := &handlers.LedgerEntryMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	const owner = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	_, ownerBytes, err := addresscodec.DecodeClassicAddressToAccountID(owner)
+	require.NoError(t, err)
+	var ownerID [20]byte
+	copy(ownerID[:], ownerBytes)
+	const seq = uint32(3)
+	expectedKey := keylet.LoanBroker(ownerID, seq).Key
+	expectedKeyHex := hex.EncodeToString(expectedKey[:])
+
+	t.Run("object form resolves to keylet.LoanBroker and returns the node", func(t *testing.T) {
+		mock.ledgerEntryResult = &types.LedgerEntryResult{
+			Index:     expectedKeyHex,
+			Node:      []byte(`{"LedgerEntryType": "LoanBroker", "Sequence": 3}`),
+			Validated: true,
+		}
+		params := map[string]any{
+			"loan_broker":  map[string]any{"owner": owner, "seq": seq},
+			"ledger_index": "validated",
+		}
+		result, rpcErr := handleLedgerEntry(t, method, ctx, params)
+		require.Nil(t, rpcErr)
+		require.NotNil(t, result)
+		assert.Equal(t, expectedKey, mock.lastRequestedKey)
+	})
+
+	t.Run("hex form resolves to the same key as the object form", func(t *testing.T) {
+		mock.ledgerEntryResult = &types.LedgerEntryResult{
+			Index:     expectedKeyHex,
+			Node:      []byte(`{"LedgerEntryType": "LoanBroker"}`),
+			Validated: true,
+		}
+		params := map[string]any{"loan_broker": expectedKeyHex, "ledger_index": "validated"}
+		_, rpcErr := handleLedgerEntry(t, method, ctx, params)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, expectedKey, mock.lastRequestedKey,
+			"hex and object forms must resolve to the same key")
+	})
+
+	malformedCases := []struct {
+		name    string
+		broker  map[string]any
+		token   string
+		message string
+	}{
+		{
+			name:    "owner not an account yields malformedOwner",
+			broker:  map[string]any{"owner": "not-an-account", "seq": seq},
+			token:   "malformedOwner",
+			message: "Invalid field 'owner', not AccountID.",
+		},
+		{
+			name:    "owner missing yields malformedRequest",
+			broker:  map[string]any{"seq": seq},
+			token:   "malformedRequest",
+			message: "Missing field 'owner'.",
+		},
+		{
+			name:    "seq non-numeric yields malformedSeq",
+			broker:  map[string]any{"owner": owner, "seq": "abc"},
+			token:   "malformedSeq",
+			message: "Invalid field 'seq', not number.",
+		},
+		{
+			name:    "seq missing yields malformedRequest",
+			broker:  map[string]any{"owner": owner},
+			token:   "malformedRequest",
+			message: "Missing field 'seq'.",
+		},
+	}
+	for _, tc := range malformedCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock.ledgerEntryResult = nil
+			params := map[string]any{"loan_broker": tc.broker, "ledger_index": "validated"}
+			result, rpcErr := handleLedgerEntry(t, method, ctx, params)
+			assert.Nil(t, result)
+			require.NotNil(t, rpcErr)
+			assert.Equal(t, tc.token, rpcErr.ErrorString)
+			assert.Equal(t, tc.message, rpcErr.Message)
+			assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		})
+	}
+}
+
+// handleLedgerEntry marshals params and dispatches them through the handler.
+func handleLedgerEntry(t *testing.T, method *handlers.LedgerEntryMethod, ctx *types.RpcContext, params map[string]any) (any, *types.RpcError) {
+	t.Helper()
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+	return method.Handle(ctx, paramsJSON)
 }
 
 // Offer Entry Tests
@@ -3113,12 +3341,11 @@ func TestLedgerEntryAccountSelector(t *testing.T) {
 	})
 }
 
-// TestLedgerEntryLoanSelectors covers the rippled 3.0.0 `loan`/`loan_broker`
-// selectors. rippled's parseLoan/parseLoanBroker fall back to a direct
-// hex-index lookup when the param is not an object; go-xrpl has no lending
-// subsystem, so it supports only that hex form (like bridge/xchain). Each field
-// must be recognized and resolve to a lookup rather than being rejected as an
-// unknown option.
+// TestLedgerEntryLoanSelectors covers the hex-index (non-object) form of the
+// `loan`/`loan_broker` selectors. A string param is treated as a direct object
+// index; an unparseable string yields rippled's parseObjectID error (the
+// "malformedRequest" token with an expected-hex-string message). The object
+// forms are covered by TestLedgerEntryLoan / TestLedgerEntryLoanBroker.
 func TestLedgerEntryLoanSelectors(t *testing.T) {
 	mock := newMockLedgerEntryService()
 	services := newLedgerEntryTestServices(mock)
@@ -3150,7 +3377,8 @@ func TestLedgerEntryLoanSelectors(t *testing.T) {
 
 			_, rpcErr := method.Handle(ctx, paramsJSON)
 			require.NotNil(t, rpcErr)
-			assert.Contains(t, rpcErr.Message, "Invalid "+field)
+			assert.Equal(t, "malformedRequest", rpcErr.ErrorString)
+			assert.Equal(t, "Invalid field '"+field+"', not hex string.", rpcErr.Message)
 		})
 	}
 }

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -457,6 +457,23 @@ func RpcErrorExpectedFieldHighFee(field, expectedType string) *RpcError {
 		"Invalid field '"+field+"', not "+expectedType+".")
 }
 
+// RpcErrorMalformedField reports a present-but-wrong-type selector subfield.
+// It carries a field-specific token (e.g. "malformedBroker", "malformedSeq"),
+// the rpcINVALID_PARAMS code, and rippled's expected_field_message, matching the
+// invalidFieldError path in rippled's ledger_entry field parsers.
+func RpcErrorMalformedField(token, field, expectedType string) *RpcError {
+	return NewRpcError(RpcINVALID_PARAMS, token, token,
+		"Invalid field '"+field+"', not "+expectedType+".")
+}
+
+// RpcErrorMalformedRequestMissingField reports an absent required selector
+// subfield. rippled's missingFieldError leaves the token at its "malformedRequest"
+// default and sets the message to missing_field_message.
+func RpcErrorMalformedRequestMissingField(field string) *RpcError {
+	return NewRpcError(RpcINVALID_PARAMS, "malformedRequest", "malformedRequest",
+		"Missing field '"+field+"'.")
+}
+
 // RpcErrorSigningMalformed returns an error when a transaction's signing is malformed
 // (matches rippled rpcSIGNING_MALFORMED, code 63, token "signingMalformed").
 func RpcErrorSigningMalformed() *RpcError {


### PR DESCRIPTION
## Summary

Implements rippled 3.1.0 parity for the `ledger_entry` **loan** and **loan_broker** object-form selectors (Phase E of #1245).

PR #1261 added the hex-index forms and PR #1260 added `keylet.Loan`/`keylet.LoanBroker` + the `ltLOAN`/`ltLOAN_BROKER` SLE types. This PR wires up the remaining **object forms** per rippled's `parseLoan`/`parseLoanBroker`:

- `loan`: `{ loan_broker_id, loan_seq }` → `keylet.Loan(loanBrokerID, loanSeq)`
- `loan_broker`: `{ owner, seq }` → `keylet.LoanBroker(owner, seq)`

A non-object param is still treated as a direct hex object index (rippled's `parseObjectID` branch).

### rippled fidelity

Required-field parsing mirrors rippled's `LedgerEntryHelpers` (`requiredUInt256` / `requiredUInt32` / `requiredAccountID`):

| condition | `error` token | `error_message` |
|---|---|---|
| field absent/null | `malformedRequest` | `Missing field '<name>'.` |
| `loan_broker_id` bad | **`malformedBroker`** | `Invalid field 'loan_broker_id', not Hash256.` |
| `loan_seq` / `seq` bad | `malformedSeq` | `Invalid field '<name>', not number.` |
| `owner` bad | `malformedOwner` | `Invalid field 'owner', not AccountID.` |
| non-object non-hex | `malformedRequest` | `Invalid field '<name>', not hex string.` |

The **only** parser change between rippled 3.0.0 and 3.1.0 is `loan_broker_id`'s token flipping `malformedOwner → malformedBroker`; this PR lands the 3.1.0 value.

`Loan`/`LoanBroker` are also registered in the `ledger_entry` type table so the `unexpectedLedgerType` check applies to these selectors.

### Changes

- `internal/rpc/handlers/ledger_entry.go` — `parseLoanKeylet` / `parseLoanBrokerKeylet` + faithful `required*` field helpers; register the two types in the filter table.
- `internal/rpc/types/errors.go` — `RpcErrorMalformedField` / `RpcErrorMalformedRequestMissingField` constructors (rippled `invalidFieldError` / `missingFieldError`).
- `internal/rpc/ledger_entry_test.go` — object-form happy paths, hex/object equivalence, and per-field malformed variants (including the `malformedBroker` token); updated the pre-existing hex-only `TestLedgerEntryLoanSelectors` to the 3.1.0 error shape.

### Verification

- `just build-all` — clean
- `just test` — green (only the pre-existing Vault conformance baseline fails; **0 new** failures vs baseline, set-diff identical)
- `golangci-lint run --config .golangci.yml ./...` — 0 issues
- docsgen (rpcmethods + registries) — no drift

Part of #1245 (Phase E). Ref rippled PR #6156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)