### PR TITLE
fix(nftoken): align preflight TER precedence with rippled

### DIFF
--- a/internal/testing/nft/precedence_test.go
+++ b/internal/testing/nft/precedence_test.go
@@ -1,0 +1,102 @@
+package nft_test
+
+// precedence_test.go - end-to-end pins for the NFToken preflight TER-precedence
+// alignment. Each test drives the full engine pipeline and asserts the exact
+// code a malformed transaction surfaces, proving the tem* verdict wins over the
+// later tec/tef it previously forked to.
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/nft"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/nftoken"
+)
+
+// fakeOfferID / fakeOfferID2 are well-formed but never-created NFTokenOffer IDs.
+const (
+	fakeOfferID  = "00000000000000000000000000000000000000000000000000000000DEADBEEF"
+	fakeOfferID2 = "00000000000000000000000000000000000000000000000000000000FEEDFACE"
+)
+
+// TestPrecedence_CancelOfferUniversalFlag pins finding 1: a NFTokenCancelOffer
+// carrying tfFullyCanonicalSig (0x80000000, set by default by many client
+// libraries) must pass the flag mask. Previously the mask was 0xFFFFFFFF, so the
+// transaction was rejected temINVALID_FLAG and never reached the ledger — a
+// direct ledger-content fork versus rippled, whose mask is ~tfUniversal.
+func TestPrecedence_CancelOfferUniversalFlag(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	env.Fund(alice)
+	env.Close()
+
+	// Cancelling a non-existent offer is a no-op success in rippled.
+	cancel := nft.NFTokenCancelOffer(alice, fakeOfferID).BuildNFTokenCancelOffer()
+	cancel.SetFlags(tx.TfFullyCanonicalSig)
+
+	result := env.Submit(cancel)
+	jtx.RequireTxSuccess(t, result)
+}
+
+// TestPrecedence_MintNegativeAmountBeforeIssuer pins finding 3: a NFTokenMint
+// with a negative Amount and a non-existent Issuer must fail temBAD_AMOUNT in
+// preflight, before the preclaim Issuer read that previously returned
+// tecNO_ISSUER (a tec that IS written to the ledger with the fee burned). tem vs
+// tec = ledger fork.
+func TestPrecedence_MintNegativeAmountBeforeIssuer(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	gw := jtx.NewAccount("gw")
+	nonExistent := jtx.NewAccount("ghost")
+	env.Fund(alice, gw)
+	env.Close()
+
+	mint := nft.NFTokenMint(alice, 0).
+		Issuer(nonExistent).
+		Amount(gw.IOU("USD", -5)).
+		Build()
+
+	result := env.Submit(mint)
+	jtx.RequireTxFail(t, result, "temBAD_AMOUNT")
+}
+
+// TestPrecedence_CreateOfferNegativeAmountBeforeFindToken pins finding 6: a
+// NFTokenCreateOffer with a negative Amount must fail temBAD_AMOUNT in preflight,
+// before the Apply-time findToken that previously returned tecNO_ENTRY.
+func TestPrecedence_CreateOfferNegativeAmountBeforeFindToken(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	gw := jtx.NewAccount("gw")
+	env.Fund(alice, gw)
+	env.Close()
+
+	// A valid-looking NFTokenID that was never minted.
+	tokenID := nft.GetNextNFTokenID(env, alice, 0, 0, 0)
+	offer := nft.NFTokenCreateSellOffer(alice, tokenID, gw.IOU("USD", -5)).Build()
+
+	result := env.Submit(offer)
+	jtx.RequireTxFail(t, result, "temBAD_AMOUNT")
+}
+
+// TestPrecedence_AcceptOfferNegativeBrokerFee pins finding 2: a brokered
+// NFTokenAcceptOffer with a negative NFTokenBrokerFee must fail temMALFORMED in
+// preflight. Previously only a zero fee was rejected, so a negative fee reached
+// the broker-payment logic and mutated state (tes/tec) — a cross-class fork.
+func TestPrecedence_AcceptOfferNegativeBrokerFee(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	broker := jtx.NewAccount("broker")
+	gw := jtx.NewAccount("gw")
+	env.Fund(broker, gw)
+	env.Close()
+
+	accept := nftoken.NewNFTokenAcceptOffer(broker.Address)
+	accept.Fee = "10"
+	accept.NFTokenBuyOffer = fakeOfferID
+	accept.NFTokenSellOffer = fakeOfferID2
+	brokerFee := gw.IOU("USD", -10)
+	accept.NFTokenBrokerFee = &brokerFee
+
+	result := env.Submit(accept)
+	jtx.RequireTxFail(t, result, "temMALFORMED")
+}

--- a/internal/tx/nftoken/constant.go
+++ b/internal/tx/nftoken/constant.go
@@ -38,9 +38,6 @@ const (
 
 	// maxTokenOfferCancelCount is the max offers that can be cancelled in one tx
 	maxTokenOfferCancelCount = 500
-
-	// tfNFTokenCancelOfferMask is the mask for invalid flags (all flags are invalid)
-	tfNFTokenCancelOfferMask uint32 = 0xFFFFFFFF
 )
 
 // nftTransferFeeXRP computes the issuer transfer fee cut for an XRP amount

--- a/internal/tx/nftoken/nftoken_accept_offer.go
+++ b/internal/tx/nftoken/nftoken_accept_offer.go
@@ -36,18 +36,20 @@ func (n *NFTokenAcceptOffer) TxType() tx.Type {
 	return tx.TypeNFTokenAcceptOffer
 }
 
+// GetFlagsMask matches rippled tfNFTokenAcceptOfferMask = ~tfUniversal (no
+// type-specific flags). The engine enforces it at preflight0, ahead of the
+// account/fee/signing-key checks.
+func (n *NFTokenAcceptOffer) GetFlagsMask(*amendment.Rules) uint32 {
+	return tx.TfUniversalMask
+}
+
 // Reference: rippled NFTokenAcceptOffer.cpp preflight
 func (n *NFTokenAcceptOffer) Validate() error {
 	if err := n.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// NFTokenAcceptOffer defines no transaction-specific flags, but the universal
-	// flags (e.g. tfFullyCanonicalSig) are always permitted.
-	// Reference: rippled TxFlags.h tfNFTokenAcceptOfferMask = ~tfUniversal.
-	if n.GetFlags()&^tx.TfUniversal != 0 {
-		return ter.Errorf(ter.TemINVALID_FLAG, "NFTokenAcceptOffer: invalid flags")
-	}
+	// Flag mask is enforced by the engine at preflight0 via GetFlagsMask.
 
 	// Must have at least one offer
 	if n.NFTokenSellOffer == "" && n.NFTokenBuyOffer == "" {
@@ -59,9 +61,11 @@ func (n *NFTokenAcceptOffer) Validate() error {
 		if n.NFTokenSellOffer == "" || n.NFTokenBuyOffer == "" {
 			return ter.Errorf(ter.TemMALFORMED, "NFTokenBrokerFee requires both sell and buy offers")
 		}
-		// BrokerFee must be positive (greater than zero)
-		// Reference: rippled NFTokenAcceptOffer.cpp:56 - if (*bf <= beast::zero)
-		if n.NFTokenBrokerFee.IsZero() {
+		// BrokerFee must be strictly positive: rippled rejects both zero and
+		// negative fees (*bf <= beast::zero → temMALFORMED). A negative IOU fee
+		// is wire-representable, so the sign check is not redundant.
+		// Reference: rippled NFTokenAcceptOffer.cpp preflight.
+		if n.NFTokenBrokerFee.IsZero() || n.NFTokenBrokerFee.IsNegative() {
 			return ter.Errorf(ter.TemMALFORMED, "NFTokenBrokerFee must be greater than zero")
 		}
 	}

--- a/internal/tx/nftoken/nftoken_cancel_offer.go
+++ b/internal/tx/nftoken/nftoken_cancel_offer.go
@@ -19,6 +19,17 @@ type NFTokenCancelOffer struct {
 	NFTokenOffers []string `json:"NFTokenOffers" xrpl:"NFTokenOffers"`
 }
 
+// tfNFTokenCancelOfferMask matches rippled TxFlags.h tfNFTokenCancelOfferMask =
+// ~tfUniversal: no type-specific flags are defined, but the universal bits
+// (tfFullyCanonicalSig, tfInnerBatchTxn) are always permitted.
+const tfNFTokenCancelOfferMask = tx.TfUniversalMask
+
+// GetFlagsMask makes the engine enforce the invalid-flags mask at preflight0,
+// ahead of the account/fee/signing-key checks — matching rippled preflight0.
+func (n *NFTokenCancelOffer) GetFlagsMask(*amendment.Rules) uint32 {
+	return tfNFTokenCancelOfferMask
+}
+
 // NewNFTokenCancelOffer creates a new NFTokenCancelOffer transaction
 func NewNFTokenCancelOffer(account string, offerIDs []string) *NFTokenCancelOffer {
 	return &NFTokenCancelOffer{
@@ -37,10 +48,7 @@ func (n *NFTokenCancelOffer) Validate() error {
 		return err
 	}
 
-	// Check flags - no flags are valid for NFTokenCancelOffer
-	if n.GetFlags()&tfNFTokenCancelOfferMask != 0 {
-		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for NFTokenCancelOffer")
-	}
+	// Flag mask is enforced by the engine at preflight0 via GetFlagsMask.
 
 	// Must have at least one offer ID
 	if len(n.NFTokenOffers) == 0 {

--- a/internal/tx/nftoken/nftoken_create_offer.go
+++ b/internal/tx/nftoken/nftoken_create_offer.go
@@ -64,86 +64,39 @@ func (n *NFTokenCreateOffer) TxType() tx.Type {
 	return tx.TypeNFTokenCreateOffer
 }
 
-// Reference: rippled NFTokenCreateOffer.cpp preflight and tokenOfferCreatePreflight
-// IMPORTANT: validation order must match rippled exactly (amount → expiration → owner → destination)
+// GetFlagsMask matches rippled tfNFTokenCreateOfferMask = ~(tfUniversal |
+// tfSellNFToken). The engine enforces it at preflight0, ahead of the
+// account/fee/signing-key checks.
+func (n *NFTokenCreateOffer) GetFlagsMask(*amendment.Rules) uint32 {
+	return tfNFTokenCreateOfferMask
+}
+
+// Validate performs the rules-free structural checks. The flag mask is enforced
+// by the engine (GetFlagsMask), and the amount/expiration/owner/destination
+// checks live in PreflightRules because their order and gating depend on the
+// active amendments.
+// Reference: rippled NFTokenCreateOffer.cpp preflight.
 func (n *NFTokenCreateOffer) Validate() error {
 	if err := n.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	if n.GetFlags()&tfNFTokenCreateOfferMask != 0 {
-		return ter.Errorf(ter.TemINVALID_FLAG, "invalid NFTokenCreateOffer flags")
-	}
-
+	// sfNFTokenID is soeREQUIRED in rippled; enforce its presence here so
+	// PreflightRules can safely derive the token flags from it.
 	if n.NFTokenID == "" {
 		return ter.Errorf(ter.TemMALFORMED, "NFTokenID is required")
 	}
 
-	// Parse NFToken flags from token ID to validate
-	nftFlags := getNFTokenFlags(n.NFTokenID)
-
-	isSellOffer := n.GetFlags()&NFTokenCreateOfferFlagSellNFToken != 0
-
-	// --- tokenOfferCreatePreflight order (must match rippled exactly) ---
-
-	// 1. Negative amount check — gated on fixNFTokenNegOffer amendment.
-	// Since Validate() has no access to amendment rules, this check is
-	// performed in Apply(). When fixNFTokenNegOffer is disabled (pre-amendment),
-	// negative offers are allowed (bug-compatible with rippled).
-	// Reference: rippled tokenOfferCreatePreflight line 847
-
-	// 2. IOU-specific amount checks
-	// Reference: rippled tokenOfferCreatePreflight lines 851-858
-	if !n.Amount.IsNative() {
-		if nftFlags&NFTokenFlagOnlyXRP != 0 {
-			return ter.Errorf(ter.TemBAD_AMOUNT, "NFToken requires XRP only")
-		}
-		if n.Amount.IsZero() {
-			return ter.Errorf(ter.TemBAD_AMOUNT, "IOU amount cannot be zero")
-		}
-	}
-
-	// 3. Buy offer zero amount check
-	// Reference: rippled tokenOfferCreatePreflight lines 863-864
-	if !isSellOffer && n.Amount.IsZero() {
-		return ter.Errorf(ter.TemBAD_AMOUNT, "buy offer amount cannot be zero")
-	}
-
-	// 4. Expiration validation - expiration of 0 is invalid
-	// Reference: rippled tokenOfferCreatePreflight lines 866-867
-	if n.Expiration != nil && *n.Expiration == 0 {
-		return ter.Errorf(ter.TemBAD_EXPIRATION, "Expiration cannot be 0")
-	}
-
-	// 5. Owner field checks
-	// Reference: rippled tokenOfferCreatePreflight lines 871-875
-	// The 'Owner' field must be present when offering to buy, but can't
-	// be present when selling (it's implicit)
-	if (n.Owner != "") == isSellOffer {
-		if !isSellOffer && n.Owner == "" {
-			return ter.Errorf(ter.TemMALFORMED, "Owner is required for buy offers")
-		}
-		if isSellOffer && n.Owner != "" {
-			return ter.Errorf(ter.TemMALFORMED, "Owner not allowed for sell offers")
-		}
-	}
-
-	// Owner cannot be the same as Account
-	// Reference: rippled tokenOfferCreatePreflight lines 874-875
-	if n.Owner != "" && n.Owner == n.Account {
-		return ter.Errorf(ter.TemMALFORMED, "Owner cannot be the same as Account")
-	}
-
-	// 6. Destination checks
-	// Reference: rippled tokenOfferCreatePreflight lines 877-892
-	if n.Destination != "" {
-		// The destination can't be the account executing the transaction
-		if n.Destination == n.Account {
-			return ter.Errorf(ter.TemMALFORMED, "Destination cannot be the same as Account")
-		}
-	}
-
 	return nil
+}
+
+// PreflightRules runs the amendment-aware structural validation shared with
+// NFTokenMint, in rippled's exact order.
+// Reference: rippled NFTokenCreateOffer.cpp preflight → nft::tokenOfferCreatePreflight.
+func (n *NFTokenCreateOffer) PreflightRules(rules *amendment.Rules) error {
+	nftFlags := getNFTokenFlags(n.NFTokenID)
+	isSellOffer := n.GetFlags()&NFTokenCreateOfferFlagSellNFToken != 0
+	return tokenOfferCreatePreflight(rules, n.Account, n.Amount, n.Destination, n.Expiration, nftFlags, n.Owner, isSellOffer)
 }
 
 func (n *NFTokenCreateOffer) Flatten() (map[string]any, error) {
@@ -180,19 +133,9 @@ func (n *NFTokenCreateOffer) Apply(ctx *tx.ApplyContext) ter.Result {
 	var tokenID [32]byte
 	copy(tokenID[:], tokenIDBytes)
 
-	// Negative amount check — gated on fixNFTokenNegOffer
-	// Reference: rippled tokenOfferCreatePreflight line 847
-	if n.Amount.IsNegative() && ctx.Rules().Enabled(amendment.FeatureFixNFTokenNegOffer) {
-		return ter.TemBAD_AMOUNT
-	}
-
-	// Destination on buy offers: pre-fixNFTokenNegOffer, any Destination on a
-	// buy offer is malformed. Post-amendment, it's allowed (for broker use).
-	// Reference: rippled tokenOfferCreatePreflight lines 877-892
+	// The negative-amount and destination-on-buy tem* checks run in preflight
+	// (PreflightRules → tokenOfferCreatePreflight), before this point.
 	isSellOffer := n.GetFlags()&NFTokenCreateOfferFlagSellNFToken != 0
-	if n.Destination != "" && !isSellOffer && !ctx.Rules().Enabled(amendment.FeatureFixNFTokenNegOffer) {
-		return ter.TemMALFORMED
-	}
 
 	if tx.HasExpired(n.Expiration, ctx.Config.ParentCloseTime) {
 		ctx.Log.Warn("nftoken create offer: offer expired")

--- a/internal/tx/nftoken/nftoken_mint.go
+++ b/internal/tx/nftoken/nftoken_mint.go
@@ -49,8 +49,12 @@ const (
 
 	// Reference: rippled TxFlags.h tfNFTokenMintMask — all masks carve out
 	// tfUniversal so inner Batch txs (which carry tfInnerBatchTxn) aren't rejected.
+	// The four variants correspond to rippled's amendment-conditional selection in
+	// NFTokenMint::getFlagsMask (fixRemoveNFTokenAutoTrustLine × DynamicNFT):
+	// the "Old" masks permit tfTrustLine, the "WithMutable" masks permit tfMutable.
 	tfNFTokenMintMask               uint32 = ^(tx.TfUniversal | NFTokenMintFlagBurnable | NFTokenMintFlagOnlyXRP | NFTokenMintFlagTransferable)
 	tfNFTokenMintMaskWithMutable    uint32 = ^(tx.TfUniversal | NFTokenMintFlagBurnable | NFTokenMintFlagOnlyXRP | NFTokenMintFlagTransferable | NFTokenMintFlagMutable)
+	tfNFTokenMintOldMask            uint32 = ^(tx.TfUniversal | NFTokenMintFlagBurnable | NFTokenMintFlagOnlyXRP | NFTokenMintFlagTrustLine | NFTokenMintFlagTransferable)
 	tfNFTokenMintOldMaskWithMutable uint32 = ^(tx.TfUniversal | NFTokenMintFlagBurnable | NFTokenMintFlagOnlyXRP | NFTokenMintFlagTrustLine | NFTokenMintFlagTransferable | NFTokenMintFlagMutable)
 )
 
@@ -66,19 +70,32 @@ func (n *NFTokenMint) TxType() tx.Type {
 	return tx.TypeNFTokenMint
 }
 
+// GetFlagsMask returns the amendment-conditional invalid-flags mask, enforced by
+// the engine at preflight0. tfTrustLine is only permitted before
+// fixRemoveNFTokenAutoTrustLine; tfMutable is only permitted once DynamicNFT is
+// enabled.
+// Reference: rippled NFTokenMint::getFlagsMask.
+func (n *NFTokenMint) GetFlagsMask(rules *amendment.Rules) uint32 {
+	dynamicNFT := rules.NFTsWithDynamicEnabled()
+	if rules.Enabled(amendment.FeatureFixRemoveNFTokenAutoTrustLine) {
+		if dynamicNFT {
+			return tfNFTokenMintMaskWithMutable
+		}
+		return tfNFTokenMintMask
+	}
+	if dynamicNFT {
+		return tfNFTokenMintOldMaskWithMutable
+	}
+	return tfNFTokenMintOldMask
+}
+
 // Reference: rippled NFTokenMint.cpp preflight
 func (n *NFTokenMint) Validate() error {
 	if err := n.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// Use the most permissive mask here since Validate() has no access to Rules.
-	// The amendment-dependent checks (rejecting tfTrustLine when
-	// fixRemoveNFTokenAutoTrustLine is enabled, rejecting tfMutable when
-	// DynamicNFT is not enabled) are in Apply().
-	if n.GetFlags()&tfNFTokenMintOldMaskWithMutable != 0 {
-		return ter.Errorf(ter.TemINVALID_FLAG, "invalid NFTokenMint flags")
-	}
+	// Flag mask is enforced by the engine at preflight0 via GetFlagsMask.
 
 	// TransferFee must be <= maxTransferFee (50000 = 50%)
 	if n.TransferFee != nil {
@@ -119,43 +136,25 @@ func (n *NFTokenMint) Validate() error {
 		return ter.Errorf(ter.TemMALFORMED, "Amount required when Destination or Expiration present")
 	}
 
-	// When Amount is present, validate the offer fields using the same logic as
-	// tokenOfferCreatePreflight in rippled. Mint always creates a sell offer.
-	// Reference: rippled NFTokenMint.cpp preflight → tokenOfferCreatePreflight
-	if n.Amount != nil {
-		// Negative amount check — only when fixNFTokenNegOffer is enabled
-		// Reference: rippled NFTokenUtils.cpp tokenOfferCreatePreflight line 847
-		// Note: checked at runtime in Apply() since Validate() doesn't have amendment context
-
-		// IOU-specific checks
-		if !n.Amount.IsNative() {
-			// Extract NFToken flags from transaction flags (lower 16 bits)
-			nftFlags := uint16(n.GetFlags() & 0xFFFF)
-
-			// If token has OnlyXRP flag, IOU offers are not allowed
-			if nftFlags&NFTokenFlagOnlyXRP != 0 {
-				return ter.Errorf(ter.TemBAD_AMOUNT, "NFToken requires XRP only")
-			}
-
-			// Zero IOU amount is not allowed
-			if n.Amount.IsZero() {
-				return ter.Errorf(ter.TemBAD_AMOUNT, "IOU amount cannot be zero")
-			}
-		}
-
-		// Expiration of 0 is invalid
-		if n.Expiration != nil && *n.Expiration == 0 {
-			return ter.Errorf(ter.TemBAD_EXPIRATION, "Expiration cannot be 0")
-		}
-
-		// Destination cannot be the same as the account creating the offer
-		// Reference: rippled tokenOfferCreatePreflight — "if (dest == acctID)"
-		if n.Destination != "" && n.Destination == n.Account {
-			return ter.Errorf(ter.TemMALFORMED, "Destination cannot be the same as Account")
-		}
-	}
+	// The Amount-dependent offer checks (negative, OnlyXRP, zero, expiration,
+	// destination) run in PreflightRules because their order and gating depend
+	// on the active amendments.
 
 	return nil
+}
+
+// PreflightRules runs the amendment-aware offer validation shared with
+// NFTokenCreateOffer, when Mint carries offer fields. A Mint always creates a
+// sell offer with no Owner. This runs after Validate (rippled invokes
+// tokenOfferCreatePreflight at the end of NFTokenMint::preflight, after the
+// TransferFee/Issuer/URI/Amount-required checks).
+// Reference: rippled NFTokenMint.cpp preflight → nft::tokenOfferCreatePreflight.
+func (n *NFTokenMint) PreflightRules(rules *amendment.Rules) error {
+	if n.Amount == nil {
+		return nil
+	}
+	nftFlags := uint16(n.GetFlags() & 0xFFFF)
+	return tokenOfferCreatePreflight(rules, n.Account, *n.Amount, n.Destination, n.Expiration, nftFlags, "", true)
 }
 
 func (n *NFTokenMint) Flatten() (map[string]any, error) {
@@ -194,27 +193,8 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) ter.Result {
 		"flags", n.GetFlags(),
 	)
 
-	// Amendment-dependent flag check.
-	// Reference: rippled NFTokenMint.cpp preflight — mask depends on amendments
-	dynamicNFT := ctx.Rules().NFTsWithDynamicEnabled()
-	if ctx.Rules().Enabled(amendment.FeatureFixRemoveNFTokenAutoTrustLine) {
-		if dynamicNFT {
-			if n.GetFlags()&tfNFTokenMintMaskWithMutable != 0 {
-				return ter.TemINVALID_FLAG
-			}
-		} else {
-			if n.GetFlags()&tfNFTokenMintMask != 0 {
-				return ter.TemINVALID_FLAG
-			}
-		}
-	} else {
-		if dynamicNFT {
-			if n.GetFlags()&tfNFTokenMintOldMaskWithMutable != 0 {
-				return ter.TemINVALID_FLAG
-			}
-		}
-		// else: use the old permissive mask (already checked in Validate)
-	}
+	// The amendment-conditional flag mask is enforced by the engine at preflight0
+	// via GetFlagsMask.
 
 	accountID := ctx.AccountID
 
@@ -265,11 +245,8 @@ func (n *NFTokenMint) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Preclaim checks for the combined mint+offer path.
 	// Reference: rippled NFTokenMint.cpp preclaim → tokenOfferCreatePreclaim
 	if n.Amount != nil {
-		// Negative amount check — gated by fixNFTokenNegOffer amendment
-		// Reference: rippled NFTokenUtils.cpp tokenOfferCreatePreflight line 847
-		if n.Amount.IsNegative() && ctx.Rules().Enabled(amendment.FeatureFixNFTokenNegOffer) {
-			return ter.TemBAD_AMOUNT
-		}
+		// The negative-amount tem* check runs in preflight (PreflightRules →
+		// tokenOfferCreatePreflight), before this point.
 
 		if tx.HasExpired(n.Expiration, ctx.Config.ParentCloseTime) {
 			return ter.TecEXPIRED

--- a/internal/tx/nftoken/preflight_precedence_test.go
+++ b/internal/tx/nftoken/preflight_precedence_test.go
@@ -1,0 +1,173 @@
+package nftoken
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+// secondNFTokenID is a second well-formed 256-bit NFTokenID, distinct from
+// validNFTokenID (defined in nftoken_validate_test.go).
+const secondNFTokenID = "000B013AB5F762798A53D543A014CAF8B297CFF8F2F937E816E5DA9C00000002"
+
+// wantTER asserts that err carries the given TER code.
+func wantTER(t *testing.T, err error, want ter.Result) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected %v, got nil", want)
+	}
+	var re *ter.ResultError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected *ter.ResultError %v, got %T: %v", want, err, err)
+	}
+	if re.Code != want {
+		t.Fatalf("got %v, want %v", re.Code, want)
+	}
+}
+
+// mainnetRules has both fixRemoveNFTokenAutoTrustLine and DynamicNFT enabled, as
+// on mainnet.
+func mainnetRules() *amendment.Rules { return amendment.AllSupportedRules() }
+
+// preV2NFTRules enables NonFungibleTokensV1 only, so fixNFTokenNegOffer,
+// fixRemoveNFTokenAutoTrustLine and DynamicNFT all read as disabled — the
+// original NFToken behaviour.
+func preV2NFTRules() *amendment.Rules {
+	return amendment.NewRulesBuilder().EnableByName("NonFungibleTokensV1").Build()
+}
+
+// --- Finding 1: NFTokenCancelOffer mask value (~tfUniversal, not 0xFFFFFFFF) ---
+
+func TestNFTokenCancelOffer_FlagsMask(t *testing.T) {
+	c := NewNFTokenCancelOffer("rAlice", []string{validNFTokenID})
+	mask := c.GetFlagsMask(mainnetRules())
+
+	// Universal bits (tfFullyCanonicalSig, tfInnerBatchTxn) must be permitted.
+	if mask&tx.TfFullyCanonicalSig != 0 {
+		t.Errorf("tfFullyCanonicalSig must not be in the invalid-flags mask")
+	}
+	if mask&tx.TfInnerBatchTxn != 0 {
+		t.Errorf("tfInnerBatchTxn must not be in the invalid-flags mask")
+	}
+	// Any other bit is invalid.
+	if mask&0x00000001 == 0 {
+		t.Errorf("a non-universal flag must be in the invalid-flags mask")
+	}
+}
+
+// --- Finding 2: NFTokenAcceptOffer rejects zero AND negative broker fees ---
+
+func TestNFTokenAcceptOffer_BrokerFeeSign(t *testing.T) {
+	build := func(fee tx.Amount) *NFTokenAcceptOffer {
+		n := NewNFTokenAcceptOffer("rBroker")
+		n.NFTokenBuyOffer = validNFTokenID
+		n.NFTokenSellOffer = secondNFTokenID
+		n.NFTokenBrokerFee = &fee
+		return n
+	}
+
+	t.Run("negative IOU broker fee", func(t *testing.T) {
+		fee := state.NewIssuedAmountFromFloat64(-10, "USD", "rIssuer")
+		wantTER(t, build(fee).Validate(), ter.TemMALFORMED)
+	})
+	t.Run("negative XRP broker fee", func(t *testing.T) {
+		wantTER(t, build(tx.NewXRPAmount(-10)).Validate(), ter.TemMALFORMED)
+	})
+	t.Run("zero broker fee", func(t *testing.T) {
+		wantTER(t, build(tx.NewXRPAmount(0)).Validate(), ter.TemMALFORMED)
+	})
+	t.Run("positive broker fee accepted", func(t *testing.T) {
+		if err := build(tx.NewXRPAmount(10)).Validate(); err != nil {
+			t.Fatalf("positive broker fee should pass Validate, got %v", err)
+		}
+	})
+}
+
+// --- Findings 4 & 5: NFTokenMint amendment-conditional flag mask ---
+
+func TestNFTokenMint_FlagsMask(t *testing.T) {
+	m := NewNFTokenMint("rAlice", 0)
+
+	t.Run("mainnet rejects tfTrustLine, allows tfMutable", func(t *testing.T) {
+		mask := m.GetFlagsMask(mainnetRules())
+		if mask&NFTokenMintFlagTrustLine == 0 {
+			t.Errorf("mainnet mask must reject tfTrustLine")
+		}
+		if mask&NFTokenMintFlagMutable != 0 {
+			t.Errorf("mainnet mask (DynamicNFT on) must allow tfMutable")
+		}
+	})
+
+	t.Run("pre-fix, no DynamicNFT: rejects tfMutable, allows tfTrustLine", func(t *testing.T) {
+		rules := amendment.NewRulesBuilder().
+			FromPreset(amendment.PresetAllSupported).
+			DisableByName("fixRemoveNFTokenAutoTrustLine").
+			DisableByName("DynamicNFT").
+			Build()
+		mask := m.GetFlagsMask(rules)
+		if mask&NFTokenMintFlagMutable == 0 {
+			t.Errorf("without DynamicNFT the mask must reject tfMutable")
+		}
+		if mask&NFTokenMintFlagTrustLine != 0 {
+			t.Errorf("without fixRemoveNFTokenAutoTrustLine the mask must allow tfTrustLine")
+		}
+	})
+}
+
+// --- Finding 3: NFTokenMint negative-amount temBAD_AMOUNT runs in preflight ---
+
+func TestNFTokenMint_PreflightRules_NegativeAmount(t *testing.T) {
+	m := NewNFTokenMint("rAlice", 0)
+	m.Issuer = "rNonExistentIssuer"
+	amt := state.NewIssuedAmountFromFloat64(-5, "USD", "rIssuer")
+	m.Amount = &amt
+
+	// The negative-amount check must win over any later offer-field check, so a
+	// negative amount together with an invalid Expiration still returns
+	// temBAD_AMOUNT, not temBAD_EXPIRATION.
+	zeroExp := uint32(0)
+	m.Expiration = &zeroExp
+
+	wantTER(t, m.PreflightRules(mainnetRules()), ter.TemBAD_AMOUNT)
+}
+
+// --- Finding 6: NFTokenCreateOffer negative-amount temBAD_AMOUNT in preflight ---
+
+func TestNFTokenCreateOffer_PreflightRules_NegativeAmountFirst(t *testing.T) {
+	// Sell offer with a negative amount and a zero Expiration: the negative-amount
+	// check precedes the expiration check, matching rippled's order.
+	o := NewNFTokenCreateOffer("rAlice", validNFTokenID, tx.NewXRPAmount(-10))
+	o.SetSellOffer()
+	zeroExp := uint32(0)
+	o.Expiration = &zeroExp
+
+	wantTER(t, o.PreflightRules(mainnetRules()), ter.TemBAD_AMOUNT)
+
+	// Validate must NOT reject on the amount/expiration (those are PreflightRules
+	// checks now); it only enforces structural presence.
+	if err := o.Validate(); err != nil {
+		t.Fatalf("Validate should not reject amount/expiration, got %v", err)
+	}
+}
+
+// --- Finding 7: destination on a buy offer is malformed pre-fixNFTokenNegOffer ---
+
+func TestNFTokenCreateOffer_PreflightRules_DestinationOnBuy(t *testing.T) {
+	// Buy offer (no tfSellNFToken), Owner required, Destination set.
+	o := NewNFTokenCreateOffer("rAlice", validNFTokenID, tx.NewXRPAmount(10))
+	o.Owner = "rOwner"
+	o.Destination = "rBroker"
+
+	t.Run("rejected before fixNFTokenNegOffer", func(t *testing.T) {
+		wantTER(t, o.PreflightRules(preV2NFTRules()), ter.TemMALFORMED)
+	})
+	t.Run("allowed with fixNFTokenNegOffer", func(t *testing.T) {
+		if err := o.PreflightRules(mainnetRules()); err != nil {
+			t.Fatalf("destination on buy offer should be allowed post-fix, got %v", err)
+		}
+	})
+}

--- a/internal/tx/nftoken/token_offer_preflight.go
+++ b/internal/tx/nftoken/token_offer_preflight.go
@@ -1,0 +1,76 @@
+package nftoken
+
+import (
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+// tokenOfferCreatePreflight is the amendment-aware structural validation shared
+// by NFTokenCreateOffer and the offer-creating path of NFTokenMint (which always
+// creates a sell offer with no Owner). It runs in the per-type preflight body
+// (via PreflightRules), so its tem* rejections happen before any ledger read and
+// before signature verification.
+//
+// The check order is identical to rippled: negative → OnlyXRP/zero → buy-zero →
+// expiration → owner presence → owner==account → destination. Keeping this order
+// matters because the negative-amount temBAD_AMOUNT must win over a later
+// temBAD_EXPIRATION/temMALFORMED on the same transaction.
+//
+// Reference: rippled NFTokenUtils.cpp nft::tokenOfferCreatePreflight.
+func tokenOfferCreatePreflight(
+	rules *amendment.Rules,
+	account string,
+	amount tx.Amount,
+	dest string,
+	expiration *uint32,
+	nftFlags uint16,
+	owner string,
+	isSellOffer bool,
+) error {
+	// An offer for a negative amount makes no sense (gated on fixNFTokenNegOffer,
+	// which the original implementation lacked).
+	if amount.IsNegative() && rules.Enabled(amendment.FeatureFixNFTokenNegOffer) {
+		return ter.Errorf(ter.TemBAD_AMOUNT, "offer amount cannot be negative")
+	}
+
+	if !amount.IsNative() {
+		if nftFlags&NFTokenFlagOnlyXRP != 0 {
+			return ter.Errorf(ter.TemBAD_AMOUNT, "NFToken requires XRP only")
+		}
+		if amount.IsZero() {
+			return ter.Errorf(ter.TemBAD_AMOUNT, "IOU amount cannot be zero")
+		}
+	}
+
+	// A buy offer must offer something; a sell offer may ask for nothing.
+	if !isSellOffer && amount.IsZero() {
+		return ter.Errorf(ter.TemBAD_AMOUNT, "buy offer amount cannot be zero")
+	}
+
+	if expiration != nil && *expiration == 0 {
+		return ter.Errorf(ter.TemBAD_EXPIRATION, "Expiration cannot be 0")
+	}
+
+	// The Owner field must be present when offering to buy, but can't be present
+	// when selling (it's implicit).
+	if (owner != "") == isSellOffer {
+		return ter.Errorf(ter.TemMALFORMED, "Owner is required for buy offers and forbidden on sell offers")
+	}
+	if owner != "" && owner == account {
+		return ter.Errorf(ter.TemMALFORMED, "Owner cannot be the same as Account")
+	}
+
+	if dest != "" {
+		// A Destination on a buy offer (used to pin a specific broker) was
+		// malformed before fixNFTokenNegOffer, which piggy-backed the relaxation.
+		if !isSellOffer && !rules.Enabled(amendment.FeatureFixNFTokenNegOffer) {
+			return ter.Errorf(ter.TemMALFORMED, "Destination not allowed on buy offer")
+		}
+		if dest == account {
+			return ter.Errorf(ter.TemMALFORMED, "Destination cannot be the same as Account")
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Aligns the preflight TER precedence of the NFToken transaction family with rippled (tag 3.1.0), fixing 7 adversarially-verified divergences. Adopts the engine `FlagsMasker`/`RulesPreflighter` seams from #1271 so flag-mask and amendment-gated `tem*` checks fire at their rippled pipeline positions (preflight0 / per-type preflight body) rather than in `Validate`/`Apply`.

## Findings addressed

| # | Tx type | Kind | Divergence | Fix |
|---|---------|------|------------|-----|
| 1 | NFTokenCancelOffer | mask-value (high) | mask was `0xFFFFFFFF`, so the ubiquitous `tfFullyCanonicalSig`/`tfInnerBatchTxn` bits were rejected `temINVALID_FLAG` → tx never in ledger (rippled: `tesSUCCESS`). Direct ledger-content fork. | `GetFlagsMask` → `~tfUniversal` |
| 2 | NFTokenAcceptOffer | missing-check (high) | only zero BrokerFee rejected; a negative BrokerFee passed preflight and reached broker-payment (tes/tec + state mutation). rippled: `*bf <= 0` → `temMALFORMED`. | reject `IsZero() \|\| IsNegative()` |
| 3 | NFTokenMint | order (high) | negative Amount check deferred to Apply, after the Issuer read → `tecNO_ISSUER` (ledger-included) vs rippled `temBAD_AMOUNT` at preflight. | negative check moved to `PreflightRules`, before preclaim |
| 4 | NFTokenMint | mask-position (medium) | amendment-conditional mask enforced at top of `Apply` (after engine seq/fee/sig) instead of preflight0. | amendment-conditional `GetFlagsMask` |
| 5 | NFTokenMint | mask-value (low) | no `tfNFTokenMintOldMask`; a `tfMutable` mint succeeded when both `fixRemoveNFTokenAutoTrustLine` and `DynamicNFT` were off (rippled: `temINVALID_FLAG`). | add `tfNFTokenMintOldMask`, select it in `GetFlagsMask` |
| 6 | NFTokenCreateOffer | order (medium) | negative Amount check deferred to Apply, after engine preclaim/signature → divergent codes at every interception point. | moved into `PreflightRules` (shared `tokenOfferCreatePreflight`) |
| 7 | NFTokenCreateOffer | order (low) | Destination-on-buy `temMALFORMED` (pre-`fixNFTokenNegOffer`) deferred to Apply. | moved into `PreflightRules`, preserving rippled's intra-preflight order |

A new shared `tokenOfferCreatePreflight` helper mirrors rippled `nft::tokenOfferCreatePreflight` and is used by both `NFTokenMint` and `NFTokenCreateOffer`, preserving the exact check order (negative → OnlyXRP/zero → buy-zero → expiration → owner → destination) so the negative-amount `temBAD_AMOUNT` correctly wins over a later `temBAD_EXPIRATION`/`temMALFORMED`.

Reconciled against the base's `fixCleanup3_1_3` (#1268): the expired-offer handling in AcceptOffer's Apply was left untouched; only the preflight broker-fee sign check was added.

## Verification

- **Pin-tests** (one per fork scenario): unit pins on `GetFlagsMask`/`PreflightRules`/`Validate` in `internal/tx/nftoken/preflight_precedence_test.go`; end-to-end engine pins in `internal/testing/nft/precedence_test.go`.
- **`just test`**: green except the pre-existing out-of-scope conformance stubs (Batch/Vault/XChain/Delegate) — no NFToken or other in-scope failures.
- **Conformance**: in-scope **1260 pass / 0 fail (100%)**; NFToken suites **325/0**. No fixture shifts.
- **Lint**: strict `.golangci.yml` clean (0 issues) on changed packages.
- **docs-check**: no registry drift.

Part of #274; follows #1271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)