### PR TITLE
feat(amendment): fixCleanup3_1_3 vault/lending arms (completes #1248)

### DIFF
--- a/internal/tx/invariants/lending.go
+++ b/internal/tx/invariants/lending.go
@@ -7,18 +7,20 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/vault"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
-// XLS-66 lending invariants, ported from rippled 3.1.0 InvariantCheck.cpp
+// XLS-66 lending invariants, ported from rippled InvariantCheck.cpp
 // (ValidLoanBroker, ValidLoan). Both are enforcement-gated on
 // featureLendingProtocol: while it is off the objects cannot exist, so the checks
 // are inert.
 //
-// The 3.1.0 ValidLoanBroker also asserts CoverAvailable >= accountHolds(pseudo,
-// asset) — a lower bound revised into an exact match by the 3.1.3 fixCleanup.
-// That cross-asset balance comparison is deferred; the numeric and structural
-// checks below are the safe subset.
+// ValidLoanBroker also compares CoverAvailable against the pseudo-account's
+// holdings of the vault asset: a lower bound (>=, from 3.1.0), plus an exact upper
+// bound (==) added by fixCleanup3_1_3. Pseudo-accounts carry no XRP reserve, so
+// the XRP holdings are the full balance (rippled xrpLiquid + isPseudoAccount).
 
 const lsfLoanOverpaymentFlag uint32 = 0x00040000
 
@@ -132,11 +134,47 @@ func checkValidLoanBroker(entries []InvariantEntry, view ReadView, rules *amendm
 		if verr != nil {
 			return lendingViolation("ValidLoanBroker", "loan broker vault ID is malformed")
 		}
-		if data, rerr := view.Read(keylet.VaultByID(vid)); rerr != nil || data == nil {
+		vaultData, rerr := view.Read(keylet.VaultByID(vid))
+		if rerr != nil || vaultData == nil {
 			return lendingViolation("ValidLoanBroker", "loan broker vault ID is invalid")
+		}
+
+		// CoverAvailable must match the pseudo-account's holdings of the vault
+		// asset: a lower bound, plus (post-fixCleanup3_1_3) an exact upper bound.
+		// A deleted broker has After==nil and is skipped above, matching rippled's
+		// ttLOAN_BROKER_DELETE exclusion from the upper bound.
+		pseudoAddr, aok := after["Account"].(string)
+		if !aok {
+			return lendingViolation("ValidLoanBroker", "loan broker has no account")
+		}
+		pseudoID, aerr := state.DecodeAccountID(pseudoAddr)
+		if aerr != nil {
+			return lendingViolation("ValidLoanBroker", "loan broker account is malformed")
+		}
+		pseudoBalance, phOK := vault.PseudoAssetHolds(view, pseudoID, vaultData)
+		if !phOK {
+			return lendingViolation("ValidLoanBroker", "could not read pseudo-account asset balance")
+		}
+		coverAvailable := coverAvailableNumber(after)
+		if coverAvailable.Cmp(pseudoBalance) < 0 {
+			return lendingViolation("ValidLoanBroker", "cover available is less than pseudo-account asset balance")
+		}
+		if rules.Enabled(amendment.FeatureFixCleanup3_1_3) && coverAvailable.Cmp(pseudoBalance) > 0 {
+			return lendingViolation("ValidLoanBroker", "cover available is greater than pseudo-account asset balance")
 		}
 	}
 	return nil
+}
+
+// coverAvailableNumber parses the LoanBroker's CoverAvailable NUMBER field; an
+// absent or malformed value is treated as zero.
+func coverAvailableNumber(fields map[string]any) state.XRPLNumber {
+	s, ok := fields["CoverAvailable"].(string)
+	if !ok {
+		return state.NewXRPLNumber(0, 0)
+	}
+	n, _ := vault.ParseLedgerNumber(s)
+	return n
 }
 
 // hexDecode32 decodes a 64-char hex string to a [32]byte.

--- a/internal/tx/invariants/lending_invariant_test.go
+++ b/internal/tx/invariants/lending_invariant_test.go
@@ -1,0 +1,123 @@
+package invariants
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// mapView routes keylet reads to crafted SLE bytes for the ValidLoanBroker
+// cross-asset balance check.
+type mapView struct {
+	stubView
+	data map[[32]byte][]byte
+}
+
+func (v mapView) Read(k keylet.Keylet) ([]byte, error) { return v.data[k.Key], nil }
+
+// TestValidLoanBroker_CoverAvailableBounds crafts an XRP-vault LoanBroker whose
+// CoverAvailable is above / equal / below the pseudo-account's XRP balance, and
+// asserts the lower bound (>=, unconditional) and upper bound (==, gated on
+// fixCleanup3_1_3). Pseudo-accounts carry no XRP reserve, so the balance is the
+// full drops amount.
+func TestValidLoanBroker_CoverAvailableBounds(t *testing.T) {
+	var ownerID, pseudoID [20]byte
+	for i := range ownerID {
+		ownerID[i] = 0x11
+		pseudoID[i] = 0x22
+	}
+	ownerAddr, err := state.EncodeAccountID(ownerID)
+	if err != nil {
+		t.Fatalf("encode owner: %v", err)
+	}
+	pseudoAddr, err := state.EncodeAccountID(pseudoID)
+	if err != nil {
+		t.Fatalf("encode pseudo: %v", err)
+	}
+
+	var vid [32]byte
+	for i := range vid {
+		vid[i] = 0x33
+	}
+	vidHex := strings.ToUpper(hex.EncodeToString(vid[:]))
+
+	const balanceDrops = "5000000000" // pseudo-account holds 5000 XRP of cover
+
+	vaultBytes := mustEncode(t, map[string]any{
+		"LedgerEntryType":  "Vault",
+		"Flags":            0,
+		"Sequence":         1,
+		"OwnerNode":        "0",
+		"Owner":            ownerAddr,
+		"Account":          pseudoAddr,
+		"Asset":            map[string]any{"currency": "XRP"},
+		"ShareMPTID":       strings.Repeat("0", 48),
+		"WithdrawalPolicy": 1,
+	})
+	accountBytes := mustEncode(t, map[string]any{
+		"LedgerEntryType": "AccountRoot",
+		"Account":         pseudoAddr,
+		"Balance":         balanceDrops,
+		"Flags":           0,
+		"OwnerCount":      0,
+		"Sequence":        0,
+	})
+	view := mapView{data: map[[32]byte][]byte{
+		keylet.VaultByID(vid).Key:    vaultBytes,
+		keylet.Account(pseudoID).Key: accountBytes,
+	}}
+
+	broker := func(cover string) []InvariantEntry {
+		return []InvariantEntry{{
+			EntryType: "LoanBroker",
+			After: mustEncode(t, map[string]any{
+				"LedgerEntryType": "LoanBroker",
+				"Flags":           0,
+				"Owner":           ownerAddr,
+				"Account":         pseudoAddr,
+				"VaultID":         vidHex,
+				"CoverAvailable":  cover,
+				"Sequence":        1,
+				"OwnerNode":       "0",
+			}),
+		}}
+	}
+
+	fixOn := amendment.NewRules([][32]byte{amendment.FeatureLendingProtocol, amendment.FeatureFixCleanup3_1_3})
+	fixOff := amendment.NewRules([][32]byte{amendment.FeatureLendingProtocol})
+
+	cases := []struct {
+		name       string
+		cover      string
+		wantFixOn  bool // expect a violation with fixCleanup3_1_3 enabled
+		wantFixOff bool // expect a violation with fixCleanup3_1_3 disabled
+	}{
+		{"exact match", balanceDrops, false, false},
+		{"cover below balance (lower bound)", "4000000000", true, true},
+		{"cover above balance (upper bound, gated)", "6000000000", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entries := broker(tc.cover)
+			if got := checkValidLoanBroker(entries, view, fixOn) != nil; got != tc.wantFixOn {
+				t.Errorf("fixCleanup3_1_3 ON: violation=%v, want %v", got, tc.wantFixOn)
+			}
+			if got := checkValidLoanBroker(entries, view, fixOff) != nil; got != tc.wantFixOff {
+				t.Errorf("fixCleanup3_1_3 OFF: violation=%v, want %v", got, tc.wantFixOff)
+			}
+		})
+	}
+}
+
+// TestValidLoanBroker_InertWhenLendingDisabled asserts the invariant does not run
+// (and cannot false-positive) while LendingProtocol is off.
+func TestValidLoanBroker_InertWhenLendingDisabled(t *testing.T) {
+	entries := []InvariantEntry{{EntryType: "LoanBroker", After: []byte{0x01}}}
+	if v := checkValidLoanBroker(entries, stubView{}, amendment.EmptyRules()); v != nil {
+		t.Fatalf("expected inert check with LendingProtocol off, got %v", v)
+	}
+}

--- a/internal/tx/lending/lmath/make_payment.go
+++ b/internal/tx/lending/lmath/make_payment.go
@@ -172,8 +172,10 @@ func doOverpayment(asset Asset, loanScale int, overpaymentComponents ExtendedPay
 // LoanMakePayment applies a payment to the loan and returns the breakdown of
 // amounts paid, mutating loan in place (rippled loanMakePayment). now is the
 // parent close time in Ripple-epoch seconds. A result other than tesSUCCESS is a
-// failure; loan must not be persisted in that case.
-func LoanMakePayment(asset Asset, now uint32, loan *LoanAccount, managementFeeRate uint32, amount N, paymentType LoanPaymentType) (LoanPaymentParts, ter.Result) {
+// failure; loan must not be persisted in that case. fixCleanupEnabled reflects
+// the fixCleanup3_1_3 amendment: when set, an overpayment Amount is truncated to
+// the loan scale so meaningless dust is not processed.
+func LoanMakePayment(asset Asset, now uint32, loan *LoanAccount, managementFeeRate uint32, amount N, paymentType LoanPaymentType, fixCleanupEnabled bool) (LoanPaymentParts, ter.Result) {
 	if loan.PaymentRemaining == 0 || loan.PrincipalOutstanding.IsZero() {
 		return LoanPaymentParts{}, ter.TecKILLED
 	}
@@ -232,9 +234,15 @@ func LoanMakePayment(asset Asset, now uint32, loan *LoanAccount, managementFeeRa
 		return LoanPaymentParts{}, ter.TecINSUFFICIENT_PAYMENT
 	}
 
+	// Post-fixCleanup3_1_3: truncate the raw Amount to the loan scale before
+	// deriving the overpayment, so dust below the asset's precision is ignored.
+	roundedAmount := amount
+	if fixCleanupEnabled {
+		roundedAmount = RoundAssetTowardsZero(asset, amount, loanScale)
+	}
 	if paymentType == PaymentOverpayment && loan.HasOverpaymentFlag && loan.PaymentRemaining > 0 &&
-		totalPaid.Cmp(amount) < 0 && numPayments < protocol.LoanMaximumPaymentsPerTransaction {
-		overpayment := minN(amount.Sub(totalPaid), loan.TotalValueOutstanding)
+		totalPaid.Cmp(roundedAmount) < 0 && numPayments < protocol.LoanMaximumPaymentsPerTransaction {
+		overpayment := minN(roundedAmount.Sub(totalPaid), loan.TotalValueOutstanding)
 		overpaymentComponents := computeOverpaymentComponents(asset, loanScale, overpayment, loan.OverpaymentInterestRate, loan.OverpaymentFee, managementFeeRate)
 		if gtZero(overpaymentComponents.TrackedPrincipalDelta) {
 			oParts, ok, err := doOverpayment(asset, loanScale, overpaymentComponents, loan, periodicRate, loan.PaymentRemaining, managementFeeRate)

--- a/internal/tx/lending/loan_apply.go
+++ b/internal/tx/lending/loan_apply.go
@@ -1,6 +1,7 @@
 package lending
 
 import (
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/lending/lmath"
@@ -191,16 +192,56 @@ func (l *LoanManage) Apply(ctx *tx.ApplyContext) ter.Result {
 	}
 
 	flags := l.GetFlags()
+	integral := assetIntegral(vinfo.Asset)
+	var result ter.Result
 	switch {
 	case flags&TfLoanDefault != 0:
-		return l.defaultLoan(ctx, loanKey, loan, brokerKey, b, vaultKey, vinfo)
+		result = l.defaultLoan(ctx, loanKey, loan, brokerKey, b, vaultKey, vinfo)
 	case flags&TfLoanImpair != 0:
-		return l.impairLoan(ctx, loanKey, loan, vaultKey, vinfo)
+		result = l.impairLoan(ctx, loanKey, loan, vaultKey, vinfo)
 	case flags&TfLoanUnimpair != 0:
-		return l.unimpairLoan(ctx, loanKey, loan, vaultKey, vinfo)
+		result = l.unimpairLoan(ctx, loanKey, loan, vaultKey, vinfo)
 	default:
-		return ter.TesSUCCESS
+		result = ter.TesSUCCESS
 	}
+
+	// Post-fixCleanup3_1_3: round the NUMBER fields of the Loan, LoanBroker, and
+	// Vault to the asset precision on every successful path. Pre-amendment only
+	// the noop path did so.
+	if result == ter.TesSUCCESS && ctx.Rules().Enabled(amendment.FeatureFixCleanup3_1_3) {
+		if r := l.associateEntities(ctx, loanKey, brokerKey, vaultKey, integral); r != ter.TesSUCCESS {
+			return r
+		}
+	}
+	return result
+}
+
+// associateEntities rounds the NUMBER fields of the Loan, LoanBroker, and Vault
+// to the vault asset's precision after a successful default/impair/unimpair, so
+// no accounting field carries sub-precision dust (rippled associateAsset).
+func (l *LoanManage) associateEntities(ctx *tx.ApplyContext, loanKey, brokerKey, vaultKey keylet.Keylet, integral bool) ter.Result {
+	loan, err := readLoan(ctx.View, loanKey)
+	if err != nil || loan == nil {
+		return ter.TefBAD_LEDGER
+	}
+	associateLoanAsset(loan, integral)
+	if r := updateLoan(ctx, loanKey, loan); r != ter.TesSUCCESS {
+		return r
+	}
+	b, berr := readLoanBroker(ctx.View, brokerKey)
+	if berr != nil || b == nil {
+		return ter.TefBAD_LEDGER
+	}
+	associateBrokerAsset(b, integral)
+	if r := updateBroker(ctx, brokerKey, b); r != ter.TesSUCCESS {
+		return r
+	}
+	v, verr := vault.ReadVaultLending(ctx.View, vaultKey)
+	if verr != nil || v == nil {
+		return ter.TefBAD_LEDGER
+	}
+	associateVaultAsset(v, integral)
+	return vault.UpdateVaultTotals(ctx, vaultKey, v.AssetsTotal, v.AssetsAvailable, v.LossUnrealized)
 }
 
 func (l *LoanManage) impairLoan(ctx *tx.ApplyContext, loanKey keylet.Keylet, loan *loanData, vaultKey keylet.Keylet, v *vault.VaultLending) ter.Result {
@@ -221,7 +262,6 @@ func (l *LoanManage) impairLoan(ctx *tx.ApplyContext, loanKey keylet.Keylet, loa
 	if !hasExpired(ctx.Config.ParentCloseTime, loan.NextPaymentDueDate) {
 		loan.NextPaymentDueDate = ctx.Config.ParentCloseTime
 	}
-	associateLoanAsset(loan, integral)
 	return updateLoan(ctx, loanKey, loan)
 }
 
@@ -248,7 +288,6 @@ func (l *LoanManage) unimpairLoan(ctx *tx.ApplyContext, loanKey keylet.Keylet, l
 	} else {
 		loan.NextPaymentDueDate = ctx.Config.ParentCloseTime + loan.PaymentInterval
 	}
-	associateLoanAsset(loan, integral)
 	return updateLoan(ctx, loanKey, loan)
 }
 
@@ -300,7 +339,6 @@ func (l *LoanManage) defaultLoan(ctx *tx.ApplyContext, loanKey keylet.Keylet, lo
 	}
 	b.DebtTotal = numStr(lmath.AdjustImprecise(asset, debtTotal, totalDefault.Negate(), vaultScale))
 	b.CoverAvailable = numStr(lendNum(b.CoverAvailable).Sub(covered))
-	associateBrokerAsset(b, integral)
 	if res := updateBroker(ctx, brokerKey, b); res != ter.TesSUCCESS {
 		return res
 	}
@@ -312,7 +350,6 @@ func (l *LoanManage) defaultLoan(ctx *tx.ApplyContext, loanKey keylet.Keylet, lo
 	loan.ManagementFeeOutstanding = ""
 	loan.PaymentRemaining = 0
 	loan.NextPaymentDueDate = 0
-	associateLoanAsset(loan, integral)
 	if res := updateLoan(ctx, loanKey, loan); res != ter.TesSUCCESS {
 		return res
 	}

--- a/internal/tx/lending/loan_pay_apply.go
+++ b/internal/tx/lending/loan_pay_apply.go
@@ -1,6 +1,7 @@
 package lending
 
 import (
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/lending/lmath"
@@ -61,8 +62,10 @@ func accountToLoan(loan *loanData, acc *lmath.LoanAccount) {
 }
 
 // CalculateBaseFee estimates the number of combined payments and charges one base
-// fee per loanPaymentsPerFeeIncrement (5). There is intentionally no 100-payment
-// cap here (rippled documents that a LoanPay may be over-charged).
+// fee per loanPaymentsPerFeeIncrement (5). With fixCleanup3_1_3 the estimate is
+// capped: the payment handler never processes more than
+// loanMaximumPaymentsPerTransaction payments, so the fee never exceeds
+// loanMaximumPaymentsPerTransaction / loanPaymentsPerFeeIncrement increments.
 func (l *LoanPay) CalculateBaseFee(view tx.LedgerView, config tx.EngineConfig) uint64 {
 	normal := config.BaseFee
 	if l.GetFlags()&(TfLoanFullPayment|TfLoanLatePayment) != 0 {
@@ -99,6 +102,15 @@ func (l *LoanPay) CalculateBaseFee(view tx.LedgerView, config tx.EngineConfig) u
 	if regular.Signum() <= 0 {
 		return normal
 	}
+	// Post-fixCleanup3_1_3: cap the estimate at the maximum number of payments the
+	// handler will process, so a large Amount does not inflate the fee unboundedly.
+	if config.GetRules().Enabled(amendment.FeatureFixCleanup3_1_3) {
+		threshold := regular.Mul(lmath.FromInt(int64(protocol.LoanMaximumPaymentsPerTransaction)))
+		if amountToLendNum(l.Amount).Cmp(threshold) >= 0 {
+			maxFeeIncrements := protocol.LoanMaximumPaymentsPerTransaction / protocol.LoanPaymentsPerFeeIncrement
+			return uint64(maxFeeIncrements) * normal
+		}
+	}
 	mode := state.RoundDownward
 	if l.GetFlags()&TfLoanOverpayment != 0 {
 		mode = state.RoundUpward
@@ -134,6 +146,9 @@ func (l *LoanPay) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Resul
 		return ter.TecNO_PERMISSION
 	}
 	if l.GetFlags()&TfLoanOverpayment != 0 && loan.Flags&LsfLoanOverpayment == 0 {
+		if config.GetRules().Enabled(amendment.FeatureFixCleanup3_1_3) {
+			return ter.TecNO_PERMISSION
+		}
 		return ter.TemINVALID_FLAG
 	}
 	if loan.PaymentRemaining == 0 || lendNum(loan.PrincipalOutstanding).IsZero() {
@@ -217,7 +232,7 @@ func (l *LoanPay) Apply(ctx *tx.ApplyContext) ter.Result {
 	}
 
 	acc := loanToAccount(loan)
-	parts, t := lmath.LoanMakePayment(mAsset, ctx.Config.ParentCloseTime, acc, uint32(b.ManagementFeeRate), amountToLendNum(l.Amount), l.paymentType())
+	parts, t := lmath.LoanMakePayment(mAsset, ctx.Config.ParentCloseTime, acc, uint32(b.ManagementFeeRate), amountToLendNum(l.Amount), l.paymentType(), ctx.Rules().Enabled(amendment.FeatureFixCleanup3_1_3))
 	if t != ter.TesSUCCESS {
 		return t
 	}

--- a/internal/tx/lending/loan_pay_preclaim_test.go
+++ b/internal/tx/lending/loan_pay_preclaim_test.go
@@ -1,0 +1,156 @@
+package lending
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// readOnlyView serves crafted SLE bytes by keylet; every mutating method is a
+// no-op. Sufficient for LoanPay.Preclaim, which only reads the Loan entry before
+// the overpayment-flag check.
+type readOnlyView struct {
+	data map[[32]byte][]byte
+}
+
+func (v readOnlyView) Read(k keylet.Keylet) ([]byte, error)      { return v.data[k.Key], nil }
+func (v readOnlyView) Exists(k keylet.Keylet) (bool, error)      { _, ok := v.data[k.Key]; return ok, nil }
+func (v readOnlyView) Insert(k keylet.Keylet, data []byte) error { return nil }
+func (v readOnlyView) Update(k keylet.Keylet, data []byte) error { return nil }
+func (v readOnlyView) Erase(k keylet.Keylet) error               { return nil }
+func (v readOnlyView) AdjustDropsDestroyed(drops.XRPAmount)      {}
+func (v readOnlyView) ForEach(fn func(key [32]byte, data []byte) bool) error {
+	return nil
+}
+func (v readOnlyView) Succ(key [32]byte) ([32]byte, []byte, bool, error) {
+	return [32]byte{}, nil, false, nil
+}
+func (v readOnlyView) TxExists(txID [32]byte) bool { return false }
+func (v readOnlyView) Rules() *amendment.Rules     { return nil }
+func (v readOnlyView) LedgerSeq() uint32           { return 0 }
+
+// TestLoanPay_OverpaymentOnNonOverpaymentLoan asserts the fixCleanup3_1_3 TER
+// change: requesting an overpayment on a loan that does not allow it returns
+// tecNO_PERMISSION post-amendment and temINVALID_FLAG pre-amendment.
+func TestLoanPay_OverpaymentOnNonOverpaymentLoan(t *testing.T) {
+	var accountID [20]byte
+	for i := range accountID {
+		accountID[i] = 0x44
+	}
+	accountAddr, err := state.EncodeAccountID(accountID)
+	if err != nil {
+		t.Fatalf("encode account: %v", err)
+	}
+
+	var loanID [32]byte
+	for i := range loanID {
+		loanID[i] = 0x55
+	}
+	loanIDHex := strings.ToUpper(hex.EncodeToString(loanID[:]))
+
+	// Loan owned by the submitter, without the lsfLoanOverpayment flag.
+	loanBytes, err := serializeLoan(&loanData{Borrower: accountID})
+	if err != nil {
+		t.Fatalf("serializeLoan: %v", err)
+	}
+	view := readOnlyView{data: map[[32]byte][]byte{keylet.LoanByID(loanID).Key: loanBytes}}
+
+	newPay := func() *LoanPay {
+		lp := NewLoanPay(accountAddr, loanIDHex, tx.NewXRPAmount(1_000_000))
+		lp.Common.SetFlags(TfLoanOverpayment)
+		return lp
+	}
+
+	fixOn := tx.EngineConfig{Rules: amendment.NewRules([][32]byte{amendment.FeatureFixCleanup3_1_3})}
+	fixOff := tx.EngineConfig{Rules: amendment.EmptyRules()}
+
+	if got := newPay().Preclaim(view, fixOn); got != ter.TecNO_PERMISSION {
+		t.Errorf("fixCleanup3_1_3 ON: got %v, want tecNO_PERMISSION", got)
+	}
+	if got := newPay().Preclaim(view, fixOff); got != ter.TemINVALID_FLAG {
+		t.Errorf("fixCleanup3_1_3 OFF: got %v, want temINVALID_FLAG", got)
+	}
+}
+
+// TestLoanPay_CalculateBaseFeeCap asserts the fixCleanup3_1_3 fee cap: a large
+// Amount is charged at most loanMaximumPaymentsPerTransaction /
+// loanPaymentsPerFeeIncrement (20) increments post-amendment, while pre-amendment
+// the estimate scales unbounded with the Amount.
+func TestLoanPay_CalculateBaseFeeCap(t *testing.T) {
+	var brokerID, vaultID, loanID [32]byte
+	for i := range brokerID {
+		brokerID[i] = 0x66
+		vaultID[i] = 0x77
+		loanID[i] = 0x88
+	}
+	var ownerID, pseudoID [20]byte
+	for i := range ownerID {
+		ownerID[i] = 0x11
+		pseudoID[i] = 0x22
+	}
+	ownerAddr, _ := state.EncodeAccountID(ownerID)
+	pseudoAddr, _ := state.EncodeAccountID(pseudoID)
+
+	// PeriodicPayment of 10 drops, LoanServiceFee 0 → regularPayment = 10.
+	loanBytes, err := serializeLoan(&loanData{
+		LoanBrokerID:     brokerID,
+		PeriodicPayment:  "10",
+		PaymentRemaining: 10, // > loanPaymentsPerFeeIncrement
+	})
+	if err != nil {
+		t.Fatalf("serializeLoan: %v", err)
+	}
+	brokerBytes, err := serializeLoanBroker(&loanBrokerData{VaultID: vaultID})
+	if err != nil {
+		t.Fatalf("serializeLoanBroker: %v", err)
+	}
+	vaultBytes, err := binarycodec.Encode(map[string]any{
+		"LedgerEntryType":  "Vault",
+		"Flags":            0,
+		"Sequence":         1,
+		"OwnerNode":        "0",
+		"Owner":            ownerAddr,
+		"Account":          pseudoAddr,
+		"Asset":            map[string]any{"currency": "XRP"},
+		"ShareMPTID":       strings.Repeat("0", 48),
+		"WithdrawalPolicy": 1,
+	})
+	if err != nil {
+		t.Fatalf("encode vault: %v", err)
+	}
+	vaultRaw, _ := hex.DecodeString(vaultBytes)
+
+	view := readOnlyView{data: map[[32]byte][]byte{
+		keylet.LoanByID(loanID).Key:         loanBytes,
+		keylet.LoanBrokerByID(brokerID).Key: brokerBytes,
+		keylet.VaultByID(vaultID).Key:       vaultRaw,
+	}}
+
+	loanIDHex := strings.ToUpper(hex.EncodeToString(loanID[:]))
+	// Amount = 2000 drops = regularPayment * 200: uncapped this estimates 200
+	// payments → 40 fee increments; capped it is 20.
+	pay := NewLoanPay(ownerAddr, loanIDHex, tx.NewXRPAmount(2000))
+
+	cfg := func(fix bool) tx.EngineConfig {
+		ids := [][32]byte{}
+		if fix {
+			ids = append(ids, amendment.FeatureFixCleanup3_1_3)
+		}
+		return tx.EngineConfig{BaseFee: 10, Rules: amendment.NewRules(ids)}
+	}
+
+	if got := pay.CalculateBaseFee(view, cfg(true)); got != 20*10 {
+		t.Errorf("fixCleanup3_1_3 ON: got %d, want %d (capped at 20 increments)", got, 20*10)
+	}
+	if got := pay.CalculateBaseFee(view, cfg(false)); got != 40*10 {
+		t.Errorf("fixCleanup3_1_3 OFF: got %d, want %d (40 increments, uncapped)", got, 40*10)
+	}
+}

--- a/internal/tx/lending/view_helpers.go
+++ b/internal/tx/lending/view_helpers.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/lending/lmath"
+	"github.com/LeJamon/go-xrpl/internal/tx/vault"
 )
 
 // assetIntegral reports whether asset counts indivisible units (native XRP or an
@@ -52,6 +53,15 @@ func associateBrokerAsset(b *loanBrokerData, integral bool) {
 	b.DebtTotal = associateNum(b.DebtTotal, integral, true)
 	b.DebtMaximum = associateNum(b.DebtMaximum, integral, true)
 	b.CoverAvailable = associateNum(b.CoverAvailable, integral, true)
+}
+
+// associateVaultAsset rounds the Vault's NUMBER accounting fields to the asset's
+// precision. AssetsTotal, AssetsAvailable, and LossUnrealized are soeDEFAULT;
+// AssetsMaximum is left untouched (LoanManage never changes it).
+func associateVaultAsset(v *vault.VaultLending, integral bool) {
+	v.AssetsTotal = associateNum(v.AssetsTotal, integral, true)
+	v.AssetsAvailable = associateNum(v.AssetsAvailable, integral, true)
+	v.LossUnrealized = associateNum(v.LossUnrealized, integral, true)
 }
 
 // associateLoanAsset rounds the Loan's NUMBER fields to the vault asset's

--- a/internal/tx/vault/exports.go
+++ b/internal/tx/vault/exports.go
@@ -1,11 +1,90 @@
 package vault
 
 import (
+	"bytes"
+
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
+
+// AssetReadView is the minimal read surface PseudoAssetHolds needs, satisfied by
+// both the apply view and the invariant framework's read-only view.
+type AssetReadView interface {
+	Read(k keylet.Keylet) ([]byte, error)
+}
+
+// PseudoAssetHolds returns how much of the vault's asset (decoded from vaultData)
+// the given pseudo-account holds. Pseudo-accounts have no XRP reserve, so the XRP
+// path returns the full balance (rippled xrpLiquid + isPseudoAccount). A missing
+// trust line / MPToken means zero holdings; ok is false only on a read/parse
+// error. Used by the ValidLoanBroker invariant.
+func PseudoAssetHolds(view AssetReadView, account [20]byte, vaultData []byte) (state.XRPLNumber, bool) {
+	vd, err := parseVault(vaultData)
+	if err != nil {
+		return state.NewXRPLNumber(0, 0), false
+	}
+	if isNativeAsset(vd.Asset) {
+		data, rerr := view.Read(keylet.Account(account))
+		if rerr != nil || data == nil {
+			return state.NewXRPLNumber(0, 0), false
+		}
+		ar, perr := state.ParseAccountRoot(data)
+		if perr != nil {
+			return state.NewXRPLNumber(0, 0), false
+		}
+		return state.NewXRPLNumber(int64(ar.Balance), 0), true
+	}
+	if vd.AssetIsMPT {
+		data, rerr := view.Read(keylet.MPTokenByID(vd.AssetMPTID, account))
+		if rerr != nil {
+			return state.NewXRPLNumber(0, 0), false
+		}
+		if data == nil {
+			return state.NewXRPLNumber(0, 0), true
+		}
+		token, perr := state.ParseMPToken(data)
+		if perr != nil {
+			return state.NewXRPLNumber(0, 0), false
+		}
+		return state.NewXRPLNumber(int64(token.MPTAmount), 0), true
+	}
+	issuerID, derr := state.DecodeAccountID(vd.Asset.Issuer)
+	if derr != nil {
+		return state.NewXRPLNumber(0, 0), false
+	}
+	data, rerr := view.Read(keylet.Line(account, issuerID, vd.Asset.Currency))
+	if rerr != nil {
+		return state.NewXRPLNumber(0, 0), false
+	}
+	if data == nil {
+		return state.NewXRPLNumber(0, 0), true
+	}
+	rs, perr := state.ParseRippleState(data)
+	if perr != nil {
+		return state.NewXRPLNumber(0, 0), false
+	}
+	bal, berr := vaultNumber(rs.Balance.Value())
+	if berr != nil {
+		return state.NewXRPLNumber(0, 0), false
+	}
+	// Balance is stored in the low account's terms; negate for the high account.
+	if bytes.Compare(account[:], issuerID[:]) > 0 {
+		bal = bal.Negate()
+	}
+	return bal, true
+}
+
+// ParseLedgerNumber parses a serialized NUMBER field's string form into an
+// XRPLNumber; "" and "0" are zero. ok is false on a malformed value.
+func ParseLedgerNumber(s string) (state.XRPLNumber, bool) {
+	n, err := vaultNumber(s)
+	if err != nil {
+		return state.NewXRPLNumber(0, 0), false
+	}
+	return n, true
+}
 
 // Reuse surface for the lending package. A LoanBroker sits on a Vault and reuses
 // its pseudo-account derivation and asset-movement machinery; these thin wrappers

--- a/internal/tx/vault/vault_clawback.go
+++ b/internal/tx/vault/vault_clawback.go
@@ -230,6 +230,7 @@ func (v *VaultClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 	held := holderMPTBalance(ctx.View, vd.ShareMPTID, holderID)
 	var sharesDestroyed uint64
 	assetsRecoveredN := state.NewXRPLNumber(0, 0)
+	clampAssets := false
 
 	if v.clawsBackShares(vd, accountID) {
 		// Owner burns every share held by the holder; the assets are already gone.
@@ -237,6 +238,9 @@ func (v *VaultClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 	} else if v.Amount == nil || v.Amount.Signum() == 0 {
 		sharesDestroyed = held
 		assetsRecoveredN = sharesToAssetsWithdraw(assetsTotalN, lossN, shareTotalN, state.NewXRPLNumber(int64(held), 0))
+		// Pre-fixCleanup3_1_3 the zero-amount path returned without clamping to
+		// AssetsAvailable, over-recovering when a loan was outstanding.
+		clampAssets = ctx.Rules().Enabled(amendment.FeatureFixCleanup3_1_3)
 	} else {
 		amountN, aerr := amountToNumber(*v.Amount)
 		if aerr != nil {
@@ -249,6 +253,19 @@ func (v *VaultClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 		}
 		sharesDestroyed = s
 		assetsRecoveredN = sharesToAssetsWithdraw(assetsTotalN, lossN, shareTotalN, state.NewXRPLNumber(int64(s), 0))
+		clampAssets = true
+	}
+
+	// Clamp the recovered assets to what the vault has available, truncating the
+	// shares so the recovery cannot breach AssetsAvailable.
+	if clampAssets && assetsRecoveredN.Cmp(availN) > 0 {
+		assetsRecoveredN = availN
+		sharesN := assetsToSharesWithdraw(assetsTotalN, lossN, shareTotalN, availN, true)
+		sharesDestroyed = uint64(sharesN.ToInt64WithMode(state.RoundTowardsZero))
+		assetsRecoveredN = sharesToAssetsWithdraw(assetsTotalN, lossN, shareTotalN, state.NewXRPLNumber(int64(sharesDestroyed), 0))
+		if assetsRecoveredN.Cmp(availN) > 0 {
+			return ter.TecINTERNAL
+		}
 	}
 
 	if sharesDestroyed == 0 {

--- a/internal/tx/vault/vault_withdraw.go
+++ b/internal/tx/vault/vault_withdraw.go
@@ -145,10 +145,21 @@ func (v *VaultWithdraw) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter
 	if derr != nil {
 		return ter.TemMALFORMED
 	}
-	// canWithdraw's trust-limit branch is exempt for MPT (and thus for a
-	// share-denominated withdrawal); the destination/tag/deposit-auth checks
-	// still apply. Reference: rippled withdrawToDestExceedsLimit.
-	if res := canWithdraw(view, accountID, dstID, v.Amount, v.DestinationTag != nil); res != ter.TesSUCCESS {
+	// canWithdraw's trust-limit branch is exempt for the share MPT, so a
+	// share-denominated withdrawal pre-amendment skipped the destination's IOU
+	// trust limit entirely. Post-fixCleanup3_1_3 the shares are converted to the
+	// equivalent asset amount so the limit is enforced. Integral (XRP/MPT) vault
+	// assets stay exempt either way — only an IOU asset needs the conversion.
+	limitAmount := v.Amount
+	if config.GetRules().Enabled(amendment.FeatureFixCleanup3_1_3) && v.amountIsShares(vd) &&
+		!isNativeAsset(vd.Asset) && !vd.AssetIsMPT {
+		assets, res := v.sharesToAssetAmount(view, vd)
+		if res != ter.TesSUCCESS {
+			return res
+		}
+		limitAmount = assets
+	}
+	if res := canWithdraw(view, accountID, dstID, limitAmount, v.DestinationTag != nil); res != ter.TesSUCCESS {
 		return res
 	}
 
@@ -158,6 +169,29 @@ func (v *VaultWithdraw) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter
 	}
 
 	return ter.TesSUCCESS
+}
+
+// sharesToAssetAmount converts the share-denominated withdrawal Amount into the
+// equivalent IOU asset amount, so the destination trust-line limit can be
+// enforced. Reference: rippled VaultWithdraw::preclaim sharesToAssetsWithdraw.
+func (v *VaultWithdraw) sharesToAssetAmount(view tx.LedgerView, vd *vaultData) (tx.Amount, ter.Result) {
+	shareData, rerr := view.Read(keylet.MPTIssuance(vd.ShareMPTID))
+	if rerr != nil || shareData == nil {
+		return tx.Amount{}, ter.TefINTERNAL
+	}
+	issuance, perr := state.ParseMPTokenIssuance(shareData)
+	if perr != nil || issuance.OutstandingAmount == 0 {
+		return tx.Amount{}, ter.TefINTERNAL
+	}
+	sharesN, aerr := amountToNumber(v.Amount)
+	if aerr != nil {
+		return tx.Amount{}, ter.TefINTERNAL
+	}
+	assetsTotalN, _ := vaultNumber(vd.AssetsTotal)
+	lossN, _ := vaultNumber(vd.LossUnrealized)
+	shareTotalN := state.NewXRPLNumber(int64(issuance.OutstandingAmount), 0)
+	assetsN := sharesToAssetsWithdraw(assetsTotalN, lossN, shareTotalN, sharesN)
+	return state.NewIssuedAmountFromValue(assetsN.Mantissa(), assetsN.Exponent(), vd.Asset.Currency, vd.Asset.Issuer), ter.TesSUCCESS
 }
 
 // Apply redeems the caller's shares for the underlying asset and delivers it to

--- a/internal/tx/vault/vault_withdraw_preclaim_test.go
+++ b/internal/tx/vault/vault_withdraw_preclaim_test.go
@@ -1,0 +1,141 @@
+package vault
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// roView serves crafted SLE bytes by keylet; mutating methods are no-ops.
+type roView struct {
+	data map[[32]byte][]byte
+}
+
+func (v roView) Read(k keylet.Keylet) ([]byte, error)      { return v.data[k.Key], nil }
+func (v roView) Exists(k keylet.Keylet) (bool, error)      { _, ok := v.data[k.Key]; return ok, nil }
+func (v roView) Insert(k keylet.Keylet, data []byte) error { return nil }
+func (v roView) Update(k keylet.Keylet, data []byte) error { return nil }
+func (v roView) Erase(k keylet.Keylet) error               { return nil }
+func (v roView) AdjustDropsDestroyed(drops.XRPAmount)      {}
+func (v roView) ForEach(fn func(key [32]byte, data []byte) bool) error {
+	return nil
+}
+func (v roView) Succ(key [32]byte) ([32]byte, []byte, bool, error) {
+	return [32]byte{}, nil, false, nil
+}
+func (v roView) TxExists(txID [32]byte) bool { return false }
+func (v roView) Rules() *amendment.Rules     { return nil }
+func (v roView) LedgerSeq() uint32           { return 0 }
+
+func fill20(b byte) [20]byte {
+	var id [20]byte
+	for i := range id {
+		id[i] = b
+	}
+	return id
+}
+
+// TestVaultWithdraw_ShareLimitEnforced asserts the fixCleanup3_1_3 arm: a
+// share-denominated withdrawal delivered to a third party whose IOU trust limit
+// would be exceeded is rejected (tecNO_LINE) once the amendment converts the
+// shares to the equivalent asset amount. Pre-amendment the (MPT) shares skip the
+// limit check, so the withdrawal is admitted.
+func TestVaultWithdraw_ShareLimitEnforced(t *testing.T) {
+	issuerID := fill20(0xAA)
+	submitterID := fill20(0xBB)
+	dstID := fill20(0xCC)
+	pseudoID := fill20(0xDD)
+	issuerAddr, _ := state.EncodeAccountID(issuerID)
+	submitterAddr, _ := state.EncodeAccountID(submitterID)
+	dstAddr, _ := state.EncodeAccountID(dstID)
+
+	var vid [32]byte
+	for i := range vid {
+		vid[i] = 0xE1
+	}
+	vidHex := strings.ToUpper(hex.EncodeToString(vid[:]))
+	var shareMPTID [24]byte
+	for i := range shareMPTID {
+		shareMPTID[i] = 0xF2
+	}
+	shareHex := strings.ToUpper(hex.EncodeToString(shareMPTID[:]))
+
+	vaultBytes, err := serializeVault(&vaultData{
+		Sequence:         1,
+		WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+		Owner:            submitterID,
+		Account:          pseudoID,
+		Asset:            tx.Asset{Currency: "USD", Issuer: issuerAddr},
+		ShareMPTID:       shareMPTID,
+		AssetsTotal:      "1000",
+		AssetsAvailable:  "1000",
+	})
+	if err != nil {
+		t.Fatalf("serializeVault: %v", err)
+	}
+	issBytes, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+		Issuer:            issuerID,
+		OutstandingAmount: 1000,
+	})
+	if err != nil {
+		t.Fatalf("serializeMPTokenIssuance: %v", err)
+	}
+	dstBytes, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account: dstAddr, Balance: 1_000_000_000, Sequence: 1,
+	})
+	if err != nil {
+		t.Fatalf("serializeAccountRoot(dst): %v", err)
+	}
+	issAcctBytes, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account: issuerAddr, Balance: 1_000_000_000, Sequence: 1,
+	})
+	if err != nil {
+		t.Fatalf("serializeAccountRoot(issuer): %v", err)
+	}
+	// dst (0xCC) is the HIGH account vs issuer (0xAA); its trust limit is 10 USD
+	// and the balance is zero.
+	rsBytes, err := state.SerializeRippleState(&state.RippleState{
+		Balance:   state.NewIssuedAmountFromValue(0, -100, "USD", issuerAddr),
+		LowLimit:  state.NewIssuedAmountFromValue(0, -100, "USD", issuerAddr),
+		HighLimit: state.NewIssuedAmountFromValue(10, 0, "USD", dstAddr),
+	})
+	if err != nil {
+		t.Fatalf("serializeRippleState: %v", err)
+	}
+
+	view := roView{data: map[[32]byte][]byte{
+		keylet.VaultByID(vid).Key:               vaultBytes,
+		keylet.MPTIssuance(shareMPTID).Key:      issBytes,
+		keylet.Account(dstID).Key:               dstBytes,
+		keylet.Account(issuerID).Key:            issAcctBytes,
+		keylet.Line(dstID, issuerID, "USD").Key: rsBytes,
+	}}
+
+	// Withdraw 100 shares (worth 100 USD) to the third-party destination.
+	newWithdraw := func() *VaultWithdraw {
+		wd := NewVaultWithdraw(submitterAddr, vidHex, state.NewMPTAmountWithIssuanceID(100, issuerAddr, shareHex))
+		wd.Destination = dstAddr
+		return wd
+	}
+
+	fixOn := tx.EngineConfig{Rules: amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault, amendment.FeatureFixCleanup3_1_3,
+	})}
+	fixOff := tx.EngineConfig{Rules: amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault,
+	})}
+
+	if got := newWithdraw().Preclaim(view, fixOn); got != ter.TecNO_LINE {
+		t.Errorf("fixCleanup3_1_3 ON: got %v, want tecNO_LINE", got)
+	}
+	if got := newWithdraw().Preclaim(view, fixOff); got != ter.TesSUCCESS {
+		t.Errorf("fixCleanup3_1_3 OFF: got %v, want tesSUCCESS", got)
+	}
+}


### PR DESCRIPTION
Ports the **deferred vault/lending arms of the `fixCleanup3_1_3` amendment**
(rippled 3.1.3, consolidation commit `4539bb07`), completing #1248. The
independently-actionable arms landed in #1268; these depend on the Vault (#1266)
and Lending (#1270) transactors, now merged. Targets the `v3.0.0` integration
branch.

The amendment itself is already registered (`Supported::yes`, `VoteBehavior::DefaultYes`)
from #1268; this PR only wires the gated vault/lending behaviour.

## Per-arm status

| Arm | rippled ref (3.1.3) | Status |
|---|---|---|
| VaultWithdraw — share-denominated trust-line limit | `VaultWithdraw.cpp:90` | ✅ implemented + tested |
| LoanManage — `associateAsset` on default/impair/unimpair | `LoanManage.cpp:437` | ✅ implemented |
| LoanPay — overpayment on non-overpayment loan → `tecNO_PERMISSION` | `LoanPay.cpp:176` | ✅ implemented + tested |
| LoanPay — `CalculateBaseFee` payment cap | `LoanPay.cpp:119` | ✅ implemented + tested |
| LoanPay — loan-scale truncation of the overpayment Amount | `LendingHelpers.cpp:1937` | ✅ implemented |
| VaultClawback — zero-amount clamp to `AssetsAvailable` | `VaultClawback.cpp:265` | ✅ implemented |
| ValidLoanBroker — `CoverAvailable` lower + gated upper bound | `InvariantCheck.cpp:2637` | ✅ implemented + tested |

### VaultWithdraw
A share-denominated withdrawal previously skipped the destination's IOU trust
limit (the share MPT is limit-exempt). Post-amendment the shares are converted to
the equivalent asset amount and re-checked via `canWithdraw`. Integral (XRP/MPT)
vault assets stay limit-exempt either way, so the conversion is scoped to IOU
vaults — the only case where the fix is observable.

### LoanManage
`associateAsset` (rounding the Loan / LoanBroker / Vault `NUMBER` fields to the
asset precision) is now gated on the amendment and applied on **every** successful
`default`/`impair`/`unimpair` path via a single post-switch block (pre-amendment
only the noop path did so). The previously-unconditional inline `associate*Asset`
calls were removed and centralised, mirroring rippled's `doApply` structure, and
the Vault association (missing before) was added.

### LoanPay
- Overpayment requested on a loan without `lsfLoanOverpayment` now returns
  `tecNO_PERMISSION` (was `temINVALID_FLAG`).
- `CalculateBaseFee` caps the estimate at `loanMaximumPaymentsPerTransaction /
  loanPaymentsPerFeeIncrement` (20) increments so a large `Amount` cannot inflate
  the fee unboundedly.
- The overpayment `Amount` is truncated toward zero at the loan scale before the
  overpayment is derived, so sub-precision dust is ignored.

### VaultClawback
The clamp of recovered assets to `AssetsAvailable` (truncating shares so the
recovery cannot breach available assets) now also covers the zero-amount path.
Pre-amendment the zero-amount clawback returned unclamped, over-recovering when a
loan was outstanding.

### ValidLoanBroker
The invariant now compares `CoverAvailable` against the pseudo-account's holdings
of the vault asset — the lower bound (`>=`, deferred in goXRPL until now) always,
and the exact upper bound (`==`) under the amendment. Pseudo-accounts carry no XRP
reserve (`xrpLiquid` + `isPseudoAccount`), so their XRP holdings are the full
balance; the new `vault.PseudoAssetHolds` helper reads XRP / IOU / MPT holdings
from the invariant's read-only view. A deleted broker has `After == nil` and is
skipped, which reproduces rippled's `ttLOAN_BROKER_DELETE` exclusion from the
upper bound.

## Sweep for further vault/lending-gated arms

`git grep fixCleanup3_1_3` at tag 3.1.3 surfaced these additional gates; classified:

- **In scope, ported here:** the seven arms above (the base-fee cap and loan-scale
  truncation were not in the four-arm brief but are `fixCleanup3_1_3`-gated
  vault/lending arms, so they are included).
- **MPT-general, out of scope (not vault/lending):** `View.cpp:1564`/`:1875`
  (`removeEmptyMPToken` / `removeEmptyHolding` reject deletion when `LockedAmount != 0`)
  and `View.cpp:2724` (`rippleSendMultiMPT` aggregate `MaximumAmount` check). These
  are MPT-payment/authorize/destroy arms belonging to the MPT cleanup work, not the
  Vault/Lending protocol.
- **Non-vault/lending, already handled by #1268 or precedence PRs:**
  `CredentialHelpers.cpp:58`, `PermissionedDEXHelpers.cpp:76`,
  `NFTokenAcceptOffer.cpp`, `PermissionedDomainSet.cpp:122`, and the
  `InvariantCheck.cpp` PermissionedDomain/DEX overwrite arms.
- **Not a `fixCleanup3_1_3` arm:** `ValidVault` (`InvariantCheck.cpp:2743+`) has no
  amendment gate in 3.1.3. #1268 listed "ValidVault scale-aware rounding" as
  deferred, but that is a separate missing-invariant gap (the whole `ValidVault`
  checker is still absent from goXRPL), not part of this amendment — left for a
  follow-up.

## Deviations

- **VaultWithdraw conversion scoped to IOU vaults.** rippled always converts shares
  → asset when the amendment is on; for XRP/MPT vault assets the converted amount is
  limit-exempt, so the result is identical to passing the raw shares. Scoping the
  conversion to IOU avoids constructing an unused XRP/MPT amount. rippled's
  `overflow_error → tecPATH_DRY` guard has no analogue (goXRPL's `XRPLNumber`
  arithmetic does not throw).
- **LoanManage association is a no-op in practice.** goXRPL's `AdjustImprecise` /
  `RoundAsset*` already produce asset-scale values on these paths, so associating is
  behaviourally inert; the gating is ported for rippled parity and defence in depth.

## Verification

- `just build-all` clean; strict `golangci-lint --config .golangci.yml` clean on all
  touched packages (incl. tests).
- Full `go test ./internal/tx/... ./internal/testing/...` passes — no regressions.
- **Conformance diff vs a fresh `origin/v3.0.0` baseline: 0 new failures**
  (121 ≡ 121). The 54 skip-listed Vault owner-count fixtures stay skipped; no Vault
  fixture changes. (One AMM conformance test flaked once under full-suite
  parallelism and passed in isolation and on re-run.)
- `ledgerfieldsgen` and `docsgen` produce no drift.
- New tests (both amendment states): `TestVaultWithdraw_ShareLimitEnforced`,
  `TestLoanPay_OverpaymentOnNonOverpaymentLoan`, `TestLoanPay_CalculateBaseFeeCap`,
  `TestValidLoanBroker_CoverAvailableBounds` (+ inert case). The existing
  `TestLoanBroker_Lifecycle` (XRP) exercises the ValidLoanBroker happy path
  end-to-end. LoanManage / loan-scale-truncation / VaultClawback-clamp are verified
  by build + no-regression + rippled code review (their observable scenarios need
  loan-with-counterparty-signature and IOU-share-clawback harness support beyond the
  current fixtures).

Completes #1248 (fixCleanup3_1_3 vault/lending arms deferred from #1268). rippled ref `4539bb07`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
