### PR TITLE
fix(engine): align preflight TER precedence with rippled invokePreflight

### DIFF
--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -104,6 +104,18 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 			CurrentLedger: s.openLedgerView.Current().Sequence(),
 		}, nil
 	}
+	// Local submission checks (rippled STTx::passesLocalChecks via NetworkOPs):
+	// memo size/charset limits are enforced only here, on the local ingress, not
+	// in the consensus-critical engine preflight. A relayed or consensus-applied
+	// transaction carrying an oversized/invalid memo still applies, so this
+	// refusal cannot fork the ledger.
+	if localResult := tx.PassesLocalChecks(ptx.Parsed.GetCommon()); localResult != ter.TesSUCCESS {
+		return &SubmitResult{
+			Result:        localResult,
+			Message:       localResult.Message(),
+			CurrentLedger: s.openLedgerView.Current().Sequence(),
+		}, nil
+	}
 	// Verify the signature before SubmitDetailed acquires the apply mutex so the
 	// in-strand check reuses the cached verdict (#1105). Skipped in standalone
 	// mode, matching cfg.SkipSignatureVerification above.

--- a/internal/ledger/service/tx_query_submit_test.go
+++ b/internal/ledger/service/tx_query_submit_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"encoding/hex"
+	"strings"
 	"testing"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
@@ -40,6 +41,57 @@ func signedPaymentWithFee(t *testing.T, env *testenv.TestEnv, sender, receiver *
 		t.Fatalf("ComputeTransactionHash: %v", err)
 	}
 	return blob, hash
+}
+
+// memoPaymentBlob builds an (unsigned) Payment blob carrying a memo whose
+// MemoData is the given hex string. It encodes the field map directly rather
+// than via the typed Payment.Flatten, whose reflective memo conversion is a
+// separate concern; the local memo check reads the decoded Memos regardless.
+func memoPaymentBlob(t *testing.T, from, to string, memoDataHex string) []byte {
+	t.Helper()
+	txMap := map[string]any{
+		"TransactionType": "Payment",
+		"Account":         from,
+		"Destination":     to,
+		"Amount":          "100000000",
+		"Fee":             "10",
+		"Sequence":        uint32(1),
+		"Memos": []map[string]any{
+			{"Memo": map[string]any{"MemoData": memoDataHex}},
+		},
+	}
+	hexStr, err := binarycodec.Encode(txMap)
+	if err != nil {
+		t.Fatalf("binarycodec.Encode: %v", err)
+	}
+	blob, err := hex.DecodeString(hexStr)
+	if err != nil {
+		t.Fatalf("hex.DecodeString: %v", err)
+	}
+	return blob
+}
+
+// TestService_SubmitTransaction_RejectsOversizedMemo verifies the local
+// submission ingress enforces rippled's passesLocalChecks memo rule: a memo
+// whose serialized size exceeds 1024 bytes is refused temMALFORMED at
+// Service.SubmitTransaction, before the engine ever runs. This is the local-only
+// counterpart to the engine's now memo-agnostic preflight (see the engine
+// AcceptsOversizedMemo test) — a relayed or consensus-applied oversized-memo tx
+// still applies, so the two behaviours cannot fork.
+func TestService_SubmitTransaction_RejectsOversizedMemo(t *testing.T) {
+	svc := newServiceForOpenLedgerTest(t)
+	master := testenv.MasterAccount()
+	alice := testenv.NewAccount("alice")
+
+	// 1020 decoded bytes → 1025 serialized (> 1024).
+	blob := memoPaymentBlob(t, master.Address, alice.Address, strings.Repeat("AA", 1020))
+	res := submitBlob(t, svc, blob, false)
+	if res.Result != ter.TemMALFORMED {
+		t.Fatalf("Result = %s, want temMALFORMED", res.Result)
+	}
+	if res.Applied {
+		t.Errorf("Applied = true, want false for a memo-rejected tx")
+	}
 }
 
 func submitBlob(t *testing.T, svc *service.Service, blob []byte, failHard bool) *service.SubmitResult {

--- a/internal/testing/multisign/expanded_signerlist_test.go
+++ b/internal/testing/multisign/expanded_signerlist_test.go
@@ -170,8 +170,9 @@ func signerAccounts(env *jtx.TestEnv, n int) []*jtx.Account {
 
 // TestMultiSign_ArrayBound_WithExpandedAmendment asserts the rules-gated cap on
 // a transaction's Signers array: with featureExpandedSignerList enabled a 33-entry
-// array is rejected (cap is 32). The bound is checked in preflight, before the
-// SignerList lookup, so it surfaces as temBAD_SIGNATURE regardless of authorization.
+// array is rejected (cap is 32). The bound is a structural multi-sign check, so
+// it surfaces as temINVALID (rippled multiSignHelper's Unexpected → SigBad →
+// temINVALID in preflight2), regardless of the SignerList/authorization.
 // Reference: rippled STTx::checkMultiSign -> multiSignHelper size check.
 func TestMultiSign_ArrayBound_WithExpandedAmendment(t *testing.T) {
 	env := jtx.NewTestEnv(t)
@@ -188,7 +189,7 @@ func TestMultiSign_ArrayBound_WithExpandedAmendment(t *testing.T) {
 
 	payTx := payment.Pay(alice, becky, uint64(jtx.XRP(10))).Build()
 	result := env.SubmitMultiSigned(payTx, signers)
-	jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
+	jtx.RequireTxFail(t, result, "temINVALID")
 }
 
 // TestMultiSign_ArrayBound_WithoutExpandedAmendment asserts the cap drops to 8
@@ -209,10 +210,11 @@ func TestMultiSign_ArrayBound_WithoutExpandedAmendment(t *testing.T) {
 	signers := signerAccounts(env, 9)
 	env.Close()
 
-	// Nine signers exceed the pre-amendment maximum of 8 — rejected in preflight.
+	// Nine signers exceed the pre-amendment maximum of 8 — a structural
+	// multi-sign violation rejected temINVALID in preflight.
 	payTx := payment.Pay(alice, becky, uint64(jtx.XRP(10))).Build()
 	result := env.SubmitMultiSigned(payTx, signers[:9])
-	jtx.RequireTxFail(t, result, "temBAD_SIGNATURE")
+	jtx.RequireTxFail(t, result, "temINVALID")
 
 	// Eight signers are the boundary; with a matching 8-entry signer list and a
 	// met quorum the multi-signed payment succeeds.

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -72,27 +72,55 @@ func (e *Engine) preflight(tx txcore.Transaction) (result ter.Result) {
 	return ter.TesSUCCESS
 }
 
-// preflightStructure runs the ledger-state-independent preflight checks
-// (preflight0/1 minus signature verification, plus the per-type Validate and
-// rules-gated checks). It is a pure function of the transaction fields and the
-// active rules, which is what makes its verdict safe to memoise (see
-// Common.PreflightVerified).
+// preflightStructure runs the ledger-state-independent preflight checks in
+// rippled's invokePreflight order: the amendment gate and T::checkExtraFeatures,
+// then preflight1 (which invokes preflight0), then the per-type Validate body,
+// then the preflight2 structural (multi-sign) checks. Signature verification
+// itself runs separately in verifySignatures. This is a pure function of the
+// transaction fields and the active rules, which is what makes its verdict safe
+// to memoise (see Common.PreflightVerified).
+// Reference: rippled Transactor.h Transactor::invokePreflight<T>.
 func (e *Engine) preflightStructure(tx txcore.Transaction, common *txcore.Common) ter.Result {
-	// preflight0: trivial common-field presence + amendment + flag checks.
-	if result := e.preflightCommonFields(tx, common); result != ter.TesSUCCESS {
+	rules := e.rules()
+
+	// The transactions.macro amendment gate (rippled Permission::getTxFeature →
+	// temDISABLED) is the FIRST check, before checkExtraFeatures and preflight1,
+	// so a disabled tx type is rejected before any NetworkID/account/fee TER.
+	for _, featureID := range tx.RequiredAmendments() {
+		if !rules.Enabled(featureID) {
+			return ter.TemDISABLED
+		}
+	}
+
+	// T::checkExtraFeatures runs before preflight1's common checks (see
+	// ExtraFeaturesChecker). No tx type adopts this hook yet.
+	if efc, ok := tx.(txcore.ExtraFeaturesChecker); ok {
+		if err := efc.CheckExtraFeatures(rules); err != nil {
+			return parseValidationError(err)
+		}
+	}
+
+	// preflight1 (which itself runs preflight0).
+	if result := e.preflight1(tx, common, rules); result != ter.TesSUCCESS {
 		return result
 	}
 
-	// preflight1 — fee, sequence, memos, structural multi-sign checks.
-	if result := e.validateFee(common); result != ter.TesSUCCESS {
-		return result
+	// T::preflight — the tx-type-specific body: the rules-free Validate() plus
+	// any amendment-gated tem* checks that genuinely belong in the per-type
+	// preflight body (RulesPreflighter).
+	if err := tx.Validate(); err != nil {
+		return parseValidationError(err)
 	}
-	if result := e.preflightSequence(common); result != ter.TesSUCCESS {
-		return result
+	if rp, ok := tx.(txcore.RulesPreflighter); ok {
+		if err := rp.PreflightRules(rules); err != nil {
+			return parseValidationError(err)
+		}
 	}
-	if result := e.validateMemos(common); result != ter.TesSUCCESS {
-		return result
-	}
+
+	// preflight2 structural stage — the multi-sign structural rules run after
+	// T::preflight (rippled STTx::multiSignHelper reached via checkValidity) and
+	// a violation is Validity::SigBad → temINVALID. The per-signer cryptographic
+	// verification runs later in verifySignatures.
 	if result := e.preflightMultiSignStructure(tx, common); result != ter.TesSUCCESS {
 		return result
 	}
@@ -100,19 +128,69 @@ func (e *Engine) preflightStructure(tx txcore.Transaction, common *txcore.Common
 		return result
 	}
 
-	// tx-type-specific validation (the per-type preflight body).
-	if err := tx.Validate(); err != nil {
-		return parseValidationError(err)
-	}
+	return ter.TesSUCCESS
+}
 
-	// Rules-dependent preflight checks for tx types that need amendment-gated
-	// tem* validation alongside their rules-free Validate() body.
-	if rp, ok := tx.(txcore.RulesPreflighter); ok {
-		if err := rp.PreflightRules(e.rules()); err != nil {
-			return parseValidationError(err)
+// preflight1 runs rippled Transactor::preflight1 (which invokes preflight0) in
+// its exact order: ticket-amendment → delegate → preflight0 (NetworkID, flags
+// mask) → account → fee → signing-key shape → ticket+AccountTxnID → the
+// outer-only tfInnerBatchTxn rejection (last).
+// Reference: rippled Transactor.cpp preflight1/preflight0.
+func (e *Engine) preflight1(tx txcore.Transaction, common *txcore.Common, rules *amendment.Rules) ter.Result {
+	// A TicketSequence without featureTicketBatch is the first preflight1 check.
+	if result := checkTicketAmendment(common, rules); result != ter.TesSUCCESS {
+		return result
+	}
+	// The delegate check precedes preflight0 (and thus the NetworkID checks).
+	if result := checkDelegate(common, rules); result != ter.TesSUCCESS {
+		return result
+	}
+	// preflight0: NetworkID canonicality then the flags mask.
+	if result := e.preflight0(tx, common, rules); result != ter.TesSUCCESS {
+		return result
+	}
+	// Zero/empty source account.
+	if result := checkAccountPresent(common); result != ter.TesSUCCESS {
+		return result
+	}
+	// Malformed fee — before the signing-key shape check.
+	if result := e.validateFee(common); result != ter.TesSUCCESS {
+		return result
+	}
+	// A non-empty SigningPubKey of an invalid key type.
+	if result := checkSigningKeyShape(common); result != ter.TesSUCCESS {
+		return result
+	}
+	// Sequence presence (go-xrpl defensive) and the ticket+AccountTxnID rule.
+	if result := e.preflightSequence(common); result != ter.TesSUCCESS {
+		return result
+	}
+	// The outer tfInnerBatchTxn rejection is the last preflight1 check.
+	if result := preflightInnerBatchFlag(common, rules); result != ter.TesSUCCESS {
+		return result
+	}
+	return ter.TesSUCCESS
+}
+
+// preflight0 mirrors rippled preflight0 for the regular (non-pseudo) path: the
+// NetworkID canonicality check followed by the flags mask. The pseudo path, the
+// pseudo/tfInnerBatchTxn guard, and the zero-txID guard live elsewhere
+// (pseudoPreflight and ApplyWithContext respectively).
+// Reference: rippled Transactor.cpp preflight0.
+func (e *Engine) preflight0(tx txcore.Transaction, common *txcore.Common, rules *amendment.Rules) ter.Result {
+	if result := e.validateNetworkID(common); result != ter.TesSUCCESS {
+		return result
+	}
+	// Flags mask: a transaction whose flags intersect its type's invalid-flags
+	// mask is temINVALID_FLAG. rippled evaluates this with T::getFlagsMask(ctx).
+	// A type opts in via FlagsMasker; until it does, the per-type flag check in
+	// Validate() is the backstop and the engine applies no mask here (the
+	// universal mask would reject every valid type-specific flag).
+	if fm, ok := tx.(txcore.FlagsMasker); ok {
+		if common.GetFlags()&fm.GetFlagsMask(rules) != 0 {
+			return ter.TemINVALID_FLAG
 		}
 	}
-
 	return ter.TesSUCCESS
 }
 
@@ -124,12 +202,32 @@ type BatchOuter interface {
 	InnerTransactions() []txcore.Transaction
 }
 
+// preflightInner runs the common structural checks for an inner batch tx.
 // Reference: rippled preflight(stx, tapBATCH) invoked from Batch.cpp:303.
-// Fee/signature/multi-sign/inner-flag rejections are skipped here because
-// inner txs have Fee=0, no signature, no multi-signers, and tfInnerBatchTxn
-// set; the corresponding presence checks live in Batch.Validate().
+// Fee/signature/multi-sign/inner-flag rejections are skipped here because inner
+// txs carry Fee=0, no signature, no multi-signers, and tfInnerBatchTxn set (all
+// validated by Batch.Validate()).
 func (e *Engine) preflightInner(innerTx txcore.Transaction) ter.Result {
-	if result := e.preflightCommon(innerTx, innerTx.GetCommon()); result != ter.TesSUCCESS {
+	common := innerTx.GetCommon()
+	rules := e.rules()
+	if result := checkAccountPresent(common); result != ter.TesSUCCESS {
+		return result
+	}
+	if result := e.validateNetworkID(common); result != ter.TesSUCCESS {
+		return result
+	}
+	for _, featureID := range innerTx.RequiredAmendments() {
+		if !rules.Enabled(featureID) {
+			return ter.TemDISABLED
+		}
+	}
+	if result := checkSigningKeyShape(common); result != ter.TesSUCCESS {
+		return result
+	}
+	if result := checkTicketAmendment(common, rules); result != ter.TesSUCCESS {
+		return result
+	}
+	if result := checkDelegate(common, rules); result != ter.TesSUCCESS {
 		return result
 	}
 	if err := innerTx.Validate(); err != nil {
@@ -138,24 +236,13 @@ func (e *Engine) preflightInner(innerTx txcore.Transaction) ter.Result {
 	return ter.TesSUCCESS
 }
 
-// Reference: rippled Transactor.cpp preflight0/early preflight1, plus the
-// outer-only tfInnerBatchTxn rejection on directly-submitted transactions.
-func (e *Engine) preflightCommonFields(tx txcore.Transaction, common *txcore.Common) ter.Result {
-	if result := e.preflightCommon(tx, common); result != ter.TesSUCCESS {
-		return result
-	}
-
-	if result := e.preflightInnerBatchFlag(common); result != ter.TesSUCCESS {
-		return result
-	}
-
-	return ter.TesSUCCESS
-}
-
-// preflightInnerBatchFlag rejects a directly-submitted transaction that carries
-// tfInnerBatchTxn. That flag is only ever set by the Batch transactor on the
-// inner transactions it applies (which flow through preflightInner, not here),
-// so on a top-level submission it is always illegitimate.
+// preflightInnerBatchFlag rejects a transaction reaching the outer preflight
+// that carries tfInnerBatchTxn. That flag is only ever set by the Batch
+// transactor on the inner transactions it applies (which flow through
+// preflightInner, not here), so on the outer path it is always illegitimate. It
+// is the last preflight1 check, so a transaction that is both inner-flagged and
+// malformed in fee/sequence surfaces the earlier code (matching rippled, where
+// this rejection is the final preflight1 check).
 //
 // The rejection code mirrors rippled across the two amendment gates:
 //   - Batch disabled: the flag itself is undefined → temINVALID_FLAG
@@ -166,11 +253,10 @@ func (e *Engine) preflightCommonFields(tx txcore.Transaction, common *txcore.Com
 //     falls through to checkSign → SigBad → temINVALID). Before the fix it
 //     reached the transaction engine and failed with temINVALID_FLAG. Either
 //     way it can never apply.
-func (e *Engine) preflightInnerBatchFlag(common *txcore.Common) ter.Result {
+func preflightInnerBatchFlag(common *txcore.Common, rules *amendment.Rules) ter.Result {
 	if common.Flags == nil || *common.Flags&txcore.TfInnerBatchTxn == 0 {
 		return ter.TesSUCCESS
 	}
-	rules := e.rules()
 	if !rules.Enabled(amendment.FeatureBatch) {
 		return ter.TemINVALID_FLAG
 	}
@@ -180,90 +266,95 @@ func (e *Engine) preflightInnerBatchFlag(common *txcore.Common) ter.Result {
 	return ter.TemINVALID_FLAG
 }
 
-// Shared between outer (preflightCommonFields) and inner (preflightInner).
-// The tfInnerBatchTxn rejection lives only in the outer path because inner
-// txs are required to carry that flag.
-func (e *Engine) preflightCommon(tx txcore.Transaction, common *txcore.Common) ter.Result {
+// checkTicketAmendment rejects a TicketSequence field when featureTicketBatch is
+// not enabled. Reference: rippled Transactor.cpp preflight1 (first check).
+func checkTicketAmendment(common *txcore.Common, rules *amendment.Rules) ter.Result {
+	if common.TicketSequence != nil && !rules.Enabled(amendment.FeatureTicketBatch) {
+		return ter.TemMALFORMED
+	}
+	return ter.TesSUCCESS
+}
+
+// checkDelegate validates the sfDelegate field.
+// Reference: rippled Transactor.cpp preflight1 (delegate block, before preflight0).
+func checkDelegate(common *txcore.Common, rules *amendment.Rules) ter.Result {
+	if common.Delegate == "" {
+		return ter.TesSUCCESS
+	}
+	if !rules.Enabled(amendment.FeaturePermissionDelegation) {
+		return ter.TemDISABLED
+	}
+	if common.Delegate == common.Account {
+		return ter.TemBAD_SIGNER
+	}
+	return ter.TesSUCCESS
+}
+
+// checkAccountPresent rejects a zero/empty source account.
+// Reference: rippled Transactor.cpp preflight1 (id == beast::zero → temBAD_SRC_ACCOUNT).
+func checkAccountPresent(common *txcore.Common) ter.Result {
 	if common.Account == "" {
 		return ter.TemBAD_SRC_ACCOUNT
 	}
 	if common.TransactionType == "" {
 		return ter.TemINVALID
 	}
-
-	if result := e.validateNetworkID(common); result != ter.TesSUCCESS {
-		return result
-	}
-
-	for _, featureID := range tx.RequiredAmendments() {
-		if !e.rules().Enabled(featureID) {
-			return ter.TemDISABLED
-		}
-	}
-
-	// Reject a non-empty SigningPubKey whose key type is invalid, regardless of
-	// whether crypto verification runs. rippled preflight1 does this
-	// unconditionally (Transactor.cpp:129-135 — `!spk.empty() &&
-	// !publicKeyType(makeSlice(spk))` → temBAD_SIGNATURE), so even paths that
-	// skip signature verification (the standalone RPC ingress sets
-	// SkipSignatureVerification) must still bounce a malformed key here.
-	if common.SigningPubKey != "" {
-		spk, decErr := hex.DecodeString(common.SigningPubKey)
-		if decErr != nil || !txcore.IsValidPublicKey(spk) {
-			return ter.TemBAD_SIGNATURE
-		}
-	}
-
-	// Reference: rippled Transactor.cpp preflight1() line 92.
-	if common.TicketSequence != nil && !e.rules().Enabled(amendment.FeatureTicketBatch) {
-		return ter.TemMALFORMED
-	}
-
-	// Reference: rippled Transactor.cpp preflight1() lines 101-108.
-	if common.Delegate != "" {
-		if !e.rules().Enabled(amendment.FeaturePermissionDelegation) {
-			return ter.TemDISABLED
-		}
-		if common.Delegate == common.Account {
-			return ter.TemBAD_SIGNER
-		}
-	}
-
 	return ter.TesSUCCESS
 }
 
-// preflightSequence enforces the Sequence/TicketSequence/AccountTxnID rules
-// from rippled Transactor::preflight1() lines 142-153.
+// checkSigningKeyShape rejects a non-empty SigningPubKey whose key type is
+// invalid, regardless of whether crypto verification runs. rippled preflight1
+// does this unconditionally (preflightCheckSigningKey → temBAD_SIGNATURE), so
+// even paths that skip signature verification must still bounce a malformed key.
+func checkSigningKeyShape(common *txcore.Common) ter.Result {
+	if common.SigningPubKey == "" {
+		return ter.TesSUCCESS
+	}
+	spk, decErr := hex.DecodeString(common.SigningPubKey)
+	if decErr != nil || !txcore.IsValidPublicKey(spk) {
+		return ter.TemBAD_SIGNATURE
+	}
+	return ter.TesSUCCESS
+}
+
+// preflightSequence enforces the ticket+AccountTxnID rule from rippled
+// Transactor::preflight1, plus a go-xrpl-only defensive check that Sequence or
+// TicketSequence is present (rippled relies on the soeREQUIRED sfSequence
+// template field, which cannot be absent from a canonically-serialized tx).
 func (e *Engine) preflightSequence(common *txcore.Common) ter.Result {
-	// Sequence must be present (unless using tickets)
 	if common.Sequence == nil && common.TicketSequence == nil {
 		return ter.TemBAD_SEQUENCE
 	}
 
-	// TicketSequence + AccountTxnID is invalid
-	// Reference: rippled Transactor.cpp preflight1() line 153
-	if common.TicketSequence != nil && common.AccountTxnID != "" {
+	// An AccountTxnID constrains transaction ordering more than Sequence, while
+	// Tickets relax it, so the combination is unsupported — but only when the
+	// transaction actually uses a ticket. rippled gates this on
+	// getSeqProxy().isTicket(), which is true iff the Sequence field is zero (or
+	// absent) AND a TicketSequence is present; a tx with a non-zero Sequence
+	// ignores its TicketSequence entirely, so AccountTxnID is fine.
+	// Reference: rippled Transactor.cpp preflight1() + STTx::getSeqProxy.
+	usesTicket := (common.Sequence == nil || *common.Sequence == 0) && common.TicketSequence != nil
+	if usesTicket && common.AccountTxnID != "" {
 		return ter.TemINVALID
 	}
 
-	// SourceTag validation - if present, it's already a uint32 via JSON parsing
-	// No additional validation needed as the type system ensures it's valid
 	return ter.TesSUCCESS
 }
 
 // preflightMultiSignStructure performs the structural multi-sign validation
-// (sort, uniqueness, self-sign rejection) that runs regardless of
-// SkipSignatureVerification.
-// Reference: rippled STTx.cpp multiSignHelper() lines 468-485
+// (bounds, sort, uniqueness, self-sign rejection). rippled runs these inside
+// STTx::multiSignHelper, reached via checkValidity in preflight2 — AFTER the
+// per-type preflight body — and a violation is Validity::SigBad → temINVALID
+// (NOT temBAD_SIGNATURE, which the submission layer reports separately). It runs
+// regardless of SkipSignatureVerification.
+// Reference: rippled STTx.cpp multiSignHelper() + Transactor::preflight2.
 func (e *Engine) preflightMultiSignStructure(tx txcore.Transaction, common *txcore.Common) ter.Result {
 	if !sign.IsMultiSigned(tx) {
 		return ter.TesSUCCESS
 	}
-	// The signer array must lie within the rules-gated bounds. An out-of-range
-	// array is "Invalid Signers array size" in rippled's multiSignHelper, which
-	// surfaces as temBAD_SIGNATURE at the verification call site.
+	// The signer array must lie within the rules-gated bounds.
 	if n := len(common.Signers); n < sign.MinMultiSigners || n > sign.MaxMultiSigners(e.rules()) {
-		return ter.TemBAD_SIGNATURE
+		return ter.TemINVALID
 	}
 	txAccountID, acctErr := state.DecodeAccountID(common.Account)
 	if acctErr != nil {
@@ -273,19 +364,19 @@ func (e *Engine) preflightMultiSignStructure(tx txcore.Transaction, common *txco
 	for _, sw := range common.Signers {
 		signerID, decErr := state.DecodeAccountID(sw.Signer.Account)
 		if decErr != nil {
-			return ter.TemBAD_SIGNATURE
+			return ter.TemINVALID
 		}
 		// The account owner may not multisign for themselves.
 		if signerID == txAccountID {
-			return ter.TemBAD_SIGNATURE
+			return ter.TemINVALID
 		}
 		// No duplicate signers allowed.
 		if signerID == lastAccountID {
-			return ter.TemBAD_SIGNATURE
+			return ter.TemINVALID
 		}
 		// Accounts must be in order by binary AccountID.
 		if bytes.Compare(lastAccountID[:], signerID[:]) > 0 {
-			return ter.TemBAD_SIGNATURE
+			return ter.TemINVALID
 		}
 		lastAccountID = signerID
 	}
@@ -364,23 +455,18 @@ func (e *Engine) verifyOuterSignature(tx txcore.Transaction) ter.Result {
 	mustBeFullyCanonical := e.rules().RequireFullyCanonicalSigEnabled() ||
 		(tx.GetCommon().GetFlags()&txcore.TfFullyCanonicalSig) != 0
 	if sign.IsMultiSigned(tx) {
-		// Multi-signed transactions require signer list lookup
-		lookup := &sign.EngineSignerListLookup{View: e.view}
-		if err := sign.VerifyMultiSignature(tx, lookup, mustBeFullyCanonical); err != nil {
-			// The typed signer-verification errors carry their own Result code
-			// (ErrNotMultiSigning, ErrBadQuorum, ErrBadSignature, ErrMasterDisabled,
-			// and ErrInternalLookup for a storage/parse failure); honour it.
-			if re, ok := ter.AsResultError(err); ok {
-				return re.Code
-			}
-			// The malformed-signers sentinels are plain errors, all temBAD_SIGNATURE.
-			if errors.Is(err, sign.ErrNoSigners) ||
-				errors.Is(err, sign.ErrDuplicateSigner) ||
-				errors.Is(err, sign.ErrSignersNotSorted) {
-				return ter.TemBAD_SIGNATURE
-			}
-			// Anything else (e.g. a wrapped serialization failure) is a bad sig.
-			return ter.TefBAD_SIGNATURE
+		// Preflight verifies only the multi-sign structure (already checked in
+		// preflightMultiSignStructure) and the per-signer cryptographic
+		// signatures. The view-dependent signer-list authorization — quorum,
+		// master/regular key, and list membership — is a preclaim check
+		// (checkMultiSign), so that an under-quorum multi-signed tx whose
+		// LastLedgerSequence has passed reports tefMAX_LEDGER (from preclaim's
+		// checkPriorTxAndLastLedger) rather than tefBAD_QUORUM. This mirrors
+		// rippled, where STTx::checkMultiSign (preflight2) is crypto-only and
+		// Transactor::checkMultiSign (preclaim) does authorization. A crypto
+		// failure is preflight2's Validity::SigBad → temINVALID.
+		if err := sign.VerifyMultiSignatureCrypto(tx, mustBeFullyCanonical); err != nil {
+			return ter.TemINVALID
 		}
 		return ter.TesSUCCESS
 	}
@@ -533,97 +619,3 @@ func (e *Engine) validateFee(common *txcore.Common) ter.Result {
 	return ter.TesSUCCESS
 }
 
-// validateMemos validates the Memos array according to rippled rules
-func (e *Engine) validateMemos(common *txcore.Common) ter.Result {
-	if len(common.Memos) == 0 {
-		return ter.TesSUCCESS
-	}
-
-	// Calculate total serialized size of memos
-	totalSize := 0
-
-	for _, memoWrapper := range common.Memos {
-		memo := memoWrapper.Memo
-
-		// Validate MemoType if present
-		if memo.MemoType != "" {
-			// MemoType must be a valid hex string
-			memoTypeBytes, err := hex.DecodeString(memo.MemoType)
-			if err != nil {
-				return ter.TemINVALID
-			}
-			// MemoType max size is 256 bytes (decoded)
-			if len(memoTypeBytes) > txcore.MaxMemoTypeSize {
-				return ter.TemINVALID
-			}
-			totalSize += len(memoTypeBytes)
-
-			// MemoType characters (when decoded) must be valid URL characters per RFC 3986
-			if !isValidURLBytes(memoTypeBytes) {
-				return ter.TemINVALID
-			}
-		}
-
-		// Validate MemoData if present
-		if memo.MemoData != "" {
-			// MemoData must be a valid hex string
-			memoDataBytes, err := hex.DecodeString(memo.MemoData)
-			if err != nil {
-				return ter.TemINVALID
-			}
-			// MemoData max size is 1024 bytes (decoded)
-			if len(memoDataBytes) > txcore.MaxMemoDataSize {
-				return ter.TemINVALID
-			}
-			totalSize += len(memoDataBytes)
-			// Note: MemoData can contain any data, no character restrictions
-		}
-
-		// Validate MemoFormat if present
-		if memo.MemoFormat != "" {
-			// MemoFormat must be a valid hex string
-			memoFormatBytes, err := hex.DecodeString(memo.MemoFormat)
-			if err != nil {
-				return ter.TemINVALID
-			}
-			totalSize += len(memoFormatBytes)
-
-			// MemoFormat characters (when decoded) must be valid URL characters per RFC 3986
-			if !isValidURLBytes(memoFormatBytes) {
-				return ter.TemINVALID
-			}
-		}
-	}
-
-	// Total memo size check
-	if totalSize > txcore.MaxMemoSize {
-		return ter.TemINVALID
-	}
-
-	return ter.TesSUCCESS
-}
-
-// isValidURLBytes checks if the bytes contain only characters allowed in URLs per RFC 3986
-// Allowed: alphanumerics and -._~:/?#[]@!$&'()*+,;=%
-func isValidURLBytes(data []byte) bool {
-	for _, b := range data {
-		if !isURLChar(b) {
-			return false
-		}
-	}
-	return true
-}
-
-// isURLChar returns true if the byte is a valid URL character per RFC 3986
-func isURLChar(c byte) bool {
-	// Alphanumerics
-	if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
-		return true
-	}
-	// Special characters allowed in URLs: -._~:/?#[]@!$&'()*+,;=%
-	switch c {
-	case '-', '.', '_', '~', ':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=', '%':
-		return true
-	}
-	return false
-}

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -618,4 +618,3 @@ func (e *Engine) validateFee(common *txcore.Common) ter.Result {
 
 	return ter.TesSUCCESS
 }
-

--- a/internal/tx/engine/preflight_inner_batch_test.go
+++ b/internal/tx/engine/preflight_inner_batch_test.go
@@ -59,8 +59,7 @@ func TestPreflightInnerBatchFlag(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := NewEngine(newMockBaseView(), txcore.EngineConfig{Rules: tt.rules})
-			if got := e.preflightInnerBatchFlag(innerFlaggedTx()); got != tt.want {
+			if got := preflightInnerBatchFlag(innerFlaggedTx(), tt.rules); got != tt.want {
 				t.Fatalf("preflightInnerBatchFlag = %v, want %v", got, tt.want)
 			}
 		})
@@ -71,8 +70,8 @@ func TestPreflightInnerBatchFlag(t *testing.T) {
 // tfInnerBatchTxn) is unaffected by the gate regardless of the amendments.
 func TestPreflightInnerBatchFlag_AbsentFlag(t *testing.T) {
 	tx := txcore.NewBaseTx(txcore.TypePayment, precedenceSourceAddr)
-	e := NewEngine(newMockBaseView(), txcore.EngineConfig{Rules: batchRules("Batch", "fixBatchInnerSigs")})
-	if got := e.preflightInnerBatchFlag(tx.GetCommon()); got != ter.TesSUCCESS {
+	rules := batchRules("Batch", "fixBatchInnerSigs")
+	if got := preflightInnerBatchFlag(tx.GetCommon(), rules); got != ter.TesSUCCESS {
 		t.Fatalf("preflightInnerBatchFlag(no flag) = %v, want TesSUCCESS", got)
 	}
 }

--- a/internal/tx/engine/preflight_precedence_test.go
+++ b/internal/tx/engine/preflight_precedence_test.go
@@ -1,0 +1,298 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+// preflightEngine builds an engine over an empty mock view with the given rules
+// and signature verification skipped, so a structurally clean transaction runs
+// the full preflight ordering and returns tesSUCCESS. Every precedence test
+// below asserts the TER a specific field combination surfaces, which is fixed by
+// the pre-signature preflight order regardless of the (absent) signature.
+func preflightEngine(rules *amendment.Rules) *Engine {
+	return NewEngine(newMockBaseView(), txcore.EngineConfig{
+		BaseFee:                   10,
+		LedgerSequence:            100,
+		Rules:                     rules,
+		SkipSignatureVerification: true,
+	})
+}
+
+func allRules() *amendment.Rules { return amendment.AllSupportedRules() }
+
+func rulesWithout(name string) *amendment.Rules {
+	return amendment.NewRulesBuilder().FromPreset(amendment.PresetAllSupported).DisableByName(name).Build()
+}
+
+// --- test transaction types exercising the engine preflight seams ---
+
+// flagMaskTx adopts FlagsMasker with a fixed invalid-flags mask.
+type flagMaskTx struct {
+	*txcore.BaseTx
+	mask uint32
+}
+
+func (t *flagMaskTx) GetFlagsMask(*amendment.Rules) uint32 { return t.mask }
+
+// extraFeaturesTx adopts ExtraFeaturesChecker with a fixed verdict.
+type extraFeaturesTx struct {
+	*txcore.BaseTx
+	err error
+}
+
+func (t *extraFeaturesTx) CheckExtraFeatures(*amendment.Rules) error { return t.err }
+
+// reqAmendmentTx overrides RequiredAmendments (the macro amendment gate).
+type reqAmendmentTx struct {
+	*txcore.BaseTx
+	amendments [][32]byte
+}
+
+func (t *reqAmendmentTx) RequiredAmendments() [][32]byte { return t.amendments }
+
+func newAccountSet(account string) *txcore.BaseTx {
+	tx := txcore.NewBaseTx(txcore.TypeAccountSet, account)
+	tx.Fee = "10"
+	tx.Sequence = u32(5)
+	return tx
+}
+
+// TestPreflightPrecedence_DelegateBeforeNetworkID pins finding E-delegate: the
+// sfDelegate checks precede preflight0's NetworkID checks, so a delegate error
+// wins over telNETWORK_ID_MAKES_TX_NON_CANONICAL.
+func TestPreflightPrecedence_DelegateBeforeNetworkID(t *testing.T) {
+	t.Run("delegate==account beats NetworkID", func(t *testing.T) {
+		e := preflightEngine(batchRules("PermissionDelegation"))
+		tx := newAccountSet(precedenceSourceAddr)
+		tx.Delegate = precedenceSourceAddr // == Account → temBAD_SIGNER
+		tx.NetworkID = u32(99)             // legacy node (ID 0) forbids the field
+		if got := e.preflight(tx); got != ter.TemBAD_SIGNER {
+			t.Fatalf("preflight = %v, want TemBAD_SIGNER", got)
+		}
+	})
+
+	t.Run("delegate-disabled beats NetworkID", func(t *testing.T) {
+		e := preflightEngine(allRules()) // PermissionDelegation is Supported::no → disabled
+		tx := newAccountSet(precedenceSourceAddr)
+		tx.Delegate = precedenceGenesisAddr // present, PermissionDelegation off → temDISABLED
+		tx.NetworkID = u32(99)
+		if got := e.preflight(tx); got != ter.TemDISABLED {
+			t.Fatalf("preflight = %v, want TemDISABLED", got)
+		}
+	})
+}
+
+// TestPreflightPrecedence_TicketAmendmentFirst pins finding E-ticket: the
+// TicketSequence-without-featureTicketBatch temMALFORMED is the first preflight1
+// check, ahead of NetworkID and the signing-key shape check.
+func TestPreflightPrecedence_TicketAmendmentFirst(t *testing.T) {
+	e := preflightEngine(rulesWithout("TicketBatch"))
+
+	t.Run("ticket-amendment beats NetworkID", func(t *testing.T) {
+		tx := txcore.NewBaseTx(txcore.TypeAccountSet, precedenceSourceAddr)
+		tx.Fee = "10"
+		tx.TicketSequence = u32(7)
+		tx.NetworkID = u32(99)
+		if got := e.preflight(tx); got != ter.TemMALFORMED {
+			t.Fatalf("preflight = %v, want TemMALFORMED", got)
+		}
+	})
+
+	t.Run("ticket-amendment beats bad signing key", func(t *testing.T) {
+		tx := txcore.NewBaseTx(txcore.TypeAccountSet, precedenceSourceAddr)
+		tx.Fee = "10"
+		tx.TicketSequence = u32(7)
+		tx.SigningPubKey = "00" // invalid key type → temBAD_SIGNATURE if reached
+		if got := e.preflight(tx); got != ter.TemMALFORMED {
+			t.Fatalf("preflight = %v, want TemMALFORMED", got)
+		}
+	})
+}
+
+// TestPreflightPrecedence_NetworkIDBeforeAccount pins finding E-account: the
+// NetworkID checks (preflight0) run before the zero-account check (preflight1),
+// so a NetworkID violation wins over temBAD_SRC_ACCOUNT.
+func TestPreflightPrecedence_NetworkIDBeforeAccount(t *testing.T) {
+	e := preflightEngine(allRules())
+	tx := txcore.NewBaseTx(txcore.TypeAccountSet, "") // empty account
+	tx.Fee = "10"
+	tx.Sequence = u32(5)
+	tx.NetworkID = u32(99) // legacy node forbids the field → tel*
+	if got := e.preflight(tx); got != ter.TelNETWORK_ID_MAKES_TX_NON_CANONICAL {
+		t.Fatalf("preflight = %v, want TelNETWORK_ID_MAKES_TX_NON_CANONICAL", got)
+	}
+}
+
+// TestPreflightPrecedence_AccountBeforeFee pins that the zero-account check
+// precedes the fee check (rippled preflight1 order account → fee).
+func TestPreflightPrecedence_AccountBeforeFee(t *testing.T) {
+	e := preflightEngine(allRules())
+	tx := txcore.NewBaseTx(txcore.TypeAccountSet, "") // empty account
+	tx.Fee = "-10"                                    // malformed fee, not reached
+	tx.Sequence = u32(5)
+	if got := e.preflight(tx); got != ter.TemBAD_SRC_ACCOUNT {
+		t.Fatalf("preflight = %v, want TemBAD_SRC_ACCOUNT", got)
+	}
+}
+
+// TestPreflightPrecedence_FeeBeforeSigningKey pins finding E-fee: the fee check
+// precedes the signing-key shape check, so a malformed fee wins over
+// temBAD_SIGNATURE.
+func TestPreflightPrecedence_FeeBeforeSigningKey(t *testing.T) {
+	e := preflightEngine(allRules())
+	tx := txcore.NewBaseTx(txcore.TypeAccountSet, precedenceSourceAddr)
+	tx.Fee = "-10"          // malformed fee → temBAD_FEE
+	tx.Sequence = u32(5)
+	tx.SigningPubKey = "00" // invalid key type → temBAD_SIGNATURE if reached
+	if got := e.preflight(tx); got != ter.TemBAD_FEE {
+		t.Fatalf("preflight = %v, want TemBAD_FEE", got)
+	}
+}
+
+// TestPreflightPrecedence_TicketAccountTxnID pins finding E-seqproxy: the
+// ticket+AccountTxnID temINVALID fires only when getSeqProxy().isTicket(), i.e.
+// Sequence is zero/absent. A tx with a real Sequence ignores its TicketSequence.
+func TestPreflightPrecedence_TicketAccountTxnID(t *testing.T) {
+	const txnID = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
+	e := preflightEngine(allRules())
+
+	t.Run("nonzero Sequence with TicketSequence+AccountTxnID passes", func(t *testing.T) {
+		tx := txcore.NewBaseTx(txcore.TypeAccountSet, precedenceSourceAddr)
+		tx.Fee = "10"
+		tx.Sequence = u32(5) // real sequence → ticket ignored → AccountTxnID allowed
+		tx.TicketSequence = u32(7)
+		tx.AccountTxnID = txnID
+		if got := e.preflight(tx); got != ter.TesSUCCESS {
+			t.Fatalf("preflight = %v, want TesSUCCESS", got)
+		}
+	})
+
+	t.Run("zero Sequence with TicketSequence+AccountTxnID is temINVALID", func(t *testing.T) {
+		tx := txcore.NewBaseTx(txcore.TypeAccountSet, precedenceSourceAddr)
+		tx.Fee = "10"
+		tx.Sequence = u32(0) // zero → getSeqProxy().isTicket() true
+		tx.TicketSequence = u32(7)
+		tx.AccountTxnID = txnID
+		if got := e.preflight(tx); got != ter.TemINVALID {
+			t.Fatalf("preflight = %v, want TemINVALID", got)
+		}
+	})
+
+	t.Run("ticket-only with AccountTxnID is temINVALID", func(t *testing.T) {
+		tx := txcore.NewBaseTx(txcore.TypeAccountSet, precedenceSourceAddr)
+		tx.Fee = "10"
+		tx.TicketSequence = u32(7) // Sequence absent → isTicket() true
+		tx.AccountTxnID = txnID
+		if got := e.preflight(tx); got != ter.TemINVALID {
+			t.Fatalf("preflight = %v, want TemINVALID", got)
+		}
+	})
+}
+
+// TestPreflightPrecedence_InnerBatchFlagLast pins finding E-innerbatch: the
+// outer tfInnerBatchTxn rejection is the last preflight1 check, so a malformed
+// fee (Batch disabled) wins over temINVALID_FLAG.
+func TestPreflightPrecedence_InnerBatchFlagLast(t *testing.T) {
+	e := preflightEngine(allRules()) // Batch is Supported::no → disabled
+	tx := txcore.NewBaseTx(txcore.TypeAccountSet, precedenceSourceAddr)
+	tx.Fee = "-10" // malformed fee → temBAD_FEE
+	tx.Sequence = u32(5)
+	flags := txcore.TfInnerBatchTxn
+	tx.Flags = &flags
+	if got := e.preflight(tx); got != ter.TemBAD_FEE {
+		t.Fatalf("preflight = %v, want TemBAD_FEE", got)
+	}
+}
+
+// TestPreflightPrecedence_MacroGateBeforeNetworkID pins finding E1: the
+// transactions.macro amendment gate (RequiredAmendments) is the first
+// invokePreflight check, ahead of preflight0's NetworkID checks.
+func TestPreflightPrecedence_MacroGateBeforeNetworkID(t *testing.T) {
+	e := preflightEngine(allRules()) // Batch disabled
+	tx := &reqAmendmentTx{
+		BaseTx:     newAccountSet(precedenceSourceAddr),
+		amendments: [][32]byte{amendment.FeatureBatch},
+	}
+	tx.NetworkID = u32(99) // legacy node forbids the field → tel* if reached
+	if got := e.preflight(tx); got != ter.TemDISABLED {
+		t.Fatalf("preflight = %v, want TemDISABLED", got)
+	}
+}
+
+// TestPreflightMechanism_FlagsMasker pins the FlagsMasker seam: a type that
+// adopts it is rejected temINVALID_FLAG when its flags intersect the mask, and
+// only then; a type that does not adopt it gets no engine-level flag rejection.
+func TestPreflightMechanism_FlagsMasker(t *testing.T) {
+	e := preflightEngine(allRules())
+
+	t.Run("flag in mask is rejected", func(t *testing.T) {
+		bit := uint32(0x00010000)
+		base := newAccountSet(precedenceSourceAddr)
+		base.Flags = &bit
+		tx := &flagMaskTx{BaseTx: base, mask: bit}
+		if got := e.preflight(tx); got != ter.TemINVALID_FLAG {
+			t.Fatalf("preflight = %v, want TemINVALID_FLAG", got)
+		}
+	})
+
+	t.Run("flag outside mask passes", func(t *testing.T) {
+		other := uint32(0x00020000)
+		base := newAccountSet(precedenceSourceAddr)
+		base.Flags = &other
+		tx := &flagMaskTx{BaseTx: base, mask: 0x00010000}
+		if got := e.preflight(tx); got != ter.TesSUCCESS {
+			t.Fatalf("preflight = %v, want TesSUCCESS", got)
+		}
+	})
+
+	t.Run("type without FlagsMasker gets no engine flag check", func(t *testing.T) {
+		bit := uint32(0x00010000) // a non-universal flag the engine must not reject on its own
+		base := newAccountSet(precedenceSourceAddr)
+		base.Flags = &bit
+		if got := e.preflight(base); got != ter.TesSUCCESS {
+			t.Fatalf("preflight = %v, want TesSUCCESS", got)
+		}
+	})
+}
+
+// TestPreflight_AcceptsOversizedMemo pins the memo relocation: the engine
+// preflight no longer validates memos, so an oversized-memo transaction that
+// would be refused at local submission (PassesLocalChecks) still passes
+// preflight and can be applied. This is what prevents a memo-violating tx in an
+// agreed tx set from forking the ledger.
+func TestPreflight_AcceptsOversizedMemo(t *testing.T) {
+	e := preflightEngine(allRules())
+	tx := newAccountSet(precedenceSourceAddr)
+	tx.Memos = []txcore.MemoWrapper{{Memo: txcore.Memo{MemoData: strings.Repeat("AA", 1100)}}}
+	if got := e.preflight(tx); got != ter.TesSUCCESS {
+		t.Fatalf("preflight(oversized memo) = %v, want TesSUCCESS", got)
+	}
+}
+
+// TestPreflightMechanism_ExtraFeatures pins the ExtraFeaturesChecker seam: it
+// runs before the common checks, so a temDISABLED verdict wins over a malformed
+// fee; a nil verdict does not disturb an otherwise-clean transaction.
+func TestPreflightMechanism_ExtraFeatures(t *testing.T) {
+	e := preflightEngine(allRules())
+
+	t.Run("extra-features verdict beats bad fee", func(t *testing.T) {
+		base := newAccountSet(precedenceSourceAddr)
+		base.Fee = "-10" // malformed fee, not reached
+		tx := &extraFeaturesTx{BaseTx: base, err: ter.Errorf(ter.TemDISABLED, "feature disabled")}
+		if got := e.preflight(tx); got != ter.TemDISABLED {
+			t.Fatalf("preflight = %v, want TemDISABLED", got)
+		}
+	})
+
+	t.Run("nil verdict passes", func(t *testing.T) {
+		tx := &extraFeaturesTx{BaseTx: newAccountSet(precedenceSourceAddr), err: nil}
+		if got := e.preflight(tx); got != ter.TesSUCCESS {
+			t.Fatalf("preflight = %v, want TesSUCCESS", got)
+		}
+	})
+}

--- a/internal/tx/engine/preflight_precedence_test.go
+++ b/internal/tx/engine/preflight_precedence_test.go
@@ -146,7 +146,7 @@ func TestPreflightPrecedence_AccountBeforeFee(t *testing.T) {
 func TestPreflightPrecedence_FeeBeforeSigningKey(t *testing.T) {
 	e := preflightEngine(allRules())
 	tx := txcore.NewBaseTx(txcore.TypeAccountSet, precedenceSourceAddr)
-	tx.Fee = "-10"          // malformed fee → temBAD_FEE
+	tx.Fee = "-10" // malformed fee → temBAD_FEE
 	tx.Sequence = u32(5)
 	tx.SigningPubKey = "00" // invalid key type → temBAD_SIGNATURE if reached
 	if got := e.preflight(tx); got != ter.TemBAD_FEE {

--- a/internal/tx/engine_config.go
+++ b/internal/tx/engine_config.go
@@ -15,15 +15,6 @@ import (
 
 // Validation constants matching rippled
 const (
-	// MaxMemoSize is the maximum total serialized size of memos (in bytes)
-	MaxMemoSize = 1024
-
-	// MaxMemoTypeSize is the maximum size of MemoType field (in bytes)
-	MaxMemoTypeSize = 256
-
-	// MaxMemoDataSize is the maximum size of MemoData field (in bytes)
-	MaxMemoDataSize = 1024
-
 	// LegacyNetworkIDThreshold is the threshold for legacy network IDs
 	// Networks with ID <= this value are legacy networks
 	LegacyNetworkIDThreshold = 1024

--- a/internal/tx/local_checks.go
+++ b/internal/tx/local_checks.go
@@ -1,0 +1,118 @@
+package tx
+
+import (
+	"encoding/hex"
+	"reflect"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+// MaxSerializedMemosSize is the maximum serialized length of a transaction's
+// Memos array. rippled isMemoOkay serializes the array with per-object field
+// headers and end markers and rejects it above 1024 bytes; there are no
+// per-field size caps. Reference: rippled STTx.cpp isMemoOkay.
+const MaxSerializedMemosSize = 1024
+
+// PassesLocalChecks runs the submission-only validation rippled performs in
+// STTx::passesLocalChecks (invoked from NetworkOPs at the ingress), NOT in the
+// consensus-critical preflight. It must be applied only on the local submission
+// path: a relayed or consensus-applied transaction carrying the same memo still
+// applies, because rippled treats a memo violation as a local, non-TER refusal
+// (Validity::SigGoodOnly), which the engine preflight accepts. Applying it in
+// preflight would exclude a memo-violating transaction from an agreed tx set
+// that rippled applies with tesSUCCESS — a ledger fork.
+//
+// It returns TemMALFORMED on any violation, matching rippled's rejection of a
+// locally-submitted transaction that fails passesLocalChecks.
+func PassesLocalChecks(common *Common) ter.Result {
+	return validateMemosLocal(common)
+}
+
+// validateMemosLocal mirrors rippled isMemoOkay: the whole Memos array must
+// serialize to at most 1024 bytes (field headers included), every present
+// MemoType/MemoData/MemoFormat field must be valid hex, and the decoded
+// MemoType/MemoFormat bytes may contain only RFC 3986 URL characters (MemoData
+// is unrestricted). There are no per-field size caps.
+func validateMemosLocal(common *Common) ter.Result {
+	if len(common.Memos) == 0 {
+		return ter.TesSUCCESS
+	}
+
+	serializedLen, err := serializedMemosLength(common.Memos)
+	if err != nil {
+		return ter.TemMALFORMED
+	}
+	if serializedLen > MaxSerializedMemosSize {
+		return ter.TemMALFORMED
+	}
+
+	for _, memoWrapper := range common.Memos {
+		memo := memoWrapper.Memo
+		// MemoType and MemoFormat are URL-charset-restricted; MemoData is not.
+		if !memoHexFieldOkay(memo.MemoType, true) ||
+			!memoHexFieldOkay(memo.MemoData, false) ||
+			!memoHexFieldOkay(memo.MemoFormat, true) {
+			return ter.TemMALFORMED
+		}
+	}
+
+	return ter.TesSUCCESS
+}
+
+// memoHexFieldOkay reports whether a memo field is absent, or is valid hex whose
+// decoded bytes satisfy the RFC 3986 URL charset when urlRestricted is set.
+func memoHexFieldOkay(value string, urlRestricted bool) bool {
+	if value == "" {
+		return true
+	}
+	decoded, err := hex.DecodeString(value)
+	if err != nil {
+		return false
+	}
+	if urlRestricted && !isValidURLBytes(decoded) {
+		return false
+	}
+	return true
+}
+
+// serializedMemosLength returns the serialized length of the Memos array
+// excluding the sfMemos field header and the array end marker, matching
+// rippled's `Serializer s; memos.add(s); s.getDataLength()`. It measures the
+// overhead by encoding an empty array with the same field so the header and end
+// marker cancel out, leaving only the array contents.
+func serializedMemosLength(memos []MemoWrapper) (int, error) {
+	arr := flattenStructSlice(reflect.ValueOf(memos))
+	full, err := binarycodec.EncodeBytes(map[string]any{"Memos": arr})
+	if err != nil {
+		return 0, err
+	}
+	overhead, err := binarycodec.EncodeBytes(map[string]any{"Memos": []map[string]any{}})
+	if err != nil {
+		return 0, err
+	}
+	return len(full) - len(overhead), nil
+}
+
+// isValidURLBytes reports whether every byte is allowed in URLs per RFC 3986:
+// alphanumerics and -._~:/?#[]@!$&'()*+,;=%
+func isValidURLBytes(data []byte) bool {
+	for _, b := range data {
+		if !isURLChar(b) {
+			return false
+		}
+	}
+	return true
+}
+
+// isURLChar reports whether the byte is a valid URL character per RFC 3986.
+func isURLChar(c byte) bool {
+	if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+		return true
+	}
+	switch c {
+	case '-', '.', '_', '~', ':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=', '%':
+		return true
+	}
+	return false
+}

--- a/internal/tx/local_checks_test.go
+++ b/internal/tx/local_checks_test.go
@@ -1,0 +1,82 @@
+package tx
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+func memoCommon(memos ...Memo) *Common {
+	wrapped := make([]MemoWrapper, len(memos))
+	for i, m := range memos {
+		wrapped[i] = MemoWrapper{Memo: m}
+	}
+	return &Common{Account: "rMRxj8jED6ZCjtjgFxB4cz1MGVNtYqCEyS", Memos: wrapped}
+}
+
+// TestPassesLocalChecks_MemoSize pins the rippled isMemoOkay boundary: the whole
+// Memos array serialized (headers included, per-object end markers, but not the
+// sfMemos field header or array end marker) must be <= 1024 bytes. A MemoData of
+// 1019 bytes serializes to exactly 1024; 1020 bytes to 1025.
+func TestPassesLocalChecks_MemoSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		dataBytes int
+		want      ter.Result
+	}{
+		{"at the 1024-byte boundary", 1019, ter.TesSUCCESS},
+		{"one byte over the boundary", 1020, ter.TemMALFORMED},
+		{"well under the boundary", 100, ter.TesSUCCESS},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common := memoCommon(Memo{MemoData: strings.Repeat("AA", tt.dataBytes)})
+			if got := PassesLocalChecks(common); got != tt.want {
+				t.Fatalf("PassesLocalChecks = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPassesLocalChecks_MemoFields pins the per-field hex and charset rules:
+// every field must be valid hex, and the decoded MemoType/MemoFormat bytes must
+// be RFC 3986 URL characters — MemoData is unrestricted. There are no per-field
+// size caps.
+func TestPassesLocalChecks_MemoFields(t *testing.T) {
+	tests := []struct {
+		name string
+		memo Memo
+		want ter.Result
+	}{
+		{"no memos", Memo{}, ter.TesSUCCESS},
+		{"valid hex fields", Memo{MemoType: "41", MemoData: "42", MemoFormat: "43"}, ter.TesSUCCESS},
+		{"MemoType not hex", Memo{MemoType: "GG"}, ter.TemMALFORMED},
+		{"MemoData not hex", Memo{MemoData: "XY"}, ter.TemMALFORMED},
+		{"MemoFormat not hex", Memo{MemoFormat: "ZZ"}, ter.TemMALFORMED},
+		// 0x01 is a valid byte but not an RFC 3986 URL character.
+		{"MemoType non-URL char", Memo{MemoType: "01"}, ter.TemMALFORMED},
+		{"MemoFormat non-URL char", Memo{MemoFormat: "01"}, ter.TemMALFORMED},
+		// MemoData may hold arbitrary bytes, including non-URL characters.
+		{"MemoData non-URL char", Memo{MemoData: "01"}, ter.TesSUCCESS},
+		// No per-field cap: a MemoType larger than the retired 256-byte cap is
+		// fine as long as the whole array fits in 1024 serialized bytes and it is
+		// valid hex of URL characters ('A' = 0x41).
+		{"large MemoType within array budget", Memo{MemoType: strings.Repeat("41", 300)}, ter.TesSUCCESS},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			common := memoCommon(tt.memo)
+			if got := PassesLocalChecks(common); got != tt.want {
+				t.Fatalf("PassesLocalChecks = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPassesLocalChecks_NoMemos confirms a transaction without memos passes.
+func TestPassesLocalChecks_NoMemos(t *testing.T) {
+	if got := PassesLocalChecks(&Common{Account: "rMRxj8jED6ZCjtjgFxB4cz1MGVNtYqCEyS"}); got != ter.TesSUCCESS {
+		t.Fatalf("PassesLocalChecks(no memos) = %v, want TesSUCCESS", got)
+	}
+}

--- a/internal/tx/sign/signature.go
+++ b/internal/tx/sign/signature.go
@@ -328,6 +328,53 @@ func VerifyMultiSignature(tx txcore.Transaction, lookup SignerListLookup, mustBe
 	return nil
 }
 
+// VerifyMultiSignatureCrypto verifies only the per-signer cryptographic
+// signatures of a multi-signed transaction. Unlike VerifyMultiSignature it does
+// NOT consult the ledger signer list, quorum, or per-signer key authorization —
+// those are view-dependent preclaim checks (rippled Transactor::checkMultiSign).
+// It mirrors rippled STTx::checkMultiSign, which is reached from preflight2 and
+// is crypto-only. The structural rules (bounds, sorted, unique, no self-sign)
+// are enforced separately before this runs, so any error here is preflight2's
+// Validity::SigBad, which the caller maps to temINVALID.
+func VerifyMultiSignatureCrypto(tx txcore.Transaction, mustBeFullyCanonical bool) error {
+	common := tx.GetCommon()
+
+	if !IsMultiSigned(tx) {
+		if common.TxnSignature != "" {
+			return VerifySignature(tx, mustBeFullyCanonical)
+		}
+		return ErrMissingSignature
+	}
+	if len(common.Signers) == 0 {
+		return ErrNoSigners
+	}
+
+	txMap, err := tx.Flatten()
+	if err != nil {
+		return fmt.Errorf("failed to flatten transaction: %w", err)
+	}
+
+	for _, signerWrapper := range common.Signers {
+		signer := signerWrapper.Signer
+		if signer.SigningPubKey == "" {
+			return ErrBadSignature
+		}
+		pubKeyBytes, decErr := hex.DecodeString(signer.SigningPubKey)
+		if decErr != nil || len(pubKeyBytes) == 0 {
+			return ErrBadSignature
+		}
+		signingPayload, encErr := binarycodec.EncodeForMultisigning(copyMap(txMap), signer.Account)
+		if encErr != nil {
+			return fmt.Errorf("failed to encode for multi-signing: %w", encErr)
+		}
+		if !verifySignatureForKey(signingPayload, signer.SigningPubKey, signer.TxnSignature, mustBeFullyCanonical) {
+			return ErrBadSignature
+		}
+	}
+
+	return nil
+}
+
 // counterpartyPrefix labels every error surfaced from the nested
 // CounterpartySignature check, matching rippled's "Counterparty: " prefix.
 const counterpartyPrefix = "Counterparty: "

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -56,9 +56,41 @@ type Appliable interface {
 // body. The engine runs PreflightRules right after Validate(), so these checks
 // reject (with a tem* code and no fee) at the correct pipeline stage, before any
 // ledger-state preclaim runs — matching rippled where rules-gated tem* checks
-// are interleaved into the transactor's preflight().
+// are interleaved into the transactor's per-type preflight() body (T::preflight).
 type RulesPreflighter interface {
 	PreflightRules(rules *amendment.Rules) error
+}
+
+// ExtraFeaturesChecker is implemented by transaction types with an amendment
+// gate that rippled evaluates in T::checkExtraFeatures — which runs in
+// invokePreflight BEFORE preflight1's common checks (flags mask, NetworkID,
+// account, fee, signing key). The engine runs it first so an amendment-gated
+// rejection (e.g. CreateOffer carrying sfDomainID under a disabled
+// PermissionedDEX → temDISABLED) precedes any common-field TER. A non-nil error
+// should carry a temDISABLED-class code via ter.Errorf.
+//
+// This is the engine seam; no transaction type adopts it yet. A type opts in by
+// implementing it and moving the corresponding amendment gate out of its
+// Validate()/PreflightRules body. Reference: rippled Transactor.h invokePreflight.
+type ExtraFeaturesChecker interface {
+	CheckExtraFeatures(rules *amendment.Rules) error
+}
+
+// FlagsMasker is implemented by transaction types that declare the set of flag
+// bits that are invalid for the type. The engine rejects a transaction whose
+// flags intersect the mask with temINVALID_FLAG at the preflight0 position,
+// mirroring rippled preflight0's `tx.getFlags() & T::getFlagsMask(ctx)`. The
+// mask may depend on the active amendments (e.g. a flag valid only once an
+// amendment is enabled).
+//
+// This is the engine seam; no transaction type adopts it yet. A type that does
+// not implement it keeps its per-Validate() flag check as the backstop — the
+// engine applies no mask, because the universal mask would reject every valid
+// type-specific flag (tfPartialPayment, tfPassive, …). A type opts in by
+// implementing GetFlagsMask (typically `tfUniversalMask | typeSpecificBits`) and
+// dropping the equivalent flag check from Validate().
+type FlagsMasker interface {
+	GetFlagsMask(rules *amendment.Rules) uint32
 }
 
 // Preclaimer is implemented by transaction types that need additional


### PR DESCRIPTION
Reorders the engine's stateless preflight to match rippled 3.1.0's
`Transactor::invokePreflight<T>` exactly, so a transaction that violates several
rules surfaces the *same* TER rippled would, and introduces the central
flags-mask / extra-features engine seams. This is the engine portion of a
30-agent adversarially-verified audit of preflight TER precedence.

Canonical order converged on (verified against rippled `Transactor.cpp` @ tag 3.1.0):

```
invokePreflight:
  macro amendment gate (RequiredAmendments)  -> temDISABLED
  T::checkExtraFeatures                       -> temDISABLED
  preflight1:
    ticket-amendment (TicketSequence, !TicketBatch)  -> temMALFORMED
    delegate (!PermissionDelegation / ==Account)     -> temDISABLED / temBAD_SIGNER
    preflight0: NetworkID (tel*) -> flags mask (temINVALID_FLAG)
    account -> temBAD_SRC_ACCOUNT
    fee     -> temBAD_FEE
    signing-key shape -> temBAD_SIGNATURE
    ticket+AccountTxnID (only when getSeqProxy().isTicket()) -> temINVALID
    tfInnerBatchTxn (outer, last)             -> temINVALID_FLAG
  T::preflight (Validate + RulesPreflighter)
  preflight2: multi-sign structural (SigBad -> temINVALID) -> crypto verify
```

## Per-finding disposition

| # | Sev | Finding | Fork scenario | Disposition |
|---|-----|---------|---------------|-------------|
| 1 | high | sfDelegate checks ran *after* NetworkID/account/fee | Delegate==Account + sfNetworkID on a mainnet node: rippled temBAD_SIGNER, go-xrpl tel* | **Fixed** — `checkDelegate` before `preflight0`. Pinned. |
| 2 | high | Memo rules in consensus preflight (temINVALID), decoded-sum size + per-field caps | serialized-memo>1024 tx in an agreed tx set: rippled tesSUCCESS applies, go-xrpl temINVALID excludes → ledger fork | **Fixed** — relocated to the local submit ingress (`Service.SubmitTransaction`, temMALFORMED); rule now serialized-length≤1024, no per-field caps, hex + RFC3986. Engine preflight is memo-agnostic. Pinned (unit + service reject + engine accept). |
| 3 | high | ticket+AccountTxnID rejected regardless of Sequence | {Sequence:5, TicketSequence:7, AccountTxnID}: rippled tesSUCCESS, go-xrpl temINVALID | **Fixed** — gated on `getSeqProxy().isTicket()` (Sequence 0/absent). Pinned. |
| 4 | med | signing-key shape checked before fee | Fee="-10" + invalid SigningPubKey: rippled temBAD_FEE, go-xrpl temBAD_SIGNATURE | **Fixed** — `validateFee` before `checkSigningKeyShape`. Pinned. |
| 5 | med | account checked before NetworkID | zero account + sfNetworkID: rippled tel*, go-xrpl temBAD_SRC_ACCOUNT | **Fixed** — `preflight0` (NetworkID) before `checkAccountPresent`. Pinned. |
| 6 | med | multi-sign structural failures returned temBAD_SIGNATURE, before Validate | redundant multi-signed OfferCreate w/ unsorted signers: rippled temREDUNDANT, go-xrpl temBAD_SIGNATURE | **Fixed** — structural checks moved after Validate, now temINVALID (rippled `multiSignHelper` SigBad). Pinned; two existing assertions updated temBAD_SIGNATURE→temINVALID. |
| 7 | high | signer-list authorization done in preflight (view-dependent) | under-quorum multi-sign whose LastLedgerSequence passed: rippled tefMAX_LEDGER, go-xrpl tefBAD_QUORUM | **Fixed** — preflight is now crypto-only (`VerifyMultiSignatureCrypto`); authorization stays in preclaim `checkMultiSign`, already positioned after checkSeqProxy/checkPriorTxAndLastLedger, before checkFee (matches rippled 3.1.0 post-#6192, landed by #1262). |
| 8 | med | checkExtraFeatures (e.g. OfferCreate DomainID temDISABLED) ran after common checks | DomainID + PermissionedDEX-disabled + TakerGets==TakerPays: rippled temDISABLED, go-xrpl temREDUNDANT | **Mechanism wired** — `ExtraFeaturesChecker` hook runs before preflight1. No tx adopts it here (family PRs migrate each type). Pinned (mechanism). |
| 9 | med | outer tfInnerBatchTxn rejected first + unconditionally | tfInnerBatchTxn + Fee="-10", Batch disabled: rippled temBAD_FEE, go-xrpl temINVALID_FLAG | **Positional fix** — moved to the last preflight1 check. Batch-enabled rejection behaviour kept deliberately (see Deviations). Pinned. |
| 10 | low | TicketSequence-without-TicketBatch checked late | TicketSequence + invalid SigningPubKey, TicketBatch disabled: rippled temMALFORMED, go-xrpl temBAD_SIGNATURE | **Fixed** — first preflight1 check. Pinned. |
| 11 | low | zero-txID temINVALID guard runs post-signature | none (SHA512-half==0 is cryptographically unreachable) | **Moot** — guard stays in `ApplyWithContext` (the earliest point the id is known); documented. |
| 12 | low | no tapDRY_RUN simulate-keys guards | simulate-RPC only, never consensus | **Moot** — no simulate path exists; documented for when one is added. |
| 13 | low | temBAD_SEQUENCE / temBAD_FEE on absent required fields | JSON ingress only; cannot be canonically serialized into a tx set | **Kept** as defense-in-depth (finding rated acceptable); documented. |
| — | — | **FlagsMasker seam** (E2) | — | **Mechanism wired** — `FlagsMasker` checked at the preflight0 flags-mask position. No tx adopts it here. Pinned. |

## Deviations, justified

- **FlagsMasker default is a no-op, not the universal mask.** Applying `tfUniversalMask` to every not-yet-adopting tx type at preflight0 would reject *every* valid type-specific flag (tfPartialPayment, tfPassive, tfSetfAuth, …), because in rippled only flag-less tx types fall through to the base `getFlagsMask`; every flag-bearing type overrides it. Since no tx type adopts the interface in this PR and the instruction is to keep per-tx `Validate` flag checks as the backstop, the engine applies **no** mask unless a type implements `FlagsMasker`. Adoption is one method per type (`GetFlagsMask` returns `tfUniversalMask | typeBits`, drop the Validate check). Pinned by `TestPreflightMechanism_FlagsMasker` (adopting type rejected; non-adopting type unaffected).
- **Finding 9, Batch-enabled arm.** The positional move (to last preflight1 check) is applied. Whether the engine should *accept* an inner-flagged tx once Batch is enabled (rippled skips its sig check; the bar is at NetworkOPs) is left unchanged: go-xrpl routes real inner txs through a separate `preflightInner` path, so a tfInnerBatchTxn tx reaching the outer preflight is always illegitimate. The residual divergence needs a malicious proposer and is out of scope for a precedence PR.
- **Memo placement is local-RPC-only** (`Service.SubmitTransaction`), not the shared ingress. Peer-relay (`SubmitOpenLedgerTx`) and consensus apply (`block_processor` → `engine.Apply`) deliberately bypass it, satisfying "relayed/consensus-applied txs must not be memo-rejected".

## Pre-existing issue surfaced (not fixed here)

`ReflectFlatten` / `Common.ToMap` leave `Memos` as `[]MemoWrapper`, so the typed-tx struct→blob encode/sign path fails (`STArray fields must be STObjects`) for any memo-bearing tx. Production consensus is unaffected (wire txs hash from raw bytes); it is a struct-flatten gap. The new local memo check sidesteps it via `flattenStructSlice`; the service test builds its blob from a field map. Flagged for a follow-up.

## Verification

- `just test` / `go test ./...`: all in-scope packages pass. The only failing package is `internal/testing/conformance`, whose failures are entirely out-of-scope suites (Vault/Batch/XChain/XChainSim) and byte-identical to a clean `origin/v3.0.0` baseline.
- Conformance (fresh baseline diff): **in-scope 1260 pass / 0 fail** on both baseline and branch; out-of-scope per-suite counts (Batch 5/30, Vault 52/132, XChain 1/15, XChainSim 0/1) unchanged. **Zero fixture TER changed.**
- `golangci-lint run --config .golangci.yml ./internal/tx/... ./internal/ledger/service/...`: 0 issues.
- docsgen: no drift (RPC/registry catalogs regenerated, no diff).
- New pin-tests: one per reordered pair (`preflight_precedence_test.go`), memo boundary + charset (`local_checks_test.go`), local-submit reject (`tx_query_submit_test.go`), engine accepts oversized memo.

Part of #274 (preflight precedence audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
