### PR TITLE
fix(peer): make large-frame liveness progress-aware

### DIFF
--- a/internal/peermanagement/errors.go
+++ b/internal/peermanagement/errors.go
@@ -19,6 +19,7 @@ var (
 	ErrPingTimeout        = errors.New("peer ping timeout")
 	ErrLargeSendQueue     = errors.New("peer send queue saturated; closing")
 	ErrReadIdle           = errors.New("peer read idle deadline exceeded")
+	ErrFrameReadTooSlow   = errors.New("peer frame exceeded its read progress budget")
 	ErrWriteIdle          = errors.New("peer write idle deadline exceeded")
 
 	// Handshake errors

--- a/internal/peermanagement/message.go
+++ b/internal/peermanagement/message.go
@@ -88,6 +88,10 @@ func ReadMessage(r io.Reader) (*MessageHeader, []byte, error) {
 	return message.ReadMessage(r)
 }
 
+func readMessageWithHeader(r io.Reader, onHeader func(MessageHeader) error) (*MessageHeader, []byte, error) {
+	return message.ReadMessageWithHeader(r, onHeader)
+}
+
 // WriteMessage writes a message with header to the writer.
 func WriteMessage(w io.Writer, msgType MessageType, payload []byte) error {
 	return message.WriteMessage(w, msgType, payload)

--- a/internal/peermanagement/message/codec.go
+++ b/internal/peermanagement/message/codec.go
@@ -258,6 +258,17 @@ func DecodeHeader(buf []byte) (*Header, error) {
 // ReadMessage reads a complete message from the reader.
 // Returns the header and the payload.
 func ReadMessage(r io.Reader) (*Header, []byte, error) {
+	return readMessage(r, nil)
+}
+
+// ReadMessageWithHeader reads a complete message and calls onHeader after the
+// header and size claims have been validated but before the payload is
+// allocated.
+func ReadMessageWithHeader(r io.Reader, onHeader func(Header) error) (*Header, []byte, error) {
+	return readMessage(r, onHeader)
+}
+
+func readMessage(r io.Reader, onHeader func(Header) error) (*Header, []byte, error) {
 	// Read header (start with minimum size)
 	headerBuf := make([]byte, HeaderSizeCompressed)
 	if _, err := io.ReadFull(r, headerBuf[:HeaderSizeUncompressed]); err != nil {
@@ -297,6 +308,11 @@ func ReadMessage(r io.Reader) (*Header, []byte, error) {
 	if header.Compressed && header.UncompressedSize > maxSize {
 		return nil, nil, fmt.Errorf("%w: uncompressed %d > %d for %s",
 			ErrMessageTooLarge, header.UncompressedSize, maxSize, header.MessageType)
+	}
+	if onHeader != nil {
+		if err := onHeader(*header); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	// Read payload

--- a/internal/peermanagement/message/codec_test.go
+++ b/internal/peermanagement/message/codec_test.go
@@ -298,6 +298,42 @@ func TestReadMessageCaps(t *testing.T) {
 	}
 }
 
+func TestReadMessageWithHeaderRunsCallbackAfterSizeValidation(t *testing.T) {
+	frame := compressedFrame(t, TypeManifests, []byte{1}, MaxMessageSize+1)
+	called := false
+
+	_, _, err := ReadMessageWithHeader(bytes.NewReader(frame), func(Header) error {
+		called = true
+		return nil
+	})
+
+	if !errors.Is(err, ErrMessageTooLarge) {
+		t.Fatalf("ReadMessageWithHeader err = %v, want ErrMessageTooLarge", err)
+	}
+	if called {
+		t.Fatal("header callback ran before rejecting an oversized payload claim")
+	}
+}
+
+func TestReadMessageWithHeaderRunsCallbackBeforePayloadRead(t *testing.T) {
+	header := make([]byte, HeaderSizeUncompressed)
+	if err := EncodeHeader(header, 10, TypeManifests, AlgorithmNone, 0); err != nil {
+		t.Fatalf("EncodeHeader: %v", err)
+	}
+	want := errors.New("stop before payload")
+
+	_, _, err := ReadMessageWithHeader(bytes.NewReader(header), func(got Header) error {
+		if got.PayloadSize != 10 || got.MessageType != TypeManifests {
+			t.Fatalf("callback header = %+v", got)
+		}
+		return want
+	})
+
+	if !errors.Is(err, want) {
+		t.Fatalf("ReadMessageWithHeader err = %v, want callback error", err)
+	}
+}
+
 func TestHeaderSize(t *testing.T) {
 	uncompressed := &Header{Compressed: false}
 	if uncompressed.HeaderSize() != HeaderSizeUncompressed {

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -146,6 +146,10 @@ type Peer struct {
 	// peerTimerInterval; only the pingLoop goroutine touches it.
 	lastPingProbe time.Time
 
+	readProgressMu sync.RWMutex
+	readProgress   inboundFrameProgress
+	readPolicy     peerReadPolicy
+
 	// sendDrops counts frames dropped because the bounded send queue was
 	// full. go-xrpl drops the frame and returns ErrSendBufferFull rather
 	// than queueing unboundedly like rippled; this per-peer counter is
@@ -198,9 +202,30 @@ type Peer struct {
 	lastStatus message.NodeStatus
 
 	latencyMu     sync.RWMutex
-	pingsInFlight map[uint32]time.Time
+	pingsInFlight map[uint32]pingInFlight
 	latency       time.Duration
 	hasLatency    bool
+}
+
+type peerReadPolicy struct {
+	now               func() time.Time
+	idleTimeout       time.Duration
+	minimumFrameRate  int64
+	pingDispatchGrace time.Duration
+}
+
+type inboundFrameProgress struct {
+	id           uint64
+	active       bool
+	deadline     time.Time
+	lastProgress time.Time
+}
+
+type pingInFlight struct {
+	sentAt time.Time
+	// Fixed at send time so ordered frames cannot renew the deferral forever.
+	progressDeadline time.Time
+	deferUntil       time.Time
 }
 
 type PeerConfig struct {
@@ -225,9 +250,15 @@ func NewPeer(id PeerID, endpoint Endpoint, inbound bool, identity *Identity, eve
 		traffic:       NewTrafficCounter(),
 		metrics:       newPeerMetrics(nil),
 		squelchMap:    make(map[string]time.Time),
-		pingsInFlight: make(map[uint32]time.Time),
-		createdAt:     time.Now(),
-		closeCh:       make(chan struct{}),
+		pingsInFlight: make(map[uint32]pingInFlight),
+		readPolicy: peerReadPolicy{
+			now:               time.Now,
+			idleTimeout:       readIdleDeadline,
+			minimumFrameRate:  minimumFrameReadRate,
+			pingDispatchGrace: pingProbeInterval,
+		},
+		createdAt: time.Now(),
+		closeCh:   make(chan struct{}),
 	}
 }
 
@@ -832,6 +863,116 @@ func (p *Peer) Run(ctx context.Context) error {
 	return runErr
 }
 
+type frameProgressReader struct {
+	peer                *Peer
+	reader              io.Reader
+	conn                net.Conn
+	frameID             uint64
+	startedAt           time.Time
+	deadline            time.Time
+	budgetDeadlineArmed bool
+}
+
+func (p *Peer) newFrameProgressReader(reader io.Reader, conn net.Conn) *frameProgressReader {
+	now := p.readPolicy.now()
+	p.readProgressMu.Lock()
+	p.readProgress.id++
+	p.readProgress.active = true
+	p.readProgress.deadline = time.Time{}
+	p.readProgress.lastProgress = time.Time{}
+	id := p.readProgress.id
+	p.readProgressMu.Unlock()
+	return &frameProgressReader{
+		peer:      p,
+		reader:    reader,
+		conn:      conn,
+		frameID:   id,
+		startedAt: now,
+	}
+}
+
+func (r *frameProgressReader) setHeader(header MessageHeader) error {
+	r.deadline = r.startedAt.Add(r.peer.frameReadBudget(header.PayloadSize))
+
+	r.peer.readProgressMu.Lock()
+	if r.peer.readProgress.id == r.frameID && r.peer.readProgress.active {
+		r.peer.readProgress.deadline = r.deadline
+	}
+	r.peer.readProgressMu.Unlock()
+	return nil
+}
+
+func (p *Peer) frameReadBudget(payloadSize uint32) time.Duration {
+	return p.readPolicy.idleTimeout + time.Duration(
+		(int64(payloadSize)*int64(time.Second)+p.readPolicy.minimumFrameRate-1)/
+			p.readPolicy.minimumFrameRate,
+	)
+}
+
+func (r *frameProgressReader) Read(dst []byte) (int, error) {
+	now := r.peer.readPolicy.now()
+	if !r.deadline.IsZero() && !now.Before(r.deadline) {
+		return 0, ErrFrameReadTooSlow
+	}
+	if r.conn != nil {
+		deadline := now.Add(r.peer.readPolicy.idleTimeout)
+		r.budgetDeadlineArmed = false
+		if !r.deadline.IsZero() && !deadline.Before(r.deadline) {
+			deadline = r.deadline
+			r.budgetDeadlineArmed = true
+		}
+		if err := r.conn.SetReadDeadline(deadline); err != nil {
+			return 0, err
+		}
+	}
+
+	n, err := r.reader.Read(dst)
+	if n > 0 {
+		now = r.peer.readPolicy.now()
+		r.peer.readProgressMu.Lock()
+		if r.peer.readProgress.id == r.frameID && r.peer.readProgress.active {
+			r.peer.readProgress.lastProgress = now
+		}
+		r.peer.readProgressMu.Unlock()
+		if !r.deadline.IsZero() && !now.Before(r.deadline) {
+			return n, ErrFrameReadTooSlow
+		}
+	}
+	return n, err
+}
+
+func (r *frameProgressReader) finish(success bool, now time.Time) {
+	r.peer.readProgressMu.Lock()
+	if r.peer.readProgress.id != r.frameID {
+		r.peer.readProgressMu.Unlock()
+		return
+	}
+	lastProgress := r.peer.readProgress.lastProgress
+	r.peer.readProgress.active = false
+	if success {
+		r.peer.latencyMu.Lock()
+		for seq, ping := range r.peer.pingsInFlight {
+			if lastProgress.After(ping.sentAt) && now.Before(ping.progressDeadline) {
+				ping.deferUntil = now.Add(r.peer.readPolicy.pingDispatchGrace)
+				if ping.progressDeadline.Before(ping.deferUntil) {
+					ping.deferUntil = ping.progressDeadline
+				}
+				r.peer.pingsInFlight[seq] = ping
+			}
+		}
+		r.peer.latencyMu.Unlock()
+	}
+	r.peer.readProgressMu.Unlock()
+}
+
+func (p *Peer) frameProgressBlocksPing(progress inboundFrameProgress, ping pingInFlight, now time.Time) bool {
+	return progress.active &&
+		now.Before(ping.progressDeadline) &&
+		!progress.deadline.IsZero() && now.Before(progress.deadline) &&
+		progress.lastProgress.After(ping.sentAt) &&
+		now.Sub(progress.lastProgress) < p.readPolicy.idleTimeout
+}
+
 func (p *Peer) readLoop(ctx context.Context) error {
 	for {
 		select {
@@ -851,18 +992,25 @@ func (p *Peer) readLoop(ctx context.Context) error {
 			return ErrConnectionClosed
 		}
 
-		// Refresh the read deadline each iteration so a peer that goes
-		// silent post-handshake cannot park us in io.ReadFull forever.
-		if conn != nil {
-			_ = conn.SetReadDeadline(time.Now().Add(readIdleDeadline))
+		frameReader := p.newFrameProgressReader(reader, conn)
+		header, payload, err := readMessageWithHeader(frameReader, frameReader.setHeader)
+		now := p.readPolicy.now()
+		if err == nil && !frameReader.deadline.IsZero() && !now.Before(frameReader.deadline) {
+			err = ErrFrameReadTooSlow
 		}
-
-		header, payload, err := ReadMessage(reader)
+		frameReader.finish(err == nil, now)
 		if err != nil {
 			if p.closed.Load() {
 				return nil
 			}
-			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			if errors.Is(err, ErrFrameReadTooSlow) {
+				return ErrFrameReadTooSlow
+			}
+			var ne net.Error
+			if errors.As(err, &ne) && ne.Timeout() {
+				if frameReader.budgetDeadlineArmed {
+					return ErrFrameReadTooSlow
+				}
 				return ErrReadIdle
 			}
 			// Over-budget size claim is protocol abuse — charge so the
@@ -1004,11 +1152,12 @@ func (p *Peer) pingLoop(ctx context.Context) error {
 }
 
 func (p *Peer) runPingTick(now time.Time) error {
-	if seq, age, ok := p.staleInFlightPing(now, pingTimeout); ok {
+	timeoutSeq, age, stale, deferred := p.pingTimeoutStatus(now, pingTimeout)
+	if stale {
 		slog.Warn("peer ping timeout",
 			"t", "Peer", "peer", p.id,
 			"endpoint", p.endpoint.String(),
-			"seq", seq, "age", age,
+			"seq", timeoutSeq, "age", age,
 		)
 		return ErrPingTimeout
 	}
@@ -1020,6 +1169,9 @@ func (p *Peer) runPingTick(now time.Time) error {
 			"intervals", p.largeSendQ.Load(),
 		)
 		return ErrLargeSendQueue
+	}
+	if deferred {
+		return nil
 	}
 	// Probe at rippled's 60s peerTimerInterval cadence; the finer 15s tick
 	// serves only the stale-ping and send-queue checks above. Peers charge
@@ -1083,43 +1235,63 @@ const (
 	// a peer that completes the handshake then goes silent. Set above
 	// pingTimeout so the existing disconnect path stays primary.
 	readIdleDeadline = pingTimeout + 5*time.Second
+	// minimumFrameReadRate bounds how long a claimed payload allocation
+	// may remain pinned while still allowing bulk frames to take several
+	// minutes. The idle allowance is added once as burst tolerance.
+	minimumFrameReadRate int64 = 256 * 1024
 	// writeIdleDeadline bounds a single conn.Write so a half-open TCP
 	// peer with a never-draining kernel send buffer cannot pin
 	// writeLoop forever.
 	writeIdleDeadline = 10 * time.Second
 )
 
-func (p *Peer) staleInFlightPing(now time.Time, threshold time.Duration) (seq uint32, age time.Duration, ok bool) {
+func (p *Peer) pingTimeoutStatus(now time.Time, threshold time.Duration) (seq uint32, age time.Duration, stale, deferred bool) {
+	p.readProgressMu.RLock()
 	p.latencyMu.RLock()
-	defer p.latencyMu.RUnlock()
 	var (
 		oldestSeq  uint32
-		oldestSent time.Time
+		oldestPing pingInFlight
 		have       bool
 	)
-	for s, t := range p.pingsInFlight {
-		if !have || t.Before(oldestSent) {
+	for s, ping := range p.pingsInFlight {
+		if !have || ping.sentAt.Before(oldestPing.sentAt) {
 			oldestSeq = s
-			oldestSent = t
+			oldestPing = ping
 			have = true
 		}
 	}
+	progress := p.readProgress
+	p.latencyMu.RUnlock()
+	p.readProgressMu.RUnlock()
 	if !have {
-		return 0, 0, false
+		return 0, 0, false, false
 	}
-	age = now.Sub(oldestSent)
+	age = now.Sub(oldestPing.sentAt)
 	if age < threshold {
-		return 0, 0, false
+		return 0, 0, false, false
 	}
-	return oldestSeq, age, true
+	if now.Before(oldestPing.deferUntil) ||
+		p.frameProgressBlocksPing(progress, oldestPing, now) {
+		return oldestSeq, age, false, true
+	}
+	return oldestSeq, age, true, false
+}
+
+func (p *Peer) staleInFlightPing(now time.Time, threshold time.Duration) (seq uint32, age time.Duration, ok bool) {
+	seq, age, ok, _ = p.pingTimeoutStatus(now, threshold)
+	return
 }
 
 func (p *Peer) recordPingSent(seq uint32, sentAt time.Time) {
+	p.readProgressMu.RLock()
 	p.latencyMu.Lock()
-	defer p.latencyMu.Unlock()
+	defer func() {
+		p.latencyMu.Unlock()
+		p.readProgressMu.RUnlock()
+	}()
 	cutoff := sentAt.Add(-pingInFlightTTL)
-	for k, t := range p.pingsInFlight {
-		if t.Before(cutoff) {
+	for k, ping := range p.pingsInFlight {
+		if ping.sentAt.Before(cutoff) {
 			delete(p.pingsInFlight, k)
 		}
 	}
@@ -1129,10 +1301,10 @@ func (p *Peer) recordPingSent(seq uint32, sentAt time.Time) {
 			oldestTime time.Time
 			haveOldest bool
 		)
-		for k, t := range p.pingsInFlight {
-			if !haveOldest || t.Before(oldestTime) {
+		for k, ping := range p.pingsInFlight {
+			if !haveOldest || ping.sentAt.Before(oldestTime) {
 				oldestKey = k
-				oldestTime = t
+				oldestTime = ping.sentAt
 				haveOldest = true
 			}
 		}
@@ -1140,7 +1312,10 @@ func (p *Peer) recordPingSent(seq uint32, sentAt time.Time) {
 			delete(p.pingsInFlight, oldestKey)
 		}
 	}
-	p.pingsInFlight[seq] = sentAt
+	p.pingsInFlight[seq] = pingInFlight{
+		sentAt:           sentAt,
+		progressDeadline: sentAt.Add(p.frameReadBudget(MaxMessageSize)),
+	}
 }
 
 // roundMillisHalfEven rounds d to the nearest millisecond, breaking
@@ -1177,17 +1352,17 @@ func roundMillisHalfEven(d time.Duration) time.Duration {
 func (p *Peer) OnPong(seq uint32, receivedAt time.Time) {
 	p.latencyMu.Lock()
 	defer p.latencyMu.Unlock()
-	sentAt, ok := p.pingsInFlight[seq]
+	ping, ok := p.pingsInFlight[seq]
 	if !ok {
 		return
 	}
 	delete(p.pingsInFlight, seq)
-	for s, t := range p.pingsInFlight {
-		if !t.After(sentAt) {
+	for s, pending := range p.pingsInFlight {
+		if !pending.sentAt.After(ping.sentAt) {
 			delete(p.pingsInFlight, s)
 		}
 	}
-	rtt := roundMillisHalfEven(receivedAt.Sub(sentAt))
+	rtt := roundMillisHalfEven(receivedAt.Sub(ping.sentAt))
 	if !p.hasLatency {
 		p.latency = rtt
 		p.hasLatency = true

--- a/internal/peermanagement/peer_frame_liveness_test.go
+++ b/internal/peermanagement/peer_frame_liveness_test.go
@@ -1,0 +1,374 @@
+package peermanagement
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type livenessClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *livenessClock) current() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *livenessClock) advance(d time.Duration) time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+	return c.now
+}
+
+type connReadStep struct {
+	after time.Duration
+	data  []byte
+	err   error
+}
+
+type chunkedLivenessConn struct {
+	clock *livenessClock
+	steps []connReadStep
+
+	mu           sync.Mutex
+	readDeadline time.Time
+	deadlines    []time.Time
+}
+
+func (c *chunkedLivenessConn) Read(dst []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.steps) == 0 {
+		return 0, io.EOF
+	}
+	step := &c.steps[0]
+	next := c.clock.current().Add(step.after)
+	if !c.readDeadline.IsZero() && !next.Before(c.readDeadline) {
+		c.clock.advance(c.readDeadline.Sub(c.clock.current()))
+		return 0, livenessTimeoutError{}
+	}
+	c.clock.advance(step.after)
+	step.after = 0
+	n := copy(dst, step.data)
+	step.data = step.data[n:]
+	if len(step.data) > 0 {
+		return n, nil
+	}
+	err := step.err
+	c.steps = c.steps[1:]
+	return n, err
+}
+
+func (c *chunkedLivenessConn) Write(src []byte) (int, error) { return len(src), nil }
+func (c *chunkedLivenessConn) Close() error                  { return nil }
+func (c *chunkedLivenessConn) LocalAddr() net.Addr           { return livenessAddr("local") }
+func (c *chunkedLivenessConn) RemoteAddr() net.Addr          { return livenessAddr("remote") }
+func (c *chunkedLivenessConn) SetDeadline(time.Time) error   { return nil }
+func (c *chunkedLivenessConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+func (c *chunkedLivenessConn) SetReadDeadline(deadline time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.readDeadline = deadline
+	c.deadlines = append(c.deadlines, deadline)
+	return nil
+}
+
+type livenessAddr string
+
+func (a livenessAddr) Network() string { return string(a) }
+func (a livenessAddr) String() string  { return string(a) }
+
+type livenessTimeoutError struct{}
+
+func (livenessTimeoutError) Error() string   { return "i/o timeout" }
+func (livenessTimeoutError) Timeout() bool   { return true }
+func (livenessTimeoutError) Temporary() bool { return true }
+
+func newFrameLivenessPeer(t *testing.T, clock *livenessClock, conn net.Conn) (*Peer, chan Event) {
+	t.Helper()
+	identity, err := NewIdentity()
+	require.NoError(t, err)
+	events := make(chan Event, 4)
+	peer := NewPeer(1, Endpoint{Host: "127.0.0.1", Port: 51235}, false, identity, events)
+	peer.conn = conn
+	peer.bufReader = bufio.NewReader(conn)
+	peer.readPolicy.now = clock.current
+	return peer, events
+}
+
+func manifestFrame(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var frame bytes.Buffer
+	require.NoError(t, message.WriteMessage(&frame, message.TypeManifests, payload))
+	return frame.Bytes()
+}
+
+func TestPeerReadLoopAllowsProgressBeyondIdleInterval(t *testing.T) {
+	clock := &livenessClock{now: time.Unix(1_000, 0)}
+	frame := manifestFrame(t, []byte("manifest"))
+	conn := &chunkedLivenessConn{
+		clock: clock,
+		steps: []connReadStep{
+			{after: 3 * time.Second, data: frame[:3]},
+			{after: 3 * time.Second, data: frame[3:6]},
+			{after: 3 * time.Second, data: frame[6:10]},
+			{after: 3 * time.Second, data: frame[10:]},
+			{err: io.EOF},
+		},
+	}
+	peer, events := newFrameLivenessPeer(t, clock, conn)
+	peer.readPolicy.idleTimeout = 5 * time.Second
+	peer.readPolicy.minimumFrameRate = 1
+
+	err := peer.readLoop(context.Background())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, io.EOF))
+	require.Len(t, events, 1)
+	event := <-events
+	assert.Equal(t, uint16(message.TypeManifests), event.MessageType)
+	assert.Equal(t, []byte("manifest"), event.Payload)
+	assert.Equal(t, 12*time.Second, clock.current().Sub(time.Unix(1_000, 0)))
+	require.GreaterOrEqual(t, len(conn.deadlines), 4)
+	for i := 1; i < 4; i++ {
+		assert.True(t, conn.deadlines[i].After(conn.deadlines[i-1]))
+	}
+}
+
+func TestPeerReadLoopClassifiesWrappedMidFrameTimeoutAsReadIdle(t *testing.T) {
+	clock := &livenessClock{now: time.Unix(2_000, 0)}
+	frame := manifestFrame(t, []byte("manifest"))
+	conn := &chunkedLivenessConn{
+		clock: clock,
+		steps: []connReadStep{
+			{data: frame[:6]},
+			{after: time.Second, data: frame[6:10]},
+			{after: 10 * time.Second, data: frame[10:]},
+		},
+	}
+	peer, _ := newFrameLivenessPeer(t, clock, conn)
+	peer.readPolicy.idleTimeout = 5 * time.Second
+	peer.readPolicy.minimumFrameRate = 1
+
+	err := peer.readLoop(context.Background())
+	require.ErrorIs(t, err, ErrReadIdle)
+}
+
+func TestPeerReadLoopRejectsTricklePastFrameBudget(t *testing.T) {
+	clock := &livenessClock{now: time.Unix(3_000, 0)}
+	frame := manifestFrame(t, []byte("slow"))
+	conn := &chunkedLivenessConn{
+		clock: clock,
+		steps: []connReadStep{
+			{data: frame[:6]},
+			{after: time.Second, data: frame[6:7]},
+			{after: time.Second, data: frame[7:8]},
+			{after: time.Second, data: frame[8:9]},
+			{after: time.Second, data: frame[9:]},
+		},
+	}
+	peer, events := newFrameLivenessPeer(t, clock, conn)
+	peer.readPolicy.idleTimeout = 2 * time.Second
+	peer.readPolicy.minimumFrameRate = 2
+
+	err := peer.readLoop(context.Background())
+	require.ErrorIs(t, err, ErrFrameReadTooSlow)
+	assert.Empty(t, events)
+}
+
+func TestPeerPingTimeoutDefersOnlyForBlockingFrame(t *testing.T) {
+	clock := &livenessClock{now: time.Unix(4_000, 0)}
+	peer := newLatencyTestPeer(t)
+	peer.readPolicy.now = clock.current
+	peer.readPolicy.idleTimeout = readIdleDeadline
+	peer.readPolicy.minimumFrameRate = 1
+	reader := peer.newFrameProgressReader(bytes.NewReader([]byte{1, 2}), nil)
+	require.NoError(t, reader.setHeader(MessageHeader{PayloadSize: 100}))
+
+	clock.advance(time.Second)
+	buf := make([]byte, 1)
+	_, err := reader.Read(buf)
+	require.NoError(t, err)
+	sentAt := clock.current()
+	peer.recordPingSent(7, sentAt)
+
+	clock.advance(time.Second)
+	_, err = reader.Read(buf)
+	require.NoError(t, err)
+	clock.advance(pingTimeout - time.Second)
+
+	require.NoError(t, peer.runPingTick(clock.current()))
+	assert.Empty(t, peer.send)
+	reader.finish(true, clock.current())
+	require.NoError(t, peer.runPingTick(clock.current()))
+
+	peer.OnPong(7, clock.current().Add(time.Millisecond))
+	_, _, stale := peer.staleInFlightPing(clock.current().Add(time.Hour), pingTimeout)
+	assert.False(t, stale)
+}
+
+func TestPeerPingSentBeforeFrameUsesNextFrameProgress(t *testing.T) {
+	clock := &livenessClock{now: time.Unix(4_500, 0)}
+	peer := newLatencyTestPeer(t)
+	peer.readPolicy.now = clock.current
+	peer.readPolicy.idleTimeout = readIdleDeadline
+	peer.readPolicy.minimumFrameRate = 1
+	sentAt := clock.current()
+	peer.recordPingSent(8, sentAt)
+
+	reader := peer.newFrameProgressReader(bytes.NewReader([]byte{1}), nil)
+	require.NoError(t, reader.setHeader(MessageHeader{PayloadSize: 100}))
+	clock.advance(time.Second)
+	_, err := reader.Read(make([]byte, 1))
+	require.NoError(t, err)
+	clock.advance(pingTimeout - time.Second)
+
+	_, _, stale, deferred := peer.pingTimeoutStatus(clock.current(), pingTimeout)
+	assert.False(t, stale)
+	assert.True(t, deferred)
+}
+
+func TestPeerStoppedFrameProgressNoLongerDefersPing(t *testing.T) {
+	clock := &livenessClock{now: time.Unix(4_600, 0)}
+	peer := newLatencyTestPeer(t)
+	peer.readPolicy.now = clock.current
+	peer.readPolicy.idleTimeout = readIdleDeadline
+	peer.readPolicy.minimumFrameRate = 1
+	sentAt := clock.current()
+	peer.recordPingSent(8, sentAt)
+
+	reader := peer.newFrameProgressReader(bytes.NewReader([]byte{1}), nil)
+	require.NoError(t, reader.setHeader(MessageHeader{PayloadSize: 100}))
+	clock.advance(time.Second)
+	_, err := reader.Read(make([]byte, 1))
+	require.NoError(t, err)
+	clock.advance(readIdleDeadline)
+
+	_, _, stale, deferred := peer.pingTimeoutStatus(clock.current(), pingTimeout)
+	assert.True(t, stale)
+	assert.False(t, deferred)
+}
+
+func TestPeerCompletedFrameGraceExpiresWithoutPong(t *testing.T) {
+	clock := &livenessClock{now: time.Unix(4_700, 0)}
+	peer := newLatencyTestPeer(t)
+	peer.readPolicy.now = clock.current
+	peer.readPolicy.idleTimeout = readIdleDeadline
+	peer.readPolicy.minimumFrameRate = 1
+	sentAt := clock.current()
+	peer.recordPingSent(8, sentAt)
+
+	reader := peer.newFrameProgressReader(bytes.NewReader([]byte{1}), nil)
+	require.NoError(t, reader.setHeader(MessageHeader{PayloadSize: 100}))
+	clock.advance(time.Second)
+	_, err := reader.Read(make([]byte, 1))
+	require.NoError(t, err)
+	clock.advance(pingTimeout - time.Second)
+	reader.finish(true, clock.current())
+
+	_, _, stale, deferred := peer.pingTimeoutStatus(clock.current(), pingTimeout)
+	assert.False(t, stale)
+	assert.True(t, deferred)
+	clock.advance(peer.readPolicy.pingDispatchGrace)
+	_, _, stale, deferred = peer.pingTimeoutStatus(clock.current(), pingTimeout)
+	assert.True(t, stale)
+	assert.False(t, deferred)
+}
+
+func TestPeerReadLoopDispatchesPongBehindSlowFrame(t *testing.T) {
+	clock := &livenessClock{now: time.Unix(4_800, 0)}
+	manifest := manifestFrame(t, []byte("manifest"))
+	pong, err := message.EncodeFrame(&message.Ping{PType: message.PingTypePong, Seq: 11})
+	require.NoError(t, err)
+	conn := &chunkedLivenessConn{
+		clock: clock,
+		steps: []connReadStep{
+			{data: manifest[:6]},
+			{after: 30 * time.Second, data: manifest[6:10]},
+			{after: 30 * time.Second, data: manifest[10:]},
+			{after: time.Second, data: pong},
+			{err: io.EOF},
+		},
+	}
+	peer, events := newFrameLivenessPeer(t, clock, conn)
+	peer.readPolicy.minimumFrameRate = 1
+	peer.recordPingSent(11, clock.current())
+
+	err = peer.readLoop(context.Background())
+	require.Error(t, err)
+	require.Len(t, events, 2)
+	manifestEvent := <-events
+	pongEvent := <-events
+	assert.Equal(t, uint16(message.TypeManifests), manifestEvent.MessageType)
+	assert.Equal(t, uint16(message.TypePing), pongEvent.MessageType)
+	decoded, err := message.Decode(message.TypePing, pongEvent.Payload)
+	require.NoError(t, err)
+	peer.OnPong(decoded.(*message.Ping).Seq, clock.current())
+	_, _, stale := peer.staleInFlightPing(clock.current().Add(time.Hour), pingTimeout)
+	assert.False(t, stale)
+}
+
+func TestPeerConsecutiveFramesDeferPingWithinProgressBudget(t *testing.T) {
+	clock := &livenessClock{now: time.Unix(5_000, 0)}
+	peer := newLatencyTestPeer(t)
+	peer.readPolicy.now = clock.current
+	peer.readPolicy.idleTimeout = readIdleDeadline
+	peer.readPolicy.minimumFrameRate = 1
+
+	first := peer.newFrameProgressReader(bytes.NewReader([]byte{1}), nil)
+	require.NoError(t, first.setHeader(MessageHeader{PayloadSize: 1}))
+	sentAt := clock.current()
+	peer.recordPingSent(9, sentAt)
+	clock.advance(time.Second)
+	_, err := first.Read(make([]byte, 1))
+	require.NoError(t, err)
+	first.finish(true, clock.current())
+
+	second := peer.newFrameProgressReader(bytes.NewReader([]byte{2}), nil)
+	require.NoError(t, second.setHeader(MessageHeader{PayloadSize: 100}))
+	clock.advance(pingTimeout)
+	_, err = second.Read(make([]byte, 1))
+	require.NoError(t, err)
+
+	_, _, stale, deferred := peer.pingTimeoutStatus(clock.current(), pingTimeout)
+	assert.False(t, stale)
+	assert.True(t, deferred)
+}
+
+func TestPeerConsecutiveFramesCannotExtendPingPastProgressBudget(t *testing.T) {
+	clock := &livenessClock{now: time.Unix(5_500, 0)}
+	peer := newLatencyTestPeer(t)
+	peer.readPolicy.now = clock.current
+	peer.readPolicy.idleTimeout = readIdleDeadline
+	peer.readPolicy.minimumFrameRate = 1
+	sentAt := clock.current()
+	peer.recordPingSent(10, sentAt)
+
+	budget := peer.frameReadBudget(MaxMessageSize)
+	clock.advance(budget - time.Second)
+	reader := peer.newFrameProgressReader(bytes.NewReader([]byte{1}), nil)
+	require.NoError(t, reader.setHeader(MessageHeader{PayloadSize: MaxMessageSize}))
+	_, err := reader.Read(make([]byte, 1))
+	require.NoError(t, err)
+	clock.advance(time.Second)
+
+	seq, _, stale, deferred := peer.pingTimeoutStatus(clock.current(), pingTimeout)
+	require.True(t, stale)
+	assert.False(t, deferred)
+	assert.Equal(t, uint32(10), seq)
+}


### PR DESCRIPTION
## Summary

- refresh peer read deadlines after each successful partial frame read instead of measuring total frame duration as idle time
- bound slow readers with a 65-second progress-gap limit plus a payload-size budget based on 256 KiB/s
- defer PING timeout while ordered inbound frames are actively progressing, within a fixed non-renewable window, then resume normal PONG handling
- classify wrapped socket timeouts with `errors.As` and preserve pre-allocation frame-size validation

## Rippled v3.2.0 oracle

Verified against the clean local `3.2.0` oracle at `3c43f4614f87965298773279ff5b85d4c56c637b`.

Rippled accumulates frames through repeated `async_read_some` calls, applies no read timeout, dispatches only complete ordered frames, and enforces the same 64 MiB ceiling. The refreshed idle deadline restores the equivalent progressing-frame outcome. The finite read budget and progress-aware PING deferral are deliberate resource/liveness hardening beyond rippled.

## Verification

- `go test -race ./internal/peermanagement ./internal/peermanagement/message -count=1`
- `just test-pkg ./internal/peermanagement/...`
- `just lint`
- `just vet`
- `just build`

`just test` passes the peer, P2P, and ordinary package suites, then encounters the repository's existing broad conformance backlog. The representative Vault failure `disabled_permissioned_domain` reproduces unchanged on untouched `origin/main`.

Closes #1389
