### PR TITLE
feat: add deterministic startup ledger modes

### DIFF
--- a/amendment/amendment_test.go
+++ b/amendment/amendment_test.go
@@ -6,6 +6,7 @@ package amendment
 
 import (
 	"encoding/hex"
+	"slices"
 	"testing"
 )
 
@@ -145,6 +146,25 @@ func TestTableVoting(t *testing.T) {
 	}
 	if table.IsVetoed(FeatureAMM) {
 		t.Error("UpVote should clear any veto")
+	}
+}
+
+func TestTableDesired(t *testing.T) {
+	table := NewTable()
+	defaultYes := DefaultYesFeatures()[0].ID
+
+	if !slices.Contains(table.Desired(), defaultYes) {
+		t.Fatal("Desired omitted a default-yes amendment")
+	}
+
+	table.Veto(defaultYes)
+	if slices.Contains(table.Desired(), defaultYes) {
+		t.Fatal("Desired retained a vetoed amendment")
+	}
+
+	table.UpVote(FeatureAMM)
+	if !slices.Contains(table.Desired(), FeatureAMM) {
+		t.Fatal("Desired omitted an explicitly upvoted supported amendment")
 	}
 }
 

--- a/amendment/table.go
+++ b/amendment/table.go
@@ -5,7 +5,9 @@
 package amendment
 
 import (
+	"bytes"
 	"maps"
+	"sort"
 	"sync"
 )
 
@@ -159,6 +161,27 @@ func (t *Table) IsUpVoted(featureID [32]byte) bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.upVoted[featureID]
+}
+
+// Desired returns the supported amendments this node currently votes to enable.
+func (t *Table) Desired() [][32]byte {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	result := make([][32]byte, 0)
+	for _, feature := range AllFeatures() {
+		if feature.Supported != SupportedYes || t.vetoed[feature.ID] {
+			continue
+		}
+		if t.upVoted[feature.ID] ||
+			(feature.Vote == VoteDefaultYes && !feature.Retired) {
+			result = append(result, feature.ID)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return bytes.Compare(result[i][:], result[j][:]) < 0
+	})
+	return result
 }
 
 // HasUnsupportedEnabled returns the sticky unsupportedEnabled flag: true once an

--- a/config/examples/xrpld.toml
+++ b/config/examples/xrpld.toml
@@ -33,6 +33,7 @@ fetch_depth = "full"             # integer, "full", or "none" (values < 10 are c
 # Network: "main", "testnet", "devnet", or integer
 network_id = "main"
 
+# Peer replay capability only; unrelated to the server's startup --replay mode.
 ledger_replay = 0    # 0 = disabled, 1 = enabled
 
 # Database path (SQLite location)
@@ -141,6 +142,9 @@ cache_mb = 256                   # Pebble block cache in MiB (0 = default 256)
 open_files = 500                # steady-state Pebble open-file soft limit (0 = default 500)
 cache_size = 16384               # decoded node-object cache entries (0 = node_size profile)
 cache_age = 5                    # decoded node-object cache age in minutes (0 = node_size profile)
+# With no startup flag on a networked node, try the newest local ledger first.
+# Also permits failed explicit --load, --ledger, --ledgerfile, or --replay
+# startup to fall back to genesis (standalone) or network acquisition.
 fast_load = false
 earliest_seq = 32570
 delete_batch = 100

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -59,6 +59,62 @@ A fully-commented example lives at
 is **required** unless marked optional — the server refuses to start if a required
 field is missing.
 
+### Startup ledger selection
+
+The `server` command accepts one startup mode:
+
+| Flag | Behavior |
+|------|----------|
+| `--start` | Start from a fresh ledger without consulting local history or the network. |
+| `--load` | Load the newest complete ledger available in local storage. |
+| `--ledger ID` | Load a locally stored ledger selected by `ID`. |
+| `--ledgerfile PATH` | Load a full, expanded rippled ledger JSON file. |
+| `--replay --ledger ID` | Load the selected ledger and its parent, then deterministically replay the selected close. |
+| `--net` | Ignore local startup history and acquire the initial ledger from peers. |
+
+The modes are mutually exclusive, except that `--replay` requires an explicitly
+specified `--ledger`. A ledger identifier may be a 64-character hexadecimal hash,
+the case-insensitive word `latest`, or an unsigned 32-bit decimal ledger sequence.
+An explicitly empty `--ledger=` also means the latest local ledger.
+`--ledgerfile` requires a non-empty path; its input is the full expanded ledger
+JSON produced by rippled, including the expanded account state.
+
+Fresh startup seeds the temporary chain with the configured genesis amendments
+and does not request a network ledger. Network startup uses an amendment-empty,
+unvalidated temporary ledger until a peer ledger is acquired. A successfully
+loaded ledger file is stored in the configured node and relational databases, so
+later `--load` or `--ledger` startups can select it without the source file.
+
+An explicit local load, file load, or replay failure normally stops startup. Set
+`[node_db].fast_load = true` only when falling back is acceptable: a failed
+explicit load then starts from genesis in standalone mode or acquires an initial
+ledger from the network in networked mode. With no startup flag on a networked
+node, `fast_load` first attempts the latest local ledger and otherwise acquires
+one from peers.
+
+Startup replay is separate from the top-level `ledger_replay` setting.
+`ledger_replay` advertises and controls peer replay capability; it does not select
+a startup mode. `--replay` starts from the selected ledger's stored parent and
+stages the selected transactions and close metadata for deterministic application
+on the next ledger close.
+
+Common recovery commands:
+
+```bash
+# Resume from the newest complete local ledger.
+xrpld server --conf /etc/xrpld/xrpld.toml --load
+
+# Recover from a known local sequence (a 64-character hash also works).
+xrpld server --conf /etc/xrpld/xrpld.toml --ledger 32570
+
+# Import an expanded ledger snapshot.
+xrpld server --conf /etc/xrpld/xrpld.toml --ledgerfile /var/lib/xrpld/recovery-ledger.json
+
+# Reproduce a stored close from its parent, or bypass suspect local history.
+xrpld server --conf /etc/xrpld/xrpld.toml --replay --ledger 32570
+xrpld server --conf /etc/xrpld/xrpld.toml --net
+```
+
 ### Time synchronization
 
 Accurate host time is a hard requirement. The peer handshake rejects a connection
@@ -160,7 +216,7 @@ keys to precede any `[section]` header.
 | `ledger_history` | `256` | Ledgers to retain: integer, `"full"`, or `"none"`. |
 | `fetch_depth` | `"full"` | Back-fill depth: integer, `"full"`, or `"none"` (values < 10 clamp to 10). |
 | `network_id` | `"main"` | `"main"`, `"testnet"`, `"devnet"`, or an integer. |
-| `ledger_replay` | `0` | `0` = disabled, `1` = enabled. |
+| `ledger_replay` | `0` | `0` = disabled, `1` = advertise peer replay capability. Unrelated to startup `--replay`. |
 
 ### Top-level — client, storage, diagnostics
 
@@ -193,6 +249,7 @@ List IPs in `admin` to grant those clients admin role.
 | `open_files` | `1000` | Pebble open-file soft limit (`0` = 500). Single stores require at least 74; rotating stores require an even value of at least 148 and split it between generations. A rotation briefly opens a third generation and may use another half-limit. |
 | `cache_size` | `16384` | Decoded node-object cache entries (`0` = the `node_size` profile). This is independent of `cache_mb`. |
 | `cache_age` | `5` | Decoded node-object cache age in minutes (`0` = the `node_size` profile). |
+| `fast_load` | `false` | On networked startup, try the newest local ledger by default; also permit explicit load/replay failures to fall back to genesis or network acquisition. |
 | `earliest_seq` | `32570` | Lowest ledger sequence to retain. |
 | `delete_batch` / `back_off_milliseconds` / `age_threshold_seconds` / `recovery_wait_seconds` | `100`/`100`/`60`/`5` | Online-delete pacing (batch size, inter-batch pause, minimum age, catch-up wait). |
 

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -5,11 +5,13 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/node"
 	"github.com/LeJamon/go-xrpl/internal/observability"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/LeJamon/go-xrpl/version"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -39,6 +41,7 @@ func init() {
 
 	// Server-specific flags — operational concerns only
 	serverCmd.Flags().BoolVarP(&standalone, "standalone", "a", false, "run in standalone mode (no peers)")
+	bindStartupFlags(serverCmd.Flags())
 }
 
 func runServer(cmd *cobra.Command, args []string) error {
@@ -47,6 +50,11 @@ func runServer(cmd *cobra.Command, args []string) error {
 		// pre-print here would duplicate the message Execute() emits.
 		return fmt.Errorf("%w\n  Use 'xrpld generate-config' to create an initial configuration file."+
 			"\n  Example: xrpld server --conf /path/to/xrpld.toml", err)
+	}
+
+	startup, err := startupConfigFromFlags(cmd.Flags())
+	if err != nil {
+		return err
 	}
 
 	// Initialize structured logger from config + CLI flag overrides.
@@ -90,5 +98,86 @@ func runServer(cmd *cobra.Command, args []string) error {
 		serverLog.Info("prometheus metrics enabled", "addr", addr)
 	}
 
-	return node.Run(globalConfig, configFile, standalone, rootLogger, serverLog)
+	return node.Run(globalConfig, configFile, standalone, startup, rootLogger, serverLog)
+}
+
+func bindStartupFlags(flags *pflag.FlagSet) {
+	flags.Bool("start", false, "start from a fresh ledger")
+	flags.Bool("load", false, "load the latest ledger from local storage")
+	flags.Bool("net", false, "acquire the initial ledger from the network")
+	flags.Bool("replay", false, "replay the ledger close selected by --ledger")
+	flags.String("ledger", "", "load the ledger identified by a hash, sequence, or shortcut")
+	flags.String("ledgerfile", "", "load a ledger from a JSON file")
+}
+
+func startupConfigFromFlags(flags *pflag.FlagSet) (service.StartupConfig, error) {
+	start, err := flags.GetBool("start")
+	if err != nil {
+		return service.StartupConfig{}, err
+	}
+	load, err := flags.GetBool("load")
+	if err != nil {
+		return service.StartupConfig{}, err
+	}
+	network, err := flags.GetBool("net")
+	if err != nil {
+		return service.StartupConfig{}, err
+	}
+	replay, err := flags.GetBool("replay")
+	if err != nil {
+		return service.StartupConfig{}, err
+	}
+	ledger, err := flags.GetString("ledger")
+	if err != nil {
+		return service.StartupConfig{}, err
+	}
+	ledgerFile, err := flags.GetString("ledgerfile")
+	if err != nil {
+		return service.StartupConfig{}, err
+	}
+
+	ledgerSet := flags.Changed("ledger")
+	ledgerFileSet := flags.Changed("ledgerfile")
+	if replay && !ledgerSet {
+		return service.StartupConfig{}, fmt.Errorf("--replay requires --ledger")
+	}
+	if ledgerFileSet && ledgerFile == "" {
+		return service.StartupConfig{}, fmt.Errorf("--ledgerfile requires a non-empty path")
+	}
+
+	selected := 0
+	for _, active := range []bool{
+		start,
+		load,
+		network,
+		replay,
+		ledgerFileSet,
+		ledgerSet && !replay,
+	} {
+		if active {
+			selected++
+		}
+	}
+	if selected > 1 {
+		return service.StartupConfig{}, fmt.Errorf(
+			"startup modes are mutually exclusive: choose only one of --start, --load, --net, --replay, --ledger, or --ledgerfile",
+		)
+	}
+
+	switch {
+	case start:
+		return service.StartupConfig{Mode: service.StartupFresh}, nil
+	case load:
+		return service.StartupConfig{Mode: service.StartupLoad}, nil
+	case network:
+		return service.StartupConfig{Mode: service.StartupNetwork}, nil
+	case replay:
+		return service.StartupConfig{Mode: service.StartupReplay, Ledger: ledger}, nil
+	case ledgerFileSet:
+		return service.StartupConfig{Mode: service.StartupLoadFile, Ledger: ledgerFile}, nil
+	case ledgerSet:
+		return service.StartupConfig{Mode: service.StartupLoad, Ledger: ledger}, nil
+	default:
+		return service.StartupConfig{Mode: service.StartupNormal}, nil
+	}
 }

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -39,9 +39,13 @@ func init() {
 	// Set server as the default command
 	rootCmd.RunE = runServer
 
-	// Server-specific flags — operational concerns only
-	serverCmd.Flags().BoolVarP(&standalone, "standalone", "a", false, "run in standalone mode (no peers)")
-	bindStartupFlags(serverCmd.Flags())
+	bindServerFlags(rootCmd.Flags())
+	bindServerFlags(serverCmd.Flags())
+}
+
+func bindServerFlags(flags *pflag.FlagSet) {
+	flags.BoolVarP(&standalone, "standalone", "a", false, "run in standalone mode (no peers)")
+	bindStartupFlags(flags)
 }
 
 func runServer(cmd *cobra.Command, args []string) error {

--- a/internal/cli/server_test.go
+++ b/internal/cli/server_test.go
@@ -9,6 +9,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDefaultServerCommandHasStartupFlags(t *testing.T) {
+	for _, name := range []string{"standalone", "start", "load", "net", "replay", "ledger", "ledgerfile"} {
+		require.NotNil(t, rootCmd.Flags().Lookup(name), "root command is missing --%s", name)
+	}
+
+	startup, err := startupConfigFromFlags(rootCmd.Flags())
+	require.NoError(t, err)
+	assert.Equal(t, service.StartupConfig{Mode: service.StartupNormal}, startup)
+}
+
 func TestStartupConfigFromFlags(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/cli/server_test.go
+++ b/internal/cli/server_test.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartupConfigFromFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want service.StartupConfig
+	}{
+		{
+			name: "normal",
+			want: service.StartupConfig{Mode: service.StartupNormal},
+		},
+		{
+			name: "fresh",
+			args: []string{"--start"},
+			want: service.StartupConfig{Mode: service.StartupFresh},
+		},
+		{
+			name: "latest local",
+			args: []string{"--load"},
+			want: service.StartupConfig{Mode: service.StartupLoad},
+		},
+		{
+			name: "network",
+			args: []string{"--net"},
+			want: service.StartupConfig{Mode: service.StartupNetwork},
+		},
+		{
+			name: "selected ledger",
+			args: []string{"--ledger", "43"},
+			want: service.StartupConfig{Mode: service.StartupLoad, Ledger: "43"},
+		},
+		{
+			name: "explicit empty ledger means latest",
+			args: []string{"--ledger="},
+			want: service.StartupConfig{Mode: service.StartupLoad},
+		},
+		{
+			name: "ledger file",
+			args: []string{"--ledgerfile", "ledger.json"},
+			want: service.StartupConfig{Mode: service.StartupLoadFile, Ledger: "ledger.json"},
+		},
+		{
+			name: "replay selected ledger",
+			args: []string{"--replay", "--ledger", "32570"},
+			want: service.StartupConfig{Mode: service.StartupReplay, Ledger: "32570"},
+		},
+		{
+			name: "replay latest ledger",
+			args: []string{"--replay", "--ledger="},
+			want: service.StartupConfig{Mode: service.StartupReplay},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := pflag.NewFlagSet(tt.name, pflag.ContinueOnError)
+			bindStartupFlags(flags)
+			require.NoError(t, flags.Parse(tt.args))
+
+			got, err := startupConfigFromFlags(flags)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStartupConfigFromFlagsRejectsInvalidCombinations(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "replay without ledger",
+			args:    []string{"--replay"},
+			wantErr: "--replay requires --ledger",
+		},
+		{
+			name:    "empty ledger file",
+			args:    []string{"--ledgerfile="},
+			wantErr: "--ledgerfile requires a non-empty path",
+		},
+		{
+			name:    "fresh and load",
+			args:    []string{"--start", "--load"},
+			wantErr: "startup modes are mutually exclusive",
+		},
+		{
+			name:    "network and selected ledger",
+			args:    []string{"--net", "--ledger", "43"},
+			wantErr: "startup modes are mutually exclusive",
+		},
+		{
+			name:    "load and replay",
+			args:    []string{"--load", "--replay", "--ledger", "32570"},
+			wantErr: "startup modes are mutually exclusive",
+		},
+		{
+			name:    "ledger and ledger file",
+			args:    []string{"--ledger", "43", "--ledgerfile", "ledger.json"},
+			wantErr: "startup modes are mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := pflag.NewFlagSet(tt.name, pflag.ContinueOnError)
+			bindStartupFlags(flags)
+			require.NoError(t, flags.Parse(tt.args))
+
+			_, err := startupConfigFromFlags(flags)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/internal/ledger/inbound/replay_delta.go
+++ b/internal/ledger/inbound/replay_delta.go
@@ -186,6 +186,154 @@ func NewReplayDeltaWithClock(hash [32]byte, peerID uint64, parent *ledger.Ledger
 	}
 }
 
+// NewStoredLedgerReplay creates a complete replay from locally stored parent
+// and target ledgers. The target's transaction leaves are decoded and ordered
+// by sfTransactionIndex so Apply can rebuild the target deterministically.
+func NewStoredLedgerReplay(parent, target *ledger.Ledger, logger *slog.Logger) (*ReplayDelta, error) {
+	if parent == nil {
+		return nil, errors.New("stored replay parent is nil")
+	}
+	if target == nil {
+		return nil, errors.New("stored replay target is nil")
+	}
+	if !parent.IsClosed() {
+		return nil, errors.New("stored replay parent is not closed")
+	}
+	if !target.IsClosed() {
+		return nil, errors.New("stored replay target is not closed")
+	}
+
+	parentHash := parent.Hash()
+	targetHeader := target.Header()
+	if targetHeader.ParentHash != parentHash {
+		return nil, fmt.Errorf(
+			"%w: target parent %x, expected %x",
+			ErrReplayParentMismatch,
+			targetHeader.ParentHash[:8],
+			parentHash[:8],
+		)
+	}
+	if parent.Sequence() == ^uint32(0) {
+		return nil, fmt.Errorf(
+			"%w: parent sequence %d has no successor",
+			ErrReplaySequenceMismatch,
+			parent.Sequence(),
+		)
+	}
+	expectedSequence := parent.Sequence() + 1
+	if targetHeader.LedgerIndex != expectedSequence {
+		return nil, fmt.Errorf(
+			"%w: target %d, expected %d",
+			ErrReplaySequenceMismatch,
+			targetHeader.LedgerIndex,
+			expectedSequence,
+		)
+	}
+	parentHeader := parent.Header()
+	expectedResolution := consensus.GetNextLedgerTimeResolution(
+		parentHeader.CloseTimeResolution,
+		parentHeader.GetCloseAgree(),
+		targetHeader.LedgerIndex,
+	)
+	if targetHeader.CloseTimeResolution != expectedResolution {
+		return nil, fmt.Errorf(
+			"stored replay target close time resolution: got %d, derived %d from parent",
+			targetHeader.CloseTimeResolution,
+			expectedResolution,
+		)
+	}
+	targetHash := target.Hash()
+	if calculated := header.CalculateHash(targetHeader); calculated != targetHash {
+		return nil, fmt.Errorf(
+			"stored replay target header hash mismatch: computed %x stored %x",
+			calculated[:8],
+			targetHash[:8],
+		)
+	}
+	txRoot, err := target.TxMapHash()
+	if err != nil {
+		return nil, fmt.Errorf("stored replay target transaction map: %w", err)
+	}
+	if txRoot != targetHeader.TxHash {
+		return nil, fmt.Errorf(
+			"stored replay target transaction root mismatch: computed %x header %x",
+			txRoot[:8],
+			targetHeader.TxHash[:8],
+		)
+	}
+
+	decoded := make([]DecodedTx, 0, target.TxCount())
+	seenIndices := make(map[uint32][32]byte)
+	var decodeErr error
+	err = target.ForEachTransaction(func(itemHash [32]byte, leafBlob []byte) bool {
+		txBytes, metaBytes, err := tx.SplitTxWithMetaBlob(leafBlob)
+		if err != nil {
+			decodeErr = fmt.Errorf("stored replay tx %x: split leaf: %w", itemHash[:8], err)
+			return false
+		}
+		if len(metaBytes) == 0 {
+			decodeErr = fmt.Errorf("stored replay tx %x: missing metadata", itemHash[:8])
+			return false
+		}
+		txIndex, ok := tx.TransactionIndexFromMetadata(metaBytes)
+		if !ok {
+			decodeErr = fmt.Errorf("stored replay tx %x: missing transaction index", itemHash[:8])
+			return false
+		}
+		if previous, duplicate := seenIndices[txIndex]; duplicate {
+			decodeErr = fmt.Errorf(
+				"stored replay duplicate transaction index %d for %x and %x",
+				txIndex,
+				previous[:8],
+				itemHash[:8],
+			)
+			return false
+		}
+		computedHash := sha512half.Sum(protocol.HashPrefixTransactionID().Bytes(), txBytes)
+		if computedHash != itemHash {
+			decodeErr = fmt.Errorf(
+				"stored replay transaction hash mismatch: computed %x stored %x",
+				computedHash[:8],
+				itemHash[:8],
+			)
+			return false
+		}
+
+		seenIndices[txIndex] = itemHash
+		decoded = append(decoded, DecodedTx{
+			Index:     txIndex,
+			Hash:      itemHash,
+			TxBytes:   append([]byte(nil), txBytes...),
+			MetaBytes: append([]byte(nil), metaBytes...),
+			LeafBlob:  append([]byte(nil), leafBlob...),
+		})
+		return true
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk stored replay transactions: %w", err)
+	}
+	if decodeErr != nil {
+		return nil, decodeErr
+	}
+
+	sort.Slice(decoded, func(i, j int) bool { return decoded[i].Index < decoded[j].Index })
+	for expected, dtx := range decoded {
+		if dtx.Index != uint32(expected) {
+			return nil, fmt.Errorf(
+				"stored replay missing transaction index %d; next index is %d",
+				expected,
+				dtx.Index,
+			)
+		}
+	}
+
+	replay := NewReplayDelta(targetHash, 0, parent, logger)
+	replay.result = target
+	replay.txs = decoded
+	replay.state = StateComplete
+	return replay, nil
+}
+
 // Hash returns the ledger hash being acquired.
 func (r *ReplayDelta) Hash() [32]byte { return r.hash }
 

--- a/internal/ledger/inbound/replay_delta_stored_test.go
+++ b/internal/ledger/inbound/replay_delta_stored_test.go
@@ -1,0 +1,269 @@
+package inbound
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeStoredReplayTarget(
+	t *testing.T,
+	parent *ledger.Ledger,
+	blobs [][]byte,
+	txIDs [][32]byte,
+	mutateHeader func(*header.LedgerHeader),
+) *ledger.Ledger {
+	t.Helper()
+	require.Len(t, txIDs, len(blobs))
+
+	txMap := shamap.New(shamap.TypeTransaction)
+	for i, blob := range blobs {
+		require.NoError(t, txMap.PutWithNodeType(
+			txIDs[i],
+			blob,
+			shamap.NodeTypeTransactionWithMeta,
+		))
+	}
+	require.NoError(t, txMap.SetImmutable())
+	txRoot, err := txMap.Hash()
+	require.NoError(t, err)
+
+	stateMap, err := parent.StateMapSnapshot()
+	require.NoError(t, err)
+	stateRoot, err := stateMap.Hash()
+	require.NoError(t, err)
+
+	hdr := header.LedgerHeader{
+		LedgerIndex:         parent.Sequence() + 1,
+		ParentHash:          parent.Hash(),
+		TxHash:              txRoot,
+		AccountHash:         stateRoot,
+		ParentCloseTime:     parent.CloseTime(),
+		CloseTime:           time.Date(2025, 2, 3, 4, 5, 6, 0, time.UTC),
+		CloseTimeResolution: parent.CloseTimeResolution(),
+		Drops:               parent.TotalDrops(),
+		Accepted:            true,
+	}
+	if mutateHeader != nil {
+		mutateHeader(&hdr)
+	}
+	hdr.Hash = header.CalculateHash(hdr)
+
+	target, err := ledger.NewFromHeader(hdr, stateMap, txMap, parent.GetFees())
+	require.NoError(t, err)
+	return target
+}
+
+func makeStoredReplayLeafWithoutIndex(t *testing.T, txBytes []byte) ([]byte, [32]byte) {
+	t.Helper()
+	metaHex, err := binarycodec.Encode(map[string]any{
+		"TransactionResult": "tesSUCCESS",
+	})
+	require.NoError(t, err)
+	metaBytes, err := hex.DecodeString(metaHex)
+	require.NoError(t, err)
+
+	blob := make([]byte, 0, len(txBytes)+len(metaBytes)+4)
+	blob = append(blob, encodeVL(len(txBytes))...)
+	blob = append(blob, txBytes...)
+	blob = append(blob, encodeVL(len(metaBytes))...)
+	blob = append(blob, metaBytes...)
+
+	_, txID := makeTxWithMetaBlob(t, txBytes, 0)
+	return blob, txID
+}
+
+func TestNewStoredLedgerReplayOrdersTransactions(t *testing.T) {
+	t.Parallel()
+	parent := makeGenesisLedger(t)
+
+	txBytes := [][]byte{
+		[]byte("stored-replay-tx-index-2-padding"),
+		[]byte("stored-replay-tx-index-0-padding"),
+		[]byte("stored-replay-tx-index-1-padding"),
+	}
+	indices := []uint32{2, 0, 1}
+	blobs := make([][]byte, len(txBytes))
+	txIDs := make([][32]byte, len(txBytes))
+	for i := range txBytes {
+		blobs[i], txIDs[i] = makeTxWithMetaBlob(t, txBytes[i], indices[i])
+	}
+	target := makeStoredReplayTarget(t, parent, blobs, txIDs, nil)
+
+	replay, err := NewStoredLedgerReplay(parent, target, nil)
+	require.NoError(t, err)
+	require.True(t, replay.IsComplete())
+	assert.Equal(t, target.Hash(), replay.Hash())
+
+	result, err := replay.Result()
+	require.NoError(t, err)
+	assert.Same(t, target, result)
+
+	ordered := replay.OrderedTxs()
+	require.Len(t, ordered, 3)
+	assert.Equal(t, []uint32{0, 1, 2}, []uint32{
+		ordered[0].Index,
+		ordered[1].Index,
+		ordered[2].Index,
+	})
+	assert.Equal(t, txIDs[1], ordered[0].Hash)
+	assert.Equal(t, txIDs[2], ordered[1].Hash)
+	assert.Equal(t, txIDs[0], ordered[2].Hash)
+}
+
+func TestNewStoredLedgerReplayIsReadyToApply(t *testing.T) {
+	t.Parallel()
+	parent := makeGenesisLedger(t)
+	closeTime := time.Date(2025, 2, 3, 4, 5, 6, 0, time.UTC)
+	target, err := ledger.NewOpen(parent, closeTime)
+	require.NoError(t, err)
+	require.NoError(t, target.Close(closeTime, 0))
+
+	replay, err := NewStoredLedgerReplay(parent, target, nil)
+	require.NoError(t, err)
+
+	derived, err := replay.Apply(tx.EngineConfig{})
+	require.NoError(t, err)
+	assert.Equal(t, target.Hash(), derived.Hash())
+	assert.Equal(t, target.Header().AccountHash, derived.Header().AccountHash)
+	assert.Equal(t, target.Header().TxHash, derived.Header().TxHash)
+}
+
+func TestNewStoredLedgerReplayRejectsInvalidLinkage(t *testing.T) {
+	t.Parallel()
+	parent := makeGenesisLedger(t)
+
+	t.Run("nil parent", func(t *testing.T) {
+		_, err := NewStoredLedgerReplay(nil, parent, nil)
+		require.ErrorContains(t, err, "parent is nil")
+	})
+	t.Run("nil target", func(t *testing.T) {
+		_, err := NewStoredLedgerReplay(parent, nil, nil)
+		require.ErrorContains(t, err, "target is nil")
+	})
+	t.Run("open parent", func(t *testing.T) {
+		open, err := ledger.NewOpen(parent, time.Now())
+		require.NoError(t, err)
+		target := makeStoredReplayTarget(t, parent, nil, nil, nil)
+		_, err = NewStoredLedgerReplay(open, target, nil)
+		require.ErrorContains(t, err, "parent is not closed")
+	})
+	t.Run("open target", func(t *testing.T) {
+		open, err := ledger.NewOpen(parent, time.Now())
+		require.NoError(t, err)
+		_, err = NewStoredLedgerReplay(parent, open, nil)
+		require.ErrorContains(t, err, "target is not closed")
+	})
+	t.Run("parent hash mismatch", func(t *testing.T) {
+		target := makeStoredReplayTarget(t, parent, nil, nil, func(h *header.LedgerHeader) {
+			h.ParentHash[0] ^= 0xff
+		})
+		_, err := NewStoredLedgerReplay(parent, target, nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrReplayParentMismatch)
+	})
+	t.Run("sequence mismatch", func(t *testing.T) {
+		target := makeStoredReplayTarget(t, parent, nil, nil, func(h *header.LedgerHeader) {
+			h.LedgerIndex++
+		})
+		_, err := NewStoredLedgerReplay(parent, target, nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrReplaySequenceMismatch)
+	})
+	t.Run("close time resolution mismatch", func(t *testing.T) {
+		target := makeStoredReplayTarget(t, parent, nil, nil, func(h *header.LedgerHeader) {
+			h.CloseTimeResolution = 120
+		})
+		_, err := NewStoredLedgerReplay(parent, target, nil)
+		require.ErrorContains(t, err, "derived")
+	})
+}
+
+func TestNewStoredLedgerReplayRejectsInvalidTransactionLeaves(t *testing.T) {
+	t.Parallel()
+	parent := makeGenesisLedger(t)
+
+	t.Run("malformed leaf", func(t *testing.T) {
+		malformed := make([]byte, 12)
+		malformed[0] = 0xff
+		target := makeStoredReplayTarget(
+			t,
+			parent,
+			[][]byte{malformed},
+			[][32]byte{{1}},
+			nil,
+		)
+		_, err := NewStoredLedgerReplay(parent, target, nil)
+		require.ErrorContains(t, err, "split leaf")
+	})
+	t.Run("missing index field", func(t *testing.T) {
+		blob, txID := makeStoredReplayLeafWithoutIndex(
+			t,
+			[]byte("stored-replay-missing-index-padding"),
+		)
+		target := makeStoredReplayTarget(t, parent, [][]byte{blob}, [][32]byte{txID}, nil)
+		_, err := NewStoredLedgerReplay(parent, target, nil)
+		require.ErrorContains(t, err, "missing transaction index")
+	})
+	t.Run("duplicate index", func(t *testing.T) {
+		blobA, txA := makeTxWithMetaBlob(t, []byte("stored-replay-duplicate-a-padding"), 0)
+		blobB, txB := makeTxWithMetaBlob(t, []byte("stored-replay-duplicate-b-padding"), 0)
+		target := makeStoredReplayTarget(
+			t,
+			parent,
+			[][]byte{blobA, blobB},
+			[][32]byte{txA, txB},
+			nil,
+		)
+		_, err := NewStoredLedgerReplay(parent, target, nil)
+		require.ErrorContains(t, err, "duplicate transaction index 0")
+	})
+	t.Run("index gap", func(t *testing.T) {
+		blobA, txA := makeTxWithMetaBlob(t, []byte("stored-replay-gap-a-padding"), 0)
+		blobB, txB := makeTxWithMetaBlob(t, []byte("stored-replay-gap-b-padding"), 2)
+		target := makeStoredReplayTarget(
+			t,
+			parent,
+			[][]byte{blobA, blobB},
+			[][32]byte{txA, txB},
+			nil,
+		)
+		_, err := NewStoredLedgerReplay(parent, target, nil)
+		require.ErrorContains(t, err, "missing transaction index 1")
+	})
+	t.Run("transaction hash mismatch", func(t *testing.T) {
+		blob, txID := makeTxWithMetaBlob(t, []byte("stored-replay-hash-mismatch-padding"), 0)
+		wrongID := txID
+		wrongID[0] ^= 0xff
+		target := makeStoredReplayTarget(t, parent, [][]byte{blob}, [][32]byte{wrongID}, nil)
+		_, err := NewStoredLedgerReplay(parent, target, nil)
+		require.ErrorContains(t, err, "transaction hash mismatch")
+	})
+}
+
+func TestNewStoredLedgerReplayRejectsInvalidHeaderHash(t *testing.T) {
+	t.Parallel()
+	parent := makeGenesisLedger(t)
+	target := makeStoredReplayTarget(t, parent, nil, nil, nil)
+	hdr := target.Header()
+	hdr.Hash[0] ^= 0xff
+
+	stateMap, err := target.StateMapSnapshot()
+	require.NoError(t, err)
+	txMap, err := target.TxMapSnapshot()
+	require.NoError(t, err)
+	target, err = ledger.NewFromHeader(hdr, stateMap, txMap, target.GetFees())
+	require.NoError(t, err)
+
+	_, err = NewStoredLedgerReplay(parent, target, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "header hash mismatch")
+}

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -149,6 +149,9 @@ func newOpen(parent *Ledger, closeTime time.Time, building bool) (*Ledger, error
 	if parent == nil {
 		return nil, errors.New("parent ledger cannot be nil")
 	}
+	if parent.header.LedgerIndex == ^uint32(0) {
+		return nil, fmt.Errorf("parent ledger sequence %d has no successor", parent.header.LedgerIndex)
+	}
 	parentRules, err := parent.loadRules()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load parent amendment rules: %w", err)

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -168,6 +168,22 @@ func TestNewOpenForBuildUsesProvisionalApplicationTime(t *testing.T) {
 	}
 }
 
+func TestNewOpenRejectsParentWithoutSuccessor(t *testing.T) {
+	result, err := genesis.Create(genesis.DefaultConfig())
+	if err != nil {
+		t.Fatalf("genesis.Create: %v", err)
+	}
+	parent := FromGenesis(result.Header, result.StateMap, result.TxMap, drops.Fees{})
+	parent.header.LedgerIndex = ^uint32(0)
+
+	if _, err = NewOpen(parent, time.Now()); err == nil {
+		t.Fatal("NewOpen accepted a maximum-sequence parent")
+	}
+	if _, err = NewOpenForBuild(parent, time.Now()); err == nil {
+		t.Fatal("NewOpenForBuild accepted a maximum-sequence parent")
+	}
+}
+
 // TestLedger_Close_DynamicResolution_Disagree verifies the
 // symmetric path: when the parent's CloseFlags carry
 // sLCF_NoConsensusTime (previousAgree=false) and the child seq is on

--- a/internal/ledger/service/ledger_by_hash_nodestore_test.go
+++ b/internal/ledger/service/ledger_by_hash_nodestore_test.go
@@ -46,6 +46,7 @@ func TestService_GetLedgerByHashLoadsEvictedLedgerFromNodeStore(t *testing.T) {
 	genesisConfig.Amendments = append(genesisConfig.Amendments, amendment.FeatureXRPFees)
 	svc, err := New(Config{
 		Standalone:    true,
+		Startup:       StartupConfig{Mode: StartupFresh},
 		GenesisConfig: genesisConfig,
 		NodeStore:     db,
 		SHAMapFamily:  shamapbackend.New(db),

--- a/internal/ledger/service/ledger_file.go
+++ b/internal/ledger/service/ledger_file.go
@@ -1,0 +1,387 @@
+package service
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/tx/ledgerfields"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+const xrpLedgerEarliestFees uint32 = 562177
+
+func (s *Service) loadLedgerFile(
+	ctx context.Context,
+	path string,
+	defaultCloseTime time.Time,
+) (*ledger.Ledger, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open ledger file %q: %w", path, err)
+	}
+	defer file.Close()
+
+	loaded, err := s.loadLedgerJSON(ctx, file, defaultCloseTime)
+	if err != nil {
+		return nil, fmt.Errorf("load ledger file %q: %w", path, err)
+	}
+	return loaded, nil
+}
+
+func (s *Service) loadLedgerJSON(
+	ctx context.Context,
+	r io.Reader,
+	defaultCloseTime time.Time,
+) (*ledger.Ledger, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	decoder := json.NewDecoder(r)
+	decoder.UseNumber()
+
+	var document any
+	if err := decoder.Decode(&document); err != nil {
+		return nil, fmt.Errorf("decode ledger JSON: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("decode ledger JSON: multiple JSON values")
+		}
+		return nil, fmt.Errorf("decode ledger JSON trailing data: %w", err)
+	}
+
+	selected := document
+	if object, ok := selected.(map[string]any); ok {
+		if result, exists := object["result"]; exists {
+			selected = result
+		}
+	}
+	if object, ok := selected.(map[string]any); ok {
+		if ledgerValue, exists := object["ledger"]; exists {
+			selected = ledgerValue
+		}
+	}
+	selected, err := normalizeLedgerJSONNumbers(selected)
+	if err != nil {
+		return nil, err
+	}
+
+	sequence := uint32(1)
+	closeTime := protocol.FromRippleTime(protocol.ToRippleTime(defaultCloseTime))
+	closeTimeResolution := uint32(30)
+	closeTimeEstimated := false
+	totalDrops := uint64(0)
+	stateValue := selected
+
+	if object, ok := selected.(map[string]any); ok {
+		accountState, exists := object["accountState"]
+		if !exists {
+			return nil, errors.New("ledger JSON state nodes must be an array")
+		}
+		stateValue = accountState
+
+		if value, exists := object["ledger_index"]; exists {
+			sequence, err = ledgerFileUint32("ledger_index", value)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if value, exists := object["close_time"]; exists {
+			seconds, parseErr := ledgerFileUint32("close_time", value)
+			if parseErr != nil {
+				return nil, parseErr
+			}
+			closeTime = protocol.FromRippleTime(seconds)
+		}
+		if value, exists := object["close_time_resolution"]; exists {
+			closeTimeResolution, err = ledgerFileUint32("close_time_resolution", value)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if value, exists := object["close_time_estimated"]; exists {
+			closeTimeEstimated = ledgerFileBool(value)
+		}
+		if value, exists := object["total_coins"]; exists {
+			totalDrops, err = ledgerFileUint64("total_coins", value)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	var stateNodes []any
+	switch value := stateValue.(type) {
+	case []any:
+		stateNodes = value
+	case nil:
+	default:
+		return nil, errors.New("ledger JSON state nodes must be an array")
+	}
+
+	stateMap := shamap.New(shamap.TypeState)
+	for i, node := range stateNodes {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		object, ok := node.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("accountState[%d] must be an object", i)
+		}
+
+		indexValue, exists := object["index"]
+		if !exists {
+			return nil, fmt.Errorf("accountState[%d] is missing index", i)
+		}
+		index, err := ledgerFileIndex(indexValue)
+		if err != nil {
+			return nil, fmt.Errorf("accountState[%d] index: %w", i, err)
+		}
+		delete(object, "index")
+
+		exists, err = stateMap.HasContext(ctx, index)
+		if err != nil {
+			return nil, fmt.Errorf("check accountState[%d] index: %w", i, err)
+		}
+		if exists {
+			return nil, fmt.Errorf("accountState[%d] duplicates index %s", i, strings.ToUpper(indexValue.(string)))
+		}
+
+		entryType, ok := object["LedgerEntryType"].(string)
+		if !ok || entryType == "" {
+			return nil, fmt.Errorf("accountState[%d] has invalid LedgerEntryType", i)
+		}
+		if entryType == "MPTokenIssuance" {
+			delete(object, "mpt_issuance_id")
+		}
+
+		typed := ledgerfields.New(entryType)
+		if typed == nil {
+			return nil, fmt.Errorf("accountState[%d] has unknown LedgerEntryType %q", i, entryType)
+		}
+		blob, err := binarycodec.EncodeBytes(object)
+		if err != nil {
+			return nil, fmt.Errorf("encode accountState[%d] %s: %w", i, entryType, err)
+		}
+		if err := typed.Decode(blob); err != nil {
+			return nil, fmt.Errorf("validate accountState[%d] %s: %w", i, entryType, err)
+		}
+		if err := stateMap.Put(index, blob); err != nil {
+			return nil, fmt.Errorf("insert accountState[%d] %s: %w", i, entryType, err)
+		}
+	}
+
+	accountHash, err := stateMap.Hash()
+	if err != nil {
+		return nil, fmt.Errorf("hash ledger state map: %w", err)
+	}
+	if accountHash == ([32]byte{}) {
+		return nil, errors.New("ledger JSON state map is empty")
+	}
+	if sequence >= xrpLedgerEarliestFees {
+		found, err := stateMap.HasContext(ctx, keylet.Fees().Key)
+		if err != nil {
+			return nil, fmt.Errorf("read FeeSettings entry: %w", err)
+		}
+		if !found {
+			return nil, fmt.Errorf("ledger %d is missing FeeSettings", sequence)
+		}
+	}
+
+	rules, err := ledger.LoadAmendmentsFromSHAMapContext(ctx, stateMap)
+	if err != nil {
+		return nil, fmt.Errorf("load amendment rules: %w", err)
+	}
+	fees, err := storedLedgerFees(ctx, stateMap, rules.XRPFeesEnabled(), s.configuredFees)
+	if err != nil {
+		return nil, fmt.Errorf("load ledger fees: %w", err)
+	}
+
+	txMap := shamap.New(shamap.TypeTransaction)
+	txHash, err := txMap.Hash()
+	if err != nil {
+		return nil, fmt.Errorf("hash ledger transaction map: %w", err)
+	}
+
+	closeFlags := uint8(0)
+	if closeTimeEstimated {
+		closeFlags = header.LCFNoConsensusTime
+	}
+	hdr := header.LedgerHeader{
+		LedgerIndex:         sequence,
+		TxHash:              txHash,
+		AccountHash:         accountHash,
+		Drops:               totalDrops,
+		Accepted:            true,
+		CloseFlags:          closeFlags,
+		CloseTimeResolution: closeTimeResolution,
+		CloseTime:           closeTime,
+	}
+	hdr.Hash = header.CalculateHash(hdr)
+
+	loaded, err := ledger.NewClosedFromHeaderContext(ctx, hdr, stateMap, txMap, fees)
+	if err != nil {
+		return nil, fmt.Errorf("construct loaded ledger: %w", err)
+	}
+	if s.shamapFamily != nil {
+		loaded.SetSHAMapFamily(s.shamapFamily)
+	}
+	return loaded, nil
+}
+
+func normalizeLedgerJSONNumbers(value any) (any, error) {
+	switch value := value.(type) {
+	case json.Number:
+		parsed, err := strconv.ParseInt(value.String(), 10, 64)
+		if err == nil {
+			return parsed, nil
+		}
+		real, realErr := strconv.ParseFloat(value.String(), 64)
+		if realErr != nil {
+			return nil, fmt.Errorf("invalid number %q: %w", value, realErr)
+		}
+		return real, nil
+	case []any:
+		for i := range value {
+			normalized, err := normalizeLedgerJSONNumbers(value[i])
+			if err != nil {
+				return nil, err
+			}
+			value[i] = normalized
+		}
+		return value, nil
+	case map[string]any:
+		for key, item := range value {
+			normalized, err := normalizeLedgerJSONNumbers(item)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %w", key, err)
+			}
+			value[key] = normalized
+		}
+		return value, nil
+	default:
+		return value, nil
+	}
+}
+
+func ledgerFileBool(value any) bool {
+	switch value := value.(type) {
+	case nil:
+		return false
+	case bool:
+		return value
+	case int64:
+		return value != 0
+	case float64:
+		return value != 0
+	case string:
+		return value != ""
+	case []any:
+		return len(value) != 0
+	case map[string]any:
+		return len(value) != 0
+	default:
+		return false
+	}
+}
+
+func ledgerFileUint32(name string, value any) (uint32, error) {
+	var parsed uint64
+	switch value := value.(type) {
+	case nil:
+		return 0, nil
+	case bool:
+		if value {
+			return 1, nil
+		}
+		return 0, nil
+	case string:
+		var err error
+		parsed, err = strconv.ParseUint(value, 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("invalid %s: %w", name, err)
+		}
+	case int64:
+		if value < 0 {
+			return 0, fmt.Errorf("%s must be non-negative", name)
+		}
+		parsed = uint64(value)
+	case float64:
+		if value < 0 || value > math.MaxUint32 {
+			return 0, fmt.Errorf("%s is out of range: %v", name, value)
+		}
+		return uint32(value), nil
+	default:
+		return 0, fmt.Errorf("%s must be convertible to an unsigned integer, got %T", name, value)
+	}
+	if parsed > math.MaxUint32 {
+		return 0, fmt.Errorf("%s is out of range: %d", name, parsed)
+	}
+	return uint32(parsed), nil
+}
+
+func ledgerFileUint64(name string, value any) (uint64, error) {
+	return ledgerFileUnsigned(name, value, math.MaxUint64)
+}
+
+func ledgerFileUnsigned(name string, value any, maximum uint64) (uint64, error) {
+	var (
+		parsed uint64
+		err    error
+	)
+	switch value := value.(type) {
+	case string:
+		parsed, err = strconv.ParseUint(value, 10, 64)
+	case int64:
+		if value < 0 {
+			return 0, fmt.Errorf("%s must be non-negative", name)
+		}
+		parsed = uint64(value)
+	default:
+		return 0, fmt.Errorf("%s must be an integer or decimal string, got %T", name, value)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s: %w", name, err)
+	}
+	if parsed > maximum {
+		return 0, fmt.Errorf("%s is out of range: %d", name, parsed)
+	}
+	return parsed, nil
+}
+
+func ledgerFileIndex(value any) ([32]byte, error) {
+	text, ok := value.(string)
+	if !ok {
+		return [32]byte{}, fmt.Errorf("must be a hexadecimal string, got %T", value)
+	}
+	if len(text) != 64 {
+		return [32]byte{}, fmt.Errorf("must contain exactly 64 hexadecimal digits")
+	}
+	decoded, err := hex.DecodeString(text)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("invalid hexadecimal value: %w", err)
+	}
+	var index [32]byte
+	copy(index[:], decoded)
+	if index == ([32]byte{}) {
+		return [32]byte{}, errors.New("must not be zero")
+	}
+	return index, nil
+}

--- a/internal/ledger/service/ledger_file_test.go
+++ b/internal/ledger/service/ledger_file_test.go
@@ -1,0 +1,476 @@
+package service
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/LeJamon/go-xrpl/shamap"
+)
+
+const (
+	ledgerFileTestAccount = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	ledgerFileTestIndex   = "1111111111111111111111111111111111111111111111111111111111111111"
+)
+
+func TestLoadLedgerJSONWrappersAndDefaults(t *testing.T) {
+	defaultCloseTime := time.Date(2026, time.July, 27, 14, 15, 16, 0, time.UTC)
+	entry := ledgerFileTestAccountRoot(ledgerFileTestIndex)
+	tests := []struct {
+		name           string
+		document       any
+		wantSequence   uint32
+		wantCloseTime  time.Time
+		wantResolution uint32
+		wantDrops      uint64
+		wantFlags      uint8
+	}{
+		{
+			name:           "bare account state",
+			document:       []any{entry},
+			wantSequence:   1,
+			wantCloseTime:  defaultCloseTime,
+			wantResolution: 30,
+		},
+		{
+			name: "ledger wrapper and API v1 sequence",
+			document: map[string]any{
+				"ledger": map[string]any{
+					"ledger_index":          "7",
+					"close_time":            800000000,
+					"close_time_resolution": 20,
+					"close_time_estimated":  true,
+					"total_coins":           "999999999",
+					"ledger_hash":           strings.Repeat("A", 64),
+					"account_hash":          strings.Repeat("B", 64),
+					"transaction_hash":      strings.Repeat("C", 64),
+					"parent_hash":           strings.Repeat("D", 64),
+					"parent_close_time":     799999990,
+					"close_flags":           0,
+					"accountState":          []any{entry},
+				},
+			},
+			wantSequence:   7,
+			wantCloseTime:  protocol.FromRippleTime(800000000),
+			wantResolution: 20,
+			wantDrops:      999999999,
+			wantFlags:      header.LCFNoConsensusTime,
+		},
+		{
+			name: "result and ledger wrappers with API v2 sequence",
+			document: map[string]any{
+				"result": map[string]any{
+					"ledger": map[string]any{
+						"ledger_index": 8,
+						"accountState": []any{entry},
+					},
+				},
+			},
+			wantSequence:   8,
+			wantCloseTime:  defaultCloseTime,
+			wantResolution: 30,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			svc := ledgerFileTestService(t)
+			loaded, err := svc.loadLedgerJSON(
+				context.Background(),
+				strings.NewReader(ledgerFileMarshal(t, test.document)),
+				defaultCloseTime,
+			)
+			if err != nil {
+				t.Fatalf("loadLedgerJSON() error = %v", err)
+			}
+
+			gotHeader := loaded.Header()
+			if gotHeader.LedgerIndex != test.wantSequence {
+				t.Errorf("LedgerIndex = %d, want %d", gotHeader.LedgerIndex, test.wantSequence)
+			}
+			if !gotHeader.CloseTime.Equal(test.wantCloseTime) {
+				t.Errorf("CloseTime = %v, want %v", gotHeader.CloseTime, test.wantCloseTime)
+			}
+			if gotHeader.CloseTimeResolution != test.wantResolution {
+				t.Errorf("CloseTimeResolution = %d, want %d", gotHeader.CloseTimeResolution, test.wantResolution)
+			}
+			if gotHeader.Drops != test.wantDrops {
+				t.Errorf("Drops = %d, want %d", gotHeader.Drops, test.wantDrops)
+			}
+			if gotHeader.CloseFlags != test.wantFlags {
+				t.Errorf("CloseFlags = %d, want %d", gotHeader.CloseFlags, test.wantFlags)
+			}
+			if gotHeader.ParentHash != ([32]byte{}) {
+				t.Errorf("ParentHash = %x, want zero", gotHeader.ParentHash)
+			}
+			if !gotHeader.Accepted || gotHeader.Validated {
+				t.Errorf("accepted/validated = %v/%v, want true/false", gotHeader.Accepted, gotHeader.Validated)
+			}
+			if !loaded.IsClosed() {
+				t.Error("loaded ledger is not closed")
+			}
+
+			wantStateHash := ledgerFileTestStateHash(t, entry)
+			gotStateHash, err := loaded.StateMapHash()
+			if err != nil {
+				t.Fatalf("StateMapHash() error = %v", err)
+			}
+			if gotStateHash != wantStateHash {
+				t.Errorf("AccountHash = %x, want %x", gotStateHash, wantStateHash)
+			}
+			if gotHeader.AccountHash != wantStateHash {
+				t.Errorf("header AccountHash = %x, want %x", gotHeader.AccountHash, wantStateHash)
+			}
+
+			gotTxHash, err := loaded.TxMapHash()
+			if err != nil {
+				t.Fatalf("TxMapHash() error = %v", err)
+			}
+			if gotHeader.TxHash != gotTxHash {
+				t.Errorf("header TxHash = %x, map hash %x", gotHeader.TxHash, gotTxHash)
+			}
+			if gotHeader.Hash != header.CalculateHash(gotHeader) {
+				t.Errorf("ledger hash = %x, want recomputed %x", gotHeader.Hash, header.CalculateHash(gotHeader))
+			}
+		})
+	}
+}
+
+func TestLoadLedgerJSONRebuildsExpandedLedgerState(t *testing.T) {
+	source, err := genesis.Create(genesis.DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	accountState := make([]any, 0, source.StateMap.Size())
+	if err := source.StateMap.ForEach(func(item *shamap.Item) bool {
+		entry, decodeErr := binarycodec.Decode(hex.EncodeToString(item.Data()))
+		if decodeErr != nil {
+			t.Errorf("decode source entry %x: %v", item.Key(), decodeErr)
+			return false
+		}
+		entry["index"] = fmt.Sprintf("%X", item.Key())
+		accountState = append(accountState, entry)
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	document := map[string]any{
+		"result": map[string]any{
+			"ledger": map[string]any{
+				"ledger_index":          source.Header.LedgerIndex,
+				"close_time":            protocol.ToRippleTime(source.Header.CloseTime),
+				"close_time_resolution": source.Header.CloseTimeResolution,
+				"total_coins":           fmt.Sprintf("%d", source.Header.Drops),
+				"accountState":          accountState,
+			},
+		},
+	}
+
+	loaded, err := ledgerFileTestService(t).loadLedgerJSON(
+		context.Background(),
+		strings.NewReader(ledgerFileMarshal(t, document)),
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("loadLedgerJSON() error = %v", err)
+	}
+	gotHash, err := loaded.StateMapHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantHash, err := source.StateMap.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotHash != wantHash {
+		t.Errorf("state map hash = %x, want %x", gotHash, wantHash)
+	}
+	loadedSize := 0
+	if err := loaded.ForEach(func(_ [32]byte, _ []byte) bool {
+		loadedSize++
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if loadedSize != source.StateMap.Size() {
+		t.Errorf("state map size = %d, want %d", loadedSize, source.StateMap.Size())
+	}
+}
+
+func TestLoadLedgerJSONRejectsMalformedState(t *testing.T) {
+	validEntry := ledgerFileTestAccountRoot(ledgerFileTestIndex)
+	duplicateEntry := ledgerFileTestAccountRoot(ledgerFileTestIndex)
+	zeroIndexEntry := ledgerFileTestAccountRoot(strings.Repeat("0", 64))
+	missingIndexEntry := ledgerFileTestAccountRoot(ledgerFileTestIndex)
+	delete(missingIndexEntry, "index")
+
+	tests := []struct {
+		name      string
+		document  string
+		wantError string
+	}{
+		{name: "truncated JSON", document: `{"ledger":`, wantError: "decode ledger JSON"},
+		{name: "multiple JSON values", document: `[] []`, wantError: "multiple JSON values"},
+		{name: "object without account state", document: `{}`, wantError: "state nodes must be an array"},
+		{name: "state is object", document: `{"accountState":{}}`, wantError: "state nodes must be an array"},
+		{name: "empty state", document: `[]`, wantError: "state map is empty"},
+		{name: "null state node", document: `[null]`, wantError: "must be an object"},
+		{
+			name:      "missing index",
+			document:  ledgerFileMarshal(t, []any{missingIndexEntry}),
+			wantError: "missing index",
+		},
+		{
+			name:      "short index",
+			document:  ledgerFileMarshal(t, []any{ledgerFileTestAccountRoot("01")}),
+			wantError: "exactly 64",
+		},
+		{
+			name:      "zero index",
+			document:  ledgerFileMarshal(t, []any{zeroIndexEntry}),
+			wantError: "must not be zero",
+		},
+		{
+			name:      "duplicate index",
+			document:  ledgerFileMarshal(t, []any{validEntry, duplicateEntry}),
+			wantError: "duplicates index",
+		},
+		{
+			name: "unknown ledger entry type",
+			document: ledgerFileMarshal(t, []any{map[string]any{
+				"index":           ledgerFileTestIndex,
+				"LedgerEntryType": "Unknown",
+			}}),
+			wantError: "unknown LedgerEntryType",
+		},
+		{
+			name: "missing required entry field",
+			document: ledgerFileMarshal(t, []any{map[string]any{
+				"index":             ledgerFileTestIndex,
+				"LedgerEntryType":   "AccountRoot",
+				"Account":           ledgerFileTestAccount,
+				"Flags":             0,
+				"OwnerCount":        0,
+				"Sequence":          1,
+				"PreviousTxnID":     strings.Repeat("0", 64),
+				"PreviousTxnLgrSeq": 0,
+			}}),
+			wantError: "required field Balance is missing",
+		},
+	}
+
+	svc := ledgerFileTestService(t)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := svc.loadLedgerJSON(
+				context.Background(),
+				strings.NewReader(test.document),
+				time.Date(2026, time.July, 27, 0, 0, 0, 0, time.UTC),
+			)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("loadLedgerJSON() error = %v, want containing %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestLoadLedgerJSONRejectsInvalidNumbers(t *testing.T) {
+	entryJSON := ledgerFileMarshal(t, []any{ledgerFileTestAccountRoot(ledgerFileTestIndex)})
+	tests := []struct {
+		name      string
+		document  string
+		wantError string
+	}{
+		{
+			name:      "negative close time",
+			document:  `{"close_time":-1,"accountState":` + entryJSON + `}`,
+			wantError: "close_time must be non-negative",
+		},
+		{
+			name:      "sequence overflow",
+			document:  `{"ledger_index":4294967296,"accountState":` + entryJSON + `}`,
+			wantError: "ledger_index is out of range",
+		},
+		{
+			name:      "drops overflow",
+			document:  `{"total_coins":"18446744073709551616","accountState":` + entryJSON + `}`,
+			wantError: "invalid total_coins",
+		},
+	}
+
+	svc := ledgerFileTestService(t)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := svc.loadLedgerJSON(
+				context.Background(),
+				strings.NewReader(test.document),
+				time.Now(),
+			)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("loadLedgerJSON() error = %v, want containing %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestLedgerFileBoolMatchesRippledJSONTruthiness(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  bool
+	}{
+		{name: "null", value: nil},
+		{name: "false", value: false},
+		{name: "true", value: true, want: true},
+		{name: "zero integer", value: int64(0)},
+		{name: "nonzero integer", value: int64(-1), want: true},
+		{name: "zero real", value: float64(0)},
+		{name: "nonzero real", value: 0.5, want: true},
+		{name: "empty string", value: ""},
+		{name: "nonempty string", value: "false", want: true},
+		{name: "empty array", value: []any{}},
+		{name: "nonempty array", value: []any{nil}, want: true},
+		{name: "empty object", value: map[string]any{}},
+		{name: "nonempty object", value: map[string]any{"value": nil}, want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ledgerFileBool(test.value); got != test.want {
+				t.Errorf("ledgerFileBool(%#v) = %v, want %v", test.value, got, test.want)
+			}
+		})
+	}
+}
+
+func TestLedgerFileUint32MatchesRippledJSONConversions(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   any
+		want    uint32
+		wantErr bool
+	}{
+		{name: "null", value: nil},
+		{name: "false", value: false},
+		{name: "true", value: true, want: 1},
+		{name: "integer", value: int64(43), want: 43},
+		{name: "fraction truncates", value: 43.9, want: 43},
+		{name: "decimal string", value: "43", want: 43},
+		{name: "negative", value: int64(-1), wantErr: true},
+		{name: "overflow", value: int64(4294967296), wantErr: true},
+		{name: "object", value: map[string]any{}, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ledgerFileUint32("value", test.value)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("ledgerFileUint32(%#v) succeeded", test.value)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ledgerFileUint32(%#v) error = %v", test.value, err)
+			}
+			if got != test.want {
+				t.Errorf("ledgerFileUint32(%#v) = %d, want %d", test.value, got, test.want)
+			}
+		})
+	}
+}
+
+func TestLoadLedgerFile(t *testing.T) {
+	svc := ledgerFileTestService(t)
+	path := filepath.Join(t.TempDir(), "ledger.json")
+	document := ledgerFileMarshal(t, map[string]any{
+		"ledger": map[string]any{
+			"accountState": []any{ledgerFileTestAccountRoot(ledgerFileTestIndex)},
+		},
+	})
+	if err := os.WriteFile(path, []byte(document), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := svc.loadLedgerFile(context.Background(), path, time.Now())
+	if err != nil {
+		t.Fatalf("loadLedgerFile() error = %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("loadLedgerFile() returned nil ledger")
+	}
+
+	_, err = svc.loadLedgerFile(context.Background(), path+".missing", time.Now())
+	if err == nil || !strings.Contains(err.Error(), "open ledger file") {
+		t.Fatalf("missing file error = %v, want open ledger file error", err)
+	}
+}
+
+func ledgerFileTestService(t *testing.T) *Service {
+	t.Helper()
+	svc, err := New(Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc
+}
+
+func ledgerFileTestAccountRoot(index string) map[string]any {
+	return map[string]any{
+		"index":             index,
+		"LedgerEntryType":   "AccountRoot",
+		"Account":           ledgerFileTestAccount,
+		"Balance":           "100000000",
+		"Flags":             0,
+		"OwnerCount":        0,
+		"Sequence":          1,
+		"PreviousTxnID":     strings.Repeat("0", 64),
+		"PreviousTxnLgrSeq": 0,
+	}
+}
+
+func ledgerFileTestStateHash(t *testing.T, state map[string]any) [32]byte {
+	t.Helper()
+	index, err := ledgerFileIndex(state["index"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	object := make(map[string]any, len(state)-1)
+	for key, value := range state {
+		if key != "index" {
+			object[key] = value
+		}
+	}
+	blob, err := binarycodec.EncodeBytes(object)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateMap := shamap.New(shamap.TypeState)
+	if err := stateMap.Put(index, blob); err != nil {
+		t.Fatal(err)
+	}
+	hash, err := stateMap.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hash
+}
+
+func ledgerFileMarshal(t *testing.T, value any) string {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(encoded)
+}

--- a/internal/ledger/service/lifecycle.go
+++ b/internal/ledger/service/lifecycle.go
@@ -46,7 +46,13 @@ func (s *Service) AcceptLedgerAt(ctx context.Context, explicitCloseTime time.Tim
 
 	// Re-apply pending in canonical order on a fresh ledger built from the LCL.
 	var retriableTxs []openledger.PendingTx
-	if len(s.pendingTxs) > 0 {
+	replayed, err := s.applyStartupReplayLocked()
+	if err != nil {
+		return 0, err
+	}
+	if replayed {
+		retriableTxs = append(retriableTxs, s.pendingTxs...)
+	} else if len(s.pendingTxs) > 0 {
 		built, err := s.buildClosedLedgerLocked(s.pendingTxs, closeTime, s.config.Standalone)
 		if err != nil {
 			return 0, err
@@ -61,13 +67,19 @@ func (s *Service) AcceptLedgerAt(ctx context.Context, explicitCloseTime time.Tim
 
 	s.pendingTxs = nil
 
-	if err := s.openLedger.Close(closeTime, 0); err != nil {
-		return 0, fmt.Errorf("failed to close ledger: %w", err)
+	if !replayed {
+		if err := s.openLedger.Close(closeTime, 0); err != nil {
+			return 0, fmt.Errorf("failed to close ledger: %w", err)
+		}
 	}
 
 	// Standalone validates immediately.
 	if err := s.openLedger.SetValidated(); err != nil {
 		return 0, fmt.Errorf("failed to validate ledger: %w", err)
+	}
+	if replayed {
+		s.startupReplay = nil
+		closeTime = s.openLedger.CloseTime()
 	}
 
 	// Persist best-effort: a persistence failure must not be fatal — treating it
@@ -535,10 +547,22 @@ func (s *Service) acceptConsensusResult(
 		}
 		pending = append(pending, ptx)
 	}
-
-	retriableTxs, err := s.buildClosedLedgerLocked(pending, closeTime, false)
+	replayed, err := s.applyStartupReplayLocked()
 	if err != nil {
 		return 0, err
+	}
+	var retriableTxs []openledger.PendingTx
+	if !replayed {
+		retriableTxs, err = s.buildClosedLedgerLocked(pending, closeTime, false)
+		if err != nil {
+			return 0, err
+		}
+	} else {
+		canonicalSort(pending, computeSalt(pending))
+		retriableTxs = append(retriableTxs, pending...)
+		s.startupReplay = nil
+		closeTime = s.openLedger.CloseTime()
+		closeTimeCorrect = s.openLedger.Header().CloseFlags&header.LCFNoConsensusTime == 0
 	}
 
 	// Pseudo-txs can't succeed in a later ledger; malformed blobs are
@@ -584,8 +608,12 @@ func (s *Service) acceptConsensusResult(
 	if !closeTimeCorrect {
 		closeFlags = header.LCFNoConsensusTime
 	}
-	if err := s.openLedger.Close(closeTime, closeFlags); err != nil {
-		return 0, fmt.Errorf("failed to close ledger: %w", err)
+	if !replayed {
+		if err := s.openLedger.Close(closeTime, closeFlags); err != nil {
+			return 0, fmt.Errorf("failed to close ledger: %w", err)
+		}
+	} else {
+		closeFlags = s.openLedger.Header().CloseFlags
 	}
 
 	// Do NOT auto-validate — validation comes from the consensus validation tracker.
@@ -610,7 +638,7 @@ func (s *Service) acceptConsensusResult(
 			"state_root", fmt.Sprintf("%x", stateRoot[:8]),
 			"tx_root", fmt.Sprintf("%x", txRoot[:8]),
 			"total_drops", s.openLedger.TotalDrops(),
-			"tx_count", len(txBlobs),
+			"tx_count", s.openLedger.TxCount(),
 			"tx_hashes", canonicalTxHashes,
 		)
 	}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -53,8 +53,7 @@ var (
 // Config holds configuration for the LedgerService
 type Config struct {
 	Standalone bool
-	// Startup selects an explicit initial-ledger workflow.
-	Startup StartupConfig
+	Startup    StartupConfig
 	// NodeSize selects rippled's cache sweep cadence. Empty uses the medium
 	// profile, matching the top-level configuration default.
 	NodeSize string

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -485,7 +485,11 @@ func (s *Service) Start() error {
 
 	genesisConfig := s.config.GenesisConfig
 	switch s.config.Startup.Mode {
-	case StartupLoad, StartupLoadFile, StartupReplay, StartupNetwork:
+	case StartupFresh:
+		if s.amendmentTable != nil {
+			genesisConfig.Amendments = s.amendmentTable.Desired()
+		}
+	default:
 		genesisConfig.Amendments = nil
 	}
 	genesisResult, err := genesis.Create(genesisConfig)
@@ -532,6 +536,7 @@ func (s *Service) Start() error {
 	}
 	if selection.loaded {
 		s.installLoadedStartupLocked(selection.ledger, genesisLedger)
+		s.syncTable(selection.ledger)
 	} else {
 		s.closedLedger = selection.ledger
 		s.putHistoryLocked(selection.ledger)

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
 	"github.com/LeJamon/go-xrpl/internal/ledger/localtxs"
 	"github.com/LeJamon/go-xrpl/internal/ledger/manager"
 	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
@@ -52,6 +53,8 @@ var (
 // Config holds configuration for the LedgerService
 type Config struct {
 	Standalone bool
+	// Startup selects an explicit initial-ledger workflow.
+	Startup StartupConfig
 	// NodeSize selects rippled's cache sweep cadence. Empty uses the medium
 	// profile, matching the top-level configuration default.
 	NodeSize string
@@ -212,6 +215,10 @@ type Service struct {
 	// needsInitialSync is true when the node is in consensus mode
 	// and hasn't yet adopted a ledger from peers.
 	needsInitialSync bool
+
+	// startupReplay is the one-shot replay staged for the first close and is
+	// guarded by mu together with the closed/open ledger frontier.
+	startupReplay *inbound.ReplayDelta
 
 	// serverStateFunc optionally provides the operating mode string for server_info.
 	// Set by the consensus adaptor after startup.
@@ -476,7 +483,12 @@ func (s *Service) Start() error {
 		go s.runLedgerEventDispatcher()
 	}
 
-	genesisResult, err := genesis.Create(s.config.GenesisConfig)
+	genesisConfig := s.config.GenesisConfig
+	switch s.config.Startup.Mode {
+	case StartupLoad, StartupLoadFile, StartupReplay, StartupNetwork:
+		genesisConfig.Amendments = nil
+	}
+	genesisResult, err := genesis.Create(genesisConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create genesis ledger: %w", err)
 	}
@@ -501,57 +513,35 @@ func (s *Service) Start() error {
 		"hash", strconv.FormatUint(uint64(hash[0])<<24|uint64(hash[1])<<16|uint64(hash[2])<<8|uint64(hash[3]), 16)+"...",
 	)
 
-	var latest *ledger.Ledger
-	if !s.config.Standalone && s.config.FastLoad {
-		latest, err = s.loadLatestLedger(context.Background())
-		if err != nil {
-			s.logger.Warn("fast load failed; starting from genesis", "err", err)
-		}
+	initialClosed, err := ledger.NewOpen(genesisLedger, time.Now())
+	if err != nil {
+		return fmt.Errorf("failed to create initial closed ledger: %w", err)
+	}
+	if err := initialClosed.Close(time.Now(), 0); err != nil {
+		return fmt.Errorf("failed to close initial ledger: %w", err)
 	}
 
-	if latest == nil {
-		initialClosed, err := ledger.NewOpen(genesisLedger, time.Now())
-		if err != nil {
-			return fmt.Errorf("failed to create initial closed ledger: %w", err)
+	selection, err := s.selectStartup(context.Background(), initialClosed)
+	if err != nil {
+		return fmt.Errorf("select startup ledger: %w", err)
+	}
+	if selection.validate && !selection.ledger.IsValidated() {
+		if err := selection.ledger.SetValidated(); err != nil {
+			return fmt.Errorf("validate startup ledger: %w", err)
 		}
-		if err := initialClosed.Close(time.Now(), 0); err != nil {
-			return fmt.Errorf("failed to close initial ledger: %w", err)
-		}
-		s.closedLedger = initialClosed
-		s.putHistoryLocked(initialClosed)
-
-		if s.config.Standalone {
-			if err := initialClosed.SetValidated(); err != nil {
-				return fmt.Errorf("failed to validate initial ledger: %w", err)
-			}
-			s.validatedLedger = initialClosed
-			s.validatedSignTime = initialClosed.CloseTime()
-		} else {
-			s.needsInitialSync = true
-		}
+	}
+	if selection.loaded {
+		s.installLoadedStartupLocked(selection.ledger, genesisLedger)
 	} else {
-		s.closedLedger = latest
-		s.validatedLedger = latest
-		s.validatedSignTime = latest.CloseTime()
-		s.publishedLedgerSeq = latest.Sequence()
-		s.havePublished = true
-		s.ledgerEventMu.Lock()
-		s.ledgerEventFrontierSeq = latest.Sequence()
-		s.ledgerEventFrontierHash = latest.Hash()
-		s.ledgerEventHaveFrontier = true
-		s.ledgerEventMu.Unlock()
-		s.completeMu.Lock()
-		s.completedLedgers.Add(latest.Sequence())
-		s.completeLedgerHashes[latest.Sequence()] = latest.Hash()
-		s.completeMu.Unlock()
-		if latest.Sequence() != genesisLedger.Sequence() {
-			s.deleteHistoryLocked(genesisLedger.Sequence())
+		s.closedLedger = selection.ledger
+		s.putHistoryLocked(selection.ledger)
+		if selection.ledger.IsValidated() {
+			s.validatedLedger = selection.ledger
+			s.validatedSignTime = selection.ledger.CloseTime()
 		}
-		s.putHistoryLocked(latest)
-		s.collectTransactionResults(latest, latest.Sequence(), latest.Hash())
-		s.needsInitialSync = false
-		s.logger.Info("Loaded persisted validated ledger", "sequence", latest.Sequence())
+		s.needsInitialSync = selection.needsInitialSync
 	}
+	s.startupReplay = selection.replay
 
 	openLedger, err := ledger.NewOpen(s.closedLedger, time.Now())
 	if err != nil {
@@ -563,6 +553,9 @@ func (s *Service) Start() error {
 
 	// Initialise the persistent open-ledger view, anchored on closedLedger.
 	if err := s.rebuildOpenLedgerViewLocked(); err != nil {
+		return err
+	}
+	if err := s.stageStartupReplayLocked(); err != nil {
 		return err
 	}
 

--- a/internal/ledger/service/simulate_amm_test.go
+++ b/internal/ledger/service/simulate_amm_test.go
@@ -73,6 +73,7 @@ func TestService_SimulateTransaction_AMMCreateUsesParentHash(t *testing.T) {
 	// absent from the default genesis set — enable them explicitly, else the
 	// AMMCreate is temDISABLED.
 	cfg := service.DefaultConfig()
+	cfg.Startup = service.StartupConfig{Mode: service.StartupFresh}
 	cfg.GenesisConfig.Amendments = append(cfg.GenesisConfig.Amendments,
 		amendment.FeatureAMM, amendment.FeatureFixUniversalNumber)
 	svc, err := service.New(cfg)

--- a/internal/ledger/service/startup.go
+++ b/internal/ledger/service/startup.go
@@ -1,0 +1,300 @@
+package service
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/LeJamon/go-xrpl/storage/relationaldb"
+)
+
+// StartupMode selects how the ledger service establishes its initial frontier.
+type StartupMode uint8
+
+const (
+	// StartupNormal preserves the configured default startup behavior.
+	StartupNormal StartupMode = iota
+	// StartupFresh starts from a newly created ledger without network acquisition.
+	StartupFresh
+	// StartupLoad loads a ledger from local durable storage.
+	StartupLoad
+	// StartupLoadFile constructs a ledger from expanded JSON state.
+	StartupLoadFile
+	// StartupReplay loads a target and replays its close from the stored parent.
+	StartupReplay
+	// StartupNetwork starts from a temporary ledger and requests a network ledger.
+	StartupNetwork
+)
+
+// StartupConfig describes the explicitly selected startup mode and its operand.
+type StartupConfig struct {
+	Mode   StartupMode
+	Ledger string
+}
+
+func (c StartupConfig) validate() error {
+	switch c.Mode {
+	case StartupNormal, StartupFresh, StartupNetwork:
+		if c.Ledger != "" {
+			return fmt.Errorf("startup mode %d does not accept a ledger identifier", c.Mode)
+		}
+	case StartupLoad:
+	case StartupLoadFile:
+		if c.Ledger == "" {
+			return errors.New("ledger file path cannot be empty")
+		}
+	case StartupReplay:
+	default:
+		return fmt.Errorf("unknown startup mode %d", c.Mode)
+	}
+	return nil
+}
+
+type startupSelection struct {
+	ledger           *ledger.Ledger
+	replay           *inbound.ReplayDelta
+	loaded           bool
+	validate         bool
+	needsInitialSync bool
+}
+
+func (s *Service) selectStartup(ctx context.Context, initial *ledger.Ledger) (startupSelection, error) {
+	if err := s.config.Startup.validate(); err != nil {
+		return startupSelection{}, err
+	}
+
+	mode := s.config.Startup.Mode
+	switch mode {
+	case StartupNormal:
+		if !s.config.Standalone && s.config.FastLoad {
+			loaded, err := s.loadLatestLedger(ctx)
+			if err == nil && loaded != nil {
+				return startupSelection{ledger: loaded, loaded: true, validate: true}, nil
+			}
+			if err != nil {
+				s.logger.Warn("fast load failed; acquiring initial ledger from network", "err", err)
+			}
+		}
+		return startupSelection{
+			ledger:           initial,
+			validate:         s.config.Standalone,
+			needsInitialSync: !s.config.Standalone,
+		}, nil
+	case StartupFresh:
+		return startupSelection{ledger: initial, validate: s.config.Standalone}, nil
+	case StartupNetwork:
+		return startupSelection{
+			ledger:           initial,
+			validate:         s.config.Standalone,
+			needsInitialSync: !s.config.Standalone,
+		}, nil
+	}
+
+	selected, err := s.loadExplicitStartup(ctx)
+	if err == nil {
+		return selected, nil
+	}
+	if !s.config.FastLoad {
+		return startupSelection{}, err
+	}
+
+	s.logger.Warn("explicit startup load failed; acquiring initial ledger from network",
+		"mode", mode,
+		"ledger", s.config.Startup.Ledger,
+		"err", err,
+	)
+	return startupSelection{
+		ledger:           initial,
+		validate:         s.config.Standalone,
+		needsInitialSync: !s.config.Standalone,
+	}, nil
+}
+
+func (s *Service) loadExplicitStartup(ctx context.Context) (startupSelection, error) {
+	switch s.config.Startup.Mode {
+	case StartupLoad:
+		loaded, err := s.loadStartupLedger(ctx, s.config.Startup.Ledger)
+		if err != nil {
+			return startupSelection{}, fmt.Errorf("load startup ledger %q: %w", s.config.Startup.Ledger, err)
+		}
+		return startupSelection{ledger: loaded, loaded: true, validate: true}, nil
+	case StartupLoadFile:
+		loaded, err := s.loadLedgerFile(ctx, s.config.Startup.Ledger, time.Now())
+		if err != nil {
+			return startupSelection{}, fmt.Errorf("load startup ledger file %q: %w", s.config.Startup.Ledger, err)
+		}
+		if err := loaded.SetValidated(); err != nil {
+			return startupSelection{}, fmt.Errorf("validate startup ledger file: %w", err)
+		}
+		if err := s.persistValidatedLedger(ctx, loaded, true); err != nil {
+			return startupSelection{}, fmt.Errorf("persist startup ledger file: %w", err)
+		}
+		return startupSelection{ledger: loaded, loaded: true, validate: true}, nil
+	case StartupReplay:
+		target, err := s.loadStartupLedger(ctx, s.config.Startup.Ledger)
+		if err != nil {
+			return startupSelection{}, fmt.Errorf("load replay target %q: %w", s.config.Startup.Ledger, err)
+		}
+		parent, err := s.loadVerifiedStoredLedgerByHash(ctx, target.ParentHash())
+		if err != nil {
+			return startupSelection{}, fmt.Errorf("load replay parent %x: %w", target.ParentHash(), err)
+		}
+		replay, err := inbound.NewStoredLedgerReplay(parent, target, nil)
+		if err != nil {
+			return startupSelection{}, fmt.Errorf("prepare startup replay: %w", err)
+		}
+		return startupSelection{ledger: parent, replay: replay, loaded: true, validate: true}, nil
+	default:
+		return startupSelection{}, fmt.Errorf("startup mode %d is not an explicit load mode", s.config.Startup.Mode)
+	}
+}
+
+func (s *Service) loadStartupLedger(ctx context.Context, id string) (*ledger.Ledger, error) {
+	if id == "" || strings.EqualFold(id, "latest") {
+		if s.relationalDB == nil {
+			return nil, errors.New("relational database is required to load the latest ledger")
+		}
+		info, err := s.relationalDB.Ledger().GetNewestLedgerInfo(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return s.loadStartupLedgerInfo(ctx, info)
+	}
+
+	if len(id) == 64 {
+		raw, err := hex.DecodeString(id)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ledger hash: %w", err)
+		}
+		var hash [32]byte
+		copy(hash[:], raw)
+		return s.loadVerifiedStoredLedgerByHash(ctx, hash)
+	}
+
+	sequence, err := strconv.ParseUint(id, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ledger sequence %q: %w", id, err)
+	}
+	if s.relationalDB == nil {
+		return nil, errors.New("relational database is required to load a ledger by sequence")
+	}
+	info, err := s.relationalDB.Ledger().GetLedgerInfoBySeq(ctx, relationaldb.LedgerIndex(sequence))
+	if err != nil {
+		return nil, err
+	}
+	return s.loadStartupLedgerInfo(ctx, info)
+}
+
+func (s *Service) loadStartupLedgerInfo(ctx context.Context, info *relationaldb.LedgerInfo) (*ledger.Ledger, error) {
+	if info == nil {
+		return nil, ErrLedgerNotFound
+	}
+	loaded, err := s.loadVerifiedStoredLedgerByHash(ctx, [32]byte(info.Hash))
+	if err != nil {
+		return nil, err
+	}
+	if !storedHeaderMatchesInfo(loaded.Header(), info) {
+		return nil, fmt.Errorf("stored ledger %d does not match relational metadata", info.Sequence)
+	}
+	return loaded, nil
+}
+
+func (s *Service) loadVerifiedStoredLedgerByHash(ctx context.Context, hash [32]byte) (*ledger.Ledger, error) {
+	loaded, err := s.loadStoredLedgerByHash(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+	if loaded == nil {
+		return nil, ErrLedgerNotFound
+	}
+	h := loaded.Header()
+	if h.AccountHash == ([32]byte{}) {
+		return nil, errors.New("stored ledger has an empty state root")
+	}
+	if err := s.verifyStoredSHAMap(ctx, h.AccountHash, shamap.TypeState); err != nil {
+		return nil, fmt.Errorf("verify stored state tree: %w", err)
+	}
+	if h.TxHash != ([32]byte{}) {
+		if err := s.verifyStoredSHAMap(ctx, h.TxHash, shamap.TypeTransaction); err != nil {
+			return nil, fmt.Errorf("verify stored transaction tree: %w", err)
+		}
+	}
+	if err := loaded.SetValidated(); err != nil {
+		return nil, fmt.Errorf("mark stored ledger validated: %w", err)
+	}
+	return loaded, nil
+}
+
+func (s *Service) installLoadedStartupLocked(loaded, genesisLedger *ledger.Ledger) {
+	s.closedLedger = loaded
+	s.validatedLedger = loaded
+	s.validatedSignTime = loaded.CloseTime()
+	s.publishedLedgerSeq = loaded.Sequence()
+	s.havePublished = true
+	s.ledgerEventMu.Lock()
+	s.ledgerEventFrontierSeq = loaded.Sequence()
+	s.ledgerEventFrontierHash = loaded.Hash()
+	s.ledgerEventHaveFrontier = true
+	s.ledgerEventMu.Unlock()
+	s.completeMu.Lock()
+	s.completedLedgers.Add(loaded.Sequence())
+	s.completeLedgerHashes[loaded.Sequence()] = loaded.Hash()
+	s.completeMu.Unlock()
+	if loaded.Sequence() != genesisLedger.Sequence() {
+		s.deleteHistoryLocked(genesisLedger.Sequence())
+	}
+	s.putHistoryLocked(loaded)
+	s.collectTransactionResults(loaded, loaded.Sequence(), loaded.Hash())
+	s.needsInitialSync = false
+	loadedHash := loaded.Hash()
+	s.logger.Info("Loaded startup ledger", "sequence", loaded.Sequence(), "hash", fmt.Sprintf("%x", loadedHash[:8]))
+}
+
+func (s *Service) stageStartupReplayLocked() error {
+	if s.startupReplay == nil {
+		return nil
+	}
+	for _, replayTx := range s.startupReplay.OrderedTxs() {
+		if err := s.openLedger.AddTransaction(replayTx.Hash, replayTx.TxBytes); err != nil {
+			return fmt.Errorf("stage replay transaction %x: %w", replayTx.Hash[:8], err)
+		}
+		var insertErr error
+		if !s.openLedgerView.Modify(func(view *ledger.Ledger) bool {
+			insertErr = view.AddTransaction(replayTx.Hash, replayTx.TxBytes)
+			return insertErr == nil
+		}) {
+			if insertErr == nil {
+				insertErr = errors.New("open ledger view rejected replay transaction")
+			}
+			return fmt.Errorf("stage replay transaction %x in open view: %w", replayTx.Hash[:8], insertErr)
+		}
+	}
+	return nil
+}
+
+func (s *Service) applyStartupReplayLocked() (bool, error) {
+	if s.startupReplay == nil {
+		return false, nil
+	}
+	parent := s.startupReplay.Parent()
+	if parent == nil || s.closedLedger == nil ||
+		parent.Sequence() != s.closedLedger.Sequence() ||
+		parent.Hash() != s.closedLedger.Hash() {
+		s.logger.Warn("startup replay canceled after closed-ledger change")
+		s.startupReplay = nil
+		return false, nil
+	}
+	replayed, err := s.startupReplay.Apply(s.EngineConfigForReplay(s.closedLedger))
+	if err != nil {
+		return true, fmt.Errorf("apply startup replay: %w", err)
+	}
+	s.openLedger = replayed
+	return true, nil
+}

--- a/internal/ledger/service/startup.go
+++ b/internal/ledger/service/startup.go
@@ -73,13 +73,16 @@ func (s *Service) selectStartup(ctx context.Context, initial *ledger.Ledger) (st
 	mode := s.config.Startup.Mode
 	switch mode {
 	case StartupNormal:
-		if !s.config.Standalone && s.config.FastLoad {
+		if s.config.FastLoad {
 			loaded, err := s.loadLatestLedger(ctx)
 			if err == nil && loaded != nil {
 				return startupSelection{ledger: loaded, loaded: true, validate: true}, nil
 			}
 			if err != nil {
-				s.logger.Warn("fast load failed; acquiring initial ledger from network", "err", err)
+				s.logger.Warn("fast load failed; using initial ledger",
+					"network_acquisition", !s.config.Standalone,
+					"err", err,
+				)
 			}
 		}
 		return startupSelection{
@@ -105,9 +108,10 @@ func (s *Service) selectStartup(ctx context.Context, initial *ledger.Ledger) (st
 		return startupSelection{}, err
 	}
 
-	s.logger.Warn("explicit startup load failed; acquiring initial ledger from network",
+	s.logger.Warn("explicit startup load failed; using initial ledger",
 		"mode", mode,
 		"ledger", s.config.Startup.Ledger,
+		"network_acquisition", !s.config.Standalone,
 		"err", err,
 	)
 	return startupSelection{

--- a/internal/ledger/service/startup.go
+++ b/internal/ledger/service/startup.go
@@ -15,7 +15,6 @@ import (
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
 
-// StartupMode selects how the ledger service establishes its initial frontier.
 type StartupMode uint8
 
 const (
@@ -33,7 +32,6 @@ const (
 	StartupNetwork
 )
 
-// StartupConfig describes the explicitly selected startup mode and its operand.
 type StartupConfig struct {
 	Mode   StartupMode
 	Ledger string

--- a/internal/ledger/service/startup_test.go
+++ b/internal/ledger/service/startup_test.go
@@ -1,0 +1,357 @@
+package service
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/LeJamon/go-xrpl/shamap/backend"
+	"github.com/LeJamon/go-xrpl/storage/kvstore/memorydb"
+	"github.com/LeJamon/go-xrpl/storage/nodestore"
+	sqlitedb "github.com/LeJamon/go-xrpl/storage/relationaldb/sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_StartupFreshAndNetworkAreDistinct(t *testing.T) {
+	fresh, err := New(Config{
+		Standalone:    false,
+		Startup:       StartupConfig{Mode: StartupFresh},
+		GenesisConfig: genesis.DefaultConfig(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, fresh.Start())
+	t.Cleanup(fresh.Stop)
+	require.False(t, fresh.NeedsInitialSync())
+	require.Nil(t, fresh.GetValidatedLedger())
+	freshAmendments, err := fresh.GetClosedLedger().Read(keylet.Amendments())
+	require.NoError(t, err)
+	require.NotNil(t, freshAmendments)
+
+	network, err := New(Config{
+		Standalone:    false,
+		Startup:       StartupConfig{Mode: StartupNetwork},
+		GenesisConfig: genesis.DefaultConfig(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, network.Start())
+	t.Cleanup(network.Stop)
+	require.True(t, network.NeedsInitialSync())
+	require.Nil(t, network.GetValidatedLedger())
+	networkAmendments, err := network.GetClosedLedger().Read(keylet.Amendments())
+	require.NoError(t, err)
+	require.Nil(t, networkAmendments)
+}
+
+func TestService_ExplicitLoadFailureUsesConfiguredFastLoadFallback(t *testing.T) {
+	fatalLoad, err := New(Config{
+		Standalone:    false,
+		Startup:       StartupConfig{Mode: StartupLoad},
+		GenesisConfig: genesis.DefaultConfig(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(fatalLoad.Stop)
+	require.ErrorContains(t, fatalLoad.Start(), "relational database is required")
+
+	fallback, err := New(Config{
+		Standalone:    false,
+		Startup:       StartupConfig{Mode: StartupLoad},
+		GenesisConfig: genesis.DefaultConfig(),
+		FastLoad:      true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, fallback.Start())
+	t.Cleanup(fallback.Stop)
+	require.True(t, fallback.NeedsInitialSync())
+	require.Nil(t, fallback.GetValidatedLedger())
+	fallbackAmendments, err := fallback.GetClosedLedger().Read(keylet.Amendments())
+	require.NoError(t, err)
+	require.Nil(t, fallbackAmendments)
+}
+
+func TestService_StartupLoadIdentifiers(t *testing.T) {
+	ctx := context.Background()
+	db, rm := newStartupTestStorage(t, ctx)
+	target := persistStartupTarget(t, ctx, db, rm, false)
+	targetHash := target.Hash()
+
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{name: "latest"},
+		{name: "keyword", id: "LaTeSt"},
+		{name: "hash", id: fmt.Sprintf("%X", targetHash)},
+		{name: "sequence", id: fmt.Sprintf("%d", target.Sequence())},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			svc, err := New(Config{
+				Standalone:    true,
+				Startup:       StartupConfig{Mode: StartupLoad, Ledger: test.id},
+				GenesisConfig: genesis.DefaultConfig(),
+				NodeStore:     db,
+				SHAMapFamily:  backend.New(db),
+				RelationalDB:  rm,
+			})
+			require.NoError(t, err)
+			require.NoError(t, svc.Start())
+			t.Cleanup(svc.Stop)
+			require.Equal(t, targetHash, svc.GetClosedLedger().Hash())
+			require.Equal(t, targetHash, svc.GetValidatedLedger().Hash())
+			require.False(t, svc.NeedsInitialSync())
+		})
+	}
+}
+
+func TestService_StartupLedgerFilePersistsForSubsequentLoad(t *testing.T) {
+	ctx := context.Background()
+	db, rm := newStartupTestStorage(t, ctx)
+	path := filepath.Join(t.TempDir(), "ledger.json")
+	document := ledgerFileMarshal(t, map[string]any{
+		"ledger": map[string]any{
+			"accountState": []any{ledgerFileTestAccountRoot(ledgerFileTestIndex)},
+		},
+	})
+	require.NoError(t, os.WriteFile(path, []byte(document), 0o600))
+
+	importer, err := New(Config{
+		Standalone:    true,
+		Startup:       StartupConfig{Mode: StartupLoadFile, Ledger: path},
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  backend.New(db),
+		RelationalDB:  rm,
+	})
+	require.NoError(t, err)
+	require.NoError(t, importer.Start())
+	importedHash := importer.GetClosedLedger().Hash()
+	importer.Stop()
+
+	reader, err := New(Config{
+		Standalone:    true,
+		Startup:       StartupConfig{Mode: StartupLoad},
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  backend.New(db),
+		RelationalDB:  rm,
+	})
+	require.NoError(t, err)
+	require.NoError(t, reader.Start())
+	t.Cleanup(reader.Stop)
+	require.Equal(t, importedHash, reader.GetClosedLedger().Hash())
+}
+
+func TestService_StartupReplayStagesParentAndRebuildsTarget(t *testing.T) {
+	ctx := context.Background()
+	db, rm := newStartupTestStorage(t, ctx)
+	parent, target, txHash := persistStartupReplayChain(t, ctx, db, rm)
+	targetHash := target.Hash()
+	targetHeader := target.Header()
+
+	svc, err := New(Config{
+		Standalone:    true,
+		Startup:       StartupConfig{Mode: StartupReplay, Ledger: fmt.Sprintf("%X", targetHash)},
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  backend.New(db),
+		RelationalDB:  rm,
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	require.Equal(t, parent.Hash(), svc.GetClosedLedger().Hash())
+	openStateRoot, err := svc.GetOpenLedger().StateMapHash()
+	require.NoError(t, err)
+	require.Equal(t, parent.Header().AccountHash, openStateRoot)
+	hasTx, err := svc.GetOpenLedger().HasTransaction(txHash)
+	require.NoError(t, err)
+	require.True(t, hasTx)
+
+	seq, err := svc.AcceptLedgerAt(ctx, time.Unix(1, 0))
+	require.NoError(t, err)
+	require.Equal(t, target.Sequence(), seq)
+	replayed := svc.GetClosedLedger()
+	require.Equal(t, targetHash, replayed.Hash())
+	require.Equal(t, targetHeader.AccountHash, replayed.Header().AccountHash)
+	require.Equal(t, targetHeader.TxHash, replayed.Header().TxHash)
+	require.Equal(t, protocol.ToRippleTime(targetHeader.CloseTime), protocol.ToRippleTime(replayed.Header().CloseTime))
+	require.Equal(t, targetHeader.CloseTimeResolution, replayed.Header().CloseTimeResolution)
+	require.Equal(t, targetHeader.CloseFlags, replayed.Header().CloseFlags)
+}
+
+func TestService_StartupReplayOverridesFirstConsensusBuildOnly(t *testing.T) {
+	ctx := context.Background()
+	db, rm := newStartupTestStorage(t, ctx)
+	_, target, _ := persistStartupReplayChain(t, ctx, db, rm)
+	targetHash := target.Hash()
+	extraBlob, extraHash := startupPaymentBlob(t, "startup-replay-extra", 2)
+
+	svc, err := New(Config{
+		Standalone:    false,
+		Startup:       StartupConfig{Mode: StartupReplay, Ledger: fmt.Sprintf("%X", targetHash)},
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  backend.New(db),
+		RelationalDB:  rm,
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	parent := svc.GetClosedLedger()
+	seq, err := svc.AcceptConsensusResult(
+		ctx,
+		parent,
+		[][]byte{extraBlob},
+		nil,
+		time.Unix(1, 0),
+		false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, target.Sequence(), seq)
+	require.Equal(t, targetHash, svc.GetClosedLedger().Hash())
+	require.True(t, svc.OpenLedgerHasTx(extraHash))
+
+	parent = svc.GetClosedLedger()
+	seq, err = svc.AcceptConsensusResult(ctx, parent, nil, nil, target.CloseTime().Add(time.Minute), true)
+	require.NoError(t, err)
+	require.Equal(t, target.Sequence()+1, seq)
+	require.NotEqual(t, targetHash, svc.GetClosedLedger().Hash())
+}
+
+func TestService_StartupReplayCancelsAfterPreferredLedgerSwitch(t *testing.T) {
+	ctx := context.Background()
+	db, rm := newStartupTestStorage(t, ctx)
+	_, target, _ := persistStartupReplayChain(t, ctx, db, rm)
+	targetHash := target.Hash()
+
+	svc, err := New(Config{
+		Standalone:    false,
+		Startup:       StartupConfig{Mode: StartupReplay, Ledger: fmt.Sprintf("%X", targetHash)},
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  backend.New(db),
+		RelationalDB:  rm,
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	require.NoError(t, svc.SwitchToPreferredLedger(target))
+	seq, err := svc.AcceptConsensusResult(
+		ctx,
+		target,
+		nil,
+		nil,
+		target.CloseTime().Add(time.Minute),
+		true,
+	)
+	require.NoError(t, err)
+	require.Equal(t, target.Sequence()+1, seq)
+	require.NotEqual(t, targetHash, svc.GetClosedLedger().Hash())
+}
+
+func newStartupTestStorage(t *testing.T, ctx context.Context) (nodestore.Database, *sqlitedb.RepositoryManager) {
+	t.Helper()
+	db := nodestore.NewKVDatabase(memorydb.New(), "startup-test", 10_000, time.Hour)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	rm, err := sqlitedb.NewRepositoryManager(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, rm.Open(ctx))
+	t.Cleanup(func() { require.NoError(t, rm.Close(ctx)) })
+	return db, rm
+}
+
+func persistStartupTarget(
+	t *testing.T,
+	ctx context.Context,
+	db nodestore.Database,
+	rm *sqlitedb.RepositoryManager,
+	withTransaction bool,
+) *ledger.Ledger {
+	t.Helper()
+	if withTransaction {
+		_, target, _ := persistStartupReplayChain(t, ctx, db, rm)
+		return target
+	}
+	writer, err := New(Config{
+		Standalone:    true,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  backend.New(db),
+		RelationalDB:  rm,
+	})
+	require.NoError(t, err)
+	require.NoError(t, writer.Start())
+	_, err = writer.AcceptLedger(ctx)
+	require.NoError(t, err)
+	writer.FlushPersists()
+	target := writer.GetValidatedLedger()
+	writer.Stop()
+	return target
+}
+
+func persistStartupReplayChain(
+	t *testing.T,
+	ctx context.Context,
+	db nodestore.Database,
+	rm *sqlitedb.RepositoryManager,
+) (*ledger.Ledger, *ledger.Ledger, [32]byte) {
+	t.Helper()
+	writer, err := New(Config{
+		Standalone:    true,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  backend.New(db),
+		RelationalDB:  rm,
+	})
+	require.NoError(t, err)
+	require.NoError(t, writer.Start())
+	parent := writer.GetClosedLedger()
+	require.NoError(t, writer.persistValidatedLedger(ctx, parent, false))
+
+	blob, txHash := startupPaymentBlob(t, "startup-replay-destination", 1)
+	parsed, err := tx.ParseFromBinary(blob)
+	require.NoError(t, err)
+	result, err := writer.SubmitTransaction(parsed, blob, false)
+	require.NoError(t, err)
+	require.True(t, result.Applied)
+	_, err = writer.AcceptLedger(ctx)
+	require.NoError(t, err)
+	writer.FlushPersists()
+	target := writer.GetValidatedLedger()
+	writer.Stop()
+	return parent, target, txHash
+}
+
+func startupPaymentBlob(t *testing.T, destinationName string, sequence uint32) ([]byte, [32]byte) {
+	t.Helper()
+	env := jtx.NewTestEnv(t)
+	env.SetVerifySignatures(true)
+	master := jtx.MasterAccount()
+	destination := jtx.NewAccount(destinationName)
+	transaction := payment.Pay(master, destination, 1_000_000).Sequence(sequence).Build()
+	env.SignWith(transaction, master)
+	txJSON, err := transaction.Flatten()
+	require.NoError(t, err)
+	blobHex, err := binarycodec.Encode(txJSON)
+	require.NoError(t, err)
+	blob, err := hex.DecodeString(blobHex)
+	require.NoError(t, err)
+	txHash, err := tx.ComputeTransactionHash(transaction)
+	require.NoError(t, err)
+	return blob, txHash
+}

--- a/internal/ledger/service/startup_test.go
+++ b/internal/ledger/service/startup_test.go
@@ -9,12 +9,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap/backend"
@@ -25,10 +28,15 @@ import (
 )
 
 func TestService_StartupFreshAndNetworkAreDistinct(t *testing.T) {
+	table := amendment.NewTable()
+	table.Veto(amendment.DefaultYesFeatures()[0].ID)
+	table.UpVote(amendment.FeatureAMM)
+
 	fresh, err := New(Config{
 		Standalone:    false,
 		Startup:       StartupConfig{Mode: StartupFresh},
 		GenesisConfig: genesis.DefaultConfig(),
+		Table:         table,
 	})
 	require.NoError(t, err)
 	require.NoError(t, fresh.Start())
@@ -38,6 +46,9 @@ func TestService_StartupFreshAndNetworkAreDistinct(t *testing.T) {
 	freshAmendments, err := fresh.GetClosedLedger().Read(keylet.Amendments())
 	require.NoError(t, err)
 	require.NotNil(t, freshAmendments)
+	freshAmendmentSLE, err := pseudo.ParseAmendmentsSLE(freshAmendments)
+	require.NoError(t, err)
+	require.ElementsMatch(t, table.Desired(), freshAmendmentSLE.Amendments)
 
 	network, err := New(Config{
 		Standalone:    false,
@@ -52,6 +63,21 @@ func TestService_StartupFreshAndNetworkAreDistinct(t *testing.T) {
 	networkAmendments, err := network.GetClosedLedger().Read(keylet.Amendments())
 	require.NoError(t, err)
 	require.Nil(t, networkAmendments)
+}
+
+func TestService_StartupNormalUsesEmptyInitialAmendments(t *testing.T) {
+	svc, err := New(Config{
+		Standalone:    true,
+		Startup:       StartupConfig{Mode: StartupNormal},
+		GenesisConfig: genesis.DefaultConfig(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	data, err := svc.GetClosedLedger().Read(keylet.Amendments())
+	require.NoError(t, err)
+	require.Nil(t, data)
 }
 
 func TestService_ExplicitLoadFailureUsesConfiguredFastLoadFallback(t *testing.T) {
@@ -113,6 +139,68 @@ func TestService_StartupLoadIdentifiers(t *testing.T) {
 			require.False(t, svc.NeedsInitialSync())
 		})
 	}
+}
+
+func TestService_StartupLoadSynchronizesAmendmentTable(t *testing.T) {
+	ctx := context.Background()
+	db, rm := newStartupTestStorage(t, ctx)
+	unknown := amendment.FeatureID("startup-test-unsupported-amendment")
+	genesisConfig := genesis.DefaultConfig()
+	genesisConfig.Amendments = append(genesisConfig.Amendments, unknown)
+	target := persistStartupTargetWithGenesis(t, ctx, db, rm, genesisConfig)
+
+	table := amendment.NewTable()
+	svc, err := New(Config{
+		Standalone:    true,
+		Startup:       StartupConfig{Mode: StartupLoad, Ledger: fmt.Sprintf("%X", target.Hash())},
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  backend.New(db),
+		RelationalDB:  rm,
+		Table:         table,
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	require.True(t, table.IsEnabled(unknown))
+	require.True(t, svc.IsAmendmentBlocked())
+	require.False(t, table.NeedValidatedLedger(target.Sequence()))
+}
+
+func TestService_StartupLoadRejectsLedgerWithoutSuccessor(t *testing.T) {
+	ctx := context.Background()
+	db, rm := newStartupTestStorage(t, ctx)
+	source := persistStartupTarget(t, ctx, db, rm, false)
+	stateMap, err := source.StateMapSnapshot()
+	require.NoError(t, err)
+	txMap, err := source.TxMapSnapshot()
+	require.NoError(t, err)
+	hdr := source.Header()
+	hdr.LedgerIndex = ^uint32(0)
+	hdr.Hash = header.CalculateHash(hdr)
+	maxLedger, err := ledger.NewFromHeader(hdr, stateMap, txMap, source.GetFees())
+	require.NoError(t, err)
+
+	persister, err := New(Config{
+		NodeStore:    db,
+		SHAMapFamily: backend.New(db),
+		RelationalDB: rm,
+	})
+	require.NoError(t, err)
+	require.NoError(t, persister.persistValidatedLedger(ctx, maxLedger, false))
+
+	svc, err := New(Config{
+		Standalone:    true,
+		Startup:       StartupConfig{Mode: StartupLoad, Ledger: fmt.Sprintf("%X", maxLedger.Hash())},
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  backend.New(db),
+		RelationalDB:  rm,
+	})
+	require.NoError(t, err)
+	t.Cleanup(svc.Stop)
+	require.ErrorContains(t, svc.Start(), "has no successor")
 }
 
 func TestService_StartupLedgerFilePersistsForSubsequentLoad(t *testing.T) {
@@ -287,9 +375,21 @@ func persistStartupTarget(
 		_, target, _ := persistStartupReplayChain(t, ctx, db, rm)
 		return target
 	}
+	return persistStartupTargetWithGenesis(t, ctx, db, rm, genesis.DefaultConfig())
+}
+
+func persistStartupTargetWithGenesis(
+	t *testing.T,
+	ctx context.Context,
+	db nodestore.Database,
+	rm *sqlitedb.RepositoryManager,
+	genesisConfig genesis.Config,
+) *ledger.Ledger {
+	t.Helper()
 	writer, err := New(Config{
 		Standalone:    true,
-		GenesisConfig: genesis.DefaultConfig(),
+		Startup:       StartupConfig{Mode: StartupFresh},
+		GenesisConfig: genesisConfig,
 		NodeStore:     db,
 		SHAMapFamily:  backend.New(db),
 		RelationalDB:  rm,

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -133,7 +133,7 @@ func isFullGitHash(value string) bool {
 // Run assembles and starts every node subsystem from the parsed config, then
 // blocks until a terminating signal or fatal error. It is the composition root
 // extracted from the CLI so flag parsing and node wiring stay separable.
-func Run(appConfig *config.Config, configPath string, standalone bool, rootLogger, serverLog xrpllog.Logger) error {
+func Run(appConfig *config.Config, configPath string, standalone bool, startup service.StartupConfig, rootLogger, serverLog xrpllog.Logger) error {
 	if err := validateTrustedValidatorConfig(appConfig, standalone); err != nil {
 		return err
 	}
@@ -241,6 +241,7 @@ func Run(appConfig *config.Config, configPath string, standalone bool, rootLogge
 		Logger:       rootLogger,
 		Table:        amendmentTable,
 		TxQ:          &txqCfg,
+		Startup:      startup,
 	}
 	cfg.GenesisConfig = genesisConfig
 	configuredFees := configuredLedgerLoadFees(appConfig)


### PR DESCRIPTION
## Summary

- add explicit fresh, latest-local, selected-ledger, ledger-file, replay, and
  network startup modes with strict CLI validation
- load durable ledgers and expanded ledger JSON with rippled-compatible
  validation, persistence, and `fast_load` fallback behavior
- deterministically replay a stored child ledger on its parent while preserving
  retriable transactions across standalone and consensus closes
- document startup recovery modes, accepted identifiers, and the distinction
  between startup replay and `ledger_replay`

## Verification

- `go test -count=1 -timeout 15m ./...`
- focused race tests for CLI, node, ledger service, and inbound replay packages
- CI core race-test package grouping
- `just vet`
- `just build`
- `just build-nocgo`
- golangci-lint v2.11.3 with the repository configuration
- behavioral audit against the pinned local rippled v3.2.0 oracle

Fixes #1433
