### PR TITLE
fix: reconstruct loan replay state

### DIFF
--- a/internal/replaytool/replay_reconstruct.go
+++ b/internal/replaytool/replay_reconstruct.go
@@ -132,7 +132,9 @@ func applyAffectedNode(
 
 		switch kind {
 		case "DeletedNode":
-			recordMembership(deltas, idx, entryType, asMap(fields["FinalFields"]), false)
+			if err := recordMembership(state, deltas, idx, entryType, asMap(fields["FinalFields"]), false); err != nil {
+				return fmt.Errorf("recording deleted %s membership: %w", idxHex, err)
+			}
 			if entryType == "DirectoryNode" {
 				deletedDirs[idx] = true
 			}
@@ -151,7 +153,9 @@ func applyAffectedNode(
 			fillCreatedDefaults(obj, entryType)
 			fillBookDirectoryDefaults(obj, entryType)
 			threadPreviousTxn(obj, entryType, txHash, ledgerSeq)
-			recordMembership(deltas, idx, entryType, obj, true)
+			if err := recordMembership(state, deltas, idx, entryType, obj, true); err != nil {
+				return fmt.Errorf("recording created %s membership: %w", idxHex, err)
+			}
 			if err := putEncoded(state, idx, obj); err != nil {
 				return fmt.Errorf("creating %s: %w", idxHex, err)
 			}

--- a/internal/replaytool/replay_reconstruct.go
+++ b/internal/replaytool/replay_reconstruct.go
@@ -88,8 +88,9 @@ func reconstructFromMeta(preState *shamap.SHAMap, metas []metaTx, ledgerIndex ui
 		if !ok {
 			continue
 		}
+		brokerAccounts := loanBrokerAccountsFromMeta(affected)
 		for _, node := range affected {
-			if err := applyAffectedNode(corrected, node, m.TxHash, ledgerIndex, deltas, deletedDirs); err != nil {
+			if err := applyAffectedNode(corrected, node, m.TxHash, ledgerIndex, deltas, deletedDirs, brokerAccounts); err != nil {
 				return nil, fmt.Errorf("applying metadata for tx %d: %w", i, err)
 			}
 		}
@@ -113,6 +114,7 @@ func applyAffectedNode(
 	ledgerSeq uint32,
 	deltas map[[32]byte]*dirDelta,
 	deletedDirs map[[32]byte]bool,
+	brokerAccounts map[[32]byte][20]byte,
 ) error {
 	affectedNode, ok := node.(map[string]any)
 	if !ok {
@@ -132,7 +134,7 @@ func applyAffectedNode(
 
 		switch kind {
 		case "DeletedNode":
-			if err := recordMembership(state, deltas, idx, entryType, asMap(fields["FinalFields"]), false); err != nil {
+			if err := recordMembership(state, deltas, idx, entryType, asMap(fields["FinalFields"]), false, brokerAccounts); err != nil {
 				return fmt.Errorf("recording deleted %s membership: %w", idxHex, err)
 			}
 			if entryType == "DirectoryNode" {
@@ -153,7 +155,7 @@ func applyAffectedNode(
 			fillCreatedDefaults(obj, entryType)
 			fillBookDirectoryDefaults(obj, entryType)
 			threadPreviousTxn(obj, entryType, txHash, ledgerSeq)
-			if err := recordMembership(state, deltas, idx, entryType, obj, true); err != nil {
+			if err := recordMembership(state, deltas, idx, entryType, obj, true, brokerAccounts); err != nil {
 				return fmt.Errorf("recording created %s membership: %w", idxHex, err)
 			}
 			if err := putEncoded(state, idx, obj); err != nil {

--- a/internal/replaytool/replay_reconstruct_defaults.go
+++ b/internal/replaytool/replay_reconstruct_defaults.go
@@ -161,6 +161,11 @@ var requiredDefaults = map[string][]createdField{
 		{Name: "OwnerNode", Value: "0"},
 		{Name: "Balance", Value: "0"},
 	},
+	"Loan": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+		{Name: "LoanBrokerNode", Value: "0"},
+	},
 	"AMM": {
 		{Name: "Flags", Value: 0},
 		{Name: "OwnerNode", Value: "0"},

--- a/internal/replaytool/replay_reconstruct_dir.go
+++ b/internal/replaytool/replay_reconstruct_dir.go
@@ -57,8 +57,8 @@ type dirDelta struct {
 
 // recordMembership attributes an object's creation (isAdd) or deletion to every
 // directory page it belongs to, accumulating the per-page deltas.
-func recordMembership(state *shamap.SHAMap, deltas map[[32]byte]*dirDelta, objKey [32]byte, entryType string, fields map[string]any, isAdd bool) error {
-	placements, err := directoryPlacements(state, entryType, fields)
+func recordMembership(state *shamap.SHAMap, deltas map[[32]byte]*dirDelta, objKey [32]byte, entryType string, fields map[string]any, isAdd bool, brokerAccounts map[[32]byte][20]byte) error {
+	placements, err := directoryPlacements(state, entryType, fields, brokerAccounts)
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func recordMembership(state *shamap.SHAMap, deltas map[[32]byte]*dirDelta, objKe
 // the given fields is listed in. The fields come from a CreatedNode's (default-
 // filled) NewFields or a DeletedNode's FinalFields, both of which carry the
 // node-pointer and owner fields needed to locate each page.
-func directoryPlacements(state *shamap.SHAMap, entryType string, fields map[string]any) ([]dirPlacement, error) {
+func directoryPlacements(state *shamap.SHAMap, entryType string, fields map[string]any, brokerAccounts map[[32]byte][20]byte) ([]dirPlacement, error) {
 	var out []dirPlacement
 	add := func(k keylet.Keylet, s dirStrategy) { out = append(out, dirPlacement{Key: k.Key, Strategy: s}) }
 
@@ -125,7 +125,7 @@ func directoryPlacements(state *shamap.SHAMap, entryType string, fields map[stri
 		if !ok {
 			return nil, fmt.Errorf("Loan has invalid LoanBrokerID")
 		}
-		broker, err := loanBrokerAccount(state, brokerID)
+		broker, err := loanBrokerAccount(state, brokerID, brokerAccounts)
 		if err != nil {
 			return nil, err
 		}
@@ -189,7 +189,10 @@ func directoryPlacements(state *shamap.SHAMap, entryType string, fields map[stri
 	return out, nil
 }
 
-func loanBrokerAccount(state *shamap.SHAMap, brokerID [32]byte) ([20]byte, error) {
+func loanBrokerAccount(state *shamap.SHAMap, brokerID [32]byte, brokerAccounts map[[32]byte][20]byte) ([20]byte, error) {
+	if account, ok := brokerAccounts[brokerID]; ok {
+		return account, nil
+	}
 	brokerKey := keylet.LoanBrokerByID(brokerID).Key
 	item, found, err := state.Get(brokerKey)
 	if err != nil {
@@ -210,6 +213,41 @@ func loanBrokerAccount(state *shamap.SHAMap, brokerID [32]byte) ([20]byte, error
 		return [20]byte{}, fmt.Errorf("LoanBroker %X has invalid Account", brokerID)
 	}
 	return account, nil
+}
+
+func loanBrokerAccountsFromMeta(affected []any) map[[32]byte][20]byte {
+	accounts := make(map[[32]byte][20]byte)
+	for _, node := range affected {
+		affectedNode, ok := node.(map[string]any)
+		if !ok {
+			continue
+		}
+		for kind, body := range affectedNode {
+			fields, ok := body.(map[string]any)
+			if !ok || fields["LedgerEntryType"] != "LoanBroker" {
+				continue
+			}
+			index, ok := fields["LedgerIndex"].(string)
+			if !ok {
+				continue
+			}
+			brokerID, err := protocol.Hash256FromHex(index)
+			if err != nil {
+				continue
+			}
+			var values map[string]any
+			switch kind {
+			case "CreatedNode":
+				values = asMap(fields["NewFields"])
+			case "DeletedNode", "ModifiedNode":
+				values = asMap(fields["FinalFields"])
+			}
+			if account, ok := metaAccountID(values, "Account"); ok {
+				accounts[brokerID] = account
+			}
+		}
+	}
+	return accounts
 }
 
 // reconstructDirIndexes rewrites the sfIndexes of every directory page touched

--- a/internal/replaytool/replay_reconstruct_dir.go
+++ b/internal/replaytool/replay_reconstruct_dir.go
@@ -57,8 +57,12 @@ type dirDelta struct {
 
 // recordMembership attributes an object's creation (isAdd) or deletion to every
 // directory page it belongs to, accumulating the per-page deltas.
-func recordMembership(deltas map[[32]byte]*dirDelta, objKey [32]byte, entryType string, fields map[string]any, isAdd bool) {
-	for _, p := range directoryPlacements(entryType, fields) {
+func recordMembership(state *shamap.SHAMap, deltas map[[32]byte]*dirDelta, objKey [32]byte, entryType string, fields map[string]any, isAdd bool) error {
+	placements, err := directoryPlacements(state, entryType, fields)
+	if err != nil {
+		return err
+	}
+	for _, p := range placements {
 		d := deltas[p.Key]
 		if d == nil {
 			d = &dirDelta{strategy: p.Strategy}
@@ -66,20 +70,21 @@ func recordMembership(deltas map[[32]byte]*dirDelta, objKey [32]byte, entryType 
 		}
 		d.operations = append(d.operations, dirOperation{key: objKey, add: isAdd})
 	}
+	return nil
 }
 
 // directoryPlacements returns the directory pages an object of entryType with
 // the given fields is listed in. The fields come from a CreatedNode's (default-
 // filled) NewFields or a DeletedNode's FinalFields, both of which carry the
 // node-pointer and owner fields needed to locate each page.
-func directoryPlacements(entryType string, fields map[string]any) []dirPlacement {
+func directoryPlacements(state *shamap.SHAMap, entryType string, fields map[string]any) ([]dirPlacement, error) {
 	var out []dirPlacement
 	add := func(k keylet.Keylet, s dirStrategy) { out = append(out, dirPlacement{Key: k.Key, Strategy: s}) }
 
 	switch entryType {
 	case "DirectoryNode", "Amendments", "FeeSettings", "NegativeUNL", "LedgerHashes", "AccountRoot":
 		// Directory pages and singletons are not themselves listed in a directory.
-		return nil
+		return nil, nil
 
 	case "RippleState":
 		// A trust line is listed in both endpoints' owner directories.
@@ -89,7 +94,7 @@ func directoryPlacements(entryType string, fields map[string]any) []dirPlacement
 		if hi, ok := metaIssuer(fields, "HighLimit"); ok {
 			add(keylet.OwnerDirPage(hi, metaUint64(fields["HighNode"])), dirSorted)
 		}
-		return out
+		return out, nil
 
 	case "Credential":
 		// The issuer always lists the credential in its directory. The subject
@@ -103,19 +108,36 @@ func directoryPlacements(entryType string, fields map[string]any) []dirPlacement
 				add(keylet.OwnerDirPage(sub, metaUint64(fields["SubjectNode"])), dirSorted)
 			}
 		}
-		return out
+		return out, nil
 
 	case "Vault":
 		if owner, ok := metaAccountID(fields, "Owner"); ok {
 			add(keylet.OwnerDirPage(owner, metaUint64(fields["OwnerNode"])), dirSorted)
 		}
-		return out
+		return out, nil
+
+	case "Loan":
+		borrower, ok := metaAccountID(fields, "Borrower")
+		if !ok {
+			return nil, fmt.Errorf("Loan has invalid Borrower")
+		}
+		brokerID, ok := metaHash256(fields, "LoanBrokerID")
+		if !ok {
+			return nil, fmt.Errorf("Loan has invalid LoanBrokerID")
+		}
+		broker, err := loanBrokerAccount(state, brokerID)
+		if err != nil {
+			return nil, err
+		}
+		add(keylet.OwnerDirPage(borrower, metaUint64(fields["OwnerNode"])), dirSorted)
+		add(keylet.OwnerDirPage(broker, metaUint64(fields["LoanBrokerNode"])), dirSorted)
+		return out, nil
 
 	case "MPTokenIssuance":
 		if issuer, ok := metaAccountID(fields, "Issuer"); ok {
 			add(keylet.OwnerDirPage(issuer, metaUint64(fields["OwnerNode"])), dirSorted)
 		}
-		return out
+		return out, nil
 	}
 
 	// Owner directory: the object's owner lists it at OwnerNode. The owner is the
@@ -164,7 +186,30 @@ func directoryPlacements(entryType string, fields map[string]any) []dirPlacement
 		}
 	}
 
-	return out
+	return out, nil
+}
+
+func loanBrokerAccount(state *shamap.SHAMap, brokerID [32]byte) ([20]byte, error) {
+	brokerKey := keylet.LoanBrokerByID(brokerID).Key
+	item, found, err := state.Get(brokerKey)
+	if err != nil {
+		return [20]byte{}, fmt.Errorf("reading LoanBroker %X: %w", brokerID, err)
+	}
+	if !found || item == nil {
+		return [20]byte{}, fmt.Errorf("LoanBroker %X not found", brokerID)
+	}
+	broker, err := binarycodec.Decode(hex.EncodeToString(item.Data()))
+	if err != nil {
+		return [20]byte{}, fmt.Errorf("decoding LoanBroker %X: %w", brokerID, err)
+	}
+	if broker["LedgerEntryType"] != "LoanBroker" {
+		return [20]byte{}, fmt.Errorf("LoanBroker %X resolved to %v", brokerID, broker["LedgerEntryType"])
+	}
+	account, ok := metaAccountID(broker, "Account")
+	if !ok {
+		return [20]byte{}, fmt.Errorf("LoanBroker %X has invalid Account", brokerID)
+	}
+	return account, nil
 }
 
 // reconstructDirIndexes rewrites the sfIndexes of every directory page touched

--- a/internal/replaytool/replay_reconstruct_test.go
+++ b/internal/replaytool/replay_reconstruct_test.go
@@ -3,6 +3,9 @@ package replaytool
 import (
 	"bytes"
 	"encoding/hex"
+	"maps"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -768,8 +771,12 @@ func TestRecordMembership_LastOperationWins(t *testing.T) {
 
 	t.Run("remove then add", func(t *testing.T) {
 		deltas := map[[32]byte]*dirDelta{}
-		recordMembership(deltas, objectKey, "DID", fields, false)
-		recordMembership(deltas, objectKey, "DID", fields, true)
+		if err := recordMembership(nil, deltas, objectKey, "DID", fields, false); err != nil {
+			t.Fatalf("record remove: %v", err)
+		}
+		if err := recordMembership(nil, deltas, objectKey, "DID", fields, true); err != nil {
+			t.Fatalf("record add: %v", err)
+		}
 		members := applyDirDelta([][32]byte{objectKey}, deltas[pageKey])
 		if len(members) != 1 || members[0] != objectKey {
 			t.Fatalf("members = %x, want recreated key", members)
@@ -778,8 +785,12 @@ func TestRecordMembership_LastOperationWins(t *testing.T) {
 
 	t.Run("add then remove", func(t *testing.T) {
 		deltas := map[[32]byte]*dirDelta{}
-		recordMembership(deltas, objectKey, "DID", fields, true)
-		recordMembership(deltas, objectKey, "DID", fields, false)
+		if err := recordMembership(nil, deltas, objectKey, "DID", fields, true); err != nil {
+			t.Fatalf("record add: %v", err)
+		}
+		if err := recordMembership(nil, deltas, objectKey, "DID", fields, false); err != nil {
+			t.Fatalf("record remove: %v", err)
+		}
 		members := applyDirDelta(nil, deltas[pageKey])
 		if len(members) != 0 {
 			t.Fatalf("members = %x, want empty", members)
@@ -1046,6 +1057,205 @@ func TestReconstructFromMeta_VaultCreateDefaultsAndDirectories(t *testing.T) {
 	assertEntryBytes(t, corrected, vaultKey, wantVault, "vault")
 	assertEntryBytes(t, corrected, mustIndex(t, "9EDC99BAA48E5FC2A28C355D8CA9A723CD52CC36DC76E946D118D3DB679B8DB5"), wantPseudo, "pseudo account")
 	assertEntryBytes(t, corrected, issuanceKey, wantIssuance, "share issuance")
+}
+
+func TestReconstructFromMeta_LoanCreateDirectories(t *testing.T) {
+	const borrower = "rEaWzpDUL2cBckwDJhRENZiKCbNKwG2cAZ"
+	const brokerAccount = "rpRrVjCLggyjBaAYreukcyuWuzb23wuWrn"
+	const brokerOwner = "rrrrrrrrrrrrrrrrrrrrBZbvji"
+	const brokerIDHex = "33353F075781FD714AE43F61FC6B4A88BCB5CE3C348FE0FF40B1F6F803C7D86A"
+	const loanKeyHex = "6BABEC1111496AD23DDFCD51DAF11AF98DC018F297A2EE82509D7881A2F50F9C"
+
+	borrowerID, err := state.DecodeAccountID(borrower)
+	if err != nil {
+		t.Fatalf("decode borrower: %v", err)
+	}
+	brokerAccountID, err := state.DecodeAccountID(brokerAccount)
+	if err != nil {
+		t.Fatalf("decode broker account: %v", err)
+	}
+	brokerID := mustIndex(t, brokerIDHex)
+	brokerKey := keylet.LoanBrokerByID(brokerID).Key
+	loanKey := mustIndex(t, loanKeyHex)
+
+	for _, tt := range []struct {
+		name string
+		page uint64
+	}{
+		{name: "page zero", page: 0},
+		{name: "nonzero page", page: 7},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			borrowerDir := keylet.OwnerDirPage(borrowerID, tt.page).Key
+			brokerDir := keylet.OwnerDirPage(brokerAccountID, tt.page).Key
+			borrowerDirHex := protocol.Hash256Hex(borrowerDir)
+			brokerDirHex := protocol.Hash256Hex(brokerDir)
+			page := strconv.FormatUint(tt.page, 16)
+
+			preState := putAll(t, map[[32]byte][]byte{
+				brokerKey: loanBrokerSLE(t, brokerAccount, brokerOwner),
+				borrowerDir: encodeSLE(t, map[string]any{
+					"LedgerEntryType": "DirectoryNode", "Flags": 0,
+					"RootIndex": protocol.Hash256Hex(keylet.OwnerDir(borrowerID).Key),
+					"Owner":     borrower,
+				}),
+				brokerDir: encodeSLE(t, map[string]any{
+					"LedgerEntryType": "DirectoryNode", "Flags": 0,
+					"RootIndex": protocol.Hash256Hex(keylet.OwnerDir(brokerAccountID).Key),
+					"Owner":     brokerAccount,
+				}),
+			})
+			loanNewFields := map[string]any{
+				"Borrower": borrower, "LoanBrokerID": brokerIDHex, "LoanSequence": uint32(1),
+				"StartDate": uint32(836247371), "PaymentInterval": uint32(400),
+				"PeriodicPayment": "10000", "PrincipalOutstanding": "10000",
+				"TotalValueOutstanding": "10000",
+			}
+			if tt.page != 0 {
+				loanNewFields["OwnerNode"] = page
+				loanNewFields["LoanBrokerNode"] = page
+			}
+			meta := encodeMeta(t,
+				map[string]any{"ModifiedNode": map[string]any{
+					"LedgerEntryType": "DirectoryNode", "LedgerIndex": borrowerDirHex,
+					"FinalFields": map[string]any{"Flags": 0, "Owner": borrower,
+						"RootIndex": protocol.Hash256Hex(keylet.OwnerDir(borrowerID).Key)},
+				}},
+				map[string]any{"ModifiedNode": map[string]any{
+					"LedgerEntryType": "DirectoryNode", "LedgerIndex": brokerDirHex,
+					"FinalFields": map[string]any{"Flags": 0, "Owner": brokerAccount,
+						"RootIndex": protocol.Hash256Hex(keylet.OwnerDir(brokerAccountID).Key)},
+				}},
+				map[string]any{"CreatedNode": map[string]any{
+					"LedgerEntryType": "Loan", "LedgerIndex": loanKeyHex,
+					"NewFields": loanNewFields,
+				}},
+			)
+
+			corrected, err := reconstructFromMeta(preState, []metaTx{{Blob: meta, TxHash: mustIndex(t, testTxHashHex)}}, testLedgerSeq)
+			if err != nil {
+				t.Fatalf("reconstructFromMeta: %v", err)
+			}
+			wantLoan := encodeSLE(t, map[string]any{
+				"LedgerEntryType": "Loan", "Flags": 0, "OwnerNode": page, "LoanBrokerNode": page,
+				"Borrower": borrower, "LoanBrokerID": brokerIDHex, "LoanSequence": uint32(1),
+				"StartDate": uint32(836247371), "PaymentInterval": uint32(400),
+				"PeriodicPayment": "10000", "PrincipalOutstanding": "10000",
+				"TotalValueOutstanding": "10000", "PreviousTxnID": testTxHashHex,
+				"PreviousTxnLgrSeq": testLedgerSeq,
+			})
+			assertEntryBytes(t, corrected, loanKey, wantLoan, "loan")
+			assertDirectoryMembers(t, corrected, borrowerDir, loanKey)
+			assertDirectoryMembers(t, corrected, brokerDir, loanKey)
+		})
+	}
+}
+
+func TestReconstructFromMeta_LoanDeleteDirectories(t *testing.T) {
+	const borrower = "rEaWzpDUL2cBckwDJhRENZiKCbNKwG2cAZ"
+	const brokerAccount = "rpRrVjCLggyjBaAYreukcyuWuzb23wuWrn"
+	const brokerOwner = "rrrrrrrrrrrrrrrrrrrrBZbvji"
+	const brokerIDHex = "33353F075781FD714AE43F61FC6B4A88BCB5CE3C348FE0FF40B1F6F803C7D86A"
+	const loanKeyHex = "6BABEC1111496AD23DDFCD51DAF11AF98DC018F297A2EE82509D7881A2F50F9C"
+
+	borrowerID, _ := state.DecodeAccountID(borrower)
+	brokerAccountID, _ := state.DecodeAccountID(brokerAccount)
+	brokerID := mustIndex(t, brokerIDHex)
+	brokerKey := keylet.LoanBrokerByID(brokerID).Key
+	loanKey := mustIndex(t, loanKeyHex)
+	borrowerDir := keylet.OwnerDirPage(borrowerID, 0).Key
+	brokerDir := keylet.OwnerDirPage(brokerAccountID, 0).Key
+	loanFields := map[string]any{
+		"LedgerEntryType": "Loan", "Flags": 0, "OwnerNode": "0", "LoanBrokerNode": "0",
+		"Borrower": borrower, "LoanBrokerID": brokerIDHex, "LoanSequence": uint32(1),
+		"StartDate": uint32(836247371), "PaymentInterval": uint32(400), "PeriodicPayment": "10000",
+		"PreviousTxnID": testTxHashHex, "PreviousTxnLgrSeq": testLedgerSeq - 1,
+	}
+	preState := putAll(t, map[[32]byte][]byte{
+		brokerKey: loanBrokerSLE(t, brokerAccount, brokerOwner),
+		loanKey:   encodeSLE(t, loanFields),
+		borrowerDir: encodeSLE(t, map[string]any{
+			"LedgerEntryType": "DirectoryNode", "Flags": 0, "Owner": borrower,
+			"RootIndex": protocol.Hash256Hex(borrowerDir), "Indexes": []string{loanKeyHex},
+		}),
+		brokerDir: encodeSLE(t, map[string]any{
+			"LedgerEntryType": "DirectoryNode", "Flags": 0, "Owner": brokerAccount,
+			"RootIndex": protocol.Hash256Hex(brokerDir), "Indexes": []string{loanKeyHex},
+		}),
+	})
+	finalFields := maps.Clone(loanFields)
+	delete(finalFields, "LedgerEntryType")
+	delete(finalFields, "PreviousTxnID")
+	delete(finalFields, "PreviousTxnLgrSeq")
+	meta := encodeMeta(t, map[string]any{"DeletedNode": map[string]any{
+		"LedgerEntryType": "Loan", "LedgerIndex": loanKeyHex, "FinalFields": finalFields,
+	}})
+
+	corrected, err := reconstructFromMeta(preState, []metaTx{{Blob: meta, TxHash: mustIndex(t, testTxHashHex)}}, testLedgerSeq)
+	if err != nil {
+		t.Fatalf("reconstructFromMeta: %v", err)
+	}
+	if _, found, err := corrected.Get(loanKey); err != nil || found {
+		t.Fatalf("deleted loan present (found=%v err=%v)", found, err)
+	}
+	assertDirectoryMembers(t, corrected, borrowerDir)
+	assertDirectoryMembers(t, corrected, brokerDir)
+}
+
+func TestReconstructFromMeta_LoanBrokerResolutionErrors(t *testing.T) {
+	const brokerIDHex = "33353F075781FD714AE43F61FC6B4A88BCB5CE3C348FE0FF40B1F6F803C7D86A"
+	brokerID := mustIndex(t, brokerIDHex)
+	brokerKey := keylet.LoanBrokerByID(brokerID).Key
+	meta := encodeMeta(t, map[string]any{"CreatedNode": map[string]any{
+		"LedgerEntryType": "Loan",
+		"LedgerIndex":     "6BABEC1111496AD23DDFCD51DAF11AF98DC018F297A2EE82509D7881A2F50F9C",
+		"NewFields": map[string]any{
+			"Borrower": "rEaWzpDUL2cBckwDJhRENZiKCbNKwG2cAZ", "LoanBrokerID": brokerIDHex,
+			"LoanSequence": uint32(1), "StartDate": uint32(1), "PaymentInterval": uint32(1),
+			"PeriodicPayment": "1",
+		},
+	}})
+
+	for _, tt := range []struct {
+		name    string
+		entries map[[32]byte][]byte
+		want    string
+	}{
+		{name: "missing broker", want: "not found"},
+		{name: "corrupt broker", entries: map[[32]byte][]byte{brokerKey: bytes.Repeat([]byte{0xff}, 12)}, want: "decoding LoanBroker"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := reconstructFromMeta(putAll(t, tt.entries), []metaTx{{Blob: meta}}, testLedgerSeq)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func loanBrokerSLE(t *testing.T, account, owner string) []byte {
+	t.Helper()
+	return encodeSLE(t, map[string]any{
+		"LedgerEntryType": "LoanBroker", "Flags": 0, "Sequence": uint32(0),
+		"OwnerNode": "0", "VaultNode": "0", "VaultID": strings.Repeat("0", 64),
+		"Account": account, "Owner": owner, "LoanSequence": uint32(0),
+		"PreviousTxnID": strings.Repeat("0", 64), "PreviousTxnLgrSeq": uint32(0),
+	})
+}
+
+func assertDirectoryMembers(t *testing.T, m *shamap.SHAMap, key [32]byte, want ...[32]byte) {
+	t.Helper()
+	item, found, err := m.Get(key)
+	if err != nil || !found || item == nil {
+		t.Fatalf("directory missing (found=%v err=%v)", found, err)
+	}
+	obj, err := binarycodec.Decode(hex.EncodeToString(item.Data()))
+	if err != nil {
+		t.Fatalf("decode directory: %v", err)
+	}
+	if got := decodeIndexes(obj["Indexes"]); !slices.Equal(got, want) {
+		t.Fatalf("directory members = %X, want %X", got, want)
+	}
 }
 
 func assertEntryBytes(t *testing.T, m *shamap.SHAMap, key [32]byte, want []byte, label string) {

--- a/internal/replaytool/replay_reconstruct_test.go
+++ b/internal/replaytool/replay_reconstruct_test.go
@@ -373,7 +373,7 @@ func TestApplyAffectedNode_AMMCreateDefaults(t *testing.T) {
 	}}
 
 	for _, node := range []map[string]any{ammNode, line1Node, line2Node} {
-		if err := applyAffectedNode(stateMap, node, txHash, testLedgerSeq, deltas, deletedDirs); err != nil {
+		if err := applyAffectedNode(stateMap, node, txHash, testLedgerSeq, deltas, deletedDirs, nil); err != nil {
 			t.Fatalf("applyAffectedNode: %v", err)
 		}
 	}
@@ -436,6 +436,7 @@ func TestApplyAffectedNode_AMMAsset2Default(t *testing.T) {
 		testLedgerSeq,
 		map[[32]byte]*dirDelta{},
 		map[[32]byte]bool{},
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("applyAffectedNode: %v", err)
@@ -771,10 +772,10 @@ func TestRecordMembership_LastOperationWins(t *testing.T) {
 
 	t.Run("remove then add", func(t *testing.T) {
 		deltas := map[[32]byte]*dirDelta{}
-		if err := recordMembership(nil, deltas, objectKey, "DID", fields, false); err != nil {
+		if err := recordMembership(nil, deltas, objectKey, "DID", fields, false, nil); err != nil {
 			t.Fatalf("record remove: %v", err)
 		}
-		if err := recordMembership(nil, deltas, objectKey, "DID", fields, true); err != nil {
+		if err := recordMembership(nil, deltas, objectKey, "DID", fields, true, nil); err != nil {
 			t.Fatalf("record add: %v", err)
 		}
 		members := applyDirDelta([][32]byte{objectKey}, deltas[pageKey])
@@ -785,10 +786,10 @@ func TestRecordMembership_LastOperationWins(t *testing.T) {
 
 	t.Run("add then remove", func(t *testing.T) {
 		deltas := map[[32]byte]*dirDelta{}
-		if err := recordMembership(nil, deltas, objectKey, "DID", fields, true); err != nil {
+		if err := recordMembership(nil, deltas, objectKey, "DID", fields, true, nil); err != nil {
 			t.Fatalf("record add: %v", err)
 		}
-		if err := recordMembership(nil, deltas, objectKey, "DID", fields, false); err != nil {
+		if err := recordMembership(nil, deltas, objectKey, "DID", fields, false, nil); err != nil {
 			t.Fatalf("record remove: %v", err)
 		}
 		members := applyDirDelta(nil, deltas[pageKey])
@@ -1197,6 +1198,63 @@ func TestReconstructFromMeta_LoanDeleteDirectories(t *testing.T) {
 	}
 	if _, found, err := corrected.Get(loanKey); err != nil || found {
 		t.Fatalf("deleted loan present (found=%v err=%v)", found, err)
+	}
+	assertDirectoryMembers(t, corrected, borrowerDir)
+	assertDirectoryMembers(t, corrected, brokerDir)
+}
+
+func TestReconstructFromMeta_LoanDeleteAfterLoanBrokerDelete(t *testing.T) {
+	const borrower = "rEaWzpDUL2cBckwDJhRENZiKCbNKwG2cAZ"
+	const brokerAccount = "rpRrVjCLggyjBaAYreukcyuWuzb23wuWrn"
+	const brokerOwner = "rrrrrrrrrrrrrrrrrrrrBZbvji"
+	const brokerIDHex = "33353F075781FD714AE43F61FC6B4A88BCB5CE3C348FE0FF40B1F6F803C7D86A"
+	const loanKeyHex = "6BABEC1111496AD23DDFCD51DAF11AF98DC018F297A2EE82509D7881A2F50F9C"
+
+	borrowerID, _ := state.DecodeAccountID(borrower)
+	brokerAccountID, _ := state.DecodeAccountID(brokerAccount)
+	brokerID := mustIndex(t, brokerIDHex)
+	brokerKey := keylet.LoanBrokerByID(brokerID).Key
+	loanKey := mustIndex(t, loanKeyHex)
+	borrowerDir := keylet.OwnerDirPage(borrowerID, 0).Key
+	brokerDir := keylet.OwnerDirPage(brokerAccountID, 0).Key
+	loanFields := map[string]any{
+		"LedgerEntryType": "Loan", "Flags": 0, "OwnerNode": "0", "LoanBrokerNode": "0",
+		"Borrower": borrower, "LoanBrokerID": brokerIDHex, "LoanSequence": uint32(1),
+		"StartDate": uint32(836247371), "PaymentInterval": uint32(400), "PeriodicPayment": "10000",
+	}
+	preState := putAll(t, map[[32]byte][]byte{
+		brokerKey: loanBrokerSLE(t, brokerAccount, brokerOwner),
+		loanKey:   encodeSLE(t, loanFields),
+		borrowerDir: encodeSLE(t, map[string]any{
+			"LedgerEntryType": "DirectoryNode", "Flags": 0, "Owner": borrower,
+			"RootIndex": protocol.Hash256Hex(borrowerDir), "Indexes": []string{loanKeyHex},
+		}),
+		brokerDir: encodeSLE(t, map[string]any{
+			"LedgerEntryType": "DirectoryNode", "Flags": 0, "Owner": brokerAccount,
+			"RootIndex": protocol.Hash256Hex(brokerDir), "Indexes": []string{loanKeyHex},
+		}),
+	})
+	finalFields := maps.Clone(loanFields)
+	delete(finalFields, "LedgerEntryType")
+	meta := encodeMeta(t,
+		map[string]any{"DeletedNode": map[string]any{
+			"LedgerEntryType": "LoanBroker", "LedgerIndex": brokerIDHex,
+			"FinalFields": map[string]any{"Account": brokerAccount, "OwnerNode": "0"},
+		}},
+		map[string]any{"DeletedNode": map[string]any{
+			"LedgerEntryType": "Loan", "LedgerIndex": loanKeyHex,
+			"FinalFields": finalFields,
+		}},
+	)
+
+	corrected, err := reconstructFromMeta(preState, []metaTx{{Blob: meta}}, testLedgerSeq)
+	if err != nil {
+		t.Fatalf("reconstructFromMeta: %v", err)
+	}
+	for name, key := range map[string][32]byte{"loan": loanKey, "broker": brokerKey} {
+		if _, found, err := corrected.Get(key); err != nil || found {
+			t.Fatalf("deleted %s present (found=%v err=%v)", name, found, err)
+		}
 	}
 	assertDirectoryMembers(t, corrected, borrowerDir)
 	assertDirectoryMembers(t, corrected, brokerDir)


### PR DESCRIPTION
## Summary
- restore required default-zero fields when metadata creates a Loan
- reconstruct Loan membership in the borrower and LoanBroker pseudo-account owner directories
- fail reconstruction explicitly when the referenced LoanBroker is missing or corrupt

## Test plan
- [x] `go test -race ./internal/replaytool`
- [x] `just build`
- [x] `just vet`
- [x] `golangci-lint run`
- [x] `just lint`
- [x] `git diff --check`

Fixes #1405
