### PR TITLE
Fix AMMCreate replay default reconstruction

### DIFF
--- a/internal/replaytool/replay_reconstruct.go
+++ b/internal/replaytool/replay_reconstruct.go
@@ -144,7 +144,7 @@ func applyAffectedNode(
 			if let, ok := fields["LedgerEntryType"]; ok {
 				obj["LedgerEntryType"] = let
 			}
-			fillRequiredDefaults(obj, entryType)
+			fillCreatedDefaults(obj, entryType)
 			fillBookDirectoryDefaults(obj, entryType)
 			threadPreviousTxn(obj, entryType, txHash, ledgerSeq)
 			recordMembership(deltas, idx, entryType, obj, true)

--- a/internal/replaytool/replay_reconstruct_defaults.go
+++ b/internal/replaytool/replay_reconstruct_defaults.go
@@ -43,12 +43,12 @@ func isThreadedType(entryType string) bool {
 	return true
 }
 
-// requiredField is one soeREQUIRED ledger-entry field whose STObject default (a
+// createdField is one ledger-entry field whose STObject default (a
 // "zero" that rippled's isDefault() reports true) is omitted from a CreatedNode's
-// NewFields, even though the real serialized SLE always carries it. Value is the
-// form binarycodec.Encode accepts for that zero, identical to the bytes
+// NewFields, even though the real serialized SLE carries it. Value is the form
+// binarycodec.Encode accepts for that zero, identical to the bytes
 // binarycodec.Decode would have produced had the field been present.
-type requiredField struct {
+type createdField struct {
 	Name  string
 	Value any
 }
@@ -71,14 +71,15 @@ type requiredField struct {
 // level).
 //
 // Representations: UInt32 -> int(0); UInt64 -> "0" (lowercase hex, no leading
-// zeros, == binarycodec UInt64.ToJSON); native Amount -> "0" (drops).
+// zeros, == binarycodec UInt64.ToJSON); native Amount -> "0" (drops); Issue ->
+// {"currency":"XRP"}.
 //
 // DirectoryNode deliberately carries only Flags: its Indexes (sMD_Never) never
 // appears in metadata and is reconstructed from object membership instead (see
 // replay_reconstruct_dir.go); RootIndex (sMD_Always) is always already present;
 // the soeOPTIONAL book fields a book directory drops are restored by
 // fillBookDirectoryDefaults.
-var requiredDefaults = map[string][]requiredField{
+var requiredDefaults = map[string][]createdField{
 	"AccountRoot": {
 		{Name: "Sequence", Value: 0},
 		{Name: "Balance", Value: "0"},
@@ -166,6 +167,8 @@ var requiredDefaults = map[string][]requiredField{
 	"AMM": {
 		{Name: "Flags", Value: 0},
 		{Name: "OwnerNode", Value: "0"},
+		{Name: "Asset", Value: map[string]any{"currency": "XRP"}},
+		{Name: "Asset2", Value: map[string]any{"currency": "XRP"}},
 	},
 	"MPTokenIssuance": {
 		{Name: "Flags", Value: 0},
@@ -200,12 +203,27 @@ var requiredDefaults = map[string][]requiredField{
 	},
 }
 
-// fillRequiredDefaults adds every soeREQUIRED default-zero field for entryType
-// that obj does not already carry. A soeREQUIRED field absent from a CreatedNode's
-// NewFields is, by rippled's rule, at its default — so re-adding the default zero
-// is exact.
-func fillRequiredDefaults(obj map[string]any, entryType string) {
+// explicitlyCreatedDefaults lists optional fields that the sole creation path
+// always writes, including when their value is zero. CreatedNode.NewFields drops
+// those zero values, but the canonical SLE retains the explicitly present field.
+var explicitlyCreatedDefaults = map[string][]createdField{
+	"RippleState": {
+		{Name: "LowNode", Value: "0"},
+		{Name: "HighNode", Value: "0"},
+	},
+}
+
+// fillCreatedDefaults restores both required default-zero fields and optional
+// defaults that the entry's constructor always writes. An absent field in
+// CreatedNode.NewFields is therefore known to carry the listed default in the
+// canonical SLE.
+func fillCreatedDefaults(obj map[string]any, entryType string) {
 	for _, f := range requiredDefaults[entryType] {
+		if _, present := obj[f.Name]; !present {
+			obj[f.Name] = f.Value
+		}
+	}
+	for _, f := range explicitlyCreatedDefaults[entryType] {
 		if _, present := obj[f.Name]; !present {
 			obj[f.Name] = f.Value
 		}

--- a/internal/replaytool/replay_reconstruct_test.go
+++ b/internal/replaytool/replay_reconstruct_test.go
@@ -304,6 +304,153 @@ func TestReconstructFromMeta_CreatedOfferDefaults(t *testing.T) {
 	}
 }
 
+func TestApplyAffectedNode_AMMCreateDefaults(t *testing.T) {
+	const (
+		ammIndex   = "00000000000000000000000000000000000000000000000000000000000000A0"
+		line1Index = "00000000000000000000000000000000000000000000000000000000000000A1"
+		line2Index = "00000000000000000000000000000000000000000000000000000000000000A2"
+	)
+
+	stateMap := putAll(t, nil)
+	deltas := map[[32]byte]*dirDelta{}
+	deletedDirs := map[[32]byte]bool{}
+	txHash := mustIndex(t, testTxHashHex)
+
+	asset2 := map[string]any{
+		"currency": "USD",
+		"issuer":   testAccount,
+	}
+	lpTokens := map[string]any{
+		"value":    "1000",
+		"currency": "039C99CD9AB0B70B32ECDA51EAAE471625608EA2",
+		"issuer":   testAccount,
+	}
+	ammNode := map[string]any{"CreatedNode": map[string]any{
+		"LedgerEntryType": "AMM",
+		"LedgerIndex":     ammIndex,
+		"NewFields": map[string]any{
+			"Account":        testAccount,
+			"LPTokenBalance": lpTokens,
+			"Asset2":         asset2,
+		},
+	}}
+
+	lineFields := func(currency string) map[string]any {
+		return map[string]any{
+			"Flags": uint32(0x00110000),
+			"Balance": map[string]any{
+				"value":    "10",
+				"currency": currency,
+				"issuer":   state.AccountOneAddress,
+			},
+			"LowLimit": map[string]any{
+				"value":    "0",
+				"currency": currency,
+				"issuer":   testAccount,
+			},
+			"HighLimit": map[string]any{
+				"value":    "0",
+				"currency": currency,
+				"issuer":   state.AccountOneAddress,
+			},
+		}
+	}
+	line1Fields := lineFields("USD")
+	line2Fields := lineFields("EUR")
+	line1Node := map[string]any{"CreatedNode": map[string]any{
+		"LedgerEntryType": "RippleState",
+		"LedgerIndex":     line1Index,
+		"NewFields":       line1Fields,
+	}}
+	line2Node := map[string]any{"CreatedNode": map[string]any{
+		"LedgerEntryType": "RippleState",
+		"LedgerIndex":     line2Index,
+		"NewFields":       line2Fields,
+	}}
+
+	for _, node := range []map[string]any{ammNode, line1Node, line2Node} {
+		if err := applyAffectedNode(stateMap, node, txHash, testLedgerSeq, deltas, deletedDirs); err != nil {
+			t.Fatalf("applyAffectedNode: %v", err)
+		}
+	}
+
+	wantAMM := map[string]any{
+		"LedgerEntryType":   "AMM",
+		"Account":           testAccount,
+		"Flags":             0,
+		"LPTokenBalance":    lpTokens,
+		"Asset":             map[string]any{"currency": "XRP"},
+		"Asset2":            asset2,
+		"OwnerNode":         "0",
+		"PreviousTxnID":     testTxHashHex,
+		"PreviousTxnLgrSeq": testLedgerSeq,
+	}
+	assertEntryBytes(t, stateMap, mustIndex(t, ammIndex), encodeSLE(t, wantAMM), "AMM")
+
+	for _, line := range []struct {
+		index  string
+		fields map[string]any
+	}{
+		{line1Index, line1Fields},
+		{line2Index, line2Fields},
+	} {
+		want := copyFields(line.fields)
+		want["LedgerEntryType"] = "RippleState"
+		want["LowNode"] = "0"
+		want["HighNode"] = "0"
+		want["PreviousTxnID"] = testTxHashHex
+		want["PreviousTxnLgrSeq"] = testLedgerSeq
+		assertEntryBytes(t, stateMap, mustIndex(t, line.index), encodeSLE(t, want), "RippleState")
+	}
+}
+
+func TestApplyAffectedNode_AMMAsset2Default(t *testing.T) {
+	const index = "00000000000000000000000000000000000000000000000000000000000000AB"
+	asset := map[string]any{
+		"mpt_issuance_id": "BAADF00DBAADF00DBAADF00DBAADF00DBAADF00DBAADF00D",
+	}
+	lpTokens := map[string]any{
+		"value":    "1000",
+		"currency": "039C99CD9AB0B70B32ECDA51EAAE471625608EA2",
+		"issuer":   testAccount,
+	}
+	node := map[string]any{"CreatedNode": map[string]any{
+		"LedgerEntryType": "AMM",
+		"LedgerIndex":     index,
+		"NewFields": map[string]any{
+			"Account":        testAccount,
+			"LPTokenBalance": lpTokens,
+			"Asset":          asset,
+		},
+	}}
+	stateMap := putAll(t, nil)
+
+	err := applyAffectedNode(
+		stateMap,
+		node,
+		mustIndex(t, testTxHashHex),
+		testLedgerSeq,
+		map[[32]byte]*dirDelta{},
+		map[[32]byte]bool{},
+	)
+	if err != nil {
+		t.Fatalf("applyAffectedNode: %v", err)
+	}
+
+	want := map[string]any{
+		"LedgerEntryType":   "AMM",
+		"Account":           testAccount,
+		"Flags":             0,
+		"LPTokenBalance":    lpTokens,
+		"Asset":             asset,
+		"Asset2":            map[string]any{"currency": "XRP"},
+		"OwnerNode":         "0",
+		"PreviousTxnID":     testTxHashHex,
+		"PreviousTxnLgrSeq": testLedgerSeq,
+	}
+	assertEntryBytes(t, stateMap, mustIndex(t, index), encodeSLE(t, want), "AMM")
+}
+
 // TestReconstructFromMeta_DirectoryIndexes covers the directory-page path, whose
 // sfIndexes is sMD_Never and so absent from metadata: an owner directory (kept
 // sorted) gains a created Ticket, and an order-book directory (insertion-ordered)

--- a/internal/testing/amm/amm_create_metadata_test.go
+++ b/internal/testing/amm/amm_create_metadata_test.go
@@ -1,0 +1,47 @@
+package amm_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/testing/amm"
+	"github.com/LeJamon/go-xrpl/internal/testing/metadata"
+)
+
+func TestAMMCreateMetadataOmitsDefaultFields(t *testing.T) {
+	env := amm.NewAMMTestEnv(t)
+	env.FundWithIOUs(30_000, 0)
+	env.Close()
+
+	result := env.Submit(amm.AMMCreate(
+		env.Alice,
+		amm.XRPAmount(10_000),
+		amm.IOUAmount(env.GW, "USD", 10_000),
+	).Build())
+	if !result.Success {
+		t.Fatalf("AMMCreate: %s - %s", result.Code, result.Message)
+	}
+
+	ammNode := metadata.FindNode(result.Metadata, "CreatedNode", "AMM")
+	if ammNode == nil {
+		t.Fatal("AMMCreate metadata has no created AMM node")
+	}
+	if _, present := ammNode.NewFields["Asset"]; present {
+		t.Error("default XRP Asset must be omitted from AMM NewFields")
+	}
+	if _, present := ammNode.NewFields["Asset2"]; !present {
+		t.Error("non-default Asset2 must be present in AMM NewFields")
+	}
+
+	lines := metadata.FindNodes(result.Metadata, "CreatedNode", "RippleState")
+	if len(lines) != 2 {
+		t.Fatalf("created RippleState nodes = %d, want 2", len(lines))
+	}
+	for _, line := range lines {
+		if _, present := line.NewFields["LowNode"]; present {
+			t.Errorf("RippleState %s includes default LowNode", line.LedgerIndex)
+		}
+		if _, present := line.NewFields["HighNode"]; present {
+			t.Errorf("RippleState %s includes default HighNode", line.LedgerIndex)
+		}
+	}
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -485,3 +485,47 @@ PR: https://github.com/LeJamon/go-xrpl/pull/1319
   transaction-level regressions.
 
 PR: https://github.com/LeJamon/go-xrpl/pull/1324
+
+# AMMCreate replay default-field conformance
+
+Target: `origin/v3.0.0` at
+`13080bc66fe678314f7633f65caf36f3737e3564`. Behavioral oracle: clean local
+rippled `3.2.0` worktree at
+`3c43f4614f87965298773279ff5b85d4c56c637b`.
+
+## Plan
+
+- [x] Trace AMMCreate construction of the AMM and both RippleState objects.
+- [x] Compare all conditionally present fields with rippled 3.2.0 and its tests.
+- [x] Reproduce the XRP `Asset` and zero trust-line node field divergences.
+- [x] Implement the minimal metadata-reconstruction fix and audit adjacent
+      AMMCreate default fields.
+- [x] Run focused AMM and serialization tests, transaction tests, vet, lint,
+      and build.
+- [x] Review the final diff and record exact results below.
+
+## Review
+
+- Root cause: AMMCreate and RippleState serialization already match rippled.
+  Rippled stores required XRP AMM assets and explicitly written zero
+  `LowNode`/`HighNode` values in the SLE, but omits them from
+  `CreatedNode.NewFields` because their serialized values are defaults. Replay
+  reconstruction was treating those deliberately partial NewFields as the
+  complete object.
+- Fix: restore default XRP for either required AMM asset slot and restore absent
+  zero node hints for newly created RippleState objects before re-encoding.
+- Rippled 3.2.0 references checked: `AMMCreate.cpp`, `ApplyStateTable.cpp`,
+  `RippleStateHelpers.cpp`, `STIssue.cpp`, `STInteger.h`, and the AMM/RippleState
+  ledger-entry formats.
+- Regression coverage: byte-level CreatedNode reconstruction for XRP/IOU and
+  XRP/MPT AMMs, both XRP/IOU trust lines, and end-to-end AMMCreate metadata
+  omission behavior.
+- Passed: replaytool tests; all AMM transaction and integration tests; all
+  `internal/tx/...` tests; focused race tests; `just vet`; required and advisory
+  golangci-lint configurations; `just build-all`; `git diff --check`.
+- Full `go test ./... -count=1 -timeout 15m` passed every package except the
+  existing conformance corpus failures under Vault, XChain, and XChainSim,
+  which are listed in `scripts/conformance-out-of-scope.txt`.
+- The original ledger 3025006 replay was not rerun because its VM database is
+  not present locally; the supplied field-level divergence is covered directly
+  by the byte-level reconstruction tests.


### PR DESCRIPTION
## Summary

- restore default XRP in either required AMM asset slot when rebuilding CreatedNodes from transaction metadata
- restore zero LowNode and HighNode fields for newly created RippleState objects
- add byte-level replay regressions for XRP/IOU and XRP/MPT AMMs
- add an end-to-end AMMCreate metadata regression

## Root cause

AMMCreate and RippleState serialization already match rippled 3.2.0. Rippled stores the required XRP AMM asset and explicitly written zero directory-node hints in the canonical SLE, but omits those default-valued fields from CreatedNode.NewFields.

Replay reconstruction treated NewFields as the complete object, so the reconstructed AMM and RippleState blobs omitted fields that are present in the canonical ledger objects.

## Behavior

The transaction engine and metadata emitters are unchanged. The replay reconstructor now restores the fields that are known to be present in a newly created SLE even when rippled metadata omits their default values.

## Validation

- go test ./internal/replaytool -count=1
- go test ./internal/tx/amm/... ./internal/testing/amm -count=1
- go test ./internal/tx/... -count=1
- go test -race -count=1 ./internal/replaytool
- focused AMM race suite
- just vet
- golangci-lint run --config .golangci.yml
- just lint
- just build-all
- git diff --check

The full go test ./... run passed all packages except the documented out-of-scope Vault, XChain, and XChainSim conformance suites. The original ledger 3025006 replay was not rerun because its VM database is not available locally; its supplied field-level divergence is covered byte-for-byte by the new replay tests.