### PR TITLE
fix: retarget stale missing-node requests

### DIFF
--- a/internal/consensus/adaptor/acquisition_disconnect_test.go
+++ b/internal/consensus/adaptor/acquisition_disconnect_test.go
@@ -1,0 +1,420 @@
+package adaptor
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
+	"github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type missingNodeTarget struct {
+	peerID      uint64
+	transaction bool
+}
+
+type missingNodeSendCall struct {
+	missingNodeTarget
+	nodeIDs    [][]byte
+	queryDepth uint32
+}
+
+type missingNodeChurnSender struct {
+	noopSender
+	mu           sync.Mutex
+	errs         map[missingNodeTarget]error
+	replacements []uint64
+	calls        []missingNodeSendCall
+}
+
+func (s *missingNodeChurnSender) RequestStateNodes(
+	peerID uint64,
+	_ [32]byte,
+	nodeIDs [][]byte,
+	queryDepth uint32,
+	_ bool,
+) error {
+	return s.record(peerID, false, nodeIDs, queryDepth)
+}
+
+func (s *missingNodeChurnSender) RequestTransactionNodes(
+	peerID uint64,
+	_ [32]byte,
+	nodeIDs [][]byte,
+	queryDepth uint32,
+	_ bool,
+) error {
+	return s.record(peerID, true, nodeIDs, queryDepth)
+}
+
+func (s *missingNodeChurnSender) record(
+	peerID uint64,
+	transaction bool,
+	nodeIDs [][]byte,
+	queryDepth uint32,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	target := missingNodeTarget{peerID: peerID, transaction: transaction}
+	s.calls = append(s.calls, missingNodeSendCall{
+		missingNodeTarget: target,
+		nodeIDs:           append([][]byte(nil), nodeIDs...),
+		queryDepth:        queryDepth,
+	})
+	return s.errs[target]
+}
+
+func (s *missingNodeChurnSender) SelectLedgerPeers(
+	_ [32]byte,
+	_ uint32,
+	excluded []uint64,
+	maxPeers int,
+) []uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	skip := make(map[uint64]struct{}, len(excluded))
+	for _, peerID := range excluded {
+		skip[peerID] = struct{}{}
+	}
+	selected := make([]uint64, 0, maxPeers)
+	for _, peerID := range s.replacements {
+		if _, excluded := skip[peerID]; excluded {
+			continue
+		}
+		selected = append(selected, peerID)
+		if len(selected) == maxPeers {
+			break
+		}
+	}
+	return selected
+}
+
+func (s *missingNodeChurnSender) snapshotCalls() []missingNodeSendCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]missingNodeSendCall(nil), s.calls...)
+}
+
+func newMissingNodeChurnRouter(t *testing.T, sender *missingNodeChurnSender) *Router {
+	t.Helper()
+	adaptor := newTestAdaptor(t)
+	adaptor.sender = sender
+	return NewRouter(nil, adaptor, nil)
+}
+
+func newDisconnectFrontier(
+	t *testing.T,
+	transaction bool,
+) (*inbound.Ledger, []message.LedgerNode) {
+	t.Helper()
+	mapType := shamap.TypeState
+	if transaction {
+		mapType = shamap.TypeTransaction
+	}
+	source := shamap.New(mapType)
+	for i, prefix := range []byte{0x10, 0xE0} {
+		var key [32]byte
+		key[0] = prefix
+		key[31] = byte(i + 1)
+		data := make([]byte, 12)
+		data[0] = byte(i + 1)
+		data[1] = 0xA5
+		require.NoError(t, source.Put(key, data))
+	}
+	rootHash, err := source.Hash()
+	require.NoError(t, err)
+	rootData, err := source.SerializeRoot()
+	require.NoError(t, err)
+	ledgerHeader := header.LedgerHeader{LedgerIndex: 200}
+	baseNodes := []message.LedgerNode{{}}
+	var stateReplies []message.LedgerNode
+	if transaction {
+		state := shamap.New(shamap.TypeState)
+		for i, prefix := range []byte{0x20, 0xD0} {
+			var stateKey [32]byte
+			stateKey[0] = prefix
+			stateKey[31] = byte(i + 1)
+			require.NoError(t, state.Put(stateKey, make([]byte, 12)))
+		}
+		stateHash, err := state.Hash()
+		require.NoError(t, err)
+		stateRoot, err := state.SerializeRoot()
+		require.NoError(t, err)
+		stateWire, err := state.WalkWireNodes()
+		require.NoError(t, err)
+		for _, node := range stateWire {
+			if node.NodeID[32] > 0 {
+				stateReplies = append(stateReplies, message.LedgerNode{
+					NodeID: node.NodeID, NodeData: node.Data,
+				})
+			}
+		}
+		ledgerHeader.AccountHash = stateHash
+		ledgerHeader.TxHash = rootHash
+		baseNodes = append(baseNodes,
+			message.LedgerNode{NodeData: stateRoot},
+			message.LedgerNode{NodeData: rootData},
+		)
+	} else {
+		ledgerHeader.AccountHash = rootHash
+		baseNodes = append(baseNodes, message.LedgerNode{NodeData: rootData})
+	}
+	headerData := header.AddRaw(ledgerHeader, false)
+	ledgerHash := sha512half.Sum(protocol.HashPrefixLedgerMaster().Bytes(), headerData)
+	ledger := inbound.New(ledgerHash, ledgerHeader.LedgerIndex, 1, serveTestLogger())
+	baseNodes[0].NodeData = headerData
+	require.NoError(t, ledger.GotBase(baseNodes))
+	require.Equal(t, inbound.StateWantState, ledger.State())
+	if transaction {
+		require.NoError(t, ledger.GotStateNodes(stateReplies))
+		_, _, complete, err := ledger.CollectMissingRequestContext(t.Context(), false)
+		require.NoError(t, err)
+		require.False(t, complete)
+	}
+
+	wire, err := source.WalkWireNodes()
+	require.NoError(t, err)
+	replies := make([]message.LedgerNode, 0, len(wire)-1)
+	for _, node := range wire {
+		if node.NodeID[32] == 0 {
+			continue
+		}
+		replies = append(replies, message.LedgerNode{NodeID: node.NodeID, NodeData: node.Data})
+	}
+	require.NotEmpty(t, replies)
+	return ledger, replies
+}
+
+func TestAcquisitionWorkResult_RecoversStaleTimerTargets(t *testing.T) {
+	t.Run("all stale retargets exact batch", func(t *testing.T) {
+		sender := &missingNodeChurnSender{
+			errs: map[missingNodeTarget]error{
+				{peerID: 1}: peermanagement.ErrPeerNotFound,
+			},
+			replacements: []uint64{2},
+		}
+		router := newMissingNodeChurnRouter(t, sender)
+		ledger, _ := newDisconnectFrontier(t, false)
+		router.fetchTracker.Track(ledger)
+		trackCatchupPeer(router, 1, ledger.Seq())
+		stateIDs, _, complete, err := ledger.CollectMissingRequestContext(t.Context(), false)
+		require.NoError(t, err)
+		require.False(t, complete)
+		require.NotEmpty(t, stateIDs)
+
+		router.handleAcquisitionWorkResult(acquisitionWorkResult{
+			ledger:   ledger,
+			targets:  []uint64{1},
+			stateIDs: stateIDs,
+		})
+
+		calls := sender.snapshotCalls()
+		require.Len(t, calls, 2)
+		assert.Equal(t, []uint64{1, 2}, []uint64{calls[0].peerID, calls[1].peerID})
+		assert.Equal(t, calls[0].nodeIDs, calls[1].nodeIDs)
+		assert.NotContains(t, ledger.Peers(), uint64(1))
+		assert.Contains(t, ledger.Peers(), uint64(2))
+		router.peersMu.RLock()
+		_, stale := router.peerStates[1]
+		router.peersMu.RUnlock()
+		assert.False(t, stale)
+	})
+
+	t.Run("mixed fanout keeps live delivery", func(t *testing.T) {
+		sender := &missingNodeChurnSender{
+			errs: map[missingNodeTarget]error{
+				{peerID: 1}: peermanagement.ErrConnectionClosed,
+			},
+		}
+		router := newMissingNodeChurnRouter(t, sender)
+		ledger, _ := newDisconnectFrontier(t, false)
+		require.True(t, ledger.AddPeer(2))
+		router.fetchTracker.Track(ledger)
+		stateIDs, _, complete, err := ledger.CollectMissingRequestContext(t.Context(), false)
+		require.NoError(t, err)
+		require.False(t, complete)
+
+		router.handleAcquisitionWorkResult(acquisitionWorkResult{
+			ledger:   ledger,
+			targets:  []uint64{1, 2},
+			stateIDs: stateIDs,
+		})
+
+		calls := sender.snapshotCalls()
+		require.Len(t, calls, 2)
+		assert.Equal(t, []uint64{1, 2}, []uint64{calls[0].peerID, calls[1].peerID})
+		assert.Equal(t, calls[0].nodeIDs, calls[1].nodeIDs)
+		assert.NotContains(t, ledger.Peers(), uint64(1))
+		assert.Contains(t, ledger.Peers(), uint64(2))
+	})
+}
+
+func TestMissingReplyRequest_DisconnectErrorsReleaseAndRetarget(t *testing.T) {
+	tests := []struct {
+		name        string
+		transaction bool
+		err         error
+	}{
+		{name: "state peer not found", err: peermanagement.ErrPeerNotFound},
+		{name: "transaction connection closed", transaction: true, err: peermanagement.ErrConnectionClosed},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			target := missingNodeTarget{peerID: 1, transaction: tc.transaction}
+			sender := &missingNodeChurnSender{
+				errs:         map[missingNodeTarget]error{target: tc.err},
+				replacements: []uint64{2},
+			}
+			router := newMissingNodeChurnRouter(t, sender)
+			ledger, _ := newDisconnectFrontier(t, tc.transaction)
+			router.fetchTracker.Track(ledger)
+			trackCatchupPeer(router, 1, ledger.Seq())
+			requests, complete, err := ledger.CollectMissingReplyRequestsContext(t.Context(), []uint64{1})
+			require.NoError(t, err)
+			require.False(t, complete)
+			require.Len(t, requests, 1)
+			require.Equal(t, tc.transaction, requests[0].Transaction)
+
+			router.handleAcquisitionWorkResult(acquisitionWorkResult{
+				ledger:   ledger,
+				requests: requests,
+			})
+
+			calls := sender.snapshotCalls()
+			require.Len(t, calls, 2)
+			assert.Equal(t, []uint64{1, 2}, []uint64{calls[0].peerID, calls[1].peerID})
+			assert.Equal(t, tc.transaction, calls[1].transaction)
+			assert.Equal(t, calls[0].nodeIDs, calls[1].nodeIDs)
+			assert.Equal(t, uint32(1), calls[1].queryDepth)
+			assert.NotContains(t, ledger.Peers(), uint64(1))
+			assert.Contains(t, ledger.Peers(), uint64(2))
+			assert.Equal(t, 1, ledger.Snapshot().RequestPeers)
+		})
+	}
+}
+
+func TestRequestMissingAcquisitionNodes_MixedStaleLiveFanout(t *testing.T) {
+	sender := &missingNodeChurnSender{
+		errs: map[missingNodeTarget]error{
+			{peerID: 1}: peermanagement.ErrPeerNotFound,
+		},
+	}
+	router := newMissingNodeChurnRouter(t, sender)
+	ledger, _ := newDisconnectFrontier(t, false)
+	require.True(t, ledger.AddPeer(2))
+	router.fetchTracker.Track(ledger)
+
+	router.requestMissingAcquisitionNodes(ledger, 0)
+
+	calls := sender.snapshotCalls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, []uint64{1, 2}, []uint64{calls[0].peerID, calls[1].peerID})
+	assert.NotContains(t, ledger.Peers(), uint64(1))
+	assert.Contains(t, ledger.Peers(), uint64(2))
+}
+
+func TestMissingNodeRecovery_ChurnIsBoundedAndCompletes(t *testing.T) {
+	sender := &missingNodeChurnSender{
+		errs: map[missingNodeTarget]error{
+			{peerID: 1}: peermanagement.ErrPeerNotFound,
+			{peerID: 2}: peermanagement.ErrConnectionClosed,
+		},
+		replacements: []uint64{2},
+	}
+	router := newMissingNodeChurnRouter(t, sender)
+	ledger, replies := newDisconnectFrontier(t, false)
+	router.fetchTracker.Track(ledger)
+	stateIDs, _, complete, err := ledger.CollectMissingRequestContext(t.Context(), false)
+	require.NoError(t, err)
+	require.False(t, complete)
+
+	router.handleAcquisitionWorkResult(acquisitionWorkResult{
+		ledger:   ledger,
+		targets:  []uint64{1},
+		stateIDs: stateIDs,
+	})
+
+	calls := sender.snapshotCalls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, []uint64{1, 2}, []uint64{calls[0].peerID, calls[1].peerID})
+	assert.Empty(t, ledger.Peers())
+	assert.Len(t, sender.snapshotCalls(), 2)
+
+	router.handlePeerConnect(3)
+
+	calls = sender.snapshotCalls()
+	require.Len(t, calls, 3)
+	assert.Equal(t, uint64(3), calls[2].peerID)
+	assert.Equal(t, calls[0].nodeIDs, calls[2].nodeIDs)
+	require.NoError(t, ledger.GotStateNodes(replies))
+	_, _, complete, err = ledger.CollectMissingRequestContext(t.Context(), false)
+	require.NoError(t, err)
+	assert.True(t, complete)
+	assert.True(t, ledger.IsComplete())
+}
+
+func TestMissingNodeRecovery_LatePeerAfterNoReplacement(t *testing.T) {
+	sender := &missingNodeChurnSender{
+		errs: map[missingNodeTarget]error{
+			{peerID: 1}: peermanagement.ErrPeerNotFound,
+		},
+	}
+	router := newMissingNodeChurnRouter(t, sender)
+	ledger, _ := newDisconnectFrontier(t, false)
+	router.fetchTracker.Track(ledger)
+	stateIDs, _, complete, err := ledger.CollectMissingRequestContext(t.Context(), false)
+	require.NoError(t, err)
+	require.False(t, complete)
+
+	router.handleAcquisitionWorkResult(acquisitionWorkResult{
+		ledger:   ledger,
+		targets:  []uint64{1},
+		stateIDs: stateIDs,
+	})
+
+	calls := sender.snapshotCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, uint64(1), calls[0].peerID)
+
+	router.handlePeerConnect(2)
+
+	calls = sender.snapshotCalls()
+	require.Len(t, calls, 2)
+	assert.Equal(t, uint64(2), calls[1].peerID)
+	assert.Equal(t, calls[0].nodeIDs, calls[1].nodeIDs)
+}
+
+func TestMissingReplyRequest_NonDisconnectErrorDoesNotEvictOrRetarget(t *testing.T) {
+	sendErr := errors.New("temporary queue failure")
+	sender := &missingNodeChurnSender{
+		errs: map[missingNodeTarget]error{
+			{peerID: 1}: sendErr,
+		},
+		replacements: []uint64{2},
+	}
+	router := newMissingNodeChurnRouter(t, sender)
+	ledger, _ := newDisconnectFrontier(t, false)
+	router.fetchTracker.Track(ledger)
+	requests, complete, err := ledger.CollectMissingReplyRequestsContext(t.Context(), []uint64{1})
+	require.NoError(t, err)
+	require.False(t, complete)
+	require.Len(t, requests, 1)
+
+	router.handleAcquisitionWorkResult(acquisitionWorkResult{
+		ledger:   ledger,
+		requests: requests,
+	})
+
+	assert.Len(t, sender.snapshotCalls(), 1)
+	assert.Contains(t, ledger.Peers(), uint64(1))
+	assert.NotContains(t, ledger.Peers(), uint64(2))
+	assert.Zero(t, ledger.Snapshot().RequestPeers)
+}

--- a/internal/consensus/adaptor/acquisition_work.go
+++ b/internal/consensus/adaptor/acquisition_work.go
@@ -38,19 +38,24 @@ const (
 	acquisitionWorkLocal
 	acquisitionWorkFailure
 	acquisitionWorkAdded
+	acquisitionWorkRetarget
 )
 
 type acquisitionWorkEvent struct {
-	kind   acquisitionWorkKind
-	data   *message.LedgerData
-	peerID uint64
-	resume bool
-	useful int
-	fetch  func([32]byte) ([]byte, bool)
-	after  func()
-	peers  []uint64
-	added  []uint64
-	at     time.Time
+	kind       acquisitionWorkKind
+	data       *message.LedgerData
+	peerID     uint64
+	resume     bool
+	useful     int
+	fetch      func([32]byte) ([]byte, bool)
+	after      func()
+	peers      []uint64
+	added      []uint64
+	stateIDs   [][]byte
+	txIDs      [][]byte
+	queryDepth uint32
+	collect    bool
+	at         time.Time
 }
 
 type acquisitionWorkBatch struct {
@@ -78,6 +83,8 @@ type acquisitionWorkResult struct {
 	timerAt        time.Time
 	rearmTimer     bool
 	retryBase      bool
+	retarget       bool
+	queryDepth     uint32
 	complete       bool
 	snapshot       inbound.Snapshot
 	haveSnapshot   bool
@@ -397,6 +404,7 @@ func processAcquisitionWorkWithBudget(ctx context.Context, ledger *inbound.Ledge
 	}
 	usefulByPeer := make(map[uint64]int)
 	var addedPeers []uint64
+	var retargetPeers []uint64
 	var runLocal, runTimerCheck, runTimer, runFailure bool
 	var timerAt time.Time
 	var fetch func([32]byte) ([]byte, bool)
@@ -508,6 +516,18 @@ func processAcquisitionWorkWithBudget(ctx context.Context, ledger *inbound.Ledge
 		case acquisitionWorkFailure:
 		case acquisitionWorkAdded:
 			addedPeers = append(addedPeers, event.peerID)
+		case acquisitionWorkRetarget:
+			result.retarget = true
+			if len(result.stateIDs) == 0 && len(result.txIDs) == 0 &&
+				len(event.peers) > 0 && (len(event.stateIDs) > 0 || len(event.txIDs) > 0) {
+				result.targets = append(result.targets[:0], event.peers[0])
+				result.stateIDs = event.stateIDs
+				result.txIDs = event.txIDs
+				result.queryDepth = event.queryDepth
+			}
+			if event.collect {
+				retargetPeers = append(retargetPeers, event.peers...)
+			}
 		}
 	}
 
@@ -559,6 +579,22 @@ func processAcquisitionWorkWithBudget(ctx context.Context, ledger *inbound.Ledge
 		peers := acquisitionRequestCandidates(preferred, ledger.Peers())
 		result.requests, result.complete, result.err = ledger.CollectMissingReplyRequestsContext(workCtx, peers)
 		if result.err != nil || result.complete {
+			return result
+		}
+	}
+	if len(retargetPeers) > 0 {
+		requests, complete, err := ledger.CollectMissingReplyRequestsContext(workCtx, retargetPeers)
+		if err != nil {
+			for _, request := range result.requests {
+				ledger.ReleaseMissingRequest(request.PeerID, request.NodeHashes)
+			}
+			result.requests = nil
+			result.err = err
+			return result
+		}
+		result.requests = append(result.requests, requests...)
+		if complete {
+			result.complete = true
 			return result
 		}
 	}
@@ -722,11 +758,21 @@ func (r *Router) handleAcquisitionWorkResult(result acquisitionWorkResult) {
 			"useful", reply.useful,
 		)
 	}
+	retry := missingNodeRetry{queryDepth: result.queryDepth}
 	if len(result.stateIDs) > 0 || len(result.txIDs) > 0 {
-		r.sendMissingAcquisitionNodes(ledger, result.targets, result.stateIDs, result.txIDs)
+		retry = r.sendMissingAcquisitionNodes(
+			ledger,
+			result.targets,
+			result.stateIDs,
+			result.txIDs,
+			result.queryDepth,
+		)
 	}
+	released := 0
 	for _, request := range result.requests {
-		r.sendMissingReplyRequest(ledger, request)
+		if r.sendMissingReplyRequest(ledger, request) {
+			released++
+		}
 	}
 	if len(result.requests) > 0 {
 		var stateNodes, txNodes int
@@ -746,6 +792,11 @@ func (r *Router) handleAcquisitionWorkResult(result acquisitionWorkResult) {
 			"tx_nodes", txNodes,
 		)
 	}
+	if result.retarget && (len(retry.stateIDs) > 0 || len(retry.txIDs) > 0) {
+		ledger.ReleaseUnreservedMissingNodes()
+	} else if !result.retarget {
+		r.retryMissingAcquisitionNodes(ledger, retry, released)
+	}
 	if len(result.byHashState) > 0 || len(result.byHashTx) > 0 {
 		peers := ledger.Peers()
 		r.sendNodesByHash(peers, ledger.Hash(), ledger.Seq(), result.byHashState, message.ObjectTypeStateNode)
@@ -753,7 +804,7 @@ func (r *Router) handleAcquisitionWorkResult(result acquisitionWorkResult) {
 	}
 }
 
-func (r *Router) sendMissingReplyRequest(ledger *inbound.Ledger, request inbound.MissingRequest) {
+func (r *Router) sendMissingReplyRequest(ledger *inbound.Ledger, request inbound.MissingRequest) bool {
 	indirect := ledger.Timeouts() > 0
 	queryDepth := uint32(1)
 	if request.Blind {
@@ -768,27 +819,58 @@ func (r *Router) sendMissingReplyRequest(ledger *inbound.Ledger, request inbound
 		err = r.adaptor.RequestStateNodes(request.PeerID, ledger.Hash(), request.NodeIDs, queryDepth, indirect)
 	}
 	if err == nil {
-		return
+		return false
 	}
 	ledger.ReleaseMissingRequest(request.PeerID, request.NodeHashes)
-	r.logger.Warn("inbound ledger: failed to request missing nodes", "peer", request.PeerID, "transaction", request.Transaction, "error", err)
+	return r.handleMissingNodeSendFailure(ledger, request.PeerID, request.Transaction, err)
 }
 
-func (r *Router) sendMissingAcquisitionNodes(ledger *inbound.Ledger, peers []uint64, stateIDs, txIDs [][]byte) {
+type missingNodeRetry struct {
+	stateIDs   [][]byte
+	txIDs      [][]byte
+	queryDepth uint32
+}
+
+func (r *Router) sendMissingAcquisitionNodes(
+	ledger *inbound.Ledger,
+	peers []uint64,
+	stateIDs, txIDs [][]byte,
+	queryDepth uint32,
+) missingNodeRetry {
 	indirect := ledger.Timeouts() > 0
-	queryDepth := uint32(0)
+	var stateSent, stateDisconnected bool
+	var txSent, txDisconnected bool
 	for _, peerID := range peers {
+		disconnected := false
 		if len(stateIDs) > 0 {
 			if err := r.adaptor.RequestStateNodes(peerID, ledger.Hash(), stateIDs, queryDepth, indirect); err != nil {
-				r.logger.Warn("inbound ledger: failed to request state nodes", "error", err)
+				disconnected = r.handleMissingNodeSendFailure(ledger, peerID, false, err)
+				stateDisconnected = stateDisconnected || disconnected
+			} else {
+				stateSent = true
 			}
+		}
+		if disconnected {
+			txDisconnected = txDisconnected || len(txIDs) > 0
+			continue
 		}
 		if len(txIDs) > 0 {
 			if err := r.adaptor.RequestTransactionNodes(peerID, ledger.Hash(), txIDs, queryDepth, indirect); err != nil {
-				r.logger.Warn("inbound ledger: failed to request tx nodes", "error", err)
+				disconnected = r.handleMissingNodeSendFailure(ledger, peerID, true, err)
+				txDisconnected = txDisconnected || disconnected
+			} else {
+				txSent = true
 			}
 		}
 	}
+	retry := missingNodeRetry{queryDepth: queryDepth}
+	if stateDisconnected && !stateSent {
+		retry.stateIDs = stateIDs
+	}
+	if txDisconnected && !txSent {
+		retry.txIDs = txIDs
+	}
+	return retry
 }
 
 func applyAcquisitionData(ctx context.Context, ledger *inbound.Ledger, data *message.LedgerData) (useful int, badKind string, remove, complete bool, err error) {

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -957,13 +957,17 @@ func (r *Router) requestLedgerBaseFromPeer(il *inbound.Ledger, peerID uint64, lo
 		return true
 	}
 	r.logger.Warn(logMessage, "error", err, "peer", peerID)
-	if !errors.Is(err, peermanagement.ErrPeerNotFound) &&
-		!errors.Is(err, peermanagement.ErrConnectionClosed) {
+	if !isAcquisitionDisconnectError(err) {
 		return true
 	}
 	il.RemovePeer(peerID)
 	r.HandlePeerDisconnect(peermanagement.PeerID(peerID))
 	return false
+}
+
+func isAcquisitionDisconnectError(err error) bool {
+	return errors.Is(err, peermanagement.ErrPeerNotFound) ||
+		errors.Is(err, peermanagement.ErrConnectionClosed)
 }
 
 func (r *Router) invalidateHistoryPeer(peerID uint64) {
@@ -2209,17 +2213,27 @@ func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerD
 // indirect (query_type=qtINDIRECT) so peers relay them on our behalf,
 // mirroring rippled's InboundLedger::trigger timeouts_ != 0 gate.
 func (r *Router) requestMissingAcquisitionNodes(il *inbound.Ledger, target uint64) {
-	indirect := il.Timeouts() > 0
-	// target != 0 is the reply path (re-request to the answering peer), throttled
-	// against nodes already requested this timer interval so a reply can't
-	// re-request outstanding nodes at RTT rate; target == 0 is the timeout
-	// fan-out, which bypasses that throttle to still reach everyone.
-	isReply := target != 0
-	queryDepth := uint32(0)
-	if isReply {
-		queryDepth = 1
+	if target != 0 {
+		requests, complete, err := il.CollectMissingReplyRequestsContext(context.Background(), []uint64{target})
+		if err != nil {
+			r.logger.Warn("inbound ledger: failed to collect missing nodes", "error", err)
+			return
+		}
+		if complete {
+			r.completeInboundLedger(il)
+			return
+		}
+		released := 0
+		for _, request := range requests {
+			if r.sendMissingReplyRequest(il, request) {
+				released++
+			}
+		}
+		r.retryMissingAcquisitionNodes(il, missingNodeRetry{}, released)
+		return
 	}
-	stateIDs, txIDs, complete, err := il.CollectMissingRequestContext(context.Background(), isReply)
+
+	stateIDs, txIDs, complete, err := il.CollectMissingRequestContext(context.Background(), false)
 	if err != nil {
 		r.logger.Warn("inbound ledger: failed to collect missing nodes", "error", err)
 		return
@@ -2231,23 +2245,9 @@ func (r *Router) requestMissingAcquisitionNodes(il *inbound.Ledger, target uint6
 	if len(stateIDs) == 0 && len(txIDs) == 0 {
 		return
 	}
-	hash := il.Hash()
 	peers := il.Peers()
-	if target != 0 {
-		peers = []uint64{target}
-	}
-	for _, peerID := range peers {
-		if len(stateIDs) > 0 {
-			if err := r.adaptor.RequestStateNodes(peerID, hash, stateIDs, queryDepth, indirect); err != nil {
-				r.logger.Warn("inbound ledger: failed to request state nodes", "error", err)
-			}
-		}
-		if len(txIDs) > 0 {
-			if err := r.adaptor.RequestTransactionNodes(peerID, hash, txIDs, queryDepth, indirect); err != nil {
-				r.logger.Warn("inbound ledger: failed to request tx nodes", "error", err)
-			}
-		}
-	}
+	retry := r.sendMissingAcquisitionNodes(il, peers, stateIDs, txIDs, 0)
+	r.retryMissingAcquisitionNodes(il, retry, 0)
 }
 
 func (r *Router) requestMissingAcquisitionNodesFromAddedPeer(il *inbound.Ledger, peerID uint64) {
@@ -2260,8 +2260,88 @@ func (r *Router) requestMissingAcquisitionNodesFromAddedPeer(il *inbound.Ledger,
 		r.completeInboundLedger(il)
 		return
 	}
+	released := 0
 	for _, request := range requests {
-		r.sendMissingReplyRequest(il, request)
+		if r.sendMissingReplyRequest(il, request) {
+			released++
+		}
+	}
+	r.retryMissingAcquisitionNodes(il, missingNodeRetry{}, released)
+}
+
+func (r *Router) handleMissingNodeSendFailure(
+	il *inbound.Ledger,
+	peerID uint64,
+	transaction bool,
+	err error,
+) bool {
+	hash := il.Hash()
+	r.logger.Warn(
+		"inbound ledger: failed to request missing nodes",
+		"peer", peerID,
+		"ledger_seq", il.Seq(),
+		"ledger_hash", fmt.Sprintf("%x", hash[:8]),
+		"transaction", transaction,
+		"error", err,
+	)
+	if !isAcquisitionDisconnectError(err) {
+		return false
+	}
+	il.RemovePeer(peerID)
+	r.HandlePeerDisconnect(peermanagement.PeerID(peerID))
+	return true
+}
+
+func (r *Router) retryMissingAcquisitionNodes(
+	il *inbound.Ledger,
+	retry missingNodeRetry,
+	released int,
+) {
+	if len(retry.stateIDs) == 0 && len(retry.txIDs) == 0 && released == 0 {
+		return
+	}
+
+	peers := il.Peers()
+	replacements := released
+	if len(retry.stateIDs) > 0 || len(retry.txIDs) > 0 {
+		replacements++
+	}
+	replacements = min(max(replacements, 1), acquisitionMaxUsefulPeers)
+	added := make([]uint64, 0, replacements)
+	for _, peerID := range r.adaptor.SelectLedgerPeers(il.Hash(), il.Seq(), peers, replacements) {
+		if il.AddPeer(peerID) {
+			added = append(added, peerID)
+		}
+	}
+	candidates := acquisitionRequestCandidates(added, il.Peers())
+	if len(candidates) > acquisitionMaxUsefulPeers {
+		candidates = candidates[:acquisitionMaxUsefulPeers]
+	}
+	if len(candidates) == 0 {
+		if len(retry.stateIDs) > 0 || len(retry.txIDs) > 0 {
+			il.ReleaseUnreservedMissingNodes()
+		}
+		return
+	}
+
+	queued := r.submitAcquisitionWork(il, acquisitionWorkEvent{
+		kind:       acquisitionWorkRetarget,
+		peers:      candidates,
+		stateIDs:   append([][]byte(nil), retry.stateIDs...),
+		txIDs:      append([][]byte(nil), retry.txIDs...),
+		queryDepth: retry.queryDepth,
+		collect:    released > 0,
+	})
+	if !queued {
+		if len(retry.stateIDs) > 0 || len(retry.txIDs) > 0 {
+			il.ReleaseUnreservedMissingNodes()
+		}
+		hash := il.Hash()
+		r.logger.Warn(
+			"inbound ledger: missing-node retarget deferred; acquisition worker saturated",
+			"ledger_seq", il.Seq(),
+			"ledger_hash", fmt.Sprintf("%x", hash[:8]),
+		)
 	}
 }
 

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -1310,6 +1310,18 @@ func (l *Ledger) ReleaseMissingRequest(peerID uint64, hashes [][32]byte) {
 	l.releaseMissingRequests([]MissingRequest{{PeerID: peerID, NodeHashes: hashes}})
 }
 
+// ReleaseUnreservedMissingNodes makes a failed timeout fan-out eligible for a
+// later peer without disturbing peer-owned reservations.
+func (l *Ledger) ReleaseUnreservedMissingNodes() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for hash, owner := range l.recentNodes {
+		if owner == 0 {
+			delete(l.recentNodes, hash)
+		}
+	}
+}
+
 // ReleaseMissingPeer marks a peer's previous request as answered. Its node
 // reservations remain until they arrive or the acquisition timer advances.
 func (l *Ledger) ReleaseMissingPeer(peerID uint64) {


### PR DESCRIPTION
## Summary

- classify missing-node send failures that prove a peer disconnected
- evict stale acquisition targets and release their reserved frontier
- schedule one bounded replacement send while preserving live fan-out and retry pacing
- make failed timeout work immediately eligible for peers that connect later

## Behavioral conformance

The recovery flow was checked against the local rippled 3.2.0 `InboundLedger`,
`PeerSet`, and `TimeoutCounter` implementations. The Go implementation retains
state-first acquisition, reply/timeout query depths, bounded peer selection,
and the timer-based terminal retry budget.

## Verification

- `go test ./internal/consensus/adaptor ./internal/ledger/inbound`
- `go test -race ./internal/consensus/adaptor ./internal/ledger/inbound`
- `just test-core`
- `just build-all`
- `just vet`
- `go vet -tags postgres ./storage/relationaldb/postgres/`
- `golangci-lint run --config .golangci.yml`
- `just lint`

Fixes #1440
