### PR TITLE
fix: include credential count in preauth key

### DIFF
--- a/keylet/keylet.go
+++ b/keylet/keylet.go
@@ -272,6 +272,9 @@ func DepositPreauthCredentials(owner [20]byte, sortedCreds []CredentialPair) Key
 	for i := range hashes {
 		data = append(data, hashes[i][:])
 	}
+	var sizeBytes [8]byte
+	binary.BigEndian.PutUint64(sizeBytes[:], uint64(len(hashes)))
+	data = append(data, sizeBytes[:])
 
 	return Keylet{
 		Type: entry.TypeDepositPreauth,

--- a/keylet/keylet.go
+++ b/keylet/keylet.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"sort"
 
 	"github.com/LeJamon/go-xrpl/crypto/sha512half"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
@@ -253,21 +254,32 @@ func DepositPreauth(owner, authorized [20]byte) Keylet {
 }
 
 // CredentialPair represents an (issuer, credentialType) pair for credential-based
-// deposit preauth keylet computation. Pairs must be sorted before use.
+// deposit preauth keylet computation.
 type CredentialPair struct {
 	Issuer         [20]byte
 	CredentialType []byte
 }
 
 // DepositPreauthCredentials returns the keylet for a credential-based deposit
-// preauthorization entry. The credentials must already be sorted.
+// preauthorization entry. Credentials are sorted and deduplicated before hashing.
 // Reference: rippled Indexes.cpp depositPreauth(owner, authCreds)
-func DepositPreauthCredentials(owner [20]byte, sortedCreds []CredentialPair) Keylet {
-	hashes := make([][32]byte, len(sortedCreds))
-	for i, c := range sortedCreds {
-		hashes[i] = sha512half.Sum(c.Issuer[:], c.CredentialType)
+func DepositPreauthCredentials(owner [20]byte, credentials []CredentialPair) Keylet {
+	sorted := append([]CredentialPair(nil), credentials...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if cmp := bytes.Compare(sorted[i].Issuer[:], sorted[j].Issuer[:]); cmp != 0 {
+			return cmp < 0
+		}
+		return bytes.Compare(sorted[i].CredentialType, sorted[j].CredentialType) < 0
+	})
+
+	hashes := make([][32]byte, 0, len(sorted))
+	for i, c := range sorted {
+		if i > 0 && c.Issuer == sorted[i-1].Issuer && bytes.Equal(c.CredentialType, sorted[i-1].CredentialType) {
+			continue
+		}
+		hashes = append(hashes, sha512half.Sum(c.Issuer[:], c.CredentialType))
 	}
-	data := make([][]byte, 0, 1+len(sortedCreds))
+	data := make([][]byte, 0, 2+len(hashes))
 	data = append(data, owner[:])
 	for i := range hashes {
 		data = append(data, hashes[i][:])

--- a/keylet/keylet_test.go
+++ b/keylet/keylet_test.go
@@ -156,3 +156,39 @@ func TestXChainClaimKeyletsHashRawBridgeFields(t *testing.T) {
 		})
 	}
 }
+
+func TestDepositPreauthKeylets(t *testing.T) {
+	decodeAccount := func(encoded string) [20]byte {
+		t.Helper()
+		decoded, err := hex.DecodeString(encoded)
+		if err != nil {
+			t.Fatalf("decode account ID %s: %v", encoded, err)
+		}
+		if len(decoded) != 20 {
+			t.Fatalf("account ID %s decoded to %d bytes, want 20", encoded, len(decoded))
+		}
+		var account [20]byte
+		copy(account[:], decoded)
+		return account
+	}
+
+	owner := decodeAccount("09127e0295e2e0fcb76f70d816fed9029a771f30")
+	issuer := decodeAccount("0811f666a9c82537a71592b583c4b78e4b7dcc2c")
+	credentials := []CredentialPair{{Issuer: issuer, CredentialType: []byte("Administration")}}
+
+	tests := []struct {
+		name     string
+		key      Keylet
+		expected string
+	}{
+		{"account", DepositPreauth(owner, issuer), "06d8409e9a8d44925723cddb021e1260dc294098da1d7b0eda2245557c622ca0"},
+		{"credentials", DepositPreauthCredentials(owner, credentials), "95a4bc7f742e6191c206128c655c59fdfd1344e5421b258536c4d00314e577a2"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := hex.EncodeToString(tc.key.Key[:]); actual != tc.expected {
+				t.Fatalf("DepositPreauth key = %s, want %s", actual, tc.expected)
+			}
+		})
+	}
+}

--- a/keylet/keylet_test.go
+++ b/keylet/keylet_test.go
@@ -175,6 +175,11 @@ func TestDepositPreauthKeylets(t *testing.T) {
 	owner := decodeAccount("09127e0295e2e0fcb76f70d816fed9029a771f30")
 	issuer := decodeAccount("0811f666a9c82537a71592b583c4b78e4b7dcc2c")
 	credentials := []CredentialPair{{Issuer: issuer, CredentialType: []byte("Administration")}}
+	multipleCredentials := []CredentialPair{
+		{Issuer: owner, CredentialType: []byte("KYC")},
+		{Issuer: issuer, CredentialType: []byte("Administration")},
+		{Issuer: issuer, CredentialType: []byte("Administration")},
+	}
 
 	tests := []struct {
 		name     string
@@ -182,7 +187,12 @@ func TestDepositPreauthKeylets(t *testing.T) {
 		expected string
 	}{
 		{"account", DepositPreauth(owner, issuer), "06d8409e9a8d44925723cddb021e1260dc294098da1d7b0eda2245557c622ca0"},
+		{"empty credentials", DepositPreauthCredentials(owner, nil), "01f6ddb0c831858957ec1b50a82f7c703e45792b09034549ba5a394a26508337"},
 		{"credentials", DepositPreauthCredentials(owner, credentials), "95a4bc7f742e6191c206128c655c59fdfd1344e5421b258536c4d00314e577a2"},
+		{"multiple credentials", DepositPreauthCredentials(owner, multipleCredentials), "9bee57bf61f0bcb2e201abcc1014722491e75f23dcb41f00327c59804af81824"},
+	}
+	if multipleCredentials[0].Issuer != owner {
+		t.Fatal("DepositPreauthCredentials mutated its input")
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- append the big-endian credential vector count when deriving credential-based DepositPreauth keylets
- add exact devnet replay and account-based oracle vectors to prevent key drift

## Test plan
- [x] `just test-pkg ./keylet/...`
- [x] `just test-pkg ./internal/testing/depositpreauth/...`
- [x] `just conformance DepositPreauth`
- [x] `just build`
- [x] `just vet`
- [x] `golangci-lint run`

Fixes #1350
