### PR TITLE
feat(rpc): rippled 3.1.3 ungated RPC + engine hardening set

### DIFF
--- a/codec/binarycodec/codec.go
+++ b/codec/binarycodec/codec.go
@@ -33,6 +33,17 @@ var (
 	ErrUnknownField = errors.New("unknown field")
 )
 
+// AsArrayTooLargeError reports whether err is a JSON array-size-cap violation
+// raised during JSON->binary encoding and, if so, returns rippled's error
+// message. RPC entry points map it to invalidParams.
+func AsArrayTooLargeError(err error) (string, bool) {
+	var e *types.JSONArrayTooLargeError
+	if errors.As(err, &e) {
+		return e.Error(), true
+	}
+	return "", false
+}
+
 const (
 	txMultiSigPrefix          = "534D5400"
 	paymentChannelClaimPrefix = "434C4D00"

--- a/codec/binarycodec/codec_arraycap_test.go
+++ b/codec/binarycodec/codec_arraycap_test.go
@@ -1,0 +1,80 @@
+package binarycodec
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEncode_JSONArraySizeCap verifies rippled's per-array-field cap of 512
+// elements (maxSTParsedJSONArraySize) is enforced when encoding JSON to binary,
+// across the three JSON-array field kinds. Reference: rippled commit 377b155ddc.
+func TestEncode_JSONArraySizeCap(t *testing.T) {
+	const issuer = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+	hashes := func(n int) []any {
+		h := make([]any, n)
+		for i := range h {
+			h[i] = strings.Repeat("A", 64)
+		}
+		return h
+	}
+
+	t.Run("Vector256 over cap rejected with exact message", func(t *testing.T) {
+		_, err := Encode(map[string]any{"Amendments": hashes(513)})
+		msg, ok := AsArrayTooLargeError(err)
+		if !ok {
+			t.Fatalf("expected JSONArrayTooLargeError, got %v", err)
+		}
+		want := "Field 'Amendments' exceeds allowed JSON array size of 512 elements per field."
+		if msg != want {
+			t.Fatalf("message mismatch:\n got %q\nwant %q", msg, want)
+		}
+	})
+
+	t.Run("Vector256 at cap accepted", func(t *testing.T) {
+		if _, err := Encode(map[string]any{"Amendments": hashes(512)}); err != nil {
+			t.Fatalf("512-element Amendments array must encode: %v", err)
+		}
+	})
+
+	t.Run("STArray over cap rejected", func(t *testing.T) {
+		memos := make([]any, 513)
+		for i := range memos {
+			memos[i] = map[string]any{"Memo": map[string]any{"MemoData": "AB"}}
+		}
+		_, err := Encode(map[string]any{"Memos": memos})
+		msg, ok := AsArrayTooLargeError(err)
+		if !ok {
+			t.Fatalf("expected JSONArrayTooLargeError, got %v", err)
+		}
+		if !strings.Contains(msg, "Field 'Memos'") {
+			t.Fatalf("expected Memos in message, got %q", msg)
+		}
+	})
+
+	t.Run("PathSet outer over cap rejected", func(t *testing.T) {
+		paths := make([]any, 513)
+		for i := range paths {
+			paths[i] = []any{map[string]any{"currency": "USD", "issuer": issuer}}
+		}
+		_, err := Encode(map[string]any{"Paths": paths})
+		if _, ok := AsArrayTooLargeError(err); !ok {
+			t.Fatalf("expected JSONArrayTooLargeError for outer Paths, got %v", err)
+		}
+	})
+
+	t.Run("PathSet inner path over cap rejected with index", func(t *testing.T) {
+		inner := make([]any, 513)
+		for i := range inner {
+			inner[i] = map[string]any{"account": issuer}
+		}
+		_, err := Encode(map[string]any{"Paths": []any{inner}})
+		msg, ok := AsArrayTooLargeError(err)
+		if !ok {
+			t.Fatalf("expected JSONArrayTooLargeError for inner path, got %v", err)
+		}
+		if !strings.Contains(msg, "Paths[0]") {
+			t.Fatalf("expected inner path index in message, got %q", msg)
+		}
+	})
+}

--- a/codec/binarycodec/types/errors.go
+++ b/codec/binarycodec/types/errors.go
@@ -1,7 +1,28 @@
 //revive:disable:var-naming
 package types
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
+
+// MaxJSONArrayElements caps how many elements a single JSON array field may hold
+// when encoding JSON to binary, matching rippled's STParsedJSON
+// maxSTParsedJSONArraySize (STParsedJSON.h). Fields exceeding it are rejected.
+const MaxJSONArrayElements = 512
+
+// JSONArrayTooLargeError is returned when a JSON array field exceeds
+// MaxJSONArrayElements during JSON->binary encoding. Field names the offending
+// field so RPC entry points can surface rippled's exact invalidParams message.
+type JSONArrayTooLargeError struct {
+	Field string
+}
+
+func (e *JSONArrayTooLargeError) Error() string {
+	return fmt.Sprintf(
+		"Field '%s' exceeds allowed JSON array size of %d elements per field.",
+		e.Field, MaxJSONArrayElements)
+}
 
 var (
 	errNotValidJSON         = errors.New("not a valid json")

--- a/codec/binarycodec/types/pathset.go
+++ b/codec/binarycodec/types/pathset.go
@@ -55,6 +55,14 @@ func (p PathSet) FromJSON(json any) ([]byte, error) {
 		return nil, ErrInvalidPathSet
 	}
 
+	// rippled caps each inner path (STI_PATHSET) at maxSTParsedJSONArraySize as
+	// well as the outer array; the outer array is capped by checkJSONArraySize.
+	for i, path := range outer {
+		if inner, ok := path.([]any); ok && len(inner) > MaxJSONArrayElements {
+			return nil, &JSONArrayTooLargeError{Field: fmt.Sprintf("Paths[%d]", i)}
+		}
+	}
+
 	if !isPathSet(outer) {
 		return nil, ErrInvalidPathSet
 	}

--- a/codec/binarycodec/types/st_object.go
+++ b/codec/binarycodec/types/st_object.go
@@ -52,6 +52,9 @@ func (t *STObject) FromJSON(json any) ([]byte, error) {
 		}
 
 		st := GetSerializedType(v.Type)
+		if err := checkJSONArraySize(v.FieldName, v.Type, fimap[v]); err != nil {
+			return nil, err
+		}
 		b, err := st.FromJSON(fimap[v])
 		if err != nil {
 			return nil, err
@@ -62,6 +65,35 @@ func (t *STObject) FromJSON(json any) ([]byte, error) {
 		}
 	}
 	return t.binarySerializer.GetSink(), nil
+}
+
+// checkJSONArraySize enforces MaxJSONArrayElements on a JSON array field before
+// it is serialized, mirroring rippled's per-array-field maxSTParsedJSONArraySize
+// cap. Only STArray/Vector256/PathSet field values are JSON arrays; the outer
+// PathSet array is capped here, its inner paths in PathSet.FromJSON.
+func checkJSONArraySize(fieldName, fieldType string, value any) error {
+	switch fieldType {
+	case "STArray", "Vector256", "PathSet":
+		if n, ok := jsonArrayLen(value); ok && n > MaxJSONArrayElements {
+			return &JSONArrayTooLargeError{Field: fieldName}
+		}
+	}
+	return nil
+}
+
+// jsonArrayLen reports the length of a JSON array value in any of the shapes the
+// codec accepts, or (0, false) if the value is not an array.
+func jsonArrayLen(value any) (int, bool) {
+	switch v := value.(type) {
+	case []any:
+		return len(v), true
+	case []map[string]any:
+		return len(v), true
+	case []string:
+		return len(v), true
+	default:
+		return 0, false
+	}
 }
 
 // ToJSON takes a BinaryParser and optional parameters, and converts the serialized byte data

--- a/internal/rpc/account_tx_test.go
+++ b/internal/rpc/account_tx_test.go
@@ -1090,9 +1090,9 @@ func TestAccountTxLimitParameter(t *testing.T) {
 		assert.Equal(t, float64(10), resp["limit"])
 	})
 
-	t.Run("Default limit (0) when not specified", func(t *testing.T) {
+	t.Run("Absent limit defaults to accountTx rdefault (200)", func(t *testing.T) {
 		mock.getAccountTransactionsFn = func(ctx context.Context, account string, ledgerMin, ledgerMax int64, limit uint32, marker *types.AccountTxMarker, forward bool) (*types.AccountTxResult, error) {
-			assert.Equal(t, uint32(0), limit, "Limit should default to 0 when not specified")
+			assert.Equal(t, uint32(200), limit, "absent limit routes through readLimitField -> accountTx default 200")
 			return &types.AccountTxResult{
 				Account:      account,
 				LedgerMin:    1,
@@ -1112,6 +1112,34 @@ func TestAccountTxLimitParameter(t *testing.T) {
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)
 		require.NotNil(t, result)
+	})
+
+	t.Run("explicit limit 0 is rejected (3.1.3 readLimitField)", func(t *testing.T) {
+		paramsJSON := []byte(`{"account":"` + validAccount + `","limit":0}`)
+		_, rpcErr := method.Handle(ctx, paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Invalid field 'limit'.", rpcErr.Message)
+	})
+
+	t.Run("malformed limit is expected_field_error", func(t *testing.T) {
+		paramsJSON := []byte(`{"account":"` + validAccount + `","limit":"abc"}`)
+		_, rpcErr := method.Handle(ctx, paramsJSON)
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Invalid field 'limit', not unsigned integer.", rpcErr.Message)
+	})
+
+	t.Run("below-min limit clamps to 10 for non-admin", func(t *testing.T) {
+		var captured uint32
+		mock.getAccountTransactionsFn = func(_ context.Context, account string, _, _ int64, limit uint32, _ *types.AccountTxMarker, _ bool) (*types.AccountTxResult, error) {
+			captured = limit
+			return &types.AccountTxResult{Account: account, Limit: limit, Transactions: []types.AccountTransaction{}, Validated: true}, nil
+		}
+		paramsJSON := []byte(`{"account":"` + validAccount + `","limit":5}`)
+		_, rpcErr := method.Handle(ctx, paramsJSON)
+		require.Nil(t, rpcErr)
+		assert.Equal(t, uint32(10), captured, "non-admin limit below rmin clamps to 10")
 	})
 }
 

--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -1012,14 +1012,6 @@ func TestBookOffersLimitParameter(t *testing.T) {
 			limit:         nil,
 			expectedLimit: 60, // rippled rdefault (60) when user omits limit
 		},
-		{
-			// rippled readLimitField (RPCHelpers.cpp:703-712) clamps to
-			// [rmin, rmax] = [0, 100] for bookOffers; explicit 0 is valid
-			// and yields zero offers.
-			name:          "Explicit limit 0",
-			limit:         0,
-			expectedLimit: 0,
-		},
 	}
 
 	for _, tc := range tests {
@@ -1057,6 +1049,23 @@ func TestBookOffersLimitParameter(t *testing.T) {
 			assert.NotContains(t, resp, "limit", "limit must not be echoed when no marker is returned")
 		})
 	}
+
+	// rippled 3.1.3 readLimitField rejects an explicit limit=0 for every role
+	// (bookOffers rmin also bumped 0->1). Reference: RPCHelpers.cpp readLimitField.
+	t.Run("Explicit limit 0 is rejected", func(t *testing.T) {
+		params := map[string]any{
+			"taker_pays": map[string]any{"currency": "XRP"},
+			"taker_gets": map[string]any{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+			"limit":      0,
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(ctx, paramsJSON)
+		require.NotNil(t, rpcErr, "limit=0 must be rejected")
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Invalid field 'limit'.", rpcErr.Message)
+	})
 }
 
 // TestBookOffersResponseStructure tests the response structure
@@ -1678,14 +1687,6 @@ func TestBookOffersLimitClampingConformance(t *testing.T) {
 		expectedLimit uint32
 	}{
 		{
-			// Book_test.cpp:1713-1716 — explicit 0 stays 0 for either role.
-			name:          "limit 0 (admin)",
-			role:          types.RoleAdmin,
-			unlimited:     true,
-			limit:         0,
-			expectedLimit: 0,
-		},
-		{
 			// Book_test.cpp:1718-1723 — limit rmax+1 (101) clamps to rmax (100)
 			// for non-admin callers (asAdmin=false branch).
 			name:          "rmax+1 clamps to rmax for guest",
@@ -1753,6 +1754,30 @@ func TestBookOffersLimitClampingConformance(t *testing.T) {
 				"Limit passed to service should match clamp/passthrough rule")
 		})
 	}
+
+	// rippled 3.1.3: limit=0 is rejected before the isUnlimited clamp, so admin
+	// (unlimited) callers are rejected too. Reference: RPCHelpers.cpp readLimitField.
+	t.Run("limit 0 rejected even for admin", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			Role:       types.RoleAdmin,
+			Unlimited:  true,
+			ApiVersion: types.ApiVersion1,
+			Services:   services,
+		}
+		params := map[string]any{
+			"taker_pays": map[string]any{"currency": "XRP"},
+			"taker_gets": map[string]any{"currency": "USD", "issuer": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+			"limit":      0,
+		}
+		paramsJSON, err := json.Marshal(params)
+		require.NoError(t, err)
+
+		_, rpcErr := method.Handle(ctx, paramsJSON)
+		require.NotNil(t, rpcErr, "admin limit=0 must be rejected")
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Invalid field 'limit'.", rpcErr.Message)
+	})
 }
 
 // TestBookOffersTakerXAddressRejected nails down that the `taker` field rejects

--- a/internal/rpc/handlers/account_channels.go
+++ b/internal/rpc/handlers/account_channels.go
@@ -52,7 +52,10 @@ func (m *AccountChannelsMethod) Handle(ctx *types.RpcContext, params json.RawMes
 	}
 
 	// Get account channels from the ledger service
-	limit := ClampLimit(request.Limit, LimitAccountChannels, ctx.Unlimited)
+	limit, limitErr := ReadLimitField(params, LimitAccountChannels, ctx.Unlimited)
+	if limitErr != nil {
+		return nil, limitErr
+	}
 	result, err := ctx.Services.Ledger.GetAccountChannels(
 		ctx.Context,
 		request.Account,

--- a/internal/rpc/handlers/account_lines.go
+++ b/internal/rpc/handlers/account_lines.go
@@ -52,7 +52,10 @@ func (m *AccountLinesMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		return nil, mErr
 	}
 
-	limit := ClampLimit(request.Limit, LimitAccountLines, ctx.Unlimited)
+	limit, limitErr := ReadLimitField(params, LimitAccountLines, ctx.Unlimited)
+	if limitErr != nil {
+		return nil, limitErr
+	}
 	result, err := ctx.Services.Ledger.GetAccountLines(ctx.Context, request.Account, ledgerIndex, request.Peer, limit, markerStr)
 	if err != nil {
 		if rerr := mapLedgerLookupErr(err); rerr != nil {

--- a/internal/rpc/handlers/account_nfts.go
+++ b/internal/rpc/handlers/account_nfts.go
@@ -37,7 +37,10 @@ func (m *AccountNftsMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		return nil, selErr
 	}
 
-	limit := ClampLimit(request.Limit, LimitAccountNFTokens, ctx.Unlimited)
+	limit, limitErr := ReadLimitField(params, LimitAccountNFTokens, ctx.Unlimited)
+	if limitErr != nil {
+		return nil, limitErr
+	}
 	result, err := ctx.Services.Ledger.GetAccountNFTs(
 		ctx.Context,
 		request.Account,

--- a/internal/rpc/handlers/account_objects.go
+++ b/internal/rpc/handlers/account_objects.go
@@ -124,7 +124,10 @@ func (m *AccountObjectsMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		return nil, selErr
 	}
 
-	limit := ClampLimit(request.Limit, LimitAccountObjects, ctx.Unlimited)
+	limit, limitErr := ReadLimitField(params, LimitAccountObjects, ctx.Unlimited)
+	if limitErr != nil {
+		return nil, limitErr
+	}
 
 	// Determine effective type filter based on deletion_blockers_only and type params.
 	// Matches rippled's doAccountObjects logic in AccountObjects.cpp.

--- a/internal/rpc/handlers/account_offers.go
+++ b/internal/rpc/handlers/account_offers.go
@@ -42,7 +42,10 @@ func (m *AccountOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		return nil, mErr
 	}
 
-	limit := ClampLimit(request.Limit, LimitAccountOffers, ctx.Unlimited)
+	limit, limitErr := ReadLimitField(params, LimitAccountOffers, ctx.Unlimited)
+	if limitErr != nil {
+		return nil, limitErr
+	}
 	result, err := ctx.Services.Ledger.GetAccountOffers(ctx.Context, request.Account, ledgerIndex, limit, markerStr)
 	if err != nil {
 		if rerr := mapLedgerLookupErr(err); rerr != nil {

--- a/internal/rpc/handlers/account_tx.go
+++ b/internal/rpc/handlers/account_tx.go
@@ -26,7 +26,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		LedgerIndex    string           `json:"ledger_index,omitempty"`
 		Binary         bool             `json:"binary,omitempty"`
 		Forward        bool             `json:"forward,omitempty"`
-		types.PaginationParams
+		Marker         any              `json:"marker,omitempty"`
 	}
 
 	// notEnabled takes precedence over any parameter validation, matching
@@ -123,12 +123,20 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		}
 	}
 
+	// account_tx routes through readLimitField in 3.1.3 (Tuning::accountTx):
+	// absent -> 200, explicit 0 -> invalidParams, malformed -> expected_field,
+	// non-admin clamped to [10, 400]. Reference: AccountTx.cpp:435.
+	limit, limitErr := ReadLimitField(params, LimitAccountTx, ctx.Unlimited)
+	if limitErr != nil {
+		return nil, limitErr
+	}
+
 	result, err := ctx.Services.Ledger.GetAccountTransactions(
 		ctx.Context,
 		request.Account,
 		int64(ledgerIndexMin),
 		int64(ledgerIndexMax),
-		request.Limit,
+		limit,
 		marker,
 		request.Forward,
 	)

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -423,6 +423,12 @@ func parseIssue(raw json.RawMessage) ([20]byte, [20]byte, error) {
 	}
 	copy(issuer[:], issuerBytes)
 
+	// rippled issueFromJson (Issue.cpp) rejects the two reserved AccountIDs —
+	// xrpAccount() (ACCOUNT_ZERO) and noAccount() (ACCOUNT_ONE) — as an issuer.
+	if issuer == noAccountID || issuer == xrpAccountID {
+		return issuer, currency, errors.New("issuer must be a valid account")
+	}
+
 	return issuer, currency, nil
 }
 

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -154,6 +154,10 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		if err := json.Unmarshal(rawLimit, &v); err != nil {
 			return nil, types.RpcErrorExpectedField("limit", "unsigned integer")
 		}
+		// rippled readLimitField rejects an explicit limit=0 for every role.
+		if v == 0 {
+			return nil, types.RpcErrorInvalidField("limit")
+		}
 		limit = v
 		if !ctx.Unlimited {
 			if limit < LimitBookOffers.Min {

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -329,7 +329,8 @@ var (
 	LimitAccountChannels = LimitRange{10, 200, 400}
 	LimitAccountObjects  = LimitRange{10, 200, 400}
 	LimitAccountOffers   = LimitRange{10, 200, 400}
-	LimitBookOffers      = LimitRange{0, 60, 100}
+	LimitAccountTx       = LimitRange{10, 200, 400}
+	LimitBookOffers      = LimitRange{1, 60, 100}
 	LimitNoRippleCheck   = LimitRange{10, 300, 400}
 	LimitAccountNFTokens = LimitRange{20, 100, 400}
 	LimitNFTOffers       = LimitRange{50, 250, 500}
@@ -341,11 +342,15 @@ var (
 	LimitLedgerDataBinary = LimitRange{16, 2048, 2048}
 )
 
-// ClampLimit applies rippled's readLimitField logic: if the user provides
+// ClampLimit applies rippled's pre-3.1.3 clamp logic: if the user provides
 // a limit, clamp it to [range.Min, range.Max] when unlimited is false;
 // otherwise return the user value unchanged. unlimited is true for both
 // admin and identified roles (matches rippled isUnlimited in Role.cpp).
 // If the user does not provide a limit (0), use the default.
+//
+// Prefer ReadLimitField for commands that route through rippled's readLimitField
+// (which rejects an explicit limit=0). ClampLimit is retained for ledger_data,
+// whose rippled handler does not use readLimitField and still maps 0 to default.
 func ClampLimit(userLimit uint32, r LimitRange, unlimited bool) uint32 {
 	if userLimit == 0 {
 		return r.Default
@@ -360,6 +365,58 @@ func ClampLimit(userLimit uint32, r LimitRange, unlimited bool) uint32 {
 		return r.Max
 	}
 	return userLimit
+}
+
+// ReadLimitField mirrors rippled's readLimitField (RPCHelpers.cpp): it reads the
+// "limit" field from the raw request params. An absent or null limit yields the
+// range default; a non-integer or negative value is expected_field_error; an
+// explicit 0 is invalid_field_error — rejected for every role, before clamping;
+// otherwise the value is clamped to [Min, Max] for non-unlimited roles.
+func ReadLimitField(params json.RawMessage, r LimitRange, unlimited bool) (uint32, *types.RpcError) {
+	raw, present := rawLimitField(params)
+	if !present || isJSONNull(raw) {
+		return r.Default, nil
+	}
+	var v uint32
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return 0, types.RpcErrorExpectedField("limit", "unsigned integer")
+	}
+	if v == 0 {
+		return 0, types.RpcErrorInvalidField("limit")
+	}
+	if !unlimited {
+		if v < r.Min {
+			v = r.Min
+		}
+		if v > r.Max {
+			v = r.Max
+		}
+	}
+	return v, nil
+}
+
+// rawLimitField extracts the raw "limit" value from a params object, reporting
+// whether it was present.
+func rawLimitField(params json.RawMessage) (json.RawMessage, bool) {
+	if len(params) == 0 {
+		return nil, false
+	}
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(params, &probe); err != nil {
+		return nil, false
+	}
+	raw, ok := probe["limit"]
+	return raw, ok
+}
+
+// arraySizeRPCError maps a binarycodec.Encode failure that is a JSON array-size
+// overflow to invalidParams (matching rippled's STParsedJSON cap), returning nil
+// for any other error so the caller keeps its existing mapping.
+func arraySizeRPCError(err error) *types.RpcError {
+	if msg, ok := binarycodec.AsArrayTooLargeError(err); ok {
+		return types.RpcErrorInvalidParams(msg)
+	}
+	return nil
 }
 
 // BaseHandler provides default implementations of RequiredRole (RoleGuest),

--- a/internal/rpc/handlers/ledger_entry.go
+++ b/internal/rpc/handlers/ledger_entry.go
@@ -969,6 +969,11 @@ func parseCurrencyIssuer(raw json.RawMessage) (currency [20]byte, issuer [20]byt
 		if err != nil {
 			return currency, issuer, err
 		}
+		// rippled issueFromJson (Issue.cpp) rejects the two reserved AccountIDs —
+		// xrpAccount() (ACCOUNT_ZERO) and noAccount() (ACCOUNT_ONE) — as an issuer.
+		if issuer == noAccountID || issuer == xrpAccountID {
+			return currency, issuer, errors.New("issuer must be a valid account")
+		}
 	}
 
 	return currency, issuer, nil

--- a/internal/rpc/handlers/nft_buy_offers.go
+++ b/internal/rpc/handlers/nft_buy_offers.go
@@ -63,13 +63,12 @@ func handleNFTOffers(ctx *types.RpcContext, params json.RawMessage, fetch func(c
 		return nil, selErr
 	}
 
-	// Apply limit clamping matching rippled's readLimitField with nftOffers tuning.
-	// Reference: NFTOffers.cpp line 69: readLimitField(limit, RPC::Tuning::nftOffers, context)
-	var userLimit uint32
-	if request.Limit != nil {
-		userLimit = *request.Limit
+	// Apply rippled's readLimitField with nftOffers tuning (NFTOffers.cpp:69):
+	// absent limit -> default, explicit 0 -> invalidParams, else clamp.
+	limit, limitErr := ReadLimitField(params, LimitNFTOffers, ctx.Unlimited)
+	if limitErr != nil {
+		return nil, limitErr
 	}
-	limit := ClampLimit(userLimit, LimitNFTOffers, ctx.Unlimited)
 
 	// Validate marker if provided - must be a valid hex string
 	marker := request.Marker

--- a/internal/rpc/handlers/noripple_check.go
+++ b/internal/rpc/handlers/noripple_check.go
@@ -65,7 +65,10 @@ func (m *NoRippleCheckMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 	}
 
 	// Apply limit clamping matching rippled's readLimitField with noRippleCheck tuning
-	limit := ClampLimit(request.Limit, LimitNoRippleCheck, ctx.Unlimited)
+	limit, limitErr := ReadLimitField(params, LimitNoRippleCheck, ctx.Unlimited)
+	if limitErr != nil {
+		return nil, limitErr
+	}
 
 	result, err := ctx.Services.Ledger.GetNoRippleCheck(
 		ctx.Context,

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
@@ -87,6 +88,23 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		return nil, types.RpcErrorMissingField("Account")
 	}
 
+	// On networks with ID > 1024, sign_for requires tx_json to carry a matching
+	// integral NetworkID, else invalidParams. Unlike sign/submit — which autofill
+	// a missing NetworkID — sign_for rejects, so a multisigner cannot sign for the
+	// wrong network. Mirrors rippled checkNetworkID in transactionSignFor.
+	if ctx.Services != nil && ctx.Services.Ledger != nil {
+		if networkID := ctx.Services.Ledger.GetServerInfo().NetworkID; networkID > 1024 {
+			v, ok := txMap["NetworkID"]
+			if !ok {
+				return nil, types.RpcErrorMissingField("tx_json.NetworkID")
+			}
+			n, ok := v.(float64)
+			if !ok || n != math.Trunc(n) || n < 0 || uint32(n) != networkID {
+				return nil, types.RpcErrorInvalidField("tx_json.NetworkID")
+			}
+		}
+	}
+
 	// For multi-signing, the top-level SigningPubKey must be empty. With a
 	// signature_target the signature goes into a nested object, so an existing
 	// top-level SigningPubKey (the primary signer's) is preserved.
@@ -136,6 +154,9 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 	// Encode for multisigning (adds the signer's account as suffix)
 	signingPayload, err := binarycodec.EncodeForMultisigning(txMapForSigning, request.Account)
 	if err != nil {
+		if e := arraySizeRPCError(err); e != nil {
+			return nil, e
+		}
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode for multisigning: %v", err))
 	}
 
@@ -172,6 +193,9 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 
 	txBlob, err := binarycodec.Encode(txMap)
 	if err != nil {
+		if e := arraySizeRPCError(err); e != nil {
+			return nil, e
+		}
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode transaction: %v", err))
 	}
 

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -349,6 +349,9 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 
 	txBlob, err := binarycodec.Encode(txMap)
 	if err != nil {
+		if e := arraySizeRPCError(err); e != nil {
+			return nil, e
+		}
 		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode transaction: %v", err))
 	}
 

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -212,6 +212,16 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		}
 	}
 
+	// STParsedJSONObject also caps each JSON array field at MaxJSONArrayElements
+	// (rippled maxSTParsedJSONArraySize); surface an overflow as invalidParams
+	// before the transaction is parsed and simulated. Other encode failures are
+	// left to the parse/validate path below.
+	if _, encErr := binarycodec.Encode(txJsonMap); encErr != nil {
+		if e := arraySizeRPCError(encErr); e != nil {
+			return nil, e
+		}
+	}
+
 	// Marshal tx_json for parse + service call.
 	txJSON, err := json.Marshal(txJsonMap)
 	if err != nil {

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -100,6 +100,9 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 	if txBlobHex == "" {
 		encoded, err := binarycodec.Encode(txJsonMap)
 		if err != nil {
+			if e := arraySizeRPCError(err); e != nil {
+				return nil, e
+			}
 			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode tx_json: %v", err))
 		}
 		txBlobHex = encoded

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -183,6 +183,9 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	// Encode the transaction to binary
 	txBlob, encErr := binarycodec.Encode(txMap)
 	if encErr != nil {
+		if e := arraySizeRPCError(encErr); e != nil {
+			return nil, e
+		}
 		return nil, types.RpcErrorInternal("Failed to encode transaction: " + encErr.Error())
 	}
 

--- a/internal/rpc/handlers/v313_hardening_test.go
+++ b/internal/rpc/handlers/v313_hardening_test.go
@@ -1,0 +1,142 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+// sentinelAddr returns the classic address of a reserved AccountID sentinel.
+func sentinelAddr(t *testing.T, id [20]byte) string {
+	t.Helper()
+	addr, err := addresscodec.EncodeAccountIDToClassicAddress(id[:])
+	require.NoError(t, err)
+	return addr
+}
+
+// TestIssueFromJSON_RejectsSentinelIssuers verifies that issue parsing rejects
+// xrpAccount() (ACCOUNT_ZERO) and noAccount() (ACCOUNT_ONE) as an IOU issuer,
+// matching rippled issueFromJson. Reference: rippled commit af7e5ef995.
+func TestIssueFromJSON_RejectsSentinelIssuers(t *testing.T) {
+	xrpAddr := sentinelAddr(t, xrpAccountID)
+	noAddr := sentinelAddr(t, noAccountID)
+	validIssuer := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+	t.Run("amm_info parseIssue rejects xrpAccount", func(t *testing.T) {
+		_, _, err := parseIssue(json.RawMessage(`{"currency":"USD","issuer":"` + xrpAddr + `"}`))
+		require.Error(t, err)
+	})
+	t.Run("amm_info parseIssue rejects noAccount", func(t *testing.T) {
+		_, _, err := parseIssue(json.RawMessage(`{"currency":"USD","issuer":"` + noAddr + `"}`))
+		require.Error(t, err)
+	})
+	t.Run("amm_info parseIssue accepts a valid issuer", func(t *testing.T) {
+		_, _, err := parseIssue(json.RawMessage(`{"currency":"USD","issuer":"` + validIssuer + `"}`))
+		require.NoError(t, err)
+	})
+
+	t.Run("ledger_entry parseCurrencyIssuer rejects xrpAccount", func(t *testing.T) {
+		_, _, err := parseCurrencyIssuer(json.RawMessage(`{"currency":"USD","issuer":"` + xrpAddr + `"}`))
+		require.Error(t, err)
+	})
+	t.Run("ledger_entry parseCurrencyIssuer rejects noAccount", func(t *testing.T) {
+		_, _, err := parseCurrencyIssuer(json.RawMessage(`{"currency":"USD","issuer":"` + noAddr + `"}`))
+		require.Error(t, err)
+	})
+	t.Run("ledger_entry parseCurrencyIssuer accepts a valid issuer", func(t *testing.T) {
+		_, _, err := parseCurrencyIssuer(json.RawMessage(`{"currency":"USD","issuer":"` + validIssuer + `"}`))
+		require.NoError(t, err)
+	})
+	t.Run("ledger_entry parseCurrencyIssuer accepts XRP without issuer", func(t *testing.T) {
+		_, _, err := parseCurrencyIssuer(json.RawMessage(`{"currency":"XRP"}`))
+		require.NoError(t, err)
+	})
+}
+
+// TestArraySizeRPCError verifies the JSON-array-size overflow from the codec is
+// mapped to invalidParams (item 2, rippled STParsedJSON cap), and other encode
+// errors fall through (nil). Reference: rippled commit 377b155ddc.
+func TestArraySizeRPCError(t *testing.T) {
+	hashes := make([]any, 513)
+	for i := range hashes {
+		hashes[i] = strings.Repeat("A", 64)
+	}
+	_, encErr := binarycodec.Encode(map[string]any{"Amendments": hashes})
+	require.Error(t, encErr)
+
+	rpcErr := arraySizeRPCError(encErr)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Equal(t, "invalidParams", rpcErr.ErrorString)
+	assert.Contains(t, rpcErr.Message, "exceeds allowed JSON array size of 512 elements per field.")
+
+	assert.Nil(t, arraySizeRPCError(errors.New("some other encode error")))
+	assert.Nil(t, arraySizeRPCError(nil))
+}
+
+// TestReadLimitField exercises the readLimitField port directly: absent/null ->
+// default, explicit 0 -> invalidParams for every role, malformed ->
+// expected_field, and non-admin clamping. Reference: rippled RPCHelpers.cpp.
+func TestReadLimitField(t *testing.T) {
+	r := LimitRange{Min: 10, Default: 200, Max: 400}
+
+	check := func(t *testing.T, params string, unlimited bool) (uint32, *types.RpcError) {
+		t.Helper()
+		return ReadLimitField(json.RawMessage(params), r, unlimited)
+	}
+
+	t.Run("absent -> default", func(t *testing.T) {
+		v, err := check(t, `{}`, false)
+		require.Nil(t, err)
+		assert.Equal(t, uint32(200), v)
+	})
+	t.Run("null -> default", func(t *testing.T) {
+		v, err := check(t, `{"limit":null}`, false)
+		require.Nil(t, err)
+		assert.Equal(t, uint32(200), v)
+	})
+	t.Run("explicit 0 -> invalidParams (guest)", func(t *testing.T) {
+		_, err := check(t, `{"limit":0}`, false)
+		require.NotNil(t, err)
+		assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
+		assert.Equal(t, "Invalid field 'limit'.", err.Message)
+	})
+	t.Run("explicit 0 -> invalidParams (admin/unlimited)", func(t *testing.T) {
+		_, err := check(t, `{"limit":0}`, true)
+		require.NotNil(t, err)
+		assert.Equal(t, "Invalid field 'limit'.", err.Message)
+	})
+	t.Run("string -> expected_field", func(t *testing.T) {
+		_, err := check(t, `{"limit":"abc"}`, false)
+		require.NotNil(t, err)
+		assert.Equal(t, "Invalid field 'limit', not unsigned integer.", err.Message)
+	})
+	t.Run("negative -> expected_field", func(t *testing.T) {
+		_, err := check(t, `{"limit":-5}`, false)
+		require.NotNil(t, err)
+		assert.Equal(t, "Invalid field 'limit', not unsigned integer.", err.Message)
+	})
+	t.Run("below min clamped (guest)", func(t *testing.T) {
+		v, err := check(t, `{"limit":5}`, false)
+		require.Nil(t, err)
+		assert.Equal(t, uint32(10), v)
+	})
+	t.Run("above max clamped (guest)", func(t *testing.T) {
+		v, err := check(t, `{"limit":9999}`, false)
+		require.Nil(t, err)
+		assert.Equal(t, uint32(400), v)
+	})
+	t.Run("above max not clamped for unlimited", func(t *testing.T) {
+		v, err := check(t, `{"limit":9999}`, true)
+		require.Nil(t, err)
+		assert.Equal(t, uint32(9999), v)
+	})
+}

--- a/internal/rpc/sign_for_networkid_test.go
+++ b/internal/rpc/sign_for_networkid_test.go
@@ -1,0 +1,79 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+// TestSignFor_NetworkIDEnforcement verifies sign_for enforces NetworkID on
+// networks with ID > 1024: tx_json must carry a matching integral NetworkID,
+// else invalidParams. Unlike sign/submit, sign_for rejects rather than autofills.
+// Reference: rippled commit 2ddef8c87d (checkNetworkID in transactionSignFor).
+func TestSignFor_NetworkIDEnforcement(t *testing.T) {
+	method := &handlers.SignForMethod{}
+	const signer = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh" // masterpassphrase
+
+	ctxWith := func(networkID uint32) *types.RpcContext {
+		mock := newMockLedgerService()
+		mock.serverInfo = types.LedgerServerInfo{NetworkID: networkID}
+		return &types.RpcContext{
+			Context:    context.Background(),
+			ApiVersion: types.ApiVersion1,
+			Services:   &types.ServiceContainer{Ledger: mock},
+		}
+	}
+
+	params := func(networkID *int) json.RawMessage {
+		txJSON := map[string]any{
+			"TransactionType": "Payment",
+			"Account":         signer,
+			"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount":          "1000000",
+			"Fee":             "10",
+			"Sequence":        1,
+		}
+		if networkID != nil {
+			txJSON["NetworkID"] = *networkID
+		}
+		b, err := json.Marshal(map[string]any{
+			"account":    signer,
+			"passphrase": "masterpassphrase",
+			"tx_json":    txJSON,
+		})
+		require.NoError(t, err)
+		return b
+	}
+
+	t.Run("network > 1024 requires NetworkID", func(t *testing.T) {
+		_, rpcErr := method.Handle(ctxWith(1025), params(nil))
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Missing field 'tx_json.NetworkID'.", rpcErr.Message)
+	})
+
+	t.Run("network > 1024 rejects mismatched NetworkID", func(t *testing.T) {
+		nid := 999
+		_, rpcErr := method.Handle(ctxWith(1025), params(&nid))
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+		assert.Equal(t, "Invalid field 'tx_json.NetworkID'.", rpcErr.Message)
+	})
+
+	t.Run("network > 1024 accepts matching NetworkID", func(t *testing.T) {
+		nid := 1025
+		_, rpcErr := method.Handle(ctxWith(1025), params(&nid))
+		require.Nil(t, rpcErr)
+	})
+
+	t.Run("network <= 1024 does not require NetworkID", func(t *testing.T) {
+		_, rpcErr := method.Handle(ctxWith(1024), params(nil))
+		require.Nil(t, rpcErr)
+	})
+}

--- a/internal/tx/account/account_delete.go
+++ b/internal/tx/account/account_delete.go
@@ -68,7 +68,7 @@ func (a *AccountDelete) Flatten() (map[string]any, error) { return tx.ReflectFla
 // sandbox is rolled back for tec results.
 // Reference: rippled Transactor.cpp - tecEXPIRED re-applies removeExpiredCredentials
 func (a *AccountDelete) ApplyOnTec(ctx *tx.ApplyContext) {
-	credential.RemoveExpiredCredentials(ctx, a.CredentialIDs)
+	credential.RemoveExpiredCredentialsOnTec(ctx, a.CredentialIDs)
 }
 
 func (a *AccountDelete) Apply(ctx *tx.ApplyContext) ter.Result {

--- a/internal/tx/credential/credential_helpers.go
+++ b/internal/tx/credential/credential_helpers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"sort"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
@@ -281,13 +282,16 @@ func ValidCredentials(view tx.LedgerView, subject [20]byte, credentialIDs []stri
 	return ter.TesSUCCESS
 }
 
-// RemoveExpiredCredentials deletes any expired credentials in credentialIDs
-// from the ledger, adjusting owner directories and counts. It returns true if
-// at least one credential was expired.
+// removeExpired is the shared per-credential deletion loop. anyExpired reports
+// whether any credential was expired; failTER is the first failing deletion TER
+// (tesSUCCESS if none failed). When stopOnFailure is true it returns immediately
+// on the first deletion failure — the success-path behaviour rippled gates on
+// fixCleanup3_1_3; otherwise every expired credential is processed and failures
+// are only logged (the tec-recovery cleanup).
 // Reference: rippled CredentialHelpers.cpp credentials::removeExpired()
-func RemoveExpiredCredentials(ctx *tx.ApplyContext, credentialIDs []string) bool {
+func removeExpired(ctx *tx.ApplyContext, credentialIDs []string, stopOnFailure bool) (anyExpired bool, failTER ter.Result) {
 	closeTime := ctx.Config.ParentCloseTime
-	anyExpired := false
+	failTER = ter.TesSUCCESS
 
 	for _, idHex := range credentialIDs {
 		credIDBytes, err := hex.DecodeString(idHex)
@@ -309,12 +313,43 @@ func RemoveExpiredCredentials(ctx *tx.ApplyContext, credentialIDs []string) bool
 		}
 
 		if CheckCredentialExpired(cred, closeTime) {
-			_ = DeleteSLE(ctx, credKey, cred)
+			if r := DeleteSLE(ctx, credKey, cred); r != ter.TesSUCCESS {
+				ctx.Log.Error("removeExpiredCredentials: failed to delete expired credential", "ter", r.String())
+				if stopOnFailure {
+					return anyExpired, r
+				}
+				if failTER == ter.TesSUCCESS {
+					failTER = r
+				}
+			}
 			anyExpired = true
 		}
 	}
 
-	return anyExpired
+	return anyExpired, failTER
+}
+
+// RemoveExpiredCredentials deletes any expired credentials in credentialIDs on a
+// transaction's success path, adjusting owner directories and counts. It returns
+// whether at least one credential was expired and the TER to abort with. Under
+// fixCleanup3_1_3 a deletion failure aborts the transaction (returns the failing
+// TER); before the amendment the failure is swallowed (returns tesSUCCESS),
+// matching rippled removeExpired.
+func RemoveExpiredCredentials(ctx *tx.ApplyContext, credentialIDs []string) (bool, ter.Result) {
+	fix313 := ctx.Rules().Enabled(amendment.FeatureID("fixCleanup3_1_3"))
+	anyExpired, failTER := removeExpired(ctx, credentialIDs, fix313)
+	if fix313 {
+		return anyExpired, failTER
+	}
+	return anyExpired, ter.TesSUCCESS
+}
+
+// RemoveExpiredCredentialsOnTec runs the tec-recovery cleanup: every expired
+// credential is deleted and a deletion failure is only logged, never propagated,
+// matching rippled Transactor::removeExpiredCredentials. This path is unchanged
+// by fixCleanup3_1_3.
+func RemoveExpiredCredentialsOnTec(ctx *tx.ApplyContext, credentialIDs []string) {
+	removeExpired(ctx, credentialIDs, false)
 }
 
 // VerifyDepositPreauth enforces deposit authorization for a transaction
@@ -327,8 +362,14 @@ func RemoveExpiredCredentials(ctx *tx.ApplyContext, credentialIDs []string) bool
 func VerifyDepositPreauth(ctx *tx.ApplyContext, credentialIDs []string, src, dst [20]byte, dstAccount *state.AccountRoot) ter.Result {
 	credentialsPresent := len(credentialIDs) > 0
 
-	if credentialsPresent && RemoveExpiredCredentials(ctx, credentialIDs) {
-		return ter.TecEXPIRED
+	if credentialsPresent {
+		anyExpired, r := RemoveExpiredCredentials(ctx, credentialIDs)
+		if r != ter.TesSUCCESS {
+			return r
+		}
+		if anyExpired {
+			return ter.TecEXPIRED
+		}
 	}
 
 	if dstAccount != nil && (dstAccount.Flags&state.LsfDepositAuth) != 0 && src != dst {

--- a/internal/tx/credential/credential_helpers_test.go
+++ b/internal/tx/credential/credential_helpers_test.go
@@ -1,0 +1,120 @@
+package credential
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+)
+
+// mapView is a minimal in-memory tx.LedgerView for helper-level tests.
+type mapView struct{ data map[[32]byte][]byte }
+
+func newMapView() *mapView { return &mapView{data: make(map[[32]byte][]byte)} }
+
+func (m *mapView) Read(k keylet.Keylet) ([]byte, error)      { return m.data[k.Key], nil }
+func (m *mapView) Exists(k keylet.Keylet) (bool, error)      { _, ok := m.data[k.Key]; return ok, nil }
+func (m *mapView) Insert(k keylet.Keylet, data []byte) error { m.data[k.Key] = data; return nil }
+func (m *mapView) Update(k keylet.Keylet, data []byte) error { m.data[k.Key] = data; return nil }
+func (m *mapView) Erase(k keylet.Keylet) error               { delete(m.data, k.Key); return nil }
+func (m *mapView) AdjustDropsDestroyed(drops.XRPAmount)      {}
+func (m *mapView) ForEach(fn func(key [32]byte, data []byte) bool) error {
+	for k, v := range m.data {
+		if !fn(k, v) {
+			break
+		}
+	}
+	return nil
+}
+func (m *mapView) Succ([32]byte) ([32]byte, []byte, bool, error) { return [32]byte{}, nil, false, nil }
+func (m *mapView) TxExists([32]byte) bool                        { return false }
+func (m *mapView) Rules() *amendment.Rules                       { return nil }
+func (m *mapView) LedgerSeq() uint32                             { return 0 }
+
+// TestRemoveExpiredCredentials_DeletionFailure mirrors rippled's
+// testRemoveExpiredCorruption (Credentials_test.cpp): an expired accepted
+// credential whose issuer account has been erased makes deleteSLE fail with
+// tecINTERNAL. Under fixCleanup3_1_3 that failure aborts verifyDepositPreauth
+// (tecINTERNAL); before the amendment it is swallowed and the caller still
+// returns tecEXPIRED. (PR #6715)
+func TestRemoveExpiredCredentials_DeletionFailure(t *testing.T) {
+	var subjectID, issuerID [20]byte
+	subjectID[0], subjectID[19] = 0x01, 0x11
+	issuerID[0], issuerID[19] = 0x02, 0x22
+
+	subjectAddr, err := addresscodec.EncodeAccountIDToClassicAddress(subjectID[:])
+	require.NoError(t, err)
+
+	credType := []byte("abcde")
+	credKey := keylet.Credential(subjectID, issuerID, credType)
+	credIDHex := hex.EncodeToString(credKey.Key[:])
+
+	const expiration = uint32(100)
+	const closeTime = uint32(200) // strictly after expiration -> expired
+
+	buildCtx := func(rules *amendment.Rules) *tx.ApplyContext {
+		view := newMapView()
+
+		// Accepted, expired credential owned across the subject and issuer dirs.
+		exp := expiration
+		credBlob, serr := serializeCredentialEntry(&CredentialEntry{
+			Subject:        subjectID,
+			Issuer:         issuerID,
+			CredentialType: credType,
+			Expiration:     &exp,
+			Flags:          LsfCredentialAccepted,
+		})
+		require.NoError(t, serr)
+		require.NoError(t, view.Insert(credKey, credBlob))
+
+		// The subject account exists; the issuer account is intentionally absent
+		// so deleteSLE's owner-account existence check fails with tecINTERNAL.
+		subjAcct := &state.AccountRoot{Account: subjectAddr, Balance: 100_000_000, Sequence: 1}
+		subjBlob, aerr := state.SerializeAccountRoot(subjAcct)
+		require.NoError(t, aerr)
+		require.NoError(t, view.Insert(keylet.Account(subjectID), subjBlob))
+
+		return &tx.ApplyContext{
+			View:      view,
+			Account:   subjAcct,
+			AccountID: subjectID,
+			Config: tx.EngineConfig{
+				Rules:           rules,
+				ParentCloseTime: closeTime,
+			},
+			Metadata: &tx.Metadata{},
+			Log:      xrpllog.Discard(),
+			Ctx:      context.Background(),
+		}
+	}
+
+	// fixCleanup3_1_3 is registered by a sibling PR; enable it here by ID so the
+	// gate can be exercised before that registration lands.
+	fix313On := amendment.NewRulesBuilder().
+		FromPreset(amendment.PresetAllSupported).
+		Enable(amendment.FeatureID("fixCleanup3_1_3")).
+		Build()
+	fix313Off := amendment.AllSupportedRules()
+
+	t.Run("before fix: deletion failure swallowed, tecEXPIRED", func(t *testing.T) {
+		ctx := buildCtx(fix313Off)
+		result := VerifyDepositPreauth(ctx, []string{credIDHex}, subjectID, [20]byte{}, nil)
+		require.Equal(t, ter.TecEXPIRED, result)
+	})
+
+	t.Run("after fix: deletion failure aborts, tecINTERNAL", func(t *testing.T) {
+		ctx := buildCtx(fix313On)
+		result := VerifyDepositPreauth(ctx, []string{credIDHex}, subjectID, [20]byte{}, nil)
+		require.Equal(t, ter.TecINTERNAL, result)
+	})
+}

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -136,7 +136,7 @@ func (e *EscrowFinish) Preclaim(_ tx.LedgerView, config tx.EngineConfig) ter.Res
 // sandbox is rolled back for tec results.
 // Reference: rippled Transactor.cpp - tecEXPIRED re-applies removeExpiredCredentials
 func (e *EscrowFinish) ApplyOnTec(ctx *tx.ApplyContext) {
-	credential.RemoveExpiredCredentials(ctx, e.CredentialIDs)
+	credential.RemoveExpiredCredentialsOnTec(ctx, e.CredentialIDs)
 }
 
 // Apply applies an EscrowFinish transaction

--- a/internal/tx/paychan/payment_channel_claim.go
+++ b/internal/tx/paychan/payment_channel_claim.go
@@ -426,5 +426,5 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) ter.Result {
 // When tecEXPIRED is returned, expired credentials must still be deleted from the ledger.
 // Reference: rippled CredentialHelpers.cpp removeExpired() — called from verifyDepositPreauth()
 func (p *PaymentChannelClaim) ApplyOnTec(ctx *tx.ApplyContext) {
-	credential.RemoveExpiredCredentials(ctx, p.CredentialIDs)
+	credential.RemoveExpiredCredentialsOnTec(ctx, p.CredentialIDs)
 }

--- a/internal/tx/payment/payment_iou.go
+++ b/internal/tx/payment/payment_iou.go
@@ -391,5 +391,5 @@ func deliveredWithDstIssue(actualOut EitherAmount, dstAmount tx.Amount) tx.Amoun
 // credential expiration deletion against the engine's view so the side-effects persist.
 // Reference: rippled Transactor.cpp - tecEXPIRED re-applies removeExpiredCredentials
 func (p *Payment) ApplyOnTec(ctx *tx.ApplyContext) {
-	credential.RemoveExpiredCredentials(ctx, p.CredentialIDs)
+	credential.RemoveExpiredCredentialsOnTec(ctx, p.CredentialIDs)
 }


### PR DESCRIPTION
Implements the ungated RPC + engine hardening items of the rippled **3.1.3** parity wave. Targets `v3.0.0`. Part of #1248 — completes the ungated 3.1.3 set together with #1267 (peer/wire) and #1268 (fixCleanup3_1_3 gated arms).

## Items

| # | Item | rippled | Status |
|---|---|---|---|
| 1 | Unified RPC limit validation | [#5891](https://github.com/XRPLF/rippled/pull/5891), [#6812](https://github.com/XRPLF/rippled/pull/6812), `56a9d69bfb` | implemented |
| 2 | STParsedJSON 512-element array cap | `377b155ddc` | implemented |
| 3 | Expired-credential deletion failure aborts tx | [#6715](https://github.com/XRPLF/rippled/pull/6715) | implemented (gated) |
| 4 | PermissionedDomainSet ticket-aware sequence | `dde7ca9f28` | already covered (ungated) |
| 5 | Dry-run (simulate) never enters TxQ | `3004e04936` | already covered |
| 6 | queue_data txJson by apiVersion | `066e3956fe` | already covered |
| 7 | gateway_balances excludes MPT escrows | [#6143](https://github.com/XRPLF/rippled/pull/6143) | already covered |
| 8 | get_aggregate_price ledger-lookup hoist | [#6570](https://github.com/XRPLF/rippled/pull/6570) | already covered |
| 9 | issueFromJson rejects noAccount/xrpAccount issuer | `af7e5ef995` | implemented |
| — | sign_for enforces NetworkID | `2ddef8c87d` | implemented |

### 1. Unified RPC limit validation (#5891, #6812)
New `ReadLimitField(params, LimitRange, unlimited)` in `handlers/helpers.go` ports rippled `readLimitField`: absent/null → default, explicit **limit=0 → invalidParams for every role** (before clamping), malformed → `expected_field_error`, else clamp `[min,max]` for non-unlimited. Threaded through account_channels/lines/objects/offers/nfts, no_ripple_check, nft_buy/sell_offers, book_offers, and newly account_tx. `LimitBookOffers` min `0→1`; new `LimitAccountTx {10,200,400}`. `ClampLimit` retained for `ledger_data` (rippled `LedgerData` does not use `readLimitField`). `account_tx` drops its strict `PaginationParams` embed so malformed → `expected_field_error` (part of its 3.1.3 change).

### 2. STParsedJSON 512-element-per-array cap (377b155d)
`MaxJSONArrayElements = 512` + `JSONArrayTooLargeError{Field}` in the binary codec. Enforced on the JSON→binary (`FromJSON`) path for STArray/Vector256/PathSet (outer at the STObject dispatch with the field name; PathSet inner paths inside `PathSet.FromJSON`). Message matches rippled: `Field '<name>' exceeds allowed JSON array size of 512 elements per field.` Surfaced as **invalidParams** via `binarycodec.AsArrayTooLargeError` at submit / sign / sign_for / submit_multisigned / simulate. Binary blob submission is unaffected.

### 3. Expired-credential deletion failure aborts the tx (#6715, gated)
`removeExpired` is split faithfully into a gated success-path (`RemoveExpiredCredentials`, returns `(bool, TER)`; under `fixCleanup3_1_3` a `deleteSLE` failure propagates the TER) and the tec-recovery cleanup (`RemoveExpiredCredentialsOnTec`, log-only), with the 4 `ApplyOnTec` callers moved to the latter. `VerifyDepositPreauth` propagates the failing TER.

**Gating note:** the gate reads `amendment.FeatureID("fixCleanup3_1_3")` (goXRPL references amendments by runtime name-hash), so it compiles against `v3.0.0` and stays **inert (old swallow behaviour)** until #1268 registers the amendment, then activates on rebase. No amendment-registry change here (avoids conflict with #1268). goXRPL's DomainID path (`AccountInDomain`) is read-only (rippled `validDomain`), so #6715 touches only the CredentialIDs path.

### 4. PermissionedDomainSet ticket-aware sequence — already covered (ungated)
goXRPL already uses `Common.SeqProxy()` unconditionally = the post-fix behaviour. The rippled gate falls back to raw `sfSequence` (=0, the pre-fix collision bug) when disabled; adding it would **regress** ticket-created domains whenever the (currently unregistered) `fixCleanup3_1_3` is off, so it is deliberately left ungated (the gate is optional per #1248).

### 9. issueFromJson sentinel rejection (af7e5ef9)
`amm_info` `parseIssue` and `ledger_entry` `parseCurrencyIssuer` now reject `xrpAccount()` (ACCOUNT_ZERO) and `noAccount()` (ACCOUNT_ONE) as an IOU issuer. book_offers / subscribe already rejected.

### sign_for NetworkID (2ddef8c8)
On networks with ID > 1024, `sign_for` requires a matching integral `tx_json.NetworkID`, else `Missing`/`Invalid field 'tx_json.NetworkID'.` — rejecting rather than autofilling (unlike sign/submit).

### Items 5–8 — already correct (verified, no change)
Dry-run applies over an isolated snapshot and never touches the TxQ; `buildLedgerQueueData` already branches by apiVersion/binary; `addEscrowLocked` already skips MPT escrows; `get_aggregate_price` resolves the ledger selector once before the oracle loop.

## Tests
- `codec/binarycodec`: array-size cap across STArray/Vector256/PathSet (outer+inner), exact message, at-cap accepted.
- `handlers`: `ReadLimitField` matrix (absent/null/0/malformed/clamp/unlimited); issueFromJson sentinel rejection (amm_info + ledger_entry); array-cap → invalidParams mapping.
- `rpc`: sign_for NetworkID (missing/mismatch/match/legacy); account_tx limit (0-reject, malformed, min-clamp, default 200); book_offers limit=0 rejected for guest and admin.
- `tx/credential`: deletion-failure corruption test mirroring rippled `testRemoveExpiredCorruption` — `tecEXPIRED` before fix, `tecINTERNAL` after.

## Verification
- `go build ./...` clean; full `go test ./...` green except the pre-existing conformance failures.
- Conformance: **178 failures, byte-identical set to the v3.0.0 baseline (0 new, 0 regressions).**
- `golangci-lint run --config .golangci.yml ./...` → 0 issues.
- No docsgen drift (no amendment/definition changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)