### PR TITLE
fix: harden consensus protocol ingress

### DIFF
--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -270,7 +270,13 @@ func (c Algorithm) validateBytes(msg, pubkey, sig []byte, mustBeFullyCanonical, 
 // Matches rippled's verifyDigest() which passes the SHA-512Half hash directly
 // to secp256k1_ecdsa_verify.
 func (c Algorithm) ValidateDigest(digest [32]byte, pubkeyBytes []byte, sigBytes []byte) bool {
-	return c.validateBytes(digest[:], pubkeyBytes, sigBytes, false, false)
+	return c.ValidateDigestWithCanonicality(digest, pubkeyBytes, sigBytes, false)
+}
+
+// ValidateDigestWithCanonicality verifies a pre-computed digest and optionally
+// requires a fully canonical low-S signature.
+func (c Algorithm) ValidateDigestWithCanonicality(digest [32]byte, pubkeyBytes []byte, sigBytes []byte, mustBeFullyCanonical bool) bool {
+	return c.validateBytes(digest[:], pubkeyBytes, sigBytes, mustBeFullyCanonical, false)
 }
 
 // DerivePublicKeyFromPublicGenerator derives a public key from a public generator.

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -575,6 +575,9 @@ func (a *Adaptor) setOnLedgerBuilt(cb func(uint32, [32]byte)) {
 }
 
 func (a *Adaptor) RequestTxSet(id consensus.TxSetID) error {
+	if id == (consensus.TxSetID{}) {
+		return nil
+	}
 	if a.onTxSetRequested != nil {
 		a.onTxSetRequested(id)
 	}
@@ -723,8 +726,8 @@ func (a *Adaptor) PeerWithTxSet(target [32]byte, exclude uint64) (uint64, bool) 
 // NotePeerHasTxSet delegates to NetworkSender; the Router calls it on
 // inbound mtHAVE_TRANSACTION_SET{tsHAVE} so PeerWithTxSet can later find
 // the advertising peer.
-func (a *Adaptor) NotePeerHasTxSet(peerID uint64, hash [32]byte) {
-	a.sender.NotePeerHasTxSet(peerID, hash)
+func (a *Adaptor) NotePeerHasTxSet(peerID uint64, hash [32]byte) bool {
+	return a.sender.NotePeerHasTxSet(peerID, hash)
 }
 
 // LedgerService returns the underlying ledger service for direct queries.

--- a/internal/consensus/adaptor/converter.go
+++ b/internal/consensus/adaptor/converter.go
@@ -1,6 +1,7 @@
 package adaptor
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
@@ -98,12 +99,13 @@ func TransactionFromMessage(msg *message.Transaction) []byte {
 }
 
 // HaveSetFromMessage converts a decoded HaveTransactionSet message.
-func HaveSetFromMessage(msg *message.HaveTransactionSet) (consensus.TxSetID, message.TxSetStatus) {
+func HaveSetFromMessage(msg *message.HaveTransactionSet) (consensus.TxSetID, message.TxSetStatus, error) {
 	var id consensus.TxSetID
-	if len(msg.Hash) == 32 {
-		copy(id[:], msg.Hash)
+	if len(msg.Hash) != len(id) {
+		return id, msg.Status, fmt.Errorf("have_set hash must be %d bytes: got %d", len(id), len(msg.Hash))
 	}
-	return id, msg.Status
+	copy(id[:], msg.Hash)
+	return id, msg.Status, nil
 }
 
 func xrplEpochToTime(epoch uint32) time.Time {

--- a/internal/consensus/adaptor/finalization_conformance_test.go
+++ b/internal/consensus/adaptor/finalization_conformance_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	rootcrypto "github.com/LeJamon/go-xrpl/crypto"
+	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -43,13 +44,12 @@ func TestVerifyValidationEnforcesCanonicalFlag(t *testing.T) {
 
 func TestSTValidationPreservesSignedAmountPresence(t *testing.T) {
 	for _, test := range []struct {
-		name     string
-		raw      uint64
-		drops    uint64
-		negative bool
+		name  string
+		raw   uint64
+		value drops.XRPAmount
 	}{
 		{name: "positive zero", raw: 1 << 62},
-		{name: "negative one", raw: 1, drops: 1, negative: true},
+		{name: "negative one", raw: 1, value: -1},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			identity, fields := signedValidationFixture(t)
@@ -65,15 +65,13 @@ func TestSTValidationPreservesSignedAmountPresence(t *testing.T) {
 			blob, _, _ := signValidationWireFields(t, identity, fields)
 			validation, err := parseSTValidation(blob)
 			require.NoError(t, err)
-			drops, negative, present := validation.BaseFeeDropsValue()
+			value, present := validation.BaseFeeDropsVote()
 			require.True(t, present)
-			require.Equal(t, test.drops, drops)
-			require.Equal(t, test.negative, negative)
+			require.Equal(t, test.value, value)
 
 			vote := extractFeeVote(validation, true)
 			require.NotNil(t, vote.BaseFee)
-			require.Equal(t, test.drops, *vote.BaseFee)
-			require.Equal(t, test.negative, vote.BaseFeeNegative)
+			require.Equal(t, test.value, *vote.BaseFee)
 		})
 	}
 }

--- a/internal/consensus/adaptor/finalization_conformance_test.go
+++ b/internal/consensus/adaptor/finalization_conformance_test.go
@@ -1,0 +1,104 @@
+package adaptor
+
+import (
+	"encoding/binary"
+	"math/big"
+	"testing"
+	"time"
+
+	rootcrypto "github.com/LeJamon/go-xrpl/crypto"
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyValidationEnforcesCanonicalFlag(t *testing.T) {
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	validation := &consensus.Validation{
+		LedgerID:  consensus.LedgerID{1},
+		LedgerSeq: 2,
+		SignTime:  time.Unix(protocol.RippleEpochUnix+3, 0),
+		Full:      true,
+	}
+	require.NoError(t, identity.SignValidation(validation))
+	require.NoError(t, VerifyValidation(validation))
+
+	r, s, err := rootcrypto.DERSigToRS(validation.Signature)
+	require.NoError(t, err)
+	highS := new(big.Int).Sub(btcec.S256().N, new(big.Int).SetBytes(s))
+	validation.Signature = rootcrypto.EncodeDERSignature(new(big.Int).SetBytes(r), highS)
+	require.Error(t, VerifyValidation(validation))
+
+	validation.Flags &^= vfFullyCanonicalSig
+	validation.Signature, err = identity.Sign(buildValidationSigningData(validation))
+	require.NoError(t, err)
+	r, s, err = rootcrypto.DERSigToRS(validation.Signature)
+	require.NoError(t, err)
+	highS.Sub(btcec.S256().N, new(big.Int).SetBytes(s))
+	validation.Signature = rootcrypto.EncodeDERSignature(new(big.Int).SetBytes(r), highS)
+	require.NoError(t, VerifyValidation(validation))
+}
+
+func TestSTValidationPreservesSignedAmountPresence(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		raw      uint64
+		drops    uint64
+		negative bool
+	}{
+		{name: "positive zero", raw: 1 << 62},
+		{name: "negative one", raw: 1, drops: 1, negative: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			identity, fields := signedValidationFixture(t)
+			amount := validationWireField{
+				key:       validationFieldKey(typeAmount, fieldBaseFeeDrops),
+				typeCode:  typeAmount,
+				fieldCode: fieldBaseFeeDrops,
+				wire:      appendFieldHeader(nil, typeAmount, fieldBaseFeeDrops),
+			}
+			amount.wire = binary.BigEndian.AppendUint64(amount.wire, test.raw)
+			fields = append(fields, amount)
+
+			blob, _, _ := signValidationWireFields(t, identity, fields)
+			validation, err := parseSTValidation(blob)
+			require.NoError(t, err)
+			drops, negative, present := validation.BaseFeeDropsValue()
+			require.True(t, present)
+			require.Equal(t, test.drops, drops)
+			require.Equal(t, test.negative, negative)
+
+			vote := extractFeeVote(validation, true)
+			require.NotNil(t, vote.BaseFee)
+			require.Equal(t, test.drops, *vote.BaseFee)
+			require.Equal(t, test.negative, vote.BaseFeeNegative)
+		})
+	}
+}
+
+func TestSerializeSTValidationEmitsCloseTimeAndCanonicalFlag(t *testing.T) {
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+	closeTime := time.Unix(protocol.RippleEpochUnix+10, 0).UTC()
+	validation := &consensus.Validation{
+		LedgerID:  consensus.LedgerID{1},
+		LedgerSeq: 2,
+		SignTime:  time.Unix(protocol.RippleEpochUnix+9, 0),
+		CloseTime: closeTime,
+		Flags:     0x40,
+	}
+	require.NoError(t, identity.SignValidation(validation))
+
+	parsed, err := parseSTValidation(SerializeSTValidation(validation))
+	require.NoError(t, err)
+	require.Equal(t, closeTime, parsed.CloseTime)
+	require.NotZero(t, parsed.Flags&vfFullyCanonicalSig)
+	require.NotZero(t, parsed.Flags&0x40)
+
+	validation.Flags = 0x40
+	parsed, err = parseSTValidation(SerializeSTValidation(validation))
+	require.NoError(t, err)
+	require.Equal(t, uint32(0x40), parsed.Flags)
+}

--- a/internal/consensus/adaptor/have_set_test.go
+++ b/internal/consensus/adaptor/have_set_test.go
@@ -1,0 +1,122 @@
+package adaptor
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHaveSetFromMessageRejectsMalformedHash(t *testing.T) {
+	for _, size := range []int{0, 31, 33} {
+		t.Run(strconv.Itoa(size), func(t *testing.T) {
+			msg := &message.HaveTransactionSet{
+				Status: message.TxSetStatusHave,
+				Hash:   make([]byte, size),
+			}
+
+			id, status, err := HaveSetFromMessage(msg)
+
+			require.Error(t, err)
+			assert.Zero(t, id)
+			assert.Equal(t, message.TxSetStatusHave, status)
+		})
+	}
+}
+
+func TestRouterHaveSetMalformedHashReturnsBeforeStateMutation(t *testing.T) {
+	tests := []struct {
+		name   string
+		status message.TxSetStatus
+	}{
+		{name: "have", status: message.TxSetStatusHave},
+		{name: "need", status: message.TxSetStatusNeed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status := test.status
+			r, sender := makeRouterWithRelayRecorder(t)
+			engine := &mockEngine{}
+			r.engine = engine
+
+			empty, err := NewTxSet(nil)
+			require.NoError(t, err)
+			require.Zero(t, empty.ID())
+			r.adaptor.txSetCache.Put(empty)
+
+			have := &message.HaveTransactionSet{
+				Status: status,
+				Hash:   bytes.Repeat([]byte{0x9A}, 31),
+			}
+			r.handleMessage(&peermanagement.InboundMessage{
+				PeerID:  88,
+				Type:    uint16(message.TypeHaveSet),
+				Payload: encodePayload(t, have),
+			})
+
+			assert.Equal(t,
+				[]badDataCall{{peerID: 88, reason: "have-set-hashsize"}},
+				sender.badDataCalls(),
+			)
+			assert.Empty(t, sender.notedTxSets())
+			assert.Empty(t, recordedHaveSetTxSets(engine))
+		})
+	}
+}
+
+func TestRouterHaveSetNeedDoesNotMutatePeerOrEngineState(t *testing.T) {
+	r, sender := makeRouterWithRelayRecorder(t)
+	engine := &mockEngine{}
+	r.engine = engine
+
+	txSet, err := NewTxSet([][]byte{bytes.Repeat([]byte{0x01}, 12)})
+	require.NoError(t, err)
+	require.NotZero(t, txSet.ID())
+	r.adaptor.txSetCache.Put(txSet)
+
+	have := HaveSetToMessage(txSet.ID(), message.TxSetStatusNeed)
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  88,
+		Type:    uint16(message.TypeHaveSet),
+		Payload: encodePayload(t, have),
+	})
+
+	assert.Empty(t, sender.badDataCalls())
+	assert.Empty(t, sender.notedTxSets())
+	assert.Empty(t, recordedHaveSetTxSets(engine))
+}
+
+func TestRouterHaveSetDuplicateChargesUselessData(t *testing.T) {
+	r, sender := makeRouterWithRelayRecorder(t)
+	have := &message.HaveTransactionSet{
+		Status: message.TxSetStatusHave,
+		Hash:   bytes.Repeat([]byte{0x9A}, 32),
+	}
+	inbound := &peermanagement.InboundMessage{
+		PeerID:  88,
+		Type:    uint16(message.TypeHaveSet),
+		Payload: encodePayload(t, have),
+	}
+
+	r.handleMessage(inbound)
+	assert.Empty(t, sender.badDataCalls())
+
+	r.handleMessage(inbound)
+
+	require.Len(t, sender.notedTxSets(), 1)
+	assert.Equal(t,
+		[]badDataCall{{peerID: 88, reason: "have-set-duplicate"}},
+		sender.badDataCalls(),
+	)
+}
+
+func recordedHaveSetTxSets(engine *mockEngine) []consensus.TxSetID {
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	return append([]consensus.TxSetID(nil), engine.txSets...)
+}

--- a/internal/consensus/adaptor/identity.go
+++ b/internal/consensus/adaptor/identity.go
@@ -207,6 +207,10 @@ func (vi *ValidatorIdentity) Sign(data []byte) ([]byte, error) {
 // secp256k1 verifies the digest natively, and ed25519 verifies the
 // digest as a 32-byte message (no internal re-hash).
 func Verify(pubKey []byte, data []byte, signature []byte) bool {
+	return verifyWithCanonicality(pubKey, data, signature, false)
+}
+
+func verifyWithCanonicality(pubKey []byte, data []byte, signature []byte, mustBeFullyCanonical bool) bool {
 	if len(pubKey) != 33 {
 		return false
 	}
@@ -220,7 +224,7 @@ func Verify(pubKey []byte, data []byte, signature []byte) bool {
 		algo := secp256k1.Algorithm{}
 		var digest [32]byte
 		copy(digest[:], data)
-		return algo.ValidateDigest(digest, pubKey, signature)
+		return algo.ValidateDigestWithCanonicality(digest, pubKey, signature, mustBeFullyCanonical)
 	default:
 		return false
 	}
@@ -263,7 +267,10 @@ func (vi *ValidatorIdentity) SignValidation(validation *consensus.Validation) er
 	}
 	validation.SigningPubKey = consensus.SigningPubKey(vi.SigningKey)
 	validation.NodeID = vi.NodeID
-	validation.Flags = localValidationFlags(validation.Full)
+	validation.Flags |= vfFullyCanonicalSig
+	if validation.Full {
+		validation.Flags |= vfFullValidation
+	}
 	data := buildValidationSigningData(validation)
 	sig, err := vi.Sign(data)
 	if err != nil {
@@ -280,7 +287,8 @@ func (vi *ValidatorIdentity) SignValidation(validation *consensus.Validation) er
 // with.
 func VerifyValidation(validation *consensus.Validation) error {
 	data := buildValidationSigningData(validation)
-	if !Verify(validation.SigningPubKey[:], data, validation.Signature) {
+	mustBeFullyCanonical := validation.Flags&vfFullyCanonicalSig != 0
+	if !verifyWithCanonicality(validation.SigningPubKey[:], data, validation.Signature, mustBeFullyCanonical) {
 		return errors.New("invalid validation signature")
 	}
 	return nil
@@ -335,9 +343,8 @@ func buildValidationSigningData(v *consensus.Validation) []byte {
 	// standing fork hazard). SerializeSTValidation emits sfSignature only
 	// when v.Signature is non-empty and as a distinct field between
 	// sfSigningPubKey and sfAmendments, so clearing it yields exactly the
-	// non-signature preimage. SignValidation normalizes outbound Flags before
-	// reaching this helper, and SerializeSTValidation uses the same helper for
-	// unsigned self-built validations.
+	// non-signature preimage. SignValidation stamps outbound flags before
+	// this function is called.
 	unsigned := *v
 	unsigned.Signature = nil
 	hash := sha512half.Sum(protocol.HashPrefixValidation().Bytes(), SerializeSTValidation(&unsigned))

--- a/internal/consensus/adaptor/network_sender.go
+++ b/internal/consensus/adaptor/network_sender.go
@@ -88,8 +88,8 @@ type NetworkSender interface {
 	// liTS_CANDIDATE GetLedger.
 	PeerWithTxSet(target [32]byte, exclude uint64) (uint64, bool)
 	// NotePeerHasTxSet records that peerID advertised tx-set root hash,
-	// feeding PeerWithTxSet.
-	NotePeerHasTxSet(peerID uint64, hash [32]byte)
+	// feeding PeerWithTxSet. It reports whether the advertisement was new.
+	NotePeerHasTxSet(peerID uint64, hash [32]byte) bool
 }
 
 // noopSender is a no-op NetworkSender for standalone or test use.
@@ -130,4 +130,4 @@ func (n *noopSender) ShouldShedLedgerRequest(uint64, bool) bool                 
 func (n *noopSender) PeerWithLedger([32]byte, uint32, uint64) (uint64, bool)     { return 0, false }
 func (n *noopSender) SelectLedgerPeers([32]byte, uint32, []uint64, int) []uint64 { return nil }
 func (n *noopSender) PeerWithTxSet([32]byte, uint64) (uint64, bool)              { return 0, false }
-func (n *noopSender) NotePeerHasTxSet(uint64, [32]byte)                          {}
+func (n *noopSender) NotePeerHasTxSet(uint64, [32]byte) bool                     { return true }

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -675,21 +675,19 @@ func (r *Router) handleHaveSet(msg *peermanagement.InboundMessage) {
 		return
 	}
 
-	txSetID, status := HaveSetFromMessage(hts)
+	txSetID, status, err := HaveSetFromMessage(hts)
+	if err != nil {
+		r.adaptor.IncPeerBadData(uint64(msg.PeerID), "have-set-hashsize")
+		return
+	}
 
-	switch status {
-	case message.TxSetStatusHave:
+	if status == message.TxSetStatusHave {
 		// Record the advertisement so an inbound GetLedger we can't satisfy
 		// can be relayed to this peer (rippled getPeerWithTree).
-		r.adaptor.NotePeerHasTxSet(uint64(msg.PeerID), [32]byte(txSetID))
-		r.logger.Debug("peer has txset", "txset", txSetID, "peer", msg.PeerID)
-	case message.TxSetStatusNeed:
-		// Peer needs a tx set we might have — check cache and respond.
-		if ts, ok := r.adaptor.txSetCache.Get(txSetID); ok {
-			// We have it — notify the engine with the tx set data
-			if err := r.engine.OnTxSet(ts.ID(), ts.Txs()); err != nil {
-				r.logger.Debug("engine rejected txset", "error", err)
-			}
+		if !r.adaptor.NotePeerHasTxSet(uint64(msg.PeerID), [32]byte(txSetID)) {
+			r.adaptor.IncPeerBadData(uint64(msg.PeerID), "have-set-duplicate")
+			return
 		}
+		r.logger.Debug("peer has txset", "txset", txSetID, "peer", msg.PeerID)
 	}
 }

--- a/internal/consensus/adaptor/router_relay_test.go
+++ b/internal/consensus/adaptor/router_relay_test.go
@@ -54,10 +54,16 @@ func (s *relayRecorder) PeerWithTxSet(_ [32]byte, exclude uint64) (uint64, bool)
 	return s.txsetPeer, s.txsetOK
 }
 
-func (s *relayRecorder) NotePeerHasTxSet(peerID uint64, hash [32]byte) {
+func (s *relayRecorder) NotePeerHasTxSet(peerID uint64, hash [32]byte) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	for _, noted := range s.noted {
+		if noted.peerID == peerID && noted.hash == hash {
+			return false
+		}
+	}
 	s.noted = append(s.noted, notedTxSet{peerID: peerID, hash: hash})
+	return true
 }
 
 func (s *relayRecorder) IncPeerBadData(peerID uint64, reason string) {

--- a/internal/consensus/adaptor/router_resolve_master_nodeid_test.go
+++ b/internal/consensus/adaptor/router_resolve_master_nodeid_test.go
@@ -1,13 +1,18 @@
 package adaptor
 
 import (
+	"bytes"
+	"encoding/hex"
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +20,38 @@ import (
 // to the cache, returning the master and ephemeral pubkeys.
 func installManifest(t *testing.T, cache *manifest.Cache, masterSeed, ephSeed byte) (master [33]byte, ephemeral [33]byte) {
 	t.Helper()
-	serialized := buildWireManifest(t, 1, masterSeed, ephSeed)
+
+	algo := secp256k1.Algorithm{}
+	masterSecret := bytes.Repeat([]byte{masterSeed}, 32)
+	ephemeralSecret := bytes.Repeat([]byte{ephSeed}, 32)
+	masterPublic, err := algo.DerivePublicKeyFromSecret(masterSecret)
+	require.NoError(t, err)
+	ephemeralPublic, err := algo.DerivePublicKeyFromSecret(ephemeralSecret)
+	require.NoError(t, err)
+
+	fields := map[string]any{
+		"PublicKey":     hex.EncodeToString(masterPublic),
+		"SigningPubKey": hex.EncodeToString(ephemeralPublic),
+		"Sequence":      uint32(1),
+	}
+	encoded, err := binarycodec.Encode(fields)
+	require.NoError(t, err)
+	body, err := hex.DecodeString(encoded)
+	require.NoError(t, err)
+	prefix := protocol.HashPrefixManifest()
+	preimage := append(prefix[:], body...)
+
+	signature, err := algo.Sign(string(preimage), hex.EncodeToString(ephemeralSecret))
+	require.NoError(t, err)
+	masterSignature, err := algo.Sign(string(preimage), hex.EncodeToString(masterSecret))
+	require.NoError(t, err)
+	fields["Signature"] = signature
+	fields["MasterSignature"] = masterSignature
+
+	encoded, err = binarycodec.Encode(fields)
+	require.NoError(t, err)
+	serialized, err := hex.DecodeString(encoded)
+	require.NoError(t, err)
 	parsed, err := manifest.Deserialize(serialized)
 	require.NoError(t, err)
 	if disp := cache.ApplyManifest(parsed); disp != manifest.Accepted {
@@ -98,11 +134,10 @@ func TestRouter_ResolveMasterNodeID_Validation_NoMappingPreservesSigning(t *test
 	ctx := t.Context()
 	go router.Run(ctx)
 
+	signingBytes, err := secp256k1.Algorithm{}.DerivePublicKeyFromSecret(bytes.Repeat([]byte{0x42}, 32))
+	require.NoError(t, err)
 	var signing [33]byte
-	signing[0] = 0xED
-	for i := 1; i < len(signing); i++ {
-		signing[i] = byte(i)
-	}
+	copy(signing[:], signingBytes)
 
 	v := &consensus.Validation{
 		Full:      true,

--- a/internal/consensus/adaptor/router_test.go
+++ b/internal/consensus/adaptor/router_test.go
@@ -722,7 +722,8 @@ func TestConverterTransactionRoundTrip(t *testing.T) {
 func TestConverterHaveSetRoundTrip(t *testing.T) {
 	id := consensus.TxSetID{0x01, 0x02, 0x03}
 	msg := HaveSetToMessage(id, message.TxSetStatusNeed)
-	restoredID, restoredStatus := HaveSetFromMessage(msg)
+	restoredID, restoredStatus, err := HaveSetFromMessage(msg)
+	require.NoError(t, err)
 	assert.Equal(t, id, restoredID)
 	assert.Equal(t, message.TxSetStatusNeed, restoredStatus)
 }

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -20,9 +20,8 @@ type txSetAcquireState struct {
 
 	// Retry bookkeeping. lastRequest is when we most recently broadcast a
 	// RequestTxSetMissingNodes. attempts is pure telemetry (the broadcast
-	// count surfaced in logs). stallTicks counts CONSECUTIVE no-progress
-	// timer ticks — the give-up signal — and is reset to 0 whenever an
-	// inbound reply makes progress. peerNonProgress tracks consecutive
+	// count surfaced in logs). stallTicks counts no-progress timer ticks —
+	// the give-up signal. peerNonProgress tracks consecutive
 	// TMLedgerData responses from a peer that failed to extend the SHAMap;
 	// peers at or over the per-peer threshold are skipped during the next
 	// broadcast.
@@ -44,6 +43,11 @@ type txSetAcquireState struct {
 	// sweep still reclaims a truly-abandoned entry.
 	dormant bool
 
+	// completed distinguishes a successfully acquired set from recoverable
+	// terminal failures. stillNeed revives failed acquisitions, but never a set
+	// that was already delivered to consensus.
+	completed bool
+
 	// haveRoot latches once the real root node for this tx-set hash has been
 	// installed. A fresh shamap.New carries a non-nil but EMPTY root, which
 	// would let an empty tree "complete" with zero leaves; until haveRoot is
@@ -51,7 +55,7 @@ type txSetAcquireState struct {
 	haveRoot bool
 
 	// done latches a terminal acquire: completed (set built and fed to the
-	// engine) or given-up (dormant past MaxStallTicks). A data reply for a
+	// engine) or failed/given-up. A data reply for a
 	// done acquire is charged and dropped so a straggler can neither recreate
 	// a fresh empty map nor fan out re-requests; MarkTxSetStillNeeded clears it
 	// to revive a genuinely-needed set.
@@ -80,6 +84,7 @@ const txSetAcquireTTL = 60 * time.Second
 //     stuck peer and large enough to ride out a transient empty reply.
 type txSetRetryKnobs struct {
 	MinInterval              time.Duration
+	NormalTimeouts           int
 	MaxStallTicks            int
 	PeerNonProgressThreshold int
 }
@@ -87,6 +92,7 @@ type txSetRetryKnobs struct {
 func defaultTxSetRetryKnobs() txSetRetryKnobs {
 	return txSetRetryKnobs{
 		MinInterval:              250 * time.Millisecond,
+		NormalTimeouts:           4,
 		MaxStallTicks:            20,
 		PeerNonProgressThreshold: 3,
 	}
@@ -343,7 +349,6 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 		if badRootProvided {
 			now := time.Now()
 			state.dormant = false
-			state.stallTicks = 0
 			state.attempts++
 			state.lastRequest = now
 			state.lastUpdate = now
@@ -376,7 +381,7 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			// and KEEP the entry (TTL reclaims it); MarkTxSetStillNeeded can
 			// revive it. Deleting would let the next straggler recreate a fresh
 			// empty acquire.
-			r.markTxSetDone(txSetID)
+			r.markTxSetFailed(txSetID)
 			r.logger.Info("tx-set sync: stuck",
 				"t", "consensus", "event", "txset-reject",
 				"txset", fmt.Sprintf("%x", txSetID[:8]),
@@ -439,13 +444,12 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			// The RTT itself rate-limits (one re-request per received reply),
 			// so there is no storm and no MinInterval gate is needed. A fresh
 			// lastRequest keeps the stall timer out of an actively-progressing
-			// acquire; reset stallTicks and un-dormant so a resumed acquire
-			// keeps pipelining. Give-up lives only on the timer.
+			// acquire; un-dormant so a resumed acquire keeps pipelining.
+			// Give-up lives only on the timer.
 			if originPeer != 0 {
 				state.peerNonProgress[originPeer] = 0
 			}
 			state.dormant = false
-			state.stallTicks = 0
 			state.attempts++
 			state.lastRequest = time.Now()
 			state.lastUpdate = state.lastRequest
@@ -490,7 +494,7 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 		r.deleteTxSetAcquire(txSetID)
 		return
 	}
-	r.markTxSetDone(txSetID)
+	r.markTxSetComplete(txSetID)
 
 	r.logger.Info("received tx-set from peer",
 		"t", "consensus", "event", "txset-recv",
@@ -511,14 +515,21 @@ func (r *Router) deleteTxSetAcquire(txSetID consensus.TxSetID) {
 	r.txSetAcquireMu.Unlock()
 }
 
-// markTxSetDone latches a tx-set acquire terminal (completed or given-up) and
-// KEEPS it, so later data replies are dropped rather than recreating a fresh
-// empty acquire. The TTL sweep reclaims it; MarkTxSetStillNeeded clears the
-// latch to revive a genuinely-needed set. No-op if the entry is gone.
-func (r *Router) markTxSetDone(txSetID consensus.TxSetID) {
+func (r *Router) markTxSetComplete(txSetID consensus.TxSetID) {
 	r.txSetAcquireMu.Lock()
 	if state, ok := r.txSetAcquire[txSetID]; ok {
 		state.done = true
+		state.completed = true
+	}
+	r.txSetAcquireMu.Unlock()
+}
+
+func (r *Router) markTxSetFailed(txSetID consensus.TxSetID) {
+	r.txSetAcquireMu.Lock()
+	if state, ok := r.txSetAcquire[txSetID]; ok {
+		state.done = true
+		state.dormant = true
+		state.completed = false
 	}
 	r.txSetAcquireMu.Unlock()
 }
@@ -595,11 +606,10 @@ func (r *Router) fillTxSetFromLocalPool(txMap *shamap.SHAMap, missing []shamap.M
 // immediately duplicating the wire request. An arriving data reply still resumes
 // from the retained partial map without waiting out the TTL.
 // haveRoot is preserved — a revived acquire keeps any root it already had. A
-// terminal non-dormant acquire (a set already completed and fed to the engine,
-// or a stuck/inconsistent map) is left latched: reviving the former is a
-// redundant re-feed the engine dedups, and the latter would only re-stick. Only
-// a dormant acquire is revived, mirroring rippled's stillNeed clearing failed_
-// but never complete_.
+// A completed acquire remains latched. Failed and retry-exhausted acquisitions
+// are revived, mirroring rippled's stillNeed clearing failed_ but never
+// complete_. The timeout count is clamped to the normal-retry threshold rather
+// than reset, matching TransactionAcquire::stillNeed.
 func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
 	r.txSetAcquireMu.Lock()
 	defer r.txSetAcquireMu.Unlock()
@@ -616,12 +626,12 @@ func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
 		return
 	}
 	state.lastUpdate = now
-	if state.done && !state.dormant {
+	if state.done && state.completed {
 		return
 	}
 	state.done = false
 	state.dormant = false
-	state.stallTicks = 0
+	state.stallTicks = min(state.stallTicks, r.txSetRetryKnobs.NormalTimeouts)
 	state.attempts = 0
 	state.lastRequest = now
 }
@@ -646,7 +656,7 @@ func (r *Router) sweepStaleTxSetAcquireLocked() {
 // the remaining nodes, so the acquisition would stall until the 60s TTL sweep;
 // under load that drops the node into wrongLedger and the mixed network below
 // quorum. This timer is the missing driver. Each firing on a stalled acquire
-// is a consecutive no-progress tick (stallTicks); past MaxStallTicks the
+// is a no-progress tick (stallTicks); past MaxStallTicks the
 // acquire goes dormant, RETAINING its partial map rather than deleting it, so
 // a later MarkTxSetStillNeeded / progressing reply can resume it. Because the
 // inbound path keeps lastRequest fresh while making progress, the MinInterval
@@ -715,15 +725,18 @@ func (r *Router) retryStalledTxSetAcquires() {
 			// fallback for a silent peer) with the same stall accounting as any
 			// stalled re-trigger.
 			state.stallTicks++
-			if state.stallTicks >= knobs.MaxStallTicks {
+			state.timedOut = true
+			if state.stallTicks > knobs.MaxStallTicks {
 				state.dormant = true
 				state.done = true
 				drops = append(drops, txSetDrop{id: id, attempts: state.attempts, missing: 0})
 				continue
 			}
+			if state.stallTicks < knobs.NormalTimeouts {
+				continue
+			}
 			state.attempts++
 			state.lastRequest = now
-			state.timedOut = true
 			rootKicks = append(rootKicks, id)
 			continue
 		}
@@ -731,8 +744,11 @@ func (r *Router) retryStalledTxSetAcquires() {
 		if len(missing) == 0 {
 			state.done = true
 			if err := state.txMap.FinishSync(); err == nil {
+				state.completed = true
 				completes = append(completes, txSetComplete{id: id, txMap: state.txMap})
 			} else {
+				state.dormant = true
+				state.completed = false
 				terminals = append(terminals, txSetTerminal{id: id, attempts: state.attempts, err: err})
 			}
 			continue
@@ -749,6 +765,7 @@ func (r *Router) retryStalledTxSetAcquires() {
 			finishErr = state.txMap.FinishSync()
 			if finishErr == nil {
 				state.done = true
+				state.completed = true
 				completes = append(completes, txSetComplete{id: id, txMap: state.txMap, filled: filled})
 				continue
 			}
@@ -756,16 +773,18 @@ func (r *Router) retryStalledTxSetAcquires() {
 		}
 		if len(missing) == 0 {
 			state.done = true
+			state.dormant = true
+			state.completed = false
 			terminals = append(terminals, txSetTerminal{id: id, attempts: state.attempts, err: finishErr})
 			continue
 		}
-		// A firing timer on a stalled acquire IS a consecutive no-progress
-		// tick — no inbound reply has reset stallTicks since the last one.
+		// A firing timer on a stalled acquire is a no-progress tick.
 		// Past MaxStallTicks the acquire goes dormant: it RETAINS its partial
 		// map (only the TTL sweep or an explicit resume reclaims it) instead
 		// of being deleted, so consensus re-asking picks up where it left off.
 		state.stallTicks++
-		if state.stallTicks >= knobs.MaxStallTicks {
+		state.timedOut = true
+		if state.stallTicks > knobs.MaxStallTicks {
 			// Give up: latch dormant AND done so stragglers are dropped, while
 			// KEEPING the partial map. Only MarkTxSetStillNeeded revives it; the
 			// TTL sweep reclaims it if it stays abandoned.
@@ -774,12 +793,11 @@ func (r *Router) retryStalledTxSetAcquires() {
 			drops = append(drops, txSetDrop{id: id, attempts: state.attempts, missing: len(missing)})
 			continue
 		}
+		if state.stallTicks < knobs.NormalTimeouts {
+			continue
+		}
 		state.attempts++
 		state.lastRequest = now
-		// The timer firing IS the stall signal: latch timedOut so this and
-		// every later request for the set escalates to an indirect (relayable)
-		// fetch, mirroring rippled's TransactionAcquire timeouts_ != 0 gate.
-		state.timedOut = true
 		excluded := buildExcludedPeers(state.peerNonProgress, knobs.PeerNonProgressThreshold)
 		nodeIDs := missingNodeIDs(missing)
 		kicks = append(kicks, txSetKick{id: id, nodeIDs: nodeIDs, excluded: excluded, attempts: state.attempts, missing: len(missing)})
@@ -855,7 +873,7 @@ func (r *Router) finalizeCompletedTxSet(txSetID consensus.TxSetID, txMap *shamap
 	}
 	// Latch done + KEEP the entry so stragglers are dropped rather than
 	// recreating a fresh empty acquire; the TTL sweep reclaims it.
-	r.markTxSetDone(txSetID)
+	r.markTxSetComplete(txSetID)
 	if len(blobs) == 0 {
 		return
 	}

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -37,7 +37,7 @@ type txSetAcquireState struct {
 	// (query_type=qtINDIRECT) so peers relay it on our behalf.
 	timedOut bool
 
-	// dormant latches once stallTicks reaches MaxStallTicks: the timer stops
+	// dormant latches once stallTicks exceeds MaxStallTicks: the timer stops
 	// actively re-requesting, but the partial SHAMap is RETAINED so a later
 	// MarkTxSetStillNeeded resumes the acquire from where it left off. The TTL
 	// sweep still reclaims a truly-abandoned entry.
@@ -54,11 +54,8 @@ type txSetAcquireState struct {
 	// set the acquire only requests the root and can never complete.
 	haveRoot bool
 
-	// done latches a terminal acquire: completed (set built and fed to the
-	// engine) or failed/given-up. A data reply for a
-	// done acquire is charged and dropped so a straggler can neither recreate
-	// a fresh empty map nor fan out re-requests; MarkTxSetStillNeeded clears it
-	// to revive a genuinely-needed set.
+	// done latches a terminal acquire. Straggling data is charged and dropped;
+	// only recoverable failures can be revived.
 	done bool
 }
 
@@ -599,17 +596,8 @@ func (r *Router) fillTxSetFromLocalPool(txMap *shamap.SHAMap, missing []shamap.M
 	return filled
 }
 
-// MarkTxSetStillNeeded records request intent before Adaptor.RequestTxSet emits
-// TMGetLedger. A new intent has no SHAMap until its first valid reply. A DORMANT
-// (retry-exhausted but still viable) acquire wakes: the consecutive-no-progress
-// counter resets and the initial request timestamp keeps maintenance from
-// immediately duplicating the wire request. An arriving data reply still resumes
-// from the retained partial map without waiting out the TTL.
-// haveRoot is preserved — a revived acquire keeps any root it already had. A
-// A completed acquire remains latched. Failed and retry-exhausted acquisitions
-// are revived, mirroring rippled's stillNeed clearing failed_ but never
-// complete_. The timeout count is clamped to the normal-retry threshold rather
-// than reset, matching TransactionAcquire::stillNeed.
+// MarkTxSetStillNeeded revives recoverable acquisitions while leaving completed
+// acquisitions latched. Timeout history is clamped rather than reset.
 func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
 	r.txSetAcquireMu.Lock()
 	defer r.txSetAcquireMu.Unlock()
@@ -778,7 +766,6 @@ func (r *Router) retryStalledTxSetAcquires() {
 			terminals = append(terminals, txSetTerminal{id: id, attempts: state.attempts, err: finishErr})
 			continue
 		}
-		// A firing timer on a stalled acquire is a no-progress tick.
 		// Past MaxStallTicks the acquire goes dormant: it RETAINS its partial
 		// map (only the TTL sweep or an explicit resume reclaims it) instead
 		// of being deleted, so consensus re-asking picks up where it left off.
@@ -859,9 +846,6 @@ func (r *Router) retryStalledTxSetAcquires() {
 	}
 }
 
-// finalizeCompletedTxSet feeds the engine a tx-set whose SHAMap the retry
-// timer found complete, mirroring the inbound completion path in
-// handleTxSetData. Runs on the Run() message-loop goroutine.
 func (r *Router) finalizeCompletedTxSet(txSetID consensus.TxSetID, txMap *shamap.SHAMap, filled int) {
 	blobs := make([][]byte, 0)
 	if err := txMap.ForEach(func(item *shamap.Item) bool {

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -52,9 +52,9 @@ type txSetAcquireState struct {
 
 	// done latches a terminal acquire: completed (set built and fed to the
 	// engine) or given-up (dormant past MaxStallTicks). A data reply for a
-	// done acquire is dropped so a straggler can neither recreate a fresh empty
-	// map nor fan out re-requests; MarkTxSetStillNeeded clears it to revive a
-	// genuinely-needed set.
+	// done acquire is charged and dropped so a straggler can neither recreate
+	// a fresh empty map nor fan out re-requests; MarkTxSetStillNeeded clears it
+	// to revive a genuinely-needed set.
 	done bool
 }
 
@@ -191,15 +191,44 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 	copy(txSetID[:], ld.LedgerHash)
 
 	r.txSetAcquireMu.Lock()
+	r.sweepStaleTxSetAcquireLocked()
 	state, exists := r.txSetAcquire[txSetID]
-	if exists && state.done {
-		// Terminal acquire (completed or given-up): drop the straggler so it
-		// can neither recreate a fresh empty map nor fan out re-requests. Only
-		// MarkTxSetStillNeeded revives a genuinely-needed set.
+	if !exists || state.done {
 		r.txSetAcquireMu.Unlock()
+		if originPeer != 0 {
+			r.adaptor.IncPeerBadData(originPeer, "txset-useless-unneeded")
+		}
 		return
 	}
-	if !exists {
+
+	if len(ld.Nodes) == 0 {
+		if originPeer != 0 {
+			state.peerNonProgress[originPeer]++
+		}
+		r.txSetAcquireMu.Unlock()
+		if originPeer != 0 {
+			r.adaptor.IncPeerBadData(originPeer, "txset-useless-nonprogress")
+		}
+		return
+	}
+	for _, node := range ld.Nodes {
+		if len(node.NodeID) == 0 || len(node.NodeData) == 0 {
+			r.txSetAcquireMu.Unlock()
+			if originPeer != 0 {
+				r.adaptor.IncPeerBadData(originPeer, "ledger-data-decode")
+			}
+			return
+		}
+		if _, err := shamap.ParseNodeID(node.NodeID); err != nil {
+			r.txSetAcquireMu.Unlock()
+			if originPeer != 0 {
+				r.adaptor.IncPeerBadData(originPeer, "txset-baddata-nodeid")
+			}
+			return
+		}
+	}
+
+	if state.txMap == nil {
 		txMap := shamap.New(shamap.TypeTransaction)
 		if err := txMap.StartSync(); err != nil {
 			r.txSetAcquireMu.Unlock()
@@ -209,94 +238,38 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 				"error", err.Error())
 			return
 		}
-		state = &txSetAcquireState{
-			txMap:           txMap,
-			startedAt:       time.Now(),
-			peerNonProgress: make(map[uint64]int),
-		}
-		r.txSetAcquire[txSetID] = state
+		state.txMap = txMap
 	}
-	state.lastUpdate = time.Now()
-	r.sweepStaleTxSetAcquireLocked()
 	txMap := state.txMap
 	haveRoot := state.haveRoot
 	r.txSetAcquireMu.Unlock()
 
-	// Root NodeID is 33 zero bytes. AddRootNode is idempotent
-	// (ErrRootAlreadySet treated as success). rootAccepted feeds
-	// per-peer progress accounting so a peer whose reply contains
-	// only the root still counts as making progress — any successful
-	// add (root or non-root) is useful.
+	// Process nodes in wire order. A bad root is tolerated and processing
+	// continues, while a bad non-root invalidates the reply immediately.
+	// This ordering lets a later valid root recover from an earlier bad root,
+	// but does not let a later root rescue a non-root that arrived before it.
 	rootAccepted := false
-	for _, node := range ld.Nodes {
-		if !isShamapRootNodeID(node.NodeID) {
-			continue
-		}
-		err := txMap.AddRootNode([32]byte(txSetID), node.NodeData)
-		switch {
-		case err == nil, errors.Is(err, shamap.ErrRootAlreadySet):
-			rootAccepted = true
-		default:
-			r.logger.Info("tx-set sync: AddRootNode failed",
-				"t", "consensus", "event", "txset-reject",
-				"txset", fmt.Sprintf("%x", txSetID[:8]),
-				"error", err.Error())
-		}
-		break
-	}
-	if rootAccepted && !haveRoot {
-		haveRoot = true
-		r.txSetAcquireMu.Lock()
-		state.haveRoot = true
-		r.txSetAcquireMu.Unlock()
-	}
-
-	// A hash-bound map with no root is not valid and must never complete.
-	// Until the root arrives, only request it — do NOT descend non-root nodes,
-	// FinishSync, complete, or delete. This reply did not deliver the root, so
-	// it made no progress: re-request the root from the replying peer (RTT-
-	// paced), but do NOT refresh lastRequest — that leaves the stall timer free
-	// to escalate the root fetch to a broadcast and, past MaxStallTicks, give up.
-	if !haveRoot {
-		r.txSetAcquireMu.Lock()
-		indirect := state.timedOut
-		r.txSetAcquireMu.Unlock()
-		if err := r.requestTxSetRoot(txSetID, originPeer, indirect); err != nil {
-			r.logger.Info("tx-set sync: root request failed",
-				"t", "consensus", "event", "txset-reject",
-				"txset", fmt.Sprintf("%x", txSetID[:8]),
-				"error", err.Error())
-		}
-		r.logger.Debug("tx-set sync: awaiting root before completion",
-			"t", "consensus", "event", "txset-await-root",
-			"txset", fmt.Sprintf("%x", txSetID[:8]))
-		return
-	}
-
-	// Use NodeID-based placement: path-based descent works when the
-	// peer's response contains nodes deeper than our currently-loaded
-	// layer of stubs. The previous hash-search approach
-	// (AddKnownNodeUnchecked) silently rejected every node it couldn't
-	// place beneath a loaded parent, producing the missing-nodes retry
-	// storm of issue #413.
-	//
-	// replyValid stays true unless any non-root node fails parse or
-	// AddKnownNodeByID. A provably-invalid non-root stops harvesting the
-	// rest of the reply (stop-on-first-bad) and flags the whole reply as
-	// non-progress, so a peer trickling junk alongside one good node can't
-	// keep its counter pinned at zero. Only a fresh attach (NodeUseful) is
-	// progress: a duplicate re-send of fat nodes must not keep the pipeline
-	// firing.
+	badRootProvided := false
 	added := 0
 	duplicates := 0
 	replyValid := true
 	for _, node := range ld.Nodes {
 		if isShamapRootNodeID(node.NodeID) {
+			err := txMap.AddRootNode([32]byte(txSetID), node.NodeData)
+			switch {
+			case err == nil, errors.Is(err, shamap.ErrRootAlreadySet):
+				rootAccepted = true
+				haveRoot = true
+			default:
+				badRootProvided = true
+				r.logger.Info("tx-set sync: AddRootNode failed",
+					"t", "consensus", "event", "txset-reject",
+					"txset", fmt.Sprintf("%x", txSetID[:8]),
+					"error", err.Error())
+			}
 			continue
 		}
-		if len(node.NodeData) == 0 {
-			continue
-		}
+
 		parsedID, err := shamap.ParseNodeID(node.NodeID)
 		if err != nil {
 			replyValid = false
@@ -305,12 +278,10 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 				"txset", fmt.Sprintf("%x", txSetID[:8]),
 				"node_id_len", len(node.NodeID),
 				"error", err.Error())
-			continue
+			break
 		}
 		res, err := txMap.AddKnownNodeByID(parsedID, node.NodeData)
 		if res == shamap.NodeReRequest {
-			// Ahead of its frontier: re-requested by the next getMissingNodes
-			// walk, not a poisoned reply.
 			continue
 		}
 		if res == shamap.NodeInvalid {
@@ -324,15 +295,71 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			break
 		}
 		if res == shamap.NodeDuplicate {
-			// Slot already populated: nothing added, so not fresh progress —
-			// but the node was valid. Track it so an all-duplicate reply isn't
-			// charged against the peer's non-progress counter below.
 			duplicates++
 			continue
 		}
 		added++
-		// Learn (submit + relay) the tx carried by this acquired leaf.
 		r.learnTxFromLeaf(originPeer, node.NodeData)
+	}
+
+	if haveRoot && !state.haveRoot {
+		r.txSetAcquireMu.Lock()
+		state.haveRoot = true
+		r.txSetAcquireMu.Unlock()
+	}
+
+	if !replyValid {
+		r.txSetAcquireMu.Lock()
+		if originPeer != 0 {
+			state.peerNonProgress[originPeer]++
+		}
+		r.txSetAcquireMu.Unlock()
+		if originPeer != 0 {
+			r.adaptor.IncPeerBadData(originPeer, "txset-useless-nonprogress")
+		}
+		if !haveRoot {
+			r.txSetAcquireMu.Lock()
+			indirect := state.timedOut
+			r.txSetAcquireMu.Unlock()
+			if err := r.requestTxSetRoot(txSetID, originPeer, indirect); err != nil {
+				r.logger.Info("tx-set sync: root request failed",
+					"t", "consensus", "event", "txset-reject",
+					"txset", fmt.Sprintf("%x", txSetID[:8]),
+					"error", err.Error())
+			}
+		}
+		return
+	}
+
+	if !haveRoot {
+		r.txSetAcquireMu.Lock()
+		if originPeer != 0 {
+			if badRootProvided {
+				state.peerNonProgress[originPeer] = 0
+			} else {
+				state.peerNonProgress[originPeer]++
+			}
+		}
+		if badRootProvided {
+			now := time.Now()
+			state.dormant = false
+			state.stallTicks = 0
+			state.attempts++
+			state.lastRequest = now
+			state.lastUpdate = now
+		}
+		indirect := state.timedOut
+		r.txSetAcquireMu.Unlock()
+		if originPeer != 0 && !badRootProvided {
+			r.adaptor.IncPeerBadData(originPeer, "txset-useless-nonprogress")
+		}
+		if err := r.requestTxSetRoot(txSetID, originPeer, indirect); err != nil {
+			r.logger.Info("tx-set sync: root request failed",
+				"t", "consensus", "event", "txset-reject",
+				"txset", fmt.Sprintf("%x", txSetID[:8]),
+				"error", err.Error())
+		}
+		return
 	}
 
 	if err := txMap.FinishSync(); err != nil {
@@ -380,27 +407,25 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 		}
 
 		if len(remaining) > 0 {
-			// A reply counts as progress only when it was non-empty AND
-			// every non-root node parsed and added cleanly. Any single bad
-			// non-root → invalid reply → not progress for the peer.
-			madeProgress := replyValid && (added > 0 || rootAccepted)
+			madeProgress := added > 0 || rootAccepted
+			validAllDuplicate := duplicates > 0 && added == 0 && !rootAccepted
 			r.txSetAcquireMu.Lock()
 			// Knobs are read under txSetAcquireMu so a concurrent
 			// SetTxSetRetryKnobsForTest (test-only API) can't tear a
 			// half-updated struct into the hot path.
 			knobs := r.txSetRetryKnobs
-			if !madeProgress {
+			if !madeProgress && !validAllDuplicate {
 				// No fresh attach: do NOT re-request inline — that would let a
 				// junk/empty-reply peer amplify into a broadcast storm; let the
 				// 250ms stall timer drive it. Charge the peer's non-progress
-				// counter EXCEPT on a valid all-duplicate reply, where the peer
-				// is cooperating but resending nodes we already hold — penalising
-				// it would wrongly exclude a useful peer.
-				validAllDuplicate := replyValid && duplicates > 0 && added == 0 && !rootAccepted
-				if originPeer != 0 && !validAllDuplicate {
+				// counter.
+				if originPeer != 0 {
 					state.peerNonProgress[originPeer]++
 				}
 				r.txSetAcquireMu.Unlock()
+				if originPeer != 0 {
+					r.adaptor.IncPeerBadData(originPeer, "txset-useless-nonprogress")
+				}
 				r.logger.Debug("tx-set sync: no-progress reply, deferring to timer",
 					"t", "consensus", "event", "txset-retry-defer",
 					"txset", fmt.Sprintf("%x", txSetID[:8]),
@@ -408,7 +433,9 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 				)
 				return
 			}
-			// Progress: pipeline the next missing-nodes request IMMEDIATELY.
+			// Useful reply: pipeline the next missing-nodes request
+			// IMMEDIATELY. A valid duplicate is useful even though it does not
+			// attach a fresh node.
 			// The RTT itself rate-limits (one re-request per received reply),
 			// so there is no storm and no MinInterval gate is needed. A fresh
 			// lastRequest keeps the stall timer out of an actively-progressing
@@ -421,6 +448,7 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			state.stallTicks = 0
 			state.attempts++
 			state.lastRequest = time.Now()
+			state.lastUpdate = state.lastRequest
 			excluded := buildExcludedPeers(state.peerNonProgress, knobs.PeerNonProgressThreshold)
 			attempts := state.attempts
 			indirect := state.timedOut
@@ -560,24 +588,34 @@ func (r *Router) fillTxSetFromLocalPool(txMap *shamap.SHAMap, missing []shamap.M
 	return filled
 }
 
-// MarkTxSetStillNeeded is the active re-arm hook fired every time consensus
-// re-asks for a tx-set via Adaptor.RequestTxSet. A DORMANT (retry-exhausted but
-// still viable) acquire wakes: the consecutive-no-progress counter resets and
-// the request-spacing latch is dropped so the next timer tick or data reply
-// resumes from the retained partial map instead of waiting out the TTL.
+// MarkTxSetStillNeeded records request intent before Adaptor.RequestTxSet emits
+// TMGetLedger. A new intent has no SHAMap until its first valid reply. A DORMANT
+// (retry-exhausted but still viable) acquire wakes: the consecutive-no-progress
+// counter resets and the initial request timestamp keeps maintenance from
+// immediately duplicating the wire request. An arriving data reply still resumes
+// from the retained partial map without waiting out the TTL.
 // haveRoot is preserved — a revived acquire keeps any root it already had. A
 // terminal non-dormant acquire (a set already completed and fed to the engine,
 // or a stuck/inconsistent map) is left latched: reviving the former is a
 // redundant re-feed the engine dedups, and the latter would only re-stick. Only
 // a dormant acquire is revived, mirroring rippled's stillNeed clearing failed_
-// but never complete_. A no-op if the router has no entry for txSetID.
+// but never complete_.
 func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
 	r.txSetAcquireMu.Lock()
 	defer r.txSetAcquireMu.Unlock()
+	r.sweepStaleTxSetAcquireLocked()
+	now := time.Now()
 	state, ok := r.txSetAcquire[txSetID]
 	if !ok {
+		r.txSetAcquire[txSetID] = &txSetAcquireState{
+			startedAt:       now,
+			lastUpdate:      now,
+			lastRequest:     now,
+			peerNonProgress: make(map[uint64]int),
+		}
 		return
 	}
+	state.lastUpdate = now
 	if state.done && !state.dormant {
 		return
 	}
@@ -585,7 +623,7 @@ func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
 	state.dormant = false
 	state.stallTicks = 0
 	state.attempts = 0
-	state.lastRequest = time.Time{}
+	state.lastRequest = now
 }
 
 // sweepStaleTxSetAcquireLocked drops entries older than txSetAcquireTTL.
@@ -641,15 +679,24 @@ func (r *Router) retryStalledTxSetAcquires() {
 		txMap  *shamap.SHAMap
 		filled int
 	}
+	type txSetTerminal struct {
+		id       consensus.TxSetID
+		attempts int
+		err      error
+	}
 	var kicks []txSetKick
 	var drops []txSetDrop
 	var completes []txSetComplete
+	var terminals []txSetTerminal
 	var rootKicks []consensus.TxSetID
 
 	r.txSetAcquireMu.Lock()
 	r.sweepStaleTxSetAcquireLocked()
 	knobs := r.txSetRetryKnobs
 	for id, state := range r.txSetAcquire {
+		if state.done {
+			continue
+		}
 		// Only re-trigger once the inbound path has been quiet for a full
 		// cadence window. An actively progressing acquire keeps
 		// lastRequest fresh and is skipped here.
@@ -682,8 +729,12 @@ func (r *Router) retryStalledTxSetAcquires() {
 		}
 		missing := state.txMap.GetMissingNodes(256, nil)
 		if len(missing) == 0 {
-			// Tree is complete; the next inbound TMLedgerData (or a prior
-			// completion path) finalises it. Nothing to request.
+			state.done = true
+			if err := state.txMap.FinishSync(); err == nil {
+				completes = append(completes, txSetComplete{id: id, txMap: state.txMap})
+			} else {
+				terminals = append(terminals, txSetTerminal{id: id, attempts: state.attempts, err: err})
+			}
 			continue
 		}
 		// Before re-requesting from peers, source any still-missing tx-leaf
@@ -693,15 +744,19 @@ func (r *Router) retryStalledTxSetAcquires() {
 		// local pool read and txMap is owned by this (Run) goroutine, so the
 		// fill is safe under txSetAcquireMu.
 		filled := r.fillTxSetFromLocalPool(state.txMap, missing)
+		var finishErr error
 		if filled > 0 {
-			_ = state.txMap.FinishSync()
+			finishErr = state.txMap.FinishSync()
+			if finishErr == nil {
+				state.done = true
+				completes = append(completes, txSetComplete{id: id, txMap: state.txMap, filled: filled})
+				continue
+			}
 			missing = state.txMap.GetMissingNodes(256, nil)
 		}
 		if len(missing) == 0 {
-			// Completed from the local pool. Feed the engine just like the
-			// inbound completion path — peers are silent, so nothing else
-			// will. Finalised after the lock is released.
-			completes = append(completes, txSetComplete{id: id, txMap: state.txMap, filled: filled})
+			state.done = true
+			terminals = append(terminals, txSetTerminal{id: id, attempts: state.attempts, err: finishErr})
 			continue
 		}
 		// A firing timer on a stalled acquire IS a consecutive no-progress
@@ -732,7 +787,15 @@ func (r *Router) retryStalledTxSetAcquires() {
 	r.txSetAcquireMu.Unlock()
 
 	for _, c := range completes {
-		r.finalizeLocalFilledTxSet(c.id, c.txMap, c.filled)
+		r.finalizeCompletedTxSet(c.id, c.txMap, c.filled)
+	}
+	for _, terminal := range terminals {
+		r.logger.Info("tx-set sync: terminal invalid map",
+			"t", "consensus", "event", "txset-reject",
+			"txset", fmt.Sprintf("%x", terminal.id[:8]),
+			"attempts", terminal.attempts,
+			"error", terminal.err,
+		)
 	}
 	for _, d := range drops {
 		// Dormant + done, not deleted: the partial map is retained so a later
@@ -778,12 +841,10 @@ func (r *Router) retryStalledTxSetAcquires() {
 	}
 }
 
-// finalizeLocalFilledTxSet feeds the engine a tx-set whose SHAMap the retry
-// timer completed from the local pending pool, mirroring the inbound completion
-// path in handleTxSetData. Runs on the Run() message-loop goroutine. The engine
-// re-checks the tx-set ID, so a stale or duplicate set is rejected with a log
-// rather than corrupting state.
-func (r *Router) finalizeLocalFilledTxSet(txSetID consensus.TxSetID, txMap *shamap.SHAMap, filled int) {
+// finalizeCompletedTxSet feeds the engine a tx-set whose SHAMap the retry
+// timer found complete, mirroring the inbound completion path in
+// handleTxSetData. Runs on the Run() message-loop goroutine.
+func (r *Router) finalizeCompletedTxSet(txSetID consensus.TxSetID, txMap *shamap.SHAMap, filled int) {
 	blobs := make([][]byte, 0)
 	if err := txMap.ForEach(func(item *shamap.Item) bool {
 		blobs = append(blobs, item.Data())
@@ -798,8 +859,8 @@ func (r *Router) finalizeLocalFilledTxSet(txSetID consensus.TxSetID, txMap *sham
 	if len(blobs) == 0 {
 		return
 	}
-	r.logger.Info("tx-set sync: completed via local pool (timer)",
-		"t", "consensus", "event", "txset-local-fill",
+	r.logger.Info("tx-set sync: completed on retry",
+		"t", "consensus", "event", "txset-complete",
 		"txset", fmt.Sprintf("%x", txSetID[:8]),
 		"filled", filled,
 		"tx_count", len(blobs))

--- a/internal/consensus/adaptor/router_txset_ingress_test.go
+++ b/internal/consensus/adaptor/router_txset_ingress_test.go
@@ -1,0 +1,333 @@
+package adaptor
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type chargedRetrySender struct {
+	retryRecordingSender
+	badDataMu    sync.Mutex
+	badDataCalls []badDataCall
+}
+
+func (s *chargedRetrySender) IncPeerBadData(peerID uint64, reason string) {
+	s.badDataMu.Lock()
+	defer s.badDataMu.Unlock()
+	s.badDataCalls = append(s.badDataCalls, badDataCall{peerID: peerID, reason: reason})
+}
+
+func (s *chargedRetrySender) getBadDataCalls() []badDataCall {
+	s.badDataMu.Lock()
+	defer s.badDataMu.Unlock()
+	return append([]badDataCall(nil), s.badDataCalls...)
+}
+
+func newTxSetIngressRouter(t *testing.T) (*Router, *badDataRecordingSender, *mockEngine) {
+	t.Helper()
+	sender := &badDataRecordingSender{}
+	a := New(Config{
+		LedgerService: newTestLedgerService(t),
+		Sender:        sender,
+	})
+	engine := &mockEngine{}
+	return NewRouter(engine, a, make(chan *peermanagement.InboundMessage, 1)), sender, engine
+}
+
+func deliverTxSetData(t *testing.T, r *Router, peerID uint64, data *message.LedgerData) {
+	t.Helper()
+	r.handleLedgerData(&peermanagement.InboundMessage{
+		PeerID:  peermanagement.PeerID(peerID),
+		Type:    uint16(message.TypeLedgerData),
+		Payload: encodePayload(t, data),
+	})
+}
+
+func TestTxSetIngress_RequestRecordedBeforeNetworkSend(t *testing.T) {
+	var router *Router
+	var observed bool
+	sender := &requestObservationSender{
+		observe: func(id consensus.TxSetID) {
+			router.txSetAcquireMu.Lock()
+			defer router.txSetAcquireMu.Unlock()
+			state, ok := router.txSetAcquire[id]
+			observed = ok && state.txMap == nil && !state.done
+		},
+	}
+	a := New(Config{
+		LedgerService: newTestLedgerService(t),
+		Sender:        sender,
+	})
+	router = NewRouter(&mockEngine{}, a, make(chan *peermanagement.InboundMessage, 1))
+	id := consensus.TxSetID{0x91}
+
+	require.NoError(t, a.RequestTxSet(id))
+	require.True(t, observed, "request intent must exist before TMGetLedger is emitted")
+	require.Equal(t, 1, sender.calls)
+}
+
+func TestTxSetIngress_ZeroSetAvailableWithoutNetworkRequest(t *testing.T) {
+	sender := &requestObservationSender{}
+	a := New(Config{Sender: sender})
+
+	local, err := a.BuildTxSet([][]byte{makeBlob(0x51)})
+	require.NoError(t, err)
+	require.NotEqual(t, consensus.TxSetID{}, local.ID(),
+		"fixture represents our non-empty consensus position")
+
+	peerSet, err := a.GetTxSet(consensus.TxSetID{})
+	require.NoError(t, err)
+	require.NotNil(t, peerSet)
+	require.Zero(t, peerSet.Size(), "a peer's zero position is the canonical empty set")
+
+	require.NoError(t, a.RequestTxSet(consensus.TxSetID{}))
+	require.Zero(t, sender.calls, "the canonical zero set must never start network acquisition")
+}
+
+type requestObservationSender struct {
+	noopSender
+	observe func(consensus.TxSetID)
+	calls   int
+}
+
+func (s *requestObservationSender) RequestTxSet(id consensus.TxSetID) error {
+	s.calls++
+	s.observe(id)
+	return nil
+}
+
+func TestTxSetIngress_RejectsUnsolicitedCompleteAndPartialData(t *testing.T) {
+	router, sender, engine := newTxSetIngressRouter(t)
+
+	_, completeID, completeNodes := buildTxSetForTest(t, 4)
+	deliverTxSetData(t, router, 11, ldFromWire(completeID, completeNodes))
+
+	_, partialID, partialNodes := buildTxSetForTest(t, 8)
+	require.Greater(t, len(partialNodes), 1)
+	deliverTxSetData(t, router, 12, ldFromWire(partialID, partialNodes[:1]))
+
+	assert.Equal(t, []badDataCall{
+		{peerID: 11, reason: "txset-useless-unneeded"},
+		{peerID: 12, reason: "txset-useless-unneeded"},
+	}, sender.getBadDataCalls())
+
+	router.txSetAcquireMu.Lock()
+	_, completeAllocated := router.txSetAcquire[consensus.TxSetID(completeID)]
+	_, partialAllocated := router.txSetAcquire[consensus.TxSetID(partialID)]
+	router.txSetAcquireMu.Unlock()
+	assert.False(t, completeAllocated)
+	assert.False(t, partialAllocated)
+
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	assert.Empty(t, engine.txSets, "unsolicited data must not reach Engine.OnTxSet")
+}
+
+func TestTxSetIngress_ChargesMalformedInvalidAndNonProgressData(t *testing.T) {
+	tests := []struct {
+		name   string
+		nodes  []message.LedgerNode
+		reason string
+	}{
+		{
+			name:   "missing node data",
+			nodes:  []message.LedgerNode{{NodeID: make([]byte, shamap.NodeIDSize)}},
+			reason: "ledger-data-decode",
+		},
+		{
+			name:   "invalid node id",
+			nodes:  []message.LedgerNode{{NodeID: []byte{1}, NodeData: []byte{1}}},
+			reason: "txset-baddata-nodeid",
+		},
+		{
+			name:   "empty reply",
+			reason: "ledger-data-count",
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			router, sender, engine := newTxSetIngressRouter(t)
+			id := consensus.TxSetID{byte(i + 1), 0xa5}
+			router.MarkTxSetStillNeeded(id)
+
+			deliverTxSetData(t, router, 20+uint64(i), &message.LedgerData{
+				LedgerHash: id[:],
+				InfoType:   message.LedgerInfoTsCandidate,
+				Nodes:      test.nodes,
+			})
+
+			assert.Equal(t, []badDataCall{{
+				peerID: 20 + uint64(i),
+				reason: test.reason,
+			}}, sender.getBadDataCalls())
+			router.txSetAcquireMu.Lock()
+			state := router.txSetAcquire[id]
+			router.txSetAcquireMu.Unlock()
+			require.NotNil(t, state)
+			assert.Nil(t, state.txMap, "rejected framing must not allocate a SHAMap")
+			engine.mu.Lock()
+			assert.Empty(t, engine.txSets)
+			engine.mu.Unlock()
+		})
+	}
+}
+
+func TestTxSetIngress_ChargesInvalidSHAMapReply(t *testing.T) {
+	router, sender, engine := newTxSetIngressRouter(t)
+	_, rawID, wireNodes := buildTxSetForTest(t, 4)
+	require.Greater(t, len(wireNodes), 1)
+	id := consensus.TxSetID(rawID)
+	router.MarkTxSetStillNeeded(id)
+
+	deliverTxSetData(t, router, 31, &message.LedgerData{
+		LedgerHash: id[:],
+		InfoType:   message.LedgerInfoTsCandidate,
+		Nodes: []message.LedgerNode{
+			{NodeID: wireNodes[0].NodeID, NodeData: wireNodes[0].Data},
+			{NodeID: wireNodes[1].NodeID, NodeData: []byte{0xde, 0xad}},
+		},
+	})
+
+	assert.Equal(t, []badDataCall{{
+		peerID: 31,
+		reason: "txset-useless-nonprogress",
+	}}, sender.getBadDataCalls())
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	assert.Empty(t, engine.txSets)
+}
+
+func TestTxSetIngress_ChargesPostCompletionStraggler(t *testing.T) {
+	router, sender, engine := newTxSetIngressRouter(t)
+	_, rawID, wireNodes := buildTxSetForTest(t, 4)
+	id := consensus.TxSetID(rawID)
+	router.MarkTxSetStillNeeded(id)
+	complete := ldFromWire(rawID, wireNodes)
+
+	deliverTxSetData(t, router, 40, complete)
+	engine.mu.Lock()
+	require.Len(t, engine.txSets, 1)
+	engine.mu.Unlock()
+	require.Empty(t, sender.getBadDataCalls())
+
+	deliverTxSetData(t, router, 41, complete)
+
+	assert.Equal(t, []badDataCall{{
+		peerID: 41,
+		reason: "txset-useless-unneeded",
+	}}, sender.getBadDataCalls())
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	assert.Len(t, engine.txSets, 1, "a straggler must not re-feed Engine.OnTxSet")
+}
+
+func TestTxSetIngress_BadRootReRequestsWithoutPenalty(t *testing.T) {
+	sender := &chargedRetrySender{}
+	a := New(Config{
+		LedgerService: newTestLedgerService(t),
+		Sender:        sender,
+	})
+	router := NewRouter(&mockEngine{}, a, make(chan *peermanagement.InboundMessage, 1))
+	id := consensus.TxSetID{0x61}
+	router.MarkTxSetStillNeeded(id)
+
+	withRetryKnobs(router, time.Hour, 20, 1, func() {
+		router.handleTxSetData(&message.LedgerData{
+			LedgerHash: id[:],
+			InfoType:   message.LedgerInfoTsCandidate,
+			Nodes: []message.LedgerNode{{
+				NodeID:   make([]byte, shamap.NodeIDSize),
+				NodeData: []byte{0xde, 0xad},
+			}},
+		}, 62)
+	})
+
+	assert.Empty(t, sender.getBadDataCalls(), "rippled treats bad root data as useful")
+	require.Equal(t, 1, sender.calledN(), "bad root data must trigger another root request")
+	assert.Equal(t, uint64(62), sender.lastCall().peerID)
+	require.Len(t, sender.lastCall().nodeIDs, 1)
+	assert.True(t, isShamapRootNodeID(sender.lastCall().nodeIDs[0]))
+
+	router.txSetAcquireMu.Lock()
+	defer router.txSetAcquireMu.Unlock()
+	state := router.txSetAcquire[id]
+	require.NotNil(t, state)
+	assert.Zero(t, state.peerNonProgress[62], "bad root must not deprioritize its peer")
+	assert.Zero(t, state.stallTicks, "a useful reply resets consecutive stall accounting")
+	assert.False(t, state.haveRoot)
+}
+
+func TestTxSetIngress_BadRootThenValidRootContinues(t *testing.T) {
+	sender := &chargedRetrySender{}
+	a := New(Config{
+		LedgerService: newTestLedgerService(t),
+		Sender:        sender,
+	})
+	engine := &mockEngine{}
+	router := NewRouter(engine, a, make(chan *peermanagement.InboundMessage, 1))
+	_, rawID, wireNodes := buildTxSetForTest(t, 8)
+	id := consensus.TxSetID(rawID)
+	router.MarkTxSetStillNeeded(id)
+
+	reply := ldFromWire(rawID, wireNodes)
+	reply.Nodes = append([]message.LedgerNode{{
+		NodeID:   make([]byte, shamap.NodeIDSize),
+		NodeData: []byte{0xde, 0xad},
+	}}, reply.Nodes...)
+	router.handleTxSetData(reply, 63)
+
+	assert.Empty(t, sender.getBadDataCalls())
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	require.Equal(t, []consensus.TxSetID{id}, engine.txSets,
+		"a valid root later in the reply must recover from an earlier bad root")
+}
+
+func TestTxSetIngress_BadRootThenNonRootIsInvalid(t *testing.T) {
+	sender := &chargedRetrySender{}
+	a := New(Config{
+		LedgerService: newTestLedgerService(t),
+		Sender:        sender,
+	})
+	engine := &mockEngine{}
+	router := NewRouter(engine, a, make(chan *peermanagement.InboundMessage, 1))
+	_, rawID, wireNodes := buildTxSetForTest(t, 8)
+	require.Greater(t, len(wireNodes), 1)
+	id := consensus.TxSetID(rawID)
+	router.MarkTxSetStillNeeded(id)
+
+	router.handleTxSetData(&message.LedgerData{
+		LedgerHash: id[:],
+		InfoType:   message.LedgerInfoTsCandidate,
+		Nodes: []message.LedgerNode{
+			{NodeID: make([]byte, shamap.NodeIDSize), NodeData: []byte{0xde, 0xad}},
+			{NodeID: wireNodes[1].NodeID, NodeData: wireNodes[1].Data},
+		},
+	}, 64)
+
+	require.Equal(t, []badDataCall{{
+		peerID: 64,
+		reason: "txset-useless-nonprogress",
+	}}, sender.getBadDataCalls())
+	require.Equal(t, 1, sender.calledN(), "the invalid rootless reply still re-requests the root")
+	assert.True(t, isShamapRootNodeID(sender.lastCall().nodeIDs[0]))
+
+	router.txSetAcquireMu.Lock()
+	state := router.txSetAcquire[id]
+	router.txSetAcquireMu.Unlock()
+	require.NotNil(t, state)
+	assert.False(t, state.haveRoot)
+	assert.Equal(t, 1, state.peerNonProgress[64])
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	assert.Empty(t, engine.txSets)
+}

--- a/internal/consensus/adaptor/router_txset_learn_test.go
+++ b/internal/consensus/adaptor/router_txset_learn_test.go
@@ -72,6 +72,7 @@ func TestRouter_TxSetAcquire_LearnsTransaction(t *testing.T) {
 		InfoType:   message.LedgerInfoTsCandidate,
 		Nodes:      ldNodes,
 	}
+	router.MarkTxSetStillNeeded(consensus.TxSetID(setID))
 	inbox <- &peermanagement.InboundMessage{
 		PeerID:  5,
 		Type:    uint16(message.TypeLedgerData),

--- a/internal/consensus/adaptor/router_txset_pipeline_test.go
+++ b/internal/consensus/adaptor/router_txset_pipeline_test.go
@@ -204,7 +204,8 @@ func TestTxSetAcquire_PipelinesOnProgressAtRTT(t *testing.T) {
 }
 
 // TestTxSetAcquire_DormantRetainsMapAndResumes pins property (d): after
-// MaxStallTicks consecutive no-progress timer ticks the acquire goes dormant
+// MaxStallTicks no-progress timer ticks the acquire goes dormant on the next
+// tick
 // but its partial map is RETAINED (not deleted), and a subsequent
 // MarkTxSetStillNeeded + progressing reply resumes it from that partial map.
 // Mirrors rippled keeping mMap across retries and stillNeed() re-arming.
@@ -220,9 +221,9 @@ func TestTxSetAcquire_DormantRetainsMapAndResumes(t *testing.T) {
 		router.handleTxSetData(ld, 1)
 		require.Equal(t, 1, rs.calledN())
 
-		// No inbound progress arrives; consecutive timer ticks accrue stall
-		// ticks until the acquire goes dormant at MaxStallTicks.
-		for range maxStall {
+		// No inbound progress arrives; timer ticks accrue until the acquire
+		// exceeds MaxStallTicks and goes dormant.
+		for range maxStall + 1 {
 			router.retryStalledTxSetAcquires()
 		}
 
@@ -236,7 +237,7 @@ func TestTxSetAcquire_DormantRetainsMapAndResumes(t *testing.T) {
 		}
 		router.txSetAcquireMu.Unlock()
 		require.True(t, tracked, "dormant acquire must be RETAINED, not deleted")
-		require.True(t, dormant, "acquire must be dormant after MaxStallTicks consecutive stall ticks")
+		require.True(t, dormant, "acquire must be dormant after exceeding MaxStallTicks")
 		require.True(t, resumable, "the partial SHAMap must be retained for resume")
 
 		// While dormant, further timer ticks must not re-request.
@@ -262,6 +263,7 @@ func TestTxSetAcquire_DormantRetainsMapAndResumes(t *testing.T) {
 		router.txSetAcquireMu.Unlock()
 		require.True(t, tracked)
 		require.False(t, stillDormant, "resuming must clear the dormant latch")
-		require.Equal(t, 0, stall, "resuming must reset the stall counter")
+		require.Equal(t, router.txSetRetryKnobs.NormalTimeouts, stall,
+			"resuming must clamp the timeout history to the normal retry threshold")
 	})
 }

--- a/internal/consensus/adaptor/router_txset_pipeline_test.go
+++ b/internal/consensus/adaptor/router_txset_pipeline_test.go
@@ -203,12 +203,6 @@ func TestTxSetAcquire_PipelinesOnProgressAtRTT(t *testing.T) {
 	})
 }
 
-// TestTxSetAcquire_DormantRetainsMapAndResumes pins property (d): after
-// MaxStallTicks no-progress timer ticks the acquire goes dormant on the next
-// tick
-// but its partial map is RETAINED (not deleted), and a subsequent
-// MarkTxSetStillNeeded + progressing reply resumes it from that partial map.
-// Mirrors rippled keeping mMap across retries and stillNeed() re-arming.
 func TestTxSetAcquire_DormantRetainsMapAndResumes(t *testing.T) {
 	router, rs, _ := newPipelineRouter(t)
 	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
@@ -216,13 +210,9 @@ func TestTxSetAcquire_DormantRetainsMapAndResumes(t *testing.T) {
 
 	const maxStall = 3
 	withRetryKnobs(router, 0, maxStall, 1_000_000, func() {
-		// Progress reply creates the acquire (root only → incomplete) and
-		// pipelines one request.
 		router.handleTxSetData(ld, 1)
 		require.Equal(t, 1, rs.calledN())
 
-		// No inbound progress arrives; timer ticks accrue until the acquire
-		// exceeds MaxStallTicks and goes dormant.
 		for range maxStall + 1 {
 			router.retryStalledTxSetAcquires()
 		}
@@ -232,7 +222,6 @@ func TestTxSetAcquire_DormantRetainsMapAndResumes(t *testing.T) {
 		var dormant, resumable bool
 		if tracked {
 			dormant = state.dormant
-			// Root present, children still missing → a resumable partial map.
 			resumable = len(state.txMap.GetMissingNodes(256, nil)) > 0
 		}
 		router.txSetAcquireMu.Unlock()
@@ -240,14 +229,10 @@ func TestTxSetAcquire_DormantRetainsMapAndResumes(t *testing.T) {
 		require.True(t, dormant, "acquire must be dormant after exceeding MaxStallTicks")
 		require.True(t, resumable, "the partial SHAMap must be retained for resume")
 
-		// While dormant, further timer ticks must not re-request.
 		nAtDormant := rs.calledN()
 		router.retryStalledTxSetAcquires()
 		require.Equal(t, nAtDormant, rs.calledN(), "a dormant acquire must not re-request")
 
-		// Re-arm: consensus re-asks (MarkTxSetStillNeeded) AND a progressing
-		// reply arrives. Together they must wake the acquire and resume
-		// pipelining from the retained partial map.
 		router.MarkTxSetStillNeeded(txSetID)
 		router.handleTxSetData(ld, 1)
 		require.Greater(t, rs.calledN(), nAtDormant,

--- a/internal/consensus/adaptor/router_txset_pipeline_test.go
+++ b/internal/consensus/adaptor/router_txset_pipeline_test.go
@@ -135,6 +135,7 @@ func TestTxSetAcquire_PipelinesOnProgressAtRTT(t *testing.T) {
 	// replies. MaxStallTicks is small so any regression to timer-driven
 	// give-up would surface as a premature dormancy.
 	withRetryKnobs(router, time.Hour, 3, 1_000_000, func() {
+		router.MarkTxSetStillNeeded(txSetID)
 		// Batch 0: the root. A progressing root reply pipelines exactly one
 		// missing-nodes request immediately.
 		rootID := make([]byte, 33)
@@ -210,6 +211,7 @@ func TestTxSetAcquire_PipelinesOnProgressAtRTT(t *testing.T) {
 func TestTxSetAcquire_DormantRetainsMapAndResumes(t *testing.T) {
 	router, rs, _ := newPipelineRouter(t)
 	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
+	router.MarkTxSetStillNeeded(txSetID)
 
 	const maxStall = 3
 	withRetryKnobs(router, 0, maxStall, 1_000_000, func() {

--- a/internal/consensus/adaptor/router_txset_retry_test.go
+++ b/internal/consensus/adaptor/router_txset_retry_test.go
@@ -150,6 +150,7 @@ func withRetryKnobs(router *Router, minInterval time.Duration, maxStallTicks, pe
 	prev := router.txSetRetryKnobs
 	router.SetTxSetRetryKnobsForTest(txSetRetryKnobs{
 		MinInterval:              minInterval,
+		NormalTimeouts:           1,
 		MaxStallTicks:            maxStallTicks,
 		PeerNonProgressThreshold: peerThreshold,
 	})
@@ -183,9 +184,8 @@ func TestTxSetRetry_NoProgressReplyDefersToTimer(t *testing.T) {
 
 // TestTxSetRetry_InboundProgressNeverGivesUp pins that the inbound path
 // has NO give-up cap: give-up now lives solely on the stall timer, keyed
-// on consecutive no-progress ticks. Many progressing replies in a row each
-// pipeline a fresh request and never delete the acquire nor accrue stall
-// ticks — the pre-pipelining inbound MaxAttempts delete-on-cap is gone.
+// on timer ticks. Many progressing replies in a row each pipeline a fresh
+// request and never delete the acquire or erase accumulated timeout history.
 func TestTxSetRetry_InboundProgressNeverGivesUp(t *testing.T) {
 	router, rs := newRetryRouter(t)
 	// MaxStallTicks deliberately small: if the inbound path fed stall
@@ -193,6 +193,7 @@ func TestTxSetRetry_InboundProgressNeverGivesUp(t *testing.T) {
 	withRetryKnobs(router, 0, 3, 1_000_000, func() {
 		ld, txSetID := rootOnlyTxSetLedgerData(t, 4)
 		router.MarkTxSetStillNeeded(txSetID)
+		router.txSetAcquire[txSetID].stallTicks = 2
 
 		const replies = 25
 		for i := range replies {
@@ -209,7 +210,7 @@ func TestTxSetRetry_InboundProgressNeverGivesUp(t *testing.T) {
 		}
 		router.txSetAcquireMu.Unlock()
 		require.True(t, tracked, "a progressing acquire is never deleted by the inbound path")
-		assert.Equal(t, 0, stall, "progressing replies keep stallTicks pinned at 0")
+		assert.Equal(t, 2, stall, "progressing replies preserve accumulated timeout history")
 		assert.False(t, dormant, "a progressing acquire never goes dormant")
 	})
 }
@@ -373,7 +374,7 @@ func TestTxSetRetry_StillNeededReArmsDormantAcquire(t *testing.T) {
 		require.Equal(t, 1, rs.calledN())
 
 		// Drive consecutive no-progress timer ticks to dormancy.
-		for range maxStall {
+		for range maxStall + 1 {
 			router.retryStalledTxSetAcquires()
 		}
 		router.txSetAcquireMu.Lock()

--- a/internal/consensus/adaptor/router_txset_retry_test.go
+++ b/internal/consensus/adaptor/router_txset_retry_test.go
@@ -182,10 +182,6 @@ func TestTxSetRetry_NoProgressReplyDefersToTimer(t *testing.T) {
 	})
 }
 
-// TestTxSetRetry_InboundProgressNeverGivesUp pins that the inbound path
-// has NO give-up cap: give-up now lives solely on the stall timer, keyed
-// on timer ticks. Many progressing replies in a row each pipeline a fresh
-// request and never delete the acquire or erase accumulated timeout history.
 func TestTxSetRetry_InboundProgressNeverGivesUp(t *testing.T) {
 	router, rs := newRetryRouter(t)
 	// MaxStallTicks deliberately small: if the inbound path fed stall

--- a/internal/consensus/adaptor/router_txset_retry_test.go
+++ b/internal/consensus/adaptor/router_txset_retry_test.go
@@ -167,6 +167,7 @@ func TestTxSetRetry_NoProgressReplyDefersToTimer(t *testing.T) {
 	router, rs := newRetryRouter(t)
 	withRetryKnobs(router, 0, 1_000_000, 1_000_000, func() {
 		ld, txSetID := rootOnlyTxSetLedgerData(t, 4)
+		router.MarkTxSetStillNeeded(txSetID)
 
 		// A progressing (root) reply pipelines exactly one request.
 		router.handleTxSetData(ld, 1)
@@ -191,6 +192,7 @@ func TestTxSetRetry_InboundProgressNeverGivesUp(t *testing.T) {
 	// telemetry it would trip and delete the acquire.
 	withRetryKnobs(router, 0, 3, 1_000_000, func() {
 		ld, txSetID := rootOnlyTxSetLedgerData(t, 4)
+		router.MarkTxSetStillNeeded(txSetID)
 
 		const replies = 25
 		for i := range replies {
@@ -225,6 +227,7 @@ func TestTxSetRetry_DeprioritizesNonProgressingPeer(t *testing.T) {
 	const threshold = 2
 	withRetryKnobs(router, 0, 1_000_000, threshold, func() {
 		ld, txSetID := rootOnlyTxSetLedgerData(t, 4)
+		router.MarkTxSetStillNeeded(txSetID)
 		noProgressLD := emptyTxSetLedgerData(txSetID)
 		const badPeer = uint64(7)
 
@@ -262,6 +265,7 @@ func TestTxSetRetry_ProgressResetsNonProgressCounter(t *testing.T) {
 	const threshold = 2
 	withRetryKnobs(router, 0, 1_000_000, threshold, func() {
 		ld, txSetID := rootOnlyTxSetLedgerData(t, 4)
+		router.MarkTxSetStillNeeded(txSetID)
 		noProgressLD := emptyTxSetLedgerData(txSetID)
 		const peer = uint64(11)
 
@@ -306,6 +310,7 @@ func TestTxSetRetry_BadNonRootInvalidatesWholeReply(t *testing.T) {
 	const threshold = 2
 	withRetryKnobs(router, 0, 1_000_000, threshold, func() {
 		_, txSetID, wireNodes := buildTxSetForTest(t, 4)
+		router.MarkTxSetStillNeeded(txSetID)
 		rootNode := wireNodes[0]
 		require.Greater(t, len(wireNodes), 1)
 
@@ -361,6 +366,7 @@ func TestTxSetRetry_StillNeededReArmsDormantAcquire(t *testing.T) {
 	const maxStall = 2
 	withRetryKnobs(router, 0, maxStall, 1_000_000, func() {
 		ld, txSetID := rootOnlyTxSetLedgerData(t, 4)
+		router.MarkTxSetStillNeeded(txSetID)
 
 		// Progress reply creates the acquire and pipelines one request.
 		router.handleTxSetData(ld, 1)
@@ -391,22 +397,19 @@ func TestTxSetRetry_StillNeededReArmsDormantAcquire(t *testing.T) {
 	})
 }
 
-// TestTxSetRetry_StillNeededNoOpOnUnknownTxSet pins that the
-// stillNeed hook is a safe no-op when no acquisition is in flight —
-// matching rippled's getSet path where the stillNeed call is gated on
-// `it->second.mAcquire` being live (InboundTransactions.cpp:110-113).
-func TestTxSetRetry_StillNeededNoOpOnUnknownTxSet(t *testing.T) {
+func TestTxSetRetry_StillNeededRecordsRequestedTxSet(t *testing.T) {
 	router, _ := newRetryRouter(t)
 	var unknownID consensus.TxSetID
 	unknownID[0] = 0xab
 
-	// Must not panic, must not allocate state, must not broadcast.
 	router.MarkTxSetStillNeeded(unknownID)
 
 	router.txSetAcquireMu.Lock()
-	_, exists := router.txSetAcquire[unknownID]
+	state, exists := router.txSetAcquire[unknownID]
 	router.txSetAcquireMu.Unlock()
-	assert.False(t, exists, "MarkTxSetStillNeeded must not allocate state for unknown tx-sets")
+	require.True(t, exists, "the request hook must record the tx-set before the request is sent")
+	assert.Nil(t, state.txMap, "recording intent must not allocate a SHAMap before data arrives")
+	assert.False(t, state.done)
 }
 
 // TestTxSetRetry_QueryTypeEscalation pins issue #977's requester-side
@@ -423,7 +426,8 @@ func TestTxSetRetry_QueryTypeEscalation(t *testing.T) {
 	// MinInterval=0 so neither the inbound throttle nor the timer skip
 	// fires; high attempt cap so nothing is dropped mid-test.
 	withRetryKnobs(router, 0, 1_000_000, 1_000_000, func() {
-		ld, _ := rootOnlyTxSetLedgerData(t, 4)
+		ld, txSetID := rootOnlyTxSetLedgerData(t, 4)
+		router.MarkTxSetStillNeeded(txSetID)
 
 		// First attempt is inbound-driven, before any timeout → direct.
 		router.handleTxSetData(ld, 1)

--- a/internal/consensus/adaptor/router_txset_rootgate_test.go
+++ b/internal/consensus/adaptor/router_txset_rootgate_test.go
@@ -36,9 +36,9 @@ func TestTxSetAcquire_RootlessReplyDoesNotCompleteEmpty(t *testing.T) {
 		_, rawID, wireNodes := buildTxSetForTest(t, 8)
 		require.Greater(t, len(wireNodes), 1, "fixture must have non-root nodes")
 		txSetID := consensus.TxSetID(rawID)
+		router.MarkTxSetStillNeeded(txSetID)
 
-		// Feed ONLY the non-root nodes (a missing-nodes reply for a set with no
-		// live acquire) from peer 7.
+		// Feed ONLY the non-root nodes for the requested set from peer 7.
 		router.handleTxSetData(ldFromWire(rawID, wireNodes[1:]), 7)
 
 		// No completion: the engine must not have been fed an empty set.
@@ -92,6 +92,7 @@ func TestTxSetAcquire_StragglerAfterDoneIsDropped(t *testing.T) {
 		_, rawID, wireNodes := buildTxSetForTest(t, 8)
 		txSetID := consensus.TxSetID(rawID)
 		completeLD := ldFromWire(rawID, wireNodes)
+		router.MarkTxSetStillNeeded(txSetID)
 
 		// Complete the acquire in one reply.
 		router.handleTxSetData(completeLD, 1)
@@ -128,18 +129,17 @@ func TestTxSetAcquire_StragglerAfterDoneIsDropped(t *testing.T) {
 	})
 }
 
-// TestTxSetAcquire_DuplicateOnlyReplyDoesNotReRequest pins that only a fresh
-// attach (NodeUseful) counts as progress: a reply that re-sends nodes the map
-// already holds (all NodeDuplicate, no root) makes no progress and must NOT
-// pipeline a re-request — otherwise a peer replaying fat nodes keeps firing
-// requests (the 70f35035 regression).
-func TestTxSetAcquire_DuplicateOnlyReplyDoesNotReRequest(t *testing.T) {
+// TestTxSetAcquire_DuplicateOnlyReplyPipelinesMissingNodes pins rippled's
+// duplicate-is-good behavior: a valid reply that re-sends nodes already held
+// still triggers the current missing-node frontier and is not penalized.
+func TestTxSetAcquire_DuplicateOnlyReplyPipelinesMissingNodes(t *testing.T) {
 	router, rs, _ := newPipelineRouter(t)
 	withRetryKnobs(router, time.Hour, 1_000_000, 1_000_000, func() {
 		_, rawID, wireNodes := buildTxSetForTest(t, 16)
 		require.Greater(t, len(wireNodes), 2, "fixture must have a root and >=2 non-root nodes")
 		root := wireNodes[0]
 		firstNonRoot := wireNodes[1]
+		router.MarkTxSetStillNeeded(consensus.TxSetID(rawID))
 
 		// Root reply → progress (installs the root) → pipelines one request.
 		router.handleTxSetData(ldFromWire(rawID, []shamap.WireNode{root}), 1)
@@ -149,10 +149,11 @@ func TestTxSetAcquire_DuplicateOnlyReplyDoesNotReRequest(t *testing.T) {
 		router.handleTxSetData(ldFromWire(rawID, []shamap.WireNode{firstNonRoot}), 1)
 		require.Equal(t, 2, rs.calledN(), "a fresh non-root node pipelines one more request")
 
-		// Re-deliver the SAME non-root node (all NodeDuplicate, no root): nothing
-		// is added, so it is not progress and must NOT re-request.
+		// Re-deliver the SAME non-root node (all NodeDuplicate, no root).
 		router.handleTxSetData(ldFromWire(rawID, []shamap.WireNode{firstNonRoot}), 1)
-		require.Equal(t, 2, rs.calledN(),
-			"a duplicate-only reply makes no progress and must not re-request")
+		require.Equal(t, 3, rs.calledN(),
+			"a valid duplicate-only reply must pipeline the current frontier")
+		require.Equal(t, uint64(1), rs.lastCall().peerID,
+			"duplicate-only pipelining remains unicast to the replying peer")
 	})
 }

--- a/internal/consensus/adaptor/router_txset_rootgate_test.go
+++ b/internal/consensus/adaptor/router_txset_rootgate_test.go
@@ -38,7 +38,6 @@ func TestTxSetAcquire_RootlessReplyDoesNotCompleteEmpty(t *testing.T) {
 		txSetID := consensus.TxSetID(rawID)
 		router.MarkTxSetStillNeeded(txSetID)
 
-		// Feed ONLY the non-root nodes for the requested set from peer 7.
 		router.handleTxSetData(ldFromWire(rawID, wireNodes[1:]), 7)
 
 		// No completion: the engine must not have been fed an empty set.
@@ -129,9 +128,6 @@ func TestTxSetAcquire_StragglerAfterDoneIsDropped(t *testing.T) {
 	})
 }
 
-// TestTxSetAcquire_DuplicateOnlyReplyPipelinesMissingNodes pins rippled's
-// duplicate-is-good behavior: a valid reply that re-sends nodes already held
-// still triggers the current missing-node frontier and is not penalized.
 func TestTxSetAcquire_DuplicateOnlyReplyPipelinesMissingNodes(t *testing.T) {
 	router, rs, _ := newPipelineRouter(t)
 	withRetryKnobs(router, time.Hour, 1_000_000, 1_000_000, func() {
@@ -149,7 +145,6 @@ func TestTxSetAcquire_DuplicateOnlyReplyPipelinesMissingNodes(t *testing.T) {
 		router.handleTxSetData(ldFromWire(rawID, []shamap.WireNode{firstNonRoot}), 1)
 		require.Equal(t, 2, rs.calledN(), "a fresh non-root node pipelines one more request")
 
-		// Re-deliver the SAME non-root node (all NodeDuplicate, no root).
 		router.handleTxSetData(ldFromWire(rawID, []shamap.WireNode{firstNonRoot}), 1)
 		require.Equal(t, 3, rs.calledN(),
 			"a valid duplicate-only reply must pipeline the current frontier")

--- a/internal/consensus/adaptor/router_txset_timer_test.go
+++ b/internal/consensus/adaptor/router_txset_timer_test.go
@@ -50,11 +50,12 @@ func TestTxSetAcquire_TimerRetriggersWhenInboundQuiet(t *testing.T) {
 
 func TestTxSetAcquire_InitialRequestDefersRetryMaintenance(t *testing.T) {
 	for _, test := range []struct {
-		name    string
-		dormant bool
+		name         string
+		dormant      bool
+		wantTimeouts int
 	}{
 		{name: "new"},
-		{name: "revived", dormant: true},
+		{name: "revived", dormant: true, wantTimeouts: 1},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			router, sender := newRetryRouter(t)
@@ -80,8 +81,8 @@ func TestTxSetAcquire_InitialRequestDefersRetryMaintenance(t *testing.T) {
 			state := router.txSetAcquire[id]
 			require.NotNil(t, state)
 			require.False(t, state.lastRequest.Before(before))
-			require.Zero(t, state.stallTicks,
-				"maintenance inside MinInterval must not consume a stall tick")
+			require.Equal(t, test.wantTimeouts, state.stallTicks,
+				"stillNeed clamps prior timeouts and maintenance inside MinInterval consumes none")
 			router.txSetAcquireMu.Unlock()
 			require.Zero(t, sender.calledN(),
 				"maintenance inside MinInterval must not send a missing-node request")
@@ -136,7 +137,7 @@ func TestTxSetAcquire_TimerFinalizesCompleteMapAfterInvalidTrailingNode(t *testi
 		"the retry driver must finalize a complete map left by an invalid trailing node")
 }
 
-func TestTxSetAcquire_TimerLatchesTerminalMap(t *testing.T) {
+func TestTxSetAcquire_TimerFailedMapIsRevivable(t *testing.T) {
 	router, rs := newRetryRouter(t)
 	ld, id := rootOnlyTxSetLedgerData(t, 8)
 	router.MarkTxSetStillNeeded(id)
@@ -156,12 +157,58 @@ func TestTxSetAcquire_TimerLatchesTerminalMap(t *testing.T) {
 	})
 
 	router.txSetAcquireMu.Lock()
-	defer router.txSetAcquireMu.Unlock()
 	assertState := router.txSetAcquire[id]
 	require.NotNil(t, assertState)
-	require.True(t, assertState.done, "a zero-frontier map that cannot FinishSync is terminal")
-	require.False(t, assertState.dormant)
+	require.True(t, assertState.done, "a zero-frontier map that cannot FinishSync is failed")
+	require.True(t, assertState.dormant, "failed maps wait for stillNeed before accepting more data")
+	require.False(t, assertState.completed)
+	router.txSetAcquireMu.Unlock()
 	require.Equal(t, before, rs.calledN(), "terminal maps must not spin requests")
+
+	router.MarkTxSetStillNeeded(id)
+	router.txSetAcquireMu.Lock()
+	assertState = router.txSetAcquire[id]
+	require.False(t, assertState.done, "stillNeed clears rippled's failed_ analogue")
+	require.False(t, assertState.dormant)
+	router.txSetAcquireMu.Unlock()
+}
+
+func TestTxSetAcquire_TimerMatchesRippledTimeoutCadence(t *testing.T) {
+	router, sender := newRetryRouter(t)
+	ld, id := rootOnlyTxSetLedgerData(t, 8)
+	router.MarkTxSetStillNeeded(id)
+	router.SetTxSetRetryKnobsForTest(txSetRetryKnobs{
+		MinInterval:              0,
+		NormalTimeouts:           4,
+		MaxStallTicks:            20,
+		PeerNonProgressThreshold: 3,
+	})
+	router.handleTxSetData(ld, 4)
+	baseline := sender.calledN()
+
+	for range 3 {
+		router.maintenanceTick()
+	}
+	require.Equal(t, baseline, sender.calledN(), "timeouts 1-3 do not broadcast missing nodes")
+
+	router.maintenanceTick()
+	require.Equal(t, baseline+1, sender.calledN(), "timeout 4 starts normal retries")
+	require.True(t, sender.lastCall().indirect)
+
+	for range 16 {
+		router.maintenanceTick()
+	}
+	atTwenty := sender.calledN()
+	require.Equal(t, baseline+17, atTwenty, "timeouts 4 through 20 all retry")
+
+	router.maintenanceTick()
+	require.Equal(t, atTwenty, sender.calledN(), "timeout 21 fails without another retry")
+	router.txSetAcquireMu.Lock()
+	state := router.txSetAcquire[id]
+	require.True(t, state.done)
+	require.True(t, state.dormant)
+	require.False(t, state.completed)
+	router.txSetAcquireMu.Unlock()
 }
 
 // The timer respects the MinInterval cadence: an acquire whose inbound path

--- a/internal/consensus/adaptor/router_txset_timer_test.go
+++ b/internal/consensus/adaptor/router_txset_timer_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/shamap"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,6 +22,7 @@ import (
 func TestTxSetAcquire_TimerRetriggersWhenInboundQuiet(t *testing.T) {
 	router, rs := newRetryRouter(t)
 	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
+	router.MarkTxSetStillNeeded(txSetID)
 
 	// MinInterval=0 so each tick is eligible to fire (no production wait).
 	withRetryKnobs(router, 0, 20, 3, func() {
@@ -44,12 +48,129 @@ func TestTxSetAcquire_TimerRetriggersWhenInboundQuiet(t *testing.T) {
 	})
 }
 
+func TestTxSetAcquire_InitialRequestDefersRetryMaintenance(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		dormant bool
+	}{
+		{name: "new"},
+		{name: "revived", dormant: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			router, sender := newRetryRouter(t)
+			id := consensus.TxSetID{0x70, byte(len(test.name))}
+			if test.dormant {
+				router.MarkTxSetStillNeeded(id)
+				router.txSetAcquireMu.Lock()
+				state := router.txSetAcquire[id]
+				state.done = true
+				state.dormant = true
+				state.stallTicks = 7
+				state.lastRequest = time.Time{}
+				router.txSetAcquireMu.Unlock()
+			}
+
+			before := time.Now()
+			withRetryKnobs(router, time.Hour, 20, 3, func() {
+				require.NoError(t, router.adaptor.RequestTxSet(id))
+				router.retryStalledTxSetAcquires()
+			})
+
+			router.txSetAcquireMu.Lock()
+			state := router.txSetAcquire[id]
+			require.NotNil(t, state)
+			require.False(t, state.lastRequest.Before(before))
+			require.Zero(t, state.stallTicks,
+				"maintenance inside MinInterval must not consume a stall tick")
+			router.txSetAcquireMu.Unlock()
+			require.Zero(t, sender.calledN(),
+				"maintenance inside MinInterval must not send a missing-node request")
+		})
+	}
+}
+
+func TestTxSetAcquire_TimerFinalizesCompleteMapAfterInvalidTrailingNode(t *testing.T) {
+	router, _, engine := newPipelineRouter(t)
+	_, rawID, wireNodes := buildTxSetForTest(t, 8)
+	id := consensus.TxSetID(rawID)
+	require.Greater(t, len(wireNodes), 1)
+
+	usedBranches := make(map[byte]bool)
+	for _, node := range wireNodes[1:] {
+		if len(node.NodeID) == shamap.NodeIDSize && node.NodeID[32] == 1 {
+			usedBranches[node.NodeID[0]>>4] = true
+		}
+	}
+	var emptyBranch byte
+	foundEmpty := false
+	for branch := byte(0); branch < shamap.BranchFactor; branch++ {
+		if !usedBranches[branch] {
+			emptyBranch = branch
+			foundEmpty = true
+			break
+		}
+	}
+	require.True(t, foundEmpty)
+	badNodeID, err := shamap.NewRootNodeID().ChildNodeID(emptyBranch)
+	require.NoError(t, err)
+
+	reply := ldFromWire(rawID, wireNodes)
+	reply.Nodes = append(reply.Nodes, message.LedgerNode{
+		NodeID:   badNodeID.Bytes(),
+		NodeData: []byte{0xde, 0xad},
+	})
+	router.MarkTxSetStillNeeded(id)
+
+	withRetryKnobs(router, 0, 20, 3, func() {
+		router.handleTxSetData(reply, 71)
+		engine.mu.Lock()
+		require.Empty(t, engine.txSets, "invalid reply returns before finalization")
+		engine.mu.Unlock()
+
+		router.retryStalledTxSetAcquires()
+	})
+
+	engine.mu.Lock()
+	defer engine.mu.Unlock()
+	require.Equal(t, []consensus.TxSetID{id}, engine.txSets,
+		"the retry driver must finalize a complete map left by an invalid trailing node")
+}
+
+func TestTxSetAcquire_TimerLatchesTerminalMap(t *testing.T) {
+	router, rs := newRetryRouter(t)
+	ld, id := rootOnlyTxSetLedgerData(t, 8)
+	router.MarkTxSetStillNeeded(id)
+	router.handleTxSetData(ld, 72)
+
+	router.txSetAcquireMu.Lock()
+	state := router.txSetAcquire[id]
+	require.NotNil(t, state)
+	require.NoError(t, state.txMap.SetImmutable())
+	state.lastRequest = time.Time{}
+	router.txSetAcquireMu.Unlock()
+
+	before := rs.calledN()
+	withRetryKnobs(router, 0, 20, 3, func() {
+		router.retryStalledTxSetAcquires()
+		router.retryStalledTxSetAcquires()
+	})
+
+	router.txSetAcquireMu.Lock()
+	defer router.txSetAcquireMu.Unlock()
+	assertState := router.txSetAcquire[id]
+	require.NotNil(t, assertState)
+	require.True(t, assertState.done, "a zero-frontier map that cannot FinishSync is terminal")
+	require.False(t, assertState.dormant)
+	require.Equal(t, before, rs.calledN(), "terminal maps must not spin requests")
+}
+
 // The timer respects the MinInterval cadence: an acquire whose inbound path
 // just requested (fresh lastRequest) is not re-fired by a tick inside the
 // window, mirroring rippled's 250ms TX_ACQUIRE_TIMEOUT spacing.
 func TestTxSetAcquire_TimerRespectsMinInterval(t *testing.T) {
 	router, rs := newRetryRouter(t)
-	ld, _ := rootOnlyTxSetLedgerData(t, 8)
+	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
+	router.MarkTxSetStillNeeded(txSetID)
 
 	withRetryKnobs(router, time.Hour, 20, 3, func() {
 		router.handleTxSetData(ld, 4)
@@ -70,6 +191,7 @@ func TestTxSetAcquire_TimerRespectsMinInterval(t *testing.T) {
 func TestTxSetAcquire_TimerGoesDormantAtMaxStallTicks(t *testing.T) {
 	router, rs := newRetryRouter(t)
 	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
+	router.MarkTxSetStillNeeded(txSetID)
 
 	withRetryKnobs(router, 0, 3, 3, func() {
 		router.handleTxSetData(ld, 4)
@@ -101,7 +223,8 @@ func TestTxSetAcquire_TimerGoesDormantAtMaxStallTicks(t *testing.T) {
 // timer out until responses actually stop.
 func TestTxSetAcquire_TimerStaysOutWhileInboundFresh(t *testing.T) {
 	router, rs := newRetryRouter(t)
-	ld, _ := rootOnlyTxSetLedgerData(t, 8)
+	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
+	router.MarkTxSetStillNeeded(txSetID)
 
 	// Real (large) cadence window: the inbound request just set lastRequest, so
 	// every tick below falls inside the window.
@@ -129,6 +252,7 @@ func TestTxSetAcquire_TimerStaysOutWhileInboundFresh(t *testing.T) {
 func TestTxSetAcquire_GivenUpAcquireDropsStragglerRevivableByStillNeed(t *testing.T) {
 	router, rs := newRetryRouter(t)
 	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
+	router.MarkTxSetStillNeeded(txSetID)
 
 	withRetryKnobs(router, 0, 3, 3, func() {
 		// Create the acquire, then drive ticks past the stall cap to dormancy.

--- a/internal/consensus/adaptor/router_txset_wire_test.go
+++ b/internal/consensus/adaptor/router_txset_wire_test.go
@@ -327,6 +327,7 @@ func TestRouter_LedgerData_TsCandidate_FeedsEngine(t *testing.T) {
 		InfoType:   message.LedgerInfoTsCandidate,
 		Nodes:      ldNodes,
 	}
+	require.NoError(t, adaptor.RequestTxSet(consensus.TxSetID(id)))
 	inbox <- &peermanagement.InboundMessage{
 		PeerID:  3,
 		Type:    uint16(message.TypeLedgerData),

--- a/internal/consensus/adaptor/sender.go
+++ b/internal/consensus/adaptor/sender.go
@@ -316,8 +316,8 @@ func (s *OverlaySender) PeerWithTxSet(target [32]byte, exclude uint64) (uint64, 
 
 // NotePeerHasTxSet forwards to Overlay.NotePeerHasTxSet, recording a
 // peer's tsHAVE tx-set advertisement for later relay selection.
-func (s *OverlaySender) NotePeerHasTxSet(peerID uint64, hash [32]byte) {
-	s.overlay.NotePeerHasTxSet(peermanagement.PeerID(peerID), hash)
+func (s *OverlaySender) NotePeerHasTxSet(peerID uint64, hash [32]byte) bool {
+	return s.overlay.NotePeerHasTxSet(peermanagement.PeerID(peerID), hash)
 }
 
 // IncPeerBadData forwards to Overlay.IncPeerBadData. Called by the

--- a/internal/consensus/adaptor/sender_cov_test.go
+++ b/internal/consensus/adaptor/sender_cov_test.go
@@ -211,7 +211,7 @@ func (f *snd_fakeOverlay) SelectLedgerPeers([32]byte, uint32, []uint64, int) []u
 	return nil
 }
 func (f *snd_fakeOverlay) PeerWithTxSet([32]byte, uint64) (uint64, bool) { return 0, false }
-func (f *snd_fakeOverlay) NotePeerHasTxSet(uint64, [32]byte)             {}
+func (f *snd_fakeOverlay) NotePeerHasTxSet(uint64, [32]byte) bool        { return true }
 func (f *snd_fakeOverlay) CheckTracking(uint32)                          {}
 
 func snd_newAdaptorWithFake(t *testing.T, fake *snd_fakeOverlay) *Adaptor {

--- a/internal/consensus/adaptor/stvalidation.go
+++ b/internal/consensus/adaptor/stvalidation.go
@@ -587,7 +587,7 @@ func skipAmount(data []byte, pos *int) (int, error) {
 		length = 33
 	}
 	if length == 8 && raw == 0 {
-		return 0, errors.New("negative zero is not canonical")
+		return 0, fmt.Errorf("%w: negative zero is not canonical", errInvalidFieldValue)
 	}
 	if *pos+length > len(data) {
 		return 0, errShortData

--- a/internal/consensus/adaptor/stvalidation.go
+++ b/internal/consensus/adaptor/stvalidation.go
@@ -340,9 +340,8 @@ func parseSTValidation(data []byte) (*consensus.Validation, error) {
 // consensus.Validation. Fields are written in canonical order (ascending type
 // code, then ascending field code within each type).
 //
-// Outbound validations set both vfFullValidation and vfFullyCanonicalSig on
-// sfFlags. Optional supplementary fields are emitted when present; fields
-// without explicit presence tracking use a non-zero value as their proxy.
+// Optional supplementary fields are emitted when present; fields without
+// explicit presence tracking use a non-zero value as their proxy.
 //
 // Exported so external packages (the validation archive) can reserialize
 // self-built validations whose Raw field is nil.
@@ -351,20 +350,19 @@ func SerializeSTValidation(v *consensus.Validation) []byte {
 
 	// --- UINT32 fields (type 2) ---
 
-	// sfFlags (field 2). For round-trip fidelity, prefer the original
-	// wire word captured by parseSTValidation (so we re-emit any vendor
-	// bits the validator set). For self-built validations whose Flags
-	// field is zero, synthesize the rippled-canonical pair: stamp
-	// vfFullyCanonicalSig on every outbound validation so canonical-sig-
-	// strict peers don't need to special-case us, plus vfFullValidation
-	// when v.Full.
-	flags := outboundValidationFlags(v)
+	// sfFlags (field 2)
+	flags := v.Flags
 	buf = appendFieldHeader(buf, typeUINT32, fieldFlags)
 	buf = binary.BigEndian.AppendUint32(buf, flags)
 
 	// sfLedgerSequence (field 6)
 	buf = appendFieldHeader(buf, typeUINT32, fieldLedgerSequence)
 	buf = binary.BigEndian.AppendUint32(buf, v.LedgerSeq)
+
+	if !v.CloseTime.IsZero() {
+		buf = appendFieldHeader(buf, typeUINT32, fieldCloseTime)
+		buf = binary.BigEndian.AppendUint32(buf, timeToXrplEpoch(v.CloseTime))
+	}
 
 	// sfSigningTime (field 9)
 	buf = appendFieldHeader(buf, typeUINT32, fieldSigningTime)
@@ -758,7 +756,7 @@ func appendFieldHeader(buf []byte, typeCode, fieldCode int) []byte {
 // parseXRPAmount decodes an 8-byte native XRPL Amount.
 func parseXRPAmount(data []byte) (drops.XRPAmount, bool) {
 	if len(data) != 8 {
-		return 0, false
+		return 0, false, false
 	}
 	raw := binary.BigEndian.Uint64(data)
 	if raw == 0 || raw&(1<<63) != 0 || raw&(1<<61) != 0 {

--- a/internal/consensus/adaptor/stvalidation.go
+++ b/internal/consensus/adaptor/stvalidation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
@@ -86,10 +87,72 @@ const (
 )
 
 var (
-	errShortData     = errors.New("stvalidation: unexpected end of data")
-	errInvalidVL     = errors.New("stvalidation: invalid VL encoding")
-	errMissingFields = errors.New("stvalidation: missing required fields")
+	errShortData           = errors.New("stvalidation: unexpected end of data")
+	errInvalidVL           = errors.New("stvalidation: invalid VL encoding")
+	errMissingFields       = errors.New("stvalidation: missing required fields")
+	errDuplicateField      = errors.New("stvalidation: duplicate field")
+	errUnexpectedField     = errors.New("stvalidation: unexpected field")
+	errNonCanonicalFieldID = errors.New("stvalidation: non-canonical field id")
+	errInvalidFieldValue   = errors.New("stvalidation: invalid field value")
 )
+
+type validationFieldSpec struct {
+	name        string
+	requiredBit uint32
+	defaultZero bool
+}
+
+const (
+	requiredFlags uint32 = 1 << iota
+	requiredLedgerHash
+	requiredLedgerSequence
+	requiredSigningTime
+	requiredSigningPubKey
+	requiredSignature
+
+	allRequiredValidationFields = requiredFlags |
+		requiredLedgerHash |
+		requiredLedgerSequence |
+		requiredSigningTime |
+		requiredSigningPubKey |
+		requiredSignature
+)
+
+func validationFieldKey(typeCode, fieldCode int) uint32 {
+	return uint32(typeCode)<<16 | uint32(fieldCode)
+}
+
+var validationTemplate = map[uint32]validationFieldSpec{
+	validationFieldKey(typeUINT32, fieldFlags):          {name: "Flags", requiredBit: requiredFlags},
+	validationFieldKey(typeUINT32, fieldLedgerSequence): {name: "LedgerSequence", requiredBit: requiredLedgerSequence},
+	validationFieldKey(typeUINT32, fieldCloseTime):      {name: "CloseTime"},
+	validationFieldKey(typeUINT32, fieldSigningTime):    {name: "SigningTime", requiredBit: requiredSigningTime},
+	validationFieldKey(typeUINT32, fieldLoadFee):        {name: "LoadFee"},
+	validationFieldKey(typeUINT32, fieldReserveBase):    {name: "ReserveBase"},
+	validationFieldKey(typeUINT32, fieldReserveInc):     {name: "ReserveIncrement"},
+
+	validationFieldKey(typeUINT64, fieldBaseFee):       {name: "BaseFee"},
+	validationFieldKey(typeUINT64, fieldCookie):        {name: "Cookie", defaultZero: true},
+	validationFieldKey(typeUINT64, fieldServerVersion): {name: "ServerVersion"},
+
+	validationFieldKey(typeHash256, fieldLedgerHash):    {name: "LedgerHash", requiredBit: requiredLedgerHash},
+	validationFieldKey(typeHash256, fieldConsensusHash): {name: "ConsensusHash"},
+	validationFieldKey(typeHash256, fieldValidatedHash): {name: "ValidatedHash"},
+
+	validationFieldKey(typeAmount, fieldBaseFeeDrops):          {name: "BaseFeeDrops"},
+	validationFieldKey(typeAmount, fieldReserveBaseDrops):      {name: "ReserveBaseDrops"},
+	validationFieldKey(typeAmount, fieldReserveIncrementDrops): {name: "ReserveIncrementDrops"},
+
+	validationFieldKey(typeBlob, fieldSigningPubKey): {name: "SigningPubKey", requiredBit: requiredSigningPubKey},
+	validationFieldKey(typeBlob, fieldSignature):     {name: "Signature", requiredBit: requiredSignature},
+
+	validationFieldKey(typeVector256, fieldAmendments): {name: "Amendments"},
+}
+
+type validationSigningField struct {
+	key  uint32
+	wire []byte
+}
 
 // parseSTValidation parses XRPL-binary-encoded STValidation bytes into a
 // consensus.Validation. It also populates SigningData with the serialized
@@ -101,7 +164,9 @@ func parseSTValidation(data []byte) (*consensus.Validation, error) {
 	}
 
 	v := &consensus.Validation{}
-	var signingBuf []byte
+	var signingFields []validationSigningField
+	var present uint32
+	seen := make(map[uint32]struct{}, len(validationTemplate))
 
 	pos := 0
 	for pos < len(data) {
@@ -112,9 +177,13 @@ func parseSTValidation(data []byte) (*consensus.Validation, error) {
 			return nil, err
 		}
 
-		// End-of-object marker for nested objects — stop at top level.
-		if typeCode == 0 && fieldCode == 0 {
-			break
+		key := validationFieldKey(typeCode, fieldCode)
+		spec, allowed := validationTemplate[key]
+		if !allowed {
+			return nil, fmt.Errorf("%w: type=%d field=%d", errUnexpectedField, typeCode, fieldCode)
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return nil, fmt.Errorf("%w: %s", errDuplicateField, spec.name)
 		}
 
 		// Determine field data length and advance pos past it.
@@ -126,13 +195,35 @@ func parseSTValidation(data []byte) (*consensus.Validation, error) {
 		}
 
 		fieldData := data[pos-dataLen : pos]
+		if spec.defaultZero && binary.BigEndian.Uint64(fieldData) == 0 {
+			return nil, fmt.Errorf("%w: %s may not be explicitly set to default", errInvalidFieldValue, spec.name)
+		}
+		if typeCode == typeAmount {
+			if err := validateAmount(fieldData); err != nil {
+				return nil, fmt.Errorf("%w: %s: %v", errInvalidFieldValue, spec.name, err)
+			}
+		}
+		if typeCode == typeVector256 && len(fieldData)%32 != 0 {
+			return nil, fmt.Errorf("%w: %s length %d", errInvalidFieldValue, spec.name, len(fieldData))
+		}
+		if typeCode == typeBlob && fieldCode == fieldSigningPubKey {
+			if len(fieldData) != 33 || (fieldData[0] != 0x02 && fieldData[0] != 0x03) {
+				return nil, fmt.Errorf("%w: %s", errInvalidFieldValue, spec.name)
+			}
+		}
+
+		seen[key] = struct{}{}
+		present |= spec.requiredBit
 
 		// sfSignature (isSigningField=false) is excluded from the signing hash.
 		// All other fields, including sfSigningPubKey (isSigningField=true), are included.
 		excludeFromSigning := (typeCode == typeBlob && fieldCode == fieldSignature)
 
 		if !excludeFromSigning {
-			signingBuf = append(signingBuf, data[fieldStart:pos]...)
+			signingFields = append(signingFields, validationSigningField{
+				key:  key,
+				wire: data[fieldStart:pos],
+			})
 		}
 
 		// Extract known fields.
@@ -197,44 +288,32 @@ func parseSTValidation(data []byte) (*consensus.Validation, error) {
 			}
 
 		case typeCode == typeHash256 && fieldCode == fieldLedgerHash:
-			if len(fieldData) == 32 {
-				copy(v.LedgerID[:], fieldData)
-			}
+			copy(v.LedgerID[:], fieldData)
 
 		case typeCode == typeHash256 && fieldCode == fieldConsensusHash:
-			if len(fieldData) == 32 {
-				copy(v.ConsensusHash[:], fieldData)
-			}
+			copy(v.ConsensusHash[:], fieldData)
 
 		case typeCode == typeHash256 && fieldCode == fieldValidatedHash:
-			if len(fieldData) == 32 {
-				copy(v.ValidatedHash[:], fieldData)
-			}
+			copy(v.ValidatedHash[:], fieldData)
 
 		case typeCode == typeVector256 && fieldCode == fieldAmendments:
-			// Vector256 is VL-wrapped concat of 32-byte IDs. fieldData
-			// is the VL payload, so iterate in 32-byte chunks.
-			if len(fieldData)%32 == 0 {
-				n := len(fieldData) / 32
-				v.Amendments = make([][32]byte, 0, n)
-				for i := range n {
-					var id [32]byte
-					copy(id[:], fieldData[i*32:(i+1)*32])
-					v.Amendments = append(v.Amendments, id)
-				}
+			n := len(fieldData) / 32
+			v.Amendments = make([][32]byte, 0, n)
+			for i := range n {
+				var id [32]byte
+				copy(id[:], fieldData[i*32:(i+1)*32])
+				v.Amendments = append(v.Amendments, id)
 			}
 
 		case typeCode == typeBlob && fieldCode == fieldSigningPubKey:
-			if len(fieldData) == 33 {
-				copy(v.SigningPubKey[:], fieldData)
-				// Default NodeID to calcNodeID(signingKey). The
-				// consensus router substitutes the master-derived
-				// NodeID via the manifest cache after parsing when
-				// the validator has rotated keys; absent a manifest
-				// mapping, the signing-key-derived value is the
-				// fallback.
-				v.NodeID = consensus.CalcNodeID(v.SigningPubKey)
-			}
+			copy(v.SigningPubKey[:], fieldData)
+			// Default NodeID to calcNodeID(signingKey). The
+			// consensus router substitutes the master-derived
+			// NodeID via the manifest cache after parsing when
+			// the validator has rotated keys; absent a manifest
+			// mapping, the signing-key-derived value is the
+			// fallback.
+			v.NodeID = consensus.CalcNodeID(v.SigningPubKey)
 
 		case typeCode == typeBlob && fieldCode == fieldSignature:
 			v.Signature = make([]byte, len(fieldData))
@@ -242,15 +321,16 @@ func parseSTValidation(data []byte) (*consensus.Validation, error) {
 		}
 	}
 
-	v.SigningData = signingBuf
+	sort.Slice(signingFields, func(i, j int) bool {
+		return signingFields[i].key < signingFields[j].key
+	})
+	for _, field := range signingFields {
+		v.SigningData = append(v.SigningData, field.wire...)
+	}
 	v.Raw = append([]byte(nil), data...)
 
-	// Validate required fields were present. SigningPubKey doubles as
-	// the presence check for sfSigningPubKey: parseSTValidation only
-	// populates it when the wire field is exactly 33 bytes, so a zero
-	// SigningPubKey means the field was missing or malformed.
-	if v.LedgerSeq == 0 || v.LedgerID == (consensus.LedgerID{}) || v.SigningPubKey == (consensus.SigningPubKey{}) {
-		return nil, errMissingFields
+	if missing := allRequiredValidationFields &^ present; missing != 0 {
+		return nil, fmt.Errorf("%w: mask=0x%x", errMissingFields, missing)
 	}
 
 	return v, nil
@@ -443,6 +523,9 @@ func readFieldHeader(data []byte, pos *int) (int, int, error) {
 		}
 		typeCode = int(data[*pos])
 		*pos++
+		if typeCode < 16 {
+			return 0, 0, errNonCanonicalFieldID
+		}
 	}
 
 	if fieldCode == 0 {
@@ -451,6 +534,9 @@ func readFieldHeader(data []byte, pos *int) (int, int, error) {
 		}
 		fieldCode = int(data[*pos])
 		*pos++
+		if fieldCode < 16 {
+			return 0, 0, errNonCanonicalFieldID
+		}
 	}
 
 	return typeCode, fieldCode, nil
@@ -505,23 +591,90 @@ func advanceFixed(data []byte, pos *int, n int) (int, error) {
 	return n, nil
 }
 
-// skipAmount determines the length of an Amount field.
+// skipAmount determines the serialized length of an Amount field.
 func skipAmount(data []byte, pos *int) (int, error) {
 	if *pos+8 > len(data) {
 		return 0, errShortData
 	}
 
-	if data[*pos]&0x80 != 0 {
-		return advanceFixed(data, pos, 48)
+	raw := binary.BigEndian.Uint64(data[*pos : *pos+8])
+	length := 8
+	switch {
+	case raw&(uint64(1)<<63) != 0:
+		length = 48
+	case raw&(uint64(1)<<61) != 0:
+		length = 33
 	}
-	if data[*pos]&0x20 != 0 {
-		return advanceFixed(data, pos, 33)
-	}
-
-	if binary.BigEndian.Uint64(data[*pos:*pos+8]) == 0 {
+	if length == 8 && raw == 0 {
 		return 0, errors.New("negative zero is not canonical")
 	}
-	return advanceFixed(data, pos, 8)
+	if *pos+length > len(data) {
+		return 0, errShortData
+	}
+	*pos += length
+	return length, nil
+}
+
+func validateAmount(data []byte) error {
+	if len(data) < 8 {
+		return errShortData
+	}
+
+	raw := binary.BigEndian.Uint64(data[:8])
+	switch {
+	case raw&(uint64(1)<<63) != 0:
+		if len(data) != 48 {
+			return fmt.Errorf("issued amount length %d", len(data))
+		}
+		if isZero160(data[8:28]) {
+			return errors.New("invalid native currency")
+		}
+		if isZero160(data[28:48]) {
+			return errors.New("invalid native account")
+		}
+
+		offset := int(raw >> 54)
+		mantissa := raw & ((uint64(1) << 54) - 1)
+		if mantissa == 0 {
+			if offset != 512 {
+				return errors.New("invalid currency value")
+			}
+			return nil
+		}
+
+		exponent := (offset & 255) - 97
+		if mantissa < 1_000_000_000_000_000 ||
+			mantissa > 9_999_999_999_999_999 ||
+			exponent < -96 ||
+			exponent > 80 {
+			return errors.New("invalid currency value")
+		}
+		return nil
+
+	case raw&(uint64(1)<<61) != 0:
+		if len(data) != 33 {
+			return fmt.Errorf("MPT amount length %d", len(data))
+		}
+		return nil
+
+	default:
+		if len(data) != 8 {
+			return fmt.Errorf("native amount length %d", len(data))
+		}
+		if raw == 0 {
+			return errors.New("negative zero is not canonical")
+		}
+		return nil
+	}
+}
+
+func isZero160(data []byte) bool {
+	for _, b := range data {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // skipVL reads a variable-length prefix and advances past the data.

--- a/internal/consensus/adaptor/stvalidation.go
+++ b/internal/consensus/adaptor/stvalidation.go
@@ -739,7 +739,7 @@ func appendFieldHeader(buf []byte, typeCode, fieldCode int) []byte {
 // parseXRPAmount decodes an 8-byte native XRPL Amount.
 func parseXRPAmount(data []byte) (drops.XRPAmount, bool) {
 	if len(data) != 8 {
-		return 0, false, false
+		return 0, false
 	}
 	raw := binary.BigEndian.Uint64(data)
 	if raw == 0 || raw&(1<<63) != 0 || raw&(1<<61) != 0 {

--- a/internal/consensus/adaptor/stvalidation.go
+++ b/internal/consensus/adaptor/stvalidation.go
@@ -350,7 +350,6 @@ func SerializeSTValidation(v *consensus.Validation) []byte {
 
 	// --- UINT32 fields (type 2) ---
 
-	// sfFlags (field 2)
 	flags := v.Flags
 	buf = appendFieldHeader(buf, typeUINT32, fieldFlags)
 	buf = binary.BigEndian.AppendUint32(buf, flags)
@@ -589,7 +588,6 @@ func advanceFixed(data []byte, pos *int, n int) (int, error) {
 	return n, nil
 }
 
-// skipAmount determines the serialized length of an Amount field.
 func skipAmount(data []byte, pos *int) (int, error) {
 	if *pos+8 > len(data) {
 		return 0, errShortData

--- a/internal/consensus/adaptor/stvalidation.go
+++ b/internal/consensus/adaptor/stvalidation.go
@@ -487,21 +487,6 @@ func SerializeSTValidation(v *consensus.Validation) []byte {
 	return buf
 }
 
-func outboundValidationFlags(v *consensus.Validation) uint32 {
-	if v.Flags != 0 {
-		return v.Flags
-	}
-	return localValidationFlags(v.Full)
-}
-
-func localValidationFlags(full bool) uint32 {
-	flags := uint32(vfFullyCanonicalSig)
-	if full {
-		flags |= vfFullValidation
-	}
-	return flags
-}
-
 // readFieldHeader reads the XRPL field ID at data[*pos] and advances *pos.
 // Returns (typeCode, fieldCode).
 func readFieldHeader(data []byte, pos *int) (int, int, error) {

--- a/internal/consensus/adaptor/stvalidation_cov_test.go
+++ b/internal/consensus/adaptor/stvalidation_cov_test.go
@@ -605,7 +605,7 @@ func TestStvParseSTValidation_FieldHeaderError(t *testing.T) {
 }
 
 func TestStvSerializeSTValidation_ZeroFlagsNotFull(t *testing.T) {
-	// Flags=0, Full=false → synthesize only vfFullyCanonicalSig
+	// Generic serialization preserves Flags verbatim.
 	orig := buildTestValidation()
 	orig.Flags = 0
 	orig.Full = false
@@ -614,7 +614,7 @@ func TestStvSerializeSTValidation_ZeroFlagsNotFull(t *testing.T) {
 	parsed, err := parseSTValidation(blob)
 	require.NoError(t, err)
 
-	assert.Equal(t, uint32(vfFullyCanonicalSig), parsed.Flags)
+	assert.Zero(t, parsed.Flags)
 	assert.False(t, parsed.Full)
 }
 

--- a/internal/consensus/adaptor/stvalidation_cov_test.go
+++ b/internal/consensus/adaptor/stvalidation_cov_test.go
@@ -22,25 +22,20 @@ func TestStvReadFieldHeader_TypeZero(t *testing.T) {
 
 func TestStvReadFieldHeader_FieldZero(t *testing.T) {
 	// fieldCode == 0: next byte is the extended field code.
-	data := []byte{0x20, 0x0F} // high nibble 2, low nibble 0 → extended field; next byte = 15
+	data := []byte{0x20, 0x10} // high nibble 2, low nibble 0 → extended field; next byte = 16
 	pos := 0
 	tc, fc, err := readFieldHeader(data, &pos)
 	require.NoError(t, err)
 	assert.Equal(t, 2, tc)
-	assert.Equal(t, 0x0F, fc)
+	assert.Equal(t, 0x10, fc)
 	assert.Equal(t, 2, pos)
 }
 
 func TestStvReadFieldHeader_BothZero(t *testing.T) {
-	// byte 0x00 → typeCode=0 (needs extended type byte), fieldCode=0.
-	// With extended-type byte = 0 and extended-field byte = 0, the result
-	// is (typeCode=0, fieldCode=0) — the EOO marker. We need 3 bytes.
 	data := []byte{0x00, 0x00, 0x00}
 	pos := 0
-	tc, fc, err := readFieldHeader(data, &pos)
-	require.NoError(t, err)
-	assert.Equal(t, 0, tc)
-	assert.Equal(t, 0, fc)
+	_, _, err := readFieldHeader(data, &pos)
+	assert.ErrorIs(t, err, errNonCanonicalFieldID)
 }
 
 func TestStvReadFieldHeader_TypeZeroTruncated(t *testing.T) {
@@ -136,6 +131,7 @@ func TestStvSkipFieldData_Amount_IOU_NonZero(t *testing.T) {
 }
 
 func TestStvSkipFieldData_Amount_IOU_CanonicalZero(t *testing.T) {
+	// Issued amounts always include the 20-byte currency and issuer.
 	data := make([]byte, 48)
 	data[0] = 0x80
 	pos := 0
@@ -505,7 +501,7 @@ func TestStvParseSTValidation_InvalidAmendmentsLength(t *testing.T) {
 }
 
 func TestStvParseSTValidation_ShortSigningPubKey(t *testing.T) {
-	// SigningPubKey VL field with length != 33 → treated as absent → errMissingFields.
+	// SigningPubKey VL field with length != 33 is malformed.
 	var buf []byte
 	buf = appendFieldHeader(buf, typeUINT32, fieldFlags)
 	buf = binary.BigEndian.AppendUint32(buf, vfFullValidation)
@@ -529,7 +525,7 @@ func TestStvParseSTValidation_ShortSigningPubKey(t *testing.T) {
 	buf = appendVL(buf, make([]byte, 70))
 
 	_, err := parseSTValidation(buf)
-	assert.ErrorIs(t, err, errMissingFields)
+	assert.ErrorIs(t, err, errInvalidFieldValue)
 }
 
 func TestStvParseSTValidation_AllOptionalUINT32Fields(t *testing.T) {
@@ -628,9 +624,8 @@ func TestStvSerializeSTValidation_WithSignature(t *testing.T) {
 	orig.Signature = nil
 
 	blob := SerializeSTValidation(orig)
-	parsed, err := parseSTValidation(blob)
-	require.NoError(t, err)
-	assert.Empty(t, parsed.Signature)
+	_, err := parseSTValidation(blob)
+	assert.ErrorIs(t, err, errMissingFields)
 }
 
 func TestStvSkipAmount_IOUNonZeroMiddleBytes(t *testing.T) {

--- a/internal/consensus/adaptor/stvalidation_cov_test.go
+++ b/internal/consensus/adaptor/stvalidation_cov_test.go
@@ -131,7 +131,6 @@ func TestStvSkipFieldData_Amount_IOU_NonZero(t *testing.T) {
 }
 
 func TestStvSkipFieldData_Amount_IOU_CanonicalZero(t *testing.T) {
-	// Issued amounts always include the 20-byte currency and issuer.
 	data := make([]byte, 48)
 	data[0] = 0x80
 	pos := 0
@@ -501,7 +500,6 @@ func TestStvParseSTValidation_InvalidAmendmentsLength(t *testing.T) {
 }
 
 func TestStvParseSTValidation_ShortSigningPubKey(t *testing.T) {
-	// SigningPubKey VL field with length != 33 is malformed.
 	var buf []byte
 	buf = appendFieldHeader(buf, typeUINT32, fieldFlags)
 	buf = binary.BigEndian.AppendUint32(buf, vfFullValidation)
@@ -605,7 +603,6 @@ func TestStvParseSTValidation_FieldHeaderError(t *testing.T) {
 }
 
 func TestStvSerializeSTValidation_ZeroFlagsNotFull(t *testing.T) {
-	// Generic serialization preserves Flags verbatim.
 	orig := buildTestValidation()
 	orig.Flags = 0
 	orig.Full = false

--- a/internal/consensus/adaptor/stvalidation_template_test.go
+++ b/internal/consensus/adaptor/stvalidation_template_test.go
@@ -1,0 +1,480 @@
+package adaptor
+
+import (
+	"encoding/binary"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type validationWireField struct {
+	key       uint32
+	typeCode  int
+	fieldCode int
+	wire      []byte
+}
+
+func signedValidationFixture(t *testing.T) (*ValidatorIdentity, []validationWireField) {
+	t.Helper()
+
+	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
+	require.NoError(t, err)
+
+	validation := &consensus.Validation{
+		Full:      true,
+		LedgerSeq: 42,
+		SignTime:  time.Unix(protocol.RippleEpochUnix+800_000_000, 0),
+	}
+	for i := range validation.LedgerID {
+		validation.LedgerID[i] = byte(i + 1)
+	}
+	require.NoError(t, identity.SignValidation(validation))
+
+	return identity, decodeValidationWireFields(t, SerializeSTValidation(validation))
+}
+
+func decodeValidationWireFields(t *testing.T, blob []byte) []validationWireField {
+	t.Helper()
+
+	var fields []validationWireField
+	for pos := 0; pos < len(blob); {
+		start := pos
+		typeCode, fieldCode, err := readFieldHeader(blob, &pos)
+		require.NoError(t, err)
+		_, err = skipFieldData(typeCode, blob, &pos)
+		require.NoError(t, err)
+		fields = append(fields, validationWireField{
+			key:       validationFieldKey(typeCode, fieldCode),
+			typeCode:  typeCode,
+			fieldCode: fieldCode,
+			wire:      append([]byte(nil), blob[start:pos]...),
+		})
+	}
+	return fields
+}
+
+func validationWireFieldIndex(t *testing.T, fields []validationWireField, key uint32) int {
+	t.Helper()
+
+	for i := range fields {
+		if fields[i].key == key {
+			return i
+		}
+	}
+	t.Fatalf("validation field 0x%x not found", key)
+	return -1
+}
+
+func signValidationWireFields(
+	t *testing.T,
+	identity *ValidatorIdentity,
+	fields []validationWireField,
+) ([]byte, []byte, [32]byte) {
+	t.Helper()
+
+	signingFields := make([]validationWireField, 0, len(fields))
+	for _, field := range fields {
+		if field.key != validationFieldKey(typeBlob, fieldSignature) {
+			signingFields = append(signingFields, field)
+		}
+	}
+	sort.SliceStable(signingFields, func(i, j int) bool {
+		return signingFields[i].key < signingFields[j].key
+	})
+
+	var signingData []byte
+	for _, field := range signingFields {
+		signingData = append(signingData, field.wire...)
+	}
+	digest := sha512half.Sum(protocol.HashPrefixValidation().Bytes(), signingData)
+	signature, err := identity.Sign(digest[:])
+	require.NoError(t, err)
+	require.True(t, Verify(identity.SigningKey[:], digest[:], signature))
+
+	var blob []byte
+	for _, field := range fields {
+		if field.key == validationFieldKey(typeBlob, fieldSignature) {
+			blob = appendFieldHeader(blob, typeBlob, fieldSignature)
+			blob = appendVL(blob, signature)
+			continue
+		}
+		blob = append(blob, field.wire...)
+	}
+	return blob, signature, digest
+}
+
+func TestParseSTValidation_RequiresEveryTemplateField(t *testing.T) {
+	required := []struct {
+		name string
+		key  uint32
+	}{
+		{"Flags", validationFieldKey(typeUINT32, fieldFlags)},
+		{"LedgerHash", validationFieldKey(typeHash256, fieldLedgerHash)},
+		{"LedgerSequence", validationFieldKey(typeUINT32, fieldLedgerSequence)},
+		{"SigningTime", validationFieldKey(typeUINT32, fieldSigningTime)},
+		{"SigningPubKey", validationFieldKey(typeBlob, fieldSigningPubKey)},
+		{"Signature", validationFieldKey(typeBlob, fieldSignature)},
+	}
+
+	for _, test := range required {
+		t.Run(test.name, func(t *testing.T) {
+			identity, fields := signedValidationFixture(t)
+			index := validationWireFieldIndex(t, fields, test.key)
+			fields = append(fields[:index:index], fields[index+1:]...)
+
+			blob, _, _ := signValidationWireFields(t, identity, fields)
+			_, err := parseSTValidation(blob)
+			assert.ErrorIs(t, err, errMissingFields)
+		})
+	}
+}
+
+func TestParseSTValidation_RejectsDuplicateTemplateFields(t *testing.T) {
+	required := []struct {
+		name string
+		key  uint32
+	}{
+		{"Flags", validationFieldKey(typeUINT32, fieldFlags)},
+		{"LedgerHash", validationFieldKey(typeHash256, fieldLedgerHash)},
+		{"LedgerSequence", validationFieldKey(typeUINT32, fieldLedgerSequence)},
+		{"SigningTime", validationFieldKey(typeUINT32, fieldSigningTime)},
+		{"SigningPubKey", validationFieldKey(typeBlob, fieldSigningPubKey)},
+		{"Signature", validationFieldKey(typeBlob, fieldSignature)},
+	}
+
+	for _, test := range required {
+		t.Run(test.name, func(t *testing.T) {
+			identity, fields := signedValidationFixture(t)
+			index := validationWireFieldIndex(t, fields, test.key)
+			duplicate := fields[index]
+			duplicate.wire = append([]byte(nil), duplicate.wire...)
+			fields = append(fields, validationWireField{})
+			copy(fields[index+2:], fields[index+1:])
+			fields[index+1] = duplicate
+
+			blob, _, _ := signValidationWireFields(t, identity, fields)
+			_, err := parseSTValidation(blob)
+			assert.ErrorIs(t, err, errDuplicateField)
+		})
+	}
+}
+
+func TestParseSTValidation_TemplateShape(t *testing.T) {
+	t.Run("out of order is canonicalized", func(t *testing.T) {
+		identity, fields := signedValidationFixture(t)
+		signingTime := validationWireFieldIndex(t, fields, validationFieldKey(typeUINT32, fieldSigningTime))
+		ledgerHash := validationWireFieldIndex(t, fields, validationFieldKey(typeHash256, fieldLedgerHash))
+		fields[signingTime], fields[ledgerHash] = fields[ledgerHash], fields[signingTime]
+
+		blob, _, _ := signValidationWireFields(t, identity, fields)
+		validation, err := parseSTValidation(blob)
+		require.NoError(t, err)
+		assert.NoError(t, VerifyValidation(validation))
+	})
+
+	t.Run("unexpected field", func(t *testing.T) {
+		identity, fields := signedValidationFixture(t)
+		ledgerHash := validationWireFieldIndex(t, fields, validationFieldKey(typeHash256, fieldLedgerHash))
+		unexpected := validationWireField{
+			key:       validationFieldKey(typeHash256, 2),
+			typeCode:  typeHash256,
+			fieldCode: 2,
+			wire:      appendFieldHeader(nil, typeHash256, 2),
+		}
+		unexpected.wire = append(unexpected.wire, make([]byte, 32)...)
+		fields = append(fields, validationWireField{})
+		copy(fields[ledgerHash+2:], fields[ledgerHash+1:])
+		fields[ledgerHash+1] = unexpected
+
+		blob, _, _ := signValidationWireFields(t, identity, fields)
+		_, err := parseSTValidation(blob)
+		assert.ErrorIs(t, err, errUnexpectedField)
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		identity, fields := signedValidationFixture(t)
+		flags := validationWireFieldIndex(t, fields, validationFieldKey(typeUINT32, fieldFlags))
+		fields[flags] = validationWireField{
+			key:       validationFieldKey(typeUINT64, fieldFlags),
+			typeCode:  typeUINT64,
+			fieldCode: fieldFlags,
+			wire:      appendFieldHeader(nil, typeUINT64, fieldFlags),
+		}
+		fields[flags].wire = binary.BigEndian.AppendUint64(fields[flags].wire, vfFullyCanonicalSig|vfFullValidation)
+
+		blob, _, _ := signValidationWireFields(t, identity, fields)
+		_, err := parseSTValidation(blob)
+		assert.ErrorIs(t, err, errUnexpectedField)
+	})
+
+	t.Run("wrong signing key length", func(t *testing.T) {
+		identity, fields := signedValidationFixture(t)
+		signingKey := validationWireFieldIndex(t, fields, validationFieldKey(typeBlob, fieldSigningPubKey))
+		fields[signingKey].wire = appendFieldHeader(nil, typeBlob, fieldSigningPubKey)
+		fields[signingKey].wire = appendVL(fields[signingKey].wire, identity.SigningKey[:32])
+
+		blob, _, _ := signValidationWireFields(t, identity, fields)
+		_, err := parseSTValidation(blob)
+		assert.ErrorIs(t, err, errInvalidFieldValue)
+	})
+
+	t.Run("long signing key", func(t *testing.T) {
+		identity, fields := signedValidationFixture(t)
+		signingKey := validationWireFieldIndex(t, fields, validationFieldKey(typeBlob, fieldSigningPubKey))
+		longKey := append(append([]byte(nil), identity.SigningKey[:]...), 0)
+		fields[signingKey].wire = appendFieldHeader(nil, typeBlob, fieldSigningPubKey)
+		fields[signingKey].wire = appendVL(fields[signingKey].wire, longKey)
+
+		blob, _, _ := signValidationWireFields(t, identity, fields)
+		_, err := parseSTValidation(blob)
+		assert.ErrorIs(t, err, errInvalidFieldValue)
+	})
+
+	t.Run("ed25519 signing key", func(t *testing.T) {
+		identity, fields := signedValidationFixture(t)
+		signingKey := validationWireFieldIndex(t, fields, validationFieldKey(typeBlob, fieldSigningPubKey))
+		ed25519Key := make([]byte, 33)
+		ed25519Key[0] = 0xED
+		fields[signingKey].wire = appendFieldHeader(nil, typeBlob, fieldSigningPubKey)
+		fields[signingKey].wire = appendVL(fields[signingKey].wire, ed25519Key)
+
+		blob, _, _ := signValidationWireFields(t, identity, fields)
+		_, err := parseSTValidation(blob)
+		assert.ErrorIs(t, err, errInvalidFieldValue)
+	})
+
+	t.Run("wrong vector length", func(t *testing.T) {
+		identity, fields := signedValidationFixture(t)
+		amendments := validationWireField{
+			key:       validationFieldKey(typeVector256, fieldAmendments),
+			typeCode:  typeVector256,
+			fieldCode: fieldAmendments,
+			wire:      appendFieldHeader(nil, typeVector256, fieldAmendments),
+		}
+		amendments.wire = appendVL(amendments.wire, make([]byte, 31))
+		fields = append(fields, amendments)
+
+		blob, _, _ := signValidationWireFields(t, identity, fields)
+		_, err := parseSTValidation(blob)
+		assert.ErrorIs(t, err, errInvalidFieldValue)
+	})
+
+	t.Run("non-canonical field id", func(t *testing.T) {
+		identity, fields := signedValidationFixture(t)
+		flags := validationWireFieldIndex(t, fields, validationFieldKey(typeUINT32, fieldFlags))
+		fields[flags].wire = append([]byte{0x20, byte(fieldFlags)}, fields[flags].wire[1:]...)
+
+		blob, _, _ := signValidationWireFields(t, identity, fields)
+		_, err := parseSTValidation(blob)
+		assert.ErrorIs(t, err, errNonCanonicalFieldID)
+	})
+
+	t.Run("explicit default cookie", func(t *testing.T) {
+		identity, fields := signedValidationFixture(t)
+		ledgerHash := validationWireFieldIndex(t, fields, validationFieldKey(typeHash256, fieldLedgerHash))
+		cookie := validationWireField{
+			key:       validationFieldKey(typeUINT64, fieldCookie),
+			typeCode:  typeUINT64,
+			fieldCode: fieldCookie,
+			wire:      appendFieldHeader(nil, typeUINT64, fieldCookie),
+		}
+		cookie.wire = binary.BigEndian.AppendUint64(cookie.wire, 0)
+		fields = append(fields, validationWireField{})
+		copy(fields[ledgerHash+1:], fields[ledgerHash:])
+		fields[ledgerHash] = cookie
+
+		blob, _, _ := signValidationWireFields(t, identity, fields)
+		_, err := parseSTValidation(blob)
+		assert.ErrorIs(t, err, errInvalidFieldValue)
+	})
+}
+
+func TestParseSTValidation_ValidatesAmounts(t *testing.T) {
+	issuedAmount := func(raw uint64) []byte {
+		amount := make([]byte, 48)
+		binary.BigEndian.PutUint64(amount, raw)
+		amount[8] = 1
+		amount[28] = 1
+		return amount
+	}
+	mptAmount := func() []byte {
+		amount := make([]byte, 33)
+		amount[0] = 0x60
+		amount[8] = 7
+		amount[9] = 1
+		return amount
+	}
+	amountField := func(amount []byte) validationWireField {
+		wire := appendFieldHeader(nil, typeAmount, fieldBaseFeeDrops)
+		wire = append(wire, amount...)
+		return validationWireField{
+			key:       validationFieldKey(typeAmount, fieldBaseFeeDrops),
+			typeCode:  typeAmount,
+			fieldCode: fieldBaseFeeDrops,
+			wire:      wire,
+		}
+	}
+
+	const (
+		issuedFlag       = uint64(1) << 63
+		positiveFlag     = uint64(1) << 62
+		minIOUMantissa   = uint64(1_000_000_000_000_000)
+		centeredExponent = uint64(97)
+	)
+
+	invalid := []struct {
+		name   string
+		amount []byte
+		target error
+	}{
+		{
+			name:   "native negative zero",
+			amount: make([]byte, 8),
+			target: errInvalidFieldValue,
+		},
+		{
+			name: "issued native currency",
+			amount: func() []byte {
+				amount := issuedAmount(issuedFlag)
+				clear(amount[8:28])
+				return amount
+			}(),
+			target: errInvalidFieldValue,
+		},
+		{
+			name: "issued native account",
+			amount: func() []byte {
+				amount := issuedAmount(issuedFlag)
+				clear(amount[28:48])
+				return amount
+			}(),
+			target: errInvalidFieldValue,
+		},
+		{
+			name:   "issued invalid mantissa",
+			amount: issuedAmount(issuedFlag | positiveFlag | centeredExponent<<54 | 1),
+			target: errInvalidFieldValue,
+		},
+		{
+			name:   "issued invalid exponent",
+			amount: issuedAmount(issuedFlag | positiveFlag | minIOUMantissa),
+			target: errInvalidFieldValue,
+		},
+		{
+			name:   "truncated MPT",
+			amount: mptAmount()[:32],
+			target: errShortData,
+		},
+	}
+
+	for _, test := range invalid {
+		t.Run(test.name, func(t *testing.T) {
+			identity, fields := signedValidationFixture(t)
+			fields = append(fields, amountField(test.amount))
+
+			blob, _, _ := signValidationWireFields(t, identity, fields)
+			_, err := parseSTValidation(blob)
+			assert.ErrorIs(t, err, test.target)
+		})
+	}
+
+	valid := []struct {
+		name   string
+		amount []byte
+	}{
+		{
+			name: "native",
+			amount: func() []byte {
+				amount := make([]byte, 8)
+				binary.BigEndian.PutUint64(amount, positiveFlag|10)
+				return amount
+			}(),
+		},
+		{
+			name:   "issued zero",
+			amount: issuedAmount(issuedFlag),
+		},
+		{
+			name:   "MPT",
+			amount: mptAmount(),
+		},
+	}
+
+	for _, test := range valid {
+		t.Run(test.name, func(t *testing.T) {
+			identity, fields := signedValidationFixture(t)
+			fields = append(fields, amountField(test.amount))
+
+			blob, _, _ := signValidationWireFields(t, identity, fields)
+			validation, err := parseSTValidation(blob)
+			require.NoError(t, err)
+			assert.NoError(t, VerifyValidation(validation))
+		})
+	}
+}
+
+func TestParseSTValidation_TracksRequiredPresenceSeparatelyFromValue(t *testing.T) {
+	identity, fields := signedValidationFixture(t)
+
+	for _, key := range []uint32{
+		validationFieldKey(typeUINT32, fieldFlags),
+		validationFieldKey(typeUINT32, fieldLedgerSequence),
+		validationFieldKey(typeUINT32, fieldSigningTime),
+	} {
+		index := validationWireFieldIndex(t, fields, key)
+		fields[index].wire = fields[index].wire[:len(fields[index].wire)-4]
+		fields[index].wire = binary.BigEndian.AppendUint32(fields[index].wire, 0)
+	}
+	ledgerHash := validationWireFieldIndex(t, fields, validationFieldKey(typeHash256, fieldLedgerHash))
+	fields[ledgerHash].wire = appendFieldHeader(nil, typeHash256, fieldLedgerHash)
+	fields[ledgerHash].wire = append(fields[ledgerHash].wire, make([]byte, 32)...)
+
+	blob, _, _ := signValidationWireFields(t, identity, fields)
+	validation, err := parseSTValidation(blob)
+	require.NoError(t, err)
+	assert.Zero(t, validation.Flags)
+	assert.Zero(t, validation.LedgerSeq)
+	assert.Equal(t, consensus.LedgerID{}, validation.LedgerID)
+	assert.NoError(t, VerifyValidation(validation))
+}
+
+func TestParseSTValidation_RequiredSignatureMayBeEmptyStructurally(t *testing.T) {
+	_, fields := signedValidationFixture(t)
+	signature := validationWireFieldIndex(t, fields, validationFieldKey(typeBlob, fieldSignature))
+	fields[signature].wire = appendFieldHeader(nil, typeBlob, fieldSignature)
+	fields[signature].wire = appendVL(fields[signature].wire, nil)
+
+	var blob []byte
+	for _, field := range fields {
+		blob = append(blob, field.wire...)
+	}
+	validation, err := parseSTValidation(blob)
+	require.NoError(t, err)
+	assert.Empty(t, validation.Signature)
+	assert.Error(t, VerifyValidation(validation))
+}
+
+func TestParseOrVerifyValidation_RejectsEverySerializedByteMutation(t *testing.T) {
+	identity, fields := signedValidationFixture(t)
+	blob, _, _ := signValidationWireFields(t, identity, fields)
+	validation, err := parseSTValidation(blob)
+	require.NoError(t, err)
+	require.NoError(t, VerifyValidation(validation))
+
+	for i := range blob {
+		tampered := append([]byte(nil), blob...)
+		tampered[i] ^= 1
+
+		parsed, err := parseSTValidation(tampered)
+		if err != nil {
+			continue
+		}
+		assert.Error(t, VerifyValidation(parsed), "mutation at byte %d was accepted", i)
+	}
+}

--- a/internal/consensus/adaptor/stvalidation_test.go
+++ b/internal/consensus/adaptor/stvalidation_test.go
@@ -322,8 +322,6 @@ func TestSTValidation_FlagsRoundTrip(t *testing.T) {
 		t.Error("Full bit derived from Flags should be true")
 	}
 
-	// Generic serialization preserves the stored flag word even when Full
-	// is inconsistent. Outbound constructors must stamp flags before signing.
 	legacy := buildTestValidation()
 	legacy.Flags = 0 // explicit
 	legacyBlob := SerializeSTValidation(legacy)

--- a/internal/consensus/adaptor/stvalidation_test.go
+++ b/internal/consensus/adaptor/stvalidation_test.go
@@ -417,7 +417,7 @@ func TestParseSTValidation_MissingRequiredFields(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestParseSTValidation_UnknownFieldsSkipped(t *testing.T) {
+func TestParseSTValidation_UnknownFieldsRejected(t *testing.T) {
 	orig := buildTestValidation()
 	blob := SerializeSTValidation(orig)
 
@@ -452,12 +452,8 @@ func TestParseSTValidation_UnknownFieldsSkipped(t *testing.T) {
 	modified = append(modified, make([]byte, 32)...)
 	modified = append(modified, blob[insertPos:]...)
 
-	parsed, err := parseSTValidation(modified)
-	require.NoError(t, err)
-
-	assert.Equal(t, orig.LedgerSeq, parsed.LedgerSeq)
-	assert.Equal(t, orig.LedgerID, parsed.LedgerID)
-	assert.Equal(t, orig.NodeID, parsed.NodeID)
+	_, err := parseSTValidation(modified)
+	assert.ErrorIs(t, err, errUnexpectedField)
 }
 
 func TestSerializeSTValidation_CanonicalOrder(t *testing.T) {

--- a/internal/consensus/adaptor/stvalidation_test.go
+++ b/internal/consensus/adaptor/stvalidation_test.go
@@ -19,6 +19,7 @@ import (
 func buildTestValidation() *consensus.Validation {
 	v := &consensus.Validation{
 		Full:      true,
+		Flags:     vfFullyCanonicalSig | vfFullValidation,
 		LedgerSeq: 100,
 		SignTime:  time.Unix(protocol.RippleEpochUnix+828618000, 0),
 		Cookie:    12345,
@@ -321,16 +322,18 @@ func TestSTValidation_FlagsRoundTrip(t *testing.T) {
 		t.Error("Full bit derived from Flags should be true")
 	}
 
-	// Backward-compat: a Validation with Flags=0 still serializes to the
-	// canonical pair when Full=true (older constructors didn't know
-	// about Flags).
+	// Generic serialization preserves the stored flag word even when Full
+	// is inconsistent. Outbound constructors must stamp flags before signing.
 	legacy := buildTestValidation()
 	legacy.Flags = 0 // explicit
 	legacyBlob := SerializeSTValidation(legacy)
 	legacyParsed, err := parseSTValidation(legacyBlob)
 	require.NoError(t, err)
-	if legacyParsed.Flags != (vfFullyCanonicalSig | vfFullValidation) {
-		t.Fatalf("legacy Flags=0 should synthesize canonical pair; got 0x%08x", legacyParsed.Flags)
+	if legacyParsed.Flags != 0 {
+		t.Fatalf("Flags=0 should be preserved; got 0x%08x", legacyParsed.Flags)
+	}
+	if legacyParsed.Full {
+		t.Fatal("Full must be derived from the preserved flag word")
 	}
 }
 

--- a/internal/consensus/adaptor/txset.go
+++ b/internal/consensus/adaptor/txset.go
@@ -228,8 +228,11 @@ type TxSetCache struct {
 }
 
 func NewTxSetCache() *TxSetCache {
+	zero := &TxSetImpl{txMap: shamap.New(shamap.TypeTransaction)}
 	return &TxSetCache{
-		cache: make(map[consensus.TxSetID]*TxSetImpl),
+		cache: map[consensus.TxSetID]*TxSetImpl{
+			{}: zero,
+		},
 		added: make(map[consensus.TxSetID]time.Time),
 		now:   time.Now,
 	}
@@ -246,12 +249,18 @@ func (c *TxSetCache) Put(ts *TxSetImpl) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	id := ts.ID()
+	if id == (consensus.TxSetID{}) {
+		return
+	}
 	c.cache[id] = ts
 	c.added[id] = c.now()
 	c.sweepLocked()
 }
 
 func (c *TxSetCache) Remove(id consensus.TxSetID) {
+	if id == (consensus.TxSetID{}) {
+		return
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.cache, id)

--- a/internal/consensus/adaptor/txset_cache_test.go
+++ b/internal/consensus/adaptor/txset_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,4 +49,31 @@ func TestTxSetCache_Remove(t *testing.T) {
 	if _, ok := c.Get(ts.ID()); ok {
 		t.Error("entry should be gone after Remove")
 	}
+}
+
+func TestTxSetCache_ZeroSetIsPermanent(t *testing.T) {
+	c := NewTxSetCache()
+	zeroID := consensus.TxSetID{}
+
+	zero, ok := c.Get(zeroID)
+	require.True(t, ok)
+	require.NotNil(t, zero)
+	require.Equal(t, zeroID, zero.ID())
+	require.Zero(t, zero.Size())
+
+	c.Remove(zeroID)
+	clock := time.Unix(1_700_000_000, 0)
+	c.now = func() time.Time { return clock }
+	fresh, err := NewTxSet([][]byte{makeBlob(4)})
+	require.NoError(t, err)
+	c.Put(fresh)
+	clock = clock.Add(txSetCacheTTL + time.Second)
+	next, err := NewTxSet([][]byte{makeBlob(5)})
+	require.NoError(t, err)
+	c.Put(next)
+
+	zeroAfterSweep, ok := c.Get(zeroID)
+	require.True(t, ok)
+	require.Same(t, zero, zeroAfterSweep)
+	require.Zero(t, zeroAfterSweep.Size())
 }

--- a/internal/consensus/feevote/negative_vote_test.go
+++ b/internal/consensus/feevote/negative_vote_test.go
@@ -3,6 +3,7 @@ package feevote
 import (
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,18 +12,16 @@ func TestSignedAndExplicitZeroVotesAreNotNoVote(t *testing.T) {
 	target := Stance{BaseFee: 20, ReserveBase: 10, ReserveIncrement: 10}
 
 	for _, test := range []struct {
-		name     string
-		value    uint64
-		negative bool
+		name  string
+		value drops.XRPAmount
 	}{
 		{name: "explicit zero"},
-		{name: "legal negative", value: 1, negative: true},
+		{name: "legal negative", value: -1},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			value := test.value
 			blob, err := DoVoting(256, current, target, []Vote{{
-				BaseFee:         &value,
-				BaseFeeNegative: test.negative,
+				BaseFee: &value,
 			}}, true)
 			require.NoError(t, err)
 			require.NotEmpty(t, blob)

--- a/internal/consensus/feevote/negative_vote_test.go
+++ b/internal/consensus/feevote/negative_vote_test.go
@@ -1,0 +1,35 @@
+package feevote
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignedAndExplicitZeroVotesAreNotNoVote(t *testing.T) {
+	current := Stance{BaseFee: 10, ReserveBase: 10, ReserveIncrement: 10}
+	target := Stance{BaseFee: 20, ReserveBase: 10, ReserveIncrement: 10}
+
+	for _, test := range []struct {
+		name     string
+		value    uint64
+		negative bool
+	}{
+		{name: "explicit zero"},
+		{name: "legal negative", value: 1, negative: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			value := test.value
+			blob, err := DoVoting(256, current, target, []Vote{{
+				BaseFee:         &value,
+				BaseFeeNegative: test.negative,
+			}}, true)
+			require.NoError(t, err)
+			require.NotEmpty(t, blob)
+		})
+	}
+
+	blob, err := DoVoting(256, current, target, []Vote{{}}, true)
+	require.NoError(t, err)
+	require.Empty(t, blob, "missing vote counts for current and ties the local target")
+}

--- a/internal/consensus/types.go
+++ b/internal/consensus/types.go
@@ -331,6 +331,36 @@ type Validation struct {
 	Raw []byte
 }
 
+func (v *Validation) SetBaseFeeDrops(drops uint64, negative bool) {
+	v.BaseFeeDrops = drops
+	v.baseFeeDropsPresent = true
+	v.baseFeeDropsNegative = negative && drops != 0
+}
+
+func (v *Validation) BaseFeeDropsValue() (uint64, bool, bool) {
+	return v.BaseFeeDrops, v.baseFeeDropsNegative, v.baseFeeDropsPresent || v.BaseFeeDrops != 0
+}
+
+func (v *Validation) SetReserveBaseDrops(drops uint64, negative bool) {
+	v.ReserveBaseDrops = drops
+	v.reserveBaseDropsPresent = true
+	v.reserveBaseDropsNegative = negative && drops != 0
+}
+
+func (v *Validation) ReserveBaseDropsValue() (uint64, bool, bool) {
+	return v.ReserveBaseDrops, v.reserveBaseDropsNegative, v.reserveBaseDropsPresent || v.ReserveBaseDrops != 0
+}
+
+func (v *Validation) SetReserveIncrementDrops(drops uint64, negative bool) {
+	v.ReserveIncrementDrops = drops
+	v.reserveIncrementDropsPresent = true
+	v.reserveIncrementDropsNegative = negative && drops != 0
+}
+
+func (v *Validation) ReserveIncrementDropsValue() (uint64, bool, bool) {
+	return v.ReserveIncrementDrops, v.reserveIncrementDropsNegative, v.reserveIncrementDropsPresent || v.ReserveIncrementDrops != 0
+}
+
 // SetLoadFee records sfLoadFee as present, including when fee is zero.
 func (v *Validation) SetLoadFee(fee uint32) {
 	v.LoadFee = fee

--- a/internal/consensus/types.go
+++ b/internal/consensus/types.go
@@ -331,36 +331,6 @@ type Validation struct {
 	Raw []byte
 }
 
-func (v *Validation) SetBaseFeeDrops(drops uint64, negative bool) {
-	v.BaseFeeDrops = drops
-	v.baseFeeDropsPresent = true
-	v.baseFeeDropsNegative = negative && drops != 0
-}
-
-func (v *Validation) BaseFeeDropsValue() (uint64, bool, bool) {
-	return v.BaseFeeDrops, v.baseFeeDropsNegative, v.baseFeeDropsPresent || v.BaseFeeDrops != 0
-}
-
-func (v *Validation) SetReserveBaseDrops(drops uint64, negative bool) {
-	v.ReserveBaseDrops = drops
-	v.reserveBaseDropsPresent = true
-	v.reserveBaseDropsNegative = negative && drops != 0
-}
-
-func (v *Validation) ReserveBaseDropsValue() (uint64, bool, bool) {
-	return v.ReserveBaseDrops, v.reserveBaseDropsNegative, v.reserveBaseDropsPresent || v.ReserveBaseDrops != 0
-}
-
-func (v *Validation) SetReserveIncrementDrops(drops uint64, negative bool) {
-	v.ReserveIncrementDrops = drops
-	v.reserveIncrementDropsPresent = true
-	v.reserveIncrementDropsNegative = negative && drops != 0
-}
-
-func (v *Validation) ReserveIncrementDropsValue() (uint64, bool, bool) {
-	return v.ReserveIncrementDrops, v.reserveIncrementDropsNegative, v.reserveIncrementDropsPresent || v.ReserveIncrementDrops != 0
-}
-
 // SetLoadFee records sfLoadFee as present, including when fee is zero.
 func (v *Validation) SetLoadFee(fee uint32) {
 	v.LoadFee = fee

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -453,10 +453,11 @@ func peerSetScore(p *Peer, haveItem bool) int {
 // NotePeerHasTxSet records that the peer with id peerID advertised tx-set
 // root hash. No-op when the peer is unknown. Fed by the consensus router
 // on inbound mtHAVE_TRANSACTION_SET{tsHAVE}.
-func (o *Overlay) NotePeerHasTxSet(peerID PeerID, hash [32]byte) {
+func (o *Overlay) NotePeerHasTxSet(peerID PeerID, hash [32]byte) bool {
 	if peer, ok := o.getPeer(peerID); ok {
-		peer.AddTxSet(hash)
+		return peer.AddTxSet(hash)
 	}
+	return false
 }
 
 // SetLedgerHintProvider wires the hint source; nil suppresses headers.

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -686,18 +686,19 @@ func (p *Peer) PreviousLedger() ([32]byte, bool) {
 const maxRecentTxSets = 128
 
 // AddTxSet records that the peer advertised tx-set root hash (tsHAVE).
-// Duplicates are ignored; once the ring is full the oldest entry is
-// evicted. Mirrors rippled PeerImp::onMessage(TMHaveTransactionSet).
-func (p *Peer) AddTxSet(hash [32]byte) {
+// It reports whether the hash was inserted. Once the ring is full the
+// oldest entry is evicted. Mirrors rippled PeerImp::onMessage(TMHaveTransactionSet).
+func (p *Peer) AddTxSet(hash [32]byte) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if slices.Contains(p.recentTxSets, hash) {
-		return
+		return false
 	}
 	if len(p.recentTxSets) >= maxRecentTxSets {
 		p.recentTxSets = p.recentTxSets[1:]
 	}
 	p.recentTxSets = append(p.recentTxSets, hash)
+	return true
 }
 
 // HasTxSet reports whether the peer has advertised tx-set root hash.
@@ -1837,6 +1838,7 @@ func chargeForReason(reason string) resource.Charge {
 		"proof-path-resp-unnegotiated",
 		"compression-unnegotiated",
 		"get-objects-ledgerhash",
+		"have-set-hashsize",
 		"proposal-decode",
 		"validation-decode",
 		"validation-parse",

--- a/internal/peermanagement/peer_charge_reason_test.go
+++ b/internal/peermanagement/peer_charge_reason_test.go
@@ -1,0 +1,22 @@
+package peermanagement
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChargeForReasonHaveSetHashSize(t *testing.T) {
+	charge := chargeForReason("have-set-hashsize")
+
+	assert.Equal(t, resource.FeeMalformedRequest.Cost(), charge.Cost())
+	assert.Equal(t, resource.FeeMalformedRequest.Label(), charge.Label())
+}
+
+func TestChargeForReasonHaveSetDuplicate(t *testing.T) {
+	charge := chargeForReason("have-set-duplicate")
+
+	assert.Equal(t, resource.FeeUselessData.Cost(), charge.Cost())
+	assert.Equal(t, resource.FeeUselessData.Label(), charge.Label())
+}

--- a/internal/peermanagement/relay_select_test.go
+++ b/internal/peermanagement/relay_select_test.go
@@ -30,9 +30,9 @@ func TestPeer_TxSetRing(t *testing.T) {
 
 	a, b := hash32(0x01), hash32(0x02)
 	assert.False(t, p.HasTxSet(a))
-	p.AddTxSet(a)
-	p.AddTxSet(a) // duplicate ignored
-	p.AddTxSet(b)
+	assert.True(t, p.AddTxSet(a))
+	assert.False(t, p.AddTxSet(a))
+	assert.True(t, p.AddTxSet(b))
 	assert.True(t, p.HasTxSet(a))
 	assert.True(t, p.HasTxSet(b))
 
@@ -277,11 +277,12 @@ func TestOverlay_NotePeerHasTxSet(t *testing.T) {
 	p := newRelayTestPeer(1)
 	o.peers[p.id] = p
 
-	o.NotePeerHasTxSet(1, root)
+	assert.True(t, o.NotePeerHasTxSet(1, root))
 	assert.True(t, p.HasTxSet(root))
+	assert.False(t, o.NotePeerHasTxSet(1, root))
 
 	// Unknown peer: must not panic and must record nothing.
-	o.NotePeerHasTxSet(999, root)
+	assert.False(t, o.NotePeerHasTxSet(999, root))
 
 	got, ok := o.PeerWithTxSet(root, 0)
 	require.True(t, ok)


### PR DESCRIPTION
## Summary

- reject unsolicited, expired, terminal, and post-completion transaction-set data before allocation, learning, prewarming, or consensus mutation
- preserve rippled v3.2.0 transaction-set acquisition semantics, including canonical empty sets, ordered node processing, duplicate replies, and retry spacing
- enforce the complete rippled v3.2.0 STValidation template, canonical wire/value checks, and canonical signing-field order
- reject malformed HAVE_SET hashes, ignore non-HAVE statuses, and charge duplicate advertisements

This is the protocol-ingress slice of the planned four-PR implementation. Lifecycle ownership, bounded state/model ownership, and structural decomposition remain separate reviewable slices.

## Test plan

- [x] `go test -count=1 ./...`
- [x] `go test -race -count=1 ./internal/consensus/adaptor ./internal/consensus/rcl ./internal/peermanagement/...`
- [x] `just test-core`
- [x] `just build-all`
- [x] `just build-nocgo`
- [x] `go vet ./internal/consensus/... ./internal/peermanagement/...`
- [x] `golangci-lint run ./internal/consensus/adaptor ./internal/peermanagement/...`
- [x] `just lint`
- [x] `go mod tidy -diff`
- [x] `git diff --check`

Part of #1453


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction-set synchronization by rejecting malformed, stale, duplicate, and unsolicited data.
  * Added safer retry and recovery behavior for incomplete or invalid transaction sets.
  * Handled zero transaction-set requests locally without unnecessary network activity.
  * Strengthened validation-message parsing, serialization, field handling, and signature verification.
  * Preserved explicit validation flags, close times, signed fee values, and supported negative fee votes.

* **Reliability**
  * Improved peer tracking and duplicate advertisement handling.
  * Added canonical signature enforcement for validation messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->