### PR TITLE
fix: harden CLI state comparison

### DIFF
--- a/internal/cli/compare.go
+++ b/internal/cli/compare.go
@@ -21,10 +21,10 @@ type stateFile struct {
 }
 
 type stateFileEntry struct {
-	Index   string         `json:"index"`
-	Data    string         `json:"data,omitempty"`
-	DataHex string         `json:"data_hex,omitempty"`
-	Decoded map[string]any `json:"decoded,omitempty"`
+	Index   string          `json:"index"`
+	Data    json.RawMessage `json:"data"`
+	DataHex json.RawMessage `json:"data_hex"`
+	Decoded map[string]any  `json:"decoded,omitempty"`
 }
 
 var (
@@ -213,12 +213,23 @@ func normalizeStateEntries(entries []stateFileEntry) (map[string]stateEntry, err
 		}
 		originalIndexes[key] = index
 
-		if entry.Data != "" && entry.DataHex != "" {
+		if entry.Data != nil && entry.DataHex != nil {
 			return nil, fmt.Errorf("entry %q has both data and data_hex", index)
 		}
-		dataHex := entry.Data
-		if dataHex == "" {
-			dataHex = entry.DataHex
+
+		var rawData json.RawMessage
+		switch {
+		case entry.Data != nil:
+			rawData = entry.Data
+		case entry.DataHex != nil:
+			rawData = entry.DataHex
+		default:
+			return nil, fmt.Errorf("entry %q has no raw data", index)
+		}
+
+		var dataHex string
+		if err := json.Unmarshal(rawData, &dataHex); err != nil {
+			return nil, fmt.Errorf("entry %q raw data must be a string: %w", index, err)
 		}
 		if dataHex == "" {
 			return nil, fmt.Errorf("entry %q has no raw data", index)

--- a/internal/cli/compare.go
+++ b/internal/cli/compare.go
@@ -1,10 +1,13 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
@@ -13,19 +16,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// StateFile represents a state dump file (either from fixtures or debug output)
-type StateFile struct {
-	LedgerIndex uint32           `json:"ledger_index,omitempty"`
-	AccountHash string           `json:"account_hash,omitempty"`
-	Entries     []StateFileEntry `json:"entries,omitempty"`
+type stateFile struct {
+	Entries json.RawMessage `json:"entries"`
 }
 
-// StateFileEntry represents a state entry that could come from different formats
-type StateFileEntry struct {
+type stateFileEntry struct {
 	Index   string         `json:"index"`
-	Data    string         `json:"data,omitempty"`     // From fixture state.json
-	DataHex string         `json:"data_hex,omitempty"` // From debug post_state.json
-	Decoded map[string]any `json:"decoded,omitempty"`  // Pre-decoded data
+	Data    string         `json:"data,omitempty"`
+	DataHex string         `json:"data_hex,omitempty"`
+	Decoded map[string]any `json:"decoded,omitempty"`
 }
 
 var (
@@ -85,23 +84,19 @@ func runCompare(cmd *cobra.Command, args []string) error {
 	fmt.Fprintln(w)
 
 	// Load both files
-	state1, err := loadStateFile(file1Path)
+	map1, err := loadStateFile(file1Path)
 	if err != nil {
 		return fmt.Errorf("loading file1 %q: %w", file1Path, err)
 	}
 
-	state2, err := loadStateFile(file2Path)
+	map2, err := loadStateFile(file2Path)
 	if err != nil {
 		return fmt.Errorf("loading file2 %q: %w", file2Path, err)
 	}
 
-	fmt.Fprintf(w, "File 1: %d entries\n", len(state1))
-	fmt.Fprintf(w, "File 2: %d entries\n", len(state2))
+	fmt.Fprintf(w, "File 1: %d entries\n", len(map1))
+	fmt.Fprintf(w, "File 2: %d entries\n", len(map2))
 	fmt.Fprintln(w)
-
-	// Build maps for comparison
-	map1 := buildStateMap(state1)
-	map2 := buildStateMap(state2)
 
 	// Find differences
 	added, removed, modified, unchanged := compareStates(map1, map2)
@@ -155,77 +150,95 @@ func runCompare(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func loadStateFile(path string) ([]StateFileEntry, error) {
+func loadStateFile(path string) (map[string]stateEntry, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	// Try parsing as StateFile first
-	var stateFile StateFile
-	if err := json.Unmarshal(data, &stateFile); err == nil {
-		if len(stateFile.Entries) > 0 {
-			return stateFile.Entries, nil
+	entries, err := parseStateEntries(data)
+	if err != nil {
+		return nil, err
+	}
+	return normalizeStateEntries(entries)
+}
+
+func parseStateEntries(data []byte) ([]stateFileEntry, error) {
+	var topLevel json.RawMessage
+	if err := json.Unmarshal(data, &topLevel); err != nil {
+		return nil, fmt.Errorf("decoding JSON: %w", err)
+	}
+	topLevel = bytes.TrimSpace(topLevel)
+
+	var entries []stateFileEntry
+	switch {
+	case len(topLevel) > 0 && topLevel[0] == '{':
+		var snapshot stateFile
+		if err := json.Unmarshal(topLevel, &snapshot); err != nil {
+			return nil, fmt.Errorf("decoding state snapshot: %w", err)
 		}
-	}
-
-	// Try parsing as array of entries directly (debug post_state.json format)
-	var entries []StateFileEntry
-	if err := json.Unmarshal(data, &entries); err == nil {
-		return entries, nil
-	}
-
-	// Try parsing as array of maps
-	var mapEntries []map[string]any
-	if err := json.Unmarshal(data, &mapEntries); err == nil {
-		entries := make([]StateFileEntry, 0, len(mapEntries))
-		for _, m := range mapEntries {
-			entry := StateFileEntry{}
-			if idx, ok := m["index"].(string); ok {
-				entry.Index = idx
-			}
-			if data, ok := m["data"].(string); ok {
-				entry.Data = data
-			}
-			if dataHex, ok := m["data_hex"].(string); ok {
-				entry.DataHex = dataHex
-			}
-			if decoded, ok := m["decoded"].(map[string]any); ok {
-				entry.Decoded = decoded
-			}
-			if entry.Index != "" {
-				entries = append(entries, entry)
-			}
+		if snapshot.Entries == nil {
+			return nil, fmt.Errorf("state snapshot is missing entries")
 		}
-		return entries, nil
+		snapshot.Entries = bytes.TrimSpace(snapshot.Entries)
+		if len(snapshot.Entries) == 0 || snapshot.Entries[0] != '[' {
+			return nil, fmt.Errorf("state snapshot entries must be an array")
+		}
+		if err := json.Unmarshal(snapshot.Entries, &entries); err != nil {
+			return nil, fmt.Errorf("decoding state entries: %w", err)
+		}
+	case len(topLevel) > 0 && topLevel[0] == '[':
+		if err := json.Unmarshal(topLevel, &entries); err != nil {
+			return nil, fmt.Errorf("decoding state entries: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("expected a state snapshot object or entry array")
 	}
-
-	return nil, fmt.Errorf("unrecognized file format")
+	return entries, nil
 }
 
 type stateEntry = replaytool.ComparableStateEntry
 
-func buildStateMap(entries []StateFileEntry) map[string]stateEntry {
-	result := make(map[string]stateEntry)
-	for _, e := range entries {
-		key := strings.ToLower(e.Index)
-		dataHex := e.Data
+func normalizeStateEntries(entries []stateFileEntry) (map[string]stateEntry, error) {
+	result := make(map[string]stateEntry, len(entries))
+	originalIndexes := make(map[string]string, len(entries))
+	for i, entry := range entries {
+		index := strings.TrimSpace(entry.Index)
+		if index == "" {
+			return nil, fmt.Errorf("entry %d has no index", i+1)
+		}
+		key := strings.ToLower(index)
+		if original, exists := originalIndexes[key]; exists {
+			return nil, fmt.Errorf("entry %d index %q duplicates %q", i+1, index, original)
+		}
+		originalIndexes[key] = index
+
+		if entry.Data != "" && entry.DataHex != "" {
+			return nil, fmt.Errorf("entry %q has both data and data_hex", index)
+		}
+		dataHex := entry.Data
 		if dataHex == "" {
-			dataHex = e.DataHex
+			dataHex = entry.DataHex
+		}
+		if dataHex == "" {
+			return nil, fmt.Errorf("entry %q has no raw data", index)
+		}
+		if _, err := hex.DecodeString(dataHex); err != nil {
+			return nil, fmt.Errorf("entry %q has invalid raw data: %w", index, err)
 		}
 
-		decoded := e.Decoded
-		if decoded == nil && dataHex != "" {
-			decoded = decodeStateData(dataHex)
+		decoded := decodeStateData(dataHex)
+		if decoded == nil {
+			decoded = entry.Decoded
 		}
 
 		result[key] = stateEntry{
-			Index:   e.Index,
+			Index:   index,
 			DataHex: dataHex,
 			Decoded: decoded,
 		}
 	}
-	return result
+	return result, nil
 }
 
 func decodeStateData(hexData string) map[string]any {
@@ -241,10 +254,6 @@ type modifiedEntry = replaytool.StateModification
 func compareStates(map1, map2 map[string]stateEntry) (added, removed []stateEntry, modified []modifiedEntry, unchanged []stateEntry) {
 	comparison := replaytool.CompareStates(map1, map2)
 	return comparison.Added, comparison.Removed, comparison.Modified, comparison.Unchanged
-}
-
-func findChangedKeys(old, new map[string]any) []string {
-	return replaytool.ChangedStateKeys(old, new)
 }
 
 func filterByType(entries []stateEntry, entryType string) []stateEntry {
@@ -401,11 +410,15 @@ func printKeyFields(w io.Writer, decoded map[string]any) {
 			fmt.Fprintf(w, "    Amendments: %d enabled\n", len(amendments))
 		}
 	default:
-		// Print all fields for unknown types
-		for k, v := range decoded {
-			if k != "LedgerEntryType" {
-				fmt.Fprintf(w, "    %s: %v\n", k, formatValue(v))
+		fields := make([]string, 0, len(decoded))
+		for field := range decoded {
+			if field != "LedgerEntryType" {
+				fields = append(fields, field)
 			}
+		}
+		sort.Strings(fields)
+		for _, field := range fields {
+			fmt.Fprintf(w, "    %s: %v\n", field, formatValue(decoded[field]))
 		}
 	}
 }
@@ -457,15 +470,17 @@ func writeDiffJSON(w io.Writer, path string, added, removed []stateEntry, modifi
 
 	for _, e := range added {
 		output["added"] = append(output["added"].([]map[string]any), map[string]any{
-			"index":   e.Index,
-			"decoded": e.Decoded,
+			"index":    e.Index,
+			"data_hex": e.DataHex,
+			"decoded":  e.Decoded,
 		})
 	}
 
 	for _, e := range removed {
 		output["removed"] = append(output["removed"].([]map[string]any), map[string]any{
-			"index":   e.Index,
-			"decoded": e.Decoded,
+			"index":    e.Index,
+			"data_hex": e.DataHex,
+			"decoded":  e.Decoded,
 		})
 	}
 
@@ -473,6 +488,8 @@ func writeDiffJSON(w io.Writer, path string, added, removed []stateEntry, modifi
 		output["modified"] = append(output["modified"].([]map[string]any), map[string]any{
 			"index":        e.Index,
 			"changed_keys": e.ChangedKeys,
+			"old_data_hex": e.OldDataHex,
+			"new_data_hex": e.NewDataHex,
 			"old":          e.OldDecoded,
 			"new":          e.NewDecoded,
 		})

--- a/internal/cli/compare_test.go
+++ b/internal/cli/compare_test.go
@@ -112,6 +112,21 @@ func TestLoadStateFileRejectsAmbiguousEntries(t *testing.T) {
 			wantErr: `entry "AB" has both data and data_hex`,
 		},
 		{
+			name:    "empty data with data hex",
+			content: `[{"index":"AB","data":"","data_hex":"11"}]`,
+			wantErr: `entry "AB" has both data and data_hex`,
+		},
+		{
+			name:    "null data with data hex",
+			content: `[{"index":"AB","data":null,"data_hex":"11"}]`,
+			wantErr: `entry "AB" has both data and data_hex`,
+		},
+		{
+			name:    "non-string raw data",
+			content: `[{"index":"AB","data":11}]`,
+			wantErr: `entry "AB" raw data must be a string`,
+		},
+		{
 			name:    "invalid raw data",
 			content: `[{"index":"AB","data":"not-hex"}]`,
 			wantErr: `entry "AB" has invalid raw data`,
@@ -154,9 +169,9 @@ func TestDecodeStateData(t *testing.T) {
 func TestNormalizeStateEntries(t *testing.T) {
 	feeHex := feeSettingsHex(t)
 	entries := []stateFileEntry{
-		{Index: "AA", Data: feeHex},
-		{Index: "BB", DataHex: feeHex, Decoded: map[string]interface{}{"LedgerEntryType": "Stale"}},
-		{Index: "CC", DataHex: "00", Decoded: map[string]interface{}{"LedgerEntryType": "AccountRoot"}},
+		{Index: "AA", Data: json.RawMessage(`"` + feeHex + `"`)},
+		{Index: "BB", DataHex: json.RawMessage(`"` + feeHex + `"`), Decoded: map[string]interface{}{"LedgerEntryType": "Stale"}},
+		{Index: "CC", DataHex: json.RawMessage(`"00"`), Decoded: map[string]interface{}{"LedgerEntryType": "AccountRoot"}},
 	}
 	m, err := normalizeStateEntries(entries)
 	if err != nil {

--- a/internal/cli/compare_test.go
+++ b/internal/cli/compare_test.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/cmdexit"
@@ -33,54 +35,110 @@ func feeSettingsHex(t *testing.T) string {
 func TestLoadStateFile_Formats(t *testing.T) {
 	dir := t.TempDir()
 
-	// 1. StateFile wrapper format with entries.
 	wrapped := filepath.Join(dir, "wrapped.json")
 	if err := os.WriteFile(wrapped, []byte(`{"ledger_index":100,"entries":[{"index":"AB","data":"CD"}]}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	entries, err := loadStateFile(wrapped)
-	if err != nil || len(entries) != 1 || entries[0].Index != "AB" {
+	if err != nil || len(entries) != 1 || entries["ab"].Index != "AB" {
 		t.Fatalf("wrapped format: entries=%v err=%v", entries, err)
 	}
 
-	// 2. Bare array of StateFileEntry.
 	bareArr := filepath.Join(dir, "bare.json")
 	if err := os.WriteFile(bareArr, []byte(`[{"index":"11","data_hex":"22"}]`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	entries, err = loadStateFile(bareArr)
-	if err != nil || len(entries) != 1 || entries[0].DataHex != "22" {
+	if err != nil || len(entries) != 1 || entries["11"].DataHex != "22" {
 		t.Fatalf("bare array format: entries=%v err=%v", entries, err)
 	}
 
-	// 3. Map-fallback path: content that does not unmarshal cleanly into
-	// []StateFileEntry (here `decoded` is a string, not an object) falls back to
-	// generic-map parsing, which keeps only entries carrying a non-empty index.
-	mapArr := filepath.Join(dir, "maps.json")
-	content := `[{"index":"33","data":"44","decoded":"not-an-object"},{"index":"","data":"noindex"}]`
-	if err := os.WriteFile(mapArr, []byte(content), 0o644); err != nil {
+	empty := filepath.Join(dir, "empty.json")
+	if err := os.WriteFile(empty, []byte(`{"entries":[]}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	entries, err = loadStateFile(mapArr)
-	if err != nil {
-		t.Fatalf("map array format: %v", err)
-	}
-	if len(entries) != 1 || entries[0].Index != "33" || entries[0].Data != "44" {
-		t.Fatalf("map array format: unexpected entries %+v", entries)
+	entries, err = loadStateFile(empty)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("empty wrapper: entries=%v err=%v", entries, err)
 	}
 
-	// 4. Missing file → error.
 	if _, err := loadStateFile(filepath.Join(dir, "nope.json")); err == nil {
 		t.Fatal("expected error for missing file")
 	}
 
-	// 5. Unrecognized content → error.
 	junk := filepath.Join(dir, "junk.json")
 	if err := os.WriteFile(junk, []byte(`"just a string"`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := loadStateFile(junk); err == nil {
 		t.Fatal("expected unrecognized-format error")
+	}
+}
+
+func TestLoadStateFileRejectsAmbiguousEntries(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name:    "missing wrapper entries",
+			content: `{"ledger_index":100}`,
+			wantErr: "state snapshot is missing entries",
+		},
+		{
+			name:    "missing index",
+			content: `[{"data":"11"}]`,
+			wantErr: "entry 1 has no index",
+		},
+		{
+			name:    "blank index",
+			content: `[{"index":"  ","data":"11"}]`,
+			wantErr: "entry 1 has no index",
+		},
+		{
+			name:    "duplicate normalized index",
+			content: `[{"index":"AB","data":"11"},{"index":"ab","data":"22"}]`,
+			wantErr: `entry 2 index "ab" duplicates "AB"`,
+		},
+		{
+			name:    "decoded only",
+			content: `[{"index":"AB","decoded":{"LedgerEntryType":"AccountRoot"}}]`,
+			wantErr: `entry "AB" has no raw data`,
+		},
+		{
+			name:    "both raw fields",
+			content: `[{"index":"AB","data":"11","data_hex":"11"}]`,
+			wantErr: `entry "AB" has both data and data_hex`,
+		},
+		{
+			name:    "invalid raw data",
+			content: `[{"index":"AB","data":"not-hex"}]`,
+			wantErr: `entry "AB" has invalid raw data`,
+		},
+		{
+			name:    "wrong decoded type",
+			content: `[{"index":"AB","data":"11","decoded":"object required"}]`,
+			wantErr: "decoding state entries",
+		},
+		{
+			name:    "null entries",
+			content: `{"entries":null}`,
+			wantErr: "state snapshot entries must be an array",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "state.json")
+			if err := os.WriteFile(path, []byte(tt.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			_, err := loadStateFile(path)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("loadStateFile() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
 	}
 }
 
@@ -93,21 +151,19 @@ func TestDecodeStateData(t *testing.T) {
 	}
 }
 
-func TestBuildStateMap(t *testing.T) {
+func TestNormalizeStateEntries(t *testing.T) {
 	feeHex := feeSettingsHex(t)
-	entries := []StateFileEntry{
-		// data present → decoded lazily from the codec.
+	entries := []stateFileEntry{
 		{Index: "AA", Data: feeHex},
-		// only data_hex present → falls back to DataHex.
-		{Index: "BB", DataHex: feeHex},
-		// pre-decoded → used as-is, codec not invoked.
-		{Index: "CC", Decoded: map[string]interface{}{"LedgerEntryType": "AccountRoot"}},
-		// nothing decodable.
-		{Index: "DD"},
+		{Index: "BB", DataHex: feeHex, Decoded: map[string]interface{}{"LedgerEntryType": "Stale"}},
+		{Index: "CC", DataHex: "00", Decoded: map[string]interface{}{"LedgerEntryType": "AccountRoot"}},
 	}
-	m := buildStateMap(entries)
-	if len(m) != 4 {
-		t.Fatalf("expected 4 entries, got %d", len(m))
+	m, err := normalizeStateEntries(entries)
+	if err != nil {
+		t.Fatalf("normalizeStateEntries: %v", err)
+	}
+	if len(m) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(m))
 	}
 	if m["aa"].Decoded["LedgerEntryType"] != "FeeSettings" {
 		t.Errorf("aa not decoded from Data: %+v", m["aa"])
@@ -115,11 +171,11 @@ func TestBuildStateMap(t *testing.T) {
 	if m["bb"].DataHex != feeHex || m["bb"].Decoded == nil {
 		t.Errorf("bb not decoded from DataHex: %+v", m["bb"])
 	}
+	if m["bb"].Decoded["LedgerEntryType"] != "FeeSettings" {
+		t.Errorf("bb used stale supplied decoded data: %+v", m["bb"])
+	}
 	if m["cc"].Decoded["LedgerEntryType"] != "AccountRoot" {
 		t.Errorf("cc pre-decoded value lost: %+v", m["cc"])
-	}
-	if m["dd"].Decoded != nil {
-		t.Errorf("dd should have no decoded data: %+v", m["dd"])
 	}
 }
 
@@ -150,27 +206,6 @@ func TestCompareStates(t *testing.T) {
 	}
 	if len(modified[0].ChangedKeys) != 1 || modified[0].ChangedKeys[0] != "Balance" {
 		t.Errorf("changed keys = %v", modified[0].ChangedKeys)
-	}
-}
-
-func TestFindChangedKeys(t *testing.T) {
-	if got := findChangedKeys(nil, map[string]interface{}{"a": 1}); got != nil {
-		t.Errorf("nil old should yield nil, got %v", got)
-	}
-	if got := findChangedKeys(map[string]interface{}{"a": 1}, nil); got != nil {
-		t.Errorf("nil new should yield nil, got %v", got)
-	}
-	old := map[string]interface{}{"same": 1, "changed": 1, "removed": 1}
-	new := map[string]interface{}{"same": 1, "changed": 2, "added": 1}
-	got := findChangedKeys(old, new)
-	want := []string{"added", "changed", "removed"} // sorted
-	if len(got) != len(want) {
-		t.Fatalf("got %v want %v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("got %v want %v", got, want)
-		}
 	}
 }
 
@@ -221,49 +256,160 @@ func TestFormatValue(t *testing.T) {
 	}
 }
 
-func TestPrintFunctions(t *testing.T) {
+func TestPrintEntries(t *testing.T) {
 	idx := "00000000000000000000000000000000000000000000000000000000000000FF"
-	added := []stateEntry{{Index: idx, Decoded: map[string]interface{}{
+	entry := stateEntry{Index: idx, Decoded: map[string]interface{}{
 		"LedgerEntryType": "AccountRoot", "Account": "rAcct", "Balance": "1", "Sequence": uint32(1), "OwnerCount": uint32(0), "Flags": uint32(0),
-	}}}
-	removed := []stateEntry{{Index: idx, Decoded: nil}} // exercises the "unable to decode" branch
-	modified := []modifiedEntry{{
-		Index:       idx,
-		OldDecoded:  map[string]interface{}{"LedgerEntryType": "RippleState", "Balance": "1"},
-		NewDecoded:  map[string]interface{}{"LedgerEntryType": "RippleState", "Balance": "2"},
-		ChangedKeys: []string{"Balance"},
 	}}
-	unchanged := []stateEntry{{Index: idx, Decoded: map[string]interface{}{"LedgerEntryType": "Offer"}}}
 
-	// compareShowAll/compareShowDecoded influence the print depth; restore after.
 	prevAll, prevDecoded := compareShowAll, compareShowDecoded
 	defer func() { compareShowAll, compareShowDecoded = prevAll, prevDecoded }()
-	compareShowAll, compareShowDecoded = true, true
 
-	printAddedEntries(io.Discard, added)
-	printRemovedEntries(io.Discard, removed)
-	printModifiedEntries(io.Discard, modified)
-	printUnchangedEntries(io.Discard, unchanged)
+	tests := []struct {
+		name       string
+		showAll    bool
+		showDecode bool
+		want       string
+	}{
+		{
+			name: "summary only",
+			want: "\n[+] Entry 1: " + idx + "\n    Type: AccountRoot\n\n",
+		},
+		{
+			name:       "decoded key fields",
+			showDecode: true,
+			want: "\n[+] Entry 1: " + idx + "\n" +
+				"    Type: AccountRoot\n" +
+				"    Account: rAcct\n" +
+				"    Balance: 1\n" +
+				"    Sequence: 1\n" +
+				"    OwnerCount: 0\n" +
+				"    Flags: 0\n\n",
+		},
+		{
+			name:    "all with decoded disabled",
+			showAll: true,
+			want:    "\n[+] Entry 1: " + idx + "\n    Type: AccountRoot\n\n",
+		},
+		{
+			name:       "all decoded",
+			showAll:    true,
+			showDecode: true,
+			want: "\n[+] Entry 1: " + idx + "\n" +
+				"    Type: AccountRoot\n" +
+				"    Account: rAcct\n" +
+				"    Balance: 1\n" +
+				"    Sequence: 1\n" +
+				"    OwnerCount: 0\n" +
+				"    Flags: 0\n" +
+				"    Full data:\n" +
+				"    {\n" +
+				"      \"Account\": \"rAcct\",\n" +
+				"      \"Balance\": \"1\",\n" +
+				"      \"Flags\": 0,\n" +
+				"      \"LedgerEntryType\": \"AccountRoot\",\n" +
+				"      \"OwnerCount\": 0,\n" +
+				"      \"Sequence\": 1\n" +
+				"    }\n\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compareShowAll, compareShowDecoded = tt.showAll, tt.showDecode
+			var output bytes.Buffer
+			printAddedEntries(&output, []stateEntry{entry})
+			got := output.String()
+			const banner = "================================================================================\n" +
+				"                              ADDED ENTRIES\n" +
+				"================================================================================\n"
+			if got != banner+tt.want {
+				t.Fatalf("printAddedEntries() =\n%q\nwant\n%q", got, banner+tt.want)
+			}
+		})
+	}
+}
 
-	// Exercise printKeyFields for each well-known entry type.
-	for _, d := range []map[string]interface{}{
-		{"LedgerEntryType": "AccountRoot", "Account": "rA", "Balance": "1", "Sequence": uint32(1), "OwnerCount": uint32(0), "Flags": uint32(0)},
-		{"LedgerEntryType": "RippleState", "Balance": map[string]interface{}{"currency": "USD", "value": "1", "issuer": "rIssuerAcct"}, "LowLimit": "0", "HighLimit": "0", "Flags": uint32(0)},
-		{"LedgerEntryType": "Offer", "Account": "rA", "TakerGets": "1", "TakerPays": "2", "Sequence": uint32(1)},
-		{"LedgerEntryType": "DirectoryNode", "Owner": "rA", "RootIndex": "X"},
-		{"LedgerEntryType": "FeeSettings", "BaseFeeDrops": "10", "ReserveBaseDrops": "1", "ReserveIncrementDrops": "1"},
-		{"LedgerEntryType": "Amendments", "Amendments": []interface{}{"a", "b"}},
-		{"LedgerEntryType": "SomethingUnknown", "FieldOne": "v", "FieldTwo": uint32(3)},
+func TestPrintUnchangedEntries(t *testing.T) {
+	var output bytes.Buffer
+	printUnchangedEntries(&output, []stateEntry{{
+		Index:   "123456789012345678901234567890123",
+		Decoded: map[string]any{"LedgerEntryType": "Offer"},
+	}})
+	want := "================================================================================\n" +
+		"                           UNCHANGED ENTRIES\n" +
+		"================================================================================\n" +
+		"[=] 1: 12345678901234567890123456789012... (Offer)\n\n"
+	if got := output.String(); got != want {
+		t.Fatalf("printUnchangedEntries() =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestPrintUnknownFieldsSorted(t *testing.T) {
+	prevAll, prevDecoded := compareShowAll, compareShowDecoded
+	defer func() { compareShowAll, compareShowDecoded = prevAll, prevDecoded }()
+	compareShowAll, compareShowDecoded = false, true
+
+	var output bytes.Buffer
+	printEntryDetails(&output, map[string]any{
+		"LedgerEntryType": "SomethingUnknown",
+		"Zulu":            3,
+		"Alpha":           1,
+		"Middle":          2,
+	})
+	want := "    Type: SomethingUnknown\n" +
+		"    Alpha: 1\n" +
+		"    Middle: 2\n" +
+		"    Zulu: 3\n"
+	if got := output.String(); got != want {
+		t.Fatalf("printEntryDetails() =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestPrintModifiedEntriesDecodedFlag(t *testing.T) {
+	entry := modifiedEntry{
+		Index:       "AB",
+		OldDecoded:  map[string]any{"LedgerEntryType": "RippleState", "Balance": "1"},
+		NewDecoded:  map[string]any{"LedgerEntryType": "RippleState", "Balance": "2"},
+		ChangedKeys: []string{"Balance"},
+	}
+	prevDecoded := compareShowDecoded
+	defer func() { compareShowDecoded = prevDecoded }()
+
+	const banner = "================================================================================\n" +
+		"                            MODIFIED ENTRIES\n" +
+		"================================================================================\n" +
+		"\n[~] Entry 1: AB\n" +
+		"    Type: RippleState\n" +
+		"    Changed fields: [Balance]\n" +
+		"    ---\n"
+	for _, tt := range []struct {
+		name    string
+		decoded bool
+		want    string
+	}{
+		{"decoded", true, banner + "    Balance:\n      - 1\n      + 2\n\n"},
+		{"raw summary", false, banner + "\n"},
 	} {
-		printEntryDetails(io.Discard, d)
+		t.Run(tt.name, func(t *testing.T) {
+			compareShowDecoded = tt.decoded
+			var output bytes.Buffer
+			printModifiedEntries(&output, []modifiedEntry{entry})
+			if got := output.String(); got != tt.want {
+				t.Fatalf("printModifiedEntries() =\n%q\nwant\n%q", got, tt.want)
+			}
+		})
 	}
 }
 
 func TestWriteDiffJSON(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "diff.json")
-	added := []stateEntry{{Index: "A", Decoded: map[string]interface{}{"k": "v"}}}
-	removed := []stateEntry{{Index: "B"}}
-	modified := []modifiedEntry{{Index: "C", ChangedKeys: []string{"Balance"}, OldDecoded: map[string]interface{}{"Balance": "1"}, NewDecoded: map[string]interface{}{"Balance": "2"}}}
+	added := []stateEntry{{Index: "A", DataHex: "AA", Decoded: map[string]interface{}{"k": "v"}}}
+	removed := []stateEntry{{Index: "B", DataHex: "BB"}}
+	modified := []modifiedEntry{{
+		Index:      "C",
+		OldDataHex: "CC",
+		NewDataHex: "DD",
+	}}
 
 	if err := writeDiffJSON(io.Discard, out, added, removed, modified); err != nil {
 		t.Fatalf("writeDiffJSON: %v", err)
@@ -273,19 +419,16 @@ func TestWriteDiffJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading diff: %v", err)
 	}
-	var parsed struct {
-		Added    []map[string]interface{} `json:"added"`
-		Removed  []map[string]interface{} `json:"removed"`
-		Modified []map[string]interface{} `json:"modified"`
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, data); err != nil {
+		t.Fatalf("compacting diff: %v", err)
 	}
-	if err := json.Unmarshal(data, &parsed); err != nil {
-		t.Fatalf("unmarshalling diff: %v", err)
-	}
-	if len(parsed.Added) != 1 || len(parsed.Removed) != 1 || len(parsed.Modified) != 1 {
-		t.Fatalf("unexpected diff contents: %+v", parsed)
-	}
-	if parsed.Modified[0]["index"] != "C" {
-		t.Errorf("modified index = %v", parsed.Modified[0]["index"])
+	want := `{"added":[{"data_hex":"AA","decoded":{"k":"v"},"index":"A"}],` +
+		`"modified":[{"changed_keys":null,"index":"C","new":null,` +
+		`"new_data_hex":"DD","old":null,"old_data_hex":"CC"}],` +
+		`"removed":[{"data_hex":"BB","decoded":null,"index":"B"}]}`
+	if got := compact.String(); got != want {
+		t.Fatalf("writeDiffJSON() =\n%s\nwant\n%s", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- validate wrapped and bare state snapshots through one normalization path
- reject missing, duplicate, raw-less, ambiguous, and malformed serialized entries
- make human output deterministic and preserve raw bytes in JSON diffs
- remove dead/exported CLI-only comparison surface and add exact output regressions

## Verification

- `go test -count=1 ./...`
- `go test -race -count=1 ./internal/cli ./internal/replaytool`
- `just build-all`
- `just build-nocgo`
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go build ./...`
- `just vet`
- `golangci-lint run`
- `golangci-lint run --config .golangci-warnings.yml`
- `git diff --check`

Part of #1451.
