### PR TITLE
fix: harden ledger trie invariants

### DIFF
--- a/internal/consensus/ledgertrie/span.go
+++ b/internal/consensus/ledgertrie/span.go
@@ -39,11 +39,11 @@ func (s span) before(spot uint32) (span, bool) { return s.sub(s.start, spot) }
 
 func (s span) startID() consensus.LedgerID { return s.ledger.Ancestor(s.start) }
 
-func (s span) diff(o Ledger) uint32 { return s.clamp(Mismatch(s.ledger, o)) }
+func (s span) diff(o Ledger) uint32 { return s.clamp(mismatch(s.ledger, o)) }
 
 func (s span) tip() SpanTip {
 	tipSeq := s.end - 1
-	return SpanTip{Seq: tipSeq, ID: s.ledger.Ancestor(tipSeq), ledger: s.ledger}
+	return SpanTip{Seq: tipSeq, ID: s.ledger.Ancestor(tipSeq)}
 }
 
 // mergeSpans combines two adjacent spans, taking the ledger from the

--- a/internal/consensus/ledgertrie/trie.go
+++ b/internal/consensus/ledgertrie/trie.go
@@ -4,6 +4,8 @@ package ledgertrie
 
 import (
 	"bytes"
+	"math"
+	"reflect"
 	"slices"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
@@ -19,10 +21,10 @@ type Ledger interface {
 	Ancestor(s uint32) consensus.LedgerID
 }
 
-// Mismatch returns the first sequence at which a and b diverge, or 1 when the
+// mismatch returns the first sequence at which a and b diverge, or 1 when the
 // overlap is empty or mismatches at its floor (rippled's post-genesis-divergence
 // fallback, RCLValidations.cpp:99).
-func Mismatch(a, b Ledger) uint32 {
+func mismatch(a, b Ledger) uint32 {
 	upper := min(b.Seq(), a.Seq())
 	lower := a.MinSeq()
 	if bm := b.MinSeq(); bm > lower {
@@ -51,18 +53,13 @@ func Mismatch(a, b Ledger) uint32 {
 
 // SpanTip is the read-only view of a span's tip.
 type SpanTip struct {
-	Seq    uint32
-	ID     consensus.LedgerID
-	ledger Ledger
+	Seq uint32
+	ID  consensus.LedgerID
 }
-
-// Ancestor returns the ID at sequence s; s must be <= Seq.
-func (t SpanTip) Ancestor(s uint32) consensus.LedgerID { return t.ledger.Ancestor(s) }
 
 // Trie is the ancestry trie. The zero value is not usable — call New.
 type Trie struct {
-	root    *node
-	genesis Ledger
+	root *node
 
 	// seqKeys is the sorted-key view over seqSupport.
 	seqSupport map[uint32]uint32
@@ -71,15 +68,32 @@ type Trie struct {
 
 // New constructs an empty trie. genesis must satisfy Seq() == 0.
 func New(genesis Ledger) *Trie {
+	if isNilLedger(genesis) {
+		panic("ledgertrie: nil genesis ledger")
+	}
+	if genesis.Seq() != 0 {
+		panic("ledgertrie: genesis sequence must be zero")
+	}
 	return &Trie{
 		root:       newEmptyNode(genesis),
-		genesis:    genesis,
 		seqSupport: make(map[uint32]uint32),
 	}
 }
 
-// Empty reports whether the trie holds any support.
-func (t *Trie) Empty() bool { return t.root == nil || t.root.branchSupport == 0 }
+func isNilLedger(l Ledger) bool {
+	if l == nil {
+		return true
+	}
+	v := reflect.ValueOf(l)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+
+func (t *Trie) empty() bool { return t.root == nil || t.root.branchSupport == 0 }
 
 // find returns the node sharing the longest common prefix with l and
 // the sequence at which they diverge.
@@ -126,11 +140,15 @@ func findByIDWalk(curr *node, id consensus.LedgerID) *node {
 // seqSupportAdd/seqSupportSub keep seqKeys sorted with O(n) shifts. The set of
 // distinct sequences with active branch support is small, so this stays simple.
 func (t *Trie) seqSupportAdd(seq uint32, delta uint32) {
-	if _, ok := t.seqSupport[seq]; !ok {
+	current, ok := t.seqSupport[seq]
+	if current > math.MaxUint32-delta {
+		panic("ledgertrie: sequence support overflow")
+	}
+	if !ok {
 		idx, _ := slices.BinarySearch(t.seqKeys, seq)
 		t.seqKeys = slices.Insert(t.seqKeys, idx, seq)
 	}
-	t.seqSupport[seq] += delta
+	t.seqSupport[seq] = current + delta
 }
 
 // seqSupportSub panics on under-subtract (XRPL_ASSERT, LedgerTrie.h:553).
@@ -154,16 +172,35 @@ func (t *Trie) seqSupportSub(seq uint32, delta uint32) {
 // no-op: a 0-count insert that takes the newSuffix branch would create a
 // 0-tip leaf and break the compressed-trie invariant.
 func (t *Trie) Insert(l Ledger, count uint32) {
+	if isNilLedger(l) {
+		panic("ledgertrie: nil ledger")
+	}
+	seq := l.Seq()
+	if seq == math.MaxUint32 {
+		panic("ledgertrie: ledger sequence cannot be represented")
+	}
 	if count == 0 {
 		return
 	}
 	loc, diffSeq := t.find(l)
 
-	incNode := loc
-
 	prefix, hasPrefix := loc.s.before(diffSeq)
 	oldSuffix, hasOldSuffix := loc.s.from(diffSeq)
 	newSuffix, hasNewSuffix := newSpanFromLedger(l).from(diffSeq)
+
+	if !hasOldSuffix && !hasNewSuffix && loc.tipSupport > math.MaxUint32-count {
+		panic("ledgertrie: tip support overflow")
+	}
+	for cur := loc; cur != nil; cur = cur.parent {
+		if cur.branchSupport > math.MaxUint32-count {
+			panic("ledgertrie: branch support overflow")
+		}
+	}
+	if t.seqSupport[seq] > math.MaxUint32-count {
+		panic("ledgertrie: sequence support overflow")
+	}
+
+	incNode := loc
 
 	if hasOldSuffix {
 		if !hasPrefix {
@@ -196,7 +233,7 @@ func (t *Trie) Insert(l Ledger, count uint32) {
 		cur.branchSupport += count
 	}
 
-	t.seqSupportAdd(l.Seq(), count)
+	t.seqSupportAdd(seq, count)
 }
 
 // Remove decreases l's tip support by up to count, compacting the trie
@@ -266,12 +303,12 @@ func (t *Trie) BranchSupport(l Ledger) uint32 {
 // trie is empty. largestIssued seeds uncommitted support from earlier
 // sequences so ancient validations cannot retroactively swing preference.
 func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
-	if t.Empty() {
+	if t.empty() {
 		return SpanTip{}, false
 	}
 
 	curr := t.root
-	uncommitted := uint32(0)
+	uncommitted := uint64(0)
 	uncommittedIdx := 0
 
 	for curr != nil {
@@ -279,14 +316,14 @@ func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
 		nextSeq := curr.s.start + 1
 		floor := max(largestIssued, nextSeq)
 		for uncommittedIdx < len(t.seqKeys) && t.seqKeys[uncommittedIdx] < floor {
-			uncommitted += t.seqSupport[t.seqKeys[uncommittedIdx]]
+			uncommitted += uint64(t.seqSupport[t.seqKeys[uncommittedIdx]])
 			uncommittedIdx++
 		}
 
-		for nextSeq < curr.s.end && curr.branchSupport > uncommitted {
+		for nextSeq < curr.s.end && uint64(curr.branchSupport) > uncommitted {
 			if uncommittedIdx < len(t.seqKeys) && t.seqKeys[uncommittedIdx] < curr.s.end {
 				nextSeq = t.seqKeys[uncommittedIdx] + 1
-				uncommitted += t.seqSupport[t.seqKeys[uncommittedIdx]]
+				uncommitted += uint64(t.seqSupport[t.seqKeys[uncommittedIdx]])
 				uncommittedIdx++
 			} else {
 				nextSeq = curr.s.end
@@ -303,24 +340,41 @@ func (t *Trie) GetPreferred(largestIssued uint32) (SpanTip, bool) {
 		}
 
 		var best *node
-		var margin uint32
+		var margin uint64
 		switch len(curr.children) {
 		case 0:
 			best = nil
 		case 1:
 			best = curr.children[0]
-			margin = best.branchSupport
+			margin = uint64(best.branchSupport)
 		default:
-			// Inline top-2 by (branchSupport, startID) desc.
-			var second *node
-			for _, c := range curr.children {
-				if best == nil || nodeOutranks(c, best) {
-					second, best = best, c
-				} else if second == nil || nodeOutranks(c, second) {
-					second = c
+			bestIndex := 0
+			secondIndex := 1
+			if nodeOutranks(curr.children[secondIndex], curr.children[bestIndex]) {
+				bestIndex, secondIndex = secondIndex, bestIndex
+			}
+			for i := 2; i < len(curr.children); i++ {
+				if nodeOutranks(curr.children[i], curr.children[bestIndex]) {
+					secondIndex = bestIndex
+					bestIndex = i
+				} else if nodeOutranks(curr.children[i], curr.children[secondIndex]) {
+					secondIndex = i
 				}
 			}
-			margin = best.branchSupport - second.branchSupport
+
+			best = curr.children[bestIndex]
+			second := curr.children[secondIndex]
+			if bestIndex != 0 {
+				curr.children[0], curr.children[bestIndex] = curr.children[bestIndex], curr.children[0]
+			}
+			for i := 1; i < len(curr.children); i++ {
+				if curr.children[i] == second {
+					curr.children[1], curr.children[i] = curr.children[i], curr.children[1]
+					break
+				}
+			}
+
+			margin = uint64(best.branchSupport) - uint64(second.branchSupport)
 			if ledgerIDGreater(best.s.startID(), second.s.startID()) {
 				margin++
 			}
@@ -352,29 +406,48 @@ func nodeOutranks(a, b *node) bool {
 // branchSupport == tipSupport + Σ child.branchSupport, parent pointers
 // are consistent, and seqSupport matches the sum of tip supports.
 func (t *Trie) CheckInvariants() bool {
-	expected := make(map[uint32]uint32)
+	if t == nil || t.root == nil || t.root.parent != nil {
+		return false
+	}
+	if len(t.seqKeys) != len(t.seqSupport) {
+		return false
+	}
+	for i, seq := range t.seqKeys {
+		if i > 0 && t.seqKeys[i-1] >= seq {
+			return false
+		}
+		if support, ok := t.seqSupport[seq]; !ok || support == 0 {
+			return false
+		}
+	}
+
+	expected := make(map[uint32]uint64)
 	stack := []*node{t.root}
 	for len(stack) > 0 {
 		curr := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
-		if curr == nil {
-			continue
+		if curr == nil || curr.s.start >= curr.s.end || isNilLedger(curr.s.ledger) {
+			return false
 		}
 		if curr != t.root && curr.tipSupport == 0 && len(curr.children) < 2 {
 			return false
 		}
-		support := curr.tipSupport
+		support := uint64(curr.tipSupport)
 		if curr.tipSupport != 0 {
-			expected[curr.s.end-1] += curr.tipSupport
+			seq := curr.s.end - 1
+			expected[seq] += uint64(curr.tipSupport)
+			if expected[seq] > math.MaxUint32 {
+				return false
+			}
 		}
 		for _, c := range curr.children {
 			if c.parent != curr {
 				return false
 			}
-			support += c.branchSupport
+			support += uint64(c.branchSupport)
 			stack = append(stack, c)
 		}
-		if support != curr.branchSupport {
+		if support > math.MaxUint32 || support != uint64(curr.branchSupport) {
 			return false
 		}
 	}
@@ -382,7 +455,7 @@ func (t *Trie) CheckInvariants() bool {
 		return false
 	}
 	for k, v := range expected {
-		if t.seqSupport[k] != v {
+		if uint64(t.seqSupport[k]) != v {
 			return false
 		}
 	}

--- a/internal/consensus/ledgertrie/trie.go
+++ b/internal/consensus/ledgertrie/trie.go
@@ -246,9 +246,16 @@ func (t *Trie) Remove(l Ledger, count uint32) bool {
 	if count > loc.tipSupport {
 		count = loc.tipSupport
 	}
+	seq := l.Seq()
+	if seq != loc.s.end-1 {
+		panic("ledgertrie: ledger sequence mismatch")
+	}
+	if support, ok := t.seqSupport[seq]; !ok || support < count {
+		panic("ledgertrie: seqSupport invariant violation")
+	}
 
 	loc.tipSupport -= count
-	t.seqSupportSub(l.Seq(), count)
+	t.seqSupportSub(seq, count)
 
 	for cur := loc; cur != nil; cur = cur.parent {
 		cur.branchSupport -= count
@@ -441,6 +448,9 @@ func (t *Trie) CheckInvariants() bool {
 			}
 		}
 		for _, c := range curr.children {
+			if c == nil {
+				return false
+			}
 			if c.parent != curr {
 				return false
 			}

--- a/internal/consensus/ledgertrie/trie_test.go
+++ b/internal/consensus/ledgertrie/trie_test.go
@@ -32,6 +32,32 @@ func newTestTrie() (*Trie, *ledgertrietest.TestLedgerBuilder) {
 	return New(b.Genesis()), b
 }
 
+func TestMismatch(t *testing.T) {
+	b := ledgertrietest.NewTestLedgerBuilder()
+	tests := []struct {
+		name string
+		a    Ledger
+		b    Ledger
+		want uint32
+	}{
+		{name: "EmptyOverlap", a: b.Build(""), b: b.Build("a"), want: 1},
+		{name: "SharedHistory", a: b.Build("abc"), b: b.Build("abcde"), want: 4},
+		{name: "DivergentAtFloor", a: b.Build("abc"), b: b.Build("xyz"), want: 1},
+		{name: "SameSequenceDivergence", a: b.Build("abc"), b: b.Build("abd"), want: 3},
+		{name: "DifferentSequenceDivergence", a: b.Build("abc"), b: b.Build("abdef"), want: 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mismatch(tt.a, tt.b); got != tt.want {
+				t.Fatalf("mismatch(a, b) = %d, want %d", got, tt.want)
+			}
+			if got := mismatch(tt.b, tt.a); got != tt.want {
+				t.Fatalf("mismatch(b, a) = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 // --- TestLedgerTrie_ParityTable --------------------------------------
 //
 // Ports the state-assertion tests from rippled's
@@ -902,6 +928,22 @@ func TestLedgerTrie_SupportOverflowIsAtomic(t *testing.T) {
 	}
 }
 
+func TestLedgerTrie_RemoveSequenceMismatchIsAtomic(t *testing.T) {
+	trie, b := newTestTrie()
+	ledger := b.Build("a")
+	trie.Insert(ledger, 2)
+
+	mismatched := &boundaryLedger{id: ledger.ID(), seq: 2}
+	requirePanic(t, func() { trie.Remove(mismatched, 1) })
+
+	if got := trie.TipSupport(ledger); got != 2 {
+		t.Fatalf("tip support changed after rejected remove: got %d, want 2", got)
+	}
+	if !trie.CheckInvariants() {
+		t.Fatal("rejected remove broke invariants")
+	}
+}
+
 func TestLedgerTrie_CheckInvariantsRejectsWrappedSupport(t *testing.T) {
 	trie, b := newTestTrie()
 	first := b.Build("a")
@@ -914,10 +956,17 @@ func TestLedgerTrie_CheckInvariantsRejectsWrappedSupport(t *testing.T) {
 	sibling.branchSupport = 1
 	trie.root.children = append(trie.root.children, sibling)
 	trie.root.branchSupport = 0
-	trie.seqSupport[1] = 0
 
 	if trie.CheckInvariants() {
 		t.Fatal("wrapped support state passed invariants")
+	}
+}
+
+func TestLedgerTrie_CheckInvariantsRejectsNilChild(t *testing.T) {
+	trie, _ := newTestTrie()
+	trie.root.children = append(trie.root.children, nil)
+	if trie.CheckInvariants() {
+		t.Fatal("nil child passed invariants")
 	}
 }
 
@@ -935,6 +984,9 @@ func TestLedgerTrie_CheckInvariantsRejectsSequenceKeyDrift(t *testing.T) {
 		"Unsorted": func(trie *Trie) {
 			trie.seqKeys[0], trie.seqKeys[1] = trie.seqKeys[1], trie.seqKeys[0]
 		},
+		"Substituted": func(trie *Trie) {
+			trie.seqKeys[1] = 3
+		},
 	}
 	for name, corrupt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -946,6 +998,27 @@ func TestLedgerTrie_CheckInvariantsRejectsSequenceKeyDrift(t *testing.T) {
 				t.Fatal("corrupt sequence-key index passed invariants")
 			}
 		})
+	}
+}
+
+func TestLedgerTrie_GetPreferredOrdersTopTwoChildren(t *testing.T) {
+	trie, b := newTestTrie()
+	a := b.Build("a")
+	bLedger := b.Build("b")
+	c := b.Build("c")
+	trie.Insert(a, 1)
+	trie.Insert(bLedger, 2)
+	trie.Insert(c, 3)
+
+	preferred, ok := trie.GetPreferred(0)
+	if !ok || preferred.ID != c.ID() {
+		t.Fatalf("preferred ledger = (%x, %t), want %x", preferred.ID, ok, c.ID())
+	}
+	if got := trie.root.children[0].s.tip().ID; got != c.ID() {
+		t.Fatalf("first child = %x, want %x", got, c.ID())
+	}
+	if got := trie.root.children[1].s.tip().ID; got != bLedger.ID() {
+		t.Fatalf("second child = %x, want %x", got, bLedger.ID())
 	}
 }
 

--- a/internal/consensus/ledgertrie/trie_test.go
+++ b/internal/consensus/ledgertrie/trie_test.go
@@ -511,8 +511,6 @@ func TestLedgerTrie_GetPreferred_SingleLargerChildren(t *testing.T) {
 }
 
 func TestLedgerTrie_GetPreferred_TieBreakerByID(t *testing.T) {
-	// Compute which sibling has the larger ID at seq 4 and steer the
-	// assertions accordingly.
 	trie, b := newTestTrie()
 	abcd := b.Build("abcd")
 	abce := b.Build("abce")

--- a/internal/consensus/ledgertrie/trie_test.go
+++ b/internal/consensus/ledgertrie/trie_test.go
@@ -40,11 +40,25 @@ func TestMismatch(t *testing.T) {
 		b    Ledger
 		want uint32
 	}{
-		{name: "EmptyOverlap", a: b.Build(""), b: b.Build("a"), want: 1},
+		{name: "GenesisOverlap", a: b.Build(""), b: b.Build("a"), want: 1},
 		{name: "SharedHistory", a: b.Build("abc"), b: b.Build("abcde"), want: 4},
 		{name: "DivergentAtFloor", a: b.Build("abc"), b: b.Build("xyz"), want: 1},
 		{name: "SameSequenceDivergence", a: b.Build("abc"), b: b.Build("abd"), want: 3},
 		{name: "DifferentSequenceDivergence", a: b.Build("abc"), b: b.Build("abdef"), want: 3},
+		{name: "NoKnownOverlap", a: limitedHistoryLedger{seq: 300}, b: limitedHistoryLedger{seq: 1}, want: 1},
+		{name: "SharedAtWindow", a: limitedHistoryLedger{seq: 300}, b: limitedHistoryLedger{seq: 299}, want: 300},
+		{
+			name: "DivergenceAtWindowFloor",
+			a:    limitedHistoryBranchLedger{seq: 300, fork: 44, branch: 1},
+			b:    limitedHistoryBranchLedger{seq: 300, fork: 44, branch: 2},
+			want: 1,
+		},
+		{
+			name: "DivergenceInsideWindow",
+			a:    limitedHistoryBranchLedger{seq: 300, fork: 100, branch: 1},
+			b:    limitedHistoryBranchLedger{seq: 300, fork: 100, branch: 2},
+			want: 100,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -846,6 +860,31 @@ func (l limitedHistoryLedger) Ancestor(seq uint32) consensus.LedgerID {
 		return consensus.LedgerID{}
 	}
 	return sequenceLedgerID(seq)
+}
+
+type limitedHistoryBranchLedger struct {
+	seq    uint32
+	fork   uint32
+	branch byte
+}
+
+func (l limitedHistoryBranchLedger) ID() consensus.LedgerID { return l.Ancestor(l.seq) }
+func (l limitedHistoryBranchLedger) Seq() uint32            { return l.seq }
+func (l limitedHistoryBranchLedger) MinSeq() uint32 {
+	if l.seq > 256 {
+		return l.seq - 256
+	}
+	return 0
+}
+func (l limitedHistoryBranchLedger) Ancestor(seq uint32) consensus.LedgerID {
+	if seq < l.MinSeq() || seq > l.seq {
+		return consensus.LedgerID{}
+	}
+	id := sequenceLedgerID(seq)
+	if seq >= l.fork {
+		id[0] = l.branch
+	}
+	return id
 }
 
 func sequenceLedgerID(seq uint32) consensus.LedgerID {

--- a/internal/consensus/ledgertrie/trie_test.go
+++ b/internal/consensus/ledgertrie/trie_test.go
@@ -883,6 +883,10 @@ func (l limitedHistoryBranchLedger) Ancestor(seq uint32) consensus.LedgerID {
 	id := sequenceLedgerID(seq)
 	if seq >= l.fork {
 		id[0] = l.branch
+		id[1] = byte(l.fork >> 24)
+		id[2] = byte(l.fork >> 16)
+		id[3] = byte(l.fork >> 8)
+		id[4] = byte(l.fork)
 	}
 	return id
 }

--- a/internal/consensus/ledgertrie/trie_test.go
+++ b/internal/consensus/ledgertrie/trie_test.go
@@ -1,10 +1,15 @@
 package ledgertrie
 
 import (
+	"maps"
+	"math"
 	"math/rand"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrietest"
 )
 
 // idGreater reports whether a > b in lexicographic byte order. Local
@@ -22,8 +27,8 @@ func idGreater(a, b consensus.LedgerID) bool {
 // newTestTrie constructs an empty trie paired with a fresh builder.
 // The genesis ledger for the trie is builder's genesis so ID matching
 // works naturally.
-func newTestTrie() (*Trie, *TestLedgerBuilder) {
-	b := NewTestLedgerBuilder()
+func newTestTrie() (*Trie, *ledgertrietest.TestLedgerBuilder) {
+	b := ledgertrietest.NewTestLedgerBuilder()
 	return New(b.Genesis()), b
 }
 
@@ -42,7 +47,7 @@ type trieAssertion struct {
 	branch uint32
 }
 
-func assertSupport(t *testing.T, trie *Trie, b *TestLedgerBuilder, a trieAssertion) {
+func assertSupport(t *testing.T, trie *Trie, b *ledgertrietest.TestLedgerBuilder, a trieAssertion) {
 	t.Helper()
 	l := b.Build(a.path)
 	if got := trie.TipSupport(l); got != a.tip {
@@ -322,29 +327,29 @@ func TestLedgerTrie_ParityTable(t *testing.T) {
 
 func TestLedgerTrie_Empty(t *testing.T) {
 	trie, b := newTestTrie()
-	if !trie.Empty() {
+	if !trie.empty() {
 		t.Fatal("new trie should be empty")
 	}
 
 	trie.Insert(b.Build(""), 1) // genesis
-	if trie.Empty() {
+	if trie.empty() {
 		t.Fatal("trie with genesis support should not be empty")
 	}
 	if !trie.Remove(b.Build(""), 1) {
 		t.Fatal("Remove(genesis) should return true")
 	}
-	if !trie.Empty() {
+	if !trie.empty() {
 		t.Fatal("trie should be empty after genesis removal")
 	}
 
 	trie.Insert(b.Build("abc"), 1)
-	if trie.Empty() {
+	if trie.empty() {
 		t.Fatal("trie with abc should not be empty")
 	}
 	if !trie.Remove(b.Build("abc"), 1) {
 		t.Fatal("Remove(abc) should return true")
 	}
-	if !trie.Empty() {
+	if !trie.empty() {
 		t.Fatal("trie should be empty after abc removal")
 	}
 }
@@ -352,7 +357,7 @@ func TestLedgerTrie_Empty(t *testing.T) {
 // --- getPreferred parity tests ---------------------------------------
 
 // idOf is a small convenience helper for the getPreferred tests below.
-func idOf(b *TestLedgerBuilder, path string) string { // returns hex-like
+func idOf(b *ledgertrietest.TestLedgerBuilder, path string) string { // returns hex-like
 	id := b.Build(path).ID()
 	return string(id[:])
 }
@@ -466,10 +471,8 @@ func TestLedgerTrie_GetPreferred_SingleLargerChildren(t *testing.T) {
 }
 
 func TestLedgerTrie_GetPreferred_TieBreakerByID(t *testing.T) {
-	// IDs in our TestLedgerBuilder are sha256-derived and thus
-	// unpredictable. We compute which sibling has the larger ID at
-	// seq 4 and steer assertions accordingly — mirroring rippled's
-	// test which does the same with an explicit `>` check.
+	// Compute which sibling has the larger ID at seq 4 and steer the
+	// assertions accordingly.
 	trie, b := newTestTrie()
 	abcd := b.Build("abcd")
 	abce := b.Build("abce")
@@ -779,5 +782,289 @@ func TestLedgerTrie_Stress_InvariantsHold(t *testing.T) {
 		if !trie.CheckInvariants() {
 			t.Fatalf("invariants broken at iter %d after %s(%q)", i, "op", path)
 		}
+	}
+}
+
+type boundaryLedger struct {
+	id  consensus.LedgerID
+	seq uint32
+}
+
+func (l *boundaryLedger) ID() consensus.LedgerID { return l.id }
+func (l *boundaryLedger) Seq() uint32            { return l.seq }
+func (l *boundaryLedger) MinSeq() uint32         { return 0 }
+func (l *boundaryLedger) Ancestor(seq uint32) consensus.LedgerID {
+	if seq == 0 {
+		return consensus.LedgerID{}
+	}
+	if seq == l.seq {
+		return l.id
+	}
+	return consensus.LedgerID{}
+}
+
+type limitedHistoryLedger struct {
+	seq uint32
+}
+
+func (l limitedHistoryLedger) ID() consensus.LedgerID { return sequenceLedgerID(l.seq) }
+func (l limitedHistoryLedger) Seq() uint32            { return l.seq }
+func (l limitedHistoryLedger) MinSeq() uint32 {
+	if l.seq > 256 {
+		return l.seq - 256
+	}
+	return 0
+}
+func (l limitedHistoryLedger) Ancestor(seq uint32) consensus.LedgerID {
+	if seq < l.MinSeq() || seq > l.seq {
+		return consensus.LedgerID{}
+	}
+	return sequenceLedgerID(seq)
+}
+
+func sequenceLedgerID(seq uint32) consensus.LedgerID {
+	var id consensus.LedgerID
+	id[28] = byte(seq >> 24)
+	id[29] = byte(seq >> 16)
+	id[30] = byte(seq >> 8)
+	id[31] = byte(seq)
+	return id
+}
+
+func requirePanic(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	fn()
+}
+
+func TestLedgerTrie_RejectsInvalidBoundaries(t *testing.T) {
+	t.Run("NilGenesis", func(t *testing.T) {
+		requirePanic(t, func() { New(nil) })
+	})
+	t.Run("TypedNilGenesis", func(t *testing.T) {
+		var genesis *boundaryLedger
+		requirePanic(t, func() { New(genesis) })
+	})
+	t.Run("NonGenesisSequence", func(t *testing.T) {
+		requirePanic(t, func() { New(&boundaryLedger{seq: 1}) })
+	})
+	t.Run("NilInsert", func(t *testing.T) {
+		trie, _ := newTestTrie()
+		requirePanic(t, func() { trie.Insert(nil, 1) })
+		if !trie.CheckInvariants() {
+			t.Fatal("nil insert mutated the trie")
+		}
+	})
+	t.Run("MaximumSequence", func(t *testing.T) {
+		trie, _ := newTestTrie()
+		ledger := &boundaryLedger{seq: math.MaxUint32}
+		requirePanic(t, func() { trie.Insert(ledger, 1) })
+		if !trie.CheckInvariants() {
+			t.Fatal("maximum-sequence insert mutated the trie")
+		}
+	})
+}
+
+func TestLedgerTrie_SupportOverflowIsAtomic(t *testing.T) {
+	trie, b := newTestTrie()
+	first := b.Build("a")
+	second := b.Build("b")
+	trie.Insert(first, math.MaxUint32)
+
+	beforeDump := trie.String()
+	beforeKeys := slices.Clone(trie.seqKeys)
+	beforeSeqSupport := maps.Clone(trie.seqSupport)
+	beforePreferred, beforeOK := trie.GetPreferred(1)
+
+	requirePanic(t, func() { trie.Insert(second, 1) })
+	requirePanic(t, func() { trie.Insert(first, 1) })
+
+	if got := trie.String(); got != beforeDump {
+		t.Fatalf("trie shape changed after rejected insert:\n got %q\nwant %q", got, beforeDump)
+	}
+	if !slices.Equal(trie.seqKeys, beforeKeys) {
+		t.Fatalf("sequence keys changed after rejected insert: got %v, want %v", trie.seqKeys, beforeKeys)
+	}
+	if !maps.Equal(trie.seqSupport, beforeSeqSupport) {
+		t.Fatalf("sequence support changed after rejected insert: got %v, want %v", trie.seqSupport, beforeSeqSupport)
+	}
+	afterPreferred, afterOK := trie.GetPreferred(1)
+	if afterOK != beforeOK || afterPreferred != beforePreferred {
+		t.Fatalf("preferred tip changed after rejected insert: got (%v, %t), want (%v, %t)",
+			afterPreferred, afterOK, beforePreferred, beforeOK)
+	}
+	if !trie.CheckInvariants() {
+		t.Fatal("rejected insert broke invariants")
+	}
+}
+
+func TestLedgerTrie_CheckInvariantsRejectsWrappedSupport(t *testing.T) {
+	trie, b := newTestTrie()
+	first := b.Build("a")
+	second := b.Build("b")
+	trie.Insert(first, math.MaxUint32)
+
+	sibling := newNodeFromSpan(newSpanFromLedger(second))
+	sibling.parent = trie.root
+	sibling.tipSupport = 1
+	sibling.branchSupport = 1
+	trie.root.children = append(trie.root.children, sibling)
+	trie.root.branchSupport = 0
+	trie.seqSupport[1] = 0
+
+	if trie.CheckInvariants() {
+		t.Fatal("wrapped support state passed invariants")
+	}
+}
+
+func TestLedgerTrie_CheckInvariantsRejectsSequenceKeyDrift(t *testing.T) {
+	tests := map[string]func(*Trie){
+		"Missing": func(trie *Trie) {
+			trie.seqKeys = trie.seqKeys[:1]
+		},
+		"Extra": func(trie *Trie) {
+			trie.seqKeys = append(trie.seqKeys, 3)
+		},
+		"Duplicate": func(trie *Trie) {
+			trie.seqKeys[1] = trie.seqKeys[0]
+		},
+		"Unsorted": func(trie *Trie) {
+			trie.seqKeys[0], trie.seqKeys[1] = trie.seqKeys[1], trie.seqKeys[0]
+		},
+	}
+	for name, corrupt := range tests {
+		t.Run(name, func(t *testing.T) {
+			trie, b := newTestTrie()
+			trie.Insert(b.Build("a"), 1)
+			trie.Insert(b.Build("ab"), 1)
+			corrupt(trie)
+			if trie.CheckInvariants() {
+				t.Fatal("corrupt sequence-key index passed invariants")
+			}
+		})
+	}
+}
+
+func TestLedgerTrie_LimitedHistoryExactRemoval(t *testing.T) {
+	trie := New(limitedHistoryLedger{})
+	ledger2 := limitedHistoryLedger{seq: 2}
+	ledger258 := limitedHistoryLedger{seq: 258}
+	ledger259 := limitedHistoryLedger{seq: 259}
+
+	trie.Insert(ledger2, 1)
+	trie.Insert(ledger258, 4)
+	if got := trie.TipSupport(ledger2); got != 1 {
+		t.Fatalf("ledger 2 tip support = %d, want 1", got)
+	}
+	if got := trie.BranchSupport(ledger2); got != 5 {
+		t.Fatalf("ledger 2 branch support = %d, want 5", got)
+	}
+	if got := trie.TipSupport(ledger258); got != 4 {
+		t.Fatalf("ledger 258 tip support = %d, want 4", got)
+	}
+
+	if !trie.Remove(ledger258, 3) {
+		t.Fatal("remove ledger 258 support")
+	}
+	trie.Insert(ledger259, 3)
+	if _, ok := trie.GetPreferred(1); !ok {
+		t.Fatal("expected preferred ledger")
+	}
+	if got := trie.BranchSupport(ledger2); got != 2 {
+		t.Fatalf("split ledger 2 branch support = %d, want 2", got)
+	}
+	if got := trie.TipSupport(ledger258); got != 1 {
+		t.Fatalf("split ledger 258 tip support = %d, want 1", got)
+	}
+	if got := trie.TipSupport(ledger259); got != 3 {
+		t.Fatalf("split ledger 259 tip support = %d, want 3", got)
+	}
+
+	if !trie.Remove(ledger258, 1) {
+		t.Fatal("remove exact ledger 258 support after preferred traversal")
+	}
+	trie.Insert(ledger259, 1)
+	if _, ok := trie.GetPreferred(1); !ok {
+		t.Fatal("expected preferred ledger after support move")
+	}
+	if got := trie.BranchSupport(ledger2); got != 1 {
+		t.Fatalf("final ledger 2 branch support = %d, want 1", got)
+	}
+	if got := trie.TipSupport(ledger258); got != 0 {
+		t.Fatalf("final ledger 258 tip support = %d, want 0", got)
+	}
+	if got := trie.BranchSupport(ledger258); got != 4 {
+		t.Fatalf("final ledger 258 branch support = %d, want 4\n%s", got, trie.String())
+	}
+	if got := trie.TipSupport(ledger259); got != 4 {
+		t.Fatalf("final ledger 259 tip support = %d, want 4", got)
+	}
+	if !trie.CheckInvariants() {
+		t.Fatal("limited-history support move broke invariants")
+	}
+}
+
+func TestLedgerTrie_LimitedHistoryPreferredOrderGuidesInsert(t *testing.T) {
+	trie := New(limitedHistoryLedger{})
+	ledger2 := limitedHistoryLedger{seq: 2}
+	ledger200 := limitedHistoryLedger{seq: 200}
+	ledger258 := limitedHistoryLedger{seq: 258}
+	ledger259 := limitedHistoryLedger{seq: 259}
+
+	trie.Insert(ledger2, 1)
+	trie.Insert(ledger258, 1)
+	trie.Insert(ledger259, 3)
+	if _, ok := trie.GetPreferred(1); !ok {
+		t.Fatal("expected preferred ledger for newer branch")
+	}
+
+	if !trie.Remove(ledger259, 2) {
+		t.Fatal("reduce newer branch support")
+	}
+	trie.Insert(ledger2, 2)
+	if got := trie.BranchSupport(ledger2); got != 4 {
+		t.Fatalf("older branch support = %d, want 4", got)
+	}
+	if _, ok := trie.GetPreferred(1); !ok {
+		t.Fatal("expected preferred ledger for older branch")
+	}
+
+	trie.Insert(ledger200, 1)
+	if got := trie.BranchSupport(ledger2); got != 5 {
+		t.Fatalf("intermediate support followed wrong limited-history branch: got %d, want 5", got)
+	}
+	if got := trie.BranchSupport(ledger259); got != 1 {
+		t.Fatalf("newer split branch support = %d, want 1", got)
+	}
+	if !trie.CheckInvariants() {
+		t.Fatal("preferred-order insertion broke invariants")
+	}
+}
+
+func TestLedgerTrie_TestLedgerPathValidation(t *testing.T) {
+	b := ledgertrietest.NewTestLedgerBuilder()
+	for name, path := range map[string]string{
+		"NUL":        "\x00",
+		"NonASCII":   "é",
+		"InvalidUTF": string([]byte{0xff}),
+		"TooLong":    strings.Repeat("a", 32),
+	} {
+		t.Run(name, func(t *testing.T) {
+			requirePanic(t, func() { b.Build(path) })
+		})
+	}
+
+	ledger := b.Build("abc")
+	wantID := consensus.LedgerID{'a', 'b', 'c'}
+	if ledger.ID() != wantID {
+		t.Fatalf("Build(abc) ID = %x, want %x", ledger.ID(), wantID)
+	}
+	wantAncestor := consensus.LedgerID{'a', 'b'}
+	if got := ledger.Ancestor(2); got != wantAncestor {
+		t.Fatalf("Build(abc).Ancestor(2) = %x, want %x", got, wantAncestor)
 	}
 }

--- a/internal/consensus/ledgertrietest/testledger.go
+++ b/internal/consensus/ledgertrietest/testledger.go
@@ -1,10 +1,7 @@
-package ledgertrie
+package ledgertrietest
 
-import (
-	"github.com/LeJamon/go-xrpl/internal/consensus"
-)
+import "github.com/LeJamon/go-xrpl/internal/consensus"
 
-// TestLedger is a deterministic in-memory ledger for unit tests.
 type TestLedger struct {
 	id        consensus.LedgerID
 	seq       uint32
@@ -22,11 +19,6 @@ func (l *TestLedger) Ancestor(s uint32) consensus.LedgerID {
 	return l.ancestors[s]
 }
 
-// TestLedgerBuilder constructs TestLedgers from path strings: Build("abc")
-// is genesis → 'a' → 'b' → 'c'; "ab" and "abc" share the "ab" prefix.
-// Each path rune is written into byte `depth` of the LedgerID so
-// lexicographic byte-order on IDs agrees with rune-order on paths.
-// Limited to ASCII paths shorter than 32 bytes.
 type TestLedgerBuilder struct {
 	genesis  *TestLedger
 	children map[childKey]*TestLedger
@@ -34,12 +26,11 @@ type TestLedgerBuilder struct {
 
 type childKey struct {
 	parent consensus.LedgerID
-	r      rune
+	edge   byte
 }
 
 func NewTestLedgerBuilder() *TestLedgerBuilder {
 	genesis := &TestLedger{
-		seq:       0,
 		ancestors: []consensus.LedgerID{{}},
 	}
 	return &TestLedgerBuilder{
@@ -50,17 +41,23 @@ func NewTestLedgerBuilder() *TestLedgerBuilder {
 
 func (b *TestLedgerBuilder) Genesis() *TestLedger { return b.genesis }
 
-// Build returns the memoized ledger for s; empty s returns genesis.
-func (b *TestLedgerBuilder) Build(s string) *TestLedger {
-	if len(s) >= 32 {
+func (b *TestLedgerBuilder) Build(path string) *TestLedger {
+	if len(path) >= len(consensus.LedgerID{}) {
 		panic("TestLedgerBuilder: path too long for 32-byte ID encoding")
 	}
+	for i := range len(path) {
+		if path[i] == 0 || path[i] > 0x7f {
+			panic("TestLedgerBuilder: path must contain non-NUL ASCII bytes")
+		}
+	}
+
 	curr := b.genesis
-	for i, r := range s {
-		key := childKey{parent: curr.id, r: r}
+	for depth := range len(path) {
+		edge := path[depth]
+		key := childKey{parent: curr.id, edge: edge}
 		child, ok := b.children[key]
 		if !ok {
-			child = b.extend(curr, r, i)
+			child = extend(curr, edge, depth)
 			b.children[key] = child
 		}
 		curr = child
@@ -68,10 +65,9 @@ func (b *TestLedgerBuilder) Build(s string) *TestLedger {
 	return curr
 }
 
-func (b *TestLedgerBuilder) extend(parent *TestLedger, r rune, depth int) *TestLedger {
-	var id consensus.LedgerID
-	copy(id[:], parent.id[:])
-	id[depth] = byte(r)
+func extend(parent *TestLedger, edge byte, depth int) *TestLedger {
+	id := parent.id
+	id[depth] = edge
 
 	ancestors := make([]consensus.LedgerID, parent.seq+2)
 	copy(ancestors, parent.ancestors)

--- a/internal/consensus/rcl/validations_acquire_test.go
+++ b/internal/consensus/rcl/validations_acquire_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrie"
+	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrietest"
 )
 
 type lockProbeAncestryProvider struct {
@@ -32,7 +33,7 @@ func TestValidationTracker_UnresolvableValidationParksThenReplays(t *testing.T) 
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abc := b.Build("abc")
 	abcd := b.Build("abcd")
 
@@ -83,7 +84,7 @@ func TestValidationTracker_AncestryLookupDoesNotHoldTrackerLock(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	ledger := ledgertrie.NewTestLedgerBuilder().Build("abc")
+	ledger := ledgertrietest.NewTestLedgerBuilder().Build("abc")
 	node := consensus.NodeID{1}
 	provider := &lockProbeAncestryProvider{}
 	vt.SetTrusted([]consensus.NodeID{node})
@@ -123,7 +124,7 @@ func TestValidationTracker_TrieDecidesWithMajorityParked(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abc := b.Build("abc")   // island tip, locally held
 	abde := b.Build("abde") // majority tip, not held yet
 
@@ -172,7 +173,7 @@ func TestValidationTracker_ReadPollReplaysParked(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abc := b.Build("abc")
 	abcd := b.Build("abcd")
 
@@ -205,7 +206,7 @@ func TestValidationTracker_GetTrustedSupportPollReplaysParked(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abcd := b.Build("abcd")
 
 	provider := newMapAncestryProvider()
@@ -230,7 +231,7 @@ func TestValidationTracker_GetPreferred_AcquiringMajorityFallback(t *testing.T) 
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abcx := b.Build("abcx")
 	abcy := b.Build("abcy")
 
@@ -255,7 +256,7 @@ func TestValidationTracker_GetPreferred_AcquiringTieBreaksOnGreaterID(t *testing
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abcx := b.Build("abcx")
 	abcy := b.Build("abcy") // same seq, greater ID than abcx
 
@@ -281,7 +282,7 @@ func TestValidationTracker_SupersededValidationUnparks(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abcz := b.Build("abcz")   // greater ID: would win the tie-break if it lingered
 	abcwv := b.Build("abcwv") // higher seq, lesser ID at the fork byte
 
@@ -308,7 +309,7 @@ func TestValidationTracker_ExpireOldUnparks(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abcd := b.Build("abcd")
 
 	n1 := consensus.NodeID{1}
@@ -334,7 +335,7 @@ func TestValidationTracker_FlushStaleUnparks(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abcd := b.Build("abcd")
 
 	provider := newMapAncestryProvider()
@@ -374,7 +375,7 @@ func TestValidationTracker_DetrustedParkedValidationNotReplayed(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abcd := b.Build("abcd")
 
 	provider := newMapAncestryProvider()
@@ -406,7 +407,7 @@ func TestValidationTracker_TrustChangeReparksFromByNode(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abcd := b.Build("abcd")
 
 	n1 := consensus.NodeID{1}

--- a/internal/consensus/rcl/validations_partial_test.go
+++ b/internal/consensus/rcl/validations_partial_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
-	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrie"
+	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrietest"
 )
 
 // TestValidationTracker_TrustedPartialSteersButNotQuorum pins the A1
@@ -20,7 +20,7 @@ func TestValidationTracker_TrustedPartialSteersButNotQuorum(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abc := b.Build("abc")
 	abcd := b.Build("abcd")
 	provider := newMapAncestryProvider()

--- a/internal/consensus/rcl/validations_test.go
+++ b/internal/consensus/rcl/validations_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
-	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrie"
+	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrietest"
 )
 
 func TestValidationTracker_Add(t *testing.T) {
@@ -866,7 +866,7 @@ func TestValidationTracker_Flush(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abc := b.Build("abc")
 	provider := newMapAncestryProvider()
 	provider.add(abc)

--- a/internal/consensus/rcl/validations_trie.go
+++ b/internal/consensus/rcl/validations_trie.go
@@ -185,9 +185,14 @@ func (vt *ValidationTracker) unparkLocked(key acquiringKey, nodeID consensus.Nod
 // Caller must hold vt.mu (write).
 func (vt *ValidationTracker) insertTipLocked(nodeID consensus.NodeID, lgr ledgertrie.Ledger) {
 	if prev, existed := vt.trieTips[nodeID]; existed {
-		safeTrieCall("Remove", func() { vt.trie.Remove(prev, 1) })
+		if safeTrieCall("Remove", func() { vt.trie.Remove(prev, 1) }) {
+			return
+		}
+		delete(vt.trieTips, nodeID)
 	}
-	safeTrieCall("Insert", func() { vt.trie.Insert(lgr, 1) })
+	if safeTrieCall("Insert", func() { vt.trie.Insert(lgr, 1) }) {
+		return
+	}
 	vt.trieTips[nodeID] = lgr
 }
 

--- a/internal/consensus/rcl/validations_trie_test.go
+++ b/internal/consensus/rcl/validations_trie_test.go
@@ -11,9 +11,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrietest"
 )
 
-// mapAncestryProvider is a tiny LedgerAncestryProvider backed by a
-// map, used to wire test ledgers into the
-// ValidationTracker for these tests.
 type mapAncestryProvider struct {
 	byID map[consensus.LedgerID]ledgertrie.Ledger
 }

--- a/internal/consensus/rcl/validations_trie_test.go
+++ b/internal/consensus/rcl/validations_trie_test.go
@@ -2,15 +2,17 @@ package rcl
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrie"
+	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrietest"
 )
 
 // mapAncestryProvider is a tiny LedgerAncestryProvider backed by a
-// map, used to wire ledgertrie.TestLedger instances into the
+// map, used to wire test ledgers into the
 // ValidationTracker for these tests.
 type mapAncestryProvider struct {
 	byID map[consensus.LedgerID]ledgertrie.Ledger
@@ -27,6 +29,13 @@ func (m *mapAncestryProvider) LedgerByID(id consensus.LedgerID) (ledgertrie.Ledg
 	return l, ok
 }
 
+type maxSequenceLedger struct{}
+
+func (maxSequenceLedger) ID() consensus.LedgerID             { return consensus.LedgerID{1} }
+func (maxSequenceLedger) Seq() uint32                        { return math.MaxUint32 }
+func (maxSequenceLedger) MinSeq() uint32                     { return 0 }
+func (maxSequenceLedger) Ancestor(uint32) consensus.LedgerID { return consensus.LedgerID{} }
+
 // makeTrustedValidation constructs a trusted validation at the given
 // seq from nodeID pointing at ledgerID. Close enough to the isCurrent
 // window that Add() will accept it with SetNow(time.Now).
@@ -38,6 +47,30 @@ func makeTrustedValidation(nodeID consensus.NodeID, ledgerID consensus.LedgerID,
 		SignTime:  now,
 		SeenTime:  now,
 		Full:      true,
+	}
+}
+
+func TestValidationTracker_InsertTipDoesNotRecordRejectedLedger(t *testing.T) {
+	vt := NewValidationTracker(1, 5*time.Minute)
+	vt.trie = ledgertrie.New(genesisLedger{})
+	vt.trieTips = make(map[consensus.NodeID]ledgertrie.Ledger)
+
+	nodeID := consensus.NodeID{1}
+	valid := ledgertrietest.NewTestLedgerBuilder().Build("a")
+	vt.insertTipLocked(nodeID, valid)
+	if vt.trieTips[nodeID] != valid {
+		t.Fatal("valid ledger was not recorded")
+	}
+
+	vt.insertTipLocked(nodeID, maxSequenceLedger{})
+	if _, ok := vt.trieTips[nodeID]; ok {
+		t.Fatal("rejected ledger was recorded as the node tip")
+	}
+	if vt.trie.TipSupport(valid) != 0 {
+		t.Fatal("replaced ledger retained support after the new ledger was rejected")
+	}
+	if _, ok := vt.trie.GetPreferred(0); ok {
+		t.Fatal("rejected ledger left support in the trie")
 	}
 }
 
@@ -61,7 +94,7 @@ func TestValidationTracker_TrieDeepestSharedAncestor(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	ab := b.Build("ab")
 	abc := b.Build("abc")
 	abd := b.Build("abd")
@@ -119,7 +152,7 @@ func TestValidationTracker_TrieNewerValidationReplacesOld(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abc := b.Build("abc")
 	abde := b.Build("abde")
 
@@ -161,7 +194,7 @@ func TestValidationTracker_TrieNegUNLExcluded(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abc := b.Build("abc")
 	provider := newMapAncestryProvider()
 	provider.add(abc)
@@ -201,7 +234,7 @@ func TestValidationTracker_TrieNegUNLSteersButExcludedFromQuorum(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	a := b.Build("a")
 	ab := b.Build("ab")
 	ac := b.Build("ac")
@@ -253,7 +286,7 @@ func TestValidationTracker_TrieGetPreferred(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abc := b.Build("abc")
 	abde := b.Build("abde")
 	provider := newMapAncestryProvider()
@@ -304,7 +337,7 @@ func TestValidationTracker_TrieGetPreferred_LargestIssuedAffectsDescent(t *testi
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	a := b.Build("a")
 	ab := b.Build("ab")
 	ac := b.Build("ac")
@@ -359,7 +392,7 @@ func TestValidationTracker_TrieDisabled_FallsBack(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abc := b.Build("abc")
 
 	n1 := consensus.NodeID{1}
@@ -390,7 +423,7 @@ func TestValidationTracker_ExpireOldDropsTrieTip(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	ab := b.Build("ab")   // seq 2 — common ancestor
 	abc := b.Build("abc") // seq 3
 	abd := b.Build("abd") // seq 3
@@ -466,7 +499,7 @@ func TestValidationTracker_GetJSONTrie(t *testing.T) {
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
-	b := ledgertrie.NewTestLedgerBuilder()
+	b := ledgertrietest.NewTestLedgerBuilder()
 	abc := b.Build("abc")
 	provider := newMapAncestryProvider()
 	provider.add(abc)


### PR DESCRIPTION
## Summary
- reject nil, invalid-sequence, and overflowing ledger-trie inserts before mutation, and strengthen support/index invariant checks
- preserve rippled's limited-history child ordering, move deterministic fixtures into internal test support, and add boundary regressions

## Test plan
- [x] `go test -count=1 ./internal/consensus/ledgertrie ./internal/consensus/rcl`
- [x] `go test -race -count=1 ./internal/consensus/ledgertrie ./internal/consensus/rcl`
- [x] `just test-core`
- [x] `just test`
- [x] `just vet`
- [x] `golangci-lint run`
- [x] `golangci-lint run --config .golangci-warnings.yml`
- [x] `just build-all`
- [x] `just build-nocgo`
- [x] `go mod tidy -diff`
- [x] `git diff --check`

Fixes #1459


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ledger validation for invalid paths, unsupported sequences, empty values, and numeric overflow conditions.
  - Prevented rejected or failed ledger updates from being retained in validation state.
  - Improved consistency checks when removing ledger history.
  - Enhanced preferred-ledger selection when multiple candidates have similar support.
  - Added safeguards against invalid characters in ledger paths.

- **Tests**
  - Expanded coverage for boundary conditions, corrupted state, ordering, limited history, path validation, and rejected ledger updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->