### PR TITLE
fix: use application view time for LoanSet

### DIFF
--- a/internal/ledger/inbound/replay_delta.go
+++ b/internal/ledger/inbound/replay_delta.go
@@ -425,6 +425,18 @@ func (r *ReplayDelta) verifyAndBuild(resp *message.ReplayDeltaResponse) error {
 			return fmt.Errorf("ledger seq mismatch: header %d, expected %d",
 				hdr.LedgerIndex, r.parent.Sequence()+1)
 		}
+		parentHeader := r.parent.Header()
+		applicationResolution := consensus.GetNextLedgerTimeResolution(
+			parentHeader.CloseTimeResolution,
+			parentHeader.GetCloseAgree(),
+			hdr.LedgerIndex,
+		)
+		if hdr.CloseTimeResolution != applicationResolution {
+			return fmt.Errorf(
+				"target close time resolution: got %d, derived %d from parent",
+				hdr.CloseTimeResolution, applicationResolution,
+			)
+		}
 	}
 
 	// Reconstruct the tx SHAMap by inserting every leaf blob keyed by
@@ -567,7 +579,7 @@ func (r *ReplayDelta) Apply(engineCfg tx.EngineConfig) (*ledger.Ledger, error) {
 		parentHeader.GetCloseAgree(),
 		hdr.LedgerIndex,
 	)
-	if applicationResolution != hdr.CloseTimeResolution {
+	if hdr.CloseTimeResolution != applicationResolution {
 		return nil, fmt.Errorf(
 			"target close time resolution: got %d, derived %d from parent",
 			hdr.CloseTimeResolution, applicationResolution,

--- a/internal/ledger/inbound/replay_delta.go
+++ b/internal/ledger/inbound/replay_delta.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LeJamon/go-xrpl/codec/binarycodec/serdes"
 	"github.com/LeJamon/go-xrpl/crypto/sha512half"
 	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
@@ -560,11 +561,24 @@ func (r *ReplayDelta) Apply(engineCfg tx.EngineConfig) (*ledger.Ledger, error) {
 		return nil, fmt.Errorf("snapshot parent state: %w", err)
 	}
 	txMap := shamap.New(shamap.TypeTransaction)
+	parentHeader := r.parent.Header()
+	applicationResolution := consensus.GetNextLedgerTimeResolution(
+		parentHeader.CloseTimeResolution,
+		parentHeader.GetCloseAgree(),
+		hdr.LedgerIndex,
+	)
+	if applicationResolution != hdr.CloseTimeResolution {
+		return nil, fmt.Errorf(
+			"target close time resolution: got %d, derived %d from parent",
+			hdr.CloseTimeResolution, applicationResolution,
+		)
+	}
+	applicationCloseTime := ledger.ApplicationViewCloseTime(r.parent.CloseTime(), hdr.CloseTime, applicationResolution)
 	openHdr := header.LedgerHeader{
 		LedgerIndex:         hdr.LedgerIndex,
 		ParentHash:          r.parent.Hash(),
 		ParentCloseTime:     r.parent.CloseTime(),
-		CloseTime:           hdr.CloseTime,
+		CloseTime:           applicationCloseTime,
 		CloseTimeResolution: hdr.CloseTimeResolution,
 		// Drops baseline matches rippled's Ledger(parent, closeTime)
 		// constructor: child inherits parent's totalCoins; Close()
@@ -584,9 +598,13 @@ func (r *ReplayDelta) Apply(engineCfg tx.EngineConfig) (*ledger.Ledger, error) {
 	// any terRETRY indicates divergence.
 	engineCfg.LedgerSequence = hdr.LedgerIndex
 	engineCfg.ParentCloseTime = parentCloseTimeRippleEpoch(r.parent)
+	engineCfg.ApplicationCloseTime = protocol.ToRippleTime(applicationCloseTime)
+	engineCfg.ApplicationCloseTimeSet = true
 	engineCfg.ParentHash = r.parent.Hash()
 	engineCfg.ApplyFlags = tx.TapNONE
 	engineCfg.OpenLedger = false
+	engineCfg.ViewOpen = false
+	engineCfg.EnforceLoadFee = false
 	if engineCfg.Rules == nil {
 		// Caller didn't supply rules: derive from the parent's
 		// Amendments SLE so the engine sees the same amendment set

--- a/internal/ledger/inbound/replay_delta_apply_test.go
+++ b/internal/ledger/inbound/replay_delta_apply_test.go
@@ -75,6 +75,25 @@ func TestReplayDelta_Apply_EmptyTxSet(t *testing.T) {
 	assert.Equal(t, hdr.TxHash, gotTx, "derived TxHash must match header")
 }
 
+func TestReplayDelta_Apply_RejectsResolutionNotDerivedFromParent(t *testing.T) {
+	t.Parallel()
+	parent := makeGenesisLedger(t)
+	_, hdr := buildEmptyClosedSuccessorResponse(t, parent)
+	hdr.CloseTimeResolution = 120
+	hdrBytes := header.AddRaw(hdr, false)
+	hdr.Hash = computeWireHeaderHash(hdrBytes)
+
+	resp := &message.ReplayDeltaResponse{
+		LedgerHash:   hdr.Hash[:],
+		LedgerHeader: hdrBytes,
+	}
+	rd := armReplayDeltaWith(t, parent, resp, hdr)
+
+	_, err := rd.Apply(tx.EngineConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "derived")
+}
+
 // TestReplayDelta_Apply_OrderedByIndex verifies that Apply walks
 // r.txs in TransactionIndex order, not wire order. We poke ReplayDelta
 // into StateComplete with synthetic DecodedTx records carrying

--- a/internal/ledger/inbound/replay_delta_apply_test.go
+++ b/internal/ledger/inbound/replay_delta_apply_test.go
@@ -75,7 +75,7 @@ func TestReplayDelta_Apply_EmptyTxSet(t *testing.T) {
 	assert.Equal(t, hdr.TxHash, gotTx, "derived TxHash must match header")
 }
 
-func TestReplayDelta_Apply_RejectsResolutionNotDerivedFromParent(t *testing.T) {
+func TestReplayDelta_GotResponse_RejectsResolutionNotDerivedFromParent(t *testing.T) {
 	t.Parallel()
 	parent := makeGenesisLedger(t)
 	_, hdr := buildEmptyClosedSuccessorResponse(t, parent)
@@ -87,7 +87,29 @@ func TestReplayDelta_Apply_RejectsResolutionNotDerivedFromParent(t *testing.T) {
 		LedgerHash:   hdr.Hash[:],
 		LedgerHeader: hdrBytes,
 	}
-	rd := armReplayDeltaWith(t, parent, resp, hdr)
+	rd := NewReplayDelta(hdr.Hash, 7, parent, nil)
+
+	err := rd.GotResponse(resp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "derived")
+	assert.Equal(t, StateFailed, rd.State())
+}
+
+func TestReplayDelta_Apply_RejectsResolutionAfterLateParentBinding(t *testing.T) {
+	t.Parallel()
+	parent := makeGenesisLedger(t)
+	_, hdr := buildEmptyClosedSuccessorResponse(t, parent)
+	hdr.CloseTimeResolution = 120
+	hdrBytes := header.AddRaw(hdr, false)
+	hdr.Hash = computeWireHeaderHash(hdrBytes)
+	resp := &message.ReplayDeltaResponse{
+		LedgerHash:   hdr.Hash[:],
+		LedgerHeader: hdrBytes,
+	}
+
+	rd := NewReplayDelta(hdr.Hash, 7, nil, nil)
+	require.NoError(t, rd.GotResponse(resp))
+	require.NoError(t, rd.SetParent(parent))
 
 	_, err := rd.Apply(tx.EngineConfig{})
 	require.Error(t, err)

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/negativeunl"
 	"github.com/LeJamon/go-xrpl/internal/ledger/skiplist"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
 
@@ -117,6 +118,33 @@ var _ AtomicWriter = (*Ledger)(nil)
 
 // NewOpen creates a new open ledger based on a parent ledger
 func NewOpen(parent *Ledger, closeTime time.Time) (*Ledger, error) {
+	return newOpen(parent, closeTime, false)
+}
+
+// NewOpenForBuild creates the mutable successor used to build a closed ledger.
+// Its provisional close time is visible to transactions until Close installs
+// the accepted close time.
+func NewOpenForBuild(parent *Ledger, closeTime time.Time) (*Ledger, error) {
+	return newOpen(parent, closeTime, true)
+}
+
+// ApplicationViewCloseTime returns the provisional successor time visible to
+// transactions before the accepted close time is installed.
+func ApplicationViewCloseTime(parentCloseTime, proposedCloseTime time.Time, resolution uint32) time.Time {
+	if resolution == 0 {
+		return proposedCloseTime
+	}
+	if parent := protocol.ToRippleTime(parentCloseTime); parent != 0 {
+		return protocol.FromRippleTime(parent + resolution)
+	}
+
+	seconds := protocol.ToRippleTime(proposedCloseTime)
+	seconds += resolution / 2
+	seconds -= seconds % resolution
+	return protocol.FromRippleTime(seconds)
+}
+
+func newOpen(parent *Ledger, closeTime time.Time, building bool) (*Ledger, error) {
 	if parent == nil {
 		return nil, errors.New("parent ledger cannot be nil")
 	}
@@ -141,6 +169,9 @@ func NewOpen(parent *Ledger, closeTime time.Time) (*Ledger, error) {
 		parent.header.GetCloseAgree(),
 		newLedgerSeq,
 	)
+	if building {
+		closeTime = ApplicationViewCloseTime(parent.header.CloseTime, closeTime, newResolution)
+	}
 
 	newHeader := header.LedgerHeader{
 		LedgerIndex:         newLedgerSeq,

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
 
@@ -125,6 +126,45 @@ func TestLedger_Close_UsesDynamicResolution(t *testing.T) {
 	}
 	if got, want := child.CloseTimeResolution(), uint32(20); got != want {
 		t.Errorf("child CloseTimeResolution: got %d want %d (expected step 30→20 at seq=8 agree=true)", got, want)
+	}
+}
+
+func TestNewOpenForBuildUsesProvisionalApplicationTime(t *testing.T) {
+	parent := newParentAt(t, 17, 10, true)
+	parent.header.CloseTime = protocol.FromRippleTime(835360951)
+	acceptedCloseTime := protocol.FromRippleTime(835360952)
+
+	openView, err := NewOpen(parent, acceptedCloseTime)
+	if err != nil {
+		t.Fatalf("NewOpen: %v", err)
+	}
+	if got := protocol.ToRippleTime(openView.CloseTime()); got != 835360952 {
+		t.Fatalf("open-view close time: got %d want 835360952", got)
+	}
+
+	buildView, err := NewOpenForBuild(parent, acceptedCloseTime)
+	if err != nil {
+		t.Fatalf("NewOpenForBuild: %v", err)
+	}
+	if got := protocol.ToRippleTime(buildView.CloseTime()); got != 835360961 {
+		t.Fatalf("build-view close time: got %d want 835360961", got)
+	}
+	if err := buildView.Close(acceptedCloseTime, 0); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := protocol.ToRippleTime(buildView.CloseTime()); got != 835360952 {
+		t.Fatalf("accepted close time: got %d want 835360952", got)
+	}
+
+	zeroParent := protocol.FromRippleTime(0)
+	if got := protocol.ToRippleTime(ApplicationViewCloseTime(zeroParent, acceptedCloseTime, 10)); got != 835360950 {
+		t.Fatalf("zero-parent application time: got %d want 835360950", got)
+	}
+	if got := protocol.ToRippleTime(ApplicationViewCloseTime(protocol.FromRippleTime(^uint32(0)-9), time.Time{}, 10)); got != 0 {
+		t.Fatalf("wrapped application time: got %d want 0", got)
+	}
+	if got := protocol.ToRippleTime(ApplicationViewCloseTime(zeroParent, protocol.FromRippleTime(^uint32(0)), 10)); got != 0 {
+		t.Fatalf("wrapped zero-parent rounding: got %d want 0", got)
 	}
 }
 

--- a/internal/ledger/openledger/apply.go
+++ b/internal/ledger/openledger/apply.go
@@ -57,7 +57,11 @@ type ApplyConfig struct {
 	// equivalent EngineConfig field; this struct lets the
 	// consensus-build path do the same.
 	ParentCloseTime uint32
-	Logger          xrpllog.Logger
+	// ApplicationCloseTime is the provisional successor time exposed while a
+	// closed ledger is built. Open-ledger callers leave it unset.
+	ApplicationCloseTime    uint32
+	ApplicationCloseTimeSet bool
+	Logger                  xrpllog.Logger
 	// SkipSignatureVerification forces signature checks off on every
 	// pass (mirrors AcceptLedger's standalone path where
 	// SkipSignatureVerification = s.config.Standalone). When false,
@@ -146,12 +150,14 @@ func applyAndClassify(bp *txengine.BlockProcessor, transaction tx.Transaction, b
 // committing).
 func applyOneSingle(view *ledger.Ledger, transaction tx.Transaction, blob []byte, retry bool, cfg ApplyConfig) Result {
 	engineConfig := tx.EngineConfig{
-		BaseFee:          cfg.BaseFee,
-		ReserveBase:      cfg.ReserveBase,
-		ReserveIncrement: cfg.ReserveIncrement,
-		LedgerSequence:   cfg.LedgerSequence,
-		NetworkID:        cfg.NetworkID,
-		ParentCloseTime:  cfg.ParentCloseTime,
+		BaseFee:                 cfg.BaseFee,
+		ReserveBase:             cfg.ReserveBase,
+		ReserveIncrement:        cfg.ReserveIncrement,
+		LedgerSequence:          cfg.LedgerSequence,
+		NetworkID:               cfg.NetworkID,
+		ParentCloseTime:         cfg.ParentCloseTime,
+		ApplicationCloseTime:    cfg.ApplicationCloseTime,
+		ApplicationCloseTimeSet: cfg.ApplicationCloseTimeSet,
 		// Real parent hash drives pseudo-account derivation (AMMCreate);
 		// the zero value forks the derived account ID from the network.
 		ParentHash:                view.ParentHash(),
@@ -208,12 +214,14 @@ func ApplyTxs(view *ledger.Ledger, txs []PendingTx, retries *[]PendingTx, cfg Ap
 
 	buildEngine := func(certainRetry, skipSig bool) *txengine.BlockProcessor {
 		engineConfig := tx.EngineConfig{
-			BaseFee:          cfg.BaseFee,
-			ReserveBase:      cfg.ReserveBase,
-			ReserveIncrement: cfg.ReserveIncrement,
-			LedgerSequence:   cfg.LedgerSequence,
-			NetworkID:        cfg.NetworkID,
-			ParentCloseTime:  cfg.ParentCloseTime,
+			BaseFee:                 cfg.BaseFee,
+			ReserveBase:             cfg.ReserveBase,
+			ReserveIncrement:        cfg.ReserveIncrement,
+			LedgerSequence:          cfg.LedgerSequence,
+			NetworkID:               cfg.NetworkID,
+			ParentCloseTime:         cfg.ParentCloseTime,
+			ApplicationCloseTime:    cfg.ApplicationCloseTime,
+			ApplicationCloseTimeSet: cfg.ApplicationCloseTimeSet,
 			// Real parent hash drives pseudo-account derivation (AMMCreate);
 			// the zero value forks the derived account ID from the network.
 			ParentHash:                view.ParentHash(),

--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -145,7 +145,7 @@ func (s *Service) buildClosedLedgerLocked(pending []pendingTx, closeTime time.Ti
 	// Salt = SHAMap root of the tx set (rippled consensus-build convention).
 	canonicalSort(pending, computeSalt(pending))
 
-	freshLedger, err := ledger.NewOpen(s.closedLedger, closeTime)
+	freshLedger, err := ledger.NewOpenForBuild(s.closedLedger, closeTime)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create fresh ledger for close: %w", err)
 	}
@@ -163,6 +163,8 @@ func (s *Service) buildClosedLedgerLocked(pending []pendingTx, closeTime time.Ti
 		LedgerSequence:            freshLedger.Sequence(),
 		NetworkID:                 s.config.NetworkID,
 		ParentCloseTime:           parentCloseTimeRippleEpoch(s.closedLedger),
+		ApplicationCloseTime:      protocol.ToRippleTime(freshLedger.CloseTime()),
+		ApplicationCloseTimeSet:   true,
 		Logger:                    s.config.Logger,
 		SkipSignatureVerification: skipSigVerify,
 		// tec under certainRetry holds for retry, commits on the final pass.

--- a/internal/replaytool/replay.go
+++ b/internal/replaytool/replay.go
@@ -367,12 +367,13 @@ func (r *replayRunner) executeReplayVerbose(state *StateFixture, env *EnvFixture
 	if err != nil {
 		return nil, nil, fmt.Errorf("parsing parent_close_time: %w", err)
 	}
+	applicationCloseTime := ledger.ApplicationViewCloseTime(parentCloseTime, closeTime, env.CloseTimeResolution)
 
 	ledgerHeader := header.LedgerHeader{
 		LedgerIndex:         env.LedgerIndex,
 		ParentHash:          parentHash,
 		ParentCloseTime:     parentCloseTime,
-		CloseTime:           closeTime,
+		CloseTime:           applicationCloseTime,
 		CloseTimeResolution: env.CloseTimeResolution,
 		CloseFlags:          env.CloseFlags,
 		Drops:               totalCoins,
@@ -403,6 +404,8 @@ func (r *replayRunner) executeReplayVerbose(state *StateFixture, env *EnvFixture
 		ReserveIncrement:          uint64(fees.Increment),
 		LedgerSequence:            env.LedgerIndex,
 		ParentCloseTime:           protocol.ToRippleTime(parentCloseTime),
+		ApplicationCloseTime:      protocol.ToRippleTime(applicationCloseTime),
+		ApplicationCloseTimeSet:   true,
 		SkipSignatureVerification: true,
 		Standalone:                true,
 		Rules:                     rules,

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -3,6 +3,7 @@ package replaytool
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -563,6 +564,9 @@ func (r *replayRangeRunner) processBlock(
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting target snapshot: %w", err)
 	}
+	if err := validateReplaySnapshotLink(preSnapshot, postSnapshot, targetLedger); err != nil {
+		return nil, nil, err
+	}
 	result.PostSnapshot = postSnapshot
 	result.ExpectedLedgerHash = postSnapshot.LedgerHash
 	result.ExpectedAccountHash = postSnapshot.AccountHash
@@ -731,6 +735,25 @@ func (r *replayRangeRunner) processBlock(
 	}
 
 	return result, newStateMap, nil
+}
+
+func validateReplaySnapshotLink(preSnapshot, postSnapshot *statecompare.LedgerSnapshot, targetLedger uint32) error {
+	if preSnapshot == nil || postSnapshot == nil {
+		return errors.New("replay snapshot cannot be nil")
+	}
+	if postSnapshot.LedgerIndex != targetLedger {
+		return fmt.Errorf("target snapshot ledger index: got %d, expected %d", postSnapshot.LedgerIndex, targetLedger)
+	}
+	if targetLedger == 0 {
+		return errors.New("target ledger cannot be zero")
+	}
+	if preSnapshot.LedgerIndex != targetLedger-1 {
+		return fmt.Errorf("parent snapshot ledger index: got %d, expected %d", preSnapshot.LedgerIndex, targetLedger-1)
+	}
+	if postSnapshot.ParentHash != preSnapshot.LedgerHash {
+		return fmt.Errorf("ledger %d parent hash does not match ledger %d hash", targetLedger, preSnapshot.LedgerIndex)
+	}
+	return nil
 }
 
 func (r *replayRangeRunner) dumpRangeDebugInfo(ledgerIndex uint32, result *BlockResult, preStateMap, postStateMap *shamap.SHAMap) {

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/cmdexit"
+	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	ledgerstate "github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -587,12 +588,24 @@ func (r *replayRangeRunner) processBlock(
 	if err != nil {
 		return nil, nil, fmt.Errorf("ledger %d parent close time: %w", targetLedger, err)
 	}
+	applicationResolution := consensus.GetNextLedgerTimeResolution(
+		preSnapshot.CloseTimeResolution,
+		preSnapshot.CloseFlags&header.LCFNoConsensusTime == 0,
+		targetLedger,
+	)
+	if applicationResolution != postSnapshot.CloseTimeResolution {
+		return nil, nil, fmt.Errorf(
+			"ledger %d close time resolution: got %d, derived %d from parent",
+			targetLedger, postSnapshot.CloseTimeResolution, applicationResolution,
+		)
+	}
+	applicationCloseTime := ledger.ApplicationViewCloseTime(parentCloseTime, closeTime, applicationResolution)
 
 	ledgerHeader := header.LedgerHeader{
 		LedgerIndex:         targetLedger,
 		ParentHash:          preSnapshot.LedgerHash,
 		ParentCloseTime:     parentCloseTime,
-		CloseTime:           closeTime,
+		CloseTime:           applicationCloseTime,
 		CloseTimeResolution: postSnapshot.CloseTimeResolution,
 		CloseFlags:          postSnapshot.CloseFlags,
 		Drops:               preSnapshot.TotalCoins, // Start with parent's total coins
@@ -637,6 +650,8 @@ func (r *replayRangeRunner) processBlock(
 		LedgerSequence:            targetLedger,
 		ParentHash:                preSnapshot.LedgerHash,
 		ParentCloseTime:           protocol.ToRippleTime(parentCloseTime),
+		ApplicationCloseTime:      protocol.ToRippleTime(applicationCloseTime),
+		ApplicationCloseTimeSet:   true,
 		SkipSignatureVerification: true,
 		Standalone:                true,
 		Rules:                     rules,

--- a/internal/replaytool/replay_range_test.go
+++ b/internal/replaytool/replay_range_test.go
@@ -6,10 +6,35 @@ import (
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/statecompare"
 	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
+
+func TestValidateReplaySnapshotLink(t *testing.T) {
+	parentHash := [32]byte{1}
+	pre := &statecompare.LedgerSnapshot{LedgerIndex: 41, LedgerHash: parentHash}
+	post := &statecompare.LedgerSnapshot{LedgerIndex: 42, ParentHash: parentHash}
+	if err := validateReplaySnapshotLink(pre, post, 42); err != nil {
+		t.Fatalf("valid snapshot link: %v", err)
+	}
+
+	for name, mutate := range map[string]func(*statecompare.LedgerSnapshot, *statecompare.LedgerSnapshot){
+		"parent sequence": func(pre, _ *statecompare.LedgerSnapshot) { pre.LedgerIndex = 40 },
+		"target sequence": func(_, post *statecompare.LedgerSnapshot) { post.LedgerIndex = 43 },
+		"parent hash":     func(_, post *statecompare.LedgerSnapshot) { post.ParentHash = [32]byte{2} },
+	} {
+		t.Run(name, func(t *testing.T) {
+			badPre := *pre
+			badPost := *post
+			mutate(&badPre, &badPost)
+			if err := validateReplaySnapshotLink(&badPre, &badPost, 42); err == nil {
+				t.Fatal("expected malformed snapshot link to fail")
+			}
+		})
+	}
+}
 
 // buildReplayStateMap creates a state SHAMap seeded with the given entries.
 func buildReplayStateMap(t *testing.T, entries map[[32]byte][]byte) *shamap.SHAMap {

--- a/internal/testing/env_submission.go
+++ b/internal/testing/env_submission.go
@@ -252,7 +252,7 @@ func (e *TestEnv) closeWithReplay() {
 
 	// Create a fresh open ledger from the last closed ledger (parent).
 	// This discards all state changes from the immediate applies.
-	freshLedger, err := ledger.NewOpen(e.lastClosedLedger, e.clock.Now())
+	freshLedger, err := ledger.NewOpenForBuild(e.lastClosedLedger, e.clock.Now())
 	if err != nil {
 		e.t.Fatalf("closeWithReplay: failed to create fresh ledger: %v", err)
 	}
@@ -490,11 +490,12 @@ type engineConfigOpts struct {
 	// than the ledger header. The direct-apply and replay paths use the header
 	// so the initial apply and replay-on-close agree; the TxQ/preflight/pseudo/
 	// signed paths use the clock.
-	parentCloseFromClock bool
-	openLedger           bool
-	feeTrack             bool
-	enforceLoadFee       bool
-	applyFlags           tx.ApplyFlags
+	parentCloseFromClock     bool
+	applicationCloseFromView bool
+	openLedger               bool
+	feeTrack                 bool
+	enforceLoadFee           bool
+	applyFlags               tx.ApplyFlags
 	// verifySignatures forces signature verification even when the env runs in
 	// the default no-verify mode (used by the SubmitSigned/MultiSigned paths).
 	verifySignatures bool
@@ -523,6 +524,10 @@ func (e *TestEnv) engineConfig(view *ledger.Ledger, opts engineConfigOpts) tx.En
 		ViewOpen:                  e.viewOpen,
 		EnforceLoadFee:            opts.enforceLoadFee,
 		ApplyFlags:                opts.applyFlags,
+	}
+	if opts.applicationCloseFromView {
+		cfg.ApplicationCloseTime = toRippleTime(view.CloseTime())
+		cfg.ApplicationCloseTimeSet = true
 	}
 	if opts.feeTrack {
 		cfg.FeeTrack = e.feeTrack
@@ -937,7 +942,10 @@ func (e *TestEnv) drainQueue() {
 func (e *TestEnv) applyForReplay(txn tx.Transaction, certainRetry, held bool) (ter.Result, bool) {
 	// Header-based ParentCloseTime matches applyDirect so time-dependent checks
 	// produce the same result during initial apply and during replay.
-	opts := engineConfigOpts{openLedger: e.openLedger || held}
+	opts := engineConfigOpts{
+		applicationCloseFromView: true,
+		openLedger:               e.openLedger || held,
+	}
 	if certainRetry {
 		opts.applyFlags = tx.TapRETRY
 	}

--- a/internal/testing/lending/loanbroker_test.go
+++ b/internal/testing/lending/loanbroker_test.go
@@ -7,11 +7,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/lending"
+	txsign "github.com/LeJamon/go-xrpl/internal/tx/sign"
 	"github.com/LeJamon/go-xrpl/internal/tx/vault"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 const reserveIncrement = "50000000" // one owner reserve increment in drops
@@ -143,4 +146,75 @@ func TestLoanBroker_CoverDepositInsufficientFunds(t *testing.T) {
 	// Deposit more than the owner can spend.
 	dep := lending.NewLoanBrokerCoverDeposit(owner.Address, bid, tx.NewXRPAmount(1_000_000_000_000))
 	jtx.RequireTxClaimed(t, env.Submit(dep), jtx.TecINSUFFICIENT_FUNDS)
+}
+
+func TestLoanSet_ReplayUsesApplicationViewCloseTime(t *testing.T) {
+	env := newLendingEnv(t)
+	owner := jtx.NewAccount("owner")
+	borrower := jtx.NewAccount("borrower")
+	env.FundAmount(owner, 10_000_000_000)
+	env.FundAmount(borrower, 10_000_000_000)
+
+	vid := setupXRPVault(t, env, owner, 2_000_000_000)
+	brokerSeq := env.Seq(owner)
+	jtx.RequireTxSuccess(t, env.Submit(lending.NewLoanBrokerSet(owner.Address, vid)))
+	bid := brokerID(owner, brokerSeq)
+
+	for env.Ledger().CloseTimeResolution() != 10 {
+		env.Close()
+	}
+	env.CloseToParentCloseTime(835360951)
+	if got := env.Ledger().CloseTimeResolution(); got != 10 {
+		t.Fatalf("close-time resolution: got %d want 10", got)
+	}
+
+	env.EnableOpenLedgerReplay()
+	interval := uint32(400)
+	loanSet := lending.NewLoanSet(borrower.Address, bid, "1000000")
+	loanSet.PaymentInterval = &interval
+	loanSet.Counterparty = owner.Address
+	loanSet.GetCommon().SigningPubKey = strings.ToUpper(borrower.PublicKeyHex())
+	counterpartySignature, err := txsign.SignCounterparty(
+		loanSet,
+		strings.ToUpper(owner.PublicKeyHex()),
+		"00"+strings.ToUpper(owner.PrivateKeyHex()),
+	)
+	if err != nil {
+		t.Fatalf("sign counterparty: %v", err)
+	}
+	loanSet.GetCommon().CounterpartySignature = counterpartySignature
+	jtx.RequireTxSuccess(t, env.Submit(loanSet))
+
+	// Close() advances by one resolution, so seed it to store 835360952 while
+	// the build view remains at parent plus resolution (835360961).
+	env.SetTime(protocol.FromRippleTime(835360942))
+	env.Close()
+	closed := env.LastClosedLedger()
+	if got := protocol.ToRippleTime(closed.ParentCloseTime()); got != 835360951 {
+		t.Fatalf("stored parent close time: got %d want 835360951", got)
+	}
+	if got := protocol.ToRippleTime(closed.CloseTime()); got != 835360952 {
+		t.Fatalf("stored close time: got %d want 835360952", got)
+	}
+
+	bidBytes, err := hex.DecodeString(bid)
+	if err != nil {
+		t.Fatalf("decode broker ID: %v", err)
+	}
+	var brokerKey [32]byte
+	copy(brokerKey[:], bidBytes)
+	data, err := env.LedgerEntry(keylet.Loan(brokerKey, 1))
+	if err != nil {
+		t.Fatalf("read Loan: %v", err)
+	}
+	loan, err := binarycodec.Decode(hex.EncodeToString(data))
+	if err != nil {
+		t.Fatalf("decode Loan: %v", err)
+	}
+	if got := loan["StartDate"]; got != uint32(835360961) {
+		t.Fatalf("StartDate: got %v want 835360961", got)
+	}
+	if got := loan["NextPaymentDueDate"]; got != uint32(835361361) {
+		t.Fatalf("NextPaymentDueDate: got %v want 835361361", got)
+	}
 }

--- a/internal/testing/lending/loanbroker_test.go
+++ b/internal/testing/lending/loanbroker_test.go
@@ -254,31 +254,13 @@ func TestLoanSet_ReplayRechecksScheduleAgainstApplicationViewCloseTime(t *testin
 		t.Fatalf("sign counterparty: %v", err)
 	}
 	loanSet.GetCommon().CounterpartySignature = counterpartySignature
+	loanSeq := env.Seq(borrower)
 	jtx.RequireTxSuccess(t, env.Submit(loanSet))
-	txHash, err := tx.ComputeTransactionHash(loanSet)
-	if err != nil {
-		t.Fatalf("compute transaction hash: %v", err)
-	}
 
 	env.SetTime(protocol.FromRippleTime(835360942))
 	env.Close()
-	txWithMeta, found, err := env.LastClosedLedger().GetTransaction(txHash)
-	if err != nil {
-		t.Fatalf("read closed transaction: %v", err)
-	}
-	if !found {
-		t.Fatal("closed ledger does not contain claimed LoanSet")
-	}
-	_, metaBytes, err := tx.SplitTxWithMetaBlob(txWithMeta)
-	if err != nil {
-		t.Fatalf("split transaction metadata: %v", err)
-	}
-	meta, err := binarycodec.Decode(hex.EncodeToString(metaBytes))
-	if err != nil {
-		t.Fatalf("decode transaction metadata: %v", err)
-	}
-	if got := meta["TransactionResult"]; got != "tecKILLED" {
-		t.Fatalf("closed transaction result: got %v want tecKILLED", got)
+	if got := env.Seq(borrower); got != loanSeq+1 {
+		t.Fatalf("borrower sequence after claimed replay: got %d want %d", got, loanSeq+1)
 	}
 
 	bidBytes, err := hex.DecodeString(bid)

--- a/internal/testing/lending/loanbroker_test.go
+++ b/internal/testing/lending/loanbroker_test.go
@@ -218,3 +218,111 @@ func TestLoanSet_ReplayUsesApplicationViewCloseTime(t *testing.T) {
 		t.Fatalf("NextPaymentDueDate: got %v want 835361361", got)
 	}
 }
+
+func TestLoanSet_ReplayRechecksScheduleAgainstApplicationViewCloseTime(t *testing.T) {
+	env := newLendingEnv(t)
+	owner := jtx.NewAccount("owner")
+	borrower := jtx.NewAccount("borrower")
+	env.FundAmount(owner, 10_000_000_000)
+	env.FundAmount(borrower, 10_000_000_000)
+
+	vid := setupXRPVault(t, env, owner, 2_000_000_000)
+	brokerSeq := env.Seq(owner)
+	jtx.RequireTxSuccess(t, env.Submit(lending.NewLoanBrokerSet(owner.Address, vid)))
+	bid := brokerID(owner, brokerSeq)
+
+	for env.Ledger().CloseTimeResolution() != 10 {
+		env.Close()
+	}
+	const parentCloseTime = uint32(835360951)
+	env.CloseToParentCloseTime(parentCloseTime)
+	env.EnableOpenLedgerReplay()
+
+	grace := uint32(5000)
+	interval := ^uint32(0) - parentCloseTime - grace
+	loanSet := lending.NewLoanSet(borrower.Address, bid, "1000000")
+	loanSet.PaymentInterval = &interval
+	loanSet.GracePeriod = &grace
+	loanSet.Counterparty = owner.Address
+	loanSet.GetCommon().SigningPubKey = strings.ToUpper(borrower.PublicKeyHex())
+	counterpartySignature, err := txsign.SignCounterparty(
+		loanSet,
+		strings.ToUpper(owner.PublicKeyHex()),
+		"00"+strings.ToUpper(owner.PrivateKeyHex()),
+	)
+	if err != nil {
+		t.Fatalf("sign counterparty: %v", err)
+	}
+	loanSet.GetCommon().CounterpartySignature = counterpartySignature
+	jtx.RequireTxSuccess(t, env.Submit(loanSet))
+	txHash, err := tx.ComputeTransactionHash(loanSet)
+	if err != nil {
+		t.Fatalf("compute transaction hash: %v", err)
+	}
+
+	env.SetTime(protocol.FromRippleTime(835360942))
+	env.Close()
+	txWithMeta, found, err := env.LastClosedLedger().GetTransaction(txHash)
+	if err != nil {
+		t.Fatalf("read closed transaction: %v", err)
+	}
+	if !found {
+		t.Fatal("closed ledger does not contain claimed LoanSet")
+	}
+	_, metaBytes, err := tx.SplitTxWithMetaBlob(txWithMeta)
+	if err != nil {
+		t.Fatalf("split transaction metadata: %v", err)
+	}
+	meta, err := binarycodec.Decode(hex.EncodeToString(metaBytes))
+	if err != nil {
+		t.Fatalf("decode transaction metadata: %v", err)
+	}
+	if got := meta["TransactionResult"]; got != "tecKILLED" {
+		t.Fatalf("closed transaction result: got %v want tecKILLED", got)
+	}
+
+	bidBytes, err := hex.DecodeString(bid)
+	if err != nil {
+		t.Fatalf("decode broker ID: %v", err)
+	}
+	var brokerKey [32]byte
+	copy(brokerKey[:], bidBytes)
+	if env.LedgerEntryExists(keylet.Loan(brokerKey, 1)) {
+		t.Fatal("LoanSet accepted a schedule that overflows from application view close time")
+	}
+
+	const applicationCloseTime = uint32(835360962)
+	interval = ^uint32(0) - applicationCloseTime - grace
+	loanSet = lending.NewLoanSet(borrower.Address, bid, "1000000")
+	loanSet.PaymentInterval = &interval
+	loanSet.GracePeriod = &grace
+	loanSet.Counterparty = owner.Address
+	loanSet.GetCommon().SigningPubKey = strings.ToUpper(borrower.PublicKeyHex())
+	counterpartySignature, err = txsign.SignCounterparty(
+		loanSet,
+		strings.ToUpper(owner.PublicKeyHex()),
+		"00"+strings.ToUpper(owner.PrivateKeyHex()),
+	)
+	if err != nil {
+		t.Fatalf("sign boundary counterparty: %v", err)
+	}
+	loanSet.GetCommon().CounterpartySignature = counterpartySignature
+	jtx.RequireTxSuccess(t, env.Submit(loanSet))
+
+	env.SetTime(protocol.FromRippleTime(835360943))
+	env.Close()
+	data, err := env.LedgerEntry(keylet.Loan(brokerKey, 1))
+	if err != nil {
+		t.Fatalf("read boundary Loan: %v", err)
+	}
+	loan, err := binarycodec.Decode(hex.EncodeToString(data))
+	if err != nil {
+		t.Fatalf("decode boundary Loan: %v", err)
+	}
+	if got := loan["StartDate"]; got != applicationCloseTime {
+		t.Fatalf("boundary StartDate: got %v want %d", got, applicationCloseTime)
+	}
+	if got := loan["NextPaymentDueDate"]; got != ^uint32(0)-grace {
+		t.Fatalf("boundary NextPaymentDueDate: got %v want %d", got, ^uint32(0)-grace)
+	}
+}

--- a/internal/testing/oracle/application_close_time_test.go
+++ b/internal/testing/oracle/application_close_time_test.go
@@ -1,0 +1,43 @@
+package oracle_test
+
+import (
+	"testing"
+
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	oracletest "github.com/LeJamon/go-xrpl/internal/testing/oracle"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/protocol"
+)
+
+func TestOracleSet_ReplayUsesApplicationViewCloseTime(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	owner := jtx.NewAccount("owner")
+	env.Fund(owner)
+
+	for env.Ledger().CloseTimeResolution() != 10 {
+		env.Close()
+	}
+	const parentCloseTime = uint32(835360951)
+	env.CloseToParentCloseTime(parentCloseTime)
+
+	env.EnableOpenLedgerReplay()
+	lastUpdateTime := uint32(protocol.RippleEpochUnix) + parentCloseTime + 301
+	result := env.Submit(oracletest.OracleSet(owner, 1, lastUpdateTime).
+		ProviderHex(32).
+		AssetClassHex(8).
+		AddPrice("XRP", "USD", 740, 1).
+		Fee(env.BaseFee()).
+		Build())
+	jtx.RequireTxClaimed(t, result, "tecINVALID_UPDATE_TIME")
+
+	env.SetTime(protocol.FromRippleTime(835360942))
+	env.Close()
+
+	closed := env.LastClosedLedger()
+	if got := protocol.ToRippleTime(closed.CloseTime()); got != 835360952 {
+		t.Fatalf("stored close time: got %d want 835360952", got)
+	}
+	if !env.LedgerEntryExists(keylet.Oracle(owner.ID, 1)) {
+		t.Fatal("OracleSet was not accepted against application view close time 835360961")
+	}
+}

--- a/internal/tx/engine_config.go
+++ b/internal/tx/engine_config.go
@@ -73,6 +73,14 @@ type EngineConfig struct {
 	// This is used for checking offer/escrow expiration
 	ParentCloseTime uint32
 
+	// ApplicationCloseTime is the successor header close time visible while
+	// transactions are applied. It differs from ParentCloseTime during a closed
+	// ledger build and from the accepted close time until the build is finalized.
+	ApplicationCloseTime uint32
+	// ApplicationCloseTimeSet distinguishes an explicitly supplied zero after
+	// NetClock wraparound from an unset application close time.
+	ApplicationCloseTimeSet bool
+
 	// ParentHash is the hash of the parent ledger.
 	// Used by pseudoAccountAddress for deterministic AMM account derivation.
 	// Reference: rippled View.cpp pseudoAccountAddress uses view.info().parentHash
@@ -134,6 +142,16 @@ type EngineConfig struct {
 	// flag controls (so fee=0 / already-validated txns are unaffected at normal
 	// load). Genuinely closed-ledger applies leave this false and never scale.
 	EnforceLoadFee bool
+}
+
+// CurrentCloseTime returns the application-view close time. The parent-time
+// fallback preserves open-view behavior for callers that do not build a closed
+// successor.
+func (c EngineConfig) CurrentCloseTime() uint32 {
+	if c.ApplicationCloseTimeSet {
+		return c.ApplicationCloseTime
+	}
+	return c.ParentCloseTime
 }
 
 // RequireRules returns the amendment rules for this apply. Rules must be plumbed

--- a/internal/tx/engine_config_test.go
+++ b/internal/tx/engine_config_test.go
@@ -1,0 +1,19 @@
+package tx
+
+import "testing"
+
+func TestCurrentCloseTimePreservesExplicitZero(t *testing.T) {
+	cfg := EngineConfig{
+		ParentCloseTime:         123,
+		ApplicationCloseTime:    0,
+		ApplicationCloseTimeSet: true,
+	}
+	if got := cfg.CurrentCloseTime(); got != 0 {
+		t.Fatalf("CurrentCloseTime() = %d, want explicit zero", got)
+	}
+
+	cfg.ApplicationCloseTimeSet = false
+	if got := cfg.CurrentCloseTime(); got != cfg.ParentCloseTime {
+		t.Fatalf("CurrentCloseTime() = %d, want parent %d", got, cfg.ParentCloseTime)
+	}
+}

--- a/internal/tx/lending/loan_set_apply.go
+++ b/internal/tx/lending/loan_set_apply.go
@@ -50,7 +50,7 @@ func (l *LoanSet) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Resul
 	}
 
 	// Schedule must fit in the 32-bit time field.
-	now := config.ParentCloseTime
+	now := config.CurrentCloseTime()
 	timeAvailable := ^uint32(0) - now
 	interval := valOr(l.PaymentInterval, minPaymentInterval)
 	total := valOr(l.PaymentTotal, 1)
@@ -215,7 +215,7 @@ func (l *LoanSet) Apply(ctx *tx.ApplyContext) ter.Result {
 		}
 	}
 
-	startDate := ctx.Config.ParentCloseTime
+	startDate := ctx.Config.CurrentCloseTime()
 	loanSeq := b.LoanSequence
 	loanKey := keylet.Loan(brokerID, loanSeq)
 

--- a/internal/tx/oracle/oracle_set.go
+++ b/internal/tx/oracle/oracle_set.go
@@ -158,6 +158,23 @@ type pairEntry struct {
 	scale      *uint8
 }
 
+func validateOracleUpdateTime(config tx.EngineConfig, lastUpdateTime uint32) ter.Result {
+	closeTime := uint64(config.CurrentCloseTime())
+	updateTime := uint64(lastUpdateTime)
+	if updateTime < uint64(protocol.RippleEpochUnix) {
+		return ter.TecINVALID_UPDATE_TIME
+	}
+	updateTime -= uint64(protocol.RippleEpochUnix)
+	if closeTime < MaxLastUpdateTimeDelta {
+		return ter.TecINTERNAL
+	}
+	if updateTime < closeTime-MaxLastUpdateTimeDelta ||
+		updateTime > closeTime+MaxLastUpdateTimeDelta {
+		return ter.TecINVALID_UPDATE_TIME
+	}
+	return ter.TesSUCCESS
+}
+
 // Apply applies an OracleSet transaction to the ledger state.
 // Combines rippled's SetOracle::preclaim() and SetOracle::doApply().
 // Reference: rippled SetOracle.cpp
@@ -169,26 +186,8 @@ func (o *OracleSet) Apply(ctx *tx.ApplyContext) ter.Result {
 		"priceDataCount", len(o.PriceDataSeries),
 	)
 
-	// --- Preclaim: Time validation ---
-	// Reference: rippled SetOracle.cpp preclaim lines 80-93
-	closeTime := uint64(ctx.Config.ParentCloseTime)
-	lastUpdateTime := uint64(o.LastUpdateTime)
-
-	if lastUpdateTime < uint64(protocol.RippleEpochUnix) {
-		return ter.TecINVALID_UPDATE_TIME
-	}
-	lastUpdateTimeEpoch := lastUpdateTime - uint64(protocol.RippleEpochUnix)
-
-	// Validate that lastUpdateTimeEpoch is within maxLastUpdateTimeDelta of closeTime.
-	// The lower-bound subtraction (closeTime - delta) is guarded to prevent underflow.
-	// In rippled this guard returns tecINTERNAL (LCOV_EXCL_LINE — effectively dead code
-	// since close time is always well past 300s in practice). We skip the range check
-	// entirely when closeTime is too small, matching the intent of the unreachable guard.
-	if closeTime >= MaxLastUpdateTimeDelta {
-		if lastUpdateTimeEpoch < (closeTime-MaxLastUpdateTimeDelta) ||
-			lastUpdateTimeEpoch > (closeTime+MaxLastUpdateTimeDelta) {
-			return ter.TecINVALID_UPDATE_TIME
-		}
+	if result := validateOracleUpdateTime(ctx.Config, o.LastUpdateTime); result != ter.TesSUCCESS {
+		return result
 	}
 
 	// --- Read oracle SLE to determine create vs update ---

--- a/internal/tx/oracle/oracle_set_time_test.go
+++ b/internal/tx/oracle/oracle_set_time_test.go
@@ -1,0 +1,26 @@
+package oracle
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/protocol"
+)
+
+func TestValidateOracleUpdateTimeUsesApplicationCloseTime(t *testing.T) {
+	config := tx.EngineConfig{
+		ParentCloseTime:         1000,
+		ApplicationCloseTime:    0,
+		ApplicationCloseTimeSet: true,
+	}
+	lastUpdateTime := uint32(protocol.RippleEpochUnix) + 1000
+	if got := validateOracleUpdateTime(config, lastUpdateTime); got != ter.TecINTERNAL {
+		t.Fatalf("wrapped application close time: got %s want tecINTERNAL", got)
+	}
+
+	config.ApplicationCloseTimeSet = false
+	if got := validateOracleUpdateTime(config, lastUpdateTime); got != ter.TesSUCCESS {
+		t.Fatalf("parent close time fallback: got %s want tesSUCCESS", got)
+	}
+}


### PR DESCRIPTION
## Summary

- use the closed application view's provisional successor time for `LoanSet` schedule validation and creation
- reconstruct that time for consensus builds, offline replay, replay-range, and inbound replay while preserving parent time for ordinary open-ledger ingress
- preserve uint32 NetClock wraparound and reject replay resolutions that do not derive from the parent header
- add the reported 835360951 / 10-second regression for `StartDate=835360961` and `NextPaymentDueDate=835361361`

## Test plan

- [x] focused ledger, engine, lending, replay, inbound, service, and synthetic replay regression tests
- [x] `just test-tx`
- [x] `just test-core` with an isolated Go build cache
- [x] affected packages with `-race`
- [x] `just build`
- [x] `just vet`
- [x] `go vet -tags postgres ./storage/relationaldb/postgres/`
- [x] `golangci-lint run --config .golangci.yml` (CI-pinned v2.11.3)
- [x] full integration run outside the existing conformance backlog; the sampled Vault failure reproduces on `origin/main`

Public devnet confirms the expected account and transaction roots for ledger 3,025,008. The historical multi-GB parent-state checkpoint is not available locally, so the committed regression exercises the same replay timing transition and exact serialized Loan fields without embedding the full devnet state.

Fixes #1332
