### PR TITLE
fix: coordinate cold peer bootstrap

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -103,8 +103,8 @@ type Adaptor struct {
 	txSetCache *TxSetCache
 
 	// Peer-reported last-closed ledger hashes, keyed by overlay peer ID.
-	// Populated by the router on every inbound statusChange so getNetworkLedger
-	// can use peer LCLs even without a fresh proposal from that peer.
+	// Populated from the handshake and subsequent status changes so
+	// getNetworkLedger can use peer LCLs before a proposal arrives.
 	peerLCLsMu sync.RWMutex
 	peerLCLs   map[uint64]consensus.LedgerID
 
@@ -450,9 +450,9 @@ func newPendingValidationResolver(rechecker consensus.ValidationQuorumRechecker)
 	}
 }
 
-// UpdatePeerLCL records the last-closed-ledger hash a peer reported via
-// statusChange, so getNetworkLedger can fall back to peer LCLs when proposal
-// votes are absent or stale. The zero hash removes any existing entry.
+// UpdatePeerLCL records a peer's last-closed-ledger hash so getNetworkLedger
+// can fall back to peer LCLs when proposal votes are absent or stale. The zero
+// hash removes any existing entry.
 func (a *Adaptor) UpdatePeerLCL(peerID uint64, ledger consensus.LedgerID) {
 	a.peerLCLsMu.Lock()
 	defer a.peerLCLsMu.Unlock()

--- a/internal/consensus/adaptor/manifest_emit.go
+++ b/internal/consensus/adaptor/manifest_emit.go
@@ -95,14 +95,13 @@ func (r *Router) manifestEmitter() manifestSender {
 }
 
 // HandlePeerConnect is the callback wired into Overlay.SetPeerConnectCallback.
-// Fires once a peer has finished its handshake and joined the overlay;
-// emits the cached validator manifests so the peer can resolve every
-// known ephemeral signing key back to its trusted master before any
-// validation arrives.
-//
-// Skip cases (cache empty, no overlay) are handled inside
-// SendLocalManifestTo so this stays a thin event-loop trampoline.
+// It records the handshake ledger hint and emits cached validator manifests.
 func (r *Router) HandlePeerConnect(peerID peermanagement.PeerID) {
+	if hints, ok := r.peerSessions.(peerLedgerHintView); ok && r.adaptor != nil {
+		if closed, exists := hints.PeerClosedLedger(peerID); exists {
+			r.adaptor.UpdatePeerLCL(uint64(peerID), closed)
+		}
+	}
 	r.SendLocalManifestTo(peerID)
 }
 

--- a/internal/consensus/adaptor/manifest_emit_test.go
+++ b/internal/consensus/adaptor/manifest_emit_test.go
@@ -31,6 +31,35 @@ type sendCall struct {
 	frame  []byte
 }
 
+type peerLedgerHints struct {
+	closed [32]byte
+}
+
+func (p peerLedgerHints) IsPeerConnected(peermanagement.PeerID) bool {
+	return true
+}
+
+func (p peerLedgerHints) PeerClosedLedger(peermanagement.PeerID) ([32]byte, bool) {
+	return p.closed, true
+}
+
+type peerBootstrapSessions struct {
+	acknowledged peermanagement.PeerID
+	rejected     peermanagement.PeerID
+}
+
+func (*peerBootstrapSessions) IsPeerConnected(peermanagement.PeerID) bool {
+	return true
+}
+
+func (p *peerBootstrapSessions) AcknowledgePeerBootstrap(peerID peermanagement.PeerID) {
+	p.acknowledged = peerID
+}
+
+func (p *peerBootstrapSessions) RejectPeerBootstrap(peerID peermanagement.PeerID) {
+	p.rejected = peerID
+}
+
 func (f *fakeManifestSender) Send(peerID peermanagement.PeerID, frame []byte) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -273,6 +302,72 @@ func TestRouter_HandlePeerConnect_DelegatesToSendLocalManifest(t *testing.T) {
 	}
 	if sender.sends[0].peerID != 42 {
 		t.Errorf("HandlePeerConnect routed to wrong peer: got %v want 42", sender.sends[0].peerID)
+	}
+}
+
+func TestRouterHandlePeerConnectSeedsHandshakeLedgerHint(t *testing.T) {
+	ad := newTestAdaptor(t)
+	router := NewRouter(&mockEngine{}, ad, nil)
+	closed := [32]byte{0xAA, 0xBB}
+	router.setPeerSessionView(peerLedgerHints{closed: closed})
+
+	router.HandlePeerConnect(peermanagement.PeerID(42))
+
+	ledgers := ad.PeerReportedLedgers()
+	if len(ledgers) != 1 {
+		t.Fatalf("peer ledger hints: got %d entries, want 1", len(ledgers))
+	}
+	if got := [32]byte(ledgers[0]); got != closed {
+		t.Fatalf("peer ledger hint: got %x, want %x", got, closed)
+	}
+}
+
+func TestRouterAcknowledgesBootstrapOnlyAfterManifestDecode(t *testing.T) {
+	router, _, _ := routerWithCache(t, nil, 0, 0)
+	sessions := &peerBootstrapSessions{}
+	router.setPeerSessionView(sessions)
+
+	router.processManifestJob(&peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    uint16(message.TypeManifests),
+		Payload: []byte("malformed"),
+	})
+	if sessions.acknowledged != 0 {
+		t.Fatalf("malformed manifests acknowledged peer %d", sessions.acknowledged)
+	}
+	if sessions.rejected != 7 {
+		t.Fatalf("malformed manifests rejected peer %d, want 7", sessions.rejected)
+	}
+
+	sessions.rejected = 0
+	payload, err := message.Encode(&message.Manifests{})
+	if err != nil {
+		t.Fatalf("encode manifests: %v", err)
+	}
+	router.processManifestJob(&peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    uint16(message.TypeManifests),
+		Payload: payload,
+	})
+	if sessions.acknowledged != 7 {
+		t.Fatalf("decoded manifests acknowledged peer %d, want 7", sessions.acknowledged)
+	}
+	if sessions.rejected != 0 {
+		t.Fatalf("decoded empty manifests rejected peer %d", sessions.rejected)
+	}
+}
+
+func TestRouterRejectsBootstrapWhenManifestWorkerIsFull(t *testing.T) {
+	router, _, _ := routerWithCache(t, nil, 0, 0)
+	sessions := &peerBootstrapSessions{}
+	router.setPeerSessionView(sessions)
+	router.manifestJobs = make(chan *peermanagement.InboundMessage, 1)
+	router.manifestJobs <- &peermanagement.InboundMessage{}
+
+	router.submitManifestJob(&peermanagement.InboundMessage{PeerID: 9})
+
+	if sessions.rejected != 9 {
+		t.Fatalf("saturated manifest worker rejected peer %d, want 9", sessions.rejected)
 	}
 }
 

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -36,6 +36,15 @@ type peerSessionView interface {
 	IsPeerConnected(peermanagement.PeerID) bool
 }
 
+type peerLedgerHintView interface {
+	PeerClosedLedger(peermanagement.PeerID) ([32]byte, bool)
+}
+
+type peerBootstrapAcknowledger interface {
+	AcknowledgePeerBootstrap(peermanagement.PeerID)
+	RejectPeerBootstrap(peermanagement.PeerID)
+}
+
 // Router reads inbound messages from the P2P overlay and dispatches
 // them to the consensus engine and adaptor.
 type Router struct {
@@ -653,8 +662,21 @@ func (r *Router) stopManifestWorker() {
 }
 
 func (r *Router) processManifestJob(msg *peermanagement.InboundMessage) {
+	processed := false
+	defer func() {
+		if !processed {
+			if acknowledger, ok := r.peerSessions.(peerBootstrapAcknowledger); ok {
+				acknowledger.RejectPeerBootstrap(msg.PeerID)
+			}
+		}
+	}()
 	defer r.recoverFrame(msg, "manifest")
-	r.handleManifests(msg)
+	processed = r.handleManifests(msg)
+	if processed {
+		if acknowledger, ok := r.peerSessions.(peerBootstrapAcknowledger); ok {
+			acknowledger.AcknowledgePeerBootstrap(msg.PeerID)
+		}
+	}
 }
 
 func (r *Router) submitManifestJob(msg *peermanagement.InboundMessage) {
@@ -666,6 +688,9 @@ func (r *Router) submitManifestJob(msg *peermanagement.InboundMessage) {
 	case r.manifestJobs <- msg:
 	default:
 		r.droppedManifestJobs.Add(1)
+		if acknowledger, ok := r.peerSessions.(peerBootstrapAcknowledger); ok {
+			acknowledger.RejectPeerBootstrap(msg.PeerID)
+		}
 		r.logger.Debug("inbound manifests dropped: worker queue saturated",
 			"t", "consensus", "event", "manifest-shed", "peer", msg.PeerID)
 	}

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -78,21 +78,24 @@ func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
 // Decode failures attribute "manifest-decode" badData to the sender. A
 // mix of valid and invalid entries in the same frame results in the
 // valid ones being applied; the frame isn't rejected wholesale.
-func (r *Router) handleManifests(msg *peermanagement.InboundMessage) {
+func (r *Router) handleManifests(msg *peermanagement.InboundMessage) bool {
 	if r.manifests == nil {
 		// Cache not wired (tests or minimal configs) — silently drop.
-		return
+		return false
 	}
 
 	decoded, err := message.Decode(message.TypeManifests, msg.Payload)
 	if err != nil {
 		r.logger.Warn("failed to decode manifests frame", "error", err, "peer", msg.PeerID)
 		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "manifests-decode")
-		return
+		return false
 	}
 	mfs, ok := decoded.(*message.Manifests)
-	if !ok || len(mfs.List) == 0 {
-		return
+	if !ok {
+		return false
+	}
+	if len(mfs.List) == 0 {
+		return true
 	}
 
 	accepted := make([][]byte, 0, len(mfs.List))
@@ -118,6 +121,7 @@ func (r *Router) handleManifests(msg *peermanagement.InboundMessage) {
 		}
 	}
 	r.relayManifests(accepted)
+	return true
 }
 
 func (r *Router) relayManifests(serialized [][]byte) {

--- a/internal/peermanagement/bootstrap.go
+++ b/internal/peermanagement/bootstrap.go
@@ -1,0 +1,58 @@
+package peermanagement
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type bootstrapGovernor struct {
+	ready atomic.Bool
+
+	mu       sync.Mutex
+	reserved bool
+}
+
+func (g *bootstrapGovernor) isReady() bool {
+	return g.ready.Load()
+}
+
+func (g *bootstrapGovernor) tryReserve() (*bootstrapLease, bool) {
+	if g.ready.Load() {
+		return nil, true
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.ready.Load() {
+		return nil, true
+	}
+	if g.reserved {
+		return nil, false
+	}
+	g.reserved = true
+	return &bootstrapLease{governor: g}, true
+}
+
+type bootstrapLease struct {
+	governor *bootstrapGovernor
+	released atomic.Bool
+}
+
+func (l *bootstrapLease) markReady() {
+	if l == nil || l.released.Swap(true) {
+		return
+	}
+	l.governor.ready.Store(true)
+	l.governor.mu.Lock()
+	l.governor.reserved = false
+	l.governor.mu.Unlock()
+}
+
+func (l *bootstrapLease) release() {
+	if l == nil || l.released.Swap(true) {
+		return
+	}
+	l.governor.mu.Lock()
+	l.governor.reserved = false
+	l.governor.mu.Unlock()
+}

--- a/internal/peermanagement/bootstrap_test.go
+++ b/internal/peermanagement/bootstrap_test.go
@@ -1,0 +1,297 @@
+package peermanagement
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type bootstrapConnection struct {
+	overlay *Overlay
+	peerID  PeerID
+}
+
+func startBootstrapTestOverlay(t *testing.T, opts ...Option) *Overlay {
+	t.Helper()
+	base := []Option{
+		WithListenAddr("127.0.0.1:0"),
+		WithDataDir(t.TempDir()),
+		WithMaxPeers(4),
+		WithMaxInbound(2),
+		WithMaxOutbound(0),
+		WithPrivateMode(true),
+		WithCompression(false),
+	}
+	overlay, err := New(append(base, opts...)...)
+	require.NoError(t, err)
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- overlay.Run(context.Background())
+	}()
+	select {
+	case <-overlay.ListenerReady():
+	case err := <-runDone:
+		t.Fatalf("overlay stopped before its listener became ready: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("overlay listener did not become ready")
+	}
+	t.Cleanup(func() {
+		require.NoError(t, overlay.Stop())
+		select {
+		case <-runDone:
+		case <-time.After(10 * time.Second):
+			t.Error("overlay did not stop")
+		}
+	})
+	return overlay
+}
+
+func TestBootstrapGovernorSerializesColdConnections(t *testing.T) {
+	var governor bootstrapGovernor
+	first, ok := governor.tryReserve()
+	require.True(t, ok)
+	require.NotNil(t, first)
+
+	_, ok = governor.tryReserve()
+	assert.False(t, ok)
+
+	first.release()
+	second, ok := governor.tryReserve()
+	require.True(t, ok)
+	require.NotNil(t, second)
+	second.markReady()
+
+	assert.True(t, governor.isReady())
+	lease, ok := governor.tryReserve()
+	assert.True(t, ok)
+	assert.Nil(t, lease)
+}
+
+func TestDiscoveryBootstrapSelectionLimitsFixedPeers(t *testing.T) {
+	now := time.Unix(1_000, 0)
+	d := NewDiscovery(&Config{
+		MaxOutbound: 3,
+		FixedPeers: []string{
+			"192.0.2.1:51235",
+			"192.0.2.2:51235",
+		},
+		Clock: func() time.Time { return now },
+	}, nil)
+	for _, address := range []string{
+		"192.0.2.1:51235",
+		"192.0.2.2:51235",
+		"192.0.2.3:51235",
+	} {
+		d.AddPeer(address, 0, 0)
+	}
+
+	candidates := d.selectPeersToConnect(1, true)
+	require.Len(t, candidates, 1)
+	assert.True(t, d.IsFixed(candidates[0]))
+}
+
+func TestDiscoveryBootstrapSelectionPreservesFixedPeersAtZeroOrdinaryCapacity(t *testing.T) {
+	d := NewDiscovery(&Config{
+		MaxOutbound: 0,
+		FixedPeers: []string{
+			"192.0.2.1:51235",
+			"192.0.2.2:51235",
+		},
+	}, nil)
+	d.AddPeer("192.0.2.1:51235", 0, 0)
+	d.AddPeer("192.0.2.2:51235", 0, 0)
+
+	candidates := d.selectPeersToConnect(0, true)
+	require.Len(t, candidates, 1)
+	assert.True(t, d.IsFixed(candidates[0]))
+}
+
+func TestDiscoveryBootstrapSelectionPrefersKnownCompression(t *testing.T) {
+	now := time.Unix(2_000, 0)
+	d := NewDiscovery(&Config{
+		MaxOutbound: 3,
+		Clock:       func() time.Time { return now },
+	}, nil)
+	for _, address := range []string{
+		"192.0.2.1:51235",
+		"192.0.2.2:51235",
+		"192.0.2.3:51235",
+	} {
+		d.AddPeer(address, 0, 0)
+	}
+	d.markNegotiatedCompression("192.0.2.1:51235", false)
+	d.markNegotiatedCompression("192.0.2.2:51235", true)
+
+	candidates := d.selectPeersToConnect(1, true)
+	require.Equal(t, []string{"192.0.2.2:51235"}, candidates)
+}
+
+func TestDiscoveryBootstrapSelectionPrefersCompressionOverFixedPeer(t *testing.T) {
+	now := time.Unix(2_500, 0)
+	fixed := "192.0.2.1:51235"
+	compressed := "192.0.2.2:51235"
+	d := NewDiscovery(&Config{
+		MaxOutbound: 2,
+		FixedPeers:  []string{fixed},
+		Clock:       func() time.Time { return now },
+	}, nil)
+	d.AddPeer(fixed, 0, 0)
+	d.AddPeer(compressed, 0, 0)
+	d.markNegotiatedCompression(fixed, false)
+	d.markNegotiatedCompression(compressed, true)
+
+	assert.Equal(t, []string{compressed}, d.selectPeersToConnect(1, true))
+}
+
+func TestDiscoveryBootstrapRetryDelayStartsAtDisconnect(t *testing.T) {
+	now := time.Unix(3_000, 0)
+	address := "192.0.2.1:51235"
+	d := NewDiscovery(&Config{
+		MaxOutbound: 1,
+		Clock:       func() time.Time { return now },
+	}, nil)
+	d.AddPeer(address, 0, 0)
+	d.MarkConnected(address, 1)
+	d.delayBootstrapRetry(address)
+	d.MarkDisconnected(1)
+
+	assert.Empty(t, d.selectPeersToConnect(1, true))
+	now = now.Add(recentConnectAttempt)
+	assert.Equal(t, []string{address}, d.selectPeersToConnect(1, true))
+}
+
+func TestPeerBootstrapAcknowledgementFiresOnce(t *testing.T) {
+	called := 0
+	peer := &Peer{onBootstrapReady: func() { called++ }}
+
+	peer.acknowledgeBootstrap()
+	peer.acknowledgeBootstrap()
+	assert.Equal(t, 1, called)
+}
+
+func TestOverlayMalformedPingDoesNotAcknowledgeBootstrap(t *testing.T) {
+	var governor bootstrapGovernor
+	lease, ok := governor.tryReserve()
+	require.True(t, ok)
+	overlay := &Overlay{peers: map[PeerID]*Peer{
+		1: {id: 1, onBootstrapReady: lease.markReady},
+	}}
+
+	overlay.onMessageReceived(Event{
+		PeerID:      1,
+		MessageType: uint16(message.TypePing),
+		Payload:     []byte("not-a-ping"),
+	})
+
+	assert.False(t, governor.isReady())
+}
+
+func TestOverlayPingDoesNotBypassSeenManifest(t *testing.T) {
+	var governor bootstrapGovernor
+	lease, ok := governor.tryReserve()
+	require.True(t, ok)
+	peer := &Peer{id: 1, onBootstrapReady: lease.markReady}
+	peer.bootstrapManifest.Store(true)
+	overlay := &Overlay{peers: map[PeerID]*Peer{1: peer}}
+	payload, err := message.Encode(&message.Ping{PType: message.PingTypePong, Seq: 1})
+	require.NoError(t, err)
+
+	overlay.onMessageReceived(Event{
+		PeerID:      1,
+		MessageType: uint16(message.TypePing),
+		Payload:     payload,
+	})
+
+	assert.False(t, governor.isReady())
+}
+
+func TestOverlayDroppedManifestDoesNotAcknowledgeBootstrap(t *testing.T) {
+	var governor bootstrapGovernor
+	lease, ok := governor.tryReserve()
+	require.True(t, ok)
+	peer := &Peer{id: 1, onBootstrapReady: lease.markReady, closeCh: make(chan struct{})}
+	peer.bootstrapManifest.Store(true)
+	messages := make(chan *InboundMessage, 1)
+	messages <- &InboundMessage{}
+	overlay := &Overlay{
+		peers:    map[PeerID]*Peer{1: peer},
+		messages: messages,
+	}
+	payload, err := message.Encode(&message.Manifests{
+		List: []message.Manifest{{STObject: []byte{1}}},
+	})
+	require.NoError(t, err)
+
+	overlay.onMessageReceived(Event{
+		PeerID:      1,
+		MessageType: uint16(message.TypeManifests),
+		Payload:     payload,
+	})
+
+	assert.False(t, governor.isReady())
+	select {
+	case <-peer.closeCh:
+	default:
+		t.Fatal("dropped bootstrap manifests did not close the peer")
+	}
+}
+
+func TestOverlayColdBootstrapAdmitsOnePeerUntilStartupFrameCompletes(t *testing.T) {
+	connections := make(chan bootstrapConnection, 2)
+	first := startBootstrapTestOverlay(t)
+	second := startBootstrapTestOverlay(t, WithListenAddr("[::1]:0"))
+	first.SetPeerConnectCallback(func(peerID PeerID) {
+		connections <- bootstrapConnection{overlay: first, peerID: peerID}
+	})
+	second.SetPeerConnectCallback(func(peerID PeerID) {
+		connections <- bootstrapConnection{overlay: second, peerID: peerID}
+	})
+
+	client := startBootstrapTestOverlay(t,
+		WithMaxOutbound(2),
+		WithFixedPeers(first.ListenAddr(), second.ListenAddr()),
+	)
+
+	var connected bootstrapConnection
+	select {
+	case connected = <-connections:
+	case <-time.After(10 * time.Second):
+		t.Fatal("first bootstrap peer did not connect")
+	}
+
+	client.autoconnect(context.Background())
+	select {
+	case <-connections:
+		t.Fatal("second bootstrap peer connected before the first startup frame completed")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	payload, err := message.Encode(&message.Manifests{
+		List: []message.Manifest{{STObject: []byte{1}}},
+	})
+	require.NoError(t, err)
+	var frame bytes.Buffer
+	require.NoError(t, message.WriteMessage(&frame, message.TypeManifests, payload))
+	require.NoError(t, connected.overlay.Send(connected.peerID, frame.Bytes()))
+	select {
+	case inbound := <-client.Messages():
+		_, err := message.Decode(message.TypeManifests, inbound.Payload)
+		require.NoError(t, err)
+		client.AcknowledgePeerBootstrap(inbound.PeerID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("startup manifests did not reach the protocol consumer")
+	}
+	require.Eventually(t, client.bootstrap.isReady, 5*time.Second, 10*time.Millisecond)
+
+	client.autoconnect(context.Background())
+	select {
+	case <-connections:
+	case <-time.After(10 * time.Second):
+		t.Fatal("second bootstrap peer did not connect after the startup frame completed")
+	}
+}

--- a/internal/peermanagement/discovery.go
+++ b/internal/peermanagement/discovery.go
@@ -347,6 +347,9 @@ type DiscoveredPeer struct {
 	PeerID    PeerID
 	Source    PeerID
 
+	compressionKnown    bool
+	supportsCompression bool
+
 	// Position in Discovery.lru; guarded by Discovery.mu.
 	lruEntry *list.Element
 }
@@ -824,6 +827,10 @@ func (d *Discovery) NeedsMorePeers() bool {
 
 // SelectPeersToConnect returns candidate addresses to connect to.
 func (d *Discovery) SelectPeersToConnect(count int) []string {
+	return d.selectPeersToConnect(count, false)
+}
+
+func (d *Discovery) selectPeersToConnect(count int, bootstrap bool) []string {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -891,14 +898,28 @@ func (d *Discovery) SelectPeersToConnect(count int) []string {
 		rand.Shuffle(len(candidates), func(i, j int) {
 			candidates[i], candidates[j] = candidates[j], candidates[i]
 		})
-
-		if count > 0 && count < len(candidates) {
+		if !bootstrap && count > 0 && count < len(candidates) {
 			candidates = candidates[:count]
 		} else if count <= 0 {
 			candidates = nil
 		}
 	}
 	candidates = append(fixedCandidates, candidates...)
+	if bootstrap {
+		d.rankCompressionCandidatesLocked(candidates)
+		if count <= 0 && len(fixedCandidates) > 0 {
+			for _, address := range candidates {
+				if d.fixedPeers[address] {
+					candidates = []string{address}
+					break
+				}
+			}
+		} else if count <= 0 {
+			candidates = nil
+		} else if len(candidates) > count {
+			candidates = candidates[:count]
+		}
+	}
 	for _, address := range candidates {
 		attempt := d.connectAttempts[address]
 		if attempt == nil {
@@ -915,6 +936,52 @@ func (d *Discovery) SelectPeersToConnect(count int) []string {
 		d.recentAttempts[connectAttemptHost(address)] = now.Add(recentConnectAttempt)
 	}
 	return candidates
+}
+
+func (d *Discovery) rankCompressionCandidatesLocked(candidates []string) {
+	rand.Shuffle(len(candidates), func(i, j int) {
+		candidates[i], candidates[j] = candidates[j], candidates[i]
+	})
+	rank := func(address string) int {
+		peer := d.peers[address]
+		if peer != nil && peer.compressionKnown && peer.supportsCompression {
+			if d.fixedPeers[address] {
+				return 0
+			}
+			return 1
+		}
+		if (peer == nil || !peer.compressionKnown) && d.fixedPeers[address] {
+			return 2
+		}
+		if peer == nil || !peer.compressionKnown {
+			return 3
+		}
+		if d.fixedPeers[address] {
+			return 4
+		}
+		return 5
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return rank(candidates[i]) < rank(candidates[j])
+	})
+}
+
+func (d *Discovery) markNegotiatedCompression(address string, enabled bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	peer := d.peers[address]
+	if peer == nil {
+		peer = &DiscoveredPeer{Address: address, LastSeen: d.now()}
+		d.insertPeerLocked(peer)
+	}
+	peer.compressionKnown = true
+	peer.supportsCompression = enabled
+}
+
+func (d *Discovery) delayBootstrapRetry(address string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.recentAttempts[connectAttemptHost(address)] = d.now().Add(recentConnectAttempt)
 }
 
 // finishConnectAttempt releases an autoconnect reservation. Network failures

--- a/internal/peermanagement/errors.go
+++ b/internal/peermanagement/errors.go
@@ -3,6 +3,7 @@ package peermanagement
 import (
 	"errors"
 	"fmt"
+	"time"
 )
 
 // Sentinel errors for peer management operations.
@@ -49,6 +50,30 @@ var (
 )
 
 var errCompressionUnnegotiated = errors.New("outbound compressed frame without negotiated compression")
+var errBootstrapManifestDropped = errors.New("bootstrap manifests could not be delivered")
+
+// FrameReadError describes a failed payload transfer after its header was read.
+type FrameReadError struct {
+	MessageType MessageType
+	WireSize    uint32
+	Compressed  bool
+	BytesRead   uint64
+	Elapsed     time.Duration
+	Err         error
+}
+
+func (e *FrameReadError) Error() string {
+	var rate uint64
+	if e.Elapsed > 0 {
+		rate = e.BytesRead * uint64(time.Second) / uint64(e.Elapsed)
+	}
+	return fmt.Sprintf("failed to read %s payload: wire_size=%d compressed=%t bytes_read=%d elapsed=%s rate=%dB/s: %v",
+		e.MessageType, e.WireSize, e.Compressed, e.BytesRead, e.Elapsed, rate, e.Err)
+}
+
+func (e *FrameReadError) Unwrap() error {
+	return e.Err
+}
 
 // PeerError wraps an error with peer context.
 type PeerError struct {

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -80,7 +80,11 @@ type Overlay struct {
 
 	// outboundSem caps concurrent autoconnect Connect goroutines so
 	// a slow discovery tick cannot stack one goroutine per candidate.
-	outboundSem chan struct{}
+	outboundSem      chan struct{}
+	peerStartMu      sync.Mutex
+	peerStartWG      sync.WaitGroup
+	peerStartsClosed bool
+	bootstrap        bootstrapGovernor
 
 	// relayedIndex maps suppression-hash → set of peers known to have
 	// that message. Populated as we forward a validator message (each
@@ -631,6 +635,41 @@ func (o *Overlay) PeerSupports(peerID PeerID, f Feature) bool {
 	return caps.HasFeature(f)
 }
 
+// PeerClosedLedger returns the closed-ledger hash advertised during the
+// handshake or in the peer's latest status message.
+func (o *Overlay) PeerClosedLedger(peerID PeerID) ([32]byte, bool) {
+	peer, ok := o.getPeer(peerID)
+	if !ok {
+		return [32]byte{}, false
+	}
+	return peer.ClosedLedger()
+}
+
+// AcknowledgePeerBootstrap releases cold-start admission after a peer's
+// startup traffic has been parsed and accepted by its protocol handler.
+func (o *Overlay) AcknowledgePeerBootstrap(peerID PeerID) {
+	peer, ok := o.getPeer(peerID)
+	if ok {
+		peer.acknowledgeBootstrap()
+	}
+}
+
+// RejectPeerBootstrap closes a cold-start peer whose startup traffic could
+// not be processed, allowing the automatic dialer to retry another endpoint.
+func (o *Overlay) RejectPeerBootstrap(peerID PeerID) {
+	peer, ok := o.getPeer(peerID)
+	if ok && peer.onBootstrapReady != nil && !o.bootstrap.isReady() {
+		peer.Close()
+	}
+}
+
+func (o *Overlay) acknowledgePeerBootstrapPing(peerID PeerID) {
+	peer, ok := o.getPeer(peerID)
+	if ok && !peer.bootstrapManifest.Load() {
+		peer.acknowledgeBootstrap()
+	}
+}
+
 // PeerRemoteAddr returns the peer's remote endpoint as "host:port", or
 // "" if the peer is unknown. Used to populate the `uri` field on
 // per-publisher state for peer-sourced lists.
@@ -932,6 +971,10 @@ func (o *Overlay) Run(ctx context.Context) error {
 // calls (defensive cleanup, error-path + deferred stop) are no-ops.
 func (o *Overlay) Stop() error {
 	o.stopOnce.Do(func() {
+		o.peerStartMu.Lock()
+		o.peerStartsClosed = true
+		o.peerStartMu.Unlock()
+
 		// Release any lifecycle send blocked on an event loop that is
 		// about to exit, so run-watcher goroutines drain cleanly under
 		// peerWG.Wait below. Guarded for overlays built outside New (some
@@ -965,6 +1008,7 @@ func (o *Overlay) Stop() error {
 		}
 		o.peersMu.Unlock()
 
+		o.peerStartWG.Wait()
 		o.peerWG.Wait()
 
 		if o.resourceManager != nil {

--- a/internal/peermanagement/overlay_discovery.go
+++ b/internal/peermanagement/overlay_discovery.go
@@ -29,34 +29,56 @@ func (o *Overlay) discoveryLoop(ctx context.Context) error {
 
 // autoconnect attempts to connect to peers if we need more.
 func (o *Overlay) autoconnect(ctx context.Context) {
-	// Reconcile discovery's Connected view with the live overlay peer
-	// set first. Without this, an event-bus race on disconnect can
-	// leave fixed peers marked Connected=true in d.peers even after
-	// their TCP connection ended — and SelectPeersToConnect filters
-	// them out forever. Observed in iter23/24 soak: a single dropped
-	// rippled connection on goxrpl-1 stranded the network sub-quorum
-	// because Autoconnect reported `candidates=0 needed=N` indefinitely.
 	o.reconcileDiscoveryConnected()
 
 	count := o.cfg.MaxOutbound - o.ordinaryOutboundCount()
 	count = max(count, 0)
 
-	addrs := o.discovery.SelectPeersToConnect(count)
+	cold := !o.bootstrap.isReady()
+	var lease *bootstrapLease
+	if cold {
+		var ok bool
+		lease, ok = o.bootstrap.tryReserve()
+		if !ok {
+			slog.Info("Autoconnect", "t", "Overlay", "candidates", 0, "needed", 0, "bootstrap", "waiting")
+			return
+		}
+		count = min(count, 1)
+	}
+
+	addrs := o.discovery.selectPeersToConnect(count, cold)
+	if len(addrs) == 0 {
+		lease.release()
+	}
 	slog.Info("Autoconnect", "t", "Overlay", "candidates", len(addrs), "needed", count)
 	for i, addr := range addrs {
 		select {
 		case <-ctx.Done():
+			lease.release()
 			for _, pending := range addrs[i:] {
 				o.discovery.finishConnectAttempt(pending, connectAttemptReleased)
 			}
 			return
 		case o.outboundSem <- struct{}{}:
 		}
-		go func(a string) {
+		dialDone, ok := o.beginPeerStart()
+		if !ok {
+			<-o.outboundSem
+			lease.release()
+			for _, pending := range addrs[i:] {
+				o.discovery.finishConnectAttempt(pending, connectAttemptReleased)
+			}
+			return
+		}
+		peerLease := lease
+		lease = nil
+		go func(a string, bootstrapLease *bootstrapLease, dialDone func()) {
+			defer dialDone()
 			defer func() { <-o.outboundSem }()
-			err := o.Connect(a)
+			err := o.connectReserved(a, bootstrapLease)
 			result := connectAttemptSucceeded
 			if err != nil {
+				bootstrapLease.release()
 				result = connectAttemptReleased
 				if ctx.Err() == nil &&
 					!errors.Is(err, ErrAlreadyConnected) &&
@@ -70,7 +92,7 @@ func (o *Overlay) autoconnect(ctx context.Context) {
 			} else {
 				slog.Info("Peer connected", "t", "Overlay", "addr", a)
 			}
-		}(addr)
+		}(addr, peerLease, dialDone)
 	}
 }
 

--- a/internal/peermanagement/overlay_inbound.go
+++ b/internal/peermanagement/overlay_inbound.go
@@ -102,12 +102,17 @@ func (o *Overlay) acceptLoop(ctx context.Context) error {
 			return ctx.Err()
 		}
 
-		o.peerWG.Add(1)
-		go func(c net.Conn) {
-			defer o.peerWG.Done()
+		startDone, ok := o.beginPeerStart()
+		if !ok {
+			<-o.inboundSem
+			conn.Close()
+			return ErrConnectionClosed
+		}
+		go func(c net.Conn, startDone func()) {
+			defer startDone()
 			defer func() { <-o.inboundSem }()
 			o.handleInbound(ctx, c)
-		}(conn)
+		}(conn, startDone)
 	}
 }
 

--- a/internal/peermanagement/overlay_message.go
+++ b/internal/peermanagement/overlay_message.go
@@ -30,14 +30,6 @@ func (o *Overlay) handleEvent(evt Event) {
 }
 
 func (o *Overlay) onPeerConnected(evt Event) {
-	// Only track outbound connections in discovery — inbound endpoints
-	// use ephemeral source ports that aren't connectable.
-	if !evt.Inbound {
-		o.discovery.MarkConnected(evt.Endpoint.String(), evt.PeerID)
-	}
-	// Notify higher layers AFTER discovery state is updated so any work
-	// they do (e.g. sending us-originated frames to the peer) sees a
-	// fully-bookkept overlay. Mirrors the disconnect callback ordering.
 	if cb := o.onPeerConnectSnapshot(); cb != nil {
 		cb(evt.PeerID)
 	}
@@ -45,7 +37,6 @@ func (o *Overlay) onPeerConnected(evt Event) {
 
 func (o *Overlay) onPeerDisconnected(evt Event) {
 	o.peerDisconnects.Add(1)
-	o.discovery.MarkDisconnected(evt.PeerID)
 	o.relay.RemovePeer(evt.PeerID)
 	// Fire the higher-layer disconnect callback so per-peer state in
 	// consumers (router peerStates, adaptor peerLCLs) gets cleaned.
@@ -118,7 +109,9 @@ func (o *Overlay) onMessageReceived(evt Event) {
 
 	// Handle PING at transport level — respond with PONG immediately
 	if msgType == message.TypePing {
-		o.handlePing(evt)
+		if o.handlePing(evt) {
+			o.acknowledgePeerBootstrapPing(evt.PeerID)
+		}
 		return
 	}
 
@@ -275,6 +268,9 @@ func (o *Overlay) onMessageReceived(evt Event) {
 	default:
 		o.droppedMessages.Add(1)
 		slog.Warn("Message dropped: channel full", "t", "Overlay", "type", msgType.String())
+		if msgType == message.TypeManifests {
+			o.RejectPeerBootstrap(evt.PeerID)
+		}
 	}
 }
 
@@ -593,14 +589,14 @@ func (o *Overlay) handleSquelchMessage(evt Event) {
 	}
 }
 
-func (o *Overlay) handlePing(evt Event) {
+func (o *Overlay) handlePing(evt Event) bool {
 	decoded, err := message.Decode(message.TypePing, evt.Payload)
 	if err != nil {
-		return
+		return false
 	}
 	ping, ok := decoded.(*message.Ping)
 	if !ok {
-		return
+		return false
 	}
 
 	switch ping.PType {
@@ -612,14 +608,17 @@ func (o *Overlay) handlePing(evt Event) {
 		}
 		wireMsg, err := message.EncodeFrame(pong)
 		if err != nil {
-			return
+			return false
 		}
 		o.Send(evt.PeerID, wireMsg)
 	case message.PingTypePong:
 		if peer, exists := o.getPeer(evt.PeerID); exists {
 			peer.OnPong(ping.Seq, time.Now())
 		}
+	default:
+		return false
 	}
+	return true
 }
 
 // onLedgerResponse ships an already-wire-framed ledger-sync response

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -24,6 +24,25 @@ import (
 // this matters only for direct external callers driving many parallel
 // Connects.
 func (o *Overlay) Connect(addr string) error {
+	done, ok := o.beginPeerStart()
+	if !ok {
+		return ErrConnectionClosed
+	}
+	defer done()
+	return o.connectReserved(addr, nil)
+}
+
+func (o *Overlay) beginPeerStart() (func(), bool) {
+	o.peerStartMu.Lock()
+	defer o.peerStartMu.Unlock()
+	if o.peerStartsClosed {
+		return nil, false
+	}
+	o.peerStartWG.Add(1)
+	return o.peerStartWG.Done, true
+}
+
+func (o *Overlay) connectReserved(addr string, bootstrapLease *bootstrapLease) error {
 	endpoint, err := ParseEndpoint(addr)
 	if err != nil {
 		return err
@@ -78,6 +97,13 @@ func (o *Overlay) Connect(addr string) error {
 		})
 		return err
 	}
+	compression := peer.compressionNegotiated()
+	o.discovery.markNegotiatedCompression(addr, compression)
+	slog.Info("Peer handshake complete", "t", "Overlay", "addr", addr,
+		"protocol", peer.ProtocolVersion(), "compression", compression)
+	if bootstrapLease != nil {
+		peer.onBootstrapReady = bootstrapLease.markReady
+	}
 
 	// Re-check after handshake: another goroutine may have connected
 	// to the resolved endpoint while we were handshaking.
@@ -95,6 +121,10 @@ func (o *Overlay) Connect(addr string) error {
 	go func() {
 		defer o.peerWG.Done()
 		err := peer.Run(baseCtx)
+		if bootstrapLease != nil && !o.bootstrap.isReady() && baseCtx.Err() == nil {
+			o.discovery.delayBootstrapRetry(addr)
+		}
+		bootstrapLease.release()
 		if err != nil {
 			slog.Info("Peer run ended", "t", "Overlay", "addr", addr, "err", err)
 			o.notePeerRunEnded(err)
@@ -374,6 +404,9 @@ func (o *Overlay) addPeer(peer *Peer) error {
 		}
 		peer.attachUsage(c, o.bumpPeerDisconnectCharges)
 	}
+	if !peer.Inbound() {
+		o.discovery.MarkConnected(peer.Endpoint().String(), peer.ID())
+	}
 
 	o.dispatchLifecycle(Event{
 		Type:     EventPeerConnected,
@@ -407,6 +440,8 @@ func (o *Overlay) removePeer(peerID PeerID) {
 	if exists {
 		if peer.inbound {
 			o.releaseInboundIP(peer.Endpoint().Host)
+		} else {
+			o.discovery.MarkDisconnected(peerID)
 		}
 		peer.releaseUsage()
 		o.dispatchLifecycle(Event{

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -86,6 +86,13 @@ type Peer struct {
 	// no lock. nil for inbound peers and in tests.
 	onRedirect func([]string)
 
+	// onBootstrapReady is installed before Run for the one outbound peer
+	// admitted during cold start. A protocol handler fires it after accepting
+	// manifests, or a valid PING when the remote had no manifests to send.
+	onBootstrapReady   func()
+	bootstrapReadyOnce sync.Once
+	bootstrapManifest  atomic.Bool
+
 	send   chan []byte
 	events chan<- Event
 
@@ -271,16 +278,18 @@ func (p *Peer) SetDroppedEventsCounter(c *atomic.Uint64) {
 // dispatchEvent attempts a non-blocking send to the events channel.
 // The read hot path and Close path must never block on the event
 // loop, which itself takes overlay-level locks.
-func (p *Peer) dispatchEvent(evt Event) {
+func (p *Peer) dispatchEvent(evt Event) bool {
 	if p.events == nil {
-		return
+		return false
 	}
 	select {
 	case p.events <- evt:
+		return true
 	default:
 		if p.droppedEvents != nil {
 			p.droppedEvents.Add(1)
 		}
+		return false
 	}
 }
 
@@ -871,6 +880,11 @@ type frameProgressReader struct {
 	startedAt           time.Time
 	deadline            time.Time
 	budgetDeadlineArmed bool
+	header              MessageHeader
+	headerSet           bool
+	bytesRead           uint64
+	payloadStart        uint64
+	payloadStartedAt    time.Time
 }
 
 func (p *Peer) newFrameProgressReader(reader io.Reader, conn net.Conn) *frameProgressReader {
@@ -892,6 +906,10 @@ func (p *Peer) newFrameProgressReader(reader io.Reader, conn net.Conn) *framePro
 }
 
 func (r *frameProgressReader) setHeader(header MessageHeader) error {
+	r.header = header
+	r.headerSet = true
+	r.payloadStart = r.bytesRead
+	r.payloadStartedAt = r.peer.readPolicy.now()
 	r.deadline = r.startedAt.Add(r.peer.frameReadBudget(header.PayloadSize))
 
 	r.peer.readProgressMu.Lock()
@@ -928,6 +946,7 @@ func (r *frameProgressReader) Read(dst []byte) (int, error) {
 
 	n, err := r.reader.Read(dst)
 	if n > 0 {
+		r.bytesRead += uint64(n)
 		now = r.peer.readPolicy.now()
 		r.peer.readProgressMu.Lock()
 		if r.peer.readProgress.id == r.frameID && r.peer.readProgress.active {
@@ -939,6 +958,25 @@ func (r *frameProgressReader) Read(dst []byte) (int, error) {
 		}
 	}
 	return n, err
+}
+
+func (r *frameProgressReader) failure(err error, now time.Time) error {
+	if !r.headerSet {
+		return err
+	}
+	bytesRead := r.bytesRead - r.payloadStart
+	elapsed := now.Sub(r.payloadStartedAt)
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	return &FrameReadError{
+		MessageType: r.header.MessageType,
+		WireSize:    r.header.PayloadSize,
+		Compressed:  r.header.Compressed,
+		BytesRead:   bytesRead,
+		Elapsed:     elapsed,
+		Err:         err,
+	}
 }
 
 func (r *frameProgressReader) finish(success bool, now time.Time) {
@@ -1004,14 +1042,14 @@ func (p *Peer) readLoop(ctx context.Context) error {
 				return nil
 			}
 			if errors.Is(err, ErrFrameReadTooSlow) {
-				return ErrFrameReadTooSlow
+				return frameReader.failure(ErrFrameReadTooSlow, now)
 			}
 			var ne net.Error
 			if errors.As(err, &ne) && ne.Timeout() {
 				if frameReader.budgetDeadlineArmed {
-					return ErrFrameReadTooSlow
+					return frameReader.failure(ErrFrameReadTooSlow, now)
 				}
-				return ErrReadIdle
+				return frameReader.failure(ErrReadIdle, now)
 			}
 			// Over-budget size claim is protocol abuse — charge so the
 			// reputation system evicts. Other framing errors are
@@ -1019,7 +1057,7 @@ func (p *Peer) readLoop(ctx context.Context) error {
 			if errors.Is(err, message.ErrMessageTooLarge) {
 				p.IncBadData("message-too-large")
 			}
-			return err
+			return frameReader.failure(err, now)
 		}
 
 		// Account wire bytes (header + on-the-wire payload, before
@@ -1050,11 +1088,17 @@ func (p *Peer) readLoop(ctx context.Context) error {
 		if !message.IsKnownMessageType(header.MessageType) {
 			continue
 		}
+		if header.MessageType == TypeManifests {
+			p.bootstrapManifest.Store(true)
+		}
 
 		if header.Compressed {
 			payload, err = DecompressLZ4(payload, int(header.UncompressedSize))
 			if err != nil {
 				p.IncBadData("decompress-lz4-failed")
+				if header.MessageType == TypeManifests && p.onBootstrapReady != nil {
+					return fmt.Errorf("bootstrap manifests decompression failed: %w", err)
+				}
 				if p.consecutiveDecompressFailures.Add(1) >= maxConsecutiveDecompressFailures {
 					return fmt.Errorf("decompress-lz4 failed %d times in a row: %w",
 						maxConsecutiveDecompressFailures, err)
@@ -1063,17 +1107,26 @@ func (p *Peer) readLoop(ctx context.Context) error {
 			}
 			p.consecutiveDecompressFailures.Store(0)
 		}
-
 		p.traffic.AddCount(CategorizeMessage(uint16(header.MessageType)), true, len(payload))
 
-		p.dispatchEvent(Event{
+		delivered := p.dispatchEvent(Event{
 			Type:        EventMessageReceived,
 			PeerID:      p.id,
 			MessageType: uint16(header.MessageType),
 			Payload:     payload,
 			WireSize:    payloadWireSize,
 		})
+		if !delivered && header.MessageType == TypeManifests && p.onBootstrapReady != nil {
+			return errBootstrapManifestDropped
+		}
 	}
+}
+
+func (p *Peer) acknowledgeBootstrap() {
+	if p.onBootstrapReady == nil {
+		return
+	}
+	p.bootstrapReadyOnce.Do(p.onBootstrapReady)
 }
 
 func (p *Peer) writeLoop(ctx context.Context) error {

--- a/internal/peermanagement/peer_frame_liveness_test.go
+++ b/internal/peermanagement/peer_frame_liveness_test.go
@@ -169,6 +169,54 @@ func TestPeerReadLoopClassifiesWrappedMidFrameTimeoutAsReadIdle(t *testing.T) {
 	require.ErrorIs(t, err, ErrReadIdle)
 }
 
+func TestPeerReadLoopReportsPartialFrameProgress(t *testing.T) {
+	clock := &livenessClock{now: time.Unix(2_500, 0)}
+	payload := []byte("manifest")
+	frame := manifestFrame(t, payload)
+	conn := &chunkedLivenessConn{
+		clock: clock,
+		steps: []connReadStep{
+			{data: frame[:HeaderSizeUncompressed]},
+			{after: 2 * time.Second, data: frame[HeaderSizeUncompressed : HeaderSizeUncompressed+3], err: io.ErrUnexpectedEOF},
+		},
+	}
+	peer, _ := newFrameLivenessPeer(t, clock, conn)
+	peer.readPolicy.minimumFrameRate = 1
+	bootstrapReady := false
+	peer.onBootstrapReady = func() { bootstrapReady = true }
+
+	err := peer.readLoop(context.Background())
+	var frameErr *FrameReadError
+	require.ErrorAs(t, err, &frameErr)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	assert.Equal(t, TypeManifests, frameErr.MessageType)
+	assert.Equal(t, uint32(len(payload)), frameErr.WireSize)
+	assert.False(t, frameErr.Compressed)
+	assert.Equal(t, uint64(3), frameErr.BytesRead)
+	assert.Equal(t, 2*time.Second, frameErr.Elapsed)
+	assert.Contains(t, frameErr.Error(), "rate=1B/s")
+	assert.False(t, bootstrapReady)
+}
+
+func TestPeerReadLoopRejectsDroppedBootstrapManifest(t *testing.T) {
+	clock := &livenessClock{now: time.Unix(2_750, 0)}
+	frame := manifestFrame(t, []byte("manifest"))
+	conn := &chunkedLivenessConn{
+		clock: clock,
+		steps: []connReadStep{{data: frame}},
+	}
+	peer, events := newFrameLivenessPeer(t, clock, conn)
+	for range cap(events) {
+		events <- Event{}
+	}
+	bootstrapReady := false
+	peer.onBootstrapReady = func() { bootstrapReady = true }
+
+	err := peer.readLoop(context.Background())
+	require.ErrorIs(t, err, errBootstrapManifestDropped)
+	assert.False(t, bootstrapReady)
+}
+
 func TestPeerReadLoopRejectsTricklePastFrameBudget(t *testing.T) {
 	clock := &livenessClock{now: time.Unix(3_000, 0)}
 	frame := manifestFrame(t, []byte("slow"))


### PR DESCRIPTION
## Summary

- serialize automatic outbound cold bootstrap until startup manifests are processed, with an empty-cache PING fallback
- prefer learned LZ4-capable endpoints while preserving fixed-peer and reconnect behavior
- seed handshake closed-ledger hints and expose complete partial-frame diagnostics

## Design and rippled parity

- keeps rippled's verified-handshake-to-active lifecycle and startup message ordering
- limits the intentional divergence to automatic outbound admission; inbound and explicit operator connections are unchanged
- treats failures after the active handshake as local retry cooldowns instead of fixed-peer or boot-cache reputation failures

## Test plan

- `go test -count=1 ./internal/peermanagement/... ./internal/consensus/adaptor/...`
- `go test -race ./internal/peermanagement/...`
- `go test -race ./internal/consensus/adaptor/...`
- `just test-core`
- `just build-all`
- `just build-nocgo`
- `just vet`
- `golangci-lint run --config .golangci.yml`
- `just lint`

`just test` remains red only in the existing Batch, NFToken, Vault, XChain, and XChainSim conformance backlog reproduced uncached at exact base `1a115452`.

Fixes #1399
