### PR TITLE
fix: sanitize RPC internal error responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/sync v0.18.0
+	golang.org/x/tools v0.38.0
 	google.golang.org/grpc v1.78.0
 	modernc.org/sqlite v1.46.1
 )
@@ -39,6 +40,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
+	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251029180050-ab9386a59fda // indirect
 	modernc.org/libc v1.67.6 // indirect

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/internal/rpc"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/txq"
 	validatorlist "github.com/LeJamon/go-xrpl/internal/validator/list"
@@ -742,8 +743,10 @@ func runServer(cmd *cobra.Command, args []string) error {
 		)
 	}
 
+	transportLoad := loadtrack.New()
+
 	// Create HTTP JSON-RPC server with 30 second timeout
-	httpServer := rpc.NewServer(30*time.Second, services)
+	httpServer := rpc.NewServerWithLoadTracker(30*time.Second, services, transportLoad)
 	if consensusComponents != nil && consensusComponents.Overlay != nil {
 		httpServer.SetPeerSource(consensusComponents.Overlay)
 	}
@@ -751,7 +754,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 	services.SetDispatcher(httpServer)
 
 	// Create WebSocket server for real-time subscriptions
-	wsServer = rpc.NewWebSocketServer(30*time.Second, services)
+	wsServer = rpc.NewWebSocketServerWithLoadTracker(30*time.Second, services, transportLoad)
 	if globalConfig.WebsocketPingFrequency > 0 {
 		wsServer.SetPingInterval(time.Duration(globalConfig.WebsocketPingFrequency) * time.Second)
 	}

--- a/internal/rpc/account_channels_test.go
+++ b/internal/rpc/account_channels_test.go
@@ -927,7 +927,7 @@ func TestAccountChannelsServiceUnavailable(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // TestAccountChannelsMethodMetadata tests the method's metadata functions

--- a/internal/rpc/account_currencies_test.go
+++ b/internal/rpc/account_currencies_test.go
@@ -602,7 +602,7 @@ func TestAccountCurrenciesServiceUnavailable(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // TestAccountCurrenciesMethodMetadata tests the method's metadata functions

--- a/internal/rpc/account_info_test.go
+++ b/internal/rpc/account_info_test.go
@@ -849,7 +849,7 @@ func TestAccountInfoServiceUnavailable(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // TestAccountInfoServiceNilLedger tests behavior when ledger service is nil
@@ -873,7 +873,7 @@ func TestAccountInfoServiceNilLedger(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // TestAccountInfoMethodMetadata tests the method's metadata functions

--- a/internal/rpc/account_lines_test.go
+++ b/internal/rpc/account_lines_test.go
@@ -1213,7 +1213,7 @@ func TestAccountLinesServiceUnavailable(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // TestAccountLinesServiceNilLedger tests behavior when ledger service is nil
@@ -1237,7 +1237,7 @@ func TestAccountLinesServiceNilLedger(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // TestAccountLinesMethodMetadata tests the method's metadata functions

--- a/internal/rpc/account_nfts_test.go
+++ b/internal/rpc/account_nfts_test.go
@@ -892,7 +892,7 @@ func TestAccountNFTsServiceUnavailable(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // TestAccountNFTsMethodMetadata tests the method's metadata functions

--- a/internal/rpc/account_objects_test.go
+++ b/internal/rpc/account_objects_test.go
@@ -986,7 +986,8 @@ func TestAccountObjectsServiceErrors(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Failed to get account objects")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
+		assert.NotContains(t, rpcErr.Message, "database connection failed")
 	})
 }
 

--- a/internal/rpc/account_objects_test.go
+++ b/internal/rpc/account_objects_test.go
@@ -783,7 +783,7 @@ func TestAccountObjectsServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 
 	t.Run("Ledger is nil", func(t *testing.T) {
@@ -799,7 +799,7 @@ func TestAccountObjectsServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 }
 

--- a/internal/rpc/account_offers_test.go
+++ b/internal/rpc/account_offers_test.go
@@ -1278,6 +1278,7 @@ func TestAccountOffersServiceError(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Failed to get account offers")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
+		assert.NotContains(t, rpcErr.Message, "database connection failed")
 	})
 }

--- a/internal/rpc/account_offers_test.go
+++ b/internal/rpc/account_offers_test.go
@@ -956,7 +956,7 @@ func TestAccountOffersServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 
 	t.Run("Ledger nil", func(t *testing.T) {
@@ -978,7 +978,7 @@ func TestAccountOffersServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 }
 

--- a/internal/rpc/account_tx_test.go
+++ b/internal/rpc/account_tx_test.go
@@ -1222,7 +1222,8 @@ func TestAccountTxServiceErrors(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Failed to get account transactions")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
+		assert.NotContains(t, rpcErr.Message, "database connection failed")
 	})
 
 	t.Run("Account not found error", func(t *testing.T) {

--- a/internal/rpc/account_tx_test.go
+++ b/internal/rpc/account_tx_test.go
@@ -971,7 +971,7 @@ func TestAccountTxServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 
 	t.Run("Services.Ledger is nil", func(t *testing.T) {
@@ -987,7 +987,7 @@ func TestAccountTxServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 }
 

--- a/internal/rpc/admin_forbidden_test.go
+++ b/internal/rpc/admin_forbidden_test.go
@@ -74,8 +74,8 @@ func TestHTTPAdminDenialChargesFeeMalformed(t *testing.T) {
 	// The malformed bucket is 100; the reference bucket is 20. Allow for a hair
 	// of decay between the charge and this read, but confirm it is the malformed
 	// charge, not a cheaper one.
-	if got := srv.loadTracker.Balance("198.51.100.7"); got <= float64(loadtrack.ChargeReference) {
-		t.Fatalf("forbidden admin denial charged %v, want feeMalformedRPC (~%d)", got, loadtrack.ChargeMalformed)
+	if got, want := srv.loadTracker.Balance("198.51.100.7"), float64(loadtrack.ChargeMalformed/uint32(loadtrack.DecayWindow/time.Second)); got != want {
+		t.Fatalf("forbidden admin denial charged %v, want %v", got, want)
 	}
 
 	// An admin caller is unlimited and accrues nothing.

--- a/internal/rpc/api_version_gate_test.go
+++ b/internal/rpc/api_version_gate_test.go
@@ -287,9 +287,13 @@ func TestApiVersion_WSRequiresJSONInteger(t *testing.T) {
 	ws := versionEchoWSServer(t, false)
 	for _, rawVersion := range []string{`"2"`, `1.5`, `1.0`, `1e0`} {
 		t.Run(rawVersion, func(t *testing.T) {
-			resp := wsRoundTrip(t, ws, `{"command":"ping","api_version":`+rawVersion+`}`)
-			if resp.Error != "invalid_API_version" {
-				t.Fatalf("error = %q, want invalid_API_version", resp.Error)
+			raw := wsRawRoundTrip(t, ws, `{"command":"ping","api_version":`+rawVersion+`}`)
+			var resp map[string]any
+			if err := json.Unmarshal(raw, &resp); err != nil {
+				t.Fatalf("unmarshal response: %v\nraw: %s", err, string(raw))
+			}
+			if resp["error"] != "invalid_API_version" {
+				t.Fatalf("error = %q, want invalid_API_version", resp["error"])
 			}
 		})
 	}

--- a/internal/rpc/api_version_gate_test.go
+++ b/internal/rpc/api_version_gate_test.go
@@ -265,9 +265,6 @@ func TestApiVersion_WS_V3GatedByBeta(t *testing.T) {
 	})
 }
 
-// TestApiVersion_WS_UnspecifiedDefaultsToV1 verifies a WS command without
-// api_version resolves to v1 internally without adding an api_version field
-// that was absent from the request.
 func TestApiVersion_WS_UnspecifiedDefaultsToV1(t *testing.T) {
 	ws := versionEchoWSServer(t, false)
 	resp := wsRoundTrip(t, ws, `{"command":"ping"}`)

--- a/internal/rpc/api_version_gate_test.go
+++ b/internal/rpc/api_version_gate_test.go
@@ -189,7 +189,7 @@ func versionEchoWSServer(t *testing.T, beta bool) *WebSocketServer {
 	return ws
 }
 
-func wsRoundTrip(t *testing.T, ws *WebSocketServer, request string) types.WebSocketResponse {
+func wsRawRoundTrip(t *testing.T, ws *WebSocketServer, request string) []byte {
 	t.Helper()
 	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
 	defer httpSrv.Close()
@@ -209,7 +209,22 @@ func wsRoundTrip(t *testing.T, ws *WebSocketServer, request string) types.WebSoc
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
-	var resp types.WebSocketResponse
+	return raw
+}
+
+type apiVersionWSResponse struct {
+	Status       string `json:"status"`
+	Result       any    `json:"result,omitempty"`
+	ApiVersion   int    `json:"api_version,omitempty"`
+	Error        string `json:"error,omitempty"`
+	ErrorCode    int    `json:"error_code,omitempty"`
+	ErrorMessage string `json:"error_message,omitempty"`
+}
+
+func wsRoundTrip(t *testing.T, ws *WebSocketServer, request string) apiVersionWSResponse {
+	t.Helper()
+	raw := wsRawRoundTrip(t, ws, request)
+	var resp apiVersionWSResponse
 	if err := json.Unmarshal(raw, &resp); err != nil {
 		t.Fatalf("unmarshal response: %v\nraw: %s", err, string(raw))
 	}
@@ -251,14 +266,40 @@ func TestApiVersion_WS_V3GatedByBeta(t *testing.T) {
 }
 
 // TestApiVersion_WS_UnspecifiedDefaultsToV1 verifies a WS command without
-// api_version resolves to v1.
+// api_version resolves to v1 internally without adding an api_version field
+// that was absent from the request.
 func TestApiVersion_WS_UnspecifiedDefaultsToV1(t *testing.T) {
 	ws := versionEchoWSServer(t, false)
 	resp := wsRoundTrip(t, ws, `{"command":"ping"}`)
 	if resp.Status != "success" {
 		t.Fatalf("WS ping status = %q, want success", resp.Status)
 	}
-	if resp.ApiVersion != types.ApiVersion1 {
-		t.Fatalf("WS unspecified api_version resolved to %d, want %d", resp.ApiVersion, types.ApiVersion1)
+	if resp.ApiVersion != 0 {
+		t.Fatalf("WS response added unspecified api_version %d", resp.ApiVersion)
+	}
+	result, ok := resp.Result.(map[string]any)
+	if !ok || result["api_version"] != float64(types.ApiVersion1) {
+		t.Fatalf("WS handler context did not resolve unspecified version to v1: %v", resp.Result)
+	}
+}
+
+func TestApiVersion_WSRequiresJSONInteger(t *testing.T) {
+	ws := versionEchoWSServer(t, false)
+	for _, rawVersion := range []string{`"2"`, `1.5`, `1.0`, `1e0`} {
+		t.Run(rawVersion, func(t *testing.T) {
+			resp := wsRoundTrip(t, ws, `{"command":"ping","api_version":`+rawVersion+`}`)
+			if resp.Error != "invalid_API_version" {
+				t.Fatalf("error = %q, want invalid_API_version", resp.Error)
+			}
+		})
+	}
+}
+
+func TestApiVersion_WSInvalidVersionPrecedesCommandValidation(t *testing.T) {
+	ws := versionEchoWSServer(t, false)
+	raw := wsRawRoundTrip(t, ws, `{"command":7,"api_version":1e0,"id":7}`)
+	const want = `{"api_version":1,"error":"invalid_API_version","id":7,"request":{"api_version":1,"command":7,"id":7},"status":"error","type":"response"}`
+	if got := string(raw); got != want {
+		t.Fatalf("response = %s, want %s", got, want)
 	}
 }

--- a/internal/rpc/book_changes_test.go
+++ b/internal/rpc/book_changes_test.go
@@ -390,7 +390,7 @@ func TestBookChangesServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 
 	t.Run("Services.Ledger is nil", func(t *testing.T) {
@@ -411,7 +411,7 @@ func TestBookChangesServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 }
 

--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -1299,7 +1299,7 @@ func TestBookOffersServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 
 	t.Run("Ledger is nil", func(t *testing.T) {
@@ -1315,7 +1315,7 @@ func TestBookOffersServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 }
 

--- a/internal/rpc/book_offers_test.go
+++ b/internal/rpc/book_offers_test.go
@@ -1353,7 +1353,8 @@ func TestBookOffersServiceError(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Failed to get book offers")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
+	assert.NotContains(t, rpcErr.Message, "ledger not found")
 }
 
 // TestBookOffersMarkerPassthrough exercises the handler's marker handling:

--- a/internal/rpc/deposit_authorized_test.go
+++ b/internal/rpc/deposit_authorized_test.go
@@ -611,7 +611,7 @@ func TestDepositAuthorizedServiceUnavailable(t *testing.T) {
 	resp, err := method.Handle(ctx, paramsJSON)
 
 	require.NotNil(t, err)
-	assert.Contains(t, err.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", err.Message)
 	assert.Nil(t, resp)
 }
 

--- a/internal/rpc/dispatch_gate_order_test.go
+++ b/internal/rpc/dispatch_gate_order_test.go
@@ -97,8 +97,9 @@ func TestDispatchGateOrder(t *testing.T) {
 // TestHTTPForbiddenBeatsBusy pins the observable wire-shape divergence the
 // resequencing fixes: a forbidden admin request concurrent with a saturated
 // job queue returns HTTP 403 "Forbidden" (the role-layer short-circuit), not
-// the rpcTOO_BUSY 503 envelope. An unknown method under the same saturation
-// stays 503, confirming busy still precedes the unknown-command failure.
+// the rpcTOO_BUSY envelope. An unknown method under the same saturation keeps
+// the legacy HTTP 200 status while returning tooBusy, confirming busy still
+// precedes the unknown-command failure.
 func TestHTTPForbiddenBeatsBusy(t *testing.T) {
 	services := types.NewServiceContainer(nil)
 	srv := NewServer(time.Second, services)
@@ -122,14 +123,14 @@ func TestHTTPForbiddenBeatsBusy(t *testing.T) {
 		assert.NotContains(t, rr.Body.String(), "tooBusy")
 	})
 
-	t.Run("unknown method stays 503 tooBusy", func(t *testing.T) {
+	t.Run("unknown method returns legacy HTTP 200 tooBusy", func(t *testing.T) {
 		req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"nope","params":[{}]}`))
 		req.RemoteAddr = "192.0.2.1:1234"
 		rr := httptest.NewRecorder()
 		srv.ServeHTTP(rr, req)
 
-		require.Equal(t, http.StatusServiceUnavailable, rr.Code,
-			"unknown method under saturation must stay 503; body: %s", rr.Body.String())
+		require.Equal(t, http.StatusOK, rr.Code,
+			"default ripplerpc must retain HTTP 200; body: %s", rr.Body.String())
 		result := decodeEnvelope(t, rr.Body.Bytes())
 		assert.Equal(t, "tooBusy", result["error"])
 	})

--- a/internal/rpc/dispatch_parity_test.go
+++ b/internal/rpc/dispatch_parity_test.go
@@ -58,7 +58,8 @@ func TestDispatchMethodEnforcesConditionMet(t *testing.T) {
 
 // TestResolveWSCommand pins M4's command resolution: `method` is accepted as an
 // alias for `command`, and the request is malformed (→ missingCommand) only
-// when neither is a non-empty string or both are present and disagree.
+// when neither field is present, a supplied field is not a string, or both
+// fields are present and disagree. An empty string reaches normal dispatch.
 func TestResolveWSCommand(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -71,7 +72,7 @@ func TestResolveWSCommand(t *testing.T) {
 		{"both agree", map[string]any{"command": "ping", "method": "ping"}, "ping", true},
 		{"both disagree", map[string]any{"command": "ping", "method": "pong"}, "", false},
 		{"neither", map[string]any{"id": 1}, "", false},
-		{"empty command", map[string]any{"command": ""}, "", false},
+		{"empty command", map[string]any{"command": ""}, "", true},
 		{"non-string command", map[string]any{"command": 7}, "", false},
 	}
 	for _, c := range cases {
@@ -171,9 +172,40 @@ func TestWSCommandAliasAndMissingCommand(t *testing.T) {
 		assert.NotContains(t, resp, "error_message")
 	})
 
+	t.Run("missing command redacts credential-shaped metadata", func(t *testing.T) {
+		resp := roundtrip(map[string]any{
+			"id": map[string]any{"secret": "private seed"},
+		})
+		assert.Equal(t, "missingCommand", resp["error"])
+		assert.Equal(t, map[string]any{"secret": maskedValue}, resp["id"])
+		encoded, err := json.Marshal(resp)
+		require.NoError(t, err)
+		assert.NotContains(t, string(encoded), "private seed")
+	})
+
 	t.Run("command/method mismatch is missingCommand", func(t *testing.T) {
 		resp := roundtrip(map[string]any{"command": "ping", "method": "pong", "id": float64(3)})
 		assert.Equal(t, "error", resp["status"])
 		assert.Equal(t, "missingCommand", resp["error"])
+	})
+
+	t.Run("non-string command is not rescued by method", func(t *testing.T) {
+		resp := roundtrip(map[string]any{"command": float64(7), "method": "ping", "id": float64(4)})
+		assert.Equal(t, "error", resp["status"])
+		assert.Equal(t, "missingCommand", resp["error"])
+	})
+
+	t.Run("non-string method is not rescued by command", func(t *testing.T) {
+		resp := roundtrip(map[string]any{"command": "ping", "method": float64(7), "id": float64(5)})
+		assert.Equal(t, "error", resp["status"])
+		assert.Equal(t, "missingCommand", resp["error"])
+	})
+
+	t.Run("empty command reaches unknown method", func(t *testing.T) {
+		resp := roundtrip(map[string]any{"command": "", "id": float64(6)})
+		assert.Equal(t, "error", resp["status"])
+		assert.Equal(t, "unknownCmd", resp["error"])
+		assert.Equal(t, float64(types.RpcUNKNOWN_COMMAND), resp["error_code"])
+		assert.Equal(t, "Unknown method.", resp["error_message"])
 	})
 }

--- a/internal/rpc/dispatch_parity_test.go
+++ b/internal/rpc/dispatch_parity_test.go
@@ -205,7 +205,7 @@ func TestWSCommandAliasAndMissingCommand(t *testing.T) {
 		resp := roundtrip(map[string]any{"command": "", "id": float64(6)})
 		assert.Equal(t, "error", resp["status"])
 		assert.Equal(t, "unknownCmd", resp["error"])
-		assert.Equal(t, float64(types.RpcUNKNOWN_COMMAND), resp["error_code"])
+		assert.Equal(t, float64(types.RpcMETHOD_NOT_FOUND), resp["error_code"])
 		assert.Equal(t, "Unknown method.", resp["error_message"])
 	})
 }

--- a/internal/rpc/events.go
+++ b/internal/rpc/events.go
@@ -233,6 +233,8 @@ type PathFindEvent struct {
 	DestinationAmount  json.RawMessage   `json:"destination_amount"`  // Amount to deliver
 	FullReply          bool              `json:"full_reply"`          // Whether this is a full reply
 	Alternatives       []PathAlternative `json:"alternatives"`        // Alternative paths found
+	Status             string            `json:"status,omitempty"`
+	Closed             bool              `json:"closed,omitempty"`
 }
 
 // PathAlternative represents a single path alternative

--- a/internal/rpc/gateway_balances_test.go
+++ b/internal/rpc/gateway_balances_test.go
@@ -732,7 +732,7 @@ func TestGatewayBalancesServiceUnavailable(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // TestGatewayBalancesMethodMetadata tests the method's metadata functions

--- a/internal/rpc/handlers/account_channels.go
+++ b/internal/rpc/handlers/account_channels.go
@@ -121,5 +121,6 @@ func (m *AccountChannelsMethod) Handle(ctx *types.RpcContext, params json.RawMes
 		response["marker"] = result.Marker
 	}
 
+	setLoadMedium(ctx)
 	return response, nil
 }

--- a/internal/rpc/handlers/account_channels.go
+++ b/internal/rpc/handlers/account_channels.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -71,7 +70,7 @@ func (m *AccountChannelsMethod) Handle(ctx *types.RpcContext, params json.RawMes
 		if errors.Is(err, svcerr.ErrInvalidMarker) {
 			return nil, types.RpcErrorInvalidField("marker")
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account channels: %v", err))
+		return nil, rpcInternalError("account_channels: ledger query failed", err)
 	}
 
 	// Build channels array with proper field handling

--- a/internal/rpc/handlers/account_currencies.go
+++ b/internal/rpc/handlers/account_currencies.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -52,7 +51,7 @@ func (m *AccountCurrenciesMethod) Handle(ctx *types.RpcContext, params json.RawM
 		if errors.Is(err, svcerr.ErrAccountMalformed) {
 			return nil, types.RpcErrorActMalformed("Account malformed.")
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account currencies: %v", err))
+		return nil, rpcInternalError("account_currencies: ledger query failed", err)
 	}
 
 	// Build response

--- a/internal/rpc/handlers/account_info.go
+++ b/internal/rpc/handlers/account_info.go
@@ -112,7 +112,7 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		if errors.Is(err, svcerr.ErrLedgerNotFound) {
 			return nil, types.RpcErrorLgrNotFound("Ledger not found.")
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account info: %v", err))
+		return nil, rpcInternalError("account_info: ledger query failed", err)
 	}
 
 	// Build account_data by decoding the full SLE binary via binarycodec,

--- a/internal/rpc/handlers/account_lines.go
+++ b/internal/rpc/handlers/account_lines.go
@@ -128,6 +128,7 @@ func (m *AccountLinesMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		response["marker"] = result.Marker
 	}
 
+	setLoadMedium(ctx)
 	return response, nil
 }
 

--- a/internal/rpc/handlers/account_lines.go
+++ b/internal/rpc/handlers/account_lines.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -64,7 +63,7 @@ func (m *AccountLinesMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 		if errors.Is(err, svcerr.ErrInvalidMarker) {
 			return nil, types.RpcErrorInvalidField("marker")
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account lines: %v", err))
+		return nil, rpcInternalError("account_lines: ledger query failed", err)
 	}
 
 	// Filter out default-state trust lines when ignore_default is true

--- a/internal/rpc/handlers/account_nfts.go
+++ b/internal/rpc/handlers/account_nfts.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -54,7 +53,7 @@ func (m *AccountNftsMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		if errors.Is(err, svcerr.ErrAccountMalformed) {
 			return nil, types.RpcErrorActMalformed("Account malformed.")
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account NFTs: %v", err))
+		return nil, rpcInternalError("account_nfts: ledger query failed", err)
 	}
 
 	// Build NFTs array with proper field handling

--- a/internal/rpc/handlers/account_nfts.go
+++ b/internal/rpc/handlers/account_nfts.go
@@ -92,5 +92,6 @@ func (m *AccountNftsMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		response["marker"] = result.Marker
 	}
 
+	setLoadMedium(ctx)
 	return response, nil
 }

--- a/internal/rpc/handlers/account_objects.go
+++ b/internal/rpc/handlers/account_objects.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
@@ -185,7 +184,7 @@ func (m *AccountObjectsMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		if errors.Is(err, svcerr.ErrInvalidMarker) {
 			return nil, types.RpcErrorInvalidField("marker")
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account objects: %v", err))
+		return nil, rpcInternalError("account_objects: ledger query failed", err)
 	}
 
 	// Build account_objects array with deserialized fields. When

--- a/internal/rpc/handlers/account_objects.go
+++ b/internal/rpc/handlers/account_objects.go
@@ -230,6 +230,7 @@ func (m *AccountObjectsMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		response["marker"] = result.Marker
 	}
 
+	setLoadMedium(ctx)
 	return response, nil
 }
 

--- a/internal/rpc/handlers/account_offers.go
+++ b/internal/rpc/handlers/account_offers.go
@@ -69,5 +69,6 @@ func (m *AccountOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		response["marker"] = result.Marker
 	}
 
+	setLoadMedium(ctx)
 	return response, nil
 }

--- a/internal/rpc/handlers/account_offers.go
+++ b/internal/rpc/handlers/account_offers.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -54,7 +53,7 @@ func (m *AccountOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		if errors.Is(err, svcerr.ErrInvalidMarker) {
 			return nil, types.RpcErrorInvalidField("marker")
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account offers: %v", err))
+		return nil, rpcInternalError("account_offers: ledger query failed", err)
 	}
 
 	// Build response

--- a/internal/rpc/handlers/account_tx.go
+++ b/internal/rpc/handlers/account_tx.go
@@ -139,7 +139,7 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
 			return nil, types.RpcErrorActNotFound("Account not found.")
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get account transactions: %v", err))
+		return nil, rpcInternalError("account_tx: transaction query failed", err)
 	}
 
 	// Cache for ledger lookups by sequence, to avoid repeated lookups

--- a/internal/rpc/handlers/account_tx.go
+++ b/internal/rpc/handlers/account_tx.go
@@ -68,23 +68,6 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		return nil, types.RpcErrorInvalidParams("invalidParams")
 	}
 
-	// When a single ledger is named via ledger_hash/ledger_index and no
-	// ledger_index_min/max range was given, the query is constrained to that one
-	// ledger: resolve it and collapse the range to [seq, seq] instead of scanning
-	// the whole validated range (AccountTx.cpp parseLedgerArgs:52-130).
-	if !hasMinMax && hasLedgerSpec {
-		targetLedger, _, lerr := LookupLedger(ctx, types.LedgerSpecifier{
-			LedgerHash:  request.LedgerHash,
-			LedgerIndex: types.LedgerIndex(request.LedgerIndex),
-		})
-		if lerr != nil {
-			return nil, lerr
-		}
-		seq := int32(targetLedger.Sequence())
-		ledgerIndexMin = seq
-		ledgerIndexMax = seq
-	}
-
 	// Parse marker if provided
 	var marker *types.AccountTxMarker
 	if request.Marker != nil {
@@ -123,6 +106,19 @@ func (m *AccountTxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		}
 	}
 
+	setLoadMedium(ctx)
+	if !hasMinMax && hasLedgerSpec {
+		targetLedger, _, lerr := LookupLedger(ctx, types.LedgerSpecifier{
+			LedgerHash:  request.LedgerHash,
+			LedgerIndex: types.LedgerIndex(request.LedgerIndex),
+		})
+		if lerr != nil {
+			return nil, lerr
+		}
+		seq := int32(targetLedger.Sequence())
+		ledgerIndexMin = seq
+		ledgerIndexMax = seq
+	}
 	result, err := ctx.Services.Ledger.GetAccountTransactions(
 		ctx.Context,
 		request.Account,

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -104,7 +104,7 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		// Decode the account to get AMMID
 		decoded, decodeErr := binarycodec.Decode(hex.EncodeToString(accountEntry.Node))
 		if decodeErr != nil {
-			return nil, types.RpcErrorInternal("Failed to decode account: " + decodeErr.Error())
+			return nil, rpcInternalError("amm_info: account decoding failed", decodeErr)
 		}
 
 		ammIDHex, ok := decoded["AMMID"].(string)
@@ -149,7 +149,7 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 
 	decoded, decodeErr := binarycodec.Decode(hex.EncodeToString(ammEntry.Node))
 	if decodeErr != nil {
-		return nil, types.RpcErrorInternal("Failed to decode AMM: " + decodeErr.Error())
+		return nil, rpcInternalError("amm_info: AMM decoding failed", decodeErr)
 	}
 
 	// Build the response

--- a/internal/rpc/handlers/amm_info.go
+++ b/internal/rpc/handlers/amm_info.go
@@ -113,8 +113,11 @@ func (m *AMMInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		}
 
 		ammIDBytes, hexErr := hex.DecodeString(ammIDHex)
-		if hexErr != nil || len(ammIDBytes) != 32 {
-			return nil, types.RpcErrorInternal("Invalid AMMID in account")
+		if hexErr != nil {
+			return nil, rpcInternalError("amm_info: AMMID decoding failed", hexErr)
+		}
+		if len(ammIDBytes) != 32 {
+			return nil, rpcInternalInvariantError("amm_info: AMMID has invalid length")
 		}
 		copy(ammKey[:], ammIDBytes)
 		if ammKey == ([32]byte{}) {

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -243,6 +243,7 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		return nil, rpcInternalError("book_offers: ledger query failed", err)
 	}
 
+	setLoadMedium(ctx)
 	response := map[string]any{
 		"offers": result.Offers,
 	}

--- a/internal/rpc/handlers/book_offers.go
+++ b/internal/rpc/handlers/book_offers.go
@@ -240,7 +240,7 @@ func (m *BookOffersMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		if errors.Is(err, svcerr.ErrLedgerNotFound) {
 			return nil, types.RpcErrorLgrNotFound("ledgerNotFound")
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get book offers: %v", err))
+		return nil, rpcInternalError("book_offers: ledger query failed", err)
 	}
 
 	response := map[string]any{

--- a/internal/rpc/handlers/channel_authorize.go
+++ b/internal/rpc/handlers/channel_authorize.go
@@ -114,20 +114,20 @@ func (m *ChannelAuthorizeMethod) Handle(ctx *types.RpcContext, params json.RawMe
 	}
 	messageHex, err := binarycodec.EncodeForSigningClaim(claimJSON)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode claim: %v", err))
+		return nil, rpcInternalError("channel_authorize: claim encoding failed", err)
 	}
 
 	// Convert hex message to raw bytes for signing
 	messageBytes, err := hex.DecodeString(messageHex)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to decode message: %v", err))
+		return nil, rpcInternalError("channel_authorize: claim decoding failed", err)
 	}
 
 	// Sign the message
 	// The Sign functions expect the raw message bytes (as a string)
 	signature, err := signMessage(messageBytes, privateKeyHex, request.KeyType)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Exception occurred during signing: %v", err))
+		return nil, rpcInternalError("channel_authorize: claim signing failed", err)
 	}
 
 	response := map[string]any{

--- a/internal/rpc/handlers/channel_verify.go
+++ b/internal/rpc/handlers/channel_verify.go
@@ -139,13 +139,13 @@ func (m *ChannelVerifyMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 	}
 	messageHex, err := binarycodec.EncodeForSigningClaim(claimJSON)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode claim: %v", err))
+		return nil, rpcInternalError("channel_verify: claim encoding failed", err)
 	}
 
 	// Convert hex message to raw bytes for verification
 	messageBytes, err := hex.DecodeString(messageHex)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to decode message: %v", err))
+		return nil, rpcInternalError("channel_verify: claim decoding failed", err)
 	}
 
 	// Verify the signature

--- a/internal/rpc/handlers/deposit_authorized.go
+++ b/internal/rpc/handlers/deposit_authorized.go
@@ -98,7 +98,7 @@ func (m *DepositAuthorizedMethod) Handle(ctx *types.RpcContext, params json.RawM
 			}
 			return nil, types.RpcErrorBadCredentials(detail)
 		}
-		return nil, types.RpcErrorInternal(err.Error())
+		return nil, rpcInternalError("deposit_authorized: ledger query failed", err)
 	}
 
 	// Build response

--- a/internal/rpc/handlers/feature.go
+++ b/internal/rpc/handlers/feature.go
@@ -64,7 +64,7 @@ func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 			return nil, types.RpcErrorNotSupported("amendment voting is not available on this server")
 		}
 		if err := ctrl.SetAmendmentVote(ctx.Context, f.ID, *request.Vetoed); err != nil {
-			return nil, types.RpcErrorInternal("failed to record amendment vote: " + err.Error())
+			return nil, rpcInternalError("feature: recording amendment vote failed", err)
 		}
 		hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
 		return map[string]any{

--- a/internal/rpc/handlers/gateway_balances.go
+++ b/internal/rpc/handlers/gateway_balances.go
@@ -30,6 +30,11 @@ func (m *GatewayBalancesMethod) Handle(ctx *types.RpcContext, params json.RawMes
 	if err := RequireLedgerService(ctx.Services); err != nil {
 		return nil, err
 	}
+	ledgerIndex, selErr := resolveLedgerSelector(request.LedgerSpecifier)
+	if selErr != nil {
+		return nil, selErr
+	}
+	setLoadHeavy(ctx)
 
 	// Parse hotwallet parameter - can be a string or array of strings
 	var hotWallets []string
@@ -63,11 +68,6 @@ func (m *GatewayBalancesMethod) Handle(ctx *types.RpcContext, params json.RawMes
 		}
 	}
 
-	ledgerIndex, selErr := resolveLedgerSelector(request.LedgerSpecifier)
-	if selErr != nil {
-		return nil, selErr
-	}
-
 	// Get gateway balances from the ledger service
 	result, err := ctx.Services.Ledger.GetGatewayBalances(
 		ctx.Context,
@@ -77,6 +77,7 @@ func (m *GatewayBalancesMethod) Handle(ctx *types.RpcContext, params json.RawMes
 	)
 	if err != nil {
 		if rerr := mapLedgerLookupErr(err); rerr != nil {
+			setLoadReference(ctx)
 			return nil, rerr
 		}
 		if errors.Is(err, svcerr.ErrAccountNotFound) {

--- a/internal/rpc/handlers/gateway_balances.go
+++ b/internal/rpc/handlers/gateway_balances.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -92,7 +91,7 @@ func (m *GatewayBalancesMethod) Handle(ctx *types.RpcContext, params json.RawMes
 			}
 			return nil, types.RpcErrorInvalidParams("Invalid field 'hotwallet'.")
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get gateway balances: %v", err))
+		return nil, rpcInternalError("gateway_balances: ledger query failed", err)
 	}
 
 	// Build response matching rippled's GatewayBalances.cpp format: rippled only

--- a/internal/rpc/handlers/get_aggregate_price.go
+++ b/internal/rpc/handlers/get_aggregate_price.go
@@ -294,7 +294,7 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 			filtered = prices
 		}
 		if len(filtered) == 0 {
-			return nil, types.RpcErrorInternal("Internal error.")
+			return nil, rpcInternalInvariantError("get_aggregate_price: filtering removed all prices")
 		}
 		prices = filtered
 	}

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -29,7 +29,6 @@ func rpcInternalInvariantError(operation string) *types.RpcError {
 	return types.RpcErrorInternal()
 }
 
-// rippled fixes the submission exception text; the runtime cause stays in server logs.
 func rpcTransactionSubmissionError(operation string, err error) *types.RpcError {
 	logRPCError(operation, err)
 	return types.RpcErrorTransactionSubmission()
@@ -76,10 +75,7 @@ func shedCheck(ctx *types.RpcContext) *types.ClientLoadShedder {
 	return ctx.Services.ClientLoad
 }
 
-// RequireNotBusyClient is the generic RPC admission gate fired before
-// every non-admin RPC dispatches. Mirrors rippled's fillHandler check
-// at RPCHandler.cpp:132-141: shed when admitting this request would put the
-// jtCLIENT-or-higher job count above Tuning::maxJobQueueClients (500).
+// RequireNotBusyClient rejects non-admin RPC requests when the client job queue is full.
 func RequireNotBusyClient(ctx *types.RpcContext) *types.RpcError {
 	s := shedCheck(ctx)
 	if s == nil {

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -15,16 +15,36 @@ import (
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 )
 
-func rpcInternalError(operation string, err error) *types.RpcError {
+func logRPCError(operation string, err error) {
 	xrpllog.Named(xrpllog.PartitionRPC).Error(operation, "err", err)
-	return types.RpcErrorInternal("Internal error.")
+}
+
+func rpcInternalError(operation string, err error) *types.RpcError {
+	logRPCError(operation, err)
+	return types.RpcErrorInternal()
+}
+
+func rpcInternalInvariantError(operation string) *types.RpcError {
+	xrpllog.Named(xrpllog.PartitionRPC).Error(operation)
+	return types.RpcErrorInternal()
+}
+
+// rippled fixes the submission exception text; the runtime cause stays in server logs.
+func rpcTransactionSubmissionError(operation string, err error) *types.RpcError {
+	logRPCError(operation, err)
+	return types.RpcErrorTransactionSubmission()
+}
+
+func rpcDBDeserializationError(operation string, err error) *types.RpcError {
+	logRPCError(operation, err)
+	return types.RpcErrorDBDeserialization()
 }
 
 // RequireLedgerService checks that the ledger service is available
 // on the request's service container. Returns an RpcError if not.
 func RequireLedgerService(services *types.ServiceContainer) *types.RpcError {
 	if services == nil || services.Ledger == nil {
-		return types.RpcErrorInternal("Ledger service not available")
+		return rpcInternalInvariantError("rpc: ledger service unavailable")
 	}
 	return nil
 }
@@ -58,14 +78,14 @@ func shedCheck(ctx *types.RpcContext) *types.ClientLoadShedder {
 
 // RequireNotBusyClient is the generic RPC admission gate fired before
 // every non-admin RPC dispatches. Mirrors rippled's fillHandler check
-// at RPCHandler.cpp:132-141: shed when the jtCLIENT-or-higher job count
-// exceeds Tuning::maxJobQueueClients (500).
+// at RPCHandler.cpp:132-141: shed when admitting this request would put the
+// jtCLIENT-or-higher job count above Tuning::maxJobQueueClients (500).
 func RequireNotBusyClient(ctx *types.RpcContext) *types.RpcError {
 	s := shedCheck(ctx)
 	if s == nil {
 		return nil
 	}
-	if s.InFlight() > types.MaxJobQueueClients {
+	if s.InFlight() >= types.MaxJobQueueClients {
 		return types.RpcErrorTooBusy()
 	}
 	return nil
@@ -396,17 +416,38 @@ func (AdminHandler) RequiredCondition() types.Condition { return types.NoConditi
 //
 // It tries VL binary decode first, then falls back to JSON unmarshal.
 func decodeTxBlob(data []byte) (StoredTransaction, error) {
+	return decodeTxBlobWithMetadataMode(data, false, true, false)
+}
+
+func decodeTxBlobForTx(data []byte) (StoredTransaction, error) {
+	return decodeTxBlobWithMetadataMode(data, true, false, false)
+}
+
+func decodeTxBlobForTransactionEntry(data []byte) (StoredTransaction, error) {
+	return decodeTxBlobWithMetadataMode(data, false, true, true)
+}
+
+func decodeTxBlobWithMetadataMode(data []byte, requireMetadataFields, preserveEmptyMetadata, requireBinaryMetadata bool) (StoredTransaction, error) {
 	// Try VL-encoded binary format first
 	txBytes, metaBytes, err := tx.SplitTxWithMetaBlob(data)
 	if err == nil {
-		txJSON, decErr := binarycodec.Decode(hex.EncodeToString(txBytes))
+		if requireBinaryMetadata && metaBytes == nil {
+			return StoredTransaction{}, errors.New("stored transaction is missing binary metadata")
+		}
+		txJSON, decErr := binarycodec.DecodeBytes(txBytes)
 		if decErr == nil {
 			st := StoredTransaction{TxJSON: txJSON}
 			if len(metaBytes) > 0 {
-				metaJSON, metaErr := binarycodec.Decode(hex.EncodeToString(metaBytes))
-				if metaErr == nil {
-					st.Meta = metaJSON
+				metaJSON, metaErr := binarycodec.DecodeBytes(metaBytes)
+				if metaErr != nil {
+					return StoredTransaction{}, fmt.Errorf("decode transaction metadata: %w", metaErr)
 				}
+				st.Meta = metaJSON
+			} else if metaBytes != nil && (preserveEmptyMetadata || requireMetadataFields) {
+				st.Meta = map[string]any{}
+			}
+			if err := validateStoredTransaction(&st, requireMetadataFields); err != nil {
+				return StoredTransaction{}, err
 			}
 			return st, nil
 		}
@@ -417,7 +458,34 @@ func decodeTxBlob(data []byte) (StoredTransaction, error) {
 	if jsonErr := json.Unmarshal(data, &st); jsonErr != nil {
 		return StoredTransaction{}, jsonErr
 	}
+	if err := validateStoredTransaction(&st, requireMetadataFields); err != nil {
+		return StoredTransaction{}, err
+	}
 	return st, nil
+}
+
+func validateStoredTransaction(st *StoredTransaction, requireMetadataFields bool) error {
+	if st.TxJSON == nil {
+		return errors.New("stored transaction is missing tx_json")
+	}
+	canonicalTx, err := tx.CanonicalizeSerializedTransaction(st.TxJSON)
+	if err != nil {
+		return fmt.Errorf("validate stored transaction: %w", err)
+	}
+	st.TxJSON = canonicalTx
+	if st.Meta != nil {
+		var canonicalMeta map[string]any
+		if requireMetadataFields {
+			canonicalMeta, err = tx.CanonicalizeSerializedMetadata(st.Meta)
+		} else {
+			canonicalMeta, err = tx.CanonicalizeSerializedObject(st.Meta)
+		}
+		if err != nil {
+			return fmt.Errorf("validate stored transaction metadata: %w", err)
+		}
+		st.Meta = canonicalMeta
+	}
+	return nil
 }
 
 // InjectDeliveredAmount adds DeliveredAmount to metadata for Payment transactions.

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -12,7 +12,13 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
 )
+
+func rpcInternalError(operation string, err error) *types.RpcError {
+	xrpllog.Named(xrpllog.PartitionRPC).Error(operation, "err", err)
+	return types.RpcErrorInternal("Internal error.")
+}
 
 // RequireLedgerService checks that the ledger service is available
 // on the request's service container. Returns an RpcError if not.

--- a/internal/rpc/handlers/internal_error_test.go
+++ b/internal/rpc/handlers/internal_error_test.go
@@ -1,0 +1,111 @@
+package handlers
+
+import (
+	"bytes"
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRPCInternalErrorSanitizesCause(t *testing.T) {
+	original := xrpllog.Root()
+	t.Cleanup(func() { xrpllog.SetRoot(original) })
+
+	var logs bytes.Buffer
+	cfg := &xrpllog.Config{Level: xrpllog.LevelError, Format: "json", Output: &logs}
+	xrpllog.SetRoot(xrpllog.New(xrpllog.NewHandler(cfg), cfg))
+
+	rpcErr := rpcInternalError("test operation failed", errors.New("backend detail"))
+
+	require.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+	require.Equal(t, "Internal error.", rpcErr.Message)
+	require.NotContains(t, rpcErr.Message, "backend detail")
+	require.Contains(t, logs.String(), "test operation failed")
+	require.Contains(t, logs.String(), "backend detail")
+	require.Contains(t, logs.String(), xrpllog.PartitionRPC)
+}
+
+func TestRPCErrorInternalMessagesAreLiterals(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	dir := filepath.Dir(testFile)
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		require.NoError(t, err)
+
+		typeAliases := make(map[string]struct{})
+		dotImported := false
+		for _, spec := range file.Imports {
+			importPath, err := strconv.Unquote(spec.Path.Value)
+			require.NoError(t, err)
+			if importPath != "github.com/LeJamon/go-xrpl/internal/rpc/types" {
+				continue
+			}
+			if spec.Name == nil {
+				typeAliases["types"] = struct{}{}
+			} else if spec.Name.Name == "." {
+				dotImported = true
+			} else if spec.Name.Name != "_" {
+				typeAliases[spec.Name.Name] = struct{}{}
+			}
+		}
+
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			isInternalError := false
+			switch fun := call.Fun.(type) {
+			case *ast.SelectorExpr:
+				ident, ok := fun.X.(*ast.Ident)
+				if ok && fun.Sel.Name == "RpcErrorInternal" {
+					_, isInternalError = typeAliases[ident.Name]
+				}
+			case *ast.Ident:
+				isInternalError = dotImported && fun.Name == "RpcErrorInternal"
+			}
+			if !isInternalError {
+				return true
+			}
+
+			if len(call.Args) != 1 {
+				t.Errorf(
+					"%s: RpcErrorInternal requires exactly one literal message",
+					fset.Position(call.Pos()),
+				)
+				return true
+			}
+			literal, isLiteral := call.Args[0].(*ast.BasicLit)
+			if !isLiteral || literal.Kind != token.STRING {
+				t.Errorf(
+					"%s: RpcErrorInternal message must be a string literal; log runtime errors with rpcInternalError",
+					fset.Position(call.Pos()),
+				)
+			}
+			return true
+		})
+	}
+}

--- a/internal/rpc/handlers/internal_error_test.go
+++ b/internal/rpc/handlers/internal_error_test.go
@@ -3,28 +3,24 @@ package handlers
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"go/ast"
-	"go/parser"
+	"go/constant"
 	"go/token"
-	"os"
+	gotypes "go/types"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
 )
 
 func TestRPCInternalErrorSanitizesCause(t *testing.T) {
-	original := xrpllog.Root()
-	t.Cleanup(func() { xrpllog.SetRoot(original) })
-
-	var logs bytes.Buffer
-	cfg := &xrpllog.Config{Level: xrpllog.LevelError, Format: "json", Output: &logs}
-	xrpllog.SetRoot(xrpllog.New(xrpllog.NewHandler(cfg), cfg))
+	logs := captureRPCErrorLogs(t)
 
 	rpcErr := rpcInternalError("test operation failed", errors.New("backend detail"))
 
@@ -36,76 +32,602 @@ func TestRPCInternalErrorSanitizesCause(t *testing.T) {
 	require.Contains(t, logs.String(), xrpllog.PartitionRPC)
 }
 
-func TestRPCErrorInternalMessagesAreLiterals(t *testing.T) {
-	_, testFile, _, ok := runtime.Caller(0)
-	require.True(t, ok)
+func TestRPCInternalInvariantErrorIsCanonicalAndLogged(t *testing.T) {
+	logs := captureRPCErrorLogs(t)
 
-	dir := filepath.Dir(testFile)
-	entries, err := os.ReadDir(dir)
+	rpcErr := rpcInternalInvariantError("test invariant failed")
+
+	require.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+	require.Equal(t, "internal", rpcErr.ErrorString)
+	require.Equal(t, "Internal error.", rpcErr.Message)
+	require.Contains(t, logs.String(), "test invariant failed")
+}
+
+func TestRPCTransactionSubmissionErrorPreservesFixedMessage(t *testing.T) {
+	logs := captureRPCErrorLogs(t)
+	cause := errors.New("backend submission detail")
+
+	rpcErr := rpcTransactionSubmissionError("test submission failed", cause)
+
+	require.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+	require.Equal(t, "internal", rpcErr.ErrorString)
+	require.Equal(t, "Exception occurred during transaction submission.", rpcErr.Message)
+	require.NotContains(t, rpcErr.Message, cause.Error())
+	require.Contains(t, logs.String(), "test submission failed")
+	require.Contains(t, logs.String(), cause.Error())
+}
+
+func TestRPCDBDeserializationErrorIsCanonicalAndLogged(t *testing.T) {
+	logs := captureRPCErrorLogs(t)
+	cause := errors.New("corrupt stored transaction")
+
+	rpcErr := rpcDBDeserializationError("test transaction decode failed", cause)
+
+	require.Equal(t, types.RpcDB_DESERIALIZATION, rpcErr.Code)
+	require.Equal(t, "dbDeserialization", rpcErr.ErrorString)
+	require.Equal(t, "Database deserialization error.", rpcErr.Message)
+	require.NotContains(t, rpcErr.Message, cause.Error())
+	require.Contains(t, logs.String(), "test transaction decode failed")
+	require.Contains(t, logs.String(), cause.Error())
+}
+
+func captureRPCErrorLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	original := xrpllog.Root()
+	t.Cleanup(func() { xrpllog.SetRoot(original) })
+
+	logs := &bytes.Buffer{}
+	cfg := &xrpllog.Config{Level: xrpllog.LevelError, Format: "json", Output: logs}
+	xrpllog.SetRoot(xrpllog.New(xrpllog.NewHandler(cfg), cfg))
+	return logs
+}
+
+func TestRPCInternalErrorConstructionsAreSafe(t *testing.T) {
+	moduleRoot := rpcInternalAuditModuleRoot(t)
+	loaded, err := loadRPCInternalAuditPackages(moduleRoot, "./...")
 	require.NoError(t, err)
+	require.Empty(t, auditRPCInternalErrors(loaded))
+}
 
-	fset := token.NewFileSet()
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".go" || strings.HasSuffix(entry.Name(), "_test.go") {
-			continue
-		}
+func TestRPCInternalErrorAuditFixtures(t *testing.T) {
+	moduleRoot := rpcInternalAuditModuleRoot(t)
+	tests := []struct {
+		name        string
+		fixture     string
+		wantFinding string
+	}{
+		{name: "safe constructors and shadowing", fixture: "safe"},
+		{name: "direct constructor", fixture: "unsafe_direct", wantFinding: "code 73 construction outside approved constructors"},
+		{name: "constructor alias", fixture: "unsafe_alias", wantFinding: "NewRpcError may only be called directly"},
+		{name: "constructor wrapper", fixture: "unsafe_wrapper", wantFinding: "NewRpcError code must be a compile-time constant"},
+		{name: "constructor reassignment", fixture: "unsafe_reassignment", wantFinding: "NewRpcError may only be called directly"},
+		{name: "composite literal", fixture: "unsafe_composite", wantFinding: "RpcError composite literal with code 73"},
+		{name: "dynamic composite literal", fixture: "unsafe_dynamic_composite", wantFinding: "RpcError composite literal code must be a compile-time constant"},
+		{name: "field mutation", fixture: "unsafe_mutation", wantFinding: "RpcError fields must not be mutated"},
+		{name: "promoted field mutation", fixture: "unsafe_promoted_mutation", wantFinding: "RpcError fields must not be mutated"},
+		{name: "range field mutation", fixture: "unsafe_range_mutation", wantFinding: "RpcError fields must not be mutated"},
+		{name: "field address", fixture: "unsafe_address", wantFinding: "RpcError fields must not be addressable for mutation"},
+		{name: "indirect field mutation", fixture: "unsafe_indirect_mutation", wantFinding: "RpcError fields must not be mutated"},
+		{name: "whole value mutation", fixture: "unsafe_whole_value", wantFinding: "RpcError values must not be mutated"},
+		{name: "defined type", fixture: "unsafe_defined_type", wantFinding: "RpcError composite literal with code 73"},
+	}
 
-		path := filepath.Join(dir, entry.Name())
-		file, err := parser.ParseFile(fset, path, nil, 0)
-		require.NoError(t, err)
-
-		typeAliases := make(map[string]struct{})
-		dotImported := false
-		for _, spec := range file.Imports {
-			importPath, err := strconv.Unquote(spec.Path.Value)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pattern := "./internal/rpc/handlers/testdata/internal_error_audit/" + tc.fixture
+			loaded, err := loadRPCInternalAuditPackages(moduleRoot, pattern)
 			require.NoError(t, err)
-			if importPath != "github.com/LeJamon/go-xrpl/internal/rpc/types" {
-				continue
+			findings := auditRPCInternalErrors(loaded)
+			if tc.wantFinding == "" {
+				require.Empty(t, findings)
+				return
 			}
-			if spec.Name == nil {
-				typeAliases["types"] = struct{}{}
-			} else if spec.Name.Name == "." {
-				dotImported = true
-			} else if spec.Name.Name != "_" {
-				typeAliases[spec.Name.Name] = struct{}{}
+			require.NotEmpty(t, findings)
+			require.Contains(t, strings.Join(findings, "\n"), tc.wantFinding)
+			for _, finding := range findings {
+				require.Contains(t, finding, "fixture.go:")
 			}
-		}
-
-		ast.Inspect(file, func(node ast.Node) bool {
-			call, ok := node.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-
-			isInternalError := false
-			switch fun := call.Fun.(type) {
-			case *ast.SelectorExpr:
-				ident, ok := fun.X.(*ast.Ident)
-				if ok && fun.Sel.Name == "RpcErrorInternal" {
-					_, isInternalError = typeAliases[ident.Name]
-				}
-			case *ast.Ident:
-				isInternalError = dotImported && fun.Name == "RpcErrorInternal"
-			}
-			if !isInternalError {
-				return true
-			}
-
-			if len(call.Args) != 1 {
-				t.Errorf(
-					"%s: RpcErrorInternal requires exactly one literal message",
-					fset.Position(call.Pos()),
-				)
-				return true
-			}
-			literal, isLiteral := call.Args[0].(*ast.BasicLit)
-			if !isLiteral || literal.Kind != token.STRING {
-				t.Errorf(
-					"%s: RpcErrorInternal message must be a string literal; log runtime errors with rpcInternalError",
-					fset.Position(call.Pos()),
-				)
-			}
-			return true
 		})
 	}
+}
+
+func TestRPCFunctionIdentityRejectsMethods(t *testing.T) {
+	pkg := gotypes.NewPackage(rpcTypesPackagePath, "types")
+	params := gotypes.NewTuple(gotypes.NewVar(token.NoPos, pkg, "code", gotypes.Typ[gotypes.Int]))
+	result := gotypes.NewTuple(gotypes.NewVar(token.NoPos, pkg, "result", gotypes.NewPointer(gotypes.Typ[gotypes.Int])))
+	function := gotypes.NewFunc(token.NoPos, pkg, "NewRpcError", gotypes.NewSignatureType(nil, nil, nil, params, result, false))
+	pkg.Scope().Insert(function)
+	receiverType := gotypes.NewNamed(gotypes.NewTypeName(token.NoPos, pkg, "receiver", nil), gotypes.NewStruct(nil, nil), nil)
+	receiver := gotypes.NewVar(token.NoPos, pkg, "", receiverType)
+	method := gotypes.NewFunc(token.NoPos, pkg, "NewRpcError", gotypes.NewSignatureType(receiver, nil, nil, params, result, false))
+
+	require.True(t, isRPCFunction(function, "NewRpcError"))
+	require.False(t, isRPCFunction(method, "NewRpcError"))
+}
+
+const rpcTypesPackagePath = "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+type rpcInternalErrorAuditor struct {
+	findings []string
+	reported map[string]struct{}
+}
+
+func rpcInternalAuditModuleRoot(t *testing.T) string {
+	t.Helper()
+	_, testFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	return filepath.Clean(filepath.Join(filepath.Dir(testFile), "..", "..", ".."))
+}
+
+func loadRPCInternalAuditPackages(moduleRoot string, patterns ...string) ([]*packages.Package, error) {
+	loaded, err := packages.Load(&packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
+			packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo |
+			packages.NeedImports | packages.NeedDeps,
+		Dir:   moduleRoot,
+		Tests: false,
+	}, patterns...)
+	if err != nil {
+		return nil, err
+	}
+	var packageErrors []string
+	for _, pkg := range loaded {
+		for _, loadErr := range pkg.Errors {
+			packageErrors = append(packageErrors, loadErr.Error())
+		}
+	}
+	if len(packageErrors) > 0 {
+		return nil, fmt.Errorf("load RPC packages: %s", strings.Join(packageErrors, "; "))
+	}
+	return loaded, nil
+}
+
+func auditRPCInternalErrors(loaded []*packages.Package) []string {
+	audit := &rpcInternalErrorAuditor{
+		reported: make(map[string]struct{}),
+	}
+	for _, pkg := range loaded {
+		for _, file := range pkg.Syntax {
+			audit.scanFile(pkg, file)
+		}
+	}
+	return audit.findings
+}
+
+func (a *rpcInternalErrorAuditor) scanFile(pkg *packages.Package, file *ast.File) {
+	parents := make(map[ast.Node]ast.Node)
+	var stack []ast.Node
+	ast.Inspect(file, func(node ast.Node) bool {
+		if node == nil {
+			stack = stack[:len(stack)-1]
+			return true
+		}
+		if len(stack) != 0 {
+			parents[node] = stack[len(stack)-1]
+		}
+		stack = append(stack, node)
+		return true
+	})
+
+	approvedCalls := a.approvedInternalConstructorCalls(pkg, file)
+	approvedLiterals := a.approvedRPCErrorFactoryLiterals(pkg, file)
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch node := node.(type) {
+		case *ast.CallExpr:
+			if !isRPCFunction(auditUsedFunction(pkg, node.Fun), "NewRpcError") {
+				break
+			}
+			if _, approved := approvedCalls[node]; approved {
+				break
+			}
+			if len(node.Args) == 0 || pkg.TypesInfo.Types[node.Args[0]].Value == nil {
+				a.report(pkg, node, "NewRpcError code must be a compile-time constant")
+				break
+			}
+			if isRPCInternalConstant(pkg.TypesInfo.Types[node.Args[0]].Value) {
+				a.report(pkg, node, "RPC code 73 construction outside approved constructors")
+			}
+		case *ast.SelectorExpr:
+			if isRPCFunction(auditUsedFunction(pkg, node), "NewRpcError") && !isDirectCallTarget(node, parents) {
+				a.report(pkg, node, "NewRpcError may only be called directly")
+			}
+		case *ast.Ident:
+			if selector, ok := parents[node].(*ast.SelectorExpr); ok && selector.Sel == node {
+				break
+			}
+			if isRPCFunction(auditUsedFunction(pkg, node), "NewRpcError") && !isDirectCallTarget(node, parents) {
+				a.report(pkg, node, "NewRpcError may only be called directly")
+			}
+		case *ast.CompositeLit:
+			if !isRPCErrorType(pkg.TypesInfo.TypeOf(node)) {
+				break
+			}
+			if _, approved := approvedLiterals[node]; approved {
+				break
+			}
+			value := rpcErrorLiteralCode(pkg, node)
+			if value == nil {
+				a.report(pkg, node, "RpcError composite literal code must be a compile-time constant")
+			} else if isRPCInternalConstant(value) {
+				a.report(pkg, node, "RpcError composite literal with code 73 is forbidden")
+			}
+		case *ast.AssignStmt:
+			for _, lhs := range node.Lhs {
+				if a.isRPCErrorField(pkg, lhs) {
+					a.report(pkg, lhs, "RpcError fields must not be mutated")
+				} else if isRPCErrorMutationTarget(pkg, lhs) {
+					a.report(pkg, lhs, "RpcError values must not be mutated")
+				}
+			}
+		case *ast.IncDecStmt:
+			if a.isRPCErrorField(pkg, node.X) {
+				a.report(pkg, node.X, "RpcError fields must not be mutated")
+			}
+		case *ast.RangeStmt:
+			if node.Tok == token.ASSIGN {
+				for _, field := range []ast.Expr{node.Key, node.Value} {
+					if field != nil && a.isRPCErrorField(pkg, field) {
+						a.report(pkg, field, "RpcError fields must not be mutated")
+					}
+				}
+			}
+		case *ast.UnaryExpr:
+			if node.Op.String() == "&" && a.isRPCErrorField(pkg, node.X) {
+				a.report(pkg, node.X, "RpcError fields must not be addressable for mutation")
+			}
+		}
+		return true
+	})
+}
+
+func (a *rpcInternalErrorAuditor) approvedInternalConstructorCalls(pkg *packages.Package, file *ast.File) map[*ast.CallExpr]struct{} {
+	approved := make(map[*ast.CallExpr]struct{})
+	if !a.isErrorsImplementation(pkg, file) {
+		return approved
+	}
+	seen := make(map[string]bool)
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		message, fixed := fixedInternalConstructorMessage(function.Name.Name)
+		if !fixed {
+			continue
+		}
+		seen[function.Name.Name] = true
+		call, exact := exactInternalConstructorCall(pkg, function, message)
+		if !exact {
+			a.report(pkg, function, function.Name.Name+" must remain an exact no-argument fixed RPC error constructor")
+			continue
+		}
+		approved[call] = struct{}{}
+	}
+	for _, name := range []string{"RpcErrorInternal", "RpcErrorTransactionSubmission"} {
+		if !seen[name] {
+			a.report(pkg, file, name+" must remain an exact no-argument fixed RPC error constructor")
+		}
+	}
+	return approved
+}
+
+func (a *rpcInternalErrorAuditor) approvedRPCErrorFactoryLiterals(pkg *packages.Package, file *ast.File) map[*ast.CompositeLit]struct{} {
+	approved := make(map[*ast.CompositeLit]struct{})
+	if !a.isErrorsImplementation(pkg, file) {
+		return approved
+	}
+	found := false
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Name.Name != "NewRpcError" {
+			continue
+		}
+		object := auditDefinedFunction(pkg, function.Name)
+		if !isRPCFunction(object, "NewRpcError") {
+			continue
+		}
+		found = true
+		literal, exact := exactRPCErrorFactory(pkg, function, object)
+		if !exact {
+			a.report(pkg, function, "NewRpcError must remain an exact field-copy factory")
+			continue
+		}
+		approved[literal] = struct{}{}
+	}
+	if !found {
+		a.report(pkg, file, "NewRpcError must remain an exact field-copy factory")
+	}
+	return approved
+}
+
+func exactRPCErrorFactory(pkg *packages.Package, function *ast.FuncDecl, object *gotypes.Func) (*ast.CompositeLit, bool) {
+	signature, _ := object.Type().(*gotypes.Signature)
+	if signature == nil || signature.Recv() != nil || function.Recv != nil || function.Type.TypeParams != nil ||
+		signature.Variadic() || signature.Params().Len() != 4 || signature.Results().Len() != 1 ||
+		!isBasicType(signature.Params().At(0).Type(), gotypes.Int) ||
+		!isBasicType(signature.Params().At(1).Type(), gotypes.String) ||
+		!isBasicType(signature.Params().At(2).Type(), gotypes.String) ||
+		!isBasicType(signature.Params().At(3).Type(), gotypes.String) ||
+		!isRPCErrorPointer(signature.Results().At(0).Type()) || function.Body == nil || len(function.Body.List) != 1 {
+		return nil, false
+	}
+	result, ok := function.Body.List[0].(*ast.ReturnStmt)
+	if !ok || len(result.Results) != 1 {
+		return nil, false
+	}
+	address, ok := unparen(result.Results[0]).(*ast.UnaryExpr)
+	if !ok || address.Op != token.AND {
+		return nil, false
+	}
+	literal, ok := unparen(address.X).(*ast.CompositeLit)
+	if !ok || !isRPCErrorType(pkg.TypesInfo.TypeOf(literal)) || len(literal.Elts) != 4 {
+		return nil, false
+	}
+	expected := map[string]*gotypes.Var{
+		"Code":        signature.Params().At(0),
+		"ErrorString": signature.Params().At(1),
+		"Type":        signature.Params().At(2),
+		"Message":     signature.Params().At(3),
+	}
+	seen := make(map[string]bool, len(expected))
+	for _, element := range literal.Elts {
+		keyed, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			return nil, false
+		}
+		key, ok := keyed.Key.(*ast.Ident)
+		if !ok || seen[key.Name] {
+			return nil, false
+		}
+		parameter, ok := expected[key.Name]
+		if !ok {
+			return nil, false
+		}
+		value, ok := unparen(keyed.Value).(*ast.Ident)
+		if !ok || pkg.TypesInfo.Uses[value] != parameter {
+			return nil, false
+		}
+		seen[key.Name] = true
+	}
+	return literal, len(seen) == len(expected)
+}
+
+func isBasicType(value gotypes.Type, kind gotypes.BasicKind) bool {
+	basic, ok := gotypes.Unalias(value).(*gotypes.Basic)
+	return ok && basic.Kind() == kind
+}
+
+func fixedInternalConstructorMessage(name string) (string, bool) {
+	switch name {
+	case "RpcErrorInternal":
+		return "Internal error.", true
+	case "RpcErrorTransactionSubmission":
+		return "Exception occurred during transaction submission.", true
+	default:
+		return "", false
+	}
+}
+
+func exactInternalConstructorCall(pkg *packages.Package, function *ast.FuncDecl, message string) (*ast.CallExpr, bool) {
+	object, _ := pkg.TypesInfo.Defs[function.Name].(*gotypes.Func)
+	if object == nil {
+		return nil, false
+	}
+	signature, _ := object.Type().(*gotypes.Signature)
+	if signature == nil || function.Recv != nil || function.Type.TypeParams != nil ||
+		signature.Params().Len() != 0 || signature.Results().Len() != 1 ||
+		!isRPCErrorPointer(signature.Results().At(0).Type()) || function.Body == nil || len(function.Body.List) != 1 {
+		return nil, false
+	}
+	result, ok := function.Body.List[0].(*ast.ReturnStmt)
+	if !ok || len(result.Results) != 1 {
+		return nil, false
+	}
+	call, ok := unparen(result.Results[0]).(*ast.CallExpr)
+	if !ok || !isRPCFunction(auditUsedFunction(pkg, call.Fun), "NewRpcError") || len(call.Args) != 4 {
+		return nil, false
+	}
+	return call, isRPCInternalConstant(pkg.TypesInfo.Types[call.Args[0]].Value) &&
+		isStringConstant(pkg, call.Args[1], "internal") &&
+		isStringConstant(pkg, call.Args[2], "internal") &&
+		isStringConstant(pkg, call.Args[3], message)
+}
+
+func isStringConstant(pkg *packages.Package, expression ast.Expr, expected string) bool {
+	value := pkg.TypesInfo.Types[expression].Value
+	return value != nil && value.Kind() == constant.String && constant.StringVal(value) == expected
+}
+
+func rpcErrorLiteralCode(pkg *packages.Package, literal *ast.CompositeLit) constant.Value {
+	for _, element := range literal.Elts {
+		if keyed, ok := element.(*ast.KeyValueExpr); ok {
+			if field, ok := keyed.Key.(*ast.Ident); ok && field.Name == "Code" {
+				return pkg.TypesInfo.Types[keyed.Value].Value
+			}
+		}
+	}
+
+	structure, _ := rpcErrorStruct(pkg.TypesInfo.TypeOf(literal))
+	if structure == nil {
+		return nil
+	}
+	for i := 0; i < structure.NumFields() && i < len(literal.Elts); i++ {
+		if structure.Field(i).Name() == "Code" {
+			return pkg.TypesInfo.Types[literal.Elts[i]].Value
+		}
+	}
+	return constant.MakeInt64(0)
+}
+
+func (a *rpcInternalErrorAuditor) isRPCErrorField(pkg *packages.Package, expr ast.Expr) bool {
+	selector, ok := unparen(expr).(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	selection := pkg.TypesInfo.Selections[selector]
+	if selection == nil {
+		return false
+	}
+	selected, ok := selection.Obj().(*gotypes.Var)
+	if !ok {
+		return false
+	}
+	if !selected.IsField() || selected.Pkg() == nil || selected.Pkg().Path() != rpcTypesPackagePath {
+		return false
+	}
+	switch selected.Name() {
+	case "Code", "ErrorString", "Type", "Message", "ErrorException":
+		return true
+	default:
+		return false
+	}
+}
+
+func isRPCErrorMutationTarget(pkg *packages.Package, expr ast.Expr) bool {
+	expr = unparen(expr)
+	switch expr.(type) {
+	case *ast.StarExpr, *ast.IndexExpr:
+		return isRPCErrorType(pkg.TypesInfo.TypeOf(expr))
+	default:
+		return false
+	}
+}
+
+func (a *rpcInternalErrorAuditor) isErrorsImplementation(pkg *packages.Package, node ast.Node) bool {
+	return pkg.PkgPath == rpcTypesPackagePath && filepath.Base(pkg.Fset.Position(node.Pos()).Filename) == "errors.go"
+}
+
+func (a *rpcInternalErrorAuditor) report(pkg *packages.Package, node ast.Node, message string) {
+	finding := fmt.Sprintf("%s: %s", pkg.Fset.Position(node.Pos()), message)
+	if _, exists := a.reported[finding]; exists {
+		return
+	}
+	a.reported[finding] = struct{}{}
+	a.findings = append(a.findings, finding)
+}
+
+func auditUsedFunction(pkg *packages.Package, expr ast.Expr) *gotypes.Func {
+	switch expr := unparen(expr).(type) {
+	case *ast.Ident:
+		function, _ := pkg.TypesInfo.Uses[expr].(*gotypes.Func)
+		return function
+	case *ast.SelectorExpr:
+		function, _ := pkg.TypesInfo.Uses[expr.Sel].(*gotypes.Func)
+		return function
+	default:
+		return nil
+	}
+}
+
+func auditDefinedFunction(pkg *packages.Package, identifier *ast.Ident) *gotypes.Func {
+	function, _ := pkg.TypesInfo.Defs[identifier].(*gotypes.Func)
+	return function
+}
+
+func isDirectCallTarget(node ast.Node, parents map[ast.Node]ast.Node) bool {
+	for {
+		parent := parents[node]
+		parenthesized, ok := parent.(*ast.ParenExpr)
+		if !ok {
+			call, ok := parent.(*ast.CallExpr)
+			return ok && call.Fun == node
+		}
+		node = parenthesized
+	}
+}
+
+func unparen(expr ast.Expr) ast.Expr {
+	for {
+		parenthesized, ok := expr.(*ast.ParenExpr)
+		if !ok {
+			return expr
+		}
+		expr = parenthesized.X
+	}
+}
+
+func isRPCFunction(function *gotypes.Func, name string) bool {
+	if function == nil || function.Name() != name || function.Pkg() == nil || function.Pkg().Path() != rpcTypesPackagePath || function.Parent() != function.Pkg().Scope() {
+		return false
+	}
+	signature, _ := function.Type().(*gotypes.Signature)
+	return signature != nil && signature.Recv() == nil
+}
+
+func isRPCErrorType(value gotypes.Type) bool {
+	if value == nil {
+		return false
+	}
+	value = gotypes.Unalias(value)
+	if pointer, ok := value.(*gotypes.Pointer); ok {
+		value = gotypes.Unalias(pointer.Elem())
+	}
+	named, ok := value.(*gotypes.Named)
+	if !ok {
+		return false
+	}
+	if named.Obj().Name() == "RpcError" && named.Obj().Pkg() != nil && named.Obj().Pkg().Path() == rpcTypesPackagePath {
+		return true
+	}
+	structure, ok := named.Underlying().(*gotypes.Struct)
+	return ok && isRPCErrorStructShape(structure)
+}
+
+func isRPCErrorStructShape(structure *gotypes.Struct) bool {
+	fields := []struct {
+		name string
+		kind gotypes.BasicKind
+		tag  string
+	}{
+		{name: "Code", kind: gotypes.Int, tag: `json:"error_code"`},
+		{name: "ErrorString", kind: gotypes.String, tag: `json:"error"`},
+		{name: "Type", kind: gotypes.String, tag: `json:"type"`},
+		{name: "Message", kind: gotypes.String, tag: `json:"error_message,omitempty"`},
+		{name: "ErrorException", kind: gotypes.String, tag: `json:"error_exception,omitempty"`},
+		{name: "bareToken", kind: gotypes.Bool},
+		{name: "invalidApiVersion", kind: gotypes.Bool},
+		{name: "overloaded", kind: gotypes.Bool},
+	}
+	if structure.NumFields() != len(fields) {
+		return false
+	}
+	for i, expected := range fields {
+		field := structure.Field(i)
+		if field.Name() != expected.name || !isBasicType(field.Type(), expected.kind) || structure.Tag(i) != expected.tag {
+			return false
+		}
+	}
+	return true
+}
+
+func isRPCErrorPointer(value gotypes.Type) bool {
+	if value == nil {
+		return false
+	}
+	pointer, ok := gotypes.Unalias(value).(*gotypes.Pointer)
+	return ok && isRPCErrorType(pointer.Elem())
+}
+
+func rpcErrorStruct(value gotypes.Type) (*gotypes.Struct, bool) {
+	if value == nil {
+		return nil, false
+	}
+	value = gotypes.Unalias(value)
+	if pointer, ok := value.(*gotypes.Pointer); ok {
+		value = gotypes.Unalias(pointer.Elem())
+	}
+	structure, ok := value.Underlying().(*gotypes.Struct)
+	return structure, ok
+}
+
+func isRPCInternalConstant(value constant.Value) bool {
+	if value == nil {
+		return false
+	}
+	integer := constant.ToInt(value)
+	if integer.Kind() == constant.Unknown {
+		return false
+	}
+	number, ok := constant.Int64Val(integer)
+	return ok && number == 73
 }

--- a/internal/rpc/handlers/json.go
+++ b/internal/rpc/handlers/json.go
@@ -29,7 +29,7 @@ func (m *JsonMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any,
 	}
 
 	if ctx.Services == nil || ctx.Services.Dispatcher == nil {
-		return nil, types.RpcErrorInternal("Method dispatcher not available")
+		return nil, rpcInternalInvariantError("json: method dispatcher unavailable")
 	}
 
 	// The params field in the json method can be either:

--- a/internal/rpc/handlers/ledger.go
+++ b/internal/rpc/handlers/ledger.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"maps"
 	"strconv"
 	"strings"
@@ -11,6 +10,7 @@ import (
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	ledgerheader "github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/tx"
@@ -25,17 +25,24 @@ type LedgerMethod struct{ BaseHandler }
 func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	var request struct {
 		types.LedgerSpecifier
-		Accounts     bool `json:"accounts,omitempty"`
-		Full         bool `json:"full,omitempty"`
-		Transactions bool `json:"transactions,omitempty"`
-		Expand       bool `json:"expand,omitempty"`
-		OwnerFunds   bool `json:"owner_funds,omitempty"`
-		Binary       bool `json:"binary,omitempty"`
-		Queue        bool `json:"queue,omitempty"`
+		Accounts     bool            `json:"accounts,omitempty"`
+		Full         bool            `json:"full,omitempty"`
+		Transactions bool            `json:"transactions,omitempty"`
+		Expand       bool            `json:"expand,omitempty"`
+		OwnerFunds   bool            `json:"owner_funds,omitempty"`
+		Binary       bool            `json:"binary,omitempty"`
+		Queue        bool            `json:"queue,omitempty"`
+		Type         json.RawMessage `json:"type,omitempty"`
 	}
 
 	if err := ParseParams(params, &request); err != nil {
 		return nil, err
+	}
+	var rawRequest map[string]json.RawMessage
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &rawRequest); err != nil {
+			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+		}
 	}
 
 	if err := RequireLedgerService(ctx.Services); err != nil {
@@ -46,10 +53,25 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 	// unlimited (admin / identified) role else rpcNO_PERMISSION
 	// (LedgerHandler.cpp:66-72). full also implies expand + transactions +
 	// accounts (LedgerToJson.cpp isFull/isExpanded).
-	if request.Full || request.Accounts {
-		if !ctx.Unlimited {
-			return nil, types.RpcErrorNoPermission("ledger")
+	_, hasLedgerHash := rawRequest["ledger_hash"]
+	_, hasLedgerIndex := rawRequest["ledger_index"]
+	_, hasLegacyLedger := rawRequest["ledger"]
+	hasLedgerSelector := hasLedgerHash || hasLedgerIndex || hasLegacyLedger
+	if !hasLedgerSelector {
+		closed, err := ctx.Services.Ledger.GetLedgerBySequence(ctx.Services.Ledger.GetClosedLedgerIndex())
+		if err != nil || closed == nil {
+			return nil, types.RpcErrorLgrNotFound("ledgerNotFound")
 		}
+		open, err := ctx.Services.Ledger.GetLedgerBySequence(ctx.Services.Ledger.GetCurrentLedgerIndex())
+		if err != nil || open == nil {
+			return nil, types.RpcErrorLgrNotFound("ledgerNotFound")
+		}
+		response := map[string]any{
+			"closed": buildLedgerSummaryJSON(closed, true, ctx.ApiVersion),
+			"open":   buildLedgerSummaryJSON(open, false, ctx.ApiVersion),
+		}
+		addLedgerTypeWarning(response, len(request.Type) > 0)
+		return response, nil
 	}
 	if request.Full {
 		request.Transactions = true
@@ -65,10 +87,22 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 	if lerr != nil {
 		return nil, lerr
 	}
+	if request.Full || request.Accounts {
+		if !ctx.Unlimited {
+			return nil, types.RpcErrorNoPermission("ledger")
+		}
+		if request.Binary {
+			setLoadMedium(ctx)
+		} else {
+			setLoadHeavy(ctx)
+		}
+	}
+	if request.Queue && targetLedger.IsClosed() {
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
 
-	// Build ledger info (shared with ledger_request).
-	ledgerInfo := ledgerInfoJSON(targetLedger)
-	ledgerHash := ledgerInfo["ledger_hash"].(string)
+	ledgerInfo := ledgerRPCInfoJSON(targetLedger, request.Binary, request.Full, ctx.ApiVersion)
+	ledgerHash := FormatLedgerHash(targetLedger.Hash())
 
 	closeTimeSec := targetLedger.CloseTime()
 	closeTimeISO := rippleEpochTime.Add(time.Duration(closeTimeSec) * time.Second).UTC().Format(time.RFC3339)
@@ -122,22 +156,88 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 	}
 
 	response := map[string]any{
-		"ledger":       ledgerInfo,
-		"ledger_hash":  ledgerHash,
-		"ledger_index": targetLedger.Sequence(),
-		"validated":    validated,
+		"ledger":    ledgerInfo,
+		"validated": validated,
 	}
-
-	response["reserve_base_drops"] = fmt.Sprintf("%d", reserveBase)
-	response["reserve_inc_drops"] = fmt.Sprintf("%d", reserveInc)
+	if targetLedger.IsClosed() {
+		response["ledger_hash"] = ledgerHash
+		response["ledger_index"] = targetLedger.Sequence()
+	} else {
+		response["ledger_current_index"] = targetLedger.Sequence()
+	}
 
 	if request.Queue {
 		if queueData := buildLedgerQueueData(ctx, request.Binary, request.Expand); len(queueData) > 0 {
 			response["queue_data"] = queueData
 		}
 	}
+	addLedgerTypeWarning(response, len(request.Type) > 0)
 
 	return response, nil
+}
+
+func ledgerRPCInfoJSON(l types.LedgerReader, binary, full bool, apiVersion int) map[string]any {
+	if binary {
+		result := map[string]any{"closed": l.IsClosed()}
+		if l.IsClosed() {
+			result["ledger_data"] = strings.ToUpper(formatLedgerHeaderBinary(&types.LedgerHeaderInfo{
+				AccountHash:         l.StateMapHash(),
+				CloseFlags:          l.CloseFlags(),
+				CloseTime:           l.CloseTime(),
+				CloseTimeResolution: l.CloseTimeResolution(),
+				LedgerIndex:         l.Sequence(),
+				ParentCloseTime:     l.ParentCloseTime(),
+				ParentHash:          l.ParentHash(),
+				TotalCoins:          l.TotalDrops(),
+				TransactionHash:     l.TxMapHash(),
+			}))
+		}
+		return result
+	}
+
+	ledgerIndex := any(strconv.FormatUint(uint64(l.Sequence()), 10))
+	if apiVersion > 1 {
+		ledgerIndex = l.Sequence()
+	}
+	result := map[string]any{
+		"parent_hash":  FormatLedgerHash(l.ParentHash()),
+		"ledger_index": ledgerIndex,
+	}
+	if l.IsClosed() {
+		result["closed"] = true
+	} else if !full {
+		result["closed"] = false
+		return result
+	}
+
+	result["ledger_hash"] = FormatLedgerHash(l.Hash())
+	result["transaction_hash"] = FormatLedgerHash(l.TxMapHash())
+	result["account_hash"] = FormatLedgerHash(l.StateMapHash())
+	result["total_coins"] = strconv.FormatUint(l.TotalDrops(), 10)
+	result["close_flags"] = l.CloseFlags()
+	result["parent_close_time"] = l.ParentCloseTime()
+	result["close_time"] = l.CloseTime()
+	result["close_time_resolution"] = l.CloseTimeResolution()
+	if l.CloseTime() != 0 {
+		closeTime := rippleEpochTime.Add(time.Duration(l.CloseTime()) * time.Second).UTC()
+		result["close_time_human"] = closeTime.Format("2006-Jan-02 15:04:05.000000000 UTC")
+		result["close_time_iso"] = closeTime.Format(time.RFC3339)
+		if l.CloseFlags()&ledgerheader.LCFNoConsensusTime != 0 {
+			result["close_time_estimated"] = true
+		}
+	}
+	return result
+}
+
+func addLedgerTypeWarning(response map[string]any, typePresent bool) {
+	if !typePresent {
+		return
+	}
+	response["warnings"] = []map[string]any{{
+		"id": 2004,
+		"message": "Some fields from your request are deprecated. Please check the documentation at " +
+			"https://xrpl.org/docs/references/http-websocket-apis/ and update your request. Field `type` is deprecated.",
+	}}
 }
 
 // ownerFundsLedgerView resolves the state view for the target ledger so

--- a/internal/rpc/handlers/ledger_accept.go
+++ b/internal/rpc/handlers/ledger_accept.go
@@ -46,7 +46,7 @@ func (m *LedgerAcceptMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 
 	closedSeq, err := ctx.Services.Ledger.AcceptLedgerAt(ctx.Context, closeTime)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to accept ledger: %v", err))
+		return nil, rpcInternalError("ledger_accept: accepting ledger failed", err)
 	}
 
 	response := map[string]any{

--- a/internal/rpc/handlers/ledger_cleaner.go
+++ b/internal/rpc/handlers/ledger_cleaner.go
@@ -26,7 +26,7 @@ func (m *LedgerCleanerMethod) RequiredCondition() types.Condition {
 
 func (m *LedgerCleanerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	if ctx.Services == nil || ctx.Services.LedgerCleanerConfigure == nil {
-		return nil, types.RpcErrorInternal("Ledger cleaner service not available")
+		return nil, rpcInternalInvariantError("ledger_cleaner: service unavailable")
 	}
 
 	var req struct {

--- a/internal/rpc/handlers/ledger_data.go
+++ b/internal/rpc/handlers/ledger_data.go
@@ -85,7 +85,7 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 		if errors.Is(err, svcerr.ErrInvalidMarker) {
 			return nil, types.RpcErrorExpectedField("marker", "valid")
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get ledger data: %v", err))
+		return nil, rpcInternalError("ledger_data: ledger query failed", err)
 	}
 
 	// Build state array based on binary flag

--- a/internal/rpc/handlers/ledger_entry.go
+++ b/internal/rpc/handlers/ledger_entry.go
@@ -387,7 +387,7 @@ func (m *LedgerEntryMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 		if errors.Is(err, svcerr.ErrLedgerNotFound) {
 			return nil, types.RpcErrorLgrNotFound("ledgerNotFound")
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get ledger entry: %v", err))
+		return nil, rpcInternalError("ledger_entry: ledger query failed", err)
 	}
 
 	response := map[string]any{

--- a/internal/rpc/handlers/ledger_header.go
+++ b/internal/rpc/handlers/ledger_header.go
@@ -134,14 +134,21 @@ func serializeLedgerHeader(lr types.LedgerReader) []byte {
 // fillJson(json, closed, info, bFull=false, apiVersion=1).
 // Reference: rippled/src/xrpld/app/ledger/detail/LedgerToJson.cpp fillJson()
 func buildLedgerHeaderJSON(lr types.LedgerReader, closed bool) map[string]any {
+	return buildLedgerSummaryJSON(lr, closed, types.ApiVersion1)
+}
+
+func buildLedgerSummaryJSON(lr types.LedgerReader, closed bool, apiVersion int) map[string]any {
 	ledgerObj := map[string]any{}
 
 	// parent_hash is always present
 	parentHash := lr.ParentHash()
 	ledgerObj["parent_hash"] = FormatLedgerHash(parentHash)
 
-	// ledger_index as string (API v1 behavior, which is the only version this method supports)
-	ledgerObj["ledger_index"] = strconv.FormatUint(uint64(lr.Sequence()), 10)
+	if apiVersion > types.ApiVersion1 {
+		ledgerObj["ledger_index"] = lr.Sequence()
+	} else {
+		ledgerObj["ledger_index"] = strconv.FormatUint(uint64(lr.Sequence()), 10)
+	}
 
 	if !closed {
 		ledgerObj["closed"] = false

--- a/internal/rpc/handlers/ledger_range.go
+++ b/internal/rpc/handlers/ledger_range.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
@@ -41,7 +40,7 @@ func (m *LedgerRangeMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 
 	result, err := ctx.Services.Ledger.GetLedgerRange(ctx.Context, request.StartLedger, request.StopLedger)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get ledger range: %v", err))
+		return nil, rpcInternalError("ledger_range: ledger query failed", err)
 	}
 
 	// Build ledgers array

--- a/internal/rpc/handlers/ledger_request.go
+++ b/internal/rpc/handlers/ledger_request.go
@@ -76,7 +76,6 @@ func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 	if (hasHash && hasIndex) || (!hasHash && !hasIndex) {
 		return nil, types.RpcErrorInvalidParams("Exactly one of ledger_hash and ledger_index can be set.")
 	}
-
 	var targetHash [32]byte
 	var targetSeq uint32
 

--- a/internal/rpc/handlers/load_shed_test.go
+++ b/internal/rpc/handlers/load_shed_test.go
@@ -47,19 +47,17 @@ func TestGates_NilOrUnwiredIsNoOp(t *testing.T) {
 	}
 }
 
-// Strict-greater semantics for the generic gate mirror
-// rippled RPCHandler.cpp:135 (maxJobQueueClients = 500).
 func TestRequireNotBusyClient_Strictness(t *testing.T) {
 	s := types.NewClientLoadShedder()
-	loadInFlight(s, types.MaxJobQueueClients)
+	loadInFlight(s, types.MaxJobQueueClients-1)
 
 	if rpcErr := RequireNotBusyClient(gatedCtx(s)); rpcErr != nil {
-		t.Fatalf("count==500 should not shed, got %v", rpcErr)
+		t.Fatalf("count==499 should not shed, got %v", rpcErr)
 	}
 	s.Begin()
 	rpcErr := RequireNotBusyClient(gatedCtx(s))
 	if rpcErr == nil {
-		t.Fatal("count==501 should shed")
+		t.Fatal("count==500 should shed")
 	}
 	if rpcErr.Code != types.RpcTOO_BUSY || rpcErr.ErrorString != "tooBusy" {
 		t.Errorf("got code=%d errorString=%q, want %d/%q", rpcErr.Code, rpcErr.ErrorString, types.RpcTOO_BUSY, "tooBusy")

--- a/internal/rpc/handlers/loadkinds.go
+++ b/internal/rpc/handlers/loadkinds.go
@@ -1,34 +1,18 @@
 package handlers
 
-import "github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
+import (
+	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
 
-// LoadKind overrides per method. Handlers that don't declare one pay
-// loadtrack.LoadReference (rippled feeReferenceRPC parity). Costs are
-// taken from rippled's Resource::Fees catalogue: medium = 400, heavy =
-// 3000 (Resource/Fees.cpp).
-//
-// Heavy: anything that walks the full state map (book_offers,
-// ledger_data, noripple_check) or runs pathfinding (ripple_path_find,
-// path_find). account_tx scans the transaction history table.
-//
-// Medium: per-account ledger reads with a configurable limit. They do
-// work proportional to account size; not as costly as pathfinding but
-// noticeably more than a ping.
+func setLoadReference(ctx *types.RpcContext) {
+	ctx.LoadCost = uint32(loadtrack.LoadReference)
+}
 
-func (PathFindMethod) LoadKind() loadtrack.LoadKind       { return loadtrack.LoadHeavy }
-func (RipplePathFindMethod) LoadKind() loadtrack.LoadKind { return loadtrack.LoadHeavy }
-func (LedgerDataMethod) LoadKind() loadtrack.LoadKind     { return loadtrack.LoadHeavy }
-func (BookOffersMethod) LoadKind() loadtrack.LoadKind     { return loadtrack.LoadHeavy }
-func (NoRippleCheckMethod) LoadKind() loadtrack.LoadKind  { return loadtrack.LoadHeavy }
-func (AccountTxMethod) LoadKind() loadtrack.LoadKind      { return loadtrack.LoadHeavy }
+func setLoadMedium(ctx *types.RpcContext) {
+	ctx.LoadCost = uint32(loadtrack.LoadMedium)
+}
 
-func (AccountLinesMethod) LoadKind() loadtrack.LoadKind      { return loadtrack.LoadMedium }
-func (AccountObjectsMethod) LoadKind() loadtrack.LoadKind    { return loadtrack.LoadMedium }
-func (AccountOffersMethod) LoadKind() loadtrack.LoadKind     { return loadtrack.LoadMedium }
-func (AccountChannelsMethod) LoadKind() loadtrack.LoadKind   { return loadtrack.LoadMedium }
-func (AccountNftsMethod) LoadKind() loadtrack.LoadKind       { return loadtrack.LoadMedium }
-func (GatewayBalancesMethod) LoadKind() loadtrack.LoadKind   { return loadtrack.LoadMedium }
-func (SubmitMethod) LoadKind() loadtrack.LoadKind            { return loadtrack.LoadMedium }
-func (SubmitMultisignedMethod) LoadKind() loadtrack.LoadKind { return loadtrack.LoadMedium }
-func (SignMethod) LoadKind() loadtrack.LoadKind              { return loadtrack.LoadMedium }
-func (SignForMethod) LoadKind() loadtrack.LoadKind           { return loadtrack.LoadMedium }
+func setLoadHeavy(ctx *types.RpcContext) {
+	ctx.LoadCost = uint32(loadtrack.LoadHeavy)
+}

--- a/internal/rpc/handlers/loadkinds_test.go
+++ b/internal/rpc/handlers/loadkinds_test.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+func TestLoadCostEarlyErrorTiming(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler types.MethodHandler
+		params  json.RawMessage
+		want    loadtrack.LoadKind
+	}{
+		{"sign", &SignMethod{}, json.RawMessage(`{}`), loadtrack.LoadHeavy},
+		{"sign_for", &SignForMethod{}, json.RawMessage(`{}`), loadtrack.LoadHeavy},
+		{"submit_multisigned", &SubmitMultisignedMethod{}, json.RawMessage(`{}`), loadtrack.LoadHeavy},
+		{"submit", &SubmitMethod{}, json.RawMessage(`{}`), loadtrack.LoadMedium},
+		{"simulate", &SimulateMethod{}, json.RawMessage(`{"binary":"invalid"}`), loadtrack.LoadMedium},
+		{"account_tx", &AccountTxMethod{}, json.RawMessage(`{}`), loadtrack.LoadReference},
+		{"gateway_balances", &GatewayBalancesMethod{}, json.RawMessage(`{}`), loadtrack.LoadReference},
+		{"account_lines", &AccountLinesMethod{}, json.RawMessage(`{}`), loadtrack.LoadReference},
+		{"account_objects", &AccountObjectsMethod{}, json.RawMessage(`{}`), loadtrack.LoadReference},
+		{"account_offers", &AccountOffersMethod{}, json.RawMessage(`{}`), loadtrack.LoadReference},
+		{"account_channels", &AccountChannelsMethod{}, json.RawMessage(`{}`), loadtrack.LoadReference},
+		{"account_nfts", &AccountNftsMethod{}, json.RawMessage(`{}`), loadtrack.LoadReference},
+		{"ledger_data", &LedgerDataMethod{}, json.RawMessage(`{}`), loadtrack.LoadReference},
+		{"noripple_check", &NoRippleCheckMethod{}, json.RawMessage(`{}`), loadtrack.LoadReference},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := &types.RpcContext{
+				Context:  context.Background(),
+				LoadCost: uint32(loadtrack.LoadReference),
+			}
+			_, rpcErr := test.handler.Handle(ctx, test.params)
+			if rpcErr == nil {
+				t.Fatal("expected request to fail before normal completion")
+			}
+			if got := loadtrack.LoadKind(ctx.LoadCost); got != test.want {
+				t.Fatalf("load cost = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRipplePathFindBusyAdmissionIsHeavy(t *testing.T) {
+	shedder := types.NewClientLoadShedder()
+	for range types.MaxPathfindClients + 1 {
+		shedder.Begin()
+	}
+	ctx := &types.RpcContext{
+		Context:  context.Background(),
+		LoadCost: uint32(loadtrack.LoadReference),
+		Services: &types.ServiceContainer{ClientLoad: shedder},
+	}
+
+	_, rpcErr := (&RipplePathFindMethod{}).Handle(ctx, json.RawMessage(`{}`))
+	if rpcErr == nil {
+		t.Fatal("expected busy path-find request to fail admission")
+	}
+	if got := loadtrack.LoadKind(ctx.LoadCost); got != loadtrack.LoadHeavy {
+		t.Fatalf("load cost = %d, want %d", got, loadtrack.LoadHeavy)
+	}
+}

--- a/internal/rpc/handlers/manifest.go
+++ b/internal/rpc/handlers/manifest.go
@@ -83,7 +83,7 @@ func (m *ManifestMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 
 	masterB58, err := addresscodec.EncodeNodePublicKey(master[:])
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("encode master key: %v", err))
+		return nil, rpcInternalError("manifest: master key encoding failed", err)
 	}
 
 	details := map[string]any{
@@ -93,7 +93,7 @@ func (m *ManifestMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	if ephOK {
 		ephB58, err := addresscodec.EncodeNodePublicKey(ephemeral[:])
 		if err != nil {
-			return nil, types.RpcErrorInternal(fmt.Sprintf("encode ephemeral key: %v", err))
+			return nil, rpcInternalError("manifest: ephemeral key encoding failed", err)
 		}
 		details["ephemeral_key"] = ephB58
 	}

--- a/internal/rpc/handlers/nft_buy_offers.go
+++ b/internal/rpc/handlers/nft_buy_offers.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
@@ -93,7 +92,7 @@ func handleNFTOffers(ctx *types.RpcContext, params json.RawMessage, fetch func(c
 		case errors.Is(err, svcerr.ErrInvalidMarker):
 			return nil, types.RpcErrorInvalidParams("Invalid marker")
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get NFT offers: %v", err))
+		return nil, rpcInternalError("nft_offers: ledger query failed", err)
 	}
 
 	return buildNFTOffersResponse(nftIDHex, result, limit), nil

--- a/internal/rpc/handlers/nft_buy_offers.go
+++ b/internal/rpc/handlers/nft_buy_offers.go
@@ -95,6 +95,7 @@ func handleNFTOffers(ctx *types.RpcContext, params json.RawMessage, fetch func(c
 		return nil, rpcInternalError("nft_offers: ledger query failed", err)
 	}
 
+	setLoadMedium(ctx)
 	return buildNFTOffersResponse(nftIDHex, result, limit), nil
 }
 

--- a/internal/rpc/handlers/noripple_check.go
+++ b/internal/rpc/handlers/noripple_check.go
@@ -85,7 +85,7 @@ func (m *NoRippleCheckMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		if errors.Is(err, svcerr.ErrLedgerNotFound) {
 			return nil, types.RpcErrorLgrNotFound("ledgerNotFound")
 		}
-		return nil, types.RpcErrorInternal(err.Error())
+		return nil, rpcInternalError("noripple_check: ledger query failed", err)
 	}
 
 	// Build response matching rippled's NoRippleCheck.cpp format

--- a/internal/rpc/handlers/peers.go
+++ b/internal/rpc/handlers/peers.go
@@ -66,7 +66,7 @@ func (m *PeerReservationsAddMethod) Handle(ctx *types.RpcContext, params json.Ra
 	if ctx.Services != nil && ctx.Services.PeerReservationAdd != nil {
 		prevDesc, replaced, err := ctx.Services.PeerReservationAdd(key, desc)
 		if err != nil {
-			return nil, types.RpcErrorInternal("Failed to persist peer reservation: " + err.Error())
+			return nil, rpcInternalError("peer_reservations_add: persisting reservation failed", err)
 		}
 		if replaced {
 			result["previous"] = reservationJSON(key, prevDesc)
@@ -100,7 +100,7 @@ func (m *PeerReservationsDelMethod) Handle(ctx *types.RpcContext, params json.Ra
 	if ctx.Services != nil && ctx.Services.PeerReservationDel != nil {
 		prevDesc, existed, err := ctx.Services.PeerReservationDel(key)
 		if err != nil {
-			return nil, types.RpcErrorInternal("Failed to persist peer reservation: " + err.Error())
+			return nil, rpcInternalError("peer_reservations_del: persisting reservation failed", err)
 		}
 		if existed {
 			result["previous"] = reservationJSON(key, prevDesc)

--- a/internal/rpc/handlers/random.go
+++ b/internal/rpc/handlers/random.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -18,7 +17,7 @@ func (m *RandomMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 	randomBytes := make([]byte, 32)
 	_, err := rand.Read(randomBytes)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to generate random data: %v", err))
+		return nil, rpcInternalError("random: random data generation failed", err)
 	}
 
 	response := map[string]any{

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -52,6 +52,7 @@ type pathAlternativeJSON struct {
 type RipplePathFindMethod struct{}
 
 func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+	setLoadHeavy(ctx)
 	release, rpcErr := AcquirePathfind(ctx)
 	if rpcErr != nil {
 		return nil, rpcErr
@@ -167,7 +168,7 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 	pr := pathfinder.NewPathRequest(srcAccount, dstAccount, dstAmount, sendMax, srcCurrencies, convertAll)
 	result := pr.Execute(view)
 	if result.SourceCurrencyOverflow {
-		return nil, types.RpcErrorInternal("Internal error.")
+		return nil, rpcInternalInvariantError("ripple_path_find: source currency limit exceeded")
 	}
 
 	response := ripplePathFindResponse{
@@ -220,11 +221,11 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 	// `result.data`, which no XRPL client understands.
 	encoded, mErr := json.Marshal(response)
 	if mErr != nil {
-		return nil, types.RpcErrorInternal("Internal error.")
+		return nil, rpcInternalError("ripple_path_find: response marshaling failed", mErr)
 	}
 	var flat map[string]any
 	if uErr := json.Unmarshal(encoded, &flat); uErr != nil {
-		return nil, types.RpcErrorInternal("Internal error.")
+		return nil, rpcInternalError("ripple_path_find: response normalization failed", uErr)
 	}
 	return flat, nil
 }

--- a/internal/rpc/handlers/sign.go
+++ b/internal/rpc/handlers/sign.go
@@ -12,6 +12,7 @@ import (
 type SignMethod struct{}
 
 func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+	setLoadHeavy(ctx)
 	var request struct {
 		TxJson     json.RawMessage `json:"tx_json"`
 		Secret     string          `json:"secret,omitempty"`

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -19,6 +19,7 @@ import (
 type SignForMethod struct{}
 
 func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+	setLoadHeavy(ctx)
 	var request struct {
 		Account    string          `json:"account"`
 		TxJson     json.RawMessage `json:"tx_json"`

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -110,13 +110,13 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 	// Encode for multisigning (adds the signer's account as suffix)
 	signingPayload, err := binarycodec.EncodeForMultisigning(txMapForSigning, request.Account)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode for multisigning: %v", err))
+		return nil, rpcInternalError("sign_for: multisigning payload encoding failed", err)
 	}
 
 	// Sign the payload
 	signature, err := signPayload(signingPayload, privateKey, keyType)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to sign transaction: %v", err))
+		return nil, rpcInternalError("sign_for: transaction signing failed", err)
 	}
 
 	newSigner := map[string]any{
@@ -146,7 +146,7 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 
 	txBlob, err := binarycodec.Encode(txMap)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode transaction: %v", err))
+		return nil, rpcInternalError("sign_for: transaction encoding failed", err)
 	}
 
 	txHash := CalculateTxHash(txBlob)

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -176,7 +176,7 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 	// Derive address from public key
 	address, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(publicKey)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to derive address: %v", err))
+		return nil, rpcInternalError("sign: account address derivation failed", err)
 	}
 
 	// Parse the transaction JSON
@@ -209,7 +209,7 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 			if errors.Is(err, svcerr.ErrAccountNotFound) {
 				return nil, types.RpcErrorSrcActNotFound("Source account not found.")
 			}
-			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to read source account: %v", err))
+			return nil, rpcInternalError("sign: source account lookup failed", err)
 		}
 
 		// Auto-fill Sequence from the open ledger / TxQ; a present
@@ -221,7 +221,7 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 				if errors.Is(err, svcerr.ErrAccountNotFound) {
 					return nil, types.RpcErrorSrcActNotFound("Source account not found.")
 				}
-				return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill sequence: %v", err))
+				return nil, rpcInternalError("sign: sequence autofill failed", err)
 			}
 			txMap["Sequence"] = seq
 		}
@@ -262,7 +262,7 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 				if errors.As(feeErr, &hfe) {
 					return nil, types.RpcErrorHighFee(hfe.Error())
 				}
-				return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill fee: %v", feeErr))
+				return nil, rpcInternalError("sign: fee autofill failed", feeErr)
 			}
 			txMap["Fee"] = formatUint64AsString(fee)
 		}
@@ -282,7 +282,7 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 
 	txBytes, err := json.Marshal(txMap)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to marshal transaction: %v", err))
+		return nil, rpcInternalError("sign: transaction marshaling failed", err)
 	}
 
 	transaction, err := tx.ParseJSON(txBytes)
@@ -295,14 +295,14 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 
 	signature, err := sign.SignTransaction(transaction, privateKey)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to sign transaction: %v", err))
+		return nil, rpcInternalError("sign: transaction signing failed", err)
 	}
 
 	txMap["TxnSignature"] = signature
 
 	txBlob, err := binarycodec.Encode(txMap)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode transaction: %v", err))
+		return nil, rpcInternalError("sign: transaction encoding failed", err)
 	}
 
 	txHash := CalculateTxHash(txBlob)

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -157,7 +157,7 @@ type signResult struct {
 func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, txJSON json.RawMessage, creds signCredentials, offline bool, unlimited bool, apiVersion int, rawParams json.RawMessage) (*signResult, *types.RpcError) {
 	// Check if ledger service is available (needed for auto-filling fields)
 	if !offline && (services == nil || services.Ledger == nil) {
-		return nil, types.RpcErrorInternal("Ledger service not available")
+		return nil, rpcInternalInvariantError("sign: ledger service unavailable")
 	}
 
 	// Parse credentials and derive keypair using the shared helper
@@ -254,7 +254,7 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 			}
 			probe, mErr := json.Marshal(txMap)
 			if mErr != nil {
-				return nil, types.RpcErrorInternal("Failed to marshal tx_json for fee autofill")
+				return nil, rpcInternalError("sign: fee probe marshaling failed", mErr)
 			}
 			fee, feeErr := services.Ledger.GetAutofillFee(probe, unlimited, feeOpts.Mult, feeOpts.Div)
 			if feeErr != nil {

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -117,7 +117,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 			if errors.As(feeErr, &hfe) {
 				return nil, types.RpcErrorHighFee(hfe.Error())
 			}
-			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill fee: %v", feeErr))
+			return nil, rpcInternalError("simulate: fee autofill failed", feeErr)
 		}
 		txJsonMap["Fee"] = strconv.FormatUint(fee, 10)
 	}
@@ -159,7 +159,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 			case errors.Is(seqErr, svcerr.ErrAccountNotFound):
 				return nil, types.RpcErrorSrcActNotFound("Source account not found.")
 			default:
-				return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to autofill sequence: %v", seqErr))
+				return nil, rpcInternalError("simulate: sequence autofill failed", seqErr)
 			}
 		}
 		txJsonMap["Sequence"] = seq
@@ -235,7 +235,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 
 	result, err := ctx.Services.Ledger.SimulateTransaction(txJSON)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Simulation failed: %v", err))
+		return nil, rpcInternalError("simulate: transaction simulation failed", err)
 	}
 
 	// rippled overrides the tesSUCCESS message for simulate (Simulate.cpp:258-262).

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -22,6 +22,7 @@ import (
 type SimulateMethod struct{}
 
 func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+	setLoadMedium(ctx)
 	var rawParams map[string]json.RawMessage
 	if params != nil {
 		if err := json.Unmarshal(params, &rawParams); err != nil {
@@ -59,7 +60,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	}
 
 	if ctx.Services == nil || ctx.Services.Ledger == nil {
-		return nil, types.RpcErrorInternal("Ledger service not available")
+		return nil, rpcInternalInvariantError("simulate: ledger service unavailable")
 	}
 
 	var txJsonMap map[string]any
@@ -106,7 +107,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	if _, hasFee := txJsonMap["Fee"]; !hasFee {
 		probe, marshalErr := json.Marshal(txJsonMap)
 		if marshalErr != nil {
-			return nil, types.RpcErrorInternal("Failed to marshal tx_json for fee autofill")
+			return nil, rpcInternalError("simulate: fee probe marshaling failed", marshalErr)
 		}
 		// rippled's simulate autofill uses the default fee_mult_max /
 		// fee_div_max (getCurrentNetworkFee default arguments).
@@ -215,7 +216,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	// Marshal tx_json for parse + service call.
 	txJSON, err := json.Marshal(txJsonMap)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to marshal tx_json")
+		return nil, rpcInternalError("simulate: transaction marshaling failed", err)
 	}
 
 	// STTx ctor parity — rippled Simulate.cpp:332-343. A parse failure or

--- a/internal/rpc/handlers/stop.go
+++ b/internal/rpc/handlers/stop.go
@@ -13,7 +13,7 @@ type StopMethod struct{ AdminHandler }
 
 func (m *StopMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	if ctx.Services == nil || ctx.Services.ShutdownFunc == nil {
-		return nil, types.RpcErrorInternal("Shutdown function not available")
+		return nil, rpcInternalInvariantError("stop: shutdown function unavailable")
 	}
 
 	// Trigger shutdown asynchronously so the response can be sent first

--- a/internal/rpc/handlers/stored_transaction_test.go
+++ b/internal/rpc/handlers/stored_transaction_test.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeTxBlobCanonicalizesJSONStoredObjects(t *testing.T) {
+	txJSON := map[string]any{
+		"TransactionType": "Payment",
+		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+		"Amount":          "1000000",
+		"Fee":             "10",
+		"Sequence":        1,
+		"SigningPubKey":   "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+		"TxnSignature":    "30440220143759437C04F7B61F012563AFE90D8DAFC46E86035E1D965A9CED282C97D4CE02204CFD241E86F17E011298FC1A39B63386C74306A5DE047E213B0F29EFA4571C2C",
+	}
+	meta := map[string]any{
+		"TransactionResult": "tesSUCCESS",
+		"TransactionIndex":  0,
+		"AffectedNodes": []any{map[string]any{
+			"CreatedNode": map[string]any{
+				"LedgerEntryType": "AccountRoot",
+				"LedgerIndex":     "1111111111111111111111111111111111111111111111111111111111111111",
+				"NewFields":       map[string]any{"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
+			},
+			"ModifiedNode": map[string]any{
+				"LedgerEntryType": "AccountRoot",
+				"LedgerIndex":     "2222222222222222222222222222222222222222222222222222222222222222",
+				"FinalFields":     map[string]any{},
+			},
+		}},
+	}
+	data, err := json.Marshal(map[string]any{"tx_json": txJSON, "meta": meta})
+	require.NoError(t, err)
+
+	stored, err := decodeTxBlob(data)
+	require.NoError(t, err)
+	require.IsType(t, uint32(0), stored.TxJSON["Sequence"])
+	nodes, ok := stored.Meta["AffectedNodes"].([]any)
+	require.True(t, ok)
+	require.Len(t, nodes, 2)
+	for _, rawNode := range nodes {
+		node, ok := rawNode.(map[string]any)
+		require.True(t, ok)
+		require.Len(t, node, 1)
+	}
+}

--- a/internal/rpc/handlers/stubs_admin.go
+++ b/internal/rpc/handlers/stubs_admin.go
@@ -161,7 +161,7 @@ func (m *CanDeleteMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	}
 	stored, err := store.SetCanDelete(seq)
 	if err != nil {
-		return nil, types.RpcErrorInternal("failed to persist can_delete: " + err.Error())
+		return nil, rpcInternalError("can_delete: persisting boundary failed", err)
 	}
 	return map[string]any{"can_delete": stored}, nil
 }

--- a/internal/rpc/handlers/stubs_admin.go
+++ b/internal/rpc/handlers/stubs_admin.go
@@ -30,7 +30,7 @@ type PrintMethod struct{ AdminHandler }
 
 func (m *PrintMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	if ctx.Services == nil || ctx.Services.Ledger == nil {
-		return nil, types.RpcErrorInternal("Ledger service not available")
+		return nil, rpcInternalInvariantError("print: ledger service unavailable")
 	}
 
 	out := map[string]any{}
@@ -275,7 +275,7 @@ func uptimeText(d time.Duration) string {
 
 func (m *GetCountsMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	if ctx.Services == nil || ctx.Services.Ledger == nil {
-		return nil, types.RpcErrorInternal("Ledger service not available")
+		return nil, rpcInternalInvariantError("get_counts: ledger service unavailable")
 	}
 
 	result := map[string]any{

--- a/internal/rpc/handlers/stubs_ledger.go
+++ b/internal/rpc/handlers/stubs_ledger.go
@@ -83,7 +83,7 @@ func (m *OwnerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 func ownerInfoSection(ctx *types.RpcContext, walker types.OwnerDirectoryReader, account, ledgerIndex string) (map[string]any, *types.RpcError) {
 	result, err := walker.GetOwnerInfo(ctx.Context, account, ledgerIndex)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get owner info: %v", err))
+		return nil, rpcInternalError("owner_info: ledger query failed", err)
 	}
 
 	section := make(map[string]any)

--- a/internal/rpc/handlers/stubs_ledger.go
+++ b/internal/rpc/handlers/stubs_ledger.go
@@ -58,7 +58,7 @@ func (m *OwnerInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	}
 	walker, ok := ctx.Services.Ledger.(types.OwnerDirectoryReader)
 	if !ok {
-		return nil, types.RpcErrorInternal("owner_info: ledger service cannot walk owner directories")
+		return nil, rpcInternalInvariantError("owner_info: ledger service cannot walk owner directories")
 	}
 
 	accepted, rpcErr := ownerInfoSection(ctx, walker, strIdent, "closed")

--- a/internal/rpc/handlers/stubs_network.go
+++ b/internal/rpc/handlers/stubs_network.go
@@ -111,7 +111,7 @@ func (m *ConnectMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 	// ip check (Connect.cpp:41), so connect in standalone reports notSynced
 	// regardless of the supplied params.
 	if ctx.Services == nil || ctx.Services.Ledger == nil {
-		return nil, types.RpcErrorInternal("Ledger service not available")
+		return nil, rpcInternalInvariantError("connect: ledger service unavailable")
 	}
 	if ctx.Services.Ledger.IsStandalone() {
 		return nil, types.NewRpcError(types.RpcNOT_SYNCED, "notSynced", "notSynced",

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -17,6 +17,7 @@ import (
 type SubmitMethod struct{}
 
 func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+	setLoadMedium(ctx)
 	var request struct {
 		TxBlob     string          `json:"tx_blob,omitempty"`
 		TxJson     json.RawMessage `json:"tx_json,omitempty"`
@@ -61,7 +62,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 		// Marshal back to JSON for submission
 		txJSON, err = json.Marshal(decoded)
 		if err != nil {
-			return nil, types.RpcErrorInternal("Failed to marshal decoded tx_blob")
+			return nil, rpcInternalError("submit: decoded transaction marshaling failed", err)
 		}
 	} else if hasSigningCreds {
 		// Sign-and-submit path: sign the transaction first, then submit the blob.
@@ -84,7 +85,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 		var err error
 		txJSON, err = json.Marshal(txJsonMap)
 		if err != nil {
-			return nil, types.RpcErrorInternal("Failed to marshal signed transaction")
+			return nil, rpcInternalError("submit: signed transaction marshaling failed", err)
 		}
 	} else {
 		// Submit using tx_json directly (no signing)
@@ -123,7 +124,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 		result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON, txBlobHex)
 	}
 	if submitErr != nil {
-		return nil, rpcInternalError("submit: transaction submission failed", submitErr)
+		return nil, rpcTransactionSubmissionError("submit: transaction submission failed", submitErr)
 	}
 	txHashStr := CalculateTxHash(txBlobHex)
 
@@ -140,6 +141,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 				Meta: map[string]any{
 					"TransactionResult": result.EngineResult,
 					"TransactionIndex":  0,
+					"AffectedNodes":     []any{},
 				},
 			}
 			storedData, mErr := json.Marshal(storedTx)

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -99,7 +99,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 	if txBlobHex == "" {
 		encoded, err := binarycodec.Encode(txJsonMap)
 		if err != nil {
-			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode tx_json: %v", err))
+			return nil, rpcInternalError("submit: transaction encoding failed", err)
 		}
 		txBlobHex = encoded
 	}
@@ -123,7 +123,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 		result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON, txBlobHex)
 	}
 	if submitErr != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to submit transaction: %v", submitErr))
+		return nil, rpcInternalError("submit: transaction submission failed", submitErr)
 	}
 	txHashStr := CalculateTxHash(txBlobHex)
 

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -97,7 +97,7 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		if errors.Is(err, svcerr.ErrAccountNotFound) {
 			return nil, types.RpcErrorSrcActNotFound("Source account not found.")
 		}
-		return nil, types.RpcErrorInternal("Failed to read source account: " + err.Error())
+		return nil, rpcInternalError("submit_multisigned: source account lookup failed", err)
 	}
 
 	// --- Post-serialization validation (rippled TransactionSign.cpp:1325-1391) ---
@@ -183,7 +183,7 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	// Encode the transaction to binary
 	txBlob, encErr := binarycodec.Encode(txMap)
 	if encErr != nil {
-		return nil, types.RpcErrorInternal("Failed to encode transaction: " + encErr.Error())
+		return nil, rpcInternalError("submit_multisigned: transaction encoding failed", encErr)
 	}
 
 	// Calculate transaction hash
@@ -192,7 +192,7 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	// Submit the transaction
 	txJSON, encErr := json.Marshal(txMap)
 	if encErr != nil {
-		return nil, types.RpcErrorInternal("Failed to marshal transaction: " + encErr.Error())
+		return nil, rpcInternalError("submit_multisigned: transaction marshaling failed", encErr)
 	}
 
 	// Route fail_hard submissions through the optional surface so they
@@ -212,7 +212,7 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON, txBlob)
 	}
 	if submitErr != nil {
-		return nil, types.RpcErrorInternal("Transaction submission failed: " + submitErr.Error())
+		return nil, rpcInternalError("submit_multisigned: transaction submission failed", submitErr)
 	}
 
 	txMap["hash"] = txHash

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -16,6 +16,7 @@ import (
 type SubmitMultisignedMethod struct{}
 
 func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+	setLoadHeavy(ctx)
 	var request struct {
 		TxJson   json.RawMessage `json:"tx_json"`
 		FailHard bool            `json:"fail_hard,omitempty"`
@@ -212,7 +213,7 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		result, submitErr = ctx.Services.Ledger.SubmitTransaction(txJSON, txBlob)
 	}
 	if submitErr != nil {
-		return nil, rpcInternalError("submit_multisigned: transaction submission failed", submitErr)
+		return nil, rpcTransactionSubmissionError("submit_multisigned: transaction submission failed", submitErr)
 	}
 
 	txMap["hash"] = txHash

--- a/internal/rpc/handlers/testdata/internal_error_audit/safe/fixture.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/safe/fixture.go
@@ -1,0 +1,26 @@
+package safe
+
+import rpctypes "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+const RpcINTERNAL = 72 + 1
+
+type RpcError struct {
+	Code    int
+	Message string
+}
+
+func NewRpcError(code int, message string) *RpcError {
+	return &RpcError{Code: code, Message: message}
+}
+
+func Build(message string) (*rpctypes.RpcError, *RpcError) {
+	_ = rpctypes.RpcErrorInternal()
+	_ = rpctypes.RpcErrorTransactionSubmission()
+	remote := rpctypes.NewRpcError(rpctypes.RpcINVALID_PARAMS, "invalidParams", "invalidParams", message)
+
+	constructor := NewRpcError
+	local := constructor(RpcINTERNAL, message)
+	local.Code = 73
+	local.Message = message
+	return remote, local
+}

--- a/internal/rpc/handlers/testdata/internal_error_audit/unsafe_address/fixture.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/unsafe_address/fixture.go
@@ -1,0 +1,10 @@
+package unsafe_address
+
+import rpctypes "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+func Mutate(message string) *rpctypes.RpcError {
+	rpcErr := rpctypes.RpcErrorInvalidParams(message)
+	field := &rpcErr.Code
+	*field = rpctypes.RpcINTERNAL
+	return rpcErr
+}

--- a/internal/rpc/handlers/testdata/internal_error_audit/unsafe_alias/fixture.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/unsafe_alias/fixture.go
@@ -1,0 +1,8 @@
+package unsafe_alias
+
+import rpctypes "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+func Build(message string) *rpctypes.RpcError {
+	constructor := rpctypes.NewRpcError
+	return constructor(rpctypes.RpcINTERNAL, "internal", "internal", message)
+}

--- a/internal/rpc/handlers/testdata/internal_error_audit/unsafe_composite/fixture.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/unsafe_composite/fixture.go
@@ -1,0 +1,14 @@
+package unsafe_composite
+
+import rpctypes "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+type rpcErrorAlias = rpctypes.RpcError
+
+func Build(message string) *rpcErrorAlias {
+	return &rpcErrorAlias{
+		Code:        72 + 1,
+		ErrorString: "internal",
+		Type:        "internal",
+		Message:     message,
+	}
+}

--- a/internal/rpc/handlers/testdata/internal_error_audit/unsafe_defined_type/fixture.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/unsafe_defined_type/fixture.go
@@ -1,0 +1,11 @@
+package unsafe_defined_type
+
+import "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+type shadow types.RpcError
+
+func InternalError(private string) *types.RpcError {
+	value := shadow{Code: types.RpcINTERNAL, Message: private}
+	rpcErr := types.RpcError(value)
+	return &rpcErr
+}

--- a/internal/rpc/handlers/testdata/internal_error_audit/unsafe_direct/fixture.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/unsafe_direct/fixture.go
@@ -1,0 +1,7 @@
+package unsafe_direct
+
+import rpctypes "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+func Build(message string) *rpctypes.RpcError {
+	return rpctypes.NewRpcError(72+1, "internal", "internal", message)
+}

--- a/internal/rpc/handlers/testdata/internal_error_audit/unsafe_dynamic_composite/fixture.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/unsafe_dynamic_composite/fixture.go
@@ -1,0 +1,12 @@
+package unsafe_dynamic_composite
+
+import rpctypes "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+func Build(code int, message string) *rpctypes.RpcError {
+	return &rpctypes.RpcError{
+		Code:        code,
+		ErrorString: "dynamic",
+		Type:        "dynamic",
+		Message:     message,
+	}
+}

--- a/internal/rpc/handlers/testdata/internal_error_audit/unsafe_indirect_mutation/bridge/bridge.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/unsafe_indirect_mutation/bridge/bridge.go
@@ -1,0 +1,7 @@
+package bridge
+
+import "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+func Error() *types.RpcError {
+	return types.RpcErrorInvalidParams("invalid")
+}

--- a/internal/rpc/handlers/testdata/internal_error_audit/unsafe_indirect_mutation/fixture.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/unsafe_indirect_mutation/fixture.go
@@ -1,0 +1,8 @@
+package unsafeindirectmutation
+
+import "github.com/LeJamon/go-xrpl/internal/rpc/handlers/testdata/internal_error_audit/unsafe_indirect_mutation/bridge"
+
+func mutate() {
+	err := bridge.Error()
+	err.Message = "private detail"
+}

--- a/internal/rpc/handlers/testdata/internal_error_audit/unsafe_mutation/fixture.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/unsafe_mutation/fixture.go
@@ -1,0 +1,12 @@
+package unsafe_mutation
+
+import rpctypes "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+type rpcErrorAlias = rpctypes.RpcError
+
+func Mutate(message string) *rpcErrorAlias {
+	rpcErr := rpctypes.RpcErrorInvalidParams(message)
+	rpcErr.Code = 72 + 1
+	rpcErr.Message = message
+	return rpcErr
+}

--- a/internal/rpc/handlers/testdata/internal_error_audit/unsafe_promoted_mutation/fixture.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/unsafe_promoted_mutation/fixture.go
@@ -1,0 +1,13 @@
+package unsafe_promoted_mutation
+
+import rpctypes "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+type wrappedError struct {
+	*rpctypes.RpcError
+}
+
+func Mutate(message string) *rpctypes.RpcError {
+	wrapper := wrappedError{RpcError: rpctypes.RpcErrorInvalidParams(message)}
+	wrapper.Message = message
+	return wrapper.RpcError
+}

--- a/internal/rpc/handlers/testdata/internal_error_audit/unsafe_range_mutation/fixture.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/unsafe_range_mutation/fixture.go
@@ -1,0 +1,10 @@
+package unsafe_range_mutation
+
+import rpctypes "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+func Mutate(message string) *rpctypes.RpcError {
+	rpcErr := rpctypes.RpcErrorInvalidParams(message)
+	for rpcErr.Code = range []int{rpctypes.RpcINTERNAL} {
+	}
+	return rpcErr
+}

--- a/internal/rpc/handlers/testdata/internal_error_audit/unsafe_reassignment/fixture.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/unsafe_reassignment/fixture.go
@@ -1,0 +1,13 @@
+package unsafe_reassignment
+
+import rpctypes "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+func safeConstructor(_ int, _, _, message string) *rpctypes.RpcError {
+	return rpctypes.RpcErrorInvalidParams(message)
+}
+
+func Build(message string) *rpctypes.RpcError {
+	constructor := safeConstructor
+	constructor = rpctypes.NewRpcError
+	return constructor(72+1, "internal", "internal", message)
+}

--- a/internal/rpc/handlers/testdata/internal_error_audit/unsafe_whole_value/fixture.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/unsafe_whole_value/fixture.go
@@ -1,0 +1,7 @@
+package unsafewholevalue
+
+import "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+func mutate(err *types.RpcError) {
+	*err = types.RpcError{Code: types.RpcINTERNAL, Message: "private detail"}
+}

--- a/internal/rpc/handlers/testdata/internal_error_audit/unsafe_wrapper/fixture.go
+++ b/internal/rpc/handlers/testdata/internal_error_audit/unsafe_wrapper/fixture.go
@@ -1,0 +1,12 @@
+package unsafe_wrapper
+
+import rpctypes "github.com/LeJamon/go-xrpl/internal/rpc/types"
+
+func wrap(code int, message string) *rpctypes.RpcError {
+	return rpctypes.NewRpcError(code, "internal", "internal", message)
+}
+
+func Build(message string) *rpctypes.RpcError {
+	constructor := wrap
+	return constructor(72+1, message)
+}

--- a/internal/rpc/handlers/transaction_entry.go
+++ b/internal/rpc/handlers/transaction_entry.go
@@ -65,9 +65,9 @@ func (m *TransactionEntryMethod) Handle(ctx *types.RpcContext, params json.RawMe
 	}
 
 	// Parse the stored transaction data (VL-encoded binary or JSON)
-	storedTx, err := decodeTxBlob(txInfo.TxData)
+	storedTx, err := decodeTxBlobForTransactionEntry(txInfo.TxData)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to parse transaction data")
+		return nil, rpcInternalError("transaction_entry: transaction decoding failed", err)
 	}
 
 	ledgerHash := txInfo.LedgerHash
@@ -85,11 +85,12 @@ func (m *TransactionEntryMethod) Handle(ctx *types.RpcContext, params json.RawMe
 		"tx_json": storedTx.TxJSON,
 	}
 
-	// Metadata key: "meta" for v2+, "metadata" for v1
-	if ctx.ApiVersion > 1 {
-		response["meta"] = storedTx.Meta
-	} else {
-		response["metadata"] = storedTx.Meta
+	if storedTx.Meta != nil {
+		if ctx.ApiVersion > 1 {
+			response["meta"] = storedTx.Meta
+		} else {
+			response["metadata"] = storedTx.Meta
+		}
 	}
 
 	if ctx.ApiVersion > 1 {

--- a/internal/rpc/handlers/transaction_entry.go
+++ b/internal/rpc/handlers/transaction_entry.go
@@ -76,11 +76,6 @@ func (m *TransactionEntryMethod) Handle(ctx *types.RpcContext, params json.RawMe
 		ledgerHash = fmt.Sprintf("%X", h)
 	}
 
-	// Inject DeliveredAmount for Payment transactions
-	if storedTx.Meta != nil {
-		InjectDeliveredAmount(storedTx.TxJSON, storedTx.Meta)
-	}
-
 	response := map[string]any{
 		"tx_json": storedTx.TxJSON,
 	}

--- a/internal/rpc/handlers/tx.go
+++ b/internal/rpc/handlers/tx.go
@@ -87,9 +87,9 @@ func (m *TxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *
 	if err != nil {
 		return nil, types.RpcErrorTxnNotFound("Transaction not found")
 	}
-	storedTx, err := decodeTxBlob(txInfo.TxData)
+	storedTx, err := decodeTxBlobForTx(txInfo.TxData)
 	if err != nil {
-		return nil, types.RpcErrorInternal("Failed to decode transaction data")
+		return nil, rpcDBDeserializationError("tx: transaction deserialization failed", err)
 	}
 
 	// Resolve close time from the containing ledger
@@ -259,23 +259,20 @@ func (m *TxMethod) lookupByCTID(ctx *types.RpcContext, ledgerSeq uint32, txIndex
 	closeTimeSec := ledger.CloseTime()
 	ledgerHashStr := fmt.Sprintf("%X", ledger.Hash())
 
-	storedTx, decodeErr := decodeTxBlob(foundData)
+	storedTx, decodeErr := decodeTxBlobForTx(foundData)
+	if decodeErr != nil {
+		return nil, rpcDBDeserializationError("tx: CTID transaction deserialization failed", decodeErr)
+	}
 
-	return m.ctidResponse(ctx, storedTx, decodeErr, foundData, hashStr, ledgerSeq, txIndex, closeTimeSec, validated, ledgerHashStr, binary), nil
+	return m.ctidResponse(ctx, storedTx, hashStr, ledgerSeq, txIndex, closeTimeSec, validated, ledgerHashStr, binary), nil
 }
 
-// ctidResponse shapes a CTID-lookup response by reusing buildResponse and then
-// applying the CTID-specific deltas: the root "ctid" (v1) / in-tx_json "ctid"
-// (v2) is grafted by buildResponse already; here we keep the root ledger fields
-// unconditionally present (a fetched closed ledger is always available even if
-// not yet validated), drop the v1 binary "inLedger"/"date" that the CTID format
-// omits, and preserve the raw-hex tx_blob fallback used when the stored blob
-// cannot be decoded.
+// ctidResponse shapes a CTID lookup by reusing buildResponse, then keeping the
+// containing ledger fields unconditionally present and removing v1 fields that
+// the CTID format omits.
 func (m *TxMethod) ctidResponse(
 	ctx *types.RpcContext,
 	storedTx StoredTransaction,
-	decodeErr error,
-	foundData []byte,
 	hashStr string,
 	ledgerSeq uint32,
 	txIndex uint16,
@@ -291,12 +288,8 @@ func (m *TxMethod) ctidResponse(
 		TxIndex:     uint32(txIndex),
 	}
 
-	tx := storedTx
-	if decodeErr != nil {
-		tx = StoredTransaction{}
-	}
 	networkID := uint16(ctx.Services.Ledger.GetServerInfo().NetworkID)
-	response := m.buildResponse(ctx, tx, txInfo, hashStr, closeTimeSec, binary)
+	response := m.buildResponse(ctx, storedTx, txInfo, hashStr, closeTimeSec, binary)
 
 	// The CTID format reports the containing ledger unconditionally, whereas
 	// buildResponseV2 gates these on validated. ledger_hash is always set by
@@ -309,23 +302,14 @@ func (m *TxMethod) ctidResponse(
 	}
 
 	if binary {
-		// buildResponseV1's "inLedger"/"date" and an empty Encode(nil) tx_blob
-		// have no CTID equivalent; on a decode failure CTID emits the raw blob.
+		// buildResponseV1's "inLedger" and "date" fields have no CTID
+		// equivalent.
 		delete(response, "inLedger")
 		delete(response, "date")
-		if decodeErr != nil {
-			response["tx_blob"] = strings.ToUpper(hex.EncodeToString(foundData))
-		}
 		return response
 	}
 
 	if ctx.ApiVersion > 1 {
-		if decodeErr != nil {
-			// On a decode failure the CTID format emits no tx_json at all,
-			// whereas buildResponseV2 always wraps one.
-			delete(response, "tx_json")
-			return response
-		}
 		if txJSON, ok := response["tx_json"].(map[string]any); ok {
 			// buildResponseV2 omits the ctid for ledger 0; the CTID lookup
 			// still reports it.

--- a/internal/rpc/handlers/tx.go
+++ b/internal/rpc/handlers/tx.go
@@ -267,9 +267,6 @@ func (m *TxMethod) lookupByCTID(ctx *types.RpcContext, ledgerSeq uint32, txIndex
 	return m.ctidResponse(ctx, storedTx, hashStr, ledgerSeq, txIndex, closeTimeSec, validated, ledgerHashStr, binary), nil
 }
 
-// ctidResponse shapes a CTID lookup by reusing buildResponse, then keeping the
-// containing ledger fields unconditionally present and removing v1 fields that
-// the CTID format omits.
 func (m *TxMethod) ctidResponse(
 	ctx *types.RpcContext,
 	storedTx StoredTransaction,

--- a/internal/rpc/handlers/tx_history.go
+++ b/internal/rpc/handlers/tx_history.go
@@ -24,6 +24,7 @@ func (m *TxHistoryMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	if err := RequireTxTables(ctx.Services); err != nil {
 		return nil, err
 	}
+	setLoadMedium(ctx)
 
 	if err := ParseParams(params, &request); err != nil {
 		return nil, err

--- a/internal/rpc/handlers/tx_history.go
+++ b/internal/rpc/handlers/tx_history.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
@@ -35,7 +34,7 @@ func (m *TxHistoryMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		if errors.Is(err, svcerr.ErrTxHistoryUnavailable) {
 			return nil, types.RpcErrorNotEnabled("")
 		}
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to get transaction history: %v", err))
+		return nil, rpcInternalError("tx_history: transaction query failed", err)
 	}
 
 	// Build transactions array with deserialized JSON

--- a/internal/rpc/handlers/validation_create.go
+++ b/internal/rpc/handlers/validation_create.go
@@ -47,34 +47,34 @@ func (m *ValidationCreateMethod) Handle(ctx *types.RpcContext, params json.RawMe
 	algo := secp256k1.SECP256K1()
 	privHex, pubHex, err := algo.DeriveKeypair(seed, true)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to derive validator keypair: %v", err))
+		return nil, rpcInternalError("validation_create: validator keypair derivation failed", err)
 	}
 
 	pubBytes, err := hex.DecodeString(pubHex)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to decode public key: %v", err))
+		return nil, rpcInternalError("validation_create: public key decoding failed", err)
 	}
 	validationPublicKey, err := addresscodec.EncodeNodePublicKey(pubBytes)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode validation public key: %v", err))
+		return nil, rpcInternalError("validation_create: validation public key encoding failed", err)
 	}
 
 	// DeriveKeypair returns the private key as "00"+64 hex; the NodePrivate
 	// token encodes the raw 32-byte key, so drop the leading "00".
 	privBytes, err := hex.DecodeString(privHex[2:])
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to decode private key: %v", err))
+		return nil, rpcInternalError("validation_create: private key decoding failed", err)
 	}
 	validationPrivateKey := addresscodec.Base58CheckEncode(privBytes, addresscodec.NodePrivateKeyPrefix)
 
 	encodedSeed, err := addresscodec.EncodeSeed(seed, algo)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode seed: %v", err))
+		return nil, rpcInternalError("validation_create: seed encoding failed", err)
 	}
 
 	validationKey, err := rfc1751.SeedToEnglish(seed)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode RFC-1751 key: %v", err))
+		return nil, rpcInternalError("validation_create: RFC-1751 key encoding failed", err)
 	}
 
 	return map[string]any{

--- a/internal/rpc/handlers/validator_info.go
+++ b/internal/rpc/handlers/validator_info.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 
 	"github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -49,7 +48,7 @@ func (m *ValidatorInfoMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (
 
 	masterB58, err := addresscodec.EncodeNodePublicKey(masterKey[:])
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("encode master key: %v", err))
+		return nil, rpcInternalError("validator_info: master key encoding failed", err)
 	}
 	resp := validatorInfoResponse{MasterKey: masterB58}
 
@@ -61,7 +60,7 @@ func (m *ValidatorInfoMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (
 	if masterKey != keyArr {
 		ephB58, err := addresscodec.EncodeNodePublicKey(keyArr[:])
 		if err != nil {
-			return nil, types.RpcErrorInternal(fmt.Sprintf("encode ephemeral key: %v", err))
+			return nil, rpcInternalError("validator_info: ephemeral key encoding failed", err)
 		}
 		resp.EphemeralKey = ephB58
 

--- a/internal/rpc/handlers/validator_info.go
+++ b/internal/rpc/handlers/validator_info.go
@@ -35,7 +35,7 @@ func (m *ValidatorInfoMethod) Handle(ctx *types.RpcContext, _ json.RawMessage) (
 
 	validationPK := ctx.Services.ValidatorPublicKey
 	if len(validationPK) != 33 {
-		return nil, types.RpcErrorInternal("validator public key has invalid length")
+		return nil, rpcInternalInvariantError("validator_info: validator public key has invalid length")
 	}
 
 	var keyArr [33]byte

--- a/internal/rpc/handlers/validator_info_test.go
+++ b/internal/rpc/handlers/validator_info_test.go
@@ -248,5 +248,5 @@ func TestValidatorInfo_InvalidPublicKeyLength(t *testing.T) {
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
 	assert.Equal(t, "internal", rpcErr.ErrorString)
-	assert.Contains(t, rpcErr.Message, "invalid length")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }

--- a/internal/rpc/handlers/vault_info.go
+++ b/internal/rpc/handlers/vault_info.go
@@ -79,7 +79,7 @@ func (m *VaultInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 
 	vaultDecoded, decodeErr := binarycodec.Decode(hex.EncodeToString(vaultEntry.Node))
 	if decodeErr != nil {
-		return nil, types.RpcErrorInternal("Failed to decode Vault: " + decodeErr.Error())
+		return nil, rpcInternalError("vault_info: vault decoding failed", decodeErr)
 	}
 
 	// Get the ShareMPTID to lookup the MPToken issuance

--- a/internal/rpc/handlers/wallet_propose.go
+++ b/internal/rpc/handlers/wallet_propose.go
@@ -105,7 +105,7 @@ func (m *WalletProposeMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		// Generate random seed
 		entropy = make([]byte, 16)
 		if _, err := rand.Read(entropy); err != nil {
-			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to generate random seed: %v", err))
+			return nil, rpcInternalError("wallet_propose: random seed generation failed", err)
 		}
 	}
 
@@ -118,21 +118,21 @@ func (m *WalletProposeMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		algo := ed25519.ED25519()
 		privateKey, publicKey, err = algo.DeriveKeypair(entropy, false)
 		if err != nil {
-			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to derive keypair: %v", err))
+			return nil, rpcInternalError("wallet_propose: ed25519 keypair derivation failed", err)
 		}
 		encodedSeed, err = addresscodec.EncodeSeed(entropy, algo)
 		if err != nil {
-			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode seed: %v", err))
+			return nil, rpcInternalError("wallet_propose: ed25519 seed encoding failed", err)
 		}
 	} else {
 		algo := secp256k1.SECP256K1()
 		privateKey, publicKey, err = algo.DeriveKeypair(entropy, false)
 		if err != nil {
-			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to derive keypair: %v", err))
+			return nil, rpcInternalError("wallet_propose: secp256k1 keypair derivation failed", err)
 		}
 		encodedSeed, err = addresscodec.EncodeSeed(entropy, algo)
 		if err != nil {
-			return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode seed: %v", err))
+			return nil, rpcInternalError("wallet_propose: secp256k1 seed encoding failed", err)
 		}
 	}
 	_ = privateKey // Private key is derived but not returned (security)
@@ -140,17 +140,17 @@ func (m *WalletProposeMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 	// Derive account address from public key
 	accountID, err := addresscodec.EncodeClassicAddressFromPublicKeyHex(publicKey)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to derive account address: %v", err))
+		return nil, rpcInternalError("wallet_propose: account address derivation failed", err)
 	}
 
 	// Encode public key in base58
 	pubKeyBytes, err := hex.DecodeString(publicKey)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to decode public key: %v", err))
+		return nil, rpcInternalError("wallet_propose: public key decoding failed", err)
 	}
 	encodedPublicKey, err := addresscodec.EncodeAccountPublicKey(pubKeyBytes)
 	if err != nil {
-		return nil, types.RpcErrorInternal(fmt.Sprintf("Failed to encode public key: %v", err))
+		return nil, rpcInternalError("wallet_propose: public key encoding failed", err)
 	}
 
 	// Encode seed as RFC-1751 human-readable words (master_key)

--- a/internal/rpc/json_proxy_regression_test.go
+++ b/internal/rpc/json_proxy_regression_test.go
@@ -1,0 +1,200 @@
+package rpc
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONProxyUsesSingleDispatchAccounting(t *testing.T) {
+	services := types.NewServiceContainer(nil)
+	server := NewServer(time.Second, services)
+	services.SetDispatcher(server)
+
+	for range types.MaxJobQueueClients - 1 {
+		services.ClientLoad.Begin()
+	}
+	t.Cleanup(func() {
+		for range types.MaxJobQueueClients - 1 {
+			services.ClientLoad.End()
+		}
+	})
+
+	var targetCalls int
+	server.registry.Register("json_proxy_target", &stubHandler{
+		handle: func(ctx *types.RpcContext, _ json.RawMessage) (any, *types.RpcError) {
+			targetCalls++
+			assert.Equal(t, types.MaxJobQueueClients, services.ClientLoad.InFlight())
+			ctx.LoadCost = loadtrack.ChargeHeavy
+			return map[string]any{"proxied": true}, nil
+		},
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(
+		`{"method":"json","params":[{"method":"json_proxy_target","params":[{}]}]}`,
+	))
+	request.RemoteAddr = transportRegressionClientIP + ":1234"
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, 1, targetCalls)
+	assert.Equal(t, int64(types.MaxJobQueueClients-1), services.ClientLoad.InFlight())
+	assert.Equal(t,
+		float64(loadtrack.ChargeHeavy/uint32(loadtrack.DecayWindow/time.Second)),
+		server.loadTracker.LocalBalance(transportRegressionClientIP),
+	)
+
+	envelope := decodeEnvelope(t, response.Body.Bytes())
+	result, ok := envelope["result"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, result["proxied"])
+	assert.Equal(t, "success", result["status"])
+}
+
+func TestHTTPStructuredIDRedactionAcrossDispatchShapes(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		secrets []string
+		result  func(*testing.T, []byte) map[string]any
+	}{
+		{
+			name:    "single",
+			body:    `{"method":"capture","params":[{"id":{"SeCrEt":"single-private"},"payload":"kept"}]}`,
+			secrets: []string{"single-private"},
+			result: func(t *testing.T, body []byte) map[string]any {
+				envelope := decodeEnvelope(t, body)
+				assertMaskedStructuredID(t, envelope["id"])
+				result, ok := envelope["result"].(map[string]any)
+				require.True(t, ok)
+				return result
+			},
+		},
+		{
+			name:    "batch",
+			body:    `{"method":"batch","params":[{"method":"capture","id":{"SeCrEt":"batch-private"},"payload":"kept"}]}`,
+			secrets: []string{"batch-private"},
+			result: func(t *testing.T, body []byte) map[string]any {
+				var envelopes []map[string]any
+				require.NoError(t, json.Unmarshal(body, &envelopes))
+				require.Len(t, envelopes, 1)
+				assertMaskedStructuredID(t, envelopes[0]["id"])
+				result, ok := envelopes[0]["result"].(map[string]any)
+				require.True(t, ok)
+				return result
+			},
+		},
+		{
+			name: "nested json",
+			body: `{"method":"json","params":[{"id":{"SeCrEt":"outer-private"},"method":"capture","params":[{"id":{"SeCrEt":"inner-private"},"payload":"kept"}]}]}`,
+			secrets: []string{
+				"outer-private",
+				"inner-private",
+			},
+			result: func(t *testing.T, body []byte) map[string]any {
+				envelope := decodeEnvelope(t, body)
+				assertMaskedStructuredID(t, envelope["id"])
+				result, ok := envelope["result"].(map[string]any)
+				require.True(t, ok)
+				return result
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			services := types.NewServiceContainer(nil)
+			server := NewServer(time.Second, services)
+			services.SetDispatcher(server)
+			server.registry.Register("capture", &stubHandler{
+				handle: func(_ *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+					var received map[string]any
+					require.NoError(t, json.Unmarshal(params, &received))
+					assertMaskedStructuredID(t, received["id"])
+					return map[string]any{"received": received}, nil
+				},
+			})
+
+			response := postTransportRegressionRequest(t, server, test.body)
+			require.Equal(t, http.StatusOK, response.Code)
+			for _, secret := range test.secrets {
+				assert.NotContains(t, response.Body.String(), secret)
+			}
+
+			result := test.result(t, response.Body.Bytes())
+			received, ok := result["received"].(map[string]any)
+			require.True(t, ok)
+			assertMaskedStructuredID(t, received["id"])
+			assert.Equal(t, "kept", received["payload"])
+		})
+	}
+}
+
+func TestURLUserinfoIsRedactedAcrossTransportEchoes(t *testing.T) {
+	const maskedURL = `"url":"<masked>"`
+
+	fail := &stubHandler{
+		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+		},
+	}
+	httpServer := NewServer(time.Second, types.NewServiceContainer(nil))
+	httpServer.registry.Register("userinfo_fail", fail)
+
+	urls := []struct {
+		name  string
+		value string
+	}{
+		{name: "valid", value: "https://alice:private-password@example.com/events"},
+		{name: "malformed path", value: "https://alice:private-password@example.com/%zz"},
+	}
+	for _, testURL := range urls {
+		t.Run(testURL.name, func(t *testing.T) {
+			requests := []struct {
+				name string
+				body string
+			}{
+				{name: "HTTP single", body: `{"method":"userinfo_fail","params":[{"url":"` + testURL.value + `"}]}`},
+				{name: "HTTP batch", body: `{"method":"batch","params":[{"method":"userinfo_fail","url":"` + testURL.value + `"}]}`},
+			}
+			for _, request := range requests {
+				t.Run(request.name, func(t *testing.T) {
+					response := postTransportRegressionRequest(t, httpServer, request.body)
+					require.Equal(t, http.StatusOK, response.Code)
+					assert.NotContains(t, response.Body.String(), testURL.value)
+					assert.NotContains(t, response.Body.String(), "alice")
+					assert.NotContains(t, response.Body.String(), "private-password")
+					assert.Contains(t, response.Body.String(), maskedURL)
+				})
+			}
+
+			t.Run("WebSocket", func(t *testing.T) {
+				server := NewWebSocketServer(time.Second, nil)
+				server.methodRegistry.Register("userinfo_fail", fail)
+				body := wsRawRoundTrip(t, server,
+					`{"command":"userinfo_fail","url":"`+testURL.value+`"}`,
+				)
+				assert.NotContains(t, string(body), testURL.value)
+				assert.NotContains(t, string(body), "alice")
+				assert.NotContains(t, string(body), "private-password")
+				assert.Contains(t, string(body), maskedURL)
+			})
+		})
+	}
+}
+
+func assertMaskedStructuredID(t *testing.T, value any) {
+	t.Helper()
+	id, ok := value.(map[string]any)
+	require.True(t, ok, "id is not an object: %v", value)
+	assert.Equal(t, map[string]any{"SeCrEt": maskedValue}, id)
+}

--- a/internal/rpc/json_proxy_regression_test.go
+++ b/internal/rpc/json_proxy_regression_test.go
@@ -53,9 +53,7 @@ func TestJSONProxyUsesSingleDispatchAccounting(t *testing.T) {
 		server.loadTracker.LocalBalance(transportRegressionClientIP),
 	)
 
-	envelope := decodeEnvelope(t, response.Body.Bytes())
-	result, ok := envelope["result"].(map[string]any)
-	require.True(t, ok)
+	result := decodeEnvelope(t, response.Body.Bytes())
 	assert.Equal(t, true, result["proxied"])
 	assert.Equal(t, "success", result["status"])
 }
@@ -72,7 +70,8 @@ func TestHTTPStructuredIDRedactionAcrossDispatchShapes(t *testing.T) {
 			body:    `{"method":"capture","params":[{"id":{"SeCrEt":"single-private"},"payload":"kept"}]}`,
 			secrets: []string{"single-private"},
 			result: func(t *testing.T, body []byte) map[string]any {
-				envelope := decodeEnvelope(t, body)
+				var envelope map[string]any
+				require.NoError(t, json.Unmarshal(body, &envelope))
 				assertMaskedStructuredID(t, envelope["id"])
 				result, ok := envelope["result"].(map[string]any)
 				require.True(t, ok)
@@ -101,7 +100,8 @@ func TestHTTPStructuredIDRedactionAcrossDispatchShapes(t *testing.T) {
 				"inner-private",
 			},
 			result: func(t *testing.T, body []byte) map[string]any {
-				envelope := decodeEnvelope(t, body)
+				var envelope map[string]any
+				require.NoError(t, json.Unmarshal(body, &envelope))
 				assertMaskedStructuredID(t, envelope["id"])
 				result, ok := envelope["result"].(map[string]any)
 				require.True(t, ok)

--- a/internal/rpc/json_proxy_regression_test.go
+++ b/internal/rpc/json_proxy_regression_test.go
@@ -47,7 +47,7 @@ func TestJSONProxyUsesSingleDispatchAccounting(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, response.Code)
 	require.Equal(t, 1, targetCalls)
-	assert.Equal(t, int64(types.MaxJobQueueClients-1), services.ClientLoad.InFlight())
+	assert.Equal(t, types.MaxJobQueueClients-1, services.ClientLoad.InFlight())
 	assert.Equal(t,
 		float64(loadtrack.ChargeHeavy/uint32(loadtrack.DecayWindow/time.Second)),
 		server.loadTracker.LocalBalance(transportRegressionClientIP),

--- a/internal/rpc/ledger_closed_test.go
+++ b/internal/rpc/ledger_closed_test.go
@@ -163,7 +163,7 @@ func TestLedgerClosedServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 
 	t.Run("Nil ledger in services", func(t *testing.T) {
@@ -178,7 +178,7 @@ func TestLedgerClosedServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 
 	t.Run("Closed ledger index is zero", func(t *testing.T) {

--- a/internal/rpc/ledger_data_test.go
+++ b/internal/rpc/ledger_data_test.go
@@ -506,7 +506,7 @@ func TestLedgerDataServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 
 	t.Run("Nil ledger in services", func(t *testing.T) {
@@ -521,7 +521,7 @@ func TestLedgerDataServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 
 	t.Run("Service returns error", func(t *testing.T) {

--- a/internal/rpc/ledger_entry_test.go
+++ b/internal/rpc/ledger_entry_test.go
@@ -980,7 +980,7 @@ func TestLedgerEntryServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 
 	t.Run("Services.Ledger is nil", func(t *testing.T) {
@@ -1002,7 +1002,7 @@ func TestLedgerEntryServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 }
 

--- a/internal/rpc/ledger_owner_funds_test.go
+++ b/internal/rpc/ledger_owner_funds_test.go
@@ -100,8 +100,9 @@ func TestLedgerOwnerFunds(t *testing.T) {
 			"issuer":   "rrrrrrrrrrrrrrrrrrrrBZbvji",
 			"value":    "100",
 		},
-		"Sequence": 1,
-		"Fee":      "10",
+		"Sequence":      1,
+		"Fee":           "10",
+		"SigningPubKey": "",
 	}
 	stored := map[string]any{"tx_json": offerCreate}
 	storedJSON, err := json.Marshal(stored)

--- a/internal/rpc/ledger_test.go
+++ b/internal/rpc/ledger_test.go
@@ -196,7 +196,7 @@ func TestLedgerBasicRequest(t *testing.T) {
 			resp := resultToMap(t, result)
 			assert.NotContains(t, resp, "closed")
 			assert.NotContains(t, resp, "open")
-			assert.Equal(t, uint32(3), resp["ledger_current_index"])
+			assert.Equal(t, float64(3), resp["ledger_current_index"])
 		})
 	}
 
@@ -228,7 +228,7 @@ func TestLedgerBasicRequest(t *testing.T) {
 			require.Nil(t, rpcErr)
 			ledgerIndex := any("3")
 			if apiVersion > 1 {
-				ledgerIndex = uint32(3)
+				ledgerIndex = float64(3)
 			}
 			assert.Equal(t, map[string]any{
 				"ledger": map[string]any{
@@ -236,7 +236,7 @@ func TestLedgerBasicRequest(t *testing.T) {
 					"ledger_index": ledgerIndex,
 					"closed":       false,
 				},
-				"ledger_current_index": uint32(3),
+				"ledger_current_index": float64(3),
 				"validated":            false,
 			}, resultToMap(t, result))
 		}
@@ -248,7 +248,7 @@ func TestLedgerBasicRequest(t *testing.T) {
 		require.Nil(t, rpcErr)
 		assert.Equal(t, map[string]any{
 			"ledger":               map[string]any{"closed": false},
-			"ledger_current_index": uint32(3),
+			"ledger_current_index": float64(3),
 			"validated":            false,
 		}, resultToMap(t, result))
 
@@ -260,7 +260,7 @@ func TestLedgerBasicRequest(t *testing.T) {
 				"ledger_data": expectedLedgerHeaderHex(reader),
 			},
 			"ledger_hash":  handlers.FormatLedgerHash(reader.Hash()),
-			"ledger_index": uint32(2),
+			"ledger_index": float64(2),
 			"validated":    true,
 		}, resultToMap(t, result))
 	})
@@ -275,20 +275,20 @@ func TestLedgerBasicRequest(t *testing.T) {
 			"ledger": map[string]any{
 				"accountState":          []any{},
 				"account_hash":          handlers.FormatLedgerHash(currentReader.StateMapHash()),
-				"close_flags":           currentReader.CloseFlags(),
-				"close_time":            currentReader.CloseTime(),
+				"close_flags":           float64(currentReader.CloseFlags()),
+				"close_time":            float64(currentReader.CloseTime()),
 				"close_time_human":      closeTime.Format("2006-Jan-02 15:04:05.000000000 UTC"),
 				"close_time_iso":        closeTime.Format(time.RFC3339),
-				"close_time_resolution": currentReader.CloseTimeResolution(),
+				"close_time_resolution": float64(currentReader.CloseTimeResolution()),
 				"ledger_hash":           handlers.FormatLedgerHash(currentReader.Hash()),
 				"ledger_index":          "3",
-				"parent_close_time":     currentReader.ParentCloseTime(),
+				"parent_close_time":     float64(currentReader.ParentCloseTime()),
 				"parent_hash":           handlers.FormatLedgerHash(currentReader.ParentHash()),
 				"total_coins":           "99999999999999980",
 				"transaction_hash":      handlers.FormatLedgerHash(currentReader.TxMapHash()),
 				"transactions":          []any{},
 			},
-			"ledger_current_index": uint32(3),
+			"ledger_current_index": float64(3),
 			"validated":            false,
 		}, resultToMap(t, result))
 		ctx.Role = types.RoleGuest
@@ -298,9 +298,11 @@ func TestLedgerBasicRequest(t *testing.T) {
 	t.Run("Deprecated type field emits warning", func(t *testing.T) {
 		result, rpcErr := method.Handle(ctx, json.RawMessage(`{"type":"ledger"}`))
 		require.Nil(t, rpcErr)
-		warnings := resultToMap(t, result)["warnings"].([]map[string]any)
+		warnings := resultToMap(t, result)["warnings"].([]any)
 		require.Len(t, warnings, 1)
-		assert.Equal(t, 2004, warnings[0]["id"])
+		warning, ok := warnings[0].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, float64(2004), warning["id"])
 	})
 
 	t.Run("Numeric ledger_index", func(t *testing.T) {
@@ -714,21 +716,21 @@ func TestLedgerResponseStructure(t *testing.T) {
 	assert.Equal(t, map[string]any{
 		"ledger": map[string]any{
 			"account_hash":          handlers.FormatLedgerHash(reader.StateMapHash()),
-			"close_flags":           reader.CloseFlags(),
-			"close_time":            reader.CloseTime(),
+			"close_flags":           float64(reader.CloseFlags()),
+			"close_time":            float64(reader.CloseTime()),
 			"close_time_human":      closeTime.Format("2006-Jan-02 15:04:05.000000000 UTC"),
 			"close_time_iso":        closeTime.Format(time.RFC3339),
-			"close_time_resolution": reader.CloseTimeResolution(),
+			"close_time_resolution": float64(reader.CloseTimeResolution()),
 			"closed":                true,
 			"ledger_hash":           handlers.FormatLedgerHash(reader.Hash()),
 			"ledger_index":          "2",
-			"parent_close_time":     reader.ParentCloseTime(),
+			"parent_close_time":     float64(reader.ParentCloseTime()),
 			"parent_hash":           handlers.FormatLedgerHash(reader.ParentHash()),
 			"total_coins":           "99999999999999980",
 			"transaction_hash":      handlers.FormatLedgerHash(reader.TxMapHash()),
 		},
 		"ledger_hash":  handlers.FormatLedgerHash(reader.Hash()),
-		"ledger_index": uint32(2),
+		"ledger_index": float64(2),
 		"validated":    true,
 	}, resultToMap(t, result))
 }

--- a/internal/rpc/ledger_test.go
+++ b/internal/rpc/ledger_test.go
@@ -2,10 +2,13 @@ package rpc
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -109,6 +112,22 @@ func newDefaultLedgerReader(seq uint32, validated bool) *mockLedgerReader {
 	}
 }
 
+func expectedLedgerHeaderHex(l *mockLedgerReader) string {
+	data := make([]byte, 0, 118)
+	data = binary.BigEndian.AppendUint32(data, l.Sequence())
+	data = binary.BigEndian.AppendUint64(data, l.TotalDrops())
+	parentHash := l.ParentHash()
+	txHash := l.TxMapHash()
+	stateHash := l.StateMapHash()
+	data = append(data, parentHash[:]...)
+	data = append(data, txHash[:]...)
+	data = append(data, stateHash[:]...)
+	data = binary.BigEndian.AppendUint32(data, uint32(l.ParentCloseTime()))
+	data = binary.BigEndian.AppendUint32(data, uint32(l.CloseTime()))
+	data = append(data, byte(l.CloseTimeResolution()), l.CloseFlags())
+	return strings.ToUpper(hex.EncodeToString(data))
+}
+
 // TestLedgerBasicRequest tests basic ledger request with default params
 // Based on rippled LedgerRPC_test.cpp testLedgerRequest()
 func TestLedgerBasicRequest(t *testing.T) {
@@ -136,19 +155,152 @@ func TestLedgerBasicRequest(t *testing.T) {
 		Services:   services,
 	}
 
-	t.Run("Default params returns current ledger", func(t *testing.T) {
+	t.Run("Default params returns closed and open summaries", func(t *testing.T) {
 		result, rpcErr := method.Handle(ctx, nil)
 		require.Nil(t, rpcErr, "Expected no error, got: %v", rpcErr)
 		require.NotNil(t, result)
 
 		resp := resultToMap(t, result)
-		assert.Contains(t, resp, "ledger")
-		assert.Contains(t, resp, "ledger_hash")
-		assert.Contains(t, resp, "ledger_index")
-		assert.Contains(t, resp, "validated")
-		// rippled defaults to the current (open) ledger when no ledger is
-		// specified (RPCHelpers.cpp:388-389), so validated is false.
-		assert.Equal(t, false, resp["validated"])
+		closed := resp["closed"].(map[string]any)
+		open := resp["open"].(map[string]any)
+		assert.Equal(t, true, closed["closed"])
+		assert.Equal(t, "2", closed["ledger_index"])
+		assert.Contains(t, closed, "ledger_hash")
+		assert.Equal(t, map[string]any{
+			"parent_hash":  handlers.FormatLedgerHash(currentReader.ParentHash()),
+			"ledger_index": "3",
+			"closed":       false,
+		}, open)
+	})
+
+	t.Run("Default params ignore dump flags", func(t *testing.T) {
+		result, rpcErr := method.Handle(ctx, json.RawMessage(`{"full":true,"accounts":true,"transactions":true}`))
+		require.Nil(t, rpcErr)
+		resp := resultToMap(t, result)
+		assert.Contains(t, resp, "closed")
+		assert.Contains(t, resp, "open")
+		assert.NotContains(t, resp, "ledger")
+	})
+
+	for _, params := range []string{
+		`{"ledger_index":""}`,
+		`{"ledger_index":null}`,
+		`{"ledger_hash":""}`,
+		`{"ledger_hash":null}`,
+		`{"ledger":""}`,
+		`{"ledger":null}`,
+	} {
+		t.Run("Present empty selector "+params, func(t *testing.T) {
+			result, rpcErr := method.Handle(ctx, json.RawMessage(params))
+			require.Nil(t, rpcErr)
+			resp := resultToMap(t, result)
+			assert.NotContains(t, resp, "closed")
+			assert.NotContains(t, resp, "open")
+			assert.Equal(t, uint32(3), resp["ledger_current_index"])
+		})
+	}
+
+	t.Run("Present empty selector does not bypass dump permission", func(t *testing.T) {
+		_, rpcErr := method.Handle(ctx, json.RawMessage(`{"ledger_index":"","full":true}`))
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcNO_PERMISSION, rpcErr.Code)
+	})
+
+	t.Run("Malformed selector precedes dump permission", func(t *testing.T) {
+		_, rpcErr := method.Handle(ctx, json.RawMessage(`{"ledger_hash":"DEADBEEF","full":true}`))
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	})
+
+	t.Run("Queue requires open ledger", func(t *testing.T) {
+		_, rpcErr := method.Handle(ctx, json.RawMessage(`{"ledger_index":"validated","queue":true}`))
+		require.NotNil(t, rpcErr)
+		assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+
+		_, rpcErr = method.Handle(ctx, json.RawMessage(`{"ledger_index":"current","queue":true}`))
+		require.Nil(t, rpcErr)
+	})
+
+	t.Run("Selected current response shape", func(t *testing.T) {
+		for _, apiVersion := range []int{types.ApiVersion1, types.ApiVersion2} {
+			ctx.ApiVersion = apiVersion
+			result, rpcErr := method.Handle(ctx, json.RawMessage(`{"ledger_index":"current"}`))
+			require.Nil(t, rpcErr)
+			ledgerIndex := any("3")
+			if apiVersion > 1 {
+				ledgerIndex = uint32(3)
+			}
+			assert.Equal(t, map[string]any{
+				"ledger": map[string]any{
+					"parent_hash":  handlers.FormatLedgerHash(currentReader.ParentHash()),
+					"ledger_index": ledgerIndex,
+					"closed":       false,
+				},
+				"ledger_current_index": uint32(3),
+				"validated":            false,
+			}, resultToMap(t, result))
+		}
+		ctx.ApiVersion = types.ApiVersion1
+	})
+
+	t.Run("Selected binary response shape", func(t *testing.T) {
+		result, rpcErr := method.Handle(ctx, json.RawMessage(`{"ledger_index":"current","binary":true}`))
+		require.Nil(t, rpcErr)
+		assert.Equal(t, map[string]any{
+			"ledger":               map[string]any{"closed": false},
+			"ledger_current_index": uint32(3),
+			"validated":            false,
+		}, resultToMap(t, result))
+
+		result, rpcErr = method.Handle(ctx, json.RawMessage(`{"ledger_index":"validated","binary":true}`))
+		require.Nil(t, rpcErr)
+		assert.Equal(t, map[string]any{
+			"ledger": map[string]any{
+				"closed":      true,
+				"ledger_data": expectedLedgerHeaderHex(reader),
+			},
+			"ledger_hash":  handlers.FormatLedgerHash(reader.Hash()),
+			"ledger_index": uint32(2),
+			"validated":    true,
+		}, resultToMap(t, result))
+	})
+
+	t.Run("Open full response omits closed", func(t *testing.T) {
+		ctx.Role = types.RoleAdmin
+		ctx.Unlimited = true
+		result, rpcErr := method.Handle(ctx, json.RawMessage(`{"ledger_index":"current","full":true}`))
+		require.Nil(t, rpcErr)
+		closeTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(currentReader.CloseTime()) * time.Second)
+		assert.Equal(t, map[string]any{
+			"ledger": map[string]any{
+				"accountState":          []any{},
+				"account_hash":          handlers.FormatLedgerHash(currentReader.StateMapHash()),
+				"close_flags":           currentReader.CloseFlags(),
+				"close_time":            currentReader.CloseTime(),
+				"close_time_human":      closeTime.Format("2006-Jan-02 15:04:05.000000000 UTC"),
+				"close_time_iso":        closeTime.Format(time.RFC3339),
+				"close_time_resolution": currentReader.CloseTimeResolution(),
+				"ledger_hash":           handlers.FormatLedgerHash(currentReader.Hash()),
+				"ledger_index":          "3",
+				"parent_close_time":     currentReader.ParentCloseTime(),
+				"parent_hash":           handlers.FormatLedgerHash(currentReader.ParentHash()),
+				"total_coins":           "99999999999999980",
+				"transaction_hash":      handlers.FormatLedgerHash(currentReader.TxMapHash()),
+				"transactions":          []any{},
+			},
+			"ledger_current_index": uint32(3),
+			"validated":            false,
+		}, resultToMap(t, result))
+		ctx.Role = types.RoleGuest
+		ctx.Unlimited = false
+	})
+
+	t.Run("Deprecated type field emits warning", func(t *testing.T) {
+		result, rpcErr := method.Handle(ctx, json.RawMessage(`{"type":"ledger"}`))
+		require.Nil(t, rpcErr)
+		warnings := resultToMap(t, result)["warnings"].([]map[string]any)
+		require.Len(t, warnings, 1)
+		assert.Equal(t, 2004, warnings[0]["id"])
 	})
 
 	t.Run("Numeric ledger_index", func(t *testing.T) {
@@ -558,51 +710,27 @@ func TestLedgerResponseStructure(t *testing.T) {
 	require.Nil(t, rpcErr)
 	require.NotNil(t, result)
 
-	resp := resultToMap(t, result)
-
-	// Top-level fields
-	assert.Contains(t, resp, "ledger")
-	assert.Contains(t, resp, "ledger_hash")
-	assert.Contains(t, resp, "ledger_index")
-	assert.Contains(t, resp, "validated")
-
-	// Ledger object fields
-	ledger := resp["ledger"].(map[string]any)
-	assert.Contains(t, ledger, "accepted")
-	assert.Contains(t, ledger, "account_hash")
-	assert.Contains(t, ledger, "close_flags")
-	assert.Contains(t, ledger, "close_time")
-	assert.Contains(t, ledger, "close_time_human")
-	assert.Contains(t, ledger, "close_time_iso")
-	assert.Contains(t, ledger, "close_time_resolution")
-	assert.Contains(t, ledger, "closed")
-	// rippled emits only "ledger_hash" on the inner ledger object
-	// (LedgerToJson.cpp:78). No top-level "hash" alias.
-	assert.NotContains(t, ledger, "hash")
-	assert.Contains(t, ledger, "ledger_hash")
-	assert.Contains(t, ledger, "ledger_index")
-	assert.Contains(t, ledger, "parent_close_time")
-	assert.Contains(t, ledger, "parent_hash")
-	assert.Contains(t, ledger, "seqNum")
-	assert.Contains(t, ledger, "totalCoins")
-	assert.Contains(t, ledger, "total_coins")
-	assert.Contains(t, ledger, "transaction_hash")
-
-	// ledger_hash should be 64-char uppercase hex
-	ledgerHash, ok := resp["ledger_hash"].(string)
-	assert.True(t, ok, "ledger_hash should be a string")
-	assert.Equal(t, 64, len(ledgerHash), "ledger_hash should be 64 characters")
-
-	// validated should be true for validated ledger
-	assert.Equal(t, true, resp["validated"])
-
-	// closed should be true for validated ledger
-	assert.Equal(t, true, ledger["closed"])
-
-	// ledger_index inside ledger should be string representation
-	ledgerIndex, ok := ledger["ledger_index"].(string)
-	assert.True(t, ok, "ledger.ledger_index should be a string")
-	assert.Equal(t, "2", ledgerIndex)
+	closeTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(reader.CloseTime()) * time.Second)
+	assert.Equal(t, map[string]any{
+		"ledger": map[string]any{
+			"account_hash":          handlers.FormatLedgerHash(reader.StateMapHash()),
+			"close_flags":           reader.CloseFlags(),
+			"close_time":            reader.CloseTime(),
+			"close_time_human":      closeTime.Format("2006-Jan-02 15:04:05.000000000 UTC"),
+			"close_time_iso":        closeTime.Format(time.RFC3339),
+			"close_time_resolution": reader.CloseTimeResolution(),
+			"closed":                true,
+			"ledger_hash":           handlers.FormatLedgerHash(reader.Hash()),
+			"ledger_index":          "2",
+			"parent_close_time":     reader.ParentCloseTime(),
+			"parent_hash":           handlers.FormatLedgerHash(reader.ParentHash()),
+			"total_coins":           "99999999999999980",
+			"transaction_hash":      handlers.FormatLedgerHash(reader.TxMapHash()),
+		},
+		"ledger_hash":  handlers.FormatLedgerHash(reader.Hash()),
+		"ledger_index": uint32(2),
+		"validated":    true,
+	}, resultToMap(t, result))
 }
 
 // TestLedgerServiceUnavailable tests behavior when ledger service is not available
@@ -621,7 +749,7 @@ func TestLedgerServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 
 	t.Run("Nil ledger in services", func(t *testing.T) {
@@ -636,7 +764,7 @@ func TestLedgerServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 }
 

--- a/internal/rpc/load_shed_http_test.go
+++ b/internal/rpc/load_shed_http_test.go
@@ -21,8 +21,7 @@ func TestNewServerWiresClientLoadShedder(t *testing.T) {
 	}
 }
 
-// 503 status mapping matches rippled ErrorCodes.cpp:114 (rpcTOO_BUSY row).
-func TestRpcTooBusyReturnsHTTP503(t *testing.T) {
+func TestRpcTooBusyUsesLegacyHTTP200(t *testing.T) {
 	services := types.NewServiceContainer(nil)
 	srv := NewServer(time.Second, services)
 	srv.registry.Register("book_offers", &handlers.BookOffersMethod{})
@@ -41,8 +40,8 @@ func TestRpcTooBusyReturnsHTTP503(t *testing.T) {
 
 	srv.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("expected HTTP 503, got %d\nbody: %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected HTTP 200, got %d\nbody: %s", rr.Code, rr.Body.String())
 	}
 
 	var env map[string]any

--- a/internal/rpc/loadtrack/consumer_test.go
+++ b/internal/rpc/loadtrack/consumer_test.go
@@ -102,7 +102,7 @@ func TestDisconnectConsumesDropFee(t *testing.T) {
 	if !tr.Disconnect(key) {
 		t.Fatal("expected repeated disconnect while still over threshold")
 	}
-	if got, want := tr.Balance(key), float64(DropThreshold+2*(ChargeDrop/uint32(decayWindowSeconds))); got != want {
+	if got, want := tr.Balance(key), float64(DropThreshold+(2*ChargeDrop)/uint32(decayWindowSeconds)); got != want {
 		t.Fatalf("balance after repeated disconnect = %v, want %v", got, want)
 	}
 }

--- a/internal/rpc/loadtrack/consumer_test.go
+++ b/internal/rpc/loadtrack/consumer_test.go
@@ -1,0 +1,183 @@
+package loadtrack
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWarnConsumesFeeOncePerClockInstant(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	tr := newWithClock(func() time.Time { return now })
+	const key = "198.51.100.7"
+	tr.Import("peer", Gossip{Items: []GossipItem{{Key: key, Balance: WarningThreshold}}})
+
+	if !tr.Warn(key) {
+		t.Fatal("expected the first warning at the threshold")
+	}
+	if got, want := tr.Balance(key), float64(WarningThreshold+ChargeWarning/uint32(decayWindowSeconds)); got != want {
+		t.Fatalf("balance after warning = %v, want %v", got, want)
+	}
+	if tr.Warn(key) {
+		t.Fatal("expected a second warning at the same clock instant to be suppressed")
+	}
+	if got, want := tr.Balance(key), float64(WarningThreshold+ChargeWarning/uint32(decayWindowSeconds)); got != want {
+		t.Fatalf("balance after suppressed warning = %v, want %v", got, want)
+	}
+
+	now = now.Add(time.Second)
+	before := tr.LocalBalance(key)
+	if !tr.Warn(key) {
+		t.Fatal("expected a warning at a new clock instant")
+	}
+	if got, want := tr.LocalBalance(key), before+float64(ChargeWarning/uint32(decayWindowSeconds)); got != want {
+		t.Fatalf("new-clock warning balance = %v, want %v", got, want)
+	}
+	if tr.Warn(key) {
+		t.Fatal("expected only one warning at the new clock instant")
+	}
+}
+
+func TestWarnConsumesFeeOncePerSecond(t *testing.T) {
+	base := time.Unix(1_000_000, 0)
+	now := base.Add(100 * time.Millisecond)
+	tr := newWithClock(func() time.Time { return now })
+	const key = "198.51.100.7"
+	tr.Import("peer", Gossip{Items: []GossipItem{{Key: key, Balance: WarningThreshold}}})
+
+	if !tr.Warn(key) {
+		t.Fatal("expected the first warning in the second")
+	}
+	now = base.Add(900 * time.Millisecond)
+	if tr.Warn(key) {
+		t.Fatal("expected a second warning in the same second to be suppressed")
+	}
+}
+
+func TestSubsecondOperationsDoNotPostponeDecay(t *testing.T) {
+	base := time.Unix(1_000_000, 0)
+	now := base.Add(100 * time.Millisecond)
+	tr := newWithClock(func() time.Time { return now })
+	const key = "198.51.100.7"
+	tr.Charge(key, LoadKind(3200))
+
+	now = base.Add(900 * time.Millisecond)
+	if got := tr.LocalBalance(key); got != 100 {
+		t.Fatalf("subsecond balance = %v, want 100", got)
+	}
+	now = base.Add(1100 * time.Millisecond)
+	if got := tr.LocalBalance(key); got != 96 {
+		t.Fatalf("one-second decayed balance = %v, want 96", got)
+	}
+}
+
+func TestWarnWhenChargeCrossesThreshold(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	tr := newWithClock(func() time.Time { return now })
+	const key = "198.51.100.7"
+
+	tr.Import("peer", Gossip{Items: []GossipItem{{Key: key, Balance: WarningThreshold - 1}}})
+	if got := tr.Charge(key, LoadKind(decayWindowSeconds)); got != OutcomeWarn {
+		t.Fatalf("threshold-crossing charge outcome = %v, want %v", got, OutcomeWarn)
+	}
+	if !tr.Warn(key) {
+		t.Fatal("expected warning after threshold crossing")
+	}
+	if got, want := tr.Balance(key), float64(WarningThreshold+ChargeWarning/uint32(decayWindowSeconds)); got != want {
+		t.Fatalf("balance after threshold warning = %v, want %v", got, want)
+	}
+}
+
+func TestDisconnectConsumesDropFee(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	tr := newWithClock(func() time.Time { return now })
+	const key = "198.51.100.7"
+	tr.Import("peer", Gossip{Items: []GossipItem{{Key: key, Balance: DropThreshold}}})
+
+	if !tr.Disconnect(key) {
+		t.Fatal("expected disconnect at drop threshold")
+	}
+	if got, want := tr.Balance(key), float64(DropThreshold+ChargeDrop/uint32(decayWindowSeconds)); got != want {
+		t.Fatalf("balance after disconnect = %v, want %v", got, want)
+	}
+	if !tr.Disconnect(key) {
+		t.Fatal("expected repeated disconnect while still over threshold")
+	}
+	if got, want := tr.Balance(key), float64(DropThreshold+2*(ChargeDrop/uint32(decayWindowSeconds))); got != want {
+		t.Fatalf("balance after repeated disconnect = %v, want %v", got, want)
+	}
+}
+
+func TestDisconnectRecoversAfterRemoteOnlyBalanceExpires(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	tr := newWithClock(func() time.Time { return now })
+	const key = "198.51.100.7"
+	tr.Import("peer", Gossip{Items: []GossipItem{{Key: key, Balance: DropThreshold}}})
+
+	if !tr.Disconnect(key) {
+		t.Fatal("expected imported balance to trigger disconnect")
+	}
+	now = now.Add(GossipExpiration)
+	if tr.Disconnect(key) {
+		t.Fatal("remote-only threshold did not recover after gossip expiry")
+	}
+	if got := tr.Balance(key); got >= DropThreshold {
+		t.Fatalf("post-expiry balance = %v, want below %d", got, DropThreshold)
+	}
+}
+
+func TestConsumerOperationsIgnoreEmptyKey(t *testing.T) {
+	tr := New()
+	if tr.Warn("") {
+		t.Fatal("empty key must not emit a warning")
+	}
+	if tr.Disconnect("") {
+		t.Fatal("empty key must not disconnect")
+	}
+	if got := tr.Balance(""); got != 0 {
+		t.Fatalf("empty-key balance = %v, want 0", got)
+	}
+}
+
+func TestRemoteOnlyThresholdExpiresOnReadPaths(t *testing.T) {
+	readers := []struct {
+		name string
+		read func(*Tracker, string)
+	}{
+		{name: "balance", read: func(tr *Tracker, key string) { tr.Balance(key) }},
+		{name: "local balance", read: func(tr *Tracker, key string) { tr.LocalBalance(key) }},
+		{name: "threshold", read: func(tr *Tracker, key string) { tr.OverDropThreshold(key) }},
+		{name: "warning", read: func(tr *Tracker, key string) { tr.Warn(key) }},
+		{name: "disconnect", read: func(tr *Tracker, key string) { tr.Disconnect(key) }},
+		{name: "export", read: func(tr *Tracker, _ string) { tr.Export() }},
+	}
+
+	for _, tc := range readers {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Unix(1_000_000, 0)
+			tr := newWithClock(func() time.Time { return now })
+			const key = "198.51.100.7"
+			tr.Import("peer", Gossip{Items: []GossipItem{
+				{Key: key, Balance: DropThreshold / 2},
+				{Key: key, Balance: DropThreshold / 2},
+			}})
+			if !tr.OverDropThreshold(key) {
+				t.Fatal("expected imported balance to reach drop threshold")
+			}
+
+			now = now.Add(GossipExpiration)
+			tc.read(tr, key)
+			if got := tr.entries[key].remoteBalance; got != 0 {
+				t.Fatalf("remote balance after expiry = %d, want 0", got)
+			}
+			if len(tr.imports) != 0 {
+				t.Fatalf("expired imports retained: %d", len(tr.imports))
+			}
+			if tr.OverDropThreshold(key) {
+				t.Fatal("remote-only consumer remained over drop threshold after expiry")
+			}
+			if got := tr.Balance(key); got != 0 {
+				t.Fatalf("balance after remote-only expiry = %v, want 0", got)
+			}
+		})
+	}
+}

--- a/internal/rpc/loadtrack/gossip_test.go
+++ b/internal/rpc/loadtrack/gossip_test.go
@@ -12,8 +12,9 @@ func TestGossip_ExportFiltersBelowMinimum(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	tr := newWithClock(func() time.Time { return now })
 
-	// chatty client: 1 heavy (3000) is above MinimumGossipBalance(1000)
-	tr.Charge("loud", LoadHeavy)
+	for range 11 {
+		tr.Charge("loud", LoadHeavy)
+	}
 	// quiet client: 1 reference (20) is below
 	tr.Charge("quiet", LoadReference)
 
@@ -118,8 +119,9 @@ func TestGossip_RoundTrip(t *testing.T) {
 	a := newWithClock(func() time.Time { return now })
 	b := newWithClock(func() time.Time { return now })
 
-	// Node A sees a chatty client.
-	a.Charge("loud", LoadHeavy) // 3000
+	for range 11 {
+		a.Charge("loud", LoadHeavy)
+	}
 
 	g := a.Export()
 	if len(g.Items) == 0 {

--- a/internal/rpc/loadtrack/tracker.go
+++ b/internal/rpc/loadtrack/tracker.go
@@ -1,7 +1,7 @@
 // Package loadtrack implements a per-client-IP load tracker that
 // mirrors rippled's Resource::Manager / LoadFeeTrack approach: each
 // inbound RPC method is assigned a Charge (a numeric cost), the cost
-// accumulates against a per-IP balance, balances decay exponentially
+// accumulates against a per-IP balance, balances use an integer decaying sample
 // over time, and a balance crossing a warning / drop threshold causes
 // the next request to be slowed or rejected.
 //
@@ -20,7 +20,6 @@
 package loadtrack
 
 import (
-	"math"
 	"sync"
 	"time"
 )
@@ -32,6 +31,8 @@ const (
 	ChargeHeavy     uint32 = 3000
 	ChargeMalformed uint32 = 100
 	ChargeException uint32 = 100
+	ChargeWarning   uint32 = 4000
+	ChargeDrop      uint32 = 6000
 )
 
 // LoadKind names the cost bucket a handler falls into. The numeric
@@ -41,16 +42,13 @@ type LoadKind uint32
 const (
 	// LoadReference is the default — a lightweight RPC (ping, fee, server_info).
 	LoadReference LoadKind = LoadKind(ChargeReference)
-	// LoadMedium is a moderately expensive RPC that does ledger work
-	// (account_lines, gateway_balances, book_offers).
+	// LoadMedium is a moderately expensive RPC that does ledger work.
 	LoadMedium LoadKind = LoadKind(ChargeMedium)
-	// LoadHeavy is a very expensive RPC: pathfinding, account_tx scans,
-	// large ledger_data dumps.
+	// LoadHeavy is a very expensive RPC, such as pathfinding or signing.
 	LoadHeavy LoadKind = LoadKind(ChargeHeavy)
-	// LoadMalformed is charged for invalidParams / methodNotFound — bad
-	// input that should not be a cheap probe (rippled feeMalformedRPC).
+	// LoadMalformed is charged at malformed transport and authorization boundaries.
 	LoadMalformed LoadKind = LoadKind(ChargeMalformed)
-	// LoadException is charged when a handler returns rpcINTERNAL.
+	// LoadException is charged when dispatch recovers a handler panic.
 	// Numerically equal to LoadMalformed but reported as a distinct
 	// label, mirroring rippled's separate feeExceptionRPC charge
 	// (Fees.cpp).
@@ -61,8 +59,8 @@ const (
 const (
 	WarningThreshold = 5000
 	DropThreshold    = 25000
-	// DecayWindow is the exponential half-life window used to decay
-	// the per-IP balance toward zero.
+	// DecayWindow is the denominator and update interval used by the
+	// integer decaying sample.
 	DecayWindow = 32 * time.Second
 	// EntryExpiration is the LRU eviction deadline — entries that
 	// haven't been touched for this long are dropped from the map.
@@ -82,26 +80,26 @@ type Outcome int
 const (
 	// OutcomeOK means the request may proceed without warning.
 	OutcomeOK Outcome = iota
-	// OutcomeWarn means the request may proceed but the client has
-	// crossed the warning threshold — callers should attach a
-	// "warning" envelope to the response (rippled's feeWarning emit).
+	// OutcomeWarn means the request may proceed but the client is at the
+	// warning threshold. Call Warn to decide whether to notify the client.
 	OutcomeWarn
-	// OutcomeDrop means the request must be rejected with rpcSlowDown;
-	// the client has crossed the drop threshold.
+	// OutcomeDrop means the client is at the drop threshold. Admission
+	// paths should use Disconnect before dispatch instead of this outcome.
 	OutcomeDrop
 )
 
 type entry struct {
-	// balance is the locally accumulated, exponentially-decayed
-	// charge — mirrors rippled Entry.local_balance.
-	balance float64
+	// balance is the raw locally accumulated decaying sample. Thresholds
+	// use its normalized value, balance / decayWindowSeconds.
+	balance int64
 	// remoteBalance is the sum of imported gossip contributions for
 	// this key across all peer origins — mirrors
 	// rippled Entry.remote_balance. Not decayed; it changes only on
 	// import refresh / expiration.
-	remoteBalance int
-	updated       time.Time
-	lastSeen      time.Time
+	remoteBalance   int
+	updated         time.Time
+	lastSeen        time.Time
+	lastWarningTime time.Time
 }
 
 // Gossip is the snapshot exchanged with peers — see
@@ -132,13 +130,13 @@ type importRecord struct {
 	items       map[string]int
 }
 
-// Tracker is the per-IP load accountant. The zero value is ready to
-// use but callers should typically use New() so the clock can be set.
+// Tracker is the per-IP load accountant. Construct one with New.
 type Tracker struct {
-	mu      sync.Mutex
-	now     func() time.Time
-	entries map[string]*entry
-	imports map[string]*importRecord
+	mu          sync.Mutex
+	now         func() time.Time
+	clockOrigin time.Time
+	entries     map[string]*entry
+	imports     map[string]*importRecord
 
 	// lastSweep is updated by sweep() to amortise the cost of LRU
 	// eviction across Charge() calls.
@@ -147,51 +145,58 @@ type Tracker struct {
 
 // New returns a Tracker that reads the wall clock.
 func New() *Tracker {
+	now := time.Now
 	return &Tracker{
-		now:     time.Now,
-		entries: make(map[string]*entry),
-		imports: make(map[string]*importRecord),
+		now:         now,
+		clockOrigin: now(),
+		entries:     make(map[string]*entry),
+		imports:     make(map[string]*importRecord),
 	}
 }
 
 // newWithClock is used by tests to inject a fake clock.
 func newWithClock(now func() time.Time) *Tracker {
 	return &Tracker{
-		now:     now,
-		entries: make(map[string]*entry),
-		imports: make(map[string]*importRecord),
+		now:         now,
+		clockOrigin: now(),
+		entries:     make(map[string]*entry),
+		imports:     make(map[string]*importRecord),
 	}
 }
 
+func (t *Tracker) currentTime() time.Time {
+	return t.clockOrigin.Add(t.now().Sub(t.clockOrigin).Truncate(time.Second))
+}
+
 // Charge debits the configured charge against key (typically a client
-// IP) and returns the verdict. An empty key is treated as anonymous /
-// untracked and always returns OutcomeOK so unit-test fixtures that
-// supply no ClientIP keep working.
+// IP) and returns the resulting threshold state. An empty key is
+// untracked and always returns OutcomeOK.
 //
-// The threshold check uses local + remote balance, matching rippled
-// Entry.h:74's balance(now) = local_balance.value(now) + remote_balance.
+// The Outcome return is retained for compatibility. RPC transports should
+// call Disconnect before dispatch, call Charge after dispatch, and then call
+// Warn; those operations apply the additional drop and warning fees.
 func (t *Tracker) Charge(key string, kind LoadKind) Outcome {
 	if key == "" {
 		return OutcomeOK
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	now := t.now()
+	now := t.currentTime()
+	t.expireImportsLocked(now)
 	e, ok := t.entries[key]
 	if !ok {
 		e = &entry{}
 		t.entries[key] = e
 	}
 	t.decayLocked(e, now)
-	e.balance += float64(kind)
+	e.balance += int64(kind)
 	e.updated = now
 	e.lastSeen = now
 	if now.Sub(t.lastSweep) >= EntryExpiration {
 		t.sweepLocked(now)
 		t.lastSweep = now
 	}
-	t.expireImportsLocked(now)
-	combined := e.balance + float64(e.remoteBalance)
+	combined := combinedBalance(e)
 	switch {
 	case combined >= DropThreshold:
 		return OutcomeDrop
@@ -202,17 +207,72 @@ func (t *Tracker) Charge(key string, kind LoadKind) Outcome {
 	}
 }
 
+// Warn reports whether a load warning should be sent for key. At most one
+// warning is returned for a given clock instant. Each emitted warning adds
+// ChargeWarning to the local balance. Callers responsible for unlimited
+// consumers must bypass this operation; an empty key is never limited.
+func (t *Tracker) Warn(key string) bool {
+	if key == "" {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.currentTime()
+	t.expireImportsLocked(now)
+	e, ok := t.entries[key]
+	if !ok {
+		return false
+	}
+	t.decayLocked(e, now)
+	if combinedBalance(e) < WarningThreshold || now.Equal(e.lastWarningTime) {
+		return false
+	}
+	e.balance += int64(ChargeWarning)
+	e.updated = now
+	e.lastSeen = now
+	e.lastWarningTime = now
+	return true
+}
+
+// Disconnect reports whether key is at or above the drop threshold. Each
+// true result adds ChargeDrop to the local balance so a dropped consumer
+// cannot immediately reconnect. Callers responsible for unlimited consumers
+// must bypass this operation; an empty key is never limited.
+func (t *Tracker) Disconnect(key string) bool {
+	if key == "" {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.currentTime()
+	t.expireImportsLocked(now)
+	e, ok := t.entries[key]
+	if !ok {
+		return false
+	}
+	t.decayLocked(e, now)
+	if combinedBalance(e) < DropThreshold {
+		return false
+	}
+	e.balance += int64(ChargeDrop)
+	e.updated = now
+	e.lastSeen = now
+	return true
+}
+
 // Balance reports the current combined (local + remote) balance for a
 // key. Returns 0 if the key is unknown.
 func (t *Tracker) Balance(key string) float64 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	now := t.currentTime()
+	t.expireImportsLocked(now)
 	e, ok := t.entries[key]
 	if !ok {
 		return 0
 	}
-	t.decayLocked(e, t.now())
-	return e.balance + float64(e.remoteBalance)
+	t.decayLocked(e, now)
+	return float64(combinedBalance(e))
 }
 
 // LocalBalance reports just the locally-decayed component, ignoring
@@ -221,31 +281,33 @@ func (t *Tracker) Balance(key string) float64 {
 func (t *Tracker) LocalBalance(key string) float64 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	now := t.currentTime()
+	t.expireImportsLocked(now)
 	e, ok := t.entries[key]
 	if !ok {
 		return 0
 	}
-	t.decayLocked(e, t.now())
-	return e.balance
+	t.decayLocked(e, now)
+	return float64(localBalance(e))
 }
 
-// OverDropThreshold reports whether the combined balance for key is
-// already at or above DropThreshold. Used by the pre-dispatch gate to
-// reject before the handler runs — mirrors rippled's
-// Resource::Consumer::disconnect() check at ServerHandler.cpp:735.
-// An empty key is treated as anonymous and is never over-threshold.
+// OverDropThreshold reports whether the combined balance for key is already
+// at or above DropThreshold without applying ChargeDrop. New admission paths
+// should use Disconnect. An empty key is never over-threshold.
 func (t *Tracker) OverDropThreshold(key string) bool {
 	if key == "" {
 		return false
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	now := t.currentTime()
+	t.expireImportsLocked(now)
 	e, ok := t.entries[key]
 	if !ok {
 		return false
 	}
-	t.decayLocked(e, t.now())
-	return e.balance+float64(e.remoteBalance) >= DropThreshold
+	t.decayLocked(e, now)
+	return combinedBalance(e) >= DropThreshold
 }
 
 // Reset removes a key from the tracker; used by tests.
@@ -274,15 +336,17 @@ func (t *Tracker) Reset(key string) {
 func (t *Tracker) Export() Gossip {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	now := t.now()
+	now := t.currentTime()
+	t.expireImportsLocked(now)
 	g := Gossip{}
 	for k, e := range t.entries {
 		if k == "" {
 			continue
 		}
 		t.decayLocked(e, now)
-		if e.balance >= MinimumGossipBalance {
-			g.Items = append(g.Items, GossipItem{Key: k, Balance: int(e.balance)})
+		balance := localBalance(e)
+		if balance >= MinimumGossipBalance {
+			g.Items = append(g.Items, GossipItem{Key: k, Balance: int(balance)})
 		}
 	}
 	return g
@@ -304,7 +368,8 @@ func (t *Tracker) Import(origin string, gossip Gossip) {
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	now := t.now()
+	now := t.currentTime()
+	t.expireImportsLocked(now)
 
 	if prev, ok := t.imports[origin]; ok {
 		for k, bal := range prev.items {
@@ -332,7 +397,7 @@ func (t *Tracker) Import(origin string, gossip Gossip) {
 		}
 		e.remoteBalance += item.Balance
 		e.lastSeen = now
-		rec.items[item.Key] = item.Balance
+		rec.items[item.Key] += item.Balance
 	}
 	t.imports[origin] = rec
 }
@@ -358,9 +423,18 @@ func (t *Tracker) expireImportsLocked(now time.Time) {
 	}
 }
 
-// decayLocked applies an exponential decay with half-life DecayWindow
-// to e.balance based on the elapsed time since e.updated. Caller must
-// hold t.mu.
+const decayWindowSeconds int64 = int64(DecayWindow / time.Second)
+
+func localBalance(e *entry) int64 {
+	return e.balance / decayWindowSeconds
+}
+
+func combinedBalance(e *entry) int64 {
+	return localBalance(e) + int64(e.remoteBalance)
+}
+
+// decayLocked applies the integer decaying-sample update used by rippled.
+// Caller must hold t.mu.
 func (t *Tracker) decayLocked(e *entry, now time.Time) {
 	if e.updated.IsZero() || e.balance == 0 {
 		e.updated = now
@@ -370,11 +444,16 @@ func (t *Tracker) decayLocked(e *entry, now time.Time) {
 	if dt <= 0 {
 		return
 	}
-	// Exponential decay with half-life = DecayWindow.
-	factor := math.Pow(0.5, dt.Seconds()/DecayWindow.Seconds())
-	e.balance *= factor
-	if e.balance < 1 {
+	elapsed := int64(dt / time.Second)
+	if elapsed > 4*decayWindowSeconds {
 		e.balance = 0
+	} else {
+		for range elapsed {
+			e.balance -= (e.balance + decayWindowSeconds - 1) / decayWindowSeconds
+			if e.balance == 0 {
+				break
+			}
+		}
 	}
 	e.updated = now
 }

--- a/internal/rpc/loadtrack/tracker_test.go
+++ b/internal/rpc/loadtrack/tracker_test.go
@@ -16,7 +16,7 @@ func TestCharge_NoKeyAlwaysOK(t *testing.T) {
 
 func TestCharge_ReferenceStaysBelowWarning(t *testing.T) {
 	tr := New()
-	// 200 × ChargeReference = 4000 — below warning (5000).
+	// The raw sample is normalized by the 32-second decay window.
 	for i := range 200 {
 		if got := tr.Charge("1.2.3.4", LoadReference); got != OutcomeOK {
 			t.Fatalf("got %v at iter %d, balance %v", got, i, tr.Balance("1.2.3.4"))
@@ -27,16 +27,15 @@ func TestCharge_ReferenceStaysBelowWarning(t *testing.T) {
 func TestCharge_HeavyCrossesWarnThenDrop(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	tr := newWithClock(func() time.Time { return now })
-	// 1 × Heavy (3000) — below warning still.
-	if got := tr.Charge("1.2.3.4", LoadHeavy); got != OutcomeOK {
-		t.Fatalf("1×heavy: expected OK, got %v", got)
+	for i := range 53 {
+		if got := tr.Charge("1.2.3.4", LoadHeavy); got != OutcomeOK {
+			t.Fatalf("charge %d: expected OK, got %v", i+1, got)
+		}
 	}
-	// 2 × Heavy (6000) — over warning, below drop.
 	if got := tr.Charge("1.2.3.4", LoadHeavy); got != OutcomeWarn {
-		t.Fatalf("2×heavy: expected Warn, got %v (balance %v)", got, tr.Balance("1.2.3.4"))
+		t.Fatalf("charge 54: expected Warn, got %v (balance %v)", got, tr.Balance("1.2.3.4"))
 	}
-	// Subsequent heavies climb to >= 25000 ⇒ Drop.
-	for range 10 {
+	for range 300 {
 		got := tr.Charge("1.2.3.4", LoadHeavy)
 		if got == OutcomeDrop {
 			return
@@ -48,16 +47,17 @@ func TestCharge_HeavyCrossesWarnThenDrop(t *testing.T) {
 func TestCharge_DecayRecovers(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	tr := newWithClock(func() time.Time { return now })
-	for range 3 {
-		tr.Charge("1.2.3.4", LoadHeavy) // 9000
+	tr.Charge("1.2.3.4", LoadKind(3200))
+	if got := tr.Balance("1.2.3.4"); got != 100 {
+		t.Fatalf("initial normalized balance = %v, want 100", got)
 	}
-	if got := tr.Balance("1.2.3.4"); got < 8000 {
-		t.Fatalf("expected balance ~9000, got %v", got)
+	now = now.Add(time.Second)
+	if got := tr.Balance("1.2.3.4"); got != 96 {
+		t.Fatalf("one-second normalized balance = %v, want 96", got)
 	}
-	// Advance two full decay windows — balance should fall by ~75%.
-	now = now.Add(2 * DecayWindow)
-	if got := tr.Balance("1.2.3.4"); got > 9000*0.30 {
-		t.Fatalf("expected decay to <30%% of initial, got %v", got)
+	now = now.Add(4*DecayWindow + time.Second)
+	if got := tr.Balance("1.2.3.4"); got != 0 {
+		t.Fatalf("balance after reset horizon = %v, want 0", got)
 	}
 }
 
@@ -74,7 +74,7 @@ func TestCharge_PerKeyIsolated(t *testing.T) {
 func TestSweep_EvictsIdleEntries(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	tr := newWithClock(func() time.Time { return now })
-	tr.Charge("1.2.3.4", LoadReference)
+	tr.Charge("1.2.3.4", LoadKind(decayWindowSeconds))
 	if tr.Balance("1.2.3.4") == 0 {
 		t.Fatal("expected non-zero balance immediately after charge")
 	}

--- a/internal/rpc/nft_offers_test.go
+++ b/internal/rpc/nft_offers_test.go
@@ -654,7 +654,7 @@ func TestNftBuyOffersServiceUnavailable(t *testing.T) {
 	resp, err := method.Handle(ctx, paramsJSON)
 
 	require.NotNil(t, err)
-	assert.Contains(t, err.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", err.Message)
 	assert.Nil(t, resp)
 }
 
@@ -676,7 +676,7 @@ func TestNftSellOffersServiceUnavailable(t *testing.T) {
 	resp, err := method.Handle(ctx, paramsJSON)
 
 	require.NotNil(t, err)
-	assert.Contains(t, err.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", err.Message)
 	assert.Nil(t, resp)
 }
 

--- a/internal/rpc/noripple_check_test.go
+++ b/internal/rpc/noripple_check_test.go
@@ -696,7 +696,7 @@ func TestNoRippleCheckServiceUnavailable(t *testing.T) {
 	resp, err := method.Handle(ctx, paramsJSON)
 
 	require.NotNil(t, err)
-	assert.Contains(t, err.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", err.Message)
 	assert.Nil(t, resp)
 }
 

--- a/internal/rpc/overload_gate_test.go
+++ b/internal/rpc/overload_gate_test.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"encoding/json"
+	"math"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -12,8 +13,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/gorilla/websocket"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // pushOverDropThreshold charges key until the tracker reports it is over the
@@ -186,36 +185,106 @@ func TestHTTPBatchOverloadElement(t *testing.T) {
 	}
 }
 
-// TestWSOverloadBeforeForbid confirms the WebSocket ordering: an over-budget caller
-// invoking a forbidden admin command is rejected by the overload gate ahead of
-// FORBID, surfacing rippled's WS overload code rpcSLOW_DOWN (slowDown, 10) rather
-// than the forbidden token. A non-admin role is forced by AdminNets that exclude
-// the loopback peer, disabling the localhost-admin fallback.
-func TestWSOverloadBeforeForbid(t *testing.T) {
-	ws := NewWebSocketServer(2*time.Second, nil)
-	ws.methodRegistry.Register("stop", &stubHandler{role: types.RoleAdmin})
-	ws.loadTracker = loadtrack.New()
-	pushOverDropThreshold(t, ws.loadTracker, "127.0.0.1")
+func TestWSOverloadClosesBeforeRequestValidation(t *testing.T) {
+	tests := []string{
+		`{"command":"stop","id":1}`,
+		`{"command":"subscribe","streams":["ledger"]}`,
+		`{"command":"unsubscribe","streams":["ledger"]}`,
+		`{"command":"path_find","subcommand":"status"}`,
+		`{"command":7,"api_version":99}`,
+	}
+	for _, request := range tests {
+		t.Run(request, func(t *testing.T) {
+			ws := NewWebSocketServer(2*time.Second, nil)
+			ws.methodRegistry.Register("stop", &stubHandler{role: types.RoleAdmin})
+			ws.loadTracker = loadtrack.New()
+			pushOverDropThreshold(t, ws.loadTracker, "127.0.0.1")
 
-	_, adminNet, _ := net.ParseCIDR("10.0.0.0/8")
-	pc := &PortContext{AdminNets: []net.IPNet{*adminNet}}
-	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ws.ServeHTTP(w, r.WithContext(WithPortContext(r.Context(), pc)))
-	}))
-	defer httpSrv.Close()
-	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http")
+			_, adminNet, _ := net.ParseCIDR("10.0.0.0/8")
+			pc := &PortContext{AdminNets: []net.IPNet{*adminNet}}
+			httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ws.ServeHTTP(w, r.WithContext(WithPortContext(r.Context(), pc)))
+			}))
+			defer httpSrv.Close()
 
-	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
-	require.NoError(t, err)
-	defer c.Close()
+			client, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(httpSrv.URL, "http"), nil)
+			if err != nil {
+				t.Fatalf("dial: %v", err)
+			}
+			defer client.Close()
+			if err := client.WriteMessage(websocket.TextMessage, []byte(request)); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if err := client.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+				t.Fatalf("set read deadline: %v", err)
+			}
+			_, body, err := client.ReadMessage()
+			if err == nil {
+				t.Fatalf("received an application response before close: %s", body)
+			}
+			closeErr, ok := err.(*websocket.CloseError)
+			if !ok {
+				t.Fatalf("read error = %T %v, want WebSocket close error", err, err)
+			}
+			if closeErr.Code != websocket.ClosePolicyViolation || closeErr.Text != "threshold exceeded" {
+				t.Fatalf("close = %d %q, want %d %q", closeErr.Code, closeErr.Text, websocket.ClosePolicyViolation, "threshold exceeded")
+			}
+		})
+	}
+}
 
-	require.NoError(t, c.WriteJSON(map[string]any{"command": "stop", "id": float64(1)}))
-	require.NoError(t, c.SetReadDeadline(time.Now().Add(2*time.Second)))
-	var resp map[string]any
-	require.NoError(t, c.ReadJSON(&resp))
+func TestWSEarlyMalformedResponsesChargeWithoutLoadWarning(t *testing.T) {
+	tests := []struct {
+		name    string
+		request string
+		want    string
+	}{
+		{
+			name:    "invalid API version",
+			request: `{"command":"ping","api_version":99,"id":1}`,
+			want:    `{"api_version":99,"error":"invalid_API_version","id":1,"request":{"api_version":99,"command":"ping","id":1},"status":"error","type":"response"}`,
+		},
+		{
+			name:    "missing command",
+			request: `{"id":2}`,
+			want:    `{"error":"missingCommand","id":2,"request":{"id":2},"status":"error","type":"response"}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ws := NewWebSocketServer(2*time.Second, nil)
+			ws.loadTracker.Import("warning-peer", loadtrack.Gossip{Items: []loadtrack.GossipItem{{
+				Key:     "127.0.0.1",
+				Balance: loadtrack.WarningThreshold - int(loadtrack.ChargeMalformed/uint32(loadtrack.DecayWindow/time.Second)),
+			}}})
 
-	assert.Equal(t, "error", resp["status"])
-	assert.Equal(t, "slowDown", resp["error"], "overload must precede FORBID on the WS path")
-	assert.Equal(t, float64(types.RpcSLOW_DOWN), resp["error_code"])
-	assert.Equal(t, float64(1), resp["id"])
+			pc := &PortContext{AdminNets: []net.IPNet{mustParseCIDR("10.0.0.0/8")}}
+			httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ws.ServeHTTP(w, r.WithContext(WithPortContext(r.Context(), pc)))
+			}))
+			defer httpSrv.Close()
+
+			client, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(httpSrv.URL, "http"), nil)
+			if err != nil {
+				t.Fatalf("dial: %v", err)
+			}
+			defer client.Close()
+			if err := client.WriteMessage(websocket.TextMessage, []byte(test.request)); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if err := client.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+				t.Fatalf("set read deadline: %v", err)
+			}
+			_, body, err := client.ReadMessage()
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if got := string(body); got != test.want {
+				t.Fatalf("response = %s, want %s", got, test.want)
+			}
+			if got, want := math.Round(ws.loadTracker.LocalBalance("127.0.0.1")), float64(loadtrack.ChargeMalformed/uint32(loadtrack.DecayWindow/time.Second)); got != want {
+				t.Fatalf("local charge = %v, want %v", got, want)
+			}
+		})
+	}
 }

--- a/internal/rpc/path_find_session.go
+++ b/internal/rpc/path_find_session.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"encoding/json"
-	"fmt"
 	"sync"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -56,7 +55,7 @@ type pathFindCreateRequest struct {
 func ParseAndCreateSession(params json.RawMessage, id any) (*PathFindSession, *rpctypes.RpcError) {
 	var request pathFindCreateRequest
 	if err := json.Unmarshal(params, &request); err != nil {
-		return nil, rpctypes.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", err))
+		return nil, rpctypes.RpcErrorInvalidParams("Invalid parameters.")
 	}
 
 	// Validate required fields

--- a/internal/rpc/path_find_session_test.go
+++ b/internal/rpc/path_find_session_test.go
@@ -62,3 +62,13 @@ func TestParseAndCreateSession_AmountGuards(t *testing.T) {
 		})
 	}
 }
+
+func TestParseAndCreateSession_DecodeErrorIsFixed(t *testing.T) {
+	_, rpcErr := ParseAndCreateSession(json.RawMessage(`{"private":"decoder-detail"`), nil)
+	if rpcErr == nil {
+		t.Fatal("expected invalid parameters error")
+	}
+	if rpcErr.ErrorString != "invalidParams" || rpcErr.Message != "Invalid parameters." {
+		t.Fatalf("error = %#v, want fixed invalidParams message", rpcErr)
+	}
+}

--- a/internal/rpc/rpcsub.go
+++ b/internal/rpc/rpcsub.go
@@ -74,7 +74,16 @@ func (r *URLSubscriptionRegistry) Subscribe(ctx *types.RpcContext, request types
 	}
 	// Like rippled, a failing stream/account/book parse leaves the freshly
 	// created registry entry in place.
-	if rpcErr := r.ws.subscriptionManager.HandleSubscribe(sub.conn, request, true); rpcErr != nil {
+	if rpcErr := r.ws.subscriptionManager.HandleSubscribe(sub.conn, request.WithoutBooks(), true); rpcErr != nil {
+		return nil, rpcErr
+	}
+	if rpcErr := applyURLSubscriptionBooks(request, func(bookRequest types.SubscriptionRequest) *types.RpcError {
+		if rpcErr := r.ws.subscriptionManager.HandleSubscribe(sub.conn, bookRequest, true); rpcErr != nil {
+			return rpcErr
+		}
+		setSubscriptionLoadCost(ctx, bookRequest)
+		return nil
+	}); rpcErr != nil {
 		return nil, rpcErr
 	}
 	return r.ws.buildSubscribeAck(ctx, request), nil
@@ -90,11 +99,29 @@ func (r *URLSubscriptionRegistry) Unsubscribe(ctx *types.RpcContext, request typ
 	if !ok {
 		return map[string]any{}, nil
 	}
-	if rpcErr := r.ws.subscriptionManager.HandleUnsubscribe(sub.conn, request, true); rpcErr != nil {
+	if rpcErr := r.ws.subscriptionManager.HandleUnsubscribe(sub.conn, request.WithoutBooks(), true); rpcErr != nil {
+		return nil, rpcErr
+	}
+	if rpcErr := applyURLSubscriptionBooks(request, func(bookRequest types.SubscriptionRequest) *types.RpcError {
+		return r.ws.subscriptionManager.HandleUnsubscribe(sub.conn, bookRequest, true)
+	}); rpcErr != nil {
 		return nil, rpcErr
 	}
 	r.tryRemove(request.URL)
 	return map[string]any{}, nil
+}
+
+func applyURLSubscriptionBooks(request types.SubscriptionRequest, apply func(types.SubscriptionRequest) *types.RpcError) *types.RpcError {
+	wire := request.WireArrays()
+	if wire.Present {
+		return applySubscriptionBooks(wire.Books, apply)
+	}
+	for _, book := range request.Books {
+		if rpcErr := apply(types.SubscriptionRequest{Books: []types.BookRequest{book}}); rpcErr != nil {
+			return rpcErr
+		}
+	}
+	return nil
 }
 
 func (r *URLSubscriptionRegistry) findOrCreate(request types.SubscriptionRequest) (*rpcSub, *types.RpcError) {
@@ -103,7 +130,8 @@ func (r *URLSubscriptionRegistry) findOrCreate(request types.SubscriptionRequest
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.closed {
-		return nil, types.RpcErrorInternal("Internal error.")
+		wsLog().Error("rpcsub: subscription requested after registry closed")
+		return nil, types.RpcErrorInternal()
 	}
 	if sub, ok := r.subs[request.URL]; ok {
 		// Credentials on an existing url subscription are only updated via

--- a/internal/rpc/rpcsub_test.go
+++ b/internal/rpc/rpcsub_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -228,6 +229,51 @@ func TestRPCSub_URLValidation(t *testing.T) {
 			assert.Equal(t, tc.message, rpcErr.Message)
 		})
 	}
+}
+
+func TestRPCSubBooksApplyInWireOrder(t *testing.T) {
+	const account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	ws, services := newRPCSubTestServer(t)
+	sink := newRPCSubSink(t)
+	ctx := adminCtx(services)
+	method := &handlers.SubscribeMethod{}
+	params := `{"url":"` + sink.srv.URL + `","books":[` +
+		`{"taker_pays":{"currency":"XRP"},"taker_gets":{"currency":"USD","issuer":"` + account + `"},"snapshot":true},` +
+		`{"taker_pays":{"currency":"XRP"},"taker_gets":{"currency":"XRP"}}]}`
+
+	_, rpcErr := method.Handle(ctx, json.RawMessage(params))
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, uint32(loadtrack.LoadMedium), ctx.LoadCost)
+
+	ws.urlSubs.mu.Lock()
+	sub := ws.urlSubs.subs[sink.srv.URL]
+	ws.urlSubs.mu.Unlock()
+	require.NotNil(t, sub)
+	assert.Len(t, sub.conn.Subscriptions[types.SubBook].Books, 1)
+}
+
+func TestRPCSubBookUnsubscribeAppliesInWireOrder(t *testing.T) {
+	const account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	ws, services := newRPCSubTestServer(t)
+	sink := newRPCSubSink(t)
+	urlParam := `"url":"` + sink.srv.URL + `"`
+	first := `{"taker_pays":{"currency":"XRP"},"taker_gets":{"currency":"USD","issuer":"` + account + `"}}`
+	second := `{"taker_pays":{"currency":"XRP"},"taker_gets":{"currency":"EUR","issuer":"` + account + `"}}`
+
+	_, rpcErr := subscribeURL(t, services, `{`+urlParam+`,"books":[`+first+`,`+second+`]}`)
+	require.Nil(t, rpcErr)
+	_, rpcErr = unsubscribeURL(t, services, `{`+urlParam+`,"books":[`+first+`,{"taker_pays":{"currency":"XRP"},"taker_gets":{"currency":"XRP"}}]}`)
+	require.NotNil(t, rpcErr)
+
+	ws.urlSubs.mu.Lock()
+	sub := ws.urlSubs.subs[sink.srv.URL]
+	ws.urlSubs.mu.Unlock()
+	require.NotNil(t, sub)
+	books := sub.conn.Subscriptions[types.SubBook].Books
+	require.Len(t, books, 1)
+	encoded, err := json.Marshal(books[0])
+	require.NoError(t, err)
+	assert.JSONEq(t, second, string(encoded))
 }
 
 // TestRPCSub_EmptyHostAcceptedAtSubscribe mirrors rippled's parseUrl host

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -1,13 +1,16 @@
 package rpc
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"maps"
 	"net"
 	"net/http"
+	"net/url"
 	"runtime/debug"
 	"slices"
 	"strconv"
@@ -29,16 +32,16 @@ import (
 // goxrpl and rippled reject the same oversized payloads on the wire.
 const MaxRequestBytes = 1_000_000
 
+const jsonContentType = "application/json; charset=UTF-8"
+
+// The size-only rippled rejection has no parser detail. Use that same fixed
+// response for every parse-boundary failure so Go decoder diagnostics and
+// request fragments never reach clients.
+const unableToParseRequest = "Unable to parse request: "
+
 // rpcLog returns the logger for the HTTP JSON-RPC server.
 // Resolved lazily so it picks up the root logger set during CLI bootstrap.
 func rpcLog() xrpllog.Logger { return xrpllog.Named(xrpllog.PartitionRPC) }
-
-// LoadCharger is the optional interface a MethodHandler may implement
-// to declare its load bucket. Handlers that don't implement it pay
-// loadtrack.LoadReference (rippled feeReferenceRPC parity).
-type LoadCharger interface {
-	LoadKind() loadtrack.LoadKind
-}
 
 type Server struct {
 	peerSourceHolder
@@ -127,11 +130,21 @@ func (s *Server) resolveCORSOrigin(requestOrigin string) string {
 // service container handlers will read through ctx.Services. The
 // container may be nil for test contexts that exercise routing only.
 func NewServer(timeout time.Duration, services *types.ServiceContainer) *Server {
+	return NewServerWithLoadTracker(timeout, services, nil)
+}
+
+// NewServerWithLoadTracker creates a server using tracker for transport-level
+// admission and charging. A nil tracker preserves NewServer's standalone
+// default.
+func NewServerWithLoadTracker(timeout time.Duration, services *types.ServiceContainer, tracker *loadtrack.Tracker) *Server {
+	if tracker == nil {
+		tracker = loadtrack.New()
+	}
 	server := &Server{
 		registry:    types.NewMethodRegistry(),
 		timeout:     timeout,
 		services:    services,
-		loadTracker: loadtrack.New(),
+		loadTracker: tracker,
 	}
 
 	if services != nil && services.ClientLoad == nil {
@@ -159,8 +172,8 @@ type JsonRpcResponseOptions struct {
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		if rec := recover(); rec != nil {
-			rpcLog().Error("rpc handler panic", "err", rec, "stack", string(debug.Stack()), "method", r.Method, "remote", r.RemoteAddr)
-			s.writeXrplError(w, nil, "internal", "Internal server error")
+			rpcLog().Error("rpc transport panic", "err", rec, "stack", string(debug.Stack()), "method", r.Method, "remote", r.RemoteAddr)
+			s.writeXrplResponseWithOptions(w, nil, nil, rpcInternalError(), nil)
 		}
 	}()
 
@@ -177,7 +190,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", jsonContentType)
 
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
@@ -185,7 +198,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method != "POST" && r.Method != "GET" {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		writePlainHTTPError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}
 
@@ -230,10 +243,11 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
-			http.Error(w, "Request body exceeds limit", http.StatusBadRequest)
+			writePlainHTTPError(w, http.StatusBadRequest, unableToParseRequest)
 			return
 		}
-		s.writeXrplError(w, nil, "internal", "Failed to read request body")
+		rpcLog().Error("Failed to read request body", "err", err)
+		s.writeXrplResponseWithOptions(w, nil, nil, rpcInternalError(), nil)
 		return
 	}
 
@@ -250,16 +264,17 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 	// body, then the method field validated for the same three malformed shapes
 	// the batch path distinguishes. The bodies are application/json (rippled's
 	// HTTPReply quirk), not Go's http.Error text/plain default.
+	if !validJSONObjectDocument(body) {
+		writePlainHTTPError(w, http.StatusBadRequest, unableToParseRequest)
+		return
+	}
 	if err := json.Unmarshal(body, &request); err != nil {
-		writePlainHTTPError(w, http.StatusBadRequest, "Unable to parse request: "+err.Error())
+		writePlainHTTPError(w, http.StatusBadRequest, unableToParseRequest)
 		return
 	}
 
-	method, methodErr := decodeMethodField(request.Method)
-	if methodErr != "" {
-		writePlainHTTPError(w, http.StatusBadRequest, methodErr)
-		return
-	}
+	var method string
+	_ = json.Unmarshal(request.Method, &method)
 
 	portCtx := GetPortContext(r.Context())
 	peerIP := remoteAddrIP(r.RemoteAddr)
@@ -287,75 +302,185 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		// rejects as "not an array"; an empty [] unmarshals to a non-nil empty
 		// slice and is accepted.
 		if err := json.Unmarshal(request.Params, &elements); err != nil || elements == nil {
-			http.Error(w, "Malformed batch request", http.StatusBadRequest)
+			writePlainHTTPError(w, http.StatusBadRequest, "Malformed batch request")
 			return
 		}
 		replies := make([]map[string]any, len(elements))
 		for i, el := range elements {
 			replies[i] = s.dispatchBatchElement(el, dispatchCtx, role, clientIP)
 		}
+		w.Header().Set("Content-Type", jsonContentType)
 		w.WriteHeader(http.StatusOK)
-		enc := json.NewEncoder(&trimNewlineWriter{w: w})
-		if err := enc.Encode(replies); err != nil {
+		if err := writeJSONRPCBody(w, replies); err != nil {
 			rpcLog().Error("Failed to encode batch response", "err", err)
 		}
 		return
 	}
 
-	// XRPL JSON-RPC uses params as an array with a single object.
-	var params json.RawMessage
-	if len(request.Params) > 0 {
-		var arr []json.RawMessage
-		if err := json.Unmarshal(request.Params, &arr); err != nil {
-			// params present but not a JSON array → HTTP 400
-			// (ServerHandler.cpp:826).
-			writePlainHTTPError(w, http.StatusBadRequest, "params unparseable")
-			return
-		}
-		if len(arr) > 0 {
-			params = arr[0]
-		}
+	apiVersion := types.DefaultApiVersion
+	if version, present := apiVersionFromSingleParams(request.Params); present {
+		apiVersion = version
 	}
-
-	ctx := newRpcContext(dispatchCtx, role, types.DefaultApiVersion, clientIP, s.loadPeerSource(), s.services)
-
-	if params != nil {
-		applyApiVersionFromObject(ctx, params)
-	}
-
-	result, rpcErr := s.executeMethod(method, params, ctx)
-
-	// rippled answers an unsupported api_version on the HTTP-single path with
-	// HTTPReply(400, "invalid_API_version") — a 400 whose body is the bare
-	// token, not a JSON-RPC result envelope (ServerHandler.cpp:687-690).
-	if rpcErr != nil && rpcErr.IsInvalidApiVersion() {
+	versionCtx := newRpcContext(dispatchCtx, role, apiVersion, clientIP, s.loadPeerSource(), s.services)
+	if rpcErr := validateApiVersion(versionCtx); rpcErr != nil {
 		writeInvalidApiVersionHTTP(w)
 		return
 	}
-
-	// rippled rejects a caller already over its per-IP resource budget at the
-	// overload-admission layer, ahead of FORBID: a positive usage.disconnect()
-	// yields HTTPReply(503, "Server is overloaded") — a 503 whose body is the
-	// bare string, not the JSON-RPC result envelope (ServerHandler.cpp:735-740).
-	// This precedes the FORBID render below, matching rippled's order.
-	if rpcErr != nil && rpcErr.IsOverloaded() {
-		writePlainHTTPError(w, http.StatusServiceUnavailable, "Server is overloaded")
+	ctx := versionCtx
+	resolution := resolveMethod(s.registry, method, ctx.ApiVersion)
+	if rpcErr := admitMethod(s.loadTracker, ctx, method, resolution, types.RpcErrorForbidden, true, rpcLog()); rpcErr != nil {
+		if rpcErr.IsOverloaded() {
+			writePlainHTTPError(w, http.StatusServiceUnavailable, "Server is overloaded")
+		} else {
+			writePlainHTTPError(w, http.StatusForbidden, "Forbidden")
+		}
 		return
 	}
 
-	// rippled rejects an admin-only command from a non-admin caller at the role
-	// layer: a FORBID role yields HTTPReply(403, "Forbidden") before the handler
-	// runs, not the JSON-RPC result envelope (ServerHandler.cpp:750-757). The
-	// feeMalformedRPC charge is applied in the shared dispatch core; here we only
-	// render the 403.
-	if rpcErr != nil && rpcErr.IsForbidden() {
-		writePlainHTTPError(w, http.StatusForbidden, "Forbidden")
+	var methodErr string
+	method, methodErr = decodeMethodField(request.Method)
+	if methodErr != "" {
+		chargeLoad(s.loadTracker, ctx, method, loadtrack.LoadMalformed, rpcLog())
+		writePlainHTTPError(w, http.StatusBadRequest, methodErr)
 		return
+	}
+
+	// XRPL JSON-RPC uses params as an array with a single object.
+	params := json.RawMessage("{}")
+	if len(request.Params) > 0 && !rawJSONNull(request.Params) {
+		var arr []json.RawMessage
+		if err := json.Unmarshal(request.Params, &arr); err != nil || len(arr) != 1 {
+			chargeLoad(s.loadTracker, ctx, method, loadtrack.LoadMalformed, rpcLog())
+			writePlainHTTPError(w, http.StatusBadRequest, "params unparseable")
+			return
+		}
+		params = arr[0]
+		if !rawJSONNull(params) {
+			var object map[string]any
+			if err := json.Unmarshal(params, &object); err != nil || object == nil {
+				chargeLoad(s.loadTracker, ctx, method, loadtrack.LoadMalformed, rpcLog())
+				writePlainHTTPError(w, http.StatusBadRequest, "params unparseable")
+				return
+			}
+		}
 	}
 
 	requestObj := buildRequestEcho(method, params)
+	if _, valid := ripplerpcVersion(requestObj); !valid {
+		chargeLoad(s.loadTracker, ctx, method, loadtrack.LoadMalformed, rpcLog())
+		writePlainHTTPError(w, http.StatusBadRequest, "ripplerpc is not a string")
+		return
+	}
+
+	result, rpcErr := dispatchResolvedMethod(s.loadTracker, s.services, ctx, method, params, resolution, rpcLog())
 
 	s.writeXrplResponseWithOptions(w, requestObj, result, rpcErr, loadWarningOpts(ctx))
+}
+
+func rawJSONNull(value json.RawMessage) bool {
+	return strings.TrimSpace(string(value)) == "null"
+}
+
+func decodeJSONUseNumber(data []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	switch out := target.(type) {
+	case *map[string]any:
+		normalized, err := normalizeJSONValue(*out)
+		if err != nil {
+			return err
+		}
+		if normalized == nil {
+			*out = nil
+		} else {
+			*out = normalized.(map[string]any)
+		}
+	case *any:
+		normalized, err := normalizeJSONValue(*out)
+		if err != nil {
+			return err
+		}
+		*out = normalized
+	}
+	return nil
+}
+
+func validJSONObjectDocument(data []byte) bool {
+	var value any
+	if err := decodeJSONUseNumber(data, &value); err != nil {
+		return false
+	}
+	object, ok := value.(map[string]any)
+	return ok && object != nil
+}
+
+type jsonReal float64
+
+func (value jsonReal) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.FormatFloat(float64(value), 'g', 16, 64)), nil
+}
+
+func normalizeJSONValue(value any) (any, error) {
+	return normalizeJSONValueAtDepth(value, 0)
+}
+
+func normalizeJSONValueAtDepth(value any, depth int) (any, error) {
+	if depth > 25 {
+		return nil, errors.New("maximum JSON nesting depth exceeded")
+	}
+	switch value := value.(type) {
+	case json.Number:
+		raw := value.String()
+		if strings.ContainsAny(raw, ".eE") {
+			number, err := strconv.ParseFloat(raw, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid JSON number %q: %w", raw, err)
+			}
+			return jsonReal(number), nil
+		}
+		if strings.HasPrefix(raw, "-") {
+			number, err := strconv.ParseInt(raw, 10, 64)
+			if err != nil || number < -1<<31 {
+				return nil, fmt.Errorf("JSON integer %q exceeds the allowable range", raw)
+			}
+			return int32(number), nil
+		}
+		number, err := strconv.ParseUint(raw, 10, 64)
+		if err != nil || number > 1<<32-1 {
+			return nil, fmt.Errorf("JSON integer %q exceeds the allowable range", raw)
+		}
+		if number <= 1<<31-1 {
+			return int32(number), nil
+		}
+		return uint32(number), nil
+	case map[string]any:
+		for key, item := range value {
+			normalized, err := normalizeJSONValueAtDepth(item, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			value[key] = normalized
+		}
+	case []any:
+		for i, item := range value {
+			normalized, err := normalizeJSONValueAtDepth(item, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			value[i] = normalized
+		}
+	}
+	return value, nil
 }
 
 // writeInvalidApiVersionHTTP mirrors rippled's HTTP-single rejection of an
@@ -363,11 +488,7 @@ func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 // (ServerHandler.cpp:689 → HTTPReply(400, ...)). The body carries no JSON
 // envelope, matching rippled's plain-string reply.
 func writeInvalidApiVersionHTTP(w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.WriteHeader(http.StatusBadRequest)
-	if _, err := io.WriteString(w, types.InvalidApiVersionToken); err != nil {
-		rpcLog().Error("Failed to write invalid_API_version response", "err", err)
-	}
+	writePlainHTTPError(w, http.StatusBadRequest, types.InvalidApiVersionToken)
 }
 
 // writePlainHTTPError mirrors rippled's HTTPReply(status, content): a bare
@@ -375,7 +496,7 @@ func writeInvalidApiVersionHTTP(w http.ResponseWriter) {
 // strings that way) terminated with CRLF (JSONRPCUtil.cpp:148-158), rather
 // than Go's http.Error text/plain + LF default.
 func writePlainHTTPError(w http.ResponseWriter, status int, content string) {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.Header().Set("Content-Type", jsonContentType)
 	w.WriteHeader(status)
 	if _, err := io.WriteString(w, content+"\r\n"); err != nil {
 		rpcLog().Error("Failed to write HTTP error response", "err", err)
@@ -400,32 +521,64 @@ func decodeMethodField(raw json.RawMessage) (method string, errMsg string) {
 	return method, ""
 }
 
-// applyApiVersionFromObject overrides ctx.ApiVersion when the given JSON object
-// carries a numeric "api_version" field.
-func applyApiVersionFromObject(ctx *types.RpcContext, obj json.RawMessage) {
-	var m map[string]any
-	if err := json.Unmarshal(obj, &m); err == nil {
-		if apiVer, ok := m["api_version"]; ok {
-			if ver, ok := apiVer.(float64); ok {
-				ctx.ApiVersion = int(ver)
-			}
-		}
+func apiVersionFromObject(obj json.RawMessage) (int, bool) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(obj, &fields); err != nil {
+		return 0, false
 	}
+	raw, present := fields["api_version"]
+	if !present {
+		return 0, false
+	}
+	version, valid := strictAPIVersion(raw)
+	if !valid {
+		return types.ApiVersion1 - 1, true
+	}
+	return version, true
+}
+
+func apiVersionFromSingleParams(paramsRaw json.RawMessage) (int, bool) {
+	var params []json.RawMessage
+	if err := json.Unmarshal(paramsRaw, &params); err != nil || len(params) == 0 {
+		return 0, false
+	}
+	return apiVersionFromObject(params[0])
+}
+
+func strictAPIVersion(raw json.RawMessage) (int, bool) {
+	var version *int
+	if err := json.Unmarshal(raw, &version); err != nil || version == nil {
+		return 0, false
+	}
+	return *version, true
 }
 
 // buildRequestEcho builds the request echo attached to error responses, masking
-// credentials before the echo leaves the process (see redactCredentials).
-func buildRequestEcho(method string, params json.RawMessage) any {
+// credentials before the echo leaves the process.
+func buildRequestEcho(method string, params json.RawMessage) map[string]any {
 	if params != nil {
 		var reqMap map[string]any
 		// params may unmarshal to JSON null, which yields a nil map.
-		if err := json.Unmarshal(params, &reqMap); err == nil && reqMap != nil {
-			redactCredentials(reqMap)
+		if err := decodeJSONUseNumber(params, &reqMap); err == nil && reqMap != nil {
+			reqMap = redactedRequestMap(reqMap)
 			reqMap["command"] = method
 			return reqMap
 		}
 	}
 	return map[string]any{"command": method}
+}
+
+func ripplerpcVersion(request any) (string, bool) {
+	requestMap, ok := request.(map[string]any)
+	if !ok {
+		return "1.0", true
+	}
+	value, exists := requestMap["ripplerpc"]
+	if !exists {
+		return "1.0", true
+	}
+	version, ok := value.(string)
+	return version, ok
 }
 
 // dispatchBatchElement processes one element of a batch envelope and returns its
@@ -435,15 +588,34 @@ func buildRequestEcho(method string, params json.RawMessage) any {
 // element's top level (ServerHandler.cpp:668-683).
 func (s *Server) dispatchBatchElement(el json.RawMessage, baseCtx context.Context, role types.Role, clientIP string) map[string]any {
 	var elem map[string]any
-	if err := json.Unmarshal(el, &elem); err != nil || elem == nil {
+	if err := decodeJSONUseNumber(el, &elem); err != nil || elem == nil {
 		// Non-object element: echo it under "request" with a method_not_found
 		// JSON-RPC error (ServerHandler.cpp:658-665).
 		var raw any
-		_ = json.Unmarshal(el, &raw)
+		_ = decodeJSONUseNumber(el, &raw)
 		return map[string]any{
-			"request": raw,
+			"request": redactJSONValue(raw),
 			"error":   makeBatchJSONError(rpcMethodNotFoundCode, "Method not found"),
 		}
+	}
+	ctx := newRpcContext(baseCtx, role, types.DefaultApiVersion, clientIP, s.loadPeerSource(), s.services)
+	if ver, ok := apiVersionFromBatchElement(el); ok {
+		ctx.ApiVersion = ver
+	}
+	if rpcErr := validateApiVersion(ctx); rpcErr != nil {
+		echo := redactedRequestMap(elem)
+		return map[string]any{
+			"request": echo,
+			"error":   makeBatchJSONError(types.WrongVersionJSONRPCCode, types.InvalidApiVersionToken),
+		}
+	}
+	method, _ := elem["method"].(string)
+	resolution := resolveMethod(s.registry, method, ctx.ApiVersion)
+	if rpcErr := admitMethod(s.loadTracker, ctx, method, resolution, types.RpcErrorForbidden, true, rpcLog()); rpcErr != nil {
+		if rpcErr.IsOverloaded() {
+			return batchOverloadedElement(elem)
+		}
+		return batchForbiddenElement(elem)
 	}
 
 	// rippled validates the method field and emits a distinct message per
@@ -451,58 +623,26 @@ func (s *Server) dispatchBatchElement(el json.RawMessage, baseCtx context.Contex
 	// (ServerHandler.cpp:764-808).
 	mv, present := elem["method"]
 	if !present || mv == nil {
+		chargeLoad(s.loadTracker, ctx, method, loadtrack.LoadMalformed, rpcLog())
 		return batchMalformedElement(elem, "Null method")
 	}
 	method, ok := mv.(string)
 	if !ok {
+		chargeLoad(s.loadTracker, ctx, method, loadtrack.LoadMalformed, rpcLog())
 		return batchMalformedElement(elem, "method is not string")
 	}
 	if method == "" {
+		chargeLoad(s.loadTracker, ctx, method, loadtrack.LoadMalformed, rpcLog())
 		return batchMalformedElement(elem, "method is empty")
 	}
-
-	ctx := newRpcContext(baseCtx, role, types.DefaultApiVersion, clientIP, s.loadPeerSource(), s.services)
-	if ver, ok := apiVersionFromBatchElement(elem); ok {
-		ctx.ApiVersion = ver
+	if _, valid := ripplerpcVersion(elem); !valid {
+		chargeLoad(s.loadTracker, ctx, method, loadtrack.LoadMalformed, rpcLog())
+		return batchMalformedElement(elem, "ripplerpc is not a string")
 	}
 
-	result, rpcErr := s.executeMethod(method, el, ctx)
+	result, rpcErr := dispatchResolvedMethod(s.loadTracker, s.services, ctx, method, el, resolution, rpcLog())
 
-	// rippled rejects an unsupported api_version per batch element with
-	// {request: <element>, error: make_json_error(wrong_version,
-	// "invalid_API_version")} — a JSON-RPC error object, not the XRPL result
-	// envelope (ServerHandler.cpp:692-697). The element is echoed raw (its own
-	// fields, no injected `command`), so redact credentials but keep the shape.
-	if rpcErr != nil && rpcErr.IsInvalidApiVersion() {
-		echo := make(map[string]any, len(elem))
-		maps.Copy(echo, elem)
-		redactCredentials(echo)
-		return map[string]any{
-			"request": echo,
-			"error":   makeBatchJSONError(types.WrongVersionJSONRPCCode, types.InvalidApiVersionToken),
-		}
-	}
-
-	// rippled rejects a batch element whose caller is over its per-IP budget at
-	// the overload-admission layer, ahead of FORBID: the echoed element plus
-	// make_json_error(server_overloaded, "Server is overloaded")
-	// (ServerHandler.cpp:735-746). Like the single path, this precedes the FORBID
-	// branch below.
-	if rpcErr != nil && rpcErr.IsOverloaded() {
-		return batchOverloadedElement(elem)
-	}
-
-	// rippled renders a batch element denied at the role layer as the echoed
-	// element plus a make_json_error(forbidden, "Forbidden") object — the
-	// malformed-element early-exit shape, not the XRPL result envelope
-	// (ServerHandler.cpp:758-760).
-	if rpcErr != nil && rpcErr.IsForbidden() {
-		return batchForbiddenElement(elem)
-	}
-
-	echo := make(map[string]any, len(elem)+1)
-	maps.Copy(echo, elem)
-	redactCredentials(echo)
+	echo := redactedRequestMap(elem)
 	echo["command"] = method
 	return buildXrplResponseBody(echo, result, rpcErr, loadWarningOpts(ctx))
 }
@@ -540,12 +680,10 @@ func makeBatchJSONError(code int, message string) map[string]any {
 }
 
 // batchMalformedElement builds the reply for a method-less batch element: the
-// element's own fields are echoed at the top level — unmasked, matching
-// rippled's early-exit paths which echo the raw element (ServerHandler.cpp:764-808) —
-// with a method_not_found JSON-RPC error attached.
+// element's own fields are echoed at the top level with credentials redacted
+// and a method_not_found JSON-RPC error attached.
 func batchMalformedElement(elem map[string]any, message string) map[string]any {
-	r := make(map[string]any, len(elem)+1)
-	maps.Copy(r, elem)
+	r := redactedRequestMap(elem)
 	r["error"] = makeBatchJSONError(rpcMethodNotFoundCode, message)
 	return r
 }
@@ -553,11 +691,10 @@ func batchMalformedElement(elem map[string]any, message string) map[string]any {
 // batchForbiddenElement builds the reply for a batch element whose admin-only
 // command is refused for a non-admin caller. Like rippled's FORBID branch
 // (ServerHandler.cpp:758-760), the element's own fields are echoed at the top
-// level — unmasked, matching the other early-exit paths — with a forbidden
-// JSON-RPC error attached, rather than the XRPL result envelope.
+// level with credentials redacted and a forbidden JSON-RPC error attached,
+// rather than the XRPL result envelope.
 func batchForbiddenElement(elem map[string]any) map[string]any {
-	r := make(map[string]any, len(elem)+1)
-	maps.Copy(r, elem)
+	r := redactedRequestMap(elem)
 	r["error"] = makeBatchJSONError(forbiddenJSONRPCCode, "Forbidden")
 	return r
 }
@@ -565,11 +702,10 @@ func batchForbiddenElement(elem map[string]any) map[string]any {
 // batchOverloadedElement builds the reply for a batch element whose caller is
 // over its per-IP resource budget. Like rippled's overload branch
 // (ServerHandler.cpp:742-746), the element's own fields are echoed at the top
-// level — unmasked, matching the other early-exit paths — with a
-// server_overloaded JSON-RPC error attached, rather than the XRPL result envelope.
+// level with credentials redacted and a server_overloaded JSON-RPC error
+// attached, rather than the XRPL result envelope.
 func batchOverloadedElement(elem map[string]any) map[string]any {
-	r := make(map[string]any, len(elem)+1)
-	maps.Copy(r, elem)
+	r := redactedRequestMap(elem)
 	r["error"] = makeBatchJSONError(serverOverloadedJSONRPCCode, "Server is overloaded")
 	return r
 }
@@ -577,16 +713,40 @@ func batchOverloadedElement(elem map[string]any) map[string]any {
 // apiVersionFromBatchElement resolves a batch element's api_version, preferring
 // params[0].api_version and falling back to a top-level api_version, mirroring
 // rippled's two-level lookup (ServerHandler.cpp:668-683).
-func apiVersionFromBatchElement(elem map[string]any) (int, bool) {
-	if params, ok := elem["params"].([]any); ok && len(params) > 0 {
-		if first, ok := params[0].(map[string]any); ok {
-			if v, ok := first["api_version"].(float64); ok {
-				return int(v), true
+func apiVersionFromBatchElement(raw json.RawMessage) (int, bool) {
+	var elem map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &elem); err != nil {
+		return 0, false
+	}
+	nestedDefault := false
+	if paramsRaw, exists := elem["params"]; exists {
+		var params []json.RawMessage
+		if err := json.Unmarshal(paramsRaw, &params); err == nil && len(params) > 0 {
+			var first map[string]json.RawMessage
+			if err := json.Unmarshal(params[0], &first); err == nil {
+				value, present := first["api_version"]
+				if present {
+					version, valid := strictAPIVersion(value)
+					if !valid {
+						return types.ApiVersion1 - 1, true
+					}
+					if version != types.DefaultApiVersion {
+						return version, true
+					}
+					nestedDefault = true
+				}
 			}
 		}
 	}
-	if v, ok := elem["api_version"].(float64); ok {
-		return int(v), true
+	if value, exists := elem["api_version"]; exists {
+		version, valid := strictAPIVersion(value)
+		if !valid {
+			return types.ApiVersion1 - 1, true
+		}
+		return version, true
+	}
+	if nestedDefault {
+		return types.DefaultApiVersion, true
 	}
 	return 0, false
 }
@@ -613,16 +773,20 @@ func newRpcContext(ctx context.Context, role types.Role, apiVersion int, clientI
 	}
 }
 
-// credentialKeys are request fields masked in error envelopes.
-// rippled (ServerHandler.cpp:535-542) masks only the lowercase
-// top-level keys "passphrase", "secret", "seed", "seed_hex"; goxrpl
-// extends that list with the PascalCase variants used by some clients
-// and traverses into the nested "tx_json" / "transaction" objects
-// (see redactCredentials). This is a strict superset of rippled —
-// masking more, never less.
+// credentialKeys are request fields masked in error envelopes. Matching is
+// case-insensitive and recursive so alternate client spellings cannot bypass
+// redaction.
 var credentialKeys = []string{
-	"secret", "seed", "passphrase", "seed_hex",
-	"Secret", "Seed", "Passphrase", "SeedHex",
+	"secret",
+	"seed",
+	"passphrase",
+	"seed_hex",
+	"seedhex",
+	"password",
+	"url_password",
+	"urlpassword",
+	"admin_password",
+	"adminpassword",
 }
 
 // maskedValue is the literal rippled writes in place of credential
@@ -630,21 +794,81 @@ var credentialKeys = []string{
 // debugging client can see a credential was supplied.
 const maskedValue = "<masked>"
 
-func redactCredentials(m map[string]any) {
-	for _, k := range credentialKeys {
-		if _, ok := m[k]; ok {
-			m[k] = maskedValue
-		}
+func redactedRequestMap(request map[string]any) map[string]any {
+	if request == nil {
+		return nil
 	}
-	for _, nested := range []string{"tx_json", "transaction"} {
-		if sub, ok := m[nested].(map[string]any); ok {
-			redactCredentials(sub)
+	return redactJSONValue(request).(map[string]any)
+}
+
+func redactJSONValue(value any) any {
+	switch value := value.(type) {
+	case map[string]any:
+		redacted := make(map[string]any, len(value))
+		for key, item := range value {
+			if isCredentialKey(key) {
+				redacted[key] = maskedValue
+				continue
+			}
+			if strings.EqualFold(key, "url") {
+				if rawURL, ok := item.(string); ok && urlContainsUserinfo(rawURL) {
+					redacted[key] = maskedValue
+					continue
+				}
+			}
+			redacted[key] = redactJSONValue(item)
 		}
+		return redacted
+	case []any:
+		redacted := make([]any, len(value))
+		for i, item := range value {
+			redacted[i] = redactJSONValue(item)
+		}
+		return redacted
+	default:
+		return value
 	}
 }
 
+func urlContainsUserinfo(rawURL string) bool {
+	parsed, err := url.Parse(rawURL)
+	if err == nil && parsed.User != nil {
+		return true
+	}
+
+	authority := rawURL
+	if _, after, ok := strings.Cut(authority, "://"); ok {
+		authority = after
+	} else if strings.HasPrefix(authority, "//") {
+		authority = authority[2:]
+	} else {
+		return false
+	}
+	if end := strings.IndexAny(authority, "/?#"); end >= 0 {
+		authority = authority[:end]
+	}
+	return strings.Contains(authority, "@")
+}
+
+func isCredentialKey(key string) bool {
+	for _, credentialKey := range credentialKeys {
+		if strings.EqualFold(key, credentialKey) {
+			return true
+		}
+	}
+	return false
+}
+
+func rpcInternalError() *types.RpcError {
+	return types.RpcErrorInternal()
+}
+
 func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types.RpcContext) (any, *types.RpcError) {
-	rpcLog().Debug("rpc", "method", method, "client", ctx.ClientIP)
+	clientIP := ""
+	if ctx != nil {
+		clientIP = ctx.ClientIP
+	}
+	rpcLog().Debug("rpc", "method", method, "client", clientIP)
 	// Both transports signal a forbidden admin-only command via RpcErrorForbidden.
 	// rippled resolves it at the role layer (Role::FORBID) ahead of the handler
 	// and renders it per transport — HTTP single 403 "Forbidden", batch
@@ -654,28 +878,19 @@ func (s *Server) executeMethod(method string, params json.RawMessage, ctx *types
 	return dispatchMethod(s.registry, s.loadTracker, s.services, ctx, method, params, types.RpcErrorForbidden, rpcLog())
 }
 
-// dispatchMethod is the transport-agnostic dispatch core shared by the HTTP
-// (Server.executeMethod) and WebSocket (WebSocketServer.handleRPCMethod)
-// paths. Hoisting it keeps the two transports from drifting (the WS path
-// previously skipped conditionMet). The only transport-specific bit is the
-// admin-gate error, supplied by adminGate.
-//
-// The gate order spans rippled's two layers: the per-IP overload check and the
-// role-layer FORBID short-circuit both fire in ServerHandler::processRequest
-// *before* doCommand, while the job-queue busy gate lives inside fillHandler.
-// The effective sequence is:
-//
-//	api-version (400) → overload (503) → FORBID (403) → busy (rpcTOO_BUSY) →
-//	unknown-command → conditionMet → handle → load finalize
-//
-// The overload admission (usage.disconnect()) precedes FORBID: a forbidden admin
-// request from a caller already over its per-IP budget is denied 503 "Server is
-// overloaded", not 403 (ServerHandler.cpp:735 ahead of :750). FORBID in turn
-// precedes busy: a forbidden admin request under queue saturation is denied 403,
-// not rpcTOO_BUSY. busy still precedes the unknown-command failure, so an
-// unresolved command under saturation stays rpcTOO_BUSY (a command that does not
-// resolve — unknown, or known but not served at the requested api_version — is
-// never forbidden; rippled's roleRequired yields GUEST for it).
+type methodResolution struct {
+	handler  types.MethodHandler
+	resolved bool
+}
+
+func resolveMethod(registry *types.MethodRegistry, method string, apiVersion int) methodResolution {
+	handler, exists := registry.Get(method)
+	return methodResolution{
+		handler:  handler,
+		resolved: exists && handlerSupportsVersion(handler, apiVersion),
+	}
+}
+
 func dispatchMethod(
 	registry *types.MethodRegistry,
 	tracker *loadtrack.Tracker,
@@ -686,58 +901,63 @@ func dispatchMethod(
 	adminGate func(string) *types.RpcError,
 	log xrpllog.Logger,
 ) (any, *types.RpcError) {
-	// Resolve the handler without yet failing: the api-version and FORBID gates
-	// run ahead of the unknown-command failure, with the busy gate between them.
-	handler, exists := registry.Get(method)
-
-	// The api_version range is handler-independent and rejected ahead of command
-	// resolution.
 	if rpcErr := validateApiVersion(ctx); rpcErr != nil {
 		return nil, rpcErr
 	}
-
-	// A known command whose handler does not serve the requested (in-range)
-	// api_version resolves to "unknown command", mirroring rippled's getHandler
-	// returning null on a name match with no version-range match
-	// (Handler.cpp:265-272) → rpcUNKNOWN_COMMAND, not invalid_API_version. Such a
-	// request is also not forbidden: rippled's roleRequired yields GUEST when the
-	// lookup misses, deferring to the busy-then-unknown-command path below.
-	resolved := exists && handlerSupportsVersion(handler, ctx.ApiVersion)
-
-	// The per-IP resource-overload admission check runs before FORBID and busy,
-	// mirroring usage.disconnect() consulted ahead of doCommand and the FORBID
-	// short-circuit (ServerHandler.cpp:735 ahead of :750). A caller already over
-	// its budget is denied here (503 "Server is overloaded") regardless of whether
-	// the command is forbidden, unknown, or saturated. Admin / unlimited callers
-	// no-op (matching isUnlimited taking the newUnlimitedEndpoint branch).
-	if rpcErr := gateLoad(tracker, ctx, method, log); rpcErr != nil {
+	resolution := resolveMethod(registry, method, ctx.ApiVersion)
+	if rpcErr := admitMethod(tracker, ctx, method, resolution, adminGate, true, log); rpcErr != nil {
 		return nil, rpcErr
 	}
+	return dispatchResolvedMethod(tracker, services, ctx, method, params, resolution, log)
+}
 
-	// Refuse an admin-only command for a non-admin caller. rippled decides this
-	// at the role layer (Role::FORBID) before doCommand runs and charges
-	// feeMalformedRPC (ServerHandler.cpp:750-762, :482-486). The gate returns
-	// before the normal finalizeLoad site, so charge here; loadKindFor maps the
-	// forbidden error to the malformed bucket.
-	if resolved && handler.RequiredRole() == types.RoleAdmin && ctx.Role != types.RoleAdmin {
+func admitMethod(
+	tracker *loadtrack.Tracker,
+	ctx *types.RpcContext,
+	method string,
+	resolution methodResolution,
+	adminGate func(string) *types.RpcError,
+	checkLoad bool,
+	log xrpllog.Logger,
+) *types.RpcError {
+	if checkLoad {
+		if rpcErr := gateLoad(tracker, ctx, method, log); rpcErr != nil {
+			return rpcErr
+		}
+	}
+	if resolution.resolved && resolution.handler.RequiredRole() == types.RoleAdmin && ctx.Role != types.RoleAdmin {
 		rpcErr := adminGate(method)
-		finalizeLoad(tracker, ctx, method, handler, rpcErr, log)
-		return nil, rpcErr
+		chargeLoad(tracker, ctx, method, loadtrack.LoadMalformed, log)
+		return rpcErr
 	}
+	return nil
+}
 
-	// The job-queue busy gate sheds after FORBID but before the unknown-command
-	// failure (RPCHandler.cpp:132-141, ahead of :143-164).
+func dispatchResolvedMethod(
+	tracker *loadtrack.Tracker,
+	services *types.ServiceContainer,
+	ctx *types.RpcContext,
+	method string,
+	params json.RawMessage,
+	resolution methodResolution,
+	log xrpllog.Logger,
+) (any, *types.RpcError) {
+	ctx.LoadCost = loadtrack.ChargeReference
+	ctx.LoadWarning = false
+
 	if rpcErr := handlers.RequireNotBusyClient(ctx); rpcErr != nil {
+		finalizeLoad(tracker, ctx, method, loadtrack.LoadReference, log)
 		return nil, rpcErr
 	}
 
-	if !resolved {
-		return nil, types.RpcErrorMethodNotFound(method)
+	if !resolution.resolved {
+		rpcErr := types.RpcErrorMethodNotFound()
+		finalizeLoad(tracker, ctx, method, loadtrack.LoadReference, log)
+		return nil, rpcErr
 	}
 
-	// Enforce the method's precondition, mirroring rippled's RPC::conditionMet
-	// (Handler.h:78-139), after the admin gate (RPCHandler.cpp:169).
-	if rpcErr := conditionMet(handler.RequiredCondition(), ctx); rpcErr != nil {
+	if rpcErr := conditionMet(resolution.handler.RequiredCondition(), ctx); rpcErr != nil {
+		finalizeLoad(tracker, ctx, method, loadtrack.LoadReference, log)
 		return nil, rpcErr
 	}
 
@@ -745,9 +965,83 @@ func dispatchMethod(
 		services.ClientLoad.Begin()
 		defer services.ClientLoad.End()
 	}
-	result, rpcErr := handler.Handle(ctx, params)
-	finalizeLoad(tracker, ctx, method, handler, rpcErr, log)
+	result, rpcErr, recovered := invokeHandler(resolution.handler, ctx, params, method, log)
+	kind := loadtrack.LoadKind(ctx.LoadCost)
+	if recovered && kind == loadtrack.LoadReference {
+		kind = loadtrack.LoadException
+	}
+	finalizeLoad(tracker, ctx, method, kind, log)
 	return result, rpcErr
+}
+
+func dispatchNestedMethod(
+	registry *types.MethodRegistry,
+	ctx *types.RpcContext,
+	method string,
+	params json.RawMessage,
+	log xrpllog.Logger,
+) (any, *types.RpcError) {
+	if rpcErr := validateApiVersion(ctx); rpcErr != nil {
+		return nil, rpcErr
+	}
+	resolution := resolveMethod(registry, method, ctx.ApiVersion)
+	if !resolution.resolved {
+		return nil, types.RpcErrorMethodNotFound()
+	}
+	if resolution.handler.RequiredRole() == types.RoleAdmin && ctx.Role != types.RoleAdmin {
+		ctx.LoadCost = loadtrack.ChargeMalformed
+		return nil, types.RpcErrorForbidden(method)
+	}
+	if rpcErr := conditionMet(resolution.handler.RequiredCondition(), ctx); rpcErr != nil {
+		return nil, rpcErr
+	}
+	result, rpcErr, recovered := invokeHandler(resolution.handler, ctx, params, method, log)
+	if recovered && ctx.LoadCost == loadtrack.ChargeReference {
+		ctx.LoadCost = loadtrack.ChargeException
+	}
+	return result, rpcErr
+}
+
+func invokeHandler(handler types.MethodHandler, ctx *types.RpcContext, params json.RawMessage, method string, log xrpllog.Logger) (result any, rpcErr *types.RpcError, recovered bool) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			clientIP := ""
+			if ctx != nil {
+				clientIP = ctx.ClientIP
+			}
+			log.Error("rpc handler panic", "err", rec, "stack", string(debug.Stack()), "method", method, "client", clientIP)
+			result = nil
+			rpcErr = rpcInternalError()
+			recovered = true
+		}
+	}()
+	result, rpcErr = handler.Handle(ctx, redactStructuredID(params))
+	return result, rpcErr, false
+}
+
+func redactStructuredID(params json.RawMessage) json.RawMessage {
+	if len(params) == 0 {
+		return params
+	}
+	var request map[string]any
+	if err := decodeJSONUseNumber(params, &request); err != nil || request == nil {
+		return params
+	}
+	id, ok := request["id"]
+	if !ok {
+		return params
+	}
+	switch id.(type) {
+	case map[string]any, []any:
+		request["id"] = redactJSONValue(id)
+	default:
+		return params
+	}
+	redacted, err := json.Marshal(request)
+	if err != nil {
+		return params
+	}
+	return redacted
 }
 
 // betaEnabled reports whether the operator turned on the beta RPC API for
@@ -823,20 +1117,17 @@ func conditionMet(cond types.Condition, ctx *types.RpcContext) *types.RpcError {
 	info := svc.GetServerInfo()
 
 	if !atLeastSyncing(info.ServerState) {
-		return notSyncedError(ctx.ApiVersion, types.RpcNO_NETWORK, "noNetwork",
-			"Not synced to the network.")
+		return notSyncedError(ctx.ApiVersion, syncFailureNoNetwork)
 	}
 
 	if !info.Standalone {
 		if validatedLedgerStale(info) || info.OpenLedgerSeq+10 < info.ValidatedLedgerSeq {
-			return notSyncedError(ctx.ApiVersion, types.RpcNO_CURRENT, "noCurrent",
-				"Current ledger is unavailable.")
+			return notSyncedError(ctx.ApiVersion, syncFailureNoCurrent)
 		}
 	}
 
 	if info.ClosedLedgerSeq == 0 {
-		return notSyncedError(ctx.ApiVersion, types.RpcNO_CLOSED, "noClosed",
-			"Closed ledger is unavailable.")
+		return notSyncedError(ctx.ApiVersion, syncFailureNoClosed)
 	}
 
 	return nil
@@ -884,31 +1175,34 @@ func validatedLedgerStale(info types.LedgerServerInfo) bool {
 	return age > int64(maxValidatedLedgerAge/time.Second)
 }
 
-// notSyncedError returns the apiVersion-1 code with its token/message, or
-// rpcNOT_SYNCED for later versions, mirroring rippled conditionMet.
-func notSyncedError(apiVersion, v1Code int, v1Token, v1Message string) *types.RpcError {
+type syncFailure uint8
+
+const (
+	syncFailureNoNetwork syncFailure = iota
+	syncFailureNoCurrent
+	syncFailureNoClosed
+)
+
+func notSyncedError(apiVersion int, failure syncFailure) *types.RpcError {
 	if apiVersion == types.ApiVersion1 {
-		return types.NewRpcError(v1Code, v1Token, v1Token, v1Message)
+		switch failure {
+		case syncFailureNoCurrent:
+			return types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent", "Current ledger is unavailable.")
+		case syncFailureNoClosed:
+			return types.NewRpcError(types.RpcNO_CLOSED, "noClosed", "noClosed", "Closed ledger is unavailable.")
+		default:
+			return types.NewRpcError(types.RpcNO_NETWORK, "noNetwork", "noNetwork", "Not synced to the network.")
+		}
 	}
 	return types.NewRpcError(types.RpcNOT_SYNCED, "notSynced", "notSynced",
 		"Not synced to the network.")
 }
 
-// gateLoad is the pre-dispatch overload admission check, run ahead of the FORBID
-// and busy gates. It does NOT charge the caller; it only rejects when the
-// (decayed) balance is already at or above DropThreshold. Mirrors rippled
-// ServerHandler.cpp:735 where usage.disconnect() is consulted *before* the FORBID
-// short-circuit and doCommand, returning without charging feeMalformedRPC. The
-// rejection carries the overloaded flag so the transport writers render rippled's
-// 503 "Server is overloaded" (single) / make_json_error(server_overloaded) (batch).
-//
-// Admin / identified callers bypass tracking entirely, matching rippled
-// isUnlimited() (Role.cpp:124-128).
 func gateLoad(tracker *loadtrack.Tracker, ctx *types.RpcContext, method string, log xrpllog.Logger) *types.RpcError {
-	if tracker == nil || ctx.Unlimited {
+	if tracker == nil || ctx == nil || ctx.Unlimited {
 		return nil
 	}
-	if tracker.OverDropThreshold(ctx.ClientIP) {
+	if tracker.Disconnect(ctx.ClientIP) {
 		log.Warn("rpc dropped: client over load threshold",
 			"client", ctx.ClientIP, "method", method, "balance", tracker.Balance(ctx.ClientIP))
 		return types.RpcErrorOverloaded()
@@ -916,48 +1210,32 @@ func gateLoad(tracker *loadtrack.Tracker, ctx *types.RpcContext, method string, 
 	return nil
 }
 
-// finalizeLoad is the post-dispatch charge step. The charge applied is
-// LoadMalformed when the handler returned an invalidParams / methodNotFound
-// error (rippled bumps loadType to feeMalformedRPC for the same condition
-// in RPCHandler.cpp:211-215 and ServerHandler.cpp:766-808). Otherwise
-// the handler's declared LoadKind (or LoadReference) is used.
-//
-// Admin / identified callers bypass tracking entirely.
-func finalizeLoad(tracker *loadtrack.Tracker, ctx *types.RpcContext, method string, handler types.MethodHandler, rpcErr *types.RpcError, log xrpllog.Logger) {
-	if tracker == nil || ctx.Unlimited {
+func chargeLoad(tracker *loadtrack.Tracker, ctx *types.RpcContext, method string, kind loadtrack.LoadKind, log xrpllog.Logger) {
+	if tracker == nil || ctx == nil || ctx.Unlimited {
 		return
 	}
-	kind := loadKindFor(handler, rpcErr)
 	switch tracker.Charge(ctx.ClientIP, kind) {
 	case loadtrack.OutcomeDrop:
 		log.Warn("rpc client crossed drop threshold (post-charge)",
 			"client", ctx.ClientIP, "method", method, "balance", tracker.Balance(ctx.ClientIP))
 	case loadtrack.OutcomeWarn:
-		// Surface rippled's warning:"load" on the reply (ServerHandler.cpp:519,920).
-		ctx.LoadWarning = true
 		log.Info("rpc client over warn threshold",
 			"client", ctx.ClientIP, "method", method, "balance", tracker.Balance(ctx.ClientIP))
 	}
 }
 
-// loadKindFor returns the charge bucket to apply for one dispatch. A
-// malformed / unknown-method response, and a role-layer FORBID, are charged
-// LoadMalformed so a client cannot use bad input or admin-probing as a cheap
-// probe (matches rippled's feeMalformedRPC bump in RPCHandler.cpp /
-// ServerHandler.cpp:752,:484).
-func loadKindFor(handler types.MethodHandler, rpcErr *types.RpcError) loadtrack.LoadKind {
-	if rpcErr != nil {
-		switch rpcErr.Code {
-		case types.RpcINVALID_PARAMS, types.RpcMETHOD_NOT_FOUND, types.RpcFORBIDDEN:
-			return loadtrack.LoadMalformed
-		case types.RpcINTERNAL:
-			return loadtrack.LoadException
-		}
+func finalizeLoad(tracker *loadtrack.Tracker, ctx *types.RpcContext, method string, kind loadtrack.LoadKind, log xrpllog.Logger) {
+	chargeLoad(tracker, ctx, method, kind, log)
+	warnLoad(tracker, ctx, method, log)
+}
+
+func warnLoad(tracker *loadtrack.Tracker, ctx *types.RpcContext, method string, log xrpllog.Logger) {
+	if tracker == nil || ctx == nil || ctx.Unlimited || !tracker.Warn(ctx.ClientIP) {
+		return
 	}
-	if c, ok := handler.(LoadCharger); ok {
-		return c.LoadKind()
-	}
-	return loadtrack.LoadReference
+	ctx.LoadWarning = true
+	log.Info("rpc load warning issued",
+		"client", ctx.ClientIP, "method", method, "balance", tracker.Balance(ctx.ClientIP))
 }
 
 // loadWarningOpts returns response options carrying warning:"load" when the
@@ -971,12 +1249,12 @@ func loadWarningOpts(ctx *types.RpcContext) *JsonRpcResponseOptions {
 	return nil
 }
 
-// buildXrplResponseBody assembles the `{"result": {...}}` envelope for a single
-// dispatched request. It is shared by the single-request writer and by each
-// element of a batch envelope, so every batch reply has the same shape as a
-// standalone reply.
+// buildXrplResponseBody assembles one versioned JSON-RPC response. ripplerpc
+// 1.x uses the legacy result envelope; 2.x and later move errors to the top
+// level and preserve the request metadata alongside either result or error.
 func buildXrplResponseBody(request any, result any, rpcErr *types.RpcError, opts *JsonRpcResponseOptions) map[string]any {
 	response := make(map[string]any)
+	ripplerpc, _ := ripplerpcVersion(request)
 
 	var resultObj map[string]any
 	if rpcErr != nil {
@@ -984,18 +1262,16 @@ func buildXrplResponseBody(request any, result any, rpcErr *types.RpcError, opts
 			"status": "error",
 			"error":  rpcErr.ErrorString,
 		}
-		// rippled bare-token handlers emit only `error`; inject_error paths add
-		// error_code + error_message. Mirror both.
-		if !rpcErr.IsBareToken() {
+		if rpcErr.ErrorException != "" {
+			resultObj["error_exception"] = rpcErr.ErrorException
+		} else if !rpcErr.IsBareToken() {
 			resultObj["error_code"] = rpcErr.Code
 			resultObj["error_message"] = rpcErr.Message
 		}
-		if request != nil {
-			resultObj["request"] = request
-		}
 	} else if resultMap, ok := result.(map[string]any); ok {
-		resultMap["status"] = "success"
-		resultObj = resultMap
+		resultObj = make(map[string]any, len(resultMap)+1)
+		maps.Copy(resultObj, resultMap)
+		resultObj["status"] = "success"
 	} else {
 		resultObj = map[string]any{
 			"status": "success",
@@ -1011,7 +1287,28 @@ func buildXrplResponseBody(request any, result any, rpcErr *types.RpcError, opts
 			resultObj["warning"] = opts.Warning
 		}
 	}
-	response["result"] = resultObj
+	if rpcErr != nil && ripplerpc < "2.0" && request != nil {
+		resultObj["request"] = request
+	}
+	if rpcErr != nil && ripplerpc >= "2.0" {
+		if _, exists := resultObj["error_code"]; !exists {
+			resultObj["error_code"] = nil
+		}
+		resultObj["code"] = resultObj["error_code"]
+		resultObj["message"] = resultObj["error_message"]
+		delete(resultObj, "error_message")
+		response["error"] = resultObj
+	} else {
+		response["result"] = resultObj
+	}
+
+	if requestMap, ok := request.(map[string]any); ok {
+		for _, key := range []string{"jsonrpc", "ripplerpc", "id"} {
+			if value, exists := requestMap[key]; exists {
+				response[key] = value
+			}
+		}
+	}
 
 	if opts != nil {
 		if len(opts.Warnings) > 0 {
@@ -1027,87 +1324,75 @@ func buildXrplResponseBody(request any, result any, rpcErr *types.RpcError, opts
 
 func (s *Server) writeXrplResponseWithOptions(w http.ResponseWriter, request any, result any, rpcErr *types.RpcError, opts *JsonRpcResponseOptions) {
 	response := buildXrplResponseBody(request, result, rpcErr, opts)
-
-	// Stream-encode straight to the response writer through trimNewlineWriter.
-	// json.Encoder.Encode would otherwise emit a trailing '\n' that rippled's
-	// equivalent path does not produce, changing the byte-exact wire shape
-	// for parity-sensitive clients. Streaming avoids buffering large
-	// payloads (book_offers, ledger_data, ripple_path_find) into a []byte
-	// before w.Write; on encode error headers are already sent, so logging
-	// is the only honest signal.
-	//
-	// rpcTOO_BUSY maps to HTTP 503, matching rippled ErrorCodes.cpp:114
-	// (`{rpcTOO_BUSY, "tooBusy", ..., 503}`). The per-IP overload rejection is
-	// also a 503 (ServerHandler.cpp:739); the HTTP-single POST path renders its
-	// bare-string body earlier, so this branch only covers the GET extension,
-	// which keeps the result envelope. All other errors ride on 200 OK; XRPL
-	// clients parse result.error, not the HTTP status.
-	if rpcErr != nil && (rpcErr.Code == types.RpcTOO_BUSY || rpcErr.IsOverloaded()) {
-		w.WriteHeader(http.StatusServiceUnavailable)
-	} else {
-		w.WriteHeader(http.StatusOK)
+	status := http.StatusOK
+	ripplerpc, _ := ripplerpcVersion(request)
+	if rpcErr != nil {
+		if rpcErr.IsOverloaded() {
+			status = http.StatusServiceUnavailable
+		} else if ripplerpc >= "3.0" && rpcErr.ErrorException == "" && !rpcErr.IsBareToken() {
+			status = rpcErrorHTTPStatus(rpcErr.Code)
+		}
 	}
-	enc := json.NewEncoder(&trimNewlineWriter{w: w})
-	if err := enc.Encode(response); err != nil {
+	w.Header().Set("Content-Type", jsonContentType)
+	w.WriteHeader(status)
+	if err := writeJSONRPCBody(w, response); err != nil {
 		rpcLog().Error("Failed to encode response", "err", err)
 	}
 }
 
-// trimNewlineWriter wraps an io.Writer and discards a single trailing
-// newline byte across Write calls. json.Encoder.Encode always appends
-// '\n' after the JSON value; rippled's serialiser does not.
-type trimNewlineWriter struct {
-	w       io.Writer
-	pending bool // a '\n' was buffered from the previous Write
+func writeJSONRPCBody(w io.Writer, response any) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(response); err != nil {
+		return err
+	}
+	_, err := io.WriteString(w, "\r\n")
+	return err
 }
 
-func (t *trimNewlineWriter) Write(p []byte) (int, error) {
-	written := 0
-	if t.pending && len(p) > 0 {
-		if _, err := t.w.Write([]byte{'\n'}); err != nil {
-			return 0, err
-		}
-		t.pending = false
+func rpcErrorHTTPStatus(code int) int {
+	switch code {
+	case types.RpcLGR_NOT_VALIDATED:
+		return http.StatusAccepted
+	case types.RpcHIGH_FEE:
+		return http.StatusPaymentRequired
+	case types.RpcBAD_SECRET, types.RpcBAD_SEED, types.RpcFORBIDDEN, types.RpcMASTER_DISABLED:
+		return http.StatusForbidden
+	case types.RpcBAD_MARKET, types.RpcDST_ACT_NOT_FOUND, types.RpcLGR_NOT_FOUND,
+		types.RpcNO_PF_REQUEST, types.RpcOBJECT_NOT_FOUND, types.RpcSRC_ACT_NOT_FOUND,
+		types.RpcDELEGATE_ACT_NOT_FOUND, types.RpcTXN_NOT_FOUND:
+		return http.StatusNotFound
+	case types.RpcNO_EVENTS, types.RpcMETHOD_NOT_FOUND:
+		return http.StatusMethodNotAllowed
+	case types.RpcSLOW_DOWN:
+		return http.StatusTooManyRequests
+	case types.RpcNO_PERMISSION:
+		return http.StatusUnauthorized
+	case types.RpcDB_DESERIALIZATION:
+		return http.StatusBadGateway
+	case types.RpcNOT_ENABLED, types.RpcNOT_IMPL, types.RpcNOT_SUPPORTED:
+		return http.StatusNotImplemented
+	case types.RpcAMENDMENT_BLOCKED, types.RpcEXPIRED_VALIDATOR_LIST, types.RpcNOT_READY,
+		types.RpcNO_CLOSED, types.RpcNO_CURRENT, types.RpcNOT_SYNCED, types.RpcNO_NETWORK,
+		types.RpcWRONG_NETWORK, types.RpcTOO_BUSY:
+		return http.StatusServiceUnavailable
+	case types.RpcBAD_FEATURE, types.RpcINTERNAL, types.RpcJSON_RPC:
+		return http.StatusInternalServerError
+	case types.RpcATX_DEPRECATED, types.RpcBAD_KEY_TYPE, types.RpcBAD_ISSUER,
+		types.RpcBAD_SYNTAX, types.RpcCHANNEL_MALFORMED, types.RpcCHANNEL_AMT_MALFORMED,
+		types.RpcMISSING_COMMAND, types.RpcDST_ACT_MALFORMED, types.RpcDST_ACT_MISSING,
+		types.RpcDST_AMT_MALFORMED, types.RpcDST_AMT_MISSING, types.RpcDST_ISR_MALFORMED,
+		types.RpcEXCESSIVE_LGR_RANGE, types.RpcINVALID_LGR_RANGE, types.RpcINVALID_PARAMS,
+		types.RpcINVALID_HOTWALLET, types.RpcISSUE_MALFORMED, types.RpcLGR_IDXS_INVALID,
+		types.RpcLGR_IDX_MALFORMED, types.RpcPUBLIC_MALFORMED, types.RpcSENDMAX_MALFORMED,
+		types.RpcSIGNING_MALFORMED, types.RpcSRC_ACT_MALFORMED, types.RpcSRC_ACT_MISSING,
+		types.RpcSRC_CUR_MALFORMED, types.RpcSRC_ISR_MALFORMED, types.RpcSTREAM_MALFORMED,
+		types.RpcORACLE_MALFORMED, types.RpcBAD_CREDENTIALS, types.RpcTX_SIGNED,
+		types.RpcDOMAIN_MALFORMED:
+		return http.StatusBadRequest
+	default:
+		return http.StatusOK
 	}
-	if len(p) > 0 && p[len(p)-1] == '\n' {
-		t.pending = true
-		body := p[:len(p)-1]
-		if len(body) > 0 {
-			n, err := t.w.Write(body)
-			written = n
-			if err != nil {
-				return written, err
-			}
-		}
-		return written + 1, nil
-	}
-	n, err := t.w.Write(p)
-	return n, err
-}
-
-func (s *Server) writeXrplError(w http.ResponseWriter, request any, errorCode string, message string) {
-	resultObj := map[string]any{
-		"status":        "error",
-		"error":         errorCode,
-		"error_message": message,
-	}
-	if request != nil {
-		resultObj["request"] = request
-	}
-
-	response := map[string]any{
-		"result": resultObj,
-	}
-
-	responseData, err := json.Marshal(response)
-	if err != nil {
-		rpcLog().Error("Failed to marshal error response", "err", err)
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	w.Write(responseData)
 }
 
 // ExecuteMethod implements types.MethodDispatcher, allowing the 'json' RPC
@@ -1117,7 +1402,7 @@ func (s *Server) writeXrplError(w http.ResponseWriter, request any, errorCode st
 // client IP (a fresh guest/empty-IP context previously let `json` callers
 // dodge per-IP charging and escape the request timeout).
 func (s *Server) ExecuteMethod(ctx *types.RpcContext, method string, params []byte) (any, *types.RpcError) {
-	return s.executeMethod(method, json.RawMessage(params), ctx)
+	return dispatchNestedMethod(s.registry, ctx, method, json.RawMessage(params), rpcLog())
 }
 
 // isLocalhost returns true if the IP address is a loopback address.

--- a/internal/rpc/server_hardening_test.go
+++ b/internal/rpc/server_hardening_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -201,13 +202,15 @@ func TestCredentialsMaskedInErrorEnvelope(t *testing.T) {
 // TestHandlerPanicRecovered ensures a panicking handler returns an error
 // envelope to the client instead of crashing the server goroutine.
 func TestHandlerPanicRecovered(t *testing.T) {
+	const panicCause = "synthetic panic must stay private"
 	srv := newHardeningServer(t, time.Second, "panic", &stubHandler{
 		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
-			panic("synthetic panic")
+			panic(panicCause)
 		},
 	})
+	srv.loadTracker = loadtrack.New()
 
-	req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"panic","params":[{}]}`))
+	req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"panic","params":[{"secret":"private seed"}]}`))
 	req.RemoteAddr = "203.0.113.5:1234"
 	rr := httptest.NewRecorder()
 
@@ -216,9 +219,44 @@ func TestHandlerPanicRecovered(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
-	result := decodeEnvelope(t, rr.Body.Bytes())
-	if result["error"] != "internal" {
-		t.Fatalf("expected error=internal after panic, got %v\nbody: %s", result["error"], rr.Body.String())
+	const want = "{\"result\":{\"error\":\"internal\",\"error_code\":73,\"error_message\":\"Internal error.\",\"request\":{\"command\":\"panic\",\"secret\":\"<masked>\"},\"status\":\"error\"}}\n\r\n"
+	if got := rr.Body.String(); got != want {
+		t.Fatalf("panic response = %s, want %s", got, want)
+	}
+	if strings.Contains(rr.Body.String(), panicCause) || strings.Contains(rr.Body.String(), "private seed") {
+		t.Fatalf("panic response leaked private details: %s", rr.Body.String())
+	}
+	if got, want := srv.loadTracker.Balance("203.0.113.5"), float64(loadtrack.ChargeException/uint32(loadtrack.DecayWindow/time.Second)); got != want {
+		t.Fatalf("panic charged %v, want %v", got, want)
+	}
+}
+
+type failingReader struct {
+	err error
+}
+
+func (r failingReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func TestRequestBodyReadErrorIsCanonical(t *testing.T) {
+	const privateCause = "private request body failure"
+	srv := newHardeningServer(t, time.Second, "ping", &stubHandler{})
+	req := httptest.NewRequest(http.MethodPost, "/", failingReader{err: errors.New(privateCause)})
+	req.RemoteAddr = "203.0.113.5:1234"
+	rr := httptest.NewRecorder()
+
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	const want = "{\"result\":{\"error\":\"internal\",\"error_code\":73,\"error_message\":\"Internal error.\",\"status\":\"error\"}}\n\r\n"
+	if got := rr.Body.String(); got != want {
+		t.Fatalf("read-error response = %s, want %s", got, want)
+	}
+	if strings.Contains(rr.Body.String(), privateCause) {
+		t.Fatalf("read-error response leaked cause: %s", rr.Body.String())
 	}
 }
 
@@ -291,12 +329,12 @@ func TestSecureGatewayPromotesToIdentifiedWithUser(t *testing.T) {
 	}
 }
 
-// heavyStub is a stub MethodHandler that declares LoadHeavy via the
-// optional LoadCharger interface — used to exercise the per-IP load
-// budget rejection path.
 type heavyStub struct{ stubHandler }
 
-func (heavyStub) LoadKind() loadtrack.LoadKind { return loadtrack.LoadHeavy }
+func (s *heavyStub) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+	ctx.LoadCost = loadtrack.ChargeHeavy
+	return s.stubHandler.Handle(ctx, params)
+}
 
 // Once the per-IP balance crosses DropThreshold, the overload-admission gate
 // (gateLoad) rejects with rippled's canonical HTTP 503 "Server is overloaded"
@@ -306,7 +344,7 @@ func TestLoadTracker_RejectsAfterDropThreshold(t *testing.T) {
 	srv.loadTracker = loadtrack.New()
 
 	var lastBody string
-	for range 12 {
+	for range 400 {
 		req := httptest.NewRequest("POST", "/", strings.NewReader(`{"method":"path_find","params":[{}]}`))
 		req.RemoteAddr = "198.51.100.7:5555"
 		rr := httptest.NewRecorder()
@@ -323,7 +361,7 @@ func TestLoadTracker_RejectsAfterDropThreshold(t *testing.T) {
 			return
 		}
 	}
-	t.Fatalf("never received HTTP 503 after 12 heavy invocations; last body %s", lastBody)
+	t.Fatalf("never received HTTP 503 after 400 heavy invocations; last body %s", lastBody)
 }
 
 func TestLoadTracker_AdminBypassesCharge(t *testing.T) {

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -577,7 +577,7 @@ func TestServerInfoServiceUnavailable(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // TestServerInfoServiceNilLedger tests behavior when ledger service is nil
@@ -595,7 +595,7 @@ func TestServerInfoServiceNilLedger(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // Method Metadata Tests
@@ -917,7 +917,7 @@ func TestServerStateServiceUnavailable(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // Integration-like Tests

--- a/internal/rpc/sign_test.go
+++ b/internal/rpc/sign_test.go
@@ -399,7 +399,7 @@ func TestSign_LedgerServiceUnavailable(t *testing.T) {
 	_, err := handler.Handle(ctx, params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcINTERNAL, err.Code)
-	assert.Contains(t, err.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", err.Message)
 }
 
 func TestSign_OfflineMode(t *testing.T) {
@@ -1488,7 +1488,7 @@ func TestSubmitMultisigned_LedgerServiceUnavailable(t *testing.T) {
 	}`)
 	_, err := handler.Handle(ctx, params)
 	require.NotNil(t, err)
-	assert.Contains(t, err.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", err.Message)
 }
 
 func TestSubmitMultisigned_Metadata(t *testing.T) {

--- a/internal/rpc/stored_transaction_test.go
+++ b/internal/rpc/stored_transaction_test.go
@@ -1,0 +1,222 @@
+package rpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	txpkg "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type storedTransactionDataCase struct {
+	name string
+	data []byte
+}
+
+func validStoredPaymentTransaction() map[string]any {
+	return map[string]any{
+		"TransactionType": "Payment",
+		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+		"Amount":          "1000000",
+		"Fee":             "10",
+		"Sequence":        1,
+		"SigningPubKey":   "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+		"TxnSignature":    "30440220143759437C04F7B61F012563AFE90D8DAFC46E86035E1D965A9CED282C97D4CE02204CFD241E86F17E011298FC1A39B63386C74306A5DE047E213B0F29EFA4571C2C",
+	}
+}
+
+func validStoredMetadata() map[string]any {
+	return map[string]any{
+		"TransactionResult": "tesSUCCESS",
+		"TransactionIndex":  0,
+		"AffectedNodes":     []any{},
+	}
+}
+
+func validStoredMetadataWithAffectedNode() map[string]any {
+	meta := validStoredMetadata()
+	meta["AffectedNodes"] = []any{map[string]any{
+		"CreatedNode": map[string]any{
+			"LedgerEntryType": "AccountRoot",
+			"LedgerIndex":     "1111111111111111111111111111111111111111111111111111111111111111",
+			"NewFields": map[string]any{
+				"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			},
+		},
+	}}
+	return meta
+}
+
+func TestDecodeTxBlobCanonicalizesJSONStoredObjects(t *testing.T) {
+	txJSON := validStoredPaymentTransaction()
+	meta := validStoredMetadataWithAffectedNode()
+	created := meta["AffectedNodes"].([]any)[0].(map[string]any)["CreatedNode"]
+	meta["AffectedNodes"] = []any{map[string]any{
+		"CreatedNode": created,
+		"ModifiedNode": map[string]any{
+			"LedgerEntryType": "AccountRoot",
+			"LedgerIndex":     "2222222222222222222222222222222222222222222222222222222222222222",
+			"FinalFields":     map[string]any{},
+		},
+	}}
+
+	stored, err := decodeTxBlob(marshalStoredTransaction(t, txJSON, meta, true))
+	require.NoError(t, err)
+	require.IsType(t, uint32(0), stored.TxJSON["Sequence"])
+	nodes, ok := stored.Meta["AffectedNodes"].([]any)
+	require.True(t, ok)
+	require.Len(t, nodes, 2)
+	for _, rawNode := range nodes {
+		node, ok := rawNode.(map[string]any)
+		require.True(t, ok)
+		require.Len(t, node, 1)
+	}
+}
+
+func marshalStoredTransaction(t *testing.T, txJSON map[string]any, meta any, includeMeta bool) []byte {
+	t.Helper()
+	stored := map[string]any{"tx_json": txJSON}
+	if includeMeta {
+		stored["meta"] = meta
+	}
+	data, err := json.Marshal(stored)
+	require.NoError(t, err)
+	return data
+}
+
+func corruptedStoredTransactionData(t *testing.T) []storedTransactionDataCase {
+	t.Helper()
+
+	validTx := validStoredPaymentTransaction()
+	txBytes, err := binarycodec.EncodeBytes(validTx)
+	require.NoError(t, err)
+	vlTx, err := txpkg.EncodeWithVL(txBytes)
+	require.NoError(t, err)
+
+	incompleteTxBytes, err := binarycodec.EncodeBytes(map[string]any{"TransactionType": "Payment"})
+	require.NoError(t, err)
+	vlIncompleteTx, err := txpkg.EncodeWithVL(incompleteTxBytes)
+	require.NoError(t, err)
+	vlEmptyMeta, err := txpkg.EncodeWithVL(nil)
+	require.NoError(t, err)
+	incompleteVLTransaction := append(append([]byte(nil), vlIncompleteTx...), vlEmptyMeta...)
+
+	vlMeta, err := txpkg.EncodeWithVL([]byte{0xff})
+	require.NoError(t, err)
+	malformedMetadata := append(append([]byte(nil), vlTx...), vlMeta...)
+	missingDestination := validStoredPaymentTransaction()
+	delete(missingDestination, "Destination")
+	wrongSequenceType := validStoredPaymentTransaction()
+	wrongSequenceType["Sequence"] = "one"
+	fractionalSequence := validStoredPaymentTransaction()
+	fractionalSequence["Sequence"] = 1.5
+	fractionalMetaIndex := validStoredMetadata()
+	fractionalMetaIndex["TransactionIndex"] = 1.5
+	badAffectedNodesType := validStoredMetadata()
+	badAffectedNodesType["AffectedNodes"] = "not an array"
+	return []storedTransactionDataCase{
+		{name: "invalid JSON", data: []byte("not valid json")},
+		{name: "JSON null", data: []byte(`null`)},
+		{name: "empty JSON object", data: []byte(`{}`)},
+		{name: "missing tx_json", data: []byte(`{"meta":{}}`)},
+		{name: "null tx_json", data: []byte(`{"tx_json":null,"meta":{}}`)},
+		{name: "empty tx_json", data: []byte(`{"tx_json":{},"meta":{}}`)},
+		{name: "non-object tx_json", data: []byte(`{"tx_json":"corrupt transaction"}`)},
+		{name: "non-string transaction type", data: []byte(`{"tx_json":{"TransactionType":7}}`)},
+		{name: "unknown transaction type", data: []byte(`{"tx_json":{"TransactionType":"Unknown"}}`)},
+		{name: "missing required transaction field", data: marshalStoredTransaction(t, missingDestination, nil, false)},
+		{name: "wrong transaction field type", data: marshalStoredTransaction(t, wrongSequenceType, nil, false)},
+		{name: "fractional integer transaction field", data: marshalStoredTransaction(t, fractionalSequence, nil, false)},
+		{name: "scalar metadata", data: marshalStoredTransaction(t, validTx, "corrupt metadata", true)},
+		{name: "fractional metadata index", data: marshalStoredTransaction(t, validTx, fractionalMetaIndex, true)},
+		{name: "wrong AffectedNodes type", data: marshalStoredTransaction(t, validTx, badAffectedNodesType, true)},
+		{name: "incomplete VL transaction", data: incompleteVLTransaction},
+		{name: "malformed non-empty VL metadata", data: malformedMetadata},
+	}
+}
+
+func txMetadataCorruptionData(t *testing.T) []storedTransactionDataCase {
+	t.Helper()
+	validTx := validStoredPaymentTransaction()
+	missingResult := validStoredMetadata()
+	delete(missingResult, "TransactionResult")
+	missingAffectedNodes := map[string]any{
+		"TransactionResult": "tesSUCCESS",
+		"TransactionIndex":  0,
+	}
+	txBytes, err := binarycodec.EncodeBytes(validTx)
+	require.NoError(t, err)
+	metaBytes, err := binarycodec.EncodeBytes(missingAffectedNodes)
+	require.NoError(t, err)
+	vlTx, err := txpkg.EncodeWithVL(txBytes)
+	require.NoError(t, err)
+	vlMeta, err := txpkg.EncodeWithVL(metaBytes)
+	require.NoError(t, err)
+	return []storedTransactionDataCase{
+		{name: "missing required JSON metadata field", data: marshalStoredTransaction(t, validTx, missingResult, true)},
+		{name: "VL metadata missing AffectedNodes", data: append(append([]byte(nil), vlTx...), vlMeta...)},
+	}
+}
+
+func storedTransactionDataWithoutMetadata(t *testing.T) []storedTransactionDataCase {
+	t.Helper()
+	validTx := validStoredPaymentTransaction()
+	txBytes, err := binarycodec.EncodeBytes(validTx)
+	require.NoError(t, err)
+	vlTx, err := txpkg.EncodeWithVL(txBytes)
+	require.NoError(t, err)
+	vlEmptyMeta, err := txpkg.EncodeWithVL(nil)
+	require.NoError(t, err)
+	vlTxWithEmptyMeta := append(append([]byte(nil), vlTx...), vlEmptyMeta...)
+	return []storedTransactionDataCase{
+		{name: "metadata absent", data: marshalStoredTransaction(t, validTx, nil, false)},
+		{name: "metadata null", data: marshalStoredTransaction(t, validTx, nil, true)},
+		{name: "VL metadata absent", data: vlTx},
+		{name: "VL metadata empty", data: vlTxWithEmptyMeta},
+	}
+}
+
+func storedTransactionDataWithMetadata(t *testing.T) []storedTransactionDataCase {
+	t.Helper()
+	validTx := validStoredPaymentTransaction()
+	validMeta := validStoredMetadataWithAffectedNode()
+	txBytes, err := binarycodec.EncodeBytes(validTx)
+	require.NoError(t, err)
+	metaBytes, err := binarycodec.EncodeBytes(validMeta)
+	require.NoError(t, err)
+	vlTx, err := txpkg.EncodeWithVL(txBytes)
+	require.NoError(t, err)
+	vlMeta, err := txpkg.EncodeWithVL(metaBytes)
+	require.NoError(t, err)
+	vlData := append(append([]byte(nil), vlTx...), vlMeta...)
+	return []storedTransactionDataCase{
+		{name: "JSON", data: marshalStoredTransaction(t, validTx, validMeta, true)},
+		{name: "VL", data: vlData},
+	}
+}
+
+func requireDBDeserializationError(t *testing.T, result any, rpcErr *types.RpcError) {
+	t.Helper()
+
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcDB_DESERIALIZATION, rpcErr.Code)
+	assert.Equal(t, "dbDeserialization", rpcErr.ErrorString)
+	assert.Equal(t, "dbDeserialization", rpcErr.Type)
+	assert.Equal(t, "Database deserialization error.", rpcErr.Message)
+}
+
+func requireCanonicalInternalError(t *testing.T, result any, rpcErr *types.RpcError) {
+	t.Helper()
+
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+	assert.Equal(t, "internal", rpcErr.ErrorString)
+	assert.Equal(t, "internal", rpcErr.Type)
+	assert.Equal(t, "Internal error.", rpcErr.Message)
+}

--- a/internal/rpc/stored_transaction_test.go
+++ b/internal/rpc/stored_transaction_test.go
@@ -51,32 +51,6 @@ func validStoredMetadataWithAffectedNode() map[string]any {
 	return meta
 }
 
-func TestDecodeTxBlobCanonicalizesJSONStoredObjects(t *testing.T) {
-	txJSON := validStoredPaymentTransaction()
-	meta := validStoredMetadataWithAffectedNode()
-	created := meta["AffectedNodes"].([]any)[0].(map[string]any)["CreatedNode"]
-	meta["AffectedNodes"] = []any{map[string]any{
-		"CreatedNode": created,
-		"ModifiedNode": map[string]any{
-			"LedgerEntryType": "AccountRoot",
-			"LedgerIndex":     "2222222222222222222222222222222222222222222222222222222222222222",
-			"FinalFields":     map[string]any{},
-		},
-	}}
-
-	stored, err := decodeTxBlob(marshalStoredTransaction(t, txJSON, meta, true))
-	require.NoError(t, err)
-	require.IsType(t, uint32(0), stored.TxJSON["Sequence"])
-	nodes, ok := stored.Meta["AffectedNodes"].([]any)
-	require.True(t, ok)
-	require.Len(t, nodes, 2)
-	for _, rawNode := range nodes {
-		node, ok := rawNode.(map[string]any)
-		require.True(t, ok)
-		require.Len(t, node, 1)
-	}
-}
-
 func marshalStoredTransaction(t *testing.T, txJSON map[string]any, meta any, includeMeta bool) []byte {
 	t.Helper()
 	stored := map[string]any{"tx_json": txJSON}

--- a/internal/rpc/submit_multisigned_test.go
+++ b/internal/rpc/submit_multisigned_test.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
@@ -378,6 +379,29 @@ func TestSubmitMultisigned_HappyPath(t *testing.T) {
 	respTxJSON, ok := resp["tx_json"].(map[string]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, respTxJSON["hash"])
+}
+
+func TestSubmitMultisigned_SubmissionErrorUsesFixedMessage(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	mock.submitError = errors.New("backend submission detail")
+	services := newSubmitTestServices(mock)
+
+	handler := &handlers.SubmitMultisignedMethod{}
+	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
+
+	txJSON := validMultisignedTxJSON()
+	txJSON["Destination"] = "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
+	signer := txJSON["Signers"].([]any)[0].(map[string]any)["Signer"].(map[string]any)
+	signer["Account"] = "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
+
+	result, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+	assert.Equal(t, "internal", rpcErr.ErrorString)
+	assert.Equal(t, "Exception occurred during transaction submission.", rpcErr.Message)
+	assert.NotContains(t, rpcErr.Message, mock.submitError.Error())
 }
 
 // TestSubmitMultisigned_ValidationOrder_TxnSignatureBeforeFee verifies that

--- a/internal/rpc/submit_test.go
+++ b/internal/rpc/submit_test.go
@@ -733,24 +733,20 @@ func TestSubmitMethodSubmitError(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		submitError   error
-		expectedError string
+		name        string
+		submitError error
 	}{
 		{
-			name:          "Internal error",
-			submitError:   errors.New("internal ledger error"),
-			expectedError: "Failed to submit transaction",
+			name:        "Internal error",
+			submitError: errors.New("internal ledger error"),
 		},
 		{
-			name:          "Network error",
-			submitError:   errors.New("network unavailable"),
-			expectedError: "Failed to submit transaction",
+			name:        "Network error",
+			submitError: errors.New("network unavailable"),
 		},
 		{
-			name:          "Validation error",
-			submitError:   errors.New("transaction validation failed"),
-			expectedError: "Failed to submit transaction",
+			name:        "Validation error",
+			submitError: errors.New("transaction validation failed"),
 		},
 	}
 
@@ -773,7 +769,9 @@ func TestSubmitMethodSubmitError(t *testing.T) {
 
 			assert.Nil(t, result)
 			require.NotNil(t, rpcErr)
-			assert.Contains(t, rpcErr.Message, tc.expectedError)
+			assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+			assert.Equal(t, "Internal error.", rpcErr.Message)
+			assert.NotContains(t, rpcErr.Message, tc.submitError.Error())
 		})
 	}
 }

--- a/internal/rpc/submit_test.go
+++ b/internal/rpc/submit_test.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"testing"
 
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/stretchr/testify/assert"
@@ -287,6 +288,29 @@ func TestSubmitMethodValidTxJson(t *testing.T) {
 
 			tc.validateResp(t, respMap)
 		})
+	}
+}
+
+func TestSubmitMethodStoredMetadataIncludesAffectedNodes(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion1,
+		Services:   newSubmitTestServices(mock),
+	}
+	params, err := json.Marshal(map[string]any{"tx_json": validStoredPaymentTransaction()})
+	require.NoError(t, err)
+
+	_, rpcErr := (&handlers.SubmitMethod{}).Handle(ctx, params)
+	require.Nil(t, rpcErr)
+	require.Len(t, mock.storedTxs, 1)
+	for _, storedData := range mock.storedTxs {
+		var stored handlers.StoredTransaction
+		require.NoError(t, json.Unmarshal(storedData, &stored))
+		nodes, ok := stored.Meta["AffectedNodes"].([]any)
+		require.True(t, ok)
+		assert.Empty(t, nodes)
 	}
 }
 
@@ -687,7 +711,7 @@ func TestSubmitMethodServiceUnavailable(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // TestSubmitMethodServiceNilLedger tests behavior when ledger service is nil
@@ -716,7 +740,7 @@ func TestSubmitMethodServiceNilLedger(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // TestSubmitMethodSubmitError tests handling of ledger service errors
@@ -770,10 +794,45 @@ func TestSubmitMethodSubmitError(t *testing.T) {
 			assert.Nil(t, result)
 			require.NotNil(t, rpcErr)
 			assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-			assert.Equal(t, "Internal error.", rpcErr.Message)
+			assert.Equal(t, "Exception occurred during transaction submission.", rpcErr.Message)
 			assert.NotContains(t, rpcErr.Message, tc.submitError.Error())
 		})
 	}
+}
+
+func TestSubmitMethodTxBlobSubmitErrorIsSanitized(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	submitErr := errors.New("private ledger backend failure")
+	mock.submitError = submitErr
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion1,
+		Services:   newSubmitTestServices(mock),
+	}
+	txBlob, err := binarycodec.Encode(map[string]any{
+		"TransactionType": "Payment",
+		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+		"Amount":          "1000000",
+		"Fee":             "10",
+		"Sequence":        1,
+		"SigningPubKey":   "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+		"TxnSignature":    "30440220143759437C04F7B61F012563AFE90D8DAFC46E86035E1D965A9CED282C97D4CE02204CFD241E86F17E011298FC1A39B63386C74306A5DE047E213B0F29EFA4571C2C",
+	})
+	require.NoError(t, err)
+	params, err := json.Marshal(map[string]any{"tx_blob": txBlob})
+	require.NoError(t, err)
+
+	result, rpcErr := (&handlers.SubmitMethod{}).Handle(ctx, params)
+
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+	assert.Equal(t, "internal", rpcErr.ErrorString)
+	assert.Equal(t, "internal", rpcErr.Type)
+	assert.Equal(t, "Exception occurred during transaction submission.", rpcErr.Message)
+	assert.NotContains(t, rpcErr.Message, submitErr.Error())
 }
 
 // TestSubmitMethodMetadata tests the method's metadata functions

--- a/internal/rpc/subscribe_test.go
+++ b/internal/rpc/subscribe_test.go
@@ -1807,6 +1807,7 @@ func TestWebSocketSnapshot_Single(t *testing.T) {
 		types.Amount{Currency: "XRP"},
 		types.Amount{Currency: "USD", Issuer: "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},
 		"",
+		"",
 	)
 	require.NoError(t, err)
 	require.Len(t, offers, 2)
@@ -1829,9 +1830,9 @@ func TestWebSocketSnapshot_Both(t *testing.T) {
 	ws := &WebSocketServer{services: services}
 	ctx := &types.RpcContext{Context: context.Background(), Services: services}
 
-	bids, err := ws.snapshotBook(ctx, types.Amount{Currency: "XRP"}, types.Amount{Currency: "USD", Issuer: gateway}, "")
+	bids, err := ws.snapshotBook(ctx, types.Amount{Currency: "XRP"}, types.Amount{Currency: "USD", Issuer: gateway}, "", "")
 	require.NoError(t, err)
-	asks, err := ws.snapshotBook(ctx, types.Amount{Currency: "USD", Issuer: gateway}, types.Amount{Currency: "XRP"}, "")
+	asks, err := ws.snapshotBook(ctx, types.Amount{Currency: "USD", Issuer: gateway}, types.Amount{Currency: "XRP"}, "", "")
 	require.NoError(t, err)
 	require.Len(t, mock.calls, 2, "both:true snapshot must issue one GetBookOffers per side")
 	require.Equal(t, "rBid", bids[0].Account)

--- a/internal/rpc/subscription/manager.go
+++ b/internal/rpc/subscription/manager.go
@@ -178,7 +178,7 @@ func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.Subscri
 				return rpcErr
 			}
 			normalised = append(normalised, book)
-			if book.Both {
+			if book.Both || book.BothSides {
 				normalised = append(normalised, reverseBook(book))
 			}
 		}
@@ -225,7 +225,9 @@ func reverseBook(b types.BookRequest) types.BookRequest {
 		TakerPays: b.TakerGets,
 		TakerGets: b.TakerPays,
 		Snapshot:  b.Snapshot,
+		StateNow:  b.StateNow,
 		Both:      false,
+		BothSides: false,
 		Taker:     b.Taker,
 		Domain:    b.Domain,
 	}
@@ -682,7 +684,7 @@ func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.Subsc
 				return rpcErr
 			}
 			toRemove = append(toRemove, book)
-			if book.Both {
+			if book.Both || book.BothSides {
 				toRemove = append(toRemove, reverseBook(book))
 			}
 		}

--- a/internal/rpc/transaction_entry_test.go
+++ b/internal/rpc/transaction_entry_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -265,14 +266,8 @@ func TestTransactionEntryLedgerResolution(t *testing.T) {
 	copy(txHash[:], txHashBytes)
 
 	storedTx := map[string]any{
-		"tx_json": map[string]any{
-			"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-			"TransactionType": "Payment",
-			"Fee":             "10",
-		},
-		"meta": map[string]any{
-			"TransactionResult": "tesSUCCESS",
-		},
+		"tx_json": validStoredPaymentTransaction(),
+		"meta":    validStoredMetadata(),
 	}
 	txData, _ := json.Marshal(storedTx)
 
@@ -435,13 +430,8 @@ func TestTransactionEntryTxNotInRequestedLedger(t *testing.T) {
 	txHashStr := "E2FE8D4AF3FCC3944DDF6CD8CDDC5E3F0AD50863EF8919AFEF10CB6408CD4D05"
 
 	storedTx := map[string]any{
-		"tx_json": map[string]any{
-			"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-			"TransactionType": "Payment",
-		},
-		"meta": map[string]any{
-			"TransactionResult": "tesSUCCESS",
-		},
+		"tx_json": validStoredPaymentTransaction(),
+		"meta":    validStoredMetadata(),
 	}
 	txData, _ := json.Marshal(storedTx)
 
@@ -488,17 +478,9 @@ func TestTransactionEntryResponseStructure(t *testing.T) {
 
 	txHashStr := "E2FE8D4AF3FCC3944DDF6CD8CDDC5E3F0AD50863EF8919AFEF10CB6408CD4D05"
 
-	storedTx := map[string]any{
-		"tx_json": map[string]any{
-			"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-			"TransactionType": "Payment",
-			"Fee":             "10",
-			"Sequence":        float64(3),
-		},
-		"meta": map[string]any{
-			"TransactionResult": "tesSUCCESS",
-		},
-	}
+	txJSON := validStoredPaymentTransaction()
+	txJSON["Sequence"] = 3
+	storedTx := map[string]any{"tx_json": txJSON, "meta": validStoredMetadata()}
 	txData, _ := json.Marshal(storedTx)
 
 	mock.transactions[txHashStr] = &types.TransactionInfo{
@@ -554,6 +536,116 @@ func TestTransactionEntryResponseStructure(t *testing.T) {
 	assert.Equal(t, "tesSUCCESS", meta["TransactionResult"])
 }
 
+func TestTransactionEntryCorruptedStoredDataIsSanitized(t *testing.T) {
+	mock := newMockLedgerServiceTE()
+	ledger := newMockLedgerReaderTE(2)
+	mock.addLedger(ledger)
+
+	txHash := "E2FE8D4AF3FCC3944DDF6CD8CDDC5E3F0AD50863EF8919AFEF10CB6408CD4D05"
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   newTransactionEntryTestServices(mock),
+	}
+	params, err := json.Marshal(map[string]any{"tx_hash": txHash, "ledger_index": ledger.seq})
+	require.NoError(t, err)
+
+	for _, tc := range corruptedStoredTransactionData(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			mock.transactions[txHash] = &types.TransactionInfo{
+				TxData:      tc.data,
+				LedgerIndex: ledger.seq,
+				Validated:   true,
+			}
+
+			result, rpcErr := (&handlers.TransactionEntryMethod{}).Handle(ctx, params)
+
+			requireCanonicalInternalError(t, result, rpcErr)
+		})
+	}
+}
+
+func TestTransactionEntryStoredDataWithoutMetadata(t *testing.T) {
+	mock := newMockLedgerServiceTE()
+	ledger := newMockLedgerReaderTE(2)
+	mock.addLedger(ledger)
+
+	txHash := "E2FE8D4AF3FCC3944DDF6CD8CDDC5E3F0AD50863EF8919AFEF10CB6408CD4D05"
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   newTransactionEntryTestServices(mock),
+	}
+	params, err := json.Marshal(map[string]any{"tx_hash": txHash, "ledger_index": ledger.seq})
+	require.NoError(t, err)
+
+	for _, tc := range storedTransactionDataWithoutMetadata(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			mock.transactions[txHash] = &types.TransactionInfo{
+				TxData:      tc.data,
+				LedgerIndex: ledger.seq,
+				Validated:   true,
+			}
+
+			for _, apiVersion := range []int{types.ApiVersion1, types.ApiVersion2} {
+				t.Run(fmt.Sprintf("API v%d", apiVersion), func(t *testing.T) {
+					requestCtx := *ctx
+					requestCtx.ApiVersion = apiVersion
+					result, rpcErr := (&handlers.TransactionEntryMethod{}).Handle(&requestCtx, params)
+					if tc.name == "VL metadata absent" {
+						requireCanonicalInternalError(t, result, rpcErr)
+						return
+					}
+
+					require.Nil(t, rpcErr)
+					response, ok := result.(map[string]any)
+					require.True(t, ok)
+					txJSON, ok := response["tx_json"].(map[string]any)
+					require.True(t, ok)
+					assert.Equal(t, "Payment", txJSON["TransactionType"])
+					if tc.name == "VL metadata empty" {
+						key := "metadata"
+						if apiVersion > types.ApiVersion1 {
+							key = "meta"
+						}
+						assert.Equal(t, map[string]any{}, response[key])
+					} else {
+						assert.NotContains(t, response, "metadata")
+						assert.NotContains(t, response, "meta")
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestTransactionEntryAcceptsGenericCodecMetadata(t *testing.T) {
+	mock := newMockLedgerServiceTE()
+	ledger := newMockLedgerReaderTE(2)
+	mock.addLedger(ledger)
+	const txHash = "E2FE8D4AF3FCC3944DDF6CD8CDDC5E3F0AD50863EF8919AFEF10CB6408CD4D05"
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   newTransactionEntryTestServices(mock),
+	}
+	params, err := json.Marshal(map[string]any{"tx_hash": txHash, "ledger_index": ledger.seq})
+	require.NoError(t, err)
+
+	for _, tc := range txMetadataCorruptionData(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			mock.transactions[txHash] = &types.TransactionInfo{TxData: tc.data, LedgerIndex: ledger.seq, Validated: true}
+			result, rpcErr := (&handlers.TransactionEntryMethod{}).Handle(ctx, params)
+			require.Nil(t, rpcErr)
+			response := result.(map[string]any)
+			require.IsType(t, map[string]any{}, response["metadata"])
+		})
+	}
+}
+
 // TestTransactionEntryServiceUnavailable tests behavior when ledger service is not available.
 func TestTransactionEntryServiceUnavailable(t *testing.T) {
 	method := &handlers.TransactionEntryMethod{}
@@ -577,7 +669,7 @@ func TestTransactionEntryServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 
 	t.Run("Services.Ledger is nil", func(t *testing.T) {
@@ -599,7 +691,7 @@ func TestTransactionEntryServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 }
 
@@ -636,10 +728,8 @@ func TestTransactionEntryInvalidLedgerHash(t *testing.T) {
 	txHashStr := "E2FE8D4AF3FCC3944DDF6CD8CDDC5E3F0AD50863EF8919AFEF10CB6408CD4D05"
 
 	storedTx := map[string]any{
-		"tx_json": map[string]any{
-			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-		},
-		"meta": map[string]any{},
+		"tx_json": validStoredPaymentTransaction(),
+		"meta":    validStoredMetadata(),
 	}
 	txData, _ := json.Marshal(storedTx)
 	mock.transactions[txHashStr] = &types.TransactionInfo{

--- a/internal/rpc/transaction_entry_test.go
+++ b/internal/rpc/transaction_entry_test.go
@@ -534,6 +534,7 @@ func TestTransactionEntryResponseStructure(t *testing.T) {
 	meta, ok := resp["metadata"].(map[string]any)
 	require.True(t, ok, "metadata must be an object")
 	assert.Equal(t, "tesSUCCESS", meta["TransactionResult"])
+	assert.NotContains(t, meta, "DeliveredAmount")
 }
 
 func TestTransactionEntryCorruptedStoredDataIsSanitized(t *testing.T) {

--- a/internal/rpc/transport_conformance_test.go
+++ b/internal/rpc/transport_conformance_test.go
@@ -1,0 +1,277 @@
+package rpc
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+func postTransportRequest(t *testing.T, server *Server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.RemoteAddr = "203.0.113.5:1234"
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func TestHTTPRipplerpcVersionedInternalError(t *testing.T) {
+	server := newHardeningServer(t, time.Second, "fail", &stubHandler{
+		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+			return nil, rpcInternalError()
+		},
+	})
+
+	tests := []struct {
+		version string
+		status  int
+		want    string
+	}{
+		{
+			version: "1.0",
+			status:  http.StatusOK,
+			want:    "{\"id\":7,\"jsonrpc\":\"2.0\",\"result\":{\"error\":\"internal\",\"error_code\":73,\"error_message\":\"Internal error.\",\"request\":{\"command\":\"fail\",\"id\":7,\"jsonrpc\":\"2.0\",\"ripplerpc\":\"1.0\",\"secret\":\"<masked>\"},\"status\":\"error\"},\"ripplerpc\":\"1.0\"}\n\r\n",
+		},
+		{
+			version: "2.0",
+			status:  http.StatusOK,
+			want:    "{\"error\":{\"code\":73,\"error\":\"internal\",\"error_code\":73,\"message\":\"Internal error.\",\"status\":\"error\"},\"id\":7,\"jsonrpc\":\"2.0\",\"ripplerpc\":\"2.0\"}\n\r\n",
+		},
+		{
+			version: "2.00",
+			status:  http.StatusOK,
+			want:    "{\"error\":{\"code\":73,\"error\":\"internal\",\"error_code\":73,\"message\":\"Internal error.\",\"status\":\"error\"},\"id\":7,\"jsonrpc\":\"2.0\",\"ripplerpc\":\"2.00\"}\n\r\n",
+		},
+		{
+			version: "3.0",
+			status:  http.StatusInternalServerError,
+			want:    "{\"error\":{\"code\":73,\"error\":\"internal\",\"error_code\":73,\"message\":\"Internal error.\",\"status\":\"error\"},\"id\":7,\"jsonrpc\":\"2.0\",\"ripplerpc\":\"3.0\"}\n\r\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.version, func(t *testing.T) {
+			body := `{"method":"fail","params":[{"id":7,"jsonrpc":"2.0","ripplerpc":"` + test.version + `","secret":"private seed"}]}`
+			recorder := postTransportRequest(t, server, body)
+			if recorder.Code != test.status {
+				t.Fatalf("status = %d, want %d; body: %s", recorder.Code, test.status, recorder.Body.String())
+			}
+			if got := recorder.Header().Get("Content-Type"); got != jsonContentType {
+				t.Fatalf("content type = %q, want %q", got, jsonContentType)
+			}
+			if got := recorder.Body.String(); got != test.want {
+				t.Fatalf("body = %q, want %q", got, test.want)
+			}
+			if strings.Contains(recorder.Body.String(), "private seed") {
+				t.Fatalf("response leaked credential: %s", recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestHTTPRipplerpcV3StatusMapping(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		rpcErr  *types.RpcError
+		status  int
+	}{
+		{name: "v2 too busy remains 200", version: "2.0", rpcErr: types.RpcErrorTooBusy(), status: http.StatusOK},
+		{name: "v3 too busy", version: "3.0", rpcErr: types.RpcErrorTooBusy(), status: http.StatusServiceUnavailable},
+		{name: "v3 database deserialization", version: "3.0", rpcErr: types.RpcErrorDBDeserialization(), status: http.StatusBadGateway},
+		{name: "v3 invalid params", version: "3.0", rpcErr: types.RpcErrorInvalidParams("Invalid parameters."), status: http.StatusBadRequest},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := newHardeningServer(t, time.Second, "fail", &stubHandler{
+				handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+					return nil, test.rpcErr
+				},
+			})
+			recorder := postTransportRequest(t, server, `{"method":"fail","params":[{"ripplerpc":"`+test.version+`"}]}`)
+			if recorder.Code != test.status {
+				t.Fatalf("status = %d, want %d; body: %s", recorder.Code, test.status, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestHTTPResponseFraming(t *testing.T) {
+	t.Run("normal", func(t *testing.T) {
+		server := newHardeningServer(t, time.Second, "ping", &stubHandler{})
+		recorder := postTransportRequest(t, server, `{"method":"ping","params":[{}]}`)
+		const want = "{\"result\":{\"ok\":true,\"status\":\"success\"}}\n\r\n"
+		if got := recorder.Body.String(); got != want {
+			t.Fatalf("body = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("batch", func(t *testing.T) {
+		server := newHardeningServer(t, time.Second, "ping", &stubHandler{})
+		recorder := postTransportRequest(t, server, `{"method":"batch","params":[]}`)
+		if got := recorder.Body.String(); got != "[]\n\r\n" {
+			t.Fatalf("body = %q, want empty batch framing", got)
+		}
+	})
+
+	t.Run("plain error", func(t *testing.T) {
+		server := newHardeningServer(t, time.Second, "ping", &stubHandler{})
+		recorder := postTransportRequest(t, server, `{"method":"batch","params":null}`)
+		if recorder.Code != http.StatusBadRequest || recorder.Body.String() != "Malformed batch request\r\n" {
+			t.Fatalf("status/body = %d/%q", recorder.Code, recorder.Body.String())
+		}
+		if got := recorder.Header().Get("Content-Type"); got != jsonContentType {
+			t.Fatalf("content type = %q, want %q", got, jsonContentType)
+		}
+	})
+
+	t.Run("versioned success metadata", func(t *testing.T) {
+		server := newHardeningServer(t, time.Second, "ping", &stubHandler{})
+		recorder := postTransportRequest(t, server, `{"method":"ping","params":[{"id":7,"jsonrpc":"2.0","ripplerpc":"2.0"}]}`)
+		const want = "{\"id\":7,\"jsonrpc\":\"2.0\",\"result\":{\"ok\":true,\"status\":\"success\"},\"ripplerpc\":\"2.0\"}\n\r\n"
+		if recorder.Code != http.StatusOK || recorder.Body.String() != want {
+			t.Fatalf("status/body = %d/%q, want 200/%q", recorder.Code, recorder.Body.String(), want)
+		}
+	})
+}
+
+func TestHTTPParamsShape(t *testing.T) {
+	var observed string
+	server := newHardeningServer(t, time.Second, "capture", &stubHandler{
+		handle: func(_ *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+			observed = string(params)
+			return map[string]any{"ok": true}, nil
+		},
+	})
+
+	valid := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "missing", body: `{"method":"capture"}`, want: `{}`},
+		{name: "top-level null", body: `{"method":"capture","params":null}`, want: `{}`},
+		{name: "array null", body: `{"method":"capture","params":[null]}`, want: `null`},
+		{name: "object", body: `{"method":"capture","params":[{}]}`, want: `{}`},
+	}
+	for _, test := range valid {
+		t.Run(test.name, func(t *testing.T) {
+			observed = ""
+			recorder := postTransportRequest(t, server, test.body)
+			if recorder.Code != http.StatusOK || observed != test.want {
+				t.Fatalf("status/params = %d/%q, want 200/%q", recorder.Code, observed, test.want)
+			}
+		})
+	}
+
+	invalid := []string{
+		`{"method":"capture","params":[]}`,
+		`{"method":"capture","params":[{},{}]}`,
+		`{"method":"capture","params":["x"]}`,
+	}
+	for _, body := range invalid {
+		recorder := postTransportRequest(t, server, body)
+		if recorder.Code != http.StatusBadRequest || recorder.Body.String() != "params unparseable\r\n" {
+			t.Fatalf("body %s produced %d/%q", body, recorder.Code, recorder.Body.String())
+		}
+	}
+}
+
+func TestHTTPRipplerpcValidation(t *testing.T) {
+	server := newHardeningServer(t, time.Second, "ping", &stubHandler{})
+
+	single := postTransportRequest(t, server, `{"method":"ping","params":[{"ripplerpc":2}]}`)
+	if single.Code != http.StatusBadRequest || single.Body.String() != "ripplerpc is not a string\r\n" {
+		t.Fatalf("single status/body = %d/%q", single.Code, single.Body.String())
+	}
+
+	batch := postTransportRequest(t, server, `{"method":"batch","params":[{"method":"ping","ripplerpc":2}]}`)
+	const wantBatch = "[{\"error\":{\"error\":{\"code\":-32601,\"message\":\"ripplerpc is not a string\"}},\"method\":\"ping\",\"ripplerpc\":2}]\n\r\n"
+	if batch.Code != http.StatusOK || batch.Body.String() != wantBatch {
+		t.Fatalf("batch status/body = %d/%q", batch.Code, batch.Body.String())
+	}
+}
+
+func TestHTTPErrorExceptionEnvelope(t *testing.T) {
+	server := newHardeningServer(t, time.Second, "simulate", &stubHandler{
+		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+			return nil, types.RpcErrorInvalidTransaction("invalid transaction detail")
+		},
+	})
+	recorder := postTransportRequest(t, server, `{"method":"simulate","params":[{"id":9,"secret":"private seed"}]}`)
+	const want = "{\"id\":9,\"result\":{\"error\":\"invalidTransaction\",\"error_exception\":\"invalid transaction detail\",\"request\":{\"command\":\"simulate\",\"id\":9,\"secret\":\"<masked>\"},\"status\":\"error\"}}\n\r\n"
+	if recorder.Code != http.StatusOK || recorder.Body.String() != want {
+		t.Fatalf("status/body = %d/%q, want 200/%q", recorder.Code, recorder.Body.String(), want)
+	}
+	if strings.Contains(recorder.Body.String(), "error_code") || strings.Contains(recorder.Body.String(), "error_message") {
+		t.Fatalf("manual error gained injected fields: %s", recorder.Body.String())
+	}
+}
+
+func TestHTTPRipplerpcV2SparseErrorFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		rpcErr *types.RpcError
+		want   string
+	}{
+		{
+			name:   "exception",
+			rpcErr: types.RpcErrorInvalidTransaction("invalid transaction detail"),
+			want:   "{\"error\":{\"code\":null,\"error\":\"invalidTransaction\",\"error_code\":null,\"error_exception\":\"invalid transaction detail\",\"message\":null,\"status\":\"error\"},\"id\":9,\"ripplerpc\":\"2.0\"}\n\r\n",
+		},
+		{
+			name:   "bare token",
+			rpcErr: types.RpcErrorEntryNotFound("Entry not found."),
+			want:   "{\"error\":{\"code\":null,\"error\":\"entryNotFound\",\"error_code\":null,\"message\":null,\"status\":\"error\"},\"id\":9,\"ripplerpc\":\"2.0\"}\n\r\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := newHardeningServer(t, time.Second, "fail", &stubHandler{
+				handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+					return nil, test.rpcErr
+				},
+			})
+			recorder := postTransportRequest(t, server, `{"method":"fail","params":[{"id":9,"ripplerpc":"2.0"}]}`)
+			if recorder.Code != http.StatusOK || recorder.Body.String() != test.want {
+				t.Fatalf("status/body = %d/%q, want 200/%q", recorder.Code, recorder.Body.String(), test.want)
+			}
+		})
+	}
+}
+
+func TestHTTPApiVersionRequiresJSONInteger(t *testing.T) {
+	server := newHardeningServer(t, time.Second, "ping", &stubHandler{})
+	for _, rawVersion := range []string{`"2"`, `1.5`, `1.0`, `1e0`} {
+		t.Run(rawVersion, func(t *testing.T) {
+			recorder := postTransportRequest(t, server, `{"method":"ping","params":[{"api_version":`+rawVersion+`}]}`)
+			if recorder.Code != http.StatusBadRequest || recorder.Body.String() != "invalid_API_version\r\n" {
+				t.Fatalf("status/body = %d/%q", recorder.Code, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestHTTPApiVersionValidationPrecedesMethodValidation(t *testing.T) {
+	server := newHardeningServer(t, time.Second, "ping", &stubHandler{})
+	recorder := postTransportRequest(t, server, `{"params":[{"api_version":"2"}]}`)
+	if recorder.Code != http.StatusBadRequest || recorder.Body.String() != "invalid_API_version\r\n" {
+		t.Fatalf("status/body = %d/%q", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestBatchApiVersionRequiresJSONIntegerAndPrecedesMethodValidation(t *testing.T) {
+	server := newHardeningServer(t, time.Second, "ping", &stubHandler{})
+	recorder := postTransportRequest(t, server, `{"method":"batch","params":[{"method":7,"api_version":1e0,"id":4294967295}]}`)
+	const want = "[{\"error\":{\"error\":{\"code\":-32606,\"message\":\"invalid_API_version\"}},\"request\":{\"api_version\":1,\"id\":4294967295,\"method\":7}}]\n\r\n"
+	if recorder.Code != http.StatusOK || recorder.Body.String() != want {
+		t.Fatalf("status/body = %d/%q, want 200/%q", recorder.Code, recorder.Body.String(), want)
+	}
+}

--- a/internal/rpc/transport_regression_test.go
+++ b/internal/rpc/transport_regression_test.go
@@ -1,0 +1,505 @@
+package rpc
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const transportRegressionClientIP = "203.0.113.5"
+
+func postTransportRegressionRequest(t *testing.T, server *Server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.RemoteAddr = transportRegressionClientIP + ":1234"
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func newTransportRegressionServer(t *testing.T) *Server {
+	t.Helper()
+	server := newHardeningServer(t, time.Second, "ping", &stubHandler{})
+	server.registry.Register("stop", &stubHandler{role: types.RoleAdmin})
+	server.registry.Register("fail", &stubHandler{
+		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+		},
+	})
+	server.loadTracker = loadtrack.New()
+	return server
+}
+
+func TestTransportConstructorsShareInjectedLoadTracker(t *testing.T) {
+	tracker := loadtrack.New()
+	httpServer := NewServerWithLoadTracker(time.Second, nil, tracker)
+	wsServer := NewWebSocketServerWithLoadTracker(time.Second, nil, tracker)
+
+	require.Same(t, tracker, httpServer.loadTracker)
+	require.Same(t, tracker, wsServer.loadTracker)
+	tracker.Charge("shared-client", loadtrack.LoadMalformed)
+	assert.Greater(t, wsServer.loadTracker.Balance("shared-client"), float64(0))
+
+	defaultHTTP := NewServer(time.Second, nil)
+	defaultWS := NewWebSocketServer(time.Second, nil)
+	require.NotNil(t, defaultHTTP.loadTracker)
+	require.NotNil(t, defaultWS.loadTracker)
+	require.NotSame(t, defaultHTTP.loadTracker, defaultWS.loadTracker)
+}
+
+func seedTransportRegressionLoad(tracker *loadtrack.Tracker, balance int) {
+	tracker.Import("transport-regression", loadtrack.Gossip{Items: []loadtrack.GossipItem{{
+		Key:     transportRegressionClientIP,
+		Balance: balance,
+	}}})
+}
+
+func transportRegressionLocalBalance(t *testing.T, tracker *loadtrack.Tracker) uint32 {
+	t.Helper()
+	return uint32(tracker.LocalBalance(transportRegressionClientIP))
+}
+
+func batchRegressionResult(t *testing.T, recorder *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var replies []map[string]any
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &replies))
+	require.Len(t, replies, 1)
+	result, ok := replies[0]["result"].(map[string]any)
+	require.True(t, ok, "batch response has no result: %v", replies[0])
+	return result
+}
+
+func batchRegressionError(t *testing.T, recorder *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var replies []map[string]any
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &replies))
+	require.Len(t, replies, 1)
+	return nestedBatchError(t, replies[0])
+}
+
+func TestHTTPAdmissionOrderingAtTransportBoundary(t *testing.T) {
+	for _, batch := range []bool{false, true} {
+		name := "single"
+		body := `{"method":"ping","params":[{"api_version":99}]}`
+		if batch {
+			name = "batch"
+			body = `{"method":"batch","params":[{"method":"ping","api_version":99}]}`
+		}
+		t.Run("invalid API precedes overload/"+name, func(t *testing.T) {
+			server := newTransportRegressionServer(t)
+			seedTransportRegressionLoad(server.loadTracker, loadtrack.DropThreshold)
+
+			recorder := postTransportRegressionRequest(t, server, body)
+
+			if batch {
+				assert.Equal(t, http.StatusOK, recorder.Code)
+				errorObject := batchRegressionError(t, recorder)
+				assert.Equal(t, float64(types.WrongVersionJSONRPCCode), errorObject["code"])
+				assert.Equal(t, types.InvalidApiVersionToken, errorObject["message"])
+			} else {
+				assert.Equal(t, http.StatusBadRequest, recorder.Code)
+				assert.Equal(t, types.InvalidApiVersionToken+"\r\n", recorder.Body.String())
+			}
+			assert.Equal(t, uint32(0), transportRegressionLocalBalance(t, server.loadTracker))
+		})
+	}
+
+	overloadCases := []struct {
+		name  string
+		body  string
+		batch bool
+	}{
+		{name: "single forbidden", body: `{"method":"stop","params":[{}]}`},
+		{name: "single malformed method", body: `{"method":7,"params":[{}]}`},
+		{name: "single malformed params", body: `{"method":"ping","params":[]}`},
+		{name: "single malformed ripplerpc", body: `{"method":"ping","params":[{"ripplerpc":2}]}`},
+		{name: "batch forbidden", body: `{"method":"batch","params":[{"method":"stop"}]}`, batch: true},
+		{name: "batch malformed method", body: `{"method":"batch","params":[{"method":7}]}`, batch: true},
+		{name: "batch malformed ripplerpc", body: `{"method":"batch","params":[{"method":"ping","ripplerpc":2}]}`, batch: true},
+	}
+	for _, test := range overloadCases {
+		t.Run("overload precedes "+test.name, func(t *testing.T) {
+			server := newTransportRegressionServer(t)
+			seedTransportRegressionLoad(server.loadTracker, loadtrack.DropThreshold)
+
+			recorder := postTransportRegressionRequest(t, server, test.body)
+
+			if test.batch {
+				assert.Equal(t, http.StatusOK, recorder.Code)
+				errorObject := batchRegressionError(t, recorder)
+				assert.Equal(t, float64(serverOverloadedJSONRPCCode), errorObject["code"])
+				assert.Equal(t, "Server is overloaded", errorObject["message"])
+			} else {
+				assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+				assert.Equal(t, "Server is overloaded\r\n", recorder.Body.String())
+			}
+			assert.Equal(t, loadtrack.ChargeDrop/uint32(loadtrack.DecayWindow/time.Second), transportRegressionLocalBalance(t, server.loadTracker))
+		})
+	}
+}
+
+func TestHTTPForbiddenPrecedesMalformedTransportFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		body  string
+		batch bool
+	}{
+		{name: "single params", body: `{"method":"stop","params":[]}`},
+		{name: "single ripplerpc", body: `{"method":"stop","params":[{"ripplerpc":2}]}`},
+		{name: "batch ripplerpc", body: `{"method":"batch","params":[{"method":"stop","ripplerpc":2}]}`, batch: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := newTransportRegressionServer(t)
+
+			recorder := postTransportRegressionRequest(t, server, test.body)
+
+			if test.batch {
+				assert.Equal(t, http.StatusOK, recorder.Code)
+				errorObject := batchRegressionError(t, recorder)
+				assert.Equal(t, float64(forbiddenJSONRPCCode), errorObject["code"])
+				assert.Equal(t, "Forbidden", errorObject["message"])
+			} else {
+				assert.Equal(t, http.StatusForbidden, recorder.Code)
+				assert.Equal(t, "Forbidden\r\n", recorder.Body.String())
+			}
+			assert.Equal(t, loadtrack.ChargeMalformed/uint32(loadtrack.DecayWindow/time.Second), transportRegressionLocalBalance(t, server.loadTracker))
+		})
+	}
+}
+
+func TestHTTPMalformedAndForbiddenExactLoadCharge(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "single malformed method", body: `{"method":7,"params":[{}]}`},
+		{name: "single malformed params", body: `{"method":"ping","params":[]}`},
+		{name: "single malformed ripplerpc", body: `{"method":"ping","params":[{"ripplerpc":2}]}`},
+		{name: "single forbidden", body: `{"method":"stop","params":[{}]}`},
+		{name: "batch malformed method", body: `{"method":"batch","params":[{"method":7}]}`},
+		{name: "batch malformed ripplerpc", body: `{"method":"batch","params":[{"method":"ping","ripplerpc":2}]}`},
+		{name: "batch forbidden", body: `{"method":"batch","params":[{"method":"stop"}]}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := newTransportRegressionServer(t)
+
+			postTransportRegressionRequest(t, server, test.body)
+
+			assert.Equal(t, loadtrack.ChargeMalformed/uint32(loadtrack.DecayWindow/time.Second), transportRegressionLocalBalance(t, server.loadTracker))
+		})
+	}
+}
+
+func TestHTTPEarlyDispatchErrorsChargeReferenceAndWarn(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		token  string
+		setup  func(*Server)
+	}{
+		{
+			name:   "busy",
+			method: "ping",
+			token:  "tooBusy",
+			setup: func(server *Server) {
+				server.services.ClientLoad = saturatedShedder()
+			},
+		},
+		{name: "unknown", method: "does_not_exist", token: "unknownCmd", setup: func(*Server) {}},
+		{
+			name:   "condition",
+			method: "gated",
+			token:  "noNetwork",
+			setup: func(server *Server) {
+				server.registry.Register("gated", &condStubHandler{cond: types.NeedsNetworkConnection})
+				server.services.Ledger = newMockLedgerService()
+			},
+		},
+	}
+	for _, test := range tests {
+		for _, batch := range []bool{false, true} {
+			name := "single"
+			body := `{"method":"` + test.method + `","params":[{}]}`
+			if batch {
+				name = "batch"
+				body = `{"method":"batch","params":[{"method":"` + test.method + `"}]}`
+			}
+			t.Run(test.name+"/"+name, func(t *testing.T) {
+				server := newTransportRegressionServer(t)
+				test.setup(server)
+				seedTransportRegressionLoad(server.loadTracker, loadtrack.WarningThreshold)
+
+				recorder := postTransportRegressionRequest(t, server, body)
+
+				assert.Equal(t, http.StatusOK, recorder.Code)
+				var result map[string]any
+				if batch {
+					result = batchRegressionResult(t, recorder)
+				} else {
+					result = decodeEnvelope(t, recorder.Body.Bytes())
+				}
+				assert.Equal(t, test.token, result["error"])
+				assert.Equal(t, "load", result["warning"])
+				assert.Equal(t, (loadtrack.ChargeReference+loadtrack.ChargeWarning)/uint32(loadtrack.DecayWindow/time.Second), transportRegressionLocalBalance(t, server.loadTracker))
+			})
+		}
+	}
+}
+
+const recursiveCredentialFields = `"SeCrEt":"private-1","nested":{"SEED":"private-2","items":[{"PassPhrase":"private-3","Seed_Hex":"private-4"},{"SeedHex":"private-5","Password":"private-6","public":"visible"}],"deeper":{"Url_Password":"private-7","UrlPassword":"private-8","Admin_Password":"private-9","AdminPassword":"private-10"}}`
+
+func assertRecursiveCredentialRedaction(t *testing.T, body []byte) {
+	t.Helper()
+	for _, secret := range []string{
+		"private-1", "private-2", "private-3", "private-4", "private-5",
+		"private-6", "private-7", "private-8", "private-9", "private-10",
+	} {
+		assert.NotContains(t, string(body), secret)
+	}
+	assert.Contains(t, string(body), "visible")
+
+	var value any
+	require.NoError(t, json.Unmarshal(body, &value))
+	credentialNames := map[string]struct{}{
+		"SeCrEt":         {},
+		"SEED":           {},
+		"PassPhrase":     {},
+		"Seed_Hex":       {},
+		"SeedHex":        {},
+		"Password":       {},
+		"Url_Password":   {},
+		"UrlPassword":    {},
+		"Admin_Password": {},
+		"AdminPassword":  {},
+	}
+	masked := 0
+	var walk func(any)
+	walk = func(value any) {
+		switch value := value.(type) {
+		case map[string]any:
+			for key, item := range value {
+				if _, credential := credentialNames[key]; credential {
+					masked++
+					assert.Equal(t, maskedValue, item, "credential %s was not masked", key)
+					continue
+				}
+				walk(item)
+			}
+		case []any:
+			for _, item := range value {
+				walk(item)
+			}
+		}
+	}
+	walk(value)
+	assert.Equal(t, len(credentialNames), masked)
+}
+
+func TestBatchAllErrorEchoesRecursivelyRedactCredentials(t *testing.T) {
+	tests := []struct {
+		name       string
+		element    string
+		overloaded bool
+	}{
+		{name: "non-object", element: `[{` + recursiveCredentialFields + `}]`},
+		{name: "invalid API", element: `{"method":"ping","api_version":99,` + recursiveCredentialFields + `}`},
+		{name: "overload", element: `{"method":"ping",` + recursiveCredentialFields + `}`, overloaded: true},
+		{name: "forbidden", element: `{"method":"stop",` + recursiveCredentialFields + `}`},
+		{name: "missing method", element: `{` + recursiveCredentialFields + `}`},
+		{name: "null method", element: `{"method":null,` + recursiveCredentialFields + `}`},
+		{name: "non-string method", element: `{"method":7,` + recursiveCredentialFields + `}`},
+		{name: "empty method", element: `{"method":"",` + recursiveCredentialFields + `}`},
+		{name: "malformed ripplerpc", element: `{"method":"ping","ripplerpc":2,` + recursiveCredentialFields + `}`},
+		{name: "unknown method", element: `{"method":"does_not_exist",` + recursiveCredentialFields + `}`},
+		{name: "handler error", element: `{"method":"fail",` + recursiveCredentialFields + `}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := newTransportRegressionServer(t)
+			if test.overloaded {
+				seedTransportRegressionLoad(server.loadTracker, loadtrack.DropThreshold)
+			}
+			body := `{"method":"batch","params":[` + test.element + `]}`
+
+			recorder := postTransportRegressionRequest(t, server, body)
+
+			assert.Equal(t, http.StatusOK, recorder.Code)
+			assertRecursiveCredentialRedaction(t, recorder.Body.Bytes())
+		})
+	}
+}
+
+func TestBuildXrplResponseBodyDoesNotMutateHandlerResult(t *testing.T) {
+	result := map[string]any{
+		"value":  7,
+		"nested": map[string]any{"ok": true},
+	}
+	want := map[string]any{
+		"value":  7,
+		"nested": map[string]any{"ok": true},
+	}
+
+	response := buildXrplResponseBody(nil, result, nil, &JsonRpcResponseOptions{Warning: "load"})
+
+	assert.True(t, reflect.DeepEqual(want, result), "handler result mutated: %v", result)
+	assert.NotContains(t, result, "status")
+	assert.NotContains(t, result, "warning")
+	responseResult, ok := response["result"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "success", responseResult["status"])
+	assert.Equal(t, "load", responseResult["warning"])
+}
+
+func TestBuildXrplResponseBodyHandlesTypedNilMap(t *testing.T) {
+	var result map[string]any
+
+	response := buildXrplResponseBody(nil, result, nil, nil)
+
+	responseResult, ok := response["result"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"status": "success"}, responseResult)
+	assert.NotContains(t, responseResult, "data")
+}
+
+func TestTransportJSONNumberBoundsAndCanonicalization(t *testing.T) {
+	valid := []struct {
+		raw       string
+		wantType  reflect.Type
+		canonical string
+	}{
+		{raw: `-2147483648`, wantType: reflect.TypeOf(int32(0)), canonical: `-2147483648`},
+		{raw: `2147483647`, wantType: reflect.TypeOf(int32(0)), canonical: `2147483647`},
+		{raw: `2147483648`, wantType: reflect.TypeOf(uint32(0)), canonical: `2147483648`},
+		{raw: `4294967295`, wantType: reflect.TypeOf(uint32(0)), canonical: `4294967295`},
+		{raw: `-0`, wantType: reflect.TypeOf(int32(0)), canonical: `0`},
+		{raw: `1.0`, wantType: reflect.TypeOf(jsonReal(0)), canonical: `1`},
+		{raw: `1e0`, wantType: reflect.TypeOf(jsonReal(0)), canonical: `1`},
+		{raw: `1.25e2`, wantType: reflect.TypeOf(jsonReal(0)), canonical: `125`},
+		{raw: `999999999999999.0`, wantType: reflect.TypeOf(jsonReal(0)), canonical: `999999999999999`},
+		{raw: `1000000000000000.0`, wantType: reflect.TypeOf(jsonReal(0)), canonical: `1000000000000000`},
+		{raw: `10000000000000000.0`, wantType: reflect.TypeOf(jsonReal(0)), canonical: `1e+16`},
+		{raw: `0.0001`, wantType: reflect.TypeOf(jsonReal(0)), canonical: `0.0001`},
+		{raw: `0.00001`, wantType: reflect.TypeOf(jsonReal(0)), canonical: `1e-05`},
+		{raw: `1e20`, wantType: reflect.TypeOf(jsonReal(0)), canonical: `1e+20`},
+	}
+	for _, test := range valid {
+		t.Run(test.raw, func(t *testing.T) {
+			var value any
+			require.NoError(t, decodeJSONUseNumber([]byte(test.raw), &value))
+			assert.Equal(t, test.wantType, reflect.TypeOf(value))
+			encoded, err := json.Marshal(value)
+			require.NoError(t, err)
+			assert.Equal(t, test.canonical, string(encoded))
+		})
+	}
+
+	for _, raw := range []string{`4294967296`, `-2147483649`} {
+		t.Run("reject "+raw, func(t *testing.T) {
+			var value any
+			err := decodeJSONUseNumber([]byte(raw), &value)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "exceeds the allowable range")
+		})
+	}
+}
+
+func TestHTTPJSONIntegerBoundsAndCanonicalization(t *testing.T) {
+	server := newHardeningServer(t, time.Second, "ping", &stubHandler{})
+	for _, rawID := range []string{`4294967296`, `-2147483649`} {
+		t.Run("reject "+rawID, func(t *testing.T) {
+			body := `{"method":"ping","params":[{"id":` + rawID + `}]}`
+
+			recorder := postTransportRegressionRequest(t, server, body)
+
+			assert.Equal(t, http.StatusBadRequest, recorder.Code)
+			assert.Equal(t, unableToParseRequest+"\r\n", recorder.Body.String())
+		})
+	}
+
+	valid := []struct {
+		rawID string
+		want  string
+	}{
+		{rawID: `4294967295`, want: "{\"id\":4294967295,\"result\":{\"ok\":true,\"status\":\"success\"}}\n\r\n"},
+		{rawID: `-2147483648`, want: "{\"id\":-2147483648,\"result\":{\"ok\":true,\"status\":\"success\"}}\n\r\n"},
+		{rawID: `1e0`, want: "{\"id\":1,\"result\":{\"ok\":true,\"status\":\"success\"}}\n\r\n"},
+		{rawID: `1e20`, want: "{\"id\":1e+20,\"result\":{\"ok\":true,\"status\":\"success\"}}\n\r\n"},
+	}
+	for _, test := range valid {
+		t.Run("accept "+test.rawID, func(t *testing.T) {
+			body := `{"method":"ping","params":[{"id":` + test.rawID + `}]}`
+
+			recorder := postTransportRegressionRequest(t, server, body)
+
+			assert.Equal(t, http.StatusOK, recorder.Code)
+			assert.Equal(t, test.want, recorder.Body.String())
+		})
+	}
+}
+
+func TestHTTPParseBoundaryUsesFixedResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "malformed", body: `{not json`},
+		{name: "null", body: `null`},
+		{name: "boolean", body: `true`},
+		{name: "number", body: `7`},
+		{name: "string", body: `"request"`},
+		{name: "array", body: `[{"method":"ping"}]`},
+		{name: "integer below range", body: `{"method":"ping","params":[{"id":-2147483649}]}`},
+		{name: "integer above range", body: `{"method":"ping","params":[{"id":4294967296}]}`},
+		{name: "real out of range", body: `{"method":"ping","params":[{"id":1e999}]}`},
+		{name: "too deeply nested", body: nestedJSONObject(26)},
+		{name: "oversized", body: strings.Repeat(" ", MaxRequestBytes+1)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := newTransportRegressionServer(t)
+			seedTransportRegressionLoad(server.loadTracker, loadtrack.DropThreshold)
+
+			recorder := postTransportRegressionRequest(t, server, test.body)
+
+			assert.Equal(t, http.StatusBadRequest, recorder.Code)
+			assert.Equal(t, jsonContentType, recorder.Header().Get("Content-Type"))
+			assert.Equal(t, unableToParseRequest+"\r\n", recorder.Body.String())
+			assert.Equal(t, uint32(0), transportRegressionLocalBalance(t, server.loadTracker))
+		})
+	}
+}
+
+func nestedJSONObject(containers int) string {
+	return strings.Repeat(`{"a":`, containers) + `0` + strings.Repeat(`}`, containers)
+}
+
+func TestBatchFallsBackToTopLevelAPIVersion(t *testing.T) {
+	server := newBatchServer(t)
+	body := `{"method":"batch","params":[
+		{"method":"ping","api_version":2,"params":[{}]},
+		{"method":"ping","api_version":2,"params":[{"api_version":1}]}
+	]}`
+
+	recorder := postTransportRegressionRequest(t, server, body)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	var replies []map[string]any
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &replies))
+	require.Len(t, replies, 2)
+	for i, reply := range replies {
+		result, ok := reply["result"].(map[string]any)
+		require.True(t, ok, "reply %d has no result: %v", i, reply)
+		assert.Equal(t, float64(types.ApiVersion2), result["api_version"])
+	}
+}

--- a/internal/rpc/tx_history_test.go
+++ b/internal/rpc/tx_history_test.go
@@ -265,7 +265,7 @@ func TestTxHistoryServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 
 	t.Run("Services.Ledger is nil", func(t *testing.T) {
@@ -286,7 +286,7 @@ func TestTxHistoryServiceUnavailable(t *testing.T) {
 		assert.Nil(t, result)
 		require.NotNil(t, rpcErr)
 		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-		assert.Contains(t, rpcErr.Message, "Ledger service not available")
+		assert.Equal(t, "Internal error.", rpcErr.Message)
 	})
 }
 

--- a/internal/rpc/tx_test.go
+++ b/internal/rpc/tx_test.go
@@ -27,6 +27,35 @@ type mockLedgerServiceTx struct {
 	maxAvailableLedger uint32
 }
 
+type mockCTIDLedgerService struct {
+	*mockLedgerServiceTx
+	ledger *mockCTIDLedger
+}
+
+func (m *mockCTIDLedgerService) GetLedgerBySequence(seq uint32) (types.LedgerReader, error) {
+	if m.ledger != nil && m.ledger.sequence == seq {
+		return m.ledger, nil
+	}
+	return nil, errors.New("ledger not found")
+}
+
+type mockCTIDLedger struct {
+	types.LedgerReader
+	sequence uint32
+	hash     [32]byte
+	txHash   [32]byte
+	txData   []byte
+}
+
+func (m *mockCTIDLedger) Sequence() uint32  { return m.sequence }
+func (m *mockCTIDLedger) Hash() [32]byte    { return m.hash }
+func (m *mockCTIDLedger) IsValidated() bool { return true }
+func (m *mockCTIDLedger) CloseTime() int64  { return 0 }
+func (m *mockCTIDLedger) ForEachTransaction(fn func([32]byte, []byte) bool) error {
+	fn(m.txHash, m.txData)
+	return nil
+}
+
 func newMockLedgerServiceTx() *mockLedgerServiceTx {
 	return &mockLedgerServiceTx{
 		mockLedgerService:  newMockLedgerService(),
@@ -305,12 +334,15 @@ func TestTxMethodLookupByHash(t *testing.T) {
 		"Amount":          "1000000",
 		"Fee":             "10",
 		"Sequence":        1,
+		"SigningPubKey":   "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+		"TxnSignature":    "30440220143759437C04F7B61F012563AFE90D8DAFC46E86035E1D965A9CED282C97D4CE02204CFD241E86F17E011298FC1A39B63386C74306A5DE047E213B0F29EFA4571C2C",
 	}
 	storedTx := handlers.StoredTransaction{
 		TxJSON: txJSON,
 		Meta: map[string]any{
 			"TransactionResult": "tesSUCCESS",
 			"TransactionIndex":  0,
+			"AffectedNodes":     []any{},
 		},
 	}
 	storedData, _ := json.Marshal(storedTx)
@@ -419,12 +451,15 @@ func TestTxMethodBinaryOption(t *testing.T) {
 		"Amount":          "1000000",
 		"Fee":             "10",
 		"Sequence":        1,
+		"SigningPubKey":   "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+		"TxnSignature":    "30440220143759437C04F7B61F012563AFE90D8DAFC46E86035E1D965A9CED282C97D4CE02204CFD241E86F17E011298FC1A39B63386C74306A5DE047E213B0F29EFA4571C2C",
 	}
 	storedTx := handlers.StoredTransaction{
 		TxJSON: txJSON,
 		Meta: map[string]any{
 			"TransactionResult": "tesSUCCESS",
 			"TransactionIndex":  0,
+			"AffectedNodes":     []any{},
 		},
 	}
 	storedData, _ := json.Marshal(storedTx)
@@ -1045,10 +1080,7 @@ func TestTxMethodLedgerRange(t *testing.T) {
 
 	validHash := "E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7"
 
-	txJSON := map[string]any{
-		"TransactionType": "Payment",
-		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-	}
+	txJSON := validStoredPaymentTransaction()
 	storedTx := handlers.StoredTransaction{TxJSON: txJSON}
 	storedData, _ := json.Marshal(storedTx)
 
@@ -1155,12 +1187,8 @@ func TestTxMethodInvalidLedgerRange(t *testing.T) {
 
 	validHash := "E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7"
 	storedTx := handlers.StoredTransaction{
-		TxJSON: map[string]any{
-			"TransactionType": "Payment",
-			"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-			"Fee":             "10",
-		},
-		Meta: map[string]any{"TransactionResult": "tesSUCCESS"},
+		TxJSON: validStoredPaymentTransaction(),
+		Meta:   validStoredMetadata(),
 	}
 	storedData, _ := json.Marshal(storedTx)
 	mock.transactions[validHash] = &types.TransactionInfo{
@@ -1281,6 +1309,8 @@ func TestTxMethodResponseFields(t *testing.T) {
 		"Amount":          "1000000",
 		"Fee":             "10",
 		"Sequence":        1,
+		"SigningPubKey":   "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+		"TxnSignature":    "30440220143759437C04F7B61F012563AFE90D8DAFC46E86035E1D965A9CED282C97D4CE02204CFD241E86F17E011298FC1A39B63386C74306A5DE047E213B0F29EFA4571C2C",
 	}
 	storedTx := handlers.StoredTransaction{
 		TxJSON: txJSON,
@@ -1429,7 +1459,7 @@ func TestTxMethodServiceUnavailable(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // TestTxMethodServiceNilLedger tests behavior when ledger service is nil
@@ -1453,7 +1483,7 @@ func TestTxMethodServiceNilLedger(t *testing.T) {
 	assert.Nil(t, result)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	assert.Contains(t, rpcErr.Message, "Ledger service not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message)
 }
 
 // Method Metadata Tests
@@ -1492,11 +1522,17 @@ func TestTxMethodApiVersions(t *testing.T) {
 		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 		"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 		"Amount":          "1000000",
+		"Fee":             "10",
+		"Sequence":        1,
+		"SigningPubKey":   "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+		"TxnSignature":    "30440220143759437C04F7B61F012563AFE90D8DAFC46E86035E1D965A9CED282C97D4CE02204CFD241E86F17E011298FC1A39B63386C74306A5DE047E213B0F29EFA4571C2C",
 	}
 	storedTx := handlers.StoredTransaction{
 		TxJSON: txJSON,
 		Meta: map[string]any{
 			"TransactionResult": "tesSUCCESS",
+			"TransactionIndex":  0,
+			"AffectedNodes":     []any{},
 		},
 	}
 	storedData, _ := json.Marshal(storedTx)
@@ -1644,31 +1680,9 @@ func TestTxMethodEdgeCases(t *testing.T) {
 		Services:   services,
 	}
 
-	t.Run("Transaction with corrupted stored data", func(t *testing.T) {
-		// Store invalid JSON as transaction data
-		invalidHash := "1111111111111111111111111111111111111111111111111111111111111111"
-		mock.transactions[invalidHash] = &types.TransactionInfo{
-			TxData:      []byte("not valid json"),
-			LedgerIndex: 100,
-			LedgerHash:  "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652",
-			Validated:   true,
-		}
-
-		params := map[string]any{
-			"transaction": strings.ToLower(invalidHash),
-		}
-		paramsJSON, _ := json.Marshal(params)
-
-		result, rpcErr := method.Handle(ctx, paramsJSON)
-
-		assert.Nil(t, result)
-		require.NotNil(t, rpcErr)
-		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-	})
-
 	t.Run("Transaction hash with leading zeros", func(t *testing.T) {
 		leadingZeroHash := "0000000000000000000000000000000000000000000000000000000000000001"
-		txJSON := map[string]any{"TransactionType": "Payment"}
+		txJSON := validStoredPaymentTransaction()
 		storedTx := handlers.StoredTransaction{TxJSON: txJSON}
 		storedData, _ := json.Marshal(storedTx)
 
@@ -1691,7 +1705,7 @@ func TestTxMethodEdgeCases(t *testing.T) {
 
 	t.Run("All-F hash (max value)", func(t *testing.T) {
 		maxHash := "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
-		txJSON := map[string]any{"TransactionType": "Payment"}
+		txJSON := validStoredPaymentTransaction()
 		storedTx := handlers.StoredTransaction{TxJSON: txJSON}
 		storedData, _ := json.Marshal(storedTx)
 
@@ -1711,6 +1725,182 @@ func TestTxMethodEdgeCases(t *testing.T) {
 		require.Nil(t, rpcErr)
 		require.NotNil(t, result)
 	})
+}
+
+func TestTxMethodCorruptedStoredData(t *testing.T) {
+	mock := newMockLedgerServiceTx()
+	method := &handlers.TxMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   servicesForTx(mock),
+	}
+	txHash := "1111111111111111111111111111111111111111111111111111111111111111"
+	params, err := json.Marshal(map[string]any{"transaction": txHash})
+	require.NoError(t, err)
+
+	for _, tc := range append(corruptedStoredTransactionData(t), txMetadataCorruptionData(t)...) {
+		t.Run(tc.name, func(t *testing.T) {
+			mock.transactions[txHash] = &types.TransactionInfo{
+				TxData:      tc.data,
+				LedgerIndex: 100,
+				LedgerHash:  "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652",
+				Validated:   true,
+			}
+
+			result, rpcErr := method.Handle(ctx, params)
+
+			requireDBDeserializationError(t, result, rpcErr)
+		})
+	}
+}
+
+func TestTxMethodStoredDataWithoutMetadata(t *testing.T) {
+	mock := newMockLedgerServiceTx()
+	method := &handlers.TxMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   servicesForTx(mock),
+	}
+	txHash := "2222222222222222222222222222222222222222222222222222222222222222"
+	params, err := json.Marshal(map[string]any{"transaction": txHash})
+	require.NoError(t, err)
+
+	for _, tc := range storedTransactionDataWithoutMetadata(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			mock.transactions[txHash] = &types.TransactionInfo{
+				TxData:      tc.data,
+				LedgerIndex: 100,
+				Validated:   true,
+			}
+
+			result, rpcErr := method.Handle(ctx, params)
+			if tc.name == "VL metadata empty" {
+				requireDBDeserializationError(t, result, rpcErr)
+				return
+			}
+
+			require.Nil(t, rpcErr)
+			response, ok := result.(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "Payment", response["TransactionType"])
+			assert.NotContains(t, response, "meta")
+		})
+	}
+}
+
+func TestTxMethodValidStoredDataFormats(t *testing.T) {
+	mock := newMockLedgerServiceTx()
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   servicesForTx(mock),
+	}
+	txHash := "3333333333333333333333333333333333333333333333333333333333333333"
+	params, err := json.Marshal(map[string]any{"transaction": txHash})
+	require.NoError(t, err)
+
+	for _, tc := range storedTransactionDataWithMetadata(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			mock.transactions[txHash] = &types.TransactionInfo{
+				TxData:      tc.data,
+				LedgerIndex: 100,
+				Validated:   true,
+			}
+
+			result, rpcErr := (&handlers.TxMethod{}).Handle(ctx, params)
+
+			require.Nil(t, rpcErr)
+			response, ok := result.(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "Payment", response["TransactionType"])
+			meta, ok := response["meta"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "tesSUCCESS", meta["TransactionResult"])
+		})
+	}
+}
+
+func TestTxMethodCTIDCorruptedStoredData(t *testing.T) {
+	base := newMockLedgerServiceTx()
+	ledger := &mockCTIDLedger{
+		sequence: 45,
+		txHash:   [32]byte{1},
+	}
+	mock := &mockCTIDLedgerService{mockLedgerServiceTx: base, ledger: ledger}
+	method := &handlers.TxMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: mock},
+	}
+	ctid, err := EncodeCTID(ledger.sequence, 0, 0)
+	require.NoError(t, err)
+
+	for _, storedData := range append(corruptedStoredTransactionData(t), txMetadataCorruptionData(t)...) {
+		t.Run(storedData.name, func(t *testing.T) {
+			ledger.txData = storedData.data
+			for _, responseFormat := range []struct {
+				name   string
+				binary bool
+			}{
+				{name: "json", binary: false},
+				{name: "binary", binary: true},
+			} {
+				t.Run(responseFormat.name, func(t *testing.T) {
+					params, err := json.Marshal(map[string]any{"ctid": ctid, "binary": responseFormat.binary})
+					require.NoError(t, err)
+
+					result, rpcErr := method.Handle(ctx, params)
+
+					requireDBDeserializationError(t, result, rpcErr)
+				})
+			}
+		})
+	}
+}
+
+func TestTxMethodCTIDStoredDataWithoutMetadata(t *testing.T) {
+	base := newMockLedgerServiceTx()
+	ledger := &mockCTIDLedger{
+		sequence: 45,
+		txHash:   [32]byte{1},
+	}
+	mock := &mockCTIDLedgerService{mockLedgerServiceTx: base, ledger: ledger}
+	method := &handlers.TxMethod{}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: mock},
+	}
+	ctid, err := EncodeCTID(ledger.sequence, 0, 0)
+	require.NoError(t, err)
+	params, err := json.Marshal(map[string]any{"ctid": ctid})
+	require.NoError(t, err)
+
+	for _, tc := range storedTransactionDataWithoutMetadata(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			ledger.txData = tc.data
+
+			result, rpcErr := method.Handle(ctx, params)
+			if tc.name == "VL metadata empty" {
+				requireDBDeserializationError(t, result, rpcErr)
+				return
+			}
+
+			require.Nil(t, rpcErr)
+			response, ok := result.(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "Payment", response["TransactionType"])
+			assert.NotContains(t, response, "meta")
+		})
+	}
 }
 
 // TestTxMethodInternalErrors tests internal error handling

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -251,8 +251,8 @@ func RpcErrorInvalidParams(message string) *RpcError {
 	return NewRpcError(RpcINVALID_PARAMS, "invalidParams", "invalidParams", message)
 }
 
-func RpcErrorMethodNotFound(method string) *RpcError {
-	return NewRpcError(RpcMETHOD_NOT_FOUND, "unknownCmd", "unknownCmd", "Unknown method: "+method)
+func RpcErrorMethodNotFound() *RpcError {
+	return NewRpcError(RpcMETHOD_NOT_FOUND, "unknownCmd", "unknownCmd", "Unknown method.")
 }
 
 func RpcErrorLgrNotFound(message string) *RpcError {
@@ -283,8 +283,16 @@ func RpcErrorInvalidHotWallet() *RpcError {
 	return NewRpcError(RpcINVALID_HOTWALLET, "invalidHotWallet", "invalidHotWallet", "Invalid hotwallet.")
 }
 
-func RpcErrorInternal(message string) *RpcError {
-	return NewRpcError(RpcINTERNAL, "internal", "internal", message)
+func RpcErrorInternal() *RpcError {
+	return NewRpcError(RpcINTERNAL, "internal", "internal", "Internal error.")
+}
+
+func RpcErrorTransactionSubmission() *RpcError {
+	return NewRpcError(RpcINTERNAL, "internal", "internal", "Exception occurred during transaction submission.")
+}
+
+func RpcErrorDBDeserialization() *RpcError {
+	return NewRpcError(RpcDB_DESERIALIZATION, "dbDeserialization", "dbDeserialization", "Database deserialization error.")
 }
 
 func RpcErrorNoPermission(method string) *RpcError {

--- a/internal/rpc/types/errors_test.go
+++ b/internal/rpc/types/errors_test.go
@@ -141,13 +141,15 @@ func TestErrorConstructorsTokenCodePairs(t *testing.T) {
 	}{
 		{RpcErrorUnknown("x"), "unknown", RpcUNKNOWN},
 		{RpcErrorInvalidParams("x"), "invalidParams", 31},
-		{RpcErrorMethodNotFound("m"), "unknownCmd", 32},
+		{RpcErrorMethodNotFound(), "unknownCmd", 32},
 		{RpcErrorLgrNotFound("x"), "lgrNotFound", 21},
 		{RpcErrorActNotFound("x"), "actNotFound", 19},
 		{RpcErrorActMalformed("x"), "actMalformed", 35},
 		{RpcErrorTxnNotFound("x"), "txnNotFound", 29},
 		{RpcErrorInvalidHotWallet(), "invalidHotWallet", 30},
-		{RpcErrorInternal("x"), "internal", 73},
+		{RpcErrorInternal(), "internal", 73},
+		{RpcErrorTransactionSubmission(), "internal", 73},
+		{RpcErrorDBDeserialization(), "dbDeserialization", 77},
 		{RpcErrorNoPermission("m"), "noPermission", 6},
 		{RpcErrorForbidden("m"), "forbidden", 3},
 		{RpcErrorTooBusy(), "tooBusy", 9},
@@ -193,6 +195,19 @@ func TestErrorConstructorsTokenCodePairs(t *testing.T) {
 	}
 }
 
+func TestRpcErrorMethodNotFoundMessage(t *testing.T) {
+	if got := RpcErrorMethodNotFound().Message; got != "Unknown method." {
+		t.Fatalf("message = %q, want %q", got, "Unknown method.")
+	}
+}
+
+func TestRpcErrorDBDeserialization(t *testing.T) {
+	err := RpcErrorDBDeserialization()
+	if err.Message != "Database deserialization error." {
+		t.Fatalf("message = %q, want %q", err.Message, "Database deserialization error.")
+	}
+}
+
 // Bare-token errors mirror rippled handlers that set jvResult[jss::error]
 // directly (e.g. VaultInfo.cpp:101, LedgerEntry.cpp:1044,
 // TransactionEntry.cpp:71): only `error` is wired, never error_code or
@@ -216,7 +231,7 @@ func TestBareTokenErrors(t *testing.T) {
 	notBare := []*RpcError{
 		RpcErrorTxnNotFound("x"),
 		RpcErrorLgrNotFound("x"),
-		RpcErrorInternal("x"),
+		RpcErrorInternal(),
 		RpcErrorActNotFound("x"),
 	}
 	for _, e := range notBare {
@@ -245,7 +260,7 @@ func TestInvalidApiVersionError(t *testing.T) {
 		t.Errorf("error_message = %q, want empty (rippled omits it)", e.Message)
 	}
 	// Only the invalid-version error carries the transport marker.
-	if RpcErrorInternal("x").IsInvalidApiVersion() {
+	if RpcErrorInternal().IsInvalidApiVersion() {
 		t.Error("unrelated error must not report IsInvalidApiVersion")
 	}
 }

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -101,6 +101,10 @@ type RpcContext struct {
 	// fixtures they need. Replaces the former package-level
 	// types.Services global.
 	Services *ServiceContainer
+	// LoadCost is the resource charge selected while handling the request.
+	// Dispatch initializes it to the reference cost; handlers raise it only
+	// after reaching the equivalent rippled work boundary.
+	LoadCost uint32
 	// LoadWarning is set by the post-dispatch load charge when the caller
 	// crosses the resource warn threshold. Transport writers surface it as
 	// the top-level warning:"load" field, mirroring rippled's
@@ -150,6 +154,10 @@ type LedgerIndex string
 
 // UnmarshalJSON implements custom unmarshaling for LedgerIndex
 func (li *LedgerIndex) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*li = ""
+		return nil
+	}
 	// First try to unmarshal as a string (handles "validated", "current", "closed", "12345")
 	var strVal string
 	if err := json.Unmarshal(data, &strVal); err == nil {
@@ -207,25 +215,7 @@ type WebSocketCommand struct {
 	Command string
 	ID      any
 	Params  json.RawMessage
-}
-
-// WebSocketResponse represents an XRPL WebSocket API response
-type WebSocketResponse struct {
-	Status       string          `json:"status"`
-	Type         string          `json:"type"`
-	Result       any             `json:"result,omitempty"`
-	ID           any             `json:"id,omitempty"`
-	Warning      string          `json:"warning,omitempty"`
-	Warnings     []WarningObject `json:"warnings,omitempty"`
-	Forwarded    bool            `json:"forwarded,omitempty"`
-	ApiVersion   int             `json:"api_version,omitempty"`
-	Error        string          `json:"error,omitempty"`
-	ErrorCode    int             `json:"error_code,omitempty"`
-	ErrorMessage string          `json:"error_message,omitempty"`
-	// Request echoes the original command back on an error reply. rippled's
-	// WS missingCommand path returns the unparsed request alongside the
-	// error token (ServerHandler.cpp:457).
-	Request any `json:"request,omitempty"`
+	Request map[string]any
 }
 
 // Subscription types for WebSocket streams. Rippled's per-book stream
@@ -315,6 +305,17 @@ func (r *SubscriptionRequest) WireArrays() WireSubscriptionArrays {
 	}
 }
 
+// WithoutBooks returns a copy that preserves every wire field except books.
+func (r SubscriptionRequest) WithoutBooks() SubscriptionRequest {
+	r.Books = nil
+	if r.wire != nil {
+		wire := *r.wire
+		wire.books = nil
+		r.wire = &wire
+	}
+	return r
+}
+
 // UnmarshalJSON captures the raw JSON of the array-valued fields before
 // decoding the typed fields, so the subscription manager can apply rippled's
 // per-field, per-shape error codes — a typed slice cannot tell an absent field
@@ -386,7 +387,9 @@ type BookRequest struct {
 	TakerPays json.RawMessage `json:"taker_pays"`
 	TakerGets json.RawMessage `json:"taker_gets"`
 	Snapshot  bool            `json:"snapshot,omitempty"`
+	StateNow  bool            `json:"state_now,omitempty"`
 	Both      bool            `json:"both,omitempty"`
+	BothSides bool            `json:"both_sides,omitempty"`
 	// Taker is the perspective account used when computing snapshot
 	// quality (sfTaker on rippled Subscribe.cpp:282-299). Optional; an
 	// empty value means "anonymous" — the same default rippled uses

--- a/internal/rpc/validators_test.go
+++ b/internal/rpc/validators_test.go
@@ -512,8 +512,8 @@ func TestStopServiceUnavailable(t *testing.T) {
 	require.NotNil(t, rpcErr, "Expected RPC error when service unavailable")
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code,
 		"Should return internal error code")
-	assert.Contains(t, rpcErr.Message, "Shutdown function not available",
-		"Error message should indicate shutdown function not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message,
+		"internal error text must remain canonical")
 }
 
 // TestStopShutdownFuncNil tests behavior when ShutdownFunc is nil.
@@ -539,8 +539,8 @@ func TestStopShutdownFuncNil(t *testing.T) {
 	require.NotNil(t, rpcErr, "Expected RPC error when shutdown func nil")
 	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code,
 		"Should return internal error code")
-	assert.Contains(t, rpcErr.Message, "Shutdown function not available",
-		"Error message should indicate shutdown function not available")
+	assert.Equal(t, "Internal error.", rpcErr.Message,
+		"internal error text must remain canonical")
 }
 
 // TestStopWithParams tests that providing params does not affect stop behavior.

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -405,8 +405,6 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 	}
 	rpcCtx := newRpcContext(dispatchCtx, role, apiVersion, clientIP, ws.loadPeerSource(), ws.services)
 
-	// Handle connection-bound commands specially while retaining the same
-	// admission and resource-accounting lifecycle as registry handlers.
 	switch cmd.Command {
 	case "subscribe":
 		ws.handleSpecialCommand(wsConn, rpcCtx, cmd, ws.executeSubscribe)
@@ -457,8 +455,7 @@ func (ws *WebSocketServer) handleSpecialCommand(wsConn *WebSocketConnection, ctx
 	}
 	finalizeLoad(ws.loadTracker, ctx, cmd.Command, kind, wsLog())
 	if rpcErr != nil {
-		// rippled replaces the outer response object with rpcError here, so a
-		// warning produced by the final charge is deliberately not exposed.
+		// Error responses deliberately omit warnings produced by the final charge.
 		ws.sendCommandError(wsConn, rpcErr, cmd)
 		return
 	}

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -1,11 +1,12 @@
 package rpc
 
 import (
+	"bytes"
 	"context"
 	cryptorand "crypto/rand"
 	"encoding/json"
 	"fmt"
-	"maps"
+	"io"
 	"net"
 	"net/http"
 	"runtime/debug"
@@ -98,6 +99,16 @@ type WebSocketConnection struct {
 // server so handlers reach the ledger via ctx.Services. May be nil for
 // test contexts.
 func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer) *WebSocketServer {
+	return NewWebSocketServerWithLoadTracker(timeout, services, nil)
+}
+
+// NewWebSocketServerWithLoadTracker creates a WebSocket server using tracker
+// for transport-level admission and charging. A nil tracker preserves
+// NewWebSocketServer's standalone default.
+func NewWebSocketServerWithLoadTracker(timeout time.Duration, services *types.ServiceContainer, tracker *loadtrack.Tracker) *WebSocketServer {
+	if tracker == nil {
+		tracker = loadtrack.New()
+	}
 	if services != nil && services.ClientLoad == nil {
 		services.ClientLoad = types.NewClientLoadShedder()
 	}
@@ -114,7 +125,7 @@ func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer)
 		connections:         make(map[string]*WebSocketConnection),
 		timeout:             timeout,
 		services:            services,
-		loadTracker:         loadtrack.New(),
+		loadTracker:         tracker,
 		pingInterval:        30 * time.Second,
 	}
 	// The url (RPCSub) registry lives on the WebSocket server because url
@@ -213,11 +224,6 @@ func (ws *WebSocketServer) handleConnection(wsConn *WebSocketConnection) {
 	defer ws.closeConnection(wsConn)
 	defer recoverPanic("handleConnection", wsConn.ID)
 
-	// Match the HTTP body cap. rippled enforces RPC::Tuning::maxRequestSize
-	// (1 MB) on both onWSMessage and processRequest (ServerHandler.cpp:343
-	// and :625), so the WS path uses the same byte ceiling as POST.
-	wsConn.conn.SetReadLimit(int64(MaxRequestBytes))
-
 	wsConn.conn.SetPongHandler(func(string) error {
 		wsConn.conn.SetReadDeadline(time.Now().Add(90 * time.Second))
 		return nil
@@ -232,12 +238,21 @@ func (ws *WebSocketServer) handleConnection(wsConn *WebSocketConnection) {
 	for {
 		wsConn.conn.SetReadDeadline(time.Now().Add(90 * time.Second))
 
-		_, message, err := wsConn.conn.ReadMessage()
+		_, reader, err := wsConn.conn.NextReader()
 		if err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
 				wsLog().Debug("WebSocket read error", "err", err)
 			}
 			return
+		}
+		message, err := io.ReadAll(io.LimitReader(reader, MaxRequestBytes+1))
+		if err != nil {
+			wsLog().Debug("WebSocket read error", "err", err)
+			return
+		}
+		if len(message) > MaxRequestBytes {
+			ws.sendJSONInvalid(wsConn, nil, false)
+			continue
 		}
 
 		select {
@@ -307,20 +322,26 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 	defer func() {
 		if rec := recover(); rec != nil {
 			wsLog().Error("ws message panic", "conn", wsConn.ID, "err", rec, "stack", string(debug.Stack()))
-			ws.sendError(wsConn, types.NewRpcError(types.RpcINTERNAL, "internal", "internal", "Internal server error"), nil)
+			ws.sendErrorResponse(wsConn, rpcInternalError(), nil, nil, buildWSRequestEcho(message))
 		}
 	}()
 
-	// XRPL WebSocket format: command and id at top level, all other fields are params.
-	var cmdMap map[string]any
-	if err := json.Unmarshal(message, &cmdMap); err != nil {
-		ws.sendError(wsConn, types.RpcErrorInvalidParams("Invalid JSON: "+err.Error()), nil)
+	var requestValue any
+	if err := decodeJSONUseNumber(message, &requestValue); err != nil {
+		ws.sendJSONInvalid(wsConn, nil, false)
+		return
+	}
+	cmdMap, ok := requestValue.(map[string]any)
+	if !ok || cmdMap == nil {
+		ws.sendJSONInvalid(wsConn, requestValue, true)
 		return
 	}
 
+	requestEcho := redactedRequestMap(cmdMap)
 	var id any
-	if idVal, exists := cmdMap["id"]; exists {
+	if idVal, exists := requestEcho["id"]; exists {
 		id = idVal
+		cmdMap["id"] = idVal
 	}
 
 	// Role is always derived from the socket-level peer, never from
@@ -332,6 +353,22 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 	peerIP := getWebSocketClientIP(wsConn.conn)
 	clientIP := resolveWSClientIP(peerIP, wsConn.forwardedFor, wsConn.portCtx)
 	role := roleForRequest(peerIP, wsConn.user, wsConn.portCtx)
+	loadCtx := newRpcContext(wsConn.ctx, role, types.DefaultApiVersion, clientIP, ws.loadPeerSource(), ws.services)
+	if rpcErr := gateLoad(ws.loadTracker, loadCtx, "", wsLog()); rpcErr != nil {
+		wsConn.closeWithPolicyViolation("threshold exceeded")
+		return
+	}
+
+	apiVersion := types.DefaultApiVersion
+	if version, present := apiVersionFromObject(message); present {
+		apiVersion = version
+	}
+	versionCtx := newRpcContext(wsConn.ctx, role, apiVersion, clientIP, ws.loadPeerSource(), ws.services)
+	if rpcErr := validateApiVersion(versionCtx); rpcErr != nil {
+		chargeLoad(ws.loadTracker, versionCtx, "", loadtrack.LoadMalformed, wsLog())
+		ws.sendErrorResponse(wsConn, rpcErr, id, nil, requestEcho)
+		return
+	}
 
 	// rippled accepts `method` as an alias for `command`, rejecting only when
 	// neither is present (or both are present strings that disagree) with a
@@ -339,29 +376,20 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 	// feeMalformedRPC (ServerHandler.cpp:446-468).
 	command, ok := resolveWSCommand(cmdMap)
 	if !ok {
+		chargeLoad(ws.loadTracker, versionCtx, "", loadtrack.LoadMalformed, wsLog())
 		ws.sendMissingCommand(wsConn, cmdMap, id)
-		if ws.loadTracker != nil && !role.IsUnlimited() {
-			ws.loadTracker.Charge(clientIP, loadtrack.LoadMalformed)
-		}
 		return
 	}
 
 	cmd := types.WebSocketCommand{
 		Command: command,
 		ID:      id,
+		Request: requestEcho,
 	}
 
 	delete(cmdMap, "command")
 	delete(cmdMap, "method")
-	delete(cmdMap, "id")
-
-	var apiVersion int = types.DefaultApiVersion
-	if apiVer, exists := cmdMap["api_version"]; exists {
-		if ver, ok := apiVer.(float64); ok {
-			apiVersion = int(ver)
-		}
-		delete(cmdMap, "api_version")
-	}
+	delete(cmdMap, "api_version")
 
 	if len(cmdMap) > 0 {
 		paramsBytes, _ := json.Marshal(cmdMap)
@@ -377,171 +405,283 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 	}
 	rpcCtx := newRpcContext(dispatchCtx, role, apiVersion, clientIP, ws.loadPeerSource(), ws.services)
 
-	// Handle subscription commands specially
+	// Handle connection-bound commands specially while retaining the same
+	// admission and resource-accounting lifecycle as registry handlers.
 	switch cmd.Command {
 	case "subscribe":
-		ws.handleSubscribe(wsConn, rpcCtx, cmd)
+		ws.handleSpecialCommand(wsConn, rpcCtx, cmd, ws.executeSubscribe)
 		return
 	case "unsubscribe":
-		ws.handleUnsubscribe(wsConn, rpcCtx, cmd)
+		ws.handleSpecialCommand(wsConn, rpcCtx, cmd, ws.executeUnsubscribe)
 		return
 	case "path_find":
-		ws.handlePathFind(wsConn, rpcCtx, cmd)
+		ws.handleSpecialCommand(wsConn, rpcCtx, cmd, ws.executePathFind)
 		return
 	}
 
 	ws.handleRPCMethod(wsConn, rpcCtx, cmd)
 }
 
-func (ws *WebSocketServer) handleSubscribe(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+type wsSpecialHandler func(*WebSocketConnection, *types.RpcContext, types.WebSocketCommand) (any, *types.RpcError)
+
+func (ws *WebSocketServer) handleSpecialCommand(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand, handler wsSpecialHandler) {
+	ctx.LoadCost = uint32(loadtrack.LoadReference)
+	if rpcErr := handlers.RequireNotBusyClient(ctx); rpcErr != nil {
+		finalizeLoad(ws.loadTracker, ctx, cmd.Command, loadtrack.LoadReference, wsLog())
+		ws.sendCommandError(wsConn, rpcErr, cmd)
+		return
+	}
+
+	resolution := resolveMethod(ws.methodRegistry, cmd.Command, ctx.ApiVersion)
+	if !resolution.resolved {
+		finalizeLoad(ws.loadTracker, ctx, cmd.Command, loadtrack.LoadReference, wsLog())
+		ws.sendCommandError(wsConn, types.RpcErrorMethodNotFound(), cmd)
+		return
+	}
+	if rpcErr := conditionMet(resolution.handler.RequiredCondition(), ctx); rpcErr != nil {
+		finalizeLoad(ws.loadTracker, ctx, cmd.Command, loadtrack.LoadReference, wsLog())
+		ws.sendCommandError(wsConn, rpcErr, cmd)
+		return
+	}
+
+	result, rpcErr, recovered := func() (any, *types.RpcError, bool) {
+		if ws.services != nil && ws.services.ClientLoad != nil {
+			ws.services.ClientLoad.Begin()
+			defer ws.services.ClientLoad.End()
+		}
+		return invokeWSSpecial(handler, wsConn, ctx, cmd)
+	}()
+	kind := loadtrack.LoadKind(ctx.LoadCost)
+	if recovered && kind == loadtrack.LoadReference {
+		kind = loadtrack.LoadException
+	}
+	finalizeLoad(ws.loadTracker, ctx, cmd.Command, kind, wsLog())
+	if rpcErr != nil {
+		// rippled replaces the outer response object with rpcError here, so a
+		// warning produced by the final charge is deliberately not exposed.
+		ws.sendCommandError(wsConn, rpcErr, cmd)
+		return
+	}
+	ws.sendCommandResponse(wsConn, result, cmd, wsLoadWarningOpts(ctx))
+}
+
+func invokeWSSpecial(handler wsSpecialHandler, wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (result any, rpcErr *types.RpcError, recovered bool) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			wsLog().Error("rpc handler panic", "err", rec, "stack", string(debug.Stack()), "method", cmd.Command, "client", ctx.ClientIP)
+			result = nil
+			rpcErr = rpcInternalError()
+			recovered = true
+		}
+	}()
+	result, rpcErr = handler(wsConn, ctx, cmd)
+	return result, rpcErr, false
+}
+
+func (ws *WebSocketServer) executeSubscribe(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
 	var request types.SubscriptionRequest
 	if len(cmd.Params) > 0 {
 		if err := json.Unmarshal(cmd.Params, &request); err != nil {
-			ws.sendError(wsConn, types.RpcErrorInvalidParams("Invalid subscription parameters: "+err.Error()), cmd.ID)
-			return
+			return nil, types.RpcErrorInvalidParams("Invalid subscription parameters.")
 		}
 	}
-
 	// url requests are server-to-server (RPCSub) subscriptions: events go
 	// to the url's subscriber, not to this WebSocket connection.
 	if request.HasURL() {
 		if !ctx.IsAdmin {
-			ws.sendError(wsConn, types.RpcErrorNoPermission("subscribe"), cmd.ID)
-			return
+			return nil, types.RpcErrorNoPermission("subscribe")
 		}
 		result, rpcErr := ws.urlSubs.Subscribe(ctx, request)
 		if rpcErr != nil {
-			ws.sendError(wsConn, rpcErr, cmd.ID)
-			return
+			return nil, rpcErr
 		}
-		ws.sendResponse(wsConn, types.WebSocketResponse{
-			Type:       "response",
-			ID:         cmd.ID,
-			Status:     "success",
-			Result:     result,
-			ApiVersion: ctx.ApiVersion,
-		})
-		return
+		setSubscriptionLoadCost(ctx, request)
+		return result, nil
 	}
 
 	// wsConn.legacy is the same connection the subscription manager already
 	// tracks (created in attachConnection, before any message can arrive); it
 	// shares the subscriptions map and carries the Disconnect callback a
 	// freshly-built copy would lack.
-	if err := ws.subscriptionManager.HandleSubscribe(wsConn.legacy, request, ctx.IsAdmin); err != nil {
-		ws.sendError(wsConn, err, cmd.ID)
-		return
+	prefix, err := subscriptionRequestExcluding(cmd.Params, "books")
+	if err != nil {
+		return nil, types.RpcErrorInvalidParams("Invalid subscription parameters.")
+	}
+	if rpcErr := ws.subscriptionManager.HandleSubscribe(wsConn.legacy, prefix, ctx.IsAdmin); rpcErr != nil {
+		return nil, rpcErr
+	}
+	if rpcErr := applySubscriptionBooks(request.WireArrays().Books, func(bookRequest types.SubscriptionRequest) *types.RpcError {
+		if rpcErr := ws.subscriptionManager.HandleSubscribe(wsConn.legacy, bookRequest, ctx.IsAdmin); rpcErr != nil {
+			return rpcErr
+		}
+		setSubscriptionLoadCost(ctx, bookRequest)
+		return nil
+	}); rpcErr != nil {
+		return nil, rpcErr
 	}
 
 	result := ws.buildSubscribeAck(ctx, request)
-
-	response := types.WebSocketResponse{
-		Type:       "response",
-		ID:         cmd.ID,
-		Status:     "success",
-		Result:     result,
-		ApiVersion: ctx.ApiVersion,
-	}
-	ws.sendResponse(wsConn, response)
+	return result, nil
 }
 
-func (ws *WebSocketServer) handleUnsubscribe(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+func subscriptionRequestExcluding(params json.RawMessage, fields ...string) (types.SubscriptionRequest, error) {
+	var request types.SubscriptionRequest
+	if len(params) == 0 {
+		return request, nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(params, &raw); err != nil {
+		return request, err
+	}
+	for _, field := range fields {
+		delete(raw, field)
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return request, err
+	}
+	err = json.Unmarshal(data, &request)
+	return request, err
+}
+
+func applySubscriptionBooks(raw json.RawMessage, apply func(types.SubscriptionRequest) *types.RpcError) *types.RpcError {
+	if raw == nil {
+		return nil
+	}
+	if rawJSONNull(raw) {
+		request, err := subscriptionRequestForBooks(raw)
+		if err != nil {
+			return types.RpcErrorInvalidParams("Invalid subscription parameters.")
+		}
+		return apply(request)
+	}
+	var books []json.RawMessage
+	if err := json.Unmarshal(raw, &books); err != nil {
+		request, decodeErr := subscriptionRequestForBooks(raw)
+		if decodeErr != nil {
+			return types.RpcErrorInvalidParams("Invalid subscription parameters.")
+		}
+		return apply(request)
+	}
+	for _, book := range books {
+		request, err := subscriptionRequestForBooks(json.RawMessage("[" + string(book) + "]"))
+		if err != nil {
+			return types.RpcErrorInvalidParams("Invalid subscription parameters.")
+		}
+		if rpcErr := apply(request); rpcErr != nil {
+			return rpcErr
+		}
+	}
+	return nil
+}
+
+func subscriptionRequestForBooks(books json.RawMessage) (types.SubscriptionRequest, error) {
+	data, err := json.Marshal(map[string]json.RawMessage{"books": books})
+	if err != nil {
+		return types.SubscriptionRequest{}, err
+	}
+	var request types.SubscriptionRequest
+	err = json.Unmarshal(data, &request)
+	return request, err
+}
+
+func (ws *WebSocketServer) finishUnsubscribe(wsConn *WebSocketConnection, request types.SubscriptionRequest, params json.RawMessage, isAdmin bool) *types.RpcError {
+	prefix, err := subscriptionRequestExcluding(params, "books")
+	if err != nil {
+		return types.RpcErrorInvalidParams("Invalid unsubscription parameters.")
+	}
+	if rpcErr := ws.subscriptionManager.HandleUnsubscribe(wsConn.legacy, prefix, isAdmin); rpcErr != nil {
+		return rpcErr
+	}
+	return applySubscriptionBooks(request.WireArrays().Books, func(bookRequest types.SubscriptionRequest) *types.RpcError {
+		return ws.subscriptionManager.HandleUnsubscribe(wsConn.legacy, bookRequest, isAdmin)
+	})
+}
+
+func setSubscriptionLoadCost(ctx *types.RpcContext, request types.SubscriptionRequest) {
+	for _, book := range request.Books {
+		if book.Snapshot || book.StateNow {
+			ctx.LoadCost = uint32(loadtrack.LoadMedium)
+			return
+		}
+	}
+}
+
+func (ws *WebSocketServer) executeUnsubscribe(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
 	var request types.SubscriptionRequest
 	if len(cmd.Params) > 0 {
 		if err := json.Unmarshal(cmd.Params, &request); err != nil {
-			ws.sendError(wsConn, types.RpcErrorInvalidParams("Invalid unsubscription parameters: "+err.Error()), cmd.ID)
-			return
+			return nil, types.RpcErrorInvalidParams("Invalid unsubscription parameters.")
 		}
 	}
-
 	// See handleSubscribe: url requests target the RPCSub registry.
 	if request.HasURL() {
 		if !ctx.IsAdmin {
-			ws.sendError(wsConn, types.RpcErrorNoPermission("unsubscribe"), cmd.ID)
-			return
+			return nil, types.RpcErrorNoPermission("unsubscribe")
 		}
 		result, rpcErr := ws.urlSubs.Unsubscribe(ctx, request)
 		if rpcErr != nil {
-			ws.sendError(wsConn, rpcErr, cmd.ID)
-			return
+			return nil, rpcErr
 		}
-		ws.sendResponse(wsConn, types.WebSocketResponse{
-			Type:       "response",
-			ID:         cmd.ID,
-			Status:     "success",
-			Result:     result,
-			ApiVersion: ctx.ApiVersion,
-		})
-		return
+		return result, nil
 	}
 
-	if err := ws.subscriptionManager.HandleUnsubscribe(wsConn.legacy, request, ctx.IsAdmin); err != nil {
-		ws.sendError(wsConn, err, cmd.ID)
-		return
+	if rpcErr := ws.finishUnsubscribe(wsConn, request, cmd.Params, ctx.IsAdmin); rpcErr != nil {
+		return nil, rpcErr
 	}
 
-	response := types.WebSocketResponse{
-		Type:       "response",
-		ID:         cmd.ID,
-		Status:     "success",
-		Result:     map[string]any{},
-		ApiVersion: ctx.ApiVersion,
-	}
-	ws.sendResponse(wsConn, response)
+	return map[string]any{}, nil
 }
 
-// handlePathFind processes path_find commands (special WebSocket-only method).
-// Subcommands: "create" (start session), "close" (stop session), "status" (get current paths).
-// Reference: rippled PathFind.cpp
-func (ws *WebSocketServer) handlePathFind(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+func (ws *WebSocketServer) executePathFind(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
 	var sub struct {
 		Subcommand string `json:"subcommand"`
 	}
 	if len(cmd.Params) > 0 {
 		if err := json.Unmarshal(cmd.Params, &sub); err != nil {
-			ws.sendError(wsConn, types.RpcErrorInvalidParams("Invalid parameters: "+err.Error()), cmd.ID)
-			return
+			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 		}
 	}
 
 	switch sub.Subcommand {
 	case "create":
-		ws.handlePathFindCreate(wsConn, ctx, cmd)
+		ctx.LoadCost = uint32(loadtrack.LoadHeavy)
+		return ws.executePathFindCreate(wsConn, ctx, cmd)
 	case "close":
-		ws.handlePathFindClose(wsConn, ctx, cmd)
+		return ws.executePathFindClose(wsConn, ctx, cmd)
 	case "status":
-		ws.handlePathFindStatus(wsConn, ctx, cmd)
+		return ws.executePathFindStatus(wsConn, ctx, cmd)
 	default:
-		ws.sendError(wsConn, types.RpcErrorInvalidParams("Invalid field 'subcommand'."), cmd.ID)
+		return nil, types.RpcErrorInvalidParams("Invalid field 'subcommand'.")
 	}
 }
 
-// handlePathFindCreate creates a new persistent pathfinding session.
+// executePathFindCreate creates a new persistent pathfinding session.
 // Any existing session on this connection is replaced (matching rippled).
-func (ws *WebSocketServer) handlePathFindCreate(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+func (ws *WebSocketServer) executePathFindCreate(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
+	wsConn.mutex.Lock()
+	wsConn.pathFindSession = nil
+	wsConn.mutex.Unlock()
+
 	release, rpcErr := handlers.AcquirePathfind(ctx)
 	if rpcErr != nil {
-		ws.sendError(wsConn, rpcErr, cmd.ID)
-		return
+		return nil, rpcErr
 	}
 	defer release()
 
 	session, rpcErr := ParseAndCreateSession(cmd.Params, cmd.ID)
 	if rpcErr != nil {
-		ws.sendError(wsConn, rpcErr, cmd.ID)
-		return
+		return nil, rpcErr
 	}
 
 	if ctx.Services == nil || ctx.Services.Ledger == nil {
-		ws.sendError(wsConn, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
-			"No closed ledger available"), cmd.ID)
-		return
+		return nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
+			"No closed ledger available")
 	}
 	view, err := ctx.Services.Ledger.GetClosedLedgerView()
 	if err != nil {
-		ws.sendError(wsConn, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
-			"No closed ledger available"), cmd.ID)
-		return
+		return nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
+			"No closed ledger available")
 	}
 
 	event := session.Execute(view)
@@ -551,59 +691,38 @@ func (ws *WebSocketServer) handlePathFindCreate(wsConn *WebSocketConnection, ctx
 	wsConn.pathFindSession = session
 	wsConn.mutex.Unlock()
 
-	response := types.WebSocketResponse{
-		Type:       "response",
-		ID:         cmd.ID,
-		Status:     "success",
-		Result:     event,
-		ApiVersion: ctx.ApiVersion,
-	}
-	ws.sendResponse(wsConn, response)
+	return event, nil
 }
 
-// handlePathFindClose closes the active pathfinding session on this connection.
-func (ws *WebSocketServer) handlePathFindClose(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+// executePathFindClose closes the active pathfinding session on this connection.
+func (ws *WebSocketServer) executePathFindClose(wsConn *WebSocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
 	wsConn.mutex.Lock()
 	session := wsConn.pathFindSession
 	wsConn.pathFindSession = nil
 	wsConn.mutex.Unlock()
 
 	if session == nil {
-		ws.sendError(wsConn, types.RpcErrorNoPathRequest(), cmd.ID)
-		return
+		return nil, types.RpcErrorNoPathRequest()
 	}
 
-	response := types.WebSocketResponse{
-		Type:       "response",
-		ID:         cmd.ID,
-		Status:     "success",
-		Result:     map[string]any{"closed": true},
-		ApiVersion: ctx.ApiVersion,
-	}
-	ws.sendResponse(wsConn, response)
+	event := *session.GetLastResult()
+	event.Closed = true
+	return &event, nil
 }
 
-// handlePathFindStatus returns the current status of the active pathfinding session.
-func (ws *WebSocketServer) handlePathFindStatus(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+// executePathFindStatus returns the current status of the active pathfinding session.
+func (ws *WebSocketServer) executePathFindStatus(wsConn *WebSocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
 	wsConn.mutex.RLock()
 	session := wsConn.pathFindSession
 	wsConn.mutex.RUnlock()
 
 	if session == nil {
-		ws.sendError(wsConn, types.RpcErrorNoPathRequest(), cmd.ID)
-		return
+		return nil, types.RpcErrorNoPathRequest()
 	}
 
-	event := session.GetLastResult()
-
-	response := types.WebSocketResponse{
-		Type:       "response",
-		ID:         cmd.ID,
-		Status:     "success",
-		Result:     event,
-		ApiVersion: ctx.ApiVersion,
-	}
-	ws.sendResponse(wsConn, response)
+	event := *session.GetLastResult()
+	event.Status = "success"
+	return &event, nil
 }
 
 // UpdatePathFindSessions re-runs pathfinding for all active sessions on ledger close.
@@ -660,19 +779,18 @@ func (ws *WebSocketServer) handleRPCMethod(wsConn *WebSocketConnection, ctx *typ
 	// rpcNO_PERMISSION (ServerHandler.cpp:482-486): when requestRole returns
 	// Role::FORBID for an admin-required command, rippled writes
 	// rpcError(rpcFORBIDDEN) before doCommand ever runs.
-	result, rpcErr := dispatchMethod(ws.methodRegistry, ws.loadTracker, ws.services, ctx, cmd.Command, cmd.Params, types.RpcErrorForbidden, wsLog())
-	opts := wsLoadWarningOpts(ctx)
-	if rpcErr != nil {
-		ws.sendErrorWithOptions(wsConn, rpcErr, cmd.ID, opts)
+	resolution := resolveMethod(ws.methodRegistry, cmd.Command, ctx.ApiVersion)
+	if rpcErr := admitMethod(ws.loadTracker, ctx, cmd.Command, resolution, types.RpcErrorForbidden, false, wsLog()); rpcErr != nil {
+		warnLoad(ws.loadTracker, ctx, cmd.Command, wsLog())
+		ws.sendErrorResponse(wsConn, rpcErr, cmd.ID, nil, cmd.Request)
 		return
 	}
-	ws.sendResponseWithOptions(wsConn, types.WebSocketResponse{
-		Type:       "response",
-		ID:         cmd.ID,
-		Status:     "success",
-		Result:     result,
-		ApiVersion: ctx.ApiVersion,
-	}, opts)
+	result, rpcErr := dispatchResolvedMethod(ws.loadTracker, ws.services, ctx, cmd.Command, cmd.Params, resolution, wsLog())
+	if rpcErr != nil {
+		ws.sendErrorResponse(wsConn, rpcErr, cmd.ID, nil, cmd.Request)
+		return
+	}
+	ws.sendCommandResponse(wsConn, result, cmd, wsLoadWarningOpts(ctx))
 }
 
 // wsLoadWarningOpts surfaces rippled's warning:"load" on a WS reply when the
@@ -685,18 +803,28 @@ func wsLoadWarningOpts(ctx *types.RpcContext) *types.WebSocketResponseOptions {
 	return nil
 }
 
-func (ws *WebSocketServer) sendResponse(wsConn *WebSocketConnection, response types.WebSocketResponse) {
-	ws.sendResponseWithOptions(wsConn, response, nil)
-}
-
-func (ws *WebSocketServer) sendResponseWithOptions(wsConn *WebSocketConnection, response types.WebSocketResponse, opts *types.WebSocketResponseOptions) {
+func (ws *WebSocketServer) sendCommandResponse(wsConn *WebSocketConnection, result any, cmd types.WebSocketCommand, opts *types.WebSocketResponseOptions) {
+	payload := map[string]any{
+		"type":   "response",
+		"status": "success",
+	}
+	if result != nil {
+		payload["result"] = result
+	}
+	copyWSMetadata(payload, cmd.Request, cmd.ID)
 	if opts != nil {
-		response.Warning = opts.Warning
-		response.Warnings = opts.Warnings
-		response.Forwarded = opts.Forwarded
+		if opts.Warning != "" {
+			payload["warning"] = opts.Warning
+		}
+		if len(opts.Warnings) > 0 {
+			payload["warnings"] = opts.Warnings
+		}
+		if opts.Forwarded {
+			payload["forwarded"] = true
+		}
 	}
 
-	data, err := json.Marshal(response)
+	data, err := marshalWebSocketJSON(payload)
 	if err != nil {
 		wsLog().Error("Failed to marshal WebSocket response", "err", err)
 		return
@@ -726,21 +854,27 @@ func (ws *WebSocketServer) deliver(wsConn *WebSocketConnection, data []byte) {
 
 // resolveWSCommand resolves the WS command name from the incoming JSON,
 // accepting `method` as an alias for `command` (ServerHandler.cpp:446-475).
-// ok is false — meaning the caller emits missingCommand — when neither is a
-// non-empty string, or both are present strings that disagree.
+// ok is false when either supplied field is not a string, neither is supplied,
+// or both strings disagree. Empty strings are valid at this layer and resolve
+// to unknownCmd during dispatch.
 func resolveWSCommand(m map[string]any) (string, bool) {
-	cmd, cmdOK := m["command"].(string)
-	method, methodOK := m["method"].(string)
+	cmdValue, cmdPresent := m["command"]
+	methodValue, methodPresent := m["method"]
+	cmd, cmdOK := cmdValue.(string)
+	method, methodOK := methodValue.(string)
+	if (cmdPresent && !cmdOK) || (methodPresent && !methodOK) {
+		return "", false
+	}
 	switch {
-	case cmdOK && methodOK:
+	case cmdPresent && methodPresent:
 		if cmd != method {
 			return "", false
 		}
-		return cmd, cmd != ""
-	case cmdOK:
-		return cmd, cmd != ""
-	case methodOK:
-		return method, method != ""
+		return cmd, true
+	case cmdPresent:
+		return cmd, true
+	case methodPresent:
+		return method, true
 	default:
 		return "", false
 	}
@@ -751,26 +885,15 @@ func resolveWSCommand(m map[string]any) (string, bool) {
 // (ServerHandler.cpp:452-468). Credentials in the echo are redacted — a
 // deliberate goxrpl superset of rippled's raw echo.
 func (ws *WebSocketServer) sendMissingCommand(wsConn *WebSocketConnection, request map[string]any, id any) {
-	echo := make(map[string]any, len(request))
-	maps.Copy(echo, request)
-	redactCredentials(echo)
+	echo := redactedRequestMap(request)
 	resp := map[string]any{
 		"type":    "response",
 		"status":  "error",
 		"error":   "missingCommand",
 		"request": echo,
 	}
-	if id != nil {
-		resp["id"] = id
-	}
-	// rippled also lifts jsonrpc/ripplerpc/api_version to the top level of the
-	// error reply, alongside the request echo (ServerHandler.cpp:460-465).
-	for _, k := range []string{"jsonrpc", "ripplerpc", "api_version"} {
-		if v, ok := request[k]; ok {
-			resp[k] = v
-		}
-	}
-	data, err := json.Marshal(resp)
+	copyWSMetadata(resp, echo, id)
+	data, err := marshalWebSocketJSON(resp)
 	if err != nil {
 		wsLog().Error("Failed to marshal missingCommand response", "err", err)
 		return
@@ -778,39 +901,97 @@ func (ws *WebSocketServer) sendMissingCommand(wsConn *WebSocketConnection, reque
 	ws.deliver(wsConn, data)
 }
 
-func (ws *WebSocketServer) sendError(wsConn *WebSocketConnection, rpcErr *types.RpcError, id any) {
-	ws.sendErrorWithOptions(wsConn, rpcErr, id, nil)
+func (ws *WebSocketServer) sendJSONInvalid(wsConn *WebSocketConnection, value any, parsed bool) {
+	rawValue := "<redacted>"
+	if parsed {
+		if data, err := marshalWebSocketJSON(redactJSONValue(value)); err == nil {
+			rawValue = string(data)
+		}
+	}
+	data, err := marshalWebSocketJSON(map[string]any{
+		"type":  "error",
+		"error": "jsonInvalid",
+		"value": rawValue,
+	})
+	if err != nil {
+		wsLog().Error("Failed to marshal invalid JSON response", "err", err)
+		return
+	}
+	ws.deliver(wsConn, data)
 }
 
-// sendErrorWithOptions writes an XRPL-format error: error fields are at top
-// level (not nested in result) per the WebSocket spec.
-func (ws *WebSocketServer) sendErrorWithOptions(wsConn *WebSocketConnection, rpcErr *types.RpcError, id any, opts *types.WebSocketResponseOptions) {
-	response := types.WebSocketResponse{
-		Type:   "response",
-		Status: "error",
-		ID:     id,
-		Error:  rpcErr.ErrorString,
+func (ws *WebSocketServer) sendCommandError(wsConn *WebSocketConnection, rpcErr *types.RpcError, cmd types.WebSocketCommand) {
+	ws.sendErrorResponse(wsConn, rpcErr, cmd.ID, nil, cmd.Request)
+}
+
+func (ws *WebSocketServer) sendErrorResponse(wsConn *WebSocketConnection, rpcErr *types.RpcError, id any, opts *types.WebSocketResponseOptions, request map[string]any) {
+	response := map[string]any{
+		"type":   "response",
+		"status": "error",
+		"error":  rpcErr.ErrorString,
 	}
-	// Bare-token errors carry only `error` on the wire (rippled's direct
-	// jvResult[jss::error] path); leave error_code/error_message zero so
-	// omitempty drops them.
-	if !rpcErr.IsBareToken() {
-		response.ErrorCode = rpcErr.Code
-		response.ErrorMessage = rpcErr.Message
+	if id != nil {
+		response["id"] = id
+	}
+	if rpcErr.ErrorException != "" {
+		response["error_exception"] = rpcErr.ErrorException
+	} else if !rpcErr.IsBareToken() {
+		response["error_code"] = rpcErr.Code
+		response["error_message"] = rpcErr.Message
 	}
 
 	if opts != nil {
-		response.Warning = opts.Warning
-		response.Warnings = opts.Warnings
-		response.Forwarded = opts.Forwarded
+		if opts.Warning != "" {
+			response["warning"] = opts.Warning
+		}
+		if len(opts.Warnings) > 0 {
+			response["warnings"] = opts.Warnings
+		}
+		if opts.Forwarded {
+			response["forwarded"] = true
+		}
 	}
 
-	data, err := json.Marshal(response)
+	if request != nil {
+		response["request"] = request
+	}
+	copyWSMetadata(response, request, id)
+
+	data, err := marshalWebSocketJSON(response)
 	if err != nil {
 		wsLog().Error("Failed to marshal WebSocket error response", "err", err)
 		return
 	}
 	ws.deliver(wsConn, data)
+}
+
+func buildWSRequestEcho(message []byte) map[string]any {
+	var request map[string]any
+	if err := decodeJSONUseNumber(message, &request); err != nil || request == nil {
+		return nil
+	}
+	return redactedRequestMap(request)
+}
+
+func copyWSMetadata(response map[string]any, request map[string]any, fallbackID any) {
+	if fallbackID != nil {
+		response["id"] = fallbackID
+	}
+	for _, key := range []string{"id", "jsonrpc", "ripplerpc", "api_version"} {
+		if value, ok := request[key]; ok {
+			response[key] = value
+		}
+	}
+}
+
+func marshalWebSocketJSON(value any) ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSuffix(buffer.Bytes(), []byte{'\n'}), nil
 }
 
 // attachConnection is the single point at which a new WS connection
@@ -853,6 +1034,16 @@ func (ws *WebSocketServer) detachConnection(wsConn *WebSocketConnection) {
 // closes again and gorilla tolerates the double close.
 func (wsConn *WebSocketConnection) closeSocket() {
 	wsConn.cancel()
+	wsConn.conn.Close()
+}
+
+func (wsConn *WebSocketConnection) closeWithPolicyViolation(reason string) {
+	wsConn.cancel()
+	_ = wsConn.conn.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.ClosePolicyViolation, reason),
+		time.Now().Add(time.Second),
+	)
 	wsConn.conn.Close()
 }
 
@@ -915,7 +1106,7 @@ func (ws *WebSocketServer) buildSubscribeAck(ctx *types.RpcContext, request type
 	}
 
 	for _, book := range request.Books {
-		if !book.Snapshot || ctx.Services == nil || ctx.Services.Ledger == nil {
+		if (!book.Snapshot && !book.StateNow) || ctx.Services == nil || ctx.Services.Ledger == nil {
 			continue
 		}
 		var takerGets, takerPays types.CurrencySpec
@@ -927,9 +1118,9 @@ func (ws *WebSocketServer) buildSubscribeAck(ctx *types.RpcContext, request type
 		}
 		gets := types.Amount{Currency: takerGets.Currency, Issuer: takerGets.Issuer}
 		pays := types.Amount{Currency: takerPays.Currency, Issuer: takerPays.Issuer}
-		if book.Both {
-			bids, _ := ws.snapshotBook(ctx, gets, pays, book.Taker)
-			asks, _ := ws.snapshotBook(ctx, pays, gets, book.Taker)
+		if book.Both || book.BothSides {
+			bids, _ := ws.snapshotBook(ctx, gets, pays, book.Taker, book.Domain)
+			asks, _ := ws.snapshotBook(ctx, pays, gets, book.Taker, book.Domain)
 			if bids != nil {
 				result["bids"] = appendOffers(result["bids"], bids)
 			}
@@ -938,7 +1129,7 @@ func (ws *WebSocketServer) buildSubscribeAck(ctx *types.RpcContext, request type
 			}
 			continue
 		}
-		offers, _ := ws.snapshotBook(ctx, gets, pays, book.Taker)
+		offers, _ := ws.snapshotBook(ctx, gets, pays, book.Taker, book.Domain)
 		if offers != nil {
 			result["offers"] = appendOffers(result["offers"], offers)
 		}
@@ -952,11 +1143,11 @@ func (ws *WebSocketServer) buildSubscribeAck(ctx *types.RpcContext, request type
 // subscribe ack. Errors are squashed — a snapshot failure mustn't
 // reject the entire subscribe (rippled Subscribe.cpp:339-394 ignores
 // the snapshot block on lookup failure too).
-func (ws *WebSocketServer) snapshotBook(ctx *types.RpcContext, takerGets, takerPays types.Amount, taker string) ([]types.BookOffer, error) {
+func (ws *WebSocketServer) snapshotBook(ctx *types.RpcContext, takerGets, takerPays types.Amount, taker, domain string) ([]types.BookOffer, error) {
 	if ctx == nil || ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, nil
 	}
-	res, err := ctx.Services.Ledger.GetBookOffers(ctx.Context, takerGets, takerPays, taker, "", "current", DefaultBookSnapshotLimit, "", false)
+	res, err := ctx.Services.Ledger.GetBookOffers(ctx.Context, takerGets, takerPays, taker, domain, "validated", DefaultBookSnapshotLimit, "", false)
 	if err != nil || res == nil {
 		return nil, err
 	}

--- a/internal/rpc/websocket_special_dispatch_test.go
+++ b/internal/rpc/websocket_special_dispatch_test.go
@@ -1,0 +1,246 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+func newSpecialDispatchHarness(t *testing.T) (*WebSocketServer, *WebSocketConnection, *types.RpcContext) {
+	t.Helper()
+	services := &types.ServiceContainer{ClientLoad: types.NewClientLoadShedder()}
+	ws := NewWebSocketServerWithLoadTracker(time.Second, services, loadtrack.New())
+	ws.methodRegistry.Register("subscribe", &stubHandler{})
+	ws.methodRegistry.Register("path_find", &stubHandler{})
+	send := make(chan []byte, 1)
+	conn := &WebSocketConnection{
+		ID:          "special-dispatch",
+		sendChannel: send,
+		ctx:         context.Background(),
+		legacy: &types.Connection{
+			ID:            "special-dispatch",
+			Subscriptions: make(map[types.SubscriptionType]types.SubscriptionConfig),
+			SendChannel:   send,
+		},
+	}
+	ctx := newRpcContext(context.Background(), types.RoleGuest, types.DefaultApiVersion, "192.0.2.1", nil, services)
+	return ws, conn, ctx
+}
+
+func specialDispatchResponse(t *testing.T, conn *WebSocketConnection) map[string]any {
+	t.Helper()
+	select {
+	case body := <-conn.sendChannel:
+		var response map[string]any
+		if err := json.Unmarshal(body, &response); err != nil {
+			t.Fatalf("decode response %s: %v", body, err)
+		}
+		return response
+	default:
+		t.Fatal("special dispatch produced no response")
+		return nil
+	}
+}
+
+func specialDispatchCommand(command string) types.WebSocketCommand {
+	return types.WebSocketCommand{
+		Command: command,
+		ID:      int32(7),
+		Request: map[string]any{"command": command, "id": int32(7)},
+	}
+}
+
+func TestWebSocketSpecialDispatchBusyBoundary(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		inFlight   int
+		wantCalled bool
+		wantStatus string
+	}{
+		{name: "499 admitted", inFlight: 499, wantCalled: true, wantStatus: "success"},
+		{name: "500 rejected", inFlight: 500, wantCalled: false, wantStatus: "error"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ws, conn, ctx := newSpecialDispatchHarness(t)
+			for range test.inFlight {
+				ws.services.ClientLoad.Begin()
+			}
+			if !test.wantCalled {
+				ws.loadTracker.Import("peer", loadtrack.Gossip{Items: []loadtrack.GossipItem{{
+					Key:     ctx.ClientIP,
+					Balance: loadtrack.WarningThreshold,
+				}}})
+			}
+			called := false
+			ws.handleSpecialCommand(conn, ctx, specialDispatchCommand("subscribe"), func(_ *WebSocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
+				called = true
+				if got := ws.services.ClientLoad.InFlight(); got != int64(test.inFlight+1) {
+					t.Fatalf("in-flight inside handler = %d, want %d", got, test.inFlight+1)
+				}
+				return map[string]any{}, nil
+			})
+
+			response := specialDispatchResponse(t, conn)
+			if called != test.wantCalled {
+				t.Fatalf("handler called = %t, want %t", called, test.wantCalled)
+			}
+			if got := response["status"]; got != test.wantStatus {
+				t.Fatalf("status = %v, want %s", got, test.wantStatus)
+			}
+			if !test.wantCalled && (!ctx.LoadWarning || response["warning"] != nil) {
+				t.Fatalf("busy admission must consume but hide its load warning: %v", response)
+			}
+			if got := ws.services.ClientLoad.InFlight(); got != int64(test.inFlight) {
+				t.Fatalf("in-flight after dispatch = %d, want %d", got, test.inFlight)
+			}
+		})
+	}
+}
+
+func TestWebSocketSpecialDispatchWarningVisibility(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		handler     wsSpecialHandler
+		wantWarning bool
+	}{
+		{
+			name: "success exposes warning",
+			handler: func(_ *WebSocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
+				return map[string]any{}, nil
+			},
+			wantWarning: true,
+		},
+		{
+			name: "error suppresses warning",
+			handler: func(_ *WebSocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
+				return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ws, conn, ctx := newSpecialDispatchHarness(t)
+			ws.loadTracker.Import("peer", loadtrack.Gossip{Items: []loadtrack.GossipItem{{
+				Key:     ctx.ClientIP,
+				Balance: loadtrack.WarningThreshold,
+			}}})
+
+			ws.handleSpecialCommand(conn, ctx, specialDispatchCommand("subscribe"), test.handler)
+			response := specialDispatchResponse(t, conn)
+			if got := response["warning"] == "load"; got != test.wantWarning {
+				t.Fatalf("warning present = %t, want %t (response %v)", got, test.wantWarning, response)
+			}
+			if !ctx.LoadWarning {
+				t.Fatal("post-dispatch Warn was not consumed")
+			}
+		})
+	}
+}
+
+func TestWebSocketSpecialDispatchRecoversPanic(t *testing.T) {
+	ws, conn, ctx := newSpecialDispatchHarness(t)
+	ws.handleSpecialCommand(conn, ctx, specialDispatchCommand("subscribe"), func(_ *WebSocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
+		panic("private panic detail")
+	})
+
+	response := specialDispatchResponse(t, conn)
+	wantResponse := map[string]any{
+		"type":          "response",
+		"status":        "error",
+		"error":         "internal",
+		"error_code":    float64(types.RpcINTERNAL),
+		"error_message": "Internal error.",
+		"id":            float64(7),
+		"request":       map[string]any{"command": "subscribe", "id": float64(7)},
+	}
+	if !reflect.DeepEqual(response, wantResponse) {
+		t.Fatalf("panic response = %v, want %v", response, wantResponse)
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal panic response: %v", err)
+	}
+	if strings.Contains(string(encoded), "private panic detail") {
+		t.Fatalf("panic response leaked private detail: %s", encoded)
+	}
+	if got, want := ws.loadTracker.LocalBalance(ctx.ClientIP), float64(loadtrack.ChargeException/uint32(loadtrack.DecayWindow/time.Second)); got != want {
+		t.Fatalf("panic charge = %v, want %v", got, want)
+	}
+	if got := ws.services.ClientLoad.InFlight(); got != 0 {
+		t.Fatalf("in-flight leaked after panic: %d", got)
+	}
+}
+
+func TestWebSocketPathFindDynamicLoadCost(t *testing.T) {
+	ws, conn, ctx := newSpecialDispatchHarness(t)
+	for _, test := range []struct {
+		subcommand string
+		want       loadtrack.LoadKind
+	}{
+		{subcommand: "create", want: loadtrack.LoadHeavy},
+		{subcommand: "close", want: loadtrack.LoadReference},
+		{subcommand: "status", want: loadtrack.LoadReference},
+	} {
+		t.Run(test.subcommand, func(t *testing.T) {
+			ctx.LoadCost = uint32(loadtrack.LoadReference)
+			cmd := specialDispatchCommand("path_find")
+			cmd.Params = json.RawMessage(`{"subcommand":"` + test.subcommand + `"}`)
+			_, _ = ws.executePathFind(conn, ctx, cmd)
+			if got := loadtrack.LoadKind(ctx.LoadCost); got != test.want {
+				t.Fatalf("load kind = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestWebSocketSubscribeSnapshotLoadCostAfterValidation(t *testing.T) {
+	const validSnapshot = `{"books":[{"taker_pays":{"currency":"XRP"},"taker_gets":{"currency":"USD","issuer":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},"snapshot":true}]}`
+	const validStateNow = `{"books":[{"taker_pays":{"currency":"XRP"},"taker_gets":{"currency":"USD","issuer":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},"state_now":true}]}`
+	const invalidSnapshot = `{"books":[{"taker_pays":{"currency":"XRP"},"taker_gets":{"currency":"XRP"},"snapshot":true}]}`
+	const validThenInvalidSnapshot = `{"books":[{"taker_pays":{"currency":"XRP"},"taker_gets":{"currency":"USD","issuer":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},"snapshot":true},{"taker_pays":{"currency":"XRP"},"taker_gets":{"currency":"XRP"}}]}`
+	for _, test := range []struct {
+		name      string
+		params    string
+		want      loadtrack.LoadKind
+		wantError bool
+	}{
+		{name: "validated snapshot", params: validSnapshot, want: loadtrack.LoadMedium},
+		{name: "validated state_now", params: validStateNow, want: loadtrack.LoadMedium},
+		{name: "invalid snapshot", params: invalidSnapshot, want: loadtrack.LoadReference, wantError: true},
+		{name: "later invalid book retains snapshot load", params: validThenInvalidSnapshot, want: loadtrack.LoadMedium, wantError: true},
+		{name: "no snapshot", params: `{}`, want: loadtrack.LoadReference},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ws, conn, ctx := newSpecialDispatchHarness(t)
+			ctx.LoadCost = uint32(loadtrack.LoadReference)
+			cmd := specialDispatchCommand("subscribe")
+			cmd.Params = json.RawMessage(test.params)
+			_, rpcErr := ws.executeSubscribe(conn, ctx, cmd)
+			if (rpcErr != nil) != test.wantError {
+				t.Fatalf("error = %v, wantError %t", rpcErr, test.wantError)
+			}
+			if got := loadtrack.LoadKind(ctx.LoadCost); got != test.want {
+				t.Fatalf("load kind = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestWebSocketSubscribeBothSidesAlias(t *testing.T) {
+	ws, conn, ctx := newSpecialDispatchHarness(t)
+	cmd := specialDispatchCommand("subscribe")
+	cmd.Params = json.RawMessage(`{"books":[{"taker_pays":{"currency":"XRP"},"taker_gets":{"currency":"USD","issuer":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"},"both_sides":true}]}`)
+	_, rpcErr := ws.executeSubscribe(conn, ctx, cmd)
+	if rpcErr != nil {
+		t.Fatalf("subscribe error = %v", rpcErr)
+	}
+	books := conn.legacy.Subscriptions[types.SubBook].Books
+	if len(books) != 2 {
+		t.Fatalf("book subscriptions = %d, want 2", len(books))
+	}
+}

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -504,7 +504,7 @@ func TestWebSocketSpecialCommandDecodeErrorsAreFixed(t *testing.T) {
 				Request: map[string]any{"command": test.command, "id": int32(7)},
 			}
 
-			test.invoke(ws, wsConn, &types.RpcContext{}, cmd)
+			test.invoke(ws, wsConn, &types.RpcContext{ApiVersion: types.DefaultApiVersion}, cmd)
 			body := <-wsConn.sendChannel
 			if got := string(body); got != test.want {
 				t.Fatalf("response = %s, want %s", got, test.want)
@@ -538,7 +538,7 @@ func TestWebSocketJSONInvalidWireEnvelope(t *testing.T) {
 		{name: "oversized", request: strings.Repeat(" ", MaxRequestBytes+1), want: `{"error":"jsonInvalid","type":"error","value":"<redacted>"}`},
 		{name: "null", request: `null`, want: `{"error":"jsonInvalid","type":"error","value":"null"}`},
 		{name: "scalar", request: `7`, want: `{"error":"jsonInvalid","type":"error","value":"7"}`},
-		{name: "redacted array", request: `[{"secret":"private seed","nested":{"Seed":"nested seed"}}]`, want: `{"error":"jsonInvalid","type":"error","value":"[{\\"nested\\":{\\"Seed\\":\\"<masked>\\"},\\"secret\\":\\"<masked>\\"}]"}`},
+		{name: "redacted array", request: `[{"secret":"private seed","nested":{"Seed":"nested seed"}}]`, want: `{"error":"jsonInvalid","type":"error","value":"[{\"nested\":{\"Seed\":\"<masked>\"},\"secret\":\"<masked>\"}]"}`},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -491,6 +491,7 @@ func TestWebSocketSpecialCommandDecodeErrorsAreFixed(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ws := NewWebSocketServer(time.Second, nil)
+			ws.RegisterAllMethods()
 			wsConn := &WebSocketConnection{
 				ID:          "decode-test",
 				sendChannel: make(chan []byte, 1),

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/gorilla/websocket"
 )
 
@@ -352,6 +354,253 @@ func TestWebSocketSubscribeErrorWireEnvelope(t *testing.T) {
 				t.Errorf("error_message = %v, want %q", got, tc.wantMessage)
 			}
 		})
+	}
+}
+
+func TestWebSocketHandlerPanicWireEnvelope(t *testing.T) {
+	const panicCause = "websocket panic must stay private"
+	ws := NewWebSocketServer(30*time.Second, nil)
+	ws.methodRegistry.Register("panic", &stubHandler{
+		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+			panic(panicCause)
+		},
+	})
+
+	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
+	defer httpSrv.Close()
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = ws.Close(ctx)
+	}()
+
+	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http")
+	client, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	request := `{"command":"panic","id":7,"jsonrpc":"2.0","ripplerpc":"1.0","api_version":2,"secret":"private seed","transaction":{"Seed":"nested private seed"}}`
+	if err := client.WriteMessage(websocket.TextMessage, []byte(request)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := client.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	_, body, err := client.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	const want = `{"api_version":2,"error":"internal","error_code":73,"error_message":"Internal error.","id":7,"jsonrpc":"2.0","request":{"api_version":2,"command":"panic","id":7,"jsonrpc":"2.0","ripplerpc":"1.0","secret":"<masked>","transaction":{"Seed":"<masked>"}},"ripplerpc":"1.0","status":"error","type":"response"}`
+	if got := string(body); got != want {
+		t.Fatalf("panic response = %s, want %s", got, want)
+	}
+	for _, private := range []string{panicCause, "private seed", "nested private seed"} {
+		if strings.Contains(string(body), private) {
+			t.Fatalf("panic response leaked %q: %s", private, body)
+		}
+	}
+}
+
+func TestWebSocketOrdinaryErrorWireEnvelope(t *testing.T) {
+	ws := NewWebSocketServer(30*time.Second, nil)
+	ws.methodRegistry.Register("fail", &stubHandler{
+		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+			return nil, rpcInternalError()
+		},
+	})
+
+	body := wsRawRoundTrip(t, ws, `{"command":"fail","id":7,"jsonrpc":"2.0","ripplerpc":"1.0","api_version":2,"secret":"private seed"}`)
+	const want = `{"api_version":2,"error":"internal","error_code":73,"error_message":"Internal error.","id":7,"jsonrpc":"2.0","request":{"api_version":2,"command":"fail","id":7,"jsonrpc":"2.0","ripplerpc":"1.0","secret":"<masked>"},"ripplerpc":"1.0","status":"error","type":"response"}`
+	if got := string(body); got != want {
+		t.Fatalf("response = %s, want %s", got, want)
+	}
+}
+
+func TestWebSocketRedactsIDAndPreservesItInHandlerParams(t *testing.T) {
+	received := make(chan json.RawMessage, 1)
+	ws := NewWebSocketServer(30*time.Second, nil)
+	ws.methodRegistry.Register("capture", &stubHandler{
+		handle: func(_ *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+			received <- append(json.RawMessage(nil), params...)
+			return map[string]any{"ok": true}, nil
+		},
+	})
+
+	body := wsRawRoundTrip(t, ws, `{"command":"capture","method":"capture","api_version":1,"id":{"SeCrEt":"private-id"},"payload":"kept"}`)
+	const want = `{"api_version":1,"id":{"SeCrEt":"<masked>"},"result":{"ok":true},"status":"success","type":"response"}`
+	if got := string(body); got != want {
+		t.Fatalf("response = %s, want %s", got, want)
+	}
+	if strings.Contains(string(body), "private-id") {
+		t.Fatalf("response leaked id credential: %s", body)
+	}
+
+	var params map[string]any
+	if err := json.Unmarshal(<-received, &params); err != nil {
+		t.Fatalf("decode handler params: %v", err)
+	}
+	id, ok := params["id"].(map[string]any)
+	if !ok || len(id) != 1 || id["SeCrEt"] != maskedValue {
+		t.Fatalf("handler id = %v, want redacted id", params["id"])
+	}
+	if params["payload"] != "kept" {
+		t.Fatalf("handler payload = %v, want kept", params["payload"])
+	}
+	for _, stripped := range []string{"command", "method", "api_version"} {
+		if _, exists := params[stripped]; exists {
+			t.Fatalf("handler params retained %q: %v", stripped, params)
+		}
+	}
+}
+
+func TestWebSocketSpecialCommandDecodeErrorsAreFixed(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+		invoke  func(*WebSocketServer, *WebSocketConnection, *types.RpcContext, types.WebSocketCommand)
+	}{
+		{
+			name:    "subscribe",
+			command: "subscribe",
+			want:    `{"error":"invalidParams","error_code":31,"error_message":"Invalid subscription parameters.","id":7,"request":{"command":"subscribe","id":7},"status":"error","type":"response"}`,
+			invoke:  (*WebSocketServer).handleSubscribe,
+		},
+		{
+			name:    "unsubscribe",
+			command: "unsubscribe",
+			want:    `{"error":"invalidParams","error_code":31,"error_message":"Invalid unsubscription parameters.","id":7,"request":{"command":"unsubscribe","id":7},"status":"error","type":"response"}`,
+			invoke:  (*WebSocketServer).handleUnsubscribe,
+		},
+		{
+			name:    "path find",
+			command: "path_find",
+			want:    `{"error":"invalidParams","error_code":31,"error_message":"Invalid parameters.","id":7,"request":{"command":"path_find","id":7},"status":"error","type":"response"}`,
+			invoke:  (*WebSocketServer).handlePathFind,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ws := NewWebSocketServer(time.Second, nil)
+			wsConn := &WebSocketConnection{
+				ID:          "decode-test",
+				sendChannel: make(chan []byte, 1),
+				ctx:         context.Background(),
+			}
+			cmd := types.WebSocketCommand{
+				Command: test.command,
+				ID:      int32(7),
+				Params:  json.RawMessage(`{"private":"decoder-detail"`),
+				Request: map[string]any{"command": test.command, "id": int32(7)},
+			}
+
+			test.invoke(ws, wsConn, &types.RpcContext{}, cmd)
+			body := <-wsConn.sendChannel
+			if got := string(body); got != test.want {
+				t.Fatalf("response = %s, want %s", got, test.want)
+			}
+			if strings.Contains(string(body), "decoder-detail") || strings.Contains(string(body), "unexpected end") {
+				t.Fatalf("response leaked decoder detail: %s", body)
+			}
+		})
+	}
+}
+
+func TestWebSocketRejectsTrailingJSON(t *testing.T) {
+	ws := NewWebSocketServer(30*time.Second, nil)
+	ws.methodRegistry.Register("ping", &stubHandler{})
+
+	body := wsRawRoundTrip(t, ws, `{"command":"ping","id":7}{"command":"ping","id":8}`)
+	const want = `{"error":"jsonInvalid","type":"error","value":"<redacted>"}`
+	if got := string(body); got != want {
+		t.Fatalf("trailing JSON response = %s, want %s", got, want)
+	}
+}
+
+func TestWebSocketJSONInvalidWireEnvelope(t *testing.T) {
+	ws := NewWebSocketServer(30*time.Second, nil)
+	tests := []struct {
+		name    string
+		request string
+		want    string
+	}{
+		{name: "malformed", request: `{`, want: `{"error":"jsonInvalid","type":"error","value":"<redacted>"}`},
+		{name: "oversized", request: strings.Repeat(" ", MaxRequestBytes+1), want: `{"error":"jsonInvalid","type":"error","value":"<redacted>"}`},
+		{name: "null", request: `null`, want: `{"error":"jsonInvalid","type":"error","value":"null"}`},
+		{name: "scalar", request: `7`, want: `{"error":"jsonInvalid","type":"error","value":"7"}`},
+		{name: "redacted array", request: `[{"secret":"private seed","nested":{"Seed":"nested seed"}}]`, want: `{"error":"jsonInvalid","type":"error","value":"[{\\"nested\\":{\\"Seed\\":\\"<masked>\\"},\\"secret\\":\\"<masked>\\"}]"}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := wsRawRoundTrip(t, ws, test.request)
+			if got := string(body); got != test.want {
+				t.Fatalf("response = %s, want %s", got, test.want)
+			}
+			if strings.Contains(string(body), "private seed") || strings.Contains(string(body), "nested seed") {
+				t.Fatalf("response leaked a credential: %s", body)
+			}
+		})
+	}
+}
+
+func TestWebSocketJSONIntegerBounds(t *testing.T) {
+	ws := NewWebSocketServer(30*time.Second, nil)
+	ws.methodRegistry.Register("ping", &stubHandler{})
+
+	for _, request := range []string{
+		`{"command":"ping","id":4294967296}`,
+		`{"command":"ping","id":-2147483649}`,
+	} {
+		body := wsRawRoundTrip(t, ws, request)
+		const want = `{"error":"jsonInvalid","type":"error","value":"<redacted>"}`
+		if got := string(body); got != want {
+			t.Fatalf("response for %s = %s, want %s", request, got, want)
+		}
+	}
+
+	tests := []struct {
+		request string
+		want    string
+	}{
+		{
+			request: `{"command":"ping","id":4294967295}`,
+			want:    `{"id":4294967295,"result":{"ok":true},"status":"success","type":"response"}`,
+		},
+		{
+			request: `{"command":"ping","id":-2147483648}`,
+			want:    `{"id":-2147483648,"result":{"ok":true},"status":"success","type":"response"}`,
+		},
+		{
+			request: `{"command":"ping","id":1e20}`,
+			want:    `{"id":1e+20,"result":{"ok":true},"status":"success","type":"response"}`,
+		},
+	}
+	for _, test := range tests {
+		body := wsRawRoundTrip(t, ws, test.request)
+		if got := string(body); got != test.want {
+			t.Fatalf("response for %s = %s, want %s", test.request, got, test.want)
+		}
+	}
+}
+
+func TestWebSocketErrorExceptionWireEnvelope(t *testing.T) {
+	ws := NewWebSocketServer(30*time.Second, nil)
+	ws.methodRegistry.Register("simulate", &stubHandler{
+		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+			return nil, types.RpcErrorInvalidTransaction("invalid transaction detail")
+		},
+	})
+
+	body := wsRawRoundTrip(t, ws, `{"command":"simulate","id":9}`)
+	const want = `{"error":"invalidTransaction","error_exception":"invalid transaction detail","id":9,"request":{"command":"simulate","id":9},"status":"error","type":"response"}`
+	if got := string(body); got != want {
+		t.Fatalf("response = %s, want %s", got, want)
+	}
+	if strings.Contains(string(body), "error_code") || strings.Contains(string(body), "error_message") {
+		t.Fatalf("manual error gained injected fields: %s", body)
 	}
 }
 

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -467,19 +467,25 @@ func TestWebSocketSpecialCommandDecodeErrorsAreFixed(t *testing.T) {
 			name:    "subscribe",
 			command: "subscribe",
 			want:    `{"error":"invalidParams","error_code":31,"error_message":"Invalid subscription parameters.","id":7,"request":{"command":"subscribe","id":7},"status":"error","type":"response"}`,
-			invoke:  (*WebSocketServer).handleSubscribe,
+			invoke: func(ws *WebSocketServer, conn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+				ws.handleSpecialCommand(conn, ctx, cmd, ws.executeSubscribe)
+			},
 		},
 		{
 			name:    "unsubscribe",
 			command: "unsubscribe",
 			want:    `{"error":"invalidParams","error_code":31,"error_message":"Invalid unsubscription parameters.","id":7,"request":{"command":"unsubscribe","id":7},"status":"error","type":"response"}`,
-			invoke:  (*WebSocketServer).handleUnsubscribe,
+			invoke: func(ws *WebSocketServer, conn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+				ws.handleSpecialCommand(conn, ctx, cmd, ws.executeUnsubscribe)
+			},
 		},
 		{
 			name:    "path find",
 			command: "path_find",
 			want:    `{"error":"invalidParams","error_code":31,"error_message":"Invalid parameters.","id":7,"request":{"command":"path_find","id":7},"status":"error","type":"response"}`,
-			invoke:  (*WebSocketServer).handlePathFind,
+			invoke: func(ws *WebSocketServer, conn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+				ws.handleSpecialCommand(conn, ctx, cmd, ws.executePathFind)
+			},
 		},
 	}
 	for _, test := range tests {

--- a/internal/testing/rpcenv/rpcenv.go
+++ b/internal/testing/rpcenv/rpcenv.go
@@ -67,7 +67,7 @@ func (e *Env) RPCAs(method string, params any, role types.Role, apiVersion int) 
 
 	handler, ok := e.registry.Get(method)
 	if !ok {
-		return nil, types.RpcErrorMethodNotFound(method)
+		return nil, types.RpcErrorMethodNotFound()
 	}
 
 	var raw json.RawMessage

--- a/internal/tx/engine/apply_panic_test.go
+++ b/internal/tx/engine/apply_panic_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
 	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -76,6 +77,10 @@ func (t *stagedStateApplyTx) Apply(ctx *txcore.ApplyContext) ter.Result {
 type failingAtomicPseudoView struct {
 	*ledger.Ledger
 	candidate *ledger.Ledger
+}
+
+func (v *failingAtomicPseudoView) ApplyAtomically(apply func(ledger.Writer) error) error {
+	return v.Ledger.ApplyAtomically(apply)
 }
 
 func (v *failingAtomicPseudoView) AdoptState(candidate *ledger.Ledger) error {
@@ -357,7 +362,7 @@ func newApplyPanicLedger() *ledger.Ledger {
 	)
 }
 
-func pseudoRecoveryEngine(view txcore.LedgerView, ledgerSequence uint32) *Engine {
+func pseudoRecoveryEngine(view applystate.AtomicLedgerView, ledgerSequence uint32) *Engine {
 	return NewEngine(view, txcore.EngineConfig{
 		LedgerSequence: ledgerSequence,
 		Rules:          amendment.AllSupportedRules(),

--- a/internal/tx/engine/engine_recovery_886_test.go
+++ b/internal/tx/engine/engine_recovery_886_test.go
@@ -108,9 +108,8 @@ func readRecoveryAccount(t *testing.T, view txcore.LedgerView, k keylet.Keylet) 
 	return acct
 }
 
-// recoveryTx builds a closed-ledger-applicable single-signed AccountSet-shaped
-// BaseTx with an explicit fee and sequence. AccountSet is a no-op when it has no
-// fields, so it never reaches a per-type Apply that would itself fail.
+// recoveryTx builds the common fields used by the closed-ledger recovery tests.
+// Tests that reach doApply wrap it in an Appliable fixture.
 func recoveryTx(fee, seq uint32) *txcore.BaseTx {
 	tx := txcore.NewBaseTx(txcore.TypeAccountSet, recoveryTestAccount)
 	tx.Common.Fee = strconv.FormatUint(uint64(fee), 10)
@@ -119,11 +118,17 @@ func recoveryTx(fee, seq uint32) *txcore.BaseTx {
 	return tx
 }
 
+type successfulRecoveryTx struct {
+	*txcore.BaseTx
+}
+
+func (successfulRecoveryTx) Apply(*txcore.ApplyContext) ter.Result { return ter.TesSUCCESS }
+
 func TestApply_SuccessStagesFeeAtomically(t *testing.T) {
 	view := newRecordingBaseView()
 	acctKey := fundRecoveryAccount(t, view, 1_000_000, 1)
 
-	res := recoveryEngine(view, txcore.TapNONE).Apply(recoveryTx(10, 1))
+	res := recoveryEngine(view, txcore.TapNONE).Apply(successfulRecoveryTx{recoveryTx(10, 1)})
 	if res.Result != ter.TesSUCCESS || !res.Applied {
 		t.Fatalf("result/applied = %s/%v, want tesSUCCESS/true", res.Result, res.Applied)
 	}

--- a/internal/tx/engine/engine_recovery_886_test.go
+++ b/internal/tx/engine/engine_recovery_886_test.go
@@ -108,8 +108,6 @@ func readRecoveryAccount(t *testing.T, view txcore.LedgerView, k keylet.Keylet) 
 	return acct
 }
 
-// recoveryTx builds the common fields used by the closed-ledger recovery tests.
-// Tests that reach doApply wrap it in an Appliable fixture.
 func recoveryTx(fee, seq uint32) *txcore.BaseTx {
 	tx := txcore.NewBaseTx(txcore.TypeAccountSet, recoveryTestAccount)
 	tx.Common.Fee = strconv.FormatUint(uint64(fee), 10)

--- a/internal/tx/serialize.go
+++ b/internal/tx/serialize.go
@@ -3,11 +3,126 @@ package tx
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
+	"math"
 	"sort"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec/definitions"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec/serdes"
 )
+
+// CanonicalizeSerializedTransaction validates and returns the codec-decoded
+// representation of a serialized transaction.
+func CanonicalizeSerializedTransaction(fields map[string]any) (map[string]any, error) {
+	encoded, err := serializedObjectBytes(fields)
+	if err != nil {
+		return nil, err
+	}
+	parsed, err := ParseFromBinary(encoded)
+	if err != nil {
+		return nil, err
+	}
+	common := parsed.GetCommon()
+	if common.TransactionType == "" {
+		return nil, errors.New("transaction is missing TransactionType")
+	}
+	txType, ok := TypeFromName(common.TransactionType)
+	if !ok {
+		return nil, fmt.Errorf("unknown transaction type %q", common.TransactionType)
+	}
+
+	if err := checkRequiredFields(commonFields, common.PresentFields); err != nil {
+		return nil, err
+	}
+	if err := checkRequiredFields(txTemplates[txType], common.PresentFields); err != nil {
+		return nil, err
+	}
+	return binarycodec.DecodeBytes(encoded)
+}
+
+// CanonicalizeSerializedMetadata validates and returns the codec-decoded
+// representation of transaction metadata.
+func CanonicalizeSerializedMetadata(fields map[string]any) (map[string]any, error) {
+	canonical, err := CanonicalizeSerializedObject(fields)
+	if err != nil {
+		return nil, err
+	}
+	for _, name := range []string{"TransactionResult", "TransactionIndex", "AffectedNodes"} {
+		if _, ok := canonical[name]; !ok {
+			return nil, fmt.Errorf("metadata is missing %s", name)
+		}
+	}
+	return canonical, nil
+}
+
+// CanonicalizeSerializedObject validates codec field types and returns the
+// decoded canonical object without applying a higher-level object template.
+func CanonicalizeSerializedObject(fields map[string]any) (map[string]any, error) {
+	encoded, err := serializedObjectBytes(fields)
+	if err != nil {
+		return nil, err
+	}
+	return binarycodec.DecodeBytes(encoded)
+}
+
+func serializedObjectBytes(fields map[string]any) ([]byte, error) {
+	if err := validateSerializedJSONNumbers(fields); err != nil {
+		return nil, err
+	}
+	return binarycodec.EncodeBytes(fields)
+}
+
+func validateSerializedJSONNumbers(value any) error {
+	switch value := value.(type) {
+	case map[string]any:
+		defs := definitions.Get()
+		for name, fieldValue := range value {
+			if number, ok := fieldValue.(float64); ok {
+				field, err := defs.GetFieldInstanceByFieldName(name)
+				if err == nil {
+					var max float64
+					switch field.Type {
+					case "UInt8":
+						max = 1<<8 - 1
+					case "UInt16":
+						max = 1<<16 - 1
+					case "UInt32":
+						max = 1<<32 - 1
+					}
+					if max != 0 && (number < 0 || number > max || math.Trunc(number) != number) {
+						return fmt.Errorf("field %q is not a valid %s", name, field.Type)
+					}
+				}
+			}
+			if err := validateSerializedJSONNumbers(fieldValue); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for _, element := range value {
+			if err := validateSerializedJSONNumbers(element); err != nil {
+				return err
+			}
+		}
+	case []map[string]any:
+		for _, element := range value {
+			if err := validateSerializedJSONNumbers(element); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func checkRequiredFields(template map[string]fieldStyle, present map[string]bool) error {
+	for name, style := range template {
+		if style == soeREQUIRED && !present[name] {
+			return fmt.Errorf("transaction is missing required field %q", name)
+		}
+	}
+	return nil
+}
 
 var (
 	// ErrLengthPrefixTooLong is returned when the length exceeds 918744 bytes
@@ -66,22 +181,19 @@ func MetadataToMap(meta *Metadata) map[string]any {
 	result["TransactionIndex"] = meta.TransactionIndex
 
 	// AffectedNodes - sort by LedgerIndex to match rippled's ordering
-	if len(meta.AffectedNodes) > 0 {
-		// Sort nodes by LedgerIndex (ascending)
-		sortedNodes := make([]AffectedNode, len(meta.AffectedNodes))
-		copy(sortedNodes, meta.AffectedNodes)
-		sort.Slice(sortedNodes, func(i, j int) bool {
-			return sortedNodes[i].LedgerIndex < sortedNodes[j].LedgerIndex
-		})
+	sortedNodes := make([]AffectedNode, len(meta.AffectedNodes))
+	copy(sortedNodes, meta.AffectedNodes)
+	sort.Slice(sortedNodes, func(i, j int) bool {
+		return sortedNodes[i].LedgerIndex < sortedNodes[j].LedgerIndex
+	})
 
-		nodes := make([]map[string]any, len(sortedNodes))
-		for i, node := range sortedNodes {
-			nodes[i] = map[string]any{
-				node.NodeType: buildAffectedNodeInner(node),
-			}
+	nodes := make([]map[string]any, len(sortedNodes))
+	for i, node := range sortedNodes {
+		nodes[i] = map[string]any{
+			node.NodeType: buildAffectedNodeInner(node),
 		}
-		result["AffectedNodes"] = nodes
 	}
+	result["AffectedNodes"] = nodes
 
 	// DeliveredAmount (optional). The BINARY metadata field is sfDeliveredAmount
 	// (codec/definitions name "DeliveredAmount", type Amount). The snake_case
@@ -187,6 +299,5 @@ func SplitTxWithMetaBlob(blob []byte) (txData []byte, metaData []byte, err error
 	if err != nil {
 		return nil, nil, err
 	}
-
 	return txData, metaData, nil
 }


### PR DESCRIPTION
## Summary

- return generic `rpcINTERNAL` text for all 69 handler-side runtime error paths
- log the underlying cause and operation in the RPC partition
- add an AST guard and integration coverage preventing runtime-composed internal messages from leaking again

The issue's seven-site count covered direct `.Error()` calls; the same leak also occurred through formatting and concatenation. Those equivalent paths are included here. This intentionally hardens the legacy PayChan/TransactionSign-style exception paths where rippled exposes runtime detail.

## Test plan

- [x] `go test -race ./internal/rpc/... -count=1`
- [x] full conformance (1260/1260 in scope)
- [x] `just build-all`
- [x] `just vet`
- [x] `just lint`

Fixes #1176