### PR TITLE
fix: support historical paychan replay

### DIFF
--- a/internal/ledger/amendments.go
+++ b/internal/ledger/amendments.go
@@ -25,8 +25,7 @@ func LoadAmendmentsFromLedger(reader Reader) (*amendment.Rules, error) {
 		return nil, fmt.Errorf("failed to check amendments existence: %w", err)
 	}
 	if !exists {
-		// No SLE: only the permanently-enabled retired amendments are active
-		// (never stored, but their code runs unconditionally in rippled).
+		// No SLE: only the permanently-enabled retired baseline is active.
 		return amendment.NewRules(amendment.PermanentlyEnabledIDs()), nil
 	}
 
@@ -58,7 +57,7 @@ func loadAmendmentsFromData(data []byte) (*amendment.Rules, error) {
 		return nil, fmt.Errorf("failed to parse amendments entry: %w", err)
 	}
 
-	// Retired amendments are permanently enabled but never stored in the SLE.
+	// Retired amendments are enabled independently of their serialized presence.
 	enabledIDs = append(enabledIDs, amendment.PermanentlyEnabledIDs()...)
 	return amendment.NewRules(enabledIDs), nil
 }
@@ -248,9 +247,24 @@ func LoadAmendmentsFromLedgerEntry(data []byte) (*amendment.Rules, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Retired amendments are permanently enabled but never stored (see LoadAmendmentsFromLedger).
+	// Retired amendments are enabled independently of their serialized presence.
 	enabledIDs = append(enabledIDs, amendment.PermanentlyEnabledIDs()...)
 	return amendment.NewRules(enabledIDs), nil
+}
+
+// IsAmendmentStoredInLedgerEntry reports whether featureID is serialized in the
+// entry, without applying rule aliases or the current retired-amendment baseline.
+func IsAmendmentStoredInLedgerEntry(data []byte, featureID [32]byte) (bool, error) {
+	enabledIDs, err := parseAmendmentsEntry(data)
+	if err != nil {
+		return false, err
+	}
+	for _, id := range enabledIDs {
+		if id == featureID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // LoadAmendmentsFromHex parses a hex-encoded Amendments ledger entry.

--- a/internal/ledger/amendments_obsolete_test.go
+++ b/internal/ledger/amendments_obsolete_test.go
@@ -105,3 +105,38 @@ func TestLoadAmendments_RetiredPermanentlyEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestIsAmendmentStoredInLedgerEntry_ExactMembership(t *testing.T) {
+	data := encodeAmendmentsEntry(t, [][32]byte{
+		amendment.FeatureFlow,
+		amendment.FeatureNonFungibleTokensV1_1,
+	})
+
+	for _, tc := range []struct {
+		name string
+		id   [32]byte
+		want bool
+	}{
+		{name: "stored", id: amendment.FeatureFlow, want: true},
+		{name: "retired baseline is not injected", id: amendment.FeatureFixPayChanRecipientOwnerDir},
+		{name: "rule alias is not treated as stored", id: amendment.FeatureNonFungibleTokensV1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := IsAmendmentStoredInLedgerEntry(data, tc.id)
+			if err != nil {
+				t.Fatalf("IsAmendmentStoredInLedgerEntry: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("IsAmendmentStoredInLedgerEntry = %t, want %t", got, tc.want)
+			}
+		})
+	}
+
+	current, err := LoadAmendmentsFromLedgerEntry(data)
+	if err != nil {
+		t.Fatalf("LoadAmendmentsFromLedgerEntry: %v", err)
+	}
+	if !current.Enabled(amendment.FeatureFixPayChanRecipientOwnerDir) {
+		t.Fatal("the default loader must preserve the current retired-amendment baseline")
+	}
+}

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -49,6 +49,7 @@ type replayRangeRunner struct {
 	continueOnDivergence bool
 	findingsOut          string
 	goxrplCommit         string
+	legacyPayChanDirGate bool
 }
 
 // newReplayRangeCmd builds the `replay-range` command and its flags.
@@ -78,6 +79,12 @@ pseudo-transactions are applied, so modern (post-amendment) ranges replay
 correctly. The seed state's tree root is verified against the known
 account_hash before replay starts, so an incomplete or corrupt import fails
 fast instead of looking like an execution bug at from+1.
+
+Retired amendment IDs may be absent from that ledger entry, so it cannot always
+identify their historical behavior. Replay uses rippled v3.2.0 semantics by
+default. For ranges known to predate fixPayChanRecipientOwnerDir,
+--legacy-paychan-owner-dir-gate restores that amendment's historical
+parent-ledger gate without changing live behavior.
 
 By default the whole state tree is held in RAM (~6-12 GB for a mainnet
 checkpoint). With --nodestore-dir the seed state is instead held lazily in a
@@ -129,6 +136,7 @@ Example:
 	cmd.Flags().BoolVar(&r.continueOnDivergence, "continue-on-divergence", false, "On a hash mismatch, record a finding and reset to mainnet ground truth, then continue (survey all divergences) instead of stopping")
 	cmd.Flags().StringVar(&r.findingsOut, "findings-out", "", "Path to the findings JSONL file (default <dump-dir>/findings.jsonl or ./debug/findings.jsonl); used with --continue-on-divergence")
 	cmd.Flags().StringVar(&r.goxrplCommit, "goxrpl-commit", "", "Commit/image tag recorded in findings (default: VCS revision from build info)")
+	cmd.Flags().BoolVar(&r.legacyPayChanDirGate, "legacy-paychan-owner-dir-gate", false, "Derive fixPayChanRecipientOwnerDir from each parent ledger instead of assuming current v3.2.0 semantics")
 
 	// MarkFlagRequired only errors if the flag does not exist — a construction
 	// bug, so fail fast rather than ignoring the error.
@@ -197,6 +205,11 @@ func (r *replayRangeRunner) run() error {
 	fmt.Fprintln(r.out, "                    XRPL Continuous State Replay")
 	fmt.Fprintln(r.out, "================================================================================")
 	fmt.Fprintf(r.out, "Range:      %d -> %d (%d blocks)\n", r.from, r.to, r.to-r.from)
+	if r.legacyPayChanDirGate {
+		fmt.Fprintln(r.out, "Compatibility: historical fixPayChanRecipientOwnerDir gate")
+	} else {
+		fmt.Fprintln(r.out, "Compatibility: rippled v3.2.0 retired-amendment semantics")
+	}
 	fmt.Fprintf(r.out, "Started at: %s\n", startTime.Format(time.RFC3339))
 	fmt.Fprintln(r.out)
 
@@ -528,6 +541,24 @@ func loadRulesFromState(stateMap *shamap.SHAMap) (*amendment.Rules, error) {
 	return rules, nil
 }
 
+func replayPreFixPayChanRecipientOwnerDir(stateMap *shamap.SHAMap, historicalGate bool) (bool, error) {
+	if !historicalGate {
+		return false, nil
+	}
+	item, found, err := stateMap.Get(keylet.Amendments().Key)
+	if err != nil {
+		return false, fmt.Errorf("reading amendments entry: %w", err)
+	}
+	if !found || item == nil {
+		return true, nil
+	}
+	enabled, err := ledger.IsAmendmentStoredInLedgerEntry(item.Data(), amendment.FeatureFixPayChanRecipientOwnerDir)
+	if err != nil {
+		return false, fmt.Errorf("parsing stored amendments entry: %w", err)
+	}
+	return !enabled, nil
+}
+
 // extractFeesFromSHAMap extracts the fee schedule from the FeeSettings entry of
 // a state SHAMap, falling back to the default schedule when it is absent or
 // undecodable.
@@ -613,6 +644,10 @@ func (r *replayRangeRunner) processBlock(
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading amendments: %w", err)
 	}
+	replayPreFix, err := replayPreFixPayChanRecipientOwnerDir(preStateMap, r.legacyPayChanDirGate)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading historical fixPayChanRecipientOwnerDir state: %w", err)
+	}
 
 	// Flag-ledger NegativeUNL transition: on a flag ledger, apply the pending
 	// ValidatorToDisable / ValidatorToReEnable transitions to the NegativeUNL
@@ -631,15 +666,16 @@ func (r *replayRangeRunner) processBlock(
 
 	// Setup engine
 	engineConfig := tx.EngineConfig{
-		BaseFee:                   uint64(fees.Base),
-		ReserveBase:               uint64(fees.Reserve),
-		ReserveIncrement:          uint64(fees.Increment),
-		LedgerSequence:            targetLedger,
-		ParentHash:                preSnapshot.LedgerHash,
-		ParentCloseTime:           protocol.ToRippleTime(parentCloseTime),
-		SkipSignatureVerification: true,
-		Standalone:                true,
-		Rules:                     rules,
+		BaseFee:                              uint64(fees.Base),
+		ReserveBase:                          uint64(fees.Reserve),
+		ReserveIncrement:                     uint64(fees.Increment),
+		LedgerSequence:                       targetLedger,
+		ParentHash:                           preSnapshot.LedgerHash,
+		ParentCloseTime:                      protocol.ToRippleTime(parentCloseTime),
+		SkipSignatureVerification:            true,
+		Standalone:                           true,
+		ReplayPreFixPayChanRecipientOwnerDir: replayPreFix,
+		Rules:                                rules,
 	}
 
 	engine := txengine.NewEngine(openLedger, engineConfig)

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -113,6 +113,7 @@ Example:
     xrpld replay-range --from 32750 --to 32800
     xrpld replay-range --from 32750 --to 32800 -v
     xrpld replay-range --from 32750 --to 32800 --dump-dir ./debug
+    xrpld replay-range --from 3100000 --to 3278999 --legacy-paychan-owner-dir-gate
     xrpld replay-range --from 99226370 --to 99236370 --checkpoint-dir ./ckpt
     xrpld replay-range --from 99226370 --to 99236370 --checkpoint-dir ./ckpt --resume-from 99230000`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/replaytool/replay_range_test.go
+++ b/internal/replaytool/replay_range_test.go
@@ -99,6 +99,62 @@ func TestLoadRulesFromState_Populated(t *testing.T) {
 	if rules.Enabled(disabledID) {
 		t.Error("expected AMM to be disabled")
 	}
+	if !rules.Enabled(amendment.FeatureFixPayChanRecipientOwnerDir) {
+		t.Error("expected the current retired-amendment baseline to enable fixPayChanRecipientOwnerDir")
+	}
+}
+
+func TestReplayPreFixPayChanRecipientOwnerDir(t *testing.T) {
+	withoutFix, err := pseudo.SerializeAmendmentsSLE(&pseudo.AmendmentsSLE{
+		Amendments: [][32]byte{amendment.FeatureFlow},
+	})
+	if err != nil {
+		t.Fatalf("serializing amendments SLE without fix: %v", err)
+	}
+	withFix, err := pseudo.SerializeAmendmentsSLE(&pseudo.AmendmentsSLE{
+		Amendments: [][32]byte{amendment.FeatureFlow, amendment.FeatureFixPayChanRecipientOwnerDir},
+	})
+	if err != nil {
+		t.Fatalf("serializing amendments SLE with fix: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name           string
+		historicalGate bool
+		entry          []byte
+		wantPreFix     bool
+	}{
+		{name: "default ignores absent retired ID", entry: withoutFix},
+		{name: "historical gate before activation", historicalGate: true, entry: withoutFix, wantPreFix: true},
+		{name: "historical gate after activation", historicalGate: true, entry: withFix},
+		{name: "historical gate without Amendments entry", historicalGate: true, wantPreFix: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			entries := map[[32]byte][]byte{{0x01}: entry(0xaa)}
+			if tc.entry != nil {
+				entries[keylet.Amendments().Key] = tc.entry
+			}
+			stateMap := buildReplayStateMap(t, entries)
+			got, err := replayPreFixPayChanRecipientOwnerDir(stateMap, tc.historicalGate)
+			if err != nil {
+				t.Fatalf("replayPreFixPayChanRecipientOwnerDir: %v", err)
+			}
+			if got != tc.wantPreFix {
+				t.Fatalf("replayPreFixPayChanRecipientOwnerDir = %t, want %t", got, tc.wantPreFix)
+			}
+		})
+	}
+}
+
+func TestReplayRangeLegacyPayChanOwnerDirFlag(t *testing.T) {
+	cmd := newReplayRangeCmd()
+	flag := cmd.Flags().Lookup("legacy-paychan-owner-dir-gate")
+	if flag == nil {
+		t.Fatal("legacy-paychan-owner-dir-gate flag is not registered")
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("legacy-paychan-owner-dir-gate default = %q, want false", flag.DefValue)
+	}
 }
 
 func TestCheckpointRoundTrip(t *testing.T) {

--- a/internal/testing/paychan/paychan_recipient_owner_dir_test.go
+++ b/internal/testing/paychan/paychan_recipient_owner_dir_test.go
@@ -1,0 +1,67 @@
+package paychan
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayChanCreateRecipientOwnerDirectoryCompatibility(t *testing.T) {
+	tests := []struct {
+		name             string
+		replayPreFix     bool
+		wantRecipientDir bool
+	}{
+		{name: "v3.2.0", wantRecipientDir: true},
+		{name: "pre-fix replay", replayPreFix: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			env := jtx.NewTestEnv(t)
+			alice := jtx.NewAccount("alice")
+			bob := jtx.NewAccount("bob")
+			env.FundAmount(alice, uint64(jtx.XRP(10000)))
+			env.FundAmount(bob, uint64(jtx.XRP(10000)))
+			env.Close()
+
+			sequence := env.Seq(alice)
+			channelKey := chanKeylet(alice, bob, sequence)
+			transaction := ChannelCreate(alice, bob, xrp(1000), 100, alice.PublicKeyHex()).
+				Sequence(sequence).
+				Build()
+
+			result := txengine.NewEngine(env.Ledger(), tx.EngineConfig{
+				BaseFee:                              env.BaseFee(),
+				ReserveBase:                          env.ReserveBase(),
+				ReserveIncrement:                     env.ReserveIncrement(),
+				LedgerSequence:                       env.LedgerSeq(),
+				SkipSignatureVerification:            true,
+				ReplayPreFixPayChanRecipientOwnerDir: test.replayPreFix,
+				ParentCloseTime:                      env.NowRipple(),
+				ParentHash:                           env.Ledger().ParentHash(),
+				Rules:                                amendment.AllSupportedRules(),
+				OpenLedger:                           true,
+			}).Apply(transaction)
+			require.Equal(t, "tesSUCCESS", result.Result.String())
+			require.True(t, result.Applied)
+
+			data, err := env.LedgerEntry(channelKey)
+			require.NoError(t, err)
+			channel, err := state.ParsePayChannel(data)
+			require.NoError(t, err)
+
+			require.True(t, inOwnerDir(env, alice, channelKey.Key))
+			require.Equal(t, test.wantRecipientDir, inOwnerDir(env, bob, channelKey.Key))
+			require.Equal(t, test.wantRecipientDir, channel.HasDestNode)
+			if test.wantRecipientDir {
+				require.Equal(t, uint64(0), channel.DestinationNode)
+			}
+		})
+	}
+}

--- a/internal/tx/engine_config.go
+++ b/internal/tx/engine_config.go
@@ -58,6 +58,11 @@ type EngineConfig struct {
 	// Standalone indicates if running in standalone mode (relaxes some validation)
 	Standalone bool
 
+	// ReplayPreFixPayChanRecipientOwnerDir reproduces PaymentChannelCreate before
+	// fixPayChanRecipientOwnerDir was enabled. Only historical replay tools should
+	// set it; the zero value preserves rippled v3.2.0 behavior.
+	ReplayPreFixPayChanRecipientOwnerDir bool
+
 	// NetworkID is the network identifier for this node
 	// Networks with ID > 1024 require NetworkID in transactions
 	// Networks with ID <= 1024 are legacy networks and cannot have NetworkID in transactions

--- a/internal/tx/paychan/payment_channel_create.go
+++ b/internal/tx/paychan/payment_channel_create.go
@@ -225,17 +225,19 @@ func (p *PaymentChannelCreate) Apply(ctx *tx.ApplyContext) ter.Result {
 		channelSLE.HasSequence = true
 	}
 
-	// DirInsert into the recipient's owner directory.
-	// Reference: rippled PayChan.cpp doApply() — recipient owner directory.
-	destDirKey := keylet.OwnerDir(destID)
-	destResult, err := state.DirInsert(ctx.View, destDirKey, channelKey.Key, false, func(dir *state.DirectoryNode) {
-		dir.Owner = destID
-	})
-	if err != nil {
-		return ter.TecDIR_FULL
+	if !ctx.Config.ReplayPreFixPayChanRecipientOwnerDir {
+		// DirInsert into the recipient's owner directory.
+		// Reference: rippled PayChan.cpp doApply() — recipient owner directory.
+		destDirKey := keylet.OwnerDir(destID)
+		destResult, err := state.DirInsert(ctx.View, destDirKey, channelKey.Key, false, func(dir *state.DirectoryNode) {
+			dir.Owner = destID
+		})
+		if err != nil {
+			return ter.TecDIR_FULL
+		}
+		channelSLE.DestinationNode = destResult.Page
+		channelSLE.HasDestNode = true
 	}
-	channelSLE.DestinationNode = destResult.Page
-	channelSLE.HasDestNode = true
 
 	// Re-serialize with updated OwnerNode/DestinationNode
 	updatedData, err := state.SerializePayChannelFromData(channelSLE)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,41 @@
+# Issue #1334 — historical retired-amendment replay compatibility
+
+Target: `origin/main` at `f0db8a22e1386116d08eb7efb21889997bd97af4`.
+Behavioral oracle: clean local rippled v3.2.0 worktree at
+`3c43f4614f87965298773279ff5b85d4c56c637b`.
+
+## Plan
+
+- [x] Validate the open issue, absence of linked PRs, repository authentication,
+      active release branches, clean issue worktree, and exact merge base.
+- [x] Confirm rippled v3.2.0 unconditionally inserts PaymentChannelCreate into
+      the recipient owner directory and serializes `DestinationNode`.
+- [x] Add an explicit replay-only historical gate for
+      `fixPayChanRecipientOwnerDir`, with current v3.2.0 behavior as the default.
+- [x] Thread the compatibility choice only through `replay-range`; leave every
+      live, consensus, standalone, and default replay apply on v3.2.0 semantics.
+- [x] Add focused command/config and PaymentChannelCreate regressions covering
+      default v3.2.0 behavior and the opted-in historical behavior.
+- [x] Run formatting, focused and affected tests, race coverage where useful,
+      build, vet, strict lint, and final diff/merge-base review.
+- [x] Record review results and prepare only the intentional files for commit
+      and a pull request against `main`.
+
+## Review
+
+- `replay-range --legacy-paychan-owner-dir-gate` derives the historical
+  `fixPayChanRecipientOwnerDir` state from each parent ledger's raw Amendments
+  SLE, so a replay crossing activation switches behavior at the correct ledger.
+- The default path remains rippled v3.2.0: PaymentChannelCreate always inserts
+  the recipient owner-directory backlink and serializes `DestinationNode`.
+- The replay-only engine compatibility bit omits that backlink only while the
+  opted-in historical gate is disabled; production Rules and ledger loaders are
+  unchanged.
+- Focused replay, ledger, PayChannel transaction, and PayChannel integration
+  suites pass, as do the full transaction tree and focused race suites.
+- `just build-all`, `just vet`, CI-pinned golangci-lint v2.11.3 with both strict
+  and advisory configs, formatting, and `git diff --check` pass.
+
 # Issue #1322 — nodestore fallback for ledger hash lookup
 
 ## Goal


### PR DESCRIPTION
## Summary
- add an explicit `replay-range --legacy-paychan-owner-dir-gate` compatibility mode for ledgers created before `fixPayChanRecipientOwnerDir`
- derive the historical gate from each parent ledger's exact serialized Amendments membership, preserving the activation boundary
- keep default and live PaymentChannelCreate behavior aligned with rippled v3.2.0 while covering both ledger shapes with regression tests

## Test plan
- [x] `go test ./internal/ledger ./internal/replaytool ./internal/tx/paychan ./internal/testing/paychan -count=1`
- [x] `go test ./internal/tx/... -count=1`
- [x] `go test -race ./internal/ledger ./internal/replaytool ./internal/tx/paychan ./internal/testing/paychan -count=1`
- [x] `just build-all`
- [x] `just vet`
- [x] `golangci-lint run --config .golangci.yml`
- [x] `just lint`
- [x] `git diff --check`

Fixes #1334
