### PR TITLE
fix: retain permissioned domain owner root

### DIFF
--- a/internal/testing/permissioneddomain/permissioned_domain_delete_owner_dir_test.go
+++ b/internal/testing/permissioneddomain/permissioned_domain_delete_owner_dir_test.go
@@ -114,7 +114,8 @@ func TestPermissionedDomainDeleteUsesRecordedOwnerDirectoryPage(t *testing.T) {
 	env := jtx.NewTestEnv(t)
 	alice := jtx.NewAccount("alice")
 	issuer := jtx.NewAccount("issuer")
-	env.Fund(alice, issuer)
+	env.FundAmount(alice, uint64(jtx.XRP(100_000)))
+	env.Fund(issuer)
 	env.Close()
 
 	var pageOneDomain keylet.Keylet

--- a/internal/testing/permissioneddomain/permissioned_domain_delete_owner_dir_test.go
+++ b/internal/testing/permissioneddomain/permissioned_domain_delete_owner_dir_test.go
@@ -1,0 +1,131 @@
+package permissioneddomain_test
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/metadata"
+	pd "github.com/LeJamon/go-xrpl/internal/testing/permissioneddomain"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func readOwnerDirectory(t *testing.T, env *jtx.TestEnv, owner *jtx.Account) *state.DirectoryNode {
+	t.Helper()
+
+	data, err := env.LedgerEntry(keylet.OwnerDir(owner.ID))
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	dir, err := state.ParseDirectoryNode(data)
+	require.NoError(t, err)
+	return dir
+}
+
+func TestPermissionedDomainDeleteKeepsEmptyOwnerDirectory(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	issuer := jtx.NewAccount("issuer")
+	env.Fund(alice, issuer)
+	env.Close()
+
+	createLedgerSeq := env.LedgerSeq()
+	domainSeq := env.Seq(alice)
+	create := pd.DomainSet(alice).Credential(issuer, credTypeHex(10)).Build()
+	createResult := env.Submit(create)
+	jtx.RequireTxSuccess(t, createResult)
+	createHash, err := tx.ComputeTransactionHash(create)
+	require.NoError(t, err)
+	env.Close()
+
+	ownerDirKey := keylet.OwnerDir(alice.ID)
+	domainKey := domainKeylet(alice, domainSeq)
+	dirBefore := readOwnerDirectory(t, env, alice)
+	require.Equal(t, [][32]byte{domainKey.Key}, dirBefore.Indexes)
+	require.Equal(t, createHash, dirBefore.PreviousTxnID)
+	require.Equal(t, createLedgerSeq, dirBefore.PreviousTxnLgrSeq)
+
+	deleteLedgerSeq := env.LedgerSeq()
+	deleteTx := pd.DomainDelete(alice, domainIDHex(domainKey)).Build()
+	deleteResult := env.Submit(deleteTx)
+	jtx.RequireTxSuccess(t, deleteResult)
+	deleteHash, err := tx.ComputeTransactionHash(deleteTx)
+	require.NoError(t, err)
+	env.Close()
+
+	dirAfter := readOwnerDirectory(t, env, alice)
+	require.Empty(t, dirAfter.Indexes)
+	require.Equal(t, alice.ID, dirAfter.Owner)
+	require.Equal(t, ownerDirKey.Key, dirAfter.RootIndex)
+	require.Equal(t, deleteHash, dirAfter.PreviousTxnID)
+	require.Equal(t, deleteLedgerSeq, dirAfter.PreviousTxnLgrSeq)
+	require.Zero(t, env.OwnerCount(alice))
+	require.Nil(t, getDomainEntry(t, env, domainKey))
+
+	require.NotNil(t, deleteResult.Metadata)
+	dirNode := metadata.FindNode(deleteResult.Metadata, "ModifiedNode", "DirectoryNode")
+	require.NotNil(t, dirNode)
+	require.Equal(t, strings.ToUpper(hex.EncodeToString(ownerDirKey.Key[:])), dirNode.LedgerIndex)
+	require.Equal(t, strings.ToUpper(hex.EncodeToString(createHash[:])), dirNode.PreviousTxnID)
+	require.Equal(t, createLedgerSeq, dirNode.PreviousTxnLgrSeq)
+	require.NotContains(t, dirNode.FinalFields, "Indexes")
+	require.NotContains(t, dirNode.PreviousFields, "Indexes")
+	require.Nil(t, metadata.FindNode(deleteResult.Metadata, "DeletedNode", "DirectoryNode"))
+}
+
+func TestPermissionedDomainDeleteKeepsRemainingOwnerDirectoryEntries(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	issuer := jtx.NewAccount("issuer")
+	env.Fund(alice, issuer)
+	env.Close()
+
+	firstSeq := env.Seq(alice)
+	jtx.RequireTxSuccess(t, env.Submit(pd.DomainSet(alice).Credential(issuer, credTypeHex(1)).Build()))
+	env.Close()
+	secondSeq := env.Seq(alice)
+	jtx.RequireTxSuccess(t, env.Submit(pd.DomainSet(alice).Credential(issuer, credTypeHex(2)).Build()))
+	env.Close()
+
+	firstDomain := domainKeylet(alice, firstSeq)
+	secondDomain := domainKeylet(alice, secondSeq)
+	require.Len(t, readOwnerDirectory(t, env, alice).Indexes, 2)
+
+	result := env.Submit(pd.DomainDelete(alice, domainIDHex(firstDomain)).Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	dir := readOwnerDirectory(t, env, alice)
+	require.Equal(t, [][32]byte{secondDomain.Key}, dir.Indexes)
+	require.Equal(t, uint32(1), env.OwnerCount(alice))
+	require.Nil(t, getDomainEntry(t, env, firstDomain))
+	require.NotNil(t, getDomainEntry(t, env, secondDomain))
+
+	require.NotNil(t, result.Metadata)
+	require.NotNil(t, metadata.FindNode(result.Metadata, "ModifiedNode", "DirectoryNode"))
+	require.Nil(t, metadata.FindNode(result.Metadata, "DeletedNode", "DirectoryNode"))
+}
+
+func TestPermissionedDomainDeleteRejectsMissingOwnerDirectoryEntry(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	issuer := jtx.NewAccount("issuer")
+	env.Fund(alice, issuer)
+	env.Close()
+
+	domainSeq := env.Seq(alice)
+	jtx.RequireTxSuccess(t, env.Submit(pd.DomainSet(alice).Credential(issuer, credTypeHex(10)).Build()))
+	env.Close()
+
+	domainKey := domainKeylet(alice, domainSeq)
+	require.NoError(t, env.Ledger().Erase(keylet.OwnerDir(alice.ID)))
+
+	result := env.Submit(pd.DomainDelete(alice, domainIDHex(domainKey)).Build())
+	jtx.RequireTxFail(t, result, jtx.TefBAD_LEDGER)
+	require.Equal(t, uint32(1), env.OwnerCount(alice))
+	require.NotNil(t, getDomainEntry(t, env, domainKey))
+}

--- a/internal/testing/permissioneddomain/permissioned_domain_delete_owner_dir_test.go
+++ b/internal/testing/permissioneddomain/permissioned_domain_delete_owner_dir_test.go
@@ -110,22 +110,122 @@ func TestPermissionedDomainDeleteKeepsRemainingOwnerDirectoryEntries(t *testing.
 	require.Nil(t, metadata.FindNode(result.Metadata, "DeletedNode", "DirectoryNode"))
 }
 
-func TestPermissionedDomainDeleteRejectsMissingOwnerDirectoryEntry(t *testing.T) {
+func TestPermissionedDomainDeleteUsesRecordedOwnerDirectoryPage(t *testing.T) {
 	env := jtx.NewTestEnv(t)
 	alice := jtx.NewAccount("alice")
 	issuer := jtx.NewAccount("issuer")
 	env.Fund(alice, issuer)
 	env.Close()
 
-	domainSeq := env.Seq(alice)
-	jtx.RequireTxSuccess(t, env.Submit(pd.DomainSet(alice).Credential(issuer, credTypeHex(10)).Build()))
+	var pageOneDomain keylet.Keylet
+	for i := range 33 {
+		seq := env.Seq(alice)
+		domainKey := domainKeylet(alice, seq)
+		jtx.RequireTxSuccess(t, env.Submit(pd.DomainSet(alice).Credential(issuer, credTypeHex(i+1)).Build()))
+		if i == 32 {
+			pageOneDomain = domainKey
+		}
+	}
 	env.Close()
 
-	domainKey := domainKeylet(alice, domainSeq)
-	require.NoError(t, env.Ledger().Erase(keylet.OwnerDir(alice.ID)))
+	domainData, err := env.LedgerEntry(pageOneDomain)
+	require.NoError(t, err)
+	domain, err := state.ParsePermissionedDomain(domainData)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), domain.OwnerNode)
 
-	result := env.Submit(pd.DomainDelete(alice, domainIDHex(domainKey)).Build())
-	jtx.RequireTxFail(t, result, jtx.TefBAD_LEDGER)
-	require.Equal(t, uint32(1), env.OwnerCount(alice))
-	require.NotNil(t, getDomainEntry(t, env, domainKey))
+	ownerDirKey := keylet.OwnerDir(alice.ID)
+	root := readOwnerDirectory(t, env, alice)
+	require.Len(t, root.Indexes, 32)
+	require.Equal(t, uint64(1), root.IndexNext)
+	require.Equal(t, uint64(1), root.IndexPrevious)
+
+	pageOneKey := keylet.DirPage(ownerDirKey.Key, 1)
+	pageOneData, err := env.LedgerEntry(pageOneKey)
+	require.NoError(t, err)
+	pageOne, err := state.ParseDirectoryNode(pageOneData)
+	require.NoError(t, err)
+	require.Equal(t, [][32]byte{pageOneDomain.Key}, pageOne.Indexes)
+
+	result := env.Submit(pd.DomainDelete(alice, domainIDHex(pageOneDomain)).Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	root = readOwnerDirectory(t, env, alice)
+	require.Len(t, root.Indexes, 32)
+	require.Zero(t, root.IndexNext)
+	require.Zero(t, root.IndexPrevious)
+	pageOneData, err = env.LedgerEntry(pageOneKey)
+	require.NoError(t, err)
+	require.Nil(t, pageOneData)
+	require.Nil(t, getDomainEntry(t, env, pageOneDomain))
+	require.Equal(t, uint32(32), env.OwnerCount(alice))
+}
+
+func TestPermissionedDomainDeleteRejectsCorruptOwnerDirectory(t *testing.T) {
+	tests := []struct {
+		name    string
+		corrupt func(*testing.T, *jtx.TestEnv, keylet.Keylet)
+	}{
+		{
+			name: "missing page",
+			corrupt: func(t *testing.T, env *jtx.TestEnv, ownerDirKey keylet.Keylet) {
+				t.Helper()
+				require.NoError(t, env.Ledger().Erase(ownerDirKey))
+			},
+		},
+		{
+			name: "missing item",
+			corrupt: func(t *testing.T, env *jtx.TestEnv, ownerDirKey keylet.Keylet) {
+				t.Helper()
+				data, err := env.LedgerEntry(ownerDirKey)
+				require.NoError(t, err)
+				dir, err := state.ParseDirectoryNode(data)
+				require.NoError(t, err)
+				dir.Indexes = nil
+				data, err = state.SerializeDirectoryNode(dir, false)
+				require.NoError(t, err)
+				require.NoError(t, env.Ledger().Update(ownerDirKey, data))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := jtx.NewTestEnv(t)
+			alice := jtx.NewAccount("alice")
+			issuer := jtx.NewAccount("issuer")
+			env.Fund(alice, issuer)
+			env.Close()
+
+			domainSeq := env.Seq(alice)
+			jtx.RequireTxSuccess(t, env.Submit(pd.DomainSet(alice).Credential(issuer, credTypeHex(10)).Build()))
+			env.Close()
+
+			domainKey := domainKeylet(alice, domainSeq)
+			ownerDirKey := keylet.OwnerDir(alice.ID)
+			domainBefore, err := env.LedgerEntry(domainKey)
+			require.NoError(t, err)
+			tt.corrupt(t, env, ownerDirKey)
+			dirBefore, err := env.LedgerEntry(ownerDirKey)
+			require.NoError(t, err)
+			balanceBefore := env.Balance(alice)
+			sequenceBefore := env.Seq(alice)
+			ownerCountBefore := env.OwnerCount(alice)
+
+			result := env.Submit(pd.DomainDelete(alice, domainIDHex(domainKey)).Build())
+			jtx.RequireTxFail(t, result, jtx.TefBAD_LEDGER)
+			require.Nil(t, result.Metadata)
+			require.Equal(t, balanceBefore, env.Balance(alice))
+			require.Equal(t, sequenceBefore, env.Seq(alice))
+			require.Equal(t, ownerCountBefore, env.OwnerCount(alice))
+
+			domainAfter, err := env.LedgerEntry(domainKey)
+			require.NoError(t, err)
+			require.Equal(t, domainBefore, domainAfter)
+			dirAfter, err := env.LedgerEntry(ownerDirKey)
+			require.NoError(t, err)
+			require.Equal(t, dirBefore, dirAfter)
+		})
+	}
 }

--- a/internal/tx/permissioneddomain/permissioned_domain_delete.go
+++ b/internal/tx/permissioneddomain/permissioned_domain_delete.go
@@ -131,9 +131,9 @@ func (p *PermissionedDomainDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	// Remove from owner directory
 	// Reference: rippled PermissionedDomainDelete.cpp doApply()
 	ownerDirKey := keylet.OwnerDir(ctx.AccountID)
-	if _, err := state.DirRemove(ctx.View, ownerDirKey, existing.OwnerNode, domainKeylet.Key, false); err != nil {
-		ctx.Log.Error("permissioned domain delete: failed to remove from directory", "error", err)
-		return ter.TefBAD_LEDGER
+	if result := tx.DirRemoveOrBadLedger(ctx.View, ownerDirKey, existing.OwnerNode, domainKeylet.Key); result != ter.TesSUCCESS {
+		ctx.Log.Error("permissioned domain delete: failed to remove from directory")
+		return result
 	}
 
 	if err := ctx.View.Erase(domainKeylet); err != nil {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -21,7 +21,7 @@ transaction metadata without changing removal behavior when other entries remain
       `DirRemove` call sites for accidental behavior expansion.
 - [x] Run formatting, focused and affected-package tests, build, vet, strict CI
       lint, diff checks, and a final Go-quality/rippled-conformance review.
-- [ ] Stage intentional files only, commit, push, open the PR against `main`, and
+- [x] Stage intentional files only, commit, push, open the PR against `main`, and
       verify the published branch, PR head, mergeability, and CI state.
 
 ## Review
@@ -42,6 +42,9 @@ transaction metadata without changing removal behavior when other entries remain
   issue are not present in the workspace, so the exact full-ledger root replay
   was not rerun locally; the focused regression directly pins the divergent SLE
   bytes' semantic fields and metadata classification.
+- Behavior commit `3821b3ef` is pushed on
+  `fix/issue-1338-keep-owner-directory`; PR #1346 targets `main` at
+  https://github.com/LeJamon/go-xrpl/pull/1346.
 
 # Issue #1331 — VaultCreate Scale template allowlist
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,48 @@
+# Issue #1338 — PermissionedDomainDelete owner-directory retention
+
+## Goal
+
+Make `PermissionedDomainDelete` retain an empty page-zero owner-directory root
+after deleting its final domain, matching rippled v3.2.0 ledger state and
+transaction metadata without changing removal behavior when other entries remain.
+
+## Plan
+
+- [x] Validate GitHub auth, issue state and discussion, linked PRs, current remote
+      refs, exact base branch, clean worktree, and local rippled v3.2.0 provenance.
+- [x] Read the complete Go delete path, directory-removal implementation, metadata
+      stamping path, callers, and existing permissioned-domain tests.
+- [x] Read the complete rippled v3.2.0 delete implementation, directory-removal
+      semantics, and every relevant PermissionedDomain test case.
+- [x] Add focused regressions proving final-entry deletion retains an empty root
+      with matching previous-transaction fields and non-final deletion removes
+      only the target index.
+- [x] Implement the smallest production-quality parity fix and inspect all
+      `DirRemove` call sites for accidental behavior expansion.
+- [x] Run formatting, focused and affected-package tests, build, vet, strict CI
+      lint, diff checks, and a final Go-quality/rippled-conformance review.
+- [ ] Stage intentional files only, commit, push, open the PR against `main`, and
+      verify the published branch, PR head, mergeability, and CI state.
+
+## Review
+
+- `PermissionedDomainDelete.Apply` now uses `tx.DirRemoveOrBadLedger`, matching
+  rippled v3.2.0's `keepRoot=true` and `tefBAD_LEDGER` behavior when the recorded
+  directory page or item is missing.
+- Focused regressions prove the sole-domain root remains a threaded
+  `ModifiedNode` with empty on-ledger `Indexes`, deleting one of two domains
+  preserves the sibling, and a corrupt missing directory rolls back the delete.
+- Oracle coverage maps the Go apply call and shared helper to rippled
+  `PermissionedDomainDelete.cpp:55-63` and `ApplyView.cpp:255-392`; the clean
+  oracle is tag `3.2.0` at `3c43f4614f87965298773279ff5b85d4c56c637b`.
+- Affected packages, race tests, `just test-tx`, PermissionedDomains conformance
+  (6/6), build, vet, tagged PostgreSQL vet, strict CI lint v2.11.3, advisory
+  lint, formatting, and diff checks pass.
+- The historical ledger 3,300,730 checkpoint/debug artifacts referenced by the
+  issue are not present in the workspace, so the exact full-ledger root replay
+  was not rerun locally; the focused regression directly pins the divergent SLE
+  bytes' semantic fields and metadata classification.
+
 # Issue #1331 — VaultCreate Scale template allowlist
 
 ## Goal


### PR DESCRIPTION
## Summary
- retain the page-zero owner directory when `PermissionedDomainDelete` removes its final entry, matching rippled v3.2.0
- treat a missing recorded directory page or item as `tefBAD_LEDGER` instead of erasing the domain from inconsistent state
- cover empty-root threading and metadata, sibling preservation, and corrupt-directory rollback

## Test plan
- [x] `just test-pkg './internal/tx/permissioneddomain/... ./internal/testing/permissioneddomain/... -count=1'`
- [x] `go test -race -count=1 -timeout 15m ./internal/tx/permissioneddomain/... ./internal/testing/permissioneddomain/...`
- [x] `just conformance PermissionedDomains` (6/6)
- [x] `just test-tx`
- [x] `just build`
- [x] `just vet`
- [x] `go vet -tags postgres ./storage/relationaldb/postgres/`
- [x] `golangci-lint run` (v2.11.3)
- [x] `golangci-lint run --allow-parallel-runners --config .golangci-warnings.yml`
- [x] `git diff --check`

## Oracle
- rippled tag `3.2.0`, commit `3c43f4614f87965298773279ff5b85d4c56c637b`
- `PermissionedDomainDelete.cpp` passes `keepRoot=true` and maps failed directory removal to `tefBAD_LEDGER`

## Notes
- The ledger 3,300,730 checkpoint/debug artifacts referenced by the issue are not present locally, so the exact full-ledger root replay was not rerun. The focused regression directly pins the divergent retained SLE fields, transaction threading, and `ModifiedNode` metadata classification.

Fixes #1338
