### PR TITLE
fix(delegate,permissioneddomain,pseudo,batch): align preflight TER precedence with rippled

### DIFF
--- a/codec/binarycodec/types/st_object.go
+++ b/codec/binarycodec/types/st_object.go
@@ -321,11 +321,17 @@ func createFieldInstanceMapFromJson(json map[string]any) (map[definitions.FieldI
 func parseSpecialFields(k string, v any) (any, error) {
 	if k == "PermissionValue" {
 		if strValue, ok := v.(string); ok {
-			permissionValue, err := definitions.Get().GetDelegatablePermissionValueByName(strValue)
-			if err != nil {
-				return nil, err
+			if permissionValue, err := definitions.Get().GetDelegatablePermissionValueByName(strValue); err == nil {
+				return uint32(permissionValue), nil
 			}
-			return uint32(permissionValue), nil
+			// A value with no registered name may be supplied in its decimal form
+			// (the round-trip of an unknown sfPermissionValue). Parse it as a plain
+			// UINT32 so it re-encodes rather than erroring.
+			n, err := strconv.ParseUint(strValue, 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("PermissionValue: unknown permission %q", strValue)
+			}
+			return uint32(n), nil
 		}
 	}
 
@@ -400,11 +406,16 @@ func enumToStr(fieldName string, value any) (any, error) {
 		if !ok {
 			return nil, fmt.Errorf("PermissionValue: expected uint32 but got %T", value)
 		}
-		// Convert permission value to permission name if available, otherwise return numeric value
+		// Convert the permission value to its name when one is registered.
 		if name, err := definitions.Get().GetDelegatablePermissionNameByValue(int32(code)); err == nil {
 			return name, nil
 		}
-		return value, nil
+		// sfPermissionValue is a plain UINT32; a value with no registered name is
+		// still valid on the wire (rippled includes such DelegateSets before
+		// fixDelegateV1_1). Emit its decimal form so it round-trips through the
+		// string-typed struct field and reaches the delegatability check rather
+		// than failing to decode.
+		return strconv.FormatUint(uint64(code), 10), nil
 	default:
 		return value, nil
 	}

--- a/internal/ledger/state/delegate_entry.go
+++ b/internal/ledger/state/delegate_entry.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
@@ -150,13 +151,31 @@ func (d *DelegateData) HasTxPermission(txType uint32) bool {
 	return slices.Contains(d.Permissions, txPermission)
 }
 
-// LookupPermissionValue converts a permission name (e.g., "Payment") to its
-// numeric delegatable permission value using the definitions package.
-// Returns 0 if the name is not found.
+// LookupPermissionValue converts a permission value to its numeric form. It
+// accepts a permission name (e.g. "Payment") and, for values that have no
+// registered name, a plain decimal string. rippled's sfPermissionValue is a
+// plain UINT32, so a wire value with no known name decodes to its decimal form
+// (see the codec's enumToStr); accepting it here lets those values round-trip
+// and reach the delegatability check. Returns 0 when neither form resolves.
 func LookupPermissionValue(name string) uint32 {
-	pv, err := definitions.Get().GetDelegatablePermissionValueByName(name)
-	if err != nil {
-		return 0
+	if pv, err := definitions.Get().GetDelegatablePermissionValueByName(name); err == nil {
+		return uint32(pv)
 	}
-	return uint32(pv)
+	if n, err := strconv.ParseUint(name, 10, 32); err == nil {
+		return uint32(n)
+	}
+	return 0
+}
+
+// IsGranularPermissionValue reports whether the numeric permission value is a
+// registered granular permission (rippled getGranularName != nullopt). Unknown
+// values in the granular range are not granular and must fall through to the
+// transaction-type delegatability path.
+func IsGranularPermissionValue(value uint32) bool {
+	for _, v := range definitions.Get().GranularPermissions {
+		if uint32(v) == value {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -168,10 +168,11 @@ func TestPreflight(t *testing.T) {
 		env.Fund(alice, bob)
 		env.Close()
 
-		// Use an invalid flag (e.g., tfDisallowXRP = 0x00010000 for batch)
+		// Use a bit that is outside tfBatchMask (not a mode flag, not universal),
+		// so the flag mask at preflight0 rejects it before any inner check.
 		seq := env.Seq(alice)
 		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
-		batch := NewBatchBuilder(alice, seq, batchFee, 0x00010000). // invalid flag
+		batch := NewBatchBuilder(alice, seq, batchFee, 0x00100000). // invalid flag
 										AddInnerTx(MakeFakeInnerTx()).
 										AddInnerTx(MakeFakeInnerTx()).
 										Build()
@@ -563,6 +564,30 @@ func TestPreflight(t *testing.T) {
 
 		result := env.Submit(batch)
 		xtesting.RequireTxFail(t, result, "temINVALID")
+	})
+
+	t.Run("temINVALID_INNER_BATCH - inner ticket with AccountTxnID", func(t *testing.T) {
+		// Pins finding Batch-inner-ticket-AccountTxnID: an inner tx that uses a
+		// ticket may not also carry AccountTxnID (rippled inner preflight1 ->
+		// temINVALID, surfaced on the outer as temINVALID_INNER_BATCH).
+		env := newBatchEnv(t)
+		alice := xtesting.NewAccount("alice")
+		bob := xtesting.NewAccount("bob")
+		env.Fund(alice, bob)
+		env.Close()
+
+		seq := env.Seq(alice)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		badInner := MakeInnerPaymentXRPWithTicket(alice, bob, 1, seq+5)
+		badInner.GetCommon().AccountTxnID = "00000000000000000000000000000000000000000000000000000000000000AA"
+
+		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
+			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
+			AddInnerTx(badInner).
+			Build()
+
+		result := env.Submit(batch)
+		xtesting.RequireTxFail(t, result, "temINVALID_INNER_BATCH")
 	})
 
 	t.Run("temINVALID_FLAG - inner missing tfInnerBatchTxn", func(t *testing.T) {

--- a/internal/testing/batch/builder_test.go
+++ b/internal/testing/batch/builder_test.go
@@ -33,11 +33,11 @@ func TestBuilderSortsNestedSignersByBinaryAccountID(t *testing.T) {
 		signers = []*xtesting.Account{b, a}
 	}
 
-	batch := NewBatchBuilder(master, 1, 100, 0x00000001).
-		AddInnerTx(MakeFakeInnerTx()).
-		AddInnerTx(MakeFakeInnerTx()).
-		AddMultiSignBatchSigner(master, signers).
-		Build()
+	batch := NewBatchBuilder(master, 1, 100, 0x00010000). // tfAllOrNothing
+								AddInnerTx(MakeFakeInnerTx()).
+								AddInnerTx(MakeFakeInnerTx()).
+								AddMultiSignBatchSigner(master, signers).
+								Build()
 
 	require.Len(t, batch.BatchSigners, 1)
 	nested := batch.BatchSigners[0].BatchSigner.Signers

--- a/internal/testing/delegate/precedence_test.go
+++ b/internal/testing/delegate/precedence_test.go
@@ -1,0 +1,95 @@
+// Preflight TER-precedence pins for DelegateSet, covering the flags mask
+// (preflight0), the unknown-granular delegatability rule (preflight body under
+// fixDelegateV1_1), and the round-trip of an unregistered sfPermissionValue.
+//
+// Reference: rippled DelegateSet.cpp / Permissions.cpp isDelegatable().
+package delegate_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	delegatetx "github.com/LeJamon/go-xrpl/internal/tx/delegate"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDelegateSet_FlagsMaskPrecedence pins DelegateSet finding-1: DelegateSet
+// has no getFlagsMask override, so any non-universal flag bit is temINVALID_FLAG
+// at preflight0 — before the (would-be-malformed) self-authorize check and every
+// ledger-state TER.
+func TestDelegateSet_FlagsMaskPrecedence(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegation")
+	gw := jtx.NewAccount("gw")
+	alice := jtx.NewAccount("alice")
+	env.Fund(gw, alice)
+	env.Close()
+
+	ds := delegatetx.NewDelegateSet(gw.Address)
+	ds.Authorize = alice.Address
+	ds.Permissions = []delegatetx.Permission{
+		{Permission: delegatetx.PermissionData{PermissionValue: "Payment"}},
+	}
+	ds.GetCommon().SetFlags(0x00000001) // non-universal bit
+	jtx.RequireTxFail(t, env.SubmitSignedWith(ds, gw), "temINVALID_FLAG")
+}
+
+// TestDelegateSet_UnknownGranularNotDelegatable pins DelegateSet finding-3: a
+// value in the granular range (>= 65536) that is NOT a registered granular
+// permission is not delegatable. Under fixDelegateV1_1 the check runs in
+// preflight and rejects with temMALFORMED (rippled isDelegatable falls through
+// getGranularName to the tx-type path).
+func TestDelegateSet_UnknownGranularNotDelegatable(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("PermissionDelegation")
+	env.EnableFeature("fixDelegateV1_1")
+	gw := jtx.NewAccount("gw")
+	alice := jtx.NewAccount("alice")
+	env.Fund(gw, alice)
+	env.Close()
+
+	ds := delegatetx.NewDelegateSet(gw.Address)
+	ds.Authorize = alice.Address
+	ds.Permissions = []delegatetx.Permission{
+		{Permission: delegatetx.PermissionData{PermissionValue: "70000"}}, // unknown, >= 65536
+	}
+	jtx.RequireTxFail(t, env.SubmitSignedWith(ds, gw), "temMALFORMED")
+}
+
+// TestDelegateSet_UnknownPermissionValueRoundTrips pins DelegateSet finding-2:
+// sfPermissionValue is a plain UINT32, so a value with no registered name must
+// still decode (rippled includes such DelegateSets before fixDelegateV1_1). A
+// binary blob carrying value 60000 round-trips through the string-typed field as
+// its decimal form rather than failing to parse.
+func TestDelegateSet_UnknownPermissionValueRoundTrips(t *testing.T) {
+	gw := jtx.NewAccount("gw")
+	alice := jtx.NewAccount("alice")
+
+	ds := delegatetx.NewDelegateSet(gw.Address)
+	ds.Authorize = alice.Address
+	ds.Fee = "10"
+	seq := uint32(1)
+	ds.GetCommon().Sequence = &seq
+	ds.GetCommon().SigningPubKey = ""
+	ds.Permissions = []delegatetx.Permission{
+		{Permission: delegatetx.PermissionData{PermissionValue: "60000"}},
+	}
+
+	flat, err := ds.Flatten()
+	require.NoError(t, err)
+	blobHex, err := binarycodec.Encode(flat)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(blobHex)
+	require.NoError(t, err)
+
+	parsed, err := txcore.ParseFromBinary(blob)
+	require.NoError(t, err, "unknown sfPermissionValue must still parse")
+
+	back, ok := parsed.(*delegatetx.DelegateSet)
+	require.True(t, ok)
+	require.Len(t, back.Permissions, 1)
+	require.Equal(t, "60000", back.Permissions[0].Permission.PermissionValue)
+}

--- a/internal/testing/nft/builder.go
+++ b/internal/testing/nft/builder.go
@@ -553,7 +553,7 @@ func (b *NFTokenModifyBuilder) BuildNFTokenModify() *nftoken.NFTokenModify {
 type LedgerStateFixBuilder struct {
 	account  *testing.Account
 	owner    *testing.Account
-	fixType  *uint8
+	fixType  *uint16
 	fee      uint64
 	sequence *uint32
 	flags    uint32
@@ -562,7 +562,7 @@ type LedgerStateFixBuilder struct {
 // LedgerStateFixNFTPageLinks creates a new LedgerStateFixBuilder for NFToken page link repair.
 // account submits the fix; owner is the account whose pages are repaired.
 func LedgerStateFixNFTPageLinks(account, owner *testing.Account) *LedgerStateFixBuilder {
-	fixType := uint8(1) // LedgerFixTypeNFTokenPageLink
+	fixType := uint16(1) // LedgerFixTypeNFTokenPageLink
 	return &LedgerStateFixBuilder{
 		account: account,
 		owner:   owner,
@@ -590,7 +590,7 @@ func (b *LedgerStateFixBuilder) Flags(flags uint32) *LedgerStateFixBuilder {
 }
 
 // FixType overrides the LedgerFixType field.
-func (b *LedgerStateFixBuilder) FixType(ft uint8) *LedgerStateFixBuilder {
+func (b *LedgerStateFixBuilder) FixType(ft uint16) *LedgerStateFixBuilder {
 	b.fixType = &ft
 	return b
 }

--- a/internal/testing/pseudotx/previous_txn_id_test.go
+++ b/internal/testing/pseudotx/previous_txn_id_test.go
@@ -1,0 +1,27 @@
+// Pin for the Change-family sequence gate: rippled Change::preflight rejects a
+// pseudo-transaction that carries sfPreviousTxnID (a deserializable optional
+// common field) with temBAD_SEQUENCE, in the same gate as a non-zero Sequence.
+// Reference: rippled Change.cpp:70-75.
+package pseudotx_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPseudoPreflight_PreviousTxnIDRejected pins finding pseudo-PreviousTxnID: an
+// otherwise-valid pseudo-tx whose decoded field set includes PreviousTxnID is
+// temBAD_SEQUENCE, even with Sequence == 0.
+func TestPseudoPreflight_PreviousTxnIDRejected(t *testing.T) {
+	engine, _ := closedEngine(t, amendment.AllSupportedRules())
+	tx := newAmendmentTx()
+	// Mark PreviousTxnID as present in the decoded field set, mirroring a binary
+	// pseudo-tx that carries the (optional, deserializable) sfPreviousTxnID.
+	tx.Common.SetPresentFields(map[string]bool{"PreviousTxnID": true})
+
+	result := engine.ApplyPseudo(tx)
+	require.False(t, result.Applied)
+	require.Equal(t, "temBAD_SEQUENCE", result.Result.String())
+}

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -52,19 +52,24 @@ type BatchSignerData struct {
 	Signers           []tx.SignerWrapper `json:"Signers,omitempty"`
 }
 
-// Batch flags
+// Batch flags. The mode-flag bit positions match rippled TxFlags.h exactly so
+// that cross-implementation batches share one canonical flag word (and one
+// signing digest); the low-nibble values previously used here were wire- and
+// signature-incompatible with rippled.
 const (
 	// tfAllOrNothing fails the batch if any transaction fails
-	BatchFlagAllOrNothing uint32 = 0x00000001
+	BatchFlagAllOrNothing uint32 = 0x00010000
 	// tfOnlyOne succeeds if exactly one transaction succeeds
-	BatchFlagOnlyOne uint32 = 0x00000002
+	BatchFlagOnlyOne uint32 = 0x00020000
 	// tfUntilFailure processes until the first failure
-	BatchFlagUntilFailure uint32 = 0x00000004
+	BatchFlagUntilFailure uint32 = 0x00040000
 	// tfIndependent processes all transactions independently
-	BatchFlagIndependent uint32 = 0x00000008
+	BatchFlagIndependent uint32 = 0x00080000
 
-	// tfBatchMask is the mask for invalid batch flags
-	tfBatchMask uint32 = ^(BatchFlagAllOrNothing | BatchFlagOnlyOne | BatchFlagUntilFailure | BatchFlagIndependent)
+	// tfBatchMask is the mask of invalid outer Batch flags. It permits the four
+	// mode bits plus tfFullyCanonicalSig, and rejects tfInnerBatchTxn on the
+	// outer (nested batches are not supported), matching rippled TxFlags.h.
+	tfBatchMask uint32 = ^(tx.TfUniversal | BatchFlagAllOrNothing | BatchFlagOnlyOne | BatchFlagUntilFailure | BatchFlagIndependent) | tx.TfInnerBatchTxn
 
 	// MaxBatchTransactions is the maximum number of inner transactions
 	MaxBatchTransactions = 8
@@ -75,7 +80,6 @@ const (
 var (
 	ErrBatchTooFewTxns            = ter.Errorf(ter.TemARRAY_EMPTY, "batch must have at least 2 transactions")
 	ErrBatchTooManyTxns           = ter.Errorf(ter.TemARRAY_TOO_LARGE, "batch exceeds 8 transactions")
-	ErrBatchInvalidFlags          = ter.Errorf(ter.TemINVALID_FLAG, "invalid batch flags")
 	ErrBatchMustHaveOneFlag       = ter.Errorf(ter.TemINVALID_FLAG, "exactly one batch mode flag required")
 	ErrBatchTooManySigners        = ter.Errorf(ter.TemARRAY_TOO_LARGE, "batch signers exceeds 8 entries")
 	ErrBatchDuplicateSigner       = ter.Errorf(ter.TemREDUNDANT, "duplicate batch signer")
@@ -93,6 +97,7 @@ var (
 	ErrBatchInnerHasSigningPubKey = ter.Errorf(ter.TemBAD_REGKEY, "inner transaction SigningPubKey must be empty")
 	ErrBatchInnerBadFee           = ter.Errorf(ter.TemBAD_FEE, "inner transaction must have a fee of 0")
 	ErrBatchInnerSeqAndTicket     = ter.Errorf(ter.TemSEQ_AND_TICKET, "inner transaction must have exactly one of Sequence and TicketSequence")
+	ErrBatchInnerTicketAndTxnID   = ter.Errorf(ter.TemINVALID_INNER_BATCH, "inner transaction must not carry AccountTxnID when using a ticket")
 	ErrBatchInnerDupSeqOrTicket   = ter.Errorf(ter.TemREDUNDANT, "duplicate inner Sequence or TicketSequence for account")
 	ErrBatchInnerHashUncomputable = ter.Errorf(ter.TemINVALID, "failed to compute inner transaction hash")
 )
@@ -129,6 +134,13 @@ func NewBatch(account string) *Batch {
 
 func (b *Batch) TxType() tx.Type {
 	return tx.TypeBatch
+}
+
+// GetFlagsMask adopts the engine FlagsMasker seam, checking tfBatchMask at
+// preflight0 — before the popcount mode check in Validate — mirroring rippled
+// Batch::getFlagsMask.
+func (b *Batch) GetFlagsMask(rules *amendment.Rules) uint32 {
+	return tfBatchMask
 }
 
 // InnerTxCount returns the number of inner transactions in the batch.
@@ -220,6 +232,17 @@ func (b *Batch) validateInnerTransactions() (map[string]struct{}, error) {
 			return nil, err
 		}
 
+		// The inner's own preflight1 rejects a ticket combined with AccountTxnID
+		// (getSeqProxy().isTicket() && sfAccountTxnID present -> temINVALID, surfaced
+		// on the outer as temINVALID_INNER_BATCH). rippled runs the full inner
+		// preflight here, after the fee check; go-xrpl folds this specific rule into
+		// the inner loop since it never reaches the deferred engine inner-preflight
+		// otherwise. Reference: rippled Batch.cpp inner preflight -> Transactor.cpp preflight1.
+		usesTicket := innerCommon.TicketSequence != nil && (innerCommon.Sequence == nil || *innerCommon.Sequence == 0)
+		if usesTicket && innerCommon.AccountTxnID != "" {
+			return nil, ErrBatchInnerTicketAndTxnID
+		}
+
 		// rippled treats sfSequence absent and sfSequence==0 identically via
 		// getFieldU32; Go's *uint32 nil and *0 collapse the same way here.
 		seqVal := uint32(0)
@@ -283,11 +306,8 @@ func (b *Batch) Validate() error {
 		return err
 	}
 
-	// Check for invalid flags
-	// Reference: rippled Batch.cpp:213-217
-	if b.Common.Flags != nil && *b.Common.Flags&tfBatchMask != 0 {
-		return ErrBatchInvalidFlags
-	}
+	// The tfBatchMask flag check runs at preflight0 via GetFlagsMask (before this
+	// body), matching rippled where getFlagsMask precedes Batch::preflight.
 
 	// Must have exactly one of the mutually exclusive flags
 	// Reference: rippled Batch.cpp:220-227

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -387,10 +387,20 @@ func TestBatchRequiredAmendments(t *testing.T) {
 
 func TestBatchConstants(t *testing.T) {
 	assert.Equal(t, 8, MaxBatchTransactions)
-	assert.Equal(t, uint32(0x00000001), BatchFlagAllOrNothing)
-	assert.Equal(t, uint32(0x00000002), BatchFlagOnlyOne)
-	assert.Equal(t, uint32(0x00000004), BatchFlagUntilFailure)
-	assert.Equal(t, uint32(0x00000008), BatchFlagIndependent)
+	assert.Equal(t, uint32(0x00010000), BatchFlagAllOrNothing)
+	assert.Equal(t, uint32(0x00020000), BatchFlagOnlyOne)
+	assert.Equal(t, uint32(0x00040000), BatchFlagUntilFailure)
+	assert.Equal(t, uint32(0x00080000), BatchFlagIndependent)
+
+	// Pins finding Batch-mask-value: tfBatchMask matches rippled TxFlags.h
+	// (0x7FF0FFFF) — it permits tfFullyCanonicalSig and the four mode bits, and
+	// rejects tfInnerBatchTxn on the outer Batch.
+	assert.Equal(t, uint32(0x7FF0FFFF), tfBatchMask)
+	assert.Zero(t, tx.TfFullyCanonicalSig&tfBatchMask, "tfFullyCanonicalSig must be allowed")
+	assert.NotZero(t, tx.TfInnerBatchTxn&tfBatchMask, "tfInnerBatchTxn must be rejected on the outer")
+	for _, mode := range []uint32{BatchFlagAllOrNothing, BatchFlagOnlyOne, BatchFlagUntilFailure, BatchFlagIndependent} {
+		assert.Zero(t, mode&tfBatchMask, "mode flag must be allowed")
+	}
 }
 
 // TestCalculateMinimumFee_SingleSignBaseline pins the common case

--- a/internal/tx/batch/sign_test.go
+++ b/internal/tx/batch/sign_test.go
@@ -17,7 +17,7 @@ func TestSerializeBatchDigest(t *testing.T) {
 		{0x01},
 		{0x02, 0x03},
 	}
-	flags := uint32(0x00000001)
+	flags := BatchFlagAllOrNothing
 
 	got := serializeBatch(flags, txids)
 

--- a/internal/tx/delegate/delegate_set.go
+++ b/internal/tx/delegate/delegate_set.go
@@ -27,11 +27,6 @@ var notDelegatableTxTypes = map[uint16]bool{
 	102: true, // ttUNL_MODIFY (UNLModify)
 }
 
-// granularPermissionMin is the threshold above which a permission value is granular.
-// Granular permissions have values > UINT16_MAX (65535) and are always delegatable.
-// Reference: rippled Permissions.h — GranularPermissionType values start at 65537
-const granularPermissionMin = 65536
-
 // DelegateSet sets up delegation for an account.
 // Reference: rippled DelegateSet.cpp
 type DelegateSet struct {
@@ -67,6 +62,14 @@ func NewDelegateSet(account string) *DelegateSet {
 
 func (d *DelegateSet) TxType() tx.Type {
 	return tx.TypeDelegateSet
+}
+
+// GetFlagsMask adopts the engine FlagsMasker seam. DelegateSet defines no
+// type-specific flags (rippled does not override getFlagsMask), so the base
+// universal mask is checked at preflight0 — before the account/fee/NetworkID
+// checks — matching rippled's Transactor::getFlagsMask default.
+func (d *DelegateSet) GetFlagsMask(rules *amendment.Rules) uint32 {
+	return tx.TfUniversalMask
 }
 
 // Reference: rippled DelegateSet.cpp preflight()
@@ -318,8 +321,13 @@ func (d *DelegateSet) permissionValues() []uint32 {
 // map to a registered transaction type, and that type's introducing amendment
 // (if any) must be enabled.
 func isDelegatable(permissionValue uint32, rules *amendment.Rules) bool {
-	// Granular permissions are always delegatable.
-	if permissionValue >= granularPermissionMin {
+	// Granular permissions are always delegatable — but only KNOWN granular
+	// permissions. rippled short-circuits on getGranularName(value) != nullopt,
+	// so an unknown value in the granular range (>= 65536) is NOT treated as
+	// granular; it falls through to the transaction-type path below (where it is
+	// not a registered type and, under fixDelegateV1_1, is rejected).
+	// Reference: rippled Permissions.cpp isDelegatable().
+	if state.IsGranularPermissionValue(permissionValue) {
 		return true
 	}
 

--- a/internal/tx/engine/pseudo_gates.go
+++ b/internal/tx/engine/pseudo_gates.go
@@ -98,12 +98,15 @@ func (e *Engine) pseudoPreflight(tx txcore.Transaction, rules *amendment.Rules) 
 		return ter.TemBAD_SIGNATURE
 	}
 
-	// Sequence must be zero. Rippled also rejects sfPreviousTxnID here, but
-	// go-xrpl's Common has no such field. sfTicketSequence is NOT consulted in
-	// Change::preflight — rippled rejects it at the structural tx-format layer
-	// (Transactor::preflight1), so we do not gate on it here either.
-	// Reference: Change.cpp:65-69.
-	if common.Sequence != nil && *common.Sequence != 0 {
+	// Sequence must be zero AND sfPreviousTxnID must be absent. sfPreviousTxnID is
+	// a deserializable optional common field, so a binary pseudo-tx can carry it;
+	// rippled rejects both in the same gate. HasField reflects the decoded field
+	// set, which is exactly the binary/consensus path where this matters.
+	// sfTicketSequence is NOT consulted in Change::preflight — rippled rejects it
+	// at the structural tx-format layer (Transactor::preflight1), so we do not gate
+	// on it here either.
+	// Reference: Change.cpp:70-75 — `Sequence != 0 || isFieldPresent(sfPreviousTxnID)`.
+	if (common.Sequence != nil && *common.Sequence != 0) || common.HasField("PreviousTxnID") {
 		return ter.TemBAD_SEQUENCE
 	}
 

--- a/internal/tx/ledgerstatefix/ledger_state_fix.go
+++ b/internal/tx/ledgerstatefix/ledger_state_fix.go
@@ -12,10 +12,10 @@ import (
 )
 
 // LedgerStateFix fix types
-// Reference: rippled LedgerStateFix.h FixType enum
+// Reference: rippled LedgerStateFix.h FixType enum (std::uint16_t)
 const (
 	// LedgerFixTypeNFTokenPageLink repairs NFToken directory page links
-	LedgerFixTypeNFTokenPageLink uint8 = 1
+	LedgerFixTypeNFTokenPageLink uint16 = 1
 )
 
 // LedgerStateFix errors
@@ -29,14 +29,17 @@ var (
 type LedgerStateFix struct {
 	tx.BaseTx
 
-	// LedgerFixType identifies the type of fix (required)
-	LedgerFixType uint8 `json:"LedgerFixType" xrpl:"LedgerFixType"`
+	// LedgerFixType identifies the type of fix (required). sfLedgerFixType is a
+	// UINT16 on the wire, so wire values above 255 must still parse and reach the
+	// default preflight arm (tefINVALID_LEDGER_FIX_TYPE) rather than failing to
+	// decode.
+	LedgerFixType uint16 `json:"LedgerFixType" xrpl:"LedgerFixType"`
 
 	// Owner is the owner account (required for nfTokenPageLink fix)
 	Owner string `json:"Owner,omitempty" xrpl:"Owner,omitempty"`
 }
 
-func NewLedgerStateFix(account string, fixType uint8) *LedgerStateFix {
+func NewLedgerStateFix(account string, fixType uint16) *LedgerStateFix {
 	return &LedgerStateFix{
 		BaseTx:        *tx.NewBaseTx(tx.TypeLedgerStateFix, account),
 		LedgerFixType: fixType,
@@ -55,14 +58,16 @@ func (l *LedgerStateFix) TxType() tx.Type {
 	return tx.TypeLedgerStateFix
 }
 
+// GetFlagsMask adopts the engine FlagsMasker seam. LedgerStateFix defines no
+// type-specific flags, so it uses the base universal mask, checked at preflight0
+// (rippled does not override getFlagsMask for LedgerStateFix).
+func (l *LedgerStateFix) GetFlagsMask(rules *amendment.Rules) uint32 {
+	return tx.TfUniversalMask
+}
+
 // Reference: rippled LedgerStateFix.cpp preflight()
 func (l *LedgerStateFix) Validate() error {
 	if err := l.BaseTx.Validate(); err != nil {
-		return err
-	}
-
-	// Reference: rippled LedgerStateFix.cpp:36-37
-	if err := tx.CheckFlags(l.GetFlags(), tx.TfUniversalMask); err != nil {
 		return err
 	}
 
@@ -87,11 +92,10 @@ func (l *LedgerStateFix) Flatten() (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	// LedgerFixType is UInt16 in the binary codec but uint8 in Go.
 	// Convert to int so the codec's UInt16.FromJSON() can handle it.
 	if v, ok := m["LedgerFixType"]; ok {
 		switch val := v.(type) {
-		case uint8:
+		case uint16:
 			m["LedgerFixType"] = int(val)
 		}
 	}

--- a/internal/tx/ledgerstatefix/ledger_state_fix_test.go
+++ b/internal/tx/ledgerstatefix/ledger_state_fix_test.go
@@ -61,16 +61,17 @@ func TestLedgerStateFixValidation(t *testing.T) {
 			errMsg:  "INVALID_LEDGER_FIX_TYPE",
 		},
 		{
-			name: "invalid - universal flags set",
-			tx: func() *LedgerStateFix {
-				l := NewNFTokenPageLinkFix("rAdmin", "rOwner")
-				flags := tx.TfUniversalMask
-				l.Common.Flags = &flags
-				return l
-			}(),
+			// Pins finding LedgerStateFix-uint16: sfLedgerFixType is a UINT16, so a
+			// wire value above 255 must decode and reach the default preflight arm
+			// (tefINVALID_LEDGER_FIX_TYPE) rather than overflow a uint8 at parse.
+			name:    "invalid - unknown fix type (256, needs uint16)",
+			tx:      NewLedgerStateFix("rAdmin", 256),
 			wantErr: true,
-			errMsg:  "invalid flags",
+			errMsg:  "INVALID_LEDGER_FIX_TYPE",
 		},
+		// The universal-flags rejection moved from Validate() to the engine
+		// FlagsMasker seam (preflight0), so it is covered by the engine precedence
+		// pin-test rather than this Validate()-only table.
 	}
 
 	for _, tt := range tests {
@@ -126,7 +127,7 @@ func TestLedgerStateFixConstructors(t *testing.T) {
 		lsf := NewLedgerStateFix("rAdmin", LedgerFixTypeNFTokenPageLink)
 		require.NotNil(t, lsf)
 		assert.Equal(t, "rAdmin", lsf.Account)
-		assert.Equal(t, uint8(1), lsf.LedgerFixType)
+		assert.Equal(t, uint16(1), lsf.LedgerFixType)
 		assert.Equal(t, "", lsf.Owner)
 		assert.Equal(t, tx.TypeLedgerStateFix, lsf.TxType())
 	})
@@ -152,5 +153,5 @@ func TestLedgerStateFixRequiredAmendments(t *testing.T) {
 // Constants Tests
 
 func TestLedgerStateFixConstants(t *testing.T) {
-	assert.Equal(t, uint8(1), LedgerFixTypeNFTokenPageLink)
+	assert.Equal(t, uint16(1), LedgerFixTypeNFTokenPageLink)
 }

--- a/internal/tx/permissioneddomain/permissioned_domain_set.go
+++ b/internal/tx/permissioneddomain/permissioned_domain_set.go
@@ -36,27 +36,24 @@ func (p *PermissionedDomainSet) TxType() tx.Type {
 	return tx.TypePermissionedDomainSet
 }
 
+// GetFlagsMask adopts the engine FlagsMasker seam. PermissionedDomainSet defines
+// no type-specific flags, so the base universal mask is checked at preflight0
+// (before the credentials array checks), matching rippled's default
+// Transactor::getFlagsMask.
+func (p *PermissionedDomainSet) GetFlagsMask(rules *amendment.Rules) uint32 {
+	return tx.TfUniversalMask
+}
+
 // Reference: rippled PermissionedDomainSet.cpp preflight()
 func (p *PermissionedDomainSet) Validate() error {
 	if err := p.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	// Check for invalid flags (tfUniversalMask)
-	// Reference: rippled PermissionedDomainSet.cpp:41-45
-	if err := tx.CheckFlags(p.GetFlags(), tx.TfUniversalMask); err != nil {
-		return err
-	}
-
-	// If DomainID is present, it must be a valid non-zero 256-bit hash.
-	if p.DomainID != "" {
-		if _, err := tx.ParseHash256NonZero(p.DomainID); err != nil {
-			return err
-		}
-	}
-
-	// Validate AcceptedCredentials array
-	// Reference: rippled PermissionedDomainSet.cpp checkArray()
+	// credentials::checkArray runs FIRST (rippled preflight order): array bounds,
+	// then per-credential zero-issuer / credential-type / duplicate checks. Only
+	// after it succeeds is the DomainID present-and-zero check evaluated.
+	// Reference: rippled PermissionedDomainSet.cpp preflight() -> CredentialHelpers.cpp checkArray().
 	if len(p.AcceptedCredentials) == 0 {
 		return ErrPermDomainEmptyCredentials
 	}
@@ -70,6 +67,16 @@ func (p *PermissionedDomainSet) Validate() error {
 
 		if data.Issuer == "" {
 			return ErrPermDomainNoIssuer
+		}
+		// A zero (all-0x00) issuer AccountID is temINVALID_ACCOUNT_ID, and it
+		// precedes the credential-type rules. A zero AccountID decodes to the
+		// non-empty classic address, so the "" check above cannot catch it.
+		// rippled rejects only the zero account (`!issuer`); a well-formed
+		// non-zero account decodes here and is used to key the duplicate set.
+		// Reference: CredentialHelpers.cpp checkArray -> `if (!issuer) return temINVALID_ACCOUNT_ID`.
+		issuerID, decErr := state.DecodeAccountID(data.Issuer)
+		if decErr == nil && issuerID == ([20]byte{}) {
+			return ter.Errorf(ter.TemINVALID_ACCOUNT_ID, "credential issuer account is invalid")
 		}
 
 		if data.CredentialType == "" {
@@ -87,11 +94,29 @@ func (p *PermissionedDomainSet) Validate() error {
 			return ErrPermDomainCredTypeTooLong
 		}
 
-		key := data.Issuer + ":" + data.CredentialType
+		// Duplicates are detected on the decoded (issuer, credentialType) bytes so
+		// two entries differing only in credential-type hex case still collide,
+		// mirroring rippled's sha512Half(issuer, ct) dedup key. A non-decodable
+		// placeholder issuer falls back to its raw string.
+		var issuerKey string
+		if decErr == nil {
+			issuerKey = string(issuerID[:])
+		} else {
+			issuerKey = data.Issuer
+		}
+		key := issuerKey + "\x00" + string(credTypeBytes)
 		if seen[key] {
 			return ErrPermDomainDuplicateCredential
 		}
 		seen[key] = true
+	}
+
+	// If DomainID is present, it must be a valid non-zero 256-bit hash. Checked
+	// after the credentials array. Reference: rippled PermissionedDomainSet.cpp preflight().
+	if p.DomainID != "" {
+		if _, err := tx.ParseHash256NonZero(p.DomainID); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/tx/permissioneddomain/permissioned_domain_test.go
+++ b/internal/tx/permissioneddomain/permissioned_domain_test.go
@@ -190,18 +190,9 @@ func TestPermissionedDomainSetValidation(t *testing.T) {
 			wantErr: true,
 			errMsg:  "exceeds",
 		},
-		{
-			name: "invalid - non-universal flags set",
-			tx: func() *PermissionedDomainSet {
-				tx := NewPermissionedDomainSet("rOwner")
-				tx.AddAcceptedCredential("rIssuer1", makeCredTypeHex(10))
-				flags := uint32(0x00010000) // Not a universal flag
-				tx.Common.Flags = &flags
-				return tx
-			}(),
-			wantErr: true,
-			errMsg:  "invalid flags",
-		},
+		// The non-universal-flags rejection moved from Validate() to the engine
+		// FlagsMasker seam (preflight0), so it is covered by the engine precedence
+		// pin-test rather than this Validate()-only table.
 	}
 
 	for _, tt := range tests {

--- a/internal/tx/permissioneddomain/precedence_test.go
+++ b/internal/tx/permissioneddomain/precedence_test.go
@@ -1,0 +1,60 @@
+package permissioneddomain
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPermissionedDomainSet_CheckArrayBeforeDomainID pins finding
+// PermissionedDomainSet-order: rippled runs credentials::checkArray before the
+// DomainID present-and-zero check, so an empty AcceptedCredentials array wins
+// (temARRAY_EMPTY) even when DomainID is also zero (which alone would be
+// temMALFORMED).
+func TestPermissionedDomainSet_CheckArrayBeforeDomainID(t *testing.T) {
+	pd := NewPermissionedDomainSet("rOwner")
+	pd.DomainID = strings.Repeat("00", 32) // zero DomainID -> temMALFORMED if reached first
+	pd.AcceptedCredentials = nil           // empty -> temARRAY_EMPTY
+	pd.Common.Fee = "10"
+	seq := uint32(1)
+	pd.Common.Sequence = &seq
+
+	err := pd.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "temARRAY_EMPTY")
+}
+
+// TestPermissionedDomainSet_ZeroIssuer pins finding
+// PermissionedDomainSet-zero-issuer: a zero (all-0x00) issuer AccountID is
+// temINVALID_ACCOUNT_ID in checkArray, not the tecNO_ISSUER an included tx would
+// later report.
+func TestPermissionedDomainSet_ZeroIssuer(t *testing.T) {
+	pd := NewPermissionedDomainSet("rOwner")
+	pd.AddAcceptedCredential(protocol.ZeroAccount, makeCredTypeHex(4))
+	pd.Common.Fee = "10"
+	seq := uint32(1)
+	pd.Common.Sequence = &seq
+
+	err := pd.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "temINVALID_ACCOUNT_ID")
+}
+
+// TestPermissionedDomainSet_DuplicateCredentialHexCase pins finding
+// PermissionedDomainSet-dedup: duplicate detection operates on decoded bytes, so
+// two credentials with the same issuer whose CredentialType differs only in hex
+// case ("AB" vs "ab") still collide -> temMALFORMED.
+func TestPermissionedDomainSet_DuplicateCredentialHexCase(t *testing.T) {
+	pd := NewPermissionedDomainSet("rOwner")
+	pd.AddAcceptedCredential("rIssuer1", "AB")
+	pd.AddAcceptedCredential("rIssuer1", "ab")
+	pd.Common.Fee = "10"
+	seq := uint32(1)
+	pd.Common.Sequence = &seq
+
+	err := pd.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "temMALFORMED")
+}


### PR DESCRIPTION
Aligns preflight TER precedence with rippled 3.1.0 for the **Delegate /
PermissionedDomain / LedgerStateFix**, **pseudo-transaction (Change family)**,
and **Batch** transaction families — the final group of the preflight-precedence
campaign. Each family type adopts the PR #1271 preflight seams (FlagsMasker at
preflight0; per-type body checks) so a transaction that violates several rules
surfaces the same TER rippled would.

All 16 adversarially-verified findings were re-verified against rippled tag
**3.1.0** before fixing (the delegate/permdomain/lsf and pseudo audits ran with a
degraded reviewer, and the batch audit was verified against 3.0.0 — see the
refuted/moot rows).

## Per-finding disposition

| # | Family | Sev | Finding | Disposition |
|---|--------|-----|---------|-------------|
| 1 | DelegateSet | high | no getFlagsMask → any non-universal flag must be temINVALID_FLAG at preflight0 | **Fixed** — FlagsMasker(tfUniversalMask). Pinned. |
| 2 | DelegateSet | high | unknown sfPermissionValue fails to parse (string field vs numeric decode) | **Fixed** — unregistered values round-trip as their decimal form (codec + LookupPermissionValue), so goXRPL can process a validated ledger's DelegateSet with an unknown permission and reach the right TER. Pinned (binary round-trip). Minor deviation: an unknown value renders as a decimal string in JSON (rippled emits a number); such values never occur via honest clients and PermissionDelegation is off-mainnet. |
| 3 | DelegateSet | low | isDelegatable returns true for ANY value ≥ 65536 | **Fixed** — short-circuit only on KNOWN granular permissions (rippled getGranularName); unknowns fall through to the tx-type path → temMALFORMED under fixDelegateV1_1. Pinned. |
| 4 | PermissionedDomainSet | high | zero issuer AccountID → tecNO_ISSUER instead of temINVALID_ACCOUNT_ID | **Fixed** — decode issuer, reject the zero AccountID with temINVALID_ACCOUNT_ID at preflight. Pinned. |
| 5 | PermissionedDomainSet | med | DomainID checked before the AcceptedCredentials array | **Fixed** — checkArray runs first (rippled order); empty array → temARRAY_EMPTY beats DomainID temMALFORMED. Pinned. |
| 6 | PermissionedDomainSet | low | dedup by raw string misses hex-case duplicates | **Fixed** — dedup on decoded (issuer, credentialType) bytes. Pinned. |
| 7 | LedgerStateFix | med | LedgerFixType uint8 → wire values 256-65535 fail to parse | **Fixed** — widened to uint16; 256 now reaches tefINVALID_LEDGER_FIX_TYPE. Also adopted FlagsMasker. Pinned. |
| 8 | Change family | med | pseudo seq gate ignores sfPreviousTxnID | **Fixed** — reject when the decoded field set contains PreviousTxnID (HasField), matching rippled's `Sequence != 0 \|\| isFieldPresent(sfPreviousTxnID)`. Pinned. |
| 9 | Change family | low | zero-txID temINVALID guard runs post-preflight | **Moot** — SHA512-half == 0 is cryptographically unreachable; guard stays where the id is first known (same disposition as #1271 finding 11). |
| 10 | SetFee | low | goXRPL rejects IOU-valued drops fields (temMALFORMED) that rippled accepts | **Refuted / deviation** — matching would remove a defensive parse guard to accept byzantine-only malformed data; unreachable via honest FeeVote, rippled's acceptance is arguably a bug, and no fixture exercises it (per the auditor's own recommendation). |
| 11 | Batch | high | mode-flag bit positions wrong (0x1/0x2/0x4/0x8 vs 0x00010000+); tfBatchMask wrong | **Fixed** — rippled-canonical bits + tfBatchMask 0x7FF0FFFF + FlagsMasker at preflight0. Pinned. |
| 12 | Batch | high | preflightInner never runs the inner type's PreflightRules | **Dependency on #1274** — the engine inner-seam wiring (checkExtraFeatures/checkFlagsMask/checkPreflightRules in preflightInner) is owned by #1274; not duplicated here. |
| 13 | Batch | med | inner preflight verdict deferred behind fee/seq/dup | **Partially refuted + dependency** — rippled **swapped** the fee-check and inner-preflight order between 3.0.0 and 3.1.0 (fee now precedes inner preflight), so the headline fee-vs-preflight scenario already matches goXRPL under the 3.1.0 target. The residual "deferred behind later inners' checks" divergence is owned by the #1274 inner-seam rework. |
| 14 | Batch | med | BatchSigners structural checks run in Validate, before signature verification | **Dependency on #1277** — the SigValidatedPreflighter seam (post-signature stage mirroring Batch::preflightSigValidated) is owned by #1277; not duplicated here. |
| 15 | Batch | med | inner ticket + AccountTxnID not rejected | **Fixed** — validateInnerTransactions rejects a ticket-using inner that carries AccountTxnID (temINVALID_INNER_BATCH). Kept in Batch-owned code to avoid churning the #1274 inner-seam. Pinned. |
| 16 | Batch | low | inner Counterparty not added to requiredSigners | **Moot** — the only sfCounterparty-bearing type (LoanSet) is on the Batch inner-type blocklist, so unreachable until a counterparty-bearing type is allowed in batches. |

### Dependencies (noted, not duplicated)
- Findings **12** and the residual of **13** rely on the engine `preflightInner` seam wiring in **#1274** (`fix/v3-precedence-account`), which is not yet merged.
- Finding **14** relies on the `SigValidatedPreflighter` seam in **#1277** (`fix/v3-precedence-escrow-paychan`), which is not yet merged.

Batch code was reconciled against the current v3.0.0 (#1251 blocklist, #1258 nested sigs, #1262 fixBatchInnerSigs); the flag-constants and inner-ticket findings remain live. Delegate code was reconciled against the fixDelegateV1_1 rework (#1257).

## Verification
- `go test ./internal/... ./codec/... ./amendment/... ./keylet/... ./ledger/...`: all in-scope packages pass. The only failing package is `internal/testing/conformance`, whose failures are entirely out-of-scope suites (Vault) and byte-identical to a fresh `origin/v3.0.0` baseline.
- Conformance (fresh clean-base diff): **in-scope 1260 pass / 0 fail** on both baseline and branch; out-of-scope per-suite counts unchanged (**app/Batch 5/30**, app/Vault, app/XChain, …). **app/Delegate 16/16 green** and **app/PermissionedDomains 6/6 green** on both. Zero fixture TER changed.
- `golangci-lint run --config .golangci.yml` on all changed packages: 0 issues.
- docsgen (registries): no drift.
- New pin-tests: one per surviving fork scenario (DelegateSet flags/unknown-granular/unknown-parse round-trip; PermissionedDomainSet order/zero-issuer/dedup; LedgerStateFix 256; pseudo PreviousTxnID; Batch tfBatchMask semantics + inner ticket+AccountTxnID).

Part of #274; completes the family waves following #1271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
