### PR TITLE
fix: protect consensus ingress from divergent peers

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -145,6 +145,7 @@ type Adaptor struct {
 	onLedgerSwitched func(seq uint32, hash, parentHash [32]byte, historyFloor uint32)
 	// Set once by NewRouter before validation processing starts.
 	onLedgerFullyValidated func(seq uint32, hash [32]byte)
+	onLedgerBuilt          func(seq uint32, hash [32]byte)
 
 	// onTxSetBuilt fires when BuildTxSet caches a new tx set, so the overlay
 	// can broadcast mtHAVE_SET{tsHAVE} for it. nil-safe.
@@ -556,6 +557,10 @@ func (a *Adaptor) setOnLedgerSwitched(cb func(uint32, [32]byte, [32]byte, uint32
 
 func (a *Adaptor) setOnLedgerFullyValidated(cb func(uint32, [32]byte)) {
 	a.onLedgerFullyValidated = cb
+}
+
+func (a *Adaptor) setOnLedgerBuilt(cb func(uint32, [32]byte)) {
+	a.onLedgerBuilt = cb
 }
 
 func (a *Adaptor) RequestTxSet(id consensus.TxSetID) error {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -143,6 +143,8 @@ type Adaptor struct {
 
 	// Set once by NewRouter before the engine starts.
 	onLedgerSwitched func(seq uint32, hash, parentHash [32]byte, historyFloor uint32)
+	// Set once by NewRouter before validation processing starts.
+	onLedgerFullyValidated func(seq uint32, hash [32]byte)
 
 	// onTxSetBuilt fires when BuildTxSet caches a new tx set, so the overlay
 	// can broadcast mtHAVE_SET{tsHAVE} for it. nil-safe.
@@ -550,6 +552,10 @@ func (a *Adaptor) SetOnLedgerRequested(cb func(consensus.LedgerID) error) {
 
 func (a *Adaptor) setOnLedgerSwitched(cb func(uint32, [32]byte, [32]byte, uint32)) {
 	a.onLedgerSwitched = cb
+}
+
+func (a *Adaptor) setOnLedgerFullyValidated(cb func(uint32, [32]byte)) {
+	a.onLedgerFullyValidated = cb
 }
 
 func (a *Adaptor) RequestTxSet(id consensus.TxSetID) error {

--- a/internal/consensus/adaptor/consensus_events.go
+++ b/internal/consensus/adaptor/consensus_events.go
@@ -325,6 +325,9 @@ func (a *Adaptor) OnLedgerFullyValidated(ledgerID consensus.LedgerID, seq uint32
 
 	var hash [32]byte
 	copy(hash[:], ledgerID[:])
+	if a.onLedgerFullyValidated != nil {
+		a.onLedgerFullyValidated(seq, hash)
+	}
 	if a.ledgerService.NeedsInitialSync() {
 		if _, err := a.ledgerService.GetLedgerByHash(hash); err != nil {
 			a.sender.CheckTracking(seq)

--- a/internal/consensus/adaptor/consensus_events.go
+++ b/internal/consensus/adaptor/consensus_events.go
@@ -70,6 +70,9 @@ func (a *Adaptor) OnConsensusReached(ledger consensus.Ledger, validations []*con
 	}
 
 	a.maybePromoteAfterConsensus(ledger)
+	if a.onLedgerBuilt != nil {
+		a.onLedgerBuilt(ledger.Seq(), [32]byte(ledger.ID()))
+	}
 }
 
 // emitConsensusPhase delivers a consensus-phase notification through a single

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -383,12 +383,10 @@ func (r *Router) SetTxInbox(txInbox <-chan *peermanagement.InboundMessage) {
 	r.txInbox = txInbox
 }
 
-// SetServiceInbox installs the overlay's best-effort service lane.
 func (r *Router) SetServiceInbox(serviceInbox <-chan *peermanagement.InboundMessage) {
 	r.serviceInbox = serviceInbox
 }
 
-// SetConsensusControlInbox installs the overlay's protected consensus-control lane.
 func (r *Router) SetConsensusControlInbox(inbox <-chan *peermanagement.InboundMessage) {
 	r.consensusControlInbox = inbox
 }

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -369,6 +369,7 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, inbox <-chan *peermana
 		adaptor.SetOnLedgerRequested(r.requestConsensusLedger)
 		adaptor.setOnLedgerSwitched(r.onLedgerSwitched)
 		adaptor.setOnLedgerFullyValidated(r.onLedgerFullyValidated)
+		adaptor.setOnLedgerBuilt(r.onLedgerBuilt)
 	}
 	return r
 }

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -57,7 +57,15 @@ type peerBootstrapAcknowledger interface {
 type Router struct {
 	engine  consensus.Engine
 	adaptor *Adaptor
-	inbox   <-chan *peermanagement.InboundMessage
+	// inbox is the overlay's bounded, backpressured consensus lane.
+	inbox <-chan *peermanagement.InboundMessage
+	// serviceInbox carries best-effort, recoverable peer traffic. Keeping it
+	// separate prevents ledger requests and other service frames from occupying
+	// the consensus lane.
+	serviceInbox <-chan *peermanagement.InboundMessage
+	// consensusControlInbox carries status changes and transaction-set
+	// availability on a protected lane separate from proposals and validations.
+	consensusControlInbox <-chan *peermanagement.InboundMessage
 	// txInbox is the overlay's dedicated transaction lane. Run drains it
 	// alongside inbox and hands each frame to the worker pool, so a tx
 	// flood on this lane can't starve consensus/acquisition frames
@@ -253,7 +261,16 @@ type catchupTarget struct {
 	seq    uint32
 	hash   [32]byte
 	peerID uint64
+	source catchupTargetSource
 }
+
+type catchupTargetSource uint8
+
+const (
+	catchupSourcePeer catchupTargetSource = iota
+	catchupSourceValidation
+	catchupSourceQuorum
+)
 
 type consensusRecovery struct {
 	targetHash [32]byte
@@ -351,6 +368,7 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, inbox <-chan *peermana
 		adaptor.SetOnTxSetRequested(r.MarkTxSetStillNeeded)
 		adaptor.SetOnLedgerRequested(r.requestConsensusLedger)
 		adaptor.setOnLedgerSwitched(r.onLedgerSwitched)
+		adaptor.setOnLedgerFullyValidated(r.onLedgerFullyValidated)
 	}
 	return r
 }
@@ -362,6 +380,16 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, inbox <-chan *peermana
 // inbox-only behaviour tests rely on.
 func (r *Router) SetTxInbox(txInbox <-chan *peermanagement.InboundMessage) {
 	r.txInbox = txInbox
+}
+
+// SetServiceInbox installs the overlay's best-effort service lane.
+func (r *Router) SetServiceInbox(serviceInbox <-chan *peermanagement.InboundMessage) {
+	r.serviceInbox = serviceInbox
+}
+
+// SetConsensusControlInbox installs the overlay's protected consensus-control lane.
+func (r *Router) SetConsensusControlInbox(inbox <-chan *peermanagement.InboundMessage) {
+	r.consensusControlInbox = inbox
 }
 
 // SetAcqInbox installs the overlay's dedicated acquisition-reply lane (see the
@@ -644,6 +672,9 @@ func (r *Router) Run(ctx context.Context) {
 	defer ticker.Stop()
 	r.drainPeerConnects()
 	for {
+		if !r.drainConsensusInbox(ctx) {
+			return
+		}
 		acqInbox := r.acqInbox
 		if !workLane.canAcceptData() {
 			acqInbox = nil
@@ -654,6 +685,18 @@ func (r *Router) Run(ctx context.Context) {
 		case msg, ok := <-r.inbox:
 			if !ok {
 				return
+			}
+			r.handleMessage(msg)
+		case msg, ok := <-r.serviceInbox:
+			if !ok {
+				r.serviceInbox = nil
+				continue
+			}
+			r.handleMessage(msg)
+		case msg, ok := <-r.consensusControlInbox:
+			if !ok {
+				r.consensusControlInbox = nil
+				continue
 			}
 			r.handleMessage(msg)
 		case msg, ok := <-acqInbox:
@@ -687,6 +730,25 @@ func (r *Router) Run(ctx context.Context) {
 			r.maintenanceTick()
 		}
 	}
+}
+
+const consensusDrainBatch = 32
+
+func (r *Router) drainConsensusInbox(ctx context.Context) bool {
+	for range consensusDrainBatch {
+		select {
+		case <-ctx.Done():
+			return false
+		case msg, ok := <-r.inbox:
+			if !ok {
+				return false
+			}
+			r.handleMessage(msg)
+		default:
+			return true
+		}
+	}
+	return true
 }
 
 func (r *Router) drainAcquisitionInboxBeforeMaintenance(workLane *acquisitionWorkLane) int {

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -562,7 +562,7 @@ func (r *Router) armCatchupTowardTargetWithPeer(peerHint uint64) {
 	r.catchupMu.Lock()
 	target := r.catchup
 	r.catchupMu.Unlock()
-	if peerHint == 0 {
+	if peerHint == 0 && target.source == catchupSourceQuorum {
 		peerHint = target.peerID
 	}
 	tSeq, tHash := target.seq, target.hash

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -559,12 +559,26 @@ func (r *Router) armCatchupTowardTargetWithPeer(peerHint uint64) {
 	if r.catchupInFlight() >= maxConcurrentSpeculativeCatchup {
 		return
 	}
-	tSeq, tHash, _ := r.bestCatchupTarget()
+	r.catchupMu.Lock()
+	target := r.catchup
+	r.catchupMu.Unlock()
+	tSeq, tHash := target.seq, target.hash
 	if tSeq == 0 {
 		return
 	}
 	closed := svc.GetClosedLedgerIndex()
 	if tSeq <= closed {
+		if target.source != catchupSourceQuorum {
+			return
+		}
+		if held, err := svc.GetLedgerByHash(tHash); err == nil && held != nil {
+			return
+		}
+		peer, found := r.resolveAcquisitionPeer(tSeq, peerHint)
+		if !found || r.isBuildingLedger(tSeq) {
+			return
+		}
+		r.startLedgerAcquisition(tSeq, tHash, peer)
 		return
 	}
 	if !svc.NeedsInitialSync() && !aheadByMoreThan(tSeq, closed, 1) {
@@ -1742,6 +1756,9 @@ func (r *Router) maybeAcquireFromValidation(v *consensus.Validation, originPeer 
 	// closed, so acquire it directly — without it the validation trie can never
 	// place the majority branch (rippled RCLValidationsAdaptor::acquire).
 	if v.LedgerSeq <= svc.GetClosedLedgerIndex() {
+		if r.isBuildingLedger(v.LedgerSeq) {
+			return
+		}
 		r.startLedgerAcquisition(v.LedgerSeq, hash, originPeer)
 		return
 	}
@@ -1841,6 +1858,10 @@ type buildingLedgerEngine interface {
 func (r *Router) isBuildingLedger(seq uint32) bool {
 	engine, ok := r.engine.(buildingLedgerEngine)
 	return ok && seq != 0 && engine.BuildingLedgerSeq() == seq
+}
+
+func (r *Router) onLedgerBuilt(uint32, [32]byte) {
+	r.armCatchupTowardTarget()
 }
 
 // checkBehind decides what to do based on how far behind a peer

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -562,6 +562,9 @@ func (r *Router) armCatchupTowardTargetWithPeer(peerHint uint64) {
 	r.catchupMu.Lock()
 	target := r.catchup
 	r.catchupMu.Unlock()
+	if peerHint == 0 {
+		peerHint = target.peerID
+	}
 	tSeq, tHash := target.seq, target.hash
 	if tSeq == 0 {
 		return
@@ -1021,8 +1024,14 @@ func (r *Router) onLedgerFullyValidated(seq uint32, hash [32]byte) {
 	r.acquisitionMu.Unlock()
 
 	r.catchupMu.Lock()
-	if r.catchup.seq == seq && r.catchup.hash != hash {
+	if r.catchup.seq < seq {
 		r.catchup = catchupTarget{seq: seq, hash: hash, source: catchupSourceQuorum}
+	} else if r.catchup.seq == seq {
+		if r.catchup.hash == hash {
+			r.catchup.source = catchupSourceQuorum
+		} else {
+			r.catchup = catchupTarget{seq: seq, hash: hash, source: catchupSourceQuorum}
+		}
 	}
 	r.catchupMu.Unlock()
 

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -660,9 +660,13 @@ func (r *Router) ensureCatchupAcquisitionWithPriority(
 		r.recordCatchupTarget(seq, hash, peerID)
 	} else {
 		r.recordValidationCatchupTarget(seq, hash, peerID, source)
-		if r.adaptor.GetOperatingMode() == consensus.OpModeFull &&
-			!aheadByMoreThan(seq, svc.GetClosedLedgerIndex(), 1) {
-			return
+		if r.engine != nil {
+			state := r.engine.State()
+			if state != nil &&
+				state.Round.Seq == seq &&
+				r.engine.Phase() != consensus.PhaseOpen {
+				return
+			}
 		}
 		if il := r.fetchTracker.Find(hash); il != nil && il.Reason() == inbound.ReasonConsensus {
 			r.refreshCatchupAcquisitionPeer(il, peerID)

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -576,11 +576,17 @@ func (r *Router) armCatchupTowardTargetWithPeer(peerHint uint64) {
 		if !found {
 			return
 		}
+		if r.isBuildingLedger(seq) {
+			return
+		}
 		r.startLedgerAcquisition(seq, hash, peer)
 		return
 	}
 	peer, found := r.resolveAcquisitionPeer(tSeq, peerHint)
 	if !found {
+		return
+	}
+	if r.isBuildingLedger(tSeq) {
 		return
 	}
 	r.startLedgerAcquisition(tSeq, tHash, peer)
@@ -660,13 +666,8 @@ func (r *Router) ensureCatchupAcquisitionWithPriority(
 		r.recordCatchupTarget(seq, hash, peerID)
 	} else {
 		r.recordValidationCatchupTarget(seq, hash, peerID, source)
-		if r.engine != nil {
-			state := r.engine.State()
-			if state != nil &&
-				state.Round.Seq == seq &&
-				r.engine.Phase() != consensus.PhaseOpen {
-				return
-			}
+		if r.isBuildingLedger(seq) {
+			return
 		}
 		if il := r.fetchTracker.Find(hash); il != nil && il.Reason() == inbound.ReasonConsensus {
 			r.refreshCatchupAcquisitionPeer(il, peerID)
@@ -1822,12 +1823,24 @@ func (r *Router) armValidationStashAcquisition(seq uint32, hash [32]byte) {
 		preferredPeerID,
 		catchupSourceQuorum,
 	)
+	if r.isBuildingLedger(seq) {
+		return
+	}
 	r.logger.Info("arming acquisition for stashed validation",
 		"seq", seq,
 		"hash", fmt.Sprintf("%x", hash[:8]),
 		"preferred_peer", preferredPeerID,
 	)
 	r.startLedgerAcquisition(seq, hash, preferredPeerID)
+}
+
+type buildingLedgerEngine interface {
+	BuildingLedgerSeq() uint32
+}
+
+func (r *Router) isBuildingLedger(seq uint32) bool {
+	engine, ok := r.engine.(buildingLedgerEngine)
+	return ok && seq != 0 && engine.BuildingLedgerSeq() == seq
 }
 
 // checkBehind decides what to do based on how far behind a peer

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -82,7 +82,9 @@ func (r *Router) handleStatusChange(msg *peermanagement.InboundMessage) {
 		// During initial sync, fetch the full ledger from the peer.
 		// Don't adopt with synthetic headers — wait for real state data.
 		if r.adaptor.NeedsInitialSync() && sc.LedgerSeq > 1 {
-			r.ensureCatchupAcquisition(sc.LedgerSeq, peerHash, uint64(msg.PeerID))
+			if r.peerLedgerIsPreferred(peerHash) {
+				r.ensureCatchupAcquisition(sc.LedgerSeq, peerHash, uint64(msg.PeerID))
+			}
 			return
 		}
 
@@ -94,6 +96,9 @@ func (r *Router) handleStatusChange(msg *peermanagement.InboundMessage) {
 			if svc != nil {
 				ourSeq := svc.GetClosedLedgerIndex()
 				if aheadByMoreThan(sc.LedgerSeq, ourSeq, 2) {
+					if !r.peerLedgerIsPreferred(peerHash) {
+						return
+					}
 					leftFull := false
 					if lcl, err := r.adaptor.GetLastClosedLedger(); err == nil && lcl != nil &&
 						r.adaptor.networkLedgerDiffers(lcl, consensus.OpModeFull) {
@@ -119,35 +124,9 @@ func (r *Router) handleStatusChange(msg *peermanagement.InboundMessage) {
 			if svc != nil {
 				ourSeq := svc.GetClosedLedgerIndex()
 				if aheadByMoreThan(sc.LedgerSeq, ourSeq, 1) {
-					r.ensureCatchupAcquisition(sc.LedgerSeq, peerHash, uint64(msg.PeerID))
-					return
-				}
-			}
-		}
-
-		// Hash-divergence catch-up. A late-join node (or a node whose
-		// consensus ran in isolation while disconnected) can end up at
-		// the same seq as its peers but with a different ledger hash.
-		// The seq-based branches above don't fire because ourSeq ==
-		// peerSeq; we need to detect that our LCL hash differs from the
-		// peer's and acquire theirs. Only fire if we're NOT already
-		// acquiring that hash (startLedgerAcquisition dedupes internally
-		// via the replayer / acquisition-registry guards, but checking
-		// here saves a lookup in the hot path).
-		svc := r.adaptor.LedgerService()
-		if svc != nil && sc.LedgerSeq > 1 && len(sc.LedgerHash) == 32 {
-			closed := svc.GetClosedLedger()
-			if closed != nil {
-				ourSeq := closed.Sequence()
-				ourHash := closed.Hash()
-				if ourSeq == sc.LedgerSeq && ourHash != peerHash {
-					r.logger.Warn("ledger hash divergence at same seq, acquiring peer's ledger",
-						"seq", sc.LedgerSeq,
-						"our_hash", fmt.Sprintf("%x", ourHash[:8]),
-						"peer_hash", fmt.Sprintf("%x", peerHash[:8]),
-						"peer", msg.PeerID,
-					)
-					r.startLedgerAcquisition(sc.LedgerSeq, peerHash, uint64(msg.PeerID))
+					if r.peerLedgerIsPreferred(peerHash) {
+						r.ensureCatchupAcquisition(sc.LedgerSeq, peerHash, uint64(msg.PeerID))
+					}
 					return
 				}
 			}
@@ -155,6 +134,15 @@ func (r *Router) handleStatusChange(msg *peermanagement.InboundMessage) {
 
 		r.checkBehind(sc.LedgerSeq, peerHash, uint64(msg.PeerID))
 	}
+}
+
+func (r *Router) peerLedgerIsPreferred(hash [32]byte) bool {
+	closed, err := r.adaptor.GetLastClosedLedger()
+	if err != nil || closed == nil {
+		return false
+	}
+	preferred := r.adaptor.preferredLCL(closed, r.adaptor.GetOperatingMode())
+	return preferred != closed.ID() && preferred == consensus.LedgerID(hash)
 }
 
 // maxConcurrentCatchup bounds the hash-keyed current-ledger acquisition set.
@@ -281,8 +269,32 @@ func (r *Router) catchupInFlight() int {
 func (r *Router) recordCatchupTarget(seq uint32, hash [32]byte, peerID uint64) {
 	r.catchupMu.Lock()
 	defer r.catchupMu.Unlock()
+	if r.catchup.source != catchupSourcePeer && r.catchup.hash == hash {
+		r.catchup.peerID = peerID
+		return
+	}
 	if seq > r.catchup.seq {
 		r.catchup = catchupTarget{seq: seq, hash: hash, peerID: peerID}
+	} else if seq == r.catchup.seq && hash == r.catchup.hash {
+		r.catchup.peerID = peerID
+	}
+}
+
+func (r *Router) recordValidationCatchupTarget(
+	seq uint32,
+	hash [32]byte,
+	peerID uint64,
+	source catchupTargetSource,
+) {
+	r.catchupMu.Lock()
+	defer r.catchupMu.Unlock()
+	// Trusted evidence replaces a peer-derived target at any sequence. Once
+	// validation-driven, only a higher sequence or same-sequence quorum can
+	// move the frontier.
+	if r.catchup.source == catchupSourcePeer ||
+		(source == catchupSourceQuorum && seq == r.catchup.seq) ||
+		seq > r.catchup.seq {
+		r.catchup = catchupTarget{seq: seq, hash: hash, peerID: peerID, source: source}
 	} else if seq == r.catchup.seq && hash == r.catchup.hash {
 		r.catchup.peerID = peerID
 	}
@@ -618,6 +630,21 @@ func (r *Router) forwardDeltaStep(svc *service.Service, closed, tipSeq uint32) (
 // path re-arms toward the latest target. Bounds CONCURRENCY only — callers do
 // their own eligibility gating first.
 func (r *Router) ensureCatchupAcquisition(seq uint32, hash [32]byte, peerID uint64) {
+	r.ensureCatchupAcquisitionWithPriority(seq, hash, peerID, catchupSourcePeer)
+}
+
+// ensureValidationCatchupAcquisition acquires each trusted-validation ledger
+// without allowing a lagging validator to lower the preferred catch-up frontier.
+func (r *Router) ensureValidationCatchupAcquisition(seq uint32, hash [32]byte, peerID uint64) {
+	r.ensureCatchupAcquisitionWithPriority(seq, hash, peerID, catchupSourceValidation)
+}
+
+func (r *Router) ensureCatchupAcquisitionWithPriority(
+	seq uint32,
+	hash [32]byte,
+	peerID uint64,
+	source catchupTargetSource,
+) {
 	svc := r.adaptor.LedgerService()
 	if svc == nil {
 		return
@@ -625,8 +652,25 @@ func (r *Router) ensureCatchupAcquisition(seq uint32, hash [32]byte, peerID uint
 	if seq == 0 || seq <= svc.GetClosedLedgerIndex() {
 		return
 	}
+	if held, err := svc.GetLedgerByHash(hash); err == nil && held != nil {
+		return
+	}
 	peerID, _ = r.resolveAcquisitionPeer(seq, peerID)
-	r.recordCatchupTarget(seq, hash, peerID)
+	if source == catchupSourcePeer {
+		r.recordCatchupTarget(seq, hash, peerID)
+	} else {
+		r.recordValidationCatchupTarget(seq, hash, peerID, source)
+		if r.adaptor.GetOperatingMode() == consensus.OpModeFull &&
+			!aheadByMoreThan(seq, svc.GetClosedLedgerIndex(), 1) {
+			return
+		}
+		if il := r.fetchTracker.Find(hash); il != nil && il.Reason() == inbound.ReasonConsensus {
+			r.refreshCatchupAcquisitionPeer(il, peerID)
+			return
+		}
+		r.startLedgerAcquisition(seq, hash, peerID)
+		return
+	}
 	if il := r.fetchTracker.Find(hash); il != nil && il.Reason() == inbound.ReasonConsensus {
 		r.refreshCatchupAcquisitionPeer(il, peerID)
 		return
@@ -927,6 +971,50 @@ func (r *Router) onLedgerSwitched(seq uint32, _ [32]byte, parentHash [32]byte, h
 		return
 	}
 	r.startHistoryBackfill(seq-1, parentHash, 0, historyFloor)
+}
+
+func (r *Router) onLedgerFullyValidated(seq uint32, hash [32]byte) {
+	r.recordSeqHash(seq, hash, [32]byte{}, false)
+
+	removed := make(map[[32]byte]struct{})
+	var legacy []*inbound.Ledger
+
+	r.acquisitionMu.Lock()
+	for _, candidate := range r.fetchTracker.Active() {
+		if candidate.Reason() != inbound.ReasonConsensus ||
+			candidate.Seq() != seq || candidate.Hash() == hash {
+			continue
+		}
+		if r.fetchTracker.DiscardExpected(candidate) {
+			legacy = append(legacy, candidate)
+			removed[candidate.Hash()] = struct{}{}
+		}
+	}
+	for _, replayHash := range r.replayer.AbandonOtherAtSequence(seq, hash) {
+		removed[replayHash] = struct{}{}
+	}
+	if _, ok := removed[r.consensusRecovery.stepHash]; ok {
+		r.consensusRecovery.stepHash = [32]byte{}
+	}
+	if _, ok := removed[r.consensusRecovery.targetHash]; ok {
+		r.consensusRecovery = consensusRecovery{}
+	}
+	r.acquisitionMu.Unlock()
+
+	r.catchupMu.Lock()
+	if r.catchup.seq == seq && r.catchup.hash != hash {
+		r.catchup = catchupTarget{seq: seq, hash: hash, source: catchupSourceQuorum}
+	}
+	r.catchupMu.Unlock()
+
+	r.retireLegacyAcquisitions(legacy)
+	if len(removed) > 0 {
+		r.logger.Info("canceled acquisitions superseded by trusted validation quorum",
+			"seq", seq,
+			"hash", fmt.Sprintf("%x", hash[:8]),
+			"canceled", len(removed),
+		)
+	}
 }
 
 func (r *Router) completeHistoryBackfill(seq uint32, hash, parentHash [32]byte, peerID uint64) {
@@ -1633,6 +1721,12 @@ func (r *Router) maybeAcquireFromValidation(v *consensus.Validation, originPeer 
 		return
 	}
 	hash := [32]byte(v.LedgerID)
+	r.recordValidationCatchupTarget(
+		v.LedgerSeq,
+		hash,
+		originPeer,
+		catchupSourceValidation,
+	)
 	// Already have it (built or adopted) — nothing to fetch.
 	if l, err := svc.GetLedgerByHash(hash); err == nil && l != nil {
 		return
@@ -1646,7 +1740,7 @@ func (r *Router) maybeAcquireFromValidation(v *consensus.Validation, originPeer 
 		r.startLedgerAcquisition(v.LedgerSeq, hash, originPeer)
 		return
 	}
-	r.ensureCatchupAcquisition(v.LedgerSeq, hash, originPeer)
+	r.ensureValidationCatchupAcquisition(v.LedgerSeq, hash, originPeer)
 }
 
 // armValidationStashAcquisition arms inbound acquisition for a (seq, hash)
@@ -1718,7 +1812,12 @@ func (r *Router) armValidationStashAcquisition(seq uint32, hash [32]byte) {
 
 	// Keep the newest target even when the speculative slots are full; completion
 	// or maintenance will re-arm it when capacity becomes available.
-	r.recordCatchupTarget(seq, hash, preferredPeerID)
+	r.recordValidationCatchupTarget(
+		seq,
+		hash,
+		preferredPeerID,
+		catchupSourceQuorum,
+	)
 	r.logger.Info("arming acquisition for stashed validation",
 		"seq", seq,
 		"hash", fmt.Sprintf("%x", hash[:8]),
@@ -1732,12 +1831,11 @@ func (r *Router) armValidationStashAcquisition(seq uint32, hash [32]byte) {
 //
 //   - peerSeq <= ourSeq+1: we're caught up. If still in Tracking and
 //     our LCL hash matches peers' majority, transition to Full.
-//     Otherwise stay in Tracking — the hash-mismatch branch in
-//     handleStatusChange will have already fired the right acquisition.
-//   - peerSeq > ourSeq+1: we're behind by more than one ledger. Arm a
-//     single acquisition for the peer's tip. Subsequent status changes
-//     from peers will chain more acquisitions forward as we adopt each
-//     ledger and ourSeq advances.
+//     Otherwise stay in Tracking until network preference is established.
+//   - peerSeq > ourSeq+1: we're behind by more than one ledger. If the
+//     peer's tip is network-preferred, arm one acquisition. Subsequent
+//     status changes chain acquisitions forward as we adopt each ledger
+//     and ourSeq advances.
 //
 // Only one acquisition fires per call. A faster "range walk" that
 // issues concurrent requests for every seq between ourLCL+1 and
@@ -1787,6 +1885,9 @@ func (r *Router) checkBehind(peerSeq uint32, peerHash [32]byte, peerID uint64) {
 		return
 	}
 	if !aheadByMoreThan(peerSeq, ourSeq, 1) {
+		return
+	}
+	if !r.peerLedgerIsPreferred(peerHash) {
 		return
 	}
 

--- a/internal/consensus/adaptor/router_catchup_test.go
+++ b/internal/consensus/adaptor/router_catchup_test.go
@@ -452,10 +452,19 @@ func TestRouter_ActiveBuildDoesNotAcquireItsTargetLedger(t *testing.T) {
 	assert.Zero(t, r.catchupInFlight())
 	assert.Equal(t, closed, svc.GetClosedLedgerIndex())
 
+	_, err = svc.AcceptConsensusResult(
+		context.Background(),
+		svc.GetClosedLedger(),
+		nil,
+		nil,
+		time.Now(),
+		true,
+	)
+	require.NoError(t, err)
+	built := svc.GetClosedLedger()
+	require.NotNil(t, built)
 	engine.buildingSeq = 0
-	r.maybeAcquireFromValidation(&consensus.Validation{
-		NodeID: trusted, LedgerSeq: closed + 1, LedgerID: hash,
-	}, 7)
+	r.onLedgerBuilt(built.Sequence(), built.Hash())
 	require.GreaterOrEqual(t, acquireCount(rs), 1)
 }
 

--- a/internal/consensus/adaptor/router_catchup_test.go
+++ b/internal/consensus/adaptor/router_catchup_test.go
@@ -408,12 +408,15 @@ func TestRouter_TrustedValidationAheadLeavesFullBeforeAcquire(t *testing.T) {
 	require.GreaterOrEqual(t, acquireCount(rs), 1)
 }
 
-func TestRouter_FullNodeDoesNotSpeculativelyAcquireNextLedger(t *testing.T) {
+func TestRouter_OpenRoundAcquiresTargetLedger(t *testing.T) {
 	r, a, rs, svc := makeRouter(t)
 	a.SetOperatingMode(consensus.OpModeFull)
 	trusted, err := a.GetValidatorKey()
 	require.NoError(t, err)
 	closed := svc.GetClosedLedgerIndex()
+	r.engine = &mockEngine{state: &consensus.RoundState{
+		Round: consensus.RoundID{Seq: closed + 1},
+	}}
 	hash := consensus.LedgerID{0xCA, 0x12}
 
 	r.maybeAcquireFromValidation(&consensus.Validation{
@@ -423,9 +426,37 @@ func TestRouter_FullNodeDoesNotSpeculativelyAcquireNextLedger(t *testing.T) {
 	r.armConsensusCatchup()
 
 	assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode())
-	assert.Zero(t, acquireCount(rs))
-	assert.Zero(t, r.catchupInFlight())
+	require.GreaterOrEqual(t, acquireCount(rs), 1)
+	assert.Equal(t, 1, r.catchupInFlight())
 	assert.Equal(t, closed, svc.GetClosedLedgerIndex())
+}
+
+func TestRouter_ActiveBuildDoesNotAcquireItsTargetLedger(t *testing.T) {
+	for _, phase := range []consensus.Phase{consensus.PhaseEstablish, consensus.PhaseAccepted} {
+		t.Run(phase.String(), func(t *testing.T) {
+			r, a, rs, svc := makeRouter(t)
+			a.SetOperatingMode(consensus.OpModeFull)
+			trusted, err := a.GetValidatorKey()
+			require.NoError(t, err)
+			closed := svc.GetClosedLedgerIndex()
+			r.engine = &mockEngine{
+				state: &consensus.RoundState{
+					Round: consensus.RoundID{Seq: closed + 1},
+				},
+				phase: phase,
+			}
+			hash := consensus.LedgerID{0xCA, 0x12}
+
+			r.maybeAcquireFromValidation(&consensus.Validation{
+				NodeID: trusted, LedgerSeq: closed + 1, LedgerID: hash,
+			}, 7)
+			r.armValidationStashAcquisition(closed+1, [32]byte(hash))
+
+			assert.Zero(t, acquireCount(rs))
+			assert.Zero(t, r.catchupInFlight())
+			assert.Equal(t, closed, svc.GetClosedLedgerIndex())
+		})
+	}
 }
 
 // An UNTRUSTED validator must not steer acquisition (RCLValidations.cpp:194).

--- a/internal/consensus/adaptor/router_catchup_test.go
+++ b/internal/consensus/adaptor/router_catchup_test.go
@@ -414,9 +414,6 @@ func TestRouter_OpenRoundAcquiresTargetLedger(t *testing.T) {
 	trusted, err := a.GetValidatorKey()
 	require.NoError(t, err)
 	closed := svc.GetClosedLedgerIndex()
-	r.engine = &mockEngine{state: &consensus.RoundState{
-		Round: consensus.RoundID{Seq: closed + 1},
-	}}
 	hash := consensus.LedgerID{0xCA, 0x12}
 
 	r.maybeAcquireFromValidation(&consensus.Validation{
@@ -432,31 +429,34 @@ func TestRouter_OpenRoundAcquiresTargetLedger(t *testing.T) {
 }
 
 func TestRouter_ActiveBuildDoesNotAcquireItsTargetLedger(t *testing.T) {
-	for _, phase := range []consensus.Phase{consensus.PhaseEstablish, consensus.PhaseAccepted} {
-		t.Run(phase.String(), func(t *testing.T) {
-			r, a, rs, svc := makeRouter(t)
-			a.SetOperatingMode(consensus.OpModeFull)
-			trusted, err := a.GetValidatorKey()
-			require.NoError(t, err)
-			closed := svc.GetClosedLedgerIndex()
-			r.engine = &mockEngine{
-				state: &consensus.RoundState{
-					Round: consensus.RoundID{Seq: closed + 1},
-				},
-				phase: phase,
-			}
-			hash := consensus.LedgerID{0xCA, 0x12}
-
-			r.maybeAcquireFromValidation(&consensus.Validation{
-				NodeID: trusted, LedgerSeq: closed + 1, LedgerID: hash,
-			}, 7)
-			r.armValidationStashAcquisition(closed+1, [32]byte(hash))
-
-			assert.Zero(t, acquireCount(rs))
-			assert.Zero(t, r.catchupInFlight())
-			assert.Equal(t, closed, svc.GetClosedLedgerIndex())
-		})
+	r, a, rs, svc := makeRouter(t)
+	a.SetOperatingMode(consensus.OpModeFull)
+	trusted, err := a.GetValidatorKey()
+	require.NoError(t, err)
+	closed := svc.GetClosedLedgerIndex()
+	engine := &mockEngine{buildingSeq: closed + 1}
+	r.engine = engine
+	hash := consensus.LedgerID{0xCA, 0x12}
+	r.peerStates[7] = &peerLedgerState{
+		LedgerSeq:  closed + 1,
+		LedgerHash: [32]byte(hash),
 	}
+
+	r.maybeAcquireFromValidation(&consensus.Validation{
+		NodeID: trusted, LedgerSeq: closed + 1, LedgerID: hash,
+	}, 7)
+	r.armValidationStashAcquisition(closed+1, [32]byte(hash))
+	r.armConsensusCatchup()
+
+	assert.Zero(t, acquireCount(rs))
+	assert.Zero(t, r.catchupInFlight())
+	assert.Equal(t, closed, svc.GetClosedLedgerIndex())
+
+	engine.buildingSeq = 0
+	r.maybeAcquireFromValidation(&consensus.Validation{
+		NodeID: trusted, LedgerSeq: closed + 1, LedgerID: hash,
+	}, 7)
+	require.GreaterOrEqual(t, acquireCount(rs), 1)
 }
 
 // An UNTRUSTED validator must not steer acquisition (RCLValidations.cpp:194).

--- a/internal/consensus/adaptor/router_catchup_test.go
+++ b/internal/consensus/adaptor/router_catchup_test.go
@@ -468,6 +468,47 @@ func TestRouter_ActiveBuildDoesNotAcquireItsTargetLedger(t *testing.T) {
 	require.GreaterOrEqual(t, acquireCount(rs), 1)
 }
 
+func TestRouter_LedgerBuiltRearmsQuorumTargetWithoutPeerStatus(t *testing.T) {
+	r, a, rs, svc := makeRouter(t)
+	a.SetOperatingMode(consensus.OpModeFull)
+	trusted, err := a.GetValidatorKey()
+	require.NoError(t, err)
+	closed := svc.GetClosedLedgerIndex()
+	engine := &mockEngine{buildingSeq: closed + 1}
+	r.engine = engine
+	hash := consensus.LedgerID{0xCA, 0x13}
+
+	r.onLedgerFullyValidated(closed+1, [32]byte(hash))
+	r.maybeAcquireFromValidation(&consensus.Validation{
+		NodeID: trusted, LedgerSeq: closed + 1, LedgerID: hash,
+	}, 7)
+
+	assert.Equal(t, catchupTarget{
+		seq:    closed + 1,
+		hash:   [32]byte(hash),
+		peerID: 7,
+		source: catchupSourceQuorum,
+	}, r.catchup)
+	assert.Empty(t, r.peerStates)
+	assert.Zero(t, acquireCount(rs))
+
+	_, err = svc.AcceptConsensusResult(
+		context.Background(),
+		svc.GetClosedLedger(),
+		nil,
+		nil,
+		time.Now(),
+		true,
+	)
+	require.NoError(t, err)
+	built := svc.GetClosedLedger()
+	require.NotNil(t, built)
+	engine.buildingSeq = 0
+	r.onLedgerBuilt(built.Sequence(), built.Hash())
+
+	require.GreaterOrEqual(t, acquireCount(rs), 1)
+}
+
 // An UNTRUSTED validator must not steer acquisition (RCLValidations.cpp:194).
 func TestRouter_UntrustedValidation_NoAcquire(t *testing.T) {
 	r, _, rs, svc := makeRouter(t)

--- a/internal/consensus/adaptor/router_catchup_test.go
+++ b/internal/consensus/adaptor/router_catchup_test.go
@@ -6,9 +6,12 @@ package adaptor
 
 import (
 	"bytes"
+	"context"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/stretchr/testify/assert"
@@ -36,15 +39,8 @@ func statusChangeMessage(t *testing.T, peerID peermanagement.PeerID, seq uint32,
 	}
 }
 
-// TestRouter_HashDivergenceAtSameSeq_AcquiresPeerTip verifies the
-// continuous-catchup hole we closed: when a peer reports the same seq
-// as ours but with a different ledger hash, the router must acquire
-// the peer's ledger — otherwise isolated consensus never reconverges.
-//
-// Mirrors rippled's wrongLedger recovery path where a node that
-// disagrees with the majority on its LCL asks a peer for their fork.
-func TestRouter_HashDivergenceAtSameSeq_AcquiresPeerTip(t *testing.T) {
-	r, _, rs, svc := makeRouter(t)
+func TestRouter_HashDivergenceAtSameSeq_RecordsWithoutAcquiring(t *testing.T) {
+	r, adaptor, sender, svc := makeRouter(t)
 	closed := svc.GetClosedLedger()
 	require.NotNil(t, closed)
 	ourHash := closed.Hash()
@@ -59,27 +55,18 @@ func TestRouter_HashDivergenceAtSameSeq_AcquiresPeerTip(t *testing.T) {
 	msg := statusChangeMessage(t, peermanagement.PeerID(7), ourSeq, peerHash)
 	r.handleMessage(msg)
 
-	// Either replay-delta (if parent is local) or legacy must have been
-	// issued for peerHash. Coordinator or InboundLedger must now hold
-	// an acquisition.
-	replayCalls := rs.replayCalls()
-	legacyCalls := rs.legacyCalls()
-	totalCalls := len(replayCalls) + len(legacyCalls)
-	require.Equal(t, 1, totalCalls,
-		"exactly one acquisition request must fire on hash divergence (replay=%d legacy=%d)",
-		len(replayCalls), len(legacyCalls))
-
-	assert.True(t, r.replayer.Has(peerHash) || r.fetchTracker.Find(peerHash) != nil,
-		"an acquisition state machine must be armed for the peer's hash")
-
-	if len(replayCalls) > 0 {
-		assert.Equal(t, peerHash, replayCalls[0].hash)
-		assert.Equal(t, uint64(7), replayCalls[0].peerID)
-	} else {
-		assert.Equal(t, peerHash, legacyCalls[0].hash)
-		assert.Equal(t, uint64(7), legacyCalls[0].peerID)
-		assert.Equal(t, ourSeq, legacyCalls[0].seq)
-	}
+	assert.Empty(t, sender.replayCalls())
+	assert.Empty(t, sender.legacyCalls())
+	assert.False(t, r.isAcquiring(peerHash))
+	r.peersMu.RLock()
+	state := r.peerStates[peermanagement.PeerID(7)]
+	r.peersMu.RUnlock()
+	require.NotNil(t, state)
+	assert.Equal(t, ourSeq, state.LedgerSeq)
+	assert.Equal(t, peerHash, state.LedgerHash)
+	reported := adaptor.PeerReportedLedgers()
+	require.Len(t, reported, 1)
+	assert.Equal(t, consensus.LedgerID(peerHash), reported[0])
 }
 
 // TestRouter_SameHashAtSameSeq_NoAcquisition verifies the negative
@@ -203,6 +190,97 @@ func TestRouter_FullNodeBehindPeerLeavesFullBeforeCatchup(t *testing.T) {
 	require.GreaterOrEqual(t, acquireCount(rs), 1)
 }
 
+func TestRouter_FullNodeDoesNotAcquireNonPreferredPeerTip(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	a.SetOperatingMode(consensus.OpModeFull)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+
+	peerHash := closed.Hash()
+	for i := len(peerHash) - 1; i >= 0; i-- {
+		if peerHash[i] > 0 {
+			peerHash[i]--
+			break
+		}
+		peerHash[i] = 0xff
+	}
+	require.NotEqual(t, [32]byte{}, peerHash)
+
+	r.handleMessage(statusChangeMessage(
+		t,
+		peermanagement.PeerID(7),
+		closed.Sequence()+100,
+		peerHash,
+	))
+
+	assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode())
+	assert.Zero(t, acquireCount(sender))
+	assert.False(t, r.isAcquiring(peerHash))
+}
+
+func TestRouter_TrustedValidationReplacesStatusSequenceTarget(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	fakeSeq := closed.Sequence() + 100
+
+	r.handleMessage(statusChangeMessage(t, peermanagement.PeerID(7), fakeSeq, closed.Hash()))
+	assert.Equal(t, catchupTarget{}, r.catchup)
+	assert.Zero(t, acquireCount(sender))
+
+	peerHash := [32]byte{}
+	for i := range peerHash {
+		peerHash[i] = 0xff
+	}
+	r.handleMessage(statusChangeMessage(t, peermanagement.PeerID(8), fakeSeq, peerHash))
+	assert.Equal(t, catchupTarget{seq: fakeSeq, hash: peerHash, peerID: 8}, r.catchup)
+
+	trusted, err := a.GetValidatorKey()
+	require.NoError(t, err)
+	trustedSeq := closed.Sequence() + 3
+	trustedHash := consensus.LedgerID{0xCA, 0x14}
+	r.maybeAcquireFromValidation(&consensus.Validation{
+		NodeID:    trusted,
+		LedgerSeq: trustedSeq,
+		LedgerID:  trustedHash,
+	}, 9)
+
+	assert.Equal(t, catchupTarget{
+		seq:    trustedSeq,
+		hash:   [32]byte(trustedHash),
+		peerID: 9,
+		source: catchupSourceValidation,
+	}, r.catchup)
+	assert.True(t, r.isAcquiring([32]byte(trustedHash)))
+}
+
+func TestRouter_TrustedCatchupTargetDoesNotRegress(t *testing.T) {
+	r, _, _, svc := makeRouter(t)
+	closed := svc.GetClosedLedgerIndex()
+	aheadHash := [32]byte{0xD1}
+	laggingHash := [32]byte{0xD2}
+
+	r.ensureValidationCatchupAcquisition(
+		closed+10,
+		aheadHash,
+		7,
+	)
+	r.ensureValidationCatchupAcquisition(
+		closed+3,
+		laggingHash,
+		8,
+	)
+
+	assert.Equal(t, catchupTarget{
+		seq:    closed + 10,
+		hash:   aheadHash,
+		peerID: 7,
+		source: catchupSourceValidation,
+	}, r.catchup)
+	assert.True(t, r.isAcquiring(aheadHash))
+	assert.True(t, r.isAcquiring(laggingHash))
+}
+
 // acquireCount totals the acquisition requests the router emitted via either
 // the replay-delta or the legacy GET_LEDGER path.
 func acquireCount(rs *recordingSender) int {
@@ -236,6 +314,81 @@ func TestRouter_TrustedValidation_FutureUnknownLedger_Acquires(t *testing.T) {
 	assert.Equal(t, hash, calls[0].hash)
 	assert.Equal(t, uint32(99999), calls[0].seq)
 	assert.Equal(t, uint64(7), calls[0].peerID, "the validating peer is used as the acquisition hint")
+}
+
+func TestRouter_TrustedValidation_SameSequenceUnknownLedger_Acquires(t *testing.T) {
+	r, a, sender, svc := makeRouter(t)
+	trusted, err := a.GetValidatorKey()
+	require.NoError(t, err)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	_, err = svc.AcceptConsensusResult(context.Background(), closed, nil, nil, time.Now(), true)
+	require.NoError(t, err)
+	closed = svc.GetClosedLedger()
+	hash := consensus.LedgerID{0xCA, 0x13}
+
+	r.handleMessage(statusChangeMessage(t, peermanagement.PeerID(7), closed.Sequence(), [32]byte{0xBA, 0xD0}))
+	assert.Zero(t, acquireCount(sender))
+
+	r.maybeAcquireFromValidation(&consensus.Validation{
+		NodeID: trusted, LedgerSeq: closed.Sequence(), LedgerID: hash,
+	}, 7)
+
+	assert.Equal(t, 1, acquireCount(sender))
+	assert.True(t, r.isAcquiring([32]byte(hash)))
+}
+
+func TestRouter_FullyValidatedHashCancelsOnlyConsensusSiblings(t *testing.T) {
+	r, a, _, svc := makeRouter(t)
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	seq := closed.Sequence() + 1
+	canonical := [32]byte{0xA0}
+
+	legacyHash := [32]byte{0xA1}
+	otherSeqHash := [32]byte{0xA2}
+	genericHash := [32]byte{0xA3}
+	historyHash := [32]byte{0xA4}
+	keep := inbound.New(canonical, seq, 1, r.logger)
+	legacy := inbound.New(legacyHash, seq, 2, r.logger)
+	otherSeq := inbound.New(otherSeqHash, seq+1, 3, r.logger)
+	generic := inbound.NewGeneric(genericHash, seq, 4, r.logger)
+	history := inbound.NewHistory(historyHash, seq, 5, r.logger)
+	for _, acquisition := range []*inbound.Ledger{keep, legacy, otherSeq, generic, history} {
+		r.fetchTracker.Track(acquisition)
+	}
+	r.acquisitionMu.Lock()
+	r.consensusRecovery = consensusRecovery{
+		targetHash: legacyHash,
+		stepHash:   legacyHash,
+	}
+	r.acquisitionMu.Unlock()
+	r.catchupMu.Lock()
+	r.catchup = catchupTarget{seq: seq, hash: legacyHash, peerID: 2}
+	r.catchupMu.Unlock()
+
+	replayHash := [32]byte{0xB1}
+	require.NoError(t, r.startReplayDeltaAcquisition(seq, replayHash, 6, closed))
+	require.NoError(t, r.startReplayDeltaAcquisition(seq, canonical, 7, closed))
+
+	a.OnLedgerFullyValidated(consensus.LedgerID(canonical), seq)
+
+	assert.Nil(t, r.fetchTracker.Find(legacyHash))
+	assert.NotNil(t, r.fetchTracker.Find(canonical))
+	assert.NotNil(t, r.fetchTracker.Find(otherSeqHash))
+	assert.NotNil(t, r.fetchTracker.Find(genericHash))
+	assert.NotNil(t, r.fetchTracker.Find(historyHash))
+	assert.False(t, r.replayer.Has(replayHash))
+	assert.True(t, r.replayer.Has(canonical))
+	assert.Equal(t, consensusRecovery{}, r.consensusRecovery)
+	assert.Equal(t, catchupTarget{
+		seq:    seq,
+		hash:   canonical,
+		source: catchupSourceQuorum,
+	}, r.catchup)
+	recorded, ok := r.lookupSeqHash(seq)
+	require.True(t, ok)
+	assert.Equal(t, canonical, recorded.hash)
 }
 
 func TestRouter_TrustedValidationAheadLeavesFullBeforeAcquire(t *testing.T) {

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -28,14 +28,16 @@ type mockEngine struct {
 	acquireFailed []consensus.LedgerID
 	switchResult  consensus.LedgerSwitchResult
 	switchHook    func(consensus.LedgerID)
+	state         *consensus.RoundState
+	phase         consensus.Phase
 }
 
 func (m *mockEngine) Start(context.Context) error              { return nil }
 func (m *mockEngine) Stop() error                              { return nil }
 func (m *mockEngine) StartRound(consensus.RoundID, bool) error { return nil }
-func (m *mockEngine) State() *consensus.RoundState             { return nil }
+func (m *mockEngine) State() *consensus.RoundState             { return m.state }
 func (m *mockEngine) Mode() consensus.Mode                     { return consensus.ModeObserving }
-func (m *mockEngine) Phase() consensus.Phase                   { return consensus.PhaseOpen }
+func (m *mockEngine) Phase() consensus.Phase                   { return m.phase }
 func (m *mockEngine) IsProposing() bool                        { return false }
 func (m *mockEngine) Timing() consensus.Timing                 { return consensus.DefaultTiming() }
 func (m *mockEngine) GetLastCloseInfo() (int, time.Duration)   { return 0, 0 }

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -28,16 +28,16 @@ type mockEngine struct {
 	acquireFailed []consensus.LedgerID
 	switchResult  consensus.LedgerSwitchResult
 	switchHook    func(consensus.LedgerID)
-	state         *consensus.RoundState
-	phase         consensus.Phase
+	buildingSeq   uint32
 }
 
 func (m *mockEngine) Start(context.Context) error              { return nil }
 func (m *mockEngine) Stop() error                              { return nil }
 func (m *mockEngine) StartRound(consensus.RoundID, bool) error { return nil }
-func (m *mockEngine) State() *consensus.RoundState             { return m.state }
+func (m *mockEngine) State() *consensus.RoundState             { return nil }
 func (m *mockEngine) Mode() consensus.Mode                     { return consensus.ModeObserving }
-func (m *mockEngine) Phase() consensus.Phase                   { return m.phase }
+func (m *mockEngine) Phase() consensus.Phase                   { return consensus.PhaseOpen }
+func (m *mockEngine) BuildingLedgerSeq() uint32                { return m.buildingSeq }
 func (m *mockEngine) IsProposing() bool                        { return false }
 func (m *mockEngine) Timing() consensus.Timing                 { return consensus.DefaultTiming() }
 func (m *mockEngine) GetLastCloseInfo() (int, time.Duration)   { return 0, 0 }

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -347,9 +347,6 @@ func NewFromConfig(
 	// proposing, so wrongLedger needs to demote opMode.
 	engine.Subscribe(modeManager)
 
-	// Consensus, transaction, acquisition-reply, and manifest traffic arrive
-	// on independent overlay lanes, so expensive verification or a flood on
-	// one lane cannot starve the others.
 	router := NewRouter(engine, adaptor, overlay.ConsensusMessages())
 	router.SetConsensusControlInbox(overlay.ConsensusControlMessages())
 	router.SetServiceInbox(overlay.Messages())

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -350,7 +350,9 @@ func NewFromConfig(
 	// Consensus, transaction, acquisition-reply, and manifest traffic arrive
 	// on independent overlay lanes, so expensive verification or a flood on
 	// one lane cannot starve the others.
-	router := NewRouter(engine, adaptor, overlay.Messages())
+	router := NewRouter(engine, adaptor, overlay.ConsensusMessages())
+	router.SetConsensusControlInbox(overlay.ConsensusControlMessages())
+	router.SetServiceInbox(overlay.Messages())
 	router.SetTxInbox(overlay.TxMessages())
 	router.SetAcqInbox(overlay.LedgerDataMessages())
 	router.SetManifestInbox(overlay.ManifestMessages())

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -60,6 +60,7 @@ type Engine struct {
 	// OnLedger) parks so no second goroutine starts a round before the commit
 	// tail runs. Mutated under e.mu.
 	buildInProgress       bool
+	buildingLedgerSeq     atomic.Uint32
 	pendingRecoveryLedger consensus.Ledger
 
 	ourTxSet  consensus.TxSet
@@ -781,6 +782,12 @@ func (e *Engine) Phase() consensus.Phase {
 	return e.phase
 }
 
+// BuildingLedgerSeq returns the ledger sequence being built after the open
+// phase, or zero when no ledger build is active.
+func (e *Engine) BuildingLedgerSeq() uint32 {
+	return e.buildingLedgerSeq.Load()
+}
+
 // IsProposing reports whether we're actively proposing (lock-free atomic
 // read; called on the RPC hot path under ledger.service.s.mu — see modeAtomic).
 func (e *Engine) IsProposing() bool {
@@ -1230,6 +1237,8 @@ func (e *Engine) closeLedger() {
 			)
 		}
 	}
+
+	e.buildingLedgerSeq.Store(e.state.Round.Seq)
 
 	// Filter pending txs through the open-ledger gate when proposing;
 	// non-proposing modes skip the per-round apply cost (position isn't broadcast).

--- a/internal/consensus/rcl/engine_accept.go
+++ b/internal/consensus/rcl/engine_accept.go
@@ -114,6 +114,7 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 		e.processPendingRecoveryLedgerLocked()
 		return
 	}
+	e.buildingLedgerSeq.Store(0)
 
 	parentID := prevLedger.ID()
 	parentClose := prevLedger.CloseTime()

--- a/internal/consensus/rcl/engine_accept.go
+++ b/internal/consensus/rcl/engine_accept.go
@@ -114,8 +114,6 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 		e.processPendingRecoveryLedgerLocked()
 		return
 	}
-	e.buildingLedgerSeq.Store(0)
-
 	parentID := prevLedger.ID()
 	parentClose := prevLedger.CloseTime()
 	newID := newLedger.ID()
@@ -251,6 +249,7 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 
 	validations := e.proposalTracker.ValidationsFor(newLedger.ID())
 
+	e.buildingLedgerSeq.Store(0)
 	e.adaptor.OnConsensusReached(newLedger, validations, roundTime)
 
 	e.eventBus.Publish(&consensus.LedgerAcceptedEvent{

--- a/internal/consensus/rcl/engine_accept_offlock_test.go
+++ b/internal/consensus/rcl/engine_accept_offlock_test.go
@@ -33,6 +33,7 @@ func driveToEstablish(t *testing.T, e *Engine, a *mockAdaptor) {
 	t.Helper()
 	e.mu.Lock()
 	e.prevLedger = a.lastLCL
+	e.buildingLedgerSeq.Store(e.state.Round.Seq)
 	e.setPhase(consensus.PhaseEstablish)
 	e.mu.Unlock()
 }

--- a/internal/consensus/rcl/engine_accept_offlock_test.go
+++ b/internal/consensus/rcl/engine_accept_offlock_test.go
@@ -1,6 +1,7 @@
 package rcl
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -57,6 +58,9 @@ func TestEngine_AcceptLedger_OffLockDoesNotBlockPeerHandlers(t *testing.T) {
 	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
 	engine.StartRound(round, true)
 	driveToEstablish(t, engine, adaptor)
+	if got := engine.BuildingLedgerSeq(); got != round.Seq {
+		t.Fatalf("building ledger sequence after close = %d, want %d", got, round.Seq)
+	}
 
 	// The parent is seq 100; the mock mints its child as ID {101}. A proposal
 	// built on that child belongs to the NEXT round.
@@ -75,6 +79,9 @@ func TestEngine_AcceptLedger_OffLockDoesNotBlockPeerHandlers(t *testing.T) {
 	case <-entered:
 	case <-time.After(2 * time.Second):
 		t.Fatal("BuildLedger never started")
+	}
+	if got := engine.BuildingLedgerSeq(); got != round.Seq {
+		t.Fatalf("building ledger sequence during apply = %d, want %d", got, round.Seq)
 	}
 
 	// e.mu is now released for the whole (blocked) apply. Peer handlers must
@@ -135,6 +142,29 @@ func TestEngine_AcceptLedger_OffLockDoesNotBlockPeerHandlers(t *testing.T) {
 	engine.mu.RUnlock()
 	if newSeq != 101 {
 		t.Fatalf("expected prevLedger to advance to seq 101, got %d", newSeq)
+	}
+	if got := engine.BuildingLedgerSeq(); got != 0 {
+		t.Fatalf("building ledger sequence after successful apply = %d, want 0", got)
+	}
+}
+
+func TestEngine_AcceptLedger_BuildFailureRetainsBuildingSequence(t *testing.T) {
+	adaptor := newMockAdaptor()
+	adaptor.buildLedgerErr = errors.New("build failed")
+	engine := NewEngine(adaptor, DefaultConfig())
+	round := consensus.RoundID{Seq: 101, ParentHash: consensus.LedgerID{1}}
+	engine.StartRound(round, true)
+	driveToEstablish(t, engine, adaptor)
+
+	engine.mu.Lock()
+	engine.acceptLedger(consensus.ResultSuccess)
+	engine.mu.Unlock()
+
+	if got := engine.BuildingLedgerSeq(); got != round.Seq {
+		t.Fatalf("building ledger sequence after failed apply = %d, want %d", got, round.Seq)
+	}
+	if got := engine.Phase(); got != consensus.PhaseEstablish {
+		t.Fatalf("phase after failed apply = %s, want establish", got)
 	}
 }
 

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -192,6 +192,7 @@ type mockAdaptor struct {
 	// observe engine behaviour while it runs. Read under a.mu, then called
 	// without the lock so it can't deadlock adaptor calls made concurrently.
 	buildLedgerHook func()
+	buildLedgerErr  error
 }
 
 func newMockAdaptor() *mockAdaptor {
@@ -306,9 +307,13 @@ func (a *mockAdaptor) GetLastClosedLedger() (consensus.Ledger, error) {
 func (a *mockAdaptor) BuildLedger(parent consensus.Ledger, txSet consensus.TxSet, closeTime time.Time, _ bool, _ [][]byte) (consensus.Ledger, error) {
 	a.mu.RLock()
 	hook := a.buildLedgerHook
+	buildErr := a.buildLedgerErr
 	a.mu.RUnlock()
 	if hook != nil {
 		hook()
+	}
+	if buildErr != nil {
+		return nil, buildErr
 	}
 	newLedger := &mockLedger{
 		id:        consensus.LedgerID{byte(parent.Seq() + 1)},

--- a/internal/ledger/inbound/inflight_registry.go
+++ b/internal/ledger/inbound/inflight_registry.go
@@ -91,6 +91,19 @@ func (r *inFlightRegistry[T]) remove(hash [32]byte) {
 	delete(r.items, hash)
 }
 
+func (r *inFlightRegistry[T]) removeMatching(match func([32]byte, T) bool) [][32]byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	removed := make([][32]byte, 0)
+	for hash, item := range r.items {
+		if match(hash, item) {
+			delete(r.items, hash)
+			removed = append(removed, hash)
+		}
+	}
+	return removed
+}
+
 func (r *inFlightRegistry[T]) has(hash [32]byte) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/ledger/inbound/replayer.go
+++ b/internal/ledger/inbound/replayer.go
@@ -196,6 +196,17 @@ func (r *Replayer) Abandon(hash [32]byte) {
 	r.Complete(hash)
 }
 
+// AbandonOtherAtSequence removes replay acquisitions for competing hashes at
+// seq while preserving the hash selected by trusted validation quorum.
+func (r *Replayer) AbandonOtherAtSequence(seq uint32, keep [32]byte) [][32]byte {
+	if r == nil {
+		return nil
+	}
+	return r.delta.removeMatching(func(hash [32]byte, replay *ReplayDelta) bool {
+		return hash != keep && replay.Seq() == seq
+	})
+}
+
 // Stop drains the coordinator's in-flight map on shutdown. Returns the
 // number of acquisitions that were in flight at stop time. Intended
 // to be called from Components.Stop() during graceful shutdown so

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -212,8 +212,6 @@ type Overlay struct {
 	// case the cluster timer leaves the self-entry out.
 	localNodeIdentity []byte
 
-	// droppedMessages counts how many times the non-blocking send to the
-	// best-effort messages channel hit its default branch.
 	droppedMessages atomic.Uint64
 
 	// droppedTransactions counts inbound TMTransaction frames shed

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -103,9 +103,9 @@ type Overlay struct {
 	// Coordination channels
 	//
 	// events is the best-effort hot path for ordinary EventMessageReceived
-	// traffic and EventLedgerResponse. Acquisition traffic uses the separate
-	// bounded acquisitionEvents path so requested replies apply transport
-	// backpressure instead of being discarded.
+	// traffic and EventLedgerResponse. Consensus and acquisition traffic use
+	// separate bounded paths so they apply transport backpressure instead of
+	// being discarded.
 	//
 	// lifecycle is the dedicated NON-LOSSY path for peer lifecycle events
 	// (Connecting/Connected/Disconnected/Failed). Sends BLOCK until the
@@ -114,20 +114,21 @@ type Overlay struct {
 	// would leak router/relay per-peer state until the idle sweep. Keeping
 	// it off the message channel means a message burst can no longer crowd
 	// out a disconnect. Both are drained by the single eventLoop goroutine.
-	events            chan Event
-	acquisitionEvents chan Event
-	lifecycle         chan Event
+	events                 chan Event
+	consensusEvents        chan Event
+	consensusControlEvents chan Event
+	acquisitionEvents      chan Event
+	lifecycle              chan Event
 
-	// messages carries ordinary consensus peer frames (proposals,
-	// validations, status changes, and validator lists) to the
-	// router. txMessages carries inbound TMTransaction frames on a
-	// separate lane. Splitting the two means a transaction flood that
-	// saturates txMessages can no longer crowd consensus/acquisition
-	// traffic out of a single shared buffer and get the node
-	// resource-disconnected for dropping mtLEDGER_DATA/mtPROPOSE/
-	// mtVALIDATION (issue #1103).
-	messages   chan *InboundMessage
-	txMessages chan *InboundMessage
+	// consensusMessages preserves ordering between trust updates and the
+	// proposals and validations that depend on them. consensusControlMessages
+	// isolates advisory status and transaction-set availability frames.
+	// Both lanes use bounded backpressure. messages remains best-effort for
+	// recoverable service traffic.
+	consensusMessages        chan *InboundMessage
+	consensusControlMessages chan *InboundMessage
+	messages                 chan *InboundMessage
+	txMessages               chan *InboundMessage
 	// manifestMessages is fed directly by peer read loops with bounded
 	// backpressure. Signature verification is intentionally isolated from both
 	// the overlay event loop and the consensus router.
@@ -211,12 +212,8 @@ type Overlay struct {
 	// case the cluster timer leaves the self-entry out.
 	localNodeIdentity []byte
 
-	// droppedMessages counts how many times the non-blocking send to
-	// the consensus messages channel hit its default branch (downstream
-	// consumer slow). Exposed via DroppedMessages() so server_info /
-	// telemetry can surface back-pressure to operators. Without this
-	// counter a slow consumer silently loses events with only a
-	// debug-level log.
+	// droppedMessages counts how many times the non-blocking send to the
+	// best-effort messages channel hit its default branch.
 	droppedMessages atomic.Uint64
 
 	// droppedTransactions counts inbound TMTransaction frames shed
@@ -834,34 +831,38 @@ func New(opts ...Option) (*Overlay, error) {
 	}
 
 	o := &Overlay{
-		cfg:                cfg,
-		identity:           identity,
-		cluster:            clusterReg,
-		instanceCookie:     cookie,
-		discovery:          NewDiscovery(&cfg, events),
-		autoconnectWake:    make(chan struct{}, 1),
-		ledgerSync:         NewLedgerSyncHandler(events),
-		peers:              make(map[PeerID]*Peer),
-		peerKeys:           make(map[string]PeerID),
-		peerEndpoints:      make(map[string]PeerID),
-		inboundIPs:         make(map[string]int),
-		pendingInbound:     make(map[PeerID]struct{}),
-		events:             events,
-		acquisitionEvents:  make(chan Event, acquisitionEventBufferSize),
-		messages:           make(chan *InboundMessage, messageBufferSize(cfg.MessageBufferSize)),
-		txMessages:         make(chan *InboundMessage, txLaneBufferSize(cfg.MaxTransactions)),
-		manifestMessages:   make(chan *InboundMessage, manifestMessageBufferSize(cfg.MaxPeers)),
-		manifestReadBudget: newReadBudget(manifestReadBudgetBytes),
-		manifestSpoolDir:   manifestSpoolDir,
-		ledgerData:         make(chan *InboundMessage, DefaultLedgerDataBufferSize),
-		lifecycle:          make(chan Event, lifecycleBufferSize(&cfg)),
-		stopCh:             make(chan struct{}),
-		listenerReady:      make(chan struct{}),
-		relayedIndex:       make(map[[32]byte]*relayedEntry),
-		clockForIndex:      time.Now,
-		inboundSem:         make(chan struct{}, inboundCap),
-		outboundSem:        make(chan struct{}, outboundCap),
-		resourceManager:    resource.NewManager(nil, nil),
+		cfg:                      cfg,
+		identity:                 identity,
+		cluster:                  clusterReg,
+		instanceCookie:           cookie,
+		discovery:                NewDiscovery(&cfg, events),
+		autoconnectWake:          make(chan struct{}, 1),
+		ledgerSync:               NewLedgerSyncHandler(events),
+		peers:                    make(map[PeerID]*Peer),
+		peerKeys:                 make(map[string]PeerID),
+		peerEndpoints:            make(map[string]PeerID),
+		inboundIPs:               make(map[string]int),
+		pendingInbound:           make(map[PeerID]struct{}),
+		events:                   events,
+		consensusEvents:          make(chan Event, eventBufferSize(cfg.EventBufferSize)),
+		consensusControlEvents:   make(chan Event, eventBufferSize(cfg.EventBufferSize)),
+		acquisitionEvents:        make(chan Event, acquisitionEventBufferSize),
+		consensusMessages:        make(chan *InboundMessage, messageBufferSize(cfg.MessageBufferSize)),
+		consensusControlMessages: make(chan *InboundMessage, messageBufferSize(cfg.MessageBufferSize)),
+		messages:                 make(chan *InboundMessage, messageBufferSize(cfg.MessageBufferSize)),
+		txMessages:               make(chan *InboundMessage, txLaneBufferSize(cfg.MaxTransactions)),
+		manifestMessages:         make(chan *InboundMessage, manifestMessageBufferSize(cfg.MaxPeers)),
+		manifestReadBudget:       newReadBudget(manifestReadBudgetBytes),
+		manifestSpoolDir:         manifestSpoolDir,
+		ledgerData:               make(chan *InboundMessage, DefaultLedgerDataBufferSize),
+		lifecycle:                make(chan Event, lifecycleBufferSize(&cfg)),
+		stopCh:                   make(chan struct{}),
+		listenerReady:            make(chan struct{}),
+		relayedIndex:             make(map[[32]byte]*relayedEntry),
+		clockForIndex:            time.Now,
+		inboundSem:               make(chan struct{}, inboundCap),
+		outboundSem:              make(chan struct{}, outboundCap),
+		resourceManager:          resource.NewManager(nil, nil),
 	}
 	if identity != nil {
 		o.localNodeIdentity = identity.PublicKey()
@@ -973,6 +974,8 @@ func (o *Overlay) Run(ctx context.Context) error {
 
 	// Event processing loops
 	g.Go(func() error { return o.eventLoop(gCtx) })
+	g.Go(func() error { return o.consensusEventLoop(gCtx) })
+	g.Go(func() error { return o.consensusControlEventLoop(gCtx) })
 	g.Go(func() error { return o.acquisitionEventLoop(gCtx) })
 
 	// Discovery/autoconnect loop
@@ -1060,6 +1063,28 @@ func (o *Overlay) acquisitionEventLoop(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case evt := <-o.acquisitionEvents:
+			o.onMessageReceived(evt)
+		}
+	}
+}
+
+func (o *Overlay) consensusEventLoop(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case evt := <-o.consensusEvents:
+			o.onMessageReceived(evt)
+		}
+	}
+}
+
+func (o *Overlay) consensusControlEventLoop(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case evt := <-o.consensusControlEvents:
 			o.onMessageReceived(evt)
 		}
 	}

--- a/internal/peermanagement/overlay_inbound.go
+++ b/internal/peermanagement/overlay_inbound.go
@@ -141,6 +141,8 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 	peerID := PeerID(o.nextID.Add(1))
 	peer := NewPeer(peerID, endpoint, true, o.identity, o.events)
 	peer.SetDroppedEventsCounter(&o.droppedEvents)
+	peer.SetConsensusEvents(o.consensusEvents)
+	peer.SetConsensusControlEvents(o.consensusControlEvents)
 	peer.SetAcquisitionEvents(o.acquisitionEvents)
 	peer.SetManifestMessages(o.manifestMessages)
 	peer.SetManifestReadBudget(o.manifestReadBudget)

--- a/internal/peermanagement/overlay_message.go
+++ b/internal/peermanagement/overlay_message.go
@@ -256,9 +256,25 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		return
 	}
 
-	// Forward consensus/acquisition frames. On back-pressure (channel
-	// full), increment a visible counter rather than silently dropping —
-	// the warn log alone is easy to miss at production log levels.
+	if isConsensusPriorityMessageType(msgType) {
+		o.forwardConsensus(&InboundMessage{
+			PeerID:  evt.PeerID,
+			Type:    evt.MessageType,
+			Payload: evt.Payload,
+		})
+		return
+	}
+	if isConsensusControlMessageType(msgType) {
+		o.forwardConsensusControl(&InboundMessage{
+			PeerID:  evt.PeerID,
+			Type:    evt.MessageType,
+			Payload: evt.Payload,
+		})
+		return
+	}
+
+	// Recoverable service and control frames remain best-effort. Peers can
+	// retry requests or refresh control state after pressure subsides.
 	select {
 	case o.messages <- &InboundMessage{
 		PeerID:  evt.PeerID,
@@ -271,6 +287,28 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		if msgType == message.TypeManifests {
 			o.RejectPeerBootstrap(evt.PeerID)
 		}
+	}
+}
+
+func (o *Overlay) forwardConsensus(msg *InboundMessage) {
+	if o.consensusMessages == nil {
+		return
+	}
+	select {
+	case o.consensusMessages <- msg:
+	case <-o.stopCh:
+	case <-o.runDone:
+	}
+}
+
+func (o *Overlay) forwardConsensusControl(msg *InboundMessage) {
+	if o.consensusControlMessages == nil {
+		return
+	}
+	select {
+	case o.consensusControlMessages <- msg:
+	case <-o.stopCh:
+	case <-o.runDone:
 	}
 }
 
@@ -313,11 +351,8 @@ func (o *Overlay) forwardLedgerData(msg *InboundMessage) {
 	}
 }
 
-// DroppedMessages returns the cumulative count of inbound messages the
-// overlay had to drop because the downstream consumer channel was
-// full. Surfaced via server_info/server_state for operators to detect
-// consumer back-pressure — a nonzero and growing value indicates the
-// router/engine can't keep up with network ingress.
+// DroppedMessages returns the cumulative count of best-effort inbound
+// messages shed because the downstream consumer channel was full.
 func (o *Overlay) DroppedMessages() uint64 {
 	return o.droppedMessages.Load()
 }

--- a/internal/peermanagement/overlay_message.go
+++ b/internal/peermanagement/overlay_message.go
@@ -145,7 +145,6 @@ func (o *Overlay) onMessageReceived(evt Event) {
 	// the engine's timerEntry would never advance (issue #381).
 	if msgType == message.TypeStatusChange {
 		o.handleStatusChange(evt)
-		// fall through to the o.messages forward
 	}
 
 	// Serve mtREPLAY_DELTA_REQ from the local ledger sync handler.
@@ -199,13 +198,6 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		}
 	}
 
-	// mtREPLAY_DELTA_RESPONSE / mtPROOF_PATH_RESPONSE that pass the
-	// feature gate above reach the consensus router via the overlay's
-	// Messages() channel — like every other peer-originated consensus
-	// frame (mtLEDGER_DATA, mtPROPOSE, mtVALIDATION). Transactions ride
-	// the separate TxMessages() lane. The router owns the verification +
-	// adoption state and is the only place that can drive it.
-
 	// Transport-level messages with no consensus-router impact are
 	// handled inline here and NOT forwarded to o.messages.
 	switch msgType {
@@ -228,10 +220,6 @@ func (o *Overlay) onMessageReceived(evt Event) {
 
 	slog.Debug("Message received", "t", "Overlay", "type", msgType.String(), "peer", evt.PeerID, "size", len(evt.Payload))
 
-	// Transactions ride a dedicated lane so a tx flood can't crowd
-	// consensus/acquisition frames out of the messages channel and get
-	// us resource-disconnected for dropping mtLEDGER_DATA/mtPROPOSE/
-	// mtVALIDATION (issue #1103).
 	if msgType == message.TypeTransaction {
 		o.forwardTransaction(&InboundMessage{
 			PeerID:  evt.PeerID,
@@ -241,11 +229,6 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		return
 	}
 
-	// Acquisition replies ride a dedicated lane so a
-	// serve/propose/validation flood on the shared messages channel can't
-	// shed a reply this node explicitly requested and wedge catch-up. The
-	// replay-delta / proof-path responses already passed their feature gate
-	// above.
 	switch msgType {
 	case message.TypeLedgerData, message.TypeReplayDeltaResponse, message.TypeProofPathResponse:
 		o.forwardLedgerData(&InboundMessage{
@@ -273,8 +256,6 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		return
 	}
 
-	// Recoverable service and control frames remain best-effort. Peers can
-	// retry requests or refresh control state after pressure subsides.
 	select {
 	case o.messages <- &InboundMessage{
 		PeerID:  evt.PeerID,

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -426,8 +426,6 @@ func (o *Overlay) PeerCount() int {
 	return len(o.peers)
 }
 
-// Messages returns the best-effort channel for recoverable service and
-// control frames.
 func (o *Overlay) Messages() <-chan *InboundMessage {
 	return o.messages
 }

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -68,6 +68,8 @@ func (o *Overlay) connectReserved(addr string, bootstrapLease *bootstrapLease) e
 	peerID := PeerID(o.nextID.Add(1))
 	peer := NewPeer(peerID, endpoint, false, o.identity, o.events)
 	peer.SetDroppedEventsCounter(&o.droppedEvents)
+	peer.SetConsensusEvents(o.consensusEvents)
+	peer.SetConsensusControlEvents(o.consensusControlEvents)
 	peer.SetAcquisitionEvents(o.acquisitionEvents)
 	peer.SetManifestMessages(o.manifestMessages)
 	peer.SetManifestReadBudget(o.manifestReadBudget)
@@ -424,10 +426,22 @@ func (o *Overlay) PeerCount() int {
 	return len(o.peers)
 }
 
-// Messages returns the channel of inbound consensus- and
-// ledger-acquisition-relevant frames (everything except transactions).
+// Messages returns the best-effort channel for recoverable service and
+// control frames.
 func (o *Overlay) Messages() <-chan *InboundMessage {
 	return o.messages
+}
+
+// ConsensusMessages returns the lossless bounded lane for validator-list
+// updates, proposals, and validations.
+func (o *Overlay) ConsensusMessages() <-chan *InboundMessage {
+	return o.consensusMessages
+}
+
+// ConsensusControlMessages returns the lossless bounded lane for status
+// changes and transaction-set availability.
+func (o *Overlay) ConsensusControlMessages() <-chan *InboundMessage {
+	return o.consensusControlMessages
 }
 
 // TxMessages returns the channel of inbound TMTransaction frames. It is

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -94,15 +94,17 @@ type Peer struct {
 	bootstrapManifest        atomic.Bool
 	bootstrapManifestPending atomic.Bool
 
-	sendMu             sync.Mutex
-	send               chan []byte
-	prioritySend       chan []byte
-	manifestSend       chan [][]byte
-	events             chan<- Event
-	acquisitionEvents  chan<- Event
-	manifestMessages   chan<- *InboundMessage
-	manifestReadBudget *readBudget
-	manifestSpoolDir   string
+	sendMu                 sync.Mutex
+	send                   chan []byte
+	prioritySend           chan []byte
+	manifestSend           chan [][]byte
+	events                 chan<- Event
+	consensusEvents        chan<- Event
+	consensusControlEvents chan<- Event
+	acquisitionEvents      chan<- Event
+	manifestMessages       chan<- *InboundMessage
+	manifestReadBudget     *readBudget
+	manifestSpoolDir       string
 
 	// droppedEvents counts non-blocking event sends that fell through
 	// because the overlay event loop was wedged. nil until wired by
@@ -288,6 +290,14 @@ func (p *Peer) SetAcquisitionEvents(events chan<- Event) {
 	p.acquisitionEvents = events
 }
 
+func (p *Peer) SetConsensusEvents(events chan<- Event) {
+	p.consensusEvents = events
+}
+
+func (p *Peer) SetConsensusControlEvents(events chan<- Event) {
+	p.consensusControlEvents = events
+}
+
 func (p *Peer) SetManifestMessages(messages chan<- *InboundMessage) {
 	p.manifestMessages = messages
 }
@@ -308,9 +318,9 @@ func manifestReadReservation(header MessageHeader) int64 {
 	return size
 }
 
-// dispatchEvent applies bounded backpressure to acquisition traffic and uses
-// the best-effort event lane for other traffic. Closing the peer releases a
-// read loop waiting for acquisition capacity.
+// dispatchEvent applies bounded backpressure to consensus and acquisition
+// traffic and uses the best-effort event lane for other traffic. Closing the
+// peer releases a read loop waiting for capacity.
 func (p *Peer) dispatchEvent(evt Event) bool {
 	if evt.Type == EventMessageReceived && message.MessageType(evt.MessageType) == message.TypeManifests && p.manifestMessages != nil {
 		select {
@@ -320,6 +330,22 @@ func (p *Peer) dispatchEvent(evt Event) bool {
 			Payload:       evt.Payload,
 			ManifestFrame: evt.ManifestFrame,
 		}:
+			return true
+		case <-p.closeCh:
+			return false
+		}
+	}
+	if evt.Type == EventMessageReceived && isConsensusPriorityMessageType(message.MessageType(evt.MessageType)) && p.consensusEvents != nil {
+		select {
+		case p.consensusEvents <- evt:
+			return true
+		case <-p.closeCh:
+			return false
+		}
+	}
+	if evt.Type == EventMessageReceived && isConsensusControlMessageType(message.MessageType(evt.MessageType)) && p.consensusControlEvents != nil {
+		select {
+		case p.consensusControlEvents <- evt:
 			return true
 		case <-p.closeCh:
 			return false
@@ -343,6 +369,27 @@ func (p *Peer) dispatchEvent(evt Event) bool {
 		if p.droppedEvents != nil {
 			p.droppedEvents.Add(1)
 		}
+		return false
+	}
+}
+
+func isConsensusPriorityMessageType(msgType message.MessageType) bool {
+	switch msgType {
+	case message.TypeProposeLedger,
+		message.TypeValidation,
+		message.TypeValidatorList,
+		message.TypeValidatorListCollection:
+		return true
+	default:
+		return false
+	}
+}
+
+func isConsensusControlMessageType(msgType message.MessageType) bool {
+	switch msgType {
+	case message.TypeStatusChange, message.TypeHaveSet:
+		return true
+	default:
 		return false
 	}
 }

--- a/internal/peermanagement/peer_dispatch_test.go
+++ b/internal/peermanagement/peer_dispatch_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Ordinary dispatch must never block; only acquisition traffic intentionally
-// propagates bounded backpressure to the peer read loop.
 func TestPeer_DispatchEvent_NonBlocking(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)

--- a/internal/peermanagement/peer_dispatch_test.go
+++ b/internal/peermanagement/peer_dispatch_test.go
@@ -1,6 +1,7 @@
 package peermanagement
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -93,6 +94,186 @@ func TestPeer_DispatchEvent_BackpressuresAcquisitionSeparately(t *testing.T) {
 		require.True(t, delivered)
 	case <-time.After(time.Second):
 		t.Fatal("acquisition dispatch did not resume")
+	}
+}
+
+func TestPeer_DispatchEvent_BackpressuresConsensusSeparately(t *testing.T) {
+	for _, msgType := range []message.MessageType{
+		message.TypeProposeLedger,
+		message.TypeValidation,
+		message.TypeValidatorList,
+		message.TypeValidatorListCollection,
+	} {
+		t.Run(msgType.String(), func(t *testing.T) {
+			id, err := NewIdentity()
+			require.NoError(t, err)
+			events := make(chan Event, 1)
+			consensus := make(chan Event, 1)
+			peer := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, events)
+			peer.SetConsensusEvents(consensus)
+
+			evt := Event{Type: EventMessageReceived, MessageType: uint16(msgType)}
+			require.True(t, peer.dispatchEvent(evt))
+			done := make(chan bool, 1)
+			go func() { done <- peer.dispatchEvent(evt) }()
+			select {
+			case <-done:
+				t.Fatal("full consensus lane did not apply backpressure")
+			case <-time.After(20 * time.Millisecond):
+			}
+
+			<-consensus
+			select {
+			case delivered := <-done:
+				require.True(t, delivered)
+			case <-time.After(time.Second):
+				t.Fatal("consensus dispatch did not resume")
+			}
+			assert.Empty(t, events)
+		})
+	}
+}
+
+func TestPeer_DispatchEvent_BackpressuresConsensusControlSeparately(t *testing.T) {
+	for _, msgType := range []message.MessageType{
+		message.TypeStatusChange,
+		message.TypeHaveSet,
+	} {
+		t.Run(msgType.String(), func(t *testing.T) {
+			id, err := NewIdentity()
+			require.NoError(t, err)
+			events := make(chan Event, 1)
+			control := make(chan Event, 1)
+			peer := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, events)
+			peer.SetConsensusControlEvents(control)
+
+			evt := Event{Type: EventMessageReceived, MessageType: uint16(msgType)}
+			require.True(t, peer.dispatchEvent(evt))
+			done := make(chan bool, 1)
+			go func() { done <- peer.dispatchEvent(evt) }()
+			select {
+			case <-done:
+				t.Fatal("full consensus control lane did not apply backpressure")
+			case <-time.After(20 * time.Millisecond):
+			}
+
+			<-control
+			select {
+			case delivered := <-done:
+				require.True(t, delivered)
+			case <-time.After(time.Second):
+				t.Fatal("consensus control dispatch did not resume")
+			}
+			assert.Empty(t, events)
+		})
+	}
+}
+
+func TestPeer_DispatchEvent_ConsensusBackpressureReleasesOnClose(t *testing.T) {
+	tests := []struct {
+		name    string
+		msgType message.MessageType
+		wire    func(*Peer, chan<- Event)
+	}{
+		{"priority", message.TypeValidation, (*Peer).SetConsensusEvents},
+		{"control", message.TypeStatusChange, (*Peer).SetConsensusControlEvents},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := NewIdentity()
+			require.NoError(t, err)
+			lane := make(chan Event, 1)
+			peer := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, make(chan Event, 1))
+			tc.wire(peer, lane)
+			evt := Event{Type: EventMessageReceived, MessageType: uint16(tc.msgType)}
+			require.True(t, peer.dispatchEvent(evt))
+
+			done := make(chan bool, 1)
+			go func() { done <- peer.dispatchEvent(evt) }()
+			select {
+			case <-done:
+				t.Fatal("full consensus lane did not apply backpressure")
+			case <-time.After(20 * time.Millisecond):
+			}
+			require.NoError(t, peer.Close())
+			select {
+			case delivered := <-done:
+				assert.False(t, delivered)
+			case <-time.After(time.Second):
+				t.Fatal("consensus dispatch did not release when the peer closed")
+			}
+			assert.Len(t, lane, 1)
+		})
+	}
+}
+
+func TestConsensusMessageClassification(t *testing.T) {
+	for _, msgType := range []message.MessageType{
+		message.TypeProposeLedger,
+		message.TypeValidation,
+		message.TypeValidatorList,
+		message.TypeValidatorListCollection,
+	} {
+		assert.True(t, isConsensusPriorityMessageType(msgType), msgType.String())
+		assert.False(t, isConsensusControlMessageType(msgType), msgType.String())
+	}
+	for _, msgType := range []message.MessageType{
+		message.TypeStatusChange,
+		message.TypeHaveSet,
+	} {
+		assert.False(t, isConsensusPriorityMessageType(msgType), msgType.String())
+		assert.True(t, isConsensusControlMessageType(msgType), msgType.String())
+	}
+	for _, msgType := range []message.MessageType{
+		message.TypeGetLedger,
+		message.TypeTransaction,
+		message.TypeLedgerData,
+	} {
+		assert.False(t, isConsensusPriorityMessageType(msgType), msgType.String())
+		assert.False(t, isConsensusControlMessageType(msgType), msgType.String())
+	}
+}
+
+func TestConsensusPriorityLanePreservesValidatorListValidationOrder(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	o := &Overlay{
+		consensusEvents:   make(chan Event, 2),
+		consensusMessages: make(chan *InboundMessage, 2),
+		stopCh:            make(chan struct{}),
+	}
+	peer := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, make(chan Event, 1))
+	peer.SetConsensusEvents(o.consensusEvents)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	loopDone := make(chan error, 1)
+	go func() { loopDone <- o.consensusEventLoop(ctx) }()
+
+	require.True(t, peer.dispatchEvent(Event{
+		Type:        EventMessageReceived,
+		PeerID:      PeerID(1),
+		MessageType: uint16(message.TypeValidatorList),
+		Payload:     []byte{0x01},
+	}))
+	require.True(t, peer.dispatchEvent(Event{
+		Type:        EventMessageReceived,
+		PeerID:      PeerID(1),
+		MessageType: uint16(message.TypeValidation),
+		Payload:     []byte{0x02},
+	}))
+
+	first := <-o.consensusMessages
+	second := <-o.consensusMessages
+	assert.Equal(t, uint16(message.TypeValidatorList), first.Type)
+	assert.Equal(t, []byte{0x01}, first.Payload)
+	assert.Equal(t, uint16(message.TypeValidation), second.Type)
+	assert.Equal(t, []byte{0x02}, second.Payload)
+
+	cancel()
+	select {
+	case <-loopDone:
+	case <-time.After(time.Second):
+		t.Fatal("consensus event loop did not stop")
 	}
 }
 

--- a/internal/peermanagement/peer_status_test.go
+++ b/internal/peermanagement/peer_status_test.go
@@ -414,13 +414,8 @@ func TestOverlay_PeersJSON_StatusOmittedForOutOfRangeEnum(t *testing.T) {
 	assert.False(t, present, "unknown enum values must not surface as `status`")
 }
 
-// TestOverlay_onMessageReceived_StatusChangeReachesRouter pins issue
-// #381: an inbound TMStatusChange must be forwarded to the consensus lane so
-// the consensus router's handleStatusChange runs. PR #270 introduced
-// an early-return after the overlay-level handleStatusChange that
-// severed this path; without forwarding, a fresh observer node never
-// kicks off ledger acquisition, never leaves OpModeDisconnected, and
-// the engine's heartbeat loop is a no-op forever.
+// Issue #381: without forwarding TMStatusChange to the consensus lane, a fresh
+// observer never starts ledger acquisition or leaves OpModeDisconnected.
 func TestOverlay_onMessageReceived_StatusChangeReachesRouter(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)

--- a/internal/peermanagement/peer_status_test.go
+++ b/internal/peermanagement/peer_status_test.go
@@ -415,7 +415,7 @@ func TestOverlay_PeersJSON_StatusOmittedForOutOfRangeEnum(t *testing.T) {
 }
 
 // TestOverlay_onMessageReceived_StatusChangeReachesRouter pins issue
-// #381: an inbound TMStatusChange must be forwarded to o.messages so
+// #381: an inbound TMStatusChange must be forwarded to the consensus lane so
 // the consensus router's handleStatusChange runs. PR #270 introduced
 // an early-return after the overlay-level handleStatusChange that
 // severed this path; without forwarding, a fresh observer node never
@@ -428,8 +428,9 @@ func TestOverlay_onMessageReceived_StatusChangeReachesRouter(t *testing.T) {
 	peer := NewPeer(PeerID(7), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
 
 	o := &Overlay{
-		peers:    map[PeerID]*Peer{7: peer},
-		messages: make(chan *InboundMessage, 4),
+		peers:                    map[PeerID]*Peer{7: peer},
+		consensusControlMessages: make(chan *InboundMessage, 4),
+		stopCh:                   make(chan struct{}),
 	}
 
 	closed := make([]byte, 32)
@@ -458,13 +459,13 @@ func TestOverlay_onMessageReceived_StatusChangeReachesRouter(t *testing.T) {
 	// Forward to consensus router must have happened. Without this the
 	// router cannot drive initial-sync ledger acquisition.
 	select {
-	case msg := <-o.messages:
+	case msg := <-o.consensusControlMessages:
 		require.NotNil(t, msg, "forwarded InboundMessage must be non-nil")
 		assert.Equal(t, PeerID(7), msg.PeerID)
 		assert.Equal(t, uint16(message.TypeStatusChange), msg.Type)
 		assert.Equal(t, encoded, msg.Payload)
 	default:
-		t.Fatal("TMStatusChange was not forwarded to o.messages — issue #381 regression: " +
+		t.Fatal("TMStatusChange was not forwarded to the consensus lane — issue #381 regression: " +
 			"the consensus router will never see peer status, never start ledger " +
 			"acquisition, and the engine will never advance past genesis")
 	}

--- a/internal/peermanagement/tx_ingress_test.go
+++ b/internal/peermanagement/tx_ingress_test.go
@@ -12,16 +12,18 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 )
 
-// newLaneTestOverlay builds a bare Overlay with the three inbound lanes
+// newLaneTestOverlay builds a bare Overlay with the inbound lanes
 // wired, sized for ingress-routing tests. The zero-value cfg leaves
 // reduce-relay metrics off so onMessageReceived takes the plain forward
 // path.
 func newLaneTestOverlay(consensusCap, txCap, ledgerDataCap int) *Overlay {
 	return &Overlay{
-		messages:   make(chan *InboundMessage, consensusCap),
-		txMessages: make(chan *InboundMessage, txCap),
-		ledgerData: make(chan *InboundMessage, ledgerDataCap),
-		stopCh:     make(chan struct{}),
+		consensusMessages:        make(chan *InboundMessage, consensusCap),
+		consensusControlMessages: make(chan *InboundMessage, consensusCap),
+		messages:                 make(chan *InboundMessage, consensusCap),
+		txMessages:               make(chan *InboundMessage, txCap),
+		ledgerData:               make(chan *InboundMessage, ledgerDataCap),
+		stopCh:                   make(chan struct{}),
 	}
 }
 
@@ -52,7 +54,11 @@ func TestOverlay_TxLane_BoundedByCapacity(t *testing.T) {
 	// The consensus lane is a different buffer and must be untouched by a
 	// pure transaction flood — that is the whole point of issue #1103.
 	assert.Equal(t, 0, len(o.messages),
+		"transaction flood must not consume the ordinary lane")
+	assert.Equal(t, 0, len(o.consensusMessages),
 		"transaction flood must not consume the consensus lane")
+	assert.Equal(t, 0, len(o.consensusControlMessages),
+		"transaction flood must not consume the consensus control lane")
 	assert.Equal(t, uint64(0), o.DroppedMessages(),
 		"DroppedMessages must not move for transaction-lane shedding")
 }
@@ -99,7 +105,7 @@ func TestOverlay_TxFlood_DoesNotStarveConsensusLane(t *testing.T) {
 		Payload:     []byte{0x00},
 	})
 
-	assert.Equal(t, 2, len(o.messages),
+	assert.Equal(t, 2, len(o.consensusMessages),
 		"proposals/validations must reach the consensus lane despite the tx flood")
 	assert.Equal(t, 1, len(o.ledgerData),
 		"acquisition replies must reach the dedicated lane despite the tx flood")
@@ -107,31 +113,215 @@ func TestOverlay_TxFlood_DoesNotStarveConsensusLane(t *testing.T) {
 		"no consensus frame may be dropped while only the tx lane is saturated")
 }
 
-// TestOverlay_NonTxUsesConsensusLane confirms the counters stay
-// class-specific: a consensus frame (mtPROPOSE) that overflows the
-// consensus lane bumps droppedMessages and never touches
+// TestOverlay_OrdinaryTrafficUsesBestEffortLane confirms the counters stay
+// class-specific: a recoverable request that overflows the ordinary lane
+// bumps droppedMessages and never touches
 // droppedTransactions, so the jq_trans_overflow signal isn't polluted by
 // unrelated traffic. The tx and acquisition lanes stay empty.
-func TestOverlay_NonTxUsesConsensusLane(t *testing.T) {
+func TestOverlay_OrdinaryTrafficUsesBestEffortLane(t *testing.T) {
 	o := newLaneTestOverlay(1, 8, 8)
 
 	for range 4 {
 		o.onMessageReceived(Event{
 			Type:        EventMessageReceived,
 			PeerID:      PeerID(1),
-			MessageType: uint16(message.TypeProposeLedger),
+			MessageType: uint16(message.TypeGetLedger),
 			Payload:     []byte{0x00},
 		})
 	}
 
 	assert.Greater(t, o.DroppedMessages(), uint64(0),
-		"DroppedMessages must record consensus-lane overflow")
+		"DroppedMessages must record best-effort lane overflow")
 	assert.Equal(t, uint64(0), o.DroppedTransactions(),
 		"DroppedTransactions must not move when only consensus frames overflow")
 	assert.Equal(t, 0, len(o.txMessages),
-		"consensus traffic must never reach the tx lane")
+		"ordinary traffic must never reach the tx lane")
 	assert.Equal(t, 0, len(o.ledgerData),
-		"consensus traffic must never reach the acquisition lane")
+		"ordinary traffic must never reach the acquisition lane")
+	assert.Equal(t, 0, len(o.consensusMessages),
+		"ordinary traffic must never reach the consensus lane")
+	assert.Equal(t, 0, len(o.consensusControlMessages),
+		"ordinary traffic must never reach the consensus control lane")
+}
+
+func TestOverlay_ConsensusTrafficBackpressures(t *testing.T) {
+	for _, msgType := range []message.MessageType{
+		message.TypeProposeLedger,
+		message.TypeValidation,
+		message.TypeValidatorList,
+		message.TypeValidatorListCollection,
+	} {
+		t.Run(msgType.String(), func(t *testing.T) {
+			o := newLaneTestOverlay(1, 8, 8)
+			evt := Event{
+				Type:        EventMessageReceived,
+				PeerID:      PeerID(1),
+				MessageType: uint16(msgType),
+				Payload:     []byte{0x00},
+			}
+			o.onMessageReceived(evt)
+
+			done := make(chan struct{})
+			go func() {
+				o.onMessageReceived(evt)
+				close(done)
+			}()
+			select {
+			case <-done:
+				t.Fatal("full consensus message lane did not apply backpressure")
+			case <-time.After(20 * time.Millisecond):
+			}
+
+			first := <-o.consensusMessages
+			assert.Equal(t, uint16(msgType), first.Type)
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("consensus message did not resume after capacity became available")
+			}
+			second := <-o.consensusMessages
+			assert.Equal(t, uint16(msgType), second.Type)
+			assert.Equal(t, uint64(0), o.DroppedMessages())
+			assert.Empty(t, o.messages)
+		})
+	}
+}
+
+func TestOverlay_ConsensusControlTrafficBackpressures(t *testing.T) {
+	for _, msgType := range []message.MessageType{
+		message.TypeStatusChange,
+		message.TypeHaveSet,
+	} {
+		t.Run(msgType.String(), func(t *testing.T) {
+			o := newLaneTestOverlay(1, 8, 8)
+			evt := Event{
+				Type:        EventMessageReceived,
+				PeerID:      PeerID(1),
+				MessageType: uint16(msgType),
+				Payload:     []byte{0x00},
+			}
+			o.onMessageReceived(evt)
+
+			done := make(chan struct{})
+			go func() {
+				o.onMessageReceived(evt)
+				close(done)
+			}()
+			select {
+			case <-done:
+				t.Fatal("full consensus control lane did not apply backpressure")
+			case <-time.After(20 * time.Millisecond):
+			}
+
+			first := <-o.consensusControlMessages
+			assert.Equal(t, uint16(msgType), first.Type)
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("consensus control message did not resume after capacity became available")
+			}
+			second := <-o.consensusControlMessages
+			assert.Equal(t, uint16(msgType), second.Type)
+			assert.Equal(t, uint64(0), o.DroppedMessages())
+			assert.Empty(t, o.messages)
+			assert.Empty(t, o.consensusMessages)
+		})
+	}
+}
+
+func TestOverlay_ConsensusBackpressureReleasesOnShutdown(t *testing.T) {
+	tests := []struct {
+		name    string
+		msgType message.MessageType
+		lane    func(*Overlay) chan *InboundMessage
+	}{
+		{"priority", message.TypeValidation, func(o *Overlay) chan *InboundMessage { return o.consensusMessages }},
+		{"control", message.TypeStatusChange, func(o *Overlay) chan *InboundMessage { return o.consensusControlMessages }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := newLaneTestOverlay(1, 8, 8)
+			evt := Event{
+				Type:        EventMessageReceived,
+				PeerID:      PeerID(1),
+				MessageType: uint16(tc.msgType),
+				Payload:     []byte{0x00},
+			}
+			o.onMessageReceived(evt)
+
+			done := make(chan struct{})
+			go func() {
+				o.onMessageReceived(evt)
+				close(done)
+			}()
+			select {
+			case <-done:
+				t.Fatal("full consensus lane did not apply backpressure")
+			case <-time.After(20 * time.Millisecond):
+			}
+			close(o.stopCh)
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("consensus backpressure did not release during shutdown")
+			}
+			assert.Len(t, tc.lane(o), 1)
+			assert.Equal(t, uint64(0), o.DroppedMessages())
+		})
+	}
+}
+
+func TestOverlay_ServiceSaturationDoesNotBlockConsensusLanes(t *testing.T) {
+	o := newLaneTestOverlay(8, 8, 8)
+	serviceEvent := Event{
+		Type:        EventMessageReceived,
+		PeerID:      PeerID(1),
+		MessageType: uint16(message.TypeGetLedger),
+		Payload:     []byte{0x00},
+	}
+	for range cap(o.messages) + 3 {
+		o.onMessageReceived(serviceEvent)
+	}
+	require.Len(t, o.messages, cap(o.messages))
+	require.Equal(t, uint64(3), o.DroppedMessages())
+
+	priorityTypes := []message.MessageType{
+		message.TypeProposeLedger,
+		message.TypeValidation,
+		message.TypeValidatorList,
+		message.TypeValidatorListCollection,
+	}
+	for _, msgType := range priorityTypes {
+		o.onMessageReceived(Event{
+			Type:        EventMessageReceived,
+			PeerID:      PeerID(1),
+			MessageType: uint16(msgType),
+			Payload:     []byte{0x00},
+		})
+	}
+	controlTypes := []message.MessageType{
+		message.TypeStatusChange,
+		message.TypeHaveSet,
+	}
+	for _, msgType := range controlTypes {
+		o.onMessageReceived(Event{
+			Type:        EventMessageReceived,
+			PeerID:      PeerID(1),
+			MessageType: uint16(msgType),
+			Payload:     []byte{0x00},
+		})
+	}
+
+	assert.Len(t, o.consensusMessages, 4)
+	assert.Len(t, o.consensusControlMessages, 2)
+	for _, want := range priorityTypes {
+		assert.Equal(t, uint16(want), (<-o.consensusMessages).Type)
+	}
+	for _, want := range controlTypes {
+		assert.Equal(t, uint16(want), (<-o.consensusControlMessages).Type)
+	}
+	assert.Equal(t, uint64(3), o.DroppedMessages(),
+		"consensus traffic must not increment service shedding")
 }
 
 // TestOverlay_AcquisitionRepliesUseDedicatedLane pins bounded backpressure:
@@ -174,9 +364,13 @@ func TestOverlay_AcquisitionRepliesUseDedicatedLane(t *testing.T) {
 	assert.Equal(t, uint64(0), o.DroppedTransactions(),
 		"acquisition-lane overflow must not touch the tx-lane counter")
 	assert.Equal(t, 0, len(o.messages),
-		"acquisition replies must never reach the consensus lane")
+		"acquisition replies must never reach the ordinary lane")
 	assert.Equal(t, 0, len(o.txMessages),
 		"acquisition replies must never reach the tx lane")
+	assert.Equal(t, 0, len(o.consensusMessages),
+		"acquisition replies must never reach the consensus lane")
+	assert.Equal(t, 0, len(o.consensusControlMessages),
+		"acquisition replies must never reach the consensus control lane")
 }
 
 func TestOverlay_AcquisitionBackpressureReleasesOnRunShutdown(t *testing.T) {

--- a/internal/peermanagement/tx_ingress_test.go
+++ b/internal/peermanagement/tx_ingress_test.go
@@ -12,10 +12,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 )
 
-// newLaneTestOverlay builds a bare Overlay with the inbound lanes
-// wired, sized for ingress-routing tests. The zero-value cfg leaves
-// reduce-relay metrics off so onMessageReceived takes the plain forward
-// path.
 func newLaneTestOverlay(consensusCap, txCap, ledgerDataCap int) *Overlay {
 	return &Overlay{
 		consensusMessages:        make(chan *InboundMessage, consensusCap),
@@ -69,10 +65,8 @@ func TestOverlay_TxLane_BoundedByCapacity(t *testing.T) {
 // (mtLEDGER_DATA) to be dropped. Each rides its own lane, so a saturated
 // tx lane leaves both untouched.
 func TestOverlay_TxFlood_DoesNotStarveConsensusLane(t *testing.T) {
-	// Tiny tx lane, easily saturated; the other lanes have their own room.
 	o := newLaneTestOverlay(8, 2, 8)
 
-	// Saturate the tx lane well past capacity.
 	for range 1000 {
 		o.onMessageReceived(Event{
 			Type:        EventMessageReceived,
@@ -113,11 +107,6 @@ func TestOverlay_TxFlood_DoesNotStarveConsensusLane(t *testing.T) {
 		"no consensus frame may be dropped while only the tx lane is saturated")
 }
 
-// TestOverlay_OrdinaryTrafficUsesBestEffortLane confirms the counters stay
-// class-specific: a recoverable request that overflows the ordinary lane
-// bumps droppedMessages and never touches
-// droppedTransactions, so the jq_trans_overflow signal isn't polluted by
-// unrelated traffic. The tx and acquisition lanes stay empty.
 func TestOverlay_OrdinaryTrafficUsesBestEffortLane(t *testing.T) {
 	o := newLaneTestOverlay(1, 8, 8)
 


### PR DESCRIPTION
## Summary

- gate status-driven catch-up on the network-preferred LCL instead of trusting a single peer's hash or sequence
- preserve trusted-validation and quorum target precedence, and cancel obsolete same-sequence consensus acquisitions once a hash is fully validated
- split proposals/validations, status/HaveSet, and recoverable service traffic into independent bounded ingress lanes
- preserve validator-list ordering with dependent validations and apply shutdown-aware backpressure at both peer and overlay boundaries

## rippled v3.2.0 parity

- `PeerImp::onMessage(TMStatusChange)` records peer ledger state without directly acquiring that peer's ledger
- `NetworkOPsImp::checkLastClosedLedger` acquires only the LCL selected by trusted validations and peer support
- trusted validations may independently trigger acquisition, while lagging validators do not lower the preferred catch-up frontier

## Test plan

- `go test ./internal/consensus/adaptor ./internal/ledger/inbound ./internal/peermanagement -count=1`
- `go test -race ./internal/consensus/adaptor ./internal/ledger/inbound ./internal/peermanagement -count=1`
- `just test-core`
- `just test-integration`
- `just lint`
- `just vet`
- `just build`
- `just build-nocgo`

Fixes #1432
