### PR TITLE
fix: record deletion metadata transitions

### DIFF
--- a/internal/testing/lending/loanbroker_delete_metadata_test.go
+++ b/internal/testing/lending/loanbroker_delete_metadata_test.go
@@ -12,6 +12,7 @@ import (
 	mpttest "github.com/LeJamon/go-xrpl/internal/testing/mpt"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/lending"
+	"github.com/LeJamon/go-xrpl/internal/tx/trustset"
 	"github.com/LeJamon/go-xrpl/internal/tx/vault"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -99,6 +100,64 @@ func TestLoanBrokerDeleteMPTMetadataOwnerCount(t *testing.T) {
 	result := env.Submit(lending.NewLoanBrokerDelete(owner.Address, strings.ToUpper(hex.EncodeToString(brokerKey.Key[:]))))
 	jtx.RequireTxSuccess(t, result)
 	assertDeletedTransition(t, result.Metadata, keylet.Account(pseudoID), "AccountRoot", "OwnerCount", uint32(0), uint32(1))
+}
+
+func TestLoanBrokerDeleteIOUIssuerOwnerCount(t *testing.T) {
+	env := newLendingEnv(t)
+	owner := jtx.NewAccount("owner")
+	env.Fund(owner)
+
+	vaultSeq := env.Seq(owner)
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{Currency: "USD", Issuer: owner.Address})
+	create.Common.Fee = reserveIncrement
+	jtx.RequireTxSuccess(t, env.Submit(create))
+
+	brokerSeq := env.Seq(owner)
+	jtx.RequireTxSuccess(t, env.Submit(lending.NewLoanBrokerSet(owner.Address, vaultID(owner, vaultSeq))))
+	brokerKey := keylet.LoanBroker(owner.AccountID(), brokerSeq)
+	pseudoID := loanBrokerPseudoID(t, env, brokerKey)
+	pseudoAddress, err := state.EncodeAccountID(pseudoID)
+	if err != nil {
+		t.Fatalf("encode broker pseudo-account: %v", err)
+	}
+	missing := tx.NewIssuedAmountFromFloat64(1, "EUR", pseudoAddress)
+	jtx.RequireTxClaimed(t, env.Submit(trustset.NewTrustSet(owner.Address, missing)), jtx.TecNO_PERMISSION)
+	limit := tx.NewIssuedAmountFromFloat64(1, "USD", pseudoAddress)
+	jtx.RequireTxSuccess(t, env.Submit(trustset.NewTrustSet(owner.Address, limit)))
+	if got := env.OwnerCount(owner); got != 5 {
+		t.Fatalf("owner count before delete = %d, want 5", got)
+	}
+
+	result := env.Submit(lending.NewLoanBrokerDelete(owner.Address, strings.ToUpper(hex.EncodeToString(brokerKey.Key[:]))))
+	jtx.RequireTxSuccess(t, result)
+	assertModifiedTransition(t, result.Metadata, keylet.Account(owner.AccountID()), "AccountRoot", "OwnerCount", uint32(2), uint32(5))
+	if got := env.OwnerCount(owner); got != 2 {
+		t.Errorf("owner count = %d, want 2", got)
+	}
+}
+
+func assertModifiedTransition(
+	t *testing.T,
+	meta *tx.Metadata,
+	key keylet.Keylet,
+	entryType, field string,
+	wantFinal, wantPrevious uint32,
+) {
+	t.Helper()
+	wantIndex := strings.ToUpper(hex.EncodeToString(key.Key[:]))
+	for _, node := range meta.AffectedNodes {
+		if node.NodeType != "ModifiedNode" || node.LedgerEntryType != entryType || node.LedgerIndex != wantIndex {
+			continue
+		}
+		if got, ok := node.FinalFields[field].(uint32); !ok || got != wantFinal {
+			t.Errorf("%s FinalFields.%s = %#v, want %d", entryType, field, node.FinalFields[field], wantFinal)
+		}
+		if got, ok := node.PreviousFields[field].(uint32); !ok || got != wantPrevious {
+			t.Errorf("%s PreviousFields.%s = %#v, want %d", entryType, field, node.PreviousFields[field], wantPrevious)
+		}
+		return
+	}
+	t.Errorf("modified %s %s not found in metadata", entryType, wantIndex)
 }
 
 func loanBrokerPseudoID(t *testing.T, env *jtx.TestEnv, brokerKey keylet.Keylet) [20]byte {

--- a/internal/testing/lending/loanbroker_delete_metadata_test.go
+++ b/internal/testing/lending/loanbroker_delete_metadata_test.go
@@ -17,9 +17,6 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
-// The metadata golden covers the complete serialized blob after applying
-// RippleStateHelpers::removeEmptyHolding's v3.2.0 update-before-delete order.
-// The state root was captured from this fixture before the metadata-only fix.
 const (
 	loanBrokerDeleteIOUMetadataSHA256 = "52AEA2C45DFCB21A917B6A8EE7F75B803DC34F98961AFFE1DABE7343CC789F7D"
 	loanBrokerDeleteIOUStateRoot      = "B042E3865CD1895BBCD90C63D30B258D28AE13C0DCC2B8D7119B605325A3B802"

--- a/internal/testing/lending/loanbroker_delete_metadata_test.go
+++ b/internal/testing/lending/loanbroker_delete_metadata_test.go
@@ -124,15 +124,15 @@ func TestLoanBrokerDeleteIOUIssuerOwnerCount(t *testing.T) {
 	jtx.RequireTxClaimed(t, env.Submit(trustset.NewTrustSet(owner.Address, missing)), jtx.TecNO_PERMISSION)
 	limit := tx.NewIssuedAmountFromFloat64(1, "USD", pseudoAddress)
 	jtx.RequireTxSuccess(t, env.Submit(trustset.NewTrustSet(owner.Address, limit)))
-	if got := env.OwnerCount(owner); got != 5 {
-		t.Fatalf("owner count before delete = %d, want 5", got)
+	if got := env.OwnerCount(owner); got != 6 {
+		t.Fatalf("owner count before delete = %d, want 6", got)
 	}
 
 	result := env.Submit(lending.NewLoanBrokerDelete(owner.Address, strings.ToUpper(hex.EncodeToString(brokerKey.Key[:]))))
 	jtx.RequireTxSuccess(t, result)
-	assertModifiedTransition(t, result.Metadata, keylet.Account(owner.AccountID()), "AccountRoot", "OwnerCount", uint32(2), uint32(5))
-	if got := env.OwnerCount(owner); got != 2 {
-		t.Errorf("owner count = %d, want 2", got)
+	assertModifiedTransition(t, result.Metadata, keylet.Account(owner.AccountID()), "AccountRoot", "OwnerCount", uint32(3), uint32(6))
+	if got := env.OwnerCount(owner); got != 3 {
+		t.Errorf("owner count = %d, want 3", got)
 	}
 }
 

--- a/internal/testing/lending/loanbroker_delete_metadata_test.go
+++ b/internal/testing/lending/loanbroker_delete_metadata_test.go
@@ -1,0 +1,147 @@
+package lending_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	mpttest "github.com/LeJamon/go-xrpl/internal/testing/mpt"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/lending"
+	"github.com/LeJamon/go-xrpl/internal/tx/vault"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// The metadata golden covers the complete serialized blob after applying
+// RippleStateHelpers::removeEmptyHolding's v3.2.0 update-before-delete order.
+// The state root was captured from this fixture before the metadata-only fix.
+const (
+	loanBrokerDeleteIOUMetadataSHA256 = "52AEA2C45DFCB21A917B6A8EE7F75B803DC34F98961AFFE1DABE7343CC789F7D"
+	loanBrokerDeleteIOUStateRoot      = "B042E3865CD1895BBCD90C63D30B258D28AE13C0DCC2B8D7119B605325A3B802"
+)
+
+func TestLoanBrokerDeleteIOUMetadataTransitions(t *testing.T) {
+	env := newLendingEnv(t)
+	issuer := jtx.NewAccount("issuer")
+	owner := jtx.NewAccount("owner")
+	env.Fund(issuer, owner)
+
+	vaultSeq := env.Seq(owner)
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{Currency: "USD", Issuer: issuer.Address})
+	create.Common.Fee = reserveIncrement
+	jtx.RequireTxSuccess(t, env.Submit(create))
+
+	brokerSeq := env.Seq(owner)
+	jtx.RequireTxSuccess(t, env.Submit(lending.NewLoanBrokerSet(owner.Address, vaultID(owner, vaultSeq))))
+	brokerKey := keylet.LoanBroker(owner.AccountID(), brokerSeq)
+	pseudoID := loanBrokerPseudoID(t, env, brokerKey)
+
+	lineKey := keylet.Line(pseudoID, issuer.ID, "USD")
+	lineData, err := env.LedgerEntry(lineKey)
+	if err != nil {
+		t.Fatalf("read broker trust line: %v", err)
+	}
+	line, err := state.ParseRippleState(lineData)
+	if err != nil {
+		t.Fatalf("parse broker trust line: %v", err)
+	}
+	if keylet.IsLowAccount(pseudoID, issuer.ID) {
+		t.Fatal("fixture must cover the high-account reserve transition")
+	}
+	reserveFlag := state.LsfHighReserve
+	if line.Flags&reserveFlag == 0 {
+		t.Fatalf("broker trust line flags = %#x, missing reserve flag %#x", line.Flags, reserveFlag)
+	}
+
+	result := env.Submit(lending.NewLoanBrokerDelete(owner.Address, strings.ToUpper(hex.EncodeToString(brokerKey.Key[:]))))
+	jtx.RequireTxSuccess(t, result)
+	assertDeletedTransition(t, result.Metadata, keylet.Account(pseudoID), "AccountRoot", "OwnerCount", uint32(0), uint32(1))
+	assertDeletedTransition(t, result.Metadata, lineKey, "RippleState", "Flags", line.Flags&^reserveFlag, line.Flags)
+
+	blob, err := tx.SerializeMetadata(result.Metadata)
+	if err != nil {
+		t.Fatalf("serialize metadata: %v", err)
+	}
+	root, err := env.Ledger().StateMapHash()
+	if err != nil {
+		t.Fatalf("state map hash: %v", err)
+	}
+	metadataHash := sha256.Sum256(blob)
+	if got := strings.ToUpper(hex.EncodeToString(metadataHash[:])); got != loanBrokerDeleteIOUMetadataSHA256 {
+		t.Errorf("full metadata blob SHA-256 = %s, want %s", got, loanBrokerDeleteIOUMetadataSHA256)
+	}
+	if got := strings.ToUpper(hex.EncodeToString(root[:])); got != loanBrokerDeleteIOUStateRoot {
+		t.Errorf("state root = %s, want %s", got, loanBrokerDeleteIOUStateRoot)
+	}
+}
+
+func TestLoanBrokerDeleteMPTMetadataOwnerCount(t *testing.T) {
+	env := newLendingEnv(t)
+	issuer := jtx.NewAccount("issuer")
+	owner := jtx.NewAccount("owner")
+	token := mpttest.NewMPTTester(t, env, issuer, mpttest.MPTInit{Holders: []*jtx.Account{owner}})
+	token.Create(mpttest.CreateOpts{Flags: mpttest.TfMPTCanTransfer})
+
+	vaultSeq := env.Seq(owner)
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{MPTIssuanceID: token.IssuanceID()})
+	create.Common.Fee = reserveIncrement
+	jtx.RequireTxSuccess(t, env.Submit(create))
+
+	brokerSeq := env.Seq(owner)
+	jtx.RequireTxSuccess(t, env.Submit(lending.NewLoanBrokerSet(owner.Address, vaultID(owner, vaultSeq))))
+	brokerKey := keylet.LoanBroker(owner.AccountID(), brokerSeq)
+	pseudoID := loanBrokerPseudoID(t, env, brokerKey)
+
+	result := env.Submit(lending.NewLoanBrokerDelete(owner.Address, strings.ToUpper(hex.EncodeToString(brokerKey.Key[:]))))
+	jtx.RequireTxSuccess(t, result)
+	assertDeletedTransition(t, result.Metadata, keylet.Account(pseudoID), "AccountRoot", "OwnerCount", uint32(0), uint32(1))
+}
+
+func loanBrokerPseudoID(t *testing.T, env *jtx.TestEnv, brokerKey keylet.Keylet) [20]byte {
+	t.Helper()
+	brokerData, err := env.LedgerEntry(brokerKey)
+	if err != nil {
+		t.Fatalf("read LoanBroker: %v", err)
+	}
+	brokerFields, err := binarycodec.DecodeBytes(brokerData)
+	if err != nil {
+		t.Fatalf("decode LoanBroker: %v", err)
+	}
+	pseudoAddress, ok := brokerFields["Account"].(string)
+	if !ok {
+		t.Fatalf("LoanBroker Account = %#v, want address", brokerFields["Account"])
+	}
+	pseudoID, err := state.DecodeAccountID(pseudoAddress)
+	if err != nil {
+		t.Fatalf("decode broker pseudo-account: %v", err)
+	}
+	return pseudoID
+}
+
+func assertDeletedTransition(
+	t *testing.T,
+	meta *tx.Metadata,
+	key keylet.Keylet,
+	entryType, field string,
+	wantFinal, wantPrevious uint32,
+) {
+	t.Helper()
+	wantIndex := strings.ToUpper(hex.EncodeToString(key.Key[:]))
+	for _, node := range meta.AffectedNodes {
+		if node.NodeType != "DeletedNode" || node.LedgerEntryType != entryType || node.LedgerIndex != wantIndex {
+			continue
+		}
+		if got, ok := node.FinalFields[field].(uint32); !ok || got != wantFinal {
+			t.Errorf("%s FinalFields.%s = %#v, want %d", entryType, field, node.FinalFields[field], wantFinal)
+		}
+		if got, ok := node.PreviousFields[field].(uint32); !ok || got != wantPrevious {
+			t.Errorf("%s PreviousFields.%s = %#v, want %d", entryType, field, node.PreviousFields[field], wantPrevious)
+		}
+		return
+	}
+	t.Errorf("deleted %s %s not found in metadata", entryType, wantIndex)
+}

--- a/internal/testing/vault/vault_delete_metadata_test.go
+++ b/internal/testing/vault/vault_delete_metadata_test.go
@@ -98,13 +98,13 @@ func TestVaultDeleteIOUIssuerOwnerCount(t *testing.T) {
 	jtx.RequireTxClaimed(t, env.Submit(trustset.NewTrustSet(owner.Address, missing)), jtx.TecNO_PERMISSION)
 	limit := tx.NewIssuedAmountFromFloat64(1, "USD", pseudoAddress)
 	jtx.RequireTxSuccess(t, env.Submit(trustset.NewTrustSet(owner.Address, limit)))
-	if got := env.OwnerCount(owner); got != 3 {
-		t.Fatalf("owner count before delete = %d, want 3", got)
+	if got := env.OwnerCount(owner); got != 4 {
+		t.Fatalf("owner count before delete = %d, want 4", got)
 	}
 
 	result := env.Submit(vault.NewVaultDelete(owner.Address, strings.ToUpper(hex.EncodeToString(vaultKey.Key[:]))))
 	jtx.RequireTxSuccess(t, result)
-	assertVaultModifiedTransition(t, result.Metadata, keylet.Account(owner.AccountID()), "AccountRoot", "OwnerCount", uint32(0), uint32(3))
+	assertVaultModifiedTransition(t, result.Metadata, keylet.Account(owner.AccountID()), "AccountRoot", "OwnerCount", uint32(0), uint32(4))
 	if got := env.OwnerCount(owner); got != 0 {
 		t.Errorf("owner count = %d, want 0", got)
 	}

--- a/internal/testing/vault/vault_delete_metadata_test.go
+++ b/internal/testing/vault/vault_delete_metadata_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/trustset"
 	"github.com/LeJamon/go-xrpl/internal/tx/vault"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -73,6 +74,64 @@ func TestVaultDeleteIOUMetadataTransitions(t *testing.T) {
 	if got := strings.ToUpper(hex.EncodeToString(root[:])); got != vaultDeleteIOUStateRoot {
 		t.Errorf("state root = %s, want %s", got, vaultDeleteIOUStateRoot)
 	}
+}
+
+func TestVaultDeleteIOUIssuerOwnerCount(t *testing.T) {
+	env := newVaultEnv(t)
+	owner := jtx.NewAccount("owner")
+	env.Fund(owner)
+
+	vaultSeq := env.Seq(owner)
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{Currency: "USD", Issuer: owner.Address})
+	create.Common.Fee = createFee
+	jtx.RequireTxSuccess(t, env.Submit(create))
+	vaultKey := keylet.Vault(owner.AccountID(), vaultSeq)
+	info, err := vault.ReadVaultInfo(env.Ledger(), vaultKey)
+	if err != nil || info == nil {
+		t.Fatalf("read Vault: %v", err)
+	}
+	pseudoAddress, err := state.EncodeAccountID(info.Account)
+	if err != nil {
+		t.Fatalf("encode vault pseudo-account: %v", err)
+	}
+	missing := tx.NewIssuedAmountFromFloat64(1, "EUR", pseudoAddress)
+	jtx.RequireTxClaimed(t, env.Submit(trustset.NewTrustSet(owner.Address, missing)), jtx.TecNO_PERMISSION)
+	limit := tx.NewIssuedAmountFromFloat64(1, "USD", pseudoAddress)
+	jtx.RequireTxSuccess(t, env.Submit(trustset.NewTrustSet(owner.Address, limit)))
+	if got := env.OwnerCount(owner); got != 3 {
+		t.Fatalf("owner count before delete = %d, want 3", got)
+	}
+
+	result := env.Submit(vault.NewVaultDelete(owner.Address, strings.ToUpper(hex.EncodeToString(vaultKey.Key[:]))))
+	jtx.RequireTxSuccess(t, result)
+	assertVaultModifiedTransition(t, result.Metadata, keylet.Account(owner.AccountID()), "AccountRoot", "OwnerCount", uint32(0), uint32(3))
+	if got := env.OwnerCount(owner); got != 0 {
+		t.Errorf("owner count = %d, want 0", got)
+	}
+}
+
+func assertVaultModifiedTransition(
+	t *testing.T,
+	meta *tx.Metadata,
+	key keylet.Keylet,
+	entryType, field string,
+	wantFinal, wantPrevious uint32,
+) {
+	t.Helper()
+	wantIndex := strings.ToUpper(hex.EncodeToString(key.Key[:]))
+	for _, node := range meta.AffectedNodes {
+		if node.NodeType != "ModifiedNode" || node.LedgerEntryType != entryType || node.LedgerIndex != wantIndex {
+			continue
+		}
+		if got, ok := node.FinalFields[field].(uint32); !ok || got != wantFinal {
+			t.Errorf("%s FinalFields.%s = %#v, want %d", entryType, field, node.FinalFields[field], wantFinal)
+		}
+		if got, ok := node.PreviousFields[field].(uint32); !ok || got != wantPrevious {
+			t.Errorf("%s PreviousFields.%s = %#v, want %d", entryType, field, node.PreviousFields[field], wantPrevious)
+		}
+		return
+	}
+	t.Errorf("modified %s %s not found in metadata", entryType, wantIndex)
 }
 
 func assertVaultDeletedTransition(

--- a/internal/testing/vault/vault_delete_metadata_test.go
+++ b/internal/testing/vault/vault_delete_metadata_test.go
@@ -14,9 +14,6 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
-// The metadata golden covers the complete serialized blob after applying
-// RippleStateHelpers::removeEmptyHolding's v3.2.0 update-before-delete order.
-// The state root was captured from this fixture before the metadata-only fix.
 const (
 	vaultDeleteIOUMetadataSHA256 = "1BACA50A02B428E51CEE967477384BF6124C28214966C950A9CAF26224908E0C"
 	vaultDeleteIOUStateRoot      = "ABA2266EB9DC0FF1ED790C5A81CB5C21DDA3317EAA1C2E47AE57FE6A27DF1089"

--- a/internal/testing/vault/vault_delete_metadata_test.go
+++ b/internal/testing/vault/vault_delete_metadata_test.go
@@ -1,0 +1,100 @@
+package vault_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/vault"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+// The metadata golden covers the complete serialized blob after applying
+// RippleStateHelpers::removeEmptyHolding's v3.2.0 update-before-delete order.
+// The state root was captured from this fixture before the metadata-only fix.
+const (
+	vaultDeleteIOUMetadataSHA256 = "1BACA50A02B428E51CEE967477384BF6124C28214966C950A9CAF26224908E0C"
+	vaultDeleteIOUStateRoot      = "ABA2266EB9DC0FF1ED790C5A81CB5C21DDA3317EAA1C2E47AE57FE6A27DF1089"
+)
+
+func TestVaultDeleteIOUMetadataTransitions(t *testing.T) {
+	env := newVaultEnv(t)
+	issuer := jtx.NewAccount("issuer")
+	owner := jtx.NewAccount("owner")
+	env.Fund(issuer, owner)
+
+	vaultSeq := env.Seq(owner)
+	create := vault.NewVaultCreate(owner.Address, tx.Asset{Currency: "USD", Issuer: issuer.Address})
+	create.Common.Fee = createFee
+	jtx.RequireTxSuccess(t, env.Submit(create))
+	vaultKey := keylet.Vault(owner.AccountID(), vaultSeq)
+	info, err := vault.ReadVaultInfo(env.Ledger(), vaultKey)
+	if err != nil || info == nil {
+		t.Fatalf("read Vault: %v", err)
+	}
+
+	lineKey := keylet.Line(info.Account, issuer.ID, "USD")
+	lineData, err := env.LedgerEntry(lineKey)
+	if err != nil {
+		t.Fatalf("read vault trust line: %v", err)
+	}
+	line, err := state.ParseRippleState(lineData)
+	if err != nil {
+		t.Fatalf("parse vault trust line: %v", err)
+	}
+	if !keylet.IsLowAccount(info.Account, issuer.ID) {
+		t.Fatal("fixture must cover the low-account reserve transition")
+	}
+	reserveFlag := state.LsfLowReserve
+	if line.Flags&reserveFlag == 0 {
+		t.Fatalf("vault trust line flags = %#x, missing reserve flag %#x", line.Flags, reserveFlag)
+	}
+
+	result := env.Submit(vault.NewVaultDelete(owner.Address, strings.ToUpper(hex.EncodeToString(vaultKey.Key[:]))))
+	jtx.RequireTxSuccess(t, result)
+	assertVaultDeletedTransition(t, result.Metadata, lineKey, "RippleState", "Flags", line.Flags&^reserveFlag, line.Flags)
+
+	blob, err := tx.SerializeMetadata(result.Metadata)
+	if err != nil {
+		t.Fatalf("serialize metadata: %v", err)
+	}
+	root, err := env.Ledger().StateMapHash()
+	if err != nil {
+		t.Fatalf("state map hash: %v", err)
+	}
+	metadataHash := sha256.Sum256(blob)
+	if got := strings.ToUpper(hex.EncodeToString(metadataHash[:])); got != vaultDeleteIOUMetadataSHA256 {
+		t.Errorf("full metadata blob SHA-256 = %s, want %s", got, vaultDeleteIOUMetadataSHA256)
+	}
+	if got := strings.ToUpper(hex.EncodeToString(root[:])); got != vaultDeleteIOUStateRoot {
+		t.Errorf("state root = %s, want %s", got, vaultDeleteIOUStateRoot)
+	}
+}
+
+func assertVaultDeletedTransition(
+	t *testing.T,
+	meta *tx.Metadata,
+	key keylet.Keylet,
+	entryType, field string,
+	wantFinal, wantPrevious uint32,
+) {
+	t.Helper()
+	wantIndex := strings.ToUpper(hex.EncodeToString(key.Key[:]))
+	for _, node := range meta.AffectedNodes {
+		if node.NodeType != "DeletedNode" || node.LedgerEntryType != entryType || node.LedgerIndex != wantIndex {
+			continue
+		}
+		if got, ok := node.FinalFields[field].(uint32); !ok || got != wantFinal {
+			t.Errorf("%s FinalFields.%s = %#v, want %d", entryType, field, node.FinalFields[field], wantFinal)
+		}
+		if got, ok := node.PreviousFields[field].(uint32); !ok || got != wantPrevious {
+			t.Errorf("%s PreviousFields.%s = %#v, want %d", entryType, field, node.PreviousFields[field], wantPrevious)
+		}
+		return
+	}
+	t.Errorf("deleted %s %s not found in metadata", entryType, wantIndex)
+}

--- a/internal/tx/lending/loan_broker_apply.go
+++ b/internal/tx/lending/loan_broker_apply.go
@@ -269,9 +269,19 @@ func (l *LoanBrokerDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	}
 	pseudo, perr := tx.ReadAccountRoot(ctx.View, b.Account)
 	if perr != nil || pseudo == nil {
+		if assetDelta != 0 {
+			return ter.TecINTERNAL
+		}
 		return ter.TefBAD_LEDGER
 	}
 	pseudo.OwnerCount = uint32(int32(pseudo.OwnerCount) + assetDelta)
+	pseudoData, serr := state.SerializeAccountRoot(pseudo)
+	if serr != nil {
+		return ter.TefINTERNAL
+	}
+	if uerr := ctx.View.Update(keylet.Account(b.Account), pseudoData); uerr != nil {
+		return ter.TefINTERNAL
+	}
 	if pseudo.Balance != 0 || pseudo.OwnerCount != 0 {
 		return ter.TecHAS_OBLIGATIONS
 	}

--- a/internal/tx/lending/loan_broker_apply.go
+++ b/internal/tx/lending/loan_broker_apply.go
@@ -267,14 +267,10 @@ func (l *LoanBrokerDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 	if res != ter.TesSUCCESS {
 		return res
 	}
-	pseudo, perr := tx.ReadAccountRoot(ctx.View, b.Account)
-	if perr != nil || pseudo == nil {
-		if assetDelta != 0 {
-			return ter.TecINTERNAL
-		}
-		return ter.TefBAD_LEDGER
+	pseudo, res := vault.ApplyAssetHoldingOwnerCount(ctx.View, b.Account, assetDelta)
+	if res != ter.TesSUCCESS {
+		return res
 	}
-	pseudo.OwnerCount = uint32(int32(pseudo.OwnerCount) + assetDelta)
 	pseudoData, serr := state.SerializeAccountRoot(pseudo)
 	if serr != nil {
 		return ter.TefINTERNAL

--- a/internal/tx/mptutil/mpt.go
+++ b/internal/tx/mptutil/mpt.go
@@ -812,8 +812,11 @@ func RemoveHolding(view state.LedgerView, id [24]byte, holder [20]byte, adjustOw
 		return ter.TecHAS_OBLIGATIONS
 	}
 	removed, err := state.DirRemove(view, keylet.OwnerDir(holder), token.OwnerNode, tokenKey.Key, false)
-	if err != nil || !removed.Success {
+	if err != nil {
 		return ter.TefINTERNAL
+	}
+	if !removed.Success {
+		return ter.TecINTERNAL
 	}
 	if err := view.Erase(tokenKey); err != nil {
 		return ter.TefINTERNAL

--- a/internal/tx/mptutil/mpt_test.go
+++ b/internal/tx/mptutil/mpt_test.go
@@ -244,6 +244,20 @@ func TestEnsureAndRemoveHolding(t *testing.T) {
 	require.Equal(t, [][3]uint32{{2, 3}, {3, 2}}, view.adjustments)
 }
 
+func TestRemoveHoldingOwnerDirectoryFailureTER(t *testing.T) {
+	view := newMPTTestView()
+	var issuer, holder [20]byte
+	issuer[19] = 1
+	holder[19] = 2
+	id := keylet.MakeMPTID(1, issuer)
+	putTestAccount(t, view, holder, 0, [32]byte{})
+	putTestHolding(t, view, id, holder, 0)
+
+	require.Equal(t, ter.TecINTERNAL, RemoveHolding(view, id, holder, false))
+	view.readErrors[keylet.OwnerDir(holder).Key] = errors.New("storage read failed")
+	require.Equal(t, ter.TefINTERNAL, RemoveHolding(view, id, holder, false))
+}
+
 func TestCreditOverflowStillCapsSingleIssueAtMaximum(t *testing.T) {
 	view := newMPTTestView()
 	var id [24]byte

--- a/internal/tx/trustset/trustset.go
+++ b/internal/tx/trustset/trustset.go
@@ -336,6 +336,10 @@ func (t *TrustSet) Apply(ctx *tx.ApplyContext) ter.Result {
 				}
 				// LP token trust line to non-empty AMM — allow creation
 			}
+		} else if issuerAccount.VaultID != [32]byte{} || issuerAccount.LoanBrokerID != [32]byte{} {
+			if !trustLineExists {
+				return ter.TecNO_PERMISSION
+			}
 		} else {
 			return ter.TecPSEUDO_ACCOUNT
 		}

--- a/internal/tx/vault/apply_helpers.go
+++ b/internal/tx/vault/apply_helpers.go
@@ -843,33 +843,42 @@ func removeVaultAssetHolding(ctx *tx.ApplyContext, accountID [20]byte, asset tx.
 	if err != nil {
 		return 0, ter.TefINTERNAL
 	}
-	if accountID == issuerID {
-		return 0, ter.TesSUCCESS
-	}
+	accountIsIssuer := accountID == issuerID
 	lineKey := keylet.Line(accountID, issuerID, asset.Currency)
 	data, rerr := ctx.View.Read(lineKey)
 	if rerr != nil {
 		return 0, ter.TefINTERNAL
 	}
 	if data == nil {
+		if accountIsIssuer {
+			return 0, ter.TesSUCCESS
+		}
 		return 0, ter.TecOBJECT_NOT_FOUND
 	}
 	rs, perr := state.ParseRippleState(data)
 	if perr != nil {
 		return 0, ter.TefINTERNAL
 	}
-	if rs.Balance.Signum() != 0 {
+	if !accountIsIssuer && rs.Balance.Signum() != 0 {
 		return 0, ter.TecHAS_OBLIGATIONS
 	}
 
-	lowID, highID := accountID, issuerID
-	if bytes.Compare(accountID[:], issuerID[:]) > 0 {
-		lowID, highID = issuerID, accountID
+	lowID, err := state.DecodeAccountID(rs.LowLimit.Issuer)
+	if err != nil {
+		return 0, ter.TefINTERNAL
+	}
+	highID, err := state.DecodeAccountID(rs.HighLimit.Issuer)
+	if err != nil {
+		return 0, ter.TefINTERNAL
 	}
 	delta := int32(0)
 	adjust := func(owner [20]byte) ter.Result {
 		if owner == accountID {
 			delta--
+			return ter.TesSUCCESS
+		}
+		if owner == ctx.AccountID {
+			ctx.Account.OwnerCount = tx.ConfineOwnerCount(ctx.Account.OwnerCount, -1)
 			return ter.TesSUCCESS
 		}
 		exists, err := ctx.View.Exists(keylet.Account(owner))
@@ -907,6 +916,21 @@ func removeVaultAssetHolding(ctx *tx.ApplyContext, accountID [20]byte, asset tx.
 		return 0, result
 	}
 	return delta, ter.TesSUCCESS
+}
+
+func applyAssetHoldingOwnerCount(view tx.LedgerView, accountID [20]byte, delta int32) (*state.AccountRoot, ter.Result) {
+	account, err := tx.ReadAccountRoot(view, accountID)
+	if err != nil {
+		return nil, ter.TefINTERNAL
+	}
+	if account == nil {
+		if delta != 0 {
+			return nil, ter.TecINTERNAL
+		}
+		return nil, ter.TefBAD_LEDGER
+	}
+	account.OwnerCount = tx.ConfineOwnerCount(account.OwnerCount, int(delta))
+	return account, ter.TesSUCCESS
 }
 
 // removeEmptyShareMPToken deletes a holder's share MPToken when its balance is

--- a/internal/tx/vault/apply_helpers.go
+++ b/internal/tx/vault/apply_helpers.go
@@ -872,6 +872,13 @@ func removeVaultAssetHolding(ctx *tx.ApplyContext, accountID [20]byte, asset tx.
 			delta--
 			return ter.TesSUCCESS
 		}
+		exists, err := ctx.View.Exists(keylet.Account(owner))
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		if !exists {
+			return ter.TecINTERNAL
+		}
 		if err := tx.AdjustOwnerCount(ctx.View, owner, -1); err != nil {
 			return ter.TefINTERNAL
 		}
@@ -881,11 +888,20 @@ func removeVaultAssetHolding(ctx *tx.ApplyContext, accountID [20]byte, asset tx.
 		if result := adjust(lowID); result != ter.TesSUCCESS {
 			return 0, result
 		}
+		rs.Flags &^= state.LsfLowReserve
 	}
 	if rs.Flags&state.LsfHighReserve != 0 {
 		if result := adjust(highID); result != ter.TesSUCCESS {
 			return 0, result
 		}
+		rs.Flags &^= state.LsfHighReserve
+	}
+	updated, serr := state.SerializeRippleState(rs)
+	if serr != nil {
+		return 0, ter.TefINTERNAL
+	}
+	if uerr := ctx.View.Update(lineKey, updated); uerr != nil {
+		return 0, ter.TefINTERNAL
 	}
 	if result := tx.TrustDelete(ctx.View, lineKey, lowID, highID, rs.LowNode, rs.HighNode); result != ter.TesSUCCESS {
 		return 0, result

--- a/internal/tx/vault/exports.go
+++ b/internal/tx/vault/exports.go
@@ -121,6 +121,12 @@ func RemoveAssetHolding(ctx *tx.ApplyContext, accountID [20]byte, asset tx.Asset
 	return removeVaultAssetHolding(ctx, accountID, asset)
 }
 
+// ApplyAssetHoldingOwnerCount loads accountID and applies the owner-count delta
+// returned by RemoveAssetHolding.
+func ApplyAssetHoldingOwnerCount(view tx.LedgerView, accountID [20]byte, delta int32) (*state.AccountRoot, ter.Result) {
+	return applyAssetHoldingOwnerCount(view, accountID, delta)
+}
+
 // CanWithdraw validates delivery of amount from → to (destination exists,
 // dest-tag / deposit-auth, IOU trust-limit).
 func CanWithdraw(view tx.LedgerView, from, to [20]byte, amount tx.Amount, hasDestTag bool, numberContext state.NumberContext) ter.Result {

--- a/internal/tx/vault/shared_helpers_test.go
+++ b/internal/tx/vault/shared_helpers_test.go
@@ -257,3 +257,81 @@ func TestRemoveVaultAssetMPTHoldingHonorsLockedAmountAmendment(t *testing.T) {
 		require.True(t, exists)
 	})
 }
+
+func TestRemoveVaultAssetHoldingDeletesLegacyIssuerLine(t *testing.T) {
+	rules := amendment.NewRulesBuilder().Enable(amendment.FeatureSingleAssetVault).Build()
+	view := newSharedHelperView(rules)
+	var low, high, source [20]byte
+	low[19] = 0x10
+	high[19] = 0x20
+	source[19] = 0x30
+	ctx := buildArmsCtx(t, view.mptArmsView, source, rules)
+	ctx.View = view
+
+	insertAccount := func(account [20]byte) {
+		raw, err := state.SerializeAccountRoot(&state.AccountRoot{
+			Account:    state.EncodeAccountIDSafe(account),
+			Balance:    100_000_000,
+			OwnerCount: 1,
+		})
+		require.NoError(t, err)
+		require.NoError(t, view.Insert(keylet.Account(account), raw))
+	}
+	insertAccount(low)
+	insertAccount(high)
+
+	lineKey := keylet.Line(low, low, "USD")
+	lowDir, err := state.DirInsert(view, keylet.OwnerDir(low), lineKey.Key, false, nil)
+	require.NoError(t, err)
+	highDir, err := state.DirInsert(view, keylet.OwnerDir(high), lineKey.Key, false, nil)
+	require.NoError(t, err)
+	lineRaw, err := state.SerializeRippleState(&state.RippleState{
+		Balance:   state.NewIssuedAmountFromValue(1, 0, "USD", state.AccountOneAddress),
+		LowLimit:  state.NewIssuedAmountFromValue(0, state.MinExponent, "USD", state.EncodeAccountIDSafe(low)),
+		HighLimit: state.NewIssuedAmountFromValue(0, state.MinExponent, "USD", state.EncodeAccountIDSafe(high)),
+		Flags:     state.LsfLowReserve | state.LsfHighReserve,
+		LowNode:   lowDir.Page,
+		HighNode:  highDir.Page,
+	})
+	require.NoError(t, err)
+	require.NoError(t, view.Insert(lineKey, lineRaw))
+
+	delta, result := removeVaultAssetHolding(ctx, low, tx.Asset{Currency: "USD", Issuer: state.EncodeAccountIDSafe(low)})
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Equal(t, int32(-1), delta)
+	exists, err := view.Exists(lineKey)
+	require.NoError(t, err)
+	require.False(t, exists)
+	highRaw, err := view.Read(keylet.Account(high))
+	require.NoError(t, err)
+	highAccount, err := state.ParseAccountRoot(highRaw)
+	require.NoError(t, err)
+	require.Zero(t, highAccount.OwnerCount)
+}
+
+func TestApplyAssetHoldingOwnerCountResultClassification(t *testing.T) {
+	view := newMPTArmsView()
+	var accountID [20]byte
+	accountID[19] = 1
+
+	account, result := applyAssetHoldingOwnerCount(view, accountID, -1)
+	require.Nil(t, account)
+	require.Equal(t, ter.TecINTERNAL, result)
+	account, result = applyAssetHoldingOwnerCount(view, accountID, 0)
+	require.Nil(t, account)
+	require.Equal(t, ter.TefBAD_LEDGER, result)
+
+	require.NoError(t, view.Insert(keylet.Account(accountID), []byte{1}))
+	account, result = applyAssetHoldingOwnerCount(view, accountID, -1)
+	require.Nil(t, account)
+	require.Equal(t, ter.TefINTERNAL, result)
+
+	raw, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account: state.EncodeAccountIDSafe(accountID),
+	})
+	require.NoError(t, err)
+	require.NoError(t, view.Update(keylet.Account(accountID), raw))
+	account, result = applyAssetHoldingOwnerCount(view, accountID, -1)
+	require.Equal(t, ter.TesSUCCESS, result)
+	require.Zero(t, account.OwnerCount)
+}

--- a/internal/tx/vault/vault_delete.go
+++ b/internal/tx/vault/vault_delete.go
@@ -137,19 +137,9 @@ func (v *VaultDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 		return res
 	}
 
-	pseudo, perr := tx.ReadAccountRoot(ctx.View, vd.Account)
-	if perr != nil || pseudo == nil {
-		return ter.TefBAD_LEDGER
-	}
-	if assetDelta < 0 {
-		decrement := uint32(-assetDelta)
-		if pseudo.OwnerCount >= decrement {
-			pseudo.OwnerCount -= decrement
-		} else {
-			pseudo.OwnerCount = 0
-		}
-	} else {
-		pseudo.OwnerCount += uint32(assetDelta)
+	pseudo, res := applyAssetHoldingOwnerCount(ctx.View, vd.Account, assetDelta)
+	if res != ter.TesSUCCESS {
+		return res
 	}
 
 	ownerShareKey := keylet.MPTokenByID(vd.ShareMPTID, ctx.AccountID)
@@ -194,7 +184,7 @@ func (v *VaultDelete) Apply(ctx *tx.ApplyContext) ter.Result {
 		return ter.TecHAS_OBLIGATIONS
 	}
 
-	pseudo, perr = tx.ReadAccountRoot(ctx.View, vd.Account)
+	pseudo, perr := tx.ReadAccountRoot(ctx.View, vd.Account)
 	if perr != nil || pseudo == nil || pseudo.VaultID != vaultKey.Key {
 		return ter.TefBAD_LEDGER
 	}


### PR DESCRIPTION
## Summary
- persist IOU reserve-flag and LoanBroker pseudo-account owner-count transitions before deletion so metadata matches rippled v3.2.0
- add full serialized-metadata, state-root, low/high reserve-side, and MPT owner-count regressions

## Test plan
- [x] `go test -race ./internal/testing/lending ./internal/testing/vault -run 'Test(LoanBrokerDelete|VaultDelete)' -count=1`
- [x] `go test ./internal/testing/lending ./internal/testing/vault ./internal/tx/lending ./internal/tx/vault -count=1`
- [x] `just test-tx`
- [x] `just build`
- [x] `just vet`
- [x] `go vet -tags postgres ./storage/relationaldb/postgres/`
- [x] `golangci-lint run`
- [x] `golangci-lint run --allow-parallel-runners --config .golangci-warnings.yml`
- [x] `just conformance` (879/879 in-scope)

Fixes #1359
