### PR TITLE
fix(escrow,paychan): align preflight TER precedence with rippled

### DIFF
--- a/internal/testing/escrow/precedence_test.go
+++ b/internal/testing/escrow/precedence_test.go
@@ -1,0 +1,53 @@
+package escrow_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
+	"github.com/stretchr/testify/require"
+)
+
+// strayEscrowFlag is a bit outside tfUniversalMask — Escrow has no type-specific
+// flags, so any non-universal bit is stray for every escrow transaction.
+const strayEscrowFlag = uint32(0x00010000)
+
+// TestEscrowCreate_MaskBeatsBadAmount pins the EscrowCreate mask-position finding
+// through the engine: the fix1543 flag mask fires at preflight0 (temINVALID_FLAG),
+// ahead of the PreflightRules amount check that a zero Amount would otherwise
+// report as temBAD_AMOUNT.
+func TestEscrowCreate_MaskBeatsBadAmount(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.FundAmount(bob, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	create := escrow.EscrowCreate(alice, bob, 0). // zero Amount
+							Flags(strayEscrowFlag).
+							FinishAfter(900000000).
+							Build()
+	require.Equal(t, "temINVALID_FLAG", env.Submit(create).Code)
+}
+
+// TestEscrowFinish_CredentialsDisabledBeatsShape pins EscrowFinish CredentialIDs
+// finding #1 through the engine: with Credentials disabled a CredentialIDs-bearing
+// finish is temDISABLED (checkExtraFeatures, before preflight1), winning over the
+// Condition/Fulfillment XOR temMALFORMED that would otherwise fire in Validate.
+func TestEscrowFinish_CredentialsDisabledBeatsShape(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.DisableFeature("Credentials")
+	alice := jtx.NewAccount("alice")
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.Close()
+
+	// Condition-without-Fulfillment (a Validate temMALFORMED) plus CredentialIDs on
+	// a Credentials-disabled network: temDISABLED must win.
+	finish := escrow.EscrowFinish(alice, alice, 999).
+		ConditionHex("A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100").
+		CredentialIDs([]string{"00000000000000000000000000000000000000000000000000000000000000AB"}).
+		Sequence(env.Seq(alice) + 10).
+		Build()
+	require.Equal(t, "temDISABLED", env.Submit(finish).Code)
+}

--- a/internal/testing/paychan/precedence_test.go
+++ b/internal/testing/paychan/precedence_test.go
@@ -1,0 +1,59 @@
+package paychan
+
+import (
+	"encoding/hex"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// openChannel funds alice + bob and opens a 1000-XRP channel, returning its hex ID.
+func openChannel(t *testing.T, env *jtx.TestEnv, alice, bob *jtx.Account) string {
+	t.Helper()
+	env.FundAmount(alice, uint64(jtx.XRP(10000)))
+	env.FundAmount(bob, uint64(jtx.XRP(10000)))
+	env.Close()
+	createSeq := env.Seq(alice)
+	jtx.RequireTxSuccess(t, env.Submit(ChannelCreate(alice, bob, xrp(1000), 3600, alice.PublicKeyHex()).Build()))
+	env.Close()
+	chanK := chanKeylet(alice, bob, createSeq)
+	return hex.EncodeToString(chanK.Key[:])
+}
+
+// TestPayChanClaim_MaskBeatsSeqGap pins the mask-position finding through the full
+// engine: a stray flag is rejected at preflight0 (temINVALID_FLAG) ahead of the
+// preclaim sequence check, so it wins over the retriable terPRE_SEQ that a future
+// Sequence would otherwise produce.
+func TestPayChanClaim_MaskBeatsSeqGap(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	chanID := openChannel(t, env, alice, bob)
+
+	claim := ChannelClaim(alice, chanID).
+		Balance(xrp(500)).Amount(xrp(500)).
+		Sequence(env.Seq(alice) + 10).
+		Build()
+	claim = withFlag(claim, strayPayChanFlag)
+	require.Equal(t, "temINVALID_FLAG", env.Submit(claim).Code)
+}
+
+// TestPayChanClaim_CredentialsDisabledBeatsSeqGap pins the CredentialIDs finding
+// through the engine: with Credentials disabled a CredentialIDs-bearing claim is
+// temDISABLED (checkExtraFeatures, before preflight1), winning over the sequence
+// gap's terPRE_SEQ.
+func TestPayChanClaim_CredentialsDisabledBeatsSeqGap(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.DisableFeature("Credentials")
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	chanID := openChannel(t, env, alice, bob)
+
+	claim := ChannelClaim(alice, chanID).
+		Balance(xrp(500)).Amount(xrp(500)).
+		CredentialIDs([]string{"00000000000000000000000000000000000000000000000000000000000000AB"}).
+		Sequence(env.Seq(alice) + 10).
+		Build()
+	require.Equal(t, "temDISABLED", env.Submit(claim).Code)
+}

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -57,6 +57,17 @@ func (e *Engine) preflight(tx txcore.Transaction) (result ter.Result) {
 		return result
 	}
 
+	// preflightSigValidated — a per-type stage rippled runs AFTER preflight2's
+	// signature verification (Transactor::invokePreflight). A check placed here
+	// (EscrowFinish's CredentialIDs shape check) is therefore trumped by a
+	// bad-signature temINVALID, not the reverse. Reached only once verifySignatures
+	// succeeds, exactly as rippled reaches it only once preflight2 passes.
+	if svp, ok := tx.(txcore.SigValidatedPreflighter); ok {
+		if err := svp.PreflightSigValidated(); err != nil {
+			return parseValidationError(err)
+		}
+	}
+
 	// Reference: rippled Batch.cpp:303-312.
 	if outer, ok := tx.(BatchOuter); ok {
 		for _, inner := range outer.InnerTransactions() {

--- a/internal/tx/escrow/escrow_cancel.go
+++ b/internal/tx/escrow/escrow_cancel.go
@@ -37,9 +37,6 @@ func (e *EscrowCancel) Validate() error {
 		return err
 	}
 
-	// The tfUniversalMask flag check is gated on fix1543 and runs in Preclaim,
-	// where the amendment rules are available.
-
 	if e.Owner == "" {
 		return ter.Errorf(ter.TemMALFORMED, "Owner is required")
 	}
@@ -51,18 +48,14 @@ func (e *EscrowCancel) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(e)
 }
 
-// Preclaim performs the rules-aware fix1543 flag check.
-// Reference: rippled Escrow.cpp:1203 — stray (non-universal) flags are rejected
-// only once fix1543 is active. rippled runs this check first in preflight; the
-// gate is rules-aware and go-xrpl exposes rules only at Preclaim, so it runs
-// after the common preflight/preclaim steps. For a tx malformed in two ways this
-// can surface a different tem code than rippled; the result is tem-only (never
-// enters a ledger) so there is no consensus divergence.
-func (e *EscrowCancel) Preclaim(_ tx.LedgerView, config tx.EngineConfig) ter.Result {
-	if config.GetRules().Enabled(amendment.FeatureFix1543) && (e.GetFlags()&tx.TfUniversalMask) != 0 {
-		return ter.TemINVALID_FLAG
+// GetFlagsMask returns the invalid-flags mask enforced at preflight0. fix1543
+// rejects any stray (non-universal) flag; before it, any flags are allowed.
+// Reference: rippled Escrow.cpp EscrowCancel::getFlagsMask.
+func (e *EscrowCancel) GetFlagsMask(rules *amendment.Rules) uint32 {
+	if rules.Enabled(amendment.FeatureFix1543) {
+		return tx.TfUniversalMask
 	}
-	return ter.TesSUCCESS
+	return 0
 }
 
 // Apply applies an EscrowCancel transaction

--- a/internal/tx/escrow/escrow_create.go
+++ b/internal/tx/escrow/escrow_create.go
@@ -56,54 +56,70 @@ func (e *EscrowCreate) Validate() error {
 		return err
 	}
 
-	// The tfUniversalMask flag check is gated on fix1543 and runs in Preclaim,
-	// where the amendment rules are available.
-
+	// sfDestination is a required field; a missing one is temMALFORMED before the
+	// per-type preflight body (which lives in PreflightRules).
 	if err := tx.CheckDestRequired(e.Destination); err != nil {
 		return err
 	}
 
-	// For XRP the zero/negative check runs unconditionally in preflight. For
-	// non-XRP amounts rippled gates every check behind featureTokenEscrow: with
-	// the amendment disabled a non-XRP amount is temBAD_AMOUNT, and with it
-	// enabled the per-asset helper runs (zero/negative, MPT range,
-	// temBAD_CURRENCY for the reserved "XRP" currency code). Those amendment-
-	// dependent checks are deferred to Preclaim (see L1).
-	//
-	// The lone exception is the "XRP"/empty IOU currency code: the binary codec
-	// cannot even serialize it, so the transaction can never be hashed and would
-	// surface tefINTERNAL before Preclaim runs. It is therefore rejected here in
-	// Validate with temBAD_CURRENCY (matching the amendment-enabled outcome).
-	// Reference: rippled Escrow.cpp preflight lines 130-148, escrowCreatePreflightHelper<Issue>
-	if e.Amount.IsNative() {
-		if e.Amount.IsZero() || e.Amount.IsNegative() {
-			return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
+	return nil
+}
+
+func (e *EscrowCreate) Flatten() (map[string]any, error) {
+	return tx.ReflectFlatten(e)
+}
+
+// GetFlagsMask returns the invalid-flags mask enforced at preflight0. fix1543
+// rejects any stray (non-universal) flag; before it, any flags are allowed.
+// Reference: rippled Escrow.cpp EscrowCreate::getFlagsMask.
+func (e *EscrowCreate) GetFlagsMask(rules *amendment.Rules) uint32 {
+	if rules.Enabled(amendment.FeatureFix1543) {
+		return tx.TfUniversalMask
+	}
+	return 0
+}
+
+// PreflightRules is the amendment-aware body of rippled's EscrowCreate::preflight.
+// The whole sequence lives here (rather than split across Validate) so that a
+// transaction malformed in two ways surfaces the same tem* code rippled reports:
+// the rules-gated amount checks stay ahead of the rules-free expiration/condition
+// checks, matching rippled's intra-preflight order.
+// Reference: rippled Escrow.cpp EscrowCreate::preflight.
+func (e *EscrowCreate) PreflightRules(rules *amendment.Rules) error {
+	// Amount validity. For XRP the zero/negative check is unconditional. For
+	// non-XRP amounts every check is gated behind featureTokenEscrow: disabled →
+	// temBAD_AMOUNT; enabled → the per-asset helper (zero/negative → temBAD_AMOUNT,
+	// then the reserved "XRP" currency code → temBAD_CURRENCY, MPT → temDISABLED).
+	if !e.Amount.IsNative() {
+		if !rules.Enabled(amendment.FeatureTokenEscrow) {
+			return ter.Errorf(ter.TemBAD_AMOUNT, "cannot escrow non-XRP without TokenEscrow")
 		}
-	} else if !e.Amount.IsMPT() {
-		if e.Amount.Currency == "" || e.Amount.Currency == "XRP" {
-			return ter.Errorf(ter.TemBAD_CURRENCY, "cannot escrow XRP as IOU")
+		if err := escrowCreateNonXRPPreflight(rules, e.Amount); err != nil {
+			return err
 		}
+	} else if e.Amount.IsZero() || e.Amount.IsNegative() {
+		return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
 	}
 
-	// Must have at least one timeout value
-	// Reference: rippled Escrow.cpp:151-152
+	// Must have at least one timeout value.
 	if e.CancelAfter == nil && e.FinishAfter == nil {
 		return ter.Errorf(ter.TemBAD_EXPIRATION, "must specify CancelAfter or FinishAfter")
 	}
 
-	// If both times are specified, CancelAfter must be strictly after FinishAfter
-	// Reference: rippled Escrow.cpp:156-158
-	if e.CancelAfter != nil && e.FinishAfter != nil {
-		if *e.CancelAfter <= *e.FinishAfter {
-			return ter.Errorf(ter.TemBAD_EXPIRATION, "CancelAfter must be after FinishAfter")
+	// When both are present, CancelAfter must be strictly after FinishAfter.
+	if e.CancelAfter != nil && e.FinishAfter != nil && *e.CancelAfter <= *e.FinishAfter {
+		return ter.Errorf(ter.TemBAD_EXPIRATION, "CancelAfter must be after FinishAfter")
+	}
+
+	// fix1571: an escrow must specify a FinishAfter or a Condition, otherwise it
+	// could be finished immediately.
+	if rules.Enabled(amendment.FeatureFix1571) {
+		if e.FinishAfter == nil && (e.Condition == nil || *e.Condition == "") {
+			return ter.Errorf(ter.TemMALFORMED, "escrow must specify FinishAfter or Condition")
 		}
 	}
 
-	// NOTE: the fix1571 check (FinishAfter or Condition required) is amendment-
-	// gated and runs in Preclaim, the earliest rules-aware point.
-
-	// Validate condition format if present
-	// Reference: rippled Escrow.cpp:170-190 condition deserialization
+	// Condition format.
 	if e.Condition != nil {
 		if *e.Condition == "" {
 			return ter.Errorf(ter.TemMALFORMED, "empty condition")
@@ -114,10 +130,6 @@ func (e *EscrowCreate) Validate() error {
 	}
 
 	return nil
-}
-
-func (e *EscrowCreate) Flatten() (map[string]any, error) {
-	return tx.ReflectFlatten(e)
 }
 
 // Preclaim performs stateful validation for EscrowCreate before doApply.
@@ -139,42 +151,9 @@ func (e *EscrowCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.
 	rules := config.GetRules()
 	closeTime := config.ParentCloseTime
 
-	// fix1543: stray (non-universal) flags are rejected only once the amendment
-	// is active. Reference: rippled Escrow.cpp:124. rippled runs this check first
-	// in preflight; the gate is rules-aware, and go-xrpl exposes rules only at
-	// Preclaim, so it runs after the common preflight/preclaim steps. The check
-	// is the first statement of Preclaim, the earliest rules-aware point. For a
-	// tx malformed in two ways this can surface a different tem code than rippled;
-	// the result is tem-only (never enters a ledger) so there is no consensus
-	// divergence.
-	if rules.Enabled(amendment.FeatureFix1543) && (e.GetFlags()&tx.TfUniversalMask) != 0 {
-		return ter.TemINVALID_FLAG
-	}
-
-	// Non-XRP preflight checks are all gated behind featureTokenEscrow: when it
-	// is disabled, any non-XRP amount is temBAD_AMOUNT; when enabled, the
-	// per-asset preflight helper runs (temBAD_CURRENCY for currency code "XRP",
-	// temDISABLED/temBAD_AMOUNT for MPT). rippled runs these in preflight, which
-	// has no rules access here, so they run at the top of Preclaim, the earliest
-	// rules-aware point, before any stateful check.
-	// Reference: rippled Escrow.cpp preflight lines 130-148, 88-119
-	if !e.Amount.IsNative() {
-		if !rules.Enabled(amendment.FeatureTokenEscrow) {
-			return ter.TemBAD_AMOUNT
-		}
-		if result := escrowCreateNonXRPPreflight(rules, e.Amount); result != ter.TesSUCCESS {
-			return result
-		}
-	}
-
-	// fix1571: an escrow must specify a FinishAfter or a Condition (otherwise it
-	// could be finished immediately). rippled gates this in preflight behind
-	// fix1571. Reference: rippled Escrow.cpp:160-167
-	if rules.Enabled(amendment.FeatureFix1571) {
-		if e.FinishAfter == nil && (e.Condition == nil || *e.Condition == "") {
-			return ter.TemMALFORMED
-		}
-	}
+	// The flag mask (GetFlagsMask), the non-XRP amount validity checks, and the
+	// fix1571 FinishAfter-or-Condition check all run in preflight now (GetFlagsMask
+	// and PreflightRules); Preclaim keeps only the ledger-state-dependent checks.
 
 	accountID, err := state.DecodeAccountID(e.Account)
 	if err != nil {
@@ -248,29 +227,29 @@ func readDestinationForEscrow(view tx.LedgerView, destID [20]byte) (*state.Accou
 }
 
 // escrowCreateNonXRPPreflight runs the per-asset preflight validity checks for a
-// non-XRP escrow amount, assuming featureTokenEscrow is enabled. IOU amounts
-// must be positive and may not use the reserved "XRP" currency code; MPT
-// amounts require featureMPTokensV1 and must be positive and within range.
-// Reference: rippled Escrow.cpp escrowCreatePreflightHelper<Issue> lines 92-103
-// and escrowCreatePreflightHelper<MPTIssue> lines 106-119.
-func escrowCreateNonXRPPreflight(rules *amendment.Rules, amount tx.Amount) ter.Result {
+// non-XRP escrow amount, assuming featureTokenEscrow is enabled. Following
+// rippled's helper order the zero/negative check comes first (temBAD_AMOUNT),
+// then the reserved "XRP" currency code (temBAD_CURRENCY); MPT amounts require
+// featureMPTokensV1 (temDISABLED) and must be positive.
+// Reference: rippled Escrow.cpp escrowCreatePreflightHelper<Issue>/<MPTIssue>.
+func escrowCreateNonXRPPreflight(rules *amendment.Rules, amount tx.Amount) error {
 	if amount.IsMPT() {
 		if !rules.Enabled(amendment.FeatureMPTokensV1) {
-			return ter.TemDISABLED
+			return ter.Errorf(ter.TemDISABLED, "MPT escrow requires MPTokensV1")
 		}
 		if amount.IsZero() || amount.IsNegative() {
-			return ter.TemBAD_AMOUNT
+			return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
 		}
-		return ter.TesSUCCESS
+		return nil
 	}
 
 	if amount.IsZero() || amount.IsNegative() {
-		return ter.TemBAD_AMOUNT
+		return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
 	}
 	if amount.Currency == "" || amount.Currency == "XRP" {
-		return ter.TemBAD_CURRENCY
+		return ter.Errorf(ter.TemBAD_CURRENCY, "cannot escrow XRP as IOU")
 	}
-	return ter.TesSUCCESS
+	return nil
 }
 
 // Apply applies an EscrowCreate transaction

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -55,15 +55,11 @@ func (e *EscrowFinish) Validate() error {
 		return err
 	}
 
-	// The tfUniversalMask flag check is gated on fix1543 and runs in Preclaim,
-	// where the amendment rules are available.
-
 	if e.Owner == "" {
 		return ter.Errorf(ter.TemMALFORMED, "Owner is required")
 	}
 
-	// Both Condition and Fulfillment must be present or absent together
-	// Reference: rippled Escrow.cpp:644-646
+	// Both Condition and Fulfillment must be present or absent together.
 	// "Present" means the field exists in the transaction (even if empty value).
 	hasCondition := e.Condition != nil
 	hasFulfillment := e.Fulfillment != nil
@@ -71,20 +67,45 @@ func (e *EscrowFinish) Validate() error {
 		return ter.Errorf(ter.TemMALFORMED, "Condition and Fulfillment must be provided together")
 	}
 
-	// Validate CredentialIDs field
-	// Reference: rippled Escrow.cpp preflight() calls credentials::checkFields()
-	// Use HasField to detect empty arrays from binary parsing where omitempty
-	// causes the Go struct field to be nil even though the field was present.
-	present := e.CredentialIDs != nil || e.HasField("CredentialIDs")
-	if err := credential.CheckFields(e.CredentialIDs, present, "Duplicate credential ID"); err != nil {
-		return err
-	}
-
 	return nil
 }
 
 func (e *EscrowFinish) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(e)
+}
+
+// GetFlagsMask returns the invalid-flags mask enforced at preflight0. fix1543
+// rejects any stray (non-universal) flag; before it, any flags are allowed.
+// Reference: rippled Escrow.cpp EscrowFinish::getFlagsMask.
+func (e *EscrowFinish) GetFlagsMask(rules *amendment.Rules) uint32 {
+	if rules.Enabled(amendment.FeatureFix1543) {
+		return tx.TfUniversalMask
+	}
+	return 0
+}
+
+// CheckExtraFeatures gates the CredentialIDs field on the Credentials amendment.
+// rippled evaluates this in checkExtraFeatures — before preflight1's common
+// checks and before the tx-type preflight body — so a CredentialIDs-bearing
+// EscrowFinish on a network without Credentials is temDISABLED ahead of every
+// other TER, keyed on field presence (not element count).
+// Reference: rippled Escrow.cpp EscrowFinish::checkExtraFeatures.
+func (e *EscrowFinish) CheckExtraFeatures(rules *amendment.Rules) error {
+	present := e.CredentialIDs != nil || e.HasField("CredentialIDs")
+	if present && !rules.Enabled(amendment.FeatureCredentials) {
+		return ter.Errorf(ter.TemDISABLED, "Credentials amendment not enabled")
+	}
+	return nil
+}
+
+// PreflightSigValidated runs the CredentialIDs shape check (empty / >8 /
+// duplicate → temMALFORMED). rippled runs credentials::checkFields in
+// preflightSigValidated, AFTER the signature is verified, so a mis-signed
+// EscrowFinish surfaces temINVALID rather than this temMALFORMED.
+// Reference: rippled Escrow.cpp EscrowFinish::preflightSigValidated.
+func (e *EscrowFinish) PreflightSigValidated() error {
+	present := e.CredentialIDs != nil || e.HasField("CredentialIDs")
+	return credential.CheckFields(e.CredentialIDs, present, "Duplicate credential ID")
 }
 
 // CalculateBaseFee mirrors rippled's EscrowFinish::calculateBaseFee: the
@@ -116,20 +137,6 @@ func (e *EscrowFinish) CalculateBaseFee(view tx.LedgerView, config tx.EngineConf
 	return fee
 }
 
-// Preclaim performs the rules-aware fix1543 flag check.
-// Reference: rippled Escrow.cpp:630 — stray (non-universal) flags are rejected
-// only once fix1543 is active. rippled runs this check first in preflight; the
-// gate is rules-aware and go-xrpl exposes rules only at Preclaim, so it runs
-// after the common preflight/preclaim steps. For a tx malformed in two ways this
-// can surface a different tem code than rippled; the result is tem-only (never
-// enters a ledger) so there is no consensus divergence.
-func (e *EscrowFinish) Preclaim(_ tx.LedgerView, config tx.EngineConfig) ter.Result {
-	if config.GetRules().Enabled(amendment.FeatureFix1543) && (e.GetFlags()&tx.TfUniversalMask) != 0 {
-		return ter.TemINVALID_FLAG
-	}
-	return ter.TesSUCCESS
-}
-
 // ApplyOnTec implements TecApplier. When tecEXPIRED is returned, this re-runs
 // credential expiration deletion against the engine's view so the side-effects
 // (credential deletion, owner count adjustment) persist even though the tx
@@ -150,11 +157,8 @@ func (e *EscrowFinish) Apply(ctx *tx.ApplyContext) ter.Result {
 
 	rules := ctx.Rules()
 
-	// Amendment-gated check: CredentialIDs requires Credentials amendment
-	// Reference: rippled Escrow.cpp preflight() credential check
-	if len(e.CredentialIDs) > 0 && !rules.Enabled(amendment.FeatureCredentials) {
-		return ter.TemDISABLED
-	}
+	// The CredentialIDs amendment gate (temDISABLED, keyed on field presence) runs
+	// in CheckExtraFeatures, and the shape check in PreflightSigValidated.
 
 	// --- Preclaim: credential validation (before time checks) ---
 	// Reference: rippled EscrowFinish::preclaim() calls credentials::valid()

--- a/internal/tx/escrow/escrow_test.go
+++ b/internal/tx/escrow/escrow_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 )
@@ -62,12 +63,10 @@ func TestEscrowCreateValidation(t *testing.T) {
 			errorMsg:    "temDST_NEEDED: Destination is required",
 		},
 		{
-			// A zero-value Amount is a non-native (IOU) zero with an empty
-			// currency code, which the binary codec cannot serialize. It is
-			// rejected in Validate with temBAD_CURRENCY (see L1). The amendment-
-			// gated zero/negative checks for serializable currencies are deferred
-			// to Preclaim.
-			name: "empty (non-XRP zero) amount - temBAD_CURRENCY",
+			// A zero-value Amount is a non-native (IOU) zero. rippled's Issue
+			// helper checks the zero/negative amount BEFORE the reserved-currency
+			// check, so this surfaces temBAD_AMOUNT (not temBAD_CURRENCY).
+			name: "empty (non-XRP zero) amount - temBAD_AMOUNT",
 			escrow: &EscrowCreate{
 				BaseTx:      *tx.NewBaseTx(tx.TypeEscrowCreate, "rAlice"),
 				Amount:      tx.Amount{},
@@ -75,12 +74,11 @@ func TestEscrowCreateValidation(t *testing.T) {
 				FinishAfter: ptrUint32(700000000),
 			},
 			expectError: true,
-			errorMsg:    "temBAD_CURRENCY: cannot escrow XRP as IOU",
+			errorMsg:    "temBAD_AMOUNT: Amount must be positive",
 		},
 		{
-			// With featureTokenEscrow, IOU amounts are valid in Validate().
-			// The amendment check is deferred to Apply() where rules are available.
-			name: "non-XRP amount - passes Validate (amendment checked in Apply)",
+			// With featureTokenEscrow, a well-formed IOU amount passes preflight.
+			name: "non-XRP amount - passes preflight (amendment checked in Apply)",
 			escrow: &EscrowCreate{
 				BaseTx:      *tx.NewBaseTx(tx.TypeEscrowCreate, "rAlice"),
 				Amount:      tx.NewIssuedAmountFromFloat64(100.0, "USD", "rGateway"),
@@ -159,9 +157,9 @@ func TestEscrowCreateValidation(t *testing.T) {
 			errorMsg:    "temBAD_EXPIRATION: must specify CancelAfter or FinishAfter",
 		},
 		{
-			// fix1571 check is amendment-gated and deferred to Apply().
-			// Validate() only checks stateless invariants.
-			name: "cancel only without condition - passes Validate (fix1571 checked in Apply)",
+			// fix1571 (on in the default rules) requires a FinishAfter or a
+			// Condition, so a CancelAfter-only escrow is temMALFORMED in preflight.
+			name: "cancel only without condition - temMALFORMED (fix1571)",
 			escrow: &EscrowCreate{
 				BaseTx:      *tx.NewBaseTx(tx.TypeEscrowCreate, "rAlice"),
 				Amount:      tx.NewXRPAmount(1000000000),
@@ -169,7 +167,8 @@ func TestEscrowCreateValidation(t *testing.T) {
 				CancelAfter: ptrUint32(700000100),
 				// No FinishAfter and no Condition
 			},
-			expectError: false,
+			expectError: true,
+			errorMsg:    "temMALFORMED: escrow must specify FinishAfter or Condition",
 		},
 		{
 			name: "cancel time equals finish time - temBAD_EXPIRATION equivalent",
@@ -219,9 +218,16 @@ func TestEscrowCreateValidation(t *testing.T) {
 		},
 	}
 
+	// The amount / expiration / condition checks now live in PreflightRules
+	// (rippled's per-type preflight body); run the full preflight body under the
+	// default mainnet-like rules (fix1543 / fix1571 / TokenEscrow / MPTokensV1 on).
+	rules := amendment.AllSupportedRules()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.escrow.Validate()
+			if err == nil {
+				err = tt.escrow.PreflightRules(rules)
+			}
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("expected error containing %q, got nil", tt.errorMsg)

--- a/internal/tx/escrow/preflight_precedence_test.go
+++ b/internal/tx/escrow/preflight_precedence_test.go
@@ -1,0 +1,101 @@
+package escrow
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/stretchr/testify/require"
+)
+
+// preflightCode extracts the TER code carried by a preflight/seam error.
+func preflightCode(t *testing.T, err error) ter.Result {
+	t.Helper()
+	require.Error(t, err)
+	var re *ter.ResultError
+	require.ErrorAs(t, err, &re)
+	return re.Code
+}
+
+// rulesDisabling returns the all-supported rule set with one amendment removed.
+func rulesDisabling(name string) *amendment.Rules {
+	return amendment.NewRulesBuilder().FromPreset(amendment.PresetAllSupported).DisableByName(name).Build()
+}
+
+// TestEscrowCreate_PreflightPrecedence pins the EscrowCreate mask-position finding
+// and the non-XRP amount-vs-currency order that moving the preflight body into
+// PreflightRules must preserve.
+func TestEscrowCreate_PreflightPrecedence(t *testing.T) {
+	on := amendment.AllSupportedRules()
+	no1543 := rulesDisabling("fix1543")
+
+	// fix1543 gates the flag mask: on → reject stray flags; off → allow any flags.
+	require.Equal(t, tx.TfUniversalMask, (&EscrowCreate{}).GetFlagsMask(on))
+	require.Equal(t, uint32(0), (&EscrowCreate{}).GetFlagsMask(no1543))
+
+	// A zero non-XRP amount whose currency is also the reserved "XRP" code
+	// surfaces temBAD_AMOUNT — rippled's Issue helper checks the amount before the
+	// currency, so temBAD_AMOUNT wins over temBAD_CURRENCY.
+	zeroBadCurrency := &EscrowCreate{
+		BaseTx:      *tx.NewBaseTx(tx.TypeEscrowCreate, "rAlice"),
+		Amount:      tx.NewIssuedAmountFromFloat64(0.0, "XRP", "rGw"),
+		Destination: "rBob",
+		FinishAfter: ptrUint32(700000000),
+	}
+	require.Equal(t, ter.TemBAD_AMOUNT, preflightCode(t, zeroBadCurrency.PreflightRules(on)))
+
+	// A well-formed positive amount with the reserved currency surfaces
+	// temBAD_CURRENCY (the amount check passes, the currency check fires).
+	positiveBadCurrency := &EscrowCreate{
+		BaseTx:      *tx.NewBaseTx(tx.TypeEscrowCreate, "rAlice"),
+		Amount:      tx.NewIssuedAmountFromFloat64(100.0, "XRP", "rGw"),
+		Destination: "rBob",
+		FinishAfter: ptrUint32(700000000),
+	}
+	require.Equal(t, ter.TemBAD_CURRENCY, preflightCode(t, positiveBadCurrency.PreflightRules(on)))
+}
+
+// TestEscrowFinish_PreflightPrecedence pins the two EscrowFinish CredentialIDs
+// findings and the mask-position finding.
+func TestEscrowFinish_PreflightPrecedence(t *testing.T) {
+	on := amendment.AllSupportedRules()
+	noCreds := rulesDisabling("Credentials")
+
+	require.Equal(t, tx.TfUniversalMask, (&EscrowFinish{}).GetFlagsMask(on))
+	require.Equal(t, uint32(0), (&EscrowFinish{}).GetFlagsMask(rulesDisabling("fix1543")))
+
+	// A CredentialIDs-bearing EscrowFinish that is ALSO shape-malformed (duplicate
+	// IDs) and carries a Condition without a Fulfillment.
+	dup := &EscrowFinish{
+		BaseTx:        *tx.NewBaseTx(tx.TypeEscrowFinish, "rBob"),
+		Owner:         "rAlice",
+		OfferSequence: 1,
+		Condition:     ptrString("A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100"),
+		CredentialIDs: []string{"AB", "AB"},
+	}
+
+	// Finding #1: with Credentials disabled the field-presence gate (CheckExtraFeatures)
+	// returns temDISABLED — ahead of the shape check and the Condition/Fulfillment XOR.
+	require.Equal(t, ter.TemDISABLED, preflightCode(t, dup.CheckExtraFeatures(noCreds)))
+	require.NoError(t, dup.CheckExtraFeatures(on))
+
+	// Finding #2: the CredentialIDs shape check no longer lives in Validate — it
+	// runs in PreflightSigValidated (after the signature). A duplicate therefore
+	// does NOT fail Validate; only PreflightSigValidated reports temMALFORMED, so a
+	// bad-signature temINVALID can win over it.
+	valid := &EscrowFinish{
+		BaseTx:        *tx.NewBaseTx(tx.TypeEscrowFinish, "rBob"),
+		Owner:         "rAlice",
+		OfferSequence: 1,
+		CredentialIDs: []string{"AB", "AB"},
+	}
+	require.NoError(t, valid.Validate())
+	require.Equal(t, ter.TemMALFORMED, preflightCode(t, valid.PreflightSigValidated()))
+}
+
+// TestEscrowCancel_PreflightPrecedence pins the EscrowCancel mask-position finding.
+func TestEscrowCancel_PreflightPrecedence(t *testing.T) {
+	require.Equal(t, tx.TfUniversalMask, (&EscrowCancel{}).GetFlagsMask(amendment.AllSupportedRules()))
+	require.Equal(t, uint32(0), (&EscrowCancel{}).GetFlagsMask(rulesDisabling("fix1543")))
+}

--- a/internal/tx/paychan/paychan_test.go
+++ b/internal/tx/paychan/paychan_test.go
@@ -574,53 +574,50 @@ func TestPaymentChannelClaimValidation(t *testing.T) {
 // Flag-gate (Preclaim) Tests
 //
 // The tfUniversalMask / tfPayChanClaimMask stray-flag check is rules-aware and
-// runs in Preclaim (gated on fix1543), not Validate. With the default rules
+// runs at preflight0 via GetFlagsMask (gated on fix1543). With the default rules
 // (all supported amendments, fix1543 included) a stray flag is rejected with
-// temINVALID_FLAG; universal flags are accepted.
-// Reference: rippled PayChan.cpp:177 (Create), :443 (Claim) and the Fund mirror.
+// temINVALID_FLAG; universal flags (and tfRenew for a claim) are accepted.
+// Reference: rippled PayChan.cpp getFlagsMask (Create/Fund/Claim).
 
 func TestPaymentChannelFlagGate(t *testing.T) {
-	cfg := tx.EngineConfig{Rules: amendment.AllSupportedRules()} // all supported amendments (fix1543 on)
+	rules := amendment.AllSupportedRules() // all supported amendments (fix1543 on)
+
+	// maskResult mirrors the engine's preflight0 flag check:
+	// flags & GetFlagsMask(rules) != 0 → temINVALID_FLAG.
+	maskResult := func(m tx.FlagsMasker, flags uint32) ter.Result {
+		if flags&m.GetFlagsMask(rules) != 0 {
+			return ter.TemINVALID_FLAG
+		}
+		return ter.TesSUCCESS
+	}
 
 	t.Run("create rejects stray flag", func(t *testing.T) {
 		pcc := &PaymentChannelCreate{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelCreate, "rIssuer")}
-		flags := strayFlag
-		pcc.Common.Flags = &flags
-		assert.Equal(t, ter.TemINVALID_FLAG, pcc.Preclaim(nil, cfg))
+		assert.Equal(t, ter.TemINVALID_FLAG, maskResult(pcc, strayFlag))
 	})
 
 	t.Run("create accepts universal flags", func(t *testing.T) {
 		pcc := &PaymentChannelCreate{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelCreate, "rIssuer")}
-		flags := tx.TfUniversal
-		pcc.Common.Flags = &flags
-		assert.Equal(t, ter.TesSUCCESS, pcc.Preclaim(nil, cfg))
+		assert.Equal(t, ter.TesSUCCESS, maskResult(pcc, tx.TfUniversal))
 	})
 
 	t.Run("fund rejects stray flag", func(t *testing.T) {
 		pcf := &PaymentChannelFund{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelFund, "rOwner")}
-		flags := strayFlag
-		pcf.Common.Flags = &flags
-		assert.Equal(t, ter.TemINVALID_FLAG, pcf.Preclaim(nil, cfg))
+		assert.Equal(t, ter.TemINVALID_FLAG, maskResult(pcf, strayFlag))
 	})
 
 	t.Run("fund accepts universal flags", func(t *testing.T) {
 		pcf := &PaymentChannelFund{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelFund, "rOwner")}
-		flags := tx.TfUniversal
-		pcf.Common.Flags = &flags
-		assert.Equal(t, ter.TesSUCCESS, pcf.Preclaim(nil, cfg))
+		assert.Equal(t, ter.TesSUCCESS, maskResult(pcf, tx.TfUniversal))
 	})
 
 	t.Run("claim rejects stray flag", func(t *testing.T) {
 		pcc := &PaymentChannelClaim{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelClaim, "rOwner")}
-		flags := strayFlag
-		pcc.Common.Flags = &flags
-		assert.Equal(t, ter.TemINVALID_FLAG, pcc.Preclaim(nil, cfg))
+		assert.Equal(t, ter.TemINVALID_FLAG, maskResult(pcc, strayFlag))
 	})
 
 	t.Run("claim accepts tfRenew", func(t *testing.T) {
-		pcc := &PaymentChannelClaim{BaseTx: *tx.NewBaseTx(tx.TypePaymentChannelClaim, "rOwner")}
-		pcc.SetRenew()
-		assert.Equal(t, ter.TesSUCCESS, pcc.Preclaim(nil, cfg))
+		assert.Equal(t, ter.TesSUCCESS, maskResult(&PaymentChannelClaim{}, tfPayChanRenew))
 	})
 }
 

--- a/internal/tx/paychan/payment_channel_claim.go
+++ b/internal/tx/paychan/payment_channel_claim.go
@@ -65,60 +65,43 @@ func (p *PaymentChannelClaim) Validate() error {
 		return ter.Errorf(ter.TemMALFORMED, "Channel must be a valid 256-bit hash")
 	}
 
-	// The tfPayChanClaimMask flag check is gated on fix1543 and runs in
-	// Preclaim, where the amendment rules are available. The tfClose/tfRenew
-	// conflict check below is NOT gated. Reference: rippled PayChan.cpp:443-447.
-	flags := p.GetFlags()
-
-	// Cannot set both tfClose and tfRenew
-	if (flags&tfPayChanClose != 0) && (flags&tfPayChanRenew != 0) {
-		return ErrPayChanCloseAndRenew
-	}
-
-	// Validate Balance if present
+	// Validate Balance if present.
 	if p.Balance != nil {
 		if !p.Balance.IsNative() {
 			return ter.Errorf(ter.TemBAD_AMOUNT, "Balance must be XRP")
 		}
-		balVal := p.Balance.Drops()
-		if balVal <= 0 {
+		if p.Balance.Drops() <= 0 {
 			return ter.Errorf(ter.TemBAD_AMOUNT, "Balance must be positive")
 		}
 	}
 
-	// Validate Amount if present
+	// Validate Amount if present.
 	if p.Amount != nil {
 		if !p.Amount.IsNative() {
 			return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be XRP")
 		}
-		amtVal := p.Amount.Drops()
-		if amtVal <= 0 {
+		if p.Amount.Drops() <= 0 {
 			return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
 		}
 	}
 
-	// Balance cannot exceed Amount
-	if p.Balance != nil && p.Amount != nil {
-		balVal := p.Balance.Drops()
-		amtVal := p.Amount.Drops()
-		if balVal > amtVal {
-			return ErrPayChanBalanceGTAmount
-		}
+	// Balance cannot exceed Amount.
+	if p.Balance != nil && p.Amount != nil && p.Balance.Drops() > p.Amount.Drops() {
+		return ErrPayChanBalanceGTAmount
 	}
 
-	// Validate CredentialIDs if present
-	// Reference: rippled credentials::checkFields()
-	// Use HasField to detect empty arrays from binary parsing where omitempty
-	// causes the Go struct field to be nil even though the field was present.
-	present := p.CredentialIDs != nil || p.HasField("CredentialIDs")
-	if err := credential.CheckFields(p.CredentialIDs, present, "duplicates in credentials"); err != nil {
-		return err
+	// Cannot set both tfClose and tfRenew. rippled checks this AFTER the
+	// Balance/Amount validity, so a bad amount surfaces temBAD_AMOUNT first.
+	// Reference: rippled PayChan.cpp PayChanClaim::preflight (flag block).
+	flags := p.GetFlags()
+	if (flags&tfPayChanClose != 0) && (flags&tfPayChanRenew != 0) {
+		return ErrPayChanCloseAndRenew
 	}
 
-	// If Signature is provided, PublicKey and Balance must also be provided,
-	// and the signature is verified here — entirely from tx fields, before any
-	// ledger access. Reference: rippled PayChan.cpp PayChanClaim::preflight()
-	// lines 450-474.
+	// If Signature is provided, PublicKey and Balance must also be provided, and
+	// the claim signature is verified here — entirely from tx fields, before any
+	// ledger access. rippled runs this whole block before the CredentialIDs shape
+	// check. Reference: rippled PayChan.cpp PayChanClaim::preflight (Signature block).
 	if p.Signature != "" {
 		if p.PublicKey == "" {
 			return ErrPayChanSigNeedsKey
@@ -127,8 +110,7 @@ func (p *PaymentChannelClaim) Validate() error {
 			return ErrPayChanSigNeedsBalance
 		}
 
-		// Authorized amount: Amount if present, else Balance. Balance may not
-		// exceed it. Reference: PayChan.cpp lines 459-463.
+		// Authorized amount: Amount if present, else Balance. Balance may not exceed it.
 		authAmt := p.Balance.Drops()
 		if p.Amount != nil {
 			authAmt = p.Amount.Drops()
@@ -137,19 +119,23 @@ func (p *PaymentChannelClaim) Validate() error {
 			return ter.Errorf(ter.TemBAD_AMOUNT, "Balance exceeds authorized amount")
 		}
 
-		// Validate PublicKey is valid hex with the type rippled's
-		// publicKeyType() accepts: 33 bytes prefixed 0xED / 0x02 / 0x03.
-		// Reference: rippled PayChan.cpp preflight() publicKeyType()
+		// PublicKey must be a 33-byte key prefixed 0xED / 0x02 / 0x03.
 		pkBytes, err := hex.DecodeString(p.PublicKey)
 		if err != nil || !tx.IsValidPublicKey(pkBytes) {
 			return ErrPayChanPublicKeyInvalid
 		}
 
-		// Verify the claim signature over the authorized amount.
-		// Reference: PayChan.cpp lines 469-473 serializePayChanAuthorization.
 		if !verifyClaimSignature(p.Channel, uint64(authAmt), p.PublicKey, p.Signature) {
 			return ter.Errorf(ter.TemBAD_SIGNATURE, "invalid claim signature")
 		}
+	}
+
+	// CredentialIDs shape check runs LAST in rippled's PayChanClaim::preflight,
+	// after the Signature block. Use HasField to detect an empty array that binary
+	// parsing leaves as a nil Go slice. Reference: rippled credentials::checkFields.
+	present := p.CredentialIDs != nil || p.HasField("CredentialIDs")
+	if err := credential.CheckFields(p.CredentialIDs, present, "duplicates in credentials"); err != nil {
+		return err
 	}
 
 	return nil
@@ -163,20 +149,31 @@ func (p *PaymentChannelClaim) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePayChan}
 }
 
-// Preclaim performs the rules-aware fix1543 flag check. Only the
-// tfPayChanClaimMask check is gated; the tfClose/tfRenew conflict check runs
-// unconditionally in Validate. Reference: rippled PayChan.cpp:443-447. rippled
-// runs the mask check first in preflight; the gate is rules-aware and go-xrpl
-// exposes rules only at Preclaim, so it runs after the common preflight/preclaim
-// steps. For a tx malformed in two ways this can surface a different tem code
-// than rippled; the result is tem-only (never enters a ledger) so there is no
-// consensus divergence.
-func (p *PaymentChannelClaim) Preclaim(_ tx.LedgerView, config tx.EngineConfig) ter.Result {
-	const tfPayChanClaimMask = ^(tfPayChanRenew | tfPayChanClose | tx.TfUniversal)
-	if config.GetRules().Enabled(amendment.FeatureFix1543) && (p.GetFlags()&tfPayChanClaimMask) != 0 {
-		return ter.TemINVALID_FLAG
+// tfPayChanClaimMask is the invalid-flags mask for a claim once fix1543 is
+// active: everything except the universal flags plus tfRenew/tfClose.
+const tfPayChanClaimMask = ^(tfPayChanRenew | tfPayChanClose | tx.TfUniversal)
+
+// GetFlagsMask returns the invalid-flags mask enforced at preflight0. fix1543
+// rejects any flag outside tfPayChanClaimMask; before it, any flags are allowed.
+// Reference: rippled PayChan.cpp PayChanClaim::getFlagsMask.
+func (p *PaymentChannelClaim) GetFlagsMask(rules *amendment.Rules) uint32 {
+	if rules.Enabled(amendment.FeatureFix1543) {
+		return tfPayChanClaimMask
 	}
-	return ter.TesSUCCESS
+	return 0
+}
+
+// CheckExtraFeatures gates the CredentialIDs field on the Credentials amendment.
+// rippled evaluates this in checkExtraFeatures — before preflight1 and the
+// tx-type preflight body — so a CredentialIDs-bearing claim on a network without
+// Credentials is temDISABLED ahead of every other TER, keyed on field presence.
+// Reference: rippled PayChan.cpp PayChanClaim::checkExtraFeatures.
+func (p *PaymentChannelClaim) CheckExtraFeatures(rules *amendment.Rules) error {
+	present := p.CredentialIDs != nil || p.HasField("CredentialIDs")
+	if present && !rules.Enabled(amendment.FeatureCredentials) {
+		return ter.Errorf(ter.TemDISABLED, "Credentials amendment not enabled")
+	}
+	return nil
 }
 
 // SetClose sets the close flag
@@ -213,11 +210,8 @@ func (p *PaymentChannelClaim) Apply(ctx *tx.ApplyContext) ter.Result {
 
 	rules := ctx.Rules()
 
-	// --- Preclaim: credential checks ---
-	// Reference: rippled PayChan.cpp PayChanClaim::preflight() credential check
-	if len(p.CredentialIDs) > 0 && !rules.Enabled(amendment.FeatureCredentials) {
-		return ter.TemDISABLED
-	}
+	// The CredentialIDs amendment gate (temDISABLED, keyed on field presence) runs
+	// in CheckExtraFeatures; the shape check runs last in Validate.
 
 	// Reference: rippled PayChan.cpp PayChanClaim::preclaim() credentials::valid()
 	if len(p.CredentialIDs) > 0 && rules.Enabled(amendment.FeatureCredentials) {

--- a/internal/tx/paychan/payment_channel_create.go
+++ b/internal/tx/paychan/payment_channel_create.go
@@ -109,18 +109,14 @@ func (p *PaymentChannelCreate) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePayChan}
 }
 
-// Preclaim performs the rules-aware fix1543 flag check.
-// Reference: rippled PayChan.cpp:177 — stray (non-universal) flags are rejected
-// only once fix1543 is active. rippled runs this check first in preflight; the
-// gate is rules-aware and go-xrpl exposes rules only at Preclaim, so it runs
-// after the common preflight/preclaim steps. For a tx malformed in two ways this
-// can surface a different tem code than rippled; the result is tem-only (never
-// enters a ledger) so there is no consensus divergence.
-func (p *PaymentChannelCreate) Preclaim(_ tx.LedgerView, config tx.EngineConfig) ter.Result {
-	if config.GetRules().Enabled(amendment.FeatureFix1543) && (p.GetFlags()&tx.TfUniversalMask) != 0 {
-		return ter.TemINVALID_FLAG
+// GetFlagsMask returns the invalid-flags mask enforced at preflight0. fix1543
+// rejects any stray (non-universal) flag; before it, any flags are allowed.
+// Reference: rippled PayChan.cpp PayChanCreate::getFlagsMask.
+func (p *PaymentChannelCreate) GetFlagsMask(rules *amendment.Rules) uint32 {
+	if rules.Enabled(amendment.FeatureFix1543) {
+		return tx.TfUniversalMask
 	}
-	return ter.TesSUCCESS
+	return 0
 }
 
 // Reference: rippled PayChan.cpp PayChanCreate::doApply()

--- a/internal/tx/paychan/payment_channel_fund.go
+++ b/internal/tx/paychan/payment_channel_fund.go
@@ -83,18 +83,14 @@ func (p *PaymentChannelFund) RequiredAmendments() [][32]byte {
 	return [][32]byte{amendment.FeaturePayChan}
 }
 
-// Preclaim performs the rules-aware fix1543 flag check.
-// Reference: rippled PayChan.cpp:332 — stray (non-universal) flags are rejected
-// only once fix1543 is active. rippled runs this check first in preflight; the
-// gate is rules-aware and go-xrpl exposes rules only at Preclaim, so it runs
-// after the common preflight/preclaim steps. For a tx malformed in two ways this
-// can surface a different tem code than rippled; the result is tem-only (never
-// enters a ledger) so there is no consensus divergence.
-func (p *PaymentChannelFund) Preclaim(_ tx.LedgerView, config tx.EngineConfig) ter.Result {
-	if config.GetRules().Enabled(amendment.FeatureFix1543) && (p.GetFlags()&tx.TfUniversalMask) != 0 {
-		return ter.TemINVALID_FLAG
+// GetFlagsMask returns the invalid-flags mask enforced at preflight0. fix1543
+// rejects any stray (non-universal) flag; before it, any flags are allowed.
+// Reference: rippled PayChan.cpp PayChanFund::getFlagsMask.
+func (p *PaymentChannelFund) GetFlagsMask(rules *amendment.Rules) uint32 {
+	if rules.Enabled(amendment.FeatureFix1543) {
+		return tx.TfUniversalMask
 	}
-	return ter.TesSUCCESS
+	return 0
 }
 
 // Reference: rippled PayChan.cpp PayChanFund::doApply()

--- a/internal/tx/paychan/preflight_precedence_test.go
+++ b/internal/tx/paychan/preflight_precedence_test.go
@@ -1,0 +1,87 @@
+package paychan
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/stretchr/testify/require"
+)
+
+const validChannelHex = "0000000000000000000000000000000000000000000000000000000000000001"
+
+// preflightCode extracts the TER code carried by a preflight/seam error.
+func preflightCode(t *testing.T, err error) ter.Result {
+	t.Helper()
+	require.Error(t, err)
+	var re *ter.ResultError
+	require.ErrorAs(t, err, &re)
+	return re.Code
+}
+
+// rulesDisabling returns the all-supported rule set with one amendment removed.
+func rulesDisabling(name string) *amendment.Rules {
+	return amendment.NewRulesBuilder().FromPreset(amendment.PresetAllSupported).DisableByName(name).Build()
+}
+
+// TestPayChan_GetFlagsMaskGating pins the mask-position finding for all three
+// payment-channel transactions: the mask is enforced at preflight0 and is
+// fix1543-gated (off → allow any flags).
+func TestPayChan_GetFlagsMaskGating(t *testing.T) {
+	on := amendment.AllSupportedRules()
+	off := rulesDisabling("fix1543")
+
+	require.Equal(t, tx.TfUniversalMask, (&PaymentChannelCreate{}).GetFlagsMask(on))
+	require.Equal(t, uint32(0), (&PaymentChannelCreate{}).GetFlagsMask(off))
+
+	require.Equal(t, tx.TfUniversalMask, (&PaymentChannelFund{}).GetFlagsMask(on))
+	require.Equal(t, uint32(0), (&PaymentChannelFund{}).GetFlagsMask(off))
+
+	require.Equal(t, tfPayChanClaimMask, (&PaymentChannelClaim{}).GetFlagsMask(on))
+	require.Equal(t, uint32(0), (&PaymentChannelClaim{}).GetFlagsMask(off))
+}
+
+// TestPayChanClaim_CredentialsExtraFeature pins the CredentialIDs amendment gate:
+// with Credentials disabled, a CredentialIDs-bearing claim is temDISABLED via
+// CheckExtraFeatures (keyed on field presence, not element count).
+func TestPayChanClaim_CredentialsExtraFeature(t *testing.T) {
+	claim := &PaymentChannelClaim{
+		BaseTx:        *tx.NewBaseTx(tx.TypePaymentChannelClaim, "rOwner"),
+		Channel:       validChannelHex,
+		CredentialIDs: []string{"AB", "AB"},
+	}
+	require.Equal(t, ter.TemDISABLED, preflightCode(t, claim.CheckExtraFeatures(rulesDisabling("Credentials"))))
+	require.NoError(t, claim.CheckExtraFeatures(amendment.AllSupportedRules()))
+}
+
+// TestPayChanClaim_BadAmountBeatsFlagConflict pins the Balance/Amount vs
+// tfClose+tfRenew order: rippled checks amount validity first, so a non-XRP
+// Balance surfaces temBAD_AMOUNT even when the flag conflict is also present.
+func TestPayChanClaim_BadAmountBeatsFlagConflict(t *testing.T) {
+	nonXRP := tx.NewIssuedAmountFromFloat64(100.0, "USD", "rGw")
+	claim := &PaymentChannelClaim{
+		BaseTx:  *tx.NewBaseTx(tx.TypePaymentChannelClaim, "rOwner"),
+		Channel: validChannelHex,
+		Balance: &nonXRP,
+	}
+	claim.SetClose()
+	claim.SetRenew()
+	require.Equal(t, ter.TemBAD_AMOUNT, preflightCode(t, claim.Validate()))
+}
+
+// TestPayChanClaim_BadSignatureBeatsCheckFields pins the Signature-block vs
+// CredentialIDs-shape order: the CredentialIDs shape check runs LAST, so a bad
+// claim signature surfaces temBAD_SIGNATURE even with duplicate CredentialIDs.
+func TestPayChanClaim_BadSignatureBeatsCheckFields(t *testing.T) {
+	bal := tx.NewXRPAmount(500)
+	claim := &PaymentChannelClaim{
+		BaseTx:        *tx.NewBaseTx(tx.TypePaymentChannelClaim, "rOwner"),
+		Channel:       validChannelHex,
+		Balance:       &bal,
+		PublicKey:     "ED0000000000000000000000000000000000000000000000000000000000000000",
+		Signature:     "DEADBEEF",
+		CredentialIDs: []string{"AB", "AB"},
+	}
+	require.Equal(t, ter.TemBAD_SIGNATURE, preflightCode(t, claim.Validate()))
+}

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -93,6 +93,17 @@ type FlagsMasker interface {
 	GetFlagsMask(rules *amendment.Rules) uint32
 }
 
+// SigValidatedPreflighter is implemented by transaction types with a preflight
+// check that rippled runs in T::preflightSigValidated — the invokePreflight stage
+// AFTER preflight2's cryptographic signature verification. The engine runs it
+// once signature verification succeeds, so a check placed here is trumped by a
+// bad-signature temINVALID, matching rippled. EscrowFinish adopts it for its
+// CredentialIDs shape check (credentials::checkFields), which rippled defers past
+// the signature. A non-nil error carries a tem* code via ter.Errorf.
+type SigValidatedPreflighter interface {
+	PreflightSigValidated() error
+}
+
 // Preclaimer is implemented by transaction types that need additional
 // stateful validation beyond the engine's common preclaim checks.
 // Preclaim runs AFTER the engine's sequence/fee/signature checks and


### PR DESCRIPTION
Aligns the preflight TER precedence of the **Escrow** and **PaymentChannel** transaction families with rippled (tag 3.1.0), fixing 9 adversarially-verified divergences. Adopts the engine `FlagsMasker` / `CheckExtraFeatures` / `RulesPreflighter` seams from #1271 so flag-mask and amendment-gated `tem*` checks fire at their rippled pipeline positions (`preflight0` / `checkExtraFeatures` / the per-type preflight body) rather than being buried in `Preclaim`/`Apply`, and adds one new seam — `SigValidatedPreflighter` — for the single check rippled defers past signature verification (`preflightSigValidated`).

## Findings addressed

| # | Tx | Kind | Sev | Divergence (goXRPL before → rippled) | Fix |
|---|----|------|-----|--------------------------------------|-----|
| E1 | EscrowFinish | order | med | CredentialIDs amendment gate at top of `Apply()` keyed on `len>0`: `temMALFORMED`/engine-common → **`temDISABLED`** before preflight1, keyed on field presence | `CheckExtraFeatures` (Credentials) |
| E2 | EscrowFinish | order | med | CredentialIDs shape check in `Validate()` (before sig): dup + bad-sig → `temMALFORMED` vs rippled **`temINVALID`** (sig wins) | shape check → `PreflightSigValidated` (post-signature) |
| E3 | EscrowCreate | mask-position | med | fix1543 mask at top of `Preclaim()` (after sig): stray flag + zero Amount → `temBAD_AMOUNT` vs **`temINVALID_FLAG`** | fix1543-conditional `GetFlagsMask`; whole preflight body → `PreflightRules` (preserves amount-before-currency order → zero non-XRP is `temBAD_AMOUNT` not `temBAD_CURRENCY`) |
| E4 | EscrowFinish | mask-position | med | fix1543 mask in `Preclaim()`: stray flag + Condition-without-Fulfillment → `temMALFORMED` vs **`temINVALID_FLAG`** | fix1543-conditional `GetFlagsMask` |
| E5 | EscrowCancel | mask-position | med | fix1543 mask in `Preclaim()` (after fee/sig): stray flag + bad fee/sig → `temBAD_FEE`/`temINVALID` vs **`temINVALID_FLAG`** | fix1543-conditional `GetFlagsMask` |
| P1 | PayChanCreate/Fund/Claim | mask-position | high | fix1543 mask in per-tx `Preclaim()` (after account/seq/fee/sig): stray flag on a non-existent account / seq gap → **`terNO_ACCOUNT`/`terPRE_SEQ`** (retriable) vs rippled `temINVALID_FLAG` (hard-reject) — TER-class fork | fix1543-conditional `GetFlagsMask` (Claim = `tfPayChanClaimMask`) at preflight0 |
| P2 | PayChanClaim | order | high | CredentialIDs gate at top of `Apply()` keyed on `len>0`: `terNO_ACCOUNT`/`temBAD_AMOUNT`/`temMALFORMED` vs rippled **`temDISABLED`** before preflight1 | `CheckExtraFeatures` (Credentials), field-presence keyed; Apply gate removed |
| P3 | PayChanClaim | order | med | `Validate()` checks tfClose+tfRenew conflict before Balance/Amount: IOU Balance + `tfRenew\|tfClose` → `temMALFORMED` vs rippled **`temBAD_AMOUNT`** | reorder: Balance/Amount validity before the flag conflict |
| P4 | PayChanClaim | order | med | `Validate()` checks CredentialIDs shape before the Signature block: dup CredentialIDs + bad claim-sig → `temMALFORMED` vs rippled **`temBAD_SIGNATURE`** | reorder: CredentialIDs shape check moved after the Signature block |

The four PayChan findings lost their verifier and were **re-verified from scratch** against rippled 3.1.0 (`PayChan.cpp` `getFlagsMask`/`checkExtraFeatures`/`preflight` for all three types) before fixing. All 9 findings are **fixed** (0 refuted).

## New engine seam

The only check rippled runs *after* signature verification is EscrowFinish's `credentials::checkFields` (in `preflightSigValidated`). goXRPL's engine ran signature verification last with nothing after it, so no existing seam could host a post-signature check. This adds a minimal `SigValidatedPreflighter` interface, invoked in the outer `preflight` right after `verifySignatures` succeeds — mirroring rippled's `invokePreflight` (`preflight2` → `T::preflightSigValidated`). Only EscrowFinish adopts it.

## Dependency note (#1274, batch-inner seams)

rippled preflights each **batch-inner** transaction via the full `invokePreflight<T>`, so inner escrow/paychan run these same seams. The engine wiring that makes goXRPL's `preflightInner` run `CheckExtraFeatures`/`GetFlagsMask`/`PreflightRules` lives in **#1274**, which is **not yet merged into `v3.0.0`** (verified against `git log origin/v3.0.0`). Per the coordination guidance, this PR bases its seam usage only on what IS merged (#1271, outer-tx seams) and does **not** touch `preflightInner` (that would collide with #1274). Until #1274 merges, batch-inner escrow/paychan skip the relocated checks; the new `SigValidatedPreflighter` is likewise not wired into `preflightInner`. Batch is out-of-scope for conformance, so there is no in-scope impact, and once #1274 lands the two compose. The new seam is added in a location #1274 does not modify (the outer `preflight` after `verifySignatures`), so there is no merge conflict.

## Verification

- **Pin tests** — one per surviving fork scenario. Unit pins in `internal/tx/{escrow,paychan}/preflight_precedence_test.go` assert the exact TER code each seam / reordered `Validate` produces (mask gating, `CheckExtraFeatures` temDISABLED, `PreflightSigValidated` temMALFORMED, amount-before-currency, tfClose+tfRenew-after-amount, checkFields-after-signature). Engine-level pins in `internal/testing/{escrow,paychan}/precedence_test.go` demonstrate the high-severity tem-vs-ter wins through the full engine (`temINVALID_FLAG`/`temDISABLED` beat a `terPRE_SEQ` sequence gap).
- **`just test`** — all in-scope packages pass; `TestConformance` fails only on the pre-existing out-of-scope Batch/Vault/XChain/Delegate stubs (identical to clean `origin/v3.0.0`).
- **Conformance** — in-scope **1260 pass / 0 fail (100%)**; `app/Escrow` 18/0, `app/EscrowToken` 32/0, `app/PayChan` 24/0. **0 new failures** vs a fresh clean-base baseline.
- **Strict lint** (`.golangci.yml`) — 0 issues on changed packages. **`go vet`** clean. **gofmt** clean. **docsgen** (rpcmethods + registries) — no drift.

Part of #274; follows #1271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
