### PR TITLE
fix: prevent stale bootstrap frontier split

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -141,6 +141,9 @@ type Adaptor struct {
 	// by standalone adaptors and focused tests.
 	onLedgerRequested func(consensus.LedgerID) error
 
+	// Set once by NewRouter before the engine starts.
+	onLedgerSwitched func(seq uint32, hash, parentHash [32]byte, historyFloor uint32)
+
 	// onTxSetBuilt fires when BuildTxSet caches a new tx set, so the overlay
 	// can broadcast mtHAVE_SET{tsHAVE} for it. nil-safe.
 	onTxSetBuilt func(consensus.TxSetID)
@@ -543,6 +546,10 @@ func (a *Adaptor) SetOnTxSetRequested(cb func(consensus.TxSetID)) {
 
 func (a *Adaptor) SetOnLedgerRequested(cb func(consensus.LedgerID) error) {
 	a.onLedgerRequested = cb
+}
+
+func (a *Adaptor) setOnLedgerSwitched(cb func(uint32, [32]byte, [32]byte, uint32)) {
+	a.onLedgerSwitched = cb
 }
 
 func (a *Adaptor) RequestTxSet(id consensus.TxSetID) error {

--- a/internal/consensus/adaptor/consensus_events.go
+++ b/internal/consensus/adaptor/consensus_events.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
@@ -459,15 +460,55 @@ func (a *Adaptor) OnLedgerSwitched(ledger consensus.Ledger) error {
 	if ledger == nil {
 		return nil
 	}
+	var historyFloor uint32
+	switched := false
 	if wrapped, ok := ledger.(*LedgerWrapper); ok {
+		selected := wrapped.Unwrap()
+		historyFloor = switchedLedgerHistoryFloor(
+			selected,
+			a.ledgerService.GetClosedLedger(),
+			a.ledgerService.GetValidatedLedger(),
+		)
 		if err := a.ledgerService.SwitchToPreferredLedger(wrapped.Unwrap()); err != nil {
 			return fmt.Errorf("switch canonical closed ledger at sequence %d: %w", ledger.Seq(), err)
 		}
+		switched = true
 	}
 	id := ledger.ID()
 	parent := ledger.ParentID()
+	if switched && a.onLedgerSwitched != nil {
+		a.onLedgerSwitched(ledger.Seq(), [32]byte(id), [32]byte(parent), historyFloor)
+	}
 	a.broadcastSwitchedLedger(ledger.Seq(), id[:], parent[:])
 	return nil
+}
+
+func switchedLedgerHistoryFloor(selected, closed, validated *ledger.Ledger) uint32 {
+	if selected == nil || selected.Sequence() == 0 {
+		return 0
+	}
+	if closed != nil {
+		if selected.Hash() == closed.Hash() {
+			return selected.Sequence() - 1
+		}
+		if selected.Sequence() > closed.Sequence() &&
+			selected.Sequence()-closed.Sequence() == 1 &&
+			selected.ParentHash() == closed.Hash() {
+			return selected.Sequence() - 1
+		}
+	}
+
+	var floor uint32
+	for _, candidate := range []*ledger.Ledger{validated, closed} {
+		if candidate == nil || candidate.Sequence() >= selected.Sequence() || candidate.Sequence() <= floor {
+			continue
+		}
+		hash, ok, err := selected.HashOfSeq(candidate.Sequence())
+		if err == nil && ok && hash == candidate.Hash() {
+			floor = candidate.Sequence()
+		}
+	}
+	return floor
 }
 
 // networkTime is the current time-adjusted clock as ripple-epoch seconds, for

--- a/internal/consensus/adaptor/preferred_switch_integration_test.go
+++ b/internal/consensus/adaptor/preferred_switch_integration_test.go
@@ -40,18 +40,97 @@ func TestFreshNodeSwitchesToNetworkLedgerTwoBeforeFirstValidation(t *testing.T) 
 	networkHeader.Hash = header.CalculateHash(networkHeader)
 	require.NotEqual(t, local.Hash(), networkHeader.Hash)
 
-	bootstrapped, err := svc.BootstrapLedgerWithState(t.Context(), &networkHeader, stateMap, txMap)
+	initialCandidate, err := svc.BootstrapLedgerWithState(t.Context(), &networkHeader, stateMap, txMap)
 	require.NoError(t, err)
-	require.True(t, bootstrapped)
+	require.True(t, initialCandidate)
+	require.True(t, svc.NeedsInitialSync())
 	require.Equal(t, consensus.LedgerID{}, a.GetValidatedLedgerHash())
 
+	a.UpdatePeerLCL(1, consensus.LedgerID(networkHeader.Hash))
+	a.UpdatePeerLCL(2, consensus.LedgerID(networkHeader.Hash))
 	engine.TimerEntry()
 
+	require.False(t, svc.NeedsInitialSync())
 	require.Equal(t, consensus.ModeSwitchedLedger, engine.Mode())
 	state := engine.State()
 	require.NotNil(t, state)
 	require.Equal(t, uint32(3), state.Round.Seq)
 	require.Equal(t, networkHeader.Hash, state.Round.ParentHash)
+}
+
+func TestSlowInitialAcquisitionWaitsForCurrentConsensusSwitch(t *testing.T) {
+	svc := adg_newNonStandaloneService(t)
+	t.Cleanup(svc.Stop)
+	a := New(Config{LedgerService: svc})
+	a.SetOperatingMode(consensus.OpModeConnected)
+
+	local := svc.GetClosedLedger()
+	require.NotNil(t, local)
+	require.Equal(t, uint32(2), local.Sequence())
+
+	cfg := rcl.DefaultConfig()
+	cfg.ManualTick = true
+	engine := rcl.NewEngine(a, cfg)
+	require.NoError(t, engine.Start(t.Context()))
+	t.Cleanup(func() { require.NoError(t, engine.Stop()) })
+	require.NoError(t, engine.StartRound(consensus.RoundID{
+		Seq:        local.Sequence() + 1,
+		ParentHash: consensus.LedgerID(local.Hash()),
+	}, false))
+	router := NewRouter(engine, a, make(chan *peermanagement.InboundMessage, 1))
+
+	now := a.Now()
+	stale := completedCatchUpAcquisitionWithHeader(t, header.LedgerHeader{
+		LedgerIndex:         10_000,
+		ParentHash:          [32]byte{0xA0},
+		ParentCloseTime:     now.Add(-7 * time.Minute),
+		CloseTime:           now.Add(-7*time.Minute + time.Second),
+		CloseTimeResolution: 10,
+	})
+	router.fetchTracker.Track(stale)
+	a.UpdatePeerLCL(1, consensus.LedgerID(stale.Hash()))
+	a.UpdatePeerLCL(2, consensus.LedgerID(stale.Hash()))
+	engine.TimerEntry()
+	require.Equal(t, consensus.ModeWrongLedger, engine.Mode())
+
+	router.completeInboundLedger(stale)
+
+	storedStale, err := svc.GetLedgerByHash(stale.Hash())
+	require.NoError(t, err)
+	require.Equal(t, stale.Hash(), storedStale.Hash())
+	require.Equal(t, local.Hash(), svc.GetClosedLedger().Hash())
+	require.True(t, svc.NeedsInitialSync())
+	require.Equal(t, consensus.OpModeConnected, a.GetOperatingMode())
+	require.Equal(t, consensus.ModeWrongLedger, engine.Mode())
+	require.False(t, engine.IsProposing())
+	state := engine.State()
+	require.NotNil(t, state)
+	require.Equal(t, local.Hash(), state.Round.ParentHash)
+
+	fresh := completedCatchUpAcquisitionWithHeader(t, header.LedgerHeader{
+		LedgerIndex:         stale.Seq() + 1,
+		ParentHash:          stale.Hash(),
+		ParentCloseTime:     now.Add(-2 * time.Second),
+		CloseTime:           now,
+		CloseTimeResolution: 10,
+	})
+	router.fetchTracker.Track(fresh)
+	a.UpdatePeerLCL(1, consensus.LedgerID(fresh.Hash()))
+	a.UpdatePeerLCL(2, consensus.LedgerID(fresh.Hash()))
+	engine.TimerEntry()
+	require.Equal(t, consensus.ModeWrongLedger, engine.Mode())
+
+	router.completeInboundLedger(fresh)
+
+	require.False(t, svc.NeedsInitialSync())
+	require.Equal(t, fresh.Hash(), svc.GetClosedLedger().Hash())
+	require.Equal(t, consensus.OpModeTracking, a.GetOperatingMode())
+	require.Equal(t, consensus.ModeSwitchedLedger, engine.Mode())
+	require.False(t, engine.IsProposing())
+	state = engine.State()
+	require.NotNil(t, state)
+	require.Equal(t, fresh.Seq()+1, state.Round.Seq)
+	require.Equal(t, fresh.Hash(), state.Round.ParentHash)
 }
 
 func TestAcquiredValidatedTipSurvivesRecoveryTimerTick(t *testing.T) {

--- a/internal/consensus/adaptor/preferred_switch_integration_test.go
+++ b/internal/consensus/adaptor/preferred_switch_integration_test.go
@@ -131,6 +131,14 @@ func TestSlowInitialAcquisitionWaitsForCurrentConsensusSwitch(t *testing.T) {
 	require.NotNil(t, state)
 	require.Equal(t, fresh.Seq()+1, state.Round.Seq)
 	require.Equal(t, fresh.Hash(), state.Round.ParentHash)
+
+	svc.SetValidatedLedger(fresh.Seq(), fresh.Hash())
+	router.maintenanceTick()
+
+	historicalStale, err := svc.AdoptedLedgerBySequence(stale.Seq())
+	require.NoError(t, err)
+	require.Equal(t, stale.Hash(), historicalStale.Hash())
+	require.Equal(t, fresh.Hash(), svc.GetClosedLedger().Hash())
 }
 
 func TestAcquiredValidatedTipSurvivesRecoveryTimerTick(t *testing.T) {
@@ -138,6 +146,11 @@ func TestAcquiredValidatedTipSurvivesRecoveryTimerTick(t *testing.T) {
 	svc := a.ledgerService
 	stale := svc.GetClosedLedger()
 	require.NotNil(t, stale)
+	cfg := rcl.DefaultConfig()
+	cfg.ManualTick = true
+	engine := rcl.NewEngine(a, cfg)
+	require.NoError(t, engine.Start(t.Context()))
+	t.Cleanup(func() { require.NoError(t, engine.Stop()) })
 
 	stateMap, err := stale.StateMapSnapshot()
 	require.NoError(t, err)
@@ -160,13 +173,18 @@ func TestAcquiredValidatedTipSurvivesRecoveryTimerTick(t *testing.T) {
 	targetHeader.Validated = false
 
 	require.NoError(t, svc.StoreLedgerWithState(t.Context(), &targetHeader, stateMap, txMap))
-	svc.SetValidatedLedger(targetHeader.LedgerIndex, targetHeader.Hash)
-	require.Equal(t, targetHeader.Hash, svc.GetValidatedLedger().Hash())
+	validation := &consensus.Validation{
+		LedgerSeq: targetHeader.LedgerIndex,
+		LedgerID:  consensus.LedgerID(targetHeader.Hash),
+		SignTime:  a.Now(),
+		SeenTime:  a.Now(),
+		Full:      true,
+	}
+	require.NoError(t, a.SignValidation(validation))
+	require.NoError(t, engine.OnValidation(validation, 0))
+	require.Equal(t, stale.Hash(), svc.GetValidatedLedger().Hash())
 	require.Equal(t, stale.Hash(), svc.GetClosedLedger().Hash())
 
-	cfg := rcl.DefaultConfig()
-	cfg.ManualTick = true
-	engine := rcl.NewEngine(a, cfg)
 	require.NoError(t, engine.StartRound(consensus.RoundID{
 		Seq:        stale.Sequence() + 1,
 		ParentHash: consensus.LedgerID(stale.Hash()),
@@ -192,6 +210,11 @@ func TestAcquiredValidatedTipSurvivesMovingRecoveryTarget(t *testing.T) {
 	svc := a.ledgerService
 	stale := svc.GetClosedLedger()
 	require.NotNil(t, stale)
+	cfg := rcl.DefaultConfig()
+	cfg.ManualTick = true
+	engine := rcl.NewEngine(a, cfg)
+	require.NoError(t, engine.Start(t.Context()))
+	t.Cleanup(func() { require.NoError(t, engine.Stop()) })
 
 	stateMap, err := stale.StateMapSnapshot()
 	require.NoError(t, err)
@@ -214,12 +237,16 @@ func TestAcquiredValidatedTipSurvivesMovingRecoveryTarget(t *testing.T) {
 	targetHeader.Validated = false
 
 	require.NoError(t, svc.StoreLedgerWithState(t.Context(), &targetHeader, stateMap, txMap))
-	svc.SetValidatedLedger(targetHeader.LedgerIndex, targetHeader.Hash)
-	require.Equal(t, targetHeader.Hash, svc.GetValidatedLedger().Hash())
-
-	cfg := rcl.DefaultConfig()
-	cfg.ManualTick = true
-	engine := rcl.NewEngine(a, cfg)
+	validation := &consensus.Validation{
+		LedgerSeq: targetHeader.LedgerIndex,
+		LedgerID:  consensus.LedgerID(targetHeader.Hash),
+		SignTime:  a.Now(),
+		SeenTime:  a.Now(),
+		Full:      true,
+	}
+	require.NoError(t, a.SignValidation(validation))
+	require.NoError(t, engine.OnValidation(validation, 0))
+	require.Equal(t, stale.Hash(), svc.GetValidatedLedger().Hash())
 	require.NoError(t, engine.StartRound(consensus.RoundID{
 		Seq:        stale.Sequence() + 1,
 		ParentHash: consensus.LedgerID(stale.Hash()),

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -350,6 +350,7 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, inbox <-chan *peermana
 		// attempt-cap state.
 		adaptor.SetOnTxSetRequested(r.MarkTxSetStillNeeded)
 		adaptor.SetOnLedgerRequested(r.requestConsensusLedger)
+		adaptor.setOnLedgerSwitched(r.onLedgerSwitched)
 	}
 	return r
 }

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -386,17 +386,11 @@ func (r *Router) armPendingConsensusLedger() bool {
 					}
 					return false
 				}
-				r.acquisitionMu.Lock()
-				if r.consensusRecovery.targetHash != hash {
-					r.acquisitionMu.Unlock()
-					continue
+				accepted, rearm := r.tryConsensusLedgerSwitch(held.Sequence(), held.Hash())
+				if accepted || !rearm {
+					return true
 				}
-				r.consensusRecovery.anchorHash = held.Hash()
-				r.consensusRecovery.anchorSeq = held.Sequence()
-				r.consensusRecovery.targetHash = [32]byte{}
-				r.consensusRecovery.stepHash = [32]byte{}
-				r.acquisitionMu.Unlock()
-				return true
+				return false
 			}
 		}
 		seq, known := r.lookupSeqForHash(hash)
@@ -928,11 +922,23 @@ func (r *Router) startHistoryBackfill(seq uint32, hash [32]byte, peerID uint64, 
 	r.historyMu.Unlock()
 }
 
-// currentHistoryFloor returns the active backfill walk's lower bound.
-func (r *Router) currentHistoryFloor() uint32 {
+func (r *Router) onLedgerSwitched(seq uint32, _ [32]byte, parentHash [32]byte, historyFloor uint32) {
+	if seq == 0 {
+		return
+	}
+	r.startHistoryBackfill(seq-1, parentHash, 0, historyFloor)
+}
+
+func (r *Router) completeHistoryBackfill(seq uint32, hash, parentHash [32]byte, peerID uint64) {
+	if seq == 0 {
+		return
+	}
 	r.historyMu.Lock()
 	defer r.historyMu.Unlock()
-	return r.historyFloor
+	if r.history.seq != seq || r.history.hash != hash {
+		return
+	}
+	r.history = catchupTarget{seq: seq - 1, hash: parentHash, peerID: peerID}
 }
 
 // armHistoryBackfill drives one backward history-backfill acquisition from the
@@ -961,8 +967,10 @@ func (r *Router) armHistoryBackfill() {
 	for {
 		if target.seq == 0 || target.seq <= floor || target.hash == ([32]byte{}) || r.belowFloor(target.seq) {
 			r.historyMu.Lock()
-			r.history = catchupTarget{}
-			r.historyFloor = 0
+			if r.history == target && r.historyFloor == floor {
+				r.history = catchupTarget{}
+				r.historyFloor = 0
+			}
 			r.historyMu.Unlock()
 			return
 		}
@@ -970,10 +978,39 @@ func (r *Router) armHistoryBackfill() {
 		if err != nil || held == nil {
 			break
 		}
-		target = catchupTarget{seq: target.seq - 1, hash: held.ParentHash(), peerID: target.peerID}
+		hdr := held.Header()
+		stateMap, err := held.StateMapSnapshot()
+		if err != nil {
+			r.logger.Warn("history backfill: snapshot held ledger state failed",
+				"error", err, "seq", target.seq)
+			return
+		}
+		txMap, err := held.TxMapSnapshot()
+		if err != nil {
+			r.logger.Warn("history backfill: snapshot held ledger transactions failed",
+				"error", err, "seq", target.seq)
+			return
+		}
+		if err = svc.IngestHistoricalLedgerWithState(context.TODO(), &hdr, stateMap, txMap); err != nil {
+			r.logger.Warn("history backfill: held ledger ingest failed",
+				"error", err, "seq", target.seq)
+			return
+		}
+		next := catchupTarget{seq: target.seq - 1, hash: held.ParentHash(), peerID: target.peerID}
 		r.historyMu.Lock()
-		r.history = target
+		if r.history != target || r.historyFloor != floor {
+			r.historyMu.Unlock()
+			return
+		}
+		r.history = next
 		r.historyMu.Unlock()
+		target = next
+	}
+	r.historyMu.Lock()
+	stillCurrent := r.history == target && r.historyFloor == floor
+	r.historyMu.Unlock()
+	if !stillCurrent {
+		return
 	}
 	if r.fetchTracker.CountReason(inbound.ReasonHistory) >= 1 || r.isAcquiring(target.hash) {
 		return
@@ -982,24 +1019,39 @@ func (r *Router) armHistoryBackfill() {
 	if !ok {
 		return
 	}
-	r.startHistoryAcquisition(target.seq, target.hash, peer)
+	r.historyMu.Lock()
+	if r.history != target || r.historyFloor != floor {
+		r.historyMu.Unlock()
+		return
+	}
+	il := r.prepareHistoryAcquisition(target.seq, target.hash, peer)
+	r.historyMu.Unlock()
+	if il == nil {
+		return
+	}
+	r.requestHistoryAcquisition(il, peer)
 }
 
-// startHistoryAcquisition requests a skipped historical ledger (header + state)
-// over legacy mtGET_LEDGER as a ReasonHistory acquisition. Replay-delta doesn't
-// apply: the walk is backward, so the parent is never locally available.
-func (r *Router) startHistoryAcquisition(seq uint32, hash [32]byte, peerID uint64) {
+func (r *Router) prepareHistoryAcquisition(seq uint32, hash [32]byte, peerID uint64) *inbound.Ledger {
 	if r.replayer.Has(hash) {
-		return
+		return nil
 	}
 	il, created := r.fetchTracker.GetOrCreate(hash, func() *inbound.Ledger {
 		return inbound.NewHistory(hash, seq, peerID, r.logger, r.acquisitionOpts()...)
 	})
 	if !created {
-		return
+		return nil
 	}
+	return il
+}
+
+// requestHistoryAcquisition requests a skipped historical ledger (header +
+// state) over legacy mtGET_LEDGER. Replay-delta doesn't apply: the walk is
+// backward, so the parent is never locally available.
+func (r *Router) requestHistoryAcquisition(il *inbound.Ledger, peerID uint64) {
+	hash := il.Hash()
 	r.logger.Info("starting history backfill acquisition",
-		"seq", seq,
+		"seq", il.Seq(),
 		"hash", fmt.Sprintf("%x", hash[:8]),
 		"peer", peerID,
 	)
@@ -1317,19 +1369,67 @@ func (r *Router) completeStoredConsensusRecovery(seq uint32, hash, parentHash [3
 		return accepted
 	}
 
-	notify, rearm := r.finishConsensusRecoveryStep(seq, hash)
-	if notify && r.adaptor.GetOperatingMode() < consensus.OpModeTracking {
-		r.adaptor.SetOperatingMode(consensus.OpModeTracking)
-	}
-	if notify && r.engine != nil {
-		if err := r.engine.OnLedger(consensus.LedgerID(hash), nil); err != nil {
-			r.logger.Debug("engine rejected adopted ledger", "error", err, "seq", seq)
+	if !r.shouldSwitchConsensusLedger(seq, hash) {
+		_, rearm := r.finishConsensusRecoveryStep(seq, hash)
+		if rearm {
+			r.armConsensusCatchup()
 		}
+		return false
 	}
+
+	accepted, rearm := r.tryConsensusLedgerSwitch(seq, hash)
 	if rearm {
 		r.armConsensusCatchup()
 	}
-	return false
+	return accepted
+}
+
+func (r *Router) shouldSwitchConsensusLedger(seq uint32, hash [32]byte) bool {
+	frontierSeq, _, _ := r.bestCatchupTarget()
+	validatedRecovery := r.isCurrentValidatedLedger(seq, hash)
+
+	r.acquisitionMu.Lock()
+	defer r.acquisitionMu.Unlock()
+
+	target := r.consensusRecovery.targetHash
+	if target != ([32]byte{}) {
+		return target == hash || validatedRecovery && seq > r.lastHandoffSeq
+	}
+	if validatedRecovery && seq > r.lastHandoffSeq {
+		return true
+	}
+	return !aheadByMoreThan(frontierSeq, seq, 1) && seq > r.lastHandoffSeq
+}
+
+func (r *Router) tryConsensusLedgerSwitch(seq uint32, hash [32]byte) (accepted, rearm bool) {
+	result := consensus.LedgerSwitchIrrelevant
+	if r.engine != nil {
+		var err error
+		result, err = r.engine.TrySwitchToLedger(consensus.LedgerID(hash))
+		if err != nil {
+			r.logger.Debug("consensus ledger switch failed", "error", err, "seq", seq)
+			result = consensus.LedgerSwitchIrrelevant
+		}
+	}
+	if result != consensus.LedgerSwitchAccepted {
+		r.retainConsensusLedgerSwitch(hash)
+		return false, false
+	}
+
+	_, rearm = r.finishConsensusRecoveryStep(seq, hash)
+	if r.adaptor.GetOperatingMode() < consensus.OpModeTracking {
+		r.adaptor.SetOperatingMode(consensus.OpModeTracking)
+	}
+	return true, rearm
+}
+
+func (r *Router) retainConsensusLedgerSwitch(hash [32]byte) {
+	r.acquisitionMu.Lock()
+	defer r.acquisitionMu.Unlock()
+
+	if r.consensusRecovery.targetHash == ([32]byte{}) {
+		r.consensusRecovery.targetHash = hash
+	}
 }
 
 func (r *Router) finishConsensusRecoveryStep(seq uint32, hash [32]byte) (notify, rearm bool) {
@@ -1420,6 +1520,9 @@ func (r *Router) finishInitialLedgerSwitch(
 	}
 	target := r.consensusRecovery.targetHash
 	if result == consensus.LedgerSwitchBusy {
+		if target == ([32]byte{}) {
+			r.consensusRecovery.targetHash = hash
+		}
 		return false
 	}
 
@@ -1458,7 +1561,8 @@ func (r *Router) isCurrentValidatedLedger(seq uint32, hash [32]byte) bool {
 		return false
 	}
 	validated := svc.GetValidatedLedger()
-	return validated != nil && validated.Sequence() == seq && validated.Hash() == hash
+	return validated != nil && validated.Sequence() == seq && validated.Hash() == hash ||
+		svc.HasPendingLedgerValidation(seq, hash)
 }
 
 func (r *Router) recordConsensusHandoffLocked(seq uint32) {
@@ -1573,6 +1677,12 @@ func (r *Router) armValidationStashAcquisition(seq uint32, hash [32]byte) {
 	// closedSeq >> validatedSeq, leaving us stuck on the private chain
 	// forever.
 	if seq <= svc.GetValidatedLedgerIndex() {
+		return
+	}
+	if held, err := svc.GetLedgerByHash(hash); err == nil && held != nil && held.Sequence() == seq {
+		r.acquisitionMu.Lock()
+		r.consensusRecovery.targetHash = hash
+		r.acquisitionMu.Unlock()
 		return
 	}
 
@@ -2227,11 +2337,11 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 	recoveryTarget := r.consensusRecovery.targetHash == h.Hash
 	r.acquisitionMu.Unlock()
 
-	// A history backfill is a store-only ingest below the closed tip: persist,
-	// then advance the backward walk to its parent. Never touches operating mode
-	// or the consensus engine.
+	// A history backfill installs validated sequence history below the closed tip,
+	// then advances the backward walk to its parent. It never touches operating
+	// mode or the consensus engine.
 	if il.Reason() == inbound.ReasonHistory {
-		if err = svc.StoreLedgerWithState(context.TODO(), h, stateMap, txMap); err != nil {
+		if err = svc.IngestHistoricalLedgerWithState(context.TODO(), h, stateMap, txMap); err != nil {
 			r.logger.Warn("inbound ledger: history backfill ingest failed",
 				"error", err, "seq", h.LedgerIndex)
 			return
@@ -2239,7 +2349,7 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 		if recoveryTarget {
 			r.completeStoredConsensusRecovery(h.LedgerIndex, h.Hash, h.ParentHash, false)
 		} else {
-			r.startHistoryBackfill(h.LedgerIndex-1, h.ParentHash, peerID, r.currentHistoryFloor())
+			r.completeHistoryBackfill(h.LedgerIndex, h.Hash, h.ParentHash, peerID)
 		}
 		return
 	}
@@ -2268,7 +2378,6 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 		return
 	}
 
-	preBootstrapClosed := svc.GetClosedLedgerIndex()
 	initialCandidate, err := svc.BootstrapLedgerWithState(context.TODO(), h, stateMap, txMap)
 	if err != nil {
 		r.logger.Warn("inbound ledger: failed to store consensus ledger", "error", err, "seq", h.LedgerIndex)
@@ -2281,8 +2390,5 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 		"account_hash", fmt.Sprintf("%x", h.AccountHash[:8]),
 		"initial_candidate", initialCandidate,
 	)
-	switched := r.completeStoredConsensusRecovery(h.LedgerIndex, h.Hash, h.ParentHash, initialCandidate)
-	if switched && h.LedgerIndex > preBootstrapClosed+1 {
-		r.startHistoryBackfill(h.LedgerIndex-1, h.ParentHash, peerID, preBootstrapClosed)
-	}
+	r.completeStoredConsensusRecovery(h.LedgerIndex, h.Hash, h.ParentHash, initialCandidate)
 }

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -379,6 +379,13 @@ func (r *Router) armPendingConsensusLedger() bool {
 		svc := r.adaptor.LedgerService()
 		if svc != nil {
 			if held, err := svc.GetLedgerByHash(hash); err == nil && held != nil {
+				if svc.NeedsInitialSync() {
+					accepted, rearm := r.tryInitialLedgerSwitch(held.Sequence(), held.Hash())
+					if accepted || !rearm {
+						return true
+					}
+					return false
+				}
 				r.acquisitionMu.Lock()
 				if r.consensusRecovery.targetHash != hash {
 					r.acquisitionMu.Unlock()
@@ -1259,13 +1266,12 @@ func (r *Router) handleReplayDeltaResponse(msg *peermanagement.InboundMessage) {
 	}
 	r.replayer.Complete(rd.Hash())
 	if err := r.adoptVerifiedLedger(derived); err != nil {
-		r.logger.Warn("failed to adopt replay-delta ledger", "error", err)
+		r.logger.Warn("failed to store replay-delta ledger", "error", err)
 	}
 }
 
 // adoptVerifiedLedger stores a ledger reconstructed from a verified replay
-// delta. Only the first peer ledger establishes the service's initial frontier;
-// later ledgers remain hash-addressable until consensus selects them.
+// delta until consensus selects it as the canonical frontier.
 func (r *Router) adoptVerifiedLedger(l *ledger.Ledger) error {
 	svc := r.adaptor.LedgerService()
 	if svc == nil {
@@ -1276,9 +1282,9 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger) error {
 	if err != nil {
 		return fmt.Errorf("snapshot state map: %w", err)
 	}
-	// Pass the verified tx map through so the adopted ledger carries
+	// Pass the verified tx map through so the stored ledger carries
 	// real transactions — without this, tx/tx_history/account_tx RPCs
-	// can't answer for replay-delta-adopted ledgers and we can't
+	// can't answer for replay-delta ledgers and we can't
 	// re-serve the replay-delta to other peers.
 	txMap, err := l.TxMapSnapshot()
 	if err != nil {
@@ -1288,22 +1294,30 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger) error {
 	// handler stack that does not currently carry a context. Threading
 	// one through the message-dispatch chain is tracked separately from
 	// this issue (#185).
-	bootstrapped, err := svc.BootstrapLedgerWithState(context.TODO(), &hdr, stateMap, txMap)
+	initialCandidate, err := svc.BootstrapLedgerWithState(context.TODO(), &hdr, stateMap, txMap)
 	if err != nil {
 		return fmt.Errorf("store replay-delta ledger: %w", err)
 	}
 	r.logger.Info("acquired ledger via replay delta",
 		"seq", hdr.LedgerIndex,
 		"hash", fmt.Sprintf("%x", hdr.Hash[:8]),
-		"bootstrapped", bootstrapped,
+		"initial_candidate", initialCandidate,
 	)
-	r.completeStoredConsensusRecovery(hdr.LedgerIndex, hdr.Hash, hdr.ParentHash, bootstrapped)
+	r.completeStoredConsensusRecovery(hdr.LedgerIndex, hdr.Hash, hdr.ParentHash, initialCandidate)
 	return nil
 }
 
-func (r *Router) completeStoredConsensusRecovery(seq uint32, hash, parentHash [32]byte, bootstrapped bool) {
+func (r *Router) completeStoredConsensusRecovery(seq uint32, hash, parentHash [32]byte, initialCandidate bool) bool {
 	r.recordSeqHash(seq, hash, parentHash, true)
-	notify, rearm := r.finishConsensusRecoveryStepWithBootstrap(seq, hash, bootstrapped)
+	if initialCandidate {
+		accepted, rearm := r.tryInitialLedgerSwitch(seq, hash)
+		if rearm {
+			r.armConsensusCatchup()
+		}
+		return accepted
+	}
+
+	notify, rearm := r.finishConsensusRecoveryStep(seq, hash)
 	if notify && r.adaptor.GetOperatingMode() < consensus.OpModeTracking {
 		r.adaptor.SetOperatingMode(consensus.OpModeTracking)
 	}
@@ -1315,17 +1329,10 @@ func (r *Router) completeStoredConsensusRecovery(seq uint32, hash, parentHash [3
 	if rearm {
 		r.armConsensusCatchup()
 	}
+	return false
 }
 
 func (r *Router) finishConsensusRecoveryStep(seq uint32, hash [32]byte) (notify, rearm bool) {
-	return r.finishConsensusRecoveryStepWithBootstrap(seq, hash, false)
-}
-
-func (r *Router) finishConsensusRecoveryStepWithBootstrap(
-	seq uint32,
-	hash [32]byte,
-	bootstrapped bool,
-) (notify, rearm bool) {
 	frontierSeq, _, _ := r.bestCatchupTarget()
 	validatedRecovery := r.isCurrentValidatedLedger(seq, hash)
 
@@ -1349,10 +1356,6 @@ func (r *Router) finishConsensusRecoveryStepWithBootstrap(
 				r.consensusRecovery.anchorSeq = seq
 				r.consensusRecovery.anchorHash = hash
 			}
-			if bootstrapped {
-				r.recordConsensusHandoffLocked(seq)
-				return true, true
-			}
 			if validatedRecovery && seq > r.lastHandoffSeq {
 				r.recordConsensusHandoffLocked(seq)
 				return true, true
@@ -1367,10 +1370,6 @@ func (r *Router) finishConsensusRecoveryStepWithBootstrap(
 		return true, false
 	}
 
-	if bootstrapped {
-		r.recordConsensusHandoffLocked(seq)
-		return true, aheadByMoreThan(frontierSeq, seq, 0)
-	}
 	if validatedRecovery && seq > r.lastHandoffSeq {
 		r.recordConsensusHandoffLocked(seq)
 		return true, aheadByMoreThan(frontierSeq, seq, 0)
@@ -1383,6 +1382,71 @@ func (r *Router) finishConsensusRecoveryStepWithBootstrap(
 	}
 	r.lastHandoffSeq = seq
 	return true, false
+}
+
+func (r *Router) tryInitialLedgerSwitch(seq uint32, hash [32]byte) (accepted, rearm bool) {
+	result := consensus.LedgerSwitchIrrelevant
+	if r.engine != nil {
+		var err error
+		result, err = r.engine.TrySwitchToLedger(consensus.LedgerID(hash))
+		if err != nil {
+			r.logger.Debug("initial ledger switch failed", "error", err, "seq", seq)
+			result = consensus.LedgerSwitchIrrelevant
+		}
+	}
+
+	rearm = r.finishInitialLedgerSwitch(seq, hash, result)
+	if result == consensus.LedgerSwitchAccepted {
+		if r.adaptor.GetOperatingMode() < consensus.OpModeTracking {
+			r.adaptor.SetOperatingMode(consensus.OpModeTracking)
+		}
+		return true, rearm
+	}
+	return false, rearm
+}
+
+func (r *Router) finishInitialLedgerSwitch(
+	seq uint32,
+	hash [32]byte,
+	result consensus.LedgerSwitchResult,
+) bool {
+	frontierSeq, _, _ := r.bestCatchupTarget()
+
+	r.acquisitionMu.Lock()
+	defer r.acquisitionMu.Unlock()
+
+	if r.consensusRecovery.stepHash == hash {
+		r.consensusRecovery.stepHash = [32]byte{}
+	}
+	target := r.consensusRecovery.targetHash
+	if result == consensus.LedgerSwitchBusy {
+		return false
+	}
+
+	if target == hash {
+		r.consensusRecovery.anchorSeq = seq
+		r.consensusRecovery.anchorHash = hash
+		r.consensusRecovery.targetHash = [32]byte{}
+	}
+	if target != ([32]byte{}) && target != hash &&
+		r.recoveryAnchorReachesTarget(seq, hash, target) {
+		currentAnchorUsable := r.consensusRecovery.anchorHash != ([32]byte{}) &&
+			r.recoveryAnchorReachesTarget(
+				r.consensusRecovery.anchorSeq,
+				r.consensusRecovery.anchorHash,
+				target,
+			)
+		if !currentAnchorUsable || seq > r.consensusRecovery.anchorSeq {
+			r.consensusRecovery.anchorSeq = seq
+			r.consensusRecovery.anchorHash = hash
+		}
+	}
+
+	if result == consensus.LedgerSwitchAccepted {
+		r.recordConsensusHandoffLocked(seq)
+	}
+	return (target != ([32]byte{}) && target != hash) ||
+		aheadByMoreThan(frontierSeq, seq, 0)
 }
 
 func (r *Router) isCurrentValidatedLedger(seq uint32, hash [32]byte) bool {
@@ -2167,7 +2231,7 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 	// then advance the backward walk to its parent. Never touches operating mode
 	// or the consensus engine.
 	if il.Reason() == inbound.ReasonHistory {
-		if err = svc.AdoptLedgerWithState(context.TODO(), h, stateMap, txMap); err != nil {
+		if err = svc.StoreLedgerWithState(context.TODO(), h, stateMap, txMap); err != nil {
 			r.logger.Warn("inbound ledger: history backfill ingest failed",
 				"error", err, "seq", h.LedgerIndex)
 			return
@@ -2205,20 +2269,20 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 	}
 
 	preBootstrapClosed := svc.GetClosedLedgerIndex()
-	bootstrapped, err := svc.BootstrapLedgerWithState(context.TODO(), h, stateMap, txMap)
+	initialCandidate, err := svc.BootstrapLedgerWithState(context.TODO(), h, stateMap, txMap)
 	if err != nil {
 		r.logger.Warn("inbound ledger: failed to store consensus ledger", "error", err, "seq", h.LedgerIndex)
 		return
-	}
-	if bootstrapped && h.LedgerIndex > preBootstrapClosed+1 {
-		r.startHistoryBackfill(h.LedgerIndex-1, h.ParentHash, peerID, preBootstrapClosed)
 	}
 
 	r.logger.Info("acquired ledger with full state from peer",
 		"seq", h.LedgerIndex,
 		"hash", fmt.Sprintf("%x", h.Hash[:8]),
 		"account_hash", fmt.Sprintf("%x", h.AccountHash[:8]),
-		"bootstrapped", bootstrapped,
+		"initial_candidate", initialCandidate,
 	)
-	r.completeStoredConsensusRecovery(h.LedgerIndex, h.Hash, h.ParentHash, bootstrapped)
+	switched := r.completeStoredConsensusRecovery(h.LedgerIndex, h.Hash, h.ParentHash, initialCandidate)
+	if switched && h.LedgerIndex > preBootstrapClosed+1 {
+		r.startHistoryBackfill(h.LedgerIndex-1, h.ParentHash, peerID, preBootstrapClosed)
+	}
 }

--- a/internal/consensus/adaptor/router_catchup_bound_test.go
+++ b/internal/consensus/adaptor/router_catchup_bound_test.go
@@ -136,17 +136,21 @@ func TestRouter_InitialSyncPathStillArms(t *testing.T) {
 		"a fresh node in initial sync must still arm a bounded catch-up acquisition")
 }
 
-func TestRouter_InitialConsensusAcquisitionBootstrapsClosedLedger(t *testing.T) {
+func TestRouter_InitialConsensusAcquisitionStagesClosedLedger(t *testing.T) {
 	svc := adg_newNonStandaloneService(t)
 	a, _ := newRecordingAdaptor(t, svc)
 	r := NewRouter(nil, a, make(chan *peermanagement.InboundMessage, 8))
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
 	tipSeq := svc.GetClosedLedgerIndex() + 1
 	il := completedCatchUpAcquisition(t, tipSeq)
 	r.fetchTracker.Track(il)
 
 	r.completeInboundLedger(il)
 
-	require.False(t, svc.NeedsInitialSync())
-	require.Equal(t, tipSeq, svc.GetClosedLedgerIndex())
-	require.Equal(t, il.Hash(), svc.GetClosedLedger().Hash())
+	require.True(t, svc.NeedsInitialSync())
+	require.Equal(t, closed.Hash(), svc.GetClosedLedger().Hash())
+	stored, err := svc.GetLedgerByHash(il.Hash())
+	require.NoError(t, err)
+	require.Equal(t, tipSeq, stored.Sequence())
 }

--- a/internal/consensus/adaptor/router_catchup_handoff_test.go
+++ b/internal/consensus/adaptor/router_catchup_handoff_test.go
@@ -2,8 +2,10 @@ package adaptor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -11,7 +13,7 @@ import (
 func newCatchupHandoffRouter(t *testing.T) (*Router, *Adaptor, *mockEngine) {
 	t.Helper()
 	r, a, _, _ := makeRouter(t)
-	engine := &mockEngine{}
+	engine := &mockEngine{switchResult: consensus.LedgerSwitchAccepted}
 	r.engine = engine
 	a.SetOperatingMode(consensus.OpModeConnected)
 	return r, a, engine
@@ -112,23 +114,131 @@ func TestRejectedInitialCandidateRemainsStoreOnlyAnchor(t *testing.T) {
 }
 
 func TestBusyInitialCandidateRetainsTargetForRetry(t *testing.T) {
-	r, a, engine := newCatchupHandoffRouter(t)
+	svc := adg_newNonStandaloneService(t)
+	t.Cleanup(svc.Stop)
+	a := New(Config{LedgerService: svc})
+	a.SetOperatingMode(consensus.OpModeConnected)
+	engine := &mockEngine{}
+	engine.switchHook = func(id consensus.LedgerID) {
+		selected, err := a.GetLedger(id)
+		require.NoError(t, err)
+		require.NoError(t, a.OnLedgerSwitched(selected))
+	}
 	engine.switchResult = consensus.LedgerSwitchBusy
-	hash := [32]byte{0xF2}
-	r.consensusRecovery = consensusRecovery{targetHash: hash, stepHash: hash}
+	r := NewRouter(engine, a, nil)
 
-	switched := r.completeStoredConsensusRecovery(100, hash, [32]byte{0xF1}, true)
+	local := svc.GetClosedLedger()
+	require.NotNil(t, local)
+	stateMap, err := local.StateMapSnapshot()
+	require.NoError(t, err)
+	txMap, err := local.TxMapSnapshot()
+	require.NoError(t, err)
+	hdr := local.Header()
+	hdr.LedgerIndex = local.Sequence() + 5
+	hdr.ParentHash = [32]byte{0xF1}
+	hdr.Hash = header.CalculateHash(hdr)
+	initialCandidate, err := svc.BootstrapLedgerWithState(t.Context(), &hdr, stateMap, txMap)
+	require.NoError(t, err)
+	require.True(t, initialCandidate)
+
+	switched := r.completeStoredConsensusRecovery(
+		hdr.LedgerIndex,
+		hdr.Hash,
+		hdr.ParentHash,
+		initialCandidate,
+	)
 
 	assert.False(t, switched)
 	assert.Equal(t, consensus.OpModeConnected, a.GetOperatingMode())
 	assert.Equal(t, uint32(0), r.lastHandoffSeq)
-	assert.Equal(t, consensusRecovery{targetHash: hash}, r.consensusRecovery)
+	assert.Equal(t, consensusRecovery{targetHash: hdr.Hash}, r.consensusRecovery)
 
 	engine.switchResult = consensus.LedgerSwitchAccepted
-	switched = r.completeStoredConsensusRecovery(100, hash, [32]byte{0xF1}, true)
+	r.maintenanceTick()
 
-	assert.True(t, switched)
 	assert.Equal(t, consensus.OpModeTracking, a.GetOperatingMode())
-	assert.Equal(t, uint32(100), r.lastHandoffSeq)
-	assert.Equal(t, consensusRecovery{anchorHash: hash, anchorSeq: 100}, r.consensusRecovery)
+	assert.Equal(t, hdr.LedgerIndex, r.lastHandoffSeq)
+	assert.Equal(t, consensusRecovery{anchorHash: hdr.Hash, anchorSeq: hdr.LedgerIndex}, r.consensusRecovery)
+	assert.Equal(t, []consensus.LedgerID{
+		consensus.LedgerID(hdr.Hash),
+		consensus.LedgerID(hdr.Hash),
+	}, engine.getLedgers())
+
+	r.historyMu.Lock()
+	assert.Equal(t, catchupTarget{
+		seq:  hdr.LedgerIndex - 1,
+		hash: hdr.ParentHash,
+	}, r.history)
+	assert.Zero(t, r.historyFloor)
+	r.historyMu.Unlock()
+}
+
+func TestStoredConsensusCandidateRetriesUntilEngineAccepts(t *testing.T) {
+	tests := []struct {
+		name        string
+		firstResult consensus.LedgerSwitchResult
+	}{
+		{name: "busy", firstResult: consensus.LedgerSwitchBusy},
+		{name: "quorum unavailable", firstResult: consensus.LedgerSwitchIrrelevant},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := adg_newNonStandaloneService(t)
+			t.Cleanup(svc.Stop)
+			local := svc.GetClosedLedger()
+			require.NotNil(t, local)
+			require.NoError(t, svc.SwitchToPreferredLedger(local))
+
+			a := New(Config{LedgerService: svc})
+			a.SetOperatingMode(consensus.OpModeConnected)
+			engine := &mockEngine{switchResult: tt.firstResult}
+			engine.switchHook = func(id consensus.LedgerID) {
+				selected, err := a.GetLedger(id)
+				require.NoError(t, err)
+				require.NoError(t, a.OnLedgerSwitched(selected))
+			}
+			r := NewRouter(engine, a, nil)
+
+			stateMap, err := local.StateMapSnapshot()
+			require.NoError(t, err)
+			txMap, err := local.TxMapSnapshot()
+			require.NoError(t, err)
+			hdr := local.Header()
+			hdr.LedgerIndex = local.Sequence() + 5
+			hdr.ParentHash = [32]byte{0xF2}
+			hdr.Hash = header.CalculateHash(hdr)
+			initialCandidate, err := svc.BootstrapLedgerWithState(t.Context(), &hdr, stateMap, txMap)
+			require.NoError(t, err)
+			require.False(t, initialCandidate)
+
+			svc.SetValidatedLedgerAt(hdr.LedgerIndex, hdr.Hash, time.Now())
+			require.Eventually(t, func() bool {
+				r.acquisitionMu.Lock()
+				defer r.acquisitionMu.Unlock()
+				return r.consensusRecovery.targetHash == hdr.Hash
+			}, time.Second, time.Millisecond)
+			r.maintenanceTick()
+
+			assert.Equal(t, local.Hash(), svc.GetClosedLedger().Hash())
+			assert.Equal(t, consensus.OpModeConnected, a.GetOperatingMode())
+			assert.Equal(t, uint32(0), r.lastHandoffSeq)
+			assert.Equal(t, hdr.Hash, r.consensusRecovery.targetHash)
+
+			engine.switchResult = consensus.LedgerSwitchAccepted
+			r.maintenanceTick()
+
+			assert.Equal(t, hdr.Hash, svc.GetClosedLedger().Hash())
+			assert.Equal(t, consensus.OpModeTracking, a.GetOperatingMode())
+			assert.Equal(t, hdr.LedgerIndex, r.lastHandoffSeq)
+			assert.Equal(t, consensusRecovery{
+				anchorHash: hdr.Hash,
+				anchorSeq:  hdr.LedgerIndex,
+			}, r.consensusRecovery)
+			assert.Equal(t, []consensus.LedgerID{
+				consensus.LedgerID(hdr.Hash),
+				consensus.LedgerID(hdr.Hash),
+			}, engine.getLedgers())
+		})
+	}
 }

--- a/internal/consensus/adaptor/router_catchup_handoff_test.go
+++ b/internal/consensus/adaptor/router_catchup_handoff_test.go
@@ -85,6 +85,7 @@ func TestMovingCatchupFrontierEventuallyNotifies(t *testing.T) {
 
 func TestInitialBootstrapNotifiesBehindFrontier(t *testing.T) {
 	r, a, engine := newCatchupHandoffRouter(t)
+	engine.switchResult = consensus.LedgerSwitchAccepted
 	hash := [32]byte{0xF0}
 	r.recordCatchupTarget(200, [32]byte{0xF2}, 7)
 
@@ -93,4 +94,41 @@ func TestInitialBootstrapNotifiesBehindFrontier(t *testing.T) {
 	require.Equal(t, []consensus.LedgerID{consensus.LedgerID(hash)}, engine.getLedgers())
 	assert.Equal(t, consensus.OpModeTracking, a.GetOperatingMode())
 	assert.Equal(t, uint32(100), r.lastHandoffSeq)
+}
+
+func TestRejectedInitialCandidateRemainsStoreOnlyAnchor(t *testing.T) {
+	r, a, engine := newCatchupHandoffRouter(t)
+	engine.switchResult = consensus.LedgerSwitchRejected
+	hash := [32]byte{0xF1}
+	r.consensusRecovery = consensusRecovery{targetHash: hash, stepHash: hash}
+
+	switched := r.completeStoredConsensusRecovery(100, hash, [32]byte{0xF0}, true)
+
+	assert.False(t, switched)
+	require.Equal(t, []consensus.LedgerID{consensus.LedgerID(hash)}, engine.getLedgers())
+	assert.Equal(t, consensus.OpModeConnected, a.GetOperatingMode())
+	assert.Equal(t, uint32(0), r.lastHandoffSeq)
+	assert.Equal(t, consensusRecovery{anchorHash: hash, anchorSeq: 100}, r.consensusRecovery)
+}
+
+func TestBusyInitialCandidateRetainsTargetForRetry(t *testing.T) {
+	r, a, engine := newCatchupHandoffRouter(t)
+	engine.switchResult = consensus.LedgerSwitchBusy
+	hash := [32]byte{0xF2}
+	r.consensusRecovery = consensusRecovery{targetHash: hash, stepHash: hash}
+
+	switched := r.completeStoredConsensusRecovery(100, hash, [32]byte{0xF1}, true)
+
+	assert.False(t, switched)
+	assert.Equal(t, consensus.OpModeConnected, a.GetOperatingMode())
+	assert.Equal(t, uint32(0), r.lastHandoffSeq)
+	assert.Equal(t, consensusRecovery{targetHash: hash}, r.consensusRecovery)
+
+	engine.switchResult = consensus.LedgerSwitchAccepted
+	switched = r.completeStoredConsensusRecovery(100, hash, [32]byte{0xF1}, true)
+
+	assert.True(t, switched)
+	assert.Equal(t, consensus.OpModeTracking, a.GetOperatingMode())
+	assert.Equal(t, uint32(100), r.lastHandoffSeq)
+	assert.Equal(t, consensusRecovery{anchorHash: hash, anchorSeq: 100}, r.consensusRecovery)
 }

--- a/internal/consensus/adaptor/router_catchup_selfheal_test.go
+++ b/internal/consensus/adaptor/router_catchup_selfheal_test.go
@@ -21,18 +21,21 @@ func completedCatchUpAcquisition(t *testing.T, seq uint32) *inbound.Ledger {
 
 	var parentHash [32]byte
 	parentHash[0] = 0xEE // not in local history — forces the parentless path
-
-	rootHash, rootData, wire := buildSelfHealSourceState(t)
-	hdr := header.LedgerHeader{
+	return completedCatchUpAcquisitionWithHeader(t, header.LedgerHeader{
 		LedgerIndex: seq,
 		ParentHash:  parentHash,
-		AccountHash: rootHash,
-		// TxHash left zero: empty tx tree, complete once the state tree is filled.
-	}
+	})
+}
+
+func completedCatchUpAcquisitionWithHeader(t *testing.T, hdr header.LedgerHeader) *inbound.Ledger {
+	t.Helper()
+
+	rootHash, rootData, wire := buildSelfHealSourceState(t)
+	hdr.AccountHash = rootHash
 	data := header.AddRaw(hdr, false)
 	ledgerHash := sha512half.Sum(protocol.HashPrefixLedgerMaster().Bytes(), data)
 
-	il := inbound.New(ledgerHash, seq, 7, serveTestLogger())
+	il := inbound.New(ledgerHash, hdr.LedgerIndex, 7, serveTestLogger())
 	require.NoError(t, il.GotBase([]message.LedgerNode{
 		{NodeData: data},
 		{NodeData: rootData},

--- a/internal/consensus/adaptor/router_ledger_request_test.go
+++ b/internal/consensus/adaptor/router_ledger_request_test.go
@@ -81,7 +81,7 @@ func TestRouter_RequestLedger_NoPeers(t *testing.T) {
 
 func TestGenericAcquisitionJoinedByConsensusNotifiesExactTarget(t *testing.T) {
 	r, _, _, svc := makeRouter(t)
-	engine := &mockEngine{}
+	engine := &mockEngine{switchResult: consensus.LedgerSwitchAccepted}
 	r.engine = engine
 	rootHash, rootData, wire := buildSelfHealSourceState(t)
 	closed := svc.GetClosedLedger()

--- a/internal/consensus/adaptor/router_recovery_test.go
+++ b/internal/consensus/adaptor/router_recovery_test.go
@@ -19,7 +19,7 @@ func makeRouterWithEngine(t *testing.T) (*Router, *mockEngine, *service.Service)
 	svc := newTestLedgerService(t)
 	a, _ := newRecordingAdaptor(t, svc)
 	inbox := make(chan *peermanagement.InboundMessage, 8)
-	engine := &mockEngine{}
+	engine := &mockEngine{switchResult: consensus.LedgerSwitchAccepted}
 	r := NewRouter(engine, a, inbox)
 	return r, engine, svc
 }

--- a/internal/consensus/adaptor/router_replay_delta_test.go
+++ b/internal/consensus/adaptor/router_replay_delta_test.go
@@ -397,9 +397,7 @@ func TestRouter_ReplayDeltaResponse_Routed(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, seq, stored.Sequence())
 	assert.NotEqual(t, expectedHash, svc.GetClosedLedger().Hash())
-	// And the operating mode should be at least Tracking.
-	assert.True(t, a.GetOperatingMode() >= consensus.OpModeTracking,
-		"adoption should advance to Tracking or higher (was %s)", a.GetOperatingMode())
+	assert.Equal(t, consensus.OpModeDisconnected, a.GetOperatingMode())
 }
 
 // TestRouter_FallsBackToLegacyOnReplayFailure verifies that a malformed
@@ -644,7 +642,7 @@ func buildSuccessorAgainstParent(t *testing.T, parent *ledger.Ledger) (*message.
 
 func TestRouter_ConsensusRecoveryWalkNotifiesOnlyExactTarget(t *testing.T) {
 	r, a, sender, svc := makeRouter(t)
-	engine := &mockEngine{}
+	engine := &mockEngine{switchResult: consensus.LedgerSwitchAccepted}
 	r.engine = engine
 	_, err := svc.AcceptLedger(context.TODO())
 	require.NoError(t, err)
@@ -913,8 +911,7 @@ func TestRouter_ReplayDeltaStoresOutOfOrderArrivalsByHash(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, hashN2, gotN2.Hash())
 	assert.Equal(t, parentSeq, svc.GetClosedLedger().Sequence())
-	assert.True(t, a.GetOperatingMode() >= consensus.OpModeTracking,
-		"operating mode must be at least Tracking after acquisition (was %s)", a.GetOperatingMode())
+	assert.Equal(t, consensus.OpModeDisconnected, a.GetOperatingMode())
 }
 
 // A verified replay delta already carries a complete derived ledger, so storing
@@ -968,6 +965,111 @@ func TestRouter_ReplayDeltaStoresWithoutParentChase(t *testing.T) {
 
 	totalAutoArmCalls := len(rs.replayCalls()) + len(rs.legacyCalls())
 	require.Zero(t, totalAutoArmCalls)
+}
+
+func TestRouter_InitialReplaySwitchSchedulesHistoryBackfill(t *testing.T) {
+	svc := adg_newNonStandaloneService(t)
+	t.Cleanup(svc.Stop)
+	a, _ := newRecordingAdaptor(t, svc)
+	a.SetOperatingMode(consensus.OpModeConnected)
+	engine := &mockEngine{switchResult: consensus.LedgerSwitchAccepted}
+	engine.switchHook = func(id consensus.LedgerID) {
+		selected, err := a.GetLedger(id)
+		require.NoError(t, err)
+		require.NoError(t, a.OnLedgerSwitched(selected))
+	}
+	r := NewRouter(engine, a, make(chan *peermanagement.InboundMessage, 1))
+
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	_, anchor, anchorHash, anchorSeq := buildSuccessorAgainstParent(t, closed)
+	anchorState, err := anchor.StateMapSnapshot()
+	require.NoError(t, err)
+	anchorTx, err := anchor.TxMapSnapshot()
+	require.NoError(t, err)
+	anchorHeader := anchor.Header()
+	require.NoError(t, svc.StoreLedgerWithState(t.Context(), &anchorHeader, anchorState, anchorTx))
+
+	response, _, targetHash, targetSeq := buildSuccessorAgainstParent(t, anchor)
+	require.NoError(t, r.startReplayDeltaAcquisition(targetSeq, targetHash, 7, anchor))
+	payload, err := message.Encode(response)
+	require.NoError(t, err)
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    uint16(message.TypeReplayDeltaResponse),
+		Payload: payload,
+	})
+
+	require.Equal(t, []consensus.LedgerID{consensus.LedgerID(targetHash)}, engine.getLedgers())
+	r.historyMu.Lock()
+	assert.Equal(t, catchupTarget{seq: anchorSeq, hash: anchorHash}, r.history)
+	assert.Equal(t, closed.Sequence(), r.historyFloor)
+	r.historyMu.Unlock()
+}
+
+func TestRouter_LaterPreferredInitialSwitchSchedulesHistoryBackfill(t *testing.T) {
+	svc := adg_newNonStandaloneService(t)
+	t.Cleanup(svc.Stop)
+	a, _ := newRecordingAdaptor(t, svc)
+	engine := &mockEngine{switchResult: consensus.LedgerSwitchIrrelevant}
+	r := NewRouter(engine, a, nil)
+
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	_, anchor, anchorHash, anchorSeq := buildSuccessorAgainstParent(t, closed)
+	_, selected, selectedHash, selectedSeq := buildSuccessorAgainstParent(t, anchor)
+	stateMap, err := selected.StateMapSnapshot()
+	require.NoError(t, err)
+	txMap, err := selected.TxMapSnapshot()
+	require.NoError(t, err)
+	selectedHeader := selected.Header()
+	initialCandidate, err := svc.BootstrapLedgerWithState(t.Context(), &selectedHeader, stateMap, txMap)
+	require.NoError(t, err)
+	require.True(t, initialCandidate)
+	require.False(t, r.completeStoredConsensusRecovery(
+		selectedSeq,
+		selectedHash,
+		anchorHash,
+		initialCandidate,
+	))
+
+	r.historyMu.Lock()
+	assert.Equal(t, catchupTarget{}, r.history)
+	r.historyMu.Unlock()
+
+	require.NoError(t, a.OnLedgerSwitched(WrapLedger(selected)))
+
+	r.historyMu.Lock()
+	assert.Equal(t, catchupTarget{seq: anchorSeq, hash: anchorHash}, r.history)
+	assert.Equal(t, closed.Sequence(), r.historyFloor)
+	r.historyMu.Unlock()
+}
+
+func TestSwitchedLedgerHistoryFloorFallsBackFromForkedClosedLedger(t *testing.T) {
+	svc := newTestLedgerService(t)
+	validated := svc.GetClosedLedger()
+	require.NotNil(t, validated)
+	_, canonicalChild, _, _ := buildSuccessorAgainstParent(t, validated)
+	_, canonicalGrandchild, _, _ := buildSuccessorAgainstParent(t, canonicalChild)
+	_, selected, _, _ := buildSuccessorAgainstParent(t, canonicalGrandchild)
+
+	forkTime := canonicalChild.CloseTime().Add(time.Hour)
+	forkedClosed, err := ledger.NewOpen(validated, forkTime)
+	require.NoError(t, err)
+	require.NoError(t, forkedClosed.Close(forkTime, 0))
+	require.NotEqual(t, canonicalChild.Hash(), forkedClosed.Hash())
+	_, forkedGrandchild, _, _ := buildSuccessorAgainstParent(t, forkedClosed)
+	_, forkedGreatGrandchild, _, _ := buildSuccessorAgainstParent(t, forkedGrandchild)
+	_, laterForkedClosed, _, _ := buildSuccessorAgainstParent(t, forkedGreatGrandchild)
+
+	assert.Equal(t, validated.Sequence(), switchedLedgerHistoryFloor(selected, forkedClosed, validated))
+	assert.Equal(t, validated.Sequence(), switchedLedgerHistoryFloor(selected, laterForkedClosed, validated))
+	assert.Equal(t, validated.Sequence(), switchedLedgerHistoryFloor(canonicalGrandchild, forkedClosed, validated))
+	assert.Equal(t, canonicalGrandchild.Sequence()-1,
+		switchedLedgerHistoryFloor(canonicalGrandchild, canonicalChild, validated))
+	assert.Equal(t, canonicalChild.Sequence()-1, switchedLedgerHistoryFloor(canonicalChild, forkedClosed, validated))
+	assert.Equal(t, canonicalChild.Sequence()-1,
+		switchedLedgerHistoryFloor(canonicalChild, canonicalChild, validated))
 }
 
 // autoArmTarget returns the hash and seq of the single auto-armed

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -27,6 +27,7 @@ type mockEngine struct {
 	ledgers       []consensus.LedgerID
 	acquireFailed []consensus.LedgerID
 	switchResult  consensus.LedgerSwitchResult
+	switchHook    func(consensus.LedgerID)
 }
 
 func (m *mockEngine) Start(context.Context) error              { return nil }
@@ -50,9 +51,14 @@ func (m *mockEngine) OnLedger(id consensus.LedgerID, _ []byte) error {
 
 func (m *mockEngine) TrySwitchToLedger(id consensus.LedgerID) (consensus.LedgerSwitchResult, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.ledgers = append(m.ledgers, id)
-	return m.switchResult, nil
+	result := m.switchResult
+	hook := m.switchHook
+	m.mu.Unlock()
+	if result == consensus.LedgerSwitchAccepted && hook != nil {
+		hook(id)
+	}
+	return result, nil
 }
 
 func (m *mockEngine) OnLedgerAcquireFailed(id consensus.LedgerID) {

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -26,6 +26,7 @@ type mockEngine struct {
 	txSets        []consensus.TxSetID
 	ledgers       []consensus.LedgerID
 	acquireFailed []consensus.LedgerID
+	switchResult  consensus.LedgerSwitchResult
 }
 
 func (m *mockEngine) Start(context.Context) error              { return nil }
@@ -45,6 +46,13 @@ func (m *mockEngine) OnLedger(id consensus.LedgerID, _ []byte) error {
 	defer m.mu.Unlock()
 	m.ledgers = append(m.ledgers, id)
 	return nil
+}
+
+func (m *mockEngine) TrySwitchToLedger(id consensus.LedgerID) (consensus.LedgerSwitchResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ledgers = append(m.ledgers, id)
+	return m.switchResult, nil
 }
 
 func (m *mockEngine) OnLedgerAcquireFailed(id consensus.LedgerID) {

--- a/internal/consensus/adaptor/router_wrong_ledger_acquisition_test.go
+++ b/internal/consensus/adaptor/router_wrong_ledger_acquisition_test.go
@@ -42,15 +42,15 @@ func TestAdaptorRequestLedgerTracksExactConsensusTarget(t *testing.T) {
 	assert.Nil(t, r.fetchTracker.Find(target), "matching reply must be consumed by the tracked acquisition")
 }
 
-func TestHeldConsensusTargetDoesNotReenterEngine(t *testing.T) {
+func TestHeldConsensusTargetRequiresEngineAcceptance(t *testing.T) {
 	r, _, _, svc := makeRouter(t)
-	engine := &mockEngine{}
+	engine := &mockEngine{switchResult: consensus.LedgerSwitchAccepted}
 	r.engine = engine
 	target := svc.GetClosedLedger().Hash()
 	r.consensusRecovery.targetHash = target
 
 	require.True(t, r.armPendingConsensusLedger())
-	assert.Empty(t, engine.getLedgers())
+	assert.Equal(t, []consensus.LedgerID{consensus.LedgerID(target)}, engine.getLedgers())
 	assert.Equal(t, consensusRecovery{
 		anchorHash: target,
 		anchorSeq:  svc.GetClosedLedgerIndex(),
@@ -307,6 +307,21 @@ func TestHistoryBackfillWaitsForConsensusCatchup(t *testing.T) {
 	r.armHistoryBackfill()
 	require.NotNil(t, r.fetchTracker.Find(historyHash))
 	assert.Len(t, sender.legacyCalls(), 1)
+}
+
+func TestSupersededHistoryCompletionDoesNotOverwriteNewWalk(t *testing.T) {
+	r, _, _, _ := makeRouter(t)
+	oldHash := [32]byte{0xC3}
+	newHash := [32]byte{0xC4}
+	r.startHistoryBackfill(90, oldHash, 7, 10)
+	r.startHistoryBackfill(190, newHash, 8, 20)
+
+	r.completeHistoryBackfill(90, oldHash, [32]byte{0xC2}, 7)
+
+	r.historyMu.Lock()
+	defer r.historyMu.Unlock()
+	assert.Equal(t, catchupTarget{seq: 190, hash: newHash, peerID: 8}, r.history)
+	assert.Equal(t, uint32(20), r.historyFloor)
 }
 
 func TestBehindPeerCannotPromoteWhileNetworkTargetIsAhead(t *testing.T) {

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -27,6 +27,11 @@ type Engine interface {
 
 	OnLedger(id LedgerID, ledger []byte) error
 
+	// TrySwitchToLedger synchronously attempts to make a locally-held ledger
+	// the consensus parent. The candidate must be the exact wrong-ledger
+	// recovery target, the validated tip, or the current network preference.
+	TrySwitchToLedger(id LedgerID) (LedgerSwitchResult, error)
+
 	// OnLedgerAcquireFailed reports a clean inbound-acquire failure after the
 	// retry budget. Lets a node pinned in wrongLedger un-pin and drop to
 	// degraded resync rather than starving the stall watchdog into os.Exit.
@@ -52,6 +57,16 @@ type Engine interface {
 	// fires events on its own goroutine, so OnEvent must not block.
 	Subscribe(sub EventSubscriber)
 }
+
+// LedgerSwitchResult describes the outcome of a synchronous ledger switch.
+type LedgerSwitchResult uint8
+
+const (
+	LedgerSwitchIrrelevant LedgerSwitchResult = iota
+	LedgerSwitchAccepted
+	LedgerSwitchBusy
+	LedgerSwitchRejected
+)
 
 // ValidationHistorian exposes the validation subsystem to an adaptor:
 // per-ledger trusted-validation lookups and trie-based preferred-LCL

--- a/internal/consensus/rcl/engine_handlers.go
+++ b/internal/consensus/rcl/engine_handlers.go
@@ -342,12 +342,17 @@ func (e *Engine) OnLedger(id consensus.LedgerID, ledger []byte) error {
 	defer e.mu.Unlock()
 
 	recovering := e.mode == consensus.ModeWrongLedger
-	validatedTip := e.adaptor.GetValidatedLedgerHash() == id
 	exactRecoveryTarget := recovering && id == e.wrongLedgerID
-	if recovering && !exactRecoveryTarget && !validatedTip {
+	l, err := e.adaptor.GetLedger(id)
+	if err != nil || l == nil {
 		return nil
 	}
-	if !recovering && !validatedTip {
+	validatedCandidate := e.adaptor.GetValidatedLedgerHash() == id ||
+		e.isQuorumValidatedCandidateLocked(l)
+	if recovering && !exactRecoveryTarget && !validatedCandidate {
+		return nil
+	}
+	if !recovering && !validatedCandidate {
 		return nil
 	}
 	slog.Info("Recovery ledger completion received",
@@ -356,17 +361,6 @@ func (e *Engine) OnLedger(id consensus.LedgerID, ledger []byte) error {
 		"hash", fmt.Sprintf("%x", id[:8]),
 		"build_in_progress", e.buildInProgress,
 	)
-
-	l, err := e.adaptor.GetLedger(id)
-	if err != nil || l == nil {
-		slog.Info("Completed recovery ledger is not locally available",
-			"t", "consensus",
-			"event", "recovery-ledger-unavailable",
-			"hash", fmt.Sprintf("%x", id[:8]),
-			"error", err,
-		)
-		return nil
-	}
 
 	// acceptLedger applies off-lock like rippled's serialized jtACCEPT job.
 	// Retain the newest completed recovery acquisition until its commit tail
@@ -389,17 +383,18 @@ func (e *Engine) TrySwitchToLedger(id consensus.LedgerID) (consensus.LedgerSwitc
 	defer e.mu.Unlock()
 
 	exactRecoveryTarget := e.mode == consensus.ModeWrongLedger && id == e.wrongLedgerID
-	validatedTip := e.adaptor.GetValidatedLedgerHash() == id
 	networkPreferred := e.prevLedger != nil && e.getNetworkLedger() == id
-	if !exactRecoveryTarget && !validatedTip && !networkPreferred {
-		return consensus.LedgerSwitchIrrelevant, nil
-	}
 
 	l, err := e.adaptor.GetLedger(id)
 	if err != nil {
 		return consensus.LedgerSwitchIrrelevant, err
 	}
 	if l == nil {
+		return consensus.LedgerSwitchIrrelevant, nil
+	}
+	validatedCandidate := e.adaptor.GetValidatedLedgerHash() == id ||
+		e.isQuorumValidatedCandidateLocked(l)
+	if !exactRecoveryTarget && !validatedCandidate && !networkPreferred {
 		return consensus.LedgerSwitchIrrelevant, nil
 	}
 	if e.buildInProgress {
@@ -413,14 +408,15 @@ func (e *Engine) TrySwitchToLedger(id consensus.LedgerID) (consensus.LedgerSwitc
 
 func (e *Engine) switchToAcquiredLedgerLocked(id consensus.LedgerID, l consensus.Ledger) bool {
 	exactRecoveryTarget := e.mode == consensus.ModeWrongLedger && id == e.wrongLedgerID
-	validatedTip := e.adaptor.GetValidatedLedgerHash() == id
-	if e.mode == consensus.ModeWrongLedger && !exactRecoveryTarget && !validatedTip {
+	validatedCandidate := e.adaptor.GetValidatedLedgerHash() == id ||
+		e.isQuorumValidatedCandidateLocked(l)
+	if e.mode == consensus.ModeWrongLedger && !exactRecoveryTarget && !validatedCandidate {
 		return false
 	}
 	// Never regress on out-of-order acquisition arrivals — EXCEPT for the hash
 	// checkLedger explicitly pinned: the preferred ledger may be on a lower
 	// sequence of another chain.
-	if e.prevLedger != nil && l.Seq() <= e.prevLedger.Seq() && !exactRecoveryTarget && !validatedTip {
+	if e.prevLedger != nil && l.Seq() <= e.prevLedger.Seq() && !exactRecoveryTarget && !validatedCandidate {
 		return false
 	}
 	if e.mode != consensus.ModeWrongLedger {
@@ -433,6 +429,17 @@ func (e *Engine) switchToAcquiredLedgerLocked(id consensus.LedgerID, l consensus
 		}
 	}
 	return e.switchToLedgerLocked(id, l)
+}
+
+// isQuorumValidatedCandidateLocked rechecks the live trusted-validation set
+// without advancing the adaptor's accepted validated tip. The selected ledger
+// still passes canSwitchToLedgerLocked before it can become current.
+func (e *Engine) isQuorumValidatedCandidateLocked(l consensus.Ledger) bool {
+	if l == nil || e.validationTracker == nil || e.adaptor.IsQuorumUnavailable() {
+		return false
+	}
+	_, _, accepted := e.validationTracker.RecheckFullyValidated(l.ID(), l.Seq())
+	return accepted
 }
 
 func (e *Engine) switchToLedgerLocked(id consensus.LedgerID, l consensus.Ledger) bool {

--- a/internal/consensus/rcl/engine_handlers.go
+++ b/internal/consensus/rcl/engine_handlers.go
@@ -382,6 +382,35 @@ func (e *Engine) OnLedger(id consensus.LedgerID, ledger []byte) error {
 	return nil
 }
 
+// TrySwitchToLedger synchronously evaluates and adopts a locally-held ledger
+// selected by consensus recovery, validation, or the current network view.
+func (e *Engine) TrySwitchToLedger(id consensus.LedgerID) (consensus.LedgerSwitchResult, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	exactRecoveryTarget := e.mode == consensus.ModeWrongLedger && id == e.wrongLedgerID
+	validatedTip := e.adaptor.GetValidatedLedgerHash() == id
+	networkPreferred := e.prevLedger != nil && e.getNetworkLedger() == id
+	if !exactRecoveryTarget && !validatedTip && !networkPreferred {
+		return consensus.LedgerSwitchIrrelevant, nil
+	}
+
+	l, err := e.adaptor.GetLedger(id)
+	if err != nil {
+		return consensus.LedgerSwitchIrrelevant, err
+	}
+	if l == nil {
+		return consensus.LedgerSwitchIrrelevant, nil
+	}
+	if e.buildInProgress {
+		return consensus.LedgerSwitchBusy, nil
+	}
+	if !e.switchToLedgerLocked(id, l) {
+		return consensus.LedgerSwitchRejected, nil
+	}
+	return consensus.LedgerSwitchAccepted, nil
+}
+
 func (e *Engine) switchToAcquiredLedgerLocked(id consensus.LedgerID, l consensus.Ledger) bool {
 	exactRecoveryTarget := e.mode == consensus.ModeWrongLedger && id == e.wrongLedgerID
 	validatedTip := e.adaptor.GetValidatedLedgerHash() == id
@@ -403,6 +432,10 @@ func (e *Engine) switchToAcquiredLedgerLocked(id consensus.LedgerID, l consensus
 			l = next
 		}
 	}
+	return e.switchToLedgerLocked(id, l)
+}
+
+func (e *Engine) switchToLedgerLocked(id consensus.LedgerID, l consensus.Ledger) bool {
 	if !e.canSwitchToLedgerLocked(l) {
 		if e.lastRefusedSwitch != id {
 			e.lastRefusedSwitch = id

--- a/internal/consensus/rcl/engine_onledger_test.go
+++ b/internal/consensus/rcl/engine_onledger_test.go
@@ -314,6 +314,145 @@ func TestEngine_OnLedger_IgnoresOrdinaryAcquisitionOutsideRecovery(t *testing.T)
 	}
 }
 
+func TestEngine_TrySwitchToLedger_AcceptsEligibleLedger(t *testing.T) {
+	tests := []struct {
+		name         string
+		selectLedger func(*Engine, *mockAdaptor, consensus.LedgerID)
+	}{
+		{
+			name: "exact wrong-ledger target",
+			selectLedger: func(e *Engine, _ *mockAdaptor, id consensus.LedgerID) {
+				e.mode = consensus.ModeWrongLedger
+				e.wrongLedgerID = id
+			},
+		},
+		{
+			name: "validated tip",
+			selectLedger: func(e *Engine, a *mockAdaptor, id consensus.LedgerID) {
+				e.mode = consensus.ModeObserving
+				a.validatedLedgerHashOverride = id
+			},
+		},
+		{
+			name: "network preference",
+			selectLedger: func(e *Engine, a *mockAdaptor, id consensus.LedgerID) {
+				e.mode = consensus.ModeObserving
+				a.peerLCLs = []consensus.LedgerID{id, id}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := newMockAdaptor()
+			e := NewEngine(a, DefaultConfig())
+			initial := a.ledgers[consensus.LedgerID{1}]
+			target := chainLedger(101, 101, 1)
+			a.ledgers[target.ID()] = target
+			descendant := chainLedger(102, 102, 101)
+			a.ledgers[descendant.ID()] = descendant
+			e.prevLedger = initial
+			tt.selectLedger(e, a, target.ID())
+
+			got, err := e.TrySwitchToLedger(target.ID())
+			if err != nil {
+				t.Fatalf("TrySwitchToLedger: %v", err)
+			}
+			if got != consensus.LedgerSwitchAccepted {
+				t.Fatalf("result = %v, want Accepted", got)
+			}
+			if e.prevLedger.ID() != target.ID() {
+				t.Fatal("eligible ledger was not selected")
+			}
+			if got := e.Mode(); got != consensus.ModeSwitchedLedger {
+				t.Fatalf("mode = %v, want switchedLedger", got)
+			}
+			if len(a.switchedLedgers) != 1 || a.switchedLedgers[0].ID() != target.ID() {
+				t.Fatalf("switched ledgers = %v, want target", a.switchedLedgers)
+			}
+		})
+	}
+}
+
+func TestEngine_TrySwitchToLedger_ReturnsBusyWithoutQueuing(t *testing.T) {
+	a := newMockAdaptor()
+	e := NewEngine(a, DefaultConfig())
+	initial := a.ledgers[consensus.LedgerID{1}]
+	target := chainLedger(101, 101, 1)
+	a.ledgers[target.ID()] = target
+	e.prevLedger = initial
+	e.mode = consensus.ModeWrongLedger
+	e.wrongLedgerID = target.ID()
+	e.buildInProgress = true
+
+	got, err := e.TrySwitchToLedger(target.ID())
+	if err != nil {
+		t.Fatalf("TrySwitchToLedger: %v", err)
+	}
+	if got != consensus.LedgerSwitchBusy {
+		t.Fatalf("result = %v, want Busy", got)
+	}
+	if e.prevLedger.ID() != initial.ID() {
+		t.Fatal("busy switch changed the consensus parent")
+	}
+	if e.pendingRecoveryLedger != nil {
+		t.Fatal("synchronous switch queued a deferred recovery ledger")
+	}
+	if len(a.switchedLedgers) != 0 {
+		t.Fatal("busy switch announced a ledger change")
+	}
+}
+
+func TestEngine_TrySwitchToLedger_RejectsUnsafeLedger(t *testing.T) {
+	a := newMockAdaptor()
+	e := NewEngine(a, DefaultConfig())
+	initial := a.ledgers[consensus.LedgerID{1}]
+	target := chainLedger(101, 101, 1)
+	target.closeTime = a.Now().Add(-6 * time.Minute)
+	a.ledgers[target.ID()] = target
+	a.validatedLedgerHashOverride = target.ID()
+	e.prevLedger = initial
+	e.mode = consensus.ModeObserving
+
+	got, err := e.TrySwitchToLedger(target.ID())
+	if err != nil {
+		t.Fatalf("TrySwitchToLedger: %v", err)
+	}
+	if got != consensus.LedgerSwitchRejected {
+		t.Fatalf("result = %v, want Rejected", got)
+	}
+	if e.prevLedger.ID() != initial.ID() {
+		t.Fatal("rejected switch changed the consensus parent")
+	}
+	if len(a.switchedLedgers) != 0 {
+		t.Fatal("rejected switch announced a ledger change")
+	}
+}
+
+func TestEngine_TrySwitchToLedger_IgnoresUnselectedLedger(t *testing.T) {
+	a := newMockAdaptor()
+	e := NewEngine(a, DefaultConfig())
+	initial := a.ledgers[consensus.LedgerID{1}]
+	target := chainLedger(101, 101, 1)
+	a.ledgers[target.ID()] = target
+	e.prevLedger = initial
+	e.mode = consensus.ModeObserving
+
+	got, err := e.TrySwitchToLedger(target.ID())
+	if err != nil {
+		t.Fatalf("TrySwitchToLedger: %v", err)
+	}
+	if got != consensus.LedgerSwitchIrrelevant {
+		t.Fatalf("result = %v, want Irrelevant", got)
+	}
+	if e.prevLedger.ID() != initial.ID() {
+		t.Fatal("irrelevant switch changed the consensus parent")
+	}
+	if len(a.switchedLedgers) != 0 {
+		t.Fatal("irrelevant switch announced a ledger change")
+	}
+}
+
 func TestEngine_CurrentPreferredLCL_RejectsValidatedTipAhead(t *testing.T) {
 	a := newMockAdaptor()
 	e := NewEngine(a, DefaultConfig())

--- a/internal/consensus/rcl/engine_onledger_test.go
+++ b/internal/consensus/rcl/engine_onledger_test.go
@@ -20,6 +20,24 @@ func chainLedger(seq uint32, idb, pb byte) *mockLedger {
 	}
 }
 
+func stageQuorumValidatedLedger(e *Engine, a *mockAdaptor, l consensus.Ledger) {
+	nodes := []consensus.NodeID{{0x21}, {0x22}}
+	e.validationTracker = NewValidationTracker(len(nodes), 5*time.Minute)
+	e.validationTracker.SetTrustedAndQuorum(nodes, len(nodes))
+	e.validationTracker.SetNow(a.Now)
+	now := a.Now()
+	for _, node := range nodes {
+		e.validationTracker.Add(&consensus.Validation{
+			NodeID:    node,
+			LedgerID:  l.ID(),
+			LedgerSeq: l.Seq(),
+			Full:      true,
+			SignTime:  now,
+			SeenTime:  now,
+		})
+	}
+}
+
 func TestEngine_OnLedger_SelectsExactWrongLedgerTarget(t *testing.T) {
 	a := newMockAdaptor()
 	e := NewEngine(a, DefaultConfig())
@@ -295,6 +313,29 @@ func TestEngine_OnLedger_UsesValidatedTipOutsideRecovery(t *testing.T) {
 	}
 }
 
+func TestEngine_OnLedger_UsesQuorumValidatedCandidateBeforeTipAdvances(t *testing.T) {
+	a := newMockAdaptor()
+	e := NewEngine(a, DefaultConfig())
+	initial := a.ledgers[consensus.LedgerID{1}]
+	target := chainLedger(105, 105, 104)
+	a.StoreLedger(target)
+	stageQuorumValidatedLedger(e, a, target)
+
+	e.prevLedger = initial
+	e.mode = consensus.ModeObserving
+
+	if err := e.OnLedger(target.ID(), nil); err != nil {
+		t.Fatalf("OnLedger: %v", err)
+	}
+	if got := e.prevLedger.ID(); got != target.ID() {
+		want := target.ID()
+		t.Fatalf("prevLedger = %x, want quorum-validated candidate %x", got[:2], want[:2])
+	}
+	if got := e.Mode(); got != consensus.ModeSwitchedLedger {
+		t.Fatalf("mode = %v, want switchedLedger", got)
+	}
+}
+
 func TestEngine_OnLedger_IgnoresOrdinaryAcquisitionOutsideRecovery(t *testing.T) {
 	a := newMockAdaptor()
 	e := NewEngine(a, DefaultConfig())
@@ -331,6 +372,13 @@ func TestEngine_TrySwitchToLedger_AcceptsEligibleLedger(t *testing.T) {
 			selectLedger: func(e *Engine, a *mockAdaptor, id consensus.LedgerID) {
 				e.mode = consensus.ModeObserving
 				a.validatedLedgerHashOverride = id
+			},
+		},
+		{
+			name: "quorum validated candidate",
+			selectLedger: func(e *Engine, a *mockAdaptor, id consensus.LedgerID) {
+				e.mode = consensus.ModeObserving
+				stageQuorumValidatedLedger(e, a, a.ledgers[id])
 			},
 		},
 		{

--- a/internal/ledger/service/cache.go
+++ b/internal/ledger/service/cache.go
@@ -309,6 +309,15 @@ type pendingValidationEntry struct {
 // 10min covers deep-gap catch-up (one backward hop per peer round-trip)
 const pendingValidationTTL = 10 * time.Minute
 
+// HasPendingLedgerValidation reports whether seq and hash still have a
+// non-expired trusted-validation notification awaiting canonical selection.
+func (s *Service) HasPendingLedgerValidation(seq uint32, hash [32]byte) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.pendingLedgerValidations[seq]
+	return ok && entry.expectedHash == hash && time.Since(entry.at) < pendingValidationTTL
+}
+
 // stashPendingLedgerValidationLocked stores a (seq, expectedHash, at) entry
 // drained when ledgerHistory[seq] lands, LRU-evicting at the cap.
 // Caller must hold s.mu.

--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -910,17 +910,14 @@ func (s *Service) StoreLedgerWithState(ctx context.Context, h *header.LedgerHead
 	return s.storeLedgerWithStateLocked(ctx, h, stateMap, txMap)
 }
 
-// BootstrapLedgerWithState adopts the first peer ledger. Once bootstrap has
-// completed, later calls only store the acquired ledger for explicit consensus
-// selection.
+// BootstrapLedgerWithState stores an acquired ledger and reports whether the
+// node still needs an initial network-ledger switch. Consensus owns that switch.
 func (s *Service) BootstrapLedgerWithState(ctx context.Context, h *header.LedgerHeader, stateMap *shamap.SHAMap, txMap *shamap.SHAMap) (bool, error) {
 	s.mu.Lock()
 	previousValidatedSeq := s.validatedLedgerSeqLocked()
 	defer s.unlockAndNotifyValidatedLedger(previousValidatedSeq)
-	if !s.needsInitialSync {
-		return false, s.storeLedgerWithStateLocked(ctx, h, stateMap, txMap)
-	}
-	return true, s.adoptLedgerWithStateLocked(ctx, h, stateMap, txMap, 0)
+	initialCandidate := s.needsInitialSync
+	return initialCandidate, s.storeLedgerWithStateLocked(ctx, h, stateMap, txMap)
 }
 
 // AdoptLedgerWithState adopts a ledger using a fully-fetched state map from a

--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -399,7 +399,19 @@ func (s *Service) AcceptConsensusResult(ctx context.Context, parent *ledger.Ledg
 func (s *Service) SwitchToPreferredLedger(parent *ledger.Ledger) error {
 	s.mu.Lock()
 	previousValidatedSeq := s.validatedLedgerSeqLocked()
-	defer s.unlockAndNotifyValidatedLedger(previousValidatedSeq)
+	pool := s.localTxs
+	var promotedLedger *ledger.Ledger
+	defer func() {
+		notification := s.validatedLedgerNotificationLocked(previousValidatedSeq)
+		s.mu.Unlock()
+		if promotedLedger != nil {
+			s.syncTable(promotedLedger)
+			if pool != nil {
+				pool.Sweep(promotedLedger)
+			}
+		}
+		notification.notify()
+	}()
 
 	if s.closedLedger == nil {
 		return ErrNoClosedLedger
@@ -417,6 +429,7 @@ func (s *Service) SwitchToPreferredLedger(parent *ledger.Ledger) error {
 		}
 	}
 	if parent.Sequence() == s.closedLedger.Sequence() && parentHash == s.closedLedger.Hash() {
+		s.needsInitialSync = false
 		return nil
 	}
 
@@ -432,8 +445,15 @@ func (s *Service) SwitchToPreferredLedger(parent *ledger.Ledger) error {
 	s.closedLedger = parent
 	s.openLedger = newOpen
 	s.needsInitialSync = false
-	s.collectTransactionResults(parent, parent.Sequence(), parentHash)
-	if parent.IsValidated() {
+	promotedByDrain := s.drainPendingLedgerValidationLocked(parent.Sequence(), parent)
+	txResults := s.collectTransactionResults(parent, parent.Sequence(), parentHash)
+	if promotedByDrain {
+		s.enqueuePersist(parent)
+		event := s.validatedLedgerEventLocked(parent)
+		event.TransactionResults = txResults
+		s.dispatchLedgerEvent(event)
+		promotedLedger = parent
+	} else if parent.IsValidated() {
 		s.evictOldHistoryLocked(parent.Sequence())
 		s.enqueuePersist(parent)
 	}
@@ -701,11 +721,6 @@ func (s *Service) SetValidatedLedgerAt(seq uint32, expectedHash [32]byte, signTi
 	s.mu.Lock()
 	previousValidatedSeq := s.validatedLedgerSeqLocked()
 	l, ok := s.ledgerHistory[seq]
-	if !ok || l.Hash() != expectedHash {
-		if acquired, found := s.persistedLedgers[expectedHash]; found && acquired.Sequence() == seq {
-			l, ok = acquired, true
-		}
-	}
 	// rippled checkAccept is hash-keyed; our seq-keyed map splits into "no entry"
 	// or "different-hash" (same-height fork) — both stash and arm acquisition.
 	if !ok || l.Hash() != expectedHash {
@@ -905,8 +920,7 @@ func (s *Service) NeedsInitialSync() bool {
 // the stored ledger as its preferred parent.
 func (s *Service) StoreLedgerWithState(ctx context.Context, h *header.LedgerHeader, stateMap *shamap.SHAMap, txMap *shamap.SHAMap) error {
 	s.mu.Lock()
-	previousValidatedSeq := s.validatedLedgerSeqLocked()
-	defer s.unlockAndNotifyValidatedLedger(previousValidatedSeq)
+	defer s.mu.Unlock()
 	return s.storeLedgerWithStateLocked(ctx, h, stateMap, txMap)
 }
 
@@ -914,10 +928,77 @@ func (s *Service) StoreLedgerWithState(ctx context.Context, h *header.LedgerHead
 // node still needs an initial network-ledger switch. Consensus owns that switch.
 func (s *Service) BootstrapLedgerWithState(ctx context.Context, h *header.LedgerHeader, stateMap *shamap.SHAMap, txMap *shamap.SHAMap) (bool, error) {
 	s.mu.Lock()
-	previousValidatedSeq := s.validatedLedgerSeqLocked()
-	defer s.unlockAndNotifyValidatedLedger(previousValidatedSeq)
+	defer s.mu.Unlock()
 	initialCandidate := s.needsInitialSync
 	return initialCandidate, s.storeLedgerWithStateLocked(ctx, h, stateMap, txMap)
+}
+
+// IngestHistoricalLedgerWithState installs an acquired ledger into validated
+// history without changing the node's current ledger frontiers.
+func (s *Service) IngestHistoricalLedgerWithState(ctx context.Context, h *header.LedgerHeader, stateMap *shamap.SHAMap, txMap *shamap.SHAMap) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	historical, err := s.ledgerWithStateLocked(h, stateMap, txMap)
+	if err != nil {
+		return err
+	}
+
+	seq := historical.Sequence()
+	hash := historical.Hash()
+	if s.closedLedger == nil || seq >= s.closedLedger.Sequence() {
+		return fmt.Errorf("historical ledger %d is not below the closed ledger frontier", seq)
+	}
+	existing, existingAtSeq := s.ledgerHistory[seq]
+	sameHistoricalLedger := existingAtSeq && existing.Hash() == hash
+	child, childExists := s.ledgerHistory[seq+1]
+	if childExists && child.ParentHash() != hash {
+		return fmt.Errorf("historical ledger %d does not connect to canonical child", seq)
+	}
+	if sameHistoricalLedger {
+		historical = existing
+	} else if !childExists {
+		return fmt.Errorf("historical ledger %d has no canonical child", seq)
+	}
+	if !historical.IsValidated() {
+		if err := historical.SetValidated(); err != nil {
+			return fmt.Errorf("failed to validate historical ledger: %w", err)
+		}
+	}
+
+	if existing, ok := s.ledgerHistory[seq]; ok && existing.Hash() != hash {
+		existingHash := existing.Hash()
+		_ = existing.ForEachTransaction(func(txHash [32]byte, _ []byte) bool {
+			delete(s.txIndex, txHash)
+			delete(s.txPositionIndex, txHash)
+			return true
+		})
+		s.invalidateCompleteLedgerHash(seq, existingHash)
+	}
+
+	s.putHistoryLocked(historical)
+	s.cachePersistedLedgerLocked(historical)
+	s.collectTransactionResults(historical, seq, hash)
+	delete(s.pendingLedgerValidations, seq)
+	for i, pendingSeq := range s.pendingLedgerValidationsOrder {
+		if pendingSeq == seq {
+			s.pendingLedgerValidationsOrder = append(
+				s.pendingLedgerValidationsOrder[:i],
+				s.pendingLedgerValidationsOrder[i+1:]...,
+			)
+			break
+		}
+	}
+	s.enqueueValidatedHistoryPersist(historical)
+
+	s.logger.Info("Ingested historical ledger",
+		"seq", seq,
+		"hash", fmt.Sprintf("%x", hash[:8]),
+	)
+	return nil
 }
 
 // AdoptLedgerWithState adopts a ledger using a fully-fetched state map from a
@@ -965,26 +1046,7 @@ func (s *Service) storeLedgerWithStateLocked(ctx context.Context, h *header.Ledg
 	}
 
 	s.cachePersistedLedgerLocked(stored)
-	promotedByDrain := s.drainPendingLedgerValidationLocked(stored.Sequence(), stored)
-	if promotedByDrain {
-		s.enqueuePersist(stored)
-		s.dispatchLedgerEvent(&LedgerAcceptedEvent{
-			LedgerInfo: &LedgerInfo{
-				Sequence:   stored.Sequence(),
-				Hash:       stored.Hash(),
-				ParentHash: stored.ParentHash(),
-				CloseTime:  stored.CloseTime(),
-				TotalDrops: stored.TotalDrops(),
-				Validated:  true,
-				Closed:     stored.IsClosed(),
-			},
-			Ledger: stored,
-		})
-	} else if stored.IsValidated() {
-		s.enqueueValidatedHistoryPersist(stored)
-	} else {
-		s.enqueueNodePersist(stored)
-	}
+	s.enqueueNodePersist(stored)
 
 	storedHash := stored.Hash()
 	s.logger.Info("Stored acquired ledger",

--- a/internal/ledger/service/server_info_initial_sync_test.go
+++ b/internal/ledger/service/server_info_initial_sync_test.go
@@ -17,8 +17,12 @@ func TestServerInfoReportsNeedForNetworkLedger(t *testing.T) {
 	require.True(t, svc.GetServerInfo().NeedsNetworkLedger)
 
 	header, stateMap, txMap := acquiredLedgerFixture(t, 100, 0xb1)
-	bootstrapped, err := svc.BootstrapLedgerWithState(t.Context(), header, stateMap, txMap)
+	initialCandidate, err := svc.BootstrapLedgerWithState(t.Context(), header, stateMap, txMap)
 	require.NoError(t, err)
-	require.True(t, bootstrapped)
+	require.True(t, initialCandidate)
+	require.True(t, svc.GetServerInfo().NeedsNetworkLedger)
+	stored, err := svc.GetLedgerByHash(header.Hash)
+	require.NoError(t, err)
+	require.NoError(t, svc.SwitchToPreferredLedger(stored))
 	require.False(t, svc.GetServerInfo().NeedsNetworkLedger)
 }

--- a/internal/ledger/service/store_acquired_test.go
+++ b/internal/ledger/service/store_acquired_test.go
@@ -83,26 +83,141 @@ func TestBootstrapLedgerWithStateStagesUntilConsensusSwitch(t *testing.T) {
 	require.Equal(t, second.LedgerIndex, stored.Sequence())
 }
 
-func TestStoredLedgerDrainsPendingTrustedValidationWithoutMovingClosed(t *testing.T) {
+func TestStoredLedgerDefersPendingTrustedValidationUntilConsensusSwitch(t *testing.T) {
+	for _, validationFirst := range []bool{true, false} {
+		t.Run(map[bool]string{true: "validation-before-store", false: "validation-after-store"}[validationFirst], func(t *testing.T) {
+			svc, err := New(DefaultConfig())
+			require.NoError(t, err)
+			require.NoError(t, svc.Start())
+			t.Cleanup(svc.Stop)
+
+			closedSeq := svc.GetClosedLedgerIndex()
+			startValidated := svc.GetValidatedLedger()
+			require.NotNil(t, startValidated)
+			h, stateMap, txMap := acquiredLedgerFixture(t, closedSeq+4, 0xC1)
+			if validationFirst {
+				svc.SetValidatedLedger(h.LedgerIndex, h.Hash)
+			}
+			require.NoError(t, svc.StoreLedgerWithState(context.Background(), h, stateMap, txMap))
+			if !validationFirst {
+				svc.SetValidatedLedger(h.LedgerIndex, h.Hash)
+			}
+
+			require.Equal(t, closedSeq, svc.GetClosedLedgerIndex())
+			require.Equal(t, startValidated.Hash(), svc.GetValidatedLedger().Hash())
+			stored, err := svc.GetLedgerByHash(h.Hash)
+			require.NoError(t, err)
+			require.False(t, stored.IsValidated())
+			svc.mu.RLock()
+			_, pending := svc.pendingLedgerValidations[h.LedgerIndex]
+			svc.mu.RUnlock()
+			require.True(t, pending)
+
+			require.NoError(t, svc.SwitchToPreferredLedger(stored))
+			validated := svc.GetValidatedLedger()
+			require.NotNil(t, validated)
+			require.Equal(t, h.LedgerIndex, validated.Sequence())
+			require.Equal(t, h.Hash, validated.Hash())
+			require.True(t, validated.IsValidated())
+			require.Equal(t, h.LedgerIndex, svc.GetClosedLedgerIndex())
+			svc.mu.RLock()
+			_, pending = svc.pendingLedgerValidations[h.LedgerIndex]
+			svc.mu.RUnlock()
+			require.False(t, pending)
+		})
+	}
+}
+
+func TestSwitchToCurrentPreferredLedgerCompletesInitialSync(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Standalone = false
+	svc, err := New(cfg)
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+	require.True(t, svc.NeedsInitialSync())
+
+	require.NoError(t, svc.SwitchToPreferredLedger(svc.GetClosedLedger()))
+	require.False(t, svc.NeedsInitialSync())
+}
+
+func TestIngestHistoricalLedgerWithStatePreservesFrontiers(t *testing.T) {
 	svc, err := New(DefaultConfig())
 	require.NoError(t, err)
 	require.NoError(t, svc.Start())
 	t.Cleanup(svc.Stop)
 
-	closedSeq := svc.GetClosedLedgerIndex()
-	h, stateMap, txMap := acquiredLedgerFixture(t, closedSeq+4, 0xC1)
-	svc.SetValidatedLedger(h.LedgerIndex, h.Hash)
-	require.NoError(t, svc.StoreLedgerWithState(context.Background(), h, stateMap, txMap))
-
-	require.Equal(t, closedSeq, svc.GetClosedLedgerIndex())
-	validated := svc.GetValidatedLedger()
-	require.NotNil(t, validated)
-	require.Equal(t, h.LedgerIndex, validated.Sequence())
-	require.Equal(t, h.Hash, validated.Hash())
-	require.True(t, validated.IsValidated())
-	stored, err := svc.GetLedgerByHash(h.Hash)
+	historical, stateMap, txMap := acquiredLedgerFixture(t, svc.GetClosedLedgerIndex()+9, 0xC2)
+	txBlob, txHash := makeTxMetaBlobForTest(t, []byte("historical-ingest-tx-padding-padpad"), 7)
+	require.NoError(t, txMap.PutWithNodeType(txHash, txBlob, shamap.NodeTypeTransactionWithMeta))
+	txRoot, err := txMap.Hash()
 	require.NoError(t, err)
-	require.True(t, stored.IsValidated())
+	historical.TxHash = txRoot
+
+	preferred, preferredState, preferredTx := acquiredLedgerFixture(t, historical.LedgerIndex+1, 0xC3)
+	preferred.ParentHash = historical.Hash
+	require.NoError(t, svc.StoreLedgerWithState(t.Context(), preferred, preferredState, preferredTx))
+	storedPreferred, err := svc.GetLedgerByHash(preferred.Hash)
+	require.NoError(t, err)
+	require.NoError(t, svc.SwitchToPreferredLedger(storedPreferred))
+
+	closedBefore := svc.GetClosedLedger()
+	require.NotNil(t, closedBefore)
+	openSeqBefore := svc.GetCurrentLedgerIndex()
+	validatedBefore := svc.GetValidatedLedger()
+	require.NotNil(t, validatedBefore)
+	needsInitialSyncBefore := svc.NeedsInitialSync()
+	svc.SetValidatedLedger(historical.LedgerIndex, historical.Hash)
+	require.Equal(t, validatedBefore.Hash(), svc.GetValidatedLedger().Hash())
+
+	require.NoError(t, svc.IngestHistoricalLedgerWithState(t.Context(), historical, stateMap, txMap))
+	require.NoError(t, svc.IngestHistoricalLedgerWithState(t.Context(), historical, stateMap, txMap))
+	svc.FlushPersists()
+
+	got, err := svc.AdoptedLedgerBySequence(historical.LedgerIndex)
+	require.NoError(t, err)
+	require.Equal(t, historical.Hash, got.Hash())
+	require.True(t, got.IsValidated())
+	require.True(t, svc.hasCompleteLedger(got))
+	require.Equal(t, closedBefore.Hash(), svc.GetClosedLedger().Hash())
+	require.Equal(t, openSeqBefore, svc.GetCurrentLedgerIndex())
+	require.Equal(t, validatedBefore.Hash(), svc.GetValidatedLedger().Hash())
+	require.Equal(t, needsInitialSyncBefore, svc.NeedsInitialSync())
+	svc.mu.RLock()
+	indexedSeq, indexed := svc.txIndex[txHash]
+	indexedPosition := svc.txPositionIndex[txHash]
+	_, pending := svc.pendingLedgerValidations[historical.LedgerIndex]
+	svc.mu.RUnlock()
+	require.True(t, indexed)
+	require.Equal(t, historical.LedgerIndex, indexedSeq)
+	require.Equal(t, uint32(7), indexedPosition)
+	require.False(t, pending)
+}
+
+func TestIngestHistoricalLedgerWithStateRejectsNonCanonicalHistory(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	historical, stateMap, txMap := acquiredLedgerFixture(t, svc.GetClosedLedgerIndex()+9, 0xC4)
+	preferred, preferredState, preferredTx := acquiredLedgerFixture(t, historical.LedgerIndex+1, 0xC5)
+	preferred.ParentHash = [32]byte{0xFF}
+	require.NoError(t, svc.StoreLedgerWithState(t.Context(), preferred, preferredState, preferredTx))
+	storedPreferred, err := svc.GetLedgerByHash(preferred.Hash)
+	require.NoError(t, err)
+	require.NoError(t, svc.SwitchToPreferredLedger(storedPreferred))
+
+	closedBefore := svc.GetClosedLedger()
+	require.Error(t, svc.IngestHistoricalLedgerWithState(t.Context(), historical, stateMap, txMap))
+	_, err = svc.AdoptedLedgerBySequence(historical.LedgerIndex)
+	require.ErrorIs(t, err, ErrLedgerNotFound)
+	require.Equal(t, closedBefore.Hash(), svc.GetClosedLedger().Hash())
+
+	current, currentState, currentTx := acquiredLedgerFixture(t, closedBefore.Sequence(), 0xC6)
+	require.Error(t, svc.IngestHistoricalLedgerWithState(t.Context(), current, currentState, currentTx))
+	_, err = svc.GetLedgerByHash(current.Hash)
+	require.ErrorIs(t, err, ErrLedgerNotFound)
 }
 
 func TestStoredLedgerMovesCanonicalFrontierOnlyThroughConsensusSwitch(t *testing.T) {

--- a/internal/ledger/service/store_acquired_test.go
+++ b/internal/ledger/service/store_acquired_test.go
@@ -50,7 +50,7 @@ func TestStoreLedgerWithStateDoesNotMoveCanonicalFrontier(t *testing.T) {
 	require.ErrorIs(t, err, ErrLedgerNotFound)
 }
 
-func TestBootstrapLedgerWithStateAdoptsOnlyFirstPeerLedger(t *testing.T) {
+func TestBootstrapLedgerWithStateStagesUntilConsensusSwitch(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Standalone = false
 	svc, err := New(cfg)
@@ -58,18 +58,25 @@ func TestBootstrapLedgerWithStateAdoptsOnlyFirstPeerLedger(t *testing.T) {
 	require.NoError(t, svc.Start())
 	t.Cleanup(svc.Stop)
 	require.True(t, svc.NeedsInitialSync())
+	originalClosed := svc.GetClosedLedger()
+	require.NotNil(t, originalClosed)
 
 	first, firstState, firstTx := acquiredLedgerFixture(t, 100, 0xB1)
-	bootstrapped, err := svc.BootstrapLedgerWithState(t.Context(), first, firstState, firstTx)
+	initialCandidate, err := svc.BootstrapLedgerWithState(t.Context(), first, firstState, firstTx)
 	require.NoError(t, err)
-	require.True(t, bootstrapped)
+	require.True(t, initialCandidate)
+	require.True(t, svc.NeedsInitialSync())
+	require.Equal(t, originalClosed.Hash(), svc.GetClosedLedger().Hash())
+	storedFirst, err := svc.GetLedgerByHash(first.Hash)
+	require.NoError(t, err)
+	require.NoError(t, svc.SwitchToPreferredLedger(storedFirst))
 	require.False(t, svc.NeedsInitialSync())
-	require.Equal(t, first.LedgerIndex, svc.GetClosedLedgerIndex())
+	require.Equal(t, first.Hash, svc.GetClosedLedger().Hash())
 
 	second, secondState, secondTx := acquiredLedgerFixture(t, 105, 0xB2)
-	bootstrapped, err = svc.BootstrapLedgerWithState(t.Context(), second, secondState, secondTx)
+	initialCandidate, err = svc.BootstrapLedgerWithState(t.Context(), second, secondState, secondTx)
 	require.NoError(t, err)
-	require.False(t, bootstrapped)
+	require.False(t, initialCandidate)
 	require.Equal(t, first.LedgerIndex, svc.GetClosedLedgerIndex())
 	stored, err := svc.GetLedgerByHash(second.Hash)
 	require.NoError(t, err)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1962,3 +1962,48 @@ replacing its specialized traversal algorithms.
   SHAMap normal and race suites, package vet, repository-wide `go test ./...`,
   `just build-all`, `just build-nocgo`, strict `golangci-lint` with zero issues,
   coverage, benchmarks, and `git diff --check`.
+
+# PR #1429 regression fixes
+
+Target: `fix/issue-1428-slow-bootstrap-wedge` at
+`b90ba356b5fccdbba16aeb633a3fa536453ba4c1`.
+Behavioral oracle: local rippled v3.2.0 checkout at
+`rippled-worktrees/v3.2.0-oracle/`.
+
+## Plan
+
+- [x] Keep staged bootstrap candidates hash-addressable without advancing the
+      validated frontier before currentness and compatibility checks.
+- [x] Install fetched and already-held validated history into sequence history,
+      durable indexes, and `complete_ledgers` without moving closed/open state.
+- [x] Schedule deep-gap history recovery after immediate, replay, and deferred
+      initial switches.
+- [x] Add regressions for stale pending-validation promotion, history completion,
+      held bootstrap anchors, replay switches, and maintenance retries.
+- [x] Run focused and full verification, review the complete diff against
+      rippled v3.2.0, and record the results.
+- [x] Stage only the scoped changes, commit, push the PR branch, and confirm the
+      published head and checks.
+
+## Review
+
+- Stored/bootstrap candidates remain hash-addressable but cannot advance the
+  closed, open, or validated frontiers before a successful consensus switch.
+  Live trusted quorum and currentness are rechecked before adoption; router
+  handoff, recovery, and operating-mode state commit only after acceptance.
+- Historical acquisitions now populate validated sequence history, transaction
+  indexes, persistence, and `complete_ledgers` only when they connect to the
+  selected canonical child, without moving current ledger frontiers.
+- Every successful preferred-ledger switch schedules ancestry-bounded history
+  recovery. Held anchors, replay switches, deferred Busy retries, stale walk
+  generations, and synchronous peer failures are covered by regressions.
+- Post-validation amendment and local-transaction work runs after releasing the
+  service mutex. Independent conformance review found no remaining issues.
+- Passing gates: affected packages normally and under `-race`, `just test-core`,
+  `just build`, `just vet`, configured and strict `golangci-lint`, and
+  `git diff --check`. The aggregate core gate initially hit an unrelated missing
+  Go build-cache entry in an RPC analyzer; its isolated test and uncontended
+  core rerun passed.
+- The local rippled oracle files were reviewed, but its `.git` worktree pointer
+  is broken, so the configured v3.2.0 SHA/tag and clean status could not be
+  independently re-verified.


### PR DESCRIPTION
## Summary
- Store completed initial peer ledgers without moving the canonical service frontier until consensus accepts a current, compatible switch.
- Keep stale or busy bootstrap candidates out of operating-mode and handoff bookkeeping while retaining safe recovery anchors.
- Add deterministic coverage for a stale high-sequence acquisition followed by atomic convergence on a fresh successor.

## Test plan
- [x] `go test ./internal/consensus/... ./internal/ledger/service/...`
- [x] `go test -race ./internal/consensus/adaptor ./internal/consensus/rcl ./internal/ledger/service`
- [x] `just test-core`
- [x] `just test`
- [x] `just vet`
- [x] `go vet -tags postgres ./storage/relationaldb/postgres/`
- [x] `golangci-lint run`
- [x] `just lint`
- [x] `just build-all`

Fixes #1428
