### PR TITLE
Fix LoanBrokerSet MPT holding invariant

### DIFF
--- a/internal/testing/lending/loanbroker_test.go
+++ b/internal/testing/lending/loanbroker_test.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	mpttest "github.com/LeJamon/go-xrpl/internal/testing/mpt"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/lending"
 	"github.com/LeJamon/go-xrpl/internal/tx/vault"
@@ -88,6 +91,77 @@ func TestLoanBroker_Lifecycle(t *testing.T) {
 	jtx.RequireTxSuccess(t, env.Submit(del))
 	if env.LedgerEntryExists(keylet.LoanBrokerByID(bk)) {
 		t.Fatalf("LoanBroker entry still exists after delete")
+	}
+}
+
+func TestLoanBrokerSet_MPTVaultCreatesEmptyHolding(t *testing.T) {
+	env := newLendingEnv(t)
+	issuer := jtx.NewAccount("issuer")
+	owner := jtx.NewAccount("owner")
+	token := mpttest.NewMPTTester(t, env, issuer, mpttest.MPTInit{
+		Holders: []*jtx.Account{owner},
+	})
+	token.Create(mpttest.CreateOpts{Flags: mpttest.TfMPTCanTransfer})
+
+	vaultSeq := env.Seq(owner)
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{MPTIssuanceID: token.IssuanceID()})
+	create.Common.Fee = reserveIncrement
+	jtx.RequireTxSuccess(t, env.Submit(create))
+
+	brokerSeq := env.Seq(owner)
+	result := env.Submit(lending.NewLoanBrokerSet(owner.Address, vaultID(owner, vaultSeq)))
+	jtx.RequireTxSuccess(t, result)
+	createdMPTokens := 0
+	for _, node := range result.Metadata.AffectedNodes {
+		if node.NodeType == "CreatedNode" && node.LedgerEntryType == "MPToken" {
+			createdMPTokens++
+		}
+	}
+	if createdMPTokens != 1 {
+		t.Fatalf("created MPToken count = %d, want 1", createdMPTokens)
+	}
+
+	brokerKey := keylet.LoanBroker(owner.AccountID(), brokerSeq)
+	brokerData, err := env.LedgerEntry(brokerKey)
+	if err != nil {
+		t.Fatalf("read LoanBroker: %v", err)
+	}
+	brokerFields, err := binarycodec.DecodeBytes(brokerData)
+	if err != nil {
+		t.Fatalf("decode LoanBroker: %v", err)
+	}
+	pseudoAddress, ok := brokerFields["Account"].(string)
+	if !ok {
+		t.Fatalf("LoanBroker Account = %#v, want address", brokerFields["Account"])
+	}
+	pseudoID, err := state.DecodeAccountID(pseudoAddress)
+	if err != nil {
+		t.Fatalf("decode broker pseudo-account: %v", err)
+	}
+
+	issuanceBytes, err := hex.DecodeString(token.IssuanceID())
+	if err != nil {
+		t.Fatalf("decode MPTokenIssuanceID: %v", err)
+	}
+	var issuanceID [24]byte
+	copy(issuanceID[:], issuanceBytes)
+	holdingData, err := env.LedgerEntry(keylet.MPTokenByID(issuanceID, pseudoID))
+	if err != nil {
+		t.Fatalf("read broker MPToken: %v", err)
+	}
+	holdingFields, err := binarycodec.DecodeBytes(holdingData)
+	if err != nil {
+		t.Fatalf("decode broker MPToken: %v", err)
+	}
+	if got := holdingFields["Account"]; got != pseudoAddress {
+		t.Fatalf("MPToken Account = %v, want %s", got, pseudoAddress)
+	}
+	gotIssuanceID, ok := holdingFields["MPTokenIssuanceID"].(string)
+	if !ok || !strings.EqualFold(gotIssuanceID, token.IssuanceID()) {
+		t.Fatalf("MPTokenIssuanceID = %v, want %s", holdingFields["MPTokenIssuanceID"], token.IssuanceID())
+	}
+	if _, present := holdingFields["MPTAmount"]; present {
+		t.Fatalf("empty broker MPToken unexpectedly contains MPTAmount")
 	}
 }
 

--- a/internal/tx/invariants/highrisk_test.go
+++ b/internal/tx/invariants/highrisk_test.go
@@ -15,6 +15,7 @@ import (
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // Distinct, round-trippable test addresses (re-used across the file).
@@ -373,20 +374,20 @@ func TestValidMPTIssuance_CreateAndDestroy(t *testing.T) {
 	deleted := InvariantEntry{EntryType: "MPTokenIssuance", Before: nonNil, IsDelete: true}
 
 	create := stubTx{txType: TypeMPTokenIssuanceCreate}
-	if v := checkValidMPTIssuance(create, TesSUCCESS, []InvariantEntry{created}); v != nil {
+	if v := checkValidMPTIssuance(create, TesSUCCESS, []InvariantEntry{created}, amendment.AllSupportedRules()); v != nil {
 		t.Fatalf("create exactly one issuance: unexpected violation %v", v)
 	}
-	if v := checkValidMPTIssuance(create, TesSUCCESS, []InvariantEntry{created, created}); v == nil {
+	if v := checkValidMPTIssuance(create, TesSUCCESS, []InvariantEntry{created, created}, amendment.AllSupportedRules()); v == nil {
 		t.Fatal("expected ValidMPTIssuance violation: created two issuances")
 	} else if v.Name != "ValidMPTIssuance" {
 		t.Fatalf("unexpected violation name %q", v.Name)
 	}
 
 	destroy := stubTx{txType: TypeMPTokenIssuanceDestroy}
-	if v := checkValidMPTIssuance(destroy, TesSUCCESS, []InvariantEntry{deleted}); v != nil {
+	if v := checkValidMPTIssuance(destroy, TesSUCCESS, []InvariantEntry{deleted}, amendment.AllSupportedRules()); v != nil {
 		t.Fatalf("destroy exactly one issuance: unexpected violation %v", v)
 	}
-	if v := checkValidMPTIssuance(destroy, TesSUCCESS, nil); v == nil {
+	if v := checkValidMPTIssuance(destroy, TesSUCCESS, nil, amendment.AllSupportedRules()); v == nil {
 		t.Fatal("expected ValidMPTIssuance violation: destroy deleted no issuance")
 	}
 }
@@ -400,15 +401,60 @@ func TestValidMPTIssuance_AuthorizeByActor(t *testing.T) {
 	mptoken := []InvariantEntry{{EntryType: "MPToken", After: nonNil}}
 
 	byHolder := holderTx{stubTx: stubTx{txType: TypeMPTokenAuthorize}, hasHolder: false}
-	if v := checkValidMPTIssuance(byHolder, TesSUCCESS, mptoken); v != nil {
+	if v := checkValidMPTIssuance(byHolder, TesSUCCESS, mptoken, amendment.AllSupportedRules()); v != nil {
 		t.Fatalf("holder authorize creating one mptoken: unexpected violation %v", v)
 	}
 
 	byIssuer := holderTx{stubTx: stubTx{txType: TypeMPTokenAuthorize}, hasHolder: true}
-	if v := checkValidMPTIssuance(byIssuer, TesSUCCESS, mptoken); v == nil {
+	if v := checkValidMPTIssuance(byIssuer, TesSUCCESS, mptoken, amendment.AllSupportedRules()); v == nil {
 		t.Fatal("expected ValidMPTIssuance violation: issuer authorize created an mptoken")
 	} else if v.Name != "ValidMPTIssuance" {
 		t.Fatalf("unexpected violation name %q", v.Name)
+	}
+}
+
+func TestValidMPTIssuance_MayAuthorizePrivilege(t *testing.T) {
+	nonNil := []byte{0x01}
+	created := InvariantEntry{EntryType: "MPToken", After: nonNil}
+	deleted := InvariantEntry{EntryType: "MPToken", Before: nonNil, IsDelete: true}
+	loanBrokerSet := stubTx{txType: protocol.TxTypeLoanBrokerSet}
+	lendingRules := amendment.NewRulesBuilder().Enable(amendment.FeatureLendingProtocol).Build()
+
+	for name, entries := range map[string][]InvariantEntry{
+		"no MPT change": nil,
+		"create one":    {created},
+		"delete one":    {deleted},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if v := checkValidMPTIssuance(loanBrokerSet, TesSUCCESS, entries, lendingRules); v != nil {
+				t.Fatalf("unexpected violation: %v", v)
+			}
+		})
+	}
+
+	if v := checkValidMPTIssuance(
+		loanBrokerSet,
+		TesSUCCESS,
+		[]InvariantEntry{created, deleted},
+		lendingRules,
+	); v == nil {
+		t.Fatal("expected ValidMPTIssuance violation for two MPToken changes")
+	}
+
+	issuance := []InvariantEntry{{EntryType: "MPTokenIssuance", After: nonNil}}
+	if v := checkValidMPTIssuance(loanBrokerSet, TesSUCCESS, issuance, lendingRules); v == nil {
+		t.Fatal("expected ValidMPTIssuance violation for issuance creation")
+	}
+
+	withoutLending := amendment.NewRulesBuilder().Enable(amendment.FeatureSingleAssetVault).Build()
+	vaultDeposit := stubTx{txType: TypeVaultDeposit}
+	if v := checkValidMPTIssuance(
+		vaultDeposit,
+		TesSUCCESS,
+		[]InvariantEntry{created, deleted},
+		withoutLending,
+	); v != nil {
+		t.Fatalf("lending-disabled MayAuthorizeMPT count was capped: %v", v)
 	}
 }
 
@@ -420,10 +466,10 @@ func TestValidMPTIssuance_UnexpectedChanges(t *testing.T) {
 	tx := stubTx{txType: TypePayment}
 
 	created := []InvariantEntry{{EntryType: "MPTokenIssuance", After: nonNil}}
-	if v := checkValidMPTIssuance(tx, TesSUCCESS, created); v == nil {
+	if v := checkValidMPTIssuance(tx, TesSUCCESS, created, amendment.AllSupportedRules()); v == nil {
 		t.Fatal("expected ValidMPTIssuance violation: Payment created an MPTokenIssuance")
 	}
-	if v := checkValidMPTIssuance(tx, TesSUCCESS, nil); v != nil {
+	if v := checkValidMPTIssuance(tx, TesSUCCESS, nil, amendment.AllSupportedRules()); v != nil {
 		t.Fatalf("Payment with no MPT changes: unexpected violation %v", v)
 	}
 }

--- a/internal/tx/invariants/highrisk_test.go
+++ b/internal/tx/invariants/highrisk_test.go
@@ -365,29 +365,74 @@ type holderTx struct {
 
 func (t holderTx) HasHolder() bool { return t.hasHolder }
 
+func mptIssuanceInvariantEntry(t *testing.T, referenceHolding *string, deleted bool) InvariantEntry {
+	t.Helper()
+	issuer, err := state.DecodeAccountID(addrIssuer)
+	if err != nil {
+		t.Fatalf("decode MPT issuer: %v", err)
+	}
+	data, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+		Issuer:           issuer,
+		Sequence:         1,
+		ReferenceHolding: referenceHolding,
+	})
+	if err != nil {
+		t.Fatalf("serialize MPTokenIssuance: %v", err)
+	}
+	if deleted {
+		return InvariantEntry{EntryType: "MPTokenIssuance", Before: data, IsDelete: true}
+	}
+	return InvariantEntry{EntryType: "MPTokenIssuance", After: data}
+}
+
+func mptInvariantEntry(t *testing.T, account, issuer string, deleted bool) InvariantEntry {
+	t.Helper()
+	accountID, err := state.DecodeAccountID(account)
+	if err != nil {
+		t.Fatalf("decode MPToken account: %v", err)
+	}
+	issuerID, err := state.DecodeAccountID(issuer)
+	if err != nil {
+		t.Fatalf("decode MPToken issuer: %v", err)
+	}
+	var issuanceID [24]byte
+	issuanceID[3] = 1
+	copy(issuanceID[4:], issuerID[:])
+	data, err := state.SerializeMPToken(&state.MPTokenData{
+		Account:           accountID,
+		MPTokenIssuanceID: issuanceID,
+	})
+	if err != nil {
+		t.Fatalf("serialize MPToken: %v", err)
+	}
+	if deleted {
+		return InvariantEntry{EntryType: "MPToken", Before: data, IsDelete: true}
+	}
+	return InvariantEntry{EntryType: "MPToken", After: data}
+}
+
 // TestValidMPTIssuance_CreateAndDestroy: a successful MPTokenIssuanceCreate must
 // create exactly one issuance; destroy must delete exactly one.
 // Reference: rippled InvariantCheck.cpp ValidMPTIssuance (lines 1366-1534).
 func TestValidMPTIssuance_CreateAndDestroy(t *testing.T) {
-	nonNil := []byte{0x01}
-	created := InvariantEntry{EntryType: "MPTokenIssuance", After: nonNil}
-	deleted := InvariantEntry{EntryType: "MPTokenIssuance", Before: nonNil, IsDelete: true}
+	created := mptIssuanceInvariantEntry(t, nil, false)
+	deleted := mptIssuanceInvariantEntry(t, nil, true)
 
 	create := stubTx{txType: TypeMPTokenIssuanceCreate}
-	if v := checkValidMPTIssuance(create, TesSUCCESS, []InvariantEntry{created}, amendment.AllSupportedRules()); v != nil {
+	if v := checkValidMPTIssuance(create, TesSUCCESS, []InvariantEntry{created}, stubView{}, amendment.AllSupportedRules()); v != nil {
 		t.Fatalf("create exactly one issuance: unexpected violation %v", v)
 	}
-	if v := checkValidMPTIssuance(create, TesSUCCESS, []InvariantEntry{created, created}, amendment.AllSupportedRules()); v == nil {
+	if v := checkValidMPTIssuance(create, TesSUCCESS, []InvariantEntry{created, created}, stubView{}, amendment.AllSupportedRules()); v == nil {
 		t.Fatal("expected ValidMPTIssuance violation: created two issuances")
 	} else if v.Name != "ValidMPTIssuance" {
 		t.Fatalf("unexpected violation name %q", v.Name)
 	}
 
 	destroy := stubTx{txType: TypeMPTokenIssuanceDestroy}
-	if v := checkValidMPTIssuance(destroy, TesSUCCESS, []InvariantEntry{deleted}, amendment.AllSupportedRules()); v != nil {
+	if v := checkValidMPTIssuance(destroy, TesSUCCESS, []InvariantEntry{deleted}, stubView{}, amendment.AllSupportedRules()); v != nil {
 		t.Fatalf("destroy exactly one issuance: unexpected violation %v", v)
 	}
-	if v := checkValidMPTIssuance(destroy, TesSUCCESS, nil, amendment.AllSupportedRules()); v == nil {
+	if v := checkValidMPTIssuance(destroy, TesSUCCESS, nil, stubView{}, amendment.AllSupportedRules()); v == nil {
 		t.Fatal("expected ValidMPTIssuance violation: destroy deleted no issuance")
 	}
 }
@@ -397,16 +442,15 @@ func TestValidMPTIssuance_CreateAndDestroy(t *testing.T) {
 // (Holder field present) is forbidden.
 // Reference: rippled InvariantCheck.cpp lines 1455-1499.
 func TestValidMPTIssuance_AuthorizeByActor(t *testing.T) {
-	nonNil := []byte{0x01}
-	mptoken := []InvariantEntry{{EntryType: "MPToken", After: nonNil}}
+	mptoken := []InvariantEntry{mptInvariantEntry(t, addrHolderA, addrIssuer, false)}
 
 	byHolder := holderTx{stubTx: stubTx{txType: TypeMPTokenAuthorize}, hasHolder: false}
-	if v := checkValidMPTIssuance(byHolder, TesSUCCESS, mptoken, amendment.AllSupportedRules()); v != nil {
+	if v := checkValidMPTIssuance(byHolder, TesSUCCESS, mptoken, stubView{}, amendment.AllSupportedRules()); v != nil {
 		t.Fatalf("holder authorize creating one mptoken: unexpected violation %v", v)
 	}
 
 	byIssuer := holderTx{stubTx: stubTx{txType: TypeMPTokenAuthorize}, hasHolder: true}
-	if v := checkValidMPTIssuance(byIssuer, TesSUCCESS, mptoken, amendment.AllSupportedRules()); v == nil {
+	if v := checkValidMPTIssuance(byIssuer, TesSUCCESS, mptoken, stubView{}, amendment.AllSupportedRules()); v == nil {
 		t.Fatal("expected ValidMPTIssuance violation: issuer authorize created an mptoken")
 	} else if v.Name != "ValidMPTIssuance" {
 		t.Fatalf("unexpected violation name %q", v.Name)
@@ -414,9 +458,8 @@ func TestValidMPTIssuance_AuthorizeByActor(t *testing.T) {
 }
 
 func TestValidMPTIssuance_MayAuthorizePrivilege(t *testing.T) {
-	nonNil := []byte{0x01}
-	created := InvariantEntry{EntryType: "MPToken", After: nonNil}
-	deleted := InvariantEntry{EntryType: "MPToken", Before: nonNil, IsDelete: true}
+	created := mptInvariantEntry(t, addrHolderA, addrIssuer, false)
+	deleted := mptInvariantEntry(t, addrHolderA, addrIssuer, true)
 	loanBrokerSet := stubTx{txType: protocol.TxTypeLoanBrokerSet}
 	lendingRules := amendment.NewRulesBuilder().Enable(amendment.FeatureLendingProtocol).Build()
 
@@ -426,7 +469,7 @@ func TestValidMPTIssuance_MayAuthorizePrivilege(t *testing.T) {
 		"delete one":    {deleted},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if v := checkValidMPTIssuance(loanBrokerSet, TesSUCCESS, entries, lendingRules); v != nil {
+			if v := checkValidMPTIssuance(loanBrokerSet, TesSUCCESS, entries, stubView{}, lendingRules); v != nil {
 				t.Fatalf("unexpected violation: %v", v)
 			}
 		})
@@ -436,13 +479,14 @@ func TestValidMPTIssuance_MayAuthorizePrivilege(t *testing.T) {
 		loanBrokerSet,
 		TesSUCCESS,
 		[]InvariantEntry{created, deleted},
+		stubView{},
 		lendingRules,
 	); v == nil {
 		t.Fatal("expected ValidMPTIssuance violation for two MPToken changes")
 	}
 
-	issuance := []InvariantEntry{{EntryType: "MPTokenIssuance", After: nonNil}}
-	if v := checkValidMPTIssuance(loanBrokerSet, TesSUCCESS, issuance, lendingRules); v == nil {
+	issuance := []InvariantEntry{mptIssuanceInvariantEntry(t, nil, false)}
+	if v := checkValidMPTIssuance(loanBrokerSet, TesSUCCESS, issuance, stubView{}, lendingRules); v == nil {
 		t.Fatal("expected ValidMPTIssuance violation for issuance creation")
 	}
 
@@ -452,9 +496,121 @@ func TestValidMPTIssuance_MayAuthorizePrivilege(t *testing.T) {
 		vaultDeposit,
 		TesSUCCESS,
 		[]InvariantEntry{created, deleted},
+		stubView{},
 		withoutLending,
 	); v != nil {
 		t.Fatalf("lending-disabled MayAuthorizeMPT count was capped: %v", v)
+	}
+
+	selfHolding := []InvariantEntry{mptInvariantEntry(t, addrIssuer, addrIssuer, false)}
+	if v := checkValidMPTIssuance(loanBrokerSet, TesSUCCESS, selfHolding, stubView{}, lendingRules); v == nil {
+		t.Fatal("expected ValidMPTIssuance violation for an issuer self-holding")
+	}
+}
+
+func TestValidMPTIssuance_EscrowFinishFeatureGate(t *testing.T) {
+	issuance := []InvariantEntry{mptIssuanceInvariantEntry(t, nil, false)}
+	escrowFinish := stubTx{txType: TypeEscrowFinish}
+
+	if v := checkValidMPTIssuance(escrowFinish, TesSUCCESS, issuance, stubView{}, amendment.EmptyRules()); v != nil {
+		t.Fatalf("pre-amendment EscrowFinish was constrained: %v", v)
+	}
+	rules := amendment.NewRulesBuilder().Enable(amendment.FeatureSingleAssetVault).Build()
+	if v := checkValidMPTIssuance(escrowFinish, TesSUCCESS, issuance, stubView{}, rules); v == nil {
+		t.Fatal("expected amended EscrowFinish issuance creation to violate ValidMPTIssuance")
+	}
+}
+
+func TestValidMPTIssuance_ReferenceHolding(t *testing.T) {
+	rules := amendment.NewRulesBuilder().Enable(amendment.FeatureFixCleanup3_2_0).Build()
+	referenceA := strings.Repeat("11", 32)
+	referenceB := strings.Repeat("22", 32)
+	created := mptIssuanceInvariantEntry(t, &referenceA, false)
+
+	if v := checkValidMPTIssuance(
+		stubTx{txType: TypeMPTokenIssuanceCreate},
+		TesSUCCESS,
+		[]InvariantEntry{created},
+		stubView{},
+		rules,
+	); v == nil {
+		t.Fatal("expected non-VaultCreate ReferenceHolding initialization to violate ValidMPTIssuance")
+	}
+	if v := checkValidMPTIssuance(
+		stubTx{txType: TypeVaultCreate},
+		TesSUCCESS,
+		[]InvariantEntry{created},
+		stubView{},
+		rules,
+	); v != nil {
+		t.Fatalf("VaultCreate ReferenceHolding initialization failed: %v", v)
+	}
+
+	before := mptIssuanceInvariantEntry(t, &referenceA, false).After
+	after := mptIssuanceInvariantEntry(t, &referenceB, false).After
+	modified := InvariantEntry{EntryType: "MPTokenIssuance", Before: before, After: after}
+	if v := checkValidMPTIssuance(
+		stubTx{txType: TypePayment},
+		TesSUCCESS,
+		[]InvariantEntry{modified},
+		stubView{},
+		rules,
+	); v == nil {
+		t.Fatal("expected ReferenceHolding mutation to violate ValidMPTIssuance")
+	}
+}
+
+func TestValidMPTIssuance_VaultPseudoHoldingDeletion(t *testing.T) {
+	pseudoID, err := state.DecodeAccountID(addrHolderA)
+	if err != nil {
+		t.Fatalf("decode vault pseudo-account: %v", err)
+	}
+	var vaultID [32]byte
+	vaultID[31] = 1
+	accountData, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account:  addrHolderA,
+		Balance:  1,
+		VaultID:  vaultID,
+		Sequence: 0,
+	})
+	if err != nil {
+		t.Fatalf("serialize vault pseudo-account: %v", err)
+	}
+	view := mapView{data: map[[32]byte][]byte{keylet.Account(pseudoID).Key: accountData}}
+	rules := amendment.NewRulesBuilder().Enable(amendment.FeatureFixCleanup3_2_0).Build()
+
+	deletedToken := mptInvariantEntry(t, addrHolderA, addrIssuer, true)
+	if v := checkValidMPTIssuance(
+		stubTx{txType: protocol.TxTypeVaultClawback},
+		TesSUCCESS,
+		[]InvariantEntry{deletedToken},
+		view,
+		rules,
+	); v == nil {
+		t.Fatal("expected non-VaultDelete MPToken removal from a vault pseudo-account to violate ValidMPTIssuance")
+	}
+
+	line := frozenLine(t, addrHolderA, addrIssuer, "0", "0", 0)
+	deletedLine := InvariantEntry{EntryType: "RippleState", Before: line.After, IsDelete: true}
+	if v := checkValidMPTIssuance(
+		stubTx{txType: TypePayment},
+		TesSUCCESS,
+		[]InvariantEntry{deletedLine},
+		view,
+		rules,
+	); v == nil {
+		t.Fatal("expected non-VaultDelete trust-line removal from a vault pseudo-account to violate ValidMPTIssuance")
+	}
+
+	deletedIssuance := mptIssuanceInvariantEntry(t, nil, true)
+	if v := checkValidMPTIssuance(
+		stubTx{txType: TypeVaultDelete},
+		TesSUCCESS,
+		[]InvariantEntry{deletedToken, deletedIssuance},
+		view,
+		rules,
+	); v != nil {
+		t.Fatalf("VaultDelete holding cleanup failed: %v", v)
 	}
 }
 
@@ -462,14 +618,13 @@ func TestValidMPTIssuance_MayAuthorizePrivilege(t *testing.T) {
 // touch MPT objects (here Payment) must trip when one is created.
 // Reference: rippled InvariantCheck.cpp lines 1524-1533.
 func TestValidMPTIssuance_UnexpectedChanges(t *testing.T) {
-	nonNil := []byte{0x01}
 	tx := stubTx{txType: TypePayment}
 
-	created := []InvariantEntry{{EntryType: "MPTokenIssuance", After: nonNil}}
-	if v := checkValidMPTIssuance(tx, TesSUCCESS, created, amendment.AllSupportedRules()); v == nil {
+	created := []InvariantEntry{mptIssuanceInvariantEntry(t, nil, false)}
+	if v := checkValidMPTIssuance(tx, TesSUCCESS, created, stubView{}, amendment.AllSupportedRules()); v == nil {
 		t.Fatal("expected ValidMPTIssuance violation: Payment created an MPTokenIssuance")
 	}
-	if v := checkValidMPTIssuance(tx, TesSUCCESS, nil, amendment.AllSupportedRules()); v != nil {
+	if v := checkValidMPTIssuance(tx, TesSUCCESS, nil, stubView{}, amendment.AllSupportedRules()); v != nil {
 		t.Fatalf("Payment with no MPT changes: unexpected violation %v", v)
 	}
 }

--- a/internal/tx/invariants/invariants.go
+++ b/internal/tx/invariants/invariants.go
@@ -210,7 +210,7 @@ func CheckInvariants(tx Transaction, result Result, fee uint64, txDeclaredFee ui
 			return checkValidClawback(tx, result, entries, view)
 		},
 		func() *InvariantViolation {
-			return checkValidMPTIssuance(tx, result, entries)
+			return checkValidMPTIssuance(tx, result, entries, rules)
 		},
 		func() *InvariantViolation {
 			return checkValidPermissionedDomain(tx, result, entries, rules)

--- a/internal/tx/invariants/invariants.go
+++ b/internal/tx/invariants/invariants.go
@@ -210,7 +210,7 @@ func CheckInvariants(tx Transaction, result Result, fee uint64, txDeclaredFee ui
 			return checkValidClawback(tx, result, entries, view)
 		},
 		func() *InvariantViolation {
-			return checkValidMPTIssuance(tx, result, entries, rules)
+			return checkValidMPTIssuance(tx, result, entries, view, rules)
 		},
 		func() *InvariantViolation {
 			return checkValidPermissionedDomain(tx, result, entries, rules)

--- a/internal/tx/invariants/mpt.go
+++ b/internal/tx/invariants/mpt.go
@@ -163,7 +163,6 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 		enforceEscrowFinish := txType == TypeEscrowFinish && rules != nil &&
 			(rules.Enabled(amendment.FeatureSingleAssetVault) || lendingEnabled)
 		if hasPrivilege(txType, mustAuthorizeMPT|mayAuthorizeMPT) || enforceEscrowFinish {
-			// No issuance changes allowed.
 			if mptIssuancesCreated > 0 {
 				return &InvariantViolation{
 					Name:    "ValidMPTIssuance",
@@ -200,7 +199,6 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 					Message: "MPT authorize submitted by issuer succeeded but created/deleted mptokens",
 				}
 			}
-			// A holder-submitted must-authorize transaction must create or delete one MPToken.
 			if !submittedByIssuer && hasPrivilege(txType, mustAuthorizeMPT) &&
 				(mptokensCreated+mptokensDeleted != 1) {
 				return &InvariantViolation{
@@ -229,8 +227,6 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 		}
 	}
 
-	// A transaction with the mayDeleteMPT privilege may delete exactly one
-	// MPToken with no other MPT changes.
 	if result == TesSUCCESS && hasPrivilege(txType, mayDeleteMPT) &&
 		mptokensDeleted == 1 && mptokensCreated == 0 &&
 		mptIssuancesCreated == 0 && mptIssuancesDeleted == 0 {

--- a/internal/tx/invariants/mpt.go
+++ b/internal/tx/invariants/mpt.go
@@ -1,5 +1,7 @@
 package invariants
 
+import "github.com/LeJamon/go-xrpl/amendment"
+
 // ---------------------------------------------------------------------------
 // ValidMPTIssuance
 // ---------------------------------------------------------------------------
@@ -9,7 +11,7 @@ package invariants
 // visitEntry: counts created and deleted MPTokenIssuance and MPToken entries.
 // finalize: switch on transaction type with specific count requirements.
 
-func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEntry) *InvariantViolation {
+func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEntry, rules *amendment.Rules) *InvariantViolation {
 	// visitEntry phase: count created/deleted MPTokenIssuance and MPToken entries.
 	// In rippled, visitEntry receives (isDelete, before, after) where `after` is
 	// always the SLE data (even for deletions). In Go's CollectEntries, deleted
@@ -65,8 +67,7 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 			return nil
 		}
 
-		switch txType {
-		case TypeMPTokenAuthorize, TypeVaultDeposit:
+		if hasPrivilege(txType, mustAuthorizeMPT|mayAuthorizeMPT) {
 			// No issuance changes allowed.
 			if mptIssuancesCreated > 0 {
 				return &InvariantViolation{
@@ -78,6 +79,13 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 				return &InvariantViolation{
 					Name:    "ValidMPTIssuance",
 					Message: "MPT authorize succeeded but deleted issuances",
+				}
+			}
+			if rules != nil && rules.Enabled(amendment.FeatureLendingProtocol) &&
+				mptokensCreated+mptokensDeleted > 1 {
+				return &InvariantViolation{
+					Name:    "ValidMPTIssuance",
+					Message: "MPT authorize succeeded but created/deleted bad number of mptokens",
 				}
 			}
 
@@ -97,8 +105,8 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 					Message: "MPT authorize submitted by issuer succeeded but created/deleted mptokens",
 				}
 			}
-			// If holder submitted (not VaultDeposit), exactly 1 MPToken must be created or deleted.
-			if !submittedByIssuer && txType != TypeVaultDeposit &&
+			// A holder-submitted must-authorize transaction must create or delete one MPToken.
+			if !submittedByIssuer && hasPrivilege(txType, mustAuthorizeMPT) &&
 				(mptokensCreated+mptokensDeleted != 1) {
 				return &InvariantViolation{
 					Name:    "ValidMPTIssuance",
@@ -106,7 +114,9 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 				}
 			}
 			return nil
+		}
 
+		switch txType {
 		case TypeMPTokenIssuanceSet:
 			// Must not create/delete any.
 			if mptIssuancesCreated != 0 || mptIssuancesDeleted != 0 ||

--- a/internal/tx/invariants/mpt.go
+++ b/internal/tx/invariants/mpt.go
@@ -1,6 +1,12 @@
 package invariants
 
-import "github.com/LeJamon/go-xrpl/amendment"
+import (
+	"fmt"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
 
 // ---------------------------------------------------------------------------
 // ValidMPTIssuance
@@ -11,7 +17,7 @@ import "github.com/LeJamon/go-xrpl/amendment"
 // visitEntry: counts created and deleted MPTokenIssuance and MPToken entries.
 // finalize: switch on transaction type with specific count requirements.
 
-func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEntry, rules *amendment.Rules) *InvariantViolation {
+func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEntry, view ReadView, rules *amendment.Rules) *InvariantViolation {
 	// visitEntry phase: count created/deleted MPTokenIssuance and MPToken entries.
 	// In rippled, visitEntry receives (isDelete, before, after) where `after` is
 	// always the SLE data (even for deletions). In Go's CollectEntries, deleted
@@ -21,6 +27,12 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 	//   Deleted = isDelete                  (entry marked as erased)
 	var mptIssuancesCreated, mptIssuancesDeleted int
 	var mptokensCreated, mptokensDeleted int
+	var referenceHoldingSetOnCreate, referenceHoldingMutated bool
+	var mptCreatedByIssuer bool
+	var deletedHoldingAccounts [][20]byte
+	fixCleanup := rules != nil && rules.Enabled(amendment.FeatureFixCleanup3_2_0)
+	enforceCreatedByIssuer := rules != nil &&
+		(rules.Enabled(amendment.FeatureSingleAssetVault) || rules.Enabled(amendment.FeatureLendingProtocol))
 
 	for _, e := range entries {
 		if e.EntryType == "MPTokenIssuance" {
@@ -28,21 +40,101 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 				mptIssuancesDeleted++
 			} else if e.Before == nil {
 				mptIssuancesCreated++
+				if fixCleanup {
+					issuance, err := state.ParseMPTokenIssuance(e.After)
+					if err != nil {
+						return invalidMPTEntry("MPTokenIssuance", err)
+					}
+					referenceHoldingSetOnCreate = referenceHoldingSetOnCreate || issuance.ReferenceHolding != nil
+				}
+			} else if fixCleanup {
+				before, err := state.ParseMPTokenIssuance(e.Before)
+				if err != nil {
+					return invalidMPTEntry("MPTokenIssuance before", err)
+				}
+				after, err := state.ParseMPTokenIssuance(e.After)
+				if err != nil {
+					return invalidMPTEntry("MPTokenIssuance after", err)
+				}
+				referenceHoldingMutated = referenceHoldingMutated ||
+					!sameOptionalString(before.ReferenceHolding, after.ReferenceHolding)
 			}
 		}
 		if e.EntryType == "MPToken" {
 			if e.IsDelete {
 				mptokensDeleted++
+				if fixCleanup {
+					token, err := state.ParseMPToken(e.Before)
+					if err != nil {
+						return invalidMPTEntry("deleted MPToken", err)
+					}
+					deletedHoldingAccounts = append(deletedHoldingAccounts, token.Account)
+				}
 			} else if e.Before == nil {
 				mptokensCreated++
+				if enforceCreatedByIssuer {
+					token, err := state.ParseMPToken(e.After)
+					if err != nil {
+						return invalidMPTEntry("created MPToken", err)
+					}
+					mptCreatedByIssuer = mptCreatedByIssuer || token.Account == mptIssuer(token.MPTokenIssuanceID)
+				}
+			}
+		}
+		if fixCleanup && e.IsDelete && e.EntryType == "RippleState" {
+			line, err := state.ParseRippleState(e.Before)
+			if err != nil {
+				return invalidMPTEntry("deleted RippleState", err)
+			}
+			for _, address := range []string{line.LowLimit.Issuer, line.HighLimit.Issuer} {
+				account, err := state.DecodeAccountID(address)
+				if err != nil {
+					return invalidMPTEntry("deleted RippleState account", err)
+				}
+				deletedHoldingAccounts = append(deletedHoldingAccounts, account)
 			}
 		}
 	}
 
 	// finalize phase
 	txType := tx.TxType()
+	if fixCleanup {
+		if referenceHoldingMutated {
+			return &InvariantViolation{
+				Name:    "ValidMPTIssuance",
+				Message: "ReferenceHolding was modified on an existing MPTokenIssuance",
+			}
+		}
+		if referenceHoldingSetOnCreate && txType != TypeVaultCreate {
+			return &InvariantViolation{
+				Name:    "ValidMPTIssuance",
+				Message: "ReferenceHolding was set by a non-VaultCreate transaction",
+			}
+		}
+		if txType != TypeVaultDelete {
+			for _, account := range deletedHoldingAccounts {
+				vaultPseudo, err := isVaultPseudoAccount(view, account)
+				if err != nil {
+					return invalidMPTEntry("vault pseudo-account", err)
+				}
+				if vaultPseudo {
+					return &InvariantViolation{
+						Name:    "ValidMPTIssuance",
+						Message: "vault pseudo-account holding deleted by a non-VaultDelete transaction",
+					}
+				}
+			}
+		}
+	}
 
 	if result == TesSUCCESS {
+		if mptCreatedByIssuer && enforceCreatedByIssuer {
+			return &InvariantViolation{
+				Name:    "ValidMPTIssuance",
+				Message: "MPToken created for the MPT issuer",
+			}
+		}
+
 		// A createMPTIssuance transaction (MPTokenIssuanceCreate/VaultCreate)
 		// must create exactly 1 issuance and delete 0.
 		if hasPrivilege(txType, createMPTIssuance) {
@@ -67,7 +159,10 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 			return nil
 		}
 
-		if hasPrivilege(txType, mustAuthorizeMPT|mayAuthorizeMPT) {
+		lendingEnabled := rules != nil && rules.Enabled(amendment.FeatureLendingProtocol)
+		enforceEscrowFinish := txType == TypeEscrowFinish && rules != nil &&
+			(rules.Enabled(amendment.FeatureSingleAssetVault) || lendingEnabled)
+		if hasPrivilege(txType, mustAuthorizeMPT|mayAuthorizeMPT) || enforceEscrowFinish {
 			// No issuance changes allowed.
 			if mptIssuancesCreated > 0 {
 				return &InvariantViolation{
@@ -81,7 +176,7 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 					Message: "MPT authorize succeeded but deleted issuances",
 				}
 			}
-			if rules != nil && rules.Enabled(amendment.FeatureLendingProtocol) &&
+			if lendingEnabled &&
 				mptokensCreated+mptokensDeleted > 1 {
 				return &InvariantViolation{
 					Name:    "ValidMPTIssuance",
@@ -134,8 +229,8 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 		}
 	}
 
-	// A transaction with the mayDeleteMPT privilege (VaultWithdraw /
-	// VaultClawback) may delete exactly one MPToken with no other MPT changes.
+	// A transaction with the mayDeleteMPT privilege may delete exactly one
+	// MPToken with no other MPT changes.
 	if result == TesSUCCESS && hasPrivilege(txType, mayDeleteMPT) &&
 		mptokensDeleted == 1 && mptokensCreated == 0 &&
 		mptIssuancesCreated == 0 && mptIssuancesDeleted == 0 {
@@ -152,4 +247,36 @@ func checkValidMPTIssuance(tx Transaction, result Result, entries []InvariantEnt
 	}
 
 	return nil
+}
+
+func invalidMPTEntry(entry string, err error) *InvariantViolation {
+	return &InvariantViolation{
+		Name:    "ValidMPTIssuance",
+		Message: fmt.Sprintf("could not parse %s: %v", entry, err),
+	}
+}
+
+func sameOptionalString(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
+func mptIssuer(id [24]byte) [20]byte {
+	var issuer [20]byte
+	copy(issuer[:], id[4:])
+	return issuer
+}
+
+func isVaultPseudoAccount(view ReadView, account [20]byte) (bool, error) {
+	data, err := view.Read(keylet.Account(account))
+	if err != nil || data == nil {
+		return false, err
+	}
+	root, err := state.ParseAccountRoot(data)
+	if err != nil {
+		return false, err
+	}
+	return root.HasVaultID(), nil
 }

--- a/internal/tx/invariants/privileges_test.go
+++ b/internal/tx/invariants/privileges_test.go
@@ -31,8 +31,12 @@ func TestPrivilegeTable(t *testing.T) {
 		{protocol.TxTypeVaultDelete, mustDeleteAcct | destroyMPTIssuance | mustModifyVault},
 		{protocol.TxTypeVaultDeposit, mayAuthorizeMPT | mustModifyVault},
 		{protocol.TxTypeVaultWithdraw, mayDeleteMPT | mayAuthorizeMPT | mustModifyVault},
-		{TxType(74), createPseudoAcct | mayAuthorizeMPT}, // ttLOAN_BROKER_SET
-		{TxType(75), mustDeleteAcct | mayAuthorizeMPT},   // ttLOAN_BROKER_DELETE
+		{protocol.TxTypeLoanBrokerSet, createPseudoAcct | mayAuthorizeMPT},
+		{protocol.TxTypeLoanBrokerDelete, mustDeleteAcct | mayAuthorizeMPT},
+		{protocol.TxTypeLoanBrokerCoverWithdraw, mayAuthorizeMPT},
+		{protocol.TxTypeLoanSet, mayAuthorizeMPT | mustModifyVault},
+		{protocol.TxTypeLoanManage, mayModifyVault},
+		{protocol.TxTypeLoanPay, mayAuthorizeMPT | mustModifyVault},
 	}
 	for _, c := range cases {
 		if got := txPrivileges[c.txType]; got != c.priv {


### PR DESCRIPTION
## Summary

- make ValidMPTIssuance use transaction authorization privileges instead of a hard-coded transaction shortlist
- apply the LendingProtocol one-holding cap to MustAuthorizeMPT and MayAuthorizeMPT transactions
- add invariant and end-to-end LoanBrokerSet coverage for MPT-backed vaults

## Rippled oracle

Validated against local rippled v3.2.0 at commit 3c43f4614f87965298773279ff5b85d4c56c637b, including MPTInvariant privilege handling and LoanBrokerSet MayAuthorizeMpt behavior.

## Verification

- just build
- just vet
- just test-tx
- go test ./internal/testing/lending/... -count=1
- golangci-lint run
- just lint
- git diff --check

The broad conformance command go test ./internal/testing/conformance -count=1 remains red in the existing rippled 2.6.2 Vault/XChain/Batch fixture backlog. Representative Vault failures reproduce identically on untouched origin/main and are unrelated to this change.

Closes #1333