### PR TITLE
fix: make apply state flush atomic

### DIFF
--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -85,6 +85,13 @@ type Writer interface {
 	AdjustDropsDestroyed(drops drops.XRPAmount)
 }
 
+// AtomicWriter can commit a group of ledger and destroyed-drop changes as one
+// unit. The supplied writer is valid only for the duration of apply.
+type AtomicWriter interface {
+	Writer
+	ApplyAtomically(apply func(Writer) error) error
+}
+
 // Ledger represents a single ledger in the chain
 type Ledger struct {
 	mu sync.RWMutex
@@ -101,6 +108,8 @@ type Ledger struct {
 	// Drops destroyed in this ledger (transaction fees)
 	dropsDestroyed drops.XRPAmount
 }
+
+var _ AtomicWriter = (*Ledger)(nil)
 
 // NewOpen creates a new open ledger based on a parent ledger
 func NewOpen(parent *Ledger, closeTime time.Time) (*Ledger, error) {
@@ -428,6 +437,36 @@ func (l *Ledger) AdjustDropsDestroyed(drops drops.XRPAmount) {
 	defer l.mu.Unlock()
 
 	l.dropsDestroyed = l.dropsDestroyed.Add(drops)
+}
+
+// ApplyAtomically commits state changes made through apply as one unit.
+func (l *Ledger) ApplyAtomically(apply func(Writer) error) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.state != StateOpen {
+		return ErrLedgerImmutable
+	}
+
+	stateMap, err := l.stateMap.MutableFork()
+	if err != nil {
+		return fmt.Errorf("fork ledger state: %w", err)
+	}
+	staged := &Ledger{
+		stateMap:       stateMap,
+		txMap:          l.txMap,
+		header:         l.header,
+		fees:           l.fees,
+		state:          l.state,
+		dropsDestroyed: l.dropsDestroyed,
+	}
+	if err := apply(staged); err != nil {
+		return err
+	}
+
+	l.stateMap = staged.stateMap
+	l.dropsDestroyed = staged.dropsDestroyed
+	return nil
 }
 
 // AdoptState replaces this ledger's state map, tx map, and destroyed-drops tally

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -439,7 +439,6 @@ func (l *Ledger) AdjustDropsDestroyed(drops drops.XRPAmount) {
 	l.dropsDestroyed = l.dropsDestroyed.Add(drops)
 }
 
-// ApplyAtomically commits state changes made through apply as one unit.
 func (l *Ledger) ApplyAtomically(apply func(Writer) error) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/internal/ledger/ledger_mutation_test.go
+++ b/internal/ledger/ledger_mutation_test.go
@@ -102,6 +102,64 @@ func TestLedger_MutateHappyAndErrorPaths(t *testing.T) {
 	}
 }
 
+func TestLedger_ApplyAtomically(t *testing.T) {
+	l := newOpenChild(t)
+	existing := mutAcct(0x03)
+	original := mutData(0x11)
+	if err := l.Insert(existing, original); err != nil {
+		t.Fatalf("seed existing entry: %v", err)
+	}
+	l.AdjustDropsDestroyed(drops.XRPAmount(10))
+
+	inserted := mutAcct(0x04)
+	injected := errors.New("injected apply failure")
+	err := l.ApplyAtomically(func(view Writer) error {
+		if err := view.Update(existing, mutData(0x22)); err != nil {
+			return err
+		}
+		if err := view.Insert(inserted, mutData(0x33)); err != nil {
+			return err
+		}
+		view.AdjustDropsDestroyed(drops.XRPAmount(5))
+		return injected
+	})
+	if !errors.Is(err, injected) {
+		t.Fatalf("ApplyAtomically error = %v, want %v", err, injected)
+	}
+	if got, _ := l.Read(existing); !bytes.Equal(got, original) {
+		t.Fatalf("failed apply changed existing entry: got %x want %x", got, original)
+	}
+	if exists, _ := l.Exists(inserted); exists {
+		t.Fatal("failed apply committed inserted entry")
+	}
+	if l.dropsDestroyed != drops.XRPAmount(10) {
+		t.Fatalf("failed apply destroyed %d drops, want 10", l.dropsDestroyed)
+	}
+
+	err = l.ApplyAtomically(func(view Writer) error {
+		if err := view.Update(existing, mutData(0x22)); err != nil {
+			return err
+		}
+		if err := view.Insert(inserted, mutData(0x33)); err != nil {
+			return err
+		}
+		view.AdjustDropsDestroyed(drops.XRPAmount(5))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ApplyAtomically success: %v", err)
+	}
+	if got, _ := l.Read(existing); !bytes.Equal(got, mutData(0x22)) {
+		t.Fatalf("successful apply existing entry = %x, want %x", got, mutData(0x22))
+	}
+	if got, _ := l.Read(inserted); !bytes.Equal(got, mutData(0x33)) {
+		t.Fatalf("successful apply inserted entry = %x, want %x", got, mutData(0x33))
+	}
+	if l.dropsDestroyed != drops.XRPAmount(15) {
+		t.Fatalf("successful apply destroyed %d drops, want 15", l.dropsDestroyed)
+	}
+}
+
 // TestLedger_MutatorsRejectedWhenImmutable verifies that once a ledger is
 // closed (state != StateOpen), all three mutators are rejected with
 // ErrLedgerImmutable. The targeted entry is seeded while the ledger is

--- a/internal/ledger/service/snapshot_view.go
+++ b/internal/ledger/service/snapshot_view.go
@@ -16,6 +16,8 @@ type snapshotView struct {
 	ledger   *ledger.Ledger // for TxExists
 }
 
+var _ ledger.AtomicWriter = (*snapshotView)(nil)
+
 // newSnapshotView creates a new snapshot-based ledger view.
 func newSnapshotView(snapshot *shamap.SHAMap, l *ledger.Ledger) *snapshotView {
 	return &snapshotView{
@@ -53,6 +55,19 @@ func (v *snapshotView) Erase(k keylet.Keylet) error {
 
 func (v *snapshotView) AdjustDropsDestroyed(d drops.XRPAmount) {
 	// No-op for simulation — drops destroyed are discarded
+}
+
+func (v *snapshotView) ApplyAtomically(apply func(ledger.Writer) error) error {
+	stateMap, err := v.stateMap.MutableFork()
+	if err != nil {
+		return err
+	}
+	staged := newSnapshotView(stateMap, v.ledger)
+	if err := apply(staged); err != nil {
+		return err
+	}
+	v.stateMap = staged.stateMap
+	return nil
 }
 
 func (v *snapshotView) ForEach(fn func(key [32]byte, data []byte) bool) error {

--- a/internal/ledger/service/snapshot_view_atomic_test.go
+++ b/internal/ledger/service/snapshot_view_atomic_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	ledgercore "github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+func TestSnapshotViewApplyAtomically(t *testing.T) {
+	stateMap := shamap.New(shamap.TypeState)
+	existing := keylet.Keylet{Key: [32]byte{1}}
+	inserted := keylet.Keylet{Key: [32]byte{2}}
+	original := bytes.Repeat([]byte{1}, 12)
+	updated := bytes.Repeat([]byte{2}, 12)
+	created := bytes.Repeat([]byte{3}, 12)
+	if err := stateMap.Put(existing.Key, original); err != nil {
+		t.Fatalf("seed state map: %v", err)
+	}
+	view := newSnapshotView(stateMap, nil)
+	injected := errors.New("injected apply failure")
+
+	err := view.ApplyAtomically(func(writer ledgercore.Writer) error {
+		if err := writer.Update(existing, updated); err != nil {
+			return err
+		}
+		if err := writer.Insert(inserted, created); err != nil {
+			return err
+		}
+		return injected
+	})
+	if !errors.Is(err, injected) {
+		t.Fatalf("ApplyAtomically error = %v, want %v", err, injected)
+	}
+	if got, _ := view.Read(existing); !bytes.Equal(got, original) {
+		t.Fatalf("failed apply changed existing entry: got %v want %v", got, original)
+	}
+	if exists, _ := view.Exists(inserted); exists {
+		t.Fatal("failed apply committed inserted entry")
+	}
+
+	err = view.ApplyAtomically(func(writer ledgercore.Writer) error {
+		if err := writer.Update(existing, updated); err != nil {
+			return err
+		}
+		return writer.Insert(inserted, created)
+	})
+	if err != nil {
+		t.Fatalf("ApplyAtomically success: %v", err)
+	}
+	if got, _ := view.Read(existing); !bytes.Equal(got, updated) {
+		t.Fatalf("successful apply existing entry = %v, want %v", got, updated)
+	}
+	if got, _ := view.Read(inserted); !bytes.Equal(got, created) {
+		t.Fatalf("successful apply inserted entry = %v, want %v", got, created)
+	}
+}

--- a/internal/tx/applystate/apply_atomicity_test.go
+++ b/internal/tx/applystate/apply_atomicity_test.go
@@ -257,6 +257,28 @@ func TestApplyStateTableAtomicFailureDoesNotMutateTable(t *testing.T) {
 	}
 }
 
+func TestApplyStateTableAtomicSuccessCopiesCallbackData(t *testing.T) {
+	base := newMockBaseView()
+	table := NewApplyStateTable(base, [32]byte{1}, 2, amendment.AllSupportedRules())
+	data := []byte{1}
+
+	err := table.ApplyAtomically(func(view ledgercore.Writer) error {
+		return view.Insert(kl(1), data)
+	})
+	if err != nil {
+		t.Fatalf("ApplyAtomically: %v", err)
+	}
+
+	data[0] = 9
+	got, err := table.Read(kl(1))
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !bytes.Equal(got, []byte{1}) {
+		t.Fatalf("stored data changed through callback-owned slice: got %v", got)
+	}
+}
+
 func TestApplyFlushesTrackedItemsInKeyOrder(t *testing.T) {
 	entry := encodeApplyTestEntry(t, map[string]any{
 		"LedgerEntryType": "AccountRoot",

--- a/internal/tx/applystate/apply_atomicity_test.go
+++ b/internal/tx/applystate/apply_atomicity_test.go
@@ -1,0 +1,352 @@
+package applystate
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/drops"
+	ledgercore "github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/tx/ledgerfields"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+var errInjectedMutation = errors.New("injected base mutation failure")
+
+type recordedMutation struct {
+	action string
+	key    [32]byte
+}
+
+type recordingBaseView struct {
+	*mockBaseView
+	mutations []recordedMutation
+	reads     [][32]byte
+	destroyed drops.XRPAmount
+	attempts  int
+	failAt    int
+}
+
+func newRecordingBaseView() *recordingBaseView {
+	return &recordingBaseView{mockBaseView: newMockBaseView()}
+}
+
+func (m *recordingBaseView) Read(k keylet.Keylet) ([]byte, error) {
+	m.reads = append(m.reads, k.Key)
+	return m.mockBaseView.Read(k)
+}
+
+func (m *recordingBaseView) Insert(k keylet.Keylet, data []byte) error {
+	m.attempts++
+	if m.failAt == m.attempts {
+		return errInjectedMutation
+	}
+	m.mutations = append(m.mutations, recordedMutation{action: "insert", key: k.Key})
+	return m.mockBaseView.Insert(k, data)
+}
+
+func (m *recordingBaseView) Update(k keylet.Keylet, data []byte) error {
+	m.attempts++
+	if m.failAt == m.attempts {
+		return errInjectedMutation
+	}
+	m.mutations = append(m.mutations, recordedMutation{action: "update", key: k.Key})
+	return m.mockBaseView.Update(k, data)
+}
+
+func (m *recordingBaseView) Erase(k keylet.Keylet) error {
+	m.attempts++
+	if m.failAt == m.attempts {
+		return errInjectedMutation
+	}
+	m.mutations = append(m.mutations, recordedMutation{action: "erase", key: k.Key})
+	return m.mockBaseView.Erase(k)
+}
+
+func (m *recordingBaseView) AdjustDropsDestroyed(amount drops.XRPAmount) {
+	m.destroyed = m.destroyed.Add(amount)
+}
+
+func (m *recordingBaseView) ApplyAtomically(apply func(ledgercore.Writer) error) error {
+	staged := newRecordingBaseView()
+	for key, data := range m.data {
+		staged.data[key] = bytes.Clone(data)
+	}
+	staged.mutations = append(staged.mutations, m.mutations...)
+	staged.reads = append(staged.reads, m.reads...)
+	staged.destroyed = m.destroyed
+	staged.attempts = m.attempts
+	staged.failAt = m.failAt
+
+	err := apply(staged)
+	m.attempts = staged.attempts
+	m.reads = staged.reads
+	if err != nil {
+		return err
+	}
+	m.mockBaseView = staged.mockBaseView
+	m.mutations = staged.mutations
+	m.destroyed = staged.destroyed
+	return nil
+}
+
+func encodeApplyTestEntry(t *testing.T, fields map[string]any) []byte {
+	t.Helper()
+	hexData, err := binarycodec.Encode(fields)
+	if err != nil {
+		t.Fatalf("encode ledger entry: %v", err)
+	}
+	data, err := hex.DecodeString(hexData)
+	if err != nil {
+		t.Fatalf("decode ledger entry: %v", err)
+	}
+	return data
+}
+
+func TestApplyMetadataBuildErrorDoesNotMutateBase(t *testing.T) {
+	valid := encodeApplyTestEntry(t, map[string]any{
+		"LedgerEntryType": "AccountRoot",
+	})
+	invalid := encodeApplyTestEntry(t, map[string]any{
+		"LedgerEntryType": "AccountRoot",
+		"DestinationTag":  uint32(1),
+	})
+
+	base := newRecordingBaseView()
+	table := NewApplyStateTable(base, [32]byte{1}, 2, amendment.AllSupportedRules())
+	if err := table.Insert(kl(1), valid); err != nil {
+		t.Fatalf("insert valid entry: %v", err)
+	}
+	if err := table.Insert(kl(255), invalid); err != nil {
+		t.Fatalf("insert invalid entry: %v", err)
+	}
+	table.AdjustDropsDestroyed(drops.NewXRPAmount(1))
+	metadata, err := table.Apply()
+	if err == nil {
+		t.Fatal("Apply succeeded with a metadata field invalid for AccountRoot")
+	}
+	if metadata != nil {
+		t.Fatalf("Apply metadata = %+v, want nil", metadata)
+	}
+	var unknownField *ledgerfields.ErrUnknownField
+	if !errors.As(err, &unknownField) {
+		t.Fatalf("Apply error = %v, want ErrUnknownField", err)
+	}
+	if unknownField.EntryType != "AccountRoot" || unknownField.TypeCode != 2 || unknownField.FieldCode != 14 {
+		t.Fatalf("unexpected unknown field: %+v", unknownField)
+	}
+	if base.attempts != 0 {
+		t.Fatalf("made %d base mutation attempts before returning the build error", base.attempts)
+	}
+	if len(base.mutations) != 0 {
+		t.Fatalf("committed %d base mutations before returning the build error", len(base.mutations))
+	}
+	if len(base.data) != 0 {
+		t.Fatalf("left %d entries in the base after the build error", len(base.data))
+	}
+	if !base.destroyed.IsZero() {
+		t.Fatalf("destroyed %s before returning the build error", base.destroyed)
+	}
+	if got := table.items[key(1)].Current; !bytes.Equal(got, valid) {
+		t.Fatalf("failed apply changed valid tracked entry: got %x want %x", got, valid)
+	}
+	if len(table.threadOnlyOwners) != 0 {
+		t.Fatalf("failed apply retained %d threaded owners", len(table.threadOnlyOwners))
+	}
+}
+
+func TestApplyBaseWriteErrorRollsBackAndCanRetry(t *testing.T) {
+	entry := encodeApplyTestEntry(t, map[string]any{
+		"LedgerEntryType": "AccountRoot",
+	})
+	base := newRecordingBaseView()
+	base.failAt = 2
+	table := NewApplyStateTable(base, [32]byte{1}, 2, amendment.AllSupportedRules())
+	if err := table.Insert(kl(1), entry); err != nil {
+		t.Fatalf("insert first entry: %v", err)
+	}
+	if err := table.Insert(kl(2), entry); err != nil {
+		t.Fatalf("insert second entry: %v", err)
+	}
+	table.AdjustDropsDestroyed(drops.NewXRPAmount(1))
+
+	metadata, err := table.Apply()
+	if !errors.Is(err, errInjectedMutation) {
+		t.Fatalf("Apply error = %v, want %v", err, errInjectedMutation)
+	}
+	if metadata != nil {
+		t.Fatalf("Apply metadata = %+v, want nil", metadata)
+	}
+	if base.attempts != 2 {
+		t.Fatalf("got %d base mutation attempts, want 2", base.attempts)
+	}
+	if len(base.mutations) != 0 {
+		t.Fatalf("committed %d base mutations after write failure", len(base.mutations))
+	}
+	if len(base.data) != 0 {
+		t.Fatalf("left %d entries in the base after write failure", len(base.data))
+	}
+	if !base.destroyed.IsZero() {
+		t.Fatalf("destroyed %s after write failure", base.destroyed)
+	}
+	for _, k := range [][32]byte{key(1), key(2)} {
+		if got := table.items[k].Current; !bytes.Equal(got, entry) {
+			t.Fatalf("failed apply changed tracked entry %x: got %x want %x", k, got, entry)
+		}
+	}
+	if len(table.threadOnlyOwners) != 0 {
+		t.Fatalf("failed apply retained %d threaded owners", len(table.threadOnlyOwners))
+	}
+
+	metadata, err = table.Apply()
+	if err != nil {
+		t.Fatalf("retry Apply: %v", err)
+	}
+	if len(metadata.AffectedNodes) != 2 {
+		t.Fatalf("retry affected nodes = %d, want 2", len(metadata.AffectedNodes))
+	}
+	for _, node := range metadata.AffectedNodes {
+		if node.PreviousTxnID != "" || node.PreviousTxnLgrSeq != 0 {
+			t.Fatalf("retry emitted self-referential previous transaction: %+v", node)
+		}
+	}
+	if len(base.data) != 2 || len(base.mutations) != 2 {
+		t.Fatalf("retry committed data/mutations = %d/%d, want 2/2", len(base.data), len(base.mutations))
+	}
+	if base.destroyed != drops.NewXRPAmount(1) {
+		t.Fatalf("retry destroyed %s, want 1 drop", base.destroyed)
+	}
+}
+
+func TestApplyStateTableAtomicFailureDoesNotMutateTable(t *testing.T) {
+	base := newMockBaseView()
+	table := NewApplyStateTable(base, [32]byte{1}, 2, amendment.AllSupportedRules())
+	if err := table.Insert(kl(1), []byte{1}); err != nil {
+		t.Fatalf("seed table: %v", err)
+	}
+	injected := errors.New("injected nested apply failure")
+
+	err := table.ApplyAtomically(func(view ledgercore.Writer) error {
+		staged := view.(*ApplyStateTable)
+		data, err := staged.Read(kl(1))
+		if err != nil {
+			return err
+		}
+		data[0] = 9
+		if err := view.Insert(kl(2), []byte{2}); err != nil {
+			return err
+		}
+		view.AdjustDropsDestroyed(drops.NewXRPAmount(1))
+		return injected
+	})
+	if !errors.Is(err, injected) {
+		t.Fatalf("ApplyAtomically error = %v, want %v", err, injected)
+	}
+	if data, _ := table.Read(kl(1)); !bytes.Equal(data, []byte{1}) {
+		t.Fatalf("existing entry changed to %v after failed nested apply", data)
+	}
+	if exists, _ := table.Exists(kl(2)); exists {
+		t.Fatal("failed nested apply inserted a new entry")
+	}
+	if !table.drops.IsZero() {
+		t.Fatalf("failed nested apply destroyed %s", table.drops)
+	}
+}
+
+func TestApplyFlushesTrackedItemsInKeyOrder(t *testing.T) {
+	entry := encodeApplyTestEntry(t, map[string]any{
+		"LedgerEntryType": "AccountRoot",
+	})
+	base := newRecordingBaseView()
+	table := NewApplyStateTable(base, [32]byte{1}, 2, amendment.AllSupportedRules())
+
+	for i := 32; i >= 1; i-- {
+		if err := table.Insert(kl(byte(i)), entry); err != nil {
+			t.Fatalf("insert entry %d: %v", i, err)
+		}
+	}
+
+	metadata, err := table.Apply()
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(base.mutations) != 32 {
+		t.Fatalf("got %d mutations, want 32", len(base.mutations))
+	}
+	if len(metadata.AffectedNodes) != 32 {
+		t.Fatalf("got %d affected nodes, want 32", len(metadata.AffectedNodes))
+	}
+	for i := 1; i <= 32; i++ {
+		wantKey := key(byte(i))
+		mutation := base.mutations[i-1]
+		if mutation.action != "insert" || mutation.key != wantKey {
+			t.Fatalf("mutation %d = {%s %x}, want {insert %x}", i-1, mutation.action, mutation.key, wantKey)
+		}
+		if metadata.AffectedNodes[i-1].LedgerIndex != hexUpper(wantKey) {
+			t.Fatalf("affected node %d has index %s, want %s", i-1, metadata.AffectedNodes[i-1].LedgerIndex, hexUpper(wantKey))
+		}
+	}
+}
+
+func TestApplyThreadsTrackedItemsInKeyOrder(t *testing.T) {
+	base := newRecordingBaseView()
+	table := NewApplyStateTable(base, [32]byte{1}, 2, amendment.AllSupportedRules())
+	wantReads := make([][32]byte, 8)
+
+	for i := 8; i >= 1; i-- {
+		var accountID [20]byte
+		accountID[19] = byte(i)
+		account, err := addresscodec.EncodeAccountIDToClassicAddress(accountID[:])
+		if err != nil {
+			t.Fatalf("encode account %d: %v", i, err)
+		}
+		entry := encodeApplyTestEntry(t, map[string]any{
+			"LedgerEntryType": "Offer",
+			"Account":         account,
+		})
+		if err := table.Insert(kl(byte(i)), entry); err != nil {
+			t.Fatalf("insert entry %d: %v", i, err)
+		}
+		wantReads[i-1] = keylet.Account(accountID).Key
+	}
+
+	if _, err := table.Apply(); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(base.reads) != len(wantReads) {
+		t.Fatalf("got %d owner reads, want %d", len(base.reads), len(wantReads))
+	}
+	for i, want := range wantReads {
+		if base.reads[i] != want {
+			t.Fatalf("owner read %d = %x, want %x", i, base.reads[i], want)
+		}
+	}
+}
+
+func TestApplyFlushesThreadOnlyOwnersInKeyOrder(t *testing.T) {
+	base := newRecordingBaseView()
+	table := NewApplyStateTable(base, [32]byte{}, 2, amendment.AllSupportedRules())
+
+	for i := 32; i >= 1; i-- {
+		ownerKey := key(byte(i))
+		table.threadOnlyOwners[ownerKey] = &ThreadedOwner{Updated: []byte{byte(i)}}
+	}
+
+	if _, err := table.Apply(); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(base.mutations) != 32 {
+		t.Fatalf("got %d mutations, want 32", len(base.mutations))
+	}
+	for i := 1; i <= 32; i++ {
+		wantKey := key(byte(i))
+		mutation := base.mutations[i-1]
+		if mutation.action != "update" || mutation.key != wantKey {
+			t.Fatalf("mutation %d = {%s %x}, want {update %x}", i-1, mutation.action, mutation.key, wantKey)
+		}
+	}
+}

--- a/internal/tx/applystate/apply_state_table.go
+++ b/internal/tx/applystate/apply_state_table.go
@@ -193,7 +193,7 @@ func (t *ApplyStateTable) Insert(k keylet.Keylet, data []byte) error {
 		}
 		// Re-inserting a deleted entry becomes a modify
 		entry.Action = ActionModify
-		entry.Current = data
+		entry.Current = bytes.Clone(data)
 		entry.reinserted = true
 		return nil
 	}
@@ -211,7 +211,7 @@ func (t *ApplyStateTable) Insert(k keylet.Keylet, data []byte) error {
 	t.items[k.Key] = &TrackedEntry{
 		Action:   ActionInsert,
 		Original: nil,
-		Current:  data,
+		Current:  bytes.Clone(data),
 	}
 
 	return nil
@@ -228,7 +228,7 @@ func (t *ApplyStateTable) Update(k keylet.Keylet, data []byte) error {
 			entry.Action = ActionModify
 		}
 		// For insert, keep it as insert with new data
-		entry.Current = data
+		entry.Current = bytes.Clone(data)
 		return nil
 	}
 
@@ -245,14 +245,14 @@ func (t *ApplyStateTable) Update(k keylet.Keylet, data []byte) error {
 		// Reference: rippled's ApplyView uses insert() for new entries.
 		t.items[k.Key] = &TrackedEntry{
 			Action:  ActionInsert,
-			Current: data,
+			Current: bytes.Clone(data),
 		}
 	} else {
 		// Track as modified
 		t.items[k.Key] = &TrackedEntry{
 			Action:   ActionModify,
 			Original: original,
-			Current:  data,
+			Current:  bytes.Clone(data),
 		}
 	}
 

--- a/internal/tx/applystate/apply_state_table.go
+++ b/internal/tx/applystate/apply_state_table.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/drops"
+	ledgercore "github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/invariants"
@@ -69,7 +71,7 @@ type ThreadedOwner struct {
 // ApplyStateTable wraps a LedgerView and tracks all modifications
 // for automatic metadata generation, similar to rippled's ApplyStateTable
 type ApplyStateTable struct {
-	base             tx.LedgerView
+	base             AtomicLedgerView
 	items            map[[32]byte]*TrackedEntry
 	threadOnlyOwners map[[32]byte]*ThreadedOwner
 	drops            drops.XRPAmount
@@ -78,10 +80,18 @@ type ApplyStateTable struct {
 	rules            *amendment.Rules
 }
 
+// AtomicLedgerView is a ledger view that can commit a group of writes as one unit.
+type AtomicLedgerView interface {
+	tx.LedgerView
+	ledgercore.AtomicWriter
+}
+
+var _ AtomicLedgerView = (*ApplyStateTable)(nil)
+
 // NewApplyStateTable creates a new ApplyStateTable wrapping the given base view.
 // rules controls amendment-gated behaviour (threading, metadata flags).
 // If nil, defaults to all amendments enabled.
-func NewApplyStateTable(base tx.LedgerView, txHash [32]byte, txSeq uint32, rules *amendment.Rules) *ApplyStateTable {
+func NewApplyStateTable(base AtomicLedgerView, txHash [32]byte, txSeq uint32, rules *amendment.Rules) *ApplyStateTable {
 	return &ApplyStateTable{
 		base:             base,
 		items:            make(map[[32]byte]*TrackedEntry),
@@ -90,6 +100,49 @@ func NewApplyStateTable(base tx.LedgerView, txHash [32]byte, txSeq uint32, rules
 		txSeq:            txSeq,
 		rules:            rules,
 	}
+}
+
+func (t *ApplyStateTable) clone() *ApplyStateTable {
+	items := make(map[[32]byte]*TrackedEntry, len(t.items))
+	for key, entry := range t.items {
+		cloned := *entry
+		cloned.Original = bytes.Clone(entry.Original)
+		cloned.Current = bytes.Clone(entry.Current)
+		items[key] = &cloned
+	}
+
+	threadOnlyOwners := make(map[[32]byte]*ThreadedOwner, len(t.threadOnlyOwners))
+	for key, owner := range t.threadOnlyOwners {
+		cloned := *owner
+		cloned.Updated = bytes.Clone(owner.Updated)
+		threadOnlyOwners[key] = &cloned
+	}
+
+	return &ApplyStateTable{
+		base:             t.base,
+		items:            items,
+		threadOnlyOwners: threadOnlyOwners,
+		drops:            t.drops,
+		txHash:           t.txHash,
+		txSeq:            t.txSeq,
+		rules:            t.rules,
+	}
+}
+
+func (t *ApplyStateTable) adopt(staged *ApplyStateTable) {
+	t.items = staged.items
+	t.threadOnlyOwners = staged.threadOnlyOwners
+	t.drops = staged.drops
+}
+
+// ApplyAtomically stages changes in an isolated copy of the table.
+func (t *ApplyStateTable) ApplyAtomically(apply func(ledgercore.Writer) error) error {
+	staged := t.clone()
+	if err := apply(staged); err != nil {
+		return err
+	}
+	t.adopt(staged)
+	return nil
 }
 
 // Read reads a ledger entry, tracking it as cached
@@ -338,21 +391,45 @@ func (t *ApplyStateTable) Succ(key [32]byte) ([32]byte, []byte, bool, error) {
 	return bestKey, bestData, found, nil
 }
 
+func sortedLedgerKeys[V any](entries map[[32]byte]V) [][32]byte {
+	keys := make([][32]byte, 0, len(entries))
+	for key := range entries {
+		keys = append(keys, key)
+	}
+	slices.SortFunc(keys, func(a, b [32]byte) int {
+		return bytes.Compare(a[:], b[:])
+	})
+	return keys
+}
+
 // Apply commits all changes to the base view and returns generated metadata.
-// Threading is applied first (PreviousTxnID/PreviousTxnLgrSeq updates),
-// then metadata is generated from the final state.
+// Threading and metadata generation complete before changes are flushed.
 // Reference: rippled ApplyStateTable.cpp apply() lines 113-292
 func (t *ApplyStateTable) Apply() (*tx.Metadata, error) {
-	// Phase 1: Apply threading to all entries
-	// This updates PreviousTxnID/PreviousTxnLgrSeq on entries and their owners
-	t.applyThreading()
+	staged := t.clone()
+	staged.applyThreading()
+	metadata, err := staged.applyOrdered(
+		staged.base,
+		sortedLedgerKeys(staged.items),
+		sortedLedgerKeys(staged.threadOnlyOwners),
+	)
+	if err != nil {
+		return nil, err
+	}
+	t.adopt(staged)
+	return metadata, nil
+}
 
-	// Phase 2: Generate metadata and apply to base
+func (t *ApplyStateTable) applyOrdered(
+	atomicBase ledgercore.AtomicWriter,
+	itemKeys, ownerKeys [][32]byte,
+) (*tx.Metadata, error) {
 	metadata := &tx.Metadata{
 		AffectedNodes: make([]tx.AffectedNode, 0),
 	}
 
-	for key, entry := range t.items {
+	for _, key := range itemKeys {
+		entry := t.items[key]
 		switch entry.Action {
 		case ActionCache:
 			// No change, skip
@@ -364,10 +441,6 @@ func (t *ApplyStateTable) Apply() (*tx.Metadata, error) {
 				return nil, err
 			}
 			metadata.AffectedNodes = append(metadata.AffectedNodes, node)
-
-			if err := t.base.Insert(keylet.Keylet{Key: key}, entry.Current); err != nil {
-				return nil, err
-			}
 
 		case ActionModify:
 			// Skip if no actual change
@@ -381,20 +454,12 @@ func (t *ApplyStateTable) Apply() (*tx.Metadata, error) {
 			}
 			metadata.AffectedNodes = append(metadata.AffectedNodes, node)
 
-			if err := t.base.Update(keylet.Keylet{Key: key}, entry.Current); err != nil {
-				return nil, err
-			}
-
 		case ActionErase:
 			node, err := t.buildDeletedNode(key, entry.Original, entry.Current)
 			if err != nil {
 				return nil, err
 			}
 			metadata.AffectedNodes = append(metadata.AffectedNodes, node)
-
-			if err := t.base.Erase(keylet.Keylet{Key: key}); err != nil {
-				return nil, err
-			}
 		}
 	}
 
@@ -410,7 +475,8 @@ func (t *ApplyStateTable) Apply() (*tx.Metadata, error) {
 	// zero. Those extra leaves inflated every tx's meta blob → tx+meta
 	// SHAMap root diverged from rippled → fork at the first ledger
 	// carrying transactions that touched fresh owner accounts.
-	for key, owner := range t.threadOnlyOwners {
+	for _, key := range ownerKeys {
+		owner := t.threadOnlyOwners[key]
 		if entry, alreadyEmitted := t.items[key]; alreadyEmitted {
 			// Skip the bare emission only when the tracked item emits its own
 			// node. A no-op ActionModify (Original == Current) is dropped by the
@@ -434,14 +500,45 @@ func (t *ApplyStateTable) Apply() (*tx.Metadata, error) {
 			}
 			metadata.AffectedNodes = append(metadata.AffectedNodes, node)
 		}
-
-		if err := t.base.Update(keylet.Keylet{Key: key}, owner.Updated); err != nil {
-			return nil, err
-		}
 	}
 
-	if t.drops.IsPositive() {
-		t.base.AdjustDropsDestroyed(t.drops)
+	// Metadata builders may fail; keep the base unchanged until all succeed.
+	err := atomicBase.ApplyAtomically(func(base ledgercore.Writer) error {
+		for _, key := range itemKeys {
+			entry := t.items[key]
+			switch entry.Action {
+			case ActionInsert:
+				if err := base.Insert(keylet.Keylet{Key: key}, entry.Current); err != nil {
+					return err
+				}
+			case ActionModify:
+				if bytes.Equal(entry.Original, entry.Current) {
+					continue
+				}
+				if err := base.Update(keylet.Keylet{Key: key}, entry.Current); err != nil {
+					return err
+				}
+			case ActionErase:
+				if err := base.Erase(keylet.Keylet{Key: key}); err != nil {
+					return err
+				}
+			}
+		}
+
+		for _, key := range ownerKeys {
+			owner := t.threadOnlyOwners[key]
+			if err := base.Update(keylet.Keylet{Key: key}, owner.Updated); err != nil {
+				return err
+			}
+		}
+
+		if t.drops.IsPositive() {
+			base.AdjustDropsDestroyed(t.drops)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return metadata, nil
@@ -469,8 +566,9 @@ func (t *ApplyStateTable) applyThreading() {
 		key   [32]byte
 		entry *TrackedEntry
 	}
-	var work []threadWork
-	for key, entry := range t.items {
+	work := make([]threadWork, 0, len(t.items))
+	for _, key := range sortedLedgerKeys(t.items) {
+		entry := t.items[key]
 		if entry.Action == ActionInsert || entry.Action == ActionModify || entry.Action == ActionErase {
 			work = append(work, threadWork{key, entry})
 		}

--- a/internal/tx/applystate/apply_state_table.go
+++ b/internal/tx/applystate/apply_state_table.go
@@ -80,7 +80,6 @@ type ApplyStateTable struct {
 	rules            *amendment.Rules
 }
 
-// AtomicLedgerView is a ledger view that can commit a group of writes as one unit.
 type AtomicLedgerView interface {
 	tx.LedgerView
 	ledgercore.AtomicWriter
@@ -135,7 +134,6 @@ func (t *ApplyStateTable) adopt(staged *ApplyStateTable) {
 	t.drops = staged.drops
 }
 
-// ApplyAtomically stages changes in an isolated copy of the table.
 func (t *ApplyStateTable) ApplyAtomically(apply func(ledgercore.Writer) error) error {
 	staged := t.clone()
 	if err := apply(staged); err != nil {

--- a/internal/tx/applystate/apply_state_table_test.go
+++ b/internal/tx/applystate/apply_state_table_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/drops"
+	ledgercore "github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -44,6 +45,18 @@ func (m *mockBaseView) Erase(k keylet.Keylet) error {
 }
 
 func (m *mockBaseView) AdjustDropsDestroyed(drops.XRPAmount) {}
+
+func (m *mockBaseView) ApplyAtomically(apply func(ledgercore.Writer) error) error {
+	staged := newMockBaseView()
+	for key, data := range m.data {
+		staged.data[key] = bytes.Clone(data)
+	}
+	if err := apply(staged); err != nil {
+		return err
+	}
+	m.data = staged.data
+	return nil
+}
 
 func (m *mockBaseView) TxExists([32]byte) bool { return false }
 

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -523,7 +523,11 @@ func (b *Batch) Apply(ctx *tx.ApplyContext) ter.Result {
 // Reference: rippled Batch.cpp applyBatchTransactions() with tfAllOrNothing
 func (b *Batch) applyAllOrNothing(ctx *tx.ApplyContext, innerTxns []tx.Transaction) ter.Result {
 	// Create a batch-level state table wrapping ctx.View
-	batchTable := applystate.NewApplyStateTable(ctx.View, ctx.TxHash, ctx.Config.LedgerSequence, ctx.Config.Rules)
+	base, ok := ctx.View.(applystate.AtomicLedgerView)
+	if !ok {
+		return ter.TefINTERNAL
+	}
+	batchTable := applystate.NewApplyStateTable(base, ctx.TxHash, ctx.Config.LedgerSequence, ctx.Config.Rules)
 
 	batchCtx := &tx.ApplyContext{
 		View:            batchTable,
@@ -629,7 +633,11 @@ func applyInnerTransaction(ctx *tx.ApplyContext, innerTx tx.Transaction) ter.Res
 	}
 
 	// Create per-tx state table for isolation
-	perTxTable := applystate.NewApplyStateTable(ctx.View, ctx.TxHash, ctx.Config.LedgerSequence, ctx.Config.Rules)
+	base, ok := ctx.View.(applystate.AtomicLedgerView)
+	if !ok {
+		return ter.TefINTERNAL
+	}
+	perTxTable := applystate.NewApplyStateTable(base, ctx.TxHash, ctx.Config.LedgerSequence, ctx.Config.Rules)
 
 	if isTicket {
 		// Ticket-based: consume the ticket (delete it, adjust owner/ticket counts).

--- a/internal/tx/engine/apply.go
+++ b/internal/tx/engine/apply.go
@@ -185,9 +185,9 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx txcore.Transaction) tx
 		applied = false
 	}
 
-	// Record fee as destroyed and assign TransactionIndex
+	// Assign TransactionIndex. The charged fee was committed atomically with
+	// the state table that produced this applied result.
 	if applied {
-		e.view.AdjustDropsDestroyed(drops.XRPAmount(fee))
 		metadata.TransactionIndex = e.txCount.Add(1) - 1
 	}
 
@@ -400,6 +400,7 @@ func (e *Engine) commitPreclaimTec(ctx context.Context, tx txcore.Transaction, t
 		return r, st.chargedFee
 	}
 
+	tecTable.AdjustDropsDestroyed(drops.XRPAmount(st.chargedFee))
 	generatedMeta, applyErr := tecTable.Apply()
 	if applyErr != nil {
 		return ter.TefINTERNAL, 0

--- a/internal/tx/engine/apply.go
+++ b/internal/tx/engine/apply.go
@@ -185,8 +185,7 @@ func (e *Engine) ApplyWithContext(ctx context.Context, tx txcore.Transaction) tx
 		applied = false
 	}
 
-	// Assign TransactionIndex. The charged fee was committed atomically with
-	// the state table that produced this applied result.
+	// The charged fee was committed atomically with the state table.
 	if applied {
 		metadata.TransactionIndex = e.txCount.Add(1) - 1
 	}

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -203,6 +204,7 @@ func (e *Engine) doApply(ctx context.Context, tx txcore.Transaction, metadata *t
 	}
 
 	// Apply all tracked changes to the base view and generate metadata automatically
+	table.AdjustDropsDestroyed(drops.XRPAmount(st.chargedFee))
 	generatedMeta, err := table.Apply()
 	if err != nil {
 		return ter.TefINTERNAL, 0
@@ -455,6 +457,7 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 	}
 
 	// Apply all tracked changes and generate proper metadata
+	tecTable.AdjustDropsDestroyed(drops.XRPAmount(st.chargedFee))
 	generatedMeta, applyErr := tecTable.Apply()
 	if applyErr != nil {
 		return ter.TefINTERNAL
@@ -885,6 +888,7 @@ func (e *Engine) applyInvariantViolation(st *applyState, txDeclaredFee uint64) (
 		return ter.TefINVARIANT_FAILED
 	}
 
+	invTecTable.AdjustDropsDestroyed(drops.XRPAmount(st.chargedFee))
 	generatedMeta, applyErr := invTecTable.Apply()
 	if applyErr != nil {
 		return ter.TefINTERNAL

--- a/internal/tx/engine/engine.go
+++ b/internal/tx/engine/engine.go
@@ -25,7 +25,7 @@ import (
 // for observers — it is not a license to call Apply concurrently.
 type Engine struct {
 	// View provides access to ledger state
-	view txcore.LedgerView
+	view applystate.AtomicLedgerView
 
 	// Config holds engine configuration
 	config txcore.EngineConfig
@@ -59,7 +59,7 @@ type rulesView struct {
 func (v rulesView) Rules() *amendment.Rules { return v.rules }
 
 // NewEngine creates a new transaction engine
-func NewEngine(view txcore.LedgerView, config txcore.EngineConfig) *Engine {
+func NewEngine(view applystate.AtomicLedgerView, config txcore.EngineConfig) *Engine {
 	logger := config.Logger
 	if logger == nil {
 		logger = xrpllog.Discard()

--- a/internal/tx/engine/engine_recovery_886_test.go
+++ b/internal/tx/engine/engine_recovery_886_test.go
@@ -1,11 +1,13 @@
 package engine
 
 import (
+	"bytes"
 	"strconv"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/drops"
+	ledgercore "github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
@@ -22,7 +24,9 @@ const recoveryTestAccount = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
 // fee actually charged — is destroyed.
 type recordingBaseView struct {
 	*mockBaseView
-	destroyed drops.XRPAmount
+	destroyed          drops.XRPAmount
+	insideAtomic       bool
+	outsideAdjustments int
 }
 
 func newRecordingBaseView() *recordingBaseView {
@@ -30,13 +34,34 @@ func newRecordingBaseView() *recordingBaseView {
 }
 
 func (r *recordingBaseView) AdjustDropsDestroyed(d drops.XRPAmount) {
+	if !r.insideAtomic {
+		r.outsideAdjustments++
+	}
 	r.destroyed += d
+}
+
+func (r *recordingBaseView) ApplyAtomically(apply func(ledgercore.Writer) error) error {
+	staged := newRecordingBaseView()
+	for key, data := range r.data {
+		staged.data[key] = bytes.Clone(data)
+	}
+	staged.destroyed = r.destroyed
+	staged.insideAtomic = true
+	staged.outsideAdjustments = r.outsideAdjustments
+	if err := apply(staged); err != nil {
+		return err
+	}
+	staged.insideAtomic = false
+	r.mockBaseView = staged.mockBaseView
+	r.destroyed = staged.destroyed
+	r.outsideAdjustments = staged.outsideAdjustments
+	return nil
 }
 
 // recoveryEngine builds an engine over the supplied view configured for a
 // closed-ledger apply (OpenLedger=false) with signature verification skipped, so
 // a single-signed BaseTx reaches preclaim/commit without real crypto.
-func recoveryEngine(view txcore.LedgerView, flags txcore.ApplyFlags) *Engine {
+func recoveryEngine(view applystate.AtomicLedgerView, flags txcore.ApplyFlags) *Engine {
 	return NewEngine(view, txcore.EngineConfig{
 		BaseFee:                   10,
 		LedgerSequence:            100,
@@ -94,6 +119,26 @@ func recoveryTx(fee, seq uint32) *txcore.BaseTx {
 	return tx
 }
 
+func TestApply_SuccessStagesFeeAtomically(t *testing.T) {
+	view := newRecordingBaseView()
+	acctKey := fundRecoveryAccount(t, view, 1_000_000, 1)
+
+	res := recoveryEngine(view, txcore.TapNONE).Apply(recoveryTx(10, 1))
+	if res.Result != ter.TesSUCCESS || !res.Applied {
+		t.Fatalf("result/applied = %s/%v, want tesSUCCESS/true", res.Result, res.Applied)
+	}
+	if view.destroyed != drops.XRPAmount(10) {
+		t.Fatalf("destroyed drops = %d, want 10", view.destroyed)
+	}
+	if view.outsideAdjustments != 0 {
+		t.Fatalf("destroyed drops adjusted %d times outside atomic commit", view.outsideAdjustments)
+	}
+	acct := readRecoveryAccount(t, view, acctKey)
+	if acct.Balance != 999_990 || acct.Sequence != 2 {
+		t.Fatalf("payer balance/seq = %d/%d, want 999990/2", acct.Balance, acct.Sequence)
+	}
+}
+
 // TestApply_TecInsuffFee_ClampsToBalance is the Item 1 regression: a closed-ledger
 // apply that hits tecINSUFF_FEE (payer balance non-zero but below the fee) must
 // charge only the balance, leaving the payer at exactly 0 — never underflowing
@@ -120,6 +165,9 @@ func TestApply_TecInsuffFee_ClampsToBalance(t *testing.T) {
 	}
 	if view.destroyed != drops.XRPAmount(5) {
 		t.Fatalf("destroyed drops = %d, want 5 (clamped fee)", view.destroyed)
+	}
+	if view.outsideAdjustments != 0 {
+		t.Fatalf("destroyed drops adjusted %d times outside atomic commit", view.outsideAdjustments)
 	}
 	acct := readRecoveryAccount(t, view, acctKey)
 	if acct.Balance != 0 {
@@ -252,6 +300,9 @@ func TestApply_Retry_WorkOnTecReapplied(t *testing.T) {
 	if view.destroyed != drops.XRPAmount(10) {
 		t.Fatalf("destroyed drops = %d, want 10 (fee claimed)", view.destroyed)
 	}
+	if view.outsideAdjustments != 0 {
+		t.Fatalf("destroyed drops adjusted %d times outside atomic commit", view.outsideAdjustments)
+	}
 	acct := readRecoveryAccount(t, view, acctKey)
 	if acct.Balance != 999_990 {
 		t.Fatalf("payer balance = %d, want 999990 (fee charged)", acct.Balance)
@@ -291,6 +342,12 @@ func TestApply_PreclaimTec_InvariantViolation(t *testing.T) {
 	res := e.Apply(recoveryTx(10, 1))
 	if res.Result != ter.TecINVARIANT_FAILED {
 		t.Fatalf("result = %s, want tecINVARIANT_FAILED", res.Result)
+	}
+	if view.destroyed != drops.XRPAmount(5) {
+		t.Fatalf("destroyed drops = %d, want 5 (clamped fee)", view.destroyed)
+	}
+	if view.outsideAdjustments != 0 {
+		t.Fatalf("destroyed drops adjusted %d times outside atomic commit", view.outsideAdjustments)
 	}
 }
 

--- a/internal/tx/engine/mock_view_test.go
+++ b/internal/tx/engine/mock_view_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/drops"
+	ledgercore "github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
@@ -42,6 +43,18 @@ func (m *mockBaseView) Erase(k keylet.Keylet) error {
 }
 
 func (m *mockBaseView) AdjustDropsDestroyed(drops.XRPAmount) {}
+
+func (m *mockBaseView) ApplyAtomically(apply func(ledgercore.Writer) error) error {
+	staged := newMockBaseView()
+	for key, data := range m.data {
+		staged.data[key] = bytes.Clone(data)
+	}
+	if err := apply(staged); err != nil {
+		return err
+	}
+	m.data = staged.data
+	return nil
+}
 
 func (m *mockBaseView) TxExists([32]byte) bool { return false }
 

--- a/internal/tx/payment/flow_test.go
+++ b/internal/tx/payment/flow_test.go
@@ -3,12 +3,14 @@ package payment
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/drops"
+	ledgercore "github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -22,6 +24,15 @@ type paymentMockLedgerView struct {
 	data       map[[32]byte][]byte
 	ownerCount map[[20]byte]uint32
 	rules      *amendment.Rules
+}
+
+type paymentReadErrorView struct {
+	*paymentMockLedgerView
+	err error
+}
+
+func (v *paymentReadErrorView) Read(keylet.Keylet) ([]byte, error) {
+	return nil, v.err
 }
 
 func newPaymentMockLedgerView() *paymentMockLedgerView {
@@ -321,6 +332,64 @@ func TestPaymentSandbox_ChildSandbox(t *testing.T) {
 	if parentAccount2.Balance != 25_000_000 {
 		t.Errorf("expected parent balance after apply=25M, got %d", parentAccount2.Balance)
 	}
+}
+
+func TestPaymentSandbox_ApplyAtomicallyReinsertAfterErase(t *testing.T) {
+	view := newPaymentMockLedgerView()
+	key := keylet.Keylet{Key: [32]byte{1}}
+	original := []byte{1}
+	replacement := []byte{2}
+	view.data[key.Key] = original
+
+	sandbox := NewPaymentSandbox(view)
+	require.NoError(t, sandbox.Erase(key))
+	require.NoError(t, sandbox.ApplyAtomically(func(writer ledgercore.Writer) error {
+		return writer.Insert(key, replacement)
+	}))
+
+	require.False(t, sandbox.deletions[key.Key])
+	require.NotContains(t, sandbox.insertions, key.Key)
+	require.Equal(t, replacement, sandbox.modifications[key.Key])
+	require.NoError(t, sandbox.ApplyToView(view))
+	require.Equal(t, replacement, view.data[key.Key])
+}
+
+func TestPaymentSandbox_ApplyAtomicallyEraseAfterInsert(t *testing.T) {
+	view := newPaymentMockLedgerView()
+	key := keylet.Keylet{Key: [32]byte{1}}
+	sandbox := NewPaymentSandbox(view)
+	require.NoError(t, sandbox.Insert(key, []byte{1}))
+
+	require.NoError(t, sandbox.ApplyAtomically(func(writer ledgercore.Writer) error {
+		return writer.Erase(key)
+	}))
+
+	require.Empty(t, sandbox.deletions)
+	require.Empty(t, sandbox.insertions)
+	require.Empty(t, sandbox.modifications)
+	require.NoError(t, sandbox.ApplyToView(view))
+	require.NotContains(t, view.data, key.Key)
+}
+
+func TestPaymentSandbox_ApplyAtomicallyMergeFailureRollsBack(t *testing.T) {
+	injected := errors.New("injected read failure")
+	view := &paymentReadErrorView{
+		paymentMockLedgerView: newPaymentMockLedgerView(),
+		err:                   injected,
+	}
+	key := keylet.Keylet{Key: [32]byte{1}}
+	sandbox := NewPaymentSandbox(view)
+	require.NoError(t, sandbox.Erase(key))
+
+	err := sandbox.ApplyAtomically(func(writer ledgercore.Writer) error {
+		return writer.Insert(key, []byte{1})
+	})
+	require.ErrorIs(t, err, injected)
+	require.True(t, sandbox.deletions[key.Key])
+	require.Empty(t, sandbox.insertions)
+	require.Empty(t, sandbox.modifications)
+	require.ErrorIs(t, sandbox.Insert(key, []byte{2}), injected)
+	require.True(t, sandbox.deletions[key.Key])
 }
 
 // XRPEndpointStep Tests

--- a/internal/tx/payment/flow_test.go
+++ b/internal/tx/payment/flow_test.go
@@ -392,6 +392,72 @@ func TestPaymentSandbox_ApplyAtomicallyMergeFailureRollsBack(t *testing.T) {
 	require.True(t, sandbox.deletions[key.Key])
 }
 
+func TestPaymentSandbox_ApplyAtomicallyUpdateReadFailureRollsBack(t *testing.T) {
+	injected := errors.New("injected read failure")
+	view := &paymentReadErrorView{
+		paymentMockLedgerView: newPaymentMockLedgerView(),
+		err:                   injected,
+	}
+	key := keylet.Keylet{Key: [32]byte{1}}
+	sandbox := NewPaymentSandbox(view)
+
+	err := sandbox.ApplyAtomically(func(writer ledgercore.Writer) error {
+		return writer.Update(key, []byte{1})
+	})
+	require.ErrorIs(t, err, injected)
+	require.Empty(t, sandbox.preImages)
+	require.Empty(t, sandbox.modifications)
+	require.Empty(t, sandbox.insertions)
+	require.Empty(t, sandbox.deletions)
+}
+
+func TestPaymentSandbox_ApplyAtomicallyComposesActions(t *testing.T) {
+	t.Run("local insert then erase", func(t *testing.T) {
+		view := newPaymentMockLedgerView()
+		key := keylet.Keylet{Key: [32]byte{1}}
+		sandbox := NewPaymentSandbox(view)
+
+		require.NoError(t, sandbox.ApplyAtomically(func(writer ledgercore.Writer) error {
+			require.NoError(t, writer.Insert(key, []byte{1}))
+			return writer.Erase(key)
+		}))
+		require.Empty(t, sandbox.insertions)
+		require.Empty(t, sandbox.modifications)
+		require.Empty(t, sandbox.deletions)
+	})
+
+	t.Run("parent insert then child modify", func(t *testing.T) {
+		view := newPaymentMockLedgerView()
+		key := keylet.Keylet{Key: [32]byte{1}}
+		sandbox := NewPaymentSandbox(view)
+		require.NoError(t, sandbox.Insert(key, []byte{1}))
+
+		require.NoError(t, sandbox.ApplyAtomically(func(writer ledgercore.Writer) error {
+			return writer.Update(key, []byte{2})
+		}))
+		require.Equal(t, []byte{2}, sandbox.insertions[key.Key])
+		require.Empty(t, sandbox.modifications)
+		require.Empty(t, sandbox.deletions)
+	})
+
+	t.Run("parent modify then child erase", func(t *testing.T) {
+		view := newPaymentMockLedgerView()
+		key := keylet.Keylet{Key: [32]byte{1}}
+		view.data[key.Key] = []byte{1}
+		sandbox := NewPaymentSandbox(view)
+		require.NoError(t, sandbox.Update(key, []byte{2}))
+
+		require.NoError(t, sandbox.ApplyAtomically(func(writer ledgercore.Writer) error {
+			return writer.Erase(key)
+		}))
+		require.True(t, sandbox.deletions[key.Key])
+		require.Empty(t, sandbox.insertions)
+		require.Empty(t, sandbox.modifications)
+		require.NoError(t, sandbox.ApplyToView(view))
+		require.NotContains(t, view.data, key.Key)
+	})
+}
+
 // XRPEndpointStep Tests
 
 func TestXRPEndpointStep_Source(t *testing.T) {

--- a/internal/tx/payment/sandbox.go
+++ b/internal/tx/payment/sandbox.go
@@ -391,7 +391,6 @@ func (s *PaymentSandbox) AdjustDropsDestroyed(drops drops.XRPAmount) {
 	s.dropsDestroyed = s.dropsDestroyed.Add(drops)
 }
 
-// ApplyAtomically stages changes in a child sandbox before merging them.
 func (s *PaymentSandbox) ApplyAtomically(apply func(ledgercore.Writer) error) error {
 	staged := NewChildSandbox(s)
 	if err := apply(staged); err != nil {

--- a/internal/tx/payment/sandbox.go
+++ b/internal/tx/payment/sandbox.go
@@ -326,7 +326,10 @@ func (s *PaymentSandbox) Update(k keylet.Keylet, data []byte) error {
 	if _, hasPreImage := s.preImages[key]; !hasPreImage {
 		// Get the original value from parent chain or underlying view
 		origData, err := s.readOriginal(k)
-		if err == nil && origData != nil {
+		if err != nil {
+			return err
+		}
+		if origData != nil {
 			preImageCopy := make([]byte, len(origData))
 			copy(preImageCopy, origData)
 			s.preImages[key] = preImageCopy

--- a/internal/tx/payment/sandbox.go
+++ b/internal/tx/payment/sandbox.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/drops"
+	ledgercore "github.com/LeJamon/go-xrpl/internal/ledger"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -63,6 +64,8 @@ type PaymentSandbox struct {
 	// playing the role of rippled's Throw<FlowException>(telFAILED_PROCESSING).
 	fundsFailure bool
 }
+
+var _ ledgercore.AtomicWriter = (*PaymentSandbox)(nil)
 
 // DeferredCredits tracks credits that shouldn't be spendable mid-transaction.
 // This prevents consuming liquidity from one path from affecting other paths.
@@ -286,9 +289,12 @@ func (s *PaymentSandbox) Insert(k keylet.Keylet, data []byte) error {
 	// "entry already exists".
 	// Reference: rippled OpenView::insert → if erased && existed in parent → modify
 	if _, wasDeleted := s.deletions[key]; wasDeleted {
-		delete(s.deletions, key)
 		// Check if the entry existed in the base view before this sandbox
-		origData, _ := s.readOriginal(k)
+		origData, err := s.readOriginal(k)
+		if err != nil {
+			return err
+		}
+		delete(s.deletions, key)
 		if origData != nil {
 			// Entry exists in base → treat as modification
 			s.modifications[key] = dataCopy
@@ -348,6 +354,10 @@ func (s *PaymentSandbox) readOriginal(k keylet.Keylet) ([]byte, error) {
 // Erase marks a ledger entry for deletion
 func (s *PaymentSandbox) Erase(k keylet.Keylet) error {
 	key := k.Key
+	if _, inserted := s.insertions[key]; inserted {
+		delete(s.insertions, key)
+		return nil
+	}
 	// If this entry was modified, save the final state before deletion
 	// This is needed for correct metadata generation (PreviousFields vs FinalFields)
 	if modData, ok := s.modifications[key]; ok {
@@ -376,6 +386,15 @@ func (s *PaymentSandbox) getDeletedFinalState(key [32]byte) []byte {
 // AdjustDropsDestroyed records XRP that has been destroyed
 func (s *PaymentSandbox) AdjustDropsDestroyed(drops drops.XRPAmount) {
 	s.dropsDestroyed = s.dropsDestroyed.Add(drops)
+}
+
+// ApplyAtomically stages changes in a child sandbox before merging them.
+func (s *PaymentSandbox) ApplyAtomically(apply func(ledgercore.Writer) error) error {
+	staged := NewChildSandbox(s)
+	if err := apply(staged); err != nil {
+		return err
+	}
+	return staged.Apply(s)
 }
 
 // TxExists delegates to the parent sandbox or underlying view.
@@ -760,8 +779,29 @@ func (s *PaymentSandbox) Apply(to *PaymentSandbox) error {
 		return errors.New("PaymentSandbox.Apply: parent mismatch")
 	}
 
+	var reinserted map[[32]byte]bool
+	for key := range s.insertions {
+		if !to.deletions[key] {
+			continue
+		}
+		original, err := to.readOriginal(keylet.Keylet{Key: key})
+		if err != nil {
+			return err
+		}
+		if reinserted == nil {
+			reinserted = make(map[[32]byte]bool)
+		}
+		reinserted[key] = original != nil
+	}
+
 	// Apply ledger item changes
 	for key := range s.deletions {
+		if _, inserted := to.insertions[key]; inserted {
+			delete(to.insertions, key)
+			delete(to.modifications, key)
+			delete(to.deletedFinalStates, key)
+			continue
+		}
 		// Before marking as deleted in parent, save the final state if we have one
 		// or if parent has a modification that should become the final state
 		if finalState, ok := s.deletedFinalStates[key]; ok {
@@ -787,8 +827,14 @@ func (s *PaymentSandbox) Apply(to *PaymentSandbox) error {
 	}
 
 	for key, data := range s.insertions {
-		if to.deletions[key] {
+		if existed, wasDeleted := reinserted[key]; wasDeleted {
 			delete(to.deletions, key)
+			if existed {
+				to.modifications[key] = data
+			} else {
+				to.insertions[key] = data
+			}
+			continue
 		}
 		// If parent has this as a modification, keep it as modification
 		if _, ok := to.modifications[key]; ok {
@@ -802,7 +848,11 @@ func (s *PaymentSandbox) Apply(to *PaymentSandbox) error {
 		if to.deletions[key] {
 			continue
 		}
-		to.modifications[key] = data
+		if _, inserted := to.insertions[key]; inserted {
+			to.insertions[key] = data
+		} else {
+			to.modifications[key] = data
+		}
 	}
 
 	// Propagate preImages (only if parent doesn't already have one)

--- a/shamap/mutable_fork_test.go
+++ b/shamap/mutable_fork_test.go
@@ -1,0 +1,58 @@
+package shamap
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestMutableForkDoesNotFlushBackedMap(t *testing.T) {
+	family := newMemoryFamily()
+	source, err := NewBacked(TypeState, family)
+	if err != nil {
+		t.Fatalf("NewBacked: %v", err)
+	}
+	key := [32]byte{1}
+	original := bytes.Repeat([]byte{1}, 12)
+	if err := source.Put(key, original); err != nil {
+		t.Fatalf("source Put: %v", err)
+	}
+
+	fork, err := source.MutableFork()
+	if err != nil {
+		t.Fatalf("MutableFork: %v", err)
+	}
+	if family.Len() != 0 {
+		t.Fatalf("MutableFork flushed %d dirty nodes", family.Len())
+	}
+
+	updated := bytes.Repeat([]byte{2}, 12)
+	if err := fork.Put(key, updated); err != nil {
+		t.Fatalf("fork Put: %v", err)
+	}
+	item, found, err := source.Get(key)
+	if err != nil {
+		t.Fatalf("source Get: %v", err)
+	}
+	if !found {
+		t.Fatal("source item missing after fork update")
+	}
+	if !bytes.Equal(item.Data(), original) {
+		t.Fatalf("source changed through fork: data=%x", item.Data())
+	}
+	item, found, err = fork.Get(key)
+	if err != nil {
+		t.Fatalf("fork Get: %v", err)
+	}
+	if !found {
+		t.Fatal("fork item missing after update")
+	}
+	if !bytes.Equal(item.Data(), updated) {
+		t.Fatalf("fork update missing: data=%x", item.Data())
+	}
+	if _, err := fork.Snapshot(false); err != nil {
+		t.Fatalf("Snapshot fork: %v", err)
+	}
+	if family.Len() == 0 {
+		t.Fatal("snapshot did not persist retained fork")
+	}
+}

--- a/shamap/shamap.go
+++ b/shamap/shamap.go
@@ -688,7 +688,20 @@ func (sm *SHAMap) Snapshot(mutable bool) (*SHAMap, error) {
 
 	sm.mu.RLock()
 	defer sm.mu.RUnlock()
+	return sm.snapshotLocked(mutable)
+}
 
+// MutableFork returns a mutable, structurally shared copy without flushing
+// dirty backed nodes. It is intended for short-lived transactional staging;
+// path-copy persistence keeps subsequent mutations isolated. Neither map may
+// be flushed until the caller has discarded one of them.
+func (sm *SHAMap) MutableFork() (*SHAMap, error) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.snapshotLocked(true)
+}
+
+func (sm *SHAMap) snapshotLocked(mutable bool) (*SHAMap, error) {
 	if sm.state == StateInvalid {
 		return nil, fmt.Errorf("%w: cannot snapshot invalid map", ErrInvalidState)
 	}


### PR DESCRIPTION
## Summary

- build metadata and threading in deterministic ledger-key order before flushing state
- commit ledger entries, charged XRP, and destroyed drops through copy-on-write atomic views
- enforce atomic-view capability at engine/table construction and preserve nested sandbox action semantics
- verify metadata, write, fee, snapshot, sandbox, and retry failures leave observable state unchanged

## Test plan

- [x] focused regressions (20 repetitions)
- [x] race checks for applystate, engine, payment, SHAMap, ledger, and ledger service
- [x] `go test ./internal/tx/... ./internal/ledger/... ./shamap/...`
- [x] full conformance (1260/1260 in scope)
- [x] `just build-all`
- [x] `just vet`
- [x] `just lint`

Fixes #1177