### PR TITLE
fix(payment,offer): align preflight TER precedence with rippled

### DIFF
--- a/internal/tx/engine/payment_offer_precedence_test.go
+++ b/internal/tx/engine/payment_offer_precedence_test.go
@@ -1,0 +1,200 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/offer"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+// zeroAccountAddr is the classic address of the all-zero AccountID
+// (rippled xrpAccount()/noAccount()), which is wire-valid and signable.
+const zeroAccountAddr = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+
+// mptIDA / mptIDB are two distinct 24-byte MPT issuance IDs (48 hex chars).
+const (
+	mptIDA = "00000000000000000000000000000000000000000000000A"
+	mptIDB = "00000000000000000000000000000000000000000000000B"
+)
+
+func preflightPayment(dst string, amount txcore.Amount) *payment.Payment {
+	p := payment.NewPayment(precedenceSourceAddr, dst, amount)
+	p.Fee = "10"
+	p.Sequence = u32(5)
+	return p
+}
+
+func preflightOfferCreate(gets, pays txcore.Amount) *offer.OfferCreate {
+	o := offer.NewOfferCreate(precedenceSourceAddr, gets, pays)
+	o.Fee = "10"
+	o.Sequence = u32(5)
+	return o
+}
+
+// --- Payment ---
+
+// P1: a non-MPT Payment's flags mask (tfPaymentMask) rejects any undefined flag
+// bit at preflight0 — an XRP→XRP payment carrying flag 0x1 is temINVALID_FLAG.
+func TestPaymentPrecedence_UndefinedFlagRejected(t *testing.T) {
+	e := preflightEngine(allRules())
+	p := preflightPayment(precedenceGenesisAddr, txcore.NewXRPAmount(1_000_000))
+	p.SetFlags(0x00000001)
+	if got := e.preflight(p); got != ter.TemINVALID_FLAG {
+		t.Fatalf("preflight = %v, want TemINVALID_FLAG", got)
+	}
+}
+
+// P2: temDST_NEEDED fires for the zero AccountID destination, not just an absent
+// Destination field.
+func TestPaymentPrecedence_ZeroDestinationNeeded(t *testing.T) {
+	e := preflightEngine(allRules())
+	p := preflightPayment(zeroAccountAddr, txcore.NewIssuedAmountFromFloat64(10, "USD", precedenceGenesisAddr))
+	if got := e.preflight(p); got != ter.TemDST_NEEDED {
+		t.Fatalf("preflight = %v, want TemDST_NEEDED", got)
+	}
+}
+
+// P3: equalTokens compares the currency only (issuer ignored), so a self-payment
+// of USD/issuerB with SendMax USD/issuerA and no paths is temREDUNDANT.
+func TestPaymentPrecedence_SelfPaymentDifferentIssuerRedundant(t *testing.T) {
+	e := preflightEngine(allRules())
+	p := payment.NewPayment(precedenceSourceAddr, precedenceSourceAddr,
+		txcore.NewIssuedAmountFromFloat64(10, "USD", precedenceGenesisAddr))
+	p.Fee = "10"
+	p.Sequence = u32(5)
+	sendMax := txcore.NewIssuedAmountFromFloat64(11, "USD", precedenceSourceAddr)
+	p.SendMax = &sendMax
+	if got := e.preflight(p); got != ter.TemREDUNDANT {
+		t.Fatalf("preflight = %v, want TemREDUNDANT", got)
+	}
+}
+
+// P4: path-element shape validation no longer runs in preflight, so an otherwise
+// well-formed IOU payment carrying a malformed (account+currency) path element
+// passes preflight — the divergent code is decided later at preclaim/apply.
+func TestPaymentPrecedence_BadPathElementPassesPreflight(t *testing.T) {
+	e := preflightEngine(allRules())
+	p := preflightPayment(precedenceGenesisAddr, txcore.NewIssuedAmountFromFloat64(10, "USD", precedenceGenesisAddr))
+	p.Paths = [][]payment.PathStep{{{Account: precedenceSourceAddr, Currency: "USD"}}}
+	if got := e.preflight(p); got != ter.TesSUCCESS {
+		t.Fatalf("preflight = %v, want TesSUCCESS (path shape checked at apply)", got)
+	}
+}
+
+// P5: DeliverMin must hold the same asset as Amount by full asset identity — an
+// MPT DeliverMin of a different issuance than the MPT Amount is temBAD_AMOUNT.
+func TestPaymentPrecedence_DeliverMinAssetIdentity(t *testing.T) {
+	e := preflightEngine(allRules())
+	amt := state.NewMPTAmountWithIssuanceID(100, precedenceGenesisAddr, mptIDA)
+	p := preflightPayment(precedenceGenesisAddr, amt)
+	p.SetFlags(payment.PaymentFlagPartialPayment)
+	dMin := state.NewMPTAmountWithIssuanceID(1, precedenceGenesisAddr, mptIDB)
+	p.DeliverMin = &dMin
+	if got := e.preflight(p); got != ter.TemBAD_AMOUNT {
+		t.Fatalf("preflight = %v, want TemBAD_AMOUNT", got)
+	}
+}
+
+// P6: the MPT flags mask is enforced at preflight0, before the body's zero-amount
+// check — a zero MPT Amount with tfLimitQuality is temINVALID_FLAG, not
+// temBAD_AMOUNT.
+func TestPaymentPrecedence_MPTMaskBeforeZeroAmount(t *testing.T) {
+	e := preflightEngine(allRules())
+	amt := state.NewMPTAmountWithIssuanceID(0, precedenceGenesisAddr, mptIDA)
+	p := preflightPayment(precedenceGenesisAddr, amt)
+	p.SetFlags(payment.PaymentFlagLimitQuality)
+	if got := e.preflight(p); got != ter.TemINVALID_FLAG {
+		t.Fatalf("preflight = %v, want TemINVALID_FLAG", got)
+	}
+}
+
+// P7: the MPT+Paths temMALFORMED check precedes the zero-amount temBAD_AMOUNT
+// check, so a zero MPT Amount with paths is temMALFORMED.
+func TestPaymentPrecedence_MPTPathsBeforeZeroAmount(t *testing.T) {
+	e := preflightEngine(allRules())
+	amt := state.NewMPTAmountWithIssuanceID(0, precedenceGenesisAddr, mptIDA)
+	p := preflightPayment(precedenceGenesisAddr, amt)
+	p.Paths = [][]payment.PathStep{{{Account: precedenceSourceAddr}}}
+	if got := e.preflight(p); got != ter.TemMALFORMED {
+		t.Fatalf("preflight = %v, want TemMALFORMED", got)
+	}
+}
+
+// P9: the MPT amendment gate lives after the mask. With MPTokensV1 disabled, an
+// MPT payment carrying a mask-invalid flag surfaces temINVALID_FLAG (mask first);
+// a well-flagged MPT payment surfaces temDISABLED (the gate).
+func TestPaymentPrecedence_MPTGateAfterMask(t *testing.T) {
+	e := preflightEngine(rulesWithout("MPTokensV1"))
+
+	t.Run("mask beats disabled gate", func(t *testing.T) {
+		amt := state.NewMPTAmountWithIssuanceID(100, precedenceGenesisAddr, mptIDA)
+		p := preflightPayment(precedenceGenesisAddr, amt)
+		p.SetFlags(payment.PaymentFlagLimitQuality)
+		if got := e.preflight(p); got != ter.TemINVALID_FLAG {
+			t.Fatalf("preflight = %v, want TemINVALID_FLAG", got)
+		}
+	})
+
+	t.Run("valid flags reach disabled gate", func(t *testing.T) {
+		amt := state.NewMPTAmountWithIssuanceID(100, precedenceGenesisAddr, mptIDA)
+		p := preflightPayment(precedenceGenesisAddr, amt)
+		if got := e.preflight(p); got != ter.TemDISABLED {
+			t.Fatalf("preflight = %v, want TemDISABLED", got)
+		}
+	})
+}
+
+// --- OfferCreate ---
+
+// O1: isLegalNet passes zero amounts, so a zero TakerPays falls through to the
+// non-positive-amount check and is temBAD_OFFER, not temBAD_AMOUNT.
+func TestOfferPrecedence_ZeroAmountBadOffer(t *testing.T) {
+	e := preflightEngine(allRules())
+	o := preflightOfferCreate(txcore.NewIssuedAmountFromFloat64(100, "USD", precedenceGenesisAddr), txcore.NewXRPAmount(0))
+	if got := e.preflight(o); got != ter.TemBAD_OFFER {
+		t.Fatalf("preflight = %v, want TemBAD_OFFER", got)
+	}
+}
+
+// O3: the sfDomainID-without-PermissionedDEX temDISABLED gate runs in
+// checkExtraFeatures, before the preflight body — it beats a body temBAD_EXPIRATION.
+func TestOfferPrecedence_DomainDisabledBeatsBody(t *testing.T) {
+	e := preflightEngine(rulesWithout("PermissionedDEX"))
+	o := preflightOfferCreate(txcore.NewIssuedAmountFromFloat64(100, "USD", precedenceGenesisAddr), txcore.NewXRPAmount(1_000_000))
+	dom := [32]byte{1}
+	o.DomainID = &dom
+	exp := uint32(0)
+	o.Expiration = &exp // temBAD_EXPIRATION if the body were reached
+	if got := e.preflight(o); got != ter.TemDISABLED {
+		t.Fatalf("preflight = %v, want TemDISABLED", got)
+	}
+}
+
+// O4: the flags mask is amendment-conditional — with PermissionedDEX disabled it
+// includes tfHybrid, rejected at preflight0 ahead of the fee check.
+func TestOfferPrecedence_ConditionalMaskBeatsFee(t *testing.T) {
+	e := preflightEngine(rulesWithout("PermissionedDEX"))
+	o := preflightOfferCreate(txcore.NewIssuedAmountFromFloat64(100, "USD", precedenceGenesisAddr), txcore.NewXRPAmount(1_000_000))
+	o.Fee = "-10"          // malformed fee, not reached
+	o.SetFlags(0x00100000) // tfHybrid, no DomainID
+	if got := e.preflight(o); got != ter.TemINVALID_FLAG {
+		t.Fatalf("preflight = %v, want TemINVALID_FLAG", got)
+	}
+}
+
+// --- OfferCancel ---
+
+// OfferCancel adopts the universal flags mask at preflight0.
+func TestOfferCancelPrecedence_FlagMask(t *testing.T) {
+	e := preflightEngine(allRules())
+	o := offer.NewOfferCancel(precedenceSourceAddr, 12345)
+	o.Fee = "10"
+	o.Sequence = u32(5)
+	o.SetFlags(0x00000001)
+	if got := e.preflight(o); got != ter.TemINVALID_FLAG {
+		t.Fatalf("preflight = %v, want TemINVALID_FLAG", got)
+	}
+}

--- a/internal/tx/offer/offer_amount.go
+++ b/internal/tx/offer/offer_amount.go
@@ -4,11 +4,22 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
 )
 
-// isLegalNetAmount checks if an amount is a valid net amount.
-// Reference: rippled protocol/STAmount.h isLegalNet()
+// maxNativeDrops is rippled STAmount::cMaxNativeN — the isLegalNet ceiling on a
+// native (XRP) amount's magnitude.
+const maxNativeDrops uint64 = 100_000_000_000_000_000
+
+// isLegalNetAmount mirrors rippled STAmount isLegalNet: a native amount's
+// magnitude may not exceed cMaxNativeN; non-native amounts are always legal.
+// Zero amounts are legal here and are rejected later by the temBAD_OFFER check.
 func isLegalNetAmount(amt tx.Amount) bool {
-	// A legal net amount is non-zero
-	return !amt.IsZero()
+	if !amt.IsNative() {
+		return true
+	}
+	d := amt.Drops()
+	if d < 0 {
+		d = -d
+	}
+	return uint64(d) <= maxNativeDrops
 }
 
 // isAmountZeroOrNegative checks if an amount is zero or negative.

--- a/internal/tx/offer/offer_cancel.go
+++ b/internal/tx/offer/offer_cancel.go
@@ -2,6 +2,7 @@
 package offer
 
 import (
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -29,14 +30,17 @@ func (o *OfferCancel) TxType() tx.Type {
 	return tx.TypeOfferCancel
 }
 
+// GetFlagsMask returns the invalid-flags mask enforced by the engine at the
+// preflight0 position. CancelOffer defines no type-specific flags, so it uses the
+// universal mask (rippled's base Transactor::getFlagsMask).
+func (o *OfferCancel) GetFlagsMask(*amendment.Rules) uint32 {
+	return tx.TfUniversalMask
+}
+
 // Reference: rippled CancelOffer.cpp preflight()
 func (o *OfferCancel) Validate() error {
 	if err := o.BaseTx.Validate(); err != nil {
 		return err
-	}
-
-	if err := tx.CheckFlags(o.GetFlags(), tx.TfUniversalMask); err != nil {
-		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags set")
 	}
 
 	if o.OfferSequence == 0 {

--- a/internal/tx/offer/offer_create_validate.go
+++ b/internal/tx/offer/offer_create_validate.go
@@ -9,33 +9,29 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
-// Validate performs rules-independent validation on the OfferCreate transaction.
-// This is called by the engine's preflight step BEFORE hash computation and fee deduction.
-// All checks here must NOT depend on amendment rules (rules-dependent checks go in Preflight).
-// Reference: rippled CreateOffer.cpp preflight() - rules-independent subset
+// Validate runs the rules-free structural preflight checks of OfferCreate, in
+// rippled's preflight order. The flags mask (amendment-conditional, GetFlagsMask)
+// and the sfDomainID amendment gate (CheckExtraFeatures) are enforced by the
+// engine before this body, so no rules-dependent check remains here.
 func (o *OfferCreate) Validate() error {
 	if err := o.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// Reference: rippled CreateOffer.cpp preflight() lines 61-65
+	// The invalid-flags mask (GetFlagsMask) is enforced by the engine at the
+	// preflight0 position, before this body — mirroring rippled preflight0.
 	flags := o.GetFlags()
-	if flags&tfOfferCreateMask != 0 {
-		return ter.Errorf(ter.TemINVALID_FLAG, "invalid flags set")
+
+	// tfHybrid requires DomainID (rules-independent; rippled's first body check).
+	if (flags&tfHybrid != 0) && o.DomainID == nil {
+		return ter.Errorf(ter.TemINVALID_FLAG, "tfHybrid requires DomainID")
 	}
 
-	// IoC and FoK are mutually exclusive
-	// Reference: lines 73-80
+	// IoC and FoK are mutually exclusive.
 	bImmediateOrCancel := (flags & OfferCreateFlagImmediateOrCancel) != 0
 	bFillOrKill := (flags & OfferCreateFlagFillOrKill) != 0
 	if bImmediateOrCancel && bFillOrKill {
 		return ter.Errorf(ter.TemINVALID_FLAG, "cannot set both ImmediateOrCancel and FillOrKill")
-	}
-
-	// tfHybrid requires DomainID (rules-independent check)
-	// Reference: lines 70-71
-	if (flags&tfHybrid != 0) && o.DomainID == nil {
-		return ter.Errorf(ter.TemINVALID_FLAG, "tfHybrid requires DomainID")
 	}
 
 	// Reference: lines 82-88
@@ -114,24 +110,25 @@ func badCurrency() string {
 	return "XRP"
 }
 
-// PreflightRules performs the amendment-rules-dependent preflight checks for
-// OfferCreate. The rules-independent structural validation lives in Validate().
-// The engine runs this right after Validate(), so these tem* rejections happen
-// before fee deduction, matching rippled's preflight().
-// Reference: rippled CreateOffer.cpp preflight() lines 49-51, 67-68
-func (o *OfferCreate) PreflightRules(rules *amendment.Rules) error {
-	// Check if DomainID field is present without PermissionedDEX amendment
-	// Reference: rippled CreateOffer.cpp preflight() lines 49-51
+// GetFlagsMask returns the invalid-flags mask enforced by the engine at the
+// preflight0 position. It is amendment-conditional, mirroring rippled
+// CreateOffer::getFlagsMask: tfHybrid is only a valid flag once PermissionedDEX
+// is enabled, so with the amendment off it is added to the invalid mask.
+func (o *OfferCreate) GetFlagsMask(rules *amendment.Rules) uint32 {
+	if rules.PermissionedDEXEnabled() {
+		return tfOfferCreateMask
+	}
+	return tfOfferCreateMask | tfHybrid
+}
+
+// CheckExtraFeatures runs the amendment gate rippled evaluates in
+// checkExtraFeatures — before preflight0's flags mask and the common checks — so
+// an sfDomainID under a disabled PermissionedDEX surfaces temDISABLED ahead of
+// every other tx-specific tem code.
+func (o *OfferCreate) CheckExtraFeatures(rules *amendment.Rules) error {
 	if o.DomainID != nil && !rules.PermissionedDEXEnabled() {
 		return ter.Errorf(ter.TemDISABLED, "DomainID requires PermissionedDEX amendment")
 	}
-
-	// Reference: lines 67-68
-	flags := o.GetFlags()
-	if !rules.PermissionedDEXEnabled() && (flags&tfHybrid != 0) {
-		return ter.Errorf(ter.TemINVALID_FLAG, "tfHybrid requires PermissionedDEX amendment")
-	}
-
 	return nil
 }
 

--- a/internal/tx/offer/offer_test.go
+++ b/internal/tx/offer/offer_test.go
@@ -345,22 +345,23 @@ func TestOfferCancelValidation(t *testing.T) {
 	}
 }
 
-// TestOfferCancelFlagValidation verifies OfferCancel rejects any non-universal
-// flag, matching rippled CancelOffer::preflight (temINVALID_FLAG).
+// TestOfferCancelFlagValidation verifies OfferCancel's invalid-flags mask. The
+// mask itself is enforced by the engine at preflight0 (FlagsMasker); Validate no
+// longer checks flags. Matches rippled's base Transactor::getFlagsMask (universal).
 func TestOfferCancelFlagValidation(t *testing.T) {
-	t.Run("non-universal flag rejected", func(t *testing.T) {
-		o := NewOfferCancel("rAlice", 12345)
-		o.SetFlags(0x00000001)
-		err := o.Validate()
-		if err == nil || err.Error() != "temINVALID_FLAG: invalid flags set" {
-			t.Errorf("expected temINVALID_FLAG, got %v", err)
+	o := NewOfferCancel("rAlice", 12345)
+	mask := o.GetFlagsMask(nil)
+	if mask != tx.TfUniversalMask {
+		t.Fatalf("GetFlagsMask = %#x, want tfUniversalMask %#x", mask, tx.TfUniversalMask)
+	}
+	t.Run("non-universal flag intersects mask", func(t *testing.T) {
+		if uint32(0x00000001)&mask == 0 {
+			t.Errorf("non-universal flag 0x1 should intersect the invalid mask")
 		}
 	})
-	t.Run("universal flag accepted", func(t *testing.T) {
-		o := NewOfferCancel("rAlice", 12345)
-		o.SetFlags(tx.TfFullyCanonicalSig)
-		if err := o.Validate(); err != nil {
-			t.Errorf("expected no error for universal flag, got %v", err)
+	t.Run("universal flag outside mask", func(t *testing.T) {
+		if tx.TfFullyCanonicalSig&mask != 0 {
+			t.Errorf("tfFullyCanonicalSig should not intersect the invalid mask")
 		}
 	})
 }

--- a/internal/tx/payment/payment.go
+++ b/internal/tx/payment/payment.go
@@ -72,6 +72,16 @@ const (
 	PaymentFlagLimitQuality uint32 = 0x00040000
 )
 
+// Payment invalid-flag masks (rippled tfPaymentMask / tfMPTPaymentMask).
+const (
+	tfPaymentMask    uint32 = ^(tx.TfUniversal | PaymentFlagPartialPayment | PaymentFlagLimitQuality | PaymentFlagNoDirectRipple)
+	tfMPTPaymentMask uint32 = ^(tx.TfUniversal | PaymentFlagPartialPayment)
+)
+
+// maxNativeDrops is rippled STAmount::cMaxNativeN — the isLegalNet ceiling on a
+// native (XRP) amount's magnitude.
+const maxNativeDrops uint64 = 100_000_000_000_000_000
+
 // Path constraints matching rippled
 const (
 	// MaxPathSize is the maximum number of paths in a payment (rippled: Payment.h MaxPathSize = 6)
@@ -93,13 +103,13 @@ func (p *Payment) TxType() tx.Type {
 	return tx.TypePayment
 }
 
-// RequiredAmendments returns amendments required for this transaction.
-// Reference: rippled Payment.cpp preflight() - featureCredentials check for sfCredentialIDs
+// RequiredAmendments returns amendments required for this transaction. These
+// mirror rippled's checkExtraFeatures gates (sfCredentialIDs → featureCredentials,
+// sfDomainID → featurePermissionedDEX), which the engine evaluates before the
+// flags mask. The MPT gate is NOT here: rippled evaluates it inside the preflight
+// body, AFTER the mask, so it lives in PreflightRules.
 func (p *Payment) RequiredAmendments() [][32]byte {
 	var amendments [][32]byte
-	if p.isMPTDirect() {
-		amendments = append(amendments, amendment.FeatureMPTokensV1)
-	}
 	if p.CredentialIDs != nil || p.HasField("CredentialIDs") {
 		amendments = append(amendments, amendment.FeatureCredentials)
 	}
@@ -109,6 +119,27 @@ func (p *Payment) RequiredAmendments() [][32]byte {
 	return amendments
 }
 
+// GetFlagsMask returns the invalid-flags mask enforced by the engine at the
+// preflight0 position, mirroring rippled Payment::getFlagsMask: an MPT-denominated
+// Amount uses tfMPTPaymentMask, everything else tfPaymentMask.
+func (p *Payment) GetFlagsMask(*amendment.Rules) uint32 {
+	if p.isMPTDirect() {
+		return tfMPTPaymentMask
+	}
+	return tfPaymentMask
+}
+
+// PreflightRules carries the amendment-gated tem* checks that rippled evaluates
+// inside Payment::preflight (after the flags mask). The MPT-amount temDISABLED
+// gate must run after the mask so an MPT payment carrying a mask-invalid flag
+// surfaces temINVALID_FLAG, not temDISABLED.
+func (p *Payment) PreflightRules(rules *amendment.Rules) error {
+	if p.isMPTDirect() && !rules.Enabled(amendment.FeatureMPTokensV1) {
+		return ter.Errorf(ter.TemDISABLED, "MPT payment requires MPTokensV1 amendment")
+	}
+	return nil
+}
+
 // isMPTDirect returns true if this payment is an MPT direct payment.
 // Checks both the legacy MPTokenIssuanceID field and the Amount's embedded mpt_issuance_id.
 // Reference: rippled Payment.cpp: bool const mptDirect = dstAmount.holds<MPTIssue>();
@@ -116,158 +147,112 @@ func (p *Payment) isMPTDirect() bool {
 	return p.MPTokenIssuanceID != "" || p.Amount.IsMPT()
 }
 
-// Reference: rippled Payment.cpp preflight() function
+// Validate runs the rules-free structural preflight checks of Payment::preflight
+// in rippled's exact order. The flags mask (GetFlagsMask) is enforced by the
+// engine at the preflight0 position, before this body; the MPT amendment gate is
+// in PreflightRules, after the mask. Path-element shape validation is NOT done
+// here — rippled surfaces it at doApply (toStrand), so it lives in the strand
+// builder, letting preclaim codes (tecNO_DST, …) win as rippled intends.
 func (p *Payment) Validate() error {
 	if err := p.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	if p.Destination == "" {
-		return ter.Errorf(ter.TemDST_NEEDED, "Destination is required")
-	}
-
-	if p.Amount.IsZero() {
-		return ter.Errorf(ter.TemBAD_AMOUNT, "Amount is required")
-	}
-
-	// Determine if this is an MPT direct payment
-	// Reference: rippled Payment.cpp:86: bool const mptDirect = dstAmount.holds<MPTIssue>();
 	mptDirect := p.isMPTDirect()
-
-	// Determine if this is an XRP-to-XRP (direct) payment
-	// Reference: rippled Payment.cpp:129
-	xrpDirect := p.Amount.IsNative() && (p.SendMax == nil || p.SendMax.IsNative())
-
-	// Check flags based on payment type
 	flags := p.GetFlags()
-
-	// MPT payments use a stricter flag mask (no tfNoRippleDirect, no tfLimitQuality)
-	// Reference: rippled Payment.cpp:93-99 tfMPTPaymentMask
-	if mptDirect {
-		// tfMPTPaymentMask = ~(tfUniversal | tfPartialPayment)
-		// Only tfPartialPayment is allowed for MPT payments (beyond universal flags)
-		mptPaymentMask := ^(tx.TfUniversal | PaymentFlagPartialPayment)
-		if flags&mptPaymentMask != 0 {
-			return ter.Errorf(ter.TemINVALID_FLAG, "Invalid flags for MPT payment")
-		}
-	}
-
-	partialPaymentAllowed := (flags & PaymentFlagPartialPayment) != 0
-	limitQuality := (flags & PaymentFlagLimitQuality) != 0
-	noRippleDirect := (flags & PaymentFlagNoDirectRipple) != 0
 	hasPaths := len(p.Paths) > 0
 
-	// MPT payments cannot have paths (sfPaths)
-	// Reference: rippled Payment.cpp:101-102
+	// MPT payments cannot carry paths.
 	if mptDirect && hasPaths {
 		return ter.Errorf(ter.TemMALFORMED, "Paths not allowed for MPT payment")
 	}
 
-	// MPT issue consistency check.
-	// When Amount carries an embedded mpt_issuance_id (wire format), SendMax must
-	// also be MPT with the same issuance ID. Non-MPT SendMax with MPT Amount is invalid.
-	// Reference: rippled Payment.cpp:116-124
-	//   if ((mptDirect && dstAmount.asset() != maxSourceAmount.asset()) ||
-	//       (!mptDirect && maxSourceAmount.holds<MPTIssue>()))
+	// maxSourceAmount is SendMax when present, else the delivered Amount. The
+	// inconsistent-issues check rejects an MPT Amount whose source asset differs,
+	// and an MPT SendMax paired with a non-MPT Amount.
 	srcAmount := p.Amount
 	if p.SendMax != nil {
 		srcAmount = *p.SendMax
 	}
 	if p.Amount.IsMPT() {
-		// Wire-format MPT: SendMax must be same MPT or absent
 		if p.SendMax != nil && (!p.SendMax.IsMPT() ||
 			p.SendMax.MPTIssuanceID() != p.Amount.MPTIssuanceID()) {
 			return ter.Errorf(ter.TemMALFORMED, "Inconsistent MPT issues in Amount and SendMax")
 		}
 	} else if !mptDirect && srcAmount.IsMPT() {
-		// Non-MPT payment cannot have MPT SendMax
 		return ter.Errorf(ter.TemMALFORMED, "MPT SendMax not allowed for non-MPT payment")
 	}
 
-	// Amount and SendMax must be positive (> 0)
-	// Reference: rippled Payment.cpp:142-153
+	xrpDirect := srcAmount.IsNative() && p.Amount.IsNative()
+
+	// isLegalNet(dstAmount) / isLegalNet(maxSourceAmount) — native magnitude cap.
+	if !isLegalNet(p.Amount) || !isLegalNet(srcAmount) {
+		return ter.Errorf(ter.TemBAD_AMOUNT, "amount exceeds native limit")
+	}
+
+	// temDST_NEEDED fires for a missing Destination field and for the zero
+	// AccountID (rippled `if (!dstAccountID)`), which is wire-valid and signable.
+	if p.Destination == "" {
+		return ter.Errorf(ter.TemDST_NEEDED, "Destination is required")
+	}
+	if destID, decErr := state.DecodeAccountID(p.Destination); decErr == nil && destID == ([20]byte{}) {
+		return ter.Errorf(ter.TemDST_NEEDED, "Destination is required")
+	}
+
+	// maxSourceAmount and dstAmount must be strictly positive.
 	if p.SendMax != nil && (p.SendMax.IsZero() || p.SendMax.IsNegative()) {
 		return ter.Errorf(ter.TemBAD_AMOUNT, "SendMax must be positive")
 	}
-	if p.Amount.IsNegative() {
+	if p.Amount.IsZero() || p.Amount.IsNegative() {
 		return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
 	}
 
-	// Reject "XRP" used as a non-native (IOU) currency code on either the
-	// source asset (SendMax if present, else Amount) or the destination asset.
-	// Reference: rippled Payment.cpp:154-158 — badCurrency() == srcAsset || dstAsset.
+	// Reject "XRP" used as a non-native (IOU) currency code on either the source
+	// asset (SendMax if present, else Amount) or the destination asset.
 	if (!srcAmount.IsNative() && !srcAmount.IsMPT() && srcAmount.Currency == tx.BadCurrency) ||
 		(!p.Amount.IsNative() && !p.Amount.IsMPT() && p.Amount.Currency == tx.BadCurrency) {
 		return ter.Errorf(ter.TemBAD_CURRENCY, "cannot use XRP as non-native currency code")
 	}
 
-	// Cannot send to self with same source/destination asset (temREDUNDANT)
-	// Reference: rippled Payment.cpp:126-127,159-167
-	// srcAsset = maxSourceAmount.asset() (SendMax if set, else Amount)
-	// dstAsset = dstAmount.asset()
-	// Only redundant if equalTokens(srcAsset, dstAsset) — same currency+issuer
-	equalTokens := (srcAmount.IsNative() && p.Amount.IsNative()) ||
-		(!srcAmount.IsNative() && !p.Amount.IsNative() &&
-			srcAmount.Currency == p.Amount.Currency &&
-			srcAmount.Issuer == p.Amount.Issuer)
-	if mptDirect {
-		equalTokens = true // MPT direct: src and dst are same issuance
-	}
-	if p.Account == p.Destination && equalTokens && !hasPaths {
+	// Redundant self-payment: same account, same token, no paths. equalTokens
+	// compares the token (currency for IOU, issuance for MPT), NOT the issuer.
+	if p.Account == p.Destination && equalTokens(srcAmount, p.Amount, mptDirect) && !hasPaths {
 		return ter.Errorf(ter.TemREDUNDANT, "cannot send to self without path")
 	}
 
-	// XRP to XRP with SendMax is invalid (temBAD_SEND_XRP_MAX)
-	// Reference: rippled Payment.cpp:168-174
+	partialPaymentAllowed := (flags & PaymentFlagPartialPayment) != 0
+	limitQuality := (flags & PaymentFlagLimitQuality) != 0
+	noRippleDirect := (flags & PaymentFlagNoDirectRipple) != 0
+
 	if xrpDirect && p.SendMax != nil {
 		return ter.Errorf(ter.TemBAD_SEND_XRP_MAX, "SendMax specified for XRP to XRP")
 	}
-
-	// XRP/MPT with paths is invalid (temBAD_SEND_XRP_PATHS)
-	// Reference: rippled Payment.cpp:175-181
 	if (xrpDirect || mptDirect) && hasPaths {
 		return ter.Errorf(ter.TemBAD_SEND_XRP_PATHS, "Paths specified for XRP to XRP or MPT to MPT")
 	}
-
-	// tfPartialPayment flag is invalid for XRP-to-XRP payments (temBAD_SEND_XRP_PARTIAL)
-	// Reference: rippled Payment.cpp:182-188
 	if xrpDirect && partialPaymentAllowed {
 		return ter.Errorf(ter.TemBAD_SEND_XRP_PARTIAL, "Partial payment specified for XRP to XRP")
 	}
-
-	// tfLimitQuality flag is invalid for XRP/MPT direct payments (temBAD_SEND_XRP_LIMIT)
-	// Reference: rippled Payment.cpp:189-196
 	if (xrpDirect || mptDirect) && limitQuality {
 		return ter.Errorf(ter.TemBAD_SEND_XRP_LIMIT, "Limit quality specified for XRP to XRP or MPT to MPT")
 	}
-
-	// tfNoRippleDirect flag is invalid for XRP/MPT direct payments (temBAD_SEND_XRP_NO_DIRECT)
-	// Reference: rippled Payment.cpp:197-204
 	if (xrpDirect || mptDirect) && noRippleDirect {
 		return ter.Errorf(ter.TemBAD_SEND_XRP_NO_DIRECT, "No ripple direct specified for XRP to XRP or MPT to MPT")
 	}
 
-	// DeliverMin can only be used with tfPartialPayment flag (temBAD_AMOUNT)
-	// Reference: rippled Payment.cpp:206-214
-	if p.DeliverMin != nil && !partialPaymentAllowed {
-		return ter.Errorf(ter.TemBAD_AMOUNT, "DeliverMin requires tfPartialPayment flag")
-	}
-
-	// Validate DeliverMin if present
-	// Reference: rippled Payment.cpp:216-238
+	// DeliverMin: requires tfPartialPayment, must be legal/positive, must hold the
+	// same asset as Amount (rippled dMin.asset() != dstAmount.asset()), and must
+	// not exceed Amount.
 	if p.DeliverMin != nil {
-		// DeliverMin must be positive (not zero, not negative)
-		if p.DeliverMin.IsZero() || p.DeliverMin.IsNegative() {
+		if !partialPaymentAllowed {
+			return ter.Errorf(ter.TemBAD_AMOUNT, "DeliverMin requires tfPartialPayment flag")
+		}
+		if !isLegalNet(*p.DeliverMin) || p.DeliverMin.IsZero() || p.DeliverMin.IsNegative() {
 			return ter.Errorf(ter.TemBAD_AMOUNT, "DeliverMin must be positive")
 		}
-
-		// DeliverMin currency must match Amount currency
-		if p.DeliverMin.Currency != p.Amount.Currency || p.DeliverMin.Issuer != p.Amount.Issuer {
-			return ter.Errorf(ter.TemBAD_AMOUNT, "DeliverMin currency must match Amount")
+		if !sameAsset(*p.DeliverMin, p.Amount) {
+			return ter.Errorf(ter.TemBAD_AMOUNT, "DeliverMin asset must match Amount")
 		}
-
-		// DeliverMin cannot exceed Amount
-		// Reference: rippled Payment.cpp:232-238
 		if p.DeliverMin.Compare(p.Amount) > 0 {
 			return ter.Errorf(ter.TemBAD_AMOUNT, "DeliverMin cannot exceed Amount")
 		}
@@ -275,12 +260,20 @@ func (p *Payment) Validate() error {
 
 	// Path count/length limits are NOT checked here. rippled enforces them in
 	// preclaim, gated on an open ledger, returning telBAD_PATH_COUNT — see
-	// Payment.Preclaim() below and rippled Payment.cpp:348-360.
+	// Payment.Preclaim() below.
 
-	// Validate path elements
-	// Reference: rippled PaySteps.cpp:157-186
-	if err := p.validatePathElements(); err != nil {
-		return err
+	// Path-element shape validation lives in the strand builder (strand.go), at
+	// doApply, matching rippled toStrand — so preclaim codes win over a malformed
+	// path. The sole exception is a type-zero element (none of account/currency/
+	// issuer): go-xrpl cannot serialize it, so it can never reach the strand
+	// builder. Reject it here to surface rippled's temBAD_PATH rather than an
+	// internal serialization failure.
+	for _, path := range p.Paths {
+		for _, elem := range path {
+			if elem.Account == "" && elem.Currency == "" && elem.Issuer == "" {
+				return ter.Errorf(ter.TemBAD_PATH, "path element has no account, currency, or issuer")
+			}
+		}
 	}
 
 	// Validate CredentialIDs field. HasField detects an empty array supplied on
@@ -293,64 +286,35 @@ func (p *Payment) Validate() error {
 	return nil
 }
 
-// validatePathElements validates individual path elements
-// Reference: rippled PaySteps.cpp toStrand() lines 157-186
-func (p *Payment) validatePathElements() error {
-	for _, path := range p.Paths {
-		for _, elem := range path {
-			// Determine what the element has
-			hasAccount := elem.Account != ""
-			hasCurrency := elem.Currency != ""
-			hasIssuer := elem.Issuer != ""
-
-			// Calculate element type
-			elemType := 0
-			if hasAccount {
-				elemType |= int(PathTypeAccount)
-			}
-			if hasCurrency {
-				elemType |= int(PathTypeCurrency)
-			}
-			if hasIssuer {
-				elemType |= int(PathTypeIssuer)
-			}
-
-			// Path element with type zero is invalid
-			// Reference: rippled PaySteps.cpp:161 - if ((t & ~STPathElement::typeAll) || !t)
-			if elemType == 0 {
-				return ter.Errorf(ter.TemBAD_PATH, "Path element has no account, currency, or issuer")
-			}
-
-			// Account element cannot also have currency or issuer
-			// Reference: rippled PaySteps.cpp:168-169
-			if hasAccount && (hasCurrency || hasIssuer) {
-				return ter.Errorf(ter.TemBAD_PATH, "Path element has account with currency or issuer")
-			}
-
-			// XRP issuer is invalid (issuer must not be XRP pseudo-account)
-			// Reference: rippled PaySteps.cpp:171-172
-			if hasIssuer && (elem.Issuer == "rrrrrrrrrrrrrrrrrrrrrhoLvTp" || elem.Issuer == "" && hasCurrency && elem.Currency == "XRP") {
-				return ter.Errorf(ter.TemBAD_PATH, "Path element has XRP issuer")
-			}
-
-			// XRP account in path is invalid (account must not be XRP pseudo-account)
-			// Reference: rippled PaySteps.cpp:174-175
-			if hasAccount && elem.Account == "rrrrrrrrrrrrrrrrrrrrrhoLvTp" {
-				return ter.Errorf(ter.TemBAD_PATH, "Path element has XRP account")
-			}
-
-			// XRP currency with non-XRP issuer or vice versa is invalid
-			// Reference: rippled PaySteps.cpp:177-179
-			if hasCurrency && hasIssuer {
-				isXRPCurrency := elem.Currency == "XRP" || elem.Currency == ""
-				isXRPIssuer := elem.Issuer == "rrrrrrrrrrrrrrrrrrrrrhoLvTp" || elem.Issuer == ""
-				if isXRPCurrency != isXRPIssuer {
-					return ter.Errorf(ter.TemBAD_PATH, "XRP currency mismatch with issuer")
-				}
-			}
-		}
+// isLegalNet mirrors rippled STAmount isLegalNet: a native amount's magnitude may
+// not exceed cMaxNativeN; non-native amounts are always legal.
+func isLegalNet(a tx.Amount) bool {
+	if !a.IsNative() {
+		return true
 	}
-	return nil
+	d := a.Drops()
+	if d < 0 {
+		d = -d
+	}
+	return uint64(d) <= maxNativeDrops
+}
+
+// equalTokens mirrors rippled equalTokens: two IOU tokens are equal iff their
+// currencies match (issuer ignored); two MPT tokens iff their issuances match;
+// two native amounts are always equal; any cross-kind pair is unequal. mptDirect
+// signals both sides are the same MPT issuance (the inconsistent-issues check
+// above already guaranteed it).
+func equalTokens(src, dst tx.Amount, mptDirect bool) bool {
+	switch {
+	case src.IsNative() && dst.IsNative():
+		return true
+	case mptDirect:
+		return true
+	case !src.IsNative() && !src.IsMPT() && !dst.IsNative() && !dst.IsMPT():
+		return src.Currency == dst.Currency
+	default:
+		return false
+	}
 }
 
 // Preclaim performs stateful validation against the current ledger view,

--- a/internal/tx/payment/payment_test.go
+++ b/internal/tx/payment/payment_test.go
@@ -146,7 +146,7 @@ func TestPaymentValidation(t *testing.T) {
 				Destination: "rBob",
 			},
 			expectError: true,
-			errorMsg:    "temBAD_AMOUNT: Amount is required",
+			errorMsg:    "temBAD_AMOUNT: Amount must be positive",
 		},
 		{
 			name: "missing account",
@@ -1154,7 +1154,7 @@ func TestDeliverMinValidation(t *testing.T) {
 				return p
 			}(),
 			expectError: true,
-			errorMsg:    "temBAD_AMOUNT: DeliverMin currency must match Amount",
+			errorMsg:    "temBAD_AMOUNT: DeliverMin asset must match Amount",
 		},
 
 		// DeliverMin issuer must match Amount issuer
@@ -1173,7 +1173,7 @@ func TestDeliverMinValidation(t *testing.T) {
 				return p
 			}(),
 			expectError: true,
-			errorMsg:    "temBAD_AMOUNT: DeliverMin currency must match Amount",
+			errorMsg:    "temBAD_AMOUNT: DeliverMin asset must match Amount",
 		},
 
 		// DeliverMin must not exceed Amount.

--- a/internal/tx/payment/strand.go
+++ b/internal/tx/payment/strand.go
@@ -328,11 +328,53 @@ func ToStrandWithContext(
 	path []PathStep,
 	isDefaultPath bool,
 ) (Strand, ter.Result) {
+	// Path-element shape validation runs here, at strand-construction time (during
+	// doApply), not in Payment preflight — mirroring rippled toStrand. This lets
+	// preclaim codes (tecNO_DST, tecDST_TAG_NEEDED, …) win over a malformed path,
+	// exactly as rippled orders them.
+	if r := validatePathElementShapes(path); r != ter.TesSUCCESS {
+		return nil, r
+	}
 	normPath := buildNormalizedPath(ctx, src, dst, dstIssue, srcIssue, path)
 	if len(normPath) < 2 {
 		return nil, ter.TemBAD_PATH
 	}
 	return ctx.buildStrandSteps(src, dst, dstIssue, srcIssue, normPath)
+}
+
+// validatePathElementShapes rejects malformed path elements with temBAD_PATH,
+// mirroring rippled toStrand(): an element must set at least one of
+// account/currency/issuer; an account element may not also carry
+// currency or issuer; the XRP pseudo-account may not appear as account or issuer;
+// and a currency+issuer pair must agree on XRP-ness.
+func validatePathElementShapes(path []PathStep) ter.Result {
+	const xrpPseudoAccount = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+	for _, elem := range path {
+		hasAccount := elem.Account != ""
+		hasCurrency := elem.Currency != ""
+		hasIssuer := elem.Issuer != ""
+
+		if !hasAccount && !hasCurrency && !hasIssuer {
+			return ter.TemBAD_PATH
+		}
+		if hasAccount && (hasCurrency || hasIssuer) {
+			return ter.TemBAD_PATH
+		}
+		if hasIssuer && elem.Issuer == xrpPseudoAccount {
+			return ter.TemBAD_PATH
+		}
+		if hasAccount && elem.Account == xrpPseudoAccount {
+			return ter.TemBAD_PATH
+		}
+		if hasCurrency && hasIssuer {
+			isXRPCurrency := elem.Currency == "XRP"
+			isXRPIssuer := elem.Issuer == xrpPseudoAccount
+			if isXRPCurrency != isXRPIssuer {
+				return ter.TemBAD_PATH
+			}
+		}
+	}
+	return ter.TesSUCCESS
 }
 
 // buildNormalizedPath expands an explicit path into the normalized node list


### PR DESCRIPTION
Aligns the **Payment** and **Offer** transaction families' preflight TER precedence with rippled (tag 3.1.0), adopting the engine seams merged in #1271 (`FlagsMasker`, `ExtraFeaturesChecker`) so the flags mask and amendment gates fire at their rippled preflight positions, and reordering each `Validate` body to rippled's exact `T::preflight` sequence.

Part of #274 (preflight precedence audit); follows #1271.

## Findings

### Payment
| # | Finding | Kind | Sev | Status | How |
|---|---------|------|-----|--------|-----|
| P1 | Payment mask accepts undefined flag bits | mask-value | high | **Fixed** | `FlagsMasker` returns `tfPaymentMask`/`tfMPTPaymentMask` by Amount kind; enforced at preflight0 |
| P2 | `temDST_NEEDED` missing for the zero AccountID | missing-check | high | **Fixed** | decode Destination; zero AccountID → `temDST_NEEDED`, at rippled's position (after isLegalNet) |
| P3 | `equalTokens` compared the issuer | missing-check | high | **Fixed** | currency-only for IOU, issuance-id for MPT, native/native true, else false |
| P4 | path-element validation ran in preflight | extra-check | high | **Fixed** | moved to the strand builder (`doApply`), so preclaim codes (`tecNO_DST`, …) win; type-0 element kept guarded (see Deviations) |
| P5 | DeliverMin asset check was string-only | missing-check | high | **Fixed** | full asset identity (native / IOU currency+issuer / MPT issuance) |
| P6 | MPT flags mask ran after body checks | mask-position | medium | **Fixed** | subsumed by P1 (`FlagsMasker` at preflight0) |
| P7 | `dstAmount<=0` checked too early | order | medium | **Fixed** | moved after the MPT+Paths and inconsistent-issues `temMALFORMED` checks |
| P8 | native `isLegalNet` bound | missing-check | medium | **Partial** | preflight `isLegalNet` added at rippled's position; codec-decode reporting residual deferred (see Deviations) |
| P9 | MPT `temDISABLED` ran before the mask | order | low | **Fixed** | moved to `PreflightRules` (after mask); dropped `FeatureMPTokensV1` from `RequiredAmendments` |

### Offer
| # | Finding | Kind | Sev | Status | How |
|---|---------|------|-----|--------|-----|
| O1 | `isLegalNetAmount` was `!IsZero()` → zero gave `temBAD_AMOUNT` | other | high | **Fixed** | rippled `isLegalNet` (native magnitude cap; zero passes) → zero falls through to `temBAD_OFFER` |
| O2 | native `>cMaxNativeN` codec-decode reporting | missing-check | medium | **Partial** | preflight predicate now faithful (shared with O1); codec-decode reporting residual deferred (see Deviations) |
| O3 | sfDomainID `temDISABLED` ran after the body | order | medium | **Fixed** | `ExtraFeaturesChecker`: DomainID + !PermissionedDEX → `temDISABLED` before the body |
| O4 | flags mask was not amendment-conditional | mask-position | low | **Fixed** | `FlagsMasker` returns `tfOfferCreateMask` (`\| tfHybrid` when PermissionedDEX off) at preflight0 |

Also: **OfferCancel** adopts `FlagsMasker` (universal mask), replacing its in-`Validate` flag check.

No findings were refuted; the "unverified" offer zero-amount finding (O1) was re-verified against `CreateOffer.cpp`/`STAmount.h` at 3.1.0 and confirmed.

## Deviations
- **P8 / O2 codec-decode residual (deferred).** go-xrpl enforces the native `cMaxNativeN` (10^17 drops) cap at three deliberate overflow-defense layers — binary codec decode, codec encode/`verifyXrpValue`, and JSON parse — so an over-cap native amount (e.g. 2×10^17 drops, above the total XRP supply) submitted as a `tx_blob` is rejected at decode rather than reaching preflight's `isLegalNet` (`temBAD_AMOUNT`). rippled's own JSON path also rejects such amounts (`canonicalize` throws); only the wire/blob path differs, and no ledger state is affected. The preflight `isLegalNet` logic is now rippled-faithful in both families; relaxing the three-layer cap for an adversarial, unrepresentable-in-state amount was judged out of scope for its blast radius.
- **P4 type-zero path element.** go-xrpl cannot serialize a type-zero (all-empty) path element, so it can never reach the strand builder where rippled's `toStrand` rejects it. A minimal type-zero guard remains in preflight to surface rippled's `temBAD_PATH` rather than an internal serialization `tefINTERNAL`; all serializable shape checks moved to the strand builder, so the finding's fork scenario (account+currency element + nonexistent destination → `tecNO_DST`) is fixed.

## Verification
- One engine-preflight pin-test per finding in `internal/tx/engine/payment_offer_precedence_test.go` (12 tests, all green), constructing each divergent tx and asserting rippled's code.
- `go test ./...` — green except the pre-existing out-of-scope conformance stubs (Batch/Vault/XChain/XChainSim).
- Conformance failing-set diff vs a fresh `origin/v3.0.0` checkout: **identical (120 = 120), zero new failures, zero fixture TER changes**. Test edits are unit-level only (two DeliverMin/Amount message rewordings — same TER — and the OfferCancel flag assertion moved from `Validate` to `GetFlagsMask`).
- `golangci-lint run --config .golangci.yml ./...` — **0 issues**.
- `docs-gen` registry/RPC catalogs regenerate with no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
