### PR TITLE
fix: aggregate bootstrap manifest relay

### DIFF
--- a/internal/consensus/adaptor/manifest_emit.go
+++ b/internal/consensus/adaptor/manifest_emit.go
@@ -19,8 +19,8 @@ type manifestSender interface {
 // encodeManifestsFrame wraps one or more wire-format manifest STObjects
 // in a TMManifests frame ready for Overlay.Broadcast / Overlay.Send.
 //
-// Shared by relayManifest (single-manifest gossip from a peer) and the
-// local-manifest emission paths so both produce byte-identical frames;
+// Shared by inbound manifest relay and the local-manifest emission paths
+// so both produce byte-identical frames;
 // peers don't distinguish between the two on the wire.
 func encodeManifestsFrame(serialized ...[]byte) ([]byte, error) {
 	list := make([]message.Manifest, 0, len(serialized))

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -95,10 +95,15 @@ type Router struct {
 	// frames and — on Accepted — relay them to other peers.
 	// May be nil in tests that don't exercise the manifest path.
 	manifests *manifest.Cache
+	// manifestJobs moves manifest deserialization, signature verification,
+	// and relay construction off the router loop. A single worker preserves
+	// frame order; Cache.ApplyManifest already serializes concurrent writers.
+	manifestJobs        chan *peermanagement.InboundMessage
+	manifestWorkerDone  chan struct{}
+	droppedManifestJobs atomic.Uint64
 
-	// overlay is held so the router can relay accepted manifests
-	// directly via Overlay.BroadcastExcept. Nil in tests that
-	// construct a router without manifest support.
+	// overlay is held so the router can relay accepted manifests and emit
+	// the local cache to peers. Nil in tests without manifest support.
 	overlay *peermanagement.Overlay
 
 	// validatorList is the publisher-trust subsystem. Wired by the
@@ -112,9 +117,7 @@ type Router struct {
 	// local-manifest emission paths (SendLocalManifestTo /
 	// BroadcastLocalManifest). Tests install a fake here to observe
 	// the emitted frame without standing up real listeners; production
-	// leaves it nil so the real overlay is used. The relayManifest
-	// path still needs r.overlay directly because BroadcastExcept has
-	// no equivalent on the sender interface.
+	// leaves it nil so the real overlay is used.
 	overrideManifestSender manifestSender
 
 	// manifestFrameMu guards the cached TMManifests emission frame and
@@ -260,6 +263,10 @@ const txQueueDepth = 1024
 var serveWorkerCount = max(2, runtime.GOMAXPROCS(0)/2)
 
 const serveQueueDepth = 256
+
+// manifestQueueDepth bounds pending verification work without blocking the
+// consensus router. Each wire frame is already bounded by MaxMessageSize.
+const manifestQueueDepth = 4
 
 // messageDedupTTL is how long a proposal/validation hash is
 // remembered for duplicate-detection purposes. 30s comfortably covers a
@@ -425,6 +432,8 @@ func (r *Router) HandlePeerDisconnect(peerID peermanagement.PeerID) {
 func (r *Router) Run(ctx context.Context) {
 	r.startTxWorkers(ctx)
 	r.startServeWorkers(ctx)
+	r.startManifestWorker()
+	defer r.stopManifestWorker()
 	ticker := time.NewTicker(inboundReplayDeltaTickInterval)
 	defer ticker.Stop()
 	for {
@@ -555,6 +564,51 @@ func (r *Router) submitServeJob(msg *peermanagement.InboundMessage) {
 // requests shed because the serve pool was saturated.
 func (r *Router) DroppedServeJobs() uint64 {
 	return r.droppedServeJobs.Load()
+}
+
+func (r *Router) startManifestWorker() {
+	r.manifestJobs = make(chan *peermanagement.InboundMessage, manifestQueueDepth)
+	r.manifestWorkerDone = make(chan struct{})
+	jobs := r.manifestJobs
+	done := r.manifestWorkerDone
+
+	go func() {
+		defer close(done)
+		for msg := range jobs {
+			r.processManifestJob(msg)
+		}
+	}()
+}
+
+func (r *Router) stopManifestWorker() {
+	close(r.manifestJobs)
+	<-r.manifestWorkerDone
+	r.manifestJobs = nil
+}
+
+func (r *Router) processManifestJob(msg *peermanagement.InboundMessage) {
+	defer r.recoverFrame(msg, "manifest")
+	r.handleManifests(msg)
+}
+
+func (r *Router) submitManifestJob(msg *peermanagement.InboundMessage) {
+	if r.manifestJobs == nil {
+		r.processManifestJob(msg)
+		return
+	}
+	select {
+	case r.manifestJobs <- msg:
+	default:
+		r.droppedManifestJobs.Add(1)
+		r.logger.Debug("inbound manifests dropped: worker queue saturated",
+			"t", "consensus", "event", "manifest-shed", "peer", msg.PeerID)
+	}
+}
+
+// DroppedManifestJobs returns the cumulative count of inbound manifest frames
+// shed because the worker queue was saturated.
+func (r *Router) DroppedManifestJobs() uint64 {
+	return r.droppedManifestJobs.Load()
 }
 
 // maintenanceTick runs out-of-band housekeeping: detect replay-delta

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -54,7 +54,7 @@ func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
 	case message.TypeReplayDeltaResponse:
 		r.handleReplayDeltaResponse(msg)
 	case message.TypeManifests:
-		r.handleManifests(msg)
+		r.submitManifestJob(msg)
 	case message.TypeValidatorList:
 		r.handleValidatorList(msg)
 	case message.TypeValidatorListCollection:
@@ -63,10 +63,8 @@ func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
 	}
 }
 
-// handleManifests ingests a TMManifests frame. For each serialized
-// manifest in the list: deserialize, apply to the cache, and — on
-// Accepted — relay the single-manifest frame to every peer except the
-// origin.
+// handleManifests ingests a TMManifests frame, applies every entry, and
+// relays the accepted subset as one aggregate frame.
 //
 // Decode failures attribute "manifest-decode" badData to the sender. A
 // mix of valid and invalid entries in the same frame results in the
@@ -88,6 +86,7 @@ func (r *Router) handleManifests(msg *peermanagement.InboundMessage) {
 		return
 	}
 
+	accepted := make([][]byte, 0, len(mfs.List))
 	for _, wire := range mfs.List {
 		parsed, err := manifest.Deserialize(wire.STObject)
 		if err != nil {
@@ -98,7 +97,7 @@ func (r *Router) handleManifests(msg *peermanagement.InboundMessage) {
 		}
 		switch d := r.manifests.ApplyManifest(parsed); d {
 		case manifest.Accepted:
-			r.relayManifest(msg.PeerID, wire.STObject)
+			accepted = append(accepted, wire.STObject)
 		case manifest.Invalid, manifest.BadMasterKey, manifest.BadEphemeralKey:
 			// Charge the sender — they gave us a manifest that
 			// passed structural parse but failed the cache's
@@ -109,22 +108,25 @@ func (r *Router) handleManifests(msg *peermanagement.InboundMessage) {
 			// already have at equal or higher seq. No action.
 		}
 	}
+	r.relayManifests(accepted)
 }
 
-// relayManifest rebroadcasts a single accepted manifest to every peer
-// except the origin. Wraps the serialized STObject in a TMManifests
-// frame (a list of one). Shares its framing with the local-manifest
-// emission paths in manifest_emit.go.
-func (r *Router) relayManifest(exceptPeer peermanagement.PeerID, serialized []byte) {
-	if r.overlay == nil {
+func (r *Router) relayManifests(serialized [][]byte) {
+	if len(serialized) == 0 {
 		return
 	}
-	frame, err := encodeManifestsFrame(serialized)
+	frame, err := encodeManifestsFrame(serialized...)
 	if err != nil {
 		r.logger.Warn("failed to encode manifest relay frame", "error", err)
 		return
 	}
-	_ = r.overlay.BroadcastExcept(exceptPeer, frame)
+	sender := r.manifestEmitter()
+	if sender == nil {
+		return
+	}
+	if err := sender.Broadcast(frame); err != nil {
+		r.logger.Warn("failed to broadcast manifest relay frame", "error", err)
+	}
 }
 
 func (r *Router) handleProposal(msg *peermanagement.InboundMessage) {

--- a/internal/consensus/adaptor/router_manifests_test.go
+++ b/internal/consensus/adaptor/router_manifests_test.go
@@ -2,8 +2,10 @@ package adaptor
 
 import (
 	"bytes"
+	"context"
 	"crypto/ed25519"
 	"encoding/hex"
+	"sync"
 	"testing"
 	"time"
 
@@ -148,4 +150,202 @@ func TestRouter_HandleManifests_InvalidDoesNotStore(t *testing.T) {
 	if _, ok := cache.GetSigningKey(parsed.MasterKey); ok {
 		t.Fatal("cache stored a manifest whose master signature was corrupted")
 	}
+}
+
+func TestRouter_HandleManifests_AggregatesAcceptedEntries(t *testing.T) {
+	sender := &fakeManifestSender{broadcastErr: peermanagement.ErrSendBufferFull}
+	router, _, _ := routerWithCache(t, sender, 0, 0)
+
+	const acceptedCount = 100
+	wires := make([][]byte, 0, acceptedCount)
+	list := make([]message.Manifest, 0, acceptedCount+2)
+	for i := range acceptedCount {
+		wire := buildWireManifest(t, 1, byte(i), byte(i+acceptedCount))
+		wires = append(wires, wire)
+		list = append(list, message.Manifest{STObject: wire})
+	}
+	list = append(list,
+		message.Manifest{STObject: wires[0]},
+		message.Manifest{STObject: []byte{0x01}},
+	)
+
+	router.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    uint16(message.TypeManifests),
+		Payload: encodePayload(t, &message.Manifests{List: list}),
+	})
+
+	sender.mu.Lock()
+	broadcasts := append([][]byte(nil), sender.bcasts...)
+	sender.mu.Unlock()
+	require.Len(t, broadcasts, 1, "one inbound collection must produce one broadcast attempt")
+
+	got := frameToManifestBytes(t, broadcasts[0])
+	require.Len(t, got, acceptedCount)
+	for i := range wires {
+		require.Equal(t, wires[i], got[i], "accepted manifests must retain input order and bytes")
+	}
+}
+
+func TestRouter_ManifestWorkerDoesNotBlockDispatch(t *testing.T) {
+	adaptor := newTestAdaptor(t)
+	inbox := make(chan *peermanagement.InboundMessage, 10)
+	router := NewRouter(&mockEngine{}, adaptor, inbox)
+	cache := manifest.NewCache()
+	router.SetManifestCache(cache, nil)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	var blockOnce sync.Once
+	releaseWorker := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseWorker()
+	cache.SetOnAccepted(func(*manifest.Manifest) {
+		blockOnce.Do(func() {
+			close(entered)
+			<-release
+		})
+	})
+
+	go router.Run(t.Context())
+	inbox <- &peermanagement.InboundMessage{
+		PeerID: 7,
+		Type:   uint16(message.TypeManifests),
+		Payload: encodePayload(t, &message.Manifests{List: []message.Manifest{{
+			STObject: buildWireManifest(t, 1, 220, 221),
+		}}}),
+	}
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("manifest worker did not begin processing")
+	}
+
+	queued := make([]*manifest.Manifest, 0, manifestQueueDepth)
+	for i := range manifestQueueDepth {
+		wire := buildWireManifest(t, 1, byte(222+i), byte(232+i))
+		parsed, err := manifest.Deserialize(wire)
+		require.NoError(t, err)
+		queued = append(queued, parsed)
+		inbox <- &peermanagement.InboundMessage{
+			PeerID:  peermanagement.PeerID(10 + i),
+			Type:    uint16(message.TypeManifests),
+			Payload: encodePayload(t, &message.Manifests{List: []message.Manifest{{STObject: wire}}}),
+		}
+	}
+	for i := range 2 {
+		wire := buildWireManifest(t, 1, byte(240+i), byte(242+i))
+		inbox <- &peermanagement.InboundMessage{
+			PeerID:  8,
+			Type:    uint16(message.TypeManifests),
+			Payload: encodePayload(t, &message.Manifests{List: []message.Manifest{{STObject: wire}}}),
+		}
+	}
+	require.Eventually(t, func() bool {
+		return router.DroppedManifestJobs() == 2
+	}, time.Second, 5*time.Millisecond)
+
+	var ledgerHash [32]byte
+	ledgerHash[0] = 0xAB
+	inbox <- statusChangeMessage(t, 9, 1, ledgerHash)
+	require.Eventually(t, func() bool {
+		router.peersMu.RLock()
+		state := router.peerStates[9]
+		router.peersMu.RUnlock()
+		return state != nil && state.LedgerSeq == 1 && state.LedgerHash == ledgerHash
+	}, time.Second, 5*time.Millisecond)
+
+	releaseWorker()
+	require.Eventually(t, func() bool {
+		for _, parsed := range queued {
+			if _, ok := cache.GetSigningKey(parsed.MasterKey); !ok {
+				return false
+			}
+		}
+		return true
+	}, time.Second, 5*time.Millisecond)
+	require.Equal(t, uint64(2), router.DroppedManifestJobs())
+}
+
+func TestRouter_ManifestWorkerJoinsOnShutdown(t *testing.T) {
+	inbox := make(chan *peermanagement.InboundMessage, 3)
+	router := NewRouter(&mockEngine{}, newTestAdaptor(t), inbox)
+	cache := manifest.NewCache()
+	sender := &fakeManifestSender{}
+	router.SetManifestCache(cache, nil)
+	router.overrideManifestSender = sender
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	var blockOnce sync.Once
+	releaseWorker := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseWorker()
+	cache.SetOnAccepted(func(*manifest.Manifest) {
+		blockOnce.Do(func() {
+			close(entered)
+			<-release
+		})
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		router.Run(ctx)
+		close(done)
+	}()
+	inbox <- &peermanagement.InboundMessage{
+		PeerID: 1,
+		Type:   uint16(message.TypeManifests),
+		Payload: encodePayload(t, &message.Manifests{List: []message.Manifest{{
+			STObject: buildWireManifest(t, 1, 240, 241),
+		}}}),
+	}
+
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("manifest worker did not begin processing")
+	}
+
+	queuedWire := buildWireManifest(t, 1, 242, 243)
+	queuedManifest, err := manifest.Deserialize(queuedWire)
+	require.NoError(t, err)
+	inbox <- &peermanagement.InboundMessage{
+		PeerID: 2,
+		Type:   uint16(message.TypeManifests),
+		Payload: encodePayload(t, &message.Manifests{List: []message.Manifest{{
+			STObject: queuedWire,
+		}}}),
+	}
+	var ledgerHash [32]byte
+	ledgerHash[0] = 0xCD
+	inbox <- statusChangeMessage(t, 3, 1, ledgerHash)
+	require.Eventually(t, func() bool {
+		router.peersMu.RLock()
+		state := router.peerStates[3]
+		router.peersMu.RUnlock()
+		return state != nil && state.LedgerHash == ledgerHash
+	}, time.Second, 5*time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+		t.Fatal("router returned before its manifest worker stopped")
+	case <-time.After(25 * time.Millisecond):
+	}
+	releaseWorker()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("router did not join its manifest worker")
+	}
+	_, ok := cache.GetSigningKey(queuedManifest.MasterKey)
+	require.True(t, ok, "shutdown must drain queued manifest jobs")
+	sender.mu.Lock()
+	broadcasts := len(sender.bcasts)
+	sender.mu.Unlock()
+	require.Equal(t, 2, broadcasts, "shutdown must relay active and queued accepted manifests")
 }

--- a/internal/peermanagement/overlay_broadcast_test.go
+++ b/internal/peermanagement/overlay_broadcast_test.go
@@ -1,0 +1,26 @@
+package peermanagement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBroadcast_AttemptsBackpressuredPeerOnceAndContinues(t *testing.T) {
+	full := newTestPeer(t, 1)
+	healthy := newTestPeer(t, 2)
+	full.setState(PeerStateConnected)
+	healthy.setState(PeerStateConnected)
+	for i := range DefaultSendBufferSize {
+		require.NoError(t, full.Send([]byte{byte(i)}))
+	}
+
+	overlay := newTestOverlayWithPeers(map[PeerID]*Peer{1: full, 2: healthy})
+	frame := []byte{0xAA, 0xBB, 0xCC}
+	require.NoError(t, overlay.Broadcast(frame))
+
+	require.Equal(t, uint64(1), full.SendDrops())
+	require.Equal(t, uint32(1), full.largeSendQ.Load())
+	require.Len(t, full.send, DefaultSendBufferSize)
+	require.Equal(t, frame, <-healthy.send)
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1262,3 +1262,49 @@ Behavioral oracle: clean local rippled `3.2.0` worktree at
 - Final adversarial review found no unresolved lock-order, data-race, retry-bound,
   peer-replacement, or rippled-conformance blocker after centralizing the failed
   hash gate in the shared consensus acquisition entry point.
+
+# Issue #1395 — bootstrap manifest relay amplification
+
+Target: `origin/main` at `e171f7c3dbf7741cbcd89ca7c5b1bad270aefe19`.
+Behavioral oracle: clean local rippled `3.2.0` worktree at
+`3c43f4614f87965298773279ff5b85d4c56c637b`.
+
+## Plan
+
+- [x] Validate GitHub access, issue state and discussion, linked PRs, active
+      release branches, exact base, and clean dedicated worktree.
+- [x] Trace manifest acceptance, relay, recipient selection, send-queue
+      backpressure, router dispatch, counters, logging, and existing tests.
+- [x] Verify the complete corresponding behavior and tests against local
+      rippled v3.2.0, including batching and execution context.
+- [x] Add deterministic regressions for bounded relay frames, one post-processing
+      recipient snapshot, one backpressure attempt, and router progress.
+- [x] Implement the smallest production-quality fix that preserves accepted
+      manifest semantics while bounding fan-out and dispatch latency.
+- [x] Run formatting, focused and race tests, affected core tests, build, vet,
+      strict CI lint, advisory lint, and diff checks.
+- [x] Review the complete diff for concurrency, failure paths, oracle parity, and
+      test coverage; record exact results below.
+- [ ] Stage only intentional files, commit, push, open the PR against `main`, and
+      verify the published head and initial CI state.
+
+## Review
+
+- Moved inbound manifest verification off the consensus router onto a single
+  four-entry FIFO worker lane. Saturation is non-blocking and counted; admitted
+  work drains completely before router shutdown.
+- Matched rippled v3.2.0 for admitted frames: apply the full list, preserve the
+  accepted bytes and order, then broadcast one aggregate frame to one
+  post-processing peer snapshot, including the source peer.
+- Added deterministic coverage for 100-entry aggregation, bounded saturation
+  and status-message progress, shutdown drain/join behavior, and a real overlay
+  with one full and one healthy peer send queue.
+- Passed `go test -race ./internal/consensus/adaptor`,
+  `go test -race ./internal/peermanagement`, `just build-all`, `just test-core`,
+  `just vet`, postgres-tagged `go vet`, strict and advisory golangci-lint 2.11.3,
+  and `git diff --check`. The core suite was rerun successfully with an isolated
+  Go build cache after the shared cache reported a missing entry.
+- Three final focused reviews found no unresolved concurrency, lifecycle,
+  test-design, or rippled-conformance defect. Rippled does not shed its manifest
+  job queue; the bounded saturation policy is an intentional Go overload
+  safeguard required to keep this repository's single router responsive.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1285,7 +1285,7 @@ Behavioral oracle: clean local rippled `3.2.0` worktree at
       strict CI lint, advisory lint, and diff checks.
 - [x] Review the complete diff for concurrency, failure paths, oracle parity, and
       test coverage; record exact results below.
-- [ ] Stage only intentional files, commit, push, open the PR against `main`, and
+- [x] Stage only intentional files, commit, push, open the PR against `main`, and
       verify the published head and initial CI state.
 
 ## Review


### PR DESCRIPTION
## Summary

- move inbound `TMManifests` verification off the consensus router and drain admitted work safely
- relay accepted manifests as one aggregate frame to a single post-processing peer snapshot
- bound pending manifest work without blocking consensus dispatch, with explicit saturation accounting

## Rippled v3.2.0 parity

For admitted frames, this matches the local rippled v3.2.0 oracle: apply the complete collection, preserve accepted manifest bytes and order, then broadcast one aggregate frame to all peers including the source. The bounded overload shed is an intentional Go queue policy that keeps the shared router responsive.

## Test plan

- [x] `go test -race ./internal/consensus/adaptor`
- [x] `go test -race ./internal/peermanagement`
- [x] `just build-all`
- [x] `just test-core`
- [x] `just vet`
- [x] postgres-tagged `go vet`
- [x] strict and advisory golangci-lint 2.11.3
- [x] `git diff --check`

Fixes #1395
