### PR TITLE
fix: reject stale peer session work

### DIFF
--- a/internal/consensus/adaptor/fetchpack.go
+++ b/internal/consensus/adaptor/fetchpack.go
@@ -253,6 +253,10 @@ func (r *Router) tryFetchPackEscalation(il *inbound.Ledger) bool {
 	if r.fetchPacks == nil || il.FetchPackRequested() {
 		return false
 	}
+	peerID := il.PeerID()
+	if peerID == 0 {
+		return false
+	}
 	svc := r.adaptor.LedgerService()
 	if svc == nil {
 		return false
@@ -275,7 +279,7 @@ func (r *Router) tryFetchPackEscalation(il *inbound.Ledger) bool {
 	if err != nil {
 		return false
 	}
-	if err := r.adaptor.SendToPeer(il.PeerID(), frame); err != nil {
+	if err := r.adaptor.SendToPeer(peerID, frame); err != nil {
 		r.logger.Debug("fetch-pack request send failed",
 			"seq", il.Seq(), "err", err)
 		return false
@@ -286,7 +290,7 @@ func (r *Router) tryFetchPackEscalation(il *inbound.Ledger) bool {
 		"seq", il.Seq(),
 		"hash", fmt.Sprintf("%x", wantHash[:4]),
 		"child", fmt.Sprintf("%x", childHash[:4]),
-		"peer", il.PeerID(),
+		"peer", peerID,
 	)
 	return true
 }

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -32,6 +32,10 @@ type peerLedgerState struct {
 	LedgerHash [32]byte
 }
 
+type peerSessionView interface {
+	IsPeerConnected(peermanagement.PeerID) bool
+}
+
 // Router reads inbound messages from the P2P overlay and dispatches
 // them to the consensus engine and adaptor.
 type Router struct {
@@ -56,8 +60,14 @@ type Router struct {
 	logger   *slog.Logger
 
 	// Peer ledger tracking for catch-up detection
-	peersMu    sync.RWMutex
-	peerStates map[peermanagement.PeerID]*peerLedgerState
+	peerSessions peerSessionView
+	peersMu      sync.RWMutex
+	peerStates   map[peermanagement.PeerID]*peerLedgerState
+
+	// The overlay callback only records disconnects; a router-owned worker performs
+	// cleanup so acquisition scans never block the overlay event loop.
+	pendingPeerDisconnects sync.Map
+	peerDisconnectWake     chan struct{}
 
 	// replayer coordinates concurrent mtREPLAY_DELTA_REQUEST acquisitions
 	// keyed by target ledger hash, under a configurable concurrency cap, so a
@@ -277,18 +287,19 @@ const messageDedupMaxEntries = 4096
 func NewRouter(engine consensus.Engine, adaptor *Adaptor, inbox <-chan *peermanagement.InboundMessage) *Router {
 	logger := slog.Default().With("component", "consensus-router")
 	r := &Router{
-		engine:          engine,
-		adaptor:         adaptor,
-		inbox:           inbox,
-		logger:          logger,
-		peerStates:      make(map[peermanagement.PeerID]*peerLedgerState),
-		replayer:        inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
-		fetchTracker:    inbound.NewTracker(),
-		fetchPacks:      newFetchPackCache(),
-		messageSeen:     newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
-		txSetAcquire:    make(map[consensus.TxSetID]*txSetAcquireState),
-		txSetRetryKnobs: defaultTxSetRetryKnobs(),
-		seqHash:         make(map[uint32]ledgerHashEntry),
+		engine:             engine,
+		adaptor:            adaptor,
+		inbox:              inbox,
+		logger:             logger,
+		peerStates:         make(map[peermanagement.PeerID]*peerLedgerState),
+		peerDisconnectWake: make(chan struct{}, 1),
+		replayer:           inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
+		fetchTracker:       inbound.NewTracker(),
+		fetchPacks:         newFetchPackCache(),
+		messageSeen:        newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
+		txSetAcquire:       make(map[consensus.TxSetID]*txSetAcquireState),
+		txSetRetryKnobs:    defaultTxSetRetryKnobs(),
+		seqHash:            make(map[uint32]ledgerHashEntry),
 	}
 	// Wire the stash → acquisition hook so quorum decisions on unknown
 	// ledgers don't sit silently in pendingLedgerValidations.
@@ -367,6 +378,10 @@ func (r *Router) SetManifestCache(cache *manifest.Cache, overlay *peermanagement
 	r.overlay = overlay
 }
 
+func (r *Router) setPeerSessionView(view peerSessionView) {
+	r.peerSessions = view
+}
+
 // SetValidatorListAggregator installs the publisher-trust subsystem.
 // Calling with a nil aggregator disables the TMValidatorList /
 // TMValidatorListCollection paths — the dispatch switch silently
@@ -405,6 +420,8 @@ func (r *Router) HandlePeerDisconnect(peerID peermanagement.PeerID) {
 	delete(r.peerStates, peerID)
 	r.peersMu.Unlock()
 	r.invalidateCatchupPeer(uint64(peerID))
+	r.invalidateHistoryPeer(uint64(peerID))
+	r.removePeerFromAcquisitions(uint64(peerID))
 
 	// Clear the peer's LCL vote so getNetworkLedger stops counting its
 	// stale hash. The adaptor uses the zero LedgerID as a delete key.
@@ -418,11 +435,60 @@ func (r *Router) HandlePeerDisconnect(peerID peermanagement.PeerID) {
 	}
 }
 
+func (r *Router) queuePeerDisconnect(peerID peermanagement.PeerID) {
+	r.pendingPeerDisconnects.Store(peerID, struct{}{})
+	select {
+	case r.peerDisconnectWake <- struct{}{}:
+	default:
+	}
+}
+
+func (r *Router) drainPeerDisconnects() {
+	r.pendingPeerDisconnects.Range(func(key, _ any) bool {
+		peerID := key.(peermanagement.PeerID)
+		if _, loaded := r.pendingPeerDisconnects.LoadAndDelete(peerID); loaded {
+			r.HandlePeerDisconnect(peerID)
+		}
+		return true
+	})
+}
+
+func (r *Router) runPeerDisconnectCleanup(ctx context.Context) {
+	r.drainPeerDisconnects()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-r.peerDisconnectWake:
+			r.drainPeerDisconnects()
+		}
+	}
+}
+
+func (r *Router) removePeerFromAcquisitions(peerID uint64) {
+	if r.fetchTracker != nil {
+		for _, il := range r.fetchTracker.Active() {
+			il.RemovePeer(peerID)
+		}
+	}
+}
+
 // Run reads messages from the overlay and dispatches them.
 // It blocks until the context is cancelled. A periodic maintenance tick
 // also runs in this loop to time out stuck inbound replay-delta
 // acquisitions and fall back to the legacy mtGET_LEDGER path.
 func (r *Router) Run(ctx context.Context) {
+	disconnectCtx, stopDisconnectCleanup := context.WithCancel(ctx)
+	disconnectCleanupDone := make(chan struct{})
+	go func() {
+		defer close(disconnectCleanupDone)
+		r.runPeerDisconnectCleanup(disconnectCtx)
+	}()
+	defer func() {
+		stopDisconnectCleanup()
+		<-disconnectCleanupDone
+	}()
+
 	r.startTxWorkers(ctx)
 	r.startServeWorkers(ctx)
 	ticker := time.NewTicker(inboundReplayDeltaTickInterval)

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -309,24 +309,16 @@ func (r *Router) armCatchupTowardTargetWithPeer(peerHint uint64) {
 	}
 
 	if seq, hash, ok := r.forwardDeltaStep(svc, closed, tSeq); ok {
-		peer := peerHint
-		if peer == 0 {
-			var found bool
-			peer, found = r.selectAcquisitionPeer(seq)
-			if !found {
-				return
-			}
+		peer, found := r.resolveAcquisitionPeer(seq, peerHint)
+		if !found {
+			return
 		}
 		r.startLedgerAcquisition(seq, hash, peer)
 		return
 	}
-	peer := peerHint
-	if peer == 0 {
-		var found bool
-		peer, found = r.selectAcquisitionPeer(tSeq)
-		if !found {
-			return
-		}
+	peer, found := r.resolveAcquisitionPeer(tSeq, peerHint)
+	if !found {
+		return
 	}
 	r.startLedgerAcquisition(tSeq, tHash, peer)
 }
@@ -382,6 +374,7 @@ func (r *Router) ensureCatchupAcquisition(seq uint32, hash [32]byte, peerID uint
 	if seq == 0 || seq <= svc.GetClosedLedgerIndex() {
 		return
 	}
+	peerID, _ = r.resolveAcquisitionPeer(seq, peerID)
 	r.recordCatchupTarget(seq, hash, peerID)
 	if il := r.fetchTracker.Find(hash); il != nil && il.Reason() == inbound.ReasonConsensus {
 		r.refreshCatchupAcquisitionPeer(il, peerID)
@@ -394,9 +387,8 @@ func (r *Router) refreshCatchupAcquisitionPeer(il *inbound.Ledger, peerID uint64
 	if peerID == 0 || il.State() != inbound.StateWantBase || slices.Contains(il.Peers(), peerID) {
 		return
 	}
-	il.AddPeer(peerID)
-	if err := r.adaptor.RequestLedgerBaseFromPeer(peerID, il.Hash(), il.Seq()); err != nil {
-		r.logger.Warn("failed to request ledger base from replacement peer", "error", err)
+	if !r.requestLedgerBase(il, peerID, "failed to request ledger base from replacement peer") {
+		r.fetchTracker.Remove(il.Hash(), false)
 	}
 }
 
@@ -506,7 +498,7 @@ func (r *Router) startLedgerAcquisitionLegacy(seq uint32, hash [32]byte, peerID 
 		return
 	}
 
-	_, created := r.fetchTracker.GetOrCreate(hash, func() *inbound.Ledger {
+	il, created := r.fetchTracker.GetOrCreate(hash, func() *inbound.Ledger {
 		return inbound.New(hash, seq, peerID, r.logger, r.acquisitionOpts()...)
 	})
 	if !created {
@@ -520,8 +512,45 @@ func (r *Router) startLedgerAcquisitionLegacy(seq uint32, hash [32]byte, peerID 
 		"peer", peerID,
 	)
 
-	if err := r.adaptor.RequestLedgerBaseFromPeer(peerID, hash, seq); err != nil {
-		r.logger.Warn("failed to request ledger base from peer", "error", err)
+	if !r.requestLedgerBase(il, peerID, "failed to request ledger base from peer") {
+		r.fetchTracker.Remove(hash, false)
+	}
+}
+
+func (r *Router) requestLedgerBase(il *inbound.Ledger, peerID uint64, logMessage string) bool {
+	excluded := make(map[uint64]struct{})
+	for {
+		if peerID == 0 {
+			var ok bool
+			peerID, ok = r.selectAcquisitionPeerExcluding(il.Seq(), excluded)
+			if !ok {
+				return false
+			}
+		}
+
+		il.AddPeer(peerID)
+		err := r.adaptor.RequestLedgerBaseFromPeer(peerID, il.Hash(), il.Seq())
+		if err == nil {
+			return true
+		}
+		r.logger.Warn(logMessage, "error", err, "peer", peerID)
+		if !errors.Is(err, peermanagement.ErrPeerNotFound) &&
+			!errors.Is(err, peermanagement.ErrConnectionClosed) {
+			return true
+		}
+
+		il.RemovePeer(peerID)
+		r.HandlePeerDisconnect(peermanagement.PeerID(peerID))
+		excluded[peerID] = struct{}{}
+		peerID = 0
+	}
+}
+
+func (r *Router) invalidateHistoryPeer(peerID uint64) {
+	r.historyMu.Lock()
+	defer r.historyMu.Unlock()
+	if r.history.peerID == peerID {
+		r.history.peerID = 0
 	}
 }
 
@@ -583,11 +612,8 @@ func (r *Router) armHistoryBackfill() {
 	if r.fetchTracker.CountReason(inbound.ReasonHistory) >= 1 || r.isAcquiring(target.hash) {
 		return
 	}
-	peer := target.peerID
-	if p, ok := r.selectAcquisitionPeer(target.seq); ok {
-		peer = p
-	}
-	if peer == 0 {
+	peer, ok := r.resolveAcquisitionPeer(target.seq, target.peerID)
+	if !ok {
 		return
 	}
 	r.startHistoryAcquisition(target.seq, target.hash, peer)
@@ -600,7 +626,7 @@ func (r *Router) startHistoryAcquisition(seq uint32, hash [32]byte, peerID uint6
 	if r.replayer.Has(hash) {
 		return
 	}
-	_, created := r.fetchTracker.GetOrCreate(hash, func() *inbound.Ledger {
+	il, created := r.fetchTracker.GetOrCreate(hash, func() *inbound.Ledger {
 		return inbound.NewHistory(hash, seq, peerID, r.logger, r.acquisitionOpts()...)
 	})
 	if !created {
@@ -611,8 +637,7 @@ func (r *Router) startHistoryAcquisition(seq uint32, hash [32]byte, peerID uint6
 		"hash", fmt.Sprintf("%x", hash[:8]),
 		"peer", peerID,
 	)
-	if err := r.adaptor.RequestLedgerBaseFromPeer(peerID, hash, seq); err != nil {
-		r.logger.Warn("failed to request ledger base from peer", "error", err)
+	if !r.requestLedgerBase(il, peerID, "failed to request history ledger base from peer") {
 		r.fetchTracker.Remove(hash, false)
 	}
 }
@@ -713,10 +738,7 @@ func (r *Router) startGenericAcquisition(hash [32]byte, seq uint32) (map[string]
 		return inbound.AcquisitionJSON(il.Snapshot()), true
 	}
 
-	peerID, ok := r.selectAcquisitionPeer(seq)
-	if !ok {
-		return nil, false
-	}
+	peerID, _ := r.selectAcquisitionPeer(seq)
 
 	il, created := r.fetchTracker.GetOrCreate(hash, func() *inbound.Ledger {
 		return inbound.NewGeneric(hash, seq, peerID, r.logger, r.acquisitionOpts()...)
@@ -727,10 +749,8 @@ func (r *Router) startGenericAcquisition(hash [32]byte, seq uint32) (map[string]
 			"hash", fmt.Sprintf("%x", hash[:8]),
 			"peer", peerID,
 		)
-		if err := r.adaptor.RequestLedgerBaseFromPeer(peerID, hash, seq); err != nil {
-			r.logger.Warn("ledger_request: failed to request ledger base", "error", err)
-			r.fetchTracker.Remove(hash, false)
-			return nil, false
+		if peerID != 0 {
+			r.requestLedgerBase(il, peerID, "ledger_request: failed to request ledger base")
 		}
 	}
 	return inbound.AcquisitionJSON(il.Snapshot()), true
@@ -749,18 +769,43 @@ func getCandidateLedger(seq uint32) uint32 {
 // (and therefore likely to hold it). When seq is unknown (0) or no peer is far
 // enough along, it falls back to any connected peer. Returns (0,false) when no
 // peer has reported a ledger state.
+func (r *Router) resolveAcquisitionPeer(seq uint32, preferred uint64) (uint64, bool) {
+	if preferred != 0 && (r.peerSessions == nil || r.peerSessions.IsPeerConnected(peermanagement.PeerID(preferred))) {
+		return preferred, true
+	}
+	return r.selectAcquisitionPeer(seq)
+}
+
 func (r *Router) selectAcquisitionPeer(seq uint32) (uint64, bool) {
+	return r.selectAcquisitionPeerExcluding(seq, nil)
+}
+
+func (r *Router) selectAcquisitionPeerExcluding(seq uint32, excluded map[uint64]struct{}) (uint64, bool) {
 	r.peersMu.RLock()
-	defer r.peersMu.RUnlock()
+	type candidate struct {
+		id  uint64
+		seq uint32
+	}
+	candidates := make([]candidate, 0, len(r.peerStates))
+	for pid, st := range r.peerStates {
+		candidates = append(candidates, candidate{id: uint64(pid), seq: st.LedgerSeq})
+	}
+	r.peersMu.RUnlock()
 
 	var fallback uint64
 	var haveFallback bool
-	for pid, st := range r.peerStates {
-		if !haveFallback {
-			fallback, haveFallback = uint64(pid), true
+	for _, peer := range candidates {
+		if _, skip := excluded[peer.id]; skip {
+			continue
 		}
-		if seq == 0 || st.LedgerSeq >= seq {
-			return uint64(pid), true
+		if r.peerSessions != nil && !r.peerSessions.IsPeerConnected(peermanagement.PeerID(peer.id)) {
+			continue
+		}
+		if !haveFallback {
+			fallback, haveFallback = peer.id, true
+		}
+		if seq == 0 || peer.seq >= seq {
+			return peer.id, true
 		}
 	}
 	return fallback, haveFallback
@@ -1346,9 +1391,8 @@ func (r *Router) requestAcquisitionBase(il *inbound.Ledger) {
 	if !ok {
 		return
 	}
-	il.AddPeer(peerID)
-	if err := r.adaptor.RequestLedgerBaseFromPeer(peerID, il.Hash(), il.Seq()); err != nil {
-		r.logger.Warn("failed to retry ledger base request", "error", err)
+	if !r.requestLedgerBase(il, peerID, "failed to retry ledger base request") && il.Reason() != inbound.ReasonGeneric {
+		r.fetchTracker.Remove(il.Hash(), false)
 	}
 }
 

--- a/internal/consensus/adaptor/router_catchup_peer_test.go
+++ b/internal/consensus/adaptor/router_catchup_peer_test.go
@@ -1,6 +1,10 @@
 package adaptor
 
 import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,42 +15,182 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testPeerSessions struct {
+	mu        sync.RWMutex
+	connected map[peermanagement.PeerID]bool
+}
+
+func (s *testPeerSessions) IsPeerConnected(peerID peermanagement.PeerID) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.connected[peerID]
+}
+
+func (s *testPeerSessions) set(peerID peermanagement.PeerID, connected bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.connected[peerID] = connected
+}
+
+type disconnectingPeerSession struct {
+	checks atomic.Uint32
+}
+
+func (s *disconnectingPeerSession) IsPeerConnected(peermanagement.PeerID) bool {
+	return s.checks.Add(1) == 1
+}
+
 func trackCatchupPeer(r *Router, peerID peermanagement.PeerID, seq uint32) {
 	r.peersMu.Lock()
 	r.peerStates[peerID] = &peerLedgerState{LedgerSeq: seq}
 	r.peersMu.Unlock()
 }
 
-func TestRouter_CatchupUsesSameTargetReplacementPeer(t *testing.T) {
+func TestRouter_DropsQueuedStatusAfterPeerDisconnect(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	sessions := &testPeerSessions{connected: map[peermanagement.PeerID]bool{1: true, 2: true}}
+	r.setPeerSessionView(sessions)
+	targetSeq := svc.GetClosedLedgerIndex() + 40
+	targetHash := [32]byte{0xD0}
+	queued := statusChangeMessage(t, 1, targetSeq, targetHash)
+
+	sessions.set(1, false)
+	r.HandlePeerDisconnect(1)
+	trackCatchupPeer(r, 2, targetSeq)
+	r.handleMessage(queued)
+
+	r.peersMu.RLock()
+	_, restored := r.peerStates[1]
+	r.peersMu.RUnlock()
+	assert.False(t, restored)
+	assert.Empty(t, a.PeerReportedLedgers())
+	assert.Empty(t, sender.legacyCalls())
+	assert.Empty(t, sender.replayCalls())
+	seq, hash, preferred := r.bestCatchupTarget()
+	assert.Zero(t, seq)
+	assert.Zero(t, hash)
+	assert.Zero(t, preferred)
+}
+
+func TestRouter_CleansStatusWhenDisconnectRacesDispatch(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	r.setPeerSessionView(&disconnectingPeerSession{})
+	targetSeq := svc.GetClosedLedgerIndex() + 40
+	targetHash := [32]byte{0xCF}
+
+	r.handleMessage(statusChangeMessage(t, 1, targetSeq, targetHash))
+
+	r.peersMu.RLock()
+	_, restored := r.peerStates[1]
+	r.peersMu.RUnlock()
+	assert.False(t, restored)
+	assert.Empty(t, a.PeerReportedLedgers())
+	assert.Empty(t, sender.legacyCalls())
+	assert.Empty(t, sender.replayCalls())
+}
+
+func TestRouter_QueuesDisconnectCleanupOffOverlayLoop(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	targetSeq := svc.GetClosedLedgerIndex() + 40
+	targetHash := [32]byte{0xCE}
+	il := inbound.New(targetHash, targetSeq, 1, serveTestLogger())
+	r.fetchTracker.Track(il)
+	for peerID := peermanagement.PeerID(1); peerID <= 128; peerID++ {
+		trackCatchupPeer(r, peerID, targetSeq)
+	}
+
+	r.peersMu.Lock()
+	queued := make(chan struct{})
+	go func() {
+		for peerID := peermanagement.PeerID(1); peerID <= 128; peerID++ {
+			r.queuePeerDisconnect(peerID)
+		}
+		close(queued)
+	}()
+	select {
+	case <-queued:
+	case <-time.After(time.Second):
+		r.peersMu.Unlock()
+		t.Fatal("queuePeerDisconnect blocked on peer cleanup")
+	}
+	r.peersMu.Unlock()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		r.Run(ctx)
+	}()
+	require.Eventually(t, func() bool {
+		r.peersMu.RLock()
+		remaining := len(r.peerStates)
+		r.peersMu.RUnlock()
+		return remaining == 0 && !containsPeer(il.Peers(), 1)
+	}, time.Second, time.Millisecond)
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatal("router did not join peer disconnect cleanup")
+	}
+}
+
+func TestRouter_CatchupRevalidatesPeerHint(t *testing.T) {
 	r, _, sender, svc := makeRouter(t)
 	targetSeq := svc.GetClosedLedgerIndex() + 40
 	targetHash := [32]byte{0xD1}
+	sessions := &testPeerSessions{connected: map[peermanagement.PeerID]bool{1: false, 2: true}}
+	r.setPeerSessionView(sessions)
 
 	trackCatchupPeer(r, 1, targetSeq)
-	sender.mu.Lock()
-	sender.legacyBaseErr = peermanagement.ErrPeerNotFound
-	sender.mu.Unlock()
-	r.ensureCatchupAcquisition(targetSeq, targetHash, 1)
-	require.NotNil(t, r.fetchTracker.Find(targetHash))
-
-	r.HandlePeerDisconnect(1)
-	_, _, preferred := r.bestCatchupTarget()
-	assert.Zero(t, preferred)
-
-	sender.mu.Lock()
-	sender.legacyBaseErr = nil
-	sender.mu.Unlock()
 	trackCatchupPeer(r, 2, targetSeq)
-	r.ensureCatchupAcquisition(targetSeq, targetHash, 2)
+	r.ensureCatchupAcquisition(targetSeq, targetHash, 1)
 
-	calls := sender.legacyCalls()
-	require.Len(t, calls, 2)
-	assert.Equal(t, uint64(1), calls[0].peerID)
-	assert.Equal(t, uint64(2), calls[1].peerID)
+	require.Equal(t, []legacyBaseCall{{peerID: 2, hash: targetHash, seq: targetSeq}}, sender.legacyCalls())
+	il := r.fetchTracker.Find(targetHash)
+	require.NotNil(t, il)
+	assert.Equal(t, []uint64{2}, il.Peers())
 	seq, hash, preferred := r.bestCatchupTarget()
 	assert.Equal(t, targetSeq, seq)
 	assert.Equal(t, targetHash, hash)
 	assert.Equal(t, uint64(2), preferred)
+}
+
+func TestRouter_CatchupDisconnectErrorRetargetsImmediately(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "peer not found", err: peermanagement.ErrPeerNotFound},
+		{name: "connection closed", err: peermanagement.ErrConnectionClosed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, _, sender, svc := makeRouter(t)
+			targetSeq := svc.GetClosedLedgerIndex() + 40
+			targetHash := [32]byte{0xD2}
+			sessions := &testPeerSessions{connected: map[peermanagement.PeerID]bool{1: true, 2: true}}
+			r.setPeerSessionView(sessions)
+			trackCatchupPeer(r, 1, targetSeq)
+			trackCatchupPeer(r, 2, targetSeq)
+			sender.mu.Lock()
+			sender.legacyBaseErrs = map[uint64]error{1: tc.err}
+			sender.mu.Unlock()
+
+			r.ensureCatchupAcquisition(targetSeq, targetHash, 1)
+
+			calls := sender.legacyCalls()
+			require.Len(t, calls, 2)
+			assert.Equal(t, uint64(1), calls[0].peerID)
+			assert.Equal(t, uint64(2), calls[1].peerID)
+			il := r.fetchTracker.Find(targetHash)
+			require.NotNil(t, il)
+			assert.Equal(t, []uint64{2}, il.Peers())
+			r.peersMu.RLock()
+			_, stale := r.peerStates[1]
+			r.peersMu.RUnlock()
+			assert.False(t, stale)
+		})
+	}
 }
 
 func TestRouter_CatchupWaitsWithoutConnectedPeers(t *testing.T) {
@@ -64,13 +208,167 @@ func TestRouter_CatchupWaitsWithoutConnectedPeers(t *testing.T) {
 	assert.Nil(t, r.fetchTracker.Find(targetHash))
 }
 
+func TestRouter_CatchupPeerNotFoundWaitsWithoutReplacement(t *testing.T) {
+	r, _, sender, svc := makeRouter(t)
+	targetSeq := svc.GetClosedLedgerIndex() + 40
+	targetHash := [32]byte{0xD6}
+	sessions := &testPeerSessions{connected: map[peermanagement.PeerID]bool{1: true}}
+	r.setPeerSessionView(sessions)
+	trackCatchupPeer(r, 1, targetSeq)
+	sender.mu.Lock()
+	sender.legacyBaseErrs = map[uint64]error{1: peermanagement.ErrPeerNotFound}
+	sender.mu.Unlock()
+
+	r.ensureCatchupAcquisition(targetSeq, targetHash, 1)
+	assert.Nil(t, r.fetchTracker.Find(targetHash))
+	for range 20 {
+		r.maintenanceTick()
+	}
+	require.Len(t, sender.legacyCalls(), 1)
+}
+
+func TestRouter_DisconnectRemovesPeerFromActiveAcquisitions(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	targetHash := [32]byte{0xD7}
+	il := inbound.New(targetHash, svc.GetClosedLedgerIndex()+40, 1, serveTestLogger())
+	for peerID := uint64(2); peerID <= 8; peerID++ {
+		require.True(t, il.AddPeer(peerID))
+	}
+	r.fetchTracker.Track(il)
+
+	r.HandlePeerDisconnect(1)
+
+	assert.NotContains(t, il.Peers(), uint64(1))
+	assert.Len(t, il.Peers(), 7)
+	assert.True(t, il.AddPeer(9))
+}
+
+func TestRouter_HistoryPeerNotFoundDoesNotHotLoop(t *testing.T) {
+	r, _, sender, svc := makeRouter(t)
+	targetSeq := svc.GetClosedLedgerIndex() + 40
+	targetHash := [32]byte{0xD8}
+	sessions := &testPeerSessions{connected: map[peermanagement.PeerID]bool{1: true}}
+	r.setPeerSessionView(sessions)
+	trackCatchupPeer(r, 1, targetSeq)
+	sender.mu.Lock()
+	sender.legacyBaseErrs = map[uint64]error{1: peermanagement.ErrPeerNotFound}
+	sender.mu.Unlock()
+	r.startHistoryBackfill(targetSeq, targetHash, 1, svc.GetClosedLedgerIndex())
+
+	for range 20 {
+		r.maintenanceTick()
+	}
+
+	require.Len(t, sender.legacyCalls(), 1)
+	assert.Nil(t, r.fetchTracker.Find(targetHash))
+	r.historyMu.Lock()
+	preferred := r.history.peerID
+	r.historyMu.Unlock()
+	assert.Zero(t, preferred)
+}
+
+func TestRouter_GenericAcquisitionRetargetsDisconnectedPeer(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "peer not found", err: peermanagement.ErrPeerNotFound},
+		{name: "connection closed", err: peermanagement.ErrConnectionClosed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, _, sender, svc := makeRouter(t)
+			targetSeq := svc.GetClosedLedgerIndex() + 40
+			targetHash := [32]byte{0xD9}
+			r.setPeerSessionView(&testPeerSessions{connected: map[peermanagement.PeerID]bool{1: true, 2: true}})
+			trackCatchupPeer(r, 1, targetSeq)
+			trackCatchupPeer(r, 2, targetSeq-1)
+			sender.mu.Lock()
+			sender.legacyBaseErrs = map[uint64]error{1: tc.err}
+			sender.mu.Unlock()
+
+			snap, started, reference := r.RequestLedger(targetHash, targetSeq)
+
+			require.True(t, started)
+			assert.False(t, reference)
+			require.NotNil(t, snap)
+			calls := sender.legacyCalls()
+			require.Len(t, calls, 2)
+			assert.Equal(t, uint64(1), calls[0].peerID)
+			assert.Equal(t, uint64(2), calls[1].peerID)
+			il := r.fetchTracker.Find(targetHash)
+			require.NotNil(t, il)
+			assert.Equal(t, inbound.ReasonGeneric, il.Reason())
+			assert.Equal(t, []uint64{2}, il.Peers())
+		})
+	}
+}
+
+func TestRouter_GenericAcquisitionWaitsForReplacementPeer(t *testing.T) {
+	r, _, sender, svc := makeRouter(t)
+	targetSeq := svc.GetClosedLedgerIndex() + 40
+	targetHash := [32]byte{0xDA}
+	sessions := &testPeerSessions{connected: map[peermanagement.PeerID]bool{1: true}}
+	r.setPeerSessionView(sessions)
+	trackCatchupPeer(r, 1, targetSeq)
+	sender.mu.Lock()
+	sender.legacyBaseErrs = map[uint64]error{1: peermanagement.ErrPeerNotFound}
+	sender.mu.Unlock()
+
+	snap, started, _ := r.RequestLedger(targetHash, targetSeq)
+	require.True(t, started)
+	require.NotNil(t, snap)
+	il := r.fetchTracker.Find(targetHash)
+	require.NotNil(t, il)
+	assert.Empty(t, il.Peers())
+	require.Len(t, sender.legacyCalls(), 1)
+
+	joined, joinedStarted, _ := r.RequestLedger(targetHash, targetSeq)
+	assert.True(t, joinedStarted)
+	assert.NotNil(t, joined)
+	assert.Len(t, sender.legacyCalls(), 1)
+
+	sessions.set(2, true)
+	trackCatchupPeer(r, 2, targetSeq)
+	r.escalateAcquisition(il, time.Now().Add(4*time.Second))
+
+	calls := sender.legacyCalls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, uint64(2), calls[1].peerID)
+	assert.Equal(t, []uint64{2}, il.Peers())
+}
+
+func TestRouter_PeerlessAcquisitionSkipsFetchPackEscalation(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	child := svc.GetClosedLedger()
+	require.NotNil(t, child)
+	parent, err := svc.GetLedgerByHash(child.ParentHash())
+	require.NoError(t, err)
+	require.NotNil(t, parent)
+	il := inbound.NewGeneric(parent.Hash(), parent.Sequence(), 1, serveTestLogger())
+	require.NoError(t, il.GotBase(r.buildLedgerBaseNodes(parent)))
+	require.True(t, il.RemovePeer(1))
+
+	r.escalateAcquisition(il, time.Now().Add(4*time.Second))
+
+	assert.False(t, il.FetchPackRequested())
+}
+
+func containsPeer(peers []uint64, peerID uint64) bool {
+	for _, candidate := range peers {
+		if candidate == peerID {
+			return true
+		}
+	}
+	return false
+}
+
 func TestRouter_CatchupBaseRequestFailureUsesInboundRetryTimer(t *testing.T) {
 	r, _, sender, svc := makeRouter(t)
 	targetSeq := svc.GetClosedLedgerIndex() + 40
 	targetHash := [32]byte{0xD3}
 	trackCatchupPeer(r, 7, targetSeq)
 	sender.mu.Lock()
-	sender.legacyBaseErr = peermanagement.ErrPeerNotFound
+	sender.legacyBaseErr = errors.New("temporary send failure")
 	sender.mu.Unlock()
 
 	r.ensureCatchupAcquisition(targetSeq, targetHash, 7)
@@ -136,7 +434,7 @@ func TestRouter_CatchupUsesReplacementValidationPeer(t *testing.T) {
 		LedgerID:  consensus.LedgerID([32]byte{0xD4}),
 	}
 	sender.mu.Lock()
-	sender.legacyBaseErr = peermanagement.ErrPeerNotFound
+	sender.legacyBaseErrs = map[uint64]error{7: peermanagement.ErrPeerNotFound}
 	sender.mu.Unlock()
 
 	r.maybeAcquireFromValidation(v, 7)

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -19,6 +19,15 @@ import (
 func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
 	defer r.recoverFrame(msg, "dispatch")
 
+	if r.peerSessions != nil && !r.peerSessions.IsPeerConnected(msg.PeerID) {
+		return
+	}
+	defer func() {
+		if r.peerSessions != nil && !r.peerSessions.IsPeerConnected(msg.PeerID) {
+			r.HandlePeerDisconnect(msg.PeerID)
+		}
+	}()
+
 	msgType := message.MessageType(msg.Type)
 
 	switch msgType {

--- a/internal/consensus/adaptor/router_ledger_request_test.go
+++ b/internal/consensus/adaptor/router_ledger_request_test.go
@@ -2,6 +2,7 @@ package adaptor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
@@ -47,8 +48,8 @@ func TestRouter_RequestLedger_TriggersGenericAcquisition(t *testing.T) {
 	assert.Len(t, rs.legacyCalls(), 1, "repeat request must not re-issue the fetch")
 }
 
-// TestRouter_RequestLedger_NoPeers verifies that with no connected peer the
-// coordinator reports it could not start an acquisition.
+// TestRouter_RequestLedger_NoPeers verifies that an acquisition remains
+// available for a peer that connects after the RPC request.
 func TestRouter_RequestLedger_NoPeers(t *testing.T) {
 	r, _, rs, _ := makeRouter(t)
 
@@ -56,8 +57,19 @@ func TestRouter_RequestLedger_NoPeers(t *testing.T) {
 	target[0] = 0x99
 
 	snap, started, _ := r.RequestLedger(target, 0)
-	assert.False(t, started)
-	assert.Nil(t, snap)
+	require.True(t, started)
+	require.NotNil(t, snap)
 	assert.Empty(t, rs.legacyCalls())
-	assert.Nil(t, r.fetchTracker.Find(target))
+	il := r.fetchTracker.Find(target)
+	require.NotNil(t, il)
+	assert.Equal(t, inbound.ReasonGeneric, il.Reason())
+	assert.Empty(t, il.Peers())
+
+	trackCatchupPeer(r, 7, 1)
+	r.escalateAcquisition(il, time.Now().Add(4*time.Second))
+
+	calls := rs.legacyCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, uint64(7), calls[0].peerID)
+	assert.Equal(t, []uint64{7}, il.Peers())
 }

--- a/internal/consensus/adaptor/router_replay_delta_test.go
+++ b/internal/consensus/adaptor/router_replay_delta_test.go
@@ -33,6 +33,7 @@ type recordingSender struct {
 	replayDeltaCalls []replayDeltaCall
 	legacyBaseCalls  []legacyBaseCall
 	legacyBaseErr    error
+	legacyBaseErrs   map[uint64]error
 	// peerSupportsReplay controls the handshake-feature answer. Defaults
 	// to true so existing tests continue to exercise the "peer advertises
 	// ledger-replay" path without extra setup; tests that want to cover
@@ -68,6 +69,9 @@ func (s *recordingSender) RequestLedgerBaseFromPeer(peerID uint64, hash [32]byte
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.legacyBaseCalls = append(s.legacyBaseCalls, legacyBaseCall{peerID: peerID, hash: hash, seq: seq})
+	if err, ok := s.legacyBaseErrs[peerID]; ok {
+		return err
+	}
 	return s.legacyBaseErr
 }
 

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -391,6 +391,7 @@ func NewFromConfig(
 	router.SetTxInbox(overlay.TxMessages())
 	router.SetAcqInbox(overlay.LedgerDataMessages())
 	router.SetManifestCache(manifestCache, overlay)
+	router.setPeerSessionView(overlay)
 	router.SetMinimumOnlineFloor(floor)
 
 	// Build the publisher-list aggregator when validator_list_keys are
@@ -464,12 +465,12 @@ func NewFromConfig(
 		}
 	}
 
-	// Plumb peer disconnect notifications back through the router so
+	// Queue peer disconnect notifications for router-owned cleanup so
 	// per-peer state (peerStates for catch-up, peerLCLs for the
-	// getNetworkLedger vote) is cleaned the instant a peer goes away.
+	// getNetworkLedger vote) is cleaned without blocking the overlay event loop.
 	// Without this a disconnected peer's stale LCL keeps influencing
 	// consensus convergence.
-	overlay.SetPeerDisconnectCallback(router.HandlePeerDisconnect)
+	overlay.SetPeerDisconnectCallback(router.queuePeerDisconnect)
 
 	// Emit cached validator manifests (local + aggregated remote) the
 	// moment a peer's handshake completes, so the new peer can resolve

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -202,6 +202,9 @@ func New(hash [32]byte, seq uint32, peerID uint64, logger *slog.Logger, opts ...
 // the ledger is persisted for querying but not adopted into the active chain.
 func NewGeneric(hash [32]byte, seq uint32, peerID uint64, logger *slog.Logger, opts ...Option) *Ledger {
 	l := New(hash, seq, peerID, logger, opts...)
+	if peerID == 0 {
+		l.peers = nil
+	}
 	l.reason = ReasonGeneric
 	return l
 }
@@ -264,6 +267,19 @@ func (l *Ledger) AddPeer(peerID uint64) bool {
 	}
 	l.peers = append(l.peers, peerID)
 	return true
+}
+
+// RemovePeer removes peerID from the acquisition's source set.
+func (l *Ledger) RemovePeer(peerID uint64) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i, id := range l.peers {
+		if id == peerID {
+			l.peers = slices.Delete(l.peers, i, i+1)
+			return true
+		}
+	}
+	return false
 }
 
 // Timeouts returns the number of no-progress timer intervals counted so far,

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -134,6 +134,12 @@ func (o *Overlay) getPeer(peerID PeerID) (*Peer, bool) {
 	return peer, ok
 }
 
+// IsPeerConnected reports whether peerID still identifies a live session.
+func (o *Overlay) IsPeerConnected(peerID PeerID) bool {
+	peer, ok := o.getPeer(peerID)
+	return ok && peer.State() == PeerStateConnected
+}
+
 // Send sends a message to a specific peer.
 func (o *Overlay) Send(peerID PeerID, msg []byte) error {
 	peer, ok := o.getPeer(peerID)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1219,50 +1219,6 @@ Behavioral oracle: clean local rippled `3.2.0` worktree at
   on `fix/issue-1360-peer-private-fixed-peers`; PR #1364 targets `main` at
   https://github.com/LeJamon/go-xrpl/pull/1364.
 
-# Issue #1391 — stale initial-sync catch-up peer
-
-Target: `origin/main` at `456073c17acc79b2022c010f2173ab3e71e92580`.
-Behavioral oracle: clean local rippled `3.2.0` worktree at
-`3c43f4614f87965298773279ff5b85d4c56c637b`.
-
-## Plan
-
-- [x] Validate GitHub access, issue state and discussion, linked PRs, active
-      release branches, exact base, and clean dedicated worktree.
-- [x] Trace the complete catch-up target, peer lifecycle, acquisition dispatch,
-      immediate-failure, and maintenance retry paths with their current tests.
-- [x] Verify rippled v3.2.0 peer selection, disconnect, and acquisition retry
-      behavior in the pinned local oracle.
-- [x] Add focused regressions for same-sequence replacement, no eligible peers,
-      disconnect invalidation, and bounded retries after immediate dispatch failure.
-- [x] Implement the smallest production-quality fix preserving existing sync
-      behavior while eliminating stale-peer dispatch and the 100 ms hot loop.
-- [x] Run formatting, focused and race tests, affected core tests, build, vet,
-      strict CI lint, advisory lint, and diff checks.
-- [x] Review the complete diff for concurrency, failure paths, oracle parity, and
-      test coverage; record exact results below.
-- [x] Stage only intentional files, commit, push, open the PR against `main`, and
-      verify the published head and initial CI state.
-
-## Review
-
-- Catch-up dispatch now uses a fresh gossip origin or selects from currently
-  connected peer state at timer-driven dispatch; disconnects invalidate cached
-  target provenance and same-ledger replacements join the retained acquisition.
-- Immediate base-request failures remain in one acquisition governed by the
-  existing three-second timer and seven-attempt no-progress budget. Exhausted
-  acquisition hashes enter a five-minute recent-failure cache, including forward
-  child ledgers and direct validation/status acquisition paths.
-- The behavior matches rippled v3.2.0's live peer resolution, fixed timeout
-  progression, bounded retry count, and five-minute recent-failure suppression.
-- Verification passed: `go test ./internal/consensus/adaptor/... -count=1`, the
-  focused race suite, `just test-core`, `just build-all`, `just vet`, tagged
-  PostgreSQL vet, strict golangci-lint v2.11.3, advisory lint, gofmt, and
-  `git diff --check`.
-- Final adversarial review found no unresolved lock-order, data-race, retry-bound,
-  peer-replacement, or rippled-conformance blocker after centralizing the failed
-  hash gate in the shared consensus acquisition entry point.
-
 # Issue #1396 — queued status from a disconnected peer
 
 Target: `origin/main` at `e171f7c3dbf7741cbcd89ca7c5b1bad270aefe19`.
@@ -1334,3 +1290,47 @@ Behavioral oracle: clean local rippled `3.2.0` worktree at
   `golangci-lint`; PostgreSQL-tagged vet; and `git diff --check`.
 - Two independent final reviews found no remaining correctness, race, deadlock,
   callback-lifecycle, test-coverage, or rippled-conformance blockers.
+
+# Issue #1391 — stale initial-sync catch-up peer
+
+Target: `origin/main` at `456073c17acc79b2022c010f2173ab3e71e92580`.
+Behavioral oracle: clean local rippled `3.2.0` worktree at
+`3c43f4614f87965298773279ff5b85d4c56c637b`.
+
+## Plan
+
+- [x] Validate GitHub access, issue state and discussion, linked PRs, active
+      release branches, exact base, and clean dedicated worktree.
+- [x] Trace the complete catch-up target, peer lifecycle, acquisition dispatch,
+      immediate-failure, and maintenance retry paths with their current tests.
+- [x] Verify rippled v3.2.0 peer selection, disconnect, and acquisition retry
+      behavior in the pinned local oracle.
+- [x] Add focused regressions for same-sequence replacement, no eligible peers,
+      disconnect invalidation, and bounded retries after immediate dispatch failure.
+- [x] Implement the smallest production-quality fix preserving existing sync
+      behavior while eliminating stale-peer dispatch and the 100 ms hot loop.
+- [x] Run formatting, focused and race tests, affected core tests, build, vet,
+      strict CI lint, advisory lint, and diff checks.
+- [x] Review the complete diff for concurrency, failure paths, oracle parity, and
+      test coverage; record exact results below.
+- [x] Stage only intentional files, commit, push, open the PR against `main`, and
+      verify the published head and initial CI state.
+
+## Review
+
+- Catch-up dispatch now uses a fresh gossip origin or selects from currently
+  connected peer state at timer-driven dispatch; disconnects invalidate cached
+  target provenance and same-ledger replacements join the retained acquisition.
+- Immediate base-request failures remain in one acquisition governed by the
+  existing three-second timer and seven-attempt no-progress budget. Exhausted
+  acquisition hashes enter a five-minute recent-failure cache, including forward
+  child ledgers and direct validation/status acquisition paths.
+- The behavior matches rippled v3.2.0's live peer resolution, fixed timeout
+  progression, bounded retry count, and five-minute recent-failure suppression.
+- Verification passed: `go test ./internal/consensus/adaptor/... -count=1`, the
+  focused race suite, `just test-core`, `just build-all`, `just vet`, tagged
+  PostgreSQL vet, strict golangci-lint v2.11.3, advisory lint, gofmt, and
+  `git diff --check`.
+- Final adversarial review found no unresolved lock-order, data-race, retry-bound,
+  peer-replacement, or rippled-conformance blocker after centralizing the failed
+  hash gate in the shared consensus acquisition entry point.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1262,3 +1262,75 @@ Behavioral oracle: clean local rippled `3.2.0` worktree at
 - Final adversarial review found no unresolved lock-order, data-race, retry-bound,
   peer-replacement, or rippled-conformance blocker after centralizing the failed
   hash gate in the shared consensus acquisition entry point.
+
+# Issue #1396 — queued status from a disconnected peer
+
+Target: `origin/main` at `e171f7c3dbf7741cbcd89ca7c5b1bad270aefe19`.
+Behavioral oracle: clean local rippled `3.2.0` worktree at
+`3c43f4614f87965298773279ff5b85d4c56c637b`.
+
+## Problem
+
+- The overlay can enqueue a peer's status frame before removing that peer, while
+  the router consumes the frame only after `HandlePeerDisconnect` has cleared
+  the peer's state.
+- Router dispatch carries only the process-unique peer ID, so the delayed status
+  currently recreates `peerStates` and the peer LCL vote for a dead session.
+- Catch-up treats the status origin as a valid send destination. An immediate
+  `ErrPeerNotFound` then remains in the legacy acquisition for its full retry
+  budget instead of selecting a connected replacement.
+- Rippled v3.2.0 serializes status dispatch with the owning connection lifetime
+  and resolves retained acquisition peer IDs through the live overlay at each
+  send boundary.
+
+## Plan
+
+- [x] Validate GitHub access, issue state and comments, linked PRs, active release
+      branches, exact base, clean dedicated worktree, and oracle provenance.
+- [x] Trace router dispatch, peer lifecycle callbacks, status-derived state,
+      acquisition hinting, immediate send failures, timer retries, and existing
+      issue #1391 regressions.
+- [x] Verify the corresponding session-ordering, unique peer identity, live-peer
+      resolution, and replacement behavior against local rippled v3.2.0.
+- [x] Add live-session dispatch checks and a lossless router-owned disconnect
+      cleanup worker so queued messages from ended sessions cannot restore state
+      and the overlay callback never performs acquisition scans.
+- [x] Re-resolve ledger-base destinations after disconnect-class send failures;
+      immediately use a live eligible replacement, retain peerless generic
+      acquisitions, or remove consensus/history acquisitions until re-armed.
+- [x] Add focused regressions for the exact enqueue/disconnect/replacement/status
+      ordering, no-replacement behavior, immediate reselection, and non-disconnect
+      send errors retaining the existing bounded retry semantics.
+- [x] Run formatting, focused and race tests, affected core tests, build, vet,
+      strict CI lint, advisory lint, and diff checks.
+- [x] Review the complete diff for lock ordering, callback races, acquisition
+      ownership, oracle parity, and test coverage; record exact results below.
+- [x] Stage only intentional files, commit, push, open the PR against `main`, and
+      verify the published head and CI state.
+
+## Review
+
+- Dispatch rejects messages whose originating peer session is no longer live and
+  repeats idempotent disconnect cleanup after handling to close the admitted-
+  message/disconnect race. Process-unique, monotonic peer IDs keep that cleanup
+  scoped to the ended connection.
+- The overlay callback publishes disconnect IDs through a coalescing mailbox and
+  nonblocking wake. One router-owned worker performs peer-state, LCL, validator-
+  list, catch-up/history hint, and active-acquisition cleanup and is joined when
+  `Router.Run` exits.
+- Consensus, history, validation-stash, and RPC generic base requests all resolve
+  their peer at the final send boundary. `ErrPeerNotFound` and
+  `ErrConnectionClosed` remove the dead source and immediately try another live
+  peer. Generic acquisitions remain registered with an empty peer set when no
+  peer is available, matching rippled's later timer-driven peer attachment;
+  fetch-pack escalation snapshots one nonzero peer at its own send boundary.
+- Compared with the clean local rippled v3.2.0 oracle at
+  `3c43f4614f87965298773279ff5b85d4c56c637b`: per-session dispatch/close ordering,
+  live peer lookup at send time, `PeerSet` dead-session skipping, generic
+  acquisition retention, and timer-driven replacement behavior match.
+- Verification passed: `just fmt`; relevant package tests and their race build;
+  focused ordering/generic regressions at `-count=100`; `just test-core`;
+  `just build-all`; `just build-nocgo`; `just vet`; strict and advisory
+  `golangci-lint`; PostgreSQL-tagged vet; and `git diff --check`.
+- Two independent final reviews found no remaining correctness, race, deadlock,
+  callback-lifecycle, test-coverage, or rippled-conformance blockers.


### PR DESCRIPTION
## Summary

- drop queued frames once their originating peer session has ended, including disconnect races
- move full disconnect cleanup off the overlay event loop and remove dead peers from every active acquisition
- revalidate consensus, history, and generic ledger acquisition peers at final send boundaries, retaining peerless generic acquisitions for later recovery
- match the pinned local rippled v3.2.0 oracle for session lifetime and inbound-ledger peer selection behavior

## Test plan

- [x] `go test ./internal/ledger/inbound ./internal/consensus/adaptor ./internal/peermanagement -count=1`
- [x] `go test -race ./internal/ledger/inbound ./internal/consensus/adaptor ./internal/peermanagement -count=1`
- [x] focused lifecycle and acquisition regressions at `-count=100`
- [x] `just test-core`
- [x] `just build-all`
- [x] `just build-nocgo`
- [x] `just vet`
- [x] `golangci-lint run --config .golangci.yml`
- [x] `golangci-lint run --config .golangci-warnings.yml`
- [x] `go vet -tags postgres ./storage/relationaldb/postgres/`

Fixes #1396
