### PR TITLE
fix: preserve unassociated Loan numbers

### DIFF
--- a/internal/testing/lending/loanbroker_test.go
+++ b/internal/testing/lending/loanbroker_test.go
@@ -221,6 +221,127 @@ func TestLoanBroker_CoverDepositInsufficientFunds(t *testing.T) {
 	jtx.RequireTxClaimed(t, env.Submit(dep), jtx.TecINSUFFICIENT_FUNDS)
 }
 
+func TestLoanSet_UpwardPaymentCountXRP(t *testing.T) {
+	env := newLendingEnv(t)
+	owner := jtx.NewAccount("owner")
+	borrower := jtx.NewAccount("borrower")
+	env.FundAmount(owner, 10_000_000_000)
+	env.FundAmount(borrower, 10_000_000_000)
+
+	vaultSeq := env.Seq(owner)
+	vid := setupXRPVault(t, env, owner, 10_000_000)
+	vaultKey := keylet.Vault(owner.AccountID(), vaultSeq)
+
+	brokerSeq := env.Seq(owner)
+	jtx.RequireTxSuccess(t, env.Submit(lending.NewLoanBrokerSet(owner.Address, vid)))
+	bid := brokerID(owner, brokerSeq)
+	brokerKey := keylet.LoanBroker(owner.AccountID(), brokerSeq)
+
+	interestRate := uint32(500)
+	paymentInterval := uint32(60)
+	paymentTotal := uint32(12)
+	loanSet := lending.NewLoanSet(borrower.Address, bid, "1000000")
+	loanSet.InterestRate = &interestRate
+	loanSet.PaymentInterval = &paymentInterval
+	loanSet.PaymentTotal = &paymentTotal
+	loanSet.Counterparty = owner.Address
+	loanSet.GetCommon().Fee = "20"
+	loanSet.GetCommon().SigningPubKey = strings.ToUpper(borrower.PublicKeyHex())
+	counterpartySignature, err := txsign.SignCounterparty(
+		loanSet,
+		strings.ToUpper(owner.PublicKeyHex()),
+		"00"+strings.ToUpper(owner.PrivateKeyHex()),
+	)
+	if err != nil {
+		t.Fatalf("sign counterparty: %v", err)
+	}
+	loanSet.GetCommon().CounterpartySignature = counterpartySignature
+
+	borrowerBalance := env.Balance(borrower)
+	jtx.RequireTxSuccess(t, env.Submit(loanSet))
+
+	decode := func(name string, k keylet.Keylet) map[string]any {
+		t.Helper()
+		data, err := env.LedgerEntry(k)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		fields, err := binarycodec.DecodeBytes(data)
+		if err != nil {
+			t.Fatalf("decode %s: %v", name, err)
+		}
+		return fields
+	}
+	assertField := func(name string, fields map[string]any, field string, want any) {
+		t.Helper()
+		if got := fields[field]; got != want {
+			t.Errorf("%s %s = %v, want %v", name, field, got, want)
+		}
+	}
+
+	loanKey := keylet.Loan(brokerKey.Key, 1)
+	loan := decode("Loan", loanKey)
+	assertField("Loan", loan, "PeriodicPayment", "83333.33848930448955")
+	assertField("Loan", loan, "PrincipalOutstanding", "1000000")
+	assertField("Loan", loan, "TotalValueOutstanding", "1000001")
+	if _, ok := loan["LoanScale"]; ok {
+		t.Errorf("Loan LoanScale = %v, want omitted", loan["LoanScale"])
+	}
+	assertField("Loan", loan, "PaymentRemaining", uint32(12))
+
+	vaultFields := decode("Vault", vaultKey)
+	assertField("Vault", vaultFields, "AssetsAvailable", "9000000")
+	assertField("Vault", vaultFields, "AssetsTotal", "10000001")
+
+	broker := decode("LoanBroker", brokerKey)
+	assertField("LoanBroker", broker, "DebtTotal", "1000001")
+	assertField("LoanBroker", broker, "LoanSequence", uint32(2))
+	assertField("LoanBroker", broker, "OwnerCount", uint32(1))
+
+	accountID := func(name string, fields map[string]any) [20]byte {
+		t.Helper()
+		address, ok := fields["Account"].(string)
+		if !ok {
+			t.Fatalf("%s Account = %v, want address", name, fields["Account"])
+		}
+		id, err := state.DecodeAccountID(address)
+		if err != nil {
+			t.Fatalf("decode %s Account: %v", name, err)
+		}
+		return id
+	}
+	inOwnerDir := func(name string, owner [20]byte) bool {
+		t.Helper()
+		found := false
+		if err := state.DirForEach(env.Ledger(), keylet.OwnerDir(owner), func(item [32]byte) error {
+			if item == loanKey.Key {
+				found = true
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("read %s owner directory: %v", name, err)
+		}
+		return found
+	}
+	if !inOwnerDir("LoanBroker", accountID("LoanBroker", broker)) {
+		t.Error("Loan missing from LoanBroker pseudo-account owner directory")
+	}
+	if !inOwnerDir("borrower", borrower.AccountID()) {
+		t.Error("Loan missing from borrower owner directory")
+	}
+	if inOwnerDir("Vault", accountID("Vault", vaultFields)) {
+		t.Error("Loan present in Vault pseudo-account owner directory")
+	}
+
+	if got := env.OwnerCount(borrower); got != 1 {
+		t.Errorf("borrower OwnerCount = %d, want 1", got)
+	}
+	wantBorrowerBalance := borrowerBalance + 1_000_000 - 2*env.BaseFee()
+	if got := env.Balance(borrower); got != wantBorrowerBalance {
+		t.Errorf("borrower balance = %d, want %d", got, wantBorrowerBalance)
+	}
+}
+
 func TestLoanSet_ReplayUsesApplicationViewCloseTime(t *testing.T) {
 	env := newLendingEnv(t)
 	owner := jtx.NewAccount("owner")
@@ -246,6 +367,7 @@ func TestLoanSet_ReplayUsesApplicationViewCloseTime(t *testing.T) {
 	loanSet := lending.NewLoanSet(borrower.Address, bid, "1000000")
 	loanSet.PaymentInterval = &interval
 	loanSet.Counterparty = owner.Address
+	loanSet.GetCommon().Fee = "20"
 	loanSet.GetCommon().SigningPubKey = strings.ToUpper(borrower.PublicKeyHex())
 	counterpartySignature, err := txsign.SignCounterparty(
 		loanSet,
@@ -317,6 +439,7 @@ func TestLoanSet_ReplayRechecksScheduleAgainstApplicationViewCloseTime(t *testin
 	loanSet.PaymentInterval = &interval
 	loanSet.GracePeriod = &grace
 	loanSet.Counterparty = owner.Address
+	loanSet.GetCommon().Fee = "20"
 	loanSet.GetCommon().SigningPubKey = strings.ToUpper(borrower.PublicKeyHex())
 	counterpartySignature, err := txsign.SignCounterparty(
 		loanSet,
@@ -352,6 +475,7 @@ func TestLoanSet_ReplayRechecksScheduleAgainstApplicationViewCloseTime(t *testin
 	loanSet.PaymentInterval = &interval
 	loanSet.GracePeriod = &grace
 	loanSet.Counterparty = owner.Address
+	loanSet.GetCommon().Fee = "20"
 	loanSet.GetCommon().SigningPubKey = strings.ToUpper(borrower.PublicKeyHex())
 	counterpartySignature, err = txsign.SignCounterparty(
 		loanSet,

--- a/internal/tx/lending/view_helpers.go
+++ b/internal/tx/lending/view_helpers.go
@@ -64,15 +64,9 @@ func associateVaultAsset(v *vault.VaultLending, integral bool, rules *amendment.
 	v.LossUnrealized = associateNum(v.LossUnrealized, integral, true, rules)
 }
 
-// associateLoanAsset rounds the Loan's NUMBER fields to the vault asset's
-// precision at the end of doApply. PeriodicPayment is soeREQUIRED; the rest are
-// soeDEFAULT.
+// associateLoanAsset rounds the Loan's asset-associated NUMBER fields to the
+// vault asset's precision at the end of doApply.
 func associateLoanAsset(l *loanData, integral bool, rules *amendment.Rules) {
-	l.LoanOriginationFee = associateNum(l.LoanOriginationFee, integral, true, rules)
-	l.LoanServiceFee = associateNum(l.LoanServiceFee, integral, true, rules)
-	l.LatePaymentFee = associateNum(l.LatePaymentFee, integral, true, rules)
-	l.ClosePaymentFee = associateNum(l.ClosePaymentFee, integral, true, rules)
-	l.PeriodicPayment = associateNum(l.PeriodicPayment, integral, false, rules)
 	l.PrincipalOutstanding = associateNum(l.PrincipalOutstanding, integral, true, rules)
 	l.TotalValueOutstanding = associateNum(l.TotalValueOutstanding, integral, true, rules)
 	l.ManagementFeeOutstanding = associateNum(l.ManagementFeeOutstanding, integral, true, rules)

--- a/internal/tx/lending/view_helpers.go
+++ b/internal/tx/lending/view_helpers.go
@@ -64,8 +64,6 @@ func associateVaultAsset(v *vault.VaultLending, integral bool, rules *amendment.
 	v.LossUnrealized = associateNum(v.LossUnrealized, integral, true, rules)
 }
 
-// associateLoanAsset rounds the Loan's asset-associated NUMBER fields to the
-// vault asset's precision at the end of doApply.
 func associateLoanAsset(l *loanData, integral bool, rules *amendment.Rules) {
 	l.PrincipalOutstanding = associateNum(l.PrincipalOutstanding, integral, true, rules)
 	l.TotalValueOutstanding = associateNum(l.TotalValueOutstanding, integral, true, rules)

--- a/internal/tx/lending/view_helpers_test.go
+++ b/internal/tx/lending/view_helpers_test.go
@@ -1,0 +1,52 @@
+package lending
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+)
+
+func TestAssociateLoanAssetUsesSFieldMetadata(t *testing.T) {
+	rules := amendment.NewRules([][32]byte{
+		amendment.FeatureSingleAssetVault,
+		amendment.FeatureLendingProtocol,
+		amendment.FeatureFixCleanup3_2_0,
+	})
+	loan := &loanData{
+		LoanOriginationFee:       "1.4",
+		LoanServiceFee:           "2.4",
+		LatePaymentFee:           "3.4",
+		ClosePaymentFee:          "4.4",
+		PeriodicPayment:          "10.00000001505552512",
+		PrincipalOutstanding:     "11.4",
+		TotalValueOutstanding:    "12.6",
+		ManagementFeeOutstanding: "0.4",
+	}
+
+	associateLoanAsset(loan, true, rules)
+
+	for _, field := range []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"LoanOriginationFee", loan.LoanOriginationFee, "1.4"},
+		{"LoanServiceFee", loan.LoanServiceFee, "2.4"},
+		{"LatePaymentFee", loan.LatePaymentFee, "3.4"},
+		{"ClosePaymentFee", loan.ClosePaymentFee, "4.4"},
+		{"PeriodicPayment", loan.PeriodicPayment, "10.00000001505552512"},
+	} {
+		if field.got != field.want {
+			t.Errorf("%s = %q, want %q", field.name, field.got, field.want)
+		}
+	}
+	if got := lendNumForRules(loan.PrincipalOutstanding, rules); !got.Equal(lendNumForRules("11", rules)) {
+		t.Errorf("PrincipalOutstanding = %q, want 11", loan.PrincipalOutstanding)
+	}
+	if got := lendNumForRules(loan.TotalValueOutstanding, rules); !got.Equal(lendNumForRules("13", rules)) {
+		t.Errorf("TotalValueOutstanding = %q, want 13", loan.TotalValueOutstanding)
+	}
+	if got := loan.ManagementFeeOutstanding; got != "" {
+		t.Errorf("ManagementFeeOutstanding = %q, want empty", got)
+	}
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12,7 +12,7 @@ v3.2.0 worktree at `3c43f4614f87965298773279ff5b85d4c56c637b`.
 - [x] Implement the smallest idiomatic Go fix matching rippled v3.2.0 metadata.
 - [x] Run formatting, focused and affected tests, race coverage where useful,
       build, vet, lint, and final diff/conformance review.
-- [ ] Record exact review results, commit only intentional files, push, and open
+- [x] Record exact review results, commit only intentional files, push, and open
       a pull request against `main`.
 
 ## Review
@@ -35,6 +35,9 @@ v3.2.0 worktree at `3c43f4614f87965298773279ff5b85d4c56c637b`.
 - The historical devnet checkpoint/debug artifacts referenced by the issue are
   not present in this worktree, so the full ledger replay was not rerun; the
   exact divergent field value and metadata boundary are covered directly.
+- Behavior commit `ed568282` is published on
+  `fix/issue-1349-loanset-asset-rounding`; PR #1352 targets `main` at
+  https://github.com/LeJamon/go-xrpl/pull/1352.
 
 # Issue #1338 — PermissionedDomainDelete owner-directory retention
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,41 @@
+# Issue #1349 — LoanSet NUMBER asset association
+
+Target: `origin/main` at `ce13cadd`. Behavioral oracle: clean local rippled
+v3.2.0 worktree at `3c43f4614f87965298773279ff5b85d4c56c637b`.
+
+## Plan
+
+- [x] Confirm the Loan NUMBER fields carrying `kSmdNeedsAsset` and trace the Go
+      association path and all callers.
+- [x] Add a focused regression that preserves fractional fee/payment values while
+      continuing to associate the three outstanding-value fields.
+- [x] Implement the smallest idiomatic Go fix matching rippled v3.2.0 metadata.
+- [x] Run formatting, focused and affected tests, race coverage where useful,
+      build, vet, lint, and final diff/conformance review.
+- [ ] Record exact review results, commit only intentional files, push, and open
+      a pull request against `main`.
+
+## Review
+
+- `associateLoanAsset` now applies asset precision only to
+  `PrincipalOutstanding`, `TotalValueOutstanding`, and
+  `ManagementFeeOutstanding`, matching the complete `kSmdNeedsAsset` set for
+  Loan entries in rippled v3.2.0. The four fee fields and `PeriodicPayment`
+  retain their full NUMBER precision across LoanSet, LoanPay, and LoanManage.
+- The focused regression pins the replay's `10.00000001505552512` periodic
+  payment, covers all five unassociated Loan fields, and proves the three
+  associated fields still round or disappear at their default. It failed on
+  the original helper and passes with the fix.
+- Passed focused lending transaction and integration tests, focused race tests,
+  the full `internal/tx/...` suite, `just fmt`, `just vet`, `just build-all`,
+  `just lint` with zero issues, and `git diff --check`.
+- Independent final Go-quality and rippled-conformance reviews found no
+  Blocking, Minor, or Nit issues. The oracle is the clean local tag `3.2.0` at
+  `3c43f4614f87965298773279ff5b85d4c56c637b`.
+- The historical devnet checkpoint/debug artifacts referenced by the issue are
+  not present in this worktree, so the full ledger replay was not rerun; the
+  exact divergent field value and metadata boundary are covered directly.
+
 # Issue #1338 — PermissionedDomainDelete owner-directory retention
 
 ## Goal


### PR DESCRIPTION
## Summary
- preserve Loan fee fields and `PeriodicPayment` when applying vault-asset precision
- restrict Loan asset association to the three NUMBER fields marked by rippled metadata
- add a regression covering the reported fractional periodic payment and all eight Loan NUMBER fields

## Test plan
- [x] `just test-pkg ./internal/tx/lending/...`
- [x] `just test-pkg ./internal/testing/lending/...`
- [x] `go test -race ./internal/tx/lending/... ./internal/testing/lending -count=1`
- [x] `just test-tx`
- [x] `just vet`
- [x] `just build-all`
- [x] `just lint`

Fixes #1349
