### PR TITLE
fix: use canonical MPT rounding for escrow fees

### DIFF
--- a/internal/testing/escrow/token_escrow_mpt_test.go
+++ b/internal/testing/escrow/token_escrow_mpt_test.go
@@ -10,6 +10,8 @@ import (
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/escrow"
 	"github.com/LeJamon/go-xrpl/internal/testing/mpt"
+	"github.com/LeJamon/go-xrpl/internal/tx/mptutil"
+	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1063,6 +1065,85 @@ func TestMPTEscrow_CancelPreclaim(t *testing.T) {
 		jtx.RequireTxFail(t, result, jtx.TecNO_AUTH)
 		env.Close()
 	})
+}
+
+// --------------------------------------------------------------------------
+// TestMPTEscrow_TransferFeeRounding
+//
+// Regression for #1402: MPT escrow transfer fees use rippled's canonical MPT
+// divideRound path, whose decimal canonicalization is not a rational ceiling.
+// --------------------------------------------------------------------------
+
+func TestMPTEscrow_TransferFeeRounding(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	env.EnableFeature("TokenEscrow")
+
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	gw := jtx.NewAccount("gw")
+	mptGw := mpt.NewMPTTester(t, env, gw, mpt.MPTInit{
+		Holders: []*jtx.Account{alice, bob},
+	})
+	mptGw.Create(mpt.CreateOpts{
+		TransferFee: mpt.PtrUint16(100),
+		OwnerCount:  mpt.PtrUint32(1),
+		Flags:       mpt.TfMPTCanEscrow | mpt.TfMPTCanTransfer,
+	})
+	mptGw.Authorize(mpt.AuthorizeOpts{Account: alice})
+	mptGw.Authorize(mpt.AuthorizeOpts{Account: bob})
+	mptGw.Pay(gw, alice, 100_000)
+	env.Close()
+
+	mptGw.RequireMPTokenAmount(alice, 100_000)
+	mptGw.RequireMPTokenAmount(bob, 0)
+	require.Equal(t, uint64(100_000), mptGw.IssuanceOutstandingAmount())
+
+	amt := mptAmount(10_000, gw.Address, mptGw.IssuanceID())
+	seq := env.Seq(alice)
+	result := env.Submit(
+		escrow.EscrowCreate(alice, bob, 0).
+			MPTAmount(amt).
+			Condition(escrow.TestCondition1).
+			FinishTime(env.Now().Add(1 * time.Second)).
+			Fee(env.BaseFee() * 150).
+			Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	mptGw.RequireMPTokenAmount(alice, 90_000)
+	mptGw.RequireMPTokenAmount(bob, 0)
+	require.Equal(t, uint64(10_000), mptGw.HolderLockedAmount(alice))
+	require.Equal(t, uint64(10_000), mptGw.IssuanceLockedAmount())
+	require.Equal(t, uint64(100_000), mptGw.IssuanceOutstandingAmount())
+
+	result = env.Submit(
+		escrow.EscrowFinish(bob, alice, seq).
+			Condition(escrow.TestCondition1).
+			Fulfillment(escrow.TestFulfillment1).
+			Fee(env.BaseFee() * 150).
+			Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+
+	mptGw.RequireMPTokenAmount(alice, 90_000)
+	mptGw.RequireMPTokenAmount(bob, 9_990)
+	finalOutstanding := mptGw.IssuanceOutstandingAmount()
+	require.Equal(t, uint64(99_990), finalOutstanding)
+	require.Equal(t, uint64(10), uint64(100_000)-finalOutstanding, "transfer fee burn")
+
+	mptID, err := mptutil.DecodeID(mptGw.IssuanceID())
+	require.NoError(t, err)
+	issuanceData, err := env.Ledger().Read(keylet.MPTIssuance(mptID))
+	require.NoError(t, err)
+	issuance, err := state.ParseMPTokenIssuance(issuanceData)
+	require.NoError(t, err)
+	require.Nil(t, issuance.LockedAmount, "issuance LockedAmount must be removed")
+
+	tokenData, err := env.Ledger().Read(keylet.MPTokenByID(mptID, alice.ID))
+	require.NoError(t, err)
+	token, err := state.ParseMPToken(tokenData)
+	require.NoError(t, err)
+	require.Nil(t, token.LockedAmount, "holder LockedAmount must be removed")
 }
 
 // --------------------------------------------------------------------------

--- a/internal/testing/escrow/token_escrow_mpt_test.go
+++ b/internal/testing/escrow/token_escrow_mpt_test.go
@@ -1067,13 +1067,6 @@ func TestMPTEscrow_CancelPreclaim(t *testing.T) {
 	})
 }
 
-// --------------------------------------------------------------------------
-// TestMPTEscrow_TransferFeeRounding
-//
-// Regression for #1402: MPT escrow transfer fees use rippled's canonical MPT
-// divideRound path, whose decimal canonicalization is not a rational ceiling.
-// --------------------------------------------------------------------------
-
 func TestMPTEscrow_TransferFeeRounding(t *testing.T) {
 	env := jtx.NewTestEnv(t)
 	env.EnableFeature("TokenEscrow")

--- a/internal/tx/escrow/token_helpers.go
+++ b/internal/tx/escrow/token_helpers.go
@@ -1269,24 +1269,27 @@ func computeMPTTransferFee(
 	// Transfer fee only applies when neither party is issuer
 	if (!senderIsIssuer && !receiverIsIssuer) && effectiveRate != parityRate {
 		// fee = amount - divideRound(amount, rate, asset, true)
-		// For MPT amounts (uint64), use big.Int:
-		// divideRound = amount * 1_000_000_000 / rate (rounded up)
-		bigAmount := new(big.Int).SetUint64(originalAmount)
-		bigParity := new(big.Int).SetUint64(uint64(parityRate))
-		bigRate := new(big.Int).SetUint64(uint64(effectiveRate))
+		amount := state.NewMPTAmountWithIssuanceID(
+			int64(originalAmount),
+			state.EncodeAccountIDSafe(issuerID),
+			mptHexID,
+		)
+		rate := state.NewIssuedAmountFromValue(int64(effectiveRate), -9, "", "")
 
-		// amount * parityRate / rate, rounded up
-		numerator := new(big.Int).Mul(bigAmount, bigParity)
-		divided := new(big.Int).Div(numerator, bigRate)
-		// Round up: if numerator % rate != 0, add 1
-		remainder := new(big.Int).Mod(numerator, bigRate)
-		if remainder.Sign() > 0 {
-			divided.Add(divided, big.NewInt(1))
+		// rippled's muldivRound throws if the pre-canonicalization quotient does
+		// not fit in uint64. Guard this path before DivRoundMPT's Uint64 conversion
+		// so an oversized MPT finish becomes tefEXCEPTION instead of truncating.
+		numVal, _ := state.PrepareMulDivOperand(amount)
+		denVal, _ := state.PrepareMulDivOperand(rate)
+		rounded := new(big.Int).Mul(big.NewInt(numVal), big.NewInt(100_000_000_000_000_000))
+		rounded.Add(rounded, big.NewInt(denVal-1))
+		rounded.Quo(rounded, big.NewInt(denVal))
+		if !rounded.IsUint64() {
+			panic("MPT divRound overflow")
 		}
 
-		dividedResult := divided.Uint64()
-		fee := originalAmount - dividedResult
-		return originalAmount, originalAmount - fee
+		finalAmount := uint64(state.DivRoundMPT(amount, rate, true))
+		return originalAmount, finalAmount
 	}
 
 	return originalAmount, originalAmount

--- a/internal/tx/escrow/token_helpers_rounding_test.go
+++ b/internal/tx/escrow/token_helpers_rounding_test.go
@@ -1,0 +1,129 @@
+package escrow
+
+import (
+	"encoding/hex"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+func TestComputeMPTTransferFeeUsesCanonicalRounding(t *testing.T) {
+	const originalAmount = uint64(10_000)
+
+	var issuerID, senderID, receiverID [20]byte
+	issuerID[19] = 0xab
+	senderID[19] = 0xcd
+	receiverID[19] = 0xef
+
+	mptID := keylet.MakeMPTID(1, issuerID)
+	mptHexID := hex.EncodeToString(mptID[:])
+	issuer := state.EncodeAccountIDSafe(issuerID)
+	rate := state.NewIssuedAmountFromValue(1_001_000_000, -9, "", "")
+
+	withoutIssuanceID := state.NewMPTAmountDirect(int64(originalAmount), "", issuer)
+	require.False(t, withoutIssuanceID.IsMPT())
+	require.Equal(t, int64(9_991), state.DivRoundMPT(withoutIssuanceID, rate, true))
+
+	withIssuanceID := state.NewMPTAmountWithIssuanceID(
+		int64(originalAmount),
+		issuer,
+		mptHexID,
+	)
+	require.True(t, withIssuanceID.IsMPT())
+	require.Equal(t, int64(9_990), state.DivRoundMPT(withIssuanceID, rate, true))
+
+	tests := []struct {
+		name         string
+		lockedRate   uint32
+		currentFee   uint16
+		issuerIsDest bool
+		finalAmount  uint64
+	}{
+		{
+			name:        "issue 1402 rounding",
+			lockedRate:  getMPTTransferRate(100),
+			currentFee:  100,
+			finalAmount: 9_990,
+		},
+		{
+			name:        "parity rate",
+			lockedRate:  parityRate,
+			currentFee:  100,
+			finalAmount: originalAmount,
+		},
+		{
+			name:         "issuer is destination",
+			lockedRate:   getMPTTransferRate(100),
+			currentFee:   100,
+			issuerIsDest: true,
+			finalAmount:  originalAmount,
+		},
+		{
+			name:        "locked rate is lower",
+			lockedRate:  getMPTTransferRate(100),
+			currentFee:  200,
+			finalAmount: 9_990,
+		},
+		{
+			name:        "current rate is lower",
+			lockedRate:  getMPTTransferRate(200),
+			currentFee:  100,
+			finalAmount: 9_990,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			view := newMapView()
+			issuance, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+				Issuer:      issuerID,
+				Sequence:    1,
+				TransferFee: tt.currentFee,
+			})
+			require.NoError(t, err)
+			require.NoError(t, view.Insert(keylet.MPTIssuance(mptID), issuance))
+
+			destinationID := receiverID
+			if tt.issuerIsDest {
+				destinationID = issuerID
+			}
+
+			original, final := computeMPTTransferFee(
+				view,
+				tt.lockedRate,
+				mptHexID,
+				senderID,
+				destinationID,
+				originalAmount,
+			)
+			require.Equal(t, originalAmount, original)
+			require.Equal(t, tt.finalAmount, final)
+		})
+	}
+
+	t.Run("canonical intermediate overflow", func(t *testing.T) {
+		view := newMapView()
+		issuance, err := state.SerializeMPTokenIssuance(&state.MPTokenIssuanceData{
+			Issuer:      issuerID,
+			Sequence:    1,
+			TransferFee: 100,
+		})
+		require.NoError(t, err)
+		require.NoError(t, view.Insert(keylet.MPTIssuance(mptID), issuance))
+
+		require.Panics(t, func() {
+			computeMPTTransferFee(
+				view,
+				getMPTTransferRate(100),
+				mptHexID,
+				senderID,
+				receiverID,
+				math.MaxInt64,
+			)
+		})
+	})
+}


### PR DESCRIPTION
## Summary

- replace `EscrowFinish`'s manual MPT transfer-fee ceiling with the issuance-aware `state.DivRoundMPT` path
- preserve the existing `min(lockedRate, currentRate)` selection, parity behavior, and issuer exemption
- add focused rounding/matrix coverage plus a ledger-level regression for the two state differences from ledger 3,275,736
- preserve rippled's pre-canonicalization `uint64` overflow behavior locally so oversized finishes become `tefEXCEPTION` instead of truncating

This is limited to MPT fee calculation during `EscrowFinish`; it contains no v3.3.0-related changes and no public API changes.

## Root cause

The old helper computed a rational integer ceiling directly:

```text
ceil(10000 * 1000000000 / 1001000000) = 9991
```

rippled instead passes an issuance-aware MPT `STAmount` through `divideRound(..., true)`. Its integral normalization and legacy decimal canonicalization produce `9,990`. An amount without its issuance ID does not select that MPT path and reproduces the incorrect `9,991` result.

The fix constructs the amount with `NewMPTAmountWithIssuanceID`, constructs the rate with exponent `-9`, and delegates the result to `DivRoundMPT`.

## State impact

| State | Before | After / rippled |
|---|---:|---:|
| receiver `MPTAmount` | 9,991 | 9,990 |
| fee burn | 9 | 10 |
| issuance `OutstandingAmount` | 99,991 | 99,990 |

The regression also verifies that the holder and issuance `LockedAmount` fields are removed after finish.

## rippled references

- [`Escrow.cpp` MPT unlock/transfer-fee calculation](https://github.com/XRPLF/rippled/blob/3.2.0/src/xrpld/app/tx/detail/Escrow.cpp#L1001-L1009)
- [`STAmount.cpp` `muldivRound` overflow check](https://github.com/XRPLF/rippled/blob/3.2.0/src/libxrpl/protocol/STAmount.cpp#L1315-L1336)
- [`STAmount.cpp` `divRoundImpl`](https://github.com/XRPLF/rippled/blob/3.2.0/src/libxrpl/protocol/STAmount.cpp#L1718-L1797)

## Validation

Passed locally with `CGO_ENABLED=0` (the sandbox-only `GOCACHE=/private/tmp/go-xrpl-issues-gocache` prefix is omitted below):

```text
go test -count=1 -run '^TestComputeMPTTransferFeeUsesCanonicalRounding$' ./internal/tx/escrow
go test -count=1 -run '^TestMPTEscrow_TransferFeeRounding$' ./internal/testing/escrow
go test -count=1 ./internal/tx/escrow ./internal/testing/escrow
go test -count=1 -timeout 15m ./internal/tx/...
go test -count=1 -timeout 15m $(CGO_ENABLED=0 go list ./internal/testing/... | rg -v '/internal/testing/p2p$')
go build ./...
go vet -stdmethods=false ./...
golangci-lint run --config .golangci.yml
golangci-lint run --config .golangci-warnings.yml
git diff --cached --check
```

The focused test was confirmed red before the production change (`9,991` instead of `9,990`). Existing 25% fee and pre-`fixTokenEscrowV1` behavior remain covered and passing.

## Replay and environment limitations

`xrpld replay-range --from 3275000 --to 3275736` was not run because this environment has the source repository but no historical Devnet database, blobstore, or checkpoint for that range. The ledger-level regression reproduces the exact receiver and issuance differences from the issue.

Local CGO/race validation was not available because `pkg-config` is absent. Consequently, `internal/testing/p2p` cannot run with `CGO_ENABLED=0` because peer TLS intentionally uses a fail-closed stub; every other integration package passes. Local golangci-lint is v2.12.2, while CI pins v2.11.3, so GitHub CI remains authoritative for the exact lint/CGO/race matrix.

Fixes #1402
