### PR TITLE
fix: use canonical IOU escrow division

### DIFF
--- a/internal/testing/escrow/token_escrow_test.go
+++ b/internal/testing/escrow/token_escrow_test.go
@@ -544,6 +544,51 @@ func TestIOUEscrow_FinishBasic(t *testing.T) {
 		"bob balance should increase by 1000 after escrow finish")
 }
 
+func TestIOUEscrow_LockedRate(t *testing.T) {
+	tests := []struct {
+		name        string
+		currentRate uint32
+		wantCredit  float64
+	}{
+		{name: "higher current rate uses locked rate", currentRate: 1_260_000_000, wantCredit: 100},
+		{name: "lower current rate uses current rate", currentRate: 0, wantCredit: 125},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, gw, alice, bob := setupIOUEscrowEnv(t)
+			env.SetTransferRate(gw, 1_250_000_000)
+			env.Close()
+
+			preBobUSD := env.BalanceIOU(bob, "USD", gw)
+			seq := env.Seq(alice)
+			result := env.Submit(
+				escrow.EscrowCreate(alice, bob, 0).
+					IOUAmount(usd(125, gw)).
+					Condition(escrow.TestCondition1).
+					FinishTime(env.Now().Add(time.Second)).
+					Fee(env.BaseFee() * 150).
+					Build())
+			jtx.RequireTxSuccess(t, result)
+			env.Close()
+
+			env.SetTransferRate(gw, tt.currentRate)
+			env.Close()
+
+			result = env.Submit(
+				escrow.EscrowFinish(bob, alice, seq).
+					Condition(escrow.TestCondition1).
+					Fulfillment(escrow.TestFulfillment1).
+					Fee(env.BaseFee() * 150).
+					Build())
+			jtx.RequireTxSuccess(t, result)
+			env.Close()
+
+			require.InDelta(t, preBobUSD+tt.wantCredit, env.BalanceIOU(bob, "USD", gw), 1e-12)
+		})
+	}
+}
+
 // --------------------------------------------------------------------------
 // TestIOUEscrow_CancelBasic
 // Reference: rippled EscrowToken_test.cpp testIOUBalances (cancel part)

--- a/internal/tx/escrow/token_helpers.go
+++ b/internal/tx/escrow/token_helpers.go
@@ -499,7 +499,6 @@ func escrowUnlockIOU(
 	if currentRate != 0 && currentRate < effectiveRate {
 		effectiveRate = currentRate
 	}
-	// If no rate was locked (0 or parityRate), use currentRate
 	if effectiveRate == 0 {
 		effectiveRate = currentRate
 	}
@@ -1099,9 +1098,8 @@ func divideAmountByRate(amount tx.Amount, rate uint32) tx.Amount {
 		return amount
 	}
 
-	// For IOU: result = amount * 1_000_000_000 / rate
-	// Use MulRatio which does amount * num / den
-	return amount.MulRatio(parityRate, rate, true)
+	rateAmount := state.NewIssuedAmountFromValue(int64(rate), -9, "", "")
+	return state.DivRound(amount, rateAmount, amount.Currency, amount.Issuer, true)
 }
 
 // createMPTokenForEscrow creates a new MPToken SLE for holderID during escrow unlock.

--- a/internal/tx/escrow/token_helpers_rounding_test.go
+++ b/internal/tx/escrow/token_helpers_rounding_test.go
@@ -11,6 +11,15 @@ import (
 	"github.com/LeJamon/go-xrpl/keylet"
 )
 
+func TestDivideAmountByRateUsesCanonicalIOURounding(t *testing.T) {
+	const issuer = "rDC7wGzpzUjS2qTASSzGWkUytS7FD9xyVK"
+	amount := state.NewIssuedAmountFromValue(1_000_000_000_000_000, -13, "USD", issuer)
+
+	want := state.NewIssuedAmountFromValue(9_900_990_099_009_901, -14, "USD", issuer)
+	require.Equal(t, want, divideAmountByRate(amount, 1_010_000_000))
+	require.Equal(t, amount, divideAmountByRate(amount, parityRate))
+}
+
 func TestComputeMPTTransferFeeUsesCanonicalRounding(t *testing.T) {
 	const originalAmount = uint64(10_000)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1407,3 +1407,51 @@ Behavioral oracle: clean local rippled `3.2.0` worktree at
   rollback, top-up recovery, signer roles, owner directories, and existing holdings.
 - Passed lending transaction and integration tests, `just build-all`, `just vet`,
   `just lint`, and `git diff --check`.
+
+# Issue #1408 — IOU EscrowFinish divideRound parity
+
+Target: `origin/main` at `a7caa2fb4e2efed48288c42294ede0783d92fd40`.
+Behavioral oracle: clean local rippled `3.2.0` worktree at
+`3c43f4614f87965298773279ff5b85d4c56c637b`.
+
+## Plan
+
+- [x] Validate GitHub access, issue state and discussion, linked PRs, active
+      release branches, exact base, clean dedicated worktree, and oracle provenance.
+- [x] Trace IOU escrow transfer-fee calculation and rate selection in go-xrpl and
+      rippled v3.2.0, including parity and issuer-involved behavior.
+- [x] Add focused regressions for the ledger 3,275,748 rounding value and
+      `min(lockedRate, currentRate)` selection.
+- [x] Replace the escrow-only `MulRatio` shortcut with rippled's non-strict
+      `divideRound` operation while preserving the escrow amount's issue.
+- [x] Run formatting, focused escrow and state tests, affected transaction and
+      integration suites, build, vet, strict/advisory lint, and diff checks.
+- [x] Attempt the ledger 3,275,748 replay and record the unavailable local database
+      and checkpoint inputs when it cannot run.
+- [x] Review the final diff for arithmetic parity, failure paths, adjacent rate
+      behavior, and test coverage; record exact results below.
+- [ ] Stage only intentional files, commit, push, open the PR against `main`, and
+      verify the published head and initial CI state.
+
+## Review
+
+- Replaced the escrow-only `MulRatio` shortcut with non-strict `state.DivRound`,
+  representing the transfer rate as mantissa `rate` at exponent `-9` and retaining
+  the escrow amount's currency and issuer. This matches rippled v3.2.0
+  `Rate2.cpp` and `EscrowHelpers.h` behavior without changing global `MulRatio`.
+- Added an exact regression for `100 / 1.01 = 99.00990099009901` and end-to-end
+  coverage proving the lower of the locked and current issuer rates is used.
+  Existing parity and issuer guards remain unchanged.
+- Passed focused transaction, integration, and state tests; the complete
+  `internal/tx/...` shard; focused race tests; repeated rounding/rate-selection
+  regressions; `just build-all`; `just vet`; strict CI and advisory golangci-lint
+  v2.11.3; gofmt; and `git diff --check`.
+- The full integration shard passed the changed escrow package and reproduced only
+  the repository's existing out-of-scope Vault, XChain, Batch, and NFT conformance
+  corpus failures.
+- The one-ledger replay started with rippled v3.2.0 compatibility semantics but
+  could not connect to PostgreSQL at `localhost:5432`. No ledger 3,275,748 fixture
+  or checkpoint exists in the workspace, so account/transaction roots could not
+  be replay-verified locally.
+- Three independent final reviews found no Go-correctness, test-quality,
+  verification, or rippled v3.2.0 conformance findings.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1430,7 +1430,7 @@ Behavioral oracle: clean local rippled `3.2.0` worktree at
       and checkpoint inputs when it cannot run.
 - [x] Review the final diff for arithmetic parity, failure paths, adjacent rate
       behavior, and test coverage; record exact results below.
-- [ ] Stage only intentional files, commit, push, open the PR against `main`, and
+- [x] Stage only intentional files, commit, push, open the PR against `main`, and
       verify the published head and initial CI state.
 
 ## Review
@@ -1455,3 +1455,4 @@ Behavioral oracle: clean local rippled `3.2.0` worktree at
   be replay-verified locally.
 - Three independent final reviews found no Go-correctness, test-quality,
   verification, or rippled v3.2.0 conformance findings.
+- Published as PR #1411: https://github.com/LeJamon/go-xrpl/pull/1411.


### PR DESCRIPTION
## Summary
- replace the IOU escrow `MulRatio` shortcut with rippled-compatible non-strict `divideRound`
- preserve the escrow amount's issue while matching the exact ledger 3,275,748 canonical rounding result
- cover locked/current transfer-rate selection end to end

## Test plan
- [x] `go test -count=1 ./internal/tx/escrow/...`
- [x] `go test -count=1 ./internal/testing/escrow/...`
- [x] `go test -count=1 ./internal/ledger/state/...`
- [x] `GOCACHE=/private/tmp/goxrpl-issue-1408-gocache just test-tx`
- [x] focused race and repeated regression tests
- [x] `just build-all`
- [x] `just vet`
- [x] strict CI and advisory golangci-lint v2.11.3
- [ ] replay ledger 3,275,748 (local PostgreSQL and checkpoint/fixture data unavailable)

Fixes #1408
