### PR TITLE
fix(vault): ripple IOU vault movements through the issuer

### DIFF
--- a/internal/testing/vault/vault_test.go
+++ b/internal/testing/vault/vault_test.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/accountset"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/vault"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -68,6 +70,149 @@ func TestVault_XRPLifecycle(t *testing.T) {
 	}
 	if env.VaultExists(id) {
 		t.Fatalf("vault still exists after delete")
+	}
+}
+
+// iouLineBalance returns the RippleState balance between a and b for currency,
+// expressed in a's perspective, and whether the trust line exists.
+func iouLineBalance(t *testing.T, env *jtx.TestEnv, a, b [20]byte, currency string) (float64, bool) {
+	t.Helper()
+	key := keylet.Line(a, b, currency)
+	if !env.LedgerEntryExists(key) {
+		return 0, false
+	}
+	data, err := env.LedgerEntry(key)
+	if err != nil {
+		t.Fatalf("read trust line: %v", err)
+	}
+	rs, err := state.ParseRippleState(data)
+	if err != nil {
+		t.Fatalf("parse trust line: %v", err)
+	}
+	bal := rs.Balance
+	if !keylet.IsLowAccount(a, b) {
+		bal = bal.Negate()
+	}
+	return bal.Float64(), true
+}
+
+func approxEq(got, want float64) bool {
+	d := got - want
+	if d < 0 {
+		d = -d
+	}
+	return d < 1e-6
+}
+
+// TestVault_IOULifecycle exercises create → deposit → withdraw → clawback →
+// delete for an IOU vault, asserting that every asset movement ripples through
+// the issuer: it settles on the holder↔issuer and issuer↔pseudo trust lines and
+// never creates a direct holder↔pseudo line.
+func TestVault_IOULifecycle(t *testing.T) {
+	env := newVaultEnv(t)
+	issuer := jtx.NewAccount("issuer")
+	owner := jtx.NewAccount("owner")
+	depositor := jtx.NewAccount("depositor")
+
+	// The issuer must permit clawback before it owns any objects.
+	env.Fund(issuer)
+	if res := env.Submit(accountset.AccountSet(issuer).AllowClawback().Build()); res.Code != "tesSUCCESS" {
+		t.Fatalf("AccountSet AllowClawback: got %s", res.Code)
+	}
+	env.Fund(owner, depositor)
+
+	const cur = "USD"
+	env.Trust(depositor, tx.NewIssuedAmountFromFloat64(10000, cur, issuer.Address))
+	env.PayIOU(issuer, depositor, issuer, cur, 1000)
+
+	issuerID := issuer.ID
+	depID := depositor.ID
+
+	// Create the IOU vault.
+	createSeq := env.Seq(owner)
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{Currency: cur, Issuer: issuer.Address})
+	create.Common.Fee = createFee
+	if res := env.Submit(create); res.Code != "tesSUCCESS" {
+		t.Fatalf("VaultCreate(IOU): got %s, want tesSUCCESS", res.Code)
+	}
+	id := vaultID(owner, createSeq)
+
+	rawID, _ := hex.DecodeString(id)
+	var vkey [32]byte
+	copy(vkey[:], rawID)
+	vinfo, verr := vault.ReadVaultInfo(env.Ledger(), keylet.VaultByID(vkey))
+	if verr != nil || vinfo == nil {
+		t.Fatalf("ReadVaultInfo: %v", verr)
+	}
+	pseudoID := vinfo.Account
+
+	// The pseudo-account holds the asset via an issuer trust line, created at
+	// VaultCreate.
+	if _, ok := iouLineBalance(t, env, pseudoID, issuerID, cur); !ok {
+		t.Fatalf("pseudo<->issuer trust line missing after create")
+	}
+	depOwnerBefore := env.AccountInfo(depositor).OwnerCount
+
+	// Deposit 100 USD.
+	dep := vault.NewVaultDeposit(depositor.Address, id, tx.NewIssuedAmountFromFloat64(100, cur, issuer.Address))
+	if res := env.Submit(dep); res.Code != "tesSUCCESS" {
+		t.Fatalf("VaultDeposit: got %s, want tesSUCCESS", res.Code)
+	}
+
+	if env.LedgerEntryExists(keylet.Line(depID, pseudoID, cur)) {
+		t.Fatalf("direct depositor<->pseudo trust line created on deposit (fork bug)")
+	}
+	if bal, ok := iouLineBalance(t, env, depID, issuerID, cur); !ok || !approxEq(bal, 900) {
+		t.Fatalf("depositor<->issuer balance = %v (exists=%v), want 900", bal, ok)
+	}
+	if bal, ok := iouLineBalance(t, env, pseudoID, issuerID, cur); !ok || !approxEq(bal, 100) {
+		t.Fatalf("pseudo<->issuer balance = %v (exists=%v), want 100", bal, ok)
+	}
+	if got := env.AccountInfo(depositor).OwnerCount; got != depOwnerBefore+1 {
+		t.Fatalf("depositor owner count after deposit = %d, want %d", got, depOwnerBefore+1)
+	}
+
+	// Withdraw 40 USD back to the depositor.
+	wd := vault.NewVaultWithdraw(depositor.Address, id, tx.NewIssuedAmountFromFloat64(40, cur, issuer.Address))
+	if res := env.Submit(wd); res.Code != "tesSUCCESS" {
+		t.Fatalf("VaultWithdraw: got %s, want tesSUCCESS", res.Code)
+	}
+	if env.LedgerEntryExists(keylet.Line(depID, pseudoID, cur)) {
+		t.Fatalf("direct depositor<->pseudo trust line created on withdraw (fork bug)")
+	}
+	if bal, ok := iouLineBalance(t, env, depID, issuerID, cur); !ok || !approxEq(bal, 940) {
+		t.Fatalf("depositor<->issuer balance = %v, want 940", bal)
+	}
+	if bal, ok := iouLineBalance(t, env, pseudoID, issuerID, cur); !ok || !approxEq(bal, 60) {
+		t.Fatalf("pseudo<->issuer balance = %v, want 60", bal)
+	}
+
+	// Issuer claws back the depositor's remaining shares: the 60 USD still held
+	// by the vault is redeemed off the pseudo<->issuer line.
+	claw := vault.NewVaultClawback(issuer.Address, id, depositor.Address)
+	if res := env.Submit(claw); res.Code != "tesSUCCESS" {
+		t.Fatalf("VaultClawback: got %s, want tesSUCCESS", res.Code)
+	}
+	if bal, ok := iouLineBalance(t, env, pseudoID, issuerID, cur); !ok || !approxEq(bal, 0) {
+		t.Fatalf("pseudo<->issuer balance after clawback = %v (exists=%v), want 0", bal, ok)
+	}
+	if bal, _ := iouLineBalance(t, env, depID, issuerID, cur); !approxEq(bal, 940) {
+		t.Fatalf("depositor<->issuer balance after clawback = %v, want 940 (unchanged)", bal)
+	}
+	if got := env.AccountInfo(depositor).OwnerCount; got != depOwnerBefore {
+		t.Fatalf("depositor owner count after clawback = %d, want %d", got, depOwnerBefore)
+	}
+
+	// Delete the now-empty vault; the pseudo's issuer trust line is removed.
+	del := vault.NewVaultDelete(owner.Address, id)
+	if res := env.Submit(del); res.Code != "tesSUCCESS" {
+		t.Fatalf("VaultDelete: got %s, want tesSUCCESS", res.Code)
+	}
+	if env.VaultExists(id) {
+		t.Fatalf("vault still exists after delete")
+	}
+	if env.LedgerEntryExists(keylet.Line(pseudoID, issuerID, cur)) {
+		t.Fatalf("pseudo<->issuer trust line not removed on delete")
 	}
 }
 

--- a/internal/tx/nftoken/iou_helpers.go
+++ b/internal/tx/nftoken/iou_helpers.go
@@ -7,7 +7,6 @@ import (
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
-	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -119,49 +118,12 @@ func offerIOUToAmount(offer *state.NFTokenOfferData) (tx.Amount, error) {
 	return state.NewIssuedAmountFromDecimalString(offer.AmountIOU.Value, offer.AmountIOU.Currency, issuerAddr)
 }
 
-// accountSendIOU transfers IOU between accounts via trust lines.
-// Handles three cases:
-//  1. from == IOU issuer: issuer creates tokens → credit receiver
-//  2. to == IOU issuer: holder redeems tokens → debit sender
-//  3. third party: two trust line modifications with optional transfer rate
+// accountSendIOU transfers IOU between accounts via trust lines, applying the
+// issuer's transfer rate to the sender's leg on a third-party transfer.
 //
 // Reference: rippled View.cpp accountSend → rippleSendIOU → rippleCreditIOU
 func accountSendIOU(view tx.LedgerView, from, to [20]byte, amount tx.Amount) ter.Result {
-	if amount.IsZero() || from == to {
-		return ter.TesSUCCESS
-	}
-
-	issuerID, err := state.DecodeAccountID(amount.Issuer)
-	if err != nil {
-		return ter.TefINTERNAL
-	}
-
-	if from == issuerID || to == issuerID {
-		// Direct: issuer is one side — no transfer fee
-		return tx.RippleCredit(view, from, to, amount)
-	}
-
-	// Third party: sender → issuer (with transfer rate) and issuer → receiver
-	transferRate := payment.GetTransferRate(view, issuerID)
-	if transferRate != payment.QualityOne {
-		// Charge the sender amount * transferRate, rounded to nearest. rippled's
-		// rippleSendIOU uses multiply() (round-to-nearest), not the round-up
-		// multiplyRound(), so MulRatio(..., roundUp=true) would diverge by 1 ulp.
-		rateAmount := state.NewIssuedAmountFromValue(int64(transferRate), -9, amount.Currency, amount.Issuer)
-		senderAmount := amount.Mul(rateAmount, false)
-		// Credit receiver the original amount
-		if r := tx.RippleCredit(view, issuerID, to, amount); r != ter.TesSUCCESS {
-			return r
-		}
-		// Debit sender the increased amount
-		return tx.RippleCredit(view, from, issuerID, senderAmount)
-	}
-
-	// No transfer rate — direct credit/debit
-	if r := tx.RippleCredit(view, issuerID, to, amount); r != ter.TesSUCCESS {
-		return r
-	}
-	return tx.RippleCredit(view, from, issuerID, amount)
+	return tx.RippleSendIOU(view, from, to, amount, false)
 }
 
 // payIOU wraps accountSendIOU with post-hoc balance validation.

--- a/internal/tx/ripple_credit.go
+++ b/internal/tx/ripple_credit.go
@@ -150,6 +150,45 @@ func RippleCredit(view LedgerView, sender, receiver [20]byte, amount Amount) ter
 	return ter.TesSUCCESS
 }
 
+// RippleSendIOU moves `amount` of an IOU from sender to receiver, rippling
+// through the issuer when neither party is the issuer: it credits the
+// issuer→receiver trust line and debits the sender→issuer line, so the balance
+// settles on the canonical issuer lines rather than a direct sender↔receiver
+// line. When either party is the issuer, it is a single direct RippleCredit
+// (redeeming or issuing the asset). Unless the fee is waived, the sender is
+// additionally charged the issuer's transfer rate, rounded to nearest.
+//
+// Reference: rippled View.cpp rippleSendIOU.
+func RippleSendIOU(view LedgerView, sender, receiver [20]byte, amount Amount, waiveFee bool) ter.Result {
+	if amount.IsZero() || sender == receiver {
+		return ter.TesSUCCESS
+	}
+
+	issuerID, err := state.DecodeAccountID(amount.Issuer)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+
+	if sender == issuerID || receiver == issuerID {
+		return RippleCredit(view, sender, receiver, amount)
+	}
+
+	// Third-party transit: the receiver is credited the delivered amount while
+	// the sender is debited the (possibly fee-inflated) actual cost.
+	senderAmount := amount
+	if !waiveFee {
+		if rate := GetTransferRate(view, amount.Issuer); rate != TransferRateParity {
+			rateAmount := state.NewIssuedAmountFromValue(int64(rate), -9, amount.Currency, amount.Issuer)
+			senderAmount = amount.Mul(rateAmount, false)
+		}
+	}
+
+	if r := RippleCredit(view, issuerID, receiver, amount); r != ter.TesSUCCESS {
+		return r
+	}
+	return RippleCredit(view, sender, issuerID, senderAmount)
+}
+
 // rippleCreditCreate is RippleCredit's missing-line branch: it auto-creates the
 // trust line carrying the credited balance and bumps the receiver's owner count,
 // mirroring rippled's rippleCreditIOU create path.

--- a/internal/tx/vault/apply_helpers.go
+++ b/internal/tx/vault/apply_helpers.go
@@ -591,7 +591,7 @@ func sendAssetToVault(ctx *tx.ApplyContext, vaultAccountID [20]byte, orig tx.Amo
 	}
 
 	amt := state.NewIssuedAmountFromValue(assetsN.Mantissa(), assetsN.Exponent(), orig.Currency, orig.Issuer)
-	return tx.RippleCredit(ctx.View, ctx.AccountID, vaultAccountID, amt)
+	return tx.RippleSendIOU(ctx.View, ctx.AccountID, vaultAccountID, amt, true)
 }
 
 // decodeMPTID decodes a 48-char hex MPT issuance ID.
@@ -654,7 +654,7 @@ func sendAssetFromVault(ctx *tx.ApplyContext, vaultAccountID, dstID [20]byte, as
 	}
 
 	amt := state.NewIssuedAmountFromValue(assetsN.Mantissa(), assetsN.Exponent(), asset.Currency, asset.Issuer)
-	return tx.RippleCredit(ctx.View, vaultAccountID, dstID, amt)
+	return tx.RippleSendIOU(ctx.View, vaultAccountID, dstID, amt, true)
 }
 
 // burnShares decreases the share issuance's OutstandingAmount and debits the

--- a/internal/tx/vault/exports.go
+++ b/internal/tx/vault/exports.go
@@ -84,7 +84,7 @@ func SendAsset(ctx *tx.ApplyContext, from, to [20]byte, asset tx.Asset, amountN 
 		return sendMPTAsset(ctx, id, from, to, uint64(amountN.ToInt64WithMode(state.RoundTowardsZero)))
 	}
 	amt := state.NewIssuedAmountFromValue(amountN.Mantissa(), amountN.Exponent(), asset.Currency, asset.Issuer)
-	return tx.RippleCredit(ctx.View, from, to, amt)
+	return tx.RippleSendIOU(ctx.View, from, to, amt, true)
 }
 
 // adjustXRPBalance adds delta drops to an account, modifying ctx.Account for the

--- a/internal/tx/vault/vault_clawback.go
+++ b/internal/tx/vault/vault_clawback.go
@@ -143,9 +143,16 @@ func (v *VaultClawback) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter
 		return ter.TefINTERNAL
 	}
 
-	// Ambiguous: issuer-is-owner must name the asset explicitly.
-	if v.Amount == nil && !isNativeAsset(vd.Asset) && !vd.AssetIsMPT && vd.Asset.Issuer == v.Account {
-		return ter.TecWRONG_ASSET
+	// Ambiguous: when the vault asset's issuer is the vault owner, the clawback
+	// must name the asset explicitly.
+	if v.Amount == nil && !isNativeAsset(vd.Asset) && !vd.AssetIsMPT {
+		ownerAddr, oerr := state.EncodeAccountID(vd.Owner)
+		if oerr != nil {
+			return ter.TefINTERNAL
+		}
+		if vd.Asset.Issuer == ownerAddr {
+			return ter.TecWRONG_ASSET
+		}
 	}
 
 	if v.clawsBackShares(vd, accountID) {


### PR DESCRIPTION
## The fork

Vault (and vault-reused lending) IOU asset movements credited a **direct
`holder <-> pseudo-account` trust line** instead of rippling through the
asset's issuer, the way rippled's `accountSend` does. rippled moves a
third-party IOU by `rippleSendIOU`: credit the `issuer -> receiver` line and
debit the `sender -> issuer` line, so the balance settles on the canonical
issuer lines. go-xrpl's helpers called `tx.RippleCredit(from, to)` directly,
which operates on `keylet.Line(from, to)` and ignores the amount's issuer.

The consequence: an IOU vault's balances land at a **different ledger key**
than rippled (`keylet.Line(depositor, pseudo)` instead of
`keylet.Line(depositor, issuer)` + `keylet.Line(pseudo, issuer)`) — an
`account_hash` divergence for any IOU vault, and the reason PR #1285's
`ValidVault` invariant scoped its asset-delta reconciliation to integral
(XRP/MPT) assets only.

## The fix

- **New shared `tx.RippleSendIOU`** (in `internal/tx/ripple_credit.go`),
  mirroring rippled `View.cpp rippleSendIOU`: third-party transfers ripple
  through the issuer (`issuer -> receiver` credit, `sender -> issuer` debit,
  with an optional transfer rate); a transfer where one party is the issuer is
  a single direct credit (redeem/issue).
- **Route the three vault IOU movement helpers** — `sendAssetToVault`,
  `sendAssetFromVault`, and the lending-facing `SendAsset` — through it with
  the **fee waived**, matching rippled's `WaiveTransferFee::Yes` on every
  Vault and LoanBroker/Loan asset movement. The pseudo-account already holds
  the asset on its issuer trust line (created at `VaultCreate`, removed at
  `VaultDelete`), so the credit now lands on the canonical issuer lines and no
  phantom `holder <-> pseudo` line is ever created.
- **`nftoken.accountSendIOU`** already implemented this rippling privately; it
  now delegates to the shared primitive (reuse, not reimplement), removing the
  duplicate and its `payment` import. Behavior-preserving — full NFToken
  conformance unchanged.

### Adjacent VaultClawback fork (surfaced while verifying the clawback leg)

`VaultClawback` preclaim's "must name the asset explicitly" ambiguity guard
compared the **asset issuer to the transaction submitter**. For a valid IOU
asset clawback the submitter is *always* the issuer, so an implicit-"all" IOU
clawback always returned `tecWRONG_ASSET`. rippled compares the asset issuer
to the **vault owner** (`vaultAsset.getIssuer() == sfOwner`). Fixed to match.

## Verification

- **New Go test** `TestVault_IOULifecycle` (create -> deposit -> withdraw ->
  clawback -> delete) asserts the **ledger keys** of every touched trust line:
  `holder<->issuer` and `issuer<->pseudo` exist and move; **no direct
  `holder<->pseudo` line is ever created**; balances and owner counts are
  checked at each step. The pseudo's issuer line is created at `VaultCreate`
  and removed at `VaultDelete`.
- **Full conformance: 0 new failures, 0 regressions** (baseline
  `origin/v3.0.0`: 120 failing fixtures; this branch: 120; identical set).
  The `app/Vault` IOU fixtures did not change count: the `rippled-2.6.2-v2`
  corpus predates rippled #5954 and fails at Step 0 on the old owner-count
  model / stale balances — **before** any asset movement — so the trust-line
  key is never reached. The movement fix is therefore verified by the targeted
  Go test rather than by a fixture pass-count delta.
- `go build ./...`, `go vet`, all `internal/tx/...` and `internal/testing/...`
  (non-conformance) suites green, strict `golangci-lint` clean on the affected
  packages, no docsgen/ledgerfieldsgen drift.

## Follow-up

Once #1285 merges, `ValidVault`'s asset-delta reconciliation can be extended
from integral-only to IOU (un-deferred): with this fix, IOU vault balances now
settle on the same `keylet.Line(account, issuer)` lines rippled's `ValidVault`
inspects. Left untouched here to avoid conflicting with #1285's open changes to
`internal/tx/invariants/vault.go`.

Follow-up to #1266 / #1285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)