### PR TITLE
fix(oracle,did,credential): align preflight TER precedence with rippled

### DIFF
--- a/internal/testing/credential/precedence_test.go
+++ b/internal/testing/credential/precedence_test.go
@@ -1,0 +1,60 @@
+package credential_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	credentialtest "github.com/LeJamon/go-xrpl/internal/testing/credential"
+)
+
+// The Credential family's fixInvalidTxFlags-gated flag mask now lives in
+// GetFlagsMask, enforced at preflight0 — before the type's field checks and
+// before signature verification — matching rippled. Previously it was the first
+// statement of Apply(), so a transaction that was both flag-invalid and
+// field-malformed surfaced the field's tem* code instead of temINVALID_FLAG.
+//
+// Each pin combines an invalid flag (0x1, rejected under fixInvalidTxFlags, which
+// the test env enables via PresetAllSupported) with a field that would otherwise
+// fail Validate. The expected result is temINVALID_FLAG, proving the mask wins.
+
+func TestPrecedence_CredentialCreateFlagBeforeField(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	issuer := jtx.NewAccount("issuer")
+	subject := jtx.NewAccount("subject")
+	env.Fund(issuer)
+	env.Close()
+
+	// Empty CredentialType is temMALFORMED in Validate; the invalid flag must win.
+	create := credentialtest.CredentialCreate(issuer, subject, "").
+		Flags(0x00000001).
+		Build()
+	jtx.RequireTxFail(t, env.Submit(create), "temINVALID_FLAG")
+}
+
+func TestPrecedence_CredentialAcceptFlagBeforeField(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	subject := jtx.NewAccount("subject")
+	issuer := jtx.NewAccount("issuer")
+	env.Fund(subject)
+	env.Close()
+
+	// Empty CredentialType is temMALFORMED in Validate; the invalid flag must win.
+	accept := credentialtest.CredentialAccept(subject, issuer, "").
+		Flags(0x00000001).
+		Build()
+	jtx.RequireTxFail(t, env.Submit(accept), "temINVALID_FLAG")
+}
+
+func TestPrecedence_CredentialDeleteFlagBeforeField(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	sender := jtx.NewAccount("sender")
+	env.Fund(sender)
+	env.Close()
+
+	// Neither Subject nor Issuer present is temMALFORMED in Validate; the invalid
+	// flag must win.
+	del := credentialtest.CredentialDelete(sender, nil, nil, "credType").
+		Flags(0x00000001).
+		Build()
+	jtx.RequireTxFail(t, env.Submit(del), "temINVALID_FLAG")
+}

--- a/internal/testing/oracle/precedence_test.go
+++ b/internal/testing/oracle/precedence_test.go
@@ -1,0 +1,33 @@
+package oracle_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	oracletest "github.com/LeJamon/go-xrpl/internal/testing/oracle"
+)
+
+// TestPrecedence_OracleSetTimeBeforePairs pins that the per-entry base==quote /
+// scale / duplicate checks are preclaim checks ordered AFTER the
+// tecINVALID_UPDATE_TIME window check, matching rippled SetOracle. A
+// LastUpdateTime outside the window combined with a base==quote pair must be
+// claimed (fee taken, included) as tecINVALID_UPDATE_TIME — NOT rejected at
+// preflight as temMALFORMED. The tem-vs-tec class difference is a ledger-content
+// fork in a mixed network, which is why the pair loop was removed from Validate.
+func TestPrecedence_OracleSetTimeBeforePairs(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	owner := jtx.NewAccount("owner")
+	env.Fund(owner)
+	env.Close()
+
+	// LastUpdateTime = 0 is below the Ripple epoch, so preclaim returns
+	// tecINVALID_UPDATE_TIME. BaseAsset == QuoteAsset would be a preflight
+	// temMALFORMED if the pair loop still ran in Validate.
+	result := env.Submit(oracletest.OracleSet(owner, 1, 0).
+		ProviderHex(32).
+		AssetClassHex(8).
+		AddPrice("USD", "USD", 740, 1).
+		Fee(10).
+		Build())
+	jtx.RequireTxClaimed(t, result, "tecINVALID_UPDATE_TIME")
+}

--- a/internal/tx/credential/credential.go
+++ b/internal/tx/credential/credential.go
@@ -34,16 +34,23 @@ func (c *CredentialAccept) TxType() tx.Type {
 	return tx.TypeCredentialAccept
 }
 
+// GetFlagsMask reports the invalid-flag mask. rippled's
+// CredentialAccept::getFlagsMask is `fixInvalidTxFlags ? tfUniversalMask : 0`,
+// so with the amendment active any flag is rejected temINVALID_FLAG at
+// preflight0 (before the field checks and signature verification); with it off
+// the mask is zero and all flags pass.
+func (c *CredentialAccept) GetFlagsMask(rules *amendment.Rules) uint32 {
+	if rules.Enabled(amendment.FeatureFixInvalidTxFlags) {
+		return tx.TfUniversalMask
+	}
+	return 0
+}
+
 // Reference: rippled Credentials.cpp CredentialAccept::preflight()
-// Note: The fixInvalidTxFlags-gated flag check is done in Apply() because
-// Validate() has no access to amendment rules.
 func (c *CredentialAccept) Validate() error {
 	if err := c.BaseTx.Validate(); err != nil {
 		return err
 	}
-
-	// Flag check is deferred to Apply() where amendment rules are available.
-	// Reference: rippled Credentials.cpp:304-308 — gated behind fixInvalidTxFlags.
 
 	// Issuer is required and must not be zero
 	// Reference: rippled Credentials.cpp:310-314
@@ -129,14 +136,6 @@ func (c *CredentialAccept) ApplyOnTec(ctx *tx.ApplyContext) {
 
 // Reference: rippled Credentials.cpp CredentialAccept::doApply()
 func (c *CredentialAccept) Apply(ctx *tx.ApplyContext) ter.Result {
-	// Check for invalid flags, gated behind fixInvalidTxFlags
-	// Reference: rippled Credentials.cpp:304-308
-	if ctx.Rules().Enabled(amendment.FeatureFixInvalidTxFlags) {
-		if c.GetFlags()&tx.TfUniversalMask != 0 {
-			return ter.TemINVALID_FLAG
-		}
-	}
-
 	ctx.Log.Trace("credential accept apply",
 		"account", c.Account,
 		"issuer", c.Issuer,

--- a/internal/tx/credential/credential_create.go
+++ b/internal/tx/credential/credential_create.go
@@ -41,16 +41,23 @@ func (c *CredentialCreate) TxType() tx.Type {
 	return tx.TypeCredentialCreate
 }
 
+// GetFlagsMask reports the invalid-flag mask. rippled's
+// CredentialCreate::getFlagsMask is `fixInvalidTxFlags ? tfUniversalMask : 0`,
+// so with the amendment active any flag is rejected temINVALID_FLAG at
+// preflight0 (before the field checks and signature verification); with it off
+// the mask is zero and all flags pass.
+func (c *CredentialCreate) GetFlagsMask(rules *amendment.Rules) uint32 {
+	if rules.Enabled(amendment.FeatureFixInvalidTxFlags) {
+		return tx.TfUniversalMask
+	}
+	return 0
+}
+
 // Reference: rippled Credentials.cpp CredentialCreate::preflight()
-// Note: The fixInvalidTxFlags-gated flag check is done in Apply() because
-// Validate() has no access to amendment rules.
 func (c *CredentialCreate) Validate() error {
 	if err := c.BaseTx.Validate(); err != nil {
 		return err
 	}
-
-	// Flag check is deferred to Apply() where amendment rules are available.
-	// Reference: rippled Credentials.cpp:66-71 — gated behind fixInvalidTxFlags.
 
 	// Subject is required and must not be the zero account
 	// Reference: rippled Credentials.cpp:73-77
@@ -109,14 +116,6 @@ func (c *CredentialCreate) RequiredAmendments() [][32]byte {
 
 // Reference: rippled Credentials.cpp CredentialCreate::doApply()
 func (c *CredentialCreate) Apply(ctx *tx.ApplyContext) ter.Result {
-	// Check for invalid flags, gated behind fixInvalidTxFlags
-	// Reference: rippled Credentials.cpp:66-71
-	if ctx.Rules().Enabled(amendment.FeatureFixInvalidTxFlags) {
-		if c.GetFlags()&tx.TfUniversalMask != 0 {
-			return ter.TemINVALID_FLAG
-		}
-	}
-
 	ctx.Log.Trace("credential create apply",
 		"issuer", c.Account,
 		"subject", c.Subject,

--- a/internal/tx/credential/credential_delete.go
+++ b/internal/tx/credential/credential_delete.go
@@ -36,16 +36,23 @@ func (c *CredentialDelete) TxType() tx.Type {
 	return tx.TypeCredentialDelete
 }
 
+// GetFlagsMask reports the invalid-flag mask. rippled's
+// CredentialDelete::getFlagsMask is `fixInvalidTxFlags ? tfUniversalMask : 0`,
+// so with the amendment active any flag is rejected temINVALID_FLAG at
+// preflight0 (before the Subject/Issuer/CredentialType checks and signature
+// verification); with it off the mask is zero and all flags pass.
+func (c *CredentialDelete) GetFlagsMask(rules *amendment.Rules) uint32 {
+	if rules.Enabled(amendment.FeatureFixInvalidTxFlags) {
+		return tx.TfUniversalMask
+	}
+	return 0
+}
+
 // Reference: rippled Credentials.cpp CredentialDelete::preflight()
-// Note: The fixInvalidTxFlags-gated flag check is done in Apply() because
-// Validate() has no access to amendment rules.
 func (c *CredentialDelete) Validate() error {
 	if err := c.BaseTx.Validate(); err != nil {
 		return err
 	}
-
-	// Flag check is deferred to Apply() where amendment rules are available.
-	// Reference: rippled Credentials.cpp:217-222 — gated behind fixInvalidTxFlags.
 
 	// At least one of Subject or Issuer must be present
 	// Reference: rippled Credentials.cpp:224-233
@@ -57,8 +64,14 @@ func (c *CredentialDelete) Validate() error {
 		}
 	}
 
-	// If present, Subject and Issuer must not be zero accounts
-	// Reference: rippled Credentials.cpp:235-241
+	// If present, Subject and Issuer must not be zero accounts. A present but
+	// zero-length STAccount deserializes to "", which rippled sees as a present
+	// account that isZero(), so it must be rejected the same as a present 20-byte
+	// zero account — not treated as absent.
+	// Reference: rippled Credentials.cpp — (subject && subject->isZero()) etc.
+	if c.HasField("Subject") && c.Subject == "" {
+		return ErrCredentialZeroAccount
+	}
 	if c.Subject != "" {
 		if subjectID, err := state.DecodeAccountID(c.Subject); err == nil {
 			var zeroAccount [20]byte
@@ -66,6 +79,9 @@ func (c *CredentialDelete) Validate() error {
 				return ErrCredentialZeroAccount
 			}
 		}
+	}
+	if c.HasField("Issuer") && c.Issuer == "" {
+		return ErrCredentialZeroAccount
 	}
 	if c.Issuer != "" {
 		if issuerID, err := state.DecodeAccountID(c.Issuer); err == nil {
@@ -105,14 +121,6 @@ func (c *CredentialDelete) RequiredAmendments() [][32]byte {
 
 // Reference: rippled Credentials.cpp CredentialDelete::doApply()
 func (c *CredentialDelete) Apply(ctx *tx.ApplyContext) ter.Result {
-	// Check for invalid flags, gated behind fixInvalidTxFlags
-	// Reference: rippled Credentials.cpp:217-222
-	if ctx.Rules().Enabled(amendment.FeatureFixInvalidTxFlags) {
-		if c.GetFlags()&tx.TfUniversalMask != 0 {
-			return ter.TemINVALID_FLAG
-		}
-	}
-
 	ctx.Log.Trace("credential delete apply",
 		"account", c.Account,
 		"subject", c.Subject,

--- a/internal/tx/credential/preflight_precedence_test.go
+++ b/internal/tx/credential/preflight_precedence_test.go
@@ -1,0 +1,74 @@
+package credential
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/stretchr/testify/require"
+)
+
+// rulesFixFlags builds a minimal Rules set with fixInvalidTxFlags on or off.
+func rulesFixFlags(on bool) *amendment.Rules {
+	b := amendment.NewRulesBuilder()
+	if on {
+		b = b.Enable(amendment.FeatureFixInvalidTxFlags)
+	}
+	return b.Build()
+}
+
+// TestCredentialFlagsMask pins the fixInvalidTxFlags-gated mask for all three
+// Credential types. rippled's getFlagsMask is `fixInvalidTxFlags ? tfUniversalMask
+// : 0`, enforced at preflight0. The mask value and gate already matched rippled;
+// this locks in that the check is now GetFlagsMask (preflight0) rather than the
+// first statement of Apply(), so it fires before the type's field checks and
+// before signature verification.
+func TestCredentialFlagsMask(t *testing.T) {
+	on := rulesFixFlags(true)
+	off := rulesFixFlags(false)
+
+	require.Equal(t, tx.TfUniversalMask, (&CredentialCreate{}).GetFlagsMask(on))
+	require.Equal(t, uint32(0), (&CredentialCreate{}).GetFlagsMask(off))
+
+	require.Equal(t, tx.TfUniversalMask, (&CredentialAccept{}).GetFlagsMask(on))
+	require.Equal(t, uint32(0), (&CredentialAccept{}).GetFlagsMask(off))
+
+	require.Equal(t, tx.TfUniversalMask, (&CredentialDelete{}).GetFlagsMask(on))
+	require.Equal(t, uint32(0), (&CredentialDelete{}).GetFlagsMask(off))
+}
+
+// validateCode runs Validate and returns the mapped TER code.
+func validateCode(t *testing.T, err error) ter.Result {
+	t.Helper()
+	require.Error(t, err)
+	var re *ter.ResultError
+	require.True(t, errors.As(err, &re), "expected a typed ResultError, got %v", err)
+	return re.Code
+}
+
+// TestCredentialDeletePresentEmptyAccountZeroed pins that a present but
+// zero-length sfSubject / sfIssuer is rejected temINVALID_ACCOUNT_ID. The binary
+// codec decodes a present zero-length STAccount to "", which rippled treats as a
+// present account that isZero() -> temINVALID_ACCOUNT_ID. Before the fix goXRPL
+// only ran the zero check on a non-empty decoded string, so a present-empty
+// field slipped through Validate and Apply defaulted it to the sender.
+func TestCredentialDeletePresentEmptyAccountZeroed(t *testing.T) {
+	t.Run("Subject present but empty", func(t *testing.T) {
+		c := NewCredentialDelete("rSenderAccountForTestingOnly000000", "ABCD")
+		c.SetPresentFields(map[string]bool{"Subject": true})
+		require.Equal(t, ter.TemINVALID_ACCOUNT_ID, validateCode(t, c.Validate()))
+	})
+
+	t.Run("Issuer present but empty", func(t *testing.T) {
+		c := NewCredentialDelete("rSenderAccountForTestingOnly000000", "ABCD")
+		c.SetPresentFields(map[string]bool{"Issuer": true})
+		require.Equal(t, ter.TemINVALID_ACCOUNT_ID, validateCode(t, c.Validate()))
+	})
+
+	t.Run("neither present is malformed not zeroed", func(t *testing.T) {
+		c := NewCredentialDelete("rSenderAccountForTestingOnly000000", "ABCD")
+		require.Equal(t, ter.TemMALFORMED, validateCode(t, c.Validate()))
+	})
+}

--- a/internal/tx/oracle/oracle_set.go
+++ b/internal/tx/oracle/oracle_set.go
@@ -109,29 +109,11 @@ func (o *OracleSet) Validate() error {
 		}
 	}
 
-	// Validate each price data entry and check for duplicates
-	// Reference: rippled SetOracle.cpp checkArray()
-	seenPairs := make(map[string]bool)
-	for _, pd := range o.PriceDataSeries {
-		entry := pd.PriceData
-
-		// BaseAsset and QuoteAsset must be different
-		if entry.BaseAsset == entry.QuoteAsset {
-			return ter.Errorf(ter.TemMALFORMED, "BaseAsset and QuoteAsset must be different")
-		}
-
-		// Scale cannot exceed MaxPriceScale
-		if entry.Scale != nil && *entry.Scale > MaxPriceScale {
-			return ter.Errorf(ter.TemMALFORMED, "Scale cannot exceed %d", MaxPriceScale)
-		}
-
-		pairKey := entry.TokenPairKey()
-		if seenPairs[pairKey] {
-			return ter.Errorf(ter.TemMALFORMED, "duplicate token pair in PriceDataSeries")
-		}
-		seenPairs[pairKey] = true
-	}
-
+	// The per-entry base==quote, scale, and duplicate-pair checks are stateful
+	// preclaim checks in rippled (SetOracle::preclaim), ordered AFTER the
+	// tecINVALID_UPDATE_TIME time-window check. Keeping them here in preflight
+	// would surface a tem* code before the tec* time check ever runs, forking
+	// ledger inclusion in a mixed network — so they live only in Apply().
 	return nil
 }
 


### PR DESCRIPTION
Aligns the preflight TER precedence of the Oracle and Credential transaction families with rippled (tag 3.1.0), fixing 5 adversarially-verified divergences. Adopts the engine `FlagsMasker` seam from #1271 so the amendment-gated flag-mask checks fire at their rippled pipeline position (preflight0) rather than in `Apply`, and relocates the OracleSet pair checks to their rippled preclaim position.

The DID family was audited and left unchanged: `DIDSet`/`DIDDelete` check the unconditional `tfUniversalMask` in `Validate()`, matching rippled's default `getFlagsMask` value — the same accepted pattern as `NFTokenBurn`/`NFTokenModify`, with no surviving finding.

## Findings addressed

| # | Tx type | Kind | Divergence | Fix |
|---|---------|------|------------|-----|
| 1 | OracleSet | extra-check (high) | The `base==quote` / duplicate-pair / `Scale>maxPriceScale` checks ran in `Validate()` (preflight), but in rippled they are preclaim checks ordered **after** the `tecINVALID_UPDATE_TIME` window check. A bad `LastUpdateTime` + `base==quote` was `temMALFORMED` at preflight (never included) vs rippled `tecINVALID_UPDATE_TIME` (claimed/included) — a tem-vs-tec ledger-content fork. | remove the pair loop from `Validate()`; `Apply()` already performs it at the exact rippled preclaim position |
| 2 | CredentialDelete | missing-check (high) | A present but zero-length `sfSubject`/`sfIssuer` decodes to `""`; the zero-account check only ran on a non-empty decoded string, so it slipped preflight and `Apply` defaulted it to the sender and deleted a self-issued credential. rippled: `temINVALID_ACCOUNT_ID`. | reject a present-but-empty `Subject`/`Issuer` as a present zero account |
| 3 | CredentialCreate | mask-position (medium) | `fixInvalidTxFlags ? tfUniversalMask : 0` was enforced as the first statement of `Apply()`; a flag-invalid + field-malformed / mis-signed tx surfaced `temMALFORMED` / `temBAD_SIGNATURE` instead of `temINVALID_FLAG`. | amendment-conditional `GetFlagsMask` (preflight0); drop the `Apply()` check |
| 4 | CredentialAccept | mask-position (medium) | same as #3 | same |
| 5 | CredentialDelete | mask-position (medium) | same as #3 | same |

The mask value (`~tfUniversal`) and amendment gate were already correct in every case; only the pipeline position moves to preflight0, matching rippled's `getFlagsMask` at preflight0 before the per-type field checks and signature verification.

## Verification

- **Pin-tests** (one per fork scenario):
  - `internal/tx/credential/preflight_precedence_test.go` — `GetFlagsMask` value/gate for all three types; present-empty `Subject`/`Issuer` → `temINVALID_ACCOUNT_ID`.
  - `internal/testing/oracle/precedence_test.go` — bad `LastUpdateTime` + `base==quote` is claimed `tecINVALID_UPDATE_TIME`, not preflight `temMALFORMED`.
  - `internal/testing/credential/precedence_test.go` — an invalid flag paired with a malformed field surfaces `temINVALID_FLAG` (mask wins at preflight0) for Create/Accept/Delete.
- **`just test`**: green except the pre-existing out-of-scope conformance stubs (Batch/Delegate/Vault/XChain); no in-scope or package-level failures.
- **Conformance**: in-scope **1260 pass / 0 fail (100%)**; **Credentials 42/42**, **Oracle 7/7**. No fixture shifts.
- **Lint**: strict `.golangci.yml` clean (0 issues) on changed packages.
- **docs-check**: no registry drift.

Part of #274; follows #1271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
