### PR TITLE
fix: flatten typed transaction memo wrappers

### DIFF
--- a/internal/tx/flatten.go
+++ b/internal/tx/flatten.go
@@ -287,6 +287,10 @@ func flattenAsset(a Asset) map[string]any {
 	}
 }
 
+func flattenMemos(memos []MemoWrapper) []map[string]any {
+	return flattenStructSlice(reflect.ValueOf(memos))
+}
+
 // flattenStructSlice converts a slice of structs to []map[string]any for STArray serialization.
 // This is needed because the binary codec expects arrays to contain maps, not Go structs.
 // It uses JSON tags to determine field names in the map.

--- a/internal/tx/local_checks.go
+++ b/internal/tx/local_checks.go
@@ -2,7 +2,6 @@ package tx
 
 import (
 	"encoding/hex"
-	"reflect"
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -82,7 +81,7 @@ func memoHexFieldOkay(value string, urlRestricted bool) bool {
 // overhead by encoding an empty array with the same field so the header and end
 // marker cancel out, leaving only the array contents.
 func serializedMemosLength(memos []MemoWrapper) (int, error) {
-	arr := flattenStructSlice(reflect.ValueOf(memos))
+	arr := flattenMemos(memos)
 	full, err := binarycodec.EncodeBytes(map[string]any{"Memos": arr})
 	if err != nil {
 		return 0, err

--- a/internal/tx/payment/payment_test.go
+++ b/internal/tx/payment/payment_test.go
@@ -1,9 +1,11 @@
 package payment
 
 import (
+	"reflect"
 	"strconv"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -790,6 +792,52 @@ func TestPaymentFlatten(t *testing.T) {
 			}
 			tt.checkMap(t, m)
 		})
+	}
+}
+
+func TestPaymentFlattenMemosAreCanonicalSTObjects(t *testing.T) {
+	payment := NewPayment(
+		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+		tx.NewXRPAmount(1_000_000),
+	)
+	payment.Fee = "10"
+	payment.SetSequence(1)
+	payment.AddMemo("74657874", "68656C6C6F", "746578742F706C61696E")
+	payment.AddMemo("", "00", "")
+
+	wantMemos := []map[string]any{
+		{
+			"Memo": map[string]any{
+				"MemoType":   "74657874",
+				"MemoData":   "68656C6C6F",
+				"MemoFormat": "746578742F706C61696E",
+			},
+		},
+		{
+			"Memo": map[string]any{
+				"MemoData": "00",
+			},
+		},
+	}
+
+	commonMap := payment.Common.ToMap()
+	if got := commonMap["Memos"]; !reflect.DeepEqual(got, wantMemos) {
+		t.Fatalf("Common.ToMap Memos = %#v, want %#v", got, wantMemos)
+	}
+
+	flat, err := payment.Flatten()
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	if got := flat["Memos"]; !reflect.DeepEqual(got, wantMemos) {
+		t.Fatalf("Flatten Memos = %#v, want %#v", got, wantMemos)
+	}
+	if _, err := binarycodec.Encode(flat); err != nil {
+		t.Fatalf("encode memo-bearing typed transaction: %v", err)
+	}
+	if _, err := binarycodec.EncodeForSigning(flat); err != nil {
+		t.Fatalf("encode memo-bearing typed transaction for signing: %v", err)
 	}
 }
 

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -471,7 +471,7 @@ func (c *Common) ToMap() map[string]any {
 		m["LastLedgerSequence"] = *c.LastLedgerSequence
 	}
 	if len(c.Memos) > 0 {
-		m["Memos"] = c.Memos
+		m["Memos"] = flattenMemos(c.Memos)
 	}
 	if c.NetworkID != nil {
 		m["NetworkID"] = *c.NetworkID


### PR DESCRIPTION
## Summary
- Canonicalize typed transaction `MemoWrapper` values into STObject-shaped maps before binary and signing-payload encoding.
- Reuse the same memo flattening path for local serialized-size validation and pin the exact omitted-field behavior.

## Test plan
- [x] `go test ./internal/tx/payment -run '^TestPaymentFlattenMemosAreCanonicalSTObjects$' -count=1`
- [x] `go test ./internal/tx/... ./codec/binarycodec/...`
- [x] `go build ./internal/tx/... ./codec/binarycodec/...`
- [x] `go vet ./internal/tx/... ./codec/binarycodec/...`

Fixes #1272
