### PR TITLE
fix: recover pseudo transaction apply panics

### DIFF
--- a/internal/ledger/inbound/replay_delta.go
+++ b/internal/ledger/inbound/replay_delta.go
@@ -628,7 +628,12 @@ func (r *ReplayDelta) Apply(engineCfg tx.EngineConfig) (*ledger.Ledger, error) {
 		}
 		txn.SetRawBytes(dtx.TxBytes)
 
-		result := engine.Apply(txn)
+		var result tx.ApplyResult
+		if txn.TxType().IsPseudoTransaction() {
+			result = engine.ApplyPseudo(txn)
+		} else {
+			result = engine.Apply(txn)
+		}
 
 		// R6b.2a: compare engine-generated meta against the peer-supplied
 		// meta so operators can see when our engine drifts from rippled's

--- a/internal/testing/p2p/replay_delta_apply_integration_test.go
+++ b/internal/testing/p2p/replay_delta_apply_integration_test.go
@@ -2,11 +2,13 @@ package p2p
 
 import (
 	"encoding/hex"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	consensuscommon "github.com/LeJamon/go-xrpl/internal/consensus/common"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
@@ -19,6 +21,7 @@ import (
 	xrplgoTesting "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
@@ -123,6 +126,62 @@ func TestReplayDelta_Apply_Integration(t *testing.T) {
 	wantTx, err := successor.TxMapHash()
 	require.NoError(t, err)
 	assert.Equal(t, wantTx, gotTx, "derived TxHash must match successor's")
+}
+
+func TestReplayDelta_Apply_PseudoTransaction(t *testing.T) {
+	env := xrplgoTesting.NewTestEnv(t)
+	env.Close()
+	parent := env.LastClosedLedger()
+	require.NotNil(t, parent)
+
+	ledgerSequence := parent.Sequence() + 1
+	txBlob, err := consensuscommon.BuildPseudoTx(tx.TypeAmendment, func(base tx.BaseTx) tx.Transaction {
+		return &pseudo.EnableAmendment{
+			BaseTx:         base,
+			Amendment:      strings.Repeat("AB", 32),
+			LedgerSequence: &ledgerSequence,
+		}
+	})
+	require.NoError(t, err)
+	txn, err := tx.ParseFromBinary(txBlob)
+	require.NoError(t, err)
+	txn.SetRawBytes(txBlob)
+	txHash, err := tx.ComputeTransactionHash(txn)
+	require.NoError(t, err)
+
+	closeTime := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	successor, txMetaBlob := buildClosedSuccessor(t, parent, txn, txBlob, txHash, closeTime)
+	successorHash := successor.Hash()
+	resp := &message.ReplayDeltaResponse{
+		LedgerHash:   successorHash[:],
+		LedgerHeader: header.AddRaw(successor.Header(), false),
+		Transactions: [][]byte{txMetaBlob},
+	}
+	rd := inbound.NewReplayDelta(successorHash, 7, parent, nil)
+	require.NoError(t, rd.GotResponse(resp))
+
+	derived, err := rd.Apply(tx.EngineConfig{
+		BaseFee:                   10,
+		ReserveBase:               200_000_000,
+		ReserveIncrement:          50_000_000,
+		SkipSignatureVerification: false,
+		Rules:                     amendment.AllSupportedRules(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, derived)
+	assert.Equal(t, successorHash, derived.Hash())
+
+	gotState, err := derived.StateMapHash()
+	require.NoError(t, err)
+	wantState, err := successor.StateMapHash()
+	require.NoError(t, err)
+	assert.Equal(t, wantState, gotState)
+
+	gotTx, err := derived.TxMapHash()
+	require.NoError(t, err)
+	wantTx, err := successor.TxMapHash()
+	require.NoError(t, err)
+	assert.Equal(t, wantTx, gotTx)
 }
 
 // TestReplay_TefTxDoesNotInstallPeerLeaf verifies D5 — the apply
@@ -250,9 +309,17 @@ func buildClosedSuccessor(
 		ApplyFlags:                tx.TapNONE,
 		Rules:                     amendment.AllSupportedRules(),
 	})
-	res := engine.Apply(txn)
+	var res tx.ApplyResult
+	if txn.TxType().IsPseudoTransaction() {
+		res = engine.ApplyPseudo(txn)
+	} else {
+		res = engine.Apply(txn)
+	}
 	require.True(t, res.Result.IsApplied(),
 		"setup tx must apply cleanly (got %s: %s)", res.Result.String(), res.Message)
+	require.NotNil(t, res.Metadata)
+	require.Equal(t, uint32(0), res.Metadata.TransactionIndex)
+	require.Equal(t, uint32(1), engine.TxCount())
 
 	// Build the tx-with-meta blob and install it as a leaf — this is
 	// what the peer would have serialized and what Apply expects to

--- a/internal/testing/pseudotx/preflight_test.go
+++ b/internal/testing/pseudotx/preflight_test.go
@@ -71,6 +71,7 @@ func TestPseudoPreflight_AccountMustBeZero(t *testing.T) {
 	result := engine.ApplyPseudo(tx)
 	require.False(t, result.Applied)
 	require.Equal(t, "temBAD_SRC_ACCOUNT", result.Result.String())
+	require.Nil(t, result.Metadata)
 }
 
 // TestPseudoPreflight_AcceptsEmptyAccount confirms an empty Account passes the
@@ -194,6 +195,7 @@ func TestSetFee_PreclaimXRPFeesEnabled_RequiresModernFields(t *testing.T) {
 	result := engine.ApplyPseudo(setFee)
 	require.False(t, result.Applied)
 	require.Equal(t, "temMALFORMED", result.Result.String())
+	require.Nil(t, result.Metadata)
 }
 
 // TestSetFee_PreclaimXRPFeesEnabled_ForbidsLegacyFields rejects a SetFee

--- a/internal/tx/engine/apply.go
+++ b/internal/tx/engine/apply.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
@@ -216,11 +217,39 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx txcore.Transaction) tx
 //
 // Equivalent to ApplyPseudoWithContext(context.Background(), tx).
 func (e *Engine) ApplyPseudo(tx txcore.Transaction) txcore.ApplyResult {
-	return e.applyPseudoTransaction(context.Background(), tx)
+	return e.ApplyPseudoWithContext(context.Background(), tx)
 }
 
 func (e *Engine) ApplyPseudoWithContext(ctx context.Context, tx txcore.Transaction) txcore.ApplyResult {
-	return e.applyPseudoTransaction(ctx, tx)
+	return e.applyPseudoSafely(func() txcore.ApplyResult {
+		return e.applyPseudoTransaction(ctx, tx)
+	})
+}
+
+type atomicPseudoView interface {
+	txcore.LedgerView
+	MutableSnapshot() (*ledger.Ledger, error)
+	AdoptState(*ledger.Ledger) error
+}
+
+func (e *Engine) applyPseudoSafely(apply func() txcore.ApplyResult) (result txcore.ApplyResult) {
+	completed := false
+	result = txcore.ApplyResult{
+		Result:  ter.TefEXCEPTION,
+		Applied: false,
+		Message: ter.TefEXCEPTION.Message(),
+	}
+	defer func() {
+		recovered := recover()
+		if !completed {
+			e.logger.Error("pseudo-transaction apply panic recovered, returning tefEXCEPTION",
+				"panic", recovered)
+		}
+	}()
+
+	result = apply()
+	completed = true
+	return result
 }
 
 // applyPseudoTransaction handles pseudo-transactions (Amendment, SetFee, UNLModify).
@@ -240,11 +269,10 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx txcore.Transa
 	// result rather than a serialization-induced tefINTERNAL.
 	if gate := e.pseudoPreflight(tx, rules); !gate.IsSuccess() {
 		return txcore.ApplyResult{
-			Result:   gate,
-			Applied:  false,
-			Fee:      0,
-			Metadata: &txcore.Metadata{TransactionResult: gate},
-			Message:  gate.Message(),
+			Result:  gate,
+			Applied: false,
+			Fee:     0,
+			Message: gate.Message(),
 		}
 	}
 
@@ -253,11 +281,10 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx txcore.Transa
 	// gating (e.g. XRPFees) runs through the PseudoPreclaim interface.
 	if gate := e.pseudoPreclaim(tx, rules); !gate.IsSuccess() {
 		return txcore.ApplyResult{
-			Result:   gate,
-			Applied:  false,
-			Fee:      0,
-			Metadata: &txcore.Metadata{TransactionResult: gate},
-			Message:  gate.Message(),
+			Result:  gate,
+			Applied: false,
+			Fee:     0,
+			Message: gate.Message(),
 		}
 	}
 
@@ -274,11 +301,27 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx txcore.Transa
 	// A zero transaction id is never valid (rippled preflight0, Transactor.cpp).
 	if txHash == ([32]byte{}) {
 		return txcore.ApplyResult{
-			Result:   ter.TemINVALID,
-			Applied:  false,
-			Fee:      0,
-			Metadata: &txcore.Metadata{TransactionResult: ter.TemINVALID},
-			Message:  "transaction id may not be zero",
+			Result:  ter.TemINVALID,
+			Applied: false,
+			Fee:     0,
+			Message: "transaction id may not be zero",
+		}
+	}
+
+	base, ok := e.view.(atomicPseudoView)
+	if !ok {
+		return txcore.ApplyResult{
+			Result:  ter.TefINTERNAL,
+			Applied: false,
+			Message: "pseudo-transaction application requires an atomic ledger view",
+		}
+	}
+	snapshot, err := base.MutableSnapshot()
+	if err != nil {
+		return txcore.ApplyResult{
+			Result:  ter.TefINTERNAL,
+			Applied: false,
+			Message: fmt.Sprintf("failed to create ledger snapshot: %v", err),
 		}
 	}
 
@@ -289,7 +332,7 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx txcore.Transa
 	}
 
 	// Create ApplyStateTable to track changes
-	table := applystate.NewApplyStateTable(e.view, txHash, e.config.LedgerSequence, rules)
+	table := applystate.NewApplyStateTable(snapshot, txHash, e.config.LedgerSequence, rules)
 
 	// Create a minimal ApplyContext for pseudo-transactions
 	ctx := &txcore.ApplyContext{
@@ -310,7 +353,7 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx txcore.Transa
 			return appliable.Apply(ctx)
 		})
 	} else {
-		result = ter.TesSUCCESS
+		result = ter.TefINTERNAL
 	}
 
 	metadata.TransactionResult = result
@@ -320,10 +363,9 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx txcore.Transa
 		generatedMeta, err := table.Apply()
 		if err != nil {
 			return txcore.ApplyResult{
-				Result:   ter.TefINTERNAL,
-				Applied:  false,
-				Metadata: metadata,
-				Message:  fmt.Sprintf("failed to apply state changes: %v", err),
+				Result:  ter.TefINTERNAL,
+				Applied: false,
+				Message: fmt.Sprintf("failed to apply state changes: %v", err),
 			}
 		}
 		metadata.AffectedNodes = generatedMeta.AffectedNodes
@@ -332,7 +374,15 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx txcore.Transa
 	// Assign TransactionIndex for applied pseudo-transactions
 	applied := result.IsApplied()
 	if applied {
-		metadata.TransactionIndex = e.txCount.Add(1) - 1
+		metadata.TransactionIndex = e.txCount.Load()
+		if err := base.AdoptState(snapshot); err != nil {
+			return txcore.ApplyResult{
+				Result:  ter.TefINTERNAL,
+				Applied: false,
+				Message: fmt.Sprintf("failed to commit ledger snapshot: %v", err),
+			}
+		}
+		e.txCount.Add(1)
 	} else {
 		metadata = nil
 	}

--- a/internal/tx/engine/apply.go
+++ b/internal/tx/engine/apply.go
@@ -189,6 +189,8 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx txcore.Transaction) tx
 	if applied {
 		e.view.AdjustDropsDestroyed(drops.XRPAmount(fee))
 		metadata.TransactionIndex = e.txCount.Add(1) - 1
+	} else {
+		metadata = nil
 	}
 
 	e.logger.Debug("apply result",
@@ -304,7 +306,9 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx txcore.Transa
 	// Apply the transaction
 	var result ter.Result
 	if appliable, ok := tx.(txcore.Appliable); ok {
-		result = appliable.Apply(ctx)
+		result = e.invokeApplySafely(txHash, func() ter.Result {
+			return appliable.Apply(ctx)
+		})
 	} else {
 		result = ter.TesSUCCESS
 	}
@@ -326,13 +330,16 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx txcore.Transa
 	}
 
 	// Assign TransactionIndex for applied pseudo-transactions
-	if result.IsApplied() {
+	applied := result.IsApplied()
+	if applied {
 		metadata.TransactionIndex = e.txCount.Add(1) - 1
+	} else {
+		metadata = nil
 	}
 
 	return txcore.ApplyResult{
 		Result:   result,
-		Applied:  result.IsApplied(),
+		Applied:  applied,
 		Fee:      0, // Pseudo-transactions have no fee
 		Metadata: metadata,
 		Message:  result.Message(),

--- a/internal/tx/engine/apply_panic_test.go
+++ b/internal/tx/engine/apply_panic_test.go
@@ -1,0 +1,99 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/protocol"
+)
+
+type panicApplyTx struct {
+	txcore.Transaction
+	writeKey keylet.Keylet
+	mutated  bool
+}
+
+func (t *panicApplyTx) Apply(ctx *txcore.ApplyContext) ter.Result {
+	if err := ctx.View.Insert(t.writeKey, []byte("uncommitted")); err != nil {
+		panic(err)
+	}
+	t.mutated = true
+	panic("apply failed")
+}
+
+func TestApplyPanicReturnsTefExceptionWithoutMutatingState(t *testing.T) {
+	view := newMockBaseView()
+	accountKey := fundRecoveryAccount(t, view, 1_000_000, 1)
+	writeKey := keylet.Keylet{Key: [32]byte{1}}
+	txn := &panicApplyTx{
+		Transaction: recoveryTx(10, 1),
+		writeKey:    writeKey,
+	}
+	engine := recoveryEngine(view, txcore.TapNONE)
+
+	result := engine.Apply(txn)
+
+	assertRecoveredApplyPanic(t, result, txn, view, writeKey)
+	if engine.TxCount() != 0 {
+		t.Fatalf("transaction count = %d, want 0", engine.TxCount())
+	}
+	account := readRecoveryAccount(t, view, accountKey)
+	if account.Balance != 1_000_000 || account.Sequence != 1 {
+		t.Fatalf("account balance/sequence = %d/%d, want 1000000/1", account.Balance, account.Sequence)
+	}
+}
+
+func TestApplyPseudoPanicReturnsTefExceptionWithoutMutatingState(t *testing.T) {
+	view := newMockBaseView()
+	writeKey := keylet.Keylet{Key: [32]byte{2}}
+	ledgerSequence := uint32(100)
+	txn := &panicApplyTx{
+		Transaction: &pseudo.EnableAmendment{
+			BaseTx:         *txcore.NewBaseTx(txcore.TypeAmendment, protocol.ZeroAccount),
+			Amendment:      "0101010101010101010101010101010101010101010101010101010101010101",
+			LedgerSequence: &ledgerSequence,
+		},
+		writeKey: writeKey,
+	}
+	engine := NewEngine(view, txcore.EngineConfig{
+		LedgerSequence: ledgerSequence,
+		Rules:          amendment.AllSupportedRules(),
+	})
+
+	result := engine.ApplyPseudo(txn)
+
+	assertRecoveredApplyPanic(t, result, txn, view, writeKey)
+	if engine.TxCount() != 0 {
+		t.Fatalf("transaction count = %d, want 0", engine.TxCount())
+	}
+}
+
+func assertRecoveredApplyPanic(t *testing.T, result txcore.ApplyResult, txn *panicApplyTx, view *mockBaseView, writeKey keylet.Keylet) {
+	t.Helper()
+	if !txn.mutated {
+		t.Fatal("Apply did not mutate its sandbox before panicking")
+	}
+	if result.Result != ter.TefEXCEPTION {
+		t.Fatalf("result = %s, want tefEXCEPTION", result.Result)
+	}
+	if result.Applied {
+		t.Fatal("panicking transaction must not be applied")
+	}
+	if result.Fee != 0 {
+		t.Fatalf("fee = %d, want 0", result.Fee)
+	}
+	if result.Metadata != nil {
+		t.Fatalf("metadata = %#v, want nil", result.Metadata)
+	}
+	data, err := view.Read(writeKey)
+	if err != nil {
+		t.Fatalf("read sandbox mutation: %v", err)
+	}
+	if data != nil {
+		t.Fatalf("sandbox mutation was committed: %q", data)
+	}
+}

--- a/internal/tx/engine/apply_panic_test.go
+++ b/internal/tx/engine/apply_panic_test.go
@@ -1,20 +1,28 @@
 package engine
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/LeJamon/go-xrpl/shamap"
 )
 
 type panicApplyTx struct {
 	txcore.Transaction
 	writeKey keylet.Keylet
 	mutated  bool
+	panicNil bool
 }
 
 func (t *panicApplyTx) Apply(ctx *txcore.ApplyContext) ter.Result {
@@ -22,7 +30,57 @@ func (t *panicApplyTx) Apply(ctx *txcore.ApplyContext) ter.Result {
 		panic(err)
 	}
 	t.mutated = true
+	if t.panicNil {
+		panic(nil)
+	}
 	panic("apply failed")
+}
+
+type nonAppliableTx struct {
+	txcore.Transaction
+}
+
+type panicGetCommonTx struct {
+	txcore.Transaction
+	panicNil bool
+}
+
+func (t *panicGetCommonTx) GetCommon() *txcore.Common {
+	if t.panicNil {
+		panic(nil)
+	}
+	panic("preflight failed")
+}
+
+type panicPseudoPreclaimTx struct {
+	txcore.Transaction
+}
+
+func (t *panicPseudoPreclaimTx) PreclaimPseudo(*amendment.Rules) ter.Result {
+	panic("preclaim failed")
+}
+
+type stagedStateApplyTx struct {
+	txcore.Transaction
+	key  keylet.Keylet
+	data []byte
+}
+
+func (t *stagedStateApplyTx) Apply(ctx *txcore.ApplyContext) ter.Result {
+	if err := ctx.View.Insert(t.key, t.data); err != nil {
+		return ter.TefINTERNAL
+	}
+	return ter.TesSUCCESS
+}
+
+type failingAtomicPseudoView struct {
+	*ledger.Ledger
+	candidate *ledger.Ledger
+}
+
+func (v *failingAtomicPseudoView) AdoptState(candidate *ledger.Ledger) error {
+	v.candidate = candidate
+	return errors.New("commit failed")
 }
 
 func TestApplyPanicReturnsTefExceptionWithoutMutatingState(t *testing.T) {
@@ -47,8 +105,33 @@ func TestApplyPanicReturnsTefExceptionWithoutMutatingState(t *testing.T) {
 	}
 }
 
-func TestApplyPseudoPanicReturnsTefExceptionWithoutMutatingState(t *testing.T) {
+func TestApplyNilPanicReturnsTefExceptionWithoutMutatingState(t *testing.T) {
+	enableNilPanic(t)
+
 	view := newMockBaseView()
+	accountKey := fundRecoveryAccount(t, view, 1_000_000, 1)
+	writeKey := keylet.Keylet{Key: [32]byte{3}}
+	txn := &panicApplyTx{
+		Transaction: recoveryTx(10, 1),
+		writeKey:    writeKey,
+		panicNil:    true,
+	}
+	engine := recoveryEngine(view, txcore.TapNONE)
+
+	result := engine.Apply(txn)
+
+	assertRecoveredApplyPanic(t, result, txn, view, writeKey)
+	if engine.TxCount() != 0 {
+		t.Fatalf("transaction count = %d, want 0", engine.TxCount())
+	}
+	account := readRecoveryAccount(t, view, accountKey)
+	if account.Balance != 1_000_000 || account.Sequence != 1 {
+		t.Fatalf("account balance/sequence = %d/%d, want 1000000/1", account.Balance, account.Sequence)
+	}
+}
+
+func TestApplyPseudoPanicReturnsTefExceptionWithoutMutatingState(t *testing.T) {
+	view := newApplyPanicLedger()
 	writeKey := keylet.Keylet{Key: [32]byte{2}}
 	ledgerSequence := uint32(100)
 	txn := &panicApplyTx{
@@ -59,10 +142,7 @@ func TestApplyPseudoPanicReturnsTefExceptionWithoutMutatingState(t *testing.T) {
 		},
 		writeKey: writeKey,
 	}
-	engine := NewEngine(view, txcore.EngineConfig{
-		LedgerSequence: ledgerSequence,
-		Rules:          amendment.AllSupportedRules(),
-	})
+	engine := pseudoRecoveryEngine(view, ledgerSequence)
 
 	result := engine.ApplyPseudo(txn)
 
@@ -72,7 +152,144 @@ func TestApplyPseudoPanicReturnsTefExceptionWithoutMutatingState(t *testing.T) {
 	}
 }
 
-func assertRecoveredApplyPanic(t *testing.T, result txcore.ApplyResult, txn *panicApplyTx, view *mockBaseView, writeKey keylet.Keylet) {
+func TestApplyMissingAppliableReturnsTefInternal(t *testing.T) {
+	view := newMockBaseView()
+	accountKey := fundRecoveryAccount(t, view, 1_000_000, 1)
+	engine := recoveryEngine(view, txcore.TapNONE)
+
+	result := engine.Apply(nonAppliableTx{Transaction: recoveryTx(10, 1)})
+
+	assertNonAppliedResult(t, result, ter.TefINTERNAL)
+	if engine.TxCount() != 0 {
+		t.Fatalf("transaction count = %d, want 0", engine.TxCount())
+	}
+	account := readRecoveryAccount(t, view, accountKey)
+	if account.Balance != 1_000_000 || account.Sequence != 1 {
+		t.Fatalf("account balance/sequence = %d/%d, want 1000000/1", account.Balance, account.Sequence)
+	}
+}
+
+func TestApplyPseudoMissingAppliableReturnsTefInternal(t *testing.T) {
+	ledgerSequence := uint32(100)
+	view := newApplyPanicLedger()
+	engine := pseudoRecoveryEngine(view, ledgerSequence)
+	txn := nonAppliableTx{Transaction: newApplyPanicAmendment(ledgerSequence)}
+
+	result := engine.ApplyPseudo(txn)
+
+	assertNonAppliedResult(t, result, ter.TefINTERNAL)
+	if engine.TxCount() != 0 {
+		t.Fatalf("transaction count = %d, want 0", engine.TxCount())
+	}
+}
+
+func TestApplyPseudoPreflightPanicReturnsTefException(t *testing.T) {
+	ledgerSequence := uint32(100)
+	view := newApplyPanicLedger()
+	engine := pseudoRecoveryEngine(view, ledgerSequence)
+	txn := &panicGetCommonTx{Transaction: newApplyPanicAmendment(ledgerSequence)}
+
+	result := engine.ApplyPseudo(txn)
+
+	assertNonAppliedResult(t, result, ter.TefEXCEPTION)
+	if engine.TxCount() != 0 {
+		t.Fatalf("transaction count = %d, want 0", engine.TxCount())
+	}
+}
+
+func TestApplyPseudoNilPreflightPanicReturnsTefException(t *testing.T) {
+	enableNilPanic(t)
+	ledgerSequence := uint32(100)
+	view := newApplyPanicLedger()
+	engine := pseudoRecoveryEngine(view, ledgerSequence)
+	txn := &panicGetCommonTx{
+		Transaction: newApplyPanicAmendment(ledgerSequence),
+		panicNil:    true,
+	}
+
+	result := engine.ApplyPseudo(txn)
+
+	assertNonAppliedResult(t, result, ter.TefEXCEPTION)
+	if engine.TxCount() != 0 {
+		t.Fatalf("transaction count = %d, want 0", engine.TxCount())
+	}
+}
+
+func TestApplyPseudoPreclaimPanicReturnsTefException(t *testing.T) {
+	ledgerSequence := uint32(100)
+	view := newApplyPanicLedger()
+	engine := pseudoRecoveryEngine(view, ledgerSequence)
+	txn := &panicPseudoPreclaimTx{Transaction: newApplyPanicAmendment(ledgerSequence)}
+
+	result := engine.ApplyPseudo(txn)
+
+	assertNonAppliedResult(t, result, ter.TefEXCEPTION)
+	if engine.TxCount() != 0 {
+		t.Fatalf("transaction count = %d, want 0", engine.TxCount())
+	}
+}
+
+func TestApplyPseudoStateCommitErrorDoesNotMutateLedger(t *testing.T) {
+	ledgerSequence := uint32(100)
+	view := newApplyPanicLedger()
+	atomicView := &failingAtomicPseudoView{Ledger: view}
+	engine := pseudoRecoveryEngine(atomicView, ledgerSequence)
+	accountID, err := state.DecodeAccountID(recoveryTestAccount)
+	if err != nil {
+		t.Fatalf("DecodeAccountID: %v", err)
+	}
+	validData, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account:  recoveryTestAccount,
+		Balance:  1_000_000,
+		Sequence: 1,
+	})
+	if err != nil {
+		t.Fatalf("SerializeAccountRoot: %v", err)
+	}
+	writeKey := keylet.Account(accountID)
+	txn := &stagedStateApplyTx{
+		Transaction: newApplyPanicAmendment(ledgerSequence),
+		key:         writeKey,
+		data:        validData,
+	}
+	wantHash, err := view.StateMapHash()
+	if err != nil {
+		t.Fatalf("StateMapHash: %v", err)
+	}
+
+	result := engine.ApplyPseudo(txn)
+
+	assertNonAppliedResult(t, result, ter.TefINTERNAL)
+	if atomicView.candidate == nil {
+		t.Fatal("atomic commit was not attempted")
+	}
+	staged, readErr := atomicView.candidate.Read(writeKey)
+	if readErr != nil {
+		t.Fatalf("read staged key: %v", readErr)
+	}
+	if staged == nil {
+		t.Fatal("snapshot did not contain the staged write")
+	}
+	gotHash, err := view.StateMapHash()
+	if err != nil {
+		t.Fatalf("StateMapHash: %v", err)
+	}
+	if gotHash != wantHash {
+		t.Fatalf("state map hash changed after failed atomic commit")
+	}
+	data, readErr := view.Read(writeKey)
+	if readErr != nil {
+		t.Fatalf("read key after failed commit: %v", readErr)
+	}
+	if data != nil {
+		t.Fatalf("key %x committed after failed atomic commit", writeKey.Key)
+	}
+	if engine.TxCount() != 0 {
+		t.Fatalf("transaction count = %d, want 0", engine.TxCount())
+	}
+}
+
+func assertRecoveredApplyPanic(t *testing.T, result txcore.ApplyResult, txn *panicApplyTx, view txcore.LedgerView, writeKey keylet.Keylet) {
 	t.Helper()
 	if !txn.mutated {
 		t.Fatal("Apply did not mutate its sandbox before panicking")
@@ -96,4 +313,53 @@ func assertRecoveredApplyPanic(t *testing.T, result txcore.ApplyResult, txn *pan
 	if data != nil {
 		t.Fatalf("sandbox mutation was committed: %q", data)
 	}
+}
+
+func assertNonAppliedResult(t *testing.T, result txcore.ApplyResult, want ter.Result) {
+	t.Helper()
+	if result.Result != want {
+		t.Fatalf("result = %s, want %s", result.Result, want)
+	}
+	if result.Applied {
+		t.Fatal("transaction must not be applied")
+	}
+	if result.Fee != 0 {
+		t.Fatalf("fee = %d, want 0", result.Fee)
+	}
+	if result.Metadata != nil {
+		t.Fatalf("metadata = %#v, want nil", result.Metadata)
+	}
+}
+
+func enableNilPanic(t *testing.T) {
+	t.Helper()
+	godebug := os.Getenv("GODEBUG")
+	if godebug != "" {
+		godebug += ","
+	}
+	t.Setenv("GODEBUG", godebug+"panicnil=1")
+}
+
+func newApplyPanicAmendment(ledgerSequence uint32) *pseudo.EnableAmendment {
+	return &pseudo.EnableAmendment{
+		BaseTx:         *txcore.NewBaseTx(txcore.TypeAmendment, protocol.ZeroAccount),
+		Amendment:      "0101010101010101010101010101010101010101010101010101010101010101",
+		LedgerSequence: &ledgerSequence,
+	}
+}
+
+func newApplyPanicLedger() *ledger.Ledger {
+	return ledger.NewOpenWithHeader(
+		header.LedgerHeader{LedgerIndex: 100},
+		shamap.New(shamap.TypeState),
+		shamap.New(shamap.TypeTransaction),
+		drops.Fees{},
+	)
+}
+
+func pseudoRecoveryEngine(view txcore.LedgerView, ledgerSequence uint32) *Engine {
+	return NewEngine(view, txcore.EngineConfig{
+		LedgerSequence: ledgerSequence,
+		Rules:          amendment.AllSupportedRules(),
+	})
 }

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -313,12 +313,9 @@ func (e *Engine) invokeApplySafely(txHash [32]byte, apply func() ter.Result) (re
 	return result
 }
 
-// invokeApplyInner is the body of invokeApply, separated so the panic-recovery
-// defer in invokeApplySafely does not have to walk back through the dispatch.
 func (e *Engine) invokeApplyInner(st *applyState) ter.Result {
 	sigWithMaster := txcore.SignedWithMasterKey(e.config.SkipSignatureVerification, st.common)
 
-	// All transaction types implement Appliable
 	ctx := &txcore.ApplyContext{
 		View:             st.table,
 		Account:          st.account,

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -290,34 +290,27 @@ func (e *Engine) consumeTicket(st *applyState, table *applystate.ApplyStateTable
 	return ter.TesSUCCESS
 }
 
-// invokeApply dispatches to the per-tx-type Apply() implementation. Any panic
-// raised inside the per-tx Apply() — most commonly an arithmetic overflow from
-// IOUAmount / XRPLNumber operating on adversarial peer-supplied ledger data —
-// is recovered and turned into tefEXCEPTION.
-//
-// Reference: rippled applySteps.cpp:447-466 doApply() wraps invoke_apply(ctx)
-// in `try { ... } catch (std::exception const&) { return {tefEXCEPTION, false}; }`.
-// tefEXCEPTION is a tef* code, so the transaction is NOT applied to the ledger:
-// no fee is charged, no sequence is consumed, and no metadata is emitted. The
-// caller at doApply() returns immediately on tef* via the `!IsSuccess() &&
-// !IsTec()` branch.
-//
-// Returning tecINTERNAL here would diverge from rippled because tec* commits
-// fee+seq+meta to the ledger, producing a different account_hash on the same
-// adversarial input → consensus fork.
-func (e *Engine) invokeApply(st *applyState) (result ter.Result) {
+func (e *Engine) invokeApply(st *applyState) ter.Result {
+	return e.invokeApplySafely(st.txHash, func() ter.Result {
+		return e.invokeApplyInner(st)
+	})
+}
+
+// invokeApplySafely is the shared panic boundary for normal and pseudo Apply.
+// A recovered panic becomes tefEXCEPTION, so tracked changes are not committed.
+func (e *Engine) invokeApplySafely(txHash [32]byte, apply func() ter.Result) (result ter.Result) {
 	defer func() {
 		if r := recover(); r != nil {
 			e.logger.Error("transaction Apply() panic recovered, returning tefEXCEPTION",
-				"txHash", fmt.Sprintf("%x", st.txHash), "panic", r)
+				"txHash", fmt.Sprintf("%x", txHash), "panic", r)
 			result = ter.TefEXCEPTION
 		}
 	}()
-	return e.invokeApplyInner(st)
+	return apply()
 }
 
 // invokeApplyInner is the body of invokeApply, separated so the panic-recovery
-// defer in invokeApply does not have to walk back through the dispatch.
+// defer in invokeApplySafely does not have to walk back through the dispatch.
 func (e *Engine) invokeApplyInner(st *applyState) ter.Result {
 	sigWithMaster := txcore.SignedWithMasterKey(e.config.SkipSignatureVerification, st.common)
 

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -299,14 +299,18 @@ func (e *Engine) invokeApply(st *applyState) ter.Result {
 // invokeApplySafely is the shared panic boundary for normal and pseudo Apply.
 // A recovered panic becomes tefEXCEPTION, so tracked changes are not committed.
 func (e *Engine) invokeApplySafely(txHash [32]byte, apply func() ter.Result) (result ter.Result) {
+	completed := false
+	result = ter.TefEXCEPTION
 	defer func() {
-		if r := recover(); r != nil {
+		recovered := recover()
+		if !completed {
 			e.logger.Error("transaction Apply() panic recovered, returning tefEXCEPTION",
-				"txHash", fmt.Sprintf("%x", txHash), "panic", r)
-			result = ter.TefEXCEPTION
+				"txHash", fmt.Sprintf("%x", txHash), "panic", recovered)
 		}
 	}()
-	return apply()
+	result = apply()
+	completed = true
+	return result
 }
 
 // invokeApplyInner is the body of invokeApply, separated so the panic-recovery
@@ -332,7 +336,7 @@ func (e *Engine) invokeApplyInner(st *applyState) ter.Result {
 	if appliable, ok := st.tx.(txcore.Appliable); ok {
 		return appliable.Apply(ctx)
 	}
-	return ter.TesSUCCESS
+	return ter.TefINTERNAL
 }
 
 // isReapplyOnRetryTec reports whether a tec returned from doApply must still be


### PR DESCRIPTION
## Summary

- route normal and pseudo transaction `Apply` calls through one panic boundary
- convert recovered panics to `tefEXCEPTION` without committing sandbox state
- return no fee or metadata and preserve account sequence/balance on recovered failures

## Test plan

- [x] `go test -race ./internal/tx/engine ./internal/testing/pseudotx -count=1`
- [x] `just test-tx`
- [x] `just build-all`
- [x] `just vet`
- [x] `just lint`

Fixes #1175