### PR TITLE
fix: restore escrow replay directory nodes

### DIFF
--- a/internal/replaytool/replay_reconstruct.go
+++ b/internal/replaytool/replay_reconstruct.go
@@ -145,6 +145,9 @@ func applyAffectedNode(
 			if let, ok := fields["LedgerEntryType"]; ok {
 				obj["LedgerEntryType"] = let
 			}
+			if entryType == "DirectoryNode" {
+				delete(deletedDirs, idx)
+			}
 			fillCreatedDefaults(obj, entryType)
 			fillBookDirectoryDefaults(obj, entryType)
 			threadPreviousTxn(obj, entryType, txHash, ledgerSeq)

--- a/internal/replaytool/replay_reconstruct_defaults.go
+++ b/internal/replaytool/replay_reconstruct_defaults.go
@@ -210,10 +210,6 @@ var explicitlyCreatedDefaults = map[string][]createdField{
 	},
 }
 
-// fillCreatedDefaults restores both required default-zero fields and optional
-// defaults that the entry's constructor always writes. An absent field in
-// CreatedNode.NewFields is therefore known to carry the listed default in the
-// canonical SLE.
 func fillCreatedDefaults(obj map[string]any, entryType string) {
 	for _, f := range requiredDefaults[entryType] {
 		if _, present := obj[f.Name]; !present {

--- a/internal/replaytool/replay_reconstruct_defaults.go
+++ b/internal/replaytool/replay_reconstruct_defaults.go
@@ -225,6 +225,29 @@ func fillCreatedDefaults(obj map[string]any, entryType string) {
 			obj[f.Name] = f.Value
 		}
 	}
+	if entryType == "Escrow" {
+		fillEscrowDirectoryDefaults(obj)
+	}
+}
+
+func fillEscrowDirectoryDefaults(obj map[string]any) {
+	account, hasAccount := metaAccountID(obj, "Account")
+	destination, hasDestination := metaAccountID(obj, "Destination")
+	if !hasAccount || !hasDestination {
+		return
+	}
+	if account != destination {
+		if _, present := obj["DestinationNode"]; !present {
+			obj["DestinationNode"] = "0"
+		}
+	}
+
+	issuer, hasIssuer := metaIssuer(obj, "Amount")
+	if hasIssuer && issuer != account && issuer != destination {
+		if _, present := obj["IssuerNode"]; !present {
+			obj["IssuerNode"] = "0"
+		}
+	}
 }
 
 // zeroHash160 is the JSON form binarycodec produces for an all-zero Hash160: the

--- a/internal/replaytool/replay_reconstruct_dir.go
+++ b/internal/replaytool/replay_reconstruct_dir.go
@@ -45,13 +45,16 @@ type dirPlacement struct {
 	Strategy dirStrategy
 }
 
-// dirDelta accumulates the membership changes a ledger makes to one directory
-// page. adds is in operation order (needed for append-ordered offer books);
-// removes is a set.
+type dirOperation struct {
+	key [32]byte
+	add bool
+}
+
+// dirDelta accumulates the ordered membership changes a ledger makes to one
+// directory page.
 type dirDelta struct {
-	strategy dirStrategy
-	adds     [][32]byte
-	removes  map[[32]byte]bool
+	strategy   dirStrategy
+	operations []dirOperation
 }
 
 // recordMembership attributes an object's creation (isAdd) or deletion to every
@@ -60,14 +63,10 @@ func recordMembership(deltas map[[32]byte]*dirDelta, objKey [32]byte, entryType 
 	for _, p := range directoryPlacements(entryType, fields) {
 		d := deltas[p.Key]
 		if d == nil {
-			d = &dirDelta{strategy: p.Strategy, removes: map[[32]byte]bool{}}
+			d = &dirDelta{strategy: p.Strategy}
 			deltas[p.Key] = d
 		}
-		if isAdd {
-			d.adds = append(d.adds, objKey)
-		} else {
-			d.removes[objKey] = true
-		}
+		d.operations = append(d.operations, dirOperation{key: objKey, add: isAdd})
 	}
 }
 
@@ -199,32 +198,33 @@ func reconstructDirIndexes(state *shamap.SHAMap, deltas map[[32]byte]*dirDelta, 
 	return nil
 }
 
-// applyDirDelta applies one page's membership delta to its prior members,
-// reproducing rippled's ordering: removals preserve relative order; additions
-// append in operation order, then the whole page is sorted when the directory is
-// sorted (dirInsert) rather than append-ordered (dirAppend). A key both added
-// and removed in the same ledger ends up absent.
+// applyDirDelta applies one page's membership operations in transaction order.
+// Removals preserve relative order and additions append, then the whole page is
+// sorted when the directory is sorted (dirInsert) rather than append-ordered
+// (dirAppend).
 func applyDirDelta(members [][32]byte, d *dirDelta) [][32]byte {
-	if len(d.removes) > 0 {
-		kept := make([][32]byte, 0, len(members))
-		for _, k := range members {
-			if !d.removes[k] {
-				kept = append(kept, k)
-			}
-		}
-		members = kept
-	}
-
 	present := make(map[[32]byte]bool, len(members))
 	for _, k := range members {
 		present[k] = true
 	}
-	for _, k := range d.adds {
-		if present[k] || d.removes[k] {
+	for _, op := range d.operations {
+		if op.add {
+			if !present[op.key] {
+				members = append(members, op.key)
+				present[op.key] = true
+			}
 			continue
 		}
-		members = append(members, k)
-		present[k] = true
+		if !present[op.key] {
+			continue
+		}
+		for i, key := range members {
+			if key == op.key {
+				members = append(members[:i], members[i+1:]...)
+				break
+			}
+		}
+		delete(present, op.key)
 	}
 
 	if d.strategy == dirSorted {

--- a/internal/replaytool/replay_reconstruct_dir.go
+++ b/internal/replaytool/replay_reconstruct_dir.go
@@ -269,10 +269,9 @@ func encodeIndexes(members [][32]byte) []string {
 }
 
 // metaUint64 reads a UInt64 (hex string) or UInt32 (numeric) metadata field as a
-// uint64, returning 0 when the field is absent or unparseable. Node-pointer
-// fields are sMD_Default (always present on created/deleted nodes), so an absent
-// field attributing to page 0 only arises on malformed input, which the final
-// account_hash check catches.
+// uint64, returning 0 when the field is absent or unparseable. Callers establish
+// whether an optional node-pointer applies before interpreting an absent value
+// as page zero.
 func metaUint64(v any) uint64 {
 	switch t := v.(type) {
 	case string:

--- a/internal/replaytool/replay_reconstruct_dir.go
+++ b/internal/replaytool/replay_reconstruct_dir.go
@@ -50,8 +50,6 @@ type dirOperation struct {
 	add bool
 }
 
-// dirDelta accumulates the ordered membership changes a ledger makes to one
-// directory page.
 type dirDelta struct {
 	strategy   dirStrategy
 	operations []dirOperation

--- a/internal/replaytool/replay_reconstruct_test.go
+++ b/internal/replaytool/replay_reconstruct_test.go
@@ -550,6 +550,131 @@ func TestReconstructFromMeta_DirectoryIndexes(t *testing.T) {
 	assertEntryBytes(t, corrected, bookRoot, wantBook, "order book directory")
 }
 
+func TestFillCreatedDefaults_EscrowDirectoryNodes(t *testing.T) {
+	const destination = "rrrrrrrrrrrrrrrrrrrrBZbvji"
+	const issuer = "rrrrrrrrrrrrrrrrrrrrrhoLvTp"
+
+	tests := []struct {
+		name       string
+		fields     map[string]any
+		wantDest   any
+		wantIssuer any
+	}{
+		{
+			name: "cross-account page zero",
+			fields: map[string]any{
+				"Account": testAccount, "Destination": destination, "Amount": "10000",
+			},
+			wantDest: "0",
+		},
+		{
+			name: "self escrow",
+			fields: map[string]any{
+				"Account": testAccount, "Destination": testAccount, "Amount": "10000",
+			},
+		},
+		{
+			name: "self IOU escrow with third-party issuer",
+			fields: map[string]any{
+				"Account": testAccount, "Destination": testAccount,
+				"Amount": map[string]any{"value": "10", "currency": "USD", "issuer": issuer},
+			},
+			wantIssuer: "0",
+		},
+		{
+			name: "explicit nonzero directory pages",
+			fields: map[string]any{
+				"Account": testAccount, "Destination": destination,
+				"Amount":          map[string]any{"value": "10", "currency": "USD", "issuer": issuer},
+				"DestinationNode": "2", "IssuerNode": "3",
+			},
+			wantDest: "2", wantIssuer: "3",
+		},
+		{
+			name: "third-party IOU issuer page zero",
+			fields: map[string]any{
+				"Account": testAccount, "Destination": destination,
+				"Amount": map[string]any{"value": "10", "currency": "USD", "issuer": issuer},
+			},
+			wantDest: "0", wantIssuer: "0",
+		},
+		{
+			name: "destination is IOU issuer",
+			fields: map[string]any{
+				"Account": testAccount, "Destination": destination,
+				"Amount": map[string]any{"value": "10", "currency": "USD", "issuer": destination},
+			},
+			wantDest: "0",
+		},
+		{
+			name: "MPT has no issuer directory",
+			fields: map[string]any{
+				"Account": testAccount, "Destination": destination,
+				"Amount": map[string]any{"value": "10", "mpt_issuance_id": "000000000000000000000000000000000000000000000001"},
+			},
+			wantDest: "0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fillCreatedDefaults(tt.fields, "Escrow")
+			if got := tt.fields["DestinationNode"]; got != tt.wantDest {
+				t.Fatalf("DestinationNode = %v, want %v", got, tt.wantDest)
+			}
+			if got := tt.fields["IssuerNode"]; got != tt.wantIssuer {
+				t.Fatalf("IssuerNode = %v, want %v", got, tt.wantIssuer)
+			}
+		})
+	}
+}
+
+func TestReconstructFromMeta_EscrowDestinationDirPageZero(t *testing.T) {
+	const destination = "rrrrrrrrrrrrrrrrrrrrBZbvji"
+	const escrowKeyHex = "07D546EC9389810CEEC2D5C843171BE9F07EAEA05039E5466BF4AC5B19AEAE7C"
+
+	destinationID, err := state.DecodeAccountID(destination)
+	if err != nil {
+		t.Fatalf("DecodeAccountID: %v", err)
+	}
+	destinationPage := keylet.OwnerDirPage(destinationID, 0).Key
+	destinationPageHex := strings.ToUpper(hex.EncodeToString(destinationPage[:]))
+	escrowKey := mustIndex(t, escrowKeyHex)
+
+	meta := encodeMeta(t,
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "DirectoryNode",
+			"LedgerIndex":     destinationPageHex,
+			"NewFields":       map[string]any{"Owner": destination, "RootIndex": destinationPageHex},
+		}},
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "Escrow",
+			"LedgerIndex":     escrowKeyHex,
+			"NewFields": map[string]any{
+				"Account": testAccount, "Destination": destination, "Amount": "10000",
+			},
+		}},
+	)
+
+	corrected, err := reconstructFromMeta(putAll(t, nil), []metaTx{{Blob: meta, TxHash: mustIndex(t, testTxHashHex)}}, testLedgerSeq)
+	if err != nil {
+		t.Fatalf("reconstructFromMeta: %v", err)
+	}
+
+	wantEscrow := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "Escrow", "Flags": 0, "OwnerNode": "0", "DestinationNode": "0",
+		"Account": testAccount, "Destination": destination, "Amount": "10000",
+		"PreviousTxnID": testTxHashHex, "PreviousTxnLgrSeq": testLedgerSeq,
+	})
+	wantDestinationDir := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "DirectoryNode", "Flags": 0, "Owner": destination,
+		"RootIndex": destinationPageHex, "Indexes": []string{escrowKeyHex},
+		"PreviousTxnID": testTxHashHex, "PreviousTxnLgrSeq": testLedgerSeq,
+	})
+	assertEntryBytes(t, corrected, escrowKey, wantEscrow, "escrow")
+	assertEntryBytes(t, corrected, destinationPage, wantDestinationDir, "destination directory")
+}
+
 // TestReconstructFromMeta_EscrowIssuerDir covers the issuer owner-directory an
 // IOU escrow is listed in (beyond the owner's and destination's): rippled adds a
 // cross-issuer IOU escrow to the issuer's directory to track the locked balance,
@@ -590,12 +715,9 @@ func TestReconstructFromMeta_EscrowIssuerDir(t *testing.T) {
 			"LedgerEntryType": "Escrow",
 			"LedgerIndex":     escrowKey,
 			"NewFields": map[string]any{
-				"Account":         testAccount,
-				"Destination":     destination,
-				"Amount":          map[string]any{"value": "10", "currency": "USD", "issuer": issuer},
-				"OwnerNode":       "0",
-				"DestinationNode": "0",
-				"IssuerNode":      "0",
+				"Account":     testAccount,
+				"Destination": destination,
+				"Amount":      map[string]any{"value": "10", "currency": "USD", "issuer": issuer},
 			},
 		}},
 	)
@@ -615,7 +737,15 @@ func TestReconstructFromMeta_EscrowIssuerDir(t *testing.T) {
 		"PreviousTxnID":     testTxHashHex,
 		"PreviousTxnLgrSeq": testLedgerSeq,
 	})
+	wantEscrow := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "Escrow", "Flags": 0, "OwnerNode": "0",
+		"DestinationNode": "0", "IssuerNode": "0", "Account": testAccount,
+		"Destination":   destination,
+		"Amount":        map[string]any{"value": "10", "currency": "USD", "issuer": issuer},
+		"PreviousTxnID": testTxHashHex, "PreviousTxnLgrSeq": testLedgerSeq,
+	})
 	assertEntryBytes(t, corrected, issuerPage, wantIssuerDir, "issuer directory")
+	assertEntryBytes(t, corrected, mustIndex(t, escrowKey), wantEscrow, "escrow")
 }
 
 // TestReconstructFromMeta_CreatedBookDirectoryXRPSide is the issue's exact

--- a/internal/replaytool/replay_reconstruct_test.go
+++ b/internal/replaytool/replay_reconstruct_test.go
@@ -675,6 +675,132 @@ func TestReconstructFromMeta_EscrowDestinationDirPageZero(t *testing.T) {
 	assertEntryBytes(t, corrected, destinationPage, wantDestinationDir, "destination directory")
 }
 
+func TestReconstructFromMeta_DirectoryDeletedThenRecreated(t *testing.T) {
+	const destination = "rrrrrrrrrrrrrrrrrrrrBZbvji"
+	const escrowKeyHex = "07D546EC9389810CEEC2D5C843171BE9F07EAEA05039E5466BF4AC5B19AEAE7C"
+	const deletedTxHashHex = "1111111111111111111111111111111111111111111111111111111111111111"
+	const priorTxHashHex = "2222222222222222222222222222222222222222222222222222222222222222"
+
+	destinationID, err := state.DecodeAccountID(destination)
+	if err != nil {
+		t.Fatalf("DecodeAccountID: %v", err)
+	}
+	authorizedID, err := state.DecodeAccountID(testAccount)
+	if err != nil {
+		t.Fatalf("DecodeAccountID: %v", err)
+	}
+	destinationPage := keylet.OwnerDirPage(destinationID, 0).Key
+	destinationPageHex := strings.ToUpper(hex.EncodeToString(destinationPage[:]))
+	oldKey := keylet.DepositPreauth(destinationID, authorizedID).Key
+	oldKeyHex := strings.ToUpper(hex.EncodeToString(oldKey[:]))
+	escrowKey := mustIndex(t, escrowKeyHex)
+
+	preState := putAll(t, map[[32]byte][]byte{
+		destinationPage: encodeSLE(t, map[string]any{
+			"LedgerEntryType": "DirectoryNode", "Flags": 0, "Owner": destination,
+			"RootIndex": destinationPageHex, "Indexes": []string{oldKeyHex},
+		}),
+		oldKey: encodeSLE(t, map[string]any{
+			"LedgerEntryType": "DepositPreauth", "Flags": 0,
+			"Account": destination, "Authorize": testAccount, "OwnerNode": "0",
+			"PreviousTxnID": priorTxHashHex, "PreviousTxnLgrSeq": testLedgerSeq - 1,
+		}),
+	})
+	deleteMeta := encodeMeta(t,
+		map[string]any{"DeletedNode": map[string]any{
+			"LedgerEntryType": "DepositPreauth",
+			"LedgerIndex":     oldKeyHex,
+			"FinalFields":     map[string]any{"Account": destination, "Authorize": testAccount, "Flags": 0, "OwnerNode": "0"},
+		}},
+		map[string]any{"DeletedNode": map[string]any{
+			"LedgerEntryType": "DirectoryNode",
+			"LedgerIndex":     destinationPageHex,
+			"FinalFields":     map[string]any{"Flags": 0, "Owner": destination, "RootIndex": destinationPageHex},
+		}},
+	)
+	createMeta := encodeMeta(t,
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "DirectoryNode",
+			"LedgerIndex":     destinationPageHex,
+			"NewFields":       map[string]any{"Owner": destination, "RootIndex": destinationPageHex},
+		}},
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "Escrow",
+			"LedgerIndex":     escrowKeyHex,
+			"NewFields": map[string]any{
+				"Account": testAccount, "Destination": destination, "Amount": "10000",
+			},
+		}},
+	)
+
+	corrected, err := reconstructFromMeta(preState, []metaTx{
+		{Blob: deleteMeta, TxHash: mustIndex(t, deletedTxHashHex)},
+		{Blob: createMeta, TxHash: mustIndex(t, testTxHashHex)},
+	}, testLedgerSeq)
+	if err != nil {
+		t.Fatalf("reconstructFromMeta: %v", err)
+	}
+
+	wantDestinationDir := encodeSLE(t, map[string]any{
+		"LedgerEntryType": "DirectoryNode", "Flags": 0, "Owner": destination,
+		"RootIndex": destinationPageHex, "Indexes": []string{escrowKeyHex},
+		"PreviousTxnID": testTxHashHex, "PreviousTxnLgrSeq": testLedgerSeq,
+	})
+	assertEntryBytes(t, corrected, destinationPage, wantDestinationDir, "recreated destination directory")
+	if _, found, err := corrected.Get(escrowKey); err != nil || !found {
+		t.Fatalf("recreated escrow missing (found=%v err=%v)", found, err)
+	}
+	if _, found, err := corrected.Get(oldKey); err != nil || found {
+		t.Fatalf("deleted deposit preauth present (found=%v err=%v)", found, err)
+	}
+}
+
+func TestRecordMembership_LastOperationWins(t *testing.T) {
+	const account = "rrrrrrrrrrrrrrrrrrrrBZbvji"
+	objectKey := mustIndex(t, "00000000000000000000000000000000000000000000000000000000000000D1")
+	otherKey := mustIndex(t, "00000000000000000000000000000000000000000000000000000000000000D2")
+	accountID, err := state.DecodeAccountID(account)
+	if err != nil {
+		t.Fatalf("DecodeAccountID: %v", err)
+	}
+	pageKey := keylet.OwnerDirPage(accountID, 0).Key
+	fields := map[string]any{"Account": account, "OwnerNode": "0"}
+
+	t.Run("remove then add", func(t *testing.T) {
+		deltas := map[[32]byte]*dirDelta{}
+		recordMembership(deltas, objectKey, "DID", fields, false)
+		recordMembership(deltas, objectKey, "DID", fields, true)
+		members := applyDirDelta([][32]byte{objectKey}, deltas[pageKey])
+		if len(members) != 1 || members[0] != objectKey {
+			t.Fatalf("members = %x, want recreated key", members)
+		}
+	})
+
+	t.Run("add then remove", func(t *testing.T) {
+		deltas := map[[32]byte]*dirDelta{}
+		recordMembership(deltas, objectKey, "DID", fields, true)
+		recordMembership(deltas, objectKey, "DID", fields, false)
+		members := applyDirDelta(nil, deltas[pageKey])
+		if len(members) != 0 {
+			t.Fatalf("members = %x, want empty", members)
+		}
+	})
+
+	t.Run("append remove then add", func(t *testing.T) {
+		delta := &dirDelta{
+			strategy: dirAppend,
+			operations: []dirOperation{
+				{key: objectKey, add: false},
+				{key: objectKey, add: true},
+			},
+		}
+		members := applyDirDelta([][32]byte{objectKey, otherKey}, delta)
+		if len(members) != 2 || members[0] != otherKey || members[1] != objectKey {
+			t.Fatalf("members = %x, want existing key then re-added key", members)
+		}
+	})
+}
+
 // TestReconstructFromMeta_EscrowIssuerDir covers the issuer owner-directory an
 // IOU escrow is listed in (beyond the owner's and destination's): rippled adds a
 // cross-issuer IOU escrow to the issuer's directory to track the locked balance,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,45 @@
+# Issue #1336 — Escrow replay directory defaults
+
+Target: `origin/main` at `f0db8a22e1386116d08eb7efb21889997bd97af4`.
+Behavioral oracle: clean local rippled `3.2.0` worktree at
+`3c43f4614f87965298773279ff5b85d4c56c637b`.
+
+## Plan
+
+- [x] Validate GitHub state, duplicate PRs, the post-v3.0.0 `main` base, and a
+      clean dedicated worktree.
+- [x] Trace created-Escrow default restoration and directory placement in Go,
+      then verify `DestinationNode` and `IssuerNode` semantics against rippled
+      v3.2.0.
+- [x] Add focused regressions for cross-account page zero, self-escrow, and an
+      explicit nonzero destination page, plus any oracle-confirmed IOU issuer
+      default case.
+- [x] Implement the minimal deterministic default inference before directory
+      placement without extending the inference to PayChannels.
+- [x] Run formatting, focused and race tests, vet, strict lint, build, and a
+      final correctness/conformance diff review.
+- [x] Record review results, commit intentional files, push the branch, open the
+      PR, and verify its exact remote head and checks.
+
+## Review
+
+- Created Escrows now recover a missing zero `DestinationNode` only when sender
+  and destination differ, and a missing zero `IssuerNode` only for a classic
+  IOU whose issuer differs from both. Explicit nonzero pages are preserved;
+  XRP, MPT, self, and issuer-equals-destination cases retain rippled's field
+  presence semantics. PayChannel inference remains unchanged.
+- The restored fields feed the existing directory-placement pass, rebuilding
+  page-zero destination and issuer membership as well as the canonical Escrow
+  bytes omitted by CreatedNode metadata.
+- Regression coverage includes cross-account XRP page zero, XRP and IOU self
+  escrow, explicit nonzero destination/issuer pages, third-party IOU issuer page
+  zero, issuer-as-destination, and MPT exclusion.
+- Independent Go and conformance reviews are clean against local rippled 3.2.0
+  at `3c43f4614f87965298773279ff5b85d4c56c637b`.
+- Passed `go test ./internal/replaytool -count=1`, focused race tests, `just vet`,
+  CI-pinned strict and advisory lint with zero issues, `just build`, formatting,
+  and `git diff --check`.
+
 # Issue #1322 — nodestore fallback for ledger hash lookup
 
 ## Goal


### PR DESCRIPTION
## Summary
- restore zero-valued `DestinationNode` for created cross-account Escrows when rippled metadata omits the field
- restore zero-valued `IssuerNode` for third-party classic IOU Escrows and rebuild both owner-directory memberships
- preserve self-escrow, shared-issuer, MPT, and explicit nonzero page behavior from rippled v3.2.0

## Test plan
- [x] `go test ./internal/replaytool -count=1`
- [x] `go test -race ./internal/replaytool -count=1`
- [x] `just vet`
- [x] `golangci-lint run`
- [x] `just lint`
- [x] `just build`
- [x] `git diff --check`

Fixes #1336
