### PR TITLE
fix: serialize large transaction metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
         run: bash scripts/consensus-smoke/smoke.sh
         env:
           GOXRPL_IMAGE: goxrpl:latest
-          RIPPLED_IMAGE: rippleci/rippled:2.6.2
+          RIPPLED_IMAGE: xrpllabsofficial/xrpld:3.2.0
           PAYMENT_COUNT: "3"
           MIN_SEQ_EMPTY: "15"
           BOOT_TIMEOUT: "240"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,7 +70,7 @@ jobs:
         run: bash scripts/consensus-smoke/smoke.sh
         env:
           GOXRPL_IMAGE: goxrpl:latest
-          RIPPLED_IMAGE: rippleci/rippled:2.6.2
+          RIPPLED_IMAGE: xrpllabsofficial/xrpld:3.2.0
           PAYMENT_COUNT: "25"
           MIN_SEQ_EMPTY: "40"
           BOOT_TIMEOUT: "360"

--- a/codec/binarycodec/codec.go
+++ b/codec/binarycodec/codec.go
@@ -74,6 +74,17 @@ func hexUpper(src []byte) string {
 // EncodeBytes does not mutate the caller-supplied map. An unknown field name
 // is treated as an error rather than silently dropped — see [ErrUnknownField].
 func EncodeBytes(json map[string]any) ([]byte, error) {
+	return encodeBytes(json, false)
+}
+
+// EncodeBytesTrusted encodes a protocol object constructed by trusted internal
+// code. Unlike EncodeBytes, it does not apply the JSON-input-only 512-element
+// array limit. Unknown fields and all binary-format validation remain enforced.
+func EncodeBytesTrusted(json map[string]any) ([]byte, error) {
+	return encodeBytes(json, true)
+}
+
+func encodeBytes(json map[string]any, trusted bool) ([]byte, error) {
 	defs := definitions.Get()
 	for k := range json {
 		if !defs.HasField(k) {
@@ -81,7 +92,11 @@ func EncodeBytes(json map[string]any) ([]byte, error) {
 		}
 	}
 
-	st := types.NewSTObject(serdes.NewBinarySerializer(serdes.DefaultFieldIDCodec()))
+	serializer := serdes.NewBinarySerializer(serdes.DefaultFieldIDCodec())
+	st := types.NewSTObject(serializer)
+	if trusted {
+		st = types.NewTrustedSTObject(serializer)
+	}
 	return st.FromJSON(json)
 }
 

--- a/codec/binarycodec/codec_arraycap_test.go
+++ b/codec/binarycodec/codec_arraycap_test.go
@@ -78,3 +78,42 @@ func TestEncode_JSONArraySizeCap(t *testing.T) {
 		}
 	})
 }
+
+func TestEncodeBytesTrusted_BypassesJSONInputArrayCap(t *testing.T) {
+	const issuer = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+	hashes := make([]any, 513)
+	for i := range hashes {
+		hashes[i] = strings.Repeat("A", 64)
+	}
+	memos := make([]any, 513)
+	for i := range memos {
+		memos[i] = map[string]any{"Memo": map[string]any{"MemoData": "AB"}}
+	}
+	path := make([]any, 513)
+	for i := range path {
+		path[i] = map[string]any{"account": issuer}
+	}
+
+	tests := []struct {
+		name  string
+		value map[string]any
+	}{
+		{name: "Vector256", value: map[string]any{"Amendments": hashes}},
+		{name: "STArray", value: map[string]any{"Memos": memos}},
+		{name: "nested Vector256", value: map[string]any{
+			"ModifiedNode": map[string]any{
+				"FinalFields": map[string]any{"Amendments": hashes},
+			},
+		}},
+		{name: "inner PathSet", value: map[string]any{"Paths": []any{path}}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := EncodeBytesTrusted(tc.value); err != nil {
+				t.Fatalf("trusted encode rejected protocol object: %v", err)
+			}
+		})
+	}
+}

--- a/codec/binarycodec/types/pathset.go
+++ b/codec/binarycodec/types/pathset.go
@@ -34,7 +34,9 @@ func serializePathCurrency(currency string) ([]byte, error) {
 
 // PathSet is the binary codec for the PathSet field type — the set of payment
 // paths carried by a Payment transaction.
-type PathSet struct{}
+type PathSet struct {
+	skipJSONArrayLimit bool
+}
 
 // ErrInvalidPathSet is an error that's thrown when an invalid path set is provided.
 var ErrInvalidPathSet = errors.New("invalid path set: expected [][]any")
@@ -65,9 +67,11 @@ func (p PathSet) FromJSON(json any) ([]byte, error) {
 
 	// rippled caps each inner path (STI_PATHSET) at maxSTParsedJSONArraySize as
 	// well as the outer array; the outer array is capped by checkJSONArraySize.
-	for i, path := range outer {
-		if inner, ok := path.([]any); ok && len(inner) > MaxJSONArrayElements {
-			return nil, &JSONArrayTooLargeError{Field: fmt.Sprintf("Paths[%d]", i)}
+	if !p.skipJSONArrayLimit {
+		for i, path := range outer {
+			if inner, ok := path.([]any); ok && len(inner) > MaxJSONArrayElements {
+				return nil, &JSONArrayTooLargeError{Field: fmt.Sprintf("Paths[%d]", i)}
+			}
 		}
 	}
 

--- a/codec/binarycodec/types/serialized_type.go
+++ b/codec/binarycodec/types/serialized_type.go
@@ -65,3 +65,14 @@ func SerializedTypeFor(t string) SerializedType {
 	}
 	return nil
 }
+
+func setSkipJSONArrayLimit(st SerializedType, skip bool) {
+	switch v := st.(type) {
+	case *STObject:
+		v.skipJSONArrayLimit = skip
+	case *STArray:
+		v.skipJSONArrayLimit = skip
+	case *PathSet:
+		v.skipJSONArrayLimit = skip
+	}
+}

--- a/codec/binarycodec/types/st_array.go
+++ b/codec/binarycodec/types/st_array.go
@@ -15,7 +15,9 @@ const (
 )
 
 // STArray represents an array of STObject instances.
-type STArray struct{}
+type STArray struct {
+	skipJSONArrayLimit bool
+}
 
 // ErrNotSTObjectInSTArray is returned when a non-STObject value is found in an STArray.
 var ErrNotSTObjectInSTArray = errors.New("STArray fields must be STObjects")
@@ -42,6 +44,7 @@ func (t *STArray) FromJSON(json any) ([]byte, error) {
 	var sink []byte
 	for _, v := range elems {
 		st := NewSTObject(serdes.NewBinarySerializer(serdes.DefaultFieldIDCodec()))
+		st.skipJSONArrayLimit = t.skipJSONArrayLimit
 		b, err := st.FromJSON(v)
 		if err != nil {
 			return nil, err

--- a/codec/binarycodec/types/st_object.go
+++ b/codec/binarycodec/types/st_object.go
@@ -21,12 +21,20 @@ const maxNestingDepth = 10
 // and the associated value is the field's value. This structure allows us to represent nested
 // and complex structures of the Ripple protocol.
 type STObject struct {
-	binarySerializer *serdes.BinarySerializer
+	binarySerializer   *serdes.BinarySerializer
+	skipJSONArrayLimit bool
 }
 
 // NewSTObject returns a new STObject with the given binary serializer.
 func NewSTObject(bs *serdes.BinarySerializer) *STObject {
 	return &STObject{binarySerializer: bs}
+}
+
+// NewTrustedSTObject returns an STObject for protocol objects constructed by
+// trusted internal code. It preserves all structural validation while skipping
+// the JSON-input-only array element limit.
+func NewTrustedSTObject(bs *serdes.BinarySerializer) *STObject {
+	return &STObject{binarySerializer: bs, skipJSONArrayLimit: true}
 }
 
 // FromJSON converts a JSON object into a serialized byte slice.
@@ -52,8 +60,11 @@ func (t *STObject) FromJSON(json any) ([]byte, error) {
 		}
 
 		st := SerializedTypeFor(v.Type)
-		if err := checkJSONArraySize(v.FieldName, v.Type, fimap[v]); err != nil {
-			return nil, err
+		setSkipJSONArrayLimit(st, t.skipJSONArrayLimit)
+		if !t.skipJSONArrayLimit {
+			if err := checkJSONArraySize(v.FieldName, v.Type, fimap[v]); err != nil {
+				return nil, err
+			}
 		}
 		b, err := st.FromJSON(fimap[v])
 		if err != nil {

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -730,6 +730,32 @@ func (l *Ledger) MutableSnapshot() (*Ledger, error) {
 	}, nil
 }
 
+// MutableSnapshotUnflushed returns a mutable copy without persisting dirty
+// SHAMap nodes, for short-lived transactional staging that is then adopted or
+// discarded.
+func (l *Ledger) MutableSnapshotUnflushed() (*Ledger, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	stateMapCopy, err := l.stateMap.SnapshotMutableUnflushed()
+	if err != nil {
+		return nil, err
+	}
+	txMapCopy, err := l.txMap.SnapshotMutableUnflushed()
+	if err != nil {
+		return nil, err
+	}
+	return &Ledger{
+		stateMap:       stateMapCopy,
+		txMap:          txMapCopy,
+		header:         l.header,
+		fees:           l.fees,
+		state:          l.state,
+		dropsDestroyed: l.dropsDestroyed,
+		rules:          l.rules,
+	}, nil
+}
+
 func (l *Ledger) StateMapHash() ([32]byte, error) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()

--- a/internal/ledger/openledger/apply.go
+++ b/internal/ledger/openledger/apply.go
@@ -116,29 +116,13 @@ type ApplyConfig struct {
 // inline-queueing during a replay would re-enter the queue path we are
 // supposed to be draining.
 
-// applyAndClassify runs a single tx through bp against view and classifies
-// the engine result per the selected Mode.
-//
-// OpenLedgerMode: tec is always Success+commit, matching
-// OpenLedger::apply_one (OpenLedger.cpp:170-189) where
-// result.applied = isTesSuccess || isTecClaim (Transactor.cpp:1108-1218).
-//
-// BuildLedgerMode: tec is Retry on retriable passes (certainRetry=true)
-// and Success+commit on the final non-retry pass — mirrors
-// BuildLedger.cpp's apply loop.
-//
-// Shared by ApplyTxs's per-pass inner loop and OpenLedger.Submit so the
-// success/tec/retry classification lives in exactly one place.
-func applyAndClassify(view *ledger.Ledger, bp *txengine.BlockProcessor, transaction tx.Transaction, blob []byte, certainRetry bool, mode Mode, logger xrpllog.Logger) Result {
+// applyAndClassify runs a single transaction through bp. Applied results are
+// successful regardless of TER; tef/tem/tel results fail; all other non-applied
+// results retry. The engine's apply flags decide whether a tec result is applied.
+func applyAndClassify(bp *txengine.BlockProcessor, transaction tx.Transaction, blob []byte, mode Mode, logger xrpllog.Logger) Result {
 	result, applyErr := bp.ApplyTransaction(transaction, blob)
 	if applyErr != nil {
-		// Surface the error rather than swallowing it. A non-nil applyErr
-		// drops the tx (no commit, no retry) while the engine may already
-		// have mutated state — yielding a ledger with advanced state but the
-		// tx absent from the tx tree (an empty/short-tx-tree consensus fork,
-		// e.g. metadata that failed to binary-serialize). Logged loud so a
-		// divergence shows the underlying error + tx.
-		logger.Warn("apply error — tx dropped (state may be mutated)",
+		logger.Warn("apply error — staged transaction discarded",
 			"mode", mode,
 			"hash", fmt.Sprintf("%x", result.Hash[:8]),
 			"err", applyErr)
@@ -146,29 +130,12 @@ func applyAndClassify(view *ledger.Ledger, bp *txengine.BlockProcessor, transact
 	}
 	engineResult := result.ApplyResult.Result
 	switch {
-	case engineResult.IsSuccess():
-		if err := view.AddTransactionWithMeta(result.Hash, result.TxWithMetaBlob); err != nil {
-			logger.Warn("AddTransactionWithMeta failed for committed tx (tree out of sync with state)",
-				"hash", fmt.Sprintf("%x", result.Hash[:8]),
-				"ter", engineResult.String(),
-				"err", err)
-		}
+	case result.ApplyResult.Applied:
 		return ResultSuccess
-	case engineResult.IsTec():
-		if mode == BuildLedgerMode && certainRetry {
-			return ResultRetry
-		}
-		if err := view.AddTransactionWithMeta(result.Hash, result.TxWithMetaBlob); err != nil {
-			logger.Warn("AddTransactionWithMeta failed for committed tec tx (tree out of sync with state)",
-				"hash", fmt.Sprintf("%x", result.Hash[:8]),
-				"ter", engineResult.String(),
-				"err", err)
-		}
-		return ResultSuccess
-	case engineResult.ShouldRetry():
-		return ResultRetry
-	default:
+	case engineResult.IsTef(), engineResult.IsTem(), engineResult.IsTel():
 		return ResultFailure
+	default:
+		return ResultRetry
 	}
 }
 
@@ -209,7 +176,7 @@ func applyOneSingle(view *ledger.Ledger, transaction tx.Transaction, blob []byte
 	if logger == nil {
 		logger = xrpllog.Discard()
 	}
-	return applyAndClassify(view, bp, transaction, blob, retry, cfg.Mode, logger)
+	return applyAndClassify(bp, transaction, blob, cfg.Mode, logger)
 }
 
 func ApplyTxs(view *ledger.Ledger, txs []PendingTx, retries *[]PendingTx, cfg ApplyConfig) error {
@@ -283,7 +250,7 @@ func ApplyTxs(view *ledger.Ledger, txs []PendingTx, retries *[]PendingTx, cfg Ap
 		if view.TxExists(ptx.Hash) {
 			continue
 		}
-		switch applyAndClassify(view, bp, parsed[i], ptx.Blob, true, cfg.Mode, logger) {
+		switch applyAndClassify(bp, parsed[i], ptx.Blob, cfg.Mode, logger) {
 		case ResultRetry:
 			retrySet = append(retrySet, i)
 		}
@@ -307,7 +274,7 @@ func ApplyTxs(view *ledger.Ledger, txs []PendingTx, retries *[]PendingTx, cfg Ap
 			if parsed[idx] == nil {
 				continue
 			}
-			switch applyAndClassify(view, bp, parsed[idx], ptx.Blob, certainRetry, cfg.Mode, logger) {
+			switch applyAndClassify(bp, parsed[idx], ptx.Blob, cfg.Mode, logger) {
 			case ResultSuccess:
 				changes++
 			case ResultRetry:

--- a/internal/ledger/openledger/apply_test.go
+++ b/internal/ledger/openledger/apply_test.go
@@ -54,6 +54,52 @@ func freshView(t *testing.T, env *jtx.TestEnv) *ledger.Ledger {
 	return view
 }
 
+func TestTxqAdapter_ApplyTransaction_ContinuesTransactionIndex(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	carol := jtx.NewAccount("carol")
+	env.Fund(alice, bob, carol)
+	view := freshView(t, env)
+
+	sequence := env.Seq(alice)
+	transactions := []tx.Transaction{
+		payment.Pay(alice, bob, 1_000_000).Sequence(sequence).Build(),
+		payment.Pay(alice, carol, 1_000_000).Sequence(sequence + 1).Build(),
+	}
+	adapter := openledger.NewTxqAdapter(view, openledger.ApplyConfig{
+		BaseFee:                   10,
+		ReserveBase:               200_000_000,
+		ReserveIncrement:          50_000_000,
+		Rules:                     amendment.AllSupportedRules(),
+		SkipSignatureVerification: true,
+	})
+
+	for i, transaction := range transactions {
+		blob := buildSignedBlob(t, env, transaction, alice)
+		parsed, err := tx.ParseFromBinary(blob)
+		if err != nil {
+			t.Fatalf("parse transaction %d: %v", i, err)
+		}
+		parsed.SetRawBytes(blob)
+		result, applied := adapter.ApplyTransaction(parsed)
+		if !applied {
+			t.Fatalf("transaction %d result = %s, want applied", i, result)
+		}
+		applyResult := adapter.LastApplyResult()
+		if applyResult == nil || applyResult.Metadata == nil {
+			t.Fatalf("transaction %d has no metadata", i)
+		}
+		if applyResult.Metadata.TransactionIndex != uint32(i) {
+			t.Fatalf("transaction %d metadata index = %d, want %d",
+				i, applyResult.Metadata.TransactionIndex, i)
+		}
+	}
+	if view.TxCount() != uint32(len(transactions)) {
+		t.Fatalf("ledger transaction count = %d, want %d", view.TxCount(), len(transactions))
+	}
+}
+
 // TestApplyTxs_RetrySettles submits two dependent payments in the wrong
 // order. The first creates bob with a 1 XRP payment; the second sends
 // from bob. On pass 0 the bob→carol payment fails with terNO_ACCOUNT

--- a/internal/ledger/openledger/txqadapter.go
+++ b/internal/ledger/openledger/txqadapter.go
@@ -2,7 +2,6 @@ package openledger
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -175,6 +174,7 @@ func (a *TxqAdapter) ApplyTransaction(txn tx.Transaction) (ter.Result, bool) {
 		EnforceLoadFee:            true,
 	}
 	engine := txengine.NewEngine(a.view, engineCfg)
+	engine.SetBaseTxCount(a.view.TxCount())
 	bp := txengine.NewBlockProcessor(engine)
 
 	result, err := bp.ApplyTransaction(txn, blob)
@@ -187,22 +187,7 @@ func (a *TxqAdapter) ApplyTransaction(txn tx.Transaction) (ter.Result, bool) {
 	applyRes := result.ApplyResult
 	a.lastApply = &applyRes
 	engineResult := applyRes.Result
-	applied := engineResult.IsSuccess() || engineResult.IsTec()
-	if applied {
-		if werr := a.view.AddTransactionWithMeta(result.Hash, result.TxWithMetaBlob); werr != nil {
-			// The tx's state effects are already in the open view, but its blob
-			// is not in the tx map. Left silent, the next consensus round's
-			// proposal set omits it and the rebuilt open view loses the effects —
-			// a silently vanished transaction. Fail loudly and do not report it
-			// applied, so the caller doesn't treat effects-without-record as a
-			// committed tx.
-			if a.cfg.Logger != nil {
-				a.cfg.Logger.Error("txq apply: AddTransactionWithMeta failed; open view holds effects for an unrecorded tx",
-					"hash", fmt.Sprintf("%x", result.Hash[:8]), "ter", engineResult.String(), "err", werr)
-			}
-			return ter.TefINTERNAL, false
-		}
-	}
+	applied := applyRes.Applied
 	return engineResult, applied
 }
 

--- a/internal/replaytool/replay.go
+++ b/internal/replaytool/replay.go
@@ -476,11 +476,6 @@ func (r *replayRunner) executeReplayVerbose(state *StateFixture, env *EnvFixture
 				}
 			}
 		}
-
-		// Add transaction to ledger using the pre-computed hash and blob from BlockProcessor
-		if err := openLedger.AddTransactionWithMeta(blockTxResult.Hash, blockTxResult.TxWithMetaBlob); err != nil {
-			result.Errors = append(result.Errors, fmt.Sprintf("tx %d: failed to add to ledger: %v", txEntry.Index, err))
-		}
 	}
 
 	// Step 5: Close the ledger. Close() updates the LedgerHashes skip lists

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -739,11 +739,6 @@ func (r *replayRangeRunner) processBlock(
 
 		result.TxResults = append(result.TxResults, txInfo)
 
-		// Add to ledger
-		if err := openLedger.AddTransactionWithMeta(blockTxResult.Hash, blockTxResult.TxWithMetaBlob); err != nil {
-			result.Errors = append(result.Errors, fmt.Sprintf("tx %d: failed to add to ledger: %v", txEntry.TxIndex, err))
-		}
-
 		if r.verbose && r.decoded {
 			fmt.Fprintf(r.out, "        [%d] %-20s %-12s\n", txEntry.TxIndex, txInfo.TxType, txInfo.Result)
 		}

--- a/internal/tx/engine/block_processor.go
+++ b/internal/tx/engine/block_processor.go
@@ -94,7 +94,7 @@ func (bp *BlockProcessor) ApplyTransaction(transaction txcore.Transaction, txBlo
 		return result, fmt.Errorf("block processor requires a ledger-backed engine view")
 	}
 
-	staged, err := base.MutableSnapshot()
+	staged, err := base.MutableSnapshotUnflushed()
 	if err != nil {
 		return result, fmt.Errorf("snapshot ledger for transaction apply: %w", err)
 	}

--- a/internal/tx/engine/block_processor.go
+++ b/internal/tx/engine/block_processor.go
@@ -102,7 +102,6 @@ func (bp *BlockProcessor) ApplyTransaction(transaction txcore.Transaction, txBlo
 	stagedEngine.SetBaseTxCount(bp.engine.TxCount())
 	stagedEngine.invariantViolationHook = bp.engine.invariantViolationHook
 
-	// Apply the transaction using an unpublished ledger snapshot.
 	// Pseudo-transactions (Amendment, SetFee, UNLModify) use ApplyPseudo()
 	// since Apply() rejects them (matching rippled's passesLocalChecks).
 	var applyResult txcore.ApplyResult

--- a/internal/tx/engine/block_processor.go
+++ b/internal/tx/engine/block_processor.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"fmt"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 )
 
@@ -20,6 +21,8 @@ type BlockProcessor struct {
 
 	// txIndex tracks the current transaction index (0-based)
 	txIndex uint32
+
+	createTxWithMetaBlob func([]byte, *txcore.Metadata) ([]byte, error)
 }
 
 // BlockTxResult contains the result of applying a single transaction in a block
@@ -44,8 +47,9 @@ type BlockTxResult struct {
 // NewBlockProcessor creates a new BlockProcessor with the given engine
 func NewBlockProcessor(engine *Engine) *BlockProcessor {
 	return &BlockProcessor{
-		engine:  engine,
-		txIndex: 0,
+		engine:               engine,
+		txIndex:              0,
+		createTxWithMetaBlob: txcore.CreateTxWithMetaBlob,
 	}
 }
 
@@ -53,6 +57,7 @@ func NewBlockProcessor(engine *Engine) *BlockProcessor {
 // It handles:
 // - Calling the engine to apply the transaction
 // - Creating the tx+meta blob
+// - Publishing applied state and the transaction leaf atomically
 // The engine assigns TransactionIndex in metadata for applied transactions.
 func (bp *BlockProcessor) ApplyTransaction(transaction txcore.Transaction, txBlob []byte) (result BlockTxResult, err error) {
 	// Backstop for the consensus build loop: any panic escaping the engine's
@@ -84,25 +89,46 @@ func (bp *BlockProcessor) ApplyTransaction(transaction txcore.Transaction, txBlo
 	}
 	result.Hash = hash
 
-	// Apply the transaction using the engine.
+	base, ok := bp.engine.view.(*ledger.Ledger)
+	if !ok {
+		return result, fmt.Errorf("block processor requires a ledger-backed engine view")
+	}
+
+	staged, err := base.MutableSnapshot()
+	if err != nil {
+		return result, fmt.Errorf("snapshot ledger for transaction apply: %w", err)
+	}
+	stagedEngine := NewEngine(staged, bp.engine.config)
+	stagedEngine.SetBaseTxCount(bp.engine.TxCount())
+	stagedEngine.invariantViolationHook = bp.engine.invariantViolationHook
+
+	// Apply the transaction using an unpublished ledger snapshot.
 	// Pseudo-transactions (Amendment, SetFee, UNLModify) use ApplyPseudo()
 	// since Apply() rejects them (matching rippled's passesLocalChecks).
 	var applyResult txcore.ApplyResult
 	if transaction.TxType().IsPseudoTransaction() {
-		applyResult = bp.engine.ApplyPseudo(transaction)
+		applyResult = stagedEngine.ApplyPseudo(transaction)
 	} else {
-		applyResult = bp.engine.Apply(transaction)
+		applyResult = stagedEngine.Apply(transaction)
 	}
 	result.ApplyResult = applyResult
 
-	// Create the tx+meta blob for the transaction tree.
-	// The engine assigns TransactionIndex in metadata for applied transactions
-	// (matching rippled's txCount-based indexing), so we don't overwrite it here.
-	txWithMetaBlob, err := txcore.CreateTxWithMetaBlob(txBlob, applyResult.Metadata)
-	if err != nil {
-		return result, err
+	if applyResult.Applied {
+		// The engine assigns TransactionIndex in metadata for applied transactions
+		// (matching rippled's txCount-based indexing), so we don't overwrite it here.
+		txWithMetaBlob, err := bp.createTxWithMetaBlob(txBlob, applyResult.Metadata)
+		if err != nil {
+			return result, err
+		}
+		result.TxWithMetaBlob = txWithMetaBlob
+		if err := staged.AddTransactionWithMeta(hash, txWithMetaBlob); err != nil {
+			return result, fmt.Errorf("stage transaction metadata: %w", err)
+		}
+		if err := base.AdoptState(staged); err != nil {
+			return result, fmt.Errorf("commit transaction state and metadata: %w", err)
+		}
+		bp.engine.SetBaseTxCount(stagedEngine.TxCount())
 	}
-	result.TxWithMetaBlob = txWithMetaBlob
 
 	// Increment the processing order counter for the next transaction
 	bp.txIndex++

--- a/internal/tx/engine/block_processor_atomic_test.go
+++ b/internal/tx/engine/block_processor_atomic_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/shamap"
 )
 
 func TestBlockProcessor_MetadataSerializationFailureIsAtomic(t *testing.T) {
@@ -84,5 +85,35 @@ func TestBlockProcessor_MetadataSerializationFailureIsAtomic(t *testing.T) {
 	}
 	if !view.TxExists(succeeded.Hash) {
 		t.Fatal("successful transaction state was published without its transaction leaf")
+	}
+}
+
+func TestBlockProcessor_StagingDoesNotFlushBackedSHAMaps(t *testing.T) {
+	genesisResult, err := genesis.Create(genesis.DefaultConfig())
+	if err != nil {
+		t.Fatalf("create genesis: %v", err)
+	}
+	parent := ledger.FromGenesis(genesisResult.Header, genesisResult.StateMap, genesisResult.TxMap, drops.Fees{})
+	view, err := ledger.NewOpen(parent, time.Unix(0, 0))
+	if err != nil {
+		t.Fatalf("create open ledger: %v", err)
+	}
+	family := shamap.NewMemoryNodeStoreFamily()
+	family.SetMinimumLedgerSeq(view.Sequence() + 1)
+	view.SetStateMapFamily(family)
+	if _, err := view.MutableSnapshot(); !errors.Is(err, shamap.ErrStoreBelowMinimum) {
+		t.Fatalf("flushing snapshot error = %v, want %v", err, shamap.ErrStoreBelowMinimum)
+	}
+
+	bp := NewBlockProcessor(recoveryEngine(view, txcore.TapNONE))
+	result, err := bp.ApplyTransaction(recoveryTx(10, 1), []byte{0x12, 0x03})
+	if err != nil {
+		t.Fatalf("apply with backed SHAMap: %v", err)
+	}
+	if !result.ApplyResult.Applied {
+		t.Fatalf("transaction result = %s, want applied", result.ApplyResult.Result)
+	}
+	if view.TxCount() != 1 || !view.TxExists(result.Hash) {
+		t.Fatal("applied transaction was not committed atomically")
 	}
 }

--- a/internal/tx/engine/block_processor_atomic_test.go
+++ b/internal/tx/engine/block_processor_atomic_test.go
@@ -1,0 +1,88 @@
+package engine
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+func TestBlockProcessor_MetadataSerializationFailureIsAtomic(t *testing.T) {
+	genesisResult, err := genesis.Create(genesis.DefaultConfig())
+	if err != nil {
+		t.Fatalf("create genesis: %v", err)
+	}
+	parent := ledger.FromGenesis(genesisResult.Header, genesisResult.StateMap, genesisResult.TxMap, drops.Fees{})
+	view, err := ledger.NewOpen(parent, time.Unix(0, 0))
+	if err != nil {
+		t.Fatalf("create open ledger: %v", err)
+	}
+
+	accountID, err := state.DecodeAccountID(recoveryTestAccount)
+	if err != nil {
+		t.Fatalf("decode account: %v", err)
+	}
+	accountKey := keylet.Account(accountID)
+	before, err := view.Read(accountKey)
+	if err != nil {
+		t.Fatalf("read account before apply: %v", err)
+	}
+
+	engine := recoveryEngine(view, txcore.TapNONE)
+	bp := NewBlockProcessor(engine)
+	serializeErr := errors.New("forced metadata serialization failure")
+	bp.createTxWithMetaBlob = func([]byte, *txcore.Metadata) ([]byte, error) {
+		return nil, serializeErr
+	}
+
+	txn := recoveryTx(10, 1)
+	failed, err := bp.ApplyTransaction(txn, []byte{0x12, 0x03})
+	if !errors.Is(err, serializeErr) {
+		t.Fatalf("apply error = %v, want %v", err, serializeErr)
+	}
+	after, err := view.Read(accountKey)
+	if err != nil {
+		t.Fatalf("read account after failed apply: %v", err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatal("metadata serialization failure committed account state")
+	}
+	if view.TxCount() != 0 {
+		t.Fatalf("ledger transaction count = %d, want 0", view.TxCount())
+	}
+	if engine.TxCount() != 0 {
+		t.Fatalf("engine transaction count = %d, want 0", engine.TxCount())
+	}
+	if failed.Index != 0 {
+		t.Fatalf("failed transaction index = %d, want 0", failed.Index)
+	}
+	if view.TxExists(failed.Hash) {
+		t.Fatal("metadata serialization failure committed a transaction leaf")
+	}
+
+	bp.createTxWithMetaBlob = txcore.CreateTxWithMetaBlob
+	succeeded, err := bp.ApplyTransaction(txn, []byte{0x12, 0x03})
+	if err != nil {
+		t.Fatalf("apply after serialization failure: %v", err)
+	}
+	if !succeeded.ApplyResult.Applied {
+		t.Fatalf("subsequent transaction result = %s, want applied", succeeded.ApplyResult.Result)
+	}
+	if succeeded.Index != 0 || succeeded.ApplyResult.Metadata.TransactionIndex != 0 {
+		t.Fatalf("subsequent indexes = block %d metadata %d, want 0/0",
+			succeeded.Index, succeeded.ApplyResult.Metadata.TransactionIndex)
+	}
+	if view.TxCount() != 1 || engine.TxCount() != 1 {
+		t.Fatalf("transaction counts = ledger %d engine %d, want 1/1", view.TxCount(), engine.TxCount())
+	}
+	if !view.TxExists(succeeded.Hash) {
+		t.Fatal("successful transaction state was published without its transaction leaf")
+	}
+}

--- a/internal/tx/engine/engine_tefexception_test.go
+++ b/internal/tx/engine/engine_tefexception_test.go
@@ -2,8 +2,12 @@ package engine
 
 import (
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
@@ -96,8 +100,15 @@ func TestApply_PreflightPanic_YieldsTefException(t *testing.T) {
 // and the processor keeps working — a following good tx still applies. Mirrors
 // rippled applyTransactions' per-tx catch(std::exception): mark failed, continue.
 func TestBlockProcessor_ApplyPanic_BecomesErrorAndContinues(t *testing.T) {
-	view := newRecordingBaseView()
-	fundRecoveryAccount(t, view, 1_000_000, 1)
+	genesisResult, err := genesis.Create(genesis.DefaultConfig())
+	if err != nil {
+		t.Fatalf("create genesis: %v", err)
+	}
+	parent := ledger.FromGenesis(genesisResult.Header, genesisResult.StateMap, genesisResult.TxMap, drops.Fees{})
+	view, err := ledger.NewOpen(parent, time.Unix(0, 0))
+	if err != nil {
+		t.Fatalf("create open ledger: %v", err)
+	}
 
 	bp := NewBlockProcessor(recoveryEngine(view, txcore.TapNONE))
 

--- a/internal/tx/serialize.go
+++ b/internal/tx/serialize.go
@@ -124,12 +124,7 @@ func SerializeMetadata(meta *Metadata) ([]byte, error) {
 		return nil, nil
 	}
 
-	hexStr, err := binarycodec.Encode(metaMap)
-	if err != nil {
-		return nil, err
-	}
-
-	return hex.DecodeString(hexStr)
+	return binarycodec.EncodeBytesTrusted(metaMap)
 }
 
 // CreateTxWithMetaBlob creates the combined VL-encoded transaction + VL-encoded metadata blob

--- a/internal/tx/serialize_test.go
+++ b/internal/tx/serialize_test.go
@@ -2,10 +2,83 @@ package tx
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"math"
 	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
+
+func TestCreateTxWithMetaBlob_TrustedMetadataOverJSONLimit(t *testing.T) {
+	const (
+		inputOffers   = 500
+		deletedNodes  = 962
+		affectedNodes = 1027
+	)
+
+	offers := make([]any, inputOffers)
+	for i := range offers {
+		offers[i] = fmt.Sprintf("%064X", i+1)
+	}
+	txHex, err := binarycodec.Encode(map[string]any{
+		"TransactionType": "NFTokenCancelOffer",
+		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"Fee":             "10",
+		"Sequence":        uint32(1),
+		"SigningPubKey":   "",
+		"NFTokenOffers":   offers,
+	})
+	if err != nil {
+		t.Fatalf("encode NFTokenCancelOffer at protocol limit: %v", err)
+	}
+	txBlob, err := hex.DecodeString(txHex)
+	if err != nil {
+		t.Fatalf("decode transaction blob: %v", err)
+	}
+
+	nodes := make([]AffectedNode, affectedNodes)
+	for i := range nodes {
+		nodes[i] = AffectedNode{
+			NodeType:        "DeletedNode",
+			LedgerEntryType: "NFTokenOffer",
+			LedgerIndex:     fmt.Sprintf("%064X", i+1),
+		}
+		if i >= deletedNodes {
+			nodes[i].NodeType = "ModifiedNode"
+			nodes[i].LedgerEntryType = "AccountRoot"
+		}
+	}
+
+	combined, err := CreateTxWithMetaBlob(txBlob, &Metadata{
+		AffectedNodes:     nodes,
+		TransactionResult: ter.TesSUCCESS,
+	})
+	if err != nil {
+		t.Fatalf("create tx+meta blob with %d affected nodes: %v", affectedNodes, err)
+	}
+
+	gotTx, metaBlob, err := SplitTxWithMetaBlob(combined)
+	if err != nil {
+		t.Fatalf("split tx+meta blob: %v", err)
+	}
+	if !bytes.Equal(gotTx, txBlob) {
+		t.Fatal("transaction blob changed during combination")
+	}
+	decoded, err := binarycodec.DecodeBytes(metaBlob)
+	if err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	gotNodes, ok := decoded["AffectedNodes"].([]any)
+	if !ok {
+		t.Fatalf("AffectedNodes type = %T, want []any", decoded["AffectedNodes"])
+	}
+	if len(gotNodes) != affectedNodes {
+		t.Fatalf("AffectedNodes count = %d, want %d", len(gotNodes), affectedNodes)
+	}
+}
 
 func TestTransactionIndexFromMetadata(t *testing.T) {
 	metaData, err := SerializeMetadata(&Metadata{TransactionIndex: 37})

--- a/scripts/consensus-smoke/README.md
+++ b/scripts/consensus-smoke/README.md
@@ -43,15 +43,18 @@ containers up after a failure for inspection.
 
 ## Knobs
 
-| env var          | default                  | meaning                                            |
-|------------------|--------------------------|----------------------------------------------------|
-| `GOXRPL_IMAGE`   | `goxrpl:latest`          | image for goxrpl-0                                 |
-| `RIPPLED_IMAGE`  | `rippleci/rippled:2.6.2` | image for rippled-0,1                              |
-| `MIN_SEQ_EMPTY`  | `15`                     | seq target for phase 1 (empty ledger)              |
-| `PAYMENT_COUNT`  | `5`                      | number of payments to submit in phase 2            |
-| `BOOT_TIMEOUT`   | `180`                    | seconds to wait for phase 1 to validate            |
-| `TX_TIMEOUT`     | `180`                    | seconds to wait for a payment to validate          |
-| `KEEP_RUNNING`   | `0`                      | `1` = keep containers up after exit (debug)        |
+| env var          | default                            | meaning                                       |
+|------------------|------------------------------------|-----------------------------------------------|
+| `GOXRPL_IMAGE`   | `goxrpl:latest`                    | image for goxrpl-0                            |
+| `RIPPLED_IMAGE`  | `xrpllabsofficial/xrpld:3.2.0`    | image for rippled-0,1                         |
+| `MIN_SEQ_EMPTY`  | `15`                               | seq target for phase 1 (empty ledger)         |
+| `PAYMENT_COUNT`  | `5`                                | number of payments to submit in phase 2       |
+| `BOOT_TIMEOUT`   | `180`                              | seconds to wait for phase 1 to validate       |
+| `TX_TIMEOUT`     | `180`                              | seconds to wait for a payment to validate     |
+| `KEEP_RUNNING`   | `0`                                | `1` = keep containers up after exit (debug)   |
+
+`RIPPLED_IMAGE` overrides must use the official image's `/config/xrpld.cfg`
+and `/config/validators.txt` entrypoint contract.
 
 ## Files
 

--- a/scripts/consensus-smoke/docker-compose.yml
+++ b/scripts/consensus-smoke/docker-compose.yml
@@ -11,14 +11,14 @@ name: goxrpl-consensus-smoke
 
 services:
   rippled-0:
-    image: ${RIPPLED_IMAGE:-rippleci/rippled:2.6.2}
+    image: ${RIPPLED_IMAGE:-xrpllabsofficial/xrpld:3.2.0}
     hostname: rippled-0
     ports:
       - "5005"
       - "6006"
     volumes:
-      - ./configs:/etc/rippled:ro
-    command: ["--conf", "/etc/rippled/rippled-0.cfg"]
+      - ./configs/rippled-0.cfg:/config/xrpld.cfg:ro
+      - ./configs/validators.txt:/config/validators.txt:ro
     networks: [smoke]
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- --post-data='{\"method\":\"server_info\"}' http://localhost:5005 || exit 1"]
@@ -28,14 +28,14 @@ services:
       start_period: 5s
 
   rippled-1:
-    image: ${RIPPLED_IMAGE:-rippleci/rippled:2.6.2}
+    image: ${RIPPLED_IMAGE:-xrpllabsofficial/xrpld:3.2.0}
     hostname: rippled-1
     ports:
       - "5005"
       - "6006"
     volumes:
-      - ./configs:/etc/rippled:ro
-    command: ["--conf", "/etc/rippled/rippled-1.cfg"]
+      - ./configs/rippled-1.cfg:/config/xrpld.cfg:ro
+      - ./configs/validators.txt:/config/validators.txt:ro
     networks: [smoke]
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- --post-data='{\"method\":\"server_info\"}' http://localhost:5005 || exit 1"]
@@ -55,8 +55,10 @@ services:
     command: ["server", "--conf", "/etc/goxrpl/goxrpl-0.toml"]
     networks: [smoke]
     depends_on:
-      - rippled-0
-      - rippled-1
+      rippled-0:
+        condition: service_healthy
+      rippled-1:
+        condition: service_healthy
 
 networks:
   smoke:

--- a/scripts/consensus-smoke/smoke.sh
+++ b/scripts/consensus-smoke/smoke.sh
@@ -18,7 +18,7 @@
 #
 # Knobs (env vars):
 #   GOXRPL_IMAGE        image to use for goxrpl-0 (default: goxrpl:latest)
-#   RIPPLED_IMAGE       image to use for rippled-0,1 (default: rippleci/rippled:2.6.2)
+#   RIPPLED_IMAGE       image to use for rippled-0,1 (default: xrpllabsofficial/xrpld:3.2.0)
 #   MIN_SEQ_EMPTY       minimum validated seq for the empty-ledger phase (default 15)
 #   (phase 2 no longer takes a MIN_SEQ_TX — it waits for one submitted
 #    payment to land in a validated ledger, then asserts hash agreement at
@@ -35,7 +35,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
 
 GOXRPL_IMAGE="${GOXRPL_IMAGE:-goxrpl:latest}"
-RIPPLED_IMAGE="${RIPPLED_IMAGE:-rippleci/rippled:2.6.2}"
+RIPPLED_IMAGE="${RIPPLED_IMAGE:-xrpllabsofficial/xrpld:3.2.0}"
 MIN_SEQ_EMPTY="${MIN_SEQ_EMPTY:-15}"
 MIN_SEQ_TX="${MIN_SEQ_TX:-12}"
 PAYMENT_COUNT="${PAYMENT_COUNT:-5}"

--- a/shamap/shamap.go
+++ b/shamap/shamap.go
@@ -669,13 +669,20 @@ func (sm *SHAMap) consolidateAfterDelete(stack *nodeStack, key [32]byte) (Node, 
 // SnapshotMutable returns a structurally-shared copy that may be modified.
 // See snapshot for the sharing and flushing semantics.
 func (sm *SHAMap) SnapshotMutable() (*SHAMap, error) {
-	return sm.snapshot(true)
+	return sm.snapshot(true, true)
+}
+
+// SnapshotMutableUnflushed returns a mutable structurally-shared copy without
+// persisting dirty nodes first. It is for short-lived transactional staging;
+// callers must publish or discard the copy before releasing shared children.
+func (sm *SHAMap) SnapshotMutableUnflushed() (*SHAMap, error) {
+	return sm.snapshot(true, false)
 }
 
 // SnapshotImmutable returns a read-only structurally-shared copy.
 // See snapshot for the sharing and flushing semantics.
 func (sm *SHAMap) SnapshotImmutable() (*SHAMap, error) {
-	return sm.snapshot(false)
+	return sm.snapshot(false, true)
 }
 
 // snapshot returns a structurally-shared copy of the SHAMap in O(1).
@@ -684,16 +691,16 @@ func (sm *SHAMap) SnapshotImmutable() (*SHAMap, error) {
 // each touched inner node), so the snapshot's tree is never observed
 // being mutated.
 //
-// For backed maps, dirty nodes present at entry are flushed to the store
-// before the root is shared. flushDirty and the subsequent RLock are
+// When requested for backed maps, dirty nodes present at entry are flushed to
+// the store before the root is shared. flushDirty and the subsequent RLock are
 // separate critical sections, so a writer racing between the two can
 // produce a snapshot whose root references dirty inner nodes that are
 // not yet in the store; those will be flushed on the next flush.
 // Flushing a structurally-shared subtree from either map is safe: the
 // dirty flag is atomic and node hashes are read and written under each
 // node's own lock.
-func (sm *SHAMap) snapshot(mutable bool) (*SHAMap, error) {
-	if sm.backed && sm.family != nil {
+func (sm *SHAMap) snapshot(mutable, flush bool) (*SHAMap, error) {
+	if flush && sm.backed && sm.family != nil {
 		if err := sm.StoreDirty(func(entries []FlushEntry) error {
 			return sm.family.StoreBatch(context.Background(), entries)
 		}); err != nil {

--- a/shamap/store_test.go
+++ b/shamap/store_test.go
@@ -1059,6 +1059,62 @@ func TestBacked_Snapshot(t *testing.T) {
 	}
 }
 
+func TestBacked_SnapshotMutableUnflushedDefersStore(t *testing.T) {
+	family := newMemoryFamily()
+	source, err := NewBacked(TypeState, family)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key1 := hexToHash("092891fe4ef6cee585fdc6fda0e09eb4d386363158ec3321b8123e5a772c6ca7")
+	key2 := hexToHash("b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8")
+	if err := source.Put(key1, intToBytes(1)); err != nil {
+		t.Fatal(err)
+	}
+	sourceHash, err := source.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := source.SnapshotMutableUnflushed()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := family.Len(); got != 0 {
+		t.Fatalf("stored nodes during unflushed snapshot = %d, want 0", got)
+	}
+	if err := snap.Put(key2, intToBytes(2)); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := source.Hash(); err != nil || got != sourceHash {
+		t.Fatalf("source hash after fork mutation = %x, %v; want %x, nil", got, err, sourceHash)
+	}
+	if _, found, err := source.Get(key2); err != nil || found {
+		t.Fatalf("source lookup after fork mutation = %v, %v; want false, nil", found, err)
+	}
+	if err := snap.StoreDirty(func(entries []FlushEntry) error {
+		return family.StoreBatch(context.Background(), entries)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rootHash, err := snap.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := NewFromRootHash(TypeState, rootHash, family)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, want := range map[[32]byte][]byte{key1: intToBytes(1), key2: intToBytes(2)} {
+		item, found, err := reloaded.Get(key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !found || !bytes.Equal(item.Data(), want) {
+			t.Fatalf("reloaded item %x = %v, %v; want %v, true", key, item, found, want)
+		}
+	}
+}
+
 // TestBacked_NewBacked verifies NewBacked creates a working backed map.
 func TestBacked_NewBacked(t *testing.T) {
 	family := newMemoryFamily()

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -590,3 +590,43 @@ rippled `3.2.0` worktree at
 - The original ledger 3025006 replay was not rerun because its VM database is
   not present locally; the supplied field-level divergence is covered directly
   by the byte-level reconstruction tests.
+
+# Issue #1326 — trusted metadata STArray serialization
+
+Target: `origin/v3.0.0` at
+`bf5709635715a158437b3718982a8a363fb01c59`. Behavioral oracle: clean local
+rippled `3.2.0` worktree at
+`3c43f4614f87965298773279ff5b85d4c56c637b`.
+
+## Plan
+
+- [x] Trace trusted metadata serialization and the transaction/state commit
+      boundary, including every caller of the codec array-size guard.
+- [x] Confirm rippled 3.2.0 separates untrusted JSON limits from internally
+      generated metadata and preserves atomic ledger application.
+- [x] Add focused regressions for a 1,027-node metadata array, the 512-element
+      untrusted-input limit, and serialization failure before state commit.
+- [x] Implement the smallest production-quality API and engine changes that
+      satisfy those contracts.
+- [x] Run formatting, focused codec/transaction/engine tests, broader affected
+      suites, vet, strict lint, build, and diff review.
+- [x] Record the review results and prepare only intentional files for delivery
+      against `v3.0.0`.
+
+## Review
+
+- Rippled v3.2.0 applies its 512-element limit only while parsing untrusted JSON;
+  native `TxMeta` STArrays serialize without that cap. Its separate metadata
+  safeguard is the 5,200 modified-entry `tecOVERSIZE` limit.
+- Trusted internal metadata now bypasses only the JSON-input array guard while
+  retaining unknown-field and binary-format validation. Ordinary `Encode` and
+  `EncodeBytes` calls still reject arrays over 512.
+- `BlockProcessor` applies each transaction to an unpublished mutable snapshot,
+  serializes and inserts the tx+meta leaf there, then adopts state, transaction
+  map, and destroyed drops together. Serialization/insertion failure discards
+  the snapshot without advancing either transaction counter.
+- Applied-first result classification and TxQ transaction-index seeding match
+  rippled's open-ledger behavior. Replay callers no longer insert a second leaf.
+- Passed uncached focused and broad codec, transaction, ledger, and replay tests;
+  focused race tests; `just fmt`; `just build-all`; `just vet`; CI-pinned strict
+  golangci-lint v2.11.3; advisory lint; and `git diff --check`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -630,3 +630,21 @@ rippled `3.2.0` worktree at
 - Passed uncached focused and broad codec, transaction, ledger, and replay tests;
   focused race tests; `just fmt`; `just build-all`; `just vet`; CI-pinned strict
   golangci-lint v2.11.3; advisory lint; and `git diff --check`.
+
+## PR #1329 finalization
+
+- [x] Review the complete PR diff and production callers for correctness.
+- [x] Verify every protocol-bearing change against local rippled v3.2.0.
+- [x] Make transaction staging atomic without flushing backed SHAMaps per tx.
+- [x] Remove redundant implementation narration in a separate cleanup commit.
+- [x] Diagnose the final merged-head consensus failure against both PR and base.
+- [x] Pin the mixed-node smoke to rippled v3.2.0 and pass the local topology.
+
+### Finalization review
+
+The original consensus smoke used rippled 2.6.2. Its newly funded AccountRoot
+starts at Sequence 1, while rippled v3.2.0 sets Sequence to the current ledger
+sequence in `Payment::doApply`. The Go implementation matches v3.2.0, so the old
+image created deterministic account-state and transaction-metadata divergence
+before exercising PR #1329. The smoke topology and both CI callers now use the
+project's mandated rippled 3.2.0 image and its `/config` entrypoint contract.


### PR DESCRIPTION
## Summary
- keep the 512-element limit on untrusted JSON input while allowing trusted internally generated metadata to serialize larger protocol-valid arrays
- stage ledger effects and the transaction metadata leaf on a private snapshot, then publish them together only after serialization and insertion succeed
- align open-ledger applied-result classification and TxQ transaction indexes with rippled v3.2.0

## Test plan
- [x] `go test -count=1 -timeout 20m ./codec/... ./internal/tx/... ./internal/ledger/... ./internal/replaytool/...`
- [x] `go test -race -count=1 -timeout 15m ./internal/tx/engine ./internal/ledger/openledger ./internal/replaytool`
- [x] `just build-all`
- [x] `just vet`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `just lint`
- [x] `git diff --check`

Fixes #1326
