### PR TITLE
fix(trustset,depositpreauth): align preflight TER precedence with rippled

### DIFF
--- a/internal/testing/depositpreauth/precedence_test.go
+++ b/internal/testing/depositpreauth/precedence_test.go
@@ -1,0 +1,47 @@
+package depositpreauth_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	dp "github.com/LeJamon/go-xrpl/internal/testing/depositpreauth"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/depositpreauth"
+)
+
+// TestDepositPreauth_Precedence_FullyCanonicalSigAllowed pins finding #1: a
+// DepositPreauth carrying tfFullyCanonicalSig (set by default by many client
+// libraries, and by every inner-batch transaction via tfInnerBatchTxn) is valid.
+// The flags mask permits the tfUniversal bits, so the transaction succeeds rather
+// than being rejected temINVALID_FLAG (a tes-vs-tem consensus fork before the fix).
+// Reference: rippled DepositPreauth has no getFlagsMask override → tfUniversalMask.
+func TestDepositPreauth_Precedence_FullyCanonicalSigAllowed(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	becky := jtx.NewAccount("becky")
+	env.Fund(alice, becky)
+	env.Close()
+
+	result := env.Submit(dp.Auth(alice, becky).Flags(tx.TfFullyCanonicalSig).Build())
+	jtx.RequireTxSuccess(t, result)
+	jtx.RequireLedgerEntryExists(t, env, dp.DepositPreauthKeylet(alice, becky))
+}
+
+// TestDepositPreauth_Precedence_EmptyCredentialsDisabledAmendment pins finding #6:
+// with featureCredentials disabled, a present-but-empty AuthorizeCredentials array
+// is temDISABLED (the checkExtraFeatures field-presence gate), not temARRAY_EMPTY.
+// The amendment gate is keyed on field presence and precedes the preflight body.
+// Reference: rippled DepositPreauth.cpp checkExtraFeatures (isFieldPresent gate).
+func TestDepositPreauth_Precedence_EmptyCredentialsDisabledAmendment(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.DisableFeature("Credentials")
+	alice := jtx.NewAccount("alice")
+	env.Fund(alice)
+	env.Close()
+
+	raw := dp.Raw(alice.Address).
+		AuthorizeCredentials([]depositpreauth.CredentialWrapper{}).
+		Fee("10").
+		Sequence(env.Seq(alice))
+	jtx.RequireTxFail(t, env.Submit(raw.Build()), "temDISABLED")
+}

--- a/internal/testing/trustset/builder.go
+++ b/internal/testing/trustset/builder.go
@@ -120,6 +120,18 @@ func (b *TrustSetBuilder) ClearFreeze() *TrustSetBuilder {
 	return b
 }
 
+// DeepFreeze deep-freezes this trust line (requires featureDeepFreeze).
+func (b *TrustSetBuilder) DeepFreeze() *TrustSetBuilder {
+	b.flags |= trustsettx.TrustSetFlagSetDeepFreeze
+	return b
+}
+
+// ClearDeepFreeze clears the deep-freeze flag on this trust line.
+func (b *TrustSetBuilder) ClearDeepFreeze() *TrustSetBuilder {
+	b.flags |= trustsettx.TrustSetFlagClearDeepFreeze
+	return b
+}
+
 // Build constructs the TrustSet transaction.
 func (b *TrustSetBuilder) Build() tx.Transaction {
 	ts := trustsettx.NewTrustSet(b.account.Address, b.limitAmount)

--- a/internal/testing/trustset/precedence_test.go
+++ b/internal/testing/trustset/precedence_test.go
@@ -1,0 +1,86 @@
+package trustset
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+// TestTrustSet_Precedence_DeepFreezeDisabledIsPreflightReject pins finding #2:
+// without featureDeepFreeze, a deep-freeze flag is rejected temINVALID_FLAG at
+// preflight — before any ledger-stage tec/tef. Previously this rejection lived
+// in Apply(), after the tecNO_DST/tecNO_PERMISSION/tefNO_AUTH_REQUIRED checks, so
+// a deep-freeze flag combined with e.g. tfSetfAuth surfaced tefNO_AUTH_REQUIRED
+// (or a tec) instead — a tem-vs-tec/tef consensus fork.
+// Reference: rippled SetTrust.cpp preflight() featureDeepFreeze gate (first check).
+func TestTrustSet_Precedence_DeepFreezeDisabledIsPreflightReject(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.DisableFeature("DeepFreeze")
+	gw := jtx.NewAccount("gw")
+	alice := jtx.NewAccount("alice")
+	env.Fund(gw, alice)
+	env.Close()
+
+	// Plain deep-freeze flag on a well-formed limit → temINVALID_FLAG.
+	jtx.RequireTxFail(t, env.Submit(TrustLine(alice, "USD", gw, "100").DeepFreeze().Build()),
+		"temINVALID_FLAG")
+
+	// Combined with tfSetfAuth (no lsfRequireAuth): the preflight flag rejection
+	// still wins over the Apply-stage tefNO_AUTH_REQUIRED.
+	jtx.RequireTxFail(t, env.Submit(TrustLine(alice, "USD", gw, "100").SetAuth().DeepFreeze().Build()),
+		"temINVALID_FLAG")
+}
+
+// TestTrustSet_Precedence_NativeLimitTooLarge pins finding #5: a native
+// LimitAmount whose magnitude exceeds the total XRP supply (cMaxNativeN, 1e17
+// drops) is temBAD_AMOUNT (isLegalNet), not temBAD_LIMIT.
+// Reference: rippled SetTrust.cpp preflight() !isLegalNet check ahead of native.
+func TestTrustSet_Precedence_NativeLimitTooLarge(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	gw := jtx.NewAccount("gw")
+	alice := jtx.NewAccount("alice")
+	env.Fund(gw, alice)
+	env.Close()
+
+	ts := TrustSet(alice, tx.NewXRPAmount(200_000_000_000_000_000)).Build()
+	jtx.RequireTxFail(t, env.Submit(ts), "temBAD_AMOUNT")
+}
+
+// TestTrustSet_Precedence_SelfTrustAuthOrdering pins finding #3: temDST_IS_SRC is
+// a ledger-stage preclaim check, evaluated AFTER the tfSetfAuth check. A self
+// trust line carrying tfSetfAuth without lsfRequireAuth therefore surfaces
+// tefNO_AUTH_REQUIRED, not temDST_IS_SRC; a plain self trust line still gets
+// temDST_IS_SRC (fixTrustLinesToSelf is enabled in the test env).
+// Reference: rippled SetTrust.cpp preclaim() order (tefNO_AUTH_REQUIRED then temDST_IS_SRC).
+func TestTrustSet_Precedence_SelfTrustAuthOrdering(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	env.Fund(alice)
+	env.Close()
+
+	// Self trust + tfSetfAuth, sender lacks lsfRequireAuth → tefNO_AUTH_REQUIRED.
+	jtx.RequireTxFail(t, env.Submit(TrustLine(alice, "USD", alice, "100").SetAuth().Build()),
+		"tefNO_AUTH_REQUIRED")
+
+	// Plain self trust → temDST_IS_SRC at the ledger stage.
+	jtx.RequireTxFail(t, env.Submit(TrustLine(alice, "USD", alice, "100").Build()),
+		"temDST_IS_SRC")
+}
+
+// TestTrustSet_Precedence_AuthBeforeNoDst pins finding #4: the tfSetfAuth check
+// (tefNO_AUTH_REQUIRED) precedes the destination-existence check (tecNO_DST). A
+// tfSetfAuth TrustSet without lsfRequireAuth, naming a non-existent issuer on a
+// ledger with DisallowIncoming/AMM enabled, surfaces tefNO_AUTH_REQUIRED — not
+// tecNO_DST (a tef-vs-tec consensus fork before the fix).
+// Reference: rippled SetTrust.cpp preclaim() order (tefNO_AUTH_REQUIRED then tecNO_DST).
+func TestTrustSet_Precedence_AuthBeforeNoDst(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	ghost := jtx.NewAccount("ghost") // never funded → does not exist in the ledger
+	env.Fund(alice)
+	env.Close()
+
+	jtx.RequireTxFail(t, env.Submit(TrustLine(alice, "USD", ghost, "100").SetAuth().Build()),
+		"tefNO_AUTH_REQUIRED")
+}

--- a/internal/tx/depositpreauth/depositpreauth.go
+++ b/internal/tx/depositpreauth/depositpreauth.go
@@ -72,24 +72,36 @@ func (d *DepositPreauth) TxType() tx.Type {
 	return tx.TypeDepositPreauth
 }
 
-// Reference: rippled DepositPreauth::preflight() amendment checks
 func (d *DepositPreauth) RequiredAmendments() [][32]byte {
-	amendments := [][32]byte{amendment.FeatureDepositPreauth}
-	if len(d.AuthorizeCredentials) > 0 || len(d.UnauthorizeCredentials) > 0 {
-		amendments = append(amendments, amendment.FeatureCredentials)
+	return [][32]byte{amendment.FeatureDepositPreauth}
+}
+
+// CheckExtraFeatures gates the credential-based forms on the Credentials
+// amendment. Presence is keyed on the field, not its length, so a present but
+// empty AuthorizeCredentials/UnauthorizeCredentials array with the amendment
+// disabled is temDISABLED — the same NotTEC rippled returns from
+// checkExtraFeatures, before preflight1's common checks and before the
+// temARRAY_EMPTY body check.
+func (d *DepositPreauth) CheckExtraFeatures(rules *amendment.Rules) error {
+	if (d.AuthorizeCredentials != nil || d.UnauthorizeCredentials != nil) &&
+		!rules.Enabled(amendment.FeatureCredentials) {
+		return ter.Errorf(ter.TemDISABLED, "credentials require the Credentials amendment")
 	}
-	return amendments
+	return nil
+}
+
+// GetFlagsMask reports the invalid-flag mask. DepositPreauth defines no
+// type-specific flags, so only the universal bits (tfFullyCanonicalSig,
+// tfInnerBatchTxn) are permitted — matching rippled, which leaves getFlagsMask
+// at its tfUniversalMask default. The engine rejects flags intersecting the
+// mask at preflight0.
+func (d *DepositPreauth) GetFlagsMask(rules *amendment.Rules) uint32 {
+	return tx.TfUniversalMask
 }
 
 // Reference: rippled DepositPreauth::preflight()
 func (d *DepositPreauth) Validate() error {
 	if err := d.BaseTx.Validate(); err != nil {
-		return err
-	}
-
-	// No flags allowed
-	// Reference: rippled preflight() - tx.getFlags() & tfUniversalMask
-	if err := tx.CheckNoFlags(d.GetFlags()); err != nil {
 		return err
 	}
 

--- a/internal/tx/trustset/trustset.go
+++ b/internal/tx/trustset/trustset.go
@@ -68,17 +68,31 @@ func (t *TrustSet) TxType() tx.Type {
 	return tx.TypeTrustSet
 }
 
-// Reference: rippled SetTrust.cpp preflight()
+// cMaxNativeN is the largest legal native (XRP) mantissa: the total XRP supply
+// in drops. A native LimitAmount whose magnitude exceeds it is temBAD_AMOUNT.
+// Reference: rippled STAmount::cMaxNativeN / isLegalNet.
+const cMaxNativeN int64 = 100_000_000_000_000_000
+
+// Validate runs the rules-independent structural checks of rippled's
+// SetTrust::preflight body. The flag mask lives in GetFlagsMask (preflight0),
+// the amendment-gated deep-freeze rejection in PreflightRules, and the
+// self-issuer check is a ledger-stage preclaim check (see Apply) — not preflight.
+// Reference: rippled SetTrust.cpp preflight().
 func (t *TrustSet) Validate() error {
 	if err := t.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	txFlags := t.GetFlags()
-
-	// Check for invalid transaction flags
-	if txFlags&TrustSetFlagMask != 0 {
-		return ter.Errorf(ter.TemINVALID_FLAG, "invalid transaction flags")
+	// isLegalNet: a native limit whose magnitude exceeds the total XRP supply is
+	// temBAD_AMOUNT, checked before the native -> temBAD_LIMIT rejection.
+	if t.LimitAmount.IsNative() {
+		mag := t.LimitAmount.Drops()
+		if mag < 0 {
+			mag = -mag
+		}
+		if mag > cMaxNativeN {
+			return ter.Errorf(ter.TemBAD_AMOUNT, "limit amount exceeds maximum")
+		}
 	}
 
 	// LimitAmount must be an issued currency, not XRP
@@ -107,11 +121,28 @@ func (t *TrustSet) Validate() error {
 		return ter.Errorf(ter.TemDST_NEEDED, "issuer is required")
 	}
 
-	// Cannot create trust line to self
-	if t.LimitAmount.Issuer == t.Account {
-		return ter.Errorf(ter.TemDST_IS_SRC, "cannot create trust line to self")
-	}
+	return nil
+}
 
+// GetFlagsMask reports the invalid-flag mask (rippled SetTrust::getFlagsMask =
+// tfTrustSetMask). The deep-freeze bits are valid in this mask; their amendment
+// gating is the separate preflight-body check in PreflightRules, so the mask is
+// unconditional. The engine rejects flags intersecting it at preflight0.
+func (t *TrustSet) GetFlagsMask(rules *amendment.Rules) uint32 {
+	return TrustSetFlagMask
+}
+
+// PreflightRules runs the amendment-gated deep-freeze rejection at rippled's
+// position: the first statement of SetTrust::preflight's body, after preflight1's
+// fee/account/key checks. The deep-freeze flag bits are valid within
+// tfTrustSetMask, so the flag mask never rejects them; only this
+// amendment-conditional check does.
+// Reference: rippled SetTrust.cpp preflight() (featureDeepFreeze gate).
+func (t *TrustSet) PreflightRules(rules *amendment.Rules) error {
+	if !rules.DeepFreezeEnabled() &&
+		t.GetFlags()&(TrustSetFlagSetDeepFreeze|TrustSetFlagClearDeepFreeze) != 0 {
+		return ter.Errorf(ter.TemINVALID_FLAG, "deep freeze flags require the DeepFreeze amendment")
+	}
 	return nil
 }
 
@@ -191,19 +222,55 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) ter.Result {
 		"flags", t.GetFlags(),
 	)
 
-	// Cannot create trust line to self
-	if t.LimitAmount.Issuer == ctx.Account.Account {
-		return ter.TemDST_IS_SRC
+	accountID, err := state.DecodeAccountID(ctx.Account.Account)
+	if err != nil {
+		return ter.TefINTERNAL
 	}
-
 	issuerAccountID, err := state.DecodeAccountID(t.LimitAmount.Issuer)
 	if err != nil {
 		return ter.TemBAD_ISSUER
 	}
 	issuerKey := keylet.Account(issuerAccountID)
 
-	// Check issuer exists and get issuer account for flag checks
-	// Per rippled SetTrust.cpp: returns tecNO_DST when destination (issuer) doesn't exist
+	// Parse transaction flags up front — tfSetfAuth gates the first preclaim check.
+	txFlags := uint32(0)
+	if t.Flags != nil {
+		txFlags = *t.Flags
+	}
+	bSetAuth := (txFlags & TrustSetFlagSetfAuth) != 0
+	bSetNoRipple := (txFlags & TrustSetFlagSetNoRipple) != 0
+	bClearNoRipple := (txFlags & TrustSetFlagClearNoRipple) != 0
+	bSetFreeze := (txFlags & TrustSetFlagSetFreeze) != 0
+	bClearFreeze := (txFlags & TrustSetFlagClearFreeze) != 0
+	bSetDeepFreeze := (txFlags & TrustSetFlagSetDeepFreeze) != 0
+	bClearDeepFreeze := (txFlags & TrustSetFlagClearDeepFreeze) != 0
+
+	// tefNO_AUTH_REQUIRED — tfSetfAuth requires the sender to have lsfRequireAuth.
+	// rippled SetTrust::preclaim evaluates this right after loading the sender
+	// account, before the self-issuer and destination-existence checks.
+	if bSetAuth && (ctx.Account.Flags&state.LsfRequireAuth) == 0 {
+		return ter.TefNO_AUTH_REQUIRED
+	}
+
+	// Get or create the trust line.
+	trustLineKey := keylet.Line(accountID, issuerAccountID, t.LimitAmount.Currency)
+	trustLineExists, err := ctx.View.Exists(trustLineKey)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+
+	// temDST_IS_SRC — a trust line to self. With fixTrustLinesToSelf any self
+	// line is rejected; without it a pre-existing self line falls through to
+	// doApply, which cleans it up. rippled SetTrust::preclaim orders this after
+	// the tfSetfAuth check and before the destination read.
+	if accountID == issuerAccountID {
+		if ctx.Rules().Enabled(amendment.FeatureFixTrustLinesToSelf) || !trustLineExists {
+			return ter.TemDST_IS_SRC
+		}
+	}
+
+	// Check issuer (destination) exists and load it for the flag checks below.
+	// Per rippled SetTrust.cpp: returns tecNO_DST when the destination doesn't exist.
 	issuerData, err := ctx.View.Read(issuerKey)
 	if err != nil || issuerData == nil {
 		ctx.Log.Warn("trust set: issuer account does not exist",
@@ -212,11 +279,6 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TecNO_DST
 	}
 	issuerAccount, err := state.ParseAccountRoot(issuerData)
-	if err != nil {
-		return ter.TefINTERNAL
-	}
-
-	accountID, err := state.DecodeAccountID(ctx.Account.Account)
 	if err != nil {
 		return ter.TefINTERNAL
 	}
@@ -237,14 +299,6 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) ter.Result {
 
 	// Determine low/high accounts (for consistent trust line ordering)
 	bHigh := state.CompareAccountIDs(accountID, issuerAccountID) > 0
-
-	// Get or create the trust line
-	trustLineKey := keylet.Line(accountID, issuerAccountID, t.LimitAmount.Currency)
-
-	trustLineExists, err := ctx.View.Exists(trustLineKey)
-	if err != nil {
-		return ter.TefINTERNAL
-	}
 
 	// If the destination has opted to disallow incoming trustlines, honour that flag.
 	// Reference: rippled SetTrust.cpp lines 254-271
@@ -293,29 +347,11 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) ter.Result {
 		}
 	}
 
-	// Parse transaction flags
-	txFlags := uint32(0)
-	if t.Flags != nil {
-		txFlags = *t.Flags
-	}
-
-	bSetAuth := (txFlags & TrustSetFlagSetfAuth) != 0
-	bSetNoRipple := (txFlags & TrustSetFlagSetNoRipple) != 0
-	bClearNoRipple := (txFlags & TrustSetFlagClearNoRipple) != 0
-	bSetFreeze := (txFlags & TrustSetFlagSetFreeze) != 0
-	bClearFreeze := (txFlags & TrustSetFlagClearFreeze) != 0
-	bSetDeepFreeze := (txFlags & TrustSetFlagSetDeepFreeze) != 0
-	bClearDeepFreeze := (txFlags & TrustSetFlagClearDeepFreeze) != 0
-
-	// Validate tfSetfAuth - requires issuer to have lsfRequireAuth set
-	if bSetAuth && (ctx.Account.Flags&state.LsfRequireAuth) == 0 {
-		return ter.TefNO_AUTH_REQUIRED
-	}
-
 	bNoFreeze := (ctx.Account.Flags & state.LsfNoFreeze) != 0
 
-	// Deep freeze preclaim checks.
-	// Reference: rippled SetTrust.cpp preflight() lines 87-95 and preclaim() lines 311-361
+	// Deep freeze preclaim invariants. The amendment-disabled flag rejection is a
+	// preflight check (PreflightRules); only these ledger-state invariants remain.
+	// Reference: rippled SetTrust.cpp preclaim() freeze/deep-freeze checks.
 	if ctx.Rules().DeepFreezeEnabled() {
 		// Check #1: Cannot freeze if account has lsfNoFreeze set.
 		// Reference: rippled preclaim() lines 318-322
@@ -364,12 +400,6 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) ter.Result {
 
 		if deepFrozen && !frozen {
 			return ter.TecNO_PERMISSION
-		}
-	} else {
-		// Without featureDeepFreeze, deep freeze flags are invalid.
-		// Reference: rippled preflight() lines 87-95
-		if bSetDeepFreeze || bClearDeepFreeze {
-			return ter.TemINVALID_FLAG
 		}
 	}
 

--- a/internal/tx/trustset/trustset_test.go
+++ b/internal/tx/trustset/trustset_test.go
@@ -107,13 +107,26 @@ func TestTrustSetValidation(t *testing.T) {
 		},
 
 		{
-			name: "trust line to self - should fail",
+			// Self-issuer (temDST_IS_SRC) is a ledger-stage preclaim check in
+			// rippled, not a preflight one, so Validate() must accept it here; the
+			// rejection is exercised at the integration layer.
+			name: "trust line to self - passes preflight",
 			trustSet: &TrustSet{
 				BaseTx:      *tx.NewBaseTx(tx.TypeTrustSet, "rAlice"),
 				LimitAmount: tx.NewIssuedAmountFromFloat64(100, "USD", "rAlice"),
 			},
+			expectError: false,
+		},
+		{
+			// isLegalNet: a native limit above the total XRP supply is temBAD_AMOUNT,
+			// ahead of the native -> temBAD_LIMIT rejection.
+			name: "native limit above max drops - temBAD_AMOUNT",
+			trustSet: &TrustSet{
+				BaseTx:      *tx.NewBaseTx(tx.TypeTrustSet, "rAlice"),
+				LimitAmount: tx.NewXRPAmount(200_000_000_000_000_000),
+			},
 			expectError: true,
-			errorMsg:    "temDST_IS_SRC: cannot create trust line to self",
+			errorMsg:    "temBAD_AMOUNT: limit amount exceeds maximum",
 		},
 
 		{
@@ -650,11 +663,12 @@ func TestTrustSetIssuerValidation(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name:        "same account and issuer - should fail",
+			// Self-issuer is a ledger-stage preclaim check (temDST_IS_SRC), not a
+			// preflight one, so Validate() accepts it.
+			name:        "same account and issuer - passes preflight",
 			account:     "rAlice",
 			issuer:      "rAlice",
-			expectError: true,
-			errorMsg:    "temDST_IS_SRC: cannot create trust line to self",
+			expectError: false,
 		},
 		{
 			name:        "empty issuer - should fail",


### PR DESCRIPTION
Aligns TrustSet and DepositPreauth preflight TER precedence with rippled 3.1.0, fixing 6 adversarially-verified divergences. All fixes adopt the engine preflight seams from #1271 (FlagsMasker / PreflightRules / CheckExtraFeatures), following the exemplar pattern of #1273/#1274.

Part of #274; follows #1271.

## Findings fixed

| # | Tx | Kind | Fork before fix | After fix |
|---|----|------|-----------------|-----------|
| 1 | DepositPreauth | mask-value (high) | `tfFullyCanonicalSig` (client-lib default) / `tfInnerBatchTxn` rejected `temINVALID_FLAG` by `CheckNoFlags` — killed every DepositPreauth in a Batch (**tes-vs-tem** fork) | `FlagsMasker` returns `tfUniversalMask`; universal bits permitted → `tesSUCCESS` |
| 2 | TrustSet | missing-check (high) | Deep-freeze-disabled rejection lived in `Apply()`, after `tecNO_DST`/`tecNO_PERMISSION`/`tefNO_AUTH_REQUIRED` (**tem-vs-tec/tef** fork) | `PreflightRules` deep-freeze gate → `temINVALID_FLAG` at preflight body position; `Apply()` else-branch removed |
| 3 | TrustSet | extra-check (high) | Self-issuer `temDST_IS_SRC` rejected at `Validate()`, ahead of `tefNO_AUTH_REQUIRED` / `terNO_ACCOUNT` (**tem-vs-tef** class mismatch) | Removed from `Validate()`; ledger-stage `temDST_IS_SRC` in `Apply()`, gated on `fixTrustLinesToSelf`, after `tefNO_AUTH_REQUIRED` |
| 4 | TrustSet | order (high) | `tefNO_AUTH_REQUIRED` ran 5th (after issuer read/`tecNO_DST`, DisallowIncoming, pseudo) (**tef-vs-tec** fork) | `Apply()` reordered to rippled preclaim order: auth → self → dst → DisallowIncoming → pseudo → deep-freeze |
| 5 | TrustSet | missing-check (med) | Native limit above total XRP supply → `temBAD_LIMIT` | `isLegalNet` check in `Validate()` → `temBAD_AMOUNT`, ahead of the native rejection (`cMaxNativeN` = 1e17 drops) |
| 6 | DepositPreauth | other (low) | Present-but-empty credentials array with Credentials disabled → `temARRAY_EMPTY` (`RequiredAmendments` used `len>0`) | `CheckExtraFeatures` gates on field presence → `temDISABLED` before the body check |

## Approach notes

- **TrustSet FlagsMasker is unconditional** (`tfTrustSetMask`), matching rippled's `SetTrust::getFlagsMask`. The deep-freeze bits are valid within that mask; their amendment gating is a separate preflight-body check, so it lives in `PreflightRules` (which runs after `preflight1`, exactly matching rippled's body position relative to the fee/account/key checks) — not in a conditional mask, which would reject deep-freeze at preflight0 ahead of the fee check and diverge on `{deep-freeze + bad fee}`.
- **DepositPreauth** is the first adopter of the `CheckExtraFeatures` seam (Credentials gate) and, with TrustSet, the first `FlagsMasker` adopter on `v3.0.0` (#1273/#1274 are not in this base; the `preflightInner` seam is already wired).
- The residual `{deep-freeze + malformed-amount, DeepFreeze off}` ordering edge is `tem`-vs-`tem` (no consensus fork, no fixture/finding exercises it); keeping the rules-free amount/currency/dst checks in `Validate()` preserves inner-batch validation coverage.

## Verification

- **Pin-tests**: one per fork scenario — `TestTrustSet_Precedence_{DeepFreezeDisabledIsPreflightReject,NativeLimitTooLarge,SelfTrustAuthOrdering,AuthBeforeNoDst}` and `TestDepositPreauth_Precedence_{FullyCanonicalSigAllowed,EmptyCredentialsDisabledAmendment}`. All pass.
- **Full `just test`**: pass except the pre-existing out-of-scope conformance stubs (Batch/Vault/XChain), identical to the clean base.
- **Conformance**: In-scope **1260 pass / 0 fail (100%)** — byte-identical to the `v3.0.0` baseline (Total 1334/120 both sides; the 120 failures are OOS Batch/Vault/XChain). SetTrust 14/14, SetAuth 1/1, TrustAndBalance 13/13, DepositAuth 4/4, DepositPreauth 11/11, Credentials 42/42.
- **Strict lint** (`golangci-lint --config .golangci.yml`): 0 issues. **go vet**: clean. **docs-check**: no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
