### PR TITLE
feat: implement Sponsor transaction authorization

### DIFF
--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -754,7 +754,7 @@ func TestAllOrNothing(t *testing.T) {
 		preAlice := env.Balance(alice)
 		preBob := env.Balance(bob)
 
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
 		seq := env.Seq(alice)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
@@ -1413,6 +1413,7 @@ func TestBatchDelegate(t *testing.T) {
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(innerTx0).
 			AddInnerTx(innerTx1).
+			AddSigner(bob, "").
 			Build()
 
 		result := env.Submit(batch)
@@ -1462,7 +1463,7 @@ func TestBatchDelegate(t *testing.T) {
 		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(innerTx0).
 			AddInnerTx(innerTx1).
-			AddSigner(bob, "DEADBEEF").
+			AddSigner(carol, "").
 			Build()
 
 		result := env.Submit(batch)
@@ -1726,9 +1727,7 @@ func TestTicketsOpenLedger(t *testing.T) {
 // =============================================================================
 
 func TestBatchTxQueue(t *testing.T) {
-	t.Run("outer batch txns count towards queue size", func(t *testing.T) {
-		// Reference: rippled Batch_test.cpp testBatchTxQueue() first sub-test
-		// "only outer batch transactions are counter towards the queue size"
+	t.Run("batch cannot queue", func(t *testing.T) {
 		cfg := makeSmallQueueConfig(2)
 		env := jtx.NewTestEnvWithTxQ(t, cfg)
 		env.EnableFeatureNow("Batch")
@@ -1760,17 +1759,18 @@ func TestBatchTxQueue(t *testing.T) {
 		bobSeq := env.Seq(bob)
 		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
 
-		// Queue Batch: regular batch fee is too low to bypass escalation.
+		// A Batch paying only its base fee cannot bypass escalation and is rejected
+		// instead of entering the queue.
 		batch := NewBatchBuilder(alice, aliceSeq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+1)).
 			AddInnerTx(MakeInnerPaymentXRP(bob, alice, 5, bobSeq)).
 			AddSigner(bob, "").
 			Build()
 		result = env.Submit(batch)
-		jtx.RequireTxFail(t, result, "terQUEUED")
-		checkMetrics(t, env, 2, nil, 3, 2)
+		jtx.RequireTxFail(t, result, "telCAN_NOT_QUEUE")
+		checkMetrics(t, env, 1, nil, 3, 2)
 
-		// Replace Queued Batch with open ledger fee.
+		// Paying the open-ledger fee allows direct application.
 		olFee := env.OpenLedgerFee(batchFee)
 		batch2 := NewBatchBuilder(alice, aliceSeq, olFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 10, aliceSeq+1)).

--- a/internal/testing/batch/batch_test.go
+++ b/internal/testing/batch/batch_test.go
@@ -754,7 +754,7 @@ func TestAllOrNothing(t *testing.T) {
 		preAlice := env.Balance(alice)
 		preBob := env.Balance(bob)
 
-		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
+		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
 		seq := env.Seq(alice)
 		batch := NewBatchBuilder(alice, seq, batchFee, batchtx.BatchFlagAllOrNothing).
 			AddInnerTx(MakeInnerPaymentXRP(alice, bob, 1, seq+1)).
@@ -1402,7 +1402,7 @@ func TestBatchDelegate(t *testing.T) {
 		preAlice := env.Balance(alice)
 		preBob := env.Balance(bob)
 
-		batchFee := CalcBatchFeeFromEnv(env, 0, 2)
+		batchFee := CalcBatchFeeFromEnv(env, 1, 2)
 		seq := env.Seq(alice)
 
 		// Inner tx[0]: payment from alice to bob, delegated to bob

--- a/internal/testing/sponsor/sponsor_test.go
+++ b/internal/testing/sponsor/sponsor_test.go
@@ -9,7 +9,11 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	accounttx "github.com/LeJamon/go-xrpl/internal/tx/account"
 	checktx "github.com/LeJamon/go-xrpl/internal/tx/check"
+	delegatetx "github.com/LeJamon/go-xrpl/internal/tx/delegate"
+	paymenttx "github.com/LeJamon/go-xrpl/internal/tx/payment"
+	signtx "github.com/LeJamon/go-xrpl/internal/tx/sign"
 	sponsortx "github.com/LeJamon/go-xrpl/internal/tx/sponsor"
 	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/stretchr/testify/require"
@@ -45,6 +49,124 @@ func setSponsorship(
 	}
 	txn.RemainingOwnerCount = remaining
 	return env.Submit(txn)
+}
+
+func setFeeSponsorship(
+	env *jtx.TestEnv,
+	sponsor, sponsee *jtx.Account,
+	feeDrops, maxFeeDrops uint64,
+) jtx.TxResult {
+	txn := sponsortx.NewSponsorshipSet(sponsor.Address)
+	txn.Sponsee = sponsee.Address
+	feeAmount := tx.NewXRPAmount(int64(feeDrops))
+	txn.FeeAmount = &feeAmount
+	if maxFeeDrops != 0 {
+		maxFee := tx.NewXRPAmount(int64(maxFeeDrops))
+		txn.MaxFee = &maxFee
+	}
+	return env.Submit(txn)
+}
+
+func grantDelegatePermission(
+	t *testing.T,
+	env *jtx.TestEnv,
+	source, delegate *jtx.Account,
+	permission string,
+) {
+	t.Helper()
+	env.EnableFeature("PermissionDelegationV1_1")
+	env.Close()
+	transaction := delegatetx.NewDelegateSet(source.Address)
+	transaction.Authorize = delegate.Address
+	transaction.Permissions = []delegatetx.Permission{{
+		Permission: delegatetx.PermissionData{PermissionValue: permission},
+	}}
+	require.Equal(t, "tesSUCCESS", env.SubmitSignedWith(transaction, source).Code)
+	env.Close()
+}
+
+func signingPrivateKey(account *jtx.Account) string {
+	prefix := "00"
+	if account.IsEd25519() {
+		prefix = "ED"
+	}
+	return prefix + account.PrivateKeyHex()
+}
+
+// attachSponsorSignature fills every ordinary signed field first, then signs
+// the same STX projection as the transaction's top-level account.
+func attachSponsorSignature(
+	t *testing.T,
+	env *jtx.TestEnv,
+	transaction tx.Transaction,
+	source, signer *jtx.Account,
+) {
+	t.Helper()
+	attachSponsorSignatureFor(t, env, transaction, source, source, signer)
+}
+
+func attachSponsorSignatureFor(
+	t *testing.T,
+	env *jtx.TestEnv,
+	transaction tx.Transaction,
+	source, transactionSigner, sponsorSigner *jtx.Account,
+) {
+	t.Helper()
+	common := transaction.GetCommon()
+	if common.Sequence == nil && common.TicketSequence == nil {
+		sequence := env.Seq(source)
+		common.Sequence = &sequence
+	}
+	if common.Fee == "" {
+		common.Fee = "10"
+	}
+	common.SigningPubKey = transactionSigner.PublicKeyHex()
+	signature, err := signtx.SignSponsor(
+		transaction,
+		sponsorSigner.PublicKeyHex(),
+		signingPrivateKey(sponsorSigner),
+	)
+	require.NoError(t, err)
+	common.SponsorSignature = signature
+}
+
+func attachSponsorMultiSignature(
+	t *testing.T,
+	env *jtx.TestEnv,
+	transaction tx.Transaction,
+	source *jtx.Account,
+	signers ...*jtx.Account,
+) {
+	t.Helper()
+	common := transaction.GetCommon()
+	if common.Sequence == nil && common.TicketSequence == nil {
+		sequence := env.Seq(source)
+		common.Sequence = &sequence
+	}
+	common.SigningPubKey = source.PublicKeyHex()
+
+	wrappers := make([]tx.SignerWrapper, 0, len(signers))
+	for _, signer := range signers {
+		signature, err := signtx.SignTransactionForMultiSign(
+			transaction,
+			signer.Address,
+			signingPrivateKey(signer),
+		)
+		require.NoError(t, err)
+		wrappers = append(wrappers, tx.SignerWrapper{Signer: tx.Signer{
+			Account:       signer.Address,
+			SigningPubKey: signer.PublicKeyHex(),
+			TxnSignature:  signature,
+		}})
+	}
+	sort.Slice(wrappers, func(i, j int) bool {
+		left, leftErr := state.DecodeAccountID(wrappers[i].Signer.Account)
+		right, rightErr := state.DecodeAccountID(wrappers[j].Signer.Account)
+		require.NoError(t, leftErr)
+		require.NoError(t, rightErr)
+		return string(left[:]) < string(right[:])
+	})
+	common.SponsorSignature = &tx.SponsorSignature{Signers: wrappers}
 }
 
 func sponsorshipEntry(t *testing.T, env *jtx.TestEnv, sponsor, sponsee *jtx.Account) *state.SponsorshipData {
@@ -469,6 +591,607 @@ func TestSponsorshipTransferAuthorizationLimitAndRollback(t *testing.T) {
 	require.Equal(t, uint32(0), sponsorshipEntry(t, env, sponsor, sponsee).RemainingOwnerCount)
 }
 
+func TestSponsorSingleSignatureAuthorizationAndReplayProtection(t *testing.T) {
+	t.Run("master key", func(t *testing.T) {
+		env, source, _, sponsor, _ := sponsorEnv(t)
+		sourceBefore := env.Balance(source)
+		sponsorBefore := env.Balance(sponsor)
+
+		transaction := accounttx.NewAccountSet(source.Address)
+		transaction.Fee = "10"
+		transaction.Sponsor = sponsor.Address
+		flags := tx.SpfSponsorFee
+		transaction.SponsorFlags = &flags
+		attachSponsorSignature(t, env, transaction, source, sponsor)
+
+		result := env.SubmitSigned(transaction)
+		require.Equal(t, "tesSUCCESS", result.Code)
+		require.Equal(t, sourceBefore, env.Balance(source))
+		require.Equal(t, sponsorBefore-10, env.Balance(sponsor))
+	})
+
+	t.Run("stale after mutation", func(t *testing.T) {
+		env, source, _, sponsor, _ := sponsorEnv(t)
+		sourceBefore := env.Balance(source)
+		sponsorBefore := env.Balance(sponsor)
+		sequenceBefore := env.Seq(source)
+
+		transaction := accounttx.NewAccountSet(source.Address)
+		transaction.Fee = "10"
+		transaction.Sponsor = sponsor.Address
+		flags := tx.SpfSponsorFee
+		transaction.SponsorFlags = &flags
+		attachSponsorSignature(t, env, transaction, source, sponsor)
+		transaction.Fee = "11"
+
+		result := env.SubmitSigned(transaction)
+		require.Equal(t, "temINVALID", result.Code)
+		require.Equal(t, sequenceBefore, env.Seq(source))
+		require.Equal(t, sourceBefore, env.Balance(source))
+		require.Equal(t, sponsorBefore, env.Balance(sponsor))
+	})
+
+	t.Run("unauthorized key", func(t *testing.T) {
+		env, source, _, sponsor, wrongSigner := sponsorEnv(t)
+		sourceBefore := env.Balance(source)
+		sponsorBefore := env.Balance(sponsor)
+		sequenceBefore := env.Seq(source)
+
+		transaction := accounttx.NewAccountSet(source.Address)
+		transaction.Fee = "10"
+		transaction.Sponsor = sponsor.Address
+		flags := tx.SpfSponsorFee
+		transaction.SponsorFlags = &flags
+		attachSponsorSignature(t, env, transaction, source, wrongSigner)
+
+		result := env.SubmitSigned(transaction)
+		require.Equal(t, "tefBAD_AUTH", result.Code)
+		require.Equal(t, sequenceBefore, env.Seq(source))
+		require.Equal(t, sourceBefore, env.Balance(source))
+		require.Equal(t, sponsorBefore, env.Balance(sponsor))
+	})
+
+	t.Run("regular key and disabled master", func(t *testing.T) {
+		env, source, _, sponsor, regularKey := sponsorEnv(t)
+		env.SetRegularKey(sponsor, regularKey)
+		env.DisableMasterKey(sponsor)
+
+		masterSigned := accounttx.NewAccountSet(source.Address)
+		masterSigned.Fee = "10"
+		masterSigned.Sponsor = sponsor.Address
+		flags := tx.SpfSponsorFee
+		masterSigned.SponsorFlags = &flags
+		attachSponsorSignature(t, env, masterSigned, source, sponsor)
+		sponsorBefore := env.Balance(sponsor)
+
+		result := env.SubmitSigned(masterSigned)
+		require.Equal(t, "tefMASTER_DISABLED", result.Code)
+		require.Equal(t, sponsorBefore, env.Balance(sponsor))
+
+		regularSigned := accounttx.NewAccountSet(source.Address)
+		regularSigned.Fee = "10"
+		regularSigned.Sponsor = sponsor.Address
+		regularSigned.SponsorFlags = &flags
+		attachSponsorSignature(t, env, regularSigned, source, regularKey)
+
+		result = env.SubmitSigned(regularSigned)
+		require.Equal(t, "tesSUCCESS", result.Code)
+		require.Equal(t, sponsorBefore-10, env.Balance(sponsor))
+	})
+}
+
+func TestSponsorAuthorizationFailuresNeverDebit(t *testing.T) {
+	t.Run("missing relationship and signature", func(t *testing.T) {
+		env, source, _, sponsor, _ := sponsorEnv(t)
+		sourceBefore := env.Balance(source)
+		sponsorBefore := env.Balance(sponsor)
+		sequenceBefore := env.Seq(source)
+
+		transaction := accounttx.NewAccountSet(source.Address)
+		transaction.Fee = "10"
+		transaction.Sponsor = sponsor.Address
+		flags := tx.SpfSponsorFee
+		transaction.SponsorFlags = &flags
+
+		require.Equal(t, "terNO_PERMISSION", env.Submit(transaction).Code)
+		require.Equal(t, sequenceBefore, env.Seq(source))
+		require.Equal(t, sourceBefore, env.Balance(source))
+		require.Equal(t, sponsorBefore, env.Balance(sponsor))
+	})
+
+	t.Run("missing sponsor account", func(t *testing.T) {
+		env, source, _, _, _ := sponsorEnv(t)
+		missingSponsor := jtx.NewAccount("missing-fee-sponsor")
+		sourceBefore := env.Balance(source)
+		sequenceBefore := env.Seq(source)
+
+		transaction := accounttx.NewAccountSet(source.Address)
+		transaction.Fee = "10"
+		transaction.Sponsor = missingSponsor.Address
+		flags := tx.SpfSponsorFee
+		transaction.SponsorFlags = &flags
+		transaction.SponsorSignature = &tx.SponsorSignature{}
+
+		require.Equal(t, "terNO_ACCOUNT", env.Submit(transaction).Code)
+		require.Equal(t, sequenceBefore, env.Seq(source))
+		require.Equal(t, sourceBefore, env.Balance(source))
+	})
+}
+
+func TestSponsorSignatureStructuralFailures(t *testing.T) {
+	env, source, _, sponsor, _ := sponsorEnv(t)
+	signer1 := jtx.NewAccount("sponsor-structure-signer-1")
+	signer2 := jtx.NewAccount("sponsor-structure-signer-2")
+	flags := tx.SpfSponsorFee
+
+	sorted := []tx.SignerWrapper{
+		{Signer: tx.Signer{Account: signer1.Address}},
+		{Signer: tx.Signer{Account: signer2.Address}},
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		left, _ := state.DecodeAccountID(sorted[i].Signer.Account)
+		right, _ := state.DecodeAccountID(sorted[j].Signer.Account)
+		return string(left[:]) < string(right[:])
+	})
+	unsorted := append([]tx.SignerWrapper(nil), sorted...)
+	unsorted[0], unsorted[1] = unsorted[1], unsorted[0]
+
+	testCases := []struct {
+		name      string
+		signature *tx.SponsorSignature
+	}{
+		{
+			name: "single and multi",
+			signature: &tx.SponsorSignature{
+				SigningPubKey: sponsor.PublicKeyHex(),
+				TxnSignature:  "AA",
+				Signers:       sorted,
+			},
+		},
+		{
+			name:      "unsorted multisigners",
+			signature: &tx.SponsorSignature{Signers: unsorted},
+		},
+		{
+			name:      "duplicate multisigners",
+			signature: &tx.SponsorSignature{Signers: []tx.SignerWrapper{sorted[0], sorted[0]}},
+		},
+		{
+			name:      "signature without key",
+			signature: &tx.SponsorSignature{TxnSignature: "AA"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			sourceBefore := env.Balance(source)
+			sponsorBefore := env.Balance(sponsor)
+			sequenceBefore := env.Seq(source)
+			transaction := accounttx.NewAccountSet(source.Address)
+			transaction.Fee = "10"
+			transaction.Sponsor = sponsor.Address
+			transaction.SponsorFlags = &flags
+			transaction.SponsorSignature = testCase.signature
+
+			require.Equal(t, "temINVALID", env.Submit(transaction).Code)
+			require.Equal(t, sequenceBefore, env.Seq(source))
+			require.Equal(t, sourceBefore, env.Balance(source))
+			require.Equal(t, sponsorBefore, env.Balance(sponsor))
+		})
+	}
+}
+
+func TestSponsorMultisignAuthorizationAndFeeUnits(t *testing.T) {
+	env, source, _, sponsor, _ := sponsorEnv(t)
+	signer1 := jtx.NewAccount("sponsor-multisigner-1")
+	signer2 := jtx.NewAccount("sponsor-multisigner-2")
+	env.SetSignerList(sponsor, 2, []jtx.TestSigner{
+		{Account: signer1, Weight: 1},
+		{Account: signer2, Weight: 1},
+	})
+
+	flags := tx.SpfSponsorFee
+	oneSigner := accounttx.NewAccountSet(source.Address)
+	oneSigner.Fee = "20"
+	oneSigner.Sponsor = sponsor.Address
+	oneSigner.SponsorFlags = &flags
+	attachSponsorMultiSignature(t, env, oneSigner, source, signer1)
+	require.Equal(t, "tefBAD_QUORUM", env.SubmitSigned(oneSigner).Code)
+
+	underpaid := accounttx.NewAccountSet(source.Address)
+	underpaid.Fee = "29"
+	underpaid.Sponsor = sponsor.Address
+	underpaid.SponsorFlags = &flags
+	attachSponsorMultiSignature(t, env, underpaid, source, signer1, signer2)
+	require.Equal(t, "telINSUF_FEE_P", env.SubmitSigned(underpaid).Code)
+
+	sourceBefore := env.Balance(source)
+	sponsorBefore := env.Balance(sponsor)
+	valid := accounttx.NewAccountSet(source.Address)
+	valid.Fee = "30"
+	valid.Sponsor = sponsor.Address
+	valid.SponsorFlags = &flags
+	attachSponsorMultiSignature(t, env, valid, source, signer1, signer2)
+	require.Equal(t, "tesSUCCESS", env.SubmitSigned(valid).Code)
+	require.Equal(t, sourceBefore, env.Balance(source))
+	require.Equal(t, sponsorBefore-30, env.Balance(sponsor))
+}
+
+func TestTopLevelMultisignWithSponsorFee(t *testing.T) {
+	env, source, _, sponsor, _ := sponsorEnv(t)
+	sourceSigner := jtx.NewAccount("source-multisigner")
+	env.SetSignerList(source, 1, []jtx.TestSigner{{Account: sourceSigner, Weight: 1}})
+
+	transaction := accounttx.NewAccountSet(source.Address)
+	transaction.Fee = "20"
+	sequence := env.Seq(source)
+	transaction.Sequence = &sequence
+	transaction.SigningPubKey = ""
+	transaction.Sponsor = sponsor.Address
+	flags := tx.SpfSponsorFee
+	transaction.SponsorFlags = &flags
+	sponsorSignature, err := signtx.SignSponsor(
+		transaction,
+		sponsor.PublicKeyHex(),
+		signingPrivateKey(sponsor),
+	)
+	require.NoError(t, err)
+	transaction.SponsorSignature = sponsorSignature
+
+	sourceBefore := env.Balance(source)
+	sponsorBefore := env.Balance(sponsor)
+	require.Equal(t, "tesSUCCESS", env.SubmitMultiSigned(transaction, []*jtx.Account{sourceSigner}).Code)
+	require.Equal(t, sourceBefore, env.Balance(source))
+	require.Equal(t, sponsorBefore-20, env.Balance(sponsor))
+}
+
+func TestSponsorPrefundedFeeSelectionLimitsAndRecovery(t *testing.T) {
+	env, source, destination, sponsor, _ := sponsorEnv(t)
+	require.Equal(t, "tesSUCCESS", setFeeSponsorship(env, sponsor, source, 100, 10).Code)
+
+	sourceBefore := env.Balance(source)
+	destinationBefore := env.Balance(destination)
+	sponsorBefore := env.Balance(sponsor)
+	flags := tx.SpfSponsorFee
+	payment := paymenttx.NewPayment(source.Address, destination.Address, tx.NewXRPAmount(1_000))
+	payment.Fee = "10"
+	payment.Sponsor = sponsor.Address
+	payment.SponsorFlags = &flags
+	// Even with a co-signature present, the existing pre-funded relationship
+	// remains the selected payer.
+	payment.SponsorSignature = &tx.SponsorSignature{}
+	require.Equal(t, "tesSUCCESS", env.Submit(payment).Code)
+	require.Equal(t, sourceBefore-1_000, env.Balance(source))
+	require.Equal(t, destinationBefore+1_000, env.Balance(destination))
+	require.Equal(t, sponsorBefore, env.Balance(sponsor))
+	require.Equal(t, uint64(90), sponsorshipEntry(t, env, sponsor, source).FeeAmount)
+
+	overMax := accounttx.NewAccountSet(source.Address)
+	overMax.Fee = "11"
+	overMax.Sponsor = sponsor.Address
+	overMax.SponsorFlags = &flags
+	require.Equal(t, "terINSUF_FEE_B", env.Submit(overMax).Code)
+	require.Equal(t, uint64(90), sponsorshipEntry(t, env, sponsor, source).FeeAmount)
+
+	sourceBefore = env.Balance(source)
+	destinationBefore = env.Balance(destination)
+	failingPayment := paymenttx.NewPayment(
+		source.Address,
+		destination.Address,
+		tx.NewXRPAmount(jtx.XRP(20_000)),
+	)
+	failingPayment.Fee = "10"
+	failingPayment.Sponsor = sponsor.Address
+	failingPayment.SponsorFlags = &flags
+	require.Equal(t, "tecUNFUNDED_PAYMENT", env.Submit(failingPayment).Code)
+	require.Equal(t, sourceBefore, env.Balance(source))
+	require.Equal(t, destinationBefore, env.Balance(destination))
+	require.Equal(t, sponsorBefore, env.Balance(sponsor))
+	require.Equal(t, uint64(80), sponsorshipEntry(t, env, sponsor, source).FeeAmount)
+
+	// On a closed view, a fee above MaxFee claims only the authorized cap.
+	env.SetOpenLedger(false)
+	closedLedgerFailure := accounttx.NewAccountSet(source.Address)
+	closedLedgerFailure.Fee = "1000"
+	closedLedgerFailure.Sponsor = sponsor.Address
+	closedLedgerFailure.SponsorFlags = &flags
+	require.Equal(t, "tecINSUFF_FEE", env.Submit(closedLedgerFailure).Code)
+	require.Equal(t, uint64(70), sponsorshipEntry(t, env, sponsor, source).FeeAmount)
+	require.Equal(t, sponsorBefore, env.Balance(sponsor))
+}
+
+func TestReserveOnlySponsorDoesNotPayFee(t *testing.T) {
+	env, source, _, sponsor, _ := sponsorEnv(t)
+	transaction := accounttx.NewAccountSet(source.Address)
+	transaction.Fee = "10"
+	transaction.Sponsor = sponsor.Address
+	flags := tx.SpfSponsorReserve
+	transaction.SponsorFlags = &flags
+	attachSponsorSignature(t, env, transaction, source, sponsor)
+
+	sourceBefore := env.Balance(source)
+	sponsorBefore := env.Balance(sponsor)
+	require.Equal(t, "tesSUCCESS", env.SubmitSigned(transaction).Code)
+	require.Equal(t, sourceBefore-10, env.Balance(source))
+	require.Equal(t, sponsorBefore, env.Balance(sponsor))
+}
+
+func TestCosignedSponsorFeeNeverConsumesReserve(t *testing.T) {
+	t.Run("exactly fee above reserve", func(t *testing.T) {
+		env, source, _, sponsor, _ := sponsorEnv(t)
+		setAccountBalance(t, env, sponsor, env.ReserveBase()+10)
+		sourceBefore := env.Balance(source)
+
+		transaction := accounttx.NewAccountSet(source.Address)
+		transaction.Fee = "10"
+		transaction.Sponsor = sponsor.Address
+		flags := tx.SpfSponsorFee
+		transaction.SponsorFlags = &flags
+		attachSponsorSignature(t, env, transaction, source, sponsor)
+
+		require.Equal(t, "tesSUCCESS", env.SubmitSigned(transaction).Code)
+		require.Equal(t, sourceBefore, env.Balance(source))
+		require.Equal(t, env.ReserveBase(), env.Balance(sponsor))
+	})
+
+	t.Run("one drop short", func(t *testing.T) {
+		env, source, _, sponsor, _ := sponsorEnv(t)
+		setAccountBalance(t, env, sponsor, env.ReserveBase()+9)
+		sourceBefore := env.Balance(source)
+		sponsorBefore := env.Balance(sponsor)
+		sequenceBefore := env.Seq(source)
+
+		transaction := accounttx.NewAccountSet(source.Address)
+		transaction.Fee = "10"
+		transaction.Sponsor = sponsor.Address
+		flags := tx.SpfSponsorFee
+		transaction.SponsorFlags = &flags
+		attachSponsorSignature(t, env, transaction, source, sponsor)
+
+		require.Equal(t, "terINSUF_FEE_B", env.SubmitSigned(transaction).Code)
+		require.Equal(t, sequenceBefore, env.Seq(source))
+		require.Equal(t, sourceBefore, env.Balance(source))
+		require.Equal(t, sponsorBefore, env.Balance(sponsor))
+	})
+}
+
+func TestSponsorFeeWithTicketConsumesTicketNotSequence(t *testing.T) {
+	env, source, _, sponsor, _ := sponsorEnv(t)
+	ticketSequence := env.CreateTickets(source, 1)
+	require.Equal(t, "tesSUCCESS", setFeeSponsorship(env, sponsor, source, 30, 0).Code)
+
+	sourceBalance := env.Balance(source)
+	sourceSequence := env.Seq(source)
+	transaction := accounttx.NewAccountSet(source.Address)
+	transaction.Fee = "10"
+	transaction.Sponsor = sponsor.Address
+	flags := tx.SpfSponsorFee
+	transaction.SponsorFlags = &flags
+	jtx.WithTicketSeq(transaction, ticketSequence)
+
+	require.Equal(t, "tesSUCCESS", env.Submit(transaction).Code)
+	require.Equal(t, sourceBalance, env.Balance(source))
+	require.Equal(t, sourceSequence, env.Seq(source))
+	require.Zero(t, env.TicketCount(source))
+	require.Equal(t, uint64(20), sponsorshipEntry(t, env, sponsor, source).FeeAmount)
+}
+
+func TestDelegatedTransactionSponsorFeePayer(t *testing.T) {
+	t.Run("co-signed sponsor account", func(t *testing.T) {
+		env, source, destination, sponsor, delegate := sponsorEnv(t)
+		grantDelegatePermission(t, env, source, delegate, "Payment")
+
+		sourceBefore := env.Balance(source)
+		delegateBefore := env.Balance(delegate)
+		destinationBefore := env.Balance(destination)
+		sponsorBefore := env.Balance(sponsor)
+
+		payment := paymenttx.NewPayment(source.Address, destination.Address, tx.NewXRPAmount(1_000))
+		payment.Fee = "10"
+		payment.Delegate = delegate.Address
+		payment.Sponsor = sponsor.Address
+		flags := tx.SpfSponsorFee
+		payment.SponsorFlags = &flags
+		attachSponsorSignatureFor(t, env, payment, source, delegate, sponsor)
+
+		require.Equal(t, "tesSUCCESS", env.SubmitSignedWith(payment, delegate).Code)
+		require.Equal(t, sourceBefore-1_000, env.Balance(source))
+		require.Equal(t, delegateBefore, env.Balance(delegate))
+		require.Equal(t, destinationBefore+1_000, env.Balance(destination))
+		require.Equal(t, sponsorBefore-10, env.Balance(sponsor))
+	})
+
+	t.Run("pre-funded relationship targets delegate", func(t *testing.T) {
+		env, source, destination, sponsor, delegate := sponsorEnv(t)
+		grantDelegatePermission(t, env, source, delegate, "Payment")
+		require.Equal(t, "tesSUCCESS", setFeeSponsorship(env, sponsor, delegate, 100, 0).Code)
+		env.Close()
+
+		sourceBefore := env.Balance(source)
+		delegateBefore := env.Balance(delegate)
+		destinationBefore := env.Balance(destination)
+		sponsorBefore := env.Balance(sponsor)
+		require.False(t, env.LedgerEntryExists(keylet.Sponsorship(sponsor.ID, source.ID)))
+
+		payment := paymenttx.NewPayment(source.Address, destination.Address, tx.NewXRPAmount(1_000))
+		payment.Fee = "10"
+		payment.Delegate = delegate.Address
+		payment.Sponsor = sponsor.Address
+		flags := tx.SpfSponsorFee
+		payment.SponsorFlags = &flags
+
+		require.Equal(t, "tesSUCCESS", env.SubmitSignedWith(payment, delegate).Code)
+		require.Equal(t, sourceBefore-1_000, env.Balance(source))
+		require.Equal(t, delegateBefore, env.Balance(delegate))
+		require.Equal(t, destinationBefore+1_000, env.Balance(destination))
+		require.Equal(t, sponsorBefore, env.Balance(sponsor))
+		require.Equal(t, uint64(90), sponsorshipEntry(t, env, sponsor, delegate).FeeAmount)
+	})
+}
+
+func TestDelegatedTransactionRejectsReserveSponsor(t *testing.T) {
+	for _, testCase := range []struct {
+		name      string
+		prefunded bool
+	}{
+		{name: "co-signed"},
+		{name: "pre-funded", prefunded: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			env, source, destination, sponsor, delegate := sponsorEnv(t)
+			grantDelegatePermission(t, env, source, delegate, "CheckCreate")
+			if testCase.prefunded {
+				remaining := uint32(1)
+				require.Equal(t, "tesSUCCESS", setSponsorship(env, sponsor, delegate, 0, &remaining).Code)
+			}
+			env.Close()
+
+			sourceBefore := env.Balance(source)
+			delegateBefore := env.Balance(delegate)
+			sponsorBefore := env.Balance(sponsor)
+			sequenceBefore := env.Seq(source)
+
+			transaction := checktx.NewCheckCreate(
+				source.Address,
+				destination.Address,
+				tx.NewXRPAmount(1_000),
+			)
+			transaction.Delegate = delegate.Address
+			transaction.Sponsor = sponsor.Address
+			flags := tx.SpfSponsorReserve
+			transaction.SponsorFlags = &flags
+			if !testCase.prefunded {
+				attachSponsorSignatureFor(t, env, transaction, source, delegate, sponsor)
+			}
+
+			require.Equal(t, "temINVALID", env.SubmitSignedWith(transaction, delegate).Code)
+			require.Equal(t, sequenceBefore, env.Seq(source))
+			require.Equal(t, sourceBefore, env.Balance(source))
+			require.Equal(t, delegateBefore, env.Balance(delegate))
+			require.Equal(t, sponsorBefore, env.Balance(sponsor))
+		})
+	}
+}
+
+func TestSponsorCreatedAccount(t *testing.T) {
+	t.Run("one drop account", func(t *testing.T) {
+		env, source, _, _, _ := sponsorEnv(t)
+		destination := jtx.NewAccount("sponsor-created-destination")
+		sourceBefore := env.Balance(source)
+
+		payment := paymenttx.NewPayment(source.Address, destination.Address, tx.NewXRPAmount(1))
+		payment.Fee = "10"
+		payment.SetFlags(paymenttx.PaymentFlagSponsorCreatedAccount)
+		require.Equal(t, "tesSUCCESS", env.Submit(payment).Code)
+
+		require.Equal(t, sourceBefore-11, env.Balance(source))
+		require.Equal(t, uint64(1), env.Balance(destination))
+		destinationRoot := accountState(t, env, destination)
+		require.True(t, destinationRoot.HasSponsor)
+		require.Equal(t, source.Address, destinationRoot.Sponsor)
+		require.Equal(t, uint32(1), accountState(t, env, source).SponsoringAccountCount)
+	})
+
+	t.Run("existing destination", func(t *testing.T) {
+		env, source, destination, _, _ := sponsorEnv(t)
+		sourceBefore := env.Balance(source)
+		destinationBefore := env.Balance(destination)
+
+		payment := paymenttx.NewPayment(source.Address, destination.Address, tx.NewXRPAmount(1))
+		payment.Fee = "10"
+		payment.SetFlags(paymenttx.PaymentFlagSponsorCreatedAccount)
+		require.Equal(t, "tecNO_SPONSOR_PERMISSION", env.Submit(payment).Code)
+		require.Equal(t, sourceBefore-10, env.Balance(source))
+		require.Equal(t, destinationBefore, env.Balance(destination))
+		require.Zero(t, accountState(t, env, source).SponsoringAccountCount)
+	})
+
+	t.Run("source reserve boundary", func(t *testing.T) {
+		t.Run("one drop short", func(t *testing.T) {
+			env, source, _, _, _ := sponsorEnv(t)
+			destination := jtx.NewAccount("sponsor-created-boundary-short")
+			required := 2*env.ReserveBase() + 1
+			setAccountBalance(t, env, source, required-1)
+
+			payment := paymenttx.NewPayment(source.Address, destination.Address, tx.NewXRPAmount(1))
+			payment.Fee = "10"
+			payment.SetFlags(paymenttx.PaymentFlagSponsorCreatedAccount)
+			require.Equal(t, "tecUNFUNDED_PAYMENT", env.Submit(payment).Code)
+			require.False(t, env.LedgerEntryExists(keylet.Account(destination.ID)))
+			require.Equal(t, required-1-10, env.Balance(source))
+			require.Zero(t, accountState(t, env, source).SponsoringAccountCount)
+		})
+
+		t.Run("exact", func(t *testing.T) {
+			env, source, _, _, _ := sponsorEnv(t)
+			destination := jtx.NewAccount("sponsor-created-boundary-exact")
+			required := 2*env.ReserveBase() + 1
+			setAccountBalance(t, env, source, required)
+
+			payment := paymenttx.NewPayment(source.Address, destination.Address, tx.NewXRPAmount(1))
+			payment.Fee = "10"
+			payment.SetFlags(paymenttx.PaymentFlagSponsorCreatedAccount)
+			require.Equal(t, "tesSUCCESS", env.Submit(payment).Code)
+			require.Equal(t, required-11, env.Balance(source))
+			require.Equal(t, uint32(1), accountState(t, env, source).SponsoringAccountCount)
+		})
+	})
+}
+
+func TestSponsorCreatedAccountPreflightMatrix(t *testing.T) {
+	env, source, _, issuer, _ := sponsorEnv(t)
+	destination := jtx.NewAccount("sponsor-created-preflight-destination")
+
+	testCases := []struct {
+		name    string
+		mutate  func(*paymenttx.Payment)
+		wantTER string
+	}{
+		{
+			name: "path flag",
+			mutate: func(payment *paymenttx.Payment) {
+				payment.SetFlags(
+					paymenttx.PaymentFlagSponsorCreatedAccount |
+						paymenttx.PaymentFlagPartialPayment,
+				)
+			},
+			wantTER: "temINVALID_FLAG",
+		},
+		{
+			name: "SendMax",
+			mutate: func(payment *paymenttx.Payment) {
+				sendMax := tx.NewXRPAmount(2)
+				payment.SendMax = &sendMax
+			},
+			wantTER: "temINVALID",
+		},
+		{
+			name: "Paths",
+			mutate: func(payment *paymenttx.Payment) {
+				payment.Paths = [][]paymenttx.PathStep{{{Account: issuer.Address}}}
+			},
+			wantTER: "temINVALID",
+		},
+		{
+			name: "issued amount",
+			mutate: func(payment *paymenttx.Payment) {
+				payment.Amount = issuer.IOU("USD", 1)
+			},
+			wantTER: "temBAD_AMOUNT",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			payment := paymenttx.NewPayment(source.Address, destination.Address, tx.NewXRPAmount(1))
+			payment.Fee = "10"
+			payment.SetFlags(paymenttx.PaymentFlagSponsorCreatedAccount)
+			testCase.mutate(payment)
+			require.Equal(t, testCase.wantTER, env.Submit(payment).Code)
+		})
+	}
+}
+
 func TestSponsorshipSetDirectoryFailureRollsBackFirstInsert(t *testing.T) {
 	env, sponsee, _, sponsor, _ := sponsorEnv(t)
 
@@ -497,7 +1220,12 @@ func TestSponsorAmendmentGate(t *testing.T) {
 	env := jtx.NewTestEnv(t)
 	sponsor := jtx.NewAccount("gate-sponsor")
 	sponsee := jtx.NewAccount("gate-sponsee")
+	destination := jtx.NewAccount("gate-destination")
 	env.Fund(sponsor, sponsee)
 	remaining := uint32(1)
 	require.Equal(t, "temDISABLED", setSponsorship(env, sponsor, sponsee, 0, &remaining).Code)
+
+	payment := paymenttx.NewPayment(sponsee.Address, destination.Address, tx.NewXRPAmount(1))
+	payment.SetFlags(paymenttx.PaymentFlagSponsorCreatedAccount)
+	require.Equal(t, "temDISABLED", env.Submit(payment).Code)
 }

--- a/internal/testing/sponsor/sponsor_test.go
+++ b/internal/testing/sponsor/sponsor_test.go
@@ -781,6 +781,33 @@ func TestSponsorSignatureStructuralFailures(t *testing.T) {
 	}
 }
 
+func TestSponsorSignatureRejectsPseudoAccount(t *testing.T) {
+	env, source, _, sponsor, _ := sponsorEnv(t)
+	setPseudoAccount(t, env, sponsor)
+
+	transaction := accounttx.NewAccountSet(source.Address)
+	transaction.Fee = "10"
+	transaction.Sponsor = sponsor.Address
+	flags := tx.SpfSponsorFee
+	transaction.SponsorFlags = &flags
+	attachSponsorSignature(t, env, transaction, source, sponsor)
+
+	require.Equal(t, "tefBAD_AUTH", env.SubmitSigned(transaction).Code)
+}
+
+func TestPresentEmptySponsorIsNotIgnored(t *testing.T) {
+	env, source, _, _, _ := sponsorEnv(t)
+	transaction := accounttx.NewAccountSet(source.Address)
+	flags := tx.SpfSponsorFee
+	transaction.SponsorFlags = &flags
+	transaction.SetPresentFields(map[string]bool{
+		"Sponsor":      true,
+		"SponsorFlags": true,
+	})
+
+	require.Equal(t, "terNO_ACCOUNT", env.Submit(transaction).Code)
+}
+
 func TestSponsorMultisignAuthorizationAndFeeUnits(t *testing.T) {
 	env, source, _, sponsor, _ := sponsorEnv(t)
 	signer1 := jtx.NewAccount("sponsor-multisigner-1")

--- a/internal/tx/apply_context.go
+++ b/internal/tx/apply_context.go
@@ -23,10 +23,10 @@ type ApplyContext struct {
 	AccountID [20]byte
 
 	// SourceFeeCharged is the fee (in drops) actually deducted from Account for
-	// this transaction: the transaction fee for a normal tx, or 0 for a delegated
-	// tx (whose fee is paid by the delegate, leaving the source untouched). Added
-	// to Account.Balance it yields the prior balance the reserve checks compare
-	// against — rippled's mPriorBalance.
+	// this transaction: the transaction fee for a normal tx, or 0 when a
+	// delegate/sponsor pays and leaves the source untouched. Added to
+	// Account.Balance it yields the prior balance used by reserve checks —
+	// rippled's mPriorBalance.
 	SourceFeeCharged uint64
 
 	// Config holds engine configuration (reserves, ledger sequence, etc.)
@@ -162,9 +162,8 @@ func (ctx *ApplyContext) LookupDestination(account string) (*state.AccountRoot, 
 }
 
 // PriorBalance returns the source account's balance before its own fee was
-// deducted — rippled's mPriorBalance. For a delegated transaction the fee is
-// charged to the delegate, not the source, so SourceFeeCharged is 0 and the
-// prior balance is just the untouched source balance.
+// deducted — rippled's mPriorBalance. When a delegate or sponsor pays,
+// SourceFeeCharged is 0 and the prior balance is the untouched source balance.
 func (ctx *ApplyContext) PriorBalance() uint64 {
 	return ctx.Account.Balance + ctx.SourceFeeCharged
 }

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -126,6 +126,7 @@ var (
 	ErrBatchInnerHasSigners       = ter.Errorf(ter.TemBAD_SIGNER, "inner transaction cannot include Signers")
 	ErrBatchInnerHasSigningPubKey = ter.Errorf(ter.TemBAD_REGKEY, "inner transaction SigningPubKey must be empty")
 	ErrBatchInnerBadFee           = ter.Errorf(ter.TemBAD_FEE, "inner transaction must have a fee of 0")
+	ErrBatchInnerFeeSponsored     = ter.Errorf(ter.TemINVALID_FLAG, "inner transaction cannot sponsor its fee")
 	ErrBatchInnerSeqAndTicket     = ter.Errorf(ter.TemSEQ_AND_TICKET, "inner transaction must have exactly one of Sequence and TicketSequence")
 	ErrBatchInnerTicketAndTxnID   = ter.Errorf(ter.TemINVALID_INNER_BATCH, "inner transaction must not carry AccountTxnID when using a ticket")
 	ErrBatchInnerDupSeqOrTicket   = ter.Errorf(ter.TemREDUNDANT, "duplicate inner Sequence or TicketSequence for account")
@@ -194,7 +195,7 @@ func (b *Batch) InnerTransactions() []tx.Transaction {
 // mirroring the checkSignatureFields lambda in rippled Batch::preflight: a
 // TxnSignature yields temBAD_SIGNATURE, a Signers array temBAD_SIGNER, and a
 // non-empty SigningPubKey temBAD_REGKEY. It is applied to every inner
-// transaction and to its nested CounterpartySignature.
+// transaction and to its nested CounterpartySignature/SponsorSignature.
 func checkInnerSignatureFields(signingPubKey, txnSignature string, hasSigners bool) error {
 	if txnSignature != "" {
 		return ErrBatchInnerHasTxnSignature
@@ -258,8 +259,24 @@ func (b *Batch) validateInnerTransactions() (map[string]struct{}, error) {
 				return nil, err
 			}
 		}
+		if sponsor := innerCommon.SponsorSignature; sponsor != nil {
+			if err := checkInnerSignatureFields(
+				sponsor.SigningPubKey,
+				sponsor.TxnSignature,
+				len(sponsor.Signers) > 0,
+			); err != nil {
+				return nil, err
+			}
+		}
 		if err := validateInnerFee(innerCommon.Fee); err != nil {
 			return nil, err
+		}
+		// Inner transactions have Fee=0, so fee sponsorship is nonsensical and
+		// explicitly rejected by rippled. Reserve sponsorship remains allowed
+		// for the transaction types on the common allow-list.
+		if innerCommon.Sponsor != "" && innerCommon.SponsorFlags != nil &&
+			*innerCommon.SponsorFlags&tx.SpfSponsorFee != 0 {
+			return nil, ErrBatchInnerFeeSponsored
 		}
 
 		// The inner's own preflight1 rejects a ticket combined with AccountTxnID
@@ -310,9 +327,18 @@ func (b *Batch) validateInnerTransactions() (map[string]struct{}, error) {
 		}
 
 		// An inner account that is not the outer account must be covered by a
-		// BatchSigner. Reference: rippled Batch.cpp:376-379.
+		// BatchSigner. Delegate changes permission/signature authorization for
+		// the inner transactor, but it does not replace the inner Account in the
+		// outer BatchSigner coverage set.
+		// Reference: rippled Batch.cpp:376-379 and Batch_test.cpp
+		// testBatchDelegate.
 		if innerCommon.Account != b.Account {
 			requiredSigners[innerCommon.Account] = struct{}{}
+		}
+		if innerCommon.SponsorSignature != nil &&
+			innerCommon.Sponsor != "" &&
+			innerCommon.Sponsor != b.Account {
+			requiredSigners[innerCommon.Sponsor] = struct{}{}
 		}
 	}
 	return requiredSigners, nil
@@ -441,7 +467,7 @@ func (b *Batch) Flatten() (map[string]any, error) {
 // CalculateMinimumFee mirrors rippled Batch::calculateBaseFee
 // (Batch.cpp:53-150). The total fee a batch must pay is the sum of:
 //   - batchBase   = view.fees().base + Transactor::calculateBaseFee(view, tx)
-//     = baseFee + (1 + len(outer.Signers)) * baseFee
+//     = baseFee + (1 + len(outer.Signers) + len(sponsor.Signers)) * baseFee
 //   - txnFees     = Σ inner-tx dispatched base fees
 //   - signerFees  = effectiveSignerCount * baseFee
 //
@@ -452,7 +478,7 @@ func (b *Batch) Flatten() (map[string]any, error) {
 // transactions return the overflow sentinel as a defense-in-depth fallback.
 func (b *Batch) CalculateMinimumFee(view tx.LedgerView, config tx.EngineConfig) uint64 {
 	baseFee := config.BaseFee
-	outerSigners := uint64(len(b.Common.Signers))
+	outerSigners := uint64(len(b.Common.Signers) + sign.SponsorSignerCount(b))
 	batchBase := baseFee + (1+outerSigners)*baseFee
 
 	var txnFees uint64

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -326,14 +326,12 @@ func (b *Batch) validateInnerTransactions() (map[string]struct{}, error) {
 			}
 		}
 
-		// An inner account that is not the outer account must be covered by a
-		// BatchSigner. Delegate changes permission/signature authorization for
-		// the inner transactor, but it does not replace the inner Account in the
-		// outer BatchSigner coverage set.
-		// Reference: rippled Batch.cpp:376-379 and Batch_test.cpp
-		// testBatchDelegate.
-		if innerCommon.Account != b.Account {
-			requiredSigners[innerCommon.Account] = struct{}{}
+		authorizer := innerCommon.Account
+		if innerCommon.Delegate != "" {
+			authorizer = innerCommon.Delegate
+		}
+		if authorizer != b.Account {
+			requiredSigners[authorizer] = struct{}{}
 		}
 		if innerCommon.SponsorSignature != nil &&
 			innerCommon.Sponsor != "" &&

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -598,6 +598,22 @@ func TestCalculateMinimumFee_MultiSignBatchSigner(t *testing.T) {
 	require.Equal(t, uint64(70), b.CalculateMinimumFee(nil, tx.EngineConfig{BaseFee: 10}))
 }
 
+func TestBatchRequiredSignersUseInnerAuthorizers(t *testing.T) {
+	t.Run("delegate authorizes outer account inner", func(t *testing.T) {
+		b := NewBatch(testOuter)
+		inner := makeTestPayment()
+		inner.GetCommon().Delegate = testSigner2
+		b.AddInnerTransaction(inner)
+		b.AddInnerTransaction(makeTestPayment())
+		b.SetFlags(BatchFlagAllOrNothing)
+
+		require.ErrorIs(t, b.Validate(), ErrBatchMissingSigner)
+
+		b.BatchSigners = []BatchSigner{{BatchSigner: BatchSignerData{Account: testSigner2}}}
+		require.NoError(t, b.Validate())
+	})
+}
+
 // TestCalculateMinimumFee_MultiSignedInner pins
 // Batch.cpp:87-100 — inner transactions count their own per-tx
 // calculateBaseFee, so a multi-signed inner pays (1+n) * baseFee

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -609,7 +609,7 @@ func TestBatchRequiredSignersUseInnerAuthorizers(t *testing.T) {
 
 		require.ErrorIs(t, b.Validate(), ErrBatchMissingSigner)
 
-		b.BatchSigners = []BatchSigner{{BatchSigner: BatchSignerData{Account: testSigner2}}}
+		b.BatchSigners = []BatchSigner{{BatchSigner: BatchSignerData{Account: testSigner2, SigningPubKey: "ABC"}}}
 		require.NoError(t, b.Validate())
 	})
 }

--- a/internal/tx/batch/sponsor_test.go
+++ b/internal/tx/batch/sponsor_test.go
@@ -1,0 +1,135 @@
+package batch
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+func batchWithInnerSponsor(signature *tx.SponsorSignature, sponsorFlags uint32, withBatchSigner bool) *Batch {
+	batch := NewBatch(testOuter)
+	inner := makeTestPayment()
+	innerCommon := inner.GetCommon()
+	innerCommon.Sponsor = testSigner1
+	innerCommon.SponsorFlags = &sponsorFlags
+	innerCommon.SponsorSignature = signature
+	batch.AddInnerTransaction(inner)
+	batch.AddInnerTransaction(makeTestPayment())
+	flags := BatchFlagAllOrNothing
+	batch.Common.Flags = &flags
+	if withBatchSigner {
+		batch.BatchSigners = []BatchSigner{{
+			BatchSigner: BatchSignerData{
+				Account:           testSigner1,
+				SigningPubKey:     "ED01",
+				BatchTxnSignature: "AA",
+			},
+		}}
+	}
+	return batch
+}
+
+func TestBatchInnerSponsorSignatureFields(t *testing.T) {
+	testCases := []struct {
+		name      string
+		signature *tx.SponsorSignature
+		wantErr   error
+	}{
+		{
+			name:      "TxnSignature present",
+			signature: &tx.SponsorSignature{TxnSignature: "DEADBEEF"},
+			wantErr:   ErrBatchInnerHasTxnSignature,
+		},
+		{
+			name: "Signers present",
+			signature: &tx.SponsorSignature{Signers: []tx.SignerWrapper{
+				{Signer: tx.Signer{Account: testSigner2}},
+			}},
+			wantErr: ErrBatchInnerHasSigners,
+		},
+		{
+			name: "SigningPubKey present",
+			signature: &tx.SponsorSignature{
+				SigningPubKey: "ED0000000000000000000000000000000000000000000000000000000000000001",
+			},
+			wantErr: ErrBatchInnerHasSigningPubKey,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			batch := batchWithInnerSponsor(
+				testCase.signature,
+				tx.SpfSponsorReserve,
+				true,
+			)
+			if err := batch.Validate(); !errors.Is(err, testCase.wantErr) {
+				t.Fatalf("Validate() error = %v, want %v", err, testCase.wantErr)
+			}
+		})
+	}
+}
+
+func TestBatchInnerSponsorRules(t *testing.T) {
+	t.Run("empty cosignature requires batch signer", func(t *testing.T) {
+		batch := batchWithInnerSponsor(
+			&tx.SponsorSignature{},
+			tx.SpfSponsorReserve,
+			false,
+		)
+		if err := batch.Validate(); !errors.Is(err, ErrBatchMissingSigner) {
+			t.Fatalf("Validate() error = %v, want %v", err, ErrBatchMissingSigner)
+		}
+
+		batch.BatchSigners = []BatchSigner{{
+			BatchSigner: BatchSignerData{
+				Account:           testSigner1,
+				SigningPubKey:     "ED01",
+				BatchTxnSignature: "AA",
+			},
+		}}
+		if err := batch.Validate(); err != nil {
+			t.Fatalf("empty inner SponsorSignature with BatchSigner rejected: %v", err)
+		}
+	})
+
+	t.Run("prefunded reserve needs no batch signer", func(t *testing.T) {
+		batch := batchWithInnerSponsor(nil, tx.SpfSponsorReserve, false)
+		if err := batch.Validate(); err != nil {
+			t.Fatalf("pre-funded reserve sponsor rejected: %v", err)
+		}
+	})
+
+	t.Run("fee sponsorship is forbidden", func(t *testing.T) {
+		batch := batchWithInnerSponsor(nil, tx.SpfSponsorFee, false)
+		if err := batch.Validate(); !errors.Is(err, ErrBatchInnerFeeSponsored) {
+			t.Fatalf("Validate() error = %v, want %v", err, ErrBatchInnerFeeSponsored)
+		}
+	})
+}
+
+func TestCalculateMinimumFeeIncludesOuterSponsorMultisigners(t *testing.T) {
+	config := tx.EngineConfig{BaseFee: 10}
+
+	direct := NewBatch(testOuter)
+	direct.AddInnerTransaction(makeTestPayment())
+	direct.AddInnerTransaction(makeTestPayment())
+	direct.Common.SponsorSignature = &tx.SponsorSignature{
+		SigningPubKey: "ED01",
+		TxnSignature:  "AA",
+	}
+	if got := direct.CalculateMinimumFee(nil, config); got != 40 {
+		t.Fatalf("direct sponsor minimum fee = %d, want 40", got)
+	}
+
+	multisigned := NewBatch(testOuter)
+	multisigned.AddInnerTransaction(makeTestPayment())
+	multisigned.AddInnerTransaction(makeTestPayment())
+	multisigned.Common.SponsorSignature = &tx.SponsorSignature{
+		Signers: make([]tx.SignerWrapper, 2),
+	}
+	if got := multisigned.CalculateMinimumFee(nil, config); got != 60 {
+		t.Fatalf("multisigned sponsor minimum fee = %d, want 60", got)
+	}
+}

--- a/internal/tx/engine/apply.go
+++ b/internal/tx/engine/apply.go
@@ -158,7 +158,7 @@ func (e *Engine) applyWithContext(
 		// Otherwise the fee must still be deducted and sequence consumed, but
 		// doApply() is NOT called — the transaction has no side effects. We share
 		// the same recovery helpers used by doApply's own tec path
-		// (consumeTicketForRecovery, writeRecoveryAccount, payDelegatedFeeOnTable);
+		// (consumeTicketForRecovery, writeRecoveryAccount, payExternalFeeOnTable);
 		// the only difference is that the sandbox here is empty, so we skip
 		// the "discard sandbox + replay deletions" steps.
 		// Reference: rippled applySteps.cpp — preclaim tec with likelyToClaimFee=true
@@ -499,7 +499,7 @@ func (e *Engine) applyPseudoTransaction(reqCtx context.Context, tx txcore.Transa
 // rejected by preclaim with a tec code, doApply() never ran, but the fee and
 // sequence still need to be charged. Reuses the same recovery helpers that
 // doApply's own tec path uses (consumeTicketForRecovery, writeRecoveryAccount,
-// payDelegatedFeeOnTable) so the fee/seq commit semantics stay in lockstep.
+// payExternalFeeOnTable) so the fee/seq commit semantics stay in lockstep.
 // Reference: rippled applySteps.cpp — likelyToClaimFee tec still enters
 // Transactor::operator() which calls reset(fee) before returning.
 func (e *Engine) commitPreclaimTec(ctx context.Context, tx txcore.Transaction, txHash [32]byte, fee uint64, origResult ter.Result, metadata *txcore.Metadata) (ter.Result, uint64) {
@@ -515,6 +515,10 @@ func (e *Engine) commitPreclaimTec(ctx context.Context, tx txcore.Transaction, t
 	if parseErr != nil {
 		return ter.TefINTERNAL, 0
 	}
+	payer, payerResult := e.getFeePayer(common)
+	if payerResult != ter.TesSUCCESS {
+		return payerResult, 0
+	}
 
 	st := &applyState{
 		tx:                  tx,
@@ -526,6 +530,7 @@ func (e *Engine) commitPreclaimTec(ctx context.Context, tx txcore.Transaction, t
 		fee:                 fee,
 		chargedFee:          fee,
 		isDelegated:         common.Delegate != "",
+		feePayer:            payer,
 		isTicket:            common.TicketSequence != nil,
 		txHash:              txHash,
 		metadata:            metadata,
@@ -542,7 +547,7 @@ func (e *Engine) commitPreclaimTec(ctx context.Context, tx txcore.Transaction, t
 	if r := e.writeRecoveryAccount(st, tecTable, recoveredAccount); r != ter.TesSUCCESS {
 		return r, 0
 	}
-	if r := e.payDelegatedFeeOnTable(st, tecTable); r != ter.TesSUCCESS {
+	if r := e.payExternalFeeOnTable(st, tecTable, true); r != ter.TesSUCCESS {
 		return r, 0
 	}
 

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -34,6 +34,7 @@ type applyState struct {
 	// the fee that was really charged.
 	chargedFee  uint64
 	isDelegated bool
+	feePayer    feePayer
 	isTicket    bool
 	txHash      [32]byte
 	metadata    *txcore.Metadata
@@ -42,10 +43,10 @@ type applyState struct {
 }
 
 // sourceFeeCharged is the fee deducted from the source account for this tx — the
-// transaction fee normally, or 0 when the tx is delegated (the delegate pays the
-// fee, leaving the source balance untouched). It feeds ApplyContext.PriorBalance.
+// transaction fee normally, or 0 when a delegate or sponsor pays externally.
+// It feeds ApplyContext.PriorBalance.
 func (st *applyState) sourceFeeCharged() uint64 {
-	if st.isDelegated {
+	if st.hasExternalFeePayer() {
 		return 0
 	}
 	return st.fee
@@ -71,6 +72,10 @@ func (e *Engine) doApply(ctx context.Context, tx txcore.Transaction, metadata *t
 	}
 
 	fee := e.calculateFee(tx)
+	payer, payerResult := e.getFeePayer(common)
+	if payerResult != ter.TesSUCCESS {
+		return payerResult, 0
+	}
 
 	// Save original serialized account data for tec recovery.
 	// On tec results, we restore the account to its original state
@@ -92,6 +97,7 @@ func (e *Engine) doApply(ctx context.Context, tx txcore.Transaction, metadata *t
 		fee:                 fee,
 		chargedFee:          fee,
 		isDelegated:         common.Delegate != "",
+		feePayer:            payer,
 		isTicket:            common.TicketSequence != nil,
 		txHash:              txHash,
 		metadata:            metadata,
@@ -105,12 +111,10 @@ func (e *Engine) doApply(ctx context.Context, tx txcore.Transaction, metadata *t
 		return result, 0
 	}
 
-	// For delegated transactions, deduct the fee from the delegate's account.
-	// payDelegatedFeeOnTable clamps the charged fee to the delegate's balance and
-	// records st.chargedFee. On this success path preclaim's checkFee already
-	// guaranteed the delegate balance covers the full fee, so the clamp is a
-	// no-op and st.chargedFee == st.fee.
-	if result := e.payDelegatedFeeOnTable(st, table); result != ter.TesSUCCESS {
+	// Charge an external delegate or sponsor. Sponsor reserve/MaxFee limits are
+	// rechecked here against the apply view before any transaction effect can
+	// commit.
+	if result := e.payExternalFeeOnTable(st, table, false); result != ter.TesSUCCESS {
 		return result, 0
 	}
 
@@ -223,10 +227,9 @@ func (e *Engine) doApply(ctx context.Context, tx txcore.Transaction, metadata *t
 // AccountTxnID block).
 func (e *Engine) applyPreApplyAccountChanges(st *applyState) ter.Result {
 	// Reference: rippled Transactor::payFee + consumeSeqProxy in Transactor.cpp
-	if st.isDelegated {
-		// Delegated transactions: fee is charged to the delegate account, not the source.
-		// The source account's balance is NOT reduced by the fee.
-		// Reference: rippled Transactor::payFee() lines 327-337
+	if st.hasExternalFeePayer() {
+		// A delegate or fee sponsor pays externally; the source account's
+		// balance is not reduced by the fee.
 	} else {
 		// Normal transactions: fee is charged to the source account.
 		st.account.Balance -= st.fee
@@ -396,9 +399,9 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 		return r
 	}
 
-	// For delegated transactions, deduct the fee from the delegate's account on tec.
-	// Reference: rippled Transactor.cpp reset() lines 1011-1013, 1036
-	if r := e.payDelegatedFeeOnTable(st, tecTable); r != ter.TesSUCCESS {
+	// Charge the external delegate or sponsor on tec recovery.
+	// Reference: rippled Transactor.cpp reset().
+	if r := e.payExternalFeeOnTable(st, tecTable, true); r != ter.TesSUCCESS {
 		return r
 	}
 
@@ -599,9 +602,9 @@ func (e *Engine) removeUnfundedOffers(tecTable *applystate.ApplyStateTable, keys
 // table.
 // Reference: rippled Transactor.cpp reset() lines 998-1052.
 func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *applystate.ApplyStateTable, recoveredAccount *state.AccountRoot) ter.Result {
-	// For delegated transactions, fee is charged to the delegate, not the source.
-	// Reference: rippled Transactor.cpp reset() lines 1011-1013, 1036
-	if !st.isDelegated {
+	// An external delegate or sponsor pays instead of the source account.
+	// Reference: rippled Transactor.cpp reset().
+	if !st.hasExternalFeePayer() {
 		// Clamp the fee to the payer's balance. rippled Transactor::reset()
 		// (Transactor.cpp:1027) does `if (fee > balance) fee = balance`, so a
 		// payer that cannot cover the full fee is charged everything it has and
@@ -642,42 +645,6 @@ func (e *Engine) writeRecoveryAccount(st *applyState, tecTable *applystate.Apply
 
 	// Update account through tecTable for proper metadata diff generation
 	if err := tecTable.Update(st.accountKey, updatedData); err != nil {
-		return ter.TefINTERNAL
-	}
-	return ter.TesSUCCESS
-}
-
-// payDelegatedFeeOnTable deducts the fee from the delegate's account through
-// the supplied table. Used by both the tec-recovery and invariant-violation
-// recovery paths.
-// Reference: rippled Transactor.cpp reset() lines 1011-1013, 1036.
-func (e *Engine) payDelegatedFeeOnTable(st *applyState, table *applystate.ApplyStateTable) ter.Result {
-	if !st.isDelegated {
-		return ter.TesSUCCESS
-	}
-	delegateID, _ := state.DecodeAccountID(st.common.Delegate)
-	delegateAccountKey := keylet.Account(delegateID)
-	delegateAccountData, delegateReadErr := e.view.Read(delegateAccountKey)
-	if delegateReadErr != nil || delegateAccountData == nil {
-		return ter.TefINTERNAL
-	}
-	delegateAccount, delegateParseErr := state.ParseAccountRoot(delegateAccountData)
-	if delegateParseErr != nil {
-		return ter.TefINTERNAL
-	}
-	// On the recovery path the delegate is the fee payer, so the same reset()
-	// clamp applies: charge at most the delegate's balance, never underflow.
-	// Reference: rippled Transactor::reset() lines 1011-1013, 1027, 1036.
-	fee := min(st.fee, delegateAccount.Balance)
-	st.chargedFee = fee
-	delegateAccount.Balance -= fee
-	delegateAccount.PreviousTxnID = st.txHash
-	delegateAccount.PreviousTxnLgrSeq = e.config.LedgerSequence
-	delegateData, delegateSerErr := state.SerializeAccountRoot(delegateAccount)
-	if delegateSerErr != nil {
-		return ter.TefINTERNAL
-	}
-	if err := table.Update(delegateAccountKey, delegateData); err != nil {
 		return ter.TefINTERNAL
 	}
 	return ter.TesSUCCESS
@@ -846,8 +813,8 @@ func (e *Engine) applyInvariantViolation(st *applyState, txDeclaredFee uint64) (
 		return r
 	}
 
-	// For delegated transactions, deduct the fee from the delegate.
-	if r := e.payDelegatedFeeOnTable(st, invTecTable); r != ter.TesSUCCESS {
+	// Charge the external delegate or sponsor after invariant recovery.
+	if r := e.payExternalFeeOnTable(st, invTecTable, true); r != ter.TesSUCCESS {
 		return r
 	}
 

--- a/internal/tx/engine/do_apply.go
+++ b/internal/tx/engine/do_apply.go
@@ -111,9 +111,6 @@ func (e *Engine) doApply(ctx context.Context, tx txcore.Transaction, metadata *t
 		return result, 0
 	}
 
-	// Charge an external delegate or sponsor. Sponsor reserve/MaxFee limits are
-	// rechecked here against the apply view before any transaction effect can
-	// commit.
 	if result := e.payExternalFeeOnTable(st, table, false); result != ter.TesSUCCESS {
 		return result, 0
 	}
@@ -228,8 +225,7 @@ func (e *Engine) doApply(ctx context.Context, tx txcore.Transaction, metadata *t
 func (e *Engine) applyPreApplyAccountChanges(st *applyState) ter.Result {
 	// Reference: rippled Transactor::payFee + consumeSeqProxy in Transactor.cpp
 	if st.hasExternalFeePayer() {
-		// A delegate or fee sponsor pays externally; the source account's
-		// balance is not reduced by the fee.
+		// The fee payer is updated separately by payExternalFeeOnTable.
 	} else {
 		// Normal transactions: fee is charged to the source account.
 		st.account.Balance -= st.fee
@@ -399,7 +395,6 @@ func (e *Engine) applyTecRecovery(st *applyState, result ter.Result) ter.Result 
 		return r
 	}
 
-	// Charge the external delegate or sponsor on tec recovery.
 	// Reference: rippled Transactor.cpp reset().
 	if r := e.payExternalFeeOnTable(st, tecTable, true); r != ter.TesSUCCESS {
 		return r
@@ -813,7 +808,6 @@ func (e *Engine) applyInvariantViolation(st *applyState, txDeclaredFee uint64) (
 		return r
 	}
 
-	// Charge the external delegate or sponsor after invariant recovery.
 	if r := e.payExternalFeeOnTable(st, invTecTable, true); r != ter.TesSUCCESS {
 		return r
 	}

--- a/internal/tx/engine/fee.go
+++ b/internal/tx/engine/fee.go
@@ -17,13 +17,10 @@ func (e *Engine) calculateFee(tx txcore.Transaction) uint64 {
 			return fee
 		}
 	}
-	// If no fee specified, use base fee (adjusted for multi-sig if applicable)
-	baseFee := e.config.BaseFee
-	if sign.IsMultiSigned(tx) {
-		numSigners := len(common.Signers)
-		return sign.CalculateMultiSigFee(baseFee, numSigners)
-	}
-	return baseFee
+	// This fallback is used only by internal/test callers that have not passed
+	// through required-wire-field validation. Keep it identical to the ordinary
+	// signer + sponsor-signer fee formula.
+	return sign.CalculateDefaultBaseFee(tx, e.config)
 }
 
 // parseTxDeclaredFee extracts the fee declared in the transaction itself.

--- a/internal/tx/engine/preclaim.go
+++ b/internal/tx/engine/preclaim.go
@@ -346,6 +346,9 @@ func (e *Engine) checkPermission(tx txcore.Transaction, common *txcore.Common, a
 // SLE, but never the sponsor-account existence check.
 func (e *Engine) checkSponsor(common *txcore.Common) ter.Result {
 	if common.Sponsor == "" {
+		if common.HasField("Sponsor") {
+			return ter.TerNO_ACCOUNT
+		}
 		return ter.TesSUCCESS
 	}
 	if common.Delegate != "" && common.SponsorFlags != nil &&
@@ -415,7 +418,7 @@ func (e *Engine) checkSign(tx txcore.Transaction, common *txcore.Common) ter.Res
 		// have already failed crypto verification in preflight.
 		if !(e.config.SkipSignatureVerification &&
 			sponsor.SigningPubKey == "" && len(sponsor.Signers) == 0) {
-			if result := e.checkPseudoAccount(common.Sponsor); result != ter.TesSUCCESS {
+			if result := e.rejectPseudoAccount(common.Sponsor); result != ter.TesSUCCESS {
 				return result
 			}
 			if len(sponsor.Signers) > 0 {
@@ -448,15 +451,18 @@ func (e *Engine) checkPseudoAccountSign(common *txcore.Common) ter.Result {
 }
 
 func (e *Engine) checkPseudoAccount(idAccount string) ter.Result {
-	// Under LendingProtocol a pseudo-account (AMM / Vault / LoanBroker) can never
-	// authorize a transaction: rippled Transactor::checkSign returns tefBAD_AUTH
-	// for any tx signed by a pseudo-account, at the top of the signature stage.
-	if e.rules().Enabled(amendment.FeatureLendingProtocol) {
-		if idAccountID, err := state.DecodeAccountID(idAccount); err == nil {
-			if data, rerr := e.view.Read(keylet.Account(idAccountID)); rerr == nil && data != nil {
-				if ar, perr := state.ParseAccountRoot(data); perr == nil && ar.IsPseudoAccount() {
-					return ter.TefBAD_AUTH
-				}
+	if !e.rules().Enabled(amendment.FeatureLendingProtocol) &&
+		!e.rules().Enabled(amendment.FeatureBatch) {
+		return ter.TesSUCCESS
+	}
+	return e.rejectPseudoAccount(idAccount)
+}
+
+func (e *Engine) rejectPseudoAccount(idAccount string) ter.Result {
+	if idAccountID, err := state.DecodeAccountID(idAccount); err == nil {
+		if data, rerr := e.view.Read(keylet.Account(idAccountID)); rerr == nil && data != nil {
+			if ar, perr := state.ParseAccountRoot(data); perr == nil && ar.IsPseudoAccount() {
+				return ter.TefBAD_AUTH
 			}
 		}
 	}

--- a/internal/tx/engine/preclaim.go
+++ b/internal/tx/engine/preclaim.go
@@ -12,13 +12,15 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
 
 // preclaim validates the transaction against the current ledger state.
 // Mirrors rippled's invoke_preclaim pipeline (applySteps.cpp, PR #6192):
 //
-//	checkSeqProxy → checkPriorTxAndLastLedger → checkSign (+ checkBatchSign) →
-//	checkFee → checkPermission → tx-type preclaim.
+//	checkSeqProxy → checkPriorTxAndLastLedger → checkSponsor →
+//	checkSign (+ checkBatchSign) → checkFee → checkPermission →
+//	tx-type preclaim.
 //
 // The signature stage precedes the fee and permission checks so that no
 // fee-charging TER is ever returned before the signature has been verified.
@@ -52,6 +54,9 @@ func (e *Engine) preclaim(tx txcore.Transaction, txHash [32]byte) (result ter.Re
 		return result
 	}
 	if result := e.checkPriorTxAndLastLedger(common, account, txHash); result != ter.TesSUCCESS {
+		return result
+	}
+	if result := e.checkSponsor(common); result != ter.TesSUCCESS {
 		return result
 	}
 
@@ -121,6 +126,9 @@ func (e *Engine) preclaimInner(tx txcore.Transaction, txHash [32]byte) (result t
 		return result
 	}
 	if result := e.checkPriorTxAndLastLedger(common, account, txHash); result != ter.TesSUCCESS {
+		return result
+	}
+	if result := e.checkSponsor(common); result != ter.TesSUCCESS {
 		return result
 	}
 	if result := e.checkPseudoAccountSign(common); result != ter.TesSUCCESS {
@@ -220,10 +228,10 @@ func (e *Engine) checkPriorTxAndLastLedger(common *txcore.Common, account *state
 	return ter.TesSUCCESS
 }
 
-// checkFee enforces fee adequacy and that the fee payer (delegate or source)
-// can afford the fee. Reference: rippled Transactor::checkFee in Transactor.cpp.
+// checkFee enforces fee adequacy and that the selected source, delegate,
+// pre-funded sponsorship, or co-signed sponsor can afford the fee.
+// Reference: rippled Transactor::checkFee in Transactor.cpp.
 func (e *Engine) checkFee(tx txcore.Transaction, common *txcore.Common, account *state.AccountRoot) ter.Result {
-	// When a delegate is present, the fee is checked against the delegate's balance.
 	fee := e.calculateFee(tx)
 	baseFeeForTx := e.preclaimBaseFee(tx)
 
@@ -254,21 +262,20 @@ func (e *Engine) checkFee(tx txcore.Transaction, common *txcore.Common, account 
 		return ter.TesSUCCESS
 	}
 
-	// Determine who pays the fee: delegate (if present) or the source account.
-	// Reference: rippled Transactor::checkFee lines 295-297:
-	//   auto const id = ctx.tx.isFieldPresent(sfDelegate)
-	//       ? ctx.tx.getAccountID(sfDelegate)
-	//       : ctx.tx.getAccountID(sfAccount);
-	feePayerBalance, balResult := e.feePayerBalance(common, account)
-	if balResult != ter.TesSUCCESS {
-		return balResult
+	payer, result := e.getFeePayer(common)
+	if result != ter.TesSUCCESS {
+		return result
 	}
-	if feePayerBalance < fee {
+	_, maxSpendable, result := e.feePayerBalanceAndSpendable(payer, account)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+	if maxSpendable < fee {
 		// Reference: rippled Transactor::checkFee lines 304-316. Only a closed
 		// ledger with a non-zero balance below the fee yields a deterministic
 		// claimed-fee result; on any open view (open ledger, queued retry, or
 		// load-fee enforcement — rippled's ctx.view.open()) it is retryable.
-		if feePayerBalance > 0 && !e.config.IsViewOpen() {
+		if maxSpendable > 0 && !e.config.IsViewOpen() {
 			return ter.TecINSUFF_FEE
 		}
 		return ter.TerINSUF_FEE_B
@@ -296,27 +303,6 @@ func (e *Engine) enforceFeeFloor(fee, baseFeeForTx uint64) ter.Result {
 
 func (e *Engine) preclaimBaseFee(tx txcore.Transaction) uint64 {
 	return sign.CalculateBaseFee(tx, e.view, e.config)
-}
-
-// feePayerBalance returns the balance of the account that will be charged the fee
-// (delegate when sfDelegate is present, otherwise the source account).
-func (e *Engine) feePayerBalance(common *txcore.Common, account *state.AccountRoot) (uint64, ter.Result) {
-	if common.Delegate == "" {
-		return account.Balance, ter.TesSUCCESS
-	}
-	delegateID, delegateErr := state.DecodeAccountID(common.Delegate)
-	if delegateErr != nil {
-		return 0, ter.TerNO_ACCOUNT
-	}
-	delegateAccount, readErr := txcore.ReadAccountRoot(e.view, delegateID)
-	if readErr != nil {
-		// Real storage or parse failure, not a missing account.
-		return 0, ter.TefINTERNAL
-	}
-	if delegateAccount == nil {
-		return 0, ter.TerNO_ACCOUNT
-	}
-	return delegateAccount.Balance, ter.TesSUCCESS
 }
 
 // checkPermission validates that, when sfDelegate is set, the delegate SLE
@@ -355,14 +341,92 @@ func (e *Engine) checkPermission(tx txcore.Transaction, common *txcore.Common, a
 	return ter.TerNO_DELEGATE_PERMISSION
 }
 
-// checkSign performs signature authorization for both single-signed and
-// multi-signed transactions, dispatching to checkSingleSign / checkMultiSign.
+// checkSponsor validates the common sponsorship permission before signature
+// authorization and fee selection. A co-signature bypasses the relationship
+// SLE, but never the sponsor-account existence check.
+func (e *Engine) checkSponsor(common *txcore.Common) ter.Result {
+	if common.Sponsor == "" {
+		return ter.TesSUCCESS
+	}
+	if common.Delegate != "" && common.SponsorFlags != nil &&
+		*common.SponsorFlags&txcore.SpfSponsorReserve != 0 {
+		return ter.TemINVALID
+	}
+
+	sponsorID, err := state.DecodeAccountID(common.Sponsor)
+	if err != nil {
+		return ter.TerNO_ACCOUNT
+	}
+	sponsor, readErr := txcore.ReadAccountRoot(e.view, sponsorID)
+	if readErr != nil {
+		return ter.TefINTERNAL
+	}
+	if sponsor == nil {
+		return ter.TerNO_ACCOUNT
+	}
+	if common.SponsorSignature != nil {
+		return ter.TesSUCCESS
+	}
+
+	initiator := common.Account
+	if common.Delegate != "" {
+		initiator = common.Delegate
+	}
+	initiatorID, err := state.DecodeAccountID(initiator)
+	if err != nil {
+		return ter.TerNO_PERMISSION
+	}
+	data, readErr := e.view.Read(keylet.Sponsorship(sponsorID, initiatorID))
+	if readErr != nil {
+		return ter.TefINTERNAL
+	}
+	if data == nil {
+		return ter.TerNO_PERMISSION
+	}
+	sponsorship, parseErr := state.ParseSponsorship(data)
+	if parseErr != nil {
+		return ter.TefINTERNAL
+	}
+	flags := uint32(0)
+	if common.SponsorFlags != nil {
+		flags = *common.SponsorFlags
+	}
+	if flags&txcore.SpfSponsorFee != 0 &&
+		sponsorship.Flags&entry.LsfSponsorshipRequireSignForFee != 0 {
+		return ter.TerNO_PERMISSION
+	}
+	if flags&txcore.SpfSponsorReserve != 0 &&
+		sponsorship.Flags&entry.LsfSponsorshipRequireSignForReserve != 0 {
+		return ter.TerNO_PERMISSION
+	}
+	return ter.TesSUCCESS
+}
+
+// checkSign performs sponsor authorization first, then the transaction's
+// ordinary single- or multi-sign authorization.
 // Reference: rippled Transactor::checkSign in Transactor.cpp.
 // When a delegate is present, the idAccount for signature checking is the
 // delegate. Reference: rippled line 602:
 //
 //	auto const idAccount = ctx.tx[~sfDelegate].value_or(ctx.tx[sfAccount]);
 func (e *Engine) checkSign(tx txcore.Transaction, common *txcore.Common) ter.Result {
+	if sponsor := common.SponsorSignature; sponsor != nil {
+		// Dry-run/test mode permits an empty signature object. Real submissions
+		// have already failed crypto verification in preflight.
+		if !(e.config.SkipSignatureVerification &&
+			sponsor.SigningPubKey == "" && len(sponsor.Signers) == 0) {
+			if result := e.checkPseudoAccount(common.Sponsor); result != ter.TesSUCCESS {
+				return result
+			}
+			if len(sponsor.Signers) > 0 {
+				if result := e.checkMultiSignForAccount(common.Sponsor, sponsor.Signers); result != ter.TesSUCCESS {
+					return result
+				}
+			} else if result := e.checkSingleSignForAccount(common.Sponsor, sponsor.SigningPubKey); result != ter.TesSUCCESS {
+				return result
+			}
+		}
+	}
 	if result := e.checkPseudoAccountSign(common); result != ter.TesSUCCESS {
 		return result
 	}
@@ -376,14 +440,18 @@ func (e *Engine) checkSign(tx txcore.Transaction, common *txcore.Common) ter.Res
 }
 
 func (e *Engine) checkPseudoAccountSign(common *txcore.Common) ter.Result {
+	idAccount := common.Account
+	if common.Delegate != "" {
+		idAccount = common.Delegate
+	}
+	return e.checkPseudoAccount(idAccount)
+}
+
+func (e *Engine) checkPseudoAccount(idAccount string) ter.Result {
 	// Under LendingProtocol a pseudo-account (AMM / Vault / LoanBroker) can never
 	// authorize a transaction: rippled Transactor::checkSign returns tefBAD_AUTH
 	// for any tx signed by a pseudo-account, at the top of the signature stage.
 	if e.rules().Enabled(amendment.FeatureLendingProtocol) {
-		idAccount := common.Account
-		if common.Delegate != "" {
-			idAccount = common.Delegate
-		}
 		if idAccountID, err := state.DecodeAccountID(idAccount); err == nil {
 			if data, rerr := e.view.Read(keylet.Account(idAccountID)); rerr == nil && data != nil {
 				if ar, perr := state.ParseAccountRoot(data); perr == nil && ar.IsPseudoAccount() {
@@ -407,13 +475,17 @@ func (e *Engine) checkMultiSign(common *txcore.Common) ter.Result {
 	if common.Delegate != "" {
 		idAccount = common.Delegate
 	}
+	return e.checkMultiSignForAccount(idAccount, common.Signers)
+}
+
+func (e *Engine) checkMultiSignForAccount(idAccount string, signers []txcore.SignerWrapper) ter.Result {
 	idAccountID, idErr := state.DecodeAccountID(idAccount)
 	if idErr != nil {
 		return ter.TefBAD_SIGNATURE
 	}
 	// Convert tx Signers to SignerInfo for checkBatchMultiSign
-	txSigners := make([]txcore.SignerInfo, len(common.Signers))
-	for i, sw := range common.Signers {
+	txSigners := make([]txcore.SignerInfo, len(signers))
+	for i, sw := range signers {
 		txSigners[i] = txcore.SignerInfo{
 			Account:       sw.Signer.Account,
 			SigningPubKey: sw.Signer.SigningPubKey,
@@ -426,20 +498,22 @@ func (e *Engine) checkMultiSign(common *txcore.Common) ter.Result {
 // the idAccount's master/regular key configuration.
 // Reference: rippled Transactor::checkSingleSign in Transactor.cpp lines 682-740.
 func (e *Engine) checkSingleSign(common *txcore.Common) ter.Result {
+	idAccount := common.Account
+	if common.Delegate != "" {
+		idAccount = common.Delegate
+	}
+	return e.checkSingleSignForAccount(idAccount, common.SigningPubKey)
+}
+
+func (e *Engine) checkSingleSignForAccount(idAccount, signingPubKey string) ter.Result {
 	// Single-signed transaction: check signing key authorization.
 	// This runs regardless of SkipSignatureVerification because authorization
 	// (master key disabled, regular key) is a ledger-state check, not a
 	// cryptographic check. The actual signature verification is done in
 	// Validate() and gated by SkipSignatureVerification.
-	signerAddress, addrErr := addresscodec.EncodeClassicAddressFromPublicKeyHex(common.SigningPubKey)
+	signerAddress, addrErr := addresscodec.EncodeClassicAddressFromPublicKeyHex(signingPubKey)
 	if addrErr != nil {
 		return ter.TefBAD_AUTH
-	}
-
-	// Determine the idAccount: delegate if present, else source account.
-	idAccount := common.Account
-	if common.Delegate != "" {
-		idAccount = common.Delegate
 	}
 
 	// Read the idAccount's data for signature authorization check

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -135,6 +135,9 @@ func (e *Engine) preflightStructure(tx txcore.Transaction, common *txcore.Common
 	if result := e.preflightMultiSignStructure(tx, common); result != ter.TesSUCCESS {
 		return result
 	}
+	if result := e.preflightSponsorSignStructure(common); result != ter.TesSUCCESS {
+		return result
+	}
 	if result := e.preflightBatchSignerStructure(tx); result != ter.TesSUCCESS {
 		return result
 	}
@@ -364,6 +367,9 @@ func checkSponsorFields(transaction txcore.Transaction, common *txcore.Common, r
 	if hasSponsorSignature && (!hasSponsor || !hasSponsorFlags) {
 		return ter.TemMALFORMED
 	}
+	if hasSponsorSignature && common.SponsorSignature == nil {
+		return ter.TemMALFORMED
+	}
 	if hasSponsorFlags {
 		if common.SponsorFlags == nil {
 			return ter.TemINVALID_FLAG
@@ -508,6 +514,49 @@ func (e *Engine) preflightMultiSignStructure(tx txcore.Transaction, common *txco
 	return ter.TesSUCCESS
 }
 
+// preflightSponsorSignStructure enforces the signature-object shape even when
+// cryptographic verification is disabled (simulation and the test harness).
+// Nested multisigners are ordered and unique by binary AccountID, but unlike
+// top-level Signers they are not compared with the transaction Account.
+func (e *Engine) preflightSponsorSignStructure(common *txcore.Common) ter.Result {
+	sponsor := common.SponsorSignature
+	if sponsor == nil {
+		return ter.TesSUCCESS
+	}
+	if sponsor.SigningPubKey != "" {
+		if len(sponsor.Signers) != 0 {
+			return ter.TemINVALID
+		}
+		return ter.TesSUCCESS
+	}
+	if len(sponsor.Signers) == 0 {
+		if sponsor.TxnSignature != "" {
+			return ter.TemINVALID
+		}
+		// An empty object is accepted only by dry-run/test configurations.
+		// The crypto verifier rejects it on a normal submission.
+		return ter.TesSUCCESS
+	}
+	if sponsor.TxnSignature != "" {
+		return ter.TemINVALID
+	}
+	if n := len(sponsor.Signers); n < sign.MinMultiSigners || n > sign.MaxMultiSigners {
+		return ter.TemINVALID
+	}
+	var lastAccountID [20]byte
+	for _, sw := range sponsor.Signers {
+		signerID, err := state.DecodeAccountID(sw.Signer.Account)
+		if err != nil {
+			return ter.TemINVALID
+		}
+		if signerID == lastAccountID || bytes.Compare(lastAccountID[:], signerID[:]) > 0 {
+			return ter.TemINVALID
+		}
+		lastAccountID = signerID
+	}
+	return ter.TesSUCCESS
+}
+
 // preflightBatchSignerStructure enforces the rules-gated upper bound on each
 // multi-signed BatchSigner's nested Signers array. rippled checks this inside
 // multiSignHelper (called from Batch::preflight with ctx.rules); an out-of-range
@@ -551,6 +600,14 @@ func (e *Engine) verifySignatures(tx txcore.Transaction) ter.Result {
 	// Validity::SigBad), which rippled maps to temINVALID.
 	if cp := tx.GetCommon().CounterpartySignature; cp != nil {
 		if err := sign.VerifyCounterpartySignature(tx, cp, true); err != nil {
+			return ter.TemINVALID
+		}
+	}
+	// SponsorSignature is checked after CounterpartySignature, matching
+	// STTx::checkSign. Its contents are excluded from the signing projection,
+	// but every signature still binds all ordinary transaction fields.
+	if sponsor := tx.GetCommon().SponsorSignature; sponsor != nil {
+		if err := sign.VerifySponsorSignature(tx, sponsor, true); err != nil {
 			return ter.TemINVALID
 		}
 	}

--- a/internal/tx/engine/sponsor_fee.go
+++ b/internal/tx/engine/sponsor_fee.go
@@ -63,8 +63,6 @@ func (e *Engine) getFeePayer(common *txcore.Common) (feePayer, ter.Result) {
 	}
 
 	if common.Delegate == "" {
-		// The source AccountRoot is already loaded and passed through every fee
-		// path, so no second decode/read is needed for the ordinary payer.
 		return feePayer{payerTy: feePayerAccount}, ter.TesSUCCESS
 	}
 	payerID, err := state.DecodeAccountID(common.Delegate)

--- a/internal/tx/engine/sponsor_fee.go
+++ b/internal/tx/engine/sponsor_fee.go
@@ -1,0 +1,230 @@
+package engine
+
+import (
+	"math"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/applystate"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/keylet"
+)
+
+type feePayerType uint8
+
+const (
+	feePayerAccount feePayerType = iota
+	feePayerDelegate
+	feePayerSponsorCoSigned
+	feePayerSponsorPreFunded
+)
+
+type feePayer struct {
+	keylet  keylet.Keylet
+	payerTy feePayerType
+}
+
+func isFeeSponsored(common *txcore.Common) bool {
+	return common != nil && common.Sponsor != "" && common.SponsorFlags != nil &&
+		*common.SponsorFlags&txcore.SpfSponsorFee != 0
+}
+
+// getFeePayer mirrors Transactor::getFeePayer. A relationship SLE is preferred
+// whenever it exists, even when the transaction also carries SponsorSignature.
+func (e *Engine) getFeePayer(common *txcore.Common) (feePayer, ter.Result) {
+	if isFeeSponsored(common) {
+		sponsorID, err := state.DecodeAccountID(common.Sponsor)
+		if err != nil {
+			return feePayer{}, ter.TerNO_ACCOUNT
+		}
+		initiator := common.Account
+		if common.Delegate != "" {
+			initiator = common.Delegate
+		}
+		initiatorID, err := state.DecodeAccountID(initiator)
+		if err != nil {
+			return feePayer{}, ter.TerNO_ACCOUNT
+		}
+		sponsorshipKey := keylet.Sponsorship(sponsorID, initiatorID)
+		exists, err := e.view.Exists(sponsorshipKey)
+		if err != nil {
+			return feePayer{}, ter.TefINTERNAL
+		}
+		if exists {
+			return feePayer{
+				keylet:  sponsorshipKey,
+				payerTy: feePayerSponsorPreFunded,
+			}, ter.TesSUCCESS
+		}
+		return feePayer{
+			keylet:  keylet.Account(sponsorID),
+			payerTy: feePayerSponsorCoSigned,
+		}, ter.TesSUCCESS
+	}
+
+	if common.Delegate == "" {
+		// The source AccountRoot is already loaded and passed through every fee
+		// path, so no second decode/read is needed for the ordinary payer.
+		return feePayer{payerTy: feePayerAccount}, ter.TesSUCCESS
+	}
+	payerID, err := state.DecodeAccountID(common.Delegate)
+	if err != nil {
+		return feePayer{}, ter.TerNO_ACCOUNT
+	}
+	return feePayer{
+		keylet:  keylet.Account(payerID),
+		payerTy: feePayerDelegate,
+	}, ter.TesSUCCESS
+}
+
+func (e *Engine) accountReserve(account *state.AccountRoot) (uint64, bool) {
+	if account == nil || account.SponsoredOwnerCount > account.OwnerCount {
+		return 0, false
+	}
+	owners := uint64(account.OwnerCount-account.SponsoredOwnerCount) +
+		uint64(account.SponsoringOwnerCount)
+	accounts := uint64(account.SponsoringAccountCount)
+	if !account.HasSponsor {
+		accounts++
+	}
+	if owners > math.MaxUint32 || accounts > math.MaxUint32 {
+		return 0, false
+	}
+	return e.config.AccountReserveWithCounts(uint32(owners), uint32(accounts)), true
+}
+
+// feePayerBalanceAndSpendable returns the payer's stored balance and the
+// maximum amount this transaction may consume. For pre-funded sponsorships the
+// stored balance is FeeAmount; for a co-signed sponsor spendable excludes the
+// account reserve.
+func (e *Engine) feePayerBalanceAndSpendable(payer feePayer, source *state.AccountRoot) (uint64, uint64, ter.Result) {
+	if payer.payerTy == feePayerAccount {
+		return source.Balance, source.Balance, ter.TesSUCCESS
+	}
+
+	data, err := e.view.Read(payer.keylet)
+	if err != nil {
+		return 0, 0, ter.TefINTERNAL
+	}
+	if data == nil {
+		if payer.payerTy == feePayerSponsorPreFunded {
+			return 0, 0, ter.TefINTERNAL
+		}
+		return 0, 0, ter.TerNO_ACCOUNT
+	}
+
+	if payer.payerTy == feePayerSponsorPreFunded {
+		sponsorship, err := state.ParseSponsorship(data)
+		if err != nil {
+			return 0, 0, ter.TefINTERNAL
+		}
+		balance := uint64(0)
+		if sponsorship.HasFeeAmount {
+			balance = sponsorship.FeeAmount
+		}
+		spendable := balance
+		if sponsorship.HasMaxFee {
+			spendable = min(spendable, sponsorship.MaxFee)
+		}
+		return balance, spendable, ter.TesSUCCESS
+	}
+
+	account, err := state.ParseAccountRoot(data)
+	if err != nil {
+		return 0, 0, ter.TefINTERNAL
+	}
+	spendable := account.Balance
+	if payer.payerTy == feePayerSponsorCoSigned {
+		reserve, ok := e.accountReserve(account)
+		if !ok {
+			return 0, 0, ter.TefINTERNAL
+		}
+		if spendable > reserve {
+			spendable -= reserve
+		} else {
+			spendable = 0
+		}
+	}
+	return account.Balance, spendable, ter.TesSUCCESS
+}
+
+func (st *applyState) hasExternalFeePayer() bool {
+	return st.isDelegated || st.feePayer.payerTy != feePayerAccount
+}
+
+// payExternalFeeOnTable charges Delegate, SponsorCoSigned, and
+// SponsorPreFunded payers. On a normal apply sponsor limits are rechecked
+// against the mutable view and insufficient funds reject the transaction. On a
+// recovery path the charge is clamped to the authorized spendable amount.
+func (e *Engine) payExternalFeeOnTable(
+	st *applyState,
+	table *applystate.ApplyStateTable,
+	recovery bool,
+) ter.Result {
+	if !st.hasExternalFeePayer() {
+		return ter.TesSUCCESS
+	}
+	balance, spendable, result := e.feePayerBalanceAndSpendable(st.feePayer, st.account)
+	if result != ter.TesSUCCESS {
+		return result
+	}
+
+	fee := st.fee
+	if fee > spendable {
+		if !recovery &&
+			(st.feePayer.payerTy == feePayerSponsorPreFunded ||
+				st.feePayer.payerTy == feePayerSponsorCoSigned) {
+			if spendable > 0 && !e.config.IsViewOpen() {
+				return ter.TecINSUFF_FEE
+			}
+			return ter.TerINSUF_FEE_B
+		}
+		fee = spendable
+	}
+	st.chargedFee = fee
+	if fee == 0 {
+		return ter.TesSUCCESS
+	}
+
+	if st.feePayer.payerTy == feePayerSponsorPreFunded {
+		data, err := e.view.Read(st.feePayer.keylet)
+		if err != nil || data == nil {
+			return ter.TefINTERNAL
+		}
+		sponsorship, err := state.ParseSponsorship(data)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		after := balance - fee
+		sponsorship.FeeAmount = after
+		sponsorship.HasFeeAmount = after != 0
+		updated, err := state.SerializeSponsorship(sponsorship)
+		if err != nil {
+			return ter.TefINTERNAL
+		}
+		if err := table.Update(st.feePayer.keylet, updated); err != nil {
+			return ter.TefINTERNAL
+		}
+		return ter.TesSUCCESS
+	}
+
+	data, err := e.view.Read(st.feePayer.keylet)
+	if err != nil || data == nil {
+		return ter.TefINTERNAL
+	}
+	account, err := state.ParseAccountRoot(data)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	account.Balance = balance - fee
+	account.PreviousTxnID = st.txHash
+	account.PreviousTxnLgrSeq = e.config.LedgerSequence
+	updated, err := state.SerializeAccountRoot(account)
+	if err != nil {
+		return ter.TefINTERNAL
+	}
+	if err := table.Update(st.feePayer.keylet, updated); err != nil {
+		return ter.TefINTERNAL
+	}
+	return ter.TesSUCCESS
+}

--- a/internal/tx/escrow/escrow_finish.go
+++ b/internal/tx/escrow/escrow_finish.go
@@ -121,7 +121,10 @@ func (e *EscrowFinish) CalculateBaseFee(view tx.LedgerView, config tx.EngineConf
 		}
 	}
 
-	fee := sign.CalculateMultiSigFee(base, len(e.GetCommon().Signers))
+	fee := sign.CalculateMultiSigFee(
+		base,
+		len(e.GetCommon().Signers)+sign.SponsorSignerCount(e),
+	)
 
 	if e.Fulfillment != nil {
 		fulfillmentLen := len(*e.Fulfillment) / 2

--- a/internal/tx/lending/loan_pay_apply.go
+++ b/internal/tx/lending/loan_pay_apply.go
@@ -70,10 +70,7 @@ func accountToLoan(loan *loanData, acc *lmath.LoanAccount) {
 // loanMaximumPaymentsPerTransaction / loanPaymentsPerFeeIncrement increments.
 func (l *LoanPay) CalculateBaseFee(view tx.LedgerView, config tx.EngineConfig) uint64 {
 	number := func(value string) lmath.N { return lendNumForRules(value, config.RequireRules()) }
-	normal := config.BaseFee
-	if sign.IsMultiSigned(l) {
-		normal = sign.CalculateMultiSigFee(config.BaseFee, len(l.GetCommon().Signers))
-	}
+	normal := sign.CalculateDefaultBaseFee(l, config)
 	if l.GetFlags()&(TfLoanFullPayment|TfLoanLatePayment) != 0 {
 		return normal
 	}

--- a/internal/tx/lending/loan_set_apply.go
+++ b/internal/tx/lending/loan_set_apply.go
@@ -43,13 +43,10 @@ func (l *LoanSet) loanSetValueFields() []string {
 	return fields
 }
 
-// CalculateBaseFee includes both the transaction signers and the nested
-// counterparty signers in the minimum fee.
+// CalculateBaseFee includes transaction and sponsor signers through the common
+// fee, then adds the nested counterparty signers.
 func (l *LoanSet) CalculateBaseFee(_ tx.LedgerView, config tx.EngineConfig) uint64 {
-	normal := config.BaseFee
-	if sign.IsMultiSigned(l) {
-		normal = sign.CalculateMultiSigFee(config.BaseFee, len(l.GetCommon().Signers))
-	}
+	normal := sign.CalculateDefaultBaseFee(l, config)
 	cp := l.GetCommon().CounterpartySignature
 	if cp == nil {
 		return normal

--- a/internal/tx/payment/payment.go
+++ b/internal/tx/payment/payment.go
@@ -67,11 +67,18 @@ const (
 	PaymentFlagPartialPayment uint32 = 0x00020000
 	// tfLimitQuality limits quality of paths
 	PaymentFlagLimitQuality uint32 = 0x00040000
+	// tfSponsorCreatedAccount makes the payment source fund the new
+	// destination account's base reserve.
+	PaymentFlagSponsorCreatedAccount uint32 = 0x00080000
 )
 
 // Payment invalid-flag masks (rippled tfPaymentMask / tfMPTPaymentMask).
 const (
-	tfPaymentMask    uint32 = ^(tx.TfUniversal | PaymentFlagPartialPayment | PaymentFlagLimitQuality | PaymentFlagNoDirectRipple)
+	tfPaymentMask uint32 = ^(tx.TfUniversal |
+		PaymentFlagPartialPayment |
+		PaymentFlagLimitQuality |
+		PaymentFlagNoDirectRipple |
+		PaymentFlagSponsorCreatedAccount)
 	tfMPTPaymentMask uint32 = ^(tx.TfUniversal | PaymentFlagPartialPayment)
 )
 
@@ -153,9 +160,24 @@ func (p *Payment) validate(rules *amendment.Rules) error {
 	isDstMPT := p.Amount.IsMPT()
 	rulesAware := rules != nil
 	mpTokensV2 := rulesAware && rules.MPTokensV2Enabled()
+	flags := p.GetFlags()
 	hasPaths := len(p.Paths) > 0 || p.HasField("Paths")
 	if rulesAware && isDstMPT && !rules.Enabled(amendment.FeatureMPTokensV1) {
 		return ter.Errorf(ter.TemDISABLED, "MPT payment requires MPTokensV1 amendment")
+	}
+	if flags&PaymentFlagSponsorCreatedAccount != 0 {
+		if rulesAware && !rules.Enabled(amendment.FeatureSponsor) {
+			return ter.Errorf(ter.TemDISABLED, "sponsored account creation requires Sponsor amendment")
+		}
+		if flags&(PaymentFlagNoDirectRipple|PaymentFlagPartialPayment|PaymentFlagLimitQuality) != 0 {
+			return ter.Errorf(ter.TemINVALID_FLAG, "sponsored account creation does not allow payment path flags")
+		}
+		if p.SendMax != nil || p.HasField("SendMax") || hasPaths {
+			return ter.Errorf(ter.TemINVALID, "sponsored account creation requires a direct payment")
+		}
+		if !p.Amount.IsNative() {
+			return ter.Errorf(ter.TemBAD_AMOUNT, "sponsored account creation requires XRP")
+		}
 	}
 	if rulesAware && !mpTokensV2 && isDstMPT && hasPaths {
 		return ter.Errorf(ter.TemMALFORMED, "Paths not allowed for MPT payment")
@@ -166,7 +188,6 @@ func (p *Payment) validate(rules *amendment.Rules) error {
 		}
 	}
 
-	flags := p.GetFlags()
 	srcAmount := p.Amount
 	if p.SendMax != nil {
 		srcAmount = *p.SendMax
@@ -319,9 +340,12 @@ func (p *Payment) Preclaim(view tx.LedgerView, config tx.EngineConfig) ter.Resul
 				return ter.TelNO_DST_PARTIAL
 			}
 			// The delivered amount must cover the account reserve.
-			if uint64(p.Amount.Drops()) < config.ReserveBase {
+			if uint64(p.Amount.Drops()) < config.ReserveBase &&
+				p.GetFlags()&PaymentFlagSponsorCreatedAccount == 0 {
 				return ter.TecNO_DST_INSUF_XRP
 			}
+		} else if p.GetFlags()&PaymentFlagSponsorCreatedAccount != 0 {
+			return ter.TecNO_SPONSOR_PERMISSION
 		} else if (destAccount.Flags&state.LsfRequireDestTag) != 0 && p.DestinationTag == nil {
 			// A newly-formed account is exempt — it has no way to set the flag.
 			return ter.TecDST_TAG_NEEDED

--- a/internal/tx/payment/payment_xrp.go
+++ b/internal/tx/payment/payment_xrp.go
@@ -1,6 +1,7 @@
 package payment
 
 import (
+	"math"
 	"strconv"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -27,20 +28,25 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) ter.Result {
 	}
 
 	// PriorBalance is the source account's balance before its own fee was
-	// deducted (rippled's mPriorBalance). For a delegated payment the fee is
-	// charged to the delegate, so the source balance is untouched.
+	// deducted (rippled's mPriorBalance). When a delegate or sponsor pays the
+	// fee, the source balance is untouched.
 	priorBalance := ctx.PriorBalance()
 
-	// Calculate reserve as: ReserveBase + (ownerCount * ReserveIncrement)
-	// This matches rippled's accountReserve(ownerCount) calculation
-	reserve := ctx.Config.ReserveBase + (uint64(ctx.Account.OwnerCount) * ctx.Config.ReserveIncrement)
+	accountCountDelta := uint32(0)
+	if p.GetFlags()&PaymentFlagSponsorCreatedAccount != 0 {
+		accountCountDelta = 1
+	}
+	reserve, ok := effectiveAccountReserve(ctx.Config, ctx.Account, accountCountDelta)
+	if !ok {
+		return ter.TecINTERNAL
+	}
 
 	// The final spend may dip into the reserve to cover its own fee — but only
-	// when the source account is the fee payer. In a delegated payment the fee
-	// payer is the delegate, so the source need only keep its plain reserve.
+	// when the source account is the fee payer. With an external delegate or
+	// sponsor, the source need only keep its plain reserve.
 	// Reference: rippled Payment.cpp doApply() (fix: decouple reserve from fee).
 	minRequired := reserve
-	if p.GetCommon().Delegate == "" {
+	if ctx.SourceFeeCharged != 0 {
 		minRequired = max(feeDrops, reserve)
 	}
 
@@ -121,8 +127,11 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) ter.Result {
 	}
 
 	// Destination doesn't exist - need to create it
-	// Check minimum amount for account creation
-	if amountDrops < ctx.Config.ReserveBase {
+	sponsorCreated := p.GetFlags()&PaymentFlagSponsorCreatedAccount != 0
+
+	// A normally-created account must fund its own base reserve. A sponsored
+	// account may start with a single drop because the source funds that reserve.
+	if amountDrops < ctx.Config.ReserveBase && !sponsorCreated {
 		return ter.TecNO_DST_INSUF_XRP
 	}
 
@@ -136,6 +145,14 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) ter.Result {
 		Flags:             0,
 		PreviousTxnID:     ctx.TxHash,
 		PreviousTxnLgrSeq: ctx.Config.LedgerSequence,
+	}
+	if sponsorCreated {
+		if ctx.Account.SponsoringAccountCount == math.MaxUint32 {
+			return ter.TecINTERNAL
+		}
+		ctx.Account.SponsoringAccountCount++
+		newAccount.Sponsor = p.Account
+		newAccount.HasSponsor = true
 	}
 
 	// Debit sender
@@ -153,4 +170,23 @@ func (p *Payment) applyXRPPayment(ctx *tx.ApplyContext) ter.Result {
 	}
 
 	return ter.TesSUCCESS
+}
+
+// effectiveAccountReserve mirrors accountReserve(AccountRoot): owner increments
+// paid by another sponsor are removed, owner/account units paid by this account
+// are added, and a sponsored account does not fund its own base reserve.
+func effectiveAccountReserve(config tx.EngineConfig, account *state.AccountRoot, accountDelta uint32) (uint64, bool) {
+	if account == nil || account.SponsoredOwnerCount > account.OwnerCount {
+		return 0, false
+	}
+	owners := uint64(account.OwnerCount-account.SponsoredOwnerCount) +
+		uint64(account.SponsoringOwnerCount)
+	accounts := uint64(account.SponsoringAccountCount) + uint64(accountDelta)
+	if !account.HasSponsor {
+		accounts++
+	}
+	if owners > math.MaxUint32 || accounts > math.MaxUint32 {
+		return 0, false
+	}
+	return config.AccountReserveWithCounts(uint32(owners), uint32(accounts)), true
 }

--- a/internal/tx/sign/signature.go
+++ b/internal/tx/sign/signature.go
@@ -362,9 +362,12 @@ func VerifyMultiSignatureCrypto(tx txcore.Transaction, mustBeFullyCanonical bool
 	return nil
 }
 
-// counterpartyPrefix labels every error surfaced from the nested
-// CounterpartySignature check, matching rippled's "Counterparty: " prefix.
-const counterpartyPrefix = "Counterparty: "
+// Nested-signature prefixes match the labels surfaced by rippled's
+// STTx::checkSign for the two optional signature objects.
+const (
+	counterpartyPrefix = "Counterparty: "
+	sponsorPrefix      = "Sponsor: "
+)
 
 // VerifyCounterpartySignature cryptographically verifies the nested
 // sfCounterpartySignature object, mirroring rippled STTx::checkSign(sigObject).
@@ -380,74 +383,126 @@ const counterpartyPrefix = "Counterparty: "
 // sign for the transaction's own Account. Every error is prefixed
 // "Counterparty: " to match rippled's messages.
 func VerifyCounterpartySignature(tx txcore.Transaction, cp *txcore.CounterpartySignature, mustBeFullyCanonical bool) error {
-	if cp.SigningPubKey != "" {
-		return verifyCounterpartySingleSign(tx, cp, mustBeFullyCanonical)
-	}
-	return verifyCounterpartyMultiSign(tx, cp, mustBeFullyCanonical)
+	return verifyNestedSignature(
+		tx,
+		cp.SigningPubKey,
+		cp.TxnSignature,
+		cp.Signers,
+		counterpartyPrefix,
+		mustBeFullyCanonical,
+	)
 }
 
-// verifyCounterpartySingleSign verifies a single-signed counterparty object. A
-// nested Signers array alongside a SigningPubKey means the object is signed two
-// ways and is rejected. Reference: rippled singleSignHelper.
-func verifyCounterpartySingleSign(tx txcore.Transaction, cp *txcore.CounterpartySignature, mustBeFullyCanonical bool) error {
-	if len(cp.Signers) > 0 {
-		return errors.New(counterpartyPrefix + "Cannot both single- and multi-sign.")
+// VerifySponsorSignature cryptographically verifies sfSponsorSignature. The
+// object signs the same canonical STX/SMT projection as the transaction's
+// ordinary signer; SponsorSignature itself is a non-signing field, so attaching
+// or replacing it cannot change that projection. Ledger authorization of the
+// sponsor's master/regular key or SignerList is performed later in preclaim.
+func VerifySponsorSignature(tx txcore.Transaction, sponsor *txcore.SponsorSignature, mustBeFullyCanonical bool) error {
+	return verifyNestedSignature(
+		tx,
+		sponsor.SigningPubKey,
+		sponsor.TxnSignature,
+		sponsor.Signers,
+		sponsorPrefix,
+		mustBeFullyCanonical,
+	)
+}
+
+func verifyNestedSignature(
+	tx txcore.Transaction,
+	signingPubKey string,
+	txnSignature string,
+	signers []txcore.SignerWrapper,
+	prefix string,
+	mustBeFullyCanonical bool,
+) error {
+	if signingPubKey != "" {
+		return verifyNestedSingleSign(
+			tx,
+			signingPubKey,
+			txnSignature,
+			signers,
+			prefix,
+			mustBeFullyCanonical,
+		)
+	}
+	return verifyNestedMultiSign(tx, txnSignature, signers, prefix, mustBeFullyCanonical)
+}
+
+// verifyNestedSingleSign verifies a single-signed nested object. A Signers
+// array alongside a SigningPubKey means the object is signed two ways.
+// Reference: rippled STTx::singleSignHelper.
+func verifyNestedSingleSign(
+	tx txcore.Transaction,
+	signingPubKey string,
+	txnSignature string,
+	signers []txcore.SignerWrapper,
+	prefix string,
+	mustBeFullyCanonical bool,
+) error {
+	if len(signers) > 0 {
+		return errors.New(prefix + "Cannot both single- and multi-sign.")
 	}
 	payload, err := getSigningPayload(tx)
 	if err != nil {
-		return errors.New(counterpartyPrefix + "Invalid signature.")
+		return errors.New(prefix + "Invalid signature.")
 	}
-	if !verifySignatureForKey(payload, cp.SigningPubKey, cp.TxnSignature, mustBeFullyCanonical) {
-		return errors.New(counterpartyPrefix + "Invalid signature.")
+	if !verifySignatureForKey(payload, signingPubKey, txnSignature, mustBeFullyCanonical) {
+		return errors.New(prefix + "Invalid signature.")
 	}
 	return nil
 }
 
-// verifyCounterpartyMultiSign verifies a multi-signed counterparty object. Each
-// nested signer signs the transaction's multi-signing payload suffixed with its
-// own account ID; signers must be sorted by account ID with no duplicates. A
-// direct TxnSignature alongside the Signers array is rejected as signed two
-// ways. Reference: rippled multiSignHelper (txnAccountID unseated, so a signer
-// may equal the transaction Account).
-func verifyCounterpartyMultiSign(tx txcore.Transaction, cp *txcore.CounterpartySignature, mustBeFullyCanonical bool) error {
+// verifyNestedMultiSign verifies a multi-signed nested object. The transaction
+// account is deliberately not supplied to this helper, so a nested signer may
+// equal the transaction Account. Reference: rippled multiSignHelper with an
+// unseated txnAccountID for CounterpartySignature and SponsorSignature.
+func verifyNestedMultiSign(
+	tx txcore.Transaction,
+	txnSignature string,
+	signers []txcore.SignerWrapper,
+	prefix string,
+	mustBeFullyCanonical bool,
+) error {
 	// An empty SigningPubKey with no Signers is neither a single- nor a
 	// multi-signature (rippled multiSignHelper's !isFieldPresent(sfSigners) arm).
-	if len(cp.Signers) == 0 {
-		return errors.New(counterpartyPrefix + "Empty SigningPubKey.")
+	if len(signers) == 0 {
+		return errors.New(prefix + "Empty SigningPubKey.")
 	}
-	if cp.TxnSignature != "" {
-		return errors.New(counterpartyPrefix + "Cannot both single- and multi-sign.")
+	if txnSignature != "" {
+		return errors.New(prefix + "Cannot both single- and multi-sign.")
 	}
-	if len(cp.Signers) > MaxMultiSigners {
-		return errors.New(counterpartyPrefix + "Invalid Signers array size.")
+	if len(signers) > MaxMultiSigners {
+		return errors.New(prefix + "Invalid Signers array size.")
 	}
 
 	txMap, err := flattenForSigning(tx)
 	if err != nil {
-		return errors.New(counterpartyPrefix + "Invalid signature.")
+		return errors.New(prefix + "Invalid signature.")
 	}
 
 	var lastAccountID [20]byte
-	for _, sw := range cp.Signers {
+	for _, sw := range signers {
 		signer := sw.Signer
 		accountID, decErr := state.DecodeAccountID(signer.Account)
 		if decErr != nil {
-			return fmt.Errorf("%sInvalid signature on account %s.", counterpartyPrefix, signer.Account)
+			return fmt.Errorf("%sInvalid signature on account %s.", prefix, signer.Account)
 		}
 		if lastAccountID == accountID {
-			return errors.New(counterpartyPrefix + "Duplicate Signers not allowed.")
+			return errors.New(prefix + "Duplicate Signers not allowed.")
 		}
 		if bytes.Compare(lastAccountID[:], accountID[:]) > 0 {
-			return errors.New(counterpartyPrefix + "Unsorted Signers array.")
+			return errors.New(prefix + "Unsorted Signers array.")
 		}
 		lastAccountID = accountID
 
 		payload, encErr := binarycodec.EncodeForMultisigning(copyMap(txMap), signer.Account)
 		if encErr != nil {
-			return fmt.Errorf("%sInvalid signature on account %s.", counterpartyPrefix, signer.Account)
+			return fmt.Errorf("%sInvalid signature on account %s.", prefix, signer.Account)
 		}
 		if !verifySignatureForKey(payload, signer.SigningPubKey, signer.TxnSignature, mustBeFullyCanonical) {
-			return fmt.Errorf("%sInvalid signature on account %s.", counterpartyPrefix, signer.Account)
+			return fmt.Errorf("%sInvalid signature on account %s.", prefix, signer.Account)
 		}
 	}
 	return nil
@@ -465,6 +520,17 @@ func SignCounterparty(tx txcore.Transaction, pubKeyHex, privateKeyHex string) (*
 		return nil, err
 	}
 	return &txcore.CounterpartySignature{SigningPubKey: pubKeyHex, TxnSignature: sig}, nil
+}
+
+// SignSponsor produces a single-signed SponsorSignature over the transaction's
+// canonical signing projection. The caller must populate every signed field
+// (including Fee, Sequence, and the top-level SigningPubKey) first.
+func SignSponsor(tx txcore.Transaction, pubKeyHex, privateKeyHex string) (*txcore.SponsorSignature, error) {
+	sig, err := SignTransaction(tx, privateKeyHex)
+	if err != nil {
+		return nil, err
+	}
+	return &txcore.SponsorSignature{SigningPubKey: pubKeyHex, TxnSignature: sig}, nil
 }
 
 // copyMap creates a shallow copy of a map to avoid modifying the original
@@ -603,10 +669,25 @@ func CalculateMultiSigFee(baseFee uint64, numSigners int) uint64 {
 // CalculateDefaultBaseFee returns the ordinary transaction fee without any
 // transaction-specific override.
 func CalculateDefaultBaseFee(transaction txcore.Transaction, config txcore.EngineConfig) uint64 {
-	if IsMultiSigned(transaction) {
-		return CalculateMultiSigFee(config.BaseFee, len(transaction.GetCommon().Signers))
+	common := transaction.GetCommon()
+	return CalculateMultiSigFee(
+		config.BaseFee,
+		len(common.Signers)+SponsorSignerCount(transaction),
+	)
+}
+
+// SponsorSignerCount returns the number of signatures in a sponsor's nested
+// multisignature. A direct sponsor signature adds no extra fee unit; each
+// nested Signer adds one base-fee unit.
+func SponsorSignerCount(transaction txcore.Transaction) int {
+	if transaction == nil || transaction.GetCommon() == nil {
+		return 0
 	}
-	return config.BaseFee
+	sponsor := transaction.GetCommon().SponsorSignature
+	if sponsor == nil {
+		return 0
+	}
+	return len(sponsor.Signers)
 }
 
 // CalculateBaseFee dispatches transaction-specific fees before falling back to

--- a/internal/tx/sign/sponsor_signature_test.go
+++ b/internal/tx/sign/sponsor_signature_test.go
@@ -1,0 +1,187 @@
+package sign
+
+import (
+	"testing"
+
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+func sponsorSignedTx(t *testing.T) txcore.Transaction {
+	t.Helper()
+
+	primaryPriv, primaryPub, primaryAddress := cpKeypair(t, 0x71)
+	_, _, sponsorAddress := cpKeypair(t, 0x72)
+	transaction := txcore.NewBaseTx(txcore.TypeAccountSet, primaryAddress)
+	sequence := uint32(7)
+	sponsorFlags := txcore.SpfSponsorFee
+	transaction.Common.Sequence = &sequence
+	transaction.Common.Fee = "30"
+	transaction.Common.SigningPubKey = primaryPub
+	transaction.Common.Sponsor = sponsorAddress
+	transaction.Common.SponsorFlags = &sponsorFlags
+
+	signature, err := SignTransaction(transaction, primaryPriv)
+	if err != nil {
+		t.Fatalf("sign primary: %v", err)
+	}
+	transaction.Common.TxnSignature = signature
+	return transaction
+}
+
+func TestSponsorSignatureSigningPayloadGoldenAndExcluded(t *testing.T) {
+	transaction := sponsorSignedTx(t)
+
+	without, err := getSigningPayload(transaction)
+	if err != nil {
+		t.Fatalf("payload without sponsor signature: %v", err)
+	}
+	const want = "535458001200032400000007204A0000000168400000000000001E" +
+		"7321ED3B647A635E9ACF162B1F262885774A7C373F66FE5AFEE2F413BED997496287" +
+		"4F81148DB791CC6DA37E274C9C65C62EA7A95821DABB6A801B14EF6D30FF728633B" +
+		"134E5C7A9E7B0C5E6F37FF77F"
+	if without != want {
+		t.Fatalf("signing payload = %s", without)
+	}
+
+	sponsorPriv, sponsorPub, _ := cpKeypair(t, 0x72)
+	sponsorSignature, err := SignSponsor(transaction, sponsorPub, sponsorPriv)
+	if err != nil {
+		t.Fatalf("sign sponsor: %v", err)
+	}
+	transaction.GetCommon().SponsorSignature = sponsorSignature
+
+	with, err := getSigningPayload(transaction)
+	if err != nil {
+		t.Fatalf("payload with sponsor signature: %v", err)
+	}
+	if with != without {
+		t.Fatalf("SponsorSignature changed signing payload:\n with=%s\n without=%s", with, without)
+	}
+	if err := VerifySponsorSignature(transaction, sponsorSignature, false); err != nil {
+		t.Fatalf("valid sponsor signature rejected: %v", err)
+	}
+}
+
+func TestSponsorSignatureBindsTransactionFields(t *testing.T) {
+	transaction := sponsorSignedTx(t)
+	sponsorPriv, sponsorPub, _ := cpKeypair(t, 0x72)
+	sponsorSignature, err := SignSponsor(transaction, sponsorPub, sponsorPriv)
+	if err != nil {
+		t.Fatalf("sign sponsor: %v", err)
+	}
+	transaction.GetCommon().SponsorSignature = sponsorSignature
+
+	common := transaction.GetCommon()
+	common.Fee = "31"
+	if err := VerifySponsorSignature(transaction, sponsorSignature, false); err == nil {
+		t.Fatal("sponsor signature accepted after Fee mutation")
+	}
+	common.Fee = "30"
+
+	mutatedSequence := uint32(8)
+	common.Sequence = &mutatedSequence
+	if err := VerifySponsorSignature(transaction, sponsorSignature, false); err == nil {
+		t.Fatal("sponsor signature accepted after Sequence mutation")
+	}
+	common.Sequence = func() *uint32 {
+		sequence := uint32(7)
+		return &sequence
+	}()
+
+	_, _, otherSponsor := cpKeypair(t, 0x73)
+	common.Sponsor = otherSponsor
+	if err := VerifySponsorSignature(transaction, sponsorSignature, false); err == nil {
+		t.Fatal("sponsor signature accepted after Sponsor mutation")
+	}
+}
+
+func TestSponsorSignatureMultiSignValidation(t *testing.T) {
+	transaction := sponsorSignedTx(t)
+
+	signer1Priv, signer1Pub, signer1Address := cpKeypair(t, 0x74)
+	signer2Priv, signer2Pub, signer2Address := cpKeypair(t, 0x75)
+	signature1, err := SignTransactionForMultiSign(transaction, signer1Address, signer1Priv)
+	if err != nil {
+		t.Fatalf("sign sponsor signer 1: %v", err)
+	}
+	signature2, err := SignTransactionForMultiSign(transaction, signer2Address, signer2Priv)
+	if err != nil {
+		t.Fatalf("sign sponsor signer 2: %v", err)
+	}
+	signers := []txcore.SignerWrapper{
+		{Signer: txcore.Signer{Account: signer1Address, SigningPubKey: signer1Pub, TxnSignature: signature1}},
+		{Signer: txcore.Signer{Account: signer2Address, SigningPubKey: signer2Pub, TxnSignature: signature2}},
+	}
+	sortSigners(signers)
+
+	sponsorSignature := &txcore.SponsorSignature{Signers: signers}
+	if err := VerifySponsorSignature(transaction, sponsorSignature, false); err != nil {
+		t.Fatalf("valid sponsor multisignature rejected: %v", err)
+	}
+
+	unsorted := append([]txcore.SignerWrapper(nil), signers...)
+	unsorted[0], unsorted[1] = unsorted[1], unsorted[0]
+	if err := VerifySponsorSignature(
+		transaction,
+		&txcore.SponsorSignature{Signers: unsorted},
+		false,
+	); err == nil {
+		t.Fatal("unsorted sponsor multisigners accepted")
+	}
+
+	duplicate := []txcore.SignerWrapper{signers[0], signers[0]}
+	if err := VerifySponsorSignature(
+		transaction,
+		&txcore.SponsorSignature{Signers: duplicate},
+		false,
+	); err == nil {
+		t.Fatal("duplicate sponsor multisigners accepted")
+	}
+
+	signedTwice := &txcore.SponsorSignature{
+		SigningPubKey: signer1Pub,
+		TxnSignature:  signature1,
+		Signers:       signers,
+	}
+	if err := VerifySponsorSignature(transaction, signedTwice, false); err == nil {
+		t.Fatal("single- and multi-signed sponsor object accepted")
+	}
+}
+
+func TestCalculateDefaultBaseFeeIncludesSponsorMultisigners(t *testing.T) {
+	config := txcore.EngineConfig{BaseFee: 10}
+	testCases := []struct {
+		name           string
+		outerSigners   int
+		sponsorSigners int
+		want           uint64
+	}{
+		{name: "ordinary single sign", want: 10},
+		{name: "ordinary multisign", outerSigners: 2, want: 30},
+		{name: "direct sponsor signature adds no unit", sponsorSigners: 0, want: 10},
+		{name: "sponsor multisign", sponsorSigners: 2, want: 30},
+		{name: "outer and sponsor multisign", outerSigners: 2, sponsorSigners: 2, want: 50},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			transaction := txcore.NewBaseTx(txcore.TypeAccountSet, "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh")
+			if testCase.outerSigners > 0 {
+				transaction.Common.Signers = make([]txcore.SignerWrapper, testCase.outerSigners)
+			}
+			if testCase.name == "direct sponsor signature adds no unit" {
+				transaction.Common.SponsorSignature = &txcore.SponsorSignature{
+					SigningPubKey: "ED01",
+					TxnSignature:  "AA",
+				}
+			} else if testCase.sponsorSigners > 0 {
+				transaction.Common.SponsorSignature = &txcore.SponsorSignature{
+					Signers: make([]txcore.SignerWrapper, testCase.sponsorSigners),
+				}
+			}
+			if got := CalculateDefaultBaseFee(transaction, config); got != testCase.want {
+				t.Fatalf("CalculateDefaultBaseFee() = %d, want %d", got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/txq/admission_apply_test.go
+++ b/internal/txq/admission_apply_test.go
@@ -37,6 +37,10 @@ func (m *seqTx) GetRawBytes() []byte              { return []byte{byte(m.seq)} }
 func (m *seqTx) SetRawBytes([]byte)               {}
 func (m *seqTx) RequiredAmendments() [][32]byte   { return nil }
 
+type batchSeqTx struct{ *seqTx }
+
+func (m *batchSeqTx) TxType() tx.Type { return tx.TypeBatch }
+
 // stubApplyCtx is a configurable txq.ApplyContext for admission tests. The
 // preflight/preclaim/apply results are dialled in per test so we can pin which
 // admission path rejects (or queues) a submission.
@@ -646,6 +650,44 @@ func TestApplyFeeSponsoredTransactionCannotQueueButMayApplyDirectly(t *testing.T
 		result := q.Apply(ctx, transaction, [32]byte{0xF1}, account)
 		require.Equal(t, ter.TerQUEUED, result.Result)
 		require.True(t, result.Queued)
+	})
+}
+
+func TestApplyBatchCannotQueueButMayApplyDirectly(t *testing.T) {
+	account := [20]byte{9}
+
+	t.Run("cannot queue", func(t *testing.T) {
+		q := New(makeAdmissionConfig())
+		ctx := &stubApplyCtx{
+			seq:        5,
+			balance:    1_000_000_000,
+			exists:     true,
+			baseFee:    10,
+			txInLedger: 100,
+		}
+
+		result := q.Apply(ctx, &batchSeqTx{seqTx: &seqTx{seq: 5, fee: "10"}}, [32]byte{0xF2}, account)
+		require.Equal(t, ter.TelCAN_NOT_QUEUE, result.Result)
+		require.False(t, result.Applied)
+		require.False(t, result.Queued)
+		require.Zero(t, q.Size())
+	})
+
+	t.Run("may apply directly", func(t *testing.T) {
+		q := New(makeAdmissionConfig())
+		ctx := &stubApplyCtx{
+			seq:      5,
+			balance:  1_000_000_000,
+			exists:   true,
+			baseFee:  10,
+			applyRes: ter.TesSUCCESS,
+			applied:  true,
+		}
+
+		result := q.Apply(ctx, &batchSeqTx{seqTx: &seqTx{seq: 5, fee: "10"}}, [32]byte{0xF3}, account)
+		require.Equal(t, ter.TesSUCCESS, result.Result)
+		require.True(t, result.Applied)
+		require.False(t, result.Queued)
 	})
 }
 

--- a/internal/txq/admission_apply_test.go
+++ b/internal/txq/admission_apply_test.go
@@ -15,6 +15,7 @@ type seqTx struct {
 	seq          uint32
 	fee          string
 	delegate     string
+	sponsor      string
 	sponsorFlags *uint32
 }
 
@@ -26,6 +27,7 @@ func (m *seqTx) GetCommon() *tx.Common {
 		Sequence:     &s,
 		Fee:          m.fee,
 		Delegate:     m.delegate,
+		Sponsor:      m.sponsor,
 		SponsorFlags: m.sponsorFlags,
 	}
 }
@@ -143,38 +145,21 @@ func TestAcceptDropsTefCategory(t *testing.T) {
 	}
 }
 
-func TestApplyRejectsDelegatedAndFeeSponsoredTransactionsFromQueue(t *testing.T) {
-	feeSponsorFlags := tx.SpfSponsorFee
-	tests := []struct {
-		name string
-		txn  *seqTx
-	}{
-		{
-			name: "delegated",
-			txn:  &seqTx{seq: 6, fee: "10", delegate: "rDelegate"},
-		},
-		{
-			name: "fee sponsored",
-			txn:  &seqTx{seq: 6, fee: "10", sponsorFlags: &feeSponsorFlags},
-		},
+func TestApplyRejectsDelegatedTransactionFromQueue(t *testing.T) {
+	q := New(makeAdmissionConfig())
+	ctx := &stubApplyCtx{
+		seq:      5,
+		balance:  1_000_000,
+		exists:   true,
+		baseFee:  10,
+		preclaim: ter.TesSUCCESS,
 	}
+	transaction := &seqTx{seq: 6, fee: "10", delegate: "rDelegate"}
 
-	for i, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			q := New(makeAdmissionConfig())
-			ctx := &stubApplyCtx{
-				seq:      5,
-				balance:  1_000_000,
-				exists:   true,
-				baseFee:  10,
-				preclaim: ter.TesSUCCESS,
-			}
-			result := q.Apply(ctx, test.txn, [32]byte{byte(i + 1)}, [20]byte{1})
-			require.Equal(t, ter.TelCAN_NOT_QUEUE, result.Result)
-			require.False(t, result.Applied)
-			require.Zero(t, q.Size())
-		})
-	}
+	result := q.Apply(ctx, transaction, [32]byte{1}, [20]byte{1})
+	require.Equal(t, ter.TelCAN_NOT_QUEUE, result.Result)
+	require.False(t, result.Applied)
+	require.Zero(t, q.Size())
 }
 
 func TestAcceptRevisitsNextAccountCandidateAcrossGap(t *testing.T) {
@@ -588,6 +573,80 @@ func TestApply_H1_PreclaimPassesQueues(t *testing.T) {
 
 	require.Equal(t, ter.TerQUEUED, res.Result)
 	require.True(t, res.Queued)
+}
+
+func TestApplyFeeSponsoredTransactionCannotQueueButMayApplyDirectly(t *testing.T) {
+	account := [20]byte{9}
+	feeFlag := tx.SpfSponsorFee
+	sponsor := "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+	t.Run("cannot queue", func(t *testing.T) {
+		q := New(makeAdmissionConfig())
+		ctx := &stubApplyCtx{
+			seq:        5,
+			balance:    1_000_000_000,
+			exists:     true,
+			baseFee:    10,
+			txInLedger: 100,
+		}
+		transaction := &seqTx{
+			seq:          5,
+			fee:          "10",
+			sponsor:      sponsor,
+			sponsorFlags: &feeFlag,
+		}
+
+		result := q.Apply(ctx, transaction, [32]byte{0xEF}, account)
+		require.Equal(t, ter.TelCAN_NOT_QUEUE, result.Result)
+		require.False(t, result.Applied)
+		require.False(t, result.Queued)
+		require.Zero(t, q.Size())
+	})
+
+	t.Run("may apply directly", func(t *testing.T) {
+		q := New(makeAdmissionConfig())
+		ctx := &stubApplyCtx{
+			seq:      5,
+			balance:  1_000_000_000,
+			exists:   true,
+			baseFee:  10,
+			applyRes: ter.TesSUCCESS,
+			applied:  true,
+		}
+		transaction := &seqTx{
+			seq:          5,
+			fee:          "10",
+			sponsor:      sponsor,
+			sponsorFlags: &feeFlag,
+		}
+
+		result := q.Apply(ctx, transaction, [32]byte{0xF0}, account)
+		require.Equal(t, ter.TesSUCCESS, result.Result)
+		require.True(t, result.Applied)
+		require.False(t, result.Queued)
+	})
+
+	t.Run("reserve only remains queueable", func(t *testing.T) {
+		q := New(makeAdmissionConfig())
+		ctx := &stubApplyCtx{
+			seq:        5,
+			balance:    1_000_000_000,
+			exists:     true,
+			baseFee:    10,
+			txInLedger: 100,
+		}
+		reserveFlag := tx.SpfSponsorReserve
+		transaction := &seqTx{
+			seq:          5,
+			fee:          "10",
+			sponsor:      sponsor,
+			sponsorFlags: &reserveFlag,
+		}
+
+		result := q.Apply(ctx, transaction, [32]byte{0xF1}, account)
+		require.Equal(t, ter.TerQUEUED, result.Result)
+		require.True(t, result.Queued)
+	})
 }
 
 // TestApply_BadFeeRejected pins that a malformed Fee string is rejected with

--- a/internal/txq/apply.go
+++ b/internal/txq/apply.go
@@ -193,7 +193,12 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 	if common.Delegate != "" {
 		return ApplyResult{Result: ter.TelCAN_NOT_QUEUE, Applied: false}
 	}
-	if common.SponsorFlags != nil && *common.SponsorFlags&tx.SpfSponsorFee != 0 {
+	// A fee-sponsored transaction may apply directly, but it must never be
+	// held: its payer is external to the per-source-account balance chain
+	// modelled by TxQ. Reserve-only sponsorship does not change that chain and
+	// remains queueable.
+	if common.Sponsor != "" && common.SponsorFlags != nil &&
+		*common.SponsorFlags&tx.SpfSponsorFee != 0 {
 		return ApplyResult{Result: ter.TelCAN_NOT_QUEUE, Applied: false}
 	}
 

--- a/internal/txq/apply.go
+++ b/internal/txq/apply.go
@@ -190,6 +190,9 @@ func (q *TxQ) Apply(ctx ApplyContext, txn tx.Transaction, txID [32]byte, account
 	if ctx.GetApplyFlags()&tx.TapFAIL_HARD != 0 {
 		return ApplyResult{Result: ter.TelCAN_NOT_QUEUE, Applied: false}
 	}
+	if txn.TxType() == tx.TypeBatch {
+		return ApplyResult{Result: ter.TelCAN_NOT_QUEUE, Applied: false}
+	}
 	if common.Delegate != "" {
 		return ApplyResult{Result: ter.TelCAN_NOT_QUEUE, Applied: false}
 	}


### PR DESCRIPTION
## Summary

- verify Sponsor single-sign and multisign payloads, signer ordering, quorum, and ledger authorization
- select and charge the canonical fee payer across source, delegate, co-signed sponsor, and pre-funded sponsorship paths, including tec and invariant recovery
- account for nested Sponsor signers in transaction-specific base fees
- implement `tfSponsorCreatedAccount` reserve sponsorship and the matching account-root counters
- enforce Sponsor interactions for Batch, Delegate, Tickets, and TxQ admission

The implementation follows rippled's `Transactor.cpp`, `Batch.cpp`, `Payment.cpp`, `AccountRootHelpers.cpp`, and `Sponsor_test.cpp` behavior. The Sponsor signing regression includes a golden preimage and proves that mutating Fee, Sequence, or Sponsor invalidates the signature.

## Verification

- `CGO_ENABLED=0 go test -count=1 ./internal/tx/sign ./internal/tx/engine ./internal/tx/payment ./internal/tx/batch ./internal/tx/escrow ./internal/tx/lending ./internal/txq ./internal/testing/sponsor`
- `CGO_ENABLED=0 go test -count=1 -timeout 15m ./internal/tx/...`
- `CGO_ENABLED=0 go test -count=1 -timeout 15m ./internal/testing/...`
  - every package passed except `internal/testing/p2p`
  - its five `TestTwoOverlay_*` cases cannot start the overlay listener with the local `!cgo` peer-TLS stub; `pkg-config` is unavailable in this environment
  - the same package fails before reaching any Sponsor path, while Sponsor, Batch, Delegate, Payment, Ticket, TxQ, Offer, consensus, and validation archive integrations pass
- `CGO_ENABLED=0 go build ./...`
- `GOOS=linux GOARCH=386 CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go vet -stdmethods=false ./...`
- `CGO_ENABLED=0 golangci-lint run --config .golangci.yml`
- `CGO_ENABLED=0 golangci-lint run --config .golangci-warnings.yml`
- `git diff --check origin/v3.3.0...HEAD`

Fixes #1367
