### PR TITLE
Fix validator relay queue saturation

### DIFF
--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -516,13 +516,10 @@ func (a *Adaptor) BroadcastValidation(validation *consensus.Validation) error {
 	return a.sender.BroadcastValidation(validation)
 }
 
-// RecordMessageSource records an inbound proposal or validation source.
 func (a *Adaptor) RecordMessageSource(suppressionHash [32]byte, peerID uint64) {
 	a.sender.RecordMessageSource(suppressionHash, peerID)
 }
 
-// PeersThatHave delegates to NetworkSender so higher layers can query without
-// importing the overlay.
 func (a *Adaptor) PeersThatHave(suppressionHash [32]byte) []uint64 {
 	return a.sender.PeersThatHave(suppressionHash)
 }

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -516,10 +516,22 @@ func (a *Adaptor) BroadcastValidation(validation *consensus.Validation) error {
 	return a.sender.BroadcastValidation(validation)
 }
 
+// RecordMessageSource records an inbound proposal or validation source.
+func (a *Adaptor) RecordMessageSource(suppressionHash [32]byte, peerID uint64) {
+	a.sender.RecordMessageSource(suppressionHash, peerID)
+}
+
 // PeersThatHave delegates to NetworkSender so higher layers can query without
-// importing the overlay. See NetworkSender.PeersThatHave.
+// importing the overlay.
 func (a *Adaptor) PeersThatHave(suppressionHash [32]byte) []uint64 {
 	return a.sender.PeersThatHave(suppressionHash)
+}
+
+func (a *Adaptor) MessageRelayedRecently(suppressionHash [32]byte) bool {
+	view, ok := a.sender.(interface {
+		MessageRelayedRecently([32]byte) bool
+	})
+	return ok && view.MessageRelayedRecently(suppressionHash)
 }
 
 // RelayProposal forwards a peer-originated proposal, excluding exceptPeer

--- a/internal/consensus/adaptor/fetchpack.go
+++ b/internal/consensus/adaptor/fetchpack.go
@@ -304,7 +304,7 @@ func (r *Router) tryFetchPackEscalation(il *inbound.Ledger) bool {
 	if err != nil {
 		return false
 	}
-	if err := r.adaptor.SendToPeer(peerID, frame); err != nil {
+	if err := r.adaptor.SendPriorityToPeer(peerID, frame); err != nil {
 		r.logger.Debug("fetch-pack request send failed",
 			"seq", il.Seq(), "err", err)
 		return false

--- a/internal/consensus/adaptor/fetchpack_test.go
+++ b/internal/consensus/adaptor/fetchpack_test.go
@@ -291,6 +291,41 @@ func TestTryFetchPackEscalation_NoChildIsNoOp(t *testing.T) {
 	}
 }
 
+type fetchPackPrioritySender struct {
+	noopSender
+	ordinary int
+	priority int
+}
+
+func (s *fetchPackPrioritySender) SendToPeer(uint64, []byte) error {
+	s.ordinary++
+	return nil
+}
+
+func (s *fetchPackPrioritySender) SendPriorityToPeer(uint64, []byte) error {
+	s.priority++
+	return nil
+}
+
+func TestTryFetchPackEscalationUsesAcquisitionLane(t *testing.T) {
+	adaptor := newTestAdaptor(t)
+	sender := &fetchPackPrioritySender{}
+	adaptor.sender = sender
+	svc := adaptor.LedgerService()
+	child := svc.GetClosedLedger()
+	require.NotNil(t, child)
+	parent, err := svc.GetLedgerByHash(child.ParentHash())
+	require.NoError(t, err)
+	require.NotNil(t, parent)
+
+	r := NewRouter(nil, adaptor, make(chan *peermanagement.InboundMessage, 1))
+	il := inbound.New(parent.Hash(), parent.Sequence(), 3, serveTestLogger())
+
+	require.True(t, r.tryFetchPackEscalation(il))
+	assert.Equal(t, 1, sender.priority)
+	assert.Zero(t, sender.ordinary)
+}
+
 // armFetchAcquisition registers one in-flight acquisition so the fetch-pack
 // reply handler's solicitation gate lets a pack through.
 func armFetchAcquisition(r *Router) {

--- a/internal/consensus/adaptor/manifest_emit.go
+++ b/internal/consensus/adaptor/manifest_emit.go
@@ -1,6 +1,7 @@
 package adaptor
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
@@ -127,6 +128,10 @@ func (r *Router) BroadcastLocalManifest() int {
 	}
 	if err := sender.BroadcastManifestFrames(frames); err != nil {
 		r.logger.Warn("broadcast local manifest failed", "error", err)
+		var fanoutErr *peermanagement.FanoutError
+		if errors.As(err, &fanoutErr) {
+			return fanoutErr.Attempted - fanoutErr.Failed
+		}
 		return 0
 	}
 	return len(peers)

--- a/internal/consensus/adaptor/network_sender.go
+++ b/internal/consensus/adaptor/network_sender.go
@@ -64,9 +64,11 @@ type NetworkSender interface {
 	// the overlay can charge it toward the eviction threshold. No-op for
 	// unknown peers; reason is a short stable label for logs.
 	IncPeerBadData(peerID uint64, reason string)
-	// PeersThatHave returns the peer IDs the overlay knows have the message
-	// keyed by suppressionHash (nil if unknown or aged out). The router feeds
-	// these known-havers into the reduce-relay slot on a duplicate arrival.
+	// RecordMessageSource records every inbound source of a proposal or
+	// validation, including duplicate arrivals.
+	RecordMessageSource(suppressionHash [32]byte, peerID uint64)
+	// PeersThatHave returns the accumulated inbound sources keyed by
+	// suppressionHash (nil if unknown or aged out).
 	PeersThatHave(suppressionHash [32]byte) []uint64
 	// ShouldShedLedgerRequest reports whether a ledger-BODY request (liBASE /
 	// liAS_NODE / liTX_NODE) from peerID should be dropped under load: peer
@@ -122,6 +124,7 @@ func (n *noopSender) SendPriorityToPeer(uint64, []byte) error                   
 func (n *noopSender) PeerSupportsReplay(uint64) bool                             { return false }
 func (n *noopSender) ReplayCapablePeersExcluding([]uint64, int) []uint64         { return nil }
 func (n *noopSender) IncPeerBadData(uint64, string)                              {}
+func (n *noopSender) RecordMessageSource([32]byte, uint64)                       {}
 func (n *noopSender) PeersThatHave([32]byte) []uint64                            { return nil }
 func (n *noopSender) ShouldShedLedgerRequest(uint64, bool) bool                  { return false }
 func (n *noopSender) PeerWithLedger([32]byte, uint32, uint64) (uint64, bool)     { return 0, false }

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -37,6 +37,12 @@ type peerSessionView interface {
 	IsPeerConnected(peermanagement.PeerID) bool
 }
 
+type peerValidationTerminator interface {
+	DisconnectPeer(peermanagement.PeerID) bool
+}
+
+var _ peerValidationTerminator = (*peermanagement.Overlay)(nil)
+
 type peerCountView interface {
 	PeerCount() int
 }
@@ -131,6 +137,13 @@ type Router struct {
 	// messages would accelerate selection and produce earlier squelches for
 	// the same traffic pattern.
 	messageSeen *messageSuppression
+	// validationWork verifies signatures outside the router goroutine. Trusted
+	// and untrusted work use separate bounded queues so untrusted traffic cannot
+	// occupy the trusted capacity.
+	validationWork                      *validationWorkLane
+	validationTrustedOverloadDisconnect atomic.Uint64
+	validationTrustedOverloadUnresolved atomic.Uint64
+	validationShedUntrusted             atomic.Uint64
 
 	// manifests is the validator manifest cache. Wired by the
 	// Components bootstrap so the router can apply inbound TMManifests
@@ -333,11 +346,8 @@ var serveWorkerCount = max(2, runtime.GOMAXPROCS(0)/2)
 
 const serveQueueDepth = 256
 
-// messageDedupTTL is how long a proposal/validation hash is
-// remembered for duplicate-detection purposes. 30s comfortably covers a
-// consensus round while aging out cross-round stragglers so the dedup
-// table doesn't grow unbounded under sustained gossip.
-const messageDedupTTL = 30 * time.Second
+// messageDedupTTL matches rippled's five-minute suppression hold.
+const messageDedupTTL = 300 * time.Second
 
 // messageDedupMaxEntries caps the dedup table size. One entry per
 // unique (validator, position, txSet, closeTime) tuple in a healthy
@@ -367,6 +377,18 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, inbox <-chan *peermana
 	// Wire the stash → acquisition hook so quorum decisions on unknown
 	// ledgers don't sit silently in pendingLedgerValidations.
 	if adaptor != nil {
+		if _, ok := engine.(consensus.VerifiedValidationProcessor); ok {
+			r.validationWork = newValidationWorkLane(
+				adaptor.VerifyValidation,
+				func(peerID peermanagement.PeerID) bool {
+					return r.peerSessions == nil || r.peerSessions.IsPeerConnected(peerID)
+				},
+				adaptor.IsTrusted,
+			)
+			r.validationWork.onUntrustedResultShed = func(count uint64) {
+				r.logUntrustedValidationSaturation("result", count)
+			}
+		}
 		if svc := adaptor.LedgerService(); svc != nil {
 			svc.SetOnPendingValidationStashed(r.armValidationStashAcquisition)
 		}
@@ -676,10 +698,17 @@ func (r *Router) Run(ctx context.Context) {
 	r.startServeWorkers(ctx)
 	r.startManifestWorker(ctx)
 	defer r.stopManifestWorker()
+	if r.validationWork != nil {
+		r.validationWork.start(ctx)
+		defer r.validationWork.stop()
+	}
 	ticker := time.NewTicker(inboundReplayDeltaTickInterval)
 	defer ticker.Stop()
 	r.drainPeerConnects()
 	for {
+		if !r.drainTrustedValidationResults(ctx) {
+			return
+		}
 		if !r.drainConsensusInbox(ctx) {
 			return
 		}
@@ -731,6 +760,13 @@ func (r *Router) Run(ctx context.Context) {
 			r.submitTxJob(msg)
 		case result := <-workLane.results():
 			r.handleAcquisitionWorkResult(result)
+		case result := <-r.trustedValidationWorkResults():
+			r.handleValidationWorkResult(result)
+		case result := <-r.untrustedValidationWorkResults():
+			if !r.drainTrustedValidationResults(ctx) {
+				return
+			}
+			r.handleValidationWorkResult(result)
 		case <-r.peerConnectWake:
 			r.drainPeerConnects()
 		case <-ticker.C:
@@ -741,6 +777,19 @@ func (r *Router) Run(ctx context.Context) {
 }
 
 const consensusDrainBatch = 32
+
+func (r *Router) drainTrustedValidationResults(ctx context.Context) bool {
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case result := <-r.trustedValidationWorkResults():
+			r.handleValidationWorkResult(result)
+		default:
+			return true
+		}
+	}
+}
 
 func (r *Router) drainConsensusInbox(ctx context.Context) bool {
 	for range consensusDrainBatch {

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -37,12 +37,6 @@ type peerSessionView interface {
 	IsPeerConnected(peermanagement.PeerID) bool
 }
 
-type peerValidationTerminator interface {
-	DisconnectPeer(peermanagement.PeerID) bool
-}
-
-var _ peerValidationTerminator = (*peermanagement.Overlay)(nil)
-
 type peerCountView interface {
 	PeerCount() int
 }
@@ -140,10 +134,9 @@ type Router struct {
 	// validationWork verifies signatures outside the router goroutine. Trusted
 	// and untrusted work use separate bounded queues so untrusted traffic cannot
 	// occupy the trusted capacity.
-	validationWork                      *validationWorkLane
-	validationTrustedOverloadDisconnect atomic.Uint64
-	validationTrustedOverloadUnresolved atomic.Uint64
-	validationShedUntrusted             atomic.Uint64
+	validationWork          *validationWorkLane
+	validationShedTrusted   atomic.Uint64
+	validationShedUntrusted atomic.Uint64
 
 	// manifests is the validator manifest cache. Wired by the
 	// Components bootstrap so the router can apply inbound TMManifests
@@ -349,11 +342,7 @@ const serveQueueDepth = 256
 // messageDedupTTL matches rippled's five-minute suppression hold.
 const messageDedupTTL = 300 * time.Second
 
-// messageDedupMaxEntries caps the dedup table size. One entry per
-// unique (validator, position, txSet, closeTime) tuple in a healthy
-// 100-validator round; 4096 gives ~40x headroom before the trim
-// fires. Cheap memory — 32-byte key + 24-byte time.
-const messageDedupMaxEntries = 4096
+const messageDedupSweepThreshold = 4096
 
 // NewRouter creates a new Router.
 func NewRouter(engine consensus.Engine, adaptor *Adaptor, inbox <-chan *peermanagement.InboundMessage) *Router {
@@ -369,7 +358,7 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, inbox <-chan *peermana
 		replayer:           inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
 		fetchTracker:       inbound.NewTracker(),
 		fetchPacks:         newFetchPackCache(),
-		messageSeen:        newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
+		messageSeen:        newMessageSuppression(messageDedupTTL, messageDedupSweepThreshold),
 		txSetAcquire:       make(map[consensus.TxSetID]*txSetAcquireState),
 		txSetRetryKnobs:    defaultTxSetRetryKnobs(),
 		seqHash:            make(map[uint32]ledgerHashEntry),
@@ -385,7 +374,10 @@ func NewRouter(engine consensus.Engine, adaptor *Adaptor, inbox <-chan *peermana
 				},
 				adaptor.IsTrusted,
 			)
-			r.validationWork.onUntrustedResultShed = func(count uint64) {
+			r.validationWork.onUntrustedResultShed = func(result validationWorkResult, count uint64) {
+				if result.validation != nil {
+					r.messageSeen.allowRetry(result.validation.SuppressionHash)
+				}
 				r.logUntrustedValidationSaturation("result", count)
 			}
 		}

--- a/internal/consensus/adaptor/router_dedup.go
+++ b/internal/consensus/adaptor/router_dedup.go
@@ -101,7 +101,7 @@ func appendVLPrefix(buf []byte, n int) []byte {
 type messageSuppression struct {
 	mu sync.Mutex
 	// seen maps a suppression hash to the most recent observation time.
-	// TTL-evicted on observe when at maxSize.
+	// TTL-evicted on observe once the sweep threshold is reached.
 	seen map[[32]byte]time.Time
 	// peers maps a suppression hash to the set of peer IDs known to
 	// already have the message. Populated both on inbound observe (the
@@ -109,22 +109,22 @@ type messageSuppression struct {
 	// broadcast (the recipient now has it because we sent it to them).
 	// Used by validator-list broadcast to skip peers known to already have
 	// the same content.
-	peers   map[[32]byte]map[uint64]struct{}
-	ttl     time.Duration
-	maxSize int
-	now     func() time.Time
+	peers          map[[32]byte]map[uint64]struct{}
+	ttl            time.Duration
+	sweepThreshold int
+	nextSweep      time.Time
+	now            func() time.Time
 }
 
 // newMessageSuppression returns a dedup tracker. ttl bounds how long a
-// hash is remembered; maxSize caps memory for adversarial traffic
-// (when the set is full we trim half the oldest entries).
-func newMessageSuppression(ttl time.Duration, maxSize int) *messageSuppression {
+// hash is remembered; sweepThreshold controls when stale-entry scans begin.
+func newMessageSuppression(ttl time.Duration, sweepThreshold int) *messageSuppression {
 	return &messageSuppression{
-		seen:    make(map[[32]byte]time.Time),
-		peers:   make(map[[32]byte]map[uint64]struct{}),
-		ttl:     ttl,
-		maxSize: maxSize,
-		now:     time.Now,
+		seen:           make(map[[32]byte]time.Time),
+		peers:          make(map[[32]byte]map[uint64]struct{}),
+		ttl:            ttl,
+		sweepThreshold: sweepThreshold,
+		now:            time.Now,
 	}
 }
 
@@ -143,9 +143,8 @@ func (s *messageSuppression) observe(hash [32]byte) (firstSeen bool, lastSeenAt 
 
 	now := s.now()
 
-	// Evict stale entries if we're at capacity. A cheap scan rather
-	// than a formal LRU — the tracker is a cache, not a hot path.
-	if len(s.seen) >= s.maxSize {
+	if len(s.seen) >= s.sweepThreshold &&
+		(s.nextSweep.IsZero() || !now.Before(s.nextSweep)) {
 		cutoff := now.Add(-s.ttl)
 		for h, seenAt := range s.seen {
 			if seenAt.Before(cutoff) {
@@ -153,17 +152,11 @@ func (s *messageSuppression) observe(hash [32]byte) (firstSeen bool, lastSeenAt 
 				delete(s.peers, h)
 			}
 		}
-		if len(s.seen) >= s.maxSize {
-			i := 0
-			for h := range s.seen {
-				if i >= s.maxSize/2 {
-					break
-				}
-				delete(s.seen, h)
-				delete(s.peers, h)
-				i++
-			}
+		sweepInterval := s.ttl / 4
+		if sweepInterval <= 0 {
+			sweepInterval = s.ttl
 		}
+		s.nextSweep = now.Add(sweepInterval)
 	}
 
 	if seenAt, ok := s.seen[hash]; ok && now.Sub(seenAt) < s.ttl {
@@ -172,6 +165,12 @@ func (s *messageSuppression) observe(hash [32]byte) (firstSeen bool, lastSeenAt 
 	}
 	s.seen[hash] = now
 	return true, time.Time{}
+}
+
+func (s *messageSuppression) allowRetry(hash [32]byte) {
+	s.mu.Lock()
+	delete(s.seen, hash)
+	s.mu.Unlock()
 }
 
 func (s *messageSuppression) seenRecently(hash [32]byte) bool {

--- a/internal/consensus/adaptor/router_dedup_test.go
+++ b/internal/consensus/adaptor/router_dedup_test.go
@@ -93,3 +93,20 @@ func TestMessageSuppression_RecordPeerAndHasHash(t *testing.T) {
 	assert.False(t, s.peerHasHash(other, 42),
 		"peer-set must be scoped per hash")
 }
+
+func TestMessageSuppression_DoesNotEvictLiveEntriesAtSweepThreshold(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	s := newMessageSuppression(5*time.Minute, 4)
+	s.now = func() time.Time { return now }
+
+	first := [32]byte{1}
+	firstSeen, _ := s.observe(first)
+	assert.True(t, firstSeen)
+	for i := byte(2); i <= 8; i++ {
+		hash := [32]byte{i}
+		s.observe(hash)
+	}
+
+	firstSeen, _ = s.observe(first)
+	assert.False(t, firstSeen)
+}

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -197,22 +197,19 @@ func (r *Router) handleProposal(msg *peermanagement.InboundMessage) {
 	// can thread it to Overlay's reverse index without recomputing.
 	suppressionHash := hashProposalSuppression(proposal)
 	proposal.SuppressionHash = suppressionHash
-	firstSeen, lastSeen := r.messageSeen.observe(suppressionHash)
+	r.adaptor.RecordMessageSource(suppressionHash, originPeer)
+	firstSeen, _ := r.messageSeen.observe(suppressionHash)
 
 	// Drop duplicates before the engine path (re-running OnProposal
 	// just re-verifies ECDSA). Still feed the IDLED-gated relay slot
 	// on dupes for squelch accounting.
 	//
-	// Deliberate deviation: rippled tracks suppression per (hash, peer),
-	// re-running the handler so per-peer slot entries grow on each new
-	// sender. Our dedup is hash-only, so a second peer's copy is dropped
-	// at the gate. Quorum/position tracking unaffected (first arrival
-	// counts the validator); reduce-relay accuracy is partly compensated
-	// via PeersThatHave + UpdateRelaySlot below.
+	// Rippled counts a duplicate for reduce-relay only after the first copy
+	// was relayed. Sources received before that point are accumulated and
+	// counted atomically by RelayFromValidator.
 	if !firstSeen {
-		if time.Since(lastSeen) < peermanagement.Idled {
-			seenPeers := r.adaptor.PeersThatHave(suppressionHash)
-			r.adaptor.UpdateRelaySlot(proposal.SigningPubKey[:], originPeer, seenPeers)
+		if r.adaptor.MessageRelayedRecently(suppressionHash) {
+			r.adaptor.UpdateRelaySlot(proposal.SigningPubKey[:], originPeer, nil)
 		}
 		return
 	}
@@ -270,7 +267,8 @@ func (r *Router) handleValidation(msg *peermanagement.InboundMessage) {
 	// validations signed outside our UNL here, before the engine spends
 	// CPU verifying the signature. rippled's PeerImp does the same under
 	// RELAY_UNTRUSTED_VALIDATIONS == -1.
-	if r.adaptor.DropUntrustedValidations() && !r.adaptor.IsTrusted(validation.NodeID) {
+	trusted := r.adaptor.IsTrusted(validation.NodeID)
+	if r.adaptor.DropUntrustedValidations() && !trusted {
 		return
 	}
 
@@ -287,30 +285,177 @@ func (r *Router) handleValidation(msg *peermanagement.InboundMessage) {
 	// path can thread it to Overlay's reverse index without recomputing.
 	suppressionHash := hashValidationSuppression(val.Validation)
 	validation.SuppressionHash = suppressionHash
-	firstSeen, lastSeen := r.messageSeen.observe(suppressionHash)
+	r.adaptor.RecordMessageSource(suppressionHash, originPeer)
+	firstSeen, _ := r.messageSeen.observe(suppressionHash)
 
 	// Drop duplicates before the engine path (re-running OnValidation
 	// just re-verifies ECDSA, dominating CPU under gossip fan-out).
 	// Still update the relay slot for squelch accounting.
 	//
-	// Deliberate deviation: rippled's per-(hash, peer) suppression
-	// re-processes new senders; our hash-only dedup drops them at the
-	// gate. See handleProposal for the full rationale.
+	// Sources received before the verified first relay are accumulated by the
+	// overlay. Later duplicates feed only their current origin into the slot.
 	if !firstSeen {
-		if time.Since(lastSeen) < peermanagement.Idled {
-			seenPeers := r.adaptor.PeersThatHave(suppressionHash)
-			r.adaptor.UpdateRelaySlot(validation.SigningPubKey[:], originPeer, seenPeers)
+		if r.adaptor.MessageRelayedRecently(suppressionHash) {
+			r.adaptor.UpdateRelaySlot(validation.SigningPubKey[:], originPeer, nil)
 		}
 		return
 	}
 
+	origin, tracking := r.validationPeerContext(msg.PeerID)
+	if !trusted && (tracking == peermanagement.PeerTrackingDiverged || r.isLoadedLocal()) {
+		return
+	}
+
+	if _, ok := r.engine.(consensus.VerifiedValidationProcessor); !ok {
+		r.handleLegacyValidation(validation, originPeer, msg.PeerID)
+		return
+	}
+
+	work := validationWork{
+		validation: validation,
+		origin:     origin,
+		trusted:    trusted,
+	}
+	r.submitValidationWork(work)
+}
+
+type validationWorkAdmissionOutcome uint8
+
+const (
+	validationWorkQueued validationWorkAdmissionOutcome = iota
+	validationWorkProcessedSynchronously
+	validationWorkShedUntrusted
+	validationWorkDisconnectedTrustedPeer
+	validationWorkTrustedOverloadUnresolved
+	validationWorkStopped
+)
+
+const validationSaturationLogInterval = 64
+
+func (r *Router) submitValidationWork(work validationWork) validationWorkAdmissionOutcome {
+	if r.validationWork != nil && r.validationWork.running() {
+		switch r.validationWork.submit(work) {
+		case validationQueueAccepted:
+			return validationWorkQueued
+		case validationQueueStopped:
+			return validationWorkStopped
+		}
+		if !work.trusted {
+			count := r.validationShedUntrusted.Add(1)
+			r.logUntrustedValidationSaturation("job", count)
+			return validationWorkShedUntrusted
+		}
+
+		terminator, ok := r.peerSessions.(peerValidationTerminator)
+		if ok &&
+			work.origin.PeerID != 0 &&
+			terminator.DisconnectPeer(peermanagement.PeerID(work.origin.PeerID)) {
+			count := r.validationTrustedOverloadDisconnect.Add(1)
+			r.logTrustedValidationSaturation("peer-disconnected", work.origin.PeerID, count)
+			return validationWorkDisconnectedTrustedPeer
+		}
+
+		count := r.validationTrustedOverloadUnresolved.Add(1)
+		r.logTrustedValidationSaturation("terminator-unavailable", work.origin.PeerID, count)
+		return validationWorkTrustedOverloadUnresolved
+	}
+
+	r.handleValidationWorkResult(validationWorkResult{
+		validation: work.validation,
+		origin:     work.origin,
+		err:        r.adaptor.VerifyValidation(work.validation),
+	})
+	return validationWorkProcessedSynchronously
+}
+
+func (r *Router) logUntrustedValidationSaturation(stage string, count uint64) {
+	if count != 1 && count%validationSaturationLogInterval != 0 {
+		return
+	}
+	r.logger.Warn("untrusted validation verifier saturated",
+		"stage", stage,
+		"dropped", count)
+}
+
+func (r *Router) logTrustedValidationSaturation(resolution string, peerID, count uint64) {
+	if count != 1 && count%validationSaturationLogInterval != 0 {
+		return
+	}
+	level := slog.LevelWarn
+	if resolution == "terminator-unavailable" {
+		level = slog.LevelError
+	}
+	r.logger.Log(context.Background(), level, "trusted validation verifier saturated",
+		"resolution", resolution,
+		"peer", peerID,
+		"count", count)
+}
+
+func (r *Router) handleValidationWorkResult(result validationWorkResult) {
+	if result.err != nil {
+		r.logger.Info("invalid validation signature",
+			"t", "consensus",
+			"event", "validation-invalid-signature",
+			"error", result.err,
+			"peer", result.origin.PeerID)
+		r.adaptor.IncPeerBadData(result.origin.PeerID, "validation-invalid-signature")
+		return
+	}
+
+	processor, ok := r.engine.(consensus.VerifiedValidationProcessor)
+	if !ok {
+		return
+	}
+	disposition, err := processor.ProcessVerifiedValidation(result.validation, result.origin)
+	if err != nil {
+		r.logger.Info("engine rejected verified validation",
+			"t", "consensus",
+			"event", "validation-rejected",
+			"error", err,
+			"peer", result.origin.PeerID)
+		return
+	}
+
+	if disposition.Status == consensus.ValidationMultiple ||
+		disposition.Status == consensus.ValidationConflicting {
+		level := slog.LevelError
+		if !disposition.Trusted {
+			level = slog.LevelInfo
+		}
+		r.logger.Log(context.Background(), level, "byzantine validation detected",
+			"t", "consensus",
+			"event", "byzantine-validation",
+			"reason", disposition.Status.String(),
+			"trusted", disposition.Trusted,
+			"peer", result.origin.PeerID)
+	}
+
+	r.logger.Debug("inbound validation processed",
+		"t", "consensus",
+		"event", "validation-recv",
+		"peer", result.origin.PeerID,
+		"seq", result.validation.LedgerSeq,
+		"status", disposition.Status.String(),
+		"hash_short", fmt.Sprintf("%x", result.validation.LedgerID[:8]))
+
+	if disposition.AcquireEligible() {
+		r.maybeAcquireFromValidation(result.validation, result.origin.PeerID)
+	}
+	if disposition.Relay {
+		if err := r.adaptor.RelayValidation(result.validation, result.origin.PeerID); err != nil {
+			r.logger.Debug("failed to relay validation",
+				"error", err,
+				"peer", result.origin.PeerID)
+		}
+	}
+}
+
+func (r *Router) handleLegacyValidation(
+	validation *consensus.Validation,
+	originPeer uint64,
+	peerID peermanagement.PeerID,
+) {
 	if err := r.engine.OnValidation(validation, originPeer); err != nil {
-		// A same-seq double-sign (conflicting/multiple) is Byzantine
-		// behaviour, but the validation is well-formed and correctly
-		// signed and the engine has already relayed it. Like rippled
-		// (handleNewValidation logs trusted offenders at error, untrusted
-		// at info, and forwards; no Resource::Charge), log it and do NOT
-		// charge the delivering peer — it is an innocent relay.
 		var bv *consensus.ByzantineValidationError
 		if errors.As(err, &bv) {
 			level := slog.LevelError
@@ -322,33 +467,49 @@ func (r *Router) handleValidation(msg *peermanagement.InboundMessage) {
 				"event", "byzantine-validation",
 				"reason", bv.Reason,
 				"trusted", bv.Trusted,
-				"peer", msg.PeerID)
+				"peer", peerID)
 			return
 		}
 		r.logger.Info("engine rejected validation",
 			"t", "consensus",
 			"event", "validation-rejected",
 			"error", err.Error(),
-			"peer", msg.PeerID)
+			"peer", peerID)
 		return
 	}
-	r.logger.Debug("inbound validation processed",
-		"t", "consensus",
-		"event", "validation-recv",
-		"peer", msg.PeerID,
-		"seq", validation.LedgerSeq,
-		"hash_short", fmt.Sprintf("%x", validation.LedgerID[:8]))
-
-	// Per-validation catch-up acquire on EVERY trusted current
-	// validation, not only at quorum. Under sustained load a node that
-	// falls one ledger behind enters the wrongLedger chase loop holding
-	// no position (our_pos_seq=0); with only 3 of the 4-quorum trusted
-	// validators on the network tip, the quorum-gated stash acquire
-	// (armValidationStashAcquisition) never fires, so the node never
-	// fetches the tip the network is converging on and the chain stalls
-	// below quorum until a slow periodic sweep recovers it. Acquiring on
-	// each trusted validation breaks that loop.
 	r.maybeAcquireFromValidation(validation, originPeer)
+}
+
+func (r *Router) validationPeerContext(
+	peerID peermanagement.PeerID,
+) (consensus.ValidationOrigin, peermanagement.PeerTracking) {
+	origin := consensus.ValidationOrigin{PeerID: uint64(peerID)}
+	tracking := peermanagement.PeerTrackingUnknown
+	view, ok := r.peerSessions.(interface {
+		Peers() []peermanagement.PeerInfo
+	})
+	if !ok {
+		return origin, tracking
+	}
+	for _, peer := range view.Peers() {
+		if peer.ID != peerID {
+			continue
+		}
+		tracking = peer.Tracking
+		if r.overlay != nil && r.overlay.Cluster() != nil && len(peer.PublicKeyBytes) != 0 {
+			_, origin.Cluster = r.overlay.Cluster().Member(peer.PublicKeyBytes)
+		}
+		break
+	}
+	return origin, tracking
+}
+
+func (r *Router) isLoadedLocal() bool {
+	if r.adaptor == nil || r.adaptor.LedgerService() == nil {
+		return false
+	}
+	feeTrack := r.adaptor.LedgerService().FeeTrack()
+	return feeTrack != nil && feeTrack.IsLoadedLocal()
 }
 
 // resolveMasterNodeID looks the inbound signing pubkey up in the

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -316,7 +316,10 @@ func (r *Router) handleValidation(msg *peermanagement.InboundMessage) {
 		origin:     origin,
 		trusted:    trusted,
 	}
-	r.submitValidationWork(work)
+	outcome := r.submitValidationWork(work)
+	if outcome != validationWorkQueued && outcome != validationWorkProcessedSynchronously {
+		r.messageSeen.allowRetry(suppressionHash)
+	}
 }
 
 type validationWorkAdmissionOutcome uint8
@@ -325,8 +328,7 @@ const (
 	validationWorkQueued validationWorkAdmissionOutcome = iota
 	validationWorkProcessedSynchronously
 	validationWorkShedUntrusted
-	validationWorkDisconnectedTrustedPeer
-	validationWorkTrustedOverloadUnresolved
+	validationWorkShedTrusted
 	validationWorkStopped
 )
 
@@ -346,18 +348,9 @@ func (r *Router) submitValidationWork(work validationWork) validationWorkAdmissi
 			return validationWorkShedUntrusted
 		}
 
-		terminator, ok := r.peerSessions.(peerValidationTerminator)
-		if ok &&
-			work.origin.PeerID != 0 &&
-			terminator.DisconnectPeer(peermanagement.PeerID(work.origin.PeerID)) {
-			count := r.validationTrustedOverloadDisconnect.Add(1)
-			r.logTrustedValidationSaturation("peer-disconnected", work.origin.PeerID, count)
-			return validationWorkDisconnectedTrustedPeer
-		}
-
-		count := r.validationTrustedOverloadUnresolved.Add(1)
-		r.logTrustedValidationSaturation("terminator-unavailable", work.origin.PeerID, count)
-		return validationWorkTrustedOverloadUnresolved
+		count := r.validationShedTrusted.Add(1)
+		r.logTrustedValidationSaturation(work.origin.PeerID, count)
+		return validationWorkShedTrusted
 	}
 
 	r.handleValidationWorkResult(validationWorkResult{
@@ -377,18 +370,13 @@ func (r *Router) logUntrustedValidationSaturation(stage string, count uint64) {
 		"dropped", count)
 }
 
-func (r *Router) logTrustedValidationSaturation(resolution string, peerID, count uint64) {
+func (r *Router) logTrustedValidationSaturation(peerID, count uint64) {
 	if count != 1 && count%validationSaturationLogInterval != 0 {
 		return
 	}
-	level := slog.LevelWarn
-	if resolution == "terminator-unavailable" {
-		level = slog.LevelError
-	}
-	r.logger.Log(context.Background(), level, "trusted validation verifier saturated",
-		"resolution", resolution,
+	r.logger.Warn("trusted validation verifier saturated",
 		"peer", peerID,
-		"count", count)
+		"dropped", count)
 }
 
 func (r *Router) handleValidationWorkResult(result validationWorkResult) {

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -358,7 +358,6 @@ func TestRouterStopsOnContextCancel(t *testing.T) {
 	}
 }
 
-// countingSender wraps noopSender with a counter on UpdateRelaySlot.
 type countingSender struct {
 	noopSender
 	mu      sync.Mutex

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -358,16 +358,12 @@ func TestRouterStopsOnContextCancel(t *testing.T) {
 	}
 }
 
-// countingSender wraps noopSender with a counter on UpdateRelaySlot
-// so router tests can assert how many times the reduce-relay slot
-// was fed. B3: also captures the seenPeers argument so tests can
-// verify the slot is fed with the full known-haver set from the
-// overlay's reverse index, not just the duplicate's originator.
+// countingSender wraps noopSender with a counter on UpdateRelaySlot.
 type countingSender struct {
 	noopSender
-	mu            sync.Mutex
-	calls         []countingRelaySlotCall
-	peersThatHave map[[32]byte][]uint64
+	mu      sync.Mutex
+	calls   []countingRelaySlotCall
+	relayed map[[32]byte]bool
 }
 
 type countingRelaySlotCall struct {
@@ -385,25 +381,19 @@ func (s *countingSender) UpdateRelaySlot(validator []byte, originPeer uint64, se
 	s.calls = append(s.calls, countingRelaySlotCall{Validator: cp, OriginPeer: originPeer, SeenPeers: seenCp})
 }
 
-// PeersThatHave returns the preconfigured set for suppressionHash.
-// Router tests seed this to simulate the overlay having already
-// relayed a message to a known peer set.
-func (s *countingSender) PeersThatHave(suppressionHash [32]byte) []uint64 {
+func (s *countingSender) MessageRelayedRecently(suppressionHash [32]byte) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.peersThatHave == nil {
-		return nil
-	}
-	return append([]uint64(nil), s.peersThatHave[suppressionHash]...)
+	return s.relayed[suppressionHash]
 }
 
-func (s *countingSender) setPeersThatHave(suppressionHash [32]byte, peers []uint64) {
+func (s *countingSender) setRelayed(suppressionHash [32]byte) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.peersThatHave == nil {
-		s.peersThatHave = make(map[[32]byte][]uint64)
+	if s.relayed == nil {
+		s.relayed = make(map[[32]byte]bool)
 	}
-	s.peersThatHave[suppressionHash] = append([]uint64(nil), peers...)
+	s.relayed[suppressionHash] = true
 }
 
 func (s *countingSender) getCalls() []countingRelaySlotCall {
@@ -471,6 +461,7 @@ func TestRouter_UpdateRelaySlot_DuplicatesOnly(t *testing.T) {
 	firstRound := sender.getCalls()
 	assert.Empty(t, firstRound,
 		"first-seen proposal must NOT feed UpdateRelaySlot (rippled fires only on duplicates)")
+	sender.setRelayed(hashProposalSuppression(ProposalFromMessage(proposeSet)))
 
 	// Peer B delivers the same bytes: duplicate, MUST fire UpdateRelaySlot.
 	inbox <- &peermanagement.InboundMessage{
@@ -532,6 +523,7 @@ func TestRouter_UpdateRelaySlot_UntrustedValidator(t *testing.T) {
 
 	inbox <- &peermanagement.InboundMessage{PeerID: 1, Type: uint16(message.TypeProposeLedger), Payload: payload}
 	time.Sleep(30 * time.Millisecond)
+	sender.setRelayed(hashProposalSuppression(ProposalFromMessage(proposeSet)))
 	inbox <- &peermanagement.InboundMessage{PeerID: 2, Type: uint16(message.TypeProposeLedger), Payload: payload}
 	time.Sleep(30 * time.Millisecond)
 
@@ -541,19 +533,7 @@ func TestRouter_UpdateRelaySlot_UntrustedValidator(t *testing.T) {
 	assert.Equal(t, uint64(2), calls[0].OriginPeer)
 }
 
-// TestRelay_DuplicateArrivalFeedsAllKnownRelayers pins B3: when a
-// duplicate proposal arrives from peer C, and the overlay's reverse
-// index already maps the proposal's suppression hash to peers {A, B}
-// (from a prior outbound relay), UpdateRelaySlot must be fed with
-// the full set {A, B, C} — not just C. Matches rippled's
-// overlay_.relay returning haveMessage and PeerImp passing it whole
-// to updateSlotAndSquelch (PeerImp.cpp:3010-3017 for proposals).
-//
-// Regression guard: a mutation that feeds only originPeer — the
-// pre-B3 behavior — would register exactly one peer in the seenPeers
-// slice (C), under-counting multi-path delivery evidence and slowing
-// selection convergence vs. rippled.
-func TestRelay_DuplicateArrivalFeedsAllKnownRelayers(t *testing.T) {
+func TestRelay_DuplicateAfterRelayFeedsOnlyCurrentSource(t *testing.T) {
 	engine := &mockEngine{}
 	svc := newTestLedgerService(t)
 
@@ -598,20 +578,10 @@ func TestRelay_DuplicateArrivalFeedsAllKnownRelayers(t *testing.T) {
 	time.Sleep(30 * time.Millisecond)
 	require.Empty(t, sender.getCalls(), "first-seen proposal must not feed the slot")
 
-	// Seed the overlay reverse index: the proposal's suppression key
-	// maps to peers {A=1, B=2} — as if we had already relayed it to
-	// them after the first-seen arrival. The proposal's suppression
-	// hash is computed from its decoded fields via
-	// hashProposalSuppression, so we reconstruct a matching Proposal
-	// to produce the same key the router will compute on the
-	// duplicate arrival below.
 	seedProposal := ProposalFromMessage(proposeSet)
 	seedHash := hashProposalSuppression(seedProposal)
-	sender.setPeersThatHave(seedHash, []uint64{1, 2})
+	sender.setRelayed(seedHash)
 
-	// Duplicate delivery from peer C=3: UpdateRelaySlot must fire
-	// with originPeer=3 AND seenPeers containing 1 and 2 — the full
-	// set of peers the network believes already have this message.
 	inbox <- &peermanagement.InboundMessage{
 		PeerID:  3,
 		Type:    uint16(message.TypeProposeLedger),
@@ -624,15 +594,8 @@ func TestRelay_DuplicateArrivalFeedsAllKnownRelayers(t *testing.T) {
 	call := calls[0]
 	assert.Equal(t, uint64(3), call.OriginPeer,
 		"UpdateRelaySlot must be fed with the DUPLICATE peer's ID as originPeer")
-
-	// seenPeers must contain peers 1 and 2 (the known-havers from
-	// the reverse index). Order is not fixed (it's a set walk).
-	seenSet := make(map[uint64]struct{}, len(call.SeenPeers))
-	for _, p := range call.SeenPeers {
-		seenSet[p] = struct{}{}
-	}
-	assert.Contains(t, seenSet, uint64(1), "seenPeers must include peer A (prior known-haver)")
-	assert.Contains(t, seenSet, uint64(2), "seenPeers must include peer B (prior known-haver)")
+	assert.Empty(t, call.SeenPeers,
+		"the verified first-source set was counted when relay completed")
 }
 
 // TestRelay_FirstSeenMessageDoesNotFeedSlot pins the other half of
@@ -670,11 +633,6 @@ func TestRelay_FirstSeenMessageDoesNotFeedSlot(t *testing.T) {
 	ctx := t.Context()
 	go router.Run(ctx)
 
-	// Construct a proposal and PRE-SEED the overlay's reverse index
-	// with a non-empty known-haver set for its suppression hash. If
-	// the gate were inverted, this test would exercise a code path
-	// that feeds seenPeers into the slot even on a first-seen
-	// arrival — exactly the regression we're pinning against.
 	proposeSet := &message.ProposeSet{
 		ProposeSeq:     7,
 		CurrentTxHash:  make([]byte, 32),
@@ -687,7 +645,7 @@ func TestRelay_FirstSeenMessageDoesNotFeedSlot(t *testing.T) {
 
 	seedProposal := ProposalFromMessage(proposeSet)
 	seedHash := hashProposalSuppression(seedProposal)
-	sender.setPeersThatHave(seedHash, []uint64{11, 22, 33})
+	sender.setRelayed(seedHash)
 
 	// Deliver the message exactly once — from a fresh peer, no prior
 	// observation. This is the rippled `!added == false` branch in

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -329,13 +329,10 @@ func (s *OverlaySender) IncPeerBadData(peerID uint64, reason string) {
 	s.overlay.IncPeerBadData(peermanagement.PeerID(peerID), reason)
 }
 
-// RecordMessageSource records an inbound source for a proposal or validation.
 func (s *OverlaySender) RecordMessageSource(suppressionHash [32]byte, peerID uint64) {
 	s.overlay.RecordMessageSource(suppressionHash, peermanagement.PeerID(peerID))
 }
 
-// PeersThatHave returns the accumulated inbound sources for this
-// suppression hash.
 func (s *OverlaySender) PeersThatHave(suppressionHash [32]byte) []uint64 {
 	raw := s.overlay.PeersThatHave(suppressionHash)
 	if len(raw) == 0 {

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -58,19 +58,16 @@ func (s *OverlaySender) BroadcastValidation(validation *consensus.Validation) er
 // validator's gossip are skipped) and excluding the originating peer
 // itself.
 //
-// proposal.SuppressionHash is the router-level dedup key (populated
-// by the consensus router from the canonical proposalUniqueId hash at
-// parse time). The overlay registers each recipient against that key
-// in its reverse index; the index is queried by the consensus router
-// on a later duplicate arrival so the slot is fed with the full set
-// of known-havers.
+// proposal.SuppressionHash is the router-level dedup key populated at
+// parse time. The overlay uses it to exclude every peer that delivered
+// this message to us.
 func (s *OverlaySender) RelayProposal(proposal *consensus.Proposal, exceptPeer uint64) error {
 	msg := ProposalToMessage(proposal)
 	frame, err := message.EncodeFrame(msg)
 	if err != nil {
 		return fmt.Errorf("encode proposal: %w", err)
 	}
-	return s.overlay.RelayFromValidator(proposal.NodeID[:], proposal.SuppressionHash, peermanagement.PeerID(exceptPeer), frame)
+	return s.overlay.RelayFromValidator(proposal.SigningPubKey[:], proposal.SuppressionHash, peermanagement.PeerID(exceptPeer), frame)
 }
 
 // RelayValidation forwards a peer-originated validation to other peers
@@ -82,7 +79,7 @@ func (s *OverlaySender) RelayValidation(validation *consensus.Validation, except
 	if err != nil {
 		return fmt.Errorf("encode validation: %w", err)
 	}
-	return s.overlay.RelayFromValidator(validation.NodeID[:], validation.SuppressionHash, peermanagement.PeerID(exceptPeer), frame)
+	return s.overlay.RelayFromValidator(validation.SigningPubKey[:], validation.SuppressionHash, peermanagement.PeerID(exceptPeer), frame)
 }
 
 // UpdateRelaySlot feeds the overlay's reduce-relay state machine with
@@ -332,11 +329,13 @@ func (s *OverlaySender) IncPeerBadData(peerID uint64, reason string) {
 	s.overlay.IncPeerBadData(peermanagement.PeerID(peerID), reason)
 }
 
-// PeersThatHave returns the peer IDs the overlay knows have the
-// message with this suppression hash. Populated by the overlay as
-// messages are relayed outward (see Overlay.RelayFromValidator); the
-// consensus router queries this on duplicate arrivals so the
-// reduce-relay slot gets fed with every known-haver.
+// RecordMessageSource records an inbound source for a proposal or validation.
+func (s *OverlaySender) RecordMessageSource(suppressionHash [32]byte, peerID uint64) {
+	s.overlay.RecordMessageSource(suppressionHash, peermanagement.PeerID(peerID))
+}
+
+// PeersThatHave returns the accumulated inbound sources for this
+// suppression hash.
 func (s *OverlaySender) PeersThatHave(suppressionHash [32]byte) []uint64 {
 	raw := s.overlay.PeersThatHave(suppressionHash)
 	if len(raw) == 0 {
@@ -347,6 +346,10 @@ func (s *OverlaySender) PeersThatHave(suppressionHash [32]byte) []uint64 {
 		out[i] = uint64(p)
 	}
 	return out
+}
+
+func (s *OverlaySender) MessageRelayedRecently(suppressionHash [32]byte) bool {
+	return s.overlay.MessageRelayedRecently(suppressionHash)
 }
 
 // RequestReplayDelta asks a specific peer for a fast-catchup replay delta

--- a/internal/consensus/adaptor/sender_cov_test.go
+++ b/internal/consensus/adaptor/sender_cov_test.go
@@ -191,6 +191,15 @@ func (f *snd_fakeOverlay) PeersThatHave(suppressionHash [32]byte) []uint64 {
 	return append([]uint64(nil), f.peersThatHave[suppressionHash]...)
 }
 
+func (f *snd_fakeOverlay) RecordMessageSource(suppressionHash [32]byte, peerID uint64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.peersThatHave == nil {
+		f.peersThatHave = make(map[[32]byte][]uint64)
+	}
+	f.peersThatHave[suppressionHash] = append(f.peersThatHave[suppressionHash], peerID)
+}
+
 func (f *snd_fakeOverlay) ShouldShedLedgerRequest(peerID uint64, loadedLocal bool) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -334,6 +343,9 @@ func TestSndAdaptor_PeersThatHave(t *testing.T) {
 	hash[0] = 0x01
 	got := a.PeersThatHave(hash)
 	assert.ElementsMatch(t, []uint64{10, 20}, got)
+
+	a.RecordMessageSource(hash, 30)
+	assert.ElementsMatch(t, []uint64{10, 20, 30}, a.PeersThatHave(hash))
 
 	assert.Nil(t, a.PeersThatHave([32]byte{}))
 }

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -741,11 +741,16 @@ func OverlayOptionsFromConfig(appCfg *config.Config) []peermanagement.Option {
 
 	// Max peers
 	maxPeers, maxInbound, maxOutbound := peerLimits(appCfg.PeersMax, hasPeerPort && appCfg.PeerPrivate == 0)
+	outboundRetainedBytes := max(
+		peermanagement.DefaultOutboundRetainedBytes,
+		peermanagement.MinimumOutboundRetainedBytes(maxPeers),
+	)
 	opts = append(opts,
 		peermanagement.WithMaxPeers(maxPeers),
 		peermanagement.WithMaxInbound(maxInbound),
 		peermanagement.WithMaxOutbound(maxOutbound),
 		peermanagement.WithIPLimit(appCfg.Overlay.IPLimit),
+		peermanagement.WithOutboundRetainedBytes(outboundRetainedBytes),
 	)
 
 	// Private mode

--- a/internal/consensus/adaptor/startup_cov_test.go
+++ b/internal/consensus/adaptor/startup_cov_test.go
@@ -646,6 +646,7 @@ func TestStup_OverlayOptionsFromConfig_PeerLimits(t *testing.T) {
 		{name: "twenty peers", peersMax: 20, ports: peerPort, wantMax: 20, wantInbound: 10, wantOutbound: 10, wantIPLimit: 2},
 		{name: "rippled default", peersMax: 21, ports: peerPort, wantMax: 21, wantInbound: 11, wantOutbound: 10, wantIPLimit: 2},
 		{name: "large limit", peersMax: 100, ports: peerPort, wantMax: 100, wantInbound: 85, wantOutbound: 15, wantIPLimit: 6},
+		{name: "limit beyond default outbound budget", peersMax: 225, ports: peerPort, wantMax: 225, wantInbound: 191, wantOutbound: 34, wantIPLimit: 7},
 		{name: "private", peersMax: 20, peerPrivate: 1, ports: peerPort, wantMax: 20, wantInbound: 0, wantOutbound: 20, wantIPLimit: 1},
 		{name: "no peer listener", peersMax: 20, wantMax: 20, wantInbound: 0, wantOutbound: 20, wantIPLimit: 1},
 	}
@@ -673,6 +674,8 @@ func TestStup_OverlayOptionsFromConfig_PeerLimits(t *testing.T) {
 			}
 			require.NoError(t, pcfg.Validate())
 			assert.Equal(t, tt.wantIPLimit, pcfg.IPLimit)
+			assert.GreaterOrEqual(t, pcfg.OutboundRetainedBytes,
+				peermanagement.MinimumOutboundRetainedBytes(tt.wantMax))
 		})
 	}
 }

--- a/internal/consensus/adaptor/validation_work.go
+++ b/internal/consensus/adaptor/validation_work.go
@@ -1,0 +1,256 @@
+package adaptor
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+)
+
+const (
+	trustedValidationQueueDepth   = 256
+	untrustedValidationQueueDepth = 64
+	validationWorkerCount         = 2
+)
+
+type validationWork struct {
+	validation *consensus.Validation
+	origin     consensus.ValidationOrigin
+	trusted    bool
+}
+
+type validationWorkResult struct {
+	validation *consensus.Validation
+	origin     consensus.ValidationOrigin
+	err        error
+}
+
+type validationResultDelivery uint8
+
+const (
+	validationResultDelivered validationResultDelivery = iota
+	validationResultUntrustedSaturated
+	validationResultCancelled
+)
+
+type validationQueueAdmission uint8
+
+const (
+	validationQueueAccepted validationQueueAdmission = iota
+	validationQueueSaturated
+	validationQueueStopped
+)
+
+type validationWorkLane struct {
+	verify      func(*consensus.Validation) error
+	peerPresent func(peermanagement.PeerID) bool
+	isTrusted   func(consensus.NodeID) bool
+
+	trustedJobs       chan validationWork
+	untrustedJobs     chan validationWork
+	trustedResultCh   chan validationWorkResult
+	untrustedResultCh chan validationWorkResult
+	workers           int
+
+	// Set before start and immutable while workers run.
+	onUntrustedResultShed func(uint64)
+	untrustedResultShed   atomic.Uint64
+
+	mu     sync.Mutex
+	done   <-chan struct{}
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func newValidationWorkLane(
+	verify func(*consensus.Validation) error,
+	peerPresent func(peermanagement.PeerID) bool,
+	isTrusted func(consensus.NodeID) bool,
+) *validationWorkLane {
+	return &validationWorkLane{
+		verify:            verify,
+		peerPresent:       peerPresent,
+		isTrusted:         isTrusted,
+		trustedJobs:       make(chan validationWork, trustedValidationQueueDepth),
+		untrustedJobs:     make(chan validationWork, untrustedValidationQueueDepth),
+		trustedResultCh:   make(chan validationWorkResult, trustedValidationQueueDepth),
+		untrustedResultCh: make(chan validationWorkResult, untrustedValidationQueueDepth),
+		workers:           validationWorkerCount,
+	}
+}
+
+func (l *validationWorkLane) start(ctx context.Context) {
+	if l == nil || l.verify == nil {
+		return
+	}
+
+	l.mu.Lock()
+	if l.cancel != nil {
+		l.mu.Unlock()
+		return
+	}
+	workerCtx, cancel := context.WithCancel(ctx)
+	l.cancel = cancel
+	l.done = workerCtx.Done()
+	l.mu.Unlock()
+
+	for range l.workers {
+		l.wg.Add(1)
+		go l.run(workerCtx)
+	}
+}
+
+func (l *validationWorkLane) stop() {
+	if l == nil {
+		return
+	}
+
+	l.mu.Lock()
+	cancel := l.cancel
+	l.cancel = nil
+	l.done = nil
+	l.mu.Unlock()
+	if cancel == nil {
+		return
+	}
+	cancel()
+	l.wg.Wait()
+}
+
+func (l *validationWorkLane) submit(work validationWork) validationQueueAdmission {
+	if l == nil {
+		return validationQueueStopped
+	}
+
+	l.mu.Lock()
+	done := l.done
+	l.mu.Unlock()
+	if done == nil {
+		return validationQueueStopped
+	}
+
+	jobs := l.untrustedJobs
+	if work.trusted {
+		jobs = l.trustedJobs
+	}
+	select {
+	case jobs <- work:
+		return validationQueueAccepted
+	case <-done:
+		return validationQueueStopped
+	default:
+		return validationQueueSaturated
+	}
+}
+
+func (l *validationWorkLane) running() bool {
+	if l == nil {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.done != nil
+}
+
+func (l *validationWorkLane) trustedResults() <-chan validationWorkResult {
+	if l == nil {
+		return nil
+	}
+	return l.trustedResultCh
+}
+
+func (l *validationWorkLane) untrustedResults() <-chan validationWorkResult {
+	if l == nil {
+		return nil
+	}
+	return l.untrustedResultCh
+}
+
+func (r *Router) trustedValidationWorkResults() <-chan validationWorkResult {
+	if r.validationWork == nil {
+		return nil
+	}
+	return r.validationWork.trustedResults()
+}
+
+func (r *Router) untrustedValidationWorkResults() <-chan validationWorkResult {
+	if r.validationWork == nil {
+		return nil
+	}
+	return r.validationWork.untrustedResults()
+}
+
+func (l *validationWorkLane) run(ctx context.Context) {
+	defer l.wg.Done()
+	for {
+		work, ok := l.next(ctx)
+		if !ok {
+			return
+		}
+		if l.peerPresent != nil &&
+			work.origin.PeerID != 0 &&
+			!l.peerPresent(peermanagement.PeerID(work.origin.PeerID)) {
+			continue
+		}
+
+		result := validationWorkResult{
+			validation: work.validation,
+			origin:     work.origin,
+			err:        l.verify(work.validation),
+		}
+		trustedResult := work.trusted
+		if !trustedResult && l.isTrusted != nil {
+			trustedResult = l.isTrusted(work.validation.NodeID)
+		}
+		if l.deliverResult(ctx, result, trustedResult) == validationResultCancelled {
+			return
+		}
+	}
+}
+
+func (l *validationWorkLane) deliverResult(
+	ctx context.Context,
+	result validationWorkResult,
+	trusted bool,
+) validationResultDelivery {
+	if trusted {
+		select {
+		case l.trustedResultCh <- result:
+			return validationResultDelivered
+		case <-ctx.Done():
+			return validationResultCancelled
+		}
+	}
+
+	select {
+	case l.untrustedResultCh <- result:
+		return validationResultDelivered
+	case <-ctx.Done():
+		return validationResultCancelled
+	default:
+		count := l.untrustedResultShed.Add(1)
+		if l.onUntrustedResultShed != nil {
+			l.onUntrustedResultShed(count)
+		}
+		return validationResultUntrustedSaturated
+	}
+}
+
+func (l *validationWorkLane) next(ctx context.Context) (validationWork, bool) {
+	select {
+	case work := <-l.trustedJobs:
+		return work, true
+	default:
+	}
+
+	select {
+	case work := <-l.trustedJobs:
+		return work, true
+	case work := <-l.untrustedJobs:
+		return work, true
+	case <-ctx.Done():
+		return validationWork{}, false
+	}
+}

--- a/internal/consensus/adaptor/validation_work.go
+++ b/internal/consensus/adaptor/validation_work.go
@@ -13,6 +13,7 @@ const (
 	trustedValidationQueueDepth   = 256
 	untrustedValidationQueueDepth = 64
 	validationWorkerCount         = 2
+	trustedValidationPerPeerDepth = trustedValidationQueueDepth / 4
 )
 
 type validationWork struct {
@@ -53,9 +54,10 @@ type validationWorkLane struct {
 	trustedResultCh   chan validationWorkResult
 	untrustedResultCh chan validationWorkResult
 	workers           int
+	trustedPending    map[peermanagement.PeerID]int
 
 	// Set before start and immutable while workers run.
-	onUntrustedResultShed func(uint64)
+	onUntrustedResultShed func(validationWorkResult, uint64)
 	untrustedResultShed   atomic.Uint64
 
 	mu     sync.Mutex
@@ -78,6 +80,7 @@ func newValidationWorkLane(
 		trustedResultCh:   make(chan validationWorkResult, trustedValidationQueueDepth),
 		untrustedResultCh: make(chan validationWorkResult, untrustedValidationQueueDepth),
 		workers:           validationWorkerCount,
+		trustedPending:    make(map[peermanagement.PeerID]int),
 	}
 }
 
@@ -126,21 +129,32 @@ func (l *validationWorkLane) submit(work validationWork) validationQueueAdmissio
 
 	l.mu.Lock()
 	done := l.done
-	l.mu.Unlock()
 	if done == nil {
+		l.mu.Unlock()
 		return validationQueueStopped
 	}
 
 	jobs := l.untrustedJobs
 	if work.trusted {
 		jobs = l.trustedJobs
+		peerID := peermanagement.PeerID(work.origin.PeerID)
+		if peerID != 0 && l.trustedPending[peerID] >= trustedValidationPerPeerDepth {
+			l.mu.Unlock()
+			return validationQueueSaturated
+		}
 	}
 	select {
 	case jobs <- work:
+		if work.trusted && work.origin.PeerID != 0 {
+			l.trustedPending[peermanagement.PeerID(work.origin.PeerID)]++
+		}
+		l.mu.Unlock()
 		return validationQueueAccepted
 	case <-done:
+		l.mu.Unlock()
 		return validationQueueStopped
 	default:
+		l.mu.Unlock()
 		return validationQueueSaturated
 	}
 }
@@ -232,7 +246,7 @@ func (l *validationWorkLane) deliverResult(
 	default:
 		count := l.untrustedResultShed.Add(1)
 		if l.onUntrustedResultShed != nil {
-			l.onUntrustedResultShed(count)
+			l.onUntrustedResultShed(result, count)
 		}
 		return validationResultUntrustedSaturated
 	}
@@ -241,16 +255,32 @@ func (l *validationWorkLane) deliverResult(
 func (l *validationWorkLane) next(ctx context.Context) (validationWork, bool) {
 	select {
 	case work := <-l.trustedJobs:
+		l.markDequeued(work)
 		return work, true
 	default:
 	}
 
 	select {
 	case work := <-l.trustedJobs:
+		l.markDequeued(work)
 		return work, true
 	case work := <-l.untrustedJobs:
 		return work, true
 	case <-ctx.Done():
 		return validationWork{}, false
 	}
+}
+
+func (l *validationWorkLane) markDequeued(work validationWork) {
+	if !work.trusted || work.origin.PeerID == 0 {
+		return
+	}
+	peerID := peermanagement.PeerID(work.origin.PeerID)
+	l.mu.Lock()
+	if l.trustedPending[peerID] <= 1 {
+		delete(l.trustedPending, peerID)
+	} else {
+		l.trustedPending[peerID]--
+	}
+	l.mu.Unlock()
 }

--- a/internal/consensus/adaptor/validation_work_test.go
+++ b/internal/consensus/adaptor/validation_work_test.go
@@ -1,0 +1,558 @@
+package adaptor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/require"
+)
+
+type validationProcessorEngine struct {
+	*mockEngine
+
+	muProcessor sync.Mutex
+	disposition consensus.ValidationDisposition
+	processed   []*consensus.Validation
+	origins     []consensus.ValidationOrigin
+}
+
+func (e *validationProcessorEngine) ProcessVerifiedValidation(
+	validation *consensus.Validation,
+	origin consensus.ValidationOrigin,
+) (consensus.ValidationDisposition, error) {
+	e.muProcessor.Lock()
+	defer e.muProcessor.Unlock()
+	e.processed = append(e.processed, validation)
+	e.origins = append(e.origins, origin)
+	return e.disposition, nil
+}
+
+func (e *validationProcessorEngine) processedCount() int {
+	e.muProcessor.Lock()
+	defer e.muProcessor.Unlock()
+	return len(e.processed)
+}
+
+type validationCaptureSender struct {
+	noopSender
+
+	mu      sync.Mutex
+	relayed []*consensus.Validation
+	bad     []string
+	sources map[[32]byte][]uint64
+}
+
+func (s *validationCaptureSender) RelayValidation(
+	validation *consensus.Validation,
+	_ uint64,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.relayed = append(s.relayed, validation)
+	return nil
+}
+
+func (s *validationCaptureSender) IncPeerBadData(_ uint64, reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.bad = append(s.bad, reason)
+}
+
+func (s *validationCaptureSender) RecordMessageSource(hash [32]byte, peerID uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sources == nil {
+		s.sources = make(map[[32]byte][]uint64)
+	}
+	s.sources[hash] = append(s.sources[hash], peerID)
+}
+
+type validationPeerSessions struct {
+	mu           sync.Mutex
+	peers        []peermanagement.PeerInfo
+	disconnected []peermanagement.PeerID
+}
+
+func (s *validationPeerSessions) IsPeerConnected(peermanagement.PeerID) bool {
+	return true
+}
+
+func (s *validationPeerSessions) Peers() []peermanagement.PeerInfo {
+	return append([]peermanagement.PeerInfo(nil), s.peers...)
+}
+
+func (s *validationPeerSessions) DisconnectPeer(peerID peermanagement.PeerID) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.disconnected = append(s.disconnected, peerID)
+	return true
+}
+
+func (s *validationPeerSessions) disconnectedPeers() []peermanagement.PeerID {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]peermanagement.PeerID(nil), s.disconnected...)
+}
+
+func TestValidationWorkLanePrioritizesTrustedQueue(t *testing.T) {
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	verified := make(chan byte, 3)
+	lane := newValidationWorkLane(func(validation *consensus.Validation) error {
+		if validation.LedgerID[0] == 1 {
+			close(started)
+			<-unblock
+		}
+		verified <- validation.LedgerID[0]
+		return nil
+	}, nil, nil)
+	lane.workers = 1
+	lane.start(t.Context())
+	defer lane.stop()
+
+	require.Equal(t, validationQueueAccepted, lane.submit(validationWork{
+		validation: &consensus.Validation{LedgerID: consensus.LedgerID{1}},
+	}))
+	<-started
+	require.Equal(t, validationQueueAccepted, lane.submit(validationWork{
+		validation: &consensus.Validation{LedgerID: consensus.LedgerID{2}},
+	}))
+	require.Equal(t, validationQueueAccepted, lane.submit(validationWork{
+		validation: &consensus.Validation{LedgerID: consensus.LedgerID{3}},
+		trusted:    true,
+	}))
+	close(unblock)
+
+	require.Equal(t, byte(1), <-verified)
+	require.Equal(t, byte(3), <-verified)
+	require.Equal(t, byte(2), <-verified)
+}
+
+func TestValidationWorkLaneStopsWithoutClosingProducerChannels(t *testing.T) {
+	lane := newValidationWorkLane(func(*consensus.Validation) error { return nil }, nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	lane.start(ctx)
+	cancel()
+	lane.stop()
+
+	require.False(t, lane.running())
+	require.Equal(t, validationQueueStopped,
+		lane.submit(validationWork{validation: &consensus.Validation{}}))
+}
+
+func TestRouterTrustedValidationQueueFullDisconnectsPeerWithoutCrypto(t *testing.T) {
+	adaptor := newTestAdaptor(t)
+	engine := &validationProcessorEngine{
+		mockEngine: &mockEngine{},
+		disposition: consensus.ValidationDisposition{
+			Status:  consensus.ValidationCurrent,
+			Tracked: true,
+			Trusted: true,
+		},
+	}
+	router := NewRouter(engine, adaptor, nil)
+	verifyCalls := 0
+	lane := newValidationWorkLane(func(*consensus.Validation) error {
+		verifyCalls++
+		return nil
+	}, nil, nil)
+	lane.workers = 0
+	lane.start(t.Context())
+	defer lane.stop()
+	router.validationWork = lane
+	sessions := &validationPeerSessions{}
+	router.setPeerSessionView(sessions)
+	var logs bytes.Buffer
+	router.logger = slog.New(slog.NewTextHandler(&logs, nil))
+
+	require.Equal(t, 64, cap(lane.untrustedJobs))
+	for range cap(lane.trustedJobs) {
+		require.Equal(t, validationQueueAccepted, lane.submit(validationWork{
+			validation: &consensus.Validation{},
+			trusted:    true,
+		}))
+	}
+
+	for range 130 {
+		outcome := router.submitValidationWork(validationWork{
+			validation: &consensus.Validation{},
+			origin:     consensus.ValidationOrigin{PeerID: 15},
+			trusted:    true,
+		})
+		require.Equal(t, validationWorkDisconnectedTrustedPeer, outcome)
+	}
+	require.Zero(t, verifyCalls, "unverified trust claims must not force router-thread crypto")
+	require.Zero(t, engine.processedCount())
+	require.Len(t, sessions.disconnectedPeers(), 130)
+	require.Equal(t, uint64(130), router.validationTrustedOverloadDisconnect.Load())
+	require.Zero(t, router.validationTrustedOverloadUnresolved.Load())
+	require.Zero(t, router.validationShedUntrusted.Load())
+	require.Equal(t, 3, strings.Count(logs.String(), "trusted validation verifier saturated"),
+		"saturation logs should emit for counts 1, 64, and 128")
+}
+
+func TestRouterTrustedValidationQueueFullWithoutTerminatorRecordsUnresolved(t *testing.T) {
+	adaptor := newTestAdaptor(t)
+	engine := &validationProcessorEngine{mockEngine: &mockEngine{}}
+	router := NewRouter(engine, adaptor, nil)
+	var logs bytes.Buffer
+	router.logger = slog.New(slog.NewTextHandler(&logs, nil))
+	lane := router.validationWork
+	lane.workers = 0
+	lane.start(t.Context())
+	defer lane.stop()
+	for range cap(lane.trustedJobs) {
+		require.Equal(t, validationQueueAccepted, lane.submit(validationWork{
+			validation: &consensus.Validation{},
+			trusted:    true,
+		}))
+	}
+
+	outcome := router.submitValidationWork(validationWork{
+		validation: &consensus.Validation{},
+		origin:     consensus.ValidationOrigin{PeerID: 17},
+		trusted:    true,
+	})
+
+	require.Equal(t, validationWorkTrustedOverloadUnresolved, outcome)
+	require.Equal(t, uint64(1), router.validationTrustedOverloadUnresolved.Load())
+	require.Zero(t, router.validationTrustedOverloadDisconnect.Load())
+	require.Zero(t, engine.processedCount())
+	require.Contains(t, logs.String(), "resolution=terminator-unavailable")
+}
+
+func TestRouterUntrustedValidationQueueSaturationRateLimited(t *testing.T) {
+	adaptor := newTestAdaptor(t)
+	engine := &validationProcessorEngine{mockEngine: &mockEngine{}}
+	router := NewRouter(engine, adaptor, nil)
+	var logs bytes.Buffer
+	router.logger = slog.New(slog.NewTextHandler(&logs, nil))
+	lane := router.validationWork
+	lane.workers = 0
+	lane.start(t.Context())
+	defer lane.stop()
+
+	for range cap(lane.untrustedJobs) {
+		require.Equal(t, validationQueueAccepted, lane.submit(validationWork{
+			validation: &consensus.Validation{},
+		}))
+	}
+	for range 130 {
+		outcome := router.submitValidationWork(validationWork{
+			validation: &consensus.Validation{},
+			origin:     consensus.ValidationOrigin{PeerID: 16},
+		})
+		require.Equal(t, validationWorkShedUntrusted, outcome)
+	}
+
+	require.Equal(t, uint64(130), router.validationShedUntrusted.Load())
+	require.Equal(t, 3, strings.Count(logs.String(), "untrusted validation verifier saturated"),
+		"saturation logs should emit for counts 1, 64, and 128")
+}
+
+func TestValidationResultCapacityIsolatedAndRateLimited(t *testing.T) {
+	adaptor := newTestAdaptor(t)
+	engine := &validationProcessorEngine{mockEngine: &mockEngine{}}
+	router := NewRouter(engine, adaptor, nil)
+	var logs bytes.Buffer
+	router.logger = slog.New(slog.NewTextHandler(&logs, nil))
+	lane := router.validationWork
+	require.NotNil(t, lane)
+
+	for range cap(lane.untrustedResultCh) {
+		lane.untrustedResultCh <- validationWorkResult{}
+	}
+	for range 130 {
+		outcome := lane.deliverResult(t.Context(), validationWorkResult{}, false)
+		require.Equal(t, validationResultUntrustedSaturated, outcome)
+	}
+
+	trusted := validationWorkResult{
+		validation: &consensus.Validation{LedgerID: consensus.LedgerID{9}},
+	}
+	require.Equal(t, validationResultDelivered,
+		lane.deliverResult(t.Context(), trusted, true))
+	require.Equal(t, trusted, <-lane.trustedResultCh)
+	require.Equal(t, uint64(130), lane.untrustedResultShed.Load())
+	require.Equal(t, 3, strings.Count(logs.String(), "untrusted validation verifier saturated"),
+		"saturation logs should emit for counts 1, 64, and 128")
+}
+
+func TestUntrustedResultSaturationDoesNotBlockTrustedWorker(t *testing.T) {
+	untrustedStarted := make(chan struct{})
+	unblockUntrusted := make(chan struct{})
+	lane := newValidationWorkLane(func(validation *consensus.Validation) error {
+		if validation.LedgerID[0] == 1 {
+			close(untrustedStarted)
+			<-unblockUntrusted
+		}
+		return nil
+	}, nil, nil)
+	lane.workers = 1
+	for range cap(lane.untrustedResultCh) {
+		lane.untrustedResultCh <- validationWorkResult{}
+	}
+	lane.start(t.Context())
+	defer lane.stop()
+
+	require.Equal(t, validationQueueAccepted, lane.submit(validationWork{
+		validation: &consensus.Validation{LedgerID: consensus.LedgerID{1}},
+	}))
+	<-untrustedStarted
+	require.Equal(t, validationQueueAccepted, lane.submit(validationWork{
+		validation: &consensus.Validation{LedgerID: consensus.LedgerID{2}},
+		trusted:    true,
+	}))
+	close(unblockUntrusted)
+
+	select {
+	case result := <-lane.trustedResultCh:
+		require.Equal(t, byte(2), result.validation.LedgerID[0])
+	case <-time.After(time.Second):
+		t.Fatal("trusted worker result blocked behind saturated untrusted results")
+	}
+	require.Equal(t, uint64(1), lane.untrustedResultShed.Load())
+}
+
+func TestValidationWorkLanePromotesQueuedResultAfterTrustChange(t *testing.T) {
+	verificationStarted := make(chan struct{})
+	finishVerification := make(chan struct{})
+	nodeID := consensus.NodeID{0x31}
+	var trusted atomic.Bool
+	lane := newValidationWorkLane(
+		func(*consensus.Validation) error {
+			close(verificationStarted)
+			<-finishVerification
+			return nil
+		},
+		nil,
+		func(candidate consensus.NodeID) bool {
+			return candidate == nodeID && trusted.Load()
+		},
+	)
+	lane.workers = 1
+	for range cap(lane.untrustedResultCh) {
+		lane.untrustedResultCh <- validationWorkResult{}
+	}
+	lane.start(t.Context())
+	defer lane.stop()
+
+	validation := &consensus.Validation{
+		LedgerID: consensus.LedgerID{3},
+		NodeID:   nodeID,
+	}
+	require.Equal(t, validationQueueAccepted, lane.submit(validationWork{
+		validation: validation,
+		trusted:    false,
+	}))
+	<-verificationStarted
+	trusted.Store(true)
+	close(finishVerification)
+
+	select {
+	case result := <-lane.trustedResultCh:
+		require.Same(t, validation, result.validation)
+	case <-time.After(time.Second):
+		t.Fatal("newly trusted verified result was not routed to the trusted result lane")
+	}
+	require.Equal(t, uint64(0), lane.untrustedResultShed.Load())
+	require.Equal(t, cap(lane.untrustedResultCh), len(lane.untrustedResultCh),
+		"saturated untrusted results must remain isolated from a promoted result")
+}
+
+func TestRouterDrainsTrustedValidationResultsBeforeUntrusted(t *testing.T) {
+	adaptor := newTestAdaptor(t)
+	engine := &validationProcessorEngine{mockEngine: &mockEngine{}}
+	router := NewRouter(engine, adaptor, nil)
+	lane := router.validationWork
+	require.NotNil(t, lane)
+
+	lane.untrustedResultCh <- validationWorkResult{
+		validation: &consensus.Validation{LedgerID: consensus.LedgerID{1}},
+		origin:     consensus.ValidationOrigin{PeerID: 1},
+	}
+	lane.trustedResultCh <- validationWorkResult{
+		validation: &consensus.Validation{LedgerID: consensus.LedgerID{2}},
+		origin:     consensus.ValidationOrigin{PeerID: 2},
+	}
+
+	require.True(t, router.drainTrustedValidationResults(t.Context()))
+	require.Equal(t, 1, engine.processedCount())
+	require.Len(t, lane.untrustedResultCh, 1)
+	engine.muProcessor.Lock()
+	require.Equal(t, uint64(2), engine.origins[0].PeerID)
+	engine.muProcessor.Unlock()
+}
+
+func TestRouterValidationResultChargesOnlyInvalidSignature(t *testing.T) {
+	adaptor := newTestAdaptor(t)
+	sender := &validationCaptureSender{}
+	adaptor.sender = sender
+	engine := &validationProcessorEngine{
+		mockEngine:  &mockEngine{},
+		disposition: consensus.ValidationDisposition{Relay: true},
+	}
+	router := NewRouter(engine, adaptor, nil)
+	validation := &consensus.Validation{LedgerID: consensus.LedgerID{1}}
+
+	router.handleValidationWorkResult(validationWorkResult{
+		validation: validation,
+		origin:     consensus.ValidationOrigin{PeerID: 9},
+		err:        errors.New("bad signature"),
+	})
+
+	require.Zero(t, engine.processedCount())
+	require.Equal(t, []string{"validation-invalid-signature"}, sender.bad)
+	require.Empty(t, sender.relayed)
+}
+
+func TestRouterValidationResultUsesDispositionForAcquireAndRelay(t *testing.T) {
+	adaptor := newTestAdaptor(t)
+	sender := &validationCaptureSender{}
+	adaptor.sender = sender
+	engine := &validationProcessorEngine{
+		mockEngine: &mockEngine{},
+		disposition: consensus.ValidationDisposition{
+			Status:  consensus.ValidationCurrent,
+			Tracked: true,
+			Trusted: true,
+			Relay:   true,
+		},
+	}
+	router := NewRouter(engine, adaptor, nil)
+	validation := &consensus.Validation{
+		LedgerID:  consensus.LedgerID{0xAA},
+		LedgerSeq: 77,
+		NodeID:    adaptor.identity.NodeID,
+	}
+
+	router.handleValidationWorkResult(validationWorkResult{
+		validation: validation,
+		origin:     consensus.ValidationOrigin{PeerID: 9},
+	})
+
+	require.Equal(t, 1, engine.processedCount())
+	require.Len(t, sender.relayed, 1)
+	entry, ok := router.seqHash[validation.LedgerSeq]
+	require.True(t, ok, "trusted current validation must enter acquisition bookkeeping")
+	require.Equal(t, [32]byte(validation.LedgerID), entry.hash)
+
+	engine.disposition.Status = consensus.ValidationConflicting
+	delete(router.seqHash, validation.LedgerSeq)
+	router.handleValidationWorkResult(validationWorkResult{
+		validation: validation,
+		origin:     consensus.ValidationOrigin{PeerID: 9},
+	})
+	_, ok = router.seqHash[validation.LedgerSeq]
+	require.False(t, ok, "Byzantine validation must not drive acquisition")
+	require.Len(t, sender.relayed, 2, "valid Byzantine validation must still relay")
+	require.Empty(t, sender.bad, "Byzantine signer behavior must not charge the relay peer")
+}
+
+func TestRouterValidationAdmissionDropsUntrustedUnderLoadOrDivergence(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		prepare  func(*Router, *Adaptor)
+		tracking peermanagement.PeerTracking
+	}{
+		{
+			name: "local load",
+			prepare: func(_ *Router, adaptor *Adaptor) {
+				adaptor.LedgerService().FeeTrack().RaiseLocalFee()
+				adaptor.LedgerService().FeeTrack().RaiseLocalFee()
+			},
+		},
+		{
+			name:     "diverged peer",
+			tracking: peermanagement.PeerTrackingDiverged,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			adaptor := newTestAdaptor(t)
+			sender := &validationCaptureSender{}
+			adaptor.sender = sender
+			engine := &validationProcessorEngine{
+				mockEngine:  &mockEngine{},
+				disposition: consensus.ValidationDisposition{Relay: true},
+			}
+			router := NewRouter(engine, adaptor, nil)
+			router.setPeerSessionView(&validationPeerSessions{
+				peers: []peermanagement.PeerInfo{{
+					ID:       12,
+					Tracking: tc.tracking,
+				}},
+			})
+			if tc.prepare != nil {
+				tc.prepare(router, adaptor)
+			}
+
+			validation := &consensus.Validation{
+				Full:          true,
+				LedgerSeq:     42,
+				LedgerID:      consensus.LedgerID{1},
+				SigningPubKey: consensus.SigningPubKey{0x02, 1},
+				SignTime:      time.Now(),
+				Signature:     make([]byte, 70),
+			}
+			router.handleValidation(&peermanagement.InboundMessage{
+				PeerID: 12,
+				Payload: encodePayload(t, &message.Validation{
+					Validation: SerializeSTValidation(validation),
+				}),
+			})
+
+			require.Zero(t, engine.processedCount())
+			require.Empty(t, sender.bad,
+				"admission shedding occurs before signature verification")
+			sender.mu.Lock()
+			sourceCount := 0
+			for _, peers := range sender.sources {
+				sourceCount += len(peers)
+			}
+			sender.mu.Unlock()
+			require.Equal(t, 1, sourceCount,
+				"the proven inbound source is recorded before admission shedding")
+		})
+	}
+}
+
+func TestRouterValidationAdmissionKeepsTrustedUnderLocalLoad(t *testing.T) {
+	adaptor := newTestAdaptor(t)
+	adaptor.LedgerService().FeeTrack().RaiseLocalFee()
+	adaptor.LedgerService().FeeTrack().RaiseLocalFee()
+	engine := &validationProcessorEngine{
+		mockEngine: &mockEngine{},
+		disposition: consensus.ValidationDisposition{
+			Status:  consensus.ValidationCurrent,
+			Tracked: true,
+			Trusted: true,
+		},
+	}
+	router := NewRouter(engine, adaptor, nil)
+	validation := &consensus.Validation{
+		Full:      true,
+		LedgerSeq: 42,
+		LedgerID:  consensus.LedgerID{1},
+		SignTime:  time.Now(),
+	}
+	require.NoError(t, adaptor.identity.SignValidation(validation))
+
+	router.handleValidation(&peermanagement.InboundMessage{
+		PeerID: 12,
+		Payload: encodePayload(t, &message.Validation{
+			Validation: SerializeSTValidation(validation),
+		}),
+	})
+
+	require.Equal(t, 1, engine.processedCount())
+}

--- a/internal/consensus/adaptor/validation_work_test.go
+++ b/internal/consensus/adaptor/validation_work_test.go
@@ -78,9 +78,7 @@ func (s *validationCaptureSender) RecordMessageSource(hash [32]byte, peerID uint
 }
 
 type validationPeerSessions struct {
-	mu           sync.Mutex
-	peers        []peermanagement.PeerInfo
-	disconnected []peermanagement.PeerID
+	peers []peermanagement.PeerInfo
 }
 
 func (s *validationPeerSessions) IsPeerConnected(peermanagement.PeerID) bool {
@@ -89,19 +87,6 @@ func (s *validationPeerSessions) IsPeerConnected(peermanagement.PeerID) bool {
 
 func (s *validationPeerSessions) Peers() []peermanagement.PeerInfo {
 	return append([]peermanagement.PeerInfo(nil), s.peers...)
-}
-
-func (s *validationPeerSessions) DisconnectPeer(peerID peermanagement.PeerID) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.disconnected = append(s.disconnected, peerID)
-	return true
-}
-
-func (s *validationPeerSessions) disconnectedPeers() []peermanagement.PeerID {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return append([]peermanagement.PeerID(nil), s.disconnected...)
 }
 
 func TestValidationWorkLanePrioritizesTrustedQueue(t *testing.T) {
@@ -150,7 +135,41 @@ func TestValidationWorkLaneStopsWithoutClosingProducerChannels(t *testing.T) {
 		lane.submit(validationWork{validation: &consensus.Validation{}}))
 }
 
-func TestRouterTrustedValidationQueueFullDisconnectsPeerWithoutCrypto(t *testing.T) {
+func TestValidationWorkLaneLimitsTrustedClaimsPerPeer(t *testing.T) {
+	lane := newValidationWorkLane(func(*consensus.Validation) error { return nil }, nil, nil)
+	lane.workers = 0
+	lane.start(t.Context())
+	defer lane.stop()
+
+	for range trustedValidationPerPeerDepth {
+		require.Equal(t, validationQueueAccepted, lane.submit(validationWork{
+			validation: &consensus.Validation{},
+			origin:     consensus.ValidationOrigin{PeerID: 10},
+			trusted:    true,
+		}))
+	}
+	require.Equal(t, validationQueueSaturated, lane.submit(validationWork{
+		validation: &consensus.Validation{},
+		origin:     consensus.ValidationOrigin{PeerID: 10},
+		trusted:    true,
+	}))
+	require.Equal(t, validationQueueAccepted, lane.submit(validationWork{
+		validation: &consensus.Validation{},
+		origin:     consensus.ValidationOrigin{PeerID: 11},
+		trusted:    true,
+	}))
+
+	work, ok := lane.next(t.Context())
+	require.True(t, ok)
+	require.Equal(t, uint64(10), work.origin.PeerID)
+	require.Equal(t, validationQueueAccepted, lane.submit(validationWork{
+		validation: &consensus.Validation{},
+		origin:     consensus.ValidationOrigin{PeerID: 10},
+		trusted:    true,
+	}))
+}
+
+func TestRouterTrustedValidationQueueFullShedsWithoutCrypto(t *testing.T) {
 	adaptor := newTestAdaptor(t)
 	engine := &validationProcessorEngine{
 		mockEngine: &mockEngine{},
@@ -170,8 +189,6 @@ func TestRouterTrustedValidationQueueFullDisconnectsPeerWithoutCrypto(t *testing
 	lane.start(t.Context())
 	defer lane.stop()
 	router.validationWork = lane
-	sessions := &validationPeerSessions{}
-	router.setPeerSessionView(sessions)
 	var logs bytes.Buffer
 	router.logger = slog.New(slog.NewTextHandler(&logs, nil))
 
@@ -189,46 +206,81 @@ func TestRouterTrustedValidationQueueFullDisconnectsPeerWithoutCrypto(t *testing
 			origin:     consensus.ValidationOrigin{PeerID: 15},
 			trusted:    true,
 		})
-		require.Equal(t, validationWorkDisconnectedTrustedPeer, outcome)
+		require.Equal(t, validationWorkShedTrusted, outcome)
 	}
 	require.Zero(t, verifyCalls, "unverified trust claims must not force router-thread crypto")
 	require.Zero(t, engine.processedCount())
-	require.Len(t, sessions.disconnectedPeers(), 130)
-	require.Equal(t, uint64(130), router.validationTrustedOverloadDisconnect.Load())
-	require.Zero(t, router.validationTrustedOverloadUnresolved.Load())
+	require.Equal(t, uint64(130), router.validationShedTrusted.Load())
 	require.Zero(t, router.validationShedUntrusted.Load())
 	require.Equal(t, 3, strings.Count(logs.String(), "trusted validation verifier saturated"),
 		"saturation logs should emit for counts 1, 64, and 128")
 }
 
-func TestRouterTrustedValidationQueueFullWithoutTerminatorRecordsUnresolved(t *testing.T) {
-	adaptor := newTestAdaptor(t)
-	engine := &validationProcessorEngine{mockEngine: &mockEngine{}}
-	router := NewRouter(engine, adaptor, nil)
-	var logs bytes.Buffer
-	router.logger = slog.New(slog.NewTextHandler(&logs, nil))
-	lane := router.validationWork
-	lane.workers = 0
-	lane.start(t.Context())
-	defer lane.stop()
-	for range cap(lane.trustedJobs) {
-		require.Equal(t, validationQueueAccepted, lane.submit(validationWork{
-			validation: &consensus.Validation{},
-			trusted:    true,
-		}))
+func TestRouterValidationAdmissionFailureAllowsDuplicateRetry(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		trusted    bool
+		queue      func(*validationWorkLane) chan validationWork
+		validation func(*testing.T, *Adaptor) *consensus.Validation
+	}{
+		{
+			name:    "trusted",
+			trusted: true,
+			queue:   func(lane *validationWorkLane) chan validationWork { return lane.trustedJobs },
+			validation: func(t *testing.T, adaptor *Adaptor) *consensus.Validation {
+				validation := &consensus.Validation{
+					Full:      true,
+					LedgerSeq: 42,
+					LedgerID:  consensus.LedgerID{1},
+					SignTime:  time.Now(),
+				}
+				require.NoError(t, adaptor.identity.SignValidation(validation))
+				return validation
+			},
+		},
+		{
+			name:  "untrusted",
+			queue: func(lane *validationWorkLane) chan validationWork { return lane.untrustedJobs },
+			validation: func(_ *testing.T, _ *Adaptor) *consensus.Validation {
+				return &consensus.Validation{
+					Full:          true,
+					LedgerSeq:     42,
+					LedgerID:      consensus.LedgerID{1},
+					SigningPubKey: consensus.SigningPubKey{0x02, 1},
+					SignTime:      time.Now(),
+					Signature:     make([]byte, 70),
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			adaptor := newTestAdaptor(t)
+			router := NewRouter(&validationProcessorEngine{mockEngine: &mockEngine{}}, adaptor, nil)
+			lane := router.validationWork
+			lane.workers = 0
+			lane.start(t.Context())
+			defer lane.stop()
+			router.setPeerSessionView(&validationPeerSessions{})
+
+			jobs := tc.queue(lane)
+			for range cap(jobs) {
+				require.Equal(t, validationQueueAccepted, lane.submit(validationWork{
+					validation: &consensus.Validation{},
+					trusted:    tc.trusted,
+				}))
+			}
+
+			serialized := SerializeSTValidation(tc.validation(t, adaptor))
+			payload := encodePayload(t, &message.Validation{Validation: serialized})
+			suppressionHash := hashValidationSuppression(serialized)
+			router.handleValidation(&peermanagement.InboundMessage{PeerID: 12, Payload: payload})
+
+			require.False(t, router.messageSeen.seenRecently(suppressionHash))
+			<-jobs
+			router.handleValidation(&peermanagement.InboundMessage{PeerID: 13, Payload: payload})
+			require.Len(t, jobs, cap(jobs))
+		})
 	}
-
-	outcome := router.submitValidationWork(validationWork{
-		validation: &consensus.Validation{},
-		origin:     consensus.ValidationOrigin{PeerID: 17},
-		trusted:    true,
-	})
-
-	require.Equal(t, validationWorkTrustedOverloadUnresolved, outcome)
-	require.Equal(t, uint64(1), router.validationTrustedOverloadUnresolved.Load())
-	require.Zero(t, router.validationTrustedOverloadDisconnect.Load())
-	require.Zero(t, engine.processedCount())
-	require.Contains(t, logs.String(), "resolution=terminator-unavailable")
 }
 
 func TestRouterUntrustedValidationQueueSaturationRateLimited(t *testing.T) {
@@ -272,10 +324,19 @@ func TestValidationResultCapacityIsolatedAndRateLimited(t *testing.T) {
 	for range cap(lane.untrustedResultCh) {
 		lane.untrustedResultCh <- validationWorkResult{}
 	}
-	for range 130 {
-		outcome := lane.deliverResult(t.Context(), validationWorkResult{}, false)
+	suppressionHash := [32]byte{1}
+	router.messageSeen.observe(suppressionHash)
+	for i := range 130 {
+		result := validationWorkResult{}
+		if i == 0 {
+			result.validation = &consensus.Validation{SuppressionHash: suppressionHash}
+		}
+		outcome := lane.deliverResult(t.Context(), result, false)
 		require.Equal(t, validationResultUntrustedSaturated, outcome)
 	}
+	require.False(t, router.messageSeen.seenRecently(suppressionHash))
+	firstSeen, _ := router.messageSeen.observe(suppressionHash)
+	require.True(t, firstSeen)
 
 	trusted := validationWorkResult{
 		validation: &consensus.Validation{LedgerID: consensus.LedgerID{9}},

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -206,8 +206,7 @@ type NetworkBroadcaster interface {
 
 	// RelayProposal forwards a peer's proposal to others, honoring per-peer
 	// squelch and excluding exceptPeer (0 = all). SuppressionHash must be set:
-	// the overlay records each recipient in its reverse index for duplicate-
-	// arrival lookups.
+	// the overlay uses it to exclude known inbound sources and record relay time.
 	RelayProposal(proposal *Proposal, exceptPeer uint64) error
 
 	// RelayValidation forwards a peer's validation to others; same semantics

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -66,7 +66,6 @@ type VerifiedValidationProcessor interface {
 	ProcessVerifiedValidation(validation *Validation, origin ValidationOrigin) (ValidationDisposition, error)
 }
 
-// ValidationOrigin describes the peer that delivered a validation.
 type ValidationOrigin struct {
 	PeerID  uint64
 	Cluster bool
@@ -104,8 +103,6 @@ func (s ValidationStatus) String() string {
 	}
 }
 
-// ValidationDisposition tells the router which post-processing actions are
-// appropriate for a verified validation.
 type ValidationDisposition struct {
 	Status  ValidationStatus
 	Tracked bool

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -58,6 +58,67 @@ type Engine interface {
 	Subscribe(sub EventSubscriber)
 }
 
+// VerifiedValidationProcessor is implemented by engines that separate
+// signature verification from stateful validation processing. The router uses
+// this seam to verify on bounded worker queues, then serializes processing on
+// its own goroutine.
+type VerifiedValidationProcessor interface {
+	ProcessVerifiedValidation(validation *Validation, origin ValidationOrigin) (ValidationDisposition, error)
+}
+
+// ValidationOrigin describes the peer that delivered a validation.
+type ValidationOrigin struct {
+	PeerID  uint64
+	Cluster bool
+}
+
+// ValidationStatus describes how the validation tracker classified a verified
+// validation. Untracked means the signer was neither trusted nor listed.
+type ValidationStatus uint8
+
+const (
+	ValidationUntracked ValidationStatus = iota
+	ValidationCurrent
+	ValidationStale
+	ValidationBadSeq
+	ValidationMultiple
+	ValidationConflicting
+)
+
+func (s ValidationStatus) String() string {
+	switch s {
+	case ValidationUntracked:
+		return "untracked"
+	case ValidationCurrent:
+		return "current"
+	case ValidationStale:
+		return "stale"
+	case ValidationBadSeq:
+		return "badSeq"
+	case ValidationMultiple:
+		return "multiple"
+	case ValidationConflicting:
+		return "conflicting"
+	default:
+		return "unknown"
+	}
+}
+
+// ValidationDisposition tells the router which post-processing actions are
+// appropriate for a verified validation.
+type ValidationDisposition struct {
+	Status  ValidationStatus
+	Tracked bool
+	Trusted bool
+	Relay   bool
+}
+
+// AcquireEligible reports whether the validation can drive ledger catch-up.
+// Only trusted validations accepted as current participate.
+func (d ValidationDisposition) AcquireEligible() bool {
+	return d.Tracked && d.Trusted && d.Status == ValidationCurrent
+}
+
 // LedgerSwitchResult describes the outcome of a synchronous ledger switch.
 type LedgerSwitchResult uint8
 

--- a/internal/consensus/rcl/engine_handlers.go
+++ b/internal/consensus/rcl/engine_handlers.go
@@ -151,14 +151,39 @@ func (e *Engine) OnProposal(proposal *consensus.Proposal, originPeer uint64) err
 	return nil
 }
 
-// OnValidation handles an incoming validation. originPeer (0 = self) is
-// excluded from the RelayValidation gossip forward.
+// OnValidation is the synchronous compatibility path used by direct engine
+// callers. The network router verifies validations on its worker queues and
+// calls ProcessVerifiedValidation instead.
 func (e *Engine) OnValidation(validation *consensus.Validation, originPeer uint64) error {
-	// Verify before taking e.mu — see OnProposal.
 	if err := e.adaptor.VerifyValidation(validation); err != nil {
 		return fmt.Errorf("invalid validation signature: %w", err)
 	}
 
+	disposition, err := e.ProcessVerifiedValidation(validation, consensus.ValidationOrigin{PeerID: originPeer})
+	if err != nil {
+		return err
+	}
+	if disposition.Relay {
+		_ = e.adaptor.RelayValidation(validation, originPeer)
+	}
+	if disposition.Status == consensus.ValidationMultiple ||
+		disposition.Status == consensus.ValidationConflicting {
+		return &consensus.ByzantineValidationError{
+			NodeID:  validation.NodeID,
+			Reason:  disposition.Status.String(),
+			Trusted: disposition.Trusted,
+		}
+	}
+	return nil
+}
+
+// ProcessVerifiedValidation applies a signature-verified validation to local
+// consensus state. It deliberately performs no network I/O; the router acts on
+// the returned disposition after this method releases the engine lock.
+func (e *Engine) ProcessVerifiedValidation(
+	validation *consensus.Validation,
+	origin consensus.ValidationOrigin,
+) (consensus.ValidationDisposition, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -175,36 +200,20 @@ func (e *Engine) OnValidation(validation *consensus.Validation, originPeer uint6
 		tracked = e.listedOracle.IsListed(validation.NodeID)
 	}
 
-	// Operator [relay_validations] stance: "all" (the default, matching
-	// rippled) also forwards verified, current validations signed outside
-	// our UNL, so peers with a different UNL that do trust the signer still
-	// receive them.
-	relay := trusted || (e.relayPolicy != nil && e.relayPolicy.RelayUntrustedValidations())
-
-	// Feed the tracker — the gate that advances validated_ledger once a
-	// quorum of trusted FULL validations accumulates (partials steer the trie
-	// but don't count). Listed-but-untrusted keys are tracked too so a later
-	// trust change promotes what was already seen; untrusted-and-unlisted keys
-	// are dropped so the byNode map can't grow unboundedly.
-	//
-	// AddStatus doubles as the Byzantine detector: a validator must not sign
-	// two ledgers (or re-sign differently) for one seq, even a seq its tip has
-	// already superseded. On conflicting/multiple the validation is kept out
-	// of quorum/trie but STILL relayed under the relay policy (peers should
-	// observe it too) and no one is charged; the returned error only tells the
-	// router to skip the catch-up acquire, not to penalise the relaying peer.
-	if tracked && e.validationTracker != nil {
-		switch status := e.validationTracker.AddStatus(validation); status {
-		case ValStatusConflicting, ValStatusMultiple:
-			if relay {
-				e.adaptor.RelayValidation(validation, originPeer)
-			}
-			return &consensus.ByzantineValidationError{NodeID: validation.NodeID, Reason: status.String(), Trusted: trusted}
-		}
+	disposition := consensus.ValidationDisposition{
+		Status:  consensus.ValidationUntracked,
+		Tracked: tracked,
+		Trusted: trusted,
+		Relay: trusted ||
+			origin.Cluster ||
+			(e.relayPolicy != nil && e.relayPolicy.RelayUntrustedValidations()),
 	}
 
-	// Round-scoped bookkeeping stays trusted-only.
-	if trusted {
+	if tracked && e.validationTracker != nil {
+		disposition.Status = validationDispositionStatus(e.validationTracker.AddStatus(validation))
+	}
+
+	if disposition.AcquireEligible() {
 		e.proposalTracker.SetValidation(validation)
 	}
 
@@ -214,11 +223,24 @@ func (e *Engine) OnValidation(validation *consensus.Validation, originPeer uint6
 		Timestamp:  e.adaptor.Now(),
 	})
 
-	if relay {
-		e.adaptor.RelayValidation(validation, originPeer)
-	}
+	return disposition, nil
+}
 
-	return nil
+func validationDispositionStatus(status ValStatus) consensus.ValidationStatus {
+	switch status {
+	case ValStatusCurrent:
+		return consensus.ValidationCurrent
+	case ValStatusStale:
+		return consensus.ValidationStale
+	case ValStatusBadSeq:
+		return consensus.ValidationBadSeq
+	case ValStatusMultiple:
+		return consensus.ValidationMultiple
+	case ValStatusConflicting:
+		return consensus.ValidationConflicting
+	default:
+		return consensus.ValidationUntracked
+	}
 }
 
 // OnTxSet handles receiving a transaction set we requested.

--- a/internal/consensus/rcl/engine_validation_disposition_test.go
+++ b/internal/consensus/rcl/engine_validation_disposition_test.go
@@ -1,0 +1,149 @@
+package rcl
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessVerifiedValidationDisposition(t *testing.T) {
+	adaptor := newMockAdaptor()
+	trusted := consensus.NodeID{0x44}
+	adaptor.setTrusted([]consensus.NodeID{trusted})
+	engine := startedEngine(t, adaptor)
+	subscriber := &testSubscriber{events: make(chan consensus.Event, 4)}
+	engine.Subscribe(subscriber)
+	now := adaptor.Now()
+
+	current := &consensus.Validation{
+		LedgerSeq: 100,
+		LedgerID:  consensus.LedgerID{0xA},
+		NodeID:    trusted,
+		SignTime:  now,
+		SeenTime:  now,
+		Full:      true,
+	}
+	disposition, err := engine.ProcessVerifiedValidation(
+		current,
+		consensus.ValidationOrigin{PeerID: 7},
+	)
+	require.NoError(t, err)
+	require.Equal(t, consensus.ValidationDisposition{
+		Status:  consensus.ValidationCurrent,
+		Tracked: true,
+		Trusted: true,
+		Relay:   true,
+	}, disposition)
+	require.True(t, disposition.AcquireEligible())
+	require.Empty(t, adaptor.relayedValidations(),
+		"verified processing must not perform network I/O")
+
+	conflicting := &consensus.Validation{
+		LedgerSeq: 100,
+		LedgerID:  consensus.LedgerID{0xB},
+		NodeID:    trusted,
+		SignTime:  now,
+		SeenTime:  now,
+		Full:      true,
+	}
+	disposition, err = engine.ProcessVerifiedValidation(
+		conflicting,
+		consensus.ValidationOrigin{PeerID: 7},
+	)
+	require.NoError(t, err)
+	require.Equal(t, consensus.ValidationConflicting, disposition.Status)
+	require.True(t, disposition.Relay)
+	require.False(t, disposition.AcquireEligible())
+	require.Empty(t, adaptor.relayedValidations(),
+		"Byzantine validations are published locally but relayed by the router")
+
+	badSeq := &consensus.Validation{
+		LedgerSeq: 99,
+		LedgerID:  consensus.LedgerID{0x9},
+		NodeID:    trusted,
+		SignTime:  now,
+		SeenTime:  now,
+		Full:      true,
+	}
+	disposition, err = engine.ProcessVerifiedValidation(
+		badSeq,
+		consensus.ValidationOrigin{PeerID: 7},
+	)
+	require.NoError(t, err)
+	require.Equal(t, consensus.ValidationBadSeq, disposition.Status)
+	require.True(t, disposition.Relay)
+	require.False(t, disposition.AcquireEligible())
+
+	var validationEvents int
+	timeout := time.After(time.Second)
+	for validationEvents < 3 {
+		select {
+		case event := <-subscriber.events:
+			if _, ok := event.(*consensus.ValidationReceivedEvent); ok {
+				validationEvents++
+			}
+		case <-timeout:
+			t.Fatalf("received %d validation events, want 3", validationEvents)
+		}
+	}
+}
+
+func TestProcessVerifiedValidationClusterForcesRelay(t *testing.T) {
+	adaptor := newMockAdaptor()
+	engine := startedEngine(t, adaptor)
+	now := adaptor.Now()
+	validation := &consensus.Validation{
+		LedgerSeq: 200,
+		LedgerID:  consensus.LedgerID{0xC},
+		NodeID:    consensus.NodeID{0x55},
+		SignTime:  now,
+		SeenTime:  now,
+		Full:      true,
+	}
+
+	disposition, err := engine.ProcessVerifiedValidation(
+		validation,
+		consensus.ValidationOrigin{PeerID: 8, Cluster: true},
+	)
+	require.NoError(t, err)
+	require.Equal(t, consensus.ValidationUntracked, disposition.Status)
+	require.False(t, disposition.Tracked)
+	require.False(t, disposition.Trusted)
+	require.True(t, disposition.Relay)
+	require.False(t, disposition.AcquireEligible())
+	require.Empty(t, adaptor.relayedValidations())
+}
+
+func TestValidationDispositionStatusMappingAndAcquisitionGate(t *testing.T) {
+	tests := []struct {
+		input ValStatus
+		want  consensus.ValidationStatus
+	}{
+		{ValStatusCurrent, consensus.ValidationCurrent},
+		{ValStatusStale, consensus.ValidationStale},
+		{ValStatusBadSeq, consensus.ValidationBadSeq},
+		{ValStatusMultiple, consensus.ValidationMultiple},
+		{ValStatusConflicting, consensus.ValidationConflicting},
+	}
+	for _, test := range tests {
+		got := validationDispositionStatus(test.input)
+		require.Equal(t, test.want, got)
+		disposition := consensus.ValidationDisposition{
+			Status:  got,
+			Tracked: true,
+			Trusted: true,
+		}
+		require.Equal(t, got == consensus.ValidationCurrent, disposition.AcquireEligible())
+	}
+
+	require.False(t, (consensus.ValidationDisposition{
+		Status:  consensus.ValidationCurrent,
+		Tracked: true,
+	}).AcquireEligible())
+	require.False(t, (consensus.ValidationDisposition{
+		Status:  consensus.ValidationCurrent,
+		Trusted: true,
+	}).AcquireEligible())
+}

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -420,7 +420,7 @@ func (l *Ledger) OnTimer(now time.Time) TimerAction {
 	// No progress, budget remains: arm a by-hash escalation and surface the
 	// diagnostic that the swallowed Debug-level rejections used to hide.
 	l.byHash = true
-	l.logger.Warn("inbound ledger: no acquisition progress",
+	l.logger.Warn("inbound ledger: no progress in current interval",
 		"seq", l.seq,
 		"hash", fmt.Sprintf("%x", l.hash[:8]),
 		"timeouts", l.timeouts,

--- a/internal/ledger/inbound/onloop_test.go
+++ b/internal/ledger/inbound/onloop_test.go
@@ -1,6 +1,9 @@
 package inbound
 
 import (
+	"bytes"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -74,6 +77,34 @@ func TestLedger_OnTimer_FailsCleanlyAfterBudget(t *testing.T) {
 	}
 	if il.Err() == nil {
 		t.Fatal("a failed acquisition must carry a terminal error")
+	}
+}
+
+func TestLedger_OnTimer_ReportsIntervalStallWithLifetimeTotals(t *testing.T) {
+	t.Parallel()
+	var output bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&output, nil))
+	il := New([32]byte{0xAC}, 43, 1, logger)
+	il.state = StateWantState
+	il.stateRecv = 1365
+	il.stateUseful = 1365
+	base := time.Unix(1_700_000_000, 0)
+	il.lastTimer = base
+
+	if got := il.OnTimer(base.Add(acquireTimerInterval)); got != TimerEscalate {
+		t.Fatalf("timer action = %v, want TimerEscalate", got)
+	}
+	logged := output.String()
+	if !strings.Contains(logged, "no progress in current interval") {
+		t.Fatalf("interval-progress diagnostic missing from %q", logged)
+	}
+	for _, lifetimeField := range []string{
+		`"state_received_total":1365`,
+		`"state_useful_total":1365`,
+	} {
+		if !strings.Contains(logged, lifetimeField) {
+			t.Fatalf("lifetime progress %s missing from %q", lifetimeField, logged)
+		}
 	}
 }
 

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -288,7 +288,6 @@ func WithIPLimit(n int) Option {
 	}
 }
 
-// WithOutboundRetainedBytes sets the overlay-wide outbound memory ceiling.
 func WithOutboundRetainedBytes(bytes int64) Option {
 	return func(c *Config) {
 		c.OutboundRetainedBytes = bytes

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -3,6 +3,7 @@ package peermanagement
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"time"
 )
@@ -17,12 +18,30 @@ const (
 	DefaultConnectTimeout   = 10 * time.Second
 	DefaultHandshakeTimeout = 5 * time.Second
 
-	DefaultEventBufferSize     = 256
-	DefaultMessageBufferSize   = 256
-	DefaultSendBufferSize      = 64
-	acquisitionEventBufferSize = 16
-	acquisitionSendBufferSize  = 192
-	manifestSendBufferSize     = DefaultSendBufferSize
+	DefaultEventBufferSize             = 256
+	DefaultMessageBufferSize           = 256
+	DefaultSendBufferSize              = 64
+	DefaultOutboundRetainedBytes int64 = 8 * MaxMessageSize
+	acquisitionEventBufferSize         = 16
+
+	reliableSendBufferSize = 512
+
+	controlSendMinimum     = 8
+	consensusSendMinimum   = 256
+	acquisitionSendMinimum = 64
+	ordinarySendMinimum    = DefaultSendBufferSize
+
+	controlSendMaximum     = 16
+	consensusSendMaximum   = 320
+	acquisitionSendMaximum = 192
+	ordinarySendMaximum    = 128
+
+	bulkSequenceBufferSize         = 4
+	reliableFramesPerBulkFrame     = 16
+	outboundCriticalByteReserve    = 2 * 1024 * 1024
+	outboundNonCriticalByteMaximum = MaxMessageSize
+	outboundRetainedByteMaximum    = outboundNonCriticalByteMaximum + outboundCriticalByteReserve
+	maxOutboundReservedPeers       = (math.MaxInt64 - int64(outboundNonCriticalByteMaximum)) / int64(outboundCriticalByteReserve)
 
 	// DefaultLedgerDataBufferSize sizes the dedicated acquisition-reply
 	// lane (mtLEDGER_DATA and the replay-delta / proof-path responses).
@@ -50,6 +69,19 @@ func manifestMessageBufferSize(maxPeers int) int {
 		return 1
 	}
 	return maxPeers
+}
+
+// MinimumOutboundRetainedBytes returns the shared ceiling required to preserve
+// one critical reservation per configured peer.
+func MinimumOutboundRetainedBytes(maxPeers int) int64 {
+	if maxPeers <= 0 {
+		return int64(outboundNonCriticalByteMaximum)
+	}
+	if int64(maxPeers) > maxOutboundReservedPeers {
+		return math.MaxInt64
+	}
+	return int64(outboundNonCriticalByteMaximum) +
+		int64(maxPeers)*int64(outboundCriticalByteReserve)
 }
 
 // Config holds the configuration for the overlay network.
@@ -80,10 +112,13 @@ type Config struct {
 	HandshakeTimeout time.Duration
 
 	// Buffer sizes. EventBufferSize and MessageBufferSize size the
-	// overlay's internal channels (see New); the per-peer send queue is a
-	// fixed DefaultSendBufferSize.
+	// overlay's internal channels (see New).
 	EventBufferSize   int
 	MessageBufferSize int
+	// OutboundRetainedBytes bounds queued and actively written frame bytes
+	// across all peers. Noncritical traffic cannot consume the critical
+	// reserve derived from MaxPeers.
+	OutboundRetainedBytes int64
 
 	// MaxTransactions sizes the overlay's dedicated inbound
 	// TMTransaction lane. Inbound tx frames past this ceiling are shed
@@ -182,9 +217,10 @@ func DefaultConfig() Config {
 		ConnectTimeout:   DefaultConnectTimeout,
 		HandshakeTimeout: DefaultHandshakeTimeout,
 
-		EventBufferSize:   DefaultEventBufferSize,
-		MessageBufferSize: DefaultMessageBufferSize,
-		MaxTransactions:   DefaultMaxTransactions,
+		EventBufferSize:       DefaultEventBufferSize,
+		MessageBufferSize:     DefaultMessageBufferSize,
+		MaxTransactions:       DefaultMaxTransactions,
+		OutboundRetainedBytes: DefaultOutboundRetainedBytes,
 
 		// Reduce-relay is opt-in. Leaving these zero-valued avoids
 		// advertising vprr/txrr on a stock rippled network where peers
@@ -247,6 +283,13 @@ func WithMaxOutbound(n int) Option {
 func WithIPLimit(n int) Option {
 	return func(c *Config) {
 		c.IPLimit = n
+	}
+}
+
+// WithOutboundRetainedBytes sets the overlay-wide outbound memory ceiling.
+func WithOutboundRetainedBytes(bytes int64) Option {
+	return func(c *Config) {
+		c.OutboundRetainedBytes = bytes
 	}
 }
 
@@ -423,6 +466,17 @@ func (c *Config) Validate() error {
 	}
 	if c.MaxInbound+c.MaxOutbound > c.MaxPeers {
 		return errors.New("MaxInbound + MaxOutbound cannot exceed MaxPeers")
+	}
+	if int64(c.MaxPeers) > maxOutboundReservedPeers {
+		return errors.New("MaxPeers is too large for outbound critical reservations")
+	}
+	if c.OutboundRetainedBytes == 0 {
+		c.OutboundRetainedBytes = DefaultOutboundRetainedBytes
+	}
+	minimumOutboundBytes := MinimumOutboundRetainedBytes(c.MaxPeers)
+	if c.OutboundRetainedBytes < minimumOutboundBytes {
+		return fmt.Errorf("OutboundRetainedBytes must be at least %d for MaxPeers=%d",
+			minimumOutboundBytes, c.MaxPeers)
 	}
 	limit := c.IPLimit
 	if limit == 0 {

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -6,6 +6,8 @@ import (
 	"math"
 	"net"
 	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 )
 
 // Default configuration values.
@@ -39,7 +41,7 @@ const (
 	bulkSequenceBufferSize         = 4
 	reliableFramesPerBulkFrame     = 16
 	outboundCriticalByteReserve    = 2 * 1024 * 1024
-	outboundNonCriticalByteMaximum = MaxMessageSize
+	outboundNonCriticalByteMaximum = MaxMessageSize + message.HeaderSizeCompressed
 	outboundRetainedByteMaximum    = outboundNonCriticalByteMaximum + outboundCriticalByteReserve
 	maxOutboundReservedPeers       = (math.MaxInt64 - int64(outboundNonCriticalByteMaximum)) / int64(outboundCriticalByteReserve)
 

--- a/internal/peermanagement/disconnect_test.go
+++ b/internal/peermanagement/disconnect_test.go
@@ -87,3 +87,17 @@ func TestOverlay_Disconnect_NeverAddedPeer(t *testing.T) {
 	assert.Equal(t, 0, disconnected,
 		"closing a never-added peer must not emit a disconnect event")
 }
+
+func TestOverlayDisconnectPeerTerminatesLiveSession(t *testing.T) {
+	o, err := New(WithDataDir(t.TempDir()))
+	require.NoError(t, err)
+
+	peer := NewPeer(PeerID(19), Endpoint{Host: "127.0.0.1", Port: 51235}, true, o.identity, o.events)
+	peer.setState(PeerStateConnected)
+	require.NoError(t, o.addPeer(peer))
+
+	require.True(t, o.DisconnectPeer(peer.ID()))
+	require.Equal(t, PeerStateDisconnected, peer.State())
+	require.False(t, o.IsPeerConnected(peer.ID()))
+	require.False(t, o.DisconnectPeer(PeerID(20)))
+}

--- a/internal/peermanagement/disconnect_test.go
+++ b/internal/peermanagement/disconnect_test.go
@@ -87,17 +87,3 @@ func TestOverlay_Disconnect_NeverAddedPeer(t *testing.T) {
 	assert.Equal(t, 0, disconnected,
 		"closing a never-added peer must not emit a disconnect event")
 }
-
-func TestOverlayDisconnectPeerTerminatesLiveSession(t *testing.T) {
-	o, err := New(WithDataDir(t.TempDir()))
-	require.NoError(t, err)
-
-	peer := NewPeer(PeerID(19), Endpoint{Host: "127.0.0.1", Port: 51235}, true, o.identity, o.events)
-	peer.setState(PeerStateConnected)
-	require.NoError(t, o.addPeer(peer))
-
-	require.True(t, o.DisconnectPeer(peer.ID()))
-	require.Equal(t, PeerStateDisconnected, peer.State())
-	require.False(t, o.IsPeerConnected(peer.ID()))
-	require.False(t, o.DisconnectPeer(PeerID(20)))
-}

--- a/internal/peermanagement/errors.go
+++ b/internal/peermanagement/errors.go
@@ -9,19 +9,20 @@ import (
 // Sentinel errors for peer management operations.
 var (
 	// Connection errors
-	ErrMaxPeersReached    = errors.New("maximum peers reached")
-	ErrMaxInboundReached  = errors.New("maximum inbound connections reached")
-	ErrMaxOutboundReached = errors.New("maximum outbound connections reached")
-	ErrAlreadyConnected   = errors.New("already connected to peer")
-	ErrSelfConnection     = errors.New("cannot connect to self")
-	ErrSlotUnavailable    = errors.New("no connection slot available")
-	ErrConnectionClosed   = errors.New("connection closed")
-	ErrSendBufferFull     = errors.New("peer send buffer full")
-	ErrPingTimeout        = errors.New("peer ping timeout")
-	ErrLargeSendQueue     = errors.New("peer send queue saturated; closing")
-	ErrReadIdle           = errors.New("peer read idle deadline exceeded")
-	ErrFrameReadTooSlow   = errors.New("peer frame exceeded its read progress budget")
-	ErrWriteIdle          = errors.New("peer write idle deadline exceeded")
+	ErrMaxPeersReached       = errors.New("maximum peers reached")
+	ErrMaxInboundReached     = errors.New("maximum inbound connections reached")
+	ErrMaxOutboundReached    = errors.New("maximum outbound connections reached")
+	ErrAlreadyConnected      = errors.New("already connected to peer")
+	ErrSelfConnection        = errors.New("cannot connect to self")
+	ErrSlotUnavailable       = errors.New("no connection slot available")
+	ErrConnectionClosed      = errors.New("connection closed")
+	ErrSendBufferFull        = errors.New("peer send buffer full")
+	ErrCriticalSendQueueFull = errors.New("critical peer send queue exhausted")
+	ErrPingTimeout           = errors.New("peer ping timeout")
+	ErrLargeSendQueue        = errors.New("peer send queue saturated; closing")
+	ErrReadIdle              = errors.New("peer read idle deadline exceeded")
+	ErrFrameReadTooSlow      = errors.New("peer frame exceeded its read progress budget")
+	ErrWriteIdle             = errors.New("peer write idle deadline exceeded")
 
 	// Handshake errors
 	ErrHandshakeFailed  = errors.New("handshake failed")
@@ -48,6 +49,70 @@ var (
 	ErrNotRunning = errors.New("overlay not running")
 	ErrShutdown   = errors.New("overlay is shutting down")
 )
+
+// SendQueueError describes why a bounded outbound admission failed.
+type SendQueueError struct {
+	Class           OutboundSendClass
+	Reason          SendQueueFailureReason
+	AttemptedFrames int
+	AttemptedBytes  int64
+	RetainedFrames  int
+	RetainedBytes   int64
+}
+
+func (e *SendQueueError) Error() string {
+	base := ErrSendBufferFull
+	if e.Reason == SendQueueClosed {
+		base = ErrConnectionClosed
+	}
+	return fmt.Sprintf(
+		"%v: class=%s reason=%s attempted_frames=%d attempted_bytes=%d retained_frames=%d retained_bytes=%d",
+		base,
+		e.Class,
+		e.Reason,
+		e.AttemptedFrames,
+		e.AttemptedBytes,
+		e.RetainedFrames,
+		e.RetainedBytes,
+	)
+}
+
+func (e *SendQueueError) Unwrap() error {
+	switch {
+	case e.Reason == SendQueueClosed:
+		return ErrConnectionClosed
+	case e.Class == OutboundClassControl || e.Class == OutboundClassConsensus:
+		return errors.Join(ErrSendBufferFull, ErrCriticalSendQueueFull)
+	default:
+		return ErrSendBufferFull
+	}
+}
+
+// FanoutError summarizes enqueue failures from a broadcast and preserves every
+// cause for errors.Is and errors.As.
+type FanoutError struct {
+	Operation string
+	Attempted int
+	Failed    int
+	Critical  int
+	Err       error
+}
+
+func (e *FanoutError) Error() string {
+	return fmt.Sprintf(
+		"%s fanout: attempted=%d accepted=%d failed=%d critical=%d: %v",
+		e.Operation,
+		e.Attempted,
+		e.Attempted-e.Failed,
+		e.Failed,
+		e.Critical,
+		e.Err,
+	)
+}
+
+func (e *FanoutError) Unwrap() error {
+	return e.Err
+}
 
 var errCompressionUnnegotiated = errors.New("outbound compressed frame without negotiated compression")
 var errBootstrapManifestDropped = errors.New("bootstrap manifests could not be delivered")

--- a/internal/peermanagement/errors.go
+++ b/internal/peermanagement/errors.go
@@ -50,7 +50,6 @@ var (
 	ErrShutdown   = errors.New("overlay is shutting down")
 )
 
-// SendQueueError describes why a bounded outbound admission failed.
 type SendQueueError struct {
 	Class           OutboundSendClass
 	Reason          SendQueueFailureReason

--- a/internal/peermanagement/fetchpack_test.go
+++ b/internal/peermanagement/fetchpack_test.go
@@ -87,8 +87,7 @@ func TestServeFetchPack_RepliesWithPack(t *testing.T) {
 	require.Equal(t, 1, prov.calls, "MakeFetchPack must be invoked once")
 	require.Equal(t, haveHash, prov.gotHave[:], "the have-hash must be forwarded to the provider")
 
-	select {
-	case frame := <-peer.send:
+	if frame, ok := takeOutboundFrame(peer); ok {
 		require.GreaterOrEqual(t, len(frame), message.HeaderSizeUncompressed)
 		msgType := (uint16(frame[4]) << 8) | uint16(frame[5])
 		require.Equal(t, uint16(message.TypeGetObjects), msgType)
@@ -100,7 +99,7 @@ func TestServeFetchPack_RepliesWithPack(t *testing.T) {
 		assert.Equal(t, message.ObjectTypeFetchPack, gob.ObjType)
 		assert.Equal(t, haveHash, gob.LedgerHash)
 		assert.Len(t, gob.Objects, 2)
-	default:
+	} else {
 		t.Fatal("no fetch-pack reply was sent to the peer")
 	}
 }
@@ -127,10 +126,8 @@ func TestServeFetchPack_EmptyPackNoReply(t *testing.T) {
 	})
 
 	require.Equal(t, 1, prov.calls)
-	select {
-	case <-peer.send:
+	if _, ok := takeOutboundFrame(peer); ok {
 		t.Fatal("an empty pack must not produce a reply")
-	default:
 	}
 	assert.NotZero(t, peer.BadDataCount(),
 		"a valid fetch-pack request is charged feeHeavyBurdenPeer up front even when the pack is empty")
@@ -155,10 +152,8 @@ func TestServeFetchPack_TooEarlyAddsMalformedCharge(t *testing.T) {
 
 	require.Equal(t, 1, prov.calls)
 	assert.Greater(t, peer.Load(), controlPeer.Load())
-	select {
-	case <-peer.send:
+	if _, ok := takeOutboundFrame(peer); ok {
 		t.Fatal("a too-early fetch pack must not produce a reply")
-	default:
 	}
 }
 

--- a/internal/peermanagement/get_objects_serve_test.go
+++ b/internal/peermanagement/get_objects_serve_test.go
@@ -17,8 +17,7 @@ import (
 // frame is waiting.
 func decodeGetObjectsReply(t *testing.T, peer *Peer) *message.GetObjectByHash {
 	t.Helper()
-	select {
-	case frame := <-peer.send:
+	if frame, ok := takeOutboundFrame(peer); ok {
 		hdr, payload, err := message.ReadMessage(bytes.NewReader(frame))
 		require.NoError(t, err)
 		require.Equal(t, message.TypeGetObjects, hdr.MessageType)
@@ -27,7 +26,7 @@ func decodeGetObjectsReply(t *testing.T, peer *Peer) *message.GetObjectByHash {
 		reply, ok := decoded.(*message.GetObjectByHash)
 		require.True(t, ok)
 		return reply
-	default:
+	} else {
 		t.Fatal("expected a TMGetObjectByHash reply frame, got none")
 		return nil
 	}
@@ -123,10 +122,8 @@ func TestServeGetObjects_RejectsOversizedRequest(t *testing.T) {
 	o.serveGetObjects(peer.ID(), req)
 
 	assert.Zero(t, lookups, "an oversized request is rejected before any node-store lookup")
-	select {
-	case frame := <-peer.send:
+	if frame, ok := takeOutboundFrame(peer); ok {
 		t.Fatalf("no reply expected for an oversized request, got %d bytes", len(frame))
-	default:
 	}
 	assert.Positive(t, peer.Load(), "an oversized request must charge the peer")
 }
@@ -212,10 +209,8 @@ func TestServeGetObjects_NilProviderDropsWithoutCharge(t *testing.T) {
 	}
 	o.serveGetObjects(peer.ID(), req)
 
-	select {
-	case frame := <-peer.send:
+	if frame, ok := takeOutboundFrame(peer); ok {
 		t.Fatalf("no reply expected when no node store is wired, got %d bytes", len(frame))
-	default:
 	}
 	assert.Zero(t, peer.Load(), "unserved request must not charge the peer")
 }
@@ -244,10 +239,8 @@ func TestServeGetObjects_BadLedgerHashCharged(t *testing.T) {
 	o.serveGetObjects(peer.ID(), req)
 
 	assert.Zero(t, lookups, "a malformed ledger hash short-circuits before any fetch")
-	select {
-	case frame := <-peer.send:
+	if frame, ok := takeOutboundFrame(peer); ok {
 		t.Fatalf("no reply expected for a malformed ledger hash, got %d bytes", len(frame))
-	default:
 	}
 	assert.Positive(t, peer.Load(), "a malformed ledger hash must charge the peer")
 }

--- a/internal/peermanagement/outbound_budget.go
+++ b/internal/peermanagement/outbound_budget.go
@@ -1,0 +1,138 @@
+package peermanagement
+
+import "sync"
+
+type outboundBudget struct {
+	mu sync.Mutex
+
+	maxBytes            int64
+	generalLimit        int64
+	retainedBytes       int64
+	generalBytes        int64
+	maxReservedAccounts int
+	reservedAccounts    int
+	activeAccounts      int
+}
+
+type outboundBudgetAccount struct {
+	budget *outboundBudget
+
+	criticalBytes    int64
+	nonCriticalBytes int64
+	hasReserve       bool
+	attached         bool
+}
+
+func newOutboundBudget(maxBytes int64, maxPeers int) *outboundBudget {
+	return &outboundBudget{
+		maxBytes:            maxBytes,
+		generalLimit:        maxBytes - int64(maxPeers)*int64(outboundCriticalByteReserve),
+		maxReservedAccounts: maxPeers,
+	}
+}
+
+func (b *outboundBudget) attach() *outboundBudgetAccount {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	hasReserve := b.reservedAccounts < b.maxReservedAccounts
+	if hasReserve {
+		b.reservedAccounts++
+	}
+	b.activeAccounts++
+	return &outboundBudgetAccount{budget: b, hasReserve: hasReserve, attached: true}
+}
+
+func (a *outboundBudgetAccount) reserve(bytes int64, critical bool) bool {
+	if a == nil || bytes == 0 {
+		return true
+	}
+	b := a.budget
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !a.attached || bytes < 0 {
+		return false
+	}
+	if bytes > b.maxBytes-b.retainedBytes {
+		return false
+	}
+
+	generalDelta := bytes
+	if critical && a.hasReserve {
+		oldOverflow := max(int64(0), a.criticalBytes-int64(outboundCriticalByteReserve))
+		newOverflow := max(int64(0), a.criticalBytes+bytes-int64(outboundCriticalByteReserve))
+		generalDelta = newOverflow - oldOverflow
+	}
+	if generalDelta > b.generalLimit-b.generalBytes {
+		return false
+	}
+
+	b.retainedBytes += bytes
+	b.generalBytes += generalDelta
+	if critical {
+		a.criticalBytes += bytes
+	} else {
+		a.nonCriticalBytes += bytes
+	}
+	return true
+}
+
+func (a *outboundBudgetAccount) release(bytes int64, critical bool) {
+	if a == nil || bytes == 0 {
+		return
+	}
+	b := a.budget
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !a.attached {
+		return
+	}
+	a.releaseLocked(bytes, critical)
+}
+
+func (a *outboundBudgetAccount) releaseLocked(bytes int64, critical bool) {
+	b := a.budget
+	if critical && a.hasReserve {
+		oldOverflow := max(int64(0), a.criticalBytes-int64(outboundCriticalByteReserve))
+		a.criticalBytes -= bytes
+		newOverflow := max(int64(0), a.criticalBytes-int64(outboundCriticalByteReserve))
+		b.generalBytes -= oldOverflow - newOverflow
+	} else if critical {
+		a.criticalBytes -= bytes
+		b.generalBytes -= bytes
+	} else {
+		a.nonCriticalBytes -= bytes
+		b.generalBytes -= bytes
+	}
+	b.retainedBytes -= bytes
+}
+
+func (a *outboundBudgetAccount) close() {
+	if a == nil {
+		return
+	}
+	b := a.budget
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !a.attached {
+		return
+	}
+	a.releaseLocked(a.criticalBytes, true)
+	a.releaseLocked(a.nonCriticalBytes, false)
+	a.attached = false
+	if a.hasReserve {
+		b.reservedAccounts--
+	}
+	b.activeAccounts--
+}
+
+func (b *outboundBudget) snapshot() (retained, general int64) {
+	if b == nil {
+		return 0, 0
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.retainedBytes, b.generalBytes
+}

--- a/internal/peermanagement/outbound_emit_test.go
+++ b/internal/peermanagement/outbound_emit_test.go
@@ -80,12 +80,7 @@ func TestSendClusterUpdate_EmitsExportedConsumerGossip(t *testing.T) {
 
 	o.sendClusterUpdate()
 
-	var frame []byte
-	select {
-	case frame = <-peer.send:
-	default:
-		t.Fatal("cluster-member peer did not receive a TMCluster frame")
-	}
+	frame := requireOutboundFrame(t, peer)
 
 	_, payload, err := message.ReadMessage(bytes.NewReader(frame))
 	require.NoError(t, err)

--- a/internal/peermanagement/outbound_queue.go
+++ b/internal/peermanagement/outbound_queue.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 )
 
-// OutboundSendClass identifies an outbound admission class.
 type OutboundSendClass uint8
 
 const (
@@ -35,7 +34,6 @@ func (c OutboundSendClass) String() string {
 	}
 }
 
-// SendQueueFailureReason identifies the exhausted queue resource.
 type SendQueueFailureReason uint8
 
 const (

--- a/internal/peermanagement/outbound_queue.go
+++ b/internal/peermanagement/outbound_queue.go
@@ -1,0 +1,496 @@
+package peermanagement
+
+import (
+	"bytes"
+	"context"
+	"sync"
+)
+
+// OutboundSendClass identifies an outbound admission class.
+type OutboundSendClass uint8
+
+const (
+	OutboundClassControl OutboundSendClass = iota
+	OutboundClassConsensus
+	OutboundClassAcquisition
+	OutboundClassOrdinary
+	OutboundClassBulk
+	outboundClassCount
+)
+
+func (c OutboundSendClass) String() string {
+	switch c {
+	case OutboundClassControl:
+		return "control"
+	case OutboundClassConsensus:
+		return "consensus"
+	case OutboundClassAcquisition:
+		return "acquisition"
+	case OutboundClassOrdinary:
+		return "ordinary"
+	case OutboundClassBulk:
+		return "bulk"
+	default:
+		return "unknown"
+	}
+}
+
+// SendQueueFailureReason identifies the exhausted queue resource.
+type SendQueueFailureReason uint8
+
+const (
+	SendQueueClosed SendQueueFailureReason = iota
+	SendQueueFrameLimit
+	SendQueueByteLimit
+	SendQueueSequenceLimit
+	SendQueueSharedByteLimit
+)
+
+func (r SendQueueFailureReason) String() string {
+	switch r {
+	case SendQueueClosed:
+		return "closed"
+	case SendQueueFrameLimit:
+		return "frame_limit"
+	case SendQueueByteLimit:
+		return "byte_limit"
+	case SendQueueSequenceLimit:
+		return "sequence_limit"
+	case SendQueueSharedByteLimit:
+		return "shared_byte_limit"
+	default:
+		return "unknown"
+	}
+}
+
+type outboundFrame struct {
+	data  []byte
+	class OutboundSendClass
+}
+
+type outboundSequence struct {
+	frames [][]byte
+	next   int
+}
+
+type outboundToken struct {
+	id    uint64
+	data  []byte
+	class OutboundSendClass
+}
+
+type outboundQueueSnapshot struct {
+	ReliableQueued int
+	BulkQueued     int
+	InFlight       int
+	TotalFrames    int
+
+	ReliableBytes int64
+	BulkBytes     int64
+	InFlightBytes int64
+	TotalBytes    int64
+
+	BulkSequences int
+	ClassFrames   [outboundClassCount]int
+}
+
+type outboundQueue struct {
+	mu sync.Mutex
+
+	reliable     []outboundFrame
+	reliableHead int
+	bulk         []outboundSequence
+	bulkHead     int
+	inFlight     *outboundToken
+	nextTokenID  uint64
+
+	classFrames [outboundClassCount]int
+	totalFrames int
+	totalBytes  int64
+
+	reliableBytes int64
+	bulkBytes     int64
+
+	reliableBurst int
+	closed        bool
+	wake          chan struct{}
+	fatal         chan error
+	budget        *outboundBudgetAccount
+	onFatal       func(*SendQueueError)
+}
+
+func newOutboundQueue() *outboundQueue {
+	return &outboundQueue{
+		reliable: make([]outboundFrame, 0, reliableSendBufferSize),
+		bulk:     make([]outboundSequence, 0, bulkSequenceBufferSize),
+		wake:     make(chan struct{}, 1),
+		fatal:    make(chan error, 1),
+	}
+}
+
+func (q *outboundQueue) setBudget(budget *outboundBudget) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.totalFrames != 0 || q.totalBytes != 0 {
+		panic("cannot replace outbound budget with retained frames")
+	}
+	if q.budget != nil {
+		q.budget.close()
+	}
+	q.budget = budget.attach()
+}
+
+func (q *outboundQueue) setFatalObserver(observer func(*SendQueueError)) {
+	q.mu.Lock()
+	q.onFatal = observer
+	q.mu.Unlock()
+}
+
+func (q *outboundQueue) enqueueReliable(class OutboundSendClass, data []byte) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.closed {
+		return q.failureLocked(class, SendQueueClosed, 1, int64(len(data)))
+	}
+	if !q.canAdmitReliableLocked(class) {
+		err := q.failureLocked(class, SendQueueFrameLimit, 1, int64(len(data)))
+		q.signalFatalLocked(class, err)
+		return err
+	}
+	if !q.canAdmitBytesLocked(class, int64(len(data))) {
+		err := q.failureLocked(class, SendQueueByteLimit, 1, int64(len(data)))
+		q.signalFatalLocked(class, err)
+		return err
+	}
+	critical := outboundClassIsCritical(class)
+	if !q.budget.reserve(int64(len(data)), critical) {
+		err := q.failureLocked(class, SendQueueSharedByteLimit, 1, int64(len(data)))
+		q.signalFatalLocked(class, err)
+		return err
+	}
+
+	owned := bytes.Clone(data)
+	q.reliable = append(q.reliable, outboundFrame{data: owned, class: class})
+	q.classFrames[class]++
+	q.totalFrames++
+	q.totalBytes += int64(len(owned))
+	q.reliableBytes += int64(len(owned))
+	q.signalWakeLocked()
+	return nil
+}
+
+func (q *outboundQueue) enqueueBulk(frames [][]byte) error {
+	batch := make([][]byte, 0, len(frames))
+	var totalBytes int64
+	for _, frame := range frames {
+		if len(frame) == 0 {
+			continue
+		}
+		batch = append(batch, frame)
+		totalBytes += int64(len(frame))
+	}
+	if len(batch) == 0 {
+		return nil
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.closed {
+		return q.failureLocked(OutboundClassBulk, SendQueueClosed, len(batch), totalBytes)
+	}
+	if len(q.bulk)-q.bulkHead >= bulkSequenceBufferSize {
+		return q.failureLocked(OutboundClassBulk, SendQueueSequenceLimit, len(batch), totalBytes)
+	}
+	if !q.canAdmitBytesLocked(OutboundClassBulk, totalBytes) {
+		return q.failureLocked(OutboundClassBulk, SendQueueByteLimit, len(batch), totalBytes)
+	}
+	if !q.budget.reserve(totalBytes, false) {
+		return q.failureLocked(OutboundClassBulk, SendQueueSharedByteLimit, len(batch), totalBytes)
+	}
+
+	owned := make([][]byte, len(batch))
+	for i, frame := range batch {
+		owned[i] = bytes.Clone(frame)
+	}
+	q.bulk = append(q.bulk, outboundSequence{frames: owned})
+	q.classFrames[OutboundClassBulk] += len(owned)
+	q.totalFrames += len(owned)
+	q.totalBytes += totalBytes
+	q.bulkBytes += totalBytes
+	q.signalWakeLocked()
+	return nil
+}
+
+func (q *outboundQueue) canAdmitReliableLocked(class OutboundSendClass) bool {
+	if class >= OutboundClassBulk || q.classFrames[class] >= outboundClassMaximum(class) {
+		return false
+	}
+
+	reliableFrames := 0
+	for candidate := OutboundClassControl; candidate <= OutboundClassOrdinary; candidate++ {
+		reliableFrames += q.classFrames[candidate]
+	}
+	if reliableFrames >= reliableSendBufferSize {
+		return false
+	}
+
+	freeAfter := reliableSendBufferSize - reliableFrames - 1
+	protected := 0
+	for candidate := OutboundClassControl; candidate <= OutboundClassOrdinary; candidate++ {
+		if candidate == class {
+			continue
+		}
+		if deficit := outboundClassMinimum(candidate) - q.classFrames[candidate]; deficit > 0 {
+			protected += deficit
+		}
+	}
+	return freeAfter >= protected
+}
+
+func (q *outboundQueue) canAdmitBytesLocked(class OutboundSendClass, bytes int64) bool {
+	if bytes < 0 {
+		return false
+	}
+	limit := int64(outboundNonCriticalByteMaximum)
+	if class == OutboundClassControl || class == OutboundClassConsensus {
+		limit = int64(outboundRetainedByteMaximum)
+	}
+	return bytes <= limit-q.totalBytes
+}
+
+func outboundClassIsCritical(class OutboundSendClass) bool {
+	return class == OutboundClassControl || class == OutboundClassConsensus
+}
+
+func outboundClassMinimum(class OutboundSendClass) int {
+	switch class {
+	case OutboundClassControl:
+		return controlSendMinimum
+	case OutboundClassConsensus:
+		return consensusSendMinimum
+	case OutboundClassAcquisition:
+		return acquisitionSendMinimum
+	case OutboundClassOrdinary:
+		return ordinarySendMinimum
+	default:
+		return 0
+	}
+}
+
+func outboundClassMaximum(class OutboundSendClass) int {
+	switch class {
+	case OutboundClassControl:
+		return controlSendMaximum
+	case OutboundClassConsensus:
+		return consensusSendMaximum
+	case OutboundClassAcquisition:
+		return acquisitionSendMaximum
+	case OutboundClassOrdinary:
+		return ordinarySendMaximum
+	default:
+		return 0
+	}
+}
+
+func (q *outboundQueue) failureLocked(
+	class OutboundSendClass,
+	reason SendQueueFailureReason,
+	frames int,
+	bytes int64,
+) error {
+	return &SendQueueError{
+		Class:           class,
+		Reason:          reason,
+		AttemptedFrames: frames,
+		AttemptedBytes:  bytes,
+		RetainedFrames:  q.totalFrames,
+		RetainedBytes:   q.totalBytes,
+	}
+}
+
+func (q *outboundQueue) signalFatalLocked(class OutboundSendClass, err error) {
+	if class != OutboundClassControl && class != OutboundClassConsensus {
+		return
+	}
+	select {
+	case q.fatal <- err:
+		if queueErr, ok := err.(*SendQueueError); ok && q.onFatal != nil {
+			q.onFatal(queueErr)
+		}
+	default:
+	}
+}
+
+func (q *outboundQueue) signalWakeLocked() {
+	select {
+	case q.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (q *outboundQueue) next(ctx context.Context) (outboundToken, error) {
+	for {
+		q.mu.Lock()
+		if q.closed {
+			q.mu.Unlock()
+			return outboundToken{}, ErrConnectionClosed
+		}
+		if q.inFlight == nil {
+			if token, ok := q.nextLocked(); ok {
+				q.inFlight = &token
+				q.mu.Unlock()
+				return token, nil
+			}
+		}
+		q.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return outboundToken{}, ctx.Err()
+		case <-q.wake:
+		}
+	}
+}
+
+func (q *outboundQueue) nextLocked() (outboundToken, bool) {
+	hasReliable := q.reliableHead < len(q.reliable)
+	hasBulk := q.bulkHead < len(q.bulk)
+	if !hasReliable && !hasBulk {
+		return outboundToken{}, false
+	}
+
+	if hasBulk && (!hasReliable || q.reliableBurst >= reliableFramesPerBulkFrame) {
+		sequence := &q.bulk[q.bulkHead]
+		frame := sequence.frames[sequence.next]
+		sequence.frames[sequence.next] = nil
+		sequence.next++
+		q.bulkBytes -= int64(len(frame))
+		q.reliableBurst = 0
+		return q.newTokenLocked(frame, OutboundClassBulk), true
+	}
+
+	frame := q.reliable[q.reliableHead]
+	q.reliable[q.reliableHead] = outboundFrame{}
+	q.reliableHead++
+	q.reliableBytes -= int64(len(frame.data))
+	if q.reliableBurst < reliableFramesPerBulkFrame {
+		q.reliableBurst++
+	}
+	q.compactReliableLocked()
+	return q.newTokenLocked(frame.data, frame.class), true
+}
+
+func (q *outboundQueue) newTokenLocked(data []byte, class OutboundSendClass) outboundToken {
+	q.nextTokenID++
+	return outboundToken{id: q.nextTokenID, data: data, class: class}
+}
+
+func (q *outboundQueue) complete(token outboundToken) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.inFlight == nil || q.inFlight.id != token.id {
+		return
+	}
+	q.totalFrames--
+	q.totalBytes -= int64(len(token.data))
+	q.classFrames[token.class]--
+	critical := outboundClassIsCritical(token.class)
+	q.budget.release(int64(len(token.data)), critical)
+	q.inFlight = nil
+
+	if token.class == OutboundClassBulk && q.bulkHead < len(q.bulk) {
+		sequence := &q.bulk[q.bulkHead]
+		if sequence.next == len(sequence.frames) {
+			*sequence = outboundSequence{}
+			q.bulkHead++
+			q.compactBulkLocked()
+		}
+	}
+	q.signalWakeLocked()
+}
+
+func (q *outboundQueue) compactReliableLocked() {
+	if q.reliableHead == len(q.reliable) {
+		q.reliable = q.reliable[:0]
+		q.reliableHead = 0
+		return
+	}
+	if q.reliableHead >= 256 && q.reliableHead*2 >= len(q.reliable) {
+		copy(q.reliable, q.reliable[q.reliableHead:])
+		q.reliable = q.reliable[:len(q.reliable)-q.reliableHead]
+		q.reliableHead = 0
+	}
+}
+
+func (q *outboundQueue) compactBulkLocked() {
+	if q.bulkHead == len(q.bulk) {
+		q.bulk = q.bulk[:0]
+		q.bulkHead = 0
+		return
+	}
+	if q.bulkHead >= bulkSequenceBufferSize {
+		copy(q.bulk, q.bulk[q.bulkHead:])
+		q.bulk = q.bulk[:len(q.bulk)-q.bulkHead]
+		q.bulkHead = 0
+	}
+}
+
+func (q *outboundQueue) snapshot() outboundQueueSnapshot {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	snapshot := outboundQueueSnapshot{
+		ReliableQueued: len(q.reliable) - q.reliableHead,
+		ReliableBytes:  q.reliableBytes,
+		BulkSequences:  len(q.bulk) - q.bulkHead,
+		BulkBytes:      q.bulkBytes,
+		TotalFrames:    q.totalFrames,
+		TotalBytes:     q.totalBytes,
+		ClassFrames:    q.classFrames,
+	}
+	for i := q.bulkHead; i < len(q.bulk); i++ {
+		snapshot.BulkQueued += len(q.bulk[i].frames) - q.bulk[i].next
+	}
+	if q.inFlight != nil {
+		snapshot.InFlight = 1
+		snapshot.InFlightBytes = int64(len(q.inFlight.data))
+	}
+	return snapshot
+}
+
+func (q *outboundQueue) fatalSignal() <-chan error {
+	return q.fatal
+}
+
+func (q *outboundQueue) close() {
+	q.mu.Lock()
+	if q.closed {
+		q.mu.Unlock()
+		return
+	}
+	q.closed = true
+	q.budget.close()
+	q.budget = nil
+
+	for i := range q.reliable {
+		q.reliable[i] = outboundFrame{}
+	}
+	for i := range q.bulk {
+		q.bulk[i] = outboundSequence{}
+	}
+	q.reliable = nil
+	q.bulk = nil
+	q.reliableHead = 0
+	q.bulkHead = 0
+	q.inFlight = nil
+	q.classFrames = [outboundClassCount]int{}
+	q.totalFrames = 0
+	q.totalBytes = 0
+	q.reliableBytes = 0
+	q.bulkBytes = 0
+	q.signalWakeLocked()
+	q.mu.Unlock()
+}

--- a/internal/peermanagement/outbound_queue_test.go
+++ b/internal/peermanagement/outbound_queue_test.go
@@ -1,0 +1,453 @@
+package peermanagement
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fatalRunConn struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newFatalRunConn() *fatalRunConn {
+	return &fatalRunConn{closed: make(chan struct{})}
+}
+
+func (c *fatalRunConn) Read([]byte) (int, error) {
+	<-c.closed
+	return 0, net.ErrClosed
+}
+
+func (c *fatalRunConn) Write([]byte) (int, error) {
+	<-c.closed
+	return 0, net.ErrClosed
+}
+
+func (c *fatalRunConn) Close() error {
+	c.once.Do(func() { close(c.closed) })
+	return nil
+}
+
+func (*fatalRunConn) LocalAddr() net.Addr              { return livenessAddr("local") }
+func (*fatalRunConn) RemoteAddr() net.Addr             { return livenessAddr("remote") }
+func (*fatalRunConn) SetDeadline(time.Time) error      { return nil }
+func (*fatalRunConn) SetReadDeadline(time.Time) error  { return nil }
+func (*fatalRunConn) SetWriteDeadline(time.Time) error { return nil }
+
+func TestOutboundQueueReliableFIFOAndBulkFairness(t *testing.T) {
+	queue := newOutboundQueue()
+	for i := range reliableFramesPerBulkFrame + 1 {
+		class := OutboundClassOrdinary
+		if i%2 == 1 {
+			class = OutboundClassAcquisition
+		}
+		require.NoError(t, queue.enqueueReliable(class, []byte{0x52, byte(i)}))
+	}
+	require.NoError(t, queue.enqueueBulk([][]byte{{0x42, 0}, {0x42, 1}}))
+
+	for i := range reliableFramesPerBulkFrame {
+		token, err := queue.next(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, []byte{0x52, byte(i)}, token.data)
+		snapshot := queue.snapshot()
+		assert.Equal(t, 1, snapshot.InFlight)
+		assert.Equal(t, reliableFramesPerBulkFrame+3-i, snapshot.TotalFrames)
+		queue.complete(token)
+	}
+
+	token, err := queue.next(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x42, 0}, token.data)
+	queue.complete(token)
+
+	token, err = queue.next(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x52, reliableFramesPerBulkFrame}, token.data)
+	queue.complete(token)
+
+	token, err = queue.next(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x42, 1}, token.data)
+	queue.complete(token)
+	assert.Zero(t, queue.snapshot().TotalFrames)
+}
+
+func TestOutboundQueueProtectedMinimaAndHardMaxima(t *testing.T) {
+	queue := newOutboundQueue()
+	for range ordinarySendMinimum {
+		require.NoError(t, queue.enqueueReliable(OutboundClassOrdinary, []byte{1}))
+	}
+	for range acquisitionSendMinimum {
+		require.NoError(t, queue.enqueueReliable(OutboundClassAcquisition, []byte{1}))
+	}
+	for range consensusSendMinimum {
+		require.NoError(t, queue.enqueueReliable(OutboundClassConsensus, []byte{1}))
+	}
+	for range controlSendMinimum {
+		require.NoError(t, queue.enqueueReliable(OutboundClassControl, []byte{1}))
+	}
+
+	for range consensusSendMaximum - consensusSendMinimum {
+		require.NoError(t, queue.enqueueReliable(OutboundClassConsensus, []byte{1}))
+	}
+	err := queue.enqueueReliable(OutboundClassConsensus, []byte{1})
+	require.ErrorIs(t, err, ErrSendBufferFull)
+	require.ErrorIs(t, err, ErrCriticalSendQueueFull)
+
+	var queueErr *SendQueueError
+	require.ErrorAs(t, err, &queueErr)
+	assert.Equal(t, OutboundClassConsensus, queueErr.Class)
+	assert.Equal(t, SendQueueFrameLimit, queueErr.Reason)
+	select {
+	case fatal := <-queue.fatalSignal():
+		assert.True(t, errors.Is(fatal, ErrCriticalSendQueueFull))
+	default:
+		t.Fatal("critical admission exhaustion did not signal the peer lifecycle")
+	}
+}
+
+func TestOutboundQueueRetainedByteLimitsIncludeInFlight(t *testing.T) {
+	queue := newOutboundQueue()
+	queue.mu.Lock()
+	queue.totalBytes = int64(outboundNonCriticalByteMaximum - 1)
+	queue.mu.Unlock()
+
+	require.NoError(t, queue.enqueueReliable(OutboundClassOrdinary, []byte{1}))
+	token, err := queue.next(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(outboundNonCriticalByteMaximum), queue.snapshot().TotalBytes)
+
+	err = queue.enqueueReliable(OutboundClassOrdinary, []byte{1})
+	require.ErrorIs(t, err, ErrSendBufferFull)
+	var queueErr *SendQueueError
+	require.ErrorAs(t, err, &queueErr)
+	assert.Equal(t, SendQueueByteLimit, queueErr.Reason)
+
+	require.NoError(t, queue.enqueueReliable(
+		OutboundClassConsensus,
+		make([]byte, outboundCriticalByteReserve),
+	))
+	err = queue.enqueueReliable(OutboundClassControl, []byte{1})
+	require.ErrorIs(t, err, ErrCriticalSendQueueFull)
+
+	queue.complete(token)
+}
+
+func TestOutboundQueueCloseReleasesQueuedAndInFlightAccounting(t *testing.T) {
+	queue := newOutboundQueue()
+	require.NoError(t, queue.enqueueReliable(OutboundClassOrdinary, []byte("reliable")))
+	require.NoError(t, queue.enqueueBulk([][]byte{[]byte("bulk-1"), []byte("bulk-2")}))
+	token, err := queue.next(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, token.data)
+	require.Positive(t, queue.snapshot().TotalBytes)
+
+	queue.close()
+	snapshot := queue.snapshot()
+	assert.Zero(t, snapshot.TotalFrames)
+	assert.Zero(t, snapshot.TotalBytes)
+	assert.Zero(t, snapshot.InFlight)
+	assert.Zero(t, snapshot.BulkSequences)
+	assert.Nil(t, queue.reliable)
+	assert.Nil(t, queue.bulk)
+	require.ErrorIs(t, queue.enqueueReliable(OutboundClassOrdinary, []byte{1}), ErrConnectionClosed)
+
+	queue.complete(token)
+	assert.Zero(t, queue.snapshot().TotalFrames)
+}
+
+func TestOutboundBudgetIsSharedAndRetainsInFlightReservations(t *testing.T) {
+	maxBytes := int64(outboundNonCriticalByteMaximum + 2*outboundCriticalByteReserve)
+	budget := newOutboundBudget(maxBytes, 2)
+	first := newOutboundQueue()
+	second := newOutboundQueue()
+	first.setBudget(budget)
+	second.setBudget(budget)
+	preseed := budget.generalLimit - 1
+	require.True(t, first.budget.reserve(preseed, false))
+
+	require.NoError(t, first.enqueueReliable(OutboundClassOrdinary, []byte{1}))
+	token, err := first.next(context.Background())
+	require.NoError(t, err)
+
+	err = second.enqueueReliable(OutboundClassOrdinary, []byte{1})
+	require.ErrorIs(t, err, ErrSendBufferFull)
+	var queueErr *SendQueueError
+	require.ErrorAs(t, err, &queueErr)
+	assert.Equal(t, SendQueueSharedByteLimit, queueErr.Reason)
+
+	require.NoError(t, second.enqueueReliable(
+		OutboundClassConsensus,
+		make([]byte, outboundCriticalByteReserve),
+	))
+	first.complete(token)
+	require.NoError(t, second.enqueueReliable(OutboundClassOrdinary, []byte{1}))
+
+	first.close()
+	second.close()
+	retained, general := budget.snapshot()
+	assert.Zero(t, retained)
+	assert.Zero(t, general)
+}
+
+func TestOutboundBudgetProtectsEveryHealthyPeersCriticalSlice(t *testing.T) {
+	const peers = 3
+	maxBytes := int64(outboundNonCriticalByteMaximum + peers*outboundCriticalByteReserve)
+	budget := newOutboundBudget(maxBytes, peers)
+	queues := []*outboundQueue{newOutboundQueue(), newOutboundQueue(), newOutboundQueue()}
+	for _, queue := range queues {
+		queue.setBudget(budget)
+		t.Cleanup(queue.close)
+	}
+
+	require.True(t, queues[0].budget.reserve(budget.generalLimit, false))
+	require.NoError(t, queues[0].enqueueReliable(
+		OutboundClassConsensus,
+		make([]byte, outboundCriticalByteReserve),
+	))
+	err := queues[0].enqueueReliable(OutboundClassConsensus, []byte{1})
+	require.ErrorIs(t, err, ErrCriticalSendQueueFull)
+	var queueErr *SendQueueError
+	require.ErrorAs(t, err, &queueErr)
+	assert.Equal(t, SendQueueSharedByteLimit, queueErr.Reason)
+
+	for _, queue := range queues[1:] {
+		require.NoError(t, queue.enqueueReliable(
+			OutboundClassConsensus,
+			make([]byte, outboundCriticalByteReserve),
+		))
+	}
+	assert.Equal(t, maxBytes, func() int64 {
+		retained, _ := budget.snapshot()
+		return retained
+	}())
+}
+
+func TestOutboundBudgetAdditionalReservedPeerDoesNotPanic(t *testing.T) {
+	maxBytes := int64(outboundNonCriticalByteMaximum + outboundCriticalByteReserve)
+	budget := newOutboundBudget(maxBytes, 1)
+	first := newOutboundQueue()
+	second := newOutboundQueue()
+	first.setBudget(budget)
+	second.setBudget(budget)
+
+	assert.True(t, first.budget.hasReserve)
+	assert.False(t, second.budget.hasReserve)
+	require.True(t, first.budget.reserve(budget.generalLimit, false))
+	require.NoError(t, first.enqueueReliable(
+		OutboundClassConsensus,
+		make([]byte, outboundCriticalByteReserve),
+	))
+	require.ErrorIs(t,
+		second.enqueueReliable(OutboundClassConsensus, []byte{1}),
+		ErrCriticalSendQueueFull,
+	)
+
+	first.close()
+	second.close()
+	budget.mu.Lock()
+	assert.Zero(t, budget.activeAccounts)
+	assert.Zero(t, budget.reservedAccounts)
+	budget.mu.Unlock()
+}
+
+func TestOutboundRetainedBytesConfigDefaultsAndValidates(t *testing.T) {
+	cfg := DefaultConfig()
+	assert.Equal(t, DefaultOutboundRetainedBytes, cfg.OutboundRetainedBytes)
+
+	cfg.OutboundRetainedBytes = 0
+	require.NoError(t, cfg.Validate())
+	assert.Equal(t, DefaultOutboundRetainedBytes, cfg.OutboundRetainedBytes)
+
+	cfg = DefaultConfig()
+	cfg.OutboundRetainedBytes = int64(outboundNonCriticalByteMaximum) +
+		int64(cfg.MaxPeers)*int64(outboundCriticalByteReserve) - 1
+	require.Error(t, cfg.Validate())
+}
+
+func TestOutboundBudgetAttachesProductionPeersToOneSharedInstance(t *testing.T) {
+	overlay := &Overlay{
+		outboundBudget: newOutboundBudget(DefaultOutboundRetainedBytes, DefaultMaxPeers),
+	}
+	first := newLatencyTestPeer(t)
+	second := newLatencyTestPeer(t)
+	overlay.attachOutboundBudget(first)
+	overlay.attachOutboundBudget(second)
+	assert.Same(t, overlay.outboundBudget, first.outbound.budget.budget)
+	assert.Same(t, first.outbound.budget.budget, second.outbound.budget.budget)
+	assert.NotSame(t, first.outbound.budget, second.outbound.budget)
+}
+
+func TestOverlayCountsOneShotLocalAndSharedCriticalFailures(t *testing.T) {
+	const peers = 2
+	overlay := &Overlay{
+		outboundBudget: newOutboundBudget(
+			int64(outboundNonCriticalByteMaximum+peers*outboundCriticalByteReserve),
+			peers,
+		),
+	}
+	localPeer := newLatencyTestPeer(t)
+	sharedPeer := newLatencyTestPeer(t)
+	overlay.attachOutboundBudget(localPeer)
+	overlay.attachOutboundBudget(sharedPeer)
+
+	for range controlSendMinimum {
+		require.NoError(t, localPeer.outbound.enqueueReliable(OutboundClassControl, []byte{1}))
+	}
+	for range acquisitionSendMinimum {
+		require.NoError(t, localPeer.outbound.enqueueReliable(OutboundClassAcquisition, []byte{1}))
+	}
+	for range ordinarySendMinimum {
+		require.NoError(t, localPeer.outbound.enqueueReliable(OutboundClassOrdinary, []byte{1}))
+	}
+	for range consensusSendMaximum {
+		require.NoError(t, localPeer.outbound.enqueueReliable(OutboundClassConsensus, []byte{1}))
+	}
+	require.ErrorIs(t,
+		localPeer.outbound.enqueueReliable(OutboundClassConsensus, []byte{1}),
+		ErrCriticalSendQueueFull,
+	)
+	require.ErrorIs(t,
+		localPeer.outbound.enqueueReliable(OutboundClassConsensus, []byte{1}),
+		ErrCriticalSendQueueFull,
+	)
+
+	_, generalUsed := overlay.outboundBudget.snapshot()
+	require.True(t, sharedPeer.outbound.budget.reserve(
+		overlay.outboundBudget.generalLimit-generalUsed,
+		false,
+	))
+	require.NoError(t, sharedPeer.outbound.enqueueReliable(
+		OutboundClassConsensus,
+		make([]byte, outboundCriticalByteReserve),
+	))
+	require.ErrorIs(t,
+		sharedPeer.outbound.enqueueReliable(OutboundClassConsensus, []byte{1}),
+		ErrCriticalSendQueueFull,
+	)
+	require.ErrorIs(t,
+		sharedPeer.outbound.enqueueReliable(OutboundClassConsensus, []byte{1}),
+		ErrCriticalSendQueueFull,
+	)
+
+	local, shared := overlay.OutboundCriticalQueueFailures()
+	assert.Equal(t, uint64(1), local)
+	assert.Equal(t, uint64(1), shared)
+}
+
+func TestPeerRunTerminatesOnCriticalQueueExhaustion(t *testing.T) {
+	peer := newLatencyTestPeer(t)
+	conn := newFatalRunConn()
+	peer.conn = conn
+	peer.bufReader = bufio.NewReader(conn)
+	peer.setState(PeerStateConnected)
+
+	for range controlSendMinimum {
+		require.NoError(t, peer.outbound.enqueueReliable(OutboundClassControl, []byte{1}))
+	}
+	for range acquisitionSendMinimum {
+		require.NoError(t, peer.outbound.enqueueReliable(OutboundClassAcquisition, []byte{1}))
+	}
+	for range ordinarySendMinimum {
+		require.NoError(t, peer.outbound.enqueueReliable(OutboundClassOrdinary, []byte{1}))
+	}
+	for range consensusSendMaximum {
+		require.NoError(t, peer.outbound.enqueueReliable(OutboundClassConsensus, []byte{1}))
+	}
+	require.ErrorIs(t,
+		peer.outbound.enqueueReliable(OutboundClassConsensus, []byte{1}),
+		ErrCriticalSendQueueFull,
+	)
+
+	done := make(chan error, 1)
+	go func() { done <- peer.Run(context.Background()) }()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, ErrCriticalSendQueueFull)
+	case <-time.After(time.Second):
+		t.Fatal("Peer.Run did not terminate on critical queue exhaustion")
+	}
+	assert.True(t, peer.closed.Load())
+	assert.Equal(t, PeerStateDisconnected, peer.State())
+	assert.Zero(t, peer.SendQueueLen())
+}
+
+func TestOutboundQueueOwnsAcceptedFrameBytes(t *testing.T) {
+	queue := newOutboundQueue()
+	reliable := []byte("reliable")
+	bulkFirst := []byte("bulk-first")
+	bulkSecond := []byte("bulk-second")
+	require.NoError(t, queue.enqueueReliable(OutboundClassOrdinary, reliable))
+	require.NoError(t, queue.enqueueBulk([][]byte{bulkFirst, bulkSecond}))
+
+	copy(reliable, []byte("mutated!"))
+	copy(bulkFirst, []byte("changed-one"))
+	copy(bulkSecond, []byte("changed-two"))
+
+	token, err := queue.next(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []byte("reliable"), token.data)
+	queue.complete(token)
+	token, err = queue.next(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []byte("bulk-first"), token.data)
+	queue.complete(token)
+	token, err = queue.next(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []byte("bulk-second"), token.data)
+	queue.complete(token)
+}
+
+func TestValidationBurstBlockedWritersPreservesEveryAcceptedFrame(t *testing.T) {
+	first := newLatencyTestPeer(t)
+	second := newLatencyTestPeer(t)
+	peers := []*Peer{first, second}
+
+	expected := make([][]byte, 0, 257)
+	for i := 0; i < 255; i++ {
+		frame := outboundTestFrame(t, message.TypeValidation, []byte{byte(i), byte(i >> 8)})
+		expected = append(expected, frame)
+		for _, peer := range peers {
+			require.NoError(t, peer.Send(frame), "validation %d", i)
+		}
+	}
+	transaction := outboundTestFrame(t, message.TypeTransaction, []byte("transaction"))
+	acquisition := outboundTestFrame(t, message.TypeGetLedger, []byte("acquisition"))
+	expected = append(expected, transaction, acquisition)
+	for _, peer := range peers {
+		require.NoError(t, peer.Send(transaction))
+		require.NoError(t, peer.SendPriority(acquisition))
+		snapshot := peer.outbound.snapshot()
+		assert.Equal(t, 255, snapshot.ClassFrames[OutboundClassConsensus])
+		assert.Equal(t, 1, snapshot.ClassFrames[OutboundClassOrdinary])
+		assert.Equal(t, 1, snapshot.ClassFrames[OutboundClassAcquisition])
+		assert.Equal(t, len(expected), snapshot.TotalFrames)
+	}
+
+	for _, peer := range peers {
+		for index, want := range expected {
+			got, ok := takeOutboundFrame(peer)
+			require.True(t, ok, "accepted frame %d disappeared", index)
+			assert.Equal(t, want, got, "FIFO mismatch at frame %d", index)
+		}
+		assert.Zero(t, peer.SendQueueLen())
+	}
+}
+
+func outboundTestFrame(t *testing.T, messageType message.MessageType, payload []byte) []byte {
+	t.Helper()
+	var frame bytes.Buffer
+	require.NoError(t, message.WriteMessage(&frame, messageType, payload))
+	return frame.Bytes()
+}

--- a/internal/peermanagement/outbound_queue_test.go
+++ b/internal/peermanagement/outbound_queue_test.go
@@ -144,6 +144,14 @@ func TestOutboundQueueRetainedByteLimitsIncludeInFlight(t *testing.T) {
 	queue.complete(token)
 }
 
+func TestOutboundQueueByteLimitAllowsMaximumPayloadAndHeader(t *testing.T) {
+	queue := newOutboundQueue()
+	maxFrameBytes := int64(message.MaxMessageSize + message.HeaderSizeCompressed)
+
+	assert.True(t, queue.canAdmitBytesLocked(OutboundClassOrdinary, maxFrameBytes))
+	assert.False(t, queue.canAdmitBytesLocked(OutboundClassOrdinary, maxFrameBytes+1))
+}
+
 func TestOutboundQueueCloseReleasesQueuedAndInFlightAccounting(t *testing.T) {
 	queue := newOutboundQueue()
 	require.NoError(t, queue.enqueueReliable(OutboundClassOrdinary, []byte("reliable")))

--- a/internal/peermanagement/outbound_queue_test_helpers_test.go
+++ b/internal/peermanagement/outbound_queue_test_helpers_test.go
@@ -1,0 +1,33 @@
+package peermanagement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func takeOutboundFrame(peer *Peer) ([]byte, bool) {
+	queue := peer.outbound
+	queue.mu.Lock()
+	if queue.closed || queue.inFlight != nil {
+		queue.mu.Unlock()
+		return nil, false
+	}
+	token, ok := queue.nextLocked()
+	if !ok {
+		queue.mu.Unlock()
+		return nil, false
+	}
+	queue.inFlight = &token
+	queue.mu.Unlock()
+	data := token.data
+	queue.complete(token)
+	return data, true
+}
+
+func requireOutboundFrame(t *testing.T, peer *Peer) []byte {
+	t.Helper()
+	frame, ok := takeOutboundFrame(peer)
+	require.True(t, ok, "expected an outbound frame")
+	return frame
+}

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -899,7 +899,6 @@ func (o *Overlay) attachOutboundBudget(peer *Peer) {
 	})
 }
 
-// OutboundCriticalQueueFailures reports peer-terminal admission failures.
 func (o *Overlay) OutboundCriticalQueueFailures() (local, shared uint64) {
 	return o.outboundCriticalLocalFailures.Load(), o.outboundCriticalSharedFailures.Load()
 }

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -63,13 +63,16 @@ type Overlay struct {
 	ledgerSync *LedgerSyncHandler
 
 	// Peer management
-	peers          map[PeerID]*Peer
-	peerKeys       map[string]PeerID
-	peerEndpoints  map[string]PeerID
-	inboundIPs     map[string]int
-	pendingInbound map[PeerID]struct{}
-	peersMu        sync.RWMutex
-	nextID         atomic.Uint64
+	peers                          map[PeerID]*Peer
+	peerKeys                       map[string]PeerID
+	peerEndpoints                  map[string]PeerID
+	inboundIPs                     map[string]int
+	pendingInbound                 map[PeerID]struct{}
+	peersMu                        sync.RWMutex
+	nextID                         atomic.Uint64
+	outboundBudget                 *outboundBudget
+	outboundCriticalLocalFailures  atomic.Uint64
+	outboundCriticalSharedFailures atomic.Uint64
 
 	// peerWG joins every peer.Run goroutine launched by handleInbound
 	// or Connect. Stop blocks on it for deterministic shutdown.
@@ -91,14 +94,15 @@ type Overlay struct {
 	bootstrapLeases  map[PeerID]*bootstrapLease
 	bootstrapDiag    atomic.Uint64
 
-	// relayedIndex maps suppression-hash → set of peers known to have
-	// that message. Populated as we forward a validator message (each
-	// recipient joins the set) and queried by the consensus router on
-	// duplicate arrivals so ALL known-havers feed the reduce-relay
-	// slot — not just the peer that delivered the current duplicate.
+	// relayedIndex maps a suppression hash to peers that delivered the
+	// corresponding message to us. Outbound recipients are never recorded.
 	relayedIndex   map[[32]byte]*relayedEntry
 	relayedIndexMu sync.Mutex
 	clockForIndex  func() time.Time
+
+	fanoutLogMu         sync.Mutex
+	fanoutLogLast       time.Time
+	fanoutLogSuppressed int
 
 	// Coordination channels
 	//
@@ -861,6 +865,7 @@ func New(opts ...Option) (*Overlay, error) {
 		inboundSem:               make(chan struct{}, inboundCap),
 		outboundSem:              make(chan struct{}, outboundCap),
 		resourceManager:          resource.NewManager(nil, nil),
+		outboundBudget:           newOutboundBudget(cfg.OutboundRetainedBytes, cfg.MaxPeers),
 	}
 	if identity != nil {
 		o.localNodeIdentity = identity.PublicKey()
@@ -881,6 +886,22 @@ func New(opts ...Option) (*Overlay, error) {
 	o.ledgerSync.SetPeerLedgerHintLookup(o.PeersWithClosedLedger)
 
 	return o, nil
+}
+
+func (o *Overlay) attachOutboundBudget(peer *Peer) {
+	peer.outbound.setBudget(o.outboundBudget)
+	peer.outbound.setFatalObserver(func(err *SendQueueError) {
+		if err.Reason == SendQueueSharedByteLimit {
+			o.outboundCriticalSharedFailures.Add(1)
+			return
+		}
+		o.outboundCriticalLocalFailures.Add(1)
+	})
+}
+
+// OutboundCriticalQueueFailures reports peer-terminal admission failures.
+func (o *Overlay) OutboundCriticalQueueFailures() (local, shared uint64) {
+	return o.outboundCriticalLocalFailures.Load(), o.outboundCriticalSharedFailures.Load()
 }
 
 // chargeIgnoredSquelch is the Relay-layer callback fired when a peer

--- a/internal/peermanagement/overlay_broadcast.go
+++ b/internal/peermanagement/overlay_broadcast.go
@@ -7,76 +7,128 @@ import (
 	"time"
 )
 
-// RelayedIndexTTL bounds how long a suppression-key → peers entry is
-// kept in the reverse index. Must match the consensus router's
-// messageDedupTTL so that a hash remains queryable for as long as the
-// router may observe duplicates for it. If the index expired before
-// the dedup window, a duplicate hitting router.handleProposal could
-// find no "peers that have the message" entry and under-feed the
-// slot — the exact bug B3 was filed to fix.
-const RelayedIndexTTL = 30 * time.Second
+// RelayedIndexTTL matches rippled's default HashRouter hold time.
+const RelayedIndexTTL = 300 * time.Second
 
-// RelayedIndexMaxEntries caps memory for the reverse index under
-// adversarial traffic. Sized to match the adaptor's dedup cap so both
-// age out together under sustained churn.
-const RelayedIndexMaxEntries = 4096
+// RelayedIndexMaxEntries caps inbound source tracking under adversarial
+// traffic.
+const RelayedIndexMaxEntries = 65_536
 
-// relayedEntry is one bucket in the reverse index — the set of peers
-// we know "have" a given suppression-key, plus the last-update time
-// for TTL reaping.
+// relayedEntry holds peers that delivered a message to us. Outbound
+// recipients are never added.
 type relayedEntry struct {
-	peers  map[PeerID]struct{}
-	seenAt time.Time
+	peers     map[PeerID]struct{}
+	seenAt    time.Time
+	relayedAt time.Time
 }
 
-// sendAndLog sends msg to peer and logs a failure under opName:
-// ErrSendBufferFull at Warn (silent drops masked TMTransaction relay loss
-// in #401), other failures at Info. Shared by the broadcast / relay
-// fan-out loops below.
-func (o *Overlay) sendAndLog(peer *Peer, msg []byte, opName string, priority bool) {
-	var err error
-	if priority {
-		err = peer.SendPriority(msg)
-	} else {
-		err = peer.Send(msg)
+const fanoutLogInterval = time.Second
+
+type connectedPeer struct {
+	id   PeerID
+	peer *Peer
+}
+
+type fanoutResult struct {
+	operation string
+	attempted int
+	failed    int
+	critical  int
+	causes    []error
+}
+
+func (r *fanoutResult) record(err error) {
+	r.attempted++
+	if err == nil {
+		return
 	}
-	if err != nil {
-		level := slog.LevelInfo
-		if errors.Is(err, ErrSendBufferFull) {
-			level = slog.LevelWarn
-		}
-		slog.Log(context.Background(), level, opName+" send failed",
-			"t", "Overlay",
-			"peer", peer.ID(),
-			"frame_size", len(msg),
-			"err", err.Error(),
-		)
+	r.failed++
+	r.causes = append(r.causes, err)
+	if errors.Is(err, ErrCriticalSendQueueFull) {
+		r.critical++
 	}
 }
 
-// forEachConnected sends msg to every connected peer for which skip
-// returns false (skip nil = no filter), logging Send failures under
-// opName. Holds peersMu.RLock for the iteration and returns the peer IDs
-// the frame was handed to (best-effort: included even when the Send
-// errored, matching the reverse-index contract). Extracts the
-// send-and-log fan-out shared by Broadcast / BroadcastExcept /
-// BroadcastExceptSet / RelayFromValidator.
-func (o *Overlay) forEachConnected(msg []byte, opName string, priority bool, skip func(PeerID, *Peer) bool) []PeerID {
+func (r *fanoutResult) err() error {
+	if r.failed == 0 {
+		return nil
+	}
+	return &FanoutError{
+		Operation: r.operation,
+		Attempted: r.attempted,
+		Failed:    r.failed,
+		Critical:  r.critical,
+		Err:       errors.Join(r.causes...),
+	}
+}
+
+func (o *Overlay) connectedPeers() []connectedPeer {
 	o.peersMu.RLock()
-	defer o.peersMu.RUnlock()
-
-	var sent []PeerID
+	peers := make([]connectedPeer, 0, len(o.peers))
 	for id, peer := range o.peers {
-		if peer.State() != PeerStateConnected {
-			continue
+		if peer.State() == PeerStateConnected {
+			peers = append(peers, connectedPeer{id: id, peer: peer})
 		}
-		if skip != nil && skip(id, peer) {
-			continue
-		}
-		o.sendAndLog(peer, msg, opName, priority)
-		sent = append(sent, id)
 	}
-	return sent
+	o.peersMu.RUnlock()
+	return peers
+}
+
+func sendPeer(peer *Peer, msg []byte, priority bool) error {
+	if priority {
+		return peer.SendPriority(msg)
+	}
+	return peer.Send(msg)
+}
+
+func (o *Overlay) logFanoutFailure(err error) {
+	if err == nil {
+		return
+	}
+	var summary *FanoutError
+	if !errors.As(err, &summary) {
+		return
+	}
+
+	now := time.Now()
+	o.fanoutLogMu.Lock()
+	if summary.Critical == 0 &&
+		!o.fanoutLogLast.IsZero() &&
+		now.Sub(o.fanoutLogLast) < fanoutLogInterval {
+		o.fanoutLogSuppressed += summary.Failed
+		o.fanoutLogMu.Unlock()
+		return
+	}
+	suppressed := o.fanoutLogSuppressed
+	o.fanoutLogSuppressed = 0
+	o.fanoutLogLast = now
+	o.fanoutLogMu.Unlock()
+
+	level := slog.LevelInfo
+	if errors.Is(summary, ErrSendBufferFull) {
+		level = slog.LevelWarn
+	}
+	slog.Log(context.Background(), level, summary.Operation+" fanout enqueue failures",
+		"t", "Overlay",
+		"attempted", summary.Attempted,
+		"failed", summary.Failed,
+		"critical", summary.Critical,
+		"suppressed_since_last_log", suppressed,
+		"err", summary.Err,
+	)
+}
+
+func (o *Overlay) forEachConnected(msg []byte, operation string, priority bool, skip func(PeerID, *Peer) bool) error {
+	result := fanoutResult{operation: operation}
+	for _, target := range o.connectedPeers() {
+		if skip != nil && skip(target.id, target.peer) {
+			continue
+		}
+		result.record(sendPeer(target.peer, msg, priority))
+	}
+	err := result.err()
+	o.logFanoutFailure(err)
+	return err
 }
 
 // Broadcast sends a message to all connected peers, unfiltered. Used
@@ -90,8 +142,7 @@ func (o *Overlay) forEachConnected(msg []byte, opName string, priority bool, ski
 // forwarded, use RelayFromValidator which applies the squelch filter
 // and excludes the originating peer.
 func (o *Overlay) Broadcast(msg []byte) error {
-	o.forEachConnected(msg, "broadcast", false, nil)
-	return nil
+	return o.forEachConnected(msg, "broadcast", false, nil)
 }
 
 // BroadcastManifestFrames schedules one paced manifest sequence for every
@@ -102,32 +153,22 @@ func (o *Overlay) BroadcastManifestFrames(frames [][]byte) error {
 }
 
 func (o *Overlay) BroadcastManifestFramesExcept(exceptPeer PeerID, frames [][]byte) error {
-	o.peersMu.RLock()
-	defer o.peersMu.RUnlock()
-	for id, peer := range o.peers {
-		if peer.State() != PeerStateConnected {
+	result := fanoutResult{operation: "broadcast-manifests"}
+	for _, target := range o.connectedPeers() {
+		if exceptPeer != 0 && target.id == exceptPeer {
 			continue
 		}
-		if exceptPeer != 0 && id == exceptPeer {
-			continue
-		}
-		if err := peer.SendManifestFrames(frames); err != nil {
-			level := slog.LevelInfo
-			if errors.Is(err, ErrSendBufferFull) {
-				level = slog.LevelWarn
-			}
-			slog.Log(context.Background(), level, "broadcast-manifests send failed",
-				"t", "Overlay", "peer", peer.ID(), "frames", len(frames), "err", err.Error())
-		}
+		result.record(target.peer.SendManifestFrames(frames))
 	}
-	return nil
+	err := result.err()
+	o.logFanoutFailure(err)
+	return err
 }
 
-// BroadcastPriority sends acquisition and control traffic to all connected
-// peers using each peer's independent priority queue.
+// BroadcastPriority admits acquisition traffic to each peer's protected share
+// of the reliable FIFO.
 func (o *Overlay) BroadcastPriority(msg []byte) error {
-	o.forEachConnected(msg, "broadcast-priority", true, nil)
-	return nil
+	return o.forEachConnected(msg, "broadcast-priority", true, nil)
 }
 
 // BroadcastExcept sends a message to every connected peer except the
@@ -135,10 +176,9 @@ func (o *Overlay) BroadcastPriority(msg []byte) error {
 // RelayFromValidator doesn't apply. Pass 0 for exceptPeer to fall through
 // to a plain Broadcast.
 func (o *Overlay) BroadcastExcept(exceptPeer PeerID, msg []byte) error {
-	o.forEachConnected(msg, "broadcast-except", false, func(id PeerID, _ *Peer) bool {
+	return o.forEachConnected(msg, "broadcast-except", false, func(id PeerID, _ *Peer) bool {
 		return id == exceptPeer
 	})
-	return nil
 }
 
 // BroadcastExceptSet sends a message to every connected peer whose
@@ -175,22 +215,11 @@ func (o *Overlay) broadcastExceptSet(excluded map[PeerID]bool, msg []byte, prior
 		}
 		return o.Broadcast(msg)
 	}
-	// Hold peersMu for the whole pass so the #724 starvation decision and
-	// the sends observe the same connected set: a peer joining or leaving
-	// between a separate "all excluded?" scan and the send loop could
-	// either starve the broadcast or skip a now-eligible peer. This can't
-	// reuse forEachConnected (which takes its own lock), so the
-	// scan-then-send is inlined under a single RLock.
-	o.peersMu.RLock()
-	defer o.peersMu.RUnlock()
-
+	peers := o.connectedPeers()
 	connected, eligible := 0, 0
-	for id, peer := range o.peers {
-		if peer.State() != PeerStateConnected {
-			continue
-		}
+	for _, target := range peers {
 		connected++
-		if !excluded[id] {
+		if !excluded[target.id] {
 			eligible++
 		}
 	}
@@ -198,16 +227,16 @@ func (o *Overlay) broadcastExceptSet(excluded map[PeerID]bool, msg []byte, prior
 	// rather than dropping the request on the floor.
 	ignoreExclusion := eligible == 0 && connected > 0
 
-	for id, peer := range o.peers {
-		if peer.State() != PeerStateConnected {
+	result := fanoutResult{operation: "broadcast-except-set"}
+	for _, target := range peers {
+		if !ignoreExclusion && excluded[target.id] {
 			continue
 		}
-		if !ignoreExclusion && excluded[id] {
-			continue
-		}
-		o.sendAndLog(peer, msg, "broadcast-except-set", priority)
+		result.record(sendPeer(target.peer, msg, priority))
 	}
-	return nil
+	err := result.err()
+	o.logFanoutFailure(err)
+	return err
 }
 
 // RelayFromValidator forwards a peer-originated validator message
@@ -217,35 +246,33 @@ func (o *Overlay) broadcastExceptSet(excluded map[PeerID]bool, msg []byte, prior
 // when no peer should be excluded (e.g. tests that synthesize a relay).
 //
 // suppressionHash is the consensus-router suppression key for this
-// message (same [32]byte used by the dedup cache). Every peer we
-// actually send to is recorded in the reverse index so a later
-// duplicate arrival from ANOTHER peer can query
-// Overlay.PeersThatHave(suppressionHash) and feed the reduce-relay
-// slot with the full set of known-havers.
+// message. Peers that previously delivered the same hash are atomically
+// released from the inbound source index and excluded from this relay.
 //
 // The squelch is consulted before each outbound send and expired
 // squelches auto-clear via Peer.ExpireSquelch. Self-origin is handled
 // by a separate code path (see Broadcast) that skips the filter
 // entirely.
 func (o *Overlay) RelayFromValidator(validator []byte, suppressionHash [32]byte, exceptPeer PeerID, msg []byte) error {
-	// forEachConnected returns the peers we forwarded to (best-effort,
-	// including any whose Send errored). Record into the reverse index
-	// AFTER it releases peersMu so we never nest index-mutex inside
-	// peers-mutex.
-	forwarded := o.forEachConnected(msg, "relay-from-validator", false, func(id PeerID, peer *Peer) bool {
-		return id == exceptPeer || !peer.ExpireSquelch(validator)
-	})
-
-	if len(forwarded) > 0 {
-		o.recordRelayedPeers(suppressionHash, forwarded)
+	sources := o.releaseMessageSources(suppressionHash)
+	sourceSet := make(map[PeerID]struct{}, len(sources))
+	for _, id := range sources {
+		sourceSet[id] = struct{}{}
 	}
-	return nil
+
+	err := o.forEachConnected(msg, "relay-from-validator", false, func(id PeerID, peer *Peer) bool {
+		_, wasSource := sourceSet[id]
+		return wasSource || id == exceptPeer || !peer.ExpireSquelch(validator)
+	})
+	for _, id := range sources {
+		o.OnValidatorMessage(validator, id)
+	}
+	return err
 }
 
-// recordRelayedPeers adds peerIDs to the reverse-index bucket for
-// suppressionHash, trimming expired buckets if we hit the size cap.
-// Safe for concurrent callers.
-func (o *Overlay) recordRelayedPeers(suppressionHash [32]byte, peerIDs []PeerID) {
+// RecordMessageSource records an inbound peer as a source of the message.
+// It must be called for every arrival, including duplicates.
+func (o *Overlay) RecordMessageSource(suppressionHash [32]byte, peerID PeerID) {
 	if o.relayedIndex == nil {
 		return
 	}
@@ -258,18 +285,20 @@ func (o *Overlay) recordRelayedPeers(suppressionHash [32]byte, peerIDs []PeerID)
 	o.relayedIndexMu.Lock()
 	defer o.relayedIndexMu.Unlock()
 
-	// Trim if we're at capacity. A cheap TTL sweep rather than a
-	// formal LRU — the index is a cache, not a hot path.
-	if len(o.relayedIndex) >= RelayedIndexMaxEntries {
+	entry, ok := o.relayedIndex[suppressionHash]
+	if ok && now.Sub(entry.seenAt) >= RelayedIndexTTL {
+		delete(o.relayedIndex, suppressionHash)
+		entry = nil
+		ok = false
+	}
+
+	if !ok && len(o.relayedIndex) >= RelayedIndexMaxEntries {
 		cutoff := now.Add(-RelayedIndexTTL)
 		for h, e := range o.relayedIndex {
 			if e.seenAt.Before(cutoff) {
 				delete(o.relayedIndex, h)
 			}
 		}
-		// If that didn't free enough space (adversarial churn), drop
-		// half the map — bounded worst case, same shape as the
-		// messageSuppression eviction in the consensus router.
 		if len(o.relayedIndex) >= RelayedIndexMaxEntries {
 			i := 0
 			for h := range o.relayedIndex {
@@ -282,21 +311,17 @@ func (o *Overlay) recordRelayedPeers(suppressionHash [32]byte, peerIDs []PeerID)
 		}
 	}
 
-	entry, ok := o.relayedIndex[suppressionHash]
 	if !ok {
 		entry = &relayedEntry{peers: make(map[PeerID]struct{})}
 		o.relayedIndex[suppressionHash] = entry
 	}
-	for _, id := range peerIDs {
-		entry.peers[id] = struct{}{}
-	}
+	entry.peers[peerID] = struct{}{}
 	entry.seenAt = now
 }
 
 // PeersThatHave returns the set of peer IDs known to have the message
-// whose suppression-hash is `suppressionHash`. Entries are populated
-// when we relay a validator message outward (RelayFromValidator) and
-// expire after RelayedIndexTTL.
+// whose suppression-hash is suppressionHash. The set contains only
+// inbound sources and expires after RelayedIndexTTL.
 //
 // Returns nil when the hash is unknown or the bucket has aged out —
 // callers treat both equivalently (nothing to feed the slot with
@@ -305,6 +330,37 @@ func (o *Overlay) recordRelayedPeers(suppressionHash [32]byte, peerIDs []PeerID)
 // Thread-safe. The returned slice is a private copy the caller may
 // mutate freely.
 func (o *Overlay) PeersThatHave(suppressionHash [32]byte) []PeerID {
+	return o.messageSources(suppressionHash, false)
+}
+
+func (o *Overlay) releaseMessageSources(suppressionHash [32]byte) []PeerID {
+	return o.messageSources(suppressionHash, true)
+}
+
+// MessageRelayedRecently reports whether this hash was relayed within the
+// reduce-relay duplicate-counting window.
+func (o *Overlay) MessageRelayedRecently(suppressionHash [32]byte) bool {
+	if o.relayedIndex == nil {
+		return false
+	}
+	clock := o.clockForIndex
+	if clock == nil {
+		clock = time.Now
+	}
+	now := clock()
+	o.relayedIndexMu.Lock()
+	defer o.relayedIndexMu.Unlock()
+	entry, ok := o.relayedIndex[suppressionHash]
+	if !ok || now.Sub(entry.seenAt) >= RelayedIndexTTL {
+		if ok {
+			delete(o.relayedIndex, suppressionHash)
+		}
+		return false
+	}
+	return !entry.relayedAt.IsZero() && now.Sub(entry.relayedAt) < Idled
+}
+
+func (o *Overlay) messageSources(suppressionHash [32]byte, release bool) []PeerID {
 	if o.relayedIndex == nil {
 		return nil
 	}
@@ -324,7 +380,8 @@ func (o *Overlay) PeersThatHave(suppressionHash [32]byte) []PeerID {
 	// "unknown". Keeps queries from returning stale peers after the
 	// dedup window has elapsed (which would feed the slot with
 	// counters the rest of the network would have dropped long ago).
-	if clock().Sub(entry.seenAt) >= RelayedIndexTTL {
+	now := clock()
+	if now.Sub(entry.seenAt) >= RelayedIndexTTL {
 		delete(o.relayedIndex, suppressionHash)
 		return nil
 	}
@@ -332,6 +389,11 @@ func (o *Overlay) PeersThatHave(suppressionHash [32]byte) []PeerID {
 	out := make([]PeerID, 0, len(entry.peers))
 	for id := range entry.peers {
 		out = append(out, id)
+	}
+	if release {
+		entry.peers = make(map[PeerID]struct{})
+		entry.relayedAt = now
+		entry.seenAt = now
 	}
 	return out
 }

--- a/internal/peermanagement/overlay_broadcast_test.go
+++ b/internal/peermanagement/overlay_broadcast_test.go
@@ -11,41 +11,68 @@ func TestBroadcast_AttemptsBackpressuredPeerOnceAndContinues(t *testing.T) {
 	healthy := newTestPeer(t, 2)
 	full.setState(PeerStateConnected)
 	healthy.setState(PeerStateConnected)
-	for i := range DefaultSendBufferSize {
+	for i := range ordinarySendMaximum {
 		require.NoError(t, full.Send([]byte{byte(i)}))
 	}
 
 	overlay := newTestOverlayWithPeers(map[PeerID]*Peer{1: full, 2: healthy})
 	frame := []byte{0xAA, 0xBB, 0xCC}
-	require.NoError(t, overlay.Broadcast(frame))
+	err := overlay.Broadcast(frame)
+	require.ErrorIs(t, err, ErrSendBufferFull)
+	var fanoutErr *FanoutError
+	require.ErrorAs(t, err, &fanoutErr)
+	require.Equal(t, 2, fanoutErr.Attempted)
+	require.Equal(t, 1, fanoutErr.Failed)
+	require.Zero(t, fanoutErr.Critical)
 
 	require.Equal(t, uint64(1), full.SendDrops())
 	require.Zero(t, full.largeSendQ.Load())
-	require.Len(t, full.send, DefaultSendBufferSize)
-	require.Equal(t, frame, <-healthy.send)
+	require.Equal(t, ordinarySendMaximum, full.SendQueueLen())
+	require.Equal(t, frame, requireOutboundFrame(t, healthy))
 }
 
-func TestBroadcastPriorityUsesIndependentQueue(t *testing.T) {
+func TestBroadcastFanoutErrorPreservesMixedFailureCategories(t *testing.T) {
+	closed := newTestPeer(t, 1)
+	closed.setState(PeerStateConnected)
+	closed.closed.Store(true)
+	full := newTestPeer(t, 2)
+	full.setState(PeerStateConnected)
+	for range ordinarySendMaximum {
+		require.NoError(t, full.Send([]byte{0xAA}))
+	}
+	overlay := newTestOverlayWithPeers(map[PeerID]*Peer{1: closed, 2: full})
+
+	err := overlay.Broadcast([]byte{0xBB})
+	require.ErrorIs(t, err, ErrConnectionClosed)
+	require.ErrorIs(t, err, ErrSendBufferFull)
+	var fanoutErr *FanoutError
+	require.ErrorAs(t, err, &fanoutErr)
+	require.Equal(t, 2, fanoutErr.Attempted)
+	require.Equal(t, 2, fanoutErr.Failed)
+}
+
+func TestBroadcastPriorityUsesProtectedAdmission(t *testing.T) {
 	peer := newTestPeer(t, 1)
 	peer.setState(PeerStateConnected)
-	for i := range DefaultSendBufferSize {
+	for i := range ordinarySendMaximum {
 		require.NoError(t, peer.Send([]byte{byte(i)}))
 	}
 	overlay := newTestOverlayWithPeers(map[PeerID]*Peer{1: peer})
 	frame := []byte{0xAA}
 
 	require.NoError(t, overlay.BroadcastPriority(frame))
-	require.Len(t, peer.send, DefaultSendBufferSize)
-	require.Equal(t, frame, <-peer.prioritySend)
+	snapshot := peer.outbound.snapshot()
+	require.Equal(t, ordinarySendMaximum, snapshot.ClassFrames[OutboundClassOrdinary])
+	require.Equal(t, 1, snapshot.ClassFrames[OutboundClassAcquisition])
 	require.Zero(t, peer.SendDrops())
 }
 
-func TestBroadcastPriorityExceptSetUsesIndependentQueue(t *testing.T) {
+func TestBroadcastPriorityExceptSetUsesProtectedAdmission(t *testing.T) {
 	excluded := newTestPeer(t, 1)
 	eligible := newTestPeer(t, 2)
 	excluded.setState(PeerStateConnected)
 	eligible.setState(PeerStateConnected)
-	for i := range DefaultSendBufferSize {
+	for i := range ordinarySendMaximum {
 		require.NoError(t, excluded.Send([]byte{byte(i)}))
 		require.NoError(t, eligible.Send([]byte{byte(i)}))
 	}
@@ -53,10 +80,12 @@ func TestBroadcastPriorityExceptSetUsesIndependentQueue(t *testing.T) {
 	frame := []byte{0xAA}
 
 	require.NoError(t, overlay.BroadcastPriorityExceptSet(map[PeerID]bool{1: true}, frame))
-	require.Len(t, excluded.send, DefaultSendBufferSize)
-	require.Empty(t, excluded.prioritySend)
-	require.Len(t, eligible.send, DefaultSendBufferSize)
-	require.Equal(t, frame, <-eligible.prioritySend)
+	excludedSnapshot := excluded.outbound.snapshot()
+	require.Equal(t, ordinarySendMaximum, excludedSnapshot.ClassFrames[OutboundClassOrdinary])
+	require.Zero(t, excludedSnapshot.ClassFrames[OutboundClassAcquisition])
+	eligibleSnapshot := eligible.outbound.snapshot()
+	require.Equal(t, ordinarySendMaximum, eligibleSnapshot.ClassFrames[OutboundClassOrdinary])
+	require.Equal(t, 1, eligibleSnapshot.ClassFrames[OutboundClassAcquisition])
 	require.Zero(t, excluded.SendDrops())
 	require.Zero(t, eligible.SendDrops())
 }
@@ -70,8 +99,10 @@ func TestBroadcastManifestFramesExceptSkipsSourcePeer(t *testing.T) {
 	frames := [][]byte{{0xAA}, {0xBB}}
 
 	require.NoError(t, overlay.BroadcastManifestFramesExcept(source.ID(), frames))
-	require.Empty(t, source.manifestSend)
-	require.Equal(t, frames, <-other.manifestSend)
+	require.Zero(t, source.outbound.snapshot().BulkSequences)
+	require.Equal(t, 1, other.outbound.snapshot().BulkSequences)
+	require.Equal(t, frames[0], requireOutboundFrame(t, other))
+	require.Equal(t, frames[1], requireOutboundFrame(t, other))
 }
 
 func TestBroadcastExceptDoesNotEchoToSource(t *testing.T) {
@@ -83,6 +114,6 @@ func TestBroadcastExceptDoesNotEchoToSource(t *testing.T) {
 	frame := []byte{0xAA, 0xBB, 0xCC}
 
 	require.NoError(t, overlay.BroadcastExcept(source.ID(), frame))
-	require.Empty(t, source.send)
-	require.Equal(t, frame, <-other.send)
+	require.Zero(t, source.SendQueueLen())
+	require.Equal(t, frame, requireOutboundFrame(t, other))
 }

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -255,16 +255,6 @@ func (o *Overlay) IsPeerConnected(peerID PeerID) bool {
 	return ok && peer.State() == PeerStateConnected
 }
 
-// DisconnectPeer terminates the live session identified by peerID.
-func (o *Overlay) DisconnectPeer(peerID PeerID) bool {
-	peer, ok := o.getPeer(peerID)
-	if !ok {
-		return false
-	}
-	_ = peer.Close()
-	return true
-}
-
 // PeerLatency returns the overlay's smoothed round-trip estimate for peerID.
 func (o *Overlay) PeerLatency(peerID PeerID) (time.Duration, bool) {
 	peer, ok := o.getPeer(peerID)

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -255,6 +255,16 @@ func (o *Overlay) IsPeerConnected(peerID PeerID) bool {
 	return ok && peer.State() == PeerStateConnected
 }
 
+// DisconnectPeer terminates the live session identified by peerID.
+func (o *Overlay) DisconnectPeer(peerID PeerID) bool {
+	peer, ok := o.getPeer(peerID)
+	if !ok {
+		return false
+	}
+	_ = peer.Close()
+	return true
+}
+
 // PeerLatency returns the overlay's smoothed round-trip estimate for peerID.
 func (o *Overlay) PeerLatency(peerID PeerID) (time.Duration, bool) {
 	peer, ok := o.getPeer(peerID)
@@ -516,6 +526,7 @@ func (o *Overlay) addPeer(peer *Peer) error {
 		}
 		o.peerKeys[key] = peer.ID()
 	}
+	o.attachOutboundBudget(peer)
 	o.peerEndpoints[endpoint] = peer.ID()
 	o.peers[peer.ID()] = peer
 	delete(o.pendingInbound, peer.ID())

--- a/internal/peermanagement/overlay_rpc.go
+++ b/internal/peermanagement/overlay_rpc.go
@@ -83,11 +83,16 @@ func (o *Overlay) PeersJSON() []map[string]any {
 		// Emit the metrics object; values are decimal strings to match
 		// rippled's formatting.
 		entry["metrics"] = map[string]any{
-			"total_bytes_recv": strconv.FormatUint(p.TotalBytesRecv, 10),
-			"total_bytes_sent": strconv.FormatUint(p.TotalBytesSent, 10),
-			"avg_bps_recv":     strconv.FormatUint(p.AvgBpsRecv, 10),
-			"avg_bps_sent":     strconv.FormatUint(p.AvgBpsSent, 10),
-			"send_drops":       strconv.FormatUint(p.SendDrops, 10),
+			"total_bytes_recv":       strconv.FormatUint(p.TotalBytesRecv, 10),
+			"total_bytes_sent":       strconv.FormatUint(p.TotalBytesSent, 10),
+			"avg_bps_recv":           strconv.FormatUint(p.AvgBpsRecv, 10),
+			"avg_bps_sent":           strconv.FormatUint(p.AvgBpsSent, 10),
+			"send_drops":             strconv.FormatUint(p.SendDrops, 10),
+			"send_drops_control":     strconv.FormatUint(p.SendDropsControl, 10),
+			"send_drops_consensus":   strconv.FormatUint(p.SendDropsConsensus, 10),
+			"send_drops_acquisition": strconv.FormatUint(p.SendDropsAcquisition, 10),
+			"send_drops_ordinary":    strconv.FormatUint(p.SendDropsOrdinary, 10),
+			"send_drops_bulk":        strconv.FormatUint(p.SendDropsBulk, 10),
 		}
 		out = append(out, entry)
 	}

--- a/internal/peermanagement/overlay_rpc.go
+++ b/internal/peermanagement/overlay_rpc.go
@@ -83,16 +83,20 @@ func (o *Overlay) PeersJSON() []map[string]any {
 		// Emit the metrics object; values are decimal strings to match
 		// rippled's formatting.
 		entry["metrics"] = map[string]any{
-			"total_bytes_recv":       strconv.FormatUint(p.TotalBytesRecv, 10),
-			"total_bytes_sent":       strconv.FormatUint(p.TotalBytesSent, 10),
-			"avg_bps_recv":           strconv.FormatUint(p.AvgBpsRecv, 10),
-			"avg_bps_sent":           strconv.FormatUint(p.AvgBpsSent, 10),
-			"send_drops":             strconv.FormatUint(p.SendDrops, 10),
-			"send_drops_control":     strconv.FormatUint(p.SendDropsControl, 10),
-			"send_drops_consensus":   strconv.FormatUint(p.SendDropsConsensus, 10),
-			"send_drops_acquisition": strconv.FormatUint(p.SendDropsAcquisition, 10),
-			"send_drops_ordinary":    strconv.FormatUint(p.SendDropsOrdinary, 10),
-			"send_drops_bulk":        strconv.FormatUint(p.SendDropsBulk, 10),
+			"total_bytes_recv": strconv.FormatUint(p.TotalBytesRecv, 10),
+			"total_bytes_sent": strconv.FormatUint(p.TotalBytesSent, 10),
+			"avg_bps_recv":     strconv.FormatUint(p.AvgBpsRecv, 10),
+			"avg_bps_sent":     strconv.FormatUint(p.AvgBpsSent, 10),
+		}
+		entry["outbound_queue"] = map[string]any{
+			"send_drops": strconv.FormatUint(p.SendDrops, 10),
+			"send_drops_by_class": map[string]any{
+				"control":     strconv.FormatUint(p.SendDropsControl, 10),
+				"consensus":   strconv.FormatUint(p.SendDropsConsensus, 10),
+				"acquisition": strconv.FormatUint(p.SendDropsAcquisition, 10),
+				"ordinary":    strconv.FormatUint(p.SendDropsOrdinary, 10),
+				"bulk":        strconv.FormatUint(p.SendDropsBulk, 10),
+			},
 		}
 		out = append(out, entry)
 	}

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -94,10 +94,7 @@ type Peer struct {
 	bootstrapManifest        atomic.Bool
 	bootstrapManifestPending atomic.Bool
 
-	sendMu                 sync.Mutex
-	send                   chan []byte
-	prioritySend           chan []byte
-	manifestSend           chan [][]byte
+	outbound               *outboundQueue
 	events                 chan<- Event
 	consensusEvents        chan<- Event
 	consensusControlEvents chan<- Event
@@ -171,7 +168,8 @@ type Peer struct {
 	// than queueing unboundedly like rippled; this per-peer counter is
 	// surfaced via the `peers` RPC metrics so operators can see which
 	// peers are shedding outbound frames.
-	sendDrops atomic.Uint64
+	sendDrops        atomic.Uint64
+	sendDropsByClass [outboundClassCount]atomic.Uint64
 
 	// consecutiveDecompressFailures: back-to-back LZ4 errors; closed
 	// at maxConsecutiveDecompressFailures.
@@ -261,9 +259,7 @@ func NewPeer(id PeerID, endpoint Endpoint, inbound bool, identity *Identity, eve
 		inbound:       inbound,
 		identity:      identity,
 		state:         PeerStateDisconnected,
-		send:          make(chan []byte, DefaultSendBufferSize),
-		prioritySend:  make(chan []byte, acquisitionSendBufferSize),
-		manifestSend:  make(chan [][]byte, manifestSendBufferSize),
+		outbound:      newOutboundQueue(),
 		events:        events,
 		traffic:       NewTrafficCounter(),
 		metrics:       newPeerMetrics(nil),
@@ -977,6 +973,8 @@ func (p *Peer) Run(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		runErr = ctx.Err()
+	case err := <-p.outbound.fatalSignal():
+		runErr = err
 	case err := <-errCh:
 		runErr = err
 	}
@@ -1362,20 +1360,18 @@ func (p *Peer) acknowledgeBootstrap() {
 }
 
 func (p *Peer) writeLoop(ctx context.Context) error {
-	schedule := outboundSchedule{}
 	for {
-		data, err := p.nextOutbound(ctx, &schedule)
+		token, err := p.outbound.next(ctx)
 		if err != nil {
 			return err
 		}
-		if data == nil {
-			return nil
-		}
+		data := token.data
 		p.mu.RLock()
 		conn := p.conn
 		p.mu.RUnlock()
 
 		if conn == nil {
+			p.outbound.complete(token)
 			return ErrConnectionClosed
 		}
 
@@ -1383,6 +1379,7 @@ func (p *Peer) writeLoop(ctx context.Context) error {
 		compressionEnabled := p.compressionNegotiated()
 		if header, err := message.DecodeHeader(data); err == nil && header.Compressed {
 			if !compressionEnabled {
+				p.outbound.complete(token)
 				return errCompressionUnnegotiated
 			}
 		} else if compressionEnabled {
@@ -1390,9 +1387,11 @@ func (p *Peer) writeLoop(ctx context.Context) error {
 		}
 
 		if err := conn.SetWriteDeadline(time.Now().Add(p.frameReadBudget(uint32(len(wire))))); err != nil {
+			p.outbound.complete(token)
 			return err
 		}
-		n, err := conn.Write(wire)
+		n, err := writeComplete(conn, wire)
+		p.outbound.complete(token)
 		if err != nil {
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 				return ErrWriteIdle
@@ -1406,56 +1405,21 @@ func (p *Peer) writeLoop(ctx context.Context) error {
 	}
 }
 
-const ordinaryFramesPerManifestChunk = 16
-
-type outboundSchedule struct {
-	manifests         [][]byte
-	ordinaryRemaining int
-}
-
-func (p *Peer) nextOutbound(ctx context.Context, schedule *outboundSchedule) ([]byte, error) {
-	select {
-	case data := <-p.prioritySend:
-		return data, nil
-	default:
-	}
-	if schedule.ordinaryRemaining > 0 {
-		select {
-		case data := <-p.send:
-			schedule.ordinaryRemaining--
-			return data, nil
-		default:
+func writeComplete(conn net.Conn, data []byte) (int, error) {
+	written := 0
+	for written < len(data) {
+		n, err := conn.Write(data[written:])
+		if n > 0 {
+			written += n
+		}
+		if err != nil {
+			return written, err
+		}
+		if n == 0 {
+			return written, io.ErrNoProgress
 		}
 	}
-	if len(schedule.manifests) > 0 {
-		data := schedule.manifests[0]
-		schedule.manifests = schedule.manifests[1:]
-		schedule.ordinaryRemaining = ordinaryFramesPerManifestChunk
-		return data, nil
-	}
-	select {
-	case batch := <-p.manifestSend:
-		data := batch[0]
-		schedule.manifests = batch[1:]
-		schedule.ordinaryRemaining = ordinaryFramesPerManifestChunk
-		return data, nil
-	default:
-	}
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-p.closeCh:
-		return nil, nil
-	case data := <-p.prioritySend:
-		return data, nil
-	case batch := <-p.manifestSend:
-		data := batch[0]
-		schedule.manifests = batch[1:]
-		schedule.ordinaryRemaining = ordinaryFramesPerManifestChunk
-		return data, nil
-	case data := <-p.send:
-		return data, nil
-	}
+	return written, nil
 }
 
 func (p *Peer) pingLoop(ctx context.Context) error {
@@ -1563,14 +1527,8 @@ const (
 	pingsInFlightCap = 16
 	// Tuning::sendqIntervals (PeerImp.cpp:705 + Tuning.h).
 	sendqIntervals = 4
-	// targetSendQueue is the depth the send queue must drain back below
-	// before the large-send-queue strike count is cleared. Mirrors
-	// rippled's reset against Tuning::targetSendQueue (PeerImp.cpp:270-276)
-	// but scaled to go-xrpl's shallower DefaultSendBufferSize=64 queue. A
-	// queue oscillating at-or-above this depth keeps accumulating strikes
-	// toward the sendqIntervals disconnect instead of resetting on each
-	// transient success.
-	targetSendQueue = DefaultSendBufferSize / 2
+	// targetSendQueue is rippled's retained-frame pressure threshold.
+	targetSendQueue = 128
 	// maxConsecutiveDecompressFailures: close after this many
 	// back-to-back LZ4 errors. A single bad frame still charges
 	// bad-data but resets on the next successful decompress.
@@ -1964,17 +1922,9 @@ func (p *Peer) ExpireSquelch(validator []byte) bool {
 	return true
 }
 
-// Send enqueues a wire frame for transmission. Drop policy (a deliberate
-// divergence from rippled): the per-peer send queue is bounded
-// (DefaultSendBufferSize) and a full queue DROPS the frame and returns
-// ErrSendBufferFull rather than queueing unboundedly. rippled queues
-// without bound and disconnects only after sendqIntervals timer ticks
-// above targetSendQueue; go-xrpl's goroutine-per-peer writer makes a
-// bounded queue reasonable, and the largeSendQ strike count below
-// approximates rippled's disconnect. Callers must treat the returned error
-// as "frame not delivered" — request/response paths that discard it (e.g.
-// a TMLedgerData reply) leave the requester to time out and retry. Dropped
-// frames are counted per peer (sendDrops) and surfaced via the `peers` RPC.
+// Send admits a frame to the reliable FIFO. Control and consensus traffic
+// have protected capacity; exhausting either class signals the peer lifecycle
+// to close a connection that cannot keep up with protocol-critical traffic.
 func (p *Peer) Send(data []byte) error {
 	if p.closed.Load() {
 		return ErrConnectionClosed
@@ -1982,19 +1932,33 @@ func (p *Peer) Send(data []byte) error {
 	if p.SendQueueLen() < targetSendQueue {
 		p.largeSendQ.Store(0)
 	}
-
-	p.sendMu.Lock()
-	defer p.sendMu.Unlock()
-	if len(p.send) >= DefaultSendBufferSize {
-		p.sendDrops.Add(1)
-		return ErrSendBufferFull
+	class := outboundClassForFrame(data)
+	if err := p.outbound.enqueueReliable(class, data); err != nil {
+		p.recordSendDrop(class, err)
+		return err
 	}
-	p.send <- data
 	return nil
 }
 
-// SendPriority admits acquisition and control traffic independently from
-// best-effort gossip. The writer drains this lane first between wire frames.
+func outboundClassForFrame(data []byte) OutboundSendClass {
+	header, err := message.DecodeHeader(data)
+	if err != nil {
+		return OutboundClassOrdinary
+	}
+	switch {
+	case isConsensusPriorityMessageType(header.MessageType):
+		return OutboundClassConsensus
+	case header.MessageType == message.TypePing,
+		header.MessageType == message.TypeSquelch,
+		isConsensusControlMessageType(header.MessageType):
+		return OutboundClassControl
+	default:
+		return OutboundClassOrdinary
+	}
+}
+
+// SendPriority admits acquisition traffic to the same reliable FIFO while
+// protecting its share of the bounded queue.
 func (p *Peer) SendPriority(data []byte) error {
 	if p.closed.Load() {
 		return ErrConnectionClosed
@@ -2002,39 +1966,38 @@ func (p *Peer) SendPriority(data []byte) error {
 	if p.SendQueueLen() < targetSendQueue {
 		p.largeSendQ.Store(0)
 	}
-	p.sendMu.Lock()
-	defer p.sendMu.Unlock()
-	if len(p.prioritySend) >= cap(p.prioritySend) {
-		p.sendDrops.Add(1)
-		return ErrSendBufferFull
+	if err := p.outbound.enqueueReliable(OutboundClassAcquisition, data); err != nil {
+		p.recordSendDrop(OutboundClassAcquisition, err)
+		return err
 	}
-	p.prioritySend <- data
 	return nil
 }
 
-// SendManifestFrames schedules a complete manifest snapshot as one bounded
-// writer item. The writer pulls one frame at a time and checks the priority
-// lane between frames, so large snapshots neither fill the ordinary send
-// queue nor block acquisition traffic behind the whole snapshot.
+// SendManifestFrames schedules a complete manifest snapshot in the bounded
+// bulk lane. The writer emits at most one bulk frame per 16 reliable frames.
 func (p *Peer) SendManifestFrames(frames [][]byte) error {
 	if p.closed.Load() {
 		return ErrConnectionClosed
 	}
-	batch := make([][]byte, 0, len(frames))
-	for _, frame := range frames {
-		if len(frame) != 0 {
-			batch = append(batch, frame)
+	if err := p.outbound.enqueueBulk(frames); err != nil {
+		p.recordSendDrop(OutboundClassBulk, err)
+		return err
+	}
+	return nil
+}
+
+func (p *Peer) recordSendDrop(class OutboundSendClass, err error) {
+	frames := uint64(1)
+	var queueErr *SendQueueError
+	if errors.As(err, &queueErr) {
+		class = queueErr.Class
+		if queueErr.AttemptedFrames > 0 {
+			frames = uint64(queueErr.AttemptedFrames)
 		}
 	}
-	if len(batch) == 0 {
-		return nil
-	}
-	select {
-	case p.manifestSend <- batch:
-		return nil
-	default:
-		p.sendDrops.Add(1)
-		return ErrSendBufferFull
+	p.sendDrops.Add(frames)
+	if class < outboundClassCount {
+		p.sendDropsByClass[class].Add(frames)
 	}
 }
 
@@ -2044,13 +2007,24 @@ func (p *Peer) SendDrops() uint64 {
 	return p.sendDrops.Load()
 }
 
+// SendDropsByClass returns the dropped-frame count for one admission class.
+func (p *Peer) SendDropsByClass(class OutboundSendClass) uint64 {
+	if class >= outboundClassCount {
+		return 0
+	}
+	return p.sendDropsByClass[class].Load()
+}
+
 // SendQueueLen returns the number of frames currently buffered for
 // transmission to this peer. Used by handlers that should refuse new
 // outbound work when the pipe is already saturated — mirrors the
 // rippled gate at PeerImp.cpp:2452 (`send_queue_.size() >=
 // Tuning::dropSendQueue`).
 func (p *Peer) SendQueueLen() int {
-	return len(p.send) + len(p.prioritySend)
+	if p.outbound == nil {
+		return 0
+	}
+	return p.outbound.snapshot().TotalFrames
 }
 
 func (p *Peer) Close() error {
@@ -2061,6 +2035,9 @@ func (p *Peer) Close() error {
 	p.mu.Lock()
 	p.state = PeerStateClosing
 	close(p.closeCh)
+	if p.outbound != nil {
+		p.outbound.close()
+	}
 	conn := p.conn
 	p.conn = nil
 	p.mu.Unlock()
@@ -2127,7 +2104,12 @@ type PeerInfo struct {
 	// SendDrops is the count of outbound frames dropped because the peer's
 	// bounded send queue was full. go-xrpl-specific (rippled queues
 	// unboundedly); surfaced under the `metrics` object in `peers` RPC.
-	SendDrops uint64
+	SendDrops            uint64
+	SendDropsControl     uint64
+	SendDropsConsensus   uint64
+	SendDropsAcquisition uint64
+	SendDropsOrdinary    uint64
+	SendDropsBulk        uint64
 }
 
 func (p *Peer) Info() PeerInfo {
@@ -2158,30 +2140,35 @@ func (p *Peer) Info() PeerInfo {
 	latency, hasLatency := p.Latency()
 
 	return PeerInfo{
-		ID:              p.id,
-		Endpoint:        p.endpoint,
-		Inbound:         p.inbound,
-		State:           p.state,
-		PublicKey:       pubKey,
-		PublicKeyBytes:  pubKeyBytes,
-		ConnectedAt:     p.createdAt,
-		MessagesIn:      stats.MessagesIn,
-		MessagesOut:     stats.MessagesOut,
-		ServerDomain:    p.serverDomain,
-		NetworkID:       p.networkID,
-		Version:         p.userAgent,
-		ClosedLedger:    closedLedger,
-		CompleteLedgers: completeLedgers,
-		Tracking:        PeerTracking(p.tracking.Load()),
-		Load:            p.Load(),
-		Latency:         latency,
-		HasLatency:      hasLatency,
-		Protocol:        p.protocolVersion,
-		Status:          p.lastStatus,
-		TotalBytesRecv:  p.metrics.recv.totalBytesSnapshot(),
-		TotalBytesSent:  p.metrics.sent.totalBytesSnapshot(),
-		AvgBpsRecv:      p.metrics.recv.averageBytes(),
-		AvgBpsSent:      p.metrics.sent.averageBytes(),
-		SendDrops:       p.sendDrops.Load(),
+		ID:                   p.id,
+		Endpoint:             p.endpoint,
+		Inbound:              p.inbound,
+		State:                p.state,
+		PublicKey:            pubKey,
+		PublicKeyBytes:       pubKeyBytes,
+		ConnectedAt:          p.createdAt,
+		MessagesIn:           stats.MessagesIn,
+		MessagesOut:          stats.MessagesOut,
+		ServerDomain:         p.serverDomain,
+		NetworkID:            p.networkID,
+		Version:              p.userAgent,
+		ClosedLedger:         closedLedger,
+		CompleteLedgers:      completeLedgers,
+		Tracking:             PeerTracking(p.tracking.Load()),
+		Load:                 p.Load(),
+		Latency:              latency,
+		HasLatency:           hasLatency,
+		Protocol:             p.protocolVersion,
+		Status:               p.lastStatus,
+		TotalBytesRecv:       p.metrics.recv.totalBytesSnapshot(),
+		TotalBytesSent:       p.metrics.sent.totalBytesSnapshot(),
+		AvgBpsRecv:           p.metrics.recv.averageBytes(),
+		AvgBpsSent:           p.metrics.sent.averageBytes(),
+		SendDrops:            p.sendDrops.Load(),
+		SendDropsControl:     p.SendDropsByClass(OutboundClassControl),
+		SendDropsConsensus:   p.SendDropsByClass(OutboundClassConsensus),
+		SendDropsAcquisition: p.SendDropsByClass(OutboundClassAcquisition),
+		SendDropsOrdinary:    p.SendDropsByClass(OutboundClassOrdinary),
+		SendDropsBulk:        p.SendDropsByClass(OutboundClassBulk),
 	}
 }

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -2010,7 +2010,6 @@ func (p *Peer) SendDrops() uint64 {
 	return p.sendDrops.Load()
 }
 
-// SendDropsByClass returns the dropped-frame count for one admission class.
 func (p *Peer) SendDropsByClass(class OutboundSendClass) uint64 {
 	if class >= outboundClassCount {
 		return 0

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -166,8 +166,8 @@ type Peer struct {
 	// sendDrops counts frames dropped because the bounded send queue was
 	// full. go-xrpl drops the frame and returns ErrSendBufferFull rather
 	// than queueing unboundedly like rippled; this per-peer counter is
-	// surfaced via the `peers` RPC metrics so operators can see which
-	// peers are shedding outbound frames.
+	// surfaced via the `peers` RPC outbound_queue diagnostics so operators
+	// can see which peers are shedding outbound frames.
 	sendDrops        atomic.Uint64
 	sendDropsByClass [outboundClassCount]atomic.Uint64
 
@@ -247,7 +247,7 @@ type PeerConfig struct {
 }
 
 // DefaultPeerConfig returns defaults; callers must set PeerTLSConfig
-// before Connect. The per-peer send queue is a fixed DefaultSendBufferSize.
+// before Connect.
 func DefaultPeerConfig() PeerConfig {
 	return PeerConfig{}
 }
@@ -1990,6 +1990,9 @@ func (p *Peer) recordSendDrop(class OutboundSendClass, err error) {
 	frames := uint64(1)
 	var queueErr *SendQueueError
 	if errors.As(err, &queueErr) {
+		if queueErr.Reason == SendQueueClosed {
+			return
+		}
 		class = queueErr.Class
 		if queueErr.AttemptedFrames > 0 {
 			frames = uint64(queueErr.AttemptedFrames)
@@ -2103,7 +2106,7 @@ type PeerInfo struct {
 
 	// SendDrops is the count of outbound frames dropped because the peer's
 	// bounded send queue was full. go-xrpl-specific (rippled queues
-	// unboundedly); surfaced under the `metrics` object in `peers` RPC.
+	// unboundedly); surfaced under the `outbound_queue` object in `peers` RPC.
 	SendDrops            uint64
 	SendDropsControl     uint64
 	SendDropsConsensus   uint64

--- a/internal/peermanagement/peer_frame_liveness_test.go
+++ b/internal/peermanagement/peer_frame_liveness_test.go
@@ -54,60 +54,20 @@ type chunkedLivenessConn struct {
 	writes       [][]byte
 }
 
-type pacedManifestConn struct {
-	permit   chan struct{}
-	observed chan []byte
-	resume   chan struct{}
+type partialWriteConn struct {
+	chunkedLivenessConn
+	limit int
+	wire  []byte
 }
 
-func newPacedManifestConn() *pacedManifestConn {
-	return &pacedManifestConn{
-		permit:   make(chan struct{}),
-		observed: make(chan []byte),
-		resume:   make(chan struct{}),
-	}
+func (c *partialWriteConn) Write(src []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.writeCalls++
+	n := min(c.limit, len(src))
+	c.wire = append(c.wire, src[:n]...)
+	return n, nil
 }
-
-func (*pacedManifestConn) Read([]byte) (int, error) { return 0, io.EOF }
-
-func (c *pacedManifestConn) Write(src []byte) (int, error) {
-	<-c.permit
-	c.observed <- append([]byte(nil), src...)
-	<-c.resume
-	return len(src), nil
-}
-
-func (c *pacedManifestConn) nextWrite(t *testing.T) []byte {
-	t.Helper()
-	select {
-	case c.permit <- struct{}{}:
-	case <-time.After(time.Second):
-		t.Fatal("writer did not request the next frame")
-	}
-	select {
-	case data := <-c.observed:
-		return data
-	case <-time.After(time.Second):
-		t.Fatal("writer did not emit the permitted frame")
-		return nil
-	}
-}
-
-func (c *pacedManifestConn) resumeWrite(t *testing.T) {
-	t.Helper()
-	select {
-	case c.resume <- struct{}{}:
-	case <-time.After(time.Second):
-		t.Fatal("writer did not finish the current frame")
-	}
-}
-
-func (*pacedManifestConn) Close() error                     { return nil }
-func (*pacedManifestConn) LocalAddr() net.Addr              { return livenessAddr("local") }
-func (*pacedManifestConn) RemoteAddr() net.Addr             { return livenessAddr("remote") }
-func (*pacedManifestConn) SetDeadline(time.Time) error      { return nil }
-func (*pacedManifestConn) SetReadDeadline(time.Time) error  { return nil }
-func (*pacedManifestConn) SetWriteDeadline(time.Time) error { return nil }
 
 func (c *chunkedLivenessConn) Read(dst []byte) (int, error) {
 	c.mu.Lock()
@@ -145,7 +105,7 @@ func (c *chunkedLivenessConn) Write(src []byte) (int, error) {
 	return len(src), nil
 }
 
-func TestPeerWriteLoopPrioritizesAcquisitionTraffic(t *testing.T) {
+func TestPeerWriteLoopPreservesReliableAdmissionOrder(t *testing.T) {
 	clock := &livenessClock{now: time.Unix(5_900, 0)}
 	conn := &chunkedLivenessConn{clock: clock}
 	peer, _ := newFrameLivenessPeer(t, clock, conn)
@@ -163,113 +123,48 @@ func TestPeerWriteLoopPrioritizesAcquisitionTraffic(t *testing.T) {
 	require.ErrorIs(t, <-done, context.Canceled)
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
-	require.Equal(t, []byte("acquisition"), conn.writes[0])
-	require.Equal(t, []byte("gossip"), conn.writes[1])
+	require.Equal(t, []byte("gossip"), conn.writes[0])
+	require.Equal(t, []byte("acquisition"), conn.writes[1])
 }
 
-func TestPeerWriteLoopPacesManifestSequenceBeyondOrdinaryQueueCapacity(t *testing.T) {
+func TestPeerWriteLoopBoundsReliableBurstBeforeBulk(t *testing.T) {
 	clock := &livenessClock{now: time.Unix(5_950, 0)}
-	conn := newPacedManifestConn()
+	conn := &chunkedLivenessConn{clock: clock}
 	peer, _ := newFrameLivenessPeer(t, clock, conn)
-	frames := make([][]byte, DefaultSendBufferSize+17)
-	for i := range frames {
-		frames[i] = []byte{0x4d, byte(i)}
+	for i := range reliableFramesPerBulkFrame + 1 {
+		require.NoError(t, peer.Send([]byte{0x52, byte(i)}))
 	}
-	require.NoError(t, peer.SendManifestFrames(frames))
-	require.NoError(t, peer.Send([]byte{0x4f, 0}))
+	require.NoError(t, peer.SendManifestFrames([][]byte{{0x42, 0}, {0x42, 1}}))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() { done <- peer.writeLoop(ctx) }()
-
-	require.Equal(t, frames[0], conn.nextWrite(t), "a queued manifest batch must start despite ordinary traffic")
-	require.NoError(t, peer.SendPriority([]byte{0x50}))
-	conn.resumeWrite(t)
-	require.Equal(t, []byte{0x50}, conn.nextWrite(t), "priority traffic must preempt an active manifest batch")
-	conn.resumeWrite(t)
-
-	manifestIndex := 1
-	ordinaryObserved := 0
-	maxOrdinaryQueue := len(peer.send)
-	for manifestIndex < len(frames) {
-		ordinarySinceManifest := 0
-	manifestBurst:
-		for {
-			data := conn.nextWrite(t)
-			require.NotEmpty(t, data)
-			switch data[0] {
-			case 0x4f:
-				require.Equal(t, byte(ordinaryObserved), data[1])
-				ordinaryObserved++
-				ordinarySinceManifest++
-				require.NoError(t, peer.Send([]byte{0x4f, byte(ordinaryObserved)}))
-				if queued := len(peer.send); queued > maxOrdinaryQueue {
-					maxOrdinaryQueue = queued
-				}
-				conn.resumeWrite(t)
-			case 0x4d:
-				require.Equal(t, frames[manifestIndex], data)
-				require.Equal(t, ordinaryFramesPerManifestChunk, ordinarySinceManifest)
-				manifestIndex++
-				conn.resumeWrite(t)
-				break manifestBurst
-			default:
-				t.Fatalf("unexpected outbound frame: %x", data)
-			}
-		}
-	}
-
-	require.Equal(t, DefaultSendBufferSize+17, manifestIndex)
-	require.Equal(t, (len(frames)-1)*ordinaryFramesPerManifestChunk, ordinaryObserved)
-	require.Less(t, maxOrdinaryQueue, DefaultSendBufferSize)
-	require.Equal(t, []byte{0x4f, byte(ordinaryObserved)}, conn.nextWrite(t))
-	conn.resumeWrite(t)
-	require.Empty(t, peer.send)
+	require.Eventually(t, func() bool {
+		conn.mu.Lock()
+		defer conn.mu.Unlock()
+		return len(conn.writes) == reliableFramesPerBulkFrame+3
+	}, time.Second, time.Millisecond)
 	cancel()
 	require.ErrorIs(t, <-done, context.Canceled)
-}
-
-func TestPeerWriteLoopPacesBackToBackSingleFrameManifestBatches(t *testing.T) {
-	clock := &livenessClock{now: time.Unix(5_975, 0)}
-	conn := newPacedManifestConn()
-	peer, _ := newFrameLivenessPeer(t, clock, conn)
-	firstManifest := []byte{0x4d, 0x01}
-	secondManifest := []byte{0x4d, 0x02}
-	require.NoError(t, peer.SendManifestFrames([][]byte{firstManifest}))
-	require.NoError(t, peer.SendManifestFrames([][]byte{secondManifest}))
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- peer.writeLoop(ctx) }()
-
-	require.Equal(t, firstManifest, conn.nextWrite(t))
-	require.NoError(t, peer.Send([]byte{0x4f, 0}))
-	conn.resumeWrite(t)
-
-	for i := 0; i < ordinaryFramesPerManifestChunk; i++ {
-		require.Equal(t, []byte{0x4f, byte(i)}, conn.nextWrite(t))
-		require.NoError(t, peer.Send([]byte{0x4f, byte(i + 1)}))
-		require.Len(t, peer.send, 1)
-		conn.resumeWrite(t)
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	for i := range reliableFramesPerBulkFrame {
+		require.Equal(t, []byte{0x52, byte(i)}, conn.writes[i])
 	}
-
-	require.Equal(t, secondManifest, conn.nextWrite(t))
-	conn.resumeWrite(t)
-	require.Equal(t, []byte{0x4f, ordinaryFramesPerManifestChunk}, conn.nextWrite(t))
-	conn.resumeWrite(t)
-	require.Empty(t, peer.send)
-	cancel()
-	require.ErrorIs(t, <-done, context.Canceled)
+	require.Equal(t, []byte{0x42, 0}, conn.writes[reliableFramesPerBulkFrame])
+	require.Equal(t, []byte{0x52, reliableFramesPerBulkFrame}, conn.writes[reliableFramesPerBulkFrame+1])
+	require.Equal(t, []byte{0x42, 1}, conn.writes[reliableFramesPerBulkFrame+2])
 }
 
-func TestPeerManifestQueueIsBounded(t *testing.T) {
+func TestPeerBulkSequenceQueueIsBounded(t *testing.T) {
 	peer := newLatencyTestPeer(t)
-	for i := range manifestSendBufferSize {
+	for i := range bulkSequenceBufferSize {
 		require.NoError(t, peer.SendManifestFrames([][]byte{{0x4d, byte(i)}}))
 	}
-	require.Len(t, peer.manifestSend, manifestSendBufferSize)
+	require.Equal(t, bulkSequenceBufferSize, peer.outbound.snapshot().BulkSequences)
 	require.ErrorIs(t, peer.SendManifestFrames([][]byte{{0x4d, 0xff}}), ErrSendBufferFull)
 	require.Equal(t, uint64(1), peer.SendDrops())
+	require.Equal(t, uint64(1), peer.SendDropsByClass(OutboundClassBulk))
 }
 
 func TestPeerManifestDispatchBackpressuresUntilCapacity(t *testing.T) {
@@ -538,7 +433,7 @@ func TestPeerPingTimeoutDefersOnlyForBlockingFrame(t *testing.T) {
 	clock.advance(pingTimeout - time.Second)
 
 	require.NoError(t, peer.runPingTick(clock.current()))
-	assert.Empty(t, peer.send)
+	assert.Zero(t, peer.SendQueueLen())
 	reader.finish(true, clock.current())
 	require.NoError(t, peer.runPingTick(clock.current()))
 
@@ -730,4 +625,35 @@ func TestPeerWriteLoopMapsWriteTimeout(t *testing.T) {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 	assert.Equal(t, 1, conn.writeLimits)
+}
+
+func TestPeerWriteLoopCompletesPartialWritesAndReleasesInFlight(t *testing.T) {
+	clock := &livenessClock{now: time.Unix(6_200, 0)}
+	conn := &partialWriteConn{
+		chunkedLivenessConn: chunkedLivenessConn{clock: clock},
+		limit:               3,
+	}
+	peer, _ := newFrameLivenessPeer(t, clock, conn)
+	frame := []byte("frame requiring complete writes")
+	require.NoError(t, peer.Send(frame))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- peer.writeLoop(ctx) }()
+	require.Eventually(t, func() bool {
+		conn.mu.Lock()
+		defer conn.mu.Unlock()
+		return len(conn.wire) == len(frame)
+	}, time.Second, time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+
+	conn.mu.Lock()
+	assert.Equal(t, frame, conn.wire)
+	assert.Greater(t, conn.writeCalls, 1)
+	conn.mu.Unlock()
+	snapshot := peer.outbound.snapshot()
+	assert.Zero(t, snapshot.TotalFrames)
+	assert.Zero(t, snapshot.TotalBytes)
+	assert.Zero(t, snapshot.InFlight)
 }

--- a/internal/peermanagement/peer_metrics_test.go
+++ b/internal/peermanagement/peer_metrics_test.go
@@ -143,6 +143,16 @@ func TestOverlay_PeersJSON_EmitsMetricsObject(t *testing.T) {
 	// async read/write callbacks would (PeerImp.cpp:911, 970).
 	p.metrics.recv.addMessage(2048)
 	p.metrics.sent.addMessage(512)
+	p.recordSendDrop(OutboundClassConsensus, &SendQueueError{
+		Class:           OutboundClassConsensus,
+		Reason:          SendQueueFrameLimit,
+		AttemptedFrames: 2,
+	})
+	p.recordSendDrop(OutboundClassOrdinary, &SendQueueError{
+		Class:           OutboundClassOrdinary,
+		Reason:          SendQueueFrameLimit,
+		AttemptedFrames: 1,
+	})
 
 	o := newTestOverlayWithPeers(map[PeerID]*Peer{1: p})
 	entries := o.PeersJSON()
@@ -156,6 +166,12 @@ func TestOverlay_PeersJSON_EmitsMetricsObject(t *testing.T) {
 		"total_bytes_sent",
 		"avg_bps_recv",
 		"avg_bps_sent",
+		"send_drops",
+		"send_drops_control",
+		"send_drops_consensus",
+		"send_drops_acquisition",
+		"send_drops_ordinary",
+		"send_drops_bulk",
 	} {
 		val, present := metrics[key]
 		require.True(t, present, "metrics.%s missing", key)
@@ -173,6 +189,12 @@ func TestOverlay_PeersJSON_EmitsMetricsObject(t *testing.T) {
 	// schema is what we're pinning, not the value.
 	assert.Equal(t, "0", metrics["avg_bps_recv"])
 	assert.Equal(t, "0", metrics["avg_bps_sent"])
+	assert.Equal(t, "3", metrics["send_drops"])
+	assert.Equal(t, "0", metrics["send_drops_control"])
+	assert.Equal(t, "2", metrics["send_drops_consensus"])
+	assert.Equal(t, "0", metrics["send_drops_acquisition"])
+	assert.Equal(t, "1", metrics["send_drops_ordinary"])
+	assert.Equal(t, "0", metrics["send_drops_bulk"])
 }
 
 // TestOverlay_PeersJSON_EmitsMetricsForEveryPeer guards against a

--- a/internal/peermanagement/peer_metrics_test.go
+++ b/internal/peermanagement/peer_metrics_test.go
@@ -166,12 +166,6 @@ func TestOverlay_PeersJSON_EmitsMetricsObject(t *testing.T) {
 		"total_bytes_sent",
 		"avg_bps_recv",
 		"avg_bps_sent",
-		"send_drops",
-		"send_drops_control",
-		"send_drops_consensus",
-		"send_drops_acquisition",
-		"send_drops_ordinary",
-		"send_drops_bulk",
 	} {
 		val, present := metrics[key]
 		require.True(t, present, "metrics.%s missing", key)
@@ -189,12 +183,31 @@ func TestOverlay_PeersJSON_EmitsMetricsObject(t *testing.T) {
 	// schema is what we're pinning, not the value.
 	assert.Equal(t, "0", metrics["avg_bps_recv"])
 	assert.Equal(t, "0", metrics["avg_bps_sent"])
-	assert.Equal(t, "3", metrics["send_drops"])
-	assert.Equal(t, "0", metrics["send_drops_control"])
-	assert.Equal(t, "2", metrics["send_drops_consensus"])
-	assert.Equal(t, "0", metrics["send_drops_acquisition"])
-	assert.Equal(t, "1", metrics["send_drops_ordinary"])
-	assert.Equal(t, "0", metrics["send_drops_bulk"])
+	assert.Len(t, metrics, 4)
+
+	queue, ok := entries[0]["outbound_queue"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "3", queue["send_drops"])
+	byClass, ok := queue["send_drops_by_class"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "0", byClass["control"])
+	assert.Equal(t, "2", byClass["consensus"])
+	assert.Equal(t, "0", byClass["acquisition"])
+	assert.Equal(t, "1", byClass["ordinary"])
+	assert.Equal(t, "0", byClass["bulk"])
+}
+
+func TestPeerClosedQueueRejectionDoesNotCountAsCapacityDrop(t *testing.T) {
+	peer := NewPeer(1, Endpoint{}, false, nil, nil)
+
+	peer.recordSendDrop(OutboundClassOrdinary, &SendQueueError{
+		Class:           OutboundClassOrdinary,
+		Reason:          SendQueueClosed,
+		AttemptedFrames: 1,
+	})
+
+	assert.Zero(t, peer.SendDrops())
+	assert.Zero(t, peer.SendDropsByClass(OutboundClassOrdinary))
 }
 
 // TestOverlay_PeersJSON_EmitsMetricsForEveryPeer guards against a

--- a/internal/peermanagement/peer_ping_timeout_test.go
+++ b/internal/peermanagement/peer_ping_timeout_test.go
@@ -176,10 +176,6 @@ func TestPeer_RunPingTick_HappyPathRecordsAndSends(t *testing.T) {
 	p.latencyMu.RUnlock()
 	assert.Equal(t, 1, inFlight, "happy path records exactly one in-flight ping")
 
-	select {
-	case msg := <-p.send:
-		assert.NotEmpty(t, msg, "ping must be queued on the send channel")
-	default:
-		t.Fatal("expected a wire message on p.send after a successful tick")
-	}
+	msg := requireOutboundFrame(t, p)
+	assert.NotEmpty(t, msg, "ping must be queued")
 }

--- a/internal/peermanagement/peer_test.go
+++ b/internal/peermanagement/peer_test.go
@@ -160,14 +160,8 @@ func TestPeer_SendBufferFull(t *testing.T) {
 	peer.setState(PeerStateConnected)
 	peer.closed.Store(false)
 
-	// Fill the send buffer
-	for range DefaultSendBufferSize {
-		select {
-		case peer.send <- []byte("data"):
-		default:
-			// Buffer full
-			break
-		}
+	for range ordinarySendMaximum {
+		require.NoError(t, peer.Send([]byte("data")))
 	}
 
 	// Next send should fail with buffer full

--- a/internal/peermanagement/reduce_relay_integration_test.go
+++ b/internal/peermanagement/reduce_relay_integration_test.go
@@ -10,27 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestOverlay_ReduceRelay_NaturalSelection_EndToEnd pins the R4.2
-// integration path: the full Relay selection → Overlay.handleSquelch
-// → Peer.Send wire chain fires when natural MaxMessageThreshold +
-// MaxSelectedPeers traffic arrives through Overlay.OnValidatorMessage
-// (the production entry point called by adaptor.UpdateRelaySlot).
-//
-// Without this test the only end-to-end coverage is
-// TestTwoOverlay_Squelch_RoundTrip, which short-circuits through
-// IssueSquelch directly and skips the selection state machine and the
-// onSquelch→handleSquelch callback wiring. A regression that broke
-// any of those hops (selection not firing, callback not wired,
-// handleSquelch not finding the peer, wire encode failure, send
-// queue overflow) would pass existing tests but silently disable
-// reduce-relay for the whole fleet.
-//
-// Approach: build a bare Overlay with a fake clock past WaitOnBootup,
-// register several mock peers with real outbound queues, feed the
-// Relay enough activity to cross selection threshold via the
-// production OnValidatorMessage entry point, and assert that at least
-// one TMSquelch wire frame materialized in a non-selected peer's
-// send queue.
 func TestOverlay_ReduceRelay_NaturalSelection_EndToEnd(t *testing.T) {
 	// Fake clock: Relay captures startTime at construction, so we
 	// initialize the clock at t=0 and advance it past WaitOnBootup
@@ -48,9 +27,6 @@ func TestOverlay_ReduceRelay_NaturalSelection_EndToEnd(t *testing.T) {
 	cfg.EnableReduceRelay = true
 	cfg.Clock = fakeClock
 
-	// Build Overlay manually — NewFromConfig requires a real data dir
-	// and listener. All we need is the peer map + relay + events
-	// plumbing.
 	o := &Overlay{
 		cfg:    cfg,
 		peers:  make(map[PeerID]*Peer),
@@ -59,13 +35,8 @@ func TestOverlay_ReduceRelay_NaturalSelection_EndToEnd(t *testing.T) {
 	o.relay = NewRelay(&cfg, nil, nil)
 	o.relay.onSquelch = o.handleSquelch
 
-	// Advance the clock past WaitOnBootup so Relay.OnMessage starts
-	// accepting traffic.
 	clockNS.Store(startAt.Add(WaitOnBootup + time.Minute).UnixNano())
 
-	// Build 10 mock peers. MaxSelectedPeers=5 of them will be chosen
-	// and the other 5 will each receive a TMSquelch wire frame on
-	// their outbound queue.
 	const numPeers = 10
 	identity, err := NewIdentity()
 	require.NoError(t, err)
@@ -73,14 +44,11 @@ func TestOverlay_ReduceRelay_NaturalSelection_EndToEnd(t *testing.T) {
 	peers := make(map[PeerID]*Peer, numPeers)
 	for i := 1; i <= numPeers; i++ {
 		p := NewPeer(PeerID(i), endpoint, false, identity, make(chan Event, 1))
-		// Mark connected so o.handleSquelch can find + Send() without
-		// failing on closed state.
 		p.setState(PeerStateConnected)
 		peers[PeerID(i)] = p
 		o.peers[PeerID(i)] = p
 	}
 
-	// 33-byte validator pub-key (compressed secp256k1 shape).
 	validator := make([]byte, 33)
 	for i := range validator {
 		validator[i] = byte(0x10 | i)
@@ -98,8 +66,6 @@ func TestOverlay_ReduceRelay_NaturalSelection_EndToEnd(t *testing.T) {
 		}
 	}
 
-	// The selection state machine must have transitioned to Selected
-	// and chosen MaxSelectedPeers peers.
 	keyHex := string(validator)
 	o.relay.mu.RLock()
 	slot, ok := o.relay.slots[keyHex]
@@ -116,11 +82,6 @@ func TestOverlay_ReduceRelay_NaturalSelection_EndToEnd(t *testing.T) {
 	require.Equal(t, MaxSelectedPeers, len(selected),
 		"exactly MaxSelectedPeers must be picked as the source set")
 
-	// For each non-selected peer, its outbound queue must now
-	// contain a TMSquelch wire frame. This is the integration gate:
-	// selection fired → onSquelch callback invoked → handleSquelch
-	// built and sent the wire frame. Any regression in that chain
-	// leaves the channel empty.
 	selectedSet := make(map[PeerID]struct{}, len(selected))
 	for _, id := range selected {
 		selectedSet[id] = struct{}{}
@@ -129,18 +90,12 @@ func TestOverlay_ReduceRelay_NaturalSelection_EndToEnd(t *testing.T) {
 	squelchesSeen := 0
 	for id, p := range peers {
 		if _, isSelected := selectedSet[id]; isSelected {
-			// Selected peers MUST NOT have received a squelch.
 			if frame, ok := takeOutboundFrame(p); ok {
-				// Sanity: it's possible the overlay sent something
-				// else (unlikely in this barebones test, but guard).
 				t.Errorf("selected peer %d unexpectedly received a frame (%d bytes)", id, len(frame))
 			}
 			continue
 		}
-		// Non-selected peer — expect exactly one TMSquelch frame in
-		// the send queue.
 		if frame, ok := takeOutboundFrame(p); ok {
-			// Decode the wire frame header to confirm it's TMSquelch.
 			require.GreaterOrEqual(t, len(frame), message.HeaderSizeUncompressed,
 				"squelched peer %d received an undersized frame", id)
 			// The 4th and 5th bytes (big-endian) carry the type.

--- a/internal/peermanagement/reduce_relay_integration_test.go
+++ b/internal/peermanagement/reduce_relay_integration_test.go
@@ -26,7 +26,7 @@ import (
 // reduce-relay for the whole fleet.
 //
 // Approach: build a bare Overlay with a fake clock past WaitOnBootup,
-// register several mock peers with real Peer.send channels, feed the
+// register several mock peers with real outbound queues, feed the
 // Relay enough activity to cross selection threshold via the
 // production OnValidatorMessage entry point, and assert that at least
 // one TMSquelch wire frame materialized in a non-selected peer's
@@ -65,7 +65,7 @@ func TestOverlay_ReduceRelay_NaturalSelection_EndToEnd(t *testing.T) {
 
 	// Build 10 mock peers. MaxSelectedPeers=5 of them will be chosen
 	// and the other 5 will each receive a TMSquelch wire frame on
-	// their Peer.send channel.
+	// their outbound queue.
 	const numPeers = 10
 	identity, err := NewIdentity()
 	require.NoError(t, err)
@@ -116,7 +116,7 @@ func TestOverlay_ReduceRelay_NaturalSelection_EndToEnd(t *testing.T) {
 	require.Equal(t, MaxSelectedPeers, len(selected),
 		"exactly MaxSelectedPeers must be picked as the source set")
 
-	// For each non-selected peer, its Peer.send channel must now
+	// For each non-selected peer, its outbound queue must now
 	// contain a TMSquelch wire frame. This is the integration gate:
 	// selection fired → onSquelch callback invoked → handleSquelch
 	// built and sent the wire frame. Any regression in that chain
@@ -130,19 +130,16 @@ func TestOverlay_ReduceRelay_NaturalSelection_EndToEnd(t *testing.T) {
 	for id, p := range peers {
 		if _, isSelected := selectedSet[id]; isSelected {
 			// Selected peers MUST NOT have received a squelch.
-			select {
-			case frame := <-p.send:
+			if frame, ok := takeOutboundFrame(p); ok {
 				// Sanity: it's possible the overlay sent something
 				// else (unlikely in this barebones test, but guard).
 				t.Errorf("selected peer %d unexpectedly received a frame (%d bytes)", id, len(frame))
-			default:
 			}
 			continue
 		}
 		// Non-selected peer — expect exactly one TMSquelch frame in
 		// the send queue.
-		select {
-		case frame := <-p.send:
+		if frame, ok := takeOutboundFrame(p); ok {
 			// Decode the wire frame header to confirm it's TMSquelch.
 			require.GreaterOrEqual(t, len(frame), message.HeaderSizeUncompressed,
 				"squelched peer %d received an undersized frame", id)
@@ -151,7 +148,7 @@ func TestOverlay_ReduceRelay_NaturalSelection_EndToEnd(t *testing.T) {
 			assert.Equal(t, uint16(message.TypeSquelch), msgType,
 				"non-selected peer %d should receive a TMSquelch frame, got type %d", id, msgType)
 			squelchesSeen++
-		default:
+		} else {
 			t.Errorf("non-selected peer %d never received a TMSquelch frame", id)
 		}
 	}

--- a/internal/peermanagement/relay_transaction.go
+++ b/internal/peermanagement/relay_transaction.go
@@ -30,9 +30,6 @@ func peerTxReduceRelayEnabled(p *Peer) bool {
 // not track (see router.relayTransaction); suppressed is therefore reported as
 // the single origin peer.
 func (o *Overlay) RelayTransaction(except PeerID, frame []byte) {
-	o.peersMu.RLock()
-	defer o.peersMu.RUnlock()
-
 	// getActivePeers (OverlayImpl.cpp:1062-1094): total counts every active
 	// peer; disabled counts peers without the feature; candidates are the
 	// peers not in toSkip; enabledInSkip counts skipped peers that have the
@@ -43,10 +40,8 @@ func (o *Overlay) RelayTransaction(except PeerID, frame []byte) {
 		enabledInSkip uint64
 		candidates    []*Peer
 	)
-	for id, peer := range o.peers {
-		if peer.State() != PeerStateConnected {
-			continue
-		}
+	for _, target := range o.connectedPeers() {
+		id, peer := target.id, target.peer
 		total++
 		enabled := peerTxReduceRelayEnabled(peer)
 		if !enabled {
@@ -61,8 +56,14 @@ func (o *Overlay) RelayTransaction(except PeerID, frame []byte) {
 		candidates = append(candidates, peer)
 	}
 
-	sendFull := func(p *Peer) {
-		o.sendAndLog(p, frame, "relay-transaction", false)
+	result := fanoutResult{operation: "relay-transaction"}
+	defer func() {
+		o.logFanoutFailure(result.err())
+	}()
+	sendFull := func(p *Peer) bool {
+		err := p.Send(frame)
+		result.record(err)
+		return err == nil
 	}
 
 	const suppressed = 1 // go-xrpl's toSkip is the single originating peer
@@ -102,13 +103,23 @@ func (o *Overlay) RelayTransaction(except PeerID, frame []byte) {
 	}
 
 	enabledAndRelayed := enabledInSkip
+	relayTransactionCandidates(candidates, enabledAndRelayed, enabledTarget, sendFull)
+}
+
+func relayTransactionCandidates(
+	candidates []*Peer,
+	enabledAndRelayed uint64,
+	enabledTarget uint64,
+	sendFull func(*Peer) bool,
+) {
 	for _, p := range candidates {
 		switch {
 		case !peerTxReduceRelayEnabled(p):
 			sendFull(p) // always relay to peers without the feature
 		case enabledAndRelayed < enabledTarget:
-			enabledAndRelayed++
-			sendFull(p)
+			if sendFull(p) {
+				enabledAndRelayed++
+			}
 		default:
 			// Remaining enabled peers learn of the tx via the periodic
 			// TMHaveTransactions announce (rippled's addTxQueue analogue).

--- a/internal/peermanagement/relay_transaction_test.go
+++ b/internal/peermanagement/relay_transaction_test.go
@@ -21,7 +21,7 @@ func relayTestPeer(t *testing.T, ident *Identity, id PeerID, txrr bool) *Peer {
 	return p
 }
 
-func gotFrame(p *Peer) bool { return len(p.send) > 0 }
+func gotFrame(p *Peer) bool { return p.SendQueueLen() > 0 }
 
 // TestRelayTransaction_FeatureOff relays to every candidate peer and records
 // no metrics when tx-reduce-relay is disabled (OverlayImpl.cpp:1251-1259 with
@@ -121,6 +121,35 @@ func TestRelayTransaction_ReducePathSelectsSubset(t *testing.T) {
 	assert.Equal(t, uint64(3), o.txm.selected.accum, "selected = enabledTarget")
 	assert.Equal(t, uint64(1), o.txm.suppressed.accum, "suppressed = origin")
 	assert.Equal(t, uint64(2), o.txm.notEnabled.accum, "notEnabled = disabled count")
+}
+
+func TestRelayTransactionCandidatesReplacesFailedEnabledSend(t *testing.T) {
+	ident, err := NewIdentity()
+	require.NoError(t, err)
+	full := relayTestPeer(t, ident, 1, true)
+	firstHealthy := relayTestPeer(t, ident, 2, true)
+	secondHealthy := relayTestPeer(t, ident, 3, true)
+	for range ordinarySendMaximum {
+		require.NoError(t, full.Send([]byte{0xAA}))
+	}
+
+	result := fanoutResult{operation: "relay-transaction"}
+	send := func(peer *Peer) bool {
+		err := peer.Send([]byte{0xBB})
+		result.record(err)
+		return err == nil
+	}
+	relayTransactionCandidates(
+		[]*Peer{full, firstHealthy, secondHealthy},
+		0,
+		2,
+		send,
+	)
+
+	require.True(t, gotFrame(firstHealthy))
+	require.True(t, gotFrame(secondHealthy))
+	require.Equal(t, 1, result.failed)
+	require.Equal(t, 3, result.attempted)
 }
 
 // TestRecordInboundTxMetric_LedgerCategorisation pins that only the

--- a/internal/peermanagement/relayed_index_test.go
+++ b/internal/peermanagement/relayed_index_test.go
@@ -9,14 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestOverlay_PeersThatHave_PopulatedByRelayForward is the core B3
-// contract: when the overlay forwards a validator message to peers,
-// Overlay.PeersThatHave(suppressionHash) must return the set of
-// recipients so a later duplicate arrival from a DIFFERENT peer can
-// feed the reduce-relay slot with every known-haver. Mirrors
-// rippled's haveMessage return from overlay_.relay
-// (PeerImp.cpp:3010-3017 / 3044-3054).
-func TestOverlay_PeersThatHave_PopulatedByRelayForward(t *testing.T) {
+func TestOverlay_RecordMessageSource_AccumulatesInboundOnly(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)
 
@@ -26,6 +19,10 @@ func TestOverlay_PeersThatHave_PopulatedByRelayForward(t *testing.T) {
 		relayedIndex:  make(map[[32]byte]*relayedEntry),
 		clockForIndex: time.Now,
 	}
+	cfg := DefaultConfig()
+	cfg.EnableVPReduceRelay = true
+	o.relay = NewRelay(&cfg, nil, nil)
+	o.relay.startTime = time.Now().Add(-WaitOnBootup - time.Minute)
 
 	endpoint := Endpoint{Host: "127.0.0.1", Port: 51235}
 	peerA := NewPeer(PeerID(1), endpoint, false, id, make(chan Event, 1))
@@ -42,42 +39,41 @@ func TestOverlay_PeersThatHave_PopulatedByRelayForward(t *testing.T) {
 	hash := [32]byte{0xAB, 0xCD}
 	payload := []byte("signed-proposal-bytes")
 
-	// Relay from peer C (origin): A and B must receive the payload,
-	// and the reverse index must record {A, B} against `hash`. C is
-	// excluded as origin and must NOT appear in the index.
-	require.NoError(t, o.RelayFromValidator(validator, hash, peerC.ID(), payload))
+	o.RecordMessageSource(hash, peerA.ID())
+	o.RecordMessageSource(hash, peerC.ID())
 
 	got := o.PeersThatHave(hash)
-	require.NotNil(t, got, "PeersThatHave must return a non-nil set after a relay-forward")
 	slices.Sort(got)
-	assert.Equal(t, []PeerID{peerA.ID(), peerB.ID()}, got,
-		"reverse index must contain exactly the peers we forwarded to (A, B); origin C must be excluded")
+	assert.Equal(t, []PeerID{peerA.ID(), peerC.ID()}, got)
 
-	// A second forward for the SAME hash but to a disjoint set (say
-	// we learn about a new peer D later) must UNION in, not replace.
-	peerD := NewPeer(PeerID(4), endpoint, false, id, make(chan Event, 1))
-	peerD.setState(PeerStateConnected)
-	o.peers[peerD.ID()] = peerD
-	// Exclude A, B, C this time so only D is the recipient.
-	require.NoError(t, o.RelayFromValidator(validator, hash, peerA.ID(), payload))
+	require.NoError(t, o.RelayFromValidator(validator, hash, 0, payload))
+	assert.True(t, o.MessageRelayedRecently(hash))
 
-	got2 := o.PeersThatHave(hash)
-	gotSet := make(map[PeerID]struct{}, len(got2))
-	for _, p := range got2 {
-		gotSet[p] = struct{}{}
+	for _, source := range []*Peer{peerA, peerC} {
+		if frame, ok := takeOutboundFrame(source); ok {
+			t.Fatalf("inbound source %d received relayed frame %q", source.ID(), frame)
+		}
 	}
-	for _, want := range []PeerID{peerB.ID(), peerC.ID(), peerD.ID()} {
-		_, ok := gotSet[want]
-		assert.True(t, ok, "reverse index must retain peer %d after a second relay-forward with a different exceptPeer", want)
-	}
+	assert.Equal(t, payload, requireOutboundFrame(t, peerB))
+
+	assert.Empty(t, o.PeersThatHave(hash), "relay must release the accumulated source set")
+	o.relay.mu.RLock()
+	slot := o.relay.slots[string(validator)]
+	o.relay.mu.RUnlock()
+	require.NotNil(t, slot)
+	slot.mu.RLock()
+	_, countedA := slot.peers[peerA.ID()]
+	_, countedC := slot.peers[peerC.ID()]
+	slot.mu.RUnlock()
+	assert.True(t, countedA)
+	assert.True(t, countedC)
+
+	// Outbound delivery is not evidence that a peer supplied the message.
+	// A later arrival begins a fresh source set containing only its sender.
+	o.RecordMessageSource(hash, peerC.ID())
+	assert.Equal(t, []PeerID{peerC.ID()}, o.PeersThatHave(hash))
 }
 
-// TestOverlay_PeersThatHave_TTLExpiry pins the lazy TTL: once the
-// bucket is older than RelayedIndexTTL, PeersThatHave returns nil and
-// the bucket is dropped. This must match the consensus router's
-// messageDedupTTL so the index doesn't outlive the dedup cache — a
-// stale entry would feed the slot with counters for peers the rest of
-// the network has already aged out.
 func TestOverlay_PeersThatHave_TTLExpiry(t *testing.T) {
 	var nowVal time.Time
 	o := &Overlay{
@@ -87,25 +83,44 @@ func TestOverlay_PeersThatHave_TTLExpiry(t *testing.T) {
 	}
 	o.clockForIndex = func() time.Time { return nowVal }
 
-	// Seed the index directly so we don't need a real peer map.
 	hash := [32]byte{0x01}
 	nowVal = time.Unix(1_700_000_000, 0)
-	o.recordRelayedPeers(hash, []PeerID{PeerID(7)})
+	o.RecordMessageSource(hash, PeerID(7))
 
-	// Immediate query returns the set.
 	got := o.PeersThatHave(hash)
 	require.Len(t, got, 1)
 	assert.Equal(t, PeerID(7), got[0])
 
-	// Advance past TTL: query must return nil (lazy expiry).
+	// Every arrival refreshes the hold and accumulates its source.
+	nowVal = nowVal.Add(RelayedIndexTTL - time.Second)
+	o.RecordMessageSource(hash, PeerID(8))
+	got = o.PeersThatHave(hash)
+	slices.Sort(got)
+	assert.Equal(t, []PeerID{7, 8}, got)
+
 	nowVal = nowVal.Add(RelayedIndexTTL + time.Second)
 	got = o.PeersThatHave(hash)
 	assert.Nil(t, got, "bucket older than RelayedIndexTTL must be reaped on query")
 
-	// Bucket must also be physically removed from the map so the
-	// next query path is O(1) on the cold-miss.
 	o.relayedIndexMu.Lock()
 	_, present := o.relayedIndex[hash]
 	o.relayedIndexMu.Unlock()
 	assert.False(t, present, "expired bucket must be deleted from the index, not just hidden")
+}
+
+func TestOverlay_MessageRelayedRecentlyWindow(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	o := &Overlay{
+		relayedIndex:  make(map[[32]byte]*relayedEntry),
+		clockForIndex: func() time.Time { return now },
+	}
+	hash := [32]byte{0x02}
+	o.RecordMessageSource(hash, PeerID(7))
+	assert.False(t, o.MessageRelayedRecently(hash))
+
+	assert.Equal(t, []PeerID{7}, o.releaseMessageSources(hash))
+	assert.True(t, o.MessageRelayedRecently(hash))
+
+	now = now.Add(Idled)
+	assert.False(t, o.MessageRelayedRecently(hash))
 }

--- a/internal/peermanagement/send_policy_test.go
+++ b/internal/peermanagement/send_policy_test.go
@@ -1,7 +1,6 @@
 package peermanagement
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -9,95 +8,91 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPeer_Send_DropPolicy pins finding 9: a full bounded send queue drops
-// the frame (returning ErrSendBufferFull) and counts it per peer, and the
-// large-send-queue intervals reset as soon as a new send observes recovery.
-func TestPeer_Send_DropPolicy(t *testing.T) {
+func TestPeerSendOrdinaryHardLimitReturnsTypedOutcome(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)
-	// nil events channel: Send never touches it. No writer drains p.send,
-	// so the buffer fills deterministically.
 	peer := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
 
-	// Fill the bounded send buffer.
-	for i := range DefaultSendBufferSize {
+	for i := range ordinarySendMaximum {
 		require.NoError(t, peer.Send([]byte{byte(i)}), "enqueue %d should succeed", i)
 	}
 	require.Zero(t, peer.SendDrops(), "no drops while the queue has room")
 
-	// Queue full: further sends drop and count without accelerating the
-	// timer-based disconnect policy.
-	require.ErrorIs(t, peer.Send([]byte{0xFF}), ErrSendBufferFull)
-	require.ErrorIs(t, peer.Send([]byte{0xFE}), ErrSendBufferFull)
-	assert.Equal(t, uint64(2), peer.SendDrops(), "each dropped frame must be counted")
+	err = peer.Send([]byte{0xFF})
+	require.ErrorIs(t, err, ErrSendBufferFull)
+	var queueErr *SendQueueError
+	require.ErrorAs(t, err, &queueErr)
+	assert.Equal(t, OutboundClassOrdinary, queueErr.Class)
+	assert.Equal(t, SendQueueFrameLimit, queueErr.Reason)
+	assert.Equal(t, ordinarySendMaximum, queueErr.RetainedFrames)
+	assert.Equal(t, uint64(1), peer.SendDrops())
+	assert.Equal(t, uint64(1), peer.SendDropsByClass(OutboundClassOrdinary))
 	assert.Zero(t, peer.largeSendQ.Load())
 
-	// Drain a single frame (queue still well above target) and re-enqueue.
-	<-peer.send
+	requireOutboundFrame(t, peer)
 	require.NoError(t, peer.Send([]byte{0x01}))
-	assert.Zero(t, peer.largeSendQ.Load())
 
 	peer.largeSendQ.Store(3)
-	// A send after the queue drains below target clears prior timer strikes.
-	for len(peer.send) > 0 {
-		<-peer.send
+	for peer.SendQueueLen() > 0 {
+		requireOutboundFrame(t, peer)
 	}
 	require.NoError(t, peer.Send([]byte{0x02}))
 	assert.Zero(t, peer.largeSendQ.Load())
 }
 
-func TestPeerPrioritySendHasIndependentCapacity(t *testing.T) {
+func TestPeerAcquisitionAdmissionCannotConsumeCriticalMinima(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)
 	peer := NewPeer(1, Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
 
-	results := make(chan error, DefaultSendBufferSize*2)
-	var wg sync.WaitGroup
-	for range DefaultSendBufferSize * 2 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			results <- peer.Send([]byte("gossip"))
-		}()
+	for range ordinarySendMaximum {
+		require.NoError(t, peer.Send([]byte("gossip")))
 	}
-	wg.Wait()
-	close(results)
-
-	succeeded := 0
-	for err := range results {
-		if err == nil {
-			succeeded++
-		} else {
-			require.ErrorIs(t, err, ErrSendBufferFull)
+	acquisitionAccepted := 0
+	for {
+		err = peer.SendPriority([]byte("acquisition"))
+		if err != nil {
+			break
 		}
+		acquisitionAccepted++
 	}
-	require.Equal(t, DefaultSendBufferSize, succeeded)
-	require.Len(t, peer.send, DefaultSendBufferSize)
+	require.ErrorIs(t, err, ErrSendBufferFull)
+	assert.Equal(t, 120, acquisitionAccepted)
+	snapshot := peer.outbound.snapshot()
+	assert.Equal(t, ordinarySendMaximum, snapshot.ClassFrames[OutboundClassOrdinary])
+	assert.Equal(t, acquisitionAccepted, snapshot.ClassFrames[OutboundClassAcquisition])
 
-	for range acquisitionSendBufferSize {
-		require.NoError(t, peer.SendPriority([]byte("acquisition")))
+	for range consensusSendMinimum {
+		require.NoError(t, peer.outbound.enqueueReliable(OutboundClassConsensus, []byte("validation")))
 	}
-	require.ErrorIs(t, peer.SendPriority([]byte("acquisition")), ErrSendBufferFull)
-	assert.Len(t, peer.send, DefaultSendBufferSize)
-	assert.Len(t, peer.prioritySend, acquisitionSendBufferSize)
-	assert.Equal(t, DefaultSendBufferSize+acquisitionSendBufferSize, peer.SendQueueLen())
+	for range controlSendMinimum {
+		require.NoError(t, peer.outbound.enqueueReliable(OutboundClassControl, []byte("control")))
+	}
+	assert.Equal(t, reliableSendBufferSize, peer.SendQueueLen())
 }
 
-func TestPeerPingQueuePressureIsNotFatal(t *testing.T) {
+func TestPeerPingUsesProtectedControlAdmission(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)
 	peer := NewPeer(1, Endpoint{Host: "127.0.0.1", Port: 1}, false, id, nil)
-	for range DefaultSendBufferSize {
+	for range ordinarySendMaximum {
 		require.NoError(t, peer.Send([]byte{1}))
+	}
+	for range 120 {
+		require.NoError(t, peer.SendPriority([]byte("acquisition")))
+	}
+	for range consensusSendMinimum {
+		require.NoError(t, peer.outbound.enqueueReliable(OutboundClassConsensus, []byte("validation")))
 	}
 
 	now := time.Unix(1_000, 0)
 	require.NoError(t, peer.runPingTick(now))
-	assert.Equal(t, uint64(1), peer.SendDrops())
 	peer.latencyMu.RLock()
 	inFlight := len(peer.pingsInFlight)
 	peer.latencyMu.RUnlock()
-	assert.Zero(t, inFlight, "a ping that was not queued must not start its timeout")
+	assert.Equal(t, 1, inFlight)
+	assert.Equal(t, controlSendMinimum-1, reliableSendBufferSize-peer.SendQueueLen())
+	assert.Zero(t, peer.SendDrops())
 	assert.Equal(t, uint32(1), peer.largeSendQ.Load())
 }
 
@@ -162,12 +157,12 @@ func TestPeerSendRecoveryResetsTimerStrikesBeforeQueueRegrows(t *testing.T) {
 	clearPeerPings(peer)
 	assert.Equal(t, uint32(2), peer.largeSendQ.Load())
 
-	for len(peer.send) >= targetSendQueue {
-		<-peer.send
+	for peer.SendQueueLen() >= targetSendQueue {
+		requireOutboundFrame(t, peer)
 	}
 	require.NoError(t, peer.Send([]byte{1}))
 	assert.Zero(t, peer.largeSendQ.Load())
-	for len(peer.send) < targetSendQueue {
+	for peer.SendQueueLen() < targetSendQueue {
 		require.NoError(t, peer.Send([]byte{1}))
 	}
 

--- a/internal/peermanagement/should_shed_ledger_request_test.go
+++ b/internal/peermanagement/should_shed_ledger_request_test.go
@@ -44,7 +44,7 @@ func TestShouldShedLedgerRequest(t *testing.T) {
 		p := relayTestPeer(t, ident, 1, true)
 		o.peers[1] = p
 		for range peerSendQueueDropThreshold {
-			p.send <- []byte{0x00}
+			require.NoError(t, p.Send([]byte{0x00}))
 		}
 		assert.True(t, o.ShouldShedLedgerRequest(1, false),
 			"send_queue_ >= dropSendQueue → drop (PeerImp.cpp:3322)")

--- a/internal/peermanagement/squelch_test.go
+++ b/internal/peermanagement/squelch_test.go
@@ -196,18 +196,15 @@ func TestRelayFromValidator_SkipsSquelchedPeers(t *testing.T) {
 	require.NoError(t, o.RelayFromValidator(validator, hash, PeerID(0), payload))
 
 	// `allowed` must have received exactly the payload.
-	select {
-	case got := <-allowed.send:
+	if got, ok := takeOutboundFrame(allowed); ok {
 		assert.Equal(t, payload, got)
-	default:
+	} else {
 		t.Fatal("allowed peer did not receive the broadcast")
 	}
 
 	// `squelched` must NOT have received anything.
-	select {
-	case got := <-squelched.send:
+	if got, ok := takeOutboundFrame(squelched); ok {
 		t.Fatalf("squelched peer received a frame it should have been filtered: %q", got)
-	default:
 	}
 }
 

--- a/internal/rpc/handlers/stubs_admin.go
+++ b/internal/rpc/handlers/stubs_admin.go
@@ -29,6 +29,10 @@ import (
 // own server_info; sequence numbers and proposer/converge counts stay numeric.
 type PrintMethod struct{ AdminHandler }
 
+type outboundCriticalQueueFailureSource interface {
+	OutboundCriticalQueueFailures() (local, shared uint64)
+}
+
 func (m *PrintMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	if ctx.Services == nil || ctx.Services.Ledger == nil {
 		return nil, rpcInternalInvariantError("print: ledger service unavailable")
@@ -57,6 +61,13 @@ func (m *PrintMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any
 		}
 		if cluster := ctx.PeerSource.ClusterJSON(); cluster != nil {
 			overlay["cluster"] = cluster
+		}
+		if failures, ok := ctx.PeerSource.(outboundCriticalQueueFailureSource); ok {
+			local, shared := failures.OutboundCriticalQueueFailures()
+			overlay["outbound_queue"] = map[string]any{
+				"critical_failures_local":  fmt.Sprintf("%d", local),
+				"critical_failures_shared": fmt.Sprintf("%d", shared),
+			}
 		}
 		out["overlay"] = overlay
 	}

--- a/internal/rpc/peers_server_info_parity_test.go
+++ b/internal/rpc/peers_server_info_parity_test.go
@@ -12,13 +12,18 @@ import (
 )
 
 type stubPeerSource struct {
-	peers   []map[string]any
-	cluster map[string]any
+	peers                  []map[string]any
+	cluster                map[string]any
+	criticalFailuresLocal  uint64
+	criticalFailuresShared uint64
 }
 
 func (s *stubPeerSource) PeersJSON() []map[string]any { return s.peers }
 func (s *stubPeerSource) ClusterJSON() map[string]any { return s.cluster }
 func (s *stubPeerSource) PeerCount() int              { return len(s.peers) }
+func (s *stubPeerSource) OutboundCriticalQueueFailures() (uint64, uint64) {
+	return s.criticalFailuresLocal, s.criticalFailuresShared
+}
 
 func TestPeersAndServerInfoShareSource(t *testing.T) {
 	src := &stubPeerSource{

--- a/internal/rpc/print_wire_test.go
+++ b/internal/rpc/print_wire_test.go
@@ -39,8 +39,10 @@ func printTestServer(t *testing.T) *Server {
 	}
 	srv.registry.Register("print", &handlers.PrintMethod{})
 	srv.SetPeerSource(&stubPeerSource{
-		peers:   []map[string]any{{"address": "192.0.2.1:51235"}},
-		cluster: map[string]any{},
+		peers:                  []map[string]any{{"address": "192.0.2.1:51235"}},
+		cluster:                map[string]any{},
+		criticalFailuresLocal:  4,
+		criticalFailuresShared: 2,
 	})
 	return srv
 }
@@ -84,7 +86,11 @@ func TestPrintMethod_WireShape(t *testing.T) {
 		assert.Equal(t, "1000", full["duration_us"])
 
 		assert.IsType(t, float64(0), res["last_close"].(map[string]any)["proposers"])
-		assert.IsType(t, float64(0), res["overlay"].(map[string]any)["count"])
+		overlay := res["overlay"].(map[string]any)
+		assert.IsType(t, float64(0), overlay["count"])
+		outbound := overlay["outbound_queue"].(map[string]any)
+		assert.Equal(t, "4", outbound["critical_failures_local"])
+		assert.Equal(t, "2", outbound["critical_failures_shared"])
 	})
 
 	t.Run("subtree selector narrows output over the wire", func(t *testing.T) {


### PR DESCRIPTION
Closes #1445.

## Root cause

Validator and transaction gossip shared a small ordinary per-peer queue. A legitimate startup validation burst could fill it before slow or newly connected peer writers drained, producing a concentrated queue-full warning storm. Failed enqueues were also recorded as relay recipients, which could suppress later successful delivery. Validation signature work and freshness/trust decisions were not isolated enough from startup load.

## What changed

- Replace the ordinary/priority channel split with a peer-owned bounded outbound scheduler:
  - one 512-frame reliable FIFO with protected control, consensus, acquisition, and ordinary admission
  - a separate paced bulk-manifest lane
  - exact queued and in-flight byte accounting
  - per-peer critical reservations and an overlay-wide retained-byte ceiling
  - safe short-write handling and terminal behavior for protocol-critical saturation
- Snapshot fanout targets outside the overlay lock, aggregate/rate-limit failures, preserve all causes, and record only successful deliveries.
- Match rippled HashRouter behavior for inbound source sets, relay timing, signer identity, and duplicate suppression.
- Add explicit validation dispositions and asynchronous signature verification with isolated trusted/untrusted work and result lanes.
- Recheck trust after verification and allow only trusted current validations to drive tracking and ledger acquisition.
- Expose per-peer send-drop metrics split by control, consensus, acquisition, ordinary, and bulk traffic.
- Clarify acquisition diagnostics as `no progress in current interval` while retaining lifetime received/useful totals.
- Scale the shared outbound ceiling for large valid `peers_max` configurations without changing the normal 512 MiB floor.

Acquisition uses protected admission within the reliable FIFO. It does not overtake previously accepted reliable frames, preserving FIFO behavior while preventing gossip from consuming its reserved capacity.

## Validation

- `GOCACHE=/private/tmp/gocache-issue1445-full2 just test`
- focused normal and race tests for:
  - `./internal/peermanagement`
  - `./internal/ledger/inbound`
  - `./internal/consensus/adaptor`
  - `./internal/consensus/rcl`
- `just build-all`
- `just build-nocgo`
- `just vet`
- `just lint`
- `golangci-lint run --config .golangci.yml`
- `git diff --check`

The incident regression blocks two peer writers, queues 255 validation frames plus transaction and acquisition traffic per peer, verifies all protocol-critical admissions, and drains the exact FIFO order.

## Conformance

Reviewed against the local rippled v3.2.0 oracle for validation ingress/work/relay, HashRouter suppression semantics, proposal/validation relay, transaction reduce-relay, send FIFO/liveness thresholds, and validation classification. No correctness or conformance blockers remain.

Not run: a live warm stale-database Testnet soak or Docker interop. The local oracle source identifies v3.2.0, but broken worktree metadata prevented independently verifying its commit and clean status.