### PR TITLE
fix: honor MPTokensV2 payment flag mask

### DIFF
--- a/internal/consensus/adaptor/startup_cov_test.go
+++ b/internal/consensus/adaptor/startup_cov_test.go
@@ -472,7 +472,7 @@ func TestStup_ComponentsStart_AndStop(t *testing.T) {
 	ad := newTestAdaptor(t)
 	mm := NewModeManager(ad)
 
-	overlay, err := peermanagement.New()
+	overlay, err := peermanagement.New(peermanagement.WithListenAddr("127.0.0.1:0"))
 	require.NoError(t, err)
 
 	eng := &mockEngine{}

--- a/internal/ledger/service/account_query_test.go
+++ b/internal/ledger/service/account_query_test.go
@@ -910,7 +910,7 @@ func TestGetAccountOffers_FormatsAmounts(t *testing.T) {
 	// quality must equal the offer's book-directory rate (saDirRate), derived
 	// from the BookDirectory key — not a recomputed TakerPays/TakerGets float
 	// division.
-	wantQuality := qualityFromDirKey(state.CalculateQuality(takerPays, takerGets))
+	wantQuality := qualityFromDirKey(state.CalculateQuality(takerGets, takerPays))
 	if o.Quality != wantQuality {
 		t.Errorf("quality = %q, want %q (from book directory rate)", o.Quality, wantQuality)
 	}

--- a/internal/ledger/service/offer_query.go
+++ b/internal/ledger/service/offer_query.go
@@ -7,12 +7,15 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 	"github.com/LeJamon/go-xrpl/shamap"
@@ -155,13 +158,10 @@ func (s *Service) GetBookOffers(ctx context.Context, takerGets, takerPays tx.Amo
 		}
 	}
 
-	getsIssuer := takerGets.Issuer
-	bGlobalFreeze := tx.IsGlobalFrozen(targetLedger, takerGets.Issuer) ||
-		tx.IsGlobalFrozen(targetLedger, takerPays.Issuer)
-	rate := tx.TransferRateParity
-	if !takerGets.IsNative() {
-		rate = tx.GetTransferRate(targetLedger, getsIssuer)
-	}
+	getsIssuer := amountIssuer(takerGets)
+	bGlobalFreeze := amountGlobalFrozen(targetLedger, takerGets) ||
+		amountGlobalFrozen(targetLedger, takerPays)
+	rate := amountTransferRate(targetLedger, takerGets)
 	_, reserveBase, reserveIncrement := readFeesFromLedger(targetLedger)
 
 	// balances tracks each owner's remaining funds across the iteration.
@@ -388,7 +388,11 @@ func (s *Service) buildBookOffer(
 			if decErr != nil {
 				return BookOffer{}, decErr
 			}
-			ownerFunds = tx.AccountFunds(view, accountID, takerGets, true, reserveBase, reserveIncrement)
+			funds, fundsErr := accountBookFunds(view, accountID, takerGets, reserveBase, reserveIncrement)
+			if fundsErr != nil {
+				return BookOffer{}, fundsErr
+			}
+			ownerFunds = funds
 		}
 	}
 
@@ -458,25 +462,96 @@ func (s *Service) buildBookOffer(
 // hash including its natural low-8 bytes, so we must zero them here so the
 // returned key sorts strictly below every quality tier in the book.
 func computeBookBase(takerPays, takerGets tx.Amount, domainHex string) ([32]byte, error) {
-	payCurr := keylet.CurrencyBytes(takerPays.Currency)
-	payIssuer := state.GetIssuerBytes(takerPays.Issuer)
-	getsCurr := keylet.CurrencyBytes(takerGets.Currency)
-	getsIssuer := state.GetIssuerBytes(takerGets.Issuer)
+	pays, err := bookSideFromAmount(takerPays)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	gets, err := bookSideFromAmount(takerGets)
+	if err != nil {
+		return [32]byte{}, err
+	}
 
-	var key [32]byte
-	if domainHex == "" {
-		key = keylet.BookDir(payCurr, payIssuer, getsCurr, getsIssuer).Key
-	} else {
-		var domainID [32]byte
-		if err := decodeHex32Into(domainHex, &domainID); err != nil {
+	var domainID *[32]byte
+	if domainHex != "" {
+		domainID = new([32]byte)
+		if err := decodeHex32Into(domainHex, domainID); err != nil {
 			return [32]byte{}, err
 		}
-		key = keylet.BookDirWithDomain(payCurr, payIssuer, getsCurr, getsIssuer, domainID).Key
 	}
+	key := keylet.BookBase(pays, gets, domainID).Key
 	for i := 24; i < 32; i++ {
 		key[i] = 0
 	}
 	return key, nil
+}
+
+func bookSideFromAmount(amount tx.Amount) (keylet.BookSide, error) {
+	if amount.IsMPT() {
+		id, err := mptutil.DecodeID(amount.MPTIssuanceID())
+		if err != nil {
+			return keylet.BookSide{}, err
+		}
+		return keylet.MPTSide(id), nil
+	}
+	return keylet.IssueSide(
+		keylet.CurrencyBytes(amount.Currency),
+		state.GetIssuerBytes(amount.Issuer),
+	), nil
+}
+
+func amountMPTID(amount tx.Amount) ([24]byte, bool) {
+	if !amount.IsMPT() {
+		return [24]byte{}, false
+	}
+	id, err := mptutil.DecodeID(amount.MPTIssuanceID())
+	return id, err == nil
+}
+
+func amountIssuer(amount tx.Amount) string {
+	if id, ok := amountMPTID(amount); ok {
+		return state.EncodeAccountIDSafe(mptutil.Issuer(id))
+	}
+	return amount.Issuer
+}
+
+func amountGlobalFrozen(view tx.LedgerView, amount tx.Amount) bool {
+	issuer := amountIssuer(amount)
+	return issuer != "" && tx.IsGlobalFrozen(view, issuer)
+}
+
+func amountTransferRate(view tx.LedgerView, amount tx.Amount) uint32 {
+	issuer := amountIssuer(amount)
+	if issuer == "" {
+		return tx.TransferRateParity
+	}
+	return tx.GetTransferRate(view, issuer)
+}
+
+func accountBookFunds(view *ledger.Ledger, account [20]byte, amount tx.Amount, reserveBase, reserveIncrement uint64) (tx.Amount, error) {
+	id, ok := amountMPTID(amount)
+	if !ok {
+		return tx.AccountFunds(view, account, amount, true, reserveBase, reserveIncrement), nil
+	}
+	value, result := mptutil.Funds(view, id, account, true)
+	if result == ter.TefINTERNAL {
+		return tx.Amount{}, fmt.Errorf("book_offers MPT funds: %s", result)
+	}
+	if result != ter.TesSUCCESS {
+		value = 0
+	}
+	var parentCloseTime uint32
+	if closeTime := view.ParentCloseTime(); !closeTime.IsZero() {
+		switch seconds := toRippleTime(closeTime); {
+		case seconds > math.MaxUint32:
+			parentCloseTime = math.MaxUint32
+		case seconds > 0:
+			parentCloseTime = uint32(seconds)
+		}
+	}
+	if mptutil.RequireAuthAt(view, id, account, true, parentCloseTime) != ter.TesSUCCESS {
+		value = 0
+	}
+	return state.NewMPTAmountWithIssuanceID(value, amountIssuer(amount), mptutil.EncodeID(id)), nil
 }
 
 func decodeHex32Into(s string, out *[32]byte) error {
@@ -499,6 +574,12 @@ func amountToJSON(a tx.Amount) any {
 	if a.IsNative() {
 		return a.Value()
 	}
+	if a.IsMPT() {
+		return map[string]string{
+			"mpt_issuance_id": a.MPTIssuanceID(),
+			"value":           a.Value(),
+		}
+	}
 	return map[string]string{
 		"currency": a.Currency,
 		"issuer":   a.Issuer,
@@ -509,6 +590,9 @@ func amountToJSON(a tx.Amount) any {
 func zeroLike(model tx.Amount) tx.Amount {
 	if model.IsNative() {
 		return tx.NewXRPAmount(0)
+	}
+	if model.IsMPT() {
+		return state.NewMPTAmountWithIssuanceID(0, model.Issuer, model.MPTIssuanceID())
 	}
 	return tx.NewIssuedAmount(0, 0, model.Currency, model.Issuer)
 }
@@ -581,9 +665,17 @@ func extractOfferProof(snap *shamap.SHAMap, key [32]byte) ([]string, error) {
 // rippled's STAmount(asset, mantissa, exp) cast at STAmount.cpp:1404.
 func multiplyByDirRate(getsFunded, saDirRate, takerPays tx.Amount) tx.Amount {
 	product := saDirRate.Mul(getsFunded, false)
+	if takerPays.IsMPT() {
+		m := integralProductValue(product)
+		return state.NewMPTAmountWithIssuanceID(m, amountIssuer(takerPays), takerPays.MPTIssuanceID())
+	}
 	if !takerPays.IsNative() {
 		return product
 	}
+	return tx.NewXRPAmount(integralProductValue(product))
+}
+
+func integralProductValue(product tx.Amount) int64 {
 	m := product.Mantissa()
 	e := product.Exponent()
 	for e > 0 {
@@ -594,5 +686,5 @@ func multiplyByDirRate(getsFunded, saDirRate, takerPays tx.Amount) tx.Amount {
 		m /= 10
 		e++
 	}
-	return tx.NewXRPAmount(m)
+	return m
 }

--- a/internal/ledger/service/offer_query_mpt_test.go
+++ b/internal/ledger/service/offer_query_mpt_test.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBookOffersMPTFunding(t *testing.T) {
+	svc := newOfferTestService(t)
+	issuerAddr, issuer := addressFromBytes(t, 0x61)
+	ownerAddr, owner := addressFromBytes(t, 0x71)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000, 0)
+	insertAccountRoot(t, svc, ownerAddr, 1_000_000_000, 0)
+
+	maximum := uint64(1_000)
+	id := keylet.MakeMPTID(7, issuer)
+	issuance := &state.MPTokenIssuanceData{
+		Issuer:            issuer,
+		Sequence:          7,
+		OutstandingAmount: 80,
+		TransferFee:       25_000,
+		MaximumAmount:     &maximum,
+	}
+	issuanceData, err := state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	require.NoError(t, svc.openLedger.Insert(keylet.MPTIssuance(id), issuanceData))
+
+	holdingData, err := state.SerializeMPToken(&state.MPTokenData{
+		Account:           owner,
+		MPTokenIssuanceID: id,
+		MPTAmount:         80,
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.openLedger.Insert(keylet.MPTokenByID(id, owner), holdingData))
+
+	idString := mptutil.EncodeID(id)
+	mptModel := state.NewMPTAmountWithIssuanceID(0, issuerAddr, idString)
+	insertOffer(t, svc, ownerAddr, 1,
+		tx.NewXRPAmount(10_000_000),
+		state.NewMPTAmountWithIssuanceID(100, issuerAddr, idString),
+	)
+
+	result, err := svc.GetBookOffers(
+		context.Background(), mptModel, tx.NewXRPAmount(0), "", "", "current", 10, "", false,
+	)
+	require.NoError(t, err)
+	require.Len(t, result.Offers, 1)
+	offer := result.Offers[0]
+	require.Equal(t, "80", offer.OwnerFunds)
+	require.Equal(t, map[string]string{
+		"mpt_issuance_id": idString,
+		"value":           "80",
+	}, offer.TakerGetsFunded)
+	require.Equal(t, "8000000", offer.TakerPaysFunded)
+}
+
+func TestGetBookOffersMPTFundedPays(t *testing.T) {
+	svc := newOfferTestService(t)
+	issuerAddr, issuer := addressFromBytes(t, 0x62)
+	ownerAddr, _ := addressFromBytes(t, 0x72)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000, 0)
+	insertAccountRoot(t, svc, ownerAddr, 10_000_080, 0)
+
+	maximum := uint64(1_000)
+	id := keylet.MakeMPTID(8, issuer)
+	issuanceData, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+		Issuer:        issuer,
+		Sequence:      8,
+		MaximumAmount: &maximum,
+		Flags:         entry.LsfMPTLocked,
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.openLedger.Insert(keylet.MPTIssuance(id), issuanceData))
+
+	idString := mptutil.EncodeID(id)
+	mptModel := state.NewMPTAmountWithIssuanceID(0, issuerAddr, idString)
+	insertOffer(t, svc, ownerAddr, 1,
+		state.NewMPTAmountWithIssuanceID(1_000, issuerAddr, idString),
+		tx.NewXRPAmount(100),
+	)
+
+	result, err := svc.GetBookOffers(
+		context.Background(), tx.NewXRPAmount(0), mptModel, "", "", "current", 10, "", false,
+	)
+	require.NoError(t, err)
+	require.Len(t, result.Offers, 1)
+	offer := result.Offers[0]
+	require.Equal(t, "80", offer.OwnerFunds)
+	require.Equal(t, "80", offer.TakerGetsFunded)
+	require.Equal(t, map[string]string{
+		"mpt_issuance_id": idString,
+		"value":           "800",
+	}, offer.TakerPaysFunded)
+}
+
+func TestGetBookOffersIssuerOwnedMPTIsFullyFunded(t *testing.T) {
+	svc := newOfferTestService(t)
+	issuerAddr, issuer := addressFromBytes(t, 0x63)
+	insertAccountRoot(t, svc, issuerAddr, 1_000_000_000, 0)
+
+	maximum := uint64(100)
+	id := keylet.MakeMPTID(9, issuer)
+	issuanceData, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+		Issuer:            issuer,
+		Sequence:          9,
+		OutstandingAmount: maximum,
+		MaximumAmount:     &maximum,
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.openLedger.Insert(keylet.MPTIssuance(id), issuanceData))
+
+	idString := mptutil.EncodeID(id)
+	mptModel := state.NewMPTAmountWithIssuanceID(0, issuerAddr, idString)
+	insertOffer(t, svc, issuerAddr, 1,
+		tx.NewXRPAmount(10_000_000),
+		state.NewMPTAmountWithIssuanceID(100, issuerAddr, idString),
+	)
+
+	result, err := svc.GetBookOffers(
+		context.Background(), mptModel, tx.NewXRPAmount(0), "", "", "current", 10, "", false,
+	)
+	require.NoError(t, err)
+	require.Len(t, result.Offers, 1)
+	require.Equal(t, "100", result.Offers[0].OwnerFunds)
+	require.Nil(t, result.Offers[0].TakerGetsFunded)
+	require.Nil(t, result.Offers[0].TakerPaysFunded)
+}

--- a/internal/ledger/service/offer_query_test.go
+++ b/internal/ledger/service/offer_query_test.go
@@ -122,12 +122,20 @@ func insertOffer(t *testing.T, svc *Service, ownerAddr string, sequence uint32, 
 	copy(id[:], idBytes)
 
 	// Build the real book directory key so GetBookOffers can walk it.
+	paySide, err := bookSideFromAmount(takerPays)
+	if err != nil {
+		t.Fatalf("taker pays book side: %v", err)
+	}
+	getsSide, err := bookSideFromAmount(takerGets)
+	if err != nil {
+		t.Fatalf("taker gets book side: %v", err)
+	}
 	payCurr := keylet.CurrencyBytes(takerPays.Currency)
 	payIssuer := state.GetIssuerBytes(takerPays.Issuer)
 	getsCurr := keylet.CurrencyBytes(takerGets.Currency)
 	getsIssuer := state.GetIssuerBytes(takerGets.Issuer)
-	bookBase := keylet.BookDir(payCurr, payIssuer, getsCurr, getsIssuer).Key
-	quality := state.CalculateQuality(takerPays, takerGets)
+	bookBase := keylet.BookBase(paySide, getsSide, nil).Key
+	quality := state.CalculateQuality(takerGets, takerPays)
 	var bookDir [32]byte
 	copy(bookDir[:], bookBase[:])
 	binary.BigEndian.PutUint64(bookDir[24:], quality)
@@ -153,10 +161,20 @@ func insertOffer(t *testing.T, svc *Service, ownerAddr string, sequence uint32, 
 	// reaches it. Mirrors rippled's dirAdd from CreateOffer apply path.
 	dirKeylet := keylet.Keylet{Type: entry.TypeDirectoryNode, Key: bookDir}
 	if _, derr := state.DirInsert(svc.openLedger, dirKeylet, k.Key, true, func(d *state.DirectoryNode) {
-		d.TakerPaysCurrency = payCurr
-		d.TakerPaysIssuer = payIssuer
-		d.TakerGetsCurrency = getsCurr
-		d.TakerGetsIssuer = getsIssuer
+		if paySide.IsMPT {
+			id := paySide.MPTID
+			d.TakerPaysMPT = &id
+		} else {
+			d.TakerPaysCurrency = payCurr
+			d.TakerPaysIssuer = payIssuer
+		}
+		if getsSide.IsMPT {
+			id := getsSide.MPTID
+			d.TakerGetsMPT = &id
+		} else {
+			d.TakerGetsCurrency = getsCurr
+			d.TakerGetsIssuer = getsIssuer
+		}
 		d.ExchangeRate = quality
 	}); derr != nil {
 		t.Fatalf("dir insert: %v", derr)
@@ -381,7 +399,7 @@ func insertPermissionedOffer(t *testing.T, svc *Service, ownerAddr string, seque
 	getsCurr := keylet.CurrencyBytes(takerGets.Currency)
 	getsIssuer := state.GetIssuerBytes(takerGets.Issuer)
 	bookBase := keylet.BookDirWithDomain(payCurr, payIssuer, getsCurr, getsIssuer, domainID).Key
-	quality := state.CalculateQuality(takerPays, takerGets)
+	quality := state.CalculateQuality(takerGets, takerPays)
 	var bookDir [32]byte
 	copy(bookDir[:], bookBase[:])
 	binary.BigEndian.PutUint64(bookDir[24:], quality)

--- a/internal/ledger/state/amount.go
+++ b/internal/ledger/state/amount.go
@@ -585,57 +585,11 @@ func (a Amount) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements custom JSON unmarshaling
 func (a *Amount) UnmarshalJSON(data []byte) error {
-	// Try as string first (XRP drops)
-	var strVal string
-	if err := json.Unmarshal(data, &strVal); err == nil {
-		drops, err := strconv.ParseInt(strVal, 10, 64)
-		if err != nil {
-			return fmt.Errorf("invalid XRP drops value: %w", err)
-		}
-		a.xrp = XRPAmount{drops: drops}
-		a.Native = true
-		return nil
-	}
-
-	// Try as object (issued currency or MPT amount)
-	var objVal struct {
-		Value         string `json:"value"`
-		Currency      string `json:"currency"`
-		Issuer        string `json:"issuer"`
-		MPTIssuanceID string `json:"mpt_issuance_id"`
-	}
-	if err := json.Unmarshal(data, &objVal); err != nil {
-		return err
-	}
-
-	// MPT amounts have mpt_issuance_id instead of currency/issuer
-	if objVal.MPTIssuanceID != "" {
-		// Parse value as integer for MPT (whole number amounts)
-		raw, err := strconv.ParseInt(objVal.Value, 10, 64)
-		if err != nil {
-			// Fallback to IOU parsing if not a plain integer
-			iou, perr := parseIOUValueFromString(objVal.Value)
-			if perr != nil {
-				return perr
-			}
-			a.iou = iou
-		} else {
-			a.iou = NewIOUAmountValue(raw, 0) // normalized for binary codec
-			a.mptRaw = &raw
-		}
-		a.mptIssuanceID = strings.ToUpper(objVal.MPTIssuanceID)
-		a.Native = false
-		return nil
-	}
-
-	iou, err := parseIOUValueFromString(objVal.Value)
+	parsed, err := AmountFromJSON(data)
 	if err != nil {
 		return err
 	}
-	a.iou = iou
-	a.Currency = objVal.Currency
-	a.Issuer = objVal.Issuer
-	a.Native = false
+	*a = parsed
 	return nil
 }
 

--- a/internal/ledger/state/amount.go
+++ b/internal/ledger/state/amount.go
@@ -479,6 +479,9 @@ func (a Amount) IsZero() bool {
 	if a.IsNative() {
 		return a.xrp.IsZero()
 	}
+	if a.mptRaw != nil {
+		return *a.mptRaw == 0
+	}
 	return a.iou.IsZero()
 }
 
@@ -487,6 +490,9 @@ func (a Amount) IsNegative() bool {
 	if a.IsNative() {
 		return a.xrp.IsNegative()
 	}
+	if a.mptRaw != nil {
+		return *a.mptRaw < 0
+	}
 	return a.iou.IsNegative()
 }
 
@@ -494,6 +500,15 @@ func (a Amount) IsNegative() bool {
 func (a Amount) Signum() int {
 	if a.IsNative() {
 		return a.xrp.Signum()
+	}
+	if a.mptRaw != nil {
+		if *a.mptRaw < 0 {
+			return -1
+		}
+		if *a.mptRaw > 0 {
+			return 1
+		}
+		return 0
 	}
 	return a.iou.Signum()
 }
@@ -516,6 +531,9 @@ func (a Amount) Float64() float64 {
 	if a.IsNative() {
 		return float64(a.xrp.drops)
 	}
+	if a.mptRaw != nil {
+		return float64(*a.mptRaw)
+	}
 	return a.iou.Float64()
 }
 
@@ -527,12 +545,24 @@ func (a Amount) Negate() Amount {
 			Native: true,
 		}
 	}
+	if a.mptRaw != nil {
+		if *a.mptRaw == math.MinInt64 {
+			panic("MPT negate overflow")
+		}
+		return newMPTAmountLike(a, -*a.mptRaw)
+	}
 	return Amount{
 		iou:      a.iou.Negate(),
 		Currency: a.Currency,
 		Issuer:   a.Issuer,
 		Native:   false,
 	}
+}
+
+func newMPTAmountLike(prototype Amount, value int64) Amount {
+	result := NewMPTAmountDirect(value, prototype.Currency, prototype.Issuer)
+	result.mptIssuanceID = prototype.mptIssuanceID
+	return result
 }
 
 // MarshalJSON implements custom JSON marshaling

--- a/internal/ledger/state/amount_arithmetic.go
+++ b/internal/ledger/state/amount_arithmetic.go
@@ -35,6 +35,19 @@ func (a Amount) Add(b Amount) (Amount, error) {
 // AddRounded returns a + b, rounding the IOU result under mode. The AMM math
 // uses this to reproduce rippled's NumberRoundModeGuard around additions.
 func (a Amount) AddRounded(b Amount, mode RoundingMode) (Amount, error) {
+	if a.mptRaw != nil || b.mptRaw != nil {
+		if a.mptRaw == nil || b.mptRaw == nil {
+			return Amount{}, fmt.Errorf("temBAD_AMOUNT: cannot add MPT and non-MPT amounts")
+		}
+		if a.mptIssuanceID != b.mptIssuanceID {
+			return Amount{}, fmt.Errorf("temBAD_AMOUNT: cannot add different MPT issuances")
+		}
+		result := new(big.Int).Add(big.NewInt(*a.mptRaw), big.NewInt(*b.mptRaw))
+		if !result.IsInt64() {
+			return Amount{}, fmt.Errorf("temBAD_AMOUNT: MPT addition overflow")
+		}
+		return newMPTAmountLike(a, result.Int64()), nil
+	}
 	if a.IsNative() != b.IsNative() {
 		return Amount{}, fmt.Errorf("temBAD_AMOUNT: cannot add XRP and IOU amounts")
 	}
@@ -58,11 +71,24 @@ func (a Amount) AddRounded(b Amount, mode RoundingMode) (Amount, error) {
 
 // Sub subtracts two amounts (must be same type)
 func (a Amount) Sub(b Amount) (Amount, error) {
-	return a.Add(b.Negate())
+	return a.SubRounded(b, RoundToNearest)
 }
 
 // SubRounded returns a - b, rounding the IOU result under mode.
 func (a Amount) SubRounded(b Amount, mode RoundingMode) (Amount, error) {
+	if a.mptRaw != nil || b.mptRaw != nil {
+		if a.mptRaw == nil || b.mptRaw == nil {
+			return Amount{}, fmt.Errorf("temBAD_AMOUNT: cannot subtract MPT and non-MPT amounts")
+		}
+		if a.mptIssuanceID != b.mptIssuanceID {
+			return Amount{}, fmt.Errorf("temBAD_AMOUNT: cannot subtract different MPT issuances")
+		}
+		result := new(big.Int).Sub(big.NewInt(*a.mptRaw), big.NewInt(*b.mptRaw))
+		if !result.IsInt64() {
+			return Amount{}, fmt.Errorf("temBAD_AMOUNT: MPT subtraction overflow")
+		}
+		return newMPTAmountLike(a, result.Int64()), nil
+	}
 	return a.AddRounded(b.Negate(), mode)
 }
 
@@ -133,6 +159,15 @@ func (a Amount) Compare(b Amount) int {
 		return 0
 	}
 	if !a.IsNative() && !b.IsNative() {
+		if a.mptRaw != nil && b.mptRaw != nil {
+			if *a.mptRaw < *b.mptRaw {
+				return -1
+			}
+			if *a.mptRaw > *b.mptRaw {
+				return 1
+			}
+			return 0
+		}
 		return compareIOUValues(a.iou, b.iou)
 	}
 	// Mixed types - XRP comes first
@@ -187,6 +222,26 @@ func compareIOUValues(a, b IOUAmountValue) int {
 // Includes roomToGrow precision enhancement matching rippled's IOUAmount mulRatio.
 // Reference: IOUAmount.cpp mulRatio() lines 189-323
 func (a Amount) MulRatio(num, den uint32, roundUp bool) Amount {
+	if a.mptRaw != nil {
+		if den == 0 {
+			panic("division by zero")
+		}
+		product := new(big.Int).Mul(big.NewInt(*a.mptRaw), new(big.Int).SetUint64(uint64(num)))
+		quotient := new(big.Int)
+		remainder := new(big.Int)
+		quotient.QuoRem(product, new(big.Int).SetUint64(uint64(den)), remainder)
+		if remainder.Sign() != 0 {
+			if product.Sign() >= 0 && roundUp {
+				quotient.Add(quotient, big.NewInt(1))
+			} else if product.Sign() < 0 && !roundUp {
+				quotient.Sub(quotient, big.NewInt(1))
+			}
+		}
+		if !quotient.IsInt64() {
+			panic("MPT mulRatio overflow")
+		}
+		return newMPTAmountLike(a, quotient.Int64())
+	}
 	if a.IsNative() {
 		// Use big.Int to avoid int64 overflow for large XRP amounts.
 		// E.g. 150000000000 drops * 1000000000 overflows int64.
@@ -367,7 +422,17 @@ func (a Amount) MulRounded(other Amount, roundUp bool, mode RoundingMode) Amount
 		if a.IsNative() {
 			return NewXRPAmountFromInt(0)
 		}
+		if a.mptRaw != nil {
+			return newMPTAmountLike(a, 0)
+		}
 		return NewIssuedAmountFromValue(0, -100, a.Currency, a.Issuer)
+	}
+	if a.mptRaw != nil && other.mptRaw != nil {
+		product := new(big.Int).Mul(big.NewInt(*a.mptRaw), big.NewInt(*other.mptRaw))
+		if !product.IsInt64() {
+			panic("MPT value overflow")
+		}
+		return newMPTAmountLike(a, product.Int64())
 	}
 
 	// Handle XRP * XRP case
@@ -395,6 +460,13 @@ func (a Amount) MulRounded(other Amount, roundUp bool, mode RoundingMode) Amount
 		na := NewXRPLNumberRounded(m1, e1, mode)
 		nb := NewXRPLNumberRounded(m2, e2, mode)
 		result := na.MulRounded(nb, mode)
+		if a.mptRaw != nil {
+			value := result.ToInt64WithMode(mode)
+			if negative {
+				value = -value
+			}
+			return newMPTAmountLike(a, value)
+		}
 		iou := result.ToIOUAmountValue()
 		rm := iou.mantissa
 		if negative {
@@ -412,15 +484,15 @@ func (a Amount) MulRounded(other Amount, roundUp bool, mode RoundingMode) Amount
 		m2 = -m2
 	}
 
-	// Pre-normalize native (XRP) inputs to IOU range [cMinValue, cMaxValue)
+	// Pre-normalize integral inputs to IOU range [cMinValue, cMaxValue)
 	// Reference: rippled multiply() lines 1382-1398
-	if a.IsNative() {
+	if a.IsNative() || a.IsMPT() {
 		for m1 < MinMantissa {
 			m1 *= 10
 			e1--
 		}
 	}
-	if other.IsNative() {
+	if other.IsNative() || other.IsMPT() {
 		for m2 < MinMantissa {
 			m2 *= 10
 			e2--
@@ -504,7 +576,12 @@ func (a Amount) MulRounded(other Amount, roundUp bool, mode RoundingMode) Amount
 		return NewXRPAmountFromInt(resultMant)
 	}
 
-	return NewIssuedAmountFromValue(resultMant, resultExp, a.Currency, a.Issuer)
+	result := NewIssuedAmountFromValue(resultMant, resultExp, a.Currency, a.Issuer)
+	if a.mptRaw != nil {
+		n := NewXRPLNumberRounded(result.IOU().Mantissa(), result.IOU().Exponent(), mode)
+		return newMPTAmountLike(a, n.ToInt64WithMode(mode))
+	}
+	return result
 }
 
 // Div divides this Amount by another Amount.
@@ -524,7 +601,13 @@ func (a Amount) Div(other Amount, roundUp bool) Amount {
 		if a.IsNative() {
 			return NewXRPAmountFromInt(0)
 		}
+		if a.mptRaw != nil {
+			return newMPTAmountLike(a, 0)
+		}
 		return NewIssuedAmountFromValue(0, -100, a.Currency, a.Issuer)
+	}
+	if a.mptRaw != nil {
+		return newMPTAmountLike(a, DivRoundMPT(a, other, roundUp))
 	}
 
 	// Handle XRP / XRP case
@@ -556,15 +639,15 @@ func (a Amount) Div(other Amount, roundUp bool) Amount {
 		m2 = -m2
 	}
 
-	// Pre-normalize native (XRP) inputs to IOU range [cMinValue, cMaxValue)
+	// Pre-normalize integral inputs to IOU range [cMinValue, cMaxValue)
 	// Reference: rippled divide() lines 1307-1324
-	if a.IsNative() {
+	if a.IsNative() || a.IsMPT() {
 		for m1 < MinMantissa {
 			m1 *= 10
 			e1--
 		}
 	}
-	if other.IsNative() {
+	if other.IsNative() || other.IsMPT() {
 		for m2 < MinMantissa {
 			m2 *= 10
 			e2--

--- a/internal/ledger/state/amount_json_test.go
+++ b/internal/ledger/state/amount_json_test.go
@@ -233,6 +233,27 @@ func TestAmountFromJSON_MPT(t *testing.T) {
 	}
 }
 
+func TestAmountUnmarshalJSONUsesCanonicalMPTParser(t *testing.T) {
+	decode := func(value string) (Amount, error) {
+		var amount Amount
+		err := json.Unmarshal([]byte(
+			`{"mpt_issuance_id":"`+testMPTID+`","value":"`+value+`"}`,
+		), &amount)
+		return amount, err
+	}
+
+	if _, err := decode("1.5"); err == nil {
+		t.Fatal("fractional MPT value must be rejected")
+	}
+	amount, err := decode("922337203685477580e1")
+	if err != nil {
+		t.Fatalf("integral scientific MPT value: %v", err)
+	}
+	if raw, ok := amount.MPTRaw(); !ok || raw != 9223372036854775800 {
+		t.Fatalf("MPTRaw = %d/%v, want 9223372036854775800/true", raw, ok)
+	}
+}
+
 // GHSA-xv89-94jf-8vx2: scaling the mantissa by a positive exponent must not
 // wrap uint64 and slip past the range guard. maxMPTAmount (math.MaxInt64,
 // ~9.22e18) sits above the uint64 wrap threshold (2^64/10 ~ 1.84e18), so a

--- a/internal/ledger/state/amount_mpt_arithmetic_test.go
+++ b/internal/ledger/state/amount_mpt_arithmetic_test.go
@@ -1,0 +1,118 @@
+package state
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const arithmeticMPTID = "00000004AE123A8556F3CF91154711376AFB0F894F832B3D"
+
+func TestAmountMPTArithmeticPreservesIntegralValueAndIssue(t *testing.T) {
+	issuer := "rIssuer"
+	a := NewMPTAmountWithIssuanceID(math.MaxInt64-10, issuer, arithmeticMPTID)
+	b := NewMPTAmountWithIssuanceID(5, issuer, arithmeticMPTID)
+
+	sum, err := a.Add(b)
+	require.NoError(t, err)
+	require.Equal(t, int64(math.MaxInt64-5), mustMPTRaw(t, sum))
+	require.Equal(t, arithmeticMPTID, sum.MPTIssuanceID())
+
+	difference, err := b.Sub(a)
+	require.NoError(t, err)
+	require.Equal(t, int64(15-math.MaxInt64), mustMPTRaw(t, difference))
+	require.Equal(t, arithmeticMPTID, difference.MPTIssuanceID())
+
+	negated := b.Negate()
+	require.Equal(t, int64(-5), mustMPTRaw(t, negated))
+	require.Equal(t, arithmeticMPTID, negated.MPTIssuanceID())
+}
+
+func TestAmountMPTArithmeticRejectsMismatchedIssuesAndOverflow(t *testing.T) {
+	a := NewMPTAmountWithIssuanceID(math.MaxInt64, "rIssuer", arithmeticMPTID)
+	b := NewMPTAmountWithIssuanceID(1, "rIssuer", arithmeticMPTID)
+	_, err := a.Add(b)
+	require.ErrorContains(t, err, "MPT addition overflow")
+
+	other := NewMPTAmountWithIssuanceID(1, "rIssuer", "00000005AE123A8556F3CF91154711376AFB0F894F832B3D")
+	_, err = b.Add(other)
+	require.ErrorContains(t, err, "different MPT issuances")
+	require.PanicsWithValue(t, "MPT value overflow", func() { _ = a.Mul(NewMPTAmountWithIssuanceID(2, "rIssuer", arithmeticMPTID), false) })
+}
+
+func TestAmountMPTMulRatioUsesIntegralDirectionalRounding(t *testing.T) {
+	a := NewMPTAmountWithIssuanceID(math.MaxInt64, "rIssuer", arithmeticMPTID)
+	require.Equal(t, int64(3_074_457_345_618_258_602), mustMPTRaw(t, a.MulRatio(1, 3, false)))
+	require.Equal(t, int64(3_074_457_345_618_258_603), mustMPTRaw(t, a.MulRatio(1, 3, true)))
+
+	negative := NewMPTAmountWithIssuanceID(-5, "rIssuer", arithmeticMPTID)
+	require.Equal(t, int64(-3), mustMPTRaw(t, negative.MulRatio(1, 2, false)))
+	require.Equal(t, int64(-2), mustMPTRaw(t, negative.MulRatio(1, 2, true)))
+}
+
+func TestAmountMPTMulPreservesIssue(t *testing.T) {
+	a := NewMPTAmountWithIssuanceID(7, "rIssuer", arithmeticMPTID)
+	b := NewMPTAmountWithIssuanceID(6, "rIssuer", arithmeticMPTID)
+	product := a.Mul(b, false)
+	require.Equal(t, int64(42), mustMPTRaw(t, product))
+	require.Equal(t, arithmeticMPTID, product.MPTIssuanceID())
+
+	previous := GetNumberSwitchover()
+	SetNumberSwitchover(true)
+	t.Cleanup(func() { SetNumberSwitchover(previous) })
+	half := NewIssuedAmountFromValue(5, -1, "", "")
+	scaled := a.Mul(half, false)
+	require.Equal(t, int64(4), mustMPTRaw(t, scaled))
+	require.Equal(t, arithmeticMPTID, scaled.MPTIssuanceID())
+}
+
+func TestAmountMPTMulAsIntegralOperand(t *testing.T) {
+	previous := GetNumberSwitchover()
+	t.Cleanup(func() { SetNumberSwitchover(previous) })
+
+	for _, switchover := range []bool{false, true} {
+		SetNumberSwitchover(switchover)
+		rate := NewIssuedAmountFromValue(100_000, 0, "", "")
+		mpt := NewMPTAmountWithIssuanceID(80, "rIssuer", arithmeticMPTID)
+		product := rate.Mul(mpt, false)
+		require.Equal(t, 0, product.Compare(NewIssuedAmountFromValue(8_000_000, 0, "", "")), "switchover=%v, product=%v", switchover, product.Float64())
+	}
+}
+
+func TestAmountMPTDivPreservesIntegralIssue(t *testing.T) {
+	previous := GetNumberSwitchover()
+	t.Cleanup(func() { SetNumberSwitchover(previous) })
+
+	for _, switchover := range []bool{false, true} {
+		SetNumberSwitchover(switchover)
+		amount := NewMPTAmountWithIssuanceID(100, "rIssuer", arithmeticMPTID)
+		quotient := amount.Div(NewXRPAmountFromInt(12), false)
+		require.Equal(t, int64(8), mustMPTRaw(t, quotient), "switchover=%v", switchover)
+		require.Equal(t, arithmeticMPTID, quotient.MPTIssuanceID())
+
+		zero := NewMPTAmountWithIssuanceID(0, "rIssuer", arithmeticMPTID).
+			Div(NewXRPAmountFromInt(12), false)
+		require.Zero(t, mustMPTRaw(t, zero))
+		require.Equal(t, arithmeticMPTID, zero.MPTIssuanceID())
+	}
+}
+
+func TestMPTRoundHelpersUseIntegralRounding(t *testing.T) {
+	mpt := NewMPTAmountWithIssuanceID(5, "rIssuer", arithmeticMPTID)
+	half := NewIssuedAmountFromValue(5, -1, "", "")
+	two := NewIssuedAmountFromValue(2, 0, "", "")
+
+	require.Equal(t, int64(3), MulRoundMPT(mpt, half, true))
+	require.Equal(t, int64(3), MulRoundMPTStrict(mpt, half, true))
+	require.Equal(t, int64(2), MulRoundMPTStrict(mpt, half, false))
+	require.Equal(t, int64(3), DivRoundMPT(mpt, two, true))
+	require.Equal(t, int64(2), DivRoundMPTStrict(mpt, two, false))
+}
+
+func mustMPTRaw(t *testing.T, amount Amount) int64 {
+	t.Helper()
+	value, ok := amount.MPTRaw()
+	require.True(t, ok)
+	return value
+}

--- a/internal/ledger/state/amount_round.go
+++ b/internal/ledger/state/amount_round.go
@@ -10,6 +10,8 @@ var (
 	bigTenTo17 = new(big.Int).SetUint64(100_000_000_000_000_000) // 10^17
 )
 
+const maxInt64Value uint64 = 1<<63 - 1
+
 // PrepareMulDivOperand returns the absolute mantissa and exponent of a,
 // normalizing native (XRP) amounts up into the IOU mantissa range
 // [10^15, 10^16). This is the per-operand preamble every mul/div round variant
@@ -94,7 +96,7 @@ func finalizeMPTRound(amount uint64, offset int, resultNegative, roundUp, addSlo
 		panic("MPT amount out of range")
 	}
 	for offset > 0 {
-		if amount > uint64(^uint64(0)>>1)/10 {
+		if amount > maxInt64Value/10 {
 			panic("MPT amount out of range")
 		}
 		amount *= 10
@@ -104,7 +106,7 @@ func finalizeMPTRound(amount uint64, offset int, resultNegative, roundUp, addSlo
 		amount /= 10
 		offset++
 	}
-	if amount > uint64(^uint64(0)>>1) {
+	if amount > maxInt64Value {
 		panic("MPT amount out of range")
 	}
 	if amount == 0 && roundUp && !resultNegative {
@@ -144,7 +146,7 @@ func canonicalizeIntegralRound(amount uint64, offset int, roundUp, strict bool) 
 
 func canonicalizeMPTNoRound(amount uint64, offset int, strict bool) uint64 {
 	if !strict && GetNumberSwitchover() {
-		if amount > uint64(^uint64(0)>>1) {
+		if amount > maxInt64Value {
 			panic("MPT amount out of range")
 		}
 		value := newXRPLNumberRaw(int64(amount), offset).ToInt64WithMode(RoundToNearest)
@@ -154,7 +156,7 @@ func canonicalizeMPTNoRound(amount uint64, offset int, strict bool) uint64 {
 		return uint64(value)
 	}
 	for offset > 0 {
-		if amount > uint64(^uint64(0)>>1)/10 {
+		if amount > maxInt64Value/10 {
 			panic("MPT amount out of range")
 		}
 		amount *= 10

--- a/internal/ledger/state/amount_round.go
+++ b/internal/ledger/state/amount_round.go
@@ -17,7 +17,7 @@ var (
 func PrepareMulDivOperand(a Amount) (mantissa int64, exponent int) {
 	mantissa = a.Mantissa()
 	exponent = a.Exponent()
-	if a.IsNative() {
+	if a.IsNative() || a.IsMPT() {
 		if mantissa < 0 {
 			mantissa = -mantissa
 		}
@@ -30,6 +30,141 @@ func PrepareMulDivOperand(a Amount) (mantissa int64, exponent int) {
 		mantissa = -mantissa
 	}
 	return mantissa, exponent
+}
+
+func MulRoundMPT(v1, v2 Amount, roundUp bool) int64 {
+	return mulRoundMPT(v1, v2, roundUp, false)
+}
+
+func MulRoundMPTStrict(v1, v2 Amount, roundUp bool) int64 {
+	return mulRoundMPT(v1, v2, roundUp, true)
+}
+
+func mulRoundMPT(v1, v2 Amount, roundUp, strict bool) int64 {
+	if v1.IsZero() || v2.IsZero() {
+		return 0
+	}
+	value1, offset1 := PrepareMulDivOperand(v1)
+	value2, offset2 := PrepareMulDivOperand(v2)
+	resultNegative := v1.IsNegative() != v2.IsNegative()
+	addSlop := resultNegative != roundUp
+	amount := MulMantissas(value1, value2, addSlop)
+	offset := offset1 + offset2 + 14
+	return finalizeMPTRound(amount, offset, resultNegative, roundUp, addSlop, strict, strict)
+}
+
+func DivRoundMPT(num, den Amount, roundUp bool) int64 {
+	return divRoundMPT(num, den, roundUp, false)
+}
+
+func DivRoundMPTStrict(num, den Amount, roundUp bool) int64 {
+	return divRoundMPT(num, den, roundUp, true)
+}
+
+func divRoundMPT(num, den Amount, roundUp, strict bool) int64 {
+	if den.IsZero() {
+		panic("division by zero")
+	}
+	if num.IsZero() {
+		return 0
+	}
+	numVal, numOffset := PrepareMulDivOperand(num)
+	denVal, denOffset := PrepareMulDivOperand(den)
+	resultNegative := num.IsNegative() != den.IsNegative()
+	addSlop := resultNegative != roundUp
+	amount := DivMantissas(numVal, denVal, addSlop)
+	offset := numOffset - denOffset - 17
+	return finalizeMPTRound(amount, offset, resultNegative, roundUp, addSlop, strict, false)
+}
+
+func finalizeMPTRound(amount uint64, offset int, resultNegative, roundUp, addSlop, strict, strictCanonicalize bool) int64 {
+	if amount == 0 || offset <= -20 {
+		if roundUp && !resultNegative {
+			return 1
+		}
+		return 0
+	}
+	if addSlop {
+		amount, offset = canonicalizeIntegralRound(amount, offset, roundUp, strictCanonicalize)
+	} else {
+		amount = canonicalizeMPTNoRound(amount, offset, strict)
+		offset = 0
+	}
+	if offset > 18 {
+		panic("MPT amount out of range")
+	}
+	for offset > 0 {
+		if amount > uint64(^uint64(0)>>1)/10 {
+			panic("MPT amount out of range")
+		}
+		amount *= 10
+		offset--
+	}
+	for offset < 0 {
+		amount /= 10
+		offset++
+	}
+	if amount > uint64(^uint64(0)>>1) {
+		panic("MPT amount out of range")
+	}
+	if amount == 0 && roundUp && !resultNegative {
+		amount = 1
+	}
+	value := int64(amount)
+	if resultNegative {
+		value = -value
+	}
+	return value
+}
+
+func canonicalizeIntegralRound(amount uint64, offset int, roundUp, strict bool) (uint64, int) {
+	if offset >= 0 {
+		return amount, offset
+	}
+	loops := 0
+	hadRemainder := false
+	for offset < -1 {
+		newAmount := amount / 10
+		hadRemainder = hadRemainder || amount != newAmount*10
+		amount = newAmount
+		offset++
+		loops++
+	}
+	adder := uint64(10)
+	if strict {
+		adder = 9
+		if hadRemainder && roundUp {
+			adder = 10
+		}
+	} else if loops >= 2 {
+		adder = 9
+	}
+	return (amount + adder) / 10, offset + 1
+}
+
+func canonicalizeMPTNoRound(amount uint64, offset int, strict bool) uint64 {
+	if !strict && GetNumberSwitchover() {
+		if amount > uint64(^uint64(0)>>1) {
+			panic("MPT amount out of range")
+		}
+		value := newXRPLNumberRaw(int64(amount), offset).ToInt64WithMode(RoundToNearest)
+		if value < 0 {
+			panic("MPT amount out of range")
+		}
+		return uint64(value)
+	}
+	for offset > 0 {
+		if amount > uint64(^uint64(0)>>1)/10 {
+			panic("MPT amount out of range")
+		}
+		amount *= 10
+		offset--
+	}
+	for offset < 0 {
+		amount /= 10
+		offset++
+	}
+	return amount
 }
 
 // muldivRound computes (x*y + slop) / divisor in exact big-integer arithmetic,

--- a/internal/ledger/state/amount_sqrt.go
+++ b/internal/ledger/state/amount_sqrt.go
@@ -6,12 +6,18 @@ func (a Amount) Mantissa() int64 {
 	if a.IsNative() {
 		return a.Drops()
 	}
+	if a.mptRaw != nil {
+		return *a.mptRaw
+	}
 	return a.iou.Mantissa()
 }
 
 // Exponent returns the exponent of the Amount (for IOU) or 0 (for XRP).
 func (a Amount) Exponent() int {
 	if a.IsNative() {
+		return 0
+	}
+	if a.mptRaw != nil {
 		return 0
 	}
 	return a.iou.Exponent()

--- a/internal/ledger/state/check_entry.go
+++ b/internal/ledger/state/check_entry.go
@@ -72,11 +72,19 @@ func ParseCheck(data []byte) (*CheckData, error) {
 
 		case stAmount:
 			if f.FieldCode == 9 { // SendMax
-				if len(f.Value) == 8 {
+				switch len(f.Value) {
+				case 8:
 					check.SendMax = xrpDrops(f.Value)
 					check.IsNativeSendMax = true
 					check.SendMaxAmount = NewXRPAmountFromInt(int64(check.SendMax))
-				} else if len(f.Value) == 48 {
+				case 33:
+					mptAmount, err := ParseMPTAmountBinary(f.Value)
+					if err != nil {
+						return fmt.Errorf("Check MPT SendMax parse failed: %w", err)
+					}
+					check.SendMaxAmount = mptAmount
+					check.IsNativeSendMax = false
+				case 48:
 					iouAmount, err := ParseIOUAmountBinary(f.Value)
 					if err != nil {
 						return err
@@ -129,6 +137,11 @@ func SerializeCheckFromData(check *CheckData) ([]byte, error) {
 	// Serialize SendMax
 	if check.IsNativeSendMax {
 		jsonObj["SendMax"] = fmt.Sprintf("%d", check.SendMax)
+	} else if check.SendMaxAmount.IsMPT() {
+		jsonObj["SendMax"] = map[string]any{
+			"value":           check.SendMaxAmount.Value(),
+			"mpt_issuance_id": check.SendMaxAmount.MPTIssuanceID(),
+		}
 	} else {
 		jsonObj["SendMax"] = map[string]any{
 			"value":    check.SendMaxAmount.Value(),

--- a/internal/ledger/state/check_entry_mpt_test.go
+++ b/internal/ledger/state/check_entry_mpt_test.go
@@ -1,0 +1,37 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckDataMPTokenSendMaxRoundTrip(t *testing.T) {
+	const issuanceID = "00000001ABCDEF0123456789ABCDEF0123456789ABCDEF12"
+	check := &CheckData{
+		Account:         [20]byte{1},
+		DestinationID:   [20]byte{2},
+		Sequence:        7,
+		OwnerNode:       3,
+		DestinationNode: 4,
+		HasDestNode:     true,
+		SendMaxAmount:   NewMPTAmountWithIssuanceID(9_223_372_036_854_775_000, "", issuanceID),
+		IsNativeSendMax: false,
+	}
+
+	encoded, err := SerializeCheckFromData(check)
+	require.NoError(t, err)
+
+	parsed, err := ParseCheck(encoded)
+	require.NoError(t, err)
+	require.False(t, parsed.IsNativeSendMax)
+	require.True(t, parsed.SendMaxAmount.IsMPT())
+	require.Equal(t, issuanceID, parsed.SendMaxAmount.MPTIssuanceID())
+	raw, ok := parsed.SendMaxAmount.MPTRaw()
+	require.True(t, ok)
+	require.Equal(t, int64(9_223_372_036_854_775_000), raw)
+
+	reencoded, err := SerializeCheckFromData(parsed)
+	require.NoError(t, err)
+	require.Equal(t, encoded, reencoded)
+}

--- a/internal/ledger/state/directory.go
+++ b/internal/ledger/state/directory.go
@@ -148,11 +148,17 @@ func GetRate(offerOut, offerIn Amount) (rate uint64) {
 }
 
 // rateMantissa returns the unsigned mantissa and exponent of a (non-zero)
-// amount for use in GetRate, lifting a native amount's drops into the IOU
+// amount for use in GetRate, lifting an integral amount into the IOU
 // mantissa band [10^15, 10^16) exactly as rippled's divide() does.
 func rateMantissa(a Amount) (uint64, int) {
-	if a.IsNative() {
-		v := uint64(a.Drops())
+	if a.IsNative() || a.IsMPT() {
+		m := a.Mantissa()
+		var v uint64
+		if m < 0 {
+			v = uint64(-(m + 1)) + 1
+		} else {
+			v = uint64(m)
+		}
 		offset := 0
 		for v < cMinValue && v > 0 {
 			v *= 10

--- a/internal/ledger/state/offer_entry.go
+++ b/internal/ledger/state/offer_entry.go
@@ -47,6 +47,12 @@ func SerializeLedgerOffer(offer *LedgerOffer) ([]byte, error) {
 		if amt.IsNative() {
 			return amt.Value()
 		}
+		if amt.IsMPT() {
+			return map[string]any{
+				"value":           amt.Value(),
+				"mpt_issuance_id": amt.MPTIssuanceID(),
+			}
+		}
 		return map[string]any{
 			"value":    amt.Value(),
 			"currency": amt.Currency,
@@ -146,6 +152,12 @@ func parseLedgerOffer(data []byte) (*LedgerOffer, error) {
 				a, err := ParseIOUAmountBinary(f.Value)
 				if err != nil {
 					return fmt.Errorf("Offer IOU amount (field %d) parse failed: %w", f.FieldCode, err)
+				}
+				amt = a
+			case 33: // MPT
+				a, err := ParseMPTAmountBinary(f.Value)
+				if err != nil {
+					return fmt.Errorf("Offer MPT amount (field %d) parse failed: %w", f.FieldCode, err)
 				}
 				amt = a
 			case 8: // XRP

--- a/internal/ledger/state/offer_entry_mpt_test.go
+++ b/internal/ledger/state/offer_entry_mpt_test.go
@@ -1,0 +1,37 @@
+package state
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLedgerOfferMPTAmountRoundTrip(t *testing.T) {
+	var issuer, owner [20]byte
+	copy(issuer[:], []byte("issuer12345678901234"))
+	copy(owner[:], []byte("owner123456789012345"))
+	id := keylet.MakeMPTID(7, issuer)
+	mptID := strings.ToUpper(hex.EncodeToString(id[:]))
+
+	offer := &LedgerOffer{
+		Account:       EncodeAccountIDSafe(owner),
+		Sequence:      9,
+		TakerPays:     NewMPTAmountWithIssuanceID(123, EncodeAccountIDSafe(issuer), mptID),
+		TakerGets:     NewXRPAmountFromInt(456),
+		BookDirectory: [32]byte{1, 2, 3},
+	}
+
+	raw, err := SerializeLedgerOffer(offer)
+	require.NoError(t, err)
+	parsed, err := ParseLedgerOffer(raw)
+	require.NoError(t, err)
+
+	value, ok := parsed.TakerPays.MPTRaw()
+	require.True(t, ok)
+	require.Equal(t, int64(123), value)
+	require.Equal(t, mptID, parsed.TakerPays.MPTIssuanceID())
+	require.Equal(t, int64(456), parsed.TakerGets.Drops())
+}

--- a/internal/peermanagement/resource/manager.go
+++ b/internal/peermanagement/resource/manager.go
@@ -71,8 +71,10 @@ type Manager struct {
 	entries map[key]*entry
 	imports map[string]*importRecord
 
-	stop chan struct{}
-	wg   sync.WaitGroup
+	stop     chan struct{}
+	stopped  bool
+	wg       sync.WaitGroup
+	stopOnce sync.Once
 }
 
 // NewManager returns a Manager that uses now() for its clock. If clock
@@ -98,41 +100,37 @@ func NewManager(clock Clock, journal *slog.Logger) *Manager {
 // called for clean shutdown.
 func (m *Manager) Start() {
 	m.mu.Lock()
-	if m.stop != nil {
+	if m.stopped || m.stop != nil {
 		m.mu.Unlock()
 		return
 	}
-	m.stop = make(chan struct{})
-	m.mu.Unlock()
-
+	stop := make(chan struct{})
+	m.stop = stop
 	m.wg.Add(1)
-	go m.run()
-}
-
-// Stop signals the periodic-activity goroutine to exit and blocks until it has.
-func (m *Manager) Stop() {
-	m.mu.Lock()
-	stop := m.stop
-	m.stop = nil
 	m.mu.Unlock()
-	if stop == nil {
-		return
-	}
-	close(stop)
-	m.wg.Wait()
+
+	go m.run(stop)
 }
 
-func (m *Manager) run() {
+// Stop permanently stops periodic activity and blocks until its goroutine exits.
+func (m *Manager) Stop() {
+	m.stopOnce.Do(func() {
+		m.mu.Lock()
+		m.stopped = true
+		stop := m.stop
+		m.mu.Unlock()
+		if stop != nil {
+			close(stop)
+		}
+		m.wg.Wait()
+	})
+}
+
+func (m *Manager) run(stop <-chan struct{}) {
 	defer m.wg.Done()
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	for {
-		m.mu.Lock()
-		stop := m.stop
-		m.mu.Unlock()
-		if stop == nil {
-			return
-		}
 		select {
 		case <-stop:
 			return

--- a/internal/peermanagement/resource/manager_test.go
+++ b/internal/peermanagement/resource/manager_test.go
@@ -247,6 +247,49 @@ func TestStartStop_Idempotent(t *testing.T) {
 	m.Stop() // second call is a no-op
 }
 
+func TestStartStop_Concurrent(t *testing.T) {
+	for range 200 {
+		m, _ := newTestManager()
+
+		started := make(chan struct{})
+		go func() {
+			m.Start()
+			close(started)
+		}()
+		m.Stop()
+		<-started
+
+		m.mu.Lock()
+		stop := m.stop
+		m.mu.Unlock()
+		leftRunning := false
+		if stop != nil {
+			select {
+			case <-stop:
+			default:
+				leftRunning = true
+				close(stop)
+			}
+		}
+		m.wg.Wait()
+		if leftRunning {
+			t.Fatal("concurrent Stop returned before a late Start was stopped")
+		}
+	}
+}
+
+func TestStartAfterStopIsNoop(t *testing.T) {
+	m, _ := newTestManager()
+	m.Stop()
+	m.Start()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.stop != nil {
+		t.Fatal("Start after Stop must not arm periodic activity")
+	}
+}
+
 // TestDrop_BlacklistAndReadmit mirrors rippled's testDrop second and
 // third blocks (Logic_test.cpp:158-196): after a Consumer is dropped,
 // reacquiring the same endpoint must show a Drop disposition (the

--- a/internal/rpc/events.go
+++ b/internal/rpc/events.go
@@ -237,9 +237,10 @@ type PathFindEvent struct {
 
 // PathAlternative represents a single path alternative
 type PathAlternative struct {
-	PathsCanonical [][]types.PathStep `json:"paths_canonical,omitempty"` // Canonical path representation
-	PathsComputed  [][]types.PathStep `json:"paths_computed,omitempty"`  // Computed paths
-	SourceAmount   json.RawMessage    `json:"source_amount"`             // Amount to send
+	DestinationAmount json.RawMessage    `json:"destination_amount,omitempty"`
+	PathsCanonical    [][]types.PathStep `json:"paths_canonical,omitempty"` // Canonical path representation
+	PathsComputed     [][]types.PathStep `json:"paths_computed,omitempty"`  // Computed paths
+	SourceAmount      json.RawMessage    `json:"source_amount"`             // Amount to send
 }
 
 // ProposedTransactionEvent represents a proposed (unvalidated) transaction

--- a/internal/rpc/handlers/book_changes.go
+++ b/internal/rpc/handlers/book_changes.go
@@ -4,9 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"math"
 	"math/big"
-	"strconv"
 	"strings"
 
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -19,14 +17,16 @@ type BookChangesMethod struct{ BaseHandler }
 
 // bookChange tracks OHLCV data for a single currency pair
 type bookChange struct {
-	CurrencyA string
-	CurrencyB string
-	VolumeA   *big.Float
-	VolumeB   *big.Float
-	High      *big.Float
-	Low       *big.Float
-	Open      *big.Float
-	Close     *big.Float
+	CurrencyA      string
+	CurrencyB      string
+	MPTIssuanceIDA string
+	MPTIssuanceIDB string
+	VolumeA        *big.Float
+	VolumeB        *big.Float
+	High           *big.Float
+	Low            *big.Float
+	Open           *big.Float
+	Close          *big.Float
 }
 
 // LedgerWithTransactions is the minimal ledger surface the
@@ -59,16 +59,25 @@ func ComputeBookChanges(l LedgerWithTransactions) map[string]any {
 	changes := collectBookChanges(l)
 	changesArr := make([]map[string]any, 0, len(changes))
 	for _, bc := range changes {
-		changesArr = append(changesArr, map[string]any{
-			"currency_a": bc.CurrencyA,
-			"currency_b": bc.CurrencyB,
-			"volume_a":   formatBigFloat(bc.VolumeA),
-			"volume_b":   formatBigFloat(bc.VolumeB),
-			"high":       formatBigFloat(bc.High),
-			"low":        formatBigFloat(bc.Low),
-			"open":       formatBigFloat(bc.Open),
-			"close":      formatBigFloat(bc.Close),
-		})
+		change := map[string]any{
+			"volume_a": formatBigFloat(bc.VolumeA),
+			"volume_b": formatBigFloat(bc.VolumeB),
+			"high":     formatBigFloat(bc.High),
+			"low":      formatBigFloat(bc.Low),
+			"open":     formatBigFloat(bc.Open),
+			"close":    formatBigFloat(bc.Close),
+		}
+		if bc.MPTIssuanceIDA != "" {
+			change["mpt_issuance_id_a"] = bc.MPTIssuanceIDA
+		} else {
+			change["currency_a"] = bc.CurrencyA
+		}
+		if bc.MPTIssuanceIDB != "" {
+			change["mpt_issuance_id_b"] = bc.MPTIssuanceIDB
+		} else {
+			change["currency_b"] = bc.CurrencyB
+		}
+		changesArr = append(changesArr, change)
 	}
 	ledgerHash := l.Hash()
 	return map[string]any{
@@ -236,26 +245,32 @@ func collectBookChanges(targetLedger LedgerWithTransactions) map[string]*bookCha
 			absSecond := new(big.Float).Abs(second)
 
 			// Determine currency labels for output
-			var currA, currB string
+			var currA, currB, mptA, mptB string
 			if noswap {
 				currA = g
 				currB = p
+				mptA = finalGets.mptIssuanceID
+				mptB = finalPays.mptIssuanceID
 			} else {
 				currA = p
 				currB = g
+				mptA = finalPays.mptIssuanceID
+				mptB = finalGets.mptIssuanceID
 			}
 
 			bc, exists := changes[pairKey]
 			if !exists {
 				bc = &bookChange{
-					CurrencyA: currA,
-					CurrencyB: currB,
-					VolumeA:   new(big.Float),
-					VolumeB:   new(big.Float),
-					Open:      new(big.Float).Set(rate),
-					High:      new(big.Float).Set(rate),
-					Low:       new(big.Float).Set(rate),
-					Close:     new(big.Float).Set(rate),
+					CurrencyA:      currA,
+					CurrencyB:      currB,
+					MPTIssuanceIDA: mptA,
+					MPTIssuanceIDB: mptB,
+					VolumeA:        new(big.Float),
+					VolumeB:        new(big.Float),
+					Open:           new(big.Float).Set(rate),
+					High:           new(big.Float).Set(rate),
+					Low:            new(big.Float).Set(rate),
+					Close:          new(big.Float).Set(rate),
 				}
 				changes[pairKey] = bc
 			} else {
@@ -281,10 +296,11 @@ func collectBookChanges(targetLedger LedgerWithTransactions) map[string]*bookCha
 
 // parsedAmount holds a parsed amount with its currency info
 type parsedAmount struct {
-	value    *big.Float
-	currency string
-	issuer   string
-	isXRP    bool
+	value         *big.Float
+	currency      string
+	issuer        string
+	mptIssuanceID string
+	isXRP         bool
 }
 
 // parseAmount parses an XRPL amount (string for XRP drops, object for IOU)
@@ -319,6 +335,10 @@ func parseAmount(raw any) *parsedAmount {
 		}
 		currency, _ := v["currency"].(string)
 		issuer, _ := v["issuer"].(string)
+		mptIssuanceID, _ := v["mpt_issuance_id"].(string)
+		if mptIssuanceID != "" {
+			return &parsedAmount{value: val, mptIssuanceID: strings.ToUpper(mptIssuanceID)}
+		}
 		return &parsedAmount{value: val, currency: currency, issuer: issuer}
 	}
 
@@ -329,6 +349,9 @@ func parseAmount(raw any) *parsedAmount {
 func formatCurrencyKey(amt *parsedAmount) string {
 	if amt.isXRP {
 		return "XRP_drops"
+	}
+	if amt.mptIssuanceID != "" {
+		return amt.mptIssuanceID
 	}
 	if amt.issuer != "" {
 		return fmt.Sprintf("%s.%s", amt.currency, amt.issuer)
@@ -344,8 +367,8 @@ func formatBigFloat(f *big.Float) string {
 	if f == nil {
 		return "0"
 	}
-	if f64, _ := f.Float64(); f64 == math.Trunc(f64) && !math.IsInf(f64, 0) {
-		return strconv.FormatInt(int64(f64), 10)
+	if integer, accuracy := f.Int(nil); accuracy == big.Exact {
+		return integer.String()
 	}
 	return f.Text('f', 16)
 }

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
@@ -71,31 +72,37 @@ func (m *BookOffersMethod) Handle(ctx *types.RPCContext, params json.RawMessage)
 	paysInner := unmarshalObjectOrNull(paysRaw)
 	getsInner := unmarshalObjectOrNull(getsRaw)
 
-	paysCurrency, rpcErr := readJSONString(paysInner, "currency", "taker_pays.currency")
+	if rpcErr := validateTakerBookJSON(paysInner, "taker_pays"); rpcErr != nil {
+		return nil, rpcErr
+	}
+	if rpcErr := validateTakerBookJSON(getsInner, "taker_gets"); rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	takerPays, paysIssuerID, rpcErr := parseTakerBookAsset(paysInner, true)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
-	getsCurrency, rpcErr := readJSONString(getsInner, "currency", "taker_gets.currency")
+	takerGets, getsIssuerID, rpcErr := parseTakerBookAsset(getsInner, false)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
 
-	if !keylet.IsValidCurrencyCode(paysCurrency) {
-		return nil, types.RPCErrorSrcCurMalformed(
-			"Invalid field 'taker_pays.currency', bad currency.")
+	if !takerPays.IsMPT() {
+		issuer, issuerID, issuerErr := readAndValidateIssuer(paysInner, takerPays.Currency, true)
+		if issuerErr != nil {
+			return nil, issuerErr
+		}
+		takerPays.Issuer = canonIssuerString(issuer, takerPays.Currency)
+		paysIssuerID = issuerID
 	}
-	if !keylet.IsValidCurrencyCode(getsCurrency) {
-		return nil, types.RPCErrorDstAmtMalformed(
-			"Invalid field 'taker_gets.currency', bad currency.")
-	}
-
-	paysIssuerStr, paysIssuerID, rpcErr := readAndValidateIssuer(paysInner, paysCurrency, true)
-	if rpcErr != nil {
-		return nil, rpcErr
-	}
-	getsIssuerStr, getsIssuerID, rpcErr := readAndValidateIssuer(getsInner, getsCurrency, false)
-	if rpcErr != nil {
-		return nil, rpcErr
+	if !takerGets.IsMPT() {
+		issuer, issuerID, issuerErr := readAndValidateIssuer(getsInner, takerGets.Currency, false)
+		if issuerErr != nil {
+			return nil, issuerErr
+		}
+		takerGets.Issuer = canonIssuerString(issuer, takerGets.Currency)
+		getsIssuerID = issuerID
 	}
 
 	// taker (BookOffers.cpp:164-173).
@@ -140,7 +147,7 @@ func (m *BookOffersMethod) Handle(ctx *types.RPCContext, params json.RawMessage)
 	// bad market (BookOffers.cpp:191-195). Compare canonical forms: XRP
 	// currency normalizes to zero, issuers normalize to their decoded
 	// 20-byte AccountIDs (any valid encoding of the same account collides).
-	if canonCurrency(paysCurrency) == canonCurrency(getsCurrency) && paysIssuerID == getsIssuerID {
+	if sameBookAsset(takerPays, paysIssuerID, takerGets, getsIssuerID) {
 		return nil, types.RPCErrorBadMarket()
 	}
 
@@ -204,9 +211,6 @@ func (m *BookOffersMethod) Handle(ctx *types.RPCContext, params json.RawMessage)
 		return nil, selErr
 	}
 
-	takerPays := types.Amount{Currency: paysCurrency, Issuer: canonIssuerString(paysIssuerStr, paysCurrency)}
-	takerGets := types.Amount{Currency: getsCurrency, Issuer: canonIssuerString(getsIssuerStr, getsCurrency)}
-
 	// marker is a go-xrpl extension. rippled's handler (BookOffers.cpp:201-214)
 	// reads `marker` from params and threads it through to getBookPage, but
 	// NetworkOPsImp::getBookPage doesn't actually use it (NetworkOPs.cpp:4627
@@ -258,6 +262,81 @@ func (m *BookOffersMethod) Handle(ctx *types.RPCContext, params json.RawMessage)
 		response["limit"] = limit
 	}
 	return response, nil
+}
+
+func validateTakerBookJSON(inner map[string]json.RawMessage, name string) *types.RPCError {
+	_, hasCurrency := inner["currency"]
+	_, hasMPT := inner["mpt_issuance_id"]
+	if !hasCurrency && !hasMPT {
+		return types.RPCErrorMissingField(name + ".currency")
+	}
+	if hasMPT {
+		if hasCurrency {
+			return types.RPCErrorInvalidField(name)
+		}
+		if _, hasIssuer := inner["issuer"]; hasIssuer {
+			return types.RPCErrorInvalidField(name)
+		}
+	}
+	if raw, ok := inner["currency"]; ok && !isJSONString(raw) {
+		return types.RPCErrorExpectedField(name+".currency", "string")
+	}
+	if raw, ok := inner["mpt_issuance_id"]; ok && !isJSONString(raw) {
+		return types.RPCErrorExpectedField(name+".currency", "string")
+	}
+	return nil
+}
+
+func parseTakerBookAsset(inner map[string]json.RawMessage, isPay bool) (types.Amount, [20]byte, *types.RPCError) {
+	if raw, ok := inner["currency"]; ok {
+		var currency string
+		_ = json.Unmarshal(raw, &currency)
+		if !keylet.IsValidCurrencyCode(currency) {
+			if isPay {
+				return types.Amount{}, [20]byte{}, types.RPCErrorSrcCurMalformed(
+					"Invalid field 'taker_pays.currency', bad currency.")
+			}
+			return types.Amount{}, [20]byte{}, types.RPCErrorDstAmtMalformed(
+				"Invalid field 'taker_gets.currency', bad currency.")
+		}
+		return types.Amount{Currency: currency}, [20]byte{}, nil
+	}
+
+	var value string
+	_ = json.Unmarshal(inner["mpt_issuance_id"], &value)
+	id, ok := parseBookMPTID(value)
+	if !ok {
+		field := "taker_gets.mpt_issuance_id"
+		makeErr := types.RPCErrorDstAmtMalformed
+		if isPay {
+			field = "taker_pays.mpt_issuance_id"
+			makeErr = types.RPCErrorSrcCurMalformed
+		}
+		return types.Amount{}, [20]byte{}, makeErr(fmt.Sprintf("Invalid field '%s'", field))
+	}
+	var issuer [20]byte
+	copy(issuer[:], id[4:])
+	return types.Amount{MPTIssuanceID: strings.ToUpper(hex.EncodeToString(id[:]))}, issuer, nil
+}
+
+func parseBookMPTID(value string) ([24]byte, bool) {
+	var id [24]byte
+	if value == "0" {
+		return id, true
+	}
+	b, err := hex.DecodeString(value)
+	if err != nil || len(b) != len(id) {
+		return id, false
+	}
+	copy(id[:], b)
+	return id, true
+}
+
+func sameBookAsset(a types.Amount, aIssuer [20]byte, b types.Amount, bIssuer [20]byte) bool {
+	if a.IsMPT() || b.IsMPT() {
+		return a.IsMPT() && b.IsMPT() && strings.EqualFold(a.MPTIssuanceID, b.MPTIssuanceID)
+	}
+	return canonCurrency(a.Currency) == canonCurrency(b.Currency) && aIssuer == bIssuer
 }
 
 // readAndValidateIssuer decodes the issuer field for one side of the book and
@@ -326,23 +405,6 @@ func canonIssuerString(issuer, currency string) string {
 		return ""
 	}
 	return issuer
-}
-
-// readJSONString extracts a required string field from a sub-object, returning
-// rippled-shaped "Missing field" / "Invalid field, not string." errors.
-func readJSONString(inner map[string]json.RawMessage, key, fieldPath string) (string, *types.RPCError) {
-	raw, ok := inner[key]
-	if !ok {
-		return "", types.RPCErrorMissingField(fieldPath)
-	}
-	if !isJSONString(raw) {
-		return "", types.RPCErrorExpectedField(fieldPath, "string")
-	}
-	var s string
-	if err := json.Unmarshal(raw, &s); err != nil {
-		return "", types.RPCErrorExpectedField(fieldPath, "string")
-	}
-	return s, nil
 }
 
 // preValidateUintField inspects the probed JSON for a numeric field that

--- a/internal/rpc/handlers/mpt_rpc_test.go
+++ b/internal/rpc/handlers/mpt_rpc_test.go
@@ -1,0 +1,198 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/stretchr/testify/require"
+)
+
+const rpcMPTID = "00000004AE123A8556F3CF91154711376AFB0F894F832B3D"
+
+func TestBookOffersMPTAssetParsing(t *testing.T) {
+	inner := map[string]json.RawMessage{
+		"mpt_issuance_id": json.RawMessage(`"00000004ae123a8556f3cf91154711376afb0f894f832b3d"`),
+	}
+	require.Nil(t, validateTakerBookJSON(inner, "taker_pays"))
+
+	amount, issuer, rpcErr := parseTakerBookAsset(inner, true)
+	require.Nil(t, rpcErr)
+	require.True(t, amount.IsMPT())
+	require.Equal(t, rpcMPTID, amount.MPTIssuanceID)
+	id, err := mptutil.DecodeID(rpcMPTID)
+	require.NoError(t, err)
+	require.Equal(t, mptutil.Issuer(id), issuer)
+
+	other := amount
+	require.True(t, sameBookAsset(amount, issuer, other, issuer))
+	other.MPTIssuanceID = "00000005AE123A8556F3CF91154711376AFB0F894F832B3D"
+	require.False(t, sameBookAsset(amount, issuer, other, issuer))
+}
+
+func TestBookOffersMPTValidation(t *testing.T) {
+	for _, inner := range []map[string]json.RawMessage{
+		{
+			"currency":        json.RawMessage(`"USD"`),
+			"mpt_issuance_id": json.RawMessage(`"` + rpcMPTID + `"`),
+		},
+		{
+			"issuer":          json.RawMessage(`"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"`),
+			"mpt_issuance_id": json.RawMessage(`"` + rpcMPTID + `"`),
+		},
+	} {
+		rpcErr := validateTakerBookJSON(inner, "taker_pays")
+		require.NotNil(t, rpcErr)
+		require.Equal(t, "Invalid field 'taker_pays'.", rpcErr.Message)
+	}
+
+	_, _, rpcErr := parseTakerBookAsset(map[string]json.RawMessage{
+		"mpt_issuance_id": json.RawMessage(`"bad"`),
+	}, true)
+	require.NotNil(t, rpcErr)
+	require.Equal(t, "srcCurMalformed", rpcErr.ErrorString)
+}
+
+func TestPathFindMPTSourceAndFormatting(t *testing.T) {
+	probe := map[string]json.RawMessage{
+		"source_currencies": json.RawMessage(`[{"mpt_issuance_id":"` + rpcMPTID + `"}]`),
+	}
+	issues, rpcErr := parseSourceCurrencies(probe, [20]byte{1}, nil)
+	require.Nil(t, rpcErr)
+	require.Len(t, issues, 1)
+	id, err := mptutil.DecodeID(rpcMPTID)
+	require.NoError(t, err)
+	require.True(t, issues[0].Equal(payment.NewMPTIssue(id)))
+
+	formatted := formatAmountJSON(state.NewMPTAmountWithIssuanceID(25, "", rpcMPTID))
+	require.Equal(t, map[string]string{
+		"mpt_issuance_id": rpcMPTID,
+		"value":           "25",
+	}, formatted)
+}
+
+func TestPathFindMPTSourceRejectsConflictingMembers(t *testing.T) {
+	for _, sourceCurrencies := range []string{
+		`[{"mpt_issuance_id":"` + rpcMPTID + `","currency":null}]`,
+		`[{"mpt_issuance_id":"` + rpcMPTID + `","issuer":null}]`,
+	} {
+		_, rpcErr := parseSourceCurrencies(map[string]json.RawMessage{
+			"source_currencies": json.RawMessage(sourceCurrencies),
+		}, [20]byte{1}, nil)
+		require.NotNil(t, rpcErr)
+		require.Equal(t, "srcCurMalformed", rpcErr.ErrorString)
+	}
+}
+
+func TestBookChangesMPTAmountParsing(t *testing.T) {
+	amount := parseAmount(map[string]any{
+		"mpt_issuance_id": "00000004ae123a8556f3cf91154711376afb0f894f832b3d",
+		"value":           "50",
+	})
+	require.NotNil(t, amount)
+	require.Equal(t, rpcMPTID, amount.mptIssuanceID)
+	require.Equal(t, rpcMPTID, formatCurrencyKey(amount))
+}
+
+func TestComputeBookChangesEmitsMPTAsset(t *testing.T) {
+	blob, err := json.Marshal(StoredTransaction{
+		TxJSON: map[string]any{"TransactionType": "Payment"},
+		Meta: map[string]any{
+			"AffectedNodes": []any{
+				map[string]any{
+					"ModifiedNode": map[string]any{
+						"LedgerEntryType": "Offer",
+						"PreviousFields": map[string]any{
+							"TakerGets": map[string]any{"mpt_issuance_id": rpcMPTID, "value": "100"},
+							"TakerPays": "10000000",
+						},
+						"FinalFields": map[string]any{
+							"TakerGets": map[string]any{"mpt_issuance_id": rpcMPTID, "value": "40"},
+							"TakerPays": "4000000",
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	result := ComputeBookChanges(mptBookChangesLedger{blob: blob})
+	changes, ok := result["changes"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, changes, 1)
+	require.Equal(t, "XRP_drops", changes[0]["currency_a"])
+	require.Equal(t, rpcMPTID, changes[0]["mpt_issuance_id_b"])
+	require.NotContains(t, changes[0], "currency_b")
+}
+
+func TestComputeBookChangesPreservesLargeMPTVolumeAndRate(t *testing.T) {
+	const aboveFloat64IntegerPrecision = "9007199254740993"
+
+	change := computeMPTBookChange(t, aboveFloat64IntegerPrecision, "1")
+	require.Equal(t, aboveFloat64IntegerPrecision, change["volume_a"])
+	require.Equal(t, "1", change["volume_b"])
+	for _, field := range []string{"high", "low", "open", "close"} {
+		require.Equal(t, aboveFloat64IntegerPrecision, change[field], field)
+	}
+}
+
+func TestComputeBookChangesPreservesMaxInt64MPTVolume(t *testing.T) {
+	const maxMPTAmount = "9223372036854775807"
+
+	change := computeMPTBookChange(t, maxMPTAmount, maxMPTAmount)
+	require.Equal(t, maxMPTAmount, change["volume_a"])
+	require.Equal(t, maxMPTAmount, change["volume_b"])
+	for _, field := range []string{"high", "low", "open", "close"} {
+		require.Equal(t, "1", change[field], field)
+	}
+}
+
+func computeMPTBookChange(t *testing.T, takerGets, takerPays string) map[string]any {
+	t.Helper()
+	const otherMPTID = "00000005AE123A8556F3CF91154711376AFB0F894F832B3D"
+
+	blob, err := json.Marshal(StoredTransaction{
+		TxJSON: map[string]any{"TransactionType": "Payment"},
+		Meta: map[string]any{
+			"AffectedNodes": []any{
+				map[string]any{
+					"ModifiedNode": map[string]any{
+						"LedgerEntryType": "Offer",
+						"PreviousFields": map[string]any{
+							"TakerGets": map[string]any{"mpt_issuance_id": rpcMPTID, "value": takerGets},
+							"TakerPays": map[string]any{"mpt_issuance_id": otherMPTID, "value": takerPays},
+						},
+						"FinalFields": map[string]any{
+							"TakerGets": map[string]any{"mpt_issuance_id": rpcMPTID, "value": "0"},
+							"TakerPays": map[string]any{"mpt_issuance_id": otherMPTID, "value": "0"},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	result := ComputeBookChanges(mptBookChangesLedger{blob: blob})
+	changes, ok := result["changes"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, changes, 1)
+	require.Equal(t, rpcMPTID, changes[0]["mpt_issuance_id_a"])
+	require.Equal(t, otherMPTID, changes[0]["mpt_issuance_id_b"])
+	return changes[0]
+}
+
+type mptBookChangesLedger struct{ blob []byte }
+
+func (l mptBookChangesLedger) ForEachTransaction(fn func([32]byte, []byte) bool) error {
+	fn([32]byte{1}, l.blob)
+	return nil
+}
+
+func (mptBookChangesLedger) Sequence() uint32  { return 1 }
+func (mptBookChangesLedger) Hash() [32]byte    { return [32]byte{2} }
+func (mptBookChangesLedger) CloseTime() int64  { return 3 }
+func (mptBookChangesLedger) IsValidated() bool { return true }

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -88,11 +88,8 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RPCContext, params json.RawMess
 		return nil, types.RPCErrorDstActMalformed("Destination account is malformed.")
 	}
 
-	// MPT amounts parse (rippled accepts them at this layer too), but the
-	// pathfinder has no MPT support, so they are rejected as malformed
-	// rather than silently producing meaningless paths.
 	dstAmount, err := state.AmountFromJSON(rawDstAmount)
-	if err != nil || dstAmount.IsMPT() {
+	if err != nil || !pathfinder.IsValidAsset(dstAmount) {
 		return nil, types.RPCErrorDstAmtMalformed("Destination amount/currency/issuer is malformed.")
 	}
 
@@ -110,7 +107,7 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RPCContext, params json.RawMess
 			return nil, types.RPCErrorDstAmtMalformed("Destination amount/currency/issuer is malformed.")
 		}
 		amt, smErr := state.AmountFromJSON(rawSendMax)
-		if smErr != nil || amt.IsMPT() || (amt.Signum() <= 0 && amt.Value() != "-1") {
+		if smErr != nil || !pathfinder.IsValidAsset(amt) || (amt.Signum() <= 0 && amt.Value() != "-1") {
 			return nil, types.RPCErrorSendMaxMalformed("SendMax amount malformed.")
 		}
 		sendMax = &amt
@@ -275,14 +272,9 @@ func parseSourceCurrencies(
 		return nil, types.RPCErrorSrcCurMalformed("Source currency is malformed.")
 	}
 
-	var sendMaxCurrency string
-	var sendMaxIssuer [20]byte
+	var sendMaxIssue payment.Issue
 	if sendMax != nil {
-		sendMaxCurrency = "XRP"
-		if !sendMax.IsNative() {
-			sendMaxCurrency = sendMax.Currency
-			sendMaxIssuer, _ = state.DecodeAccountID(sendMax.Issuer)
-		}
+		sendMaxIssue = payment.GetIssue(*sendMax)
 	}
 
 	var srcCurrencies []payment.Issue
@@ -295,20 +287,50 @@ func parseSourceCurrencies(
 	}
 
 	for _, raw := range entries {
-		var sc struct {
-			Currency *string         `json:"currency"`
-			Issuer   json.RawMessage `json:"issuer"`
-		}
-		if err := json.Unmarshal(raw, &sc); err != nil || sc.Currency == nil || !keylet.IsValidCurrencyCode(*sc.Currency) {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &fields); err != nil {
 			return nil, types.RPCErrorSrcCurMalformed("Source currency is malformed.")
 		}
-		currency := canonCurrency(*sc.Currency)
+		rawCurrency, hasCurrency := fields["currency"]
+		rawMPT, hasMPT := fields["mpt_issuance_id"]
+		if hasCurrency == hasMPT {
+			return nil, types.RPCErrorSrcCurMalformed("Source currency is malformed.")
+		}
+		if hasMPT {
+			if _, hasIssuer := fields["issuer"]; hasIssuer {
+				return nil, types.RPCErrorSrcCurMalformed("Source currency is malformed.")
+			}
+			var mptID string
+			if err := json.Unmarshal(rawMPT, &mptID); err != nil {
+				return nil, types.RPCErrorSrcCurMalformed("Source currency is malformed.")
+			}
+			id, ok := pathfinder.ParseSourceMPTID(mptID)
+			if !ok {
+				return nil, types.RPCErrorSrcCurMalformed("Source currency is malformed.")
+			}
+			issue := payment.NewMPTIssue(id)
+			if sendMax != nil {
+				if !issue.Equal(sendMaxIssue) {
+					continue
+				}
+				if sendMaxIssue.Issuer != srcAccount {
+					return nil, types.RPCErrorSrcIsrMalformed("Source issuer is malformed.")
+				}
+			}
+			add(issue)
+			continue
+		}
+		var currencyValue string
+		if err := json.Unmarshal(rawCurrency, &currencyValue); err != nil || !keylet.IsValidCurrencyCode(currencyValue) {
+			return nil, types.RPCErrorSrcCurMalformed("Source currency is malformed.")
+		}
+		currency := canonCurrency(currencyValue)
 		isXRPCur := currency == "XRP"
 
 		var issuerID [20]byte
-		if sc.Issuer != nil && !isJSONNull(sc.Issuer) {
+		if rawIssuer, hasIssuer := fields["issuer"]; hasIssuer {
 			var issuerStr string
-			if err := json.Unmarshal(sc.Issuer, &issuerStr); err != nil {
+			if err := json.Unmarshal(rawIssuer, &issuerStr); err != nil {
 				return nil, types.RPCErrorSrcIsrMalformed("Source issuer is malformed.")
 			}
 			id, err := state.DecodeAccountID(issuerStr)
@@ -328,20 +350,20 @@ func parseSourceCurrencies(
 
 		if sendMax != nil {
 			// If the currencies don't match, ignore the source currency.
-			if currency != canonCurrency(sendMaxCurrency) {
+			if sendMaxIssue.IsMPT || currency != canonCurrency(sendMaxIssue.Currency) {
 				continue
 			}
 			// If neither issuer is the source and they are not equal, the
 			// source issuer is illegal.
-			if issuerID != srcAccount && sendMaxIssuer != srcAccount && issuerID != sendMaxIssuer {
+			if issuerID != srcAccount && sendMaxIssue.Issuer != srcAccount && issuerID != sendMaxIssue.Issuer {
 				return nil, types.RPCErrorSrcIsrMalformed("Source issuer is malformed.")
 			}
 			// If both are the source, use the source; otherwise use the one
 			// that's not the source.
 			if issuerID != srcAccount {
 				add(payment.Issue{Currency: currency, Issuer: issuerID})
-			} else if sendMaxIssuer != srcAccount {
-				add(payment.Issue{Currency: currency, Issuer: sendMaxIssuer})
+			} else if sendMaxIssue.Issuer != srcAccount {
+				add(payment.Issue{Currency: currency, Issuer: sendMaxIssue.Issuer})
 			} else {
 				add(payment.Issue{Currency: currency, Issuer: srcAccount})
 			}
@@ -454,6 +476,12 @@ func resolvePathFindLedger(
 func formatAmountJSON(amt state.Amount) any {
 	if amt.IsNative() {
 		return amt.Value()
+	}
+	if amt.IsMPT() {
+		return map[string]string{
+			"mpt_issuance_id": amt.MPTIssuanceID(),
+			"value":           amt.Value(),
+		}
 	}
 	return map[string]string{
 		"currency": amt.Currency,

--- a/internal/rpc/handlers/ripple_path_find_mpt_test.go
+++ b/internal/rpc/handlers/ripple_path_find_mpt_test.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRipplePathFindRejectsMPTWithZeroIssuer(t *testing.T) {
+	const (
+		acct  = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+		badID = "000000010000000000000000000000000000000000000000"
+	)
+	badAmount := `{"mpt_issuance_id":"` + badID + `","value":"10"}`
+
+	tests := []struct {
+		name   string
+		params json.RawMessage
+		token  string
+	}{
+		{
+			name: "destination_amount",
+			params: json.RawMessage(`{"source_account":"` + acct +
+				`","destination_account":"` + acct +
+				`","destination_amount":` + badAmount + `}`),
+			token: "dstAmtMalformed",
+		},
+		{
+			name: "send_max",
+			params: json.RawMessage(`{"source_account":"` + acct +
+				`","destination_account":"` + acct +
+				`","destination_amount":"-1","send_max":` + badAmount + `}`),
+			token: "sendMaxMalformed",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, rpcErr := (&RipplePathFindMethod{}).Handle(&types.RPCContext{}, test.params)
+			require.NotNil(t, rpcErr)
+			require.Equal(t, test.token, rpcErr.ErrorString)
+		})
+	}
+}
+
+func TestParseSourceCurrenciesMPTSendMaxIssuerReconciliation(t *testing.T) {
+	var issuer, holder [20]byte
+	issuer[19] = 1
+	holder[19] = 2
+	id := keylet.MakeMPTID(1, issuer)
+	idString := mptutil.EncodeID(id)
+	sendMax := state.NewMPTAmountWithIssuanceID(10, state.EncodeAccountIDSafe(issuer), idString)
+	probe := map[string]json.RawMessage{
+		"source_currencies": json.RawMessage(`[{"mpt_issuance_id":"` + idString + `"}]`),
+	}
+
+	_, rpcErr := parseSourceCurrencies(probe, holder, &sendMax)
+	require.NotNil(t, rpcErr)
+	require.Equal(t, "srcIsrMalformed", rpcErr.ErrorString)
+
+	issues, rpcErr := parseSourceCurrencies(probe, issuer, &sendMax)
+	require.Nil(t, rpcErr)
+	require.Len(t, issues, 1)
+	require.Equal(t, id, issues[0].MPTID)
+}
+
+func TestParseSourceCurrenciesAcceptsZeroMPTLiteral(t *testing.T) {
+	probe := map[string]json.RawMessage{
+		"source_currencies": json.RawMessage(`[{"mpt_issuance_id":"0"}]`),
+	}
+
+	issues, rpcErr := parseSourceCurrencies(probe, [20]byte{1}, nil)
+	require.Nil(t, rpcErr)
+	require.Len(t, issues, 1)
+	require.True(t, issues[0].IsMPT)
+	require.Equal(t, [24]byte{}, issues[0].MPTID)
+}

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -231,10 +231,9 @@ func (m *SimulateMethod) Handle(ctx *types.RPCContext, params json.RawMessage) (
 	// STTx ctor parity — rippled Simulate.cpp:332-343. A parse failure or
 	// missing-required-field surface as
 	// `error: "invalidTransaction"` + `error_exception: <reason>`
-	// instead of flowing into the engine as a TER. The duplicate
-	// Validate() vs the engine's own Validate is intentional: it
-	// guarantees the error envelope shape matches rippled even when the
-	// underlying message text differs.
+	// instead of flowing into the engine as a TER. This early structural
+	// validation guarantees the error envelope shape matches rippled even
+	// when type-specific engine preflight is rules-aware.
 	parsedTx, parseErr := tx.ParseJSON(txJSON)
 	if parseErr != nil {
 		return nil, types.RPCErrorInvalidTransaction(parseErr.Error())

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -12,9 +12,11 @@ import (
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
@@ -429,17 +431,13 @@ func (a *LedgerServiceAdapter) GetAccountOffers(ctx context.Context, account str
 
 // GetBookOffers retrieves offers from an order book
 func (a *LedgerServiceAdapter) GetBookOffers(ctx context.Context, takerGets, takerPays types.Amount, taker, domain string, ledgerIndex string, limit uint32, marker string, withProofs bool) (*types.BookOffersResult, error) {
-	// Convert RPC types.Amount to tx.Amount
-	var txTakerGets, txTakerPays tx.Amount
-	if takerGets.Currency == "" || takerGets.Currency == "XRP" {
-		txTakerGets = tx.NewXRPAmount(0) // Placeholder - book offers query uses currency/issuer only
-	} else {
-		txTakerGets = tx.NewIssuedAmountFromFloat64(0, takerGets.Currency, takerGets.Issuer)
+	txTakerGets, err := rpcBookAmount(takerGets)
+	if err != nil {
+		return nil, err
 	}
-	if takerPays.Currency == "" || takerPays.Currency == "XRP" {
-		txTakerPays = tx.NewXRPAmount(0)
-	} else {
-		txTakerPays = tx.NewIssuedAmountFromFloat64(0, takerPays.Currency, takerPays.Issuer)
+	txTakerPays, err := rpcBookAmount(takerPays)
+	if err != nil {
+		return nil, err
 	}
 
 	result, err := a.svc.GetBookOffers(ctx, txTakerGets, txTakerPays, taker, domain, ledgerIndex, limit, marker, withProofs)
@@ -480,6 +478,21 @@ func (a *LedgerServiceAdapter) GetBookOffers(ctx context.Context, takerGets, tak
 		Validated:   result.Validated,
 		Marker:      result.Marker,
 	}, nil
+}
+
+func rpcBookAmount(amount types.Amount) (tx.Amount, error) {
+	if amount.IsMPT() {
+		id, err := mptutil.DecodeID(amount.MPTIssuanceID)
+		if err != nil {
+			return tx.Amount{}, fmt.Errorf("invalid mpt issuance id: %w", err)
+		}
+		issuer := state.EncodeAccountIDSafe(mptutil.Issuer(id))
+		return state.NewMPTAmountWithIssuanceID(0, issuer, mptutil.EncodeID(id)), nil
+	}
+	if amount.Currency == "" || amount.Currency == "XRP" {
+		return tx.NewXRPAmount(0), nil
+	}
+	return tx.NewIssuedAmountFromFloat64(0, amount.Currency, amount.Issuer), nil
 }
 
 // UseTxTables implements types.TxTablesProvider.

--- a/internal/rpc/ledger_adapter_mpt_test.go
+++ b/internal/rpc/ledger_adapter_mpt_test.go
@@ -1,0 +1,23 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRPCBookAmountMPT(t *testing.T) {
+	const idString = "00000004AE123A8556F3CF91154711376AFB0F894F832B3D"
+	amount, err := rpcBookAmount(types.Amount{MPTIssuanceID: idString})
+	require.NoError(t, err)
+	require.True(t, amount.IsMPT())
+	require.Equal(t, idString, amount.MPTIssuanceID())
+	id, err := mptutil.DecodeID(idString)
+	require.NoError(t, err)
+	issuer, err := state.DecodeAccountID(amount.Issuer)
+	require.NoError(t, err)
+	require.Equal(t, mptutil.Issuer(id), issuer)
+}

--- a/internal/rpc/path_find_session.go
+++ b/internal/rpc/path_find_session.go
@@ -10,6 +10,7 @@ import (
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment/pathfinder"
+	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 // PathFindSession holds the state for a persistent WebSocket path_find session.
@@ -45,10 +46,7 @@ type pathFindCreateRequest struct {
 	DestinationAccount string          `json:"destination_account"`
 	DestinationAmount  json.RawMessage `json:"destination_amount"`
 	SendMax            json.RawMessage `json:"send_max,omitempty"`
-	SourceCurrencies   []struct {
-		Currency string `json:"currency"`
-		Issuer   string `json:"issuer,omitempty"`
-	} `json:"source_currencies,omitempty"`
+	SourceCurrencies   json.RawMessage `json:"source_currencies,omitempty"`
 }
 
 // ParseAndCreateSession parses a path_find create request and creates a session.
@@ -82,10 +80,8 @@ func ParseAndCreateSession(params json.RawMessage, id any) (*PathFindSession, *r
 			"Destination account is malformed.")
 	}
 
-	// Parse destination amount. MPT amounts parse but the pathfinder has
-	// no MPT support, so they are rejected as malformed.
 	dstAmount, amtErr := state.AmountFromJSON(request.DestinationAmount)
-	if amtErr != nil || dstAmount.IsMPT() {
+	if amtErr != nil || !pathfinder.IsValidAsset(dstAmount) {
 		return nil, rpctypes.RPCErrorDstAmtMalformed("Destination amount/currency/issuer is malformed.")
 	}
 
@@ -103,7 +99,7 @@ func ParseAndCreateSession(params json.RawMessage, id any) (*PathFindSession, *r
 			return nil, rpctypes.RPCErrorDstAmtMalformed("Destination amount/currency/issuer is malformed.")
 		}
 		amt, smErr := state.AmountFromJSON(request.SendMax)
-		if smErr != nil || amt.IsMPT() || (amt.Signum() <= 0 && amt.Value() != "-1") {
+		if smErr != nil || !pathfinder.IsValidAsset(amt) || (amt.Signum() <= 0 && amt.Value() != "-1") {
 			return nil, rpctypes.RPCErrorSendMaxMalformed("SendMax amount malformed.")
 		}
 		sendMax = &amt
@@ -111,19 +107,98 @@ func ParseAndCreateSession(params json.RawMessage, id any) (*PathFindSession, *r
 
 	// Parse optional source_currencies
 	var srcCurrencies []payment.Issue
-	for _, sc := range request.SourceCurrencies {
-		issue := payment.Issue{Currency: sc.Currency}
-		if sc.Issuer != "" {
-			issuerID, decErr := state.DecodeAccountID(sc.Issuer)
-			if decErr != nil {
-				return nil, rpctypes.NewRPCError(rpctypes.RpcINVALID_PARAMS, "srcIsrMalformed", "invalidParams",
-					"Source issuer is malformed.")
-			}
-			issue.Issuer = issuerID
-		} else if sc.Currency != "XRP" && sc.Currency != "" {
-			issue.Issuer = srcAccount
+	if request.SourceCurrencies != nil {
+		var entries []json.RawMessage
+		if err := json.Unmarshal(request.SourceCurrencies, &entries); err != nil || len(entries) == 0 || len(entries) > 18 {
+			return nil, rpctypes.RPCErrorSrcCurMalformed("Source currency is malformed.")
 		}
-		srcCurrencies = append(srcCurrencies, issue)
+		var sendMaxIssue payment.Issue
+		if sendMax != nil {
+			sendMaxIssue = payment.GetIssue(*sendMax)
+		}
+		seen := make(map[payment.Issue]bool)
+		add := func(issue payment.Issue) {
+			if !seen[issue] {
+				seen[issue] = true
+				srcCurrencies = append(srcCurrencies, issue)
+			}
+		}
+
+		for _, raw := range entries {
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &fields); err != nil {
+				return nil, rpctypes.RPCErrorSrcCurMalformed("Source currency is malformed.")
+			}
+			rawCurrency, hasCurrency := fields["currency"]
+			rawMPT, hasMPT := fields["mpt_issuance_id"]
+			if hasCurrency == hasMPT {
+				return nil, rpctypes.RPCErrorSrcCurMalformed("Source currency is malformed.")
+			}
+			if hasMPT {
+				if _, hasIssuer := fields["issuer"]; hasIssuer {
+					return nil, rpctypes.RPCErrorSrcCurMalformed("Source currency is malformed.")
+				}
+				var value string
+				if err := json.Unmarshal(rawMPT, &value); err != nil {
+					return nil, rpctypes.RPCErrorSrcCurMalformed("Source currency is malformed.")
+				}
+				mptID, ok := pathfinder.ParseSourceMPTID(value)
+				if !ok {
+					return nil, rpctypes.RPCErrorSrcCurMalformed("Source currency is malformed.")
+				}
+				issue := payment.NewMPTIssue(mptID)
+				if sendMax != nil {
+					if !issue.Equal(sendMaxIssue) {
+						continue
+					}
+					if sendMaxIssue.Issuer != srcAccount {
+						return nil, rpctypes.RPCErrorSrcIsrMalformed("Source issuer is malformed.")
+					}
+				}
+				add(issue)
+				continue
+			}
+
+			var currency string
+			if err := json.Unmarshal(rawCurrency, &currency); err != nil || !keylet.IsValidCurrencyCode(currency) {
+				return nil, rpctypes.RPCErrorSrcCurMalformed("Source currency is malformed.")
+			}
+			if currency == "" {
+				currency = "XRP"
+			}
+			var issuer [20]byte
+			if rawIssuer, hasIssuer := fields["issuer"]; hasIssuer {
+				var issuerString string
+				if err := json.Unmarshal(rawIssuer, &issuerString); err != nil {
+					return nil, rpctypes.RPCErrorSrcIsrMalformed("Source issuer is malformed.")
+				}
+				issuerID, decErr := state.DecodeAccountID(issuerString)
+				if decErr != nil {
+					return nil, rpctypes.RPCErrorSrcIsrMalformed("Source issuer is malformed.")
+				}
+				issuer = issuerID
+			}
+			if currency == "XRP" {
+				if issuer != [20]byte{} {
+					return nil, rpctypes.RPCErrorSrcCurMalformed("Source currency is malformed.")
+				}
+			} else if issuer == [20]byte{} {
+				issuer = srcAccount
+			}
+
+			if sendMax != nil {
+				if sendMaxIssue.IsMPT || currency != sendMaxIssue.Currency {
+					continue
+				}
+				if issuer != srcAccount && sendMaxIssue.Issuer != srcAccount && issuer != sendMaxIssue.Issuer {
+					return nil, rpctypes.RPCErrorSrcIsrMalformed("Source issuer is malformed.")
+				}
+				if issuer == srcAccount && sendMaxIssue.Issuer != srcAccount {
+					issuer = sendMaxIssue.Issuer
+				}
+			}
+			add(payment.Issue{Currency: currency, Issuer: issuer})
+		}
 	}
 
 	session := &PathFindSession{
@@ -174,20 +249,14 @@ func (s *PathFindSession) GetLastResult() *PathFindEvent {
 func (s *PathFindSession) buildEvent(result *pathfinder.PathRequestResult, fullReply bool) *PathFindEvent {
 	alternatives := make([]PathAlternative, 0, len(result.Alternatives))
 	for _, alt := range result.Alternatives {
-		var srcAmtJSON json.RawMessage
-		if alt.SourceAmount.IsNative() {
-			srcAmtJSON, _ = json.Marshal(alt.SourceAmount.Value())
-		} else {
-			srcAmtJSON, _ = json.Marshal(map[string]string{
-				"currency": alt.SourceAmount.Currency,
-				"issuer":   alt.SourceAmount.Issuer,
-				"value":    alt.SourceAmount.Value(),
-			})
-		}
-		alternatives = append(alternatives, PathAlternative{
-			SourceAmount:  srcAmtJSON,
+		alternative := PathAlternative{
+			SourceAmount:  pathFindAmountJSON(alt.SourceAmount),
 			PathsComputed: convertToRPCPathSteps(alt.PathsComputed),
-		})
+		}
+		if s.convertAll {
+			alternative.DestinationAmount = pathFindAmountJSON(alt.DestinationAmount)
+		}
+		alternatives = append(alternatives, alternative)
 	}
 
 	return &PathFindEvent{
@@ -201,6 +270,26 @@ func (s *PathFindSession) buildEvent(result *pathfinder.PathRequestResult, fullR
 	}
 }
 
+func pathFindAmountJSON(amount tx.Amount) json.RawMessage {
+	var value any
+	if amount.IsNative() {
+		value = amount.Value()
+	} else if amount.IsMPT() {
+		value = map[string]string{
+			"mpt_issuance_id": amount.MPTIssuanceID(),
+			"value":           amount.Value(),
+		}
+	} else {
+		value = map[string]string{
+			"currency": amount.Currency,
+			"issuer":   amount.Issuer,
+			"value":    amount.Value(),
+		}
+	}
+	encoded, _ := json.Marshal(value)
+	return encoded
+}
+
 // convertToRPCPathSteps converts payment.PathStep slices to rpctypes.PathStep slices.
 func convertToRPCPathSteps(paths [][]payment.PathStep) [][]rpctypes.PathStep {
 	if len(paths) == 0 {
@@ -211,11 +300,12 @@ func convertToRPCPathSteps(paths [][]payment.PathStep) [][]rpctypes.PathStep {
 		steps := make([]rpctypes.PathStep, len(path))
 		for j, step := range path {
 			steps[j] = rpctypes.PathStep{
-				Account:  step.Account,
-				Currency: step.Currency,
-				Issuer:   step.Issuer,
-				Type:     uint8(step.Type),
-				TypeHex:  step.TypeHex,
+				Account:       step.Account,
+				Currency:      step.Currency,
+				Issuer:        step.Issuer,
+				MPTIssuanceID: step.MPTIssuanceID,
+				Type:          uint8(step.Type),
+				TypeHex:       step.TypeHex,
 			}
 		}
 		result[i] = steps

--- a/internal/rpc/path_find_session_test.go
+++ b/internal/rpc/path_find_session_test.go
@@ -3,6 +3,13 @@ package rpc
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment/pathfinder"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
 )
 
 // The WS path_find session must enforce the same post-parse amount guards as
@@ -61,4 +68,158 @@ func TestParseAndCreateSession_AmountGuards(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseAndCreateSession_MPTAssets(t *testing.T) {
+	const (
+		acct = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+		id   = "00000004AE123A8556F3CF91154711376AFB0F894F832B3D"
+	)
+	params := json.RawMessage(`{
+		"source_account":"` + acct + `",
+		"destination_account":"` + acct + `",
+		"destination_amount":{"mpt_issuance_id":"` + id + `","value":"10"},
+		"source_currencies":[{"mpt_issuance_id":"` + id + `"}]
+	}`)
+
+	session, rpcErr := ParseAndCreateSession(params, nil)
+	require.Nil(t, rpcErr)
+	require.True(t, session.dstAmount.IsMPT())
+	require.Len(t, session.srcCurrencies, 1)
+	decoded, err := mptutil.DecodeID(id)
+	require.NoError(t, err)
+	require.True(t, session.srcCurrencies[0].Equal(payment.NewMPTIssue(decoded)))
+}
+
+func TestParseAndCreateSession_MPTAssetMemberValidation(t *testing.T) {
+	const (
+		acct = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+		id   = "00000004AE123A8556F3CF91154711376AFB0F894F832B3D"
+	)
+	for _, sourceCurrencies := range []string{
+		`[]`,
+		`[{"mpt_issuance_id":"` + id + `","currency":null}]`,
+		`[{"mpt_issuance_id":"` + id + `","issuer":null}]`,
+	} {
+		params := json.RawMessage(`{
+			"source_account":"` + acct + `",
+			"destination_account":"` + acct + `",
+			"destination_amount":{"mpt_issuance_id":"` + id + `","value":"10"},
+			"source_currencies":` + sourceCurrencies + `
+		}`)
+		_, rpcErr := ParseAndCreateSession(params, nil)
+		require.NotNil(t, rpcErr)
+		require.Equal(t, "srcCurMalformed", rpcErr.ErrorString)
+	}
+}
+
+func TestParseAndCreateSession_RejectsMPTWithZeroIssuer(t *testing.T) {
+	const (
+		acct  = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+		badID = "000000010000000000000000000000000000000000000000"
+	)
+	badAmount := `{"mpt_issuance_id":"` + badID + `","value":"10"}`
+
+	tests := []struct {
+		name   string
+		params json.RawMessage
+		token  string
+	}{
+		{
+			name: "destination_amount",
+			params: json.RawMessage(`{"source_account":"` + acct +
+				`","destination_account":"` + acct +
+				`","destination_amount":` + badAmount + `}`),
+			token: "dstAmtMalformed",
+		},
+		{
+			name: "send_max",
+			params: json.RawMessage(`{"source_account":"` + acct +
+				`","destination_account":"` + acct +
+				`","destination_amount":"-1","send_max":` + badAmount + `}`),
+			token: "sendMaxMalformed",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, rpcErr := ParseAndCreateSession(test.params, nil)
+			require.NotNil(t, rpcErr)
+			require.Equal(t, test.token, rpcErr.ErrorString)
+		})
+	}
+}
+
+func TestParseAndCreateSession_MPTSendMaxIssuerReconciliation(t *testing.T) {
+	var issuerID, holderID [20]byte
+	issuerID[19] = 1
+	holderID[19] = 2
+	issuer := state.EncodeAccountIDSafe(issuerID)
+	holder := state.EncodeAccountIDSafe(holderID)
+	id := mptutil.EncodeID(keylet.MakeMPTID(1, issuerID))
+
+	params := func(source string) json.RawMessage {
+		return json.RawMessage(`{"source_account":"` + source +
+			`","destination_account":"` + issuer +
+			`","destination_amount":"-1","send_max":{"mpt_issuance_id":"` + id +
+			`","value":"10"},"source_currencies":[{"mpt_issuance_id":"` + id + `"}]}`)
+	}
+
+	_, rpcErr := ParseAndCreateSession(params(holder), nil)
+	require.NotNil(t, rpcErr)
+	require.Equal(t, "srcIsrMalformed", rpcErr.ErrorString)
+
+	session, rpcErr := ParseAndCreateSession(params(issuer), nil)
+	require.Nil(t, rpcErr)
+	require.Len(t, session.srcCurrencies, 1)
+	require.True(t, session.srcCurrencies[0].IsMPT)
+}
+
+func TestParseAndCreateSession_AcceptsZeroMPTSourceLiteral(t *testing.T) {
+	const acct = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	params := json.RawMessage(`{"source_account":"` + acct +
+		`","destination_account":"` + acct +
+		`","destination_amount":"1","source_currencies":[{"mpt_issuance_id":"0"}]}`)
+
+	session, rpcErr := ParseAndCreateSession(params, nil)
+	require.Nil(t, rpcErr)
+	require.Len(t, session.srcCurrencies, 1)
+	require.True(t, session.srcCurrencies[0].IsMPT)
+	require.Equal(t, [24]byte{}, session.srcCurrencies[0].MPTID)
+}
+
+func TestPathFindPersistentConvertAllResponseShape(t *testing.T) {
+	const id = "00000004AE123A8556F3CF91154711376AFB0F894F832B3D"
+	session := &PathFindSession{
+		convertAll:   true,
+		dstAmountRaw: json.RawMessage(`{"mpt_issuance_id":"` + id + `","value":"-1"}`),
+	}
+	result := &pathfinder.PathRequestResult{
+		DestinationCurrencies: []string{"USD", "XRP"},
+		Alternatives: []pathfinder.PathAlternative{
+			{
+				SourceAmount:      state.NewXRPAmountFromInt(10),
+				DestinationAmount: state.NewMPTAmountWithIssuanceID(25, "", id),
+			},
+		},
+	}
+
+	encoded, err := json.Marshal(session.buildEvent(result, true))
+	require.NoError(t, err)
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &response))
+	require.NotContains(t, response, "destination_currencies")
+	topLevelDestination, ok := response["destination_amount"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "-1", topLevelDestination["value"])
+
+	alternatives, ok := response["alternatives"].([]any)
+	require.True(t, ok)
+	require.Len(t, alternatives, 1)
+	alternative, ok := alternatives[0].(map[string]any)
+	require.True(t, ok)
+	destinationAmount, ok := alternative["destination_amount"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, id, destinationAmount["mpt_issuance_id"])
+	require.Equal(t, "25", destinationAmount["value"])
 }

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -1011,17 +1011,20 @@ type TransactionInfo struct {
 	TxIndex uint32
 }
 
-// Amount represents a currency amount (XRP or IOU)
+// Amount identifies an XRP, issued-currency, or MPT amount.
 type Amount struct {
-	Value    string `json:"value,omitempty"`
-	Currency string `json:"currency,omitempty"`
-	Issuer   string `json:"issuer,omitempty"`
+	Value         string `json:"value,omitempty"`
+	Currency      string `json:"currency,omitempty"`
+	Issuer        string `json:"issuer,omitempty"`
+	MPTIssuanceID string `json:"mpt_issuance_id,omitempty"`
 }
 
-// IsNative returns true if this is an XRP amount (not an IOU)
+// IsNative returns true if this is an XRP amount.
 func (a Amount) IsNative() bool {
-	return a.Currency == "" && a.Issuer == ""
+	return a.MPTIssuanceID == "" && a.Currency == "" && a.Issuer == ""
 }
+
+func (a Amount) IsMPT() bool { return a.MPTIssuanceID != "" }
 
 // TrustLine represents a trust line from account_lines RPC
 type TrustLine struct {

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -1019,7 +1019,6 @@ type Amount struct {
 	MPTIssuanceID string `json:"mpt_issuance_id,omitempty"`
 }
 
-// IsNative returns true if this is an XRP amount.
 func (a Amount) IsNative() bool {
 	return a.MPTIssuanceID == "" && a.Currency == "" && a.Issuer == ""
 }

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -428,11 +428,12 @@ type Currency struct {
 type Path []PathStep
 
 type PathStep struct {
-	Account  string `json:"account,omitempty"`
-	Currency string `json:"currency,omitempty"`
-	Issuer   string `json:"issuer,omitempty"`
-	Type     uint8  `json:"type,omitempty"`
-	TypeHex  string `json:"type_hex,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Currency      string `json:"currency,omitempty"`
+	Issuer        string `json:"issuer,omitempty"`
+	MPTIssuanceID string `json:"mpt_issuance_id,omitempty"`
+	Type          uint8  `json:"type,omitempty"`
+	TypeHex       string `json:"type_hex,omitempty"`
 }
 
 // Quality specification

--- a/internal/testing/delegate/delegate_test.go
+++ b/internal/testing/delegate/delegate_test.go
@@ -268,7 +268,6 @@ func TestDelegate_PaymentMPT(t *testing.T) {
 
 	// gw mints MPT to alice on behalf via bob.
 	mint := paymenttx.NewPayment(gw.Address, alice.Address, m.MPTAmount(50))
-	mint.MPTokenIssuanceID = m.IssuanceID()
 	mint.GetCommon().Delegate = bob.Address
 	require.Equal(t, "tesSUCCESS", env.SubmitSignedWith(mint, bob).Code)
 }

--- a/internal/testing/depositpreauth/verify_deposit_preauth_test.go
+++ b/internal/testing/depositpreauth/verify_deposit_preauth_test.go
@@ -213,7 +213,6 @@ func TestMPTPayment_CanTransferCheckedBeforeDepositPreauth(t *testing.T) {
 	// deposit preauth runs, so the expired credential is NOT deleted.
 	result = env.Submit(
 		payment.PayIssued(bob, cindy, mptAlice.MPTAmount(10)).
-			MPTIssuanceID(mptAlice.IssuanceID()).
 			CredentialIDs([]string{credIdx}).
 			Build(),
 	)

--- a/internal/testing/mpt/builder.go
+++ b/internal/testing/mpt/builder.go
@@ -418,14 +418,8 @@ func (m *MPTTester) Pay(src, dest *jtx.Account, amount int64, expectedErr ...str
 
 	mptAmount := m.MPTAmount(amount)
 
-	// Use stored issuance ID, or compute it from current sequence if not yet created
-	id := m.id
-	if id == "" {
-		id = makeMPTIDHex(m.env.Seq(m.issuer), m.issuer)
-	}
-
 	result := m.env.Submit(
-		paybuilder.PayIssued(src, dest, mptAmount).MPTIssuanceID(id).Build(),
+		paybuilder.PayIssued(src, dest, mptAmount).Build(),
 	)
 
 	if len(expectedErr) > 0 && expectedErr[0] != "" {
@@ -445,7 +439,6 @@ func (m *MPTTester) PayWithSendMax(src, dest *jtx.Account, amount int64, sendMax
 	mptSendMax := m.MPTAmount(sendMax)
 	result := m.env.Submit(
 		paybuilder.PayIssued(src, dest, mptAmount).
-			MPTIssuanceID(m.id).
 			SendMax(mptSendMax).
 			Build(),
 	)
@@ -466,7 +459,6 @@ func (m *MPTTester) PayWithFlags(src, dest *jtx.Account, amount int64, flags uin
 	mptAmount := m.MPTAmount(amount)
 	result := m.env.Submit(
 		paybuilder.PayIssued(src, dest, mptAmount).
-			MPTIssuanceID(m.id).
 			Flags(flags).
 			Build(),
 	)
@@ -485,7 +477,7 @@ func (m *MPTTester) PayFull(src, dest *jtx.Account, amount, sendMax, deliverMin 
 	m.t.Helper()
 
 	mptAmount := m.MPTAmount(amount)
-	builder := paybuilder.PayIssued(src, dest, mptAmount).MPTIssuanceID(m.id)
+	builder := paybuilder.PayIssued(src, dest, mptAmount)
 
 	if sendMax != 0 {
 		mptSendMax := m.MPTAmount(sendMax)
@@ -550,11 +542,11 @@ func (m *MPTTester) Claw(issuer, holder *jtx.Account, amount int64, expectedErr 
 // serializes as a 33-byte MPToken amount rather than being misrouted through the
 // IOU path (which loses precision and rejects values above 16 significant digits).
 func (m *MPTTester) MPTAmount(amount int64) tx.Amount {
-	if m.id != "" {
-		return state.NewMPTAmountWithIssuanceID(amount, m.issuer.Address, m.id)
+	id := m.id
+	if id == "" {
+		id = makeMPTIDHex(m.env.Seq(m.issuer), m.issuer)
 	}
-	// Issuance not yet created: fall back to a raw MPT value (no embedded ID).
-	return state.NewMPTAmountDirect(amount, "MPT", m.issuer.Address)
+	return state.NewMPTAmountWithIssuanceID(amount, m.issuer.Address, id)
 }
 
 // mptokenAmount reads the holder's MPToken balance from the ledger.

--- a/internal/testing/mpt/mpt_delivered_amount_test.go
+++ b/internal/testing/mpt/mpt_delivered_amount_test.go
@@ -64,7 +64,6 @@ func TestMPT_DeliveredAmount(t *testing.T) {
 		env, mptAlice, bob, carol := setup(t)
 		r := env.Submit(
 			paybuilder.PayIssued(bob, carol, mptAlice.MPTAmount(1000)).
-				MPTIssuanceID(mptAlice.IssuanceID()).
 				PartialPayment().
 				Build(),
 		)
@@ -77,7 +76,6 @@ func TestMPT_DeliveredAmount(t *testing.T) {
 		env, mptAlice, bob, carol := setup(t)
 		r := env.Submit(
 			paybuilder.PayIssued(bob, carol, mptAlice.MPTAmount(1000)).
-				MPTIssuanceID(mptAlice.IssuanceID()).
 				SendMax(mptAlice.MPTAmount(1200)).
 				PartialPayment().
 				Build(),
@@ -92,7 +90,6 @@ func TestMPT_DeliveredAmount(t *testing.T) {
 		env, mptAlice, bob, carol := setup(t)
 		r := env.Submit(
 			paybuilder.PayIssued(bob, carol, mptAlice.MPTAmount(100)).
-				MPTIssuanceID(mptAlice.IssuanceID()).
 				SendMax(mptAlice.MPTAmount(125)).
 				Build(),
 		)
@@ -107,9 +104,7 @@ func TestMPT_DeliveredAmount(t *testing.T) {
 	t.Run("IssuerToHolderFull_NoField", func(t *testing.T) {
 		env, mptAlice, bob, _ := setup(t)
 		r := env.Submit(
-			paybuilder.PayIssued(mptAlice.Issuer(), bob, mptAlice.MPTAmount(500)).
-				MPTIssuanceID(mptAlice.IssuanceID()).
-				Build(),
+			paybuilder.PayIssued(mptAlice.Issuer(), bob, mptAlice.MPTAmount(500)).Build(),
 		)
 		jtx.RequireTxSuccess(t, r)
 		if r.Metadata != nil && r.Metadata.DeliveredAmount != nil {
@@ -141,7 +136,6 @@ func TestMPT_DeliveredAmount(t *testing.T) {
 
 		r := env.Submit(
 			paybuilder.PayIssued(bob, carol, mptAlice.MPTAmount(1000)).
-				MPTIssuanceID(mptAlice.IssuanceID()).
 				PartialPayment().
 				Build(),
 		)

--- a/internal/testing/mpt/mpt_payment_v2_cross_asset_test.go
+++ b/internal/testing/mpt/mpt_payment_v2_cross_asset_test.go
@@ -1,0 +1,165 @@
+package mpt_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/mpt"
+	offertest "github.com/LeJamon/go-xrpl/internal/testing/offer"
+	paybuilder "github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	paymenttx "github.com/LeJamon/go-xrpl/internal/tx/payment"
+)
+
+func newMPTCrossAssetFixture(t *testing.T) mptPaymentFixture {
+	return newMPTPaymentFixture(
+		t,
+		true,
+		mpt.TfMPTCanTransfer|mpt.TfMPTCanTrade,
+		nil,
+	)
+}
+
+func mptPath(id string) [][]paymenttx.PathStep {
+	return [][]paymenttx.PathStep{{{MPTIssuanceID: id}}}
+}
+
+func TestMPTPaymentV2CrossAssetSuccess(t *testing.T) {
+	t.Run("XRP to MPT", func(t *testing.T) {
+		fixture := newMPTCrossAssetFixture(t)
+		mptAmount := fixture.token.MPTAmount(100)
+		xrpAmount := tx.NewXRPAmount(jtx.XRP(100))
+		fixture.token.Pay(fixture.issuer, fixture.holder, 100)
+		jtx.RequireTxSuccess(t, fixture.env.CreatePassiveOffer(fixture.holder, mptAmount, xrpAmount))
+		holderXRP := fixture.env.Balance(fixture.holder)
+
+		result := fixture.env.Submit(
+			paybuilder.PayIssued(fixture.issuer, fixture.other, mptAmount).
+				SendMax(xrpAmount).
+				Paths(mptPath(fixture.token.IssuanceID())).
+				NoDirectRipple().
+				Build(),
+		)
+
+		jtx.RequireTxSuccess(t, result)
+		fixture.token.RequireMPTokenAmount(fixture.holder, 0)
+		fixture.token.RequireMPTokenAmount(fixture.other, 100)
+		jtx.RequireBalance(t, fixture.env, fixture.holder, holderXRP+uint64(jtx.XRP(100)))
+		offertest.RequireOfferCount(t, fixture.env, fixture.holder, 0)
+	})
+
+	t.Run("MPT to XRP", func(t *testing.T) {
+		fixture := newMPTCrossAssetFixture(t)
+		recipient := jtx.NewAccount("recipient")
+		fixture.env.Fund(recipient)
+		mptAmount := fixture.token.MPTAmount(100)
+		xrpAmount := tx.NewXRPAmount(jtx.XRP(100))
+		fixture.token.Pay(fixture.issuer, fixture.other, 100)
+		jtx.RequireTxSuccess(t, fixture.env.CreatePassiveOffer(fixture.holder, xrpAmount, mptAmount))
+		recipientXRP := fixture.env.Balance(recipient)
+
+		result := fixture.env.Submit(
+			paybuilder.Pay(fixture.other, recipient, uint64(jtx.XRP(100))).
+				SendMax(mptAmount).
+				PathsXRP().
+				NoDirectRipple().
+				Build(),
+		)
+
+		jtx.RequireTxSuccess(t, result)
+		fixture.token.RequireMPTokenAmount(fixture.other, 0)
+		fixture.token.RequireMPTokenAmount(fixture.holder, 100)
+		jtx.RequireBalance(t, fixture.env, recipient, recipientXRP+uint64(jtx.XRP(100)))
+		offertest.RequireOfferCount(t, fixture.env, fixture.holder, 0)
+	})
+
+	t.Run("IOU to MPT", func(t *testing.T) {
+		fixture := newMPTCrossAssetFixture(t)
+		mptAmount := fixture.token.MPTAmount(100)
+		usdAmount := tx.NewIssuedAmountFromFloat64(100, "USD", fixture.issuer.Address)
+		fixture.env.Trust(
+			fixture.holder,
+			tx.NewIssuedAmountFromFloat64(1_000, "USD", fixture.issuer.Address),
+		)
+		fixture.token.Pay(fixture.issuer, fixture.holder, 100)
+		jtx.RequireTxSuccess(t, fixture.env.CreatePassiveOffer(fixture.holder, mptAmount, usdAmount))
+
+		result := fixture.env.Submit(
+			paybuilder.PayIssued(fixture.issuer, fixture.other, mptAmount).
+				SendMax(usdAmount).
+				Paths(mptPath(fixture.token.IssuanceID())).
+				NoDirectRipple().
+				Build(),
+		)
+
+		jtx.RequireTxSuccess(t, result)
+		fixture.token.RequireMPTokenAmount(fixture.holder, 0)
+		fixture.token.RequireMPTokenAmount(fixture.other, 100)
+		jtx.RequireIOUBalance(t, fixture.env, fixture.holder, fixture.issuer, "USD", 100)
+		offertest.RequireOfferCount(t, fixture.env, fixture.holder, 0)
+	})
+
+	t.Run("MPT to IOU", func(t *testing.T) {
+		fixture := newMPTCrossAssetFixture(t)
+		recipient := jtx.NewAccount("recipient")
+		fixture.env.Fund(recipient)
+		mptAmount := fixture.token.MPTAmount(100)
+		usdAmount := tx.NewIssuedAmountFromFloat64(100, "USD", fixture.issuer.Address)
+		usdLimit := tx.NewIssuedAmountFromFloat64(1_000, "USD", fixture.issuer.Address)
+		fixture.env.Trust(fixture.holder, usdLimit)
+		fixture.env.Trust(recipient, usdLimit)
+		fixture.env.PayIOU(fixture.issuer, fixture.holder, fixture.issuer, "USD", 100)
+		fixture.token.Pay(fixture.issuer, fixture.other, 100)
+		jtx.RequireTxSuccess(t, fixture.env.CreatePassiveOffer(fixture.holder, usdAmount, mptAmount))
+
+		result := fixture.env.Submit(
+			paybuilder.PayIssued(fixture.other, recipient, usdAmount).
+				SendMax(mptAmount).
+				PathsCurrency("USD", fixture.issuer).
+				NoDirectRipple().
+				Build(),
+		)
+
+		jtx.RequireTxSuccess(t, result)
+		fixture.token.RequireMPTokenAmount(fixture.other, 0)
+		fixture.token.RequireMPTokenAmount(fixture.holder, 100)
+		jtx.RequireIOUBalance(t, fixture.env, fixture.holder, fixture.issuer, "USD", 0)
+		jtx.RequireIOUBalance(t, fixture.env, recipient, fixture.issuer, "USD", 100)
+		offertest.RequireOfferCount(t, fixture.env, fixture.holder, 0)
+	})
+
+	t.Run("MPT to different MPT", func(t *testing.T) {
+		fixture := newMPTCrossAssetFixture(t)
+		recipient := jtx.NewAccount("recipient")
+		fixture.env.Fund(recipient)
+		otherToken := mpt.NewMPTTester(t, fixture.env, fixture.issuer, mpt.MPTInit{
+			Holders: []*jtx.Account{fixture.holder, recipient},
+		})
+		otherToken.Create(mpt.CreateOpts{
+			Flags: mpt.TfMPTCanTransfer | mpt.TfMPTCanTrade,
+		})
+		otherToken.Authorize(mpt.AuthorizeOpts{Account: fixture.holder})
+		otherToken.Authorize(mpt.AuthorizeOpts{Account: recipient})
+
+		input := fixture.token.MPTAmount(100)
+		output := otherToken.MPTAmount(100)
+		fixture.token.Pay(fixture.issuer, fixture.other, 100)
+		otherToken.Pay(fixture.issuer, fixture.holder, 100)
+		jtx.RequireTxSuccess(t, fixture.env.CreatePassiveOffer(fixture.holder, output, input))
+
+		result := fixture.env.Submit(
+			paybuilder.PayIssued(fixture.other, recipient, output).
+				SendMax(input).
+				Paths(mptPath(otherToken.IssuanceID())).
+				NoDirectRipple().
+				Build(),
+		)
+
+		jtx.RequireTxSuccess(t, result)
+		fixture.token.RequireMPTokenAmount(fixture.other, 0)
+		fixture.token.RequireMPTokenAmount(fixture.holder, 100)
+		otherToken.RequireMPTokenAmount(fixture.holder, 0)
+		otherToken.RequireMPTokenAmount(recipient, 100)
+		offertest.RequireOfferCount(t, fixture.env, fixture.holder, 0)
+	})
+}

--- a/internal/testing/mpt/mpt_payment_v2_destination_test.go
+++ b/internal/testing/mpt/mpt_payment_v2_destination_test.go
@@ -1,0 +1,57 @@
+package mpt_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	paybuilder "github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+func TestMPTPaymentV2DestinationChecks(t *testing.T) {
+	t.Run("missing destination", func(t *testing.T) {
+		fixture := newMPTPaymentFixture(t, true, 0, nil)
+		missing := jtx.NewAccount("missing")
+		result := fixture.env.Submit(
+			paybuilder.PayIssued(
+				fixture.issuer,
+				missing,
+				fixture.token.MPTAmount(10),
+			).Build(),
+		)
+
+		jtx.RequireTxFail(t, result, jtx.TecNO_DST)
+	})
+
+	t.Run("destination tag required", func(t *testing.T) {
+		fixture := newMPTPaymentFixture(t, true, 0, nil)
+		fixture.env.EnableRequireDest(fixture.other)
+		result := fixture.env.Submit(
+			paybuilder.PayIssued(
+				fixture.issuer,
+				fixture.other,
+				fixture.token.MPTAmount(10),
+			).Build(),
+		)
+
+		jtx.RequireTxFail(t, result, jtx.TecDST_TAG_NEEDED)
+		fixture.token.RequireMPTokenAmount(fixture.other, 0)
+	})
+
+	t.Run("deposit authorization", func(t *testing.T) {
+		fixture := newMPTPaymentFixture(t, true, 0, nil)
+		fixture.env.EnableDepositAuth(fixture.other)
+		payment := func() tx.Transaction {
+			return paybuilder.PayIssued(
+				fixture.issuer,
+				fixture.other,
+				fixture.token.MPTAmount(10),
+			).BuildPayment()
+		}
+
+		jtx.RequireTxFail(t, fixture.env.Submit(payment()), jtx.TecNO_PERMISSION)
+		fixture.env.Preauthorize(fixture.other, fixture.issuer)
+		jtx.RequireTxSuccess(t, fixture.env.Submit(payment()))
+		fixture.token.RequireMPTokenAmount(fixture.other, 10)
+	})
+}

--- a/internal/testing/mpt/mpt_payment_v2_test.go
+++ b/internal/testing/mpt/mpt_payment_v2_test.go
@@ -1,0 +1,241 @@
+package mpt_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/mpt"
+	paybuilder "github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+type mptPaymentFixture struct {
+	env    *jtx.TestEnv
+	token  *mpt.MPTTester
+	issuer *jtx.Account
+	holder *jtx.Account
+	other  *jtx.Account
+}
+
+func newMPTPaymentFixture(
+	t *testing.T,
+	v2 bool,
+	flags uint32,
+	transferFee *uint16,
+) mptPaymentFixture {
+	t.Helper()
+
+	env := jtx.NewTestEnv(t)
+	if v2 {
+		env.EnableFeature("MPTokensV2")
+	} else {
+		env.DisableFeature("MPTokensV2")
+	}
+	env.Close()
+
+	issuer := jtx.NewAccount("issuer")
+	holder := jtx.NewAccount("holder")
+	other := jtx.NewAccount("other")
+	token := mpt.NewMPTTester(t, env, issuer, mpt.MPTInit{
+		Holders: []*jtx.Account{holder, other},
+	})
+	token.Create(mpt.CreateOpts{
+		TransferFee: transferFee,
+		OwnerCount:  mpt.PtrUint32(1),
+		HolderCount: mpt.PtrUint32(0),
+		Flags:       flags,
+	})
+	token.Authorize(mpt.AuthorizeOpts{Account: holder})
+	token.Authorize(mpt.AuthorizeOpts{Account: other})
+
+	return mptPaymentFixture{
+		env:    env,
+		token:  token,
+		issuer: issuer,
+		holder: holder,
+		other:  other,
+	}
+}
+
+func TestMPTPaymentV2Flags(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		v2   bool
+	}{
+		{name: "V1", v2: false},
+		{name: "V2", v2: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newMPTPaymentFixture(t, test.v2, 0, nil)
+			amount := fixture.token.MPTAmount(10)
+			if test.v2 {
+				amount = state.NewMPTAmountWithIssuanceID(10, "", fixture.token.IssuanceID())
+			}
+
+			noDirect := fixture.env.Submit(
+				paybuilder.PayIssued(fixture.issuer, fixture.holder, amount).
+					NoDirectRipple().
+					Build(),
+			)
+			if test.v2 {
+				jtx.RequireTxFail(t, noDirect, jtx.TemRIPPLE_EMPTY)
+			} else {
+				jtx.RequireTxFail(t, noDirect, jtx.TemINVALID_FLAG)
+			}
+			fixture.token.RequireMPTokenAmount(fixture.holder, 0)
+
+			limitQuality := fixture.env.Submit(
+				paybuilder.PayIssued(fixture.issuer, fixture.holder, amount).
+					LimitQuality().
+					Build(),
+			)
+			if test.v2 {
+				jtx.RequireTxSuccess(t, limitQuality)
+				fixture.token.RequireMPTokenAmount(fixture.holder, 10)
+			} else {
+				jtx.RequireTxFail(t, limitQuality, jtx.TemINVALID_FLAG)
+				fixture.token.RequireMPTokenAmount(fixture.holder, 0)
+			}
+		})
+	}
+}
+
+func TestMPTPaymentV2AssetCombinations(t *testing.T) {
+	type shapeCase struct {
+		name   string
+		v2Code string
+		build  func(mptPaymentFixture) tx.Transaction
+	}
+
+	cases := []shapeCase{
+		{
+			name:   "MPTAmountWithXRPSendMax",
+			v2Code: jtx.TecPATH_PARTIAL,
+			build: func(fixture mptPaymentFixture) tx.Transaction {
+				return paybuilder.PayIssued(
+					fixture.issuer,
+					fixture.other,
+					fixture.token.MPTAmount(100),
+				).SendMax(tx.NewXRPAmount(jtx.XRP(100))).Build()
+			},
+		},
+		{
+			name:   "IOUAmountWithMPTSendMax",
+			v2Code: jtx.TecPATH_DRY,
+			build: func(fixture mptPaymentFixture) tx.Transaction {
+				usd := tx.NewIssuedAmountFromFloat64(100, "USD", fixture.issuer.Address)
+				return paybuilder.PayIssued(fixture.issuer, fixture.other, usd).
+					SendMax(fixture.token.MPTAmount(100)).
+					Build()
+			},
+		},
+		{
+			name:   "XRPAmountWithMPTSendMax",
+			v2Code: jtx.TecPATH_PARTIAL,
+			build: func(fixture mptPaymentFixture) tx.Transaction {
+				return paybuilder.Pay(
+					fixture.issuer,
+					fixture.other,
+					uint64(jtx.XRP(100)),
+				).SendMax(fixture.token.MPTAmount(100)).Build()
+			},
+		},
+		{
+			name:   "DifferentMPTIssuances",
+			v2Code: jtx.TecOBJECT_NOT_FOUND,
+			build: func(fixture mptPaymentFixture) tx.Transaction {
+				missingID := mpt.MakeMPTIDHexFromAddr(
+					fixture.env.Seq(fixture.issuer)+10,
+					fixture.issuer.Address,
+				)
+				amount := state.NewMPTAmountWithIssuanceID(100, "", missingID)
+				return paybuilder.PayIssued(fixture.issuer, fixture.other, amount).
+					SendMax(fixture.token.MPTAmount(100)).
+					Build()
+			},
+		},
+		{
+			name:   "ExplicitIOUPath",
+			v2Code: jtx.TesSUCCESS,
+			build: func(fixture mptPaymentFixture) tx.Transaction {
+				return paybuilder.PayIssued(
+					fixture.issuer,
+					fixture.other,
+					fixture.token.MPTAmount(100),
+				).PathsCurrency("USD", fixture.issuer).Build()
+			},
+		},
+	}
+
+	for _, version := range []struct {
+		name string
+		v2   bool
+	}{
+		{name: "V1", v2: false},
+		{name: "V2", v2: true},
+	} {
+		t.Run(version.name, func(t *testing.T) {
+			for _, test := range cases {
+				t.Run(test.name, func(t *testing.T) {
+					fixture := newMPTPaymentFixture(
+						t,
+						version.v2,
+						mpt.TfMPTCanTransfer|mpt.TfMPTCanTrade,
+						nil,
+					)
+					result := fixture.env.Submit(test.build(fixture))
+					if !version.v2 {
+						jtx.RequireTxFail(t, result, jtx.TemMALFORMED)
+						fixture.token.RequireMPTokenAmount(fixture.other, 0)
+						return
+					}
+
+					if test.v2Code == jtx.TesSUCCESS {
+						jtx.RequireTxSuccess(t, result)
+						fixture.token.RequireMPTokenAmount(fixture.other, 100)
+						return
+					}
+					jtx.RequireTxClaimed(t, result, test.v2Code)
+					fixture.token.RequireMPTokenAmount(fixture.other, 0)
+				})
+			}
+		})
+	}
+}
+
+func TestMPTPaymentV2TransferFeeRounding(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		v2        bool
+		delivered int64
+	}{
+		{name: "V1", v2: false, delivered: 82},
+		{name: "V2", v2: true, delivered: 81},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			transferFee := uint16(10_000)
+			fixture := newMPTPaymentFixture(
+				t,
+				test.v2,
+				mpt.TfMPTCanTransfer,
+				&transferFee,
+			)
+			fixture.token.Pay(fixture.issuer, fixture.holder, 1_000)
+
+			result := fixture.env.Submit(
+				paybuilder.PayIssued(
+					fixture.holder,
+					fixture.other,
+					fixture.token.MPTAmount(100),
+				).
+					SendMax(fixture.token.MPTAmount(90)).
+					PartialPayment().
+					Build(),
+			)
+			jtx.RequireTxSuccess(t, result)
+			fixture.token.RequireMPTokenAmount(fixture.holder, 910)
+			fixture.token.RequireMPTokenAmount(fixture.other, test.delivered)
+		})
+	}
+}

--- a/internal/testing/payment/builder.go
+++ b/internal/testing/payment/builder.go
@@ -28,7 +28,6 @@ type PaymentBuilder struct {
 	flags         uint32
 	memos         []tx.MemoWrapper
 	credentialIDs []string
-	mptIssuanceID string
 	domainID      *string
 }
 
@@ -185,12 +184,6 @@ func (b *PaymentBuilder) CredentialIDs(ids []string) *PaymentBuilder {
 	return b
 }
 
-// MPTIssuanceID sets the MPT issuance ID for MPT direct payments.
-func (b *PaymentBuilder) MPTIssuanceID(id string) *PaymentBuilder {
-	b.mptIssuanceID = id
-	return b
-}
-
 // DomainID sets the permissioned domain ID for this payment.
 // The domainIDHex should be a 64-character hex string.
 func (b *PaymentBuilder) DomainID(domainIDHex string) *PaymentBuilder {
@@ -251,9 +244,6 @@ func (b *PaymentBuilder) Build() tx.Transaction {
 	}
 	if b.credentialIDs != nil {
 		payment.CredentialIDs = b.credentialIDs
-	}
-	if b.mptIssuanceID != "" {
-		payment.MPTokenIssuanceID = b.mptIssuanceID
 	}
 	if b.domainID != nil {
 		payment.DomainID = b.domainID

--- a/internal/testing/rpcenv/ripple_path_find_test.go
+++ b/internal/testing/rpcenv/ripple_path_find_test.go
@@ -522,16 +522,20 @@ func TestRipplePathFind_NonCanonicalAmountForms(t *testing.T) {
 		require.Equal(t, "dstAmtMalformed", rpcErr.ErrorString)
 	})
 
-	t.Run("MPT destination_amount rejected", func(t *testing.T) {
-		_, rpcErr := env.RPC("ripple_path_find", map[string]any{
+	t.Run("MPT destination_amount accepted", func(t *testing.T) {
+		const issuanceID = "00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8"
+		result, rpcErr := env.RPC("ripple_path_find", map[string]any{
 			"source_account":      alice.Address,
 			"destination_account": bob.Address,
 			"destination_amount": map[string]any{
-				"mpt_issuance_id": "00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8",
+				"mpt_issuance_id": issuanceID,
 				"value":           "5",
 			},
 		})
-		require.NotNil(t, rpcErr)
-		require.Equal(t, "dstAmtMalformed", rpcErr.ErrorString)
+		require.Nil(t, rpcErr)
+		resp := asJSONMap(t, result)
+		amount := resp["destination_amount"].(map[string]any)
+		require.Equal(t, issuanceID, amount["mpt_issuance_id"])
+		require.Equal(t, "5", amount["value"])
 	})
 }

--- a/internal/tx/amm/amm_clawback.go
+++ b/internal/tx/amm/amm_clawback.go
@@ -4,8 +4,10 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
 
 // AMMClawback claws back tokens from an AMM.
@@ -77,19 +79,26 @@ func (a *AMMClawback) Validate() error {
 	// If tfClawTwoAssets is set, both assets must be issued by the same issuer
 	// Reference: rippled AMMClawback.cpp preflight lines 66-72
 	if a.GetFlags()&tfClawTwoAssets != 0 {
-		if a.Asset.Issuer != a.Asset2.Issuer {
+		issuer1, result1 := assetIssuerID(a.Asset)
+		issuer2, result2 := assetIssuerID(a.Asset2)
+		if result1 != ter.TesSUCCESS || result2 != ter.TesSUCCESS || issuer1 != issuer2 {
 			return ter.Errorf(ter.TemINVALID_FLAG, "tfClawTwoAssets requires both assets to have the same issuer")
 		}
 	}
 
 	// Reference: rippled AMMClawback.cpp preflight lines 74-79
-	if a.Asset.Issuer != a.Common.Account {
+	accountID, err := state.DecodeAccountID(a.Common.Account)
+	if err != nil {
+		return ter.Errorf(ter.TemBAD_SRC_ACCOUNT, "invalid source account")
+	}
+	assetIssuer, result := assetIssuerID(a.Asset)
+	if result != ter.TesSUCCESS || assetIssuer != accountID {
 		return ter.Errorf(ter.TemMALFORMED, "Asset issuer must match Account")
 	}
 
 	// Reference: rippled AMMClawback.cpp preflight lines 81-89
 	if a.Amount != nil {
-		if a.Amount.Currency != a.Asset.Currency || a.Amount.Issuer != a.Asset.Issuer {
+		if !matchesAsset(a.Amount, a.Asset) {
 			return ter.Errorf(ter.TemBAD_AMOUNT, "Amount issue must match Asset")
 		}
 		if a.Amount.IsZero() || a.Amount.IsNegative() {
@@ -144,8 +153,25 @@ func (a *AMMClawback) Preclaim(view tx.LedgerView, _ tx.EngineConfig) ter.Result
 		return result
 	}
 
-	if (issuer.Flags&state.LsfAllowTrustLineClawback) == 0 ||
-		(issuer.Flags&state.LsfNoFreeze) != 0 {
+	issuerID, err := state.DecodeAccountID(a.Common.Account)
+	if err != nil {
+		return ter.TemBAD_SRC_ACCOUNT
+	}
+	canClawback := func(asset tx.Asset) bool {
+		if !asset.IsMPT() {
+			return issuer.Flags&state.LsfAllowTrustLineClawback != 0 && issuer.Flags&state.LsfNoFreeze == 0
+		}
+		id, err := mptutil.DecodeID(asset.MPTIssuanceID)
+		if err != nil {
+			return false
+		}
+		issuance, _, result := mptutil.ReadIssuance(view, id)
+		return result == ter.TesSUCCESS && issuance.Issuer == issuerID && issuance.Flags&entry.LsfMPTCanClawback != 0
+	}
+	if !canClawback(a.Asset) {
+		return ter.TecNO_PERMISSION
+	}
+	if a.GetFlags()&tfClawTwoAssets != 0 && !canClawback(a.Asset2) {
 		return ter.TecNO_PERMISSION
 	}
 
@@ -279,7 +305,7 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 				withdrawAmount1 = amountRounded
 				withdrawAmount2 = amount2Rounded
 			} else {
-				amount2Withdraw := assetBalance2.Mul(frac, false)
+				amount2Withdraw := toSTAmountIssue(assetBalance2, toIOUForCalc(assetBalance2).Mul(frac, false))
 				lpTokensToWithdraw = lpTokensNeeded
 				withdrawAmount1 = clawAmount
 				withdrawAmount2 = amount2Withdraw
@@ -292,8 +318,8 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 	// clamping. The clawback math inherits these guards because rippled routes
 	// the clawback through equalWithdrawTokens / withdraw.
 	// Reference: rippled AMMWithdraw.cpp withdraw() lines 539-579
-	w1EqualsB1 := toIOUForCalc(withdrawAmount1).Compare(toIOUForCalc(assetBalance1)) == 0
-	w2EqualsB2 := toIOUForCalc(withdrawAmount2).Compare(toIOUForCalc(assetBalance2)) == 0
+	w1EqualsB1 := compareAmounts(withdrawAmount1, assetBalance1) == 0
+	w2EqualsB2 := compareAmounts(withdrawAmount2, assetBalance2) == 0
 	// Cannot withdraw one side of the pool while leaving the other.
 	if (w1EqualsB1 && !w2EqualsB2) || (w2EqualsB2 && !w1EqualsB1) {
 		return ter.TecAMM_BALANCE
@@ -304,8 +330,7 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TecAMM_BALANCE
 	}
 	// Cannot withdraw more than the pool holds.
-	if isGreater(toIOUForCalc(withdrawAmount1), toIOUForCalc(assetBalance1)) ||
-		isGreater(toIOUForCalc(withdrawAmount2), toIOUForCalc(assetBalance2)) {
+	if isGreater(withdrawAmount1, assetBalance1) || isGreater(withdrawAmount2, assetBalance2) {
 		return ter.TecAMM_BALANCE
 	}
 
@@ -326,7 +351,15 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Net effect: debit AMM's trust line, tokens returned to issuer (destroyed).
 	// Asset1 cannot be XRP (enforced in preflight).
 	if !isXRP1 && !withdrawAmount1.IsZero() {
-		if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset, withdrawAmount1.Negate(), ctx.View); err != nil {
+		if a.Asset.IsMPT() {
+			if result := withdrawAssetToAccount(ctx, holderID, ammAccountID, a.Asset, withdrawAmount1,
+				ctx.Rules().Enabled(amendment.FeatureFixAMMv1_2)); result != ter.TesSUCCESS {
+				return result
+			}
+			if result := sendMPT(ctx.View, holderID, issuerID, withdrawAmount1, true); result != ter.TesSUCCESS {
+				return result
+			}
+		} else if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset, withdrawAmount1.Negate(), ctx.View); err != nil {
 			return ter.TefINTERNAL
 		}
 	}
@@ -335,7 +368,15 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 	if flags&tfClawTwoAssets != 0 {
 		// Clawback asset2 too. Same net effect as asset1.
 		if !isXRP2 && !withdrawAmount2.IsZero() {
-			if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset2, withdrawAmount2.Negate(), ctx.View); err != nil {
+			if a.Asset2.IsMPT() {
+				if result := withdrawAssetToAccount(ctx, holderID, ammAccountID, a.Asset2, withdrawAmount2,
+					ctx.Rules().Enabled(amendment.FeatureFixAMMv1_2)); result != ter.TesSUCCESS {
+					return result
+				}
+				if result := sendMPT(ctx.View, holderID, issuerID, withdrawAmount2, true); result != ter.TesSUCCESS {
+					return result
+				}
+			} else if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset2, withdrawAmount2.Negate(), ctx.View); err != nil {
 				return ter.TefINTERNAL
 			}
 		} else if isXRP2 && !withdrawAmount2.IsZero() {
@@ -348,17 +389,20 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 		// NOT clawing asset2 — holder receives it.
 		// Transfer from AMM to holder.
 		if !isXRP2 && !withdrawAmount2.IsZero() {
-			if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset2, withdrawAmount2.Negate(), ctx.View); err != nil {
-				return ter.TefINTERNAL
-			}
-			// Credit holder's trust line with asset2 issuer — BUT skip if
-			// holder IS the issuer (the IOU is just returned/destroyed).
-			// Reference: rippled rippleSendIOU line 1807: direct path when
-			// sender or receiver is the issuer.
-			issuer2ID, _ := state.DecodeAccountID(a.Asset2.Issuer)
-			if holderID != issuer2ID {
-				if err := updateTrustlineBalanceInView(holderID, issuer2ID, a.Asset2.Currency, withdrawAmount2, ctx.View); err != nil {
+			if a.Asset2.IsMPT() {
+				if result := withdrawAssetToAccount(ctx, holderID, ammAccountID, a.Asset2, withdrawAmount2,
+					ctx.Rules().Enabled(amendment.FeatureFixAMMv1_2)); result != ter.TesSUCCESS {
+					return result
+				}
+			} else {
+				if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset2, withdrawAmount2.Negate(), ctx.View); err != nil {
 					return ter.TefINTERNAL
+				}
+				issuer2ID, _ := state.DecodeAccountID(a.Asset2.Issuer)
+				if holderID != issuer2ID {
+					if err := updateTrustlineBalanceInView(holderID, issuer2ID, a.Asset2.Currency, withdrawAmount2, ctx.View); err != nil {
+						return ter.TefINTERNAL
+					}
 				}
 			}
 		} else if isXRP2 && !withdrawAmount2.IsZero() {
@@ -372,7 +416,7 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Burn LP tokens: debit the holder's LP token trust line, may delete it.
 	// Reference: rippled AMMWithdraw::withdraw calls redeemIOU(holder, lpTokens, lpIssue)
 	if !lpTokensToWithdraw.IsZero() {
-		lptCurrency := GenerateAMMLPTCurrency(amm.Asset.Currency, amm.Asset2.Currency)
+		lptCurrency := GenerateAMMLPTCurrencyForAssets(amm.Asset, amm.Asset2)
 		ammAccountAddr, _ := state.EncodeAccountID(amm.Account)
 		redeemAmt := state.NewIssuedAmountFromValue(
 			lpTokensToWithdraw.Mantissa(), lpTokensToWithdraw.Exponent(), lptCurrency, ammAccountAddr)

--- a/internal/tx/amm/amm_create.go
+++ b/internal/tx/amm/amm_create.go
@@ -1,6 +1,8 @@
 package amm
 
 import (
+	"bytes"
+
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
@@ -39,13 +41,13 @@ func (a *AMMCreate) TxType() tx.Type {
 // GetAmountAsset returns the issue (currency + issuer) of the first asset (Amount field).
 // Implements ammCreateIssueProvider for the ValidAMM invariant checker.
 func (a *AMMCreate) GetAmountAsset() tx.Asset {
-	return tx.Asset{Currency: a.Amount.Currency, Issuer: a.Amount.Issuer}
+	return amountAsset(a.Amount)
 }
 
 // GetAmount2Asset returns the issue (currency + issuer) of the second asset (Amount2 field).
 // Implements ammCreateIssueProvider for the ValidAMM invariant checker.
 func (a *AMMCreate) GetAmount2Asset() tx.Asset {
-	return tx.Asset{Currency: a.Amount2.Currency, Issuer: a.Amount2.Issuer}
+	return amountAsset(a.Amount2)
 }
 
 // Reference: rippled AMMCreate.cpp preflight
@@ -61,7 +63,7 @@ func (a *AMMCreate) Validate() error {
 	}
 
 	// Reference: rippled AMMCreate.cpp line 52-57
-	if a.Amount.Currency == a.Amount2.Currency && a.Amount.Issuer == a.Amount2.Issuer {
+	if matchesAssetByIssue(amountAsset(a.Amount), amountAsset(a.Amount2)) {
 		return ter.Errorf(ter.TemBAD_AMM_TOKENS, "tokens can not have the same currency/issuer")
 	}
 
@@ -118,8 +120,8 @@ func (a *AMMCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Res
 		return result
 	}
 
-	asset1 := tx.Asset{Currency: a.Amount.Currency, Issuer: a.Amount.Issuer}
-	asset2 := tx.Asset{Currency: a.Amount2.Currency, Issuer: a.Amount2.Issuer}
+	asset1 := amountAsset(a.Amount)
+	asset2 := amountAsset(a.Amount2)
 
 	// Reference: rippled AMMCreate.cpp line 95-100
 	ammKey := computeAMMKeylet(asset1, asset2)
@@ -128,16 +130,19 @@ func (a *AMMCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Res
 	}
 
 	// Reference: rippled AMMCreate.cpp line 102-116
-	if result := tx.RequireAuth(view, asset1, accountID); result != ter.TesSUCCESS {
+	if result := requireAssetAuth(view, asset1, accountID, true, config.ParentCloseTime); result != ter.TesSUCCESS {
 		return result
 	}
-	if result := tx.RequireAuth(view, asset2, accountID); result != ter.TesSUCCESS {
+	if result := requireAssetAuth(view, asset2, accountID, true, config.ParentCloseTime); result != ter.TesSUCCESS {
 		return result
 	}
 
 	// Reference: rippled AMMCreate.cpp line 119-124
-	if tx.IsFrozen(view, accountID, asset1) || tx.IsFrozen(view, accountID, asset2) {
-		return ter.TecFROZEN
+	if assetFrozen(view, accountID, asset1) {
+		return frozenAssetResult(asset1)
+	}
+	if assetFrozen(view, accountID, asset2) {
+		return frozenAssetResult(asset2)
 	}
 
 	// Reference: rippled AMMCreate.cpp line 126-142
@@ -174,6 +179,13 @@ func (a *AMMCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Res
 		}
 	}
 
+	if result := canMPTTradeAndTransfer(view, asset1, accountID, accountID); result != ter.TesSUCCESS {
+		return result
+	}
+	if result := canMPTTradeAndTransfer(view, asset2, accountID, accountID); result != ter.TesSUCCESS {
+		return result
+	}
+
 	// Check clawback - if featureAMMClawback is not enabled, reject clawback-enabled issuers.
 	// Reference: rippled AMMCreate.cpp preclaim lines 194-214
 	if !config.RequireRules().Enabled(amendment.FeatureAMMClawback) {
@@ -199,8 +211,8 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 
 	accountID := ctx.AccountID
 
-	asset1 := tx.Asset{Currency: a.Amount.Currency, Issuer: a.Amount.Issuer}
-	asset2 := tx.Asset{Currency: a.Amount2.Currency, Issuer: a.Amount2.Issuer}
+	asset1 := amountAsset(a.Amount)
+	asset2 := amountAsset(a.Amount2)
 
 	ammKey := computeAMMKeylet(asset1, asset2)
 
@@ -217,7 +229,7 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Reference: rippled AMMCreate.cpp line 262-264
 	sortedAsset1, sortedAsset2, sortedAmount1, sortedAmount2 := sortAssets(asset1, asset2, a.Amount, a.Amount2)
 
-	lptCurrency := GenerateAMMLPTCurrency(sortedAsset1.Currency, sortedAsset2.Currency)
+	lptCurrency := GenerateAMMLPTCurrencyForAssets(sortedAsset1, sortedAsset2)
 
 	// Reference: rippled AMMCreate.cpp line 241-247
 	lptIssuerID := ammAccountID
@@ -245,10 +257,10 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	// holds (one per non-XRP asset): each is created with the reserve charged
 	// to the AMM side. The AMM ledger object and any XRP side are not counted.
 	ammOwnerCount := uint32(0)
-	if !isXRPAsset(sortedAsset1) {
+	if !isXRPAsset(sortedAsset1) && !sortedAsset1.IsMPT() {
 		ammOwnerCount++
 	}
-	if !isXRPAsset(sortedAsset2) {
+	if !isXRPAsset(sortedAsset2) && !sortedAsset2.IsMPT() {
 		ammOwnerCount++
 	}
 	ammAccount.OwnerCount = ammOwnerCount
@@ -333,6 +345,16 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 		drops := uint64(sortedAmount1.Drops())
 		ctx.Account.Balance -= drops
 		ammAccount.Balance += drops
+	} else if sortedAsset1.IsMPT() {
+		if result := requireAssetAuth(ctx.View, sortedAsset1, ammAccountID, false, ctx.Config.ParentCloseTime); result != ter.TesSUCCESS {
+			return result
+		}
+		if result := ensureAMMMPTHolding(ctx.View, sortedAsset1, ammAccountID); result != ter.TesSUCCESS {
+			return result
+		}
+		if result := sendMPT(ctx.View, accountID, ammAccountID, sortedAmount1, true); result != ter.TesSUCCESS {
+			return result
+		}
 	} else {
 		if err := createOrUpdateAMMTrustline(ammAccountID, sortedAsset1, sortedAmount1, ctx.View); err != nil {
 			return TecNO_LINE
@@ -361,6 +383,16 @@ func (a *AMMCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 		drops := uint64(sortedAmount2.Drops())
 		ctx.Account.Balance -= drops
 		ammAccount.Balance += drops
+	} else if sortedAsset2.IsMPT() {
+		if result := requireAssetAuth(ctx.View, sortedAsset2, ammAccountID, false, ctx.Config.ParentCloseTime); result != ter.TesSUCCESS {
+			return result
+		}
+		if result := ensureAMMMPTHolding(ctx.View, sortedAsset2, ammAccountID); result != ter.TesSUCCESS {
+			return result
+		}
+		if result := sendMPT(ctx.View, accountID, ammAccountID, sortedAmount2, true); result != ter.TesSUCCESS {
+			return result
+		}
 	} else {
 		if err := createOrUpdateAMMTrustline(ammAccountID, sortedAsset2, sortedAmount2, ctx.View); err != nil {
 			return TecNO_LINE
@@ -433,6 +465,14 @@ func sortAssets(asset1, asset2 tx.Asset, amount1, amount2 tx.Amount) (tx.Asset, 
 // than their string representations (base58 r-addresses and ISO-vs-hex currency
 // codes do not sort the same as their decoded bytes).
 func assetLessEqual(a, b tx.Asset) bool {
+	if a.IsMPT() != b.IsMPT() {
+		return a.IsMPT()
+	}
+	if a.IsMPT() {
+		aID, _ := decodeMPTAsset(a)
+		bID, _ := decodeMPTAsset(b)
+		return bytes.Compare(aID[:], bID[:]) <= 0
+	}
 	return keylet.IssueLessEqual(
 		keylet.CurrencyBytes(a.Currency), getIssuerBytes(a.Issuer),
 		keylet.CurrencyBytes(b.Currency), getIssuerBytes(b.Issuer),

--- a/internal/tx/amm/amm_create.go
+++ b/internal/tx/amm/amm_create.go
@@ -158,8 +158,18 @@ func (a *AMMCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Res
 	}
 	reserveNeeded := accountReserve(config, account.OwnerCount+1)
 	xrpLiquid := int64(account.Balance) - int64(reserveNeeded)
-	if insufficientBalance(view, accountID, a.Amount, xrpLiquid) ||
-		insufficientBalance(view, accountID, a.Amount2, xrpLiquid) {
+	insufficient, result := insufficientBalance(view, accountID, a.Amount, xrpLiquid)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if insufficient {
+		return TecUNFUNDED_AMM
+	}
+	insufficient, result = insufficientBalance(view, accountID, a.Amount2, xrpLiquid)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if insufficient {
 		return TecUNFUNDED_AMM
 	}
 

--- a/internal/tx/amm/amm_delete_account.go
+++ b/internal/tx/amm/amm_delete_account.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
@@ -196,8 +197,9 @@ func deleteAMMTrustLines(view tx.LedgerView, ammAccountID [20]byte, maxTrustline
 				return ter.TecINTERNAL
 			}
 
-			// Skip the AMM SLE that coexists with the trust lines in this dir.
-			if entry.Type(entryType) == entry.TypeAMM {
+			// MPToken holdings are removed only after every trust line is gone,
+			// so an interrupted cleanup can still reinitialize the empty AMM.
+			if entry.Type(entryType) == entry.TypeAMM || entry.Type(entryType) == entry.TypeMPToken {
 				i++
 				continue
 			}
@@ -257,6 +259,22 @@ func deleteAMMTrustLines(view tx.LedgerView, ammAccountID [20]byte, maxTrustline
 	return ter.TesSUCCESS
 }
 
+func deleteAMMMPTokens(view tx.LedgerView, ammAccountID [20]byte, assets ...tx.Asset) ter.Result {
+	for _, asset := range assets {
+		if !asset.IsMPT() {
+			continue
+		}
+		id, result := decodeMPTAsset(asset)
+		if result != ter.TesSUCCESS {
+			return ter.TecINTERNAL
+		}
+		if result := mptutil.RemoveHolding(view, id, ammAccountID, false); result != ter.TesSUCCESS {
+			return ter.TecINTERNAL
+		}
+	}
+	return ter.TesSUCCESS
+}
+
 // DeleteAMMAccount performs full cleanup of an AMM account:
 // 1. Deletes trust lines from the AMM's owner directory (bounded)
 // 2. Removes AMM SLE from owner directory
@@ -286,20 +304,30 @@ func DeleteAMMAccount(view tx.LedgerView, asset, asset2 tx.Asset) ter.Result {
 	if result := deleteAMMTrustLines(view, ammAccountID, maxDeletableAMMTrustLines); result != ter.TesSUCCESS {
 		return result
 	}
+	if result := deleteAMMMPTokens(view, ammAccountID, asset, asset2); result != ter.TesSUCCESS {
+		return result
+	}
 
 	// Reference: rippled AMMUtils.cpp deleteAMMAccount line 315-323
 	ownerDirKey := keylet.OwnerDir(ammAccountID)
-	state.DirRemove(view, ownerDirKey, amm.OwnerNode, ammKey.Key, false)
+	removed, err := state.DirRemove(view, ownerDirKey, amm.OwnerNode, ammKey.Key, false)
+	if err != nil || !removed.Success {
+		return ter.TecINTERNAL
+	}
 
 	// Delete the owner directory if it is now empty.
 	// Reference: rippled AMMUtils.cpp deleteAMMAccount line 324-331
 	if exists, _ := view.Exists(ownerDirKey); exists {
 		rootData, err := view.Read(ownerDirKey)
-		if err == nil && rootData != nil {
-			rootNode, err := state.ParseDirectoryNode(rootData)
-			if err == nil && len(rootNode.Indexes) == 0 && rootNode.IndexNext == 0 {
-				view.Erase(ownerDirKey)
-			}
+		if err != nil || rootData == nil {
+			return ter.TecINTERNAL
+		}
+		rootNode, err := state.ParseDirectoryNode(rootData)
+		if err != nil || len(rootNode.Indexes) != 0 || rootNode.IndexNext != 0 {
+			return ter.TecINTERNAL
+		}
+		if err := view.Erase(ownerDirKey); err != nil {
+			return ter.TecINTERNAL
 		}
 	}
 

--- a/internal/tx/amm/amm_deposit.go
+++ b/internal/tx/amm/amm_deposit.go
@@ -302,6 +302,9 @@ func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Re
 					return ter.TefINTERNAL
 				}
 				funds, result := mptFunds(view, accountID, *amt, false)
+				if result == ter.TefINTERNAL {
+					return result
+				}
 				if result != ter.TesSUCCESS || funds < requested {
 					return TecUNFUNDED_AMM
 				}
@@ -889,6 +892,9 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) ter.Result {
 				return ter.TefINTERNAL
 			}
 			funds, result := mptFunds(ctx.View, accountID, depositAmount1, false)
+			if result == ter.TefINTERNAL {
+				return result
+			}
 			if result != ter.TesSUCCESS || funds < requested {
 				return TecUNFUNDED_AMM
 			}
@@ -910,6 +916,9 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) ter.Result {
 				return ter.TefINTERNAL
 			}
 			funds, result := mptFunds(ctx.View, accountID, depositAmount2, false)
+			if result == ter.TefINTERNAL {
+				return result
+			}
 			if result != ter.TesSUCCESS || funds < requested {
 				return TecUNFUNDED_AMM
 			}

--- a/internal/tx/amm/amm_deposit.go
+++ b/internal/tx/amm/amm_deposit.go
@@ -1004,7 +1004,6 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) ter.Result {
 			if err != nil {
 				return ter.TefINTERNAL
 			}
-			// Skip if depositor IS the issuer.
 			if accountID != issuerID {
 				if err := updateTrustlineBalanceInView(accountID, issuerID, a.Asset2.Currency, depositAmount2.Negate(), ctx.View); err != nil {
 					return TecUNFUNDED_AMM

--- a/internal/tx/amm/amm_deposit.go
+++ b/internal/tx/amm/amm_deposit.go
@@ -135,7 +135,7 @@ func (a *AMMDeposit) Validate() error {
 
 	// Reference: rippled AMMDeposit.cpp lines 108-113
 	if hasAmount && hasAmount2 {
-		if a.Amount.Currency == a.Amount2.Currency && a.Amount.Issuer == a.Amount2.Issuer {
+		if matchesAssetByIssue(amountAsset(*a.Amount), amountAsset(*a.Amount2)) {
 			return ter.Errorf(ter.TemBAD_AMM_TOKENS, "Amount and Amount2 have same issue")
 		}
 	}
@@ -160,10 +160,9 @@ func (a *AMMDeposit) Validate() error {
 		}
 	}
 
-	// Validate EPrice if provided — must match Amount's issue
+	// MPTokensV2 makes EPrice issue-agnostic; its value is still validated here.
 	if hasAmount && hasEPrice {
-		amtIssue := tx.Asset{Currency: a.Amount.Currency, Issuer: a.Amount.Issuer}
-		if err := validateAMMAmountWithPair(*a.EPrice, &amtIssue, &amtIssue, false); err != nil {
+		if err := validateAMMAmount(*a.EPrice); err != nil {
 			return err
 		}
 	}
@@ -174,6 +173,14 @@ func (a *AMMDeposit) Validate() error {
 	}
 
 	return nil
+}
+
+func (a *AMMDeposit) PreflightRules(rules *amendment.Rules) error {
+	if a.Amount == nil || a.EPrice == nil || rules.Enabled(amendment.FeatureMPTokensV2) {
+		return nil
+	}
+	amountAsset := amountAsset(*a.Amount)
+	return validateAMMAmountWithPair(*a.EPrice, &amountAsset, &amountAsset, false)
 }
 
 func (a *AMMDeposit) Flatten() (map[string]any, error) {
@@ -236,7 +243,7 @@ func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Re
 		}
 	}
 
-	lptCurrency := GenerateAMMLPTCurrency(a.Asset.Currency, a.Asset2.Currency)
+	lptCurrency := GenerateAMMLPTCurrencyForAssets(a.Asset, a.Asset2)
 	lptKey := keylet.Line(accountID, ammAccountID, lptCurrency)
 	lptExists, _ := view.Exists(lptKey)
 
@@ -244,14 +251,17 @@ func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Re
 	// AMMClawback is enabled.
 	// Reference: rippled AMMDeposit.cpp lines 244-273
 	if config.RequireRules().Enabled(amendment.FeatureAMMClawback) {
-		if result := tx.RequireAuth(view, a.Asset, accountID); result != ter.TesSUCCESS {
+		if result := requireAssetAuth(view, a.Asset, accountID, false, config.ParentCloseTime); result != ter.TesSUCCESS {
 			return result
 		}
-		if result := tx.RequireAuth(view, a.Asset2, accountID); result != ter.TesSUCCESS {
+		if result := requireAssetAuth(view, a.Asset2, accountID, false, config.ParentCloseTime); result != ter.TesSUCCESS {
 			return result
 		}
-		if tx.IsFrozen(view, accountID, a.Asset) || tx.IsFrozen(view, accountID, a.Asset2) {
-			return ter.TecFROZEN
+		if assetFrozen(view, accountID, a.Asset) {
+			return frozenAssetResult(a.Asset)
+		}
+		if assetFrozen(view, accountID, a.Asset2) {
+			return frozenAssetResult(a.Asset2)
 		}
 	}
 
@@ -259,15 +269,15 @@ func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Re
 		if amt == nil {
 			return ter.TesSUCCESS
 		}
-		amtAsset := tx.Asset{Currency: amt.Currency, Issuer: amt.Issuer}
-		if result := tx.RequireAuth(view, amtAsset, accountID); result != ter.TesSUCCESS {
+		amtAsset := amountAsset(*amt)
+		if result := requireAssetAuth(view, amtAsset, accountID, true, config.ParentCloseTime); result != ter.TesSUCCESS {
 			return result
 		}
-		if tx.IsFrozen(view, ammAccountID, amtAsset) {
-			return ter.TecFROZEN
+		if assetFrozen(view, ammAccountID, amtAsset) {
+			return frozenAssetResult(amtAsset)
 		}
-		if tx.IsIndividualFrozen(view, accountID, amtAsset) {
-			return ter.TecFROZEN
+		if assetIndividuallyFrozen(view, accountID, amtAsset) {
+			return frozenAssetResult(amtAsset)
 		}
 		if checkBalance {
 			if isXRPAsset(amtAsset) {
@@ -285,6 +295,15 @@ func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Re
 						return TecUNFUNDED_AMM
 					}
 					return TecINSUF_RESERVE_LINE
+				}
+			} else if amtAsset.IsMPT() {
+				requested, ok := amt.MPTRaw()
+				if !ok {
+					return ter.TefINTERNAL
+				}
+				funds, result := mptFunds(view, accountID, *amt, false)
+				if result != ter.TesSUCCESS || funds < requested {
+					return TecUNFUNDED_AMM
 				}
 			} else {
 				issuerID, _ := state.DecodeAccountID(amtAsset.Issuer)
@@ -336,6 +355,12 @@ func (a *AMMDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Re
 			return TecINSUF_RESERVE_LINE
 		}
 	}
+	if result := canMPTTradeAndTransfer(view, a.Asset, accountID, accountID); result != ter.TesSUCCESS {
+		return result
+	}
+	if result := canMPTTradeAndTransfer(view, a.Asset2, accountID, accountID); result != ter.TesSUCCESS {
+		return result
+	}
 
 	return ter.TesSUCCESS
 }
@@ -369,7 +394,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) ter.Result {
 
 	flags := a.GetFlags()
 	ammAccountAddr, _ := encodeAccountID(ammAccountID)
-	lptCurrency := GenerateAMMLPTCurrency(a.Asset.Currency, a.Asset2.Currency)
+	lptCurrency := GenerateAMMLPTCurrencyForAssets(a.Asset, a.Asset2)
 	lptExists, _ := ctx.View.Exists(keylet.Line(accountID, ammAccountID, lptCurrency))
 
 	// Reference: rippled AMMDeposit.cpp applyGuts lines 367-480
@@ -412,7 +437,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) ter.Result {
 	// amount1 corresponds to a.Asset and amount2 corresponds to a.Asset2.
 	// This matches rippled's ammHolds issue-hint reordering behavior.
 	if a.Amount != nil && a.Amount2 != nil {
-		amountIssue := tx.Asset{Currency: a.Amount.Currency, Issuer: a.Amount.Issuer}
+		amountIssue := amountAsset(*a.Amount)
 		if matchesAssetByIssue(a.Asset2, amountIssue) && !matchesAssetByIssue(a.Asset, amountIssue) {
 			amount1, amount2 = amount2, amount1
 		}
@@ -858,21 +883,43 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) ter.Result {
 
 	// Reference: rippled preclaim checks accountHolds >= deposit for each IOU
 	if !isXRP1 && !depositAmount1.IsZero() {
-		// Skip the check if the depositor is the issuer (unlimited supply).
-		issuerID1, _ := state.DecodeAccountID(a.Asset.Issuer)
-		if accountID != issuerID1 {
-			depositorFunds := tx.AccountFunds(ctx.View, accountID, depositAmount1, false, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
-			if depositorFunds.Compare(depositAmount1) < 0 {
+		if a.Asset.IsMPT() {
+			requested, ok := depositAmount1.MPTRaw()
+			if !ok {
+				return ter.TefINTERNAL
+			}
+			funds, result := mptFunds(ctx.View, accountID, depositAmount1, false)
+			if result != ter.TesSUCCESS || funds < requested {
 				return TecUNFUNDED_AMM
+			}
+		} else {
+			// Skip the check if the depositor is the issuer (unlimited supply).
+			issuerID1, _ := state.DecodeAccountID(a.Asset.Issuer)
+			if accountID != issuerID1 {
+				depositorFunds := tx.AccountFunds(ctx.View, accountID, depositAmount1, false, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
+				if depositorFunds.Compare(depositAmount1) < 0 {
+					return TecUNFUNDED_AMM
+				}
 			}
 		}
 	}
 	if !isXRP2 && !depositAmount2.IsZero() {
-		issuerID2, _ := state.DecodeAccountID(a.Asset2.Issuer)
-		if accountID != issuerID2 {
-			depositorFunds := tx.AccountFunds(ctx.View, accountID, depositAmount2, false, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
-			if depositorFunds.Compare(depositAmount2) < 0 {
+		if a.Asset2.IsMPT() {
+			requested, ok := depositAmount2.MPTRaw()
+			if !ok {
+				return ter.TefINTERNAL
+			}
+			funds, result := mptFunds(ctx.View, accountID, depositAmount2, false)
+			if result != ter.TesSUCCESS || funds < requested {
 				return TecUNFUNDED_AMM
+			}
+		} else {
+			issuerID2, _ := state.DecodeAccountID(a.Asset2.Issuer)
+			if accountID != issuerID2 {
+				depositorFunds := tx.AccountFunds(ctx.View, accountID, depositAmount2, false, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
+				if depositorFunds.Compare(depositAmount2) < 0 {
+					return TecUNFUNDED_AMM
+				}
 			}
 		}
 	}
@@ -917,34 +964,46 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) ter.Result {
 	// For IOU transfers, update trust lines for BOTH depositor and AMM
 	// Reference: rippled AMMDeposit.cpp - deposit handles token transfer via book::quality path
 	if !isXRP1 && !depositAmount1.IsZero() {
-		issuerID, err := state.DecodeAccountID(a.Asset.Issuer)
-		if err != nil {
-			return ter.TefINTERNAL
-		}
-		// Skip the depositor's debit if it IS the issuer — issuers issue from
-		// thin air. Reference: rippled accountSend() handles this internally.
-		if accountID != issuerID {
-			if err := updateTrustlineBalanceInView(accountID, issuerID, a.Asset.Currency, depositAmount1.Negate(), ctx.View); err != nil {
-				return TecUNFUNDED_AMM
+		if a.Asset.IsMPT() {
+			if result := sendMPT(ctx.View, accountID, ammAccountID, depositAmount1, true); result != ter.TesSUCCESS {
+				return result
 			}
-		}
-		if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset, depositAmount1, ctx.View); err != nil {
-			return TecNO_LINE
+		} else {
+			issuerID, err := state.DecodeAccountID(a.Asset.Issuer)
+			if err != nil {
+				return ter.TefINTERNAL
+			}
+			// Skip the depositor's debit if it IS the issuer — issuers issue from
+			// thin air. Reference: rippled accountSend() handles this internally.
+			if accountID != issuerID {
+				if err := updateTrustlineBalanceInView(accountID, issuerID, a.Asset.Currency, depositAmount1.Negate(), ctx.View); err != nil {
+					return TecUNFUNDED_AMM
+				}
+			}
+			if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset, depositAmount1, ctx.View); err != nil {
+				return TecNO_LINE
+			}
 		}
 	}
 	if !isXRP2 && !depositAmount2.IsZero() {
-		issuerID, err := state.DecodeAccountID(a.Asset2.Issuer)
-		if err != nil {
-			return ter.TefINTERNAL
-		}
-		// Skip if depositor IS the issuer.
-		if accountID != issuerID {
-			if err := updateTrustlineBalanceInView(accountID, issuerID, a.Asset2.Currency, depositAmount2.Negate(), ctx.View); err != nil {
-				return TecUNFUNDED_AMM
+		if a.Asset2.IsMPT() {
+			if result := sendMPT(ctx.View, accountID, ammAccountID, depositAmount2, true); result != ter.TesSUCCESS {
+				return result
 			}
-		}
-		if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset2, depositAmount2, ctx.View); err != nil {
-			return TecNO_LINE
+		} else {
+			issuerID, err := state.DecodeAccountID(a.Asset2.Issuer)
+			if err != nil {
+				return ter.TefINTERNAL
+			}
+			// Skip if depositor IS the issuer.
+			if accountID != issuerID {
+				if err := updateTrustlineBalanceInView(accountID, issuerID, a.Asset2.Currency, depositAmount2.Negate(), ctx.View); err != nil {
+					return TecUNFUNDED_AMM
+				}
+			}
+			if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset2, depositAmount2, ctx.View); err != nil {
+				return TecNO_LINE
+			}
 		}
 	}
 

--- a/internal/tx/amm/amm_withdraw.go
+++ b/internal/tx/amm/amm_withdraw.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -132,7 +133,7 @@ func (a *AMMWithdraw) Validate() error {
 	}
 
 	if hasAmount && hasAmount2 {
-		if a.Amount.Currency == a.Amount2.Currency && a.Amount.Issuer == a.Amount2.Issuer {
+		if matchesAsset(a.Amount, amountAsset(*a.Amount2)) {
 			return ter.Errorf(ter.TemBAD_AMM_TOKENS, "Amount and Amount2 cannot have the same issue")
 		}
 	}
@@ -185,7 +186,7 @@ func (a *AMMWithdraw) CheckExtraFeatures(rules *amendment.Rules) error {
 // view: AMM existence and pool sanity, per-amount balance/authorization/freeze,
 // the withdrawer's LP holdings, and the LPTokenIn / EPrice issues.
 // Reference: rippled AMMWithdraw.cpp preclaim
-func (a *AMMWithdraw) Preclaim(view tx.LedgerView, _ tx.EngineConfig) ter.Result {
+func (a *AMMWithdraw) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Result {
 	accountID, err := state.DecodeAccountID(a.Account)
 	if err != nil {
 		return ter.TemBAD_SRC_ACCOUNT
@@ -215,7 +216,7 @@ func (a *AMMWithdraw) Preclaim(view tx.LedgerView, _ tx.EngineConfig) ter.Result
 		if amt == nil {
 			return assetBalance1
 		}
-		amtAsset := tx.Asset{Currency: amt.Currency, Issuer: amt.Issuer}
+		amtAsset := amountAsset(*amt)
 		if matchesAssetByIssue(a.Asset, amtAsset) {
 			return assetBalance1
 		}
@@ -226,18 +227,18 @@ func (a *AMMWithdraw) Preclaim(view tx.LedgerView, _ tx.EngineConfig) ter.Result
 		if amt == nil {
 			return ter.TesSUCCESS
 		}
-		amtAsset := tx.Asset{Currency: amt.Currency, Issuer: amt.Issuer}
-		if isGreater(toIOUForCalc(*amt), toIOUForCalc(balance)) {
+		amtAsset := amountAsset(*amt)
+		if isGreater(*amt, balance) {
 			return ter.TecAMM_BALANCE
 		}
-		if result := tx.RequireAuth(view, amtAsset, accountID); result != ter.TesSUCCESS {
+		if result := requireAssetAuth(view, amtAsset, accountID, false, config.ParentCloseTime); result != ter.TesSUCCESS {
 			return result
 		}
-		if tx.IsFrozen(view, ammAccountID, amtAsset) {
-			return ter.TecFROZEN
+		if assetFrozen(view, ammAccountID, amtAsset) {
+			return frozenAssetResult(amtAsset)
 		}
-		if tx.IsIndividualFrozen(view, accountID, amtAsset) {
-			return ter.TecFROZEN
+		if assetIndividuallyFrozen(view, accountID, amtAsset) {
+			return frozenAssetResult(amtAsset)
 		}
 		return ter.TesSUCCESS
 	}
@@ -428,7 +429,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 		// the adjusted tokens are factored in
 		amountWithdraw := ammAssetOut(assetBalance, lptBalance, tokensAdj, tfee, fixV1_3)
 		// For OneAssetWithdrawAll, amount==zero or amountWithdraw >= amount
-		if !amount1.IsZero() && toIOUForCalc(amountWithdraw).Compare(toIOUForCalc(amount1)) < 0 {
+		if !amount1.IsZero() && compareAmounts(amountWithdraw, amount1) < 0 {
 			return ter.TecAMM_FAILED
 		}
 
@@ -501,7 +502,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 		frac = adjustFracByTokens(fixV1_3, lptBalance, tokensAdj, frac)
 		amount2Withdraw := getRoundedAsset(fixV1_3, assetBalance2, frac, false)
 
-		if toIOUForCalc(amount2Withdraw).Compare(toIOUForCalc(amount2)) <= 0 {
+		if compareAmounts(amount2Withdraw, amount2) <= 0 {
 			withdrawAmount1 = amount1
 			withdrawAmount2 = amount2Withdraw
 			lpTokensToRedeem = tokensAdj
@@ -514,7 +515,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 			frac = adjustFracByTokens(fixV1_3, lptBalance, tokensAdj, frac)
 			amountWithdraw := getRoundedAsset(fixV1_3, assetBalance1, frac, false)
 
-			if fixV1_3 && toIOUForCalc(amountWithdraw).Compare(toIOUForCalc(amount1)) > 0 {
+			if fixV1_3 && compareAmounts(amountWithdraw, amount1) > 0 {
 				return ter.TecAMM_FAILED
 			}
 
@@ -557,7 +558,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 
 		// the adjusted tokens are factored in
 		amountWithdraw := ammAssetOut(assetBalance, lptBalance, tokensAdj, tfee, fixV1_3)
-		if amount1.IsZero() || toIOUForCalc(amountWithdraw).Compare(toIOUForCalc(amount1)) >= 0 {
+		if amount1.IsZero() || compareAmounts(amountWithdraw, amount1) >= 0 {
 			if isWithdrawAsset1 {
 				withdrawAmount1 = amountWithdraw
 				withdrawAmount2 = zeroAmount(a.Asset2)
@@ -630,7 +631,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 			},
 			false)
 
-		if amount1.IsZero() || toIOUForCalc(amountWithdraw).Compare(toIOUForCalc(amount1)) >= 0 {
+		if amount1.IsZero() || compareAmounts(amountWithdraw, amount1) >= 0 {
 			if isWithdrawAsset1 {
 				withdrawAmount1 = amountWithdraw
 				withdrawAmount2 = zeroAmount(a.Asset2)
@@ -693,16 +694,16 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 	}
 
 	// Verify withdrawal doesn't exceed balances
-	if isGreater(toIOUForCalc(withdrawAmount1), toIOUForCalc(assetBalance1)) {
+	if isGreater(withdrawAmount1, assetBalance1) {
 		return ter.TecAMM_BALANCE
 	}
-	if isGreater(toIOUForCalc(withdrawAmount2), toIOUForCalc(assetBalance2)) {
+	if isGreater(withdrawAmount2, assetBalance2) {
 		return ter.TecAMM_BALANCE
 	}
 
 	// Per rippled: Cannot withdraw one side of the pool while leaving the other
-	w1EqualsB1 := toIOUForCalc(withdrawAmount1).Compare(toIOUForCalc(assetBalance1)) == 0
-	w2EqualsB2 := toIOUForCalc(withdrawAmount2).Compare(toIOUForCalc(assetBalance2)) == 0
+	w1EqualsB1 := compareAmounts(withdrawAmount1, assetBalance1) == 0
+	w2EqualsB2 := compareAmounts(withdrawAmount2, assetBalance2) == 0
 	if (w1EqualsB1 && !w2EqualsB2) || (w2EqualsB2 && !w1EqualsB1) {
 		return ter.TecAMM_BALANCE
 	}
@@ -711,6 +712,32 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 	if toIOUForCalc(lpTokensToRedeem).Compare(toIOUForCalc(lptBalance)) == 0 &&
 		(!w1EqualsB1 || !w2EqualsB2) {
 		return ter.TecAMM_BALANCE
+	}
+
+	if ctx.Rules().Enabled(amendment.FeatureMPTokensV2) {
+		remainingLP, err := lptBalance.Sub(lpTokensToRedeem)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		remaining1, err := assetBalance1.Sub(withdrawAmount1)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		remaining2, err := assetBalance2.Sub(withdrawAmount2)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		valid := remaining1.IsZero() == remaining2.IsZero() && remaining2.IsZero() == remainingLP.IsZero()
+		if isSingleAssetWithdraw {
+			if singleWithdrawIsAsset2 {
+				valid = remaining2.IsZero() == remainingLP.IsZero()
+			} else {
+				valid = remaining1.IsZero() == remainingLP.IsZero()
+			}
+		}
+		if !valid {
+			return ter.TecAMM_BALANCE
+		}
 	}
 
 	isXRP1 := isXRPAsset(a.Asset)
@@ -735,20 +762,12 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 	enabledFixAMMv1_2 := ctx.Rules().Enabled(amendment.FeatureFixAMMv1_2)
 
 	if !isXRP1 && !withdrawAmount1.IsZero() {
-		issuerID, err := state.DecodeAccountID(a.Asset.Issuer)
-		if err != nil {
-			return ter.TefINTERNAL
-		}
-		if result := withdrawIOUToAccount(ctx, accountID, issuerID, ammAccountID, a.Asset, withdrawAmount1, enabledFixAMMv1_2); result != ter.TesSUCCESS {
+		if result := withdrawAssetToAccount(ctx, accountID, ammAccountID, a.Asset, withdrawAmount1, enabledFixAMMv1_2); result != ter.TesSUCCESS {
 			return result
 		}
 	}
 	if !isXRP2 && !withdrawAmount2.IsZero() {
-		issuerID, err := state.DecodeAccountID(a.Asset2.Issuer)
-		if err != nil {
-			return ter.TefINTERNAL
-		}
-		if result := withdrawIOUToAccount(ctx, accountID, issuerID, ammAccountID, a.Asset2, withdrawAmount2, enabledFixAMMv1_2); result != ter.TesSUCCESS {
+		if result := withdrawAssetToAccount(ctx, accountID, ammAccountID, a.Asset2, withdrawAmount2, enabledFixAMMv1_2); result != ter.TesSUCCESS {
 			return result
 		}
 	}
@@ -757,7 +776,7 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Uses redeemIOUWithCleanup which handles trust line deletion when balance reaches zero.
 	// Reference: rippled AMMWithdraw.cpp — redeemIOU(account_, lpTokensActual, lpTokens.issue())
 	if !lpTokensToRedeem.IsZero() {
-		lptCurrency := GenerateAMMLPTCurrency(amm.Asset.Currency, amm.Asset2.Currency)
+		lptCurrency := GenerateAMMLPTCurrencyForAssets(amm.Asset, amm.Asset2)
 		ammAccountAddr, _ := state.EncodeAccountID(amm.Account)
 		redeemAmt := state.NewIssuedAmountFromValue(
 			lpTokensToRedeem.Mantissa(), lpTokensToRedeem.Exponent(), lptCurrency, ammAccountAddr)
@@ -796,6 +815,57 @@ func (a *AMMWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 	ctx.Account.OwnerCount = accountFromView.OwnerCount
 
 	return ter.TesSUCCESS
+}
+
+func withdrawAssetToAccount(
+	ctx *tx.ApplyContext,
+	accountID, ammAccountID [20]byte,
+	asset tx.Asset,
+	amount tx.Amount,
+	enabledFixAMMv1_2 bool,
+) ter.Result {
+	if asset.IsMPT() {
+		id, result := decodeMPTAsset(asset)
+		if result != ter.TesSUCCESS {
+			return result
+		}
+		if accountID != mptutil.Issuer(id) {
+			tokenKey := keylet.MPTokenByID(id, accountID)
+			exists, err := ctx.View.Exists(tokenKey)
+			if err != nil {
+				return ter.TefINTERNAL
+			}
+			if !exists && enabledFixAMMv1_2 {
+				ownerCount := ctx.Account.OwnerCount
+				if accountID != ctx.AccountID {
+					account, err := tx.ReadAccountRoot(ctx.View, accountID)
+					if err != nil || account == nil {
+						return ter.TefINTERNAL
+					}
+					ownerCount = account.OwnerCount
+				}
+				if ownerCount >= 2 && ctx.PriorBalance() < ctx.AccountReserve(ownerCount+1) {
+					return ter.TecINSUFFICIENT_RESERVE
+				}
+				if result := mptutil.RequireAuthAt(ctx.View, id, accountID, false, ctx.Config.ParentCloseTime); result != ter.TesSUCCESS {
+					return result
+				}
+				if result := mptutil.EnsureHolding(ctx.View, id, accountID, 0, true); result != ter.TesSUCCESS {
+					return result
+				}
+				if accountID == ctx.AccountID {
+					ctx.SyncSenderOwnerCount()
+				}
+			}
+		}
+		return sendMPT(ctx.View, ammAccountID, accountID, amount, true)
+	}
+
+	issuerID, err := state.DecodeAccountID(asset.Issuer)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	return withdrawIOUToAccount(ctx, accountID, issuerID, ammAccountID, asset, amount, enabledFixAMMv1_2)
 }
 
 // withdrawIOUToAccount handles IOU transfer from AMM to withdrawer, including

--- a/internal/tx/amm/asset.go
+++ b/internal/tx/amm/asset.go
@@ -1,8 +1,11 @@
 package amm
 
 import (
+	"strings"
+
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
@@ -11,7 +14,7 @@ import (
 // isXRPAsset reports whether an asset names XRP. XRP is encoded as either an
 // empty currency or the ISO code "XRP".
 func isXRPAsset(asset tx.Asset) bool {
-	return asset.Currency == "" || asset.Currency == "XRP"
+	return !asset.IsMPT() && (asset.Currency == "" || asset.Currency == "XRP")
 }
 
 // zeroIOU returns a zero-valued issued amount with no currency or issuer,
@@ -23,6 +26,9 @@ func zeroIOU() tx.Amount {
 // matchesAssetByIssue checks if two Assets represent the same issue.
 // Handles XRP being represented as either "" or "XRP" for currency.
 func matchesAssetByIssue(a, b tx.Asset) bool {
+	if a.IsMPT() || b.IsMPT() {
+		return a.IsMPT() && b.IsMPT() && strings.EqualFold(a.MPTIssuanceID, b.MPTIssuanceID)
+	}
 	if isXRPAsset(a) && isXRPAsset(b) {
 		return true
 	}
@@ -34,6 +40,10 @@ func matchesAssetByIssue(a, b tx.Asset) bool {
 func matchesAsset(amt *tx.Amount, asset tx.Asset) bool {
 	if amt == nil {
 		return false
+	}
+	if amt.IsMPT() || asset.IsMPT() {
+		return amt.IsMPT() && asset.IsMPT() &&
+			strings.EqualFold(amt.MPTIssuanceID(), asset.MPTIssuanceID)
 	}
 	// Check if both are XRP (currency empty or "XRP", no issuer)
 	amtIsXRP := amt.IsNative() || amt.Currency == "" || amt.Currency == "XRP"
@@ -80,7 +90,43 @@ func zeroAmount(asset tx.Asset) tx.Amount {
 	if isXRPAsset(asset) {
 		return state.NewXRPAmountFromInt(0)
 	}
+	if asset.IsMPT() {
+		return mptAmount(asset, 0)
+	}
 	return state.NewIssuedAmountFromValue(0, -100, asset.Currency, asset.Issuer)
+}
+
+func mptAmount(asset tx.Asset, value int64) tx.Amount {
+	issuer := asset.Issuer
+	if issuer == "" {
+		if id, err := mptutil.DecodeID(asset.MPTIssuanceID); err == nil {
+			issuer, _ = state.EncodeAccountID(mptutil.Issuer(id))
+		}
+	}
+	return state.NewMPTAmountWithIssuanceID(value, issuer, asset.MPTIssuanceID)
+}
+
+func mptValue(amount tx.Amount) (int64, bool) {
+	if !amount.IsMPT() {
+		return 0, false
+	}
+	return amount.MPTRaw()
+}
+
+func compareAmounts(a, b tx.Amount) int {
+	if av, aok := mptValue(a); aok {
+		if bv, bok := mptValue(b); bok {
+			switch {
+			case av < bv:
+				return -1
+			case av > bv:
+				return 1
+			default:
+				return 0
+			}
+		}
+	}
+	return a.Compare(b)
 }
 
 // compareAccountIDs compares two account IDs lexicographically.
@@ -95,7 +141,7 @@ func encodeAccountID(accountID [20]byte) (string, error) {
 
 // minAmountIOU returns the smaller of two amounts compared in IOU space.
 func minAmountIOU(a, b tx.Amount) tx.Amount {
-	if toIOUForCalc(a).Compare(toIOUForCalc(b)) < 0 {
+	if compareAmounts(a, b) < 0 {
 		return a
 	}
 	return b
@@ -104,7 +150,7 @@ func minAmountIOU(a, b tx.Amount) tx.Amount {
 // maxAmount returns the larger of two amounts.
 // Assumes both amounts are of the same type (both XRP or same IOU).
 func maxAmount(a, b tx.Amount) tx.Amount {
-	if a.Compare(b) > 0 {
+	if compareAmounts(a, b) > 0 {
 		return a
 	}
 	return b
@@ -112,17 +158,17 @@ func maxAmount(a, b tx.Amount) tx.Amount {
 
 // isGreater returns true if a > b
 func isGreater(a, b tx.Amount) bool {
-	return a.Compare(b) > 0
+	return compareAmounts(a, b) > 0
 }
 
 // isGreaterOrEqual returns true if a >= b
 func isGreaterOrEqual(a, b tx.Amount) bool {
-	return a.Compare(b) >= 0
+	return compareAmounts(a, b) >= 0
 }
 
 // isLessOrEqual returns true if a <= b
 func isLessOrEqual(a, b tx.Amount) bool {
-	return a.Compare(b) <= 0
+	return compareAmounts(a, b) <= 0
 }
 
 // withinRelativeDistance checks if two amounts are within relative distance dist.
@@ -167,7 +213,7 @@ func isOnlyLiquidityProvider(view tx.LedgerView, lptCurrency string, ammAccountI
 		return false, ter.TecINTERNAL
 	}
 
-	var nLPTokenTrustLines, nIOUTrustLines uint8
+	var nLPTokenTrustLines, nIOUTrustLines, nMPT uint8
 	hasAMM := false
 
 	ownerDirKey := keylet.OwnerDir(ammAccountID)
@@ -197,6 +243,12 @@ func isOnlyLiquidityProvider(view tx.LedgerView, lptCurrency string, ammAccountI
 					return false, ter.TecINTERNAL
 				}
 				hasAMM = true
+				continue
+			}
+			if entry.Type(entryType) == entry.TypeMPToken {
+				if nMPT++; nMPT > 2 {
+					return false, ter.TecINTERNAL
+				}
 				continue
 			}
 			if entry.Type(entryType) != entry.TypeRippleState {
@@ -232,7 +284,8 @@ func isOnlyLiquidityProvider(view tx.LedgerView, lptCurrency string, ammAccountI
 		}
 
 		if currentPage.IndexNext == 0 {
-			if nLPTokenTrustLines != 1 || nIOUTrustLines == 0 || nIOUTrustLines > 2 {
+			if nLPTokenTrustLines != 1 || nIOUTrustLines == 0 && nMPT == 0 ||
+				nIOUTrustLines > 2 || nMPT > 2 || nIOUTrustLines+nMPT > 2 {
 				return false, ter.TecINTERNAL
 			}
 			return true, ter.TesSUCCESS

--- a/internal/tx/amm/formulas.go
+++ b/internal/tx/amm/formulas.go
@@ -98,10 +98,10 @@ func adjustAmountsByLPTokens(
 	if lpTokensActual.IsZero() {
 		var amount2Opt *tx.Amount
 		if amount2 != nil {
-			zero := zeroAmount(tx.Asset{Currency: (*amount2).Currency, Issuer: (*amount2).Issuer})
+			zero := zeroAmount(amountAsset(*amount2))
 			amount2Opt = &zero
 		}
-		zero := zeroAmount(tx.Asset{Currency: amount.Currency, Issuer: amount.Issuer})
+		zero := zeroAmount(amountAsset(amount))
 		return zero, amount2Opt, lpTokensActual
 	}
 
@@ -542,7 +542,7 @@ func initializeFeeAuctionVote(amm *AMMData, accountID [20]byte, lptCurrency stri
 // the last LP's trust line balance differs from it due to rounding.
 // Reference: rippled AMMUtils.cpp verifyAndAdjustLPTokenBalance (lines 468-494)
 func verifyAndAdjustLPTokenBalance(view tx.LedgerView, ammKey keylet.Keylet, lpTokens tx.Amount, amm *AMMData, lpAccountID [20]byte) ter.Result {
-	lptCurrency := GenerateAMMLPTCurrency(amm.Asset.Currency, amm.Asset2.Currency)
+	lptCurrency := GenerateAMMLPTCurrencyForAssets(amm.Asset, amm.Asset2)
 	onlyLP, res := isOnlyLiquidityProvider(view, lptCurrency, amm.Account, lpAccountID)
 	if res != ter.TesSUCCESS {
 		return res

--- a/internal/tx/amm/keylet.go
+++ b/internal/tx/amm/keylet.go
@@ -3,6 +3,7 @@ package amm
 import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -31,12 +32,15 @@ func PseudoAccountAddress(view tx.LedgerView, parentHash [32]byte, key [32]byte)
 
 // computeAMMKeylet computes the AMM keylet from the asset pair.
 func computeAMMKeylet(asset1, asset2 tx.Asset) keylet.Keylet {
-	issuer1 := getIssuerBytes(asset1.Issuer)
-	currency1 := keylet.CurrencyBytes(asset1.Currency)
-	issuer2 := getIssuerBytes(asset2.Issuer)
-	currency2 := keylet.CurrencyBytes(asset2.Currency)
+	return keylet.AMMAsset(assetBookSide(asset1), assetBookSide(asset2))
+}
 
-	return keylet.AMM(issuer1, currency1, issuer2, currency2)
+func assetBookSide(asset tx.Asset) keylet.BookSide {
+	if asset.IsMPT() {
+		id, _ := mptutil.DecodeID(asset.MPTIssuanceID)
+		return keylet.MPTSide(id)
+	}
+	return keylet.IssueSide(keylet.CurrencyBytes(asset.Currency), getIssuerBytes(asset.Issuer))
 }
 
 // getIssuerBytes converts an issuer address string to a 20-byte account ID.

--- a/internal/tx/amm/lpt_currency_test.go
+++ b/internal/tx/amm/lpt_currency_test.go
@@ -1,7 +1,13 @@
 package amm
 
 import (
+	"encoding/hex"
+	"strings"
 	"testing"
+
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 func TestGenerateAMMLPTCurrency_XRP_USD(t *testing.T) {
@@ -21,5 +27,28 @@ func TestGenerateAMMLPTCurrency_XRP_USD(t *testing.T) {
 	t.Logf("GenerateAMMLPTCurrency('', USD)  = %s", result2)
 	if result2 != expected {
 		t.Errorf("LP currency mismatch with empty XRP:\n  got:  %s\n  want: %s", result2, expected)
+	}
+}
+
+func TestGenerateAMMLPTCurrency_MPT_XRP(t *testing.T) {
+	idHex := "00000001ABCDEF0123456789ABCDEF0123456789ABCDEF12"
+	id, err := hex.DecodeString(idHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	xrp := keylet.CurrencyBytes("XRP")
+	hash := sha512half.Sum(id, xrp[:])
+	var currency [20]byte
+	currency[0] = 3
+	copy(currency[1:], hash[:19])
+	expected := strings.ToUpper(hex.EncodeToString(currency[:]))
+
+	mpt := tx.Asset{MPTIssuanceID: idHex}
+	xrpAsset := tx.Asset{Currency: "XRP"}
+	if got := GenerateAMMLPTCurrencyForAssets(mpt, xrpAsset); got != expected {
+		t.Fatalf("MPT/XRP LP currency: got %s, want %s", got, expected)
+	}
+	if got := GenerateAMMLPTCurrencyForAssets(xrpAsset, mpt); got != expected {
+		t.Fatalf("LP currency must be symmetric: got %s, want %s", got, expected)
 	}
 }

--- a/internal/tx/amm/math.go
+++ b/internal/tx/amm/math.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/crypto/sha512half"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -43,22 +44,20 @@ func calculateLPTokens(amount1, amount2 tx.Amount, fixV1_3 bool) tx.Amount {
 // The LP token currency is 0x03 prefix + first 19 bytes of sha512Half(min(c1,c2), max(c1,c2)).
 // Reference: rippled AMMCore.cpp ammLPTCurrency()
 func GenerateAMMLPTCurrency(currency1, currency2 string) string {
-	c1 := keylet.CurrencyBytes(currency1)
-	c2 := keylet.CurrencyBytes(currency2)
+	return GenerateAMMLPTCurrencyForAssets(
+		tx.Asset{Currency: currency1},
+		tx.Asset{Currency: currency2},
+	)
+}
 
-	// Sort currencies lexicographically (std::minmax in rippled)
-	minC, maxC := c1, c2
-	for i := range 20 {
-		if c1[i] < c2[i] {
-			break
-		} else if c1[i] > c2[i] {
-			minC, maxC = c2, c1
-			break
-		}
+func GenerateAMMLPTCurrencyForAssets(asset1, asset2 tx.Asset) string {
+	minAsset, maxAsset := asset1, asset2
+	if !assetLessEqual(asset1, asset2) {
+		minAsset, maxAsset = asset2, asset1
 	}
-
-	// sha512Half(minC, maxC)
-	hash := sha512half.Sum(minC[:], maxC[:])
+	minSeed := ammLPTSeed(minAsset)
+	maxSeed := ammLPTSeed(maxAsset)
+	hash := sha512half.Sum(minSeed, maxSeed)
 
 	// AMM LPToken currency: 0x03 + first 19 bytes of hash
 	var lptCurrency [20]byte
@@ -66,6 +65,15 @@ func GenerateAMMLPTCurrency(currency1, currency2 string) string {
 	copy(lptCurrency[1:], hash[:19])
 
 	return fmt.Sprintf("%X", lptCurrency)
+}
+
+func ammLPTSeed(asset tx.Asset) []byte {
+	if asset.IsMPT() {
+		id, _ := mptutil.DecodeID(asset.MPTIssuanceID)
+		return id[:]
+	}
+	currency := keylet.CurrencyBytes(asset.Currency)
+	return currency[:]
 }
 
 // numberPower returns f^n using exponentiation by squaring.
@@ -212,6 +220,9 @@ func toSTAmount(original, result tx.Amount) tx.Amount {
 		drops := iouToDrops(result)
 		return state.NewXRPAmountFromInt(drops)
 	}
+	if original.IsMPT() {
+		return mptFromNumber(original, result, state.RoundToNearest)
+	}
 	return state.NewIssuedAmountFromValue(result.Mantissa(), result.Exponent(),
 		original.Currency, original.Issuer)
 }
@@ -224,6 +235,9 @@ func toSTAmountIssue(amt tx.Amount, result tx.Amount) tx.Amount {
 		drops := iouToDropsRounded(result, state.RoundToNearest)
 		return state.NewXRPAmountFromInt(drops)
 	}
+	if amt.IsMPT() {
+		return mptFromNumber(amt, result, state.RoundToNearest)
+	}
 	return state.NewIssuedAmountFromValue(result.Mantissa(), result.Exponent(),
 		amt.Currency, amt.Issuer)
 }
@@ -234,6 +248,9 @@ func toSTAmountIssue(amt tx.Amount, result tx.Amount) tx.Amount {
 func toSTAmountIssueRounded(amt tx.Amount, result tx.Amount, mode state.RoundingMode) tx.Amount {
 	if amt.IsNative() {
 		return state.NewXRPAmountFromInt(iouToDropsRounded(result, mode))
+	}
+	if amt.IsMPT() {
+		return mptFromNumber(amt, result, mode)
 	}
 	return state.NewIssuedAmountFromValue(result.Mantissa(), result.Exponent(),
 		amt.Currency, amt.Issuer)
@@ -253,8 +270,17 @@ func mulRoundForAsset(amount, frac tx.Amount, rm state.RoundingMode, asset tx.Am
 	}
 	// For IOU: rounding mode active during multiplication normalization
 	result := amount.MulRounded(frac, rm == state.RoundUpward, rm)
+	if asset.IsMPT() {
+		return mptFromNumber(asset, result, rm)
+	}
 	return state.NewIssuedAmountFromValue(result.Mantissa(), result.Exponent(),
 		asset.Currency, asset.Issuer)
+}
+
+func mptFromNumber(original, number tx.Amount, mode state.RoundingMode) tx.Amount {
+	value := state.NewXRPLNumberRounded(number.Mantissa(), number.Exponent(), mode).
+		ToInt64WithMode(mode)
+	return mptAmount(amountAsset(original), value)
 }
 
 // multiplyRawToDrops multiplies two IOU-format amounts and converts the
@@ -379,6 +405,9 @@ func applyGuardRound(mantissa, guardDigit int64, hasRemainder, neg bool, rm stat
 // This is necessary because XRP/XRP division uses integer arithmetic and loses precision.
 // For example, 1000 XRP / 10000 XRP = 0 with integer division, but should be 0.1 as a fraction.
 func toIOUForCalc(amt tx.Amount) tx.Amount {
+	if value, ok := amt.MPTRaw(); ok {
+		return state.NewIssuedAmountFromValue(value, 0, "", "")
+	}
 	if !amt.IsNative() {
 		// Drop the currency/issuer tag: AMM math operates in rippled's
 		// unitless Number space, where amounts of any asset are freely

--- a/internal/tx/amm/mpt_apply.go
+++ b/internal/tx/amm/mpt_apply.go
@@ -1,0 +1,115 @@
+package amm
+
+import (
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+)
+
+func decodeMPTAsset(asset tx.Asset) ([24]byte, ter.Result) {
+	id, err := mptutil.DecodeID(asset.MPTIssuanceID)
+	if err != nil {
+		return id, ter.TecOBJECT_NOT_FOUND
+	}
+	return id, ter.TesSUCCESS
+}
+
+func assetIssuerID(asset tx.Asset) ([20]byte, ter.Result) {
+	if asset.IsMPT() {
+		id, result := decodeMPTAsset(asset)
+		if result != ter.TesSUCCESS {
+			return [20]byte{}, result
+		}
+		return mptutil.Issuer(id), ter.TesSUCCESS
+	}
+	issuer, err := state.DecodeAccountID(asset.Issuer)
+	if err != nil {
+		return [20]byte{}, ter.TefINTERNAL
+	}
+	return issuer, ter.TesSUCCESS
+}
+
+func requireAssetAuth(view tx.LedgerView, asset tx.Asset, account [20]byte, strong bool, parentCloseTime uint32) ter.Result {
+	if !asset.IsMPT() {
+		return tx.RequireAuth(view, asset, account)
+	}
+	id, result := decodeMPTAsset(asset)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	return mptutil.RequireAuthAt(view, id, account, strong, parentCloseTime)
+}
+
+func assetFrozen(view tx.LedgerView, account [20]byte, asset tx.Asset) bool {
+	if !asset.IsMPT() {
+		return tx.IsFrozen(view, account, asset)
+	}
+	id, result := decodeMPTAsset(asset)
+	return result == ter.TesSUCCESS && mptutil.IsFrozen(view, id, account)
+}
+
+func assetIndividuallyFrozen(view tx.LedgerView, account [20]byte, asset tx.Asset) bool {
+	if !asset.IsMPT() {
+		return tx.IsIndividualFrozen(view, account, asset)
+	}
+	id, result := decodeMPTAsset(asset)
+	return result == ter.TesSUCCESS && mptutil.IsIndividualFrozen(view, id, account)
+}
+
+func frozenAssetResult(asset tx.Asset) ter.Result {
+	if asset.IsMPT() {
+		return ter.TecLOCKED
+	}
+	return ter.TecFROZEN
+}
+
+func canMPTTradeAndTransfer(view tx.LedgerView, asset tx.Asset, from, to [20]byte) ter.Result {
+	if !asset.IsMPT() {
+		return ter.TesSUCCESS
+	}
+	id, result := decodeMPTAsset(asset)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if result := mptutil.CanTrade(view, id); result != ter.TesSUCCESS {
+		return result
+	}
+	return mptutil.CanTransfer(view, id, from, to)
+}
+
+func mptFunds(view tx.LedgerView, account [20]byte, amount tx.Amount, zeroIfFrozen bool) (int64, ter.Result) {
+	id, result := decodeMPTAsset(amountAsset(amount))
+	if result != ter.TesSUCCESS {
+		return 0, result
+	}
+	return mptutil.Funds(view, id, account, zeroIfFrozen)
+}
+
+func sendMPT(view tx.LedgerView, from, to [20]byte, amount tx.Amount, waiveFee bool) ter.Result {
+	id, result := decodeMPTAsset(amountAsset(amount))
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	value, ok := amount.MPTRaw()
+	if !ok || value < 0 {
+		return ter.TefINTERNAL
+	}
+	_, result = mptutil.Send(view, id, from, to, value, waiveFee, false)
+	return result
+}
+
+func ensureAMMMPTHolding(view tx.LedgerView, asset tx.Asset, ammAccount [20]byte) ter.Result {
+	id, result := decodeMPTAsset(asset)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	return mptutil.EnsureHolding(
+		view,
+		id,
+		ammAccount,
+		entry.LsfMPTAMM|entry.LsfMPTAuthorized,
+		false,
+	)
+}

--- a/internal/tx/amm/mpt_apply_test.go
+++ b/internal/tx/amm/mpt_apply_test.go
@@ -1,0 +1,292 @@
+package amm
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+	"github.com/stretchr/testify/require"
+)
+
+type ammMPTView struct {
+	data  map[[32]byte][]byte
+	rules *amendment.Rules
+}
+
+func newAMMMPTView() *ammMPTView {
+	rules := amendment.NewRulesBuilder().
+		FromPreset(amendment.PresetAllSupported).
+		Enable(amendment.FeatureMPTokensV2).
+		Build()
+	return &ammMPTView{data: make(map[[32]byte][]byte), rules: rules}
+}
+
+func (v *ammMPTView) Read(k keylet.Keylet) ([]byte, error) { return v.data[k.Key], nil }
+func (v *ammMPTView) Exists(k keylet.Keylet) (bool, error) {
+	_, ok := v.data[k.Key]
+	return ok, nil
+}
+func (v *ammMPTView) Insert(k keylet.Keylet, data []byte) error {
+	v.data[k.Key] = data
+	return nil
+}
+func (v *ammMPTView) Update(k keylet.Keylet, data []byte) error {
+	v.data[k.Key] = data
+	return nil
+}
+func (v *ammMPTView) Erase(k keylet.Keylet) error {
+	delete(v.data, k.Key)
+	return nil
+}
+func (v *ammMPTView) AdjustDropsDestroyed(drops.XRPAmount) {}
+func (v *ammMPTView) ForEach(fn func([32]byte, []byte) bool) error {
+	for k, data := range v.data {
+		if !fn(k, data) {
+			break
+		}
+	}
+	return nil
+}
+func (v *ammMPTView) Succ([32]byte) ([32]byte, []byte, bool, error) {
+	return [32]byte{}, nil, false, nil
+}
+func (v *ammMPTView) TxExists([32]byte) bool                    { return false }
+func (v *ammMPTView) Rules() *amendment.Rules                   { return v.rules }
+func (v *ammMPTView) LedgerSeq() uint32                         { return 1 }
+func (v *ammMPTView) AdjustOwnerCount([20]byte, uint32, uint32) {}
+
+func ammMPTID(sequence uint32, issuer [20]byte) [24]byte {
+	var id [24]byte
+	binary.BigEndian.PutUint32(id[:4], sequence)
+	copy(id[4:], issuer[:])
+	return id
+}
+
+func insertAMMMPTAccount(t *testing.T, view *ammMPTView, id [20]byte, balance uint64, ownerCount uint32) *state.AccountRoot {
+	t.Helper()
+	account := &state.AccountRoot{
+		Account:    state.EncodeAccountIDSafe(id),
+		Balance:    balance,
+		OwnerCount: ownerCount,
+		Sequence:   1,
+	}
+	raw, err := state.SerializeAccountRoot(account)
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.Account(id), raw))
+	return account
+}
+
+func insertAMMMPTIssuance(t *testing.T, view *ammMPTView, id [24]byte, flags uint32, transferFee uint16) {
+	t.Helper()
+	maximum := uint64(1_000_000)
+	issuance := &state.MPTokenIssuanceData{
+		Issuer:        mptutil.Issuer(id),
+		Sequence:      binary.BigEndian.Uint32(id[:4]),
+		MaximumAmount: &maximum,
+		TransferFee:   transferFee,
+		Flags:         flags,
+	}
+	raw, err := state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.MPTIssuance(id), raw))
+}
+
+func readAMMMPTAccount(t *testing.T, view *ammMPTView, id [20]byte) *state.AccountRoot {
+	t.Helper()
+	raw, err := view.Read(keylet.Account(id))
+	require.NoError(t, err)
+	account, err := state.ParseAccountRoot(raw)
+	require.NoError(t, err)
+	return account
+}
+
+func ammMPTContext(view *ammMPTView, account *state.AccountRoot, accountID [20]byte) *tx.ApplyContext {
+	return &tx.ApplyContext{
+		View:      view,
+		Account:   account,
+		AccountID: accountID,
+		Config: tx.EngineConfig{
+			ReserveBase:      10_000_000,
+			ReserveIncrement: 2_000_000,
+			LedgerSequence:   1,
+			Rules:            view.rules,
+		},
+		Metadata: &tx.Metadata{},
+		Log:      xrpllog.Discard(),
+		Ctx:      context.Background(),
+	}
+}
+
+func TestAMMCreateMPTApplyAndDelete(t *testing.T) {
+	view := newAMMMPTView()
+	var issuerID, creatorID [20]byte
+	copy(issuerID[:], []byte("amm-mpt-issuer-00001"))
+	copy(creatorID[:], []byte("amm-mpt-creator-0001"))
+	issuerAddr := state.EncodeAccountIDSafe(issuerID)
+	creatorAddr := state.EncodeAccountIDSafe(creatorID)
+	insertAMMMPTAccount(t, view, issuerID, 100_000_000, 0)
+	insertAMMMPTAccount(t, view, creatorID, 100_000_000, 0)
+
+	id := ammMPTID(7, issuerID)
+	idHex := mptutil.EncodeID(id)
+	issuanceFlags := entry.LsfMPTRequireAuth | entry.LsfMPTCanTrade |
+		entry.LsfMPTCanTransfer | entry.LsfMPTCanClawback
+	insertAMMMPTIssuance(t, view, id, issuanceFlags, 5_000)
+	require.Equal(t, ter.TesSUCCESS,
+		mptutil.EnsureHolding(view, id, creatorID, entry.LsfMPTAuthorized, true))
+	require.Equal(t, ter.TesSUCCESS, mptutil.Credit(view, id, issuerID, creatorID, 2_000, false))
+
+	creator := readAMMMPTAccount(t, view, creatorID)
+	mptAsset := tx.Asset{MPTIssuanceID: idHex}
+	xrpAsset := tx.Asset{Currency: "XRP"}
+	mptDeposit := state.NewMPTAmountWithIssuanceID(1_000, issuerAddr, idHex)
+	xrpDeposit := state.NewXRPAmountFromInt(1_000_000)
+	create := NewAMMCreate(creatorAddr, mptDeposit, xrpDeposit, 300)
+	config := tx.EngineConfig{
+		ReserveBase:      10_000_000,
+		ReserveIncrement: 2_000_000,
+		LedgerSequence:   1,
+		Rules:            view.rules,
+	}
+
+	require.Equal(t, ter.TesSUCCESS, create.Preclaim(view, config))
+	issuance, _, result := mptutil.ReadIssuance(view, id)
+	require.Equal(t, ter.TesSUCCESS, result)
+	issuance.Flags |= entry.LsfMPTLocked
+	raw, err := state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	require.NoError(t, view.Update(keylet.MPTIssuance(id), raw))
+	require.Equal(t, ter.TecLOCKED, create.Preclaim(view, config))
+	issuance.Flags &^= entry.LsfMPTLocked
+	raw, err = state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	require.NoError(t, view.Update(keylet.MPTIssuance(id), raw))
+
+	ctx := ammMPTContext(view, creator, creatorID)
+	require.Equal(t, ter.TesSUCCESS, create.Apply(ctx))
+
+	ammKey := computeAMMKeylet(mptAsset, xrpAsset)
+	ammRaw, err := view.Read(ammKey)
+	require.NoError(t, err)
+	amm, err := parseAMMData(ammRaw)
+	require.NoError(t, err)
+	holding, _, result := mptutil.ReadHolding(view, id, amm.Account)
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Equal(t, uint64(1_000), holding.MPTAmount)
+	require.Equal(t, entry.LsfMPTAMM|entry.LsfMPTAuthorized, holding.Flags)
+
+	creatorHolding, _, result := mptutil.ReadHolding(view, id, creatorID)
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Equal(t, uint64(1_000), creatorHolding.MPTAmount)
+	ammAccount := readAMMMPTAccount(t, view, amm.Account)
+	require.Zero(t, ammAccount.OwnerCount)
+	require.Equal(t, uint64(1_000_000), ammAccount.Balance)
+
+	claw := NewAMMClawback(issuerAddr, creatorAddr, mptAsset, xrpAsset)
+	clawAmount := state.NewMPTAmountWithIssuanceID(100, issuerAddr, idHex)
+	claw.Amount = &clawAmount
+	require.NoError(t, claw.Validate())
+	require.Equal(t, ter.TesSUCCESS, claw.Preclaim(view, config))
+	issuance, _, result = mptutil.ReadIssuance(view, id)
+	require.Equal(t, ter.TesSUCCESS, result)
+	issuance.Flags &^= entry.LsfMPTCanClawback
+	raw, err = state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	require.NoError(t, view.Update(keylet.MPTIssuance(id), raw))
+	require.Equal(t, ter.TecNO_PERMISSION, claw.Preclaim(view, config))
+	issuance.Flags |= entry.LsfMPTCanClawback
+	raw, err = state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	require.NoError(t, view.Update(keylet.MPTIssuance(id), raw))
+	issuer := readAMMMPTAccount(t, view, issuerID)
+	require.Equal(t, ter.TesSUCCESS, claw.Apply(ammMPTContext(view, issuer, issuerID)))
+	creatorHolding, _, result = mptutil.ReadHolding(view, id, creatorID)
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Equal(t, uint64(1_000), creatorHolding.MPTAmount)
+	holding, _, result = mptutil.ReadHolding(view, id, amm.Account)
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Less(t, holding.MPTAmount, uint64(1_000))
+	require.NotZero(t, holding.MPTAmount)
+	issuance, _, result = mptutil.ReadIssuance(view, id)
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Equal(t, creatorHolding.MPTAmount+holding.MPTAmount, issuance.OutstandingAmount)
+
+	holding.MPTAmount = 0
+	raw, err = state.SerializeMPToken(holding)
+	require.NoError(t, err)
+	require.NoError(t, view.Update(keylet.MPTokenByID(id, amm.Account), raw))
+	ammAccount.Balance = 0
+	raw, err = state.SerializeAccountRoot(ammAccount)
+	require.NoError(t, err)
+	require.NoError(t, view.Update(keylet.Account(amm.Account), raw))
+	amm.LPTokenBalance = zeroAmount(tx.Asset{
+		Currency: amm.LPTokenBalance.Currency,
+		Issuer:   amm.LPTokenBalance.Issuer,
+	})
+	raw, err = serializeAMMData(amm)
+	require.NoError(t, err)
+	require.NoError(t, view.Update(ammKey, raw))
+
+	lptKey := keylet.Line(creatorID, amm.Account, amm.LPTokenBalance.Currency)
+	lptRaw, err := view.Read(lptKey)
+	require.NoError(t, err)
+	lptLine, err := state.ParseRippleState(lptRaw)
+	require.NoError(t, err)
+	lptLine.Balance, err = lptLine.Balance.Sub(lptLine.Balance)
+	require.NoError(t, err)
+	lptRaw, err = state.SerializeRippleState(lptLine)
+	require.NoError(t, err)
+	require.NoError(t, view.Update(lptKey, lptRaw))
+
+	require.Equal(t, ter.TesSUCCESS, DeleteAMMAccount(view, mptAsset, xrpAsset))
+	exists, err := view.Exists(keylet.MPTokenByID(id, amm.Account))
+	require.NoError(t, err)
+	require.False(t, exists)
+	exists, err = view.Exists(ammKey)
+	require.NoError(t, err)
+	require.False(t, exists)
+	exists, err = view.Exists(keylet.Account(amm.Account))
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestAMMWithdrawCreatesMPTWithWaivedTransferFee(t *testing.T) {
+	view := newAMMMPTView()
+	var issuerID, ammAccountID, destinationID [20]byte
+	copy(issuerID[:], []byte("withdraw-mpt-issuer1"))
+	copy(ammAccountID[:], []byte("withdraw-mpt-amm-001"))
+	copy(destinationID[:], []byte("withdraw-mpt-dest-01"))
+	insertAMMMPTAccount(t, view, issuerID, 100_000_000, 0)
+	insertAMMMPTAccount(t, view, ammAccountID, 0, 0)
+	destination := insertAMMMPTAccount(t, view, destinationID, 100_000_000, 2)
+
+	id := ammMPTID(9, issuerID)
+	insertAMMMPTIssuance(t, view, id, entry.LsfMPTCanTrade|entry.LsfMPTCanTransfer, 5_000)
+	require.Equal(t, ter.TesSUCCESS,
+		mptutil.EnsureHolding(view, id, ammAccountID, entry.LsfMPTAMM|entry.LsfMPTAuthorized, false))
+	require.Equal(t, ter.TesSUCCESS, mptutil.Credit(view, id, issuerID, ammAccountID, 100, false))
+
+	ctx := ammMPTContext(view, destination, destinationID)
+	asset := tx.Asset{MPTIssuanceID: mptutil.EncodeID(id)}
+	amount := mptAmount(asset, 25)
+	require.Equal(t, ter.TesSUCCESS,
+		withdrawAssetToAccount(ctx, destinationID, ammAccountID, asset, amount, true))
+
+	ammHolding, _, result := mptutil.ReadHolding(view, id, ammAccountID)
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Equal(t, uint64(75), ammHolding.MPTAmount)
+	destinationHolding, _, result := mptutil.ReadHolding(view, id, destinationID)
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Equal(t, uint64(25), destinationHolding.MPTAmount)
+	require.Zero(t, destinationHolding.Flags)
+	require.Equal(t, uint32(3), ctx.Account.OwnerCount)
+}

--- a/internal/tx/amm/mpt_apply_test.go
+++ b/internal/tx/amm/mpt_apply_test.go
@@ -290,3 +290,24 @@ func TestAMMWithdrawCreatesMPTWithWaivedTransferFee(t *testing.T) {
 	require.Zero(t, destinationHolding.Flags)
 	require.Equal(t, uint32(3), ctx.Account.OwnerCount)
 }
+
+func TestAMMInsufficientBalancePropagatesCorruptMPTHolding(t *testing.T) {
+	view := newAMMMPTView()
+	var issuerID, holderID [20]byte
+	copy(issuerID[:], []byte("amm-mpt-issuer-00001"))
+	copy(holderID[:], []byte("amm-mpt-holder-00001"))
+	insertAMMMPTAccount(t, view, issuerID, 100_000_000, 0)
+	insertAMMMPTAccount(t, view, holderID, 100_000_000, 0)
+	id := ammMPTID(7, issuerID)
+	insertAMMMPTIssuance(t, view, id, entry.LsfMPTCanTrade|entry.LsfMPTCanTransfer, 0)
+	view.data[keylet.MPTokenByID(id, holderID).Key] = []byte{1}
+	amount := state.NewMPTAmountWithIssuanceID(
+		1,
+		state.EncodeAccountIDSafe(issuerID),
+		mptutil.EncodeID(id),
+	)
+
+	insufficient, result := insufficientBalance(view, holderID, amount, 0)
+	require.False(t, insufficient)
+	require.Equal(t, ter.TefINTERNAL, result)
+}

--- a/internal/tx/amm/pool.go
+++ b/internal/tx/amm/pool.go
@@ -1,8 +1,12 @@
 package amm
 
 import (
+	"math"
+
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -23,6 +27,17 @@ func ammAccountHolds(view tx.LedgerView, ammAccountID [20]byte, asset tx.Asset) 
 			return state.NewXRPAmountFromInt(0)
 		}
 		return state.NewXRPAmountFromInt(int64(account.Balance))
+	}
+	if asset.IsMPT() {
+		id, err := mptutil.DecodeID(asset.MPTIssuanceID)
+		if err != nil {
+			return zeroAmount(asset)
+		}
+		holding, _, result := mptutil.ReadHolding(view, id, ammAccountID)
+		if result != ter.TesSUCCESS || holding.MPTAmount > math.MaxInt64 {
+			return zeroAmount(asset)
+		}
+		return mptAmount(asset, int64(holding.MPTAmount))
 	}
 
 	// IOU: read from trustline
@@ -67,10 +82,10 @@ func ammPoolHolds(view tx.LedgerView, ammAccountID [20]byte, asset1, asset2 tx.A
 
 	// Check for frozen assets if requested
 	if fhZeroIfFrozen {
-		if tx.IsGlobalFrozen(view, asset1.Issuer) || tx.IsIndividualFrozen(view, ammAccountID, asset1) {
+		if assetFrozen(view, ammAccountID, asset1) {
 			balance1 = zeroAmount(asset1)
 		}
-		if tx.IsGlobalFrozen(view, asset2.Issuer) || tx.IsIndividualFrozen(view, ammAccountID, asset2) {
+		if assetFrozen(view, ammAccountID, asset2) {
 			balance2 = zeroAmount(asset2)
 		}
 	}
@@ -103,7 +118,7 @@ func IsAMMEmpty(amm *AMMData) bool {
 // Reference: rippled AMMUtils.cpp ammLPHolds lines 113-160
 func ammLPHolds(view tx.LedgerView, amm *AMMData, lpAccountID [20]byte) tx.Amount {
 	// LP token currency is derived from the two asset currencies
-	lptCurrency := GenerateAMMLPTCurrency(amm.Asset.Currency, amm.Asset2.Currency)
+	lptCurrency := GenerateAMMLPTCurrencyForAssets(amm.Asset, amm.Asset2)
 	ammAccountID := amm.Account
 
 	// Read the trustline between LP account and AMM account

--- a/internal/tx/amm/serialize.go
+++ b/internal/tx/amm/serialize.go
@@ -153,7 +153,7 @@ func serializeAMMData(amm *AMMData) ([]byte, error) {
 	if lptBal.Currency == "" {
 		lptBal = state.NewIssuedAmountFromValue(
 			lptBal.Mantissa(), lptBal.Exponent(),
-			GenerateAMMLPTCurrency(amm.Asset.Currency, amm.Asset2.Currency),
+			GenerateAMMLPTCurrencyForAssets(amm.Asset, amm.Asset2),
 			accountAddr)
 	}
 
@@ -255,6 +255,10 @@ func serializeAMMData(amm *AMMData) ([]byte, error) {
 // issueMapToAsset converts a binary codec Issue map to a tx.Asset.
 func issueMapToAsset(m map[string]any) tx.Asset {
 	asset := tx.Asset{}
+	if mptID, ok := m["mpt_issuance_id"].(string); ok {
+		asset.MPTIssuanceID = strings.ToUpper(mptID)
+		return asset
+	}
 	if currency, ok := m["currency"].(string); ok {
 		asset.Currency = currency
 	}
@@ -266,6 +270,9 @@ func issueMapToAsset(m map[string]any) tx.Asset {
 
 // assetToIssueMap converts a tx.Asset to a binary codec Issue map.
 func assetToIssueMap(asset tx.Asset) map[string]any {
+	if asset.IsMPT() {
+		return map[string]any{"mpt_issuance_id": strings.ToUpper(asset.MPTIssuanceID)}
+	}
 	isXRP := isXRPAsset(asset)
 	if isXRP {
 		return map[string]any{"currency": "XRP"}

--- a/internal/tx/amm/validate.go
+++ b/internal/tx/amm/validate.go
@@ -2,6 +2,7 @@ package amm
 
 import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -11,6 +12,16 @@ import (
 // asset paired with a non-zero issuer is temBAD_ISSUER, and — when a pair is
 // supplied — an asset matching neither member is temBAD_AMM_TOKENS.
 func invalidAMMAsset(asset tx.Asset, pair *[2]tx.Asset) ter.Result {
+	if asset.IsMPT() {
+		id, err := mptutil.DecodeID(asset.MPTIssuanceID)
+		if err != nil || mptutil.Issuer(id) == ([20]byte{}) {
+			return ter.TemBAD_MPT
+		}
+		if pair != nil && !matchesAssetByIssue(asset, pair[0]) && !matchesAssetByIssue(asset, pair[1]) {
+			return ter.TemBAD_AMM_TOKENS
+		}
+		return ter.TesSUCCESS
+	}
 	if keylet.CurrencyBytes(asset.Currency) == keylet.BadCurrency() {
 		return ter.TemBAD_CURRENCY
 	}
@@ -26,7 +37,7 @@ func invalidAMMAsset(asset tx.Asset, pair *[2]tx.Asset) ter.Result {
 
 // amountAsset returns the issue (currency + issuer) of an amount.
 func amountAsset(amt tx.Amount) tx.Asset {
-	return tx.Asset{Currency: amt.Currency, Issuer: amt.Issuer}
+	return tx.Asset{Currency: amt.Currency, Issuer: amt.Issuer, MPTIssuanceID: amt.MPTIssuanceID()}
 }
 
 // validateAMMAmount mirrors rippled invalidAMMAmount() with no pair: asset

--- a/internal/tx/amm/view_helpers.go
+++ b/internal/tx/amm/view_helpers.go
@@ -40,29 +40,32 @@ func noDefaultRipple(view tx.LedgerView, asset tx.Asset) bool {
 // XRP it compares against the liquid balance; for IOU it compares held funds
 // (issuers have unlimited supply).
 // Reference: rippled AMMCreate.cpp line 153-163
-func insufficientBalance(view tx.LedgerView, accountID [20]byte, amount tx.Amount, xrpLiquid int64) bool {
+func insufficientBalance(view tx.LedgerView, accountID [20]byte, amount tx.Amount, xrpLiquid int64) (bool, ter.Result) {
 	if amount.IsNative() {
-		return xrpLiquid < amount.Drops()
+		return xrpLiquid < amount.Drops(), ter.TesSUCCESS
 	}
 	if amount.IsMPT() {
 		requested, ok := amount.MPTRaw()
 		if !ok {
-			return true
+			return false, ter.TefINTERNAL
 		}
 		held, result := mptFunds(view, accountID, amount, true)
-		return result != ter.TesSUCCESS || held < requested
+		if result == ter.TefINTERNAL {
+			return false, result
+		}
+		return result != ter.TesSUCCESS || held < requested, ter.TesSUCCESS
 	}
 
 	issuerID, err := state.DecodeAccountID(amount.Issuer)
 	if err != nil {
-		return true
+		return true, ter.TesSUCCESS
 	}
 	if accountID == issuerID {
-		return false
+		return false, ter.TesSUCCESS
 	}
 
 	held := tx.AccountFunds(view, accountID, amount, true, 0, 0)
-	return held.Compare(amount) < 0
+	return held.Compare(amount) < 0, ter.TesSUCCESS
 }
 
 // isLPToken reports whether the amount is issued by an AMM pseudo-account.

--- a/internal/tx/amm/view_helpers.go
+++ b/internal/tx/amm/view_helpers.go
@@ -3,8 +3,10 @@ package amm
 import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
 
 // noDefaultRipple reports whether the asset's issuer lacks lsfDefaultRipple,
@@ -12,7 +14,7 @@ import (
 // issuer, or when DefaultRipple is set.
 // Reference: rippled AMMCreate.cpp lines 126-135
 func noDefaultRipple(view tx.LedgerView, asset tx.Asset) bool {
-	if isXRPAsset(asset) {
+	if isXRPAsset(asset) || asset.IsMPT() {
 		return false
 	}
 
@@ -42,6 +44,14 @@ func insufficientBalance(view tx.LedgerView, accountID [20]byte, amount tx.Amoun
 	if amount.IsNative() {
 		return xrpLiquid < amount.Drops()
 	}
+	if amount.IsMPT() {
+		requested, ok := amount.MPTRaw()
+		if !ok {
+			return true
+		}
+		held, result := mptFunds(view, accountID, amount, true)
+		return result != ter.TesSUCCESS || held < requested
+	}
 
 	issuerID, err := state.DecodeAccountID(amount.Issuer)
 	if err != nil {
@@ -58,7 +68,7 @@ func insufficientBalance(view tx.LedgerView, accountID [20]byte, amount tx.Amoun
 // isLPToken reports whether the amount is issued by an AMM pseudo-account.
 // Reference: rippled AMMCreate.cpp line 172-177
 func isLPToken(view tx.LedgerView, amount tx.Amount) bool {
-	if amount.IsNative() {
+	if amount.IsNative() || amount.IsMPT() {
 		return false
 	}
 
@@ -83,6 +93,9 @@ func isLPToken(view tx.LedgerView, amount tx.Amount) bool {
 // setAMMNodeFlag sets lsfAMMNode on the AMM's trust line for an IOU asset.
 // Reference: rippled AMMCreate.cpp sendAndTrustSet line 297-306
 func setAMMNodeFlag(ammAccountID [20]byte, asset tx.Asset, view tx.LedgerView) error {
+	if asset.IsMPT() {
+		return nil
+	}
 	issuerID, err := state.DecodeAccountID(asset.Issuer)
 	if err != nil {
 		return err
@@ -115,6 +128,20 @@ func setAMMNodeFlag(ammAccountID [20]byte, asset tx.Asset, view tx.LedgerView) e
 // Reference: rippled AMMCreate.cpp preclaim lines 201-210
 func clawbackDisabled(view tx.LedgerView, asset tx.Asset) ter.Result {
 	if isXRPAsset(asset) {
+		return ter.TesSUCCESS
+	}
+	if asset.IsMPT() {
+		id, err := mptutil.DecodeID(asset.MPTIssuanceID)
+		if err != nil {
+			return ter.TecINTERNAL
+		}
+		issuance, _, result := mptutil.ReadIssuance(view, id)
+		if result != ter.TesSUCCESS {
+			return ter.TecINTERNAL
+		}
+		if issuance.Flags&entry.LsfMPTCanClawback != 0 {
+			return ter.TecNO_PERMISSION
+		}
 		return ter.TesSUCCESS
 	}
 

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -2,10 +2,13 @@ package check
 
 import (
 	"encoding/hex"
+	"math"
+	"strings"
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -68,6 +71,9 @@ func (c *CheckCash) Validate() error {
 		if c.Amount.Signum() <= 0 {
 			return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
 		}
+		if badMPTAsset(*c.Amount) {
+			return ter.Errorf(ter.TemBAD_CURRENCY, "invalid MPT issuance")
+		}
 		if !c.Amount.IsNative() && c.Amount.Currency == "XRP" {
 			return ter.Errorf(ter.TemBAD_CURRENCY, "invalid currency")
 		}
@@ -76,6 +82,9 @@ func (c *CheckCash) Validate() error {
 	if hasDeliverMin {
 		if c.DeliverMin.Signum() <= 0 {
 			return ter.Errorf(ter.TemBAD_AMOUNT, "DeliverMin must be positive")
+		}
+		if badMPTAsset(*c.DeliverMin) {
+			return ter.Errorf(ter.TemBAD_CURRENCY, "invalid MPT issuance")
 		}
 		if !c.DeliverMin.IsNative() && c.DeliverMin.Currency == "XRP" {
 			return ter.Errorf(ter.TemBAD_CURRENCY, "invalid currency")
@@ -209,6 +218,9 @@ func (c *CheckCash) Apply(ctx *tx.ApplyContext) ter.Result {
 	if value == nil {
 		value = c.DeliverMin
 	}
+	if ctx.Rules().FixCleanup3_2_0Enabled() && !legalStoredMPTAmount(check.SendMaxAmount) {
+		return ter.TefBAD_LEDGER
+	}
 	if result := matchesCheckSendMax(*value, check.SendMaxAmount); result != ter.TesSUCCESS {
 		return result
 	}
@@ -220,12 +232,27 @@ func (c *CheckCash) Apply(ctx *tx.ApplyContext) ter.Result {
 	return c.applyCashWithDeliverMin(ctx, check, checkKey)
 }
 
+func legalStoredMPTAmount(amount state.Amount) bool {
+	if !amount.IsMPT() {
+		return true
+	}
+	value, ok := amount.MPTRaw()
+	return ok && value >= 0
+}
+
 // matchesCheckSendMax reports whether the requested cash amount's currency and
 // issuer match the check's SendMax. A mismatch returns temMALFORMED, matching
 // rippled's preclaim where the currency is compared before the issuer.
 // XRP and an issued currency never match (their currencies differ).
 // Reference: CashCheck.cpp L144-155.
 func matchesCheckSendMax(value, sendMax state.Amount) ter.Result {
+	if value.IsMPT() || sendMax.IsMPT() {
+		if !value.IsMPT() || !sendMax.IsMPT() ||
+			!strings.EqualFold(value.MPTIssuanceID(), sendMax.MPTIssuanceID()) {
+			return ter.TemMALFORMED
+		}
+		return ter.TesSUCCESS
+	}
 	if value.IsNative() != sendMax.IsNative() {
 		return ter.TemMALFORMED
 	}
@@ -249,6 +276,9 @@ func (c *CheckCash) applyCashWithAmount(ctx *tx.ApplyContext, check *state.Check
 	if amount.IsNative() {
 		return c.applyCashXRP(ctx, check, checkKey, uint64(amount.Drops()), false)
 	}
+	if amount.IsMPT() {
+		return c.applyCashMPTAmount(ctx, check, checkKey, *amount, false)
+	}
 
 	// IOU Amount
 	return c.applyCashIOUAmount(ctx, check, checkKey, *amount, false)
@@ -261,6 +291,9 @@ func (c *CheckCash) applyCashWithDeliverMin(ctx *tx.ApplyContext, check *state.C
 	// For XRP checks
 	if deliverMin.IsNative() {
 		return c.applyCashXRP(ctx, check, checkKey, uint64(deliverMin.Drops()), true)
+	}
+	if deliverMin.IsMPT() {
+		return c.applyCashMPTAmount(ctx, check, checkKey, *deliverMin, true)
 	}
 
 	// IOU DeliverMin
@@ -375,6 +408,142 @@ func xrpLiquidAfterCheck(creator *state.AccountRoot, ctx *tx.ApplyContext) uint6
 		return creator.Balance - reserve
 	}
 	return 0
+}
+
+func (c *CheckCash) applyCashMPTAmount(ctx *tx.ApplyContext, check *state.CheckData, checkKey keylet.Keylet, requestedAmount tx.Amount, isDeliverMin bool) ter.Result {
+	mptID, err := mptutil.DecodeID(requestedAmount.MPTIssuanceID())
+	if err != nil {
+		return ter.TecOBJECT_NOT_FOUND
+	}
+	requested, ok := requestedAmount.MPTRaw()
+	if !ok || requested <= 0 {
+		return ter.TemBAD_AMOUNT
+	}
+	sendMax, ok := check.SendMaxAmount.MPTRaw()
+	if !ok || sendMax < requested {
+		return ter.TecPATH_PARTIAL
+	}
+
+	issuance, _, result := mptutil.ReadIssuance(ctx.View, mptID)
+	if result != ter.TesSUCCESS {
+		if result == ter.TecOBJECT_NOT_FOUND {
+			return ter.TecPATH_PARTIAL
+		}
+		return result
+	}
+	srcID := check.Account
+	dstID := ctx.AccountID
+	issuerID := issuance.Issuer
+
+	if result := mptutil.RequireAuthAt(ctx.View, mptID, srcID, true, ctx.Config.ParentCloseTime); result != ter.TesSUCCESS {
+		return ter.TecPATH_PARTIAL
+	}
+	srcFunds, result := mptutil.Funds(ctx.View, mptID, srcID, true)
+	if result != ter.TesSUCCESS || srcFunds < requested {
+		return ter.TecPATH_PARTIAL
+	}
+
+	if dstID != issuerID {
+		issuerData, err := ctx.View.Read(keylet.Account(issuerID))
+		if err != nil || issuerData == nil {
+			return ter.TecNO_ISSUER
+		}
+		if result := mptutil.RequireAuthAt(ctx.View, mptID, dstID, false, ctx.Config.ParentCloseTime); result != ter.TesSUCCESS {
+			return result
+		}
+		if mptutil.IsFrozen(ctx.View, mptID, dstID) {
+			return ter.TecLOCKED
+		}
+	}
+	if result := mptutil.CanTransfer(ctx.View, mptID, srcID, dstID); result != ter.TesSUCCESS {
+		return result
+	}
+
+	if dstID != issuerID {
+		if exists, err := ctx.View.Exists(keylet.MPTokenByID(mptID, dstID)); err != nil {
+			return ter.TefINTERNAL
+		} else if !exists {
+			if ctx.PriorBalance() < ctx.AccountReserve(ctx.Account.OwnerCount+1) {
+				return ter.TecINSUFFICIENT_RESERVE
+			}
+			if result := mptutil.EnsureHolding(ctx.View, mptID, dstID, 0, true); result != ter.TesSUCCESS {
+				return result
+			}
+			ctx.SyncSenderOwnerCount()
+		}
+	}
+
+	rate := mptutil.RateOne
+	if srcID != issuerID && dstID != issuerID {
+		rate = mptutil.TransferRate(ctx.View, mptID)
+	}
+	delivered := requested
+	if isDeliverMin {
+		maxDebit := min(sendMax, srcFunds)
+		var ok bool
+		delivered, ok = mptutil.DivideRate(maxDebit, rate)
+		if !ok {
+			return ter.TefEXCEPTION
+		}
+		if delivered > math.MaxInt64/2 {
+			delivered = math.MaxInt64 / 2
+		}
+		gross, ok := mptutil.MultiplyRate(delivered, rate)
+		if !ok {
+			return ter.TefEXCEPTION
+		}
+		for delivered > 0 && gross > maxDebit {
+			delivered--
+			gross, ok = mptutil.MultiplyRate(delivered, rate)
+			if !ok {
+				return ter.TefEXCEPTION
+			}
+		}
+		if delivered < requested {
+			return ter.TecPATH_PARTIAL
+		}
+	} else {
+		gross, ok := mptutil.MultiplyRate(delivered, rate)
+		if !ok {
+			return ter.TefEXCEPTION
+		}
+		if gross > sendMax {
+			return ter.TecPATH_PARTIAL
+		}
+	}
+
+	_, result = mptutil.Send(ctx.View, mptID, srcID, dstID, delivered, false, false)
+	if result == ter.TecINSUFFICIENT_FUNDS || result == ter.TecPATH_DRY {
+		return ter.TecPATH_PARTIAL
+	}
+	if result != ter.TesSUCCESS {
+		return result
+	}
+
+	deliveredAmount := state.NewMPTAmountWithIssuanceID(delivered, "", requestedAmount.MPTIssuanceID())
+	ctx.Metadata.DeliveredAmount = &deliveredAmount
+
+	if result := removeCheckFromDirectories(ctx, check, checkKey.Key); result != ter.TesSUCCESS {
+		return result
+	}
+	creatorData, err := ctx.View.Read(keylet.Account(srcID))
+	if err != nil || creatorData == nil {
+		return ter.TefINTERNAL
+	}
+	creatorAccount, err := state.ParseAccountRoot(creatorData)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if creatorAccount.OwnerCount > 0 {
+		creatorAccount.OwnerCount--
+	}
+	if result := ctx.UpdateAccountRoot(srcID, creatorAccount); result != ter.TesSUCCESS {
+		return result
+	}
+	if err := ctx.View.Erase(checkKey); err != nil {
+		return ter.TefINTERNAL
+	}
+	return ter.TesSUCCESS
 }
 
 // applyCashIOUAmount handles IOU check cashing for both Amount and DeliverMin.

--- a/internal/tx/check/check_cash.go
+++ b/internal/tx/check/check_cash.go
@@ -435,10 +435,15 @@ func (c *CheckCash) applyCashMPTAmount(ctx *tx.ApplyContext, check *state.CheckD
 	dstID := ctx.AccountID
 	issuerID := issuance.Issuer
 
-	if result := mptutil.RequireAuthAt(ctx.View, mptID, srcID, true, ctx.Config.ParentCloseTime); result != ter.TesSUCCESS {
+	if result := mptutil.RequireAuthAt(ctx.View, mptID, srcID, true, ctx.Config.ParentCloseTime); result == ter.TefINTERNAL {
+		return result
+	} else if result != ter.TesSUCCESS {
 		return ter.TecPATH_PARTIAL
 	}
 	srcFunds, result := mptutil.Funds(ctx.View, mptID, srcID, true)
+	if result == ter.TefINTERNAL {
+		return result
+	}
 	if result != ter.TesSUCCESS || srcFunds < requested {
 		return ter.TecPATH_PARTIAL
 	}

--- a/internal/tx/check/check_create.go
+++ b/internal/tx/check/check_create.go
@@ -162,7 +162,6 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 			return result
 		}
 	} else if !c.SendMax.IsNative() {
-		// IOU-specific checks
 		// Reference: CreateCheck.cpp L116-161
 		issuerID, err := state.DecodeAccountID(c.SendMax.Issuer)
 		if err != nil {

--- a/internal/tx/check/check_create.go
+++ b/internal/tx/check/check_create.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -68,9 +69,13 @@ func (c *CheckCreate) Validate() error {
 		return ter.Errorf(ter.TemBAD_AMOUNT, "SendMax must be positive")
 	}
 
+	if badMPTAsset(c.SendMax) {
+		return ter.Errorf(ter.TemBAD_CURRENCY, "invalid MPT issuance")
+	}
+
 	// Cannot use bad currency (XRP as IOU or null currency)
 	// Reference: CreateCheck.cpp L63-67
-	if !c.SendMax.IsNative() {
+	if !c.SendMax.IsNative() && !c.SendMax.IsMPT() {
 		if c.SendMax.Currency == "XRP" || c.SendMax.Currency == "\x00\x00\x00" || c.SendMax.Currency == "" {
 			return ter.Errorf(ter.TemBAD_CURRENCY, "invalid currency")
 		}
@@ -83,6 +88,14 @@ func (c *CheckCreate) Validate() error {
 	}
 
 	return nil
+}
+
+func badMPTAsset(amount tx.Amount) bool {
+	if !amount.IsMPT() {
+		return false
+	}
+	id, err := mptutil.DecodeID(amount.MPTIssuanceID())
+	return err != nil || mptutil.Issuer(id) == ([20]byte{})
 }
 
 func (c *CheckCreate) Flatten() (map[string]any, error) {
@@ -132,9 +145,25 @@ func (c *CheckCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TecDST_TAG_NEEDED
 	}
 
-	// IOU-specific checks
-	// Reference: CreateCheck.cpp L116-161
-	if !c.SendMax.IsNative() {
+	if c.SendMax.IsMPT() {
+		mptID, err := mptutil.DecodeID(c.SendMax.MPTIssuanceID())
+		if err != nil {
+			return ter.TecOBJECT_NOT_FOUND
+		}
+		accountID := ctx.AccountID
+		issuerID := mptutil.Issuer(mptID)
+
+		if mptutil.IsGlobalFrozen(ctx.View, mptID) ||
+			(accountID != issuerID && mptutil.IsFrozen(ctx.View, mptID, accountID)) ||
+			(destID != issuerID && mptutil.IsFrozen(ctx.View, mptID, destID)) {
+			return ter.TecLOCKED
+		}
+		if result := mptutil.CanTransfer(ctx.View, mptID, accountID, destID); result != ter.TesSUCCESS {
+			return result
+		}
+	} else if !c.SendMax.IsNative() {
+		// IOU-specific checks
+		// Reference: CreateCheck.cpp L116-161
 		issuerID, err := state.DecodeAccountID(c.SendMax.Issuer)
 		if err != nil {
 			return ter.TefINTERNAL

--- a/internal/tx/check/check_mpt_apply_test.go
+++ b/internal/tx/check/check_mpt_apply_test.go
@@ -312,6 +312,32 @@ func TestCheckCashMissingMPTIssuanceIsPathPartial(t *testing.T) {
 	}
 }
 
+func TestCheckCashCorruptMPTHoldingIsInternalError(t *testing.T) {
+	issuerID := checkMPTAccountID(0x74)
+	srcID := checkMPTAccountID(0x75)
+	dstID := checkMPTAccountID(0x76)
+	mptID := keylet.MakeMPTID(1, issuerID)
+	view := newCheckMPTView()
+	putCheckMPTAccount(t, view, issuerID, 1)
+	putCheckMPTAccount(t, view, srcID, 1)
+	dst := putCheckMPTAccount(t, view, dstID, 1)
+	putCheckMPTIssuance(t, view, mptID, issuerID, entry.LsfMPTCanTransfer, 0, 1)
+	view.data[keylet.MPTokenByID(mptID, srcID).Key] = []byte{1}
+
+	amount := state.NewMPTAmountWithIssuanceID(1, "", mptutil.EncodeID(mptID))
+	check := &state.CheckData{Account: srcID, DestinationID: dstID, SendMaxAmount: amount}
+	result := (&CheckCash{Amount: &amount}).applyCashMPTAmount(
+		checkMPTContext(view, dst, dstID),
+		check,
+		keylet.Check(srcID, 1),
+		amount,
+		false,
+	)
+	if result != ter.TefINTERNAL {
+		t.Fatalf("cash corrupt MPT holding = %v, want tefINTERNAL", result)
+	}
+}
+
 func TestCheckCashRejectsIllegalStoredMPT(t *testing.T) {
 	srcID := checkMPTAccountID(0x81)
 	dstID := checkMPTAccountID(0x82)

--- a/internal/tx/check/check_mpt_apply_test.go
+++ b/internal/tx/check/check_mpt_apply_test.go
@@ -1,0 +1,345 @@
+package check
+
+import (
+	"context"
+	"encoding/hex"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+)
+
+type checkMPTView struct {
+	data map[[32]byte][]byte
+}
+
+func newCheckMPTView() *checkMPTView { return &checkMPTView{data: make(map[[32]byte][]byte)} }
+
+func (v *checkMPTView) Read(k keylet.Keylet) ([]byte, error)      { return v.data[k.Key], nil }
+func (v *checkMPTView) Exists(k keylet.Keylet) (bool, error)      { _, ok := v.data[k.Key]; return ok, nil }
+func (v *checkMPTView) Insert(k keylet.Keylet, data []byte) error { v.data[k.Key] = data; return nil }
+func (v *checkMPTView) Update(k keylet.Keylet, data []byte) error { v.data[k.Key] = data; return nil }
+func (v *checkMPTView) Erase(k keylet.Keylet) error               { delete(v.data, k.Key); return nil }
+func (v *checkMPTView) AdjustDropsDestroyed(drops.XRPAmount)      {}
+func (v *checkMPTView) ForEach(fn func([32]byte, []byte) bool) error {
+	for k, data := range v.data {
+		if !fn(k, data) {
+			break
+		}
+	}
+	return nil
+}
+func (v *checkMPTView) Succ([32]byte) ([32]byte, []byte, bool, error) {
+	return [32]byte{}, nil, false, nil
+}
+func (v *checkMPTView) TxExists([32]byte) bool  { return false }
+func (v *checkMPTView) Rules() *amendment.Rules { return amendment.AllSupportedRules() }
+func (v *checkMPTView) LedgerSeq() uint32       { return 1 }
+
+func checkMPTAccountID(seed byte) [20]byte {
+	var id [20]byte
+	for i := range id {
+		id[i] = seed
+	}
+	return id
+}
+
+func putCheckMPTAccount(t *testing.T, view *checkMPTView, id [20]byte, ownerCount uint32) *state.AccountRoot {
+	t.Helper()
+	address, err := state.EncodeAccountID(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	account := &state.AccountRoot{Account: address, Balance: 1_000_000_000, Sequence: 1, OwnerCount: ownerCount}
+	data, err := state.SerializeAccountRoot(account)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := view.Insert(keylet.Account(id), data); err != nil {
+		t.Fatal(err)
+	}
+	return account
+}
+
+func putCheckMPTIssuance(t *testing.T, view *checkMPTView, id [24]byte, issuer [20]byte, flags uint32, transferFee uint16, outstanding uint64) {
+	t.Helper()
+	maximum := max(uint64(10_000), outstanding)
+	data, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+		Issuer:            issuer,
+		Sequence:          1,
+		Flags:             flags,
+		TransferFee:       transferFee,
+		OutstandingAmount: outstanding,
+		MaximumAmount:     &maximum,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := view.Insert(keylet.MPTIssuance(id), data); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func putCheckMPTHolding(t *testing.T, view *checkMPTView, id [24]byte, holder [20]byte, amount uint64, flags uint32) {
+	t.Helper()
+	data, err := state.SerializeMPToken(&state.MPTokenData{
+		Account:           holder,
+		MPTokenIssuanceID: id,
+		MPTAmount:         amount,
+		Flags:             flags,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := view.Insert(keylet.MPTokenByID(id, holder), data); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func checkMPTContext(view *checkMPTView, account *state.AccountRoot, accountID [20]byte) *tx.ApplyContext {
+	return &tx.ApplyContext{
+		View:      view,
+		Account:   account,
+		AccountID: accountID,
+		Config: tx.EngineConfig{
+			ReserveBase:      10_000_000,
+			ReserveIncrement: 2_000_000,
+			Rules:            amendment.AllSupportedRules(),
+		},
+		Metadata: &tx.Metadata{},
+		Log:      xrpllog.Discard(),
+		Ctx:      context.Background(),
+	}
+}
+
+func TestCheckCreateStoresMPTSendMaxAndChecksLock(t *testing.T) {
+	issuerID := checkMPTAccountID(0x11)
+	srcID := checkMPTAccountID(0x22)
+	dstID := checkMPTAccountID(0x33)
+	mptID := keylet.MakeMPTID(1, issuerID)
+	mptHex := hex.EncodeToString(mptID[:])
+
+	build := func(flags uint32) (*checkMPTView, *tx.ApplyContext, *CheckCreate) {
+		view := newCheckMPTView()
+		src := putCheckMPTAccount(t, view, srcID, 0)
+		putCheckMPTAccount(t, view, dstID, 0)
+		putCheckMPTIssuance(t, view, mptID, issuerID, flags, 0, 0)
+		srcAddress, _ := state.EncodeAccountID(srcID)
+		dstAddress, _ := state.EncodeAccountID(dstID)
+		amount := state.NewMPTAmountWithIssuanceID(100, "", mptHex)
+		create := NewCheckCreate(srcAddress, dstAddress, amount)
+		if err := create.Validate(); err != nil {
+			t.Fatalf("validate MPT check: %v", err)
+		}
+		sequence := uint32(7)
+		create.Sequence = &sequence
+		return view, checkMPTContext(view, src, srcID), create
+	}
+
+	view, ctx, create := build(entry.LsfMPTCanTransfer)
+	if result := create.Apply(ctx); result != ter.TesSUCCESS {
+		t.Fatalf("create MPT check: got %v", result)
+	}
+	checkData, err := view.Read(keylet.Check(srcID, 7))
+	if err != nil || checkData == nil {
+		t.Fatal("MPT Check SLE was not stored")
+	}
+	stored, err := state.ParseCheck(checkData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stored.SendMaxAmount.IsMPT() || stored.SendMaxAmount.MPTIssuanceID() != strings.ToUpper(mptHex) {
+		t.Fatalf("stored SendMax lost MPT identity: %#v", stored.SendMaxAmount)
+	}
+
+	_, lockedCtx, lockedCreate := build(entry.LsfMPTCanTransfer | entry.LsfMPTLocked)
+	if result := lockedCreate.Apply(lockedCtx); result != ter.TecLOCKED {
+		t.Fatalf("locked MPT: got %v, want tecLOCKED", result)
+	}
+}
+
+func TestCheckCashMPTCreatesHoldingAndAppliesTransferFee(t *testing.T) {
+	issuerID := checkMPTAccountID(0x41)
+	srcID := checkMPTAccountID(0x42)
+	dstID := checkMPTAccountID(0x43)
+	mptID := keylet.MakeMPTID(1, issuerID)
+	mptHex := strings.ToUpper(hex.EncodeToString(mptID[:]))
+	view := newCheckMPTView()
+	putCheckMPTAccount(t, view, issuerID, 1)
+	putCheckMPTAccount(t, view, srcID, 2)
+	dst := putCheckMPTAccount(t, view, dstID, 0)
+	putCheckMPTIssuance(t, view, mptID, issuerID, entry.LsfMPTCanTransfer, 25_000, 1_000)
+	putCheckMPTHolding(t, view, mptID, srcID, 1_000, 0)
+
+	checkKey := keylet.Check(srcID, 9)
+	srcDir, err := state.DirInsert(view, keylet.OwnerDir(srcID), checkKey.Key, false, func(dir *state.DirectoryNode) { dir.Owner = srcID })
+	if err != nil {
+		t.Fatal(err)
+	}
+	dstDir, err := state.DirInsert(view, keylet.OwnerDir(dstID), checkKey.Key, false, func(dir *state.DirectoryNode) { dir.Owner = dstID })
+	if err != nil {
+		t.Fatal(err)
+	}
+	check := &state.CheckData{
+		Account:         srcID,
+		DestinationID:   dstID,
+		Sequence:        9,
+		OwnerNode:       srcDir.Page,
+		DestinationNode: dstDir.Page,
+		HasDestNode:     true,
+		SendMaxAmount:   state.NewMPTAmountWithIssuanceID(125, "", mptHex),
+	}
+	checkData, err := state.SerializeCheckFromData(check)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := view.Insert(checkKey, checkData); err != nil {
+		t.Fatal(err)
+	}
+
+	deliverMin := state.NewMPTAmountWithIssuanceID(75, "", mptHex)
+	cash := &CheckCash{DeliverMin: &deliverMin}
+	ctx := checkMPTContext(view, dst, dstID)
+	if result := cash.applyCashMPTAmount(ctx, check, checkKey, deliverMin, true); result != ter.TesSUCCESS {
+		t.Fatalf("cash MPT check: got %v", result)
+	}
+
+	sourceToken, _, result := mptutil.ReadHolding(view, mptID, srcID)
+	if result != ter.TesSUCCESS || sourceToken.MPTAmount != 875 {
+		t.Fatalf("source holding = %v/%v, want 875", sourceToken, result)
+	}
+	destToken, _, result := mptutil.ReadHolding(view, mptID, dstID)
+	if result != ter.TesSUCCESS || destToken.MPTAmount != 100 {
+		t.Fatalf("destination holding = %v/%v, want 100", destToken, result)
+	}
+	if ctx.Account.OwnerCount != 1 {
+		t.Fatalf("destination owner count = %d, want 1", ctx.Account.OwnerCount)
+	}
+	if ctx.Metadata.DeliveredAmount == nil || ctx.Metadata.DeliveredAmount.Value() != "100" {
+		t.Fatalf("delivered amount = %v, want 100", ctx.Metadata.DeliveredAmount)
+	}
+	if exists, _ := view.Exists(checkKey); exists {
+		t.Fatal("cashed check was not erased")
+	}
+}
+
+func TestCheckCashMPTTransferFeeRoundsInputUp(t *testing.T) {
+	issuerID := checkMPTAccountID(0x61)
+	srcID := checkMPTAccountID(0x62)
+	dstID := checkMPTAccountID(0x63)
+	mptID := keylet.MakeMPTID(1, issuerID)
+	mptHex := mptutil.EncodeID(mptID)
+	view := newCheckMPTView()
+	putCheckMPTAccount(t, view, issuerID, 1)
+	putCheckMPTAccount(t, view, srcID, 1)
+	dst := putCheckMPTAccount(t, view, dstID, 1)
+	putCheckMPTIssuance(t, view, mptID, issuerID, entry.LsfMPTCanTransfer, 25_000, 1)
+	putCheckMPTHolding(t, view, mptID, srcID, 1, 0)
+	putCheckMPTHolding(t, view, mptID, dstID, 0, 0)
+
+	amount := state.NewMPTAmountWithIssuanceID(1, "", mptHex)
+	check := &state.CheckData{Account: srcID, DestinationID: dstID, SendMaxAmount: amount}
+	cash := &CheckCash{Amount: &amount}
+	if result := cash.applyCashMPTAmount(checkMPTContext(view, dst, dstID), check, keylet.Check(srcID, 1), amount, false); result != ter.TecPATH_PARTIAL {
+		t.Fatalf("cash MPT check = %v, want tecPATH_PARTIAL", result)
+	}
+}
+
+func TestCheckCashMPTTransferFeeOverflowReturnsTefException(t *testing.T) {
+	issuerID := checkMPTAccountID(0x64)
+	srcID := checkMPTAccountID(0x65)
+	dstID := checkMPTAccountID(0x66)
+	mptID := keylet.MakeMPTID(1, issuerID)
+	mptHex := mptutil.EncodeID(mptID)
+	view := newCheckMPTView()
+	putCheckMPTAccount(t, view, issuerID, 1)
+	putCheckMPTAccount(t, view, srcID, 1)
+	dst := putCheckMPTAccount(t, view, dstID, 1)
+	putCheckMPTIssuance(t, view, mptID, issuerID, entry.LsfMPTCanTransfer, 25_000, math.MaxInt64)
+	putCheckMPTHolding(t, view, mptID, srcID, math.MaxInt64, 0)
+	putCheckMPTHolding(t, view, mptID, dstID, 0, 0)
+
+	amount := state.NewMPTAmountWithIssuanceID(math.MaxInt64, "", mptHex)
+	check := &state.CheckData{Account: srcID, DestinationID: dstID, SendMaxAmount: amount}
+	cash := &CheckCash{Amount: &amount}
+	result := cash.applyCashMPTAmount(
+		checkMPTContext(view, dst, dstID),
+		check,
+		keylet.Check(srcID, 1),
+		amount,
+		false,
+	)
+	if result != ter.TefEXCEPTION {
+		t.Fatalf("cash MPT check = %v, want tefEXCEPTION", result)
+	}
+
+	source, _, result := mptutil.ReadHolding(view, mptID, srcID)
+	if result != ter.TesSUCCESS || source.MPTAmount != math.MaxInt64 {
+		t.Fatalf("source holding changed: %v/%v", source, result)
+	}
+	destination, _, result := mptutil.ReadHolding(view, mptID, dstID)
+	if result != ter.TesSUCCESS || destination.MPTAmount != 0 {
+		t.Fatalf("destination holding changed: %v/%v", destination, result)
+	}
+}
+
+func TestCheckCashMissingMPTIssuanceIsPathPartial(t *testing.T) {
+	issuerID := checkMPTAccountID(0x71)
+	srcID := checkMPTAccountID(0x72)
+	dstID := checkMPTAccountID(0x73)
+	mptID := keylet.MakeMPTID(1, issuerID)
+	amount := state.NewMPTAmountWithIssuanceID(1, "", mptutil.EncodeID(mptID))
+	check := &state.CheckData{Account: srcID, DestinationID: dstID, SendMaxAmount: amount}
+
+	result := (&CheckCash{Amount: &amount}).applyCashMPTAmount(
+		checkMPTContext(newCheckMPTView(), &state.AccountRoot{}, dstID),
+		check,
+		keylet.Check(srcID, 1),
+		amount,
+		false,
+	)
+	if result != ter.TecPATH_PARTIAL {
+		t.Fatalf("cash missing MPT issuance = %v, want tecPATH_PARTIAL", result)
+	}
+}
+
+func TestCheckCashRejectsIllegalStoredMPT(t *testing.T) {
+	srcID := checkMPTAccountID(0x81)
+	dstID := checkMPTAccountID(0x82)
+	issuerID := checkMPTAccountID(0x83)
+	mptID := keylet.MakeMPTID(1, issuerID)
+	mptHex := mptutil.EncodeID(mptID)
+	view := newCheckMPTView()
+	putCheckMPTAccount(t, view, srcID, 1)
+	dst := putCheckMPTAccount(t, view, dstID, 0)
+	checkKey := keylet.Check(srcID, 1)
+	check := &state.CheckData{
+		Account:       srcID,
+		DestinationID: dstID,
+		SendMaxAmount: state.NewMPTAmountWithIssuanceID(-1, "", mptHex),
+	}
+	checkData, err := state.SerializeCheckFromData(check)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := view.Insert(checkKey, checkData); err != nil {
+		t.Fatal(err)
+	}
+
+	dstAddress, _ := state.EncodeAccountID(dstID)
+	amount := state.NewMPTAmountWithIssuanceID(1, "", mptHex)
+	cash := NewCheckCash(dstAddress, hex.EncodeToString(checkKey.Key[:]))
+	cash.Amount = &amount
+	if result := cash.Apply(checkMPTContext(view, dst, dstID)); result != ter.TefBAD_LEDGER {
+		t.Fatalf("cash illegal stored MPT = %v, want tefBAD_LEDGER", result)
+	}
+}

--- a/internal/tx/check/mpt_gate_test.go
+++ b/internal/tx/check/mpt_gate_test.go
@@ -1,6 +1,7 @@
 package check
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/amendment"
@@ -19,6 +20,13 @@ func assertTemDisabled(t *testing.T, err error) {
 	t.Helper()
 	if re, ok := ter.AsResultError(err); !ok || re.Code != ter.TemDISABLED {
 		t.Fatalf("want temDISABLED, got %v", err)
+	}
+}
+
+func assertCheckResultError(t *testing.T, err error, want ter.Result) {
+	t.Helper()
+	if result, ok := ter.AsResultError(err); !ok || result.Code != want {
+		t.Fatalf("want %v, got %v", want, err)
 	}
 }
 
@@ -58,4 +66,30 @@ func TestCheckMPTGate(t *testing.T) {
 		c := &CheckCash{DeliverMin: &dm}
 		assertTemDisabled(t, c.CheckExtraFeatures(off))
 	})
+}
+
+func TestCheckRejectsMPTWithZeroIssuer(t *testing.T) {
+	source, _ := state.EncodeAccountID(checkMPTAccountID(0x51))
+	destination, _ := state.EncodeAccountID(checkMPTAccountID(0x52))
+	amount := state.NewMPTAmountWithIssuanceID(
+		1,
+		"",
+		"00000001"+strings.Repeat("00", 20),
+	)
+
+	assertCheckResultError(
+		t,
+		NewCheckCreate(source, destination, amount).Validate(),
+		ter.TemBAD_CURRENCY,
+	)
+
+	for _, useDeliverMin := range []bool{false, true} {
+		cash := NewCheckCash(destination, strings.Repeat("0", 64))
+		if useDeliverMin {
+			cash.DeliverMin = &amount
+		} else {
+			cash.Amount = &amount
+		}
+		assertCheckResultError(t, cash.Validate(), ter.TemBAD_CURRENCY)
+	}
 }

--- a/internal/tx/engine/payment_mpt_v2_preflight_test.go
+++ b/internal/tx/engine/payment_mpt_v2_preflight_test.go
@@ -1,0 +1,130 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+const validPreflightMPTID = "00000004AE123A8556F3CF91154711376AFB0F894F832B3D"
+
+func mptPaymentRules(v2 bool) *amendment.Rules {
+	b := amendment.NewRulesBuilder().
+		FromPreset(amendment.PresetAllSupported)
+	if v2 {
+		b.Enable(amendment.FeatureMPTokensV2)
+	} else {
+		b.Disable(amendment.FeatureMPTokensV2)
+	}
+	return b.Build()
+}
+
+func validMPTPreflightPayment(value int64) *payment.Payment {
+	amount := state.NewMPTAmountWithIssuanceID(value, precedenceGenesisAddr, validPreflightMPTID)
+	return preflightPayment(precedenceGenesisAddr, amount)
+}
+
+func TestPaymentMPTFlagSurfaceByVersion(t *testing.T) {
+	flags := []struct {
+		name string
+		flag uint32
+	}{
+		{name: "tfNoRippleDirect", flag: payment.PaymentFlagNoDirectRipple},
+		{name: "tfLimitQuality", flag: payment.PaymentFlagLimitQuality},
+	}
+
+	for _, tc := range flags {
+		t.Run("MPTokensV1/"+tc.name, func(t *testing.T) {
+			p := validMPTPreflightPayment(100)
+			p.SetFlags(tc.flag)
+			if got := preflightEngine(mptPaymentRules(false)).preflight(p); got != ter.TemINVALID_FLAG {
+				t.Fatalf("preflight = %v, want TemINVALID_FLAG", got)
+			}
+		})
+
+		t.Run("MPTokensV2/"+tc.name, func(t *testing.T) {
+			p := validMPTPreflightPayment(100)
+			p.SetFlags(tc.flag)
+			if got := preflightEngine(mptPaymentRules(true)).preflight(p); got != ter.TesSUCCESS {
+				t.Fatalf("preflight = %v, want TesSUCCESS", got)
+			}
+		})
+	}
+
+	t.Run("MPTokensV2 rejects undefined bit", func(t *testing.T) {
+		p := validMPTPreflightPayment(100)
+		p.SetFlags(0x00000001)
+		if got := preflightEngine(mptPaymentRules(true)).preflight(p); got != ter.TemINVALID_FLAG {
+			t.Fatalf("preflight = %v, want TemINVALID_FLAG", got)
+		}
+	})
+}
+
+func TestPaymentMPTokensV1DisabledPrecedence(t *testing.T) {
+	rules := amendment.NewRulesBuilder().
+		FromPreset(amendment.PresetAllSupported).
+		Disable(amendment.FeatureMPTokensV1).
+		Disable(amendment.FeatureMPTokensV2).
+		Build()
+
+	t.Run("invalid mask beats bad fee and disabled gate", func(t *testing.T) {
+		p := validMPTPreflightPayment(100)
+		p.Fee = "-10"
+		p.SetFlags(payment.PaymentFlagLimitQuality)
+		if got := preflightEngine(rules).preflight(p); got != ter.TemINVALID_FLAG {
+			t.Fatalf("preflight = %v, want TemINVALID_FLAG", got)
+		}
+	})
+
+	t.Run("bad fee beats disabled gate", func(t *testing.T) {
+		p := validMPTPreflightPayment(100)
+		p.Fee = "-10"
+		if got := preflightEngine(rules).preflight(p); got != ter.TemBAD_FEE {
+			t.Fatalf("preflight = %v, want TemBAD_FEE", got)
+		}
+	})
+
+	t.Run("valid common fields reach disabled gate", func(t *testing.T) {
+		if got := preflightEngine(rules).preflight(validMPTPreflightPayment(100)); got != ter.TemDISABLED {
+			t.Fatalf("preflight = %v, want TemDISABLED", got)
+		}
+	})
+
+	bodyErrors := []struct {
+		name   string
+		mutate func(*payment.Payment)
+	}{
+		{
+			name: "paths",
+			mutate: func(p *payment.Payment) {
+				p.Paths = [][]payment.PathStep{{{Account: precedenceSourceAddr}}}
+			},
+		},
+		{
+			name: "cross-asset SendMax",
+			mutate: func(p *payment.Payment) {
+				sendMax := state.NewXRPAmountFromInt(100)
+				p.SendMax = &sendMax
+			},
+		},
+		{
+			name: "zero Amount",
+			mutate: func(p *payment.Payment) {
+				p.Amount = state.NewMPTAmountWithIssuanceID(0, precedenceGenesisAddr, validPreflightMPTID)
+			},
+		},
+	}
+
+	for _, tc := range bodyErrors {
+		t.Run("disabled gate beats "+tc.name, func(t *testing.T) {
+			p := validMPTPreflightPayment(100)
+			tc.mutate(p)
+			if got := preflightEngine(rules).preflight(p); got != ter.TemDISABLED {
+				t.Fatalf("preflight = %v, want TemDISABLED", got)
+			}
+		})
+	}
+}

--- a/internal/tx/engine/payment_offer_precedence_test.go
+++ b/internal/tx/engine/payment_offer_precedence_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/offer"
@@ -109,6 +110,36 @@ func TestPaymentPrecedence_MPTMaskBeforeZeroAmount(t *testing.T) {
 	if got := e.preflight(p); got != ter.TemINVALID_FLAG {
 		t.Fatalf("preflight = %v, want TemINVALID_FLAG", got)
 	}
+}
+
+func TestPaymentPrecedence_MPTokensV2MaskBeforeFee(t *testing.T) {
+	amount := state.NewMPTAmountWithIssuanceID(100, precedenceGenesisAddr, mptIDA)
+
+	t.Run("MPTokensV1 rejects limit quality before bad fee", func(t *testing.T) {
+		rules := amendment.NewRulesBuilder().
+			FromPreset(amendment.PresetAllSupported).
+			Disable(amendment.FeatureMPTokensV2).
+			Build()
+		p := preflightPayment(precedenceGenesisAddr, amount)
+		p.Fee = "-10"
+		p.SetFlags(payment.PaymentFlagLimitQuality)
+		if got := preflightEngine(rules).preflight(p); got != ter.TemINVALID_FLAG {
+			t.Fatalf("preflight = %v, want TemINVALID_FLAG", got)
+		}
+	})
+
+	t.Run("MPTokensV2 allows limit quality so bad fee wins", func(t *testing.T) {
+		rules := amendment.NewRulesBuilder().
+			FromPreset(amendment.PresetAllSupported).
+			Enable(amendment.FeatureMPTokensV2).
+			Build()
+		p := preflightPayment(precedenceGenesisAddr, amount)
+		p.Fee = "-10"
+		p.SetFlags(payment.PaymentFlagLimitQuality)
+		if got := preflightEngine(rules).preflight(p); got != ter.TemBAD_FEE {
+			t.Fatalf("preflight = %v, want TemBAD_FEE", got)
+		}
+	})
 }
 
 // P7: the MPT+Paths temMALFORMED check precedes the zero-amount temBAD_AMOUNT

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -87,7 +87,7 @@ func (e *Engine) preflight(tx txcore.Transaction) (result ter.Result) {
 
 // preflightStructure runs the ledger-state-independent preflight checks in
 // rippled's invokePreflight order: the amendment gate and T::checkExtraFeatures,
-// then preflight1 (which invokes preflight0), then the per-type Validate body,
+// then preflight1 (which invokes preflight0), then the per-type preflight body,
 // then the preflight2 structural (multi-sign) checks. Signature verification
 // itself runs separately in verifySignatures. This is a pure function of the
 // transaction fields and the active rules, which is what makes its verdict safe
@@ -123,13 +123,8 @@ func (e *Engine) preflightStructure(tx txcore.Transaction, common *txcore.Common
 		return ter.TemBAD_AMOUNT
 	}
 
-	// T::preflight — the tx-type-specific body: the rules-free Validate() plus
-	// any amendment-gated tem* checks that genuinely belong in the per-type
-	// preflight body (RulesPreflighter).
-	if err := tx.Validate(); err != nil {
-		return parseValidationError(err)
-	}
-	if result := checkPreflightRules(tx, rules); result != ter.TesSUCCESS {
+	// T::preflight — the tx-type-specific body.
+	if result := runTypePreflight(tx, rules); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -237,6 +232,19 @@ func checkPreflightRules(tx txcore.Transaction, rules *amendment.Rules) ter.Resu
 	return ter.TesSUCCESS
 }
 
+func runTypePreflight(tx txcore.Transaction, rules *amendment.Rules) ter.Result {
+	if rp, ok := tx.(txcore.RulesAwarePreflighter); ok {
+		if err := rp.PreflightWithRules(rules); err != nil {
+			return parseValidationError(err)
+		}
+		return ter.TesSUCCESS
+	}
+	if err := tx.Validate(); err != nil {
+		return parseValidationError(err)
+	}
+	return checkPreflightRules(tx, rules)
+}
+
 // BatchOuter is implemented by transaction types whose inner transactions
 // each need to pass preflight as part of the outer's preflight pipeline.
 // Reference: rippled Batch.cpp preflight() — `ripple::preflight(..., tapBATCH)`
@@ -250,11 +258,11 @@ type BatchOuter interface {
 // preflight(stx, tapBATCH)): the amendment gate, checkExtraFeatures, preflight0's
 // flags mask, and the full T::preflight body all run — tapBATCH only makes
 // preflight1/preflight2 skip the fee and signature checks. So this must run every
-// per-type preflight seam (FlagsMasker, CheckExtraFeatures, RulesPreflighter), not
-// just Validate(): a type that carries part of its preflight body in PreflightRules
-// (e.g. Clawback, MPTokenIssuanceSet) would otherwise have that half silently
-// skipped for an inner tx, letting a malformed inner apply. Any failure collapses
-// to temINVALID_INNER_BATCH at the call site, so the intra-order here is immaterial.
+// per-type preflight seam (FlagsMasker, CheckExtraFeatures, RulesPreflighter,
+// RulesAwarePreflighter), not just Validate(): a type that carries part of its
+// preflight body in another seam would otherwise have that validation silently
+// skipped for an inner tx. Any failure collapses to temINVALID_INNER_BATCH at the
+// call site, so the intra-order here is immaterial.
 // Fee/signature/multi-sign/inner-flag rejections stay skipped (inner txs carry
 // Fee=0, no signature, no multi-signers, tfInnerBatchTxn set — all validated by
 // Batch.Validate()).
@@ -269,7 +277,7 @@ func (e *Engine) preflightInner(innerTx txcore.Transaction) ter.Result {
 			return ter.TemDISABLED
 		}
 	}
-	// The per-type seams (checkExtraFeatures, flags mask, PreflightRules) run for
+	// The per-type seams (checkExtraFeatures, flags mask, and rules-aware preflight) run for
 	// inner transactions exactly as they do on the outer path, mirroring rippled
 	// which preflights each inner via the full invokePreflight<T>. Without them an
 	// inner tx that adopts a seam would skip that validation, since inner txs
@@ -289,10 +297,7 @@ func (e *Engine) preflightInner(innerTx txcore.Transaction) ter.Result {
 	if result := checkDelegate(common, rules); result != ter.TesSUCCESS {
 		return result
 	}
-	if err := innerTx.Validate(); err != nil {
-		return parseValidationError(err)
-	}
-	return checkPreflightRules(innerTx, rules)
+	return runTypePreflight(innerTx, rules)
 }
 
 // preflightInnerBatchFlag rejects a transaction reaching the outer preflight

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -277,11 +277,6 @@ func (e *Engine) preflightInner(innerTx txcore.Transaction) ter.Result {
 			return ter.TemDISABLED
 		}
 	}
-	// The per-type seams (checkExtraFeatures, flags mask, and rules-aware preflight) run for
-	// inner transactions exactly as they do on the outer path, mirroring rippled
-	// which preflights each inner via the full invokePreflight<T>. Without them an
-	// inner tx that adopts a seam would skip that validation, since inner txs
-	// reach Apply directly and never run preclaim.
 	if result := checkExtraFeatures(innerTx, rules); result != ter.TesSUCCESS {
 		return result
 	}

--- a/internal/tx/engine/rules_aware_preflight_test.go
+++ b/internal/tx/engine/rules_aware_preflight_test.go
@@ -1,0 +1,110 @@
+package engine
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+type rulesAwareDispatchProbe struct {
+	*txcore.BaseTx
+	calls *[]string
+}
+
+func (p *rulesAwareDispatchProbe) Validate() error {
+	*p.calls = append(*p.calls, "Validate")
+	return ter.Errorf(ter.TemMALFORMED, "legacy Validate called")
+}
+
+func (p *rulesAwareDispatchProbe) PreflightRules(*amendment.Rules) error {
+	*p.calls = append(*p.calls, "PreflightRules")
+	return ter.Errorf(ter.TemMALFORMED, "legacy PreflightRules called")
+}
+
+func (p *rulesAwareDispatchProbe) PreflightWithRules(*amendment.Rules) error {
+	*p.calls = append(*p.calls, "PreflightWithRules")
+	return nil
+}
+
+type legacyDispatchProbe struct {
+	*txcore.BaseTx
+	calls *[]string
+}
+
+func (p *legacyDispatchProbe) Validate() error {
+	*p.calls = append(*p.calls, "Validate")
+	return nil
+}
+
+func (p *legacyDispatchProbe) PreflightRules(*amendment.Rules) error {
+	*p.calls = append(*p.calls, "PreflightRules")
+	return nil
+}
+
+func dispatchProbeBase(outer bool) *txcore.BaseTx {
+	base := txcore.NewBaseTx(txcore.TypeAccountSet, precedenceSourceAddr)
+	if outer {
+		base.Fee = "10"
+		base.Sequence = u32(5)
+	}
+	return base
+}
+
+func TestRulesAwarePreflightDispatch(t *testing.T) {
+	e := preflightEngine(allRules())
+	tests := []struct {
+		name string
+		run  func(txcore.Transaction) ter.Result
+	}{
+		{name: "outer", run: e.preflight},
+		{name: "batch inner", run: e.preflightInner},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := []string{}
+			probe := &rulesAwareDispatchProbe{
+				BaseTx: dispatchProbeBase(tc.name == "outer"),
+				calls:  &calls,
+			}
+			if got := tc.run(probe); got != ter.TesSUCCESS {
+				t.Fatalf("preflight = %v, want TesSUCCESS", got)
+			}
+			want := []string{"PreflightWithRules"}
+			if !reflect.DeepEqual(calls, want) {
+				t.Fatalf("calls = %v, want %v", calls, want)
+			}
+		})
+	}
+}
+
+func TestLegacyPreflightDispatchOrdering(t *testing.T) {
+	e := preflightEngine(allRules())
+	tests := []struct {
+		name string
+		run  func(txcore.Transaction) ter.Result
+	}{
+		{name: "outer", run: e.preflight},
+		{name: "batch inner", run: e.preflightInner},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := []string{}
+			probe := &legacyDispatchProbe{
+				BaseTx: dispatchProbeBase(tc.name == "outer"),
+				calls:  &calls,
+			}
+			if got := tc.run(probe); got != ter.TesSUCCESS {
+				t.Fatalf("preflight = %v, want TesSUCCESS", got)
+			}
+			want := []string{"Validate", "PreflightRules"}
+			if !reflect.DeepEqual(calls, want) {
+				t.Fatalf("calls = %v, want %v", calls, want)
+			}
+		})
+	}
+}

--- a/internal/tx/invariants/offers.go
+++ b/internal/tx/invariants/offers.go
@@ -203,7 +203,7 @@ func checkMPTokenAmounts(data []byte) *InvariantViolation {
 	return nil
 }
 
-// offerForInvariant preserves the sign of both XRP and IOU legs so NoBadOffers
+// offerForInvariant preserves the sign of XRP, IOU, and MPT legs so NoBadOffers
 // can flag a negative amount, mirroring rippled's STAmount comparison.
 type offerForInvariant struct {
 	takerPaysIsXRP    bool
@@ -225,9 +225,24 @@ func parseOfferForInvariant(data []byte) (*offerForInvariant, error) {
 		if len(f.Value) == 0 {
 			return fmt.Errorf("offer truncated at Amount value")
 		}
-		// Bit 63 is the not-XRP flag (clear for XRP) and bit 62 is the sign
-		// (set for positive). For IOU the not-XRP bit is set and the sign is
-		// decoded from the 48-byte value.
+		// Bit 63 is the IOU flag, bit 62 is the sign, and bit 61 marks MPT.
+		// MPT and XRP both have bit 63 clear, so distinguish MPT first.
+		if f.Value[0]&0x80 == 0 && f.Value[0]&0x20 != 0 {
+			amt, err := state.ParseMPTAmountBinary(f.Value)
+			if err != nil {
+				return fmt.Errorf("parse MPT amount: %w", err)
+			}
+			negative := amt.Signum() < 0
+			switch f.FieldCode {
+			case 4:
+				result.takerPaysNegative = negative
+			case 5:
+				result.takerGetsNegative = negative
+			}
+			return nil
+		}
+		// For IOU the not-XRP bit is set and the sign is decoded from the
+		// 48-byte value.
 		isXRP := (f.Value[0] & 0x80) == 0
 		if isXRP {
 			if len(f.Value) < 8 {

--- a/internal/tx/invariants/predicate_residuals_test.go
+++ b/internal/tx/invariants/predicate_residuals_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
-// offerSLE encodes an Offer ledger entry with XRP, IOU, or MPT amounts.
 func offerSLE(t *testing.T, takerPays, takerGets any) []byte {
 	t.Helper()
 	hexStr, err := binarycodec.Encode(map[string]any{

--- a/internal/tx/invariants/predicate_residuals_test.go
+++ b/internal/tx/invariants/predicate_residuals_test.go
@@ -16,8 +16,7 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
-// offerSLE encodes an Offer ledger entry. takerPays and takerGets are either a
-// drops string (XRP) or a {currency,issuer,value} map (IOU).
+// offerSLE encodes an Offer ledger entry with XRP, IOU, or MPT amounts.
 func offerSLE(t *testing.T, takerPays, takerGets any) []byte {
 	t.Helper()
 	hexStr, err := binarycodec.Encode(map[string]any{
@@ -43,6 +42,13 @@ func offerSLE(t *testing.T, takerPays, takerGets any) []byte {
 
 func usdAmount(value string) map[string]any {
 	return map[string]any{"currency": "USD", "issuer": addrIssuer, "value": value}
+}
+
+func mptOfferAmount(value string) map[string]any {
+	return map[string]any{
+		"mpt_issuance_id": "00000001B5F762798A53D543A014CAF8B297CFF8F2F937E8",
+		"value":           value,
+	}
 }
 
 // TestNoBadOffers_ZeroAmountsAccepted: rippled's isBad accepts zero amounts; an
@@ -109,6 +115,21 @@ func TestNoBadOffers_XRPForXRP(t *testing.T) {
 	}}
 	if v := checkNoBadOffers(entries); v == nil {
 		t.Fatal("expected NoBadOffers violation for XRP-for-XRP offer")
+	}
+}
+
+func TestNoBadOffers_MPTIsNotXRP(t *testing.T) {
+	entries := []InvariantEntry{{
+		EntryType: "Offer",
+		After:     offerSLE(t, "1000000", mptOfferAmount("5")),
+	}}
+	if v := checkNoBadOffers(entries); v != nil {
+		t.Fatalf("positive XRP/MPT offer must be accepted, got violation %v", v)
+	}
+
+	entries[0].After = offerSLE(t, "1000000", mptOfferAmount("-5"))
+	if v := checkNoBadOffers(entries); v == nil {
+		t.Fatal("expected NoBadOffers violation for negative MPT TakerGets")
 	}
 }
 

--- a/internal/tx/mptutil/mpt.go
+++ b/internal/tx/mptutil/mpt.go
@@ -1,0 +1,855 @@
+package mptutil
+
+import (
+	"encoding/hex"
+	"errors"
+	"math"
+	"math/big"
+	"strings"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/credential"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/internal/tx/vault"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+)
+
+const RateOne uint32 = 1_000_000_000
+
+const maxAssetCheckDepth = 5
+
+var ErrInvalidID = errors.New("invalid MPTokenIssuanceID")
+
+type balanceHookMPT interface {
+	BalanceHookMPT(account [20]byte, id [24]byte, amount int64) int64
+}
+
+type balanceHookSelfIssueMPT interface {
+	BalanceHookSelfIssueMPT(id [24]byte, amount int64) int64
+}
+
+type creditHookMPT interface {
+	CreditHookMPT(
+		sender, receiver [20]byte,
+		id [24]byte,
+		amount, preCreditHolderBalance uint64,
+		preCreditIssuerBalance int64,
+	)
+}
+
+type issuerSelfDebitHookMPT interface {
+	IssuerSelfDebitHookMPT(id [24]byte, amount uint64, origBalance int64)
+}
+
+type ownerCountHook interface {
+	AdjustOwnerCount(account [20]byte, current, next uint32)
+}
+
+func DecodeID(value string) ([24]byte, error) {
+	var id [24]byte
+	b, err := hex.DecodeString(strings.TrimSpace(value))
+	if err != nil || len(b) != len(id) {
+		return id, ErrInvalidID
+	}
+	copy(id[:], b)
+	return id, nil
+}
+
+func EncodeID(id [24]byte) string {
+	return strings.ToUpper(hex.EncodeToString(id[:]))
+}
+
+func Issuer(id [24]byte) [20]byte {
+	var issuer [20]byte
+	copy(issuer[:], id[4:])
+	return issuer
+}
+
+func ReadIssuance(view state.LedgerView, id [24]byte) (*state.MPTokenIssuanceData, keylet.Keylet, ter.Result) {
+	k := keylet.MPTIssuance(id)
+	raw, err := view.Read(k)
+	if err != nil || raw == nil {
+		return nil, k, ter.TecOBJECT_NOT_FOUND
+	}
+	issuance, err := state.ParseMPTokenIssuance(raw)
+	if err != nil {
+		return nil, k, ter.TefINTERNAL
+	}
+	return issuance, k, ter.TesSUCCESS
+}
+
+func ReadHolding(view state.LedgerView, id [24]byte, account [20]byte) (*state.MPTokenData, keylet.Keylet, ter.Result) {
+	k := keylet.MPTokenByID(id, account)
+	raw, err := view.Read(k)
+	if err != nil || raw == nil {
+		return nil, k, ter.TecNO_AUTH
+	}
+	token, err := state.ParseMPToken(raw)
+	if err != nil {
+		return nil, k, ter.TefINTERNAL
+	}
+	return token, k, ter.TesSUCCESS
+}
+
+func MaximumAmount(issuance *state.MPTokenIssuanceData) uint64 {
+	if issuance.MaximumAmount != nil {
+		return *issuance.MaximumAmount
+	}
+	return entry.MaxMPTokenAmount
+}
+
+func AvailableAmount(issuance *state.MPTokenIssuanceData) uint64 {
+	maximum := MaximumAmount(issuance)
+	if issuance.OutstandingAmount >= maximum {
+		return 0
+	}
+	return maximum - issuance.OutstandingAmount
+}
+
+func IsGlobalFrozen(view state.LedgerView, id [24]byte) bool {
+	issuance, _, result := ReadIssuance(view, id)
+	return result == ter.TesSUCCESS && issuance.Flags&entry.LsfMPTLocked != 0
+}
+
+func IsIndividualFrozen(view state.LedgerView, id [24]byte, account [20]byte) bool {
+	if account == Issuer(id) {
+		return false
+	}
+	token, _, result := ReadHolding(view, id, account)
+	return result == ter.TesSUCCESS && token.Flags&entry.LsfMPTLocked != 0
+}
+
+func IsFrozen(view state.LedgerView, id [24]byte, account [20]byte) bool {
+	return isFrozen(view, id, account, 0)
+}
+
+func isFrozen(view state.LedgerView, id [24]byte, account [20]byte, depth uint8) bool {
+	return IsGlobalFrozen(view, id) || IsIndividualFrozen(view, id, account) ||
+		isVaultPseudoAccountFrozen(view, id, account, depth)
+}
+
+func isVaultPseudoAccountFrozen(view state.LedgerView, id [24]byte, account [20]byte, depth uint8) bool {
+	rules := view.Rules()
+	if rules == nil || !rules.Enabled(amendment.FeatureSingleAssetVault) {
+		return false
+	}
+	if depth >= maxAssetCheckDepth {
+		return true
+	}
+
+	issuance, _, result := ReadIssuance(view, id)
+	if result != ter.TesSUCCESS {
+		return false
+	}
+	if issuance.ReferenceHolding != nil {
+		asset, result := referencedAsset(view, issuance)
+		if result != ter.TesSUCCESS {
+			return false
+		}
+		return isAnyAssetFrozen(view, asset, [][20]byte{issuance.Issuer, account}, depth+1)
+	}
+
+	issuerRaw, err := view.Read(keylet.Account(issuance.Issuer))
+	if err != nil || issuerRaw == nil {
+		return false
+	}
+	issuer, err := state.ParseAccountRoot(issuerRaw)
+	if err != nil || !issuer.HasVaultID() {
+		return false
+	}
+	vaultInfo, err := vault.ReadVaultInfo(view, keylet.VaultByID(issuer.VaultID))
+	if err != nil || vaultInfo == nil {
+		return false
+	}
+	return isAnyAssetFrozen(view, vaultInfo.Asset, [][20]byte{issuance.Issuer, account}, depth+1)
+}
+
+func isAnyAssetFrozen(view state.LedgerView, asset tx.Asset, accounts [][20]byte, depth uint8) bool {
+	if asset.IsMPT() {
+		id, err := DecodeID(asset.MPTIssuanceID)
+		if err != nil {
+			return false
+		}
+		for _, account := range accounts {
+			if isFrozen(view, id, account, depth) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, account := range accounts {
+		if isIOUFrozen(view, account, asset) {
+			return true
+		}
+	}
+	return false
+}
+
+func TransferRate(view state.LedgerView, id [24]byte) uint32 {
+	issuance, _, result := ReadIssuance(view, id)
+	if result != ter.TesSUCCESS || issuance.TransferFee == 0 {
+		return RateOne
+	}
+	return RateOne + 10_000*uint32(issuance.TransferFee)
+}
+
+func RequireAuth(view state.LedgerView, id [24]byte, account [20]byte, strong bool) ter.Result {
+	return RequireAuthAt(view, id, account, strong, 0)
+}
+
+func RequireAuthAt(view state.LedgerView, id [24]byte, account [20]byte, strong bool, parentCloseTime uint32) ter.Result {
+	return requireAuthAt(view, id, account, strong, parentCloseTime, 0)
+}
+
+func requireAuthAt(view state.LedgerView, id [24]byte, account [20]byte, strong bool, parentCloseTime uint32, depth uint8) ter.Result {
+	issuance, _, result := ReadIssuance(view, id)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if issuance.Issuer == account {
+		return ter.TesSUCCESS
+	}
+	if rules := view.Rules(); rules != nil && rules.Enabled(amendment.FeatureSingleAssetVault) {
+		if depth >= maxAssetCheckDepth {
+			return ter.TecINTERNAL
+		}
+		issuerRaw, err := view.Read(keylet.Account(issuance.Issuer))
+		if err != nil || issuerRaw == nil {
+			return ter.TefINTERNAL
+		}
+		issuer, err := state.ParseAccountRoot(issuerRaw)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		if issuer.HasVaultID() {
+			vaultInfo, err := vault.ReadVaultInfo(view, keylet.VaultByID(issuer.VaultID))
+			if err != nil || vaultInfo == nil {
+				return ter.TefINTERNAL
+			}
+			if result := requireAssetAuthAt(view, vaultInfo.Asset, account, strong, parentCloseTime, depth+1); result != ter.TesSUCCESS {
+				return result
+			}
+		}
+	}
+
+	token, _, tokenResult := ReadHolding(view, id, account)
+	if tokenResult != ter.TesSUCCESS && strong {
+		return ter.TecNO_AUTH
+	}
+	if issuance.DomainID != nil {
+		domainResult := validDomain(view, *issuance.DomainID, account, parentCloseTime)
+		if domainResult == ter.TesSUCCESS {
+			return ter.TesSUCCESS
+		}
+		if token == nil {
+			return domainResult
+		}
+	}
+	if issuance.Flags&entry.LsfMPTRequireAuth == 0 {
+		return ter.TesSUCCESS
+	}
+	if token != nil && token.Flags&entry.LsfMPTAuthorized != 0 {
+		return ter.TesSUCCESS
+	}
+
+	accountRaw, _ := view.Read(keylet.Account(account))
+	if accountRoot, err := state.ParseAccountRoot(accountRaw); err == nil && accountRoot.IsPseudoAccount() {
+		return ter.TesSUCCESS
+	}
+	return ter.TecNO_AUTH
+}
+
+func requireAssetAuthAt(view state.LedgerView, asset tx.Asset, account [20]byte, strong bool, parentCloseTime uint32, depth uint8) ter.Result {
+	if asset.IsMPT() {
+		id, err := DecodeID(asset.MPTIssuanceID)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		return requireAuthAt(view, id, account, strong, parentCloseTime, depth)
+	}
+	if asset.IsNative() {
+		return ter.TesSUCCESS
+	}
+	issuer, err := state.DecodeAccountID(asset.Issuer)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if account == issuer {
+		return ter.TesSUCCESS
+	}
+	lineRaw, err := view.Read(keylet.Line(account, issuer, asset.Currency))
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if lineRaw == nil && strong {
+		return ter.TecNO_LINE
+	}
+	issuerRaw, err := view.Read(keylet.Account(issuer))
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if issuerRaw == nil {
+		return ter.TesSUCCESS
+	}
+	issuerAccount, err := state.ParseAccountRoot(issuerRaw)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if issuerAccount.Flags&state.LsfRequireAuth == 0 {
+		return ter.TesSUCCESS
+	}
+	if lineRaw == nil {
+		return ter.TecNO_LINE
+	}
+	line, err := state.ParseRippleState(lineRaw)
+	if err != nil {
+		return ter.TecNO_AUTH
+	}
+	if state.CompareAccountIDs(account, issuer) > 0 {
+		if line.Flags&state.LsfLowAuth == 0 {
+			return ter.TecNO_AUTH
+		}
+	} else if line.Flags&state.LsfHighAuth == 0 {
+		return ter.TecNO_AUTH
+	}
+	return ter.TesSUCCESS
+}
+
+func isIOUFrozen(view state.LedgerView, account [20]byte, asset tx.Asset) bool {
+	if asset.IsNative() {
+		return false
+	}
+	issuer, err := state.DecodeAccountID(asset.Issuer)
+	if err != nil {
+		return false
+	}
+	issuerRaw, err := view.Read(keylet.Account(issuer))
+	if err == nil && issuerRaw != nil {
+		if issuerAccount, parseErr := state.ParseAccountRoot(issuerRaw); parseErr == nil &&
+			issuerAccount.Flags&state.LsfGlobalFreeze != 0 {
+			return true
+		}
+	}
+	if account == issuer {
+		return false
+	}
+	lineRaw, err := view.Read(keylet.Line(account, issuer, asset.Currency))
+	if err != nil || lineRaw == nil {
+		return false
+	}
+	line, err := state.ParseRippleState(lineRaw)
+	if err != nil {
+		return false
+	}
+	if state.CompareAccountIDs(issuer, account) > 0 {
+		return line.Flags&state.LsfHighFreeze != 0
+	}
+	return line.Flags&state.LsfLowFreeze != 0
+}
+
+func validDomain(view state.LedgerView, domainIDHex string, account [20]byte, parentCloseTime uint32) ter.Result {
+	domainBytes, err := hex.DecodeString(domainIDHex)
+	if err != nil || len(domainBytes) != 32 {
+		return ter.TefINTERNAL
+	}
+	var domainID [32]byte
+	copy(domainID[:], domainBytes)
+	raw, err := view.Read(keylet.PermissionedDomainByID(domainID))
+	if err != nil || raw == nil {
+		return ter.TecOBJECT_NOT_FOUND
+	}
+	domain, err := state.ParsePermissionedDomain(raw)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	foundExpired := false
+	for _, accepted := range domain.AcceptedCredentials {
+		credentialRaw, err := view.Read(keylet.Credential(account, accepted.Issuer, accepted.CredentialType))
+		if err != nil || credentialRaw == nil {
+			continue
+		}
+		credentialEntry, err := credential.ParseCredentialEntry(credentialRaw)
+		if err != nil {
+			continue
+		}
+		if credential.CheckCredentialExpired(credentialEntry, parentCloseTime) {
+			foundExpired = true
+			continue
+		}
+		if credentialEntry.IsAccepted() {
+			return ter.TesSUCCESS
+		}
+	}
+	if foundExpired {
+		return ter.TecEXPIRED
+	}
+	return ter.TecNO_AUTH
+}
+
+func CanTrade(view state.LedgerView, id [24]byte) ter.Result {
+	return canTrade(view, id, 0)
+}
+
+func canTrade(view state.LedgerView, id [24]byte, depth uint8) ter.Result {
+	issuance, _, result := ReadIssuance(view, id)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if issuance.Flags&entry.LsfMPTCanTrade == 0 {
+		return ter.TecNO_PERMISSION
+	}
+	rules := view.Rules()
+	if rules != nil && rules.FixCleanup3_2_0Enabled() && issuance.ReferenceHolding != nil {
+		if depth >= maxAssetCheckDepth {
+			return ter.TecINTERNAL
+		}
+		asset, result := referencedAsset(view, issuance)
+		if result != ter.TesSUCCESS {
+			return result
+		}
+		if asset.IsMPT() {
+			underlyingID, err := DecodeID(asset.MPTIssuanceID)
+			if err != nil {
+				return ter.TefINTERNAL
+			}
+			return canTrade(view, underlyingID, depth+1)
+		}
+	}
+	return ter.TesSUCCESS
+}
+
+func CanTransfer(view state.LedgerView, id [24]byte, from, to [20]byte) ter.Result {
+	return canTransfer(view, id, from, to, 0)
+}
+
+func canTransfer(view state.LedgerView, id [24]byte, from, to [20]byte, depth uint8) ter.Result {
+	issuance, _, result := ReadIssuance(view, id)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if from == issuance.Issuer || to == issuance.Issuer {
+		return ter.TesSUCCESS
+	}
+	if issuance.Flags&entry.LsfMPTCanTransfer == 0 {
+		return ter.TecNO_AUTH
+	}
+	rules := view.Rules()
+	if rules != nil && rules.FixCleanup3_2_0Enabled() && issuance.ReferenceHolding != nil {
+		if depth >= maxAssetCheckDepth {
+			return ter.TecINTERNAL
+		}
+		asset, result := referencedAsset(view, issuance)
+		if result != ter.TesSUCCESS {
+			return result
+		}
+		return canTransferAsset(view, asset, from, to, depth+1)
+	}
+	return ter.TesSUCCESS
+}
+
+func canTransferAsset(view state.LedgerView, asset tx.Asset, from, to [20]byte, depth uint8) ter.Result {
+	if asset.IsMPT() {
+		id, err := DecodeID(asset.MPTIssuanceID)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		return canTransfer(view, id, from, to, depth)
+	}
+	if asset.IsNative() {
+		return ter.TesSUCCESS
+	}
+	issuer, err := state.DecodeAccountID(asset.Issuer)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if from == issuer || to == issuer {
+		return ter.TesSUCCESS
+	}
+	issuerRaw, err := view.Read(keylet.Account(issuer))
+	if err != nil || issuerRaw == nil {
+		return ter.TefINTERNAL
+	}
+	issuerAccount, err := state.ParseAccountRoot(issuerRaw)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	isRippleDisabled := func(account [20]byte) bool {
+		lineRaw, _ := view.Read(keylet.Line(account, issuer, asset.Currency))
+		if lineRaw == nil {
+			return issuerAccount.Flags&state.LsfDefaultRipple == 0
+		}
+		line, err := state.ParseRippleState(lineRaw)
+		if err != nil {
+			return true
+		}
+		if state.CompareAccountIDs(issuer, account) > 0 {
+			return line.Flags&state.LsfHighNoRipple != 0
+		}
+		return line.Flags&state.LsfLowNoRipple != 0
+	}
+	if isRippleDisabled(from) && isRippleDisabled(to) {
+		return ter.TerNO_RIPPLE
+	}
+	return ter.TesSUCCESS
+}
+
+func referencedAsset(view state.LedgerView, issuance *state.MPTokenIssuanceData) (tx.Asset, ter.Result) {
+	if issuance.ReferenceHolding == nil {
+		return tx.Asset{}, ter.TefINTERNAL
+	}
+	reference, err := hex.DecodeString(*issuance.ReferenceHolding)
+	if err != nil || len(reference) != 32 {
+		return tx.Asset{}, ter.TefINTERNAL
+	}
+	var key [32]byte
+	copy(key[:], reference)
+	raw, err := view.Read(keylet.Keylet{Key: key})
+	if err != nil || raw == nil {
+		return tx.Asset{}, ter.TefINTERNAL
+	}
+	typeCode, err := state.GetLedgerEntryType(raw)
+	if err != nil {
+		return tx.Asset{}, ter.TefINTERNAL
+	}
+	switch entry.Type(typeCode) {
+	case entry.TypeMPToken:
+		holding, err := state.ParseMPToken(raw)
+		if err != nil {
+			return tx.Asset{}, ter.TefINTERNAL
+		}
+		return tx.Asset{MPTIssuanceID: EncodeID(holding.MPTokenIssuanceID)}, ter.TesSUCCESS
+	case entry.TypeRippleState:
+		holding, err := state.ParseRippleState(raw)
+		if err != nil {
+			return tx.Asset{}, ter.TefINTERNAL
+		}
+		vaultPseudo := state.EncodeAccountIDSafe(issuance.Issuer)
+		issuer := holding.LowLimit.Issuer
+		if issuer == vaultPseudo {
+			issuer = holding.HighLimit.Issuer
+		}
+		return tx.Asset{Currency: holding.LowLimit.Currency, Issuer: issuer}, ter.TesSUCCESS
+	default:
+		return tx.Asset{}, ter.TefINTERNAL
+	}
+}
+
+func Funds(view state.LedgerView, id [24]byte, account [20]byte, zeroIfFrozen bool) (int64, ter.Result) {
+	issuance, _, result := ReadIssuance(view, id)
+	if result != ter.TesSUCCESS {
+		return 0, result
+	}
+	if account == issuance.Issuer {
+		amount := int64(AvailableAmount(issuance))
+		if mptokensV2Enabled(view) {
+			if hook, ok := view.(balanceHookMPT); ok {
+				amount = hook.BalanceHookMPT(account, id, amount)
+			}
+		}
+		return amount, ter.TesSUCCESS
+	}
+	if zeroIfFrozen && IsFrozen(view, id, account) {
+		return 0, ter.TesSUCCESS
+	}
+	token, _, result := ReadHolding(view, id, account)
+	if result != ter.TesSUCCESS {
+		return 0, result
+	}
+	if token.MPTAmount > math.MaxInt64 {
+		return 0, ter.TefINTERNAL
+	}
+	amount := int64(token.MPTAmount)
+	if mptokensV2Enabled(view) {
+		if hook, ok := view.(balanceHookMPT); ok {
+			amount = hook.BalanceHookMPT(account, id, amount)
+		}
+	}
+	return amount, ter.TesSUCCESS
+}
+
+func IssuerFundsToSelfIssue(view state.LedgerView, id [24]byte) (int64, ter.Result) {
+	issuance, _, result := ReadIssuance(view, id)
+	if result != ter.TesSUCCESS {
+		return 0, result
+	}
+	amount := int64(AvailableAmount(issuance))
+	if mptokensV2Enabled(view) {
+		if hook, ok := view.(balanceHookSelfIssueMPT); ok {
+			amount = hook.BalanceHookSelfIssueMPT(id, amount)
+		}
+	}
+	return amount, ter.TesSUCCESS
+}
+
+func RecordIssuerSelfDebit(view state.LedgerView, id [24]byte, amount uint64) ter.Result {
+	if amount == 0 || !mptokensV2Enabled(view) {
+		return ter.TesSUCCESS
+	}
+	issuance, _, result := ReadIssuance(view, id)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if hook, ok := view.(issuerSelfDebitHookMPT); ok {
+		hook.IssuerSelfDebitHookMPT(id, amount, int64(AvailableAmount(issuance)))
+	}
+	return ter.TesSUCCESS
+}
+
+func EnsureHolding(view state.LedgerView, id [24]byte, holder [20]byte, flags uint32, adjustOwnerCount bool) ter.Result {
+	if holder == Issuer(id) {
+		return ter.TesSUCCESS
+	}
+	k := keylet.MPTokenByID(id, holder)
+	if exists, err := view.Exists(k); err == nil && exists {
+		return ter.TesSUCCESS
+	}
+
+	accountKey := keylet.Account(holder)
+	accountRaw, err := view.Read(accountKey)
+	if err != nil || accountRaw == nil {
+		return ter.TecNO_DST
+	}
+	account, err := state.ParseAccountRoot(accountRaw)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+
+	dirResult, err := state.DirInsert(view, keylet.OwnerDir(holder), k.Key, false, func(dir *state.DirectoryNode) {
+		dir.Owner = holder
+	})
+	if err != nil {
+		return ter.TecDIR_FULL
+	}
+	token := &state.MPTokenData{
+		Account:           holder,
+		MPTokenIssuanceID: id,
+		OwnerNode:         dirResult.Page,
+		Flags:             flags,
+	}
+	data, err := state.SerializeMPToken(token)
+	if err != nil || view.Insert(k, data) != nil {
+		return ter.TefINTERNAL
+	}
+	if adjustOwnerCount {
+		current := account.OwnerCount
+		account.OwnerCount++
+		if hook, ok := view.(ownerCountHook); ok {
+			hook.AdjustOwnerCount(holder, current, account.OwnerCount)
+		}
+		data, err = state.SerializeAccountRoot(account)
+		if err != nil || view.Update(accountKey, data) != nil {
+			return ter.TefINTERNAL
+		}
+	}
+	return ter.TesSUCCESS
+}
+
+func RemoveHolding(view state.LedgerView, id [24]byte, holder [20]byte, adjustOwnerCount bool) ter.Result {
+	tokenKey := keylet.MPTokenByID(id, holder)
+	raw, err := view.Read(tokenKey)
+	if err != nil || raw == nil {
+		if holder == Issuer(id) {
+			return ter.TesSUCCESS
+		}
+		return ter.TecOBJECT_NOT_FOUND
+	}
+	token, err := state.ParseMPToken(raw)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if token.MPTAmount != 0 || token.LockedAmount != nil && *token.LockedAmount != 0 {
+		return ter.TecHAS_OBLIGATIONS
+	}
+	removed, err := state.DirRemove(view, keylet.OwnerDir(holder), token.OwnerNode, tokenKey.Key, false)
+	if err != nil || !removed.Success {
+		return ter.TefINTERNAL
+	}
+	if err := view.Erase(tokenKey); err != nil {
+		return ter.TefINTERNAL
+	}
+	if !adjustOwnerCount {
+		return ter.TesSUCCESS
+	}
+
+	accountKey := keylet.Account(holder)
+	accountRaw, err := view.Read(accountKey)
+	if err != nil || accountRaw == nil {
+		return ter.TefINTERNAL
+	}
+	account, err := state.ParseAccountRoot(accountRaw)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	current := account.OwnerCount
+	if account.OwnerCount > 0 {
+		account.OwnerCount--
+	}
+	if hook, ok := view.(ownerCountHook); ok {
+		hook.AdjustOwnerCount(holder, current, account.OwnerCount)
+	}
+	data, err := state.SerializeAccountRoot(account)
+	if err != nil || view.Update(accountKey, data) != nil {
+		return ter.TefINTERNAL
+	}
+	return ter.TesSUCCESS
+}
+
+func Credit(view state.LedgerView, id [24]byte, sender, receiver [20]byte, amount int64, allowOverflow bool) ter.Result {
+	if amount < 0 {
+		return ter.TefINTERNAL
+	}
+	if amount == 0 || sender == receiver {
+		return ter.TesSUCCESS
+	}
+
+	issuance, issuanceKey, result := ReadIssuance(view, id)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	issuer := issuance.Issuer
+	value := uint64(amount)
+	newOutstanding := issuance.OutstandingAmount
+	available := int64(AvailableAmount(issuance))
+	var hook creditHookMPT
+	if mptokensV2Enabled(view) {
+		hook, _ = view.(creditHookMPT)
+	}
+
+	var senderToken, receiverToken *state.MPTokenData
+	var senderKey, receiverKey keylet.Keylet
+	if sender == issuer {
+		maximum := MaximumAmount(issuance)
+		limit := maximum
+		if allowOverflow {
+			limit = math.MaxUint64
+		}
+		if value > maximum || newOutstanding > limit-value {
+			return ter.TecPATH_DRY
+		}
+		newOutstanding += value
+	} else {
+		senderToken, senderKey, result = ReadHolding(view, id, sender)
+		if result != ter.TesSUCCESS {
+			return result
+		}
+		if senderToken.MPTAmount < value {
+			return ter.TecINSUFFICIENT_FUNDS
+		}
+		if hook != nil {
+			hook.CreditHookMPT(sender, receiver, id, value, senderToken.MPTAmount, available)
+		}
+	}
+
+	if receiver == issuer {
+		if newOutstanding < value {
+			return ter.TefINTERNAL
+		}
+		newOutstanding -= value
+	} else {
+		receiverToken, receiverKey, result = ReadHolding(view, id, receiver)
+		if result != ter.TesSUCCESS {
+			return result
+		}
+		if receiverToken.MPTAmount > math.MaxUint64-value {
+			return ter.TefINTERNAL
+		}
+		if hook != nil {
+			hook.CreditHookMPT(sender, receiver, id, value, receiverToken.MPTAmount, available)
+		}
+	}
+
+	if senderToken != nil {
+		senderToken.MPTAmount -= value
+		data, err := state.SerializeMPToken(senderToken)
+		if err != nil || view.Update(senderKey, data) != nil {
+			return ter.TefINTERNAL
+		}
+	}
+	if receiverToken != nil {
+		receiverToken.MPTAmount += value
+		data, err := state.SerializeMPToken(receiverToken)
+		if err != nil || view.Update(receiverKey, data) != nil {
+			return ter.TefINTERNAL
+		}
+	}
+	if newOutstanding != issuance.OutstandingAmount {
+		issuance.OutstandingAmount = newOutstanding
+		data, err := state.SerializeMPTokenIssuance(issuance)
+		if err != nil || view.Update(issuanceKey, data) != nil {
+			return ter.TefINTERNAL
+		}
+	}
+	return ter.TesSUCCESS
+}
+
+func mptokensV2Enabled(view state.LedgerView) bool {
+	rules := view.Rules()
+	return rules != nil && rules.MPTokensV2Enabled()
+}
+
+// MultiplyRate applies an MPT transfer rate, rounding positive values upward.
+// The boolean is false when the result cannot be represented as an int64.
+func MultiplyRate(amount int64, rate uint32) (int64, bool) {
+	if amount == 0 || rate == RateOne {
+		return amount, true
+	}
+	return scaleRate(amount, uint64(rate), uint64(RateOne), true)
+}
+
+// DivideRate removes an MPT transfer rate, rounding positive values downward.
+// The boolean is false when the result cannot be represented as an int64.
+func DivideRate(amount int64, rate uint32) (int64, bool) {
+	if amount == 0 || rate == RateOne {
+		return amount, true
+	}
+	return scaleRate(amount, uint64(RateOne), uint64(rate), false)
+}
+
+func scaleRate(amount int64, numeratorFactor, denominatorValue uint64, roundUp bool) (int64, bool) {
+	if denominatorValue == 0 {
+		return 0, false
+	}
+	numerator := new(big.Int).Mul(big.NewInt(amount), new(big.Int).SetUint64(numeratorFactor))
+	denominator := new(big.Int).SetUint64(denominatorValue)
+	quotient, remainder := new(big.Int), new(big.Int)
+	quotient.QuoRem(numerator, denominator, remainder)
+	if remainder.Sign() != 0 {
+		if roundUp && amount >= 0 {
+			quotient.Add(quotient, big.NewInt(1))
+		} else if !roundUp && amount < 0 {
+			quotient.Sub(quotient, big.NewInt(1))
+		}
+	}
+	if !quotient.IsInt64() {
+		return 0, false
+	}
+	return quotient.Int64(), true
+}
+
+func Send(view state.LedgerView, id [24]byte, sender, receiver [20]byte, amount int64, waiveFee, allowOverflow bool) (int64, ter.Result) {
+	if sender == receiver || amount == 0 {
+		return amount, ter.TesSUCCESS
+	}
+	issuer := Issuer(id)
+	if sender == issuer || receiver == issuer {
+		return amount, Credit(view, id, sender, receiver, amount, allowOverflow)
+	}
+	gross := amount
+	if !waiveFee {
+		var ok bool
+		gross, ok = MultiplyRate(amount, TransferRate(view, id))
+		if !ok {
+			return 0, ter.TefEXCEPTION
+		}
+	}
+	if result := Credit(view, id, issuer, receiver, amount, true); result != ter.TesSUCCESS {
+		return 0, result
+	}
+	if result := Credit(view, id, sender, issuer, gross, allowOverflow); result != ter.TesSUCCESS {
+		return 0, result
+	}
+	return gross, ter.TesSUCCESS
+}

--- a/internal/tx/mptutil/mpt.go
+++ b/internal/tx/mptutil/mpt.go
@@ -71,7 +71,10 @@ func Issuer(id [24]byte) [20]byte {
 func ReadIssuance(view state.LedgerView, id [24]byte) (*state.MPTokenIssuanceData, keylet.Keylet, ter.Result) {
 	k := keylet.MPTIssuance(id)
 	raw, err := view.Read(k)
-	if err != nil || raw == nil {
+	if err != nil {
+		return nil, k, ter.TefINTERNAL
+	}
+	if raw == nil {
 		return nil, k, ter.TecOBJECT_NOT_FOUND
 	}
 	issuance, err := state.ParseMPTokenIssuance(raw)
@@ -84,7 +87,10 @@ func ReadIssuance(view state.LedgerView, id [24]byte) (*state.MPTokenIssuanceDat
 func ReadHolding(view state.LedgerView, id [24]byte, account [20]byte) (*state.MPTokenData, keylet.Keylet, ter.Result) {
 	k := keylet.MPTokenByID(id, account)
 	raw, err := view.Read(k)
-	if err != nil || raw == nil {
+	if err != nil {
+		return nil, k, ter.TefINTERNAL
+	}
+	if raw == nil {
 		return nil, k, ter.TecNO_AUTH
 	}
 	token, err := state.ParseMPToken(raw)
@@ -236,8 +242,13 @@ func requireAuthAt(view state.LedgerView, id [24]byte, account [20]byte, strong 
 	}
 
 	token, _, tokenResult := ReadHolding(view, id, account)
-	if tokenResult != ter.TesSUCCESS && strong {
-		return ter.TecNO_AUTH
+	if tokenResult != ter.TesSUCCESS {
+		if tokenResult != ter.TecNO_AUTH {
+			return tokenResult
+		}
+		if strong {
+			return ter.TecNO_AUTH
+		}
 	}
 	if issuance.DomainID != nil {
 		domainResult := validDomain(view, *issuance.DomainID, account, parentCloseTime)
@@ -255,8 +266,22 @@ func requireAuthAt(view state.LedgerView, id [24]byte, account [20]byte, strong 
 		return ter.TesSUCCESS
 	}
 
-	accountRaw, _ := view.Read(keylet.Account(account))
-	if accountRoot, err := state.ParseAccountRoot(accountRaw); err == nil && accountRoot.IsPseudoAccount() {
+	rules := view.Rules()
+	if rules == nil || (!rules.Enabled(amendment.FeatureSingleAssetVault) && !rules.Enabled(amendment.FeatureMPTokensV2)) {
+		return ter.TecNO_AUTH
+	}
+	accountRaw, err := view.Read(keylet.Account(account))
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if accountRaw == nil {
+		return ter.TecNO_AUTH
+	}
+	accountRoot, err := state.ParseAccountRoot(accountRaw)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if accountRoot.IsPseudoAccount() {
 		return ter.TesSUCCESS
 	}
 	return ter.TecNO_AUTH
@@ -306,7 +331,7 @@ func requireAssetAuthAt(view state.LedgerView, asset tx.Asset, account [20]byte,
 	}
 	line, err := state.ParseRippleState(lineRaw)
 	if err != nil {
-		return ter.TecNO_AUTH
+		return ter.TefINTERNAL
 	}
 	if state.CompareAccountIDs(account, issuer) > 0 {
 		if line.Flags&state.LsfLowAuth == 0 {
@@ -358,7 +383,10 @@ func validDomain(view state.LedgerView, domainIDHex string, account [20]byte, pa
 	var domainID [32]byte
 	copy(domainID[:], domainBytes)
 	raw, err := view.Read(keylet.PermissionedDomainByID(domainID))
-	if err != nil || raw == nil {
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if raw == nil {
 		return ter.TecOBJECT_NOT_FOUND
 	}
 	domain, err := state.ParsePermissionedDomain(raw)
@@ -368,12 +396,15 @@ func validDomain(view state.LedgerView, domainIDHex string, account [20]byte, pa
 	foundExpired := false
 	for _, accepted := range domain.AcceptedCredentials {
 		credentialRaw, err := view.Read(keylet.Credential(account, accepted.Issuer, accepted.CredentialType))
-		if err != nil || credentialRaw == nil {
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		if credentialRaw == nil {
 			continue
 		}
 		credentialEntry, err := credential.ParseCredentialEntry(credentialRaw)
 		if err != nil {
-			continue
+			return ter.TefINTERNAL
 		}
 		if credential.CheckCredentialExpired(credentialEntry, parentCloseTime) {
 			foundExpired = true
@@ -476,21 +507,35 @@ func canTransferAsset(view state.LedgerView, asset tx.Asset, from, to [20]byte, 
 	if err != nil {
 		return ter.TefINTERNAL
 	}
-	isRippleDisabled := func(account [20]byte) bool {
-		lineRaw, _ := view.Read(keylet.Line(account, issuer, asset.Currency))
+	isRippleDisabled := func(account [20]byte) (bool, ter.Result) {
+		lineRaw, err := view.Read(keylet.Line(account, issuer, asset.Currency))
+		if err != nil {
+			return false, ter.TefINTERNAL
+		}
 		if lineRaw == nil {
-			return issuerAccount.Flags&state.LsfDefaultRipple == 0
+			return issuerAccount.Flags&state.LsfDefaultRipple == 0, ter.TesSUCCESS
 		}
 		line, err := state.ParseRippleState(lineRaw)
 		if err != nil {
-			return true
+			return false, ter.TefINTERNAL
 		}
 		if state.CompareAccountIDs(issuer, account) > 0 {
-			return line.Flags&state.LsfHighNoRipple != 0
+			return line.Flags&state.LsfHighNoRipple != 0, ter.TesSUCCESS
 		}
-		return line.Flags&state.LsfLowNoRipple != 0
+		return line.Flags&state.LsfLowNoRipple != 0, ter.TesSUCCESS
 	}
-	if isRippleDisabled(from) && isRippleDisabled(to) {
+	fromDisabled, result := isRippleDisabled(from)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if !fromDisabled {
+		return ter.TesSUCCESS
+	}
+	toDisabled, result := isRippleDisabled(to)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if toDisabled {
 		return ter.TerNO_RIPPLE
 	}
 	return ter.TesSUCCESS
@@ -603,13 +648,20 @@ func EnsureHolding(view state.LedgerView, id [24]byte, holder [20]byte, flags ui
 		return ter.TesSUCCESS
 	}
 	k := keylet.MPTokenByID(id, holder)
-	if exists, err := view.Exists(k); err == nil && exists {
+	exists, err := view.Exists(k)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if exists {
 		return ter.TesSUCCESS
 	}
 
 	accountKey := keylet.Account(holder)
 	accountRaw, err := view.Read(accountKey)
-	if err != nil || accountRaw == nil {
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if accountRaw == nil {
 		return ter.TecNO_DST
 	}
 	account, err := state.ParseAccountRoot(accountRaw)
@@ -650,7 +702,10 @@ func EnsureHolding(view state.LedgerView, id [24]byte, holder [20]byte, flags ui
 func RemoveHolding(view state.LedgerView, id [24]byte, holder [20]byte, adjustOwnerCount bool) ter.Result {
 	tokenKey := keylet.MPTokenByID(id, holder)
 	raw, err := view.Read(tokenKey)
-	if err != nil || raw == nil {
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if raw == nil {
 		if holder == Issuer(id) {
 			return ter.TesSUCCESS
 		}

--- a/internal/tx/mptutil/mpt_test.go
+++ b/internal/tx/mptutil/mpt_test.go
@@ -1,0 +1,371 @@
+package mptutil
+
+import (
+	"encoding/hex"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	"github.com/stretchr/testify/require"
+)
+
+type mptTestView struct {
+	data        map[[32]byte][]byte
+	adjustments [][3]uint32
+	rules       *amendment.Rules
+}
+
+func newMPTTestView() *mptTestView {
+	return &mptTestView{data: make(map[[32]byte][]byte)}
+}
+
+func (v *mptTestView) Read(k keylet.Keylet) ([]byte, error) { return v.data[k.Key], nil }
+func (v *mptTestView) Exists(k keylet.Keylet) (bool, error) {
+	_, exists := v.data[k.Key]
+	return exists, nil
+}
+func (v *mptTestView) Insert(k keylet.Keylet, data []byte) error {
+	v.data[k.Key] = data
+	return nil
+}
+func (v *mptTestView) Update(k keylet.Keylet, data []byte) error {
+	v.data[k.Key] = data
+	return nil
+}
+func (v *mptTestView) Erase(k keylet.Keylet) error {
+	delete(v.data, k.Key)
+	return nil
+}
+func (v *mptTestView) Rules() *amendment.Rules {
+	if v.rules != nil {
+		return v.rules
+	}
+	return amendment.AllSupportedRules()
+}
+func (v *mptTestView) AdjustOwnerCount(_ [20]byte, current, next uint32) {
+	v.adjustments = append(v.adjustments, [3]uint32{current, next})
+}
+
+func TestEnsureAndRemoveHolding(t *testing.T) {
+	view := newMPTTestView()
+	var id [24]byte
+	copy(id[4:], []byte("issuer-account-id-123"))
+	var holder [20]byte
+	copy(holder[:], []byte("holder-account-id-123"))
+
+	account := &state.AccountRoot{
+		Account:    state.EncodeAccountIDSafe(holder),
+		Balance:    100_000_000,
+		OwnerCount: 2,
+		Sequence:   1,
+	}
+	raw, err := state.SerializeAccountRoot(account)
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.Account(holder), raw))
+
+	require.Equal(t, ter.TesSUCCESS, EnsureHolding(view, id, holder, 0, true))
+	tokenKey := keylet.MPTokenByID(id, holder)
+	tokenRaw, err := view.Read(tokenKey)
+	require.NoError(t, err)
+	token, err := state.ParseMPToken(tokenRaw)
+	require.NoError(t, err)
+	locked := uint64(1)
+	token.LockedAmount = &locked
+	tokenRaw, err = state.SerializeMPToken(token)
+	require.NoError(t, err)
+	require.NoError(t, view.Update(tokenKey, tokenRaw))
+
+	require.Equal(t, ter.TecHAS_OBLIGATIONS, RemoveHolding(view, id, holder, true))
+	token.LockedAmount = nil
+	tokenRaw, err = state.SerializeMPToken(token)
+	require.NoError(t, err)
+	require.NoError(t, view.Update(tokenKey, tokenRaw))
+	require.Equal(t, ter.TesSUCCESS, RemoveHolding(view, id, holder, true))
+
+	exists, err := view.Exists(tokenKey)
+	require.NoError(t, err)
+	require.False(t, exists)
+	accountRaw, err := view.Read(keylet.Account(holder))
+	require.NoError(t, err)
+	account, err = state.ParseAccountRoot(accountRaw)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), account.OwnerCount)
+	require.Equal(t, [][3]uint32{{2, 3}, {3, 2}}, view.adjustments)
+}
+
+func TestCreditOverflowStillCapsSingleIssueAtMaximum(t *testing.T) {
+	view := newMPTTestView()
+	var id [24]byte
+	copy(id[4:], []byte("issuer-account-id-123"))
+	issuer := Issuer(id)
+	var holder [20]byte
+	copy(holder[:], []byte("holder-account-id-123"))
+	maximum := uint64(50)
+	issuance := &state.MPTokenIssuanceData{Issuer: issuer, Sequence: 1, MaximumAmount: &maximum}
+	raw, err := state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.MPTIssuance(id), raw))
+	token := &state.MPTokenData{Account: holder, MPTokenIssuanceID: id}
+	raw, err = state.SerializeMPToken(token)
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.MPTokenByID(id, holder), raw))
+
+	require.Equal(t, ter.TecPATH_DRY, Credit(view, id, issuer, holder, 51, true))
+}
+
+func TestVaultShareReferenceInheritsMPTChecks(t *testing.T) {
+	view := newMPTTestView()
+	var vaultPseudo, underlyingIssuer, from, to [20]byte
+	vaultPseudo[19] = 0x20
+	underlyingIssuer[19] = 0x10
+	from[19] = 0x30
+	to[19] = 0x40
+	shareID := keylet.MakeMPTID(1, vaultPseudo)
+	underlyingID := keylet.MakeMPTID(2, underlyingIssuer)
+
+	referenceKey := keylet.MPTokenByID(underlyingID, vaultPseudo)
+	referenceHex := strings.ToUpper(hex.EncodeToString(referenceKey.Key[:]))
+	putTestIssuance(t, view, shareID, entry.LsfMPTCanTrade|entry.LsfMPTCanTransfer, &referenceHex)
+	putTestIssuance(t, view, underlyingID, 0, nil)
+	putTestHolding(t, view, underlyingID, vaultPseudo, 0)
+
+	require.Equal(t, ter.TecNO_PERMISSION, CanTrade(view, shareID))
+	require.Equal(t, ter.TecNO_AUTH, CanTransfer(view, shareID, from, to))
+	require.False(t, IsFrozen(view, shareID, to))
+
+	putTestIssuance(t, view, underlyingID,
+		entry.LsfMPTCanTrade|entry.LsfMPTCanTransfer|entry.LsfMPTLocked, nil)
+	require.Equal(t, ter.TesSUCCESS, CanTrade(view, shareID))
+	require.Equal(t, ter.TesSUCCESS, CanTransfer(view, shareID, from, to))
+	require.True(t, IsFrozen(view, shareID, to))
+
+	view.rules = amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault,
+		amendment.FeatureMPTokensV2,
+	})
+	putTestIssuance(t, view, underlyingID, 0, nil)
+	require.Equal(t, ter.TesSUCCESS, CanTrade(view, shareID))
+	require.Equal(t, ter.TesSUCCESS, CanTransfer(view, shareID, from, to))
+}
+
+func TestVaultShareReferenceInheritsIOUChecks(t *testing.T) {
+	view := newMPTTestView()
+	var vaultPseudo, issuer, from, to [20]byte
+	issuer[19] = 0x10
+	vaultPseudo[19] = 0x20
+	from[19] = 0x30
+	to[19] = 0x40
+	shareID := keylet.MakeMPTID(1, vaultPseudo)
+	issuerAddress := state.EncodeAccountIDSafe(issuer)
+	vaultAddress := state.EncodeAccountIDSafe(vaultPseudo)
+
+	lineKey := keylet.Line(vaultPseudo, issuer, "USD")
+	referenceHex := strings.ToUpper(hex.EncodeToString(lineKey.Key[:]))
+	putTestIssuance(t, view, shareID, entry.LsfMPTCanTrade|entry.LsfMPTCanTransfer, &referenceHex)
+	lineRaw, err := state.SerializeRippleState(&state.RippleState{
+		Balance:   state.NewIssuedAmountFromValue(0, state.MinExponent, "USD", issuerAddress),
+		LowLimit:  state.NewIssuedAmountFromValue(0, state.MinExponent, "USD", issuerAddress),
+		HighLimit: state.NewIssuedAmountFromValue(0, state.MinExponent, "USD", vaultAddress),
+	})
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(lineKey, lineRaw))
+	putTestAccount(t, view, issuer, state.LsfGlobalFreeze, [32]byte{})
+
+	require.Equal(t, ter.TesSUCCESS, CanTrade(view, shareID))
+	require.Equal(t, ter.TerNO_RIPPLE, CanTransfer(view, shareID, from, to))
+	require.True(t, IsFrozen(view, shareID, to))
+}
+
+func TestVaultShareAuthorizationInheritsUnderlyingMPT(t *testing.T) {
+	view := newMPTTestView()
+	var vaultPseudo, underlyingIssuer, holder, owner [20]byte
+	vaultPseudo[19] = 0x20
+	underlyingIssuer[19] = 0x10
+	holder[19] = 0x30
+	owner[19] = 0x40
+	shareID := keylet.MakeMPTID(1, vaultPseudo)
+	underlyingID := keylet.MakeMPTID(2, underlyingIssuer)
+	vaultID := [32]byte{1, 2, 3}
+
+	putTestAccount(t, view, vaultPseudo, 0, vaultID)
+	putTestAccount(t, view, underlyingIssuer, 0, [32]byte{})
+	putTestIssuance(t, view, shareID, 0, nil)
+	putTestIssuance(t, view, underlyingID, entry.LsfMPTRequireAuth, nil)
+	putTestVault(t, view, vaultID, owner, vaultPseudo, shareID, underlyingID)
+
+	require.Equal(t, ter.TecNO_AUTH, RequireAuthAt(view, shareID, holder, false, 10))
+	putTestHolding(t, view, underlyingID, holder, entry.LsfMPTAuthorized)
+	require.Equal(t, ter.TesSUCCESS, RequireAuthAt(view, shareID, holder, false, 10))
+}
+
+func TestRequireAuthAtRejectsExpiredDomainCredential(t *testing.T) {
+	view := newMPTTestView()
+	var issuer, holder, credentialIssuer [20]byte
+	issuer[19] = 0x10
+	holder[19] = 0x20
+	credentialIssuer[19] = 0x30
+	id := keylet.MakeMPTID(1, issuer)
+	domainID := [32]byte{4, 5, 6}
+	domainHex := strings.ToUpper(hex.EncodeToString(domainID[:]))
+	credentialType := []byte("KYC")
+
+	putTestAccount(t, view, issuer, 0, [32]byte{})
+	putTestIssuance(t, view, id, entry.LsfMPTRequireAuth, nil)
+	issuanceRaw := view.data[keylet.MPTIssuance(id).Key]
+	issuance, err := state.ParseMPTokenIssuance(issuanceRaw)
+	require.NoError(t, err)
+	issuance.DomainID = &domainHex
+	issuanceRaw, err = state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	view.data[keylet.MPTIssuance(id).Key] = issuanceRaw
+
+	domainRaw, err := state.SerializePermissionedDomain(&state.PermissionedDomainData{
+		Owner:    issuer,
+		Sequence: 1,
+		AcceptedCredentials: []state.PermissionedDomainCredential{{
+			Issuer: credentialIssuer, CredentialType: credentialType,
+		}},
+	}, state.EncodeAccountIDSafe(issuer))
+	require.NoError(t, err)
+	view.data[keylet.PermissionedDomainByID(domainID).Key] = domainRaw
+
+	credentialHex, err := binarycodec.Encode(map[string]any{
+		"LedgerEntryType": "Credential",
+		"Subject":         state.EncodeAccountIDSafe(holder),
+		"Issuer":          state.EncodeAccountIDSafe(credentialIssuer),
+		"CredentialType":  hex.EncodeToString(credentialType),
+		"Expiration":      uint32(100),
+		"Flags":           entry.LsfAccepted,
+		"IssuerNode":      "0",
+		"SubjectNode":     "0",
+	})
+	require.NoError(t, err)
+	credentialRaw, err := hex.DecodeString(credentialHex)
+	require.NoError(t, err)
+	view.data[keylet.Credential(holder, credentialIssuer, credentialType).Key] = credentialRaw
+
+	require.Equal(t, ter.TesSUCCESS, RequireAuthAt(view, id, holder, false, 99))
+	require.Equal(t, ter.TesSUCCESS, RequireAuthAt(view, id, holder, false, 100))
+	require.Equal(t, ter.TecEXPIRED, RequireAuthAt(view, id, holder, false, 101))
+}
+
+func TestTransferRateRoundingIsDirectional(t *testing.T) {
+	const rate = uint32(1_250_000_000)
+	value, ok := MultiplyRate(1, rate)
+	require.True(t, ok)
+	require.Equal(t, int64(2), value)
+	value, ok = DivideRate(1, rate)
+	require.True(t, ok)
+	require.Equal(t, int64(0), value)
+	value, ok = MultiplyRate(4, rate)
+	require.True(t, ok)
+	require.Equal(t, int64(5), value)
+	value, ok = DivideRate(5, rate)
+	require.True(t, ok)
+	require.Equal(t, int64(4), value)
+	value, ok = MultiplyRate(-1, rate)
+	require.True(t, ok)
+	require.Equal(t, int64(-1), value)
+	value, ok = DivideRate(-1, rate)
+	require.True(t, ok)
+	require.Equal(t, int64(-1), value)
+}
+
+func TestTransferRateScalingReportsOverflow(t *testing.T) {
+	const rate = uint32(1_250_000_000)
+
+	value, ok := MultiplyRate(math.MaxInt64, RateOne)
+	require.True(t, ok)
+	require.Equal(t, int64(math.MaxInt64), value)
+
+	value, ok = MultiplyRate(math.MaxInt64, rate)
+	require.False(t, ok)
+	require.Zero(t, value)
+
+	value, ok = DivideRate(math.MaxInt64, rate)
+	require.True(t, ok)
+	require.Equal(t, int64(7_378_697_629_483_820_645), value)
+}
+
+func TestSendTransferRateOverflowReturnsTefException(t *testing.T) {
+	view := newMPTTestView()
+	var issuer, sender, receiver [20]byte
+	issuer[19] = 1
+	sender[19] = 2
+	receiver[19] = 3
+	id := keylet.MakeMPTID(1, issuer)
+	maximum := uint64(math.MaxInt64)
+	raw, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+		Issuer:        issuer,
+		Sequence:      1,
+		TransferFee:   25_000,
+		MaximumAmount: &maximum,
+	})
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.MPTIssuance(id), raw))
+
+	gross, result := Send(view, id, sender, receiver, math.MaxInt64, false, false)
+	require.Equal(t, ter.TefEXCEPTION, result)
+	require.Zero(t, gross)
+}
+
+func putTestAccount(t *testing.T, view *mptTestView, account [20]byte, flags uint32, vaultID [32]byte) {
+	t.Helper()
+	raw, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account:  state.EncodeAccountIDSafe(account),
+		Balance:  1_000_000_000,
+		Sequence: 1,
+		Flags:    flags,
+		VaultID:  vaultID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.Account(account), raw))
+}
+
+func putTestIssuance(t *testing.T, view *mptTestView, id [24]byte, flags uint32, reference *string) {
+	t.Helper()
+	raw, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+		Issuer:           Issuer(id),
+		Sequence:         1,
+		Flags:            flags,
+		ReferenceHolding: reference,
+	})
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.MPTIssuance(id), raw))
+}
+
+func putTestHolding(t *testing.T, view *mptTestView, id [24]byte, account [20]byte, flags uint32) {
+	t.Helper()
+	raw, err := state.SerializeMPToken(&state.MPTokenData{
+		Account:           account,
+		MPTokenIssuanceID: id,
+		Flags:             flags,
+	})
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.MPTokenByID(id, account), raw))
+}
+
+func putTestVault(t *testing.T, view *mptTestView, vaultID [32]byte, owner, pseudo [20]byte, shareID, assetID [24]byte) {
+	t.Helper()
+	hexRaw, err := binarycodec.Encode(map[string]any{
+		"LedgerEntryType":  "Vault",
+		"Flags":            uint32(0),
+		"Sequence":         uint32(1),
+		"OwnerNode":        "0",
+		"Owner":            state.EncodeAccountIDSafe(owner),
+		"Account":          state.EncodeAccountIDSafe(pseudo),
+		"Asset":            map[string]any{"mpt_issuance_id": EncodeID(assetID)},
+		"ShareMPTID":       EncodeID(shareID),
+		"WithdrawalPolicy": uint8(0),
+	})
+	require.NoError(t, err)
+	raw, err := hex.DecodeString(hexRaw)
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.VaultByID(vaultID), raw))
+}

--- a/internal/tx/mptutil/mpt_test.go
+++ b/internal/tx/mptutil/mpt_test.go
@@ -2,6 +2,7 @@ package mptutil
 
 import (
 	"encoding/hex"
+	"errors"
 	"math"
 	"strings"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
@@ -16,17 +18,31 @@ import (
 )
 
 type mptTestView struct {
-	data        map[[32]byte][]byte
-	adjustments [][3]uint32
-	rules       *amendment.Rules
+	data         map[[32]byte][]byte
+	readErrors   map[[32]byte]error
+	existsErrors map[[32]byte]error
+	adjustments  [][3]uint32
+	rules        *amendment.Rules
 }
 
 func newMPTTestView() *mptTestView {
-	return &mptTestView{data: make(map[[32]byte][]byte)}
+	return &mptTestView{
+		data:         make(map[[32]byte][]byte),
+		readErrors:   make(map[[32]byte]error),
+		existsErrors: make(map[[32]byte]error),
+	}
 }
 
-func (v *mptTestView) Read(k keylet.Keylet) ([]byte, error) { return v.data[k.Key], nil }
+func (v *mptTestView) Read(k keylet.Keylet) ([]byte, error) {
+	if err := v.readErrors[k.Key]; err != nil {
+		return nil, err
+	}
+	return v.data[k.Key], nil
+}
 func (v *mptTestView) Exists(k keylet.Keylet) (bool, error) {
+	if err := v.existsErrors[k.Key]; err != nil {
+		return false, err
+	}
 	_, exists := v.data[k.Key]
 	return exists, nil
 }
@@ -50,6 +66,135 @@ func (v *mptTestView) Rules() *amendment.Rules {
 }
 func (v *mptTestView) AdjustOwnerCount(_ [20]byte, current, next uint32) {
 	v.adjustments = append(v.adjustments, [3]uint32{current, next})
+}
+
+func TestMPTReadsPropagateStorageErrors(t *testing.T) {
+	view := newMPTTestView()
+	var id [24]byte
+	id[23] = 1
+	var holder [20]byte
+	holder[19] = 2
+	readErr := errors.New("storage read failed")
+
+	view.readErrors[keylet.MPTIssuance(id).Key] = readErr
+	_, _, result := ReadIssuance(view, id)
+	require.Equal(t, ter.TefINTERNAL, result)
+
+	delete(view.readErrors, keylet.MPTIssuance(id).Key)
+	view.readErrors[keylet.MPTokenByID(id, holder).Key] = readErr
+	_, _, result = ReadHolding(view, id, holder)
+	require.Equal(t, ter.TefINTERNAL, result)
+}
+
+func TestMPTAuthorizationPropagatesAccountReadError(t *testing.T) {
+	view := newMPTTestView()
+	var issuer, holder [20]byte
+	issuer[19] = 1
+	holder[19] = 2
+	id := keylet.MakeMPTID(1, issuer)
+	putTestAccount(t, view, issuer, 0, [32]byte{})
+	putTestIssuance(t, view, id, entry.LsfMPTRequireAuth, nil)
+	view.readErrors[keylet.Account(holder).Key] = errors.New("storage read failed")
+
+	require.Equal(t, ter.TefINTERNAL, RequireAuth(view, id, holder, false))
+}
+
+func TestPseudoAccountImplicitAuthorizationRequiresAmendment(t *testing.T) {
+	view := newMPTTestView()
+	var issuer, pseudo [20]byte
+	issuer[19] = 1
+	pseudo[19] = 2
+	id := keylet.MakeMPTID(1, issuer)
+	putTestIssuance(t, view, id, entry.LsfMPTRequireAuth, nil)
+	putTestAccount(t, view, issuer, 0, [32]byte{})
+	putTestAccount(t, view, pseudo, 0, [32]byte{1})
+
+	view.rules = amendment.NewRules(nil)
+	require.Equal(t, ter.TecNO_AUTH, RequireAuth(view, id, pseudo, false))
+
+	view.rules = amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+	require.Equal(t, ter.TesSUCCESS, RequireAuth(view, id, pseudo, false))
+
+	view.rules = amendment.NewRules([][32]byte{amendment.FeatureMPTokensV2})
+	require.Equal(t, ter.TesSUCCESS, RequireAuth(view, id, pseudo, false))
+}
+
+func TestIOUTransferCheckPropagatesTrustLineReadError(t *testing.T) {
+	view := newMPTTestView()
+	var issuer, from, to [20]byte
+	issuer[19] = 1
+	from[19] = 2
+	to[19] = 3
+	putTestAccount(t, view, issuer, 0, [32]byte{})
+	view.readErrors[keylet.Line(from, issuer, "USD").Key] = errors.New("storage read failed")
+	asset := tx.Asset{Currency: "USD", Issuer: state.EncodeAccountIDSafe(issuer)}
+
+	require.Equal(t, ter.TefINTERNAL, canTransferAsset(view, asset, from, to, 0))
+}
+
+func TestMPTAuthorizationPropagatesMalformedTrustLine(t *testing.T) {
+	view := newMPTTestView()
+	var issuer, holder [20]byte
+	issuer[19] = 1
+	holder[19] = 2
+	putTestAccount(t, view, issuer, state.LsfRequireAuth, [32]byte{})
+	view.data[keylet.Line(holder, issuer, "USD").Key] = []byte{1}
+	asset := tx.Asset{Currency: "USD", Issuer: state.EncodeAccountIDSafe(issuer)}
+
+	require.Equal(t, ter.TefINTERNAL, requireAssetAuthAt(view, asset, holder, true, 0, 0))
+}
+
+func TestDomainAuthorizationPropagatesLedgerErrors(t *testing.T) {
+	view := newMPTTestView()
+	var owner, holder, credentialIssuer [20]byte
+	owner[19] = 1
+	holder[19] = 2
+	credentialIssuer[19] = 3
+	domainID := [32]byte{1}
+	domainHex := strings.ToUpper(hex.EncodeToString(domainID[:]))
+	credentialType := []byte("KYC")
+	domainRaw, err := state.SerializePermissionedDomain(&state.PermissionedDomainData{
+		Owner:    owner,
+		Sequence: 1,
+		AcceptedCredentials: []state.PermissionedDomainCredential{{
+			Issuer: credentialIssuer, CredentialType: credentialType,
+		}},
+	}, state.EncodeAccountIDSafe(owner))
+	require.NoError(t, err)
+	view.data[keylet.PermissionedDomainByID(domainID).Key] = domainRaw
+
+	domainKey := keylet.PermissionedDomainByID(domainID)
+	view.readErrors[domainKey.Key] = errors.New("domain read failed")
+	require.Equal(t, ter.TefINTERNAL, validDomain(view, domainHex, holder, 0))
+	delete(view.readErrors, domainKey.Key)
+
+	credentialKey := keylet.Credential(holder, credentialIssuer, credentialType)
+	view.readErrors[credentialKey.Key] = errors.New("credential read failed")
+	require.Equal(t, ter.TefINTERNAL, validDomain(view, domainHex, holder, 0))
+	delete(view.readErrors, credentialKey.Key)
+	view.data[credentialKey.Key] = []byte{1}
+	require.Equal(t, ter.TefINTERNAL, validDomain(view, domainHex, holder, 0))
+}
+
+func TestMPTHoldingMutationsPropagateStorageErrors(t *testing.T) {
+	view := newMPTTestView()
+	var issuer, holder [20]byte
+	issuer[19] = 1
+	holder[19] = 2
+	id := keylet.MakeMPTID(1, issuer)
+	tokenKey := keylet.MPTokenByID(id, holder)
+	storageErr := errors.New("storage failure")
+
+	view.existsErrors[tokenKey.Key] = storageErr
+	require.Equal(t, ter.TefINTERNAL, EnsureHolding(view, id, holder, 0, true))
+	delete(view.existsErrors, tokenKey.Key)
+
+	view.readErrors[keylet.Account(holder).Key] = storageErr
+	require.Equal(t, ter.TefINTERNAL, EnsureHolding(view, id, holder, 0, true))
+	delete(view.readErrors, keylet.Account(holder).Key)
+
+	view.readErrors[tokenKey.Key] = storageErr
+	require.Equal(t, ter.TefINTERNAL, RemoveHolding(view, id, holder, true))
 }
 
 func TestEnsureAndRemoveHolding(t *testing.T) {

--- a/internal/tx/offer/offer_amount.go
+++ b/internal/tx/offer/offer_amount.go
@@ -1,7 +1,9 @@
 package offer
 
 import (
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 )
 
 // maxNativeDrops is rippled STAmount::cMaxNativeN — the isLegalNet ceiling on a
@@ -37,6 +39,9 @@ func zeroAmount(amt tx.Amount) tx.Amount {
 	if amt.IsNative() {
 		return tx.NewXRPAmount(0)
 	}
+	if amt.IsMPT() {
+		return newMPTAmountLike(amt, 0)
+	}
 	return tx.NewIssuedAmount(0, -100, amt.Currency, amt.Issuer)
 }
 
@@ -45,20 +50,24 @@ func zeroAmount(amt tx.Amount) tx.Amount {
 func subtractAmounts(a, b tx.Amount) tx.Amount {
 	result, err := a.Sub(b)
 	if err != nil {
-		// Type mismatch - return zero amount of a's type
-		if a.IsNative() {
-			return tx.NewXRPAmount(0)
-		}
-		return tx.NewIssuedAmount(0, -100, a.Currency, a.Issuer)
+		return zeroAmount(a)
 	}
 
-	// Clamp negative results to zero
 	if result.IsNegative() {
-		if result.IsNative() {
-			return tx.NewXRPAmount(0)
-		}
-		return tx.NewIssuedAmount(0, -100, a.Currency, a.Issuer)
+		return zeroAmount(a)
 	}
 
 	return result
+}
+
+func newMPTAmountLike(amount tx.Amount, value int64) tx.Amount {
+	id, err := mptutil.DecodeID(amount.MPTIssuanceID())
+	if err != nil {
+		return tx.Amount{}
+	}
+	return state.NewMPTAmountWithIssuanceID(
+		value,
+		state.EncodeAccountIDSafe(mptutil.Issuer(id)),
+		mptutil.EncodeID(id),
+	)
 }

--- a/internal/tx/offer/offer_create_apply.go
+++ b/internal/tx/offer/offer_create_apply.go
@@ -257,19 +257,14 @@ func applyHybridInSandbox(view tx.LedgerView, offer *state.LedgerOffer, offerKey
 	offer.Flags |= lsfHybrid
 
 	// Also place in open book (without domain)
-	takerPaysCurrency := keylet.CurrencyBytes(takerPays.Currency)
-	takerPaysIssuer := state.GetIssuerBytes(takerPays.Issuer)
-	takerGetsCurrency := keylet.CurrencyBytes(takerGets.Currency)
-	takerGetsIssuer := state.GetIssuerBytes(takerGets.Issuer)
-
-	bookBase := keylet.BookDir(takerPaysCurrency, takerPaysIssuer, takerGetsCurrency, takerGetsIssuer)
+	bookBase, err := offerBookBase(takerPays, takerGets, nil)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
 	openBookDirKey := keylet.Quality(bookBase, openRate)
 
 	bookDirResult, err := state.DirInsert(view, openBookDirKey, offerKey.Key, true, func(dir *state.DirectoryNode) {
-		dir.TakerPaysCurrency = takerPaysCurrency
-		dir.TakerPaysIssuer = takerPaysIssuer
-		dir.TakerGetsCurrency = takerGetsCurrency
-		dir.TakerGetsIssuer = takerGetsIssuer
+		_ = setBookDirectoryAssets(dir, takerPays, takerGets)
 		dir.ExchangeRate = openRate
 		// No DomainID for open book
 	})

--- a/internal/tx/offer/offer_create_cross.go
+++ b/internal/tx/offer/offer_create_cross.go
@@ -120,7 +120,11 @@ func (o *OfferCreate) takerCross(
 	// saTakerGets) at the top of flowCross. Reference: rippled CreateOffer.cpp
 	// flowCross lines 329-335.
 	disallowUnfunded := offerDisallowUnfunded(saTakerGets, ctx.AccountID)
-	if disallowUnfunded && isAmountZeroOrNegative(payment.AccountFundsInSandbox(sb, ctx.AccountID, saTakerGets, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)) {
+	startingFunds, fundsResult := payment.AccountFundsInSandbox(sb, ctx.AccountID, saTakerGets, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
+	if fundsResult != ter.TesSUCCESS {
+		return crossOutcome{terminated: true, result: fundsResult, applyMain: false}
+	}
+	if disallowUnfunded && isAmountZeroOrNegative(startingFunds) {
 		return crossOutcome{terminated: true, result: ter.TecUNFUNDED_OFFER, applyMain: false}
 	}
 
@@ -243,9 +247,12 @@ func (o *OfferCreate) takerCross(
 	// on-ledger balance is non-zero.
 	var takerInBalance tx.Amount
 	if crossResult.Sandbox != nil {
-		takerInBalance = payment.AccountFundsInSandbox(crossResult.Sandbox, ctx.AccountID, saTakerGets, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
+		takerInBalance, fundsResult = payment.AccountFundsInSandbox(crossResult.Sandbox, ctx.AccountID, saTakerGets, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
 	} else {
-		takerInBalance = payment.AccountFundsInSandbox(sb, ctx.AccountID, saTakerGets, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
+		takerInBalance, fundsResult = payment.AccountFundsInSandbox(sb, ctx.AccountID, saTakerGets, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
+	}
+	if fundsResult != ter.TesSUCCESS {
+		return crossOutcome{terminated: true, result: fundsResult, applyMain: false}
 	}
 
 	// Apply FlowCross sandbox changes (crossing plus the removable-offer

--- a/internal/tx/offer/offer_create_cross.go
+++ b/internal/tx/offer/offer_create_cross.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -118,7 +119,8 @@ func (o *OfferCreate) takerCross(
 	// sandbox. rippled runs the same check (on the already tick-rounded
 	// saTakerGets) at the top of flowCross. Reference: rippled CreateOffer.cpp
 	// flowCross lines 329-335.
-	if isAmountZeroOrNegative(tx.AccountFunds(sb, ctx.AccountID, saTakerGets, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)) {
+	disallowUnfunded := offerDisallowUnfunded(saTakerGets, ctx.AccountID)
+	if disallowUnfunded && isAmountZeroOrNegative(payment.AccountFundsInSandbox(sb, ctx.AccountID, saTakerGets, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)) {
 		return crossOutcome{terminated: true, result: ter.TecUNFUNDED_OFFER, applyMain: false}
 	}
 
@@ -243,7 +245,7 @@ func (o *OfferCreate) takerCross(
 	if crossResult.Sandbox != nil {
 		takerInBalance = payment.AccountFundsInSandbox(crossResult.Sandbox, ctx.AccountID, saTakerGets, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
 	} else {
-		takerInBalance = tx.AccountFunds(sb, ctx.AccountID, saTakerGets, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
+		takerInBalance = payment.AccountFundsInSandbox(sb, ctx.AccountID, saTakerGets, true, ctx.Config.ReserveBase, ctx.Config.ReserveIncrement)
 	}
 
 	// Apply FlowCross sandbox changes (crossing plus the removable-offer
@@ -263,7 +265,7 @@ func (o *OfferCreate) takerCross(
 	// view AFTER applying the sandbox (see ApplyCreate lines 421-424).
 	// Manually adjusting here would DOUBLE-COUNT the XRP changes.
 
-	if isAmountZeroOrNegative(takerInBalance) {
+	if disallowUnfunded && isAmountZeroOrNegative(takerInBalance) {
 		// Apply main sandbox with crossing results
 		return crossOutcome{terminated: true, result: ter.TesSUCCESS, applyMain: true}
 	}
@@ -277,7 +279,7 @@ func (o *OfferCreate) takerCross(
 	}
 
 	remainingGets, remainingPays := computePostCrossAmounts(
-		saTakerPays, saTakerGets, placeOffer.in, placeOffer.out, takerInBalance, bSell,
+		saTakerPays, saTakerGets, placeOffer.in, placeOffer.out, takerInBalance, bSell, disallowUnfunded,
 	)
 
 	if outcome, done := evaluatePostCrossTermination(rules, saTakerGets, grossPaid, remainingGets, remainingPays, bFillOrKill); done {
@@ -344,11 +346,11 @@ func computePostCrossAmounts(
 	saTakerPays, saTakerGets tx.Amount,
 	placeIn, placeOut tx.Amount,
 	takerInBalance tx.Amount,
-	bSell bool,
+	bSell, disallowUnfunded bool,
 ) (remainingGets, remainingPays tx.Amount) {
 	noCrossingHappened := isAmountZeroOrNegative(placeIn) && isAmountZeroOrNegative(placeOut)
 
-	if isAmountZeroOrNegative(takerInBalance) {
+	if disallowUnfunded && isAmountZeroOrNegative(takerInBalance) {
 		// Funds exhausted during crossing — no remaining offer
 		// Reference: rippled CreateOffer.cpp lines 435-441
 		return zeroAmount(saTakerGets), zeroAmount(saTakerPays)
@@ -372,10 +374,7 @@ func computePostCrossAmounts(
 			payment.ToEitherAmount(saTakerGets),
 			payment.ToEitherAmount(saTakerPays),
 		).Rate()
-		outNative := saTakerPays.IsNative()
-		outCurrency := saTakerPays.Currency
-		outIssuer := saTakerPays.Issuer
-		remainingPays = offerDivRoundStrict(remainingGets, rate, outNative, outCurrency, outIssuer, false)
+		remainingPays = offerDivRoundStrictLike(remainingGets, rate, saTakerPays, false)
 		return remainingGets, remainingPays
 	}
 	// Non-sell offer: subtract output received from TakerPays, compute TakerGets by quality
@@ -390,11 +389,16 @@ func computePostCrossAmounts(
 		payment.ToEitherAmount(saTakerGets),
 		payment.ToEitherAmount(saTakerPays),
 	).Rate()
-	outNative := saTakerGets.IsNative()
-	outCurrency := saTakerGets.Currency
-	outIssuer := saTakerGets.Issuer
-	remainingGets = offerMulRound(remainingPays, rate, outNative, outCurrency, outIssuer, true)
+	remainingGets = offerMulRoundLike(remainingPays, rate, saTakerGets, true)
 	return remainingGets, remainingPays
+}
+
+func offerDisallowUnfunded(amount tx.Amount, account [20]byte) bool {
+	if !amount.IsMPT() {
+		return true
+	}
+	id, err := mptutil.DecodeID(amount.MPTIssuanceID())
+	return err != nil || account != mptutil.Issuer(id)
 }
 
 // removeRemovableOffers deletes the offers FlowCross groomed away. The full set

--- a/internal/tx/offer/offer_create_place.go
+++ b/internal/tx/offer/offer_create_place.go
@@ -1,9 +1,12 @@
 package offer
 
 import (
+	"errors"
+
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -27,21 +30,9 @@ func (o *OfferCreate) placeRemainingOffer(
 	offerSequence := o.GetCommon().SeqProxy()
 	offerKey := keylet.Offer(ctx.AccountID, offerSequence)
 
-	// Calculate book directory fields first (needed for both owner and book directories
-	// when SortedDirectories is not enabled)
-	// Reference: lines 857-887
-	takerPaysCurrency := keylet.CurrencyBytes(saTakerPays.Currency)
-	takerPaysIssuer := state.GetIssuerBytes(saTakerPays.Issuer)
-	takerGetsCurrency := keylet.CurrencyBytes(saTakerGets.Currency)
-	takerGetsIssuer := state.GetIssuerBytes(saTakerGets.Issuer)
-
-	// Domain offers go in a separate domain-keyed book directory.
-	// Reference: rippled Indexes.cpp getBookBase() includes domain in hash when set
-	var bookBase keylet.Keylet
-	if o.DomainID != nil {
-		bookBase = keylet.BookDirWithDomain(takerPaysCurrency, takerPaysIssuer, takerGetsCurrency, takerGetsIssuer, *o.DomainID)
-	} else {
-		bookBase = keylet.BookDir(takerPaysCurrency, takerPaysIssuer, takerGetsCurrency, takerGetsIssuer)
+	bookBase, err := offerBookBase(saTakerPays, saTakerGets, o.DomainID)
+	if err != nil {
+		return ter.TefINTERNAL, false
 	}
 	bookDirKey := keylet.Quality(bookBase, uRate)
 
@@ -59,12 +50,11 @@ func (o *OfferCreate) placeRemainingOffer(
 
 	// Reference: lines 884-893
 	bookDirResult, err := state.DirInsert(sb, bookDirKey, offerKey.Key, true, func(dir *state.DirectoryNode) {
-		dir.TakerPaysCurrency = takerPaysCurrency
-		dir.TakerPaysIssuer = takerPaysIssuer
-		dir.TakerGetsCurrency = takerGetsCurrency
-		dir.TakerGetsIssuer = takerGetsIssuer
+		_ = setBookDirectoryAssets(dir, saTakerPays, saTakerGets)
 		dir.ExchangeRate = uRate
-		// Note: DomainID is stored on the offer itself, not the directory
+		if o.DomainID != nil {
+			dir.DomainID = *o.DomainID
+		}
 	})
 	if err != nil {
 		return ter.TefINTERNAL, false
@@ -127,4 +117,59 @@ func (o *OfferCreate) placeRemainingOffer(
 	}
 
 	return ter.TesSUCCESS, true // Apply main sandbox
+}
+
+func offerBookBase(takerPays, takerGets tx.Amount, domainID *[32]byte) (keylet.Keylet, error) {
+	pays, err := amountBookSide(takerPays)
+	if err != nil {
+		return keylet.Keylet{}, err
+	}
+	gets, err := amountBookSide(takerGets)
+	if err != nil {
+		return keylet.Keylet{}, err
+	}
+	return keylet.BookBase(pays, gets, domainID), nil
+}
+
+func amountBookSide(amount tx.Amount) (keylet.BookSide, error) {
+	if amount.IsMPT() {
+		id, err := mptutil.DecodeID(amount.MPTIssuanceID())
+		if err != nil {
+			return keylet.BookSide{}, err
+		}
+		return keylet.MPTSide(id), nil
+	}
+	if !amount.IsNative() && amount.Currency == "" {
+		return keylet.BookSide{}, errors.New("issued amount has no currency")
+	}
+	return keylet.IssueSide(
+		keylet.CurrencyBytes(amount.Currency),
+		state.GetIssuerBytes(amount.Issuer),
+	), nil
+}
+
+func setBookDirectoryAssets(dir *state.DirectoryNode, takerPays, takerGets tx.Amount) error {
+	pays, err := amountBookSide(takerPays)
+	if err != nil {
+		return err
+	}
+	gets, err := amountBookSide(takerGets)
+	if err != nil {
+		return err
+	}
+	if pays.IsMPT {
+		id := pays.MPTID
+		dir.TakerPaysMPT = &id
+	} else {
+		dir.TakerPaysCurrency = pays.Currency
+		dir.TakerPaysIssuer = pays.Issuer
+	}
+	if gets.IsMPT {
+		id := gets.MPTID
+		dir.TakerGetsMPT = &id
+	} else {
+		dir.TakerGetsCurrency = gets.Currency
+		dir.TakerGetsIssuer = gets.Issuer
+	}
+	return nil
 }

--- a/internal/tx/offer/offer_create_validate.go
+++ b/internal/tx/offer/offer_create_validate.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/permissioneddomain"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -49,10 +50,10 @@ func (o *OfferCreate) Validate() error {
 	saTakerGets := o.TakerGets
 
 	// Check required amounts are present (unset Amount has no type info)
-	if !saTakerPays.IsNative() && saTakerPays.Currency == "" {
+	if !saTakerPays.IsNative() && !saTakerPays.IsMPT() && saTakerPays.Currency == "" {
 		return ter.Errorf(ter.TemBAD_OFFER, "TakerPays is required")
 	}
-	if !saTakerGets.IsNative() && saTakerGets.Currency == "" {
+	if !saTakerGets.IsNative() && !saTakerGets.IsMPT() && saTakerGets.Currency == "" {
 		return ter.Errorf(ter.TemBAD_OFFER, "TakerGets is required")
 	}
 
@@ -73,35 +74,51 @@ func (o *OfferCreate) Validate() error {
 		return ter.Errorf(ter.TemBAD_OFFER, "amounts must be positive")
 	}
 
-	uPaysCurrency := saTakerPays.Currency
-	uPaysIssuerID := saTakerPays.Issuer
-	uGetsCurrency := saTakerGets.Currency
-	uGetsIssuerID := saTakerGets.Issuer
-
 	// Check for redundant offer (same currency and issuer)
 	// Reference: lines 120-124
-	if uPaysCurrency == uGetsCurrency && uPaysIssuerID == uGetsIssuerID {
+	if sameOfferAsset(saTakerPays, saTakerGets) {
 		return ter.Errorf(ter.TemREDUNDANT, "cannot create offer with same currency and issuer on both sides")
+	}
+	if badOfferMPTAsset(saTakerPays) || badOfferMPTAsset(saTakerGets) {
+		return ter.Errorf(ter.TemBAD_CURRENCY, "MPT issuance ID has a zero issuer")
 	}
 
 	// Check for bad currency (XRP as non-native currency code)
 	// Reference: lines 126-130
-	if !saTakerPays.IsNative() && uPaysCurrency == badCurrency() {
+	if !saTakerPays.IsNative() && !saTakerPays.IsMPT() && saTakerPays.Currency == badCurrency() {
 		return ter.Errorf(ter.TemBAD_CURRENCY, "cannot use XRP as non-native currency code")
 	}
-	if !saTakerGets.IsNative() && uGetsCurrency == badCurrency() {
+	if !saTakerGets.IsNative() && !saTakerGets.IsMPT() && saTakerGets.Currency == badCurrency() {
 		return ter.Errorf(ter.TemBAD_CURRENCY, "cannot use XRP as non-native currency code")
 	}
 
 	// Reference: lines 132-137
-	if saTakerPays.IsNative() != (uPaysIssuerID == "") {
+	if !saTakerPays.IsMPT() && saTakerPays.IsNative() != (saTakerPays.Issuer == "") {
 		return ter.Errorf(ter.TemBAD_ISSUER, "issuer mismatch for TakerPays")
 	}
-	if saTakerGets.IsNative() != (uGetsIssuerID == "") {
+	if !saTakerGets.IsMPT() && saTakerGets.IsNative() != (saTakerGets.Issuer == "") {
 		return ter.Errorf(ter.TemBAD_ISSUER, "issuer mismatch for TakerGets")
 	}
 
 	return nil
+}
+
+func sameOfferAsset(a, b tx.Amount) bool {
+	if a.IsMPT() || b.IsMPT() {
+		return a.IsMPT() && b.IsMPT() && a.MPTIssuanceID() == b.MPTIssuanceID()
+	}
+	if a.IsNative() || b.IsNative() {
+		return a.IsNative() && b.IsNative()
+	}
+	return a.Currency == b.Currency && a.Issuer == b.Issuer
+}
+
+func badOfferMPTAsset(amount tx.Amount) bool {
+	if !amount.IsMPT() {
+		return false
+	}
+	id, err := mptutil.DecodeID(amount.MPTIssuanceID())
+	return err != nil || mptutil.Issuer(id) == ([20]byte{})
 }
 
 // badCurrency returns the "bad" currency code - using XRP as a non-native currency code
@@ -170,12 +187,28 @@ func (o *OfferCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.R
 	uGetsIssuerID := saTakerGets.Issuer
 
 	// Reference: lines 165-170
-	if uPaysIssuerID != "" {
+	if saTakerPays.IsMPT() {
+		id, decodeErr := mptutil.DecodeID(saTakerPays.MPTIssuanceID())
+		if decodeErr != nil {
+			return ter.TefINTERNAL
+		}
+		if mptutil.IsGlobalFrozen(view, id) {
+			return ter.TecLOCKED
+		}
+	} else if uPaysIssuerID != "" {
 		if tx.IsGlobalFrozen(view, uPaysIssuerID) {
 			return ter.TecFROZEN
 		}
 	}
-	if uGetsIssuerID != "" {
+	if saTakerGets.IsMPT() {
+		id, decodeErr := mptutil.DecodeID(saTakerGets.MPTIssuanceID())
+		if decodeErr != nil {
+			return ter.TefINTERNAL
+		}
+		if mptutil.IsGlobalFrozen(view, id) {
+			return ter.TecLOCKED
+		}
+	} else if uGetsIssuerID != "" {
 		if tx.IsGlobalFrozen(view, uGetsIssuerID) {
 			return ter.TecFROZEN
 		}
@@ -185,9 +218,22 @@ func (o *OfferCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.R
 	// Reference: rippled CreateOffer.cpp preclaim() lines 172-178
 	// rippled checks accountFunds <= 0, NOT funds < takerGets.
 	// Partially-funded offers are allowed; only completely unfunded offers are rejected.
-	funds := tx.AccountFunds(view, accountID, saTakerGets, true, config.ReserveBase, config.ReserveIncrement)
-	if funds.Signum() <= 0 {
-		return ter.TecUNFUNDED_OFFER
+	if saTakerGets.IsMPT() {
+		id, decodeErr := mptutil.DecodeID(saTakerGets.MPTIssuanceID())
+		if decodeErr != nil {
+			return ter.TefINTERNAL
+		}
+		if accountID != mptutil.Issuer(id) {
+			funds, _ := mptutil.Funds(view, id, accountID, true)
+			if funds <= 0 {
+				return ter.TecUNFUNDED_OFFER
+			}
+		}
+	} else {
+		funds := tx.AccountFunds(view, accountID, saTakerGets, true, config.ReserveBase, config.ReserveIncrement)
+		if funds.Signum() <= 0 {
+			return ter.TecUNFUNDED_OFFER
+		}
 	}
 
 	// Check cancel sequence is valid. rippled compares the *pre-transaction*
@@ -208,11 +254,16 @@ func (o *OfferCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.R
 	// Check we can accept what the taker will pay us (for non-native)
 	// Reference: lines 203-213
 	if !saTakerPays.IsNative() {
-		paysIssuerID, err := state.DecodeAccountID(uPaysIssuerID)
-		if err != nil {
-			return ter.TecNO_ISSUER
+		var result ter.Result
+		if saTakerPays.IsMPT() {
+			result = checkAcceptMPT(view, accountID, saTakerPays, config.ParentCloseTime)
+		} else {
+			paysIssuerID, err := state.DecodeAccountID(uPaysIssuerID)
+			if err != nil {
+				return ter.TecNO_ISSUER
+			}
+			result = checkAcceptAsset(view, accountID, paysIssuerID, saTakerPays.Currency)
 		}
-		result := checkAcceptAsset(view, accountID, paysIssuerID, saTakerPays.Currency)
 		if result != ter.TesSUCCESS {
 			return result
 		}
@@ -226,6 +277,40 @@ func (o *OfferCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.R
 		}
 	}
 
+	for _, amount := range []tx.Amount{saTakerPays, saTakerGets} {
+		if amount.IsMPT() {
+			id, decodeErr := mptutil.DecodeID(amount.MPTIssuanceID())
+			if decodeErr != nil {
+				return ter.TefINTERNAL
+			}
+			if result := mptutil.CanTrade(view, id); result != ter.TesSUCCESS {
+				return result
+			}
+		}
+	}
+
+	return ter.TesSUCCESS
+}
+
+func checkAcceptMPT(view tx.LedgerView, accountID [20]byte, amount tx.Amount, parentCloseTime uint32) ter.Result {
+	id, err := mptutil.DecodeID(amount.MPTIssuanceID())
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	issuer := mptutil.Issuer(id)
+	issuerAccount, readErr := tx.ReadAccountRoot(view, issuer)
+	if readErr != nil || issuerAccount == nil {
+		return ter.TecNO_ISSUER
+	}
+	if accountID == issuer {
+		return ter.TesSUCCESS
+	}
+	if result := mptutil.RequireAuthAt(view, id, accountID, false, parentCloseTime); result != ter.TesSUCCESS {
+		return result
+	}
+	if mptutil.IsFrozen(view, id, accountID) {
+		return ter.TecLOCKED
+	}
 	return ter.TesSUCCESS
 }
 

--- a/internal/tx/offer/offer_create_validate.go
+++ b/internal/tx/offer/offer_create_validate.go
@@ -224,7 +224,10 @@ func (o *OfferCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.R
 			return ter.TefINTERNAL
 		}
 		if accountID != mptutil.Issuer(id) {
-			funds, _ := mptutil.Funds(view, id, accountID, true)
+			funds, result := mptutil.Funds(view, id, accountID, true)
+			if result == ter.TefINTERNAL {
+				return result
+			}
 			if funds <= 0 {
 				return ter.TecUNFUNDED_OFFER
 			}

--- a/internal/tx/offer/offer_mpt_test.go
+++ b/internal/tx/offer/offer_mpt_test.go
@@ -274,6 +274,17 @@ func TestOfferMPTPreclaimPermissionsAndFunding(t *testing.T) {
 		require.Equal(t, ter.TesSUCCESS, offer.Preclaim(view, config))
 	})
 
+	t.Run("corrupt holding is internal error", func(t *testing.T) {
+		view := newOfferMPTLedgerView()
+		putOfferMPTAccount(t, view, issuer)
+		putOfferMPTAccount(t, view, holder)
+		putOfferMPTIssuance(t, view, id, entry.LsfMPTCanTrade|entry.LsfMPTCanTransfer, 100, 1_000)
+		view.data[keylet.MPTokenByID(id, holder).Key] = []byte{1}
+
+		offer := newOffer(holder, tx.NewXRPAmount(1_000), offerMPTAmount(id, 10))
+		require.Equal(t, ter.TefINTERNAL, offer.Preclaim(view, config))
+	})
+
 	t.Run("trading disabled", func(t *testing.T) {
 		view := newOfferMPTLedgerView()
 		putOfferMPTAccount(t, view, issuer)

--- a/internal/tx/offer/offer_mpt_test.go
+++ b/internal/tx/offer/offer_mpt_test.go
@@ -1,0 +1,322 @@
+package offer
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	"github.com/stretchr/testify/require"
+)
+
+type offerMPTLedgerView struct {
+	data  map[[32]byte][]byte
+	rules *amendment.Rules
+}
+
+func newOfferMPTLedgerView() *offerMPTLedgerView {
+	return &offerMPTLedgerView{
+		data:  make(map[[32]byte][]byte),
+		rules: amendment.AllSupportedRules(),
+	}
+}
+
+func (v *offerMPTLedgerView) Read(k keylet.Keylet) ([]byte, error) {
+	return v.data[k.Key], nil
+}
+
+func (v *offerMPTLedgerView) Exists(k keylet.Keylet) (bool, error) {
+	_, ok := v.data[k.Key]
+	return ok, nil
+}
+
+func (v *offerMPTLedgerView) Insert(k keylet.Keylet, data []byte) error {
+	v.data[k.Key] = data
+	return nil
+}
+
+func (v *offerMPTLedgerView) Update(k keylet.Keylet, data []byte) error {
+	v.data[k.Key] = data
+	return nil
+}
+
+func (v *offerMPTLedgerView) Erase(k keylet.Keylet) error {
+	delete(v.data, k.Key)
+	return nil
+}
+
+func (*offerMPTLedgerView) AdjustDropsDestroyed(drops.XRPAmount) {}
+func (*offerMPTLedgerView) TxExists([32]byte) bool               { return false }
+func (v *offerMPTLedgerView) Rules() *amendment.Rules            { return v.rules }
+func (*offerMPTLedgerView) LedgerSeq() uint32                    { return 1 }
+
+func (v *offerMPTLedgerView) ForEach(fn func([32]byte, []byte) bool) error {
+	for k, data := range v.data {
+		if !fn(k, data) {
+			break
+		}
+	}
+	return nil
+}
+
+func (*offerMPTLedgerView) Succ([32]byte) ([32]byte, []byte, bool, error) {
+	return [32]byte{}, nil, false, nil
+}
+
+func putOfferMPTAccount(t *testing.T, view *offerMPTLedgerView, account [20]byte) {
+	t.Helper()
+	raw, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account:  state.EncodeAccountIDSafe(account),
+		Balance:  100_000_000,
+		Sequence: 2,
+	})
+	require.NoError(t, err)
+	view.data[keylet.Account(account).Key] = raw
+}
+
+func putOfferMPTIssuance(
+	t *testing.T,
+	view *offerMPTLedgerView,
+	id [24]byte,
+	flags uint32,
+	outstanding, maximum uint64,
+) {
+	t.Helper()
+	raw, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+		Issuer:            mptutil.Issuer(id),
+		Sequence:          1,
+		Flags:             flags,
+		OutstandingAmount: outstanding,
+		MaximumAmount:     &maximum,
+	})
+	require.NoError(t, err)
+	view.data[keylet.MPTIssuance(id).Key] = raw
+}
+
+func putOfferMPTHolding(t *testing.T, view *offerMPTLedgerView, id [24]byte, holder [20]byte, amount uint64) {
+	t.Helper()
+	raw, err := state.SerializeMPToken(&state.MPTokenData{
+		Account:           holder,
+		MPTokenIssuanceID: id,
+		MPTAmount:         amount,
+	})
+	require.NoError(t, err)
+	view.data[keylet.MPTokenByID(id, holder).Key] = raw
+}
+
+func offerMPTAmount(id [24]byte, value int64) tx.Amount {
+	return state.NewMPTAmountWithIssuanceID(
+		value,
+		state.EncodeAccountIDSafe(mptutil.Issuer(id)),
+		mptutil.EncodeID(id),
+	)
+}
+
+func TestOfferMPTBookDirectoryAssets(t *testing.T) {
+	var issuer, counterparty [20]byte
+	copy(issuer[:], []byte("issuer12345678901234"))
+	copy(counterparty[:], []byte("counterparty123456789"))
+	id := keylet.MakeMPTID(7, issuer)
+	domain := [32]byte{1, 2, 3}
+	mpt := offerMPTAmount(id, 100)
+	iou := tx.NewIssuedAmount(5_000_000_000_000_000, -15, "USD", state.EncodeAccountIDSafe(counterparty))
+
+	base, err := offerBookBase(mpt, iou, &domain)
+	require.NoError(t, err)
+	require.Equal(t, keylet.BookBase(
+		keylet.MPTSide(id),
+		keylet.IssueSide(keylet.CurrencyBytes("USD"), counterparty),
+		&domain,
+	), base)
+
+	dir := &state.DirectoryNode{RootIndex: base.Key, ExchangeRate: 1}
+	require.NoError(t, setBookDirectoryAssets(dir, mpt, iou))
+	require.NotNil(t, dir.TakerPaysMPT)
+	require.Equal(t, id, *dir.TakerPaysMPT)
+	require.Nil(t, dir.TakerGetsMPT)
+	require.Equal(t, [20]byte{}, dir.TakerPaysCurrency)
+	require.Equal(t, [20]byte{}, dir.TakerPaysIssuer)
+	require.Equal(t, keylet.CurrencyBytes("USD"), dir.TakerGetsCurrency)
+	require.Equal(t, counterparty, dir.TakerGetsIssuer)
+
+	raw, err := state.SerializeDirectoryNode(dir, true)
+	require.NoError(t, err)
+	parsed, err := state.ParseDirectoryNode(raw)
+	require.NoError(t, err)
+	require.NotNil(t, parsed.TakerPaysMPT)
+	require.Equal(t, id, *parsed.TakerPaysMPT)
+	require.Nil(t, parsed.TakerGetsMPT)
+	require.Equal(t, keylet.CurrencyBytes("USD"), parsed.TakerGetsCurrency)
+	require.Equal(t, counterparty, parsed.TakerGetsIssuer)
+}
+
+func TestOfferMPTValidationUsesIssuanceID(t *testing.T) {
+	var issuer [20]byte
+	copy(issuer[:], []byte("issuer12345678901234"))
+	firstID := keylet.MakeMPTID(1, issuer)
+	secondID := keylet.MakeMPTID(2, issuer)
+
+	offer := &OfferCreate{
+		BaseTx:    *tx.NewBaseTx(tx.TypeOfferCreate, "rAlice"),
+		TakerGets: offerMPTAmount(firstID, 100),
+		TakerPays: offerMPTAmount(secondID, 100),
+	}
+	require.NoError(t, offer.Validate())
+
+	offer.TakerPays = offerMPTAmount(firstID, 50)
+	require.EqualError(t, offer.Validate(), "temREDUNDANT: cannot create offer with same currency and issuer on both sides")
+}
+
+func TestOfferMPTValidationRejectsZeroIssuer(t *testing.T) {
+	badID := keylet.MakeMPTID(1, [20]byte{})
+	mpt := offerMPTAmount(badID, 100)
+	xrp := tx.NewXRPAmount(100)
+
+	for _, tt := range []struct {
+		name      string
+		takerPays tx.Amount
+		takerGets tx.Amount
+	}{
+		{name: "taker pays", takerPays: mpt, takerGets: xrp},
+		{name: "taker gets", takerPays: xrp, takerGets: mpt},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			offer := &OfferCreate{
+				BaseTx:    *tx.NewBaseTx(tx.TypeOfferCreate, "rAlice"),
+				TakerPays: tt.takerPays,
+				TakerGets: tt.takerGets,
+			}
+			require.EqualError(t, offer.Validate(), "temBAD_CURRENCY: MPT issuance ID has a zero issuer")
+		})
+	}
+}
+
+func TestOfferMPTPostCrossRoundingPreservesIntegralAsset(t *testing.T) {
+	var issuer [20]byte
+	copy(issuer[:], []byte("issuer12345678901234"))
+	id := keylet.MakeMPTID(1, issuer)
+	asset := offerMPTAmount(id, 5)
+	half := tx.NewIssuedAmount(5_000_000_000_000_000, -16, "", "")
+	two := tx.NewIssuedAmount(2_000_000_000_000_000, -15, "", "")
+	one := tx.NewIssuedAmount(1_000_000_000_000_000, -15, "", "")
+
+	identity := offerMulRoundLike(offerMPTAmount(id, 123_456_789), one, asset, true)
+	value, ok := identity.MPTRaw()
+	require.True(t, ok)
+	require.Equal(t, int64(123_456_789), value)
+	require.Equal(t, mptutil.EncodeID(id), identity.MPTIssuanceID())
+
+	roundedUp := offerMulRoundLike(asset, half, asset, true)
+	value, ok = roundedUp.MPTRaw()
+	require.True(t, ok)
+	require.Equal(t, int64(3), value)
+
+	roundedDown := offerDivRoundStrictLike(asset, two, asset, false)
+	value, ok = roundedDown.MPTRaw()
+	require.True(t, ok)
+	require.Equal(t, int64(2), value)
+}
+
+func TestOfferMPTIssuerMayPlaceUnfundedOffer(t *testing.T) {
+	var issuer, holder [20]byte
+	copy(issuer[:], []byte("issuer12345678901234"))
+	copy(holder[:], []byte("holder12345678901234"))
+	id := keylet.MakeMPTID(1, issuer)
+	mpt := offerMPTAmount(id, 100)
+
+	require.False(t, offerDisallowUnfunded(mpt, issuer))
+	require.True(t, offerDisallowUnfunded(mpt, holder))
+	require.True(t, offerDisallowUnfunded(tx.NewXRPAmount(100), issuer))
+
+	remainingGets, remainingPays := computePostCrossAmounts(
+		tx.NewXRPAmount(500),
+		mpt,
+		offerMPTAmount(id, 0),
+		tx.NewXRPAmount(0),
+		offerMPTAmount(id, 0),
+		true,
+		false,
+	)
+	value, ok := remainingGets.MPTRaw()
+	require.True(t, ok)
+	require.Equal(t, int64(100), value)
+	require.Equal(t, int64(500), remainingPays.Drops())
+}
+
+func TestOfferMPTPreclaimPermissionsAndFunding(t *testing.T) {
+	var issuer, holder [20]byte
+	copy(issuer[:], []byte("issuer12345678901234"))
+	copy(holder[:], []byte("holder12345678901234"))
+	id := keylet.MakeMPTID(1, issuer)
+	config := tx.EngineConfig{ReserveBase: 10_000_000, ReserveIncrement: 2_000_000}
+
+	newOffer := func(account [20]byte, takerPays, takerGets tx.Amount) *OfferCreate {
+		return &OfferCreate{
+			BaseTx:    *tx.NewBaseTx(tx.TypeOfferCreate, state.EncodeAccountIDSafe(account)),
+			TakerPays: takerPays,
+			TakerGets: takerGets,
+		}
+	}
+
+	t.Run("funded holder", func(t *testing.T) {
+		view := newOfferMPTLedgerView()
+		putOfferMPTAccount(t, view, issuer)
+		putOfferMPTAccount(t, view, holder)
+		putOfferMPTIssuance(t, view, id, entry.LsfMPTCanTrade|entry.LsfMPTCanTransfer, 100, 1_000)
+		putOfferMPTHolding(t, view, id, holder, 100)
+
+		offer := newOffer(holder, tx.NewXRPAmount(1_000), offerMPTAmount(id, 10))
+		require.Equal(t, ter.TesSUCCESS, offer.Preclaim(view, config))
+	})
+
+	t.Run("trading disabled", func(t *testing.T) {
+		view := newOfferMPTLedgerView()
+		putOfferMPTAccount(t, view, issuer)
+		putOfferMPTAccount(t, view, holder)
+		putOfferMPTIssuance(t, view, id, entry.LsfMPTCanTransfer, 100, 1_000)
+		putOfferMPTHolding(t, view, id, holder, 100)
+
+		offer := newOffer(holder, tx.NewXRPAmount(1_000), offerMPTAmount(id, 10))
+		require.Equal(t, ter.TecNO_PERMISSION, offer.Preclaim(view, config))
+	})
+
+	t.Run("globally locked", func(t *testing.T) {
+		view := newOfferMPTLedgerView()
+		putOfferMPTAccount(t, view, issuer)
+		putOfferMPTAccount(t, view, holder)
+		putOfferMPTIssuance(t, view, id, entry.LsfMPTCanTrade|entry.LsfMPTCanTransfer|entry.LsfMPTLocked, 100, 1_000)
+		putOfferMPTHolding(t, view, id, holder, 100)
+
+		offer := newOffer(holder, tx.NewXRPAmount(1_000), offerMPTAmount(id, 10))
+		require.Equal(t, ter.TecLOCKED, offer.Preclaim(view, config))
+	})
+
+	t.Run("issuer may offer beyond available issuance", func(t *testing.T) {
+		view := newOfferMPTLedgerView()
+		putOfferMPTAccount(t, view, issuer)
+		putOfferMPTIssuance(t, view, id, entry.LsfMPTCanTrade|entry.LsfMPTCanTransfer, 100, 100)
+
+		offer := newOffer(issuer, tx.NewXRPAmount(1_000), offerMPTAmount(id, 10))
+		require.Equal(t, ter.TesSUCCESS, offer.Preclaim(view, config))
+	})
+
+	t.Run("receiver requires authorization", func(t *testing.T) {
+		view := newOfferMPTLedgerView()
+		putOfferMPTAccount(t, view, issuer)
+		putOfferMPTAccount(t, view, holder)
+		putOfferMPTIssuance(t, view, id,
+			entry.LsfMPTCanTrade|entry.LsfMPTCanTransfer|entry.LsfMPTRequireAuth,
+			0, 1_000,
+		)
+
+		offer := newOffer(holder, offerMPTAmount(id, 10), tx.NewXRPAmount(1_000))
+		require.Equal(t, ter.TecNO_AUTH, offer.Preclaim(view, config))
+	})
+}
+
+var _ tx.LedgerView = (*offerMPTLedgerView)(nil)

--- a/internal/tx/offer/offer_quality.go
+++ b/internal/tx/offer/offer_quality.go
@@ -104,19 +104,33 @@ func offerMulRound(v1, v2 tx.Amount, native bool, currency, issuer string, round
 	return state.FinalizeRoundIOU(amount, offset, resultNegative, roundUp, currency, issuer, 0, false)
 }
 
+func offerMulRoundLike(v1, v2, resultAsset tx.Amount, roundUp bool) tx.Amount {
+	if !resultAsset.IsMPT() {
+		return offerMulRound(v1, v2, resultAsset.IsNative(), resultAsset.Currency, resultAsset.Issuer, roundUp)
+	}
+	return newMPTAmountLike(resultAsset, state.MulRoundMPT(v1, v2, roundUp))
+}
+
+func offerDivRoundStrictLike(num, den, resultAsset tx.Amount, roundUp bool) tx.Amount {
+	if !resultAsset.IsMPT() {
+		return offerDivRoundStrict(num, den, resultAsset.IsNative(), resultAsset.Currency, resultAsset.Issuer, roundUp)
+	}
+	return newMPTAmountLike(resultAsset, state.DivRoundMPTStrict(num, den, roundUp))
+}
+
 // applyTickSize applies tick size rounding to offer amounts.
 // Reference: rippled CreateOffer.cpp lines 643-685
 func applyTickSize(view tx.LedgerView, takerPays, takerGets tx.Amount, bSell bool, rules *amendment.Rules) (tx.Amount, tx.Amount) {
 	tickSize := maxTickSize
 
-	if !takerPays.IsNative() {
+	if !takerPays.IsNative() && !takerPays.IsMPT() {
 		issuerTickSize := getTickSize(view, takerPays.Issuer)
 		if issuerTickSize > 0 && issuerTickSize < tickSize {
 			tickSize = issuerTickSize
 		}
 	}
 
-	if !takerGets.IsNative() {
+	if !takerGets.IsNative() && !takerGets.IsMPT() {
 		issuerTickSize := getTickSize(view, takerGets.Issuer)
 		if issuerTickSize > 0 && issuerTickSize < tickSize {
 			tickSize = issuerTickSize
@@ -135,8 +149,10 @@ func applyTickSize(view tx.LedgerView, takerPays, takerGets tx.Amount, bSell boo
 
 	if bSell {
 		// Round TakerPays
-		takerPays = multiplyByQuality(takerGets, roundedQuality, takerPays.Currency, takerPays.Issuer)
-	} else {
+		if !takerPays.IsMPT() {
+			takerPays = multiplyByQuality(takerGets, roundedQuality, takerPays.Currency, takerPays.Issuer)
+		}
+	} else if !takerGets.IsMPT() {
 		// Round TakerGets
 		takerGets = divideByQuality(takerPays, roundedQuality, takerGets.Currency, takerGets.Issuer)
 	}

--- a/internal/tx/payment/amm_liquidity.go
+++ b/internal/tx/payment/amm_liquidity.go
@@ -10,6 +10,8 @@ package payment
 import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -165,7 +167,7 @@ func (l *AMMLiquidity) generateOffer(view *PaymentSandbox, poolIn, poolOut tx.Am
 	// Single-path with CLOB quality: match spot price to CLOB quality
 	offerIn, offerOut, ok, blocked := ChangeSpotPriceQuality(
 		poolIn, poolOut, *clobQuality, l.tradingFee,
-		l.fixAMMv1_1, l.issueOut.IsXRP(),
+		l.fixAMMv1_1, l.issueOut.IsXRP() || l.issueOut.IsMPT,
 	)
 	if ok {
 		return NewAMMOffer(l, offerIn, offerOut, poolIn, poolOut)
@@ -298,6 +300,13 @@ func ammAccountHoldsFromPayment(view *PaymentSandbox, ammAccountID [20]byte, iss
 			return state.NewXRPAmountFromInt(0)
 		}
 		return state.NewXRPAmountFromInt(int64(acct.Balance))
+	}
+	if issue.IsMPT {
+		funds, result := mptutil.Funds(view, issue.MPTID, ammAccountID, true)
+		if result != ter.TesSUCCESS || funds <= 0 {
+			return newMPTAmount(0, issue.MPTID)
+		}
+		return newMPTAmount(funds, issue.MPTID)
 	}
 
 	zeroIOU := state.NewIssuedAmountFromValue(0, -100, issue.Currency, state.EncodeAccountIDSafe(issue.Issuer))

--- a/internal/tx/payment/amm_offer.go
+++ b/internal/tx/payment/amm_offer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -186,6 +187,17 @@ func (o *AMMOffer) Send(sb *PaymentSandbox, from, to [20]byte, amount tx.Amount)
 	if amount.IsNative() {
 		return xrpTransferInSandbox(sb, from, to, amount.Drops())
 	}
+	if amount.IsMPT() {
+		id, err := mptutil.DecodeID(amount.MPTIssuanceID())
+		if err != nil {
+			return err
+		}
+		value, ok := amount.MPTRaw()
+		if !ok {
+			return errors.New("MPT amount has no integral value")
+		}
+		return mptTransferResult(mptutil.Credit(sb, id, from, to, value, true))
+	}
 	return iouTransferInSandbox(sb, from, to, amount)
 }
 
@@ -319,8 +331,5 @@ func adjustTrustLineBalance(sb *PaymentSandbox, account, issuer [20]byte, curren
 
 // eitherToAmount converts an EitherAmount back to a tx.Amount.
 func eitherToAmount(ea EitherAmount) tx.Amount {
-	if ea.IsNative {
-		return state.NewXRPAmountFromInt(ea.XRP)
-	}
-	return ea.IOU
+	return FromEitherAmount(ea)
 }

--- a/internal/tx/payment/amm_swap.go
+++ b/internal/tx/payment/amm_swap.go
@@ -24,6 +24,9 @@ func ammOne() tx.Amount {
 // Reference: rippled XRPAmount::operator Number() { return drops(); }
 // and Number::Number(rep mantissa) : Number{mantissa, 0} {}
 func toNumber(amt tx.Amount) tx.Amount {
+	if raw, ok := amt.MPTRaw(); ok {
+		return state.NewIssuedAmountFromValue(raw, 0, "", "")
+	}
 	if !amt.IsNative() {
 		// Drop the currency/issuer tag: swap math operates in rippled's
 		// unitless Number space, freely combining the two pool assets. The
@@ -44,6 +47,9 @@ func toNumber(amt tx.Amount) tx.Amount {
 // If the original was IOU, restores the currency/issuer.
 // Reference: rippled STAmount::operator=(Number const&) for Number->STAmount conversion
 func fromNumber(num tx.Amount, original tx.Amount) tx.Amount {
+	if original.IsMPT() {
+		return fromNumberWithGuard(num, original, state.RoundToNearest)
+	}
 	if original.IsNative() {
 		// Convert IOU-like number back to XRP drops.
 		// The Number has mantissa and exponent -- compute drops = mantissa * 10^exponent
@@ -90,6 +96,16 @@ func fromNumberRoundUp(num tx.Amount, original tx.Amount) tx.Amount {
 //
 //	and Number.cpp Number::operator rep() lines 480-512
 func fromNumberWithGuard(num tx.Amount, original tx.Amount, mode state.RoundingMode) tx.Amount {
+	if original.IsMPT() {
+		var value int64
+		if num.IsNative() {
+			value = num.Drops()
+		} else {
+			n := state.NewXRPLNumberRounded(num.Mantissa(), num.Exponent(), mode)
+			value = n.ToInt64WithMode(mode)
+		}
+		return state.NewMPTAmountWithIssuanceID(value, original.Issuer, original.MPTIssuanceID())
+	}
 	if original.IsNative() {
 		if num.IsNative() {
 			return num
@@ -644,6 +660,14 @@ func toEitherAmt(amt tx.Amount) EitherAmount {
 	if amt.IsNative() {
 		return NewXRPEitherAmount(amt.Drops())
 	}
+	if amt.IsMPT() {
+		id, ok := decodeMPTID(amt.MPTIssuanceID())
+		if !ok {
+			return EitherAmount{}
+		}
+		value, _ := amt.MPTRaw()
+		return NewMPTEitherAmount(value, id)
+	}
 	return NewIOUEitherAmount(amt)
 }
 
@@ -651,6 +675,9 @@ func toEitherAmt(amt tx.Amount) EitherAmount {
 func zeroLikeAmount(amt tx.Amount) tx.Amount {
 	if amt.IsNative() {
 		return state.NewXRPAmountFromInt(0)
+	}
+	if amt.IsMPT() {
+		return state.NewMPTAmountWithIssuanceID(0, amt.Issuer, amt.MPTIssuanceID())
 	}
 	return state.NewIssuedAmountFromValue(0, -100, amt.Currency, amt.Issuer)
 }
@@ -662,6 +689,9 @@ func zeroLikeAmount(amt tx.Amount) tx.Amount {
 func maxAmountLike(amt tx.Amount) tx.Amount {
 	if amt.IsNative() {
 		return state.NewXRPAmountFromInt(math.MaxInt64)
+	}
+	if amt.IsMPT() {
+		return state.NewMPTAmountWithIssuanceID(math.MaxInt64, amt.Issuer, amt.MPTIssuanceID())
 	}
 	// Max IOU: mantissa = cMaxValue/2 = 9999999999999999/2 = 4999999999999999
 	// exponent = cMaxOffset = 80
@@ -677,6 +707,9 @@ func maxAmountLike(amt tx.Amount) tx.Amount {
 func toMaxAmount(amt tx.Amount) tx.Amount {
 	if amt.IsNative() {
 		return state.NewXRPAmountFromInt(math.MaxInt64)
+	}
+	if amt.IsMPT() {
+		return state.NewMPTAmountWithIssuanceID(math.MaxInt64, amt.Issuer, amt.MPTIssuanceID())
 	}
 	// Full max IOU: mantissa = cMaxValue = 9999999999999999, exponent = cMaxOffset = 80
 	return state.NewIssuedAmountFromValue(9999999999999999, 80, amt.Currency, amt.Issuer)

--- a/internal/tx/payment/amm_swap_mpt_test.go
+++ b/internal/tx/payment/amm_swap_mpt_test.go
@@ -1,0 +1,48 @@
+package payment
+
+import (
+	"math"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/stretchr/testify/require"
+)
+
+const ammMPTID = "00000004AE123A8556F3CF91154711376AFB0F894F832B3D"
+
+func TestAMMMPTNumberConversionsPreserveIntegralIssue(t *testing.T) {
+	original := state.NewMPTAmountWithIssuanceID(7, "rIssuer", ammMPTID)
+	half := state.NewIssuedAmountFromValue(25, -1, "", "")
+
+	nearest := fromNumber(half, original)
+	value, ok := nearest.MPTRaw()
+	require.True(t, ok)
+	require.Equal(t, int64(2), value)
+	require.Equal(t, ammMPTID, nearest.MPTIssuanceID())
+
+	upward := fromNumberWithGuard(half, original, state.RoundUpward)
+	value, ok = upward.MPTRaw()
+	require.True(t, ok)
+	require.Equal(t, int64(3), value)
+	require.Equal(t, ammMPTID, upward.MPTIssuanceID())
+}
+
+func TestAMMMPTAmountFactoriesPreserveIssue(t *testing.T) {
+	original := state.NewMPTAmountWithIssuanceID(7, "rIssuer", ammMPTID)
+
+	zero := zeroLikeAmount(original)
+	value, ok := zero.MPTRaw()
+	require.True(t, ok)
+	require.Zero(t, value)
+	require.Equal(t, ammMPTID, zero.MPTIssuanceID())
+
+	maximum := maxAmountLike(original)
+	value, ok = maximum.MPTRaw()
+	require.True(t, ok)
+	require.Equal(t, int64(math.MaxInt64), value)
+	require.Equal(t, ammMPTID, maximum.MPTIssuanceID())
+
+	either := toEitherAmt(original)
+	require.True(t, either.IsMPT)
+	require.Equal(t, int64(7), either.MPT)
+}

--- a/internal/tx/payment/amount.go
+++ b/internal/tx/payment/amount.go
@@ -1,19 +1,26 @@
 package payment
 
 import (
+	"math/big"
+
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 )
 
-// EitherAmount holds either an XRP amount (in drops) or an IOU amount, allowing
+// EitherAmount holds either an XRP, IOU, or MPT amount, allowing
 // unified handling in the flow algorithm regardless of currency type.
 type EitherAmount struct {
 	IsNative bool
+	IsMPT    bool
 
 	// XRP holds the amount in drops (only valid if IsNative is true)
 	XRP int64
 
 	// IOU holds the IOU amount (only valid if IsNative is false)
 	IOU tx.Amount
+
+	// MPT holds an integral MPT amount and its issuance ID.
+	MPT   int64
+	MPTID [24]byte
 }
 
 func NewXRPEitherAmount(drops int64) EitherAmount {
@@ -27,6 +34,14 @@ func NewIOUEitherAmount(amount tx.Amount) EitherAmount {
 	return EitherAmount{
 		IsNative: false,
 		IOU:      amount,
+	}
+}
+
+func NewMPTEitherAmount(value int64, issuanceID [24]byte) EitherAmount {
+	return EitherAmount{
+		IsMPT: true,
+		MPT:   value,
+		MPTID: issuanceID,
 	}
 }
 
@@ -44,9 +59,16 @@ func ZeroIOUEitherAmount(currency, issuer string) EitherAmount {
 	}
 }
 
+func ZeroMPTEitherAmount(issuanceID [24]byte) EitherAmount {
+	return NewMPTEitherAmount(0, issuanceID)
+}
+
 func (e EitherAmount) IsZero() bool {
 	if e.IsNative {
 		return e.XRP == 0
+	}
+	if e.IsMPT {
+		return e.MPT == 0
 	}
 	return e.IOU.IsZero()
 }
@@ -54,6 +76,9 @@ func (e EitherAmount) IsZero() bool {
 func (e EitherAmount) IsNegative() bool {
 	if e.IsNative {
 		return e.XRP < 0
+	}
+	if e.IsMPT {
+		return e.MPT < 0
 	}
 	return e.IOU.IsNegative()
 }
@@ -63,6 +88,9 @@ func (e EitherAmount) Add(other EitherAmount) EitherAmount {
 	if e.IsNative {
 		return NewXRPEitherAmount(e.XRP + other.XRP)
 	}
+	if e.IsMPT {
+		return NewMPTEitherAmount(e.MPT+other.MPT, e.MPTID)
+	}
 	result, _ := e.IOU.Add(other.IOU)
 	return NewIOUEitherAmount(result)
 }
@@ -71,6 +99,9 @@ func (e EitherAmount) Add(other EitherAmount) EitherAmount {
 func (e EitherAmount) Sub(other EitherAmount) EitherAmount {
 	if e.IsNative {
 		return NewXRPEitherAmount(e.XRP - other.XRP)
+	}
+	if e.IsMPT {
+		return NewMPTEitherAmount(e.MPT-other.MPT, e.MPTID)
 	}
 	result, _ := e.IOU.Sub(other.IOU)
 	return NewIOUEitherAmount(result)
@@ -84,6 +115,15 @@ func (e EitherAmount) Compare(other EitherAmount) int {
 			return -1
 		}
 		if e.XRP > other.XRP {
+			return 1
+		}
+		return 0
+	}
+	if e.IsMPT {
+		if e.MPT < other.MPT {
+			return -1
+		}
+		if e.MPT > other.MPT {
 			return 1
 		}
 		return 0
@@ -109,6 +149,14 @@ func ToEitherAmount(amt tx.Amount) EitherAmount {
 	if amt.IsNative() {
 		return NewXRPEitherAmount(amt.Drops())
 	}
+	if amt.IsMPT() {
+		var id [24]byte
+		if decoded, ok := decodeMPTID(amt.MPTIssuanceID()); ok {
+			id = decoded
+		}
+		value, _ := amt.MPTRaw()
+		return NewMPTEitherAmount(value, id)
+	}
 	return NewIOUEitherAmount(amt)
 }
 
@@ -116,12 +164,15 @@ func FromEitherAmount(e EitherAmount) tx.Amount {
 	if e.IsNative {
 		return tx.NewXRPAmount(e.XRP)
 	}
+	if e.IsMPT {
+		return newMPTAmount(e.MPT, e.MPTID)
+	}
 	return e.IOU
 }
 
 func MulRatio(amt EitherAmount, num, den uint32, roundUp bool) EitherAmount {
 	if den == 0 {
-		return amt
+		panic("division by zero")
 	}
 
 	if amt.IsNative {
@@ -129,8 +180,47 @@ func MulRatio(amt EitherAmount, num, den uint32, roundUp bool) EitherAmount {
 		result := xrpAmt.MulRatio(num, den, roundUp)
 		return NewXRPEitherAmount(result.Drops())
 	}
+	if amt.IsMPT {
+		return NewMPTEitherAmount(mptMulRatio(amt.MPT, num, den, roundUp), amt.MPTID)
+	}
 
 	return NewIOUEitherAmount(amt.IOU.MulRatio(num, den, roundUp))
+}
+
+func mptMulRatio(amount int64, num, den uint32, roundUp bool) int64 {
+	if den == 0 {
+		panic("division by zero")
+	}
+	if amount == 0 {
+		return amount
+	}
+
+	numerator := new(big.Int).Mul(big.NewInt(amount), new(big.Int).SetUint64(uint64(num)))
+	denominator := new(big.Int).SetUint64(uint64(den))
+	quotient, remainder := new(big.Int), new(big.Int)
+	quotient.QuoRem(numerator, denominator, remainder)
+	if remainder.Sign() != 0 {
+		switch {
+		case amount > 0 && roundUp:
+			quotient.Add(quotient, big.NewInt(1))
+		case amount < 0 && !roundUp:
+			quotient.Sub(quotient, big.NewInt(1))
+		}
+	}
+	if !quotient.IsInt64() {
+		panic("MPT mulRatio overflow")
+	}
+	return quotient.Int64()
+}
+
+func toNumberAmount(amt EitherAmount) tx.Amount {
+	if amt.IsNative {
+		return tx.NewIssuedAmount(amt.XRP, 0, "", "")
+	}
+	if amt.IsMPT {
+		return tx.NewIssuedAmount(amt.MPT, 0, "", "")
+	}
+	return amt.IOU
 }
 
 // canonicalizeDropsRound converts an IOU-style mantissa/exponent to XRP drops

--- a/internal/tx/payment/flow.go
+++ b/internal/tx/payment/flow.go
@@ -83,15 +83,21 @@ func Flow(
 
 	// Initialize result accumulators
 	var totalIn, totalOut EitherAmount
-	if outReq.IsNative {
+	switch {
+	case outReq.IsNative:
 		totalOut = ZeroXRPEitherAmount()
-	} else {
+	case outReq.IsMPT:
+		totalOut = ZeroMPTEitherAmount(outReq.MPTID)
+	default:
 		totalOut = ZeroIOUEitherAmount(outReq.IOU.Currency, outReq.IOU.Issuer)
 	}
 	if sendMax != nil {
-		if sendMax.IsNative {
+		switch {
+		case sendMax.IsNative:
 			totalIn = ZeroXRPEitherAmount()
-		} else {
+		case sendMax.IsMPT:
+			totalIn = ZeroMPTEitherAmount(sendMax.MPTID)
+		default:
 			totalIn = ZeroIOUEitherAmount(sendMax.IOU.Currency, sendMax.IOU.Issuer)
 		}
 	} else {
@@ -491,6 +497,10 @@ func limitOut(v *PaymentSandbox, strand Strand, remainingOut EitherAmount, limit
 		// which calls Number::operator rep() (round to nearest, even on tie).
 		drops := canonicalizeDropsRound(outAmt.Mantissa(), outAmt.Exponent())
 		out = NewXRPEitherAmount(drops)
+	} else if remainingOut.IsMPT {
+		n := state.NewXRPLNumber(outAmt.Mantissa(), outAmt.Exponent())
+		value := n.ToInt64WithMode(state.RoundToNearest)
+		out = NewMPTEitherAmount(value, remainingOut.MPTID)
 	} else {
 		// Preserve currency/issuer from remainingOut (outAmt has empty currency/issuer
 		// because QualityFunction uses Number arithmetic with no issue info).
@@ -645,7 +655,7 @@ func RippleCalculate(
 	sandbox.SetOpenLedger(rcOpts.openLedger)
 
 	// Convert paths to strands (offerCrossing=false for payments).
-	strands, strandResult := ToStrands(sandbox, srcAccount, dstAccount, dstAmount, srcAmount, paths, addDefaultPath, false)
+	strands, strandResult := ToStrands(sandbox, srcAccount, dstAccount, dstAmount, srcAmount, paths, addDefaultPath, false, rcOpts.parentCloseTime)
 	if strandResult != ter.TesSUCCESS || len(strands) == 0 {
 		if strandResult == ter.TesSUCCESS {
 			strandResult = ter.TecPATH_DRY

--- a/internal/tx/payment/flow_cross.go
+++ b/internal/tx/payment/flow_cross.go
@@ -1,8 +1,11 @@
 package payment
 
 import (
+	"math"
+
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -120,11 +123,19 @@ func FlowCross(
 	// 3. Limit to available balance
 	//
 	// sendMax = min(takerGets * transferRate, balance)
-	inStartBalance := tx.AccountFunds(view, takerAccount, takerGets, true, params.ReserveBase, params.ReserveIncrement)
+	inStartBalance := accountFundsForCross(view, takerAccount, takerGets, true, params.ReserveBase, params.ReserveIncrement)
 
 	sendMax := ToEitherAmount(takerGets)
 
-	if !takerGets.IsNative() {
+	if takerGets.IsMPT() {
+		if id, ok := decodeMPTID(takerGets.MPTIssuanceID()); ok && takerAccount != mptutil.Issuer(id) {
+			transferRate := mptutil.TransferRate(view, id)
+			if transferRate != QualityOne {
+				rateAmt := rateAsAmount(transferRate)
+				sendMax = NewMPTEitherAmount(state.MulRoundMPT(takerGets, rateAmt, true), id)
+			}
+		}
+	} else if !takerGets.IsNative() {
 		issuerID, err := state.DecodeAccountID(takerGets.Issuer)
 		if err == nil && takerAccount != issuerID {
 			transferRate := GetTransferRate(view, issuerID)
@@ -171,10 +182,17 @@ func FlowCross(
 	// Note: In FlowCross, takerPays = the deliver currency (what gets delivered to the taker),
 	// so we check takerPays.IsNative() to determine the deliver type (XRP vs IOU).
 	if params.Sell {
-		if takerPays.IsNative() {
+		switch {
+		case takerPays.IsNative():
 			// Reference: rippled STAmount::cMaxNative = 9000000000000000000
 			deliver = NewXRPEitherAmount(9000000000000000000)
-		} else {
+		case takerPays.IsMPT():
+			id, ok := decodeMPTID(takerPays.MPTIssuanceID())
+			if !ok {
+				return FlowCrossResult{Result: ter.TefINTERNAL, Sandbox: sandbox}
+			}
+			deliver = NewMPTEitherAmount(math.MaxInt64/2, id)
+		default:
 			// Reference: rippled uses cMaxValue/2=4999999999999999, cMaxOffset=80
 			deliver = NewIOUEitherAmount(tx.NewIssuedAmount(
 				4999999999999999, 80,
@@ -206,6 +224,7 @@ func FlowCross(
 		paths,        // explicit paths (XRP bridge for IOU-IOU)
 		true,         // addDefaultPath
 		true,         // offerCrossing - skip trust line checks, create lines on demand
+		params.ParentCloseTime,
 	)
 
 	if strandResult != ter.TesSUCCESS || len(strands) == 0 {
@@ -284,7 +303,15 @@ func FlowCross(
 	takerPaidGross := result.In
 	takerPaidNet := result.In
 
-	if !takerGets.IsNative() {
+	if takerGets.IsMPT() {
+		if id, ok := decodeMPTID(takerGets.MPTIssuanceID()); ok && takerAccount != mptutil.Issuer(id) {
+			transferRate := mptutil.TransferRate(view, id)
+			if transferRate != QualityOne && transferRate > 0 {
+				rateAmt := rateAsAmount(transferRate)
+				takerPaidNet = NewMPTEitherAmount(state.DivRoundMPT(FromEitherAmount(result.In), rateAmt, true), id)
+			}
+		}
+	} else if !takerGets.IsNative() {
 		issuerID, err := state.DecodeAccountID(takerGets.Issuer)
 		if err == nil && takerAccount != issuerID {
 			transferRate := GetTransferRate(view, issuerID)
@@ -374,6 +401,11 @@ func zeroCrossAmount(amt tx.Amount) EitherAmount {
 	if amt.IsNative() {
 		return ZeroXRPEitherAmount()
 	}
+	if amt.IsMPT() {
+		if id, ok := decodeMPTID(amt.MPTIssuanceID()); ok {
+			return ZeroMPTEitherAmount(id)
+		}
+	}
 	return ZeroIOUEitherAmount(amt.Currency, amt.Issuer)
 }
 
@@ -404,6 +436,9 @@ func GetTransferRate(view tx.LedgerView, issuer [20]byte) uint32 {
 // Matches rippled's accountFunds(psb, ...) in CreateOffer.cpp line 432.
 // BalanceHook subtracts DeferredCredits so self-crossing round-trips report zero.
 func AccountFundsInSandbox(sb *PaymentSandbox, accountID [20]byte, amount tx.Amount, fhZeroIfFrozen bool, reserveBase, reserveIncrement uint64) tx.Amount {
+	if amount.IsMPT() {
+		return accountFundsForCross(sb, accountID, amount, fhZeroIfFrozen, reserveBase, reserveIncrement)
+	}
 	rawBalance := tx.AccountFunds(sb, accountID, amount, fhZeroIfFrozen, reserveBase, reserveIncrement)
 
 	if amount.IsNative() {
@@ -415,6 +450,21 @@ func AccountFundsInSandbox(sb *PaymentSandbox, accountID [20]byte, amount tx.Amo
 		return rawBalance
 	}
 	return sb.BalanceHook(accountID, issuerID, rawBalance)
+}
+
+func accountFundsForCross(view tx.LedgerView, accountID [20]byte, amount tx.Amount, zeroIfFrozen bool, reserveBase, reserveIncrement uint64) tx.Amount {
+	if !amount.IsMPT() {
+		return tx.AccountFunds(view, accountID, amount, zeroIfFrozen, reserveBase, reserveIncrement)
+	}
+	id, ok := decodeMPTID(amount.MPTIssuanceID())
+	if !ok {
+		return state.NewMPTAmountWithIssuanceID(0, amount.Issuer, amount.MPTIssuanceID())
+	}
+	funds, result := mptutil.Funds(view, id, accountID, zeroIfFrozen)
+	if result != ter.TesSUCCESS {
+		funds = 0
+	}
+	return state.NewMPTAmountWithIssuanceID(funds, amount.Issuer, amount.MPTIssuanceID())
 }
 
 // rateAsAmount converts a uint32 transfer rate to an Amount, matching rippled's

--- a/internal/tx/payment/flow_cross.go
+++ b/internal/tx/payment/flow_cross.go
@@ -123,7 +123,10 @@ func FlowCross(
 	// 3. Limit to available balance
 	//
 	// sendMax = min(takerGets * transferRate, balance)
-	inStartBalance := accountFundsForCross(view, takerAccount, takerGets, true, params.ReserveBase, params.ReserveIncrement)
+	inStartBalance, fundsResult := accountFundsForCross(view, takerAccount, takerGets, true, params.ReserveBase, params.ReserveIncrement)
+	if fundsResult != ter.TesSUCCESS {
+		return FlowCrossResult{Result: fundsResult, Sandbox: sandbox}
+	}
 
 	sendMax := ToEitherAmount(takerGets)
 
@@ -435,36 +438,39 @@ func GetTransferRate(view tx.LedgerView, issuer [20]byte) uint32 {
 // AccountFundsInSandbox returns account funds with BalanceHook applied.
 // Matches rippled's accountFunds(psb, ...) in CreateOffer.cpp line 432.
 // BalanceHook subtracts DeferredCredits so self-crossing round-trips report zero.
-func AccountFundsInSandbox(sb *PaymentSandbox, accountID [20]byte, amount tx.Amount, fhZeroIfFrozen bool, reserveBase, reserveIncrement uint64) tx.Amount {
+func AccountFundsInSandbox(sb *PaymentSandbox, accountID [20]byte, amount tx.Amount, fhZeroIfFrozen bool, reserveBase, reserveIncrement uint64) (tx.Amount, ter.Result) {
 	if amount.IsMPT() {
 		return accountFundsForCross(sb, accountID, amount, fhZeroIfFrozen, reserveBase, reserveIncrement)
 	}
 	rawBalance := tx.AccountFunds(sb, accountID, amount, fhZeroIfFrozen, reserveBase, reserveIncrement)
 
 	if amount.IsNative() {
-		return sb.BalanceHook(accountID, [20]byte{}, rawBalance)
+		return sb.BalanceHook(accountID, [20]byte{}, rawBalance), ter.TesSUCCESS
 	}
 
 	issuerID, err := state.DecodeAccountID(amount.Issuer)
 	if err != nil {
-		return rawBalance
+		return rawBalance, ter.TesSUCCESS
 	}
-	return sb.BalanceHook(accountID, issuerID, rawBalance)
+	return sb.BalanceHook(accountID, issuerID, rawBalance), ter.TesSUCCESS
 }
 
-func accountFundsForCross(view tx.LedgerView, accountID [20]byte, amount tx.Amount, zeroIfFrozen bool, reserveBase, reserveIncrement uint64) tx.Amount {
+func accountFundsForCross(view tx.LedgerView, accountID [20]byte, amount tx.Amount, zeroIfFrozen bool, reserveBase, reserveIncrement uint64) (tx.Amount, ter.Result) {
 	if !amount.IsMPT() {
-		return tx.AccountFunds(view, accountID, amount, zeroIfFrozen, reserveBase, reserveIncrement)
+		return tx.AccountFunds(view, accountID, amount, zeroIfFrozen, reserveBase, reserveIncrement), ter.TesSUCCESS
 	}
 	id, ok := decodeMPTID(amount.MPTIssuanceID())
 	if !ok {
-		return state.NewMPTAmountWithIssuanceID(0, amount.Issuer, amount.MPTIssuanceID())
+		return state.NewMPTAmountWithIssuanceID(0, amount.Issuer, amount.MPTIssuanceID()), ter.TefINTERNAL
 	}
 	funds, result := mptutil.Funds(view, id, accountID, zeroIfFrozen)
+	if result == ter.TefINTERNAL {
+		return tx.Amount{}, result
+	}
 	if result != ter.TesSUCCESS {
 		funds = 0
 	}
-	return state.NewMPTAmountWithIssuanceID(funds, amount.Issuer, amount.MPTIssuanceID())
+	return state.NewMPTAmountWithIssuanceID(funds, amount.Issuer, amount.MPTIssuanceID()), ter.TesSUCCESS
 }
 
 // rateAsAmount converts a uint32 transfer rate to an Amount, matching rippled's

--- a/internal/tx/payment/flow_test.go
+++ b/internal/tx/payment/flow_test.go
@@ -31,6 +31,27 @@ func newPaymentMockLedgerView() *paymentMockLedgerView {
 	}
 }
 
+func TestFlowCrossPropagatesMPTFundsCorruption(t *testing.T) {
+	view := newPaymentMockLedgerView()
+	var issuer, taker [20]byte
+	issuer[19] = 1
+	taker[19] = 2
+	id := keylet.MakeMPTID(1, issuer)
+	putMPTIssuance(t, view, id, 1, 0)
+	view.data[keylet.MPTokenByID(id, taker).Key] = []byte{1}
+
+	result := FlowCross(
+		view,
+		taker,
+		newMPTAmount(1, id),
+		tx.NewXRPAmount(1),
+		[32]byte{},
+		1,
+		FlowCrossParams{},
+	)
+	require.Equal(t, ter.TefINTERNAL, result.Result)
+}
+
 func (m *paymentMockLedgerView) Read(key keylet.Keylet) ([]byte, error) {
 	return m.data[key.Key], nil
 }

--- a/internal/tx/payment/pathfinder/account_currencies.go
+++ b/internal/tx/payment/pathfinder/account_currencies.go
@@ -32,6 +32,11 @@ func AccountSourceCurrencies(account [20]byte, cache *RippleLineCache) map[payme
 			}
 		}
 	}
+	for _, mpt := range cache.GetMPTs(account) {
+		if !mpt.ZeroBalance && !mpt.MaxedOut {
+			currencies[payment.NewMPTIssue(mpt.ID)] = true
+		}
+	}
 
 	return currencies
 }
@@ -50,6 +55,11 @@ func AccountDestCurrencies(account [20]byte, cache *RippleLineCache) map[payment
 		// Include if balance < limit (can accept more of this currency)
 		if line.Balance.Compare(line.Limit) < 0 {
 			currencies[payment.Issue{Currency: line.Currency, Issuer: line.AccountIDPeer}] = true
+		}
+	}
+	for _, mpt := range cache.GetMPTs(account) {
+		if mpt.ZeroBalance && !mpt.MaxedOut {
+			currencies[payment.NewMPTIssue(mpt.ID)] = true
 		}
 	}
 

--- a/internal/tx/payment/pathfinder/book_index.go
+++ b/internal/tx/payment/pathfinder/book_index.go
@@ -86,18 +86,19 @@ func (bi *BookIndex) IsBookToXRP(issue payment.Issue) bool {
 
 // BookExists checks whether a specific book directory exists in the ledger.
 func (bi *BookIndex) BookExists(takerPays, takerGets payment.Issue) bool {
-	paysCurrency := keylet.CurrencyBytes(takerPays.Currency)
-	getsCurrency := keylet.CurrencyBytes(takerGets.Currency)
-	k := keylet.BookDir(paysCurrency, takerPays.Issuer, getsCurrency, takerGets.Issuer)
+	k := keylet.BookBase(bookSide(takerPays), bookSide(takerGets), nil)
 	exists, _ := bi.ledger.Exists(k)
 	return exists
 }
 
+func bookSide(issue payment.Issue) keylet.BookSide {
+	if issue.IsMPT {
+		return keylet.MPTSide(issue.MPTID)
+	}
+	return keylet.IssueSide(keylet.CurrencyBytes(issue.Currency), issue.Issuer)
+}
+
 // issueFromAmount extracts an Issue from a state.Amount.
 func issueFromAmount(amt state.Amount) payment.Issue {
-	if amt.IsNative() {
-		return payment.Issue{Currency: "XRP"}
-	}
-	issuer, _ := state.DecodeAccountID(amt.Issuer)
-	return payment.Issue{Currency: amt.Currency, Issuer: issuer}
+	return payment.GetIssue(amt)
 }

--- a/internal/tx/payment/pathfinder/mpt_assets_test.go
+++ b/internal/tx/payment/pathfinder/mpt_assets_test.go
@@ -1,0 +1,183 @@
+package pathfinder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountAssetsIncludeEligibleMPTs(t *testing.T) {
+	ledger := newMockLedger()
+	issuer := testAccountID(0x41)
+	holder := testAccountID(0x42)
+	zeroHolder := testAccountID(0x43)
+	maxedIssuer := testAccountID(0x44)
+	for _, account := range [][20]byte{issuer, holder, zeroHolder, maxedIssuer} {
+		addAccount(t, ledger, account, 10_000_000, 0)
+	}
+
+	liveID := addPathfinderMPTIssuance(t, ledger, issuer, 7, 20, 100)
+	addPathfinderMPToken(t, ledger, holder, liveID, 5)
+	addPathfinderMPToken(t, ledger, zeroHolder, liveID, 0)
+	maxedID := addPathfinderMPTIssuance(t, ledger, maxedIssuer, 8, 100, 100)
+
+	cache := NewRippleLineCache(ledger)
+	liveIssue := payment.NewMPTIssue(liveID)
+	maxedIssue := payment.NewMPTIssue(maxedID)
+
+	require.True(t, AccountSourceCurrencies(issuer, cache)[liveIssue])
+	require.False(t, AccountDestCurrencies(issuer, cache)[liveIssue])
+	require.True(t, AccountSourceCurrencies(holder, cache)[liveIssue])
+	require.False(t, AccountDestCurrencies(holder, cache)[liveIssue])
+	require.False(t, AccountSourceCurrencies(zeroHolder, cache)[liveIssue])
+	require.True(t, AccountDestCurrencies(zeroHolder, cache)[liveIssue])
+	require.False(t, AccountSourceCurrencies(maxedIssuer, cache)[maxedIssue])
+	require.False(t, AccountDestCurrencies(maxedIssuer, cache)[maxedIssue])
+}
+
+func TestRippleLineCacheMPTsIgnoreOtherOwnedEntries(t *testing.T) {
+	ledger := newMockLedger()
+	account := testAccountID(0x51)
+	issuer := testAccountID(0x52)
+	addAccount(t, ledger, account, 10_000_000, 0)
+	addOffer(t, ledger, account, 1,
+		state.NewXRPAmountFromInt(1),
+		state.NewIssuedAmountFromFloat64(1, "USD", state.EncodeAccountIDSafe(issuer)),
+	)
+	ensureOwnerDirContains(t, ledger, account, keylet.Offer(account, 1).Key)
+
+	require.Empty(t, NewRippleLineCache(ledger).GetMPTs(account))
+}
+
+func TestMPTBookPathStep(t *testing.T) {
+	id, err := mptutil.DecodeID("00000004AE123A8556F3CF91154711376AFB0F894F832B3D")
+	require.NoError(t, err)
+	issue := payment.NewMPTIssue(id)
+	step := pathStepForIssue(issue)
+	require.Equal(t, 0x60, step.Type)
+	require.Equal(t, mptutil.EncodeID(id), step.MPTIssuanceID)
+	require.Equal(t, state.EncodeAccountIDSafe(mptutil.Issuer(id)), step.Issuer)
+	require.True(t, pathHasSeenBookIssue([]payment.PathStep{step}, issue))
+}
+
+func TestSamePathfindingAssetPreservesIOURippling(t *testing.T) {
+	var issuerA, issuerB [20]byte
+	issuerA[19] = 1
+	issuerB[19] = 2
+
+	require.True(t, samePathfindingAsset(
+		payment.Issue{Currency: "USD", Issuer: issuerA},
+		payment.Issue{Currency: "USD", Issuer: issuerB},
+	))
+	require.True(t, samePathfindingAsset(
+		payment.Issue{},
+		payment.Issue{Currency: "XRP"},
+	))
+	require.False(t, samePathfindingAsset(
+		payment.Issue{Currency: "USD", Issuer: issuerA},
+		payment.Issue{Currency: "EUR", Issuer: issuerA},
+	))
+
+	mptA := payment.NewMPTIssue(keylet.MakeMPTID(1, issuerA))
+	mptB := payment.NewMPTIssue(keylet.MakeMPTID(2, issuerA))
+	require.True(t, samePathfindingAsset(mptA, mptA))
+	require.False(t, samePathfindingAsset(mptA, mptB))
+	require.False(t, samePathfindingAsset(mptA, payment.Issue{Currency: "USD", Issuer: issuerA}))
+}
+
+type timedPathfinderLedger struct {
+	*mockLedgerView
+	parentCloseTime time.Time
+}
+
+func (l *timedPathfinderLedger) ParentCloseTime() time.Time {
+	return l.parentCloseTime
+}
+
+func TestPathfinderUsesLedgerParentCloseTimeForMPTAuthorization(t *testing.T) {
+	const rippleSeconds = uint32(12345)
+	ledger := &timedPathfinderLedger{
+		mockLedgerView: newMockLedger(),
+		parentCloseTime: time.Unix(
+			protocol.RippleEpochUnix+int64(rippleSeconds), 0,
+		),
+	}
+	var src, dst [20]byte
+	src[19] = 1
+	dst[19] = 2
+	id := keylet.MakeMPTID(1, src)
+	issue := payment.NewMPTIssue(id)
+	amount := state.NewMPTAmountWithIssuanceID(1, state.EncodeAccountIDSafe(src), mptutil.EncodeID(id))
+
+	closeTime := ledgerParentCloseTime(ledger)
+	require.Equal(t, rippleSeconds, closeTime)
+	pf := NewPathfinderForIssue(
+		ledger, NewRippleLineCache(ledger), src, dst,
+		amount, amount, issue, false, closeTime,
+	)
+	require.Equal(t, rippleSeconds, pf.parentCloseTime)
+}
+
+func TestIsValidAssetRejectsMPTWithZeroIssuer(t *testing.T) {
+	var id [24]byte
+	id[3] = 1
+	amount := state.NewMPTAmountWithIssuanceID(1, "", mptutil.EncodeID(id))
+	require.False(t, IsValidAsset(amount))
+
+	id[23] = 1
+	amount = state.NewMPTAmountWithIssuanceID(1, "", mptutil.EncodeID(id))
+	require.True(t, IsValidAsset(amount))
+
+	zeroID, ok := ParseSourceMPTID("0")
+	require.True(t, ok)
+	require.Equal(t, [24]byte{}, zeroID)
+}
+
+func addPathfinderMPTIssuance(
+	t *testing.T,
+	ledger *mockLedgerView,
+	issuer [20]byte,
+	sequence uint32,
+	outstanding, maximum uint64,
+) [24]byte {
+	t.Helper()
+	issuance := &state.MPTokenIssuanceData{
+		Issuer:            issuer,
+		Sequence:          sequence,
+		OutstandingAmount: outstanding,
+		MaximumAmount:     &maximum,
+	}
+	data, err := state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	id := keylet.MakeMPTID(sequence, issuer)
+	k := keylet.MPTIssuance(id)
+	ledger.entries[k.Key] = data
+	ensureOwnerDirContains(t, ledger, issuer, k.Key)
+	return id
+}
+
+func addPathfinderMPToken(
+	t *testing.T,
+	ledger *mockLedgerView,
+	holder [20]byte,
+	id [24]byte,
+	amount uint64,
+) {
+	t.Helper()
+	token := &state.MPTokenData{
+		Account:           holder,
+		MPTokenIssuanceID: id,
+		MPTAmount:         amount,
+	}
+	data, err := state.SerializeMPToken(token)
+	require.NoError(t, err)
+	k := keylet.MPTokenByID(id, holder)
+	ledger.entries[k.Key] = data
+	ensureOwnerDirContains(t, ledger, holder, k.Key)
+}

--- a/internal/tx/payment/pathfinder/path_request.go
+++ b/internal/tx/payment/pathfinder/path_request.go
@@ -1,11 +1,18 @@
 package pathfinder
 
 import (
+	"math"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // Pathfinding search levels mirror rippled's config defaults
@@ -55,6 +62,24 @@ type PathRequest struct {
 	searchLevel      int
 }
 
+// IsValidAsset reports whether an amount carries an asset that path finding
+// may use. Parsed MPT amounts must encode a non-zero issuer in their issuance
+// ID, matching rippled's validAsset check.
+func IsValidAsset(amount tx.Amount) bool {
+	return payment.GetIssue(amount).IsConsistent()
+}
+
+// ParseSourceMPTID parses the uint192 syntax accepted for an MPT entry in
+// source_currencies. In addition to a full-width ID, rippled accepts the
+// literal "0" as the zero uint192 value.
+func ParseSourceMPTID(value string) ([24]byte, bool) {
+	if value == "0" {
+		return [24]byte{}, true
+	}
+	id, err := mptutil.DecodeID(value)
+	return id, err == nil
+}
+
 // NewPathRequest creates a new path request from the given parameters.
 func NewPathRequest(
 	srcAccount, dstAccount [20]byte,
@@ -86,6 +111,14 @@ func (pr *PathRequest) SetSearchLevel(level int) {
 // Reference: rippled PathRequest::doUpdate()
 func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 	cache := NewRippleLineCache(ledger)
+	parentCloseTime := ledgerParentCloseTime(ledger)
+	fixReducedOffersV2 := false
+	if rules := ledger.Rules(); rules != nil {
+		fixReducedOffersV2 = rules.Enabled(amendment.FeatureFixReducedOffersV2)
+	}
+	calculationOptions := []payment.RippleCalculateOption{
+		payment.WithAmendments(parentCloseTime, fixReducedOffersV2),
+	}
 
 	// Determine source currencies
 	srcCurrencies := pr.sourceCurrencies
@@ -102,19 +135,19 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 		//   sourceCurrencies.insert({c, c.isZero() ? xrpAccount() : *raSrcAccount});
 		discovered := AccountSourceCurrencies(pr.srcAccount, cache)
 		sameAccount := pr.srcAccount == pr.dstAccount
-		dstCurrency := pr.dstAmount.Currency
-		if pr.dstAmount.IsNative() {
-			dstCurrency = "XRP"
-		}
-		// Track unique currencies (not issues) to avoid duplicates
-		seenCurrencies := make(map[string]bool)
+		dstIssue := payment.GetIssue(pr.dstAmount)
+		seenAssets := make(map[string]bool)
 		for issue := range discovered {
-			if seenCurrencies[issue.Currency] {
+			assetKey := issue.Currency
+			if issue.IsMPT {
+				assetKey = mptutil.EncodeID(issue.MPTID)
+			}
+			if seenAssets[assetKey] {
 				continue
 			}
-			seenCurrencies[issue.Currency] = true
+			seenAssets[assetKey] = true
 			// Skip if same account sending same currency to itself
-			if sameAccount && issue.Currency == dstCurrency {
+			if sameAccount && samePathfindingAsset(issue, dstIssue) {
 				continue
 			}
 			// More than maxAutoSrcCur auto-discovered currencies fails the
@@ -124,7 +157,9 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 			}
 			// Build issue with source account as issuer (matching rippled)
 			var srcIssue payment.Issue
-			if issue.Currency == "XRP" || issue.Currency == "" {
+			if issue.IsMPT {
+				srcIssue = issue
+			} else if issue.Currency == "XRP" || issue.Currency == "" {
 				srcIssue = payment.Issue{Currency: "XRP"}
 			} else {
 				srcIssue = payment.Issue{Currency: issue.Currency, Issuer: pr.srcAccount}
@@ -138,7 +173,11 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 	// Compute destination currencies
 	destCurrencies := AccountDestCurrencies(pr.dstAccount, cache)
 	for issue := range destCurrencies {
-		result.DestinationCurrencies = append(result.DestinationCurrencies, issue.Currency)
+		if issue.IsMPT {
+			result.DestinationCurrencies = append(result.DestinationCurrencies, mptutil.EncodeID(issue.MPTID))
+		} else {
+			result.DestinationCurrencies = append(result.DestinationCurrencies, issue.Currency)
+		}
 	}
 
 	// Track previously found paths per source currency (mContext in rippled)
@@ -159,18 +198,25 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 			srcAmount = *pr.sendMax
 		} else if srcIssue.IsXRP() {
 			srcAmount = state.NewXRPAmountFromInt(int64(99999999999)) // Max XRP
+		} else if srcIssue.IsMPT {
+			srcAmount = state.NewMPTAmountWithIssuanceID(
+				int64(entry.MaxMPTokenAmount),
+				state.EncodeAccountIDSafe(srcIssue.Issuer),
+				mptutil.EncodeID(srcIssue.MPTID),
+			)
 		} else {
 			// Max IOU amount
 			srcAmount = state.NewIssuedAmountFromFloat64(9999999999999999e80, srcIssue.Currency, state.EncodeAccountIDSafe(srcIssue.Issuer))
 		}
 
 		// Run pathfinding
-		pf := NewPathfinder(
+		pf := NewPathfinderForIssue(
 			ledger, cache,
 			pr.srcAccount, pr.dstAccount,
 			effectiveDstAmount, srcAmount,
-			srcIssue.Currency, srcIssue.Issuer,
+			srcIssue,
 			pr.convertAll,
+			parentCloseTime,
 		)
 
 		if !pf.FindPaths(pr.searchLevel) {
@@ -201,6 +247,7 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 			pr.convertAll,
 			false,
 			[32]byte{}, 0,
+			calculationOptions...,
 		)
 		calcResult := validateRC.Result
 
@@ -218,6 +265,7 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 				false,
 				false,
 				[32]byte{}, 0,
+				calculationOptions...,
 			).Result
 		}
 
@@ -233,13 +281,14 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 				pr.convertAll,
 				false,
 				[32]byte{}, 0,
+				calculationOptions...,
 			)
 
 			// Set the source amount's issuer the way rippled does
 			// (rc.actualAmountIn.setIssuer(sourceAccount)): the explicit
 			// issue account, or the source account itself for IOUs.
 			sourceAmount := payment.FromEitherAmount(finalRC.ActualIn)
-			if !sourceAmount.IsNative() {
+			if !sourceAmount.IsNative() && !sourceAmount.IsMPT() {
 				if srcIssue.Issuer != ([20]byte{}) {
 					sourceAmount.Issuer = state.EncodeAccountIDSafe(srcIssue.Issuer)
 				} else {
@@ -259,13 +308,32 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 	return result
 }
 
+type parentCloseTimeView interface {
+	ParentCloseTime() time.Time
+}
+
+func ledgerParentCloseTime(view tx.LedgerView) uint32 {
+	provider, ok := view.(parentCloseTimeView)
+	if !ok {
+		return 0
+	}
+	closeTime := provider.ParentCloseTime()
+	if closeTime.IsZero() {
+		return 0
+	}
+	seconds := closeTime.Unix() - protocol.RippleEpochUnix
+	if seconds <= 0 {
+		return 0
+	}
+	if seconds > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(seconds)
+}
+
 // issueFromTxAmount extracts an Issue from a tx.Amount.
 func issueFromTxAmount(amt tx.Amount) payment.Issue {
-	if amt.IsNative() {
-		return payment.Issue{Currency: "XRP"}
-	}
-	issuer, _ := state.DecodeAccountID(amt.Issuer)
-	return payment.Issue{Currency: amt.Currency, Issuer: issuer}
+	return payment.GetIssue(amt)
 }
 
 // AccountExists checks if an account exists in the ledger.

--- a/internal/tx/payment/pathfinder/pathfinder.go
+++ b/internal/tx/payment/pathfinder/pathfinder.go
@@ -78,7 +78,6 @@ func NewPathfinder(
 	)
 }
 
-// NewPathfinderForIssue creates a pathfinder whose source asset may be an MPT.
 func NewPathfinderForIssue(
 	ledger tx.LedgerView,
 	cache *RippleLineCache,

--- a/internal/tx/payment/pathfinder/pathfinder.go
+++ b/internal/tx/payment/pathfinder/pathfinder.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -19,6 +21,7 @@ type Pathfinder struct {
 
 	srcCurrency string
 	srcIssuer   [20]byte
+	srcIssue    payment.Issue
 	dstAmount   tx.Amount
 	srcAmount   tx.Amount
 
@@ -52,6 +55,8 @@ type Pathfinder struct {
 
 	// pathsOutCount caches getPathsOut results per Issue.
 	pathsOutCount map[payment.Issue]int
+
+	parentCloseTime uint32
 }
 
 // NewPathfinder creates a new pathfinder for the given payment parameters.
@@ -65,33 +70,54 @@ func NewPathfinder(
 	srcCurrency string,
 	srcIssuer [20]byte,
 	convertAll bool,
+	parentCloseTime ...uint32,
+) *Pathfinder {
+	return NewPathfinderForIssue(
+		ledger, cache, srcAccount, dstAccount, dstAmount, srcAmount,
+		payment.Issue{Currency: srcCurrency, Issuer: srcIssuer}, convertAll, parentCloseTime...,
+	)
+}
+
+// NewPathfinderForIssue creates a pathfinder whose source asset may be an MPT.
+func NewPathfinderForIssue(
+	ledger tx.LedgerView,
+	cache *RippleLineCache,
+	srcAccount, dstAccount [20]byte,
+	dstAmount tx.Amount,
+	srcAmount tx.Amount,
+	srcIssue payment.Issue,
+	convertAll bool,
+	parentCloseTime ...uint32,
 ) *Pathfinder {
 	// Determine effective destination.
-	// If dstAmount is IOU and the issuer differs from dstAccount, the effective
+	// If dstAmount is non-XRP and the issuer differs from dstAccount, the effective
 	// destination is the issuer (gateway). Paths must reach the issuer.
 	effectiveDst := dstAccount
-	if !dstAmount.IsNative() {
-		issuerID, err := state.DecodeAccountID(dstAmount.Issuer)
-		if err == nil && issuerID != dstAccount {
-			effectiveDst = issuerID
-		}
+	dstIssue := payment.GetIssue(dstAmount)
+	if !dstIssue.IsXRP() && dstIssue.Issuer != dstAccount {
+		effectiveDst = dstIssue.Issuer
 	}
 
 	// Build source path element
 	source := payment.PathStep{
-		Account:  state.EncodeAccountIDSafe(srcAccount),
-		Currency: srcCurrency,
+		Account: state.EncodeAccountIDSafe(srcAccount),
 	}
-	if srcCurrency != "XRP" && srcCurrency != "" {
-		source.Issuer = state.EncodeAccountIDSafe(srcIssuer)
+	if srcIssue.IsMPT {
+		source.MPTIssuanceID = mptutil.EncodeID(srcIssue.MPTID)
+	} else {
+		source.Currency = srcIssue.Currency
+		if !srcIssue.IsXRP() {
+			source.Issuer = state.EncodeAccountIDSafe(srcIssue.Issuer)
+		}
 	}
 
-	return &Pathfinder{
+	pf := &Pathfinder{
 		srcAccount:       srcAccount,
 		dstAccount:       dstAccount,
 		effectiveDst:     effectiveDst,
-		srcCurrency:      srcCurrency,
-		srcIssuer:        srcIssuer,
+		srcCurrency:      srcIssue.Currency,
+		srcIssuer:        srcIssue.Issuer,
+		srcIssue:         srcIssue,
 		dstAmount:        dstAmount,
 		srcAmount:        srcAmount,
 		convertAll:       convertAll,
@@ -103,6 +129,10 @@ func NewPathfinder(
 		pathsOutCount:    make(map[payment.Issue]int),
 		completePathKeys: make(map[string]struct{}),
 	}
+	if len(parentCloseTime) > 0 {
+		pf.parentCloseTime = parentCloseTime[0]
+	}
+	return pf
 }
 
 // CompletePaths returns the discovered complete paths.
@@ -113,6 +143,23 @@ func (pf *Pathfinder) CompletePaths() [][]payment.PathStep {
 // PathRanks returns the ranked paths.
 func (pf *Pathfinder) PathRanks() []PathRank {
 	return pf.pathRanks
+}
+
+func (pf *Pathfinder) sourceIssue() payment.Issue {
+	if pf.srcIssue.IsMPT || pf.srcIssue.Currency != "" || pf.srcIssue.Issuer != [20]byte{} {
+		return pf.srcIssue
+	}
+	return payment.Issue{Currency: pf.srcCurrency, Issuer: pf.srcIssuer}
+}
+
+func samePathfindingAsset(a, b payment.Issue) bool {
+	if a.IsMPT || b.IsMPT {
+		return a.Equal(b)
+	}
+	if a.IsXRP() || b.IsXRP() {
+		return a.IsXRP() && b.IsXRP()
+	}
+	return a.Currency == b.Currency
 }
 
 // FindPaths runs the DFS path discovery algorithm at the given search level.
@@ -126,18 +173,15 @@ func (pf *Pathfinder) FindPaths(searchLevel int) bool {
 	}
 
 	// Same account, same currency — no path needed
-	dstCurrency := pf.dstAmount.Currency
-	if pf.dstAmount.IsNative() {
-		dstCurrency = "XRP"
-	}
+	dstIssue := payment.GetIssue(pf.dstAmount)
 	if pf.srcAccount == pf.dstAccount &&
 		pf.dstAccount == pf.effectiveDst &&
-		pf.srcCurrency == dstCurrency {
+		samePathfindingAsset(pf.sourceIssue(), dstIssue) {
 		return false
 	}
 
 	// Source IS the effective destination with same currency — default path
-	if pf.srcAccount == pf.effectiveDst && pf.srcCurrency == dstCurrency {
+	if pf.srcAccount == pf.effectiveDst && samePathfindingAsset(pf.sourceIssue(), dstIssue) {
 		return true
 	}
 
@@ -186,7 +230,8 @@ func (pf *Pathfinder) FindPaths(searchLevel int) bool {
 // classifyPayment determines the PaymentType based on source/destination currencies.
 // Reference: rippled Pathfinder::findPaths() payment type determination
 func (pf *Pathfinder) classifyPayment() PaymentType {
-	srcXRP := pf.srcCurrency == "XRP" || pf.srcCurrency == ""
+	srcIssue := pf.sourceIssue()
+	srcXRP := srcIssue.IsXRP()
 	dstXRP := pf.dstAmount.IsNative()
 
 	switch {
@@ -197,8 +242,12 @@ func (pf *Pathfinder) classifyPayment() PaymentType {
 	case !srcXRP && dstXRP:
 		return ptNonXRP_to_XRP
 	case !srcXRP && !dstXRP:
-		dstCurrency := pf.dstAmount.Currency
-		if pf.srcCurrency == dstCurrency {
+		dstIssue := payment.GetIssue(pf.dstAmount)
+		if srcIssue.IsMPT || dstIssue.IsMPT {
+			if srcIssue.Equal(dstIssue) {
+				return ptNonXRP_to_same
+			}
+		} else if srcIssue.Currency == dstIssue.Currency {
 			return ptNonXRP_to_same
 		}
 		return ptNonXRP_to_nonXRP
@@ -267,48 +316,49 @@ func (pf *Pathfinder) addLinks(parentPaths [][]payment.PathStep, addFlags uint32
 // addLink extends a single path by one hop.
 // Reference: rippled Pathfinder::addLink()
 func (pf *Pathfinder) addLink(currentPath []payment.PathStep, incompletePaths *[][]payment.PathStep, addFlags uint32) {
-	// Get current path endpoint
-	var endAccount [20]byte
-	var endCurrency string
-	var endIssuer [20]byte
-
-	if len(currentPath) == 0 {
-		// Path is empty — use source
-		endAccount = pf.srcAccount
-		endCurrency = pf.srcCurrency
-		endIssuer = pf.srcIssuer
-	} else {
-		last := currentPath[len(currentPath)-1]
-		if last.Account != "" {
-			endAccount, _ = state.DecodeAccountID(last.Account)
-		}
-		endCurrency = last.Currency
-		if endCurrency == "" {
-			endCurrency = pf.srcCurrency
-		}
-		if last.Issuer != "" {
-			endIssuer, _ = state.DecodeAccountID(last.Issuer)
-		} else if last.Account != "" {
-			endIssuer = endAccount
-		}
-	}
-
-	bOnXRP := endCurrency == "XRP" || endCurrency == ""
+	endAccount, endIssue := pf.pathEnd(currentPath)
+	bOnXRP := endIssue.IsXRP()
 	hasEffectiveDst := pf.effectiveDst != pf.dstAccount
-	dstCurrency := pf.dstAmount.Currency
-	if pf.dstAmount.IsNative() {
-		dstCurrency = "XRP"
-	}
+	dstIssue := payment.GetIssue(pf.dstAmount)
 
 	// Handle account paths (rippling through trust lines)
 	if addFlags&afADD_ACCOUNTS != 0 {
-		pf.addAccountLinks(currentPath, incompletePaths, addFlags, endAccount, endCurrency, endIssuer, bOnXRP, hasEffectiveDst, dstCurrency)
+		pf.addAccountLinks(currentPath, incompletePaths, addFlags, endAccount, endIssue, bOnXRP, hasEffectiveDst, dstIssue)
 	}
 
 	// Handle order book paths
 	if addFlags&afADD_BOOKS != 0 {
-		pf.addBookLinks(currentPath, incompletePaths, addFlags, endCurrency, endIssuer, bOnXRP, hasEffectiveDst, dstCurrency)
+		pf.addBookLinks(currentPath, incompletePaths, addFlags, endIssue, bOnXRP, hasEffectiveDst, dstIssue)
 	}
+}
+
+func (pf *Pathfinder) pathEnd(path []payment.PathStep) ([20]byte, payment.Issue) {
+	account := pf.srcAccount
+	issue := pf.sourceIssue()
+	for _, step := range path {
+		if step.Account != "" {
+			if decoded, err := state.DecodeAccountID(step.Account); err == nil {
+				account = decoded
+			}
+		}
+		if step.MPTIssuanceID != "" {
+			if id, err := mptutil.DecodeID(step.MPTIssuanceID); err == nil {
+				issue = payment.NewMPTIssue(id)
+			}
+			continue
+		}
+		if step.Currency != "" {
+			issue = payment.Issue{Currency: step.Currency}
+			if step.Issuer != "" {
+				issue.Issuer, _ = state.DecodeAccountID(step.Issuer)
+			} else if !issue.IsXRP() {
+				issue.Issuer = account
+			}
+		} else if step.Account != "" && !issue.IsMPT && !issue.IsXRP() {
+			issue.Issuer = account
+		}
+	}
+	return account, issue
 }
 
 // addAccountLinks extends a path through trust lines.
@@ -318,11 +368,10 @@ func (pf *Pathfinder) addAccountLinks(
 	incompletePaths *[][]payment.PathStep,
 	addFlags uint32,
 	endAccount [20]byte,
-	endCurrency string,
-	endIssuer [20]byte,
+	endIssue payment.Issue,
 	bOnXRP bool,
 	hasEffectiveDst bool,
-	dstCurrency string,
+	dstIssue payment.Issue,
 ) {
 	if bOnXRP {
 		// On XRP — if destination is XRP and path is non-empty, it's complete
@@ -343,7 +392,7 @@ func (pf *Pathfinder) addAccountLinks(
 	}
 
 	bRequireAuth := acctRoot.Flags&state.LsfRequireAuth != 0
-	bIsEndCurrency := endCurrency == dstCurrency
+	bIsEndCurrency := samePathfindingAsset(endIssue, dstIssue)
 	bIsNoRippleOut := pf.isNoRippleOut(currentPath)
 	bDestOnly := addFlags&afAC_LAST != 0
 
@@ -351,6 +400,10 @@ func (pf *Pathfinder) addAccountLinks(
 	lineDirection := LineDirectionOutgoing
 	if bIsNoRippleOut {
 		lineDirection = LineDirectionIncoming
+	}
+	if endIssue.IsMPT {
+		pf.addMPTAccountLinks(currentPath, incompletePaths, addFlags, endAccount, endIssue, hasEffectiveDst, dstIssue)
+		return
 	}
 	lines := pf.cache.GetRippleLines(endAccount, lineDirection)
 
@@ -379,12 +432,12 @@ func (pf *Pathfinder) addAccountLinks(
 		}
 
 		// Currency must match
-		if line.Currency != endCurrency {
+		if line.Currency != endIssue.Currency {
 			continue
 		}
 
 		// Check for path loops
-		if pathHasSeen(currentPath, peerAcct, endCurrency) {
+		if pathHasSeenIssue(currentPath, peerAcct, endIssue) {
 			continue
 		}
 
@@ -428,7 +481,7 @@ func (pf *Pathfinder) addAccountLinks(
 		} else {
 			// Regular candidate — score by paths out
 			out := pf.getPathsOut(
-				payment.Issue{Currency: endCurrency, Issuer: peerAcct},
+				payment.Issue{Currency: endIssue.Currency, Issuer: peerAcct},
 				peerDirection,
 				bIsEndCurrency,
 			)
@@ -465,12 +518,51 @@ func (pf *Pathfinder) addAccountLinks(
 		copy(newPath, currentPath)
 		newPath = append(newPath, payment.PathStep{
 			Account:  state.EncodeAccountIDSafe(c.Account),
-			Currency: endCurrency,
+			Currency: endIssue.Currency,
 			Issuer:   state.EncodeAccountIDSafe(c.Account),
 			Type:     0x01, // typeAccount
 		})
 		*incompletePaths = append(*incompletePaths, newPath)
 	}
+}
+
+func (pf *Pathfinder) addMPTAccountLinks(
+	currentPath []payment.PathStep,
+	incompletePaths *[][]payment.PathStep,
+	addFlags uint32,
+	endAccount [20]byte,
+	endIssue payment.Issue,
+	hasEffectiveDst bool,
+	dstIssue payment.Issue,
+) {
+	issuer := endIssue.Issuer
+	if hasEffectiveDst && issuer == pf.dstAccount {
+		return
+	}
+	toDestination := issuer == pf.effectiveDst
+	if addFlags&afAC_LAST != 0 && !toDestination {
+		return
+	}
+	if pathHasSeenIssue(currentPath, issuer, endIssue) {
+		return
+	}
+	funds, result := mptutil.Funds(pf.ledger, endIssue.MPTID, endAccount, true)
+	if result != ter.TesSUCCESS || funds <= 0 {
+		return
+	}
+	if toDestination && samePathfindingAsset(endIssue, dstIssue) {
+		if len(currentPath) > 0 {
+			pf.addUniquePath(currentPath)
+		}
+		return
+	}
+	newPath := make([]payment.PathStep, len(currentPath), len(currentPath)+1)
+	copy(newPath, currentPath)
+	newPath = append(newPath, payment.PathStep{
+		Account: state.EncodeAccountIDSafe(issuer),
+		Type:    0x01,
+	})
+	*incompletePaths = append(*incompletePaths, newPath)
 }
 
 // addBookLinks extends a path through order books.
@@ -479,14 +571,11 @@ func (pf *Pathfinder) addBookLinks(
 	currentPath []payment.PathStep,
 	incompletePaths *[][]payment.PathStep,
 	addFlags uint32,
-	endCurrency string,
-	endIssuer [20]byte,
+	endIssue payment.Issue,
 	bOnXRP bool,
 	hasEffectiveDst bool,
-	dstCurrency string,
+	dstIssue payment.Issue,
 ) {
-	endIssue := payment.Issue{Currency: endCurrency, Issuer: endIssuer}
-
 	if addFlags&afOB_XRP != 0 {
 		// XRP book only — add path through book to XRP
 		if !bOnXRP && pf.books.IsBookToXRP(endIssue) {
@@ -523,7 +612,7 @@ func (pf *Pathfinder) addBookLinks(
 		}
 
 		// If destination only, restrict to destination currency
-		if bDestOnly && bookOut.Currency != dstCurrency {
+		if bDestOnly && !samePathfindingAsset(bookOut, dstIssue) {
 			continue
 		}
 
@@ -544,11 +633,12 @@ func (pf *Pathfinder) addBookLinks(
 			}
 		} else {
 			// Check if we've already seen this issuer account with this currency
-			if pathHasSeen(currentPath, bookOut.Issuer, bookOut.Currency) {
+			if pathHasSeenIssue(currentPath, bookOut.Issuer, bookOut) {
 				continue
 			}
 
 			issuerStr := state.EncodeAccountIDSafe(bookOut.Issuer)
+			bookStep := pathStepForIssue(bookOut)
 
 			// Path compression: book -> account -> book
 			// If the last two steps are an offer followed by an account,
@@ -556,27 +646,18 @@ func (pf *Pathfinder) addBookLinks(
 			// Reference: rippled Pathfinder::addLink() book compression
 			if len(newPath) >= 2 &&
 				newPath[len(newPath)-1].Type == 0x01 && // typeAccount
-				(newPath[len(newPath)-2].Type == 0x10 || newPath[len(newPath)-2].Type == 0x30) { // typeCurrency or typeCurrency|typeIssuer
-				newPath[len(newPath)-1] = payment.PathStep{
-					Currency: bookOut.Currency,
-					Issuer:   issuerStr,
-					Type:     0x30, // typeCurrency | typeIssuer
-				}
+				isBookPathType(newPath[len(newPath)-2].Type) {
+				newPath[len(newPath)-1] = bookStep
 			} else {
-				// Add currency+issuer step
-				newPath = append(newPath, payment.PathStep{
-					Currency: bookOut.Currency,
-					Issuer:   issuerStr,
-					Type:     0x30, // typeCurrency | typeIssuer
-				})
+				newPath = append(newPath, bookStep)
 			}
 
-			if hasEffectiveDst && bookOut.Issuer == pf.dstAccount && bookOut.Currency == dstCurrency {
+			if hasEffectiveDst && bookOut.Issuer == pf.dstAccount && samePathfindingAsset(bookOut, dstIssue) {
 				// Would skip required issuer — skip this book
 				continue
 			}
 
-			if bookOut.Issuer == pf.effectiveDst && bookOut.Currency == dstCurrency {
+			if bookOut.Issuer == pf.effectiveDst && samePathfindingAsset(bookOut, dstIssue) {
 				// Complete!
 				pf.addUniquePath(newPath)
 			} else {
@@ -584,15 +665,32 @@ func (pf *Pathfinder) addBookLinks(
 				newPath2 := make([]payment.PathStep, len(newPath), len(newPath)+1)
 				copy(newPath2, newPath)
 				newPath2 = append(newPath2, payment.PathStep{
-					Account:  issuerStr,
-					Currency: bookOut.Currency,
-					Issuer:   issuerStr,
-					Type:     0x01, // typeAccount
+					Account: issuerStr,
+					Type:    0x01, // typeAccount
 				})
 				*incompletePaths = append(*incompletePaths, newPath2)
 			}
 		}
 	}
+}
+
+func pathStepForIssue(issue payment.Issue) payment.PathStep {
+	if issue.IsMPT {
+		return payment.PathStep{
+			MPTIssuanceID: mptutil.EncodeID(issue.MPTID),
+			Issuer:        state.EncodeAccountIDSafe(issue.Issuer),
+			Type:          0x60,
+		}
+	}
+	return payment.PathStep{
+		Currency: issue.Currency,
+		Issuer:   state.EncodeAccountIDSafe(issue.Issuer),
+		Type:     0x30,
+	}
+}
+
+func isBookPathType(pathType int) bool {
+	return pathType == 0x10 || pathType == 0x30 || pathType == 0x40 || pathType == 0x60
 }
 
 // getPathsOut returns the number of outgoing paths from the given issue.
@@ -602,6 +700,28 @@ func (pf *Pathfinder) addBookLinks(
 func (pf *Pathfinder) getPathsOut(issue payment.Issue, direction LineDirection, isDstCurrency bool) int {
 	if cached, ok := pf.pathsOutCount[issue]; ok {
 		return cached
+	}
+	if issue.IsMPT {
+		if mptutil.IsGlobalFrozen(pf.ledger, issue.MPTID) {
+			pf.pathsOutCount[issue] = 0
+			return 0
+		}
+		count := len(pf.books.GetBooksByTakerPays(issue))
+		for _, mpt := range pf.cache.GetMPTs(issue.Issuer) {
+			if mpt.ID != issue.MPTID || mpt.ZeroBalance || mpt.MaxedOut {
+				continue
+			}
+			if mptutil.RequireAuthAt(pf.ledger, issue.MPTID, issue.Issuer, false, pf.parentCloseTime) != ter.TesSUCCESS {
+				continue
+			}
+			if isDstCurrency && issue.Issuer == pf.effectiveDst {
+				count += highPriority
+			} else if !mptutil.IsIndividualFrozen(pf.ledger, issue.MPTID, issue.Issuer) {
+				count++
+			}
+		}
+		pf.pathsOutCount[issue] = count
+		return count
 	}
 
 	// Check if account exists and is not globally frozen
@@ -768,6 +888,8 @@ func pathKey(path []payment.PathStep) string {
 		b.WriteByte(0)
 		b.WriteString(step.Issuer)
 		b.WriteByte(0)
+		b.WriteString(step.MPTIssuanceID)
+		b.WriteByte(0)
 	}
 	return b.String()
 }
@@ -775,6 +897,10 @@ func pathKey(path []payment.PathStep) string {
 // issueMatchesOrigin returns true if the given issue matches the source currency/issuer.
 // Reference: rippled Pathfinder::issueMatchesOrigin()
 func (pf *Pathfinder) issueMatchesOrigin(issue payment.Issue) bool {
+	srcIssue := pf.sourceIssue()
+	if issue.IsMPT || srcIssue.IsMPT {
+		return issue.Equal(srcIssue)
+	}
 	matchingCurrency := issue.Currency == pf.srcCurrency
 	matchingAccount := issue.IsXRP() ||
 		(pf.srcIssuer != [20]byte{} && issue.Issuer == pf.srcIssuer) ||
@@ -786,6 +912,15 @@ func (pf *Pathfinder) issueMatchesOrigin(issue payment.Issue) bool {
 // This uses a zero account for matching (book steps don't have real accounts).
 // Reference: rippled STPath::hasSeen(xrpAccount(), currency, issuer)
 func pathHasSeenBookIssue(path []payment.PathStep, issue payment.Issue) bool {
+	if issue.IsMPT {
+		id := mptutil.EncodeID(issue.MPTID)
+		for _, step := range path {
+			if step.Account == "" && strings.EqualFold(step.MPTIssuanceID, id) {
+				return true
+			}
+		}
+		return false
+	}
 	issuerStr := state.EncodeAccountIDSafe(issue.Issuer)
 	for _, step := range path {
 		// Match book steps (typeCurrency or typeCurrency|typeIssuer)
@@ -798,19 +933,25 @@ func pathHasSeenBookIssue(path []payment.PathStep, issue payment.Issue) bool {
 	return false
 }
 
-// pathHasSeen returns true if the path already visits the given account+currency.
-func pathHasSeen(path []payment.PathStep, account [20]byte, currency string) bool {
+func pathHasSeenIssue(path []payment.PathStep, account [20]byte, issue payment.Issue) bool {
 	acctStr := state.EncodeAccountIDSafe(account)
 	for _, step := range path {
 		if step.Account == acctStr {
+			if issue.IsMPT {
+				return step.MPTIssuanceID == "" || strings.EqualFold(step.MPTIssuanceID, mptutil.EncodeID(issue.MPTID))
+			}
 			stepCurrency := step.Currency
 			if stepCurrency == "" {
 				stepCurrency = "XRP"
 			}
-			if stepCurrency == currency {
+			if stepCurrency == issue.Currency {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+func pathHasSeen(path []payment.PathStep, account [20]byte, currency string) bool {
+	return pathHasSeenIssue(path, account, payment.Issue{Currency: currency})
 }

--- a/internal/tx/payment/pathfinder/ranking.go
+++ b/internal/tx/payment/pathfinder/ranking.go
@@ -68,6 +68,9 @@ func (pf *Pathfinder) rankMinAmount(maxPaths int) tx.Amount {
 		}
 		return minAmount
 	}
+	if minAmount.IsMPT() {
+		return minAmount.Div(state.NewXRPAmountFromInt(divisor), false)
+	}
 	if f := minAmount.Float64(); f > 0 {
 		return state.NewIssuedAmountFromFloat64(f/float64(divisor), minAmount.Currency, minAmount.Issuer)
 	}
@@ -190,6 +193,9 @@ func largestAmount(amt tx.Amount) tx.Amount {
 		// INITIAL_XRP = 100 billion XRP = 100,000,000,000 * 1,000,000 drops
 		return state.NewXRPAmountFromInt(100_000_000_000_000_000)
 	}
+	if amt.IsMPT() {
+		return state.NewMPTAmountWithIssuanceID(9_223_372_036_854_775_807, amt.Issuer, amt.MPTIssuanceID())
+	}
 	// Maximum IOU amount: 9999999999999999e80
 	return state.NewIssuedAmountFromFloat64(9999999999999999e80, amt.Currency, amt.Issuer)
 }
@@ -199,7 +205,7 @@ func largestAmount(amt tx.Amount) tx.Amount {
 // can cover the entire payment by itself.
 // Reference: rippled Pathfinder::getBestPaths()
 func (pf *Pathfinder) GetBestPaths(maxPaths int, extraPaths [][]payment.PathStep, srcIssuer [20]byte) (bestPaths [][]payment.PathStep, fullLiquidityPath []payment.PathStep) {
-	issuerIsSender := (pf.srcCurrency == "XRP" || pf.srcCurrency == "") || srcIssuer == pf.srcAccount
+	issuerIsSender := pf.sourceIssue().IsXRP() || srcIssuer == pf.srcAccount
 
 	// Rank extra paths
 	var extraRanks []PathRank

--- a/internal/tx/payment/pathfinder/ripple_line_cache.go
+++ b/internal/tx/payment/pathfinder/ripple_line_cache.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -64,6 +65,13 @@ type PathFindTrustLine struct {
 	Currency string
 }
 
+// PathFindMPT describes an account's relationship to an MPT issuance.
+type PathFindMPT struct {
+	ID          [24]byte
+	ZeroBalance bool
+	MaxedOut    bool
+}
+
 // accountKey is the cache key for RippleLineCache.
 type accountKey struct {
 	Account   [20]byte
@@ -77,6 +85,7 @@ type RippleLineCache struct {
 	ledger tx.LedgerView
 	mu     sync.RWMutex
 	lines  map[accountKey][]PathFindTrustLine
+	mpts   map[[20]byte][]PathFindMPT
 
 	// builders serializes trust-line builds per account so concurrent
 	// callers for the same account — regardless of direction — coalesce
@@ -91,6 +100,7 @@ func NewRippleLineCache(ledger tx.LedgerView) *RippleLineCache {
 	return &RippleLineCache{
 		ledger: ledger,
 		lines:  make(map[accountKey][]PathFindTrustLine),
+		mpts:   make(map[[20]byte][]PathFindMPT),
 	}
 }
 
@@ -147,6 +157,76 @@ func (c *RippleLineCache) GetRippleLines(account [20]byte, direction LineDirecti
 	}
 	c.mu.Unlock()
 	return lines
+}
+
+// GetMPTs returns the MPT issuances and holdings owned by account.
+func (c *RippleLineCache) GetMPTs(account [20]byte) []PathFindMPT {
+	c.mu.RLock()
+	cached, ok := c.mpts[account]
+	c.mu.RUnlock()
+	if ok {
+		return cached
+	}
+
+	builderAny, _ := c.builders.LoadOrStore(account, &sync.Mutex{})
+	builder := builderAny.(*sync.Mutex)
+	builder.Lock()
+	defer builder.Unlock()
+
+	c.mu.RLock()
+	cached, ok = c.mpts[account]
+	c.mu.RUnlock()
+	if ok {
+		return cached
+	}
+
+	mpts := c.buildMPTs(account)
+	c.mu.Lock()
+	c.mpts[account] = mpts
+	c.mu.Unlock()
+	return mpts
+}
+
+func (c *RippleLineCache) buildMPTs(account [20]byte) []PathFindMPT {
+	var mpts []PathFindMPT
+	_ = state.DirForEach(c.ledger, keylet.OwnerDir(account), func(itemKey [32]byte) error {
+		data, err := c.ledger.Read(keylet.Keylet{Key: itemKey})
+		if err != nil || data == nil {
+			return nil
+		}
+
+		switch state.EntryType(data) {
+		case "MPTokenIssuance":
+			issuance, err := state.ParseMPTokenIssuance(data)
+			if err != nil || issuance.Issuer != account {
+				return nil
+			}
+			id := keylet.MakeMPTID(issuance.Sequence, account)
+			mpts = append(mpts, PathFindMPT{
+				ID:       id,
+				MaxedOut: issuance.OutstandingAmount == mptutil.MaximumAmount(issuance),
+			})
+			return nil
+		case "MPToken":
+			holding, err := state.ParseMPToken(data)
+			if err != nil || holding.Account != account {
+				return nil
+			}
+			maxedOut := true
+			if issuance, _, result := mptutil.ReadIssuance(c.ledger, holding.MPTokenIssuanceID); result.IsSuccess() {
+				maxedOut = issuance.OutstandingAmount == mptutil.MaximumAmount(issuance)
+			}
+			mpts = append(mpts, PathFindMPT{
+				ID:          holding.MPTokenIssuanceID,
+				ZeroBalance: holding.MPTAmount == 0,
+				MaxedOut:    maxedOut,
+			})
+			return nil
+		default:
+			return nil
+		}
+	})
+	return mpts
 }
 
 // lookup returns a cached slice for the requested (account, direction)

--- a/internal/tx/payment/pathfinder/ripple_line_cache.go
+++ b/internal/tx/payment/pathfinder/ripple_line_cache.go
@@ -65,7 +65,6 @@ type PathFindTrustLine struct {
 	Currency string
 }
 
-// PathFindMPT describes an account's relationship to an MPT issuance.
 type PathFindMPT struct {
 	ID          [24]byte
 	ZeroBalance bool
@@ -159,7 +158,6 @@ func (c *RippleLineCache) GetRippleLines(account [20]byte, direction LineDirecti
 	return lines
 }
 
-// GetMPTs returns the MPT issuances and holdings owned by account.
 func (c *RippleLineCache) GetMPTs(account [20]byte) []PathFindMPT {
 	c.mu.RLock()
 	cached, ok := c.mpts[account]

--- a/internal/tx/payment/payment.go
+++ b/internal/tx/payment/payment.go
@@ -132,10 +132,10 @@ func (p *Payment) RequiredAmendments() [][32]byte {
 }
 
 // GetFlagsMask returns the invalid-flags mask enforced by the engine at the
-// preflight0 position, mirroring rippled Payment::getFlagsMask: an MPT-denominated
-// Amount uses tfMPTPaymentMask, everything else tfPaymentMask.
-func (p *Payment) GetFlagsMask(*amendment.Rules) uint32 {
-	if p.isMPTDirect() {
+// preflight0 position. An MPT-denominated Amount uses the restricted MPTokensV1
+// mask until MPTokensV2 enables the regular payment flag surface.
+func (p *Payment) GetFlagsMask(rules *amendment.Rules) uint32 {
+	if p.isMPTDirect() && !rules.MPTokensV2Enabled() {
 		return tfMPTPaymentMask
 	}
 	return tfPaymentMask

--- a/internal/tx/payment/payment.go
+++ b/internal/tx/payment/payment.go
@@ -55,11 +55,12 @@ type Payment struct {
 
 // PathStep represents a single step in a payment path
 type PathStep struct {
-	Account  string `json:"account,omitempty"`
-	Currency string `json:"currency,omitempty"`
-	Issuer   string `json:"issuer,omitempty"`
-	Type     int    `json:"type,omitempty"`
-	TypeHex  string `json:"type_hex,omitempty"`
+	Account       string `json:"account,omitempty"`
+	Currency      string `json:"currency,omitempty"`
+	Issuer        string `json:"issuer,omitempty"`
+	MPTIssuanceID string `json:"mpt_issuance_id,omitempty"`
+	Type          int    `json:"type,omitempty"`
+	TypeHex       string `json:"type_hex,omitempty"`
 }
 
 // Payment flags

--- a/internal/tx/payment/payment.go
+++ b/internal/tx/payment/payment.go
@@ -41,10 +41,6 @@ type Payment struct {
 	// Reference: rippled sfCredentialIDs
 	CredentialIDs []string `json:"CredentialIDs,omitempty" xrpl:"CredentialIDs,omitempty"`
 
-	// MPTokenIssuanceID is the issuance ID for MPT direct payments (optional).
-	// When set, the payment follows the MPT direct path instead of IOU trust line path.
-	MPTokenIssuanceID string `json:"MPTokenIssuanceID,omitempty" xrpl:"MPTokenIssuanceID,omitempty"`
-
 	// DomainID is the permissioned domain for this payment (optional).
 	// When set, only offers within the specified domain are consumed on the payment path.
 	// Both sender and destination must be members of the domain.
@@ -120,7 +116,7 @@ func (p *Payment) GetDomainID() (*[32]byte, bool) {
 // mirror rippled's checkExtraFeatures gates (sfCredentialIDs → featureCredentials,
 // sfDomainID → featurePermissionedDEX), which the engine evaluates before the
 // flags mask. The MPT gate is NOT here: rippled evaluates it inside the preflight
-// body, AFTER the mask, so it lives in PreflightRules.
+// body, AFTER the mask, so it lives in PreflightWithRules.
 func (p *Payment) RequiredAmendments() [][32]byte {
 	var amendments [][32]byte
 	if p.CredentialIDs != nil || p.HasField("CredentialIDs") {
@@ -136,82 +132,57 @@ func (p *Payment) RequiredAmendments() [][32]byte {
 // preflight0 position. An MPT-denominated Amount uses the restricted MPTokensV1
 // mask until MPTokensV2 enables the regular payment flag surface.
 func (p *Payment) GetFlagsMask(rules *amendment.Rules) uint32 {
-	if p.isMPTDirect() && !rules.MPTokensV2Enabled() {
+	if p.Amount.IsMPT() && !rules.MPTokensV2Enabled() {
 		return tfMPTPaymentMask
 	}
 	return tfPaymentMask
 }
 
-// PreflightRules carries the amendment-gated tem* checks that rippled evaluates
-// inside Payment::preflight (after the flags mask). The MPT-amount temDISABLED
-// gate must run after the mask so an MPT payment carrying a mask-invalid flag
-// surfaces temINVALID_FLAG, not temDISABLED.
-func (p *Payment) PreflightRules(rules *amendment.Rules) error {
-	if p.isMPTDirect() && !rules.Enabled(amendment.FeatureMPTokensV1) {
-		return ter.Errorf(ter.TemDISABLED, "MPT payment requires MPTokensV1 amendment")
-	}
-	// A zero DomainID is invalid: keylet::permissionedDomain uses the DomainID
-	// as the ledger key, so a zero DomainID can never name a domain entry.
-	if p.DomainID != nil && rules.FixCleanup3_2_0Enabled() {
-		if id, err := permissioneddomain.ParseDomainID(*p.DomainID); err == nil && id == ([32]byte{}) {
-			return ter.Errorf(ter.TemMALFORMED, "DomainID cannot be zero")
-		}
-	}
-	return nil
-}
-
-// isMPTDirect returns true if this payment is an MPT direct payment.
-// Checks both the legacy MPTokenIssuanceID field and the Amount's embedded mpt_issuance_id.
-// Reference: rippled Payment.cpp: bool const mptDirect = dstAmount.holds<MPTIssue>();
-func (p *Payment) isMPTDirect() bool {
-	return p.MPTokenIssuanceID != "" || p.Amount.IsMPT()
-}
-
-// Validate runs the rules-free structural preflight checks of Payment::preflight
-// in rippled's exact order. The flags mask (GetFlagsMask) is enforced by the
-// engine at the preflight0 position, before this body; the MPT amendment gate is
-// in PreflightRules, after the mask. Path-element shape validation is NOT done
-// here — rippled surfaces it at doApply (toStrand), so it lives in the strand
-// builder, letting preclaim codes (tecNO_DST, …) win as rippled intends.
 func (p *Payment) Validate() error {
+	return p.validate(nil)
+}
+
+func (p *Payment) PreflightWithRules(rules *amendment.Rules) error {
+	return p.validate(rules)
+}
+
+func (p *Payment) validate(rules *amendment.Rules) error {
 	if err := p.BaseTx.Validate(); err != nil {
 		return err
 	}
 
-	mptDirect := p.isMPTDirect()
-	flags := p.GetFlags()
-	hasPaths := len(p.Paths) > 0
-
-	// MPT payments cannot carry paths.
-	if mptDirect && hasPaths {
+	isDstMPT := p.Amount.IsMPT()
+	rulesAware := rules != nil
+	mpTokensV2 := rulesAware && rules.MPTokensV2Enabled()
+	hasPaths := len(p.Paths) > 0 || p.HasField("Paths")
+	if rulesAware && isDstMPT && !rules.Enabled(amendment.FeatureMPTokensV1) {
+		return ter.Errorf(ter.TemDISABLED, "MPT payment requires MPTokensV1 amendment")
+	}
+	if rulesAware && !mpTokensV2 && isDstMPT && hasPaths {
 		return ter.Errorf(ter.TemMALFORMED, "Paths not allowed for MPT payment")
 	}
+	if rulesAware && p.DomainID != nil && rules.FixCleanup3_2_0Enabled() {
+		if id, err := permissioneddomain.ParseDomainID(*p.DomainID); err == nil && id == ([32]byte{}) {
+			return ter.Errorf(ter.TemMALFORMED, "DomainID cannot be zero")
+		}
+	}
 
-	// maxSourceAmount is SendMax when present, else the delivered Amount. The
-	// inconsistent-issues check rejects an MPT Amount whose source asset differs,
-	// and an MPT SendMax paired with a non-MPT Amount.
+	flags := p.GetFlags()
 	srcAmount := p.Amount
 	if p.SendMax != nil {
 		srcAmount = *p.SendMax
 	}
-	if p.Amount.IsMPT() {
-		if p.SendMax != nil && (!p.SendMax.IsMPT() ||
-			p.SendMax.MPTIssuanceID() != p.Amount.MPTIssuanceID()) {
-			return ter.Errorf(ter.TemMALFORMED, "Inconsistent MPT issues in Amount and SendMax")
-		}
-	} else if !mptDirect && srcAmount.IsMPT() {
-		return ter.Errorf(ter.TemMALFORMED, "MPT SendMax not allowed for non-MPT payment")
+	if rulesAware && !mpTokensV2 && ((isDstMPT && !sameAsset(p.Amount, srcAmount)) ||
+		(!isDstMPT && srcAmount.IsMPT())) {
+		return ter.Errorf(ter.TemMALFORMED, "Inconsistent MPT issues in Amount and SendMax")
 	}
 
 	xrpDirect := srcAmount.IsNative() && p.Amount.IsNative()
 
-	// isLegalNet(dstAmount) / isLegalNet(maxSourceAmount) — native magnitude cap.
 	if !isLegalNet(p.Amount) || !isLegalNet(srcAmount) {
 		return ter.Errorf(ter.TemBAD_AMOUNT, "amount exceeds native limit")
 	}
 
-	// temDST_NEEDED fires for a missing Destination field and for the zero
-	// AccountID (rippled `if (!dstAccountID)`), which is wire-valid and signable.
 	if p.Destination == "" {
 		return ter.Errorf(ter.TemDST_NEEDED, "Destination is required")
 	}
@@ -219,7 +190,6 @@ func (p *Payment) Validate() error {
 		return ter.Errorf(ter.TemDST_NEEDED, "Destination is required")
 	}
 
-	// maxSourceAmount and dstAmount must be strictly positive.
 	if p.SendMax != nil && (p.SendMax.IsZero() || p.SendMax.IsNegative()) {
 		return ter.Errorf(ter.TemBAD_AMOUNT, "SendMax must be positive")
 	}
@@ -227,16 +197,11 @@ func (p *Payment) Validate() error {
 		return ter.Errorf(ter.TemBAD_AMOUNT, "Amount must be positive")
 	}
 
-	// Reject "XRP" used as a non-native (IOU) currency code on either the source
-	// asset (SendMax if present, else Amount) or the destination asset.
-	if (!srcAmount.IsNative() && !srcAmount.IsMPT() && srcAmount.Currency == tx.BadCurrency) ||
-		(!p.Amount.IsNative() && !p.Amount.IsMPT() && p.Amount.Currency == tx.BadCurrency) {
-		return ter.Errorf(ter.TemBAD_CURRENCY, "cannot use XRP as non-native currency code")
+	if badPaymentAsset(srcAmount, mpTokensV2) || badPaymentAsset(p.Amount, mpTokensV2) {
+		return ter.Errorf(ter.TemBAD_CURRENCY, "invalid payment asset")
 	}
 
-	// Redundant self-payment: same account, same token, no paths. equalTokens
-	// compares the token (currency for IOU, issuance for MPT), NOT the issuer.
-	if p.Account == p.Destination && equalTokens(srcAmount, p.Amount, mptDirect) && !hasPaths {
+	if p.Account == p.Destination && equalTokens(srcAmount, p.Amount) && !hasPaths {
 		return ter.Errorf(ter.TemREDUNDANT, "cannot send to self without path")
 	}
 
@@ -247,22 +212,20 @@ func (p *Payment) Validate() error {
 	if xrpDirect && p.SendMax != nil {
 		return ter.Errorf(ter.TemBAD_SEND_XRP_MAX, "SendMax specified for XRP to XRP")
 	}
-	if (xrpDirect || mptDirect) && hasPaths {
+	legacyMPTDirect := rulesAware && !mpTokensV2 && isDstMPT
+	if (xrpDirect || legacyMPTDirect) && hasPaths {
 		return ter.Errorf(ter.TemBAD_SEND_XRP_PATHS, "Paths specified for XRP to XRP or MPT to MPT")
 	}
 	if xrpDirect && partialPaymentAllowed {
 		return ter.Errorf(ter.TemBAD_SEND_XRP_PARTIAL, "Partial payment specified for XRP to XRP")
 	}
-	if (xrpDirect || mptDirect) && limitQuality {
+	if (xrpDirect || legacyMPTDirect) && limitQuality {
 		return ter.Errorf(ter.TemBAD_SEND_XRP_LIMIT, "Limit quality specified for XRP to XRP or MPT to MPT")
 	}
-	if (xrpDirect || mptDirect) && noRippleDirect {
+	if (xrpDirect || legacyMPTDirect) && noRippleDirect {
 		return ter.Errorf(ter.TemBAD_SEND_XRP_NO_DIRECT, "No ripple direct specified for XRP to XRP or MPT to MPT")
 	}
 
-	// DeliverMin: requires tfPartialPayment, must be legal/positive, must hold the
-	// same asset as Amount (rippled dMin.asset() != dstAmount.asset()), and must
-	// not exceed Amount.
 	if p.DeliverMin != nil {
 		if !partialPaymentAllowed {
 			return ter.Errorf(ter.TemBAD_AMOUNT, "DeliverMin requires tfPartialPayment flag")
@@ -278,32 +241,31 @@ func (p *Payment) Validate() error {
 		}
 	}
 
-	// Path count/length limits are NOT checked here. rippled enforces them in
-	// preclaim, gated on an open ledger, returning telBAD_PATH_COUNT — see
-	// Payment.Preclaim() below.
-
-	// Path-element shape validation lives in the strand builder (strand.go), at
-	// doApply, matching rippled toStrand — so preclaim codes win over a malformed
-	// path. The sole exception is a type-zero element (none of account/currency/
-	// issuer): go-xrpl cannot serialize it, so it can never reach the strand
-	// builder. Reject it here to surface rippled's temBAD_PATH rather than an
-	// internal serialization failure.
 	for _, path := range p.Paths {
 		for _, elem := range path {
-			if elem.Account == "" && elem.Currency == "" && elem.Issuer == "" {
-				return ter.Errorf(ter.TemBAD_PATH, "path element has no account, currency, or issuer")
+			if elem.Account == "" && elem.Currency == "" && elem.Issuer == "" && elem.MPTIssuanceID == "" {
+				return ter.Errorf(ter.TemBAD_PATH, "path element has no account, currency, issuer, or MPT issuance")
 			}
 		}
 	}
 
-	// Validate CredentialIDs field. HasField detects an empty array supplied on
-	// the wire, which omitempty would otherwise collapse to a nil slice.
 	present := p.CredentialIDs != nil || p.HasField("CredentialIDs")
 	if err := credential.CheckFields(p.CredentialIDs, present, "Duplicate credential ID"); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func badPaymentAsset(a tx.Amount, mpTokensV2 bool) bool {
+	if !a.IsNative() && !a.IsMPT() {
+		return a.Currency == tx.BadCurrency
+	}
+	if !mpTokensV2 || !a.IsMPT() {
+		return false
+	}
+	id, ok := decodeMPTID(a.MPTIssuanceID())
+	return !ok || mptIssuer(id) == ([20]byte{})
 }
 
 // isLegalNet mirrors rippled STAmount isLegalNet: a native amount's magnitude may
@@ -319,17 +281,12 @@ func isLegalNet(a tx.Amount) bool {
 	return uint64(d) <= maxNativeDrops
 }
 
-// equalTokens mirrors rippled equalTokens: two IOU tokens are equal iff their
-// currencies match (issuer ignored); two MPT tokens iff their issuances match;
-// two native amounts are always equal; any cross-kind pair is unequal. mptDirect
-// signals both sides are the same MPT issuance (the inconsistent-issues check
-// above already guaranteed it).
-func equalTokens(src, dst tx.Amount, mptDirect bool) bool {
+func equalTokens(src, dst tx.Amount) bool {
 	switch {
 	case src.IsNative() && dst.IsNative():
 		return true
-	case mptDirect:
-		return true
+	case src.IsMPT() && dst.IsMPT():
+		return src.MPTIssuanceID() == dst.MPTIssuanceID()
 	case !src.IsNative() && !src.IsMPT() && !dst.IsNative() && !dst.IsMPT():
 		return src.Currency == dst.Currency
 	default:
@@ -347,29 +304,20 @@ func equalTokens(src, dst tx.Amount, mptDirect bool) bool {
 // credential code.
 // Reference: rippled Payment.cpp:282-378
 func (p *Payment) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Result {
-	// Destination-existence branching for non-MPT payments. MPT direct
-	// payments resolve the destination inside Apply.
-	// Reference: rippled Payment.cpp:296-346
-	if !p.isMPTDirect() {
-		if destID, err := state.DecodeAccountID(p.Destination); err == nil {
-			destAccount, destExists := state.ReadAccountRoot(view, destID)
-			if !destExists {
-				// A non-native delivered amount cannot create the account.
-				if !p.Amount.IsNative() {
-					return ter.TecNO_DST
-				}
-				// A partial payment may not fund a new account on an open ledger.
-				if config.OpenLedger && (p.GetFlags()&PaymentFlagPartialPayment) != 0 {
-					return ter.TelNO_DST_PARTIAL
-				}
-				// The delivered amount must cover the account reserve.
-				if uint64(p.Amount.Drops()) < config.ReserveBase {
-					return ter.TecNO_DST_INSUF_XRP
-				}
-			} else if (destAccount.Flags&state.LsfRequireDestTag) != 0 && p.DestinationTag == nil {
-				// A newly-formed account is exempt — it has no way to set the flag.
-				return ter.TecDST_TAG_NEEDED
+	if destID, err := state.DecodeAccountID(p.Destination); err == nil {
+		destAccount, destExists := state.ReadAccountRoot(view, destID)
+		if !destExists {
+			if !p.Amount.IsNative() {
+				return ter.TecNO_DST
 			}
+			if config.OpenLedger && (p.GetFlags()&PaymentFlagPartialPayment) != 0 {
+				return ter.TelNO_DST_PARTIAL
+			}
+			if uint64(p.Amount.Drops()) < config.ReserveBase {
+				return ter.TecNO_DST_INSUF_XRP
+			}
+		} else if (destAccount.Flags&state.LsfRequireDestTag) != 0 && p.DestinationTag == nil {
+			return ter.TecDST_TAG_NEEDED
 		}
 	}
 
@@ -377,7 +325,7 @@ func (p *Payment) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Resul
 	// payments (those that use transitive balances).
 	// Reference: rippled Payment.cpp:348-360
 	if config.OpenLedger {
-		ripple := len(p.Paths) > 0 || p.SendMax != nil || !p.Amount.IsNative()
+		ripple := len(p.Paths) > 0 || p.HasField("Paths") || p.SendMax != nil || !p.Amount.IsNative()
 		if ripple {
 			if len(p.Paths) > MaxPathSize {
 				return ter.TelBAD_PATH_COUNT
@@ -454,6 +402,9 @@ func (p *Payment) Flatten() (map[string]any, error) {
 				if step.Issuer != "" {
 					stepMap["issuer"] = step.Issuer
 				}
+				if step.MPTIssuanceID != "" {
+					stepMap["mpt_issuance_id"] = step.MPTIssuanceID
+				}
 				pathSteps[j] = stepMap
 			}
 			pathSet[i] = pathSteps
@@ -477,7 +428,8 @@ func (p *Payment) SetNoDirectRipple() {
 }
 
 func (p *Payment) Apply(ctx *tx.ApplyContext) ter.Result {
-	mptDirect := p.isMPTDirect()
+	isDstMPT := p.Amount.IsMPT()
+	mpTokensV2 := ctx.Rules().MPTokensV2Enabled()
 
 	ctx.Log.Trace("payment apply",
 		"src", p.Account,
@@ -485,26 +437,18 @@ func (p *Payment) Apply(ctx *tx.ApplyContext) ter.Result {
 		"amount", p.Amount,
 		"hasPaths", len(p.Paths) > 0,
 		"hasSendMax", p.SendMax != nil,
-		"mpt", mptDirect,
+		"mpt", isDstMPT,
 	)
 
-	// MPT direct payment
-	if mptDirect {
+	hasPaths := len(p.Paths) > 0 || p.HasField("Paths")
+	hasSendMax := p.SendMax != nil
+	ripple := (hasPaths || hasSendMax || !p.Amount.IsNative()) && (!isDstMPT || mpTokensV2)
+	if ripple {
+		return p.applyIOUPayment(ctx)
+	}
+	if isDstMPT {
 		return p.applyMPTPayment(ctx)
 	}
 
-	// Determine if this is a "ripple" payment (uses the flow engine).
-	// Reference: rippled Payment.cpp:435-436:
-	//   bool const ripple = (hasPaths || sendMax || !dstAmount.native()) && !mptDirect;
-	hasPaths := len(p.Paths) > 0
-	hasSendMax := p.SendMax != nil
-	ripple := (hasPaths || hasSendMax || !p.Amount.IsNative()) && !mptDirect
-
-	if !ripple {
-		// XRP-to-XRP direct payment (no paths, no SendMax, Amount is native)
-		return p.applyXRPPayment(ctx)
-	}
-
-	// IOU / cross-currency payment - uses the flow engine
-	return p.applyIOUPayment(ctx)
+	return p.applyXRPPayment(ctx)
 }

--- a/internal/tx/payment/payment_iou.go
+++ b/internal/tx/payment/payment_iou.go
@@ -26,8 +26,8 @@ func (p *Payment) checkIOUDestPreamble(ctx *tx.ApplyContext, senderID, destID [2
 	return ter.TesSUCCESS
 }
 
-// applyIOUPayment applies an IOU (issued currency) or cross-currency payment.
-// This is called for any payment with paths, SendMax, or non-native Amount.
+// applyIOUPayment applies payments routed through Flow, including IOU,
+// cross-currency, and MPTokensV2 payments.
 // Reference: rippled/src/xrpld/app/tx/detail/Payment.cpp
 func (p *Payment) applyIOUPayment(ctx *tx.ApplyContext) ter.Result {
 	// Validate the amount
@@ -57,9 +57,10 @@ func (p *Payment) applyIOUPayment(ctx *tx.ApplyContext) ter.Result {
 		return p.applyRipplePayment(ctx, senderAccountID, destAccountID)
 	}
 
-	issuerAccountID, err := state.DecodeAccountID(p.Amount.Issuer)
-	if err != nil {
-		return ter.TemBAD_ISSUER
+	if !p.Amount.IsMPT() {
+		if _, err := state.DecodeAccountID(p.Amount.Issuer); err != nil {
+			return ter.TemBAD_ISSUER
+		}
 	}
 
 	// Check destination exists (needed for DepositAuth check and destination flags)
@@ -101,7 +102,7 @@ func (p *Payment) applyIOUPayment(ctx *tx.ApplyContext) ter.Result {
 		return ter.TefINTERNAL
 	}
 
-	return p.applyIOUPaymentWithPaths(ctx, senderAccountID, destAccountID, issuerAccountID)
+	return p.applyIOUPaymentWithPaths(ctx, senderAccountID, destAccountID)
 }
 
 // applyRipplePayment handles cross-currency payments where Amount is XRP but
@@ -161,8 +162,7 @@ func (p *Payment) applyRipplePayment(ctx *tx.ApplyContext, senderID, destID [20]
 
 		// A freshly created account carries no flags, so destination-tag and
 		// deposit-authorization checks do not apply.
-		var zeroID [20]byte
-		return p.applyIOUPaymentWithPaths(ctx, senderID, destID, zeroID)
+		return p.applyIOUPaymentWithPaths(ctx, senderID, destID)
 	}
 
 	destData, err := ctx.View.Read(destKey)
@@ -188,15 +188,13 @@ func (p *Payment) applyRipplePayment(ctx *tx.ApplyContext, senderID, destID [20]
 		return ter.TefINTERNAL
 	}
 
-	// Use the flow engine (issuerID is unused for XRP amount, pass zero)
-	var zeroID [20]byte
-	return p.applyIOUPaymentWithPaths(ctx, senderID, destID, zeroID)
+	return p.applyIOUPaymentWithPaths(ctx, senderID, destID)
 }
 
 // applyIOUPaymentWithPaths handles IOU payments that require path finding using the Flow Engine.
 // This is the main entry point for cross-currency payments and payments with explicit paths.
 // Reference: rippled/src/xrpld/app/paths/RippleCalc.cpp
-func (p *Payment) applyIOUPaymentWithPaths(ctx *tx.ApplyContext, senderID, destID, issuerID [20]byte) ter.Result {
+func (p *Payment) applyIOUPaymentWithPaths(ctx *tx.ApplyContext, senderID, destID [20]byte) ter.Result {
 	// Determine payment flags
 	flags := p.GetFlags()
 	partialPayment := (flags & PaymentFlagPartialPayment) != 0

--- a/internal/tx/payment/payment_mpt.go
+++ b/internal/tx/payment/payment_mpt.go
@@ -16,13 +16,7 @@ import (
 // applyMPTPayment applies an MPT direct payment.
 // Reference: rippled Payment.cpp doApply() mptDirect path + View.cpp rippleSendMPT/rippleCreditMPT
 func (p *Payment) applyMPTPayment(ctx *tx.ApplyContext) ter.Result {
-	// Get the MPT issuance ID: prefer the legacy field, fall back to Amount's embedded ID
-	mptIDHex := p.MPTokenIssuanceID
-	if mptIDHex == "" {
-		mptIDHex = p.Amount.MPTIssuanceID()
-	}
-
-	// Parse MPTokenIssuanceID
+	mptIDHex := p.Amount.MPTIssuanceID()
 	issuanceIDBytes, err := hex.DecodeString(mptIDHex)
 	if err != nil || len(issuanceIDBytes) != 24 {
 		return ter.TecOBJECT_NOT_FOUND

--- a/internal/tx/payment/payment_mpt_codec_test.go
+++ b/internal/tx/payment/payment_mpt_codec_test.go
@@ -1,0 +1,61 @@
+package payment
+
+import (
+	"encoding/hex"
+	"os"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	tx "github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+func TestMain(m *testing.M) {
+	Register()
+	os.Exit(m.Run())
+}
+
+func TestPaymentMPTPathBinaryRoundTrip(t *testing.T) {
+	p := NewPayment(
+		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+		paymentMPTAmount(100, paymentMPTIDA),
+	)
+	p.Fee = "10"
+	p.SetSequence(1)
+	p.Paths = [][]PathStep{{{MPTIssuanceID: paymentMPTIDB}}}
+
+	flat, err := p.Flatten()
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	encoded, err := binarycodec.Encode(flat)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	blob, err := hex.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("DecodeString: %v", err)
+	}
+	parsedTx, err := tx.ParseFromBinary(blob)
+	if err != nil {
+		t.Fatalf("ParseFromBinary: %v", err)
+	}
+	parsed, ok := parsedTx.(*Payment)
+	if !ok {
+		t.Fatalf("parsed transaction type = %T, want *Payment", parsedTx)
+	}
+	if !parsed.Amount.IsMPT() || parsed.Amount.MPTIssuanceID() != paymentMPTIDA {
+		t.Fatalf("parsed Amount = %#v, want MPT issuance %s", parsed.Amount, paymentMPTIDA)
+	}
+	if len(parsed.Paths) != 1 || len(parsed.Paths[0]) != 1 ||
+		parsed.Paths[0][0].MPTIssuanceID != paymentMPTIDB {
+		t.Fatalf("parsed Paths = %#v, want MPT issuance %s", parsed.Paths, paymentMPTIDB)
+	}
+	rules := paymentMPTV2Rules()
+	if mask := parsed.GetFlagsMask(rules); mask != tfPaymentMask {
+		t.Fatalf("GetFlagsMask() = 0x%08X, want 0x%08X", mask, tfPaymentMask)
+	}
+	if err := parsed.PreflightWithRules(rules); err != nil {
+		t.Fatalf("PreflightWithRules: %v", err)
+	}
+}

--- a/internal/tx/payment/payment_mpt_v2_test.go
+++ b/internal/tx/payment/payment_mpt_v2_test.go
@@ -1,0 +1,234 @@
+package payment
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+const (
+	paymentMPTIDA        = "00000000000000000000000000000000000000000000000A"
+	paymentMPTIDB        = "00000000000000000000000000000000000000000000000B"
+	paymentZeroIssuerMPT = "000000010000000000000000000000000000000000000000"
+)
+
+func paymentMPTAmount(value int64, id string) tx.Amount {
+	return state.NewMPTAmountWithIssuanceID(value, "rIssuer", id)
+}
+
+func paymentMPTV1Rules() *amendment.Rules {
+	return amendment.NewRules([][32]byte{amendment.FeatureMPTokensV1})
+}
+
+func paymentMPTV2Rules() *amendment.Rules {
+	return amendment.NewRules([][32]byte{
+		amendment.FeatureMPTokensV1,
+		amendment.FeatureMPTokensV2,
+	})
+}
+
+func requirePaymentResultError(t *testing.T, err error, want ter.Result) {
+	t.Helper()
+	resultErr, ok := ter.AsResultError(err)
+	if !ok || resultErr.Code != want {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+}
+
+func TestPaymentMPTV2FlagsMaskUsesAmountAsset(t *testing.T) {
+	mptAmount := paymentMPTAmount(100, paymentMPTIDA)
+	mptSendMax := paymentMPTAmount(110, paymentMPTIDA)
+
+	tests := []struct {
+		name    string
+		payment *Payment
+		rules   *amendment.Rules
+		want    uint32
+	}{
+		{
+			name:    "MPT amount under MPTokensV1",
+			payment: NewPayment("rAlice", "rBob", mptAmount),
+			rules:   paymentMPTV1Rules(),
+			want:    tfMPTPaymentMask,
+		},
+		{
+			name:    "MPT amount under MPTokensV2",
+			payment: NewPayment("rAlice", "rBob", mptAmount),
+			rules:   paymentMPTV2Rules(),
+			want:    tfPaymentMask,
+		},
+		{
+			name: "non-MPT amount with MPT SendMax under MPTokensV1",
+			payment: func() *Payment {
+				p := NewPayment("rAlice", "rBob", xrpAmount("100"))
+				p.SendMax = &mptSendMax
+				return p
+			}(),
+			rules: paymentMPTV1Rules(),
+			want:  tfPaymentMask,
+		},
+		{
+			name: "non-MPT amount with MPT SendMax under MPTokensV2",
+			payment: func() *Payment {
+				p := NewPayment("rAlice", "rBob", xrpAmount("100"))
+				p.SendMax = &mptSendMax
+				return p
+			}(),
+			rules: paymentMPTV2Rules(),
+			want:  tfPaymentMask,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.payment.GetFlagsMask(test.rules); got != test.want {
+				t.Fatalf("GetFlagsMask() = 0x%08X, want 0x%08X", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPaymentMPTV2RulesAwareValidation(t *testing.T) {
+	newMPTPayment := func() *Payment {
+		return NewPayment("rAlice", "rBob", paymentMPTAmount(100, paymentMPTIDA))
+	}
+
+	tests := []struct {
+		name   string
+		build  func() *Payment
+		v1Code ter.Result
+	}{
+		{
+			name: "MPT path",
+			build: func() *Payment {
+				p := newMPTPayment()
+				p.Paths = [][]PathStep{{{MPTIssuanceID: paymentMPTIDB}}}
+				return p
+			},
+			v1Code: ter.TemMALFORMED,
+		},
+		{
+			name: "MPT destination with XRP SendMax",
+			build: func() *Payment {
+				p := newMPTPayment()
+				sendMax := xrpAmount("110")
+				p.SendMax = &sendMax
+				return p
+			},
+			v1Code: ter.TemMALFORMED,
+		},
+		{
+			name: "IOU destination with MPT SendMax",
+			build: func() *Payment {
+				p := NewPayment("rAlice", "rBob", iouAmount("100", "USD", "rIssuer"))
+				sendMax := paymentMPTAmount(110, paymentMPTIDA)
+				p.SendMax = &sendMax
+				return p
+			},
+			v1Code: ter.TemMALFORMED,
+		},
+		{
+			name: "limit quality",
+			build: func() *Payment {
+				p := newMPTPayment()
+				p.SetFlags(PaymentFlagLimitQuality)
+				return p
+			},
+			v1Code: ter.TemBAD_SEND_XRP_LIMIT,
+		},
+		{
+			name: "no direct ripple",
+			build: func() *Payment {
+				p := newMPTPayment()
+				p.SetFlags(PaymentFlagNoDirectRipple)
+				return p
+			},
+			v1Code: ter.TemBAD_SEND_XRP_NO_DIRECT,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.build().Validate(); err != nil {
+				t.Fatalf("amendment-neutral Validate() returned %v", err)
+			}
+
+			requirePaymentResultError(t, test.build().PreflightWithRules(paymentMPTV1Rules()), test.v1Code)
+
+			if err := test.build().PreflightWithRules(paymentMPTV2Rules()); err != nil {
+				t.Fatalf("MPTokensV2 preflight returned %v", err)
+			}
+		})
+	}
+}
+
+func TestPaymentMPTV2SelfPaymentUsesIssuanceIdentity(t *testing.T) {
+	amountA := paymentMPTAmount(100, paymentMPTIDA)
+	sameIssue := paymentMPTAmount(110, paymentMPTIDA)
+	differentIssue := paymentMPTAmount(110, paymentMPTIDB)
+
+	if !equalTokens(amountA, sameIssue) {
+		t.Fatal("equalTokens() rejected the same MPT issuance")
+	}
+	if equalTokens(amountA, differentIssue) {
+		t.Fatal("equalTokens() accepted different MPT issuances")
+	}
+
+	same := NewPayment("rAlice", "rAlice", amountA)
+	same.SendMax = &sameIssue
+	requirePaymentResultError(t, same.PreflightWithRules(paymentMPTV2Rules()), ter.TemREDUNDANT)
+
+	different := NewPayment("rAlice", "rAlice", amountA)
+	different.SendMax = &differentIssue
+	if err := different.PreflightWithRules(paymentMPTV2Rules()); err != nil {
+		t.Fatalf("different-issuance self-payment returned %v", err)
+	}
+}
+
+func TestPaymentMPTV2RejectsZeroIssuerAsset(t *testing.T) {
+	amount := paymentMPTAmount(100, paymentZeroIssuerMPT)
+	p := NewPayment("rAlice", "rBob", amount)
+
+	if err := p.Validate(); err != nil {
+		t.Fatalf("amendment-neutral Validate() returned %v", err)
+	}
+	if err := p.PreflightWithRules(paymentMPTV1Rules()); err != nil {
+		t.Fatalf("MPTokensV1 preflight returned %v", err)
+	}
+	requirePaymentResultError(t, p.PreflightWithRules(paymentMPTV2Rules()), ter.TemBAD_CURRENCY)
+}
+
+func TestPaymentMPTPathStepValidationAndFlatten(t *testing.T) {
+	p := NewPayment("rAlice", "rBob", paymentMPTAmount(100, paymentMPTIDA))
+	p.Paths = [][]PathStep{{{MPTIssuanceID: paymentMPTIDB}}}
+
+	if err := p.Validate(); err != nil {
+		t.Fatalf("Validate() treated an MPT-only path step as empty: %v", err)
+	}
+	if err := p.PreflightWithRules(paymentMPTV2Rules()); err != nil {
+		t.Fatalf("MPTokensV2 preflight treated an MPT-only path step as empty: %v", err)
+	}
+
+	flat, err := p.Flatten()
+	if err != nil {
+		t.Fatalf("Flatten() returned %v", err)
+	}
+	paths, ok := flat["Paths"].([]any)
+	if !ok || len(paths) != 1 {
+		t.Fatalf("Paths = %#v, want one path", flat["Paths"])
+	}
+	steps, ok := paths[0].([]any)
+	if !ok || len(steps) != 1 {
+		t.Fatalf("path = %#v, want one step", paths[0])
+	}
+	step, ok := steps[0].(map[string]any)
+	if !ok {
+		t.Fatalf("step = %#v, want map[string]any", steps[0])
+	}
+	if got := step["mpt_issuance_id"]; got != paymentMPTIDB {
+		t.Fatalf("mpt_issuance_id = %v, want %s", got, paymentMPTIDB)
+	}
+}

--- a/internal/tx/payment/payment_test.go
+++ b/internal/tx/payment/payment_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -382,6 +383,28 @@ func TestPaymentFlags(t *testing.T) {
 			t.Error("tfPartialPayment flag should be set when using DeliverMin")
 		}
 	})
+}
+
+func TestPaymentGetFlagsMaskMPTokensV2(t *testing.T) {
+	amount := state.NewMPTAmountWithIssuanceID(
+		100,
+		"r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59",
+		"000000000000000000000000000000000000000000000001",
+	)
+	payment := NewPayment("rAlice", "rBob", amount)
+
+	v1Rules := amendment.NewRules([][32]byte{amendment.FeatureMPTokensV1})
+	if got := payment.GetFlagsMask(v1Rules); got != tfMPTPaymentMask {
+		t.Fatalf("MPTokensV1 mask = 0x%08X, want 0x%08X", got, tfMPTPaymentMask)
+	}
+
+	v2Rules := amendment.NewRules([][32]byte{
+		amendment.FeatureMPTokensV1,
+		amendment.FeatureMPTokensV2,
+	})
+	if got := payment.GetFlagsMask(v2Rules); got != tfPaymentMask {
+		t.Fatalf("MPTokensV2 mask = 0x%08X, want 0x%08X", got, tfPaymentMask)
+	}
 }
 
 // TestPaymentSendMax tests SendMax field validation.

--- a/internal/tx/payment/quality.go
+++ b/internal/tx/payment/quality.go
@@ -52,17 +52,8 @@ func QualityFromAmounts(in, out EitherAmount) Quality {
 	// Convert both amounts to IOU-style for precise integer division.
 	// Reference: rippled's getRate() calls divide() which normalizes XRP amounts
 	// to [10^15, 10^16) mantissa range before performing the division.
-	var inAmt, outAmt tx.Amount
-	if in.IsNative {
-		inAmt = state.NewIssuedAmountFromValue(in.XRP, 0, "", "")
-	} else {
-		inAmt = in.IOU
-	}
-	if out.IsNative {
-		outAmt = state.NewIssuedAmountFromValue(out.XRP, 0, "", "")
-	} else {
-		outAmt = out.IOU
-	}
+	inAmt := toNumberAmount(in)
+	outAmt := toNumberAmount(out)
 
 	if outAmt.IsZero() {
 		return Quality{Value: 0}
@@ -218,14 +209,13 @@ func (q Quality) CeilOutStrict(amtIn, amtOut EitherAmount, limit EitherAmount, r
 	qRate := q.Rate()
 
 	var limitAmt tx.Amount
-	if limit.IsNative {
-		limitAmt = state.NewIssuedAmountFromValue(limit.XRP, 0, "", "")
-	} else {
-		limitAmt = limit.IOU
+	limitAmt = toNumberAmount(limit)
+	if limit.IsMPT {
+		limitAmt = FromEitherAmount(limit)
 	}
 
 	var inCurrency, inIssuer string
-	if amtIn.IsNative {
+	if amtIn.IsNative || amtIn.IsMPT {
 		inCurrency = ""
 		inIssuer = ""
 	} else {
@@ -242,6 +232,9 @@ func (q Quality) CeilOutStrict(amtIn, amtOut EitherAmount, limit EitherAmount, r
 		// product to a 16-digit mantissa and discards any sub-drop remainder, so
 		// the subsequent drops canonicalize has nothing left to round up.
 		resultInEither = NewXRPEitherAmount(state.MulRoundNativeStrict(limitAmt, qRate, roundUp))
+	} else if amtIn.IsMPT {
+		value := state.MulRoundMPTStrict(limitAmt, qRate, roundUp)
+		resultInEither = NewMPTEitherAmount(value, amtIn.MPTID)
 	} else {
 		resultIn := state.MulRoundStrict(limitAmt, qRate, inCurrency, inIssuer, roundUp)
 		resultInEither = NewIOUEitherAmount(tx.NewIssuedAmount(
@@ -268,14 +261,13 @@ func (q Quality) CeilIn(amtIn, amtOut EitherAmount, limit EitherAmount) (EitherA
 	qRate := q.Rate()
 
 	var limitAmt tx.Amount
-	if limit.IsNative {
-		limitAmt = state.NewIssuedAmountFromValue(limit.XRP, 0, "", "")
-	} else {
-		limitAmt = limit.IOU
+	limitAmt = toNumberAmount(limit)
+	if limit.IsMPT {
+		limitAmt = FromEitherAmount(limit)
 	}
 
 	var outCurrency, outIssuer string
-	if amtOut.IsNative {
+	if amtOut.IsNative || amtOut.IsMPT {
 		outCurrency = ""
 		outIssuer = ""
 	} else {
@@ -291,6 +283,9 @@ func (q Quality) CeilIn(amtIn, amtOut EitherAmount, limit EitherAmount) (EitherA
 		// uses different rounding than the native path and causes off-by-one errors.
 		// Reference: rippled STAmount.cpp divRoundImpl + canonicalizeRound(native=true)
 		resultOutEither = NewXRPEitherAmount(state.DivRoundNative(limitAmt, qRate, true))
+	} else if amtOut.IsMPT {
+		value := state.DivRoundMPT(limitAmt, qRate, true)
+		resultOutEither = NewMPTEitherAmount(value, amtOut.MPTID)
 	} else {
 		// Non-strict: divRound with roundUp=true (matching rippled's ceil_in which uses divRound)
 		resultOut := state.DivRound(limitAmt, qRate, outCurrency, outIssuer, true)
@@ -318,14 +313,13 @@ func (q Quality) CeilInStrict(amtIn, amtOut EitherAmount, limit EitherAmount, ro
 	qRate := q.Rate()
 
 	var limitAmt tx.Amount
-	if limit.IsNative {
-		limitAmt = state.NewIssuedAmountFromValue(limit.XRP, 0, "", "")
-	} else {
-		limitAmt = limit.IOU
+	limitAmt = toNumberAmount(limit)
+	if limit.IsMPT {
+		limitAmt = FromEitherAmount(limit)
 	}
 
 	var outCurrency, outIssuer string
-	if amtOut.IsNative {
+	if amtOut.IsNative || amtOut.IsMPT {
 		outCurrency = ""
 		outIssuer = ""
 	} else {
@@ -341,6 +335,9 @@ func (q Quality) CeilInStrict(amtIn, amtOut EitherAmount, limit EitherAmount, ro
 		// the IOU DivRoundStrict first collapses the product to a 16-digit mantissa
 		// and discards any sub-drop remainder before the drops canonicalize.
 		resultOutEither = NewXRPEitherAmount(state.DivRoundNativeStrict(limitAmt, qRate, roundUp))
+	} else if amtOut.IsMPT {
+		value := state.DivRoundMPTStrict(limitAmt, qRate, roundUp)
+		resultOutEither = NewMPTEitherAmount(value, amtOut.MPTID)
 	} else {
 		resultOut := state.DivRoundStrict(limitAmt, qRate, outCurrency, outIssuer, roundUp)
 		resultOutEither = NewIOUEitherAmount(tx.NewIssuedAmount(

--- a/internal/tx/payment/quality_function.go
+++ b/internal/tx/payment/quality_function.go
@@ -1,6 +1,8 @@
 package payment
 
 import (
+	"math"
+
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 )
@@ -192,6 +194,11 @@ func withinRelativeDistanceAmounts(a, b EitherAmount, dist float64) bool {
 			return false
 		}
 		ratio = float64(diff.XRP) / float64(maxAmt.XRP)
+	} else if maxAmt.IsMPT {
+		if maxAmt.MPT == 0 {
+			return true
+		}
+		ratio = math.Abs(float64(diff.MPT) / float64(maxAmt.MPT))
 	} else {
 		maxF := maxAmt.IOU.Float64()
 		if maxF == 0 {

--- a/internal/tx/payment/quality_mpt_test.go
+++ b/internal/tx/payment/quality_mpt_test.go
@@ -1,0 +1,32 @@
+package payment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQualityMPTCeilUsesIntegralRounding(t *testing.T) {
+	var id [24]byte
+	id[23] = 1
+
+	in := NewMPTEitherAmount(5, id)
+	out := NewMPTEitherAmount(10, id)
+	q := QualityFromAmounts(in, out)
+	roundedIn, limitedOut := q.CeilOutStrict(in, out, NewMPTEitherAmount(5, id), true)
+	require.Equal(t, int64(3), roundedIn.MPT)
+	require.Equal(t, int64(5), limitedOut.MPT)
+	require.Equal(t, id, roundedIn.MPTID)
+	roundedIn, _ = q.CeilOutStrict(in, out, NewMPTEitherAmount(5, id), false)
+	require.Equal(t, int64(2), roundedIn.MPT)
+
+	in = NewMPTEitherAmount(10, id)
+	out = NewMPTEitherAmount(5, id)
+	q = QualityFromAmounts(in, out)
+	limitedIn, roundedOut := q.CeilIn(in, out, NewMPTEitherAmount(5, id))
+	require.Equal(t, int64(5), limitedIn.MPT)
+	require.Equal(t, int64(3), roundedOut.MPT)
+	require.Equal(t, id, roundedOut.MPTID)
+	_, roundedOut = q.CeilInStrict(in, out, NewMPTEitherAmount(5, id), false)
+	require.Equal(t, int64(2), roundedOut.MPT)
+}

--- a/internal/tx/payment/sandbox.go
+++ b/internal/tx/payment/sandbox.go
@@ -69,6 +69,7 @@ type PaymentSandbox struct {
 type DeferredCredits struct {
 	// credits maps (lowAccount, highAccount, currency) -> adjustment
 	credits map[deferredKey]*deferredValue
+	mpt     map[[24]byte]*deferredMPTValue
 
 	// ownerCounts tracks maximum owner count seen for each account
 	ownerCounts map[[20]byte]uint32
@@ -87,6 +88,18 @@ type deferredValue struct {
 	lowAcctCredits     tx.Amount
 	highAcctCredits    tx.Amount
 	lowAcctOrigBalance tx.Amount
+}
+
+type deferredMPTHolderValue struct {
+	debit       uint64
+	origBalance uint64
+}
+
+type deferredMPTValue struct {
+	holders     map[[20]byte]*deferredMPTHolderValue
+	credit      uint64
+	origBalance int64
+	selfDebit   uint64
 }
 
 // Adjustment represents the deferred credit adjustments for a balance lookup
@@ -197,6 +210,7 @@ func (s *PaymentSandbox) HasFundsFailure() bool {
 func newDeferredCredits() *DeferredCredits {
 	return &DeferredCredits{
 		credits:     make(map[deferredKey]*deferredValue),
+		mpt:         make(map[[24]byte]*deferredMPTValue),
 		ownerCounts: make(map[[20]byte]uint32),
 	}
 }
@@ -564,6 +578,30 @@ func (s *PaymentSandbox) CreditHook(sender, receiver [20]byte, amount tx.Amount,
 	s.tab.credit(sender, receiver, amount, preCreditSenderBalance)
 }
 
+func (s *PaymentSandbox) CreditHookMPT(
+	sender, receiver [20]byte,
+	id [24]byte,
+	amount, preCreditHolderBalance uint64,
+	preCreditIssuerBalance int64,
+) {
+	s.tab.creditMPT(sender, receiver, id, amount, preCreditHolderBalance, preCreditIssuerBalance)
+}
+
+func (s *PaymentSandbox) IssuerSelfDebitHookMPT(id [24]byte, amount uint64, origBalance int64) {
+	if amount == 0 {
+		return
+	}
+	v, exists := s.tab.mpt[id]
+	if !exists {
+		v = &deferredMPTValue{
+			holders:     make(map[[20]byte]*deferredMPTHolderValue),
+			origBalance: origBalance,
+		}
+		s.tab.mpt[id] = v
+	}
+	v.selfDebit += amount
+}
+
 // credit records a credit in the deferred credits table
 func (dc *DeferredCredits) credit(sender, receiver [20]byte, amount tx.Amount, preCreditSenderBalance tx.Amount) {
 	if sender == receiver {
@@ -612,6 +650,41 @@ func (dc *DeferredCredits) credit(sender, receiver [20]byte, amount tx.Amount, p
 			v.lowAcctCredits, _ = v.lowAcctCredits.Add(amount)
 		}
 	}
+}
+
+func (dc *DeferredCredits) creditMPT(
+	sender, receiver [20]byte,
+	id [24]byte,
+	amount, preCreditHolderBalance uint64,
+	preCreditIssuerBalance int64,
+) {
+	if sender == receiver || amount == 0 {
+		return
+	}
+	issuer := mptIssuer(id)
+	v, exists := dc.mpt[id]
+	if !exists {
+		v = &deferredMPTValue{
+			holders:     make(map[[20]byte]*deferredMPTHolderValue),
+			origBalance: preCreditIssuerBalance,
+		}
+		dc.mpt[id] = v
+	}
+
+	if sender == issuer {
+		v.credit += amount
+		if _, exists := v.holders[receiver]; !exists {
+			v.holders[receiver] = &deferredMPTHolderValue{origBalance: preCreditHolderBalance}
+		}
+		return
+	}
+
+	holder, exists := v.holders[sender]
+	if !exists {
+		holder = &deferredMPTHolderValue{origBalance: preCreditHolderBalance}
+		v.holders[sender] = holder
+	}
+	holder.debit += amount
 }
 
 // adjustments returns the deferred credit adjustments for a balance lookup
@@ -675,6 +748,36 @@ func (dc *DeferredCredits) apply(to *DeferredCredits) {
 		}
 	}
 
+	for id, fromVal := range dc.mpt {
+		toVal, exists := to.mpt[id]
+		if !exists {
+			toVal = &deferredMPTValue{
+				holders:     make(map[[20]byte]*deferredMPTHolderValue, len(fromVal.holders)),
+				credit:      fromVal.credit,
+				origBalance: fromVal.origBalance,
+				selfDebit:   fromVal.selfDebit,
+			}
+			for account, holder := range fromVal.holders {
+				copyHolder := *holder
+				toVal.holders[account] = &copyHolder
+			}
+			to.mpt[id] = toVal
+			continue
+		}
+
+		toVal.credit += fromVal.credit
+		toVal.selfDebit += fromVal.selfDebit
+		for account, fromHolder := range fromVal.holders {
+			toHolder, exists := toVal.holders[account]
+			if !exists {
+				copyHolder := *fromHolder
+				toVal.holders[account] = &copyHolder
+				continue
+			}
+			toHolder.debit += fromHolder.debit
+		}
+	}
+
 	for id, fromCount := range dc.ownerCounts {
 		toCount, exists := to.ownerCounts[id]
 		if !exists {
@@ -732,6 +835,63 @@ func (s *PaymentSandbox) BalanceHook(account, issuer [20]byte, amount tx.Amount)
 	}
 
 	return result
+}
+
+func (s *PaymentSandbox) BalanceHookMPT(account [20]byte, id [24]byte, amount int64) int64 {
+	issuer := mptIssuer(id)
+	accountIsHolder := account != issuer
+	var delta uint64
+	lastBalance := amount
+	minimumBalance := amount
+
+	for current := s; current != nil; current = current.parent {
+		adjustment, exists := current.tab.mpt[id]
+		if !exists {
+			continue
+		}
+		if accountIsHolder {
+			if holder, exists := adjustment.holders[account]; exists {
+				delta = addMPTDeferred(delta, holder.debit)
+				lastBalance = int64(holder.origBalance)
+			}
+		} else {
+			delta = addMPTDeferred(delta, adjustment.credit)
+			lastBalance = adjustment.origBalance
+		}
+		minimumBalance = min(minimumBalance, lastBalance)
+	}
+
+	adjusted := min(amount, minimumBalance)
+	if lastBalance <= 0 || delta >= uint64(lastBalance) {
+		return 0
+	}
+	adjusted = min(adjusted, lastBalance-int64(delta))
+	if adjusted <= 0 {
+		return 0
+	}
+	return adjusted
+}
+
+func (s *PaymentSandbox) BalanceHookSelfIssueMPT(id [24]byte, amount int64) int64 {
+	var selfDebited uint64
+	lastBalance := amount
+	for current := s; current != nil; current = current.parent {
+		if adjustment, exists := current.tab.mpt[id]; exists {
+			selfDebited = addMPTDeferred(selfDebited, adjustment.selfDebit)
+			lastBalance = adjustment.origBalance
+		}
+	}
+	if lastBalance <= 0 || selfDebited >= uint64(lastBalance) {
+		return 0
+	}
+	return lastBalance - int64(selfDebited)
+}
+
+func addMPTDeferred(current, amount uint64) uint64 {
+	if ^uint64(0)-current < amount {
+		return ^uint64(0)
+	}
+	return current + amount
 }
 
 // OwnerCountHook returns the maximum owner count seen for an account

--- a/internal/tx/payment/sandbox_mpt_test.go
+++ b/internal/tx/payment/sandbox_mpt_test.go
@@ -1,0 +1,61 @@
+package payment
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPaymentSandboxDefersMPTCreditsAndIssuerSelfDebits(t *testing.T) {
+	var id [24]byte
+	copy(id[4:], []byte("issuer-account-id-123"))
+	issuer := mptIssuer(id)
+	var alice, bob [20]byte
+	copy(alice[:], []byte("alice-account-id-1234"))
+	copy(bob[:], []byte("bob-account-id-123456"))
+
+	view := newPaymentMockLedgerView()
+	view.rules = amendment.NewRulesBuilder().FromPreset(amendment.PresetAllSupported).EnableByName("MPTokensV2").Build()
+	view.createAccount(issuer, 100_000_000, 1)
+	view.createAccount(alice, 100_000_000, 1)
+	view.createAccount(bob, 100_000_000, 1)
+	maximum := uint64(500)
+	issuance := &state.MPTokenIssuanceData{
+		Issuer:            issuer,
+		Sequence:          1,
+		OutstandingAmount: 200,
+		MaximumAmount:     &maximum,
+	}
+	raw, err := state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	view.data[keylet.MPTIssuance(id).Key] = raw
+	putMPTHolding(t, view, id, alice, 200)
+	putMPTHolding(t, view, id, bob, 0)
+
+	root := NewPaymentSandbox(view)
+	child := NewChildSandbox(root)
+	actual, result := mptutil.Send(child, id, alice, bob, 100, true, false)
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Equal(t, int64(100), actual)
+	require.NoError(t, child.Apply(root))
+
+	aliceFunds, result := mptutil.Funds(root, id, alice, false)
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Equal(t, int64(100), aliceFunds)
+	bobFunds, result := mptutil.Funds(root, id, bob, false)
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Zero(t, bobFunds)
+	issuerFunds, result := mptutil.Funds(root, id, issuer, false)
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Equal(t, int64(200), issuerFunds)
+
+	require.Equal(t, ter.TesSUCCESS, mptutil.RecordIssuerSelfDebit(root, id, 75))
+	selfIssueFunds, result := mptutil.IssuerFundsToSelfIssue(root, id)
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Equal(t, int64(225), selfIssueFunds)
+}

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx/amm"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -35,7 +36,8 @@ type BookStep struct {
 	strandSrc [20]byte
 
 	// strandDst is the destination account of the strand
-	strandDst [20]byte
+	strandDst     [20]byte
+	strandDeliver Issue
 
 	// prevStep is the previous step (for transfer fee calculation)
 	prevStep Step
@@ -225,6 +227,7 @@ func NewBookStep(inIssue, outIssue Issue, strandSrc, strandDst [20]byte, prevSte
 		},
 		strandSrc:            strandSrc,
 		strandDst:            strandDst,
+		strandDeliver:        outIssue,
 		prevStep:             prevStep,
 		ownerPaysTransferFee: ownerPaysTransferFee,
 		maxOffersToConsume:   maxOffersToConsume(),
@@ -297,35 +300,63 @@ func (s *BookStep) forEachOffer(
 			return false
 		}
 
-		// Self-cross detection (CLOB only, default path only)
-		if !isAMM && s.defaultPath && s.qualityLimit != nil {
-			offerOwner, ownerErr := state.DecodeAccountID(clobOffer.Account)
-			if ownerErr == nil {
-				if !offerQuality.WorseThan(*s.qualityLimit) &&
-					s.strandSrc == offerOwner && s.strandDst == offerOwner {
-					ofrsToRm[clobKey] = true
-					s.recordPermRm(clobKey)
-					if !offerAttempted {
-						currentQuality = nil
-					}
-					return true
-				}
+		var offerOwner [20]byte
+		if isAMM {
+			offerOwner = ammOffer.Owner()
+		} else {
+			var err error
+			offerOwner, err = state.DecodeAccountID(clobOffer.Account)
+			if err != nil {
+				return true
 			}
 		}
 
-		// Authorization check (CLOB only)
-		if !isAMM && !s.book.In.IsXRP() {
-			offerOwner, ownerErr := state.DecodeAccountID(clobOffer.Account)
-			if ownerErr == nil && offerOwner != s.book.In.Issuer {
-				if !s.isOfferOwnerAuthorized(afView, offerOwner, s.book.In.Issuer, s.book.In.Currency) {
-					ofrsToRm[clobKey] = true
-					s.recordPermRm(clobKey)
-					if !offerAttempted {
-						currentQuality = nil
-					}
-					return true
+		// Self-cross detection (CLOB only, default path only)
+		if !isAMM && s.defaultPath && s.qualityLimit != nil {
+			if !offerQuality.WorseThan(*s.qualityLimit) &&
+				s.strandSrc == offerOwner && s.strandDst == offerOwner {
+				ofrsToRm[clobKey] = true
+				s.recordPermRm(clobKey)
+				if !offerAttempted {
+					currentQuality = nil
 				}
+				return true
 			}
+		}
+
+		if s.book.In.IsMPT {
+			if result := mptutil.EnsureHolding(sb, s.book.In.MPTID, offerOwner, 0, true); result != ter.TesSUCCESS {
+				if !isAMM {
+					s.dropBecameOffer(sb, clobOffer, offerOwner)
+				}
+				return true
+			}
+		}
+
+		authView := afView
+		if rules := sb.Rules(); rules != nil && rules.MPTokensV2Enabled() {
+			authView = sb
+		}
+		authorized := true
+		if offerOwner != s.book.In.Issuer {
+			switch {
+			case s.book.In.IsMPT:
+				authorized = mptutil.RequireAuthAt(authView, s.book.In.MPTID, offerOwner, true, s.parentCloseTime) == ter.TesSUCCESS
+			case !isAMM && !s.book.In.IsXRP():
+				authorized = s.isOfferOwnerAuthorized(
+					authView, offerOwner, s.book.In.Issuer, s.book.In.Currency,
+				)
+			}
+		}
+		if !authorized || !s.checkMPTDEX(sb, offerOwner) {
+			if !isAMM {
+				ofrsToRm[clobKey] = true
+				s.recordPermRm(clobKey)
+			}
+			if !offerAttempted {
+				currentQuality = nil
+			}
+			return true
 		}
 
 		// Quality limit check
@@ -349,14 +380,35 @@ func (s *BookStep) forEachOffer(
 		// Reference: rippled OfferStream reads ownerFunds from view_ (sb),
 		// which is the execution sandbox, so consumed balances are visible.
 		if !isAMM {
-			offerOwner, _ := state.DecodeAccountID(clobOffer.Account)
 			funds := s.getOfferFundedAmount(sb, clobOffer)
-			isFundedByIssuer := offerOwner == s.book.Out.Issuer
+			isFundedByIssuer := !s.book.Out.IsMPT && offerOwner == s.book.Out.Issuer
 			if !isFundedByIssuer && funds.Compare(ownerGives) < 0 {
 				ownerGives = funds
 				stpOut = MulRatio(ownerGives, QualityOne, ofrTrOut, false)
 				ofrIn, ofrOut = offerQuality.CeilOutStrict(ofrIn, ofrOut, stpOut, false)
 				stpIn = MulRatio(ofrIn, ofrTrIn, QualityOne, true)
+			}
+		}
+
+		if s.book.In.IsMPT && s.prevStep == nil && offerOwner != s.book.In.Issuer {
+			available, result := mptutil.IssuerFundsToSelfIssue(sb, s.book.In.MPTID)
+			if result == ter.TesSUCCESS {
+				limit := NewMPTEitherAmount(available, s.book.In.MPTID)
+				if stpIn.Compare(limit) > 0 {
+					stpIn = limit
+					inLimit := MulRatio(stpIn, QualityOne, ofrTrIn, false)
+					if isAMM {
+						ofrIn, ofrOut = ammOffer.LimitIn(
+							ofrIn, ofrOut, inLimit, false, s.fixReducedOffersV2,
+						)
+					} else if s.fixReducedOffersV2 {
+						ofrIn, ofrOut = offerQuality.CeilInStrict(ofrIn, ofrOut, inLimit, false)
+					} else {
+						ofrIn, ofrOut = offerQuality.CeilIn(ofrIn, ofrOut, inLimit)
+					}
+					stpOut = ofrOut
+					ownerGives = MulRatio(ofrOut, ofrTrOut, QualityOne, false)
+				}
 			}
 		}
 
@@ -1041,24 +1093,19 @@ func (s *BookStep) bookDirHasEntries(sb *PaymentSandbox, rootKey [32]byte, rootD
 // starting point for Succ()-based iteration.
 // Reference: rippled BookTip initializes with book base (quality=0).
 func (s *BookStep) bookBaseKey() [32]byte {
-	takerPaysCurrency := keylet.CurrencyBytes(s.book.In.Currency)
-	takerPaysIssuer := s.book.In.Issuer
-	takerGetsCurrency := keylet.CurrencyBytes(s.book.Out.Currency)
-	takerGetsIssuer := s.book.Out.Issuer
+	base := keylet.BookBase(
+		bookSideFromIssue(s.book.In),
+		bookSideFromIssue(s.book.Out),
+		s.domainID,
+	)
+	return keylet.Quality(base, 0).Key
+}
 
-	var key [32]byte
-	if s.domainID != nil {
-		key = keylet.BookDirWithDomain(takerPaysCurrency, takerPaysIssuer, takerGetsCurrency, takerGetsIssuer, *s.domainID).Key
-	} else {
-		key = keylet.BookDir(takerPaysCurrency, takerPaysIssuer, takerGetsCurrency, takerGetsIssuer).Key
+func bookSideFromIssue(issue Issue) keylet.BookSide {
+	if issue.IsMPT {
+		return keylet.MPTSide(issue.MPTID)
 	}
-	// Zero out quality bytes (24-31). BookDir returns a full SHA-512Half hash,
-	// but actual book directory entries have bytes 24-31 replaced with the quality
-	// value. Zero them so Succ() finds the first quality entry.
-	for i := 24; i < 32; i++ {
-		key[i] = 0
-	}
-	return key
+	return keylet.IssueSide(keylet.CurrencyBytes(issue.Currency), issue.Issuer)
 }
 
 // Check validates the BookStep before use
@@ -1066,7 +1113,7 @@ func (s *BookStep) bookBaseKey() [32]byte {
 func (s *BookStep) Check(sb *PaymentSandbox) ter.Result {
 	// Check for same in/out issue - this is invalid
 	// Reference: rippled BookStep.cpp lines 1346-1351
-	if s.book.In.Currency == s.book.Out.Currency && s.book.In.Issuer == s.book.Out.Issuer {
+	if s.book.In.Equal(s.book.Out) {
 		return ter.TemBAD_PATH
 	}
 
@@ -1102,7 +1149,7 @@ func (s *BookStep) Check(sb *PaymentSandbox) ter.Result {
 		if prevDirect, ok := s.prevStep.(*DirectStepI); ok {
 			prev := prevDirect.src
 			cur := s.book.In.Issuer
-			if !s.book.In.IsXRP() {
+			if !s.book.In.IsXRP() && !s.book.In.IsMPT {
 				sleLineKey := keylet.Line(prev, cur, s.book.In.Currency)
 				sleLineData, err := sb.Read(sleLineKey)
 				if err != nil || sleLineData == nil {
@@ -1127,7 +1174,48 @@ func (s *BookStep) Check(sb *PaymentSandbox) ter.Result {
 		}
 	}
 
+	for _, issue := range []Issue{s.book.In, s.book.Out} {
+		if issue.IsMPT {
+			if result := mptutil.CanTrade(sb, issue.MPTID); result != ter.TesSUCCESS {
+				return result
+			}
+		}
+	}
+
 	return ter.TesSUCCESS
+}
+
+func (s *BookStep) checkMPTDEX(view *PaymentSandbox, owner [20]byte) bool {
+	for _, issue := range []Issue{s.book.In, s.book.Out} {
+		if issue.IsMPT && mptutil.CanTrade(view, issue.MPTID) != ter.TesSUCCESS {
+			return false
+		}
+	}
+
+	if s.book.In.IsMPT {
+		switch {
+		case s.prevStep == nil, owner == s.book.In.Issuer:
+		case mptutil.IsFrozen(view, s.book.In.MPTID, owner):
+			return false
+		case s.prevStep.BookStepBook() != nil:
+		default:
+			if mptutil.CanTransfer(view, s.book.In.MPTID, owner, owner) != ter.TesSUCCESS {
+				return false
+			}
+		}
+	}
+
+	if s.book.Out.IsMPT {
+		if s.book.Out.Equal(s.strandDeliver) && s.strandDst == s.book.Out.Issuer {
+			return true
+		}
+		if owner == s.book.Out.Issuer {
+			return true
+		}
+		return mptutil.CanTransfer(view, s.book.Out.MPTID, owner, owner) == ter.TesSUCCESS
+	}
+
+	return true
 }
 
 // LedgerReader is an interface for reading ledger entries.
@@ -1210,13 +1298,7 @@ func (s *BookStep) initAMMLiquidity(
 ) {
 	s.fixAMMOverflowOffer = fixAMMOverflowOffer
 
-	// Build keylet::amm(in, out) to look up the AMM SLE
-	inIssuer := issueToCurrencyBytes(s.book.In)
-	inCurrency := keylet.CurrencyBytes(s.book.In.Currency)
-	outIssuer := issueToCurrencyBytes(s.book.Out)
-	outCurrency := keylet.CurrencyBytes(s.book.Out.Currency)
-
-	ammKey := keylet.AMM(inIssuer, inCurrency, outIssuer, outCurrency)
+	ammKey := keylet.AMMAsset(bookSideFromIssue(s.book.In), bookSideFromIssue(s.book.Out))
 	ammData, err := view.Read(ammKey)
 	if err != nil || ammData == nil {
 		return
@@ -1273,9 +1355,4 @@ func getAMMTradingFee(ammEntry *amm.AMMData, account [20]byte, parentCloseTime u
 		}
 	}
 	return ammEntry.TradingFee
-}
-
-// issueToCurrencyBytes returns the issuer as [20]byte for keylet.AMM.
-func issueToCurrencyBytes(issue Issue) [20]byte {
-	return issue.Issuer
 }

--- a/internal/tx/payment/step_book_consume.go
+++ b/internal/tx/payment/step_book_consume.go
@@ -3,22 +3,18 @@ package payment
 import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 func (s *BookStep) offerTakerGets(offer *state.LedgerOffer) EitherAmount {
-	if s.book.Out.IsXRP() {
-		return NewXRPEitherAmount(offer.TakerGets.Drops())
-	}
-	return NewIOUEitherAmount(offer.TakerGets)
+	return ToEitherAmount(offer.TakerGets)
 }
 
 // offerTakerPays returns what the taker pays to this offer
 func (s *BookStep) offerTakerPays(offer *state.LedgerOffer) EitherAmount {
-	if s.book.In.IsXRP() {
-		return NewXRPEitherAmount(offer.TakerPays.Drops())
-	}
-	return NewIOUEitherAmount(offer.TakerPays)
+	return ToEitherAmount(offer.TakerPays)
 }
 
 // offerQuality returns the quality of an offer, taken from its BookDirectory key
@@ -67,6 +63,11 @@ func (s *BookStep) consumeOffer(sb *PaymentSandbox, offer *state.LedgerOffer, co
 	outRecipient := s.book.Out.Issuer // For XRP: zero account; for IOU: the issuer
 	if err := s.transferFunds(sb, offerOwner, outRecipient, ownerGives, s.book.Out); err != nil {
 		return err
+	}
+	if s.book.Out.IsMPT && offerOwner == s.book.Out.Issuer {
+		if result := mptutil.RecordIssuerSelfDebit(sb, s.book.Out.MPTID, uint64(consumedOut.MPT)); result != ter.TesSUCCESS {
+			return mptTransferResult(result)
+		}
 	}
 
 	// 3. Update offer's remaining amounts (use NET input for offer consumption)
@@ -121,6 +122,9 @@ func (s *BookStep) zeroOut() EitherAmount {
 	if s.book.Out.IsXRP() {
 		return ZeroXRPEitherAmount()
 	}
+	if s.book.Out.IsMPT {
+		return ZeroMPTEitherAmount(s.book.Out.MPTID)
+	}
 	return ZeroIOUEitherAmount(s.book.Out.Currency, state.EncodeAccountIDSafe(s.book.Out.Issuer))
 }
 
@@ -128,6 +132,9 @@ func (s *BookStep) zeroOut() EitherAmount {
 func (s *BookStep) zeroIn() EitherAmount {
 	if s.book.In.IsXRP() {
 		return ZeroXRPEitherAmount()
+	}
+	if s.book.In.IsMPT {
+		return ZeroMPTEitherAmount(s.book.In.MPTID)
 	}
 	return ZeroIOUEitherAmount(s.book.In.Currency, state.EncodeAccountIDSafe(s.book.In.Issuer))
 }
@@ -166,7 +173,8 @@ func (s *BookStep) deleteOffer(sb *PaymentSandbox, offer *state.LedgerOffer, own
 // applyDirRemoveResult applies directory removal changes to the sandbox
 func (s *BookStep) applyDirRemoveResult(sb *PaymentSandbox, result *state.DirRemoveResult) {
 	for _, mod := range result.ModifiedNodes {
-		isBookDir := mod.NewState.TakerPaysCurrency != [20]byte{} || mod.NewState.TakerGetsCurrency != [20]byte{}
+		isBookDir := mod.NewState.TakerPaysCurrency != [20]byte{} || mod.NewState.TakerGetsCurrency != [20]byte{} ||
+			mod.NewState.TakerPaysMPT != nil || mod.NewState.TakerGetsMPT != nil
 		data, err := state.SerializeDirectoryNode(mod.NewState, isBookDir)
 		if err != nil {
 			continue
@@ -182,17 +190,16 @@ func (s *BookStep) applyDirRemoveResult(sb *PaymentSandbox, result *state.DirRem
 }
 
 func (s *BookStep) subtractFromAmount(original, consumed EitherAmount) EitherAmount {
-	if original.IsNative {
-		return NewXRPEitherAmount(original.XRP - consumed.XRP)
-	}
-	result, _ := original.IOU.Sub(consumed.IOU)
-	return NewIOUEitherAmount(result)
+	return original.Sub(consumed)
 }
 
 // eitherAmountToTxAmount converts EitherAmount to tx.Amount
 func (s *BookStep) eitherAmountToTxAmount(ea EitherAmount, issue Issue) tx.Amount {
 	if ea.IsNative {
 		return tx.NewXRPAmount(ea.XRP)
+	}
+	if ea.IsMPT {
+		return newMPTAmount(ea.MPT, issue.MPTID)
 	}
 	return ea.IOU
 }
@@ -207,6 +214,13 @@ func (s *BookStep) eitherAmountToTxAmount(ea EitherAmount, issue Issue) tx.Amoun
 func retagToIssue(amt tx.Amount, issue Issue) tx.Amount {
 	if amt.IsNative() || issue.IsXRP() {
 		return amt
+	}
+	if issue.IsMPT {
+		if raw, ok := amt.MPTRaw(); ok {
+			return newMPTAmount(raw, issue.MPTID)
+		}
+		value := state.NewXRPLNumber(amt.Mantissa(), amt.Exponent()).ToInt64WithMode(state.RoundToNearest)
+		return newMPTAmount(value, issue.MPTID)
 	}
 	return tx.NewIssuedAmount(amt.Mantissa(), amt.Exponent(), issue.Currency, state.EncodeAccountIDSafe(issue.Issuer))
 }

--- a/internal/tx/payment/step_book_mpt_test.go
+++ b/internal/tx/payment/step_book_mpt_test.go
@@ -1,0 +1,129 @@
+package payment
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBookStepMPTBookBase(t *testing.T) {
+	var issuer, counterparty [20]byte
+	copy(issuer[:], []byte("issuer12345678901234"))
+	copy(counterparty[:], []byte("counterparty123456789"))
+	id := keylet.MakeMPTID(7, issuer)
+	domain := [32]byte{1, 2, 3}
+
+	step := NewBookStep(
+		NewMPTIssue(id),
+		Issue{Currency: "USD", Issuer: counterparty},
+		[20]byte{}, [20]byte{}, nil, false,
+	)
+	step.domainID = &domain
+
+	expected := keylet.Quality(keylet.BookBase(
+		keylet.MPTSide(id),
+		keylet.IssueSide(keylet.CurrencyBytes("USD"), counterparty),
+		&domain,
+	), 0).Key
+	require.Equal(t, expected, step.bookBaseKey())
+}
+
+func TestBookStepMPTFundingAndTransferFee(t *testing.T) {
+	var issuer, alice, bob [20]byte
+	copy(issuer[:], []byte("issuer12345678901234"))
+	copy(alice[:], []byte("alice123456789012345"))
+	copy(bob[:], []byte("bob12345678901234567"))
+	id := keylet.MakeMPTID(1, issuer)
+
+	view := newPaymentMockLedgerView()
+	view.rules = amendment.NewRulesBuilder().FromPreset(amendment.PresetAllSupported).EnableByName("MPTokensV2").Build()
+	view.createAccount(issuer, 100_000_000, 1)
+	view.createAccount(alice, 100_000_000, 1)
+	view.createAccount(bob, 100_000_000, 1)
+	putMPTIssuance(t, view, id, 200, 10_000)
+	putMPTHolding(t, view, id, alice, 200)
+	putMPTHolding(t, view, id, bob, 0)
+
+	sb := NewPaymentSandbox(view)
+	issue := NewMPTIssue(id)
+	step := NewBookStep(Issue{Currency: "XRP"}, issue, alice, bob, nil, true)
+	offer := &state.LedgerOffer{Account: state.EncodeAccountIDSafe(alice)}
+
+	funds := step.getOfferFundedAmount(sb, offer)
+	require.True(t, funds.IsMPT)
+	require.Equal(t, int64(200), funds.MPT)
+	require.NoError(t, step.transferFundsWithFee(
+		sb, alice, bob,
+		NewMPTEitherAmount(110, id),
+		NewMPTEitherAmount(100, id),
+		issue,
+	))
+
+	outstanding, balances := readMPTAmounts(t, sb, id, alice, bob)
+	require.Equal(t, uint64(190), outstanding)
+	require.Equal(t, []uint64{90, 100}, balances)
+}
+
+func TestBookStepMPTTransferRateFinalIssuerDelivery(t *testing.T) {
+	var issuer, owner, destination [20]byte
+	copy(issuer[:], []byte("issuer12345678901234"))
+	copy(owner[:], []byte("owner123456789012345"))
+	copy(destination[:], []byte("destination12345678"))
+	id := keylet.MakeMPTID(1, issuer)
+
+	view := newPaymentMockLedgerView()
+	view.rules = amendment.NewRulesBuilder().FromPreset(amendment.PresetAllSupported).EnableByName("MPTokensV2").Build()
+	putMPTIssuance(t, view, id, 0, 2_500)
+	sb := NewPaymentSandbox(view)
+	issue := NewMPTIssue(id)
+
+	step := NewBookStep(Issue{Currency: "XRP"}, issue, owner, destination, nil, true)
+	require.Equal(t, uint32(QualityOne+25_000_000), step.assetTransferRate(sb, issue))
+
+	step.strandDst = issuer
+	step.strandDeliver = issue
+	require.Equal(t, uint32(QualityOne), step.assetTransferRate(sb, issue))
+}
+
+func TestBookStepMPTDEXTransferPermission(t *testing.T) {
+	var issuer, owner, destination [20]byte
+	copy(issuer[:], []byte("issuer12345678901234"))
+	copy(owner[:], []byte("owner123456789012345"))
+	copy(destination[:], []byte("destination12345678"))
+	id := keylet.MakeMPTID(1, issuer)
+
+	view := newPaymentMockLedgerView()
+	view.rules = amendment.NewRulesBuilder().FromPreset(amendment.PresetAllSupported).EnableByName("MPTokensV2").Build()
+	view.createAccount(issuer, 100_000_000, 1)
+	putMPTIssuance(t, view, id, 0, 0)
+	raw := view.data[keylet.MPTIssuance(id).Key]
+	issuance, err := state.ParseMPTokenIssuance(raw)
+	require.NoError(t, err)
+	issuance.Flags = entry.LsfMPTCanTrade
+	raw, err = state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	view.data[keylet.MPTIssuance(id).Key] = raw
+	sb := NewPaymentSandbox(view)
+	issue := NewMPTIssue(id)
+
+	step := NewBookStep(Issue{Currency: "XRP"}, issue, owner, destination, nil, false)
+	require.False(t, step.checkMPTDEX(sb, owner))
+
+	step.strandDst = issuer
+	step.strandDeliver = issue
+	require.True(t, step.checkMPTDEX(sb, owner))
+
+	inputStep := NewBookStep(issue, Issue{Currency: "XRP"}, owner, destination, nil, false)
+	require.True(t, inputStep.checkMPTDEX(sb, owner))
+
+	issuance.Flags = entry.LsfMPTCanTransfer
+	raw, err = state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	require.NoError(t, sb.Update(keylet.MPTIssuance(id), raw))
+	require.Equal(t, ter.TecNO_PERMISSION, inputStep.Check(sb))
+}

--- a/internal/tx/payment/step_book_mpt_test.go
+++ b/internal/tx/payment/step_book_mpt_test.go
@@ -83,11 +83,11 @@ func TestBookStepMPTTransferRateFinalIssuerDelivery(t *testing.T) {
 	issue := NewMPTIssue(id)
 
 	step := NewBookStep(Issue{Currency: "XRP"}, issue, owner, destination, nil, true)
-	require.Equal(t, uint32(QualityOne+25_000_000), step.assetTransferRate(sb, issue))
+	require.Equal(t, QualityOne+25_000_000, step.assetTransferRate(sb, issue))
 
 	step.strandDst = issuer
 	step.strandDeliver = issue
-	require.Equal(t, uint32(QualityOne), step.assetTransferRate(sb, issue))
+	require.Equal(t, QualityOne, step.assetTransferRate(sb, issue))
 }
 
 func TestBookStepMPTDEXTransferPermission(t *testing.T) {

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/permissioneddomain"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -222,8 +224,7 @@ func (s *BookStep) getNextOfferSkipVisited(sb *PaymentSandbox, afView *PaymentSa
 				if ownerErr != nil {
 					continue
 				}
-				if offer.TakerGets.IsZero() ||
-					s.isDeepFrozen(sb, offerOwner, s.book.In.Currency, s.book.In.Issuer) {
+				if offer.TakerGets.IsZero() || s.isDeepFrozenIssue(sb, offerOwner, s.book.In) {
 					ofrsToRm[offerKey] = true
 					s.recordPermRm(offerKey)
 					continue
@@ -303,8 +304,7 @@ func (s *BookStep) firstCrossableTipQuality(sb *PaymentSandbox, ofrsToRm, visite
 				if derr != nil {
 					continue
 				}
-				if offer.TakerGets.IsZero() ||
-					s.isDeepFrozen(sb, offerOwner, s.book.In.Currency, s.book.In.Issuer) {
+				if offer.TakerGets.IsZero() || s.isDeepFrozenIssue(sb, offerOwner, s.book.In) {
 					continue
 				}
 				funds := s.getOfferFundedAmount(sb, offer)
@@ -474,7 +474,8 @@ func (s *BookStep) eraseDanglingOffer(view *PaymentSandbox, pageKey keylet.Keyle
 	}
 	page.Indexes = newIndexes
 
-	isBookDir := page.TakerPaysCurrency != [20]byte{} || page.TakerGetsCurrency != [20]byte{}
+	isBookDir := page.TakerPaysCurrency != [20]byte{} || page.TakerGetsCurrency != [20]byte{} ||
+		page.TakerPaysMPT != nil || page.TakerGetsMPT != nil
 	data, err := state.SerializeDirectoryNode(page, isBookDir)
 	if err != nil {
 		return
@@ -628,6 +629,13 @@ func (s *BookStep) isDeepFrozen(sb *PaymentSandbox, account [20]byte, currency s
 	return (rs.Flags&state.LsfHighDeepFreeze) != 0 || (rs.Flags&state.LsfLowDeepFreeze) != 0
 }
 
+func (s *BookStep) isDeepFrozenIssue(sb *PaymentSandbox, account [20]byte, issue Issue) bool {
+	if issue.IsMPT {
+		return mptutil.IsFrozen(sb, issue.MPTID, account)
+	}
+	return s.isDeepFrozen(sb, account, issue.Currency, issue.Issuer)
+}
+
 // getOfferFundedAmount returns the actual amount an offer can deliver based on owner's balance.
 // This matches rippled's calculation of funded amounts for offers.
 // For IOU output, returns zero if the owner's trust line is frozen (matching fhZERO_IF_FROZEN).
@@ -679,6 +687,20 @@ func (s *BookStep) getOfferFundedAmount(sb *PaymentSandbox, offer *state.LedgerO
 		// handles the actual cap — capping here breaks ownerPaysTransferFee cases
 		// where ownerGives > offerTakerGets.
 		return NewXRPEitherAmount(available)
+	}
+
+	if s.book.Out.IsMPT {
+		var funds int64
+		var result ter.Result
+		if offerOwner == s.book.Out.Issuer {
+			funds, result = mptutil.IssuerFundsToSelfIssue(sb, s.book.Out.MPTID)
+		} else {
+			funds, result = mptutil.Funds(sb, s.book.Out.MPTID, offerOwner, true)
+		}
+		if result != ter.TesSUCCESS || funds <= 0 {
+			return ZeroMPTEitherAmount(s.book.Out.MPTID)
+		}
+		return NewMPTEitherAmount(funds, s.book.Out.MPTID)
 	}
 
 	// For IOU TakerGets: check owner's trustline balance with issuer
@@ -790,7 +812,7 @@ func (s *BookStep) shouldRmSmallIncreasedQOffer(sb *PaymentSandbox, offer *state
 
 	// For IOU/IOU: only check if TakerPays < TakerGets
 	if !inIsXRP && !outIsXRP {
-		if ofrIn.Compare(ofrOut) >= 0 {
+		if toNumberAmount(ofrIn).Compare(toNumberAmount(ofrOut)) >= 0 {
 			return false
 		}
 	}
@@ -823,6 +845,10 @@ func (s *BookStep) shouldRmSmallIncreasedQOffer(sb *PaymentSandbox, offer *state
 	if inIsXRP {
 		// XRP: minPositiveAmount = 1 drop
 		if effectiveIn.XRP > 1 {
+			return false
+		}
+	} else if s.book.In.IsMPT {
+		if effectiveIn.MPT > 1 {
 			return false
 		}
 	} else {

--- a/internal/tx/payment/step_book_quality.go
+++ b/internal/tx/payment/step_book_quality.go
@@ -3,6 +3,7 @@ package payment
 import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 )
 
 // fixAMMv1_1Enabled reports whether fixAMMv1_1 governs this execution,
@@ -188,14 +189,6 @@ func (s *BookStep) ammOfferGetQualityFunc(offer *AMMOffer) *QualityFunction {
 //
 // Reference: rippled BookStep.cpp lines 328-359 (payment) and 519-558 (crossing).
 func (s *BookStep) adjustQualityWithFees(v *PaymentSandbox, ofrQ Quality, prevStepDir DebtDirection, waiveOutFee, isAMM bool) Quality {
-	// rate(id): parityRate when XRP or id is the strand destination.
-	rate := func(issuer [20]byte, isXRP bool) uint32 {
-		if isXRP || issuer == s.strandDst {
-			return QualityOne
-		}
-		return s.GetAccountTransferRate(v, issuer)
-	}
-
 	var trIn, trOut uint32
 
 	if s.offerCrossing {
@@ -210,7 +203,7 @@ func (s *BookStep) adjustQualityWithFees(v *PaymentSandbox, ofrQ Quality, prevSt
 		}
 		trIn = QualityOne
 		if Redeems(prevStepDir) {
-			trIn = rate(s.book.In.Issuer, s.book.In.IsXRP())
+			trIn = s.assetTransferRate(v, s.book.In)
 		}
 		trOut = QualityOne
 	} else {
@@ -219,11 +212,11 @@ func (s *BookStep) adjustQualityWithFees(v *PaymentSandbox, ofrQ Quality, prevSt
 		// Reference: rippled BookStep.cpp lines 328-359.
 		trIn = QualityOne
 		if Redeems(prevStepDir) {
-			trIn = rate(s.book.In.Issuer, s.book.In.IsXRP())
+			trIn = s.assetTransferRate(v, s.book.In)
 		}
 		trOut = QualityOne
 		if s.ownerPaysTransferFee && !waiveOutFee {
-			trOut = rate(s.book.Out.Issuer, s.book.Out.IsXRP())
+			trOut = s.assetTransferRate(v, s.book.Out)
 		}
 	}
 
@@ -239,31 +232,37 @@ func (s *BookStep) adjustQualityWithFees(v *PaymentSandbox, ofrQ Quality, prevSt
 // No fee when: XRP, issuer is strandDst, or previous step issues.
 // Reference: rippled BookStep.cpp forEachOffer() rate lambda (lines 728-731) + trIn (line 734-735)
 func (s *BookStep) transferRateIn(sb *PaymentSandbox, prevStepDir DebtDirection) uint32 {
-	if s.book.In.IsXRP() || s.book.In.Issuer == s.strandDst {
-		return QualityOne
-	}
-
 	// Only charge transfer fee when previous step redeems
 	if !Redeems(prevStepDir) {
 		return QualityOne
 	}
-
-	return s.GetAccountTransferRate(sb, s.book.In.Issuer)
+	return s.assetTransferRate(sb, s.book.In)
 }
 
 // transferRateOut returns the transfer rate for outgoing currency.
 // No fee when: XRP, issuer is strandDst, or ownerPaysTransferFee is false.
 // Reference: rippled BookStep.cpp forEachOffer() rate lambda (lines 728-731) + trOut (line 737-738)
 func (s *BookStep) transferRateOut(sb *PaymentSandbox) uint32 {
-	if s.book.Out.IsXRP() || s.book.Out.Issuer == s.strandDst {
-		return QualityOne
-	}
-
 	if !s.ownerPaysTransferFee {
 		return QualityOne
 	}
+	return s.assetTransferRate(sb, s.book.Out)
+}
 
-	return s.GetAccountTransferRate(sb, s.book.Out.Issuer)
+func (s *BookStep) assetTransferRate(sb *PaymentSandbox, issue Issue) uint32 {
+	if issue.IsXRP() {
+		return QualityOne
+	}
+	if issue.IsMPT {
+		if issue.Equal(s.strandDeliver) && issue.Issuer == s.strandDst {
+			return QualityOne
+		}
+		return mptutil.TransferRate(sb, issue.MPTID)
+	}
+	if issue.Issuer == s.strandDst {
+		return QualityOne
+	}
+	return s.GetAccountTransferRate(sb, issue.Issuer)
 }
 
 // getOfrInRate returns the per-offer input transfer rate.
@@ -274,9 +273,8 @@ func (s *BookStep) getOfrInRate(offerOwner [20]byte, trIn uint32) uint32 {
 	if !s.offerCrossing {
 		return trIn // Payment mode — no exemption
 	}
-	// Offer crossing: check if offer owner == previous DirectStep's source
-	if directStep, ok := s.prevStep.(*DirectStepI); ok {
-		if offerOwner == directStep.src {
+	if s.prevStep != nil {
+		if accounts := s.prevStep.DirectStepAccts(); accounts != nil && offerOwner == accounts[0] {
 			return QualityOne // Self-pay exemption
 		}
 	}

--- a/internal/tx/payment/step_book_transfer.go
+++ b/internal/tx/payment/step_book_transfer.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -51,6 +53,9 @@ func (s *BookStep) transferFunds(sb *PaymentSandbox, from, to [20]byte, amount E
 	if issue.IsXRP() {
 		return s.transferXRP(sb, from, to, amount.XRP, txHash, ledgerSeq)
 	}
+	if issue.IsMPT {
+		return mptTransferResult(mptutil.Credit(sb, issue.MPTID, from, to, amount.MPT, true))
+	}
 
 	return s.transferIOU(sb, from, to, amount.IOU, issue, txHash, ledgerSeq)
 }
@@ -73,6 +78,20 @@ func (s *BookStep) transferFundsWithFee(sb *PaymentSandbox, from, to [20]byte, g
 	if issue.IsXRP() {
 		return s.transferXRP(sb, from, to, grossAmount.XRP, txHash, ledgerSeq)
 	}
+	if issue.IsMPT {
+		issuer := issue.Issuer
+		switch {
+		case from == issuer:
+			return mptTransferResult(mptutil.Credit(sb, issue.MPTID, from, to, netAmount.MPT, true))
+		case to == issuer:
+			return mptTransferResult(mptutil.Credit(sb, issue.MPTID, from, to, grossAmount.MPT, true))
+		default:
+			if result := mptutil.Credit(sb, issue.MPTID, issuer, to, netAmount.MPT, true); result != ter.TesSUCCESS {
+				return mptTransferResult(result)
+			}
+			return mptTransferResult(mptutil.Credit(sb, issue.MPTID, from, issuer, grossAmount.MPT, true))
+		}
+	}
 
 	// For IOUs: debit sender by gross, credit receiver by net
 	issuer := issue.Issuer
@@ -91,6 +110,13 @@ func (s *BookStep) transferFundsWithFee(sb *PaymentSandbox, from, to [20]byte, g
 		return err
 	}
 	return s.creditTrustline(sb, to, issuer, netAmount.IOU, txHash, ledgerSeq)
+}
+
+func mptTransferResult(result ter.Result) error {
+	if result == ter.TesSUCCESS {
+		return nil
+	}
+	return ter.Errorf(result, "MPT transfer failed")
 }
 
 // transferXRP transfers XRP between accounts.

--- a/internal/tx/payment/step_mpt.go
+++ b/internal/tx/payment/step_mpt.go
@@ -1,0 +1,374 @@
+package payment
+
+import (
+	"math/big"
+
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+type mptEndpointCache struct {
+	in       int64
+	srcToDst int64
+	out      int64
+	dir      DebtDirection
+}
+
+// MPTEndpointStep moves an MPT between its issuer and a holder. MPT assets do
+// not ripple, so the step is valid only at a strand endpoint.
+type MPTEndpointStep struct {
+	src                  [20]byte
+	dst                  [20]byte
+	issue                Issue
+	prevStep             Step
+	isFirst              bool
+	isLast               bool
+	offerCrossing        bool
+	directBetweenHolders bool
+	cache                *mptEndpointCache
+}
+
+func NewMPTEndpointStep(
+	ctx *StrandContext,
+	src, dst [20]byte,
+	issue Issue,
+	prevStep Step,
+	isFirst, isLast bool,
+) (*MPTEndpointStep, ter.Result) {
+	step := &MPTEndpointStep{
+		src:           src,
+		dst:           dst,
+		issue:         issue,
+		prevStep:      prevStep,
+		isFirst:       isFirst,
+		isLast:        isLast,
+		offerCrossing: ctx.OfferCrossing,
+	}
+	step.directBetweenHolders = issue.Equal(ctx.StrandDeliver) &&
+		ctx.StrandSrc != issue.Issuer && ctx.StrandDst != issue.Issuer &&
+		(isFirst || (prevStep != nil && prevStep.BookStepBook() == nil))
+	if result := step.Check(ctx); result != ter.TesSUCCESS {
+		return nil, result
+	}
+	return step, ter.TesSUCCESS
+}
+
+func (s *MPTEndpointStep) maxPaymentFlow(sb *PaymentSandbox) (int64, DebtDirection) {
+	if s.src != s.issue.Issuer {
+		funds, result := mptutil.Funds(sb, s.issue.MPTID, s.src, false)
+		if result != ter.TesSUCCESS {
+			return 0, DebtDirectionRedeems
+		}
+		return funds, DebtDirectionRedeems
+	}
+
+	issuance, _, result := mptutil.ReadIssuance(sb, s.issue.MPTID)
+	if result != ter.TesSUCCESS {
+		return 0, DebtDirectionIssues
+	}
+	if s.prevStep == nil {
+		return int64(mptutil.AvailableAmount(issuance)), DebtDirectionIssues
+	}
+	return int64(mptutil.MaximumAmount(issuance)), DebtDirectionIssues
+}
+
+func (s *MPTEndpointStep) qualities(sb *PaymentSandbox, dir DebtDirection, strandDir StrandDirection) (uint32, uint32) {
+	if Redeems(dir) {
+		if s.prevStep == nil {
+			return QualityOne, QualityOne
+		}
+		return max(s.prevStep.LineQualityIn(sb), uint32(QualityOne)), QualityOne
+	}
+
+	prevDir := DebtDirectionIssues
+	if s.prevStep != nil {
+		prevDir = s.prevStep.DebtDirection(sb, strandDir)
+	}
+	if Redeems(prevDir) {
+		return mptutil.TransferRate(sb, s.issue.MPTID), QualityOne
+	}
+	return QualityOne, QualityOne
+}
+
+func (s *MPTEndpointStep) ensureDestinationHolding(sb *PaymentSandbox) ter.Result {
+	if !s.offerCrossing || !s.isLast || s.dst == s.issue.Issuer {
+		return ter.TesSUCCESS
+	}
+	return mptutil.EnsureHolding(sb, s.issue.MPTID, s.dst, 0, true)
+}
+
+func (s *MPTEndpointStep) send(sb *PaymentSandbox, amount int64) ter.Result {
+	return mptutil.Credit(sb, s.issue.MPTID, s.src, s.dst, amount, true)
+}
+
+func (s *MPTEndpointStep) resetCache(dir DebtDirection) {
+	s.cache = &mptEndpointCache{dir: dir}
+}
+
+func (s *MPTEndpointStep) setCacheLimiting(in, srcToDst, out int64, dir DebtDirection) {
+	if s.cache.in < in {
+		difference := in - s.cache.in
+		if difference > 1 && (s.cache.in == 0 || mptForwardDifferenceLarge(in, s.cache.in)) {
+			s.cache = &mptEndpointCache{in: in, srcToDst: srcToDst, out: out, dir: dir}
+			return
+		}
+	}
+	s.cache.in = in
+	s.cache.srcToDst = min(s.cache.srcToDst, srcToDst)
+	s.cache.out = min(s.cache.out, out)
+	s.cache.dir = dir
+}
+
+func mptForwardDifferenceLarge(forward, cached int64) bool {
+	left := new(big.Int).Mul(big.NewInt(forward), big.NewInt(100))
+	right := new(big.Int).Mul(big.NewInt(cached), big.NewInt(101))
+	return left.Cmp(right) > 0
+}
+
+func (s *MPTEndpointStep) Rev(
+	sb *PaymentSandbox,
+	_ *PaymentSandbox,
+	_ map[[32]byte]bool,
+	out EitherAmount,
+) (EitherAmount, EitherAmount) {
+	if !out.IsMPT || out.MPTID != s.issue.MPTID {
+		zero := ZeroMPTEitherAmount(s.issue.MPTID)
+		return zero, zero
+	}
+	s.cache = nil
+	maxSrcToDst, dir := s.maxPaymentFlow(sb)
+	srcQOut, _ := s.qualities(sb, dir, StrandDirectionReverse)
+	if maxSrcToDst <= 0 {
+		s.resetCache(dir)
+		zero := ZeroMPTEitherAmount(s.issue.MPTID)
+		return zero, zero
+	}
+	if result := s.ensureDestinationHolding(sb); result != ter.TesSUCCESS {
+		s.resetCache(dir)
+		zero := ZeroMPTEitherAmount(s.issue.MPTID)
+		return zero, zero
+	}
+
+	srcToDst := min(out.MPT, maxSrcToDst)
+	in := mptMulRatio(srcToDst, srcQOut, QualityOne, true)
+	s.cache = &mptEndpointCache{in: in, srcToDst: srcToDst, out: srcToDst, dir: dir}
+	if result := s.send(sb, srcToDst); result != ter.TesSUCCESS {
+		s.resetCache(dir)
+		zero := ZeroMPTEitherAmount(s.issue.MPTID)
+		return zero, zero
+	}
+	return NewMPTEitherAmount(in, s.issue.MPTID), NewMPTEitherAmount(srcToDst, s.issue.MPTID)
+}
+
+func (s *MPTEndpointStep) Fwd(
+	sb *PaymentSandbox,
+	_ *PaymentSandbox,
+	_ map[[32]byte]bool,
+	in EitherAmount,
+) (EitherAmount, EitherAmount) {
+	if !in.IsMPT || in.MPTID != s.issue.MPTID || s.cache == nil {
+		zero := ZeroMPTEitherAmount(s.issue.MPTID)
+		return zero, zero
+	}
+	maxSrcToDst, dir := s.maxPaymentFlow(sb)
+	srcQOut, _ := s.qualities(sb, dir, StrandDirectionForward)
+	if maxSrcToDst <= 0 {
+		s.resetCache(dir)
+		zero := ZeroMPTEitherAmount(s.issue.MPTID)
+		return zero, zero
+	}
+	if result := s.ensureDestinationHolding(sb); result != ter.TesSUCCESS {
+		s.resetCache(dir)
+		zero := ZeroMPTEitherAmount(s.issue.MPTID)
+		return zero, zero
+	}
+
+	srcToDst := mptMulRatio(in.MPT, QualityOne, srcQOut, false)
+	actualIn := in.MPT
+	if srcToDst > maxSrcToDst {
+		srcToDst = maxSrcToDst
+		actualIn = mptMulRatio(maxSrcToDst, srcQOut, QualityOne, true)
+	}
+	s.setCacheLimiting(actualIn, srcToDst, srcToDst, dir)
+	if result := s.send(sb, s.cache.srcToDst); result != ter.TesSUCCESS {
+		s.resetCache(dir)
+		zero := ZeroMPTEitherAmount(s.issue.MPTID)
+		return zero, zero
+	}
+	return NewMPTEitherAmount(s.cache.in, s.issue.MPTID), NewMPTEitherAmount(s.cache.out, s.issue.MPTID)
+}
+
+func (s *MPTEndpointStep) CachedIn() *EitherAmount {
+	if s.cache == nil {
+		return nil
+	}
+	value := NewMPTEitherAmount(s.cache.in, s.issue.MPTID)
+	return &value
+}
+
+func (s *MPTEndpointStep) CachedOut() *EitherAmount {
+	if s.cache == nil {
+		return nil
+	}
+	value := NewMPTEitherAmount(s.cache.out, s.issue.MPTID)
+	return &value
+}
+
+func (s *MPTEndpointStep) DebtDirection(_ *PaymentSandbox, dir StrandDirection) DebtDirection {
+	if dir == StrandDirectionForward && s.cache != nil {
+		return s.cache.dir
+	}
+	if s.src == s.issue.Issuer {
+		return DebtDirectionIssues
+	}
+	return DebtDirectionRedeems
+}
+
+func (s *MPTEndpointStep) QualityUpperBound(v *PaymentSandbox, prevStepDir DebtDirection) (*Quality, DebtDirection) {
+	dir := s.DebtDirection(v, StrandDirectionForward)
+	srcQOut := uint32(QualityOne)
+	if Redeems(dir) {
+		if s.prevStep != nil {
+			srcQOut = max(s.prevStep.LineQualityIn(v), uint32(QualityOne))
+		}
+	} else if Redeems(prevStepDir) {
+		srcQOut = mptutil.TransferRate(v, s.issue.MPTID)
+	}
+	out := NewMPTEitherAmount(int64(QualityOne), s.issue.MPTID)
+	in := NewMPTEitherAmount(int64(srcQOut), s.issue.MPTID)
+	quality := QualityFromAmounts(in, out)
+	return &quality, dir
+}
+
+func (s *MPTEndpointStep) GetQualityFunc(v *PaymentSandbox, prevStepDir DebtDirection) (*QualityFunction, DebtDirection) {
+	quality, dir := s.QualityUpperBound(v, prevStepDir)
+	if quality == nil {
+		return nil, dir
+	}
+	return NewCLOBLikeQualityFunction(*quality), dir
+}
+
+func (s *MPTEndpointStep) IsZero(amount EitherAmount) bool {
+	return !amount.IsMPT || amount.MPTID != s.issue.MPTID || amount.MPT == 0
+}
+
+func (s *MPTEndpointStep) EqualIn(a, b EitherAmount) bool {
+	return a.IsMPT && b.IsMPT && a.MPTID == b.MPTID && a.MPT == b.MPT
+}
+
+func (s *MPTEndpointStep) EqualOut(a, b EitherAmount) bool { return s.EqualIn(a, b) }
+func (s *MPTEndpointStep) Inactive() bool                  { return false }
+func (s *MPTEndpointStep) OffersUsed() uint32              { return 0 }
+
+func (s *MPTEndpointStep) DirectStepAccts() *[2][20]byte {
+	accounts := [2][20]byte{s.src, s.dst}
+	return &accounts
+}
+
+func (s *MPTEndpointStep) BookStepBook() *Book { return nil }
+
+func (s *MPTEndpointStep) LineQualityIn(_ *PaymentSandbox) uint32 { return QualityOne }
+
+func (s *MPTEndpointStep) ValidFwd(sb *PaymentSandbox, afView *PaymentSandbox, in EitherAmount) (bool, EitherAmount) {
+	if s.cache == nil || !in.IsMPT || in.MPTID != s.issue.MPTID {
+		return false, ZeroMPTEitherAmount(s.issue.MPTID)
+	}
+	saved := *s.cache
+	maxSrcToDst, _ := s.maxPaymentFlow(sb)
+	_, out := s.Fwd(sb, afView, nil, in)
+	if s.cache == nil || s.cache.srcToDst > maxSrcToDst {
+		return false, out
+	}
+	if saved.in != s.cache.in || saved.out != s.cache.out {
+		return false, out
+	}
+	return true, out
+}
+
+func (s *MPTEndpointStep) Check(ctx *StrandContext) ter.Result {
+	if s.src == [20]byte{} || s.dst == [20]byte{} || s.src == s.dst || !s.issue.IsMPT {
+		return ter.TemBAD_PATH
+	}
+	if exists, err := ctx.View.Exists(keylet.Account(s.src)); err != nil {
+		return ter.TefINTERNAL
+	} else if !exists {
+		return ter.TerNO_ACCOUNT
+	}
+
+	if !(s.isFirst && s.isLast) {
+		account := s.dst
+		if s.isFirst {
+			account = s.src
+		}
+		if (s.isFirst && mptutil.IsGlobalFrozen(ctx.View, s.issue.MPTID)) ||
+			mptutil.IsIndividualFrozen(ctx.View, s.issue.MPTID, account) {
+			return ter.TerLOCKED
+		}
+	}
+	if ctx.SeenBookOuts[s.issue] {
+		if s.prevStep == nil {
+			return ter.TemBAD_PATH_LOOP
+		}
+		if book := s.prevStep.BookStepBook(); book != nil && !book.Out.Equal(s.issue) {
+			return ter.TemBAD_PATH_LOOP
+		}
+	}
+	if s.isFirst {
+		if ctx.SeenDirectIssues[0][s.issue] {
+			return ter.TemBAD_PATH_LOOP
+		}
+		ctx.SeenDirectIssues[0][s.issue] = true
+	}
+	if s.isLast {
+		if ctx.SeenDirectIssues[1][s.issue] {
+			return ter.TemBAD_PATH_LOOP
+		}
+		ctx.SeenDirectIssues[1][s.issue] = true
+	}
+	if !s.isFirst && !s.isLast {
+		return ter.TemBAD_PATH
+	}
+	issuer := s.issue.Issuer
+	if (s.src != issuer && s.dst != issuer) || (s.src == issuer && s.dst == issuer) {
+		return ter.TemBAD_PATH
+	}
+
+	if s.offerCrossing {
+		return ter.TesSUCCESS
+	}
+	if s.src != issuer {
+		if result := mptutil.RequireAuthAt(ctx.View, s.issue.MPTID, s.src, true, ctx.ParentCloseTime); result != ter.TesSUCCESS {
+			return result
+		}
+	}
+	if s.dst != issuer {
+		if result := mptutil.RequireAuthAt(ctx.View, s.issue.MPTID, s.dst, true, ctx.ParentCloseTime); result != ter.TesSUCCESS {
+			return result
+		}
+	}
+	if s.issue.Equal(ctx.StrandDeliver) &&
+		(s.isFirst || (s.prevStep != nil && s.prevStep.BookStepBook() == nil)) {
+		if s.directBetweenHolders {
+			holder := s.dst
+			if s.isFirst {
+				holder = s.src
+			}
+			if mptutil.IsFrozen(ctx.View, s.issue.MPTID, holder) {
+				return ter.TecLOCKED
+			}
+			if result := mptutil.CanTransfer(ctx.View, s.issue.MPTID, holder, ctx.StrandDst); result != ter.TesSUCCESS {
+				return result
+			}
+		}
+	} else if result := mptutil.CanTrade(ctx.View, s.issue.MPTID); result != ter.TesSUCCESS {
+		return result
+	}
+	if s.prevStep == nil {
+		funds, result := mptutil.Funds(ctx.View, s.issue.MPTID, s.src, false)
+		if result != ter.TesSUCCESS || funds <= 0 {
+			return ter.TecPATH_DRY
+		}
+	}
+	return ter.TesSUCCESS
+}

--- a/internal/tx/payment/step_mpt.go
+++ b/internal/tx/payment/step_mpt.go
@@ -78,7 +78,7 @@ func (s *MPTEndpointStep) qualities(sb *PaymentSandbox, dir DebtDirection, stran
 		if s.prevStep == nil {
 			return QualityOne, QualityOne
 		}
-		return max(s.prevStep.LineQualityIn(sb), uint32(QualityOne)), QualityOne
+		return max(s.prevStep.LineQualityIn(sb), QualityOne), QualityOne
 	}
 
 	prevDir := DebtDirectionIssues
@@ -227,10 +227,10 @@ func (s *MPTEndpointStep) DebtDirection(_ *PaymentSandbox, dir StrandDirection) 
 
 func (s *MPTEndpointStep) QualityUpperBound(v *PaymentSandbox, prevStepDir DebtDirection) (*Quality, DebtDirection) {
 	dir := s.DebtDirection(v, StrandDirectionForward)
-	srcQOut := uint32(QualityOne)
+	srcQOut := QualityOne
 	if Redeems(dir) {
 		if s.prevStep != nil {
-			srcQOut = max(s.prevStep.LineQualityIn(v), uint32(QualityOne))
+			srcQOut = max(s.prevStep.LineQualityIn(v), QualityOne)
 		}
 	} else if Redeems(prevStepDir) {
 		srcQOut = mptutil.TransferRate(v, s.issue.MPTID)

--- a/internal/tx/payment/step_mpt_test.go
+++ b/internal/tx/payment/step_mpt_test.go
@@ -1,0 +1,190 @@
+package payment
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	"github.com/stretchr/testify/require"
+)
+
+func putMPTIssuance(t *testing.T, view *paymentMockLedgerView, id [24]byte, outstanding uint64, fee uint16) {
+	t.Helper()
+	issuance := &state.MPTokenIssuanceData{
+		Issuer:            mptIssuer(id),
+		Sequence:          1,
+		OutstandingAmount: outstanding,
+		TransferFee:       fee,
+		Flags:             entry.LsfMPTCanTransfer | entry.LsfMPTCanTrade,
+	}
+	data, err := state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	view.data[keylet.MPTIssuance(id).Key] = data
+}
+
+func putMPTHolding(t *testing.T, view *paymentMockLedgerView, id [24]byte, holder [20]byte, amount uint64) {
+	t.Helper()
+	token := &state.MPTokenData{
+		Account:           holder,
+		MPTokenIssuanceID: id,
+		MPTAmount:         amount,
+	}
+	data, err := state.SerializeMPToken(token)
+	require.NoError(t, err)
+	view.data[keylet.MPTokenByID(id, holder).Key] = data
+}
+
+func readMPTAmounts(t *testing.T, view state.LedgerView, id [24]byte, holders ...[20]byte) (uint64, []uint64) {
+	t.Helper()
+	issuanceRaw, err := view.Read(keylet.MPTIssuance(id))
+	require.NoError(t, err)
+	issuance, err := state.ParseMPTokenIssuance(issuanceRaw)
+	require.NoError(t, err)
+	amounts := make([]uint64, len(holders))
+	for i, holder := range holders {
+		raw, readErr := view.Read(keylet.MPTokenByID(id, holder))
+		require.NoError(t, readErr)
+		token, parseErr := state.ParseMPToken(raw)
+		require.NoError(t, parseErr)
+		amounts[i] = token.MPTAmount
+	}
+	return issuance.OutstandingAmount, amounts
+}
+
+func TestEitherAmountMPT(t *testing.T) {
+	id := [24]byte{0, 0, 0, 1, 1, 2, 3}
+	a := NewMPTEitherAmount(10, id)
+	b := NewMPTEitherAmount(3, id)
+
+	require.True(t, a.IsMPT)
+	require.Equal(t, int64(13), a.Add(b).MPT)
+	require.Equal(t, int64(7), a.Sub(b).MPT)
+	require.Equal(t, int64(4), mptMulRatio(10, 1, 3, true))
+	require.Equal(t, int64(3), mptMulRatio(10, 1, 3, false))
+	require.PanicsWithValue(t, "division by zero", func() { mptMulRatio(10, 1, 0, false) })
+
+	roundTrip := ToEitherAmount(FromEitherAmount(a))
+	require.Equal(t, a, roundTrip)
+	require.Equal(t, qualityOne.Value, QualityFromAmounts(a, a).Value)
+}
+
+func TestMPTEndpointStepIssuerToHolder(t *testing.T) {
+	var issuer, holder [20]byte
+	copy(issuer[:], []byte("issuer12345678901234"))
+	copy(holder[:], []byte("holder12345678901234"))
+	id := keylet.MakeMPTID(1, issuer)
+
+	view := newPaymentMockLedgerView()
+	view.rules = amendment.NewRulesBuilder().FromPreset(amendment.PresetAllSupported).EnableByName("MPTokensV2").Build()
+	view.createAccount(issuer, 100_000_000, 1)
+	view.createAccount(holder, 100_000_000, 1)
+	putMPTIssuance(t, view, id, 0, 0)
+	putMPTHolding(t, view, id, holder, 0)
+	sb := NewPaymentSandbox(view)
+
+	ctx := NewStrandContext(sb, issuer, holder)
+	ctx.StrandDeliver = NewMPTIssue(id)
+	step, result := NewMPTEndpointStep(ctx, issuer, holder, NewMPTIssue(id), nil, true, true)
+	require.Equal(t, ter.TesSUCCESS, result)
+
+	in, out := step.Rev(sb, NewChildSandbox(sb), nil, NewMPTEitherAmount(100, id))
+	require.Equal(t, int64(100), in.MPT)
+	require.Equal(t, int64(100), out.MPT)
+
+	outstanding, balances := readMPTAmounts(t, sb, id, holder)
+	require.Equal(t, uint64(100), outstanding)
+	require.Equal(t, []uint64{100}, balances)
+}
+
+func TestMPTEndpointStepHolderToHolderChargesTransferFee(t *testing.T) {
+	var issuer, alice, bob [20]byte
+	copy(issuer[:], []byte("issuer12345678901234"))
+	copy(alice[:], []byte("alice123456789012345"))
+	copy(bob[:], []byte("bob12345678901234567"))
+	id := keylet.MakeMPTID(1, issuer)
+
+	view := newPaymentMockLedgerView()
+	view.rules = amendment.NewRulesBuilder().FromPreset(amendment.PresetAllSupported).EnableByName("MPTokensV2").Build()
+	view.createAccount(issuer, 100_000_000, 1)
+	view.createAccount(alice, 100_000_000, 1)
+	view.createAccount(bob, 100_000_000, 1)
+	putMPTIssuance(t, view, id, 200, 10_000)
+	putMPTHolding(t, view, id, alice, 200)
+	putMPTHolding(t, view, id, bob, 0)
+
+	deliver := state.NewMPTAmountWithIssuanceID(100, state.EncodeAccountIDSafe(issuer), keyletIDHex(id))
+	sb := NewPaymentSandbox(view)
+	strands, result := ToStrands(sb, alice, bob, deliver, nil, nil, true, false)
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Len(t, strands, 1)
+	require.Len(t, strands[0], 2)
+
+	flowResult := Flow(sb, strands, NewMPTEitherAmount(100, id), false, nil, nil, nil, false)
+	require.Equal(t, ter.TesSUCCESS, flowResult.Result)
+	require.Equal(t, int64(110), flowResult.In.MPT)
+	require.Equal(t, int64(100), flowResult.Out.MPT)
+	require.NoError(t, flowResult.Sandbox.Apply(sb))
+	require.NoError(t, sb.ApplyToView(view))
+
+	outstanding, balances := readMPTAmounts(t, view, id, alice, bob)
+	require.Equal(t, uint64(190), outstanding)
+	require.Equal(t, []uint64{90, 100}, balances)
+}
+
+func TestMPTEndpointStepCheckMatchesRippledOrdering(t *testing.T) {
+	var issuer, alice, bob [20]byte
+	copy(issuer[:], []byte("issuer12345678901234"))
+	copy(alice[:], []byte("alice123456789012345"))
+	copy(bob[:], []byte("bob12345678901234567"))
+	id := keylet.MakeMPTID(1, issuer)
+	issue := NewMPTIssue(id)
+
+	view := newPaymentMockLedgerView()
+	view.rules = amendment.NewRulesBuilder().FromPreset(amendment.PresetAllSupported).EnableByName("MPTokensV2").Build()
+	view.createAccount(alice, 100_000_000, 1)
+	putMPTIssuance(t, view, id, 100, 0)
+	raw := view.data[keylet.MPTIssuance(id).Key]
+	issuance, err := state.ParseMPTokenIssuance(raw)
+	require.NoError(t, err)
+	issuance.Flags |= entry.LsfMPTLocked
+	raw, err = state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	view.data[keylet.MPTIssuance(id).Key] = raw
+
+	sb := NewPaymentSandbox(view)
+	ctx := NewStrandContext(sb, alice, bob)
+	ctx.StrandDeliver = issue
+	_, result := NewMPTEndpointStep(ctx, alice, bob, issue, nil, true, false)
+	require.Equal(t, ter.TerLOCKED, result)
+}
+
+func TestMPTEndpointStepAllowsSeenBookAfterNonBookStep(t *testing.T) {
+	var issuer, holder [20]byte
+	copy(issuer[:], []byte("issuer12345678901234"))
+	copy(holder[:], []byte("holder12345678901234"))
+	id := keylet.MakeMPTID(1, issuer)
+	issue := NewMPTIssue(id)
+
+	view := newPaymentMockLedgerView()
+	view.rules = amendment.NewRulesBuilder().FromPreset(amendment.PresetAllSupported).EnableByName("MPTokensV2").Build()
+	view.createAccount(issuer, 100_000_000, 1)
+	putMPTIssuance(t, view, id, 0, 0)
+
+	sb := NewPaymentSandbox(view)
+	ctx := NewStrandContext(sb, issuer, holder)
+	ctx.OfferCrossing = true
+	ctx.StrandDeliver = issue
+	ctx.SeenBookOuts[issue] = true
+	_, result := NewMPTEndpointStep(ctx, issuer, holder, issue, &fakeStep{}, false, true)
+	require.Equal(t, ter.TesSUCCESS, result)
+}
+
+func keyletIDHex(id [24]byte) string {
+	return FromEitherAmount(NewMPTEitherAmount(0, id)).MPTIssuanceID()
+}
+
+var _ tx.LedgerView = (*paymentMockLedgerView)(nil)

--- a/internal/tx/payment/strand.go
+++ b/internal/tx/payment/strand.go
@@ -139,7 +139,6 @@ const (
 	PathTypeCurrency uint8 = 0x10
 	// PathTypeIssuer indicates path element has issuer
 	PathTypeIssuer uint8 = 0x20
-	// PathTypeMPT indicates path element has an MPTokenIssuanceID.
 	PathTypeMPT uint8 = 0x40
 )
 

--- a/internal/tx/payment/strand.go
+++ b/internal/tx/payment/strand.go
@@ -139,7 +139,7 @@ const (
 	PathTypeCurrency uint8 = 0x10
 	// PathTypeIssuer indicates path element has issuer
 	PathTypeIssuer uint8 = 0x20
-	PathTypeMPT uint8 = 0x40
+	PathTypeMPT    uint8 = 0x40
 )
 
 // ToStrands converts payment paths to executable strands

--- a/internal/tx/payment/strand.go
+++ b/internal/tx/payment/strand.go
@@ -137,6 +137,8 @@ const (
 	PathTypeCurrency uint8 = 0x10
 	// PathTypeIssuer indicates path element has issuer
 	PathTypeIssuer uint8 = 0x20
+	// PathTypeMPT indicates path element has an MPTokenIssuanceID.
+	PathTypeMPT uint8 = 0x40
 )
 
 // ToStrands converts payment paths to executable strands
@@ -160,6 +162,7 @@ func ToStrands(
 	paths [][]PathStep,
 	addDefaultPath bool,
 	offerCrossing bool,
+	parentCloseTime ...uint32,
 ) ([]Strand, ter.Result) {
 	// Validate source and destination are not XRP pseudo-accounts
 	// Reference: rippled PaySteps.cpp:148-150
@@ -172,16 +175,22 @@ func ToStrands(
 	// If dstIssue has zero issuer for non-XRP currency, default to dst.
 	// RippleState balances store zero issuer; the destination account is the implied issuer.
 	// Reference: rippled treats noAccount() issuer as the destination for deliver amounts.
-	if !dstIssue.IsXRP() && dstIssue.Issuer == [20]byte{} {
+	if !dstIssue.IsXRP() && !dstIssue.IsMPT && dstIssue.Issuer == [20]byte{} {
 		dstIssue.Issuer = dst
+	}
+	if !dstIssue.IsConsistent() {
+		return nil, ter.TemBAD_PATH
 	}
 
 	var srcIssue *Issue
 	if srcAmt != nil {
 		issue := GetIssue(*srcAmt)
 		// Same fallback for source issue
-		if !issue.IsXRP() && issue.Issuer == [20]byte{} {
+		if !issue.IsXRP() && !issue.IsMPT && issue.Issuer == [20]byte{} {
 			issue.Issuer = src
+		}
+		if !issue.IsConsistent() {
+			return nil, ter.TemBAD_PATH
 		}
 		srcIssue = &issue
 	}
@@ -191,7 +200,7 @@ func ToStrands(
 
 	// Add default path if requested
 	if addDefaultPath {
-		strand, result := ToStrandWithLoopCheck(view, src, dst, dstIssue, srcIssue, nil, true, offerCrossing)
+		strand, result := ToStrandWithLoopCheck(view, src, dst, dstIssue, srcIssue, nil, true, offerCrossing, parentCloseTime...)
 		if result != ter.TesSUCCESS {
 			// For tem* errors, fail immediately
 			if isTemMalformed(result) || len(paths) == 0 {
@@ -208,7 +217,7 @@ func ToStrands(
 
 	// Convert each explicit path to a strand
 	for _, path := range paths {
-		strand, result := ToStrandWithLoopCheck(view, src, dst, dstIssue, srcIssue, path, false, offerCrossing)
+		strand, result := ToStrandWithLoopCheck(view, src, dst, dstIssue, srcIssue, path, false, offerCrossing, parentCloseTime...)
 		if result != ter.TesSUCCESS {
 			lastFailResult = result
 			// For tem* errors, fail immediately
@@ -255,11 +264,15 @@ func ToStrandWithLoopCheck(
 	path []PathStep,
 	isDefaultPath bool,
 	offerCrossing bool,
+	parentCloseTime ...uint32,
 ) (Strand, ter.Result) {
 	// Create strand context for loop detection
 	ctx := NewStrandContext(view, src, dst)
 	ctx.StrandDeliver = dstIssue
 	ctx.IsDefaultPath = isDefaultPath
+	if len(parentCloseTime) > 0 {
+		ctx.ParentCloseTime = parentCloseTime[0]
+	}
 	if offerCrossing {
 		ctx.OfferCrossing = true
 	}
@@ -279,9 +292,11 @@ type normNode struct {
 	account     [20]byte
 	currency    string
 	issuer      [20]byte
+	mptID       [24]byte
 	hasAccount  bool
 	hasCurrency bool
 	hasIssuer   bool
+	hasMPT      bool
 }
 
 // initialCurIssue returns the starting currency issue for a strand: the source
@@ -289,6 +304,12 @@ type normNode struct {
 // delivered currency. XRP normalizes to the zero issuer.
 // Per rippled: Issue{currency, src}.
 func initialCurIssue(src [20]byte, dstIssue Issue, srcIssue *Issue) Issue {
+	if srcIssue != nil && srcIssue.IsMPT {
+		return *srcIssue
+	}
+	if srcIssue == nil && dstIssue.IsMPT {
+		return dstIssue
+	}
 	var curIssue Issue
 	if srcIssue != nil {
 		curIssue = Issue{Currency: srcIssue.Currency, Issuer: src}
@@ -332,12 +353,17 @@ func ToStrandWithContext(
 // and a currency+issuer pair must agree on XRP-ness.
 func validatePathElementShapes(path []PathStep) ter.Result {
 	const xrpPseudoAccount = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
-	for _, elem := range path {
-		hasAccount := elem.Account != ""
-		hasCurrency := elem.Currency != ""
-		hasIssuer := elem.Issuer != ""
+	for index, elem := range path {
+		typeBits := uint8(elem.Type)
+		if typeBits&^(PathTypeAccount|PathTypeCurrency|PathTypeIssuer|PathTypeMPT) != 0 {
+			return ter.TemBAD_PATH
+		}
+		hasAccount := hasAccount(elem)
+		hasCurrency := hasCurrency(elem)
+		hasIssuer := hasIssuer(elem)
+		hasMPTAsset := hasMPT(elem)
 
-		if !hasAccount && !hasCurrency && !hasIssuer {
+		if !hasAccount && !hasCurrency && !hasIssuer && !hasMPTAsset {
 			return ter.TemBAD_PATH
 		}
 		if hasAccount && (hasCurrency || hasIssuer) {
@@ -355,6 +381,25 @@ func validatePathElementShapes(path []PathStep) ter.Result {
 			if isXRPCurrency != isXRPIssuer {
 				return ter.TemBAD_PATH
 			}
+		}
+		if hasMPTAsset && (hasCurrency || hasAccount) {
+			return ter.TemBAD_PATH
+		}
+		if hasMPTAsset {
+			id, ok := decodeMPTID(elem.MPTIssuanceID)
+			if !ok {
+				return ter.TemBAD_PATH
+			}
+			if hasIssuer {
+				issuer, err := state.DecodeAccountID(elem.Issuer)
+				if err != nil || issuer != mptIssuer(id) {
+					return ter.TemBAD_PATH
+				}
+			}
+		}
+		if index > 0 && hasMPT(path[index-1]) &&
+			(hasAccount || (hasIssuer && !hasCurrency && !hasMPTAsset)) {
+			return ter.TemBAD_PATH
 		}
 	}
 	return ter.TesSUCCESS
@@ -376,14 +421,20 @@ func buildNormalizedPath(
 	var normPath []normNode
 
 	// Add source node
-	normPath = append(normPath, normNode{
-		account:     src,
-		currency:    curIssue.Currency,
-		issuer:      curIssue.Issuer,
-		hasAccount:  true,
-		hasCurrency: true,
-		hasIssuer:   true,
-	})
+	sourceNode := normNode{
+		account:    src,
+		currency:   curIssue.Currency,
+		issuer:     curIssue.Issuer,
+		hasAccount: true,
+		hasIssuer:  true,
+	}
+	if curIssue.IsMPT {
+		sourceNode.mptID = curIssue.MPTID
+		sourceNode.hasMPT = true
+	} else {
+		sourceNode.hasCurrency = true
+	}
+	normPath = append(normPath, sourceNode)
 
 	// If sendMaxIssue has a different account (issuer) than src, insert it
 	// This is the key for cross-issuer ripple payments!
@@ -424,23 +475,32 @@ func buildNormalizedPath(
 				node.hasIssuer = true
 			}
 		}
+		if hasMPT(elem) {
+			if id, ok := decodeMPTID(elem.MPTIssuanceID); ok {
+				node.mptID = id
+				node.hasMPT = true
+				if !node.hasIssuer {
+					node.issuer = mptIssuer(id)
+					node.hasIssuer = true
+				}
+			}
+		}
 		normPath = append(normPath, node)
 	}
 
-	// Find the last element with a currency to check if we need a currency/issuer step.
-	// Reference: rippled PaySteps.cpp lines 219-231
-	lastCurrency := curIssue.Currency
-	var lastCurrencyIssuer [20]byte
-	lastCurrencyIssuerSet := false
+	lastAsset := curIssue
 	for i := len(normPath) - 1; i >= 0; i-- {
-		if normPath[i].hasCurrency {
-			lastCurrency = normPath[i].currency
-			if normPath[i].hasIssuer {
-				lastCurrencyIssuer = normPath[i].issuer
-				lastCurrencyIssuerSet = true
-			} else if normPath[i].hasAccount {
-				lastCurrencyIssuer = normPath[i].account
-				lastCurrencyIssuerSet = true
+		node := normPath[i]
+		if node.hasMPT {
+			lastAsset = NewMPTIssue(node.mptID)
+			break
+		}
+		if node.hasCurrency {
+			lastAsset = Issue{Currency: node.currency}
+			if node.hasIssuer {
+				lastAsset.Issuer = node.issuer
+			} else if node.hasAccount {
+				lastAsset.Issuer = node.account
 			}
 			break
 		}
@@ -453,17 +513,27 @@ func buildNormalizedPath(
 	//   if ((lastCurrency.getCurrency() != deliver.currency) ||
 	//       (offerCrossing &&
 	//        lastCurrency.getIssuerID() != deliver.account))
-	needCurrencyStep := lastCurrency != dstIssue.Currency
-	if !needCurrencyStep && ctx.OfferCrossing && lastCurrencyIssuerSet {
-		needCurrencyStep = lastCurrencyIssuer != dstIssue.Issuer
+	needCurrencyStep := lastAsset.IsMPT != dstIssue.IsMPT
+	if !needCurrencyStep {
+		if lastAsset.IsMPT {
+			needCurrencyStep = lastAsset.MPTID != dstIssue.MPTID
+		} else {
+			needCurrencyStep = lastAsset.Currency != dstIssue.Currency
+			if !needCurrencyStep && ctx.OfferCrossing {
+				needCurrencyStep = lastAsset.Issuer != dstIssue.Issuer
+			}
+		}
 	}
 	if needCurrencyStep {
-		normPath = append(normPath, normNode{
-			currency:    dstIssue.Currency,
-			issuer:      dstIssue.Issuer,
-			hasCurrency: true,
-			hasIssuer:   true,
-		})
+		node := normNode{issuer: dstIssue.Issuer, hasIssuer: true}
+		if dstIssue.IsMPT {
+			node.mptID = dstIssue.MPTID
+			node.hasMPT = true
+		} else {
+			node.currency = dstIssue.Currency
+			node.hasCurrency = true
+		}
+		normPath = append(normPath, node)
 	}
 
 	// Add destination issuer account if needed (for multi-hop through issuer)
@@ -522,14 +592,20 @@ func (ctx *StrandContext) buildStrandSteps(
 		next := normPath[i+1]
 		isLast := i == len(normPath)-2
 
-		// Update current issue based on current node
-		if cur.hasAccount {
-			curIssue.Issuer = cur.account
-		} else if cur.hasIssuer {
-			curIssue.Issuer = cur.issuer
+		// MPT issuers are immutable because the issuer is embedded in the ID.
+		if cur.hasMPT {
+			curIssue = NewMPTIssue(cur.mptID)
+		} else if !curIssue.IsMPT {
+			if cur.hasAccount {
+				curIssue.Issuer = cur.account
+			} else if cur.hasIssuer {
+				curIssue.Issuer = cur.issuer
+			}
 		}
 		if cur.hasCurrency {
 			curIssue.Currency = cur.currency
+			curIssue.MPTID = [24]byte{}
+			curIssue.IsMPT = false
 			if curIssue.IsXRP() {
 				curIssue.Issuer = [20]byte{}
 			}
@@ -537,6 +613,17 @@ func (ctx *StrandContext) buildStrandSteps(
 
 		// Handle account-to-account transitions (DirectStep or implied steps)
 		if cur.hasAccount && next.hasAccount {
+			if curIssue.IsMPT {
+				step, result := NewMPTEndpointStep(
+					ctx, cur.account, next.account, curIssue, prevStep, len(strand) == 0, isLast,
+				)
+				if result != ter.TesSUCCESS {
+					return nil, result
+				}
+				strand = append(strand, step)
+				prevStep = step
+				continue
+			}
 			// Check if we need an implied account step
 			// Per rippled: if curIssue.account != cur.account AND curIssue.account != next.account
 			if !curIssue.IsXRP() && curIssue.Issuer != cur.account && curIssue.Issuer != next.account {
@@ -600,20 +687,24 @@ func (ctx *StrandContext) buildStrandSteps(
 					prevStep = directStep
 				}
 			}
-		} else if cur.hasAccount && !next.hasAccount && (next.hasCurrency || next.hasIssuer) {
+		} else if cur.hasAccount && !next.hasAccount && (next.hasCurrency || next.hasIssuer || next.hasMPT) {
 			// Account to offer (currency change)
 			// Reference: rippled PaySteps.cpp toStep()
 
 			// Determine output issue first (needed for XRP continue check)
-			outCurrency := curIssue.Currency
-			if next.hasCurrency {
-				outCurrency = next.currency
+			outIssue := curIssue
+			if next.hasMPT {
+				outIssue = NewMPTIssue(next.mptID)
+			} else {
+				if next.hasCurrency {
+					outIssue.Currency = next.currency
+					outIssue.IsMPT = false
+					outIssue.MPTID = [24]byte{}
+				}
+				if next.hasIssuer {
+					outIssue.Issuer = next.issuer
+				}
 			}
-			outIssuer := curIssue.Issuer
-			if next.hasIssuer {
-				outIssuer = next.issuer
-			}
-			outIssue := Issue{Currency: outCurrency, Issuer: outIssuer}
 			// XRP must have zero issuer
 			if outIssue.IsXRP() {
 				outIssue.Issuer = [20]byte{}
@@ -636,7 +727,7 @@ func (ctx *StrandContext) buildStrandSteps(
 				if outIssue.IsXRP() {
 					continue
 				}
-			} else if !curIssue.IsXRP() && curIssue.Issuer != cur.account {
+			} else if !curIssue.IsXRP() && !curIssue.IsMPT && curIssue.Issuer != cur.account {
 				// May need implied DirectStep first for IOU
 				// Check for loop BEFORE creating step
 				if result := ctx.CheckDirectStepLoop(cur.account, curIssue.Issuer, curIssue.Currency); result != ter.TesSUCCESS {
@@ -658,7 +749,7 @@ func (ctx *StrandContext) buildStrandSteps(
 			}
 			// Same in/out issue means an invalid book (book_.in == book_.out).
 			// Reference: rippled BookStep::check() line 1346: returns temBAD_PATH
-			if curIssue.Currency == outIssue.Currency && curIssue.Issuer == outIssue.Issuer {
+			if curIssue.Equal(outIssue) {
 				return nil, ter.TemBAD_PATH
 			}
 			// Check for book loop BEFORE creating step
@@ -667,6 +758,7 @@ func (ctx *StrandContext) buildStrandSteps(
 			}
 			bookStep := NewBookStep(curIssue, outIssue, src, dst, prevStep, false)
 			bookStep.defaultPath = ctx.IsDefaultPath
+			bookStep.strandDeliver = ctx.StrandDeliver
 			// Validate book step (noRipple, issuer existence, etc.)
 			// Reference: rippled BookStep.cpp make_BookStepHelper() calls check(ctx)
 			if result := bookStep.Check(view); result != ter.TesSUCCESS {
@@ -685,6 +777,10 @@ func (ctx *StrandContext) buildStrandSteps(
 				}
 				step := ctx.newXRPEndpointStep(next.account, true, false) // destination, isFirst=false
 				strand = append(strand, step)
+			} else if curIssue.IsMPT {
+				if curIssue.Issuer != next.account {
+					return nil, ter.TemBAD_PATH
+				}
 			} else if curIssue.Issuer != next.account {
 				// IOU: implied DirectStep from curIssue.Issuer to next account
 				// Check for loop BEFORE creating step
@@ -699,18 +795,22 @@ func (ctx *StrandContext) buildStrandSteps(
 				strand = append(strand, directStep)
 				prevStep = directStep
 			}
-		} else if !cur.hasAccount && !next.hasAccount && (next.hasCurrency || next.hasIssuer) {
+		} else if !cur.hasAccount && !next.hasAccount && (next.hasCurrency || next.hasIssuer || next.hasMPT) {
 			// Offer to offer (consecutive currency changes)
 			// Reference: rippled PaySteps.cpp toStep() lines 105-130
-			outCurrency := curIssue.Currency
-			if next.hasCurrency {
-				outCurrency = next.currency
+			outIssue := curIssue
+			if next.hasMPT {
+				outIssue = NewMPTIssue(next.mptID)
+			} else {
+				if next.hasCurrency {
+					outIssue.Currency = next.currency
+					outIssue.IsMPT = false
+					outIssue.MPTID = [24]byte{}
+				}
+				if next.hasIssuer {
+					outIssue.Issuer = next.issuer
+				}
 			}
-			outIssuer := curIssue.Issuer
-			if next.hasIssuer {
-				outIssuer = next.issuer
-			}
-			outIssue := Issue{Currency: outCurrency, Issuer: outIssuer}
 			// XRP must have zero issuer
 			if outIssue.IsXRP() {
 				outIssue.Issuer = [20]byte{}
@@ -724,7 +824,7 @@ func (ctx *StrandContext) buildStrandSteps(
 			}
 			// Same in/out issue means an invalid book (book_.in == book_.out).
 			// Reference: rippled BookStep::check() line 1346: returns temBAD_PATH
-			if curIssue.Currency == outIssue.Currency && curIssue.Issuer == outIssue.Issuer {
+			if curIssue.Equal(outIssue) {
 				return nil, ter.TemBAD_PATH
 			}
 			// Check for book loop BEFORE creating step
@@ -733,6 +833,7 @@ func (ctx *StrandContext) buildStrandSteps(
 			}
 			bookStep := NewBookStep(curIssue, outIssue, src, dst, prevStep, false)
 			bookStep.defaultPath = ctx.IsDefaultPath
+			bookStep.strandDeliver = ctx.StrandDeliver
 			// Validate book step (noRipple, issuer existence, etc.)
 			// Reference: rippled BookStep.cpp make_BookStepHelper() calls check(ctx)
 			if result := bookStep.Check(view); result != ter.TesSUCCESS {
@@ -773,15 +874,13 @@ func hasIssuer(elem PathStep) bool {
 	return elem.Issuer != "" || (elem.Type&int(PathTypeIssuer)) != 0
 }
 
+func hasMPT(elem PathStep) bool {
+	return elem.MPTIssuanceID != "" || (elem.Type&int(PathTypeMPT)) != 0
+}
+
 // issuesEqual compares two Issues for equality
 func issuesEqual(a, b Issue) bool {
-	if a.IsXRP() != b.IsXRP() {
-		return false
-	}
-	if a.IsXRP() {
-		return true // Both XRP
-	}
-	return a.Currency == b.Currency && a.Issuer == b.Issuer
+	return a.Equal(b)
 }
 
 // strandsEqual compares two strands for equality

--- a/internal/tx/payment/strand.go
+++ b/internal/tx/payment/strand.go
@@ -6,6 +6,8 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
+var noAccountID = [20]byte{19: 1}
+
 // StrandContext tracks state during strand building for loop detection.
 // Reference: rippled Steps.h StrandContext
 type StrandContext struct {
@@ -164,21 +166,13 @@ func ToStrands(
 	offerCrossing bool,
 	parentCloseTime ...uint32,
 ) ([]Strand, ter.Result) {
-	// Validate source and destination are not XRP pseudo-accounts
-	// Reference: rippled PaySteps.cpp:148-150
-	var xrpAccount [20]byte
-	if src == xrpAccount || dst == xrpAccount {
-		return nil, ter.TemBAD_PATH
-	}
-
 	dstIssue := GetIssue(dstAmt)
 	// If dstIssue has zero issuer for non-XRP currency, default to dst.
 	// RippleState balances store zero issuer; the destination account is the implied issuer.
-	// Reference: rippled treats noAccount() issuer as the destination for deliver amounts.
 	if !dstIssue.IsXRP() && !dstIssue.IsMPT && dstIssue.Issuer == [20]byte{} {
 		dstIssue.Issuer = dst
 	}
-	if !dstIssue.IsConsistent() {
+	if dstIssue.Issuer == noAccountID || !dstIssue.IsConsistent() {
 		return nil, ter.TemBAD_PATH
 	}
 
@@ -189,10 +183,13 @@ func ToStrands(
 		if !issue.IsXRP() && !issue.IsMPT && issue.Issuer == [20]byte{} {
 			issue.Issuer = src
 		}
-		if !issue.IsConsistent() {
+		if issue.Issuer == noAccountID || !issue.IsConsistent() {
 			return nil, ter.TemBAD_PATH
 		}
 		srcIssue = &issue
+	}
+	if result := validateStrandEndpoints(src, dst, dstIssue, srcIssue); result != ter.TesSUCCESS {
+		return nil, result
 	}
 
 	var strands []Strand
@@ -332,6 +329,9 @@ func ToStrandWithContext(
 	path []PathStep,
 	isDefaultPath bool,
 ) (Strand, ter.Result) {
+	if result := validateStrandEndpoints(src, dst, dstIssue, srcIssue); result != ter.TesSUCCESS {
+		return nil, result
+	}
 	// Path-element shape validation runs here, at strand-construction time (during
 	// doApply), not in Payment preflight — mirroring rippled toStrand. This lets
 	// preclaim codes (tecNO_DST, tecDST_TAG_NEEDED, …) win over a malformed path,
@@ -344,6 +344,20 @@ func ToStrandWithContext(
 		return nil, ter.TemBAD_PATH
 	}
 	return ctx.buildStrandSteps(src, dst, dstIssue, srcIssue, normPath)
+}
+
+func validateStrandEndpoints(src, dst [20]byte, dstIssue Issue, srcIssue *Issue) ter.Result {
+	var xrpAccount [20]byte
+	if src == xrpAccount || dst == xrpAccount || src == noAccountID || dst == noAccountID {
+		return ter.TemBAD_PATH
+	}
+	if dstIssue.Issuer == noAccountID || !dstIssue.IsConsistent() {
+		return ter.TemBAD_PATH
+	}
+	if srcIssue != nil && (srcIssue.Issuer == noAccountID || !srcIssue.IsConsistent()) {
+		return ter.TemBAD_PATH
+	}
+	return ter.TesSUCCESS
 }
 
 // validatePathElementShapes rejects malformed path elements with temBAD_PATH,
@@ -374,6 +388,18 @@ func validatePathElementShapes(path []PathStep) ter.Result {
 		}
 		if hasAccount && elem.Account == xrpPseudoAccount {
 			return ter.TemBAD_PATH
+		}
+		if hasIssuer {
+			issuer, err := state.DecodeAccountID(elem.Issuer)
+			if err == nil && issuer == noAccountID {
+				return ter.TemBAD_PATH
+			}
+		}
+		if hasAccount {
+			account, err := state.DecodeAccountID(elem.Account)
+			if err == nil && account == noAccountID {
+				return ter.TemBAD_PATH
+			}
 		}
 		if hasCurrency && hasIssuer {
 			isXRPCurrency := elem.Currency == "XRP"

--- a/internal/tx/payment/strand_no_account_test.go
+++ b/internal/tx/payment/strand_no_account_test.go
@@ -1,0 +1,123 @@
+package payment
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+func TestToStrandsRejectsNoAccount(t *testing.T) {
+	normalID := [24]byte{23: 2}
+	badID := [24]byte{23: 1}
+	normalAmount := newMPTAmount(100, normalID)
+	badAmount := newMPTAmount(100, badID)
+	normalSource := [20]byte{19: 3}
+	normalDestination := [20]byte{19: 4}
+
+	tests := []struct {
+		name    string
+		source  [20]byte
+		dest    [20]byte
+		deliver tx.Amount
+		sendMax *tx.Amount
+	}{
+		{
+			name:    "source account",
+			source:  noAccountID,
+			dest:    normalDestination,
+			deliver: normalAmount,
+			sendMax: &normalAmount,
+		},
+		{
+			name:    "destination account",
+			source:  normalSource,
+			dest:    noAccountID,
+			deliver: normalAmount,
+			sendMax: &normalAmount,
+		},
+		{
+			name:    "SendMax issuer",
+			source:  normalSource,
+			dest:    normalDestination,
+			deliver: normalAmount,
+			sendMax: &badAmount,
+		},
+		{
+			name:    "deliver issuer",
+			source:  normalSource,
+			dest:    normalDestination,
+			deliver: badAmount,
+			sendMax: &normalAmount,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, result := ToStrands(
+				nil,
+				test.source,
+				test.dest,
+				test.deliver,
+				test.sendMax,
+				nil,
+				true,
+				false,
+			)
+			if result != ter.TemBAD_PATH {
+				t.Fatalf("ToStrands() = %v, want TemBAD_PATH", result)
+			}
+		})
+	}
+}
+
+func TestPathElementsRejectNoAccount(t *testing.T) {
+	address := state.EncodeAccountIDSafe(noAccountID)
+	for _, path := range [][]PathStep{
+		{{Account: address}},
+		{{Currency: "USD", Issuer: address}},
+	} {
+		if result := validatePathElementShapes(path); result != ter.TemBAD_PATH {
+			t.Fatalf("validatePathElementShapes(%+v) = %v, want TemBAD_PATH", path, result)
+		}
+	}
+}
+
+func TestToStrandWithLoopCheckRejectsNoAccount(t *testing.T) {
+	normalSource := [20]byte{19: 3}
+	normalDestination := [20]byte{19: 4}
+	normalIssue := Issue{IsMPT: true, MPTID: [24]byte{23: 2}, Issuer: normalSource}
+	badIssue := Issue{IsMPT: true, MPTID: [24]byte{23: 1}, Issuer: noAccountID}
+
+	tests := []struct {
+		name    string
+		source  [20]byte
+		dest    [20]byte
+		deliver Issue
+		sendMax *Issue
+	}{
+		{name: "source account", source: noAccountID, dest: normalDestination, deliver: normalIssue},
+		{name: "destination account", source: normalSource, dest: noAccountID, deliver: normalIssue},
+		{name: "deliver issuer", source: normalSource, dest: normalDestination, deliver: badIssue},
+		{name: "SendMax issuer", source: normalSource, dest: normalDestination, deliver: normalIssue, sendMax: &badIssue},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, result := ToStrandWithLoopCheck(
+				nil,
+				test.source,
+				test.dest,
+				test.deliver,
+				test.sendMax,
+				nil,
+				true,
+				false,
+			)
+			if result != ter.TemBAD_PATH {
+				t.Fatalf("ToStrandWithLoopCheck() = %v, want TemBAD_PATH", result)
+			}
+		})
+	}
+}

--- a/internal/tx/payment/types.go
+++ b/internal/tx/payment/types.go
@@ -1,6 +1,9 @@
 package payment
 
 import (
+	"encoding/hex"
+	"strings"
+
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -34,14 +37,16 @@ const (
 	StrandDirectionReverse
 )
 
-// Issue represents a currency/issuer pair
+// Issue identifies an XRP, issued-currency, or MPT asset.
 type Issue struct {
 	Currency string
 	Issuer   [20]byte
+	MPTID    [24]byte
+	IsMPT    bool
 }
 
 func (i Issue) IsXRP() bool {
-	return i.Currency == "XRP" || i.Currency == ""
+	return !i.IsMPT && (i.Currency == "XRP" || i.Currency == "")
 }
 
 // IsConsistent reports whether the issue's currency and issuer agree on XRP-ness:
@@ -49,7 +54,25 @@ func (i Issue) IsXRP() bool {
 // issuer. A bare-currency path element that resolves to a zero issuer yields an
 // inconsistent (uncrossable) book. Mirrors rippled isConsistent(Issue).
 func (i Issue) IsConsistent() bool {
+	if i.IsMPT {
+		return i.MPTID != [24]byte{} && i.Issuer != [20]byte{} &&
+			i.Issuer == mptIssuer(i.MPTID)
+	}
 	return i.IsXRP() == (i.Issuer == [20]byte{})
+}
+
+func NewMPTIssue(id [24]byte) Issue {
+	return Issue{MPTID: id, Issuer: mptIssuer(id), IsMPT: true}
+}
+
+func (i Issue) Equal(other Issue) bool {
+	if i.IsMPT || other.IsMPT {
+		return i.IsMPT && other.IsMPT && i.MPTID == other.MPTID
+	}
+	if i.IsXRP() && other.IsXRP() {
+		return true
+	}
+	return i.Currency == other.Currency && i.Issuer == other.Issuer
 }
 
 // Book represents an order book (input/output issue pair)
@@ -113,6 +136,12 @@ func GetIssue(amt tx.Amount) Issue {
 	if amt.IsNative() {
 		return Issue{Currency: "XRP"}
 	}
+	if amt.IsMPT() {
+		if id, ok := decodeMPTID(amt.MPTIssuanceID()); ok {
+			return NewMPTIssue(id)
+		}
+		return Issue{IsMPT: true}
+	}
 
 	var issuerBytes [20]byte
 	if issuerID, err := state.DecodeAccountID(amt.Issuer); err == nil {
@@ -123,4 +152,28 @@ func GetIssue(amt tx.Amount) Issue {
 		Currency: amt.Currency,
 		Issuer:   issuerBytes,
 	}
+}
+
+func decodeMPTID(value string) ([24]byte, bool) {
+	var id [24]byte
+	b, err := hex.DecodeString(strings.TrimSpace(value))
+	if err != nil || len(b) != len(id) {
+		return id, false
+	}
+	copy(id[:], b)
+	return id, true
+}
+
+func mptIssuer(id [24]byte) [20]byte {
+	var issuer [20]byte
+	copy(issuer[:], id[4:])
+	return issuer
+}
+
+func newMPTAmount(value int64, id [24]byte) tx.Amount {
+	return state.NewMPTAmountWithIssuanceID(
+		value,
+		state.EncodeAccountIDSafe(mptIssuer(id)),
+		strings.ToUpper(hex.EncodeToString(id[:])),
+	)
 }

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -61,6 +61,12 @@ type RulesPreflighter interface {
 	PreflightRules(rules *amendment.Rules) error
 }
 
+// RulesAwarePreflighter is implemented by transaction types whose complete
+// type-specific preflight body must interleave amendment-dependent checks.
+type RulesAwarePreflighter interface {
+	PreflightWithRules(rules *amendment.Rules) error
+}
+
 // ExtraFeaturesChecker is implemented by transaction types with an amendment
 // gate that rippled evaluates in T::checkExtraFeatures — which runs in
 // invokePreflight BEFORE preflight1's common checks (flags mask, NetworkID,

--- a/internal/tx/vault/apply_helpers.go
+++ b/internal/tx/vault/apply_helpers.go
@@ -259,7 +259,7 @@ func addEmptyHolding(ctx *tx.ApplyContext, accountID [20]byte, asset tx.Asset) (
 
 // readVault reads and parses the vault ledger entry at vaultKey, returning
 // (nil, nil) when the entry does not exist.
-func readVault(view tx.LedgerView, vaultKey keylet.Keylet) (*vaultData, error) {
+func readVault(view AssetReadView, vaultKey keylet.Keylet) (*vaultData, error) {
 	data, err := view.Read(vaultKey)
 	if err != nil || len(data) == 0 {
 		return nil, nil

--- a/internal/tx/vault/exports.go
+++ b/internal/tx/vault/exports.go
@@ -186,7 +186,7 @@ type VaultInfo struct {
 }
 
 // ReadVaultInfo reads the vault at vaultKey, returning (nil, nil) when absent.
-func ReadVaultInfo(view tx.LedgerView, vaultKey keylet.Keylet) (*VaultInfo, error) {
+func ReadVaultInfo(view AssetReadView, vaultKey keylet.Keylet) (*VaultInfo, error) {
 	vd, err := readVault(view, vaultKey)
 	if err != nil || vd == nil {
 		return nil, err

--- a/keylet/amm_mpt_test.go
+++ b/keylet/amm_mpt_test.go
@@ -1,0 +1,59 @@
+package keylet
+
+import "testing"
+
+func TestAMMAssetIssueCompatibility(t *testing.T) {
+	cur1 := [20]byte{1}
+	iss1 := [20]byte{2}
+	cur2 := [20]byte{3}
+	iss2 := [20]byte{4}
+
+	want := indexHash(spaceAMM, iss1[:], cur1[:], iss2[:], cur2[:])
+	legacy := AMM(iss1, cur1, iss2, cur2)
+	asset := AMMAsset(IssueSide(cur1, iss1), IssueSide(cur2, iss2))
+	if legacy.Key != want || asset.Key != want {
+		t.Fatalf("Issue/Issue AMM key changed: legacy=%x asset=%x want=%x", legacy.Key, asset.Key, want)
+	}
+}
+
+func TestAMMAssetMPTLayouts(t *testing.T) {
+	cur := [20]byte{3}
+	iss := [20]byte{4}
+	mpt1 := [24]byte{1}
+	mpt2 := [24]byte{2}
+
+	tests := []struct {
+		name   string
+		asset1 BookSide
+		asset2 BookSide
+		want   [32]byte
+	}{
+		{
+			name:   "Issue MPT",
+			asset1: IssueSide(cur, iss),
+			asset2: MPTSide(mpt1),
+			want:   indexHash(spaceAMM, mpt1[:], iss[:], cur[:]),
+		},
+		{
+			name:   "MPT Issue reverse input",
+			asset1: MPTSide(mpt1),
+			asset2: IssueSide(cur, iss),
+			want:   indexHash(spaceAMM, mpt1[:], iss[:], cur[:]),
+		},
+		{
+			name:   "MPT MPT",
+			asset1: MPTSide(mpt2),
+			asset2: MPTSide(mpt1),
+			want:   indexHash(spaceAMM, mpt1[:], mpt2[:]),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := AMMAsset(test.asset1, test.asset2)
+			if got.Key != test.want {
+				t.Fatalf("AMMAsset key=%x, want %x", got.Key, test.want)
+			}
+		})
+	}
+}

--- a/keylet/keylet.go
+++ b/keylet/keylet.go
@@ -560,20 +560,46 @@ func PayChannel(srcAccountID, dstAccountID [20]byte, sequence uint32) Keylet {
 // std::minmax feeding indexHash in
 // rippled/src/libxrpl/protocol/Indexes.cpp:446-456 amm().
 func AMM(issue1Issuer, issue1Currency, issue2Issuer, issue2Currency [20]byte) Keylet {
-	var minIssuer, minCurrency, maxIssuer, maxCurrency [20]byte
+	return AMMAsset(
+		IssueSide(issue1Currency, issue1Issuer),
+		IssueSide(issue2Currency, issue2Issuer),
+	)
+}
 
-	if issue1LessEqualIssue2(issue1Currency, issue1Issuer, issue2Currency, issue2Issuer) {
-		minIssuer, minCurrency = issue1Issuer, issue1Currency
-		maxIssuer, maxCurrency = issue2Issuer, issue2Currency
-	} else {
-		minIssuer, minCurrency = issue2Issuer, issue2Currency
-		maxIssuer, maxCurrency = issue1Issuer, issue1Currency
+// AMMAsset returns the AMM keylet for two Issue or MPT assets. Asset ordering
+// matches rippled's Asset comparison: MPT assets sort before Issue assets;
+// assets of the same kind retain their native Issue/MPT ordering.
+func AMMAsset(asset1, asset2 BookSide) Keylet {
+	minAsset, maxAsset := asset1, asset2
+	if !bookSideLessEqual(asset1, asset2) {
+		minAsset, maxAsset = asset2, asset1
 	}
 
-	return Keylet{
-		Type: entry.TypeAMM,
-		Key:  indexHash(spaceAMM, minIssuer[:], minCurrency[:], maxIssuer[:], maxCurrency[:]),
+	var key [32]byte
+	switch {
+	case minAsset.IsMPT && maxAsset.IsMPT:
+		key = indexHash(spaceAMM, minAsset.MPTID[:], maxAsset.MPTID[:])
+	case minAsset.IsMPT:
+		key = indexHash(spaceAMM, minAsset.MPTID[:], maxAsset.Issuer[:], maxAsset.Currency[:])
+	default:
+		key = indexHash(
+			spaceAMM,
+			minAsset.Issuer[:], minAsset.Currency[:],
+			maxAsset.Issuer[:], maxAsset.Currency[:],
+		)
 	}
+
+	return Keylet{Type: entry.TypeAMM, Key: key}
+}
+
+func bookSideLessEqual(lhs, rhs BookSide) bool {
+	if lhs.IsMPT != rhs.IsMPT {
+		return lhs.IsMPT
+	}
+	if lhs.IsMPT {
+		return bytes.Compare(lhs.MPTID[:], rhs.MPTID[:]) <= 0
+	}
+	return issue1LessEqualIssue2(lhs.Currency, lhs.Issuer, rhs.Currency, rhs.Issuer)
 }
 
 // IssueLessEqual reports whether issue1 sorts at-or-before issue2 under

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -92,6 +92,8 @@ single-host soaks; prewarm (2dd0b6a8) is the current lever, measured by iter4.
 - [x] Run focused tests, full transaction/integration coverage, build, vet, lint,
       and final rippled 3.2.0 review
 - [x] Resolve the uncached CI goimports alignment failure and re-run lint
+- [x] Fix the terminal resource-manager Start/Stop race exposed by core CI
+- [x] Run focused race tests, strict lint, and the core package suite
 
 ## Review
 
@@ -113,6 +115,9 @@ Verification:
 - `just build-all`, `just build-nocgo`, `just vet`, and `just lint` pass.
 - The CI-only goimports finding in `strand.go` was corrected and reproduced
   locally with the formatter check before repushing.
+- The core CI race exposed a pre-existing terminal lifecycle gap in the resource
+  manager. Start/Stop are now serialized against late startup, and the exact
+  core `-race` shard plus repeated manager/Components lifecycle tests pass.
 - The full module test run passes outside the established out-of-scope
   conformance failures.
 - Final conformance: 941 pass / 117 fail overall, 879 pass / 0 fail in scope;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -70,3 +70,46 @@ rewind) fixed; 2 refuted-but-real hardenings applied; iter27-trap concern
 resolved by validations-first precedence.
 Remaining known gap: 15k sustained smoothness is paced by build latency on
 single-host soaks; prewarm (2dd0b6a8) is the current lever, measured by iter4.
+
+# Issue #1287 — MPTokensV2 amendment-on engine support
+
+## Plan
+
+- [x] Map PR #1286's nine roadmap points to the v3 Go implementation and the
+      rippled 3.2.0 tag, including all reachable call sites and parity tests.
+- [x] Extend payment primitives (`EitherAmount`, `Issue`, `Book`, path nodes)
+      with a coherent MPT arm and add reusable sandbox-aware MPT credit/funding.
+- [x] Implement and wire `MPTEndpointStep`, including strand construction,
+      reverse/forward liquidity, transfer fees, authorization, locks, and clawback.
+- [x] Implement MPT order books end to end: book keys/directories, offer funding,
+      crossing, transfer, rate/auth checks, and offer placement fields.
+- [x] Implement amendment-on MPT apply behavior for AMM and Check transactions,
+      including `lsfMPTAMM` ledger marking.
+- [x] Thread `mpt_issuance_id` through book/path RPC request and response surfaces.
+- [x] Port focused rippled parity cases and add Go unit/integration coverage for
+      the new type arms, endpoint, book, AMM, Check, and RPC behavior.
+- [x] Run formatting, focused tests incrementally, relevant integration suites,
+      `just vet`, and `just build`; inspect the final diff for wiring and parity.
+
+## Review
+
+Implemented the coordinated MPT amount, sandbox, endpoint, book, offer, AMM,
+Check, and RPC path. The protocol-bearing diff was checked against the local
+rippled 3.2.0 implementations and their MPT, AMM-MPT, and Check-MPT test cases.
+The rippled C++ tests were used as the parity oracle but were not executed.
+
+Review findings fixed before handoff include zero-issuer asset rejection,
+MPT endpoint check ordering, exact transfer-fee rounding and overflow handling,
+owner-directory type discrimination, and preservation of issuer-agnostic IOU
+rippling while MPT path matching remains issuance-specific.
+
+Verification:
+
+- Focused state, ledger service, payment, pathfinder, offer, AMM, Check, vault,
+  RPC, and integration tests pass.
+- `just vet`, `just build`, and `just lint` pass (`golangci-lint`: 0 issues).
+- Feature and clean-base `just conformance --failing` results are identical:
+  941 pass / 117 fail overall, 879 pass / 0 fail in scope. The 117 failures are
+  the existing out-of-scope Batch, Vault, XChain, and XChainSim suites.
+- The full module test run passes outside those same out-of-scope conformance
+  failures.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -70,3 +70,21 @@ rewind) fixed; 2 refuted-but-real hardenings applied; iter27-trap concern
 resolved by validations-first precedence.
 Remaining known gap: 15k sustained smoothness is paced by build latency on
 single-host soaks; prewarm (2dd0b6a8) is the current lever, measured by iter4.
+
+# Issue #1280 — FlagsMasker completion audit
+
+- [x] Inventory all 75 registered transaction types
+- [x] Compare all 23 rippled 3.2.0 `getFlagsMask` overrides and the base mask
+- [x] Check for invalid-bit masks left solely in `Validate`
+- [x] Fix the residual MPTokensV2-dependent Payment mask
+- [x] Pin exact masks and bad-fee precedence
+- [x] Run transaction tests, vet, and build
+
+## Review
+
+PR #1298 covered its advertised sweep, but the earlier Payment adoption still
+used the MPTokensV1 mask after MPTokensV2 activation. `Payment.GetFlagsMask` is
+now rule-aware, matching rippled 3.2.0: MPTokensV1 rejects `tfLimitQuality` at
+preflight0, while MPTokensV2 permits it so a malformed fee returns `temBAD_FEE`.
+No second mask or validation-stage gap was found. `just test-tx`, `just vet`,
+and `just build` pass.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -82,22 +82,39 @@ single-host soaks; prewarm (2dd0b6a8) is the current lever, measured by iter4.
 
 ## Finalization fixes
 
-- [ ] Match the mask predicate to the MPT Amount, not the legacy issuance field
-- [ ] Preserve rippled's ordered MPTokensV1/V2 Payment preflight semantics
-- [ ] Route MPTokensV2 Payments through the MPT-capable flow engine
-- [ ] Port valid-fee flag, path, SendMax, disabled-gate, and routing regressions
-- [ ] Remove the legacy standalone Payment issuance field and builder plumbing
-- [ ] Run focused tests, full transaction/integration coverage, build, vet, lint,
+- [x] Match the mask predicate to the MPT Amount, not the legacy issuance field
+- [x] Preserve rippled's ordered MPTokensV1/V2 Payment preflight semantics
+- [x] Route MPTokensV2 Payments through the MPT-capable flow engine
+- [x] Port valid-fee flag, path, SendMax, disabled-gate, and routing regressions
+- [x] Remove the legacy standalone Payment issuance field and builder plumbing
+- [x] Reject malformed MPT JSON, noAccount paths, and invalid MPT offer images
+- [x] Preserve internal storage errors through MPT authorization and funding paths
+- [x] Run focused tests, full transaction/integration coverage, build, vet, lint,
       and final rippled 3.2.0 review
 
 ## Review
 
-PR #1298 covered its advertised sweep, but the earlier Payment adoption still
-used the MPTokensV1 mask after MPTokensV2 activation. `Payment.GetFlagsMask` is
-now rule-aware: MPTokensV1 rejects `tfLimitQuality` at preflight0, while
-MPTokensV2 permits it so a malformed fee returns `temBAD_FEE`. Finalization
-against rippled 3.2.0 found that the rule-aware body and apply routing were not
-yet wired; the corrective work is tracked above.
+Finalized PR #1308 against local rippled v3.2.0. Payment now uses the MPT Amount
+as the authoritative asset identity, preserves rippled's V1/V2 preflight order
+and TER precedence, and routes MPTokensV2 through Flow while retaining the V1
+direct-transfer path. The standalone Go-only issuance field was removed.
+
+The final review also fixed MPT wire/path serialization, cross-asset and
+MPT-to-MPT offer crossing, destination checks, noAccount rejection, MPT offer
+invariant parsing, pseudo-account authorization gating, canonical integral MPT
+JSON parsing, and propagation of ledger storage/parse errors through shared MPT,
+Offer, Check, AMM, and FlowCross code.
+
+Verification:
+
+- Focused state, payment, engine, invariant, mptutil, offer, check, AMM, MPT,
+  deposit-preauth, and delegate suites pass uncached.
+- `just build-all`, `just build-nocgo`, `just vet`, and `just lint` pass.
+- The full module test run passes outside the established out-of-scope
+  conformance failures.
+- Final conformance: 941 pass / 117 fail overall, 879 pass / 0 fail in scope;
+  the 117 failures remain the out-of-scope Batch, Vault, XChain, and XChainSim
+  suites.
 
 # Issue #1287 — MPTokensV2 amendment-on engine support
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -91,6 +91,7 @@ single-host soaks; prewarm (2dd0b6a8) is the current lever, measured by iter4.
 - [x] Preserve internal storage errors through MPT authorization and funding paths
 - [x] Run focused tests, full transaction/integration coverage, build, vet, lint,
       and final rippled 3.2.0 review
+- [x] Resolve the uncached CI goimports alignment failure and re-run lint
 
 ## Review
 
@@ -110,6 +111,8 @@ Verification:
 - Focused state, payment, engine, invariant, mptutil, offer, check, AMM, MPT,
   deposit-preauth, and delegate suites pass uncached.
 - `just build-all`, `just build-nocgo`, `just vet`, and `just lint` pass.
+- The CI-only goimports finding in `strand.go` was corrected and reproduced
+  locally with the formatter check before repushing.
 - The full module test run passes outside the established out-of-scope
   conformance failures.
 - Final conformance: 941 pass / 117 fail overall, 879 pass / 0 fail in scope;


### PR DESCRIPTION
## Summary
- Complete the FlagsMasker audit across all 75 registered transaction types against local rippled 3.2.0.
- Make `Payment.GetFlagsMask` use the restricted MPTokensV1 mask only until MPTokensV2 is enabled; V2 payments now receive the regular payment flag surface and correct preflight precedence.
- Pin the exact V1/V2 mask values and the invalid-flag-versus-bad-fee result ordering.

## Test plan
- [x] `just test-pkg ./internal/tx/payment/...`
- [x] `just test-pkg ./internal/tx/engine/...`
- [x] `just test-tx`
- [x] `just vet`
- [x] `just build`

Fixes #1280
