### PR TITLE
fix: align Vault replay and transaction behavior

### DIFF
--- a/internal/ledger/state/number_asset_test.go
+++ b/internal/ledger/state/number_asset_test.go
@@ -7,16 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMantissaScaleForRules(t *testing.T) {
-	t.Parallel()
-	// large when no rules, or when either amendment is enabled; small otherwise.
-	require.Equal(t, MantissaScaleLarge, MantissaScaleForRules(false, false, false))
-	require.Equal(t, MantissaScaleLarge, MantissaScaleForRules(true, true, false))
-	require.Equal(t, MantissaScaleLarge, MantissaScaleForRules(true, false, true))
-	require.Equal(t, MantissaScaleLarge, MantissaScaleForRules(true, true, true))
-	require.Equal(t, MantissaScaleSmall, MantissaScaleForRules(true, false, false))
-}
-
 func TestRoundToAsset_Integral(t *testing.T) {
 	t.Parallel()
 	// A fractional drops value rounds to the nearest whole unit.

--- a/internal/ledger/state/xrpl_number.go
+++ b/internal/ledger/state/xrpl_number.go
@@ -42,8 +42,10 @@ package state
 // crashes from a peer-fed amount overflow.
 
 import (
+	"fmt"
 	"math/big"
 	"math/bits"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -66,30 +68,42 @@ const (
 	// MantissaScaleSmall is the historical IOU range [10^15, 10^16-1]. It is the
 	// zero value, so the unscaled constructors default to it.
 	MantissaScaleSmall MantissaScale = iota
+	// MantissaScaleLargeLegacy uses the large range while preserving the
+	// historical rounding behavior at math.MaxInt64.
+	MantissaScaleLargeLegacy
 	// MantissaScaleLarge is the [10^18, 10^19-1] range that represents every
-	// int64 value exactly, used under SingleAssetVault / LendingProtocol.
+	// int64 value exactly, with the cusp-rounding fix enabled.
 	MantissaScaleLarge
 )
 
 // params returns the (min, max) normalized mantissa and the rangeLog (log10 of
 // min) for the scale.
 func (s MantissaScale) params() (minM, maxM uint64, rangeLog int) {
-	if s == MantissaScaleLarge {
+	if s != MantissaScaleSmall {
 		return 1_000_000_000_000_000_000, 9_999_999_999_999_999_999, 18
 	}
 	return 1_000_000_000_000_000, 9_999_999_999_999_999, 15
 }
 
-// MantissaScaleForRules returns the mantissa scale rippled installs for a
-// transaction: large when no rules are in effect, or when SingleAssetVault or
-// LendingProtocol is enabled; small otherwise. Callers derive the booleans from
-// *amendment.Rules at the transaction boundary and thread the result explicitly,
-// rather than mutating a process-wide global.
-func MantissaScaleForRules(hasRules, singleAssetVault, lendingProtocol bool) MantissaScale {
-	if !hasRules || singleAssetVault || lendingProtocol {
+// MantissaScaleForRulesWithFix selects the exact rippled Number range. The
+// large range predates the cusp-rounding fix, so amendment-enabled ledgers use
+// LargeLegacy until fixCleanup3_2_0 is enabled. With no Rules context rippled
+// uses the corrected Large range.
+func MantissaScaleForRulesWithFix(hasRules, singleAssetVault, lendingProtocol, fixCleanup320 bool) MantissaScale {
+	if !hasRules {
 		return MantissaScaleLarge
 	}
-	return MantissaScaleSmall
+	if !singleAssetVault && !lendingProtocol {
+		return MantissaScaleSmall
+	}
+	if fixCleanup320 {
+		return MantissaScaleLarge
+	}
+	return MantissaScaleLargeLegacy
+}
+
+func (s MantissaScale) cuspRoundingFixEnabled() bool {
+	return s == MantissaScaleLarge
 }
 
 // Package-level switchover flag, the Go equivalent of rippled's per-thread
@@ -155,6 +169,8 @@ func (g *xrplGuard) pop() uint {
 	return d
 }
 
+func (g *xrplGuard) setDropped() { g.xbit = true }
+
 // round returns the rounding direction: 1 up, -1 down, 0 exactly half.
 func (g *xrplGuard) round(mode RoundingMode) int {
 	if mode == RoundTowardsZero {
@@ -214,6 +230,42 @@ func NewXRPLNumberRounded(mantissa int64, exponent int, mode RoundingMode) XRPLN
 // NewXRPLNumberScaled creates a Number in the given scale, normalized under mode.
 func NewXRPLNumberScaled(mantissa int64, exponent int, scale MantissaScale, mode RoundingMode) XRPLNumber {
 	return newNumber(mantissa, exponent, scale, mode)
+}
+
+var xrplNumberPattern = regexp.MustCompile(`^([-+]?)(0|[1-9][0-9]*)(?:\.([0-9]+))?(?:[eE]([+-]?[0-9]+))?$`)
+
+// ParseXRPLNumber parses the canonical decimal/scientific NUMBER syntax and
+// normalizes it directly in scale. It does not pass through the codec's legacy
+// small-scale parser, so large-scale transaction arithmetic retains its digits.
+func ParseXRPLNumber(value string, scale MantissaScale, mode RoundingMode) (number XRPLNumber, err error) {
+	match := xrplNumberPattern.FindStringSubmatch(value)
+	if match == nil {
+		return XRPLNumber{}, fmt.Errorf("invalid Number %q", value)
+	}
+
+	magnitude, parseErr := strconv.ParseUint(match[2]+match[3], 10, 64)
+	if parseErr != nil {
+		return XRPLNumber{}, fmt.Errorf("invalid Number %q: %w", value, parseErr)
+	}
+	exponent := -int64(len(match[3]))
+	if match[4] != "" {
+		parsed, parseErr := strconv.ParseInt(match[4], 10, 32)
+		if parseErr != nil {
+			return XRPLNumber{}, fmt.Errorf("invalid Number %q: %w", value, parseErr)
+		}
+		exponent += parsed
+	}
+	if int64(int(exponent)) != exponent {
+		return XRPLNumber{}, fmt.Errorf("invalid Number %q: exponent out of range", value)
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			number = XRPLNumber{}
+			err = fmt.Errorf("invalid Number %q: %v", value, recovered)
+		}
+	}()
+	return normalizeFromBig(match[1] == "-", new(big.Int).SetUint64(magnitude), int(exponent), scale, mode), nil
 }
 
 // NewXRPLNumberFromInt creates a small-scale Number from a plain integer.
@@ -343,10 +395,17 @@ func bringIntoRange(negative *bool, m *uint64, e *int, minM uint64) {
 
 // doRoundUp applies the guard's round-up decision and re-ranges (rippled
 // Guard::doRoundUp). It panics on exponent overflow.
-func (g *xrplGuard) doRoundUp(negative *bool, m *uint64, e *int, minM, maxM uint64, mode RoundingMode, loc string) {
+func (g *xrplGuard) doRoundUp(negative *bool, m *uint64, e *int, minM, maxM uint64, fixCusp bool, mode RoundingMode, loc string) {
 	if r := g.round(mode); r == 1 || (r == 0 && (*m&1) == 1) {
+		if fixCusp && (*m >= maxM || *m >= xrplNumMaxRep) {
+			g.push(uint(*m % 10))
+			*m /= 10
+			*e++
+			g.doRoundUp(negative, m, e, minM, maxM, fixCusp, mode, loc)
+			return
+		}
 		*m++
-		if *m > maxM || *m > xrplNumMaxRep {
+		if !fixCusp && (*m > maxM || *m > xrplNumMaxRep) {
 			*m /= 10
 			*e++
 		}
@@ -412,7 +471,7 @@ func (n *XRPLNumber) normalize(mode RoundingMode) {
 		m /= 10
 		e++
 	}
-	g.doRoundUp(&neg, &m, &e, minM, maxM, mode, "XRPLNumber::normalize overflow")
+	g.doRoundUp(&neg, &m, &e, minM, maxM, n.scale.cuspRoundingFixEnabled(), mode, "XRPLNumber::normalize overflow")
 	n.negative = neg
 	n.mantissa = m
 	n.exponent = e
@@ -473,7 +532,7 @@ func (n XRPLNumber) AddRounded(y XRPLNumber, mode RoundingMode) XRPLNumber {
 		} else {
 			xm = lo
 		}
-		g.doRoundUp(&xn, &xm, &xe, minM, maxM, mode, "XRPLNumber::addition overflow")
+		g.doRoundUp(&xn, &xm, &xe, minM, maxM, n.scale.cuspRoundingFixEnabled(), mode, "XRPLNumber::addition overflow")
 	} else {
 		// Different sign: subtract magnitudes.
 		if xm > ym {
@@ -530,7 +589,7 @@ func (n XRPLNumber) MulRounded(y XRPLNumber, mode RoundingMode) XRPLNumber {
 		ze++
 	}
 	xm := zm.Uint64()
-	g.doRoundUp(&zn, &xm, &ze, minM, maxM, mode, "XRPLNumber::multiplication overflow")
+	g.doRoundUp(&zn, &xm, &ze, minM, maxM, n.scale.cuspRoundingFixEnabled(), mode, "XRPLNumber::multiplication overflow")
 
 	r := XRPLNumber{negative: zn, mantissa: xm, exponent: ze, scale: n.scale}
 	r.normalize(mode)
@@ -548,46 +607,44 @@ func (n XRPLNumber) DivRounded(y XRPLNumber, mode RoundingMode) XRPLNumber {
 	if n.IsZero() {
 		return n
 	}
-	small := n.scale == MantissaScaleSmall
 	zn := n.negative != y.negative
 
-	// Shift by 10^17 (small) / 10^19 (large) gives the most precision without
-	// overflowing the 128-bit intermediate or the cast back.
-	var f *big.Int
-	if small {
-		f = new(big.Int).SetUint64(100_000_000_000_000_000)
-	} else {
-		f = new(big.Int).SetUint64(10_000_000_000_000_000_000)
-	}
+	// The first stage always uses 10^17. Large scales then retain five more
+	// decimal places from the remainder before normalization.
+	f := new(big.Int).SetUint64(100_000_000_000_000_000)
 	dmu := new(big.Int).SetUint64(y.mantissa)
 	numerator := new(big.Int).Mul(new(big.Int).SetUint64(n.mantissa), f)
 
 	zm := new(big.Int)
 	remainder := new(big.Int)
 	zm.QuoRem(numerator, dmu, remainder)
-	ze := n.exponent - y.exponent
-	if small {
-		ze -= 17
-	} else {
-		ze -= 19
+	ze := n.exponent - y.exponent - 17
+	dropped := false
+
+	if n.scale != MantissaScaleSmall && remainder.Sign() != 0 {
+		correctionFactor := big.NewInt(100_000)
+		partialNumerator := new(big.Int).Mul(remainder, correctionFactor)
+		correction := new(big.Int).Quo(new(big.Int).Set(partialNumerator), dmu)
+		if correction.Sign() != 0 {
+			zm.Mul(zm, correctionFactor)
+			zm.Add(zm, correction)
+			ze -= 5
+		}
+		if n.scale.cuspRoundingFixEnabled() {
+			dropped = new(big.Int).Rem(partialNumerator, dmu).Sign() != 0
+		}
 	}
 
-	if !small && remainder.Sign() != 0 {
-		// Fold three extra digits of precision (the correctionFactor) into the
-		// quotient before rounding, then divide back out via the exponent.
-		correction := new(big.Int).Mul(remainder, big.NewInt(1000))
-		correction.Quo(correction, dmu)
-		zm.Mul(zm, big.NewInt(1000))
-		zm.Add(zm, correction)
-		ze -= 3
-	}
-
-	return normalizeFromBig(zn, zm, ze, n.scale, mode)
+	return normalizeFromBigDropped(zn, zm, ze, n.scale, mode, dropped)
 }
 
 // normalizeFromBig normalizes a big.Int mantissa (the Div intermediate can
 // exceed 64 bits) into an XRPLNumber (rippled doNormalize for uint128).
 func normalizeFromBig(negative bool, m *big.Int, e int, scale MantissaScale, mode RoundingMode) XRPLNumber {
+	return normalizeFromBigDropped(negative, m, e, scale, mode, false)
+}
+
+func normalizeFromBigDropped(negative bool, m *big.Int, e int, scale MantissaScale, mode RoundingMode, dropped bool) XRPLNumber {
 	z := XRPLNumber{scale: scale}
 	if m.Sign() == 0 {
 		return z.zero()
@@ -607,6 +664,9 @@ func normalizeFromBig(negative bool, m *big.Int, e int, scale MantissaScale, mod
 	var g xrplGuard
 	if negative {
 		g.setNegative()
+	}
+	if dropped {
+		g.setDropped()
 	}
 	for mm.Cmp(bigMaxM) > 0 {
 		if e >= xrplNumMaxExponent {
@@ -628,7 +688,7 @@ func normalizeFromBig(negative bool, m *big.Int, e int, scale MantissaScale, mod
 		e++
 	}
 	mu := mm.Uint64()
-	g.doRoundUp(&negative, &mu, &e, minM, maxM, mode, "XRPLNumber::normalize overflow")
+	g.doRoundUp(&negative, &mu, &e, minM, maxM, scale.cuspRoundingFixEnabled(), mode, "XRPLNumber::normalize overflow")
 	return XRPLNumber{negative: negative, mantissa: mu, exponent: e, scale: scale}
 }
 
@@ -685,7 +745,7 @@ func normalizeInRange(negative *bool, m *uint64, e *int, minM, maxM uint64) {
 		*m /= 10
 		*e++
 	}
-	g.doRoundUp(negative, m, e, minM, maxM, RoundToNearest, "XRPLNumber::normalize overflow")
+	g.doRoundUp(negative, m, e, minM, maxM, false, RoundToNearest, "XRPLNumber::normalize overflow")
 }
 
 // ToIOUAmountValue converts to IOUAmountValue, clamping the wider exponent range

--- a/internal/ledger/state/xrpl_number_large_legacy_test.go
+++ b/internal/ledger/state/xrpl_number_large_legacy_test.go
@@ -1,0 +1,72 @@
+package state
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMantissaScaleForRulesWithFix(t *testing.T) {
+	require.Equal(t, MantissaScaleLarge, MantissaScaleForRulesWithFix(false, false, false, false))
+	require.Equal(t, MantissaScaleSmall, MantissaScaleForRulesWithFix(true, false, false, true))
+	require.Equal(t, MantissaScaleLargeLegacy, MantissaScaleForRulesWithFix(true, true, false, false))
+	require.Equal(t, MantissaScaleLargeLegacy, MantissaScaleForRulesWithFix(true, false, true, false))
+	require.Equal(t, MantissaScaleLarge, MantissaScaleForRulesWithFix(true, true, false, true))
+}
+
+func TestLargeLegacyPreservesCuspRounding(t *testing.T) {
+	const (
+		a = int64(1_000_000_000_000_049_863)
+		b = int64(9_223_372_036_854_315_903)
+	)
+
+	legacy := NewXRPLNumberScaled(a, 0, MantissaScaleLargeLegacy, RoundUpward).
+		MulRounded(NewXRPLNumberScaled(b, 0, MantissaScaleLargeLegacy, RoundUpward), RoundUpward)
+	fixed := NewXRPLNumberScaled(a, 0, MantissaScaleLarge, RoundUpward).
+		MulRounded(NewXRPLNumberScaled(b, 0, MantissaScaleLarge, RoundUpward), RoundUpward)
+
+	require.Equal(t, (int64(math.MaxInt64)/100)*100, legacy.Mantissa())
+	require.Equal(t, 18, legacy.Exponent())
+	require.Equal(t, int64(math.MaxInt64)/10+1, fixed.Mantissa())
+	require.Equal(t, 19, fixed.Exponent())
+
+	// Constructing and operating in one mode must not mutate the other mode.
+	require.Equal(t, (int64(math.MaxInt64)/100)*100, legacy.Mantissa())
+}
+
+func TestLargeDivisionDroppedRemainderFix(t *testing.T) {
+	const denominator = int64(1_000_000_000_000_000_007)
+	legacy := NewXRPLNumberScaled(2, 0, MantissaScaleLargeLegacy, RoundUpward).
+		DivRounded(NewXRPLNumberScaled(denominator, 0, MantissaScaleLargeLegacy, RoundUpward), RoundUpward)
+	fixed := NewXRPLNumberScaled(2, 0, MantissaScaleLarge, RoundUpward).
+		DivRounded(NewXRPLNumberScaled(denominator, 0, MantissaScaleLarge, RoundUpward), RoundUpward)
+	exact := new(big.Rat).SetFrac(big.NewInt(2), big.NewInt(denominator))
+
+	require.Negative(t, numberRat(legacy).Cmp(exact))
+	require.GreaterOrEqual(t, numberRat(fixed).Cmp(exact), 0)
+	require.NotEqual(t, legacy, fixed)
+}
+
+func TestParseXRPLNumberRejectsOutOfRangeMantissa(t *testing.T) {
+	_, err := ParseXRPLNumber("9223372036854775807.6", MantissaScaleLarge, RoundToNearest)
+	require.Error(t, err)
+}
+
+func numberRat(number XRPLNumber) *big.Rat {
+	value := new(big.Rat).SetInt64(number.Mantissa())
+	exponent := number.Exponent()
+	factor := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(absInt(exponent))), nil)
+	if exponent >= 0 {
+		return value.Mul(value, new(big.Rat).SetInt(factor))
+	}
+	return value.Quo(value, new(big.Rat).SetInt(factor))
+}
+
+func absInt(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
+}

--- a/internal/replaytool/replay_reconstruct_defaults.go
+++ b/internal/replaytool/replay_reconstruct_defaults.go
@@ -63,8 +63,9 @@ type requiredField struct {
 // Hash256 = zero, empty array) AND it is metadata-eligible (rippled only drops
 // default fields that would otherwise be emitted into NewFields). sfFlags is
 // soeREQUIRED on every type (a common field), so every type carries Flags: 0.
-// Fields that are never at default-zero on creation (Account, Sequence,
-// BookDirectory, RootIndex, non-native Balance, ...) are excluded, as are
+// Fields that are never at default-zero on creation (Account, ordinary account
+// Sequence and non-native Balance, BookDirectory, RootIndex, ...) are excluded,
+// as are
 // soeOPTIONAL/soeDEFAULT fields, the never-in-metadata fields PreviousTxnID/Seq
 // (handled by threading) and Indexes, and LedgerEntryType (carried at the node
 // level).
@@ -79,6 +80,8 @@ type requiredField struct {
 // fillBookDirectoryDefaults.
 var requiredDefaults = map[string][]requiredField{
 	"AccountRoot": {
+		{Name: "Sequence", Value: 0},
+		{Name: "Balance", Value: "0"},
 		{Name: "Flags", Value: 0},
 		{Name: "OwnerCount", Value: 0},
 	},
@@ -193,6 +196,7 @@ var requiredDefaults = map[string][]requiredField{
 	"Vault": {
 		{Name: "Flags", Value: 0},
 		{Name: "OwnerNode", Value: "0"},
+		{Name: "Asset", Value: map[string]any{"currency": "XRP"}},
 	},
 }
 

--- a/internal/replaytool/replay_reconstruct_dir.go
+++ b/internal/replaytool/replay_reconstruct_dir.go
@@ -107,6 +107,18 @@ func directoryPlacements(entryType string, fields map[string]any) []dirPlacement
 			}
 		}
 		return out
+
+	case "Vault":
+		if owner, ok := metaAccountID(fields, "Owner"); ok {
+			add(keylet.OwnerDirPage(owner, metaUint64(fields["OwnerNode"])), dirSorted)
+		}
+		return out
+
+	case "MPTokenIssuance":
+		if issuer, ok := metaAccountID(fields, "Issuer"); ok {
+			add(keylet.OwnerDirPage(issuer, metaUint64(fields["OwnerNode"])), dirSorted)
+		}
+		return out
 	}
 
 	// Owner directory: the object's owner lists it at OwnerNode. The owner is the

--- a/internal/replaytool/replay_reconstruct_test.go
+++ b/internal/replaytool/replay_reconstruct_test.go
@@ -538,6 +538,112 @@ func TestReconstructFromMeta_CreatedBookDirectoryXRPSide(t *testing.T) {
 	assertEntryBytes(t, corrected, bookRoot, wantBook, "book directory")
 }
 
+func TestReconstructFromMeta_VaultCreateDefaultsAndDirectories(t *testing.T) {
+	const owner = "rEaWzpDUL2cBckwDJhRENZiKCbNKwG2cAZ"
+	const pseudo = "rpRrVjCLggyjBaAYreukcyuWuzb23wuWrn"
+	const vaultKeyHex = "DE275CBF520001E340CA0C7D8FD15D5D5CEDAC6559BDF377882BD4AF8712C622"
+	const issuanceKeyHex = "39B9656467D5B6F0AE0DD9A96BE0E27F9CAEEF6DBEBA8F7C7ECAC237EE94D8B6"
+	const shareMPTID = "000000010F8285BE96FB1972BC582434283C22113532FAB5"
+
+	ownerID, err := state.DecodeAccountID(owner)
+	if err != nil {
+		t.Fatalf("decode owner: %v", err)
+	}
+	pseudoID, err := state.DecodeAccountID(pseudo)
+	if err != nil {
+		t.Fatalf("decode pseudo: %v", err)
+	}
+	ownerDir := keylet.OwnerDirPage(ownerID, 0).Key
+	pseudoDir := keylet.OwnerDirPage(pseudoID, 0).Key
+	ownerDirHex := strings.ToUpper(hex.EncodeToString(ownerDir[:]))
+	pseudoDirHex := strings.ToUpper(hex.EncodeToString(pseudoDir[:]))
+	vaultKey := mustIndex(t, vaultKeyHex)
+	issuanceKey := mustIndex(t, issuanceKeyHex)
+
+	meta := encodeMeta(t,
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "DirectoryNode",
+			"LedgerIndex":     ownerDirHex,
+			"NewFields":       map[string]any{"Owner": owner, "RootIndex": ownerDirHex},
+		}},
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "DirectoryNode",
+			"LedgerIndex":     pseudoDirHex,
+			"NewFields":       map[string]any{"Owner": pseudo, "RootIndex": pseudoDirHex},
+		}},
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "Vault",
+			"LedgerIndex":     vaultKeyHex,
+			"NewFields": map[string]any{
+				"Account":          pseudo,
+				"Data":             "4D65746144617461",
+				"Owner":            owner,
+				"Sequence":         uint32(3024998),
+				"ShareMPTID":       shareMPTID,
+				"WithdrawalPolicy": 1,
+			},
+		}},
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "AccountRoot",
+			"LedgerIndex":     "9EDC99BAA48E5FC2A28C355D8CA9A723CD52CC36DC76E946D118D3DB679B8DB5",
+			"NewFields": map[string]any{
+				"Account":    pseudo,
+				"Flags":      uint32(26214400),
+				"OwnerCount": uint32(1),
+				"VaultID":    vaultKeyHex,
+			},
+		}},
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "MPTokenIssuance",
+			"LedgerIndex":     issuanceKeyHex,
+			"NewFields": map[string]any{
+				"Issuer":   pseudo,
+				"Sequence": uint32(1),
+			},
+		}},
+	)
+
+	corrected, err := reconstructFromMeta(putAll(t, nil), []metaTx{{Blob: meta, TxHash: mustIndex(t, testTxHashHex)}}, testLedgerSeq)
+	if err != nil {
+		t.Fatalf("reconstructFromMeta: %v", err)
+	}
+
+	wantOwnerDir := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "DirectoryNode", "Flags": 0, "Owner": owner,
+		"RootIndex": ownerDirHex, "Indexes": []string{vaultKeyHex},
+		"PreviousTxnID": testTxHashHex, "PreviousTxnLgrSeq": testLedgerSeq,
+	})
+	wantPseudoDir := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "DirectoryNode", "Flags": 0, "Owner": pseudo,
+		"RootIndex": pseudoDirHex, "Indexes": []string{issuanceKeyHex},
+		"PreviousTxnID": testTxHashHex, "PreviousTxnLgrSeq": testLedgerSeq,
+	})
+	wantVault := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "Vault", "Flags": 0, "OwnerNode": "0",
+		"Owner": owner, "Account": pseudo, "Sequence": uint32(3024998),
+		"Data": "4D65746144617461", "Asset": map[string]any{"currency": "XRP"},
+		"ShareMPTID": shareMPTID, "WithdrawalPolicy": 1,
+		"PreviousTxnID": testTxHashHex, "PreviousTxnLgrSeq": testLedgerSeq,
+	})
+	wantPseudo := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "AccountRoot", "Account": pseudo, "Balance": "0",
+		"Flags": uint32(26214400), "OwnerCount": uint32(1), "Sequence": uint32(0),
+		"VaultID": vaultKeyHex, "PreviousTxnID": testTxHashHex,
+		"PreviousTxnLgrSeq": testLedgerSeq,
+	})
+	wantIssuance := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "MPTokenIssuance", "Flags": 0, "Issuer": pseudo,
+		"Sequence": uint32(1), "OwnerNode": "0", "OutstandingAmount": "0",
+		"PreviousTxnID": testTxHashHex, "PreviousTxnLgrSeq": testLedgerSeq,
+	})
+
+	assertEntryBytes(t, corrected, ownerDir, wantOwnerDir, "vault owner directory")
+	assertEntryBytes(t, corrected, pseudoDir, wantPseudoDir, "pseudo owner directory")
+	assertEntryBytes(t, corrected, vaultKey, wantVault, "vault")
+	assertEntryBytes(t, corrected, mustIndex(t, "9EDC99BAA48E5FC2A28C355D8CA9A723CD52CC36DC76E946D118D3DB679B8DB5"), wantPseudo, "pseudo account")
+	assertEntryBytes(t, corrected, issuanceKey, wantIssuance, "share issuance")
+}
+
 func assertEntryBytes(t *testing.T, m *shamap.SHAMap, key [32]byte, want []byte, label string) {
 	t.Helper()
 	item, found, err := m.Get(key)

--- a/internal/testing/vault/vault_deposit_test.go
+++ b/internal/testing/vault/vault_deposit_test.go
@@ -1,0 +1,144 @@
+package vault_test
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/accountset"
+	credentialtest "github.com/LeJamon/go-xrpl/internal/testing/credential"
+	permissioneddomaintest "github.com/LeJamon/go-xrpl/internal/testing/permissioneddomain"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/vault"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+func TestVaultDeposit_ScaleOverflowReturnsPathDry(t *testing.T) {
+	env := newVaultEnv(t)
+	issuer := jtx.NewAccount("overflow-issuer")
+	owner := jtx.NewAccount("overflow-owner")
+	depositor := jtx.NewAccount("overflow-depositor")
+	env.Fund(issuer)
+	jtx.RequireTxSuccess(t, env.Submit(accountset.AccountSet(issuer).DefaultRipple().Build()))
+	env.Fund(owner, depositor)
+
+	const currency = "USD"
+	env.Trust(depositor, tx.NewIssuedAmountFromFloat64(1_000, currency, issuer.Address))
+	env.PayIOU(issuer, depositor, issuer, currency, 100)
+
+	sequence := env.Seq(owner)
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{Currency: currency, Issuer: issuer.Address})
+	scale := uint8(18)
+	create.Scale = &scale
+	create.Common.Fee = createFee
+	jtx.RequireTxSuccess(t, env.Submit(create))
+
+	deposit := vault.NewVaultDeposit(
+		depositor.Address,
+		vaultID(owner, sequence),
+		tx.NewIssuedAmountFromFloat64(10, currency, issuer.Address),
+	)
+	jtx.RequireTxClaimed(t, env.Submit(deposit), jtx.TecPATH_DRY)
+}
+
+func TestVaultDeposit_IOUFullBalanceIncludesOppositeLimit(t *testing.T) {
+	env := newVaultEnv(t)
+	issuer := jtx.NewAccount("full-balance-issuer")
+	owner := jtx.NewAccount("full-balance-owner")
+	depositor := jtx.NewAccount("full-balance-depositor")
+	env.Fund(issuer)
+	jtx.RequireTxSuccess(t, env.Submit(accountset.AccountSet(issuer).DefaultRipple().Build()))
+	env.Fund(owner, depositor)
+
+	const currency = "USD"
+	env.Trust(depositor, tx.NewIssuedAmountFromFloat64(1_000, currency, issuer.Address))
+	env.PayIOU(issuer, depositor, issuer, currency, 100)
+	env.Trust(issuer, tx.NewIssuedAmountFromFloat64(1_000, currency, depositor.Address))
+
+	sequence := env.Seq(owner)
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{Currency: currency, Issuer: issuer.Address})
+	create.Common.Fee = createFee
+	jtx.RequireTxSuccess(t, env.Submit(create))
+
+	deposit := vault.NewVaultDeposit(
+		depositor.Address,
+		vaultID(owner, sequence),
+		tx.NewIssuedAmountFromFloat64(500, currency, issuer.Address),
+	)
+	jtx.RequireTxSuccess(t, env.Submit(deposit))
+	if balance, ok := iouLineBalance(t, env, depositor.ID, issuer.ID, currency); !ok || !approxEq(balance, -400) {
+		t.Fatalf("depositor balance = %v (exists=%v), want -400", balance, ok)
+	}
+}
+
+func TestVaultDeposit_PrivateDomainAuthorizationAndExpiredCleanup(t *testing.T) {
+	env := newVaultEnv(t)
+	owner := jtx.NewAccount("vault-owner")
+	depositor := jtx.NewAccount("vault-depositor")
+	domainOwner := jtx.NewAccount("domain-owner")
+	validIssuer := jtx.NewAccount("valid-credential-issuer")
+	expiredIssuer := jtx.NewAccount("expired-credential-issuer")
+	env.Fund(owner, depositor, domainOwner, validIssuer, expiredIssuer)
+
+	const credentialType = "vault-access"
+	credentialTypeHex := strings.ToUpper(hex.EncodeToString([]byte(credentialType)))
+	domainSequence := env.Seq(domainOwner)
+	jtx.RequireTxSuccess(t, env.Submit(
+		permissioneddomaintest.DomainSet(domainOwner).
+			Credential(validIssuer, credentialTypeHex).
+			Credential(expiredIssuer, credentialTypeHex).
+			Build(),
+	))
+	domainKey := keylet.PermissionedDomain(domainOwner.ID, domainSequence)
+	domainID := strings.ToUpper(hex.EncodeToString(domainKey.Key[:]))
+
+	vaultSequence := env.Seq(owner)
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{Currency: "XRP"})
+	privateFlag := vault.VaultFlagPrivate
+	create.Common.Flags = &privateFlag
+	create.Common.Fee = createFee
+	jtx.RequireTxSuccess(t, env.Submit(create))
+	vaultID := vaultID(owner, vaultSequence)
+
+	set := vault.NewVaultSet(owner.Address, vaultID)
+	set.DomainID = domainID
+	jtx.RequireTxSuccess(t, env.Submit(set))
+
+	deposit := func() *vault.VaultDeposit {
+		return vault.NewVaultDeposit(depositor.Address, vaultID, tx.NewXRPAmount(1_000_000))
+	}
+	jtx.RequireTxClaimed(t, env.Submit(deposit()), jtx.TecNO_AUTH)
+
+	jtx.RequireTxSuccess(t, env.Submit(
+		credentialtest.CredentialCreate(validIssuer, depositor, credentialType).Build(),
+	))
+	jtx.RequireTxSuccess(t, env.Submit(
+		credentialtest.CredentialAccept(depositor, validIssuer, credentialType).Build(),
+	))
+	jtx.RequireTxSuccess(t, env.Submit(deposit()))
+
+	jtx.RequireTxSuccess(t, env.Submit(
+		credentialtest.CredentialDelete(validIssuer, depositor, validIssuer, credentialType).Build(),
+	))
+
+	const expiration uint32 = 2_000_000_000
+	jtx.RequireTxSuccess(t, env.Submit(
+		credentialtest.CredentialCreate(expiredIssuer, depositor, credentialType).
+			Expiration(expiration).
+			Build(),
+	))
+	jtx.RequireTxSuccess(t, env.Submit(
+		credentialtest.CredentialAccept(depositor, expiredIssuer, credentialType).Build(),
+	))
+	expiredKey := jtx.CredentialKeylet(depositor, expiredIssuer, credentialType)
+	if !env.LedgerEntryExists(expiredKey) {
+		t.Fatal("accepted credential missing before expiration")
+	}
+
+	env.CloseToParentCloseTime(expiration + 1)
+	jtx.RequireTxClaimed(t, env.Submit(deposit()), jtx.TecEXPIRED)
+	if env.LedgerEntryExists(expiredKey) {
+		t.Fatal("expired credential was not deleted on the tecEXPIRED path")
+	}
+}

--- a/internal/testing/vault/vault_test.go
+++ b/internal/testing/vault/vault_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/accountset"
@@ -29,6 +30,49 @@ func newVaultEnv(t *testing.T) *jtx.TestEnv {
 	env.EnableFeature("SingleAssetVault")
 	env.Close()
 	return env
+}
+
+func TestVault_ZeroAssetsMaximumIsAbsent(t *testing.T) {
+	env := newVaultEnv(t)
+	owner := jtx.NewAccount("owner")
+	env.Fund(owner)
+
+	seq := env.Seq(owner)
+	zero := "0"
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{Currency: "XRP"})
+	create.Common.Fee = createFee
+	create.AssetsMaximum = &zero
+	jtx.RequireTxSuccess(t, env.Submit(create))
+
+	vaultKey := keylet.Vault(owner.AccountID(), seq)
+	assertPresent := func(want bool) {
+		t.Helper()
+		data, err := env.LedgerEntry(vaultKey)
+		if err != nil {
+			t.Fatalf("read vault: %v", err)
+		}
+		decoded, err := binarycodec.DecodeBytes(data)
+		if err != nil {
+			t.Fatalf("decode vault: %v", err)
+		}
+		_, got := decoded["AssetsMaximum"]
+		if got != want {
+			t.Fatalf("AssetsMaximum presence = %v, want %v", got, want)
+		}
+	}
+	assertPresent(false)
+
+	id := vaultID(owner, seq)
+	nonzero := "1"
+	set := vault.NewVaultSet(owner.Address, id)
+	set.AssetsMaximum = &nonzero
+	jtx.RequireTxSuccess(t, env.Submit(set))
+	assertPresent(true)
+
+	set = vault.NewVaultSet(owner.Address, id)
+	set.AssetsMaximum = &zero
+	jtx.RequireTxSuccess(t, env.Submit(set))
+	assertPresent(false)
 }
 
 // TestVault_XRPLifecycle exercises create → deposit → withdraw → delete.

--- a/internal/tx/invariants/vault.go
+++ b/internal/tx/invariants/vault.go
@@ -1,42 +1,13 @@
 package invariants
 
-// vault.go — ValidVault invariant, ported from rippled InvariantCheck.cpp
-// (ValidVault) at the 3.1.3 state.
-//
-// It reconciles the balance movements of a single-asset-vault transaction: a
-// deposit trades assets for freshly minted shares, a withdrawal and a clawback
-// trade shares back for assets, and a set touches neither. The checker verifies
-// that the asset movement, the share issuance movement, and the vault's own
-// AssetsTotal / AssetsAvailable / LossUnrealized totals all agree, that the
-// vault's immutable data never changes, and that only loan transactions may move
-// LossUnrealized. Balance deltas are rounded to the coarsest asset scale before
-// comparison so IOU dust cannot trip the check.
-//
-// Enforcement mirrors rippled: the numeric machinery always runs when a vault
-// object is touched, but a detected violation only fails the transaction when
-// featureSingleAssetVault is enabled (`return !enforce`). Vault objects can only
-// exist under SingleAssetVault, so in practice enforce is always true here.
-//
-// Asset-balance reconciliation scope. rippled looks up a vault asset movement at
-// keylet::line(account, assetIssuer) for an IOU — the trust line between the
-// account and the asset's issuer, because rippled's vault moves the asset by
-// rippling through the issuer (accountSend → rippleSend). go-xrpl's vault
-// transactors instead credit a direct account↔pseudo trust line, so an IOU
-// movement lands at a different ledger key. That is a pre-existing divergence in
-// the vault asset-movement path, not in this checker; until it is aligned, the
-// asset-balance delta reconciliation here runs only for integral assets (native
-// XRP and MPT), where go-xrpl and rippled agree on the ledger key. The
-// structural, bounds, and share-issuance invariants run for every asset type.
-
 import (
 	"bytes"
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"math/big"
 	"strconv"
 
 	"github.com/LeJamon/go-xrpl/amendment"
-	"github.com/LeJamon/go-xrpl/codec/binarycodec/types"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
@@ -55,11 +26,12 @@ const vvMaxMPTokenAmount uint64 = 0x7FFFFFFFFFFFFFFF
 
 // vvAsset is a vault's underlying asset: native XRP, an MPT, or an IOU.
 type vvAsset struct {
-	isXRP    bool
-	isMPT    bool
-	mptID    [24]byte
-	currency string
-	issuer   [20]byte // IOU issuer
+	isXRP       bool
+	isMPT       bool
+	mptID       [24]byte
+	currency    string
+	issuer      [20]byte // IOU issuer
+	numberScale state.MantissaScale
 }
 
 func (a vvAsset) integral() bool { return a.isXRP || a.isMPT }
@@ -87,7 +59,49 @@ func (a vvAsset) scaleOf(n state.XRPLNumber) int {
 
 // round snaps n to this asset's precision at the given decimal scale.
 func (a vvAsset) round(n state.XRPLNumber, scale int) state.XRPLNumber {
-	return n.RoundToAssetScale(a.integral(), scale, state.RoundToNearest)
+	return a.roundMode(n, scale, state.RoundToNearest)
+}
+
+func (a vvAsset) roundMode(n state.XRPLNumber, scale int, mode state.RoundingMode) state.XRPLNumber {
+	if a.integral() || n.IsZero() {
+		return n.RoundToAssetScale(a.integral(), scale, mode)
+	}
+
+	iou := state.NewIssuedAmountFromValueRounded(
+		n.Mantissa(), n.Exponent(), a.currency, state.AccountOneAddress, mode)
+	if iou.Exponent() >= scale {
+		return state.NewXRPLNumberScaled(
+			iou.Mantissa(), iou.Exponent(), a.numberScale, state.RoundToNearest)
+	}
+
+	// Round the canonical IOU coefficient to the requested decimal exponent.
+	divisor := new(big.Int).Exp(
+		big.NewInt(10), big.NewInt(int64(scale-iou.Exponent())), nil)
+	mantissa := big.NewInt(iou.Mantissa())
+	negative := mantissa.Sign() < 0
+	mantissa.Abs(mantissa)
+	quotient, remainder := new(big.Int), new(big.Int)
+	quotient.QuoRem(mantissa, divisor, remainder)
+
+	increment := false
+	switch mode {
+	case state.RoundDownward:
+		increment = negative && remainder.Sign() != 0
+	case state.RoundUpward:
+		increment = !negative && remainder.Sign() != 0
+	case state.RoundToNearest:
+		twiceRemainder := new(big.Int).Lsh(new(big.Int).Set(remainder), 1)
+		cmp := twiceRemainder.Cmp(divisor)
+		increment = cmp > 0 || cmp == 0 && quotient.Bit(0) == 1
+	}
+	if increment {
+		quotient.Add(quotient, big.NewInt(1))
+	}
+	if negative {
+		quotient.Neg(quotient)
+	}
+	return state.NewXRPLNumberScaled(
+		quotient.Int64(), scale, a.numberScale, state.RoundToNearest)
 }
 
 func (a vvAsset) makeDelta(before, after state.XRPLNumber) vvDelta {
@@ -130,7 +144,14 @@ func checkValidVault(tx Transaction, result Result, fee uint64, entries []Invari
 		return nil
 	}
 
-	c := &vvChecker{deltas: map[[32]byte]vvDelta{}, view: view, fee: fee, txType: tx.TxType(), rules: rules}
+	c := &vvChecker{
+		deltas:      map[[32]byte]vvDelta{},
+		view:        view,
+		fee:         fee,
+		txType:      tx.TxType(),
+		rules:       rules,
+		numberScale: vvNumberScale(rules),
+	}
 	if flat, err := tx.Flatten(); err == nil {
 		c.flat = flat
 	}
@@ -161,13 +182,13 @@ type vvChecker struct {
 	flat        map[string]any
 	txAccountID [20]byte
 	rules       *amendment.Rules
+	numberScale state.MantissaScale
 }
 
 // vaultMinScale is the decimal scale that balance deltas round to before the
 // deposit/withdraw reconciliation. Post-fixCleanup3_2_0 it is simply the
 // posterior AssetsTotal scale; pre-amendment it is the coarsest scale across the
-// supplied deltas. The two agree for the integral (XRP/MPT) assets this
-// reconciliation runs on, where the scale is always zero.
+// supplied deltas.
 func (c *vvChecker) vaultMinScale(vaultAsset vvAsset, afterVault vvVault, deltas ...vvDelta) int {
 	if c.rules != nil && c.rules.FixCleanup3_2_0Enabled() {
 		return vaultAsset.scaleOf(afterVault.assetsTotal)
@@ -180,7 +201,7 @@ func (c *vvChecker) vaultMinScale(vaultAsset vvAsset, afterVault vvVault, deltas
 // reconciles.
 func (c *vvChecker) visit(entries []InvariantEntry) {
 	for _, e := range entries {
-		delta := vvZero()
+		delta := vvZero(c.numberScale)
 		scale := 0
 		sign := 0
 
@@ -188,22 +209,22 @@ func (c *vvChecker) visit(entries []InvariantEntry) {
 			if bf, err := decodeEntry(e.Before); err == nil {
 				switch e.EntryType {
 				case "Vault":
-					if v, ok := vvMakeVault(bf, e.Key); ok {
+					if v, ok := vvMakeVault(bf, e.Key, c.numberScale); ok {
 						c.beforeVault = append(c.beforeVault, v)
 					}
 				case "MPTokenIssuance":
 					c.beforeShares = append(c.beforeShares, vvMakeShares(bf))
-					delta = vvNumFromU64(vvU64(bf, "OutstandingAmount"))
+					delta = vvNumFromU64(vvU64(bf, "OutstandingAmount"), c.numberScale)
 					scale, sign = 0, 1
 				case "MPToken":
-					delta = vvNumFromU64(vvU64(bf, "MPTAmount"))
+					delta = vvNumFromU64(vvU64(bf, "MPTAmount"), c.numberScale)
 					scale, sign = 0, -1
 				case "AccountRoot":
-					delta = vvNumFromI64(vvI64(bf, "Balance"))
+					delta = vvNumFromI64(vvI64(bf, "Balance"), c.numberScale)
 					scale, sign = 0, -1
 				case "RippleState":
 					amt := vvBalanceAmount(bf)
-					delta = vvNumFromAmount(amt)
+					delta = vvNumFromAmount(amt, c.numberScale)
 					scale, sign = amt.Exponent(), -1
 				}
 			}
@@ -213,22 +234,22 @@ func (c *vvChecker) visit(entries []InvariantEntry) {
 			if af, err := decodeEntry(e.After); err == nil {
 				switch e.EntryType {
 				case "Vault":
-					if v, ok := vvMakeVault(af, e.Key); ok {
+					if v, ok := vvMakeVault(af, e.Key, c.numberScale); ok {
 						c.afterVault = append(c.afterVault, v)
 					}
 				case "MPTokenIssuance":
 					c.afterShares = append(c.afterShares, vvMakeShares(af))
-					delta = delta.Sub(vvNumFromU64(vvU64(af, "OutstandingAmount")))
+					delta = delta.Sub(vvNumFromU64(vvU64(af, "OutstandingAmount"), c.numberScale))
 					scale, sign = 0, 1
 				case "MPToken":
-					delta = delta.Sub(vvNumFromU64(vvU64(af, "MPTAmount")))
+					delta = delta.Sub(vvNumFromU64(vvU64(af, "MPTAmount"), c.numberScale))
 					scale, sign = 0, -1
 				case "AccountRoot":
-					delta = delta.Sub(vvNumFromI64(vvI64(af, "Balance")))
+					delta = delta.Sub(vvNumFromI64(vvI64(af, "Balance"), c.numberScale))
 					scale, sign = 0, -1
 				case "RippleState":
 					amt := vvBalanceAmount(af)
-					delta = delta.Sub(vvNumFromAmount(amt))
+					delta = delta.Sub(vvNumFromAmount(amt, c.numberScale))
 					if amt.Exponent() > scale {
 						scale = amt.Exponent()
 					}
@@ -278,7 +299,7 @@ func (c *vvChecker) deltaAssetsTxAccount(vaultAsset vvAsset) (vvDelta, bool) {
 	if d, present := c.flatAccountID("Delegate"); present && d != c.txAccountID {
 		return ret, ok
 	}
-	ret.delta = ret.delta.Add(vvNumFromI64(int64(c.fee)))
+	ret.delta = ret.delta.Add(vvNumFromI64(int64(c.fee), c.numberScale))
 	if ret.delta.IsZero() {
 		return vvDelta{}, false
 	}
@@ -508,10 +529,8 @@ func (c *vvChecker) finalizeSet(afterVault vvVault, updatedShares vvShares, befo
 	beforeVault := c.beforeVault[0]
 	vaultAsset := afterVault.asset
 
-	if vaultAsset.integral() {
-		if _, moved := c.deltaAssets(vaultAsset, afterVault.pseudoID); moved {
-			return "set must not change vault balance"
-		}
+	if _, moved := c.deltaAssets(vaultAsset, afterVault.pseudoID); moved {
+		return "set must not change vault balance"
 	}
 	if beforeVault.assetsTotal.Cmp(afterVault.assetsTotal) != 0 {
 		return "set must not change assets outstanding"
@@ -532,10 +551,8 @@ func (c *vvChecker) finalizeDeposit(afterVault vvVault, updatedShares vvShares) 
 	beforeVault := c.beforeVault[0]
 	vaultAsset := afterVault.asset
 
-	if vaultAsset.integral() {
-		if msg := c.reconcileDepositAssets(beforeVault, afterVault, vaultAsset); msg != "" {
-			return msg
-		}
+	if msg := c.reconcileDepositAssets(beforeVault, afterVault, vaultAsset); msg != "" {
+		return msg
 	}
 
 	if afterVault.assetsMaximum.Signum() > 0 && afterVault.assetsTotal.Cmp(afterVault.assetsMaximum) > 0 {
@@ -572,7 +589,7 @@ func (c *vvChecker) reconcileDepositAssets(beforeVault, afterVault vvVault, vaul
 
 	vaultDeltaAssets := vaultAsset.round(maybeVaultDeltaAssets.delta, minScale)
 	txAmt, _ := c.flatAmount("Amount")
-	txAmount := vaultAsset.round(vvNumFromAmount(txAmt), minScale)
+	txAmount := vaultAsset.round(vvNumFromAmount(txAmt, c.numberScale), minScale)
 
 	if vaultDeltaAssets.Cmp(txAmount) > 0 {
 		return "deposit must not change vault balance by more than deposited amount"
@@ -613,10 +630,8 @@ func (c *vvChecker) finalizeWithdraw(afterVault vvVault) string {
 	beforeVault := c.beforeVault[0]
 	vaultAsset := afterVault.asset
 
-	if vaultAsset.integral() {
-		if msg := c.reconcileWithdrawAssets(beforeVault, afterVault, vaultAsset); msg != "" {
-			return msg
-		}
+	if msg := c.reconcileWithdrawAssets(beforeVault, afterVault, vaultAsset); msg != "" {
+		return msg
 	}
 
 	accountDeltaShares, sok := c.deltaShares(afterVault, c.txAccountID)
@@ -675,11 +690,19 @@ func (c *vvChecker) reconcileWithdrawAssets(beforeVault, afterVault vvVault, vau
 		}
 		localMinScale := max(minScale, vvCoarsestScale(destinationDelta))
 		roundedDestinationDelta := vaultAsset.round(destinationDelta.delta, localMinScale)
-		if roundedDestinationDelta.Signum() <= 0 {
+		tolerateZeroDelta := c.rules != nil && c.rules.FixCleanup3_2_0Enabled() && !vaultAsset.integral()
+		invalidDestinationDelta := roundedDestinationDelta.Signum() <= 0
+		if tolerateZeroDelta {
+			invalidDestinationDelta = roundedDestinationDelta.Signum() < 0
+		}
+		if invalidDestinationDelta {
 			return "withdrawal must increase destination balance"
 		}
 		localPseudoDeltaAssets := vaultAsset.round(vaultPseudoDeltaAssets, localMinScale)
-		if localPseudoDeltaAssets.Negate().Cmp(roundedDestinationDelta) != 0 {
+		destroyedAssets := maybeVaultDeltaAssets.delta.Negate().Sub(destinationDelta.delta)
+		destroyedIsSubULP := tolerateZeroDelta &&
+			vaultAsset.roundMode(destroyedAssets, destinationDelta.scale, state.RoundDownward).IsZero()
+		if !destroyedIsSubULP && localPseudoDeltaAssets.Negate().Cmp(roundedDestinationDelta) != 0 {
 			return "withdrawal must change vault and destination balance by equal amount"
 		}
 	}
@@ -707,10 +730,8 @@ func (c *vvChecker) finalizeClawback(afterVault vvVault, beforeShares *vvShares)
 		}
 	}
 
-	if vaultAsset.integral() {
-		if msg := c.reconcileClawbackAssets(beforeVault, afterVault, vaultAsset); msg != "" {
-			return msg
-		}
+	if msg := c.reconcileClawbackAssets(beforeVault, afterVault, vaultAsset); msg != "" {
+		return msg
 	}
 
 	holderID, _ := c.flatAccountID("Holder")
@@ -737,7 +758,7 @@ func (c *vvChecker) reconcileClawbackAssets(beforeVault, afterVault vvVault, vau
 	if ok {
 		totalDelta := vaultAsset.makeDelta(beforeVault.assetsTotal, afterVault.assetsTotal)
 		availableDelta := vaultAsset.makeDelta(beforeVault.assetsAvailable, afterVault.assetsAvailable)
-		minScale := vvCoarsestScale(maybeVaultDeltaAssets, totalDelta, availableDelta)
+		minScale := c.vaultMinScale(vaultAsset, afterVault, maybeVaultDeltaAssets, totalDelta, availableDelta)
 		vaultDeltaAssets := vaultAsset.round(maybeVaultDeltaAssets.delta, minScale)
 		if vaultDeltaAssets.Signum() >= 0 {
 			return "clawback must decrease vault balance"
@@ -767,27 +788,39 @@ func (c *vvChecker) findShares(list []vvShares, shareMPTID [24]byte) (vvShares, 
 
 // --- decode + numeric helpers ---
 
-func vvZero() state.XRPLNumber {
-	return state.NewXRPLNumberScaled(0, 0, state.MantissaScaleLarge, state.RoundToNearest)
+func vvZero(scale state.MantissaScale) state.XRPLNumber {
+	return state.NewXRPLNumberScaled(0, 0, scale, state.RoundToNearest)
 }
 
-func vvNumFromI64(v int64) state.XRPLNumber {
-	return state.NewXRPLNumberScaled(v, 0, state.MantissaScaleLarge, state.RoundToNearest)
+func vvNumberScale(rules *amendment.Rules) state.MantissaScale {
+	if rules == nil {
+		return state.MantissaScaleForRulesWithFix(false, false, false, false)
+	}
+	return state.MantissaScaleForRulesWithFix(
+		true,
+		rules.Enabled(amendment.FeatureSingleAssetVault),
+		rules.Enabled(amendment.FeatureLendingProtocol),
+		rules.FixCleanup3_2_0Enabled(),
+	)
 }
 
-func vvNumFromU64(v uint64) state.XRPLNumber {
-	return vvNumFromI64(int64(v))
+func vvNumFromI64(v int64, scale state.MantissaScale) state.XRPLNumber {
+	return state.NewXRPLNumberScaled(v, 0, scale, state.RoundToNearest)
 }
 
-func vvNumFromAmount(a state.Amount) state.XRPLNumber {
+func vvNumFromU64(v uint64, scale state.MantissaScale) state.XRPLNumber {
+	return vvNumFromI64(int64(v), scale)
+}
+
+func vvNumFromAmount(a state.Amount, scale state.MantissaScale) state.XRPLNumber {
 	if a.IsNative() {
-		return vvNumFromI64(a.Drops())
+		return vvNumFromI64(a.Drops(), scale)
 	}
 	if a.IsMPT() {
 		n, _ := strconv.ParseInt(a.Value(), 10, 64)
-		return vvNumFromI64(n)
+		return vvNumFromI64(n, scale)
 	}
-	return state.NewXRPLNumberScaled(a.Mantissa(), a.Exponent(), state.MantissaScaleLarge, state.RoundToNearest)
+	return state.NewXRPLNumberScaled(a.Mantissa(), a.Exponent(), scale, state.RoundToNearest)
 }
 
 // vvCoarsestScale returns the largest scale among the deltas, or 0 when none.
@@ -810,13 +843,13 @@ func vvMPTIDIssuer(id [24]byte) [20]byte {
 	return issuer
 }
 
-func vvMakeVault(m map[string]any, key [32]byte) (vvVault, bool) {
+func vvMakeVault(m map[string]any, key [32]byte, scale state.MantissaScale) (vvVault, bool) {
 	v := vvVault{key: key}
 	am, ok := m["Asset"].(map[string]any)
 	if !ok {
 		return v, false
 	}
-	v.asset = vvAssetFromMap(am)
+	v.asset = vvAssetFromMap(am, scale)
 	pseudo, err := state.DecodeAccountID(vvStr(m, "Account"))
 	if err != nil {
 		return v, false
@@ -828,16 +861,16 @@ func vvMakeVault(m map[string]any, key [32]byte) (vvVault, bool) {
 	if b, herr := hex.DecodeString(vvStr(m, "ShareMPTID")); herr == nil && len(b) == 24 {
 		copy(v.shareMPTID[:], b)
 	}
-	v.assetsTotal = vvNumber(m, "AssetsTotal")
-	v.assetsAvailable = vvNumber(m, "AssetsAvailable")
-	v.assetsMaximum = vvNumber(m, "AssetsMaximum")
-	v.lossUnrealized = vvNumber(m, "LossUnrealized")
+	v.assetsTotal = vvNumber(m, "AssetsTotal", scale)
+	v.assetsAvailable = vvNumber(m, "AssetsAvailable", scale)
+	v.assetsMaximum = vvNumber(m, "AssetsMaximum", scale)
+	v.lossUnrealized = vvNumber(m, "LossUnrealized", scale)
 	return v, true
 }
 
-func vvAssetFromMap(m map[string]any) vvAsset {
+func vvAssetFromMap(m map[string]any, scale state.MantissaScale) vvAsset {
 	if mptID, ok := m["mpt_issuance_id"].(string); ok {
-		a := vvAsset{isMPT: true}
+		a := vvAsset{isMPT: true, numberScale: scale}
 		if b, err := hex.DecodeString(mptID); err == nil && len(b) == 24 {
 			copy(a.mptID[:], b)
 		}
@@ -846,9 +879,9 @@ func vvAssetFromMap(m map[string]any) vvAsset {
 	cur, _ := m["currency"].(string)
 	iss, _ := m["issuer"].(string)
 	if isNativeXRPCurrency(cur) && iss == "" {
-		return vvAsset{isXRP: true}
+		return vvAsset{isXRP: true, numberScale: scale}
 	}
-	a := vvAsset{currency: cur}
+	a := vvAsset{currency: cur, numberScale: scale}
 	if id, err := state.DecodeAccountID(iss); err == nil {
 		a.issuer = id
 	}
@@ -936,20 +969,17 @@ func vvI64(m map[string]any, key string) int64 {
 	return 0
 }
 
-func vvNumber(m map[string]any, key string) state.XRPLNumber {
-	return vvParseNumber(vvStr(m, key))
+func vvNumber(m map[string]any, key string, scale state.MantissaScale) state.XRPLNumber {
+	return vvParseNumber(vvStr(m, key), scale)
 }
 
-func vvParseNumber(s string) state.XRPLNumber {
+func vvParseNumber(s string, scale state.MantissaScale) state.XRPLNumber {
 	if s == "" || s == "0" {
-		return vvZero()
+		return vvZero(scale)
 	}
-	num := &types.Number{}
-	b, err := num.FromJSON(s)
-	if err != nil || len(b) < 12 {
-		return vvZero()
+	number, err := state.ParseXRPLNumber(s, scale, state.RoundToNearest)
+	if err != nil {
+		return vvZero(scale)
 	}
-	mant := int64(binary.BigEndian.Uint64(b[:8]))
-	exp := int32(binary.BigEndian.Uint32(b[8:12]))
-	return state.NewXRPLNumberScaled(mant, int(exp), state.MantissaScaleLarge, state.RoundToNearest)
+	return number
 }

--- a/internal/tx/invariants/vault_test.go
+++ b/internal/tx/invariants/vault_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
@@ -36,9 +37,20 @@ func vvTestIDs() (owner, pseudo [20]byte, ownerAddr, pseudoAddr string, shareMPT
 	return
 }
 
-// vvCraftVault encodes an XRP Vault ledger entry with the given NUMBER totals
-// (empty string ⇒ omit / soeDEFAULT zero).
-func vvCraftVault(t *testing.T, ownerAddr, pseudoAddr string, shareMPTID [24]byte, total, available, maximum, loss string) []byte {
+func vvTestAccount(t *testing.T, fill byte) ([20]byte, string) {
+	t.Helper()
+	var id [20]byte
+	for i := range id {
+		id[i] = fill
+	}
+	addr, err := state.EncodeAccountID(id)
+	if err != nil {
+		t.Fatalf("EncodeAccountID: %v", err)
+	}
+	return id, addr
+}
+
+func vvCraftVaultAsset(t *testing.T, ownerAddr, pseudoAddr string, asset map[string]any, shareMPTID [24]byte, total, available, maximum, loss string) []byte {
 	t.Helper()
 	m := map[string]any{
 		"LedgerEntryType":  "Vault",
@@ -47,7 +59,7 @@ func vvCraftVault(t *testing.T, ownerAddr, pseudoAddr string, shareMPTID [24]byt
 		"OwnerNode":        "0",
 		"Owner":            ownerAddr,
 		"Account":          pseudoAddr,
-		"Asset":            map[string]any{"currency": "XRP"},
+		"Asset":            asset,
 		"ShareMPTID":       strings.ToUpper(hex.EncodeToString(shareMPTID[:])),
 		"WithdrawalPolicy": 1,
 	}
@@ -66,6 +78,21 @@ func vvCraftVault(t *testing.T, ownerAddr, pseudoAddr string, shareMPTID [24]byt
 	return mustEncode(t, m)
 }
 
+func vvCraftVault(t *testing.T, ownerAddr, pseudoAddr string, shareMPTID [24]byte, total, available, maximum, loss string) []byte {
+	t.Helper()
+	return vvCraftVaultAsset(
+		t, ownerAddr, pseudoAddr, map[string]any{"currency": "XRP"},
+		shareMPTID, total, available, maximum, loss)
+}
+
+func vvCraftIOUVault(t *testing.T, ownerAddr, pseudoAddr, issuerAddr string, shareMPTID [24]byte, total, available string) []byte {
+	t.Helper()
+	return vvCraftVaultAsset(
+		t, ownerAddr, pseudoAddr,
+		map[string]any{"currency": "USD", "issuer": issuerAddr},
+		shareMPTID, total, available, "", "")
+}
+
 func vvCraftIssuance(t *testing.T, issuer [20]byte, seq uint32, outstanding uint64) []byte {
 	t.Helper()
 	return mustSerializeMPTIssuance(t, &state.MPTokenIssuanceData{
@@ -77,8 +104,102 @@ func vvCraftIssuance(t *testing.T, issuer [20]byte, seq uint32, outstanding uint
 	})
 }
 
+func vvCraftMPToken(t *testing.T, account [20]byte, shareMPTID [24]byte, amount uint64) []byte {
+	t.Helper()
+	b, err := state.SerializeMPToken(&state.MPTokenData{
+		Account:           account,
+		MPTokenIssuanceID: shareMPTID,
+		MPTAmount:         amount,
+	})
+	if err != nil {
+		t.Fatalf("SerializeMPToken: %v", err)
+	}
+	return b
+}
+
+func vvIssuanceEntry(t *testing.T, pseudo [20]byte, shareMPTID [24]byte, before, after uint64) InvariantEntry {
+	t.Helper()
+	return InvariantEntry{
+		Key:       keylet.MPTIssuance(shareMPTID).Key,
+		EntryType: "MPTokenIssuance",
+		Before:    vvCraftIssuance(t, pseudo, 1, before),
+		After:     vvCraftIssuance(t, pseudo, 1, after),
+	}
+}
+
+func vvMPTokenEntry(t *testing.T, account [20]byte, shareMPTID [24]byte, before, after uint64) InvariantEntry {
+	t.Helper()
+	return InvariantEntry{
+		Key:       keylet.MPTokenByID(shareMPTID, account).Key,
+		EntryType: "MPToken",
+		Before:    vvCraftMPToken(t, account, shareMPTID, before),
+		After:     vvCraftMPToken(t, account, shareMPTID, after),
+	}
+}
+
+func vvIOULineEntry(t *testing.T, account, issuer [20]byte, before, after string) InvariantEntry {
+	t.Helper()
+	low, high := account, issuer
+	if state.CompareAccountIDs(low, high) > 0 {
+		low, high = high, low
+	}
+	lowAddr, err := state.EncodeAccountID(low)
+	if err != nil {
+		t.Fatalf("EncodeAccountID(low): %v", err)
+	}
+	highAddr, err := state.EncodeAccountID(high)
+	if err != nil {
+		t.Fatalf("EncodeAccountID(high): %v", err)
+	}
+	encode := func(value string) []byte {
+		balance, err := state.NewIssuedAmountFromDecimalString(value, "USD", state.AccountOneAddress)
+		if err != nil {
+			t.Fatalf("NewIssuedAmountFromDecimalString(%q): %v", value, err)
+		}
+		if account == high {
+			balance = balance.Negate()
+		}
+		lowLimit, err := state.NewIssuedAmountFromDecimalString("100000000000000000", "USD", lowAddr)
+		if err != nil {
+			t.Fatalf("low limit: %v", err)
+		}
+		highLimit, err := state.NewIssuedAmountFromDecimalString("100000000000000000", "USD", highAddr)
+		if err != nil {
+			t.Fatalf("high limit: %v", err)
+		}
+		b, err := state.SerializeRippleState(&state.RippleState{
+			Balance: balance, LowLimit: lowLimit, HighLimit: highLimit,
+		})
+		if err != nil {
+			t.Fatalf("SerializeRippleState: %v", err)
+		}
+		return b
+	}
+	return InvariantEntry{
+		Key:       keylet.Line(account, issuer, "USD").Key,
+		EntryType: "RippleState",
+		Before:    encode(before),
+		After:     encode(after),
+	}
+}
+
 func savRules() *amendment.Rules {
 	return amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault, amendment.FeatureFixCleanup3_1_3})
+}
+
+func savFixedRules() *amendment.Rules {
+	return amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault,
+		amendment.FeatureFixCleanup3_1_3,
+		amendment.FeatureFixCleanup3_2_0,
+	})
+}
+
+func vvInvariantResult(violation *InvariantViolation) ter.Result {
+	if violation != nil {
+		return ter.TecINVARIANT_FAILED
+	}
+	return ter.TesSUCCESS
 }
 
 // TestValidVault_StructuralViolations crafts vault-modifying transactions that
@@ -208,11 +329,9 @@ func TestValidVault_EnforceGate(t *testing.T) {
 	}
 }
 
-// TestVaultMinScale_AmendmentGate pins the fixCleanup3_2_0 computeVaultMinScale
-// site: post-amendment the reconciliation rounds deltas at the posterior
-// AssetsTotal scale; pre-amendment at the coarsest delta scale. For an IOU these
-// diverge; for the integral (XRP/MPT) assets ValidVault actually reconciles they
-// both collapse to zero, which is why the gate is a structural no-op in practice.
+// TestVaultMinScale_AmendmentGate pins the fixCleanup3_2_0 scale selection:
+// post-amendment reconciliation uses the posterior AssetsTotal scale while the
+// legacy path uses the coarsest modified-value scale.
 func TestVaultMinScale_AmendmentGate(t *testing.T) {
 	fixOn := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault, amendment.FeatureFixCleanup3_2_0})
 	fixOff := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
@@ -236,5 +355,271 @@ func TestVaultMinScale_AmendmentGate(t *testing.T) {
 	if on, off := (&vvChecker{rules: fixOn}).vaultMinScale(xrp, afterXRP, xrpDelta),
 		(&vvChecker{rules: fixOff}).vaultMinScale(xrp, afterXRP, xrpDelta); on != 0 || off != 0 {
 		t.Fatalf("integral min-scale must be 0 in both eras: on=%d off=%d", on, off)
+	}
+}
+
+func TestValidVault_IOUAssetReconciliation(t *testing.T) {
+	owner, ownerAddr := vvTestAccount(t, 0x11)
+	pseudo, pseudoAddr := vvTestAccount(t, 0x22)
+	issuer, issuerAddr := vvTestAccount(t, 0x33)
+	shareMPTID := keylet.MakeMPTID(1, pseudo)
+	vault := func(total, available string) []byte {
+		return vvCraftIOUVault(t, ownerAddr, pseudoAddr, issuerAddr, shareMPTID, total, available)
+	}
+	issuance := func(before, after uint64) InvariantEntry {
+		return vvIssuanceEntry(t, pseudo, shareMPTID, before, after)
+	}
+	holderShares := func(before, after uint64) InvariantEntry {
+		return vvMPTokenEntry(t, owner, shareMPTID, before, after)
+	}
+	amount := func(value string) map[string]any {
+		return map[string]any{"currency": "USD", "issuer": issuerAddr, "value": value}
+	}
+
+	tests := []struct {
+		name    string
+		tx      vvTx
+		entries []InvariantEntry
+		wantMsg string
+	}{
+		{
+			name: "set rejects canonical vault line movement",
+			tx:   vvTx{txType: protocol.TxTypeVaultSet, acct: ownerAddr},
+			entries: []InvariantEntry{
+				{EntryType: "Vault", Before: vault("1000", "1000"), After: vault("1000", "1000")},
+				issuance(1000, 1000),
+				vvIOULineEntry(t, pseudo, issuer, "1000", "1001"),
+			},
+			wantMsg: "set must not change vault balance",
+		},
+		{
+			name: "deposit reconciles canonical issuer lines",
+			tx: vvTx{txType: protocol.TxTypeVaultDeposit, acct: ownerAddr, flat: map[string]any{
+				"Amount": amount("5"),
+			}},
+			entries: []InvariantEntry{
+				{EntryType: "Vault", Before: vault("1000", "1000"), After: vault("1005", "1005")},
+				issuance(1000, 1005),
+				holderShares(1000, 1005),
+				vvIOULineEntry(t, pseudo, issuer, "1000", "1005"),
+				vvIOULineEntry(t, owner, issuer, "100", "95"),
+			},
+		},
+		{
+			name: "deposit rejects unequal canonical issuer line movements",
+			tx: vvTx{txType: protocol.TxTypeVaultDeposit, acct: ownerAddr, flat: map[string]any{
+				"Amount": amount("5"),
+			}},
+			entries: []InvariantEntry{
+				{EntryType: "Vault", Before: vault("1000", "1000"), After: vault("1005", "1005")},
+				issuance(1000, 1005),
+				holderShares(1000, 1005),
+				vvIOULineEntry(t, pseudo, issuer, "1000", "1004"),
+				vvIOULineEntry(t, owner, issuer, "100", "95"),
+			},
+			wantMsg: "deposit must change vault and depositor balance by equal amount",
+		},
+		{
+			name: "withdraw reconciles canonical vault line",
+			tx: vvTx{txType: protocol.TxTypeVaultWithdraw, acct: ownerAddr, flat: map[string]any{
+				"Destination": issuerAddr,
+			}},
+			entries: []InvariantEntry{
+				{EntryType: "Vault", Before: vault("1000", "1000"), After: vault("995", "995")},
+				issuance(1000, 995),
+				holderShares(1000, 995),
+				vvIOULineEntry(t, pseudo, issuer, "1000", "995"),
+			},
+		},
+		{
+			name: "withdraw rejects vault total mismatch",
+			tx: vvTx{txType: protocol.TxTypeVaultWithdraw, acct: ownerAddr, flat: map[string]any{
+				"Destination": issuerAddr,
+			}},
+			entries: []InvariantEntry{
+				{EntryType: "Vault", Before: vault("1000", "1000"), After: vault("995", "995")},
+				issuance(1000, 995),
+				holderShares(1000, 995),
+				vvIOULineEntry(t, pseudo, issuer, "1000", "996"),
+			},
+			wantMsg: "withdrawal and assets outstanding must add up",
+		},
+		{
+			name: "clawback reconciles canonical vault line",
+			tx: vvTx{txType: protocol.TxTypeVaultClawback, acct: issuerAddr, flat: map[string]any{
+				"Holder": ownerAddr,
+			}},
+			entries: []InvariantEntry{
+				{EntryType: "Vault", Before: vault("1000", "1000"), After: vault("995", "995")},
+				issuance(1000, 995),
+				holderShares(1000, 995),
+				vvIOULineEntry(t, pseudo, issuer, "1000", "995"),
+			},
+		},
+		{
+			name: "clawback rejects vault total mismatch",
+			tx: vvTx{txType: protocol.TxTypeVaultClawback, acct: issuerAddr, flat: map[string]any{
+				"Holder": ownerAddr,
+			}},
+			entries: []InvariantEntry{
+				{EntryType: "Vault", Before: vault("1000", "1000"), After: vault("995", "995")},
+				issuance(1000, 995),
+				holderShares(1000, 995),
+				vvIOULineEntry(t, pseudo, issuer, "1000", "996"),
+			},
+			wantMsg: "clawback and assets outstanding must add up",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			violation := checkValidVault(tc.tx, TesSUCCESS, 0, tc.entries, stubView{}, savFixedRules())
+			got := ""
+			if violation != nil {
+				got = violation.Message
+			}
+			if got != tc.wantMsg {
+				t.Fatalf("checkValidVault = %q, want %q", got, tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestValidVault_IOUScaleBoundaryAmendment(t *testing.T) {
+	owner, ownerAddr := vvTestAccount(t, 0x11)
+	pseudo, pseudoAddr := vvTestAccount(t, 0x22)
+	issuer, issuerAddr := vvTestAccount(t, 0x33)
+	shareMPTID := keylet.MakeMPTID(1, pseudo)
+	vault := func(total string) []byte {
+		return vvCraftIOUVault(t, ownerAddr, pseudoAddr, issuerAddr, shareMPTID, total, total)
+	}
+	baseEntries := func() []InvariantEntry {
+		return []InvariantEntry{
+			{
+				EntryType: "Vault",
+				Before:    vault("10000000000000000"),
+				After:     vault("9999999999999995"),
+			},
+			vvIssuanceEntry(t, pseudo, shareMPTID, 1000, 995),
+			vvMPTokenEntry(t, owner, shareMPTID, 1000, 995),
+			vvIOULineEntry(t, pseudo, issuer, "10000000000000000", "9999999999999995"),
+		}
+	}
+	tests := []struct {
+		name       string
+		tx         vvTx
+		rules      *amendment.Rules
+		wantResult ter.Result
+	}{
+		{
+			name: "withdraw pre-fix",
+			tx: vvTx{txType: protocol.TxTypeVaultWithdraw, acct: ownerAddr, flat: map[string]any{
+				"Destination": issuerAddr,
+			}},
+			rules: savRules(), wantResult: ter.TecINVARIANT_FAILED,
+		},
+		{
+			name: "withdraw post-fix",
+			tx: vvTx{txType: protocol.TxTypeVaultWithdraw, acct: ownerAddr, flat: map[string]any{
+				"Destination": issuerAddr,
+			}},
+			rules: savFixedRules(), wantResult: ter.TesSUCCESS,
+		},
+		{
+			name: "clawback pre-fix",
+			tx: vvTx{txType: protocol.TxTypeVaultClawback, acct: issuerAddr, flat: map[string]any{
+				"Holder": ownerAddr,
+			}},
+			rules: savRules(), wantResult: ter.TecINVARIANT_FAILED,
+		},
+		{
+			name: "clawback post-fix",
+			tx: vvTx{txType: protocol.TxTypeVaultClawback, acct: issuerAddr, flat: map[string]any{
+				"Holder": ownerAddr,
+			}},
+			rules: savFixedRules(), wantResult: ter.TesSUCCESS,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			violation := checkValidVault(tc.tx, TesSUCCESS, 0, baseEntries(), stubView{}, tc.rules)
+			message := ""
+			if violation != nil {
+				message = violation.Message
+			}
+			result := vvInvariantResult(violation)
+			if result != tc.wantResult {
+				t.Fatalf("result = %s, want %s (violation %q)", result, tc.wantResult, message)
+			}
+		})
+	}
+}
+
+func TestValidVault_IOUWithdrawDestinationRounding(t *testing.T) {
+	owner, ownerAddr := vvTestAccount(t, 0x11)
+	pseudo, pseudoAddr := vvTestAccount(t, 0x22)
+	issuer, issuerAddr := vvTestAccount(t, 0x33)
+	destination, destinationAddr := vvTestAccount(t, 0x44)
+	shareMPTID := keylet.MakeMPTID(1, pseudo)
+	vault := func(total string) []byte {
+		return vvCraftIOUVault(t, ownerAddr, pseudoAddr, issuerAddr, shareMPTID, total, total)
+	}
+	entries := func(after string, shares uint64) []InvariantEntry {
+		return []InvariantEntry{
+			{EntryType: "Vault", Before: vault("1000"), After: vault(after)},
+			vvIssuanceEntry(t, pseudo, shareMPTID, 1000, shares),
+			vvMPTokenEntry(t, owner, shareMPTID, 1000, shares),
+			vvIOULineEntry(t, pseudo, issuer, "1000", after),
+			vvIOULineEntry(t, destination, issuer, "9999999999999995", "10000000000000000"),
+		}
+	}
+	tx := vvTx{txType: protocol.TxTypeVaultWithdraw, acct: ownerAddr, flat: map[string]any{
+		"Destination": destinationAddr,
+	}}
+	tests := []struct {
+		name       string
+		rules      *amendment.Rules
+		entries    []InvariantEntry
+		wantResult ter.Result
+		wantMsg    string
+	}{
+		{
+			name:       "pre-fix zero-rounded destination",
+			rules:      savRules(),
+			entries:    entries("994", 994),
+			wantResult: ter.TecINVARIANT_FAILED,
+			wantMsg:    "withdrawal must increase destination balance",
+		},
+		{
+			name:       "post-fix sub-ULP destruction",
+			rules:      savFixedRules(),
+			entries:    entries("994", 994),
+			wantResult: ter.TesSUCCESS,
+		},
+		{
+			name:       "post-fix exact-ULP destruction",
+			rules:      savFixedRules(),
+			entries:    entries("985", 985),
+			wantResult: ter.TecINVARIANT_FAILED,
+			wantMsg:    "withdrawal must change vault and destination balance by equal amount",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			violation := checkValidVault(tx, TesSUCCESS, 0, tc.entries, stubView{}, tc.rules)
+			message := ""
+			if violation != nil {
+				message = violation.Message
+			}
+			result := vvInvariantResult(violation)
+			if result != tc.wantResult {
+				t.Fatalf("result = %s, want %s (violation %q)", result, tc.wantResult, message)
+			}
+			if message != tc.wantMsg {
+				t.Fatalf("violation = %q, want %q", message, tc.wantMsg)
+			}
+		})
 	}
 }

--- a/internal/tx/mptutil/mpt.go
+++ b/internal/tx/mptutil/mpt.go
@@ -11,8 +11,8 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	tx "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/credential"
+	"github.com/LeJamon/go-xrpl/internal/tx/ledgerfields"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
-	"github.com/LeJamon/go-xrpl/internal/tx/vault"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -20,6 +20,14 @@ import (
 const RateOne uint32 = 1_000_000_000
 
 const maxAssetCheckDepth = 5
+
+type AuthType uint8
+
+const (
+	StrongAuth AuthType = iota
+	WeakAuth
+	LegacyAuth
+)
 
 var ErrInvalidID = errors.New("invalid MPTokenIssuanceID")
 
@@ -166,11 +174,22 @@ func isVaultPseudoAccountFrozen(view state.LedgerView, id [24]byte, account [20]
 	if err != nil || !issuer.HasVaultID() {
 		return false
 	}
-	vaultInfo, err := vault.ReadVaultInfo(view, keylet.VaultByID(issuer.VaultID))
-	if err != nil || vaultInfo == nil {
+	asset, result := vaultAsset(view, issuer.VaultID)
+	if result != ter.TesSUCCESS {
 		return false
 	}
-	return isAnyAssetFrozen(view, vaultInfo.Asset, [][20]byte{issuance.Issuer, account}, depth+1)
+	return isAnyAssetFrozen(view, asset, [][20]byte{issuance.Issuer, account}, depth+1)
+}
+
+func IsAssetFrozen(view state.LedgerView, asset tx.Asset, account [20]byte) bool {
+	if asset.IsNative() {
+		return false
+	}
+	if asset.IsMPT() {
+		id, err := DecodeID(asset.MPTIssuanceID)
+		return err == nil && IsFrozen(view, id, account)
+	}
+	return isIOUFrozen(view, account, asset)
 }
 
 func isAnyAssetFrozen(view state.LedgerView, asset tx.Asset, accounts [][20]byte, depth uint8) bool {
@@ -203,14 +222,30 @@ func TransferRate(view state.LedgerView, id [24]byte) uint32 {
 }
 
 func RequireAuth(view state.LedgerView, id [24]byte, account [20]byte, strong bool) ter.Result {
-	return RequireAuthAt(view, id, account, strong, 0)
+	authType := WeakAuth
+	if strong {
+		authType = StrongAuth
+	}
+	return RequireAuthWithTypeAt(view, id, account, authType, 0)
 }
 
 func RequireAuthAt(view state.LedgerView, id [24]byte, account [20]byte, strong bool, parentCloseTime uint32) ter.Result {
-	return requireAuthAt(view, id, account, strong, parentCloseTime, 0)
+	authType := WeakAuth
+	if strong {
+		authType = StrongAuth
+	}
+	return RequireAuthWithTypeAt(view, id, account, authType, parentCloseTime)
 }
 
-func requireAuthAt(view state.LedgerView, id [24]byte, account [20]byte, strong bool, parentCloseTime uint32, depth uint8) ter.Result {
+func RequireAuthWithType(view state.LedgerView, id [24]byte, account [20]byte, authType AuthType) ter.Result {
+	return RequireAuthWithTypeAt(view, id, account, authType, 0)
+}
+
+func RequireAuthWithTypeAt(view state.LedgerView, id [24]byte, account [20]byte, authType AuthType, parentCloseTime uint32) ter.Result {
+	return requireAuthAt(view, id, account, authType, parentCloseTime, 0)
+}
+
+func requireAuthAt(view state.LedgerView, id [24]byte, account [20]byte, authType AuthType, parentCloseTime uint32, depth uint8) ter.Result {
 	issuance, _, result := ReadIssuance(view, id)
 	if result != ter.TesSUCCESS {
 		return result
@@ -231,11 +266,11 @@ func requireAuthAt(view state.LedgerView, id [24]byte, account [20]byte, strong 
 			return ter.TefINTERNAL
 		}
 		if issuer.HasVaultID() {
-			vaultInfo, err := vault.ReadVaultInfo(view, keylet.VaultByID(issuer.VaultID))
-			if err != nil || vaultInfo == nil {
+			asset, result := vaultAsset(view, issuer.VaultID)
+			if result != ter.TesSUCCESS {
 				return ter.TefINTERNAL
 			}
-			if result := requireAssetAuthAt(view, vaultInfo.Asset, account, strong, parentCloseTime, depth+1); result != ter.TesSUCCESS {
+			if result := requireAssetAuthWithTypeAt(view, asset, account, authType, parentCloseTime, depth+1); result != ter.TesSUCCESS {
 				return result
 			}
 		}
@@ -246,12 +281,12 @@ func requireAuthAt(view state.LedgerView, id [24]byte, account [20]byte, strong 
 		if tokenResult != ter.TecNO_AUTH {
 			return tokenResult
 		}
-		if strong {
+		if authType == StrongAuth || authType == LegacyAuth {
 			return ter.TecNO_AUTH
 		}
 	}
 	if issuance.DomainID != nil {
-		domainResult := validDomain(view, *issuance.DomainID, account, parentCloseTime)
+		domainResult := ValidDomain(view, *issuance.DomainID, account, parentCloseTime)
 		if domainResult == ter.TesSUCCESS {
 			return ter.TesSUCCESS
 		}
@@ -287,13 +322,25 @@ func requireAuthAt(view state.LedgerView, id [24]byte, account [20]byte, strong 
 	return ter.TecNO_AUTH
 }
 
+func RequireAssetAuthAt(view state.LedgerView, asset tx.Asset, account [20]byte, authType AuthType, parentCloseTime uint32) ter.Result {
+	return requireAssetAuthWithTypeAt(view, asset, account, authType, parentCloseTime, 0)
+}
+
 func requireAssetAuthAt(view state.LedgerView, asset tx.Asset, account [20]byte, strong bool, parentCloseTime uint32, depth uint8) ter.Result {
+	authType := WeakAuth
+	if strong {
+		authType = StrongAuth
+	}
+	return requireAssetAuthWithTypeAt(view, asset, account, authType, parentCloseTime, depth)
+}
+
+func requireAssetAuthWithTypeAt(view state.LedgerView, asset tx.Asset, account [20]byte, authType AuthType, parentCloseTime uint32, depth uint8) ter.Result {
 	if asset.IsMPT() {
 		id, err := DecodeID(asset.MPTIssuanceID)
 		if err != nil {
 			return ter.TefINTERNAL
 		}
-		return requireAuthAt(view, id, account, strong, parentCloseTime, depth)
+		return requireAuthAt(view, id, account, authType, parentCloseTime, depth)
 	}
 	if asset.IsNative() {
 		return ter.TesSUCCESS
@@ -309,7 +356,7 @@ func requireAssetAuthAt(view state.LedgerView, asset tx.Asset, account [20]byte,
 	if err != nil {
 		return ter.TefINTERNAL
 	}
-	if lineRaw == nil && strong {
+	if lineRaw == nil && authType == StrongAuth {
 		return ter.TecNO_LINE
 	}
 	issuerRaw, err := view.Read(keylet.Account(issuer))
@@ -375,7 +422,7 @@ func isIOUFrozen(view state.LedgerView, account [20]byte, asset tx.Asset) bool {
 	return line.Flags&state.LsfLowFreeze != 0
 }
 
-func validDomain(view state.LedgerView, domainIDHex string, account [20]byte, parentCloseTime uint32) ter.Result {
+func ValidDomain(view state.LedgerView, domainIDHex string, account [20]byte, parentCloseTime uint32) ter.Result {
 	domainBytes, err := hex.DecodeString(domainIDHex)
 	if err != nil || len(domainBytes) != 32 {
 		return ter.TefINTERNAL
@@ -420,6 +467,10 @@ func validDomain(view state.LedgerView, domainIDHex string, account [20]byte, pa
 	return ter.TecNO_AUTH
 }
 
+func validDomain(view state.LedgerView, domainIDHex string, account [20]byte, parentCloseTime uint32) ter.Result {
+	return ValidDomain(view, domainIDHex, account, parentCloseTime)
+}
+
 func CanTrade(view state.LedgerView, id [24]byte) ter.Result {
 	return canTrade(view, id, 0)
 }
@@ -453,15 +504,19 @@ func canTrade(view state.LedgerView, id [24]byte, depth uint8) ter.Result {
 }
 
 func CanTransfer(view state.LedgerView, id [24]byte, from, to [20]byte) ter.Result {
-	return canTransfer(view, id, from, to, 0)
+	return canTransfer(view, id, from, to, false, 0)
 }
 
-func canTransfer(view state.LedgerView, id [24]byte, from, to [20]byte, depth uint8) ter.Result {
+func CanTransferWithWaive(view state.LedgerView, id [24]byte, from, to [20]byte, waiveMPTCanTransfer bool) ter.Result {
+	return canTransfer(view, id, from, to, waiveMPTCanTransfer, 0)
+}
+
+func canTransfer(view state.LedgerView, id [24]byte, from, to [20]byte, waiveMPTCanTransfer bool, depth uint8) ter.Result {
 	issuance, _, result := ReadIssuance(view, id)
 	if result != ter.TesSUCCESS {
 		return result
 	}
-	if from == issuance.Issuer || to == issuance.Issuer {
+	if waiveMPTCanTransfer || from == issuance.Issuer || to == issuance.Issuer {
 		return ter.TesSUCCESS
 	}
 	if issuance.Flags&entry.LsfMPTCanTransfer == 0 {
@@ -476,18 +531,26 @@ func canTransfer(view state.LedgerView, id [24]byte, from, to [20]byte, depth ui
 		if result != ter.TesSUCCESS {
 			return result
 		}
-		return canTransferAsset(view, asset, from, to, depth+1)
+		return canTransferAssetWithWaive(view, asset, from, to, false, depth+1)
 	}
 	return ter.TesSUCCESS
 }
 
+func CanTransferAsset(view state.LedgerView, asset tx.Asset, from, to [20]byte, waiveMPTCanTransfer bool) ter.Result {
+	return canTransferAssetWithWaive(view, asset, from, to, waiveMPTCanTransfer, 0)
+}
+
 func canTransferAsset(view state.LedgerView, asset tx.Asset, from, to [20]byte, depth uint8) ter.Result {
+	return canTransferAssetWithWaive(view, asset, from, to, false, depth)
+}
+
+func canTransferAssetWithWaive(view state.LedgerView, asset tx.Asset, from, to [20]byte, waiveMPTCanTransfer bool, depth uint8) ter.Result {
 	if asset.IsMPT() {
 		id, err := DecodeID(asset.MPTIssuanceID)
 		if err != nil {
 			return ter.TefINTERNAL
 		}
-		return canTransfer(view, id, from, to, depth)
+		return canTransfer(view, id, from, to, waiveMPTCanTransfer, depth)
 	}
 	if asset.IsNative() {
 		return ter.TesSUCCESS
@@ -580,6 +643,33 @@ func referencedAsset(view state.LedgerView, issuance *state.MPTokenIssuanceData)
 	default:
 		return tx.Asset{}, ter.TefINTERNAL
 	}
+}
+
+func vaultAsset(view state.LedgerView, vaultID [32]byte) (tx.Asset, ter.Result) {
+	raw, err := view.Read(keylet.VaultByID(vaultID))
+	if err != nil || raw == nil {
+		return tx.Asset{}, ter.TefINTERNAL
+	}
+	decoded := new(ledgerfields.Vault)
+	if err := decoded.Decode(raw); err != nil {
+		return tx.Asset{}, ter.TefINTERNAL
+	}
+	issue, ok := decoded.Asset.(map[string]any)
+	if !ok {
+		return tx.Asset{}, ter.TefINTERNAL
+	}
+	if id, ok := issue["mpt_issuance_id"].(string); ok {
+		if _, err := DecodeID(id); err != nil {
+			return tx.Asset{}, ter.TefINTERNAL
+		}
+		return tx.Asset{MPTIssuanceID: id}, ter.TesSUCCESS
+	}
+	currency, ok := issue["currency"].(string)
+	if !ok || currency == "" {
+		return tx.Asset{}, ter.TefINTERNAL
+	}
+	issuer, _ := issue["issuer"].(string)
+	return tx.Asset{Currency: currency, Issuer: issuer}, ter.TesSUCCESS
 }
 
 func Funds(view state.LedgerView, id [24]byte, account [20]byte, zeroIfFrozen bool) (int64, ter.Result) {
@@ -715,7 +805,10 @@ func RemoveHolding(view state.LedgerView, id [24]byte, holder [20]byte, adjustOw
 	if err != nil {
 		return ter.TefINTERNAL
 	}
-	if token.MPTAmount != 0 || token.LockedAmount != nil && *token.LockedAmount != 0 {
+	rules := view.Rules()
+	lockedObligation := rules != nil && rules.Enabled(amendment.FeatureFixCleanup3_1_3) &&
+		token.LockedAmount != nil && *token.LockedAmount != 0
+	if token.MPTAmount != 0 || lockedObligation {
 		return ter.TecHAS_OBLIGATIONS
 	}
 	removed, err := state.DirRemove(view, keylet.OwnerDir(holder), token.OwnerNode, tokenKey.Key, false)

--- a/internal/tx/owner_count.go
+++ b/internal/tx/owner_count.go
@@ -24,6 +24,11 @@ func confineOwnerCount(current uint32, adjustment int) uint32 {
 	return current - uint32(-adjustment)
 }
 
+// ConfineOwnerCount applies rippled's saturating OwnerCount arithmetic.
+func ConfineOwnerCount(current uint32, adjustment int) uint32 {
+	return confineOwnerCount(current, adjustment)
+}
+
 // AdjustOwnerCount adjusts an account's OwnerCount by delta on a LedgerView
 // without updating PreviousTxn fields.
 // Returns an error if the account cannot be read or serialized.

--- a/internal/tx/parse.go
+++ b/internal/tx/parse.go
@@ -27,6 +27,11 @@ func ParseJSON(data []byte) (Transaction, error) {
 		if err := json.Unmarshal(data, &baseTx); err != nil {
 			return nil, fmt.Errorf("failed to parse transaction: %w", err)
 		}
+		presentFields, err := jsonPresentFields(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse transaction fields: %w", err)
+		}
+		baseTx.SetPresentFields(presentFields)
 		baseTx.txType = txType
 		return &baseTx, nil
 	}

--- a/internal/tx/registry.go
+++ b/internal/tx/registry.go
@@ -62,8 +62,25 @@ func FromJSON(data []byte) (Transaction, error) {
 	if err := json.Unmarshal(data, tx); err != nil {
 		return nil, err
 	}
+	presentFields, err := jsonPresentFields(data)
+	if err != nil {
+		return nil, err
+	}
+	tx.GetCommon().SetPresentFields(presentFields)
 
 	return tx, nil
+}
+
+func jsonPresentFields(data []byte) (map[string]bool, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	fields := make(map[string]bool, len(raw))
+	for name := range raw {
+		fields[name] = true
+	}
+	return fields, nil
 }
 
 // ToJSON converts a Transaction to JSON

--- a/internal/tx/reserve.go
+++ b/internal/tx/reserve.go
@@ -24,7 +24,7 @@ func (c EngineConfig) ReserveForNewObject(currentOwnerCount uint32) uint64 {
 	if currentOwnerCount < 2 {
 		return 0
 	}
-	return c.AccountReserve(currentOwnerCount + 1)
+	return c.AccountReserve(ConfineOwnerCount(currentOwnerCount, 1))
 }
 
 // CanCreateNewObject reports whether priorBalance (balance before fee deduction)

--- a/internal/tx/vault/apply_helpers.go
+++ b/internal/tx/vault/apply_helpers.go
@@ -3,11 +3,13 @@ package vault
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"strings"
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
@@ -35,7 +37,10 @@ func mptIDIssuer(id [24]byte) [20]byte {
 // absent.
 func readMPTIssuance(view tx.LedgerView, id [24]byte) (*state.MPTokenIssuanceData, error) {
 	data, err := view.Read(keylet.MPTIssuance(id))
-	if err != nil || len(data) == 0 {
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
 		return nil, nil
 	}
 	return state.ParseMPTokenIssuance(data)
@@ -64,6 +69,24 @@ func canAddHolding(view tx.LedgerView, asset tx.Asset) ter.Result {
 	return ter.TesSUCCESS
 }
 
+func canTransfer(view tx.LedgerView, asset tx.Asset, from, to [20]byte, waiveMPTCanTransfer bool) ter.Result {
+	return mptutil.CanTransferAsset(view, asset, from, to, waiveMPTCanTransfer)
+}
+
+func requireAuth(view tx.LedgerView, asset tx.Asset, account [20]byte, authType mptutil.AuthType, parentCloseTime uint32) ter.Result {
+	return mptutil.RequireAssetAuthAt(view, asset, account, authType, parentCloseTime)
+}
+
+func checkFrozen(view tx.LedgerView, asset tx.Asset, account [20]byte) ter.Result {
+	if !mptutil.IsAssetFrozen(view, asset, account) {
+		return ter.TesSUCCESS
+	}
+	if asset.IsMPT() {
+		return ter.TecLOCKED
+	}
+	return ter.TecFROZEN
+}
+
 // addEmptyMPTHolding creates a zero-balance MPToken for accountID under the MPT
 // asset (nothing when the account is the issuer). Returns the owner-count delta.
 func addEmptyMPTHolding(ctx *tx.ApplyContext, accountID [20]byte, asset tx.Asset) (int32, ter.Result) {
@@ -71,12 +94,23 @@ func addEmptyMPTHolding(ctx *tx.ApplyContext, accountID [20]byte, asset tx.Asset
 	if !ok {
 		return 0, ter.TefINTERNAL
 	}
-	if mptIDIssuer(id) == accountID {
-		return 0, ter.TesSUCCESS
+	issuance, err := readMPTIssuance(ctx.View, id)
+	if err != nil || issuance == nil {
+		return 0, ter.TefINTERNAL
+	}
+	if issuance.Flags&entry.LsfMPTLocked != 0 {
+		return 0, ter.TefINTERNAL
 	}
 	tokenKey := keylet.MPTokenByID(id, accountID)
-	if exists, _ := ctx.View.Exists(tokenKey); exists {
+	exists, err := ctx.View.Exists(tokenKey)
+	if err != nil {
+		return 0, ter.TefINTERNAL
+	}
+	if exists {
 		return 0, ter.TecDUPLICATE
+	}
+	if issuance.Issuer == accountID {
+		return 0, ter.TesSUCCESS
 	}
 	token := &state.MPTokenData{Account: accountID, MPTokenIssuanceID: id}
 	dir, err := state.DirInsert(ctx.View, keylet.OwnerDir(accountID), tokenKey.Key, false, func(d *state.DirectoryNode) {
@@ -224,15 +258,22 @@ func addEmptyHolding(ctx *tx.ApplyContext, accountID [20]byte, asset tx.Asset) (
 	}
 
 	lineKey := keylet.Line(issuerID, accountID, asset.Currency)
-	if exists, _ := ctx.View.Exists(lineKey); exists {
+	exists, err := ctx.View.Exists(lineKey)
+	if err != nil {
+		return 0, ter.TefINTERNAL
+	}
+	if exists {
 		return 0, ter.TecDUPLICATE
 	}
 
-	holder, err := tx.ReadAccountRoot(ctx.View, accountID)
-	if err != nil || holder == nil {
-		return 0, ter.TefINTERNAL
+	holder := ctx.Account
+	if accountID != ctx.AccountID {
+		holder, err = tx.ReadAccountRoot(ctx.View, accountID)
+		if err != nil || holder == nil {
+			return 0, ter.TefINTERNAL
+		}
 	}
-	if ctx.PriorBalance() < ctx.AccountReserve(holder.OwnerCount+1) {
+	if ctx.PriorBalance() < ctx.AccountReserve(tx.ConfineOwnerCount(holder.OwnerCount, 1)) {
 		return 0, ter.TecNO_LINE_INSUF_RESERVE
 	}
 
@@ -261,7 +302,10 @@ func addEmptyHolding(ctx *tx.ApplyContext, accountID [20]byte, asset tx.Asset) (
 // (nil, nil) when the entry does not exist.
 func readVault(view AssetReadView, vaultKey keylet.Keylet) (*vaultData, error) {
 	data, err := view.Read(vaultKey)
-	if err != nil || len(data) == 0 {
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
 		return nil, nil
 	}
 	return parseVault(data)
@@ -270,7 +314,10 @@ func readVault(view AssetReadView, vaultKey keylet.Keylet) (*vaultData, error) {
 // readMPToken reads and parses an MPToken, returning (nil, nil) when absent.
 func readMPToken(view tx.LedgerView, tokenKey keylet.Keylet) (*state.MPTokenData, error) {
 	data, err := view.Read(tokenKey)
-	if err != nil || len(data) == 0 {
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
 		return nil, nil
 	}
 	return state.ParseMPToken(data)
@@ -331,7 +378,7 @@ func ensureHolderMPToken(ctx *tx.ApplyContext, holderID [20]byte, shareMPTID [24
 	}
 
 	if isSubmitter {
-		ctx.Account.OwnerCount++
+		ctx.Account.OwnerCount = tx.ConfineOwnerCount(ctx.Account.OwnerCount, 1)
 	} else if err := tx.AdjustOwnerCount(ctx.View, holderID, 1); err != nil {
 		return ter.TefINTERNAL
 	}
@@ -480,64 +527,138 @@ func assetMatches(amount tx.Amount, vd *vaultData) bool {
 // accountHolds(shFULL_BALANCE): the full XRP or trust-line balance, treated as
 // effectively unbounded when the account is the asset's issuer.
 func spendableAsset(view tx.LedgerView, config tx.EngineConfig, accountID [20]byte, asset tx.Asset) (state.XRPLNumber, error) {
+	scale := vaultNumberScale(config.Rules)
+	zero := func() state.XRPLNumber {
+		return state.NewXRPLNumberScaled(0, 0, scale, state.RoundToNearest)
+	}
 	if isNativeAsset(asset) {
 		ar, err := tx.ReadAccountRoot(view, accountID)
 		if err != nil || ar == nil {
-			return state.NewXRPLNumber(0, 0), err
+			return zero(), err
 		}
-		reserve := config.AccountReserve(ar.OwnerCount)
+		reserve := uint64(0)
+		if !ar.IsPseudoAccount() {
+			reserve = config.AccountReserve(ar.OwnerCount)
+		}
 		liquid := int64(ar.Balance) - int64(reserve)
 		if liquid < 0 {
 			liquid = 0
 		}
-		return state.NewXRPLNumber(liquid, 0), nil
+		return state.NewXRPLNumberScaled(liquid, 0, scale, state.RoundToNearest), nil
 	}
 
 	if asset.IsMPT() {
 		id, ok := assetMPTID(asset)
 		if !ok {
-			return state.NewXRPLNumber(0, 0), nil
+			return zero(), nil
 		}
 		if mptIDIssuer(id) == accountID {
-			iss, _ := readMPTIssuance(view, id)
+			iss, err := readMPTIssuance(view, id)
+			if err != nil {
+				return zero(), err
+			}
 			if iss == nil {
-				return state.NewXRPLNumber(0, 0), nil
+				return zero(), nil
 			}
 			maxAmt := entry.MaxMPTokenAmount
 			if iss.MaximumAmount != nil {
 				maxAmt = *iss.MaximumAmount
 			}
-			return state.NewXRPLNumber(int64(maxAmt-iss.OutstandingAmount), 0), nil
+			if iss.OutstandingAmount >= maxAmt {
+				return zero(), nil
+			}
+			return state.NewXRPLNumberScaled(int64(maxAmt-iss.OutstandingAmount), 0, scale, state.RoundToNearest), nil
 		}
-		return state.NewXRPLNumber(int64(holderMPTBalance(view, id, accountID)), 0), nil
+		return state.NewXRPLNumberScaled(int64(holderMPTBalance(view, id, accountID)), 0, scale, state.RoundToNearest), nil
 	}
 
 	issuerID, err := state.DecodeAccountID(asset.Issuer)
 	if err != nil {
-		return state.NewXRPLNumber(0, 0), err
+		return zero(), err
 	}
 	if accountID == issuerID {
 		// The issuer's spendable balance is effectively unbounded.
-		return state.NewXRPLNumber(9999999999999999, 80), nil
+		return state.NewXRPLNumberScaled(9999999999999999, 80, scale, state.RoundToNearest), nil
 	}
 
 	lineData, rerr := view.Read(keylet.Line(accountID, issuerID, asset.Currency))
-	if rerr != nil || lineData == nil {
-		return state.NewXRPLNumber(0, 0), nil
+	if rerr != nil {
+		return zero(), rerr
+	}
+	if lineData == nil {
+		return zero(), nil
 	}
 	rs, perr := state.ParseRippleState(lineData)
 	if perr != nil {
-		return state.NewXRPLNumber(0, 0), perr
+		return zero(), perr
 	}
-	bal, berr := vaultNumber(rs.Balance.Value())
+	bal, berr := vaultNumberScaled(rs.Balance.Value(), scale)
 	if berr != nil {
-		return state.NewXRPLNumber(0, 0), berr
+		return zero(), berr
 	}
-	// Balance is stored in the low account's terms; negate for the high account.
+	var oppositeLimit state.Amount
 	if bytes.Compare(accountID[:], issuerID[:]) > 0 {
 		bal = bal.Negate()
+		oppositeLimit = rs.LowLimit
+	} else {
+		oppositeLimit = rs.HighLimit
 	}
-	return bal, nil
+	limit, err := vaultNumberScaled(oppositeLimit.Value(), scale)
+	if err != nil {
+		return zero(), err
+	}
+	return bal.Add(limit), nil
+}
+
+func actualAssetHolding(view tx.LedgerView, accountID [20]byte, asset tx.Asset, rules *amendment.Rules) (state.XRPLNumber, error) {
+	scale := vaultNumberScale(rules)
+	zero := func() state.XRPLNumber {
+		return state.NewXRPLNumberScaled(0, 0, scale, state.RoundToNearest)
+	}
+	if isNativeAsset(asset) {
+		account, err := tx.ReadAccountRoot(view, accountID)
+		if err != nil || account == nil {
+			return zero(), err
+		}
+		return state.NewXRPLNumberScaled(int64(account.Balance), 0, scale, state.RoundToNearest), nil
+	}
+	if asset.IsMPT() {
+		id, ok := assetMPTID(asset)
+		if !ok {
+			return zero(), fmt.Errorf("invalid MPT issuance ID")
+		}
+		if mptIDIssuer(id) == accountID {
+			return state.NewXRPLNumberScaled(9999999999999999, 80, scale, state.RoundToNearest), nil
+		}
+		return state.NewXRPLNumberScaled(int64(holderMPTBalance(view, id, accountID)), 0, scale, state.RoundToNearest), nil
+	}
+
+	issuerID, err := state.DecodeAccountID(asset.Issuer)
+	if err != nil {
+		return zero(), err
+	}
+	if accountID == issuerID {
+		return state.NewXRPLNumberScaled(9999999999999999, 80, scale, state.RoundToNearest), nil
+	}
+	lineData, err := view.Read(keylet.Line(accountID, issuerID, asset.Currency))
+	if err != nil {
+		return zero(), err
+	}
+	if lineData == nil {
+		return zero(), nil
+	}
+	line, err := state.ParseRippleState(lineData)
+	if err != nil {
+		return zero(), err
+	}
+	balance, err := vaultNumberScaled(line.Balance.Value(), scale)
+	if err != nil {
+		return zero(), err
+	}
+	if bytes.Compare(accountID[:], issuerID[:]) > 0 {
+		balance = balance.Negate()
+	}
+	return balance, nil
 }
 
 // sendAssetToVault transfers assetsN of the vault asset from the submitter
@@ -693,12 +814,35 @@ func holderMPTBalance(view tx.LedgerView, shareMPTID [24]byte, holderID [20]byte
 	return token.MPTAmount
 }
 
-// removeVaultAssetHolding deletes the pseudo-account's trust line for an IOU
-// vault asset (XRP needs no holding). Returns the owner-count delta to apply to
-// the pseudo-account.
+// removeVaultAssetHolding removes an empty XRP, IOU, or MPT holding. It returns
+// the owner-count delta the caller must apply to accountID; owner counts for the
+// other side of an IOU line are adjusted here.
 func removeVaultAssetHolding(ctx *tx.ApplyContext, accountID [20]byte, asset tx.Asset) (int32, ter.Result) {
 	if isNativeAsset(asset) {
+		account, err := tx.ReadAccountRoot(ctx.View, accountID)
+		if err != nil || account == nil {
+			return 0, ter.TecINTERNAL
+		}
+		if account.Balance != 0 {
+			return 0, ter.TecHAS_OBLIGATIONS
+		}
 		return 0, ter.TesSUCCESS
+	}
+	if asset.IsMPT() {
+		id, ok := assetMPTID(asset)
+		if !ok {
+			return 0, ter.TefINTERNAL
+		}
+		tokenKey := keylet.MPTokenByID(id, accountID)
+		existed, err := ctx.View.Exists(tokenKey)
+		if err != nil {
+			return 0, ter.TefINTERNAL
+		}
+		result := mptutil.RemoveHolding(ctx.View, id, accountID, false)
+		if result != ter.TesSUCCESS || !existed {
+			return 0, result
+		}
+		return -1, ter.TesSUCCESS
 	}
 	issuerID, err := state.DecodeAccountID(asset.Issuer)
 	if err != nil {
@@ -709,28 +853,49 @@ func removeVaultAssetHolding(ctx *tx.ApplyContext, accountID [20]byte, asset tx.
 	}
 	lineKey := keylet.Line(accountID, issuerID, asset.Currency)
 	data, rerr := ctx.View.Read(lineKey)
-	if rerr != nil || data == nil {
-		return 0, ter.TesSUCCESS
+	if rerr != nil {
+		return 0, ter.TefINTERNAL
+	}
+	if data == nil {
+		return 0, ter.TecOBJECT_NOT_FOUND
 	}
 	rs, perr := state.ParseRippleState(data)
 	if perr != nil {
 		return 0, ter.TefINTERNAL
+	}
+	if rs.Balance.Signum() != 0 {
+		return 0, ter.TecHAS_OBLIGATIONS
 	}
 
 	lowID, highID := accountID, issuerID
 	if bytes.Compare(accountID[:], issuerID[:]) > 0 {
 		lowID, highID = issuerID, accountID
 	}
-	if res, e := state.DirRemove(ctx.View, keylet.OwnerDir(lowID), rs.LowNode, lineKey.Key, false); e != nil || !res.Success {
-		return 0, ter.TefBAD_LEDGER
+	delta := int32(0)
+	adjust := func(owner [20]byte) ter.Result {
+		if owner == accountID {
+			delta--
+			return ter.TesSUCCESS
+		}
+		if err := tx.AdjustOwnerCount(ctx.View, owner, -1); err != nil {
+			return ter.TefINTERNAL
+		}
+		return ter.TesSUCCESS
 	}
-	if res, e := state.DirRemove(ctx.View, keylet.OwnerDir(highID), rs.HighNode, lineKey.Key, false); e != nil || !res.Success {
-		return 0, ter.TefBAD_LEDGER
+	if rs.Flags&state.LsfLowReserve != 0 {
+		if result := adjust(lowID); result != ter.TesSUCCESS {
+			return 0, result
+		}
 	}
-	if e := ctx.View.Erase(lineKey); e != nil {
-		return 0, ter.TefINTERNAL
+	if rs.Flags&state.LsfHighReserve != 0 {
+		if result := adjust(highID); result != ter.TesSUCCESS {
+			return 0, result
+		}
 	}
-	return -1, ter.TesSUCCESS
+	if result := tx.TrustDelete(ctx.View, lineKey, lowID, highID, rs.LowNode, rs.HighNode); result != ter.TesSUCCESS {
+		return 0, result
+	}
+	return delta, ter.TesSUCCESS
 }
 
 // removeEmptyShareMPToken deletes a holder's share MPToken when its balance is
@@ -754,7 +919,7 @@ func removeEmptyShareMPToken(ctx *tx.ApplyContext, holderID [20]byte, shareMPTID
 		return ter.TecHAS_OBLIGATIONS
 	}
 	if res, derr := state.DirRemove(ctx.View, keylet.OwnerDir(holderID), token.OwnerNode, tokenKey.Key, false); derr != nil || !res.Success {
-		return ter.TefINTERNAL
+		return ter.TecINTERNAL
 	}
 	if eerr := ctx.View.Erase(tokenKey); eerr != nil {
 		return ter.TefINTERNAL
@@ -780,6 +945,13 @@ func mintShares(ctx *tx.ApplyContext, shareMPTID [24]byte, holderID [20]byte, sh
 	issuance, perr := state.ParseMPTokenIssuance(issData)
 	if perr != nil {
 		return ter.TefINTERNAL
+	}
+	maximum := entry.MaxMPTokenAmount
+	if issuance.MaximumAmount != nil {
+		maximum = *issuance.MaximumAmount
+	}
+	if shares > maximum || issuance.OutstandingAmount > maximum-shares {
+		return ter.TecPATH_DRY
 	}
 	issuance.OutstandingAmount += shares
 	newIss, serr := state.SerializeMPTokenIssuance(issuance)

--- a/internal/tx/vault/create_set_assets_maximum.go
+++ b/internal/tx/vault/create_set_assets_maximum.go
@@ -1,0 +1,118 @@
+package vault
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+func parseAssetsMaximumJSON(raw json.RawMessage) (*string, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, fmt.Errorf("invalid AssetsMaximum: %w", err)
+	}
+
+	var number string
+	switch value := value.(type) {
+	case string:
+		number = value
+	case json.Number:
+		number = value.String()
+		if strings.ContainsAny(number, ".eE") {
+			return nil, fmt.Errorf("invalid AssetsMaximum: JSON number must be an integer")
+		}
+		if strings.HasPrefix(number, "-") {
+			if _, err := strconv.ParseInt(number, 10, 32); err != nil {
+				return nil, fmt.Errorf("invalid AssetsMaximum: %w", err)
+			}
+		} else if _, err := strconv.ParseUint(number, 10, 32); err != nil {
+			return nil, fmt.Errorf("invalid AssetsMaximum: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("invalid AssetsMaximum: expected string or integer")
+	}
+
+	if _, err := parseCreateSetNumber(number); err != nil {
+		return nil, fmt.Errorf("invalid AssetsMaximum: %w", err)
+	}
+	return &number, nil
+}
+
+func validateAssetsMaximum(value *string) error {
+	if value == nil {
+		return nil
+	}
+	number, err := parseCreateSetNumber(*value)
+	if err != nil {
+		return ter.Errorf(ter.TemMALFORMED, "AssetsMaximum is not a valid NUMBER")
+	}
+	if number.Signum() < 0 {
+		return ErrVaultAssetsMaxNeg
+	}
+	return nil
+}
+
+func parseCreateSetNumber(s string) (state.XRPLNumber, error) {
+	return state.ParseXRPLNumber(
+		s,
+		state.MantissaScaleLarge,
+		state.RoundToNearest,
+	)
+}
+
+func parseCreateSetNumberForRules(s string, rules *amendment.Rules) (state.XRPLNumber, error) {
+	scale := state.MantissaScaleLarge
+	if rules != nil {
+		scale = state.MantissaScaleForRulesWithFix(
+			true,
+			rules.Enabled(amendment.FeatureSingleAssetVault),
+			rules.Enabled(amendment.FeatureLendingProtocol),
+			rules.FixCleanup3_2_0Enabled(),
+		)
+	}
+	return state.ParseXRPLNumber(s, scale, state.RoundToNearest)
+}
+
+func canonicalCreateSetAssetsMaximum(asset tx.Asset, value state.XRPLNumber) string {
+	integral := asset.IsNative() || asset.IsMPT()
+	var rounded state.XRPLNumber
+	var remove bool
+	if integral {
+		rounded, remove = state.AssociateAssetField(value, true, true)
+	} else {
+		if value.IsZero() {
+			return ""
+		}
+		mantissa, exponent := value.NormalizeToRange(uint64(state.MinMantissa), uint64(state.MaxMantissa))
+		if exponent > state.MaxExponent {
+			panic("issued amount exponent exceeds maximum")
+		}
+		if exponent < state.MinExponent {
+			return ""
+		}
+		rounded = state.NewXRPLNumber(mantissa, exponent)
+	}
+
+	if asset.IsNative() && rounded.Cmp(state.NewXRPLNumberScaled(
+		int64(state.MaxNativeDrops),
+		0,
+		state.MantissaScaleLarge,
+		state.RoundToNearest,
+	)) > 0 {
+		panic("native amount exceeds maximum XRP")
+	}
+
+	if remove {
+		return ""
+	}
+	return numberToString(rounded)
+}

--- a/internal/tx/vault/exports.go
+++ b/internal/tx/vault/exports.go
@@ -242,7 +242,10 @@ func UpdateVaultTotals(ctx *tx.ApplyContext, vaultKey keylet.Keylet, assetsTotal
 	vd.AssetsTotal = assetsTotal
 	vd.AssetsAvailable = assetsAvailable
 	vd.LossUnrealized = lossUnrealized
-	data, serr := serializeVault(vd)
+	if err := associateVaultAsset(vd, ctx.Rules()); err != nil {
+		return ter.TefINTERNAL
+	}
+	data, serr := serializeVaultForRules(vd, ctx.Rules())
 	if serr != nil {
 		return ter.TefINTERNAL
 	}

--- a/internal/tx/vault/number.go
+++ b/internal/tx/vault/number.go
@@ -1,34 +1,43 @@
 package vault
 
 import (
-	"encoding/binary"
 	"fmt"
 
-	"github.com/LeJamon/go-xrpl/codec/binarycodec/types"
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 )
 
-// This file is the local Number seam for the vault package. The vault ledger
-// NUMBER fields are carried as their canonical decimal/scientific string; these
-// helpers bridge that representation to state.XRPLNumber for the exact rippled
-// share-conversion arithmetic. A shared state.Number helper (built in a sibling
-// PR) can later replace the string carriage without touching call sites.
-
-// vaultNumber parses a NUMBER field string ("" meaning zero) into an XRPLNumber.
-// It round-trips through the binary codec so the parse is byte-identical to how
-// the field decodes off the ledger.
+// vaultNumber parses a NUMBER field string ("" meaning zero) using the legacy
+// small range. Rules-aware Vault paths use vaultNumberForRules.
 func vaultNumber(s string) (state.XRPLNumber, error) {
+	return vaultNumberScaled(s, state.MantissaScaleSmall)
+}
+
+func vaultNumberForRules(s string, rules *amendment.Rules) (state.XRPLNumber, error) {
+	return vaultNumberScaled(s, vaultNumberScale(rules))
+}
+
+func vaultNumberScaled(s string, scale state.MantissaScale) (state.XRPLNumber, error) {
 	if s == "" || s == "0" {
-		return state.NewXRPLNumber(0, 0), nil
+		return state.NewXRPLNumberScaled(0, 0, scale, state.RoundToNearest), nil
 	}
-	num := &types.Number{}
-	b, err := num.FromJSON(s)
+	number, err := state.ParseXRPLNumber(s, scale, state.RoundToNearest)
 	if err != nil {
-		return state.NewXRPLNumber(0, 0), fmt.Errorf("parse number %q: %w", s, err)
+		return state.NewXRPLNumberScaled(0, 0, scale, state.RoundToNearest), fmt.Errorf("parse number %q: %w", s, err)
 	}
-	mantissa := int64(binary.BigEndian.Uint64(b[:8]))
-	exp := int32(binary.BigEndian.Uint32(b[8:12]))
-	return state.NewXRPLNumber(mantissa, int(exp)), nil
+	return number, nil
+}
+
+func vaultNumberScale(rules *amendment.Rules) state.MantissaScale {
+	if rules == nil {
+		return state.MantissaScaleForRulesWithFix(false, false, false, false)
+	}
+	return state.MantissaScaleForRulesWithFix(
+		true,
+		rules.Enabled(amendment.FeatureSingleAssetVault),
+		rules.Enabled(amendment.FeatureLendingProtocol),
+		rules.FixCleanup3_2_0Enabled(),
+	)
 }
 
 // numberToString renders an XRPLNumber into the vault NUMBER-field convention:
@@ -51,6 +60,36 @@ func amountToNumber(a state.Amount) (state.XRPLNumber, error) {
 		return vaultNumber(a.Value())
 	}
 	return vaultNumber(a.Value())
+}
+
+func amountToNumberForRules(a state.Amount, rules *amendment.Rules) (state.XRPLNumber, error) {
+	scale := vaultNumberScale(rules)
+	if a.IsNative() {
+		return state.NewXRPLNumberScaled(a.Drops(), 0, scale, state.RoundToNearest), nil
+	}
+	return vaultNumberScaled(a.Value(), scale)
+}
+
+func associateVaultAsset(vd *vaultData, rules *amendment.Rules) error {
+	integral := vd.AssetIsMPT || isNativeAsset(vd.Asset)
+	for _, field := range []*string{
+		&vd.AssetsTotal,
+		&vd.AssetsAvailable,
+		&vd.AssetsMaximum,
+		&vd.LossUnrealized,
+	} {
+		value, err := vaultNumberForRules(*field, rules)
+		if err != nil {
+			return err
+		}
+		rounded, remove := state.AssociateAssetField(value, integral, true)
+		if remove {
+			*field = ""
+		} else {
+			*field = numberToString(rounded)
+		}
+	}
+	return nil
 }
 
 // pow10 returns 10^scale as an XRPLNumber.
@@ -81,11 +120,15 @@ func assetsToSharesDeposit(assetsTotal, shareTotal, assets state.XRPLNumber, sca
 
 // sharesToAssetsDeposit converts a share count back to assets on the deposit
 // path (used to verify the exchange does not exceed the offered amount).
-func sharesToAssetsDeposit(assetsTotal, shareTotal, shares state.XRPLNumber, scale uint8) state.XRPLNumber {
+func sharesToAssetsDeposit(
+	assetsTotal, shareTotal, shares state.XRPLNumber,
+	scale uint8,
+	integral bool,
+) state.XRPLNumber {
 	if assetsTotal.IsZero() {
-		return shares.Div(pow10(scale))
+		return shares.Div(pow10(scale)).RoundToAsset(integral)
 	}
-	return assetsTotal.Mul(shares).Div(shareTotal)
+	return assetsTotal.Mul(shares).Div(shareTotal).RoundToAsset(integral)
 }
 
 // assetsToSharesWithdraw converts a withdrawal of assets into the shares that
@@ -93,20 +136,23 @@ func sharesToAssetsDeposit(assetsTotal, shareTotal, shares state.XRPLNumber, sca
 func assetsToSharesWithdraw(assetsTotal, lossUnrealized, shareTotal, assets state.XRPLNumber, truncate bool) state.XRPLNumber {
 	effective := assetsTotal.Sub(lossUnrealized)
 	if effective.IsZero() {
-		return state.NewXRPLNumber(0, 0)
+		return effective
 	}
 	result := shareTotal.Mul(assets).Div(effective)
 	if truncate {
-		result = result.Truncate()
+		return result.Truncate()
 	}
-	return result
+	return result.RoundToAsset(true)
 }
 
 // sharesToAssetsWithdraw converts a share count into the assets it redeems.
-func sharesToAssetsWithdraw(assetsTotal, lossUnrealized, shareTotal, shares state.XRPLNumber) state.XRPLNumber {
+func sharesToAssetsWithdraw(
+	assetsTotal, lossUnrealized, shareTotal, shares state.XRPLNumber,
+	integral bool,
+) state.XRPLNumber {
 	effective := assetsTotal.Sub(lossUnrealized)
 	if effective.IsZero() {
-		return state.NewXRPLNumber(0, 0)
+		return effective
 	}
-	return effective.Mul(shares).Div(shareTotal)
+	return effective.Mul(shares).Div(shareTotal).RoundToAsset(integral)
 }

--- a/internal/tx/vault/number_rules_test.go
+++ b/internal/tx/vault/number_rules_test.go
@@ -1,0 +1,48 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVaultNumberRulesSelectLegacyAndFixedLargeModes(t *testing.T) {
+	legacyRules := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+	fixedRules := amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault,
+		amendment.FeatureFixCleanup3_2_0,
+	})
+
+	require.Equal(t, state.MantissaScaleLargeLegacy, vaultNumberScale(legacyRules))
+	require.Equal(t, state.MantissaScaleLarge, vaultNumberScale(fixedRules))
+}
+
+func TestAssociateVaultAssetRoundsAndRemovesDefaultFields(t *testing.T) {
+	rules := amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault,
+		amendment.FeatureFixCleanup3_2_0,
+	})
+	vd := &vaultData{
+		Asset:           tx.Asset{Currency: "XRP"},
+		AssetsTotal:     "2.5",
+		AssetsAvailable: "0.4",
+		AssetsMaximum:   "8.5",
+		LossUnrealized:  "0",
+	}
+
+	require.NoError(t, associateVaultAsset(vd, rules))
+	require.NotEmpty(t, vd.AssetsTotal)
+	require.Empty(t, vd.AssetsAvailable)
+	require.NotEmpty(t, vd.AssetsMaximum)
+	require.Empty(t, vd.LossUnrealized)
+
+	total, err := vaultNumberForRules(vd.AssetsTotal, rules)
+	require.NoError(t, err)
+	require.True(t, total.Equal(state.NewXRPLNumberScaled(2, 0, state.MantissaScaleLarge, state.RoundToNearest)))
+	maximum, err := vaultNumberForRules(vd.AssetsMaximum, rules)
+	require.NoError(t, err)
+	require.True(t, maximum.Equal(state.NewXRPLNumberScaled(8, 0, state.MantissaScaleLarge, state.RoundToNearest)))
+}

--- a/internal/tx/vault/serialize.go
+++ b/internal/tx/vault/serialize.go
@@ -1,12 +1,17 @@
 package vault
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
-	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec/definitions"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec/serdes"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec/types"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ledgerfields"
@@ -16,9 +21,7 @@ import (
 //
 // The NUMBER fields (AssetsTotal/AssetsAvailable/AssetsMaximum/LossUnrealized)
 // are held as their canonical decimal/scientific string; an empty string means
-// the field is absent (soeDEFAULT zero). This is the local Number seam noted in
-// the PR body — a shared state.Number helper can replace the string carriage
-// later without touching call sites.
+// the field is absent (soeDEFAULT zero).
 type vaultData struct {
 	Owner            [20]byte
 	Account          [20]byte // pseudo-account
@@ -56,6 +59,10 @@ func (v *vaultData) assetToIssueMap() map[string]any {
 // soeDEFAULT fields (the NUMBER totals, Scale, Data) are omitted when zero to
 // match rippled's STObject serialization.
 func serializeVault(v *vaultData) ([]byte, error) {
+	return serializeVaultForRules(v, nil)
+}
+
+func serializeVaultForRules(v *vaultData, rules *amendment.Rules) ([]byte, error) {
 	ownerAddr, err := state.EncodeAccountID(v.Owner)
 	if err != nil {
 		return nil, fmt.Errorf("encode owner: %w", err)
@@ -102,16 +109,81 @@ func serializeVault(v *vaultData) ([]byte, error) {
 		obj["PreviousTxnLgrSeq"] = v.PreviousTxnLgrSeq
 	}
 
-	hexStr, err := binarycodec.Encode(obj)
-	if err != nil {
-		return nil, fmt.Errorf("encode vault: %w", err)
+	return encodeVaultObject(obj, vaultNumberScale(rules))
+}
+
+func encodeVaultObject(obj map[string]any, scale state.MantissaScale) ([]byte, error) {
+	defs := definitions.Get()
+	fields := make([]*definitions.FieldInstance, 0, len(obj))
+	for name := range obj {
+		field, err := defs.FieldInstanceByName(name)
+		if err != nil {
+			return nil, fmt.Errorf("encode vault field %s: %w", name, err)
+		}
+		fields = append(fields, field)
 	}
-	return hex.DecodeString(hexStr)
+	sort.Slice(fields, func(i, j int) bool { return fields[i].Ordinal < fields[j].Ordinal })
+
+	serializer := serdes.NewBinarySerializer(serdes.DefaultFieldIDCodec())
+	for _, field := range fields {
+		if !field.IsSerialized {
+			continue
+		}
+		value := obj[field.FieldName]
+		var encoded []byte
+		var err error
+		if field.Type == "Number" {
+			s, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf("encode vault field %s: expected Number string", field.FieldName)
+			}
+			encoded, err = encodeVaultNumber(s, scale)
+		} else {
+			serializedType := types.SerializedTypeFor(field.Type)
+			if serializedType == nil {
+				return nil, fmt.Errorf("encode vault field %s: unknown type %s", field.FieldName, field.Type)
+			}
+			if field.FieldName == "LedgerEntryType" {
+				name, ok := value.(string)
+				if !ok {
+					return nil, fmt.Errorf("encode vault field %s: expected ledger entry type string", field.FieldName)
+				}
+				code, err := defs.LedgerEntryTypeCode(name)
+				if err != nil {
+					return nil, fmt.Errorf("encode vault field %s: %w", field.FieldName, err)
+				}
+				value = int(code)
+			}
+			encoded, err = serializedType.FromJSON(value)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("encode vault field %s: %w", field.FieldName, err)
+		}
+		if err := serializer.WriteFieldAndValue(*field, encoded); err != nil {
+			return nil, fmt.Errorf("encode vault field %s: %w", field.FieldName, err)
+		}
+	}
+	return serializer.Bytes(), nil
+}
+
+func encodeVaultNumber(s string, scale state.MantissaScale) ([]byte, error) {
+	number, err := state.ParseXRPLNumber(s, scale, state.RoundToNearest)
+	if err != nil {
+		return nil, err
+	}
+	encoded := make([]byte, 12)
+	binary.BigEndian.PutUint64(encoded[:8], uint64(number.Mantissa()))
+	binary.BigEndian.PutUint32(encoded[8:], uint32(int32(number.Exponent())))
+	return encoded, nil
 }
 
 // parseVault decodes a vault ledger entry via the canonical ledgerfields
 // decoder and maps it onto vaultData.
 func parseVault(data []byte) (*vaultData, error) {
+	numberFields, err := readVaultNumberFields(data)
+	if err != nil {
+		return nil, err
+	}
 	lv := &ledgerfields.Vault{}
 	if err := lv.Decode(data); err != nil {
 		return nil, err
@@ -123,10 +195,10 @@ func parseVault(data []byte) (*vaultData, error) {
 		Scale:            uint8(lv.Scale),
 		Flags:            lv.Flags,
 		Data:             lv.Data,
-		AssetsTotal:      normalizeNumberString(lv.AssetsTotal),
-		AssetsAvailable:  normalizeNumberString(lv.AssetsAvailable),
-		AssetsMaximum:    normalizeNumberString(lv.AssetsMaximum),
-		LossUnrealized:   normalizeNumberString(lv.LossUnrealized),
+		AssetsTotal:      numberFields["AssetsTotal"],
+		AssetsAvailable:  numberFields["AssetsAvailable"],
+		AssetsMaximum:    numberFields["AssetsMaximum"],
+		LossUnrealized:   numberFields["LossUnrealized"],
 	}
 
 	if id, err := state.DecodeAccountID(lv.Owner); err == nil {
@@ -162,12 +234,44 @@ func parseVault(data []byte) (*vaultData, error) {
 	return vd, nil
 }
 
-// normalizeNumberString coerces a decoded NUMBER value ("0" or a decimal /
-// scientific string) into vaultData's convention: "" for zero, else the string.
-func normalizeNumberString(v any) string {
-	s, ok := v.(string)
-	if !ok || s == "" || s == "0" {
-		return ""
+func readVaultNumberFields(data []byte) (map[string]string, error) {
+	parser := serdes.NewBinaryParser(data, definitions.Get())
+	fields := make(map[string]string, 4)
+	for parser.HasMore() {
+		field, err := parser.ReadField()
+		if err != nil {
+			return nil, fmt.Errorf("decode vault field: %w", err)
+		}
+		if field.Type == "Number" {
+			encoded, err := parser.ReadBytes(12)
+			if err != nil {
+				return nil, fmt.Errorf("decode vault field %s: %w", field.FieldName, err)
+			}
+			mantissa := int64(binary.BigEndian.Uint64(encoded[:8]))
+			if mantissa != 0 {
+				exponent := int(int32(binary.BigEndian.Uint32(encoded[8:])))
+				fields[field.FieldName] = fmt.Sprintf("%de%d", mantissa, exponent)
+			}
+			continue
+		}
+
+		serializedType := types.SerializedTypeFor(field.Type)
+		if serializedType == nil {
+			return nil, fmt.Errorf("decode vault field %s: unknown type %s", field.FieldName, field.Type)
+		}
+		if field.IsVLEncoded {
+			length, err := parser.ReadVariableLength()
+			if err != nil {
+				return nil, fmt.Errorf("decode vault field %s length: %w", field.FieldName, err)
+			}
+			if _, err := serializedType.ToJSON(parser, length); err != nil {
+				return nil, fmt.Errorf("decode vault field %s: %w", field.FieldName, err)
+			}
+			continue
+		}
+		if _, err := serializedType.ToJSON(parser); err != nil {
+			return nil, fmt.Errorf("decode vault field %s: %w", field.FieldName, err)
+		}
 	}
-	return s
+	return fields, nil
 }

--- a/internal/tx/vault/shared_helpers_test.go
+++ b/internal/tx/vault/shared_helpers_test.go
@@ -1,0 +1,259 @@
+package vault
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	"github.com/stretchr/testify/require"
+)
+
+type sharedHelperView struct {
+	*mptArmsView
+	rules *amendment.Rules
+}
+
+func newSharedHelperView(rules *amendment.Rules) *sharedHelperView {
+	return &sharedHelperView{mptArmsView: newMPTArmsView(), rules: rules}
+}
+
+func (v *sharedHelperView) Rules() *amendment.Rules { return v.rules }
+
+func TestSpendableAssetIncludesOppositeTrustLimit(t *testing.T) {
+	rules := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+	view := newSharedHelperView(rules)
+	var account, issuer [20]byte
+	account[19] = 0x10
+	issuer[19] = 0x20
+	accountAddress := state.EncodeAccountIDSafe(account)
+	issuerAddress := state.EncodeAccountIDSafe(issuer)
+	asset := tx.Asset{Currency: "USD", Issuer: issuerAddress}
+
+	line := &state.RippleState{
+		Balance:   state.NewIssuedAmountFromValue(3_000_000_000_000_000, -14, "USD", issuerAddress),
+		LowLimit:  state.NewIssuedAmountFromValue(0, state.MinExponent, "USD", accountAddress),
+		HighLimit: state.NewIssuedAmountFromValue(7_000_000_000_000_000, -14, "USD", issuerAddress),
+	}
+	raw, err := state.SerializeRippleState(line)
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.Line(account, issuer, "USD"), raw))
+
+	spendable, err := spendableAsset(view, tx.EngineConfig{Rules: rules}, account, asset)
+	require.NoError(t, err)
+	want := state.NewXRPLNumberScaled(100, 0, state.MantissaScaleLargeLegacy, state.RoundToNearest)
+	require.Zero(t, spendable.Cmp(want))
+
+	holding, err := actualAssetHolding(view, account, asset, rules)
+	require.NoError(t, err)
+	want = state.NewXRPLNumberScaled(30, 0, state.MantissaScaleLargeLegacy, state.RoundToNearest)
+	require.Zero(t, holding.Cmp(want))
+}
+
+func TestMintSharesEnforcesMaximumAmount(t *testing.T) {
+	view := newMPTArmsView()
+	var issuer, holder [20]byte
+	issuer[19] = 1
+	holder[19] = 2
+	ctx := buildArmsCtx(t, view, holder, rulesWithFix(true))
+	id := keylet.MakeMPTID(7, issuer)
+	maximum := uint64(100)
+	issuance := &state.MPTokenIssuanceData{
+		Issuer:            issuer,
+		Sequence:          7,
+		MaximumAmount:     &maximum,
+		OutstandingAmount: 90,
+	}
+	issuanceRaw, err := state.SerializeMPTokenIssuance(issuance)
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.MPTIssuance(id), issuanceRaw))
+	tokenRaw, err := state.SerializeMPToken(&state.MPTokenData{
+		Account:           holder,
+		MPTokenIssuanceID: id,
+		MPTAmount:         90,
+	})
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.MPTokenByID(id, holder), tokenRaw))
+
+	require.Equal(t, ter.TecPATH_DRY, mintShares(ctx, id, holder, 11))
+	updated, err := readMPTIssuance(view, id)
+	require.NoError(t, err)
+	require.Equal(t, uint64(90), updated.OutstandingAmount)
+}
+
+func TestWithdrawSelfMPTReserveAndOwnerCount(t *testing.T) {
+	var issuer, holder [20]byte
+	issuer[19] = 1
+	holder[19] = 2
+	id := keylet.MakeMPTID(9, issuer)
+	asset := tx.Asset{MPTIssuanceID: hex.EncodeToString(id[:])}
+
+	build := func(t *testing.T, ownerCount uint32, balance uint64) (*tx.ApplyContext, *mptArmsView) {
+		t.Helper()
+		view := newMPTArmsView()
+		ctx := buildArmsCtx(t, view, holder, rulesWithFix(true))
+		ctx.Account.OwnerCount = ownerCount
+		ctx.Account.Balance = balance
+		ctx.Config.ReserveBase = 20
+		ctx.Config.ReserveIncrement = 10
+		issuanceRaw, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+			Issuer: issuer,
+			Flags:  entry.LsfMPTCanTransfer,
+		})
+		require.NoError(t, err)
+		require.NoError(t, view.Insert(keylet.MPTIssuance(id), issuanceRaw))
+		return ctx, view
+	}
+
+	t.Run("third object requires reserve", func(t *testing.T) {
+		ctx, view := build(t, 2, 49)
+		require.Equal(t, ter.TecINSUFFICIENT_RESERVE, addWithdrawDestinationHolding(ctx, asset))
+		exists, err := view.Exists(keylet.MPTokenByID(id, holder))
+		require.NoError(t, err)
+		require.False(t, exists)
+		require.Equal(t, uint32(2), ctx.Account.OwnerCount)
+	})
+
+	t.Run("second object is reserve free and increments owner count", func(t *testing.T) {
+		ctx, view := build(t, 1, 0)
+		require.Equal(t, ter.TesSUCCESS, addWithdrawDestinationHolding(ctx, asset))
+		exists, err := view.Exists(keylet.MPTokenByID(id, holder))
+		require.NoError(t, err)
+		require.True(t, exists)
+		require.Equal(t, uint32(2), ctx.Account.OwnerCount)
+	})
+
+	t.Run("existing holding does not recheck reserve", func(t *testing.T) {
+		ctx, view := build(t, 2, 0)
+		raw, err := state.SerializeMPToken(&state.MPTokenData{
+			Account:           holder,
+			MPTokenIssuanceID: id,
+		})
+		require.NoError(t, err)
+		require.NoError(t, view.Insert(keylet.MPTokenByID(id, holder), raw))
+		require.Equal(t, ter.TesSUCCESS, addWithdrawDestinationHolding(ctx, asset))
+		require.Equal(t, uint32(2), ctx.Account.OwnerCount)
+	})
+}
+
+func TestWithdrawSelfIOUReserveUsesUpdatedOwnerCount(t *testing.T) {
+	var issuer, holder [20]byte
+	issuer[19] = 1
+	holder[19] = 2
+	view := newMPTArmsView()
+	ctx := buildArmsCtx(t, view, holder, rulesWithFix(true))
+	ctx.Account.OwnerCount = 2
+	ctx.Account.Balance = 40
+	ctx.Config.ReserveBase = 20
+	ctx.Config.ReserveIncrement = 10
+	require.Equal(t, ter.TesSUCCESS, ctx.UpdateAccountRoot(holder, ctx.Account))
+
+	shareID := keylet.MakeMPTID(7, issuer)
+	tokenKey := keylet.MPTokenByID(shareID, holder)
+	dir, err := state.DirInsert(view, keylet.OwnerDir(holder), tokenKey.Key, false, func(node *state.DirectoryNode) {
+		node.Owner = holder
+	})
+	require.NoError(t, err)
+	token, err := state.SerializeMPToken(&state.MPTokenData{
+		Account:           holder,
+		MPTokenIssuanceID: shareID,
+		OwnerNode:         dir.Page,
+	})
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(tokenKey, token))
+	require.Equal(t, ter.TesSUCCESS, removeEmptyShareMPToken(ctx, holder, shareID))
+	require.Equal(t, uint32(1), ctx.Account.OwnerCount)
+
+	issuerAddress := state.EncodeAccountIDSafe(issuer)
+	issuerData, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account: issuerAddress,
+		Flags:   state.LsfDefaultRipple,
+	})
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.Account(issuer), issuerData))
+	delta, result := addEmptyHolding(ctx, holder, tx.Asset{Currency: "USD", Issuer: issuerAddress})
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Equal(t, int32(1), delta)
+}
+
+func TestAssetDispatchPreservesMPTPrecedenceAndFreezeTER(t *testing.T) {
+	rules := amendment.NewRulesBuilder().
+		Enable(amendment.FeatureSingleAssetVault).
+		Enable(amendment.FeatureFixCleanup3_2_0).
+		Build()
+	view := newSharedHelperView(rules)
+	var issuer, holder [20]byte
+	issuer[19] = 1
+	holder[19] = 2
+	id := keylet.MakeMPTID(7, issuer)
+	asset := tx.Asset{MPTIssuanceID: hex.EncodeToString(id[:])}
+
+	// Issuance lookup precedes the waiver and issuer-involvement checks.
+	require.Equal(t, ter.TecOBJECT_NOT_FOUND, canTransfer(view, asset, issuer, holder, true))
+
+	issuanceRaw, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+		Issuer:   issuer,
+		Sequence: 7,
+		Flags:    entry.LsfMPTLocked,
+	})
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(keylet.MPTIssuance(id), issuanceRaw))
+	require.Equal(t, ter.TesSUCCESS, canTransfer(view, asset, issuer, holder, false))
+	require.Equal(t, ter.TecLOCKED, checkFrozen(view, asset, holder))
+	require.Equal(t, ter.TesSUCCESS, checkFrozen(view, tx.Asset{Currency: "XRP"}, holder))
+}
+
+func TestRemoveVaultAssetMPTHoldingHonorsLockedAmountAmendment(t *testing.T) {
+	var issuer, holder [20]byte
+	issuer[19] = 1
+	holder[19] = 2
+	id := keylet.MakeMPTID(9, issuer)
+	asset := tx.Asset{MPTIssuanceID: hex.EncodeToString(id[:])}
+	locked := uint64(5)
+
+	build := func(t *testing.T, fixEnabled bool) (*tx.ApplyContext, *sharedHelperView) {
+		builder := amendment.NewRulesBuilder().Enable(amendment.FeatureSingleAssetVault)
+		if fixEnabled {
+			builder.Enable(amendment.FeatureFixCleanup3_1_3)
+		}
+		view := newSharedHelperView(builder.Build())
+		tokenKey := keylet.MPTokenByID(id, holder)
+		dir, err := state.DirInsert(view, keylet.OwnerDir(holder), tokenKey.Key, false, func(node *state.DirectoryNode) {
+			node.Owner = holder
+		})
+		require.NoError(t, err)
+		raw, err := state.SerializeMPToken(&state.MPTokenData{
+			Account:           holder,
+			MPTokenIssuanceID: id,
+			LockedAmount:      &locked,
+			OwnerNode:         dir.Page,
+		})
+		require.NoError(t, err)
+		require.NoError(t, view.Insert(tokenKey, raw))
+		return &tx.ApplyContext{View: view, Config: tx.EngineConfig{Rules: view.rules}}, view
+	}
+
+	t.Run("fix disabled removes holding", func(t *testing.T) {
+		ctx, view := build(t, false)
+		delta, result := removeVaultAssetHolding(ctx, holder, asset)
+		require.Equal(t, ter.TesSUCCESS, result)
+		require.Equal(t, int32(-1), delta)
+		exists, err := view.Exists(keylet.MPTokenByID(id, holder))
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+
+	t.Run("fix enabled preserves obligation", func(t *testing.T) {
+		ctx, view := build(t, true)
+		delta, result := removeVaultAssetHolding(ctx, holder, asset)
+		require.Equal(t, ter.TecHAS_OBLIGATIONS, result)
+		require.Zero(t, delta)
+		exists, err := view.Exists(keylet.MPTokenByID(id, holder))
+		require.NoError(t, err)
+		require.True(t, exists)
+	})
+}

--- a/internal/tx/vault/vault_clawback.go
+++ b/internal/tx/vault/vault_clawback.go
@@ -148,12 +148,12 @@ func (v *VaultClawback) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter
 
 	// Ambiguous: when the vault asset's issuer is the vault owner, the clawback
 	// must name the asset explicitly.
-	if v.Amount == nil && !isNativeAsset(vd.Asset) && !vd.AssetIsMPT {
-		ownerAddr, oerr := state.EncodeAccountID(vd.Owner)
-		if oerr != nil {
+	if v.Amount == nil && !isNativeAsset(vaultAssetOf(vd)) {
+		issuerID, ok := vaultAssetIssuer(vd)
+		if !ok {
 			return ter.TefINTERNAL
 		}
-		if vd.Asset.Issuer == ownerAddr {
+		if issuerID == vd.Owner {
 			return ter.TecWRONG_ASSET
 		}
 	}
@@ -167,11 +167,12 @@ func (v *VaultClawback) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter
 		}
 		if v.Amount != nil && v.Amount.Signum() != 0 {
 			held := holderMPTBalance(view, vd.ShareMPTID, holderID)
-			want, aerr := amountToNumber(*v.Amount)
+			scale := vaultNumberScale(config.RequireRules())
+			want, aerr := amountToNumberForRules(*v.Amount, config.RequireRules())
 			if aerr != nil {
 				return ter.TefINTERNAL
 			}
-			if want.Cmp(state.NewXRPLNumber(int64(held), 0)) != 0 {
+			if want.Cmp(state.NewXRPLNumberScaled(int64(held), 0, scale, state.RoundToNearest)) != 0 {
 				return ter.TecLIMIT_EXCEEDED
 			}
 		}
@@ -180,17 +181,35 @@ func (v *VaultClawback) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter
 
 	// Asset clawback by the issuer.
 	if assetMatches(clawbackAssetAmount(v, vd), vd) {
-		if isNativeAsset(vd.Asset) {
+		if isNativeAsset(vaultAssetOf(vd)) {
 			return ter.TecNO_PERMISSION
 		}
-		if vd.Asset.Issuer != v.Account {
+		issuerID, ok := vaultAssetIssuer(vd)
+		if !ok {
+			return ter.TefINTERNAL
+		}
+		if issuerID != accountID {
 			return ter.TecNO_PERMISSION
 		}
 		if accountID == holderID {
 			return ter.TecNO_PERMISSION
 		}
 		if vd.AssetIsMPT {
-			return ter.TecNO_PERMISSION // MPT-asset clawback deferred
+			assetData, rerr := view.Read(keylet.MPTIssuance(vd.AssetMPTID))
+			if rerr != nil {
+				return ter.TefINTERNAL
+			}
+			if assetData == nil {
+				return ter.TecOBJECT_NOT_FOUND
+			}
+			assetIssuance, perr := state.ParseMPTokenIssuance(assetData)
+			if perr != nil {
+				return ter.TefINTERNAL
+			}
+			if assetIssuance.Flags&entry.LsfMPTCanClawback == 0 {
+				return ter.TecNO_PERMISSION
+			}
+			return ter.TesSUCCESS
 		}
 		issuerAcct, ierr := tx.ReadAccountRoot(view, accountID)
 		if ierr != nil || issuerAcct == nil {
@@ -232,59 +251,24 @@ func (v *VaultClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TefINTERNAL
 	}
 
-	assetsTotalN, _ := vaultNumber(vd.AssetsTotal)
-	availN, _ := vaultNumber(vd.AssetsAvailable)
-	lossN, _ := vaultNumber(vd.LossUnrealized)
-	shareTotalN := state.NewXRPLNumber(int64(issuance.OutstandingAmount), 0)
-
-	held := holderMPTBalance(ctx.View, vd.ShareMPTID, holderID)
-	var sharesDestroyed uint64
-	assetsRecoveredN := state.NewXRPLNumber(0, 0)
-	clampAssets := false
-
-	if v.clawsBackShares(vd, accountID) {
-		// Owner burns every share held by the holder; the assets are already gone.
-		sharesDestroyed = held
-	} else if v.Amount == nil || v.Amount.Signum() == 0 {
-		sharesDestroyed = held
-		assetsRecoveredN = sharesToAssetsWithdraw(assetsTotalN, lossN, shareTotalN, state.NewXRPLNumber(int64(held), 0))
-		// Pre-fixCleanup3_1_3 the zero-amount path returned without clamping to
-		// AssetsAvailable, over-recovering when a loan was outstanding.
-		clampAssets = ctx.Rules().Enabled(amendment.FeatureFixCleanup3_1_3)
-	} else {
-		amountN, aerr := amountToNumber(*v.Amount)
-		if aerr != nil {
-			return ter.TefINTERNAL
-		}
-		sharesN := assetsToSharesWithdraw(assetsTotalN, lossN, shareTotalN, amountN, true)
-		s := uint64(sharesN.ToInt64WithMode(state.RoundTowardsZero))
-		if s > held {
-			s = held
-		}
-		sharesDestroyed = s
-		assetsRecoveredN = sharesToAssetsWithdraw(assetsTotalN, lossN, shareTotalN, state.NewXRPLNumber(int64(s), 0))
-		clampAssets = true
-	}
-
-	// Clamp the recovered assets to what the vault has available, truncating the
-	// shares so the recovery cannot breach AssetsAvailable.
-	if clampAssets && assetsRecoveredN.Cmp(availN) > 0 {
-		assetsRecoveredN = availN
-		sharesN := assetsToSharesWithdraw(assetsTotalN, lossN, shareTotalN, availN, true)
-		sharesDestroyed = uint64(sharesN.ToInt64WithMode(state.RoundTowardsZero))
-		assetsRecoveredN = sharesToAssetsWithdraw(assetsTotalN, lossN, shareTotalN, state.NewXRPLNumber(int64(sharesDestroyed), 0))
-		if assetsRecoveredN.Cmp(availN) > 0 {
-			return ter.TecINTERNAL
-		}
-	}
-
-	if sharesDestroyed == 0 {
-		return ter.TecPRECISION_LOSS
+	rules := ctx.Rules()
+	assetsTotalN, availN, assetsRecoveredN, sharesDestroyed, result := v.clawbackAmounts(
+		ctx,
+		vd,
+		issuance,
+		accountID,
+		holderID,
+	)
+	if result != ter.TesSUCCESS {
+		return result
 	}
 
 	vd.AssetsTotal = numberToString(assetsTotalN.Sub(assetsRecoveredN))
 	vd.AssetsAvailable = numberToString(availN.Sub(assetsRecoveredN))
-	newVault, serr := serializeVault(vd)
+	if err := associateVaultAsset(vd, rules); err != nil {
+		return ter.TefINTERNAL
+	}
+	newVault, serr := serializeVaultForRules(vd, rules)
 	if serr != nil {
 		return ter.TefINTERNAL
 	}
@@ -307,9 +291,97 @@ func (v *VaultClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 		if res := sendAssetFromVault(ctx, vd.Account, accountID, vaultAssetOf(vd), assetsRecoveredN); res != ter.TesSUCCESS {
 			return res
 		}
+		holding, err := actualAssetHolding(ctx.View, vd.Account, vaultAssetOf(vd), rules)
+		if err != nil || holding.Signum() < 0 {
+			return ter.TefINTERNAL
+		}
 	}
 
 	return ter.TesSUCCESS
+}
+
+func (v *VaultClawback) clawbackAmounts(
+	ctx *tx.ApplyContext,
+	vd *vaultData,
+	issuance *state.MPTokenIssuanceData,
+	accountID, holderID [20]byte,
+) (
+	assetsTotalN, availN, assetsRecoveredN state.XRPLNumber,
+	sharesDestroyed uint64,
+	result ter.Result,
+) {
+	result = ter.TesSUCCESS
+	defer func() {
+		if recover() != nil {
+			result = ter.TecPATH_DRY
+		}
+	}()
+
+	rules := ctx.Rules()
+	numberScale := vaultNumberScale(rules)
+	assetsTotalN, _ = vaultNumberForRules(vd.AssetsTotal, rules)
+	availN, _ = vaultNumberForRules(vd.AssetsAvailable, rules)
+	lossN, _ := vaultNumberForRules(vd.LossUnrealized, rules)
+	shareTotalN := state.NewXRPLNumberScaled(
+		int64(issuance.OutstandingAmount),
+		0,
+		numberScale,
+		state.RoundToNearest,
+	)
+	asset := vaultAssetOf(vd)
+	integral := asset.IsNative() || asset.IsMPT()
+	held := holderMPTBalance(ctx.View, vd.ShareMPTID, holderID)
+	assetsRecoveredN = state.NewXRPLNumberScaled(0, 0, numberScale, state.RoundToNearest)
+	clampAssets := false
+
+	if v.clawsBackShares(vd, accountID) {
+		sharesDestroyed = held
+	} else if v.Amount == nil || v.Amount.Signum() == 0 {
+		sharesDestroyed = held
+		assetsRecoveredN = sharesToAssetsWithdraw(
+			assetsTotalN,
+			lossN,
+			shareTotalN,
+			state.NewXRPLNumberScaled(int64(held), 0, numberScale, state.RoundToNearest),
+			integral,
+		)
+		clampAssets = rules.Enabled(amendment.FeatureFixCleanup3_1_3)
+	} else {
+		amountN, err := amountToNumberForRules(*v.Amount, rules)
+		if err != nil {
+			return assetsTotalN, availN, assetsRecoveredN, 0, ter.TefINTERNAL
+		}
+		sharesN := assetsToSharesWithdraw(assetsTotalN, lossN, shareTotalN, amountN, false)
+		sharesDestroyed = uint64(sharesN.ToInt64WithMode(state.RoundTowardsZero))
+		assetsRecoveredN = sharesToAssetsWithdraw(
+			assetsTotalN,
+			lossN,
+			shareTotalN,
+			sharesN,
+			integral,
+		)
+		clampAssets = true
+	}
+
+	if clampAssets && assetsRecoveredN.Cmp(availN) > 0 {
+		assetsRecoveredN = availN
+		sharesN := assetsToSharesWithdraw(assetsTotalN, lossN, shareTotalN, availN, true)
+		sharesDestroyed = uint64(sharesN.ToInt64WithMode(state.RoundTowardsZero))
+		assetsRecoveredN = sharesToAssetsWithdraw(
+			assetsTotalN,
+			lossN,
+			shareTotalN,
+			sharesN,
+			integral,
+		)
+		if assetsRecoveredN.Cmp(availN) > 0 {
+			return assetsTotalN, availN, assetsRecoveredN, sharesDestroyed, ter.TecINTERNAL
+		}
+	}
+	if sharesDestroyed == 0 {
+		return assetsTotalN, availN, assetsRecoveredN, 0, ter.TecPRECISION_LOSS
+	}
+	return assetsTotalN, availN, assetsRecoveredN, sharesDestroyed, ter.TesSUCCESS
 }
 
 // clawbackAssetAmount returns a tx.Amount denominating the vault asset, used to
@@ -318,8 +390,23 @@ func clawbackAssetAmount(v *VaultClawback, vd *vaultData) tx.Amount {
 	if v.Amount != nil {
 		return *v.Amount
 	}
+	if vd.AssetIsMPT {
+		issuer, err := state.EncodeAccountID(mptIDIssuer(vd.AssetMPTID))
+		if err != nil {
+			return tx.Amount{}
+		}
+		return state.NewMPTAmountWithIssuanceID(0, issuer, hex.EncodeToString(vd.AssetMPTID[:]))
+	}
 	if isNativeAsset(vd.Asset) {
 		return tx.Amount{Native: true}
 	}
 	return state.NewIssuedAmountFromValue(0, state.MinExponent, vd.Asset.Currency, vd.Asset.Issuer)
+}
+
+func vaultAssetIssuer(vd *vaultData) ([20]byte, bool) {
+	if vd.AssetIsMPT {
+		return mptIDIssuer(vd.AssetMPTID), true
+	}
+	issuer, err := state.DecodeAccountID(vd.Asset.Issuer)
+	return issuer, err == nil
 }

--- a/internal/tx/vault/vault_clawback_test.go
+++ b/internal/tx/vault/vault_clawback_test.go
@@ -1,0 +1,363 @@
+package vault
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+)
+
+type vaultClawbackFixture struct {
+	view          *mptArmsView
+	ctx           *tx.ApplyContext
+	txn           *VaultClawback
+	vaultKey      keylet.Keylet
+	assetIssuerID [20]byte
+	ownerID       [20]byte
+	holderID      [20]byte
+	pseudoID      [20]byte
+	assetMPTID    [24]byte
+	shareMPTID    [24]byte
+}
+
+func newVaultClawbackFixture(t *testing.T, holderShares uint64) *vaultClawbackFixture {
+	t.Helper()
+	assetIssuerID := clawbackTestID(0x51)
+	ownerID := clawbackTestID(0x52)
+	holderID := clawbackTestID(0x53)
+	pseudoID := clawbackTestID(0x54)
+	assetMPTID := keylet.MakeMPTID(11, assetIssuerID)
+	shareMPTID := keylet.MakeMPTID(12, pseudoID)
+	var vaultID [32]byte
+	for i := range vaultID {
+		vaultID[i] = 0x55
+	}
+	vaultKey := keylet.VaultByID(vaultID)
+	view := newMPTArmsView()
+
+	vaultBytes, err := serializeVault(&vaultData{
+		Owner:            ownerID,
+		Account:          pseudoID,
+		Sequence:         1,
+		ShareMPTID:       shareMPTID,
+		AssetIsMPT:       true,
+		AssetMPTID:       assetMPTID,
+		WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+		AssetsTotal:      "100",
+		AssetsAvailable:  "100",
+	})
+	if err != nil {
+		t.Fatalf("serialize vault: %v", err)
+	}
+	view.data[vaultKey.Key] = vaultBytes
+
+	assetIssuance, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+		Issuer: assetIssuerID, Sequence: 11, OutstandingAmount: 100, Flags: entry.LsfMPTCanClawback,
+	})
+	if err != nil {
+		t.Fatalf("serialize asset issuance: %v", err)
+	}
+	view.data[keylet.MPTIssuance(assetMPTID).Key] = assetIssuance
+	assetToken, err := state.SerializeMPToken(&state.MPTokenData{
+		Account: pseudoID, MPTokenIssuanceID: assetMPTID, MPTAmount: 100,
+	})
+	if err != nil {
+		t.Fatalf("serialize vault asset token: %v", err)
+	}
+	view.data[keylet.MPTokenByID(assetMPTID, pseudoID).Key] = assetToken
+
+	shareIssuance, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+		Issuer: pseudoID, Sequence: 12, OutstandingAmount: 100,
+	})
+	if err != nil {
+		t.Fatalf("serialize share issuance: %v", err)
+	}
+	view.data[keylet.MPTIssuance(shareMPTID).Key] = shareIssuance
+	shareToken, err := state.SerializeMPToken(&state.MPTokenData{
+		Account: holderID, MPTokenIssuanceID: shareMPTID, MPTAmount: holderShares,
+	})
+	if err != nil {
+		t.Fatalf("serialize holder share token: %v", err)
+	}
+	view.data[keylet.MPTokenByID(shareMPTID, holderID).Key] = shareToken
+
+	issuerAddr := clawbackTestAddress(t, assetIssuerID)
+	holderAddr := clawbackTestAddress(t, holderID)
+	issuerAccount := &state.AccountRoot{Account: issuerAddr, Balance: 1_000_000_000, Sequence: 1}
+	ctx := &tx.ApplyContext{
+		View:      view,
+		Account:   issuerAccount,
+		AccountID: assetIssuerID,
+		Config:    tx.EngineConfig{Rules: rulesWithFix(true)},
+		Metadata:  &tx.Metadata{},
+		Log:       xrpllog.Discard(),
+		Ctx:       context.Background(),
+	}
+	txn := NewVaultClawback(issuerAddr, hex.EncodeToString(vaultID[:]), holderAddr)
+	return &vaultClawbackFixture{
+		view:          view,
+		ctx:           ctx,
+		txn:           txn,
+		vaultKey:      vaultKey,
+		assetIssuerID: assetIssuerID,
+		ownerID:       ownerID,
+		holderID:      holderID,
+		pseudoID:      pseudoID,
+		assetMPTID:    assetMPTID,
+		shareMPTID:    shareMPTID,
+	}
+}
+
+func TestVaultClawbackMPTPreclaimAuthorizationAndPrecedence(t *testing.T) {
+	newCase := func(t *testing.T) (*vaultClawbackFixture, tx.Amount) {
+		t.Helper()
+		f := newVaultClawbackFixture(t, 100)
+		amount := state.NewMPTAmountWithIssuanceID(
+			0,
+			clawbackTestAddress(t, f.assetIssuerID),
+			hex.EncodeToString(f.assetMPTID[:]),
+		)
+		f.txn.Amount = &amount
+		delete(f.view.data, keylet.MPTIssuance(f.assetMPTID).Key)
+		return f, amount
+	}
+
+	t.Run("issuer check precedes missing issuance", func(t *testing.T) {
+		f, _ := newCase(t)
+		f.txn.Account = clawbackTestAddress(t, clawbackTestID(0x61))
+		if got := f.txn.Preclaim(f.view, f.ctx.Config); got != ter.TecNO_PERMISSION {
+			t.Fatalf("Preclaim() = %v, want tecNO_PERMISSION", got)
+		}
+	})
+
+	t.Run("missing issuance", func(t *testing.T) {
+		f, _ := newCase(t)
+		if got := f.txn.Preclaim(f.view, f.ctx.Config); got != ter.TecOBJECT_NOT_FOUND {
+			t.Fatalf("Preclaim() = %v, want tecOBJECT_NOT_FOUND", got)
+		}
+	})
+
+	t.Run("clawback disabled", func(t *testing.T) {
+		f, _ := newCase(t)
+		data, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+			Issuer: f.assetIssuerID, Sequence: 11,
+		})
+		if err != nil {
+			t.Fatalf("serialize asset issuance: %v", err)
+		}
+		f.view.data[keylet.MPTIssuance(f.assetMPTID).Key] = data
+		if got := f.txn.Preclaim(f.view, f.ctx.Config); got != ter.TecNO_PERMISSION {
+			t.Fatalf("Preclaim() = %v, want tecNO_PERMISSION", got)
+		}
+	})
+
+	t.Run("clawback enabled", func(t *testing.T) {
+		f, _ := newCase(t)
+		data, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+			Issuer: f.assetIssuerID, Sequence: 11, Flags: entry.LsfMPTCanClawback,
+		})
+		if err != nil {
+			t.Fatalf("serialize asset issuance: %v", err)
+		}
+		f.view.data[keylet.MPTIssuance(f.assetMPTID).Key] = data
+		if got := f.txn.Preclaim(f.view, f.ctx.Config); got != ter.TesSUCCESS {
+			t.Fatalf("Preclaim() = %v, want tesSUCCESS", got)
+		}
+	})
+}
+
+func TestVaultClawbackMPTImplicitOwnerIssuerIsAmbiguous(t *testing.T) {
+	f := newVaultClawbackFixture(t, 100)
+	vaultBytes, err := serializeVault(&vaultData{
+		Owner:            f.assetIssuerID,
+		Account:          f.pseudoID,
+		Sequence:         1,
+		ShareMPTID:       f.shareMPTID,
+		AssetIsMPT:       true,
+		AssetMPTID:       f.assetMPTID,
+		WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+		AssetsTotal:      "100",
+		AssetsAvailable:  "100",
+	})
+	if err != nil {
+		t.Fatalf("serialize vault: %v", err)
+	}
+	f.view.data[f.vaultKey.Key] = vaultBytes
+	if got := f.txn.Preclaim(f.view, f.ctx.Config); got != ter.TecWRONG_ASSET {
+		t.Fatalf("Preclaim() = %v, want tecWRONG_ASSET", got)
+	}
+}
+
+func TestVaultClawbackTransfersMPTAssetToIssuer(t *testing.T) {
+	f := newVaultClawbackFixture(t, 100)
+	amount := state.NewMPTAmountWithIssuanceID(
+		40,
+		clawbackTestAddress(t, f.assetIssuerID),
+		hex.EncodeToString(f.assetMPTID[:]),
+	)
+	f.txn.Amount = &amount
+	if got := f.txn.Apply(f.ctx); got != ter.TesSUCCESS {
+		t.Fatalf("Apply() = %v, want tesSUCCESS", got)
+	}
+
+	vaultBytes := f.view.data[f.vaultKey.Key]
+	updatedVault, err := parseVault(vaultBytes)
+	if err != nil {
+		t.Fatalf("parse updated vault: %v", err)
+	}
+	total, err := vaultNumber(updatedVault.AssetsTotal)
+	if err != nil {
+		t.Fatalf("parse AssetsTotal: %v", err)
+	}
+	available, err := vaultNumber(updatedVault.AssetsAvailable)
+	if err != nil {
+		t.Fatalf("parse AssetsAvailable: %v", err)
+	}
+	want := state.NewXRPLNumber(60, 0)
+	if total.Cmp(want) != 0 || available.Cmp(want) != 0 {
+		t.Fatalf("vault totals = (%s, %s), want (60, 60)", updatedVault.AssetsTotal, updatedVault.AssetsAvailable)
+	}
+	assetIssuance := clawbackTestIssuance(t, f.view, f.assetMPTID)
+	if assetIssuance.OutstandingAmount != 60 {
+		t.Fatalf("asset outstanding = %d, want 60", assetIssuance.OutstandingAmount)
+	}
+	assetToken := clawbackTestToken(t, f.view, f.assetMPTID, f.pseudoID)
+	if assetToken.MPTAmount != 60 {
+		t.Fatalf("vault asset balance = %d, want 60", assetToken.MPTAmount)
+	}
+	shareIssuance := clawbackTestIssuance(t, f.view, f.shareMPTID)
+	if shareIssuance.OutstandingAmount != 60 {
+		t.Fatalf("share outstanding = %d, want 60", shareIssuance.OutstandingAmount)
+	}
+	shareToken := clawbackTestToken(t, f.view, f.shareMPTID, f.holderID)
+	if shareToken.MPTAmount != 60 {
+		t.Fatalf("holder shares = %d, want 60", shareToken.MPTAmount)
+	}
+}
+
+func TestVaultClawbackExplicitAmountDoesNotClampToHolderShares(t *testing.T) {
+	f := newVaultClawbackFixture(t, 10)
+	amount := state.NewMPTAmountWithIssuanceID(
+		20,
+		clawbackTestAddress(t, f.assetIssuerID),
+		hex.EncodeToString(f.assetMPTID[:]),
+	)
+	f.txn.Amount = &amount
+	if got := f.txn.Apply(f.ctx); got != ter.TecINSUFFICIENT_FUNDS {
+		t.Fatalf("Apply() = %v, want tecINSUFFICIENT_FUNDS", got)
+	}
+}
+
+func TestVaultClawbackExplicitAmountRoundsSharesToNearest(t *testing.T) {
+	f := newVaultClawbackFixture(t, 2)
+	vd, err := readVault(f.view, f.vaultKey)
+	if err != nil {
+		t.Fatalf("read vault: %v", err)
+	}
+	vd.AssetsTotal = "3"
+	vd.AssetsAvailable = "3"
+	issuance := clawbackTestIssuance(t, f.view, f.shareMPTID)
+	issuance.OutstandingAmount = 2
+	amount := state.NewMPTAmountWithIssuanceID(
+		1,
+		clawbackTestAddress(t, f.assetIssuerID),
+		hex.EncodeToString(f.assetMPTID[:]),
+	)
+	f.txn.Amount = &amount
+
+	_, _, recovered, shares, result := f.txn.clawbackAmounts(
+		f.ctx,
+		vd,
+		issuance,
+		f.assetIssuerID,
+		f.holderID,
+	)
+	if result != ter.TesSUCCESS {
+		t.Fatalf("clawbackAmounts() = %v, want tesSUCCESS", result)
+	}
+	if shares != 1 {
+		t.Fatalf("shares destroyed = %d, want nearest-rounded 1", shares)
+	}
+	want := state.NewXRPLNumberScaled(2, 0, vaultNumberScale(f.ctx.Rules()), state.RoundToNearest)
+	if recovered.Cmp(want) != 0 {
+		t.Fatalf("assets recovered = %s, want asset-rounded 2", recovered.String())
+	}
+}
+
+func TestVaultClawbackRejectsNegativeVaultAssetBalance(t *testing.T) {
+	f := newVaultClawbackFixture(t, 100)
+	issuerAddress := clawbackTestAddress(t, f.assetIssuerID)
+	pseudoAddress := clawbackTestAddress(t, f.pseudoID)
+	vaultBytes, err := serializeVaultForRules(&vaultData{
+		Owner:            f.ownerID,
+		Account:          f.pseudoID,
+		Sequence:         1,
+		ShareMPTID:       f.shareMPTID,
+		Asset:            tx.Asset{Currency: "USD", Issuer: issuerAddress},
+		WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+		AssetsTotal:      "100",
+		AssetsAvailable:  "100",
+	}, f.ctx.Rules())
+	if err != nil {
+		t.Fatalf("serialize IOU vault: %v", err)
+	}
+	f.view.data[f.vaultKey.Key] = vaultBytes
+	line, err := state.SerializeRippleState(&state.RippleState{
+		Balance:   state.NewIssuedAmountFromValue(-10, 0, "USD", issuerAddress),
+		LowLimit:  state.NewIssuedAmountFromValue(0, state.MinExponent, "USD", issuerAddress),
+		HighLimit: state.NewIssuedAmountFromValue(1_000, 0, "USD", pseudoAddress),
+	})
+	if err != nil {
+		t.Fatalf("serialize vault trust line: %v", err)
+	}
+	f.view.data[keylet.Line(f.assetIssuerID, f.pseudoID, "USD").Key] = line
+	deleteTestPutAccount(t, f.view, f.assetIssuerID, f.ctx.Account)
+	deleteTestPutAccount(t, f.view, f.pseudoID, &state.AccountRoot{Account: pseudoAddress})
+
+	amount := state.NewIssuedAmountFromValue(40, 0, "USD", issuerAddress)
+	f.txn.Amount = &amount
+	if got := f.txn.Apply(f.ctx); got != ter.TefINTERNAL {
+		t.Fatalf("Apply() = %v, want tefINTERNAL", got)
+	}
+}
+
+func clawbackTestID(b byte) [20]byte {
+	var id [20]byte
+	for i := range id {
+		id[i] = b
+	}
+	return id
+}
+
+func clawbackTestAddress(t *testing.T, id [20]byte) string {
+	t.Helper()
+	address, err := state.EncodeAccountID(id)
+	if err != nil {
+		t.Fatalf("encode account: %v", err)
+	}
+	return address
+}
+
+func clawbackTestIssuance(t *testing.T, view *mptArmsView, id [24]byte) *state.MPTokenIssuanceData {
+	t.Helper()
+	issuance, err := state.ParseMPTokenIssuance(view.data[keylet.MPTIssuance(id).Key])
+	if err != nil {
+		t.Fatalf("parse MPT issuance: %v", err)
+	}
+	return issuance
+}
+
+func clawbackTestToken(t *testing.T, view *mptArmsView, id [24]byte, holder [20]byte) *state.MPTokenData {
+	t.Helper()
+	token, err := state.ParseMPToken(view.data[keylet.MPTokenByID(id, holder).Key])
+	if err != nil {
+		t.Fatalf("parse MPToken: %v", err)
+	}
+	return token
+}

--- a/internal/tx/vault/vault_create.go
+++ b/internal/tx/vault/vault_create.go
@@ -360,7 +360,11 @@ func (v *VaultCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 		}
 	}
 	if v.AssetsMaximum != nil {
-		vd.AssetsMaximum = *v.AssetsMaximum
+		maximum, nerr := vaultNumber(*v.AssetsMaximum)
+		if nerr != nil {
+			return ter.TefINTERNAL
+		}
+		vd.AssetsMaximum = numberToString(maximum)
 	}
 	vaultBytes, err := serializeVault(vd)
 	if err != nil {

--- a/internal/tx/vault/vault_create.go
+++ b/internal/tx/vault/vault_create.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"strings"
 
 	"github.com/LeJamon/go-xrpl/amendment"
@@ -39,6 +40,25 @@ type VaultCreate struct {
 	Scale *uint8 `json:"Scale,omitempty" xrpl:"Scale,omitempty"`
 }
 
+func (v *VaultCreate) UnmarshalJSON(data []byte) error {
+	type alias VaultCreate
+	decoded := struct {
+		AssetsMaximum json.RawMessage `json:"AssetsMaximum"`
+		*alias
+	}{alias: (*alias)(v)}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	if decoded.AssetsMaximum != nil {
+		maximum, err := parseAssetsMaximumJSON(decoded.AssetsMaximum)
+		if err != nil {
+			return err
+		}
+		v.AssetsMaximum = maximum
+	}
+	return nil
+}
+
 // NewVaultCreate creates a new VaultCreate transaction
 func NewVaultCreate(account string, asset tx.Asset) *VaultCreate {
 	return &VaultCreate{
@@ -71,7 +91,7 @@ func (v *VaultCreate) Validate() error {
 
 	// Data is a Blob: present-but-empty and over-length (in decoded bytes)
 	// are both rejected.
-	if v.Data != "" {
+	if v.Data != "" || v.Common.HasField("Data") {
 		dataBytes, err := decodeBlob(v.Data)
 		if err != nil {
 			return ErrVaultDataTooLong
@@ -92,7 +112,7 @@ func (v *VaultCreate) Validate() error {
 	}
 
 	// Validate DomainID if present
-	if v.DomainID != "" {
+	if v.DomainID != "" || v.Common.HasField("DomainID") {
 		if _, err := tx.ParseHash256NonZero(v.DomainID); err != nil {
 			if isZeroHash(v.DomainID) {
 				return ErrVaultDomainIDZero
@@ -105,14 +125,13 @@ func (v *VaultCreate) Validate() error {
 		}
 	}
 
-	// Validate AssetsMaximum if present. It is a NUMBER: negative is rejected.
-	if v.AssetsMaximum != nil && isNegativeNumberString(*v.AssetsMaximum) {
-		return ErrVaultAssetsMaxNeg
+	if err := validateAssetsMaximum(v.AssetsMaximum); err != nil {
+		return err
 	}
 
 	// MPTokenMetadata is a Blob: present-but-empty and over-length (in decoded
 	// bytes) are both rejected.
-	if v.MPTokenMetadata != "" {
+	if v.MPTokenMetadata != "" || v.Common.HasField("MPTokenMetadata") {
 		metaBytes, err := decodeBlob(v.MPTokenMetadata)
 		if err != nil {
 			return ErrVaultMetadataTooLong
@@ -143,30 +162,16 @@ func isNativeAsset(a tx.Asset) bool {
 	return a.IsNative()
 }
 
-// isNegativeNumberString reports whether a NUMBER field's string form is
-// strictly negative. The binary codec renders negatives with a leading '-'
-// and normalises zero to "0", so a leading '-' is a reliable sign test.
-func isNegativeNumberString(s string) bool {
-	return strings.HasPrefix(strings.TrimSpace(s), "-")
-}
-
 func (v *VaultCreate) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(v)
 }
 
 func (v *VaultCreate) RequiredAmendments() [][32]byte {
 	amendments := [][32]byte{amendment.FeatureSingleAssetVault, amendment.FeatureMPTokensV1}
-	if v.DomainID != "" {
+	if v.DomainID != "" || v.Common.HasField("DomainID") {
 		amendments = append(amendments, amendment.FeaturePermissionedDomains)
 	}
 	return amendments
-}
-
-// CalculateBaseFee returns one owner reserve increment: creating a vault also
-// creates a pseudo-account, so rippled charges the increment as the base fee.
-// Reference: rippled VaultCreate::calculateBaseFee.
-func (v *VaultCreate) CalculateBaseFee(_ tx.LedgerView, config tx.EngineConfig) uint64 {
-	return config.ReserveIncrement
 }
 
 // Preclaim runs the stateful checks: the vault asset must be addable, must not
@@ -198,7 +203,7 @@ func (v *VaultCreate) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.R
 		}
 	}
 
-	if res := tx.AssetFrozen(view, accountID, asset); res != ter.TesSUCCESS {
+	if res := checkFrozen(view, asset, accountID); res != ter.TesSUCCESS {
 		return res
 	}
 
@@ -236,13 +241,6 @@ func (v *VaultCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TecDUPLICATE
 	}
 
-	// Creating a vault also creates its pseudo-account, so the owner is charged
-	// for two objects up front (rippled adjustOwnerCount(+2)).
-	newOwnerCount := owner.OwnerCount + 2
-	if ctx.PriorBalance() < ctx.AccountReserve(newOwnerCount) {
-		return ter.TecINSUFFICIENT_RESERVE
-	}
-
 	// Link the vault into the owner's directory.
 	ownerDirKey := keylet.OwnerDir(accountID)
 	vaultDir, err := state.DirInsert(ctx.View, ownerDirKey, vaultKey.Key, false, func(d *state.DirectoryNode) {
@@ -250,6 +248,11 @@ func (v *VaultCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 	})
 	if err != nil {
 		return ter.TecDIR_FULL
+	}
+
+	newOwnerCount := tx.ConfineOwnerCount(owner.OwnerCount, 2)
+	if ctx.PriorBalance() < ctx.AccountReserve(newOwnerCount) {
+		return ter.TecINSUFFICIENT_RESERVE
 	}
 
 	// Compute the share issuance scale and flags. Scale applies to IOU assets
@@ -360,13 +363,16 @@ func (v *VaultCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 		}
 	}
 	if v.AssetsMaximum != nil {
-		maximum, nerr := vaultNumber(*v.AssetsMaximum)
+		maximum, nerr := parseCreateSetNumberForRules(*v.AssetsMaximum, ctx.Rules())
 		if nerr != nil {
 			return ter.TefINTERNAL
 		}
-		vd.AssetsMaximum = numberToString(maximum)
+		vd.AssetsMaximum = canonicalCreateSetAssetsMaximum(asset, maximum)
 	}
-	vaultBytes, err := serializeVault(vd)
+	if err := associateVaultAsset(vd, ctx.Rules()); err != nil {
+		return ter.TefINTERNAL
+	}
+	vaultBytes, err := serializeVaultForRules(vd, ctx.Rules())
 	if err != nil {
 		return ter.TefINTERNAL
 	}

--- a/internal/tx/vault/vault_create_conformance_test.go
+++ b/internal/tx/vault/vault_create_conformance_test.go
@@ -1,0 +1,267 @@
+package vault
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+func TestVaultCreateRejectsPresentEmptyBlobs(t *testing.T) {
+	tests := []struct {
+		name  string
+		field string
+		want  error
+	}{
+		{name: "Data", field: "Data", want: ErrVaultDataEmpty},
+		{name: "MPTokenMetadata", field: "MPTokenMetadata", want: ErrVaultMetadataEmpty},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			create := NewVaultCreate("rOwner", tx.Asset{Currency: "XRP"})
+			create.Common.SetPresentFields(map[string]bool{test.field: true})
+			if got := create.Validate(); got != test.want {
+				t.Fatalf("Validate() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestVaultJSONParsingPreservesPresentEmptyFields(t *testing.T) {
+	Register()
+	parsed, err := tx.ParseJSON([]byte(`{
+		"TransactionType":"VaultCreate",
+		"Account":"rOwner",
+		"Asset":{"currency":"XRP"},
+		"Data":""
+	}`))
+	if err != nil {
+		t.Fatalf("ParseJSON: %v", err)
+	}
+	create, ok := parsed.(*VaultCreate)
+	if !ok {
+		t.Fatalf("ParseJSON returned %T, want *VaultCreate", parsed)
+	}
+	if !create.Common.HasField("Data") {
+		t.Fatal("ParseJSON lost Data field presence")
+	}
+	if got := create.Validate(); got != ErrVaultDataEmpty {
+		t.Fatalf("Validate() = %v, want %v", got, ErrVaultDataEmpty)
+	}
+
+	for _, transactionType := range []string{"VaultCreate", "VaultSet"} {
+		t.Run(transactionType+" rejects malformed AssetsMaximum", func(t *testing.T) {
+			_, err := tx.ParseJSON([]byte(`{
+				"TransactionType":"` + transactionType + `",
+				"Account":"rOwner",
+				"Asset":{"currency":"XRP"},
+				"VaultID":"0101010101010101010101010101010101010101010101010101010101010101",
+				"AssetsMaximum":"9223372036854775807.6"
+			}`))
+			if err == nil {
+				t.Fatal("ParseJSON accepted malformed AssetsMaximum")
+			}
+		})
+	}
+}
+
+func TestVaultCreateRejectsMalformedProgrammaticAssetsMaximum(t *testing.T) {
+	maximum := "not-a-number"
+	create := NewVaultCreate("rOwner", tx.Asset{Currency: "XRP"})
+	create.AssetsMaximum = &maximum
+	if got := vaultResultCode(t, create.Validate()); got != ter.TemMALFORMED {
+		t.Fatalf("Validate() = %v, want temMALFORMED", got)
+	}
+}
+
+func TestVaultCreateUsesNormalBaseFee(t *testing.T) {
+	var transaction tx.Transaction = NewVaultCreate("rOwner", tx.Asset{Currency: "XRP"})
+	if _, ok := transaction.(tx.CustomBaseFeeCalculator); ok {
+		t.Fatal("VaultCreate unexpectedly overrides the normal base fee")
+	}
+}
+
+func TestVaultCreateAcceptsNegativeZeroAssetsMaximum(t *testing.T) {
+	maximum := "-0"
+	create := NewVaultCreate("rOwner", tx.Asset{Currency: "XRP"})
+	create.AssetsMaximum = &maximum
+	if err := create.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+}
+
+func TestVaultCreatePresentEmptyDomainIsGatedAndMalformed(t *testing.T) {
+	create := NewVaultCreate("rOwner", tx.Asset{Currency: "XRP"})
+	create.Common.SetPresentFields(map[string]bool{"DomainID": true})
+
+	if got := vaultResultCode(t, create.Validate()); got != ter.TemMALFORMED {
+		t.Fatalf("Validate() = %v, want temMALFORMED", got)
+	}
+	for _, feature := range create.RequiredAmendments() {
+		if feature == amendment.FeaturePermissionedDomains {
+			return
+		}
+	}
+	t.Fatal("RequiredAmendments() omitted PermissionedDomains")
+}
+
+func TestVaultCreateAssetsMaximumMatchesAssetPrecision(t *testing.T) {
+	xrp := tx.Asset{Currency: "XRP"}
+	mpt := tx.Asset{MPTIssuanceID: "00000001ABCDEF0123456789ABCDEF0123456789ABCDEF12"}
+	iou := tx.Asset{Currency: "USD", Issuer: "rIssuer"}
+
+	tests := []struct {
+		name  string
+		asset tx.Asset
+		raw   string
+		want  string
+	}{
+		{name: "XRP network maximum", asset: xrp, raw: "100000000000000000", want: "100000000000000000e0"},
+		{name: "XRP rounds fractional drops", asset: xrp, raw: "9223372036854775.808", want: "9223372036854776e0"},
+		{name: "MPT signed int64 maximum", asset: mpt, raw: "9223372036854775807", want: "9223372036854775807e0"},
+		{name: "MPT XRP maximum plus one", asset: mpt, raw: "100000000000000001", want: "100000000000000001e0"},
+		{name: "MPT XRP maximum", asset: mpt, raw: "100000000000000000", want: "100000000000000000e0"},
+		{name: "MPT rounds fractional units", asset: mpt, raw: "922337203685477580.8", want: "922337203685477581e0"},
+		{name: "IOU signed int64 maximum", asset: iou, raw: "9223372036854775807", want: "9223372036854776e3"},
+		{name: "IOU XRP maximum plus one", asset: iou, raw: "100000000000000001", want: "1000000000000000e2"},
+		{name: "IOU XRP maximum", asset: iou, raw: "100000000000000000", want: "1000000000000000e2"},
+		{name: "IOU signed int64 maximum plus one", asset: iou, raw: "9223372036854775808", want: "9223372036854776e3"},
+		{name: "IOU maximum exponent", asset: iou, raw: "1000000000000000e80", want: "1000000000000000e80"},
+		{name: "IOU minimum exponent", asset: iou, raw: "1000000000000000e-96", want: "1000000000000000e-96"},
+		{name: "IOU rounds to sixteen digits", asset: iou, raw: "922337203685477580.8", want: "9223372036854776e2"},
+		{name: "IOU large exponent", asset: iou, raw: "9223372036854775807e40", want: "9223372036854776e43"},
+		{name: "IOU small exponent", asset: iou, raw: "9223372036854775807e-40", want: "9223372036854776e-37"},
+		{name: "IOU underflow removes default", asset: iou, raw: "9223372036854775807e-100", want: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			number, err := parseCreateSetNumber(test.raw)
+			if err != nil {
+				t.Fatalf("parseCreateSetNumber(%q): %v", test.raw, err)
+			}
+			got := canonicalCreateSetAssetsMaximum(test.asset, number)
+			if test.want == "" {
+				if got != "" {
+					t.Fatalf("canonical AssetsMaximum = %q, want default removal", got)
+				}
+				return
+			}
+			gotNumber, err := parseCreateSetNumber(got)
+			if err != nil {
+				t.Fatalf("parse canonical AssetsMaximum %q: %v", got, err)
+			}
+			wantNumber, err := parseCreateSetNumber(test.want)
+			if err != nil {
+				t.Fatalf("parse expected AssetsMaximum %q: %v", test.want, err)
+			}
+			if gotNumber.Cmp(wantNumber) != 0 {
+				t.Fatalf("canonical AssetsMaximum = %q, want value %q", got, test.want)
+			}
+		})
+	}
+
+	panicTests := []struct {
+		name  string
+		asset tx.Asset
+		raw   string
+	}{
+		{name: "XRP above network maximum", asset: xrp, raw: "100000000000000001"},
+		{name: "XRP int64 maximum", asset: xrp, raw: "9223372036854775807"},
+		{name: "MPT above int64 maximum", asset: mpt, raw: "9223372036854775808"},
+		{name: "IOU above maximum exponent", asset: iou, raw: "1000000000000000e81"},
+	}
+	for _, test := range panicTests {
+		t.Run(test.name, func(t *testing.T) {
+			number, err := parseCreateSetNumber(test.raw)
+			if err != nil {
+				t.Fatalf("parseCreateSetNumber(%q): %v", test.raw, err)
+			}
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("canonical AssetsMaximum did not panic")
+				}
+			}()
+			canonicalCreateSetAssetsMaximum(test.asset, number)
+		})
+	}
+}
+
+func TestVaultCreateApplyRemovesRoundedZeroAssetsMaximum(t *testing.T) {
+	view := newMPTArmsView()
+	var ownerID [20]byte
+	for i := range ownerID {
+		ownerID[i] = 1
+	}
+	ctx := buildArmsCtx(t, view, ownerID, rulesWithFix(true))
+	sequence := uint32(1)
+	maximum := "0.4"
+	create := NewVaultCreate(ctx.Account.Account, tx.Asset{Currency: "XRP"})
+	create.Common.Sequence = &sequence
+	create.AssetsMaximum = &maximum
+
+	if got := create.Apply(ctx); got != ter.TesSUCCESS {
+		t.Fatalf("Apply() = %v, want tesSUCCESS", got)
+	}
+	created, err := readVault(view, keylet.Vault(ownerID, sequence))
+	if err != nil {
+		t.Fatalf("read created vault: %v", err)
+	}
+	if created == nil {
+		t.Fatal("created vault is missing")
+	}
+	if created.AssetsMaximum != "" {
+		t.Fatalf("AssetsMaximum = %q, want default removal", created.AssetsMaximum)
+	}
+}
+
+func TestVaultNumberSerializationPreservesLargeMantissa(t *testing.T) {
+	encoded, err := encodeVaultNumber("9223372036854775807e0", state.MantissaScaleLarge)
+	if err != nil {
+		t.Fatalf("encodeVaultNumber: %v", err)
+	}
+	if got := int64(binary.BigEndian.Uint64(encoded[:8])); got != math.MaxInt64 {
+		t.Fatalf("encoded mantissa = %d, want %d", got, int64(math.MaxInt64))
+	}
+	if got := int32(binary.BigEndian.Uint32(encoded[8:])); got != 0 {
+		t.Fatalf("encoded exponent = %d, want 0", got)
+	}
+}
+
+func TestSerializeVaultPreservesLargeAssetsMaximum(t *testing.T) {
+	data := &vaultData{
+		Owner:            [20]byte{1},
+		Account:          [20]byte{2},
+		Sequence:         1,
+		ShareMPTID:       [24]byte{3},
+		Asset:            tx.Asset{Currency: "XRP"},
+		WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+		AssetsMaximum:    "9223372036854775807e0",
+	}
+	encoded, err := serializeVault(data)
+	if err != nil {
+		t.Fatalf("serializeVault: %v", err)
+	}
+	fields, err := readVaultNumberFields(encoded)
+	if err != nil {
+		t.Fatalf("readVaultNumberFields: %v", err)
+	}
+	if got := fields["AssetsMaximum"]; got != data.AssetsMaximum {
+		t.Fatalf("AssetsMaximum = %q, want %q", got, data.AssetsMaximum)
+	}
+}
+
+func vaultResultCode(t *testing.T, err error) ter.Result {
+	t.Helper()
+	result, ok := ter.AsResultError(err)
+	if !ok {
+		t.Fatalf("error %v does not carry a TER", err)
+	}
+	return result.Code
+}

--- a/internal/tx/vault/vault_delete.go
+++ b/internal/tx/vault/vault_delete.go
@@ -107,6 +107,9 @@ func (v *VaultDelete) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.R
 	if perr != nil {
 		return ter.TefINTERNAL
 	}
+	if issuance.Issuer != vd.Account {
+		return ter.TecNO_PERMISSION
+	}
 	if issuance.OutstandingAmount != 0 {
 		return ter.TecHAS_OBLIGATIONS
 	}
@@ -128,22 +131,34 @@ func (v *VaultDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TefINTERNAL
 	}
 
+	asset := vaultAssetOf(vd)
+	assetDelta, res := removeDeleteAssetHolding(ctx, vd.Account, asset)
+	if res != ter.TesSUCCESS {
+		return res
+	}
+
 	pseudo, perr := tx.ReadAccountRoot(ctx.View, vd.Account)
 	if perr != nil || pseudo == nil {
 		return ter.TefBAD_LEDGER
 	}
-	asset := vaultAssetOf(vd)
-
-	// Remove the pseudo-account's asset holding.
-	assetDelta, res := removeVaultAssetHolding(ctx, vd.Account, asset)
-	if res != ter.TesSUCCESS {
-		return res
+	if assetDelta < 0 {
+		decrement := uint32(-assetDelta)
+		if pseudo.OwnerCount >= decrement {
+			pseudo.OwnerCount -= decrement
+		} else {
+			pseudo.OwnerCount = 0
+		}
+	} else {
+		pseudo.OwnerCount += uint32(assetDelta)
 	}
-	pseudo.OwnerCount = uint32(int32(pseudo.OwnerCount) + assetDelta)
 
-	// Remove the owner's (kept) share MPToken, if any.
-	if res := removeEmptyShareMPToken(ctx, ctx.AccountID, vd.ShareMPTID); res != ter.TesSUCCESS && res != ter.TecHAS_OBLIGATIONS {
-		return res
+	ownerShareKey := keylet.MPTokenByID(vd.ShareMPTID, ctx.AccountID)
+	if exists, e := ctx.View.Exists(ownerShareKey); e != nil {
+		return ter.TefINTERNAL
+	} else if exists {
+		if res := removeEmptyShareMPToken(ctx, ctx.AccountID, vd.ShareMPTID); res != ter.TesSUCCESS {
+			return res
+		}
 	}
 
 	// Destroy the share issuance.
@@ -162,12 +177,36 @@ func (v *VaultDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	if pseudo.OwnerCount > 0 {
 		pseudo.OwnerCount--
 	}
+	pseudoData, serr := state.SerializeAccountRoot(pseudo)
+	if serr != nil {
+		return ter.TefINTERNAL
+	}
+	if e := ctx.View.Update(keylet.Account(vd.Account), pseudoData); e != nil {
+		return ter.TefINTERNAL
+	}
 	if e := ctx.View.Erase(shareKey); e != nil {
 		return ter.TefINTERNAL
 	}
 
-	// The pseudo-account must now be empty; destroy it.
-	if pseudo.Balance != 0 || pseudo.OwnerCount != 0 {
+	if exists, e := ctx.View.Exists(keylet.OwnerDir(vd.Account)); e != nil {
+		return ter.TefINTERNAL
+	} else if exists {
+		return ter.TecHAS_OBLIGATIONS
+	}
+
+	pseudo, perr = tx.ReadAccountRoot(ctx.View, vd.Account)
+	if perr != nil || pseudo == nil || pseudo.VaultID != vaultKey.Key {
+		return ter.TefBAD_LEDGER
+	}
+	if pseudo.Balance != 0 {
+		return ter.TecHAS_OBLIGATIONS
+	}
+	if pseudo.OwnerCount != 0 {
+		return ter.TecHAS_OBLIGATIONS
+	}
+	if exists, e := ctx.View.Exists(keylet.OwnerDir(vd.Account)); e != nil {
+		return ter.TefINTERNAL
+	} else if exists {
 		return ter.TecHAS_OBLIGATIONS
 	}
 	if e := ctx.View.Erase(keylet.Account(vd.Account)); e != nil {
@@ -177,7 +216,11 @@ func (v *VaultDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Remove the vault from the owner's directory and erase it. The owner is
 	// credited back the vault + pseudo-account it was charged for at create
 	// (rippled adjustOwnerCount(owner, -2)).
-	if r, e := state.DirRemove(ctx.View, keylet.OwnerDir(ctx.AccountID), vd.OwnerNode, vaultKey.Key, false); e != nil || !r.Success {
+	if r, e := state.DirRemove(ctx.View, keylet.OwnerDir(vd.Owner), vd.OwnerNode, vaultKey.Key, false); e != nil || !r.Success {
+		return ter.TefBAD_LEDGER
+	}
+	owner, oerr := tx.ReadAccountRoot(ctx.View, vd.Owner)
+	if oerr != nil || owner == nil {
 		return ter.TefBAD_LEDGER
 	}
 	if ctx.Account.OwnerCount >= 2 {
@@ -190,4 +233,78 @@ func (v *VaultDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	}
 
 	return ter.TesSUCCESS
+}
+
+func removeDeleteAssetHolding(ctx *tx.ApplyContext, accountID [20]byte, asset tx.Asset) (int32, ter.Result) {
+	if !asset.IsMPT() {
+		if isNativeAsset(asset) {
+			account, err := tx.ReadAccountRoot(ctx.View, accountID)
+			if err != nil || account == nil {
+				return 0, ter.TecINTERNAL
+			}
+			if account.Balance != 0 {
+				return 0, ter.TecHAS_OBLIGATIONS
+			}
+			return 0, ter.TesSUCCESS
+		}
+
+		issuerID, err := state.DecodeAccountID(asset.Issuer)
+		if err != nil {
+			return 0, ter.TefINTERNAL
+		}
+		lineData, err := ctx.View.Read(keylet.Line(accountID, issuerID, asset.Currency))
+		if err != nil {
+			return 0, ter.TefINTERNAL
+		}
+		if lineData == nil {
+			if accountID == issuerID {
+				return 0, ter.TesSUCCESS
+			}
+			return 0, ter.TecOBJECT_NOT_FOUND
+		}
+		line, err := state.ParseRippleState(lineData)
+		if err != nil {
+			return 0, ter.TefINTERNAL
+		}
+		if accountID != issuerID && line.Balance.Signum() != 0 {
+			return 0, ter.TecHAS_OBLIGATIONS
+		}
+		if account, err := tx.ReadAccountRoot(ctx.View, accountID); err != nil || account == nil {
+			return 0, ter.TecINTERNAL
+		}
+		return removeVaultAssetHolding(ctx, accountID, asset)
+	}
+
+	mptID, ok := assetMPTID(asset)
+	if !ok {
+		return 0, ter.TefINTERNAL
+	}
+	tokenKey := keylet.MPTokenByID(mptID, accountID)
+	token, err := readMPToken(ctx.View, tokenKey)
+	if err != nil {
+		return 0, ter.TefINTERNAL
+	}
+	if token == nil {
+		if accountID == mptIDIssuer(mptID) {
+			return 0, ter.TesSUCCESS
+		}
+		return 0, ter.TecOBJECT_NOT_FOUND
+	}
+	if token.MPTAmount != 0 || (ctx.Rules().Enabled(amendment.FeatureFixCleanup3_1_3) &&
+		token.LockedAmount != nil && *token.LockedAmount != 0) {
+		return 0, ter.TecHAS_OBLIGATIONS
+	}
+	if account, err := tx.ReadAccountRoot(ctx.View, accountID); err != nil || account == nil {
+		return 0, ter.TecINTERNAL
+	}
+	if r, e := state.DirRemove(ctx.View, keylet.OwnerDir(accountID), token.OwnerNode, tokenKey.Key, false); e != nil || !r.Success {
+		return 0, ter.TecINTERNAL
+	}
+	if err := tx.AdjustOwnerCount(ctx.View, accountID, -1); err != nil {
+		return 0, ter.TefINTERNAL
+	}
+	if err := ctx.View.Erase(tokenKey); err != nil {
+		return 0, ter.TefINTERNAL
+	}
+	return 0, ter.TesSUCCESS
 }

--- a/internal/tx/vault/vault_delete_test.go
+++ b/internal/tx/vault/vault_delete_test.go
@@ -1,0 +1,285 @@
+package vault
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+)
+
+type vaultDeleteFixture struct {
+	view       *mptArmsView
+	ctx        *tx.ApplyContext
+	txn        *VaultDelete
+	vaultID    [32]byte
+	vaultKey   keylet.Keylet
+	ownerID    [20]byte
+	pseudoID   [20]byte
+	assetMPTID [24]byte
+	shareMPTID [24]byte
+}
+
+func newVaultDeleteFixture(t *testing.T) *vaultDeleteFixture {
+	t.Helper()
+
+	ownerID := deleteTestID(0x11)
+	pseudoID := deleteTestID(0x22)
+	assetIssuerID := deleteTestID(0x33)
+	assetMPTID := keylet.MakeMPTID(7, assetIssuerID)
+	shareMPTID := keylet.MakeMPTID(8, pseudoID)
+	var vaultID [32]byte
+	for i := range vaultID {
+		vaultID[i] = 0x44
+	}
+	vaultKey := keylet.VaultByID(vaultID)
+	view := newMPTArmsView()
+
+	vaultDir, err := state.DirInsert(view, keylet.OwnerDir(ownerID), vaultKey.Key, false, func(dir *state.DirectoryNode) {
+		dir.Owner = ownerID
+	})
+	if err != nil {
+		t.Fatalf("insert vault directory entry: %v", err)
+	}
+	assetTokenKey := keylet.MPTokenByID(assetMPTID, pseudoID)
+	assetDir, err := state.DirInsert(view, keylet.OwnerDir(pseudoID), assetTokenKey.Key, false, func(dir *state.DirectoryNode) {
+		dir.Owner = pseudoID
+	})
+	if err != nil {
+		t.Fatalf("insert asset holding directory entry: %v", err)
+	}
+	shareKey := keylet.MPTIssuance(shareMPTID)
+	shareDir, err := state.DirInsert(view, keylet.OwnerDir(pseudoID), shareKey.Key, false, func(dir *state.DirectoryNode) {
+		dir.Owner = pseudoID
+	})
+	if err != nil {
+		t.Fatalf("insert share issuance directory entry: %v", err)
+	}
+
+	ownerAddr := deleteTestAddress(t, ownerID)
+	pseudoAddr := deleteTestAddress(t, pseudoID)
+	owner := &state.AccountRoot{Account: ownerAddr, Balance: 1_000_000_000, Sequence: 1, OwnerCount: 2}
+	pseudo := &state.AccountRoot{
+		Account: pseudoAddr, Sequence: 0, OwnerCount: 2, VaultID: vaultID,
+	}
+	deleteTestPutAccount(t, view, ownerID, owner)
+	deleteTestPutAccount(t, view, pseudoID, pseudo)
+
+	assetToken := &state.MPTokenData{
+		Account: pseudoID, MPTokenIssuanceID: assetMPTID, OwnerNode: assetDir.Page,
+	}
+	assetTokenData, err := state.SerializeMPToken(assetToken)
+	if err != nil {
+		t.Fatalf("serialize asset MPToken: %v", err)
+	}
+	view.data[assetTokenKey.Key] = assetTokenData
+
+	shareIssuance := &state.MPTokenIssuanceData{
+		Issuer: pseudoID, Sequence: 8, OwnerNode: shareDir.Page,
+	}
+	shareData, err := state.SerializeMPTokenIssuance(shareIssuance)
+	if err != nil {
+		t.Fatalf("serialize share issuance: %v", err)
+	}
+	view.data[shareKey.Key] = shareData
+
+	vaultData, err := serializeVault(&vaultData{
+		Owner:            ownerID,
+		Account:          pseudoID,
+		Sequence:         1,
+		OwnerNode:        vaultDir.Page,
+		ShareMPTID:       shareMPTID,
+		AssetIsMPT:       true,
+		AssetMPTID:       assetMPTID,
+		WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+	})
+	if err != nil {
+		t.Fatalf("serialize vault: %v", err)
+	}
+	view.data[vaultKey.Key] = vaultData
+
+	ctx := &tx.ApplyContext{
+		View:      view,
+		Account:   owner,
+		AccountID: ownerID,
+		Config:    tx.EngineConfig{Rules: rulesWithFix(true)},
+		Metadata:  &tx.Metadata{},
+		Log:       xrpllog.Discard(),
+		Ctx:       context.Background(),
+	}
+
+	return &vaultDeleteFixture{
+		view:       view,
+		ctx:        ctx,
+		txn:        NewVaultDelete(ownerAddr, hex.EncodeToString(vaultID[:])),
+		vaultID:    vaultID,
+		vaultKey:   vaultKey,
+		ownerID:    ownerID,
+		pseudoID:   pseudoID,
+		assetMPTID: assetMPTID,
+		shareMPTID: shareMPTID,
+	}
+}
+
+func (f *vaultDeleteFixture) addOwnerShare(t *testing.T, locked uint64) {
+	t.Helper()
+	tokenKey := keylet.MPTokenByID(f.shareMPTID, f.ownerID)
+	dir, err := state.DirInsert(f.view, keylet.OwnerDir(f.ownerID), tokenKey.Key, false, func(node *state.DirectoryNode) {
+		node.Owner = f.ownerID
+	})
+	if err != nil {
+		t.Fatalf("insert owner share directory entry: %v", err)
+	}
+	token := &state.MPTokenData{
+		Account: f.ownerID, MPTokenIssuanceID: f.shareMPTID, OwnerNode: dir.Page,
+	}
+	if locked != 0 {
+		token.LockedAmount = &locked
+	}
+	data, err := state.SerializeMPToken(token)
+	if err != nil {
+		t.Fatalf("serialize owner share token: %v", err)
+	}
+	f.view.data[tokenKey.Key] = data
+	f.ctx.Account.OwnerCount++
+	deleteTestPutAccount(t, f.view, f.ownerID, f.ctx.Account)
+}
+
+func (f *vaultDeleteFixture) setPseudo(t *testing.T, mutate func(*state.AccountRoot)) {
+	t.Helper()
+	pseudo, err := tx.ReadAccountRoot(f.view, f.pseudoID)
+	if err != nil || pseudo == nil {
+		t.Fatalf("read pseudo account: %v", err)
+	}
+	mutate(pseudo)
+	deleteTestPutAccount(t, f.view, f.pseudoID, pseudo)
+}
+
+func TestVaultDeleteMPTBackedVault(t *testing.T) {
+	f := newVaultDeleteFixture(t)
+	if got := f.txn.Apply(f.ctx); got != ter.TesSUCCESS {
+		t.Fatalf("Apply() = %v, want tesSUCCESS", got)
+	}
+	for name, k := range map[string]keylet.Keylet{
+		"vault":                f.vaultKey,
+		"asset holding":        keylet.MPTokenByID(f.assetMPTID, f.pseudoID),
+		"share issuance":       keylet.MPTIssuance(f.shareMPTID),
+		"pseudo account":       keylet.Account(f.pseudoID),
+		"pseudo owner dir":     keylet.OwnerDir(f.pseudoID),
+		"vault owner dir root": keylet.OwnerDir(f.ownerID),
+	} {
+		if _, ok := f.view.data[k.Key]; ok {
+			t.Errorf("%s was not erased", name)
+		}
+	}
+	if f.ctx.Account.OwnerCount != 0 {
+		t.Fatalf("owner count = %d, want 0", f.ctx.Account.OwnerCount)
+	}
+}
+
+func TestVaultDeletePropagatesLockedOwnerShareObligation(t *testing.T) {
+	f := newVaultDeleteFixture(t)
+	f.addOwnerShare(t, 5)
+	if got := f.txn.Apply(f.ctx); got != ter.TecHAS_OBLIGATIONS {
+		t.Fatalf("Apply() = %v, want tecHAS_OBLIGATIONS", got)
+	}
+	if _, ok := f.view.data[keylet.MPTokenByID(f.shareMPTID, f.ownerID).Key]; !ok {
+		t.Fatal("locked owner share MPToken was erased")
+	}
+}
+
+func TestVaultDeleteCorruptOwnerShareDirectoryClaimsFee(t *testing.T) {
+	f := newVaultDeleteFixture(t)
+	f.addOwnerShare(t, 0)
+	tokenKey := keylet.MPTokenByID(f.shareMPTID, f.ownerID)
+	token, err := readMPToken(f.view, tokenKey)
+	if err != nil || token == nil {
+		t.Fatalf("read owner share token: %v", err)
+	}
+	token.OwnerNode++
+	data, err := state.SerializeMPToken(token)
+	if err != nil {
+		t.Fatalf("serialize owner share token: %v", err)
+	}
+	f.view.data[tokenKey.Key] = data
+
+	if got := f.txn.Apply(f.ctx); got != ter.TecINTERNAL {
+		t.Fatalf("Apply() = %v, want tecINTERNAL", got)
+	}
+}
+
+func TestVaultDeleteShareIssuerPrecedesOutstandingAmount(t *testing.T) {
+	f := newVaultDeleteFixture(t)
+	wrongIssuer := deleteTestID(0x77)
+	data, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+		Issuer: wrongIssuer, Sequence: 8, OutstandingAmount: 9,
+	})
+	if err != nil {
+		t.Fatalf("serialize malformed share issuance: %v", err)
+	}
+	f.view.data[keylet.MPTIssuance(f.shareMPTID).Key] = data
+	if got := f.txn.Preclaim(f.view, f.ctx.Config); got != ter.TecNO_PERMISSION {
+		t.Fatalf("Preclaim() = %v, want tecNO_PERMISSION", got)
+	}
+}
+
+func TestVaultDeletePseudoIntegrityPrecedence(t *testing.T) {
+	t.Run("vault id before balance", func(t *testing.T) {
+		f := newVaultDeleteFixture(t)
+		f.setPseudo(t, func(pseudo *state.AccountRoot) {
+			pseudo.VaultID[0] ^= 0xff
+			pseudo.Balance = 1
+		})
+		if got := f.txn.Apply(f.ctx); got != ter.TefBAD_LEDGER {
+			t.Fatalf("Apply() = %v, want tefBAD_LEDGER", got)
+		}
+	})
+
+	t.Run("owner directory before vault id", func(t *testing.T) {
+		f := newVaultDeleteFixture(t)
+		var extra [32]byte
+		extra[0] = 0x99
+		if _, err := state.DirInsert(f.view, keylet.OwnerDir(f.pseudoID), extra, false, func(node *state.DirectoryNode) {
+			node.Owner = f.pseudoID
+		}); err != nil {
+			t.Fatalf("insert extra pseudo obligation: %v", err)
+		}
+		f.setPseudo(t, func(pseudo *state.AccountRoot) {
+			pseudo.OwnerCount++
+			pseudo.VaultID[0] ^= 0xff
+		})
+		if got := f.txn.Apply(f.ctx); got != ter.TecHAS_OBLIGATIONS {
+			t.Fatalf("Apply() = %v, want tecHAS_OBLIGATIONS", got)
+		}
+	})
+}
+
+func deleteTestID(b byte) [20]byte {
+	var id [20]byte
+	for i := range id {
+		id[i] = b
+	}
+	return id
+}
+
+func deleteTestAddress(t *testing.T, id [20]byte) string {
+	t.Helper()
+	address, err := state.EncodeAccountID(id)
+	if err != nil {
+		t.Fatalf("encode account: %v", err)
+	}
+	return address
+}
+
+func deleteTestPutAccount(t *testing.T, view *mptArmsView, id [20]byte, account *state.AccountRoot) {
+	t.Helper()
+	data, err := state.SerializeAccountRoot(account)
+	if err != nil {
+		t.Fatalf("serialize account: %v", err)
+	}
+	view.data[keylet.Account(id).Key] = data
+}

--- a/internal/tx/vault/vault_deposit.go
+++ b/internal/tx/vault/vault_deposit.go
@@ -6,6 +6,8 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/credential"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
@@ -107,6 +109,13 @@ func (v *VaultDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.
 	if !assetMatches(v.Amount, vd) {
 		return ter.TecWRONG_ASSET
 	}
+	asset := vaultAssetOf(vd)
+	if result := mptutil.CanTransferAsset(view, asset, accountID, vd.Account, false); result != ter.TesSUCCESS {
+		return result
+	}
+	if vd.AssetIsMPT && vd.AssetMPTID == vd.ShareMPTID {
+		return ter.TefINTERNAL
+	}
 
 	shareData, rerr := view.Read(keylet.MPTIssuance(vd.ShareMPTID))
 	if rerr != nil || shareData == nil {
@@ -120,8 +129,11 @@ func (v *VaultDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.
 		return ter.TefINTERNAL
 	}
 
-	asset := vaultAssetOf(vd)
-	if res := tx.AssetFrozen(view, accountID, asset); res != ter.TesSUCCESS {
+	if res := checkFrozen(view, asset, accountID); res != ter.TesSUCCESS {
+		return res
+	}
+	shareAsset := tx.Asset{MPTIssuanceID: hex.EncodeToString(vd.ShareMPTID[:])}
+	if res := checkFrozen(view, shareAsset, accountID); res != ter.TesSUCCESS {
 		return res
 	}
 
@@ -130,28 +142,36 @@ func (v *VaultDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.
 		if issuance.DomainID == nil {
 			return ter.TecNO_AUTH
 		}
-		// Domain credential validation is enforced in Apply via the MPToken
-		// authorization path; a missing domain is rejected above.
+		if result := mptutil.ValidDomain(view, *issuance.DomainID, accountID, config.ParentCloseTime); result != ter.TesSUCCESS && result != ter.TecEXPIRED {
+			return result
+		}
 	}
 
-	// The depositor must be authorized to hold the asset (MPT assets only).
-	if res := tx.RequireAuth(view, asset, accountID); res != ter.TesSUCCESS {
+	if res := mptutil.RequireAssetAuthAt(view, asset, accountID, mptutil.LegacyAuth, config.ParentCloseTime); res != ter.TesSUCCESS {
 		return res
 	}
 
 	// The depositor must hold at least the deposited amount.
+	issuerID := [20]byte{}
+	if !asset.IsNative() && !asset.IsMPT() {
+		issuerID, err = state.DecodeAccountID(asset.Issuer)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+	}
+	rules := config.RequireRules()
 	holds, herr := spendableAsset(view, config, accountID, asset)
 	if herr != nil {
 		return ter.TefINTERNAL
 	}
-	assetsN, aerr := amountToNumber(v.Amount)
+	assetsN, aerr := amountToNumberForRules(v.Amount, rules)
 	if aerr != nil {
 		return ter.TefINTERNAL
 	}
 	integral := asset.IsNative() || asset.IsMPT()
-	fix320 := config.RequireRules().FixCleanup3_2_0Enabled()
+	fix320 := rules.FixCleanup3_2_0Enabled()
 	if fix320 {
-		assetsTotalN, _ := vaultNumber(vd.AssetsTotal)
+		assetsTotalN, _ := vaultNumberForRules(vd.AssetsTotal, rules)
 		assetsN = roundToVaultScale(assetsN, assetsTotalN, integral)
 		if assetsN.IsZero() {
 			return ter.TecPRECISION_LOSS
@@ -163,8 +183,8 @@ func (v *VaultDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.
 	// IOU only: reject a deposit that canonicalizes to a no-op at the depositor's
 	// own trust-line scale. Issuer-as-depositor uses an unbounded balance, skip.
 	if fix320 && !integral {
-		if issuerID, ierr := state.DecodeAccountID(asset.Issuer); ierr == nil && accountID != issuerID {
-			origN, _ := amountToNumber(v.Amount)
+		if accountID != issuerID {
+			origN, _ := amountToNumberForRules(v.Amount, rules)
 			balScale := holds.AssetExponent(false, state.RoundToNearest)
 			if origN.RoundToAssetScale(false, balScale, state.RoundToNearest).IsZero() {
 				return ter.TecPRECISION_LOSS
@@ -173,6 +193,124 @@ func (v *VaultDeposit) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.
 	}
 
 	return ter.TesSUCCESS
+}
+
+func vaultDepositDomainCredentialIDs(view tx.LedgerView, domainIDHex string, account [20]byte) ([]string, ter.Result) {
+	domainBytes, err := hex.DecodeString(domainIDHex)
+	if err != nil || len(domainBytes) != 32 {
+		return nil, ter.TefINTERNAL
+	}
+	var domainID [32]byte
+	copy(domainID[:], domainBytes)
+	raw, err := view.Read(keylet.PermissionedDomainByID(domainID))
+	if err != nil {
+		return nil, ter.TefINTERNAL
+	}
+	if raw == nil {
+		return nil, ter.TecOBJECT_NOT_FOUND
+	}
+	domain, err := state.ParsePermissionedDomain(raw)
+	if err != nil {
+		return nil, ter.TefINTERNAL
+	}
+	ids := make([]string, 0, len(domain.AcceptedCredentials))
+	for _, accepted := range domain.AcceptedCredentials {
+		key := keylet.Credential(account, accepted.Issuer, accepted.CredentialType)
+		exists, err := view.Exists(key)
+		if err != nil {
+			return nil, ter.TefINTERNAL
+		}
+		if exists {
+			ids = append(ids, hex.EncodeToString(key.Key[:]))
+		}
+	}
+	return ids, ter.TesSUCCESS
+}
+
+func vaultDepositVerifyDomain(ctx *tx.ApplyContext, domainIDHex string, account [20]byte) ter.Result {
+	ids, result := vaultDepositDomainCredentialIDs(ctx.View, domainIDHex, account)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	foundExpired, result := credential.RemoveExpiredCredentials(ctx, ids)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if foundExpired && account == ctx.AccountID {
+		accountRoot, err := tx.ReadAccountRoot(ctx.View, account)
+		if err != nil || accountRoot == nil {
+			return ter.TefINTERNAL
+		}
+		*ctx.Account = *accountRoot
+	}
+	for _, idHex := range ids {
+		idBytes, _ := hex.DecodeString(idHex)
+		var id [32]byte
+		copy(id[:], idBytes)
+		raw, err := ctx.View.Read(keylet.CredentialByID(id))
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		if raw == nil {
+			continue
+		}
+		cred, err := credential.ParseCredentialEntry(raw)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		if cred.IsAccepted() {
+			return ter.TesSUCCESS
+		}
+	}
+	if foundExpired {
+		return ter.TecEXPIRED
+	}
+	return ter.TecNO_PERMISSION
+}
+
+func vaultDepositEnforceShareAuthorization(ctx *tx.ApplyContext, issuance *state.MPTokenIssuanceData, shareMPTID [24]byte) ter.Result {
+	if issuance.DomainID == nil {
+		return ter.TecNO_AUTH
+	}
+	token, err := readMPToken(ctx.View, keylet.MPTokenByID(shareMPTID, ctx.AccountID))
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	result := vaultDepositVerifyDomain(ctx, *issuance.DomainID, ctx.AccountID)
+	if result != ter.TesSUCCESS {
+		if result == ter.TecEXPIRED {
+			return result
+		}
+		return ter.TecNO_AUTH
+	}
+	if token != nil {
+		return ter.TesSUCCESS
+	}
+	return ensureHolderMPToken(ctx, ctx.AccountID, shareMPTID)
+}
+
+func vaultDepositExchange(assetsTotal, shareTotal, assets state.XRPLNumber, scale uint8, integral bool) (
+	sharesCreated state.XRPLNumber,
+	assetsDeposited state.XRPLNumber,
+	shares uint64,
+	result ter.Result,
+) {
+	result = ter.TesSUCCESS
+	defer func() {
+		if recover() != nil {
+			result = ter.TecPATH_DRY
+		}
+	}()
+	sharesCreated = assetsToSharesDeposit(assetsTotal, shareTotal, assets, scale)
+	if sharesCreated.IsZero() {
+		return sharesCreated, assetsDeposited, 0, ter.TecPRECISION_LOSS
+	}
+	assetsDeposited = sharesToAssetsDeposit(assetsTotal, shareTotal, sharesCreated, scale, integral)
+	if assetsDeposited.Cmp(assets) > 0 {
+		return sharesCreated, assetsDeposited, 0, ter.TefINTERNAL
+	}
+	shares = uint64(sharesCreated.ToInt64WithMode(state.RoundTowardsZero))
+	return sharesCreated, assetsDeposited, shares, ter.TesSUCCESS
 }
 
 // Apply mints shares to the depositor in exchange for the deposited asset.
@@ -197,9 +335,12 @@ func (v *VaultDeposit) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TefINTERNAL
 	}
 
-	// Ensure the depositor holds a share MPToken.
 	private := vd.Flags&VaultFlagPrivate != 0
-	if res := ensureHolderMPToken(ctx, ctx.AccountID, vd.ShareMPTID); res != ter.TesSUCCESS {
+	if private && ctx.AccountID != vd.Owner {
+		if res := vaultDepositEnforceShareAuthorization(ctx, issuance, vd.ShareMPTID); res != ter.TesSUCCESS {
+			return res
+		}
+	} else if res := ensureHolderMPToken(ctx, ctx.AccountID, vd.ShareMPTID); res != ter.TesSUCCESS {
 		return res
 	}
 	if private && ctx.AccountID == vd.Owner {
@@ -209,43 +350,55 @@ func (v *VaultDeposit) Apply(ctx *tx.ApplyContext) ter.Result {
 	}
 
 	// Compute the share/asset exchange.
-	assetsN, aerr := amountToNumber(v.Amount)
+	rules := ctx.Rules()
+	assetsN, aerr := amountToNumberForRules(v.Amount, rules)
 	if aerr != nil {
 		return ter.TefINTERNAL
 	}
-	assetsTotalN, _ := vaultNumber(vd.AssetsTotal)
-	if ctx.Rules().FixCleanup3_2_0Enabled() {
+	assetsTotalN, _ := vaultNumberForRules(vd.AssetsTotal, rules)
+	if rules.FixCleanup3_2_0Enabled() {
 		asset := vaultAssetOf(vd)
 		assetsN = roundToVaultScale(assetsN, assetsTotalN, asset.IsNative() || asset.IsMPT())
 		if assetsN.IsZero() {
 			return ter.TefINTERNAL
 		}
 	}
-	shareTotalN := state.NewXRPLNumber(int64(issuance.OutstandingAmount), 0)
-	sharesN := assetsToSharesDeposit(assetsTotalN, shareTotalN, assetsN, vd.Scale)
-	if sharesN.IsZero() {
-		return ter.TecPRECISION_LOSS
-	}
-	assetsDepositedN := sharesToAssetsDeposit(assetsTotalN, shareTotalN, sharesN, vd.Scale)
-	if assetsDepositedN.Cmp(assetsN) > 0 {
-		return ter.TefINTERNAL
+	shareTotalN := state.NewXRPLNumberScaled(
+		int64(issuance.OutstandingAmount),
+		0,
+		vaultNumberScale(rules),
+		state.RoundToNearest,
+	)
+	asset := vaultAssetOf(vd)
+	_, assetsDepositedN, shares, result := vaultDepositExchange(
+		assetsTotalN,
+		shareTotalN,
+		assetsN,
+		vd.Scale,
+		asset.IsNative() || asset.IsMPT(),
+	)
+	if result != ter.TesSUCCESS {
+		return result
 	}
 
 	// Update the vault totals.
 	newTotal := assetsTotalN.Add(assetsDepositedN)
-	availN, _ := vaultNumber(vd.AssetsAvailable)
+	availN, _ := vaultNumberForRules(vd.AssetsAvailable, rules)
 	vd.AssetsTotal = numberToString(newTotal)
 	vd.AssetsAvailable = numberToString(availN.Add(assetsDepositedN))
 
 	// Enforce the maximum after the increment.
 	if vd.AssetsMaximum != "" {
-		maxN, _ := vaultNumber(vd.AssetsMaximum)
+		maxN, _ := vaultNumberForRules(vd.AssetsMaximum, rules)
 		if maxN.Signum() != 0 && newTotal.Cmp(maxN) > 0 {
 			return ter.TecLIMIT_EXCEEDED
 		}
 	}
 
-	newVault, serr := serializeVault(vd)
+	if err := associateVaultAsset(vd, rules); err != nil {
+		return ter.TefINTERNAL
+	}
+	newVault, serr := serializeVaultForRules(vd, rules)
 	if serr != nil {
 		return ter.TefINTERNAL
 	}
@@ -257,12 +410,41 @@ func (v *VaultDeposit) Apply(ctx *tx.ApplyContext) ter.Result {
 	if res := sendAssetToVault(ctx, vd.Account, v.Amount, assetsDepositedN); res != ter.TesSUCCESS {
 		return res
 	}
+	if !rules.FixCleanup3_2_0Enabled() {
+		holding, err := actualAssetHolding(ctx.View, ctx.AccountID, asset, rules)
+		if err != nil || holding.Signum() < 0 {
+			return ter.TefINTERNAL
+		}
+	}
 
 	// Mint the shares to the depositor.
-	shares := uint64(sharesN.ToInt64WithMode(state.RoundTowardsZero))
 	if res := mintShares(ctx, vd.ShareMPTID, ctx.AccountID, shares); res != ter.TesSUCCESS {
 		return res
 	}
 
 	return ter.TesSUCCESS
+}
+
+func (v *VaultDeposit) ApplyOnTec(ctx *tx.ApplyContext) {
+	vaultID, ok := v.vaultIDBytes()
+	if !ok {
+		return
+	}
+	vd, err := readVault(ctx.View, keylet.VaultByID(vaultID))
+	if err != nil || vd == nil || vd.Flags&VaultFlagPrivate == 0 || ctx.AccountID == vd.Owner {
+		return
+	}
+	raw, err := ctx.View.Read(keylet.MPTIssuance(vd.ShareMPTID))
+	if err != nil || raw == nil {
+		return
+	}
+	issuance, err := state.ParseMPTokenIssuance(raw)
+	if err != nil || issuance.DomainID == nil {
+		return
+	}
+	ids, result := vaultDepositDomainCredentialIDs(ctx.View, *issuance.DomainID, ctx.AccountID)
+	if result != ter.TesSUCCESS {
+		return
+	}
+	credential.RemoveExpiredCredentialsOnTec(ctx, ids)
 }

--- a/internal/tx/vault/vault_deposit_audit_test.go
+++ b/internal/tx/vault/vault_deposit_audit_test.go
@@ -1,0 +1,318 @@
+package vault
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+)
+
+type vaultDepositView struct {
+	data  map[[32]byte][]byte
+	rules *amendment.Rules
+}
+
+func newVaultDepositView() *vaultDepositView {
+	return &vaultDepositView{
+		data: make(map[[32]byte][]byte),
+		rules: amendment.NewRulesBuilder().
+			FromPreset(amendment.PresetAllSupported).
+			Build(),
+	}
+}
+
+func (v *vaultDepositView) Read(k keylet.Keylet) ([]byte, error) { return v.data[k.Key], nil }
+func (v *vaultDepositView) Exists(k keylet.Keylet) (bool, error) {
+	_, ok := v.data[k.Key]
+	return ok, nil
+}
+func (v *vaultDepositView) Insert(k keylet.Keylet, data []byte) error {
+	v.data[k.Key] = data
+	return nil
+}
+func (v *vaultDepositView) Update(k keylet.Keylet, data []byte) error {
+	v.data[k.Key] = data
+	return nil
+}
+func (v *vaultDepositView) Erase(k keylet.Keylet) error {
+	delete(v.data, k.Key)
+	return nil
+}
+func (v *vaultDepositView) AdjustDropsDestroyed(drops.XRPAmount) {}
+func (v *vaultDepositView) ForEach(fn func(key [32]byte, data []byte) bool) error {
+	for key, data := range v.data {
+		if !fn(key, data) {
+			break
+		}
+	}
+	return nil
+}
+func (v *vaultDepositView) Succ([32]byte) ([32]byte, []byte, bool, error) {
+	return [32]byte{}, nil, false, nil
+}
+func (v *vaultDepositView) TxExists([32]byte) bool  { return false }
+func (v *vaultDepositView) Rules() *amendment.Rules { return v.rules }
+func (v *vaultDepositView) LedgerSeq() uint32       { return 1 }
+func vaultDepositTestID(fill byte, size int) []byte { return makeFilledBytes(fill, size) }
+func makeFilledBytes(fill byte, size int) []byte {
+	b := make([]byte, size)
+	for i := range b {
+		b[i] = fill
+	}
+	return b
+}
+
+func vaultDepositPut(t *testing.T, view *vaultDepositView, key keylet.Keylet, data []byte) {
+	t.Helper()
+	view.data[key.Key] = data
+}
+
+func vaultDepositEncoded(t *testing.T, data []byte, err error) []byte {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func vaultDepositAccount(t *testing.T, view *vaultDepositView, id [20]byte, flags uint32) string {
+	t.Helper()
+	address, err := state.EncodeAccountID(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account: address,
+		Balance: 1_000_000_000,
+		Flags:   flags,
+	})
+	vaultDepositPut(t, view, keylet.Account(id), vaultDepositEncoded(t, data, err))
+	return address
+}
+
+func vaultDepositFixture(t *testing.T, issuanceFlags uint32, withShareIssuance bool) (*vaultDepositView, *VaultDeposit, [24]byte, [20]byte) {
+	t.Helper()
+	view := newVaultDepositView()
+	var issuer, depositor, owner, pseudo [20]byte
+	copy(issuer[:], vaultDepositTestID(0x11, 20))
+	copy(depositor[:], vaultDepositTestID(0x22, 20))
+	copy(owner[:], vaultDepositTestID(0x33, 20))
+	copy(pseudo[:], vaultDepositTestID(0x44, 20))
+	issuerAddress := vaultDepositAccount(t, view, issuer, 0)
+	depositorAddress := vaultDepositAccount(t, view, depositor, 0)
+	mptID := keylet.MakeMPTID(7, issuer)
+	shareID := keylet.MakeMPTID(1, pseudo)
+	issuanceData, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+		Issuer:            issuer,
+		Sequence:          7,
+		Flags:             issuanceFlags,
+		OutstandingAmount: 1_000,
+	})
+	vaultDepositPut(t, view, keylet.MPTIssuance(mptID), vaultDepositEncoded(t, issuanceData, err))
+	if withShareIssuance {
+		shareData, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+			Issuer:   pseudo,
+			Sequence: 1,
+		})
+		vaultDepositPut(t, view, keylet.MPTIssuance(shareID), vaultDepositEncoded(t, shareData, err))
+	}
+	var vaultID [32]byte
+	copy(vaultID[:], vaultDepositTestID(0x55, 32))
+	vaultData, err := serializeVault(&vaultData{
+		Owner:            owner,
+		Account:          pseudo,
+		AssetIsMPT:       true,
+		AssetMPTID:       mptID,
+		ShareMPTID:       shareID,
+		AssetsTotal:      "1000",
+		AssetsAvailable:  "1000",
+		WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+	})
+	vaultDepositPut(t, view, keylet.VaultByID(vaultID), vaultDepositEncoded(t, vaultData, err))
+	deposit := NewVaultDeposit(
+		depositorAddress,
+		hex.EncodeToString(vaultID[:]),
+		state.NewMPTAmountWithIssuanceID(100, issuerAddress, hex.EncodeToString(mptID[:])),
+	)
+	return view, deposit, mptID, depositor
+}
+
+func TestVaultDepositPreclaim_CanTransferPrecedesShareLookup(t *testing.T) {
+	view, deposit, _, _ := vaultDepositFixture(t, entry.LsfMPTRequireAuth, false)
+	config := tx.EngineConfig{Rules: view.rules}
+	if result := deposit.Preclaim(view, config); result != ter.TecNO_AUTH {
+		t.Fatalf("non-transferable MPT: got %v, want tecNO_AUTH", result)
+	}
+
+	view, deposit, _, _ = vaultDepositFixture(t, entry.LsfMPTCanTransfer|entry.LsfMPTRequireAuth, false)
+	if result := deposit.Preclaim(view, config); result != ter.TefINTERNAL {
+		t.Fatalf("transferable MPT with missing share issuance: got %v, want tefINTERNAL", result)
+	}
+}
+
+func TestVaultDepositPreclaim_DispatchesMPTRequireAuth(t *testing.T) {
+	view, deposit, mptID, depositor := vaultDepositFixture(
+		t,
+		entry.LsfMPTCanTransfer|entry.LsfMPTRequireAuth,
+		true,
+	)
+	putToken := func(flags uint32) {
+		t.Helper()
+		data, err := state.SerializeMPToken(&state.MPTokenData{
+			Account:           depositor,
+			MPTokenIssuanceID: mptID,
+			MPTAmount:         1_000,
+			Flags:             flags,
+		})
+		vaultDepositPut(t, view, keylet.MPTokenByID(mptID, depositor), vaultDepositEncoded(t, data, err))
+	}
+	putToken(0)
+	config := tx.EngineConfig{Rules: view.rules}
+	if result := deposit.Preclaim(view, config); result != ter.TecNO_AUTH {
+		t.Fatalf("unauthorized MPT holding: got %v, want tecNO_AUTH", result)
+	}
+	putToken(entry.LsfMPTAuthorized)
+	if result := deposit.Preclaim(view, config); result != ter.TesSUCCESS {
+		t.Fatalf("authorized MPT holding: got %v, want tesSUCCESS", result)
+	}
+}
+
+func TestVaultDepositPreclaim_IOUUsesFullBalance(t *testing.T) {
+	view := newVaultDepositView()
+	var issuer, depositor, owner, pseudo [20]byte
+	copy(issuer[:], vaultDepositTestID(0x11, 20))
+	copy(depositor[:], vaultDepositTestID(0x22, 20))
+	copy(owner[:], vaultDepositTestID(0x33, 20))
+	copy(pseudo[:], vaultDepositTestID(0x44, 20))
+	issuerAddress := vaultDepositAccount(t, view, issuer, state.LsfDefaultRipple)
+	depositorAddress := vaultDepositAccount(t, view, depositor, 0)
+	pseudoAddress := vaultDepositAccount(t, view, pseudo, 0)
+
+	line := func(account [20]byte, accountAddress string, balance, oppositeLimit int64) []byte {
+		data, err := state.SerializeRippleState(&state.RippleState{
+			Balance:   state.NewIssuedAmountFromValue(balance, 0, "USD", issuerAddress),
+			LowLimit:  state.NewIssuedAmountFromValue(oppositeLimit, 0, "USD", issuerAddress),
+			HighLimit: state.NewIssuedAmountFromValue(1_000, 0, "USD", accountAddress),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return data
+	}
+	view.data[keylet.Line(depositor, issuer, "USD").Key] = line(depositor, depositorAddress, -100, 1_000)
+	view.data[keylet.Line(pseudo, issuer, "USD").Key] = line(pseudo, pseudoAddress, 0, 0)
+
+	shareID := keylet.MakeMPTID(1, pseudo)
+	shareData, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+		Issuer: pseudo,
+	})
+	vaultDepositPut(t, view, keylet.MPTIssuance(shareID), vaultDepositEncoded(t, shareData, err))
+	var vaultID [32]byte
+	copy(vaultID[:], vaultDepositTestID(0x66, 32))
+	vaultData, err := serializeVault(&vaultData{
+		Owner:            owner,
+		Account:          pseudo,
+		Asset:            tx.Asset{Currency: "USD", Issuer: issuerAddress},
+		ShareMPTID:       shareID,
+		WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+	})
+	vaultDepositPut(t, view, keylet.VaultByID(vaultID), vaultDepositEncoded(t, vaultData, err))
+	deposit := NewVaultDeposit(
+		depositorAddress,
+		hex.EncodeToString(vaultID[:]),
+		state.NewIssuedAmountFromValue(500, 0, "USD", issuerAddress),
+	)
+	config := tx.EngineConfig{Rules: view.rules}
+	if result := deposit.Preclaim(view, config); result != ter.TesSUCCESS {
+		t.Fatalf("raw 100 + opposite limit 1000: got %v, want tesSUCCESS", result)
+	}
+
+	view.data[keylet.Line(depositor, issuer, "USD").Key] = line(depositor, depositorAddress, -100, 0)
+	if result := deposit.Preclaim(view, config); result != ter.TecINSUFFICIENT_FUNDS {
+		t.Fatalf("raw balance 100 without opposite limit: got %v, want tecINSUFFICIENT_FUNDS", result)
+	}
+}
+
+func TestVaultDepositPreFixRejectsNegativeDepositorBalance(t *testing.T) {
+	view := newVaultDepositView()
+	view.rules = amendment.NewRulesBuilder().
+		FromPreset(amendment.PresetAllSupported).
+		Disable(amendment.FeatureFixCleanup3_2_0).
+		Build()
+	var issuer, depositor, owner, pseudo [20]byte
+	copy(issuer[:], vaultDepositTestID(0x11, 20))
+	copy(depositor[:], vaultDepositTestID(0x22, 20))
+	copy(owner[:], vaultDepositTestID(0x33, 20))
+	copy(pseudo[:], vaultDepositTestID(0x44, 20))
+	issuerAddress := vaultDepositAccount(t, view, issuer, state.LsfDefaultRipple)
+	depositorAddress := vaultDepositAccount(t, view, depositor, 0)
+	pseudoAddress := vaultDepositAccount(t, view, pseudo, 0)
+
+	line := func(accountAddress string, balance, oppositeLimit int64) []byte {
+		data, err := state.SerializeRippleState(&state.RippleState{
+			Balance:   state.NewIssuedAmountFromValue(balance, 0, "USD", issuerAddress),
+			LowLimit:  state.NewIssuedAmountFromValue(oppositeLimit, 0, "USD", issuerAddress),
+			HighLimit: state.NewIssuedAmountFromValue(1_000, 0, "USD", accountAddress),
+		})
+		return vaultDepositEncoded(t, data, err)
+	}
+	view.data[keylet.Line(depositor, issuer, "USD").Key] = line(depositorAddress, -100, 1_000)
+	view.data[keylet.Line(pseudo, issuer, "USD").Key] = line(pseudoAddress, 0, 0)
+
+	shareID := keylet.MakeMPTID(1, pseudo)
+	shareData, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{Issuer: pseudo, Sequence: 1})
+	vaultDepositPut(t, view, keylet.MPTIssuance(shareID), vaultDepositEncoded(t, shareData, err))
+	tokenData, err := state.SerializeMPToken(&state.MPTokenData{Account: depositor, MPTokenIssuanceID: shareID})
+	vaultDepositPut(t, view, keylet.MPTokenByID(shareID, depositor), vaultDepositEncoded(t, tokenData, err))
+
+	var vaultID [32]byte
+	copy(vaultID[:], vaultDepositTestID(0x77, 32))
+	vaultData, err := serializeVaultForRules(&vaultData{
+		Owner:            owner,
+		Account:          pseudo,
+		Asset:            tx.Asset{Currency: "USD", Issuer: issuerAddress},
+		ShareMPTID:       shareID,
+		WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+	}, view.rules)
+	vaultDepositPut(t, view, keylet.VaultByID(vaultID), vaultDepositEncoded(t, vaultData, err))
+
+	account := &state.AccountRoot{Account: depositorAddress, Balance: 1_000_000_000}
+	ctx := &tx.ApplyContext{
+		View:      view,
+		Account:   account,
+		AccountID: depositor,
+		Config:    tx.EngineConfig{Rules: view.rules},
+		Metadata:  &tx.Metadata{},
+		Log:       xrpllog.Discard(),
+		Ctx:       context.Background(),
+	}
+	deposit := NewVaultDeposit(
+		depositorAddress,
+		hex.EncodeToString(vaultID[:]),
+		state.NewIssuedAmountFromValue(500, 0, "USD", issuerAddress),
+	)
+	if got := deposit.Apply(ctx); got != ter.TefINTERNAL {
+		t.Fatalf("Apply() = %v, want tefINTERNAL", got)
+	}
+}
+
+func TestVaultDepositExchange_OverflowReturnsPathDry(t *testing.T) {
+	zero := state.NewXRPLNumber(0, 0)
+	assets := state.NewXRPLNumber(10, 0)
+	_, _, _, result := vaultDepositExchange(zero, zero, assets, 18, true)
+	if result != ter.TecPATH_DRY {
+		t.Fatalf("scale 18 first deposit: got %v, want tecPATH_DRY", result)
+	}
+	_, _, shares, result := vaultDepositExchange(zero, zero, assets, 1, true)
+	if result != ter.TesSUCCESS || shares != 100 {
+		t.Fatalf("scale 1 control: got (%d, %v), want (100, tesSUCCESS)", shares, result)
+	}
+}

--- a/internal/tx/vault/vault_set.go
+++ b/internal/tx/vault/vault_set.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"strings"
 
 	"github.com/LeJamon/go-xrpl/amendment"
@@ -28,6 +29,25 @@ type VaultSet struct {
 	// AssetsMaximum is the maximum assets (optional). NUMBER field, carried as
 	// its decimal/scientific string form.
 	AssetsMaximum *string `json:"AssetsMaximum,omitempty" xrpl:"AssetsMaximum,omitempty"`
+}
+
+func (v *VaultSet) UnmarshalJSON(data []byte) error {
+	type alias VaultSet
+	decoded := struct {
+		AssetsMaximum json.RawMessage `json:"AssetsMaximum"`
+		*alias
+	}{alias: (*alias)(v)}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	if decoded.AssetsMaximum != nil {
+		maximum, err := parseAssetsMaximumJSON(decoded.AssetsMaximum)
+		if err != nil {
+			return err
+		}
+		v.AssetsMaximum = maximum
+	}
+	return nil
 }
 
 // NewVaultSet creates a new VaultSet transaction
@@ -67,7 +87,7 @@ func (v *VaultSet) Validate() error {
 
 	// Data is a Blob: present-but-empty and over-length (in decoded bytes)
 	// are both rejected.
-	if v.Data != "" {
+	if v.Data != "" || v.Common.HasField("Data") {
 		dataBytes, err := decodeBlob(v.Data)
 		if err != nil {
 			return ErrVaultDataTooLong
@@ -80,13 +100,12 @@ func (v *VaultSet) Validate() error {
 		}
 	}
 
-	// Validate AssetsMaximum if present. It is a NUMBER: negative is rejected.
-	if v.AssetsMaximum != nil && isNegativeNumberString(*v.AssetsMaximum) {
-		return ErrVaultAssetsMaxNeg
+	if err := validateAssetsMaximum(v.AssetsMaximum); err != nil {
+		return err
 	}
 
 	// Must update at least one field
-	if v.DomainID == "" && v.AssetsMaximum == nil && v.Data == "" {
+	if !v.hasDomainID() && v.AssetsMaximum == nil && v.Data == "" && !v.Common.HasField("Data") {
 		return ErrVaultNoFieldsToUpdate
 	}
 
@@ -95,6 +114,17 @@ func (v *VaultSet) Validate() error {
 
 func (v *VaultSet) Flatten() (map[string]any, error) {
 	return tx.ReflectFlatten(v)
+}
+
+func (v *VaultSet) hasDomainID() bool {
+	return v.DomainID != "" || v.Common.HasField("DomainID")
+}
+
+func (v *VaultSet) CheckExtraFeatures(rules *amendment.Rules) error {
+	if v.hasDomainID() && !rules.Enabled(amendment.FeaturePermissionedDomains) {
+		return ter.Errorf(ter.TemDISABLED, "PermissionedDomains amendment is disabled")
+	}
+	return nil
 }
 
 func (v *VaultSet) RequiredAmendments() [][32]byte {
@@ -144,7 +174,7 @@ func (v *VaultSet) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Resu
 		return ter.TefINTERNAL
 	}
 
-	if v.DomainID != "" {
+	if v.hasDomainID() {
 		if vd.Flags&VaultFlagPrivate == 0 {
 			return ter.TecNO_PERMISSION
 		}
@@ -185,21 +215,21 @@ func (v *VaultSet) Apply(ctx *tx.ApplyContext) ter.Result {
 		vd.Data = v.Data
 	}
 	if v.AssetsMaximum != nil {
-		newMax, nerr := vaultNumber(*v.AssetsMaximum)
+		newMax, nerr := parseCreateSetNumberForRules(*v.AssetsMaximum, ctx.Rules())
 		if nerr != nil {
 			return ter.TefINTERNAL
 		}
-		total, terr := vaultNumber(vd.AssetsTotal)
+		total, terr := parseCreateSetNumberForRules(zeroNumberString(vd.AssetsTotal), ctx.Rules())
 		if terr != nil {
 			return ter.TefINTERNAL
 		}
 		if newMax.Signum() != 0 && newMax.Cmp(total) < 0 {
 			return ter.TecLIMIT_EXCEEDED
 		}
-		vd.AssetsMaximum = numberToString(newMax)
+		vd.AssetsMaximum = canonicalCreateSetAssetsMaximum(vaultAssetOf(vd), newMax)
 	}
 
-	if v.DomainID != "" {
+	if v.hasDomainID() {
 		shareKey := keylet.MPTIssuance(vd.ShareMPTID)
 		shareData, rerr := ctx.View.Read(shareKey)
 		if rerr != nil || shareData == nil {
@@ -228,7 +258,10 @@ func (v *VaultSet) Apply(ctx *tx.ApplyContext) ter.Result {
 		}
 	}
 
-	newVault, serr := serializeVault(vd)
+	if err := associateVaultAsset(vd, ctx.Rules()); err != nil {
+		return ter.TefINTERNAL
+	}
+	newVault, serr := serializeVaultForRules(vd, ctx.Rules())
 	if serr != nil {
 		return ter.TefINTERNAL
 	}
@@ -237,6 +270,13 @@ func (v *VaultSet) Apply(ctx *tx.ApplyContext) ter.Result {
 	}
 
 	return ter.TesSUCCESS
+}
+
+func zeroNumberString(s string) string {
+	if s == "" {
+		return "0"
+	}
+	return s
 }
 
 // isZeroBytes reports whether every byte in b is zero.

--- a/internal/tx/vault/vault_set.go
+++ b/internal/tx/vault/vault_set.go
@@ -196,7 +196,7 @@ func (v *VaultSet) Apply(ctx *tx.ApplyContext) ter.Result {
 		if newMax.Signum() != 0 && newMax.Cmp(total) < 0 {
 			return ter.TecLIMIT_EXCEEDED
 		}
-		vd.AssetsMaximum = *v.AssetsMaximum
+		vd.AssetsMaximum = numberToString(newMax)
 	}
 
 	if v.DomainID != "" {

--- a/internal/tx/vault/vault_set_conformance_test.go
+++ b/internal/tx/vault/vault_set_conformance_test.go
@@ -1,0 +1,133 @@
+package vault
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+func TestVaultSetPermissionedDomainsGateUsesFieldPresence(t *testing.T) {
+	disabled := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+	enabled := amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault,
+		amendment.FeaturePermissionedDomains,
+	})
+
+	tests := []struct {
+		name     string
+		domainID string
+		present  bool
+		wantGate bool
+	}{
+		{name: "absent", wantGate: false},
+		{name: "nonzero", domainID: "1", wantGate: true},
+		{name: "zero", domainID: "0", present: true, wantGate: true},
+		{name: "present empty", present: true, wantGate: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			set := NewVaultSet("rOwner", strings.Repeat("01", 32))
+			set.DomainID = test.domainID
+			if test.present {
+				set.Common.SetPresentFields(map[string]bool{"DomainID": true})
+			}
+
+			err := set.CheckExtraFeatures(disabled)
+			if test.wantGate {
+				if got := vaultResultCode(t, err); got != ter.TemDISABLED {
+					t.Fatalf("CheckExtraFeatures() = %v, want temDISABLED", got)
+				}
+			} else if err != nil {
+				t.Fatalf("CheckExtraFeatures() = %v, want nil", err)
+			}
+			if err := set.CheckExtraFeatures(enabled); err != nil {
+				t.Fatalf("enabled CheckExtraFeatures() = %v", err)
+			}
+		})
+	}
+}
+
+func TestVaultSetRejectsPresentEmptyDataBeforeNoOp(t *testing.T) {
+	set := NewVaultSet("rOwner", strings.Repeat("01", 32))
+	set.Common.SetPresentFields(map[string]bool{"Data": true})
+	if got := set.Validate(); got != ErrVaultDataEmpty {
+		t.Fatalf("Validate() = %v, want %v", got, ErrVaultDataEmpty)
+	}
+}
+
+func TestVaultSetAcceptsNegativeZeroAssetsMaximum(t *testing.T) {
+	maximum := "-0"
+	set := NewVaultSet("rOwner", strings.Repeat("01", 32))
+	set.AssetsMaximum = &maximum
+	if err := set.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+}
+
+func TestVaultSetRejectsMalformedProgrammaticAssetsMaximum(t *testing.T) {
+	maximum := "not-a-number"
+	set := NewVaultSet("rOwner", strings.Repeat("01", 32))
+	set.AssetsMaximum = &maximum
+	if got := vaultResultCode(t, set.Validate()); got != ter.TemMALFORMED {
+		t.Fatalf("Validate() = %v, want temMALFORMED", got)
+	}
+}
+
+func TestVaultSetAssetsMaximumUsesRawValueForLimitThenCanonicalizes(t *testing.T) {
+	var vaultID [32]byte
+	for i := range vaultID {
+		vaultID[i] = 1
+	}
+	vaultKey := keylet.VaultByID(vaultID)
+	rules := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+
+	build := func(t *testing.T, total string) (*VaultSet, *tx.ApplyContext, *mptArmsView) {
+		t.Helper()
+		view := newMPTArmsView()
+		encoded, err := serializeVault(&vaultData{
+			Owner:            [20]byte{1},
+			Account:          [20]byte{2},
+			Sequence:         1,
+			ShareMPTID:       [24]byte{3},
+			Asset:            tx.Asset{Currency: "XRP"},
+			WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+			AssetsTotal:      total,
+		})
+		if err != nil {
+			t.Fatalf("serialize vault: %v", err)
+		}
+		view.data[vaultKey.Key] = encoded
+		maximum := "0.4"
+		set := NewVaultSet("rOwner", strings.ToUpper(hex.EncodeToString(vaultID[:])))
+		set.AssetsMaximum = &maximum
+		ctx := &tx.ApplyContext{View: view, Config: tx.EngineConfig{Rules: rules}}
+		return set, ctx, view
+	}
+
+	t.Run("raw value below total takes precedence", func(t *testing.T) {
+		set, ctx, _ := build(t, "1e0")
+		if got := set.Apply(ctx); got != ter.TecLIMIT_EXCEEDED {
+			t.Fatalf("Apply() = %v, want tecLIMIT_EXCEEDED", got)
+		}
+	})
+
+	t.Run("rounded zero removes default field", func(t *testing.T) {
+		set, ctx, view := build(t, "")
+		if got := set.Apply(ctx); got != ter.TesSUCCESS {
+			t.Fatalf("Apply() = %v, want tesSUCCESS", got)
+		}
+		updated, err := readVault(view, vaultKey)
+		if err != nil {
+			t.Fatalf("read updated vault: %v", err)
+		}
+		if updated.AssetsMaximum != "" {
+			t.Fatalf("AssetsMaximum = %q, want default removal", updated.AssetsMaximum)
+		}
+	})
+}

--- a/internal/tx/vault/vault_test.go
+++ b/internal/tx/vault/vault_test.go
@@ -543,7 +543,7 @@ func TestVaultWithdrawValidation(t *testing.T) {
 			errMsg:  "Amount must be positive",
 		},
 		{
-			name: "invalid - DestinationTag without Destination",
+			name: "valid - DestinationTag without Destination",
 			tx: func() *VaultWithdraw {
 				v := NewVaultWithdraw("rOwner", makeValidVaultID(), tx.NewXRPAmount(1000000))
 				tag := uint32(12345)
@@ -551,8 +551,7 @@ func TestVaultWithdrawValidation(t *testing.T) {
 				// No Destination set
 				return v
 			}(),
-			wantErr: true,
-			errMsg:  "DestinationTag without Destination",
+			wantErr: false,
 		},
 	}
 

--- a/internal/tx/vault/vault_withdraw.go
+++ b/internal/tx/vault/vault_withdraw.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -69,14 +70,11 @@ func (v *VaultWithdraw) Validate() error {
 		return ErrVaultAmountNotPos
 	}
 
-	// A present Destination must not be the zero account. When no Destination
-	// is given, a DestinationTag is meaningless and rejected.
+	// A present Destination must not be the zero account.
 	if v.Destination != "" {
 		if id, err := state.DecodeAccountID(v.Destination); err == nil && id == ([20]byte{}) {
 			return ErrVaultDestZero
 		}
-	} else if v.DestinationTag != nil {
-		return ErrVaultDestTagNoAccount
 	}
 
 	return nil
@@ -114,6 +112,11 @@ func (v *VaultWithdraw) destination(accountID [20]byte) ([20]byte, error) {
 	return state.DecodeAccountID(v.Destination)
 }
 
+func checkVaultShareFrozen(view tx.LedgerView, account [20]byte, vd *vaultData) ter.Result {
+	share := tx.Asset{MPTIssuanceID: hex.EncodeToString(vd.ShareMPTID[:])}
+	return checkFrozen(view, share, account)
+}
+
 // Preclaim checks the vault exists, the amount denominates the asset or shares,
 // the withdrawal can be delivered to the destination, and nothing is frozen.
 // Reference: rippled VaultWithdraw::preclaim.
@@ -138,14 +141,25 @@ func (v *VaultWithdraw) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter
 		return ter.TecWRONG_ASSET
 	}
 
-	if vd.WithdrawalPolicy != VaultStrategyFirstComeFirstServe {
-		return ter.TefINTERNAL
-	}
-
 	dstID, derr := v.destination(accountID)
 	if derr != nil {
 		return ter.TemMALFORMED
 	}
+	asset := vaultAssetOf(vd)
+	if res := canTransfer(
+		view,
+		asset,
+		vd.Account,
+		dstID,
+		config.RequireRules().FixCleanup3_2_0Enabled(),
+	); res != ter.TesSUCCESS {
+		return res
+	}
+
+	if vd.WithdrawalPolicy != VaultStrategyFirstComeFirstServe {
+		return ter.TefINTERNAL
+	}
+
 	// canWithdraw's trust-limit branch is exempt for the share MPT, so a
 	// share-denominated withdrawal pre-amendment skipped the destination's IOU
 	// trust limit entirely. Post-fixCleanup3_1_3 the shares are converted to the
@@ -154,7 +168,12 @@ func (v *VaultWithdraw) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter
 	limitAmount := v.Amount
 	if config.RequireRules().Enabled(amendment.FeatureFixCleanup3_1_3) && v.amountIsShares(vd) &&
 		!isNativeAsset(vd.Asset) && !vd.AssetIsMPT {
-		assets, res := v.sharesToAssetAmount(view, vd)
+		assets, res := v.sharesToAssetAmount(
+			view,
+			vd,
+			accountID,
+			config.RequireRules(),
+		)
 		if res != ter.TesSUCCESS {
 			return res
 		}
@@ -164,8 +183,17 @@ func (v *VaultWithdraw) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter
 		return res
 	}
 
-	asset := vaultAssetOf(vd)
-	if res := tx.AssetFrozen(view, dstID, asset); res != ter.TesSUCCESS {
+	authType := mptutil.WeakAuth
+	if dstID != accountID {
+		authType = mptutil.StrongAuth
+	}
+	if res := requireAuth(view, asset, dstID, authType, config.ParentCloseTime); res != ter.TesSUCCESS {
+		return res
+	}
+	if res := checkFrozen(view, asset, dstID); res != ter.TesSUCCESS {
+		return res
+	}
+	if res := checkVaultShareFrozen(view, accountID, vd); res != ter.TesSUCCESS {
 		return res
 	}
 
@@ -175,7 +203,19 @@ func (v *VaultWithdraw) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter
 // sharesToAssetAmount converts the share-denominated withdrawal Amount into the
 // equivalent IOU asset amount, so the destination trust-line limit can be
 // enforced. Reference: rippled VaultWithdraw::preclaim sharesToAssetsWithdraw.
-func (v *VaultWithdraw) sharesToAssetAmount(view tx.LedgerView, vd *vaultData) (tx.Amount, ter.Result) {
+func (v *VaultWithdraw) sharesToAssetAmount(
+	view tx.LedgerView,
+	vd *vaultData,
+	accountID [20]byte,
+	rules *amendment.Rules,
+) (amount tx.Amount, result ter.Result) {
+	result = ter.TesSUCCESS
+	defer func() {
+		if recover() != nil {
+			amount = tx.Amount{}
+			result = ter.TecPATH_DRY
+		}
+	}()
 	shareData, rerr := view.Read(keylet.MPTIssuance(vd.ShareMPTID))
 	if rerr != nil || shareData == nil {
 		return tx.Amount{}, ter.TefINTERNAL
@@ -184,15 +224,143 @@ func (v *VaultWithdraw) sharesToAssetAmount(view tx.LedgerView, vd *vaultData) (
 	if perr != nil || issuance.OutstandingAmount == 0 {
 		return tx.Amount{}, ter.TefINTERNAL
 	}
-	sharesN, aerr := amountToNumber(v.Amount)
+	sharesN, aerr := amountToNumberForRules(v.Amount, rules)
 	if aerr != nil {
 		return tx.Amount{}, ter.TefINTERNAL
 	}
-	assetsTotalN, _ := vaultNumber(vd.AssetsTotal)
-	lossN, _ := vaultNumber(vd.LossUnrealized)
-	shareTotalN := state.NewXRPLNumber(int64(issuance.OutstandingAmount), 0)
-	assetsN := sharesToAssetsWithdraw(assetsTotalN, lossN, shareTotalN, sharesN)
+	assetsTotalN, _ := vaultNumberForRules(vd.AssetsTotal, rules)
+	lossN, _ := vaultNumberForRules(vd.LossUnrealized, rules)
+	scale := vaultNumberScale(rules)
+	if rules.FixCleanup3_2_0Enabled() && isSoleShareholder(view, accountID, vd.ShareMPTID, issuance.OutstandingAmount) {
+		lossN = state.NewXRPLNumberScaled(0, 0, scale, state.RoundToNearest)
+	}
+	shareTotalN := state.NewXRPLNumberScaled(int64(issuance.OutstandingAmount), 0, scale, state.RoundToNearest)
+	asset := vaultAssetOf(vd)
+	assetsN := sharesToAssetsWithdraw(
+		assetsTotalN,
+		lossN,
+		shareTotalN,
+		sharesN,
+		asset.IsNative() || asset.IsMPT(),
+	)
 	return state.NewIssuedAmountFromValue(assetsN.Mantissa(), assetsN.Exponent(), vd.Asset.Currency, vd.Asset.Issuer), ter.TesSUCCESS
+}
+
+func assetWithdrawalAmounts(
+	assetsTotal,
+	lossUnrealized,
+	shareTotal,
+	assets state.XRPLNumber,
+	integral bool,
+) (sharesRedeemed, assetsWithdrawn state.XRPLNumber) {
+	sharesRedeemed = assetsToSharesWithdraw(assetsTotal, lossUnrealized, shareTotal, assets, false)
+	assetsWithdrawn = sharesToAssetsWithdraw(
+		assetsTotal,
+		lossUnrealized,
+		shareTotal,
+		sharesRedeemed,
+		integral,
+	)
+	return sharesRedeemed, assetsWithdrawn
+}
+
+func (v *VaultWithdraw) withdrawalAmounts(
+	ctx *tx.ApplyContext,
+	vd *vaultData,
+	issuance *state.MPTokenIssuanceData,
+) (
+	assetsTotalN, availN, assetsWithdrawnN state.XRPLNumber,
+	shares uint64,
+	fix320 bool,
+	result ter.Result,
+) {
+	result = ter.TesSUCCESS
+	defer func() {
+		if recover() != nil {
+			result = ter.TecPATH_DRY
+		}
+	}()
+
+	rules := ctx.Rules()
+	numberScale := vaultNumberScale(rules)
+	assetsTotalN, _ = vaultNumberForRules(vd.AssetsTotal, rules)
+	availN, _ = vaultNumberForRules(vd.AssetsAvailable, rules)
+	lossN, _ := vaultNumberForRules(vd.LossUnrealized, rules)
+	shareTotalN := state.NewXRPLNumberScaled(
+		int64(issuance.OutstandingAmount),
+		0,
+		numberScale,
+		state.RoundToNearest,
+	)
+
+	fix320 = rules.FixCleanup3_2_0Enabled()
+	asset := vaultAssetOf(vd)
+	integral := asset.IsNative() || asset.IsMPT()
+	if fix320 && isSoleShareholder(ctx.View, ctx.AccountID, vd.ShareMPTID, issuance.OutstandingAmount) {
+		lossN = state.NewXRPLNumberScaled(0, 0, numberScale, state.RoundToNearest)
+	}
+
+	var sharesRedeemedN state.XRPLNumber
+	if v.amountIsShares(vd) {
+		var err error
+		sharesRedeemedN, err = amountToNumberForRules(v.Amount, rules)
+		if err != nil {
+			return assetsTotalN, availN, assetsWithdrawnN, 0, fix320, ter.TefINTERNAL
+		}
+		assetsWithdrawnN = sharesToAssetsWithdraw(
+			assetsTotalN,
+			lossN,
+			shareTotalN,
+			sharesRedeemedN,
+			integral,
+		)
+	} else {
+		assetsN, err := amountToNumberForRules(v.Amount, rules)
+		if err != nil {
+			return assetsTotalN, availN, assetsWithdrawnN, 0, fix320, ter.TefINTERNAL
+		}
+		sharesRedeemedN, assetsWithdrawnN = assetWithdrawalAmounts(
+			assetsTotalN,
+			lossN,
+			shareTotalN,
+			assetsN,
+			integral,
+		)
+		if sharesRedeemedN.IsZero() {
+			return assetsTotalN, availN, assetsWithdrawnN, 0, fix320, ter.TecPRECISION_LOSS
+		}
+	}
+
+	shares = uint64(sharesRedeemedN.ToInt64WithMode(state.RoundTowardsZero))
+	return assetsTotalN, availN, assetsWithdrawnN, shares, fix320, ter.TesSUCCESS
+}
+
+func addWithdrawDestinationHolding(ctx *tx.ApplyContext, asset tx.Asset) ter.Result {
+	if asset.IsMPT() {
+		id, ok := assetMPTID(asset)
+		if !ok {
+			return ter.TefINTERNAL
+		}
+		exists, err := ctx.View.Exists(keylet.MPTokenByID(id, ctx.AccountID))
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		if !exists && mptIDIssuer(id) != ctx.AccountID && ctx.Account.OwnerCount >= 2 &&
+			ctx.PriorBalance() < ctx.AccountReserve(tx.ConfineOwnerCount(ctx.Account.OwnerCount, 1)) {
+			return ter.TecINSUFFICIENT_RESERVE
+		}
+	}
+	delta, result := addEmptyHolding(ctx, ctx.AccountID, asset)
+	if result == ter.TecDUPLICATE {
+		return ter.TesSUCCESS
+	}
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if delta > 0 {
+		ctx.Account.OwnerCount = tx.ConfineOwnerCount(ctx.Account.OwnerCount, int(delta))
+	}
+	return ter.TesSUCCESS
 }
 
 // Apply redeems the caller's shares for the underlying asset and delivers it to
@@ -217,39 +385,12 @@ func (v *VaultWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TefINTERNAL
 	}
 
-	assetsTotalN, _ := vaultNumber(vd.AssetsTotal)
-	availN, _ := vaultNumber(vd.AssetsAvailable)
-	lossN, _ := vaultNumber(vd.LossUnrealized)
-	shareTotalN := state.NewXRPLNumber(int64(issuance.OutstandingAmount), 0)
-
-	fix320 := ctx.Rules().FixCleanup3_2_0Enabled()
-	// The sole shareholder owns the future value too, so the unrealized-loss
-	// subtraction is waived — otherwise they could burn every share yet strand
-	// future value in the vault.
-	if fix320 && isSoleShareholder(ctx.View, ctx.AccountID, vd.ShareMPTID, issuance.OutstandingAmount) {
-		lossN = state.NewXRPLNumber(0, 0)
+	rules := ctx.Rules()
+	asset := vaultAssetOf(vd)
+	assetsTotalN, availN, assetsWithdrawnN, shares, fix320, result := v.withdrawalAmounts(ctx, vd, issuance)
+	if result != ter.TesSUCCESS {
+		return result
 	}
-
-	var sharesRedeemedN, assetsWithdrawnN state.XRPLNumber
-	if v.amountIsShares(vd) {
-		sharesRedeemedN, err = amountToNumber(v.Amount)
-		if err != nil {
-			return ter.TefINTERNAL
-		}
-		assetsWithdrawnN = sharesToAssetsWithdraw(assetsTotalN, lossN, shareTotalN, sharesRedeemedN)
-	} else {
-		assetsN, aerr := amountToNumber(v.Amount)
-		if aerr != nil {
-			return ter.TefINTERNAL
-		}
-		sharesRedeemedN = assetsToSharesWithdraw(assetsTotalN, lossN, shareTotalN, assetsN, true)
-		if sharesRedeemedN.IsZero() {
-			return ter.TecPRECISION_LOSS
-		}
-		assetsWithdrawnN = sharesToAssetsWithdraw(assetsTotalN, lossN, shareTotalN, sharesRedeemedN)
-	}
-
-	shares := uint64(sharesRedeemedN.ToInt64WithMode(state.RoundTowardsZero))
 
 	// The caller must hold enough shares.
 	token, terr := readMPToken(ctx.View, keylet.MPTokenByID(vd.ShareMPTID, ctx.AccountID))
@@ -277,7 +418,10 @@ func (v *VaultWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 		vd.AssetsTotal = numberToString(assetsTotalN.Sub(assetsWithdrawnN))
 		vd.AssetsAvailable = numberToString(availN.Sub(assetsWithdrawnN))
 	}
-	newVault, serr := serializeVault(vd)
+	if err := associateVaultAsset(vd, rules); err != nil {
+		return ter.TefINTERNAL
+	}
+	newVault, serr := serializeVaultForRules(vd, rules)
 	if serr != nil {
 		return ter.TefINTERNAL
 	}
@@ -301,11 +445,14 @@ func (v *VaultWithdraw) Apply(ctx *tx.ApplyContext) ter.Result {
 	if derr != nil {
 		return ter.TefINTERNAL
 	}
-	asset := vaultAssetOf(vd)
 	if dstID == ctx.AccountID {
-		if _, res := addEmptyHolding(ctx, ctx.AccountID, asset); res != ter.TesSUCCESS && res != ter.TecDUPLICATE {
+		if res := addWithdrawDestinationHolding(ctx, asset); res != ter.TesSUCCESS {
 			return res
 		}
+	}
+	holding, herr := actualAssetHolding(ctx.View, vd.Account, asset, rules)
+	if herr != nil || holding.Cmp(assetsWithdrawnN) < 0 {
+		return ter.TefINTERNAL
 	}
 	if res := sendAssetFromVault(ctx, vd.Account, dstID, asset, assetsWithdrawnN); res != ter.TesSUCCESS {
 		return res

--- a/internal/tx/vault/vault_withdraw_preclaim_test.go
+++ b/internal/tx/vault/vault_withdraw_preclaim_test.go
@@ -11,11 +11,13 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
 
 // roView serves crafted SLE bytes by keylet; mutating methods are no-ops.
 type roView struct {
-	data map[[32]byte][]byte
+	data  map[[32]byte][]byte
+	rules *amendment.Rules
 }
 
 func (v roView) Read(k keylet.Keylet) ([]byte, error)      { return v.data[k.Key], nil }
@@ -31,7 +33,7 @@ func (v roView) Succ(key [32]byte) ([32]byte, []byte, bool, error) {
 	return [32]byte{}, nil, false, nil
 }
 func (v roView) TxExists(txID [32]byte) bool { return false }
-func (v roView) Rules() *amendment.Rules     { return nil }
+func (v roView) Rules() *amendment.Rules     { return v.rules }
 func (v roView) LedgerSeq() uint32           { return 0 }
 
 func fill20(b byte) [20]byte {
@@ -137,5 +139,464 @@ func TestVaultWithdraw_ShareLimitEnforced(t *testing.T) {
 	}
 	if got := newWithdraw().Preclaim(view, fixOff); got != ter.TesSUCCESS {
 		t.Errorf("fixCleanup3_1_3 OFF: got %v, want tesSUCCESS", got)
+	}
+}
+
+func mustAccountRoot(t *testing.T, id [20]byte, flags uint32) []byte {
+	t.Helper()
+	address, err := state.EncodeAccountID(id)
+	if err != nil {
+		t.Fatalf("encode account: %v", err)
+	}
+	raw, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account:  address,
+		Balance:  1_000_000_000,
+		Sequence: 1,
+		Flags:    flags,
+	})
+	if err != nil {
+		t.Fatalf("serialize account: %v", err)
+	}
+	return raw
+}
+
+func mustVaultAccountRoot(t *testing.T, id [20]byte, vaultID [32]byte) []byte {
+	t.Helper()
+	address, err := state.EncodeAccountID(id)
+	if err != nil {
+		t.Fatalf("encode account: %v", err)
+	}
+	raw, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account:  address,
+		Sequence: 0,
+		VaultID:  vaultID,
+	})
+	if err != nil {
+		t.Fatalf("serialize vault account: %v", err)
+	}
+	return raw
+}
+
+func mustVault(t *testing.T, vd *vaultData) []byte {
+	t.Helper()
+	raw, err := serializeVault(vd)
+	if err != nil {
+		t.Fatalf("serialize vault: %v", err)
+	}
+	return raw
+}
+
+func mustIssuance(t *testing.T, issuance *state.MPTokenIssuanceData) []byte {
+	t.Helper()
+	raw, err := state.SerializeMPTokenIssuance(issuance)
+	if err != nil {
+		t.Fatalf("serialize issuance: %v", err)
+	}
+	return raw
+}
+
+func mustToken(t *testing.T, token *state.MPTokenData) []byte {
+	t.Helper()
+	raw, err := state.SerializeMPToken(token)
+	if err != nil {
+		t.Fatalf("serialize token: %v", err)
+	}
+	return raw
+}
+
+func TestVaultWithdraw_CanTransferPrecedesPolicy(t *testing.T) {
+	issuerID := fill20(0x11)
+	submitterID := fill20(0x22)
+	vaultAccountID := fill20(0x33)
+	issuerAddr, _ := state.EncodeAccountID(issuerID)
+	submitterAddr, _ := state.EncodeAccountID(submitterID)
+
+	var vaultID [32]byte
+	vaultID[31] = 1
+	vaultIDHex := strings.ToUpper(hex.EncodeToString(vaultID[:]))
+	assetID := keylet.MakeMPTID(7, issuerID)
+	shareID := keylet.MakeMPTID(1, vaultAccountID)
+	assetHex := strings.ToUpper(hex.EncodeToString(assetID[:]))
+
+	baseData := map[[32]byte][]byte{
+		keylet.VaultByID(vaultID).Key: mustVault(t, &vaultData{
+			WithdrawalPolicy: 99,
+			Owner:            submitterID,
+			Account:          vaultAccountID,
+			AssetIsMPT:       true,
+			AssetMPTID:       assetID,
+			ShareMPTID:       shareID,
+			AssetsTotal:      "100",
+			AssetsAvailable:  "100",
+		}),
+		keylet.MPTIssuance(assetID).Key: mustIssuance(t, &state.MPTokenIssuanceData{
+			Issuer:   issuerID,
+			Sequence: 7,
+		}),
+		keylet.MPTIssuance(shareID).Key: mustIssuance(t, &state.MPTokenIssuanceData{
+			Issuer:            vaultAccountID,
+			Sequence:          1,
+			OutstandingAmount: 100,
+		}),
+		keylet.Account(issuerID).Key:    mustAccountRoot(t, issuerID, 0),
+		keylet.Account(submitterID).Key: mustAccountRoot(t, submitterID, 0),
+	}
+	withdraw := NewVaultWithdraw(
+		submitterAddr,
+		vaultIDHex,
+		state.NewMPTAmountWithIssuanceID(1, issuerAddr, assetHex),
+	)
+
+	t.Run("pre-fix transfer denial wins", func(t *testing.T) {
+		rules := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+		view := roView{data: baseData, rules: rules}
+		if got := withdraw.Preclaim(view, tx.EngineConfig{Rules: rules}); got != ter.TecNO_AUTH {
+			t.Fatalf("got %v, want tecNO_AUTH", got)
+		}
+	})
+
+	t.Run("fix waives MPT CanTransfer then policy wins", func(t *testing.T) {
+		rules := amendment.NewRules([][32]byte{
+			amendment.FeatureSingleAssetVault,
+			amendment.FeatureFixCleanup3_2_0,
+		})
+		view := roView{data: baseData, rules: rules}
+		if got := withdraw.Preclaim(view, tx.EngineConfig{Rules: rules}); got != ter.TefINTERNAL {
+			t.Fatalf("got %v, want tefINTERNAL", got)
+		}
+	})
+}
+
+func TestVaultWithdraw_IOUNoRipplePrecedesPolicy(t *testing.T) {
+	issuerID := fill20(0x41)
+	submitterID := fill20(0x42)
+	vaultAccountID := fill20(0x43)
+	issuerAddr, _ := state.EncodeAccountID(issuerID)
+	submitterAddr, _ := state.EncodeAccountID(submitterID)
+	var vaultID [32]byte
+	vaultID[31] = 2
+	shareID := keylet.MakeMPTID(1, vaultAccountID)
+	rules := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+	view := roView{rules: rules, data: map[[32]byte][]byte{
+		keylet.VaultByID(vaultID).Key: mustVault(t, &vaultData{
+			WithdrawalPolicy: 99,
+			Owner:            submitterID,
+			Account:          vaultAccountID,
+			Asset:            tx.Asset{Currency: "USD", Issuer: issuerAddr},
+			ShareMPTID:       shareID,
+			AssetsTotal:      "100",
+			AssetsAvailable:  "100",
+		}),
+		keylet.Account(issuerID).Key:    mustAccountRoot(t, issuerID, 0),
+		keylet.Account(submitterID).Key: mustAccountRoot(t, submitterID, 0),
+	}}
+	withdraw := NewVaultWithdraw(
+		submitterAddr,
+		strings.ToUpper(hex.EncodeToString(vaultID[:])),
+		state.NewIssuedAmountFromValue(1, 0, "USD", issuerAddr),
+	)
+	if got := withdraw.Preclaim(view, tx.EngineConfig{Rules: rules}); got != ter.TerNO_RIPPLE {
+		t.Fatalf("got %v, want terNO_RIPPLE", got)
+	}
+}
+
+func TestVaultWithdraw_DestinationAuthorization(t *testing.T) {
+	issuerID := fill20(0x51)
+	submitterID := fill20(0x52)
+	destinationID := fill20(0x53)
+	vaultAccountID := fill20(0x54)
+	issuerAddr, _ := state.EncodeAccountID(issuerID)
+	submitterAddr, _ := state.EncodeAccountID(submitterID)
+	destinationAddr, _ := state.EncodeAccountID(destinationID)
+	shareID := keylet.MakeMPTID(1, vaultAccountID)
+	rules := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+
+	t.Run("IOU destination needs trust line", func(t *testing.T) {
+		var vaultID [32]byte
+		vaultID[31] = 3
+		view := roView{rules: rules, data: map[[32]byte][]byte{
+			keylet.VaultByID(vaultID).Key: mustVault(t, &vaultData{
+				WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+				Owner:            submitterID,
+				Account:          vaultAccountID,
+				Asset:            tx.Asset{Currency: "USD", Issuer: issuerAddr},
+				ShareMPTID:       shareID,
+				AssetsTotal:      "100",
+				AssetsAvailable:  "100",
+			}),
+			keylet.MPTIssuance(shareID).Key: mustIssuance(t, &state.MPTokenIssuanceData{
+				Issuer:            vaultAccountID,
+				Sequence:          1,
+				OutstandingAmount: 100,
+			}),
+			keylet.Account(issuerID).Key:      mustAccountRoot(t, issuerID, state.LsfDefaultRipple),
+			keylet.Account(submitterID).Key:   mustAccountRoot(t, submitterID, 0),
+			keylet.Account(destinationID).Key: mustAccountRoot(t, destinationID, 0),
+		}}
+		shareHex := strings.ToUpper(hex.EncodeToString(shareID[:]))
+		withdraw := NewVaultWithdraw(
+			submitterAddr,
+			strings.ToUpper(hex.EncodeToString(vaultID[:])),
+			state.NewMPTAmountWithIssuanceID(1, issuerAddr, shareHex),
+		)
+		withdraw.Destination = destinationAddr
+		if got := withdraw.Preclaim(view, tx.EngineConfig{Rules: rules}); got != ter.TecNO_LINE {
+			t.Fatalf("got %v, want tecNO_LINE", got)
+		}
+	})
+
+	t.Run("MPT destination needs holding", func(t *testing.T) {
+		var vaultID [32]byte
+		vaultID[31] = 4
+		assetID := keylet.MakeMPTID(9, issuerID)
+		view := roView{rules: rules, data: map[[32]byte][]byte{
+			keylet.VaultByID(vaultID).Key: mustVault(t, &vaultData{
+				WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+				Owner:            submitterID,
+				Account:          vaultAccountID,
+				AssetIsMPT:       true,
+				AssetMPTID:       assetID,
+				ShareMPTID:       shareID,
+				AssetsTotal:      "100",
+				AssetsAvailable:  "100",
+			}),
+			keylet.MPTIssuance(assetID).Key: mustIssuance(t, &state.MPTokenIssuanceData{
+				Issuer:   issuerID,
+				Sequence: 9,
+				Flags:    entry.LsfMPTCanTransfer,
+			}),
+			keylet.MPTIssuance(shareID).Key: mustIssuance(t, &state.MPTokenIssuanceData{
+				Issuer:            vaultAccountID,
+				Sequence:          1,
+				OutstandingAmount: 100,
+			}),
+			keylet.Account(issuerID).Key:      mustAccountRoot(t, issuerID, 0),
+			keylet.Account(submitterID).Key:   mustAccountRoot(t, submitterID, 0),
+			keylet.Account(destinationID).Key: mustAccountRoot(t, destinationID, 0),
+		}}
+		assetHex := strings.ToUpper(hex.EncodeToString(assetID[:]))
+		withdraw := NewVaultWithdraw(
+			submitterAddr,
+			strings.ToUpper(hex.EncodeToString(vaultID[:])),
+			state.NewMPTAmountWithIssuanceID(1, issuerAddr, assetHex),
+		)
+		withdraw.Destination = destinationAddr
+		if got := withdraw.Preclaim(view, tx.EngineConfig{Rules: rules}); got != ter.TecNO_AUTH {
+			t.Fatalf("got %v, want tecNO_AUTH", got)
+		}
+	})
+}
+
+func TestVaultWithdraw_DepositorShareLock(t *testing.T) {
+	submitterID := fill20(0x61)
+	vaultAccountID := fill20(0x62)
+	submitterAddr, _ := state.EncodeAccountID(submitterID)
+	shareID := keylet.MakeMPTID(1, vaultAccountID)
+	var vaultID [32]byte
+	vaultID[31] = 5
+	rules := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+	base := map[[32]byte][]byte{
+		keylet.VaultByID(vaultID).Key: mustVault(t, &vaultData{
+			WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+			Owner:            submitterID,
+			Account:          vaultAccountID,
+			Asset:            tx.Asset{Currency: "XRP"},
+			ShareMPTID:       shareID,
+			AssetsTotal:      "100",
+			AssetsAvailable:  "100",
+		}),
+		keylet.Account(submitterID).Key: mustAccountRoot(t, submitterID, 0),
+	}
+	withdraw := NewVaultWithdraw(
+		submitterAddr,
+		strings.ToUpper(hex.EncodeToString(vaultID[:])),
+		tx.NewXRPAmount(1),
+	)
+
+	tests := []struct {
+		name          string
+		issuanceFlags uint32
+		tokenFlags    uint32
+	}{
+		{name: "issuance locked", issuanceFlags: entry.LsfMPTLocked},
+		{name: "holder locked", tokenFlags: entry.LsfMPTLocked},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data := make(map[[32]byte][]byte, len(base)+2)
+			for key, raw := range base {
+				data[key] = raw
+			}
+			data[keylet.MPTIssuance(shareID).Key] = mustIssuance(t, &state.MPTokenIssuanceData{
+				Issuer:            vaultAccountID,
+				Sequence:          1,
+				OutstandingAmount: 100,
+				Flags:             test.issuanceFlags,
+			})
+			data[keylet.MPTokenByID(shareID, submitterID).Key] = mustToken(t, &state.MPTokenData{
+				Account:           submitterID,
+				MPTokenIssuanceID: shareID,
+				MPTAmount:         100,
+				Flags:             test.tokenFlags,
+			})
+			view := roView{data: data, rules: rules}
+			if got := withdraw.Preclaim(view, tx.EngineConfig{Rules: rules}); got != ter.TecLOCKED {
+				t.Fatalf("got %v, want tecLOCKED", got)
+			}
+		})
+	}
+}
+
+func TestVaultWithdraw_ShareInheritsVaultHoldingFreeze(t *testing.T) {
+	issuerID := fill20(0x68)
+	submitterID := fill20(0x69)
+	vaultAccountID := fill20(0x67)
+	issuerAddr, _ := state.EncodeAccountID(issuerID)
+	submitterAddr, _ := state.EncodeAccountID(submitterID)
+	vaultAccountAddr, _ := state.EncodeAccountID(vaultAccountID)
+	shareID := keylet.MakeMPTID(1, vaultAccountID)
+	var vaultID [32]byte
+	vaultID[31] = 7
+
+	frozenLine, err := state.SerializeRippleState(&state.RippleState{
+		Balance:   state.NewIssuedAmountFromValue(100, 0, "USD", issuerAddr),
+		LowLimit:  state.NewIssuedAmountFromValue(0, -100, "USD", vaultAccountAddr),
+		HighLimit: state.NewIssuedAmountFromValue(0, -100, "USD", issuerAddr),
+		Flags:     state.LsfHighFreeze,
+	})
+	if err != nil {
+		t.Fatalf("serialize frozen line: %v", err)
+	}
+	rules := amendment.NewRules([][32]byte{amendment.FeatureSingleAssetVault})
+	view := roView{rules: rules, data: map[[32]byte][]byte{
+		keylet.VaultByID(vaultID).Key: mustVault(t, &vaultData{
+			WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+			Owner:            submitterID,
+			Account:          vaultAccountID,
+			Asset:            tx.Asset{Currency: "USD", Issuer: issuerAddr},
+			ShareMPTID:       shareID,
+			AssetsTotal:      "100",
+			AssetsAvailable:  "100",
+		}),
+		keylet.MPTIssuance(shareID).Key: mustIssuance(t, &state.MPTokenIssuanceData{
+			Issuer:            vaultAccountID,
+			Sequence:          1,
+			OutstandingAmount: 100,
+		}),
+		keylet.MPTokenByID(shareID, submitterID).Key: mustToken(t, &state.MPTokenData{
+			Account:           submitterID,
+			MPTokenIssuanceID: shareID,
+			MPTAmount:         100,
+		}),
+		keylet.Account(issuerID).Key:                     mustAccountRoot(t, issuerID, state.LsfDefaultRipple),
+		keylet.Account(submitterID).Key:                  mustAccountRoot(t, submitterID, 0),
+		keylet.Account(vaultAccountID).Key:               mustVaultAccountRoot(t, vaultAccountID, vaultID),
+		keylet.Line(vaultAccountID, issuerID, "USD").Key: frozenLine,
+	}}
+	withdraw := NewVaultWithdraw(
+		submitterAddr,
+		strings.ToUpper(hex.EncodeToString(vaultID[:])),
+		state.NewIssuedAmountFromValue(1, 0, "USD", issuerAddr),
+	)
+	if got := withdraw.Preclaim(view, tx.EngineConfig{Rules: rules}); got != ter.TecLOCKED {
+		t.Fatalf("got %v, want tecLOCKED", got)
+	}
+}
+
+func TestVaultWithdraw_AssetWithdrawalRoundsSharesToNearest(t *testing.T) {
+	assetsTotal, _ := vaultNumber("6666.5")
+	shareTotal := state.NewXRPLNumber(5_000_000_000, 0)
+	assets := state.NewXRPLNumber(1000, 0)
+	shares, payout := assetWithdrawalAmounts(
+		assetsTotal,
+		state.NewXRPLNumber(0, 0),
+		shareTotal,
+		assets,
+		false,
+	)
+	if got := shares.ToInt64WithMode(state.RoundTowardsZero); got != 750_018_750 {
+		t.Fatalf("shares = %d, want 750018750", got)
+	}
+	wantPayout := assetsTotal.Mul(state.NewXRPLNumber(750_018_750, 0)).Div(shareTotal)
+	if payout.Cmp(wantPayout) != 0 {
+		t.Fatalf("payout = %s, want %s", payout.String(), wantPayout.String())
+	}
+}
+
+func TestVaultWithdraw_SoleShareholderWaivesLossInPreclaimLimit(t *testing.T) {
+	issuerID := fill20(0x71)
+	submitterID := fill20(0x72)
+	destinationID := fill20(0x73)
+	vaultAccountID := fill20(0x74)
+	issuerAddr, _ := state.EncodeAccountID(issuerID)
+	submitterAddr, _ := state.EncodeAccountID(submitterID)
+	destinationAddr, _ := state.EncodeAccountID(destinationID)
+	shareID := keylet.MakeMPTID(1, vaultAccountID)
+	shareHex := strings.ToUpper(hex.EncodeToString(shareID[:]))
+	var vaultID [32]byte
+	vaultID[31] = 6
+
+	lineRaw, err := state.SerializeRippleState(&state.RippleState{
+		Balance:   state.NewIssuedAmountFromValue(0, -100, "USD", issuerAddr),
+		LowLimit:  state.NewIssuedAmountFromValue(0, -100, "USD", issuerAddr),
+		HighLimit: state.NewIssuedAmountFromValue(15, 0, "USD", destinationAddr),
+	})
+	if err != nil {
+		t.Fatalf("serialize trust line: %v", err)
+	}
+	base := map[[32]byte][]byte{
+		keylet.VaultByID(vaultID).Key: mustVault(t, &vaultData{
+			WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+			Owner:            submitterID,
+			Account:          vaultAccountID,
+			Asset:            tx.Asset{Currency: "USD", Issuer: issuerAddr},
+			ShareMPTID:       shareID,
+			AssetsTotal:      "100",
+			AssetsAvailable:  "100",
+			LossUnrealized:   "50",
+		}),
+		keylet.MPTIssuance(shareID).Key: mustIssuance(t, &state.MPTokenIssuanceData{
+			Issuer:            vaultAccountID,
+			Sequence:          1,
+			OutstandingAmount: 100,
+		}),
+		keylet.MPTokenByID(shareID, submitterID).Key: mustToken(t, &state.MPTokenData{
+			Account:           submitterID,
+			MPTokenIssuanceID: shareID,
+			MPTAmount:         100,
+		}),
+		keylet.Account(issuerID).Key:                    mustAccountRoot(t, issuerID, state.LsfDefaultRipple),
+		keylet.Account(submitterID).Key:                 mustAccountRoot(t, submitterID, 0),
+		keylet.Account(destinationID).Key:               mustAccountRoot(t, destinationID, 0),
+		keylet.Line(destinationID, issuerID, "USD").Key: lineRaw,
+	}
+	withdraw := NewVaultWithdraw(
+		submitterAddr,
+		strings.ToUpper(hex.EncodeToString(vaultID[:])),
+		state.NewMPTAmountWithIssuanceID(20, issuerAddr, shareHex),
+	)
+	withdraw.Destination = destinationAddr
+
+	withoutFix320 := amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault,
+		amendment.FeatureFixCleanup3_1_3,
+	})
+	if got := withdraw.Preclaim(
+		roView{data: base, rules: withoutFix320},
+		tx.EngineConfig{Rules: withoutFix320},
+	); got != ter.TesSUCCESS {
+		t.Fatalf("pre-fix got %v, want tesSUCCESS", got)
+	}
+
+	withFix320 := amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault,
+		amendment.FeatureFixCleanup3_1_3,
+		amendment.FeatureFixCleanup3_2_0,
+	})
+	if got := withdraw.Preclaim(
+		roView{data: base, rules: withFix320},
+		tx.EngineConfig{Rules: withFix320},
+	); got != ter.TecNO_LINE {
+		t.Fatalf("fixCleanup3_2_0 got %v, want tecNO_LINE", got)
 	}
 }

--- a/internal/tx/vault/vault_withdraw_validation_test.go
+++ b/internal/tx/vault/vault_withdraw_validation_test.go
@@ -1,0 +1,51 @@
+package vault
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+)
+
+func TestVaultWithdraw_DestinationTagWithoutDestinationIsValid(t *testing.T) {
+	withdraw := NewVaultWithdraw("rOwner", makeValidVaultID(), tx.NewXRPAmount(1))
+	withdraw.Common.Fee = "12"
+	sequence := uint32(1)
+	withdraw.Common.Sequence = &sequence
+	tag := uint32(7)
+	withdraw.DestinationTag = &tag
+
+	if err := withdraw.Validate(); err != nil {
+		t.Fatalf("Validate() returned %v", err)
+	}
+}
+
+func TestVaultWithdrawNumberOverflowReturnsPathDry(t *testing.T) {
+	view := newMPTArmsView()
+	var account [20]byte
+	account[19] = 1
+	ctx := buildArmsCtx(t, view, account, rulesWithFix(true))
+	shareID := [24]byte{1}
+	var shareIssuer [20]byte
+	copy(shareIssuer[:], shareID[4:])
+	amount := state.NewMPTAmountWithIssuanceID(
+		1,
+		state.EncodeAccountIDSafe(shareIssuer),
+		hex.EncodeToString(shareID[:]),
+	)
+	withdraw := NewVaultWithdraw(ctx.Account.Account, makeValidVaultID(), amount)
+	vd := &vaultData{
+		Account:          [20]byte{2},
+		ShareMPTID:       shareID,
+		Asset:            tx.Asset{Currency: "XRP"},
+		AssetsTotal:      "10",
+		AssetsAvailable:  "10",
+		WithdrawalPolicy: VaultStrategyFirstComeFirstServe,
+	}
+	_, _, _, _, _, result := withdraw.withdrawalAmounts(ctx, vd, &state.MPTokenIssuanceData{})
+	if result != ter.TecPATH_DRY {
+		t.Fatalf("withdrawalAmounts() = %v, want tecPATH_DRY", result)
+	}
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -445,18 +445,18 @@ and XChain backlog, which is outside this diff.
 
 PR: https://github.com/LeJamon/go-xrpl/pull/1319
 
-# Issue #1323 — v3.0.0 VaultCreate replay divergence
+# Issue #1323 — v3.0.0 Vault replay and transaction conformance
 
 ## Plan
 
 - [x] Rebase the work on a clean branch from `origin/v3.0.0`.
 - [x] Check pseudo-account, Vault, and directory behavior against local rippled 3.2.0.
-- [x] Diagnose every object in the ledger 3025004 replay finding.
-- [x] Omit default-zero `AssetsMaximum` from newly created Vault SLEs.
-- [x] Restore metadata-omitted required fields and correct Vault/MPT issuance directory reconstruction.
-- [x] Add focused engine and replay reconstruction regressions.
-- [x] Run focused tests, broader replay/Vault tests, vet, lint, and build.
-- [x] Review the final diff, commit, push, and open a draft PR against `v3.0.0`.
+- [x] Diagnose every object in the supplied replay findings, including ledger 3025004 and the offer-directory divergences.
+- [x] Audit all six Vault transactions and shared helpers against rippled 3.2.0.
+- [x] Implement the 22 NUMBER, validation, authorization, rounding, reserve, holding, and cleanup corrections.
+- [x] Add focused transaction, invariant, parser, serialization, and replay reconstruction regressions.
+- [x] Run focused tests, transaction suites, race tests, full build, vet, lint, and repository tests.
+- [x] Complete independent read-only conformance reviews of NUMBER/invariants, create/set/delete, and deposit/withdraw/clawback.
 
 ## Review
 
@@ -464,13 +464,24 @@ PR: https://github.com/LeJamon/go-xrpl/pull/1319
 - Checked protocol behavior against a clean local rippled 3.2.0 worktree at
   `3c43f4614f87965298773279ff5b85d4c56c637b`.
 - Confirmed that pseudo-account `Balance` and `Sequence`, the XRP Vault `Asset`,
-  and both directory memberships in the VM finding are valid rippled state.
-  The real engine divergence is the serialized default-zero `AssetsMaximum`.
-- Added byte-level replay reconstruction coverage for the ledger 3025004 object
-  layout and lifecycle coverage for create/set/reset of `AssetsMaximum`.
-- Focused replay/Vault tests, race tests, `just vet`, `just lint`, and
-  `just build-all` pass.
-- `go test ./...` passes outside the existing `internal/testing/conformance`
-  Batch, Vault, and XChain backlog; those unrelated scenarios remain failing.
+  and both directory memberships in the VM finding are valid rippled state. The
+  original engine divergence is the serialized default-zero `AssetsMaximum`.
+- Corrected fix-aware large/legacy NUMBER arithmetic and serialization, asset
+  association, Vault invariant reconciliation, JSON field presence, and
+  malformed `AssetsMaximum` parsing.
+- Matched rippled behavior across VaultCreate, VaultSet, VaultDelete,
+  VaultDeposit, VaultWithdraw, and VaultClawback, including TER precedence,
+  private-domain and MPT authorization, freeze/lock inheritance, share/asset
+  rounding, reserve boundaries, owner counts, and ledger-object cleanup.
+- Added byte-level reconstruction coverage for ledger 3025004 plus focused
+  regressions for every independently identified discrepancy.
+- `go test ./internal/tx/... ./internal/testing/vault -count=1`, focused race
+  tests, `just vet`, `just lint`, and `just build-all` pass.
+- `go test ./... -count=1` passes every package except the existing generated
+  `internal/testing/conformance` Vault, Batch, and XChain backlog. The focused
+  Vault integration and transaction suites pass.
+- A local replay was not rerun because this machine does not contain the VM's
+  replay database; the supplied findings are covered with byte-level and
+  transaction-level regressions.
 
 PR: https://github.com/LeJamon/go-xrpl/pull/1324

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -444,3 +444,33 @@ all packages except the existing `internal/testing/conformance` Vault, Batch,
 and XChain backlog, which is outside this diff.
 
 PR: https://github.com/LeJamon/go-xrpl/pull/1319
+
+# Issue #1323 — v3.0.0 VaultCreate replay divergence
+
+## Plan
+
+- [x] Rebase the work on a clean branch from `origin/v3.0.0`.
+- [x] Check pseudo-account, Vault, and directory behavior against local rippled 3.2.0.
+- [x] Diagnose every object in the ledger 3025004 replay finding.
+- [x] Omit default-zero `AssetsMaximum` from newly created Vault SLEs.
+- [x] Restore metadata-omitted required fields and correct Vault/MPT issuance directory reconstruction.
+- [x] Add focused engine and replay reconstruction regressions.
+- [x] Run focused tests, broader replay/Vault tests, vet, lint, and build.
+- [x] Review the final diff, commit, push, and open a draft PR against `v3.0.0`.
+
+## Review
+
+- Based on `origin/v3.0.0` at `c2c4abfa61c274f6da64451b323bb54fc44ced5b`.
+- Checked protocol behavior against a clean local rippled 3.2.0 worktree at
+  `3c43f4614f87965298773279ff5b85d4c56c637b`.
+- Confirmed that pseudo-account `Balance` and `Sequence`, the XRP Vault `Asset`,
+  and both directory memberships in the VM finding are valid rippled state.
+  The real engine divergence is the serialized default-zero `AssetsMaximum`.
+- Added byte-level replay reconstruction coverage for the ledger 3025004 object
+  layout and lifecycle coverage for create/set/reset of `AssetsMaximum`.
+- Focused replay/Vault tests, race tests, `just vet`, `just lint`, and
+  `just build-all` pass.
+- `go test ./...` passes outside the existing `internal/testing/conformance`
+  Batch, Vault, and XChain backlog; those unrelated scenarios remain failing.
+
+PR: https://github.com/LeJamon/go-xrpl/pull/1324


### PR DESCRIPTION
## Summary

- fixes ledger replay reconstruction differences for Vault objects, owner directories, pseudo accounts, and default-valued serialized fields
- aligns Vault NUMBER parsing, arithmetic modes, binary serialization, and invariant accounting with rippled 3.2.0
- audits and fixes all six Vault transaction families: Create, Set, Deposit, Withdraw, Clawback, and Delete
- matches rippled behavior for field presence, authorization and credentials, transferability, freeze/lock handling, reserve/owner counts, MPT and IOU holdings, rounding, overflow, deletion integrity, and TER precedence
- adds focused regression and conformance tests for the 22 audited discrepancies

## Reference

Protocol behavior was checked against the clean local rippled 3.2.0 tag at `3c43f4614f87965298773279ff5b85d4c56c637b`.

## Verification

- `go test ./internal/tx/vault ./internal/ledger/state ./internal/tx/invariants ./internal/tx/mptutil -count=1`
- `go test ./internal/tx/... ./internal/testing/vault -count=1`
- `go test -race ./internal/tx/vault ./internal/ledger/state ./internal/tx/invariants ./internal/tx/mptutil -count=1`
- `just vet`
- `just lint`
- `just build-all`
- `git diff origin/v3.0.0 --check`

The complete `go test ./... -count=1` run passes all packages except the repository's existing generated `internal/testing/conformance` Vault/Batch/XChain backlog. The focused Vault transaction and integration suites pass.

The VM replay database is not present on this machine, so the original replay sequence could not be rerun locally; the supplied replay findings are covered by focused regressions.

Fixes #1323