### PR TITLE
feat(peer): rippled 3.1.3 ungated peer/wire hardening

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -330,6 +330,32 @@ func validCompleteConfig() *Config {
 	}
 }
 
+func TestOverlayConfig_VerifyEndpointsValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   *int
+		wantErr bool
+	}{
+		{"absent", nil, false},
+		{"zero", intPtr(0), false},
+		{"one", intPtr(1), false},
+		{"two_rejected", intPtr(2), true},
+		{"negative_rejected", intPtr(-1), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := OverlayConfig{VerifyEndpoints: tc.value}
+			err := o.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "verify_endpoints")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestConfigValidation_CompleteConfig(t *testing.T) {
 	assert.NoError(t, ValidateConfig(validCompleteConfig()))
 }

--- a/config/examples/xrpld.toml
+++ b/config/examples/xrpld.toml
@@ -162,6 +162,9 @@ journal_size_limit = 1582080
 max_unknown_time = 600   # seconds (300-1800)
 max_diverged_time = 300  # seconds (60-900)
 # public_ip = "203.0.113.7"
+# verify_endpoints = 1   # 0|1 (default 1); 0 accepts non-public gossip
+                         # addresses for local dev — a security risk on
+                         # a public network
 
 [transaction_queue]
 ledgers_in_queue = 20

--- a/config/peer.go
+++ b/config/peer.go
@@ -12,11 +12,16 @@ import (
 //   - ip_limit 0 means auto-configure
 //   - max_unknown_time / max_diverged_time 0 means use the built-in
 //     defaults (rippled: 600s and 300s respectively)
+//   - verify_endpoints (0|1) validates addresses received in TMEndpoints
+//     gossip; nil (absent) means the built-in default (1 = verify on),
+//     0 skips validation for local dev networks — a security risk on a
+//     public network
 type OverlayConfig struct {
 	PublicIP        string `toml:"public_ip" mapstructure:"public_ip"`
 	IPLimit         int    `toml:"ip_limit" mapstructure:"ip_limit"`
 	MaxUnknownTime  int    `toml:"max_unknown_time" mapstructure:"max_unknown_time"`
 	MaxDivergedTime int    `toml:"max_diverged_time" mapstructure:"max_diverged_time"`
+	VerifyEndpoints *int   `toml:"verify_endpoints" mapstructure:"verify_endpoints"`
 }
 
 // TransactionQueueConfig represents the [transaction_queue] section (EXPERIMENTAL).
@@ -57,6 +62,12 @@ func (o *OverlayConfig) Validate() error {
 
 	if o.MaxDivergedTime != 0 && (o.MaxDivergedTime < 60 || o.MaxDivergedTime > 900) {
 		return fmt.Errorf("max_diverged_time must be between 60 and 900 seconds, got %d", o.MaxDivergedTime)
+	}
+
+	if o.VerifyEndpoints != nil {
+		if err := validateZeroOrOne("verify_endpoints", *o.VerifyEndpoints); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -643,6 +643,12 @@ func OverlayOptionsFromConfig(appCfg *config.Config) []peermanagement.Option {
 		}
 	}
 
+	// [overlay] verify_endpoints toggles TMEndpoints gossip validation.
+	// Absent leaves the default on; an explicit 0/1 overrides it.
+	if appCfg.Overlay.VerifyEndpoints != nil {
+		opts = append(opts, peermanagement.WithVerifyEndpoints(*appCfg.Overlay.VerifyEndpoints != 0))
+	}
+
 	return opts
 }
 

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -147,6 +147,14 @@ type Config struct {
 	// check; nil suppresses both.
 	PublicIP net.IP
 
+	// VerifyEndpoints validates addresses advertised in inbound
+	// TMEndpoints gossip: when true (the default), non-public / loopback
+	// / port-0 addresses are silently dropped before reaching Discovery,
+	// mirroring rippled PeerFinder is_valid_address. Setting it false
+	// (the [overlay] verify_endpoints = 0 knob) accepts them, for local
+	// dev networks — a security risk on a public network.
+	VerifyEndpoints bool
+
 	// Clock function for testing
 	Clock func() time.Time
 }
@@ -178,6 +186,10 @@ func DefaultConfig() Config {
 
 		TxReduceRelayMinPeers: DefaultTxReduceRelayMinPeers,
 		TxRelayPercentage:     DefaultTxRelayPercentage,
+
+		// Endpoint verification is on by default; only a local dev
+		// network (verify_endpoints = 0) turns it off.
+		VerifyEndpoints: true,
 
 		Clock: time.Now,
 	}
@@ -339,6 +351,16 @@ func WithServerDomain(domain string) Option {
 func WithPublicIP(ip net.IP) Option {
 	return func(c *Config) {
 		c.PublicIP = ip
+	}
+}
+
+// WithVerifyEndpoints toggles validation of addresses advertised in
+// inbound TMEndpoints gossip (the [overlay] verify_endpoints knob).
+// Defaults to true; passing false accepts non-public/loopback/port-0
+// addresses for local dev networks.
+func WithVerifyEndpoints(enabled bool) Option {
+	return func(c *Config) {
+		c.VerifyEndpoints = enabled
 	}
 }
 

--- a/internal/peermanagement/get_objects_serve_test.go
+++ b/internal/peermanagement/get_objects_serve_test.go
@@ -2,6 +2,7 @@ package peermanagement
 
 import (
 	"bytes"
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,6 +94,38 @@ func TestServeGetObjects_FetchesAndReplies(t *testing.T) {
 
 	// A generic by-hash request is charged feeModerateBurdenPeer.
 	assert.Positive(t, peer.Load(), "serving a by-hash request must charge the peer")
+}
+
+// TestServeGetObjects_TruncatesAtReplyCap pins rippled PeerImp.cpp:2551-2562
+// (#6110): a query for more objects than Tuning::hardMaxReplyNodes is
+// truncated to the cap, closing a per-object NodeStore-fetch DoS. The
+// provider is consulted only up to the cap and the reply never exceeds it.
+func TestServeGetObjects_TruncatesAtReplyCap(t *testing.T) {
+	lookups := 0
+	o := &Overlay{
+		peers: make(map[PeerID]*Peer),
+		nodeObjectProvider: func([32]byte) ([]byte, bool) {
+			lookups++
+			return []byte{0x01}, true
+		},
+	}
+	peer := newServeTestPeer(t, PeerID(404))
+	o.peers[peer.ID()] = peer
+
+	const requested = hardMaxReplyNodes + 5
+	objs := make([]message.IndexedObject, requested)
+	for i := range objs {
+		var h [32]byte
+		binary.BigEndian.PutUint32(h[:], uint32(i+1))
+		objs[i] = message.IndexedObject{Hash: h[:]}
+	}
+	req := &message.GetObjectByHash{Query: true, Objects: objs}
+	o.serveGetObjects(peer.ID(), req)
+
+	reply := decodeGetObjectsReply(t, peer)
+	assert.Len(t, reply.Objects, hardMaxReplyNodes, "reply must be capped at hardMaxReplyNodes")
+	assert.Equal(t, hardMaxReplyNodes, lookups, "provider consulted only up to the cap")
+	assert.Positive(t, peer.Load(), "serving + truncation charge the peer")
 }
 
 // TestServeGetObjects_AlwaysRepliesEvenWhenEmpty verifies the rippled

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -328,16 +328,68 @@ func configIPIsV6(ip net.IP) bool {
 	return ip.To4() == nil
 }
 
-// isPublicIP mirrors beast::IP::is_public. v6 link-local is private
-// (fe80::/10) — Go's IsPrivate doesn't cover that, so we add it.
+// isPublicIP mirrors beast::IP::is_public (rippled 3.1.3's rewrite in
+// IPAddressV4.cpp / IPAddressV6.cpp). "Public" means globally routable:
+// beyond RFC1918 / loopback / multicast it rejects the reserved IPv4
+// special-purpose ranges (0/8, CGNAT, link-local, IETF-protocol,
+// TEST-NETs, 6to4 relay, benchmarking, 240/4) and the reserved IPv6
+// ranges (ULA, link-local, discard, documentation, Teredo, ORCHIDv2,
+// 6to4). Global IPv6 unicast is public — the pre-3.1.3 beast dropped
+// essentially all IPv6 gossip.
 func isPublicIP(ip net.IP) bool {
 	if ip == nil || ip.IsUnspecified() {
 		return false
 	}
-	if ip.IsLoopback() || ip.IsPrivate() || ip.IsMulticast() {
+	if v4 := ip.To4(); v4 != nil {
+		return isPublicIPv4(v4)
+	}
+	return isPublicIPv6(ip)
+}
+
+// isPublicIPv4 ports beast::IP::is_public(AddressV4): reject private
+// (10/8, 172.16/12, 192.168/16, loopback), multicast, and every
+// reserved special-purpose range. v4 must be a 4-byte slice.
+func isPublicIPv4(v4 net.IP) bool {
+	ip := uint32(v4[0])<<24 | uint32(v4[1])<<16 | uint32(v4[2])<<8 | uint32(v4[3])
+	switch {
+	case ip&0xff000000 == 0x0a000000, // 10.0.0.0/8
+		ip&0xfff00000 == 0xac100000, // 172.16.0.0/12
+		ip&0xffff0000 == 0xc0a80000, // 192.168.0.0/16
+		ip&0xff000000 == 0x7f000000, // 127.0.0.0/8 loopback
+		ip&0xf0000000 == 0xe0000000, // 224.0.0.0/4 multicast
+		ip&0xff000000 == 0x00000000, // 0.0.0.0/8 "this network"
+		ip&0xffc00000 == 0x64400000, // 100.64.0.0/10 CGNAT
+		ip&0xffff0000 == 0xa9fe0000, // 169.254.0.0/16 link-local
+		ip&0xffffff00 == 0xc0000000, // 192.0.0.0/24 IETF protocol
+		ip&0xffffff00 == 0xc0000200, // 192.0.2.0/24 TEST-NET-1
+		ip&0xffffff00 == 0xc0586300, // 192.88.99.0/24 6to4 relay
+		ip&0xfffe0000 == 0xc6120000, // 198.18.0.0/15 benchmarking
+		ip&0xffffff00 == 0xc6336400, // 198.51.100.0/24 TEST-NET-2
+		ip&0xffffff00 == 0xcb007100, // 203.0.113.0/24 TEST-NET-3
+		ip&0xf0000000 == 0xf0000000: // 240.0.0.0/4 reserved
 		return false
 	}
-	if ip.To4() == nil && ip.IsLinkLocalUnicast() {
+	return true
+}
+
+// isPublicIPv6 ports beast::IP::is_public(AddressV6). The caller routes
+// v4-mapped addresses to isPublicIPv4 via To4, so ip here is pure IPv6.
+func isPublicIPv6(ip net.IP) bool {
+	b := ip.To16()
+	if b == nil {
+		return false
+	}
+	switch {
+	case ip.IsLoopback(), // ::1
+		b[0]&0xfe == 0xfc,                 // fc00::/7 ULA (private)
+		b[0] == 0xff,                      // ff00::/8 multicast
+		b[0] == 0xfe && b[1]&0xc0 == 0x80, // fe80::/10 link-local
+		b[0] == 0x01 && b[1] == 0 && b[2] == 0 && b[3] == 0 &&
+			b[4] == 0 && b[5] == 0 && b[6] == 0 && b[7] == 0, // 100::/64 discard
+		b[0] == 0x20 && b[1] == 0x01 && b[2] == 0x0d && b[3] == 0xb8,      // 2001:db8::/32 documentation
+		b[0] == 0x20 && b[1] == 0x01 && b[2] == 0x00 && b[3] == 0x00,      // 2001::/32 Teredo
+		b[0] == 0x20 && b[1] == 0x01 && b[2] == 0x00 && b[3]&0xf0 == 0x20, // 2001:20::/28 ORCHIDv2
+		b[0] == 0x20 && b[1] == 0x02:                                      // 2002::/16 6to4
 		return false
 	}
 	return true

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -1261,7 +1261,7 @@ func TestHandshake_RemoteIPSelfReported_MatchesTcpConn(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)
 
-	publicIP := net.ParseIP("198.51.100.1")
+	publicIP := net.ParseIP("1.2.3.4")
 	cfg := DefaultHandshakeConfig()
 	cfg.PublicIP = publicIP
 
@@ -1269,7 +1269,7 @@ func TestHandshake_RemoteIPSelfReported_MatchesTcpConn(t *testing.T) {
 
 	t.Run("matching_public_ip_passes", func(t *testing.T) {
 		headers := buildAllHeadersRequest(t, id, cfg, socketIP)
-		require.Equal(t, "198.51.100.1", headers.Get(HeaderRemoteIP))
+		require.Equal(t, "1.2.3.4", headers.Get(HeaderRemoteIP))
 
 		_, err := ParseHandshakeExtras(headers, publicIP, socketIP)
 		require.NoError(t, err)
@@ -1277,9 +1277,9 @@ func TestHandshake_RemoteIPSelfReported_MatchesTcpConn(t *testing.T) {
 
 	t.Run("mismatched_public_ip_rejected", func(t *testing.T) {
 		headers := buildAllHeadersRequest(t, id, cfg, socketIP)
-		// Peer claims our IP is 203.0.113.5 — but our config says
+		// Peer claims our IP is 5.6.7.8 — but our config says
 		// otherwise and they connected from a public address. Reject.
-		headers.Set(HeaderRemoteIP, "203.0.113.5")
+		headers.Set(HeaderRemoteIP, "5.6.7.8")
 
 		_, err := ParseHandshakeExtras(headers, publicIP, socketIP)
 		require.Error(t, err)
@@ -1291,7 +1291,7 @@ func TestHandshake_RemoteIPSelfReported_MatchesTcpConn(t *testing.T) {
 		// Same mismatched header, but the peer connected from
 		// loopback — rippled and we both skip the comparison.
 		headers := buildAllHeadersRequest(t, id, cfg, socketIP)
-		headers.Set(HeaderRemoteIP, "203.0.113.5")
+		headers.Set(HeaderRemoteIP, "5.6.7.8")
 
 		_, err := ParseHandshakeExtras(headers, publicIP, asSocketIP(t, net.ParseIP("127.0.0.1")))
 		require.NoError(t, err)
@@ -1315,8 +1315,8 @@ func TestHandshake_AllHeaders_RoundTrip(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)
 
-	pA := net.ParseIP("198.51.100.42") // sender's public IP
-	pB := net.ParseIP("203.0.113.7")   // receiver's public IP
+	pA := net.ParseIP("1.2.3.42") // sender's public IP
+	pB := net.ParseIP("5.6.7.7")  // receiver's public IP
 
 	var closed, parent [32]byte
 	for i := range closed {
@@ -1639,11 +1639,11 @@ func TestInstanceCookie_GeneratorRange(t *testing.T) {
 	}
 }
 
-// isPublicIP must mirror beast::IP::is_public: IPv4 link-local stays
-// public (rippled IPAddressV4.cpp only flags RFC1918+loopback); IPv6
-// link-local is private to match rippled IPAddressV6.cpp's `(byte0 &
-// 0xfd)` catching fe80::/10. Loopback / RFC1918 / multicast are private
-// in both families.
+// isPublicIP must mirror beast::IP::is_public after rippled 3.1.3's
+// rewrite: IPv4 link-local (169.254/16) and the other reserved
+// special-purpose ranges are no longer public, and global IPv6 unicast
+// (e.g. 2606:4700::1) IS public where the pre-3.1.3 beast dropped it.
+// Loopback / RFC1918 / multicast stay private in both families.
 func TestIsPublicIP_BeastParity(t *testing.T) {
 	cases := []struct {
 		name string
@@ -1651,18 +1651,41 @@ func TestIsPublicIP_BeastParity(t *testing.T) {
 		want bool
 	}{
 		{"public_v4", "8.8.8.8", true},
-		{"link_local_v4", "169.254.1.1", true},
+		{"public_v4_172_15", "172.15.0.1", true}, // just below the 172.16/12 block
 		{"loopback_v4", "127.0.0.1", false},
 		{"rfc1918_10", "10.0.0.1", false},
 		{"rfc1918_172_16", "172.16.5.4", false},
 		{"rfc1918_192_168", "192.168.1.1", false},
 		{"multicast_v4", "224.0.0.1", false},
 		{"unspecified_v4", "0.0.0.0", false},
-		{"public_v6", "2001:db8::1", true},
+		// Newly-reserved IPv4 ranges (3.1.3 beast rewrite).
+		{"this_network_v4", "0.1.2.3", false},   // 0.0.0.0/8
+		{"cgnat_v4", "100.64.0.1", false},       // 100.64.0.0/10
+		{"link_local_v4", "169.254.1.1", false}, // 169.254.0.0/16
+		{"ietf_protocol_v4", "192.0.0.8", false},
+		{"test_net_1_v4", "192.0.2.5", false},
+		{"6to4_relay_v4", "192.88.99.1", false},
+		{"benchmarking_v4", "198.18.0.1", false}, // 198.18.0.0/15
+		{"benchmarking_v4_19", "198.19.0.1", false},
+		{"test_net_2_v4", "198.51.100.7", false},
+		{"test_net_3_v4", "203.0.113.9", false},
+		{"reserved_240_v4", "240.0.0.1", false},
+		// IPv6.
+		{"documentation_v6", "2001:db8::1", false}, // 2001:db8::/32
+		{"global_v6", "2606:4700::1", true},        // global unicast, now public
+		{"global_v6_2400", "2400:cb00::1", true},
 		{"loopback_v6", "::1", false},
 		{"unspecified_v6", "::", false},
 		{"ula_v6", "fc00::1", false},
+		{"ula_v6_fd", "fd12:3456::1", false},
 		{"link_local_v6", "fe80::1", false},
+		{"multicast_v6", "ff02::1", false},
+		{"teredo_v6", "2001::1", false},      // 2001::/32
+		{"orchidv2_v6", "2001:20::1", false}, // 2001:20::/28
+		{"6to4_v6", "2002::1", false},        // 2002::/16
+		{"discard_v6", "0100::1", false},     // 100::/64
+		{"v4_mapped_public", "::ffff:8.8.8.8", true},
+		{"v4_mapped_private", "::ffff:10.0.0.1", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1724,13 +1747,13 @@ func TestWriteRawHandshakeRequest_EmitsAllNewHeaders(t *testing.T) {
 	cfg := DefaultHandshakeConfig()
 	cfg.InstanceCookie = 0xCAFEBABE12345678
 	cfg.ServerDomain = "example.com"
-	cfg.PublicIP = net.ParseIP("198.51.100.10")
+	cfg.PublicIP = net.ParseIP("1.2.3.10")
 	cfg.LedgerHintProvider = func() (LedgerHints, bool) {
 		return LedgerHints{Closed: closed, Parent: parent}, true
 	}
 	req, err := BuildHandshakeRequest(id, make([]byte, 32), cfg)
 	require.NoError(t, err)
-	addAddressHeaders(req.Header, cfg, net.ParseIP("203.0.113.5"))
+	addAddressHeaders(req.Header, cfg, net.ParseIP("5.6.7.8"))
 
 	var buf bytes.Buffer
 	require.NoError(t, WriteRawHandshakeRequest(&buf, req))
@@ -1741,8 +1764,8 @@ func TestWriteRawHandshakeRequest_EmitsAllNewHeaders(t *testing.T) {
 		HeaderServerDomain + ": example.com",
 		HeaderClosedLedger + ": " + strings.ToUpper(hex.EncodeToString(closed[:])),
 		HeaderPreviousLedger + ": " + strings.ToUpper(hex.EncodeToString(parent[:])),
-		HeaderRemoteIP + ": 203.0.113.5",
-		HeaderLocalIP + ": 198.51.100.10",
+		HeaderRemoteIP + ": 5.6.7.8",
+		HeaderLocalIP + ": 1.2.3.10",
 	} {
 		assert.Contains(t, wire, h, "missing %s on the wire", h)
 	}

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -390,6 +390,24 @@ const endpointsIngestMaxEntries = 1024
 // while staying under the 1024 wholesale-reject bound.
 const endpointsIngestSampleMax = 64
 
+// isValidGossipAddress mirrors rippled PeerFinder is_valid_address
+// (Logic.h): an address advertised in TMEndpoints gossip is usable only
+// if it is specified, not loopback, publicly routable, and carries a
+// non-zero port. The is_loopback check is redundant with isPublicIP but
+// kept for structural fidelity with rippled.
+func isValidGossipAddress(host net.IP, port uint16) bool {
+	if host == nil || host.IsUnspecified() {
+		return false
+	}
+	if host.IsLoopback() {
+		return false
+	}
+	if !isPublicIP(host) {
+		return false
+	}
+	return port != 0
+}
+
 // handleEndpointsMessage processes mtENDPOINTS from a peer and feeds the
 // advertised addresses into Discovery, the gossip half of overlay peer
 // discovery. Mirrors rippled PeerImp::onMessage(TMEndpoints) at
@@ -462,13 +480,25 @@ func (o *Overlay) handleEndpointsMessage(evt Event) {
 		}
 
 		address := tm.Endpoint
+		host := parsed.Host
 		if tm.Hops == 0 {
 			// hops==0 describes the sender; trust the socket IP over
 			// the self-reported host (PeerImp.cpp:1234-1235).
 			if remoteIP == "" {
 				continue
 			}
+			host = remoteIP
 			address = Endpoint{Host: remoteIP, Port: parsed.Port}.String()
+		}
+
+		// Discard addresses that aren't publicly routable when endpoint
+		// verification is on (rippled PeerFinder is_valid_address, gated
+		// on config verifyEndpoints). The check runs on the post-rewrite
+		// host so a hops==0 peer behind a private socket is dropped too.
+		// A silent drop, not a charge: the address parsed fine, it is
+		// just not gossip-worthy.
+		if o.cfg.VerifyEndpoints && !isValidGossipAddress(net.ParseIP(host), parsed.Port) {
+			continue
 		}
 
 		accepted = append(accepted, ingestEndpoint{address: address, hops: tm.Hops})
@@ -563,6 +593,13 @@ func (o *Overlay) serveDoTransactions(peerID PeerID, req *message.GetObjectByHas
 	encodeAndSend(peer, message.TypeTransactions, reply, "TMTransactions reply")
 }
 
+// hardMaxReplyNodes caps how many objects a single by-hash reply may
+// carry. Mirrors rippled Tuning::hardMaxReplyNodes: each served object
+// costs a NodeStore fetch, so an unbounded query is a per-object fetch
+// DoS. When the cap is hit the reply is truncated and the requester
+// charged an extra feeModerateBurdenPeer (PeerImp.cpp:2551-2562, #6110).
+const hardMaxReplyNodes = 12288
+
 // serveGetObjects answers an inbound mtGET_OBJECTS query for generic
 // node-store objects by hash. Mirrors rippled
 // PeerImp::onMessage(TMGetObjectByHash) generic branch
@@ -637,6 +674,13 @@ func (o *Overlay) serveGetObjects(peerID PeerID, req *message.GetObjectByHash) {
 			out.Index = append([]byte(nil), obj.NodeID...)
 		}
 		reply.Objects = append(reply.Objects, out)
+
+		// Truncate once the reply reaches the object cap, charging the
+		// requester again for the burden (PeerImp.cpp:2551-2562).
+		if len(reply.Objects) >= hardMaxReplyNodes {
+			peer.Charge(resource.FeeModerateBurdenPeer, "get object by hash reply limit reached")
+			break
+		}
 	}
 
 	encodeAndSend(peer, message.TypeGetObjects, reply, "TMGetObjectByHash reply")

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -653,6 +653,111 @@ func TestHandleEndpoints_Hops0RewrittenToSocketIP(t *testing.T) {
 	assert.Equal(t, uint32(0), o.discovery.peers["203.0.113.7:51235"].Hops)
 }
 
+// TestHandleEndpoints_VerifyOn_DropsNonPublic pins the rippled PeerFinder
+// is_valid_address filter (Logic.h) once verify_endpoints is on: only
+// publicly-routable, non-loopback, non-zero-port addresses reach
+// Discovery. The drop is silent (parsed fine, just not gossip-worthy).
+func TestHandleEndpoints_VerifyOn_DropsNonPublic(t *testing.T) {
+	o, peer := newEndpointsTestOverlay(t, PeerID(20))
+	o.cfg.VerifyEndpoints = true
+
+	payload := encodeEndpoints(t, 2, []message.Endpointv2{
+		{Endpoint: "10.0.0.1:51235", Hops: 1},    // RFC1918 → drop
+		{Endpoint: "127.0.0.1:51235", Hops: 1},   // loopback → drop
+		{Endpoint: "169.254.1.1:51235", Hops: 1}, // link-local → drop (3.1.3)
+		{Endpoint: "203.0.113.9:51235", Hops: 1}, // TEST-NET-3 → drop (3.1.3)
+		{Endpoint: "1.2.3.4:0", Hops: 1},         // port 0 → drop
+		{Endpoint: "8.8.8.8:51235", Hops: 1},     // public → keep
+	})
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeEndpoints),
+		Payload:     payload,
+	})
+
+	o.discovery.mu.RLock()
+	defer o.discovery.mu.RUnlock()
+	require.Len(t, o.discovery.peers, 1, "only the public address survives verification")
+	assert.Contains(t, o.discovery.peers, "8.8.8.8:51235")
+	assert.Zero(t, peer.BadDataCount(), "a non-public but well-formed address is a silent drop, not bad data")
+}
+
+// TestHandleEndpoints_VerifyOff_AcceptsNonPublic documents the
+// verify_endpoints = 0 escape hatch: on a local dev network, non-public
+// addresses are ingested unchanged.
+func TestHandleEndpoints_VerifyOff_AcceptsNonPublic(t *testing.T) {
+	o, peer := newEndpointsTestOverlay(t, PeerID(21))
+	o.cfg.VerifyEndpoints = false
+
+	payload := encodeEndpoints(t, 2, []message.Endpointv2{
+		{Endpoint: "10.0.0.1:51235", Hops: 1},
+		{Endpoint: "192.168.5.5:51235", Hops: 2},
+	})
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeEndpoints),
+		Payload:     payload,
+	})
+
+	o.discovery.mu.RLock()
+	defer o.discovery.mu.RUnlock()
+	require.Len(t, o.discovery.peers, 2, "verification off accepts private addresses")
+	assert.Contains(t, o.discovery.peers, "10.0.0.1:51235")
+	assert.Contains(t, o.discovery.peers, "192.168.5.5:51235")
+}
+
+// TestHandleEndpoints_VerifyOn_Hops0Validated verifies that the
+// is_valid_address check runs on the post-rewrite socket IP for a hops==0
+// entry: a peer behind a public socket is kept, one behind a private
+// socket is dropped (rippled validates ep.address after the rewrite).
+func TestHandleEndpoints_VerifyOn_Hops0Validated(t *testing.T) {
+	t.Run("public_socket_kept", func(t *testing.T) {
+		o, peer := newEndpointsTestOverlay(t, PeerID(22))
+		o.cfg.VerifyEndpoints = true
+		peer.conn = fakeAddrConn{remote: &net.TCPAddr{IP: net.ParseIP("5.6.7.8"), Port: 40000}}
+
+		payload := encodeEndpoints(t, 2, []message.Endpointv2{
+			{Endpoint: "192.168.1.1:51235", Hops: 0},
+		})
+		o.onMessageReceived(Event{
+			PeerID:      peer.ID(),
+			MessageType: uint16(message.TypeEndpoints),
+			Payload:     payload,
+		})
+
+		o.discovery.mu.RLock()
+		defer o.discovery.mu.RUnlock()
+		require.Len(t, o.discovery.peers, 1)
+		assert.Contains(t, o.discovery.peers, "5.6.7.8:51235")
+	})
+
+	t.Run("private_socket_dropped", func(t *testing.T) {
+		o, peer := newEndpointsTestOverlay(t, PeerID(23))
+		o.cfg.VerifyEndpoints = true
+		peer.conn = fakeAddrConn{remote: &net.TCPAddr{IP: net.ParseIP("10.0.0.5"), Port: 40000}}
+
+		payload := encodeEndpoints(t, 2, []message.Endpointv2{
+			{Endpoint: "1.2.3.4:51235", Hops: 0},
+		})
+		o.onMessageReceived(Event{
+			PeerID:      peer.ID(),
+			MessageType: uint16(message.TypeEndpoints),
+			Payload:     payload,
+		})
+
+		o.discovery.mu.RLock()
+		defer o.discovery.mu.RUnlock()
+		assert.Empty(t, o.discovery.peers, "hops==0 behind a private socket is dropped")
+	})
+}
+
+// TestDefaultConfig_VerifyEndpointsOn pins the rippled default: endpoint
+// verification is on unless explicitly disabled.
+func TestDefaultConfig_VerifyEndpointsOn(t *testing.T) {
+	assert.True(t, DefaultConfig().VerifyEndpoints,
+		"endpoint verification must default on")
+}
+
 // TestHandleEndpoints_DropsNonConvergedPeer pins PeerImp.cpp:1201: a peer
 // that has not reached tracking-converged must not be allowed to seed
 // Discovery, and is not charged for it.

--- a/shamap/leaf_test.go
+++ b/shamap/leaf_test.go
@@ -1,0 +1,76 @@
+package shamap
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/protocol"
+)
+
+// TestNewLeafNode_RejectsShortPayload pins rippled's minSHAMapItemBytes
+// (SHAMapTreeNode.h): a leaf whose item payload is under 12 bytes is
+// rejected across all three leaf kinds. The bound is on the payload
+// itself — for keyed kinds that is the data after the 32-byte key/tag is
+// stripped (matching rippled's post-`s.chop(tag)` check).
+func TestNewLeafNode_RejectsShortPayload(t *testing.T) {
+	var key [32]byte
+	for i := range key {
+		key[i] = byte(i + 1) // non-zero: account-state rejects a zero key
+	}
+
+	ctors := []struct {
+		name string
+		fn   func(*Item) (*leafNode, error)
+	}{
+		{"account_state", newAccountStateLeafNode},
+		{"transaction", newTransactionLeafNode},
+		{"transaction_with_meta", newTransactionWithMetaLeafNode},
+	}
+
+	for _, c := range ctors {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := c.fn(NewItem(key, make([]byte, 11))); !errors.Is(err, ErrItemTooSmall) {
+				t.Fatalf("11-byte payload: want ErrItemTooSmall, got %v", err)
+			}
+			if _, err := c.fn(NewItem(key, make([]byte, 12))); err != nil {
+				t.Fatalf("12-byte payload: unexpected error %v", err)
+			}
+		})
+	}
+}
+
+// TestLeafFromWire_RejectsShortPayload exercises the wire-deserialization
+// path actually hit by peer-received SHAMap nodes: the 12-byte minimum is
+// measured after the trailing key/tag is stripped, so a node with 11 data
+// bytes plus a full key is still rejected as too short.
+func TestLeafFromWire_RejectsShortPayload(t *testing.T) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+
+	// account-state wire = stateData | key(32) | wireType(1)
+	buildAS := func(dataLen int) []byte {
+		w := make([]byte, 0, dataLen+33)
+		w = append(w, make([]byte, dataLen)...)
+		w = append(w, key...)
+		return append(w, protocol.WireTypeAccountState)
+	}
+	if _, err := newAccountStateLeafFromWire(buildAS(11)); !errors.Is(err, ErrItemTooSmall) {
+		t.Fatalf("AS 11-byte payload: want ErrItemTooSmall, got %v", err)
+	}
+	if _, err := newAccountStateLeafFromWire(buildAS(12)); err != nil {
+		t.Fatalf("AS 12-byte payload: unexpected error %v", err)
+	}
+
+	// transaction (no meta) wire = txData | wireType(1)
+	buildTxn := func(dataLen int) []byte {
+		return append(make([]byte, dataLen), protocol.WireTypeTransaction)
+	}
+	if _, err := NewTransactionLeafFromWire(buildTxn(11)); !errors.Is(err, ErrItemTooSmall) {
+		t.Fatalf("TXN 11-byte payload: want ErrItemTooSmall, got %v", err)
+	}
+	if _, err := NewTransactionLeafFromWire(buildTxn(12)); err != nil {
+		t.Fatalf("TXN 12-byte payload: unexpected error %v", err)
+	}
+}


### PR DESCRIPTION
Part of #1248 (rippled **3.1.3** parity). Ports the **ungated peer/wire hardening** subset; targets the `v3.0.0` integration branch.

## Implemented

### 1. TMGetObjectByHash reply cap (rippled [#6110](https://github.com/XRPLF/rippled/pull/6110) / commit 986af8e27c)
`serveGetObjects` (`internal/peermanagement/inbound_handlers.go`) now truncates a by-hash reply at `hardMaxReplyNodes = 12288` objects, charging an extra `feeModerateBurdenPeer` on truncation — closing a per-object NodeStore-fetch DoS. Previously the reply was bounded only by the 64 MB protocol ceiling.

### 3. beast::IP is_public/is_private rewrite (commit f511eeb27b)
`isPublicIP` (`internal/peermanagement/handshake.go`) is rewritten to rippled 3.1.3's beast semantics:
- **IPv4**: additionally rejects `0/8`, `100.64/10` (CGNAT), `169.254/16`, `192.0.0/24`, `192.0.2/24`, `192.88.99/24`, `198.18/15`, `198.51.100/24`, `203.0.113/24`, `240/4`.
- **IPv6**: rejects ULA (`fc00::/7`), link-local, `100::/64` discard, `2001:db8::/32`, `2001::/32` Teredo, `2001:20::/28` ORCHIDv2, `2002::/16` 6to4; **accepts global IPv6 unicast** (the pre-3.1.3 beast dropped essentially all IPv6 gossip).

Because rippled's `is_public` is global (used by both `Handshake.cpp` Remote-IP/Local-IP and PeerFinder gossip), the rewrite lands in the one shared `isPublicIP`. Handshake tests that used TEST-NET/documentation IPs as "public" peer addresses were updated to genuinely-public addresses.

### 4. verify_endpoints config + gossip validation (commit f511eeb27b)
- New `[overlay] verify_endpoints` knob (`0|1`, default `1`) in `config/peer.go`, wired via `OverlayOptionsFromConfig`, plus `peermanagement.Config.VerifyEndpoints` (default true) and `WithVerifyEndpoints`.
- `handleEndpointsMessage` now applies an `is_valid_address` analog (`isValidGossipAddress`: specified, non-loopback, public, non-zero port) after the hops==0 socket-IP rewrite, gated on `verify_endpoints`. Non-public addresses are silently dropped (no charge), matching rippled PeerFinder `Logic.h`. `verify_endpoints=0` accepts them for local dev networks.

## Verified already-correct / not-applicable (no behaviour change)

- **2. SHAMap <12-byte leaf-payload rejection** (commit bc168453dd): `shamap/leaf.go`'s `newLeafNode` already rejects `<12`-byte payloads (measured after the key/tag is stripped) across all three leaf kinds, matching rippled's `minSHAMapItemBytes`. Added deterministic boundary tests (`shamap/leaf_test.go`).
- **5. Ledger-replay response validation** (commit 5aa3d5e231): the consumed surface (`TMReplayDeltaResponse`) already rejects a non-32-byte ledgerhash via `ToHash32`; `TMProofPathResponse` is serve-only in goXRPL, so there is no garbage-hash client surface. **n/a** for changes.
- **6. Peer crawler integer port** (rippled [#6318](https://github.com/XRPLF/rippled/pull/6318)): goXRPL has no `/crawl` endpoint / `getOverlayInfo` analog; the `peers` RPC emits a single address string with no separate port field. **n/a**.

## Tests
- TMGetObjectByHash cap enforcement (`TestServeGetObjects_TruncatesAtReplyCap`).
- IP classification table incl. IPv6 + newly-reserved IPv4 ranges + v4-mapped (`TestIsPublicIP_BeastParity`).
- verify_endpoints on/off, port-0, and hops==0 post-rewrite validation (`TestHandleEndpoints_VerifyOn_*`, `TestHandleEndpoints_VerifyOff_AcceptsNonPublic`, `TestDefaultConfig_VerifyEndpointsOn`).
- SHAMap short-leaf boundary vectors for all three kinds (`TestNewLeafNode_RejectsShortPayload`, `TestLeafFromWire_RejectsShortPayload`).
- config `verify_endpoints` 0/1 validation (`TestOverlayConfig_VerifyEndpointsValidation`).

## Verification
- `just build-all` clean; strict `golangci-lint run --config .golangci.yml` on affected packages: 0 issues.
- Full `just test`: only pre-existing conformance-baseline failures remain (Vault/lending stubs); 141 packages pass.
- Conformance failure set **byte-identical to the v3.0.0 baseline (179 fails) — 0 new failures**.
- docsgen: no drift (config knob is not in the RPC/tx/amendment registries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)