### PR TITLE
fix: retarget stale catch-up peers

### DIFF
--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -181,12 +181,12 @@ type Router struct {
 	// startup, before Run.
 	acquisitionFamily shamap.Family
 
-	// catchupMu guards catchup, the single consensus catch-up target: the highest
-	// trusted (seq,hash) seen, toward which at most maxConcurrentCatchup
-	// acquisitions are armed — rippled's LedgerMaster::doAdvance drives one needed
-	// target, not one InboundLedger per gossiped event.
-	catchupMu sync.Mutex
-	catchup   catchupTarget
+	// catchupMu guards the single consensus catch-up target and recent failures.
+	// The router drives at most maxConcurrentCatchup acquisitions toward the
+	// highest trusted (seq,hash), matching rippled's single needed ledger.
+	catchupMu       sync.Mutex
+	catchup         catchupTarget
+	catchupFailures map[[32]byte]time.Time
 
 	// historyMu guards history, the single backward history-backfill target: the
 	// next ledger a jump-adopt skipped (rippled Reason::HISTORY). The walk is
@@ -404,6 +404,7 @@ func (r *Router) HandlePeerDisconnect(peerID peermanagement.PeerID) {
 	r.peersMu.Lock()
 	delete(r.peerStates, peerID)
 	r.peersMu.Unlock()
+	r.invalidateCatchupPeer(uint64(peerID))
 
 	// Clear the peer's LCL vote so getNetworkLedger stops counting its
 	// stale hash. The adaptor uses the zero LedgerID as a delete key.

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -221,15 +221,52 @@ func (r *Router) catchupInFlight() int {
 	return r.fetchTracker.CountReason(inbound.ReasonConsensus) + r.replayer.Count()
 }
 
-// recordCatchupTarget raises the single consensus catch-up target only for a
-// strictly higher seq, so the router always drives toward the highest trusted
-// tip seen — the analogue of rippled's single preferred/needed ledger.
+// recordCatchupTarget raises the single consensus catch-up target or refreshes
+// its preferred peer when another peer advertises the same ledger.
 func (r *Router) recordCatchupTarget(seq uint32, hash [32]byte, peerID uint64) {
 	r.catchupMu.Lock()
 	defer r.catchupMu.Unlock()
 	if seq > r.catchup.seq {
 		r.catchup = catchupTarget{seq: seq, hash: hash, peerID: peerID}
+	} else if seq == r.catchup.seq && hash == r.catchup.hash {
+		r.catchup.peerID = peerID
 	}
+}
+
+func (r *Router) invalidateCatchupPeer(peerID uint64) {
+	r.catchupMu.Lock()
+	defer r.catchupMu.Unlock()
+	if r.catchup.peerID == peerID {
+		r.catchup.peerID = 0
+	}
+}
+
+const catchupFailureCooldown = 5 * time.Minute
+
+func (r *Router) markFailedCatchupAcquisition(hash [32]byte) {
+	r.catchupMu.Lock()
+	defer r.catchupMu.Unlock()
+	if r.catchupFailures == nil {
+		r.catchupFailures = make(map[[32]byte]time.Time)
+	}
+	now := time.Now()
+	for failedHash, retryAfter := range r.catchupFailures {
+		if !now.Before(retryAfter) {
+			delete(r.catchupFailures, failedHash)
+		}
+	}
+	r.catchupFailures[hash] = now.Add(catchupFailureCooldown)
+}
+
+func (r *Router) catchupRetryBlocked(hash [32]byte, now time.Time) bool {
+	r.catchupMu.Lock()
+	defer r.catchupMu.Unlock()
+	retryAfter, ok := r.catchupFailures[hash]
+	if ok && !now.Before(retryAfter) {
+		delete(r.catchupFailures, hash)
+		return false
+	}
+	return ok
 }
 
 // bestCatchupTarget returns the current highest recorded catch-up target.
@@ -251,6 +288,10 @@ func (r *Router) bestCatchupTarget() (seq uint32, hash [32]byte, peerID uint64) 
 //     directly; the legacy full-state path plus completeInboundLedger's gap>1
 //     branch jumps the working ledger forward.
 func (r *Router) armCatchupTowardTarget() {
+	r.armCatchupTowardTargetWithPeer(0)
+}
+
+func (r *Router) armCatchupTowardTargetWithPeer(peerHint uint64) {
 	svc := r.adaptor.LedgerService()
 	if svc == nil {
 		return
@@ -258,7 +299,7 @@ func (r *Router) armCatchupTowardTarget() {
 	if r.catchupInFlight() >= maxConcurrentCatchup {
 		return
 	}
-	tSeq, tHash, tPeer := r.bestCatchupTarget()
+	tSeq, tHash, _ := r.bestCatchupTarget()
 	if tSeq == 0 {
 		return
 	}
@@ -267,14 +308,30 @@ func (r *Router) armCatchupTowardTarget() {
 		return
 	}
 
-	if seq, hash, peer, ok := r.forwardDeltaStep(svc, closed, tSeq); ok {
+	if seq, hash, ok := r.forwardDeltaStep(svc, closed, tSeq); ok {
+		peer := peerHint
+		if peer == 0 {
+			var found bool
+			peer, found = r.selectAcquisitionPeer(seq)
+			if !found {
+				return
+			}
+		}
 		r.startLedgerAcquisition(seq, hash, peer)
 		return
 	}
-	r.startLedgerAcquisition(tSeq, tHash, tPeer)
+	peer := peerHint
+	if peer == 0 {
+		var found bool
+		peer, found = r.selectAcquisitionPeer(tSeq)
+		if !found {
+			return
+		}
+	}
+	r.startLedgerAcquisition(tSeq, tHash, peer)
 }
 
-// forwardDeltaStep returns the (seq, hash, peer) for a forward one-ledger step
+// forwardDeltaStep returns the (seq, hash) for a forward one-ledger step
 // against our held closed ledger when all hold, else ok=false (deferring to
 // jump-adopt):
 //
@@ -284,18 +341,18 @@ func (r *Router) armCatchupTowardTarget() {
 //     recorded parentHash equals our closed hash, or, when only a validation
 //     populated closed+1, the recorded hash for our closed seq equals it. The
 //     parent of closed+1 IS the ledger at our closed seq, so these are equivalent.
-func (r *Router) forwardDeltaStep(svc *service.Service, closed, tipSeq uint32) (seq uint32, hash [32]byte, peer uint64, ok bool) {
+func (r *Router) forwardDeltaStep(svc *service.Service, closed, tipSeq uint32) (seq uint32, hash [32]byte, ok bool) {
 	if tipSeq-closed > maxForwardDeltaGap {
-		return 0, [32]byte{}, 0, false
+		return 0, [32]byte{}, false
 	}
 	next := closed + 1
 	entry, known := r.lookupSeqHash(next)
 	if !known || entry.hash == ([32]byte{}) {
-		return 0, [32]byte{}, 0, false
+		return 0, [32]byte{}, false
 	}
 	closedLedger := svc.GetClosedLedger()
 	if closedLedger == nil {
-		return 0, [32]byte{}, 0, false
+		return 0, [32]byte{}, false
 	}
 	closedHash := closedLedger.Hash()
 
@@ -306,19 +363,9 @@ func (r *Router) forwardDeltaStep(svc *service.Service, closed, tipSeq uint32) (
 		sameBranch = cEntry.hash == closedHash
 	}
 	if !sameBranch {
-		return 0, [32]byte{}, 0, false
+		return 0, [32]byte{}, false
 	}
-	return next, entry.hash, r.forwardStepPeer(next), true
-}
-
-// forwardStepPeer picks a peer for a forward-delta step: one reporting at or
-// beyond the target seq, else the peer that advertised the best tip.
-func (r *Router) forwardStepPeer(seq uint32) uint64 {
-	if p, ok := r.selectAcquisitionPeer(seq); ok {
-		return p
-	}
-	_, _, peer := r.bestCatchupTarget()
-	return peer
+	return next, entry.hash, true
 }
 
 // ensureCatchupAcquisition is the single funnel for gossip-driven consensus
@@ -336,7 +383,21 @@ func (r *Router) ensureCatchupAcquisition(seq uint32, hash [32]byte, peerID uint
 		return
 	}
 	r.recordCatchupTarget(seq, hash, peerID)
-	r.armCatchupTowardTarget()
+	if il := r.fetchTracker.Find(hash); il != nil && il.Reason() == inbound.ReasonConsensus {
+		r.refreshCatchupAcquisitionPeer(il, peerID)
+		return
+	}
+	r.armCatchupTowardTargetWithPeer(peerID)
+}
+
+func (r *Router) refreshCatchupAcquisitionPeer(il *inbound.Ledger, peerID uint64) {
+	if peerID == 0 || il.State() != inbound.StateWantBase || slices.Contains(il.Peers(), peerID) {
+		return
+	}
+	il.AddPeer(peerID)
+	if err := r.adaptor.RequestLedgerBaseFromPeer(peerID, il.Hash(), il.Seq()); err != nil {
+		r.logger.Warn("failed to request ledger base from replacement peer", "error", err)
+	}
 }
 
 // startLedgerAcquisition picks the best available ledger-acquisition
@@ -352,6 +413,10 @@ func (r *Router) ensureCatchupAcquisition(seq uint32, hash [32]byte, peerID uint
 // layer that walks a range (e.g., backward from a peer's tip via
 // ParentHash) is a follow-up item.
 func (r *Router) startLedgerAcquisition(seq uint32, hash [32]byte, peerID uint64) {
+	if r.catchupRetryBlocked(hash, time.Now()) {
+		return
+	}
+
 	// Unified dedup across BOTH acquisition paths. A prior fix only
 	// checked r.replayer.Has(hash); that still allowed the cross-path
 	// race where two status changes at the same seq with different
@@ -457,7 +522,6 @@ func (r *Router) startLedgerAcquisitionLegacy(seq uint32, hash [32]byte, peerID 
 
 	if err := r.adaptor.RequestLedgerBaseFromPeer(peerID, hash, seq); err != nil {
 		r.logger.Warn("failed to request ledger base from peer", "error", err)
-		r.fetchTracker.Remove(hash, false)
 	}
 }
 
@@ -1268,9 +1332,24 @@ func (r *Router) escalateAcquisition(il *inbound.Ledger, now time.Time) {
 		return
 	}
 	r.broadenAcquisitionPeers(il)
+	if il.State() == inbound.StateWantBase {
+		r.requestAcquisitionBase(il)
+		return
+	}
 	r.requestMissingAcquisitionNodes(il, 0)
 	r.tryFetchPackEscalation(il)
 	r.requestAcquisitionNodesByHash(il)
+}
+
+func (r *Router) requestAcquisitionBase(il *inbound.Ledger) {
+	peerID, ok := r.selectAcquisitionPeer(il.Seq())
+	if !ok {
+		return
+	}
+	il.AddPeer(peerID)
+	if err := r.adaptor.RequestLedgerBaseFromPeer(peerID, il.Hash(), il.Seq()); err != nil {
+		r.logger.Warn("failed to retry ledger base request", "error", err)
+	}
 }
 
 // acquisitionPeerBroaden bounds how many fresh peers a single no-progress
@@ -1303,6 +1382,9 @@ func (r *Router) failInboundAcquisition(il *inbound.Ledger) {
 		"timeouts", il.Timeouts(),
 	)
 	r.fetchTracker.Remove(hash, false)
+	if reason == inbound.ReasonConsensus {
+		r.markFailedCatchupAcquisition(hash)
+	}
 	if reason == inbound.ReasonConsensus && r.engine != nil {
 		r.engine.OnLedgerAcquireFailed(consensus.LedgerID(hash))
 	}

--- a/internal/consensus/adaptor/router_catchup_bound_test.go
+++ b/internal/consensus/adaptor/router_catchup_bound_test.go
@@ -58,6 +58,7 @@ func TestRouter_RetargetsOnCompletion(t *testing.T) {
 	targetSeq := closedSeq + 40
 	var targetHash [32]byte
 	targetHash[0] = 0xC7
+	trackCatchupPeer(r, 7, targetSeq)
 	r.recordCatchupTarget(targetSeq, targetHash, 7)
 
 	// Complete a deep catch-up acquisition (jump-adopt). On completion the

--- a/internal/consensus/adaptor/router_catchup_forward_test.go
+++ b/internal/consensus/adaptor/router_catchup_forward_test.go
@@ -2,6 +2,7 @@ package adaptor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/crypto/sha512half"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
@@ -31,6 +32,7 @@ func TestRouter_ForwardDeltaStep_SameBranch(t *testing.T) {
 	// A far tip is the recorded catch-up target (the jump-adopt fallback).
 	var tipHash [32]byte
 	tipHash[0] = 0xF0
+	trackCatchupPeer(r, 7, closed+5)
 	r.recordCatchupTarget(closed+5, tipHash, 7)
 
 	r.armCatchupTowardTarget()
@@ -59,6 +61,7 @@ func TestRouter_ForwardDeltaStep_SameBranchViaClosedSeqProxy(t *testing.T) {
 
 	var tipHash [32]byte
 	tipHash[0] = 0xF0
+	trackCatchupPeer(r, 7, closed+3)
 	r.recordCatchupTarget(closed+3, tipHash, 7)
 
 	r.armCatchupTowardTarget()
@@ -83,6 +86,7 @@ func TestRouter_ForwardDeltaStep_ForkFallsBackToJumpAdopt(t *testing.T) {
 
 	var tipHash [32]byte
 	tipHash[0] = 0xF0
+	trackCatchupPeer(r, 7, closed+5)
 	r.recordCatchupTarget(closed+5, tipHash, 7)
 
 	r.armCatchupTowardTarget()
@@ -102,6 +106,7 @@ func TestRouter_ForwardDeltaStep_UnknownNextFallsBackToJumpAdopt(t *testing.T) {
 
 	var tipHash [32]byte
 	tipHash[0] = 0xF0
+	trackCatchupPeer(r, 7, closed+5)
 	r.recordCatchupTarget(closed+5, tipHash, 7)
 	// No seqHash entry for closed+1.
 
@@ -128,6 +133,7 @@ func TestRouter_ForwardDeltaStep_FarGapJumpAdopts(t *testing.T) {
 	var tipHash [32]byte
 	tipHash[0] = 0xF0
 	tipSeq := closed + maxForwardDeltaGap + 10
+	trackCatchupPeer(r, 7, tipSeq)
 	r.recordCatchupTarget(tipSeq, tipHash, 7)
 
 	r.armCatchupTowardTarget()
@@ -170,6 +176,7 @@ func TestRouter_ForwardWalk_RearmsNextOnCompletion(t *testing.T) {
 	r.recordSeqHash(c+2, next2, childHash, true)
 	var tipHash [32]byte
 	tipHash[0] = 0xF0
+	trackCatchupPeer(r, 7, c+10)
 	r.recordCatchupTarget(c+10, tipHash, 7)
 
 	r.completeInboundLedger(il)
@@ -193,6 +200,7 @@ func TestRouter_ForwardWalk_SerialUnderCap(t *testing.T) {
 	var nextHash [32]byte
 	nextHash[0] = 0xB1
 	r.recordSeqHash(closed+1, nextHash, closedHash, true)
+	trackCatchupPeer(r, 7, closed+5)
 	r.recordCatchupTarget(closed+5, [32]byte{0xF0}, 7)
 
 	r.armCatchupTowardTarget()
@@ -203,6 +211,27 @@ func TestRouter_ForwardWalk_SerialUnderCap(t *testing.T) {
 	assert.Equal(t, maxConcurrentCatchup, r.catchupInFlight(),
 		"the forward walk stays serial under the concurrency cap")
 	assert.Len(t, rs.replayCalls(), 1, "no second acquisition while one is in flight")
+}
+
+func TestRouter_ForwardDeltaFailureCooldownUsesChildHash(t *testing.T) {
+	r, _, rs, svc := makeRouter(t)
+	closed := svc.GetClosedLedgerIndex()
+	closedHash := svc.GetClosedLedger().Hash()
+	nextHash := [32]byte{0xB1}
+	tipHash := [32]byte{0xF0}
+	r.recordSeqHash(closed+1, nextHash, closedHash, true)
+	trackCatchupPeer(r, 7, closed+5)
+	r.recordCatchupTarget(closed+5, tipHash, 7)
+
+	il := inbound.New(nextHash, closed+1, 7, serveTestLogger())
+	r.fetchTracker.Track(il)
+	r.failInboundAcquisition(il)
+	r.armCatchupTowardTarget()
+
+	assert.Empty(t, rs.replayCalls())
+	assert.Empty(t, rs.legacyCalls())
+	assert.True(t, r.catchupRetryBlocked(nextHash, time.Now()))
+	assert.False(t, r.catchupRetryBlocked(tipHash, time.Now()))
 }
 
 // The seqHash table is bounded: once it exceeds the trailing seqHashRetain

--- a/internal/consensus/adaptor/router_catchup_peer_test.go
+++ b/internal/consensus/adaptor/router_catchup_peer_test.go
@@ -1,0 +1,162 @@
+package adaptor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func trackCatchupPeer(r *Router, peerID peermanagement.PeerID, seq uint32) {
+	r.peersMu.Lock()
+	r.peerStates[peerID] = &peerLedgerState{LedgerSeq: seq}
+	r.peersMu.Unlock()
+}
+
+func TestRouter_CatchupUsesSameTargetReplacementPeer(t *testing.T) {
+	r, _, sender, svc := makeRouter(t)
+	targetSeq := svc.GetClosedLedgerIndex() + 40
+	targetHash := [32]byte{0xD1}
+
+	trackCatchupPeer(r, 1, targetSeq)
+	sender.mu.Lock()
+	sender.legacyBaseErr = peermanagement.ErrPeerNotFound
+	sender.mu.Unlock()
+	r.ensureCatchupAcquisition(targetSeq, targetHash, 1)
+	require.NotNil(t, r.fetchTracker.Find(targetHash))
+
+	r.HandlePeerDisconnect(1)
+	_, _, preferred := r.bestCatchupTarget()
+	assert.Zero(t, preferred)
+
+	sender.mu.Lock()
+	sender.legacyBaseErr = nil
+	sender.mu.Unlock()
+	trackCatchupPeer(r, 2, targetSeq)
+	r.ensureCatchupAcquisition(targetSeq, targetHash, 2)
+
+	calls := sender.legacyCalls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, uint64(1), calls[0].peerID)
+	assert.Equal(t, uint64(2), calls[1].peerID)
+	seq, hash, preferred := r.bestCatchupTarget()
+	assert.Equal(t, targetSeq, seq)
+	assert.Equal(t, targetHash, hash)
+	assert.Equal(t, uint64(2), preferred)
+}
+
+func TestRouter_CatchupWaitsWithoutConnectedPeers(t *testing.T) {
+	r, _, sender, svc := makeRouter(t)
+	targetSeq := svc.GetClosedLedgerIndex() + 40
+	targetHash := [32]byte{0xD2}
+	r.recordCatchupTarget(targetSeq, targetHash, 7)
+
+	for range 20 {
+		r.maintenanceTick()
+	}
+
+	assert.Empty(t, sender.legacyCalls())
+	assert.Empty(t, sender.replayCalls())
+	assert.Nil(t, r.fetchTracker.Find(targetHash))
+}
+
+func TestRouter_CatchupBaseRequestFailureUsesInboundRetryTimer(t *testing.T) {
+	r, _, sender, svc := makeRouter(t)
+	targetSeq := svc.GetClosedLedgerIndex() + 40
+	targetHash := [32]byte{0xD3}
+	trackCatchupPeer(r, 7, targetSeq)
+	sender.mu.Lock()
+	sender.legacyBaseErr = peermanagement.ErrPeerNotFound
+	sender.mu.Unlock()
+
+	r.ensureCatchupAcquisition(targetSeq, targetHash, 7)
+	il := r.fetchTracker.Find(targetHash)
+	require.NotNil(t, il)
+	require.Equal(t, inbound.StateWantBase, il.State())
+
+	for range 20 {
+		r.maintenanceTick()
+	}
+	require.Len(t, sender.legacyCalls(), 1)
+
+	now := time.Now().Add(4 * time.Second)
+	require.Equal(t, inbound.TimerEscalate, il.OnTimer(now))
+	r.escalateAcquisition(il, now)
+	require.Len(t, sender.legacyCalls(), 2)
+	assert.Equal(t, 1, il.Timeouts())
+
+	for timeout := 2; timeout <= 6; timeout++ {
+		now = now.Add(4 * time.Second)
+		require.Equal(t, inbound.TimerEscalate, il.OnTimer(now))
+		r.escalateAcquisition(il, now)
+	}
+	now = now.Add(4 * time.Second)
+	require.Equal(t, inbound.TimerFailed, il.OnTimer(now))
+	r.failInboundAcquisition(il)
+	require.Len(t, sender.legacyCalls(), 7)
+	assert.Nil(t, r.fetchTracker.Find(targetHash))
+	seq, _, _ := r.bestCatchupTarget()
+	assert.Equal(t, targetSeq, seq)
+	assert.True(t, r.catchupRetryBlocked(targetHash, time.Now()))
+
+	for range 20 {
+		r.maintenanceTick()
+	}
+	assert.Len(t, sender.legacyCalls(), 7)
+
+	sender.mu.Lock()
+	sender.legacyBaseErr = nil
+	sender.mu.Unlock()
+	r.ensureCatchupAcquisition(targetSeq, targetHash, 8)
+	assert.Len(t, sender.legacyCalls(), 7)
+	assert.Zero(t, r.catchupInFlight())
+
+	r.catchupMu.Lock()
+	r.catchupFailures[targetHash] = time.Now().Add(-time.Second)
+	r.catchupMu.Unlock()
+	r.ensureCatchupAcquisition(targetSeq, targetHash, 8)
+	calls := sender.legacyCalls()
+	require.Len(t, calls, 8)
+	assert.Equal(t, uint64(8), calls[7].peerID)
+	assert.False(t, r.catchupRetryBlocked(targetHash, time.Now()))
+	assert.Equal(t, 1, r.catchupInFlight())
+}
+
+func TestRouter_CatchupUsesReplacementValidationPeer(t *testing.T) {
+	r, a, sender, _ := makeRouter(t)
+	trusted, err := a.GetValidatorKey()
+	require.NoError(t, err)
+	v := &consensus.Validation{
+		NodeID:    trusted,
+		LedgerSeq: 99999,
+		LedgerID:  consensus.LedgerID([32]byte{0xD4}),
+	}
+	sender.mu.Lock()
+	sender.legacyBaseErr = peermanagement.ErrPeerNotFound
+	sender.mu.Unlock()
+
+	r.maybeAcquireFromValidation(v, 7)
+	r.maybeAcquireFromValidation(v, 8)
+
+	calls := sender.legacyCalls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, uint64(7), calls[0].peerID)
+	assert.Equal(t, uint64(8), calls[1].peerID)
+	assert.Equal(t, 1, r.catchupInFlight())
+}
+
+func TestRouter_CatchupFailureCooldownAppliesToDirectAcquisition(t *testing.T) {
+	r, _, sender, _ := makeRouter(t)
+	targetHash := [32]byte{0xD5}
+	r.markFailedCatchupAcquisition(targetHash)
+
+	r.startLedgerAcquisition(99999, targetHash, 7)
+
+	assert.Empty(t, sender.legacyCalls())
+	assert.Empty(t, sender.replayCalls())
+	assert.Zero(t, r.catchupInFlight())
+}

--- a/internal/consensus/adaptor/router_catchup_rearm_test.go
+++ b/internal/consensus/adaptor/router_catchup_rearm_test.go
@@ -18,6 +18,7 @@ func TestRouter_MaintenanceTickReArmsCatchupTarget(t *testing.T) {
 	targetSeq := closedSeq + 40
 	var targetHash [32]byte
 	targetHash[0] = 0xD9
+	trackCatchupPeer(r, 7, targetSeq)
 	r.recordCatchupTarget(targetSeq, targetHash, 7)
 	require.Zero(t, r.catchupInFlight(), "setup: nothing in flight")
 

--- a/internal/consensus/adaptor/router_catchup_test.go
+++ b/internal/consensus/adaptor/router_catchup_test.go
@@ -207,8 +207,7 @@ func TestRouter_ValidationForHeldLedger_NoAcquire(t *testing.T) {
 	assert.Zero(t, acquireCount(rs), "a ledger already in history must not be re-acquired")
 }
 
-// Repeated trusted validations for the same unknown hash arm at most one fetch
-// (the isAcquiring dedup).
+// Repeated trusted validations for the same unknown hash share one acquisition.
 func TestRouter_RepeatedTrustedValidations_SingleAcquire(t *testing.T) {
 	r, a, rs, _ := makeRouter(t)
 	trusted, _ := a.GetValidatorKey()
@@ -219,5 +218,6 @@ func TestRouter_RepeatedTrustedValidations_SingleAcquire(t *testing.T) {
 	}
 	r.maybeAcquireFromValidation(v, 7)
 	r.maybeAcquireFromValidation(v, 8)
-	assert.Equal(t, 1, acquireCount(rs), "isAcquiring dedup → at most one fetch per hash")
+	assert.Equal(t, 1, r.catchupInFlight())
+	assert.Equal(t, 2, acquireCount(rs), "the replacement peer joins the existing acquisition")
 }

--- a/internal/consensus/adaptor/router_replay_delta_test.go
+++ b/internal/consensus/adaptor/router_replay_delta_test.go
@@ -32,6 +32,7 @@ type recordingSender struct {
 	mu               sync.Mutex
 	replayDeltaCalls []replayDeltaCall
 	legacyBaseCalls  []legacyBaseCall
+	legacyBaseErr    error
 	// peerSupportsReplay controls the handshake-feature answer. Defaults
 	// to true so existing tests continue to exercise the "peer advertises
 	// ledger-replay" path without extra setup; tests that want to cover
@@ -67,7 +68,7 @@ func (s *recordingSender) RequestLedgerBaseFromPeer(peerID uint64, hash [32]byte
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.legacyBaseCalls = append(s.legacyBaseCalls, legacyBaseCall{peerID: peerID, hash: hash, seq: seq})
-	return nil
+	return s.legacyBaseErr
 }
 
 func (s *recordingSender) replayCalls() []replayDeltaCall {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1218,3 +1218,47 @@ Behavioral oracle: clean local rippled `3.2.0` worktree at
 - Behavior commit `d1fc5be2` and test-hardening commit `5f0890f8` are published
   on `fix/issue-1360-peer-private-fixed-peers`; PR #1364 targets `main` at
   https://github.com/LeJamon/go-xrpl/pull/1364.
+
+# Issue #1391 — stale initial-sync catch-up peer
+
+Target: `origin/main` at `456073c17acc79b2022c010f2173ab3e71e92580`.
+Behavioral oracle: clean local rippled `3.2.0` worktree at
+`3c43f4614f87965298773279ff5b85d4c56c637b`.
+
+## Plan
+
+- [x] Validate GitHub access, issue state and discussion, linked PRs, active
+      release branches, exact base, and clean dedicated worktree.
+- [x] Trace the complete catch-up target, peer lifecycle, acquisition dispatch,
+      immediate-failure, and maintenance retry paths with their current tests.
+- [x] Verify rippled v3.2.0 peer selection, disconnect, and acquisition retry
+      behavior in the pinned local oracle.
+- [x] Add focused regressions for same-sequence replacement, no eligible peers,
+      disconnect invalidation, and bounded retries after immediate dispatch failure.
+- [x] Implement the smallest production-quality fix preserving existing sync
+      behavior while eliminating stale-peer dispatch and the 100 ms hot loop.
+- [x] Run formatting, focused and race tests, affected core tests, build, vet,
+      strict CI lint, advisory lint, and diff checks.
+- [x] Review the complete diff for concurrency, failure paths, oracle parity, and
+      test coverage; record exact results below.
+- [x] Stage only intentional files, commit, push, open the PR against `main`, and
+      verify the published head and initial CI state.
+
+## Review
+
+- Catch-up dispatch now uses a fresh gossip origin or selects from currently
+  connected peer state at timer-driven dispatch; disconnects invalidate cached
+  target provenance and same-ledger replacements join the retained acquisition.
+- Immediate base-request failures remain in one acquisition governed by the
+  existing three-second timer and seven-attempt no-progress budget. Exhausted
+  acquisition hashes enter a five-minute recent-failure cache, including forward
+  child ledgers and direct validation/status acquisition paths.
+- The behavior matches rippled v3.2.0's live peer resolution, fixed timeout
+  progression, bounded retry count, and five-minute recent-failure suppression.
+- Verification passed: `go test ./internal/consensus/adaptor/... -count=1`, the
+  focused race suite, `just test-core`, `just build-all`, `just vet`, tagged
+  PostgreSQL vet, strict golangci-lint v2.11.3, advisory lint, gofmt, and
+  `git diff --check`.
+- Final adversarial review found no unresolved lock-order, data-race, retry-bound,
+  peer-replacement, or rippled-conformance blocker after centralizing the failed
+  hash gate in the shared consensus acquisition entry point.


### PR DESCRIPTION
## Summary

- resolve catch-up peers at dispatch time and refresh retained acquisitions from replacement peers
- keep immediate send failures in the existing fixed three-second, bounded retry lifecycle
- suppress exhausted acquisition hashes for five minutes, matching rippled v3.2.0 recent-failure behavior

## Test plan

- [x] `go test ./internal/consensus/adaptor/... -count=1`
- [x] focused `go test -race` catch-up and validation suite
- [x] `just test-core`
- [x] `just build-all`
- [x] `just vet`
- [x] `go vet -tags postgres ./storage/relationaldb/postgres/`
- [x] golangci-lint v2.11.3 strict and advisory configurations
- [x] `git diff --check`

Fixes #1391
