### PR TITLE
fix: match peerfinder bootstrap fallback

### DIFF
--- a/config/validation.go
+++ b/config/validation.go
@@ -279,7 +279,7 @@ func validateIPEntry(entry string) error {
 	}
 
 	if len(parts) == 2 {
-		if err := validatePortString(parts[1]); err != nil {
+		if err := validatePeerPortString(parts[1]); err != nil {
 			return fmt.Errorf("invalid port: %w", err)
 		}
 	}
@@ -293,19 +293,26 @@ func validateFixedIPEntry(entry string) error {
 		return errors.New("fixed IP entry cannot be empty")
 	}
 
-	parts := strings.Fields(entry)
-	if len(parts) != 2 {
-		return errors.New("fixed IP entries must include a port, expected 'IP port'")
+	return validateIPEntry(entry)
+}
+
+func validatePeerPortString(portStr string) error {
+	if portStr == "" {
+		return errors.New("port cannot be empty")
+	}
+	for _, digit := range portStr {
+		if digit < '0' || digit > '9' {
+			return errors.New("port must be numeric")
+		}
 	}
 
-	if parts[0] == "" {
-		return errors.New("IP address cannot be empty")
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return fmt.Errorf("port must be numeric: %w", err)
 	}
-
-	if err := validatePortString(parts[1]); err != nil {
-		return fmt.Errorf("invalid port: %w", err)
+	if port < 0 || port > 65535 {
+		return fmt.Errorf("port must be between 0 and 65535, got %d", port)
 	}
-
 	return nil
 }
 

--- a/config/validation_peer_test.go
+++ b/config/validation_peer_test.go
@@ -1,0 +1,14 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateFixedIPEntryAllowsDefaultPeerPort(t *testing.T) {
+	require.NoError(t, validateFixedIPEntry("fixed.example"))
+	require.NoError(t, validateFixedIPEntry("2001:db8::1"))
+	require.NoError(t, validateFixedIPEntry("fixed.example 0"))
+	require.NoError(t, validateIPEntry("bootstrap.example 0"))
+}

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -727,12 +727,15 @@ func OverlayOptionsFromConfig(appCfg *config.Config) []peermanagement.Option {
 		opts = append(opts, peermanagement.WithListenAddr(""))
 	}
 
-	// Bootstrap peers (convert "host port" → "host:port")
-	if len(appCfg.IPs) > 0 {
-		opts = append(opts, peermanagement.WithBootstrapPeers(normalizeAddresses(appCfg.IPs)...))
+	bootstrapPeers := appCfg.IPs
+	if len(bootstrapPeers) == 0 {
+		bootstrapPeers = appCfg.IPsFixed
 	}
+	if len(bootstrapPeers) == 0 {
+		bootstrapPeers = defaultBootstrapPeers
+	}
+	opts = append(opts, peermanagement.WithBootstrapPeers(normalizeAddresses(bootstrapPeers)...))
 
-	// Fixed peers (convert "host port" → "host:port")
 	if len(appCfg.IPsFixed) > 0 {
 		opts = append(opts, peermanagement.WithFixedPeers(normalizeAddresses(appCfg.IPsFixed)...))
 	}
@@ -913,15 +916,70 @@ func DecodeValidatorKeyWithMaster(key string) (nodeID consensus.NodeID, master [
 	return consensus.CalcNodeID(master), master, nil
 }
 
-// normalizeAddresses converts rippled-style "host port" addresses to "host:port".
+const defaultPeerPort = "2459"
+
+var defaultBootstrapPeers = []string{
+	"r.ripple.com 51235",
+	"sahyadri.isrdc.in 51235",
+	"hubs.xrpkuwait.com 51235",
+	"hub.xrpl-commons.org 51235",
+}
+
 func normalizeAddresses(addrs []string) []string {
 	out := make([]string, len(addrs))
 	for i, addr := range addrs {
-		if parts := strings.Fields(addr); len(parts) == 2 && !strings.Contains(addr, ":") {
-			out[i] = parts[0] + ":" + parts[1]
-		} else {
-			out[i] = addr
+		parts := strings.Fields(addr)
+		if len(parts) == 1 {
+			if host, port, err := net.SplitHostPort(parts[0]); err == nil {
+				if strings.Trim(port, "0") == "" {
+					port = defaultPeerPort
+				}
+				out[i] = net.JoinHostPort(host, port)
+				continue
+			}
+			host, ok := normalizedHost(parts[0], true)
+			if !ok {
+				out[i] = addr
+				continue
+			}
+			out[i] = net.JoinHostPort(host, defaultPeerPort)
+			continue
 		}
+		if len(parts) != 2 {
+			out[i] = addr
+			continue
+		}
+		host, ok := normalizedHost(parts[0], false)
+		if !ok {
+			out[i] = addr
+			continue
+		}
+		port := parts[1]
+		if strings.Trim(port, "0") == "" {
+			port = defaultPeerPort
+		}
+		out[i] = net.JoinHostPort(host, port)
 	}
 	return out
+}
+
+func normalizedHost(host string, allowUnclosedBracket bool) (string, bool) {
+	hasOpen := strings.HasPrefix(host, "[")
+	hasClose := strings.HasSuffix(host, "]")
+	if hasClose && !hasOpen {
+		return "", false
+	}
+	if hasOpen && !hasClose && !allowUnclosedBracket {
+		return "", false
+	}
+	if hasOpen {
+		host = strings.TrimPrefix(host, "[")
+		if hasClose {
+			host = strings.TrimSuffix(host, "]")
+		}
+		if net.ParseIP(host) == nil {
+			return "", false
+		}
+	}
+	return host, true
 }

--- a/internal/consensus/adaptor/startup_test.go
+++ b/internal/consensus/adaptor/startup_test.go
@@ -1,11 +1,14 @@
 package adaptor
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/config"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestOverlayOptionsFromConfig_PropagatesClusterNodes guards the one-line
@@ -65,6 +68,164 @@ func TestOverlayOptionsFromConfig_UnsetDomainAndIPEmitNoOption(t *testing.T) {
 
 	assert.Empty(t, cfg.ServerDomain)
 	assert.Nil(t, cfg.PublicIP)
+}
+
+func TestOverlayOptionsFromConfig_BootstrapPrecedence(t *testing.T) {
+	tests := []struct {
+		name          string
+		appCfg        *config.Config
+		wantBootstrap []string
+		wantFixed     []string
+	}{
+		{
+			name: "configured ips",
+			appCfg: &config.Config{
+				IPs:      []string{"bootstrap.example", "2001:db8::1 51235", "zero.example:0"},
+				IPsFixed: []string{"fixed.example 6000"},
+			},
+			wantBootstrap: []string{"bootstrap.example:2459", "[2001:db8::1]:51235", "zero.example:2459"},
+			wantFixed:     []string{"fixed.example:6000"},
+		},
+		{
+			name: "fixed fallback",
+			appCfg: &config.Config{
+				IPsFixed: []string{
+					"fixed.example",
+					"2001:db8::2",
+					"empty.example:",
+					"[2001:db8::3]:0",
+					"space-zero.example 0",
+					"[2001:db8::4",
+				},
+			},
+			wantBootstrap: []string{
+				"fixed.example:2459",
+				"[2001:db8::2]:2459",
+				"empty.example:2459",
+				"[2001:db8::3]:2459",
+				"space-zero.example:2459",
+				"[2001:db8::4]:2459",
+			},
+			wantFixed: []string{
+				"fixed.example:2459",
+				"[2001:db8::2]:2459",
+				"empty.example:2459",
+				"[2001:db8::3]:2459",
+				"space-zero.example:2459",
+				"[2001:db8::4]:2459",
+			},
+		},
+		{
+			name:   "public defaults",
+			appCfg: &config.Config{},
+			wantBootstrap: []string{
+				"r.ripple.com:51235",
+				"sahyadri.isrdc.in:51235",
+				"hubs.xrpkuwait.com:51235",
+				"hub.xrpl-commons.org:51235",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := peermanagement.DefaultConfig()
+			for _, opt := range OverlayOptionsFromConfig(tt.appCfg) {
+				opt(&cfg)
+			}
+
+			assert.Equal(t, tt.wantBootstrap, cfg.BootstrapPeers)
+			assert.Equal(t, tt.wantFixed, cfg.FixedPeers)
+		})
+	}
+}
+
+func TestOverlayOptionsFromConfig_FixedFallbackConnectsThroughBootstrap(t *testing.T) {
+	source := startBootstrapFallbackOverlay(t)
+	connected := make(chan struct{}, 1)
+	source.SetPeerConnectCallback(func(peermanagement.PeerID) {
+		select {
+		case connected <- struct{}{}:
+		default:
+		}
+	})
+
+	opts := OverlayOptionsFromConfig(&config.Config{
+		IPsFixed: []string{source.ListenAddr()},
+	})
+	opts = append(opts,
+		peermanagement.WithListenAddr("127.0.0.1:0"),
+		peermanagement.WithMaxPeers(2),
+		peermanagement.WithMaxInbound(0),
+		peermanagement.WithMaxOutbound(1),
+		peermanagement.WithPrivateMode(false),
+		peermanagement.WithFixedPeers(),
+	)
+	client := startBootstrapFallbackOverlay(t, opts...)
+
+	select {
+	case <-connected:
+		require.Eventually(t, func() bool {
+			return client.PeerCount() == 1
+		}, time.Second, 10*time.Millisecond)
+	case <-time.After(5 * time.Second):
+		t.Fatal("fixed-only fallback was not selected through the bootstrap lane")
+	}
+}
+
+func TestNormalizeAddressesPreservesInvalidForms(t *testing.T) {
+	for _, input := range []string{
+		"2001:db8::1]",
+		"[not-an-ip]",
+		"[2001:db8::1 51235",
+	} {
+		got := normalizeAddresses([]string{input})
+		require.Equal(t, []string{input}, got)
+		_, err := peermanagement.ParseEndpoint(got[0])
+		require.Error(t, err)
+	}
+}
+
+func TestNormalizeAddressesIPv6WhitespacePorts(t *testing.T) {
+	assert.Equal(t,
+		[]string{"[2001:db8::1]:51235", "[2001:db8::2]:51235"},
+		normalizeAddresses([]string{"2001:db8::1 51235", "[2001:db8::2] 51235"}),
+	)
+}
+
+func startBootstrapFallbackOverlay(t *testing.T, opts ...peermanagement.Option) *peermanagement.Overlay {
+	t.Helper()
+	base := []peermanagement.Option{
+		peermanagement.WithListenAddr("127.0.0.1:0"),
+		peermanagement.WithMaxPeers(2),
+		peermanagement.WithMaxInbound(1),
+		peermanagement.WithMaxOutbound(0),
+		peermanagement.WithPrivateMode(true),
+		peermanagement.WithCompression(false),
+	}
+	overlay, err := peermanagement.New(append(base, opts...)...)
+	require.NoError(t, err)
+
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- overlay.Run(context.Background())
+	}()
+	select {
+	case <-overlay.ListenerReady():
+	case err := <-runDone:
+		t.Fatalf("overlay stopped before its listener became ready: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("overlay listener did not become ready")
+	}
+	t.Cleanup(func() {
+		require.NoError(t, overlay.Stop())
+		select {
+		case <-runDone:
+		case <-time.After(5 * time.Second):
+			t.Error("overlay did not stop")
+		}
+	})
+	return overlay
 }
 
 // TestFeeVoteFromConfig guards the [voting] → FeeVoteStance wiring:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2007,3 +2007,49 @@ Behavioral oracle: local rippled v3.2.0 checkout at
 - The local rippled oracle files were reviewed, but its `.git` worktree pointer
   is broken, so the configured v3.2.0 SHA/tag and clean status could not be
   independently re-verified.
+
+# Issue #1435 — peerfinder bootstrap fallback
+
+Target: `origin/main` at `2d58a04e3e447e0c737a1dbba779ffa3a1fd05cb`.
+Behavioral oracle: local rippled v3.2.0 snapshot at
+`rippled-worktrees/v3.2.0-oracle/`.
+
+## Plan
+
+- [x] Validate GitHub access, repository identity, open issue state, absence of
+      linked work, default base branch, and clean dedicated worktree.
+- [x] Trace bootstrap-source precedence, address normalization, fixed-peer
+      persistence, and standalone startup in goXRPL and rippled v3.2.0.
+- [x] Add focused configuration tests for explicit, fixed-only, empty, and
+      legacy address forms plus a fixed-only startup regression; verify the
+      standalone composition-root gate remains intact.
+- [x] Implement the smallest production-quality fallback matching rippled while
+      retaining the independent fixed-peer lane.
+- [x] Run formatting, focused and affected tests, race coverage where useful,
+      build, vet, strict lint, and final diff/conformance review.
+- [x] Record exact review results, stage only intentional files, commit, push,
+      open the PR against `main`, and verify the published head.
+
+## Review
+
+- `OverlayOptionsFromConfig` now applies rippled's `[ips]`, `[ips_fixed]`, then
+  four-public-default precedence. Fixed-only endpoints are copied into the
+  bootstrap source and separately retained as fixed peers.
+- The four public defaults remain explicitly on port 51235. Configured
+  endpoints with an omitted, empty, or zero port use rippled's IANA default
+  2459 in both roles; IPv4, hostname, IPv6, whitespace, and legacy bracket
+  forms follow the v3.2.0 parser behavior.
+- Portless `[ips_fixed]` entries are now valid so the same normalization is
+  reachable through loaded configurations. Standalone still skips
+  `adaptor.NewFromConfig` entirely and therefore initiates no peer discovery.
+- The startup integration regression removes the fixed-peer lane after option
+  derivation and proves a fixed-only endpoint still connects through ordinary
+  bootstrap selection.
+- Passing gates: focused tests repeated, affected packages under `-race`,
+  `just test-core`, `just test-libs`, `just build-all`, `just vet`, tagged
+  PostgreSQL vet, strict CI and advisory golangci-lint v2.11.3, formatting, and
+  `git diff --check`.
+- Independent Go-quality and rippled-conformance reviews found no remaining
+  findings. The designated local oracle snapshot was reviewed directly; its
+  detached worktree metadata cannot independently prove the expected
+  `3c43f4614f87965298773279ff5b85d4c56c637b` commit.


### PR DESCRIPTION
## Summary
- match rippled's bootstrap precedence by using `[ips]`, then `[ips_fixed]`, then the exact four public defaults while retaining fixed-peer registration
- normalize configured peer endpoints with rippled's default-port and legacy IPv4/IPv6 parsing behavior
- cover all precedence branches and prove fixed-only configuration can connect through the ordinary bootstrap lane

## Test plan
- [x] `go test ./config ./internal/consensus/adaptor ./internal/peermanagement -count=1`
- [x] `go test -race -count=1 -timeout 15m ./config/... ./internal/consensus/adaptor/... ./internal/peermanagement/...`
- [x] `just test-core`
- [x] `just test-libs`
- [x] `just build-all`
- [x] `just vet`
- [x] `go vet -tags postgres ./storage/relationaldb/postgres/`
- [x] `golangci-lint run`
- [x] `just lint`

Fixes #1435
