### PR TITLE
test: assert LoanBroker directory owner

### DIFF
--- a/internal/testing/lending/loanbroker_test.go
+++ b/internal/testing/lending/loanbroker_test.go
@@ -323,7 +323,8 @@ func TestLoanSet_UpwardPaymentCountXRP(t *testing.T) {
 		}
 		return found
 	}
-	if !inOwnerDir("LoanBroker", accountID("LoanBroker", broker)) {
+	brokerAccount := accountID("LoanBroker", broker)
+	if !inOwnerDir("LoanBroker", brokerAccount) {
 		t.Error("Loan missing from LoanBroker pseudo-account owner directory")
 	}
 	if !inOwnerDir("borrower", borrower.AccountID()) {
@@ -331,6 +332,17 @@ func TestLoanSet_UpwardPaymentCountXRP(t *testing.T) {
 	}
 	if inOwnerDir("Vault", accountID("Vault", vaultFields)) {
 		t.Error("Loan present in Vault pseudo-account owner directory")
+	}
+	dirData, err := env.LedgerEntry(keylet.OwnerDir(brokerAccount))
+	if err != nil {
+		t.Fatalf("read LoanBroker owner directory: %v", err)
+	}
+	dir, err := state.ParseDirectoryNode(dirData)
+	if err != nil {
+		t.Fatalf("decode LoanBroker owner directory: %v", err)
+	}
+	if dir.Owner != brokerAccount {
+		t.Fatalf("LoanBroker directory owner = %x, want %x", dir.Owner, brokerAccount)
 	}
 
 	if got := env.OwnerCount(borrower); got != 1 {


### PR DESCRIPTION
## Summary
- Assert that a newly created LoanBroker owner directory records the LoanBroker pseudo-account as its DirectoryNode Owner.
- Rebase onto current main, which already contains the production directory fix and broader membership regression from PR #1345.
- Confirm the asserted behavior against the local rippled v3.2.0 oracle.

## Test plan
- [x] just build
- [x] just vet
- [x] just lint
- [x] GitHub CI: build, lint, generated artifacts, corpus replay, tx/core/libs/integration suites, no-CGO, and consensus smoke

Fixes #1347
