### PR TITLE
fix: read MPT broker cover from token holding

### DIFF
--- a/internal/tx/invariants/lending.go
+++ b/internal/tx/invariants/lending.go
@@ -100,16 +100,102 @@ func checkValidLoan(entries []InvariantEntry, rules *amendment.Rules) *Invariant
 }
 
 // checkValidLoanBroker enforces the numeric and structural ValidLoanBroker
-// checks on every modified/created LoanBroker.
+// checks on every directly or indirectly affected LoanBroker.
 func checkValidLoanBroker(entries []InvariantEntry, view ReadView, rules *amendment.Rules) *InvariantViolation {
 	if rules == nil || !rules.Enabled(amendment.FeatureLendingProtocol) {
 		return nil
 	}
+
+	type brokerState struct {
+		before []byte
+		after  []byte
+	}
+
+	brokers := make(map[[32]byte]brokerState)
+	var unkeyedBrokers []brokerState
+	var lines, mpts [][]byte
+	addBroker := func(id [32]byte) {
+		if id == ([32]byte{}) {
+			return
+		}
+		if _, ok := brokers[id]; !ok {
+			brokers[id] = brokerState{}
+		}
+	}
+
 	for _, e := range entries {
-		if e.EntryType != "LoanBroker" || e.After == nil {
+		if e.After == nil {
 			continue
 		}
-		after, err := decodeEntry(e.After)
+		switch e.EntryType {
+		case "LoanBroker":
+			broker := brokerState{before: e.Before, after: e.After}
+			if e.Key == ([32]byte{}) {
+				unkeyedBrokers = append(unkeyedBrokers, broker)
+			} else {
+				brokers[e.Key] = broker
+			}
+		case "AccountRoot":
+			account, err := state.ParseAccountRoot(e.After)
+			if err != nil {
+				return lendingViolation("ValidLoanBroker", fmt.Sprintf("could not decode AccountRoot: %v", err))
+			}
+			if account.HasLoanBrokerID() {
+				addBroker(account.LoanBrokerID)
+			}
+		case "RippleState":
+			lines = append(lines, e.After)
+		case "MPToken":
+			mpts = append(mpts, e.After)
+		}
+	}
+
+	addBrokerForAccount := func(accountID [20]byte) *InvariantViolation {
+		data, err := view.Read(keylet.Account(accountID))
+		if err != nil {
+			return lendingViolation("ValidLoanBroker", fmt.Sprintf("could not read account: %v", err))
+		}
+		if data == nil {
+			return nil
+		}
+		account, err := state.ParseAccountRoot(data)
+		if err != nil {
+			return lendingViolation("ValidLoanBroker", fmt.Sprintf("could not decode AccountRoot: %v", err))
+		}
+		if account.HasLoanBrokerID() {
+			addBroker(account.LoanBrokerID)
+		}
+		return nil
+	}
+
+	for _, data := range lines {
+		line, err := state.ParseRippleState(data)
+		if err != nil {
+			return lendingViolation("ValidLoanBroker", fmt.Sprintf("could not decode RippleState: %v", err))
+		}
+		for _, address := range []string{line.LowLimit.Issuer, line.HighLimit.Issuer} {
+			accountID, err := state.DecodeAccountID(address)
+			if err != nil {
+				return lendingViolation("ValidLoanBroker", fmt.Sprintf("could not decode trust line account: %v", err))
+			}
+			if violation := addBrokerForAccount(accountID); violation != nil {
+				return violation
+			}
+		}
+	}
+
+	for _, data := range mpts {
+		token, err := state.ParseMPToken(data)
+		if err != nil {
+			return lendingViolation("ValidLoanBroker", fmt.Sprintf("could not decode MPToken: %v", err))
+		}
+		if violation := addBrokerForAccount(token.Account); violation != nil {
+			return violation
+		}
+	}
+
+	checkBroker := func(beforeData, afterData []byte) *InvariantViolation {
+		after, err := decodeEntry(afterData)
 		if err != nil {
 			return lendingViolation("ValidLoanBroker", fmt.Sprintf("could not decode LoanBroker: %v", err))
 		}
@@ -119,8 +205,8 @@ func checkValidLoanBroker(entries []InvariantEntry, view ReadView, rules *amendm
 		if numFieldIsNegative(after, "CoverAvailable") {
 			return lendingViolation("ValidLoanBroker", "cover available is negative")
 		}
-		if e.Before != nil {
-			if before, berr := decodeEntry(e.Before); berr == nil {
+		if beforeData != nil {
+			if before, berr := decodeEntry(beforeData); berr == nil {
 				if u32Field(before, "LoanSequence") > u32Field(after, "LoanSequence") {
 					return lendingViolation("ValidLoanBroker", "loan sequence number decreased")
 				}
@@ -161,6 +247,29 @@ func checkValidLoanBroker(entries []InvariantEntry, view ReadView, rules *amendm
 		}
 		if rules.Enabled(amendment.FeatureFixCleanup3_1_3) && coverAvailable.Cmp(pseudoBalance) > 0 {
 			return lendingViolation("ValidLoanBroker", "cover available is greater than pseudo-account asset balance")
+		}
+		return nil
+	}
+
+	for _, broker := range unkeyedBrokers {
+		if violation := checkBroker(broker.before, broker.after); violation != nil {
+			return violation
+		}
+	}
+	for brokerID, broker := range brokers {
+		after := broker.after
+		if after == nil {
+			var err error
+			after, err = view.Read(keylet.LoanBrokerByID(brokerID))
+			if err != nil {
+				return lendingViolation("ValidLoanBroker", fmt.Sprintf("could not read LoanBroker: %v", err))
+			}
+			if after == nil {
+				return lendingViolation("ValidLoanBroker", "loan broker is missing")
+			}
+		}
+		if violation := checkBroker(broker.before, after); violation != nil {
+			return violation
 		}
 	}
 	return nil

--- a/internal/tx/invariants/lending.go
+++ b/internal/tx/invariants/lending.go
@@ -99,8 +99,6 @@ func checkValidLoan(entries []InvariantEntry, rules *amendment.Rules) *Invariant
 	return nil
 }
 
-// checkValidLoanBroker enforces the numeric and structural ValidLoanBroker
-// checks on every directly or indirectly affected LoanBroker.
 func checkValidLoanBroker(entries []InvariantEntry, view ReadView, rules *amendment.Rules) *InvariantViolation {
 	if rules == nil || !rules.Enabled(amendment.FeatureLendingProtocol) {
 		return nil

--- a/internal/tx/invariants/lending_invariant_test.go
+++ b/internal/tx/invariants/lending_invariant_test.go
@@ -121,6 +121,90 @@ func TestValidLoanBroker_CoverAvailableBounds(t *testing.T) {
 	}
 }
 
+func TestValidLoanBroker_MPTCoverMatchesPseudoHolding(t *testing.T) {
+	var ownerID, pseudoID [20]byte
+	for i := range ownerID {
+		ownerID[i] = 0x11
+		pseudoID[i] = 0x22
+	}
+	ownerAddr, err := state.EncodeAccountID(ownerID)
+	if err != nil {
+		t.Fatalf("encode owner: %v", err)
+	}
+	pseudoAddr, err := state.EncodeAccountID(pseudoID)
+	if err != nil {
+		t.Fatalf("encode pseudo: %v", err)
+	}
+
+	var vaultID [32]byte
+	for i := range vaultID {
+		vaultID[i] = 0x33
+	}
+	mptID := keylet.MakeMPTID(50, ownerID)
+	mptIDHex := strings.ToUpper(hex.EncodeToString(mptID[:]))
+	vaultIDHex := strings.ToUpper(hex.EncodeToString(vaultID[:]))
+
+	vaultBytes := mustEncode(t, map[string]any{
+		"LedgerEntryType":   "Vault",
+		"Flags":             0,
+		"Sequence":          1,
+		"OwnerNode":         "0",
+		"Owner":             ownerAddr,
+		"Account":           pseudoAddr,
+		"Asset":             map[string]any{"mpt_issuance_id": mptIDHex},
+		"ShareMPTID":        strings.Repeat("0", 48),
+		"WithdrawalPolicy":  1,
+		"PreviousTxnID":     strings.Repeat("0", 64),
+		"PreviousTxnLgrSeq": uint32(0),
+	})
+	accountBytes := mustEncode(t, map[string]any{
+		"LedgerEntryType":   "AccountRoot",
+		"Account":           pseudoAddr,
+		"Balance":           "0",
+		"Flags":             0,
+		"OwnerCount":        0,
+		"Sequence":          0,
+		"PreviousTxnID":     strings.Repeat("0", 64),
+		"PreviousTxnLgrSeq": uint32(0),
+	})
+	tokenBytes, err := state.SerializeMPToken(&state.MPTokenData{
+		Account:           pseudoID,
+		MPTokenIssuanceID: mptID,
+		MPTAmount:         110,
+	})
+	if err != nil {
+		t.Fatalf("serialize MPToken: %v", err)
+	}
+	brokerBytes := mustEncode(t, map[string]any{
+		"LedgerEntryType":   "LoanBroker",
+		"Flags":             0,
+		"Owner":             ownerAddr,
+		"Account":           pseudoAddr,
+		"VaultID":           vaultIDHex,
+		"CoverAvailable":    "110",
+		"Sequence":          1,
+		"OwnerNode":         "0",
+		"VaultNode":         "0",
+		"LoanSequence":      uint32(0),
+		"PreviousTxnID":     strings.Repeat("0", 64),
+		"PreviousTxnLgrSeq": uint32(0),
+	})
+	view := mapView{data: map[[32]byte][]byte{
+		keylet.VaultByID(vaultID).Key:           vaultBytes,
+		keylet.Account(pseudoID).Key:            accountBytes,
+		keylet.MPTokenByID(mptID, pseudoID).Key: tokenBytes,
+	}}
+	rules := amendment.NewRules([][32]byte{
+		amendment.FeatureLendingProtocol,
+		amendment.FeatureFixCleanup3_1_3,
+	})
+	entries := []InvariantEntry{{EntryType: "LoanBroker", After: brokerBytes}}
+
+	if violation := checkValidLoanBroker(entries, view, rules); violation != nil {
+		t.Fatalf("matching MPT cover rejected: %v", violation)
+	}
+}
+
 // TestValidLoanBroker_InertWhenLendingDisabled asserts the invariant does not run
 // (and cannot false-positive) while LendingProtocol is off.
 func TestValidLoanBroker_InertWhenLendingDisabled(t *testing.T) {

--- a/internal/tx/invariants/lending_invariant_test.go
+++ b/internal/tx/invariants/lending_invariant_test.go
@@ -136,14 +136,15 @@ func TestValidLoanBroker_MPTCoverMatchesPseudoHolding(t *testing.T) {
 		t.Fatalf("encode pseudo: %v", err)
 	}
 
-	var vaultID [32]byte
+	var vaultID, brokerID [32]byte
 	for i := range vaultID {
 		vaultID[i] = 0x33
+		brokerID[i] = 0x44
 	}
 	mptID := keylet.MakeMPTID(50, ownerID)
 	mptIDHex := strings.ToUpper(hex.EncodeToString(mptID[:]))
 	vaultIDHex := strings.ToUpper(hex.EncodeToString(vaultID[:]))
-
+	brokerIDHex := strings.ToUpper(hex.EncodeToString(brokerID[:]))
 	vaultBytes := mustEncode(t, map[string]any{
 		"LedgerEntryType":   "Vault",
 		"Flags":             0,
@@ -164,6 +165,7 @@ func TestValidLoanBroker_MPTCoverMatchesPseudoHolding(t *testing.T) {
 		"Flags":             0,
 		"OwnerCount":        0,
 		"Sequence":          0,
+		"LoanBrokerID":      brokerIDHex,
 		"PreviousTxnID":     strings.Repeat("0", 64),
 		"PreviousTxnLgrSeq": uint32(0),
 	})
@@ -191,6 +193,7 @@ func TestValidLoanBroker_MPTCoverMatchesPseudoHolding(t *testing.T) {
 	})
 	view := mapView{data: map[[32]byte][]byte{
 		keylet.VaultByID(vaultID).Key:           vaultBytes,
+		keylet.LoanBrokerByID(brokerID).Key:     brokerBytes,
 		keylet.Account(pseudoID).Key:            accountBytes,
 		keylet.MPTokenByID(mptID, pseudoID).Key: tokenBytes,
 	}}
@@ -198,10 +201,146 @@ func TestValidLoanBroker_MPTCoverMatchesPseudoHolding(t *testing.T) {
 		amendment.FeatureLendingProtocol,
 		amendment.FeatureFixCleanup3_1_3,
 	})
-	entries := []InvariantEntry{{EntryType: "LoanBroker", After: brokerBytes}}
+	entries := []InvariantEntry{{Key: brokerID, EntryType: "LoanBroker", After: brokerBytes}}
 
 	if violation := checkValidLoanBroker(entries, view, rules); violation != nil {
 		t.Fatalf("matching MPT cover rejected: %v", violation)
+	}
+
+	modifiedToken := &state.MPTokenData{
+		Account:           pseudoID,
+		MPTokenIssuanceID: mptID,
+		MPTAmount:         120,
+	}
+	modifiedTokenBytes, err := state.SerializeMPToken(modifiedToken)
+	if err != nil {
+		t.Fatalf("serialize modified MPToken: %v", err)
+	}
+	view.data[keylet.MPTokenByID(mptID, pseudoID).Key] = modifiedTokenBytes
+
+	for _, tc := range []struct {
+		name  string
+		entry InvariantEntry
+	}{
+		{
+			name: "MPToken",
+			entry: InvariantEntry{
+				Key:       keylet.MPTokenByID(mptID, pseudoID).Key,
+				EntryType: "MPToken",
+				Before:    tokenBytes,
+				After:     modifiedTokenBytes,
+			},
+		},
+		{
+			name: "AccountRoot",
+			entry: InvariantEntry{
+				Key:       keylet.Account(pseudoID).Key,
+				EntryType: "AccountRoot",
+				After:     accountBytes,
+			},
+		},
+	} {
+		t.Run("discovers broker from "+tc.name, func(t *testing.T) {
+			violation := checkValidLoanBroker([]InvariantEntry{tc.entry}, view, rules)
+			if violation == nil || !strings.Contains(violation.Message, "less than") {
+				t.Fatalf("holding-only change violation = %v, want cover below holding", violation)
+			}
+		})
+	}
+}
+
+func TestValidLoanBroker_DiscoversChangedRippleState(t *testing.T) {
+	var ownerID, pseudoID, issuerID [20]byte
+	for i := range ownerID {
+		ownerID[i] = 0x11
+		pseudoID[i] = 0x22
+		issuerID[i] = 0x55
+	}
+	ownerAddr, err := state.EncodeAccountID(ownerID)
+	if err != nil {
+		t.Fatalf("encode owner: %v", err)
+	}
+	pseudoAddr, err := state.EncodeAccountID(pseudoID)
+	if err != nil {
+		t.Fatalf("encode pseudo: %v", err)
+	}
+	issuerAddr, err := state.EncodeAccountID(issuerID)
+	if err != nil {
+		t.Fatalf("encode issuer: %v", err)
+	}
+
+	var vaultID, brokerID [32]byte
+	for i := range vaultID {
+		vaultID[i] = 0x33
+		brokerID[i] = 0x44
+	}
+	vaultIDHex := strings.ToUpper(hex.EncodeToString(vaultID[:]))
+
+	vaultBytes := mustEncode(t, map[string]any{
+		"LedgerEntryType":   "Vault",
+		"Flags":             0,
+		"Sequence":          1,
+		"OwnerNode":         "0",
+		"Owner":             ownerAddr,
+		"Account":           pseudoAddr,
+		"Asset":             map[string]any{"currency": "USD", "issuer": issuerAddr},
+		"ShareMPTID":        strings.Repeat("0", 48),
+		"WithdrawalPolicy":  1,
+		"PreviousTxnID":     strings.Repeat("0", 64),
+		"PreviousTxnLgrSeq": uint32(0),
+	})
+	brokerBytes := mustEncode(t, map[string]any{
+		"LedgerEntryType":   "LoanBroker",
+		"Flags":             0,
+		"Owner":             ownerAddr,
+		"Account":           pseudoAddr,
+		"VaultID":           vaultIDHex,
+		"CoverAvailable":    "100",
+		"Sequence":          1,
+		"OwnerNode":         "0",
+		"VaultNode":         "0",
+		"LoanSequence":      uint32(0),
+		"PreviousTxnID":     strings.Repeat("0", 64),
+		"PreviousTxnLgrSeq": uint32(0),
+	})
+	pseudoBytes := mustSerializeAccount(t, &state.AccountRoot{
+		Account: pseudoAddr, LoanBrokerID: brokerID,
+	})
+	balance, err := state.NewIssuedAmountFromDecimalString("110", "USD", state.AccountOneAddress)
+	if err != nil {
+		t.Fatalf("make balance: %v", err)
+	}
+	lowLimit, err := state.NewIssuedAmountFromDecimalString("0", "USD", pseudoAddr)
+	if err != nil {
+		t.Fatalf("make low limit: %v", err)
+	}
+	highLimit, err := state.NewIssuedAmountFromDecimalString("0", "USD", issuerAddr)
+	if err != nil {
+		t.Fatalf("make high limit: %v", err)
+	}
+	lineBytes, err := state.SerializeRippleState(&state.RippleState{
+		Balance: balance, LowLimit: lowLimit, HighLimit: highLimit,
+	})
+	if err != nil {
+		t.Fatalf("serialize RippleState: %v", err)
+	}
+
+	lineKey := keylet.Line(pseudoID, issuerID, "USD")
+	view := mapView{data: map[[32]byte][]byte{
+		keylet.VaultByID(vaultID).Key:       vaultBytes,
+		keylet.LoanBrokerByID(brokerID).Key: brokerBytes,
+		keylet.Account(pseudoID).Key:        pseudoBytes,
+		lineKey.Key:                         lineBytes,
+	}}
+	rules := amendment.NewRules([][32]byte{
+		amendment.FeatureLendingProtocol,
+		amendment.FeatureFixCleanup3_1_3,
+	})
+	entry := InvariantEntry{Key: lineKey.Key, EntryType: "RippleState", After: lineBytes}
+
+	violation := checkValidLoanBroker([]InvariantEntry{entry}, view, rules)
+	if violation == nil || !strings.Contains(violation.Message, "less than") {
+		t.Fatalf("trust-line-only change violation = %v, want cover below holding", violation)
 	}
 }
 

--- a/internal/tx/vault/exports.go
+++ b/internal/tx/vault/exports.go
@@ -25,17 +25,6 @@ func PseudoAssetHolds(view AssetReadView, account [20]byte, vaultData []byte) (s
 	if err != nil {
 		return state.NewXRPLNumber(0, 0), false
 	}
-	if isNativeAsset(vd.Asset) {
-		data, rerr := view.Read(keylet.Account(account))
-		if rerr != nil || data == nil {
-			return state.NewXRPLNumber(0, 0), false
-		}
-		ar, perr := state.ParseAccountRoot(data)
-		if perr != nil {
-			return state.NewXRPLNumber(0, 0), false
-		}
-		return state.NewXRPLNumber(int64(ar.Balance), 0), true
-	}
 	if vd.AssetIsMPT {
 		data, rerr := view.Read(keylet.MPTokenByID(vd.AssetMPTID, account))
 		if rerr != nil {
@@ -49,6 +38,17 @@ func PseudoAssetHolds(view AssetReadView, account [20]byte, vaultData []byte) (s
 			return state.NewXRPLNumber(0, 0), false
 		}
 		return state.NewXRPLNumber(int64(token.MPTAmount), 0), true
+	}
+	if isNativeAsset(vd.Asset) {
+		data, rerr := view.Read(keylet.Account(account))
+		if rerr != nil || data == nil {
+			return state.NewXRPLNumber(0, 0), false
+		}
+		ar, perr := state.ParseAccountRoot(data)
+		if perr != nil {
+			return state.NewXRPLNumber(0, 0), false
+		}
+		return state.NewXRPLNumber(int64(ar.Balance), 0), true
 	}
 	issuerID, derr := state.DecodeAccountID(vd.Asset.Issuer)
 	if derr != nil {


### PR DESCRIPTION
## Summary
- Dispatch parsed MPT vault assets to their MPToken holding before the native-asset fallback, matching rippled v3.2.0.
- Add a regression with zero XRP and matching 110-unit MPToken and broker cover balances.

## Test plan
- [x] `go test -race -count=1 -timeout 15m ./internal/tx/... ./internal/testing/lending`
- [x] `just build`
- [x] `just vet`
- [x] `go vet -tags postgres ./storage/relationaldb/postgres/`
- [x] `golangci-lint run`
- [x] `just lint`
- [x] `git diff --check`

Fixes #1339
