### PR TITLE
fix: correct server info release and ledger status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
-      - run: go build -v ./cmd/xrpld
+      - name: Build versioned binary
+        run: ./scripts/build.sh
+      - name: Verify local build version
+        run: |
+          expected="$(git describe --tags --always --dirty)"
+          ../tmp/main version |
+            grep --fixed-strings --line-regexp "go-xrpl version ${expected}"
 
   # 32-bit word-size guard. go-xrpl's correctness is "produce the same bytes as
   # rippled"; an `int`-width or endianness assumption in the codec / hashing
@@ -156,7 +162,13 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Build goxrpl docker image
-        run: docker build -t goxrpl:latest .
+        run: docker build --build-arg "VERSION=${{ github.sha }}" -t goxrpl:latest .
+
+      - name: Verify goxrpl image version
+        run: |
+          set -o pipefail
+          docker run --rm goxrpl:latest version |
+            grep --fixed-strings --line-regexp "go-xrpl version ${{ github.sha }}"
 
       - name: Run consensus smoke
         run: bash scripts/consensus-smoke/smoke.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,7 +64,13 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Build goxrpl docker image
-        run: docker build -t goxrpl:latest .
+        run: docker build --build-arg "VERSION=${{ github.sha }}" -t goxrpl:latest .
+
+      - name: Verify goxrpl image version
+        run: |
+          set -o pipefail
+          docker run --rm goxrpl:latest version |
+            grep --fixed-strings --line-regexp "go-xrpl version ${{ github.sha }}"
 
       - name: Run extended consensus soak
         run: bash scripts/consensus-smoke/smoke.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,15 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=1 go build \
+ARG VERSION
+
+RUN if [ -z "${VERSION}" ] || [ "${VERSION}" = "dev" ]; then \
+      echo "VERSION must identify a release or commit" >&2; \
+      exit 2; \
+    fi \
+ && CGO_ENABLED=1 go build \
     -trimpath \
-    -ldflags="-s -w -linkmode external -extldflags '-static'" \
+    -ldflags="-s -w -linkmode external -extldflags '-static' -X=github.com/LeJamon/go-xrpl/version.Version=${VERSION}" \
     -o /usr/local/bin/goxrpl ./cmd/xrpld
 
 # Stage 2: Runtime

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ go-xrpl is not a line-by-line port of [rippled](https://github.com/XRPLF/rippled
 ### Prerequisites
 
 - Go 1.24+
+- `just`
 - PostgreSQL (optional, for relational storage)
 
 ### Build
 
 ```bash
-go build -o ./tmp/main ./cmd/xrpld
+just build
 ```
 
 ### Run
@@ -68,7 +69,7 @@ brew install openssl@3 secp256k1 pkg-config
 export PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig:$(brew --prefix secp256k1)/lib/pkgconfig"
 # Debian/Ubuntu: sudo apt install -y libssl-dev libsecp256k1-dev pkg-config
 
-go build ./cmd/xrpld        # or: just build
+just build
 ```
 
 See **[docs/operating.md](docs/operating.md)** for static/Alpine builds, the

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ just build
 
 ```bash
 # Start the node
-./tmp/main
+../tmp/main
 
 # Or with hot reload during development
 cd cmd/xrpld && air

--- a/config/grpc_test.go
+++ b/config/grpc_test.go
@@ -64,6 +64,16 @@ func TestValidateProtocols_GRPC(t *testing.T) {
 	})
 }
 
+func TestValidateProtocols_RejectsUnsupportedTLS(t *testing.T) {
+	for _, protocol := range []string{"https", "wss"} {
+		t.Run(protocol, func(t *testing.T) {
+			p := &PortConfig{Port: 5005, IP: "127.0.0.1", Protocol: protocol}
+			require.EqualError(t, p.Validate(),
+				protocol+" protocol is unsupported because RPC listeners do not terminate TLS")
+		})
+	}
+}
+
 // TestGRPCPort_SecureGatewayExpandsWildcard confirms the rippled-faithful
 // expansion of 0.0.0.0 into the IPv4+IPv6 wildcard nets. The grpc server
 // wiring (internal/cli) rejects this unspecified entry at startup,

--- a/config/server.go
+++ b/config/server.go
@@ -139,10 +139,12 @@ func (p *PortConfig) validateProtocols() error {
 
 	for _, protocol := range protocols {
 		switch protocol {
-		case "ws", "wss":
+		case "ws":
 			hasWebSocket = true
-		case "http", "https":
+		case "http":
 			hasNonWebSocket = true
+		case "https", "wss":
+			return fmt.Errorf("%s protocol is unsupported because RPC listeners do not terminate TLS", protocol)
 		case "peer":
 			peerCount++
 		case "grpc":

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -28,9 +28,10 @@ Then build:
 
 ```bash
 just build                 # → ../tmp/main (CGO + OpenSSL)
-# or
-go build -o ./tmp/main ./cmd/xrpld
 ```
+
+The recipe embeds `git describe --tags --always --dirty` in the binary. Set
+`VERSION` explicitly to override it for a packaged build.
 
 A `CGO_ENABLED=0 go build ./cmd/xrpld` also works: the resulting binary cannot
 connect to or accept peers (`peertls` returns `ErrSessionSigUnsupported`) and uses
@@ -86,6 +87,11 @@ supported). When neither `admin` nor `secure_gateway` is configured, direct
 loopback requests also receive admin role; other clients receive **guest** role.
 Always set `secure_gateway` on a same-host public proxy backend so loopback does
 not trigger that admin fallback.
+
+`server_info` and `server_state` omit rippled's optional job-queue `load`,
+requested `counters`, and `current_activities` fields. go-xrpl does not yet have
+equivalent job/performance instrumentation, so these fields remain unsupported
+rather than reporting placeholder data.
 
 ### TLS and reverse proxies
 

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -43,7 +43,7 @@ other subsystem work unchanged. Useful for contributors without a CGO toolchain.
 ```bash
 just run                   # go run ./cmd/xrpld
 # or run the built binary
-./tmp/main
+../tmp/main
 # or hot-reload during development (needs `air`)
 just dev
 ```
@@ -97,9 +97,10 @@ rather than reporting placeholder data.
 
 The HTTP and WebSocket listeners do not terminate TLS. For public RPC, run a TLS
 reverse proxy on the same host and bind the guest RPC ports to loopback rather
-than a public interface. Set `secure_gateway` on each proxied guest port to the
-proxy's exact source IP; for a same-host proxy this is normally `127.0.0.1` or
-`::1`:
+than a public interface. The configuration rejects `https` and `wss` protocols
+until native TLS termination is available. Set `secure_gateway` on each proxied
+guest port to the proxy's exact source IP; for a same-host proxy this is normally
+`127.0.0.1` or `::1`:
 
 ```toml
 [port_rpc_public]

--- a/internal/consensus/adaptor/fetchpack.go
+++ b/internal/consensus/adaptor/fetchpack.go
@@ -80,6 +80,24 @@ func (c *fetchPackCache) get(hash [32]byte, now time.Time) ([]byte, bool) {
 	return e.data, true
 }
 
+// Size returns the number of cached fetch-pack nodes.
+func (c *fetchPackCache) Size() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.nodes)
+}
+
+// FetchPackCacheSize returns the current inbound fetch-pack cache size.
+func (r *Router) FetchPackCacheSize() uint32 {
+	if r == nil {
+		return 0
+	}
+	return uint32(r.fetchPacks.Size())
+}
+
 // sweep drops entries at least as old as the effective max age for the current
 // size: the full TTL while within the target, and a proportionally shorter
 // window once over it. The age is computed once against the pre-sweep size so a

--- a/internal/consensus/adaptor/fetchpack_test.go
+++ b/internal/consensus/adaptor/fetchpack_test.go
@@ -59,7 +59,7 @@ func TestFetchPackCache_Sweep(t *testing.T) {
 	c.add([32]byte{1}, []byte{1}, t0)
 	c.add([32]byte{2}, []byte{2}, t0.Add(40*time.Second))
 	c.sweep(t0.Add(fetchPackCacheTTL + time.Second))
-	require.Equal(t, 1, c.size(), "sweep should drop only the expired entry")
+	require.Equal(t, 1, c.Size(), "sweep should drop only the expired entry")
 	if _, ok := c.get([32]byte{2}, t0.Add(40*time.Second)); !ok {
 		t.Error("sweep dropped a still-fresh entry")
 	}
@@ -73,7 +73,7 @@ func TestFetchPackCache_AcceptsNewcomersOverTarget(t *testing.T) {
 	c.add([32]byte{1}, []byte{1}, t0)
 	c.add([32]byte{2}, []byte{2}, t0)
 	c.add([32]byte{3}, []byte{3}, t0)
-	require.Equal(t, 3, c.size(), "newcomer over the target was refused")
+	require.Equal(t, 3, c.Size(), "newcomer over the target was refused")
 	got, ok := c.get([32]byte{3}, t0)
 	require.True(t, ok, "a fresh, useful node over the target must remain available")
 	require.Equal(t, byte(3), got[0])
@@ -93,7 +93,7 @@ func TestFetchPackCache_SweepShrinksProportionallyOverTarget(t *testing.T) {
 	c.add([32]byte{3}, []byte{3}, t0.Add(20*time.Second))
 	c.add([32]byte{4}, []byte{4}, t0.Add(20*time.Second))
 	c.sweep(t0.Add(30 * time.Second))
-	require.Equal(t, 2, c.size(), "oversized cache should age out the older half")
+	require.Equal(t, 2, c.Size(), "oversized cache should age out the older half")
 	for _, h := range [][32]byte{{1}, {2}} {
 		if _, ok := c.get(h, t0.Add(30*time.Second)); ok {
 			t.Errorf("entry %v older than the shrunk window survived sweep", h[0])
@@ -129,7 +129,8 @@ func TestFetchPackCache_NilReceiver(t *testing.T) {
 		t.Error("nil cache returned a hit")
 	}
 	c.sweep(time.Unix(1, 0))
-	require.Equal(t, 0, c.size())
+	require.Equal(t, 0, c.Size())
+	require.Equal(t, uint32(0), (*Router)(nil).FetchPackCacheSize())
 }
 
 // TestMakeFetchPack_PacksParentTree verifies the serve side packs the parent
@@ -261,7 +262,8 @@ func TestHandleFetchPackReply_VerifiesAndCaches(t *testing.T) {
 		Payload: payload,
 	})
 
-	assert.Equal(t, len(valid), r.fetchPacks.size(), "only verifiable SHAMap nodes should be cached")
+	assert.Equal(t, len(valid), r.fetchPacks.Size(), "only verifiable SHAMap nodes should be cached")
+	assert.Equal(t, uint32(len(valid)), r.FetchPackCacheSize())
 	for _, n := range valid {
 		if _, ok := r.fetchPacks.get(n.Hash, time.Now()); !ok {
 			t.Errorf("valid node %x not cached", n.Hash[:8])
@@ -378,7 +380,7 @@ func TestHandleFetchPackReply_NoActiveAcquisitionDropped(t *testing.T) {
 		Payload: payload,
 	})
 
-	assert.Equal(t, 0, r.fetchPacks.size(), "unsolicited pack must not be cached")
+	assert.Equal(t, 0, r.fetchPacks.Size(), "unsolicited pack must not be cached")
 	assert.Empty(t, rs.getBadDataCalls(), "an unsolicited pack is benign, not a charge")
 }
 
@@ -400,7 +402,7 @@ func TestHandleFetchPackReply_OversizedTruncatedNotCharged(t *testing.T) {
 		Payload: payload,
 	})
 
-	assert.Equal(t, fetchPackMaxObjects, r.fetchPacks.size(),
+	assert.Equal(t, fetchPackMaxObjects, r.fetchPacks.Size(),
 		"processing is bounded to the serve cap; surplus objects are ignored")
 	assert.Empty(t, rs.getBadDataCalls(),
 		"an over-cap reply from an honest peer must not be charged")
@@ -430,7 +432,7 @@ func TestHandleFetchPackReply_PoisonCharged(t *testing.T) {
 		Payload: payload,
 	})
 
-	assert.Equal(t, len(nodes), r.fetchPacks.size(), "verifiable nodes must still be cached")
+	assert.Equal(t, len(nodes), r.fetchPacks.Size(), "verifiable nodes must still be cached")
 	calls := rs.getBadDataCalls()
 	require.Len(t, calls, 1)
 	assert.Equal(t, uint64(11), calls[0].peerID)
@@ -458,7 +460,7 @@ func TestHandleFetchPackReply_HeaderObjectNotCharged(t *testing.T) {
 		Payload: payload,
 	})
 
-	assert.Equal(t, len(nodes), r.fetchPacks.size(), "valid nodes cached; header dropped")
+	assert.Equal(t, len(nodes), r.fetchPacks.Size(), "valid nodes cached; header dropped")
 	var headerHash [32]byte
 	copy(headerHash[:], bytes.Repeat([]byte{0xEE}, 32))
 	if _, ok := r.fetchPacks.get(headerHash, time.Now()); ok {

--- a/internal/consensus/adaptor/inbound_byhash_test.go
+++ b/internal/consensus/adaptor/inbound_byhash_test.go
@@ -54,7 +54,7 @@ func TestHandleNodeReply_AcceptsByHashStateNodes(t *testing.T) {
 		Payload: payload,
 	})
 
-	assert.Equal(t, len(valid), r.fetchPacks.size(), "by-hash state-node reply nodes must be cached")
+	assert.Equal(t, len(valid), r.fetchPacks.Size(), "by-hash state-node reply nodes must be cached")
 	for _, n := range valid {
 		if _, ok := r.fetchPacks.get(n.Hash, time.Now()); !ok {
 			t.Errorf("by-hash node %x not cached", n.Hash[:8])

--- a/internal/consensus/adaptor/testhelpers_test.go
+++ b/internal/consensus/adaptor/testhelpers_test.go
@@ -30,16 +30,6 @@ func HaveSetToMessage(id consensus.TxSetID, status message.TxSetStatus) *message
 	}
 }
 
-// size reports the number of cached fetch-pack nodes.
-func (c *fetchPackCache) size() int {
-	if c == nil {
-		return 0
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return len(c.nodes)
-}
-
 // newLedgerProviderForTest builds a provider over an arbitrary lookup.
 func newLedgerProviderForTest(lookup ledgerLookup) *LedgerProvider {
 	return &LedgerProvider{svc: lookup}

--- a/internal/ledger/manager/completeness.go
+++ b/internal/ledger/manager/completeness.go
@@ -57,6 +57,33 @@ func (c *CompleteLedgerSet) AddRange(start, end uint32) {
 	c.ranges = c.mergeRange(c.ranges, newRange)
 }
 
+// Remove marks a single ledger sequence as incomplete.
+func (c *CompleteLedgerSet) Remove(seq uint32) {
+	c.RemoveRange(seq, seq)
+}
+
+// RemoveRange marks a range of ledger sequences as incomplete.
+func (c *CompleteLedgerSet) RemoveRange(start, end uint32) {
+	if start > end {
+		return
+	}
+
+	result := make([]LedgerRange, 0, len(c.ranges)+1)
+	for _, existing := range c.ranges {
+		if existing.End < start || existing.Start > end {
+			result = append(result, existing)
+			continue
+		}
+		if existing.Start < start {
+			result = append(result, LedgerRange{Start: existing.Start, End: start - 1})
+		}
+		if existing.End > end {
+			result = append(result, LedgerRange{Start: end + 1, End: existing.End})
+		}
+	}
+	c.ranges = result
+}
+
 // Contains checks if a ledger sequence is marked as complete
 func (c *CompleteLedgerSet) Contains(seq uint32) bool {
 	// Binary search for efficiency
@@ -170,7 +197,7 @@ func (c *CompleteLedgerSet) mergeRange(ranges []LedgerRange, newRange LedgerRang
 
 	for i, existing := range ranges {
 		// If new range comes before this range and doesn't overlap
-		if !merged && newRange.End+1 < existing.Start {
+		if !merged && newRange.End < existing.Start && existing.Start-newRange.End > 1 {
 			result = append(result, newRange)
 			result = append(result, ranges[i:]...)
 			merged = true
@@ -209,6 +236,9 @@ func (c *CompleteLedgerSet) mergeRange(ranges []LedgerRange, newRange LedgerRang
 
 // rangesOverlapOrAdjacent checks if two ranges overlap or are adjacent
 func (c *CompleteLedgerSet) rangesOverlapOrAdjacent(a, b LedgerRange) bool {
-	// Ranges overlap if one starts before the other ends (with 1-sequence adjacency)
-	return a.Start <= b.End+1 && b.Start <= a.End+1
+	if a.Start <= b.End && b.Start <= a.End {
+		return true
+	}
+	return a.End < b.Start && b.Start-a.End == 1 ||
+		b.End < a.Start && a.Start-b.End == 1
 }

--- a/internal/ledger/manager/completeness_test.go
+++ b/internal/ledger/manager/completeness_test.go
@@ -375,3 +375,84 @@ func TestStringEmpty(t *testing.T) {
 		t.Errorf("String() on empty set = %q, want %q", got, "empty")
 	}
 }
+
+func TestRemoveRange(t *testing.T) {
+	tests := []struct {
+		name  string
+		start uint32
+		end   uint32
+		want  string
+	}{
+		{name: "single sequence splits range", start: 5, end: 5, want: "1-4,6-10"},
+		{name: "prefix", start: 0, end: 3, want: "4-10"},
+		{name: "suffix", start: 8, end: 20, want: "1-7"},
+		{name: "whole range", start: 0, end: 20, want: "empty"},
+		{name: "disjoint before", start: 0, end: 0, want: "1-10"},
+		{name: "disjoint after", start: 11, end: 20, want: "1-10"},
+		{name: "inverted ignored", start: 8, end: 7, want: "1-10"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := NewCompleteLedgerSet()
+			c.AddRange(1, 10)
+			c.RemoveRange(test.start, test.end)
+			if got := c.String(); got != test.want {
+				t.Fatalf("String() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRemoveRangeSplitPreservesLaterRanges(t *testing.T) {
+	c := NewCompleteLedgerSet()
+	c.AddRange(1, 10)
+	c.AddRange(20, 30)
+
+	c.Remove(5)
+
+	if got, want := c.String(), "1-4,6-10,20-30"; got != want {
+		t.Fatalf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveAcrossRanges(t *testing.T) {
+	c := NewCompleteLedgerSet()
+	c.AddRange(1, 5)
+	c.AddRange(10, 15)
+	c.AddRange(20, 25)
+
+	c.RemoveRange(3, 22)
+
+	if got := c.String(); got != "1-2,23-25" {
+		t.Fatalf("String() = %q, want %q", got, "1-2,23-25")
+	}
+	if got := c.Count(); got != 5 {
+		t.Fatalf("Count() = %d, want 5", got)
+	}
+}
+
+func TestRemoveSingle(t *testing.T) {
+	c := NewCompleteLedgerSet()
+	c.AddRange(7, 9)
+	c.Remove(8)
+
+	if got := c.String(); got != "7,9" {
+		t.Fatalf("String() = %q, want %q", got, "7,9")
+	}
+}
+
+func TestRangeOperationsAtUint32Max(t *testing.T) {
+	maxUint32 := ^uint32(0)
+	c := NewCompleteLedgerSet()
+	c.Add(maxUint32)
+	c.Add(maxUint32 - 1)
+	if got := c.String(); got != "4294967294-4294967295" {
+		t.Fatalf("String() = %q, want max range", got)
+	}
+
+	c.Remove(maxUint32)
+	if got := c.String(); got != "4294967294" {
+		t.Fatalf("String() after Remove(max) = %q, want %q", got, "4294967294")
+	}
+}

--- a/internal/ledger/service/backfill_validated_monotonic_test.go
+++ b/internal/ledger/service/backfill_validated_monotonic_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -59,10 +60,9 @@ func TestBackfill_BelowTipDrainDoesNotRewindValidated(t *testing.T) {
 		AccountHash: stateRoot,
 	}
 	require.NoError(t, svc.AdoptLedgerWithState(context.TODO(), hdr, stateMap, txMap))
+	svc.FlushPersists()
 
 	svc.mu.RLock()
-	defer svc.mu.RUnlock()
-
 	require.NotNil(t, svc.validatedLedger)
 	assert.Equal(t, tip.Sequence(), svc.validatedLedger.Sequence(),
 		"a below-tip backfill drain must not rewind the validated pointer")
@@ -74,4 +74,8 @@ func TestBackfill_BelowTipDrainDoesNotRewindValidated(t *testing.T) {
 		"the backfilled ledger itself is validated — only the pointer must not move")
 	_, stashed := svc.pendingLedgerValidations[baseSeq]
 	assert.False(t, stashed, "the stash must be consumed either way")
+	svc.mu.RUnlock()
+
+	assert.Equal(t, strconv.FormatUint(uint64(baseSeq), 10), svc.GetServerInfo().CompleteLedgers,
+		"a below-tip validated backfill must use validated-history persistence")
 }

--- a/internal/ledger/service/cache.go
+++ b/internal/ledger/service/cache.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/ledger/manager"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
 
@@ -14,6 +15,168 @@ import (
 const historyWindow = 256
 
 const persistedLedgerCacheSize = historyWindow
+
+func (s *Service) ensureCompleteLedgerStateLocked() {
+	if s.completedLedgers == nil {
+		s.completedLedgers = manager.NewCompleteLedgerSet()
+	}
+	if s.completeLedgerTokens == nil {
+		s.completeLedgerTokens = make(map[uint32]uint64)
+	}
+	if s.completeLedgerHashes == nil {
+		s.completeLedgerHashes = make(map[uint32][32]byte)
+	}
+}
+
+func (s *Service) beginValidatedPersistence(seq uint32, hash [32]byte) uint64 {
+	s.completeMu.Lock()
+	defer s.completeMu.Unlock()
+	s.ensureCompleteLedgerStateLocked()
+	s.nextCompleteLedgerToken++
+	token := s.nextCompleteLedgerToken
+	s.completeLedgerTokens[seq] = token
+	s.completeLedgerHashes[seq] = hash
+	if seq >= s.completeLedgerFloor {
+		s.completedLedgers.Add(seq)
+	}
+	return token
+}
+
+func (s *Service) recordValidatedPersistence(seq uint32, token uint64, success bool) {
+	s.completeMu.Lock()
+	defer s.completeMu.Unlock()
+	s.ensureCompleteLedgerStateLocked()
+	if s.completeLedgerTokens[seq] != token {
+		return
+	}
+	delete(s.completeLedgerTokens, seq)
+	if !success || seq < s.completeLedgerFloor {
+		delete(s.completeLedgerHashes, seq)
+		s.completedLedgers.Remove(seq)
+		return
+	}
+	s.completedLedgers.Add(seq)
+}
+
+// invalidateCompleteLedger removes seq and prevents already-queued persistence
+// work for the invalidated fork from adding it back.
+func (s *Service) invalidateCompleteLedger(seq uint32) {
+	s.persistMu.Lock()
+	if job := s.validatedPersistJobs[seq]; job != nil {
+		job.canceled.Store(true)
+	}
+	delete(s.validatedPersistJobs, seq)
+	s.completeMu.Lock()
+	s.ensureCompleteLedgerStateLocked()
+	delete(s.completeLedgerTokens, seq)
+	delete(s.completeLedgerHashes, seq)
+	s.completedLedgers.Remove(seq)
+	s.completeMu.Unlock()
+	s.persistMu.Unlock()
+	s.invalidatePersistedValidatedTip(seq, seq)
+}
+
+func (s *Service) invalidateCompleteLedgerHash(seq uint32, hash [32]byte) {
+	s.persistMu.Lock()
+	job := s.validatedPersistJobs[seq]
+	hasReplacement := job != nil && job.l != nil && job.l.Hash() != hash
+	if job != nil && !hasReplacement {
+		job.canceled.Store(true)
+		delete(s.validatedPersistJobs, seq)
+	}
+	s.completeMu.Lock()
+	s.ensureCompleteLedgerStateLocked()
+	if s.completeLedgerHashes[seq] == hash {
+		delete(s.completeLedgerTokens, seq)
+		delete(s.completeLedgerHashes, seq)
+		s.completedLedgers.Remove(seq)
+	}
+	s.completeMu.Unlock()
+	s.persistMu.Unlock()
+	s.invalidatePersistedValidatedTipHash(seq, hash)
+}
+
+func (s *Service) invalidateCompleteLedgerRange(start, end uint32) {
+	if start > end {
+		return
+	}
+	s.persistMu.Lock()
+	for seq, job := range s.validatedPersistJobs {
+		if seq >= start && seq <= end {
+			job.canceled.Store(true)
+			delete(s.validatedPersistJobs, seq)
+		}
+	}
+	s.completeMu.Lock()
+	s.ensureCompleteLedgerStateLocked()
+	for seq := range s.completeLedgerTokens {
+		if seq >= start && seq <= end {
+			delete(s.completeLedgerTokens, seq)
+		}
+	}
+	for seq := range s.completeLedgerHashes {
+		if seq >= start && seq <= end {
+			delete(s.completeLedgerHashes, seq)
+		}
+	}
+	s.completedLedgers.RemoveRange(start, end)
+	s.completeMu.Unlock()
+	s.persistMu.Unlock()
+	s.invalidatePersistedValidatedTip(start, end)
+}
+
+func (s *Service) clampCompleteLedgers(floor uint32) {
+	if floor == 0 {
+		return
+	}
+	s.persistMu.Lock()
+	s.completeMu.Lock()
+	defer s.persistMu.Unlock()
+	defer s.completeMu.Unlock()
+	s.ensureCompleteLedgerStateLocked()
+	if floor <= s.completeLedgerFloor {
+		return
+	}
+	s.completeLedgerFloor = floor
+	for seq, job := range s.validatedPersistJobs {
+		if seq < floor {
+			job.canceled.Store(true)
+			delete(s.validatedPersistJobs, seq)
+		}
+	}
+	for seq := range s.completeLedgerTokens {
+		if seq < floor {
+			delete(s.completeLedgerTokens, seq)
+		}
+	}
+	for seq := range s.completeLedgerHashes {
+		if seq < floor {
+			delete(s.completeLedgerHashes, seq)
+		}
+	}
+	s.completedLedgers.RemoveRange(0, floor-1)
+}
+
+func (s *Service) hasCompleteLedger(l *ledger.Ledger) bool {
+	if l == nil {
+		return false
+	}
+	s.completeMu.RLock()
+	defer s.completeMu.RUnlock()
+	if s.completedLedgers == nil || !s.completedLedgers.Contains(l.Sequence()) {
+		return false
+	}
+	return s.completeLedgerHashes[l.Sequence()] == l.Hash()
+}
+
+func (s *Service) completeLedgersString() string {
+	s.completeMu.RLock()
+	defer s.completeMu.RUnlock()
+	if s.completedLedgers == nil {
+		return "empty"
+	}
+	return s.completedLedgers.String()
+}
 
 // evictOldHistoryLocked drops ledgerHistory + tx-index entries older than the
 // historyWindow. Caller must hold s.mu.

--- a/internal/ledger/service/cache.go
+++ b/internal/ledger/service/cache.go
@@ -178,6 +178,21 @@ func (s *Service) completeLedgersString() string {
 	return s.completedLedgers.String()
 }
 
+func (s *Service) completeLedgerEvictionStatus(seq uint32) (tracked, durable bool) {
+	s.completeMu.RLock()
+	defer s.completeMu.RUnlock()
+	_, hasHash := s.completeLedgerHashes[seq]
+	_, pending := s.completeLedgerTokens[seq]
+	complete := s.completedLedgers != nil && s.completedLedgers.Contains(seq)
+	tracked = complete || hasHash || pending
+	durable = s.nodeStore != nil &&
+		s.shamapFamily != nil &&
+		complete &&
+		hasHash &&
+		!pending
+	return tracked, durable
+}
+
 // evictOldHistoryLocked drops ledgerHistory + tx-index entries older than the
 // historyWindow. Caller must hold s.mu.
 func (s *Service) evictOldHistoryLocked(latestValidatedSeq uint32) {
@@ -188,6 +203,9 @@ func (s *Service) evictOldHistoryLocked(latestValidatedSeq uint32) {
 	for seq, l := range s.ledgerHistory {
 		if seq > cutoff {
 			continue
+		}
+		if tracked, durable := s.completeLedgerEvictionStatus(seq); tracked && !durable {
+			s.invalidateCompleteLedger(seq)
 		}
 		_ = l.ForEachTransaction(func(txHash [32]byte, _ []byte) bool {
 			delete(s.txIndex, txHash)

--- a/internal/ledger/service/complete_ledgers_floor_test.go
+++ b/internal/ledger/service/complete_ledgers_floor_test.go
@@ -3,31 +3,15 @@ package service
 import (
 	"testing"
 	"time"
-
-	"github.com/LeJamon/go-xrpl/internal/ledger"
-	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 )
 
-// seedHistory replaces the in-memory history window with placeholder ledgers
-// for [lo, hi], so GetServerInfo derives complete_ledgers from a known range.
-// Start() seeds the genesis ledger; clear it first so the range is exactly
-// [lo, hi].
-func seedHistory(t *testing.T, svc *Service, lo, hi uint32) {
+func seedCompleteLedgers(t *testing.T, svc *Service, lo, hi uint32) {
 	t.Helper()
-	svc.ledgerHistory = make(map[uint32]*ledger.Ledger)
-	for seq := lo; seq <= hi; seq++ {
-		stateMap, err := svc.genesisLedger.StateMapSnapshot()
-		if err != nil {
-			t.Fatalf("StateMapSnapshot: %v", err)
-		}
-		txMap, err := svc.genesisLedger.TxMapSnapshot()
-		if err != nil {
-			t.Fatalf("TxMapSnapshot: %v", err)
-		}
-		var h header.LedgerHeader
-		h.LedgerIndex = seq
-		svc.ledgerHistory[seq] = mustNewOpenWithHeader(t, h, stateMap, txMap)
-	}
+	svc.completeMu.Lock()
+	defer svc.completeMu.Unlock()
+	svc.ensureCompleteLedgerStateLocked()
+	svc.completedLedgers.Clear()
+	svc.completedLedgers.AddRange(lo, hi)
 }
 
 // TestGetServerInfo_CompleteLedgers_ClampedToFloor verifies that after a
@@ -43,7 +27,7 @@ func TestGetServerInfo_CompleteLedgers_ClampedToFloor(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 
-	seedHistory(t, svc, 10, 100)
+	seedCompleteLedgers(t, svc, 10, 100)
 
 	// Without a floor the range is the full window.
 	if got := svc.GetServerInfo().CompleteLedgers; got != "10-100" {
@@ -68,7 +52,7 @@ func TestGetServerInfo_CompleteLedgers_FloorBelowWindow(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 
-	seedHistory(t, svc, 10, 100)
+	seedCompleteLedgers(t, svc, 10, 100)
 
 	svc.SetMinimumOnlineFunc(func() uint32 { return 5 }) // below window lo
 	if got := svc.GetServerInfo().CompleteLedgers; got != "10-100" {
@@ -93,11 +77,11 @@ func TestGetServerInfo_CompleteLedgers_FloorAboveWindow(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 
-	seedHistory(t, svc, 10, 100)
+	seedCompleteLedgers(t, svc, 10, 100)
 
 	svc.SetMinimumOnlineFunc(func() uint32 { return 200 }) // above window hi
-	if got := svc.GetServerInfo().CompleteLedgers; got != "" {
-		t.Fatalf("floor above window = %q, want empty", got)
+	if got := svc.GetServerInfo().CompleteLedgers; got != "empty" {
+		t.Fatalf("floor above window = %q, want %q", got, "empty")
 	}
 }
 
@@ -111,7 +95,7 @@ func TestGetServerInfo_CompleteLedgersDoesNotUseFetchDepth(t *testing.T) {
 	if err := svc.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	seedHistory(t, svc, 10, 100)
+	seedCompleteLedgers(t, svc, 10, 100)
 
 	if got := svc.GetServerInfo().CompleteLedgers; got != "10-100" {
 		t.Fatalf("complete_ledgers = %q, want %q", got, "10-100")

--- a/internal/ledger/service/complete_ledgers_state_test.go
+++ b/internal/ledger/service/complete_ledgers_state_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
@@ -9,6 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/shamap"
 	"github.com/LeJamon/go-xrpl/storage/kvstore/memorydb"
 	"github.com/LeJamon/go-xrpl/storage/nodestore"
@@ -45,6 +50,50 @@ func (d *controlledSyncDatabase) Sync(ctx context.Context) error {
 		return errors.New("injected sync failure")
 	}
 	return d.Database.Sync(ctx)
+}
+
+func makeStubLedgerWithTransaction(
+	t *testing.T,
+	seq uint32,
+	hash, parentHash [32]byte,
+	account string,
+	accountSequence uint32,
+) (*ledger.Ledger, [32]byte) {
+	t.Helper()
+
+	txHex, err := binarycodec.Encode(map[string]any{
+		"TransactionType": "AccountSet",
+		"Account":         account,
+		"Fee":             "10",
+		"Sequence":        accountSequence,
+	})
+	require.NoError(t, err)
+	txBytes, err := hex.DecodeString(txHex)
+	require.NoError(t, err)
+	txBlob, txID := makeTxMetaBlobForTest(t, txBytes, 0)
+
+	txMap := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, txMap.PutWithNodeType(txID, txBlob, shamap.NodeTypeTransactionWithMeta))
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	hdr := makeStubLedger(t, seq, hash, parentHash).Header()
+	hdr.TxHash = txRoot
+	l, err := ledger.NewFromHeader(hdr, shamap.New(shamap.TypeState), txMap, drops.Fees{})
+	require.NoError(t, err)
+	return l, txID
+}
+
+func accountIDFromAddress(t *testing.T, address string) relationaldb.AccountID {
+	t.Helper()
+
+	_, raw, err := addresscodec.DecodeClassicAddressToAccountID(address)
+	require.NoError(t, err)
+	require.Len(t, raw, len(relationaldb.AccountID{}))
+
+	var accountID relationaldb.AccountID
+	copy(accountID[:], raw)
+	return accountID
 }
 
 func TestCompleteLedgers_FreshNetworkStartupIsEmpty(t *testing.T) {
@@ -248,6 +297,77 @@ func TestCompleteLedgers_SameSequenceSwitchKeepsPreferredPersistence(t *testing.
 	require.NotNil(t, pair)
 	assert.Equal(t, preferredHash, [32]byte(pair.LedgerHash))
 	assert.Equal(t, fmt.Sprint(seq), svc.completeLedgersString())
+}
+
+func TestCompleteLedgers_SameSequenceReplacementRebuildsTransactionIndexes(t *testing.T) {
+	ctx := context.Background()
+	repositories, err := sqlitedb.NewRepositoryManager(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, repositories.Open(ctx))
+	t.Cleanup(func() { require.NoError(t, repositories.Close(ctx)) })
+
+	cfg := DefaultConfig()
+	cfg.RelationalDB = repositories
+	svc, err := New(cfg)
+	require.NoError(t, err)
+
+	const (
+		seq                uint32 = 27
+		abandonedAccount          = "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
+		replacementAccount        = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	)
+	parentHash := [32]byte{0x26}
+	abandoned, abandonedTx := makeStubLedgerWithTransaction(
+		t, seq, [32]byte{0xA1}, parentHash, abandonedAccount, 1,
+	)
+	replacement, replacementTx := makeStubLedgerWithTransaction(
+		t, seq, [32]byte{0xB1}, parentHash, replacementAccount, 2,
+	)
+
+	queryAccount := func(address string) []relationaldb.TransactionInfo {
+		t.Helper()
+		txs, err := repositories.AccountTransaction().GetOldestAccountTxs(ctx, relationaldb.AccountTxOptions{
+			Account:   accountIDFromAddress(t, address),
+			MinLedger: relationaldb.LedgerIndex(seq),
+			MaxLedger: relationaldb.LedgerIndex(seq),
+			Unlimited: true,
+		})
+		require.NoError(t, err)
+		return txs
+	}
+
+	require.NoError(t, svc.persistValidatedLedger(ctx, abandoned, false))
+	abandonedInfo, _, err := repositories.Transaction().GetTransaction(
+		ctx, relationaldb.Hash(abandonedTx), nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, abandonedInfo)
+	require.Len(t, queryAccount(abandonedAccount), 1)
+
+	require.NoError(t, svc.persistValidatedLedger(ctx, replacement, false))
+
+	ledgerInfo, err := repositories.Ledger().GetLedgerInfoBySeq(ctx, relationaldb.LedgerIndex(seq))
+	require.NoError(t, err)
+	require.NotNil(t, ledgerInfo)
+	assert.Equal(t, replacement.Hash(), [32]byte(ledgerInfo.Hash))
+
+	abandonedInfo, _, err = repositories.Transaction().GetTransaction(
+		ctx, relationaldb.Hash(abandonedTx), nil,
+	)
+	require.NoError(t, err)
+	assert.Nil(t, abandonedInfo)
+
+	replacementInfo, _, err := repositories.Transaction().GetTransaction(
+		ctx, relationaldb.Hash(replacementTx), nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, replacementInfo)
+	assert.Equal(t, relationaldb.LedgerIndex(seq), replacementInfo.LedgerSeq)
+
+	assert.Empty(t, queryAccount(abandonedAccount))
+	replacementAccountTxs := queryAccount(replacementAccount)
+	require.Len(t, replacementAccountTxs, 1)
+	assert.Equal(t, relationaldb.Hash(replacementTx), replacementAccountTxs[0].Hash)
 }
 
 func TestCompleteLedgers_InvalidationRepairsInFlightValidatedTip(t *testing.T) {

--- a/internal/ledger/service/complete_ledgers_state_test.go
+++ b/internal/ledger/service/complete_ledgers_state_test.go
@@ -1,0 +1,370 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/LeJamon/go-xrpl/storage/kvstore/memorydb"
+	"github.com/LeJamon/go-xrpl/storage/nodestore"
+	"github.com/LeJamon/go-xrpl/storage/relationaldb"
+	sqlitedb "github.com/LeJamon/go-xrpl/storage/relationaldb/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type controlledSyncDatabase struct {
+	nodestore.Database
+	fail atomic.Bool
+}
+
+type gatedTipDatabase struct {
+	nodestore.Database
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (d *gatedTipDatabase) Store(ctx context.Context, node *nodestore.Node) error {
+	if node.Hash == validatedTipKey && node.LedgerSeq != 0 {
+		d.once.Do(func() {
+			close(d.entered)
+			<-d.release
+		})
+	}
+	return d.Database.Store(ctx, node)
+}
+
+func (d *controlledSyncDatabase) Sync(ctx context.Context) error {
+	if d.fail.Load() {
+		return errors.New("injected sync failure")
+	}
+	return d.Database.Sync(ctx)
+}
+
+func TestCompleteLedgers_FreshNetworkStartupIsEmpty(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Standalone = false
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	info := svc.GetServerInfo()
+	assert.Equal(t, "empty", info.CompleteLedgers)
+	assert.False(t, info.HavePublished)
+}
+
+func TestCompleteLedgers_PreservesHoles(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+
+	for _, seq := range []uint32{10, 11, 13, 16, 17} {
+		l := makeStubLedger(t, seq, [32]byte{byte(seq)}, [32]byte{})
+		require.NoError(t, svc.persistValidatedLedger(context.Background(), l, false))
+	}
+
+	assert.Equal(t, "10-11,13,16-17", svc.GetServerInfo().CompleteLedgers)
+}
+
+func TestCompleteLedgers_FailedValidatedPersistenceRemovesSequence(t *testing.T) {
+	base := nodestore.NewKVDatabase(memorydb.New(), "complete-ledgers-failure", 100, time.Hour)
+	t.Cleanup(func() { require.NoError(t, base.Close()) })
+	db := &controlledSyncDatabase{Database: base}
+
+	cfg := DefaultConfig()
+	cfg.NodeStore = db
+	svc, err := New(cfg)
+	require.NoError(t, err)
+
+	l := makeStubLedger(t, 20, [32]byte{0x20}, [32]byte{0x19})
+	db.fail.Store(true)
+	require.Error(t, svc.persistValidatedLedger(context.Background(), l, false))
+	assert.Equal(t, "empty", svc.GetServerInfo().CompleteLedgers)
+}
+
+func TestCompleteLedgers_DeduplicatesPendingValidatedPersistence(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+	svc.persistMu.Lock()
+	svc.persistStarted = true
+	svc.persistMu.Unlock()
+
+	l := makeStubLedger(t, 25, [32]byte{0x25}, [32]byte{0x24})
+	svc.enqueueValidatedHistoryPersist(l)
+	svc.enqueuePersist(l)
+
+	svc.persistMu.Lock()
+	require.Len(t, svc.persistQueue, 1)
+	require.Len(t, svc.validatedPersistJobs, 1)
+	assert.True(t, svc.persistQueue[0].updatesTip.Load())
+	svc.persistMu.Unlock()
+
+	svc.invalidateCompleteLedger(25)
+	replacement := makeStubLedger(t, 25, [32]byte{0x26}, [32]byte{0x24})
+	svc.enqueuePersist(replacement)
+
+	svc.persistMu.Lock()
+	defer svc.persistMu.Unlock()
+	require.Len(t, svc.persistQueue, 2)
+	assert.Same(t, replacement, svc.validatedPersistJobs[25].l)
+}
+
+func TestCompleteLedgers_HistoryPersistenceDoesNotDisplaceCanonicalJob(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+	svc.persistMu.Lock()
+	svc.persistStarted = true
+	svc.persistMu.Unlock()
+
+	canonical := makeStubLedger(t, 25, [32]byte{0x25}, [32]byte{0x24})
+	sibling := makeStubLedger(t, 25, [32]byte{0x26}, [32]byte{0x24})
+	svc.enqueuePersist(canonical)
+	svc.enqueueValidatedHistoryPersist(sibling)
+
+	svc.persistMu.Lock()
+	defer svc.persistMu.Unlock()
+	require.Len(t, svc.persistQueue, 1)
+	assert.Same(t, canonical, svc.validatedPersistJobs[25].l)
+}
+
+func TestCompleteLedgers_InvalidatedQueuedPersistenceSkipsAbandonedFork(t *testing.T) {
+	ctx := context.Background()
+	db := nodestore.NewKVDatabase(memorydb.New(), "complete-ledgers-replacement", 100, time.Hour)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	repositories, err := sqlitedb.NewRepositoryManager(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, repositories.Open(ctx))
+	t.Cleanup(func() { require.NoError(t, repositories.Close(ctx)) })
+
+	svc, err := New(Config{
+		NodeStore:    db,
+		SHAMapFamily: shamap.NewNodeStoreFamily(db),
+		RelationalDB: repositories,
+	})
+	require.NoError(t, err)
+	svc.persistMu.Lock()
+	svc.persistStarted = true
+	svc.persistMu.Unlock()
+
+	const seq uint32 = 26
+	abandoned := makeStubLedger(t, seq, [32]byte{0x25}, [32]byte{0x24})
+	replacement := makeStubLedger(t, seq, [32]byte{0x26}, [32]byte{0x24})
+	require.NoError(t, svc.persistValidatedTip(ctx, abandoned))
+	svc.enqueuePersist(abandoned)
+	svc.invalidateCompleteLedger(seq)
+	svc.enqueuePersist(replacement)
+
+	svc.persistMu.Lock()
+	jobs := append([]*persistJob(nil), svc.persistQueue...)
+	svc.persistQueue = nil
+	svc.persistMu.Unlock()
+	require.Len(t, jobs, 2)
+	for _, job := range jobs {
+		svc.runPersistJob(job)
+	}
+
+	tip, err := db.Fetch(ctx, validatedTipKey)
+	require.NoError(t, err)
+	require.NotNil(t, tip)
+	replacementHash := replacement.Hash()
+	assert.Equal(t, replacementHash[:], []byte(tip.Data))
+	pair, err := repositories.Ledger().GetHashesByIndex(ctx, relationaldb.LedgerIndex(seq))
+	require.NoError(t, err)
+	require.NotNil(t, pair)
+	assert.Equal(t, replacementHash, [32]byte(pair.LedgerHash))
+	assert.Equal(t, "26", svc.completeLedgersString())
+}
+
+func TestCompleteLedgers_SameSequenceSwitchKeepsPreferredPersistence(t *testing.T) {
+	ctx := context.Background()
+	db := nodestore.NewKVDatabase(memorydb.New(), "complete-ledgers-sibling-switch", 100, time.Hour)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	repositories, err := sqlitedb.NewRepositoryManager(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, repositories.Open(ctx))
+	t.Cleanup(func() { require.NoError(t, repositories.Close(ctx)) })
+
+	cfg := DefaultConfig()
+	cfg.Standalone = false
+	cfg.NodeStore = db
+	cfg.SHAMapFamily = shamap.NewNodeStoreFamily(db)
+	cfg.RelationalDB = repositories
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	svc.persistMu.Lock()
+	svc.persistStarted = true
+	svc.persistMu.Unlock()
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	seq := svc.GetClosedLedgerIndex()
+	parentHash := svc.GetClosedLedger().ParentHash()
+	abandoned := makeStubLedger(t, seq, [32]byte{0xA1}, parentHash)
+	preferred := makeStubLedger(t, seq, [32]byte{0xB1}, parentHash)
+	unrelated := makeStubLedger(t, seq, [32]byte{0xC1}, parentHash)
+	require.NoError(t, svc.persistValidatedLedger(ctx, abandoned, true))
+
+	svc.mu.Lock()
+	svc.closedLedger = abandoned
+	svc.putHistoryLocked(abandoned)
+	svc.mu.Unlock()
+	svc.enqueueValidatedHistoryPersist(unrelated)
+
+	svc.persistMu.Lock()
+	require.Len(t, svc.persistQueue, 1)
+	unrelatedJob := svc.persistQueue[0]
+	svc.persistMu.Unlock()
+
+	require.NoError(t, svc.SwitchToPreferredLedger(preferred))
+	assert.True(t, unrelatedJob.canceled.Load())
+	svc.persistMu.Lock()
+	preferredJob := svc.validatedPersistJobs[seq]
+	svc.persistMu.Unlock()
+	require.NotNil(t, preferredJob)
+	assert.Same(t, preferred, preferredJob.l)
+
+	svc.persistMu.Lock()
+	jobs := append([]*persistJob(nil), svc.persistQueue...)
+	svc.persistQueue = nil
+	svc.persistMu.Unlock()
+	require.Len(t, jobs, 2)
+	for _, job := range jobs {
+		svc.runPersistJob(job)
+	}
+
+	tip, err := db.Fetch(ctx, validatedTipKey)
+	require.NoError(t, err)
+	require.NotNil(t, tip)
+	preferredHash := preferred.Hash()
+	assert.Equal(t, preferredHash[:], []byte(tip.Data))
+	pair, err := repositories.Ledger().GetHashesByIndex(ctx, relationaldb.LedgerIndex(seq))
+	require.NoError(t, err)
+	require.NotNil(t, pair)
+	assert.Equal(t, preferredHash, [32]byte(pair.LedgerHash))
+	assert.Equal(t, fmt.Sprint(seq), svc.completeLedgersString())
+}
+
+func TestCompleteLedgers_InvalidationRepairsInFlightValidatedTip(t *testing.T) {
+	ctx := context.Background()
+	base := nodestore.NewKVDatabase(memorydb.New(), "complete-ledgers-inflight", 100, time.Hour)
+	t.Cleanup(func() { require.NoError(t, base.Close()) })
+	db := &gatedTipDatabase{
+		Database: base,
+		entered:  make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	repositories, err := sqlitedb.NewRepositoryManager(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, repositories.Open(ctx))
+	t.Cleanup(func() { require.NoError(t, repositories.Close(ctx)) })
+
+	svc, err := New(Config{
+		NodeStore:    db,
+		SHAMapFamily: shamap.NewNodeStoreFamily(db),
+		RelationalDB: repositories,
+	})
+	require.NoError(t, err)
+	svc.persistMu.Lock()
+	svc.persistStarted = true
+	svc.persistMu.Unlock()
+
+	const seq uint32 = 27
+	abandoned := makeStubLedger(t, seq, [32]byte{0x27}, [32]byte{0x26})
+	replacement := makeStubLedger(t, seq, [32]byte{0x28}, [32]byte{0x26})
+	svc.enqueuePersist(abandoned)
+	svc.persistMu.Lock()
+	require.Len(t, svc.persistQueue, 1)
+	abandonedJob := svc.persistQueue[0]
+	svc.persistQueue = nil
+	svc.persistMu.Unlock()
+
+	jobDone := make(chan struct{})
+	go func() {
+		svc.runPersistJob(abandonedJob)
+		close(jobDone)
+	}()
+	select {
+	case <-db.entered:
+	case <-time.After(time.Second):
+		t.Fatal("abandoned persistence did not reach the validated-tip store")
+	}
+
+	invalidationDone := make(chan struct{})
+	go func() {
+		svc.invalidateCompleteLedger(seq)
+		close(invalidationDone)
+	}()
+	require.Eventually(t, abandonedJob.canceled.Load, time.Second, time.Millisecond)
+	close(db.release)
+	select {
+	case <-jobDone:
+	case <-time.After(time.Second):
+		t.Fatal("abandoned persistence did not finish")
+	}
+	select {
+	case <-invalidationDone:
+	case <-time.After(time.Second):
+		t.Fatal("invalidation did not repair the persisted tip")
+	}
+
+	invalidatedTip, err := db.Fetch(ctx, validatedTipKey)
+	require.NoError(t, err)
+	require.NotNil(t, invalidatedTip)
+	assert.Zero(t, invalidatedTip.LedgerSeq)
+
+	svc.enqueuePersist(replacement)
+	svc.persistMu.Lock()
+	require.Len(t, svc.persistQueue, 1)
+	replacementJob := svc.persistQueue[0]
+	svc.persistQueue = nil
+	svc.persistMu.Unlock()
+	svc.runPersistJob(replacementJob)
+
+	tip, err := db.Fetch(ctx, validatedTipKey)
+	require.NoError(t, err)
+	require.NotNil(t, tip)
+	replacementHash := replacement.Hash()
+	assert.Equal(t, replacementHash[:], []byte(tip.Data))
+	pair, err := repositories.Ledger().GetHashesByIndex(ctx, relationaldb.LedgerIndex(seq))
+	require.NoError(t, err)
+	require.NotNil(t, pair)
+	assert.Equal(t, replacementHash, [32]byte(pair.LedgerHash))
+	assert.Equal(t, "27", svc.completeLedgersString())
+}
+
+func TestCompleteLedgers_InvalidationRejectsStalePersistenceCompletion(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+
+	const seq uint32 = 30
+	staleToken := svc.beginValidatedPersistence(seq, [32]byte{0x30})
+	svc.recordValidatedPersistence(seq, staleToken, true)
+	assert.Equal(t, "30", svc.completeLedgersString())
+
+	svc.invalidateCompleteLedger(seq)
+	svc.recordValidatedPersistence(seq, staleToken, true)
+	assert.Equal(t, "empty", svc.completeLedgersString())
+
+	currentToken := svc.beginValidatedPersistence(seq, [32]byte{0x31})
+	svc.recordValidatedPersistence(seq, currentToken, true)
+	assert.Equal(t, "30", svc.completeLedgersString())
+}
+
+func TestCompleteLedgers_OnlineDeleteClampRejectsOlderPersists(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+
+	seedCompleteLedgers(t, svc, 40, 50)
+	staleToken := svc.beginValidatedPersistence(44, [32]byte{0x44})
+	svc.SetMinimumOnlineFunc(func() uint32 { return 45 })
+
+	assert.Equal(t, "45-50", svc.GetServerInfo().CompleteLedgers)
+	svc.recordValidatedPersistence(44, staleToken, true)
+	assert.Equal(t, "45-50", svc.GetServerInfo().CompleteLedgers)
+}

--- a/internal/ledger/service/consensus_parent_guard_test.go
+++ b/internal/ledger/service/consensus_parent_guard_test.go
@@ -64,6 +64,14 @@ func TestPreferredChainSwitchMovesFrontierBeforeConsensusBuild(t *testing.T) {
 		closeTime = closeTime.Add(2 * time.Second)
 		closeConsensusParentGuardLedger(t, svc, closeTime)
 	}
+	staleSeq := preferredParent.Sequence() + historyWindow + 10
+	staleToken := svc.beginValidatedPersistence(staleSeq, [32]byte{0xEE})
+	svc.completeMu.Lock()
+	svc.completedLedgers.AddRange(
+		preferredParent.Sequence()+1,
+		staleSeq,
+	)
+	svc.completeMu.Unlock()
 
 	if err := svc.SwitchToPreferredLedger(preferredParent); err != nil {
 		t.Fatalf("SwitchToPreferredLedger: %v", err)
@@ -76,6 +84,13 @@ func TestPreferredChainSwitchMovesFrontierBeforeConsensusBuild(t *testing.T) {
 	}
 	if _, err := svc.AdoptedLedgerBySequence(preferredParent.Sequence() + 2); !errors.Is(err, ErrLedgerNotFound) {
 		t.Fatalf("abandoned history tail remains after switch: %v", err)
+	}
+	if got := svc.GetServerInfo().CompleteLedgers; got != "empty" {
+		t.Fatalf("abandoned complete-ledger tail remains after switch: %q", got)
+	}
+	svc.recordValidatedPersistence(staleSeq, staleToken, true)
+	if got := svc.GetServerInfo().CompleteLedgers; got != "empty" {
+		t.Fatalf("stale deep-tail persistence restored complete-ledger state: %q", got)
 	}
 
 	seq, err := svc.AcceptConsensusResult(

--- a/internal/ledger/service/events.go
+++ b/internal/ledger/service/events.go
@@ -64,11 +64,6 @@ type Result struct {
 
 type SubmittedTxCallback func(SubmittedTxEvent)
 
-// ledgerEventBufferDepth bounds the accepted-ledger event dispatch queue. Deep
-// enough to absorb a catch-up adoption burst (many ledgers per second) without
-// dropping stream events; a wedged subscriber past this is shed and counted.
-const ledgerEventBufferDepth = 256
-
 func (s *Service) SetEventCallback(callback EventCallback) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -80,13 +75,15 @@ func (s *Service) SetEventCallback(callback EventCallback) {
 // per-event goroutines that ran it concurrently with itself — a data race on
 // the subscriber's state and out-of-order ledgerClosed delivery. rippled
 // serializes the equivalent through NetworkOPs' single job-queue strand.
-// Enqueue is non-blocking: a lagging subscriber drops the event with a counted
-// warn rather than stalling ledger close.
+// Enqueue is non-blocking and lossless: a lagging subscriber grows the queue
+// without stalling ledger close or dropping publication state.
 func (s *Service) dispatchLedgerEvent(event *LedgerAcceptedEvent) {
 	if event == nil {
 		return
 	}
-	if s.ledgerEventCh == nil {
+	s.ledgerEventMu.Lock()
+	if !s.ledgerEventStarted {
+		s.ledgerEventMu.Unlock()
 		// Dispatcher not started (paths that emit without Start). Deliver on a
 		// fresh goroutine to preserve the "callback fires, never under s.mu"
 		// contract; ordering isn't guaranteed here, but Start-anchored callers
@@ -94,12 +91,16 @@ func (s *Service) dispatchLedgerEvent(event *LedgerAcceptedEvent) {
 		go s.deliverLedgerEvent(event)
 		return
 	}
-	select {
-	case s.ledgerEventCh <- event:
-	default:
-		n := s.droppedLedgerEvents.Add(1)
-		s.logger.Warn("ledger event subscriber lagging; dropping event", "droppedTotal", n)
+	if s.ledgerEventStopping {
+		s.ledgerEventMu.Unlock()
+		return
 	}
+	s.ledgerEventQueue = append(s.ledgerEventQueue, event)
+	select {
+	case s.ledgerEventWake <- struct{}{}:
+	default:
+	}
+	s.ledgerEventMu.Unlock()
 }
 
 // runLedgerEventDispatcher is the single consumer that delivers accepted-ledger
@@ -108,37 +109,44 @@ func (s *Service) dispatchLedgerEvent(event *LedgerAcceptedEvent) {
 func (s *Service) runLedgerEventDispatcher() {
 	defer s.ledgerEventWG.Done()
 	for {
-		select {
-		case ev := <-s.ledgerEventCh:
-			s.deliverLedgerEvent(ev)
-		case <-s.ledgerEventQuit:
-			for {
-				select {
-				case ev := <-s.ledgerEventCh:
-					s.deliverLedgerEvent(ev)
-				default:
-					return
-				}
+		<-s.ledgerEventWake
+		for {
+			s.ledgerEventMu.Lock()
+			if len(s.ledgerEventQueue) != 0 {
+				ev := s.ledgerEventQueue[0]
+				s.ledgerEventQueue[0] = nil
+				s.ledgerEventQueue = s.ledgerEventQueue[1:]
+				s.ledgerEventMu.Unlock()
+				s.deliverLedgerEvent(ev)
+				continue
 			}
+			stopping := s.ledgerEventStopping
+			s.ledgerEventMu.Unlock()
+			if stopping {
+				return
+			}
+			break
 		}
 	}
 }
 
-// deliverLedgerEvent reads the current callback under a read lock (so a
-// late-wired or unwired callback is respected) and invokes it outside the lock,
-// preserving the contract that subscriber callbacks never run under s.mu.
+// deliverLedgerEvent advances the published frontier at the ordered delivery
+// boundary, then invokes the current callback outside the lock.
 func (s *Service) deliverLedgerEvent(event *LedgerAcceptedEvent) {
-	s.mu.RLock()
+	s.mu.Lock()
+	if event.Ledger != nil && event.Ledger.IsValidated() {
+		seq := event.Ledger.Sequence()
+		if !s.havePublished || seq > s.publishedLedgerSeq {
+			s.publishedLedgerSeq = seq
+			s.havePublished = true
+		}
+	}
 	cb := s.eventCallback
-	s.mu.RUnlock()
+	s.mu.Unlock()
 	if cb != nil {
 		cb(event)
 	}
 }
-
-// DroppedLedgerEvents returns the cumulative count of accepted-ledger events
-// shed because the subscriber lagged.
-func (s *Service) DroppedLedgerEvents() uint64 { return s.droppedLedgerEvents.Load() }
 
 // SetSubmittedTxCallback registers a sink fired from SubmitTransaction after
 // every apply attempt. Pass nil to unwire.

--- a/internal/ledger/service/events.go
+++ b/internal/ledger/service/events.go
@@ -17,6 +17,8 @@ import (
 
 const invalidTransactionIndex = ^uint32(0)
 
+const maxLedgerPublicationGap uint32 = 100
+
 // LedgerAcceptedEvent contains information about an accepted ledger and its transactions
 type LedgerAcceptedEvent struct {
 	LedgerInfo         *LedgerInfo
@@ -82,25 +84,82 @@ func (s *Service) dispatchLedgerEvent(event *LedgerAcceptedEvent) {
 		return
 	}
 	s.ledgerEventMu.Lock()
+	if s.ledgerEventStarted && s.ledgerEventStopping {
+		s.ledgerEventMu.Unlock()
+		return
+	}
+	ready := s.ledgerEventsReadyToQueueLocked(event)
+	if len(ready) == 0 {
+		s.ledgerEventMu.Unlock()
+		return
+	}
 	if !s.ledgerEventStarted {
 		s.ledgerEventMu.Unlock()
 		// Dispatcher not started (paths that emit without Start). Deliver on a
 		// fresh goroutine to preserve the "callback fires, never under s.mu"
 		// contract; ordering isn't guaranteed here, but Start-anchored callers
 		// (production and the event tests) always take the channel path.
-		go s.deliverLedgerEvent(event)
+		go func() {
+			for _, queued := range ready {
+				s.deliverLedgerEvent(queued)
+			}
+		}()
 		return
 	}
-	if s.ledgerEventStopping {
-		s.ledgerEventMu.Unlock()
-		return
-	}
-	s.ledgerEventQueue = append(s.ledgerEventQueue, event)
+	s.ledgerEventQueue = append(s.ledgerEventQueue, ready...)
 	select {
 	case s.ledgerEventWake <- struct{}{}:
 	default:
 	}
 	s.ledgerEventMu.Unlock()
+}
+
+func (s *Service) ledgerEventsReadyToQueueLocked(event *LedgerAcceptedEvent) []*LedgerAcceptedEvent {
+	if event.Ledger == nil || !event.Ledger.IsValidated() {
+		return []*LedgerAcceptedEvent{event}
+	}
+
+	seq := event.Ledger.Sequence()
+	hash := event.Ledger.Hash()
+	if !s.ledgerEventHaveFrontier {
+		s.ledgerEventHaveFrontier = true
+		s.ledgerEventFrontierSeq = seq
+		s.ledgerEventFrontierHash = hash
+		s.pruneLedgerEventCandidatesLocked(seq)
+		return []*LedgerAcceptedEvent{event}
+	}
+	if seq <= s.ledgerEventFrontierSeq {
+		return nil
+	}
+	if seq-s.ledgerEventFrontierSeq > maxLedgerPublicationGap {
+		s.ledgerEventFrontierSeq = seq
+		s.ledgerEventFrontierHash = hash
+		s.pruneLedgerEventCandidatesLocked(seq)
+		return []*LedgerAcceptedEvent{event}
+	}
+
+	s.ledgerEventCandidates[seq] = event
+	ready := make([]*LedgerAcceptedEvent, 0, len(s.ledgerEventCandidates))
+	for s.ledgerEventFrontierSeq != ^uint32(0) {
+		nextSeq := s.ledgerEventFrontierSeq + 1
+		next, ok := s.ledgerEventCandidates[nextSeq]
+		if !ok || next.Ledger.ParentHash() != s.ledgerEventFrontierHash {
+			break
+		}
+		delete(s.ledgerEventCandidates, nextSeq)
+		ready = append(ready, next)
+		s.ledgerEventFrontierSeq = nextSeq
+		s.ledgerEventFrontierHash = next.Ledger.Hash()
+	}
+	return ready
+}
+
+func (s *Service) pruneLedgerEventCandidatesLocked(frontier uint32) {
+	for seq := range s.ledgerEventCandidates {
+		if seq <= frontier {
+			delete(s.ledgerEventCandidates, seq)
+		}
+	}
 }
 
 // runLedgerEventDispatcher is the single consumer that delivers accepted-ledger

--- a/internal/ledger/service/fix_mismatch_test.go
+++ b/internal/ledger/service/fix_mismatch_test.go
@@ -83,6 +83,7 @@ func TestAdoptLedgerWithState_FixMismatchInvalidatesDivergedTail(t *testing.T) {
 	// slot.
 	svc.closedLedger = ledC
 	svc.mu.Unlock()
+	seedCompleteLedgers(t, svc, baseSeq, baseSeq+2)
 
 	// Build the divergent D at seq S+1. Its parentHash is NOT hashA,
 	// so it does NOT chain to our stored A — this must trip fixMismatch.
@@ -129,6 +130,8 @@ func TestAdoptLedgerWithState_FixMismatchInvalidatesDivergedTail(t *testing.T) {
 	require.NotNil(t, svc.closedLedger)
 	assert.Equal(t, hashD, svc.closedLedger.Hash(),
 		"closedLedger must track the adopted ledger after a fork-switch adopt")
+	assert.Equal(t, "empty", svc.completeLedgersString(),
+		"fork invalidation must remove every purged ledger from complete_ledgers")
 }
 
 // TestAdoptLedgerWithState_NoMismatchNoOp pins the happy path:

--- a/internal/ledger/service/history_eviction_test.go
+++ b/internal/ledger/service/history_eviction_test.go
@@ -154,8 +154,8 @@ func TestAcceptLedgerLoop_BoundsHistory(t *testing.T) {
 		t.Errorf("ledgerHistory unbounded under AcceptLedger loop: got %d, want <= %d", size, historyWindow+1)
 	}
 	last := svc.GetClosedLedgerIndex()
-	if got, want := svc.GetServerInfo().CompleteLedgers, formatRange(3, last); got != want {
-		t.Errorf("complete_ledgers changed with history eviction: got %q, want %q", got, want)
+	if got, want := svc.GetServerInfo().CompleteLedgers, formatRange(last-historyWindow+1, last); got != want {
+		t.Errorf("complete_ledgers includes evicted in-memory history: got %q, want %q", got, want)
 	}
 }
 

--- a/internal/ledger/service/history_eviction_test.go
+++ b/internal/ledger/service/history_eviction_test.go
@@ -153,6 +153,10 @@ func TestAcceptLedgerLoop_BoundsHistory(t *testing.T) {
 	if size > historyWindow+1 {
 		t.Errorf("ledgerHistory unbounded under AcceptLedger loop: got %d, want <= %d", size, historyWindow+1)
 	}
+	last := svc.GetClosedLedgerIndex()
+	if got, want := svc.GetServerInfo().CompleteLedgers, formatRange(3, last); got != want {
+		t.Errorf("complete_ledgers changed with history eviction: got %q, want %q", got, want)
+	}
 }
 
 // Covers the race where SetValidatedLedger arrives before the close

--- a/internal/ledger/service/ledger_query.go
+++ b/internal/ledger/service/ledger_query.go
@@ -258,6 +258,13 @@ func (s *Service) resolveLedgerForQuery(ctx context.Context, ledgerIndex string)
 		}
 		return l, l.IsValidated(), nil
 	}
+	if sequence, ok := selection.Sequence(); ok {
+		l, err := s.getLedgerBySequence(ctx, sequence)
+		if err != nil {
+			return nil, false, serviceLedgerSelectorError(selection, err)
+		}
+		return l, l.IsValidated(), nil
+	}
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/ledger/service/ledger_query.go
+++ b/internal/ledger/service/ledger_query.go
@@ -259,6 +259,19 @@ func (s *Service) resolveLedgerForQuery(ctx context.Context, ledgerIndex string)
 		return l, l.IsValidated(), nil
 	}
 	if sequence, ok := selection.Sequence(); ok {
+		s.mu.RLock()
+		if s.ledgerHistory[sequence] == nil &&
+			s.openLedger != nil &&
+			s.openLedger.Sequence() == sequence {
+			snapshot, snapshotErr := s.openLedger.Snapshot()
+			s.mu.RUnlock()
+			if snapshotErr != nil {
+				return nil, false, snapshotErr
+			}
+			return snapshot, snapshot.IsValidated(), nil
+		}
+		s.mu.RUnlock()
+
 		l, err := s.getLedgerBySequence(ctx, sequence)
 		if err != nil {
 			return nil, false, serviceLedgerSelectorError(selection, err)

--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -106,14 +106,11 @@ func (s *Service) AcceptLedgerAt(ctx context.Context, explicitCloseTime time.Tim
 	// eventCallback fires immediately rather than being stashed.
 	s.fireLedgerClosedHooksLocked(ledgerInfo, txResults, closeTime, validatedLedgers)
 
-	if s.eventCallback != nil {
-		event := &LedgerAcceptedEvent{
-			LedgerInfo:         ledgerInfo,
-			Ledger:             s.closedLedger,
-			TransactionResults: txResults,
-		}
-		s.dispatchLedgerEvent(event)
-	}
+	s.dispatchLedgerEvent(&LedgerAcceptedEvent{
+		LedgerInfo:         ledgerInfo,
+		Ledger:             s.closedLedger,
+		TransactionResults: txResults,
+	})
 
 	s.logger.Info("Ledger accepted",
 		"sequence", closedSeq,
@@ -284,6 +281,7 @@ func (s *Service) fixMismatchLocked(adopted *ledger.Ledger) {
 				delete(s.txPositionIndex, txHash)
 			}
 		}
+		s.invalidateCompleteLedger(adoptedSeq - 1)
 		s.deleteHistoryLocked(adoptedSeq - 1)
 		s.logger.Warn("history backfill replaced a stale fork ledger below it",
 			"seq", adoptedSeq-1,
@@ -295,6 +293,7 @@ func (s *Service) fixMismatchLocked(adopted *ledger.Ledger) {
 
 	// Purge: the mismatched prev-seq, the same-seq alt (caller overwrites it
 	// anyway, but its tx-index must go), and every seq > adoptedSeq (orphans).
+	s.invalidateCompleteLedgerRange(adoptedSeq-1, ^uint32(0))
 	var toRemove []uint32
 	toRemove = append(toRemove, adoptedSeq-1)
 	if sameSeq, ok := s.ledgerHistory[adoptedSeq]; ok && sameSeq.Hash() != adopted.Hash() {
@@ -429,6 +428,7 @@ func (s *Service) SwitchToPreferredLedger(parent *ledger.Ledger) error {
 	s.collectTransactionResults(parent, parent.Sequence(), parentHash)
 	if parent.IsValidated() {
 		s.evictOldHistoryLocked(parent.Sequence())
+		s.enqueuePersist(parent)
 	}
 
 	s.processClosedLedgerLocked()
@@ -444,12 +444,18 @@ func (s *Service) SwitchToPreferredLedger(parent *ledger.Ledger) error {
 func (s *Service) purgeHistoryAfterPreferredSwitchLocked(parent *ledger.Ledger) {
 	parentSeq := parent.Sequence()
 	parentHash := parent.Hash()
+	if parentSeq != ^uint32(0) {
+		s.invalidateCompleteLedgerRange(parentSeq+1, ^uint32(0))
+	}
 	removed := make(map[uint32]struct{})
 	for seq, existing := range s.ledgerHistory {
 		if seq < parentSeq || (seq == parentSeq && existing.Hash() == parentHash) {
 			continue
 		}
 		removed[seq] = struct{}{}
+		if seq == parentSeq {
+			s.invalidateCompleteLedgerHash(seq, existing.Hash())
+		}
 		s.deleteHistoryLocked(seq)
 	}
 	for txHash, txSeq := range s.txIndex {
@@ -608,6 +614,8 @@ func (s *Service) acceptConsensusResult(
 	}
 	if promotedByDrain {
 		s.enqueuePersist(s.closedLedger)
+	} else if s.closedLedger.IsValidated() {
+		s.enqueueValidatedHistoryPersist(s.closedLedger)
 	} else {
 		s.enqueueNodePersist(s.closedLedger)
 	}
@@ -626,17 +634,15 @@ func (s *Service) acceptConsensusResult(
 	// with validated_ledger. Exception: if the drain above already promoted
 	// inline, no SetValidatedLedger will arrive — fire inline instead of
 	// orphaning the event.
-	if s.eventCallback != nil {
-		event := &LedgerAcceptedEvent{
-			LedgerInfo:         ledgerInfo,
-			Ledger:             s.closedLedger,
-			TransactionResults: txResults,
-		}
-		if promotedByDrain {
-			s.dispatchLedgerEvent(event)
-		} else {
-			s.stashPendingValidationLocked(closedLedgerHash, event)
-		}
+	event := &LedgerAcceptedEvent{
+		LedgerInfo:         ledgerInfo,
+		Ledger:             s.closedLedger,
+		TransactionResults: txResults,
+	}
+	if promotedByDrain {
+		s.dispatchLedgerEvent(event)
+	} else if s.eventCallback != nil {
+		s.stashPendingValidationLocked(closedLedgerHash, event)
 	}
 
 	s.logger.Info("Consensus ledger accepted",
@@ -716,6 +722,28 @@ func (s *Service) SetValidatedLedgerAt(seq uint32, expectedHash [32]byte, signTi
 	event := s.drainPendingValidationLocked(expectedHash)
 	s.enqueuePersist(l)
 	notification := s.validatedLedgerNotificationLocked(previousValidatedSeq)
+	if event == nil {
+		event = &LedgerAcceptedEvent{
+			LedgerInfo: &LedgerInfo{
+				Sequence:   l.Sequence(),
+				Hash:       l.Hash(),
+				ParentHash: l.ParentHash(),
+				CloseTime:  l.CloseTime(),
+				TotalDrops: l.TotalDrops(),
+				Validated:  true,
+				Closed:     l.IsClosed(),
+			},
+			Ledger: l,
+		}
+	} else {
+		if event.LedgerInfo != nil {
+			event.LedgerInfo.Validated = true
+		}
+		for i := range event.TransactionResults {
+			event.TransactionResults[i].Validated = true
+		}
+	}
+	s.dispatchLedgerEvent(event)
 	s.mu.Unlock()
 
 	// Fold into the amendment table outside the lock (it has its own mutex).
@@ -725,15 +753,6 @@ func (s *Service) SetValidatedLedgerAt(seq uint32, expectedHash [32]byte, signTi
 		pool.Sweep(l)
 	}
 
-	if event != nil {
-		if event.LedgerInfo != nil {
-			event.LedgerInfo.Validated = true
-		}
-		for i := range event.TransactionResults {
-			event.TransactionResults[i].Validated = true
-		}
-		s.dispatchLedgerEvent(event)
-	}
 	notification.notify()
 }
 
@@ -939,6 +958,20 @@ func (s *Service) storeLedgerWithStateLocked(ctx context.Context, h *header.Ledg
 	promotedByDrain := s.drainPendingLedgerValidationLocked(stored.Sequence(), stored)
 	if promotedByDrain {
 		s.enqueuePersist(stored)
+		s.dispatchLedgerEvent(&LedgerAcceptedEvent{
+			LedgerInfo: &LedgerInfo{
+				Sequence:   stored.Sequence(),
+				Hash:       stored.Hash(),
+				ParentHash: stored.ParentHash(),
+				CloseTime:  stored.CloseTime(),
+				TotalDrops: stored.TotalDrops(),
+				Validated:  true,
+				Closed:     stored.IsClosed(),
+			},
+			Ledger: stored,
+		})
+	} else if stored.IsValidated() {
+		s.enqueueValidatedHistoryPersist(stored)
 	} else {
 		s.enqueueNodePersist(stored)
 	}
@@ -1018,6 +1051,8 @@ func (s *Service) adoptLedgerWithStateLocked(
 	txResults := s.collectTransactionResults(adopted, h.LedgerIndex, h.Hash)
 	if promotedByDrain {
 		s.enqueuePersist(adopted)
+	} else if adopted.IsValidated() {
+		s.enqueueValidatedHistoryPersist(adopted)
 	} else {
 		s.enqueueNodePersist(adopted)
 	}
@@ -1059,17 +1094,15 @@ func (s *Service) adoptLedgerWithStateLocked(
 		// drain. Exception: if the drain above promoted inline, no
 		// SetValidatedLedger will arrive — fire inline instead of orphaning the
 		// event (and avoid a double-fire on a late-duplicate SetValidatedLedger).
-		if s.eventCallback != nil {
-			event := &LedgerAcceptedEvent{
-				LedgerInfo:         ledgerInfo,
-				Ledger:             adopted,
-				TransactionResults: txResults,
-			}
-			if promotedByDrain {
-				s.dispatchLedgerEvent(event)
-			} else {
-				s.stashPendingValidationLocked(h.Hash, event)
-			}
+		event := &LedgerAcceptedEvent{
+			LedgerInfo:         ledgerInfo,
+			Ledger:             adopted,
+			TransactionResults: txResults,
+		}
+		if promotedByDrain {
+			s.dispatchLedgerEvent(event)
+		} else if s.eventCallback != nil {
+			s.stashPendingValidationLocked(h.Hash, event)
 		}
 	}
 

--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -409,6 +409,13 @@ func (s *Service) SwitchToPreferredLedger(parent *ledger.Ledger) error {
 	}
 
 	parentHash := parent.Hash()
+	if s.validatedLedger != nil {
+		validatedSeq := s.validatedLedger.Sequence()
+		if parent.Sequence() < validatedSeq ||
+			(parent.Sequence() == validatedSeq && parentHash != s.validatedLedger.Hash()) {
+			return ErrPreferredChainSwitch
+		}
+	}
 	if parent.Sequence() == s.closedLedger.Sequence() && parentHash == s.closedLedger.Hash() {
 		return nil
 	}
@@ -662,6 +669,32 @@ func (s *Service) SetValidatedLedger(seq uint32, expectedHash [32]byte) {
 	s.SetValidatedLedgerAt(seq, expectedHash, time.Time{})
 }
 
+func (s *Service) validatedLedgerEventLocked(l *ledger.Ledger) *LedgerAcceptedEvent {
+	event := s.drainPendingValidationLocked(l.Hash())
+	if event == nil {
+		return &LedgerAcceptedEvent{
+			LedgerInfo: &LedgerInfo{
+				Sequence:   l.Sequence(),
+				Hash:       l.Hash(),
+				ParentHash: l.ParentHash(),
+				CloseTime:  l.CloseTime(),
+				TotalDrops: l.TotalDrops(),
+				Validated:  true,
+				Closed:     l.IsClosed(),
+			},
+			Ledger: l,
+		}
+	}
+	if event.LedgerInfo != nil {
+		event.LedgerInfo.Validated = true
+	}
+	event.Ledger = l
+	for i := range event.TransactionResults {
+		event.TransactionResults[i].Validated = true
+	}
+	return event
+}
+
 // SetValidatedLedgerAt marks a ledger validated using the trusted-validation
 // signing-time median. A zero signing time falls back to the ledger close time.
 func (s *Service) SetValidatedLedgerAt(seq uint32, expectedHash [32]byte, signTime time.Time) {
@@ -706,6 +739,7 @@ func (s *Service) SetValidatedLedgerAt(seq uint32, expectedHash [32]byte, signTi
 	// pointer — same rule as drainPendingLedgerValidationLocked.
 	if s.validatedLedger != nil && seq <= s.validatedLedger.Sequence() {
 		s.enqueueValidatedHistoryPersist(l)
+		s.dispatchLedgerEvent(s.validatedLedgerEventLocked(l))
 		s.mu.Unlock()
 		return
 	}
@@ -719,30 +753,9 @@ func (s *Service) SetValidatedLedgerAt(seq uint32, expectedHash [32]byte, signTi
 	// Sweep the held local pool against the just-validated ledger (not every
 	// close — consensus may abandon a closed ledger).
 	pool := s.localTxs
-	event := s.drainPendingValidationLocked(expectedHash)
+	event := s.validatedLedgerEventLocked(l)
 	s.enqueuePersist(l)
 	notification := s.validatedLedgerNotificationLocked(previousValidatedSeq)
-	if event == nil {
-		event = &LedgerAcceptedEvent{
-			LedgerInfo: &LedgerInfo{
-				Sequence:   l.Sequence(),
-				Hash:       l.Hash(),
-				ParentHash: l.ParentHash(),
-				CloseTime:  l.CloseTime(),
-				TotalDrops: l.TotalDrops(),
-				Validated:  true,
-				Closed:     l.IsClosed(),
-			},
-			Ledger: l,
-		}
-	} else {
-		if event.LedgerInfo != nil {
-			event.LedgerInfo.Validated = true
-		}
-		for i := range event.TransactionResults {
-			event.TransactionResults[i].Validated = true
-		}
-	}
 	s.dispatchLedgerEvent(event)
 	s.mu.Unlock()
 

--- a/internal/ledger/service/persistence.go
+++ b/internal/ledger/service/persistence.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync/atomic"
 	"time"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
@@ -29,6 +30,22 @@ func (s *Service) persistLedger(ctx context.Context, l *ledger.Ledger) error {
 
 func (s *Service) persistValidatedLedger(ctx context.Context, l *ledger.Ledger, updateTip bool) error {
 	seq := l.Sequence()
+	var token uint64
+	if l.IsValidated() {
+		token = s.beginValidatedPersistence(seq, l.Hash())
+	}
+	return s.persistValidatedLedgerAtToken(ctx, l, updateTip, token, false, nil)
+}
+
+func (s *Service) persistValidatedLedgerAtToken(
+	ctx context.Context,
+	l *ledger.Ledger,
+	updateTip bool,
+	token uint64,
+	allowTipReplacement bool,
+	canceled func() bool,
+) error {
+	seq := l.Sequence()
 	var persistErr error
 
 	if s.nodeStore != nil {
@@ -36,18 +53,30 @@ func (s *Service) persistValidatedLedger(ctx context.Context, l *ledger.Ledger, 
 			persistErr = err
 		}
 	}
+	if canceled != nil && canceled() {
+		return nil
+	}
 
 	if s.relationalDB != nil {
+		s.canonicalPersistMu.Lock()
 		if err := s.persistToRelationalDB(ctx, l); err != nil {
 			persistErr = errors.Join(persistErr, err)
 		}
+		if canceled != nil && canceled() {
+			s.canonicalPersistMu.Unlock()
+			return nil
+		}
 		if persistErr == nil && updateTip && s.nodeStore != nil {
-			if err := s.persistValidatedTip(ctx, l); err != nil {
+			if err := s.persistValidatedTipLocked(ctx, l, allowTipReplacement); err != nil {
 				persistErr = err
 			}
 		}
+		s.canonicalPersistMu.Unlock()
 	}
 
+	if l.IsValidated() {
+		s.recordValidatedPersistence(seq, token, persistErr == nil)
+	}
 	return persistErr
 }
 
@@ -55,10 +84,13 @@ func (s *Service) persistValidatedLedger(ctx context.Context, l *ledger.Ledger, 
 // barrier (nil ledger + done) that flushes the FIFO queue for callers that
 // need persistence to be observable (tests, shutdown paths).
 type persistJob struct {
-	l          *ledger.Ledger
-	done       chan struct{}
-	validated  bool
-	updatesTip bool
+	l               *ledger.Ledger
+	done            chan struct{}
+	validated       bool
+	tipOnly         bool
+	canceled        atomic.Bool
+	updatesTip      atomic.Bool
+	completionToken uint64
 }
 
 func (s *Service) enqueuePersist(l *ledger.Ledger) {
@@ -77,20 +109,60 @@ func (s *Service) enqueueLedgerPersist(l *ledger.Ledger, validated, updatesTip b
 	if l == nil {
 		return
 	}
+	seq := l.Sequence()
 	s.persistMu.Lock()
+	if validated {
+		if existing := s.validatedPersistJobs[seq]; existing != nil {
+			if existing.l != nil && existing.l.Hash() == l.Hash() {
+				if updatesTip {
+					existing.updatesTip.Store(true)
+				}
+				s.persistMu.Unlock()
+				return
+			}
+			if !updatesTip && existing.updatesTip.Load() {
+				s.persistMu.Unlock()
+				return
+			}
+			existing.canceled.Store(true)
+			delete(s.validatedPersistJobs, seq)
+		}
+		if s.hasCompleteLedger(l) && !updatesTip {
+			s.persistMu.Unlock()
+			return
+		}
+	}
+	job := &persistJob{
+		l:         l,
+		validated: validated,
+	}
+	job.updatesTip.Store(updatesTip)
+	if validated {
+		if s.hasCompleteLedger(l) {
+			job.tipOnly = true
+		} else if l.IsValidated() {
+			job.completionToken = s.beginValidatedPersistence(seq, l.Hash())
+		}
+		s.validatedPersistJobs[seq] = job
+	}
 	if !s.persistStarted {
 		s.persistMu.Unlock()
-		if err := s.persistLedgerJob(context.Background(), l, validated, updatesTip); err != nil {
-			s.logger.Error("failed to persist ledger inline", "seq", l.Sequence(), "err", err)
-		}
+		s.runPersistJob(job)
 		return
 	}
 	if s.persistStopping {
+		if validated {
+			job.canceled.Store(true)
+			delete(s.validatedPersistJobs, seq)
+		}
 		s.persistMu.Unlock()
-		s.logger.Warn("persist skipped: service stopping", "seq", l.Sequence())
+		if validated && !job.tipOnly {
+			s.invalidateCompleteLedger(seq)
+		}
+		s.logger.Warn("persist skipped: service stopping", "seq", seq)
 		return
 	}
-	s.persistQueue = append(s.persistQueue, persistJob{l: l, validated: validated, updatesTip: updatesTip})
+	s.persistQueue = append(s.persistQueue, job)
 	s.signalPersistLocked()
 	s.persistMu.Unlock()
 }
@@ -113,7 +185,7 @@ func (s *Service) flushPersists(ctx context.Context) error {
 		s.persistMu.Unlock()
 		return nil
 	}
-	s.persistQueue = append(s.persistQueue, persistJob{done: done})
+	s.persistQueue = append(s.persistQueue, &persistJob{done: done})
 	s.signalPersistLocked()
 	s.persistMu.Unlock()
 	select {
@@ -140,17 +212,15 @@ func (s *Service) Stop() {
 	}
 	s.persistMu.Unlock()
 
-	s.mu.Lock()
-	var eventQuit chan struct{}
-	if !s.ledgerEventStopped {
-		s.ledgerEventStopped = true
-		eventQuit = s.ledgerEventQuit
+	s.ledgerEventMu.Lock()
+	if s.ledgerEventStarted && !s.ledgerEventStopping {
+		s.ledgerEventStopping = true
+		select {
+		case s.ledgerEventWake <- struct{}{}:
+		default:
+		}
 	}
-	s.mu.Unlock()
-
-	if eventQuit != nil {
-		close(eventQuit)
-	}
+	s.ledgerEventMu.Unlock()
 	if persistWasStarted {
 		s.persistWG.Wait()
 	}
@@ -163,7 +233,7 @@ func (s *Service) runPersistWorker() {
 		s.persistMu.Lock()
 		if len(s.persistQueue) > 0 {
 			job := s.persistQueue[0]
-			s.persistQueue[0] = persistJob{}
+			s.persistQueue[0] = nil
 			s.persistQueue = s.persistQueue[1:]
 			s.persistMu.Unlock()
 			s.runPersistJob(job)
@@ -178,9 +248,56 @@ func (s *Service) runPersistWorker() {
 	}
 }
 
-func (s *Service) runPersistJob(job persistJob) {
+func (s *Service) runPersistJob(job *persistJob) {
+	if job == nil {
+		return
+	}
 	if job.l != nil {
-		if err := s.persistLedgerJob(context.Background(), job.l, job.validated, job.updatesTip); err != nil {
+		updateTip := job.updatesTip.Load()
+		var err error
+		if !job.canceled.Load() && job.tipOnly {
+			if s.nodeStore != nil && s.relationalDB != nil {
+				err = s.persistValidatedTipJob(
+					context.Background(),
+					job.l,
+					true,
+					job.canceled.Load,
+				)
+			}
+		} else if !job.canceled.Load() {
+			err = s.persistLedgerJob(
+				context.Background(),
+				job.l,
+				job.validated,
+				updateTip,
+				job.completionToken,
+				true,
+				job.canceled.Load,
+			)
+		}
+		s.persistMu.Lock()
+		lateTip := job.validated && !job.tipOnly && !job.canceled.Load() &&
+			!updateTip && job.updatesTip.Load()
+		if !lateTip && job.validated && s.validatedPersistJobs[job.l.Sequence()] == job {
+			delete(s.validatedPersistJobs, job.l.Sequence())
+		}
+		s.persistMu.Unlock()
+		if err == nil && lateTip && s.nodeStore != nil && s.relationalDB != nil {
+			err = s.persistValidatedTipJob(
+				context.Background(),
+				job.l,
+				true,
+				job.canceled.Load,
+			)
+		}
+		if lateTip {
+			s.persistMu.Lock()
+			if s.validatedPersistJobs[job.l.Sequence()] == job {
+				delete(s.validatedPersistJobs, job.l.Sequence())
+			}
+			s.persistMu.Unlock()
+		}
+		if err != nil {
 			s.logger.Error("failed to persist ledger; chain advance continues",
 				"seq", job.l.Sequence(), "err", err)
 		}
@@ -190,9 +307,23 @@ func (s *Service) runPersistJob(job persistJob) {
 	}
 }
 
-func (s *Service) persistLedgerJob(ctx context.Context, l *ledger.Ledger, validated, updatesTip bool) error {
+func (s *Service) persistLedgerJob(
+	ctx context.Context,
+	l *ledger.Ledger,
+	validated, updatesTip bool,
+	completionToken uint64,
+	allowTipReplacement bool,
+	canceled func() bool,
+) error {
 	if validated {
-		return s.persistValidatedLedger(ctx, l, updatesTip)
+		return s.persistValidatedLedgerAtToken(
+			ctx,
+			l,
+			updatesTip,
+			completionToken,
+			allowTipReplacement,
+			canceled,
+		)
 	}
 	if s.nodeStore == nil {
 		return nil
@@ -255,8 +386,28 @@ func (s *Service) persistToNodeStore(ctx context.Context, l *ledger.Ledger, seq 
 }
 
 func (s *Service) persistValidatedTip(ctx context.Context, l *ledger.Ledger) error {
-	s.validatedTipMu.Lock()
-	defer s.validatedTipMu.Unlock()
+	return s.persistValidatedTipJob(ctx, l, false, nil)
+}
+
+func (s *Service) persistValidatedTipJob(
+	ctx context.Context,
+	l *ledger.Ledger,
+	allowSameSequenceReplacement bool,
+	canceled func() bool,
+) error {
+	s.canonicalPersistMu.Lock()
+	defer s.canonicalPersistMu.Unlock()
+	if canceled != nil && canceled() {
+		return nil
+	}
+	return s.persistValidatedTipLocked(ctx, l, allowSameSequenceReplacement)
+}
+
+func (s *Service) persistValidatedTipLocked(
+	ctx context.Context,
+	l *ledger.Ledger,
+	allowSameSequenceReplacement bool,
+) error {
 	hash := l.Hash()
 	current, err := s.nodeStore.Fetch(ctx, validatedTipKey)
 	if err != nil {
@@ -270,7 +421,9 @@ func (s *Service) persistValidatedTip(ctx context.Context, l *ledger.Ledger) err
 			if bytes.Equal(current.Data, hash[:]) {
 				return nil
 			}
-			return fmt.Errorf("validated ledger tip %d conflicts with persisted hash", l.Sequence())
+			if !allowSameSequenceReplacement {
+				return fmt.Errorf("validated ledger tip %d conflicts with persisted hash", l.Sequence())
+			}
 		}
 	}
 	if err := s.nodeStore.Store(ctx, &nodestore.Node{
@@ -285,6 +438,48 @@ func (s *Service) persistValidatedTip(ctx context.Context, l *ledger.Ledger) err
 		return fmt.Errorf("sync validated ledger tip %d: %w", l.Sequence(), err)
 	}
 	return nil
+}
+
+func (s *Service) invalidatePersistedValidatedTip(start, end uint32) {
+	s.invalidatePersistedValidatedTipMatching(start, end, nil)
+}
+
+func (s *Service) invalidatePersistedValidatedTipHash(seq uint32, hash [32]byte) {
+	s.invalidatePersistedValidatedTipMatching(seq, seq, &hash)
+}
+
+func (s *Service) invalidatePersistedValidatedTipMatching(start, end uint32, expectedHash *[32]byte) {
+	if s.nodeStore == nil || start > end {
+		return
+	}
+	s.canonicalPersistMu.Lock()
+	defer s.canonicalPersistMu.Unlock()
+
+	ctx := context.Background()
+	current, err := s.nodeStore.Fetch(ctx, validatedTipKey)
+	if err != nil {
+		s.logger.Error("failed to inspect validated ledger tip during invalidation", "err", err)
+		return
+	}
+	if current == nil || current.Type != nodestore.NodeLedger || len(current.Data) != 32 ||
+		current.LedgerSeq < start || current.LedgerSeq > end {
+		return
+	}
+	if expectedHash != nil && !bytes.Equal(current.Data, expectedHash[:]) {
+		return
+	}
+	if err := s.nodeStore.Store(ctx, &nodestore.Node{
+		Type:      nodestore.NodeLedger,
+		Hash:      validatedTipKey,
+		Data:      make([]byte, 32),
+		LedgerSeq: 0,
+	}); err != nil {
+		s.logger.Error("failed to invalidate validated ledger tip", "seq", current.LedgerSeq, "err", err)
+		return
+	}
+	if err := s.nodeStore.Sync(ctx); err != nil {
+		s.logger.Error("failed to sync invalidated validated ledger tip", "seq", current.LedgerSeq, "err", err)
+	}
 }
 
 const (

--- a/internal/ledger/service/persistence.go
+++ b/internal/ledger/service/persistence.go
@@ -637,6 +637,9 @@ func (s *Service) persistToRelationalDB(ctx context.Context, l *ledger.Ledger) e
 	seq := relationaldb.LedgerIndex(l.Sequence())
 
 	return s.relationalDB.WithTransaction(ctx, func(txCtx relationaldb.TransactionContext) error {
+		if err := txCtx.Transaction().DeleteTransactionsByLedgerSeq(ctx, seq); err != nil {
+			return err
+		}
 		if err := txCtx.Ledger().SaveValidatedLedger(ctx, ledgerInfo); err != nil {
 			return err
 		}

--- a/internal/ledger/service/published_frontier_test.go
+++ b/internal/ledger/service/published_frontier_test.go
@@ -11,6 +11,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func awaitPublishedLedger(t *testing.T, published <-chan uint32) uint32 {
+	t.Helper()
+	select {
+	case seq := <-published:
+		return seq
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for published ledger")
+		return 0
+	}
+}
+
+func publishSequence(event *LedgerAcceptedEvent) uint32 {
+	if event == nil || event.Ledger == nil {
+		return 0
+	}
+	return event.Ledger.Sequence()
+}
+
 func TestPublishedFrontier_AdvancesBeforeCallback(t *testing.T) {
 	svc, err := New(DefaultConfig())
 	require.NoError(t, err)
@@ -116,7 +134,7 @@ func TestPublishedFrontier_LosslessBeyondFormerQueueCapacity(t *testing.T) {
 		}
 	})
 
-	first := makeStubLedger(t, 100, [32]byte{0x01}, [32]byte{})
+	first := makeStubLedger(t, 100, [32]byte{0x00, 0x64}, [32]byte{})
 	svc.dispatchLedgerEvent(&LedgerAcceptedEvent{Ledger: first})
 	select {
 	case <-firstStarted:
@@ -141,4 +159,88 @@ func TestPublishedFrontier_LosslessBeyondFormerQueueCapacity(t *testing.T) {
 	}
 	assert.Equal(t, uint32(eventCount), calls.Load())
 	assert.Equal(t, uint32(100+eventCount-1), svc.GetServerInfo().PublishedLedgerSeq)
+}
+
+func TestPublishedFrontier_HoldsGapUntilBelowTipLedgerArrives(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	const frontier = uint32(50)
+	first := makeStubLedger(t, frontier, [32]byte{0x50}, [32]byte{0x49})
+	missing := makeStubLedger(t, frontier+1, [32]byte{0x51}, first.Hash())
+	tip := makeStubLedger(t, frontier+2, [32]byte{0x52}, missing.Hash())
+
+	published := make(chan uint32, 3)
+	svc.SetEventCallback(func(event *LedgerAcceptedEvent) {
+		published <- publishSequence(event)
+	})
+	svc.dispatchLedgerEvent(&LedgerAcceptedEvent{Ledger: first})
+	require.Equal(t, frontier, awaitPublishedLedger(t, published))
+
+	svc.mu.Lock()
+	svc.putHistoryLocked(first)
+	svc.putHistoryLocked(missing)
+	svc.putHistoryLocked(tip)
+	svc.validatedLedger = first
+	svc.localTxs = nil
+	svc.mu.Unlock()
+
+	svc.SetValidatedLedger(tip.Sequence(), tip.Hash())
+	select {
+	case seq := <-published:
+		t.Fatalf("published ledger %d across a missing sequence", seq)
+	case <-time.After(25 * time.Millisecond):
+	}
+	assert.Equal(t, frontier, svc.GetServerInfo().PublishedLedgerSeq)
+
+	svc.SetValidatedLedger(missing.Sequence(), missing.Hash())
+	assert.Equal(t, frontier+1, awaitPublishedLedger(t, published))
+	assert.Equal(t, frontier+2, awaitPublishedLedger(t, published))
+	assert.Equal(t, frontier+2, svc.GetServerInfo().PublishedLedgerSeq)
+}
+
+func TestPublishedFrontier_JumpsWhenGapExceedsLimit(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	published := make(chan uint32, 3)
+	svc.SetEventCallback(func(event *LedgerAcceptedEvent) {
+		published <- publishSequence(event)
+	})
+
+	first := makeStubLedger(t, 10, [32]byte{0x10}, [32]byte{0x09})
+	held := makeStubLedger(t, 12, [32]byte{0x12}, [32]byte{0x11})
+	tip := makeStubLedger(t, 111, [32]byte{0x6f}, [32]byte{0x6e})
+	svc.dispatchLedgerEvent(&LedgerAcceptedEvent{Ledger: first})
+	require.Equal(t, uint32(10), awaitPublishedLedger(t, published))
+
+	svc.dispatchLedgerEvent(&LedgerAcceptedEvent{Ledger: held})
+	svc.dispatchLedgerEvent(&LedgerAcceptedEvent{Ledger: tip})
+	assert.Equal(t, uint32(111), awaitPublishedLedger(t, published))
+	assert.Equal(t, uint32(111), svc.GetServerInfo().PublishedLedgerSeq)
+
+	svc.ledgerEventMu.Lock()
+	assert.Empty(t, svc.ledgerEventCandidates)
+	svc.ledgerEventMu.Unlock()
+}
+
+func TestPublishedFrontier_FirstPublicationStartsAtValidatedTip(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	published := make(chan uint32, 1)
+	svc.SetEventCallback(func(event *LedgerAcceptedEvent) {
+		published <- publishSequence(event)
+	})
+
+	tip := makeStubLedger(t, 75, [32]byte{0x75}, [32]byte{0x74})
+	svc.dispatchLedgerEvent(&LedgerAcceptedEvent{Ledger: tip})
+	assert.Equal(t, tip.Sequence(), awaitPublishedLedger(t, published))
+	assert.Equal(t, tip.Sequence(), svc.GetServerInfo().PublishedLedgerSeq)
 }

--- a/internal/ledger/service/published_frontier_test.go
+++ b/internal/ledger/service/published_frontier_test.go
@@ -1,0 +1,144 @@
+package service
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishedFrontier_AdvancesBeforeCallback(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+
+	validated := makeStubLedger(t, 10, [32]byte{0x10}, [32]byte{0x09})
+	var observed ServerInfo
+	svc.SetEventCallback(func(*LedgerAcceptedEvent) {
+		observed = svc.GetServerInfo()
+	})
+
+	svc.deliverLedgerEvent(&LedgerAcceptedEvent{Ledger: validated})
+
+	assert.True(t, observed.HavePublished)
+	assert.Equal(t, uint32(10), observed.PublishedLedgerSeq)
+}
+
+func TestPublishedFrontier_IgnoresUnvalidatedAndNeverRegresses(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+
+	unvalidated := mustNewOpenWithHeader(
+		t,
+		header.LedgerHeader{LedgerIndex: 12, Hash: [32]byte{0x12}},
+		shamap.New(shamap.TypeState),
+		shamap.New(shamap.TypeTransaction),
+	)
+	svc.deliverLedgerEvent(&LedgerAcceptedEvent{Ledger: unvalidated})
+	assert.False(t, svc.GetServerInfo().HavePublished)
+
+	newer := makeStubLedger(t, 15, [32]byte{0x15}, [32]byte{0x14})
+	older := makeStubLedger(t, 14, [32]byte{0x14}, [32]byte{0x13})
+	svc.deliverLedgerEvent(&LedgerAcceptedEvent{Ledger: newer})
+	svc.deliverLedgerEvent(&LedgerAcceptedEvent{Ledger: older})
+
+	info := svc.GetServerInfo()
+	assert.True(t, info.HavePublished)
+	assert.Equal(t, uint32(15), info.PublishedLedgerSeq)
+}
+
+func TestPublishedFrontier_LagsValidatedQueueUntilOrderedDelivery(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondDelivered := make(chan struct{})
+	var calls atomic.Uint32
+	svc.SetEventCallback(func(*LedgerAcceptedEvent) {
+		switch calls.Add(1) {
+		case 1:
+			close(firstStarted)
+			<-releaseFirst
+		case 2:
+			close(secondDelivered)
+		}
+	})
+
+	first := makeStubLedger(t, 20, [32]byte{0x20}, [32]byte{0x19})
+	second := makeStubLedger(t, 21, [32]byte{0x21}, [32]byte{0x20})
+	svc.dispatchLedgerEvent(&LedgerAcceptedEvent{Ledger: first})
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first publication was not delivered")
+	}
+	assert.Equal(t, uint32(20), svc.GetServerInfo().PublishedLedgerSeq)
+
+	svc.dispatchLedgerEvent(&LedgerAcceptedEvent{Ledger: second})
+	assert.Equal(t, uint32(20), svc.GetServerInfo().PublishedLedgerSeq,
+		"queued publication must not advance the frontier before ordered delivery")
+
+	close(releaseFirst)
+	select {
+	case <-secondDelivered:
+	case <-time.After(time.Second):
+		t.Fatal("second publication was not delivered")
+	}
+	assert.Equal(t, uint32(21), svc.GetServerInfo().PublishedLedgerSeq)
+
+	svc.Stop()
+}
+
+func TestPublishedFrontier_LosslessBeyondFormerQueueCapacity(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	const eventCount = 300
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	allDelivered := make(chan struct{})
+	var calls atomic.Uint32
+	svc.SetEventCallback(func(*LedgerAcceptedEvent) {
+		switch calls.Add(1) {
+		case 1:
+			close(firstStarted)
+			<-releaseFirst
+		case eventCount:
+			close(allDelivered)
+		}
+	})
+
+	first := makeStubLedger(t, 100, [32]byte{0x01}, [32]byte{})
+	svc.dispatchLedgerEvent(&LedgerAcceptedEvent{Ledger: first})
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first publication was not delivered")
+	}
+
+	for i := uint32(1); i < eventCount; i++ {
+		seq := 100 + i
+		hash := [32]byte{byte(seq >> 8), byte(seq)}
+		parentHash := [32]byte{byte((seq - 1) >> 8), byte(seq - 1)}
+		svc.dispatchLedgerEvent(&LedgerAcceptedEvent{
+			Ledger: makeStubLedger(t, seq, hash, parentHash),
+		})
+	}
+	close(releaseFirst)
+
+	select {
+	case <-allDelivered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("publication queue did not deliver every event")
+	}
+	assert.Equal(t, uint32(eventCount), calls.Load())
+	assert.Equal(t, uint32(100+eventCount-1), svc.GetServerInfo().PublishedLedgerSeq)
+}

--- a/internal/ledger/service/retrievable_complete_ledgers_test.go
+++ b/internal/ledger/service/retrievable_complete_ledgers_test.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/LeJamon/go-xrpl/storage/kvstore/memorydb"
+	"github.com/LeJamon/go-xrpl/storage/nodestore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompleteLedgers_EvictedSequenceLoadsFromNodeStore(t *testing.T) {
+	db := nodestore.NewKVDatabase(memorydb.New(), "complete-ledger-sequence", 10_000, time.Hour)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	cfg := DefaultConfig()
+	cfg.NodeStore = db
+	cfg.SHAMapFamily = shamap.NewNodeStoreFamily(db)
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	want := svc.GetValidatedLedger()
+	require.NotNil(t, want)
+	require.NoError(t, svc.persistValidatedLedger(t.Context(), want, false))
+
+	svc.mu.Lock()
+	svc.evictOldHistoryLocked(want.Sequence() + historyWindow)
+	_, retained := svc.ledgerHistory[want.Sequence()]
+	svc.mu.Unlock()
+	require.False(t, retained)
+	require.Equal(t, strconv.FormatUint(uint64(want.Sequence()), 10), svc.completeLedgersString())
+
+	got, err := svc.GetLedgerBySequence(want.Sequence())
+	require.NoError(t, err)
+	require.Equal(t, want.Hash(), got.Hash())
+	require.True(t, got.IsValidated())
+
+	selected, validated, err := svc.getLedgerForQuery(strconv.FormatUint(uint64(want.Sequence()), 10))
+	require.NoError(t, err)
+	require.True(t, validated)
+	require.Equal(t, want.Hash(), selected.Hash())
+}
+
+func TestCompleteLedgers_EvictionRemovesUndurableSequence(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+
+	const seq uint32 = 20
+	l := makeStubLedger(t, seq, [32]byte{0x20}, [32]byte{0x19})
+	svc.mu.Lock()
+	svc.putHistoryLocked(l)
+	svc.mu.Unlock()
+	token := svc.beginValidatedPersistence(seq, l.Hash())
+	svc.recordValidatedPersistence(seq, token, true)
+	require.Equal(t, strconv.FormatUint(uint64(seq), 10), svc.completeLedgersString())
+
+	svc.mu.Lock()
+	svc.evictOldHistoryLocked(seq + historyWindow)
+	svc.mu.Unlock()
+
+	require.Equal(t, "empty", svc.completeLedgersString())
+	_, err = svc.GetLedgerBySequence(seq)
+	require.ErrorIs(t, err, ErrLedgerNotFound)
+}
+
+func TestCompleteLedgers_EvictionCancelsPendingPersistence(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+	svc.persistMu.Lock()
+	svc.persistStarted = true
+	svc.persistMu.Unlock()
+
+	const seq uint32 = 21
+	l := makeStubLedger(t, seq, [32]byte{0x21}, [32]byte{0x20})
+	svc.mu.Lock()
+	svc.putHistoryLocked(l)
+	svc.mu.Unlock()
+	svc.enqueueValidatedHistoryPersist(l)
+
+	svc.persistMu.Lock()
+	require.Len(t, svc.persistQueue, 1)
+	job := svc.persistQueue[0]
+	svc.persistQueue = nil
+	svc.persistMu.Unlock()
+
+	svc.mu.Lock()
+	svc.evictOldHistoryLocked(seq + historyWindow)
+	svc.mu.Unlock()
+
+	require.True(t, job.canceled.Load())
+	require.Equal(t, "empty", svc.completeLedgersString())
+	svc.runPersistJob(job)
+	require.Equal(t, "empty", svc.completeLedgersString())
+}
+
+func TestSwitchToPreferredLedger_PreservesValidatedFrontier(t *testing.T) {
+	tests := []struct {
+		name      string
+		candidate func(t *testing.T, validatedSeq uint32, validatedHash [32]byte) *ledger.Ledger
+	}{
+		{
+			name: "below validated sequence",
+			candidate: func(t *testing.T, validatedSeq uint32, _ [32]byte) *ledger.Ledger {
+				return makeStubLedger(t, validatedSeq-1, [32]byte{0xA1}, [32]byte{})
+			},
+		},
+		{
+			name: "same sequence sibling",
+			candidate: func(t *testing.T, validatedSeq uint32, validatedHash [32]byte) *ledger.Ledger {
+				hash := validatedHash
+				hash[0] ^= 0xFF
+				return makeStubLedger(t, validatedSeq, hash, [32]byte{})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			svc, err := New(DefaultConfig())
+			require.NoError(t, err)
+			require.NoError(t, svc.Start())
+			t.Cleanup(svc.Stop)
+
+			closedBefore := svc.GetClosedLedger()
+			openBefore := svc.GetOpenLedger()
+			validatedBefore := svc.GetValidatedLedger()
+			require.NotNil(t, validatedBefore)
+			require.NotZero(t, validatedBefore.Sequence())
+			candidate := test.candidate(t, validatedBefore.Sequence(), validatedBefore.Hash())
+
+			err = svc.SwitchToPreferredLedger(candidate)
+			require.ErrorIs(t, err, ErrPreferredChainSwitch)
+			require.Same(t, closedBefore, svc.GetClosedLedger())
+			require.Same(t, openBefore, svc.GetOpenLedger())
+			require.Same(t, validatedBefore, svc.GetValidatedLedger())
+		})
+	}
+}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
@@ -17,6 +16,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/LeJamon/go-xrpl/internal/ledger/localtxs"
+	"github.com/LeJamon/go-xrpl/internal/ledger/manager"
 	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/tx"
@@ -138,6 +138,11 @@ type Service struct {
 	validatedSignTime time.Time
 	validatedAgeNow   func() time.Time
 
+	// Published ledger (highest ledger delivered at the ordered validated
+	// publication boundary).
+	publishedLedgerSeq uint32
+	havePublished      bool
+
 	// Genesis ledger
 	genesisLedger *ledger.Ledger
 
@@ -217,6 +222,15 @@ type Service struct {
 	// reclaimed ledgers. Nil when online_delete is off.
 	minimumOnlineFunc func() uint32
 
+	// completeMu guards completedLedgers, their canonical hashes, the retention
+	// floor, and active tokens used to reject stale persistence completions.
+	completeMu              sync.RWMutex
+	completedLedgers        *manager.CompleteLedgerSet
+	completeLedgerHashes    map[uint32][32]byte
+	completeLedgerFloor     uint32
+	completeLedgerTokens    map[uint32]uint64
+	nextCompleteLedgerToken uint64
+
 	// openLedgerView is the persistent open-ledger view — source of truth for
 	// the open pool. Built by Start, rebuilt by adopt paths, advanced by Accept.
 	openLedgerView *openledger.OpenLedger
@@ -256,28 +270,27 @@ type Service struct {
 	// the TxQ's timeLeap flag by processClosedLedgerLocked. Zero in standalone.
 	lastConsensusRoundTime time.Duration
 
-	persistMu       sync.Mutex
-	persistQueue    []persistJob
-	persistWake     chan struct{}
-	persistStarted  bool
-	persistStopping bool
-	persistWG       sync.WaitGroup
-	validatedTipMu  sync.Mutex
-	sweepMu         sync.Mutex
-	sweepCancel     context.CancelFunc
-	sweepDone       chan struct{}
-	sweepInterval   time.Duration
+	persistMu            sync.Mutex
+	persistQueue         []*persistJob
+	validatedPersistJobs map[uint32]*persistJob
+	persistWake          chan struct{}
+	persistStarted       bool
+	persistStopping      bool
+	persistWG            sync.WaitGroup
+	canonicalPersistMu   sync.Mutex
+	sweepMu              sync.Mutex
+	sweepCancel          context.CancelFunc
+	sweepDone            chan struct{}
+	sweepInterval        time.Duration
 
-	// ledgerEventCh feeds the single accepted-ledger event dispatcher (see
-	// dispatchLedgerEvent). A single consumer preserves FIFO delivery and runs
-	// eventCallback single-threaded, replacing per-event goroutines that ran the
-	// callback concurrently with itself — racing the subscriber's mutable state
-	// and reordering ledgerClosed stream events. Started by Start, joined by Stop.
-	ledgerEventCh       chan *LedgerAcceptedEvent
-	ledgerEventQuit     chan struct{}
-	ledgerEventStopped  bool
+	// ledgerEventMu guards the lossless FIFO publication queue. The single
+	// dispatcher runs eventCallback serially and is started by Start.
+	ledgerEventMu       sync.Mutex
+	ledgerEventQueue    []*LedgerAcceptedEvent
+	ledgerEventWake     chan struct{}
+	ledgerEventStarted  bool
+	ledgerEventStopping bool
 	ledgerEventWG       sync.WaitGroup
-	droppedLedgerEvents atomic.Uint64
 
 	// configCacheMu guards the memoised open-ledger ApplyConfig below. The config
 	// is a pure function of closedLedger, rebuilt only when it advances, keeping
@@ -331,6 +344,10 @@ func New(cfg Config) (*Service, error) {
 		pendingValidation:        make(map[[32]byte]*LedgerAcceptedEvent),
 		pendingLedgerValidations: make(map[uint32]pendingValidationEntry),
 		heldAdoptions:            make(map[uint32]*pendingAdopt),
+		completedLedgers:         manager.NewCompleteLedgerSet(),
+		completeLedgerHashes:     make(map[uint32][32]byte),
+		completeLedgerTokens:     make(map[uint32]uint64),
+		validatedPersistJobs:     make(map[uint32]*persistJob),
 		txQueue:                  txq.New(txqCfg),
 		localTxs:                 localtxs.New(),
 		feeTrack:                 feetrack.New(),
@@ -446,9 +463,11 @@ func (s *Service) Start() error {
 	if startWorkers {
 		go s.runPersistWorker()
 
-		s.ledgerEventCh = make(chan *LedgerAcceptedEvent, ledgerEventBufferDepth)
-		s.ledgerEventQuit = make(chan struct{})
+		s.ledgerEventMu.Lock()
+		s.ledgerEventWake = make(chan struct{}, 1)
+		s.ledgerEventStarted = true
 		s.ledgerEventWG.Add(1)
+		s.ledgerEventMu.Unlock()
 		go s.runLedgerEventDispatcher()
 	}
 
@@ -509,6 +528,12 @@ func (s *Service) Start() error {
 		s.closedLedger = latest
 		s.validatedLedger = latest
 		s.validatedSignTime = latest.CloseTime()
+		s.publishedLedgerSeq = latest.Sequence()
+		s.havePublished = true
+		s.completeMu.Lock()
+		s.completedLedgers.Add(latest.Sequence())
+		s.completeLedgerHashes[latest.Sequence()] = latest.Hash()
+		s.completeMu.Unlock()
 		if latest.Sequence() != genesisLedger.Sequence() {
 			s.deleteHistoryLocked(genesisLedger.Sequence())
 		}
@@ -1325,16 +1350,9 @@ func (s *Service) GetValidatedLedgerIndex() uint32 {
 	return s.validatedLedger.Sequence()
 }
 
-// getValidatedLedgersRange returns a string representation of validated ledger range
+// getValidatedLedgersRange returns the actual completed-ledger ranges.
 func (s *Service) getValidatedLedgersRange() string {
-	minSeq, maxSeq, ok := s.ledgerHistoryRangeLocked()
-	if !ok {
-		return "empty"
-	}
-	if minSeq == maxSeq {
-		return strconv.FormatUint(uint64(minSeq), 10)
-	}
-	return formatRange(minSeq, maxSeq)
+	return s.completeLedgersString()
 }
 
 // SetServerStateFunc sets a function that provides the server state string.
@@ -1407,8 +1425,9 @@ func (s *Service) GetServerInfo() ServerInfo {
 		Standalone:         s.config.Standalone,
 		ServerState:        "full",
 		NeedsNetworkLedger: s.needsInitialSync,
-		CompleteLedgers:    "",
 		NetworkID:          s.config.NetworkID,
+		HavePublished:      s.havePublished,
+		PublishedLedgerSeq: s.publishedLedgerSeq,
 	}
 
 	if s.openLedger != nil {
@@ -1428,7 +1447,6 @@ func (s *Service) GetServerInfo() ServerInfo {
 		info.ValidatedLedgerCloseTime = protocol.RippleSeconds(s.validatedLedger.CloseTime())
 	}
 
-	minSeq, maxSeq, haveRange := s.ledgerHistoryRangeLocked()
 	serverStateFunc := s.serverStateFunc
 	minimumOnlineFunc := s.minimumOnlineFunc
 	s.mu.RUnlock()
@@ -1437,20 +1455,9 @@ func (s *Service) GetServerInfo() ServerInfo {
 		info.ServerState = serverStateFunc()
 	}
 	if minimumOnlineFunc != nil {
-		if floor := minimumOnlineFunc(); floor > minSeq {
-			minSeq = floor
-		}
+		s.clampCompleteLedgers(minimumOnlineFunc())
 	}
-	if minSeq > maxSeq {
-		haveRange = false
-	}
-	if haveRange {
-		if minSeq == maxSeq {
-			info.CompleteLedgers = strconv.FormatUint(uint64(minSeq), 10)
-		} else {
-			info.CompleteLedgers = formatRange(minSeq, maxSeq)
-		}
-	}
+	info.CompleteLedgers = s.completeLedgersString()
 
 	return info
 }
@@ -1469,6 +1476,8 @@ type ServerInfo struct {
 	ValidatedLedgerHash      [32]byte
 	ValidatedLedgerCloseTime int64 // Ripple-epoch seconds
 	CompleteLedgers          string
+	HavePublished            bool
+	PublishedLedgerSeq       uint32
 	NetworkID                uint32
 }
 

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -283,14 +283,18 @@ type Service struct {
 	sweepDone            chan struct{}
 	sweepInterval        time.Duration
 
-	// ledgerEventMu guards the lossless FIFO publication queue. The single
-	// dispatcher runs eventCallback serially and is started by Start.
-	ledgerEventMu       sync.Mutex
-	ledgerEventQueue    []*LedgerAcceptedEvent
-	ledgerEventWake     chan struct{}
-	ledgerEventStarted  bool
-	ledgerEventStopping bool
-	ledgerEventWG       sync.WaitGroup
+	// ledgerEventMu guards the publication candidates and lossless FIFO queue.
+	// The single dispatcher runs eventCallback serially and is started by Start.
+	ledgerEventMu           sync.Mutex
+	ledgerEventQueue        []*LedgerAcceptedEvent
+	ledgerEventCandidates   map[uint32]*LedgerAcceptedEvent
+	ledgerEventFrontierSeq  uint32
+	ledgerEventFrontierHash [32]byte
+	ledgerEventHaveFrontier bool
+	ledgerEventWake         chan struct{}
+	ledgerEventStarted      bool
+	ledgerEventStopping     bool
+	ledgerEventWG           sync.WaitGroup
 
 	// configCacheMu guards the memoised open-ledger ApplyConfig below. The config
 	// is a pure function of closedLedger, rebuilt only when it advances, keeping
@@ -353,6 +357,7 @@ func New(cfg Config) (*Service, error) {
 		feeTrack:                 feetrack.New(),
 		validatedAgeNow:          time.Now,
 		persistWake:              make(chan struct{}, 1),
+		ledgerEventCandidates:    make(map[uint32]*LedgerAcceptedEvent),
 		sweepInterval:            nodeStoreSweepIntervalForSize(cfg.NodeSize),
 	}
 	return s, nil
@@ -530,6 +535,11 @@ func (s *Service) Start() error {
 		s.validatedSignTime = latest.CloseTime()
 		s.publishedLedgerSeq = latest.Sequence()
 		s.havePublished = true
+		s.ledgerEventMu.Lock()
+		s.ledgerEventFrontierSeq = latest.Sequence()
+		s.ledgerEventFrontierHash = latest.Hash()
+		s.ledgerEventHaveFrontier = true
+		s.ledgerEventMu.Unlock()
 		s.completeMu.Lock()
 		s.completedLedgers.Add(latest.Sequence())
 		s.completeLedgerHashes[latest.Sequence()] = latest.Hash()
@@ -1037,18 +1047,78 @@ func (s *Service) XRPFeesEnabled() bool {
 }
 
 // GetLedgerBySequence returns a ledger by sequence, falling back to the open
-// ledger when its sequence matches.
+// ledger or durable validated history.
 func (s *Service) GetLedgerBySequence(seq uint32) (*ledger.Ledger, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	return s.getLedgerBySequence(context.Background(), seq)
+}
 
-	if l, ok := s.ledgerHistory[seq]; ok {
-		return l, nil
-	}
+func (s *Service) getLedgerBySequence(ctx context.Context, seq uint32) (*ledger.Ledger, error) {
+	s.mu.RLock()
+	history := s.ledgerHistory[seq]
+	var open *ledger.Ledger
 	if s.openLedger != nil && s.openLedger.Sequence() == seq {
-		return s.openLedger, nil
+		open = s.openLedger
 	}
-	return nil, ErrLedgerNotFound
+	s.mu.RUnlock()
+
+	s.completeMu.RLock()
+	hash, complete := s.completeLedgerHashes[seq]
+	complete = complete && s.completedLedgers != nil && s.completedLedgers.Contains(seq)
+	s.completeMu.RUnlock()
+	if history != nil && (!complete || history.Hash() == hash) {
+		return history, nil
+	}
+	if open != nil && (!complete || open.Hash() == hash) {
+		return open, nil
+	}
+	if !complete || s.nodeStore == nil || s.shamapFamily == nil {
+		return nil, ErrLedgerNotFound
+	}
+
+	s.mu.RLock()
+	cached := s.persistedLedgers[hash]
+	s.mu.RUnlock()
+	if cached != nil && cached.Sequence() == seq {
+		if cached.IsValidated() {
+			return cached, nil
+		}
+		validated, err := cached.Snapshot()
+		if err != nil {
+			return nil, err
+		}
+		if err := validated.SetValidated(); err != nil {
+			return nil, err
+		}
+		return validated, nil
+	}
+
+	loaded, err := s.loadStoredLedgerByHash(ctx, hash)
+	if err != nil {
+		if errors.Is(err, errStoredLedgerUnavailable) {
+			return nil, fmt.Errorf("%w: load ledger %d from nodestore: %v", ErrLedgerNotFound, seq, err)
+		}
+		return nil, fmt.Errorf("load ledger %d from nodestore: %w", seq, err)
+	}
+	if loaded == nil || loaded.Sequence() != seq {
+		return nil, ErrLedgerNotFound
+	}
+	if err := loaded.SetValidated(); err != nil {
+		return nil, err
+	}
+
+	s.completeMu.RLock()
+	stillComplete := s.completedLedgers != nil &&
+		s.completedLedgers.Contains(seq) &&
+		s.completeLedgerHashes[seq] == hash
+	s.completeMu.RUnlock()
+	if !stillComplete {
+		return nil, ErrLedgerNotFound
+	}
+
+	s.mu.Lock()
+	s.cachePersistedLedgerLocked(loaded)
+	s.mu.Unlock()
+	return loaded, nil
 }
 
 // AdoptedLedgerBySequence returns a closed ledger from adopted history only,

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime/debug"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -41,6 +43,7 @@ import (
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb/postgres"
 	sqlitedb "github.com/LeJamon/go-xrpl/storage/relationaldb/sqlite"
+	"github.com/LeJamon/go-xrpl/version"
 	googlegrpc "google.golang.org/grpc"
 )
 
@@ -53,6 +56,77 @@ func effectivePeerFetchDepth(fetchDepth uint32, onlineDelete int) uint32 {
 		return uint32(onlineDelete)
 	}
 	return fetchDepth
+}
+
+func serverInfoConfigSnapshot(cfg *config.Config) types.ServerInfoConfigSnapshot {
+	if cfg == nil {
+		return types.ServerInfoConfigSnapshot{}
+	}
+
+	nodeSize := cfg.NodeSize
+	if nodeSize == "" {
+		nodeSize = "medium"
+	}
+
+	names := append([]string(nil), cfg.Server.Ports...)
+	if len(names) == 0 {
+		names = make([]string, 0, len(cfg.Ports))
+		for name := range cfg.Ports {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+	}
+
+	ports := make([]types.ServerInfoPortSnapshot, 0, len(names))
+	for _, name := range names {
+		port, ok := cfg.Ports[name]
+		if !ok {
+			continue
+		}
+		admin := port.AdminUser != "" || port.AdminPassword != ""
+		if adminNets, err := port.ParseAdminNets(); err != nil || len(adminNets) != 0 {
+			admin = true
+		}
+		ports = append(ports, types.ServerInfoPortSnapshot{
+			Port:     port.Port,
+			Protocol: port.Protocol,
+			Admin:    admin,
+		})
+	}
+
+	return types.ServerInfoConfigSnapshot{
+		Ports:        ports,
+		ServerDomain: cfg.ServerDomain,
+		NodeSize:     nodeSize,
+		GitHash:      goBuildRevision(),
+	}
+}
+
+func goBuildRevision() string {
+	info, ok := debug.ReadBuildInfo()
+	return resolveBuildRevision(info, ok, version.Version)
+}
+
+func resolveBuildRevision(info *debug.BuildInfo, haveBuildInfo bool, fallback string) string {
+	if haveBuildInfo && info != nil {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				return setting.Value
+			}
+		}
+	}
+	if isFullGitHash(fallback) {
+		return fallback
+	}
+	return ""
+}
+
+func isFullGitHash(value string) bool {
+	if len(value) != 40 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
 }
 
 // Run assembles and starts every node subsystem from the parsed config, then
@@ -191,6 +265,7 @@ func Run(appConfig *config.Config, configPath string, standalone bool, rootLogge
 	// Wire up RPC services
 	ledgerAdapter := rpc.NewLedgerServiceAdapter(ledgerService)
 	services := types.NewServiceContainer(ledgerAdapter)
+	services.ServerInfoConfig = serverInfoConfigSnapshot(appConfig)
 
 	// Gate the beta RPC API (api_version 3) on the operator's beta_rpc_api
 	// knob, mirroring rippled Config::BETA_RPC_API.
@@ -621,6 +696,7 @@ func Run(appConfig *config.Config, configPath string, standalone bool, rootLogge
 			services.FetchInfo = router.FetchInfo
 			services.FetchInfoClear = router.ClearFetchInfo
 			services.RequestLedger = router.RequestLedger
+			services.FetchPackCacheSize = router.FetchPackCacheSize
 		}
 
 		// Expose the validator-manifest cache to the `manifest` RPC.

--- a/internal/node/server_test.go
+++ b/internal/node/server_test.go
@@ -4,10 +4,13 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"sync"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/config"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/stretchr/testify/assert"
 )
@@ -48,6 +51,50 @@ func TestEffectivePeerFetchDepth(t *testing.T) {
 			assert.Equal(t, tc.want, effectivePeerFetchDepth(tc.fetchDepth, tc.onlineDelete))
 		})
 	}
+}
+
+func TestServerInfoConfigSnapshot(t *testing.T) {
+	cfg := &config.Config{
+		Server:       config.ServerConfig{Ports: []string{"public", "blank-admin", "admin-user"}},
+		ServerDomain: "example.test",
+		Ports: map[string]config.PortConfig{
+			"public": {
+				Port:     5005,
+				Protocol: "http",
+			},
+			"blank-admin": {
+				Port:     6005,
+				Protocol: "ws",
+				Admin:    []string{"", "  "},
+			},
+			"admin-user": {
+				Port:      6006,
+				Protocol:  "ws",
+				AdminUser: "operator",
+			},
+		},
+	}
+
+	snapshot := serverInfoConfigSnapshot(cfg)
+	assert.Equal(t, "example.test", snapshot.ServerDomain)
+	assert.Equal(t, "medium", snapshot.NodeSize)
+	assert.Equal(t, []types.ServerInfoPortSnapshot{
+		{Port: 5005, Protocol: "http"},
+		{Port: 6005, Protocol: "ws"},
+		{Port: 6006, Protocol: "ws", Admin: true},
+	}, snapshot.Ports)
+}
+
+func TestIsFullGitHash(t *testing.T) {
+	assert.True(t, isFullGitHash("81f392511234abcd81f392511234abcd81f39251"))
+	assert.False(t, isFullGitHash("81f3925"))
+	assert.False(t, isFullGitHash("81f392511234abcd81f392511234abcd81f3925z"))
+}
+
+func TestResolveBuildRevisionFallsBackToInjectedFullHash(t *testing.T) {
+	const injected = "81f392511234abcd81f392511234abcd81f39251"
+	assert.Equal(t, injected, resolveBuildRevision(&debug.BuildInfo{}, true, injected))
+	assert.Empty(t, resolveBuildRevision(&debug.BuildInfo{}, true, "v3.2.0"))
 }
 
 func (s *recordingSink) ReloadStaticValidators(validators []consensus.NodeID, masterKeys [][33]byte) {

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/codec/addresscodec"
@@ -137,6 +139,7 @@ func buildServerWarnings(services *types.ServiceContainer, isAdmin bool) []types
 func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 	services := ctx.Services
 	serverInfo := services.Ledger.GetServerInfo()
+	configSnapshot := services.ServerInfoConfig
 	baseFee, reserveBase, reserveIncrement := services.Ledger.GetCurrentFees()
 
 	// Uptime in seconds
@@ -190,6 +193,26 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 		// `current.count()` = now - last-transition-time.
 		"server_state_duration_us": fmt.Sprintf("%d", accounting.currentDurationUs),
 		"state_accounting":         accounting.modes,
+	}
+
+	info["ports"] = buildServerInfoPorts(configSnapshot.Ports, ctx.IsAdmin)
+	if configSnapshot.ServerDomain != "" {
+		info["server_domain"] = configSnapshot.ServerDomain
+	}
+	if ctx.IsAdmin {
+		nodeSize := configSnapshot.NodeSize
+		if nodeSize == "" {
+			nodeSize = "medium"
+		}
+		info["node_size"] = nodeSize
+		if configSnapshot.GitHash != "" {
+			info["git"] = map[string]any{"hash": configSnapshot.GitHash}
+		}
+	}
+	if services.FetchPackCacheSize != nil {
+		if size := services.FetchPackCacheSize(); size != 0 {
+			info["fetch_pack"] = size
+		}
 	}
 
 	// Rippled emits initial_sync_duration_us only when the node has
@@ -391,13 +414,13 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 		}
 	}
 
-	// published_ledger: rippled includes "none" if no published ledger,
-	// or the sequence if it differs from closed.
-	// For now, report the validated sequence as published.
-	if serverInfo.ValidatedLedgerSeq > 0 {
-		info["published_ledger"] = serverInfo.ValidatedLedgerSeq
-	} else {
-		info["published_ledger"] = "none"
+	if haveLedger {
+		switch {
+		case !serverInfo.HavePublished:
+			info["published_ledger"] = "none"
+		case serverInfo.PublishedLedgerSeq != ledgerSeq:
+			info["published_ledger"] = serverInfo.PublishedLedgerSeq
+		}
 	}
 
 	// network_id: only include if configured (non-zero), matching rippled
@@ -411,6 +434,45 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 	}
 
 	return info
+}
+
+func buildServerInfoPorts(ports []types.ServerInfoPortSnapshot, isAdmin bool) []map[string]any {
+	result := make([]map[string]any, 0, len(ports))
+	for _, port := range ports {
+		protocols, grpc := serverInfoProtocols(port.Protocol)
+		if len(protocols) != 0 && (isAdmin || !port.Admin) {
+			result = append(result, map[string]any{
+				"port":     strconv.Itoa(port.Port),
+				"protocol": protocols,
+			})
+		}
+		if grpc {
+			result = append(result, map[string]any{
+				"port":     strconv.Itoa(port.Port),
+				"protocol": []string{"grpc"},
+			})
+		}
+	}
+	return result
+}
+
+func serverInfoProtocols(configured string) ([]string, bool) {
+	set := make(map[string]struct{})
+	for _, protocol := range strings.FieldsFunc(configured, func(r rune) bool {
+		return r == ',' || unicode.IsSpace(r)
+	}) {
+		set[protocol] = struct{}{}
+	}
+
+	supported := [...]string{"http", "https", "peer", "ws", "ws2", "wss", "wss2"}
+	protocols := make([]string, 0, len(set))
+	for _, protocol := range supported {
+		if _, ok := set[protocol]; ok {
+			protocols = append(protocols, protocol)
+		}
+	}
+	_, grpc := set["grpc"]
+	return protocols, grpc
 }
 
 func getPeerCount(ctx *types.RpcContext) int {

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -91,6 +91,8 @@ func (a *LedgerServiceAdapter) GetServerInfo() types.LedgerServerInfo {
 		ValidatedLedgerHash:      info.ValidatedLedgerHash,
 		ValidatedLedgerCloseTime: info.ValidatedLedgerCloseTime,
 		CompleteLedgers:          info.CompleteLedgers,
+		HavePublished:            info.HavePublished,
+		PublishedLedgerSeq:       info.PublishedLedgerSeq,
 		NetworkID:                info.NetworkID,
 	}
 }

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -76,6 +76,8 @@ func (m *mockLedgerServiceServerInfo) GetServerInfo() types.LedgerServerInfo {
 		ValidatedLedgerHash:      m.serverInfo.ValidatedLedgerHash,
 		ValidatedLedgerCloseTime: m.serverInfo.ValidatedLedgerCloseTime,
 		CompleteLedgers:          m.serverInfo.CompleteLedgers,
+		HavePublished:            m.serverInfo.HavePublished,
+		PublishedLedgerSeq:       m.serverInfo.PublishedLedgerSeq,
 	}
 }
 
@@ -137,6 +139,189 @@ func servicesForServerInfo(mock *mockLedgerServiceServerInfo) *types.ServiceCont
 	}
 }
 
+func callServerStatus(t *testing.T, ctx *types.RpcContext, human bool) map[string]any {
+	t.Helper()
+	if human {
+		result, rpcErr := (&handlers.ServerInfoMethod{}).Handle(ctx, nil)
+		require.Nil(t, rpcErr)
+		return result.(map[string]any)["info"].(map[string]any)
+	}
+	result, rpcErr := (&handlers.ServerStateMethod{}).Handle(ctx, nil)
+	require.Nil(t, rpcErr)
+	return result.(map[string]any)["state"].(map[string]any)
+}
+
+func TestServerStatusRuntimeFields(t *testing.T) {
+	const gitHash = "0123456789abcdef0123456789abcdef01234567"
+	mock := newMockLedgerServiceServerInfo()
+	services := servicesForServerInfo(mock)
+	services.ServerInfoConfig = types.ServerInfoConfigSnapshot{
+		Ports: []types.ServerInfoPortSnapshot{
+			{Port: 5005, Protocol: "ws2 http,http ignored"},
+			{Port: 6006, Protocol: "wss2, https", Admin: true},
+			{Port: 50051, Protocol: "grpc", Admin: true},
+		},
+		ServerDomain: "example.test",
+		NodeSize:     "large",
+		GitHash:      gitHash,
+	}
+	services.FetchPackCacheSize = func() uint32 { return 7 }
+
+	publicPorts := []map[string]any{
+		{"port": "5005", "protocol": []string{"http", "ws2"}},
+		{"port": "50051", "protocol": []string{"grpc"}},
+	}
+	adminPorts := []map[string]any{
+		{"port": "5005", "protocol": []string{"http", "ws2"}},
+		{"port": "6006", "protocol": []string{"https", "wss2"}},
+		{"port": "50051", "protocol": []string{"grpc"}},
+	}
+
+	for _, human := range []bool{true, false} {
+		mode := "server_state"
+		if human {
+			mode = "server_info"
+		}
+		t.Run(mode, func(t *testing.T) {
+			for _, tc := range []struct {
+				name      string
+				admin     bool
+				wantPorts []map[string]any
+			}{
+				{name: "guest", wantPorts: publicPorts},
+				{name: "admin", admin: true, wantPorts: adminPorts},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					role := types.RoleGuest
+					if tc.admin {
+						role = types.RoleAdmin
+					}
+					ctx := &types.RpcContext{
+						Context:  t.Context(),
+						Role:     role,
+						IsAdmin:  tc.admin,
+						Services: services,
+					}
+					info := callServerStatus(t, ctx, human)
+
+					assert.Equal(t, tc.wantPorts, info["ports"])
+					assert.Equal(t, "example.test", info["server_domain"])
+					assert.IsType(t, uint32(0), info["fetch_pack"])
+					assert.Equal(t, uint32(7), info["fetch_pack"])
+
+					if tc.admin {
+						assert.Equal(t, "large", info["node_size"])
+						assert.Equal(t, map[string]any{"hash": gitHash}, info["git"])
+					} else {
+						assert.NotContains(t, info, "node_size")
+						assert.NotContains(t, info, "git")
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestServerStatusRuntimeFieldOmissions(t *testing.T) {
+	mock := newMockLedgerServiceServerInfo()
+	services := servicesForServerInfo(mock)
+	services.FetchPackCacheSize = func() uint32 { return 0 }
+
+	for _, human := range []bool{true, false} {
+		ctx := &types.RpcContext{
+			Context:  t.Context(),
+			Role:     types.RoleAdmin,
+			IsAdmin:  true,
+			Services: services,
+		}
+		info := callServerStatus(t, ctx, human)
+		assert.Equal(t, []map[string]any{}, info["ports"])
+		assert.NotContains(t, info, "fetch_pack")
+		assert.NotContains(t, info, "server_domain")
+		assert.NotContains(t, info, "git")
+		assert.Equal(t, "medium", info["node_size"])
+
+		encoded, err := json.Marshal(info)
+		require.NoError(t, err)
+		assert.Contains(t, string(encoded), `"ports":[]`)
+	}
+}
+
+func TestServerStatusPublishedLedger(t *testing.T) {
+	tests := []struct {
+		name          string
+		closed        uint32
+		validated     uint32
+		havePublished bool
+		published     uint32
+		want          any
+		wantPresent   bool
+	}{
+		{
+			name: "no selected ledger omits field",
+		},
+		{
+			name:        "no published ledger",
+			closed:      10,
+			want:        "none",
+			wantPresent: true,
+		},
+		{
+			name:          "published equals closed",
+			closed:        10,
+			havePublished: true,
+			published:     10,
+		},
+		{
+			name:          "publication lags closed",
+			closed:        10,
+			havePublished: true,
+			published:     9,
+			want:          uint32(9),
+			wantPresent:   true,
+		},
+		{
+			name:          "published equals validated selection",
+			closed:        11,
+			validated:     10,
+			havePublished: true,
+			published:     10,
+		},
+		{
+			name:          "publication lags validated selection",
+			closed:        11,
+			validated:     10,
+			havePublished: true,
+			published:     9,
+			want:          uint32(9),
+			wantPresent:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := newMockLedgerServiceServerInfo()
+			mock.closedLedgerIndex = test.closed
+			mock.validatedLedgerIndex = test.validated
+			mock.serverInfo.HavePublished = test.havePublished
+			mock.serverInfo.PublishedLedgerSeq = test.published
+			services := servicesForServerInfo(mock)
+
+			for _, human := range []bool{true, false} {
+				info := callServerStatus(t, &types.RpcContext{
+					Context:  t.Context(),
+					Services: services,
+				}, human)
+				got, present := info["published_ledger"]
+				assert.Equal(t, test.wantPresent, present)
+				if test.wantPresent {
+					assert.Equal(t, test.want, got)
+				}
+			}
+		})
+	}
+}
+
 type serverInfoValidatorList struct {
 	publisherCount int
 	threshold      int
@@ -188,7 +373,7 @@ func TestServerInfoResponseFields(t *testing.T) {
 
 		// Check build_version
 		assert.Contains(t, info, "build_version")
-		assert.NotEmpty(t, info["build_version"])
+		assert.Equal(t, handlers.BuildVersion, info["build_version"])
 	})
 
 	t.Run("info.complete_ledgers field present", func(t *testing.T) {

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -152,6 +152,23 @@ type ListedValidator struct {
 	Trusted   bool
 }
 
+// ServerInfoPortSnapshot is the immutable portion of a configured listener
+// surfaced by server_info and server_state.
+type ServerInfoPortSnapshot struct {
+	Port     int
+	Protocol string
+	Admin    bool
+}
+
+// ServerInfoConfigSnapshot holds startup configuration used by the server
+// status RPCs. The node builds it once before serving requests.
+type ServerInfoConfigSnapshot struct {
+	Ports        []ServerInfoPortSnapshot
+	ServerDomain string
+	NodeSize     string
+	GitHash      string
+}
+
 // ManifestLookup is the read-only facet of the validator-manifest cache
 // that the `manifest` RPC needs. Expressed as an interface (not a
 // concrete type) so internal/rpc/types doesn't import
@@ -186,6 +203,10 @@ type ServiceContainer struct {
 
 	// NodePublicKey is the base58-encoded node identity public key (e.g. "n9...")
 	NodePublicKey string
+
+	// ServerInfoConfig is the immutable startup configuration and build
+	// metadata surfaced by server_info and server_state.
+	ServerInfoConfig ServerInfoConfigSnapshot
 
 	// LastCloseInfo returns proposer count and convergence time (ms) from the last consensus round
 	LastCloseInfo func() (proposers int, convergeTimeMs int)
@@ -319,6 +340,10 @@ type ServiceContainer struct {
 	// object in human mode when |offset| >= 60s
 	// (NetworkOPs.cpp:2946-2949). Nil before consensus is wired.
 	CloseTimeOffset func() time.Duration
+
+	// FetchPackCacheSize returns the number of inbound fetch-pack nodes
+	// currently cached by the consensus router. Nil in standalone mode.
+	FetchPackCacheSize func() uint32
 
 	// LoadFactorFees returns the LoadFeeTrack local/net/cluster fees
 	// driving the admin-only human-mode load_factor_local/net/cluster
@@ -973,6 +998,8 @@ type LedgerServerInfo struct {
 	ValidatedLedgerHash      [32]byte
 	ValidatedLedgerCloseTime int64 // Ripple-epoch seconds; 0 when unknown.
 	CompleteLedgers          string
+	HavePublished            bool
+	PublishedLedgerSeq       uint32
 	NetworkID                uint32
 }
 

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ default:
 
 # Build the xrpld binary into ../tmp/main (CGO + OpenSSL).
 build:
-    go build -v -o ../tmp/main ./cmd/xrpld
+    ./scripts/build.sh
 
 # Compile every package in the module.
 build-all:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+build_version="${VERSION:-$(git describe --tags --always --dirty)}"
+if [[ "$build_version" =~ [[:space:]] ]]; then
+    echo "VERSION must not contain whitespace" >&2
+    exit 2
+fi
+
+mkdir -p ../tmp
+go build -v \
+    -ldflags="-X=github.com/LeJamon/go-xrpl/version.Version=${build_version}" \
+    -o ../tmp/main ./cmd/xrpld

--- a/scripts/consensus-smoke/README.md
+++ b/scripts/consensus-smoke/README.md
@@ -32,7 +32,7 @@ smoke.
 
 ```
 # Build a goxrpl image from your branch first:
-docker build -t goxrpl:latest .
+docker build --build-arg "VERSION=$(git rev-parse HEAD)" -t goxrpl:latest .
 
 # Then run the smoke:
 bash scripts/consensus-smoke/smoke.sh

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1846,14 +1846,19 @@ conditions and JSON types.
 - Completed-ledger state is independent of the bounded history cache, preserves
   holes, owns each sequence by canonical hash, and rejects stale or canceled
   persistence across failures, online deletion, deep rollback, and sibling
-  forks. Publication state advances only at the ordered validated-event
-  boundary.
+  forks. Evicted sequences remain advertised only when they can be reconstructed
+  from durable storage. Publication holds gaps of 100 ledgers or fewer and
+  advances only at the ordered validated-event boundary.
 - `server_info` and `server_state` now apply rippled-compatible omission,
   visibility, and JSON-type rules for publication, ports, fetch-pack size,
   server domain, node size, and git revision. Runtime fields without an
   authoritative source are documented as unsupported.
-- Independent build, RPC/conformance, and ledger/concurrency reviews report no
-  remaining Blocking or Minor findings.
+- Finalization reviews found and resolved publication-gap skipping,
+  unretrievable completed-ledger ranges, stale sibling transaction indexes,
+  preferred-ledger movement across the validated frontier, false secure-port
+  advertisement, and stale build-output paths. Independent build,
+  RPC/conformance, and ledger/concurrency reviews report no remaining Blocking
+  or Minor findings.
 - Passing gates: focused tests (including 20-run sibling-fork stress), full
   ledger tests, ledger race tests, `just test-core`, `just vet`, strict
   `golangci-lint`, `just build`, `just build-all`, `just build-nocgo`, shell and

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1856,9 +1856,10 @@ conditions and JSON types.
 - Finalization reviews found and resolved publication-gap skipping,
   unretrievable completed-ledger ranges, stale sibling transaction indexes,
   preferred-ledger movement across the validated frontier, false secure-port
-  advertisement, and stale build-output paths. Independent build,
-  RPC/conformance, and ledger/concurrency reviews report no remaining Blocking
-  or Minor findings.
+  advertisement, stale build-output paths, and a numeric-selector regression
+  that returned the mutable open ledger instead of a snapshot. Independent
+  build, RPC/conformance, and ledger/concurrency reviews report no remaining
+  Blocking or Minor findings.
 - Passing gates: focused tests (including 20-run sibling-fork stress), full
   ledger tests, ledger race tests, `just test-core`, `just vet`, strict
   `golangci-lint`, `just build`, `just build-all`, `just build-nocgo`, shell and

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1802,3 +1802,63 @@ Behavioral oracle: clean local rippled `3.2.0` worktree at
 - Three independent final reviews found no Go-correctness, test-quality,
   verification, or rippled v3.2.0 conformance findings.
 - Published as PR #1411: https://github.com/LeJamon/go-xrpl/pull/1411.
+# Current Task - Issue #1420 server_info release and ledger-status parity
+
+## Goal
+
+Make production builds identify their exact go-xrpl revision and make
+`server_info` / `server_state` report publication, completed-ledger ranges, and
+supported runtime fields from authoritative state with rippled 3.2.0-compatible
+conditions and JSON types.
+
+## Plan
+
+- [x] Validate GitHub access, issue state/comments, linked PRs, repository
+      identity, default base branch, and clean worktree availability.
+- [x] Compare version, publication, completed-range, and remaining-field
+      requirements with the local rippled v3.2.0 oracle.
+- [x] Inject exact build identifiers into normal and production image builds,
+      and verify propagation through the final binary.
+- [x] Replace history-cache bounds with a real completed-ledger interval set,
+      preserving holes, cache eviction independence, invalidation, persistence
+      failure, and online-delete semantics.
+- [x] Track the actual ordered publication frontier and match
+      `published_ledger` omission, string, and numeric rules.
+- [x] Wire only fields with authoritative runtime sources: ports, fetch-pack
+      size, server domain, admin node size, and admin build revision.
+- [x] Document `load`, `counters`, and `current_activities` as unsupported until
+      equivalent job/performance instrumentation exists.
+- [x] Add focused tests for fresh startup, pre-validation, progress,
+      publication lag, history holes, visibility conditions, and build version.
+- [x] Run formatting, affected tests and race tests, build variants, vet, strict
+      lint, Docker image verification, and final diff/oracle review.
+- [x] Stage intentional files only, commit, push, open the PR, and verify the
+      published head.
+
+## Review
+
+- Base: `origin/main` at `239f7c543a581d7dbc180c46c958f4cedca6538c`.
+- Oracle: clean rippled `3.2.0` at
+  `3c43f4614f87965298773279ff5b85d4c56c637b`.
+- Production binaries and images now carry an exact revision; local builds use
+  `git describe --tags --always --dirty`. Docker validation covered missing,
+  `dev`, and full-SHA build arguments plus a live admin `server_info` response.
+- Completed-ledger state is independent of the bounded history cache, preserves
+  holes, owns each sequence by canonical hash, and rejects stale or canceled
+  persistence across failures, online deletion, deep rollback, and sibling
+  forks. Publication state advances only at the ordered validated-event
+  boundary.
+- `server_info` and `server_state` now apply rippled-compatible omission,
+  visibility, and JSON-type rules for publication, ports, fetch-pack size,
+  server domain, node size, and git revision. Runtime fields without an
+  authoritative source are documented as unsupported.
+- Independent build, RPC/conformance, and ledger/concurrency reviews report no
+  remaining Blocking or Minor findings.
+- Passing gates: focused tests (including 20-run sibling-fork stress), full
+  ledger tests, ledger race tests, `just test-core`, `just vet`, strict
+  `golangci-lint`, `just build`, `just build-all`, `just build-nocgo`, shell and
+  workflow syntax checks, and `git diff --check`.
+- The repository-wide `just test` still exits non-zero in the existing
+  conformance backlog; affected packages and the complete core group pass.
+
+---


### PR DESCRIPTION
## Summary

- inject exact revision metadata into local, CI, nightly, and Docker builds
- track authoritative completed-ledger ranges and ordered publication state
- expose supported `server_info` / `server_state` runtime fields with rippled-compatible visibility and JSON semantics
- make validated persistence fork-safe across cancellation, replacement, failures, and same-sequence siblings
- document runtime fields that do not yet have authoritative instrumentation

## Verification

- `just test-core`
- `go test ./internal/ledger/manager ./internal/ledger/service -count=1`
- `go test -race ./internal/ledger/manager ./internal/ledger/service -count=1`
- sibling-fork persistence regressions stressed for 20 runs
- `just vet`
- `golangci-lint run --config .golangci.yml`
- `just build`
- `just build-all`
- `just build-nocgo`
- Docker build-argument rejection, full-SHA image version, and live admin `server_info` revision checks
- shell/workflow syntax checks and `git diff --check`

The repository-wide `just test` continues to exit non-zero in the existing conformance backlog; the affected packages and complete core group pass.

Fixes #1420
