### PR TITLE
feat: speed up fast-load verification

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -46,6 +46,7 @@ cache_mb = 2048
 open_files = 1000
 cache_size = 16384
 cache_age = 5
+fast_load_workers = 32
 earliest_seq = 32570
 online_delete = 512
 delete_batch = 100
@@ -122,6 +123,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, "/tmp/test/db", config.NodeDB.Path)
 	assert.Equal(t, int64(2048), config.NodeDB.CacheMB)
 	assert.Equal(t, 1000, config.NodeDB.OpenFiles)
+	assert.Equal(t, 32, config.NodeDB.FastLoadWorkers)
 	require.NotNil(t, config.FeeDefault)
 	assert.Equal(t, 13, *config.FeeDefault)
 
@@ -158,6 +160,36 @@ func TestNodeDBConfigPebbleResourcesValidation(t *testing.T) {
 				CacheMB:      test.cacheMB,
 				OpenFiles:    test.files,
 				OnlineDelete: test.online,
+			}
+			err := cfg.Validate()
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestNodeDBConfigFastLoadWorkersValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		workers int
+		wantErr string
+	}{
+		{name: "automatic"},
+		{name: "one worker", workers: 1},
+		{name: "maximum", workers: 64},
+		{name: "negative", workers: -1, wantErr: "fast_load_workers must be non-negative"},
+		{name: "over maximum", workers: 65, wantErr: "fast_load_workers must not exceed 64"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := NodeDBConfig{
+				Type:            "pebble",
+				Path:            t.TempDir(),
+				FastLoadWorkers: test.workers,
 			}
 			err := cfg.Validate()
 			if test.wantErr == "" {

--- a/config/database.go
+++ b/config/database.go
@@ -12,6 +12,7 @@ const (
 	// Pebble reserves 10 non-table files above its minimum 64-entry table cache.
 	minimumPebbleOpenFiles   = 74
 	minimumRotatingOpenFiles = 2 * minimumPebbleOpenFiles
+	maxFastLoadWorkers       = 64
 )
 
 // NodeDBConfig represents the [node_db] section.
@@ -26,6 +27,7 @@ type NodeDBConfig struct {
 	CacheSize           int    `toml:"cache_size" mapstructure:"cache_size"` // node-object cache entries; 0 = default
 	CacheAge            int    `toml:"cache_age" mapstructure:"cache_age"`   // node-object cache age in minutes; 0 = default
 	FastLoad            bool   `toml:"fast_load" mapstructure:"fast_load"`
+	FastLoadWorkers     int    `toml:"fast_load_workers" mapstructure:"fast_load_workers"`
 	EarliestSeq         int    `toml:"earliest_seq" mapstructure:"earliest_seq"`
 	OnlineDelete        int    `toml:"online_delete" mapstructure:"online_delete"`
 	AdvisoryDelete      int    `toml:"advisory_delete" mapstructure:"advisory_delete"`
@@ -84,6 +86,12 @@ func (n *NodeDBConfig) Validate() error {
 	}
 	if err := validateNonNegative("cache_age", n.CacheAge); err != nil {
 		return err
+	}
+	if err := validateNonNegative("fast_load_workers", n.FastLoadWorkers); err != nil {
+		return err
+	}
+	if n.FastLoadWorkers > maxFastLoadWorkers {
+		return fmt.Errorf("fast_load_workers must not exceed %d, got %d", maxFastLoadWorkers, n.FastLoadWorkers)
 	}
 	if err := validateNonNegative("earliest_seq", n.EarliestSeq); err != nil {
 		return err

--- a/config/examples/xrpld.toml
+++ b/config/examples/xrpld.toml
@@ -146,6 +146,7 @@ cache_age = 5                    # decoded node-object cache age in minutes (0 =
 # Also permits failed explicit --load, --ledger, --ledgerfile, or --replay
 # startup to fall back to genesis (standalone) or network acquisition.
 fast_load = false
+fast_load_workers = 0             # 0 = automatic based on available CPUs; maximum 64
 earliest_seq = 32570
 delete_batch = 100
 back_off_milliseconds = 100

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -92,6 +92,11 @@ ledger from the network in networked mode. With no startup flag on a networked
 node, `fast_load` first attempts the latest local ledger and otherwise acquires
 one from peers.
 
+Fast-load integrity verification uses `[node_db].fast_load_workers` concurrent
+workers. Leave it at `0` to select an automatic value based on available CPUs,
+or set an explicit value from `1` through `64`. More workers can improve
+verification throughput until storage bandwidth is saturated.
+
 Startup replay is separate from the top-level `ledger_replay` setting.
 `ledger_replay` advertises and controls peer replay capability; it does not select
 a startup mode. `--replay` starts from the selected ledger's stored parent and
@@ -250,6 +255,7 @@ List IPs in `admin` to grant those clients admin role.
 | `cache_size` | `16384` | Decoded node-object cache entries (`0` = the `node_size` profile). This is independent of `cache_mb`. |
 | `cache_age` | `5` | Decoded node-object cache age in minutes (`0` = the `node_size` profile). |
 | `fast_load` | `false` | On networked startup, try the newest local ledger by default; also permit explicit load/replay failures to fall back to genesis or network acquisition. |
+| `fast_load_workers` | `0` | Concurrent workers for fast-load integrity verification. `0` selects an automatic value based on available CPUs; explicit values may range from `1` to `64`. |
 | `earliest_seq` | `32570` | Lowest ledger sequence to retain. |
 | `delete_batch` / `back_off_milliseconds` / `age_threshold_seconds` / `recovery_wait_seconds` | `100`/`100`/`60`/`5` | Online-delete pacing (batch size, inter-batch pause, minimum age, catch-up wait). |
 

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -291,6 +291,7 @@ open_files = 500
 cache_size = 16384
 cache_age = 5
 fast_load = false
+fast_load_workers = 0 # 0 = automatic based on available CPUs; maximum 64
 earliest_seq = 32570
 delete_batch = 100
 back_off_milliseconds = 100

--- a/internal/ledger/service/fast_load.go
+++ b/internal/ledger/service/fast_load.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/drops"
@@ -222,7 +224,7 @@ func (s *Service) verifyStoredSHAMapWithTicks(
 	now func() time.Time,
 	ticks <-chan time.Time,
 ) (err error) {
-	progress := newStoredSHAMapVerificationProgress(s.logger, root, mapType, startedAt)
+	progress := newStoredSHAMapVerificationProgress(s.logger, s.nodeStore, root, mapType, startedAt)
 	defer func() {
 		progress.finish(now(), err)
 	}()
@@ -231,7 +233,13 @@ func (s *Service) verifyStoredSHAMapWithTicks(
 		return fmt.Errorf("zero root")
 	}
 
-	rootNode, _, err := s.loadStoredSHAMapNode(ctx, storedSHAMapNode{hash: root}, mapType)
+	fetch := s.storedSHAMapVerificationFetch()
+	rootNode, _, err := s.loadStoredSHAMapNodeWithFetch(
+		ctx,
+		storedSHAMapNode{hash: root},
+		mapType,
+		fetch,
+	)
 	if err != nil {
 		return err
 	}
@@ -253,38 +261,100 @@ func (s *Service) verifyStoredSHAMapWithTicks(
 		branches = append(branches, child)
 	}
 	progress.branchesTotal = uint32(len(branches))
+	workers := resolveStoredSHAMapWorkers(s.config.FastLoadWorkers)
+	progress.configureWorkers(workers, 0, len(branches))
 	progress.start()
+	frontier, outstanding, err := s.buildStoredSHAMapFrontier(
+		ctx,
+		branches,
+		workers*storedSHAMapFrontierTasksPerWorker,
+		mapType,
+		fetch,
+		func() {
+			progress.nodesChecked.Add(1)
+		},
+	)
+	for _, count := range outstanding {
+		if count == 0 {
+			progress.branchesComplete.Add(1)
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	startedWorkers := min(workers, len(frontier))
+	progress.configureWorkers(workers, startedWorkers, len(frontier))
+	if len(frontier) == 0 {
+		return nil
+	}
 
 	walkCtx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
+	var cancelOnce sync.Once
+	branchOutstanding := make([]atomic.Int64, len(outstanding))
+	for branch, count := range outstanding {
+		branchOutstanding[branch].Store(int64(count))
+	}
+
+	tasks := make(chan storedSHAMapTask, len(frontier))
+	for _, task := range frontier {
+		tasks <- task
+	}
+	close(tasks)
+
 	var wg sync.WaitGroup
-	for _, child := range branches {
+	for range startedWorkers {
 		wg.Add(1)
-		go func(child [32]byte) {
+		go func() {
 			defer wg.Done()
-			var unreportedNodes uint64
-			walkErr := s.walkStoredSHAMapNodes(
-				walkCtx,
-				[]storedSHAMapNode{{hash: child, depth: 1}},
-				mapType,
-				func([32]byte, *nodestore.Node) error {
-					unreportedNodes++
-					if unreportedNodes == storedSHAMapNodeCountBatch {
-						progress.nodesChecked.Add(unreportedNodes)
-						unreportedNodes = 0
+			for {
+				if walkCtx.Err() != nil {
+					return
+				}
+				var task storedSHAMapTask
+				var ok bool
+				select {
+				case task, ok = <-tasks:
+					if !ok {
+						return
 					}
-					return nil
-				},
-			)
-			if unreportedNodes > 0 {
-				progress.nodesChecked.Add(unreportedNodes)
+				case <-walkCtx.Done():
+					return
+				}
+
+				progress.frontierSize.Add(-1)
+				progress.activeWorkers.Add(1)
+				var unreportedNodes uint64
+				walkErr := s.walkStoredSHAMapNodesWithFetch(
+					walkCtx,
+					[]storedSHAMapNode{task.node},
+					mapType,
+					fetch,
+					func([32]byte, *nodestore.Node) error {
+						unreportedNodes++
+						if unreportedNodes == storedSHAMapNodeCountBatch {
+							progress.nodesChecked.Add(unreportedNodes)
+							unreportedNodes = 0
+						}
+						return nil
+					},
+				)
+				if unreportedNodes > 0 {
+					progress.nodesChecked.Add(unreportedNodes)
+				}
+				progress.activeWorkers.Add(-1)
+				if walkErr != nil {
+					cancelOnce.Do(func() {
+						cancel(walkErr)
+					})
+					return
+				}
+				if branchOutstanding[task.branch].Add(-1) == 0 {
+					progress.branchesComplete.Add(1)
+				}
 			}
-			if walkErr != nil {
-				cancel(walkErr)
-				return
-			}
-			progress.branchesComplete.Add(1)
-		}(child)
+		}()
 	}
 	workersDone := make(chan struct{})
 	go func() {
@@ -299,9 +369,13 @@ func (s *Service) verifyStoredSHAMapWithTicks(
 				ticks = nil
 				continue
 			}
+			select {
+			case <-workersDone:
+				return context.Cause(walkCtx)
+			default:
+			}
 			progress.report(tick)
 		case <-workersDone:
-			progress.report(now())
 			return context.Cause(walkCtx)
 		}
 	}
@@ -312,7 +386,96 @@ type storedSHAMapNode struct {
 	depth int
 }
 
+type storedSHAMapTask struct {
+	node   storedSHAMapNode
+	branch int
+}
+
 type storedSHAMapFetch func(context.Context, nodestore.Hash256) (*nodestore.Node, error)
+
+const (
+	maxStoredSHAMapWorkers             = 64
+	storedSHAMapFrontierTasksPerWorker = 4
+)
+
+func resolveStoredSHAMapWorkers(configured int) int {
+	if configured <= 0 {
+		configured = runtime.GOMAXPROCS(0)
+	}
+	return min(configured, maxStoredSHAMapWorkers)
+}
+
+func (s *Service) storedSHAMapVerificationFetch() storedSHAMapFetch {
+	uncached, ok := s.nodeStore.(interface {
+		FetchDataUncached(context.Context, nodestore.Hash256) ([]byte, error)
+	})
+	if !ok {
+		return s.nodeStore.Fetch
+	}
+	return func(ctx context.Context, hash nodestore.Hash256) (*nodestore.Node, error) {
+		data, err := uncached.FetchDataUncached(ctx, hash)
+		if err != nil || data == nil {
+			return nil, err
+		}
+		return &nodestore.Node{Hash: hash, Data: data}, nil
+	}
+}
+
+func (s *Service) buildStoredSHAMapFrontier(
+	ctx context.Context,
+	branches [][32]byte,
+	target int,
+	mapType shamap.Type,
+	fetch storedSHAMapFetch,
+	visit func(),
+) ([]storedSHAMapTask, []uint32, error) {
+	splitRootBranches := target > storedSHAMapFrontierTasksPerWorker
+	target = max(target, len(branches))
+	frontier := make(
+		[]storedSHAMapTask,
+		0,
+		target+len(branches)*(shamap.BranchFactor-1),
+	)
+	outstanding := make([]uint32, len(branches))
+	for branch, hash := range branches {
+		outstanding[branch] = 1
+		frontier = append(frontier, storedSHAMapTask{
+			node:   storedSHAMapNode{hash: hash, depth: 1},
+			branch: branch,
+		})
+	}
+	initialSplits := 0
+	if splitRootBranches {
+		initialSplits = len(branches)
+	}
+	for split := 0; len(frontier) > 0 && (split < initialSplits || len(frontier) < target); split++ {
+		task := frontier[0]
+		copy(frontier, frontier[1:])
+		frontier = frontier[:len(frontier)-1]
+
+		node, _, err := s.loadStoredSHAMapNodeWithFetch(ctx, task.node, mapType, fetch)
+		if err != nil {
+			return frontier, outstanding, err
+		}
+		var childBuffer [shamap.BranchFactor]storedSHAMapNode
+		children, err := appendStoredSHAMapChildren(childBuffer[:0], task.node, node)
+		if err != nil {
+			return frontier, outstanding, err
+		}
+		if visit != nil {
+			visit()
+		}
+		outstanding[task.branch]--
+		for _, child := range children {
+			frontier = append(frontier, storedSHAMapTask{
+				node:   child,
+				branch: task.branch,
+			})
+			outstanding[task.branch]++
+		}
+	}
+	return frontier, outstanding, nil
+}
 
 func (s *Service) walkStoredSHAMap(
 	ctx context.Context,
@@ -342,15 +505,6 @@ func (s *Service) walkStoredSHAMapWithFetch(
 	)
 }
 
-func (s *Service) walkStoredSHAMapNodes(
-	ctx context.Context,
-	stack []storedSHAMapNode,
-	mapType shamap.Type,
-	visit func([32]byte, *nodestore.Node) error,
-) error {
-	return s.walkStoredSHAMapNodesWithFetch(ctx, stack, mapType, s.nodeStore.Fetch, visit)
-}
-
 func (s *Service) walkStoredSHAMapNodesWithFetch(
 	ctx context.Context,
 	stack []storedSHAMapNode,
@@ -368,20 +522,9 @@ func (s *Service) walkStoredSHAMapNodesWithFetch(
 		if err != nil {
 			return err
 		}
-		if inner, ok := node.(shamap.InnerNodeReader); ok {
-			if pending.depth >= 64 {
-				return fmt.Errorf("inner node %x exceeds maximum depth", pending.hash[:8])
-			}
-			for branch := 0; branch < shamap.BranchFactor; branch++ {
-				if inner.IsEmptyBranch(branch) {
-					continue
-				}
-				child, err := inner.ChildHash(branch)
-				if err != nil {
-					return err
-				}
-				stack = append(stack, storedSHAMapNode{hash: child, depth: pending.depth + 1})
-			}
+		stack, err = appendStoredSHAMapChildren(stack, pending, node)
+		if err != nil {
+			return err
 		}
 		if visit != nil {
 			if err := visit(pending.hash, stored); err != nil {
@@ -390,6 +533,34 @@ func (s *Service) walkStoredSHAMapNodesWithFetch(
 		}
 	}
 	return nil
+}
+
+func appendStoredSHAMapChildren(
+	children []storedSHAMapNode,
+	pending storedSHAMapNode,
+	node shamap.NodeReader,
+) ([]storedSHAMapNode, error) {
+	inner, ok := node.(shamap.InnerNodeReader)
+	if !ok {
+		return children, nil
+	}
+	if pending.depth >= 64 {
+		return nil, fmt.Errorf("inner node %x exceeds maximum depth", pending.hash[:8])
+	}
+	for branch := range shamap.BranchFactor {
+		if inner.IsEmptyBranch(branch) {
+			continue
+		}
+		child, err := inner.ChildHash(branch)
+		if err != nil {
+			return nil, err
+		}
+		children = append(children, storedSHAMapNode{
+			hash:  child,
+			depth: pending.depth + 1,
+		})
+	}
+	return children, nil
 }
 
 func (s *Service) loadStoredSHAMapNode(

--- a/internal/ledger/service/fast_load_progress.go
+++ b/internal/ledger/service/fast_load_progress.go
@@ -7,6 +7,7 @@ import (
 
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/LeJamon/go-xrpl/storage/nodestore"
 )
 
 const (
@@ -24,28 +25,52 @@ type storedSHAMapVerificationProgress struct {
 
 	startedAt  time.Time
 	lastReport time.Time
+	lastNodes  uint64
 	interval   time.Duration
 	started    bool
 
 	nodesChecked     atomic.Uint64
 	branchesComplete atomic.Uint32
 	branchesTotal    uint32
+	workersResolved  uint32
+	workersStarted   uint32
+	activeWorkers    atomic.Int32
+	frontierSize     atomic.Int64
+
+	nodeStore    nodestore.Database
+	initialStats nodestore.Statistics
 }
 
 func newStoredSHAMapVerificationProgress(
 	logger xrpllog.Logger,
+	nodeStore nodestore.Database,
 	root [32]byte,
 	mapType shamap.Type,
 	startedAt time.Time,
 ) *storedSHAMapVerificationProgress {
-	return &storedSHAMapVerificationProgress{
+	progress := &storedSHAMapVerificationProgress{
 		logger:     logger,
+		nodeStore:  nodeStore,
 		mapType:    mapType.String(),
 		root:       fmt.Sprintf("%x", root[:8]),
 		startedAt:  startedAt,
 		lastReport: startedAt,
 		interval:   storedSHAMapVerificationLogInterval,
 	}
+	if nodeStore != nil {
+		progress.initialStats = nodeStore.Stats()
+	}
+	return progress
+}
+
+func (p *storedSHAMapVerificationProgress) configureWorkers(
+	resolved int,
+	started int,
+	frontier int,
+) {
+	p.workersResolved = uint32(resolved)
+	p.workersStarted = uint32(started)
+	p.frontierSize.Store(int64(frontier))
 }
 
 func (p *storedSHAMapVerificationProgress) start() {
@@ -57,6 +82,12 @@ func (p *storedSHAMapVerificationProgress) start() {
 		"map_type", p.mapType,
 		"root", p.root,
 		"active_branches", p.branchesTotal,
+		"workers", p.workersResolved,
+		"frontier_size", p.frontierSize.Load(),
+		"node_store_reads_before", p.initialStats.Reads,
+		"node_store_read_bytes_before", p.initialStats.ReadBytes,
+		"node_cache_hits_before", p.initialStats.CacheHits,
+		"node_cache_misses_before", p.initialStats.CacheMisses,
 	)
 }
 
@@ -64,8 +95,9 @@ func (p *storedSHAMapVerificationProgress) report(at time.Time) {
 	if at.Before(p.lastReport.Add(p.interval)) {
 		return
 	}
+	fields := p.fields(at)
 	p.lastReport = at
-	p.logger.Info("stored SHAMap verification progress", p.fields(at)...)
+	p.logger.Info("stored SHAMap verification progress", fields...)
 }
 
 func (p *storedSHAMapVerificationProgress) finish(at time.Time, err error) {
@@ -88,13 +120,45 @@ func (p *storedSHAMapVerificationProgress) fields(at time.Time) []any {
 	if elapsed > 0 {
 		nodesPerSecond = uint64(float64(nodesChecked) / elapsed.Seconds())
 	}
+	intervalElapsed := at.Sub(p.lastReport)
+	var intervalNodesPerSecond uint64
+	if intervalElapsed > 0 {
+		intervalNodesPerSecond = uint64(
+			float64(nodesChecked-p.lastNodes) / intervalElapsed.Seconds(),
+		)
+	}
+	p.lastNodes = nodesChecked
+
+	activeWorkers := p.activeWorkers.Load()
+	idleWorkers := int64(p.workersStarted) - int64(activeWorkers)
+	if idleWorkers < 0 {
+		idleWorkers = 0
+	}
+	stats := p.initialStats
+	if p.nodeStore != nil {
+		stats = p.nodeStore.Stats()
+	}
 	return []any{
 		"map_type", p.mapType,
 		"root", p.root,
 		"elapsed", elapsed.String(),
 		"nodes_checked", nodesChecked,
 		"nodes_per_second", nodesPerSecond,
+		"interval_nodes_per_second", intervalNodesPerSecond,
 		"branches_complete", p.branchesComplete.Load(),
 		"branches_total", p.branchesTotal,
+		"workers", p.workersResolved,
+		"worker_pool_size", p.workersStarted,
+		"active_workers", activeWorkers,
+		"idle_workers", idleWorkers,
+		"frontier_size", p.frontierSize.Load(),
+		"node_store_reads_before", p.initialStats.Reads,
+		"node_store_reads_after", stats.Reads,
+		"node_store_read_bytes_before", p.initialStats.ReadBytes,
+		"node_store_read_bytes_after", stats.ReadBytes,
+		"node_cache_hits_before", p.initialStats.CacheHits,
+		"node_cache_hits_after", stats.CacheHits,
+		"node_cache_misses_before", p.initialStats.CacheMisses,
+		"node_cache_misses_after", stats.CacheMisses,
 	}
 }

--- a/internal/ledger/service/fast_load_test.go
+++ b/internal/ledger/service/fast_load_test.go
@@ -33,21 +33,50 @@ type corruptDescendantFamily struct {
 
 type parallelFetchDatabase struct {
 	nodestore.Database
-	root    nodestore.Hash256
-	started chan struct{}
-	once    sync.Once
-	mu      sync.Mutex
-	active  int
-	peak    int
+	unblocked map[nodestore.Hash256]struct{}
+	started   chan struct{}
+	once      sync.Once
+	mu        sync.Mutex
+	active    int
+	peak      int
 }
 
 type blockingVerificationDatabase struct {
 	nodestore.Database
-	root    nodestore.Hash256
-	started chan struct{}
-	release chan struct{}
-	err     error
-	once    sync.Once
+	root      nodestore.Hash256
+	unblocked map[nodestore.Hash256]struct{}
+	started   chan struct{}
+	release   chan struct{}
+	err       error
+	once      sync.Once
+}
+
+type uncachedTrackingDatabase struct {
+	nodestore.Database
+	mu              sync.Mutex
+	fetches         int
+	uncachedFetches int
+	rewrite         func(nodestore.Hash256, []byte) ([]byte, error)
+}
+
+type fallbackTrackingDatabase struct {
+	nodestore.Database
+	mu      sync.Mutex
+	fetches int
+}
+
+type cancelingVerificationDatabase struct {
+	nodestore.Database
+	root      nodestore.Hash256
+	unblocked map[nodestore.Hash256]struct{}
+	fail      nodestore.Hash256
+	err       error
+	expected  int
+	ready     chan struct{}
+	once      sync.Once
+	mu        sync.Mutex
+	active    int
+	peak      int
 }
 
 type synchronizedLogBuffer struct {
@@ -57,18 +86,32 @@ type synchronizedLogBuffer struct {
 }
 
 type verificationLogRecord struct {
-	Level             string `json:"level"`
-	Message           string `json:"msg"`
-	Topic             string `json:"t"`
-	MapType           string `json:"map_type"`
-	Root              string `json:"root"`
-	Elapsed           string `json:"elapsed"`
-	NodesChecked      uint64 `json:"nodes_checked"`
-	NodesPerSecond    uint64 `json:"nodes_per_second"`
-	ActiveBranches    uint32 `json:"active_branches"`
-	BranchesComplete  uint32 `json:"branches_complete"`
-	BranchesTotal     uint32 `json:"branches_total"`
-	VerificationError string `json:"err"`
+	Level                    string `json:"level"`
+	Message                  string `json:"msg"`
+	Topic                    string `json:"t"`
+	MapType                  string `json:"map_type"`
+	Root                     string `json:"root"`
+	Elapsed                  string `json:"elapsed"`
+	NodesChecked             uint64 `json:"nodes_checked"`
+	NodesPerSecond           uint64 `json:"nodes_per_second"`
+	IntervalNodesRate        uint64 `json:"interval_nodes_per_second"`
+	ActiveBranches           uint32 `json:"active_branches"`
+	BranchesComplete         uint32 `json:"branches_complete"`
+	BranchesTotal            uint32 `json:"branches_total"`
+	Workers                  uint32 `json:"workers"`
+	WorkerPoolSize           uint32 `json:"worker_pool_size"`
+	ActiveWorkers            int32  `json:"active_workers"`
+	IdleWorkers              int64  `json:"idle_workers"`
+	FrontierSize             int64  `json:"frontier_size"`
+	NodeStoreReadsBefore     uint64 `json:"node_store_reads_before"`
+	NodeStoreReadsAfter      uint64 `json:"node_store_reads_after"`
+	NodeStoreReadBytesBefore uint64 `json:"node_store_read_bytes_before"`
+	NodeStoreReadBytesAfter  uint64 `json:"node_store_read_bytes_after"`
+	NodeCacheHitsBefore      uint64 `json:"node_cache_hits_before"`
+	NodeCacheHitsAfter       uint64 `json:"node_cache_hits_after"`
+	NodeCacheMissesBefore    uint64 `json:"node_cache_misses_before"`
+	NodeCacheMissesAfter     uint64 `json:"node_cache_misses_after"`
+	VerificationError        string `json:"err"`
 }
 
 type verificationTestClock struct {
@@ -77,7 +120,7 @@ type verificationTestClock struct {
 }
 
 func (d *parallelFetchDatabase) Fetch(ctx context.Context, hash nodestore.Hash256) (*nodestore.Node, error) {
-	if hash == d.root {
+	if _, ok := d.unblocked[hash]; ok {
 		return d.Database.Fetch(ctx, hash)
 	}
 	d.mu.Lock()
@@ -109,6 +152,9 @@ func (d *blockingVerificationDatabase) Fetch(ctx context.Context, hash nodestore
 	if hash == d.root {
 		return d.Database.Fetch(ctx, hash)
 	}
+	if _, ok := d.unblocked[hash]; ok {
+		return d.Database.Fetch(ctx, hash)
+	}
 	d.once.Do(func() { close(d.started) })
 	select {
 	case <-d.release:
@@ -119,6 +165,101 @@ func (d *blockingVerificationDatabase) Fetch(ctx context.Context, hash nodestore
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+func (d *uncachedTrackingDatabase) Fetch(
+	ctx context.Context,
+	hash nodestore.Hash256,
+) (*nodestore.Node, error) {
+	d.mu.Lock()
+	d.fetches++
+	d.mu.Unlock()
+	return d.Database.Fetch(ctx, hash)
+}
+
+func (d *uncachedTrackingDatabase) FetchDataUncached(
+	ctx context.Context,
+	hash nodestore.Hash256,
+) ([]byte, error) {
+	d.mu.Lock()
+	d.uncachedFetches++
+	d.mu.Unlock()
+	raw, ok := d.Database.(interface {
+		FetchDataUncached(context.Context, nodestore.Hash256) ([]byte, error)
+	})
+	if !ok {
+		return nil, errors.New("uncached reads are unavailable")
+	}
+	data, err := raw.FetchDataUncached(ctx, hash)
+	if err != nil || data == nil || d.rewrite == nil {
+		return data, err
+	}
+	return d.rewrite(hash, data)
+}
+
+func (d *uncachedTrackingDatabase) counts() (fetches, uncached int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.fetches, d.uncachedFetches
+}
+
+func (d *fallbackTrackingDatabase) Fetch(
+	ctx context.Context,
+	hash nodestore.Hash256,
+) (*nodestore.Node, error) {
+	d.mu.Lock()
+	d.fetches++
+	d.mu.Unlock()
+	return d.Database.Fetch(ctx, hash)
+}
+
+func (d *fallbackTrackingDatabase) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.fetches
+}
+
+func (d *cancelingVerificationDatabase) Fetch(
+	ctx context.Context,
+	hash nodestore.Hash256,
+) (*nodestore.Node, error) {
+	if hash == d.root {
+		return d.Database.Fetch(ctx, hash)
+	}
+	if _, ok := d.unblocked[hash]; ok {
+		return d.Database.Fetch(ctx, hash)
+	}
+	d.mu.Lock()
+	d.active++
+	if d.active > d.peak {
+		d.peak = d.active
+	}
+	if d.active == d.expected {
+		d.once.Do(func() { close(d.ready) })
+	}
+	d.mu.Unlock()
+	defer func() {
+		d.mu.Lock()
+		d.active--
+		d.mu.Unlock()
+	}()
+
+	select {
+	case <-d.ready:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	if hash == d.fail {
+		return nil, d.err
+	}
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (d *cancelingVerificationDatabase) fetchState() (active, peak int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.active, d.peak
 }
 
 func (b *synchronizedLogBuffer) Write(data []byte) (int, error) {
@@ -234,6 +375,91 @@ func newStoredVerificationFixture(
 		}
 	}
 	return svc, db, root, nodes, activeBranches
+}
+
+func newParallelStoredVerificationFixture(
+	t *testing.T,
+) (*Service, nodestore.Database, [32]byte, []nodestore.Hash256) {
+	t.Helper()
+	db := nodestore.NewKVDatabase(memorydb.New(), "parallel-verification", 10_000, time.Hour)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	svc, err := New(Config{NodeStore: db})
+	require.NoError(t, err)
+	sm := shamap.New(shamap.TypeState)
+	for rootBranch := range shamap.BranchFactor {
+		for childBranch := range shamap.BranchFactor {
+			var key [32]byte
+			key[0] = byte(rootBranch<<4 | childBranch)
+			key[31] = byte(childBranch + 1)
+			data := make([]byte, 12)
+			data[10] = byte(rootBranch)
+			data[11] = byte(childBranch + 1)
+			require.NoError(t, sm.Put(key, data))
+		}
+	}
+	root := persistVerificationSHAMap(t, db, sm)
+	rootNode, _, err := svc.loadStoredSHAMapNode(
+		t.Context(),
+		storedSHAMapNode{hash: root},
+		shamap.TypeState,
+	)
+	require.NoError(t, err)
+	inner, ok := rootNode.(shamap.InnerNodeReader)
+	require.True(t, ok)
+	rootChildren := make([]nodestore.Hash256, 0, shamap.BranchFactor)
+	for branch := range shamap.BranchFactor {
+		child, childErr := inner.ChildHash(branch)
+		require.NoError(t, childErr)
+		rootChildren = append(rootChildren, nodestore.Hash256(child))
+	}
+	return svc, db, root, rootChildren
+}
+
+func storePrefixedVerificationNode(
+	t *testing.T,
+	db nodestore.Database,
+	data []byte,
+) [32]byte {
+	t.Helper()
+	node, err := shamap.DeserializeFromPrefix(data)
+	require.NoError(t, err)
+	hash := node.Hash()
+	require.NoError(t, db.Store(t.Context(), &nodestore.Node{
+		Type: nodestore.NodeAccount,
+		Hash: nodestore.Hash256(hash),
+		Data: data,
+	}))
+	return hash
+}
+
+func prefixedInnerVerificationNode(branch int, child [32]byte) []byte {
+	data := make([]byte, 4+shamap.BranchFactor*32)
+	copy(data, protocol.HashPrefixInnerNode().Bytes())
+	copy(data[4+branch*32:4+(branch+1)*32], child[:])
+	return data
+}
+
+func persistVerificationSHAMap(
+	t *testing.T,
+	db nodestore.Database,
+	sm *shamap.SHAMap,
+) [32]byte {
+	t.Helper()
+	batch, err := sm.FlushDirty()
+	require.NoError(t, err)
+	nodes := make([]*nodestore.Node, 0, len(batch.Entries))
+	for _, entry := range batch.Entries {
+		nodes = append(nodes, &nodestore.Node{
+			Type:      nodestore.NodeAccount,
+			Hash:      nodestore.Hash256(entry.Hash),
+			Data:      entry.Data,
+			LedgerSeq: entry.LedgerSeq,
+		})
+	}
+	require.NoError(t, db.StoreBatch(t.Context(), nodes))
+	root, err := sm.Hash()
+	require.NoError(t, err)
+	return root
 }
 
 func (d *parallelFetchDatabase) peakFetches() int {
@@ -498,9 +724,259 @@ func TestService_FastLoadReplacesSameHeightOnlyAfterTrustedQuorum(t *testing.T) 
 	}
 }
 
-func TestService_VerifyStoredSHAMapWalksRootBranchesInParallel(t *testing.T) {
+func TestService_VerifyStoredSHAMapRebalancesBelowRoot(t *testing.T) {
 	ctx := context.Background()
 	db := nodestore.NewKVDatabase(memorydb.New(), "parallel-fast-load", 10_000, time.Hour)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	svc, err := New(Config{
+		NodeStore:       db,
+		FastLoadWorkers: 4,
+	})
+	require.NoError(t, err)
+
+	sm := shamap.New(shamap.TypeState)
+	for branch := range shamap.BranchFactor {
+		var key [32]byte
+		key[0] = byte(branch)
+		key[31] = byte(branch + 1)
+		data := make([]byte, 12)
+		data[11] = byte(branch + 1)
+		require.NoError(t, sm.Put(key, data))
+	}
+	root := persistVerificationSHAMap(t, db, sm)
+	rootNode, _, err := svc.loadStoredSHAMapNode(
+		ctx,
+		storedSHAMapNode{hash: root},
+		shamap.TypeState,
+	)
+	require.NoError(t, err)
+	inner, ok := rootNode.(shamap.InnerNodeReader)
+	require.True(t, ok)
+	require.False(t, inner.IsEmptyBranch(0))
+	rootChild, err := inner.ChildHash(0)
+	require.NoError(t, err)
+	frontier, _, err := svc.buildStoredSHAMapFrontier(
+		ctx,
+		[][32]byte{rootChild},
+		4*storedSHAMapFrontierTasksPerWorker,
+		shamap.TypeState,
+		svc.nodeStore.Fetch,
+		nil,
+	)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(frontier), 4*storedSHAMapFrontierTasksPerWorker)
+
+	tracked := &parallelFetchDatabase{
+		Database: db,
+		unblocked: map[nodestore.Hash256]struct{}{
+			nodestore.Hash256(root):      {},
+			nodestore.Hash256(rootChild): {},
+		},
+		started: make(chan struct{}),
+	}
+	svc.nodeStore = tracked
+	walkCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	err = svc.verifyStoredSHAMap(walkCtx, root, shamap.TypeState)
+	require.NoError(t, err, "peak concurrent fetches: %d", tracked.peakFetches())
+	require.Greater(t, tracked.peakFetches(), 1)
+	require.LessOrEqual(t, tracked.peakFetches(), 4)
+}
+
+func TestService_VerifyStoredSHAMapUsesUncachedReads(t *testing.T) {
+	svc, db, root, expectedNodes, _ := newStoredVerificationFixture(t, shamap.BranchFactor)
+	tracked := &uncachedTrackingDatabase{Database: db}
+	svc.nodeStore = tracked
+	svc.config.FastLoadWorkers = 4
+	before := db.Stats()
+
+	require.NoError(t, svc.verifyStoredSHAMap(t.Context(), root, shamap.TypeState))
+
+	fetches, uncached := tracked.counts()
+	require.Zero(t, fetches)
+	require.EqualValues(t, expectedNodes, uncached)
+	after := db.Stats()
+	require.Equal(t, before.CacheSize, after.CacheSize)
+	require.Equal(t, before.CacheHits, after.CacheHits)
+	require.Equal(t, before.CacheMisses, after.CacheMisses)
+	require.Equal(t, before.Reads+expectedNodes, after.Reads)
+}
+
+func TestService_VerifyStoredSHAMapFallsBackToFetch(t *testing.T) {
+	svc, db, root, expectedNodes, _ := newStoredVerificationFixture(t, shamap.BranchFactor)
+	tracked := &fallbackTrackingDatabase{Database: db}
+	svc.nodeStore = tracked
+	svc.config.FastLoadWorkers = 4
+
+	require.NoError(t, svc.verifyStoredSHAMap(t.Context(), root, shamap.TypeState))
+	require.EqualValues(t, expectedNodes, tracked.count())
+}
+
+func TestService_VerifyStoredSHAMapUncachedReadsPreserveIntegrityChecks(t *testing.T) {
+	tests := []struct {
+		name    string
+		rewrite func(rootData []byte) func(nodestore.Hash256, []byte) ([]byte, error)
+		want    string
+	}{
+		{
+			name: "content hash",
+			rewrite: func(rootData []byte) func(nodestore.Hash256, []byte) ([]byte, error) {
+				return func(nodestore.Hash256, []byte) ([]byte, error) {
+					return rootData, nil
+				}
+			},
+			want: "invalid content hash",
+		},
+		{
+			name: "missing node",
+			rewrite: func([]byte) func(nodestore.Hash256, []byte) ([]byte, error) {
+				return func(nodestore.Hash256, []byte) ([]byte, error) {
+					return nil, nil
+				}
+			},
+			want: "is missing",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			svc, db, root, _, _ := newStoredVerificationFixture(t, 1)
+			raw := db.(interface {
+				FetchDataUncached(context.Context, nodestore.Hash256) ([]byte, error)
+			})
+			rootData, err := raw.FetchDataUncached(t.Context(), nodestore.Hash256(root))
+			require.NoError(t, err)
+			tracked := &uncachedTrackingDatabase{Database: db}
+			tracked.rewrite = func(hash nodestore.Hash256, data []byte) ([]byte, error) {
+				if hash == nodestore.Hash256(root) {
+					return data, nil
+				}
+				return test.rewrite(rootData)(hash, data)
+			}
+			svc.nodeStore = tracked
+			svc.config.FastLoadWorkers = 4
+
+			err = svc.verifyStoredSHAMap(t.Context(), root, shamap.TypeState)
+			require.ErrorContains(t, err, test.want)
+			fetches, uncached := tracked.counts()
+			require.Zero(t, fetches)
+			require.Greater(t, uncached, 1)
+		})
+	}
+}
+
+func TestService_VerifyStoredSHAMapPreservesLeafAndDepthChecks(t *testing.T) {
+	t.Run("wrong leaf type", func(t *testing.T) {
+		db := nodestore.NewKVDatabase(memorydb.New(), "wrong-leaf", 32, time.Hour)
+		t.Cleanup(func() { require.NoError(t, db.Close()) })
+		txData := append(protocol.HashPrefixTransactionID().Bytes(), []byte("transaction!")...)
+		txHash := storePrefixedVerificationNode(t, db, txData)
+		root := storePrefixedVerificationNode(t, db, prefixedInnerVerificationNode(0, txHash))
+		svc, err := New(Config{
+			NodeStore:       db,
+			FastLoadWorkers: 1,
+		})
+		require.NoError(t, err)
+
+		err = svc.verifyStoredSHAMap(t.Context(), root, shamap.TypeState)
+		require.ErrorContains(t, err, "state tree contains")
+		require.ErrorContains(t, err, "transaction")
+	})
+
+	t.Run("excessive depth", func(t *testing.T) {
+		db := nodestore.NewKVDatabase(memorydb.New(), "excessive-depth", 128, time.Hour)
+		t.Cleanup(func() { require.NoError(t, db.Close()) })
+		leafData := make([]byte, 4+12+32)
+		copy(leafData, protocol.HashPrefixLeafNode().Bytes())
+		leafData[4] = 1
+		leafData[len(leafData)-1] = 1
+		root := storePrefixedVerificationNode(t, db, leafData)
+		for range 65 {
+			root = storePrefixedVerificationNode(t, db, prefixedInnerVerificationNode(0, root))
+		}
+		svc, err := New(Config{
+			NodeStore:       db,
+			FastLoadWorkers: 1,
+		})
+		require.NoError(t, err)
+
+		err = svc.verifyStoredSHAMap(t.Context(), root, shamap.TypeState)
+		require.ErrorContains(t, err, "exceeds maximum depth")
+	})
+}
+
+func TestService_VerifyStoredSHAMapWorkerCountsProduceIdenticalTotals(t *testing.T) {
+	svc, _, root, expectedNodes, expectedBranches := newStoredVerificationFixture(
+		t,
+		shamap.BranchFactor,
+	)
+	startedAt := time.Date(2026, time.July, 28, 20, 0, 0, 0, time.UTC)
+	for _, workers := range []int{1, 8} {
+		t.Run(fmt.Sprintf("%d workers", workers), func(t *testing.T) {
+			capture, logger := newVerificationLogCapture()
+			svc.logger = logger.Named(xrpllog.PartitionLedger)
+			svc.config.FastLoadWorkers = workers
+			require.NoError(t, svc.verifyStoredSHAMapWithTicks(
+				t.Context(),
+				root,
+				shamap.TypeState,
+				startedAt,
+				func() time.Time { return startedAt.Add(time.Second) },
+				nil,
+			))
+
+			records := decodeVerificationLogs(t, capture)
+			terminal := records[len(records)-1]
+			require.Equal(t, "stored SHAMap verification complete", terminal.Message)
+			require.Equal(t, expectedNodes, terminal.NodesChecked)
+			require.Equal(t, expectedBranches, terminal.BranchesComplete)
+			require.Equal(t, expectedBranches, terminal.BranchesTotal)
+			require.EqualValues(t, workers, terminal.Workers)
+		})
+	}
+}
+
+func TestService_VerifyStoredSHAMapCancelsSaturatedWorkers(t *testing.T) {
+	svc, db, root, rootChildren := newParallelStoredVerificationFixture(t)
+	branchNode, _, err := svc.loadStoredSHAMapNode(
+		t.Context(),
+		storedSHAMapNode{hash: [32]byte(rootChildren[0]), depth: 1},
+		shamap.TypeState,
+	)
+	require.NoError(t, err)
+	inner, ok := branchNode.(shamap.InnerNodeReader)
+	require.True(t, ok)
+	failingChild, err := inner.ChildHash(0)
+	require.NoError(t, err)
+	unblocked := make(map[nodestore.Hash256]struct{}, len(rootChildren))
+	for _, child := range rootChildren {
+		unblocked[child] = struct{}{}
+	}
+	fetchErr := errors.New("corrupt descendant")
+	tracked := &cancelingVerificationDatabase{
+		Database:  db,
+		root:      nodestore.Hash256(root),
+		unblocked: unblocked,
+		fail:      nodestore.Hash256(failingChild),
+		err:       fetchErr,
+		expected:  4,
+		ready:     make(chan struct{}),
+	}
+	svc.nodeStore = tracked
+	svc.config.FastLoadWorkers = 4
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	err = svc.verifyStoredSHAMap(ctx, root, shamap.TypeState)
+	require.ErrorIs(t, err, fetchErr)
+	active, peak := tracked.fetchState()
+	require.Zero(t, active)
+	require.Equal(t, 4, peak)
+}
+
+func TestService_StoredSHAMapFrontierIsBounded(t *testing.T) {
+	ctx := t.Context()
+	db := nodestore.NewKVDatabase(memorydb.New(), "bounded-frontier", 10_000, time.Hour)
 	t.Cleanup(func() { require.NoError(t, db.Close()) })
 	svc, err := New(Config{
 		Standalone:    true,
@@ -512,12 +988,14 @@ func TestService_VerifyStoredSHAMapWalksRootBranchesInParallel(t *testing.T) {
 	require.NoError(t, svc.Start())
 	t.Cleanup(svc.Stop)
 
-	for branch := range shamap.BranchFactor {
+	for i := range 256 {
 		var key [32]byte
-		key[0] = byte(branch << 4)
-		key[31] = byte(branch + 1)
+		key[0] = byte(i / shamap.BranchFactor)
+		key[1] = byte((i % shamap.BranchFactor) << 4)
+		key[31] = byte(i)
 		data := make([]byte, 12)
-		data[11] = byte(branch + 1)
+		data[10] = byte(i >> 8)
+		data[11] = byte(i)
 		require.NoError(t, svc.openLedger.Insert(keylet.Keylet{Key: key}, data))
 	}
 	_, err = svc.AcceptLedger(ctx)
@@ -525,18 +1003,197 @@ func TestService_VerifyStoredSHAMapWalksRootBranchesInParallel(t *testing.T) {
 	svc.FlushPersists()
 	root, err := svc.GetValidatedLedger().StateMapHash()
 	require.NoError(t, err)
+	rootNode, _, err := svc.loadStoredSHAMapNode(
+		ctx,
+		storedSHAMapNode{hash: root},
+		shamap.TypeState,
+	)
+	require.NoError(t, err)
+	inner, ok := rootNode.(shamap.InnerNodeReader)
+	require.True(t, ok)
+	require.False(t, inner.IsEmptyBranch(0))
+	rootChild, err := inner.ChildHash(0)
+	require.NoError(t, err)
 
-	tracked := &parallelFetchDatabase{
-		Database: db,
-		root:     nodestore.Hash256(root),
-		started:  make(chan struct{}),
+	const target = 32
+	frontier, outstanding, err := svc.buildStoredSHAMapFrontier(
+		ctx,
+		[][32]byte{rootChild},
+		target,
+		shamap.TypeState,
+		svc.nodeStore.Fetch,
+		nil,
+	)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(frontier), target)
+	require.LessOrEqual(t, len(frontier), target+shamap.BranchFactor-1)
+	require.EqualValues(t, len(frontier), outstanding[0])
+}
+
+func TestService_StoredSHAMapFrontierSplitsEveryRootBranch(t *testing.T) {
+	db := nodestore.NewKVDatabase(memorydb.New(), "fair-frontier", 256, time.Hour)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	svc, err := New(Config{NodeStore: db})
+	require.NoError(t, err)
+	sm := shamap.New(shamap.TypeState)
+	for rootBranch := range shamap.BranchFactor {
+		for childBranch := range 2 {
+			var key [32]byte
+			key[0] = byte(rootBranch<<4 | childBranch)
+			key[31] = byte(rootBranch*2 + childBranch + 1)
+			data := make([]byte, 12)
+			data[11] = key[31]
+			require.NoError(t, sm.Put(key, data))
+		}
 	}
-	svc.nodeStore = tracked
-	walkCtx, cancel := context.WithTimeout(ctx, time.Second)
-	defer cancel()
-	require.NoError(t, svc.verifyStoredSHAMap(walkCtx, root, shamap.TypeState))
-	require.Greater(t, tracked.peakFetches(), 1)
-	require.LessOrEqual(t, tracked.peakFetches(), shamap.BranchFactor)
+	root := persistVerificationSHAMap(t, db, sm)
+	rootNode, _, err := svc.loadStoredSHAMapNode(
+		t.Context(),
+		storedSHAMapNode{hash: root},
+		shamap.TypeState,
+	)
+	require.NoError(t, err)
+	inner, ok := rootNode.(shamap.InnerNodeReader)
+	require.True(t, ok)
+	branches := make([][32]byte, 0, shamap.BranchFactor)
+	for branch := range shamap.BranchFactor {
+		child, childErr := inner.ChildHash(branch)
+		require.NoError(t, childErr)
+		branches = append(branches, child)
+	}
+
+	frontier, outstanding, err := svc.buildStoredSHAMapFrontier(
+		t.Context(),
+		branches,
+		32,
+		shamap.TypeState,
+		svc.nodeStore.Fetch,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, frontier, 32)
+	for branch, count := range outstanding {
+		require.EqualValues(t, 2, count, "root branch %d was not split", branch)
+	}
+}
+
+func TestService_StoredSHAMapFrontierRedistributesUnusedCapacity(t *testing.T) {
+	db := nodestore.NewKVDatabase(memorydb.New(), "imbalanced-frontier", 2_048, time.Hour)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	svc, err := New(Config{NodeStore: db})
+	require.NoError(t, err)
+	sm := shamap.New(shamap.TypeState)
+	for rootBranch := range shamap.BranchFactor - 1 {
+		var key [32]byte
+		key[0] = byte(rootBranch << 4)
+		key[31] = byte(rootBranch + 1)
+		data := make([]byte, 12)
+		data[11] = key[31]
+		require.NoError(t, sm.Put(key, data))
+	}
+	for i := range 1_024 {
+		var seed [8]byte
+		seed[0] = byte(i >> 8)
+		seed[1] = byte(i)
+		key := sha512half.Sum(seed[:])
+		key[0] = 0xf0 | key[0]&0x0f
+		data := make([]byte, 12)
+		data[10] = seed[0]
+		data[11] = seed[1]
+		require.NoError(t, sm.Put(key, data))
+	}
+	root := persistVerificationSHAMap(t, db, sm)
+	rootNode, _, err := svc.loadStoredSHAMapNode(
+		t.Context(),
+		storedSHAMapNode{hash: root},
+		shamap.TypeState,
+	)
+	require.NoError(t, err)
+	inner, ok := rootNode.(shamap.InnerNodeReader)
+	require.True(t, ok)
+	branches := make([][32]byte, 0, shamap.BranchFactor)
+	for branch := range shamap.BranchFactor {
+		child, childErr := inner.ChildHash(branch)
+		require.NoError(t, childErr)
+		branches = append(branches, child)
+	}
+
+	const target = 4 * storedSHAMapFrontierTasksPerWorker
+	frontier, outstanding, err := svc.buildStoredSHAMapFrontier(
+		t.Context(),
+		branches,
+		target,
+		shamap.TypeState,
+		svc.nodeStore.Fetch,
+		nil,
+	)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(frontier), target)
+	for branch := range shamap.BranchFactor - 1 {
+		require.Zero(t, outstanding[branch])
+	}
+	require.EqualValues(t, len(frontier), outstanding[shamap.BranchFactor-1])
+}
+
+func BenchmarkService_VerifyStoredSHAMapWorkers(b *testing.B) {
+	ctx := b.Context()
+	db := nodestore.NewKVDatabase(memorydb.New(), "verification-benchmark", 32_768, time.Hour)
+	b.Cleanup(func() { require.NoError(b, db.Close()) })
+	svc, err := New(Config{
+		Standalone:    true,
+		GenesisConfig: genesis.DefaultConfig(),
+		NodeStore:     db,
+		SHAMapFamily:  backend.New(db),
+	})
+	require.NoError(b, err)
+	require.NoError(b, svc.Start())
+	b.Cleanup(svc.Stop)
+
+	for i := range 16_384 {
+		var seed [8]byte
+		seed[0] = byte(i >> 24)
+		seed[1] = byte(i >> 16)
+		seed[2] = byte(i >> 8)
+		seed[3] = byte(i)
+		key := sha512half.Sum(seed[:])
+		data := make([]byte, 12)
+		data[8] = seed[0]
+		data[9] = seed[1]
+		data[10] = seed[2]
+		data[11] = seed[3]
+		require.NoError(b, svc.openLedger.Insert(keylet.Keylet{Key: key}, data))
+	}
+	_, err = svc.AcceptLedger(ctx)
+	require.NoError(b, err)
+	svc.FlushPersists()
+	root, err := svc.GetValidatedLedger().StateMapHash()
+	require.NoError(b, err)
+	var nodes uint64
+	require.NoError(b, svc.walkStoredSHAMap(
+		ctx,
+		root,
+		shamap.TypeState,
+		func([32]byte, *nodestore.Node) error {
+			nodes++
+			return nil
+		},
+	))
+
+	for _, workers := range []int{8, 16, 32, 64} {
+		b.Run(fmt.Sprintf("workers=%d", workers), func(b *testing.B) {
+			svc.config.FastLoadWorkers = workers
+			b.ResetTimer()
+			startedAt := time.Now()
+			for range b.N {
+				require.NoError(b, svc.verifyStoredSHAMap(ctx, root, shamap.TypeState))
+			}
+			b.StopTimer()
+			b.ReportMetric(
+				float64(uint64(b.N)*nodes)/time.Since(startedAt).Seconds(),
+				"nodes/s",
+			)
+		})
+	}
 }
 
 func TestService_VerifyStoredSHAMapReportsConcurrentSuccess(t *testing.T) {
@@ -565,12 +1222,26 @@ func TestService_VerifyStoredSHAMapReportsConcurrentSuccess(t *testing.T) {
 	require.Equal(t, "state", records[0].MapType)
 	require.Equal(t, fmt.Sprintf("%x", root[:8]), records[0].Root)
 	require.Equal(t, expectedBranches, records[0].ActiveBranches)
+	require.EqualValues(t, resolveStoredSHAMapWorkers(0), records[0].Workers)
 	require.Equal(t, "stored SHAMap verification complete", records[1].Message)
 	require.Equal(t, "2s", records[1].Elapsed)
 	require.Equal(t, expectedNodes, records[1].NodesChecked)
 	require.Equal(t, expectedNodes/2, records[1].NodesPerSecond)
+	require.Equal(t, expectedNodes/2, records[1].IntervalNodesRate)
 	require.Equal(t, expectedBranches, records[1].BranchesComplete)
 	require.Equal(t, expectedBranches, records[1].BranchesTotal)
+	require.Zero(t, records[1].WorkerPoolSize)
+	require.Zero(t, records[1].ActiveWorkers)
+	require.Zero(t, records[1].IdleWorkers)
+	require.Zero(t, records[1].FrontierSize)
+	require.Equal(
+		t,
+		records[1].NodeStoreReadsBefore+expectedNodes,
+		records[1].NodeStoreReadsAfter,
+	)
+	require.Greater(t, records[1].NodeStoreReadBytesAfter, records[1].NodeStoreReadBytesBefore)
+	require.Equal(t, records[1].NodeCacheHitsBefore, records[1].NodeCacheHitsAfter)
+	require.Equal(t, records[1].NodeCacheMissesBefore, records[1].NodeCacheMissesAfter)
 }
 
 func TestService_VerifyStoredSHAMapReportsProgressAtCompletionBoundary(t *testing.T) {
@@ -590,22 +1261,32 @@ func TestService_VerifyStoredSHAMapReportsProgressAtCompletionBoundary(t *testin
 	))
 
 	records := decodeVerificationLogs(t, capture)
-	require.Len(t, records, 3)
+	require.Len(t, records, 2)
 	require.Equal(t, "stored SHAMap verification started", records[0].Message)
-	require.Equal(t, "stored SHAMap verification progress", records[1].Message)
+	require.Equal(t, "stored SHAMap verification complete", records[1].Message)
 	require.Equal(t, storedSHAMapVerificationLogInterval.String(), records[1].Elapsed)
 	require.Equal(t, expectedNodes, records[1].NodesChecked)
 	require.Equal(t, expectedBranches, records[1].BranchesComplete)
-	require.Equal(t, "stored SHAMap verification complete", records[2].Message)
+	require.Equal(
+		t,
+		expectedNodes/uint64(storedSHAMapVerificationLogInterval/time.Second),
+		records[1].IntervalNodesRate,
+	)
 }
 
 func TestService_VerifyStoredSHAMapRateLimitsProgressAndReportsCancellation(t *testing.T) {
-	svc, db, root, _, expectedBranches := newStoredVerificationFixture(t, 1)
+	svc, db, root, rootChildren := newParallelStoredVerificationFixture(t)
+	svc.config.FastLoadWorkers = 4
+	unblocked := make(map[nodestore.Hash256]struct{}, len(rootChildren))
+	for _, child := range rootChildren {
+		unblocked[child] = struct{}{}
+	}
 	blocked := &blockingVerificationDatabase{
-		Database: db,
-		root:     nodestore.Hash256(root),
-		started:  make(chan struct{}),
-		release:  make(chan struct{}),
+		Database:  db,
+		root:      nodestore.Hash256(root),
+		unblocked: unblocked,
+		started:   make(chan struct{}),
+		release:   make(chan struct{}),
 	}
 	svc.nodeStore = blocked
 	capture, logger := newVerificationLogCapture()
@@ -641,7 +1322,7 @@ func TestService_VerifyStoredSHAMapRateLimitsProgressAndReportsCancellation(t *t
 	require.Equal(t, "stored SHAMap verification started", records[0].Message)
 	require.Equal(t, "stored SHAMap verification progress", records[1].Message)
 	require.Equal(t, "15s", records[1].Elapsed)
-	require.EqualValues(t, 1, records[1].NodesChecked)
+	require.EqualValues(t, 1+len(rootChildren), records[1].NodesChecked)
 	require.Equal(t, "stored SHAMap verification progress", records[2].Message)
 	require.Equal(t, "30s", records[2].Elapsed)
 	require.GreaterOrEqual(t, records[2].NodesChecked, records[1].NodesChecked)
@@ -650,7 +1331,7 @@ func TestService_VerifyStoredSHAMapRateLimitsProgressAndReportsCancellation(t *t
 	require.Equal(t, "31s", records[3].Elapsed)
 	require.GreaterOrEqual(t, records[3].NodesChecked, records[2].NodesChecked)
 	require.Zero(t, records[3].BranchesComplete)
-	require.Equal(t, expectedBranches, records[3].BranchesTotal)
+	require.EqualValues(t, len(rootChildren), records[3].BranchesTotal)
 	require.Contains(t, records[3].VerificationError, context.Canceled.Error())
 }
 

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -77,6 +77,9 @@ type Config struct {
 	SHAMapFamily shamap.Family
 	// FastLoad restores the newest complete persisted ledger at startup.
 	FastLoad bool
+	// FastLoadWorkers controls persisted SHAMap verification concurrency.
+	// Zero selects an automatic value.
+	FastLoadWorkers int
 	// RelationalDB is the repository manager for transaction indexing (optional)
 	RelationalDB relationaldb.RepositoryManager
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -230,18 +230,19 @@ func Run(appConfig *config.Config, configPath string, standalone bool, startup s
 
 	// Initialize ledger service
 	cfg := service.Config{
-		Standalone:   standalone,
-		NodeSize:     appConfig.NodeSize,
-		FetchDepth:   effectivePeerFetchDepth(appConfig.GetFetchDepthUint32(), appConfig.NodeDB.OnlineDelete),
-		NetworkID:    uint32(networkID),
-		NodeStore:    db,
-		SHAMapFamily: nodeFamily,
-		FastLoad:     appConfig.NodeDB.FastLoad,
-		RelationalDB: repoManager,
-		Logger:       rootLogger,
-		Table:        amendmentTable,
-		TxQ:          &txqCfg,
-		Startup:      startup,
+		Standalone:      standalone,
+		NodeSize:        appConfig.NodeSize,
+		FetchDepth:      effectivePeerFetchDepth(appConfig.GetFetchDepthUint32(), appConfig.NodeDB.OnlineDelete),
+		NetworkID:       uint32(networkID),
+		NodeStore:       db,
+		SHAMapFamily:    nodeFamily,
+		FastLoad:        appConfig.NodeDB.FastLoad,
+		FastLoadWorkers: appConfig.NodeDB.FastLoadWorkers,
+		RelationalDB:    repoManager,
+		Logger:          rootLogger,
+		Table:           amendmentTable,
+		TxQ:             &txqCfg,
+		Startup:         startup,
 	}
 	cfg.GenesisConfig = genesisConfig
 	configuredFees := configuredLedgerLoadFees(appConfig)


### PR DESCRIPTION
## Summary

- bypass the decoded NodeStore cache during one-shot stored SHAMap verification while preserving the Pebble block cache and a safe `Fetch` fallback
- replace static root-branch ownership with a bounded, globally balanced verification frontier and configurable 1–64 worker pool (`0` selects an automatic CPU-based default)
- add worker/frontier/cache/read diagnostics, operator configuration, adversarial integrity and cancellation coverage, and 8/16/32/64-worker benchmark coverage

## Root cause

Verification read every node through the normal decoded-node LRU and permanently assigned each non-empty root branch to one goroutine. A full-tree scan therefore churned the runtime cache and could not redistribute work from small branches to workers blocked behind one large branch.

## Production-sized VM benchmark

| Workers | Overall rate | Final interval | CPU | Peak RSS |
|---:|---:|---:|---:|---:|
| 3 (automatic) | 24.0k nodes/s | 24–26k nodes/s | ~3 cores | ~3.2 GiB |
| 8 | 22.9k nodes/s | 24.6k nodes/s | 278% | 2.92 GiB |
| 16 | 22.4k nodes/s | 23.7k nodes/s | 281% | 2.93 GiB |
| 32 | 21.9k nodes/s | 22.4k nodes/s | 284% | 2.93 GiB |
| 64 | 22.5k nodes/s | 22.7k nodes/s | 285% | 3.13 GiB |

Observed baseline: 24.5k nodes/s and approximately 4.5 GiB peak RSS.

Results:

- decoded-cache counters remained unchanged in every trial, confirming that the verification walk no longer churns the decoded-node cache
- peak memory improved from approximately 4.5 GiB to 2.92–3.2 GiB
- the dynamic frontier kept every configured worker active
- the VM saturates at roughly three effective CPU cores; additional workers increase contention and do not improve throughput
- the automatic three-worker setting is appropriate for this VM; 8 is the highest explicit setting worth considering, while 16–64 should be avoided
- traversal throughput remains approximately equal to the 24.5k nodes/s baseline, so this implementation improves cache and memory behavior but does not materially shorten verification on this machine

## Validation

- [x] `just test`
- [x] `go test -race ./internal/ledger/service ./config ./internal/cli`
- [x] `just vet`
- [x] strict `golangci-lint run`
- [x] advisory `just lint`
- [x] `just build`
- [x] `just build-nocgo`
- [x] repeated imbalance, bounded-frontier, progress, and saturated-cancellation tests
- [x] synthetic memory benchmark at 8, 16, 32, and 64 workers
- [x] production-sized VM trials at automatic, 8, 16, 32, and 64 workers with CPU, peak RSS, cache behavior, and nodes/s
- [ ] material startup-time improvement (not observed on this VM)
- [ ] backend-read totals and post-verification runtime-access measurements

Fixes #1446