### PR TITLE
fix(account,signerlist,ticket): align preflight TER precedence with rippled

### DIFF
--- a/internal/testing/accountdelete/preflight_precedence_test.go
+++ b/internal/testing/accountdelete/preflight_precedence_test.go
@@ -1,0 +1,62 @@
+// Preflight TER-precedence pins for AccountDelete: the CredentialIDs amendment
+// gate is a checkExtraFeatures rejection that runs before preflight1 and the
+// AccountDelete preflight body, so temDISABLED wins over the shape check
+// (temMALFORMED), the self-delete check (temDST_IS_SRC), and every ledger-state
+// TER (terPRE_SEQ).
+//
+// Reference: rippled DeleteAccount.cpp checkExtraFeatures().
+package accountdelete_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	acctx "github.com/LeJamon/go-xrpl/internal/tx/account"
+)
+
+// credID is a well-formed 256-bit credential id (64 hex chars).
+const credID = "ABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAB0"
+
+// newCredEnv builds an environment with featureCredentials disabled and one
+// funded account, so a CredentialIDs-bearing AccountDelete hits the
+// checkExtraFeatures temDISABLED gate.
+func newCredEnv(t *testing.T) (*jtx.TestEnv, *jtx.Account, *jtx.Account) {
+	env := jtx.NewTestEnv(t)
+	env.DisableFeature("Credentials")
+	env.Close()
+	alice := jtx.NewAccount("alice")
+	becky := jtx.NewAccount("becky")
+	env.Fund(alice, becky)
+	env.Close()
+	return env, alice, becky
+}
+
+// TestAccountDelete_CredentialsDisabledPrecedence pins finding AccountDelete-order
+// across its three illustrations: the temDISABLED gate beats the duplicate-id
+// shape check, the self-delete check, and a sequence gap.
+func TestAccountDelete_CredentialsDisabledPrecedence(t *testing.T) {
+	t.Run("beats duplicate-id shape check", func(t *testing.T) {
+		env, alice, becky := newCredEnv(t)
+		d := acctx.NewAccountDelete(alice.Address, becky.Address)
+		d.Fee = "10"
+		d.CredentialIDs = []string{credID, credID} // duplicate → temMALFORMED if reached
+		jtx.RequireTxFail(t, env.Submit(d), "temDISABLED")
+	})
+
+	t.Run("beats self-delete check", func(t *testing.T) {
+		env, alice, _ := newCredEnv(t)
+		d := acctx.NewAccountDelete(alice.Address, alice.Address) // dest==src → temDST_IS_SRC if reached
+		d.Fee = "10"
+		d.CredentialIDs = []string{credID}
+		jtx.RequireTxFail(t, env.Submit(d), "temDISABLED")
+	})
+
+	t.Run("beats sequence gap", func(t *testing.T) {
+		env, alice, becky := newCredEnv(t)
+		d := acctx.NewAccountDelete(alice.Address, becky.Address)
+		d.Fee = "10"
+		d.CredentialIDs = []string{credID}
+		d.SetSequence(env.Seq(alice) + 10) // future sequence → terPRE_SEQ if reached
+		jtx.RequireTxFail(t, env.Submit(d), "temDISABLED")
+	})
+}

--- a/internal/testing/accountset/preflight_precedence_test.go
+++ b/internal/testing/accountset/preflight_precedence_test.go
@@ -1,0 +1,28 @@
+package accountset
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	accounttx "github.com/LeJamon/go-xrpl/internal/tx/account"
+)
+
+// TestAccountSet_NFTokenMinterPrecedence pins finding AccountSet-order: setting
+// asfAuthorizedNFTokenMinter without an sfNFTokenMinter field is temMALFORMED,
+// enforced in the preflight body (gated on NonFungibleTokensV1, active in the
+// default preset). It wins over the sequence gap that preclaim would otherwise
+// report as terPRE_SEQ.
+func TestAccountSet_NFTokenMinterPrecedence(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	env.Fund(alice)
+	env.Close()
+
+	// SetFlag asfAuthorizedNFTokenMinter with no NFTokenMinter present, plus a
+	// future sequence: the field-pairing tem must beat the preclaim seq check.
+	as := AccountSet(alice).
+		SetFlag(accounttx.AccountSetFlagAuthorizedNFTokenMinter).
+		Sequence(env.Seq(alice) + 10).
+		Build()
+	jtx.RequireTxFail(t, env.Submit(as), "temMALFORMED")
+}

--- a/internal/testing/multisign/preflight_precedence_test.go
+++ b/internal/testing/multisign/preflight_precedence_test.go
@@ -1,0 +1,71 @@
+// Preflight TER-precedence pins for SignerListSet: the flags mask (preflight0)
+// and the signer-entry validation (preflight body) both run before any
+// ledger-state check, matching rippled's SetSignerList preflight ordering.
+//
+// Reference: rippled SetSignerList.cpp getFlagsMask() / preflight().
+package multisign_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/tx/signerlist"
+)
+
+// invalidTxFlag is a non-universal flag bit; with fixInvalidTxFlags active it is
+// outside SignerListSet's allowed set and must be rejected as temINVALID_FLAG.
+const invalidTxFlag uint32 = 0x00010000
+
+// TestSignerListSet_FlagsMaskPrecedence pins finding SignerListSet-mask: with
+// fixInvalidTxFlags active the flags mask is evaluated at preflight0, so it wins
+// over the determineOperation shape check (temMALFORMED) and over the sequence
+// gap (terPRE_SEQ) that a preclaim check would otherwise report.
+func TestSignerListSet_FlagsMaskPrecedence(t *testing.T) {
+	t.Run("mask beats malformed shape", func(t *testing.T) {
+		env := jtx.NewTestEnv(t) // fixInvalidTxFlags active in the default preset
+		alice := jtx.NewAccount("alice")
+		env.Fund(alice)
+		env.Close()
+
+		// quorum==0 with entries present is neither a set nor a destroy, so
+		// Validate() reports temMALFORMED — but the invalid flag must win.
+		sls := signerlist.NewSignerListSet(alice.Address, 0)
+		sls.AddSigner(jtx.NewAccount("bob").Address, 1)
+		sls.SetFlags(invalidTxFlag)
+		jtx.RequireTxFail(t, env.Submit(sls), "temINVALID_FLAG")
+	})
+
+	t.Run("mask beats sequence gap", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		env.Fund(alice)
+		env.Close()
+
+		// A well-formed set list with an invalid flag and a future sequence:
+		// without the preflight0 mask this would report terPRE_SEQ from preclaim.
+		sls := signerlist.NewSignerListSet(alice.Address, 2)
+		sls.AddSigner(jtx.NewAccount("bob").Address, 1)
+		sls.AddSigner(jtx.NewAccount("carol").Address, 1)
+		sls.SetFlags(invalidTxFlag)
+		sls.SetSequence(env.Seq(alice) + 10)
+		jtx.RequireTxFail(t, env.Submit(sls), "temINVALID_FLAG")
+	})
+}
+
+// TestSignerListSet_EntryValidationPrecedence pins finding SignerListSet-order:
+// the signer-entry validation runs in the preflight body, so an over-cap list
+// (33 entries with ExpandedSignerList) reports temMALFORMED even when the
+// transaction also carries a sequence gap that preclaim would flag as terPRE_SEQ.
+func TestSignerListSet_EntryValidationPrecedence(t *testing.T) {
+	env := jtx.NewTestEnv(t) // ExpandedSignerList active → cap is 32
+	alice := jtx.NewAccount("alice")
+	env.Fund(alice)
+	env.Close()
+
+	sls := signerlist.NewSignerListSet(alice.Address, 1)
+	for _, s := range signersOfWeightOne(33) {
+		sls.AddSigner(s.Account.Address, s.Weight)
+	}
+	sls.SetSequence(env.Seq(alice) + 10)
+	jtx.RequireTxFail(t, env.Submit(sls), "temMALFORMED")
+}

--- a/internal/testing/setregularkey/preflight_precedence_test.go
+++ b/internal/testing/setregularkey/preflight_precedence_test.go
@@ -1,0 +1,29 @@
+// Preflight TER-precedence pin for SetRegularKey: the fixMasterKeyAsRegularKey
+// RegularKey==Account rejection runs in the preflight body, before any
+// ledger-state check.
+//
+// Reference: rippled SetRegularKey.cpp preflight().
+package setregularkey_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/tx/signerlist"
+)
+
+// TestSetRegularKey_BadRegKeyPrecedence pins finding SetRegularKey-order: setting
+// the regular key to the account's own address is temBAD_REGKEY (preflight),
+// which wins over the sequence gap that preclaim would otherwise report as
+// terPRE_SEQ. fixMasterKeyAsRegularKey is active in the default preset.
+func TestSetRegularKey_BadRegKeyPrecedence(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	env.Fund(alice)
+	env.Close()
+
+	setKey := signerlist.NewSetRegularKey(alice.Address)
+	setKey.SetKey(alice.Address) // RegularKey == Account
+	setKey.SetSequence(env.Seq(alice) + 10)
+	jtx.RequireTxFail(t, env.Submit(setKey), "temBAD_REGKEY")
+}

--- a/internal/tx/account/account_delete.go
+++ b/internal/tx/account/account_delete.go
@@ -28,11 +28,27 @@ func (a *AccountDelete) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureDeletableAccounts}
 }
 
+// GetFlagsMask adopts the engine FlagsMasker seam. AccountDelete defines no
+// type-specific flags, so it uses the base universal mask.
+// Reference: rippled Transactor.cpp getFlagsMask() = tfUniversalMask.
+func (a *AccountDelete) GetFlagsMask(rules *amendment.Rules) uint32 {
+	return tx.TfUniversalMask
+}
+
+// CheckExtraFeatures gates CredentialIDs behind featureCredentials. rippled runs
+// this in checkExtraFeatures — before preflight1 and DeleteAccount::preflight —
+// so the temDISABLED wins over temDST_IS_SRC, the credential shape check, and
+// every ledger-state TER.
+// Reference: rippled DeleteAccount.cpp checkExtraFeatures().
+func (a *AccountDelete) CheckExtraFeatures(rules *amendment.Rules) error {
+	if len(a.CredentialIDs) > 0 && !rules.Enabled(amendment.FeatureCredentials) {
+		return ter.Errorf(ter.TemDISABLED, "CredentialIDs requires the Credentials amendment")
+	}
+	return nil
+}
+
 func (a *AccountDelete) Validate() error {
 	if err := a.BaseTx.Validate(); err != nil {
-		return err
-	}
-	if err := tx.CheckFlags(a.GetFlags(), tx.TfUniversalMask); err != nil {
 		return err
 	}
 	if a.Destination == "" {
@@ -78,9 +94,6 @@ func (a *AccountDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	)
 
 	rules := ctx.Rules()
-	if len(a.CredentialIDs) > 0 && !rules.Enabled(amendment.FeatureCredentials) {
-		return ter.TemDISABLED
-	}
 	destAccount, destID, result := ctx.LookupAccount(a.Destination)
 	if result != ter.TesSUCCESS {
 		return result

--- a/internal/tx/account/account_set.go
+++ b/internal/tx/account/account_set.go
@@ -150,12 +150,6 @@ func (a *AccountSet) Validate() error {
 
 	txFlags := a.GetFlags()
 
-	// Check for invalid transaction flags
-	// Reference: rippled SetAccount.cpp:71-75
-	if txFlags&AccountSetTxFlagMask != 0 {
-		return ter.Errorf(ter.TemINVALID_FLAG, "invalid transaction flags")
-	}
-
 	// Cannot set and clear the same non-zero flag. SetFlag/ClearFlag of 0
 	// (or both absent, which reads as 0) is a valid no-op.
 	// Reference: rippled SetAccount.cpp:80-84
@@ -241,6 +235,25 @@ func (a *AccountSet) Validate() error {
 	return nil
 }
 
+// GetFlagsMask adopts the engine FlagsMasker seam with the AccountSet-specific
+// invalid-flags mask, checked at preflight0 (rippled SetAccount::getFlagsMask =
+// tfAccountSetMask).
+func (a *AccountSet) GetFlagsMask(rules *amendment.Rules) uint32 {
+	return AccountSetTxFlagMask
+}
+
+// PreflightRules runs the amendment-gated NFTokenMinter field-pairing check as
+// part of the preflight body, before any ledger-state check.
+// Reference: rippled SetAccount.cpp:174-184.
+func (a *AccountSet) PreflightRules(rules *amendment.Rules) error {
+	if rules.Enabled(amendment.FeatureNonFungibleTokensV1) {
+		if r := a.validateNFTokenMinter(); r != ter.TesSUCCESS {
+			return ter.Errorf(r, "invalid NFTokenMinter field pairing")
+		}
+	}
+	return nil
+}
+
 // validateNFTokenMinter enforces the NFTokenMinter field-presence rules for the
 // asfAuthorizedNFTokenMinter flag: the minter must be present when setting the
 // flag and absent when clearing it. rippled gates these checks on
@@ -296,14 +309,6 @@ func (a *AccountSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	}
 	if a.ClearFlag != nil {
 		uClearFlag = *a.ClearFlag
-	}
-
-	// NFTokenMinter field presence is validated only once NonFungibleTokensV1 is
-	// enabled, mirroring rippled's amendment-gated preflight check.
-	if ctx.Rules().Enabled(amendment.FeatureNonFungibleTokensV1) {
-		if r := a.validateNFTokenMinter(); r != ter.TesSUCCESS {
-			return r
-		}
 	}
 
 	// Legacy AccountSet flags: RequireAuth, RequireDestTag and DisallowXRP can be

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -93,11 +93,9 @@ func (e *Engine) preflightStructure(tx txcore.Transaction, common *txcore.Common
 	}
 
 	// T::checkExtraFeatures runs before preflight1's common checks (see
-	// ExtraFeaturesChecker). No tx type adopts this hook yet.
-	if efc, ok := tx.(txcore.ExtraFeaturesChecker); ok {
-		if err := efc.CheckExtraFeatures(rules); err != nil {
-			return parseValidationError(err)
-		}
+	// ExtraFeaturesChecker).
+	if result := checkExtraFeatures(tx, rules); result != ter.TesSUCCESS {
+		return result
 	}
 
 	// preflight1 (which itself runs preflight0).
@@ -111,10 +109,8 @@ func (e *Engine) preflightStructure(tx txcore.Transaction, common *txcore.Common
 	if err := tx.Validate(); err != nil {
 		return parseValidationError(err)
 	}
-	if rp, ok := tx.(txcore.RulesPreflighter); ok {
-		if err := rp.PreflightRules(rules); err != nil {
-			return parseValidationError(err)
-		}
+	if result := checkPreflightRules(tx, rules); result != ter.TesSUCCESS {
+		return result
 	}
 
 	// preflight2 structural stage — the multi-sign structural rules run after
@@ -181,14 +177,45 @@ func (e *Engine) preflight0(tx txcore.Transaction, common *txcore.Common, rules 
 	if result := e.validateNetworkID(common); result != ter.TesSUCCESS {
 		return result
 	}
-	// Flags mask: a transaction whose flags intersect its type's invalid-flags
-	// mask is temINVALID_FLAG. rippled evaluates this with T::getFlagsMask(ctx).
-	// A type opts in via FlagsMasker; until it does, the per-type flag check in
-	// Validate() is the backstop and the engine applies no mask here (the
-	// universal mask would reject every valid type-specific flag).
+	return checkFlagsMask(tx, common, rules)
+}
+
+// checkFlagsMask rejects a transaction whose flags intersect its type's
+// invalid-flags mask with temINVALID_FLAG, mirroring rippled preflight0's
+// `tx.getFlags() & T::getFlagsMask(ctx)`. A type opts in via FlagsMasker; a type
+// that does not implement it gets no engine-level flag rejection (the universal
+// mask would reject every valid type-specific flag). Reused by preflight0 and
+// preflightInner so inner batch transactions get the same mask rippled applies
+// via the per-inner invokePreflight.
+func checkFlagsMask(tx txcore.Transaction, common *txcore.Common, rules *amendment.Rules) ter.Result {
 	if fm, ok := tx.(txcore.FlagsMasker); ok {
 		if common.GetFlags()&fm.GetFlagsMask(rules) != 0 {
 			return ter.TemINVALID_FLAG
+		}
+	}
+	return ter.TesSUCCESS
+}
+
+// checkExtraFeatures runs a type's ExtraFeaturesChecker (rippled
+// T::checkExtraFeatures), which gates amendment-dependent tem*/temDISABLED
+// rejections ahead of preflight1's common checks. Reused by the outer structure
+// preflight and preflightInner.
+func checkExtraFeatures(tx txcore.Transaction, rules *amendment.Rules) ter.Result {
+	if efc, ok := tx.(txcore.ExtraFeaturesChecker); ok {
+		if err := efc.CheckExtraFeatures(rules); err != nil {
+			return parseValidationError(err)
+		}
+	}
+	return ter.TesSUCCESS
+}
+
+// checkPreflightRules runs a type's RulesPreflighter (the amendment-gated tem*
+// checks of rippled's T::preflight body) after Validate(). Reused by the outer
+// structure preflight and preflightInner.
+func checkPreflightRules(tx txcore.Transaction, rules *amendment.Rules) ter.Result {
+	if rp, ok := tx.(txcore.RulesPreflighter); ok {
+		if err := rp.PreflightRules(rules); err != nil {
+			return parseValidationError(err)
 		}
 	}
 	return ter.TesSUCCESS
@@ -213,13 +240,24 @@ func (e *Engine) preflightInner(innerTx txcore.Transaction) ter.Result {
 	if result := checkAccountPresent(common); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := e.validateNetworkID(common); result != ter.TesSUCCESS {
-		return result
-	}
 	for _, featureID := range innerTx.RequiredAmendments() {
 		if !rules.Enabled(featureID) {
 			return ter.TemDISABLED
 		}
+	}
+	// The per-type seams (checkExtraFeatures, flags mask, PreflightRules) run for
+	// inner transactions exactly as they do on the outer path, mirroring rippled
+	// which preflights each inner via the full invokePreflight<T>. Without them an
+	// inner tx that adopts a seam would skip that validation, since inner txs
+	// reach Apply directly and never run preclaim.
+	if result := checkExtraFeatures(innerTx, rules); result != ter.TesSUCCESS {
+		return result
+	}
+	if result := e.validateNetworkID(common); result != ter.TesSUCCESS {
+		return result
+	}
+	if result := checkFlagsMask(innerTx, common, rules); result != ter.TesSUCCESS {
+		return result
 	}
 	if result := checkSigningKeyShape(common); result != ter.TesSUCCESS {
 		return result
@@ -233,7 +271,7 @@ func (e *Engine) preflightInner(innerTx txcore.Transaction) ter.Result {
 	if err := innerTx.Validate(); err != nil {
 		return parseValidationError(err)
 	}
-	return ter.TesSUCCESS
+	return checkPreflightRules(innerTx, rules)
 }
 
 // preflightInnerBatchFlag rejects a transaction reaching the outer preflight

--- a/internal/tx/signerlist/signer_list_set.go
+++ b/internal/tx/signerlist/signer_list_set.go
@@ -69,6 +69,32 @@ func (s *SignerListSet) Validate() error {
 	}
 }
 
+// GetFlagsMask adopts the engine FlagsMasker seam. rippled uses an
+// amendment-conditional mask: with fixInvalidTxFlags any non-universal flag is
+// rejected at preflight0; without it any flags are allowed.
+// Reference: rippled SetSignerList.cpp getFlagsMask().
+func (s *SignerListSet) GetFlagsMask(rules *amendment.Rules) uint32 {
+	if rules.Enabled(amendment.FeatureFixInvalidTxFlags) {
+		return tx.TfUniversalMask
+	}
+	return 0
+}
+
+// PreflightRules runs the amendment-aware signer-entry validation for a set
+// operation. rippled runs validateQuorumAndSignerEntries in the preflight body;
+// Validate() only classifies set vs destroy, so a non-zero quorum reaching here
+// is a set (the malformed combinations are already rejected).
+// Reference: rippled SetSignerList.cpp preflight() → validateQuorumAndSignerEntries.
+func (s *SignerListSet) PreflightRules(rules *amendment.Rules) error {
+	if s.SignerQuorum == 0 {
+		return nil
+	}
+	if r := s.validateQuorumAndSignerEntries(rules.Enabled(amendment.FeatureExpandedSignerList)); r != ter.TesSUCCESS {
+		return ter.Errorf(r, "invalid signer entries")
+	}
+	return nil
+}
+
 // validateQuorumAndSignerEntries performs the amendment-aware validation rippled
 // runs in preflight: entry-count bounds (8 without featureExpandedSignerList, 32
 // with), no duplicates, positive weights, no self-reference, WalletLocator only
@@ -145,14 +171,25 @@ func (s *SetRegularKey) TxType() tx.Type {
 	return tx.TypeRegularKeySet
 }
 
-// Reference: rippled SetRegularKey.cpp preflight() — no type-specific flags allowed
 func (s *SetRegularKey) Validate() error {
-	if err := s.BaseTx.Validate(); err != nil {
-		return err
-	}
-	// SetRegularKey has no type-specific flags.
-	if s.GetFlags()&tx.TfUniversalMask != 0 {
-		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags for SetRegularKey")
+	return s.BaseTx.Validate()
+}
+
+// GetFlagsMask adopts the engine FlagsMasker seam. SetRegularKey defines no
+// type-specific flags, so it uses the base universal mask (rippled does not
+// override getFlagsMask for SetRegularKey).
+// Reference: rippled Transactor.cpp getFlagsMask() = tfUniversalMask.
+func (s *SetRegularKey) GetFlagsMask(rules *amendment.Rules) uint32 {
+	return tx.TfUniversalMask
+}
+
+// PreflightRules rejects setting the regular key to the account's own address
+// once fixMasterKeyAsRegularKey is active, before any ledger-state check.
+// Reference: rippled SetRegularKey.cpp preflight().
+func (s *SetRegularKey) PreflightRules(rules *amendment.Rules) error {
+	if rules.Enabled(amendment.FeatureFixMasterKeyAsRegularKey) &&
+		s.RegularKey != "" && s.RegularKey == s.Account {
+		return ter.Errorf(ter.TemBAD_REGKEY, "regular key cannot be the master key")
 	}
 	return nil
 }
@@ -171,16 +208,8 @@ func (s *SetRegularKey) ClearKey() {
 	s.RegularKey = ""
 }
 
-// Reference: rippled SetRegularKey.cpp preflight + doApply()
+// Reference: rippled SetRegularKey.cpp doApply()
 func (s *SetRegularKey) Apply(ctx *tx.ApplyContext) ter.Result {
-	// Amendment-gated preflight check: reject setting RegularKey to own account.
-	// Reference: rippled SetRegularKey.cpp preflight lines 66-71
-	if ctx.Rules().Enabled(amendment.FeatureFixMasterKeyAsRegularKey) {
-		if s.RegularKey != "" && s.RegularKey == s.Account {
-			return ter.TemBAD_REGKEY
-		}
-	}
-
 	if s.RegularKey != "" {
 		ctx.Log.Trace("set regular key apply",
 			"account", s.Account,
@@ -287,14 +316,6 @@ func signerCountBasedOwnerCountDelta(entryCount int) int {
 
 // Reference: rippled SetSignerList.cpp preflight() + doApply(), replaceSignerList(), destroySignerList()
 func (s *SignerListSet) Apply(ctx *tx.ApplyContext) ter.Result {
-	// Check for invalid flags, gated behind fixInvalidTxFlags.
-	// Reference: rippled SetSignerList.cpp preflight() lines 86-91
-	if ctx.Rules().Enabled(amendment.FeatureFixInvalidTxFlags) {
-		if s.GetFlags()&tx.TfUniversalMask != 0 {
-			return ter.TemINVALID_FLAG
-		}
-	}
-
 	ctx.Log.Trace("signer list set apply",
 		"account", s.Account,
 		"signerQuorum", s.SignerQuorum,
@@ -325,14 +346,10 @@ func (s *SignerListSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	// --- Replace (or create) signer list ---
 	// Reference: rippled SetSignerList.cpp replaceSignerList()
 
-	// Validate the signer entries now that amendment rules are available.
-	// rippled does this in preflight; go-xrpl's Validate() has no rules, so it
-	// runs here — which also covers batch inner transactions, since they reach
-	// Apply but not Preclaim.
+	// Signer-entry validity (counts, weights, duplicates, quorum, WalletLocator)
+	// is enforced in PreflightRules — the outer path and preflightInner both run
+	// it, so by the time Apply runs the entries are known valid.
 	expandedSignerList := ctx.Rules().Enabled(amendment.FeatureExpandedSignerList)
-	if r := s.validateQuorumAndSignerEntries(expandedSignerList); r != ter.TesSUCCESS {
-		return r
-	}
 
 	// Preemptively remove any old signer list. May reduce the reserve,
 	// so this is done before checking the reserve.

--- a/internal/tx/ticket/ticket_create.go
+++ b/internal/tx/ticket/ticket_create.go
@@ -34,15 +34,16 @@ func (t *TicketCreate) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeatureTicketBatch}
 }
 
+// GetFlagsMask adopts the engine FlagsMasker seam. CreateTicket defines no
+// type-specific flags, so it uses the base universal mask, checked at preflight0.
+// Reference: rippled Transactor.cpp getFlagsMask() = tfUniversalMask.
+func (t *TicketCreate) GetFlagsMask(rules *amendment.Rules) uint32 {
+	return tx.TfUniversalMask
+}
+
 // Reference: rippled CreateTicket.cpp preflight()
 func (t *TicketCreate) Validate() error {
 	if err := t.BaseTx.Validate(); err != nil {
-		return err
-	}
-
-	// Check for invalid flags (tfUniversalMask)
-	// Reference: rippled CreateTicket.cpp:36 — if (ctx.tx.getFlags() & tfUniversalMask)
-	if err := tx.CheckFlags(t.GetFlags(), tx.TfUniversalMask); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

Aligns preflight TER precedence with rippled for the **AccountSet / AccountDelete / SetRegularKey / SignerListSet / TicketCreate** family. Five adversarially-verified findings share one root cause: an amendment-gated `tem*`/`temDISABLED` check that rippled evaluates in `invokePreflight` (before any ledger read) was instead run inside `Validate()` (after the common `preflight1` checks) or at the top of `Apply()` (after preclaim). A transaction that is both malformed in one of these ways *and* carries a sequence gap therefore returned a retriable `ter*`/`tec*` code (held/queued) where rippled returns a non-retriable `tem*` (rejected outright) — a TER-class fork.

This adopts the `FlagsMasker` / `RulesPreflighter` / `ExtraFeaturesChecker` engine seams from #1271 across the family, and extends the engine so batch **inner** transactions run those same seams (rippled preflights each inner via the full `invokePreflight<T>`; the reduced `preflightInner` previously skipped them).

Part of #274; follows #1271.

## Findings addressed

| Tx | Kind | Sev | Fork (goXRPL before → rippled) | Fix mechanism |
|----|------|-----|--------------------------------|---------------|
| SignerListSet | mask-position | high | fixInvalidTxFlags mask at top of `Apply()`: `temMALFORMED`/`terPRE_SEQ` → **`temINVALID_FLAG`** at preflight0 | `GetFlagsMask` = `fixInvalidTxFlags ? tfUniversalMask : 0` |
| SignerListSet | order | high | 33-entry validation in `Apply()`: `terPRE_SEQ` → **`temMALFORMED`** in preflight | `PreflightRules` → `validateQuorumAndSignerEntries` |
| SetRegularKey | order | high | `RegularKey==Account` at top of `Apply()`: `terPRE_SEQ` → **`temBAD_REGKEY`** in preflight | `PreflightRules` (fixMasterKeyAsRegularKey) |
| AccountSet | order | high | `asfAuthorizedNFTokenMinter` pairing in `Apply()`: `terPRE_SEQ` → **`temMALFORMED`** in preflight | `PreflightRules` (NonFungibleTokensV1) |
| AccountDelete | order | med | CredentialIDs gate at top of `Apply()`: `terPRE_SEQ`/`temMALFORMED`/`temDST_IS_SRC` → **`temDISABLED`** before preflight1 | `CheckExtraFeatures` (Credentials) |

### Adjacent flag-mask relocations (same class, completes the family)

rippled evaluates every type's `getFlagsMask` at preflight0, ahead of the `preflight1` account/fee/signing-key checks. goXRPL ran these masks inside `Validate()` (the `T::preflight` position), so a bad-flag + bad-fee/account transaction forked (`temBAD_FEE` vs rippled `temINVALID_FLAG`). Adopting `FlagsMasker` for the whole family fixes this and makes `simulate` route bad flags to `engine_result` rather than the `invalidTransaction` envelope, matching rippled's STTx-ctor-vs-preflight split.

- **AccountSet** → `tfAccountSetMask`
- **SetRegularKey**, **AccountDelete**, **TicketCreate** → `tfUniversalMask` (rippled's base `getFlagsMask`)

## Verification

- **Pin tests** — one behavioral pin per fork scenario (7 subtests) under `internal/testing/{multisign,setregularkey,accountset,accountdelete}/preflight_precedence_test.go`, each asserting the `tem*` code now wins over the `terPRE_SEQ`/shape/self-delete code it previously lost to.
- **`just test`** — all packages pass. `TestConformance` fails only on the pre-existing out-of-scope Batch/Vault/XChain fixtures (identical to the clean `origin/v3.0.0` baseline).
- **Conformance** — in-scope **1260 pass / 0 fail (100%)**; the full failing-test-name set is **byte-identical** to a fresh `origin/v3.0.0` baseline → **0 new failures**.
- **Strict lint** (`.golangci.yml`) — 0 issues. **`go vet`** clean. **docsgen** — no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
