### PR TITLE
fix: classify all tef results in txq

### DIFF
--- a/internal/txq/accept.go
+++ b/internal/txq/accept.go
@@ -85,7 +85,7 @@ func (q *TxQ) Accept(ctx AcceptContext) bool {
 		candidate.LastResult = result
 
 		// Check if it's a permanent failure
-		if result.IsTef() || isTemMalformed(result) || candidate.RetriesRemaining <= 0 {
+		if result.IsTef() || result.IsTem() || candidate.RetriesRemaining <= 0 {
 			// Mark penalties
 			if candidate.RetriesRemaining <= 0 {
 				aq.RetryPenalty = true
@@ -145,16 +145,7 @@ func (q *TxQ) eraseAndAdvance(idx *int, c *Candidate) {
 	}
 
 	// Check if there's a next transaction for this account that we should try.
-	var nextCandidate *Candidate
-	if !c.SeqProxy.IsTicket {
-		nextSeq := c.Consequences.FollowingSeq.Value
-		for sp, candidate := range aq.Transactions {
-			if !sp.IsTicket && sp.Value == nextSeq {
-				nextCandidate = candidate
-				break
-			}
-		}
-	}
+	nextCandidate := aq.GetNextTx(c.SeqProxy)
 
 	// Determine what comes next in byFee after the current candidate.
 	var feeNext *Candidate
@@ -166,7 +157,6 @@ func (q *TxQ) eraseAndAdvance(idx *int, c *Candidate) {
 	// Yes if the account's next tx has a higher fee level than the next
 	// byFee entry (i.e., it would sort earlier).
 	useAccountNext := nextCandidate != nil &&
-		nextCandidate.SeqProxy.Value > c.SeqProxy.Value &&
 		(feeNext == nil || q.candidateLess(nextCandidate, feeNext))
 
 	q.erase(c)
@@ -219,9 +209,4 @@ func (q *TxQ) indexInByFee(c *Candidate) int {
 		}
 	}
 	return -1
-}
-
-// isTemMalformed returns true if the result is a tem (malformed) failure.
-func isTemMalformed(result ter.Result) bool {
-	return result <= -200 && result >= -299
 }

--- a/internal/txq/accept.go
+++ b/internal/txq/accept.go
@@ -85,7 +85,7 @@ func (q *TxQ) Accept(ctx AcceptContext) bool {
 		candidate.LastResult = result
 
 		// Check if it's a permanent failure
-		if isTefFailure(result) || isTemMalformed(result) || candidate.RetriesRemaining <= 0 {
+		if result.IsTef() || isTemMalformed(result) || candidate.RetriesRemaining <= 0 {
 			// Mark penalties
 			if candidate.RetriesRemaining <= 0 {
 				aq.RetryPenalty = true
@@ -219,11 +219,6 @@ func (q *TxQ) indexInByFee(c *Candidate) int {
 		}
 	}
 	return -1
-}
-
-// isTefFailure returns true if the result is a tef (fee claimed, not applied) failure.
-func isTefFailure(result ter.Result) bool {
-	return result <= -180 && result >= -199
 }
 
 // isTemMalformed returns true if the result is a tem (malformed) failure.

--- a/internal/txq/admission_apply_test.go
+++ b/internal/txq/admission_apply_test.go
@@ -56,6 +56,7 @@ func (c *stubApplyCtx) GetBaseFee(tx.Transaction) uint64               { return 
 func (c *stubApplyCtx) GetTxInLedger() uint32                          { return c.txInLedger }
 func (c *stubApplyCtx) GetLedgerSequence() uint32                      { return c.ledgerSeq }
 func (c *stubApplyCtx) GetApplyFlags() tx.ApplyFlags                   { return c.flags }
+func (c *stubApplyCtx) GetParentHash() [32]byte                        { return [32]byte{} }
 func (c *stubApplyCtx) PreflightTransaction(tx.Transaction) ter.Result { return c.preflight }
 func (c *stubApplyCtx) PreclaimTransaction(tx.Transaction, [20]byte, uint64, uint32) ter.Result {
 	return c.preclaim
@@ -67,9 +68,14 @@ func (c *stubApplyCtx) NewSandbox() (SandboxContext, error) {
 	return nil, errors.New("stubApplyCtx: no sandbox")
 }
 
+type stubClosedLedgerCtx struct{}
+
+func (*stubClosedLedgerCtx) GetLedgerSequence() uint32           { return 0 }
+func (*stubClosedLedgerCtx) GetTransactionFeeLevels() []FeeLevel { return nil }
+
 // addQueued appends a sequence-based candidate to the account queue with an
 // explicit followingSeq, so getNextQueuableSeq can walk the chain.
-func addQueued(q *TxQ, aq *AccountQueue, seq, followingSeq uint32) {
+func addQueued(q *TxQ, aq *AccountQueue, seq, followingSeq uint32) *Candidate {
 	sp := NewSeqProxySequence(seq)
 	c := &Candidate{
 		Txn:              &seqTx{seq: seq, fee: "10"},
@@ -81,6 +87,159 @@ func addQueued(q *TxQ, aq *AccountQueue, seq, followingSeq uint32) {
 	}
 	aq.Add(c)
 	q.insertByFee(c)
+	return c
+}
+
+func TestAcceptDropsTefCategory(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   ter.Result
+		wantSize int
+	}{
+		{name: "category lower boundary", result: ter.TefFAILURE},
+		{name: "nftoken not transferable", result: ter.TefNFTOKEN_IS_NOT_TRANSFERABLE},
+		{name: "invalid ledger fix type", result: ter.TefINVALID_LEDGER_FIX_TYPE},
+		{name: "category upper boundary", result: ter.Result(-100)},
+		{name: "retry category", result: ter.TerRETRY, wantSize: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			q := New(makeAdmissionConfig())
+			acct := [20]byte{9}
+			aq := NewAccountQueue(acct)
+			q.byAccount[acct] = aq
+			candidate := addQueued(q, aq, 1, 2)
+
+			ctx := &stubApplyCtx{applyRes: test.result}
+			require.False(t, q.Accept(ctx))
+			require.Equal(t, test.wantSize, q.Size())
+
+			retained, exists := q.byAccount[acct]
+			require.True(t, exists)
+			require.Equal(t, test.result.IsTef(), retained.DropPenalty)
+			if test.result.IsTef() {
+				require.True(t, retained.Empty())
+				require.Equal(t, RetriesAllowed, candidate.RetriesRemaining)
+			} else {
+				require.Equal(t, RetriesAllowed-1, candidate.RetriesRemaining)
+				require.Equal(t, test.result, candidate.LastResult)
+			}
+		})
+	}
+}
+
+func TestAcceptCleansRetainedPenaltyOnNextClosedLedger(t *testing.T) {
+	q := New(makeAdmissionConfig())
+	acct := [20]byte{9}
+	aq := NewAccountQueue(acct)
+	q.byAccount[acct] = aq
+	addQueued(q, aq, 1, 2)
+
+	ctx := &stubApplyCtx{applyRes: ter.TefNFTOKEN_IS_NOT_TRANSFERABLE}
+	require.False(t, q.Accept(ctx))
+	retained, exists := q.byAccount[acct]
+	require.True(t, exists)
+	require.True(t, retained.DropPenalty)
+	require.True(t, retained.Empty())
+
+	q.ProcessClosedLedger(&stubClosedLedgerCtx{}, false)
+	_, exists = q.byAccount[acct]
+	require.False(t, exists)
+}
+
+func TestEraseRetainsAccountQueueUntilNextClosedLedger(t *testing.T) {
+	q := New(makeAdmissionConfig())
+	acct := [20]byte{9}
+	aq := NewAccountQueue(acct)
+	aq.DropPenalty = true
+	aq.RetryPenalty = true
+	q.byAccount[acct] = aq
+	candidate := addQueued(q, aq, 1, 2)
+
+	q.erase(candidate)
+
+	retained, exists := q.byAccount[acct]
+	require.True(t, exists)
+	require.Same(t, aq, retained)
+	require.True(t, retained.Empty())
+	require.True(t, retained.DropPenalty)
+	require.True(t, retained.RetryPenalty)
+
+	q.ProcessClosedLedger(&stubClosedLedgerCtx{}, false)
+	_, exists = q.byAccount[acct]
+	require.False(t, exists)
+}
+
+func TestApplyReplacementPreservesAccountPenalties(t *testing.T) {
+	tests := []struct {
+		name       string
+		txInLedger uint32
+		didApply   bool
+		wantResult ter.Result
+		wantQueued bool
+		wantSize   int
+	}{
+		{
+			name:       "queued while full",
+			txInLedger: 4,
+			wantResult: ter.TerQUEUED,
+			wantQueued: true,
+			wantSize:   1,
+		},
+		{
+			name:       "applied directly",
+			didApply:   true,
+			wantResult: ter.TesSUCCESS,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := makeAdmissionConfig()
+			cfg.RetrySequencePercent = 25
+			q := New(cfg)
+			acct := [20]byte{9}
+			aq := NewAccountQueue(acct)
+			aq.DropPenalty = true
+			aq.RetryPenalty = true
+			q.byAccount[acct] = aq
+			original := addQueued(q, aq, 1, 2)
+			q.SetMaxSize(1)
+
+			replacement := &seqTx{seq: 1, fee: "130"}
+			ctx := &stubApplyCtx{
+				seq:        1,
+				balance:    1_000_000_000,
+				exists:     true,
+				baseFee:    10,
+				txInLedger: test.txInLedger,
+				applyRes:   ter.TesSUCCESS,
+				applied:    test.didApply,
+			}
+
+			result := q.Apply(ctx, replacement, [32]byte{2}, acct)
+
+			require.Equal(t, test.wantResult, result.Result)
+			require.Equal(t, test.didApply, result.Applied)
+			require.Equal(t, test.wantQueued, result.Queued)
+			require.Equal(t, test.wantSize, q.Size())
+
+			retained, exists := q.byAccount[acct]
+			require.True(t, exists)
+			require.Same(t, aq, retained)
+			require.True(t, retained.DropPenalty)
+			require.True(t, retained.RetryPenalty)
+			if test.wantQueued {
+				candidate, exists := retained.Transactions[NewSeqProxySequence(1)]
+				require.True(t, exists)
+				require.NotSame(t, original, candidate)
+				require.Same(t, replacement, candidate.Txn)
+			} else {
+				require.True(t, retained.Empty())
+			}
+		})
+	}
 }
 
 // TestApply_H2_ExpirationGap pins rippled TxQ.cpp:1031-1040: a tx that lands

--- a/internal/txq/admission_apply_test.go
+++ b/internal/txq/admission_apply_test.go
@@ -45,6 +45,7 @@ type stubApplyCtx struct {
 	preclaim  ter.Result
 	applyRes  ter.Result
 	applied   bool
+	applyFn   func(tx.Transaction) (ter.Result, bool)
 }
 
 func (c *stubApplyCtx) GetAccountSequence([20]byte) uint32             { return c.seq }
@@ -61,7 +62,11 @@ func (c *stubApplyCtx) PreflightTransaction(tx.Transaction) ter.Result { return 
 func (c *stubApplyCtx) PreclaimTransaction(tx.Transaction, [20]byte, uint64, uint32) ter.Result {
 	return c.preclaim
 }
-func (c *stubApplyCtx) ApplyTransaction(tx.Transaction) (ter.Result, bool) {
+
+func (c *stubApplyCtx) ApplyTransaction(txn tx.Transaction) (ter.Result, bool) {
+	if c.applyFn != nil {
+		return c.applyFn(txn)
+	}
 	return c.applyRes, c.applied
 }
 func (c *stubApplyCtx) NewSandbox() (SandboxContext, error) {
@@ -129,6 +134,134 @@ func TestAcceptDropsTefCategory(t *testing.T) {
 	}
 }
 
+func TestAcceptRevisitsNextAccountCandidateAcrossGap(t *testing.T) {
+	q := New(makeAdmissionConfig())
+	acct := [20]byte{9}
+	aq := NewAccountQueue(acct)
+	q.byAccount[acct] = aq
+
+	front := mkCandidate(acct, NewSeqProxySequence(1), FeeLevel(BaseLevel*2))
+	successor := mkCandidate(acct, NewSeqProxySequence(3), FeeLevel(BaseLevel*3))
+	aq.Add(front)
+	aq.Add(successor)
+	q.insertByFee(front)
+	q.insertByFee(successor)
+
+	var appliedSeqs []uint32
+	ctx := &stubApplyCtx{applyFn: func(txn tx.Transaction) (ter.Result, bool) {
+		seq := txn.(*seqTx).seq
+		appliedSeqs = append(appliedSeqs, seq)
+		if seq == 1 {
+			return ter.TefNFTOKEN_IS_NOT_TRANSFERABLE, false
+		}
+		return ter.TesSUCCESS, true
+	}}
+
+	require.True(t, q.Accept(ctx))
+	require.Equal(t, []uint32{1, 3}, appliedSeqs)
+	require.Zero(t, q.Size())
+	require.Same(t, aq, q.byAccount[acct])
+	require.True(t, aq.DropPenalty)
+}
+
+func TestAcceptRevisitsNextTicketCandidate(t *testing.T) {
+	q := New(makeAdmissionConfig())
+	acct := [20]byte{9}
+	aq := NewAccountQueue(acct)
+	q.byAccount[acct] = aq
+
+	lowerTicket := mkCandidate(acct, NewSeqProxyTicket(2), FeeLevel(BaseLevel*2))
+	higherTicket := mkCandidate(acct, NewSeqProxyTicket(3), FeeLevel(BaseLevel*3))
+	aq.Add(lowerTicket)
+	aq.Add(higherTicket)
+	q.insertByFee(lowerTicket)
+	q.insertByFee(higherTicket)
+
+	var appliedTickets []uint32
+	higherAttempts := 0
+	ctx := &stubApplyCtx{applyFn: func(txn tx.Transaction) (ter.Result, bool) {
+		ticket := txn.(*seqTx).seq
+		appliedTickets = append(appliedTickets, ticket)
+		if ticket == 2 {
+			return ter.TefNO_TICKET, false
+		}
+		higherAttempts++
+		if higherAttempts == 1 {
+			return ter.TerPRE_TICKET, false
+		}
+		return ter.TesSUCCESS, true
+	}}
+
+	require.True(t, q.Accept(ctx))
+	require.Equal(t, []uint32{3, 2, 3}, appliedTickets)
+	require.Zero(t, q.Size())
+}
+
+func TestAcceptDropsQueuedPastSequence(t *testing.T) {
+	q := New(makeAdmissionConfig())
+	acct := [20]byte{9}
+	aq := NewAccountQueue(acct)
+	q.byAccount[acct] = aq
+	addQueued(q, aq, 1, 2)
+
+	ctx := &stubApplyCtx{seq: 2}
+	ctx.applyFn = func(txn tx.Transaction) (ter.Result, bool) {
+		if *txn.GetCommon().Sequence < ctx.seq {
+			return ter.TefPAST_SEQ, false
+		}
+		return ter.TesSUCCESS, true
+	}
+
+	require.False(t, q.Accept(ctx))
+	require.True(t, aq.Empty())
+	require.True(t, aq.DropPenalty)
+}
+
+func TestAcceptRetainedRetryPenaltyAffectsNextCandidate(t *testing.T) {
+	q := New(makeAdmissionConfig())
+	acct := [20]byte{9}
+	aq := NewAccountQueue(acct)
+	q.byAccount[acct] = aq
+	addQueued(q, aq, 1, 2)
+
+	ctx := &stubApplyCtx{applyRes: ter.TerPRE_SEQ}
+	for range RetriesAllowed + 1 {
+		require.False(t, q.Accept(ctx))
+	}
+
+	require.True(t, aq.Empty())
+	require.True(t, aq.RetryPenalty)
+
+	next := addQueued(q, aq, 2, 3)
+	require.False(t, q.Accept(ctx))
+	require.Equal(t, 1, next.RetriesRemaining)
+}
+
+func TestAcceptRetainedDropPenaltyDropsLastCandidate(t *testing.T) {
+	q := New(makeAdmissionConfig())
+	acct := [20]byte{9}
+	aq := NewAccountQueue(acct)
+	q.byAccount[acct] = aq
+	addQueued(q, aq, 1, 2)
+
+	require.False(t, q.Accept(&stubApplyCtx{applyRes: ter.TefNFTOKEN_IS_NOT_TRANSFERABLE}))
+	require.True(t, aq.DropPenalty)
+
+	first := mkCandidate(acct, NewSeqProxySequence(2), FeeLevel(BaseLevel*3))
+	last := mkCandidate(acct, NewSeqProxySequence(3), FeeLevel(BaseLevel*2))
+	aq.Add(first)
+	aq.Add(last)
+	q.insertByFee(first)
+	q.insertByFee(last)
+	q.SetMaxSize(2)
+
+	require.False(t, q.Accept(&stubApplyCtx{applyRes: ter.TerPRE_SEQ}))
+	require.Equal(t, RetriesAllowed-1, first.RetriesRemaining)
+	require.Same(t, first, aq.Transactions[first.SeqProxy])
+	_, exists := aq.Transactions[last.SeqProxy]
+	require.False(t, exists)
+}
+
 func TestAcceptCleansRetainedPenaltyOnNextClosedLedger(t *testing.T) {
 	q := New(makeAdmissionConfig())
 	acct := [20]byte{9}
@@ -169,6 +302,70 @@ func TestEraseRetainsAccountQueueUntilNextClosedLedger(t *testing.T) {
 	q.ProcessClosedLedger(&stubClosedLedgerCtx{}, false)
 	_, exists = q.byAccount[acct]
 	require.False(t, exists)
+}
+
+func TestApplyReusesRetainedEmptyAccountQueue(t *testing.T) {
+	q := New(makeAdmissionConfig())
+	acct := [20]byte{9}
+	aq := NewAccountQueue(acct)
+	aq.DropPenalty = true
+	aq.RetryPenalty = true
+	q.byAccount[acct] = aq
+	candidate := addQueued(q, aq, 1, 2)
+	q.erase(candidate)
+
+	ctx := &stubApplyCtx{
+		seq:        2,
+		balance:    1_000_000_000,
+		exists:     true,
+		baseFee:    10,
+		txInLedger: 4,
+	}
+
+	past := q.Apply(ctx, &seqTx{seq: 1, fee: "10"}, [32]byte{1}, acct)
+	require.Equal(t, ter.TefPAST_SEQ, past.Result)
+	future := q.Apply(ctx, &seqTx{seq: 3, fee: "10"}, [32]byte{2}, acct)
+	require.Equal(t, ter.TerPRE_SEQ, future.Result)
+	current := q.Apply(ctx, &seqTx{seq: 2, fee: "10"}, [32]byte{3}, acct)
+	require.Equal(t, ter.TerQUEUED, current.Result)
+	require.True(t, current.Queued)
+
+	require.Same(t, aq, q.byAccount[acct])
+	require.True(t, aq.DropPenalty)
+	require.True(t, aq.RetryPenalty)
+	require.Contains(t, aq.Transactions, NewSeqProxySequence(2))
+}
+
+func TestApplyFullQueueEvictionRetainsAccountQueue(t *testing.T) {
+	q := New(makeAdmissionConfig())
+	evictedAccount := [20]byte{8}
+	evictedQueue := NewAccountQueue(evictedAccount)
+	evictedQueue.DropPenalty = true
+	evictedQueue.RetryPenalty = true
+	q.byAccount[evictedAccount] = evictedQueue
+	evicted := addQueued(q, evictedQueue, 1, 2)
+	evicted.FeeLevel = FeeLevel(BaseLevel)
+	q.SetMaxSize(1)
+
+	newAccount := [20]byte{9}
+	ctx := &stubApplyCtx{
+		seq:        1,
+		balance:    1_000_000_000,
+		exists:     true,
+		baseFee:    10,
+		txInLedger: 4,
+	}
+	result := q.Apply(ctx, &seqTx{seq: 1, fee: "130"}, [32]byte{4}, newAccount)
+
+	require.Equal(t, ter.TerQUEUED, result.Result)
+	require.True(t, result.Queued)
+	require.Same(t, evictedQueue, q.byAccount[evictedAccount])
+	require.True(t, evictedQueue.Empty())
+	require.True(t, evictedQueue.DropPenalty)
+	require.True(t, evictedQueue.RetryPenalty)
+	require.Contains(t, q.byAccount, newAccount)
+	require.Equal(t, 1, q.Size())
+	require.Equal(t, newAccount, q.byFee[0].Account)
 }
 
 func TestApplyReplacementPreservesAccountPenalties(t *testing.T) {

--- a/internal/txq/apply.go
+++ b/internal/txq/apply.go
@@ -501,14 +501,7 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 		q.erase(replacingCandidate)
 	}
 
-	// q.erase drops the account from byAccount once its queue is empty — which
-	// happens when replacingCandidate was the account's only queued tx. Re-check
-	// the live map rather than the stale `exists` snapshot, otherwise the new
-	// candidate is added to an orphaned AccountQueue and byFee/byAccount diverge,
-	// hiding the queued tx from later blocker checks.
-	if liveAq, stillInMap := q.byAccount[account]; stillInMap {
-		aq = liveAq
-	} else {
+	if !exists {
 		aq = NewAccountQueue(account)
 		q.byAccount[account] = aq
 	}

--- a/internal/txq/candidate.go
+++ b/internal/txq/candidate.go
@@ -160,6 +160,20 @@ func (aq *AccountQueue) GetPrevTx(seqProxy SeqProxy) *Candidate {
 	return prev
 }
 
+// GetNextTx finds the transaction that follows the given SeqProxy.
+// Returns nil if there is no following transaction.
+func (aq *AccountQueue) GetNextTx(seqProxy SeqProxy) *Candidate {
+	var next *Candidate
+	for sp, c := range aq.Transactions {
+		if seqProxy.Less(sp) {
+			if next == nil || sp.Less(next.SeqProxy) {
+				next = c
+			}
+		}
+	}
+	return next
+}
+
 // GetFirstSeqTx returns the first sequence-based transaction (lowest sequence).
 // Returns nil if there are no sequence-based transactions.
 func (aq *AccountQueue) GetFirstSeqTx() *Candidate {

--- a/internal/txq/candidate.go
+++ b/internal/txq/candidate.go
@@ -160,8 +160,6 @@ func (aq *AccountQueue) GetPrevTx(seqProxy SeqProxy) *Candidate {
 	return prev
 }
 
-// GetNextTx finds the transaction that follows the given SeqProxy.
-// Returns nil if there is no following transaction.
 func (aq *AccountQueue) GetNextTx(seqProxy SeqProxy) *Candidate {
 	var next *Candidate
 	for sp, c := range aq.Transactions {

--- a/internal/txq/candidate_test.go
+++ b/internal/txq/candidate_test.go
@@ -188,6 +188,27 @@ func TestAccountQueue_GetPrevTx(t *testing.T) {
 	}
 }
 
+func TestAccountQueue_GetNextTx(t *testing.T) {
+	account := [20]byte{1, 2, 3}
+	aq := NewAccountQueue(account)
+	seq1 := &Candidate{Account: account, SeqProxy: NewSeqProxySequence(1)}
+	seq3 := &Candidate{Account: account, SeqProxy: NewSeqProxySequence(3)}
+	ticket2 := &Candidate{Account: account, SeqProxy: NewSeqProxyTicket(2)}
+	aq.Add(seq1)
+	aq.Add(seq3)
+	aq.Add(ticket2)
+
+	if next := aq.GetNextTx(seq1.SeqProxy); next != seq3 {
+		t.Errorf("GetNextTx(sequence 1) = %v, want sequence 3", next)
+	}
+	if next := aq.GetNextTx(seq3.SeqProxy); next != ticket2 {
+		t.Errorf("GetNextTx(sequence 3) = %v, want ticket 2", next)
+	}
+	if next := aq.GetNextTx(ticket2.SeqProxy); next != nil {
+		t.Errorf("GetNextTx(ticket 2) = %v, want nil", next)
+	}
+}
+
 // TestAccountQueue_GetFirstSeqTx tests finding the first sequence-based tx
 func TestAccountQueue_GetFirstSeqTx(t *testing.T) {
 	account := [20]byte{1, 2, 3}

--- a/internal/txq/sandbox_test.go
+++ b/internal/txq/sandbox_test.go
@@ -183,7 +183,9 @@ func TestTryClearAccountQueue_RollbackOnNewTxFailure(t *testing.T) {
 // tx applies, the sandbox is committed exactly once, and the cleared preceding
 // txs are removed from the queue (rippled TxQ.cpp:602-611, 1218).
 func TestTryClearAccountQueue_CommitOnFullSuccess(t *testing.T) {
-	q, aq, preceding, newTx, _, seqProxy := setupClearQueue()
+	q, aq, preceding, newTx, account, seqProxy := setupClearQueue()
+	aq.DropPenalty = true
+	aq.RetryPenalty = true
 	sb := &mockSandbox{results: mkResults(
 		struct {
 			tx      *mockTx
@@ -208,5 +210,17 @@ func TestTryClearAccountQueue_CommitOnFullSuccess(t *testing.T) {
 	}
 	if _, stillQueued := aq.Transactions[NewSeqProxySequence(1)]; stillQueued {
 		t.Errorf("preceding tx must be erased from the queue after a successful clear")
+	}
+	retained, exists := q.byAccount[account]
+	if !exists || retained != aq {
+		t.Fatal("account queue must survive a successful clear until the next closed ledger")
+	}
+	if !retained.DropPenalty || !retained.RetryPenalty {
+		t.Error("account penalties must survive a successful clear")
+	}
+
+	q.ProcessClosedLedger(&stubClosedLedgerCtx{}, false)
+	if _, exists := q.byAccount[account]; exists {
+		t.Error("empty account queue must be removed after a closed ledger")
 	}
 }

--- a/internal/txq/sandbox_test.go
+++ b/internal/txq/sandbox_test.go
@@ -224,3 +224,92 @@ func TestTryClearAccountQueue_CommitOnFullSuccess(t *testing.T) {
 		t.Error("empty account queue must be removed after a closed ledger")
 	}
 }
+
+func TestTryClearAccountQueue_CommitRemovesReplacement(t *testing.T) {
+	tests := []struct {
+		name     string
+		withTail bool
+	}{
+		{name: "replace last"},
+		{name: "replace middle", withTail: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			q, aq, preceding, newTx, account, seqProxy := setupClearQueue()
+			aq.DropPenalty = true
+			aq.RetryPenalty = true
+
+			replaced := &Candidate{
+				Txn:              &mockTx{id: 3},
+				Account:          account,
+				FeeLevel:         FeeLevel(1_000_000),
+				SeqProxy:         seqProxy,
+				RetriesRemaining: RetriesAllowed,
+			}
+			aq.Add(replaced)
+			q.insertByFee(replaced)
+
+			var tail *Candidate
+			if test.withTail {
+				tail = &Candidate{
+					Txn:              &mockTx{id: 4},
+					Account:          account,
+					FeeLevel:         FeeLevel(1_000_000),
+					SeqProxy:         NewSeqProxySequence(3),
+					RetriesRemaining: RetriesAllowed,
+				}
+				aq.Add(tail)
+				q.insertByFee(tail)
+			}
+
+			sb := &mockSandbox{results: mkResults(
+				struct {
+					tx      *mockTx
+					res     ter.Result
+					applied bool
+				}{preceding.Txn.(*mockTx), ter.TesSUCCESS, true},
+				struct {
+					tx      *mockTx
+					res     ter.Result
+					applied bool
+				}{newTx, ter.TesSUCCESS, true},
+			)}
+
+			result := q.tryClearAccountQueue(
+				&mockClearCtx{sandbox: sb}, aq, newTx, seqProxy, FeeLevel(1_000_000), 4, 1,
+			)
+
+			if result == nil || !result.Applied {
+				t.Fatalf("expected an applied result, got %v", result)
+			}
+			if !sb.committed {
+				t.Fatal("sandbox must be committed")
+			}
+			if len(sb.appliedTo) != 2 || sb.appliedTo[0] != preceding.Txn || sb.appliedTo[1] != newTx {
+				t.Fatalf("replacement must not be applied: got %v", sb.appliedTo)
+			}
+			if _, exists := aq.Transactions[preceding.SeqProxy]; exists {
+				t.Error("preceding candidate must be removed")
+			}
+			if _, exists := aq.Transactions[replaced.SeqProxy]; exists {
+				t.Error("replaced candidate must be removed")
+			}
+			if test.withTail {
+				if aq.Transactions[tail.SeqProxy] != tail {
+					t.Error("candidate after the replacement must remain queued")
+				}
+				if q.Size() != 1 || q.byFee[0] != tail {
+					t.Error("only the candidate after the replacement must remain fee-indexed")
+				}
+			} else if !aq.Empty() {
+				t.Error("account queue must be empty after replacing its last candidate")
+			} else if q.Size() != 0 {
+				t.Error("fee index must be empty after replacing the last candidate")
+			}
+			if q.byAccount[account] != aq || !aq.DropPenalty || !aq.RetryPenalty {
+				t.Error("account queue and penalties must be retained")
+			}
+		})
+	}
+}

--- a/internal/txq/txq.go
+++ b/internal/txq/txq.go
@@ -206,16 +206,14 @@ func (q *TxQ) removeByFee(c *Candidate) {
 	}
 }
 
-// erase removes a candidate from both byFee and byAccount.
+// erase removes a candidate while retaining its AccountQueue until the next
+// closed-ledger cleanup.
 // Caller must hold the lock.
 func (q *TxQ) erase(c *Candidate) {
 	q.removeByFee(c)
 
 	if aq, exists := q.byAccount[c.Account]; exists {
 		aq.Remove(c.SeqProxy)
-		if aq.Empty() {
-			delete(q.byAccount, c.Account)
-		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- use the authoritative TER category predicate for the complete `tef` range
- retain per-account retry/drop penalties through every candidate-removal path
- clean retained empty accounts only during closed-ledger processing, matching rippled

## Test plan

- [x] `go test -race ./internal/txq -count=1`
- [x] `just conformance TxQ` (36/36)
- [x] full conformance (1260/1260 in scope)
- [x] `just build-all`
- [x] `just vet`
- [x] `just lint`

Fixes #1174