### PR TITLE
fix: make archive lifecycle reliable

### DIFF
--- a/config/examples/xrpld.toml
+++ b/config/examples/xrpld.toml
@@ -210,7 +210,7 @@ minimum_last_ledger_buffer = 2
 # batch_size         = 128    # rows per commit
 # flush_interval_ms  = 1000   # max latency for partial batches
 # delete_batch       = 1000   # rows per retention DELETE batch
-# in_memory_ledgers  = 256    # tracker eviction window (rippled minimum)
+# in_memory_ledgers  = 256    # tracker eviction window
 
 # Stall watchdog (optional). An out-of-band goroutine that detects a wedged
 # event loop (consensus timer or ledger close) and escalates: warn + goroutine

--- a/config/examples/xrpld.toml
+++ b/config/examples/xrpld.toml
@@ -194,18 +194,22 @@ minimum_last_ledger_buffer = 2
 # On-disk validation archive (optional). When enabled, validations
 # pruned from ValidationTracker are persisted to a `validations` table
 # in the relational DB so forensic tooling can query historical
-# validations. Omit the section to disable; uncomment + adjust to tune.
+# validations, including partial validations. This is a go-xrpl extension
+# inspired by rippled's historical validation database. Omit the section
+# to disable; uncomment + adjust to tune.
 #
 # Note: SQLite is the default backend, sharing ledger.db with single-
 # writer concurrency. Sustained ledger-write pressure can therefore
 # back up the archive's writer goroutine; under sustained overload
-# OnStale logs a warning and drops, rather than blocking consensus.
+# OnStale counts and rate-limits warnings for drops rather than blocking
+# consensus. Retention runs independently while idle and catches up through
+# bounded delete batches.
 # [validation_archive]
 # enabled            = true   # default false; set true to turn on
 # retention_ledgers  = 10000  # 0 = keep forever
 # batch_size         = 128    # rows per commit
 # flush_interval_ms  = 1000   # max latency for partial batches
-# delete_batch       = 1000   # max rows per retention sweep
+# delete_batch       = 1000   # rows per retention DELETE batch
 # in_memory_ledgers  = 256    # tracker eviction window (rippled minimum)
 
 # Stall watchdog (optional). An out-of-band goroutine that detects a wedged

--- a/config/validation_archive.go
+++ b/config/validation_archive.go
@@ -4,8 +4,8 @@ import "fmt"
 
 // ValidationArchiveConfig controls the on-disk validation archive —
 // persistence of stale validations pruned from ValidationTracker to the
-// relational DB's validations table. Follows rippled's historical
-// onStale/doStaleWrite pattern with Go-native batching semantics.
+// relational DB's validations table. It is inspired by rippled's historical
+// validation database, which was removed before rippled v3.2.0.
 type ValidationArchiveConfig struct {
 	// Enabled flips the archive on. When false no writer goroutine runs
 	// and OnStale is a no-op, regardless of whether the relational DB
@@ -16,7 +16,7 @@ type ValidationArchiveConfig struct {
 	// RetentionLedgers is the number of fully-validated ledgers of
 	// history to keep in the archive. Rows with ledger_seq below
 	// (currentFullyValidatedSeq - RetentionLedgers) are deleted on
-	// each flush tick. 0 disables retention (keep forever).
+	// independent maintenance sweeps. 0 disables retention (keep forever).
 	RetentionLedgers uint32 `toml:"retention_ledgers" mapstructure:"retention_ledgers"`
 
 	// BatchSize caps how many stale validations the writer accumulates
@@ -30,8 +30,8 @@ type ValidationArchiveConfig struct {
 	// Must be >= 10.
 	FlushIntervalMs int `toml:"flush_interval_ms" mapstructure:"flush_interval_ms"`
 
-	// DeleteBatch caps how many rows a single retention sweep deletes.
-	// Bounded so the writer never blocks on a multi-second DELETE scan.
+	// DeleteBatch caps each retention DELETE. Maintenance may issue several
+	// bounded deletes per sweep to catch up without one unbounded query.
 	// Must be >= 1.
 	DeleteBatch int `toml:"delete_batch" mapstructure:"delete_batch"`
 

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -290,10 +290,13 @@ omit one to use rippled's `TxQ::Setup` default, or set it explicitly
 ### Optional sections
 
 - **`[validation_archive]`** — persist pruned validations to a `validations` table
-  for forensic queries. `enabled` (default false), `retention_ledgers`
+  for forensic queries, including partial validations. This go-xrpl extension is
+  inspired by rippled's historical validation database. `enabled` (default false), `retention_ledgers`
   (`0` = forever), `batch_size`, `flush_interval_ms`, `delete_batch`,
   `in_memory_ledgers`. Backed by SQLite (shares `ledger.db`); under sustained
-  write overload the archive drops rather than blocking consensus.
+  write overload the archive counts drops and rate-limits warnings rather than
+  blocking consensus. Independent maintenance drains expired rows in bounded
+  batches even while archive writes are idle.
 - **`[amendments]`** — operator amendment-vote preferences. `upvote` votes *for*
   an amendment (rippled's `[amendments]` stanza); `veto` refuses to vote for it
   (rippled's `[veto_amendments]`). Names match the amendment registry; an amendment

--- a/internal/consensus/adaptor/identity.go
+++ b/internal/consensus/adaptor/identity.go
@@ -263,6 +263,7 @@ func (vi *ValidatorIdentity) SignValidation(validation *consensus.Validation) er
 	}
 	validation.SigningPubKey = consensus.SigningPubKey(vi.SigningKey)
 	validation.NodeID = vi.NodeID
+	validation.Flags = localValidationFlags(validation.Full)
 	data := buildValidationSigningData(validation)
 	sig, err := vi.Sign(data)
 	if err != nil {
@@ -334,9 +335,9 @@ func buildValidationSigningData(v *consensus.Validation) []byte {
 	// standing fork hazard). SerializeSTValidation emits sfSignature only
 	// when v.Signature is non-empty and as a distinct field between
 	// sfSigningPubKey and sfAmendments, so clearing it yields exactly the
-	// non-signature preimage. Outbound validations carry Flags == 0 (only
-	// the inbound parser sets Flags), so SerializeSTValidation synthesizes
-	// the same vfFullyCanonicalSig|vfFullValidation pair this used to build.
+	// non-signature preimage. SignValidation normalizes outbound Flags before
+	// reaching this helper, and SerializeSTValidation uses the same helper for
+	// unsigned self-built validations.
 	unsigned := *v
 	unsigned.Signature = nil
 	hash := sha512half.Sum(protocol.HashPrefixValidation().Bytes(), SerializeSTValidation(&unsigned))

--- a/internal/consensus/adaptor/identity_token_test.go
+++ b/internal/consensus/adaptor/identity_token_test.go
@@ -211,8 +211,43 @@ func TestNewValidatorIdentityFromToken_SignVerifyValidation(t *testing.T) {
 	if len(v.Signature) == 0 {
 		t.Fatal("expected non-empty signature")
 	}
+	if want := uint32(vfFullyCanonicalSig | vfFullValidation); v.Flags != want {
+		t.Fatalf("signed validation flags = %#x, want %#x", v.Flags, want)
+	}
 	if err := VerifyValidation(v); err != nil {
 		t.Fatalf("VerifyValidation: %v", err)
+	}
+
+	partial := &consensus.Validation{
+		LedgerID:  consensus.LedgerID{0x03, 0x04},
+		LedgerSeq: 43,
+		SignTime:  time.Unix(protocol.RippleEpochUnix+1001, 0),
+	}
+	if err := id.SignValidation(partial); err != nil {
+		t.Fatalf("SignValidation partial: %v", err)
+	}
+	if want := uint32(vfFullyCanonicalSig); partial.Flags != want {
+		t.Fatalf("signed partial validation flags = %#x, want %#x", partial.Flags, want)
+	}
+	if err := VerifyValidation(partial); err != nil {
+		t.Fatalf("VerifyValidation partial: %v", err)
+	}
+
+	conflicting := &consensus.Validation{
+		Full:      true,
+		Flags:     vfFullyCanonicalSig,
+		LedgerID:  consensus.LedgerID{0x05, 0x06},
+		LedgerSeq: 44,
+		SignTime:  time.Unix(protocol.RippleEpochUnix+1002, 0),
+	}
+	if err := id.SignValidation(conflicting); err != nil {
+		t.Fatalf("SignValidation conflicting flags: %v", err)
+	}
+	if want := uint32(vfFullyCanonicalSig | vfFullValidation); conflicting.Flags != want {
+		t.Fatalf("normalized conflicting flags = %#x, want %#x", conflicting.Flags, want)
+	}
+	if err := VerifyValidation(conflicting); err != nil {
+		t.Fatalf("VerifyValidation conflicting flags: %v", err)
 	}
 }
 

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -173,7 +173,8 @@ func (c *Components) runValidatorListTick(ctx context.Context, interval time.Dur
 }
 
 // Stop gracefully shuts down all components.
-func (c *Components) Stop() {
+func (c *Components) Stop() error {
+	var engineErr error
 	if c.vlTickCancel != nil {
 		c.vlTickCancel()
 	}
@@ -200,7 +201,7 @@ func (c *Components) Stop() {
 		c.Adaptor.StopConsensusPhaseDispatcher()
 	}
 	if c.Engine != nil {
-		_ = c.Engine.Stop()
+		engineErr = c.Engine.Stop()
 	}
 	// Drain both acquisition paths after the router loop has stopped. Components
 	// are one-shot; a process restart constructs a fresh Router.
@@ -219,6 +220,7 @@ func (c *Components) Stop() {
 	if c.Overlay != nil {
 		_ = c.Overlay.Stop()
 	}
+	return engineErr
 }
 
 // NewFromConfig creates and wires all consensus/networking components from the app config.

--- a/internal/consensus/adaptor/startup_cov_test.go
+++ b/internal/consensus/adaptor/startup_cov_test.go
@@ -2,6 +2,7 @@ package adaptor
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"math"
 	"testing"
@@ -507,6 +508,19 @@ func TestStup_ComponentsStop_WithMockEngine(t *testing.T) {
 	eng := &mockEngine{}
 	c := &Components{Engine: eng}
 	assert.NotPanics(t, func() { c.Stop() })
+}
+
+type stupStopErrorEngine struct {
+	mockEngine
+	err error
+}
+
+func (e *stupStopErrorEngine) Stop() error { return e.err }
+
+func TestStup_ComponentsStop_ReturnsEngineError(t *testing.T) {
+	stopErr := errors.New("engine stop failed")
+	c := &Components{Engine: &stupStopErrorEngine{err: stopErr}}
+	require.ErrorIs(t, c.Stop(), stopErr)
 }
 
 func TestStup_ComponentsStart_AndStop(t *testing.T) {

--- a/internal/consensus/adaptor/stvalidation.go
+++ b/internal/consensus/adaptor/stvalidation.go
@@ -271,13 +271,7 @@ func SerializeSTValidation(v *consensus.Validation) []byte {
 	// vfFullyCanonicalSig on every outbound validation so canonical-sig-
 	// strict peers don't need to special-case us, plus vfFullValidation
 	// when v.Full.
-	flags := v.Flags
-	if flags == 0 {
-		flags = vfFullyCanonicalSig
-		if v.Full {
-			flags |= vfFullValidation
-		}
-	}
+	flags := outboundValidationFlags(v)
 	buf = appendFieldHeader(buf, typeUINT32, fieldFlags)
 	buf = binary.BigEndian.AppendUint32(buf, flags)
 
@@ -416,6 +410,21 @@ func SerializeSTValidation(v *consensus.Validation) []byte {
 	}
 
 	return buf
+}
+
+func outboundValidationFlags(v *consensus.Validation) uint32 {
+	if v.Flags != 0 {
+		return v.Flags
+	}
+	return localValidationFlags(v.Full)
+}
+
+func localValidationFlags(full bool) uint32 {
+	flags := uint32(vfFullyCanonicalSig)
+	if full {
+		flags |= vfFullValidation
+	}
+	return flags
 }
 
 // readFieldHeader reads the XRPL field ID at data[*pos] and advances *pos.

--- a/internal/consensus/archive/archive.go
+++ b/internal/consensus/archive/archive.go
@@ -532,7 +532,6 @@ func (a *Archive) logDrop(lastLog *atomic.Int64, message string, attrs ...any) {
 	}
 }
 
-// Health returns cumulative counters and the most recent maintenance error.
 func (a *Archive) Health() Health {
 	if a == nil {
 		return Health{Healthy: true}

--- a/internal/consensus/archive/archive.go
+++ b/internal/consensus/archive/archive.go
@@ -1,42 +1,12 @@
-// Package archive persists stale validations to the relational DB via a
-// batched async writer hooked into ValidationTracker.SetOnStale.
-//
-// Matches rippled's onStale / doStaleWrite contract (RCLValidations.cpp)
-// in semantics: OnStale returns in O(1) — it only enqueues to a channel —
-// so the consensus receive path is never gated on DB I/O.
-//
-// # Eviction trigger: ledger-seq, not freshness (intentional divergence)
-//
-// Rippled (pre-2019) fired onStale from Validations<>::current() when
-// isCurrent() returned false — i.e. on time-window violations
-// (SignTime/SeenTime drifted outside the wall/local windows). go-xrpl
-// fires onStale only from ExpireOld(seq - inMemoryLedgers), which is
-// driven by ledger-seq retention from the fully-validated callback —
-// a per-ledger set accessed within validationSET_EXPIRES is held past
-// the window and archived on the first sweep after it goes cold.
-//
-// Practical consequence: time-stale validations that never reach a
-// fully-validated ledger (e.g. orphaned validations on losing forks)
-// are rejected at ValidationTracker.Add (isCurrent check at
-// validations.go:291) but are NOT archived. Rippled would have archived
-// them.
-//
-// Trade-off:
-//   - Forensic completeness for finalized network state: same as rippled.
-//   - Forensic completeness for "what did the network consider but
-//     discard": slightly lower — losing-fork validations are visible
-//     only in logs, not in the archive.
-//
-// Defensible because the dominant use case is replaying finalized state,
-// and the divergence avoids archiving orphans we'd just delete on the
-// next retention sweep. If "considered but discarded" forensics ever
-// becomes a requirement, hooking a second OnStale call from Add's
-// isCurrent reject path is straightforward.
+// Package archive persists validations evicted from the in-memory tracker.
+// It is a go-xrpl operational extension inspired by rippled's historical
+// validation database, which was removed before rippled v3.2.0.
 package archive
 
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -59,28 +29,85 @@ type Config struct {
 	DeleteBatch int
 }
 
-// Archive is the async writer. Safe for concurrent OnStale from any
-// goroutine once New has returned.
+type archiveState uint8
+
+const (
+	archiveRunning archiveState = iota
+	archiveClosing
+	archiveClosed
+)
+
+type flushRequest struct {
+	result chan error
+}
+
+type errorState struct {
+	err error
+}
+
+// Health is a cumulative snapshot of archive admission and maintenance.
+type Health struct {
+	Enqueued           uint64
+	OverloadDropped    uint64
+	ClosedDropped      uint64
+	MalformedDropped   uint64
+	PersistenceDropped uint64
+	WriteFailures      uint64
+	RetentionFailures  uint64
+	LastError          string
+	Healthy            bool
+}
+
+// Archive is the async writer. Safe for concurrent use.
 type Archive struct {
 	repo   relationaldb.ValidationRepository
 	cfg    Config
 	logger *slog.Logger
 
-	ch       chan *consensus.Validation
-	flushReq chan chan struct{} // ack channel per flush request
-	stop     chan struct{}
-	wg       sync.WaitGroup
-	flushed  chan struct{} // closed when the writer goroutine exits
+	ch                chan *consensus.Validation
+	flushWake         chan struct{}
+	retentionWake     chan struct{}
+	retentionTick     <-chan time.Time
+	stopTicker        func()
+	stop              chan struct{}
+	done              chan struct{}
+	runCtx            context.Context
+	cancelRun         context.CancelCauseFunc
+	maintenanceCtx    context.Context
+	cancelMaintenance context.CancelFunc
+
+	stateMu     sync.Mutex
+	state       archiveState
+	flushes     []*flushRequest
+	terminalErr error
 
 	lastSeq atomic.Uint32 // most-recent fully-validated seq, used as retention pivot
 
-	closed atomic.Bool
+	enqueued           atomic.Uint64
+	overloadDropped    atomic.Uint64
+	closedDropped      atomic.Uint64
+	malformedDropped   atomic.Uint64
+	persistenceDropped atomic.Uint64
+	writeFailures      atomic.Uint64
+	retentionFailures  atomic.Uint64
+	lastError          atomic.Pointer[errorState]
+	lastOverloadLog    atomic.Int64
+	lastMalformedLog   atomic.Int64
 }
 
 // New creates a running archive. repo may be nil — that turns OnStale into
-// a no-op and nothing is ever written. ch buffer is BatchSize*8 so a
-// moderate burst of stale validations never blocks the caller.
+// a no-op and nothing is ever written. The channel holds at least 64 rows and
+// otherwise scales with BatchSize so moderate bursts do not immediately shed.
 func New(repo relationaldb.ValidationRepository, cfg Config, logger *slog.Logger) *Archive {
+	return newArchive(repo, cfg, logger, nil)
+}
+
+func newArchive(
+	repo relationaldb.ValidationRepository,
+	cfg Config,
+	logger *slog.Logger,
+	retentionTick <-chan time.Time,
+) *Archive {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -93,49 +120,68 @@ func New(repo relationaldb.ValidationRepository, cfg Config, logger *slog.Logger
 	if cfg.DeleteBatch < 1 {
 		cfg.DeleteBatch = 1000
 	}
+	channelCapacity := cfg.BatchSize * 8
+	if channelCapacity < 64 {
+		channelCapacity = 64
+	}
 
+	runCtx, cancelRun := context.WithCancelCause(context.Background())
+	maintenanceCtx, cancelMaintenance := context.WithCancel(context.Background())
 	a := &Archive{
-		repo:     repo,
-		cfg:      cfg,
-		logger:   logger,
-		ch:       make(chan *consensus.Validation, cfg.BatchSize*8),
-		flushReq: make(chan chan struct{}, 4),
-		stop:     make(chan struct{}),
-		flushed:  make(chan struct{}),
+		repo:              repo,
+		cfg:               cfg,
+		logger:            logger,
+		ch:                make(chan *consensus.Validation, channelCapacity),
+		flushWake:         make(chan struct{}, 1),
+		retentionWake:     make(chan struct{}, 1),
+		retentionTick:     retentionTick,
+		stop:              make(chan struct{}),
+		done:              make(chan struct{}),
+		runCtx:            runCtx,
+		cancelRun:         cancelRun,
+		maintenanceCtx:    maintenanceCtx,
+		cancelMaintenance: cancelMaintenance,
 	}
-	if repo != nil {
-		a.wg.Add(1)
-		go a.run()
-	} else {
-		close(a.flushed)
+	if repo == nil {
+		a.state = archiveClosed
+		cancelMaintenance()
+		cancelRun(nil)
+		close(a.done)
+		return a
 	}
+	if cfg.RetentionLedgers > 0 && retentionTick == nil {
+		ticker := time.NewTicker(retentionMinInterval)
+		a.retentionTick = ticker.C
+		a.stopTicker = ticker.Stop
+	}
+	go a.run()
 	return a
 }
 
-// OnStale is the ValidationTracker.SetOnStale callback. Non-blocking when
-// the channel has space; falls through a small bounded blocking wait
-// (matches rippled's vector-append semantics) so under sustained overload
-// we apply back-pressure instead of silently dropping validations.
+// OnStale is the ValidationTracker.SetOnStale callback. It never waits for
+// channel capacity or database I/O.
 func (a *Archive) OnStale(v *consensus.Validation) {
-	if a == nil || a.repo == nil || v == nil || a.closed.Load() {
+	if a == nil || a.repo == nil || v == nil {
+		return
+	}
+
+	a.stateMu.Lock()
+	defer a.stateMu.Unlock()
+	if a.state != archiveRunning {
+		a.closedDropped.Add(1)
 		return
 	}
 	select {
 	case a.ch <- v:
-		return
+		a.enqueued.Add(1)
 	default:
-	}
-	// Fall back to a bounded blocking send — 100ms is an eternity at
-	// consensus-message timescales but still lets the caller progress if
-	// the writer goroutine is wedged.
-	t := time.NewTimer(100 * time.Millisecond)
-	defer t.Stop()
-	select {
-	case a.ch <- v:
-	case <-t.C:
-		a.logger.Warn("validation archive channel full; dropping stale validation",
-			slog.Uint64("ledger_seq", uint64(v.LedgerSeq)))
-	case <-a.stop:
+		n := a.overloadDropped.Add(1)
+		a.logDrop(
+			&a.lastOverloadLog,
+			"validation archive channel full; dropping stale validations",
+			slog.Uint64("ledger_seq", uint64(v.LedgerSeq)),
+			slog.Uint64("dropped_total", n),
+		)
 	}
 }
 
@@ -157,45 +203,38 @@ func (a *Archive) NoteFullyValidated(seq uint32) {
 	}
 }
 
-// Flush blocks until every stale validation enqueued before the call has
-// been committed. Returns ErrClosed if called after Close so callers
-// notice attempts to flush a stopped archive (the previous silent-nil
-// behaviour hid bugs); returns nil for a nil receiver or a nil-repo
-// archive (those are configured no-ops, not error states).
-//
-// Implemented as an ack-channel barrier: we send an ack channel on
-// flushReq AFTER every previously-enqueued OnStale has landed in ch
-// (FIFO on the same goroutine ordering), and the writer loop closes the
-// ack only after it has fully drained ch up to that point and committed
-// the resulting batch.
+// Flush waits until every validation admitted before its barrier has been
+// processed. A persistence failure remains sticky because a later successful
+// write cannot restore rows that were already lost.
 func (a *Archive) Flush(ctx context.Context) error {
 	if a == nil || a.repo == nil {
 		return nil
 	}
-	if a.closed.Load() {
+
+	req := &flushRequest{result: make(chan error, 1)}
+	a.stateMu.Lock()
+	if a.state != archiveRunning {
+		a.stateMu.Unlock()
 		return ErrClosed
 	}
-	ack := make(chan struct{})
+	a.flushes = append(a.flushes, req)
 	select {
-	case a.flushReq <- ack:
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-a.stop:
-		return nil
+	case a.flushWake <- struct{}{}:
+	default:
 	}
+	a.stateMu.Unlock()
+
 	select {
-	case <-ack:
-		return nil
+	case err := <-req.result:
+		return err
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-a.stop:
-		return nil
 	}
 }
 
-// ApplyRetention performs a one-shot retention sweep against the current
-// NotedFullyValidated seq. Intended for tests and manual admin flushes;
-// the writer loop calls it implicitly after each batch commit.
+// ApplyRetention performs one bounded retention delete. Automatic maintenance
+// calls it repeatedly within a work budget; callers may use it for a
+// synchronous administrative sweep.
 func (a *Archive) ApplyRetention(ctx context.Context) (int64, error) {
 	if a == nil || a.repo == nil || a.cfg.RetentionLedgers == 0 {
 		return 0, nil
@@ -208,68 +247,105 @@ func (a *Archive) ApplyRetention(ctx context.Context) (int64, error) {
 	return a.repo.DeleteOlderThanSeq(ctx, relationaldb.LedgerIndex(cutoff), a.cfg.DeleteBatch)
 }
 
-// Close drains pending validations, commits the final batch, and stops
-// the writer goroutine. Safe to call multiple times; subsequent calls
-// return nil immediately.
+// Close drains accepted validations and waits for the shared terminal result.
+// If the initiating context expires, it cancels writer I/O; later callers can
+// still wait for and observe the eventual terminal error.
 func (a *Archive) Close(ctx context.Context) error {
-	if a == nil {
+	if a == nil || a.repo == nil {
 		return nil
 	}
-	if !a.closed.CompareAndSwap(false, true) {
-		return nil
+
+	a.stateMu.Lock()
+	if a.state == archiveClosed {
+		err := a.terminalErr
+		a.stateMu.Unlock()
+		return err
 	}
-	close(a.stop)
+	first := a.state == archiveRunning
+	if first {
+		a.state = archiveClosing
+		a.cancelMaintenance()
+		close(a.stop)
+	}
+	a.stateMu.Unlock()
+
+	var stopCancel func() bool
+	if first {
+		stopCancel = context.AfterFunc(ctx, func() {
+			a.cancelRun(ctx.Err())
+		})
+	}
+
 	select {
-	case <-a.flushed:
+	case <-a.done:
+		if stopCancel != nil {
+			stopCancel()
+		}
+		return a.terminalResult()
 	case <-ctx.Done():
-		return ctx.Err()
+		select {
+		case <-a.done:
+			if stopCancel != nil {
+				stopCancel()
+			}
+			return a.terminalResult()
+		default:
+			if first {
+				a.cancelRun(ctx.Err())
+			}
+			return ctx.Err()
+		}
 	}
-	a.wg.Wait()
-	return nil
 }
 
-// retentionMinInterval is the minimum wall-clock gap between two
-// retention sweeps. Decoupling retention from the per-batch flush rate
-// caps DELETE pressure under sustained load: with BatchSize=128 and
-// FlushInterval=1s the writer can commit every second, but retention
-// only runs ~once per minute. The bounded DeleteBatch keeps each sweep
-// cheap, so the archive size still tracks RetentionLedgers within a
-// minute of any seq advance.
-const retentionMinInterval = time.Minute
+const (
+	retentionMinInterval  = time.Minute
+	retentionSweepTimeout = 5 * time.Second
+	retentionBatchBudget  = 8
+	dropLogInterval       = time.Second
+	writeTimeout          = 30 * time.Second
+	writeRetryDelay       = 50 * time.Millisecond
+)
 
-// saveBatchMaxAttempts is how many times the writer retries a failed
+// saveBatchMaxAttempts is the maximum number of write attempts for a failed
 // SaveBatch before logging and dropping the batch. One retry catches
 // transient lock contention / connection blips; persistent failure
 // (disk full, schema drift) gets logged at Error level so the operator
 // notices, then dropped to avoid unbounded memory growth.
 const saveBatchMaxAttempts = 2
 
-// run is the writer goroutine. It accumulates up to BatchSize rows or
-// waits FlushInterval, whichever comes first, then commits. Retention
-// runs after every non-empty commit BUT only if at least
-// retentionMinInterval has elapsed since the last sweep — see comment
-// on retentionMinInterval for why per-flush retention is too aggressive.
 func (a *Archive) run() {
-	defer a.wg.Done()
-	defer close(a.flushed)
-
 	ticker := time.NewTicker(a.cfg.FlushInterval)
 	defer ticker.Stop()
-
-	var lastRetention time.Time
+	if a.stopTicker != nil {
+		defer a.stopTicker()
+	}
 
 	batch := make([]*relationaldb.ValidationRecord, 0, a.cfg.BatchSize)
-	flush := func(reason string) {
-		if len(batch) == 0 {
+	var durabilityErr error
+
+	noteDurabilityFailure := func(err error, rows int) {
+		if err == nil {
 			return
 		}
+		wrapped := fmt.Errorf("%w: %w", ErrDurability, err)
+		if durabilityErr == nil {
+			durabilityErr = wrapped
+		}
+		a.lastError.Store(&errorState{err: wrapped})
+		a.writeFailures.Add(1)
+		a.persistenceDropped.Add(uint64(rows))
+	}
 
-		// Retry-once on SaveBatch error. Most failures are transient
-		// (SQLite SQLITE_BUSY under contention, brief Postgres
-		// disconnects) and a single 50ms backoff clears them.
+	flush := func(reason string) error {
+		if len(batch) == 0 {
+			return nil
+		}
+
+		rows := len(batch)
 		var err error
 		for attempt := 1; attempt <= saveBatchMaxAttempts; attempt++ {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(a.runCtx, writeTimeout)
 			err = a.repo.SaveBatch(ctx, batch)
 			cancel()
 			if err == nil {
@@ -278,39 +354,29 @@ func (a *Archive) run() {
 			if attempt < saveBatchMaxAttempts {
 				a.logger.Warn("validation archive: batch write failed; retrying",
 					slog.Int("rows", len(batch)), slog.Int("attempt", attempt), slog.String("err", err.Error()))
-				time.Sleep(50 * time.Millisecond)
+				timer := time.NewTimer(writeRetryDelay)
+				select {
+				case <-timer.C:
+				case <-a.runCtx.Done():
+					timer.Stop()
+					err = context.Cause(a.runCtx)
+					attempt = saveBatchMaxAttempts
+				}
 			}
 		}
 		if err != nil {
-			// Persistent failure: log at Error so operators notice, then
-			// drop the batch. Re-queueing indefinitely would let memory
-			// grow without bound on a permanently broken backend, which
-			// is strictly worse than visible data loss with a paper
-			// trail.
 			a.logger.Error("validation archive: batch write failed permanently; dropping rows",
 				slog.Int("rows", len(batch)),
 				slog.Int("attempts", saveBatchMaxAttempts),
 				slog.String("reason", reason),
 				slog.String("err", err.Error()))
+			noteDurabilityFailure(err, rows)
 		} else {
 			a.logger.Debug("validation archive: batch committed",
 				slog.Int("rows", len(batch)), slog.String("reason", reason))
 		}
 		batch = batch[:0]
-
-		// Retention sweep — gated on retentionMinInterval to keep
-		// DELETE pressure off the hot path under sustained flush
-		// activity. Errors are logged but don't stop the writer.
-		if a.cfg.RetentionLedgers > 0 && time.Since(lastRetention) >= retentionMinInterval {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			_, rerr := a.ApplyRetention(ctx)
-			cancel()
-			lastRetention = time.Now()
-			if rerr != nil {
-				a.logger.Warn("validation archive: retention sweep failed",
-					slog.String("err", rerr.Error()))
-			}
-		}
+		return err
 	}
 
 	drainPending := func() {
@@ -320,26 +386,20 @@ func (a *Archive) run() {
 				if v == nil {
 					continue
 				}
-				rec := toRecord(v, a.lastSeq.Load())
-				if rec == nil {
-					continue
-				}
-				batch = append(batch, rec)
+				a.appendRecord(&batch, v)
 			default:
 				return
 			}
 		}
 	}
 
-	handleFlushReq := func(ack chan struct{}) {
-		// Drain everything enqueued before flush was requested. Flush
-		// is called from outside run, so anything a caller enqueued
-		// BEFORE sending the flushReq is already on ch by the time
-		// flushReq arrives (Go channel operations are happens-before
-		// synchronized). Drain to empty to pick it all up.
+	handleFlushes := func() {
+		requests := a.takeFlushes()
 		drainPending()
-		flush("flush-request")
-		close(ack)
+		_ = flush("flush-request")
+		for _, req := range requests {
+			req.result <- durabilityErr
+		}
 	}
 
 	for {
@@ -348,34 +408,144 @@ func (a *Archive) run() {
 			if v == nil {
 				continue
 			}
-			rec := toRecord(v, a.lastSeq.Load())
-			if rec == nil {
-				continue
-			}
-			batch = append(batch, rec)
+			a.appendRecord(&batch, v)
 			if len(batch) >= a.cfg.BatchSize {
-				flush("full")
+				_ = flush("full")
 			}
-		case ack := <-a.flushReq:
-			handleFlushReq(ack)
+		case <-a.flushWake:
+			handleFlushes()
 		case <-ticker.C:
-			flush("tick")
+			_ = flush("tick")
+		case <-a.retentionTick:
+			a.applyRetentionBudget()
+		case <-a.retentionWake:
+			a.applyRetentionBudget()
 		case <-a.stop:
-			// Commit everything already enqueued BEFORE acking any
-			// pending flush requests: Flush's contract (data committed on
-			// return) must hold even when a Flush races Close.
 			drainPending()
-			flush("close")
-			for {
-				select {
-				case ack := <-a.flushReq:
-					close(ack)
-				default:
-					return
-				}
+			_ = flush("close")
+			for _, req := range a.takeFlushes() {
+				req.result <- durabilityErr
 			}
+			a.finish(durabilityErr)
+			return
+		case <-a.runCtx.Done():
+			drainPending()
+			_ = flush("close-canceled")
+			for _, req := range a.takeFlushes() {
+				req.result <- durabilityErr
+			}
+			a.finish(durabilityErr)
+			return
 		}
 	}
+}
+
+func (a *Archive) appendRecord(
+	batch *[]*relationaldb.ValidationRecord,
+	v *consensus.Validation,
+) {
+	rec := toRecord(v, a.lastSeq.Load())
+	if rec != nil {
+		*batch = append(*batch, rec)
+		return
+	}
+	n := a.malformedDropped.Add(1)
+	a.logDrop(
+		&a.lastMalformedLog,
+		"validation archive received validation without canonical raw bytes; dropping",
+		slog.Uint64("ledger_seq", uint64(v.LedgerSeq)),
+		slog.Uint64("dropped_total", n),
+	)
+}
+
+func (a *Archive) takeFlushes() []*flushRequest {
+	a.stateMu.Lock()
+	defer a.stateMu.Unlock()
+	requests := a.flushes
+	a.flushes = nil
+	return requests
+}
+
+func (a *Archive) finish(err error) {
+	a.stateMu.Lock()
+	a.state = archiveClosed
+	a.terminalErr = err
+	a.stateMu.Unlock()
+	a.cancelMaintenance()
+	a.cancelRun(err)
+	close(a.done)
+}
+
+func (a *Archive) terminalResult() error {
+	a.stateMu.Lock()
+	defer a.stateMu.Unlock()
+	return a.terminalErr
+}
+
+func (a *Archive) applyRetentionBudget() {
+	if a.cfg.RetentionLedgers == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(a.maintenanceCtx, retentionSweepTimeout)
+	defer cancel()
+
+	backlog := false
+	for range retentionBatchBudget {
+		n, err := a.ApplyRetention(ctx)
+		if err != nil {
+			if a.maintenanceCtx.Err() != nil {
+				return
+			}
+			a.retentionFailures.Add(1)
+			a.lastError.Store(&errorState{err: err})
+			a.logger.Warn("validation archive: retention sweep failed", slog.String("err", err.Error()))
+			return
+		}
+		backlog = n == int64(a.cfg.DeleteBatch)
+		if !backlog {
+			return
+		}
+	}
+	if backlog {
+		select {
+		case a.retentionWake <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (a *Archive) logDrop(lastLog *atomic.Int64, message string, attrs ...any) {
+	now := time.Now().UnixNano()
+	last := lastLog.Load()
+	if now-last >= int64(dropLogInterval) && lastLog.CompareAndSwap(last, now) {
+		a.logger.Warn(message, attrs...)
+	}
+}
+
+// Health returns cumulative counters and the most recent maintenance error.
+func (a *Archive) Health() Health {
+	if a == nil {
+		return Health{Healthy: true}
+	}
+	health := Health{
+		Enqueued:           a.enqueued.Load(),
+		OverloadDropped:    a.overloadDropped.Load(),
+		ClosedDropped:      a.closedDropped.Load(),
+		MalformedDropped:   a.malformedDropped.Load(),
+		PersistenceDropped: a.persistenceDropped.Load(),
+		WriteFailures:      a.writeFailures.Load(),
+		RetentionFailures:  a.retentionFailures.Load(),
+	}
+	if state := a.lastError.Load(); state != nil && state.err != nil {
+		health.LastError = state.err.Error()
+	}
+	health.Healthy = health.OverloadDropped == 0 &&
+		health.ClosedDropped == 0 &&
+		health.MalformedDropped == 0 &&
+		health.PersistenceDropped == 0 &&
+		health.WriteFailures == 0 &&
+		health.RetentionFailures == 0
+	return health
 }
 
 // toRecord marshals a Validation into the archive row shape. Returns nil
@@ -387,10 +557,8 @@ func (a *Archive) run() {
 // delete"). Pass 0 if no fully-validated pivot has been observed yet;
 // the column then degenerates to LedgerSeq, which is harmless.
 //
-// Non-Full validations are filtered upstream at ValidationTracker.Add
-// (validations.go:297) — they never enter the tracker, so the OnStale
-// stream never carries them. We don't re-filter here; rippled's
-// historical doStaleWrite filter is therefore moot for go-xrpl.
+// Full and partial validations are both retained. The archive is forensic,
+// and Flags preserves the distinction for readers.
 func toRecord(v *consensus.Validation, initialSeq uint32) *relationaldb.ValidationRecord {
 	if v == nil {
 		return nil
@@ -432,5 +600,9 @@ func toRecord(v *consensus.Validation, initialSeq uint32) *relationaldb.Validati
 	return rec
 }
 
-// ErrClosed is returned by callers that try to use an Archive after Close.
-var ErrClosed = errors.New("archive: closed")
+var (
+	// ErrClosed is returned by callers that try to flush a closing archive.
+	ErrClosed = errors.New("archive: closed")
+	// ErrDurability marks permanent loss of one or more admitted validations.
+	ErrDurability = errors.New("archive: durability failure")
+)

--- a/internal/consensus/archive/archive.go
+++ b/internal/consensus/archive/archive.go
@@ -68,6 +68,7 @@ type Archive struct {
 	flushWake         chan struct{}
 	retentionWake     chan struct{}
 	retentionTick     <-chan time.Time
+	retentionTimeout  time.Duration
 	stopTicker        func()
 	stop              chan struct{}
 	done              chan struct{}
@@ -135,6 +136,7 @@ func newArchive(
 		flushWake:         make(chan struct{}, 1),
 		retentionWake:     make(chan struct{}, 1),
 		retentionTick:     retentionTick,
+		retentionTimeout:  retentionSweepTimeout,
 		stop:              make(chan struct{}),
 		done:              make(chan struct{}),
 		runCtx:            runCtx,
@@ -486,7 +488,7 @@ func (a *Archive) applyRetentionBudget() {
 	if a.cfg.RetentionLedgers == 0 {
 		return
 	}
-	ctx, cancel := context.WithTimeout(a.maintenanceCtx, retentionSweepTimeout)
+	ctx, cancel := context.WithTimeout(a.maintenanceCtx, a.retentionTimeout)
 	defer cancel()
 
 	backlog := false
@@ -494,6 +496,10 @@ func (a *Archive) applyRetentionBudget() {
 		n, err := a.ApplyRetention(ctx)
 		if err != nil {
 			if a.maintenanceCtx.Err() != nil {
+				return
+			}
+			if backlog && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				a.wakeRetention()
 				return
 			}
 			a.retentionFailures.Add(1)
@@ -507,10 +513,14 @@ func (a *Archive) applyRetentionBudget() {
 		}
 	}
 	if backlog {
-		select {
-		case a.retentionWake <- struct{}{}:
-		default:
-		}
+		a.wakeRetention()
+	}
+}
+
+func (a *Archive) wakeRetention() {
+	select {
+	case a.retentionWake <- struct{}{}:
+	default:
 	}
 }
 

--- a/internal/consensus/archive/archive_test.go
+++ b/internal/consensus/archive/archive_test.go
@@ -1,8 +1,11 @@
 package archive
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -22,6 +25,7 @@ type fakeRepo struct {
 
 	deletes   []int64 // maxSeq arguments in order
 	deleteErr error
+	deleteCh  chan int64
 }
 
 func (f *fakeRepo) Save(ctx context.Context, v *relationaldb.ValidationRecord) error {
@@ -30,7 +34,13 @@ func (f *fakeRepo) Save(ctx context.Context, v *relationaldb.ValidationRecord) e
 
 func (f *fakeRepo) SaveBatch(ctx context.Context, vs []*relationaldb.ValidationRecord) error {
 	if f.saveWait > 0 {
-		time.Sleep(f.saveWait)
+		timer := time.NewTimer(f.saveWait)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -71,13 +81,16 @@ func (f *fakeRepo) DeleteOlderThanSeq(ctx context.Context, maxSeq relationaldb.L
 	kept := f.rows[:0]
 	removed := int64(0)
 	for _, r := range f.rows {
-		if r.LedgerSeq < maxSeq {
+		if r.LedgerSeq < maxSeq && (batchSize <= 0 || removed < int64(batchSize)) {
 			removed++
 			continue
 		}
 		kept = append(kept, r)
 	}
 	f.rows = kept
+	if f.deleteCh != nil {
+		f.deleteCh <- removed
+	}
 	return removed, nil
 }
 
@@ -172,8 +185,9 @@ func TestArchive_CloseDrainsPending(t *testing.T) {
 	if repo.rowCount() != 4 {
 		t.Fatalf("Close did not commit pending rows: got %d, want 4", repo.rowCount())
 	}
-	// Close is idempotent.
-	if err := a.Close(context.Background()); err != nil {
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := a.Close(canceled); err != nil {
 		t.Fatalf("second Close errored: %v", err)
 	}
 }
@@ -196,7 +210,7 @@ func TestArchive_OnStale_NonBlocking_UnderSlowRepo(t *testing.T) {
 
 func TestArchive_ApplyRetention_HonorsLastSeq(t *testing.T) {
 	repo := &fakeRepo{}
-	a := New(repo, Config{BatchSize: 1, FlushInterval: time.Hour, RetentionLedgers: 10, DeleteBatch: 1000}, nil)
+	a := New(repo, Config{BatchSize: 1000, FlushInterval: time.Hour, RetentionLedgers: 10, DeleteBatch: 1000}, nil)
 	defer a.Close(context.Background())
 
 	for i := uint32(1); i <= 20; i++ {
@@ -222,7 +236,7 @@ func TestArchive_ApplyRetention_HonorsLastSeq(t *testing.T) {
 
 func TestArchive_ApplyRetention_ZeroRetention_Noop(t *testing.T) {
 	repo := &fakeRepo{}
-	a := New(repo, Config{BatchSize: 1, FlushInterval: time.Hour, RetentionLedgers: 0, DeleteBatch: 1000}, nil)
+	a := New(repo, Config{BatchSize: 1000, FlushInterval: time.Hour, RetentionLedgers: 0, DeleteBatch: 1000}, nil)
 	defer a.Close(context.Background())
 
 	for i := uint32(1); i <= 5; i++ {
@@ -308,16 +322,15 @@ func TestArchive_SaveBatch_RetryOnceThenSucceed(t *testing.T) {
 	}
 }
 
-func TestArchive_SaveBatch_PersistentFailure_DropsAndContinues(t *testing.T) {
+func TestArchive_SaveBatch_PersistentFailureRemainsObservable(t *testing.T) {
 	base := &fakeRepo{}
 	// More failures than retries → batch is dropped after attempts.
 	repo := &flakyRepo{fakeRepo: base, failureLeft: 100}
 	a := New(repo, Config{BatchSize: 1, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
-	defer a.Close(context.Background())
 
 	a.OnStale(mkVal(100, 0x01))
-	if err := a.Flush(context.Background()); err != nil {
-		t.Fatal(err)
+	if err := a.Flush(context.Background()); !errors.Is(err, ErrDurability) {
+		t.Fatalf("Flush returned %v, want ErrDurability", err)
 	}
 
 	// Failed batch must be dropped — no row in the underlying repo.
@@ -332,11 +345,18 @@ func TestArchive_SaveBatch_PersistentFailure_DropsAndContinues(t *testing.T) {
 	repo.mu.Unlock()
 
 	a.OnStale(mkVal(101, 0x02))
-	if err := a.Flush(context.Background()); err != nil {
-		t.Fatal(err)
+	if err := a.Flush(context.Background()); !errors.Is(err, ErrDurability) {
+		t.Fatalf("later Flush returned %v, want sticky ErrDurability", err)
 	}
 	if base.rowCount() != 1 {
 		t.Fatalf("writer dead after persistent failure: rowCount=%d, want 1", base.rowCount())
+	}
+	if err := a.Close(context.Background()); !errors.Is(err, ErrDurability) {
+		t.Fatalf("Close returned %v, want sticky ErrDurability", err)
+	}
+	health := a.Health()
+	if health.WriteFailures != 1 || health.PersistenceDropped != 1 || health.Healthy {
+		t.Fatalf("unexpected health after persistence failure: %+v", health)
 	}
 }
 
@@ -375,5 +395,260 @@ func TestArchive_OnStale_AfterClose_IsNoop(t *testing.T) {
 	case <-doneCh:
 	case <-time.After(200 * time.Millisecond):
 		t.Fatalf("OnStale blocked after Close; completed %d/50", dropped.Load())
+	}
+	if got := a.Health().ClosedDropped; got != 50 {
+		t.Fatalf("closed drop count=%d, want 50", got)
+	}
+}
+
+type blockingRepo struct {
+	*fakeRepo
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingRepo() *blockingRepo {
+	return &blockingRepo{
+		fakeRepo: &fakeRepo{},
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+}
+
+func (r *blockingRepo) SaveBatch(
+	ctx context.Context,
+	vs []*relationaldb.ValidationRecord,
+) error {
+	r.once.Do(func() { close(r.started) })
+	select {
+	case <-r.release:
+		return r.fakeRepo.SaveBatch(ctx, vs)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestArchive_FlushRacingCloseWaitsForPersistence(t *testing.T) {
+	repo := newBlockingRepo()
+	a := New(repo, Config{BatchSize: 1000, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
+	a.OnStale(mkVal(1, 1))
+
+	flushDone := make(chan error, 1)
+	go func() { flushDone <- a.Flush(context.Background()) }()
+	<-repo.started
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- a.Close(context.Background()) }()
+
+	select {
+	case err := <-flushDone:
+		t.Fatalf("Flush returned before persistence completed: %v", err)
+	default:
+	}
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before persistence completed: %v", err)
+	default:
+	}
+
+	close(repo.release)
+	if err := <-flushDone; err != nil {
+		t.Fatalf("Flush returned %v", err)
+	}
+	if err := <-closeDone; err != nil {
+		t.Fatalf("Close returned %v", err)
+	}
+	if got := repo.rowCount(); got != 1 {
+		t.Fatalf("persisted rows=%d, want 1", got)
+	}
+}
+
+func TestArchive_FlushRacingCloseReturnsErrClosedWhenCloseWins(t *testing.T) {
+	repo := newBlockingRepo()
+	a := New(repo, Config{BatchSize: 1, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
+	a.OnStale(mkVal(1, 1))
+	<-repo.started
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- a.Close(context.Background()) }()
+	<-a.stop
+
+	if err := a.Flush(context.Background()); !errors.Is(err, ErrClosed) {
+		t.Fatalf("Flush returned %v, want ErrClosed", err)
+	}
+	close(repo.release)
+	if err := <-closeDone; err != nil {
+		t.Fatalf("Close returned %v", err)
+	}
+}
+
+func TestArchive_CloseTimeoutRemainsWaitable(t *testing.T) {
+	repo := newBlockingRepo()
+	a := New(repo, Config{BatchSize: 1, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
+	a.OnStale(mkVal(1, 1))
+	<-repo.started
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := a.Close(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("first Close returned %v, want deadline exceeded", err)
+	}
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+	defer waitCancel()
+	err := a.Close(waitCtx)
+	if !errors.Is(err, ErrDurability) {
+		t.Fatalf("second Close returned %v, want terminal ErrDurability", err)
+	}
+	if got := a.Health().PersistenceDropped; got != 1 {
+		t.Fatalf("persistence drops=%d, want 1", got)
+	}
+}
+
+func TestArchive_OnStaleSaturationIsNonBlockingAndCounted(t *testing.T) {
+	repo := newBlockingRepo()
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	a := New(repo, Config{BatchSize: 1, FlushInterval: time.Hour, DeleteBatch: 1}, logger)
+
+	a.OnStale(mkVal(1, 1))
+	<-repo.started
+	for i := range cap(a.ch) {
+		a.OnStale(mkVal(uint32(i+2), 1))
+	}
+	start := time.Now()
+	for i := range 100 {
+		a.OnStale(mkVal(uint32(i+100), 2))
+	}
+	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+		t.Fatalf("100 saturated OnStale calls took %v", elapsed)
+	}
+
+	health := a.Health()
+	if health.OverloadDropped != 100 {
+		t.Fatalf("overload drops=%d, want 100", health.OverloadDropped)
+	}
+	if got := strings.Count(logs.String(), "channel full"); got != 1 {
+		t.Fatalf("overload warning count=%d, want 1\n%s", got, logs.String())
+	}
+
+	close(repo.release)
+	if err := a.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := repo.rowCount(), int(health.Enqueued); got != want {
+		t.Fatalf("persisted rows=%d, admitted=%d", got, want)
+	}
+}
+
+func TestArchive_ConcurrentAdmissionAndCloseAccountsEveryValidation(t *testing.T) {
+	repo := &fakeRepo{}
+	a := New(repo, Config{BatchSize: 1000, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
+
+	start := make(chan struct{})
+	var producers sync.WaitGroup
+	for i := range 200 {
+		producers.Add(1)
+		go func(i int) {
+			defer producers.Done()
+			<-start
+			a.OnStale(mkVal(uint32(i+1), byte(i)))
+		}(i)
+	}
+	closeDone := make(chan error, 1)
+	go func() {
+		<-start
+		closeDone <- a.Close(context.Background())
+	}()
+	close(start)
+	producers.Wait()
+	if err := <-closeDone; err != nil {
+		t.Fatal(err)
+	}
+
+	health := a.Health()
+	if got := health.Enqueued + health.ClosedDropped + health.OverloadDropped; got != 200 {
+		t.Fatalf("accounted validations=%d, want 200; health=%+v", got, health)
+	}
+	if got := uint64(repo.rowCount()); got != health.Enqueued {
+		t.Fatalf("persisted rows=%d, admitted=%d", got, health.Enqueued)
+	}
+	if got := len(a.ch); got != 0 {
+		t.Fatalf("buffered rows after Close=%d, want 0", got)
+	}
+}
+
+func TestArchive_MalformedDropsAreCountedAndRateLimited(t *testing.T) {
+	repo := &fakeRepo{}
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	a := New(repo, Config{BatchSize: 100, FlushInterval: time.Hour, DeleteBatch: 1}, logger)
+	defer a.Close(context.Background())
+
+	for i := range 5 {
+		v := mkVal(uint32(i+1), 1)
+		v.Raw = nil
+		a.OnStale(v)
+	}
+	if err := a.Flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	health := a.Health()
+	if health.MalformedDropped != 5 {
+		t.Fatalf("malformed drops=%d, want 5", health.MalformedDropped)
+	}
+	if got := strings.Count(logs.String(), "without canonical raw bytes"); got != 1 {
+		t.Fatalf("malformed warning count=%d, want 1\n%s", got, logs.String())
+	}
+}
+
+func TestArchive_PersistsPartialValidation(t *testing.T) {
+	repo := &fakeRepo{}
+	a := New(repo, Config{BatchSize: 100, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
+	defer a.Close(context.Background())
+
+	v := mkVal(10, 1)
+	v.Full = false
+	v.Flags = 0x80000000
+	a.OnStale(v)
+	if err := a.Flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := repo.rowCount(); got != 1 {
+		t.Fatalf("partial validation rows=%d, want 1", got)
+	}
+}
+
+func TestArchive_RetentionRunsIdleAndContinuesPastBudget(t *testing.T) {
+	deleteCh := make(chan int64, 32)
+	repo := &fakeRepo{deleteCh: deleteCh}
+	for seq := uint32(1); seq <= 30; seq++ {
+		repo.rows = append(repo.rows, toRecord(mkVal(seq, byte(seq)), seq))
+	}
+	ticks := make(chan time.Time, 1)
+	a := newArchive(
+		repo,
+		Config{
+			BatchSize:        100,
+			FlushInterval:    time.Hour,
+			RetentionLedgers: 10,
+			DeleteBatch:      2,
+		},
+		nil,
+		ticks,
+	)
+	defer a.Close(context.Background())
+	a.NoteFullyValidated(30)
+
+	ticks <- time.Now()
+	for i := 0; i < 10; i++ {
+		<-deleteCh
+	}
+	if got := repo.rowCount(); got != 11 {
+		t.Fatalf("rows after idle catch-up=%d, want 11", got)
+	}
+	if health := a.Health(); health.RetentionFailures != 0 {
+		t.Fatalf("unexpected retention health: %+v", health)
 	}
 }

--- a/internal/consensus/archive/archive_test.go
+++ b/internal/consensus/archive/archive_test.go
@@ -652,3 +652,59 @@ func TestArchive_RetentionRunsIdleAndContinuesPastBudget(t *testing.T) {
 		t.Fatalf("unexpected retention health: %+v", health)
 	}
 }
+
+type deadlineRetentionRepo struct {
+	*fakeRepo
+	calls atomic.Int32
+}
+
+func (r *deadlineRetentionRepo) DeleteOlderThanSeq(
+	ctx context.Context,
+	maxSeq relationaldb.LedgerIndex,
+	batchSize int,
+) (int64, error) {
+	if r.calls.Add(1) == 2 {
+		<-ctx.Done()
+		return 0, errors.New("driver interrupted")
+	}
+	return r.fakeRepo.DeleteOlderThanSeq(ctx, maxSeq, batchSize)
+}
+
+func TestArchive_RetentionDeadlineAfterProgressContinuesPromptly(t *testing.T) {
+	deleteCh := make(chan int64, 8)
+	base := &fakeRepo{deleteCh: deleteCh}
+	for seq := uint32(1); seq <= 6; seq++ {
+		base.rows = append(base.rows, toRecord(mkVal(seq, byte(seq)), seq))
+	}
+	repo := &deadlineRetentionRepo{fakeRepo: base}
+	ticks := make(chan time.Time, 1)
+	a := newArchive(
+		repo,
+		Config{
+			BatchSize:        100,
+			FlushInterval:    time.Hour,
+			RetentionLedgers: 1,
+			DeleteBatch:      2,
+		},
+		nil,
+		ticks,
+	)
+	a.retentionTimeout = 20 * time.Millisecond
+	defer a.Close(context.Background())
+	a.NoteFullyValidated(10)
+
+	ticks <- time.Now()
+	for range 4 {
+		select {
+		case <-deleteCh:
+		case <-time.After(time.Second):
+			t.Fatal("retention did not continue promptly after its time budget expired")
+		}
+	}
+	if got := repo.rowCount(); got != 0 {
+		t.Fatalf("rows after deadline continuation=%d, want 0", got)
+	}
+	if health := a.Health(); health.RetentionFailures != 0 {
+		t.Fatalf("time-budget exhaustion marked retention unhealthy: %+v", health)
+	}
+}

--- a/internal/consensus/archive/archive_test.go
+++ b/internal/consensus/archive/archive_test.go
@@ -324,7 +324,6 @@ func TestArchive_SaveBatch_RetryOnceThenSucceed(t *testing.T) {
 
 func TestArchive_SaveBatch_PersistentFailureRemainsObservable(t *testing.T) {
 	base := &fakeRepo{}
-	// More failures than retries → batch is dropped after attempts.
 	repo := &flakyRepo{fakeRepo: base, failureLeft: 100}
 	a := New(repo, Config{BatchSize: 1, FlushInterval: time.Hour, DeleteBatch: 1}, nil)
 

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -523,7 +523,13 @@ func (e *Engine) Stop() error {
 
 	arc := e.loadArchive()
 	if arc != nil {
-		e.SetArchive(nil)
+		// Stop new stale deliveries, but retain the owned archive so a later
+		// Stop can observe terminal completion after a bounded Close times out.
+		e.mu.Lock()
+		if e.validationTracker != nil {
+			e.validationTracker.SetOnStale(nil)
+		}
+		e.mu.Unlock()
 	}
 
 	if e.validationTracker != nil {

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -384,8 +384,8 @@ func (e *Engine) TimerEntry() {
 
 // SetArchive wires (or, with nil, detaches) the validation archive.
 // Detach clears the onStale callback so the archive can be Close()d
-// without a use-after-close send. Safe before/after Start and with Stop,
-// not with Start.
+// without a use-after-close send. Safe before or after Start; callers must
+// not replace the owned archive concurrently with Start or Stop.
 func (e *Engine) SetArchive(a ValidationArchive) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -510,8 +510,7 @@ func (e *Engine) Start(ctx context.Context) error {
 }
 
 // Stop shuts down the engine. A wired archive is drained and committed
-// before return so no stale validations are lost (modulo SaveBatch
-// failures, which the writer re-queues).
+// before return, and any terminal durability failure is returned.
 func (e *Engine) Stop() error {
 	// Guard against Stop before Start: e.cancel is nil until Start runs, and a
 	// defensive doShutdown / error-path stop must not nil-panic (same class as
@@ -522,17 +521,23 @@ func (e *Engine) Stop() error {
 	e.wg.Wait()
 	e.eventBus.Stop()
 
-	// Flush has no archive interaction, so its ordering relative to the
-	// archive close below is irrelevant.
+	arc := e.loadArchive()
+	if arc != nil {
+		e.SetArchive(nil)
+	}
+
 	if e.validationTracker != nil {
 		e.validationTracker.Flush()
 	}
 
-	if arc := e.loadArchive(); arc != nil {
+	if arc != nil {
 		// Bounded close — a stuck archive must not hang shutdown.
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		_ = arc.Close(ctx)
+		err := arc.Close(ctx)
 		cancel()
+		if err != nil {
+			return fmt.Errorf("close validation archive: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/consensus/rcl/engine_archive_test.go
+++ b/internal/consensus/rcl/engine_archive_test.go
@@ -2,6 +2,7 @@ package rcl
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -19,6 +20,7 @@ type fakeArchive struct {
 	lastSeq atomic.Uint32
 
 	closeCalls atomic.Int32
+	closeErr   error
 }
 
 func (f *fakeArchive) OnStale(v *consensus.Validation) {
@@ -41,7 +43,7 @@ func (f *fakeArchive) NoteFullyValidated(seq uint32) {
 
 func (f *fakeArchive) Close(ctx context.Context) error {
 	f.closeCalls.Add(1)
-	return nil
+	return f.closeErr
 }
 
 func (f *fakeArchive) staleCount() int {
@@ -164,6 +166,24 @@ func TestEngine_Stop_ClosesArchive(t *testing.T) {
 
 	if arc.closeCalls.Load() != 1 {
 		t.Fatalf("Stop did not close the archive; closeCalls=%d", arc.closeCalls.Load())
+	}
+}
+
+func TestEngine_Stop_ReturnsArchiveError(t *testing.T) {
+	adaptor := newMockAdaptor()
+	engine := NewEngine(adaptor, DefaultConfig())
+	closeErr := errors.New("archive commit failed")
+	arc := &fakeArchive{closeErr: closeErr}
+	engine.SetArchive(arc)
+
+	if err := engine.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := engine.Stop(); !errors.Is(err, closeErr) {
+		t.Fatalf("Stop returned %v, want archive error", err)
+	}
+	if arc.closeCalls.Load() != 1 {
+		t.Fatalf("archive close calls=%d, want 1", arc.closeCalls.Load())
 	}
 }
 

--- a/internal/consensus/rcl/engine_archive_test.go
+++ b/internal/consensus/rcl/engine_archive_test.go
@@ -21,6 +21,7 @@ type fakeArchive struct {
 
 	closeCalls atomic.Int32
 	closeErr   error
+	closeErrs  []error
 }
 
 func (f *fakeArchive) OnStale(v *consensus.Validation) {
@@ -42,7 +43,10 @@ func (f *fakeArchive) NoteFullyValidated(seq uint32) {
 }
 
 func (f *fakeArchive) Close(ctx context.Context) error {
-	f.closeCalls.Add(1)
+	call := int(f.closeCalls.Add(1))
+	if call <= len(f.closeErrs) {
+		return f.closeErrs[call-1]
+	}
 	return f.closeErr
 }
 
@@ -184,6 +188,27 @@ func TestEngine_Stop_ReturnsArchiveError(t *testing.T) {
 	}
 	if arc.closeCalls.Load() != 1 {
 		t.Fatalf("archive close calls=%d, want 1", arc.closeCalls.Load())
+	}
+}
+
+func TestEngine_StopRetainsArchiveAfterCloseTimeout(t *testing.T) {
+	adaptor := newMockAdaptor()
+	engine := NewEngine(adaptor, DefaultConfig())
+	terminalErr := errors.New("archive terminal failure")
+	arc := &fakeArchive{closeErrs: []error{context.DeadlineExceeded, terminalErr}}
+	engine.SetArchive(arc)
+
+	if err := engine.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := engine.Stop(); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("first Stop returned %v, want deadline exceeded", err)
+	}
+	if err := engine.Stop(); !errors.Is(err, terminalErr) {
+		t.Fatalf("second Stop returned %v, want terminal archive error", err)
+	}
+	if arc.closeCalls.Load() != 2 {
+		t.Fatalf("archive close calls=%d, want 2", arc.closeCalls.Load())
 	}
 }
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -1615,7 +1615,9 @@ func doShutdown(
 	}
 
 	if consensusComponents != nil {
-		consensusComponents.Stop()
+		if err := consensusComponents.Stop(); err != nil {
+			logger.Warn("Consensus component shutdown failed", "err", err)
+		}
 		logger.Info("Consensus components stopped")
 	}
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -1615,8 +1615,32 @@ func doShutdown(
 	}
 
 	if consensusComponents != nil {
-		if err := consensusComponents.Stop(); err != nil {
-			logger.Warn("Consensus component shutdown failed", "err", err)
+		stopErr := consensusComponents.Stop()
+		if stopErr != nil {
+			logger.Warn("Consensus component shutdown failed", "err", stopErr)
+			if consensusComponents.Archive != nil {
+				waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				terminalErr := consensusComponents.Archive.Close(waitCtx)
+				waitCancel()
+				if terminalErr != nil && !errors.Is(stopErr, terminalErr) {
+					logger.Warn("Validation archive terminal shutdown failed", "err", terminalErr)
+				}
+			}
+		}
+		if consensusComponents.Archive != nil {
+			health := consensusComponents.Archive.Health()
+			if !health.Healthy {
+				logger.Warn("Validation archive unhealthy at shutdown",
+					"enqueued", health.Enqueued,
+					"overload_dropped", health.OverloadDropped,
+					"closed_dropped", health.ClosedDropped,
+					"malformed_dropped", health.MalformedDropped,
+					"persistence_dropped", health.PersistenceDropped,
+					"write_failures", health.WriteFailures,
+					"retention_failures", health.RetentionFailures,
+					"last_error", health.LastError,
+				)
+			}
 		}
 		logger.Info("Consensus components stopped")
 	}

--- a/storage/relationaldb/sqlite/validation_repository.go
+++ b/storage/relationaldb/sqlite/validation_repository.go
@@ -162,8 +162,8 @@ func (r *validationRepository) GetValidationCount(ctx context.Context) (int64, e
 }
 
 // DeleteOlderThanSeq removes up to batchSize rows with ledger_seq < maxSeq.
-// A bounded DELETE keeps the retention sweep from blocking the writer on
-// multi-second scans — the archive loop calls this once per flush tick.
+// A bounded DELETE keeps retention maintenance from blocking the writer on
+// one unbounded scan.
 func (r *validationRepository) DeleteOlderThanSeq(ctx context.Context, maxSeq relationaldb.LedgerIndex, batchSize int) (int64, error) {
 	q := `DELETE FROM validations WHERE rowid IN (
 		SELECT rowid FROM validations WHERE ledger_seq < ?`


### PR DESCRIPTION
## Summary
- make validation archive admission, flush barriers, and shutdown share one deterministic lifecycle with observable durability errors
- keep stale-validation ingestion nonblocking with rate-limited drop accounting, and run bounded retention independently during idle periods
- propagate terminal archive failures through node shutdown and document the full/partial forensic policy and historical rippled provenance

## Test plan
- [x] `go test -race -count=100 -run TestArchive_CloseTimeoutRemainsWaitable ./internal/consensus/archive`
- [x] `go test -race -count=1 ./internal/consensus/archive ./internal/consensus/rcl`
- [x] `go vet ./internal/consensus/archive ./internal/consensus/rcl`
- [x] `golangci-lint run --config .golangci.yml ./internal/consensus/archive/... ./internal/consensus/rcl/...`
- [x] `go test ./...`

Fixes #1454
