### PR TITLE
Enforce RequireAuth for synthetic AMM offers

### DIFF
--- a/internal/testing/amm/amm_bookstep_test.go
+++ b/internal/testing/amm/amm_bookstep_test.go
@@ -2986,6 +2986,49 @@ func TestAMMBookStep_RequireAuth(t *testing.T) {
 	jtx.RequireIOUBalance(t, env.TestEnv, env.Bob, env.GW, "USD", 0)
 }
 
+func TestAMMBookStep_RequireAuthRejectsUnauthorizedSyntheticOffer(t *testing.T) {
+	env := amm.NewAMMTestEnv(t)
+	env.TestEnv.FundAmount(env.GW, uint64(jtx.XRP(400000)))
+	env.TestEnv.FundAmount(env.Alice, uint64(jtx.XRP(400000)))
+	env.TestEnv.FundAmount(env.Bob, uint64(jtx.XRP(400000)))
+	env.Close()
+
+	env.TestEnv.EnableRequireAuth(env.GW)
+	env.Close()
+
+	env.TestEnv.AuthorizeTrustLine(env.GW, env.Alice, "USD")
+	env.Trust(env.Alice, env.GW, "USD", 2000)
+	env.TestEnv.AuthorizeTrustLine(env.GW, env.Bob, "USD")
+	env.Trust(env.Bob, env.GW, "USD", 100)
+	env.PayIOU(env.GW, env.Alice, "USD", 1000)
+	env.PayIOU(env.GW, env.Bob, "USD", 50)
+	env.Close()
+
+	createTx := amm.AMMCreate(env.Alice,
+		amm.IOUAmount(env.GW, "USD", 1000),
+		amm.XRPAmount(1050)).Build()
+	jtx.RequireTxSuccess(t, env.Submit(createTx))
+	env.Close()
+
+	ammAcc := amm.AMMAccount(t, env,
+		tx.Asset{Currency: "USD", Issuer: env.GW.Address},
+		amm.XRP())
+
+	offerTx := offerbuild.OfferCreate(env.Bob,
+		amm.XRPAmount(50),
+		amm.IOUAmount(env.GW, "USD", 50)).Build()
+	jtx.RequireTxSuccess(t, env.Submit(offerTx))
+	env.Close()
+
+	env.ExpectAMMBalances(t, ammAcc,
+		uint64(jtx.XRP(1050)), env.GW, "USD", 1000)
+	jtx.RequireIOUBalance(t, env.TestEnv, env.Bob, env.GW, "USD", 50)
+	offerbuild.RequireOfferCount(t, env.TestEnv, env.Bob, 1)
+	offerbuild.RequireIsOffer(t, env.TestEnv, env.Bob,
+		amm.XRPAmount(50),
+		amm.IOUAmount(env.GW, "USD", 50))
+}
+
 // TestAMMBookStep_Offers tests offer scenarios with AMM.
 // This is an umbrella test in rippled that calls:
 // testRmFundedOffer, testEnforceNoRipple, testFillModes, testOfferCrossWithXRP,

--- a/internal/tx/payment/step_book.go
+++ b/internal/tx/payment/step_book.go
@@ -342,7 +342,7 @@ func (s *BookStep) forEachOffer(
 			switch {
 			case s.book.In.IsMPT:
 				authorized = mptutil.RequireAuthAt(authView, s.book.In.MPTID, offerOwner, true, s.parentCloseTime) == ter.TesSUCCESS
-			case !isAMM && !s.book.In.IsXRP():
+			case !s.book.In.IsXRP():
 				authorized = s.isOfferOwnerAuthorized(
 					authView, offerOwner, s.book.In.Issuer, s.book.In.Currency,
 				)


### PR DESCRIPTION
## Summary

- apply IOU offer-owner authorization checks to synthetic AMM liquidity as well as CLOB offers
- add a regression proving an unauthorized AMM is skipped and the taker's full offer rests on the book
- preserve the existing positive coverage showing an explicitly authorized AMM can cross

## Root cause

`BookStep.forEachOffer` exempted synthetic AMM offers from the existing IOU `RequireAuth` check with a `!isAMM` condition. Rippled 3.2.0 applies `requireAuth(assetIn, offer.owner())` uniformly to both CLOB and synthetic AMM offers.

On Testnet, this allowed goXRPL to partially cross an OfferCreate against an AMM whose UAH trust line lacked the issuer authorization bit. Rippled skipped that AMM liquidity, so the implementations produced different transaction metadata and ledger state roots.

The fix removes only the AMM exemption. Unauthorized CLOB removal remains CLOB-only because a synthetic AMM offer has no ledger offer key.

## Validation

- focused fail-first regression and existing positive RequireAuth test
- `go test ./internal/tx/payment/... ./internal/testing/amm/... ./internal/testing/offer/...`
- focused race run
- `just vet`
- `just build-all`
- advisory and strict `golangci-lint v2.11.3`: `0 issues`
- full `just test`: every ordinary package passed; only the repository's existing unrelated conformance backlog failed
- private xrpl-confluence run with two exact rippled 3.2.0 validators (`3c43f4614f87965298773279ff5b85d4c56c637b`) and the patched goXRPL image:
  - reproducer transaction `85B9F170DC2B4EEDC78C5D41079F0B2344A019BBCF4644F61B56F336CF593D59` validated in ledger 80
  - all three nodes produced identical transaction metadata and ledger/state/transaction roots
  - AMM balances remained unchanged and the full offer rested
  - consensus continued through ledger 85 with an identical validated hash