### PR TITLE
fix: preserve bare AMMClawback account metadata

### DIFF
--- a/internal/testing/amm/amm_clawback_metadata_test.go
+++ b/internal/testing/amm/amm_clawback_metadata_test.go
@@ -1,0 +1,126 @@
+package amm_test
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/accountset"
+	"github.com/LeJamon/go-xrpl/internal/testing/amm"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/stretchr/testify/require"
+)
+
+func accountRootMetadataNode(meta *tx.Metadata, accountID [20]byte) *tx.AffectedNode {
+	key := keylet.Account(accountID).Key
+	ledgerIndex := strings.ToUpper(hex.EncodeToString(key[:]))
+	for i := range meta.AffectedNodes {
+		node := &meta.AffectedNodes[i]
+		if node.LedgerEntryType == "AccountRoot" && node.LedgerIndex == ledgerIndex {
+			return node
+		}
+	}
+	return nil
+}
+
+func TestAMMClawbackIOUPoolEmitsBareThreadedAMMAccount(t *testing.T) {
+	env := amm.NewAMMTestEnv(t)
+	gw2 := jtx.NewAccount("gw2")
+	env.EnableOpenLedgerReplay()
+	env.FundAmount(env.GW, uint64(jtx.XRP(1_000_000)))
+	env.FundAmount(gw2, uint64(jtx.XRP(1_000_000)))
+	env.FundAmount(env.Alice, uint64(jtx.XRP(1_000_000)))
+	env.FundAmount(env.Bob, uint64(jtx.XRP(1_000_000)))
+	env.Close()
+
+	jtx.RequireTxSuccess(t, env.Submit(accountset.AccountSet(env.GW).AllowClawback().Build()))
+	env.Close()
+
+	eur := tx.Asset{Currency: "EUR", Issuer: gw2.Address}
+	env.Trust(env.Alice, env.GW, "USD", 100_000)
+	env.PayIOU(env.GW, env.Alice, "USD", 3_000)
+	env.Trust(env.Alice, gw2, "EUR", 100_000)
+	env.PayIOU(gw2, env.Alice, "EUR", 3_000)
+	env.Trust(env.Bob, env.GW, "USD", 100_000)
+	env.PayIOU(env.GW, env.Bob, "USD", 3_000)
+	env.Trust(env.Bob, gw2, "EUR", 100_000)
+	env.PayIOU(gw2, env.Bob, "EUR", 3_000)
+	env.Close()
+
+	jtx.RequireTxSuccess(t, env.Submit(amm.AMMCreate(
+		env.Alice,
+		amm.IOUAmount(gw2, "EUR", 1_000),
+		amm.IOUAmount(env.GW, "USD", 2_000),
+	).Build()))
+	env.Close()
+
+	jtx.RequireTxSuccess(t, env.Submit(amm.AMMDeposit(env.Bob, env.USD, eur).
+		Amount(amm.IOUAmount(env.GW, "USD", 2_000)).
+		Amount2(amm.IOUAmount(gw2, "EUR", 1_000)).
+		TwoAsset().
+		Build()))
+	env.Close()
+
+	ammAccount := amm.AMMAccount(t, env, env.USD, eur)
+	clawbackTx := amm.AMMClawback(env.GW, env.Bob.Address, env.USD, eur).Build()
+	result := env.Submit(clawbackTx)
+	jtx.RequireTxSuccess(t, result)
+	require.NotNil(t, result.Metadata)
+
+	node := accountRootMetadataNode(result.Metadata, ammAccount.ID)
+	require.NotNil(t, node, "affected nodes: %+v", result.Metadata.AffectedNodes)
+	require.Equal(t, "ModifiedNode", node.NodeType)
+	require.NotEmpty(t, node.PreviousTxnID)
+	require.NotZero(t, node.PreviousTxnLgrSeq)
+	require.Nil(t, node.FinalFields)
+	require.Nil(t, node.PreviousFields)
+
+	metadataBlob, err := tx.SerializeMetadata(result.Metadata)
+	require.NoError(t, err)
+	require.Len(t, metadataBlob, 2_248)
+	metadataHash := sha512half.Sum(metadataBlob)
+	require.Equal(t,
+		"5BAB776D2BE53B806FA36CEB802C2E20331D1784855EB7506EFDF1C8622B8058",
+		strings.ToUpper(hex.EncodeToString(metadataHash[:])))
+	txBlob, err := tx.SerializeTransaction(clawbackTx)
+	require.NoError(t, err)
+	txWithMeta, err := tx.CreateTxWithMetaBlob(txBlob, result.Metadata)
+	require.NoError(t, err)
+	txHash, err := tx.ComputeTransactionHash(clawbackTx)
+	require.NoError(t, err)
+	txMap := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, txMap.PutWithNodeType(txHash, txWithMeta, shamap.NodeTypeTransactionWithMeta))
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+	require.Equal(t,
+		"E1BDF44F57FC43AE2CD9609009B80613FEF0430B0D03F71D3A4B433F5197FDEC",
+		strings.ToUpper(hex.EncodeToString(txRoot[:])))
+}
+
+func TestAMMClawbackXRPPoolPersistsAMMAccountBalance(t *testing.T) {
+	env := setupClawbackEnvWithUSD(t, 1_000_000, 1_000_000, 3_000)
+
+	jtx.RequireTxSuccess(t, env.Submit(amm.AMMCreate(
+		env.Alice,
+		amm.XRPAmount(1_000),
+		amm.IOUAmount(env.GW, "USD", 2_000),
+	).Build()))
+	env.Close()
+
+	ammAccount := amm.AMMAccount(t, env, env.USD, amm.XRP())
+	balanceBefore := env.Balance(ammAccount)
+	result := env.Submit(amm.AMMClawback(env.GW, env.Alice.Address, env.USD, amm.XRP()).
+		Amount(amm.IOUAmount(env.GW, "USD", 1_000)).
+		Build())
+	jtx.RequireTxSuccess(t, result)
+
+	require.Equal(t, balanceBefore-uint64(jtx.XRP(500)), env.Balance(ammAccount))
+	node := accountRootMetadataNode(result.Metadata, ammAccount.ID)
+	require.NotNil(t, node)
+	require.NotEmpty(t, node.FinalFields)
+	require.Contains(t, node.PreviousFields, "Balance")
+}

--- a/internal/testing/amm/amm_clawback_metadata_test.go
+++ b/internal/testing/amm/amm_clawback_metadata_test.go
@@ -2,6 +2,7 @@ package amm_test
 
 import (
 	"encoding/hex"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/accountset"
 	"github.com/LeJamon/go-xrpl/internal/testing/amm"
+	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/shamap"
@@ -123,4 +125,62 @@ func TestAMMClawbackXRPPoolPersistsAMMAccountBalance(t *testing.T) {
 	require.NotNil(t, node)
 	require.NotEmpty(t, node.FinalFields)
 	require.Contains(t, node.PreviousFields, "Balance")
+}
+
+func TestAMMClawbackIncompleteCleanupPreservesAMMAccountState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: creates 513 accounts")
+	}
+
+	const extraTrustLines = 513
+
+	env := setupClawbackEnvWithUSD(t, 1_000_000, 1_000_000, 3_000)
+	jtx.RequireTxSuccess(t, env.Submit(amm.AMMCreate(
+		env.Alice,
+		amm.XRPAmount(1_000),
+		amm.IOUAmount(env.GW, "USD", 2_000),
+	).Build()))
+	env.Close()
+
+	ammAccount := amm.AMMAccount(t, env, env.USD, amm.XRP())
+	lptAmount := amm.LPTokenAmount(env, env.USD, amm.XRP(), 10_000)
+	for i := range extraTrustLines {
+		account := jtx.NewAccount(fmt.Sprintf("clawback-lp-%d", i))
+		env.FundAmount(account, uint64(jtx.XRP(1_000)))
+		env.Close()
+		jtx.RequireTxSuccess(t, env.Submit(trustset.TrustSet(account, lptAmount).Build()))
+		env.Close()
+	}
+
+	balanceBefore := env.Balance(ammAccount)
+	result := env.Submit(amm.AMMClawback(env.GW, env.Alice.Address, env.USD, amm.XRP()).Build())
+	jtx.RequireTxSuccess(t, result)
+
+	ammData := env.ReadAMMData(env.USD, amm.XRP())
+	require.NotNil(t, ammData)
+	require.True(t, ammData.LPTokenBalance.IsZero())
+	require.False(t, env.LedgerEntryExists(keylet.Line(ammAccount.ID, env.GW.ID, "USD")))
+	require.Equal(t, uint32(0), env.OwnerCount(ammAccount))
+	require.Equal(t, uint64(0), env.Balance(ammAccount))
+
+	node := accountRootMetadataNode(result.Metadata, ammAccount.ID)
+	require.NotNil(t, node)
+	require.Equal(t, "ModifiedNode", node.NodeType)
+	require.Equal(t, "0", node.FinalFields["Balance"])
+	require.Equal(t, uint32(0), node.FinalFields["OwnerCount"])
+	require.Equal(t, fmt.Sprint(balanceBefore), node.PreviousFields["Balance"])
+	require.Equal(t, uint32(1), node.PreviousFields["OwnerCount"])
+
+	jtx.RequireTxSuccess(t, env.Submit(amm.AMMDeposit(env.Alice, env.USD, amm.XRP()).
+		Amount(amm.IOUAmount(env.GW, "USD", 500)).
+		Amount2(amm.XRPAmount(500)).
+		TwoAssetIfEmpty().
+		Build()))
+	require.True(t, env.LedgerEntryExists(keylet.Line(ammAccount.ID, env.GW.ID, "USD")))
+	require.Equal(t, uint32(1), env.OwnerCount(ammAccount))
+
+	jtx.RequireTxSuccess(t, env.Submit(amm.AMMWithdraw(env.Alice, env.USD, amm.XRP()).
+		WithdrawAll().
+		Build()))
+	require.Nil(t, env.ReadAMMData(env.USD, amm.XRP()))
 }

--- a/internal/tx/amm/amm_clawback.go
+++ b/internal/tx/amm/amm_clawback.go
@@ -360,7 +360,7 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 			if result := sendMPT(ctx.View, holderID, issuerID, withdrawAmount1, true); result != ter.TesSUCCESS {
 				return result
 			}
-		} else if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset, withdrawAmount1.Negate(), ctx.View, ctx.NumberContext()); err != nil {
+		} else if err := debitAMMTrustline(ammAccountID, a.Asset, withdrawAmount1, ctx.View, ctx.NumberContext()); err != nil {
 			return ter.TefINTERNAL
 		}
 	}
@@ -377,7 +377,7 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 				if result := sendMPT(ctx.View, holderID, issuerID, withdrawAmount2, true); result != ter.TesSUCCESS {
 					return result
 				}
-			} else if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset2, withdrawAmount2.Negate(), ctx.View, ctx.NumberContext()); err != nil {
+			} else if err := debitAMMTrustline(ammAccountID, a.Asset2, withdrawAmount2, ctx.View, ctx.NumberContext()); err != nil {
 				return ter.TefINTERNAL
 			}
 		} else if isXRP2 && !withdrawAmount2.IsZero() {
@@ -396,7 +396,7 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 					return result
 				}
 			} else {
-				if err := createOrUpdateAMMTrustline(ammAccountID, a.Asset2, withdrawAmount2.Negate(), ctx.View, ctx.NumberContext()); err != nil {
+				if err := debitAMMTrustline(ammAccountID, a.Asset2, withdrawAmount2, ctx.View, ctx.NumberContext()); err != nil {
 					return ter.TefINTERNAL
 				}
 				issuer2ID, _ := state.DecodeAccountID(a.Asset2.Issuer)

--- a/internal/tx/amm/amm_clawback.go
+++ b/internal/tx/amm/amm_clawback.go
@@ -437,17 +437,6 @@ func (a *AMMClawback) Apply(ctx *tx.ApplyContext) ter.Result {
 		return deleteResult
 	}
 
-	// Persist updated AMM account XRP balance if AMM still exists
-	if !newLPBalance.IsZero() || deleteResult == ter.TecINCOMPLETE {
-		ammAccountBytes, err := state.SerializeAccountRoot(ammAccount)
-		if err != nil {
-			return ter.TefINTERNAL
-		}
-		if err := ctx.View.Update(ammAccountKey, ammAccountBytes); err != nil {
-			return ter.TefINTERNAL
-		}
-	}
-
 	accountKey := keylet.Account(issuerID)
 	accountBytes, err := state.SerializeAccountRoot(ctx.Account)
 	if err != nil {

--- a/internal/tx/amm/amm_delete_account.go
+++ b/internal/tx/amm/amm_delete_account.go
@@ -1,8 +1,6 @@
 package amm
 
 import (
-	"bytes"
-
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
@@ -11,21 +9,26 @@ import (
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
 
-// updateAMMAccountIfChanged persists the AMM account only when its serialized
-// bytes actually differ from what the view already holds. An all-IOU withdraw
-// leaves the AMM account's own fields untouched (only its trust lines change);
-// rewriting it would promote it to a modified node, whereas rippled leaves it
-// as a bare threaded owner of the changed trust lines (no FinalFields). An
-// XRP-side withdraw does change its Balance, so it is still written.
-func updateAMMAccountIfChanged(view tx.LedgerView, ammAccountKey keylet.Keylet, ammAccount *state.AccountRoot) ter.Result {
-	ammAccountBytes, err := state.SerializeAccountRoot(ammAccount)
+// updateAMMAccountBalanceIfChanged merges the locally calculated XRP balance
+// into the latest AccountRoot so trust-line owner-count changes are preserved.
+func updateAMMAccountBalanceIfChanged(view tx.LedgerView, ammAccountKey keylet.Keylet, ammAccount *state.AccountRoot) ter.Result {
+	currentBytes, err := view.Read(ammAccountKey)
+	if err != nil || currentBytes == nil {
+		return ter.TefINTERNAL
+	}
+	current, err := state.ParseAccountRoot(currentBytes)
 	if err != nil {
 		return ter.TefINTERNAL
 	}
-	if cur, _ := view.Read(ammAccountKey); bytes.Equal(cur, ammAccountBytes) {
+	if current.Balance == ammAccount.Balance {
 		return ter.TesSUCCESS
 	}
-	if err := view.Update(ammAccountKey, ammAccountBytes); err != nil {
+	current.Balance = ammAccount.Balance
+	updatedBytes, err := state.SerializeAccountRoot(current)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if err := view.Update(ammAccountKey, updatedBytes); err != nil {
 		return ter.TefINTERNAL
 	}
 	return ter.TesSUCCESS
@@ -84,70 +87,24 @@ func deleteAMMTrustLine(view tx.LedgerView, lineKey keylet.Keylet, rs *state.Rip
 		return ter.TerNO_AMM
 	}
 
-	// The reserve-holding side's flag must be present before the line is erased;
-	// an AMM pool line always carries at least the AMM side's reserve flag, so its
-	// total absence is an internal inconsistency. Mirrors rippled's tecINTERNAL
-	// guard. Reference: rippled View.cpp:2759-2761.
-	if rs.Flags&(state.LsfLowReserve|state.LsfHighReserve) == 0 {
-		return ter.TecINTERNAL
-	}
-
-	// Clear the reserve flag only on the AMM side, reproducing rippled: it
-	// releases the AMM side's reserve during the payout credit and leaves the
-	// non-AMM (holder) side's flag set (e.g. on the LP-token line).
-	if rs.Flags&state.LsfLowReserve != 0 {
-		if ammLow {
-			rs.Flags &^= state.LsfLowReserve
-		}
-		if err := decrementLineOwner(view, lowAccountID, lowAccount, ammLow); err != nil {
-			return ter.TecINTERNAL
-		}
-	}
-	if rs.Flags&state.LsfHighReserve != 0 {
-		if ammHigh {
-			rs.Flags &^= state.LsfHighReserve
-		}
-		if err := decrementLineOwner(view, highAccountID, highAccount, ammHigh); err != nil {
-			return ter.TecINTERNAL
-		}
-	}
-
-	// Persist the cleared reserve flag before erasing so the DeletedNode records
-	// the flag change as PreviousFields.
-	rsBytes, err := state.SerializeRippleState(rs)
-	if err != nil {
-		return ter.TecINTERNAL
-	}
-	if err := view.Update(lineKey, rsBytes); err != nil {
-		return ter.TecINTERNAL
-	}
-
 	if trustDelete(view, lineKey, lowAccountID, highAccountID, rs.LowNode, rs.HighNode) != nil {
 		return ter.TefBAD_LEDGER
 	}
 
-	return ter.TesSUCCESS
-}
+	nonAMMAccountID := lowAccountID
+	nonAMMReserveFlag := uint32(state.LsfLowReserve)
+	if ammLow {
+		nonAMMAccountID = highAccountID
+		nonAMMReserveFlag = state.LsfHighReserve
+	}
+	if rs.Flags&nonAMMReserveFlag == 0 {
+		return ter.TecINTERNAL
+	}
+	if err := tx.AdjustOwnerCount(view, nonAMMAccountID, -1); err != nil {
+		return ter.TecINTERNAL
+	}
 
-// decrementLineOwner decrements the OwnerCount of a trust line's reserve-holding
-// side through the view, so the change is recorded as an in-place modification
-// before the line (and, for the AMM side, the AMM AccountRoot) is erased. For
-// the AMM side it routes through tx.AdjustOwnerCount, which re-reads the account
-// from the view each call so repeated decrements (one per pool line) compose to
-// the correct final OwnerCount and the AMM AccountRoot's later erase becomes a
-// DeletedNode carrying PreviousFields.OwnerCount.
-func decrementLineOwner(view tx.LedgerView, accountID [20]byte, account *state.AccountRoot, isAMM bool) error {
-	if isAMM {
-		return tx.AdjustOwnerCount(view, accountID, -1)
-	}
-	if account.OwnerCount > 0 {
-		account.OwnerCount--
-	}
-	bytes, err := state.SerializeAccountRoot(account)
-	if err != nil {
-		return err
-	}
-	return view.Update(keylet.Account(accountID), bytes)
+	return ter.TesSUCCESS
 }
 
 // deleteAMMTrustLines iterates the AMM account's owner directory and deletes
@@ -358,7 +315,7 @@ func deleteAMMAccountIfEmpty(view tx.LedgerView, ammKey keylet.Keylet, ammAccoun
 		if err := view.Update(ammKey, ammBytes); err != nil {
 			return ter.TefINTERNAL
 		}
-		if r := updateAMMAccountIfChanged(view, ammAccountKey, ammAccount); r != ter.TesSUCCESS {
+		if r := updateAMMAccountBalanceIfChanged(view, ammAccountKey, ammAccount); r != ter.TesSUCCESS {
 			return r
 		}
 		return ter.TesSUCCESS
@@ -371,7 +328,7 @@ func deleteAMMAccountIfEmpty(view tx.LedgerView, ammKey keylet.Keylet, ammAccoun
 	// DeletedNode metadata records the pre-withdrawal balance instead of the
 	// drained balance, mirroring rippled which transfers the XRP out (draining the
 	// account) before deleting it.
-	if r := updateAMMAccountIfChanged(view, ammAccountKey, ammAccount); r != ter.TesSUCCESS {
+	if r := updateAMMAccountBalanceIfChanged(view, ammAccountKey, ammAccount); r != ter.TesSUCCESS {
 		return r
 	}
 	result := DeleteAMMAccount(view, asset, asset2)
@@ -389,9 +346,6 @@ func deleteAMMAccountIfEmpty(view tx.LedgerView, ammKey keylet.Keylet, ammAccoun
 		}
 		if err := view.Update(ammKey, ammBytes); err != nil {
 			return ter.TefINTERNAL
-		}
-		if r := updateAMMAccountIfChanged(view, ammAccountKey, ammAccount); r != ter.TesSUCCESS {
-			return r
 		}
 	}
 

--- a/internal/tx/amm/amm_delete_account.go
+++ b/internal/tx/amm/amm_delete_account.go
@@ -92,7 +92,7 @@ func deleteAMMTrustLine(view tx.LedgerView, lineKey keylet.Keylet, rs *state.Rip
 	}
 
 	nonAMMAccountID := lowAccountID
-	nonAMMReserveFlag := uint32(state.LsfLowReserve)
+	nonAMMReserveFlag := state.LsfLowReserve
 	if ammLow {
 		nonAMMAccountID = highAccountID
 		nonAMMReserveFlag = state.LsfHighReserve

--- a/internal/tx/amm/amm_deposit.go
+++ b/internal/tx/amm/amm_deposit.go
@@ -1082,7 +1082,7 @@ func (a *AMMDeposit) Apply(ctx *tx.ApplyContext) ter.Result {
 	// adjusts its Balance). For an all-IOU deposit the AMM account's own fields
 	// are untouched; rewriting it would promote it to a modified node, whereas
 	// rippled leaves it a bare threaded owner of the changed trust lines (#1038).
-	if r := updateAMMAccountIfChanged(ctx.View, ammAccountKey, ammAccount); r != ter.TesSUCCESS {
+	if r := updateAMMAccountBalanceIfChanged(ctx.View, ammAccountKey, ammAccount); r != ter.TesSUCCESS {
 		return r
 	}
 

--- a/internal/tx/amm/amm_withdraw.go
+++ b/internal/tx/amm/amm_withdraw.go
@@ -888,7 +888,7 @@ func withdrawIOUToAccount(
 	// Reference: rippled accountSend → rippleCredit handles issuer case by only
 	// adjusting the single AMM-issuer trust line.
 	if accountID == issuerID {
-		if err := createOrUpdateAMMTrustline(ammAccountID, asset, amount.Negate(), ctx.View, ctx.NumberContext()); err != nil {
+		if err := debitAMMTrustline(ammAccountID, asset, amount, ctx.View, ctx.NumberContext()); err != nil {
 			return ter.TefINTERNAL
 		}
 		return ter.TesSUCCESS
@@ -932,7 +932,7 @@ func withdrawIOUToAccount(
 	}
 
 	// Debit AMM's trust line (negative delta)
-	if err := createOrUpdateAMMTrustline(ammAccountID, asset, amount.Negate(), ctx.View, ctx.NumberContext()); err != nil {
+	if err := debitAMMTrustline(ammAccountID, asset, amount, ctx.View, ctx.NumberContext()); err != nil {
 		return ter.TefINTERNAL
 	}
 

--- a/internal/tx/amm/trustline.go
+++ b/internal/tx/amm/trustline.go
@@ -180,7 +180,7 @@ func createOrUpdateAMMTrustline(ammAccountID [20]byte, asset tx.Asset, amount tx
 	if result := trustCreate(view, ammAccountID, issuerID, asset.Currency, amount, trustCreateOpts{setAMMNode: true}); result != ter.TesSUCCESS {
 		return errors.New("trust create failed")
 	}
-	return nil
+	return tx.AdjustOwnerCount(view, ammAccountID, 1)
 }
 
 // updateTrustlineBalanceInView updates the balance of a trust line for IOU transfers.
@@ -190,6 +190,36 @@ func updateTrustlineBalanceInView(accountID [20]byte, issuerID [20]byte, currenc
 	result, err := updateTrustlineBalanceInViewEx(accountID, issuerID, currency, delta, view, numberContext)
 	_ = result
 	return err
+}
+
+func debitAMMTrustline(ammAccountID [20]byte, asset tx.Asset, amount tx.Amount, view tx.LedgerView, numberContext state.NumberContext) error {
+	issuerID, err := state.DecodeAccountID(asset.Issuer)
+	if err != nil {
+		return err
+	}
+
+	result, err := updateTrustlineBalanceInViewEx(
+		ammAccountID,
+		issuerID,
+		asset.Currency,
+		amount.Negate(),
+		view,
+		numberContext,
+	)
+	if err != nil {
+		return err
+	}
+	if result.SenderOwnerCountDelta != 0 {
+		if err := tx.AdjustOwnerCount(view, ammAccountID, result.SenderOwnerCountDelta); err != nil {
+			return err
+		}
+	}
+	if result.IssuerOwnerCountDelta != 0 {
+		if err := tx.AdjustOwnerCount(view, issuerID, result.IssuerOwnerCountDelta); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // updateTrustlineBalanceInViewEx updates a trust line balance and handles reserve
@@ -308,6 +338,14 @@ func updateTrustlineBalanceInViewEx(accountID [20]byte, issuerID [20]byte, curre
 		}
 	}
 
+	serialized, err := state.SerializeRippleState(rs)
+	if err != nil {
+		return result, err
+	}
+	if err := view.Update(lineKey, serialized); err != nil {
+		return result, err
+	}
+
 	if bDelete {
 		lowAccountID, highAccountID := issuerID, accountID
 		if senderIsLow {
@@ -330,12 +368,7 @@ func updateTrustlineBalanceInViewEx(accountID [20]byte, issuerID [20]byte, curre
 		return result, err
 	}
 
-	serialized, err := state.SerializeRippleState(rs)
-	if err != nil {
-		return result, err
-	}
-
-	return result, view.Update(lineKey, serialized)
+	return result, nil
 }
 
 // createLPTokenTrustline creates or updates a trust line for LP tokens.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -43,6 +43,37 @@ Behavioral oracle: clean local rippled `3.2.0` worktree at
   rerun. The regression directly pins the exact divergent 2,248-byte metadata
   boundary and its canonical transaction leaf/tree hash.
 
+## PR #1358 finalization
+
+- [x] Pin the exact PR head, base, clean worktree, and clean local rippled 3.2.0
+      oracle at `3c43f4614f87965298773279ff5b85d4c56c637b`.
+- [x] Review the complete diff and adjacent AMM withdrawal, trust-line cleanup,
+      bounded deletion, AccountRoot persistence, and metadata paths.
+- [x] Resolve the final-LP `tecINCOMPLETE` divergence found during review by
+      deleting drained pool lines before bounded cleanup and preserving the
+      latest pseudo-account `OwnerCount` while merging XRP balance changes.
+- [x] Add a final-share AMMClawback regression with 513 excess LP trust lines.
+- [x] Restore pseudo-account `OwnerCount` when an empty AMM recreates a drained
+      IOU pool line, and extend the regression through re-seeding and deletion.
+- [ ] Repeat independent correctness and rippled-conformance review; pass build,
+      vet, lint, whitespace, and exact-head CI gates.
+- [ ] Run the required separate comment-cleanup phase, verify final CI, and
+      record the local-only conformance audit.
+
+### Finalization review
+
+- Rippled v3.2.0 drains and deletes a zero AMM pool RippleState, including its
+  reserve and pseudo-account `OwnerCount`, before applying the 512-entry AMM
+  cleanup bound. On `tecINCOMPLETE` it updates only the AMM ledger entry.
+- The shared Go debit path now applies the same balance, reserve, owner-count,
+  and deletion transition for AMMClawback and AMMWithdraw. AccountRoot balance
+  persistence merges into the latest view, and interrupted cleanup no longer
+  rewrites an earlier AccountRoot snapshot.
+- Re-seeding an interrupted empty AMM now increments `OwnerCount` for each
+  recreated IOU pool line, matching rippled's `trustCreate` transition.
+- Bounded cleanup now erases the zero line and decrements only the non-AMM
+  reserve owner, matching `deleteAMMTrustLine` in the pinned oracle.
+
 # Issue #1349 — LoanSet NUMBER asset association
 
 Target: `origin/main` at `ce13cadd`. Behavioral oracle: clean local rippled

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,48 @@
+# Issue #1357 — AMMClawback pseudo-account metadata
+
+Target: `origin/main` at `7aab186ddb36317bdb63c831e6ffb9c5dd25b364`.
+Behavioral oracle: clean local rippled `3.2.0` worktree at
+`3c43f4614f87965298773279ff5b85d4c56c637b`.
+
+## Plan
+
+- [x] Validate GitHub access, issue state and discussion, linked PRs, active
+      release branches, exact base, and clean dedicated worktree.
+- [x] Trace AMMClawback pseudo-account persistence and metadata action tracking
+      in Go, including genuine XRP-side balance changes.
+- [x] Verify the complete corresponding apply path and regression expectations
+      against local rippled v3.2.0.
+- [x] Add focused regressions for bare threaded IOU/IOU metadata, byte/root
+      parity where fixtures permit, and persisted XRP-side balance changes.
+- [x] Implement the smallest production-quality parity fix.
+- [x] Run formatting, focused and affected tests, race coverage where useful,
+      build, vet, strict CI lint, conformance/diff review, and exact-head checks.
+- [x] Record the review results, stage intentional files only, commit, push, and
+      open the PR against `main`.
+
+## Review
+
+- Removed the redundant unconditional pseudo AccountRoot write after
+  `deleteAMMAccountIfEmpty`; that helper already persists serialized-byte changes,
+  including real XRP balance changes and the `tecINCOMPLETE` survivor path.
+- Rippled v3.2.0 reads the pseudo AccountRoot but changes it economically only for
+  native XRP sends. Deleting a holder's LP RippleState threads the unchanged IOU/
+  IOU pseudo-account as a bare `ModifiedNode`, while an XRP payout updates its
+  `Balance` and emits normal `FinalFields`.
+- The IOU/IOU regression reproduces the whole-holder LP-line deletion with a
+  surviving AMM, asserts node-level threading without `FinalFields`, pins the
+  complete 2,248-byte metadata blob by SHA-512Half, and pins the resulting
+  single-transaction SHAMap root. The XRP contrast proves a 500 XRP pseudo-root
+  balance reduction remains persisted and represented in metadata.
+- Passed focused pre-fix/fixed regression runs, affected AMM transaction and
+  integration packages, focused race coverage, `just test-tx`, `just fmt`,
+  `just build-all`, `just vet`, tagged PostgreSQL vet, CI-pinned strict lint,
+  advisory lint, `git diff --check`, and AMMClawback conformance (12/12).
+- The original Devnet checkpoint and the other 12 transaction leaves from ledger
+  3,325,984 are not present locally, so its complete 13-transaction root was not
+  rerun. The regression directly pins the exact divergent 2,248-byte metadata
+  boundary and its canonical transaction leaf/tree hash.
+
 # Issue #1349 — LoanSet NUMBER asset association
 
 Target: `origin/main` at `ce13cadd`. Behavioral oracle: clean local rippled


### PR DESCRIPTION
## Summary
- remove the redundant AMM pseudo-account write that promoted metadata-only threading to a full `ModifiedNode`
- preserve change-aware persistence for genuine XRP-side pseudo-account balance updates
- add IOU/IOU metadata-byte/tree-root and XRP balance regressions against rippled v3.2.0 behavior

## Test plan
- [x] `go test ./internal/tx/amm/... ./internal/testing/amm -count=1`
- [x] `go test -race ./internal/testing/amm -run 'TestAMMClawback(IOUPool|XRPPool)' -count=1`
- [x] `just test-tx`
- [x] `just conformance AMMClawback` (12/12)
- [x] `just fmt`
- [x] `just build-all`
- [x] `just vet`
- [x] `go vet -tags postgres ./storage/relationaldb/postgres/`
- [x] `golangci-lint run --config .golangci.yml`
- [x] `just lint`

Fixes #1357
