### PR TITLE
fix: synchronize nodestore negative cache

### DIFF
--- a/storage/nodestore/kvstore_database.go
+++ b/storage/nodestore/kvstore_database.go
@@ -47,8 +47,10 @@ type KVDatabaseImpl struct {
 	store         kvstore.KeyValueStore
 	cache         *Cache
 	negativeCache *NegativeCache
-	name          string
-	stats         struct {
+	// Advances after a successful backend write and before negative-cache invalidation.
+	storeGeneration atomic.Uint64
+	name            string
+	stats           struct {
 		reads             uint64
 		fetchHits         uint64
 		cacheHits         uint64
@@ -114,17 +116,16 @@ func (d *KVDatabaseImpl) Store(ctx context.Context, node *Node) error {
 	if err != nil {
 		return fmt.Errorf("store failed: %w", err)
 	}
+	if d.negativeCache != nil {
+		d.storeGeneration.Add(1)
+		d.negativeCache.Remove(node.Hash)
+	}
 
 	atomic.AddUint64(&d.stats.writes, 1)
 	atomic.AddUint64(&d.stats.writeBytes, uint64(len(node.Data)))
 
 	if d.cache != nil {
 		d.cache.Put(node)
-	}
-
-	// Remove from negative cache since node now exists
-	if d.negativeCache != nil {
-		d.negativeCache.Remove(node.Hash)
 	}
 
 	return nil
@@ -150,19 +151,23 @@ func (d *KVDatabaseImpl) Fetch(ctx context.Context, hash Hash256) (*Node, error)
 		atomic.AddUint64(&d.stats.cacheMisses, 1)
 	}
 
+	var storeGeneration uint64
 	if d.negativeCache != nil {
 		if d.negativeCache.IsMissing(hash) {
 			atomic.AddUint64(&d.stats.negativeCacheHits, 1)
 			return nil, nil
 		}
+		storeGeneration = d.storeGeneration.Load()
 	}
 
 	data, err := d.store.Get(hash[:])
 	if err != nil {
 		if errors.Is(err, kvstore.ErrNotFound) {
-			// Mark as missing in negative cache
 			if d.negativeCache != nil {
 				d.negativeCache.MarkMissing(hash)
+				if d.storeGeneration.Load() != storeGeneration {
+					d.negativeCache.Remove(hash)
+				}
 			}
 			return nil, nil
 		}
@@ -209,6 +214,14 @@ func (d *KVDatabaseImpl) StoreBatch(ctx context.Context, nodes []*Node) error {
 	if err != nil {
 		return fmt.Errorf("store batch commit failed: %w", err)
 	}
+	if d.negativeCache != nil {
+		d.storeGeneration.Add(1)
+		for _, node := range nodes {
+			if node != nil {
+				d.negativeCache.Remove(node.Hash)
+			}
+		}
+	}
 
 	for _, node := range nodes {
 		if node == nil {
@@ -218,9 +231,6 @@ func (d *KVDatabaseImpl) StoreBatch(ctx context.Context, nodes []*Node) error {
 		atomic.AddUint64(&d.stats.writeBytes, uint64(len(node.Data)))
 		if d.cache != nil {
 			d.cache.Put(node)
-		}
-		if d.negativeCache != nil {
-			d.negativeCache.Remove(node.Hash)
 		}
 	}
 

--- a/storage/nodestore/kvstore_database.go
+++ b/storage/nodestore/kvstore_database.go
@@ -197,6 +197,7 @@ func (d *KVDatabaseImpl) StoreBatch(ctx context.Context, nodes []*Node) error {
 	}
 
 	batch := d.store.NewBatch()
+	wroteNode := false
 	for _, node := range nodes {
 		if node == nil {
 			continue
@@ -207,6 +208,7 @@ func (d *KVDatabaseImpl) StoreBatch(ctx context.Context, nodes []*Node) error {
 		if err != nil {
 			return fmt.Errorf("store batch failed: %w", err)
 		}
+		wroteNode = true
 	}
 	d.pruneMu.RLock()
 	err := batch.Write()
@@ -214,7 +216,7 @@ func (d *KVDatabaseImpl) StoreBatch(ctx context.Context, nodes []*Node) error {
 	if err != nil {
 		return fmt.Errorf("store batch commit failed: %w", err)
 	}
-	if d.negativeCache != nil {
+	if d.negativeCache != nil && wroteNode {
 		d.storeGeneration.Add(1)
 		for _, node := range nodes {
 			if node != nil {

--- a/storage/nodestore/kvstore_database_test.go
+++ b/storage/nodestore/kvstore_database_test.go
@@ -94,3 +94,30 @@ func TestFetchDoesNotCacheMissAcrossStore(t *testing.T) {
 		})
 	}
 }
+
+func TestStoreBatchWithoutNodesDoesNotAdvanceGeneration(t *testing.T) {
+	tests := []struct {
+		name  string
+		nodes []*Node
+	}{
+		{name: "empty"},
+		{name: "nil node", nodes: []*Node{nil}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := NewKVDatabaseWithConfig(memorydb.New(), "test", &DatabaseConfig{
+				NegativeCacheTTL:     time.Hour,
+				NegativeCacheMaxSize: 10,
+			})
+			t.Cleanup(func() { _ = db.Close() })
+
+			if err := db.StoreBatch(context.Background(), tt.nodes); err != nil {
+				t.Fatalf("StoreBatch: %v", err)
+			}
+			if got := db.storeGeneration.Load(); got != 0 {
+				t.Fatalf("store generation = %d, want 0", got)
+			}
+		})
+	}
+}

--- a/storage/nodestore/kvstore_database_test.go
+++ b/storage/nodestore/kvstore_database_test.go
@@ -1,0 +1,96 @@
+package nodestore
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/storage/kvstore"
+	"github.com/LeJamon/go-xrpl/storage/kvstore/memorydb"
+)
+
+type staleMissStore struct {
+	kvstore.KeyValueStore
+	target Hash256
+	onMiss func()
+	once   sync.Once
+}
+
+func (s *staleMissStore) Get(key []byte) ([]byte, error) {
+	stale := false
+	if bytes.Equal(key, s.target[:]) {
+		s.once.Do(func() {
+			stale = true
+			s.onMiss()
+		})
+	}
+	if stale {
+		return nil, kvstore.ErrNotFound
+	}
+	return s.KeyValueStore.Get(key)
+}
+
+func TestFetchDoesNotCacheMissAcrossStore(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(context.Context, *KVDatabaseImpl, *Node) error
+	}{
+		{
+			name: "Store",
+			store: func(ctx context.Context, db *KVDatabaseImpl, node *Node) error {
+				return db.Store(ctx, node)
+			},
+		},
+		{
+			name: "StoreBatch",
+			store: func(ctx context.Context, db *KVDatabaseImpl, node *Node) error {
+				return db.StoreBatch(ctx, []*Node{node})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			node := NewNode(NodeTransaction, Blob("stored during stale miss"))
+			backend := &staleMissStore{
+				KeyValueStore: memorydb.New(),
+				target:        node.Hash,
+			}
+			db := NewKVDatabaseWithConfig(backend, "test", &DatabaseConfig{
+				NegativeCacheTTL:     time.Hour,
+				NegativeCacheMaxSize: 10,
+			})
+			t.Cleanup(func() { _ = db.Close() })
+
+			var storeErr error
+			backend.onMiss = func() {
+				storeErr = tt.store(ctx, db, node)
+			}
+
+			got, err := db.Fetch(ctx, node.Hash)
+			if err != nil {
+				t.Fatalf("Fetch stale miss: %v", err)
+			}
+			if storeErr != nil {
+				t.Fatalf("write during Fetch: %v", storeErr)
+			}
+			if got != nil {
+				t.Fatalf("Fetch stale miss = %v, want nil", got)
+			}
+			if db.negativeCache.IsMissing(node.Hash) {
+				t.Fatal("stale miss remained in negative cache after write")
+			}
+
+			got, err = db.Fetch(ctx, node.Hash)
+			if err != nil {
+				t.Fatalf("Fetch stored node: %v", err)
+			}
+			if got == nil || got.Hash != node.Hash || !bytes.Equal(got.Data, node.Data) {
+				t.Fatalf("Fetch stored node = %#v, want %#v", got, node)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- coordinate negative-cache miss publication with successful `Store` and `StoreBatch` writes
- prevent a stale in-flight miss from poisoning a node stored concurrently
- add deterministic regression coverage for both write paths

## Test plan

- [x] `go test -race ./storage/nodestore -count=1`
- [x] `go test -race ./storage/... -count=1`
- [x] `just build-all`
- [x] `just vet`
- [x] `just lint`

Fixes #1173