### PR TITLE
fix: harden CLI RPC contracts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,11 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/pierrec/lz4 v2.6.1+incompatible
 	github.com/spf13/cobra v1.9.1
+	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/sync v0.18.0
+	golang.org/x/term v0.37.0
 	golang.org/x/tools v0.38.0
 	google.golang.org/grpc v1.78.0
 	modernc.org/sqlite v1.46.1
@@ -36,7 +38,6 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
-	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=
+golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=

--- a/internal/cli/rpc.go
+++ b/internal/cli/rpc.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -14,6 +16,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/config"
 	"github.com/LeJamon/go-xrpl/internal/cmdexit"
+	ledgerselector "github.com/LeJamon/go-xrpl/internal/ledger/selector"
 	"github.com/spf13/cobra"
 )
 
@@ -35,9 +38,26 @@ func init() {
 		rpcCmd.AddCommand(spec.command())
 	}
 	rpcCmd.AddCommand(jsonCmd)
+	rpcCmd.PersistentFlags().Bool(
+		"allow-insecure-rpc-credentials",
+		false,
+		"allow credentials to be sent over cleartext HTTP to a non-loopback host",
+	)
 }
 
-const rpcRequestTimeout = 30 * time.Second
+const (
+	rpcRequestTimeout   = 30 * time.Second
+	maxRPCResponseBytes = 64 << 20
+	insecureRPCFlag     = "allow-insecure-rpc-credentials"
+	adminUserParam      = "admin_user"
+	adminPasswordParam  = "admin_password"
+)
+
+var rpcHTTPClient = &http.Client{
+	CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
 
 // rpcCommandSpec is a single `xrpld rpc <name>` subcommand. The command name
 // and (by default) the RPC method are the first token of Use; params builds
@@ -45,12 +65,13 @@ const rpcRequestTimeout = 30 * time.Second
 // arg→param mapping in one closure collapses ~50 near-identical command
 // literals into a single table.
 type rpcCommandSpec struct {
-	use    string
-	short  string
-	long   string
-	method string // defaults to the first token of use
-	args   cobra.PositionalArgs
-	params func(args []string) (any, error)
+	use              string
+	short            string
+	long             string
+	method           string
+	args             cobra.PositionalArgs
+	params           func(args []string) (any, error)
+	paramsWithSecret func(cmd *cobra.Command, args []string, secret string, provided bool) (any, error)
 }
 
 func (s rpcCommandSpec) methodName() string {
@@ -61,25 +82,46 @@ func (s rpcCommandSpec) methodName() string {
 }
 
 func (s rpcCommandSpec) command() *cobra.Command {
+	return s.commandWithSecretPrompt(nil)
+}
+
+func (s rpcCommandSpec) commandWithSecretPrompt(ask rpcSecretPrompt) *cobra.Command {
 	method := s.methodName()
-	build := s.params
-	return &cobra.Command{
+	args := s.args
+	if args == nil {
+		args = cobra.NoArgs
+	}
+	var commandSecretFlags *rpcSecretFlags
+	command := &cobra.Command{
 		Use:   s.use,
 		Short: s.short,
 		Long:  s.long,
-		Args:  s.args,
+		Args:  args,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var params any
-			if build != nil {
-				p, err := build(args)
+			if s.paramsWithSecret != nil {
+				secret, provided, err := commandSecretFlags.resolve(cmd)
 				if err != nil {
 					return err
 				}
-				params = p
+				params, err = s.paramsWithSecret(cmd, args, secret, provided)
+				if err != nil {
+					return err
+				}
+			} else if s.params != nil {
+				var err error
+				params, err = s.params(args)
+				if err != nil {
+					return err
+				}
 			}
 			return runRPC(cmd, method, params)
 		},
 	}
+	if s.paramsWithSecret != nil {
+		commandSecretFlags = bindRPCSecretFlags(command, ask)
+	}
+	return command
 }
 
 // runRPC forwards a single method call to the running node's JSON-RPC port and
@@ -96,6 +138,10 @@ func runRPC(cmd *cobra.Command, method string, params any) error {
 		return err
 	}
 
+	params, err = rpcRequestParams(params, port)
+	if err != nil {
+		return err
+	}
 	reqBody := map[string]any{"method": method}
 	if params != nil {
 		reqBody["params"] = []any{params}
@@ -103,6 +149,14 @@ func runRPC(cmd *cobra.Command, method string, params any) error {
 	payload, err := json.Marshal(reqBody)
 	if err != nil {
 		return fmt.Errorf("encoding request: %w", err)
+	}
+
+	if rpcPortHasCredentials(port) && !rpcEndpointIsLoopback(endpoint) && !allowInsecureRPC(cmd) {
+		return fmt.Errorf(
+			"refusing to send RPC credentials over cleartext HTTP to %s; use --%s to allow this explicitly",
+			endpoint,
+			insecureRPCFlag,
+		)
 	}
 
 	parent := cmd.Context()
@@ -118,19 +172,22 @@ func runRPC(cmd *cobra.Command, method string, params any) error {
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json")
-	if user, pass := rpcCredentials(port); user != "" {
+	if user, pass := rpcBasicCredentials(port); user != "" || pass != "" {
 		httpReq.SetBasicAuth(user, pass)
 	}
 
-	resp, err := http.DefaultClient.Do(httpReq)
+	resp, err := rpcHTTPClient.Do(httpReq)
 	if err != nil {
 		return fmt.Errorf("connecting to node at %s: %w (is the server running?)", endpoint, err)
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := readLimitedRPCBody(resp.Body, maxRPCResponseBytes)
 	if err != nil {
 		return fmt.Errorf("reading response from %s: %w", endpoint, err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("RPC endpoint %s returned HTTP %s", endpoint, resp.Status)
 	}
 
 	return printRPCResult(cmd.OutOrStdout(), method, respBody)
@@ -153,97 +210,430 @@ func rpcEndpoint(cfg *config.Config) (string, *config.PortConfig, error) {
 
 	chosen := names[0]
 	for _, name := range names {
-		if p := ports[name]; len(p.Admin) > 0 || p.AdminUser != "" {
+		p := ports[name]
+		host := rpcTargetHost(p.IP)
+		adminCapable, err := rpcPortIsAdminCapable(p, host)
+		if err != nil {
+			return "", nil, fmt.Errorf("invalid admin configuration for port %q: %w", name, err)
+		}
+		if adminCapable {
 			chosen = name
 			break
 		}
 	}
 
 	p := ports[chosen]
-	host := p.IP
-	if host == "" || host == "0.0.0.0" || host == "::" {
-		host = "127.0.0.1"
-	}
-	return fmt.Sprintf("http://%s:%d/", host, p.Port), &p, nil
+	host := rpcTargetHost(p.IP)
+	endpoint := (&url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(host, strconv.Itoa(p.Port)),
+		Path:   "/",
+	}).String()
+	return endpoint, &p, nil
 }
 
-// rpcCredentials returns the basic-auth credentials to present to the node,
-// preferring the port's admin credentials, mirroring rippled's RPC client.
-func rpcCredentials(p *config.PortConfig) (user, pass string) {
+func rpcTargetHost(host string) string {
+	switch host {
+	case "", "0.0.0.0":
+		return "127.0.0.1"
+	case "::":
+		return "::1"
+	default:
+		return host
+	}
+}
+
+func rpcPortIsAdminCapable(p config.PortConfig, host string) (bool, error) {
+	if len(p.Admin) == 0 {
+		return false, nil
+	}
+	nets, err := p.ParseAdminNets()
+	if err != nil {
+		return false, err
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return false, nil
+	}
+	return config.IPInNets(ip, nets), nil
+}
+
+func rpcRequestParams(params any, p *config.PortConfig) (any, error) {
+	if p == nil || p.AdminUser == "" && p.AdminPassword == "" {
+		return params, nil
+	}
+
+	requestParams := make(map[string]any)
+	if params != nil {
+		source, ok := params.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("RPC parameters must be a JSON object when admin credentials are configured")
+		}
+		for key, value := range source {
+			requestParams[key] = value
+		}
+	}
+	requestParams[adminUserParam] = p.AdminUser
+	requestParams[adminPasswordParam] = p.AdminPassword
+	return requestParams, nil
+}
+
+func rpcBasicCredentials(p *config.PortConfig) (user, pass string) {
 	if p == nil {
 		return "", ""
 	}
-	if p.AdminUser != "" {
-		return p.AdminUser, p.AdminPassword
+	return p.User, p.Password
+}
+
+func rpcPortHasCredentials(p *config.PortConfig) bool {
+	return p != nil && (p.AdminUser != "" || p.AdminPassword != "" || p.User != "" || p.Password != "")
+}
+
+func rpcEndpointIsLoopback(endpoint string) bool {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return false
 	}
-	if p.User != "" {
-		return p.User, p.Password
+	host := strings.ToLower(parsed.Hostname())
+	if host == "localhost" {
+		return true
 	}
-	return "", ""
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func allowInsecureRPC(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	flag := cmd.Flags().Lookup(insecureRPCFlag)
+	if flag == nil {
+		flag = cmd.InheritedFlags().Lookup(insecureRPCFlag)
+	}
+	if flag == nil {
+		return false
+	}
+	allowed, err := strconv.ParseBool(flag.Value.String())
+	return err == nil && allowed
+}
+
+func readLimitedRPCBody(r io.Reader, limit int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("response exceeds %d-byte limit", limit)
+	}
+	return body, nil
 }
 
 // printRPCResult writes the node's result object and reports an error exit when
 // the node returned an error status. The error detail is already in the printed
 // JSON, so a server-side error maps to cmdexit.ErrReported (exit 1, no extra
-// "Error:" line); a malformed response is printed verbatim.
+// "Error:" line).
 func printRPCResult(w io.Writer, method string, body []byte) error {
-	var envelope struct {
-		Result json.RawMessage `json:"result"`
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope == nil {
+		if err == nil {
+			err = fmt.Errorf("expected a JSON object")
+		}
+		return fmt.Errorf("%s RPC returned malformed JSON: %w", method, err)
 	}
-	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Result == nil {
-		fmt.Fprintln(w, strings.TrimRight(string(body), "\n"))
-		return nil
+	resultJSON, ok := envelope["result"]
+	if !ok || bytes.Equal(bytes.TrimSpace(resultJSON), []byte("null")) {
+		return fmt.Errorf("%s RPC response is missing a result object", method)
 	}
 
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(resultJSON, &result); err != nil || result == nil {
+		if err == nil {
+			err = fmt.Errorf("expected a JSON object")
+		}
+		return fmt.Errorf("%s RPC returned an invalid result: %w", method, err)
+	}
+	var status string
+	if rawStatus, ok := result["status"]; !ok || json.Unmarshal(rawStatus, &status) != nil ||
+		status != "success" && status != "error" {
+		return fmt.Errorf("%s RPC response has an invalid result status", method)
+	}
 	var pretty bytes.Buffer
-	if err := json.Indent(&pretty, envelope.Result, "", "  "); err == nil {
+	if err := json.Indent(&pretty, resultJSON, "", "  "); err == nil {
 		fmt.Fprintln(w, pretty.String())
 	} else {
-		fmt.Fprintln(w, string(envelope.Result))
+		fmt.Fprintln(w, string(resultJSON))
 	}
 
-	var status struct {
-		Status string `json:"status"`
-	}
-	if err := json.Unmarshal(envelope.Result, &status); err == nil && status.Status == "error" {
+	if status == "error" {
 		return cmdexit.ErrReported
 	}
 	return nil
 }
 
-// optionalLedger sets ledger_index from args[i] when present.
-func optionalLedger(params map[string]any, args []string, i int) {
-	if len(args) > i {
-		params["ledger_index"] = args[i]
+func parseJSONObject(field, value string) (map[string]any, error) {
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.UseNumber()
+
+	var object map[string]any
+	if err := decoder.Decode(&object); err != nil {
+		return nil, fmt.Errorf("invalid %s JSON object: %w", field, err)
 	}
+	if object == nil {
+		return nil, fmt.Errorf("invalid %s JSON object: expected an object", field)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("unexpected trailing JSON value")
+		}
+		return nil, fmt.Errorf("invalid %s JSON object: %w", field, err)
+	}
+	return object, nil
+}
+
+func parseLedgerRangeBound(field, value string) (int64, error) {
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: expected an integer", field, value)
+	}
+	if parsed > int64(^uint32(0)) {
+		return 0, fmt.Errorf("invalid %s %q: ledger index exceeds uint32", field, value)
+	}
+	return parsed, nil
+}
+
+func parseUint32(field, value string) (uint32, error) {
+	parsed, err := strconv.ParseUint(value, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q: expected an unsigned 32-bit integer", field, value)
+	}
+	return uint32(parsed), nil
+}
+
+func parsePositiveUint32(field, value string) (uint32, error) {
+	parsed, err := parseUint32(field, value)
+	if err != nil {
+		return 0, err
+	}
+	if parsed == 0 {
+		return 0, fmt.Errorf("invalid %s %q: expected a positive integer", field, value)
+	}
+	return parsed, nil
+}
+
+func parseBool(field, value string) (bool, error) {
+	switch value {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid %s %q: expected true or false", field, value)
+	}
+}
+
+func parseEnum(field, value string, allowed ...string) (string, error) {
+	for _, candidate := range allowed {
+		if value == candidate {
+			return value, nil
+		}
+	}
+	return "", fmt.Errorf("invalid %s %q: expected %s", field, value, strings.Join(allowed, " or "))
+}
+
+func setLedgerSelector(params map[string]any, value string) error {
+	selection, err := ledgerselector.Parse(value)
+	if err != nil {
+		return fmt.Errorf("invalid ledger selector %q: %w", value, err)
+	}
+	if selection.Kind() == ledgerselector.KindHash {
+		params["ledger_hash"] = selection.String()
+	} else {
+		params["ledger_index"] = selection.String()
+	}
+	return nil
+}
+
+func setOptionalLedger(params map[string]any, args []string, i int) error {
+	if len(args) <= i {
+		return nil
+	}
+	return setLedgerSelector(params, args[i])
+}
+
+func warnPositionalSecret(cmd *cobra.Command) {
+	fmt.Fprintln(
+		cmd.ErrOrStderr(),
+		"Warning: positional secrets are deprecated; use --secret-prompt, --secret-file, or --secret-stdin",
+	)
+}
+
+func setOfflineOption(params map[string]any, command, value string) error {
+	if _, err := parseEnum(command+" option", value, "offline"); err != nil {
+		return err
+	}
+	params["offline"] = true
+	return nil
+}
+
+func submitParams(cmd *cobra.Command, args []string, secret string, provided bool) (any, error) {
+	if provided {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("submit with a secret source requires exactly one tx_json argument")
+		}
+		txJSON, err := parseJSONObject("tx_json", args[0])
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"secret": secret, "tx_json": txJSON}, nil
+	}
+	if len(args) == 1 {
+		return map[string]any{"tx_blob": args[0]}, nil
+	}
+	warnPositionalSecret(cmd)
+	txJSON, err := parseJSONObject("tx_json", args[1])
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"secret": args[0], "tx_json": txJSON}, nil
+}
+
+func signParams(cmd *cobra.Command, args []string, secret string, provided bool) (any, error) {
+	txIndex := 0
+	offlineIndex := 1
+	if !provided {
+		if len(args) < 2 {
+			return nil, fmt.Errorf("sign requires a secret source or the deprecated positional secret")
+		}
+		warnPositionalSecret(cmd)
+		secret = args[0]
+		txIndex = 1
+		offlineIndex = 2
+	}
+	if provided && len(args) > 2 || !provided && len(args) > 3 {
+		return nil, fmt.Errorf("invalid number of arguments for sign")
+	}
+	txJSON, err := parseJSONObject("tx_json", args[txIndex])
+	if err != nil {
+		return nil, err
+	}
+	params := map[string]any{"secret": secret, "tx_json": txJSON}
+	if len(args) > offlineIndex {
+		if err := setOfflineOption(params, "sign", args[offlineIndex]); err != nil {
+			return nil, err
+		}
+	}
+	return params, nil
+}
+
+func signForParams(cmd *cobra.Command, args []string, secret string, provided bool) (any, error) {
+	txIndex := 1
+	offlineIndex := 2
+	if !provided {
+		if len(args) < 3 {
+			return nil, fmt.Errorf("sign_for requires a secret source or the deprecated positional secret")
+		}
+		warnPositionalSecret(cmd)
+		secret = args[1]
+		txIndex = 2
+		offlineIndex = 3
+	}
+	if provided && len(args) > 3 || !provided && len(args) > 4 {
+		return nil, fmt.Errorf("invalid number of arguments for sign_for")
+	}
+	txJSON, err := parseJSONObject("tx_json", args[txIndex])
+	if err != nil {
+		return nil, err
+	}
+	params := map[string]any{
+		"account": args[0],
+		"secret":  secret,
+		"tx_json": txJSON,
+	}
+	if len(args) > offlineIndex {
+		if err := setOfflineOption(params, "sign_for", args[offlineIndex]); err != nil {
+			return nil, err
+		}
+	}
+	return params, nil
+}
+
+func channelAuthorizeParams(
+	cmd *cobra.Command,
+	args []string,
+	secret string,
+	provided bool,
+) (any, error) {
+	channelIndex := 0
+	amountIndex := 1
+	if !provided {
+		if len(args) != 3 {
+			return nil, fmt.Errorf("channel_authorize requires a secret source or the deprecated positional secret")
+		}
+		warnPositionalSecret(cmd)
+		secret = args[0]
+		channelIndex = 1
+		amountIndex = 2
+	} else if len(args) != 2 {
+		return nil, fmt.Errorf("channel_authorize with a secret source requires channel_id and drops")
+	}
+	amount, err := strconv.ParseUint(args[amountIndex], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid amount: %w", err)
+	}
+	return map[string]any{
+		"secret":     secret,
+		"channel_id": args[channelIndex],
+		"amount":     strconv.FormatUint(amount, 10),
+	}, nil
+}
+
+func walletProposeParams(
+	cmd *cobra.Command,
+	args []string,
+	secret string,
+	provided bool,
+) (any, error) {
+	if provided {
+		if len(args) != 0 {
+			return nil, fmt.Errorf("wallet_propose does not accept a positional passphrase with a secret source")
+		}
+		return map[string]any{"passphrase": secret}, nil
+	}
+	if len(args) == 0 {
+		return nil, nil
+	}
+	warnPositionalSecret(cmd)
+	return map[string]any{"passphrase": args[0]}, nil
+}
+
+func validationCreateParams(
+	cmd *cobra.Command,
+	args []string,
+	secret string,
+	provided bool,
+) (any, error) {
+	if provided {
+		if len(args) != 0 {
+			return nil, fmt.Errorf("validation_create does not accept a positional secret with a secret source")
+		}
+		return map[string]any{"secret": secret}, nil
+	}
+	if len(args) == 0 {
+		return nil, nil
+	}
+	warnPositionalSecret(cmd)
+	return map[string]any{"secret": args[0]}, nil
 }
 
 var rpcCommandSpecs = []rpcCommandSpec{
 	{use: "ping", short: "Ping the server"},
-	{
-		use:   "server_info [counters]",
-		short: "Get server information",
-		params: func(args []string) (any, error) {
-			if len(args) > 0 && args[0] == "counters" {
-				return map[string]any{"counters": true}, nil
-			}
-			return nil, nil
-		},
-	},
-	{
-		use:   "server_state [counters]",
-		short: "Get server state",
-		params: func(args []string) (any, error) {
-			if len(args) > 0 && args[0] == "counters" {
-				return map[string]any{"counters": true}, nil
-			}
-			return nil, nil
-		},
-	},
+	{use: "server_info", short: "Get server information"},
+	{use: "server_state", short: "Get server state"},
 	{use: "random", short: "Generate a random number"},
 	{
 		use:   "server_definitions [hash]",
 		short: "Get server field and type definitions",
+		args:  cobra.RangeArgs(0, 1),
 		params: func(args []string) (any, error) {
 			if len(args) > 0 {
 				return map[string]any{"hash": args[0]}, nil
@@ -254,13 +644,18 @@ var rpcCommandSpecs = []rpcCommandSpec{
 	{
 		use:   "feature [feature_name] [accept|reject]",
 		short: "Get or set amendment/feature status",
+		args:  cobra.RangeArgs(0, 2),
 		params: func(args []string) (any, error) {
 			if len(args) == 0 {
 				return nil, nil
 			}
 			params := map[string]any{"feature": args[0]}
 			if len(args) > 1 {
-				params["vote"] = args[1]
+				vote, err := parseEnum("feature vote", args[1], "accept", "reject")
+				if err != nil {
+					return nil, err
+				}
+				params["vetoed"] = vote == "reject"
 			}
 			return params, nil
 		},
@@ -270,101 +665,124 @@ var rpcCommandSpecs = []rpcCommandSpec{
 	{
 		use:   "account_info <account> [ledger]",
 		short: "Get account information",
-		args:  cobra.MinimumNArgs(1),
+		args:  cobra.RangeArgs(1, 2),
 		params: func(args []string) (any, error) {
 			params := map[string]any{"account": args[0]}
-			optionalLedger(params, args, 1)
+			if err := setOptionalLedger(params, args, 1); err != nil {
+				return nil, err
+			}
 			return params, nil
 		},
 	},
 	{
 		use:   "account_channels <account> [destination_account] [ledger]",
 		short: "Get account payment channels",
-		args:  cobra.MinimumNArgs(1),
+		args:  cobra.RangeArgs(1, 3),
 		params: func(args []string) (any, error) {
 			params := map[string]any{"account": args[0]}
 			if len(args) > 1 && args[1] != "" {
 				params["destination_account"] = args[1]
 			}
-			optionalLedger(params, args, 2)
+			if err := setOptionalLedger(params, args, 2); err != nil {
+				return nil, err
+			}
 			return params, nil
 		},
 	},
 	{
 		use:   "account_currencies <account> [ledger]",
 		short: "Get currencies an account can send or receive",
-		args:  cobra.MinimumNArgs(1),
+		args:  cobra.RangeArgs(1, 2),
 		params: func(args []string) (any, error) {
 			params := map[string]any{"account": args[0]}
-			optionalLedger(params, args, 1)
+			if err := setOptionalLedger(params, args, 1); err != nil {
+				return nil, err
+			}
 			return params, nil
 		},
 	},
 	{
 		use:   "account_lines <account> [peer] [ledger]",
 		short: "Get account trust lines",
-		args:  cobra.MinimumNArgs(1),
+		args:  cobra.RangeArgs(1, 3),
 		params: func(args []string) (any, error) {
 			params := map[string]any{"account": args[0]}
 			if len(args) > 1 && args[1] != "" {
 				params["peer"] = args[1]
 			}
-			optionalLedger(params, args, 2)
+			if err := setOptionalLedger(params, args, 2); err != nil {
+				return nil, err
+			}
 			return params, nil
 		},
 	},
 	{
 		use:   "account_nfts <account> [ledger]",
 		short: "Get NFTs owned by an account",
-		args:  cobra.MinimumNArgs(1),
+		args:  cobra.RangeArgs(1, 2),
 		params: func(args []string) (any, error) {
 			params := map[string]any{"account": args[0]}
-			optionalLedger(params, args, 1)
+			if err := setOptionalLedger(params, args, 1); err != nil {
+				return nil, err
+			}
 			return params, nil
 		},
 	},
 	{
 		use:   "account_objects <account> [ledger]",
 		short: "Get objects owned by an account",
-		args:  cobra.MinimumNArgs(1),
+		args:  cobra.RangeArgs(1, 2),
 		params: func(args []string) (any, error) {
 			params := map[string]any{"account": args[0]}
-			optionalLedger(params, args, 1)
+			if err := setOptionalLedger(params, args, 1); err != nil {
+				return nil, err
+			}
 			return params, nil
 		},
 	},
 	{
 		use:   "account_offers <account> [ledger]",
 		short: "Get offers placed by an account",
-		args:  cobra.MinimumNArgs(1),
+		args:  cobra.RangeArgs(1, 2),
 		params: func(args []string) (any, error) {
 			params := map[string]any{"account": args[0]}
-			optionalLedger(params, args, 1)
+			if err := setOptionalLedger(params, args, 1); err != nil {
+				return nil, err
+			}
 			return params, nil
 		},
 	},
 	{
 		use:   "account_tx <account> [ledger_index_min] [ledger_index_max] [limit] [binary]",
 		short: "Get account transaction history",
-		args:  cobra.MinimumNArgs(1),
+		args:  cobra.RangeArgs(1, 5),
 		params: func(args []string) (any, error) {
 			params := map[string]any{"account": args[0]}
 			if len(args) > 1 {
-				if min, err := strconv.Atoi(args[1]); err == nil {
-					params["ledger_index_min"] = min
+				minimum, err := parseLedgerRangeBound("ledger_index_min", args[1])
+				if err != nil {
+					return nil, err
 				}
+				params["ledger_index_min"] = minimum
 			}
 			if len(args) > 2 {
-				if max, err := strconv.Atoi(args[2]); err == nil {
-					params["ledger_index_max"] = max
+				maximum, err := parseLedgerRangeBound("ledger_index_max", args[2])
+				if err != nil {
+					return nil, err
 				}
+				params["ledger_index_max"] = maximum
 			}
 			if len(args) > 3 {
-				if limit, err := strconv.Atoi(args[3]); err == nil {
-					params["limit"] = limit
+				limit, err := parsePositiveUint32("limit", args[3])
+				if err != nil {
+					return nil, err
 				}
+				params["limit"] = limit
 			}
-			if len(args) > 4 && args[4] == "binary" {
+			if len(args) > 4 {
+				if _, err := parseEnum("output format", args[4], "binary"); err != nil {
+					return nil, err
+				}
 				params["binary"] = true
 			}
 			return params, nil
@@ -373,10 +791,12 @@ var rpcCommandSpecs = []rpcCommandSpec{
 	{
 		use:   "gateway_balances <issuer_account> [ledger] [hotwallet1] [hotwallet2]",
 		short: "Get gateway balances",
-		args:  cobra.MinimumNArgs(1),
+		args:  cobra.RangeArgs(1, 4),
 		params: func(args []string) (any, error) {
 			params := map[string]any{"account": args[0]}
-			optionalLedger(params, args, 1)
+			if err := setOptionalLedger(params, args, 1); err != nil {
+				return nil, err
+			}
 			if len(args) > 2 {
 				params["hotwallet"] = args[2:]
 			}
@@ -384,35 +804,44 @@ var rpcCommandSpecs = []rpcCommandSpec{
 		},
 	},
 	{
-		use:   "noripple_check <account> [ledger]",
+		use:   "noripple_check <account> <gateway|user> [ledger]",
 		short: "Check NoRipple flag settings",
-		args:  cobra.MinimumNArgs(1),
+		args:  cobra.RangeArgs(2, 3),
 		params: func(args []string) (any, error) {
-			params := map[string]any{"account": args[0]}
-			optionalLedger(params, args, 1)
+			role, err := parseEnum("role", args[1], "gateway", "user")
+			if err != nil {
+				return nil, err
+			}
+			params := map[string]any{"account": args[0], "role": role}
+			if err := setOptionalLedger(params, args, 2); err != nil {
+				return nil, err
+			}
 			return params, nil
 		},
 	},
 
 	{
-		use:   "ledger [ledger_identifier] [full]",
+		use:   "ledger [ledger_identifier] [full|tx]",
 		short: "Get ledger information",
+		args:  cobra.RangeArgs(0, 2),
 		params: func(args []string) (any, error) {
 			params := map[string]any{}
 			if len(args) > 0 {
-				switch args[0] {
-				case "current", "closed", "validated":
-					params["ledger_index"] = args[0]
-				default:
-					if _, err := strconv.Atoi(args[0]); err == nil {
-						params["ledger_index"] = args[0]
-					} else {
-						params["ledger_hash"] = args[0]
-					}
+				if err := setLedgerSelector(params, args[0]); err != nil {
+					return nil, err
 				}
 			}
-			if len(args) > 1 && args[1] == "full" {
-				params["full"] = true
+			if len(args) > 1 {
+				option, err := parseEnum("ledger option", args[1], "full", "tx")
+				if err != nil {
+					return nil, err
+				}
+				if option == "full" {
+					params["full"] = true
+				} else {
+					params["transactions"] = true
+					params["expand"] = true
+				}
 			}
 			return params, nil
 		},
@@ -422,15 +851,20 @@ var rpcCommandSpecs = []rpcCommandSpec{
 	{
 		use:   "ledger_data [ledger] [limit] [marker]",
 		short: "Get ledger objects",
+		args:  cobra.RangeArgs(0, 3),
 		params: func(args []string) (any, error) {
 			params := map[string]any{}
 			if len(args) > 0 {
-				params["ledger_index"] = args[0]
+				if err := setLedgerSelector(params, args[0]); err != nil {
+					return nil, err
+				}
 			}
 			if len(args) > 1 {
-				if limit, err := strconv.Atoi(args[1]); err == nil {
-					params["limit"] = limit
+				limit, err := parseUint32("limit", args[1])
+				if err != nil {
+					return nil, err
 				}
+				params["limit"] = limit
 			}
 			if len(args) > 2 {
 				params["marker"] = args[2]
@@ -461,10 +895,9 @@ See rippled's LedgerEntry.cpp for the full list of selectors.`,
 					return nil, fmt.Errorf("invalid argument %q: expected key=value", arg)
 				}
 				switch v {
-				case "true":
-					params[k] = true
-				case "false":
-					params[k] = false
+				case "true", "false":
+					boolean, _ := parseBool(k, v)
+					params[k] = boolean
 				default:
 					if n, err := strconv.Atoi(v); err == nil {
 						params[k] = n
@@ -481,14 +914,26 @@ See rippled's LedgerEntry.cpp for the full list of selectors.`,
 		short: "Get range of ledgers",
 		args:  cobra.ExactArgs(2),
 		params: func(args []string) (any, error) {
-			start, err1 := strconv.Atoi(args[0])
-			end, err2 := strconv.Atoi(args[1])
-			if err1 != nil || err2 != nil {
-				return nil, fmt.Errorf("invalid ledger indices")
+			start, err := parseUint32("start ledger", args[0])
+			if err != nil {
+				return nil, err
+			}
+			stop, err := parseUint32("stop ledger", args[1])
+			if err != nil {
+				return nil, err
+			}
+			if start == 0 || stop == 0 {
+				return nil, fmt.Errorf("start and stop ledgers must be greater than zero")
+			}
+			if start > stop {
+				return nil, fmt.Errorf("start ledger must not be greater than stop ledger")
+			}
+			if stop-start > 1000 {
+				return nil, fmt.Errorf("ledger range must not exceed 1000 ledgers")
 			}
 			return map[string]any{
-				"ledger_index_min": start,
-				"ledger_index_max": end,
+				"start_ledger": start,
+				"stop_ledger":  stop,
 			}, nil
 		},
 	},
@@ -506,171 +951,144 @@ See rippled's LedgerEntry.cpp for the full list of selectors.`,
 		short: "Get transaction history",
 		args:  cobra.ExactArgs(1),
 		params: func(args []string) (any, error) {
-			start, err := strconv.Atoi(args[0])
+			start, err := parseUint32("start index", args[0])
 			if err != nil {
-				return nil, fmt.Errorf("invalid start index")
+				return nil, err
 			}
 			return map[string]any{"start": start}, nil
 		},
 	},
 	{
-		use:   "submit <tx_blob> | <private_key> <tx_json>",
+		use:   "submit <tx_blob|tx_json>",
 		short: "Submit a transaction",
-		args:  cobra.MinimumNArgs(1),
-		params: func(args []string) (any, error) {
-			switch len(args) {
-			case 1:
-				return map[string]any{"tx_blob": args[0]}, nil
-			case 2:
-				return map[string]any{"secret": args[0], "tx_json": args[1]}, nil
-			default:
-				return nil, fmt.Errorf("invalid number of arguments")
-			}
-		},
+		long: `Submit a signed transaction blob, or submit tx_json with a secret from
+--secret-prompt, --secret-file, or --secret-stdin. Positional secrets are
+deprecated and emit a warning.`,
+		args:             cobra.RangeArgs(1, 2),
+		paramsWithSecret: submitParams,
 	},
 	{
 		use:   "submit_multisigned <tx_json>",
 		short: "Submit a multisigned transaction",
 		args:  cobra.ExactArgs(1),
 		params: func(args []string) (any, error) {
-			return map[string]any{"tx_json": args[0]}, nil
+			txJSON, err := parseJSONObject("tx_json", args[0])
+			if err != nil {
+				return nil, err
+			}
+			return map[string]any{"tx_json": txJSON}, nil
 		},
 	},
 	{
-		use:   "sign <private_key> <tx_json> [offline]",
+		use:   "sign <tx_json> [offline]",
 		short: "Sign a transaction",
-		args:  cobra.MinimumNArgs(2),
-		params: func(args []string) (any, error) {
-			params := map[string]any{"secret": args[0], "tx_json": args[1]}
-			if len(args) > 2 && args[2] == "offline" {
-				params["offline"] = true
-			}
-			return params, nil
-		},
+		long: `Sign tx_json using --secret-prompt, --secret-file, or --secret-stdin.
+Positional secrets are deprecated and emit a warning.`,
+		args:             cobra.RangeArgs(1, 3),
+		paramsWithSecret: signParams,
 	},
 	{
-		use:   "sign_for <signer_address> <signer_private_key> <tx_json> [offline]",
+		use:   "sign_for <signer_address> <tx_json> [offline]",
 		short: "Sign a transaction for multisigning",
-		args:  cobra.MinimumNArgs(3),
-		params: func(args []string) (any, error) {
-			params := map[string]any{
-				"account": args[0],
-				"secret":  args[1],
-				"tx_json": args[2],
-			}
-			if len(args) > 3 && args[3] == "offline" {
-				params["offline"] = true
-			}
-			return params, nil
-		},
+		long: `Sign tx_json for an account using --secret-prompt, --secret-file, or
+--secret-stdin. Positional secrets are deprecated and emit a warning.`,
+		args:             cobra.RangeArgs(2, 4),
+		paramsWithSecret: signForParams,
 	},
 	{
 		use:   "transaction_entry <tx_hash> <ledger>",
 		short: "Get transaction from a specific ledger",
 		args:  cobra.ExactArgs(2),
 		params: func(args []string) (any, error) {
-			return map[string]any{
-				"tx_hash":      args[0],
-				"ledger_index": args[1],
-			}, nil
+			params := map[string]any{"tx_hash": args[0]}
+			if err := setLedgerSelector(params, args[1]); err != nil {
+				return nil, err
+			}
+			return params, nil
 		},
 	},
 
 	{
-		use:   "book_offers <taker_pays> <taker_gets> [taker] [ledger] [limit] [proof] [marker]",
+		use:   "book_offers <taker_pays> <taker_gets> [taker] [ledger] [limit]",
 		short: "Get order book offers",
-		args:  cobra.MinimumNArgs(2),
+		args:  cobra.RangeArgs(2, 5),
 		params: func(args []string) (any, error) {
+			takerPays, err := parseJSONObject("taker_pays", args[0])
+			if err != nil {
+				return nil, err
+			}
+			takerGets, err := parseJSONObject("taker_gets", args[1])
+			if err != nil {
+				return nil, err
+			}
 			params := map[string]any{
-				"taker_pays": args[0],
-				"taker_gets": args[1],
+				"taker_pays": takerPays,
+				"taker_gets": takerGets,
 			}
 			if len(args) > 2 && args[2] != "" {
 				params["taker"] = args[2]
 			}
-			optionalLedger(params, args, 3)
+			if err := setOptionalLedger(params, args, 3); err != nil {
+				return nil, err
+			}
 			if len(args) > 4 {
-				if limit, err := strconv.Atoi(args[4]); err == nil {
-					params["limit"] = limit
+				limit, err := parsePositiveUint32("limit", args[4])
+				if err != nil {
+					return nil, err
 				}
-			}
-			if len(args) > 5 {
-				params["proof"] = args[5] == "true"
-			}
-			if len(args) > 6 {
-				params["marker"] = args[6]
+				params["limit"] = limit
 			}
 			return params, nil
 		},
 	},
 	{
-		use:   "path_find <source_account> <destination_account> <destination_amount>",
-		short: "Find payment paths",
-		args:  cobra.ExactArgs(3),
-		params: func(args []string) (any, error) {
-			return map[string]any{
-				"source_account":      args[0],
-				"destination_account": args[1],
-				"destination_amount":  args[2],
-			}, nil
-		},
-	},
-	{
 		use:   "ripple_path_find <json> [ledger]",
 		short: "Find payment paths (ripple format)",
-		args:  cobra.MinimumNArgs(1),
+		args:  cobra.RangeArgs(1, 2),
 		params: func(args []string) (any, error) {
-			var pathRequest any
-			if err := json.Unmarshal([]byte(args[0]), &pathRequest); err != nil {
-				return nil, fmt.Errorf("invalid JSON: %w", err)
+			pathRequest, err := parseJSONObject("path request", args[0])
+			if err != nil {
+				return nil, err
 			}
 			if len(args) > 1 {
-				if paramsMap, ok := pathRequest.(map[string]any); ok {
-					paramsMap["ledger_index"] = args[1]
-					return paramsMap, nil
+				if err := setLedgerSelector(pathRequest, args[1]); err != nil {
+					return nil, err
 				}
 			}
 			return pathRequest, nil
 		},
 	},
 	{
-		use:   "wallet_propose [passphrase]",
+		use:   "wallet_propose",
 		short: "Generate wallet credentials",
-		params: func(args []string) (any, error) {
-			if len(args) > 0 {
-				return map[string]any{"passphrase": strings.Join(args, " ")}, nil
-			}
-			return nil, nil
-		},
+		long: `Generate random wallet credentials, or supply a passphrase with
+--secret-prompt, --secret-file, or --secret-stdin. Positional passphrases are
+deprecated and emit a warning.`,
+		args:             cobra.RangeArgs(0, 1),
+		paramsWithSecret: walletProposeParams,
 	},
 	{
 		use:   "deposit_authorized <source_account> <destination_account> [ledger]",
 		short: "Check if deposit is authorized",
-		args:  cobra.MinimumNArgs(2),
+		args:  cobra.RangeArgs(2, 3),
 		params: func(args []string) (any, error) {
 			params := map[string]any{
 				"source_account":      args[0],
 				"destination_account": args[1],
 			}
-			optionalLedger(params, args, 2)
+			if err := setOptionalLedger(params, args, 2); err != nil {
+				return nil, err
+			}
 			return params, nil
 		},
 	},
 	{
-		use:   "channel_authorize <private_key> <channel_id> <drops>",
+		use:   "channel_authorize <channel_id> <drops>",
 		short: "Authorize a payment channel claim",
-		args:  cobra.ExactArgs(3),
-		params: func(args []string) (any, error) {
-			amount, err := strconv.ParseUint(args[2], 10, 64)
-			if err != nil {
-				return nil, fmt.Errorf("invalid amount: %w", err)
-			}
-			return map[string]any{
-				"secret":  args[0],
-				"channel": args[1],
-				"amount":  amount,
-			}, nil
-		},
+		long: `Authorize a payment channel claim using --secret-prompt, --secret-file,
+or --secret-stdin. Positional secrets are deprecated and emit a warning.`,
+		args:             cobra.RangeArgs(2, 3),
+		paramsWithSecret: channelAuthorizeParams,
 	},
 	{
 		use:   "channel_verify <public_key> <channel_id> <drops> <signature>",
@@ -683,8 +1101,8 @@ See rippled's LedgerEntry.cpp for the full list of selectors.`,
 			}
 			return map[string]any{
 				"public_key": args[0],
-				"channel":    args[1],
-				"amount":     amount,
+				"channel_id": args[1],
+				"amount":     strconv.FormatUint(amount, 10),
 				"signature":  args[3],
 			}, nil
 		},
@@ -693,62 +1111,37 @@ See rippled's LedgerEntry.cpp for the full list of selectors.`,
 	{
 		use:   "nft_buy_offers <nft_id> [ledger]",
 		short: "Get buy offers for an NFT",
-		args:  cobra.MinimumNArgs(1),
+		args:  cobra.RangeArgs(1, 2),
 		params: func(args []string) (any, error) {
 			params := map[string]any{"nft_id": args[0]}
-			optionalLedger(params, args, 1)
+			if err := setOptionalLedger(params, args, 1); err != nil {
+				return nil, err
+			}
 			return params, nil
 		},
 	},
 	{
 		use:   "nft_sell_offers <nft_id> [ledger]",
 		short: "Get sell offers for an NFT",
-		args:  cobra.MinimumNArgs(1),
+		args:  cobra.RangeArgs(1, 2),
 		params: func(args []string) (any, error) {
 			params := map[string]any{"nft_id": args[0]}
-			optionalLedger(params, args, 1)
-			return params, nil
-		},
-	},
-	{
-		use:   "nft_history <nft_id>",
-		short: "Get NFT transaction history",
-		args:  cobra.ExactArgs(1),
-		params: func(args []string) (any, error) {
-			return map[string]any{"nft_id": args[0]}, nil
-		},
-	},
-	{
-		use:   "nfts_by_issuer <issuer> [ledger]",
-		short: "Get NFTs by issuer",
-		args:  cobra.MinimumNArgs(1),
-		params: func(args []string) (any, error) {
-			params := map[string]any{"issuer": args[0]}
-			optionalLedger(params, args, 1)
-			return params, nil
-		},
-	},
-	{
-		use:   "nft_info <nft_id> [ledger]",
-		short: "Get NFT information",
-		args:  cobra.MinimumNArgs(1),
-		params: func(args []string) (any, error) {
-			params := map[string]any{"nft_id": args[0]}
-			optionalLedger(params, args, 1)
+			if err := setOptionalLedger(params, args, 1); err != nil {
+				return nil, err
+			}
 			return params, nil
 		},
 	},
 
 	{use: "stop", short: "Stop the server gracefully"},
 	{
-		use:   "validation_create [seed|passphrase|key]",
+		use:   "validation_create",
 		short: "Create validation credentials",
-		params: func(args []string) (any, error) {
-			if len(args) > 0 {
-				return map[string]any{"secret": strings.Join(args, " ")}, nil
-			}
-			return nil, nil
-		},
+		long: `Create random validation credentials, or supply a secret with
+--secret-prompt, --secret-file, or --secret-stdin. Positional secrets are
+deprecated and emit a warning.`,
+		args:             cobra.RangeArgs(0, 1),
+		paramsWithSecret: validationCreateParams,
 	},
 	{
 		use:   "manifest <public_key>",
@@ -761,11 +1154,11 @@ See rippled's LedgerEntry.cpp for the full list of selectors.`,
 	{
 		use:   "peer_reservations_add <public_key> [description]",
 		short: "Add peer reservation",
-		args:  cobra.MinimumNArgs(1),
+		args:  cobra.RangeArgs(1, 2),
 		params: func(args []string) (any, error) {
 			params := map[string]any{"public_key": args[0]}
 			if len(args) > 1 {
-				params["description"] = strings.Join(args[1:], " ")
+				params["description"] = args[1]
 			}
 			return params, nil
 		},
@@ -792,9 +1185,9 @@ var jsonCmd = &cobra.Command{
 	Short: "Execute any RPC method with JSON parameters",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var params any
-		if err := json.Unmarshal([]byte(args[1]), &params); err != nil {
-			return fmt.Errorf("invalid JSON parameters: %w", err)
+		params, err := parseJSONObject("parameters", args[1])
+		if err != nil {
+			return err
 		}
 		return runRPC(cmd, args[0], params)
 	},

--- a/internal/cli/rpc_secret.go
+++ b/internal/cli/rpc_secret.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"unicode/utf8"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+const maxRPCSecretBytes = 4096
+
+type rpcSecretPrompt func(io.Reader, io.Writer) ([]byte, error)
+
+type rpcSecretFlags struct {
+	file   string
+	stdin  bool
+	prompt bool
+	ask    rpcSecretPrompt
+}
+
+func bindRPCSecretFlags(cmd *cobra.Command, ask rpcSecretPrompt) *rpcSecretFlags {
+	if ask == nil {
+		ask = promptRPCSecret
+	}
+
+	flags := &rpcSecretFlags{ask: ask}
+	cmd.Flags().BoolVar(&flags.prompt, "secret-prompt", false, "read the secret from a hidden terminal prompt")
+	cmd.Flags().StringVar(&flags.file, "secret-file", "", "read the secret from an owner-only file")
+	cmd.Flags().BoolVar(&flags.stdin, "secret-stdin", false, "read the secret from standard input")
+	cmd.MarkFlagsMutuallyExclusive("secret-prompt", "secret-file", "secret-stdin")
+	return flags
+}
+
+func (f *rpcSecretFlags) resolve(cmd *cobra.Command) (string, bool, error) {
+	fileSelected := f.file != "" || cmd.Flags().Changed("secret-file")
+	selected := 0
+	if f.prompt {
+		selected++
+	}
+	if fileSelected {
+		selected++
+	}
+	if f.stdin {
+		selected++
+	}
+
+	if selected == 0 {
+		return "", false, nil
+	}
+	if selected > 1 {
+		return "", false, fmt.Errorf("only one of --secret-prompt, --secret-file, and --secret-stdin may be used")
+	}
+
+	var (
+		secret string
+		err    error
+	)
+	switch {
+	case f.prompt:
+		var value []byte
+		value, err = f.ask(cmd.InOrStdin(), cmd.ErrOrStderr())
+		defer clear(value)
+		if err == nil {
+			secret, err = readRPCSecretRecord(bytes.NewReader(value))
+		}
+	case fileSelected:
+		if f.file == "" {
+			return "", false, fmt.Errorf("--secret-file requires a path")
+		}
+		secret, err = readRPCSecretFile(f.file)
+	case f.stdin:
+		secret, err = readRPCSecretRecord(cmd.InOrStdin())
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return secret, true, nil
+}
+
+func readRPCSecretFile(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("opening secret file: %w", err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return "", fmt.Errorf("inspecting secret file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("secret file must be a regular file")
+	}
+	if permissions := info.Mode().Perm(); permissions&0o077 != 0 || permissions&0o400 == 0 {
+		return "", fmt.Errorf("secret file must be owner-readable and inaccessible to group and other users (use mode 0600)")
+	}
+
+	secret, err := readRPCSecretRecord(file)
+	if err != nil {
+		return "", fmt.Errorf("reading secret file: %w", err)
+	}
+	return secret, nil
+}
+
+func readRPCSecretRecord(reader io.Reader) (string, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, maxRPCSecretBytes+3))
+	if err != nil {
+		return "", fmt.Errorf("reading secret: %w", err)
+	}
+	defer clear(data)
+
+	if len(data) == maxRPCSecretBytes+3 {
+		return "", fmt.Errorf("secret exceeds the maximum length of %d bytes", maxRPCSecretBytes)
+	}
+
+	record := data
+	if newline := bytes.IndexByte(data, '\n'); newline >= 0 {
+		if newline != len(data)-1 {
+			return "", fmt.Errorf("secret source must contain exactly one record")
+		}
+		record = data[:newline]
+		if len(record) > 0 && record[len(record)-1] == '\r' {
+			record = record[:len(record)-1]
+		}
+	}
+
+	if len(record) == 0 {
+		return "", fmt.Errorf("secret must not be empty")
+	}
+	if bytes.ContainsAny(record, "\r\n") {
+		return "", fmt.Errorf("secret source must contain exactly one record")
+	}
+	if !utf8.Valid(record) {
+		return "", fmt.Errorf("secret must be valid UTF-8")
+	}
+	if len(record) > maxRPCSecretBytes {
+		return "", fmt.Errorf("secret exceeds the maximum length of %d bytes", maxRPCSecretBytes)
+	}
+	return string(record), nil
+}
+
+func promptRPCSecret(in io.Reader, out io.Writer) ([]byte, error) {
+	input, ok := in.(interface{ Fd() uintptr })
+	if !ok || !term.IsTerminal(int(input.Fd())) {
+		return nil, fmt.Errorf("cannot prompt for a secret without a terminal; use --secret-file or --secret-stdin")
+	}
+	if _, err := fmt.Fprint(out, "Secret: "); err != nil {
+		return nil, fmt.Errorf("writing secret prompt: %w", err)
+	}
+
+	value, err := term.ReadPassword(int(input.Fd()))
+	_, newlineErr := fmt.Fprintln(out)
+	if err != nil {
+		clear(value)
+		return nil, fmt.Errorf("reading secret from terminal: %w", err)
+	}
+	if newlineErr != nil {
+		clear(value)
+		return nil, fmt.Errorf("writing secret prompt: %w", newlineErr)
+	}
+	return value, nil
+}

--- a/internal/cli/rpc_secret_test.go
+++ b/internal/cli/rpc_secret_test.go
@@ -1,0 +1,273 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestReadRPCSecretRecord(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "without delimiter", input: "sSecret", want: "sSecret"},
+		{name: "newline", input: "sSecret\n", want: "sSecret"},
+		{name: "CRLF", input: "sSecret\r\n", want: "sSecret"},
+		{name: "spaces preserved", input: "  secret with spaces  \n", want: "  secret with spaces  "},
+		{name: "maximum length", input: strings.Repeat("x", maxRPCSecretBytes), want: strings.Repeat("x", maxRPCSecretBytes)},
+		{name: "empty", wantErr: true},
+		{name: "empty line", input: "\n", wantErr: true},
+		{name: "multiline", input: "first\nsecond", wantErr: true},
+		{name: "bare carriage return", input: "first\rsecond", wantErr: true},
+		{name: "invalid UTF-8", input: string([]byte{0xff}), wantErr: true},
+		{name: "extra empty record", input: "first\n\n", wantErr: true},
+		{name: "oversize", input: strings.Repeat("x", maxRPCSecretBytes+1), wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := readRPCSecretRecord(strings.NewReader(test.input))
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("readRPCSecretRecord() = %q, want error", got)
+				}
+				if strings.Contains(err.Error(), test.input) && test.input != "" {
+					t.Fatalf("error leaks secret input: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readRPCSecretRecord(): %v", err)
+			}
+			if got != test.want {
+				t.Errorf("readRPCSecretRecord() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestReadRPCSecretRecordBoundsReads(t *testing.T) {
+	reader := &countingReader{remaining: maxRPCSecretBytes * 2}
+	if _, err := readRPCSecretRecord(reader); err == nil {
+		t.Fatal("expected oversized secret error")
+	}
+	if reader.read > maxRPCSecretBytes+3 {
+		t.Fatalf("read %d bytes, limit is %d", reader.read, maxRPCSecretBytes+3)
+	}
+}
+
+type countingReader struct {
+	remaining int
+	read      int
+}
+
+func (r *countingReader) Read(buffer []byte) (int, error) {
+	if r.remaining == 0 {
+		return 0, io.EOF
+	}
+	n := min(len(buffer), r.remaining)
+	for i := range n {
+		buffer[i] = 'x'
+	}
+	r.remaining -= n
+	r.read += n
+	return n, nil
+}
+
+func TestReadRPCSecretFilePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(path, []byte("sSecret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readRPCSecretFile(path)
+	if err != nil {
+		t.Fatalf("readRPCSecretFile(0600): %v", err)
+	}
+	if got != "sSecret" {
+		t.Errorf("readRPCSecretFile(0600) = %q, want %q", got, "sSecret")
+	}
+
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readRPCSecretFile(path); err == nil {
+		t.Fatal("readRPCSecretFile(0644) succeeded, want permissions error")
+	}
+}
+
+func TestReadRPCSecretFileRejectsNonRegularFile(t *testing.T) {
+	if _, err := readRPCSecretFile(t.TempDir()); err == nil {
+		t.Fatal("readRPCSecretFile(directory) succeeded")
+	}
+}
+
+func TestRPCSecretFlagsResolveSources(t *testing.T) {
+	t.Run("none", func(t *testing.T) {
+		cmd, flags := newSecretTestCommand(t, nil)
+		secret, provided, err := flags.resolve(cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if provided || secret != "" {
+			t.Fatalf("resolve() = %q, %t, want no source", secret, provided)
+		}
+	})
+
+	t.Run("stdin", func(t *testing.T) {
+		cmd, flags := newSecretTestCommand(t, nil, "--secret-stdin")
+		cmd.SetIn(strings.NewReader("  stdin secret  \r\n"))
+		secret, provided, err := flags.resolve(cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !provided || secret != "  stdin secret  " {
+			t.Fatalf("resolve() = %q, %t", secret, provided)
+		}
+	})
+
+	t.Run("file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "secret")
+		if err := os.WriteFile(path, []byte("file secret\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd, flags := newSecretTestCommand(t, nil, "--secret-file", path)
+		secret, provided, err := flags.resolve(cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !provided || secret != "file secret" {
+			t.Fatalf("resolve() = %q, %t", secret, provided)
+		}
+	})
+
+	t.Run("prompt", func(t *testing.T) {
+		var gotIn io.Reader
+		var gotOut io.Writer
+		ask := func(in io.Reader, out io.Writer) ([]byte, error) {
+			gotIn, gotOut = in, out
+			return []byte("prompt secret"), nil
+		}
+		cmd, flags := newSecretTestCommand(t, ask, "--secret-prompt")
+		in := strings.NewReader("unused")
+		out := &bytes.Buffer{}
+		cmd.SetIn(in)
+		cmd.SetErr(out)
+
+		secret, provided, err := flags.resolve(cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !provided || secret != "prompt secret" {
+			t.Fatalf("resolve() = %q, %t", secret, provided)
+		}
+		if gotIn != in || gotOut != out {
+			t.Fatal("prompt did not receive command input and error streams")
+		}
+	})
+}
+
+func TestRPCSecretFlagsRejectSelectors(t *testing.T) {
+	tests := [][]string{
+		{"--secret-prompt", "--secret-stdin"},
+		{"--secret-prompt", "--secret-file", "path"},
+		{"--secret-file", "path", "--secret-stdin"},
+		{"--secret-prompt", "--secret-file", "path", "--secret-stdin"},
+	}
+
+	for _, args := range tests {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			called := false
+			cmd, flags := newSecretTestCommand(t, func(io.Reader, io.Writer) ([]byte, error) {
+				called = true
+				return []byte("must not be read"), nil
+			}, args...)
+			if _, _, err := flags.resolve(cmd); err == nil {
+				t.Fatal("resolve() succeeded with conflicting selectors")
+			}
+			if called {
+				t.Fatal("prompt called before selector validation")
+			}
+		})
+	}
+}
+
+func TestRPCSecretFlagsRejectEmptyFilePath(t *testing.T) {
+	cmd, flags := newSecretTestCommand(t, nil, "--secret-file=")
+	if _, _, err := flags.resolve(cmd); err == nil {
+		t.Fatal("resolve() succeeded with empty --secret-file")
+	}
+}
+
+func TestRPCSecretSourceErrorsDoNotLeakValues(t *testing.T) {
+	const secret = "do-not-print-this-secret"
+	tests := []struct {
+		name string
+		args []string
+		in   string
+		ask  rpcSecretPrompt
+	}{
+		{name: "stdin multiline", args: []string{"--secret-stdin"}, in: secret + "\nsecond"},
+		{
+			name: "prompt multiline",
+			args: []string{"--secret-prompt"},
+			ask: func(io.Reader, io.Writer) ([]byte, error) {
+				return []byte(secret + "\nsecond"), nil
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd, flags := newSecretTestCommand(t, test.ask, test.args...)
+			cmd.SetIn(strings.NewReader(test.in))
+			_, _, err := flags.resolve(cmd)
+			if err == nil {
+				t.Fatal("resolve() succeeded")
+			}
+			if strings.Contains(err.Error(), secret) {
+				t.Fatalf("error leaks secret: %v", err)
+			}
+		})
+	}
+}
+
+func TestPromptRPCSecretRejectsNonTerminal(t *testing.T) {
+	var output bytes.Buffer
+	value, err := promptRPCSecret(strings.NewReader("visible secret"), &output)
+	if err == nil {
+		t.Fatalf("promptRPCSecret() = %q, want error", value)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("prompt wrote to non-terminal output: %q", output.String())
+	}
+}
+
+func TestRPCSecretPromptError(t *testing.T) {
+	sentinel := errors.New("terminal unavailable")
+	cmd, flags := newSecretTestCommand(t, func(io.Reader, io.Writer) ([]byte, error) {
+		return nil, sentinel
+	}, "--secret-prompt")
+	if _, _, err := flags.resolve(cmd); !errors.Is(err, sentinel) {
+		t.Fatalf("resolve() error = %v, want %v", err, sentinel)
+	}
+}
+
+func newSecretTestCommand(t *testing.T, ask rpcSecretPrompt, args ...string) (*cobra.Command, *rpcSecretFlags) {
+	t.Helper()
+	cmd := &cobra.Command{Use: "test"}
+	flags := bindRPCSecretFlags(cmd, ask)
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("ParseFlags(%q): %v", args, err)
+	}
+	return cmd, flags
+}

--- a/internal/cli/rpc_test.go
+++ b/internal/cli/rpc_test.go
@@ -1,208 +1,976 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/config"
 	"github.com/LeJamon/go-xrpl/internal/cmdexit"
+	rpcserver "github.com/LeJamon/go-xrpl/internal/rpc"
+	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	rpctypes "github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/spf13/cobra"
 )
 
+const successfulRPCResponse = `{"result":{"status":"success"}}`
+
 func specByMethod(t *testing.T, method string) rpcCommandSpec {
 	t.Helper()
-	for _, s := range rpcCommandSpecs {
-		if s.methodName() == method {
-			return s
+	for _, spec := range rpcCommandSpecs {
+		if spec.methodName() == method {
+			return spec
 		}
 	}
 	t.Fatalf("no rpc command spec for method %q", method)
 	return rpcCommandSpec{}
 }
 
-func TestRPCEndpoint(t *testing.T) {
+func TestRPCCommandSpecsAreRegisteredHandlers(t *testing.T) {
+	registry := rpctypes.NewMethodRegistry()
+	handlers.RegisterAll(registry)
+
+	seen := make(map[string]struct{}, len(rpcCommandSpecs))
+	for _, spec := range rpcCommandSpecs {
+		method := spec.methodName()
+		if _, duplicate := seen[method]; duplicate {
+			t.Errorf("duplicate rpc command spec for %q", method)
+		}
+		seen[method] = struct{}{}
+		if _, registered := registry.Get(method); !registered {
+			t.Errorf("rpc command %q has no handler registered by handlers.RegisterAll", method)
+		}
+		if spec.command().Args == nil {
+			t.Errorf("rpc command %q has no positional argument validator", method)
+		}
+	}
+}
+
+func TestRPCUnsupportedFixedCommandsRemainGenericOnly(t *testing.T) {
+	unsupported := map[string]struct{}{
+		"path_find":      {},
+		"nft_history":    {},
+		"nfts_by_issuer": {},
+		"nft_info":       {},
+	}
+	for _, spec := range rpcCommandSpecs {
+		if _, found := unsupported[spec.methodName()]; found {
+			t.Errorf("%q must remain available only through rpc json", spec.methodName())
+		}
+	}
+}
+
+func TestRPCEndpointSelection(t *testing.T) {
 	tests := []struct {
 		name    string
 		ports   map[string]config.PortConfig
 		want    string
-		wantErr bool
+		wantErr string
 	}{
 		{
-			name:  "single http port",
-			ports: map[string]config.PortConfig{"rpc": {IP: "127.0.0.1", Port: 5005, Protocol: "http"}},
+			name:  "IPv4",
+			ports: rpcPorts(config.PortConfig{IP: "127.0.0.1", Port: 5005, Protocol: "http"}),
 			want:  "http://127.0.0.1:5005/",
 		},
 		{
-			name:  "wildcard ip rewritten to loopback",
-			ports: map[string]config.PortConfig{"rpc": {IP: "0.0.0.0", Port: 5005, Protocol: "http"}},
+			name:  "IPv6",
+			ports: rpcPorts(config.PortConfig{IP: "::1", Port: 5005, Protocol: "http"}),
+			want:  "http://[::1]:5005/",
+		},
+		{
+			name:  "hostname",
+			ports: rpcPorts(config.PortConfig{IP: "rpc.example.test", Port: 5005, Protocol: "http"}),
+			want:  "http://rpc.example.test:5005/",
+		},
+		{
+			name:  "empty wildcard",
+			ports: rpcPorts(config.PortConfig{Port: 5005, Protocol: "http"}),
 			want:  "http://127.0.0.1:5005/",
 		},
 		{
-			name: "admin port preferred over plain port",
+			name:  "IPv4 wildcard",
+			ports: rpcPorts(config.PortConfig{IP: "0.0.0.0", Port: 5005, Protocol: "http"}),
+			want:  "http://127.0.0.1:5005/",
+		},
+		{
+			name:  "IPv6 wildcard",
+			ports: rpcPorts(config.PortConfig{IP: "::", Port: 5005, Protocol: "http"}),
+			want:  "http://[::1]:5005/",
+		},
+		{
+			name: "IPv4 admin port preferred",
 			ports: map[string]config.PortConfig{
-				"a_public": {IP: "127.0.0.1", Port: 80, Protocol: "http"},
-				"b_admin":  {IP: "127.0.0.1", Port: 5005, Protocol: "http", Admin: []string{"127.0.0.1"}},
+				"a_public": {IP: "127.0.0.1", Port: 5005, Protocol: "http"},
+				"z_admin":  {IP: "127.0.0.1", Port: 5006, Protocol: "http", Admin: []string{"127.0.0.1"}},
+			},
+			want: "http://127.0.0.1:5006/",
+		},
+		{
+			name: "IPv6 admin port preferred",
+			ports: map[string]config.PortConfig{
+				"a_public": {IP: "::1", Port: 5005, Protocol: "http"},
+				"z_admin":  {IP: "::1", Port: 5006, Protocol: "http", Admin: []string{"::1"}},
+			},
+			want: "http://[::1]:5006/",
+		},
+		{
+			name: "wildcard bind may be admin capable",
+			ports: map[string]config.PortConfig{
+				"a_public": {IP: "127.0.0.1", Port: 5005, Protocol: "http"},
+				"z_admin":  {IP: "0.0.0.0", Port: 5006, Protocol: "http", Admin: []string{"127.0.0.1"}},
+			},
+			want: "http://127.0.0.1:5006/",
+		},
+		{
+			name: "hostname is not inferred to be admin",
+			ports: map[string]config.PortConfig{
+				"a_host":  {IP: "localhost", Port: 5005, Protocol: "http", Admin: []string{"127.0.0.1"}},
+				"z_admin": {IP: "127.0.0.1", Port: 5006, Protocol: "http", Admin: []string{"127.0.0.1"}},
+			},
+			want: "http://127.0.0.1:5006/",
+		},
+		{
+			name: "admin network must contain target",
+			ports: map[string]config.PortConfig{
+				"a_mismatch": {IP: "127.0.0.1", Port: 5005, Protocol: "http", Admin: []string{"192.0.2.0/24"}},
+				"z_public":   {IP: "127.0.0.1", Port: 5006, Protocol: "http"},
 			},
 			want: "http://127.0.0.1:5005/",
 		},
 		{
-			name:    "no http ports",
-			ports:   map[string]config.PortConfig{"peer": {IP: "0.0.0.0", Port: 51235, Protocol: "peer"}},
-			wantErr: true,
+			name: "invalid admin network",
+			ports: map[string]config.PortConfig{
+				"rpc": {IP: "127.0.0.1", Port: 5005, Protocol: "http", Admin: []string{"not-an-ip"}},
+			},
+			wantErr: "invalid admin configuration",
+		},
+		{
+			name: "no HTTP ports",
+			ports: map[string]config.PortConfig{
+				"peer": {IP: "0.0.0.0", Port: 51235, Protocol: "peer"},
+			},
+			wantErr: "no HTTP port configured",
 		},
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := &config.Config{Ports: tc.ports}
-			got, _, err := rpcEndpoint(cfg)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got %q", got)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			endpoint, _, err := rpcEndpoint(&config.Config{Ports: test.ports})
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("rpcEndpoint() error = %v, want error containing %q", err, test.wantErr)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("rpcEndpoint: %v", err)
+				t.Fatalf("rpcEndpoint(): %v", err)
 			}
-			if got != tc.want {
-				t.Errorf("rpcEndpoint = %q, want %q", got, tc.want)
+			if endpoint != test.want {
+				t.Errorf("rpcEndpoint() = %q, want %q", endpoint, test.want)
 			}
 		})
 	}
 }
 
-func TestRPCCommandSpecsParams(t *testing.T) {
-	t.Run("account_tx parses ints and binary", func(t *testing.T) {
-		p, err := specByMethod(t, "account_tx").params([]string{"rAcct", "10", "20", "5", "binary"})
-		if err != nil {
-			t.Fatal(err)
-		}
-		m := p.(map[string]any)
-		if m["account"] != "rAcct" || m["ledger_index_min"] != 10 || m["ledger_index_max"] != 20 || m["limit"] != 5 || m["binary"] != true {
-			t.Errorf("account_tx params = %v", m)
-		}
-	})
+func TestRPCCommandWireEnvelopes(t *testing.T) {
+	hash := strings.Repeat("AB", 32)
+	tests := []struct {
+		name   string
+		method string
+		args   []string
+		want   string
+	}{
+		{
+			name:   "no params are omitted",
+			method: "ping",
+			want:   `{"method":"ping"}`,
+		},
+		{
+			name:   "server definitions hash",
+			method: "server_definitions",
+			args:   []string{"ABCDEF"},
+			want:   `{"method":"server_definitions","params":[{"hash":"ABCDEF"}]}`,
+		},
+		{
+			name:   "account info",
+			method: "account_info",
+			args:   []string{"rAccount", "validated"},
+			want:   `{"method":"account_info","params":[{"account":"rAccount","ledger_index":"validated"}]}`,
+		},
+		{
+			name:   "account channels",
+			method: "account_channels",
+			args:   []string{"rAccount", "rDestination", "closed"},
+			want:   `{"method":"account_channels","params":[{"account":"rAccount","destination_account":"rDestination","ledger_index":"closed"}]}`,
+		},
+		{
+			name:   "account currencies",
+			method: "account_currencies",
+			args:   []string{"rAccount", "current"},
+			want:   `{"method":"account_currencies","params":[{"account":"rAccount","ledger_index":"current"}]}`,
+		},
+		{
+			name:   "account lines",
+			method: "account_lines",
+			args:   []string{"rAccount", "rPeer", "validated"},
+			want:   `{"method":"account_lines","params":[{"account":"rAccount","peer":"rPeer","ledger_index":"validated"}]}`,
+		},
+		{
+			name:   "account NFTs",
+			method: "account_nfts",
+			args:   []string{"rAccount", "closed"},
+			want:   `{"method":"account_nfts","params":[{"account":"rAccount","ledger_index":"closed"}]}`,
+		},
+		{
+			name:   "account objects",
+			method: "account_objects",
+			args:   []string{"rAccount", "validated"},
+			want:   `{"method":"account_objects","params":[{"account":"rAccount","ledger_index":"validated"}]}`,
+		},
+		{
+			name:   "account offers",
+			method: "account_offers",
+			args:   []string{"rAccount", "current"},
+			want:   `{"method":"account_offers","params":[{"account":"rAccount","ledger_index":"current"}]}`,
+		},
+		{
+			name:   "gateway balances",
+			method: "gateway_balances",
+			args:   []string{"rIssuer", "validated", "rHot1", "rHot2"},
+			want:   `{"method":"gateway_balances","params":[{"account":"rIssuer","ledger_index":"validated","hotwallet":["rHot1","rHot2"]}]}`,
+		},
+		{
+			name:   "ledger data",
+			method: "ledger_data",
+			args:   []string{"validated", "25", "MARKER"},
+			want:   `{"method":"ledger_data","params":[{"ledger_index":"validated","limit":25,"marker":"MARKER"}]}`,
+		},
+		{
+			name:   "ledger entry",
+			method: "ledger_entry",
+			args:   []string{"index=ABCDEF", "binary=true"},
+			want:   `{"method":"ledger_entry","params":[{"index":"ABCDEF","binary":true}]}`,
+		},
+		{
+			name:   "transaction lookup",
+			method: "tx",
+			args:   []string{"TXHASH"},
+			want:   `{"method":"tx","params":[{"transaction":"TXHASH"}]}`,
+		},
+		{
+			name:   "transaction history",
+			method: "tx_history",
+			args:   []string{"10"},
+			want:   `{"method":"tx_history","params":[{"start":10}]}`,
+		},
+		{
+			name:   "structured transaction JSON",
+			method: "submit_multisigned",
+			args:   []string{`{"Account":"rAccount","Sequence":7}`},
+			want:   `{"method":"submit_multisigned","params":[{"tx_json":{"Account":"rAccount","Sequence":7}}]}`,
+		},
+		{
+			name:   "structured currency JSON",
+			method: "book_offers",
+			args:   []string{`{"currency":"USD","issuer":"rIssuer"}`, `{"currency":"XRP"}`, "rTaker", "validated", "25"},
+			want:   `{"method":"book_offers","params":[{"taker_pays":{"currency":"USD","issuer":"rIssuer"},"taker_gets":{"currency":"XRP"},"taker":"rTaker","ledger_index":"validated","limit":25}]}`,
+		},
+		{
+			name:   "feature accept vote",
+			method: "feature",
+			args:   []string{"fixAMMv1_1", "accept"},
+			want:   `{"method":"feature","params":[{"feature":"fixAMMv1_1","vetoed":false}]}`,
+		},
+		{
+			name:   "feature reject vote",
+			method: "feature",
+			args:   []string{"fixAMMv1_1", "reject"},
+			want:   `{"method":"feature","params":[{"feature":"fixAMMv1_1","vetoed":true}]}`,
+		},
+		{
+			name:   "noripple role",
+			method: "noripple_check",
+			args:   []string{"rAccount", "gateway", "closed"},
+			want:   `{"method":"noripple_check","params":[{"account":"rAccount","role":"gateway","ledger_index":"closed"}]}`,
+		},
+		{
+			name:   "account transaction uint32 ledger range",
+			method: "account_tx",
+			args:   []string{"rAccount", "0", "4294967295", "1", "binary"},
+			want:   `{"method":"account_tx","params":[{"account":"rAccount","ledger_index_min":0,"ledger_index_max":4294967295,"limit":1,"binary":true}]}`,
+		},
+		{
+			name:   "channel amount remains a string",
+			method: "channel_verify",
+			args:   []string{"EDPublic", "ABC123", "1000000", "Signature"},
+			want:   `{"method":"channel_verify","params":[{"public_key":"EDPublic","channel_id":"ABC123","amount":"1000000","signature":"Signature"}]}`,
+		},
+		{
+			name:   "ledger range uses rippled field names",
+			method: "ledger_range",
+			args:   []string{"10", "20"},
+			want:   `{"method":"ledger_range","params":[{"start_ledger":10,"stop_ledger":20}]}`,
+		},
+		{
+			name:   "numeric ledger selector",
+			method: "ledger",
+			args:   []string{"12345"},
+			want:   `{"method":"ledger","params":[{"ledger_index":"12345"}]}`,
+		},
+		{
+			name:   "ledger transaction expansion",
+			method: "ledger",
+			args:   []string{"validated", "tx"},
+			want:   `{"method":"ledger","params":[{"ledger_index":"validated","transactions":true,"expand":true}]}`,
+		},
+		{
+			name:   "hash ledger selector",
+			method: "transaction_entry",
+			args:   []string{"TXHASH", hash},
+			want:   `{"method":"transaction_entry","params":[{"tx_hash":"TXHASH","ledger_hash":"` + hash + `"}]}`,
+		},
+		{
+			name:   "ripple path find",
+			method: "ripple_path_find",
+			args:   []string{`{"source_account":"rSource","destination_account":"rDestination","destination_amount":"1"}`, "validated"},
+			want:   `{"method":"ripple_path_find","params":[{"source_account":"rSource","destination_account":"rDestination","destination_amount":"1","ledger_index":"validated"}]}`,
+		},
+		{
+			name:   "deposit authorization",
+			method: "deposit_authorized",
+			args:   []string{"rSource", "rDestination", "closed"},
+			want:   `{"method":"deposit_authorized","params":[{"source_account":"rSource","destination_account":"rDestination","ledger_index":"closed"}]}`,
+		},
+		{
+			name:   "NFT buy offers",
+			method: "nft_buy_offers",
+			args:   []string{"NFTID", "validated"},
+			want:   `{"method":"nft_buy_offers","params":[{"nft_id":"NFTID","ledger_index":"validated"}]}`,
+		},
+		{
+			name:   "NFT sell offers",
+			method: "nft_sell_offers",
+			args:   []string{"NFTID", "closed"},
+			want:   `{"method":"nft_sell_offers","params":[{"nft_id":"NFTID","ledger_index":"closed"}]}`,
+		},
+		{
+			name:   "validator manifest",
+			method: "manifest",
+			args:   []string{"PUBLICKEY"},
+			want:   `{"method":"manifest","params":[{"public_key":"PUBLICKEY"}]}`,
+		},
+		{
+			name:   "peer reservation add",
+			method: "peer_reservations_add",
+			args:   []string{"PUBLICKEY", "trusted peer"},
+			want:   `{"method":"peer_reservations_add","params":[{"public_key":"PUBLICKEY","description":"trusted peer"}]}`,
+		},
+		{
+			name:   "peer reservation delete",
+			method: "peer_reservations_del",
+			args:   []string{"PUBLICKEY"},
+			want:   `{"method":"peer_reservations_del","params":[{"public_key":"PUBLICKEY"}]}`,
+		},
+	}
 
-	t.Run("ledger identifier dispatch", func(t *testing.T) {
-		build := specByMethod(t, "ledger").params
-		cur, _ := build([]string{"validated"})
-		if cur.(map[string]any)["ledger_index"] != "validated" {
-			t.Errorf("validated: %v", cur)
+	covered := make(map[string]bool, len(tests))
+	for _, test := range tests {
+		covered[test.method] = true
+		t.Run(test.name, func(t *testing.T) {
+			body, _, err := executeCapturedRPCCommand(t, test.method, test.args, "")
+			if err != nil {
+				t.Fatalf("%s command: %v", test.method, err)
+			}
+			assertJSONEqual(t, body, test.want)
+		})
+	}
+	for _, spec := range rpcCommandSpecs {
+		if spec.params != nil && !covered[spec.methodName()] {
+			t.Errorf("non-trivial RPC command %q has no wire-envelope test", spec.methodName())
 		}
-		num, _ := build([]string{"12345"})
-		if num.(map[string]any)["ledger_index"] != "12345" {
-			t.Errorf("numeric: %v", num)
-		}
-		hash, _ := build([]string{"ABCDEF"})
-		if hash.(map[string]any)["ledger_hash"] != "ABCDEF" {
-			t.Errorf("hash: %v", hash)
-		}
-	})
-
-	t.Run("ledger_entry key=value coercion", func(t *testing.T) {
-		p, err := specByMethod(t, "ledger_entry").params([]string{"index=ABC", "binary=true", "x=7"})
-		if err != nil {
-			t.Fatal(err)
-		}
-		m := p.(map[string]any)
-		if m["index"] != "ABC" || m["binary"] != true || m["x"] != 7 {
-			t.Errorf("ledger_entry params = %v", m)
-		}
-		if _, err := specByMethod(t, "ledger_entry").params([]string{"bogus"}); err == nil {
-			t.Error("expected error for non key=value arg")
-		}
-	})
-
-	t.Run("submit one vs two args", func(t *testing.T) {
-		build := specByMethod(t, "submit").params
-		one, _ := build([]string{"DEADBEEF"})
-		if one.(map[string]any)["tx_blob"] != "DEADBEEF" {
-			t.Errorf("one arg: %v", one)
-		}
-		two, _ := build([]string{"sEd", "{}"})
-		if two.(map[string]any)["secret"] != "sEd" {
-			t.Errorf("two args: %v", two)
-		}
-	})
-
-	t.Run("no-param command has nil builder", func(t *testing.T) {
-		if specByMethod(t, "ping").params != nil {
-			t.Error("ping should have no params builder")
-		}
-	})
+	}
 }
 
-// setTestConfig points the package-global config at addr (host:port) for the
-// duration of a test.
-func setTestConfig(t *testing.T, addr string) {
-	t.Helper()
-	host, portStr, err := net.SplitHostPort(addr)
-	if err != nil {
-		t.Fatalf("split %q: %v", addr, err)
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		t.Fatalf("port %q: %v", portStr, err)
-	}
-	prevCfg, prevErr := globalConfig, globalConfigErr
-	globalConfig = &config.Config{Ports: map[string]config.PortConfig{
-		"rpc": {IP: host, Port: port, Protocol: "http", Admin: []string{"127.0.0.1"}},
-	}}
-	globalConfigErr = nil
-	t.Cleanup(func() { globalConfig, globalConfigErr = prevCfg, prevErr })
-}
-
-func TestRunRPC_Success(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"result":{"status":"success","server_state":"full"}}`))
+func TestRPCCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = io.WriteString(w, successfulRPCResponse)
 	}))
-	defer srv.Close()
-	setTestConfig(t, srv.Listener.Addr().String())
+	defer server.Close()
+	setTestConfig(t, server.Listener.Addr().String())
 
-	var out strings.Builder
-	cmd := &cobra.Command{}
-	cmd.SetOut(&out)
-	if err := runRPC(cmd, "server_info", nil); err != nil {
-		t.Fatalf("runRPC: %v", err)
+	tests := []struct {
+		name   string
+		method string
+		args   []string
+	}{
+		{name: "too few arguments", method: "account_info"},
+		{name: "too many arguments", method: "ping", args: []string{"unexpected"}},
+		{name: "exact arity", method: "ledger_range", args: []string{"10"}},
+		{name: "malformed JSON", method: "submit_multisigned", args: []string{"{"}},
+		{name: "trailing JSON value", method: "submit_multisigned", args: []string{`{} {}`}},
+		{name: "JSON array is not an object", method: "book_offers", args: []string{"[]", `{}`}},
+		{name: "signed integer", method: "account_tx", args: []string{"rAccount", "not-an-integer"}},
+		{name: "zero standard limit", method: "account_tx", args: []string{"rAccount", "0", "1", "0"}},
+		{name: "unsigned integer", method: "ledger_range", args: []string{"-1", "20"}},
+		{name: "zero ledger range", method: "ledger_range", args: []string{"0", "20"}},
+		{name: "reversed ledger range", method: "ledger_range", args: []string{"20", "10"}},
+		{name: "oversized ledger range", method: "ledger_range", args: []string{"1", "1002"}},
+		{name: "enum", method: "feature", args: []string{"fixAMMv1_1", "abstain"}},
+		{name: "role enum", method: "noripple_check", args: []string{"rAccount", "issuer"}},
+		{name: "ledger selector", method: "ledger", args: []string{"latest"}},
+		{name: "channel amount", method: "channel_verify", args: []string{"key", "channel", "drops", "signature"}},
 	}
-	if !strings.Contains(out.String(), "server_state") {
-		t.Errorf("output missing result fields: %q", out.String())
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			before := requests.Load()
+			_, _, err := executeRPCCommand(t, specByMethod(t, test.method).command(), test.args, "")
+			if err == nil {
+				t.Fatalf("%s command succeeded with args %q", test.method, test.args)
+			}
+			if got := requests.Load(); got != before {
+				t.Fatalf("server received %d request(s) after local validation failed", got-before)
+			}
+		})
+	}
+
+	t.Run("generic JSON", func(t *testing.T) {
+		before := requests.Load()
+		if err := jsonCmd.RunE(jsonCmd, []string{"server_info", "{"}); err == nil {
+			t.Fatal("json command accepted malformed JSON")
+		}
+		if got := requests.Load(); got != before {
+			t.Fatalf("server received %d request(s) after local JSON validation failed", got-before)
+		}
+	})
+}
+
+func TestRunRPCAuthentication(t *testing.T) {
+	t.Run("admin credentials are request params, not Basic Auth", func(t *testing.T) {
+		var body []byte
+		var authorization string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+			body, _ = io.ReadAll(request.Body)
+			authorization = request.Header.Get("Authorization")
+			_, _ = io.WriteString(w, successfulRPCResponse)
+		}))
+		defer server.Close()
+		port := testPort(t, server.Listener.Addr().String())
+		port.AdminUser = "admin"
+		port.AdminPassword = "secret"
+		setTestRPCPorts(t, rpcPorts(port))
+
+		if err := runRPC(newRPCCommand(), "stop", nil); err != nil {
+			t.Fatalf("runRPC(): %v", err)
+		}
+		assertJSONEqual(
+			t,
+			body,
+			`{"method":"stop","params":[{"admin_user":"admin","admin_password":"secret"}]}`,
+		)
+		if authorization != "" {
+			t.Fatalf("admin credentials sent as HTTP Authorization: %q", authorization)
+		}
+	})
+
+	t.Run("ordinary credentials use Basic Auth", func(t *testing.T) {
+		var gotUser, gotPassword string
+		var gotAuth bool
+		var body []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+			gotUser, gotPassword, gotAuth = request.BasicAuth()
+			body, _ = io.ReadAll(request.Body)
+			_, _ = io.WriteString(w, successfulRPCResponse)
+		}))
+		defer server.Close()
+		port := testPort(t, server.Listener.Addr().String())
+		port.User = "http-user"
+		port.Password = "http-password"
+		setTestRPCPorts(t, rpcPorts(port))
+
+		if err := runRPC(newRPCCommand(), "ping", nil); err != nil {
+			t.Fatalf("runRPC(): %v", err)
+		}
+		if !gotAuth || gotUser != "http-user" || gotPassword != "http-password" {
+			t.Fatalf("BasicAuth() = %q, %q, %t", gotUser, gotPassword, gotAuth)
+		}
+		assertJSONEqual(t, body, `{"method":"ping"}`)
+	})
+}
+
+func TestRunRPCRejectsCleartextCredentialsToNonLoopback(t *testing.T) {
+	setTestRPCPorts(t, rpcPorts(config.PortConfig{
+		IP:       "rpc.example.test",
+		Port:     5005,
+		Protocol: "http",
+		User:     "http-user",
+		Password: "http-password",
+	}))
+
+	var requests atomic.Int32
+	setTestRPCClient(t, &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return rpcHTTPResponse(http.StatusOK, successfulRPCResponse), nil
+	})})
+
+	err := runRPC(newRPCCommand(), "ping", nil)
+	if err == nil || !strings.Contains(err.Error(), "refusing to send RPC credentials over cleartext HTTP") {
+		t.Fatalf("runRPC() error = %v, want cleartext credential refusal", err)
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("transport received %d requests despite refusal", requests.Load())
+	}
+
+	command := newRPCCommand()
+	command.Flags().Bool(insecureRPCFlag, false, "")
+	if err := command.Flags().Set(insecureRPCFlag, "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runRPC(command, "ping", nil); err != nil {
+		t.Fatalf("runRPC() with --%s: %v", insecureRPCFlag, err)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("transport received %d requests, want 1", requests.Load())
 	}
 }
 
-func TestRunRPC_ErrorStatus(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"result":{"status":"error","error":"actNotFound","error_message":"Account not found."}}`))
+func TestRunRPCDoesNotFollowRedirects(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	redirected := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectedRequests.Add(1)
+		_, _ = io.WriteString(w, successfulRPCResponse)
 	}))
-	defer srv.Close()
-	setTestConfig(t, srv.Listener.Addr().String())
+	defer redirected.Close()
 
-	var out strings.Builder
-	cmd := &cobra.Command{}
-	cmd.SetOut(&out)
-	err := runRPC(cmd, "account_info", map[string]any{"account": "rBad"})
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		http.Redirect(w, request, redirected.URL, http.StatusTemporaryRedirect)
+	}))
+	defer redirector.Close()
+	setTestConfig(t, redirector.Listener.Addr().String())
+
+	err := runRPC(newRPCCommand(), "ping", nil)
+	if err == nil || !strings.Contains(err.Error(), "HTTP 307 Temporary Redirect") {
+		t.Fatalf("runRPC() error = %v, want redirect status error", err)
+	}
+	if redirectedRequests.Load() != 0 {
+		t.Fatalf("redirect target received %d requests", redirectedRequests.Load())
+	}
+}
+
+func TestRunRPCRejectsNonSuccessfulHTTPStatus(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "request failed", status)
+			}))
+			defer server.Close()
+			setTestConfig(t, server.Listener.Addr().String())
+
+			err := runRPC(newRPCCommand(), "server_info", nil)
+			want := "HTTP " + strconv.Itoa(status) + " " + http.StatusText(status)
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Fatalf("runRPC() error = %v, want containing %q", err, want)
+			}
+		})
+	}
+}
+
+func TestPrintRPCResultRejectsInvalidEnvelopes(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "malformed JSON", body: `{`, want: "malformed JSON"},
+		{name: "non-object envelope", body: `[]`, want: "malformed JSON"},
+		{name: "null envelope", body: `null`, want: "malformed JSON"},
+		{name: "missing result", body: `{}`, want: "missing a result object"},
+		{name: "null result", body: `{"result":null}`, want: "missing a result object"},
+		{name: "string result", body: `{"result":"success"}`, want: "invalid result"},
+		{name: "array result", body: `{"result":[]}`, want: "invalid result"},
+		{name: "missing status", body: `{"result":{}}`, want: "invalid result status"},
+		{name: "non-string status", body: `{"result":{"status":true}}`, want: "invalid result status"},
+		{name: "unknown status", body: `{"result":{"status":"pending"}}`, want: "invalid result status"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var output strings.Builder
+			err := printRPCResult(&output, "test_method", []byte(test.body))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("printRPCResult() error = %v, want containing %q", err, test.want)
+			}
+			if output.Len() != 0 {
+				t.Fatalf("invalid response produced output %q", output.String())
+			}
+		})
+	}
+}
+
+func TestPrintRPCResultReportsXrplError(t *testing.T) {
+	body := []byte(`{"result":{"status":"error","error":"actNotFound","error_message":"Account not found."}}`)
+	var output strings.Builder
+	err := printRPCResult(&output, "account_info", body)
 	if !errors.Is(err, cmdexit.ErrReported) {
-		t.Fatalf("expected cmdexit.ErrReported, got %v", err)
+		t.Fatalf("printRPCResult() error = %v, want cmdexit.ErrReported", err)
 	}
-	if !strings.Contains(out.String(), "actNotFound") {
-		t.Errorf("error detail not printed: %q", out.String())
+	if !strings.Contains(output.String(), "actNotFound") || !strings.Contains(output.String(), "Account not found.") {
+		t.Fatalf("printed XRPL error is incomplete: %q", output.String())
 	}
 }
 
-func TestRunRPC_NoConfig(t *testing.T) {
-	prevCfg, prevErr := globalConfig, globalConfigErr
-	globalConfig, globalConfigErr = nil, nil
-	t.Cleanup(func() { globalConfig, globalConfigErr = prevCfg, prevErr })
+func TestReadLimitedRPCBodyBoundsReads(t *testing.T) {
+	reader := &boundedCountingReader{remaining: 100}
+	if _, err := readLimitedRPCBody(reader, 8); err == nil {
+		t.Fatal("readLimitedRPCBody() accepted an oversized response")
+	}
+	if reader.read > 9 {
+		t.Fatalf("readLimitedRPCBody() read %d bytes, limit is 9", reader.read)
+	}
+}
 
-	cmd := &cobra.Command{}
-	cmd.SetOut(&strings.Builder{})
-	if err := runRPC(cmd, "ping", nil); err == nil {
-		t.Fatal("expected error when no config is loaded")
+func TestRPCSecretCommandWireEnvelopes(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		args   []string
+		want   string
+	}{
+		{
+			name:   "submit",
+			method: "submit",
+			args:   []string{"--secret-stdin", `{"Account":"rAccount","Sequence":1}`},
+			want:   `{"method":"submit","params":[{"secret":"source-secret","tx_json":{"Account":"rAccount","Sequence":1}}]}`,
+		},
+		{
+			name:   "sign",
+			method: "sign",
+			args:   []string{"--secret-stdin", `{"Account":"rAccount"}`, "offline"},
+			want:   `{"method":"sign","params":[{"secret":"source-secret","tx_json":{"Account":"rAccount"},"offline":true}]}`,
+		},
+		{
+			name:   "sign_for",
+			method: "sign_for",
+			args:   []string{"--secret-stdin", "rSigner", `{"Account":"rAccount"}`, "offline"},
+			want:   `{"method":"sign_for","params":[{"account":"rSigner","secret":"source-secret","tx_json":{"Account":"rAccount"},"offline":true}]}`,
+		},
+		{
+			name:   "channel_authorize",
+			method: "channel_authorize",
+			args:   []string{"--secret-stdin", "ABC123", "1000000"},
+			want:   `{"method":"channel_authorize","params":[{"secret":"source-secret","channel_id":"ABC123","amount":"1000000"}]}`,
+		},
+		{
+			name:   "wallet_propose",
+			method: "wallet_propose",
+			args:   []string{"--secret-stdin"},
+			want:   `{"method":"wallet_propose","params":[{"passphrase":"source-secret"}]}`,
+		},
+		{
+			name:   "validation_create",
+			method: "validation_create",
+			args:   []string{"--secret-stdin"},
+			want:   `{"method":"validation_create","params":[{"secret":"source-secret"}]}`,
+		},
+	}
+
+	covered := make(map[string]bool, len(tests))
+	for _, test := range tests {
+		covered[test.method] = true
+		t.Run(test.name, func(t *testing.T) {
+			body, stderr, err := executeCapturedRPCCommand(t, test.method, test.args, "source-secret\n")
+			if err != nil {
+				t.Fatalf("%s command: %v", test.method, err)
+			}
+			assertJSONEqual(t, body, test.want)
+			if strings.Contains(stderr, "source-secret") {
+				t.Fatalf("stderr leaks secret: %q", stderr)
+			}
+		})
+	}
+	for _, spec := range rpcCommandSpecs {
+		if spec.paramsWithSecret != nil && !covered[spec.methodName()] {
+			t.Errorf("secret-backed RPC command %q has no wire-envelope test", spec.methodName())
+		}
+	}
+}
+
+func TestRPCDeprecatedPositionalSecretWarningDoesNotLeak(t *testing.T) {
+	const secret = "deprecated-positional-secret"
+	body, stderr, err := executeCapturedRPCCommand(
+		t,
+		"sign",
+		[]string{secret, `{"Account":"rAccount"}`},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("sign command: %v", err)
+	}
+	assertJSONEqual(
+		t,
+		body,
+		`{"method":"sign","params":[{"secret":"`+secret+`","tx_json":{"Account":"rAccount"}}]}`,
+	)
+	if !strings.Contains(stderr, "positional secrets are deprecated") {
+		t.Fatalf("missing deprecation warning: %q", stderr)
+	}
+	if strings.Contains(stderr, secret) {
+		t.Fatalf("deprecation warning leaks secret: %q", stderr)
+	}
+}
+
+func TestRPCSecretCommandsDoNotAdvertisePositionalSecrets(t *testing.T) {
+	var found int
+	for _, spec := range rpcCommandSpecs {
+		if spec.paramsWithSecret == nil {
+			continue
+		}
+		found++
+		use := strings.ToLower(spec.use)
+		if strings.Contains(use, "<secret") || strings.Contains(use, "[secret") ||
+			strings.Contains(use, "<passphrase") || strings.Contains(use, "[passphrase") {
+			t.Errorf("%s advertises a positional secret in Use: %q", spec.methodName(), spec.use)
+		}
+		command := spec.command()
+		for _, name := range []string{"secret-prompt", "secret-file", "secret-stdin"} {
+			if command.Flags().Lookup(name) == nil {
+				t.Errorf("%s does not expose --%s", spec.methodName(), name)
+			}
+		}
+	}
+	if found == 0 {
+		t.Fatal("no secret-backed RPC commands found")
+	}
+}
+
+func TestRPCStopUsesAdminCredentialsWithRPCServer(t *testing.T) {
+	tests := []struct {
+		name          string
+		adminUser     string
+		adminPassword string
+	}{
+		{name: "admin network without credentials"},
+		{name: "configured credentials", adminUser: "admin", adminPassword: "secret"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			shutdown := make(chan struct{}, 1)
+			services := &rpctypes.ServiceContainer{
+				ShutdownFunc: func() {
+					shutdown <- struct{}{}
+				},
+			}
+			server := rpcserver.NewServer(time.Second, services)
+			_, adminNet, err := net.ParseCIDR("127.0.0.0/8")
+			if err != nil {
+				t.Fatal(err)
+			}
+			httpServer := httptest.NewServer(rpcserver.PortMiddleware(
+				&rpcserver.PortContext{
+					PortName:      "rpc",
+					AdminNets:     []net.IPNet{*adminNet},
+					AdminUser:     test.adminUser,
+					AdminPassword: test.adminPassword,
+				},
+				nil,
+				server,
+			))
+			defer httpServer.Close()
+
+			port := testPort(t, httpServer.Listener.Addr().String())
+			port.Admin = []string{"127.0.0.1"}
+			port.AdminUser = test.adminUser
+			port.AdminPassword = test.adminPassword
+			setTestRPCPorts(t, rpcPorts(port))
+
+			var output strings.Builder
+			command := newRPCCommand()
+			command.SetOut(&output)
+			if err := runRPC(command, "stop", nil); err != nil {
+				t.Fatalf("runRPC(stop): %v", err)
+			}
+			select {
+			case <-shutdown:
+			case <-time.After(time.Second):
+				t.Fatal("stop RPC did not invoke the server shutdown hook")
+			}
+			if !strings.Contains(output.String(), "ripple server stopping") {
+				t.Fatalf("stop output = %q", output.String())
+			}
+		})
+	}
+}
+
+func TestRunRPCNoConfig(t *testing.T) {
+	previousConfig, previousError := globalConfig, globalConfigErr
+	globalConfig, globalConfigErr = nil, nil
+	t.Cleanup(func() {
+		globalConfig, globalConfigErr = previousConfig, previousError
+	})
+
+	if err := runRPC(newRPCCommand(), "ping", nil); err == nil {
+		t.Fatal("runRPC() succeeded without a loaded config")
+	}
+}
+
+func executeCapturedRPCCommand(
+	t *testing.T,
+	method string,
+	args []string,
+	input string,
+) ([]byte, string, error) {
+	t.Helper()
+	var body []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		body, _ = io.ReadAll(request.Body)
+		_, _ = io.WriteString(w, successfulRPCResponse)
+	}))
+	t.Cleanup(server.Close)
+	setTestConfig(t, server.Listener.Addr().String())
+
+	_, stderr, err := executeRPCCommand(t, specByMethod(t, method).command(), args, input)
+	return body, stderr, err
+}
+
+func executeRPCCommand(
+	t *testing.T,
+	command *cobra.Command,
+	args []string,
+	input string,
+) (string, string, error) {
+	t.Helper()
+	var stdout, stderr strings.Builder
+	command.SetIn(strings.NewReader(input))
+	command.SetOut(&stdout)
+	command.SetErr(&stderr)
+	if err := command.ParseFlags(args); err != nil {
+		return stdout.String(), stderr.String(), err
+	}
+	positional := command.Flags().Args()
+	if err := command.ValidateArgs(positional); err != nil {
+		return stdout.String(), stderr.String(), err
+	}
+	err := command.RunE(command, positional)
+	return stdout.String(), stderr.String(), err
+}
+
+func assertJSONEqual(t *testing.T, got []byte, want string) {
+	t.Helper()
+	decode := func(data []byte) any {
+		t.Helper()
+		decoder := json.NewDecoder(bytes.NewReader(data))
+		decoder.UseNumber()
+		var value any
+		if err := decoder.Decode(&value); err != nil {
+			t.Fatalf("decode JSON %q: %v", data, err)
+		}
+		if err := decoder.Decode(&struct{}{}); err != io.EOF {
+			t.Fatalf("JSON %q has trailing data", data)
+		}
+		return value
+	}
+	gotValue := decode(got)
+	wantValue := decode([]byte(want))
+	if !reflect.DeepEqual(gotValue, wantValue) {
+		t.Errorf("JSON mismatch\ngot:  %s\nwant: %s", got, want)
+	}
+}
+
+func rpcPorts(port config.PortConfig) map[string]config.PortConfig {
+	return map[string]config.PortConfig{"rpc": port}
+}
+
+func setTestConfig(t *testing.T, address string) {
+	t.Helper()
+	setTestRPCPorts(t, rpcPorts(testPort(t, address)))
+}
+
+func testPort(t *testing.T, address string) config.PortConfig {
+	t.Helper()
+	host, portString, err := net.SplitHostPort(address)
+	if err != nil {
+		t.Fatalf("split %q: %v", address, err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("parse port %q: %v", portString, err)
+	}
+	return config.PortConfig{
+		IP:       host,
+		Port:     port,
+		Protocol: "http",
+		Admin:    []string{host},
+	}
+}
+
+func setTestRPCPorts(t *testing.T, ports map[string]config.PortConfig) {
+	t.Helper()
+	previousConfig, previousError := globalConfig, globalConfigErr
+	globalConfig = &config.Config{Ports: ports}
+	globalConfigErr = nil
+	t.Cleanup(func() {
+		globalConfig, globalConfigErr = previousConfig, previousError
+	})
+}
+
+func setTestRPCClient(t *testing.T, client *http.Client) {
+	t.Helper()
+	previous := rpcHTTPClient
+	rpcHTTPClient = client
+	t.Cleanup(func() {
+		rpcHTTPClient = previous
+	})
+}
+
+func newRPCCommand() *cobra.Command {
+	command := &cobra.Command{}
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	return command
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+type boundedCountingReader struct {
+	remaining int
+	read      int
+}
+
+func (r *boundedCountingReader) Read(buffer []byte) (int, error) {
+	if r.remaining == 0 {
+		return 0, io.EOF
+	}
+	n := min(len(buffer), r.remaining)
+	for i := range n {
+		buffer[i] = 'x'
+	}
+	r.remaining -= n
+	r.read += n
+	return n, nil
+}
+
+func rpcHTTPResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     strconv.Itoa(status) + " " + http.StatusText(status),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 }


### PR DESCRIPTION
## Summary
- align every typed CLI RPC request with registered server contracts and remove commands that cannot succeed over HTTP
- fail closed on unsafe credential transport, redirects, HTTP/protocol errors, malformed envelopes, and oversized responses
- add prompt, owner-only file, and stdin secret sources with non-leaking positional deprecation warnings
- cover every non-trivial fixed command with final JSON-RPC wire-envelope tests

## Test plan
- [x] `go test -count=1 ./internal/cli`
- [x] `go test -race -count=1 ./internal/cli`
- [x] `go test -count=1 ./internal/rpc/...`
- [x] `just build-all`
- [x] `just build-nocgo`
- [x] `GOOS=linux GOARCH=386 CGO_ENABLED=0 go build ./...`
- [x] `just vet`
- [x] `golangci-lint run`
- [x] `golangci-lint run --config .golangci-warnings.yml`
- [x] `go mod tidy -diff`
- [x] `git diff --check`

Part of #1451
