### PR TITLE
Fix Offer cleanup for AdditionalBooks

### DIFF
--- a/internal/ledger/state/offer_delete.go
+++ b/internal/ledger/state/offer_delete.go
@@ -7,13 +7,13 @@ import (
 )
 
 // DeleteOffer removes an Offer from every directory that indexes it, then
-// erases the Offer. A nil Offer is a successful no-op. Directory removals are
-// applied in ledger order and are not rolled back if a later removal fails;
-// callers that require atomicity must provide a sandboxed view. OwnerCount
-// adjustment remains the caller's responsibility.
+// erases the Offer. A nil Offer is a successful no-op and reports removed=false.
+// Directory removals are applied in ledger order and are not rolled back if a
+// later removal fails; callers that require atomicity must provide a sandboxed
+// view. OwnerCount adjustment remains the caller's responsibility.
 func DeleteOffer(view LedgerView, offerKey keylet.Keylet, offer *LedgerOffer) (bool, error) {
 	if offer == nil {
-		return true, nil
+		return false, nil
 	}
 
 	owner, err := DecodeAccountID(offer.Account)

--- a/internal/ledger/state/offer_delete.go
+++ b/internal/ledger/state/offer_delete.go
@@ -1,0 +1,70 @@
+package state
+
+import (
+	"fmt"
+
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// DeleteOffer removes an Offer from every directory that indexes it, then
+// erases the Offer. A nil Offer is a successful no-op. Directory removals are
+// applied in ledger order and are not rolled back if a later removal fails;
+// callers that require atomicity must provide a sandboxed view. OwnerCount
+// adjustment remains the caller's responsibility.
+func DeleteOffer(view LedgerView, offerKey keylet.Keylet, offer *LedgerOffer) (bool, error) {
+	if offer == nil {
+		return true, nil
+	}
+
+	owner, err := DecodeAccountID(offer.Account)
+	if err != nil {
+		return false, fmt.Errorf("decode offer owner: %w", err)
+	}
+	additionalBooks, err := offerAdditionalBookLinks(offer)
+	if err != nil {
+		return false, err
+	}
+
+	directories := make([]offerBookLink, 0, 2+len(additionalBooks))
+	directories = append(directories,
+		offerBookLink{directory: keylet.OwnerDir(owner).Key, node: offer.OwnerNode},
+		offerBookLink{directory: offer.BookDirectory, node: offer.BookNode},
+	)
+	directories = append(directories, additionalBooks...)
+
+	for _, directory := range directories {
+		result, removeErr := DirRemove(
+			view,
+			keylet.Keylet{Key: directory.directory},
+			directory.node,
+			offerKey.Key,
+			false,
+		)
+		if removeErr != nil {
+			return false, removeErr
+		}
+		if result == nil || !result.Success {
+			return false, nil
+		}
+	}
+
+	if err := view.Erase(offerKey); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func offerAdditionalBookLinks(offer *LedgerOffer) ([]offerBookLink, error) {
+	additionalBookUnchanged := decodedFieldUnchanged(offer.decodedOptionals, "AdditionalBookDirectory", offer.AdditionalBookDirectory) &&
+		decodedFieldUnchanged(offer.decodedOptionals, "AdditionalBookNode", offer.AdditionalBookNode)
+	if raw, ok := offer.decodedOptionals["AdditionalBooks"].([]any); ok && additionalBookUnchanged {
+		return decodeAdditionalBooks(raw)
+	}
+	if offer.AdditionalBookDirectory != ([32]byte{}) {
+		return []offerBookLink{{
+			directory: offer.AdditionalBookDirectory,
+			node:      offer.AdditionalBookNode,
+		}}, nil
+	}
+	return nil, nil
+}

--- a/internal/ledger/state/offer_delete_test.go
+++ b/internal/ledger/state/offer_delete_test.go
@@ -1,0 +1,113 @@
+package state
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteOfferRemovesEveryBookDirectory(t *testing.T) {
+	t.Parallel()
+
+	view := newStubView()
+	var owner [20]byte
+	owner[19] = 1
+	var issuer [20]byte
+	issuer[19] = 2
+	offerKey := keylet.Offer(owner, 7)
+	primary := keylet.Keylet{Key: itemKeyN(10)}
+	additional := []keylet.Keylet{
+		{Key: itemKeyN(11)},
+		{Key: itemKeyN(12)},
+	}
+
+	ownerDir := keylet.OwnerDir(owner)
+	_, err := DirInsert(view, ownerDir, offerKey.Key, false, nil)
+	require.NoError(t, err)
+	_, err = DirInsert(view, primary, offerKey.Key, true, nil)
+	require.NoError(t, err)
+	for _, dir := range additional {
+		_, err = DirInsert(view, dir, offerKey.Key, true, nil)
+		require.NoError(t, err)
+	}
+	books := make([]any, 0, len(additional))
+	for _, dir := range additional {
+		books = append(books, map[string]any{
+			"Book": map[string]any{
+				"BookDirectory": strings.ToUpper(hex.EncodeToString(dir.Key[:])),
+				"BookNode":      "0",
+			},
+		})
+	}
+	offer := &LedgerOffer{
+		Account:                 EncodeAccountIDSafe(owner),
+		Sequence:                7,
+		TakerPays:               NewIssuedAmountFromValue(1_000_000_000_000_000, -15, "USD", EncodeAccountIDSafe(issuer)),
+		TakerGets:               NewXRPAmountFromInt(1_000_000),
+		BookDirectory:           primary.Key,
+		AdditionalBookDirectory: additional[0].Key,
+		decodedOptionals: map[string]any{
+			"AdditionalBooks":         books,
+			"AdditionalBookDirectory": additional[0].Key,
+			"AdditionalBookNode":      uint64(0),
+		},
+	}
+	data, err := SerializeLedgerOffer(offer)
+	require.NoError(t, err)
+	parsed, err := ParseLedgerOffer(data)
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(offerKey, data))
+
+	removed, err := DeleteOffer(view, offerKey, parsed)
+	require.NoError(t, err)
+	require.True(t, removed)
+
+	for _, dir := range append([]keylet.Keylet{ownerDir, primary}, additional...) {
+		exists, err := view.Exists(dir)
+		require.NoError(t, err)
+		require.False(t, exists)
+	}
+	exists, err := view.Exists(offerKey)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestDeleteOfferStopsAfterMissingAdditionalDirectoryEntry(t *testing.T) {
+	t.Parallel()
+
+	view := newStubView()
+	var owner [20]byte
+	owner[19] = 1
+	offerKey := keylet.Offer(owner, 7)
+	ownerDir := keylet.OwnerDir(owner)
+	primary := keylet.Keylet{Key: itemKeyN(10)}
+	additional := keylet.Keylet{Key: itemKeyN(11)}
+
+	_, err := DirInsert(view, ownerDir, offerKey.Key, false, nil)
+	require.NoError(t, err)
+	_, err = DirInsert(view, primary, offerKey.Key, true, nil)
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(offerKey, []byte{1}))
+
+	offer := &LedgerOffer{
+		Account:                 EncodeAccountIDSafe(owner),
+		Sequence:                7,
+		BookDirectory:           primary.Key,
+		AdditionalBookDirectory: additional.Key,
+	}
+	removed, err := DeleteOffer(view, offerKey, offer)
+	require.NoError(t, err)
+	require.False(t, removed)
+
+	for _, dir := range []keylet.Keylet{ownerDir, primary} {
+		exists, err := view.Exists(dir)
+		require.NoError(t, err)
+		require.False(t, exists)
+	}
+	exists, err := view.Exists(offerKey)
+	require.NoError(t, err)
+	require.True(t, exists)
+}

--- a/internal/ledger/state/offer_delete_test.go
+++ b/internal/ledger/state/offer_delete_test.go
@@ -9,6 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDeleteOfferNilIsNoop(t *testing.T) {
+	t.Parallel()
+
+	removed, err := DeleteOffer(newStubView(), keylet.Keylet{}, nil)
+	require.NoError(t, err)
+	require.False(t, removed)
+}
+
 func TestDeleteOfferRemovesEveryBookDirectory(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ledger/state/offer_entry.go
+++ b/internal/ledger/state/offer_entry.go
@@ -32,6 +32,11 @@ type LedgerOffer struct {
 	decodedOptionals        map[string]any
 }
 
+type offerBookLink struct {
+	directory [32]byte
+	node      uint64
+}
+
 // OfferCreate flags (kept here for backwards compatibility and external references)
 const (
 	OfferCreateFlagPassive           uint32 = 0x00010000
@@ -168,35 +173,55 @@ func parseLedgerOffer(data []byte) (*LedgerOffer, error) {
 }
 
 func decodeAdditionalBook(books []any, offer *LedgerOffer) error {
-	if len(books) == 0 {
-		return nil
+	links, err := decodeAdditionalBooks(books)
+	if err != nil || len(links) == 0 {
+		return err
 	}
-	element, ok := books[0].(map[string]any)
+	offer.AdditionalBookDirectory = links[0].directory
+	offer.AdditionalBookNode = links[0].node
+	return nil
+}
+
+func decodeAdditionalBooks(books []any) ([]offerBookLink, error) {
+	links := make([]offerBookLink, 0, len(books))
+	for i, value := range books {
+		link, err := decodeAdditionalBookEntry(value, i)
+		if err != nil {
+			return nil, err
+		}
+		links = append(links, link)
+	}
+	return links, nil
+}
+
+func decodeAdditionalBookEntry(value any, index int) (offerBookLink, error) {
+	var link offerBookLink
+	element, ok := value.(map[string]any)
 	if !ok {
-		return fmt.Errorf("Offer.AdditionalBooks[0]: decoded element has type %T", books[0])
+		return link, fmt.Errorf("Offer.AdditionalBooks[%d]: decoded element has type %T", index, value)
 	}
 	bookValue, ok := element["Book"]
 	if !ok {
-		return fmt.Errorf("Offer.AdditionalBooks[0]: missing Book")
+		return link, fmt.Errorf("Offer.AdditionalBooks[%d]: missing Book", index)
 	}
 	book, ok := bookValue.(map[string]any)
 	if !ok {
-		return fmt.Errorf("Offer.AdditionalBooks[0].Book: decoded value has type %T", bookValue)
+		return link, fmt.Errorf("Offer.AdditionalBooks[%d].Book: decoded value has type %T", index, bookValue)
 	}
 	directory, ok := book["BookDirectory"].(string)
 	if !ok {
-		return fmt.Errorf("Offer.AdditionalBooks[0].BookDirectory: decoded value has type %T", book["BookDirectory"])
+		return link, fmt.Errorf("Offer.AdditionalBooks[%d].BookDirectory: decoded value has type %T", index, book["BookDirectory"])
 	}
-	if err := decodeLedgerHex("Offer.AdditionalBooks[0].BookDirectory", directory, offer.AdditionalBookDirectory[:]); err != nil {
-		return err
+	if err := decodeLedgerHex(fmt.Sprintf("Offer.AdditionalBooks[%d].BookDirectory", index), directory, link.directory[:]); err != nil {
+		return link, err
 	}
 	node, ok := book["BookNode"].(string)
 	if !ok {
-		return fmt.Errorf("Offer.AdditionalBooks[0].BookNode: decoded value has type %T", book["BookNode"])
+		return link, fmt.Errorf("Offer.AdditionalBooks[%d].BookNode: decoded value has type %T", index, book["BookNode"])
 	}
 	var err error
-	offer.AdditionalBookNode, err = parseLedgerUint64("Offer.AdditionalBooks[0].BookNode", node)
-	return err
+	link.node, err = parseLedgerUint64(fmt.Sprintf("Offer.AdditionalBooks[%d].BookNode", index), node)
+	return link, err
 }
 
 // ParseLedgerOffer parses a LedgerOffer from binary data.

--- a/internal/testing/permissioneddex/permissioned_dex_test.go
+++ b/internal/testing/permissioneddex/permissioned_dex_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	ammBuilder "github.com/LeJamon/go-xrpl/internal/testing/amm"
 	cred "github.com/LeJamon/go-xrpl/internal/testing/credential"
@@ -41,6 +42,23 @@ func parseDomainID(hexStr string) [32]byte {
 	var id [32]byte
 	copy(id[:], b)
 	return id
+}
+
+func requireDirectoryMembership(t *testing.T, env *jtx.TestEnv, dir keylet.Keylet, item [32]byte, want bool) {
+	t.Helper()
+	found := false
+	err := state.DirForEach(env.Ledger(), dir, func(key [32]byte) error {
+		if key == item {
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("iterate directory %x: %v", dir.Key, err)
+	}
+	if found != want {
+		t.Fatalf("directory %x membership for %x: got %t, want %t", dir.Key, item, found, want)
+	}
 }
 
 // TestPermissionedDEX_ZeroDomainID verifies that a zero DomainID is rejected as
@@ -1332,6 +1350,18 @@ func TestPermissionedDEX_HybridOfferCreate(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 		offerBuilder.RequireOfferInLedger(t, env, dex.Bob, bobSeq)
+		hybridOffer := offerBuilder.GetOffer(env, dex.Bob, bobSeq)
+		if hybridOffer == nil {
+			t.Fatal("hybrid offer missing after creation")
+		}
+		offerKey := keylet.Offer(dex.Bob.ID, bobSeq).Key
+		ownerDir := keylet.OwnerDir(dex.Bob.ID)
+		primaryDir := keylet.Keylet{Key: hybridOffer.BookDirectory}
+		additionalDir := keylet.Keylet{Key: hybridOffer.AdditionalBookDirectory}
+		for _, dir := range []keylet.Keylet{ownerDir, primaryDir, additionalDir} {
+			requireDirectoryMembership(t, env, dir, offerKey, true)
+		}
+		ownerCount := env.OwnerCount(dex.Bob)
 
 		// alice creates regular (non-domain) offer - should cross bob's hybrid (in open book)
 		aliceSeq := env.Seq(dex.Alice)
@@ -1343,6 +1373,10 @@ func TestPermissionedDEX_HybridOfferCreate(t *testing.T) {
 
 		offerBuilder.RequireNoOfferInLedger(t, env, dex.Alice, aliceSeq)
 		offerBuilder.RequireNoOfferInLedger(t, env, dex.Bob, bobSeq)
+		for _, dir := range []keylet.Keylet{ownerDir, primaryDir, additionalDir} {
+			requireDirectoryMembership(t, env, dir, offerKey, false)
+		}
+		jtx.RequireOwnerCount(t, env, dex.Bob, ownerCount-1)
 	})
 
 	// Hybrid offer crosses with domain offer by default (looks at domain book)
@@ -1696,6 +1730,7 @@ func TestPermissionedDEX_HybridOfferDirectories(t *testing.T) {
 
 	const dirCount = 100
 	offerSeqs := make([]uint32, 0, dirCount)
+	offerDirs := make(map[uint32][]keylet.Keylet, dirCount)
 
 	for range dirCount {
 		bobSeq := env.Seq(dex.Bob)
@@ -1708,13 +1743,32 @@ func TestPermissionedDEX_HybridOfferDirectories(t *testing.T) {
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 		offerBuilder.RequireOfferInLedger(t, env, dex.Bob, bobSeq)
+		offer := offerBuilder.GetOffer(env, dex.Bob, bobSeq)
+		if offer == nil {
+			t.Fatalf("hybrid offer %d missing after creation", bobSeq)
+		}
+		offerKey := keylet.Offer(dex.Bob.ID, bobSeq).Key
+		offerDirs[bobSeq] = []keylet.Keylet{
+			keylet.OwnerDir(dex.Bob.ID),
+			{Key: offer.BookDirectory},
+			{Key: offer.AdditionalBookDirectory},
+		}
+		for _, dir := range offerDirs[bobSeq] {
+			requireDirectoryMembership(t, env, dir, offerKey, true)
+		}
 	}
 
 	// Cancel all hybrid offers - they should be removed from both directories
 	for _, seq := range offerSeqs {
+		ownerCount := env.OwnerCount(dex.Bob)
 		result := env.Submit(offerBuilder.OfferCancel(dex.Bob, seq).Build())
 		jtx.RequireTxSuccess(t, result)
 		env.Close()
 		offerBuilder.RequireNoOfferInLedger(t, env, dex.Bob, seq)
+		offerKey := keylet.Offer(dex.Bob.ID, seq).Key
+		for _, dir := range offerDirs[seq] {
+			requireDirectoryMembership(t, env, dir, offerKey, false)
+		}
+		jtx.RequireOwnerCount(t, env, dex.Bob, ownerCount-1)
 	}
 }

--- a/internal/tx/account/account_delete.go
+++ b/internal/tx/account/account_delete.go
@@ -281,19 +281,13 @@ func removeFromDir(ctx *tx.ApplyContext, dir keylet.Keylet, hint uint64, itemKey
 	return err == nil && res.Success
 }
 
-func deleteOffer(ctx *tx.ApplyContext, ownerDirKey, ik keylet.Keylet, data []byte) ter.Result {
+func deleteOffer(ctx *tx.ApplyContext, _ keylet.Keylet, ik keylet.Keylet, data []byte) ter.Result {
 	offer, err := state.ParseLedgerOffer(data)
 	if err != nil {
 		return ter.TefBAD_LEDGER
 	}
-	if !removeFromDir(ctx, ownerDirKey, offer.OwnerNode, ik.Key, false) {
-		return ter.TefBAD_LEDGER
-	}
-	bdk := keylet.Keylet{Type: 100, Key: offer.BookDirectory}
-	if !removeFromDir(ctx, bdk, offer.BookNode, ik.Key, false) {
-		return ter.TefBAD_LEDGER
-	}
-	if err := ctx.View.Erase(ik); err != nil {
+	removed, err := state.DeleteOffer(ctx.View, ik, offer)
+	if err != nil || !removed {
 		return ter.TefBAD_LEDGER
 	}
 	decrementOwnerCount(ctx)

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -588,12 +588,9 @@ func (e *Engine) removeUnfundedOffers(tecTable *applystate.ApplyStateTable, keys
 		if decodeErr != nil {
 			continue
 		}
-		ownerDirKey := keylet.OwnerDir(ownerID)
-		state.DirRemove(tecTable, ownerDirKey, offerObj.OwnerNode, offerKey, false)
-		bookDirKey := keylet.Keylet{Type: 100, Key: offerObj.BookDirectory}
-		state.DirRemove(tecTable, bookDirKey, offerObj.BookNode, offerKey, false)
-		_ = tecTable.Erase(offerKL)
-		adjustOwnerCountOnView(tecTable, ownerID, -1)
+		if removed, deleteErr := state.DeleteOffer(tecTable, offerKL, offerObj); deleteErr == nil && removed {
+			adjustOwnerCountOnView(tecTable, ownerID, -1)
+		}
 	}
 }
 

--- a/internal/tx/offer/offer_cancel.go
+++ b/internal/tx/offer/offer_cancel.go
@@ -7,7 +7,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
-	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
 
 // OfferCancel cancels an existing offer on the decentralized exchange.
@@ -106,28 +105,12 @@ func (o *OfferCancel) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TefINTERNAL
 	}
 
-	// Remove from owner directory (keepRoot = false since owner dir should persist)
-	ownerDirKey := keylet.OwnerDir(accountID)
-	ownerDirResult, err := state.DirRemove(ctx.View, ownerDirKey, ledgerOffer.OwnerNode, offerKey.Key, false)
+	removed, err := state.DeleteOffer(ctx.View, offerKey, ledgerOffer)
 	if err != nil {
 		return ter.TefINTERNAL
 	}
-	if !ownerDirResult.Success {
+	if !removed {
 		return ter.TefBAD_LEDGER
-	}
-
-	// Remove from book directory (keepRoot = false - delete directory if empty)
-	bookDirKey := keylet.Keylet{Type: entry.TypeDirectoryNode, Key: ledgerOffer.BookDirectory}
-	bookDirResult, err := state.DirRemove(ctx.View, bookDirKey, ledgerOffer.BookNode, offerKey.Key, false)
-	if err != nil {
-		return ter.TefINTERNAL
-	}
-	if !bookDirResult.Success {
-		return ter.TefBAD_LEDGER
-	}
-
-	if err := ctx.View.Erase(offerKey); err != nil {
-		return ter.TefINTERNAL
 	}
 
 	if ctx.Account.OwnerCount > 0 {

--- a/internal/tx/offer/offer_create_apply.go
+++ b/internal/tx/offer/offer_create_apply.go
@@ -219,23 +219,13 @@ func offerDeleteInView(view tx.LedgerView, offer *state.LedgerOffer) ter.Result 
 		return ter.TefINTERNAL
 	}
 	offerKey := keylet.Offer(accountID, offer.Sequence)
-
-	ownerDirKey := keylet.OwnerDir(accountID)
-	_, err = state.DirRemove(view, ownerDirKey, offer.OwnerNode, offerKey.Key, false)
+	removed, err := state.DeleteOffer(view, offerKey, offer)
 	if err != nil {
 		return ter.TefINTERNAL
 	}
-
-	bookDirKey := keylet.Keylet{Type: entry.TypeDirectoryNode, Key: offer.BookDirectory}
-	_, err = state.DirRemove(view, bookDirKey, offer.BookNode, offerKey.Key, false)
-	if err != nil {
-		return ter.TefINTERNAL
+	if !removed {
+		return ter.TefBAD_LEDGER
 	}
-
-	if err := view.Erase(offerKey); err != nil {
-		return ter.TefINTERNAL
-	}
-
 	return ter.TesSUCCESS
 }
 

--- a/internal/tx/offer/offer_create_cross.go
+++ b/internal/tx/offer/offer_create_cross.go
@@ -446,6 +446,7 @@ func removeOfferFromView(view *payment.PaymentSandbox, offerKeylet keylet.Keylet
 	if err != nil {
 		return
 	}
-	_ = offerDeleteInView(view, offer)
-	adjustOwnerCountInView(view, ownerID, -1)
+	if offerDeleteInView(view, offer) == ter.TesSUCCESS {
+		adjustOwnerCountInView(view, ownerID, -1)
+	}
 }

--- a/internal/tx/payment/flow.go
+++ b/internal/tx/payment/flow.go
@@ -563,19 +563,9 @@ func offerDeleteInSandbox(sb *PaymentSandbox, offerKey [32]byte) {
 		return
 	}
 
-	// Remove from owner directory
-	ownerDirKey := keylet.OwnerDir(ownerID)
-	state.DirRemove(sb, ownerDirKey, offer.OwnerNode, offerKey, false)
-
-	// Remove from book directory
-	bookDirKey := keylet.Keylet{Type: 100, Key: offer.BookDirectory}
-	state.DirRemove(sb, bookDirKey, offer.BookNode, offerKey, false)
-
-	// Erase the offer
-	sb.Erase(offerKL)
-
-	// Decrement owner count
-	adjustOwnerCountInSandbox(sb, ownerID, -1)
+	if removed, deleteErr := state.DeleteOffer(sb, offerKL, offer); deleteErr == nil && removed {
+		adjustOwnerCountInSandbox(sb, ownerID, -1)
+	}
 }
 
 // adjustOwnerCountInSandbox modifies an account's OwnerCount by delta in a PaymentSandbox.

--- a/internal/tx/payment/pathfinder/pathfinder_test.go
+++ b/internal/tx/payment/pathfinder/pathfinder_test.go
@@ -127,13 +127,18 @@ func testAccountAddress(id [20]byte) string {
 
 // addAccount stores a serialized AccountRoot at the proper keylet.
 func addAccount(t *testing.T, ledger *mockLedgerView, accountID [20]byte, balance uint64, flags uint32) {
+	addAccountWithOwnerCount(t, ledger, accountID, balance, flags, 0)
+}
+
+func addAccountWithOwnerCount(t *testing.T, ledger *mockLedgerView, accountID [20]byte, balance uint64, flags, ownerCount uint32) {
 	t.Helper()
 	addr := testAccountAddress(accountID)
 	acct := &state.AccountRoot{
-		Account:  addr,
-		Balance:  balance,
-		Sequence: 1,
-		Flags:    flags,
+		Account:    addr,
+		Balance:    balance,
+		Sequence:   1,
+		OwnerCount: ownerCount,
+		Flags:      flags,
 	}
 	data, err := state.SerializeAccountRoot(acct)
 	require.NoError(t, err, "serialize AccountRoot for %x", accountID[:4])
@@ -1327,7 +1332,11 @@ func TestGetPathLiquidityDoesNotReuseConsumedOffer(t *testing.T) {
 	gwAddr := testAccountAddress(gw)
 
 	for _, account := range [][20]byte{alice, bob, gw, owner} {
-		addAccount(t, ledger, account, 10_000_000_000, 0)
+		ownerCount := uint32(0)
+		if account == owner {
+			ownerCount = 1
+		}
+		addAccountWithOwnerCount(t, ledger, account, 10_000_000_000, 0, ownerCount)
 	}
 
 	low, high := bob, gw
@@ -1369,6 +1378,14 @@ func TestGetPathLiquidityDoesNotReuseConsumedOffer(t *testing.T) {
 	}, true)
 	require.NoError(t, err)
 	ledger.entries[dirKey.Key] = dirData
+	ownerDirKey := keylet.OwnerDir(owner)
+	ownerDirData, err := state.SerializeDirectoryNode(&state.DirectoryNode{
+		RootIndex: ownerDirKey.Key,
+		Indexes:   [][32]byte{offerKey},
+		Owner:     owner,
+	}, false)
+	require.NoError(t, err)
+	ledger.entries[ownerDirKey.Key] = ownerDirData
 
 	dstAmount := state.NewIssuedAmountFromFloat64(100, "USD", gwAddr)
 	pf := NewPathfinder(

--- a/internal/tx/payment/step_book_consume.go
+++ b/internal/tx/payment/step_book_consume.go
@@ -142,51 +142,18 @@ func (s *BookStep) zeroIn() EitherAmount {
 // deleteOffer properly deletes an offer from the ledger.
 func (s *BookStep) deleteOffer(sb *PaymentSandbox, offer *state.LedgerOffer, owner [20]byte) error {
 	offerKey := keylet.Offer(owner, offer.Sequence)
-
-	ownerDirKey := keylet.OwnerDir(owner)
-	ownerResult, err := state.DirRemove(sb, ownerDirKey, offer.OwnerNode, offerKey.Key, false)
+	removed, err := state.DeleteOffer(sb, offerKey, offer)
 	if err != nil {
+		return err
 	}
-	if ownerResult != nil {
-		s.applyDirRemoveResult(sb, ownerResult)
-	}
-
-	bookDirKey := keylet.Keylet{Key: offer.BookDirectory}
-	bookResult, err := state.DirRemove(sb, bookDirKey, offer.BookNode, offerKey.Key, false)
-	if err != nil {
-	}
-	if bookResult != nil {
-		s.applyDirRemoveResult(sb, bookResult)
+	if !removed {
+		return nil
 	}
 
 	if err := s.adjustOwnerCount(sb, owner, -1); err != nil {
 		return err
 	}
-
-	if err := sb.Erase(offerKey); err != nil {
-		return err
-	}
-
 	return nil
-}
-
-// applyDirRemoveResult applies directory removal changes to the sandbox
-func (s *BookStep) applyDirRemoveResult(sb *PaymentSandbox, result *state.DirRemoveResult) {
-	for _, mod := range result.ModifiedNodes {
-		isBookDir := mod.NewState.TakerPaysCurrency != [20]byte{} || mod.NewState.TakerGetsCurrency != [20]byte{} ||
-			mod.NewState.TakerPaysMPT != nil || mod.NewState.TakerGetsMPT != nil
-		data, err := state.SerializeDirectoryNode(mod.NewState, isBookDir)
-		if err != nil {
-			continue
-		}
-		if err := sb.Update(keylet.Keylet{Key: mod.Key}, data); err != nil {
-		}
-	}
-
-	for _, del := range result.DeletedNodes {
-		if err := sb.Erase(keylet.Keylet{Key: del.Key}); err != nil {
-		}
-	}
 }
 
 func (s *BookStep) subtractFromAmount(original, consumed EitherAmount) EitherAmount {

--- a/internal/tx/payment/step_book_consume_test.go
+++ b/internal/tx/payment/step_book_consume_test.go
@@ -1,0 +1,23 @@
+package payment
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBookStepDeleteOfferIgnoresMissingDirectoryEntry(t *testing.T) {
+	t.Parallel()
+
+	view := newPaymentMockLedgerView()
+	sandbox := NewPaymentSandbox(view)
+	var owner [20]byte
+	owner[19] = 1
+	offer := &state.LedgerOffer{
+		Account:  state.EncodeAccountIDSafe(owner),
+		Sequence: 7,
+	}
+
+	require.NoError(t, (&BookStep{}).deleteOffer(sandbox, offer, owner))
+}

--- a/internal/tx/payment/step_book_offer.go
+++ b/internal/tx/payment/step_book_offer.go
@@ -491,19 +491,9 @@ func (s *BookStep) removeExpiredOffer(sb *PaymentSandbox, offer *state.LedgerOff
 		return
 	}
 
-	// Remove from owner directory
-	ownerDirKey := keylet.OwnerDir(ownerID)
-	state.DirRemove(sb, ownerDirKey, offer.OwnerNode, offerKey, false)
-
-	// Remove from book directory
-	bookDirKey := keylet.Keylet{Type: 100, Key: offer.BookDirectory}
-	state.DirRemove(sb, bookDirKey, offer.BookNode, offerKey, false)
-
-	// Erase the offer
-	sb.Erase(keylet.Keylet{Key: offerKey})
-
-	// Decrement owner count
-	s.adjustOwnerCount(sb, ownerID, -1)
+	if removed, deleteErr := state.DeleteOffer(sb, keylet.Keylet{Key: offerKey}, offer); deleteErr == nil && removed {
+		_ = s.adjustOwnerCount(sb, ownerID, -1)
+	}
 }
 
 // isOfferOwnerAuthorized checks if the offer owner is authorized to hold currency


### PR DESCRIPTION
## Summary

- centralize regular Offer deletion across all transaction and payment cleanup paths
- remove owner, primary book, and every stored AdditionalBooks directory entry before erasing the Offer
- preserve rippled strict and best-effort failure semantics and caller-specific OwnerCount updates
- add consumed-hybrid, bulk cancellation, multi-book decoding, and partial-failure regressions

## Oracle

Verified against the clean local rippled v3.2.0 oracle at commit 3c43f4614f87965298773279ff5b85d4c56c637b.

## Verification

- just test-tx
- just test-pkg ./internal/ledger/state/...
- just test-pkg ./internal/testing/permissioneddex/...
- just build
- just vet
- go vet -tags postgres ./storage/relationaldb/postgres/
- golangci-lint run
- git diff --check

Fixes #1355