### PR TITLE
p2p: apply negotiated compression to outbound frames

### DIFF
--- a/internal/peermanagement/errors.go
+++ b/internal/peermanagement/errors.go
@@ -48,6 +48,8 @@ var (
 	ErrShutdown   = errors.New("overlay is shutting down")
 )
 
+var errCompressionUnnegotiated = errors.New("outbound compressed frame without negotiated compression")
+
 // PeerError wraps an error with peer context.
 type PeerError struct {
 	PeerID   PeerID

--- a/internal/peermanagement/message/compression.go
+++ b/internal/peermanagement/message/compression.go
@@ -63,7 +63,16 @@ func DecompressLZ4(compressed []byte, uncompressedSize int) ([]byte, error) {
 // matching the set rippled compresses.
 func ShouldCompress(msgType uint16) bool {
 	switch msgType {
-	case 2, 15, 30, 31, 32, 42, 54, 56, 60, 64:
+	case uint16(TypeManifests),
+		uint16(TypeEndpoints),
+		uint16(TypeTransaction),
+		uint16(TypeGetLedger),
+		uint16(TypeLedgerData),
+		uint16(TypeGetObjects),
+		uint16(TypeValidatorList),
+		uint16(TypeValidatorListCollection),
+		uint16(TypeReplayDeltaResponse),
+		uint16(TypeTransactions):
 		return true
 	default:
 		return false
@@ -82,6 +91,45 @@ func CompressIfWorthwhile(msgType uint16, data []byte) ([]byte, bool) {
 	if err != nil || compressed == nil {
 		return data, false
 	}
+	if len(compressed)+HeaderSizeCompressed >= len(data)+HeaderSizeUncompressed {
+		return data, false
+	}
 
 	return compressed, true
+}
+
+// CompressFrameIfWorthwhile returns an LZ4 wire representation when frame is
+// one complete uncompressed message and compression reduces its total size.
+// The input is never modified.
+func CompressFrameIfWorthwhile(frame []byte) ([]byte, bool) {
+	header, err := DecodeHeader(frame)
+	if err != nil || header.Compressed {
+		return frame, false
+	}
+
+	payloadSize := int(header.PayloadSize)
+	if payloadSize != len(frame)-HeaderSizeUncompressed {
+		return frame, false
+	}
+
+	payload, compressed := CompressIfWorthwhile(
+		uint16(header.MessageType),
+		frame[HeaderSizeUncompressed:],
+	)
+	if !compressed {
+		return frame, false
+	}
+
+	wire := make([]byte, HeaderSizeCompressed+len(payload))
+	if err := EncodeHeader(
+		wire,
+		uint32(len(payload)),
+		header.MessageType,
+		AlgorithmLZ4,
+		header.PayloadSize,
+	); err != nil {
+		return frame, false
+	}
+	copy(wire[HeaderSizeCompressed:], payload)
+	return wire, true
 }

--- a/internal/peermanagement/message/outbound_compression_test.go
+++ b/internal/peermanagement/message/outbound_compression_test.go
@@ -1,0 +1,129 @@
+package message
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompressFrameIfWorthwhilePolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		msgType  MessageType
+		payload  []byte
+		compress bool
+	}{
+		{
+			name:     "exactly 70 bytes",
+			msgType:  TypeManifests,
+			payload:  bytes.Repeat([]byte{'A'}, MinCompressibleSize),
+			compress: false,
+		},
+		{
+			name:     "eligible and compressible",
+			msgType:  TypeManifests,
+			payload:  bytes.Repeat([]byte("manifest"), 512),
+			compress: true,
+		},
+		{
+			name:     "ineligible",
+			msgType:  TypePing,
+			payload:  bytes.Repeat([]byte{'A'}, 4096),
+			compress: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			frame, err := BuildWireMessage(tt.msgType, tt.payload)
+			require.NoError(t, err)
+			original := bytes.Clone(frame)
+
+			wire, compressed := CompressFrameIfWorthwhile(frame)
+
+			assert.Equal(t, tt.compress, compressed)
+			assert.Equal(t, original, frame)
+			if !tt.compress {
+				assert.Equal(t, frame, wire)
+				return
+			}
+
+			header, err := DecodeHeader(wire)
+			require.NoError(t, err)
+			assert.True(t, header.Compressed)
+			assert.Equal(t, tt.msgType, header.MessageType)
+			assert.Equal(t, uint32(len(tt.payload)), header.UncompressedSize)
+			assert.Less(t, len(wire), len(frame))
+
+			decoded, err := DecompressLZ4(wire[HeaderSizeCompressed:], len(tt.payload))
+			require.NoError(t, err)
+			assert.Equal(t, tt.payload, decoded)
+		})
+	}
+}
+
+func TestShouldCompressMatchesRippledMessageTypes(t *testing.T) {
+	eligible := []MessageType{
+		TypeManifests,
+		TypeEndpoints,
+		TypeTransaction,
+		TypeGetLedger,
+		TypeLedgerData,
+		TypeGetObjects,
+		TypeValidatorList,
+		TypeValidatorListCollection,
+		TypeReplayDeltaResponse,
+		TypeTransactions,
+	}
+	for _, msgType := range eligible {
+		assert.True(t, ShouldCompress(uint16(msgType)), msgType.String())
+	}
+
+	for _, msgType := range []MessageType{TypePing, TypeSquelch, TypeValidation, TypeReplayDeltaReq} {
+		assert.False(t, ShouldCompress(uint16(msgType)), msgType.String())
+	}
+}
+
+func TestCompressIfWorthwhileAccountsForCompressedHeader(t *testing.T) {
+	rng := rand.New(rand.NewSource(1392))
+	base := make([]byte, 512)
+	_, err := rng.Read(base)
+	require.NoError(t, err)
+
+	var payload []byte
+	var compressed []byte
+	for repeated := 4; repeated < len(base); repeated++ {
+		candidate := bytes.Clone(base)
+		copy(candidate[len(candidate)-repeated:], candidate[:repeated])
+		encoded, err := CompressLZ4(candidate)
+		require.NoError(t, err)
+		if encoded != nil && len(encoded)+HeaderSizeCompressed >= len(candidate)+HeaderSizeUncompressed {
+			payload = candidate
+			compressed = encoded
+			break
+		}
+	}
+	require.NotNil(t, payload, "test fixture must compress without saving the longer header")
+	require.Less(t, len(compressed), len(payload))
+
+	selected, ok := CompressIfWorthwhile(uint16(TypeManifests), payload)
+
+	assert.False(t, ok)
+	assert.Equal(t, payload, selected)
+}
+
+func TestCompressFrameIfWorthwhileLeavesIncompressiblePayloadUnchanged(t *testing.T) {
+	payload := make([]byte, 4096)
+	_, err := rand.New(rand.NewSource(1392)).Read(payload)
+	require.NoError(t, err)
+	frame, err := BuildWireMessage(TypeManifests, payload)
+	require.NoError(t, err)
+
+	wire, compressed := CompressFrameIfWorthwhile(frame)
+
+	assert.False(t, compressed)
+	assert.Equal(t, frame, wire)
+}

--- a/internal/peermanagement/outbound_compression_test.go
+++ b/internal/peermanagement/outbound_compression_test.go
@@ -1,0 +1,143 @@
+package peermanagement
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type peerWriter struct {
+	remote net.Conn
+	errs   <-chan error
+}
+
+func startPeerWriter(t *testing.T, peer *Peer) peerWriter {
+	t.Helper()
+	local, remote := net.Pipe()
+	peer.mu.Lock()
+	peer.conn = local
+	peer.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errs := make(chan error, 1)
+	go func() {
+		errs <- peer.writeLoop(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		_ = local.Close()
+		_ = remote.Close()
+	})
+	return peerWriter{remote: remote, errs: errs}
+}
+
+func readWireFrame(t *testing.T, conn net.Conn) []byte {
+	t.Helper()
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	prefix := make([]byte, message.HeaderSizeUncompressed)
+	_, err := io.ReadFull(conn, prefix)
+	require.NoError(t, err)
+
+	headerBytes := prefix
+	if prefix[0]&0x80 != 0 {
+		headerBytes = make([]byte, message.HeaderSizeCompressed)
+		copy(headerBytes, prefix)
+		_, err = io.ReadFull(conn, headerBytes[message.HeaderSizeUncompressed:])
+		require.NoError(t, err)
+	}
+
+	header, err := message.DecodeHeader(headerBytes)
+	require.NoError(t, err)
+	payload := make([]byte, header.PayloadSize)
+	_, err = io.ReadFull(conn, payload)
+	require.NoError(t, err)
+	return append(headerBytes, payload...)
+}
+
+func newOutboundCompressionPeer(id PeerID, negotiated bool) *Peer {
+	peer := NewPeer(id, Endpoint{Host: "127.0.0.1", Port: 51235}, false, nil, nil)
+	peer.setState(PeerStateConnected)
+	peer.handshakeCfg.EnableCompression = true
+	peer.capabilities = NewPeerCapabilities()
+	if negotiated {
+		peer.capabilities.Features.Enable(FeatureCompression)
+	}
+	return peer
+}
+
+func TestBroadcastSelectsOutboundCompressionPerPeer(t *testing.T) {
+	compressedPeer := newOutboundCompressionPeer(1, true)
+	plainPeer := newOutboundCompressionPeer(2, false)
+	compressedWriter := startPeerWriter(t, compressedPeer)
+	plainWriter := startPeerWriter(t, plainPeer)
+	overlay := newTestOverlayWithPeers(map[PeerID]*Peer{
+		compressedPeer.ID(): compressedPeer,
+		plainPeer.ID():      plainPeer,
+	})
+
+	frame, err := message.EncodeFrame(&message.Manifests{
+		List: []message.Manifest{{STObject: bytes.Repeat([]byte("manifest"), 2048)}},
+	})
+	require.NoError(t, err)
+	original := bytes.Clone(frame)
+	require.NoError(t, overlay.Broadcast(frame))
+
+	compressedWire := readWireFrame(t, compressedWriter.remote)
+	plainWire := readWireFrame(t, plainWriter.remote)
+	assert.Equal(t, original, frame, "broadcast input must remain immutable")
+	assert.Equal(t, frame, plainWire)
+
+	header, err := message.DecodeHeader(compressedWire)
+	require.NoError(t, err)
+	require.True(t, header.Compressed)
+	assert.Equal(t, message.TypeManifests, header.MessageType)
+	assert.Less(t, len(compressedWire), len(frame))
+
+	payload, err := message.DecompressLZ4(
+		compressedWire[message.HeaderSizeCompressed:],
+		int(header.UncompressedSize),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, frame[message.HeaderSizeUncompressed:], payload)
+
+	require.Eventually(t, func() bool {
+		return compressedPeer.metrics.sent.totalBytesSnapshot() == uint64(len(compressedWire)) &&
+			plainPeer.metrics.sent.totalBytesSnapshot() == uint64(len(plainWire))
+	}, time.Second, time.Millisecond)
+	assert.Equal(t, uint64(len(compressedWire)), compressedPeer.traffic.Stats(CategoryManifests).BytesOut)
+	assert.Equal(t, uint64(len(plainWire)), plainPeer.traffic.Stats(CategoryManifests).BytesOut)
+}
+
+func TestWriteLoopRejectsUnnegotiatedCompressedFrame(t *testing.T) {
+	peer := newOutboundCompressionPeer(1, false)
+	writer := startPeerWriter(t, peer)
+	plain, err := message.BuildWireMessage(
+		message.TypeManifests,
+		bytes.Repeat([]byte("manifest"), 512),
+	)
+	require.NoError(t, err)
+	compressed, ok := message.CompressFrameIfWorthwhile(plain)
+	require.True(t, ok)
+	require.NoError(t, peer.Send(compressed))
+
+	select {
+	case err := <-writer.errs:
+		assert.ErrorIs(t, err, errCompressionUnnegotiated)
+	case <-time.After(time.Second):
+		t.Fatal("write loop did not reject unnegotiated compressed frame")
+	}
+
+	require.NoError(t, writer.remote.SetReadDeadline(time.Now().Add(10*time.Millisecond)))
+	buffer := make([]byte, 1)
+	_, err = writer.remote.Read(buffer)
+	var netErr net.Error
+	require.ErrorAs(t, err, &netErr)
+	assert.True(t, netErr.Timeout())
+}

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -1092,10 +1092,20 @@ func (p *Peer) writeLoop(ctx context.Context) error {
 				return ErrConnectionClosed
 			}
 
+			wire := data
+			compressionEnabled := p.compressionNegotiated()
+			if header, err := message.DecodeHeader(data); err == nil && header.Compressed {
+				if !compressionEnabled {
+					return errCompressionUnnegotiated
+				}
+			} else if compressionEnabled {
+				wire, _ = message.CompressFrameIfWorthwhile(data)
+			}
+
 			// Cap each Write so a half-open TCP peer with a
 			// never-draining kernel send buffer cannot pin the writer.
 			_ = conn.SetWriteDeadline(time.Now().Add(writeIdleDeadline))
-			n, err := conn.Write(data)
+			n, err := conn.Write(wire)
 			if err != nil {
 				if ne, ok := err.(net.Error); ok && ne.Timeout() {
 					return ErrWriteIdle
@@ -1111,7 +1121,7 @@ func (p *Peer) writeLoop(ctx context.Context) error {
 			// reflect outbound traffic (the symmetric counterpart of the
 			// inbound AddCount in readLoop). The frame carries its own
 			// header; decode it to recover the message type.
-			if hdr, derr := message.DecodeHeader(data); derr == nil {
+			if hdr, derr := message.DecodeHeader(wire); derr == nil {
 				p.traffic.AddCount(CategorizeMessage(uint16(hdr.MessageType)), false, n)
 			}
 		}


### PR DESCRIPTION
## Summary

- apply negotiated LZ4 compression in the centralized outbound peer writer
- match rippled v3.2.0's eligible message types, 70-byte threshold, and complete-frame size rule
- preserve FIFO ordering and shared broadcast inputs while selecting the wire representation per peer
- reject precompressed outbound frames when compression was not negotiated
- account metrics using the actual bytes written

## Tests

- `go test ./internal/peermanagement/... ./internal/peermanagement/message/...`
- `go test -race ./internal/peermanagement -run TestBroadcastSelectsOutboundCompressionPerPeer`
- `just build-all`
- `just build-nocgo`
- `just vet`
- `just lint`

`just test` reaches existing unrelated conformance failures in Batch, Vault, NFT, and XChain suites. Running `go test ./internal/testing/conformance` from a clean worktree at base commit `456073c1` reproduces the failures.

Fixes #1392
