### PR TITLE
fix: enforce typed keylet reads

### DIFF
--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/ledger/negativeunl"
 	"github.com/LeJamon/go-xrpl/internal/ledger/skiplist"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
@@ -442,8 +443,11 @@ func (l *Ledger) ReadContext(ctx context.Context, k keylet.Keylet) ([]byte, erro
 	if !found {
 		return nil, nil
 	}
-
-	return item.Data(), nil
+	data := item.Data()
+	if !state.MatchesKeyletType(k, data) {
+		return nil, nil
+	}
+	return data, nil
 }
 
 // SkipListHashes returns the decoded rolling 256-entry LedgerHashes skip-list,

--- a/internal/ledger/ledger_mutation_test.go
+++ b/internal/ledger/ledger_mutation_test.go
@@ -2,12 +2,14 @@ package ledger
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"strings"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
 
 // mutAcct builds a deterministic account keylet from a single seed byte by
@@ -29,7 +31,50 @@ func mutData(tag byte) []byte {
 	for i := range d {
 		d[i] = tag
 	}
+	d[0] = 0x11
+	binary.BigEndian.PutUint16(d[1:3], uint16(entry.TypeAccountRoot))
 	return d
+}
+
+func TestLedger_ReadChecksKeyletType(t *testing.T) {
+	l := newOpenChild(t)
+	accountKey := mutAcct(0x01)
+	data := mutData(0x11)
+	if err := l.Insert(accountKey, data); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	wrongType := keylet.Keylet{Type: entry.TypePermissionedDomain, Key: accountKey.Key}
+	got, err := l.Read(wrongType)
+	if err != nil {
+		t.Fatalf("Read wrong type: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Read wrong type returned %x", got)
+	}
+	exists, err := l.Exists(wrongType)
+	if err != nil {
+		t.Fatalf("Exists wrong type: %v", err)
+	}
+	if !exists {
+		t.Fatal("Exists did not report the occupied base key")
+	}
+
+	anyType := keylet.Keylet{Key: accountKey.Key}
+	got, err = l.Read(anyType)
+	if err != nil {
+		t.Fatalf("Read any type: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("Read any type: got %x want %x", got, data)
+	}
+	exists, err = l.Exists(anyType)
+	if err != nil {
+		t.Fatalf("Exists any type: %v", err)
+	}
+	if !exists {
+		t.Fatal("Exists did not report an ltANY entry")
+	}
 }
 
 // TestLedger_MutateHappyAndErrorPaths exercises Insert/Update/Erase on an

--- a/internal/ledger/service/account_query_more_test.go
+++ b/internal/ledger/service/account_query_more_test.go
@@ -341,7 +341,11 @@ func TestGetDepositAuthorized_DepositAuthFlag(t *testing.T) {
 
 	t.Run("direct preauth → authorized", func(t *testing.T) {
 		preauthKey := keylet.DepositPreauth(dstID, srcID)
-		if err := svc.openLedger.Insert(preauthKey, make([]byte, 16)); err != nil {
+		preauthData, err := state.SerializeDepositPreauth(dstID, srcID, 0)
+		if err != nil {
+			t.Fatalf("serialize deposit preauth: %v", err)
+		}
+		if err := svc.openLedger.Insert(preauthKey, preauthData); err != nil {
 			t.Fatalf("insert deposit preauth: %v", err)
 		}
 		res, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current", nil)
@@ -358,7 +362,7 @@ func TestGetDepositAuthorized_Credentials(t *testing.T) {
 	svc := newOfferTestService(t)
 	srcAddr, srcID := addressFromBytes(t, 0x10)
 	dstAddr, dstID := addressFromBytes(t, 0x20)
-	_, issuerID := addressFromBytes(t, 0x40)
+	issuerAddr, issuerID := addressFromBytes(t, 0x40)
 	insertAccountRoot(t, svc, srcAddr, 1_000_000_000, 0)
 	insertAccountRootWithFlags(t, svc, dstAddr, 1_000_000_000, 0, state.LsfDepositAuth)
 
@@ -460,7 +464,13 @@ func TestGetDepositAuthorized_Credentials(t *testing.T) {
 		key := insertCredentialEntry(t, svc, srcID, issuerID, credType, true, nil)
 		pairs := []keylet.CredentialPair{{Issuer: issuerID, CredentialType: credType}}
 		credPreauthKey := keylet.DepositPreauthCredentials(dstID, pairs)
-		if err := svc.openLedger.Insert(credPreauthKey, make([]byte, 16)); err != nil {
+		credPreauthData, err := state.SerializeDepositPreauthCredentials(dstID, []state.DepositPreauthCredential{
+			{Issuer: issuerAddr, CredentialType: hex.EncodeToString(credType)},
+		}, 0)
+		if err != nil {
+			t.Fatalf("serialize credential preauth: %v", err)
+		}
+		if err := svc.openLedger.Insert(credPreauthKey, credPreauthData); err != nil {
 			t.Fatalf("insert credential preauth: %v", err)
 		}
 		res, err := svc.GetDepositAuthorized(context.Background(), srcAddr, dstAddr, "current",

--- a/internal/ledger/service/snapshot_view.go
+++ b/internal/ledger/service/snapshot_view.go
@@ -4,6 +4,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
@@ -34,7 +35,11 @@ func (v *snapshotView) Read(k keylet.Keylet) ([]byte, error) {
 	if !found {
 		return nil, nil
 	}
-	return item.Data(), nil
+	data := item.Data()
+	if !state.MatchesKeyletType(k, data) {
+		return nil, nil
+	}
+	return data, nil
 }
 
 func (v *snapshotView) Exists(k keylet.Keylet) (bool, error) {

--- a/internal/ledger/service/snapshot_view_atomic_test.go
+++ b/internal/ledger/service/snapshot_view_atomic_test.go
@@ -7,8 +7,33 @@ import (
 
 	ledgercore "github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
+
+func TestSnapshotViewChecksKeyletType(t *testing.T) {
+	stateMap := shamap.New(shamap.TypeState)
+	key := [32]byte{1}
+	data := bytes.Repeat([]byte{1}, 12)
+	data[0] = 0x11
+	data[1] = byte(entry.TypeAccountRoot >> 8)
+	data[2] = byte(entry.TypeAccountRoot)
+	if err := stateMap.Put(key, data); err != nil {
+		t.Fatalf("seed state map: %v", err)
+	}
+	view := newSnapshotView(stateMap, nil)
+	wrongType := keylet.Keylet{Type: entry.TypePermissionedDomain, Key: key}
+
+	if got, err := view.Read(wrongType); err != nil || got != nil {
+		t.Fatalf("Read wrong-type entry = %x, %v", got, err)
+	}
+	if exists, err := view.Exists(wrongType); err != nil || !exists {
+		t.Fatalf("Exists wrong-type entry = %v, %v", exists, err)
+	}
+	if got, err := view.Read(keylet.Keylet{Key: key}); err != nil || !bytes.Equal(got, data) {
+		t.Fatalf("Read ltANY entry = %x, %v", got, err)
+	}
+}
 
 func TestSnapshotViewApplyAtomically(t *testing.T) {
 	stateMap := shamap.New(shamap.TypeState)

--- a/internal/ledger/state/sle.go
+++ b/internal/ledger/state/sle.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
 
 // IsDefaultValue reports whether a decoded field value should be omitted
@@ -95,6 +96,15 @@ func GetLedgerEntryType(data []byte) (uint16, error) {
 }
 
 // MatchesKeyletType reports whether data satisfies a keylet's type constraint.
+// TypeAny imposes no serialization constraint.
 func MatchesKeyletType(k keylet.Keylet, data []byte) bool {
-	return k.Type == 0 || EntryTypeCode(data) == uint16(k.Type)
+	entryType := entry.Type(EntryTypeCode(data))
+	switch k.Type {
+	case entry.TypeAny:
+		return true
+	case entry.TypeChild:
+		return entryType != entry.TypeAny && entryType != entry.TypeChild && entryType != entry.TypeDirectoryNode
+	default:
+		return entryType == k.Type
+	}
 }

--- a/internal/ledger/state/sle.go
+++ b/internal/ledger/state/sle.go
@@ -3,6 +3,8 @@ package state
 import (
 	"encoding/binary"
 	"errors"
+
+	"github.com/LeJamon/go-xrpl/keylet"
 )
 
 // IsDefaultValue reports whether a decoded field value should be omitted
@@ -90,4 +92,9 @@ func GetLedgerEntryType(data []byte) (uint16, error) {
 		return 0, errors.New("unexpected header byte, expected 0x11 for LedgerEntryType")
 	}
 	return EntryTypeCode(data), nil
+}
+
+// MatchesKeyletType reports whether data satisfies a keylet's type constraint.
+func MatchesKeyletType(k keylet.Keylet, data []byte) bool {
+	return k.Type == 0 || EntryTypeCode(data) == uint16(k.Type)
 }

--- a/internal/ledger/state/sle_keylet_test.go
+++ b/internal/ledger/state/sle_keylet_test.go
@@ -1,0 +1,44 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+)
+
+func TestMatchesKeyletType(t *testing.T) {
+	key := [32]byte{1}
+	child := keylet.Child(key)
+	if child.Type != entry.TypeChild || child.Key != key {
+		t.Fatalf("Child() = %#v, want type %v and key %x", child, entry.TypeChild, key)
+	}
+	data := func(typ entry.Type) []byte {
+		return []byte{0x11, byte(typ >> 8), byte(typ), 0}
+	}
+
+	tests := []struct {
+		name string
+		k    keylet.Keylet
+		data []byte
+		want bool
+	}{
+		{name: "any", k: keylet.Keylet{Type: entry.TypeAny, Key: key}, data: data(entry.TypeAccountRoot), want: true},
+		{name: "any malformed", k: keylet.Keylet{Type: entry.TypeAny, Key: key}, data: []byte{0x11, 0x00}, want: true},
+		{name: "exact", k: keylet.Keylet{Type: entry.TypeAccountRoot, Key: key}, data: data(entry.TypeAccountRoot), want: true},
+		{name: "wrong exact", k: keylet.Keylet{Type: entry.TypeOffer, Key: key}, data: data(entry.TypeAccountRoot)},
+		{name: "child", k: child, data: data(entry.TypeAccountRoot), want: true},
+		{name: "directory is not a child", k: child, data: data(entry.TypeDirectoryNode)},
+		{name: "child pseudo-type is not a child", k: child, data: data(entry.TypeChild)},
+		{name: "malformed child", k: child, data: []byte{0x11, 0x00}},
+		{name: "malformed exact", k: keylet.Keylet{Type: entry.TypeAccountRoot, Key: key}, data: []byte{0x11, 0x00}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := MatchesKeyletType(test.k, test.data); got != test.want {
+				t.Fatalf("MatchesKeyletType() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/testing/permissioneddomain/permissioned_domain_test.go
+++ b/internal/testing/permissioneddomain/permissioned_domain_test.go
@@ -669,6 +669,36 @@ func TestDelete(t *testing.T) {
 	})
 }
 
+func TestPermissionedDomainDeleteWrongTypeCollision(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	env.Fund(alice)
+	env.Close()
+	env.SetBaseFee(1)
+
+	before := env.AccountInfo(alice)
+	if before == nil {
+		t.Fatal("alice account is missing before delete")
+	}
+	accountKey := keylet.Account(alice.ID)
+	result := env.Submit(pd.DomainDelete(alice, domainIDHex(accountKey)).Fee(1).Build())
+	jtx.RequireTxClaimed(t, result, jtx.TecNO_ENTRY)
+
+	after := env.AccountInfo(alice)
+	if after == nil {
+		t.Fatal("alice account is missing after delete")
+	}
+	if after.Balance != before.Balance-1 {
+		t.Fatalf("balance = %d, want %d", after.Balance, before.Balance-1)
+	}
+	if after.Sequence != before.Sequence+1 {
+		t.Fatalf("sequence = %d, want %d", after.Sequence, before.Sequence+1)
+	}
+	if data, err := env.LedgerEntry(accountKey); err != nil || data == nil {
+		t.Fatalf("account root after collision = %x, %v", data, err)
+	}
+}
+
 // TestAccountReserve verifies reserve requirement for domain creation.
 // Reference: rippled PermissionedDomains_test.cpp testAccountReserve()
 func TestAccountReserve(t *testing.T) {

--- a/internal/tx/applystate/apply_state_table.go
+++ b/internal/tx/applystate/apply_state_table.go
@@ -151,6 +151,9 @@ func (t *ApplyStateTable) Read(k keylet.Keylet) ([]byte, error) {
 		if entry.Action == ActionErase {
 			return nil, nil
 		}
+		if !state.MatchesKeyletType(k, entry.Current) {
+			return nil, nil
+		}
 		return entry.Current, nil
 	}
 
@@ -158,6 +161,9 @@ func (t *ApplyStateTable) Read(k keylet.Keylet) ([]byte, error) {
 	data, err := t.base.Read(k)
 	if err != nil {
 		return nil, err
+	}
+	if data != nil && !state.MatchesKeyletType(k, data) {
+		return nil, nil
 	}
 
 	// Only track entries that exist in the base
@@ -174,12 +180,9 @@ func (t *ApplyStateTable) Read(k keylet.Keylet) ([]byte, error) {
 
 // Exists checks if an entry exists
 func (t *ApplyStateTable) Exists(k keylet.Keylet) (bool, error) {
-	// Check if tracked
 	if entry, exists := t.items[k.Key]; exists {
-		return entry.Action != ActionErase, nil
+		return entry.Action != ActionErase && state.MatchesKeyletType(k, entry.Current), nil
 	}
-
-	// Check base
 	return t.base.Exists(k)
 }
 

--- a/internal/tx/applystate/apply_state_table_test.go
+++ b/internal/tx/applystate/apply_state_table_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/LeJamon/go-xrpl/drops"
 	ledgercore "github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
 
 // mockBaseView implements LedgerView for ApplyStateTable tests.
@@ -100,6 +101,51 @@ func key(b byte) [32]byte {
 
 func kl(b byte) keylet.Keylet {
 	return keylet.Keylet{Key: key(b)}
+}
+
+func typedEntryData(typ entry.Type, tag byte) []byte {
+	return []byte{0x11, byte(typ >> 8), byte(typ), tag}
+}
+
+func TestReadChecksKeyletTypeForBaseAndTrackedEntries(t *testing.T) {
+	base := newMockBaseView()
+	baseKey := key(1)
+	baseData := typedEntryData(entry.TypeAccountRoot, 1)
+	base.data[baseKey] = baseData
+	table := NewApplyStateTable(base, [32]byte{}, 0, nil)
+	wrongBase := keylet.Keylet{Type: entry.TypePermissionedDomain, Key: baseKey}
+
+	if got, err := table.Read(wrongBase); err != nil || got != nil {
+		t.Fatalf("Read wrong-type base entry = %x, %v", got, err)
+	}
+	if exists, err := table.Exists(wrongBase); err != nil || !exists {
+		t.Fatalf("Exists wrong-type base entry = %v, %v", exists, err)
+	}
+	if got, err := table.Read(keylet.Keylet{Key: baseKey}); err != nil || !bytes.Equal(got, baseData) {
+		t.Fatalf("Read ltANY base entry = %x, %v", got, err)
+	}
+	if got, err := table.Read(wrongBase); err != nil || got != nil {
+		t.Fatalf("Read wrong-type cached entry = %x, %v", got, err)
+	}
+	if exists, err := table.Exists(wrongBase); err != nil || exists {
+		t.Fatalf("Exists wrong-type cached entry = %v, %v", exists, err)
+	}
+
+	insertedKey := key(2)
+	insertedData := typedEntryData(entry.TypeAccountRoot, 2)
+	if err := table.Insert(keylet.Keylet{Type: entry.TypeAccountRoot, Key: insertedKey}, insertedData); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	wrongInserted := keylet.Keylet{Type: entry.TypePermissionedDomain, Key: insertedKey}
+	if got, err := table.Read(wrongInserted); err != nil || got != nil {
+		t.Fatalf("Read wrong-type inserted entry = %x, %v", got, err)
+	}
+	if exists, err := table.Exists(wrongInserted); err != nil || exists {
+		t.Fatalf("Exists wrong-type inserted entry = %v, %v", exists, err)
+	}
+	if got, err := table.Read(keylet.Keylet{Key: insertedKey}); err != nil || !bytes.Equal(got, insertedData) {
+		t.Fatalf("Read ltANY inserted entry = %x, %v", got, err)
+	}
 }
 
 // collectForEach runs ForEach and returns all yielded key-data pairs sorted by key.

--- a/internal/tx/payment/sandbox.go
+++ b/internal/tx/payment/sandbox.go
@@ -256,22 +256,36 @@ func (s *PaymentSandbox) Read(k keylet.Keylet) ([]byte, error) {
 
 	// Check local modifications
 	if data, ok := s.modifications[key]; ok {
+		if !state.MatchesKeyletType(k, data) {
+			return nil, nil
+		}
 		return data, nil
 	}
 
 	// Check local insertions
 	if data, ok := s.insertions[key]; ok {
+		if !state.MatchesKeyletType(k, data) {
+			return nil, nil
+		}
 		return data, nil
 	}
 
 	// Check parent sandbox
 	if s.parent != nil {
-		return s.parent.Read(k)
+		data, err := s.parent.Read(k)
+		if err != nil || data == nil || state.MatchesKeyletType(k, data) {
+			return data, err
+		}
+		return nil, nil
 	}
 
 	// Read from underlying view
 	if s.view != nil {
-		return s.view.Read(k)
+		data, err := s.view.Read(k)
+		if err != nil || data == nil || state.MatchesKeyletType(k, data) {
+			return data, err
+		}
+		return nil, nil
 	}
 
 	return nil, nil
@@ -280,30 +294,21 @@ func (s *PaymentSandbox) Read(k keylet.Keylet) ([]byte, error) {
 // Exists checks if a ledger entry exists in the sandbox or underlying view
 func (s *PaymentSandbox) Exists(k keylet.Keylet) (bool, error) {
 	key := k.Key
-
-	// Check deletions first
 	if s.deletions[key] {
 		return false, nil
 	}
-
-	// Check local modifications or insertions
-	if _, ok := s.modifications[key]; ok {
-		return true, nil
+	if data, ok := s.modifications[key]; ok {
+		return state.MatchesKeyletType(k, data), nil
 	}
-	if _, ok := s.insertions[key]; ok {
-		return true, nil
+	if data, ok := s.insertions[key]; ok {
+		return state.MatchesKeyletType(k, data), nil
 	}
-
-	// Check parent sandbox
 	if s.parent != nil {
 		return s.parent.Exists(k)
 	}
-
-	// Check underlying view
 	if s.view != nil {
 		return s.view.Exists(k)
 	}
-
 	return false, nil
 }
 

--- a/internal/tx/payment/sandbox_keylet_type_test.go
+++ b/internal/tx/payment/sandbox_keylet_type_test.go
@@ -1,0 +1,70 @@
+package payment
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+)
+
+type keyletReadView interface {
+	Read(keylet.Keylet) ([]byte, error)
+	Exists(keylet.Keylet) (bool, error)
+}
+
+func sandboxEntryData(typ entry.Type, tag byte) []byte {
+	return []byte{0x11, byte(typ >> 8), byte(typ), tag}
+}
+
+func requireWrongTypeReadAbsent(t *testing.T, view keyletReadView, k keylet.Keylet) {
+	t.Helper()
+	if got, err := view.Read(k); err != nil || got != nil {
+		t.Fatalf("Read wrong-type entry = %x, %v", got, err)
+	}
+}
+
+func requireWrongTypeAbsent(t *testing.T, view keyletReadView, k keylet.Keylet) {
+	t.Helper()
+	requireWrongTypeReadAbsent(t, view, k)
+	if exists, err := view.Exists(k); err != nil || exists {
+		t.Fatalf("Exists wrong-type entry = %v, %v", exists, err)
+	}
+}
+
+func TestPaymentSandboxChecksKeyletType(t *testing.T) {
+	view := newPaymentMockLedgerView()
+	baseKey := [32]byte{1}
+	baseData := sandboxEntryData(entry.TypeAccountRoot, 1)
+	view.data[baseKey] = baseData
+	sandbox := NewPaymentSandbox(view)
+	wrongBase := keylet.Keylet{Type: entry.TypePermissionedDomain, Key: baseKey}
+
+	requireWrongTypeReadAbsent(t, sandbox, wrongBase)
+	if exists, err := sandbox.Exists(wrongBase); err != nil || !exists {
+		t.Fatalf("Exists wrong-type base entry = %v, %v", exists, err)
+	}
+	if got, err := sandbox.Read(keylet.Keylet{Key: baseKey}); err != nil || !bytes.Equal(got, baseData) {
+		t.Fatalf("Read ltANY base entry = %x, %v", got, err)
+	}
+
+	modifiedData := sandboxEntryData(entry.TypeAccountRoot, 2)
+	if err := sandbox.Update(keylet.Keylet{Type: entry.TypeAccountRoot, Key: baseKey}, modifiedData); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	requireWrongTypeAbsent(t, sandbox, wrongBase)
+
+	insertedKey := [32]byte{2}
+	insertedData := sandboxEntryData(entry.TypeAccountRoot, 3)
+	if err := sandbox.Insert(keylet.Keylet{Type: entry.TypeAccountRoot, Key: insertedKey}, insertedData); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	wrongInserted := keylet.Keylet{Type: entry.TypePermissionedDomain, Key: insertedKey}
+	requireWrongTypeAbsent(t, sandbox, wrongInserted)
+	if got, err := sandbox.Read(keylet.Keylet{Key: insertedKey}); err != nil || !bytes.Equal(got, insertedData) {
+		t.Fatalf("Read ltANY inserted entry = %x, %v", got, err)
+	}
+
+	child := NewChildSandbox(sandbox)
+	requireWrongTypeAbsent(t, child, wrongInserted)
+}

--- a/keylet/keylet.go
+++ b/keylet/keylet.go
@@ -57,6 +57,11 @@ type Keylet struct {
 	Key  [32]byte
 }
 
+// Child returns a keylet that accepts any non-directory ledger entry.
+func Child(key [32]byte) Keylet {
+	return Keylet{Type: entry.TypeChild, Key: key}
+}
+
 // indexHash computes a keylet key by hashing the space and provided data.
 func indexHash(space uint16, data ...[]byte) [32]byte {
 	var spaceBytes [2]byte

--- a/ledger/entry/entry.go
+++ b/ledger/entry/entry.go
@@ -9,6 +9,12 @@ import (
 // Type represents a ledger entry type.
 type Type uint16
 
+// Pseudo-types used only as keylet constraints.
+const (
+	TypeAny   Type = 0
+	TypeChild Type = 0x1CD2
+)
+
 // All known ledger entry types
 // Reference: rippled/include/xrpl/protocol/detail/ledger_entries.macro
 const (
@@ -76,7 +82,7 @@ const (
 	TypeLoan       Type = 0x0089 // Loans
 )
 
-// String returns the string representation of the Type.
+// String returns the concrete ledger entry type name. Pseudo-types are unknown.
 func (t Type) String() string {
 	switch t {
 	case TypeContract:


### PR DESCRIPTION
## Summary

- reject ledger entries whose serialized type does not match a typed keylet across base, snapshot, apply-state, and payment-sandbox reads
- preserve rippled v3.2.0 `ltANY` handling and its layer-dependent `Exists` behavior
- add regressions for every affected view layer and the PermissionedDomainDelete wrong-type collision

## Test plan

- `just test-core`
- `just test-tx`
- `go test -race -count=1 -timeout 15m ./internal/ledger/... ./internal/txq/... ./internal/rpc/... ./internal/consensus/... ./internal/peermanagement/...`
- `go test -race -count=1 -timeout 15m ./internal/tx/...`
- `go test -race -count=1 -timeout 15m ./internal/testing/permissioneddomain`
- `just conformance PermissionedDomain` (6/6)
- `just build`
- `just build-nocgo`
- `just vet`
- `go vet -tags postgres ./storage/relationaldb/postgres/`
- `golangci-lint run` (0 issues)

Fixes #1356
