### PR TITLE
fix: verify replay reconstruction before object findings

### DIFF
--- a/internal/replaytool/replay_findings.go
+++ b/internal/replaytool/replay_findings.go
@@ -15,16 +15,16 @@ const findingSchema = "goxrpl.replay.finding/v1"
 // form so the parallel fleet can survey every divergence in a single pass and
 // dedup by root cause downstream.
 type Finding struct {
-	Schema                 string            `json:"schema"`
-	GoXRPLCommit           string            `json:"goxrpl_commit"`
-	LedgerIndex            uint32            `json:"ledger_index"`
-	ParentLedgerHash       string            `json:"parent_ledger_hash"`
-	TxCount                int               `json:"tx_count"`
-	Hashes                 findingHashes     `json:"hashes"`
-	ReconstructionVerified bool              `json:"reconstruction_verified"`
-	DivergingObjects       []divergingObject `json:"diverging_objects"`
-	TxSet                  []findingTx       `json:"tx_set"`
-	Errors                 []string          `json:"errors,omitempty"`
+	Schema                 string             `json:"schema"`
+	GoXRPLCommit           string             `json:"goxrpl_commit"`
+	LedgerIndex            uint32             `json:"ledger_index"`
+	ParentLedgerHash       string             `json:"parent_ledger_hash"`
+	TxCount                int                `json:"tx_count"`
+	Hashes                 findingHashes      `json:"hashes"`
+	ReconstructionVerified bool               `json:"reconstruction_verified"`
+	DivergingObjects       *[]divergingObject `json:"diverging_objects,omitempty"`
+	TxSet                  []findingTx        `json:"tx_set"`
+	Errors                 []string           `json:"errors,omitempty"`
 }
 
 type findingHashes struct {
@@ -103,9 +103,17 @@ func goxrplCommit(override string) string {
 
 // buildFinding assembles a Finding from a divergent block result and the
 // reconstructed mainnet post-state. diverging holds the exact set of objects
-// that differ between goXRPL's post-state and mainnet's.
+// that differ between goXRPL's post-state and a verified mainnet reconstruction;
+// unverified candidates never carry object-level diagnoses.
 func buildFinding(commit string, ledgerIndex uint32, parentHash [32]byte, result *BlockResult, reconstructionVerified bool, diverging []divergingObject) *Finding {
 	hexOf := func(b [32]byte) string { return hex.EncodeToString(b[:]) }
+	var findingDiverging *[]divergingObject
+	if reconstructionVerified {
+		if diverging == nil {
+			diverging = []divergingObject{}
+		}
+		findingDiverging = &diverging
+	}
 
 	txSet := make([]findingTx, 0, len(result.TxResults))
 	for _, t := range result.TxResults {
@@ -134,7 +142,7 @@ func buildFinding(commit string, ledgerIndex uint32, parentHash [32]byte, result
 			TotalCoinsExpected:  result.ExpectedTotalCoins,
 		},
 		ReconstructionVerified: reconstructionVerified,
-		DivergingObjects:       diverging,
+		DivergingObjects:       findingDiverging,
 		TxSet:                  txSet,
 		Errors:                 result.Errors,
 	}

--- a/internal/replaytool/replay_findings_test.go
+++ b/internal/replaytool/replay_findings_test.go
@@ -31,12 +31,19 @@ func TestFindingsWriter_JSONL(t *testing.T) {
 	var parent [32]byte
 	parent[0] = 0x77
 	f1 := buildFinding("deadbeef0001", 100, parent, result, true, diverging)
-	f2 := buildFinding("deadbeef0001", 200, parent, result, false, nil)
+	f2 := buildFinding("deadbeef0001", 200, parent, result, false, diverging)
+	f3 := buildFinding("deadbeef0001", 300, parent, result, true, nil)
+	if f2.DivergingObjects != nil {
+		t.Fatalf("unverified finding retained diverging objects: %+v", f2.DivergingObjects)
+	}
 	if err := w.Write(f1); err != nil {
 		t.Fatalf("write f1: %v", err)
 	}
 	if err := w.Write(f2); err != nil {
 		t.Fatalf("write f2: %v", err)
+	}
+	if err := w.Write(f3); err != nil {
+		t.Fatalf("write f3: %v", err)
 	}
 	if err := w.Close(); err != nil {
 		t.Fatalf("close: %v", err)
@@ -51,6 +58,8 @@ func TestFindingsWriter_JSONL(t *testing.T) {
 	var lines int
 	scanner := bufio.NewScanner(file)
 	var first Finding
+	var second map[string]json.RawMessage
+	var third map[string]json.RawMessage
 	for scanner.Scan() {
 		var fd Finding
 		if err := json.Unmarshal(scanner.Bytes(), &fd); err != nil {
@@ -58,14 +67,22 @@ func TestFindingsWriter_JSONL(t *testing.T) {
 		}
 		if lines == 0 {
 			first = fd
+		} else if lines == 1 {
+			if err := json.Unmarshal(scanner.Bytes(), &second); err != nil {
+				t.Fatalf("decoding second finding: %v", err)
+			}
+		} else if lines == 2 {
+			if err := json.Unmarshal(scanner.Bytes(), &third); err != nil {
+				t.Fatalf("decoding third finding: %v", err)
+			}
 		}
 		lines++
 	}
 	if err := scanner.Err(); err != nil {
 		t.Fatalf("scan: %v", err)
 	}
-	if lines != 2 {
-		t.Fatalf("expected 2 JSONL lines, got %d", lines)
+	if lines != 3 {
+		t.Fatalf("expected 3 JSONL lines, got %d", lines)
 	}
 	if first.Schema != findingSchema {
 		t.Fatalf("schema = %q, want %q", first.Schema, findingSchema)
@@ -73,8 +90,21 @@ func TestFindingsWriter_JSONL(t *testing.T) {
 	if first.LedgerIndex != 100 || !first.ReconstructionVerified {
 		t.Fatalf("unexpected first finding: %+v", first)
 	}
-	if len(first.DivergingObjects) != 1 || first.DivergingObjects[0].Index != "00ff" {
+	if first.DivergingObjects == nil ||
+		len(*first.DivergingObjects) != 1 ||
+		(*first.DivergingObjects)[0].Index != "00ff" ||
+		(*first.DivergingObjects)[0].GoXRPL != "aa" ||
+		(*first.DivergingObjects)[0].Mainnet != "bb" {
 		t.Fatalf("diverging objects not recorded: %+v", first.DivergingObjects)
+	}
+	if got := string(second["reconstruction_verified"]); got != "false" {
+		t.Fatalf("second reconstruction_verified = %s, want false", got)
+	}
+	if _, present := second["diverging_objects"]; present {
+		t.Fatalf("unverified finding exposed diverging_objects: %s", second["diverging_objects"])
+	}
+	if got := string(third["diverging_objects"]); got != "[]" {
+		t.Fatalf("verified empty diverging_objects = %s, want []", got)
 	}
 	// account_expected is hex of [32]byte{0xBE,0xEF}: "beef" then zeros.
 	if len(first.Hashes.AccountExpected) != 64 || first.Hashes.AccountExpected[:4] != "beef" {

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -419,9 +419,12 @@ func recordDivergenceAndReset(
 	if err != nil {
 		return nil, fmt.Errorf("reconstructing mainnet state: %w", err)
 	}
-	diverging, err := divergingObjects(goxrplPost, corrected)
-	if err != nil {
-		return nil, fmt.Errorf("computing diverging objects: %w", err)
+	var diverging []divergingObject
+	if verified {
+		diverging, err = divergingObjects(goxrplPost, corrected)
+		if err != nil {
+			return nil, fmt.Errorf("computing diverging objects: %w", err)
+		}
 	}
 	finding := buildFinding(commit, ledgerIndex, parentHash, result, verified, diverging)
 	if err := findings.Write(finding); err != nil {

--- a/internal/replaytool/replay_reconstruct_defaults.go
+++ b/internal/replaytool/replay_reconstruct_defaults.go
@@ -166,6 +166,11 @@ var requiredDefaults = map[string][]createdField{
 		{Name: "OwnerNode", Value: "0"},
 		{Name: "LoanBrokerNode", Value: "0"},
 	},
+	"LoanBroker": {
+		{Name: "Flags", Value: 0},
+		{Name: "OwnerNode", Value: "0"},
+		{Name: "VaultNode", Value: "0"},
+	},
 	"AMM": {
 		{Name: "Flags", Value: 0},
 		{Name: "OwnerNode", Value: "0"},

--- a/internal/replaytool/replay_reconstruct_dir.go
+++ b/internal/replaytool/replay_reconstruct_dir.go
@@ -133,6 +133,23 @@ func directoryPlacements(state *shamap.SHAMap, entryType string, fields map[stri
 		add(keylet.OwnerDirPage(broker, metaUint64(fields["LoanBrokerNode"])), dirSorted)
 		return out, nil
 
+	case "LoanBroker":
+		owner, ok := metaAccountID(fields, "Owner")
+		if !ok {
+			return nil, fmt.Errorf("LoanBroker has invalid Owner")
+		}
+		vaultID, ok := metaHash256(fields, "VaultID")
+		if !ok {
+			return nil, fmt.Errorf("LoanBroker has invalid VaultID")
+		}
+		vault, err := vaultDirectoryAccount(state, vaultID)
+		if err != nil {
+			return nil, err
+		}
+		add(keylet.OwnerDirPage(owner, metaUint64(fields["OwnerNode"])), dirSorted)
+		add(keylet.OwnerDirPage(vault, metaUint64(fields["VaultNode"])), dirSorted)
+		return out, nil
+
 	case "MPTokenIssuance":
 		if issuer, ok := metaAccountID(fields, "Issuer"); ok {
 			add(keylet.OwnerDirPage(issuer, metaUint64(fields["OwnerNode"])), dirSorted)
@@ -211,6 +228,29 @@ func loanBrokerAccount(state *shamap.SHAMap, brokerID [32]byte, brokerAccounts m
 	account, ok := metaAccountID(broker, "Account")
 	if !ok {
 		return [20]byte{}, fmt.Errorf("LoanBroker %X has invalid Account", brokerID)
+	}
+	return account, nil
+}
+
+func vaultDirectoryAccount(state *shamap.SHAMap, vaultID [32]byte) ([20]byte, error) {
+	vaultKey := keylet.VaultByID(vaultID).Key
+	item, found, err := state.Get(vaultKey)
+	if err != nil {
+		return [20]byte{}, fmt.Errorf("reading Vault %X: %w", vaultID, err)
+	}
+	if !found || item == nil {
+		return [20]byte{}, fmt.Errorf("Vault %X not found", vaultID)
+	}
+	vault, err := binarycodec.Decode(hex.EncodeToString(item.Data()))
+	if err != nil {
+		return [20]byte{}, fmt.Errorf("decoding Vault %X: %w", vaultID, err)
+	}
+	if vault["LedgerEntryType"] != "Vault" {
+		return [20]byte{}, fmt.Errorf("Vault %X resolved to %v", vaultID, vault["LedgerEntryType"])
+	}
+	account, ok := metaAccountID(vault, "Account")
+	if !ok {
+		return [20]byte{}, fmt.Errorf("Vault %X has invalid Account", vaultID)
 	}
 	return account, nil
 }

--- a/internal/replaytool/replay_reconstruct_test.go
+++ b/internal/replaytool/replay_reconstruct_test.go
@@ -308,6 +308,105 @@ func TestReconstructFromMeta_CreatedOfferDefaults(t *testing.T) {
 	}
 }
 
+func TestReconstructFromMeta_CreatedLoanBrokerDefaults(t *testing.T) {
+	const (
+		ledgerIndexHex = "75F04A09A3F45F989E015B92A39F8B70B99857D31D5D61955AEB16190B7E7341"
+		txHashHex      = "B40964DF5BC8EA1DF5EDC1EDC2F44463CDBCD45B3D273D68D7AC72A397F4E7B9"
+		canonicalHex   = "11008822000000002400325E0E2500325E1C203D00000001340000000000000000301E000000000000000055B40964DF5BC8EA1DF5EDC1EDC2F44463CDBCD45B3D273D68D7AC72A397F4E7B9502315032ADB6CACAE93D1DA6C73FBF10E67071133303154EA69F2956A0BC4137D858114B87371891D6215AB177F93F8A84DC5CCBB48C0788214E6D10E126C40BA4428FEE64BC2C4F3F2C31AB9B8"
+		vaultAccount   = "rpRrVjCLggyjBaAYreukcyuWuzb23wuWrn"
+		ledgerSeq      = uint32(3_300_892)
+	)
+
+	full, err := binarycodec.Decode(canonicalHex)
+	if err != nil {
+		t.Fatalf("Decode canonical LoanBroker: %v", err)
+	}
+	owner, ok := full["Owner"].(string)
+	if !ok {
+		t.Fatalf("canonical LoanBroker Owner = %T, want string", full["Owner"])
+	}
+	vaultIDHex, ok := full["VaultID"].(string)
+	if !ok {
+		t.Fatalf("canonical LoanBroker VaultID = %T, want string", full["VaultID"])
+	}
+	ownerID, err := state.DecodeAccountID(owner)
+	if err != nil {
+		t.Fatalf("Decode owner: %v", err)
+	}
+	vaultAccountID, err := state.DecodeAccountID(vaultAccount)
+	if err != nil {
+		t.Fatalf("Decode vault account: %v", err)
+	}
+	ledgerIndex := mustIndex(t, ledgerIndexHex)
+	vaultID := mustIndex(t, vaultIDHex)
+	ownerDir := keylet.OwnerDirPage(ownerID, 0).Key
+	vaultDir := keylet.OwnerDirPage(vaultAccountID, 0).Key
+
+	newFields := maps.Clone(full)
+	for _, field := range []string{
+		"LedgerEntryType",
+		"Flags",
+		"OwnerNode",
+		"VaultNode",
+		"PreviousTxnID",
+		"PreviousTxnLgrSeq",
+	} {
+		delete(newFields, field)
+	}
+	meta := encodeMeta(t,
+		map[string]any{"ModifiedNode": map[string]any{
+			"LedgerEntryType": "DirectoryNode",
+			"LedgerIndex":     protocol.Hash256Hex(ownerDir),
+			"FinalFields": map[string]any{
+				"Flags": 0, "Owner": owner, "RootIndex": protocol.Hash256Hex(ownerDir),
+			},
+		}},
+		map[string]any{"ModifiedNode": map[string]any{
+			"LedgerEntryType": "DirectoryNode",
+			"LedgerIndex":     protocol.Hash256Hex(vaultDir),
+			"FinalFields": map[string]any{
+				"Flags": 0, "Owner": vaultAccount, "RootIndex": protocol.Hash256Hex(vaultDir),
+			},
+		}},
+		map[string]any{"CreatedNode": map[string]any{
+			"LedgerEntryType": "LoanBroker",
+			"LedgerIndex":     ledgerIndexHex,
+			"NewFields":       newFields,
+		}},
+	)
+
+	corrected, err := reconstructFromMeta(
+		putAll(t, map[[32]byte][]byte{
+			keylet.VaultByID(vaultID).Key: vaultSLE(t, vaultAccount, owner),
+			ownerDir: encodeSLE(t, map[string]any{
+				"LedgerEntryType": "DirectoryNode", "Flags": 0,
+				"Owner": owner, "RootIndex": protocol.Hash256Hex(ownerDir),
+			}),
+			vaultDir: encodeSLE(t, map[string]any{
+				"LedgerEntryType": "DirectoryNode", "Flags": 0,
+				"Owner": vaultAccount, "RootIndex": protocol.Hash256Hex(vaultDir),
+			}),
+		}),
+		[]metaTx{{Blob: meta, TxHash: mustIndex(t, txHashHex)}},
+		ledgerSeq,
+	)
+	if err != nil {
+		t.Fatalf("reconstructFromMeta: %v", err)
+	}
+	item, found, err := corrected.Get(ledgerIndex)
+	if err != nil {
+		t.Fatalf("Get LoanBroker: %v", err)
+	}
+	if !found {
+		t.Fatal("reconstructed LoanBroker is missing")
+	}
+	if got := strings.ToUpper(hex.EncodeToString(item.Data())); got != canonicalHex {
+		t.Fatalf("reconstructed LoanBroker\n got: %s\nwant: %s", got, canonicalHex)
+	}
+	assertDirectoryMembers(t, corrected, ownerDir, ledgerIndex)
+	assertDirectoryMembers(t, corrected, vaultDir, ledgerIndex)
+}
+
 func TestApplyAffectedNode_AMMCreateDefaults(t *testing.T) {
 	const (
 		ammIndex   = "00000000000000000000000000000000000000000000000000000000000000A0"
@@ -1203,6 +1302,58 @@ func TestReconstructFromMeta_LoanDeleteDirectories(t *testing.T) {
 	assertDirectoryMembers(t, corrected, brokerDir)
 }
 
+func TestReconstructFromMeta_LoanBrokerDeleteDirectories(t *testing.T) {
+	const (
+		brokerAccount = "rEaWzpDUL2cBckwDJhRENZiKCbNKwG2cAZ"
+		owner         = "rrrrrrrrrrrrrrrrrrrrBZbvji"
+		vaultAccount  = "rpRrVjCLggyjBaAYreukcyuWuzb23wuWrn"
+		brokerIDHex   = "33353F075781FD714AE43F61FC6B4A88BCB5CE3C348FE0FF40B1F6F803C7D86A"
+		vaultIDHex    = "44453F075781FD714AE43F61FC6B4A88BCB5CE3C348FE0FF40B1F6F803C7D86A"
+	)
+
+	ownerID, _ := state.DecodeAccountID(owner)
+	vaultAccountID, _ := state.DecodeAccountID(vaultAccount)
+	brokerKey := mustIndex(t, brokerIDHex)
+	vaultID := mustIndex(t, vaultIDHex)
+	ownerDir := keylet.OwnerDirPage(ownerID, 2).Key
+	vaultDir := keylet.OwnerDirPage(vaultAccountID, 3).Key
+	brokerFields := map[string]any{
+		"LedgerEntryType": "LoanBroker", "Flags": 0, "Sequence": uint32(1),
+		"OwnerNode": "2", "VaultNode": "3", "VaultID": vaultIDHex,
+		"Account": brokerAccount, "Owner": owner, "LoanSequence": uint32(1),
+		"PreviousTxnID": testTxHashHex, "PreviousTxnLgrSeq": testLedgerSeq - 1,
+	}
+	preState := putAll(t, map[[32]byte][]byte{
+		brokerKey:                     encodeSLE(t, brokerFields),
+		keylet.VaultByID(vaultID).Key: vaultSLE(t, vaultAccount, owner),
+		ownerDir: encodeSLE(t, map[string]any{
+			"LedgerEntryType": "DirectoryNode", "Flags": 0, "Owner": owner,
+			"RootIndex": protocol.Hash256Hex(keylet.OwnerDir(ownerID).Key), "Indexes": []string{brokerIDHex},
+		}),
+		vaultDir: encodeSLE(t, map[string]any{
+			"LedgerEntryType": "DirectoryNode", "Flags": 0, "Owner": vaultAccount,
+			"RootIndex": protocol.Hash256Hex(keylet.OwnerDir(vaultAccountID).Key), "Indexes": []string{brokerIDHex},
+		}),
+	})
+	finalFields := maps.Clone(brokerFields)
+	delete(finalFields, "LedgerEntryType")
+	delete(finalFields, "PreviousTxnID")
+	delete(finalFields, "PreviousTxnLgrSeq")
+	meta := encodeMeta(t, map[string]any{"DeletedNode": map[string]any{
+		"LedgerEntryType": "LoanBroker", "LedgerIndex": brokerIDHex, "FinalFields": finalFields,
+	}})
+
+	corrected, err := reconstructFromMeta(preState, []metaTx{{Blob: meta}}, testLedgerSeq)
+	if err != nil {
+		t.Fatalf("reconstructFromMeta: %v", err)
+	}
+	if _, found, err := corrected.Get(brokerKey); err != nil || found {
+		t.Fatalf("deleted LoanBroker present (found=%v err=%v)", found, err)
+	}
+	assertDirectoryMembers(t, corrected, ownerDir)
+	assertDirectoryMembers(t, corrected, vaultDir)
+}
+
 func TestReconstructFromMeta_LoanDeleteAfterLoanBrokerDelete(t *testing.T) {
 	const borrower = "rEaWzpDUL2cBckwDJhRENZiKCbNKwG2cAZ"
 	const brokerAccount = "rpRrVjCLggyjBaAYreukcyuWuzb23wuWrn"
@@ -1223,8 +1374,9 @@ func TestReconstructFromMeta_LoanDeleteAfterLoanBrokerDelete(t *testing.T) {
 		"StartDate": uint32(836247371), "PaymentInterval": uint32(400), "PeriodicPayment": "10000",
 	}
 	preState := putAll(t, map[[32]byte][]byte{
-		brokerKey: loanBrokerSLE(t, brokerAccount, brokerOwner),
-		loanKey:   encodeSLE(t, loanFields),
+		brokerKey:                        loanBrokerSLE(t, brokerAccount, brokerOwner),
+		loanKey:                          encodeSLE(t, loanFields),
+		keylet.VaultByID([32]byte{}).Key: vaultSLE(t, brokerAccount, brokerOwner),
 		borrowerDir: encodeSLE(t, map[string]any{
 			"LedgerEntryType": "DirectoryNode", "Flags": 0, "Owner": borrower,
 			"RootIndex": protocol.Hash256Hex(borrowerDir), "Indexes": []string{loanKeyHex},
@@ -1239,7 +1391,10 @@ func TestReconstructFromMeta_LoanDeleteAfterLoanBrokerDelete(t *testing.T) {
 	meta := encodeMeta(t,
 		map[string]any{"DeletedNode": map[string]any{
 			"LedgerEntryType": "LoanBroker", "LedgerIndex": brokerIDHex,
-			"FinalFields": map[string]any{"Account": brokerAccount, "OwnerNode": "0"},
+			"FinalFields": map[string]any{
+				"Account": brokerAccount, "Owner": brokerOwner,
+				"OwnerNode": "0", "VaultNode": "0", "VaultID": strings.Repeat("0", 64),
+			},
 		}},
 		map[string]any{"DeletedNode": map[string]any{
 			"LedgerEntryType": "Loan", "LedgerIndex": loanKeyHex,
@@ -1291,12 +1446,76 @@ func TestReconstructFromMeta_LoanBrokerResolutionErrors(t *testing.T) {
 	}
 }
 
+func TestReconstructFromMeta_LoanBrokerVaultResolutionErrors(t *testing.T) {
+	const vaultIDHex = "44453F075781FD714AE43F61FC6B4A88BCB5CE3C348FE0FF40B1F6F803C7D86A"
+	vaultID := mustIndex(t, vaultIDHex)
+	vaultKey := keylet.VaultByID(vaultID).Key
+	meta := encodeMeta(t, map[string]any{"CreatedNode": map[string]any{
+		"LedgerEntryType": "LoanBroker",
+		"LedgerIndex":     "33353F075781FD714AE43F61FC6B4A88BCB5CE3C348FE0FF40B1F6F803C7D86A",
+		"NewFields": map[string]any{
+			"Account":      "rEaWzpDUL2cBckwDJhRENZiKCbNKwG2cAZ",
+			"Owner":        "rrrrrrrrrrrrrrrrrrrrBZbvji",
+			"Sequence":     uint32(1),
+			"LoanSequence": uint32(1),
+			"VaultID":      vaultIDHex,
+		},
+	}})
+
+	for _, tt := range []struct {
+		name    string
+		entries map[[32]byte][]byte
+		want    string
+	}{
+		{name: "missing vault", want: "not found"},
+		{
+			name:    "corrupt vault",
+			entries: map[[32]byte][]byte{vaultKey: bytes.Repeat([]byte{0xff}, 12)},
+			want:    "decoding Vault",
+		},
+		{
+			name: "wrong entry type",
+			entries: map[[32]byte][]byte{vaultKey: encodeSLE(t, map[string]any{
+				"LedgerEntryType": "AccountRoot", "Account": testAccount,
+				"Balance": "0", "Flags": 0, "OwnerCount": 0, "Sequence": 0,
+			})},
+			want: "resolved to AccountRoot",
+		},
+		{
+			name: "missing account",
+			entries: map[[32]byte][]byte{vaultKey: encodeSLE(t, map[string]any{
+				"LedgerEntryType": "Vault", "Flags": 0, "Sequence": uint32(1),
+				"OwnerNode": "0", "Owner": testAccount,
+			})},
+			want: "invalid Account",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := reconstructFromMeta(putAll(t, tt.entries), []metaTx{{Blob: meta}}, testLedgerSeq)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func loanBrokerSLE(t *testing.T, account, owner string) []byte {
 	t.Helper()
 	return encodeSLE(t, map[string]any{
 		"LedgerEntryType": "LoanBroker", "Flags": 0, "Sequence": uint32(0),
 		"OwnerNode": "0", "VaultNode": "0", "VaultID": strings.Repeat("0", 64),
 		"Account": account, "Owner": owner, "LoanSequence": uint32(0),
+		"PreviousTxnID": strings.Repeat("0", 64), "PreviousTxnLgrSeq": uint32(0),
+	})
+}
+
+func vaultSLE(t *testing.T, account, owner string) []byte {
+	t.Helper()
+	return encodeSLE(t, map[string]any{
+		"LedgerEntryType": "Vault", "Flags": 0, "Sequence": uint32(0),
+		"OwnerNode": "0", "Owner": owner, "Account": account,
+		"Asset":      map[string]any{"currency": "XRP"},
+		"ShareMPTID": strings.Repeat("0", 48), "WithdrawalPolicy": 1,
 		"PreviousTxnID": strings.Repeat("0", 64), "PreviousTxnLgrSeq": uint32(0),
 	})
 }


### PR DESCRIPTION
## Summary

- restore canonical `LoanBroker` creation defaults and reconstruct both rippled owner-directory links for creation and deletion
- omit object-level `mainnet` diagnoses when metadata reconstruction does not verify against the expected account hash
- preserve the v1 finding shape for verified empty object diffs and add exact-SLE, directory, failure-path, and JSON regressions

## Test plan

- [x] `go test ./internal/replaytool -count=1`
- [x] `go test -race -count=1 -timeout 15m ./internal/replaytool`
- [x] `go test ./...`
- [x] `just build`
- [x] `just build-nocgo`
- [x] `just vet`
- [x] `go vet -tags postgres ./storage/relationaldb/postgres/`
- [x] `golangci-lint run`
- [x] `just lint`
- [x] `git diff --check`

Fixes #1430
