### PR TITLE
refactor(cli): own command and diagnostic server lifecycle

### DIFF
--- a/cmd/xrpld/main.go
+++ b/cmd/xrpld/main.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"context"
+	"os"
+
 	"github.com/LeJamon/go-xrpl/internal/cli"
 )
 
 func main() {
-	// Use CLI for all cases - it handles both server mode and RPC commands
-	// - No arguments: runs server (default command)
-	// - With arguments: executes CLI commands
-	cli.Execute()
+	os.Exit(cli.Run(context.Background(), os.Args[1:], cli.IOStreams{
+		In:     os.Stdin,
+		Out:    os.Stdout,
+		ErrOut: os.Stderr,
+	}))
 }

--- a/internal/cli/auxiliary.go
+++ b/internal/cli/auxiliary.go
@@ -1,0 +1,242 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/observability"
+)
+
+const auxiliaryShutdownTimeout = 5 * time.Second
+
+type auxiliaryServer struct {
+	name     string
+	addr     string
+	listener net.Listener
+	server   *http.Server
+}
+
+type auxiliaryServers struct {
+	servers      []auxiliaryServer
+	serveWG      sync.WaitGroup
+	shutdownOnce sync.Once
+	shutdownErr  error
+	stopping     atomic.Bool
+}
+
+type auxiliaryServerSpec struct {
+	name    string
+	addr    string
+	handler http.Handler
+	pprof   bool
+}
+
+func startAuxiliaryServers(
+	ctx context.Context,
+	cancel context.CancelCauseFunc,
+	getenv func(string) string,
+	listen func(string, string) (net.Listener, error),
+) (*auxiliaryServers, error) {
+	if getenv == nil {
+		return nil, errors.New("auxiliary servers: getenv dependency is nil")
+	}
+	if listen == nil {
+		return nil, errors.New("auxiliary servers: listen dependency is nil")
+	}
+
+	allowUnsafe, err := parseStrictBool("GOXRPL_PPROF_ALLOW_UNSAFE", getenv("GOXRPL_PPROF_ALLOW_UNSAFE"))
+	if err != nil {
+		return nil, err
+	}
+
+	var specs []auxiliaryServerSpec
+	if raw := strings.TrimSpace(getenv("GOXRPL_PPROF")); raw != "" {
+		addr, err := normalizeAuxiliaryAddress("pprof", raw, allowUnsafe)
+		if err != nil {
+			return nil, err
+		}
+		specs = append(specs, auxiliaryServerSpec{
+			name:    "pprof",
+			addr:    addr,
+			handler: observability.PProfHandler(),
+			pprof:   true,
+		})
+	}
+	if raw := strings.TrimSpace(getenv("GOXRPL_METRICS")); raw != "" {
+		addr, err := normalizeAuxiliaryAddress("metrics", raw, false)
+		if err != nil {
+			return nil, err
+		}
+		specs = append(specs, auxiliaryServerSpec{
+			name:    "metrics",
+			addr:    addr,
+			handler: newMetricsHandler(),
+		})
+	}
+
+	aux := &auxiliaryServers{}
+	for _, spec := range specs {
+		listener, err := listen("tcp", spec.addr)
+		if err != nil {
+			aux.closeListeners()
+			return nil, fmt.Errorf("bind %s server on %s: %w", spec.name, spec.addr, err)
+		}
+		aux.servers = append(aux.servers, auxiliaryServer{
+			name:     spec.name,
+			addr:     listener.Addr().String(),
+			listener: listener,
+			server: &http.Server{
+				Addr:              spec.addr,
+				Handler:           spec.handler,
+				ReadHeaderTimeout: 5 * time.Second,
+			},
+		})
+	}
+
+	for _, spec := range specs {
+		if spec.pprof {
+			observability.EnablePProf()
+			break
+		}
+	}
+
+	for i := range aux.servers {
+		entry := &aux.servers[i]
+		aux.serveWG.Add(1)
+		go func() {
+			defer aux.serveWG.Done()
+			if err := entry.server.Serve(entry.listener); err != nil &&
+				!errors.Is(err, http.ErrServerClosed) &&
+				!aux.stopping.Load() &&
+				ctx.Err() == nil {
+				cancel(fmt.Errorf("%s server on %s failed: %w", entry.name, entry.addr, err))
+			}
+		}()
+	}
+	if len(aux.servers) != 0 {
+		go func() {
+			<-ctx.Done()
+			_ = aux.Shutdown()
+		}()
+	}
+
+	return aux, nil
+}
+
+func (a *auxiliaryServers) Addresses() map[string]string {
+	addresses := make(map[string]string, len(a.servers))
+	for _, server := range a.servers {
+		addresses[server.name] = server.addr
+	}
+	return addresses
+}
+
+func (a *auxiliaryServers) Shutdown() error {
+	if a == nil {
+		return nil
+	}
+	a.shutdownOnce.Do(func() {
+		a.stopping.Store(true)
+		ctx, cancel := context.WithTimeout(context.Background(), auxiliaryShutdownTimeout)
+		defer cancel()
+
+		var errs []error
+		for i := range a.servers {
+			if err := observability.ShutdownHTTPServer(ctx, a.servers[i].server); err != nil {
+				errs = append(errs, fmt.Errorf("shutdown %s server: %w", a.servers[i].name, err))
+			}
+		}
+		serveDone := make(chan struct{})
+		go func() {
+			a.serveWG.Wait()
+			close(serveDone)
+		}()
+		select {
+		case <-serveDone:
+		case <-ctx.Done():
+			errs = append(errs, errors.New("timed out waiting for auxiliary servers to stop"))
+		}
+		a.shutdownErr = errors.Join(errs...)
+	})
+	return a.shutdownErr
+}
+
+func (a *auxiliaryServers) closeListeners() {
+	for i := range a.servers {
+		_ = a.servers[i].listener.Close()
+	}
+}
+
+func parseStrictBool(name, value string) (bool, error) {
+	switch value {
+	case "", "false":
+		return false, nil
+	case "true":
+		return true, nil
+	default:
+		return false, fmt.Errorf("%s must be \"true\" or \"false\"", name)
+	}
+}
+
+func normalizeAuxiliaryAddress(name, raw string, allowUnsafe bool) (string, error) {
+	host, port, err := net.SplitHostPort(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid GOXRPL_%s address %q: %w", strings.ToUpper(name), raw, err)
+	}
+	portNumber, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return "", fmt.Errorf("invalid GOXRPL_%s address %q: port must be a number from 0 to 65535", strings.ToUpper(name), raw)
+	}
+
+	if name == "pprof" && host != "" && !allowUnsafe {
+		if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
+			return "", unsafePProfAddressError(name, raw)
+		}
+	}
+	host = normalizeAuxiliaryHost(name, host, allowUnsafe)
+	if name == "pprof" && !allowUnsafe && !isLoopbackHost(host) {
+		return "", unsafePProfAddressError(name, raw)
+	}
+	return net.JoinHostPort(host, strconv.FormatUint(portNumber, 10)), nil
+}
+
+func unsafePProfAddressError(name, raw string) error {
+	return fmt.Errorf(
+		"GOXRPL_%s address %q is not loopback; set GOXRPL_PPROF_ALLOW_UNSAFE=true to expose pprof",
+		strings.ToUpper(name),
+		raw,
+	)
+}
+
+func normalizeAuxiliaryHost(name, host string, allowUnsafe bool) string {
+	if host == "" {
+		return "127.0.0.1"
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsUnspecified() {
+		return host
+	}
+	if name == "pprof" && allowUnsafe {
+		return host
+	}
+	if ip.To4() != nil {
+		return "127.0.0.1"
+	}
+	return "::1"
+}
+
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/internal/cli/auxiliary_test.go
+++ b/internal/cli/auxiliary_test.go
@@ -1,0 +1,246 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNormalizeAuxiliaryAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		server      string
+		raw         string
+		allowUnsafe bool
+		want        string
+		wantErr     string
+	}{
+		{name: "empty host", server: "pprof", raw: ":6060", want: "127.0.0.1:6060"},
+		{name: "IPv4 metrics wildcard", server: "metrics", raw: "0.0.0.0:9100", want: "127.0.0.1:9100"},
+		{name: "IPv6 metrics wildcard", server: "metrics", raw: "[::]:9100", want: "[::1]:9100"},
+		{name: "explicit loopback", server: "pprof", raw: "localhost:6060", want: "localhost:6060"},
+		{name: "remote metrics", server: "metrics", raw: "192.0.2.1:9100", want: "192.0.2.1:9100"},
+		{name: "unsafe pprof", server: "pprof", raw: "192.0.2.1:6060", wantErr: "ALLOW_UNSAFE=true"},
+		{name: "opted-in remote pprof", server: "pprof", raw: "192.0.2.1:6060", allowUnsafe: true, want: "192.0.2.1:6060"},
+		{name: "pprof wildcard requires opt-in", server: "pprof", raw: "0.0.0.0:6060", wantErr: "ALLOW_UNSAFE=true"},
+		{name: "opted-in pprof wildcard", server: "pprof", raw: "0.0.0.0:6060", allowUnsafe: true, want: "0.0.0.0:6060"},
+		{name: "missing port", server: "pprof", raw: "localhost", wantErr: "missing port"},
+		{name: "non-numeric port", server: "pprof", raw: "localhost:http", wantErr: "port must be a number"},
+		{name: "out of range port", server: "pprof", raw: "localhost:65536", wantErr: "port must be a number"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := normalizeAuxiliaryAddress(test.server, test.raw, test.allowUnsafe)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("normalizeAuxiliaryAddress() error = %v, want containing %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeAuxiliaryAddress() error = %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("normalizeAuxiliaryAddress() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestStartAuxiliaryServersRejectsMalformedUnsafeSetting(t *testing.T) {
+	t.Parallel()
+
+	_, err := startAuxiliaryServers(
+		context.Background(),
+		func(error) {},
+		envValues(map[string]string{"GOXRPL_PPROF_ALLOW_UNSAFE": "1"}),
+		net.Listen,
+	)
+	if err == nil || !strings.Contains(err.Error(), `must be "true" or "false"`) {
+		t.Fatalf("startAuxiliaryServers() error = %v, want strict boolean error", err)
+	}
+}
+
+func TestStartAuxiliaryServersUnsafePProfRequiresOptIn(t *testing.T) {
+	t.Parallel()
+
+	_, err := startAuxiliaryServers(
+		context.Background(),
+		func(error) {},
+		envValues(map[string]string{"GOXRPL_PPROF": "192.0.2.1:6060"}),
+		net.Listen,
+	)
+	if err == nil || !strings.Contains(err.Error(), "GOXRPL_PPROF_ALLOW_UNSAFE=true") {
+		t.Fatalf("startAuxiliaryServers() error = %v, want unsafe pprof error", err)
+	}
+}
+
+func TestStartAuxiliaryServersBindsAllBeforeServing(t *testing.T) {
+	t.Parallel()
+
+	var acceptCalled atomic.Bool
+	first := &testListener{
+		addr: testAddr("127.0.0.1:6060"),
+		accept: func() (net.Conn, error) {
+			acceptCalled.Store(true)
+			return nil, errors.New("unexpected accept")
+		},
+	}
+	bindErr := errors.New("address already in use")
+	listenCalls := 0
+	listen := func(_, _ string) (net.Listener, error) {
+		listenCalls++
+		if listenCalls == 1 {
+			return first, nil
+		}
+		if acceptCalled.Load() {
+			t.Fatal("first server began serving before all auxiliary sockets were bound")
+		}
+		return nil, bindErr
+	}
+
+	_, err := startAuxiliaryServers(
+		context.Background(),
+		func(error) {},
+		envValues(map[string]string{
+			"GOXRPL_PPROF":   "127.0.0.1:6060",
+			"GOXRPL_METRICS": "127.0.0.1:9100",
+		}),
+		listen,
+	)
+	if !errors.Is(err, bindErr) {
+		t.Fatalf("startAuxiliaryServers() error = %v, want %v", err, bindErr)
+	}
+	if !first.closed.Load() {
+		t.Fatal("first listener was not closed after later bind failed")
+	}
+	if acceptCalled.Load() {
+		t.Fatal("first server served despite later bind failure")
+	}
+}
+
+func TestStartAuxiliaryServersServeFailureCancelsContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	serveErr := errors.New("listener failed")
+	listener := &testListener{
+		addr: testAddr("127.0.0.1:9100"),
+		accept: func() (net.Conn, error) {
+			return nil, serveErr
+		},
+	}
+	aux, err := startAuxiliaryServers(
+		ctx,
+		cancel,
+		envValues(map[string]string{"GOXRPL_METRICS": "127.0.0.1:9100"}),
+		func(_, _ string) (net.Listener, error) { return listener, nil },
+	)
+	if err != nil {
+		t.Fatalf("startAuxiliaryServers() error = %v", err)
+	}
+	defer aux.Shutdown()
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("context was not canceled after auxiliary serve failure")
+	}
+	if cause := context.Cause(ctx); cause == nil ||
+		!strings.Contains(cause.Error(), "metrics server") ||
+		!errors.Is(cause, serveErr) {
+		t.Fatalf("context cause = %v, want wrapped metrics serve error", cause)
+	}
+}
+
+func TestStartAuxiliaryServersServesAndShutsDown(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	aux, err := startAuxiliaryServers(
+		ctx,
+		cancel,
+		envValues(map[string]string{
+			"GOXRPL_PPROF":   ":0",
+			"GOXRPL_METRICS": ":0",
+		}),
+		net.Listen,
+	)
+	if err != nil {
+		t.Fatalf("startAuxiliaryServers() error = %v", err)
+	}
+	addresses := aux.Addresses()
+	for name, addr := range addresses {
+		host, _, err := net.SplitHostPort(addr)
+		if err != nil {
+			t.Fatalf("%s address %q: %v", name, addr, err)
+		}
+		if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+			t.Fatalf("%s bound to %q, want loopback", name, addr)
+		}
+	}
+
+	resp, err := http.Get("http://" + addresses["metrics"] + "/metrics")
+	if err != nil {
+		t.Fatalf("GET metrics: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read metrics: %v", err)
+	}
+	if !strings.Contains(string(body), "goxrpl_build_info") {
+		t.Fatalf("metrics body missing goxrpl_build_info:\n%s", body)
+	}
+
+	cancel(context.Canceled)
+	if err := aux.Shutdown(); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	conn, err := net.DialTimeout("tcp", addresses["metrics"], 100*time.Millisecond)
+	if err == nil {
+		conn.Close()
+		t.Fatal("metrics listener still accepted connections after shutdown")
+	}
+}
+
+func envValues(values map[string]string) func(string) string {
+	return func(name string) string {
+		return values[name]
+	}
+}
+
+type testListener struct {
+	addr   net.Addr
+	accept func() (net.Conn, error)
+	closed atomic.Bool
+}
+
+func (l *testListener) Accept() (net.Conn, error) {
+	return l.accept()
+}
+
+func (l *testListener) Close() error {
+	l.closed.Store(true)
+	return nil
+}
+
+func (l *testListener) Addr() net.Addr {
+	return l.addr
+}
+
+type testAddr string
+
+func (a testAddr) Network() string { return "tcp" }
+func (a testAddr) String() string  { return string(a) }

--- a/internal/cli/compare.go
+++ b/internal/cli/compare.go
@@ -27,18 +27,19 @@ type stateFileEntry struct {
 	Decoded map[string]any  `json:"decoded,omitempty"`
 }
 
-var (
-	compareShowAll      bool
-	compareShowDecoded  bool
-	compareFilterType   string
-	compareOutputFormat string
-)
+type compareOptions struct {
+	showAll     bool
+	showDecoded bool
+	filterType  string
+	outputPath  string
+}
 
-// compareCmd represents the compare command
-var compareCmd = &cobra.Command{
-	Use:   "compare <file1> <file2>",
-	Short: "Compare two state dump files",
-	Long: `Compare two state dump JSON files and show differences.
+func newCompareCommand() *cobra.Command {
+	options := &compareOptions{}
+	command := &cobra.Command{
+		Use:   "compare <file1> <file2>",
+		Short: "Compare two state dump files",
+		Long: `Compare two state dump JSON files and show differences.
 
 Supports multiple formats:
 - Fixture state.json files (entries with index/data)
@@ -58,20 +59,19 @@ Examples:
     xrpld compare debug/post_state.json expected_state.json --decoded
     xrpld compare file1.json file2.json --filter AccountRoot
     xrpld compare file1.json file2.json --all`,
-	Args: cobra.ExactArgs(2),
-	RunE: runCompare,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCompare(cmd, args, options)
+		},
+	}
+	command.Flags().BoolVarP(&options.showAll, "all", "a", false, "Show all entries, not just differences")
+	command.Flags().BoolVarP(&options.showDecoded, "decoded", "d", true, "Show decoded JSON (default true)")
+	command.Flags().StringVarP(&options.filterType, "filter", "f", "", "Filter by LedgerEntryType (e.g., AccountRoot, RippleState)")
+	command.Flags().StringVarP(&options.outputPath, "output", "o", "", "Output diff to JSON file")
+	return command
 }
 
-func init() {
-	rootCmd.AddCommand(compareCmd)
-
-	compareCmd.Flags().BoolVarP(&compareShowAll, "all", "a", false, "Show all entries, not just differences")
-	compareCmd.Flags().BoolVarP(&compareShowDecoded, "decoded", "d", true, "Show decoded JSON (default true)")
-	compareCmd.Flags().StringVarP(&compareFilterType, "filter", "f", "", "Filter by LedgerEntryType (e.g., AccountRoot, RippleState)")
-	compareCmd.Flags().StringVarP(&compareOutputFormat, "output", "o", "", "Output diff to JSON file")
-}
-
-func runCompare(cmd *cobra.Command, args []string) error {
+func runCompare(cmd *cobra.Command, args []string, options *compareOptions) error {
 	w := cmd.OutOrStdout()
 	file1Path := args[0]
 	file2Path := args[1]
@@ -102,12 +102,12 @@ func runCompare(cmd *cobra.Command, args []string) error {
 	added, removed, modified, unchanged := compareStates(map1, map2)
 
 	// Apply filter if specified
-	if compareFilterType != "" {
-		added = filterByType(added, compareFilterType)
-		removed = filterByType(removed, compareFilterType)
-		modified = filterModifiedByType(modified, compareFilterType)
-		unchanged = filterByType(unchanged, compareFilterType)
-		fmt.Fprintf(w, "Filtered by type: %s\n\n", compareFilterType)
+	if options.filterType != "" {
+		added = filterByType(added, options.filterType)
+		removed = filterByType(removed, options.filterType)
+		modified = filterModifiedByType(modified, options.filterType)
+		unchanged = filterByType(unchanged, options.filterType)
+		fmt.Fprintf(w, "Filtered by type: %s\n\n", options.filterType)
 	}
 
 	// Print summary
@@ -120,24 +120,24 @@ func runCompare(cmd *cobra.Command, args []string) error {
 
 	// Print details
 	if len(added) > 0 {
-		printAddedEntries(w, added)
+		printAddedEntries(w, added, options)
 	}
 
 	if len(removed) > 0 {
-		printRemovedEntries(w, removed)
+		printRemovedEntries(w, removed, options)
 	}
 
 	if len(modified) > 0 {
-		printModifiedEntries(w, modified)
+		printModifiedEntries(w, modified, options)
 	}
 
-	if compareShowAll && len(unchanged) > 0 {
+	if options.showAll && len(unchanged) > 0 {
 		printUnchangedEntries(w, unchanged)
 	}
 
 	// Output to file if requested
-	if compareOutputFormat != "" {
-		if err := writeDiffJSON(w, compareOutputFormat, added, removed, modified); err != nil {
+	if options.outputPath != "" {
+		if err := writeDiffJSON(w, options.outputPath, added, removed, modified); err != nil {
 			return err
 		}
 	}
@@ -295,31 +295,31 @@ func filterModifiedByType(entries []modifiedEntry, entryType string) []modifiedE
 	return result
 }
 
-func printAddedEntries(w io.Writer, entries []stateEntry) {
+func printAddedEntries(w io.Writer, entries []stateEntry, options *compareOptions) {
 	fmt.Fprintln(w, "================================================================================")
 	fmt.Fprintln(w, "                              ADDED ENTRIES")
 	fmt.Fprintln(w, "================================================================================")
 
 	for i, e := range entries {
 		fmt.Fprintf(w, "\n[+] Entry %d: %s\n", i+1, e.Index)
-		printEntryDetails(w, e.Decoded)
+		printEntryDetails(w, e.Decoded, options)
 	}
 	fmt.Fprintln(w)
 }
 
-func printRemovedEntries(w io.Writer, entries []stateEntry) {
+func printRemovedEntries(w io.Writer, entries []stateEntry, options *compareOptions) {
 	fmt.Fprintln(w, "================================================================================")
 	fmt.Fprintln(w, "                             REMOVED ENTRIES")
 	fmt.Fprintln(w, "================================================================================")
 
 	for i, e := range entries {
 		fmt.Fprintf(w, "\n[-] Entry %d: %s\n", i+1, e.Index)
-		printEntryDetails(w, e.Decoded)
+		printEntryDetails(w, e.Decoded, options)
 	}
 	fmt.Fprintln(w)
 }
 
-func printModifiedEntries(w io.Writer, entries []modifiedEntry) {
+func printModifiedEntries(w io.Writer, entries []modifiedEntry, options *compareOptions) {
 	fmt.Fprintln(w, "================================================================================")
 	fmt.Fprintln(w, "                            MODIFIED ENTRIES")
 	fmt.Fprintln(w, "================================================================================")
@@ -340,7 +340,7 @@ func printModifiedEntries(w io.Writer, entries []modifiedEntry) {
 		fmt.Fprintln(w, "    ---")
 
 		// Show field-by-field diff
-		if compareShowDecoded && e.OldDecoded != nil && e.NewDecoded != nil {
+		if options.showDecoded && e.OldDecoded != nil && e.NewDecoded != nil {
 			printFieldDiff(w, e.OldDecoded, e.NewDecoded, e.ChangedKeys)
 		}
 	}
@@ -364,7 +364,7 @@ func printUnchangedEntries(w io.Writer, entries []stateEntry) {
 	fmt.Fprintln(w)
 }
 
-func printEntryDetails(w io.Writer, decoded map[string]any) {
+func printEntryDetails(w io.Writer, decoded map[string]any, options *compareOptions) {
 	if decoded == nil {
 		fmt.Fprintln(w, "    (unable to decode)")
 		return
@@ -374,12 +374,12 @@ func printEntryDetails(w io.Writer, decoded map[string]any) {
 		fmt.Fprintf(w, "    Type: %s\n", t)
 	}
 
-	if compareShowDecoded {
+	if options.showDecoded {
 		// Print key fields based on entry type
 		printKeyFields(w, decoded)
 
 		// Optionally print full JSON
-		if compareShowAll {
+		if options.showAll {
 			prettyJSON, _ := json.MarshalIndent(decoded, "    ", "  ")
 			fmt.Fprintf(w, "    Full data:\n    %s\n", string(prettyJSON))
 		}

--- a/internal/cli/compare_test.go
+++ b/internal/cli/compare_test.go
@@ -277,9 +277,6 @@ func TestPrintEntries(t *testing.T) {
 		"LedgerEntryType": "AccountRoot", "Account": "rAcct", "Balance": "1", "Sequence": uint32(1), "OwnerCount": uint32(0), "Flags": uint32(0),
 	}}
 
-	prevAll, prevDecoded := compareShowAll, compareShowDecoded
-	defer func() { compareShowAll, compareShowDecoded = prevAll, prevDecoded }()
-
 	tests := []struct {
 		name       string
 		showAll    bool
@@ -330,9 +327,9 @@ func TestPrintEntries(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			compareShowAll, compareShowDecoded = tt.showAll, tt.showDecode
+			options := &compareOptions{showAll: tt.showAll, showDecoded: tt.showDecode}
 			var output bytes.Buffer
-			printAddedEntries(&output, []stateEntry{entry})
+			printAddedEntries(&output, []stateEntry{entry}, options)
 			got := output.String()
 			const banner = "================================================================================\n" +
 				"                              ADDED ENTRIES\n" +
@@ -360,17 +357,13 @@ func TestPrintUnchangedEntries(t *testing.T) {
 }
 
 func TestPrintUnknownFieldsSorted(t *testing.T) {
-	prevAll, prevDecoded := compareShowAll, compareShowDecoded
-	defer func() { compareShowAll, compareShowDecoded = prevAll, prevDecoded }()
-	compareShowAll, compareShowDecoded = false, true
-
 	var output bytes.Buffer
 	printEntryDetails(&output, map[string]any{
 		"LedgerEntryType": "SomethingUnknown",
 		"Zulu":            3,
 		"Alpha":           1,
 		"Middle":          2,
-	})
+	}, &compareOptions{showDecoded: true})
 	want := "    Type: SomethingUnknown\n" +
 		"    Alpha: 1\n" +
 		"    Middle: 2\n" +
@@ -387,9 +380,6 @@ func TestPrintModifiedEntriesDecodedFlag(t *testing.T) {
 		NewDecoded:  map[string]any{"LedgerEntryType": "RippleState", "Balance": "2"},
 		ChangedKeys: []string{"Balance"},
 	}
-	prevDecoded := compareShowDecoded
-	defer func() { compareShowDecoded = prevDecoded }()
-
 	const banner = "================================================================================\n" +
 		"                            MODIFIED ENTRIES\n" +
 		"================================================================================\n" +
@@ -406,9 +396,8 @@ func TestPrintModifiedEntriesDecodedFlag(t *testing.T) {
 		{"raw summary", false, banner + "\n"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			compareShowDecoded = tt.decoded
 			var output bytes.Buffer
-			printModifiedEntries(&output, []modifiedEntry{entry})
+			printModifiedEntries(&output, []modifiedEntry{entry}, &compareOptions{showDecoded: tt.decoded})
 			if got := output.String(); got != tt.want {
 				t.Fatalf("printModifiedEntries() =\n%q\nwant\n%q", got, tt.want)
 			}
@@ -448,14 +437,6 @@ func TestWriteDiffJSON(t *testing.T) {
 }
 
 func TestRunCompare_IdenticalFiles(t *testing.T) {
-	// Reset the command flags to defaults so a prior test cannot trigger the
-	// diff path or a stray file write.
-	prevAll, prevDecoded, prevFilter, prevOut := compareShowAll, compareShowDecoded, compareFilterType, compareOutputFormat
-	defer func() {
-		compareShowAll, compareShowDecoded, compareFilterType, compareOutputFormat = prevAll, prevDecoded, prevFilter, prevOut
-	}()
-	compareShowAll, compareShowDecoded, compareFilterType, compareOutputFormat = false, true, "", ""
-
 	dir := t.TempDir()
 	content := []byte(`{"entries":[{"index":"00000000000000000000000000000000000000000000000000000000000000FF","data":"` + feeSettingsHex(t) + `"}]}`)
 	f1 := filepath.Join(dir, "a.json")
@@ -471,18 +452,12 @@ func TestRunCompare_IdenticalFiles(t *testing.T) {
 	cmd.SetOut(io.Discard)
 	// Identical files produce no differences, so runCompare returns nil
 	// (cmdexit.ErrReported is only returned when there is a diff).
-	if err := runCompare(cmd, []string{f1, f2}); err != nil {
+	if err := runCompare(cmd, []string{f1, f2}, &compareOptions{showDecoded: true}); err != nil {
 		t.Fatalf("runCompare on identical files: %v", err)
 	}
 }
 
 func TestRunCompare_DiffReportsExit(t *testing.T) {
-	prevAll, prevDecoded, prevFilter, prevOut := compareShowAll, compareShowDecoded, compareFilterType, compareOutputFormat
-	defer func() {
-		compareShowAll, compareShowDecoded, compareFilterType, compareOutputFormat = prevAll, prevDecoded, prevFilter, prevOut
-	}()
-	compareShowAll, compareShowDecoded, compareFilterType, compareOutputFormat = false, true, "", ""
-
 	dir := t.TempDir()
 	f1 := filepath.Join(dir, "a.json")
 	f2 := filepath.Join(dir, "b.json")
@@ -495,7 +470,7 @@ func TestRunCompare_DiffReportsExit(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)
-	if err := runCompare(cmd, []string{f1, f2}); !errors.Is(err, cmdexit.ErrReported) {
+	if err := runCompare(cmd, []string{f1, f2}, &compareOptions{showDecoded: true}); !errors.Is(err, cmdexit.ErrReported) {
 		t.Fatalf("expected cmdexit.ErrReported on diff, got %v", err)
 	}
 }

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -15,67 +15,70 @@ const generatedValidatorsFilename = "validators.toml"
 type generatedFile struct {
 	path string
 	data []byte
+	mode os.FileMode
 }
 
-var (
-	generateNetwork string
-	generateOutput  string
-)
+type generateOptions struct {
+	network string
+	output  string
+}
 
-var generateConfigCmd = &cobra.Command{
-	Use:   "generate-config",
-	Short: "Generate a complete configuration file",
-	Long: `Generate a complete xrpld.toml configuration file with all required fields.
+func newGenerateConfigCommand() *cobra.Command {
+	options := &generateOptions{}
+	command := &cobra.Command{
+		Use:   "generate-config",
+		Short: "Generate a complete configuration file",
+		Long: `Generate a complete xrpld.toml configuration file with all required fields.
 The generated file is a working starting point that passes validation.
 Review and adjust the values before using it to start the server.`,
-	RunE: runGenerateConfig,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGenerateConfig(cmd, options)
+		},
+	}
+	command.Flags().StringVar(&options.network, "network", "main", "network type: main, testnet, or devnet")
+	command.Flags().StringVar(&options.output, "output", "xrpld.toml", "output file path")
+	return command
 }
 
-func init() {
-	rootCmd.AddCommand(generateConfigCmd)
-
-	generateConfigCmd.Flags().StringVar(&generateNetwork, "network", "main", "network type: main, testnet, or devnet")
-	generateConfigCmd.Flags().StringVar(&generateOutput, "output", "xrpld.toml", "output file path")
-}
-
-func runGenerateConfig(cmd *cobra.Command, args []string) error {
+func runGenerateConfig(cmd *cobra.Command, options *generateOptions) error {
 	var networkID string
-	switch generateNetwork {
+	switch options.network {
 	case "main", "testnet", "devnet":
-		networkID = generateNetwork
+		networkID = options.network
 	default:
-		return fmt.Errorf("unknown network %q (valid: main, testnet, devnet)", generateNetwork)
+		return fmt.Errorf("unknown network %q (valid: main, testnet, devnet)", options.network)
 	}
 
 	content := generateConfigContent(networkID)
 	validatorsContent, hasValidators := generateValidatorsContent(networkID)
 	files := make([]generatedFile, 0, 2)
 	if hasValidators {
-		validatorsOutput := filepath.Join(filepath.Dir(generateOutput), generatedValidatorsFilename)
-		if filepath.Clean(validatorsOutput) == filepath.Clean(generateOutput) {
+		validatorsOutput := filepath.Join(filepath.Dir(options.output), generatedValidatorsFilename)
+		if filepath.Clean(validatorsOutput) == filepath.Clean(options.output) {
 			return fmt.Errorf("output path must not be named %s", generatedValidatorsFilename)
 		}
-		files = append(files, generatedFile{path: validatorsOutput, data: []byte(validatorsContent)})
+		files = append(files, generatedFile{path: validatorsOutput, data: []byte(validatorsContent), mode: 0o644})
 	}
-	files = append(files, generatedFile{path: generateOutput, data: []byte(content)})
+	files = append(files, generatedFile{path: options.output, data: []byte(content), mode: 0o600})
 	if err := publishGeneratedFiles(files, os.Link); err != nil {
 		return err
 	}
 
 	w := cmd.OutOrStdout()
-	fmt.Fprintf(w, "Configuration file generated: %s\n", generateOutput)
+	fmt.Fprintf(w, "Configuration file generated: %s\n", options.output)
 	fmt.Fprintf(w, "  Network: %s\n", networkID)
 	if hasValidators {
-		fmt.Fprintf(w, "  Validators: %s\n", filepath.Join(filepath.Dir(generateOutput), generatedValidatorsFilename))
+		fmt.Fprintf(w, "  Validators: %s\n", filepath.Join(filepath.Dir(options.output), generatedValidatorsFilename))
 	}
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Next steps:")
 	fmt.Fprintln(w, "  1. Review and adjust the configuration values")
 	if networkID == "devnet" {
 		fmt.Fprintln(w, "  2. Configure trusted validators, or start in standalone mode:")
-		fmt.Fprintln(w, "     xrpld server --standalone --conf", generateOutput)
+		fmt.Fprintln(w, "     xrpld server --standalone --conf", options.output)
 	} else {
-		fmt.Fprintln(w, "  2. Start the server: xrpld server --conf", generateOutput)
+		fmt.Fprintln(w, "  2. Start the server: xrpld server --conf", options.output)
 	}
 	return nil
 }
@@ -83,6 +86,7 @@ func runGenerateConfig(cmd *cobra.Command, args []string) error {
 func publishGeneratedFiles(files []generatedFile, link func(string, string) error) error {
 	seen := make(map[string]struct{}, len(files))
 	pending := make([]generatedFile, 0, len(files))
+	permissionUpdates := make([]generatedFile, 0, len(files))
 	for _, file := range files {
 		path, err := filepath.Abs(file.path)
 		if err != nil {
@@ -104,6 +108,10 @@ func publishGeneratedFiles(files []generatedFile, link func(string, string) erro
 			if !bytes.Equal(existing, file.data) {
 				return fmt.Errorf("output already exists with different content: %s", file.path)
 			}
+			if currentMode := info.Mode().Perm(); currentMode&^file.mode != 0 {
+				file.mode = currentMode & file.mode
+				permissionUpdates = append(permissionUpdates, file)
+			}
 			continue
 		} else if !os.IsNotExist(err) {
 			return fmt.Errorf("inspect output path %s: %w", file.path, err)
@@ -111,6 +119,11 @@ func publishGeneratedFiles(files []generatedFile, link func(string, string) erro
 		pending = append(pending, file)
 	}
 	files = pending
+	for _, file := range permissionUpdates {
+		if err := os.Chmod(file.path, file.mode); err != nil {
+			return fmt.Errorf("tighten output permissions %s: %w", file.path, err)
+		}
+	}
 
 	temps := make([]string, len(files))
 	defer func() {
@@ -126,7 +139,7 @@ func publishGeneratedFiles(files []generatedFile, link func(string, string) erro
 			return fmt.Errorf("stage output %s: %w", file.path, err)
 		}
 		temps[i] = tmp.Name()
-		if err := tmp.Chmod(0o644); err != nil { //nolint:gosec // generated configuration is intentionally world-readable
+		if err := tmp.Chmod(file.mode); err != nil {
 			_ = tmp.Close()
 			return fmt.Errorf("set output permissions %s: %w", file.path, err)
 		}

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -52,16 +52,12 @@ func TestGenerateConfigContent(t *testing.T) {
 }
 
 func TestRunGenerateConfig(t *testing.T) {
-	prevNet, prevOut := generateNetwork, generateOutput
-	defer func() { generateNetwork, generateOutput = prevNet, prevOut }()
-
 	out := filepath.Join(t.TempDir(), "xrpld.toml")
-	generateNetwork = "testnet"
-	generateOutput = out
+	options := &generateOptions{network: "testnet", output: out}
 
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)
-	if err := runGenerateConfig(cmd, nil); err != nil {
+	if err := runGenerateConfig(cmd, options); err != nil {
 		t.Fatalf("runGenerateConfig: %v", err)
 	}
 
@@ -88,23 +84,33 @@ func TestRunGenerateConfig(t *testing.T) {
 		!strings.Contains(string(validatorsData), "ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860") {
 		t.Error("testnet validators config does not contain only the altnet trust anchor")
 	}
+	configInfo, err := os.Stat(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := configInfo.Mode().Perm(); got != 0o600 {
+		t.Errorf("main config permissions = %o, want 600", got)
+	}
+	validatorsInfo, err := os.Stat(filepath.Join(filepath.Dir(out), generatedValidatorsFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := validatorsInfo.Mode().Perm(); got != 0o644 {
+		t.Errorf("validators permissions = %o, want 644", got)
+	}
 }
 
 func TestRunGenerateConfig_DoesNotOverwriteExistingOutput(t *testing.T) {
-	prevNet, prevOut := generateNetwork, generateOutput
-	defer func() { generateNetwork, generateOutput = prevNet, prevOut }()
-
 	dir := t.TempDir()
 	validatorsPath := filepath.Join(dir, generatedValidatorsFilename)
 	if err := os.WriteFile(validatorsPath, []byte("operator-owned\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	generateNetwork = "testnet"
-	generateOutput = filepath.Join(dir, "xrpld.toml")
+	options := &generateOptions{network: "testnet", output: filepath.Join(dir, "xrpld.toml")}
 
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)
-	if err := runGenerateConfig(cmd, nil); err == nil {
+	if err := runGenerateConfig(cmd, options); err == nil {
 		t.Fatal("expected existing validators output to be rejected")
 	}
 	data, err := os.ReadFile(validatorsPath)
@@ -114,15 +120,12 @@ func TestRunGenerateConfig_DoesNotOverwriteExistingOutput(t *testing.T) {
 	if string(data) != "operator-owned\n" {
 		t.Fatal("existing validators file was modified")
 	}
-	if _, err := os.Stat(generateOutput); !os.IsNotExist(err) {
+	if _, err := os.Stat(options.output); !os.IsNotExist(err) {
 		t.Fatalf("config output exists after rejected generation: %v", err)
 	}
 }
 
 func TestRunGenerateConfig_RecoversIdenticalValidatorsOutput(t *testing.T) {
-	prevNet, prevOut := generateNetwork, generateOutput
-	defer func() { generateNetwork, generateOutput = prevNet, prevOut }()
-
 	dir := t.TempDir()
 	validatorsContent, ok := generateValidatorsContent("testnet")
 	if !ok {
@@ -131,24 +134,47 @@ func TestRunGenerateConfig_RecoversIdenticalValidatorsOutput(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, generatedValidatorsFilename), []byte(validatorsContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	generateNetwork = "testnet"
-	generateOutput = filepath.Join(dir, "xrpld.toml")
+	options := &generateOptions{network: "testnet", output: filepath.Join(dir, "xrpld.toml")}
 
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)
-	if err := runGenerateConfig(cmd, nil); err != nil {
+	if err := runGenerateConfig(cmd, options); err != nil {
 		t.Fatalf("runGenerateConfig: %v", err)
 	}
-	if _, err := os.Stat(generateOutput); err != nil {
+	if _, err := os.Stat(options.output); err != nil {
 		t.Fatalf("config output was not recovered: %v", err)
+	}
+}
+
+func TestRunGenerateConfig_TightensIdenticalMainConfigPermissions(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "xrpld.toml")
+	if err := os.WriteFile(output, []byte(generateConfigContent("devnet")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(output, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
+	if err := runGenerateConfig(cmd, &generateOptions{network: "devnet", output: output}); err != nil {
+		t.Fatalf("runGenerateConfig: %v", err)
+	}
+
+	info, err := os.Stat(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("main config permissions = %o, want 600", got)
 	}
 }
 
 func TestPublishGeneratedFiles_RollsBackPartialPublish(t *testing.T) {
 	dir := t.TempDir()
 	files := []generatedFile{
-		{path: filepath.Join(dir, "validators.toml"), data: []byte("validators")},
-		{path: filepath.Join(dir, "xrpld.toml"), data: []byte("config")},
+		{path: filepath.Join(dir, "validators.toml"), data: []byte("validators"), mode: 0o644},
+		{path: filepath.Join(dir, "xrpld.toml"), data: []byte("config"), mode: 0o600},
 	}
 	links := 0
 	err := publishGeneratedFiles(files, func(oldPath, newPath string) error {

--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/observability"
 	"github.com/LeJamon/go-xrpl/version"
@@ -53,20 +52,9 @@ func newMetricsRegistry() *prometheus.Registry {
 	return reg
 }
 
-// startMetricsServer serves Prometheus metrics at /metrics on addr. It
-// mirrors observability.StartPProf: a standalone auxiliary HTTP server enabled
-// out-of-band (via the GOXRPL_METRICS env var) and never mounted on the
-// public JSON-RPC ports, keeping scrape traffic and internal telemetry off
-// the client-facing API surface.
-func startMetricsServer(addr string) error {
+func newMetricsHandler() http.Handler {
 	reg := newMetricsRegistry()
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}))
-
-	srv := &http.Server{
-		Addr:              addr,
-		Handler:           mux,
-		ReadHeaderTimeout: 5 * time.Second,
-	}
-	return srv.ListenAndServe()
+	return mux
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 
 	"github.com/LeJamon/go-xrpl/config"
@@ -13,99 +16,131 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	// Global flags
+type IOStreams struct {
+	In     io.Reader
+	Out    io.Writer
+	ErrOut io.Writer
+}
+
+type rootOptions struct {
 	configFile string
 	debug      bool
 	verbose    bool
+}
 
-	// globalConfig holds the loaded configuration, available to all subcommands.
-	// It is nil until initConfig() runs (which happens before any command's Run function).
-	globalConfig *config.Config
+type commandDependencies struct {
+	loadConfig func(config.Paths) (*config.Config, error)
+	httpClient *http.Client
+	runNode    nodeRunFunc
+}
 
-	// globalConfigErr captures any error from initConfig so commands that
-	// don't need config (help, generate-config) can still run and commands
-	// that do need it can surface the failure via their RunE return.
-	globalConfigErr error
-)
+type application struct {
+	options rootOptions
+	deps    commandDependencies
+}
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "xrpld",
-	Short: "go-xrpl - XRPL Node Implementation in Go",
-	Long: `go-xrpl is an idiomatic Go implementation of an XRPL (XRP Ledger) client
+func defaultCommandDependencies() commandDependencies {
+	return commandDependencies{
+		loadConfig: config.LoadConfig,
+		httpClient: newRPCHTTPClient(),
+		runNode:    runNode,
+	}
+}
+
+func NewRootCommand(streams IOStreams) *cobra.Command {
+	return newRootCommand(streams, defaultCommandDependencies())
+}
+
+func newRootCommand(streams IOStreams, deps commandDependencies) *cobra.Command {
+	all.RegisterAll()
+	streams = resolvedStreams(streams)
+	if deps.loadConfig == nil {
+		deps.loadConfig = config.LoadConfig
+	}
+	if deps.httpClient == nil {
+		deps.httpClient = newRPCHTTPClient()
+	}
+	if deps.runNode == nil {
+		deps.runNode = runNode
+	}
+
+	app := &application{deps: deps}
+	defaultServerOptions := &serverOptions{}
+	root := &cobra.Command{
+		Use:   "xrpld",
+		Short: "go-xrpl - XRPL Node Implementation in Go",
+		Long: `go-xrpl is an idiomatic Go implementation of an XRPL (XRP Ledger) client
 with concurrent processing capabilities. This is NOT a direct translation of the
 C++ rippled implementation but rather a native Go implementation that follows
 Go conventions and patterns while maintaining protocol compatibility.`,
-	Version: version.Version,
+		Version:       version.Version,
+		Args:          cobra.NoArgs,
+		RunE:          app.serverRunner(defaultServerOptions),
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+	root.SetIn(streams.In)
+	root.SetOut(streams.Out)
+	root.SetErr(streams.ErrOut)
 
-	// Execute() is the single error printer: cobra must not also print the
-	// error (it would duplicate) nor dump usage on a runtime failure.
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	root.PersistentFlags().StringVar(&app.options.configFile, "conf", "", "configuration file path (required by server, rpc)")
+	root.PersistentFlags().BoolVar(&app.options.debug, "debug", false, "enable normally suppressed debug logging")
+	root.PersistentFlags().BoolVarP(&app.options.verbose, "verbose", "v", false, "verbose logging")
+	bindServerFlags(root.Flags(), defaultServerOptions)
+
+	root.AddCommand(
+		app.newServerCommand(defaultServerOptions),
+		newCompareCommand(),
+		newGenerateConfigCommand(),
+		app.newRPCCommand(),
+		newVersionCommand(),
+	)
+	for _, command := range replaytool.NewCommands() {
+		root.AddCommand(command)
+	}
+	return root
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	// Register every transaction type with the tx registry before any
-	// subcommand can run. Safe to call multiple times.
-	all.RegisterAll()
-
-	err := rootCmd.Execute()
-	if err == nil {
-		return
+func resolvedStreams(streams IOStreams) IOStreams {
+	if streams.In == nil {
+		streams.In = os.Stdin
 	}
-	// cmdexit.ErrReported means the command already printed its own failure
-	// report (a replay divergence, a compare diff); only the exit code is
-	// left. Any other error is printed here — the single error printer, since
-	// rootCmd sets SilenceErrors.
-	if !errors.Is(err, cmdexit.ErrReported) {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	if streams.Out == nil {
+		streams.Out = os.Stdout
 	}
-	os.Exit(1)
+	if streams.ErrOut == nil {
+		streams.ErrOut = os.Stderr
+	}
+	return streams
 }
 
-func init() {
-	cobra.OnInitialize(initConfig)
-
-	// Global flags — operational concerns only
-	rootCmd.PersistentFlags().StringVar(&configFile, "conf", "", "configuration file path (required by server, rpc)")
-	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable normally suppressed debug logging")
-	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose logging")
-
-	// The replay developer commands live in their own package; register
-	// them here rather than via self-registration into this package's root.
-	for _, c := range replaytool.NewCommands() {
-		rootCmd.AddCommand(c)
-	}
-}
-
-// initConfig loads the configuration file when --conf is set; load
-// errors land in globalConfigErr so commands that don't need config
-// (help, generate-config) still run.
-func initConfig() {
-	globalConfig = nil
-	globalConfigErr = nil
-	if configFile == "" {
-		return
-	}
-	cfg, err := config.LoadConfig(config.Paths{Main: configFile, SkipValidators: standalone})
-	if err != nil {
-		globalConfigErr = fmt.Errorf("configuration error: %w", err)
-		return
-	}
-	globalConfig = cfg
-}
-
-// requireConfig returns the loaded config or an error suitable for
-// returning from a cobra RunE.
-func requireConfig() (*config.Config, error) {
-	if globalConfigErr != nil {
-		return nil, globalConfigErr
-	}
-	if globalConfig == nil {
+func (a *application) requireConfig(skipValidators bool) (*config.Config, error) {
+	if a.options.configFile == "" {
 		return nil, fmt.Errorf("missing --conf flag: this command requires a configuration file")
 	}
-	return globalConfig, nil
+	cfg, err := a.deps.loadConfig(config.Paths{
+		Main:           a.options.configFile,
+		SkipValidators: skipValidators,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("configuration error: %w", err)
+	}
+	return cfg, nil
+}
+
+func Run(ctx context.Context, args []string, streams IOStreams) int {
+	root := NewRootCommand(streams)
+	return executeRoot(ctx, root, args)
+}
+
+func executeRoot(ctx context.Context, root *cobra.Command, args []string) int {
+	root.SetArgs(args)
+	_, err := root.ExecuteContextC(ctx)
+	if err == nil {
+		return 0
+	}
+	if !errors.Is(err, cmdexit.ErrReported) {
+		fmt.Fprintf(root.ErrOrStderr(), "Error: %v\n", err)
+	}
+	return 1
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,34 +1,162 @@
 package cli
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/config"
+	"github.com/LeJamon/go-xrpl/internal/cmdexit"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestInitConfigStandaloneSkipsValidators(t *testing.T) {
-	previousConfigFile := configFile
-	previousStandalone := standalone
-	previousConfig := globalConfig
-	previousConfigErr := globalConfigErr
-	t.Cleanup(func() {
-		configFile = previousConfigFile
-		standalone = previousStandalone
-		globalConfig = previousConfig
-		globalConfigErr = previousConfigErr
+func TestRequireConfigStandaloneSkipsValidators(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "xrpld.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(generateConfigContent("main")), 0o600))
+
+	app := application{
+		options: rootOptions{configFile: configPath},
+		deps:    commandDependencies{loadConfig: config.LoadConfig},
+	}
+	cfg, err := app.requireConfig(true)
+	require.NoError(t, err)
+	assert.Empty(t, cfg.Validators.Validators)
+	assert.Empty(t, cfg.Validators.ValidatorListKeys)
+}
+
+func TestNewRootCommandHasIsolatedState(t *testing.T) {
+	var firstOut, secondOut bytes.Buffer
+	first := NewRootCommand(IOStreams{Out: &firstOut, ErrOut: &firstOut})
+	second := NewRootCommand(IOStreams{Out: &secondOut, ErrOut: &secondOut})
+
+	first.SetArgs([]string{"--debug", "version"})
+	_, err := first.ExecuteC()
+	require.NoError(t, err)
+
+	debugValue, err := second.PersistentFlags().GetBool("debug")
+	require.NoError(t, err)
+	assert.False(t, debugValue)
+	compare, _, err := second.Find([]string{"compare"})
+	require.NoError(t, err)
+	showAll, err := compare.Flags().GetBool("all")
+	require.NoError(t, err)
+	assert.False(t, showAll)
+	generate, _, err := second.Find([]string{"generate-config"})
+	require.NoError(t, err)
+	outputPath, err := generate.Flags().GetString("output")
+	require.NoError(t, err)
+	assert.Equal(t, "xrpld.toml", outputPath)
+	rpc, _, err := second.Find([]string{"rpc"})
+	require.NoError(t, err)
+	allowInsecure, err := rpc.PersistentFlags().GetBool(insecureRPCFlag)
+	require.NoError(t, err)
+	assert.False(t, allowInsecure)
+
+	second.SetArgs([]string{"version"})
+	_, err = second.ExecuteC()
+	require.NoError(t, err)
+	assert.Contains(t, firstOut.String(), "go-xrpl version")
+	assert.Contains(t, secondOut.String(), "go-xrpl version")
+}
+
+func TestRootCommandsExecuteConcurrently(t *testing.T) {
+	const commandCount = 8
+
+	var waitGroup sync.WaitGroup
+	errors := make(chan error, commandCount)
+	for i := range commandCount {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+
+			root := NewRootCommand(IOStreams{Out: io.Discard, ErrOut: io.Discard})
+			if i%2 == 0 {
+				root.SetArgs([]string{"--debug", "version"})
+			} else {
+				root.SetArgs([]string{"version"})
+			}
+			_, err := root.ExecuteC()
+			errors <- err
+		}()
+	}
+	waitGroup.Wait()
+	close(errors)
+
+	for err := range errors {
+		require.NoError(t, err)
+	}
+}
+
+func TestRootCommandNoArgumentContracts(t *testing.T) {
+	for _, args := range [][]string{
+		{"version", "extra"},
+		{"generate-config", "extra"},
+		{"server", "extra"},
+		{"extra"},
+	} {
+		root := NewRootCommand(IOStreams{Out: bytes.NewBuffer(nil), ErrOut: bytes.NewBuffer(nil)})
+		root.SetArgs(args)
+		if _, err := root.ExecuteC(); err == nil {
+			t.Errorf("ExecuteC(%q) succeeded", args)
+		}
+	}
+}
+
+func TestRunExitBehavior(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := Run(context.Background(), []string{"version"}, IOStreams{Out: &stdout, ErrOut: &stderr})
+		assert.Equal(t, 0, code)
+		assert.Contains(t, stdout.String(), "go-xrpl version")
+		assert.Empty(t, stderr.String())
 	})
 
-	configFile = filepath.Join(t.TempDir(), "xrpld.toml")
-	require.NoError(t, os.WriteFile(configFile, []byte(generateConfigContent("main")), 0o600))
-	standalone = true
+	t.Run("ordinary error is printed once", func(t *testing.T) {
+		var stderr bytes.Buffer
+		code := Run(context.Background(), []string{"does-not-exist"}, IOStreams{
+			Out:    bytes.NewBuffer(nil),
+			ErrOut: &stderr,
+		})
+		assert.Equal(t, 1, code)
+		assert.Equal(t, 1, strings.Count(stderr.String(), "Error:"))
+		assert.Contains(t, stderr.String(), `unknown command "does-not-exist"`)
+	})
 
-	initConfig()
+	t.Run("reported error is not printed again", func(t *testing.T) {
+		var stderr bytes.Buffer
+		root := &cobra.Command{Use: "test", SilenceErrors: true, SilenceUsage: true}
+		root.SetErr(&stderr)
+		root.AddCommand(&cobra.Command{
+			Use: "reported",
+			RunE: func(*cobra.Command, []string) error {
+				return cmdexit.ErrReported
+			},
+		})
+		code := executeRoot(context.Background(), root, []string{"reported"})
+		assert.Equal(t, 1, code)
+		assert.Empty(t, stderr.String())
+	})
+}
 
-	require.NoError(t, globalConfigErr)
-	require.NotNil(t, globalConfig)
-	assert.Empty(t, globalConfig.Validators.Validators)
-	assert.Empty(t, globalConfig.Validators.ValidatorListKeys)
+func TestConfigLoadsOnlyForCommandsThatRequireIt(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.toml")
+
+	versionRoot := NewRootCommand(IOStreams{Out: bytes.NewBuffer(nil), ErrOut: bytes.NewBuffer(nil)})
+	versionRoot.SetArgs([]string{"--conf", missing, "version"})
+	if _, err := versionRoot.ExecuteC(); err != nil {
+		t.Fatalf("version with missing --conf: %v", err)
+	}
+
+	rpcRoot := NewRootCommand(IOStreams{Out: bytes.NewBuffer(nil), ErrOut: bytes.NewBuffer(nil)})
+	rpcRoot.SetArgs([]string{"--conf", missing, "rpc", "ping"})
+	if _, err := rpcRoot.ExecuteC(); err == nil || !strings.Contains(err.Error(), "configuration error") {
+		t.Fatalf("rpc with missing --conf error = %v, want configuration error", err)
+	}
 }

--- a/internal/cli/rpc.go
+++ b/internal/cli/rpc.go
@@ -20,29 +20,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// rpcCmd represents the rpc command group
-var rpcCmd = &cobra.Command{
-	Use:   "rpc",
-	Short: "RPC client commands",
-	Long: `Forward RPC commands to a running go-xrpl node over HTTP JSON-RPC.
+func (a *application) newRPCCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "rpc",
+		Short: "RPC client commands",
+		Long: `Forward RPC commands to a running go-xrpl node over HTTP JSON-RPC.
 
 The target node's host and port are read from the HTTP port in --conf, so a
 config file is required. Start the node with 'xrpld server --conf ...' first;
 admin methods (stop, peers, feature, ...) succeed when the configured HTTP
 port grants admin to localhost.`,
-}
-
-func init() {
-	rootCmd.AddCommand(rpcCmd)
-	for _, spec := range rpcCommandSpecs {
-		rpcCmd.AddCommand(spec.command())
 	}
-	rpcCmd.AddCommand(jsonCmd)
-	rpcCmd.PersistentFlags().Bool(
-		"allow-insecure-rpc-credentials",
+	for _, spec := range rpcCommandSpecs {
+		command.AddCommand(spec.commandWithRunner(nil, a.runRPC))
+	}
+	command.AddCommand(newJSONCommand(a.runRPC))
+	command.PersistentFlags().Bool(
+		insecureRPCFlag,
 		false,
 		"allow credentials to be sent over cleartext HTTP to a non-loopback host",
 	)
+	return command
 }
 
 const (
@@ -53,11 +51,15 @@ const (
 	adminPasswordParam  = "admin_password"
 )
 
-var rpcHTTPClient = &http.Client{
-	CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-		return http.ErrUseLastResponse
-	},
+func newRPCHTTPClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 }
+
+type rpcRunFunc func(*cobra.Command, string, any) error
 
 // rpcCommandSpec is a single `xrpld rpc <name>` subcommand. The command name
 // and (by default) the RPC method are the first token of Use; params builds
@@ -82,10 +84,10 @@ func (s rpcCommandSpec) methodName() string {
 }
 
 func (s rpcCommandSpec) command() *cobra.Command {
-	return s.commandWithSecretPrompt(nil)
+	return s.commandWithRunner(nil, nil)
 }
 
-func (s rpcCommandSpec) commandWithSecretPrompt(ask rpcSecretPrompt) *cobra.Command {
+func (s rpcCommandSpec) commandWithRunner(ask rpcSecretPrompt, run rpcRunFunc) *cobra.Command {
 	method := s.methodName()
 	args := s.args
 	if args == nil {
@@ -115,7 +117,10 @@ func (s rpcCommandSpec) commandWithSecretPrompt(ask rpcSecretPrompt) *cobra.Comm
 					return err
 				}
 			}
-			return runRPC(cmd, method, params)
+			if run == nil {
+				return fmt.Errorf("RPC command is not attached to a root command")
+			}
+			return run(cmd, method, params)
 		},
 	}
 	if s.paramsWithSecret != nil {
@@ -128,12 +133,12 @@ func (s rpcCommandSpec) commandWithSecretPrompt(ask rpcSecretPrompt) *cobra.Comm
 // prints the result. The request uses XRPL's rippled-style envelope —
 // {"method": m, "params": [p]} — and the response is the {"result": {...}}
 // object the server returns.
-func runRPC(cmd *cobra.Command, method string, params any) error {
-	cfg, err := requireConfig()
+func (a *application) runRPC(cmd *cobra.Command, method string, params any) error {
+	cfg, err := a.requireConfig(false)
 	if err != nil {
 		return err
 	}
-	endpoint, port, err := rpcEndpoint(cfg)
+	endpoint, port, err := rpcEndpoint(cfg, a.options.configFile)
 	if err != nil {
 		return err
 	}
@@ -176,7 +181,7 @@ func runRPC(cmd *cobra.Command, method string, params any) error {
 		httpReq.SetBasicAuth(user, pass)
 	}
 
-	resp, err := rpcHTTPClient.Do(httpReq)
+	resp, err := a.deps.httpClient.Do(httpReq)
 	if err != nil {
 		return fmt.Errorf("connecting to node at %s: %w (is the server running?)", endpoint, err)
 	}
@@ -196,10 +201,10 @@ func runRPC(cmd *cobra.Command, method string, params any) error {
 // rpcEndpoint resolves the JSON-RPC URL to POST to from the HTTP ports in the
 // config. An admin port is preferred so admin methods work; ports are sorted
 // by name for deterministic selection.
-func rpcEndpoint(cfg *config.Config) (string, *config.PortConfig, error) {
+func rpcEndpoint(cfg *config.Config, configPath string) (string, *config.PortConfig, error) {
 	ports := cfg.HTTPPorts()
 	if len(ports) == 0 {
-		return "", nil, fmt.Errorf("no HTTP port configured in %s; 'xrpld rpc' forwards to a running node's JSON-RPC port", configFile)
+		return "", nil, fmt.Errorf("no HTTP port configured in %s; 'xrpld rpc' forwards to a running node's JSON-RPC port", configPath)
 	}
 
 	names := make([]string, 0, len(ports))
@@ -1178,17 +1183,20 @@ deprecated and emit a warning.`,
 	{use: "validator_list_sites", short: "Get validator list sites"},
 }
 
-// jsonCmd is the generic escape hatch: it takes the method name and a raw JSON
-// params object, so it cannot be expressed by the fixed-method table above.
-var jsonCmd = &cobra.Command{
-	Use:   "json <method> <json_params>",
-	Short: "Execute any RPC method with JSON parameters",
-	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		params, err := parseJSONObject("parameters", args[1])
-		if err != nil {
-			return err
-		}
-		return runRPC(cmd, args[0], params)
-	},
+func newJSONCommand(run rpcRunFunc) *cobra.Command {
+	return &cobra.Command{
+		Use:   "json <method> <json_params>",
+		Short: "Execute any RPC method with JSON parameters",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			params, err := parseJSONObject("parameters", args[1])
+			if err != nil {
+				return err
+			}
+			if run == nil {
+				return fmt.Errorf("RPC command is not attached to a root command")
+			}
+			return run(cmd, args[0], params)
+		},
+	}
 }

--- a/internal/cli/rpc_test.go
+++ b/internal/cli/rpc_test.go
@@ -165,7 +165,7 @@ func TestRPCEndpointSelection(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			endpoint, _, err := rpcEndpoint(&config.Config{Ports: test.ports})
+			endpoint, _, err := rpcEndpoint(&config.Config{Ports: test.ports}, "test.toml")
 			if test.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
 					t.Fatalf("rpcEndpoint() error = %v, want error containing %q", err, test.wantErr)
@@ -408,8 +408,6 @@ func TestRPCCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 		_, _ = io.WriteString(w, successfulRPCResponse)
 	}))
 	defer server.Close()
-	setTestConfig(t, server.Listener.Addr().String())
-
 	tests := []struct {
 		name   string
 		method string
@@ -448,7 +446,8 @@ func TestRPCCommandsRejectInvalidInputBeforeRequest(t *testing.T) {
 
 	t.Run("generic JSON", func(t *testing.T) {
 		before := requests.Load()
-		if err := jsonCmd.RunE(jsonCmd, []string{"server_info", "{"}); err == nil {
+		command := newJSONCommand(nil)
+		if err := command.RunE(command, []string{"server_info", "{"}); err == nil {
 			t.Fatal("json command accepted malformed JSON")
 		}
 		if got := requests.Load(); got != before {
@@ -470,9 +469,9 @@ func TestRunRPCAuthentication(t *testing.T) {
 		port := testPort(t, server.Listener.Addr().String())
 		port.AdminUser = "admin"
 		port.AdminPassword = "secret"
-		setTestRPCPorts(t, rpcPorts(port))
+		app := testRPCApplication(rpcPorts(port), nil)
 
-		if err := runRPC(newRPCCommand(), "stop", nil); err != nil {
+		if err := app.runRPC(newRPCCommand(), "stop", nil); err != nil {
 			t.Fatalf("runRPC(): %v", err)
 		}
 		assertJSONEqual(
@@ -498,9 +497,9 @@ func TestRunRPCAuthentication(t *testing.T) {
 		port := testPort(t, server.Listener.Addr().String())
 		port.User = "http-user"
 		port.Password = "http-password"
-		setTestRPCPorts(t, rpcPorts(port))
+		app := testRPCApplication(rpcPorts(port), nil)
 
-		if err := runRPC(newRPCCommand(), "ping", nil); err != nil {
+		if err := app.runRPC(newRPCCommand(), "ping", nil); err != nil {
 			t.Fatalf("runRPC(): %v", err)
 		}
 		if !gotAuth || gotUser != "http-user" || gotPassword != "http-password" {
@@ -511,21 +510,21 @@ func TestRunRPCAuthentication(t *testing.T) {
 }
 
 func TestRunRPCRejectsCleartextCredentialsToNonLoopback(t *testing.T) {
-	setTestRPCPorts(t, rpcPorts(config.PortConfig{
+	ports := rpcPorts(config.PortConfig{
 		IP:       "rpc.example.test",
 		Port:     5005,
 		Protocol: "http",
 		User:     "http-user",
 		Password: "http-password",
-	}))
+	})
 
 	var requests atomic.Int32
-	setTestRPCClient(t, &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+	app := testRPCApplication(ports, &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		requests.Add(1)
 		return rpcHTTPResponse(http.StatusOK, successfulRPCResponse), nil
 	})})
 
-	err := runRPC(newRPCCommand(), "ping", nil)
+	err := app.runRPC(newRPCCommand(), "ping", nil)
 	if err == nil || !strings.Contains(err.Error(), "refusing to send RPC credentials over cleartext HTTP") {
 		t.Fatalf("runRPC() error = %v, want cleartext credential refusal", err)
 	}
@@ -538,7 +537,7 @@ func TestRunRPCRejectsCleartextCredentialsToNonLoopback(t *testing.T) {
 	if err := command.Flags().Set(insecureRPCFlag, "true"); err != nil {
 		t.Fatal(err)
 	}
-	if err := runRPC(command, "ping", nil); err != nil {
+	if err := app.runRPC(command, "ping", nil); err != nil {
 		t.Fatalf("runRPC() with --%s: %v", insecureRPCFlag, err)
 	}
 	if requests.Load() != 1 {
@@ -558,9 +557,9 @@ func TestRunRPCDoesNotFollowRedirects(t *testing.T) {
 		http.Redirect(w, request, redirected.URL, http.StatusTemporaryRedirect)
 	}))
 	defer redirector.Close()
-	setTestConfig(t, redirector.Listener.Addr().String())
+	app := testRPCApplication(rpcPorts(testPort(t, redirector.Listener.Addr().String())), nil)
 
-	err := runRPC(newRPCCommand(), "ping", nil)
+	err := app.runRPC(newRPCCommand(), "ping", nil)
 	if err == nil || !strings.Contains(err.Error(), "HTTP 307 Temporary Redirect") {
 		t.Fatalf("runRPC() error = %v, want redirect status error", err)
 	}
@@ -576,9 +575,9 @@ func TestRunRPCRejectsNonSuccessfulHTTPStatus(t *testing.T) {
 				http.Error(w, "request failed", status)
 			}))
 			defer server.Close()
-			setTestConfig(t, server.Listener.Addr().String())
+			app := testRPCApplication(rpcPorts(testPort(t, server.Listener.Addr().String())), nil)
 
-			err := runRPC(newRPCCommand(), "server_info", nil)
+			err := app.runRPC(newRPCCommand(), "server_info", nil)
 			want := "HTTP " + strconv.Itoa(status) + " " + http.StatusText(status)
 			if err == nil || !strings.Contains(err.Error(), want) {
 				t.Fatalf("runRPC() error = %v, want containing %q", err, want)
@@ -794,12 +793,12 @@ func TestRPCStopUsesAdminCredentialsWithRPCServer(t *testing.T) {
 			port.Admin = []string{"127.0.0.1"}
 			port.AdminUser = test.adminUser
 			port.AdminPassword = test.adminPassword
-			setTestRPCPorts(t, rpcPorts(port))
+			app := testRPCApplication(rpcPorts(port), nil)
 
 			var output strings.Builder
 			command := newRPCCommand()
 			command.SetOut(&output)
-			if err := runRPC(command, "stop", nil); err != nil {
+			if err := app.runRPC(command, "stop", nil); err != nil {
 				t.Fatalf("runRPC(stop): %v", err)
 			}
 			select {
@@ -815,13 +814,11 @@ func TestRPCStopUsesAdminCredentialsWithRPCServer(t *testing.T) {
 }
 
 func TestRunRPCNoConfig(t *testing.T) {
-	previousConfig, previousError := globalConfig, globalConfigErr
-	globalConfig, globalConfigErr = nil, nil
-	t.Cleanup(func() {
-		globalConfig, globalConfigErr = previousConfig, previousError
-	})
-
-	if err := runRPC(newRPCCommand(), "ping", nil); err == nil {
+	app := &application{deps: commandDependencies{
+		loadConfig: config.LoadConfig,
+		httpClient: newRPCHTTPClient(),
+	}}
+	if err := app.runRPC(newRPCCommand(), "ping", nil); err == nil {
 		t.Fatal("runRPC() succeeded without a loaded config")
 	}
 }
@@ -839,9 +836,10 @@ func executeCapturedRPCCommand(
 		_, _ = io.WriteString(w, successfulRPCResponse)
 	}))
 	t.Cleanup(server.Close)
-	setTestConfig(t, server.Listener.Addr().String())
+	app := testRPCApplication(rpcPorts(testPort(t, server.Listener.Addr().String())), nil)
 
-	_, stderr, err := executeRPCCommand(t, specByMethod(t, method).command(), args, input)
+	command := specByMethod(t, method).commandWithRunner(nil, app.runRPC)
+	_, stderr, err := executeRPCCommand(t, command, args, input)
 	return body, stderr, err
 }
 
@@ -893,11 +891,6 @@ func rpcPorts(port config.PortConfig) map[string]config.PortConfig {
 	return map[string]config.PortConfig{"rpc": port}
 }
 
-func setTestConfig(t *testing.T, address string) {
-	t.Helper()
-	setTestRPCPorts(t, rpcPorts(testPort(t, address)))
-}
-
 func testPort(t *testing.T, address string) config.PortConfig {
 	t.Helper()
 	host, portString, err := net.SplitHostPort(address)
@@ -916,23 +909,19 @@ func testPort(t *testing.T, address string) config.PortConfig {
 	}
 }
 
-func setTestRPCPorts(t *testing.T, ports map[string]config.PortConfig) {
-	t.Helper()
-	previousConfig, previousError := globalConfig, globalConfigErr
-	globalConfig = &config.Config{Ports: ports}
-	globalConfigErr = nil
-	t.Cleanup(func() {
-		globalConfig, globalConfigErr = previousConfig, previousError
-	})
-}
-
-func setTestRPCClient(t *testing.T, client *http.Client) {
-	t.Helper()
-	previous := rpcHTTPClient
-	rpcHTTPClient = client
-	t.Cleanup(func() {
-		rpcHTTPClient = previous
-	})
+func testRPCApplication(ports map[string]config.PortConfig, client *http.Client) *application {
+	if client == nil {
+		client = newRPCHTTPClient()
+	}
+	return &application{
+		options: rootOptions{configFile: "test.toml"},
+		deps: commandDependencies{
+			loadConfig: func(config.Paths) (*config.Config, error) {
+				return &config.Config{Ports: ports}, nil
+			},
+			httpClient: client,
+		},
+	}
 }
 
 func newRPCCommand() *cobra.Command {

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -1,75 +1,115 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 
+	"github.com/LeJamon/go-xrpl/config"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/node"
-	"github.com/LeJamon/go-xrpl/internal/observability"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/LeJamon/go-xrpl/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
-var (
+type serverOptions struct {
 	standalone bool
-)
+	start      bool
+	load       bool
+	network    bool
+	replay     bool
+	ledger     string
+	ledgerFile string
+}
 
-// serverCmd represents the server command (default action)
-var serverCmd = &cobra.Command{
-	Use:   "server",
-	Short: "Start the XRPL daemon server",
-	Long: `Start the go-xrpl server which provides:
+type nodeRunFunc func(
+	context.Context,
+	*config.Config,
+	string,
+	bool,
+	service.StartupConfig,
+	xrpllog.Logger,
+	xrpllog.Logger,
+) error
+
+func runNode(
+	ctx context.Context,
+	cfg *config.Config,
+	configPath string,
+	standalone bool,
+	startup service.StartupConfig,
+	rootLogger,
+	serverLog xrpllog.Logger,
+) error {
+	return node.Run(ctx, cfg, configPath, standalone, startup, rootLogger, serverLog)
+}
+
+func (a *application) newServerCommand(options *serverOptions) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "server",
+		Short: "Start the XRPL daemon server",
+		Long: `Start the go-xrpl server which provides:
 - HTTP JSON-RPC API endpoints
 - WebSocket server for real-time subscriptions
 - Health check endpoint
 - All XRPL protocol methods
 
 Requires --conf flag to specify the configuration file.
-Use 'xrpld generate-config' to create an initial configuration file.`,
-	RunE: runServer,
+Use 'xrpld generate-config' to create an initial configuration file.
+
+GOXRPL_PPROF and GOXRPL_METRICS enable loopback diagnostic listeners. A
+configured listener that cannot bind aborts startup. Exposing pprof on a
+non-loopback address additionally requires GOXRPL_PPROF_ALLOW_UNSAFE=true.`,
+		Args: cobra.NoArgs,
+		RunE: a.serverRunner(options),
+	}
+	bindServerFlags(command.Flags(), options)
+	return command
 }
 
-func init() {
-	rootCmd.AddCommand(serverCmd)
-
-	// Set server as the default command
-	rootCmd.RunE = runServer
-
-	bindServerFlags(rootCmd.Flags())
-	bindServerFlags(serverCmd.Flags())
+func bindServerFlags(flags *pflag.FlagSet, options *serverOptions) {
+	flags.BoolVarP(&options.standalone, "standalone", "a", false, "run in standalone mode (no peers)")
+	bindStartupFlags(flags, options)
 }
 
-func bindServerFlags(flags *pflag.FlagSet) {
-	flags.BoolVarP(&standalone, "standalone", "a", false, "run in standalone mode (no peers)")
-	bindStartupFlags(flags)
+func (a *application) serverRunner(options *serverOptions) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		return a.runServer(cmd, options)
+	}
 }
 
-func runServer(cmd *cobra.Command, args []string) error {
-	if _, err := requireConfig(); err != nil {
+func (a *application) runServer(cmd *cobra.Command, options *serverOptions) error {
+	cfg, err := a.requireConfig(options.standalone)
+	if err != nil {
 		// Fold the guidance into the error so Execute() prints it once. A bare
 		// pre-print here would duplicate the message Execute() emits.
 		return fmt.Errorf("%w\n  Use 'xrpld generate-config' to create an initial configuration file."+
 			"\n  Example: xrpld server --conf /path/to/xrpld.toml", err)
 	}
 
-	startup, err := startupConfigFromFlags(cmd.Flags())
+	startup, err := startupConfig(
+		options,
+		commandFlagChanged(cmd, "ledger"),
+		commandFlagChanged(cmd, "ledgerfile"),
+	)
 	if err != nil {
 		return err
 	}
 
 	// Initialize structured logger from config + CLI flag overrides.
-	logCfg, err := globalConfig.Logging.ToLogConfig(globalConfig.DebugLogfile)
+	logCfg, err := cfg.Logging.ToLogConfig(cfg.DebugLogfile)
 	if err != nil {
 		return fmt.Errorf("configure logging: %w", err)
 	}
-	if debug {
+	if a.options.debug {
 		logCfg.Level = xrpllog.LevelDebug
 	}
-	if verbose {
+	if a.options.verbose {
 		logCfg.Level = xrpllog.LevelTrace
 	}
 	rootLogger, logHandler := xrpllog.Init(logCfg)
@@ -81,82 +121,62 @@ func runServer(cmd *cobra.Command, args []string) error {
 
 	serverLog.Info("Starting go-xrpl", "version", version.Version)
 
-	// Set GOXRPL_PPROF=:6060 (or any addr:port) to enable pprof. Off by default.
-	if addr := os.Getenv("GOXRPL_PPROF"); addr != "" {
-		go func() {
-			if err := observability.StartPProf(addr); err != nil {
-				serverLog.Warn("pprof server failed", "addr", addr, "err", err)
-			}
-		}()
-		serverLog.Info("pprof enabled", "addr", addr)
+	runCtx, cancel := context.WithCancelCause(cmd.Context())
+	defer cancel(nil)
+	auxiliary, err := startAuxiliaryServers(runCtx, cancel, os.Getenv, net.Listen)
+	if err != nil {
+		return err
 	}
-
-	// Set GOXRPL_METRICS=:9100 (or any addr:port) to expose Prometheus
-	// metrics at /metrics. Off by default.
-	if addr := os.Getenv("GOXRPL_METRICS"); addr != "" {
-		go func() {
-			if err := startMetricsServer(addr); err != nil {
-				serverLog.Warn("metrics server failed", "addr", addr, "err", err)
-			}
-		}()
-		serverLog.Info("prometheus metrics enabled", "addr", addr)
+	for name, address := range auxiliary.Addresses() {
+		serverLog.Info(name+" enabled", "addr", address)
 	}
-
-	return node.Run(globalConfig, configFile, standalone, startup, rootLogger, serverLog)
+	nodeErr := a.deps.runNode(
+		runCtx,
+		cfg,
+		a.options.configFile,
+		options.standalone,
+		startup,
+		rootLogger,
+		serverLog,
+	)
+	cancel(nil)
+	return errors.Join(nodeErr, auxiliary.Shutdown())
 }
 
-func bindStartupFlags(flags *pflag.FlagSet) {
-	flags.Bool("start", false, "start from a fresh ledger")
-	flags.Bool("load", false, "load the latest ledger from local storage")
-	flags.Bool("net", false, "acquire the initial ledger from the network")
-	flags.Bool("replay", false, "replay the ledger close selected by --ledger")
-	flags.String("ledger", "", "load the ledger identified by a hash, sequence, or shortcut")
-	flags.String("ledgerfile", "", "load a ledger from a JSON file")
+func bindStartupFlags(flags *pflag.FlagSet, options *serverOptions) {
+	flags.BoolVar(&options.start, "start", false, "start from a fresh ledger")
+	flags.BoolVar(&options.load, "load", false, "load the latest ledger from local storage")
+	flags.BoolVar(&options.network, "net", false, "acquire the initial ledger from the network")
+	flags.BoolVar(&options.replay, "replay", false, "replay the ledger close selected by --ledger")
+	flags.StringVar(&options.ledger, "ledger", "", "load the ledger identified by a hash, sequence, or shortcut")
+	flags.StringVar(&options.ledgerFile, "ledgerfile", "", "load a ledger from a JSON file")
 }
 
-func startupConfigFromFlags(flags *pflag.FlagSet) (service.StartupConfig, error) {
-	start, err := flags.GetBool("start")
-	if err != nil {
-		return service.StartupConfig{}, err
+func commandFlagChanged(command *cobra.Command, name string) bool {
+	for current := command; current != nil; current = current.Parent() {
+		if current.Flags().Changed(name) {
+			return true
+		}
 	}
-	load, err := flags.GetBool("load")
-	if err != nil {
-		return service.StartupConfig{}, err
-	}
-	network, err := flags.GetBool("net")
-	if err != nil {
-		return service.StartupConfig{}, err
-	}
-	replay, err := flags.GetBool("replay")
-	if err != nil {
-		return service.StartupConfig{}, err
-	}
-	ledger, err := flags.GetString("ledger")
-	if err != nil {
-		return service.StartupConfig{}, err
-	}
-	ledgerFile, err := flags.GetString("ledgerfile")
-	if err != nil {
-		return service.StartupConfig{}, err
-	}
+	return false
+}
 
-	ledgerSet := flags.Changed("ledger")
-	ledgerFileSet := flags.Changed("ledgerfile")
-	if replay && !ledgerSet {
+func startupConfig(options *serverOptions, ledgerSet, ledgerFileSet bool) (service.StartupConfig, error) {
+	if options.replay && !ledgerSet {
 		return service.StartupConfig{}, fmt.Errorf("--replay requires --ledger")
 	}
-	if ledgerFileSet && ledgerFile == "" {
+	if ledgerFileSet && options.ledgerFile == "" {
 		return service.StartupConfig{}, fmt.Errorf("--ledgerfile requires a non-empty path")
 	}
 
 	selected := 0
 	for _, active := range []bool{
-		start,
-		load,
-		network,
-		replay,
+		options.start,
+		options.load,
+		options.network,
+		options.replay,
 		ledgerFileSet,
-		ledgerSet && !replay,
+		ledgerSet && !options.replay,
 	} {
 		if active {
 			selected++
@@ -169,18 +189,18 @@ func startupConfigFromFlags(flags *pflag.FlagSet) (service.StartupConfig, error)
 	}
 
 	switch {
-	case start:
+	case options.start:
 		return service.StartupConfig{Mode: service.StartupFresh}, nil
-	case load:
+	case options.load:
 		return service.StartupConfig{Mode: service.StartupLoad}, nil
-	case network:
+	case options.network:
 		return service.StartupConfig{Mode: service.StartupNetwork}, nil
-	case replay:
-		return service.StartupConfig{Mode: service.StartupReplay, Ledger: ledger}, nil
+	case options.replay:
+		return service.StartupConfig{Mode: service.StartupReplay, Ledger: options.ledger}, nil
 	case ledgerFileSet:
-		return service.StartupConfig{Mode: service.StartupLoadFile, Ledger: ledgerFile}, nil
+		return service.StartupConfig{Mode: service.StartupLoadFile, Ledger: options.ledgerFile}, nil
 	case ledgerSet:
-		return service.StartupConfig{Mode: service.StartupLoad, Ledger: ledger}, nil
+		return service.StartupConfig{Mode: service.StartupLoad, Ledger: options.ledger}, nil
 	default:
 		return service.StartupConfig{Mode: service.StartupNormal}, nil
 	}

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -96,6 +96,7 @@ func (a *application) runServer(cmd *cobra.Command, options *serverOptions) erro
 		options,
 		commandFlagChanged(cmd, "ledger"),
 		commandFlagChanged(cmd, "ledgerfile"),
+		cfg.NodeDB.FastLoad,
 	)
 	if err != nil {
 		return err
@@ -161,47 +162,36 @@ func commandFlagChanged(command *cobra.Command, name string) bool {
 	return false
 }
 
-func startupConfig(options *serverOptions, ledgerSet, ledgerFileSet bool) (service.StartupConfig, error) {
-	if options.replay && !ledgerSet {
-		return service.StartupConfig{}, fmt.Errorf("--replay requires --ledger")
-	}
-	if ledgerFileSet && options.ledgerFile == "" {
-		return service.StartupConfig{}, fmt.Errorf("--ledgerfile requires a non-empty path")
-	}
-
-	selected := 0
-	for _, active := range []bool{
-		options.start,
-		options.load,
-		options.network,
-		options.replay,
-		ledgerFileSet,
-		ledgerSet && !options.replay,
-	} {
-		if active {
-			selected++
-		}
-	}
-	if selected > 1 {
-		return service.StartupConfig{}, fmt.Errorf(
-			"startup modes are mutually exclusive: choose only one of --start, --load, --net, --replay, --ledger, or --ledgerfile",
-		)
+func startupConfig(options *serverOptions, ledgerSet, ledgerFileSet, fastLoad bool) (service.StartupConfig, error) {
+	startup := service.StartupConfig{Mode: service.StartupNormal}
+	if options.start {
+		startup.Mode = service.StartupFresh
 	}
 
 	switch {
-	case options.start:
-		return service.StartupConfig{Mode: service.StartupFresh}, nil
-	case options.load:
-		return service.StartupConfig{Mode: service.StartupLoad}, nil
-	case options.network:
-		return service.StartupConfig{Mode: service.StartupNetwork}, nil
-	case options.replay:
-		return service.StartupConfig{Mode: service.StartupReplay, Ledger: options.ledger}, nil
-	case ledgerFileSet:
-		return service.StartupConfig{Mode: service.StartupLoadFile, Ledger: options.ledgerFile}, nil
 	case ledgerSet:
-		return service.StartupConfig{Mode: service.StartupLoad, Ledger: options.ledger}, nil
-	default:
-		return service.StartupConfig{Mode: service.StartupNormal}, nil
+		startup.Ledger = options.ledger
+		if options.replay {
+			startup.Mode = service.StartupReplay
+		} else {
+			startup.Mode = service.StartupLoad
+		}
+	case ledgerFileSet:
+		startup = service.StartupConfig{Mode: service.StartupLoadFile, Ledger: options.ledgerFile}
+	case options.load:
+		startup = service.StartupConfig{Mode: service.StartupLoad}
+	case fastLoad:
+		startup = service.StartupConfig{Mode: service.StartupNormal}
 	}
+
+	if options.network && !fastLoad {
+		if startup.Mode == service.StartupLoad || startup.Mode == service.StartupReplay {
+			return service.StartupConfig{}, fmt.Errorf("--net is incompatible with --load or --ledger")
+		}
+		startup = service.StartupConfig{Mode: service.StartupNetwork}
+	}
+	if startup.Mode == service.StartupLoadFile && startup.Ledger == "" && !fastLoad {
+		return service.StartupConfig{}, fmt.Errorf("--ledgerfile requires a non-empty path")
+	}
+	return startup, nil
 }

--- a/internal/cli/server_test.go
+++ b/internal/cli/server_test.go
@@ -1,25 +1,32 @@
 package cli
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/LeJamon/go-xrpl/config"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultServerCommandHasStartupFlags(t *testing.T) {
+	root := NewRootCommand(IOStreams{})
 	for _, name := range []string{"standalone", "start", "load", "net", "replay", "ledger", "ledgerfile"} {
-		require.NotNil(t, rootCmd.Flags().Lookup(name), "root command is missing --%s", name)
+		require.NotNil(t, root.Flags().Lookup(name), "root command is missing --%s", name)
 	}
-
-	startup, err := startupConfigFromFlags(rootCmd.Flags())
-	require.NoError(t, err)
-	assert.Equal(t, service.StartupConfig{Mode: service.StartupNormal}, startup)
 }
 
-func TestStartupConfigFromFlags(t *testing.T) {
+func TestStartupConfig(t *testing.T) {
 	tests := []struct {
 		name string
 		args []string
@@ -74,17 +81,18 @@ func TestStartupConfigFromFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			flags := pflag.NewFlagSet(tt.name, pflag.ContinueOnError)
-			bindStartupFlags(flags)
+			options := &serverOptions{}
+			bindStartupFlags(flags, options)
 			require.NoError(t, flags.Parse(tt.args))
 
-			got, err := startupConfigFromFlags(flags)
+			got, err := startupConfig(options, flags.Changed("ledger"), flags.Changed("ledgerfile"))
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestStartupConfigFromFlagsRejectsInvalidCombinations(t *testing.T) {
+func TestStartupConfigRejectsInvalidCombinations(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    []string
@@ -125,11 +133,160 @@ func TestStartupConfigFromFlagsRejectsInvalidCombinations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			flags := pflag.NewFlagSet(tt.name, pflag.ContinueOnError)
-			bindStartupFlags(flags)
+			options := &serverOptions{}
+			bindStartupFlags(flags, options)
 			require.NoError(t, flags.Parse(tt.args))
 
-			_, err := startupConfigFromFlags(flags)
+			_, err := startupConfig(options, flags.Changed("ledger"), flags.Changed("ledgerfile"))
 			require.ErrorContains(t, err, tt.wantErr)
 		})
 	}
+}
+
+func TestExplicitServerUsesFlagsBeforeOrAfterSubcommand(t *testing.T) {
+	t.Setenv("GOXRPL_PPROF", "")
+	t.Setenv("GOXRPL_METRICS", "")
+	t.Setenv("GOXRPL_PPROF_ALLOW_UNSAFE", "")
+
+	configPath := writeServerTestConfig(t)
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "before subcommand",
+			args: []string{"--conf", configPath, "--standalone", "--load", "server"},
+		},
+		{
+			name: "after subcommand",
+			args: []string{"--conf", configPath, "server", "--standalone", "--load"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var gotStandalone bool
+			var gotStartup service.StartupConfig
+			deps := commandDependencies{
+				loadConfig: config.LoadConfig,
+				runNode: func(
+					_ context.Context,
+					_ *config.Config,
+					_ string,
+					standalone bool,
+					startup service.StartupConfig,
+					_, _ xrpllog.Logger,
+				) error {
+					gotStandalone = standalone
+					gotStartup = startup
+					return nil
+				},
+			}
+
+			root := newRootCommand(
+				IOStreams{Out: bytes.NewBuffer(nil), ErrOut: bytes.NewBuffer(nil)},
+				deps,
+			)
+			root.SetArgs(test.args)
+			_, err := root.ExecuteC()
+			require.NoError(t, err)
+			assert.True(t, gotStandalone)
+			assert.Equal(t, service.StartupConfig{Mode: service.StartupLoad}, gotStartup)
+		})
+	}
+}
+
+func TestServerBindFailurePreventsNodeStart(t *testing.T) {
+	configPath := writeServerTestConfig(t)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+	t.Setenv("GOXRPL_PPROF", "")
+	t.Setenv("GOXRPL_METRICS", listener.Addr().String())
+	t.Setenv("GOXRPL_PPROF_ALLOW_UNSAFE", "")
+
+	var nodeStarted atomic.Bool
+	deps := defaultCommandDependencies()
+	deps.runNode = func(
+		context.Context,
+		*config.Config,
+		string,
+		bool,
+		service.StartupConfig,
+		xrpllog.Logger,
+		xrpllog.Logger,
+	) error {
+		nodeStarted.Store(true)
+		return nil
+	}
+	root := newRootCommand(IOStreams{Out: bytes.NewBuffer(nil), ErrOut: bytes.NewBuffer(nil)}, deps)
+	root.SetArgs([]string{"--conf", configPath, "server", "--standalone"})
+	_, err = root.ExecuteC()
+	require.ErrorContains(t, err, "bind metrics server")
+	assert.False(t, nodeStarted.Load())
+}
+
+func TestServerCancellationShutsDownAuxiliaryListeners(t *testing.T) {
+	configPath := writeServerTestConfig(t)
+	address := availableLoopbackAddress(t)
+	t.Setenv("GOXRPL_PPROF", "")
+	t.Setenv("GOXRPL_METRICS", address)
+	t.Setenv("GOXRPL_PPROF_ALLOW_UNSAFE", "")
+
+	started := make(chan struct{})
+	deps := defaultCommandDependencies()
+	deps.runNode = func(
+		ctx context.Context,
+		_ *config.Config,
+		_ string,
+		_ bool,
+		_ service.StartupConfig,
+		_,
+		_ xrpllog.Logger,
+	) error {
+		close(started)
+		<-ctx.Done()
+		return context.Cause(ctx)
+	}
+	root := newRootCommand(IOStreams{Out: bytes.NewBuffer(nil), ErrOut: bytes.NewBuffer(nil)}, deps)
+	root.SetArgs([]string{"--conf", configPath, "server", "--standalone"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := root.ExecuteContextC(ctx)
+		result <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("node runner did not start")
+	}
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("server error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not return after cancellation")
+	}
+
+	listener, err := net.Listen("tcp", address)
+	require.NoError(t, err, "auxiliary listener was not released")
+	require.NoError(t, listener.Close())
+}
+
+func writeServerTestConfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "xrpld.toml")
+	require.NoError(t, os.WriteFile(path, []byte(generateConfigContent("devnet")), 0o600))
+	return path
+}
+
+func availableLoopbackAddress(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	address := listener.Addr().String()
+	require.NoError(t, listener.Close())
+	return address
 }

--- a/internal/cli/server_test.go
+++ b/internal/cli/server_test.go
@@ -28,9 +28,10 @@ func TestDefaultServerCommandHasStartupFlags(t *testing.T) {
 
 func TestStartupConfig(t *testing.T) {
 	tests := []struct {
-		name string
-		args []string
-		want service.StartupConfig
+		name     string
+		args     []string
+		fastLoad bool
+		want     service.StartupConfig
 	}{
 		{
 			name: "normal",
@@ -76,6 +77,93 @@ func TestStartupConfig(t *testing.T) {
 			args: []string{"--replay", "--ledger="},
 			want: service.StartupConfig{Mode: service.StartupReplay},
 		},
+		{
+			name: "replay without ledger is ignored",
+			args: []string{"--replay"},
+			want: service.StartupConfig{Mode: service.StartupNormal},
+		},
+		{
+			name: "load overrides fresh",
+			args: []string{"--start", "--load"},
+			want: service.StartupConfig{Mode: service.StartupLoad},
+		},
+		{
+			name: "ledger overrides load and fresh",
+			args: []string{"--start", "--load", "--ledger", "43"},
+			want: service.StartupConfig{Mode: service.StartupLoad, Ledger: "43"},
+		},
+		{
+			name: "replay ledger overrides load",
+			args: []string{"--load", "--replay", "--ledger", "43"},
+			want: service.StartupConfig{Mode: service.StartupReplay, Ledger: "43"},
+		},
+		{
+			name: "ledger overrides ledger file",
+			args: []string{"--ledger", "43", "--ledgerfile", "ledger.json"},
+			want: service.StartupConfig{Mode: service.StartupLoad, Ledger: "43"},
+		},
+		{
+			name: "network overrides fresh",
+			args: []string{"--start", "--net"},
+			want: service.StartupConfig{Mode: service.StartupNetwork},
+		},
+		{
+			name: "network overrides ledger file",
+			args: []string{"--net", "--ledgerfile", "ledger.json"},
+			want: service.StartupConfig{Mode: service.StartupNetwork},
+		},
+		{
+			name:     "fast load",
+			fastLoad: true,
+			want:     service.StartupConfig{Mode: service.StartupNormal},
+		},
+		{
+			name:     "fast load overrides fresh",
+			args:     []string{"--start"},
+			fastLoad: true,
+			want:     service.StartupConfig{Mode: service.StartupNormal},
+		},
+		{
+			name:     "explicit load overrides fast load",
+			args:     []string{"--load"},
+			fastLoad: true,
+			want:     service.StartupConfig{Mode: service.StartupLoad},
+		},
+		{
+			name:     "ledger overrides fast load",
+			args:     []string{"--ledger", "43"},
+			fastLoad: true,
+			want:     service.StartupConfig{Mode: service.StartupLoad, Ledger: "43"},
+		},
+		{
+			name:     "replay ledger overrides fast load",
+			args:     []string{"--replay", "--ledger", "43"},
+			fastLoad: true,
+			want:     service.StartupConfig{Mode: service.StartupReplay, Ledger: "43"},
+		},
+		{
+			name:     "ledger file overrides fast load",
+			args:     []string{"--ledgerfile", "ledger.json"},
+			fastLoad: true,
+			want:     service.StartupConfig{Mode: service.StartupLoadFile, Ledger: "ledger.json"},
+		},
+		{
+			name:     "empty ledger file falls back with fast load",
+			args:     []string{"--ledgerfile="},
+			fastLoad: true,
+			want:     service.StartupConfig{Mode: service.StartupLoadFile},
+		},
+		{
+			name:     "fast load ignores network",
+			args:     []string{"--net"},
+			fastLoad: true,
+			want:     service.StartupConfig{Mode: service.StartupNormal},
+		},
+		{
+			name: "network overrides empty ledger file",
+			args: []string{"--net", "--ledgerfile="},
+			want: service.StartupConfig{Mode: service.StartupNetwork},
+		},
 	}
 
 	for _, tt := range tests {
@@ -85,7 +173,7 @@ func TestStartupConfig(t *testing.T) {
 			bindStartupFlags(flags, options)
 			require.NoError(t, flags.Parse(tt.args))
 
-			got, err := startupConfig(options, flags.Changed("ledger"), flags.Changed("ledgerfile"))
+			got, err := startupConfig(options, flags.Changed("ledger"), flags.Changed("ledgerfile"), tt.fastLoad)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})
@@ -99,34 +187,29 @@ func TestStartupConfigRejectsInvalidCombinations(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "replay without ledger",
-			args:    []string{"--replay"},
-			wantErr: "--replay requires --ledger",
-		},
-		{
 			name:    "empty ledger file",
 			args:    []string{"--ledgerfile="},
 			wantErr: "--ledgerfile requires a non-empty path",
 		},
 		{
-			name:    "fresh and load",
-			args:    []string{"--start", "--load"},
-			wantErr: "startup modes are mutually exclusive",
-		},
-		{
 			name:    "network and selected ledger",
 			args:    []string{"--net", "--ledger", "43"},
-			wantErr: "startup modes are mutually exclusive",
+			wantErr: "--net is incompatible",
+		},
+		{
+			name:    "network and empty ledger",
+			args:    []string{"--net", "--ledger="},
+			wantErr: "--net is incompatible",
 		},
 		{
 			name:    "load and replay",
-			args:    []string{"--load", "--replay", "--ledger", "32570"},
-			wantErr: "startup modes are mutually exclusive",
+			args:    []string{"--net", "--load", "--replay", "--ledger", "32570"},
+			wantErr: "--net is incompatible",
 		},
 		{
-			name:    "ledger and ledger file",
-			args:    []string{"--ledger", "43", "--ledgerfile", "ledger.json"},
-			wantErr: "startup modes are mutually exclusive",
+			name:    "network and load",
+			args:    []string{"--net", "--load"},
+			wantErr: "--net is incompatible",
 		},
 	}
 
@@ -137,7 +220,7 @@ func TestStartupConfigRejectsInvalidCombinations(t *testing.T) {
 			bindStartupFlags(flags, options)
 			require.NoError(t, flags.Parse(tt.args))
 
-			_, err := startupConfig(options, flags.Changed("ledger"), flags.Changed("ledgerfile"))
+			_, err := startupConfig(options, flags.Changed("ledger"), flags.Changed("ledgerfile"), false)
 			require.ErrorContains(t, err, tt.wantErr)
 		})
 	}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -9,13 +9,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Show version information",
-	Long:  `Display version information for go-xrpl including build details and Go version.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Print(versionText(rootCmd.Version))
-	},
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Show version information",
+		Long:  `Display version information for go-xrpl including build details and Go version.`,
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprint(cmd.OutOrStdout(), versionText(cmd.Root().Version))
+		},
+	}
 }
 
 // versionText renders the version command output. VCS details (commit,
@@ -55,8 +58,4 @@ func vcsText(settings []rdebug.BuildSetting) string {
 		fmt.Fprintf(&b, "Commit time: %s\n", t)
 	}
 	return b.String()
-}
-
-func init() {
-	rootCmd.AddCommand(versionCmd)
 }

--- a/internal/ledger/service/startup.go
+++ b/internal/ledger/service/startup.go
@@ -37,7 +37,7 @@ type StartupConfig struct {
 	Ledger string
 }
 
-func (c StartupConfig) validate() error {
+func (c StartupConfig) validate(fastLoad bool) error {
 	switch c.Mode {
 	case StartupNormal, StartupFresh, StartupNetwork:
 		if c.Ledger != "" {
@@ -45,7 +45,7 @@ func (c StartupConfig) validate() error {
 		}
 	case StartupLoad:
 	case StartupLoadFile:
-		if c.Ledger == "" {
+		if c.Ledger == "" && !fastLoad {
 			return errors.New("ledger file path cannot be empty")
 		}
 	case StartupReplay:
@@ -64,7 +64,7 @@ type startupSelection struct {
 }
 
 func (s *Service) selectStartup(ctx context.Context, initial *ledger.Ledger) (startupSelection, error) {
-	if err := s.config.Startup.validate(); err != nil {
+	if err := s.config.Startup.validate(s.config.FastLoad); err != nil {
 		return startupSelection{}, err
 	}
 

--- a/internal/ledger/service/startup_test.go
+++ b/internal/ledger/service/startup_test.go
@@ -81,31 +81,48 @@ func TestService_StartupNormalUsesEmptyInitialAmendments(t *testing.T) {
 }
 
 func TestService_ExplicitLoadFailureUsesConfiguredFastLoadFallback(t *testing.T) {
-	fatalLoad, err := New(Config{
-		Standalone:    false,
-		Startup:       StartupConfig{Mode: StartupLoad},
-		GenesisConfig: genesis.DefaultConfig(),
-	})
-	require.NoError(t, err)
-	t.Cleanup(fatalLoad.Stop)
-	require.ErrorContains(t, fatalLoad.Start(), "relational database is required")
+	tests := []struct {
+		name    string
+		startup StartupConfig
+	}{
+		{
+			name:    "latest ledger",
+			startup: StartupConfig{Mode: StartupLoad},
+		},
+		{
+			name:    "empty ledger file",
+			startup: StartupConfig{Mode: StartupLoadFile},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fatalLoad, err := New(Config{
+				Standalone:    false,
+				Startup:       test.startup,
+				GenesisConfig: genesis.DefaultConfig(),
+			})
+			require.NoError(t, err)
+			t.Cleanup(fatalLoad.Stop)
+			require.Error(t, fatalLoad.Start())
 
-	fallback, err := New(Config{
-		Standalone:    false,
-		Startup:       StartupConfig{Mode: StartupLoad},
-		GenesisConfig: genesis.DefaultConfig(),
-		FastLoad:      true,
-	})
-	require.NoError(t, err)
-	require.NoError(t, fallback.Start())
-	t.Cleanup(fallback.Stop)
-	require.False(t, fallback.NeedsInitialSync())
-	require.True(t, fallback.IsFastLoadProvisional())
-	require.False(t, fallback.GetServerInfo().NeedsNetworkLedger)
-	require.Nil(t, fallback.GetValidatedLedger())
-	fallbackAmendments, err := fallback.GetClosedLedger().Read(keylet.Amendments())
-	require.NoError(t, err)
-	require.Nil(t, fallbackAmendments)
+			fallback, err := New(Config{
+				Standalone:    false,
+				Startup:       test.startup,
+				GenesisConfig: genesis.DefaultConfig(),
+				FastLoad:      true,
+			})
+			require.NoError(t, err)
+			require.NoError(t, fallback.Start())
+			t.Cleanup(fallback.Stop)
+			require.False(t, fallback.NeedsInitialSync())
+			require.True(t, fallback.IsFastLoadProvisional())
+			require.False(t, fallback.GetServerInfo().NeedsNetworkLedger)
+			require.Nil(t, fallback.GetValidatedLedger())
+			fallbackAmendments, err := fallback.GetClosedLedger().Read(keylet.Amendments())
+			require.NoError(t, err)
+			require.Nil(t, fallbackAmendments)
+		})
+	}
 }
 
 func TestService_StartupLoadIdentifiers(t *testing.T) {

--- a/internal/node/lifecycle_test.go
+++ b/internal/node/lifecycle_test.go
@@ -1,0 +1,55 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+)
+
+func TestRunReturnsCanceledContextBeforeStartup(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cause := errors.New("startup canceled")
+	cancel(cause)
+
+	err := Run(ctx, nil, "", false, service.StartupConfig{}, xrpllog.Discard(), xrpllog.Discard())
+	if !errors.Is(err, cause) {
+		t.Fatalf("Run() error = %v, want %v", err, cause)
+	}
+}
+
+func TestWaitForShutdownReturnsContextCause(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cause := errors.New("auxiliary listener failed")
+	result := make(chan error, 1)
+	go func() {
+		result <- waitForShutdown(
+			ctx,
+			xrpllog.Discard(),
+			make(chan os.Signal),
+			make(chan os.Signal),
+			make(chan struct{}),
+			make(chan error),
+			nil,
+			"",
+		)
+	}()
+
+	cancel(cause)
+	select {
+	case err := <-result:
+		if !errors.Is(err, cause) {
+			t.Fatalf("waitForShutdown() error = %v, want %v", err, cause)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waitForShutdown() did not return after context cancellation")
+	}
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -133,7 +133,10 @@ func isFullGitHash(value string) bool {
 // Run assembles and starts every node subsystem from the parsed config, then
 // blocks until a terminating signal or fatal error. It is the composition root
 // extracted from the CLI so flag parsing and node wiring stay separable.
-func Run(appConfig *config.Config, configPath string, standalone bool, startup service.StartupConfig, rootLogger, serverLog xrpllog.Logger) error {
+func Run(ctx context.Context, appConfig *config.Config, configPath string, standalone bool, startup service.StartupConfig, rootLogger, serverLog xrpllog.Logger) error {
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 	if err := validateTrustedValidatorConfig(appConfig, standalone); err != nil {
 		return err
 	}
@@ -160,6 +163,9 @@ func Run(appConfig *config.Config, configPath string, standalone bool, startup s
 
 	db, repoManager, err = setupStorage(appConfig, serverLog)
 	if err != nil {
+		return err
+	}
+	if err := context.Cause(ctx); err != nil {
 		return err
 	}
 	var nodeFamily *backend.NodeStore
@@ -256,6 +262,9 @@ func Run(appConfig *config.Config, configPath string, standalone bool, startup s
 	if err := ledgerService.Start(); err != nil {
 		return fmt.Errorf("start ledger service: %w", err)
 	}
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 
 	// Start the goroutine-scheduling-latency sampler. Runs in both
 	// standalone and consensus modes; cancelled when runServer returns.
@@ -333,6 +342,9 @@ func Run(appConfig *config.Config, configPath string, standalone bool, startup s
 					nodeFamily.SetMinimumLedgerSeq,
 					nodeFamily.BeginPrune,
 				)
+				if err := context.Cause(ctx); err != nil {
+					return err
+				}
 				rotator.Start()
 				serverLog.Info("Online delete enabled",
 					"online_delete", appConfig.NodeDB.OnlineDelete,
@@ -449,6 +461,9 @@ func Run(appConfig *config.Config, configPath string, standalone bool, startup s
 		cleanerFamily = memFamily
 	}
 	ledgerCleaner = cleaner.New(&ledgerCleanerSource{svc: ledgerSvcRef, family: cleanerFamily}, rootLogger)
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 	ledgerCleaner.Start()
 
 	cleanerRef := ledgerCleaner
@@ -512,6 +527,9 @@ func Run(appConfig *config.Config, configPath string, standalone bool, startup s
 			}
 		}
 
+		if err := context.Cause(ctx); err != nil {
+			return err
+		}
 		if err := consensusComponents.Start(); err != nil {
 			return fmt.Errorf("start consensus components: %w", err)
 		}
@@ -1032,6 +1050,9 @@ func Run(appConfig *config.Config, configPath string, standalone bool, startup s
 		)
 	})
 
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 	var listenerErrCh chan error
 	if httpSrvs, wsSrvs, listenerErrCh, err = startListeners(serverLog, appConfig, httpServer, wsServer); err != nil {
 		return err
@@ -1086,6 +1107,7 @@ func Run(appConfig *config.Config, configPath string, standalone bool, startup s
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
 
 	// SIGHUP triggers a UNL reload: re-read the config from --conf and
 	// replace the adaptor's trusted validator set. Per-round delta
@@ -1096,6 +1118,7 @@ func Run(appConfig *config.Config, configPath string, standalone bool, startup s
 	// subsystem. Buffered so a flurry of HUPs coalesces.
 	reloadCh := make(chan os.Signal, 1)
 	signal.Notify(reloadCh, syscall.SIGHUP)
+	defer signal.Stop(reloadCh)
 
 	// shutdownCh lets the RPC stop command trigger the same path
 	shutdownCh := make(chan struct{}, 1)
@@ -1110,7 +1133,7 @@ func Run(appConfig *config.Config, configPath string, standalone bool, startup s
 		}
 	})
 
-	return waitForShutdown(serverLog, sigCh, reloadCh, shutdownCh, listenerErrCh, consensusComponents, configPath)
+	return waitForShutdown(ctx, serverLog, sigCh, reloadCh, shutdownCh, listenerErrCh, consensusComponents, configPath)
 }
 
 func configuredLedgerLoadFees(appConfig *config.Config) drops.Fees {
@@ -1148,6 +1171,7 @@ func validateTrustedValidatorConfig(appConfig *config.Config, standalone bool) e
 // listener error (if any) so the caller's deferred cleanup runs.
 
 func waitForShutdown(
+	ctx context.Context,
 	log xrpllog.Logger,
 	sigCh, reloadCh chan os.Signal,
 	shutdownCh chan struct{},
@@ -1157,6 +1181,8 @@ func waitForShutdown(
 ) error {
 	for {
 		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
 		case sig := <-sigCh:
 			log.Info("Received signal, shutting down", "signal", sig)
 			return nil

--- a/internal/observability/http.go
+++ b/internal/observability/http.go
@@ -1,0 +1,35 @@
+package observability
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+// ShutdownHTTPServer bounds both graceful shutdown and the forced-close fallback
+// even when a listener does not return promptly from Close.
+func ShutdownHTTPServer(ctx context.Context, server *http.Server) error {
+	shutdownResult := make(chan error, 1)
+	go func() {
+		shutdownResult <- server.Shutdown(ctx)
+	}()
+
+	select {
+	case err := <-shutdownResult:
+		if err == nil {
+			return nil
+		}
+		closeResult := make(chan error, 1)
+		go func() {
+			closeResult <- server.Close()
+		}()
+		select {
+		case closeErr := <-closeResult:
+			return errors.Join(err, closeErr)
+		case <-ctx.Done():
+			return errors.Join(err, context.Cause(ctx))
+		}
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}

--- a/internal/observability/http_test.go
+++ b/internal/observability/http_test.go
@@ -1,0 +1,73 @@
+package observability
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestShutdownHTTPServerBoundsBlockingListenerClose(t *testing.T) {
+	t.Parallel()
+
+	listener := &blockingCloseListener{
+		acceptStarted: make(chan struct{}),
+		release:       make(chan struct{}),
+	}
+	server := &http.Server{ReadHeaderTimeout: time.Second}
+	serveDone := make(chan struct{})
+	go func() {
+		_ = server.Serve(listener)
+		close(serveDone)
+	}()
+	<-listener.acceptStarted
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	err := ShutdownHTTPServer(ctx, server)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("ShutdownHTTPServer() error = %v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("ShutdownHTTPServer() took %v, want bounded return", elapsed)
+	}
+
+	close(listener.release)
+	select {
+	case <-serveDone:
+	case <-time.After(time.Second):
+		t.Fatal("Serve() did not return after releasing listener")
+	}
+}
+
+type blockingCloseListener struct {
+	acceptStarted chan struct{}
+	release       chan struct{}
+	acceptOnce    sync.Once
+}
+
+func (l *blockingCloseListener) Accept() (net.Conn, error) {
+	l.acceptOnce.Do(func() {
+		close(l.acceptStarted)
+	})
+	<-l.release
+	return nil, net.ErrClosed
+}
+
+func (l *blockingCloseListener) Close() error {
+	<-l.release
+	return nil
+}
+
+func (*blockingCloseListener) Addr() net.Addr {
+	return blockingListenerAddr("127.0.0.1:0")
+}
+
+type blockingListenerAddr string
+
+func (blockingListenerAddr) Network() string  { return "tcp" }
+func (a blockingListenerAddr) String() string { return string(a) }

--- a/internal/observability/pprof.go
+++ b/internal/observability/pprof.go
@@ -4,34 +4,19 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"runtime"
-	"time"
 )
 
-// StartPProf runs a pprof HTTP server on addr, blocking until it returns, and
-// is shared by the long-running commands (server, replay-range) so profiles can
-// be captured without each re-implementing the wiring. Run it in its own
-// goroutine.
-//
-// Mutex and block profile rates are tuned to keep overhead bounded:
-//   - MutexProfileFraction=100 samples 1-in-100 contention events; fraction=1
-//     can dominate cost on hot locks without adding ranking precision.
-//   - BlockProfileRate=1_000_000 ns samples blocks of ~1ms or longer, enough to
-//     surface off-CPU (DB / blob-store) wait without flooding the profile.
-func StartPProf(addr string) error {
+func EnablePProf() {
 	runtime.SetMutexProfileFraction(100)
 	runtime.SetBlockProfileRate(1_000_000)
+}
 
+func PProfHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
 	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-
-	srv := &http.Server{
-		Addr:              addr,
-		Handler:           mux,
-		ReadHeaderTimeout: 5 * time.Second,
-	}
-	return srv.ListenAndServe()
+	return mux
 }

--- a/internal/observability/pprof_test.go
+++ b/internal/observability/pprof_test.go
@@ -1,0 +1,23 @@
+package observability
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPProfHandler(t *testing.T) {
+	t.Parallel()
+
+	request := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	response := httptest.NewRecorder()
+	PProfHandler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+	if !strings.Contains(response.Body.String(), "profile") {
+		t.Fatalf("body does not contain pprof index:\n%s", response.Body.String())
+	}
+}

--- a/internal/replaytool/replay_pprof.go
+++ b/internal/replaytool/replay_pprof.go
@@ -1,0 +1,168 @@
+package replaytool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/observability"
+)
+
+const replayPProfShutdownTimeout = 5 * time.Second
+
+type replayPProfServer struct {
+	addr         string
+	server       *http.Server
+	done         chan error
+	shutdownOnce sync.Once
+	shutdownErr  error
+}
+
+func startReplayPProf(ctx context.Context, cancel context.CancelCauseFunc) (*replayPProfServer, error) {
+	var listenConfig net.ListenConfig
+	return startReplayPProfWithDependencies(
+		cancel,
+		os.Getenv,
+		func(network, address string) (net.Listener, error) {
+			return listenConfig.Listen(ctx, network, address)
+		},
+		observability.EnablePProf,
+	)
+}
+
+func startReplayPProfWithDependencies(
+	cancel context.CancelCauseFunc,
+	getenv func(string) string,
+	listen func(string, string) (net.Listener, error),
+	enable func(),
+) (*replayPProfServer, error) {
+	raw := strings.TrimSpace(getenv("GOXRPL_PPROF"))
+	if raw == "" {
+		return nil, nil
+	}
+
+	allowUnsafe, err := replayPProfAllowUnsafe(getenv("GOXRPL_PPROF_ALLOW_UNSAFE"))
+	if err != nil {
+		return nil, err
+	}
+	addr, err := normalizeReplayPProfAddress(raw, allowUnsafe)
+	if err != nil {
+		return nil, err
+	}
+	listener, err := listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("bind pprof server on %s: %w", addr, err)
+	}
+
+	profiler := &replayPProfServer{
+		addr: listener.Addr().String(),
+		server: &http.Server{
+			Addr:              addr,
+			Handler:           observability.PProfHandler(),
+			ReadHeaderTimeout: 5 * time.Second,
+		},
+		done: make(chan error, 1),
+	}
+	enable()
+	go profiler.serve(cancel, listener)
+	return profiler, nil
+}
+
+func (p *replayPProfServer) Addr() string {
+	return p.addr
+}
+
+func (p *replayPProfServer) serve(
+	cancel context.CancelCauseFunc,
+	listener net.Listener,
+) {
+	err := p.server.Serve(listener)
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		err = fmt.Errorf("pprof server on %s failed: %w", p.addr, err)
+		cancel(err)
+	} else {
+		err = nil
+	}
+	p.done <- err
+}
+
+func (p *replayPProfServer) Shutdown() error {
+	if p == nil {
+		return nil
+	}
+	p.shutdownOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), replayPProfShutdownTimeout)
+		defer cancel()
+
+		var errs []error
+		if err := observability.ShutdownHTTPServer(ctx, p.server); err != nil {
+			errs = append(errs, fmt.Errorf("shutdown pprof server: %w", err))
+		}
+		select {
+		case serveErr := <-p.done:
+			if serveErr != nil {
+				errs = append(errs, serveErr)
+			}
+		case <-ctx.Done():
+			errs = append(errs, errors.New("timed out waiting for pprof server to stop"))
+		}
+		p.shutdownErr = errors.Join(errs...)
+	})
+	return p.shutdownErr
+}
+
+func replayPProfAllowUnsafe(value string) (bool, error) {
+	switch value {
+	case "", "false":
+		return false, nil
+	case "true":
+		return true, nil
+	default:
+		return false, errors.New(`GOXRPL_PPROF_ALLOW_UNSAFE must be "true" or "false"`)
+	}
+}
+
+func normalizeReplayPProfAddress(raw string, allowUnsafe bool) (string, error) {
+	host, port, err := net.SplitHostPort(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid GOXRPL_PPROF address %q: %w", raw, err)
+	}
+	portNumber, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return "", fmt.Errorf("invalid GOXRPL_PPROF address %q: port must be a number from 0 to 65535", raw)
+	}
+
+	if host == "" {
+		host = "127.0.0.1"
+	} else if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
+		if !allowUnsafe {
+			if ip.To4() != nil {
+				host = "127.0.0.1"
+			} else {
+				host = "::1"
+			}
+		}
+	}
+	if !allowUnsafe && !isReplayPProfLoopback(host) {
+		return "", fmt.Errorf(
+			"GOXRPL_PPROF address %q is not loopback; set GOXRPL_PPROF_ALLOW_UNSAFE=true to expose pprof",
+			raw,
+		)
+	}
+	return net.JoinHostPort(host, strconv.FormatUint(portNumber, 10)), nil
+}
+
+func isReplayPProfLoopback(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/internal/replaytool/replay_pprof_test.go
+++ b/internal/replaytool/replay_pprof_test.go
@@ -1,0 +1,255 @@
+package replaytool
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestReplayRangeCommandUsesCommandContext(t *testing.T) {
+	t.Parallel()
+
+	wantCause := errors.New("stop replay")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(wantCause)
+
+	var gotContext context.Context
+	cmd := newReplayRangeCmdWithRun(func(ctx context.Context, _ *replayRangeRunner) error {
+		gotContext = ctx
+		return nil
+	})
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--from", "1", "--to", "2"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if cause := context.Cause(gotContext); !errors.Is(cause, wantCause) {
+		t.Fatalf("command context cause = %v, want %v", cause, wantCause)
+	}
+}
+
+func TestReplayRangeRunHonorsCanceledContext(t *testing.T) {
+	t.Setenv("GOXRPL_PPROF", "")
+	wantCause := errors.New("stop replay")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(wantCause)
+
+	runner := &replayRangeRunner{
+		out:  io.Discard,
+		from: 1,
+		to:   2,
+	}
+	if err := runner.run(ctx); !errors.Is(err, wantCause) {
+		t.Fatalf("run() error = %v, want %v", err, wantCause)
+	}
+}
+
+func TestNormalizeReplayPProfAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		raw         string
+		allowUnsafe bool
+		want        string
+		wantErr     string
+	}{
+		{name: "empty host", raw: ":6060", want: "127.0.0.1:6060"},
+		{name: "IPv4 wildcard", raw: "0.0.0.0:6060", want: "127.0.0.1:6060"},
+		{name: "IPv6 wildcard", raw: "[::]:6060", want: "[::1]:6060"},
+		{name: "unsafe IPv4 wildcard", raw: "0.0.0.0:6060", allowUnsafe: true, want: "0.0.0.0:6060"},
+		{name: "unsafe IPv6 wildcard", raw: "[::]:6060", allowUnsafe: true, want: "[::]:6060"},
+		{name: "localhost", raw: "localhost:6060", want: "localhost:6060"},
+		{name: "IPv4 loopback", raw: "127.0.0.2:6060", want: "127.0.0.2:6060"},
+		{name: "remote rejected", raw: "192.0.2.1:6060", wantErr: "ALLOW_UNSAFE=true"},
+		{name: "remote opted in", raw: "192.0.2.1:6060", allowUnsafe: true, want: "192.0.2.1:6060"},
+		{name: "missing port", raw: "localhost", wantErr: "missing port"},
+		{name: "named port", raw: "localhost:http", wantErr: "port must be a number"},
+		{name: "out of range port", raw: "localhost:65536", wantErr: "port must be a number"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := normalizeReplayPProfAddress(test.raw, test.allowUnsafe)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("normalizeReplayPProfAddress() error = %v, want containing %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeReplayPProfAddress() error = %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("normalizeReplayPProfAddress() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestStartReplayPProfRejectsMalformedUnsafeSetting(t *testing.T) {
+	t.Parallel()
+
+	_, err := startReplayPProfWithDependencies(
+		func(error) {},
+		replayPProfEnv(map[string]string{
+			"GOXRPL_PPROF":              ":6060",
+			"GOXRPL_PPROF_ALLOW_UNSAFE": "1",
+		}),
+		net.Listen,
+		func() {},
+	)
+	if err == nil || !strings.Contains(err.Error(), `must be "true" or "false"`) {
+		t.Fatalf("startReplayPProfWithDependencies() error = %v, want strict boolean error", err)
+	}
+}
+
+func TestStartReplayPProfBindsBeforeEnabling(t *testing.T) {
+	t.Parallel()
+
+	bindErr := errors.New("address already in use")
+	var enabled atomic.Bool
+	_, err := startReplayPProfWithDependencies(
+		func(error) {},
+		replayPProfEnv(map[string]string{"GOXRPL_PPROF": ":6060"}),
+		func(_, _ string) (net.Listener, error) {
+			return nil, bindErr
+		},
+		func() {
+			enabled.Store(true)
+		},
+	)
+	if !errors.Is(err, bindErr) {
+		t.Fatalf("startReplayPProfWithDependencies() error = %v, want %v", err, bindErr)
+	}
+	if enabled.Load() {
+		t.Fatal("profiling was enabled before the listener bound successfully")
+	}
+}
+
+func TestReplayRangeRunReturnsPProfBindFailure(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer listener.Close()
+	t.Setenv("GOXRPL_PPROF", listener.Addr().String())
+	t.Setenv("GOXRPL_PPROF_ALLOW_UNSAFE", "false")
+
+	runner := &replayRangeRunner{
+		out:  io.Discard,
+		from: 1,
+		to:   2,
+	}
+	err = runner.run(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "bind pprof server") {
+		t.Fatalf("run() error = %v, want pprof bind failure", err)
+	}
+}
+
+func TestStartReplayPProfServeFailureCancelsAndJoins(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	serveErr := errors.New("listener failed")
+	listener := &replayPProfTestListener{
+		addr: replayPProfTestAddr("127.0.0.1:6060"),
+		accept: func() (net.Conn, error) {
+			return nil, serveErr
+		},
+	}
+	profiler, err := startReplayPProfWithDependencies(
+		cancel,
+		replayPProfEnv(map[string]string{"GOXRPL_PPROF": ":6060"}),
+		func(_, _ string) (net.Listener, error) {
+			return listener, nil
+		},
+		func() {},
+	)
+	if err != nil {
+		t.Fatalf("startReplayPProfWithDependencies() error = %v", err)
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("context was not canceled after pprof serve failure")
+	}
+	if cause := context.Cause(ctx); cause == nil ||
+		!strings.Contains(cause.Error(), "pprof server") ||
+		!errors.Is(cause, serveErr) {
+		t.Fatalf("context cause = %v, want wrapped pprof serve error", cause)
+	}
+	if err := profiler.Shutdown(); !errors.Is(err, serveErr) {
+		t.Fatalf("Shutdown() error = %v, want wrapped %v", err, serveErr)
+	}
+}
+
+func TestStartReplayPProfServesOnLoopbackAndShutsDown(t *testing.T) {
+	t.Parallel()
+
+	_, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	profiler, err := startReplayPProfWithDependencies(
+		cancel,
+		replayPProfEnv(map[string]string{"GOXRPL_PPROF": ":0"}),
+		net.Listen,
+		func() {},
+	)
+	if err != nil {
+		t.Fatalf("startReplayPProfWithDependencies() error = %v", err)
+	}
+
+	host, _, err := net.SplitHostPort(profiler.Addr())
+	if err != nil {
+		t.Fatalf("profile address %q: %v", profiler.Addr(), err)
+	}
+	if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+		t.Fatalf("profile server bound to %q, want loopback", profiler.Addr())
+	}
+	if err := profiler.Shutdown(); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	if err := profiler.Shutdown(); err != nil {
+		t.Fatalf("second Shutdown() error = %v", err)
+	}
+	conn, err := net.DialTimeout("tcp", profiler.Addr(), 100*time.Millisecond)
+	if err == nil {
+		conn.Close()
+		t.Fatal("pprof listener still accepted connections after shutdown")
+	}
+}
+
+func replayPProfEnv(values map[string]string) func(string) string {
+	return func(name string) string {
+		return values[name]
+	}
+}
+
+type replayPProfTestListener struct {
+	addr   net.Addr
+	accept func() (net.Conn, error)
+}
+
+func (l *replayPProfTestListener) Accept() (net.Conn, error) {
+	return l.accept()
+}
+
+func (l *replayPProfTestListener) Close() error {
+	return nil
+}
+
+func (l *replayPProfTestListener) Addr() net.Addr {
+	return l.addr
+}
+
+type replayPProfTestAddr string
+
+func (a replayPProfTestAddr) Network() string { return "tcp" }
+func (a replayPProfTestAddr) String() string  { return string(a) }

--- a/internal/replaytool/replay_range.go
+++ b/internal/replaytool/replay_range.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
-	"github.com/LeJamon/go-xrpl/internal/observability"
 	txengine "github.com/LeJamon/go-xrpl/internal/tx/engine"
 
 	"github.com/spf13/cobra"
@@ -57,6 +56,12 @@ type replayRangeRunner struct {
 
 // newReplayRangeCmd builds the `replay-range` command and its flags.
 func newReplayRangeCmd() *cobra.Command {
+	return newReplayRangeCmdWithRun(func(ctx context.Context, runner *replayRangeRunner) error {
+		return runner.run(ctx)
+	})
+}
+
+func newReplayRangeCmdWithRun(run func(context.Context, *replayRangeRunner) error) *cobra.Command {
 	r := &replayRangeRunner{}
 	cmd := &cobra.Command{
 		Use:   "replay-range",
@@ -123,9 +128,9 @@ Example:
     xrpld replay-range --from 3275000 --to 3285000 --legacy-paychan-owner-dir-gate --paychan-owner-dir-first-fixed-ledger 3280000
     xrpld replay-range --from 99226370 --to 99236370 --checkpoint-dir ./ckpt
     xrpld replay-range --from 99226370 --to 99236370 --checkpoint-dir ./ckpt --resume-from 99230000`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			r.out = cmd.OutOrStdout()
-			return r.run()
+			return run(cmd.Context(), r)
 		},
 	}
 
@@ -169,7 +174,7 @@ type RangeReplayStats struct {
 	FailureReason     string
 }
 
-func (r *replayRangeRunner) run() error {
+func (r *replayRangeRunner) run(parentCtx context.Context) (runErr error) {
 	if err := r.validateFlags(); err != nil {
 		return err
 	}
@@ -190,19 +195,24 @@ func (r *replayRangeRunner) run() error {
 		startLedger = r.resumeFrom
 	}
 
-	ctx := context.Background()
-	startTime := time.Now()
-
-	// Opt-in profiling: GOXRPL_PPROF=:6060 exposes pprof for this run so the
-	// CPU-vs-IO split of a replay can be measured. Off by default.
-	if addr := os.Getenv("GOXRPL_PPROF"); addr != "" {
-		go func() {
-			if err := observability.StartPProf(addr); err != nil {
-				fmt.Fprintf(r.out, "      WARNING: pprof server failed on %s: %v\n", addr, err)
-			}
-		}()
-		fmt.Fprintf(r.out, "pprof enabled on %s\n", addr)
+	ctx, cancel := context.WithCancelCause(parentCtx)
+	defer cancel(nil)
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
 	}
+
+	profiler, err := startReplayPProf(ctx, cancel)
+	if err != nil {
+		return err
+	}
+	if profiler != nil {
+		fmt.Fprintf(r.out, "pprof enabled on %s\n", profiler.Addr())
+		defer func() {
+			runErr = errors.Join(runErr, profiler.Shutdown())
+		}()
+	}
+
+	startTime := time.Now()
 
 	// The default in-memory state path keeps the whole tree live for the run, so
 	// a higher GC trigger trades RAM for fewer full marks of a mostly-static set.
@@ -297,6 +307,9 @@ func (r *replayRangeRunner) run() error {
 		// Process this block
 		result, newStateMap, err := r.processBlock(ctx, client, currentStateMap, previousSnapshot, targetLedger, fees)
 		if err != nil {
+			if cause := context.Cause(ctx); cause != nil {
+				return cause
+			}
 			stats.FailedAtBlock = targetLedger
 			stats.FailureReason = err.Error()
 			fmt.Fprintf(r.out, "[%d] ERROR: %v\n", targetLedger, err)


### PR DESCRIPTION
## Summary

- construct a fresh Cobra command graph per execution with isolated options, dependencies, and streams
- return process exit codes from the CLI and keep `os.Exit` only in `cmd/xrpld/main.go`
- propagate command cancellation through node startup and shutdown
- bind metrics and pprof synchronously, fail startup on listener errors, use loopback-safe defaults, and own bounded shutdown
- apply the same secure pprof lifecycle to `replay-range`
- enforce Cobra argument contracts and owner-only generated main configuration files

This is the final integration slice for #1451. It contains the reviewed commits from #1456 and #1460 so the complete issue can be tested together.

Depends on #1456 and #1460. Merge those PRs first; after they land, this PR becomes the lifecycle-only remainder and should be merged last.

Fixes #1451

## Verification

- `go test -count=1 ./...`
- `go test -race -count=1 ./internal/cli ./internal/node ./internal/observability ./internal/replaytool ./cmd/xrpld`
- `just vet`
- `golangci-lint run`
- `golangci-lint run --config .golangci-warnings.yml`
- `just build-all`
- `just build-nocgo`
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go build ./...`
- `go mod tidy -diff`
- built-binary exit/output checks
