### PR TITLE
fix: validate XRP endpoints during offer crossing

### DIFF
--- a/internal/testing/offer/issue_1182_test.go
+++ b/internal/testing/offer/issue_1182_test.go
@@ -12,15 +12,21 @@ import (
 
 func TestOffer_IoCSell_GlobalFrozenTaker(t *testing.T) {
 	for _, tc := range []struct {
-		name   string
-		frozen bool
+		name                 string
+		frozen               bool
+		immediateOfferKilled bool
 	}{
-		{name: "crosses", frozen: false},
-		{name: "globally_frozen_taker", frozen: true},
+		{name: "crosses", immediateOfferKilled: true},
+		{name: "globally_frozen_taker", frozen: true, immediateOfferKilled: true},
+		{name: "globally_frozen_taker_legacy", frozen: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			env := jtx.NewTestEnv(t)
-			env.EnableFeature("ImmediateOfferKilled")
+			if tc.immediateOfferKilled {
+				env.EnableFeature("ImmediateOfferKilled")
+			} else {
+				env.DisableFeature("ImmediateOfferKilled")
+			}
 
 			const coreCurrency = "434F524500000000000000000000000000000000"
 			issuer := jtx.NewAccount("core issuer")
@@ -58,6 +64,8 @@ func TestOffer_IoCSell_GlobalFrozenTaker(t *testing.T) {
 			require.NoError(t, err)
 			takerXRPBefore := env.Balance(taker)
 			makerXRPBefore := env.Balance(maker)
+			takerOwnerCountBefore := env.OwnerCount(taker)
+			makerOwnerCountBefore := env.OwnerCount(maker)
 
 			result = env.Submit(OfferCreate(
 				taker,
@@ -65,12 +73,21 @@ func TestOffer_IoCSell_GlobalFrozenTaker(t *testing.T) {
 				takerGets,
 			).ImmediateOrCancel().Sell().Build())
 
-			if tc.frozen {
+			if tc.frozen && tc.immediateOfferKilled {
 				jtx.RequireTxClaimed(t, result, jtx.TecKILLED)
+			} else {
+				jtx.RequireTxSuccess(t, result)
+			}
+			RequireOfferCount(t, env, taker, 0)
+			jtx.RequireOwnerCount(t, env, taker, takerOwnerCountBefore)
+			jtx.RequireOwnerCount(t, env, maker, makerOwnerCountBefore)
+
+			if tc.frozen {
 				require.Equal(t, takerXRPBefore-env.BaseFee(), env.Balance(taker))
 				require.Equal(t, makerXRPBefore, env.Balance(maker))
 				jtx.RequireIOUBalance(t, env, taker, issuer, coreCurrency, 0.98745)
 				jtx.RequireIOUBalance(t, env, maker, issuer, coreCurrency, 0)
+				RequireOfferCount(t, env, maker, 1)
 
 				offerAfter, err := env.LedgerEntry(offerKey)
 				require.NoError(t, err)
@@ -78,15 +95,15 @@ func TestOffer_IoCSell_GlobalFrozenTaker(t *testing.T) {
 				return
 			}
 
-			jtx.RequireTxSuccess(t, result)
 			require.Equal(t, takerXRPBefore-env.BaseFee()+37_919, env.Balance(taker))
 			require.Equal(t, makerXRPBefore-37_919, env.Balance(maker))
 			jtx.RequireIOUBalance(t, env, taker, issuer, coreCurrency, 0)
 			jtx.RequireIOUBalance(t, env, maker, issuer, coreCurrency, 0.98745)
-
-			offerAfter, err := env.LedgerEntry(offerKey)
-			require.NoError(t, err)
-			require.NotEqual(t, offerBefore, offerAfter)
+			RequireOfferCount(t, env, maker, 1)
+			RequireIsOffer(t, env, maker,
+				core(3_372_252_095_660_040, -13),
+				tx.NewXRPAmount(12_950_020),
+			)
 		})
 	}
 }

--- a/internal/testing/offer/issue_1182_test.go
+++ b/internal/testing/offer/issue_1182_test.go
@@ -1,0 +1,92 @@
+package offer
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOffer_IoCSell_GlobalFrozenTaker(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		frozen bool
+	}{
+		{name: "crosses", frozen: false},
+		{name: "globally_frozen_taker", frozen: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := jtx.NewTestEnv(t)
+			env.EnableFeature("ImmediateOfferKilled")
+
+			const coreCurrency = "434F524500000000000000000000000000000000"
+			issuer := jtx.NewAccount("core issuer")
+			taker := jtx.NewAccount("taker")
+			maker := jtx.NewAccount("maker")
+			core := func(mantissa int64, exponent int) tx.Amount {
+				return tx.NewIssuedAmount(mantissa, exponent, coreCurrency, issuer.Address)
+			}
+
+			env.FundAmount(issuer, uint64(jtx.XRP(1_000)))
+			env.FundAmount(taker, uint64(jtx.XRP(1_000)))
+			env.FundAmount(maker, uint64(jtx.XRP(1_000)))
+			env.Close()
+
+			env.Trust(taker, core(1_000_000_000_000_000, -11))
+			env.Trust(maker, core(1_000_000_000_000_000, -11))
+			takerGets := core(9_874_500_000_000_000, -16)
+			result := env.Submit(payment.PayIssued(issuer, taker, takerGets).Build())
+			jtx.RequireTxSuccess(t, result)
+
+			makerOfferSeq := env.Seq(maker)
+			result = env.Submit(OfferCreate(
+				maker,
+				core(3_382_126_595_660_040, -13),
+				tx.NewXRPAmount(12_987_939),
+			).Build())
+			jtx.RequireTxSuccess(t, result)
+
+			if tc.frozen {
+				env.EnableGlobalFreeze(taker)
+			}
+
+			offerKey := keylet.Offer(maker.ID, makerOfferSeq)
+			offerBefore, err := env.LedgerEntry(offerKey)
+			require.NoError(t, err)
+			takerXRPBefore := env.Balance(taker)
+			makerXRPBefore := env.Balance(maker)
+
+			result = env.Submit(OfferCreate(
+				taker,
+				tx.NewXRPAmount(34_127),
+				takerGets,
+			).ImmediateOrCancel().Sell().Build())
+
+			if tc.frozen {
+				jtx.RequireTxClaimed(t, result, jtx.TecKILLED)
+				require.Equal(t, takerXRPBefore-env.BaseFee(), env.Balance(taker))
+				require.Equal(t, makerXRPBefore, env.Balance(maker))
+				jtx.RequireIOUBalance(t, env, taker, issuer, coreCurrency, 0.98745)
+				jtx.RequireIOUBalance(t, env, maker, issuer, coreCurrency, 0)
+
+				offerAfter, err := env.LedgerEntry(offerKey)
+				require.NoError(t, err)
+				require.Equal(t, offerBefore, offerAfter)
+				return
+			}
+
+			jtx.RequireTxSuccess(t, result)
+			require.Equal(t, takerXRPBefore-env.BaseFee()+37_919, env.Balance(taker))
+			require.Equal(t, makerXRPBefore-37_919, env.Balance(maker))
+			jtx.RequireIOUBalance(t, env, taker, issuer, coreCurrency, 0)
+			jtx.RequireIOUBalance(t, env, maker, issuer, coreCurrency, 0.98745)
+
+			offerAfter, err := env.LedgerEntry(offerKey)
+			require.NoError(t, err)
+			require.NotEqual(t, offerBefore, offerAfter)
+		})
+	}
+}

--- a/internal/testing/payment/xrp_path_loop_test.go
+++ b/internal/testing/payment/xrp_path_loop_test.go
@@ -1,0 +1,147 @@
+package payment
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	txpayment "github.com/LeJamon/go-xrpl/internal/tx/payment"
+)
+
+func newXRPPathLoopEnv(t *testing.T, fix1781 bool, currencies ...string) (*jtx.TestEnv, *jtx.Account, *jtx.Account, *jtx.Account) {
+	t.Helper()
+
+	env := jtx.NewTestEnv(t)
+	if fix1781 {
+		env.EnableFeature("fix1781")
+	} else {
+		env.DisableFeature("fix1781")
+	}
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	gw := jtx.NewAccount("gw")
+
+	env.FundAmount(alice, uint64(jtx.XRP(10_000)))
+	env.FundAmount(bob, uint64(jtx.XRP(10_000)))
+	env.FundAmount(gw, uint64(jtx.XRP(10_000)))
+	env.Close()
+
+	for _, currency := range currencies {
+		result := env.Submit(trust(alice, gw, currency, 1_000))
+		jtx.RequireTxSuccess(t, result)
+		result = env.Submit(trust(bob, gw, currency, 1_000))
+		jtx.RequireTxSuccess(t, result)
+	}
+	env.Close()
+
+	for _, currency := range currencies {
+		amount := tx.NewIssuedAmountFromFloat64(100, currency, gw.Address)
+		result := env.Submit(PayIssued(gw, alice, amount).Build())
+		jtx.RequireTxSuccess(t, result)
+	}
+	env.Close()
+
+	return env, alice, bob, gw
+}
+
+func TestXRPPathLoop_Start(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		fix1781 bool
+	}{
+		{name: "enabled", fix1781: true},
+		{name: "disabled"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			env, alice, bob, gw := newXRPPathLoopEnv(t, test.fix1781, "USD", "EUR")
+			xrp100 := tx.NewXRPAmount(int64(jtx.XRP(100)))
+			usd100 := tx.NewIssuedAmountFromFloat64(100, "USD", gw.Address)
+			eur100 := tx.NewIssuedAmountFromFloat64(100, "EUR", gw.Address)
+
+			jtx.RequireTxSuccess(t, env.CreatePassiveOffer(alice, usd100, xrp100))
+			jtx.RequireTxSuccess(t, env.CreatePassiveOffer(alice, xrp100, usd100))
+			jtx.RequireTxSuccess(t, env.CreatePassiveOffer(alice, eur100, xrp100))
+			env.Close()
+
+			paths := [][]txpayment.PathStep{{
+				issuePath("USD", gw),
+				currencyPath("XRP"),
+				issuePath("EUR", gw),
+			}}
+			result := env.Submit(PayIssued(alice, bob,
+				tx.NewIssuedAmountFromFloat64(1, "EUR", gw.Address),
+			).SendMax(tx.NewXRPAmount(int64(jtx.XRP(1)))).Paths(paths).NoDirectRipple().Build())
+			if test.fix1781 {
+				jtx.RequireTxFail(t, result, jtx.TemBAD_PATH_LOOP)
+			} else {
+				jtx.RequireTxSuccess(t, result)
+			}
+		})
+	}
+}
+
+func TestXRPPathLoop_End(t *testing.T) {
+	env, alice, bob, gw := newXRPPathLoopEnv(t, true, "USD", "EUR")
+	xrp100 := tx.NewXRPAmount(int64(jtx.XRP(100)))
+	usd100 := tx.NewIssuedAmountFromFloat64(100, "USD", gw.Address)
+	eur100 := tx.NewIssuedAmountFromFloat64(100, "EUR", gw.Address)
+
+	jtx.RequireTxSuccess(t, env.CreatePassiveOffer(alice, usd100, xrp100))
+	jtx.RequireTxSuccess(t, env.CreatePassiveOffer(alice, xrp100, eur100))
+	env.Close()
+
+	paths := [][]txpayment.PathStep{{
+		currencyPath("XRP"),
+		issuePath("USD", gw),
+		currencyPath("XRP"),
+	}}
+	result := env.Submit(Pay(alice, bob, uint64(jtx.XRP(1))).
+		SendMax(tx.NewIssuedAmountFromFloat64(1, "EUR", gw.Address)).
+		Paths(paths).
+		NoDirectRipple().
+		Build())
+	jtx.RequireTxFail(t, result, jtx.TemBAD_PATH_LOOP)
+}
+
+func TestXRPPathLoop_Middle(t *testing.T) {
+	env, alice, bob, gw := newXRPPathLoopEnv(t, true, "USD", "EUR", "JPY")
+	xrp100 := tx.NewXRPAmount(int64(jtx.XRP(100)))
+	usd100 := tx.NewIssuedAmountFromFloat64(100, "USD", gw.Address)
+	eur100 := tx.NewIssuedAmountFromFloat64(100, "EUR", gw.Address)
+	jpy100 := tx.NewIssuedAmountFromFloat64(100, "JPY", gw.Address)
+
+	jtx.RequireTxSuccess(t, env.CreatePassiveOffer(alice, xrp100, usd100))
+	jtx.RequireTxSuccess(t, env.CreatePassiveOffer(alice, eur100, xrp100))
+	jtx.RequireTxSuccess(t, env.CreatePassiveOffer(alice, xrp100, eur100))
+	jtx.RequireTxSuccess(t, env.CreatePassiveOffer(alice, jpy100, xrp100))
+	env.Close()
+
+	paths := [][]txpayment.PathStep{{
+		currencyPath("XRP"),
+		issuePath("EUR", gw),
+		currencyPath("XRP"),
+		issuePath("JPY", gw),
+	}}
+	result := env.Submit(PayIssued(alice, bob,
+		tx.NewIssuedAmountFromFloat64(1, "JPY", gw.Address),
+	).SendMax(tx.NewIssuedAmountFromFloat64(1, "USD", gw.Address)).Paths(paths).NoDirectRipple().Build())
+	jtx.RequireTxFail(t, result, jtx.TemBAD_PATH_LOOP)
+}
+
+func TestXRPAccountStepOnlyAllowedAtEndpoint(t *testing.T) {
+	env, alice, bob, gw := newXRPPathLoopEnv(t, true, "USD")
+	carol := jtx.NewAccount("carol")
+	env.FundAmount(carol, uint64(jtx.XRP(10_000)))
+	env.Close()
+
+	paths := [][]txpayment.PathStep{{
+		currencyPath("XRP"),
+		accountPath(carol),
+	}}
+	result := env.Submit(Pay(alice, bob, uint64(jtx.XRP(1))).
+		SendMax(tx.NewIssuedAmountFromFloat64(1, "USD", gw.Address)).
+		Paths(paths).
+		NoDirectRipple().
+		Build())
+	jtx.RequireTxFail(t, result, jtx.TemBAD_PATH)
+}

--- a/internal/testing/payment/xrp_path_loop_test.go
+++ b/internal/testing/payment/xrp_path_loop_test.go
@@ -54,7 +54,7 @@ func TestXRPPathLoop_Start(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			env, alice, bob, gw := newXRPPathLoopEnv(t, test.fix1781, "USD", "EUR")
-			xrp100 := tx.NewXRPAmount(int64(jtx.XRP(100)))
+			xrp100 := tx.NewXRPAmount(jtx.XRP(100))
 			usd100 := tx.NewIssuedAmountFromFloat64(100, "USD", gw.Address)
 			eur100 := tx.NewIssuedAmountFromFloat64(100, "EUR", gw.Address)
 
@@ -70,7 +70,7 @@ func TestXRPPathLoop_Start(t *testing.T) {
 			}}
 			result := env.Submit(PayIssued(alice, bob,
 				tx.NewIssuedAmountFromFloat64(1, "EUR", gw.Address),
-			).SendMax(tx.NewXRPAmount(int64(jtx.XRP(1)))).Paths(paths).NoDirectRipple().Build())
+			).SendMax(tx.NewXRPAmount(jtx.XRP(1))).Paths(paths).NoDirectRipple().Build())
 			if test.fix1781 {
 				jtx.RequireTxFail(t, result, jtx.TemBAD_PATH_LOOP)
 			} else {
@@ -82,7 +82,7 @@ func TestXRPPathLoop_Start(t *testing.T) {
 
 func TestXRPPathLoop_End(t *testing.T) {
 	env, alice, bob, gw := newXRPPathLoopEnv(t, true, "USD", "EUR")
-	xrp100 := tx.NewXRPAmount(int64(jtx.XRP(100)))
+	xrp100 := tx.NewXRPAmount(jtx.XRP(100))
 	usd100 := tx.NewIssuedAmountFromFloat64(100, "USD", gw.Address)
 	eur100 := tx.NewIssuedAmountFromFloat64(100, "EUR", gw.Address)
 
@@ -105,7 +105,7 @@ func TestXRPPathLoop_End(t *testing.T) {
 
 func TestXRPPathLoop_Middle(t *testing.T) {
 	env, alice, bob, gw := newXRPPathLoopEnv(t, true, "USD", "EUR", "JPY")
-	xrp100 := tx.NewXRPAmount(int64(jtx.XRP(100)))
+	xrp100 := tx.NewXRPAmount(jtx.XRP(100))
 	usd100 := tx.NewIssuedAmountFromFloat64(100, "USD", gw.Address)
 	eur100 := tx.NewIssuedAmountFromFloat64(100, "EUR", gw.Address)
 	jpy100 := tx.NewIssuedAmountFromFloat64(100, "JPY", gw.Address)

--- a/internal/tx/payment/step_direct.go
+++ b/internal/tx/payment/step_direct.go
@@ -822,40 +822,40 @@ func checkFreeze(view *PaymentSandbox, src, dst [20]byte, currency string) ter.R
 		}
 	}
 
-	// 2. Read trust line — if it doesn't exist, skip freeze checks.
+	// 2. Read trust line — if it doesn't exist, skip trust-line freeze checks.
 	// During offer crossing, trust lines may not exist yet (created on demand).
 	// Reference: rippled StepChecks.h:51 — `if (auto sle = view.read(...))`
 	trustLineKey := keylet.Line(src, dst, currency)
 	data, err := view.Read(trustLineKey)
-	if err != nil || data == nil {
-		// No trust line — nothing to freeze-check
-		return ter.TesSUCCESS
-	}
-
-	rs, err := state.ParseRippleState(data)
 	if err != nil {
 		return ter.TefINTERNAL
 	}
+	if data != nil {
+		rs, err := state.ParseRippleState(data)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
 
-	// 3. Check individual freeze
-	// Reference: rippled StepChecks.h:53 — (dst > src) ? lsfHighFreeze : lsfLowFreeze
-	// If src is low (dst is high), check lsfHighFreeze (dst's side)
-	// If src is high (dst is low), check lsfLowFreeze (dst's side)
-	srcIsLow := state.CompareAccountIDs(src, dst) < 0
-	if srcIsLow {
-		if (rs.Flags & state.LsfHighFreeze) != 0 {
+		// 3. Check individual freeze
+		// Reference: rippled StepChecks.h:53 — (dst > src) ? lsfHighFreeze : lsfLowFreeze
+		// If src is low (dst is high), check lsfHighFreeze (dst's side)
+		// If src is high (dst is low), check lsfLowFreeze (dst's side)
+		srcIsLow := state.CompareAccountIDs(src, dst) < 0
+		if srcIsLow {
+			if (rs.Flags & state.LsfHighFreeze) != 0 {
+				return ter.TerNO_LINE
+			}
+		} else {
+			if (rs.Flags & state.LsfLowFreeze) != 0 {
+				return ter.TerNO_LINE
+			}
+		}
+
+		// 4. Check deep freeze — either side having deep freeze blocks the line
+		// Reference: rippled StepChecks.h:58-62
+		if (rs.Flags&state.LsfHighDeepFreeze) != 0 || (rs.Flags&state.LsfLowDeepFreeze) != 0 {
 			return ter.TerNO_LINE
 		}
-	} else {
-		if (rs.Flags & state.LsfLowFreeze) != 0 {
-			return ter.TerNO_LINE
-		}
-	}
-
-	// 4. Check deep freeze — either side having deep freeze blocks the line
-	// Reference: rippled StepChecks.h:58-62
-	if (rs.Flags&state.LsfHighDeepFreeze) != 0 || (rs.Flags&state.LsfLowDeepFreeze) != 0 {
-		return ter.TerNO_LINE
 	}
 
 	// 5. LP-token arm: a step toward an AMM pseudo-account (the LP-token issuer,

--- a/internal/tx/payment/step_xrp.go
+++ b/internal/tx/payment/step_xrp.go
@@ -416,6 +416,11 @@ func (s *XRPEndpointStep) accountSend(sb *PaymentSandbox, amount int64) error {
 
 // Check validates the XRPEndpointStep before use
 func (s *XRPEndpointStep) Check(sb *PaymentSandbox) ter.Result {
+	var xrpAccount [20]byte
+	if s.account == xrpAccount {
+		return ter.TemBAD_PATH
+	}
+
 	// Check account exists
 	accountKey := keylet.Account(s.account)
 	exists, err := sb.Exists(accountKey)
@@ -426,7 +431,6 @@ func (s *XRPEndpointStep) Check(sb *PaymentSandbox) ter.Result {
 		return ter.TerNO_ACCOUNT
 	}
 
-	var xrpAccount [20]byte
 	src, dst := s.account, xrpAccount
 	if s.isLast {
 		src, dst = xrpAccount, s.account

--- a/internal/tx/payment/step_xrp.go
+++ b/internal/tx/payment/step_xrp.go
@@ -426,5 +426,14 @@ func (s *XRPEndpointStep) Check(sb *PaymentSandbox) ter.Result {
 		return ter.TerNO_ACCOUNT
 	}
 
+	var xrpAccount [20]byte
+	src, dst := s.account, xrpAccount
+	if s.isLast {
+		src, dst = xrpAccount, s.account
+	}
+	if result := checkFreeze(sb, src, dst, "XRP"); result != ter.TesSUCCESS {
+		return result
+	}
+
 	return ter.TesSUCCESS
 }

--- a/internal/tx/payment/step_xrp_test.go
+++ b/internal/tx/payment/step_xrp_test.go
@@ -3,6 +3,7 @@ package payment
 import (
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -35,20 +36,57 @@ func TestXRPEndpointStep_CheckGlobalFreeze(t *testing.T) {
 }
 
 func TestXRPEndpointStep_CheckUnresolvableAMM(t *testing.T) {
-	view := newPaymentMockLedgerView()
-	acct := [20]byte{2}
-	root := &state.AccountRoot{
-		Account:  state.EncodeAccountIDSafe(acct),
-		Balance:  100_000_000,
-		Sequence: 1,
+	tests := []struct {
+		name     string
+		disabled bool
+		want     ter.Result
+	}{
+		{name: "enabled", want: ter.TecINTERNAL},
+		{name: "disabled", disabled: true, want: ter.TesSUCCESS},
 	}
-	root.AMMID[0] = 1
-	data, err := state.SerializeAccountRoot(root)
-	require.NoError(t, err)
-	view.data[keylet.Account(acct).Key] = data
 
-	sb := NewPaymentSandbox(view)
-	require.Equal(t, ter.TecINTERNAL, NewXRPEndpointStep(acct, true).Check(sb))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			view := newPaymentMockLedgerView()
+			if test.disabled {
+				view.rules = amendment.NewRulesBuilder().
+					FromPreset(amendment.PresetAllSupported).
+					DisableByName("fixFrozenLPTokenTransfer").
+					Build()
+			}
+			acct := [20]byte{2}
+			root := &state.AccountRoot{
+				Account:  state.EncodeAccountIDSafe(acct),
+				Balance:  100_000_000,
+				Sequence: 1,
+			}
+			root.AMMID[0] = 1
+			data, err := state.SerializeAccountRoot(root)
+			require.NoError(t, err)
+			view.data[keylet.Account(acct).Key] = data
+
+			sb := NewPaymentSandbox(view)
+			require.Equal(t, test.want, NewXRPEndpointStep(acct, true).Check(sb))
+		})
+	}
+}
+
+func TestXRPEndpointStep_CheckAccount(t *testing.T) {
+	tests := []struct {
+		name    string
+		account [20]byte
+		want    ter.Result
+	}{
+		{name: "zero", want: ter.TemBAD_PATH},
+		{name: "missing", account: [20]byte{2}, want: ter.TerNO_ACCOUNT},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sb := NewPaymentSandbox(newPaymentMockLedgerView())
+			require.Equal(t, test.want, NewXRPEndpointStep(test.account, true).Check(sb))
+		})
+	}
 }
 
 // TestXRPEndpointStep_xrpLiquid_DeferredCredit proves that XRP credited to an

--- a/internal/tx/payment/step_xrp_test.go
+++ b/internal/tx/payment/step_xrp_test.go
@@ -5,9 +5,51 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/stretchr/testify/require"
 )
+
+func TestXRPEndpointStep_CheckGlobalFreeze(t *testing.T) {
+	view := newPaymentMockLedgerView()
+	acct := [20]byte{1}
+	root := &state.AccountRoot{
+		Account:  state.EncodeAccountIDSafe(acct),
+		Balance:  100_000_000,
+		Flags:    state.LsfGlobalFreeze,
+		Sequence: 1,
+	}
+	data, err := state.SerializeAccountRoot(root)
+	require.NoError(t, err)
+	view.data[keylet.Account(acct).Key] = data
+
+	sb := NewPaymentSandbox(view)
+	require.Equal(t, ter.TerNO_LINE, NewXRPEndpointStep(acct, true).Check(sb))
+	require.Equal(t, ter.TesSUCCESS, NewXRPEndpointStep(acct, false).Check(sb))
+
+	ctx := NewStrandContext(sb, [20]byte{2}, acct)
+	ctx.Fix1781 = true
+	ctx.SeenDirectIssues[0][Issue{Currency: "XRP"}] = true
+	_, result := ctx.newXRPEndpointStep(acct, true, false)
+	require.Equal(t, ter.TerNO_LINE, result)
+}
+
+func TestXRPEndpointStep_CheckUnresolvableAMM(t *testing.T) {
+	view := newPaymentMockLedgerView()
+	acct := [20]byte{2}
+	root := &state.AccountRoot{
+		Account:  state.EncodeAccountIDSafe(acct),
+		Balance:  100_000_000,
+		Sequence: 1,
+	}
+	root.AMMID[0] = 1
+	data, err := state.SerializeAccountRoot(root)
+	require.NoError(t, err)
+	view.data[keylet.Account(acct).Key] = data
+
+	sb := NewPaymentSandbox(view)
+	require.Equal(t, ter.TecINTERNAL, NewXRPEndpointStep(acct, true).Check(sb))
+}
 
 // TestXRPEndpointStep_xrpLiquid_DeferredCredit proves that XRP credited to an
 // account earlier in the same payment is not double-counted as spendable

--- a/internal/tx/payment/strand.go
+++ b/internal/tx/payment/strand.go
@@ -659,6 +659,9 @@ func (ctx *StrandContext) buildStrandSteps(
 		} else if !cur.hasAccount && next.hasAccount {
 			// Offer to account
 			if curIssue.IsXRP() {
+				if !isLast {
+					return nil, ter.TemBAD_PATH
+				}
 				// XRP coming out of a book — need XRPEndpointStep for the recipient
 				step, result := ctx.newXRPEndpointStep(next.account, true, false) // destination, isFirst=false
 				if result != ter.TesSUCCESS {

--- a/internal/tx/payment/strand.go
+++ b/internal/tx/payment/strand.go
@@ -132,11 +132,20 @@ func (ctx *StrandContext) CheckXRPEndpointLoop(isLast bool) ter.Result {
 // XRPEndpointOfferCrossingStep). For payments, it creates a standard step.
 // isFirst indicates whether this is the first step in the strand (source).
 // Reference: rippled XRPEndpointOfferCrossingStep::computeReserveReduction
-func (ctx *StrandContext) newXRPEndpointStep(account [20]byte, isLast bool, isFirst bool) *XRPEndpointStep {
+func (ctx *StrandContext) newXRPEndpointStep(account [20]byte, isLast bool, isFirst bool) (*XRPEndpointStep, ter.Result) {
+	var step *XRPEndpointStep
 	if ctx.OfferCrossing {
-		return NewXRPEndpointStepForOfferCrossing(account, isLast, isFirst, ctx.StrandDeliver, ctx.View)
+		step = NewXRPEndpointStepForOfferCrossing(account, isLast, isFirst, ctx.StrandDeliver, ctx.View)
+	} else {
+		step = NewXRPEndpointStep(account, isLast)
 	}
-	return NewXRPEndpointStep(account, isLast)
+	if result := step.Check(ctx.View); result != ter.TesSUCCESS {
+		return nil, result
+	}
+	if result := ctx.CheckXRPEndpointLoop(isLast); result != ter.TesSUCCESS {
+		return nil, result
+	}
+	return step, ter.TesSUCCESS
 }
 
 // Path flags - indicate what type of element this path step contains
@@ -545,20 +554,18 @@ func (ctx *StrandContext) buildStrandSteps(
 				if curIssue.IsXRP() {
 					// XRP endpoint step
 					if i == 0 {
-						// Check for XRP loop
-						if result := ctx.CheckXRPEndpointLoop(false); result != ter.TesSUCCESS {
+						step, result := ctx.newXRPEndpointStep(cur.account, false, true) // source, isFirst=true
+						if result != ter.TesSUCCESS {
 							return nil, result
 						}
-						step := ctx.newXRPEndpointStep(cur.account, false, true) // source, isFirst=true
 						strand = append(strand, step)
 						prevStep = step
 					}
 					if isLast {
-						// Check for XRP loop
-						if result := ctx.CheckXRPEndpointLoop(true); result != ter.TesSUCCESS {
+						step, result := ctx.newXRPEndpointStep(next.account, true, false) // destination, isFirst=false
+						if result != ter.TesSUCCESS {
 							return nil, result
 						}
-						step := ctx.newXRPEndpointStep(next.account, true, false) // destination, isFirst=false
 						strand = append(strand, step)
 					}
 				} else {
@@ -598,11 +605,10 @@ func (ctx *StrandContext) buildStrandSteps(
 			// Reference: rippled PaySteps.cpp toStep() lines 80-85: creates XRPEndpointStep
 			// and returns immediately. The book step is created in the next iteration.
 			if curIssue.IsXRP() && i == 0 {
-				// Check for XRP loop
-				if result := ctx.CheckXRPEndpointLoop(false); result != ter.TesSUCCESS {
+				xrpStep, result := ctx.newXRPEndpointStep(cur.account, false, true) // source, isFirst=true
+				if result != ter.TesSUCCESS {
 					return nil, result
 				}
-				xrpStep := ctx.newXRPEndpointStep(cur.account, false, true) // source, isFirst=true
 				strand = append(strand, xrpStep)
 				prevStep = xrpStep
 				// If output is also XRP, defer book step to next iteration
@@ -654,11 +660,10 @@ func (ctx *StrandContext) buildStrandSteps(
 			// Offer to account
 			if curIssue.IsXRP() {
 				// XRP coming out of a book — need XRPEndpointStep for the recipient
-				// Check for XRP loop
-				if result := ctx.CheckXRPEndpointLoop(true); result != ter.TesSUCCESS {
+				step, result := ctx.newXRPEndpointStep(next.account, true, false) // destination, isFirst=false
+				if result != ter.TesSUCCESS {
 					return nil, result
 				}
-				step := ctx.newXRPEndpointStep(next.account, true, false) // destination, isFirst=false
 				strand = append(strand, step)
 			} else if curIssue.Issuer != next.account {
 				// IOU: implied DirectStep from curIssue.Issuer to next account


### PR DESCRIPTION
## Summary
- validate XRP endpoint account and freeze constraints while constructing payment strands, matching rippled's endpoint direction and error ordering
- continue through the shared freeze helper's LP-token checks when no trust line exists
- cover the historical IoC+Sell amounts with unfrozen crossing and globally frozen `tecKILLED` regressions

## Test plan
- [x] `go test ./internal/tx/payment/... ./internal/tx/offer/...`
- [x] `go test ./internal/testing/offer -run '^TestOffer_IoCSell_GlobalFrozenTaker$' -count=1`
- [x] `go test -race ./internal/tx/payment`
- [x] `just vet`
- [x] `just lint`
- [x] `just build`

`just test` passes ordinary packages and reaches the existing Vault/XChain conformance backlog; a sampled Vault failure reproduces unchanged on `origin/main`.

Fixes #1182
