### PR TITLE
fix: restrict private discovery to fixed peers

### DIFF
--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -62,7 +62,7 @@ type Config struct {
 	FixedPeers     []string
 
 	// Privacy
-	PrivateMode bool // Don't share our address with peers
+	PrivateMode bool // Only auto-connect to fixed peers and don't share our address
 
 	// Storage
 	DataDir string // For boot cache persistence

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -244,19 +244,22 @@ func WithIPLimit(n int) Option {
 
 // WithBootstrapPeers sets the initial peers to connect to.
 func WithBootstrapPeers(peers ...string) Option {
+	peers = append([]string(nil), peers...)
 	return func(c *Config) {
-		c.BootstrapPeers = peers
+		c.BootstrapPeers = append([]string(nil), peers...)
 	}
 }
 
 // WithFixedPeers sets peers that should always be connected.
 func WithFixedPeers(peers ...string) Option {
+	peers = append([]string(nil), peers...)
 	return func(c *Config) {
-		c.FixedPeers = peers
+		c.FixedPeers = append([]string(nil), peers...)
 	}
 }
 
-// WithPrivateMode enables private mode (don't share our address).
+// WithPrivateMode limits automatic connections to fixed peers and suppresses
+// sharing our address.
 func WithPrivateMode(enabled bool) Option {
 	return func(c *Config) {
 		c.PrivateMode = enabled

--- a/internal/peermanagement/discovery.go
+++ b/internal/peermanagement/discovery.go
@@ -396,8 +396,11 @@ type Discovery struct {
 
 // NewDiscovery creates a new Discovery instance.
 func NewDiscovery(cfg *Config, events chan<- Event) *Discovery {
+	discoveryCfg := *cfg
+	discoveryCfg.BootstrapPeers = append([]string(nil), cfg.BootstrapPeers...)
+	discoveryCfg.FixedPeers = append([]string(nil), cfg.FixedPeers...)
 	d := &Discovery{
-		cfg:             *cfg,
+		cfg:             discoveryCfg,
 		peers:           make(map[string]*DiscoveredPeer),
 		connected:       make(map[PeerID]*DiscoveredPeer),
 		fixedPeers:      make(map[string]bool),
@@ -411,11 +414,11 @@ func NewDiscovery(cfg *Config, events chan<- Event) *Discovery {
 		d.cfg.Clock = time.Now
 	}
 
-	for _, addr := range cfg.FixedPeers {
+	for _, addr := range discoveryCfg.FixedPeers {
 		d.fixedPeers[addr] = true
 		d.persistentPeers[addr] = true
 	}
-	for _, addr := range cfg.BootstrapPeers {
+	for _, addr := range discoveryCfg.BootstrapPeers {
 		d.persistentPeers[addr] = true
 	}
 

--- a/internal/peermanagement/discovery.go
+++ b/internal/peermanagement/discovery.go
@@ -832,7 +832,6 @@ func (d *Discovery) SelectPeersToConnect(count int) []string {
 	}
 	var fixedCandidates []string
 	var candidates []string
-	seen := make(map[string]struct{})
 	seenHosts := make(map[string]struct{})
 	for _, peer := range d.peers {
 		if peer.Connected {
@@ -865,33 +864,36 @@ func (d *Discovery) SelectPeersToConnect(count int) []string {
 			fixedCandidates = append(fixedCandidates, address)
 		}
 	}
-	for _, peer := range d.peers {
-		seen[peer.Address] = struct{}{}
-		if d.fixedPeers[peer.Address] {
-			continue
-		}
-		if !peer.Connected && peer.Hops <= MaxHops && eligible(peer.Address) {
-			candidates = append(candidates, peer.Address)
-		}
-	}
-
-	if d.bootCache != nil {
-		for _, entry := range d.bootCache.Endpoints(50) {
-			if _, exists := seen[entry.Address]; !exists && eligible(entry.Address) {
-				candidates = append(candidates, entry.Address)
-				seen[entry.Address] = struct{}{}
+	if !d.cfg.PrivateMode {
+		seen := make(map[string]struct{})
+		for _, peer := range d.peers {
+			seen[peer.Address] = struct{}{}
+			if d.fixedPeers[peer.Address] {
+				continue
+			}
+			if !peer.Connected && peer.Hops <= MaxHops && eligible(peer.Address) {
+				candidates = append(candidates, peer.Address)
 			}
 		}
-	}
 
-	rand.Shuffle(len(candidates), func(i, j int) {
-		candidates[i], candidates[j] = candidates[j], candidates[i]
-	})
+		if d.bootCache != nil {
+			for _, entry := range d.bootCache.Endpoints(50) {
+				if _, exists := seen[entry.Address]; !exists && eligible(entry.Address) {
+					candidates = append(candidates, entry.Address)
+					seen[entry.Address] = struct{}{}
+				}
+			}
+		}
 
-	if count > 0 && count < len(candidates) {
-		candidates = candidates[:count]
-	} else if count <= 0 {
-		candidates = nil
+		rand.Shuffle(len(candidates), func(i, j int) {
+			candidates[i], candidates[j] = candidates[j], candidates[i]
+		})
+
+		if count > 0 && count < len(candidates) {
+			candidates = candidates[:count]
+		} else if count <= 0 {
+			candidates = nil
+		}
 	}
 	candidates = append(fixedCandidates, candidates...)
 	for _, address := range candidates {

--- a/internal/peermanagement/discovery_test.go
+++ b/internal/peermanagement/discovery_test.go
@@ -277,6 +277,102 @@ func TestDiscoverySelectsFixedPeersBeyondOrdinaryCapacity(t *testing.T) {
 	assert.Equal(t, []string{"192.0.2.40:51235"}, d.SelectPeersToConnect(0))
 }
 
+func TestDiscoveryPrivateModeSelectsOnlyFixedPeers(t *testing.T) {
+	dataDir := t.TempDir()
+	cache := NewBootCache(dataDir)
+	cache.Insert("198.51.100.10:51235", 51235)
+	require.NoError(t, cache.Save())
+
+	d := NewDiscovery(&Config{
+		MaxPeers:       50,
+		MaxOutbound:    25,
+		BootstrapPeers: []string{"198.51.100.20:51235"},
+		FixedPeers:     []string{"198.51.100.30:51235"},
+		PrivateMode:    true,
+		DataDir:        dataDir,
+	}, make(chan Event, 1))
+	require.NoError(t, d.Start(t.Context()))
+	t.Cleanup(d.Stop)
+	d.AddPeer("198.51.100.40:51235", 1, PeerID(1))
+	d.AddRedirectCandidate("198.51.100.50:51235", PeerID(2))
+
+	assert.Equal(t, []string{"198.51.100.30:51235"}, d.SelectPeersToConnect(25))
+}
+
+func TestDiscoveryPublicModeSelectsAllCandidateSources(t *testing.T) {
+	dataDir := t.TempDir()
+	cache := NewBootCache(dataDir)
+	cache.Insert("198.51.100.10:51235", 51235)
+	require.NoError(t, cache.Save())
+
+	d := NewDiscovery(&Config{
+		MaxPeers:       50,
+		MaxOutbound:    25,
+		BootstrapPeers: []string{"198.51.100.20:51235"},
+		FixedPeers:     []string{"198.51.100.30:51235"},
+		DataDir:        dataDir,
+	}, make(chan Event, 1))
+	require.NoError(t, d.Start(t.Context()))
+	t.Cleanup(d.Stop)
+	d.AddPeer("198.51.100.40:51235", 1, PeerID(1))
+	d.AddRedirectCandidate("198.51.100.50:51235", PeerID(2))
+
+	assert.ElementsMatch(t, []string{
+		"198.51.100.10:51235",
+		"198.51.100.20:51235",
+		"198.51.100.30:51235",
+		"198.51.100.40:51235",
+		"198.51.100.50:51235",
+	}, d.SelectPeersToConnect(25))
+}
+
+func TestDiscoveryPrivateModeFixedPeerReconnectsAfterRestartDNSResolution(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	dataDir := t.TempDir()
+	newDiscovery := func(fixedIP, bootstrapIP string) *Discovery {
+		d := NewDiscovery(&Config{
+			MaxPeers:       50,
+			MaxOutbound:    25,
+			BootstrapPeers: []string{"bootstrap.example:51235"},
+			FixedPeers:     []string{"fixed.example:51235"},
+			PrivateMode:    true,
+			DataDir:        dataDir,
+			Clock:          func() time.Time { return now },
+		}, make(chan Event, 1))
+		d.lookupIP = func(_ context.Context, host string) ([]net.IPAddr, error) {
+			switch host {
+			case "fixed.example":
+				return []net.IPAddr{{IP: net.ParseIP(fixedIP)}}, nil
+			case "bootstrap.example":
+				return []net.IPAddr{{IP: net.ParseIP(bootstrapIP)}}, nil
+			default:
+				return nil, fmt.Errorf("unexpected host %q", host)
+			}
+		}
+		return d
+	}
+
+	first := newDiscovery("192.0.2.10", "192.0.2.20")
+	require.NoError(t, first.Start(t.Context()))
+	t.Cleanup(first.Stop)
+	require.Equal(t, []string{"192.0.2.10:51235"}, first.SelectPeersToConnect(25))
+	first.MarkConnected("192.0.2.10:51235", PeerID(1))
+	first.MarkDisconnected(PeerID(1))
+	now = now.Add(recentConnectAttempt)
+	assert.Equal(t, []string{"192.0.2.10:51235"}, first.SelectPeersToConnect(25))
+	first.Stop()
+
+	second := newDiscovery("192.0.2.11", "192.0.2.21")
+	require.NoError(t, second.Start(t.Context()))
+	t.Cleanup(second.Stop)
+	var restored []string
+	for _, entry := range second.bootCache.Endpoints(50) {
+		restored = append(restored, entry.Address)
+	}
+	assert.Contains(t, restored, "192.0.2.10:51235")
+	assert.Equal(t, []string{"192.0.2.11:51235"}, second.SelectPeersToConnect(25))
+}
+
 func TestBootCache(t *testing.T) {
 	// Use temp directory for test
 	bc := NewBootCache("")

--- a/internal/peermanagement/discovery_test.go
+++ b/internal/peermanagement/discovery_test.go
@@ -365,8 +365,9 @@ func TestDiscoveryPrivateModeFixedPeerReconnectsAfterRestartDNSResolution(t *tes
 	second := newDiscovery("192.0.2.11", "192.0.2.21")
 	require.NoError(t, second.Start(t.Context()))
 	t.Cleanup(second.Stop)
-	var restored []string
-	for _, entry := range second.bootCache.Endpoints(50) {
+	entries := second.bootCache.Endpoints(50)
+	restored := make([]string, 0, len(entries))
+	for _, entry := range entries {
 		restored = append(restored, entry.Address)
 	}
 	assert.Contains(t, restored, "192.0.2.10:51235")

--- a/internal/peermanagement/discovery_test.go
+++ b/internal/peermanagement/discovery_test.go
@@ -26,6 +26,28 @@ func TestNewDiscovery(t *testing.T) {
 	}
 }
 
+func TestDiscoveryConfigPeerSlicesAreIsolated(t *testing.T) {
+	bootstrap := []string{"bootstrap.example:51235"}
+	fixed := []string{"fixed.example:51235"}
+	cfg := DefaultConfig()
+	WithBootstrapPeers(bootstrap...)(&cfg)
+	WithFixedPeers(fixed...)(&cfg)
+
+	bootstrap[0] = "mutated-bootstrap.example:51235"
+	fixed[0] = "mutated-fixed.example:51235"
+	require.Equal(t, []string{"bootstrap.example:51235"}, cfg.BootstrapPeers)
+	require.Equal(t, []string{"fixed.example:51235"}, cfg.FixedPeers)
+
+	d := NewDiscovery(&cfg, make(chan Event, 1))
+	cfg.BootstrapPeers[0] = "replaced-bootstrap.example:51235"
+	cfg.FixedPeers[0] = "replaced-fixed.example:51235"
+
+	assert.Equal(t, []string{"bootstrap.example:51235"}, d.cfg.BootstrapPeers)
+	assert.Equal(t, []string{"fixed.example:51235"}, d.cfg.FixedPeers)
+	assert.True(t, d.fixedPeers["fixed.example:51235"])
+	assert.False(t, d.fixedPeers["replaced-fixed.example:51235"])
+}
+
 func TestDiscoveryAddPeer(t *testing.T) {
 	cfg := &Config{
 		MaxPeers:    50,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,6 @@
 # Issue #1357 — AMMClawback pseudo-account metadata
 
-Target: `origin/main` at `7aab186ddb36317bdb63c831e6ffb9c5dd25b364`.
+Target: `origin/main` at `25a82672eb73ec5f76d95e00b8ef54d27cab21b2`.
 Behavioral oracle: clean local rippled `3.2.0` worktree at
 `3c43f4614f87965298773279ff5b85d4c56c637b`.
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1094,3 +1094,48 @@ sequence in `Payment::doApply`. The Go implementation matches v3.2.0, so the old
 image created deterministic account-state and transaction-metadata divergence
 before exercising PR #1329. The smoke topology and both CI callers now use the
 project's mandated rippled 3.2.0 image and its `/config` entrypoint contract.
+# Issue #1360 — peer_private fixed-peer-only policy
+
+Target: `origin/main` at `7aab186ddb36317bdb63c831e6ffb9c5dd25b364`.
+Behavioral oracle: clean local rippled `3.2.0` worktree at
+`3c43f4614f87965298773279ff5b85d4c56c637b`.
+
+## Plan
+
+- [x] Trace every outbound candidate source and private-mode configuration path
+      in go-xrpl, including bootstrap, fixed, gossip, redirect, boot cache,
+      restart, and DNS re-resolution behavior.
+- [x] Confirm rippled v3.2.0 private-mode configuration and PeerFinder selection
+      semantics in the pinned local oracle.
+- [x] Add focused regressions proving private mode dials only fixed peers while
+      public mode retains all existing discovery behavior.
+- [x] Implement the smallest layered policy enforcement that prevents current
+      and future dynamic candidate sources from bypassing private mode.
+- [x] Run formatting, focused and race tests, affected package/core tests, build,
+      vet, strict CI lint, advisory lint, and diff checks.
+- [x] Review the complete diff for concurrency, reconnect/DNS behavior, startup
+      wiring, and rippled v3.2.0 conformance; record exact results below.
+- [ ] Stage intentional files only, commit, push, open the PR against `main`, and
+      verify the published head and initial CI state.
+
+## Review
+
+- `Discovery.SelectPeersToConnect` now selects and reserves configured fixed
+  peers before applying the private-mode gate, then skips every ordinary live
+  and boot-cache candidate. This matches rippled v3.2.0's fixed handout before
+  its `autoConnect` check; learned data remains stored but cannot be auto-dialed.
+- Public-mode discovery is unchanged. The paired regression proves bootstrap,
+  fixed, gossip, redirect, and boot-cache candidates all remain eligible when
+  privacy is off and only the fixed candidate remains eligible when it is on.
+- Restart coverage proves a persisted stale fixed endpoint is loaded but not
+  selected after the configured hostname resolves to a new address. Fixed
+  disconnect/reconnect cooldown remains intact. Rippled v3.2.0 likewise
+  re-resolves configured names on process restart rather than periodically.
+- Existing zero ordinary inbound capacity and hops-0 self-gossip suppression
+  remain covered and unchanged. Manual administrative `Overlay.Connect` remains
+  available, matching rippled's `peer_connect` override.
+- Passed repeated focused tests, the full peer-management package, focused race
+  coverage, `just test-core`, `just fmt`, `just build-all`, `just vet`, tagged
+  PostgreSQL vet, CI-pinned strict lint, advisory lint, and `git diff --check`.
+- Independent final Go-quality, adversarial-test, and rippled-conformance
+  reviews found no Blocking, Major, Minor, or Nit issues.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1191,7 +1191,7 @@ Behavioral oracle: clean local rippled `3.2.0` worktree at
       vet, strict CI lint, advisory lint, and diff checks.
 - [x] Review the complete diff for concurrency, reconnect/DNS behavior, startup
       wiring, and rippled v3.2.0 conformance; record exact results below.
-- [ ] Stage intentional files only, commit, push, open the PR against `main`, and
+- [x] Stage intentional files only, commit, push, open the PR against `main`, and
       verify the published head and initial CI state.
 
 ## Review
@@ -1215,3 +1215,6 @@ Behavioral oracle: clean local rippled `3.2.0` worktree at
   PostgreSQL vet, CI-pinned strict lint, advisory lint, and `git diff --check`.
 - Independent final Go-quality, adversarial-test, and rippled-conformance
   reviews found no Blocking, Major, Minor, or Nit issues.
+- Behavior commit `d1fc5be2` and test-hardening commit `5f0890f8` are published
+  on `fix/issue-1360-peer-private-fixed-peers`; PR #1364 targets `main` at
+  https://github.com/LeJamon/go-xrpl/pull/1364.


### PR DESCRIPTION
## Summary
- enforce `peer_private` at the outbound selector so configured fixed peers remain eligible while bootstrap, gossip, redirect, and boot-cache candidates cannot be auto-dialed
- mirror rippled v3.2.0's fixed-first selection order while preserving learned endpoint storage, public discovery behavior, and manual administrative connects
- cover every candidate source plus fixed reconnects, persisted restart state, and DNS resolution changes across restart

## Test plan
- [x] `just test-pkg './internal/peermanagement -count=1'`
- [x] `just test-pkg './internal/peermanagement -race -run TestDiscovery -count=1'`
- [x] `just test-core`
- [x] `just build-all`
- [x] `just vet`
- [x] `go vet -tags postgres ./storage/relationaldb/postgres/`
- [x] `golangci-lint run`
- [x] `just lint`
- [x] `git diff --check`

Fixes #1360
