### PR TITLE
fix(sync): make initial full-state sync testnet-ready

### DIFF
--- a/internal/consensus/adaptor/adaptor_methods_cov_test.go
+++ b/internal/consensus/adaptor/adaptor_methods_cov_test.go
@@ -2,13 +2,11 @@ package adaptor
 
 import (
 	"context"
-	"encoding/binary"
 	"testing"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
-	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -279,15 +277,7 @@ func TestAdg_OnPhaseChange(t *testing.T) {
 	})
 }
 
-func TestAdg_AdoptLedgerFromHeader_InvalidBytes(t *testing.T) {
-	a := newTestAdaptor(t)
-
-	err := a.AdoptLedgerFromHeader([]byte{0x00, 0x01})
-	assert.Error(t, err, "short input must fail deserialization")
-}
-
-// adg_newNonStandaloneService builds a consensus-mode (non-standalone)
-// service that sets needsInitialSync=true, required by AdoptLedgerHeader.
+// adg_newNonStandaloneService builds a consensus-mode service.
 func adg_newNonStandaloneService(t *testing.T) *service.Service {
 	t.Helper()
 	cfg := service.Config{
@@ -298,52 +288,6 @@ func adg_newNonStandaloneService(t *testing.T) *service.Service {
 	require.NoError(t, err)
 	require.NoError(t, svc.Start())
 	return svc
-}
-
-func TestAdg_AdoptLedgerFromHeader_ValidHeader(t *testing.T) {
-	svc := adg_newNonStandaloneService(t)
-	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
-	require.NoError(t, err)
-	a := New(Config{
-		LedgerService: svc,
-		Identity:      identity,
-		Validators:    []consensus.NodeID{identity.NodeID},
-	})
-
-	cl := svc.GetClosedLedger()
-	require.NotNil(t, cl)
-	h := cl.Header()
-
-	// Serialize with hash so AdoptLedgerFromHeader can verify.
-	raw := header.AddRaw(h, true)
-
-	a.SetOperatingMode(consensus.OpModeConnected)
-	err = a.AdoptLedgerFromHeader(raw)
-	require.NoError(t, err)
-
-	assert.Equal(t, consensus.OpModeTracking, a.GetOperatingMode())
-}
-
-func TestAdg_AdoptLedgerFromHeader_PrefixedHeader(t *testing.T) {
-	svc := adg_newNonStandaloneService(t)
-	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
-	require.NoError(t, err)
-	a := New(Config{
-		LedgerService: svc,
-		Identity:      identity,
-		Validators:    []consensus.NodeID{identity.NodeID},
-	})
-	cl := svc.GetClosedLedger()
-	require.NotNil(t, cl)
-	h := cl.Header()
-	raw := header.AddRaw(h, true)
-
-	prefixed := make([]byte, 4+len(raw))
-	binary.BigEndian.PutUint32(prefixed[:4], 0x534E4400) // arbitrary prefix
-	copy(prefixed[4:], raw)
-
-	err = a.AdoptLedgerFromHeader(prefixed)
-	require.NoError(t, err)
 }
 
 func TestAdg_BroadcastStatus_NoClosedLedgerNoPanic(t *testing.T) {

--- a/internal/consensus/adaptor/consensus_events.go
+++ b/internal/consensus/adaptor/consensus_events.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
-	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
@@ -302,6 +301,11 @@ func (a *Adaptor) ancestorOf(ledger consensus.Ledger, targetSeq uint32) consensu
 func (a *Adaptor) OnLedgerFullyValidated(ledgerID consensus.LedgerID, seq uint32) {
 	var hash [32]byte
 	copy(hash[:], ledgerID[:])
+	if a.ledgerService.NeedsInitialSync() {
+		if _, err := a.ledgerService.GetLedgerByHash(hash); err != nil {
+			a.sender.CheckTracking(seq)
+		}
+	}
 	a.ledgerService.SetValidatedLedger(seq, hash)
 	a.refreshRemoteFee(ledgerID)
 	a.logger.Info("Ledger fully validated",
@@ -362,36 +366,6 @@ func (a *Adaptor) OnModeChange(oldMode, newMode consensus.Mode) {
 // NeedsInitialSync returns true if the node hasn't yet adopted a ledger from peers.
 func (a *Adaptor) NeedsInitialSync() bool {
 	return a.ledgerService.NeedsInitialSync()
-}
-
-// AdoptLedgerFromHeader adopts a peer's ledger from a serialized header.
-func (a *Adaptor) AdoptLedgerFromHeader(headerData []byte) error {
-	h, err := header.DeserializePrefixedHeader(headerData, true)
-	if err != nil {
-		// Try without prefix (some responses omit it)
-		h, err = header.DeserializeHeader(headerData, true)
-		if err != nil {
-			return fmt.Errorf("deserialize header: %w", err)
-		}
-	}
-
-	if err := a.ledgerService.AdoptLedgerHeader(h); err != nil {
-		return fmt.Errorf("adopt ledger: %w", err)
-	}
-
-	// Transition to Tracking mode — the router manages the Full transition
-	// once we verify our LCL matches the network.
-	a.SetOperatingMode(consensus.OpModeTracking)
-
-	// Tell peers about the jump so their tallies replace whatever LCL they
-	// last recorded for us.
-	a.broadcastSwitchedLedger(h.LedgerIndex, h.Hash[:], h.ParentHash[:])
-
-	a.logger.Info("Adopted peer ledger",
-		"seq", h.LedgerIndex,
-		"hash", fmt.Sprintf("%x", h.Hash[:8]),
-	)
-	return nil
 }
 
 func (a *Adaptor) OnPhaseChange(oldPhase, newPhase consensus.Phase) {

--- a/internal/consensus/adaptor/modemanager.go
+++ b/internal/consensus/adaptor/modemanager.go
@@ -11,8 +11,8 @@ import (
 // OperatingMode transitions. It is subscribed to the engine at startup
 // and its only live entry point is OnEvent.
 //
-// Production paths (router.go, AdoptLedgerFromHeader, catch-up) set the
-// operating mode directly via Adaptor.SetOperatingMode, so m.mode is not
+// Production router and catch-up paths set the operating mode directly via
+// Adaptor.SetOperatingMode, so m.mode is not
 // the authoritative source of truth — OnEvent reads the adaptor's mode
 // and only steers the wrongLedger ↔ syncing/tracking edges consensus
 // signals. The earlier peer-count / LCL-acquisition ladder
@@ -51,8 +51,8 @@ type pendingTransition struct {
 
 // OnEvent translates engine ModeChangedEvents into adaptor OperatingMode
 // transitions. Reads adaptor.GetOperatingMode() rather than m.mode because
-// production paths (router.go, AdoptLedgerFromHeader) bypass this state
-// machine via direct SetOperatingMode calls, so m.mode isn't authoritative.
+// production router paths bypass this state machine via direct SetOperatingMode
+// calls, so m.mode isn't authoritative.
 func (m *ModeManager) OnEvent(event consensus.Event) {
 	mc, ok := event.(*consensus.ModeChangedEvent)
 	if !ok {

--- a/internal/consensus/adaptor/modemanager_test.go
+++ b/internal/consensus/adaptor/modemanager_test.go
@@ -76,8 +76,7 @@ func TestModeManager_OnEvent_LeavingWrongLedgerBumpsToTracking(t *testing.T) {
 
 // TestModeManager_OnEvent_BypassedStateMachine pins the issue #401
 // behavior: in production, OperatingMode is promoted to Full by direct
-// SetOperatingMode calls in router.go and adaptor.AdoptLedgerFromHeader,
-// NOT through ModeManager. So m.mode can lag while
+// SetOperatingMode calls in router paths, not through ModeManager. So m.mode can lag while
 // adaptor.GetOperatingMode() returns Full. When a
 // ModeChangedEvent{wrongLedger} fires, OnEvent MUST consult the adaptor's
 // actual opMode and trigger Full → Syncing — otherwise the engine drops

--- a/internal/consensus/adaptor/network_sender.go
+++ b/internal/consensus/adaptor/network_sender.go
@@ -12,6 +12,7 @@ type NetworkSender interface {
 	BroadcastProposal(proposal *consensus.Proposal) error
 	BroadcastValidation(validation *consensus.Validation) error
 	BroadcastStatusChange(sc *message.StatusChange) error
+	CheckTracking(validSeq uint32)
 	// RelayProposal / RelayValidation forward a peer-originated message to
 	// other peers, subject to the squelch filter, excluding exceptPeer (the
 	// originator; 0 = unfiltered, test-only). SuppressionHash keys the
@@ -94,6 +95,7 @@ type noopSender struct{}
 func (n *noopSender) BroadcastProposal(*consensus.Proposal) error         { return nil }
 func (n *noopSender) BroadcastValidation(*consensus.Validation) error     { return nil }
 func (n *noopSender) BroadcastStatusChange(*message.StatusChange) error   { return nil }
+func (n *noopSender) CheckTracking(uint32)                                {}
 func (n *noopSender) RelayProposal(*consensus.Proposal, uint64) error     { return nil }
 func (n *noopSender) RelayValidation(*consensus.Validation, uint64) error { return nil }
 func (n *noopSender) UpdateRelaySlot([]byte, uint64, []uint64)            {}

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -1146,36 +1146,6 @@ func (r *Router) handleLedgerData(msg *peermanagement.InboundMessage) {
 		if r.handleInboundLedgerData(il, ld, uint64(msg.PeerID)) {
 			return
 		}
-		// If handleInboundLedgerData returned false (e.g. GotBase failed),
-		// fall through to the legacy header-only adoption path
-	}
-
-	// During initial sync, try to adopt the ledger header from peers
-	if ld.InfoType == message.LedgerInfoBase && len(ld.Nodes) > 0 && r.adaptor.NeedsInitialSync() {
-		headerData := ld.Nodes[0].NodeData
-		if err := r.adaptor.AdoptLedgerFromHeader(headerData); err != nil {
-			r.logger.Debug("failed to adopt ledger header", "error", err, "peer", msg.PeerID)
-		} else {
-			r.logger.Info("adopted ledger from peer",
-				"seq", ld.LedgerSeq,
-				"peer", msg.PeerID,
-			)
-			return
-		}
-	}
-
-	if len(ld.LedgerHash) == 32 {
-		var ledgerID consensus.LedgerID
-		copy(ledgerID[:], ld.LedgerHash)
-
-		var payload []byte
-		for _, node := range ld.Nodes {
-			payload = append(payload, node.NodeData...)
-		}
-
-		if err := r.engine.OnLedger(ledgerID, payload); err != nil {
-			r.logger.Debug("engine rejected ledger data", "error", err, "peer", msg.PeerID)
-		}
 	}
 }
 
@@ -1190,17 +1160,15 @@ func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerD
 	switch ld.InfoType {
 	case message.LedgerInfoBase:
 		if len(ld.Nodes) < 2 {
-			// Response doesn't include root nodes — can't do full acquisition.
-			// Drop the acquisition and fall through to legacy adoption.
-			r.logger.Debug("inbound ledger: response has < 2 nodes, falling back", "nodes", len(ld.Nodes))
+			r.logger.Debug("inbound ledger: response has < 2 nodes", "nodes", len(ld.Nodes))
 			r.fetchTracker.Remove(il.Hash(), false)
-			return false
+			return true
 		}
 		if err := il.GotBase(ld.Nodes); err != nil {
-			r.logger.Warn("inbound ledger: GotBase failed, falling back", "error", err)
+			r.logger.Warn("inbound ledger: GotBase failed", "error", err)
 			r.adaptor.IncPeerBadData(peerID, "ledger-data-base")
 			r.fetchTracker.Remove(il.Hash(), false)
-			return false
+			return true
 		}
 
 		if il.IsComplete() {

--- a/internal/consensus/adaptor/router_initial_sync_test.go
+++ b/internal/consensus/adaptor/router_initial_sync_test.go
@@ -1,0 +1,99 @@
+package adaptor
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/require"
+)
+
+type trackingCheckSender struct {
+	noopSender
+	mu   sync.Mutex
+	seqs []uint32
+}
+
+func TestRouter_MalformedMatchingBaseCannotFallThrough(t *testing.T) {
+	svc := adg_newNonStandaloneService(t)
+	engine := &mockEngine{}
+	a := New(Config{LedgerService: svc})
+	r := NewRouter(engine, a, make(chan *peermanagement.InboundMessage, 1))
+	target := [32]byte{0x72}
+	seq := svc.GetClosedLedgerIndex() + 100
+	r.fetchTracker.Track(inbound.New(target, seq, 7, nil))
+
+	ld := &message.LedgerData{
+		LedgerHash: target[:],
+		LedgerSeq:  seq,
+		InfoType:   message.LedgerInfoBase,
+		Nodes:      []message.LedgerNode{{NodeData: []byte{1, 2, 3}}},
+	}
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    uint16(message.TypeLedgerData),
+		Payload: encodePayload(t, ld),
+	})
+
+	require.Nil(t, r.fetchTracker.Find(target))
+	require.True(t, svc.NeedsInitialSync())
+	require.Empty(t, engine.getLedgers())
+}
+
+func (s *trackingCheckSender) CheckTracking(seq uint32) {
+	s.mu.Lock()
+	s.seqs = append(s.seqs, seq)
+	s.mu.Unlock()
+}
+
+func TestRouter_UnmatchedBaseCannotAdoptHeader(t *testing.T) {
+	svc := adg_newNonStandaloneService(t)
+	engine := &mockEngine{}
+	a := New(Config{LedgerService: svc})
+	r := NewRouter(engine, a, make(chan *peermanagement.InboundMessage, 1))
+
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	closedHash := closed.Hash()
+	closedSeq := closed.Sequence()
+	target := [32]byte{0x71}
+
+	ld := &message.LedgerData{
+		LedgerHash: target[:],
+		LedgerSeq:  closedSeq + 100,
+		InfoType:   message.LedgerInfoBase,
+		Nodes: []message.LedgerNode{
+			{NodeData: []byte{1, 2, 3}},
+		},
+	}
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    uint16(message.TypeLedgerData),
+		Payload: encodePayload(t, ld),
+	})
+
+	require.True(t, svc.NeedsInitialSync())
+	require.Equal(t, closedSeq, svc.GetClosedLedgerIndex())
+	require.Equal(t, closedHash, svc.GetClosedLedger().Hash())
+	require.Empty(t, engine.getLedgers())
+	_, err := a.GetLedger(consensus.LedgerID(target))
+	require.Error(t, err)
+}
+
+func TestAdaptor_ValidationQuorumChecksPeerTrackingDuringInitialSync(t *testing.T) {
+	svc := adg_newNonStandaloneService(t)
+	sender := &trackingCheckSender{}
+	a := New(Config{LedgerService: svc, Sender: sender})
+	target := consensus.LedgerID{0x44}
+
+	a.OnLedgerFullyValidated(target, 10_000)
+
+	sender.mu.Lock()
+	require.Equal(t, []uint32{10_000}, sender.seqs)
+	sender.mu.Unlock()
+	require.True(t, svc.NeedsInitialSync())
+	require.Equal(t, uint32(1), svc.GetValidatedLedgerIndex())
+}

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -19,6 +19,10 @@ func NewOverlaySender(overlay *peermanagement.Overlay) *OverlaySender {
 	return &OverlaySender{overlay: overlay}
 }
 
+func (s *OverlaySender) CheckTracking(validSeq uint32) {
+	s.overlay.CheckTracking(validSeq)
+}
+
 // BroadcastProposal sends OUR OWN proposal to every connected peer
 // WITHOUT applying the squelch filter: a peer that squelches our own
 // pubkey should NOT cause our own proposals to disappear from the

--- a/internal/consensus/adaptor/sender_cov_test.go
+++ b/internal/consensus/adaptor/sender_cov_test.go
@@ -199,6 +199,7 @@ func (f *snd_fakeOverlay) PeersWithLedger([32]byte, uint32, []uint64, int) []uin
 }
 func (f *snd_fakeOverlay) PeerWithTxSet([32]byte, uint64) (uint64, bool) { return 0, false }
 func (f *snd_fakeOverlay) NotePeerHasTxSet(uint64, [32]byte)             {}
+func (f *snd_fakeOverlay) CheckTracking(uint32)                          {}
 
 func snd_newAdaptorWithFake(t *testing.T, fake *snd_fakeOverlay) *Adaptor {
 	t.Helper()

--- a/internal/consensus/adaptor/status_change_test.go
+++ b/internal/consensus/adaptor/status_change_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
-	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,30 +92,6 @@ func TestStatusChange_OnLedgerSwitchedPayload(t *testing.T) {
 	assert.Nil(t, sc.FirstSeq)
 	assert.Nil(t, sc.LastSeq)
 	assert.NotZero(t, sc.NetworkTime)
-}
-
-// Adopting a peer's ledger during initial sync is an LCL jump and must be
-// announced to peers.
-func TestStatusChange_AdoptLedgerFromHeaderAnnouncesSwitch(t *testing.T) {
-	svc := adg_newNonStandaloneService(t)
-	sender := &scRecordingSender{}
-	a := New(Config{LedgerService: svc, Sender: sender})
-
-	cl := svc.GetClosedLedger()
-	require.NotNil(t, cl)
-	h := cl.Header()
-	raw := header.AddRaw(h, true)
-
-	require.NoError(t, a.AdoptLedgerFromHeader(raw))
-
-	sender.mu.Lock()
-	defer sender.mu.Unlock()
-	require.Len(t, sender.scs, 1)
-	sc := sender.scs[0]
-	assert.Equal(t, message.NodeEventSwitchedLedger, sc.NewEvent)
-	assert.Equal(t, h.LedgerIndex, sc.LedgerSeq)
-	assert.Equal(t, h.Hash[:], sc.LedgerHash)
-	assert.Equal(t, h.ParentHash[:], sc.LedgerHashPrevious)
 }
 
 // A phase-driven status change omits new_status (peers inherit their last

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -557,19 +557,18 @@ func (l *Ledger) GotStateNodes(nodes []message.LedgerNode) error {
 		l.markProgressLocked()
 	}
 
-	complete := l.stateMap.IsComplete()
+	// FinishSync is the authoritative completeness check (it takes the write
+	// lock, so it can't race a concurrent insert the way a bare IsComplete
+	// read can); a failure just means "still missing nodes", not fatal. It
+	// is also the only completeness walk here — the former IsComplete call
+	// for a log attribute was a second full-tree walk per reply.
+	finished := l.stateMap.FinishSync() == nil
 	l.logger.Info("inbound ledger: added state nodes",
 		"added", added,
 		"total_received", len(nodes),
-		"complete", complete,
+		"complete", finished,
 	)
-
-	// Always attempt FinishSync — it is the only authoritative check
-	// (IsComplete reads under RLock and can race a concurrent insert
-	// before the FinishSync write lock). A failure here is treated as
-	// "still missing nodes", not fatal.
-	if err := l.stateMap.FinishSync(); err != nil {
-		l.logger.Debug("inbound ledger: state still incomplete", "error", err)
+	if !finished {
 		return nil
 	}
 	l.haveState = true

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -472,6 +472,7 @@ func (l *Ledger) GotBase(nodes []message.LedgerNode) error {
 		l.err = fmt.Errorf("create state map: %w", err)
 		return l.err
 	}
+	sm.SetLedgerSeq(h.LedgerIndex)
 
 	if err := sm.AddRootNode(h.AccountHash, nodes[1].NodeData); err != nil {
 		l.state = StateFailed
@@ -494,6 +495,7 @@ func (l *Ledger) GotBase(nodes []message.LedgerNode) error {
 			l.err = fmt.Errorf("create tx map: %w", terr)
 			return l.err
 		}
+		tm.SetLedgerSeq(h.LedgerIndex)
 		if len(nodes) >= 3 && len(nodes[2].NodeData) > 0 {
 			if err := tm.AddRootNode(h.TxHash, nodes[2].NodeData); err != nil {
 				l.state = StateFailed
@@ -516,11 +518,8 @@ func (l *Ledger) GotBase(nodes []message.LedgerNode) error {
 		}
 	}
 
-	if l.haveState && l.haveTx {
-		l.state = StateComplete
-	} else {
-		l.state = StateWantState
-	}
+	l.state = StateWantState
+	l.recomputeComplete()
 
 	l.logger.Info("inbound ledger: roots added, fetching missing nodes",
 		"seq", h.LedgerIndex,

--- a/internal/ledger/inbound/inbound_backed_test.go
+++ b/internal/ledger/inbound/inbound_backed_test.go
@@ -174,4 +174,52 @@ func TestGotBase_BackedFetchesOnlyForkDelta(t *testing.T) {
 	if !il.IsComplete() {
 		t.Fatalf("acquisition should complete after the peer supplies the fork delta; state=%d", il.State())
 	}
+	var stored []shamap.FlushEntry
+	if err := il.stateMap.StoreDirty(func(entries []shamap.FlushEntry) error {
+		stored = append(stored, entries...)
+		return nil
+	}); err != nil {
+		t.Fatalf("store acquired delta: %v", err)
+	}
+	if len(stored) == 0 || len(stored) >= len(wire) {
+		t.Fatalf("stored nodes = %d, want only the received fork frontier (full tree has %d)", len(stored), len(wire))
+	}
+}
+
+func TestGotBase_StoreCompleteTreePersistsOnlyReceivedRoot(t *testing.T) {
+	source, rootHash, rootData := buildBackedTestState(t, 0)
+	family := shamap.NewMemoryNodeStoreFamily()
+	nodes, err := source.WalkFetchPackNodes(1 << 20)
+	if err != nil {
+		t.Fatalf("walk fetch-pack nodes: %v", err)
+	}
+	entries := make([]shamap.FlushEntry, 0, len(nodes)-1)
+	for _, node := range nodes {
+		if node.Hash != rootHash {
+			entries = append(entries, shamap.FlushEntry{Hash: node.Hash, Data: node.Data, LedgerSeq: 99, MapType: shamap.TypeState})
+		}
+	}
+	if err := family.StoreBatch(context.Background(), entries); err != nil {
+		t.Fatalf("seed descendants: %v", err)
+	}
+
+	hdrBytes, ledgerHash := encodeHeader(header.LedgerHeader{LedgerIndex: 100, AccountHash: rootHash})
+	il := New(ledgerHash, 100, 7, discardLogger(), WithFamily(family))
+	if err := il.GotBase([]message.LedgerNode{{NodeData: hdrBytes}, {NodeData: rootData}}); err != nil {
+		t.Fatalf("GotBase: %v", err)
+	}
+	if !il.IsComplete() {
+		t.Fatalf("descendant-backed acquisition did not complete; state=%d", il.State())
+	}
+
+	var stored []shamap.FlushEntry
+	if err := il.stateMap.StoreDirty(func(got []shamap.FlushEntry) error {
+		stored = append(stored, got...)
+		return nil
+	}); err != nil {
+		t.Fatalf("store received root: %v", err)
+	}
+	if len(stored) != 1 || stored[0].Hash != rootHash {
+		t.Fatalf("stored nodes = %v, want only received root %x", stored, rootHash[:8])
+	}
 }

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -134,6 +134,8 @@ func NewOpen(parent *Ledger, closeTime time.Time) (*Ledger, error) {
 		Drops:               parent.header.Drops,
 		// Hash, TxHash, AccountHash will be set when closed
 	}
+	stateMap.SetLedgerSeq(newLedgerSeq)
+	txMap.SetLedgerSeq(newLedgerSeq)
 
 	return &Ledger{
 		stateMap:       stateMap,
@@ -152,6 +154,8 @@ func FromGenesis(
 	txMap *shamap.SHAMap,
 	fees drops.Fees,
 ) *Ledger {
+	setMapLedgerSeq(stateMap, hdr.LedgerIndex)
+	setMapLedgerSeq(txMap, hdr.LedgerIndex)
 	return &Ledger{
 		stateMap: stateMap,
 		txMap:    txMap,
@@ -169,6 +173,8 @@ func NewFromHeader(
 	txMap *shamap.SHAMap,
 	fees drops.Fees,
 ) *Ledger {
+	setMapLedgerSeq(stateMap, hdr.LedgerIndex)
+	setMapLedgerSeq(txMap, hdr.LedgerIndex)
 	return &Ledger{
 		stateMap: stateMap,
 		txMap:    txMap,
@@ -186,12 +192,20 @@ func NewOpenWithHeader(
 	txMap *shamap.SHAMap,
 	fees drops.Fees,
 ) *Ledger {
+	setMapLedgerSeq(stateMap, hdr.LedgerIndex)
+	setMapLedgerSeq(txMap, hdr.LedgerIndex)
 	return &Ledger{
 		stateMap: stateMap,
 		txMap:    txMap,
 		header:   hdr,
 		fees:     fees,
 		state:    StateOpen,
+	}
+}
+
+func setMapLedgerSeq(sm *shamap.SHAMap, seq uint32) {
+	if sm != nil {
+		sm.SetLedgerSeq(seq)
 	}
 }
 
@@ -768,12 +782,42 @@ func (l *Ledger) TxMapSnapshot() (*shamap.SHAMap, error) {
 	return l.txMap.SnapshotMutable()
 }
 
-// SetStateMapFamily sets the Family on the state map, enabling backed mode
-// with lazy loading and efficient snapshots.
+func (l *Ledger) StoreStateDirty(store func([]shamap.FlushEntry) error) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.stateMap == nil {
+		return nil
+	}
+	return l.stateMap.StoreDirty(store)
+}
+
+func (l *Ledger) StoreTransactionDirty(store func([]shamap.FlushEntry) error) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.txMap == nil {
+		return nil
+	}
+	return l.txMap.StoreDirty(store)
+}
+
+// SetSHAMapFamily backs both ledger maps with the same node family.
+func (l *Ledger) SetSHAMapFamily(family shamap.Family) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.stateMap != nil {
+		l.stateMap.SetFamily(family)
+	}
+	if l.txMap != nil {
+		l.txMap.SetFamily(family)
+	}
+}
+
 func (l *Ledger) SetStateMapFamily(family shamap.Family) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.stateMap.SetFamily(family)
+	if l.stateMap != nil {
+		l.stateMap.SetFamily(family)
+	}
 }
 
 func (l *Ledger) SerializeHeader() []byte {

--- a/internal/ledger/service/adopt_with_state_test.go
+++ b/internal/ledger/service/adopt_with_state_test.go
@@ -171,8 +171,8 @@ func TestAdoptLedgerWithState_NilTxMapFallsBackToEmpty(t *testing.T) {
 		"nil txMap must fall back to the genesis-shaped empty tx map")
 }
 
-// TestAdoptLedgerWithState_PersistsToRelationalDB pins F1: adopting a
-// ledger with a tx map must flush those transactions to the
+// TestAdoptLedgerWithState_PersistsToRelationalDB pins F1: validating an
+// adopted ledger with a tx map must flush those transactions to the
 // RelationalDB so `tx`, `account_tx`, `tx_history`, and
 // `transaction_entry` RPCs can answer queries against peer-adopted
 // ledgers. Before F1, the adopt path never called persistLedger and
@@ -221,6 +221,11 @@ func TestAdoptLedgerWithState_PersistsToRelationalDB(t *testing.T) {
 	}
 
 	require.NoError(t, svc.AdoptLedgerWithState(context.TODO(), hdr, stateMap, txMap))
+	svc.FlushPersists()
+	unvalidatedInfo, err := rm.Ledger().GetLedgerInfoBySeq(ctx, relationaldb.LedgerIndex(hdr.LedgerIndex))
+	require.ErrorIs(t, err, relationaldb.ErrLedgerNotFound)
+	require.Nil(t, unvalidatedInfo, "unvalidated adoption must not enter the validated relational index")
+	svc.SetValidatedLedger(hdr.LedgerIndex, adoptedHash)
 	// Persistence runs on the async worker; barrier before asserting.
 	svc.FlushPersists()
 

--- a/internal/ledger/service/fast_load.go
+++ b/internal/ledger/service/fast_load.go
@@ -1,0 +1,156 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/LeJamon/go-xrpl/storage/nodestore"
+)
+
+func (s *Service) loadLatestLedger(ctx context.Context) (*ledger.Ledger, error) {
+	if s.nodeStore == nil || s.relationalDB == nil || s.shamapFamily == nil {
+		return nil, nil
+	}
+	info, err := s.relationalDB.Ledger().GetNewestLedgerInfo(ctx)
+	if err != nil || info == nil {
+		return nil, err
+	}
+	tip, err := s.nodeStore.Fetch(ctx, validatedTipKey)
+	if err != nil {
+		return nil, err
+	}
+	if tip == nil {
+		return nil, nil
+	}
+	if tip.Type != nodestore.NodeLedger || tip.LedgerSeq != uint32(info.Sequence) ||
+		len(tip.Data) != 32 || !bytes.Equal(tip.Data, info.Hash[:]) {
+		return nil, fmt.Errorf("newest relational ledger %d is not the persisted validated tip", info.Sequence)
+	}
+	stored, err := s.nodeStore.Fetch(ctx, nodestore.Hash256(info.Hash))
+	if err != nil {
+		return nil, err
+	}
+	if stored == nil || stored.Type != nodestore.NodeLedger {
+		return nil, fmt.Errorf("ledger %d header is missing", info.Sequence)
+	}
+	h, err := header.DeserializeHeader(stored.Data, true)
+	if err != nil {
+		return nil, err
+	}
+	if h.Hash != [32]byte(info.Hash) || h.LedgerIndex != uint32(info.Sequence) ||
+		h.AccountHash != [32]byte(info.AccountHash) || h.TxHash != [32]byte(info.TransactionHash) ||
+		h.ParentHash != [32]byte(info.ParentHash) || h.Drops != uint64(info.TotalCoins) ||
+		!h.CloseTime.Equal(info.CloseTime) || !h.ParentCloseTime.Equal(info.ParentCloseTime) ||
+		h.CloseTimeResolution != uint32(info.CloseTimeRes) || h.CloseFlags != uint8(info.CloseFlags) ||
+		header.CalculateHash(*h) != h.Hash {
+		return nil, fmt.Errorf("ledger %d header does not match persisted metadata", info.Sequence)
+	}
+	if err := s.verifyStoredSHAMap(ctx, h.AccountHash, shamap.TypeState); err != nil {
+		return nil, fmt.Errorf("ledger %d state tree: %w", info.Sequence, err)
+	}
+	if h.TxHash != ([32]byte{}) {
+		if err := s.verifyStoredSHAMap(ctx, h.TxHash, shamap.TypeTransaction); err != nil {
+			return nil, fmt.Errorf("ledger %d transaction tree: %w", info.Sequence, err)
+		}
+	}
+
+	stateMap, err := shamap.NewFromRootHash(shamap.TypeState, h.AccountHash, s.shamapFamily)
+	if err != nil {
+		return nil, err
+	}
+	var txMap *shamap.SHAMap
+	if h.TxHash == ([32]byte{}) {
+		txMap, err = shamap.NewBacked(shamap.TypeTransaction, s.shamapFamily)
+	} else {
+		txMap, err = shamap.NewFromRootHash(shamap.TypeTransaction, h.TxHash, s.shamapFamily)
+	}
+	if err != nil {
+		return nil, err
+	}
+	stateMap.SetLedgerSeq(h.LedgerIndex)
+	txMap.SetLedgerSeq(h.LedgerIndex)
+	if err := stateMap.SetImmutable(); err != nil {
+		return nil, err
+	}
+	if err := txMap.SetImmutable(); err != nil {
+		return nil, err
+	}
+	h.Validated = true
+	h.Accepted = true
+	return ledger.NewFromHeader(*h, stateMap, txMap, drops.Fees{}), nil
+}
+
+func (s *Service) verifyStoredSHAMap(ctx context.Context, root [32]byte, mapType shamap.Type) error {
+	return s.walkStoredSHAMap(ctx, root, mapType, nil)
+}
+
+func (s *Service) walkStoredSHAMap(
+	ctx context.Context,
+	root [32]byte,
+	mapType shamap.Type,
+	visit func([32]byte, *nodestore.Node) error,
+) error {
+	if root == ([32]byte{}) {
+		return fmt.Errorf("zero root")
+	}
+	type pendingNode struct {
+		hash  [32]byte
+		depth int
+	}
+	stack := []pendingNode{{hash: root}}
+	for len(stack) > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		pending := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		stored, err := s.nodeStore.Fetch(ctx, nodestore.Hash256(pending.hash))
+		if err != nil {
+			return err
+		}
+		if stored == nil {
+			return fmt.Errorf("node %x is missing", pending.hash[:8])
+		}
+		node, err := shamap.DeserializeFromPrefix(stored.Data)
+		if err != nil {
+			return err
+		}
+		if node.Hash() != pending.hash {
+			return fmt.Errorf("node %x has invalid content hash", pending.hash[:8])
+		}
+		if inner, ok := node.(shamap.InnerNodeReader); ok {
+			if pending.depth >= 64 {
+				return fmt.Errorf("inner node %x exceeds maximum depth", pending.hash[:8])
+			}
+			for branch := 0; branch < shamap.BranchFactor; branch++ {
+				if inner.IsEmptyBranch(branch) {
+					continue
+				}
+				child, err := inner.ChildHash(branch)
+				if err != nil {
+					return err
+				}
+				stack = append(stack, pendingNode{hash: child, depth: pending.depth + 1})
+			}
+		} else if pending.depth == 0 {
+			return fmt.Errorf("root node %x is not an inner node", pending.hash[:8])
+		} else if mapType == shamap.TypeState && node.Type() != shamap.NodeTypeAccountState {
+			return fmt.Errorf("state tree contains %s leaf", node.Type())
+		} else if mapType == shamap.TypeTransaction &&
+			node.Type() != shamap.NodeTypeTransactionNoMeta &&
+			node.Type() != shamap.NodeTypeTransactionWithMeta {
+			return fmt.Errorf("transaction tree contains %s leaf", node.Type())
+		}
+		if visit != nil {
+			if err := visit(pending.hash, stored); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/ledger/service/fast_load_test.go
+++ b/internal/ledger/service/fast_load_test.go
@@ -1,0 +1,182 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/LeJamon/go-xrpl/storage/kvstore/memorydb"
+	"github.com/LeJamon/go-xrpl/storage/nodestore"
+	sqlitedb "github.com/LeJamon/go-xrpl/storage/relationaldb/sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_FastLoadRestoresPersistedValidatedLedger(t *testing.T) {
+	ctx := context.Background()
+	db := nodestore.NewKVDatabase(memorydb.New(), "fast-load", 10_000, time.Hour)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	rm, err := sqlitedb.NewRepositoryManager(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, rm.Open(ctx))
+	t.Cleanup(func() { require.NoError(t, rm.Close(ctx)) })
+
+	first, err := New(Config{
+		Standalone:    true,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  shamap.NewNodeStoreFamily(db),
+		RelationalDB:  rm,
+	})
+	require.NoError(t, err)
+	require.NoError(t, first.Start())
+	txBlob := []byte("synthetic-tx")
+	txHash := sha512half.Sum(protocol.HashPrefixTransactionID().Bytes(), txBlob)
+	require.NoError(t, first.openLedger.AddTransaction(txHash, txBlob))
+	seq, err := first.AcceptLedger(ctx)
+	require.NoError(t, err)
+	first.FlushPersists()
+	want := first.GetValidatedLedger()
+	require.NotNil(t, want)
+	wantHash := want.Hash()
+	first.Stop()
+
+	second, err := New(Config{
+		Standalone:    false,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  shamap.NewNodeStoreFamily(db),
+		RelationalDB:  rm,
+		FastLoad:      true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, second.Start())
+	t.Cleanup(second.Stop)
+
+	require.False(t, second.NeedsInitialSync())
+	require.Equal(t, seq, second.GetValidatedLedgerIndex())
+	require.Equal(t, wantHash, second.GetValidatedLedger().Hash())
+	require.Equal(t, seq+1, second.GetCurrentLedgerIndex())
+	gotTx, ok, err := second.GetValidatedLedger().GetTransaction(txHash)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, txBlob, gotTx)
+	txResult, err := second.GetTransaction(txHash)
+	require.NoError(t, err)
+	require.Equal(t, txBlob, txResult.TxData)
+	firstSeq, lastSeq, ok := second.AdvertisableLedgerRange()
+	require.True(t, ok)
+	require.Equal(t, seq, firstSeq)
+	require.Equal(t, seq, lastSeq)
+}
+
+func TestService_FastLoadFallsBackWhenStorageIsEmpty(t *testing.T) {
+	ctx := context.Background()
+	db := nodestore.NewKVDatabase(memorydb.New(), "fast-load-empty", 100, time.Hour)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	rm, err := sqlitedb.NewRepositoryManager(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, rm.Open(ctx))
+	t.Cleanup(func() { require.NoError(t, rm.Close(ctx)) })
+
+	svc, err := New(Config{
+		Standalone:    false,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  shamap.NewNodeStoreFamily(db),
+		RelationalDB:  rm,
+		FastLoad:      true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+	require.True(t, svc.NeedsInitialSync())
+	require.Equal(t, uint32(1), svc.GetValidatedLedgerIndex())
+}
+
+func TestService_FastLoadRejectsRelationalLedgerWithoutValidatedTip(t *testing.T) {
+	ctx := context.Background()
+	db := nodestore.NewKVDatabase(memorydb.New(), "fast-load-unvalidated", 10_000, time.Hour)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	rm, err := sqlitedb.NewRepositoryManager(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, rm.Open(ctx))
+	t.Cleanup(func() { require.NoError(t, rm.Close(ctx)) })
+
+	writer, err := New(Config{
+		Standalone:    false,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  shamap.NewNodeStoreFamily(db),
+		RelationalDB:  rm,
+	})
+	require.NoError(t, err)
+	untrusted := buildLedgerWithState(t, 99)
+	require.NoError(t, writer.persistValidatedLedger(ctx, untrusted, false))
+
+	reader, err := New(Config{
+		Standalone:    false,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  shamap.NewNodeStoreFamily(db),
+		RelationalDB:  rm,
+		FastLoad:      true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, reader.Start())
+	t.Cleanup(reader.Stop)
+	require.True(t, reader.NeedsInitialSync())
+	require.Equal(t, uint32(1), reader.GetValidatedLedgerIndex())
+}
+
+func TestService_FastLoadFallsBackWhenTreeIsCorrupt(t *testing.T) {
+	ctx := context.Background()
+	db := nodestore.NewKVDatabase(memorydb.New(), "fast-load-corrupt", 10_000, time.Hour)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	rm, err := sqlitedb.NewRepositoryManager(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, rm.Open(ctx))
+	t.Cleanup(func() { require.NoError(t, rm.Close(ctx)) })
+
+	first, err := New(Config{
+		Standalone:    true,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  shamap.NewNodeStoreFamily(db),
+		RelationalDB:  rm,
+	})
+	require.NoError(t, err)
+	require.NoError(t, first.Start())
+	_, err = first.AcceptLedger(ctx)
+	require.NoError(t, err)
+	first.FlushPersists()
+	stateRoot := first.GetValidatedLedger().Header().AccountHash
+	first.Stop()
+
+	stored, err := db.Fetch(ctx, nodestore.Hash256(stateRoot))
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.NoError(t, db.Store(ctx, &nodestore.Node{
+		Type:      stored.Type,
+		Hash:      stored.Hash,
+		Data:      []byte("corrupt"),
+		LedgerSeq: stored.LedgerSeq,
+	}))
+
+	second, err := New(Config{
+		Standalone:    false,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  shamap.NewNodeStoreFamily(db),
+		RelationalDB:  rm,
+		FastLoad:      true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, second.Start())
+	t.Cleanup(second.Stop)
+	require.True(t, second.NeedsInitialSync())
+	require.Equal(t, uint32(1), second.GetValidatedLedgerIndex())
+}

--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -10,7 +10,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
-	"github.com/LeJamon/go-xrpl/internal/ledger/skiplist"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
@@ -488,10 +487,6 @@ func (s *Service) AcceptConsensusResult(ctx context.Context, parent *ledger.Ledg
 
 	// Do NOT auto-validate — validation comes from the consensus validation tracker.
 
-	// Persist best-effort: a persistence failure must not be fatal (would
-	// diverge from rippled and risk forks on transient DB issues).
-	s.enqueuePersist(s.openLedger)
-
 	closedSeq := s.openLedger.Sequence()
 	closedLedgerHash := s.openLedger.Hash()
 
@@ -537,6 +532,11 @@ func (s *Service) AcceptConsensusResult(ctx context.Context, parent *ledger.Ledg
 	// inline, so the eventCallback must fire inline below (no later
 	// SetValidatedLedger will arrive to drain a hash-keyed stash).
 	promotedByDrain := s.drainPendingLedgerValidationLocked(closedSeq, s.closedLedger)
+	if promotedByDrain {
+		s.enqueuePersist(s.closedLedger)
+	} else {
+		s.enqueueNodePersist(s.closedLedger)
+	}
 
 	var txResults []TransactionResultEvent
 	if s.eventCallback != nil || (s.hooks != nil && (s.hooks.OnLedgerClosed != nil || s.hooks.OnTransaction != nil)) {
@@ -617,6 +617,7 @@ func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 	// quorum for a below-tip seq marks it validated but must not rewind the
 	// pointer — same rule as drainPendingLedgerValidationLocked.
 	if s.validatedLedger != nil && seq <= s.validatedLedger.Sequence() {
+		s.enqueueValidatedHistoryPersist(l)
 		s.mu.Unlock()
 		return
 	}
@@ -627,6 +628,7 @@ func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 	// close — consensus may abandon a closed ledger).
 	pool := s.localTxs
 	event := s.drainPendingValidationLocked(expectedHash)
+	s.enqueuePersist(l)
 	s.mu.Unlock()
 
 	// Fold into the amendment table outside the lock (it has its own mutex).
@@ -771,129 +773,9 @@ func (s *Service) NeedsInitialSync() bool {
 	return s.needsInitialSync
 }
 
-// AdoptLedgerHeader adopts a peer's ledger header as our closed ledger during
-// initial sync. The state map is reused from genesis (valid only while no txs
-// have changed state).
-func (s *Service) AdoptLedgerHeader(h *header.LedgerHeader) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if !s.needsInitialSync {
-		return errors.New("not in initial sync mode")
-	}
-
-	if s.genesisLedger == nil {
-		return errors.New("no genesis ledger available")
-	}
-
-	stateMap, err := s.genesisLedger.StateMapSnapshot()
-	if err != nil {
-		return fmt.Errorf("failed to snapshot genesis state: %w", err)
-	}
-
-	// Update LedgerHashes skiplist so state matches rippled
-	if err := skiplist.UpdateOnMap(stateMap, h.LedgerIndex, h.ParentHash); err != nil {
-		s.logger.Warn("failed to update skip list during adoption", "error", err)
-	}
-
-	txMap, err := s.genesisLedger.TxMapSnapshot()
-	if err != nil {
-		return fmt.Errorf("failed to snapshot genesis tx map: %w", err)
-	}
-
-	adopted := ledger.NewFromHeader(*h, stateMap, txMap, drops.Fees{})
-
-	// Adopted becomes closedLedger and joins history but is NOT marked validated
-	// (no quorum yet); validatedLedger advances later via SetValidatedLedger.
-	// Source closedLedger from the install helper so validated-precedence holds.
-	s.closedLedger = s.installAdoptedLedgerLocked(h.LedgerIndex, adopted)
-
-	openLedger, err := ledger.NewOpen(s.closedLedger, time.Now())
-	if err != nil {
-		return fmt.Errorf("failed to create open ledger: %w", err)
-	}
-	s.openLedger = openLedger
-	s.needsInitialSync = false
-
-	// Adopt-from-peer is a fresh start: rebuild the open view via New, not Accept.
-	if err := s.rebuildOpenLedgerViewLocked(); err != nil {
-		return err
-	}
-
-	s.logger.Info("Adopted ledger from peer",
-		"seq", h.LedgerIndex,
-		"hash", fmt.Sprintf("%x", h.Hash[:8]),
-	)
-
-	return nil
-}
-
-// ReAdoptLedgerHeader re-adopts a peer's header during catch-up — like
-// AdoptLedgerHeader but after needsInitialSync is cleared.
-func (s *Service) ReAdoptLedgerHeader(h *header.LedgerHeader) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.genesisLedger == nil {
-		return errors.New("no genesis ledger available")
-	}
-
-	if s.closedLedger != nil && h.LedgerIndex <= s.closedLedger.Sequence() {
-		return fmt.Errorf("re-adopt seq %d not ahead of current %d", h.LedgerIndex, s.closedLedger.Sequence())
-	}
-
-	// Snapshot from the closed ledger so the skiplist accumulates across re-adoptions
-	source := s.closedLedger
-	if source == nil {
-		source = s.genesisLedger
-	}
-	stateMap, err := source.StateMapSnapshot()
-	if err != nil {
-		return fmt.Errorf("failed to snapshot state: %w", err)
-	}
-
-	// Update LedgerHashes skiplist so state matches rippled
-	if err := skiplist.UpdateOnMap(stateMap, h.LedgerIndex, h.ParentHash); err != nil {
-		s.logger.Warn("failed to update skip list during re-adoption", "error", err)
-	}
-
-	txMap, err := s.genesisLedger.TxMapSnapshot()
-	if err != nil {
-		return fmt.Errorf("failed to snapshot genesis tx map: %w", err)
-	}
-
-	adopted := ledger.NewFromHeader(*h, stateMap, txMap, drops.Fees{})
-
-	// Advance closedLedger to the peer's tip but NOT validatedLedger: "closed"
-	// is not "validated"; the quorum gate in SetValidatedLedger owns that.
-	s.closedLedger = s.installAdoptedLedgerLocked(h.LedgerIndex, adopted)
-
-	openLedger, err := ledger.NewOpen(s.closedLedger, time.Now())
-	if err != nil {
-		return fmt.Errorf("failed to create open ledger: %w", err)
-	}
-	s.openLedger = openLedger
-	s.pendingTxs = nil
-
-	// Re-adopt: fresh start on the peer's tip — rebuild via New.
-	if err := s.rebuildOpenLedgerViewLocked(); err != nil {
-		return err
-	}
-
-	s.logger.Info("Re-adopted ledger from peer",
-		"seq", h.LedgerIndex,
-		"hash", fmt.Sprintf("%x", h.Hash[:8]),
-	)
-
-	return nil
-}
-
 // AdoptLedgerWithState adopts a ledger using a fully-fetched state map from a
-// peer (unlike AdoptLedgerHeader, which reuses genesis state). txMap is the
-// verified tx SHAMap on the replay-delta path; pass nil for header-only state
-// catchup (reuses genesis's empty tx map). A nil txMap on replay-delta adoption
-// would leave tx/account_tx/transaction_entry RPCs unable to answer against the
-// adopted ledger.
+// peer. txMap is the verified tx SHAMap on the replay-delta path; pass nil for
+// state-only catchup of a ledger whose transaction root is empty.
 func (s *Service) AdoptLedgerWithState(ctx context.Context, h *header.LedgerHeader, stateMap *shamap.SHAMap, txMap *shamap.SHAMap) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -973,9 +855,11 @@ func (s *Service) adoptLedgerWithStateLocked(
 	// inline below instead of stashing (see the callback block).
 	promotedByDrain := s.drainPendingLedgerValidationLocked(h.LedgerIndex, adopted)
 
-	// Persist the adopted ledger so tx/account_tx/transaction_entry RPCs can
-	// answer against it.
-	s.enqueuePersist(adopted)
+	if promotedByDrain {
+		s.enqueuePersist(adopted)
+	} else {
+		s.enqueueNodePersist(adopted)
+	}
 
 	// Populate the tx-index and capture per-tx event records (side effect +
 	// return) so hooks and stream subscribers see every adopted tx.

--- a/internal/ledger/service/online_delete_refresh_test.go
+++ b/internal/ledger/service/online_delete_refresh_test.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/LeJamon/go-xrpl/storage/kvstore/memorydb"
+	"github.com/LeJamon/go-xrpl/storage/nodestore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_RefreshValidatedStateSurvivesPruning(t *testing.T) {
+	ctx := context.Background()
+	db := nodestore.NewKVDatabase(memorydb.New(), "refresh", 10_000, time.Hour)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	family := shamap.NewNodeStoreFamily(db)
+	svc, err := New(Config{
+		Standalone:    true,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  family,
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	seq, err := svc.AcceptLedger(ctx)
+	require.NoError(t, err)
+	svc.FlushPersists()
+	latest := svc.GetValidatedLedger()
+	require.Equal(t, seq, latest.Sequence())
+	root, err := latest.StateMapHash()
+	require.NoError(t, err)
+
+	require.NoError(t, svc.RefreshValidatedState(ctx, seq))
+	_, err = db.DeleteBefore(ctx, seq, 1024)
+	require.NoError(t, err)
+	require.NoError(t, svc.verifyStoredSHAMap(ctx, root, shamap.TypeState))
+}

--- a/internal/ledger/service/persistence.go
+++ b/internal/ledger/service/persistence.go
@@ -4,73 +4,44 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"fmt"
 	"sort"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/shamap"
 	"github.com/LeJamon/go-xrpl/storage/nodestore"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
 
-// persistLedger writes the ledger state to storage backends. The
-// caller-supplied ctx is forwarded to every storage backend call so
-// shutdown / request cancellation propagates through the persistence
-// layer.
-//
-// Caller contract: chain-advance call sites must log and discard the
-// returned error, mirroring rippled's LedgerMaster::setFullLedger ->
-// pendSaveValidated which discards the bool return
-// (rippled/src/xrpld/app/ledger/detail/LedgerMaster.cpp:831,972).
-// Treating persistence failure as fatal would diverge from rippled
-// and risk forks on transient storage issues.
-//
-// Both backends are best-effort at the rippled-equivalent boundary:
-//
-//   - NodeStore failures are logged and swallowed inside
-//     persistToNodeStore, mirroring rippled's
-//     NodeStore::Database::store / ::sync void returns
-//     (rippled/src/xrpld/nodestore/detail/DatabaseNodeImp.h:109-124).
-//     A nodestore failure must NOT short-circuit the relational
-//     persist — rippled's saveValidatedLedger calls store(...) and
-//     unconditionally proceeds to the SQL writes
-//     (rippled/src/xrpld/app/rdb/backend/detail/Node.cpp:228-229).
-//   - Relational failures bubble up so the call site can log them,
-//     but the call site discards the error (chain advance continues).
-//
-// Atomicity boundaries:
-//
-//   - NodeStore is the durable ledger store; relational DB is a
-//     supplementary index. NodeStore is persisted (and synced) FIRST,
-//     so a relational failure leaves the canonical ledger durable and
-//     the index can be rebuilt.
-//   - Within NodeStore, state nodes are written before the header.
-//     A mid-write failure leaves orphaned (unreferenced) state nodes
-//     rather than a header pointing at missing state — readers see
-//     the ledger as ABSENT, not CORRUPT.
-//   - The per-tx relational writes (SaveTransaction +
-//     SaveAccountTransaction) run inside a single WithTransaction
-//     call, matching rippled's soci::transaction over the per-tx
-//     INSERT loop in
-//     rippled/src/xrpld/app/rdb/backend/detail/Node.cpp:272-349.
-//     Caveat: on SQLite, SaveValidatedLedger writes the ledger row
-//     on a separate ledger DB connection that is non-transactional
-//     (see storage/relationaldb/sqlite/transaction_context.go), so
-//     a tx-loop rollback can leave an already-written ledger row in
-//     place. This split mirrors rippled's two-DB layout
-//     (Node.cpp:264 uses ldgDB outside the txnDB transaction) and is
-//     a backend limitation, not introduced here.
+var validatedTipKey = nodestore.Hash256(sha512half.Sum([]byte("go-xrpl validated ledger tip")))
+
+// persistLedger stores SHAMap deltas and the ledger header before updating the
+// relational index. Callers log failures without stopping chain advancement.
 func (s *Service) persistLedger(ctx context.Context, l *ledger.Ledger) error {
+	return s.persistValidatedLedger(ctx, l, true)
+}
+
+func (s *Service) persistValidatedLedger(ctx context.Context, l *ledger.Ledger, updateTip bool) error {
 	seq := l.Sequence()
 
 	if s.nodeStore != nil {
-		s.persistToNodeStore(ctx, l, seq)
+		if err := s.persistToNodeStore(ctx, l, seq); err != nil {
+			return err
+		}
 	}
 
 	if s.relationalDB != nil {
 		if err := s.persistToRelationalDB(ctx, l); err != nil {
 			return err
+		}
+		if updateTip && s.nodeStore != nil {
+			if err := s.persistValidatedTip(ctx, l); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -81,119 +52,130 @@ func (s *Service) persistLedger(ctx context.Context, l *ledger.Ledger) error {
 // barrier (nil ledger + done) that flushes the FIFO queue for callers that
 // need persistence to be observable (tests, shutdown paths).
 type persistJob struct {
-	l    *ledger.Ledger
-	done chan struct{}
+	l          *ledger.Ledger
+	done       chan struct{}
+	validated  bool
+	updatesTip bool
 }
 
-// enqueuePersist hands a closed/adopted ledger to the persistence worker.
-// Persistence walks the ENTIRE state map (seconds at 15k tx/ledger); running it
-// inline under s.mu froze consensus ticks, RPC, and inbound dispatch. rippled
-// runs the equivalent pendSaveValidated on its job queue. Best-effort: a full
-// queue drops with a loud log and the chain advances (the ledger stays servable
-// from the in-memory history window).
-//
-// Callers hold s.mu, so the persistStopped read is race-free against Stop
-// (which sets it under s.mu).
 func (s *Service) enqueuePersist(l *ledger.Ledger) {
+	s.enqueueLedgerPersist(l, true, true)
+}
+
+func (s *Service) enqueueValidatedHistoryPersist(l *ledger.Ledger) {
+	s.enqueueLedgerPersist(l, true, false)
+}
+
+func (s *Service) enqueueNodePersist(l *ledger.Ledger) {
+	s.enqueueLedgerPersist(l, false, false)
+}
+
+func (s *Service) enqueueLedgerPersist(l *ledger.Ledger, validated, updatesTip bool) {
 	if l == nil {
 		return
 	}
-	if s.persistCh == nil {
-		// Not started: persist inline.
-		if err := s.persistLedger(context.Background(), l); err != nil {
+	s.persistMu.Lock()
+	if !s.persistStarted {
+		s.persistMu.Unlock()
+		if err := s.persistLedgerJob(context.Background(), l, validated, updatesTip); err != nil {
 			s.logger.Error("failed to persist ledger inline", "seq", l.Sequence(), "err", err)
 		}
 		return
 	}
-	if s.persistStopped {
-		// Shutdown in progress: the worker is draining/joined. Dropping is safe
-		// only because Stop runs after consensus quiesces, so no validated
-		// ledger closes past this point in practice.
+	if s.persistStopping {
+		s.persistMu.Unlock()
 		s.logger.Warn("persist skipped: service stopping", "seq", l.Sequence())
 		return
 	}
+	s.persistQueue = append(s.persistQueue, persistJob{l: l, validated: validated, updatesTip: updatesTip})
+	s.signalPersistLocked()
+	s.persistMu.Unlock()
+}
+
+func (s *Service) signalPersistLocked() {
 	select {
-	case s.persistCh <- persistJob{l: l}:
+	case s.persistWake <- struct{}{}:
 	default:
-		s.logger.Error("persist queue full — dropping ledger persist; chain advance continues",
-			"seq", l.Sequence(), "depth", cap(s.persistCh))
 	}
 }
 
-// FlushPersists blocks until every ledger enqueued before the call has been
-// persisted. No-op when the worker isn't running or has stopped. It gives up if
-// Stop closes persistQuit while it waits, so it never parks past shutdown.
 func (s *Service) FlushPersists() {
-	s.mu.RLock()
-	ch, quit, stopped := s.persistCh, s.persistQuit, s.persistStopped
-	s.mu.RUnlock()
-	if ch == nil || stopped {
-		return
-	}
+	_ = s.flushPersists(context.Background())
+}
+
+func (s *Service) flushPersists(ctx context.Context) error {
 	done := make(chan struct{})
-	select {
-	case ch <- persistJob{done: done}:
-	case <-quit:
-		return
+	s.persistMu.Lock()
+	if !s.persistStarted || s.persistStopping {
+		s.persistMu.Unlock()
+		return nil
 	}
+	s.persistQueue = append(s.persistQueue, persistJob{done: done})
+	s.signalPersistLocked()
+	s.persistMu.Unlock()
 	select {
 	case <-done:
-	case <-quit:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
 // Stop drains the persistence queue and joins the worker, guaranteeing every
-// validated-ledger persist enqueued before Stop is durable before the caller
+// ledger persist enqueued before Stop is durable before the caller
 // closes the underlying node/relational stores. Idempotent and safe on a
 // never-started Service. Must be called before those stores are closed.
 func (s *Service) Stop() {
-	s.mu.Lock()
-	if s.persistCh == nil || s.persistStopped {
-		s.mu.Unlock()
-		return
+	s.persistMu.Lock()
+	persistWasStarted := s.persistStarted
+	waitPersist := s.persistStarted && !s.persistStopping
+	if waitPersist {
+		s.persistStopping = true
+		s.signalPersistLocked()
 	}
-	s.persistStopped = true
-	quit := s.persistQuit
-	eventQuit := s.ledgerEventQuit
+	s.persistMu.Unlock()
+
+	s.mu.Lock()
+	var eventQuit chan struct{}
+	if !s.ledgerEventStopped {
+		s.ledgerEventStopped = true
+		eventQuit = s.ledgerEventQuit
+	}
 	s.mu.Unlock()
 
-	// Signal the workers to drain their queues and exit, then wait for them. The
-	// channels are never closed, so the drains can complete without racing a
-	// concurrent send.
-	close(quit)
 	if eventQuit != nil {
 		close(eventQuit)
 	}
-	s.persistWG.Wait()
+	if persistWasStarted {
+		s.persistWG.Wait()
+	}
 	s.ledgerEventWG.Wait()
 }
 
-// runPersistWorker drains the persist queue in FIFO order, keeping
-// nodestore/relational writes ordered by enqueue. It runs until Stop closes
-// persistQuit, at which point it drains everything already queued before
-// exiting so a shutdown doesn't drop validated-ledger persists.
 func (s *Service) runPersistWorker() {
 	defer s.persistWG.Done()
 	for {
-		select {
-		case job := <-s.persistCh:
+		s.persistMu.Lock()
+		if len(s.persistQueue) > 0 {
+			job := s.persistQueue[0]
+			s.persistQueue[0] = persistJob{}
+			s.persistQueue = s.persistQueue[1:]
+			s.persistMu.Unlock()
 			s.runPersistJob(job)
-		case <-s.persistQuit:
-			for {
-				select {
-				case job := <-s.persistCh:
-					s.runPersistJob(job)
-				default:
-					return
-				}
-			}
+			continue
 		}
+		stopping := s.persistStopping
+		s.persistMu.Unlock()
+		if stopping {
+			return
+		}
+		<-s.persistWake
 	}
 }
 
 func (s *Service) runPersistJob(job persistJob) {
 	if job.l != nil {
-		if err := s.persistLedger(context.Background(), job.l); err != nil {
+		if err := s.persistLedgerJob(context.Background(), job.l, job.validated, job.updatesTip); err != nil {
 			s.logger.Error("failed to persist ledger; chain advance continues",
 				"seq", job.l.Sequence(), "err", err)
 		}
@@ -203,39 +185,48 @@ func (s *Service) runPersistJob(job persistJob) {
 	}
 }
 
-// persistToNodeStore writes ledger state to the nodestore.
-//
-// Mirrors rippled's NodeStore::Database::store and ::sync, which
-// return void: backend errors are logged and swallowed, never
-// propagated to the chain-advance code
-// (rippled/src/xrpld/nodestore/detail/DatabaseNodeImp.h:109-124).
-// Returning errors here would diverge from rippled and risk forks if
-// any caller forgot to log-and-discard.
-func (s *Service) persistToNodeStore(ctx context.Context, l *ledger.Ledger, seq uint32) {
-	var nodes []*nodestore.Node
+func (s *Service) persistLedgerJob(ctx context.Context, l *ledger.Ledger, validated, updatesTip bool) error {
+	if validated {
+		return s.persistValidatedLedger(ctx, l, updatesTip)
+	}
+	if s.nodeStore == nil {
+		return nil
+	}
+	return s.persistToNodeStore(ctx, l, l.Sequence())
+}
 
-	iterErr := l.ForEach(func(key [32]byte, data []byte) bool {
-		node := &nodestore.Node{
-			Type:      nodestore.NodeAccount,
-			Hash:      nodestore.Hash256(key),
-			Data:      data,
-			LedgerSeq: seq,
+// persistToNodeStore writes state and transaction deltas before the header.
+func (s *Service) persistToNodeStore(ctx context.Context, l *ledger.Ledger, seq uint32) error {
+	store := func(nodeType nodestore.NodeType) func([]shamap.FlushEntry) error {
+		return func(entries []shamap.FlushEntry) error {
+			if family, ok := s.shamapFamily.(*shamap.NodeStoreFamily); ok {
+				return family.StoreBatch(ctx, entries)
+			}
+			const batchSize = 4096
+			for start := 0; start < len(entries); start += batchSize {
+				end := min(start+batchSize, len(entries))
+				nodes := make([]*nodestore.Node, end-start)
+				for i, entry := range entries[start:end] {
+					nodes[i] = &nodestore.Node{
+						Type:      nodeType,
+						Hash:      nodestore.Hash256(entry.Hash),
+						Data:      entry.Data,
+						LedgerSeq: entry.LedgerSeq,
+					}
+				}
+				if err := s.nodeStore.StoreBatch(ctx, nodes); err != nil {
+					return err
+				}
+			}
+			return nil
 		}
-		nodes = append(nodes, node)
-		return true
-	})
-	if iterErr != nil {
-		s.logger.Error("nodestore persist: state map iteration failed; ledger state not written",
-			"seq", seq, "err", iterErr)
-		return
 	}
 
-	if len(nodes) > 0 {
-		if err := s.nodeStore.StoreBatch(ctx, nodes); err != nil {
-			s.logger.Error("nodestore persist: StoreBatch failed; chain advance continues",
-				"seq", seq, "nodes", len(nodes), "err", err)
-			return
-		}
+	if err := l.StoreStateDirty(store(nodestore.NodeAccount)); err != nil {
+		return fmt.Errorf("store state delta for ledger %d: %w", seq, err)
+	}
+	if err := l.StoreTransactionDirty(store(nodestore.NodeTransaction)); err != nil {
+		return fmt.Errorf("store transaction delta for ledger %d: %w", seq, err)
 	}
 
 	headerData := l.SerializeHeader()
@@ -246,18 +237,104 @@ func (s *Service) persistToNodeStore(ctx context.Context, l *ledger.Ledger, seq 
 		LedgerSeq: seq,
 	}
 	if err := s.nodeStore.Store(ctx, headerNode); err != nil {
-		s.logger.Error("nodestore persist: header Store failed; chain advance continues",
-			"seq", seq, "err", err)
-		return
+		return fmt.Errorf("store ledger %d header: %w", seq, err)
 	}
 
 	// Single fsync once both state nodes and header are durable.
 	// Sync is uninterruptible at the backend; ctx cancellation only
 	// unblocks the caller (see KVDatabaseImpl.Sync).
 	if err := s.nodeStore.Sync(ctx); err != nil {
-		s.logger.Error("nodestore persist: Sync failed; chain advance continues",
-			"seq", seq, "err", err)
+		return fmt.Errorf("sync ledger %d: %w", seq, err)
 	}
+	return nil
+}
+
+func (s *Service) persistValidatedTip(ctx context.Context, l *ledger.Ledger) error {
+	s.validatedTipMu.Lock()
+	defer s.validatedTipMu.Unlock()
+	hash := l.Hash()
+	current, err := s.nodeStore.Fetch(ctx, validatedTipKey)
+	if err != nil {
+		return fmt.Errorf("fetch validated ledger tip: %w", err)
+	}
+	if current != nil && current.Type == nodestore.NodeLedger && len(current.Data) == 32 {
+		switch {
+		case current.LedgerSeq > l.Sequence():
+			return nil
+		case current.LedgerSeq == l.Sequence():
+			if bytes.Equal(current.Data, hash[:]) {
+				return nil
+			}
+			return fmt.Errorf("validated ledger tip %d conflicts with persisted hash", l.Sequence())
+		}
+	}
+	if err := s.nodeStore.Store(ctx, &nodestore.Node{
+		Type:      nodestore.NodeLedger,
+		Hash:      validatedTipKey,
+		Data:      append([]byte(nil), hash[:]...),
+		LedgerSeq: l.Sequence(),
+	}); err != nil {
+		return fmt.Errorf("store validated ledger tip %d: %w", l.Sequence(), err)
+	}
+	if err := s.nodeStore.Sync(ctx); err != nil {
+		return fmt.Errorf("sync validated ledger tip %d: %w", l.Sequence(), err)
+	}
+	return nil
+}
+
+// RefreshValidatedState re-stamps the complete live state tree before online
+// deletion removes older node-store records.
+func (s *Service) RefreshValidatedState(ctx context.Context, minimumSeq uint32) error {
+	if err := s.flushPersists(ctx); err != nil {
+		return err
+	}
+
+	s.mu.RLock()
+	validated := s.validatedLedger
+	s.mu.RUnlock()
+	if validated == nil || validated.Sequence() < minimumSeq {
+		return fmt.Errorf("validated ledger is behind rotation target %d", minimumSeq)
+	}
+	seq := validated.Sequence()
+	root, err := validated.StateMapHash()
+	if err != nil {
+		return err
+	}
+
+	const batchSize = 4096
+	batch := make([]*nodestore.Node, 0, batchSize)
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		if err := s.nodeStore.StoreBatch(ctx, batch); err != nil {
+			return err
+		}
+		batch = batch[:0]
+		return nil
+	}
+
+	err = s.walkStoredSHAMap(ctx, root, shamap.TypeState, func(hash [32]byte, node *nodestore.Node) error {
+		batch = append(batch, &nodestore.Node{
+			Type:      nodestore.NodeAccount,
+			Hash:      nodestore.Hash256(hash),
+			Data:      node.Data,
+			LedgerSeq: seq,
+		})
+		if len(batch) == batchSize {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if err := flush(); err != nil {
+		return err
+	}
+	return s.nodeStore.Sync(ctx)
 }
 
 // persistToRelationalDB writes ledger metadata and transactions to the

--- a/internal/ledger/service/persistence_shutdown_test.go
+++ b/internal/ledger/service/persistence_shutdown_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"sync"
 	"testing"
@@ -75,7 +76,7 @@ func TestService_Stop_DrainsQueuedPersists(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 
-	const n = 10
+	const n = 100
 	ledgers := make([]*ledger.Ledger, n)
 	for i := range ledgers {
 		seq := uint32(100 + i)
@@ -90,10 +91,23 @@ func TestService_Stop_DrainsQueuedPersists(t *testing.T) {
 	}
 	svc.mu.Unlock()
 
-	// Release the gate and stop concurrently: Stop must not return until the
-	// worker has drained and written every queued ledger.
+	stopDone := make(chan struct{})
+	go func() {
+		svc.Stop()
+		close(stopDone)
+	}()
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned while a persist was blocked")
+	case <-time.After(50 * time.Millisecond):
+	}
+
 	store.open()
-	svc.Stop()
+	select {
+	case <-stopDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop did not drain the persistence queue")
+	}
 
 	ctx := context.Background()
 	for _, l := range ledgers {
@@ -104,6 +118,48 @@ func TestService_Stop_DrainsQueuedPersists(t *testing.T) {
 		if node == nil {
 			t.Errorf("ledger seq=%d was not persisted before Stop returned — a queued persist was dropped", l.Sequence())
 		}
+	}
+}
+
+func TestService_PersistLedgerWritesHeader(t *testing.T) {
+	store := newGatedStore()
+	store.open()
+	svc, err := New(Config{Standalone: false, NodeStore: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+	l := buildLedgerWithState(t, 99)
+	if err := svc.persistLedger(context.Background(), l); err != nil {
+		t.Fatal(err)
+	}
+	node, err := store.Fetch(context.Background(), nodestore.Hash256(l.Hash()))
+	if err != nil || node == nil {
+		t.Fatalf("header fetch = %v, %v", node, err)
+	}
+}
+
+func TestService_ValidatedTipDoesNotRegress(t *testing.T) {
+	store := newGatedStore()
+	store.open()
+	svc, err := New(Config{Standalone: false, NodeStore: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newer := buildLedgerWithState(t, 101)
+	older := buildLedgerWithState(t, 100)
+	if err := svc.persistValidatedTip(context.Background(), newer); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.persistValidatedTip(context.Background(), older); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := store.Fetch(context.Background(), validatedTipKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newerHash := newer.Hash()
+	if stored == nil || stored.LedgerSeq != newer.Sequence() || !bytes.Equal(stored.Data, newerHash[:]) {
+		t.Fatalf("validated tip regressed: %+v", stored)
 	}
 }
 

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/LeJamon/go-xrpl/shamap"
 	"github.com/LeJamon/go-xrpl/storage/nodestore"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
@@ -58,6 +59,10 @@ type Config struct {
 	// NodeStore is the persistent storage for ledger nodes (optional, nil for in-memory only)
 	NodeStore nodestore.Database
 
+	// SHAMapFamily loads and stores state and transaction tree nodes.
+	SHAMapFamily shamap.Family
+	// FastLoad restores the newest complete persisted ledger at startup.
+	FastLoad bool
 	// RelationalDB is the repository manager for transaction indexing (optional)
 	RelationalDB relationaldb.RepositoryManager
 
@@ -99,7 +104,8 @@ type Service struct {
 	logger xrpllog.Logger
 
 	// NodeStore for persistent storage (nil if in-memory only)
-	nodeStore nodestore.Database
+	nodeStore    nodestore.Database
+	shamapFamily shamap.Family
 
 	// RelationalDB for transaction indexing (nil if not configured)
 	relationalDB relationaldb.RepositoryManager
@@ -224,20 +230,13 @@ type Service struct {
 	// the TxQ's timeLeap flag by processClosedLedgerLocked. Zero in standalone.
 	lastConsensusRoundTime time.Duration
 
-	// persistCh feeds the single persistence worker (see enqueuePersist);
-	// nil until Start. It is never closed — the worker exits on persistQuit
-	// after draining the queue, so a concurrent enqueuePersist can never send
-	// on a closed channel.
-	persistCh chan persistJob
-
-	// persistQuit signals the persistence worker to drain the queue and exit.
-	// Closed by Stop. persistStopped (guarded by mu, like enqueuePersist's
-	// callers) short-circuits new enqueues once Stop has begun. persistWG joins
-	// the worker so Stop can guarantee every queued validated-ledger persist is
-	// durable before the caller closes the underlying stores.
-	persistQuit    chan struct{}
-	persistStopped bool
-	persistWG      sync.WaitGroup
+	persistMu       sync.Mutex
+	persistQueue    []persistJob
+	persistWake     chan struct{}
+	persistStarted  bool
+	persistStopping bool
+	persistWG       sync.WaitGroup
+	validatedTipMu  sync.Mutex
 
 	// ledgerEventCh feeds the single accepted-ledger event dispatcher (see
 	// dispatchLedgerEvent). A single consumer preserves FIFO delivery and runs
@@ -246,6 +245,7 @@ type Service struct {
 	// and reordering ledgerClosed stream events. Started by Start, joined by Stop.
 	ledgerEventCh       chan *LedgerAcceptedEvent
 	ledgerEventQuit     chan struct{}
+	ledgerEventStopped  bool
 	ledgerEventWG       sync.WaitGroup
 	droppedLedgerEvents atomic.Uint64
 
@@ -280,6 +280,7 @@ func New(cfg Config) (*Service, error) {
 		config:                   cfg,
 		logger:                   logger.Named(xrpllog.PartitionLedger),
 		nodeStore:                cfg.NodeStore,
+		shamapFamily:             cfg.SHAMapFamily,
 		relationalDB:             cfg.RelationalDB,
 		amendmentTable:           cfg.Table,
 		ledgerHistory:            make(map[uint32]*ledger.Ledger),
@@ -292,8 +293,8 @@ func New(cfg Config) (*Service, error) {
 		txQueue:                  txq.New(txqCfg),
 		localTxs:                 localtxs.New(),
 		feeTrack:                 feetrack.New(),
+		persistWake:              make(chan struct{}, 1),
 	}
-
 	return s, nil
 }
 
@@ -392,10 +393,14 @@ func (s *Service) Start() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.persistCh == nil {
-		s.persistCh = make(chan persistJob, 32)
-		s.persistQuit = make(chan struct{})
+	s.persistMu.Lock()
+	startWorkers := !s.persistStarted
+	if startWorkers {
+		s.persistStarted = true
 		s.persistWG.Add(1)
+	}
+	s.persistMu.Unlock()
+	if startWorkers {
 		go s.runPersistWorker()
 
 		s.ledgerEventCh = make(chan *LedgerAcceptedEvent, ledgerEventBufferDepth)
@@ -416,6 +421,9 @@ func (s *Service) Start() error {
 		genesisResult.TxMap,
 		drops.Fees{},
 	)
+	if s.shamapFamily != nil {
+		genesisLedger.SetSHAMapFamily(s.shamapFamily)
+	}
 
 	s.genesisLedger = genesisLedger
 	s.putHistoryLocked(genesisLedger)
@@ -448,13 +456,30 @@ func (s *Service) Start() error {
 		}
 		s.openLedger = openLedger
 	} else {
-		// Consensus mode: stay at genesis (seq 1) and wait to adopt a peer's ledger.
-		s.closedLedger = genesisLedger
-		s.validatedLedger = genesisLedger
-		s.needsInitialSync = true
+		var latest *ledger.Ledger
+		if s.config.FastLoad {
+			latest, err = s.loadLatestLedger(context.Background())
+			if err != nil {
+				s.logger.Warn("fast load failed; starting from genesis", "err", err)
+			}
+		}
+		if latest == nil {
+			s.closedLedger = genesisLedger
+			s.validatedLedger = genesisLedger
+			s.needsInitialSync = true
+		} else {
+			s.closedLedger = latest
+			s.validatedLedger = latest
+			if latest.Sequence() != genesisLedger.Sequence() {
+				s.deleteHistoryLocked(genesisLedger.Sequence())
+			}
+			s.putHistoryLocked(latest)
+			s.collectTransactionResults(latest, latest.Sequence(), latest.Hash())
+			s.needsInitialSync = false
+			s.logger.Info("Loaded persisted validated ledger", "sequence", latest.Sequence())
+		}
 
-		// Create open ledger (seq 2) on top of genesis — will be replaced on adoption
-		openLedger, err := ledger.NewOpen(genesisLedger, time.Now())
+		openLedger, err := ledger.NewOpen(s.closedLedger, time.Now())
 		if err != nil {
 			return fmt.Errorf("failed to create open ledger: %w", err)
 		}

--- a/internal/ledger/shamapstore/rotation.go
+++ b/internal/ledger/shamapstore/rotation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 )
@@ -54,11 +55,17 @@ type RotationConfig struct {
 // blocks the consensus / ledger-accept path; an in-flight rotation coalesces
 // further notifications to the newest validated sequence.
 type Rotator struct {
-	store  *Store
-	nodes  NodePruner
-	rel    RelationalPruner
-	cfg    RotationConfig
-	logger xrpllog.Logger
+	store      *Store
+	nodes      NodePruner
+	rel        RelationalPruner
+	cfg        RotationConfig
+	logger     xrpllog.Logger
+	refresh    func(context.Context, uint32) error
+	advance    func(uint32)
+	beginPrune func() func()
+	healthMu   sync.RWMutex
+	healthy    func() bool
+	recovery   time.Duration
 
 	notifyCh chan uint32
 	stopCh   chan struct{}
@@ -69,6 +76,31 @@ type Rotator struct {
 	// full. Acquisition / fetch-pack serving must not reach below it. Zero
 	// until the first rotation.
 	minimumOnline atomic.Uint32
+}
+
+// SetHealthCheck gates rotation on the node being fully synchronized.
+func (r *Rotator) SetHealthCheck(healthy func() bool, recoveryWait time.Duration) {
+	if r == nil {
+		return
+	}
+	if recoveryWait <= 0 {
+		recoveryWait = 5 * time.Second
+	}
+	r.healthMu.Lock()
+	r.healthy = healthy
+	r.recovery = recoveryWait
+	r.healthMu.Unlock()
+}
+
+// SetStateRefresh installs the live-state refresh, acquisition-floor advance,
+// and exclusive cache guard required around node-store pruning.
+func (r *Rotator) SetStateRefresh(refresh func(context.Context, uint32) error, advance func(uint32), beginPrune func() func()) {
+	if r == nil {
+		return
+	}
+	r.refresh = refresh
+	r.advance = advance
+	r.beginPrune = beginPrune
 }
 
 // NewRotator constructs a Rotator. store and nodes are required; rel may be nil
@@ -96,7 +128,7 @@ func NewRotator(store *Store, nodes NodePruner, rel RelationalPruner, cfg Rotati
 		stopCh:   make(chan struct{}),
 		doneCh:   make(chan struct{}),
 	}
-	r.minimumOnline.Store(store.GetLastRotated())
+	r.minimumOnline.Store(store.GetMinimumOnline())
 	return r
 }
 
@@ -148,6 +180,24 @@ func (r *Rotator) MinimumOnline() uint32 {
 	return r.minimumOnline.Load()
 }
 
+// SetMinimumOnlineFloor durably advances the retained-ledger floor. It is used
+// at startup to migrate older state from the relational ledger range and before
+// each destructive rotation so a crash cannot reopen below deleted data.
+func (r *Rotator) SetMinimumOnlineFloor(seq uint32) error {
+	if r == nil || seq == 0 {
+		return nil
+	}
+	if err := r.store.SetMinimumOnline(seq); err != nil {
+		return err
+	}
+	for {
+		current := r.minimumOnline.Load()
+		if seq <= current || r.minimumOnline.CompareAndSwap(current, seq) {
+			return nil
+		}
+	}
+}
+
 func (r *Rotator) run() {
 	defer close(r.doneCh)
 
@@ -180,7 +230,6 @@ func (r *Rotator) maybeRotate(ctx context.Context, validatedSeq uint32) {
 			r.logger.Warn("online delete: failed to persist initial lastRotated", "seq", validatedSeq, "err", err)
 			return
 		}
-		r.minimumOnline.Store(validatedSeq)
 		return
 	}
 
@@ -196,8 +245,33 @@ func (r *Rotator) maybeRotate(ctx context.Context, validatedSeq uint32) {
 	if r.store.AdvisoryDelete() && r.store.GetCanDelete() < lastRotated-1 {
 		return
 	}
+	if !r.waitHealthy(ctx) {
+		return
+	}
 
 	r.rotate(ctx, validatedSeq, lastRotated)
+}
+
+func (r *Rotator) waitHealthy(ctx context.Context) bool {
+	for {
+		r.healthMu.RLock()
+		healthy := r.healthy
+		wait := r.recovery
+		r.healthMu.RUnlock()
+		if healthy == nil || healthy() {
+			return true
+		}
+		if wait <= 0 {
+			wait = 5 * time.Second
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return false
+		case <-timer.C:
+		}
+	}
 }
 
 // rotate deletes everything below lastRotated, then advances the boundary to
@@ -210,9 +284,27 @@ func (r *Rotator) rotate(ctx context.Context, validatedSeq, lastRotated uint32) 
 		"validatedSeq", validatedSeq, "lastRotated", lastRotated,
 		"deleteInterval", r.cfg.DeleteInterval)
 
-	// Refuse to re-acquire or serve ledgers about to be deleted before any
-	// deletion begins (rippled clearPrior: minimumOnline_ = lastRotated + 1).
-	r.minimumOnline.Store(lastRotated + 1)
+	if r.refresh == nil {
+		r.logger.Warn("online delete: live-state refresh is not configured")
+		return
+	}
+	if err := r.refresh(ctx, validatedSeq); err != nil {
+		if ctx.Err() == nil {
+			r.logger.Warn("online delete: live-state refresh failed", "seq", validatedSeq, "err", err)
+		}
+		return
+	}
+	if !r.waitHealthy(ctx) {
+		return
+	}
+	minimumOnline := lastRotated + 1
+	if err := r.SetMinimumOnlineFloor(minimumOnline); err != nil {
+		r.logger.Warn("online delete: failed to persist minimum online ledger", "seq", minimumOnline, "err", err)
+		return
+	}
+	if r.advance != nil {
+		r.advance(minimumOnline)
+	}
 
 	if r.rel != nil {
 		if err := r.rel.DeleteLedgersBefore(ctx, lastRotated); err != nil {
@@ -222,8 +314,17 @@ func (r *Rotator) rotate(ctx context.Context, validatedSeq, lastRotated uint32) 
 			r.logger.Warn("online delete: relational prune failed", "boundary", lastRotated, "err", err)
 		}
 	}
+	if !r.waitHealthy(ctx) {
+		return
+	}
 
-	deleted, err := r.nodes.DeleteBefore(ctx, lastRotated, r.cfg.DeleteBatch)
+	deleted, err := func() (uint64, error) {
+		if r.beginPrune != nil {
+			unlock := r.beginPrune()
+			defer unlock()
+		}
+		return r.nodes.DeleteBefore(ctx, lastRotated, r.cfg.DeleteBatch)
+	}()
 	if err != nil {
 		if ctx.Err() != nil {
 			return
@@ -231,12 +332,11 @@ func (r *Rotator) rotate(ctx context.Context, validatedSeq, lastRotated uint32) 
 		r.logger.Warn("online delete: nodestore prune failed", "boundary", lastRotated, "deleted", deleted, "err", err)
 		return
 	}
-
-	if err := r.store.SetLastRotated(validatedSeq); err != nil {
+	if err := r.store.SetRotation(validatedSeq, minimumOnline); err != nil {
 		r.logger.Warn("online delete: failed to persist lastRotated", "seq", validatedSeq, "err", err)
 		return
 	}
 
 	r.logger.Info("online delete: rotation finished",
-		"validatedSeq", validatedSeq, "nodesDeleted", deleted, "minimumOnline", lastRotated+1)
+		"validatedSeq", validatedSeq, "nodesDeleted", deleted, "minimumOnline", minimumOnline)
 }

--- a/internal/ledger/shamapstore/rotation_integration_test.go
+++ b/internal/ledger/shamapstore/rotation_integration_test.go
@@ -12,15 +12,9 @@ import (
 )
 
 // TestRotation_ReclaimsNodeStoreSpace drives a Rotator against a real
-// nodestore and models the production persistence contract: each ledger writes
-// a unique header and re-writes the live account-state leaves at the current
-// sequence, while a churned leaf (state that existed only at that ledger) is
-// left behind at its original sequence. The production node store holds exactly
-// these seq-stamped records — state leaves and ledger headers; tx trees live in
-// the relational index, and the live state map is not NodeStoreFamily-backed in
-// production, so no LedgerSeq=0 inner nodes are written. After a rotation, the
-// headers and churned leaves below the boundary are reclaimed while the live
-// state — re-written at the latest sequence — survives.
+// nodestore. Each synthetic ledger re-stamps live state at its current sequence
+// while leaving churned state at its original sequence, allowing rotation to
+// reclaim old records without removing the live state.
 func TestRotation_ReclaimsNodeStoreSpace(t *testing.T) {
 	ctx := context.Background()
 	db := nodestore.NewKVDatabase(memorydb.New(), "mem", 10000, time.Hour)
@@ -71,6 +65,7 @@ func TestRotation_ReclaimsNodeStoreSpace(t *testing.T) {
 	if rot == nil {
 		t.Fatal("NewRotator returned nil")
 	}
+	rot.SetStateRefresh(func(context.Context, uint32) error { return nil }, nil, nil)
 
 	// Build 25 ledgers, notifying the rotator synchronously per ledger via the
 	// internal predicate path so the assertions are deterministic.

--- a/internal/ledger/shamapstore/rotation_test.go
+++ b/internal/ledger/shamapstore/rotation_test.go
@@ -2,7 +2,9 @@ package shamapstore
 
 import (
 	"context"
+	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -13,13 +15,80 @@ type fakeNodePruner struct {
 	mu         sync.Mutex
 	boundaries []uint32
 	deleted    uint64
+	err        error
+	before     func()
+}
+
+func TestRotate_RefreshFailureAbortsDeletion(t *testing.T) {
+	r, nodes, rel := newTestRotator(t, false, 256)
+	r.SetStateRefresh(func(context.Context, uint32) error {
+		return errors.New("missing live node")
+	}, nil, nil)
+	r.maybeRotate(context.Background(), 500)
+	r.maybeRotate(context.Background(), 800)
+
+	if len(nodes.calls()) != 0 || len(rel.calls()) != 0 {
+		t.Fatal("refresh failure must abort all deletion")
+	}
+	if got := r.store.GetLastRotated(); got != 500 {
+		t.Fatalf("lastRotated = %d, want 500", got)
+	}
+}
+
+func TestRotate_WaitsForHealthyNode(t *testing.T) {
+	r, nodes, _ := newTestRotator(t, false, 256)
+	r.maybeRotate(context.Background(), 500)
+	var healthy atomic.Bool
+	r.SetHealthCheck(healthy.Load, time.Millisecond)
+	done := make(chan struct{})
+	go func() {
+		r.maybeRotate(context.Background(), 800)
+		close(done)
+	}()
+	time.Sleep(10 * time.Millisecond)
+	if len(nodes.calls()) != 0 {
+		t.Fatal("unhealthy node started pruning")
+	}
+	healthy.Store(true)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("rotation did not resume after health recovered")
+	}
+	if len(nodes.calls()) != 1 {
+		t.Fatalf("prune calls = %v, want one", nodes.calls())
+	}
 }
 
 func (f *fakeNodePruner) DeleteBefore(_ context.Context, boundary uint32, _ int) (uint64, error) {
+	if f.before != nil {
+		f.before()
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.boundaries = append(f.boundaries, boundary)
-	return f.deleted, nil
+	return f.deleted, f.err
+}
+
+func TestRotate_PartialPruneResetsCacheWithoutAdvancing(t *testing.T) {
+	r, nodes, _ := newTestRotator(t, false, 256)
+	r.maybeRotate(context.Background(), 500)
+	nodes.deleted = 3
+	nodes.err = errors.New("partial prune")
+	locked, unlocked := 0, 0
+	r.SetStateRefresh(func(context.Context, uint32) error { return nil }, nil, func() func() {
+		locked++
+		return func() { unlocked++ }
+	})
+
+	r.maybeRotate(context.Background(), 800)
+
+	if locked != 1 || unlocked != 1 {
+		t.Fatalf("prune guard = (%d, %d), want (1, 1)", locked, unlocked)
+	}
+	if got := r.store.GetLastRotated(); got != 500 {
+		t.Fatalf("lastRotated = %d, want 500", got)
+	}
 }
 
 func (f *fakeNodePruner) calls() []uint32 {
@@ -58,6 +127,7 @@ func newTestRotator(t *testing.T, advisory bool, interval uint32) (*Rotator, *fa
 	if r == nil {
 		t.Fatal("NewRotator returned nil")
 	}
+	r.SetStateRefresh(func(context.Context, uint32) error { return nil }, nil, nil)
 	return r, nodes, rel
 }
 
@@ -83,8 +153,8 @@ func TestRotate_FirstNotificationSeedsBoundaryNoDelete(t *testing.T) {
 	if got := r.store.GetLastRotated(); got != 1000 {
 		t.Fatalf("lastRotated = %d, want 1000 (seeded)", got)
 	}
-	if got := r.MinimumOnline(); got != 1000 {
-		t.Fatalf("minimumOnline = %d, want 1000", got)
+	if got := r.MinimumOnline(); got != 0 {
+		t.Fatalf("minimumOnline = %d, want 0", got)
 	}
 	if len(nodes.calls()) != 0 || len(rel.calls()) != 0 {
 		t.Fatal("first notification must not delete anything")
@@ -120,6 +190,11 @@ func TestRotate_WaitsForFullInterval(t *testing.T) {
 
 func TestRotate_DeletesBelowOldBoundaryInBothStores(t *testing.T) {
 	r, nodes, rel := newTestRotator(t, false, 256)
+	nodes.before = func() {
+		if got := r.store.GetMinimumOnline(); got != 501 {
+			t.Fatalf("minimumOnline at destructive prune = %d, want durable floor 501", got)
+		}
+	}
 	r.maybeRotate(context.Background(), 500) // seed lastRotated=500
 	r.maybeRotate(context.Background(), 800) // 800 >= 500+256 → rotate
 
@@ -131,6 +206,30 @@ func TestRotate_DeletesBelowOldBoundaryInBothStores(t *testing.T) {
 	}
 	if got := r.store.GetLastRotated(); got != 800 {
 		t.Fatalf("lastRotated = %d, want 800", got)
+	}
+}
+
+func TestRotator_MinimumOnlineFloorPersistsAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	store, err := New(false, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := NewRotator(store, &fakeNodePruner{}, nil, RotationConfig{DeleteInterval: 256}, nil)
+	if err := r.SetMinimumOnlineFloor(700); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.SetMinimumOnlineFloor(650); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded, err := New(false, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restarted := NewRotator(reloaded, &fakeNodePruner{}, nil, RotationConfig{DeleteInterval: 256}, nil)
+	if got := restarted.MinimumOnline(); got != 700 {
+		t.Fatalf("minimumOnline after restart = %d, want 700", got)
 	}
 }
 
@@ -183,6 +282,7 @@ func TestRotate_TolerantOfNilRelationalPruner(t *testing.T) {
 	if r == nil {
 		t.Fatal("rotator nil with valid node pruner")
 	}
+	r.SetStateRefresh(func(context.Context, uint32) error { return nil }, nil, nil)
 	r.maybeRotate(context.Background(), 500)
 	r.maybeRotate(context.Background(), 800)
 	if nc := nodes.calls(); len(nc) != 1 || nc[0] != 500 {

--- a/internal/ledger/shamapstore/store.go
+++ b/internal/ledger/shamapstore/store.go
@@ -4,11 +4,12 @@
 // Two pieces live here:
 //
 //   - Store, the advisory-delete state the can_delete RPC reads and writes. It
-//     tracks two ledger sequences, gated by the node_db advisory_delete config
+//     tracks retention state, gated by the node_db advisory_delete config
 //     flag and persisted across restarts (mirroring rippled's SavedStateDB):
 //     canDelete (the advisory boundary: ledgers at or below it are unprotected
 //     and online delete may remove them) and lastRotated (the most recent
-//     ledger online delete has rotated; 0 until the first rotation).
+//     ledger online delete has rotated; 0 until the first rotation), and the
+//     minimum online ledger retained after the most recent deletion.
 //   - Rotator, the background job that consumes those boundaries to actually
 //     reclaim disk: every node_db online_delete validated ledgers it deletes
 //     complete ledgers below the rotation boundary from the node store and the
@@ -31,15 +32,18 @@ const stateFile = "advisory_delete_state.json"
 // Store holds the advisory-delete state. It is safe for concurrent use.
 type Store struct {
 	mu             sync.RWMutex
+	saveMu         sync.Mutex
 	advisoryDelete bool
 	canDelete      uint32
 	lastRotated    uint32
+	minimumOnline  uint32
 	filePath       string
 }
 
 type persistedState struct {
-	CanDelete   uint32 `json:"can_delete"`
-	LastRotated uint32 `json:"last_rotated"`
+	CanDelete     uint32 `json:"can_delete"`
+	LastRotated   uint32 `json:"last_rotated"`
+	MinimumOnline uint32 `json:"minimum_online,omitempty"`
 }
 
 // New constructs the advisory-delete state store. advisoryDelete reflects the
@@ -103,6 +107,31 @@ func (s *Store) SetLastRotated(seq uint32) error {
 	return s.save()
 }
 
+func (s *Store) GetMinimumOnline() uint32 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.minimumOnline
+}
+
+// SetMinimumOnline durably advances the lowest retained ledger before online
+// deletion starts removing records below it.
+func (s *Store) SetMinimumOnline(seq uint32) error {
+	s.mu.Lock()
+	if seq > s.minimumOnline {
+		s.minimumOnline = seq
+	}
+	s.mu.Unlock()
+	return s.save()
+}
+
+func (s *Store) SetRotation(lastRotated, minimumOnline uint32) error {
+	s.mu.Lock()
+	s.lastRotated = lastRotated
+	s.minimumOnline = minimumOnline
+	s.mu.Unlock()
+	return s.save()
+}
+
 func (s *Store) load() error {
 	if s.filePath == "" {
 		return nil
@@ -127,15 +156,22 @@ func (s *Store) load() error {
 		s.canDelete = ps.CanDelete
 	}
 	s.lastRotated = ps.LastRotated
+	s.minimumOnline = ps.MinimumOnline
 	return nil
 }
 
 func (s *Store) save() error {
+	s.saveMu.Lock()
+	defer s.saveMu.Unlock()
 	if s.filePath == "" {
 		return nil
 	}
 	s.mu.RLock()
-	ps := persistedState{CanDelete: s.canDelete, LastRotated: s.lastRotated}
+	ps := persistedState{
+		CanDelete:     s.canDelete,
+		LastRotated:   s.lastRotated,
+		MinimumOnline: s.minimumOnline,
+	}
 	s.mu.RUnlock()
 
 	data, err := json.MarshalIndent(ps, "", "  ")
@@ -145,5 +181,31 @@ func (s *Store) save() error {
 	if err := os.MkdirAll(filepath.Dir(s.filePath), 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(s.filePath, data, 0o600)
+	dir := filepath.Dir(s.filePath)
+	tmp, err := os.CreateTemp(dir, ".advisory-delete-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, s.filePath); err != nil {
+		return err
+	}
+	dirFile, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer dirFile.Close()
+	return dirFile.Sync()
 }

--- a/internal/ledger/shamapstore/store_test.go
+++ b/internal/ledger/shamapstore/store_test.go
@@ -67,8 +67,8 @@ func TestStore_PersistenceRoundTrip(t *testing.T) {
 	if _, err := s.SetCanDelete(900); err != nil {
 		t.Fatalf("SetCanDelete: %v", err)
 	}
-	if err := s.SetLastRotated(800); err != nil {
-		t.Fatalf("SetLastRotated: %v", err)
+	if err := s.SetRotation(800, 501); err != nil {
+		t.Fatalf("SetRotation: %v", err)
 	}
 
 	// Reopen from the same dir; state must survive.
@@ -81,6 +81,9 @@ func TestStore_PersistenceRoundTrip(t *testing.T) {
 	}
 	if got := reopened.GetLastRotated(); got != 800 {
 		t.Fatalf("reloaded lastRotated = %d, want 800", got)
+	}
+	if got := reopened.GetMinimumOnline(); got != 501 {
+		t.Fatalf("reloaded minimumOnline = %d, want 501", got)
 	}
 
 	// The state file lives under database_path.

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -42,6 +42,10 @@ import (
 	googlegrpc "google.golang.org/grpc"
 )
 
+type minimumOnlineFloorFunc func() uint32
+
+func (f minimumOnlineFloorFunc) MinimumOnline() uint32 { return f() }
+
 // Run assembles and starts every node subsystem from the parsed config, then
 // blocks until a terminating signal or fatal error. It is the composition root
 // extracted from the CLI so flag parsing and node wiring stay separable.
@@ -69,6 +73,10 @@ func Run(appConfig *config.Config, configPath string, standalone bool, rootLogge
 	db, repoManager, err = setupStorage(appConfig, serverLog)
 	if err != nil {
 		return err
+	}
+	var nodeFamily *shamap.NodeStoreFamily
+	if db != nil {
+		nodeFamily = shamap.NewNodeStoreFamily(db)
 	}
 
 	// Load genesis configuration from config file path (if set)
@@ -137,6 +145,8 @@ func Run(appConfig *config.Config, configPath string, standalone bool, rootLogge
 		Standalone:   standalone,
 		NetworkID:    uint32(networkID),
 		NodeStore:    db,
+		SHAMapFamily: nodeFamily,
+		FastLoad:     appConfig.NodeDB.FastLoad,
 		RelationalDB: repoManager,
 		Logger:       rootLogger,
 		Table:        amendmentTable,
@@ -176,6 +186,9 @@ func Run(appConfig *config.Config, configPath string, standalone bool, rootLogge
 		appConfig.NodeDB.IsAdvisoryDeleteEnabled(),
 		appConfig.DatabasePath,
 	); asErr != nil {
+		if appConfig.NodeDB.IsOnlineDeleteEnabled() {
+			return fmt.Errorf("load online-delete state: %w", asErr)
+		}
 		serverLog.Warn("Failed to load advisory-delete state", "err", asErr)
 	} else {
 		services.AdvisoryDeleteState = advisoryStore
@@ -200,16 +213,47 @@ func Run(appConfig *config.Config, configPath string, standalone bool, rootLogge
 					},
 					serverLog,
 				)
+				minimumOnline := rotator.MinimumOnline()
+				if minimumOnline == 0 && repoManager != nil {
+					minSeq, minErr := repoManager.Ledger().GetMinLedgerSeq(context.Background())
+					if minErr != nil {
+						return fmt.Errorf("load online-delete minimum ledger: %w", minErr)
+					}
+					if minSeq != nil {
+						minimumOnline = uint32(*minSeq)
+						if err := rotator.SetMinimumOnlineFloor(minimumOnline); err != nil {
+							return fmt.Errorf("persist online-delete minimum ledger: %w", err)
+						}
+					}
+				}
+				if minimumOnline > 0 {
+					nodeFamily.SetMinimumLedgerSeq(minimumOnline)
+				}
+				rotator.SetStateRefresh(
+					ledgerService.RefreshValidatedState,
+					nodeFamily.SetMinimumLedgerSeq,
+					nodeFamily.BeginPrune,
+				)
 				rotator.Start()
-				// Clamp complete_ledgers to the deletion boundary so
-				// server_info never advertises ledgers rotation reclaimed.
-				ledgerService.SetMinimumOnlineFunc(rotator.MinimumOnline)
 				serverLog.Info("Online delete enabled",
 					"online_delete", appConfig.NodeDB.OnlineDelete,
 					"advisory_delete", appConfig.NodeDB.IsAdvisoryDeleteEnabled())
 			} else {
 				serverLog.Warn("online_delete configured but node store backend does not support pruning")
 			}
+		}
+	}
+	retentionFloor := func() uint32 {
+		floor := uint32(appConfig.NodeDB.EarliestSeq)
+		if rotator != nil && rotator.MinimumOnline() > floor {
+			floor = rotator.MinimumOnline()
+		}
+		return floor
+	}
+	if appConfig.NodeDB.EarliestSeq > 0 || rotator != nil {
+		ledgerService.SetMinimumOnlineFunc(retentionFloor)
+		if nodeFamily != nil {
+			nodeFamily.SetMinimumLedgerSeq(retentionFloor())
 		}
 	}
 
@@ -291,8 +335,8 @@ func Run(appConfig *config.Config, configPath string, standalone bool, rootLogge
 	// store is configured (standalone / RPC-only). The RPC's own availability
 	// is then gated on network/sync state, as in rippled, not on storage.
 	var cleanerFamily shamap.Family
-	if db != nil {
-		cleanerFamily = shamap.NewNodeStoreFamily(db)
+	if nodeFamily != nil {
+		cleanerFamily = nodeFamily
 	} else {
 		memFamily := shamap.NewMemoryNodeStoreFamily()
 		cleanerFamily = memFamily
@@ -327,20 +371,37 @@ func Run(appConfig *config.Config, configPath string, standalone bool, rootLogge
 		// interface nil when rotation is off so the disabled path is unchanged
 		// (a typed-nil *Rotator would be a non-nil interface).
 		var floor adaptor.MinimumOnlineFloor
-		if rotator != nil {
-			floor = rotator
+		if appConfig.NodeDB.EarliestSeq > 0 || rotator != nil {
+			floor = minimumOnlineFloorFunc(retentionFloor)
 		}
 		consensusComponents, compErr = adaptor.NewFromConfig(appConfig, ledgerService, validationRepo, floor)
 		if compErr != nil {
 			return fmt.Errorf("create consensus components: %w", compErr)
 		}
+		if rotator != nil {
+			ageThreshold := 60 * time.Second
+			if appConfig.NodeDB.AgeThresholdSeconds > 0 {
+				ageThreshold = time.Duration(appConfig.NodeDB.AgeThresholdSeconds) * time.Second
+			}
+			recoveryWait := 5 * time.Second
+			if appConfig.NodeDB.RecoveryWaitSeconds > 0 {
+				recoveryWait = time.Duration(appConfig.NodeDB.RecoveryWaitSeconds) * time.Second
+			}
+			rotator.SetHealthCheck(func() bool {
+				if consensusComponents.Adaptor.GetOperatingMode() != consensus.OpModeFull {
+					return false
+				}
+				validated := ledgerService.GetValidatedLedger()
+				return validated != nil && time.Since(validated.CloseTime()) <= ageThreshold
+			}, recoveryWait)
+		}
 
 		// Back inbound acquisitions with the node store before Start launches the
 		// router loop, so the family is published before any acquisition reads it
 		// (issue #1158).
-		if db != nil {
+		if nodeFamily != nil {
 			if router := consensusComponents.Router; router != nil {
-				router.SetAcquisitionFamily(shamap.NewNodeStoreFamily(db))
+				router.SetAcquisitionFamily(nodeFamily)
 			}
 		}
 
@@ -1002,7 +1063,7 @@ func setupStorage(cfg *config.Config, log xrpllog.Logger) (nodestore.Database, r
 		if err != nil {
 			return nil, nil, fmt.Errorf("storage backend: %w", err)
 		}
-		cacheSize, cacheTTL := nodeStoreCacheParams(cfg.NodeDB)
+		cacheSize, cacheTTL := nodeStoreCacheParams(cfg.NodeDB, cfg.NodeSize)
 		db = nodestore.NewKVDatabase(store, "pebble("+nodestorePath+")", cacheSize, cacheTTL)
 		log.Info("Storage initialized", "backend", "pebble", "path", nodestorePath,
 			"cache_size", cacheSize, "cache_age", cacheTTL)
@@ -1228,19 +1289,36 @@ const (
 // Node-object cache defaults applied when the operator leaves node_db
 // cache_size / cache_age unset.
 const (
-	defaultNodeCacheSize = 10000
-	defaultNodeCacheAge  = 10 * time.Minute
+	defaultNodeCacheSize = 2_097_152
+	defaultNodeCacheAge  = 90 * time.Minute
 )
 
 // nodeStoreCacheParams maps node_db cache_size (entries) and cache_age
 // (minutes) onto the node-object cache parameters, substituting the
 // built-in defaults for unset (zero) values.
-func nodeStoreCacheParams(n config.NodeDBConfig) (int, time.Duration) {
-	size := defaultNodeCacheSize
+func nodeStoreCacheParams(n config.NodeDBConfig, nodeSize string) (int, time.Duration) {
+	profiles := map[string]struct {
+		size int
+		age  time.Duration
+	}{
+		"tiny":   {262_144, 30 * time.Minute},
+		"small":  {524_288, 60 * time.Minute},
+		"medium": {2_097_152, 90 * time.Minute},
+		"large":  {4_194_304, 120 * time.Minute},
+		"huge":   {8_388_608, 900 * time.Minute},
+	}
+	if nodeSize == "" {
+		nodeSize = "medium"
+	}
+	profile, ok := profiles[nodeSize]
+	if !ok {
+		profile = profiles["medium"]
+	}
+	size := profile.size
 	if n.CacheSize > 0 {
 		size = n.CacheSize
 	}
-	age := defaultNodeCacheAge
+	age := profile.age
 	if n.CacheAge > 0 {
 		age = time.Duration(n.CacheAge) * time.Minute
 	}
@@ -1386,7 +1464,7 @@ func doShutdown(
 	}
 
 	// Drain and join the persistence worker before closing its stores, so
-	// queued validated-ledger persists become durable instead of being
+	// queued ledger persists become durable instead of being
 	// abandoned (and so no StoreBatch races kvDB.Close). Ordered after the
 	// consensus components stop, so no new ledger closes past this point.
 	if ledgerService != nil {

--- a/internal/node/server_helpers_test.go
+++ b/internal/node/server_helpers_test.go
@@ -332,16 +332,21 @@ func TestAcceptedLedgerView_Populated(t *testing.T) {
 // TestNodeStoreCacheParams guards the node_db cache_size / cache_age
 // wiring into the node-object cache.
 func TestNodeStoreCacheParams(t *testing.T) {
-	size, age := nodeStoreCacheParams(config.NodeDBConfig{})
+	size, age := nodeStoreCacheParams(config.NodeDBConfig{}, "")
 	if size != defaultNodeCacheSize || age != defaultNodeCacheAge {
 		t.Errorf("defaults = (%d, %v), want (%d, %v)", size, age, defaultNodeCacheSize, defaultNodeCacheAge)
 	}
 
-	size, age = nodeStoreCacheParams(config.NodeDBConfig{CacheSize: 16384, CacheAge: 5})
+	size, age = nodeStoreCacheParams(config.NodeDBConfig{CacheSize: 16384, CacheAge: 5}, "tiny")
 	if size != 16384 {
 		t.Errorf("cache size = %d, want 16384", size)
 	}
 	if age != 5*time.Minute {
 		t.Errorf("cache age = %v, want 5m", age)
+	}
+
+	size, age = nodeStoreCacheParams(config.NodeDBConfig{}, "huge")
+	if size != 8_388_608 || age != 900*time.Minute {
+		t.Errorf("huge profile = (%d, %v)", size, age)
 	}
 }

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -144,6 +144,21 @@ func (o *Overlay) Peers() []PeerInfo {
 	return result
 }
 
+// CheckTracking compares every connected peer's advertised ledger range to a
+// quorum-validated sequence during initial synchronization.
+func (o *Overlay) CheckTracking(validSeq uint32) {
+	o.peersMu.RLock()
+	peers := make([]*Peer, 0, len(o.peers))
+	for _, peer := range o.peers {
+		peers = append(peers, peer)
+	}
+	o.peersMu.RUnlock()
+
+	for _, peer := range peers {
+		peer.CheckTrackingAgainst(validSeq)
+	}
+}
+
 // Cluster returns the registry of cluster-trusted node identities
 // loaded from [cluster_nodes]. Always non-nil post-construction.
 func (o *Overlay) Cluster() *cluster.Registry { return o.cluster }

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -466,6 +466,15 @@ func (p *Peer) CheckTracking(peerSeq, validSeq uint32) {
 	}
 }
 
+// CheckTrackingAgainst compares the peer's advertised ledger range to a
+// quorum-validated sequence.
+func (p *Peer) CheckTrackingAgainst(validSeq uint32) {
+	p.mu.RLock()
+	peerSeq := p.lastLedgerSeq
+	p.mu.RUnlock()
+	p.CheckTracking(peerSeq, validSeq)
+}
+
 func (p *Peer) ServerDomain() string {
 	p.mu.RLock()
 	defer p.mu.RUnlock()

--- a/internal/peermanagement/peer_tracking_test.go
+++ b/internal/peermanagement/peer_tracking_test.go
@@ -33,6 +33,8 @@ func TestPeerTracking_CheckTracking(t *testing.T) {
 	}{
 		{"converged_within_limit", 1000, 1000, PeerTrackingUnknown, PeerTrackingConverged},
 		{"converged_at_boundary_minus_one", 1000, 1023, PeerTrackingUnknown, PeerTrackingConverged},
+		{"converged_boundary_unchanged", 1000, 1024, PeerTrackingUnknown, PeerTrackingUnknown},
+		{"diverged_boundary_unchanged", 1000, 1128, PeerTrackingUnknown, PeerTrackingUnknown},
 		{"diverged_above_limit", 1000, 1200, PeerTrackingUnknown, PeerTrackingDiverged},
 		{"between_limits_no_change", 1000, 1050, PeerTrackingUnknown, PeerTrackingUnknown},
 		{"converged_overrides_previous_unknown", 5000, 5005, PeerTrackingUnknown, PeerTrackingConverged},
@@ -49,6 +51,27 @@ func TestPeerTracking_CheckTracking(t *testing.T) {
 			assert.Equal(t, tc.want, p.Tracking())
 		})
 	}
+}
+
+func TestOverlay_CheckTrackingUsesAdvertisedLastSequence(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	near := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
+	far := NewPeer(PeerID(2), Endpoint{Host: "127.0.0.1", Port: 2}, false, id, nil)
+	unknown := NewPeer(PeerID(3), Endpoint{Host: "127.0.0.1", Port: 3}, false, id, nil)
+	near.mu.Lock()
+	near.lastLedgerSeq = 9_990
+	near.mu.Unlock()
+	far.mu.Lock()
+	far.lastLedgerSeq = 9_800
+	far.mu.Unlock()
+
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{1: near, 2: far, 3: unknown})
+	o.CheckTracking(10_000)
+
+	assert.Equal(t, PeerTrackingConverged, near.Tracking())
+	assert.Equal(t, PeerTrackingDiverged, far.Tracking())
+	assert.Equal(t, PeerTrackingUnknown, unknown.Tracking())
 }
 
 func TestOverlay_handleStatusChange_UpdatesTracking(t *testing.T) {

--- a/shamap/family.go
+++ b/shamap/family.go
@@ -13,3 +13,16 @@ type Family interface {
 	// StoreBatch persists a batch of serialized nodes.
 	StoreBatch(ctx context.Context, entries []FlushEntry) error
 }
+
+type fullBelowCacheProvider interface {
+	FullBelowCache() *FullBelowCache
+}
+
+func familyFullBelowCache(family Family) *FullBelowCache {
+	if provider, ok := family.(fullBelowCacheProvider); ok {
+		if cache := provider.FullBelowCache(); cache != nil {
+			return cache
+		}
+	}
+	return NewFullBelowCache()
+}

--- a/shamap/flush.go
+++ b/shamap/flush.go
@@ -4,6 +4,51 @@ import (
 	"fmt"
 )
 
+// StoreDirty serializes dirty nodes and marks them clean only after store
+// succeeds.
+func (sm *SHAMap) StoreDirty(store func([]FlushEntry) error) error {
+	if store == nil {
+		return fmt.Errorf("shamap: nil dirty-node store")
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if sm.root == nil || sm.root.IsEmpty() {
+		return nil
+	}
+
+	batch := &NodeBatch{}
+	var nodes []Node
+	if err := sm.collectDirtyNode(sm.root, batch, &nodes); err != nil {
+		return fmt.Errorf("failed to flush: %w", err)
+	}
+	if len(batch.Entries) == 0 {
+		return nil
+	}
+	var (
+		gen  uint32
+		done = func() {}
+	)
+	if sm.backed && sm.fullBelow != nil {
+		gen, done = sm.fullBelow.Begin()
+	}
+	defer done()
+	if err := store(batch.Entries); err != nil {
+		return err
+	}
+	if sm.backed && sm.fullBelow != nil {
+		for _, node := range nodes {
+			if _, ok := node.(*innerNode); ok {
+				sm.fullBelow.Insert(gen, node.Hash())
+			}
+		}
+	}
+	for _, node := range nodes {
+		node.SetDirty(false)
+	}
+	return nil
+}
+
 // FlushDirty serializes every dirty node into the returned NodeBatch and marks
 // them clean, retaining all in-memory child pointers.
 func (sm *SHAMap) FlushDirty() (*NodeBatch, error) {
@@ -24,21 +69,28 @@ func (sm *SHAMap) flushDirty(releaseChildren bool) (*NodeBatch, error) {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	if sm.root == nil {
+	if sm.root == nil || sm.root.IsEmpty() {
 		return &NodeBatch{}, nil
 	}
 
 	batch := &NodeBatch{}
-
-	if err := sm.flushNode(sm.root, releaseChildren, batch); err != nil {
+	var nodes []Node
+	if err := sm.collectDirtyNode(sm.root, batch, &nodes); err != nil {
 		return nil, fmt.Errorf("failed to flush: %w", err)
+	}
+	for _, node := range nodes {
+		node.SetDirty(false)
+		if releaseChildren {
+			if inner, ok := node.(*innerNode); ok {
+				inner.ReleaseChildren()
+			}
+		}
 	}
 
 	return batch, nil
 }
 
-// flushNode recursively flushes a dirty node and its dirty children (post-order).
-func (sm *SHAMap) flushNode(node Node, releaseChildren bool, batch *NodeBatch) error {
+func (sm *SHAMap) collectDirtyNode(node Node, batch *NodeBatch, nodes *[]Node) error {
 	if node == nil || !node.IsDirty() {
 		return nil
 	}
@@ -48,7 +100,7 @@ func (sm *SHAMap) flushNode(node Node, releaseChildren bool, batch *NodeBatch) e
 		for i := range BranchFactor {
 			child, _, _ := inner.LoadChild(i)
 			if child != nil && child.IsDirty() {
-				if err := sm.flushNode(child, releaseChildren, batch); err != nil {
+				if err := sm.collectDirtyNode(child, batch, nodes); err != nil {
 					return err
 				}
 			}
@@ -71,19 +123,12 @@ func (sm *SHAMap) flushNode(node Node, releaseChildren bool, batch *NodeBatch) e
 
 	hash := node.Hash()
 	batch.Entries = append(batch.Entries, FlushEntry{
-		Hash: hash,
-		Data: data,
+		Hash:      hash,
+		Data:      data,
+		LedgerSeq: sm.ledgerSeq,
+		MapType:   sm.mapType,
 	})
-
-	// Mark clean
-	node.SetDirty(false)
-
-	// Release children pointers for inner nodes (retain hashes for lazy reload).
-	if releaseChildren {
-		if inner, ok := node.(*innerNode); ok {
-			inner.ReleaseChildren()
-		}
-	}
+	*nodes = append(*nodes, node)
 
 	return nil
 }

--- a/shamap/fullbelow.go
+++ b/shamap/fullbelow.go
@@ -11,7 +11,7 @@ import (
 // 2*fullBelowPartitionMax [32]byte keys without per-entry timestamps. This
 // is the idiomatic-Go stand-in for rippled's time-partitioned KeyCache
 // (FullBelowCache backed by KeyCache), which sweeps on a wall clock.
-const fullBelowPartitionMax = 1 << 17
+const fullBelowPartitionMax = 1 << 18
 
 // FullBelowCache remembers which SHAMap inner nodes have all of their
 // descendants resident, so a missing-node walk can prune whole subtrees
@@ -34,16 +34,19 @@ const fullBelowPartitionMax = 1 << 17
 //     is in the set is skipped without re-fetching and re-materializing its
 //     entire subtree from the store.
 //
-// A node hash is only ever inserted after its whole subtree has been
-// verified resident, and SHAMap trees are content-addressed and
-// path-copy-persistent, so a recorded mark can never become a false
-// positive: the subtree a hash names is immutable.
+// A node hash is inserted only after its subtree has been stored successfully.
+// This makes a shared family mark a guarantee that a hash-only child is
+// recoverable, not merely resident in another SHAMap instance.
 type FullBelowCache struct {
 	gen atomic.Uint32
 
-	mu   sync.Mutex
-	live map[[32]byte]struct{}
-	old  map[[32]byte]struct{}
+	// walks prevents a generation reset from overtaking an in-flight walk.
+	// Entries use a separate lock so a walk can populate the cache while it
+	// holds the generation read lock.
+	walks sync.RWMutex
+	mu    sync.Mutex
+	live  map[[32]byte]struct{}
+	old   map[[32]byte]struct{}
 }
 
 // NewFullBelowCache returns a cache at generation 1 (the first live
@@ -60,24 +63,41 @@ func (c *FullBelowCache) Generation() uint32 {
 	return c.gen.Load()
 }
 
-// Bump invalidates every outstanding full-below mark by advancing the
-// generation and dropping the recorded hashes. rippled bumps only on a
-// NodeFamily reset (never per acquisition, since content-addressing keeps
-// marks valid across ledgers); go-xrpl mirrors that — an acquisition gets a
-// fresh cache rather than bumping a shared one — and exposes Bump for that
-// reset path and for tests that need to defeat the cache.
+// Begin pins the current generation for one missing-node walk. The returned
+// function must be called when the walk finishes.
+func (c *FullBelowCache) Begin() (uint32, func()) {
+	c.walks.RLock()
+	return c.gen.Load(), c.walks.RUnlock
+}
+
+// Bump invalidates every outstanding full-below mark. It waits for active
+// missing-node walks so no mark from the old backing store enters the new
+// generation.
 func (c *FullBelowCache) Bump() {
+	unlock := c.invalidateAndLock()
+	unlock()
+}
+
+func (c *FullBelowCache) invalidateAndLock() func() {
+	c.walks.Lock()
+
 	c.mu.Lock()
 	c.live = make(map[[32]byte]struct{})
 	c.old = nil
+	if c.gen.Add(1) == 0 {
+		c.gen.Store(1)
+	}
 	c.mu.Unlock()
-	c.gen.Add(1)
+	return c.walks.Unlock
 }
 
 // Has reports whether hash was proven full-below in the current generation.
-func (c *FullBelowCache) Has(hash [32]byte) bool {
+func (c *FullBelowCache) Has(generation uint32, hash [32]byte) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.gen.Load() != generation {
+		return false
+	}
 	if _, ok := c.live[hash]; ok {
 		return true
 	}
@@ -88,9 +108,12 @@ func (c *FullBelowCache) Has(hash [32]byte) bool {
 // Insert records hash as full-below. When the live partition fills it is
 // demoted so recently-inserted hashes survive one more rotation, bounding
 // memory without per-entry expiry.
-func (c *FullBelowCache) Insert(hash [32]byte) {
+func (c *FullBelowCache) Insert(generation uint32, hash [32]byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.gen.Load() != generation {
+		return
+	}
 	if len(c.live) >= fullBelowPartitionMax {
 		c.old = c.live
 		c.live = make(map[[32]byte]struct{})

--- a/shamap/fullbelow.go
+++ b/shamap/fullbelow.go
@@ -1,0 +1,106 @@
+package shamap
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// fullBelowPartitionMax bounds each of the FullBelowCache's two hash
+// partitions. When the live partition fills, it is demoted to the stale
+// slot and a fresh one takes its place, capping resident memory at roughly
+// 2*fullBelowPartitionMax [32]byte keys without per-entry timestamps. This
+// is the idiomatic-Go stand-in for rippled's time-partitioned KeyCache
+// (FullBelowCache backed by KeyCache), which sweeps on a wall clock.
+const fullBelowPartitionMax = 1 << 17
+
+// FullBelowCache remembers which SHAMap inner nodes have all of their
+// descendants resident, so a missing-node walk can prune whole subtrees
+// instead of re-descending them on every peer reply. It is the go-xrpl
+// analogue of rippled's FullBelowCache (xrpld/shamap/FullBelowCache.h):
+//
+//   - A monotonically increasing generation tags the marks. Every inner
+//     node caches the generation it was last proven full-below at
+//     (innerNode.fullBelowGen); a mark counts only while it equals the
+//     cache's current generation, so Bump invalidates every outstanding
+//     mark in O(1). Fresh and wire/store-deserialized nodes carry
+//     generation 0, which never equals a live generation (>= 1), so an
+//     unproven node is never mistaken for full-below.
+//
+//   - A bounded hash set records the node hashes proven full-below. The
+//     per-node generation is the in-memory fast path (nodes stay resident
+//     across the replies of one acquisition, so it carries the walk); the
+//     hash set covers the backed case where a proven subtree's child
+//     pointers were released after a flush — a hash-only child whose hash
+//     is in the set is skipped without re-fetching and re-materializing its
+//     entire subtree from the store.
+//
+// A node hash is only ever inserted after its whole subtree has been
+// verified resident, and SHAMap trees are content-addressed and
+// path-copy-persistent, so a recorded mark can never become a false
+// positive: the subtree a hash names is immutable.
+type FullBelowCache struct {
+	gen atomic.Uint32
+
+	mu   sync.Mutex
+	live map[[32]byte]struct{}
+	old  map[[32]byte]struct{}
+}
+
+// NewFullBelowCache returns a cache at generation 1 (the first live
+// generation; 0 is reserved for "never proven").
+func NewFullBelowCache() *FullBelowCache {
+	c := &FullBelowCache{live: make(map[[32]byte]struct{})}
+	c.gen.Store(1)
+	return c
+}
+
+// Generation returns the current generation. A missing-node walk reads it
+// once and compares it against each inner node's cached generation.
+func (c *FullBelowCache) Generation() uint32 {
+	return c.gen.Load()
+}
+
+// Bump invalidates every outstanding full-below mark by advancing the
+// generation and dropping the recorded hashes. rippled bumps only on a
+// NodeFamily reset (never per acquisition, since content-addressing keeps
+// marks valid across ledgers); go-xrpl mirrors that — an acquisition gets a
+// fresh cache rather than bumping a shared one — and exposes Bump for that
+// reset path and for tests that need to defeat the cache.
+func (c *FullBelowCache) Bump() {
+	c.mu.Lock()
+	c.live = make(map[[32]byte]struct{})
+	c.old = nil
+	c.mu.Unlock()
+	c.gen.Add(1)
+}
+
+// Has reports whether hash was proven full-below in the current generation.
+func (c *FullBelowCache) Has(hash [32]byte) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.live[hash]; ok {
+		return true
+	}
+	_, ok := c.old[hash]
+	return ok
+}
+
+// Insert records hash as full-below. When the live partition fills it is
+// demoted so recently-inserted hashes survive one more rotation, bounding
+// memory without per-entry expiry.
+func (c *FullBelowCache) Insert(hash [32]byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.live) >= fullBelowPartitionMax {
+		c.old = c.live
+		c.live = make(map[[32]byte]struct{})
+	}
+	c.live[hash] = struct{}{}
+}
+
+// Size reports the number of recorded hashes across both partitions.
+func (c *FullBelowCache) Size() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.live) + len(c.old)
+}

--- a/shamap/fullbelow_test.go
+++ b/shamap/fullbelow_test.go
@@ -1,0 +1,599 @@
+package shamap
+
+import (
+	"context"
+	"crypto/rand"
+	"sync/atomic"
+	"testing"
+)
+
+// countingFamily wraps a Family and counts Fetch calls so a test can prove
+// that a full-below walk prunes subtrees instead of re-descending (and
+// re-fetching) them.
+type countingFamily struct {
+	inner   Family
+	fetches atomic.Int64
+}
+
+func newCountingFamily() *countingFamily {
+	return &countingFamily{inner: NewMemoryNodeStoreFamily()}
+}
+
+func (c *countingFamily) Fetch(ctx context.Context, hash [32]byte) ([]byte, error) {
+	c.fetches.Add(1)
+	return c.inner.Fetch(ctx, hash)
+}
+
+func (c *countingFamily) StoreBatch(ctx context.Context, entries []FlushEntry) error {
+	return c.inner.StoreBatch(ctx, entries)
+}
+
+func (c *countingFamily) count() int64 { return c.fetches.Load() }
+func (c *countingFamily) reset()       { c.fetches.Store(0) }
+
+// buildRandomState builds a state SHAMap of n random-keyed leaves and
+// returns it. Random keys spread the tree across every branch and drive it
+// several levels deep, so a walk that fails to prune has real work to skip.
+func buildRandomState(t testing.TB, n int) *SHAMap {
+	t.Helper()
+	sm := New(TypeState)
+	for range n {
+		var key [32]byte
+		if _, err := rand.Read(key[:]); err != nil {
+			t.Fatalf("rand: %v", err)
+		}
+		if err := sm.Put(key, make([]byte, 12)); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+	return sm
+}
+
+// syncInto delivers every non-root node of source into dest in WalkWireNodes
+// order (parents before children, so AddKnownNodeByID can always hook the
+// node), skipping any NodeID for which skip returns true. Returns the count
+// delivered.
+func syncInto(t testing.TB, dest, source *SHAMap, skip func(id []byte) bool) int {
+	t.Helper()
+	nodes, err := source.WalkWireNodes()
+	if err != nil {
+		t.Fatalf("WalkWireNodes: %v", err)
+	}
+	delivered := 0
+	for _, w := range nodes {
+		nid, err := ParseNodeID(w.NodeID)
+		if err != nil {
+			t.Fatalf("ParseNodeID: %v", err)
+		}
+		if nid.IsRoot() {
+			continue
+		}
+		if skip != nil && skip(w.NodeID) {
+			continue
+		}
+		if _, err := dest.AddKnownNodeByID(nid, w.Data); err != nil {
+			t.Fatalf("AddKnownNodeByID depth=%d: %v", nid.Depth(), err)
+		}
+		delivered++
+	}
+	return delivered
+}
+
+// wireDataFor returns source's wire bytes for the node at nodeID.
+func wireDataFor(t testing.TB, source *SHAMap, nodeID NodeID) []byte {
+	t.Helper()
+	nodes, err := source.WalkWireNodes()
+	if err != nil {
+		t.Fatalf("WalkWireNodes: %v", err)
+	}
+	want := string(nodeID.Bytes())
+	for _, w := range nodes {
+		if string(w.NodeID) == want {
+			return w.Data
+		}
+	}
+	t.Fatalf("no wire node for id %x", nodeID.Bytes())
+	return nil
+}
+
+// TestFullBelow_MarksCompleteSubtrees fully syncs a tree and asserts the
+// walk marks the whole tree full-below: the root and every inner node.
+func TestFullBelow_MarksCompleteSubtrees(t *testing.T) {
+	source := buildRandomState(t, 400)
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("SerializeRoot: %v", err)
+	}
+
+	dest := New(TypeState)
+	if err := dest.AddRootNode(rootHash, rootData); err != nil {
+		t.Fatalf("AddRootNode: %v", err)
+	}
+	syncInto(t, dest, source, nil)
+
+	if missing := dest.WalkMap(0, nil); len(missing) != 0 {
+		t.Fatalf("complete tree should have no missing nodes, got %d", len(missing))
+	}
+
+	gen := dest.FullBelowCache().Generation()
+	if !dest.root.isFullBelow(gen) {
+		t.Error("root should be marked full-below after a complete walk")
+	}
+	// Every resident inner node must be marked.
+	var check func(n *innerNode) bool
+	check = func(n *innerNode) bool {
+		if !n.isFullBelow(gen) {
+			return false
+		}
+		for i := range BranchFactor {
+			child, _, isSet := n.LoadChild(i)
+			if !isSet || child == nil {
+				continue
+			}
+			if inner, ok := child.(*innerNode); ok {
+				if !check(inner) {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	if !check(dest.root) {
+		t.Error("every inner node in a complete tree should be full-below")
+	}
+}
+
+// TestFullBelow_NeverMarkedWhileDescendantMissing is the invalidation-
+// correctness test: with one leaf withheld, no ancestor of the hole may be
+// marked full-below, while a complete sibling subtree must be. Filling the
+// hole and re-walking then promotes the whole tree to full-below.
+func TestFullBelow_NeverMarkedWhileDescendantMissing(t *testing.T) {
+	// Keys engineered so branch 0 and branch 1 each hold a multi-leaf
+	// subtree; we withhold one leaf under branch 1.
+	source := New(TypeState)
+	keys := make([][32]byte, 0, 16)
+	for hi := byte(0); hi < 2; hi++ { // first nibble 0 and 1
+		for lo := byte(0); lo < 8; lo++ {
+			var k [32]byte
+			k[0] = (hi << 4)
+			k[1] = lo << 4
+			k[5] = 0x01 // keep every key non-zero without changing the path
+			keys = append(keys, k)
+			if err := source.Put(k, make([]byte, 12)); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+		}
+	}
+	rootHash, _ := source.Hash()
+	rootData, _ := source.SerializeRoot()
+
+	// The withheld leaf lives under first nibble 1.
+	withheldKey := keys[len(keys)-1]
+	if withheldKey[0]>>4 != 1 {
+		t.Fatalf("expected withheld key under branch 1, got nibble %d", withheldKey[0]>>4)
+	}
+
+	dest := New(TypeState)
+	if err := dest.AddRootNode(rootHash, rootData); err != nil {
+		t.Fatalf("AddRootNode: %v", err)
+	}
+
+	// Identify the wire NodeID of the withheld leaf so we can skip it.
+	withheldLeafID := leafNodeIDFor(t, source, withheldKey)
+	withheldBytes := string(withheldLeafID.Bytes())
+	syncInto(t, dest, source, func(id []byte) bool {
+		return string(id) == withheldBytes
+	})
+
+	missing := dest.WalkMap(0, nil)
+	if len(missing) == 0 {
+		t.Fatal("expected the withheld leaf to be reported missing")
+	}
+
+	gen := dest.FullBelowCache().Generation()
+	if dest.root.isFullBelow(gen) {
+		t.Error("root must NOT be full-below while a descendant is missing")
+	}
+
+	// Branch 0's subtree is complete and must be marked; branch 1's must not.
+	b0, _, set0 := dest.root.LoadChild(0)
+	if !set0 {
+		t.Fatal("branch 0 should be populated")
+	}
+	if inner0, ok := b0.(*innerNode); ok {
+		if !inner0.isFullBelow(gen) {
+			t.Error("complete branch-0 subtree should be full-below")
+		}
+	}
+	b1, _, set1 := dest.root.LoadChild(1)
+	if !set1 {
+		t.Fatal("branch 1 should be populated")
+	}
+	if inner1, ok := b1.(*innerNode); ok {
+		if inner1.isFullBelow(gen) {
+			t.Error("branch-1 subtree with a missing leaf must NOT be full-below")
+		}
+	}
+
+	// Deliver the withheld leaf, re-walk: the whole tree is now complete.
+	leafData := wireDataFor(t, source, withheldLeafID)
+	if _, err := dest.AddKnownNodeByID(withheldLeafID, leafData); err != nil {
+		t.Fatalf("AddKnownNodeByID(withheld): %v", err)
+	}
+	if missing := dest.WalkMap(0, nil); len(missing) != 0 {
+		t.Fatalf("tree should be complete after filling the hole, got %d missing", len(missing))
+	}
+	if !dest.root.isFullBelow(gen) {
+		t.Error("root should be full-below once the hole is filled")
+	}
+}
+
+// TestFullBelow_PrunesReleasedSubtree proves the walk is O(new) not
+// O(tree): once a backed subtree is proven full-below, a re-walk prunes it
+// with zero store fetches even after its child pointers were released;
+// defeating the marks (Bump) forces the whole subtree to be re-fetched.
+func TestFullBelow_PrunesReleasedSubtree(t *testing.T) {
+	fam := newCountingFamily()
+
+	// Build a multi-level tree and flush every node to the family.
+	source, err := NewBacked(TypeState, fam)
+	if err != nil {
+		t.Fatalf("NewBacked: %v", err)
+	}
+	for range 2000 {
+		var key [32]byte
+		if _, err := rand.Read(key[:]); err != nil {
+			t.Fatalf("rand: %v", err)
+		}
+		if err := source.Put(key, make([]byte, 12)); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+	if _, err := source.SnapshotImmutable(); err != nil { // flushes dirty nodes to fam
+		t.Fatalf("snapshot: %v", err)
+	}
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+
+	// A fresh backed view of the same tree: only the root is resident.
+	dest, err := NewFromRootHash(TypeState, rootHash, fam)
+	if err != nil {
+		t.Fatalf("NewFromRootHash: %v", err)
+	}
+
+	// Walk 1 (cold): materializes the tree from the store — O(tree) fetches.
+	if missing := dest.WalkMap(0, nil); len(missing) != 0 {
+		t.Fatalf("backed complete tree should have no missing nodes, got %d", len(missing))
+	}
+	coldFetches := fam.count()
+	if coldFetches == 0 {
+		t.Fatal("cold walk should have fetched the tree from the store")
+	}
+
+	// Release the root's children so the whole tree is hash-only again, but
+	// keep the root (which stays marked full-below).
+	dest.root.ReleaseChildren()
+
+	// Walk 2 (warm marks): the root is proven full-below → prune, zero fetches.
+	fam.reset()
+	if missing := dest.WalkMap(0, nil); len(missing) != 0 {
+		t.Fatalf("warm walk found %d missing on a complete tree", len(missing))
+	}
+	if got := fam.count(); got != 0 {
+		t.Errorf("warm walk re-fetched %d nodes; expected 0 (subtree pruned)", got)
+	}
+
+	// Walk 3 (marks invalidated): with the marks bumped and children
+	// released, the walk must re-descend and re-fetch the tree — the
+	// pre-full-below O(tree) behaviour we are replacing.
+	dest.FullBelowCache().Bump()
+	fam.reset()
+	if missing := dest.WalkMap(0, nil); len(missing) != 0 {
+		t.Fatalf("post-bump walk found %d missing on a complete tree", len(missing))
+	}
+	if got := fam.count(); got == 0 {
+		t.Error("post-bump walk should re-fetch the released tree (no valid marks)")
+	}
+}
+
+// TestFullBelow_HashSetSkipsReleasedChildWithoutFetch isolates the backed
+// hash set: when a proven-complete child subtree has been released to a
+// hash-only stub, a walk of its (re-evaluated) parent prunes it via the
+// cache without fetching it from the store. Clearing the set (Bump) then
+// forces the same walk to re-fetch, proving the set is what pruned it.
+func TestFullBelow_HashSetSkipsReleasedChildWithoutFetch(t *testing.T) {
+	fam := newCountingFamily()
+	source, err := NewBacked(TypeState, fam)
+	if err != nil {
+		t.Fatalf("NewBacked: %v", err)
+	}
+	for range 1000 {
+		var key [32]byte
+		if _, err := rand.Read(key[:]); err != nil {
+			t.Fatalf("rand: %v", err)
+		}
+		if err := source.Put(key, make([]byte, 12)); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+	if _, err := source.SnapshotImmutable(); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	rootHash, _ := source.Hash()
+
+	dest, err := NewFromRootHash(TypeState, rootHash, fam)
+	if err != nil {
+		t.Fatalf("NewFromRootHash: %v", err)
+	}
+
+	// Warm: materialize + mark + populate the hash set for every subtree.
+	if missing := dest.WalkMap(0, nil); len(missing) != 0 {
+		t.Fatalf("warm-up walk found %d missing", len(missing))
+	}
+	if dest.FullBelowCache().Size() == 0 {
+		t.Fatal("hash set should be populated after a backed complete walk")
+	}
+
+	// Release the root's children to hash-only stubs (their hashes remain in
+	// the set) and force the root itself to be re-evaluated, so the walk
+	// must reach the child slots and decide via the set.
+	dest.root.ReleaseChildren()
+	dest.root.mu.Lock()
+	dest.root.fullBelowGen = 0
+	dest.root.mu.Unlock()
+
+	fam.reset()
+	if missing := dest.WalkMap(0, nil); len(missing) != 0 {
+		t.Fatalf("walk found %d missing on a complete tree", len(missing))
+	}
+	if got := fam.count(); got != 0 {
+		t.Errorf("walk fetched %d nodes; released children should be pruned via the hash set", got)
+	}
+
+	// Clear the set: the same released children must now be re-fetched.
+	dest.FullBelowCache().Bump()
+	dest.root.mu.Lock()
+	dest.root.fullBelowGen = 0
+	dest.root.mu.Unlock()
+	fam.reset()
+	if missing := dest.WalkMap(0, nil); len(missing) != 0 {
+		t.Fatalf("post-bump walk found %d missing", len(missing))
+	}
+	if got := fam.count(); got == 0 {
+		t.Error("post-bump walk should re-fetch released children (set cleared)")
+	}
+}
+
+// leafNodeIDFor returns the wire NodeID of the leaf holding key in sm.
+func leafNodeIDFor(t testing.TB, sm *SHAMap, key [32]byte) NodeID {
+	t.Helper()
+	stack := newNodeStack()
+	if _, err := sm.walkToKey(context.Background(), key, stack, true); err != nil {
+		t.Fatalf("walkToKey: %v", err)
+	}
+	_, id, ok := stack.Top()
+	if !ok {
+		t.Fatalf("no leaf on stack for key %x", key[:4])
+	}
+	return id
+}
+
+// TestFullBelowCache_GenerationAndBump covers the cache's generation
+// semantics: it starts at 1, Bump advances it and drops recorded hashes,
+// and a per-node mark only counts at the live generation.
+func TestFullBelowCache_GenerationAndBump(t *testing.T) {
+	c := NewFullBelowCache()
+	if c.Generation() != 1 {
+		t.Fatalf("fresh cache generation = %d, want 1", c.Generation())
+	}
+
+	var h [32]byte
+	h[0] = 0xAB
+	c.Insert(h)
+	if !c.Has(h) {
+		t.Error("Has should report an inserted hash")
+	}
+	if c.Size() != 1 {
+		t.Errorf("Size = %d, want 1", c.Size())
+	}
+
+	// A node marked at the current generation is full-below; after Bump it
+	// is not, and the hash is gone.
+	n := newInnerNode()
+	n.setFullBelowGen(c.Generation())
+	if !n.isFullBelow(c.Generation()) {
+		t.Error("node should be full-below at its marked generation")
+	}
+	c.Bump()
+	if c.Generation() != 2 {
+		t.Errorf("generation after Bump = %d, want 2", c.Generation())
+	}
+	if n.isFullBelow(c.Generation()) {
+		t.Error("node mark must not survive a generation bump")
+	}
+	if c.Has(h) {
+		t.Error("Bump should drop recorded hashes")
+	}
+	if c.Size() != 0 {
+		t.Errorf("Size after Bump = %d, want 0", c.Size())
+	}
+}
+
+// TestFullBelowCache_ZeroGenNeverMatches guards the core invariant: a fresh
+// or deserialized node (generation 0) is never mistaken for full-below.
+func TestFullBelowCache_ZeroGenNeverMatches(t *testing.T) {
+	c := NewFullBelowCache()
+	n := newInnerNode() // fullBelowGen defaults to 0
+	if n.isFullBelow(c.Generation()) {
+		t.Error("an unmarked node (gen 0) must never read as full-below")
+	}
+	// Even after many bumps, gen never returns to 0, so the invariant holds.
+	for range 5 {
+		c.Bump()
+	}
+	if n.isFullBelow(c.Generation()) {
+		t.Error("unmarked node still must not be full-below after bumps")
+	}
+	if c.Generation() == 0 {
+		t.Error("generation must never be 0")
+	}
+}
+
+// TestFullBelowCache_Bounded verifies the two-partition set stays bounded:
+// inserting well past a partition's capacity keeps resident size under the
+// 2x cap while the most recent inserts remain queryable.
+func TestFullBelowCache_Bounded(t *testing.T) {
+	c := NewFullBelowCache()
+	n := fullBelowPartitionMax + fullBelowPartitionMax/2
+	var last [32]byte
+	for i := range n {
+		var h [32]byte
+		h[0] = byte(i)
+		h[1] = byte(i >> 8)
+		h[2] = byte(i >> 16)
+		c.Insert(h)
+		last = h
+	}
+	if sz := c.Size(); sz > 2*fullBelowPartitionMax {
+		t.Errorf("Size = %d exceeds 2x partition cap %d", sz, 2*fullBelowPartitionMax)
+	}
+	if !c.Has(last) {
+		t.Error("most-recently inserted hash should still be present")
+	}
+}
+
+// buildStateWireNodes builds a random state tree of n leaves and returns its
+// root hash, root wire bytes, and every non-root node in deliverable order.
+func buildStateWireNodes(t testing.TB, n int) (rootHash [32]byte, rootData []byte, ordered []WireNode) {
+	t.Helper()
+	source := buildRandomState(t, n)
+	rh, err := source.Hash()
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	rd, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("SerializeRoot: %v", err)
+	}
+	nodes, err := source.WalkWireNodes()
+	if err != nil {
+		t.Fatalf("WalkWireNodes: %v", err)
+	}
+	return rh, rd, nodes
+}
+
+// benchmarkIncrementalSync replays an inbound acquisition: it delivers the
+// tree in fixed-size batches and, after each batch, runs the missing-node
+// walk the router runs per reply. bumpEachWalk defeats the full-below cache
+// (the pre-fix O(tree)-per-walk behaviour) so the two variants bracket the
+// quadratic->linear improvement.
+func benchmarkIncrementalSync(b *testing.B, leaves, batch int, bumpEachWalk bool) {
+	rootHash, rootData, nodes := buildStateWireNodes(b, leaves)
+
+	b.ResetTimer()
+	for range b.N {
+		dest := New(TypeState)
+		if err := dest.AddRootNode(rootHash, rootData); err != nil {
+			b.Fatalf("AddRootNode: %v", err)
+		}
+		pending := make([]WireNode, 0, batch)
+		flush := func() {
+			for _, w := range pending {
+				nid, err := ParseNodeID(w.NodeID)
+				if err != nil || nid.IsRoot() {
+					continue
+				}
+				_, _ = dest.AddKnownNodeByID(nid, w.Data)
+			}
+			pending = pending[:0]
+			if bumpEachWalk {
+				dest.FullBelowCache().Bump()
+			}
+			// The per-reply missing-node walk (rippled trigger()).
+			_ = dest.GetMissingNodes(256, nil)
+		}
+		for _, w := range nodes {
+			pending = append(pending, w)
+			if len(pending) >= batch {
+				flush()
+			}
+		}
+		flush()
+	}
+}
+
+func BenchmarkIncrementalSync_WithFullBelow(b *testing.B) {
+	benchmarkIncrementalSync(b, 20000, 256, false)
+}
+
+func BenchmarkIncrementalSync_WithoutFullBelow(b *testing.B) {
+	benchmarkIncrementalSync(b, 20000, 256, true)
+}
+
+// benchmarkMissingWalk isolates the per-reply missing-node walk on a large
+// tree that is complete except for a few deep leaves — the audit's
+// quadratic scenario, where late in a sync the frontier is deep and every
+// walk without a full-below cache re-scans the whole fetched tree to reach
+// it. bumpEachWalk defeats the cache to reproduce that O(tree)-per-walk cost.
+func benchmarkMissingWalk(b *testing.B, leaves int, bumpEachWalk bool) {
+	source := buildRandomState(b, leaves)
+	rootHash, err := source.Hash()
+	if err != nil {
+		b.Fatalf("Hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		b.Fatalf("SerializeRoot: %v", err)
+	}
+	nodes, err := source.WalkWireNodes()
+	if err != nil {
+		b.Fatalf("WalkWireNodes: %v", err)
+	}
+
+	dest := New(TypeState)
+	if err := dest.AddRootNode(rootHash, rootData); err != nil {
+		b.Fatalf("AddRootNode: %v", err)
+	}
+	// Deliver everything but the last few deep leaves, leaving a sparse,
+	// deep frontier over an otherwise-complete tree.
+	const withhold = 4
+	leafSeen := 0
+	for i := len(nodes) - 1; i >= 0 && leafSeen < withhold; i-- {
+		if node, derr := deserializeNodeFromWire(nodes[i].Data); derr == nil {
+			if _, isLeaf := node.(LeafNode); isLeaf {
+				nodes[i], nodes[len(nodes)-1-leafSeen] = nodes[len(nodes)-1-leafSeen], nodes[i]
+				leafSeen++
+			}
+		}
+	}
+	deliver := nodes[:len(nodes)-withhold]
+	for _, w := range deliver {
+		nid, err := ParseNodeID(w.NodeID)
+		if err != nil || nid.IsRoot() {
+			continue
+		}
+		_, _ = dest.AddKnownNodeByID(nid, w.Data)
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		if bumpEachWalk {
+			dest.FullBelowCache().Bump()
+		}
+		_ = dest.GetMissingNodes(256, nil)
+	}
+}
+
+func BenchmarkMissingWalk_WithFullBelow(b *testing.B) {
+	benchmarkMissingWalk(b, 90000, false)
+}
+
+func BenchmarkMissingWalk_WithoutFullBelow(b *testing.B) {
+	benchmarkMissingWalk(b, 90000, true)
+}

--- a/shamap/fullbelow_test.go
+++ b/shamap/fullbelow_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // countingFamily wraps a Family and counts Fetch calls so a test can prove
@@ -26,6 +27,10 @@ func (c *countingFamily) Fetch(ctx context.Context, hash [32]byte) ([]byte, erro
 
 func (c *countingFamily) StoreBatch(ctx context.Context, entries []FlushEntry) error {
 	return c.inner.StoreBatch(ctx, entries)
+}
+
+func (c *countingFamily) FullBelowCache() *FullBelowCache {
+	return c.inner.(fullBelowCacheProvider).FullBelowCache()
 }
 
 func (c *countingFamily) count() int64 { return c.fetches.Load() }
@@ -332,7 +337,7 @@ func TestFullBelow_HashSetSkipsReleasedChildWithoutFetch(t *testing.T) {
 		t.Fatalf("NewFromRootHash: %v", err)
 	}
 
-	// Warm: materialize + mark + populate the hash set for every subtree.
+	// Materialize and mark the tree; the source flush populated the shared set.
 	if missing := dest.WalkMap(0, nil); len(missing) != 0 {
 		t.Fatalf("warm-up walk found %d missing", len(missing))
 	}
@@ -370,6 +375,76 @@ func TestFullBelow_HashSetSkipsReleasedChildWithoutFetch(t *testing.T) {
 	}
 }
 
+func TestFullBelow_SharedCacheDoesNotPublishUnstoredSubtree(t *testing.T) {
+	family := NewMemoryNodeStoreFamily()
+	source := buildRandomState(t, 100)
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootWire, err := source.root.SerializeForWire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	source.fullBelow = family.FullBelowCache()
+	if missing := source.WalkMap(0, nil); len(missing) != 0 {
+		t.Fatalf("materialized source missing %d nodes", len(missing))
+	}
+
+	dest, err := NewBacked(TypeState, family)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := dest.AddRootNode(rootHash, rootWire); err != nil {
+		t.Fatal(err)
+	}
+	if missing := dest.GetMissingNodes(0, nil); len(missing) == 0 {
+		t.Fatal("shared cache hid an unstored subtree")
+	}
+}
+
+func TestStoreDirty_PinsFullBelowGenerationThroughStore(t *testing.T) {
+	family := NewMemoryNodeStoreFamily()
+	sm, err := NewBacked(TypeState, family)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sm.Put([32]byte{1}, make([]byte, 12)); err != nil {
+		t.Fatal(err)
+	}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	stored := make(chan error, 1)
+	go func() {
+		stored <- sm.StoreDirty(func([]FlushEntry) error {
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+
+	pruned := make(chan struct{})
+	go func() {
+		unlock := family.BeginPrune()
+		unlock()
+		close(pruned)
+	}()
+	select {
+	case <-pruned:
+		t.Fatal("prune invalidated the cache while dirty storage was in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	if err := <-stored; err != nil {
+		t.Fatal(err)
+	}
+	<-pruned
+	if size := family.FullBelowCache().Size(); size != 0 {
+		t.Fatalf("cache size after prune = %d, want 0", size)
+	}
+}
+
 // leafNodeIDFor returns the wire NodeID of the leaf holding key in sm.
 func leafNodeIDFor(t testing.TB, sm *SHAMap, key [32]byte) NodeID {
 	t.Helper()
@@ -395,8 +470,9 @@ func TestFullBelowCache_GenerationAndBump(t *testing.T) {
 
 	var h [32]byte
 	h[0] = 0xAB
-	c.Insert(h)
-	if !c.Has(h) {
+	gen := c.Generation()
+	c.Insert(gen, h)
+	if !c.Has(gen, h) {
 		t.Error("Has should report an inserted hash")
 	}
 	if c.Size() != 1 {
@@ -417,11 +493,37 @@ func TestFullBelowCache_GenerationAndBump(t *testing.T) {
 	if n.isFullBelow(c.Generation()) {
 		t.Error("node mark must not survive a generation bump")
 	}
-	if c.Has(h) {
+	if c.Has(c.Generation(), h) {
 		t.Error("Bump should drop recorded hashes")
 	}
 	if c.Size() != 0 {
 		t.Errorf("Size after Bump = %d, want 0", c.Size())
+	}
+}
+
+func TestFullBelowCache_RejectsStaleGenerationInsert(t *testing.T) {
+	c := NewFullBelowCache()
+	stale := c.Generation()
+	c.Bump()
+	h := [32]byte{0x7A}
+	c.Insert(stale, h)
+	if c.Has(c.Generation(), h) {
+		t.Fatal("stale generation insert survived reset")
+	}
+}
+
+func TestFullBelowCache_SharedByFamily(t *testing.T) {
+	family := NewMemoryNodeStoreFamily()
+	first, err := NewBacked(TypeState, family)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := NewBacked(TypeTransaction, family)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.FullBelowCache() != second.FullBelowCache() {
+		t.Fatal("maps backed by one family must share completeness marks")
 	}
 }
 
@@ -450,6 +552,7 @@ func TestFullBelowCache_ZeroGenNeverMatches(t *testing.T) {
 // 2x cap while the most recent inserts remain queryable.
 func TestFullBelowCache_Bounded(t *testing.T) {
 	c := NewFullBelowCache()
+	gen := c.Generation()
 	n := fullBelowPartitionMax + fullBelowPartitionMax/2
 	var last [32]byte
 	for i := range n {
@@ -457,13 +560,13 @@ func TestFullBelowCache_Bounded(t *testing.T) {
 		h[0] = byte(i)
 		h[1] = byte(i >> 8)
 		h[2] = byte(i >> 16)
-		c.Insert(h)
+		c.Insert(gen, h)
 		last = h
 	}
 	if sz := c.Size(); sz > 2*fullBelowPartitionMax {
 		t.Errorf("Size = %d exceeds 2x partition cap %d", sz, 2*fullBelowPartitionMax)
 	}
-	if !c.Has(last) {
+	if !c.Has(gen, last) {
 		t.Error("most-recently inserted hash should still be present")
 	}
 }

--- a/shamap/inner_node.go
+++ b/shamap/inner_node.go
@@ -511,8 +511,9 @@ func (n *innerNode) Clone() (Node, error) {
 	defer n.mu.RUnlock()
 
 	clone := &innerNode{
-		isBranch: n.isBranch,
-		hashes:   n.hashes, // Copy the array
+		isBranch:     n.isBranch,
+		hashes:       n.hashes, // Copy the array
+		fullBelowGen: n.fullBelowGen,
 	}
 	clone.hash = n.hash
 	clone.SetDirty(true)
@@ -542,9 +543,10 @@ func (n *innerNode) shallowClone() *innerNode {
 	n.mu.RLock()
 	defer n.mu.RUnlock()
 	clone := &innerNode{
-		isBranch: n.isBranch,
-		hashes:   n.hashes,
-		children: n.children,
+		isBranch:     n.isBranch,
+		hashes:       n.hashes,
+		children:     n.children,
+		fullBelowGen: n.fullBelowGen,
 	}
 	clone.hash = n.hash
 	clone.SetDirty(true)

--- a/shamap/inner_node.go
+++ b/shamap/inner_node.go
@@ -32,6 +32,13 @@ type innerNode struct {
 	children [BranchFactor]Node
 	hashes   [BranchFactor][32]byte
 	isBranch uint16
+	// fullBelowGen caches the FullBelowCache generation at which this node
+	// was last proven to have every descendant resident. It is meaningful
+	// only while it equals the cache's current generation (see
+	// isFullBelow); a fresh or wire/store-deserialized node carries 0,
+	// which never matches a live generation. Mirrors rippled's
+	// SHAMapInnerNode::fullBelowGen_. Guarded by mu.
+	fullBelowGen uint32
 }
 
 // newInnerNode creates a new empty inner node
@@ -142,6 +149,23 @@ func (n *innerNode) SetChildIfNil(index int, child Node) Node {
 	}
 	n.children[index] = child
 	return child
+}
+
+// isFullBelow reports whether this node was proven full-below at the given
+// (current) cache generation. Mirrors rippled
+// SHAMapInnerNode::isFullBelow.
+func (n *innerNode) isFullBelow(generation uint32) bool {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.fullBelowGen == generation
+}
+
+// setFullBelowGen records that every descendant is resident as of
+// generation. Mirrors rippled SHAMapInnerNode::setFullBelowGen.
+func (n *innerNode) setFullBelowGen(generation uint32) {
+	n.mu.Lock()
+	n.fullBelowGen = generation
+	n.mu.Unlock()
 }
 
 // ChildHash returns the hash at a given branch index

--- a/shamap/node.go
+++ b/shamap/node.go
@@ -48,6 +48,13 @@ type NodeReader interface {
 	Type() NodeType
 }
 
+// InnerNodeReader exposes the child hashes of a serialized inner node.
+type InnerNodeReader interface {
+	NodeReader
+	ChildHash(index int) ([32]byte, error)
+	IsEmptyBranch(index int) bool
+}
+
 // Node defines the interface all tree nodes must implement.
 // Concrete nodes are either *innerNode or a LeafNode; callers
 // discriminate with a type switch.

--- a/shamap/nodestore_family.go
+++ b/shamap/nodestore_family.go
@@ -2,12 +2,18 @@ package shamap
 
 import (
 	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/storage/kvstore/memorydb"
 	kvpebble "github.com/LeJamon/go-xrpl/storage/kvstore/pebble"
 	"github.com/LeJamon/go-xrpl/storage/nodestore"
 )
+
+// ErrStoreBelowMinimum reports a write rejected by the online-delete floor.
+var ErrStoreBelowMinimum = errors.New("shamap: ledger is below the minimum online sequence")
 
 // NodeStoreFamily implements the Family interface by delegating to a nodestore.Database.
 // This is the production-quality Family implementation, matching rippled's NodeFamily
@@ -20,13 +26,22 @@ import (
 // For tests: use NewMemoryNodeStoreFamily() — in-memory, zero disk I/O.
 // For production: use NewPebbleNodeStoreFamily() with a persistent path.
 type NodeStoreFamily struct {
-	db nodestore.Database
+	db        nodestore.Database
+	fullBelow *FullBelowCache
+	storeMu   sync.RWMutex
+	minimum   atomic.Uint32
 }
 
 // NewNodeStoreFamily creates a Family backed by the given nodestore.Database.
 // The Database should already be opened and configured with caching.
 func NewNodeStoreFamily(db nodestore.Database) *NodeStoreFamily {
-	return &NodeStoreFamily{db: db}
+	return &NodeStoreFamily{db: db, fullBelow: NewFullBelowCache()}
+}
+
+// FullBelowCache returns the cache shared by every SHAMap backed by this
+// family.
+func (f *NodeStoreFamily) FullBelowCache() *FullBelowCache {
+	return f.fullBelow
 }
 
 // NewMemoryNodeStoreFamily creates a Family backed by an in-memory kvstore.
@@ -83,16 +98,37 @@ func (f *NodeStoreFamily) StoreBatch(ctx context.Context, entries []FlushEntry) 
 	if len(entries) == 0 {
 		return nil
 	}
+	f.storeMu.RLock()
+	defer f.storeMu.RUnlock()
+	floor := f.minimum.Load()
 
-	nodes := make([]*nodestore.Node, len(entries))
-	for i, e := range entries {
-		nodes[i] = &nodestore.Node{
-			Hash: nodestore.Hash256(e.Hash),
-			Data: e.Data,
-			Type: nodestore.NodeAccount, // NodeStore treats data as opaque; type is for categorization only
+	nodes := make([]*nodestore.Node, 0, len(entries))
+	for _, e := range entries {
+		if floor != 0 && e.LedgerSeq < floor {
+			return ErrStoreBelowMinimum
 		}
+		nodeType := nodestore.NodeAccount
+		if e.MapType == TypeTransaction {
+			nodeType = nodestore.NodeTransaction
+		}
+		nodes = append(nodes, &nodestore.Node{
+			Hash:      nodestore.Hash256(e.Hash),
+			Data:      e.Data,
+			Type:      nodeType,
+			LedgerSeq: e.LedgerSeq,
+		})
 	}
 	return f.db.StoreBatch(ctx, nodes)
+}
+
+// SetMinimumLedgerSeq waits for older family writes to finish, then rejects
+// new writes below the online-delete boundary.
+func (f *NodeStoreFamily) SetMinimumLedgerSeq(seq uint32) {
+	f.storeMu.Lock()
+	if seq > f.minimum.Load() {
+		f.minimum.Store(seq)
+	}
+	f.storeMu.Unlock()
 }
 
 // Sweep removes expired entries from the nodestore's caches.
@@ -100,6 +136,18 @@ func (f *NodeStoreFamily) StoreBatch(ctx context.Context, entries []FlushEntry) 
 // This matches rippled's pattern of calling sweep() on NodeFamily.
 func (f *NodeStoreFamily) Sweep() error {
 	return f.db.Sweep()
+}
+
+// ResetFullBelow invalidates completeness marks after the backing store is
+// rotated or otherwise replaces its node set.
+func (f *NodeStoreFamily) ResetFullBelow() {
+	f.fullBelow.Bump()
+}
+
+// BeginPrune invalidates full-below marks and blocks missing-node walks until
+// the returned function is called after the backing-store mutation.
+func (f *NodeStoreFamily) BeginPrune() func() {
+	return f.fullBelow.invalidateAndLock()
 }
 
 // Close gracefully shuts down the underlying nodestore, flushing any pending

--- a/shamap/nodestore_family_test.go
+++ b/shamap/nodestore_family_test.go
@@ -1,0 +1,126 @@
+package shamap
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/storage/nodestore"
+)
+
+type blockingNodeStore struct {
+	nodestore.Database
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingNodeStore) StoreBatch(ctx context.Context, nodes []*nodestore.Node) error {
+	blocked := false
+	s.once.Do(func() {
+		blocked = true
+		close(s.entered)
+	})
+	if blocked {
+		select {
+		case <-s.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return s.Database.StoreBatch(ctx, nodes)
+}
+
+func TestNodeStoreFamily_RejectsWritesBelowMinimumLedger(t *testing.T) {
+	ctx := context.Background()
+	family := NewMemoryNodeStoreFamily()
+	hash := [32]byte{0x91}
+	entry := FlushEntry{Hash: hash, Data: []byte("node"), LedgerSeq: 300, MapType: TypeState}
+	if err := family.StoreBatch(ctx, []FlushEntry{entry}); err != nil {
+		t.Fatal(err)
+	}
+
+	family.SetMinimumLedgerSeq(250)
+	entry.LedgerSeq = 200
+	if err := family.StoreBatch(ctx, []FlushEntry{entry}); !errors.Is(err, ErrStoreBelowMinimum) {
+		t.Fatalf("below-floor store error = %v, want %v", err, ErrStoreBelowMinimum)
+	}
+	stored, err := family.db.Fetch(ctx, nodestore.Hash256(hash))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored == nil || stored.LedgerSeq != 300 {
+		t.Fatalf("stored sequence = %v, want 300", stored)
+	}
+
+	family.SetMinimumLedgerSeq(100)
+	belowFloor := [32]byte{0x92}
+	entry.Hash = belowFloor
+	entry.LedgerSeq = 225
+	if err := family.StoreBatch(ctx, []FlushEntry{entry}); !errors.Is(err, ErrStoreBelowMinimum) {
+		t.Fatalf("monotonic floor store error = %v, want %v", err, ErrStoreBelowMinimum)
+	}
+	stored, err = family.db.Fetch(ctx, nodestore.Hash256(belowFloor))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored != nil {
+		t.Fatalf("minimum ledger sequence regressed: stored %+v", stored)
+	}
+}
+
+func TestNodeStoreFamily_MinimumWaitsForInFlightStore(t *testing.T) {
+	ctx := context.Background()
+	base := NewMemoryNodeStoreFamily().db
+	store := &blockingNodeStore{
+		Database: base,
+		entered:  make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	family := NewNodeStoreFamily(store)
+	oldHash := [32]byte{0xA1}
+	storeDone := make(chan error, 1)
+	go func() {
+		storeDone <- family.StoreBatch(ctx, []FlushEntry{{
+			Hash: oldHash, Data: []byte("old"), LedgerSeq: 100, MapType: TypeState,
+		}})
+	}()
+	<-store.entered
+
+	floorDone := make(chan struct{})
+	go func() {
+		family.SetMinimumLedgerSeq(200)
+		close(floorDone)
+	}()
+	select {
+	case <-floorDone:
+		t.Fatal("minimum advanced before the in-flight store completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(store.release)
+	if err := <-storeDone; err != nil {
+		t.Fatal(err)
+	}
+	<-floorDone
+	stored, err := base.Fetch(ctx, nodestore.Hash256(oldHash))
+	if err != nil || stored == nil {
+		t.Fatalf("in-flight store = %v, %v", stored, err)
+	}
+
+	newHash := [32]byte{0xA2}
+	if err := family.StoreBatch(ctx, []FlushEntry{{
+		Hash: newHash, Data: []byte("new"), LedgerSeq: 100, MapType: TypeState,
+	}}); !errors.Is(err, ErrStoreBelowMinimum) {
+		t.Fatalf("post-advance store error = %v, want %v", err, ErrStoreBelowMinimum)
+	}
+	stored, err = base.Fetch(ctx, nodestore.Hash256(newHash))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored != nil {
+		t.Fatalf("below-floor store after advance = %+v", stored)
+	}
+}

--- a/shamap/overlay_family.go
+++ b/shamap/overlay_family.go
@@ -14,6 +14,7 @@ import "context"
 type OverlayFamily struct {
 	base    Family
 	overlay Family
+	cache   *FullBelowCache
 }
 
 // NewOverlayFamily returns a Family that reads overlay-then-base and writes
@@ -22,7 +23,11 @@ func NewOverlayFamily(base, overlay Family) *OverlayFamily {
 	if base == nil || overlay == nil {
 		panic("shamap: NewOverlayFamily requires non-nil base and overlay")
 	}
-	return &OverlayFamily{base: base, overlay: overlay}
+	return &OverlayFamily{base: base, overlay: overlay, cache: NewFullBelowCache()}
+}
+
+func (f *OverlayFamily) FullBelowCache() *FullBelowCache {
+	return f.cache
 }
 
 // Fetch returns the node from the overlay if present, otherwise from the base.

--- a/shamap/overlay_family.go
+++ b/shamap/overlay_family.go
@@ -26,6 +26,7 @@ func NewOverlayFamily(base, overlay Family) *OverlayFamily {
 	return &OverlayFamily{base: base, overlay: overlay, cache: NewFullBelowCache()}
 }
 
+// FullBelowCache returns the cache shared by maps backed by this family.
 func (f *OverlayFamily) FullBelowCache() *FullBelowCache {
 	return f.cache
 }

--- a/shamap/shamap.go
+++ b/shamap/shamap.go
@@ -78,11 +78,8 @@ type SHAMap struct {
 	full      bool
 	backed    bool
 	family    Family // nil for unbacked maps
-	// fullBelow prunes completed subtrees from missing-node walks. Never
-	// nil: every constructor installs one and snapshot shares the source's
-	// so structurally-shared trees agree on which subtrees are proven
-	// complete. Shared across an acquisition's state and tx maps when the
-	// caller injects one via WithFullBelowCache.
+	// fullBelow prunes completed subtrees from missing-node walks. Backed maps
+	// share their family's cache; snapshots share the source map's cache.
 	fullBelow *FullBelowCache
 	// cachedSize memoises Size(); -1 = uncached. Only written once the
 	// map is immutable, so concurrent first-readers race benignly on a
@@ -117,7 +114,7 @@ func NewBacked(mapType Type, family Family) (*SHAMap, error) {
 		full:      true,
 		backed:    true,
 		family:    family,
-		fullBelow: NewFullBelowCache(),
+		fullBelow: familyFullBelowCache(family),
 	}
 	sm.cachedSize.Store(-1)
 	return sm, nil
@@ -130,6 +127,9 @@ func (sm *SHAMap) SetFamily(family Family) {
 	defer sm.mu.Unlock()
 	sm.family = family
 	sm.backed = family != nil
+	if family != nil {
+		sm.fullBelow = familyFullBelowCache(family)
+	}
 }
 
 // NewFromRootHash creates a backed SHAMap from a root hash and a Family.
@@ -167,7 +167,7 @@ func NewFromRootHash(mapType Type, rootHash [32]byte, family Family) (*SHAMap, e
 		full:      true,
 		backed:    true,
 		family:    family,
-		fullBelow: NewFullBelowCache(),
+		fullBelow: familyFullBelowCache(family),
 	}
 	sm.cachedSize.Store(-1)
 	return sm, nil
@@ -694,14 +694,10 @@ func (sm *SHAMap) SnapshotImmutable() (*SHAMap, error) {
 // node's own lock.
 func (sm *SHAMap) snapshot(mutable bool) (*SHAMap, error) {
 	if sm.backed && sm.family != nil {
-		batch, err := sm.flushDirty(false)
-		if err != nil {
-			return nil, fmt.Errorf("failed to flush dirty nodes: %w", err)
-		}
-		if len(batch.Entries) > 0 {
-			if err := sm.family.StoreBatch(context.Background(), batch.Entries); err != nil {
-				return nil, fmt.Errorf("failed to store flushed nodes: %w", err)
-			}
+		if err := sm.StoreDirty(func(entries []FlushEntry) error {
+			return sm.family.StoreBatch(context.Background(), entries)
+		}); err != nil {
+			return nil, fmt.Errorf("failed to store dirty nodes: %w", err)
 		}
 	}
 

--- a/shamap/shamap.go
+++ b/shamap/shamap.go
@@ -78,6 +78,12 @@ type SHAMap struct {
 	full      bool
 	backed    bool
 	family    Family // nil for unbacked maps
+	// fullBelow prunes completed subtrees from missing-node walks. Never
+	// nil: every constructor installs one and snapshot shares the source's
+	// so structurally-shared trees agree on which subtrees are proven
+	// complete. Shared across an acquisition's state and tx maps when the
+	// caller injects one via WithFullBelowCache.
+	fullBelow *FullBelowCache
 	// cachedSize memoises Size(); -1 = uncached. Only written once the
 	// map is immutable, so concurrent first-readers race benignly on a
 	// frozen tree.
@@ -87,11 +93,12 @@ type SHAMap struct {
 // New creates a new empty SHAMap with the specified type
 func New(mapType Type) *SHAMap {
 	sm := &SHAMap{
-		root:    newInnerNode(),
-		mapType: mapType,
-		state:   StateModifying,
-		full:    true,
-		backed:  false,
+		root:      newInnerNode(),
+		mapType:   mapType,
+		state:     StateModifying,
+		full:      true,
+		backed:    false,
+		fullBelow: NewFullBelowCache(),
 	}
 	sm.cachedSize.Store(-1)
 	return sm
@@ -104,12 +111,13 @@ func NewBacked(mapType Type, family Family) (*SHAMap, error) {
 		return nil, ErrNilFamily
 	}
 	sm := &SHAMap{
-		root:    newInnerNode(),
-		mapType: mapType,
-		state:   StateModifying,
-		full:    true,
-		backed:  true,
-		family:  family,
+		root:      newInnerNode(),
+		mapType:   mapType,
+		state:     StateModifying,
+		full:      true,
+		backed:    true,
+		family:    family,
+		fullBelow: NewFullBelowCache(),
 	}
 	sm.cachedSize.Store(-1)
 	return sm, nil
@@ -153,12 +161,13 @@ func NewFromRootHash(mapType Type, rootHash [32]byte, family Family) (*SHAMap, e
 	}
 
 	sm := &SHAMap{
-		root:    root,
-		mapType: mapType,
-		state:   StateModifying,
-		full:    true,
-		backed:  true,
-		family:  family,
+		root:      root,
+		mapType:   mapType,
+		state:     StateModifying,
+		full:      true,
+		backed:    true,
+		family:    family,
+		fullBelow: NewFullBelowCache(),
 	}
 	sm.cachedSize.Store(-1)
 	return sm, nil
@@ -716,6 +725,7 @@ func (sm *SHAMap) snapshot(mutable bool) (*SHAMap, error) {
 		full:      sm.full,
 		backed:    sm.backed,
 		family:    sm.family,
+		fullBelow: sm.fullBelow,
 	}
 	out.cachedSize.Store(-1)
 	// Immutable→immutable snapshot observes the same leaf set; carry the
@@ -790,4 +800,11 @@ func (sm *SHAMap) createTypedLeaf(nodeType NodeType, item *Item) (LeafNode, erro
 // IsBacked returns true if this SHAMap is backed by a NodeStore.
 func (sm *SHAMap) IsBacked() bool {
 	return sm.backed
+}
+
+// FullBelowCache returns the map's full-below cache. Snapshots share the
+// source's cache, so a snapshot and its source agree on which subtrees are
+// proven complete.
+func (sm *SHAMap) FullBelowCache() *FullBelowCache {
+	return sm.fullBelow
 }

--- a/shamap/store.go
+++ b/shamap/store.go
@@ -9,8 +9,10 @@ import (
 
 // FlushEntry holds a serialized node ready to be written to NodeStore.
 type FlushEntry struct {
-	Hash [32]byte // SHAMap node hash (used as key in NodeStore)
-	Data []byte   // SerializeWithPrefix() output
+	Hash      [32]byte // SHAMap node hash (used as key in NodeStore)
+	Data      []byte   // SerializeWithPrefix() output
+	LedgerSeq uint32
+	MapType   Type
 }
 
 // NodeBatch holds a batch of serialized nodes from FlushDirty().

--- a/shamap/store_test.go
+++ b/shamap/store_test.go
@@ -316,6 +316,54 @@ func TestFlushDirty_Idempotent(t *testing.T) {
 	}
 }
 
+func TestStoreDirty_RetainsNodesAfterStoreFailure(t *testing.T) {
+	sMap := New(TypeState)
+	sMap.SetLedgerSeq(42)
+	key := hexToHash("092891fe4ef6cee585fdc6fda0e09eb4d386363158ec3321b8123e5a772c6ca7")
+	if err := sMap.Put(key, intToBytes(1)); err != nil {
+		t.Fatal(err)
+	}
+
+	wantErr := fmt.Errorf("store failed")
+	var failedEntries []FlushEntry
+	if err := sMap.StoreDirty(func(entries []FlushEntry) error {
+		failedEntries = append(failedEntries, entries...)
+		return wantErr
+	}); err != wantErr {
+		t.Fatalf("StoreDirty error = %v, want %v", err, wantErr)
+	}
+	if len(failedEntries) == 0 {
+		t.Fatal("failed store received no entries")
+	}
+	for _, entry := range failedEntries {
+		if entry.LedgerSeq != 42 || entry.MapType != TypeState {
+			t.Fatalf("entry metadata = (%d, %d), want (42, %d)", entry.LedgerSeq, entry.MapType, TypeState)
+		}
+	}
+
+	var retryEntries []FlushEntry
+	if err := sMap.StoreDirty(func(entries []FlushEntry) error {
+		retryEntries = append(retryEntries, entries...)
+		return nil
+	}); err != nil {
+		t.Fatalf("StoreDirty retry: %v", err)
+	}
+	if len(retryEntries) != len(failedEntries) {
+		t.Fatalf("retry entries = %d, want %d", len(retryEntries), len(failedEntries))
+	}
+
+	called := false
+	if err := sMap.StoreDirty(func([]FlushEntry) error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("StoreDirty after success: %v", err)
+	}
+	if called {
+		t.Fatal("StoreDirty called store after dirty nodes were persisted")
+	}
+}
+
 // TestFlushDirty_AfterModification verifies only modified nodes are re-flushed.
 func TestFlushDirty_AfterModification(t *testing.T) {
 	sMap := New(TypeState)

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -563,6 +563,7 @@ func (sm *SHAMap) insertNodeRecursive(current Node, targetHash [32]byte, newNode
 
 		if bytes.Equal(childHash[:], targetHash[:]) {
 			// Found the branch - insert the node here
+			newNode.SetDirty(true)
 			return inner.SetChild(branch, newNode)
 		}
 
@@ -570,6 +571,7 @@ func (sm *SHAMap) insertNodeRecursive(current Node, targetHash [32]byte, newNode
 			// Recurse into this inner node
 			err := sm.insertNodeRecursive(child, targetHash, newNode, depth+1)
 			if err == nil {
+				inner.SetDirty(true)
 				return nil // Successfully inserted
 			}
 			// Continue searching other branches if not found

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -140,7 +140,8 @@ func (sm *SHAMap) WalkMapParallel(maxMissing int, filter SyncFilter) []MissingNo
 		branch   int
 	}
 
-	gen, cache := fullBelowContext(sm)
+	gen, cache, done := fullBelowContext(sm)
+	defer done()
 	backed := sm != nil && sm.backed && cache != nil
 
 	sm.mu.RLock()
@@ -194,7 +195,7 @@ func (sm *SHAMap) WalkMapParallel(maxMissing int, filter SyncFilter) []MissingNo
 		}
 		// Backed short-circuit: a released depth-1 child proven full-below
 		// needs no fetch or descent.
-		if child == nil && backed && cache.Has(childHash) {
+		if child == nil && backed && cache.Has(gen, childHash) {
 			continue
 		}
 		if child == nil {
@@ -239,7 +240,7 @@ func (sm *SHAMap) WalkMapParallel(maxMissing int, filter SyncFilter) []MissingNo
 		markRoot := rootComplete && !stopped
 		mu.Unlock()
 		if markRoot {
-			markRootFullBelow(root, rootHash, gen, backed, cache)
+			markRootFullBelow(root, gen)
 		}
 		return missing
 	}
@@ -276,19 +277,15 @@ func (sm *SHAMap) WalkMapParallel(maxMissing int, filter SyncFilter) []MissingNo
 	markRoot := rootComplete && allSub && !stopped && !anyStopped.Load()
 	mu.Unlock()
 	if markRoot {
-		markRootFullBelow(root, rootHash, gen, backed, cache)
+		markRootFullBelow(root, gen)
 	}
 
 	return missing
 }
 
-// markRootFullBelow records the root as full-below at gen and, for backed
-// maps, in the family cache. Shared by both WalkMapParallel return paths.
-func markRootFullBelow(root *innerNode, rootHash [32]byte, gen uint32, backed bool, cache *FullBelowCache) {
+// markRootFullBelow records the root as full-below at gen.
+func markRootFullBelow(root *innerNode, gen uint32) {
 	root.setFullBelowGen(gen)
-	if backed {
-		cache.Insert(rootHash)
-	}
 }
 
 // GetMissingNodes returns the nodes referenced by the tree but not
@@ -471,8 +468,10 @@ func (sm *SHAMap) attachKnownNodeAt(nodeID NodeID, deserialize func() (Node, err
 	targetPath := nodeID.ID()
 
 	parent := sm.root
+	ancestors := make([]*innerNode, 0, targetDepth)
 
 	for curDepth := range targetDepth {
+		ancestors = append(ancestors, parent)
 		branch := selectBranchForPath(targetPath, curDepth)
 
 		child, childHash, isSet := parent.LoadChild(branch)
@@ -502,7 +501,13 @@ func (sm *SHAMap) attachKnownNodeAt(nodeID NodeID, deserialize func() (Node, err
 			if newNode.Hash() != childHash {
 				return NodeInvalid, ErrNodeHashMismatch
 			}
-			parent.SetChildIfNil(branch, newNode)
+			if parent.SetChildIfNil(branch, newNode) != newNode {
+				return NodeDuplicate, nil
+			}
+			newNode.SetDirty(true)
+			for _, ancestor := range ancestors {
+				ancestor.SetDirty(true)
+			}
 			return NodeUseful, nil
 		}
 
@@ -618,6 +623,7 @@ func (sm *SHAMap) AddRootNode(hash [32]byte, data []byte) error {
 	}
 
 	sm.root = root
+	root.SetDirty(true)
 	sm.state = StateSyncing
 	// Clear full as StartSync does: a stale full lets IsComplete report
 	// complete while the FinishSync walk still finds missing nodes.

--- a/shamap/sync.go
+++ b/shamap/sync.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 )
 
 // Sync-related errors
@@ -139,22 +140,33 @@ func (sm *SHAMap) WalkMapParallel(maxMissing int, filter SyncFilter) []MissingNo
 		branch   int
 	}
 
+	gen, cache := fullBelowContext(sm)
+	backed := sm != nil && sm.backed && cache != nil
+
 	sm.mu.RLock()
 	if sm.root == nil || sm.state == StateInvalid {
 		sm.mu.RUnlock()
 		return nil
 	}
+	root := sm.root
 	rootID := NewRootNodeID()
-	rootHash := sm.root.Hash()
+	rootHash := root.Hash()
+
+	// The whole tree was already proven complete — prune it.
+	if root.isFullBelow(gen) {
+		sm.mu.RUnlock()
+		return nil
+	}
 
 	// Capture every non-empty root branch under the source-map lock.
 	// Hash-only branches at depth 1 are reported synchronously here
 	// because they have no subtree to walk.
 	var (
-		mu       sync.Mutex
-		missing  []MissingNode
-		stopped  bool
-		subtrees = make([]subtreeStart, 0, BranchFactor)
+		mu           sync.Mutex
+		missing      []MissingNode
+		stopped      bool
+		rootComplete = true // every depth-1 branch resident and full-below
+		subtrees     = make([]subtreeStart, 0, BranchFactor)
 	)
 
 	reportLocked := func(m MissingNode) bool {
@@ -172,7 +184,7 @@ func (sm *SHAMap) WalkMapParallel(maxMissing int, filter SyncFilter) []MissingNo
 	}
 
 	for branch := range BranchFactor {
-		child, childHash, isSet := sm.root.LoadChild(branch)
+		child, childHash, isSet := root.LoadChild(branch)
 		if !isSet {
 			continue
 		}
@@ -180,14 +192,20 @@ func (sm *SHAMap) WalkMapParallel(maxMissing int, filter SyncFilter) []MissingNo
 		if err != nil {
 			continue
 		}
+		// Backed short-circuit: a released depth-1 child proven full-below
+		// needs no fetch or descent.
+		if child == nil && backed && cache.Has(childHash) {
+			continue
+		}
 		if child == nil {
 			// Lenient request path: a transient fetch failure reports the
 			// branch missing (self-corrects via the wire).
-			if loaded, _ := loadFromStore(sm, sm.root, branch); loaded != nil {
+			if loaded, _ := loadFromStore(sm, root, branch); loaded != nil {
 				child = loaded
 			}
 		}
 		if child == nil {
+			rootComplete = false
 			if filter.ShouldFetch(childHash) {
 				if reportLocked(MissingNode{
 					Hash:       childHash,
@@ -215,29 +233,62 @@ func (sm *SHAMap) WalkMapParallel(maxMissing int, filter SyncFilter) []MissingNo
 	sm.mu.RUnlock()
 
 	if len(subtrees) == 0 {
+		// No inner subtrees to fan out. Mark the root complete when every
+		// depth-1 branch was resident-and-full-below and nothing stopped.
+		mu.Lock()
+		markRoot := rootComplete && !stopped
+		mu.Unlock()
+		if markRoot {
+			markRootFullBelow(root, rootHash, gen, backed, cache)
+		}
 		return missing
 	}
 
+	subFull := make([]bool, len(subtrees))
+	var anyStopped atomic.Bool
 	var wg sync.WaitGroup
 	wg.Add(len(subtrees))
-	for _, s := range subtrees {
+	for i, s := range subtrees {
 		go func() {
 			defer wg.Done()
-			_, _ = walkSubtreeForMissing(
-				sm,
-				s.node,
-				s.nodeID,
-				s.nodeHash,
-				1,
-				filter,
-				false,
-				reportLocked,
+			full, stop, _ := walkFullBelow(
+				sm, s.node, s.nodeID, s.nodeHash, 1, gen, filter, false, cache, reportLocked,
 			)
+			subFull[i] = full
+			if stop {
+				anyStopped.Store(true)
+			}
 		}()
 	}
 	wg.Wait()
 
+	// Mark the root full-below only when every branch — those handled
+	// inline and every fanned-out subtree — came back complete and no
+	// worker was cut short by the missing cap.
+	allSub := true
+	for _, f := range subFull {
+		if !f {
+			allSub = false
+			break
+		}
+	}
+	mu.Lock()
+	markRoot := rootComplete && allSub && !stopped && !anyStopped.Load()
+	mu.Unlock()
+	if markRoot {
+		markRootFullBelow(root, rootHash, gen, backed, cache)
+	}
+
 	return missing
+}
+
+// markRootFullBelow records the root as full-below at gen and, for backed
+// maps, in the family cache. Shared by both WalkMapParallel return paths.
+func markRootFullBelow(root *innerNode, rootHash [32]byte, gen uint32, backed bool, cache *FullBelowCache) {
+	root.setFullBelowGen(gen)
+	if backed {
+		cache.Insert(rootHash)
+	}
 }
 
 // GetMissingNodes returns the nodes referenced by the tree but not

--- a/shamap/sync_test.go
+++ b/shamap/sync_test.go
@@ -515,6 +515,67 @@ func TestAddKnownNodeByID_RippledStyleReconstruct(t *testing.T) {
 	}
 }
 
+func TestAddKnownNode_StoreDirtyPersistsAcquiredNodes(t *testing.T) {
+	source := New(TypeTransaction)
+	for branch := range byte(4) {
+		for sub := range byte(4) {
+			var key [32]byte
+			key[0] = (branch << 4) | sub
+			key[1] = 0x80
+			if err := source.Put(key, []byte{branch, sub, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x11, 0x22, 0x33, 0x44, 0x55}); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+		}
+	}
+
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("source hash: %v", err)
+	}
+	rootData, err := source.SerializeRoot()
+	if err != nil {
+		t.Fatalf("SerializeRoot: %v", err)
+	}
+	wireNodes, err := source.WalkWireNodes()
+	if err != nil {
+		t.Fatalf("WalkWireNodes: %v", err)
+	}
+
+	dest := New(TypeTransaction)
+	if err := dest.StartSync(); err != nil {
+		t.Fatalf("StartSync: %v", err)
+	}
+	if err := dest.AddRootNode(rootHash, rootData); err != nil {
+		t.Fatalf("AddRootNode: %v", err)
+	}
+	for _, wire := range wireNodes[1:] {
+		node, err := deserializeNodeFromWire(wire.Data)
+		if err != nil {
+			t.Fatalf("deserialize acquired node: %v", err)
+		}
+		if err := node.UpdateHash(); err != nil {
+			t.Fatalf("hash acquired node: %v", err)
+		}
+		if err := dest.AddKnownNode(node.Hash(), wire.Data); err != nil {
+			t.Fatalf("AddKnownNode: %v", err)
+		}
+	}
+	if err := dest.FinishSync(); err != nil {
+		t.Fatalf("FinishSync: %v", err)
+	}
+
+	var stored []FlushEntry
+	if err := dest.StoreDirty(func(entries []FlushEntry) error {
+		stored = append(stored, entries...)
+		return nil
+	}); err != nil {
+		t.Fatalf("StoreDirty: %v", err)
+	}
+	if len(stored) != len(wireNodes) {
+		t.Fatalf("stored acquired nodes = %d, want %d", len(stored), len(wireNodes))
+	}
+}
+
 func TestAddKnownNodeByID_SentinelErrors(t *testing.T) {
 	source := New(TypeTransaction)
 	for branch := range byte(3) {

--- a/shamap/sync_test.go
+++ b/shamap/sync_test.go
@@ -496,6 +496,23 @@ func TestAddKnownNodeByID_RippledStyleReconstruct(t *testing.T) {
 	if destHash != rootHash {
 		t.Errorf("reconstructed hash mismatch: want %x got %x", rootHash[:8], destHash[:8])
 	}
+
+	dest.SetLedgerSeq(123)
+	var stored []FlushEntry
+	if err := dest.StoreDirty(func(entries []FlushEntry) error {
+		stored = append(stored, entries...)
+		return nil
+	}); err != nil {
+		t.Fatalf("StoreDirty: %v", err)
+	}
+	if len(stored) != len(wireNodes) {
+		t.Fatalf("stored acquired nodes = %d, want %d", len(stored), len(wireNodes))
+	}
+	for _, entry := range stored {
+		if entry.LedgerSeq != 123 || entry.MapType != TypeTransaction {
+			t.Fatalf("stored metadata = (%d, %d), want (123, %d)", entry.LedgerSeq, entry.MapType, TypeTransaction)
+		}
+	}
 }
 
 func TestAddKnownNodeByID_SentinelErrors(t *testing.T) {

--- a/shamap/traverse.go
+++ b/shamap/traverse.go
@@ -301,7 +301,7 @@ func walkFullBelow(
 		// Backed short-circuit: a released (hash-only) child proven
 		// full-below in the family cache needs neither a store fetch nor a
 		// re-descent of its subtree.
-		if child == nil && backed && cache.Has(childHash) {
+		if child == nil && backed && cache.Has(gen, childHash) {
 			continue
 		}
 
@@ -357,9 +357,6 @@ func walkFullBelow(
 
 	if fullBelow {
 		node.setFullBelowGen(gen)
-		if backed {
-			cache.Insert(nodeHash)
-		}
 	}
 	return fullBelow, false, nil
 }
@@ -380,7 +377,8 @@ func walkSubtreeForMissing(
 	strict bool,
 	report func(MissingNode) bool,
 ) (bool, error) {
-	gen, cache := fullBelowContext(sm)
+	gen, cache, done := fullBelowContext(sm)
+	defer done()
 	_, stopped, err := walkFullBelow(sm, start, startID, startHash, startDepth, gen, filter, strict, cache, report)
 	return stopped, err
 }
@@ -389,11 +387,12 @@ func walkSubtreeForMissing(
 // use. Every constructed SHAMap installs a cache, but defend against a
 // zero-value map by falling back to generation 0 (which no node ever
 // matches, disabling the prune) and a nil cache.
-func fullBelowContext(sm *SHAMap) (uint32, *FullBelowCache) {
+func fullBelowContext(sm *SHAMap) (uint32, *FullBelowCache, func()) {
 	if sm == nil || sm.fullBelow == nil {
-		return 0, nil
+		return 0, nil, func() {}
 	}
-	return sm.fullBelow.Generation(), sm.fullBelow
+	gen, done := sm.fullBelow.Begin()
+	return gen, sm.fullBelow, done
 }
 
 // loadFromStore lazy-fetches a hash-only branch from the backing store and

--- a/shamap/traverse.go
+++ b/shamap/traverse.go
@@ -243,16 +243,133 @@ func (sm *SHAMap) boundBelow(node Node, ascending bool) (LeafNode, error) {
 	return nil, nil
 }
 
-// walkSubtreeForMissing is the BFS-over-one-subtree primitive used by
-// WalkMap, WalkMapParallel, GetMissingNodes and the sync completeness
-// checks. It walks the subtree rooted at start and invokes report for
-// every non-empty branch whose child node is neither in memory nor
-// recoverable from sm's family.
+// walkFullBelow is the full-below-aware DFS behind WalkMap, WalkMapParallel,
+// GetMissingNodes and the sync completeness checks. It walks the subtree
+// rooted at node, invoking report for every non-empty branch whose child is
+// neither in memory nor recoverable from sm's family, and marking each
+// subtree it proves complete full-below at generation gen so a later walk
+// prunes it in O(1) instead of re-descending it. Mirrors rippled's
+// SHAMap::gmn_ProcessNodes (xrpld/shamap/detail/SHAMapSync.cpp).
 //
-// On a transient family fetch failure: strict=false reports the branch
+// Returns:
+//   - fullBelow: every descendant of node is resident AND the walk covered
+//     them all. Only then is node marked; an ancestor is marked only once
+//     all of its children come back fullBelow. A missing child, a filtered
+//     child, a report-driven stop, or a strict error all leave fullBelow
+//     false so a node is never marked while a descendant is absent.
+//   - stopped: report asked to stop (the maxMissing cap). The caller must
+//     unwind without marking anything above.
+//   - err: a transient family error in strict mode.
+//
+// On a transient family fetch failure: strict=false treats the branch as
 // missing (rippled's getMissingNodes collapse, self-correcting via the
-// wire); strict=true aborts with the error so FinishSync/IsComplete never
-// fabricate a missing node or conclude complete over a skipped subtree.
+// wire); strict=true aborts so FinishSync/IsComplete never fabricate a
+// missing node or conclude complete over a skipped subtree.
+func walkFullBelow(
+	sm *SHAMap,
+	node *innerNode,
+	nodeID NodeID,
+	nodeHash [32]byte,
+	depth int,
+	gen uint32,
+	filter SyncFilter,
+	strict bool,
+	cache *FullBelowCache,
+	report func(MissingNode) bool,
+) (fullBelow, stopped bool, err error) {
+	if node == nil {
+		return true, false, nil
+	}
+	// Proven complete this generation — prune the whole subtree.
+	if node.isFullBelow(gen) {
+		return true, false, nil
+	}
+
+	backed := sm != nil && sm.backed && cache != nil
+	fullBelow = true
+
+	for branch := range BranchFactor {
+		child, childHash, isSet := node.LoadChild(branch)
+		if !isSet {
+			continue
+		}
+		childNodeID, cerr := nodeID.ChildNodeID(uint8(branch))
+		if cerr != nil {
+			continue
+		}
+
+		// Backed short-circuit: a released (hash-only) child proven
+		// full-below in the family cache needs neither a store fetch nor a
+		// re-descent of its subtree.
+		if child == nil && backed && cache.Has(childHash) {
+			continue
+		}
+
+		if child == nil {
+			loaded, lerr := loadFromStore(sm, node, branch)
+			if lerr != nil {
+				if strict {
+					return false, false, lerr
+				}
+				// lenient: treat as missing below
+			}
+			if loaded != nil {
+				child = loaded
+			}
+		}
+
+		if child == nil {
+			fullBelow = false
+			if !filter.ShouldFetch(childHash) {
+				continue
+			}
+			if report(MissingNode{
+				Hash:       childHash,
+				Depth:      depth + 1,
+				ParentHash: nodeHash,
+				Branch:     branch,
+				NodeID:     childNodeID,
+			}) {
+				return false, true, nil
+			}
+			continue
+		}
+
+		inner, ok := child.(*innerNode)
+		if !ok {
+			// Leaf: resident, contributes to full-below.
+			continue
+		}
+
+		childFull, childStopped, cerr2 := walkFullBelow(
+			sm, inner, childNodeID, childHash, depth+1, gen, filter, strict, cache, report,
+		)
+		if cerr2 != nil {
+			return false, false, cerr2
+		}
+		if childStopped {
+			return false, true, nil
+		}
+		if !childFull {
+			fullBelow = false
+		}
+	}
+
+	if fullBelow {
+		node.setFullBelowGen(gen)
+		if backed {
+			cache.Insert(nodeHash)
+		}
+	}
+	return fullBelow, false, nil
+}
+
+// walkSubtreeForMissing walks the subtree rooted at start, reporting every
+// non-empty branch whose child node is neither in memory nor recoverable
+// from sm's family, and pruning/marking completed subtrees via the map's
+// full-below cache. It returns (stopped, err) — stopped reports whether
+// report asked to stop. Callers that need the subtree's full-below result
+// (to mark the parent) call walkFullBelow directly.
 func walkSubtreeForMissing(
 	sm *SHAMap,
 	start *innerNode,
@@ -263,79 +380,20 @@ func walkSubtreeForMissing(
 	strict bool,
 	report func(MissingNode) bool,
 ) (bool, error) {
-	type workItem struct {
-		node     *innerNode
-		nodeID   NodeID
-		nodeHash [32]byte
-		depth    int
+	gen, cache := fullBelowContext(sm)
+	_, stopped, err := walkFullBelow(sm, start, startID, startHash, startDepth, gen, filter, strict, cache, report)
+	return stopped, err
+}
+
+// fullBelowContext returns the generation and cache a walk over sm should
+// use. Every constructed SHAMap installs a cache, but defend against a
+// zero-value map by falling back to generation 0 (which no node ever
+// matches, disabling the prune) and a nil cache.
+func fullBelowContext(sm *SHAMap) (uint32, *FullBelowCache) {
+	if sm == nil || sm.fullBelow == nil {
+		return 0, nil
 	}
-
-	queue := make([]workItem, 0, 64)
-	queue = append(queue, workItem{
-		node:     start,
-		nodeID:   startID,
-		nodeHash: startHash,
-		depth:    startDepth,
-	})
-
-	for len(queue) > 0 {
-		item := queue[0]
-		queue = queue[1:]
-
-		if item.node == nil {
-			continue
-		}
-
-		for branch := range BranchFactor {
-			child, childHash, isSet := item.node.LoadChild(branch)
-			if !isSet {
-				continue
-			}
-
-			childNodeID, err := item.nodeID.ChildNodeID(uint8(branch))
-			if err != nil {
-				continue
-			}
-
-			if child == nil {
-				loaded, lerr := loadFromStore(sm, item.node, branch)
-				if lerr != nil && strict {
-					return false, lerr
-				}
-				if loaded != nil {
-					child = loaded
-				}
-			}
-
-			if child == nil {
-				if !filter.ShouldFetch(childHash) {
-					continue
-				}
-				if report(MissingNode{
-					Hash:       childHash,
-					Depth:      item.depth + 1,
-					ParentHash: item.nodeHash,
-					Branch:     branch,
-					NodeID:     childNodeID,
-				}) {
-					return true, nil
-				}
-				continue
-			}
-
-			inner, ok := child.(*innerNode)
-			if !ok {
-				continue
-			}
-			queue = append(queue, workItem{
-				node:     inner,
-				nodeID:   childNodeID,
-				nodeHash: childHash,
-				depth:    item.depth + 1,
-			})
-		}
-	}
-	return false, nil
+	return sm.fullBelow.Generation(), sm.fullBelow
 }
 
 // loadFromStore lazy-fetches a hash-only branch from the backing store and

--- a/storage/nodestore/prune.go
+++ b/storage/nodestore/prune.go
@@ -20,15 +20,10 @@ type PrunableDatabase interface {
 	Database
 
 	// DeleteBefore removes every stored node whose LedgerSeq is strictly below
-	// boundary, returning the number of nodes deleted. The production node store
-	// holds two kinds of seq-stamped record: the live state leaves and the
-	// per-ledger headers, both re-written every ledger at the current sequence
-	// (the live state map is not backed by a NodeStoreFamily in production, so
-	// no LedgerSeq=0 inner nodes are written, and transaction trees live in the
-	// relational index, not here). A leaf still part of recent state therefore
-	// always carries a LedgerSeq at or above the retained range and is immune;
-	// only the superseded copies of state leaves and old ledger headers carry a
-	// LedgerSeq below the boundary.
+	// boundary, returning the number of nodes deleted. Before pruning, online
+	// deletion re-stamps the complete validated state tree at the current ledger
+	// sequence so every node reachable from the live root remains above the
+	// boundary.
 	//
 	// Deletion is performed in batches of at most batchSize keys (a non-positive
 	// batchSize selects a default). The context is honoured between batches so a

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -262,7 +262,7 @@ Target: `v3.0.0`. Behavioral oracle: clean local rippled `3.2.0` worktree at
       vet, lint, and the broad repository test gate.
 - [x] Review the full diff for correctness, concurrency, failure paths, and test
       coverage; record exact verification results below.
-- [ ] Commit only intentional files, push the issue branch, and open a PR with
+- [x] Commit only intentional files, push the issue branch, and open a PR with
       base `v3.0.0` and `Fixes #1302`.
 
 ## Review
@@ -276,3 +276,5 @@ Verification: focused package tests and race suites pass; `just vet`,
 `just build-all`, and `just lint` pass with zero issues. `go test ./...` passes
 all packages except the existing `internal/testing/conformance` Vault, Batch,
 and XChain backlog, which is outside this diff.
+
+PR: https://github.com/LeJamon/go-xrpl/pull/1319

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -233,3 +233,46 @@ Verification:
 - `just build`, `just vet`, and `just lint` pass; lint reports 0 issues.
 - The staged merge has no unmerged paths, conflict markers, or whitespace
   errors.
+
+# Issue #1302 — testnet sync scalability and durability
+
+Target: `v3.0.0`. Behavioral oracle: clean local rippled `3.2.0` worktree at
+`3c43f4614f87965298773279ff5b85d4c56c637b`.
+
+## Plan
+
+- [x] B1: make missing-node discovery retain full-below knowledge so repeated
+      inbound replies resume at unresolved frontiers instead of rescanning the
+      state-map root.
+- [x] H1: reject stray or failed `liBASE` catch-up adoption unless the acquired
+      ledger has complete, verified state matching its header roots; preserve
+      acquisition eligibility after rejection.
+- [x] B2: persist only state nodes introduced since the validated parent while
+      retaining complete ledgers and safe retry/backpressure behavior.
+- [x] H4: stamp family-flushed SHAMap nodes with the owning ledger sequence so
+      online deletion cannot collect the live content-addressed state tree.
+- [x] B3: restore the latest complete durable validated ledger on startup and
+      honor configured history bounds rather than resetting to synthetic genesis.
+- [x] Discovery: allow peer endpoint exchange to converge during initial sync
+      once a peer quorum agrees on a ledger even when the local synthetic
+      genesis cannot yet be classified as tracking.
+- [x] Add focused regression, lifecycle, persistence, pruning, and restart tests
+      for every behavior; use rippled 3.2.0 as the protocol/operational oracle.
+- [x] Run format, focused tests, race-sensitive suites where applicable, build,
+      vet, lint, and the broad repository test gate.
+- [x] Review the full diff for correctness, concurrency, failure paths, and test
+      coverage; record exact verification results below.
+- [ ] Commit only intentional files, push the issue branch, and open a PR with
+      base `v3.0.0` and `Fixes #1302`.
+
+## Review
+
+Implemented full-below frontier pruning, complete-state-only initial adoption,
+delta node persistence, crash-safe online deletion, validated-tip fast load,
+retention-floor wiring, and initial-sync peer tracking. Protocol and operational
+behavior was audited against local rippled 3.2.0 at `3c43f4614f87965298773279ff5b85d4c56c637b`.
+
+Verification: focused package tests and race suites pass; `just vet`,
+`just build-all`, and `just lint` pass with zero issues. `go test ./...` passes
+all packages except the existing `internal/testing/conformance` Vault, Batch,
+and XChain backlog, which is outside this diff.


### PR DESCRIPTION
## Summary

- bound missing-node traversal with a shared generation-safe full-below cache and persist only acquired SHAMap deltas
- require complete state before initial ledger adoption, improve peer tracking discovery, and make persistence shutdown-safe
- make online deletion crash-safe with durable retention floors, health gates, and prune/write coordination
- fast-load only a durably marked validated ledger tip and wire node-size, cache-age, and earliest-sequence startup settings

## Behavioral oracle

Audited against the clean local rippled v3.2.0 worktree at 3c43f4614f87965298773279ff5b85d4c56c637b.

## Verification

- focused tests: shamap, inbound acquisition, ledger service, SHAMap store, node
- race tests: shamap, inbound acquisition, ledger service, SHAMap store, consensus adaptor, peer management
- just vet
- just build-all
- just lint: 0 issues
- go test ./... passes outside the existing conformance backlog in Vault, Batch, and XChain

Fixes #1302