### PR TITLE
fix: preserve fast-load recovery progress

### DIFF
--- a/internal/consensus/adaptor/acquisition_disconnect_test.go
+++ b/internal/consensus/adaptor/acquisition_disconnect_test.go
@@ -301,6 +301,67 @@ func TestMissingReplyRequest_DisconnectErrorsReleaseAndRetarget(t *testing.T) {
 	}
 }
 
+func TestMissingReplyRequest_StaleSessionSkipsSendAndRetargets(t *testing.T) {
+	for _, transaction := range []bool{false, true} {
+		name := "state"
+		if transaction {
+			name = "transaction"
+		}
+		t.Run(name, func(t *testing.T) {
+			sender := &missingNodeChurnSender{replacements: []uint64{2}}
+			router := newMissingNodeChurnRouter(t, sender)
+			router.setPeerSessionView(&testPeerSessions{
+				connected: map[peermanagement.PeerID]bool{2: true},
+			})
+			ledger, _ := newDisconnectFrontier(t, transaction)
+			router.fetchTracker.Track(ledger)
+			trackCatchupPeer(router, 1, ledger.Seq())
+			requests, complete, err := ledger.CollectMissingReplyRequestsContext(t.Context(), []uint64{1})
+			require.NoError(t, err)
+			require.False(t, complete)
+			require.Len(t, requests, 1)
+
+			router.handleAcquisitionWorkResult(acquisitionWorkResult{
+				ledger:   ledger,
+				requests: requests,
+			})
+
+			calls := sender.snapshotCalls()
+			require.Len(t, calls, 1)
+			assert.Equal(t, uint64(2), calls[0].peerID)
+			assert.Equal(t, transaction, calls[0].transaction)
+			assert.NotContains(t, ledger.Peers(), uint64(1))
+			assert.Contains(t, ledger.Peers(), uint64(2))
+		})
+	}
+}
+
+func TestAcquisitionWorkResult_StaleTimerSessionSkipsSendAndRetargets(t *testing.T) {
+	sender := &missingNodeChurnSender{replacements: []uint64{2}}
+	router := newMissingNodeChurnRouter(t, sender)
+	router.setPeerSessionView(&testPeerSessions{
+		connected: map[peermanagement.PeerID]bool{2: true},
+	})
+	ledger, _ := newDisconnectFrontier(t, false)
+	router.fetchTracker.Track(ledger)
+	stateIDs, _, complete, err := ledger.CollectMissingRequestContext(t.Context(), false)
+	require.NoError(t, err)
+	require.False(t, complete)
+	require.NotEmpty(t, stateIDs)
+
+	router.handleAcquisitionWorkResult(acquisitionWorkResult{
+		ledger:   ledger,
+		targets:  []uint64{1},
+		stateIDs: stateIDs,
+	})
+
+	calls := sender.snapshotCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, uint64(2), calls[0].peerID)
+	assert.NotContains(t, ledger.Peers(), uint64(1))
+	assert.Contains(t, ledger.Peers(), uint64(2))
+}
+
 func TestRequestMissingAcquisitionNodes_MixedStaleLiveFanout(t *testing.T) {
 	sender := &missingNodeChurnSender{
 		errs: map[missingNodeTarget]error{

--- a/internal/consensus/adaptor/acquisition_work.go
+++ b/internal/consensus/adaptor/acquisition_work.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
@@ -812,6 +813,11 @@ func (r *Router) sendMissingReplyRequest(ledger *inbound.Ledger, request inbound
 	} else if latency, ok := r.adaptor.PeerLatency(request.PeerID); ok && latency >= 300*time.Millisecond {
 		queryDepth = 2
 	}
+	if !r.acquisitionPeerConnected(request.PeerID) {
+		ledger.ReleaseMissingRequest(request.PeerID, request.NodeHashes)
+		r.removeStaleAcquisitionPeer(ledger, request.PeerID)
+		return true
+	}
 	var err error
 	if request.Transaction {
 		err = r.adaptor.RequestTransactionNodes(request.PeerID, ledger.Hash(), request.NodeIDs, queryDepth, indirect)
@@ -842,6 +848,12 @@ func (r *Router) sendMissingAcquisitionNodes(
 	var txSent, txDisconnected bool
 	for _, peerID := range peers {
 		disconnected := false
+		if !r.acquisitionPeerConnected(peerID) {
+			r.removeStaleAcquisitionPeer(ledger, peerID)
+			stateDisconnected = stateDisconnected || len(stateIDs) > 0
+			txDisconnected = txDisconnected || len(txIDs) > 0
+			continue
+		}
 		if len(stateIDs) > 0 {
 			if err := r.adaptor.RequestStateNodes(peerID, ledger.Hash(), stateIDs, queryDepth, indirect); err != nil {
 				disconnected = r.handleMissingNodeSendFailure(ledger, peerID, false, err)
@@ -871,6 +883,15 @@ func (r *Router) sendMissingAcquisitionNodes(
 		retry.txIDs = txIDs
 	}
 	return retry
+}
+
+func (r *Router) acquisitionPeerConnected(peerID uint64) bool {
+	return r.peerSessions == nil || r.peerSessions.IsPeerConnected(peermanagement.PeerID(peerID))
+}
+
+func (r *Router) removeStaleAcquisitionPeer(ledger *inbound.Ledger, peerID uint64) {
+	ledger.RemovePeer(peerID)
+	r.HandlePeerDisconnect(peermanagement.PeerID(peerID))
 }
 
 func applyAcquisitionData(ctx context.Context, ledger *inbound.Ledger, data *message.LedgerData) (useful int, badKind string, remove, complete bool, err error) {

--- a/internal/consensus/adaptor/router_wrong_ledger_acquisition_test.go
+++ b/internal/consensus/adaptor/router_wrong_ledger_acquisition_test.go
@@ -3,6 +3,7 @@ package adaptor
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
@@ -159,6 +160,66 @@ func TestAdaptorRequestLedgerKeepsActiveStepAndQueuesLatestTarget(t *testing.T) 
 	assert.Equal(t, queuedHash, r.consensusRecovery.targetHash)
 	require.Len(t, sender.legacyCalls(), 2)
 	assert.Equal(t, queuedHash, sender.legacyCalls()[1].hash)
+}
+
+func TestConsensusRecoveryKeepsProgressingStepAcrossIntermittentStalls(t *testing.T) {
+	r, a, sender, _ := makeRouter(t)
+	source := newWideWorkSource(t, 4)
+	ledger, baseNodes := newWantBaseWorkLedger(t, source, []uint64{7})
+	require.NoError(t, ledger.GotBase(baseNodes))
+
+	wire, err := source.WalkWireNodes()
+	require.NoError(t, err)
+	var ancestors, replies []message.LedgerNode
+	for _, node := range wire {
+		depth := node.NodeID[32]
+		ledgerNode := message.LedgerNode{NodeID: node.NodeID, NodeData: node.Data}
+		if depth == 1 || depth == 2 {
+			ancestors = append(ancestors, ledgerNode)
+		} else if depth == 3 && len(replies) < 7 {
+			replies = append(replies, ledgerNode)
+		}
+	}
+	added, err := ledger.GotStateNodesUseful(ancestors)
+	require.NoError(t, err)
+	require.Equal(t, len(ancestors), added)
+	require.Len(t, replies, 7)
+
+	activeHash := ledger.Hash()
+	latestHash := [32]byte{0xBA}
+	r.fetchTracker.Track(ledger)
+	r.consensusRecovery = consensusRecovery{
+		targetHash: activeHash,
+		stepHash:   activeHash,
+	}
+	require.NoError(t, a.RequestLedger(consensus.LedgerID(latestHash)))
+	require.Equal(t, latestHash, r.consensusRecovery.targetHash)
+
+	now := time.Unix(1_700_000_000, 0)
+	ledger.RearmTimer(now)
+	require.Equal(t, inbound.TimerRefresh, ledger.OnTimer(now.Add(time.Minute)))
+	now = now.Add(time.Minute)
+
+	for i, reply := range replies {
+		now = now.Add(time.Minute)
+		require.Equal(t, inbound.TimerEscalate, ledger.OnTimer(now), "stall %d", i+1)
+		ledger.RearmTimer(now)
+
+		added, err := ledger.GotStateNodesUseful([]message.LedgerNode{reply})
+		require.NoError(t, err)
+		require.Equal(t, 1, added)
+
+		now = now.Add(time.Minute)
+		require.Equal(t, inbound.TimerRefresh, ledger.OnTimer(now), "progress %d", i+1)
+		r.armConsensusCatchup()
+		require.Same(t, ledger, r.fetchTracker.Find(activeHash))
+		assert.Nil(t, r.fetchTracker.Find(latestHash))
+		assert.Equal(t, activeHash, r.consensusRecovery.stepHash)
+	}
+
+	assert.Equal(t, 7, ledger.Timeouts())
+	assert.Equal(t, inbound.StateWantState, ledger.State())
+	assert.Empty(t, sender.legacyCalls())
 }
 
 func TestSpeculativeAcquisitionDefersDuringConsensusRecovery(t *testing.T) {

--- a/internal/ledger/inbound/inbound.go
+++ b/internal/ledger/inbound/inbound.go
@@ -143,14 +143,15 @@ type Ledger struct {
 
 	// Retry-loop bookkeeping ported from rippled's TimeoutCounter. lastTimer
 	// is when OnTimer last evaluated; progress records a fresh node attach
-	// since then; timeouts is the cumulative no-progress count used for both
-	// escalation and terminal failure.
+	// since then; timeouts is the cumulative no-progress count used for
+	// diagnostics and escalation; consecutiveTimeouts bounds terminal stalls.
 	// byHash latches eligibility for a by-hash escalation on the next aggressive
 	// request. All guarded by mu.
-	lastTimer time.Time
-	progress  bool
-	timeouts  int
-	byHash    bool
+	lastTimer           time.Time
+	progress            bool
+	timeouts            int
+	consecutiveTimeouts int
+	byHash              bool
 
 	// recentNodes keeps request frontiers disjoint within a timer interval.
 	// requestPeers caps the acquisition at one active request per peer and six
@@ -392,14 +393,16 @@ func (l *Ledger) OnTimer(now time.Time) TimerAction {
 	}
 
 	l.timeouts++
-	if l.timeouts > ledgerTimeoutRetriesMax {
+	l.consecutiveTimeouts++
+	if l.consecutiveTimeouts > ledgerTimeoutRetriesMax {
 		l.state = StateFailed
-		l.err = fmt.Errorf("inbound ledger %d: acquisition failed after %d timeouts (have_state=%t have_tx=%t last_reject=%q)",
-			l.seq, l.timeouts, l.haveState, l.haveTx, l.lastRejectErr)
+		l.err = fmt.Errorf("inbound ledger %d: acquisition failed after %d consecutive timeouts (%d total; have_state=%t have_tx=%t last_reject=%q)",
+			l.seq, l.consecutiveTimeouts, l.timeouts, l.haveState, l.haveTx, l.lastRejectErr)
 		l.logger.Warn("inbound ledger: acquisition failed, retry budget exhausted",
 			"seq", l.seq,
 			"hash", fmt.Sprintf("%x", l.hash[:8]),
 			"timeouts", l.timeouts,
+			"consecutive_timeouts", l.consecutiveTimeouts,
 			"phase", l.snapshotLocked().Phase(),
 			"have_state", l.haveState,
 			"have_tx", l.haveTx,
@@ -458,6 +461,7 @@ func (l *Ledger) RearmTimer(now time.Time) {
 // timing out (rippled sets progress_ on a useful received node). Caller holds mu.
 func (l *Ledger) markProgressLocked() {
 	l.progress = true
+	l.consecutiveTimeouts = 0
 }
 
 // TakeByHashRequest returns the content hashes of up to max still-missing nodes

--- a/internal/ledger/inbound/onloop_test.go
+++ b/internal/ledger/inbound/onloop_test.go
@@ -3,6 +3,7 @@ package inbound
 import (
 	"bytes"
 	"log/slog"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,12 @@ import (
 // root for a tree with several branches, leaving it in StateWantState with
 // outstanding missing state nodes — the shape the retry loop operates on.
 func incompleteStateAcquisition(t *testing.T) *Ledger {
+	t.Helper()
+	il, _ := incompleteStateAcquisitionFixture(t)
+	return il
+}
+
+func incompleteStateAcquisitionFixture(t *testing.T) (*Ledger, []message.LedgerNode) {
 	t.Helper()
 	source := shamap.New(shamap.TypeState)
 	for branch := range byte(8) {
@@ -45,7 +52,27 @@ func incompleteStateAcquisition(t *testing.T) *Ledger {
 	if il.State() != StateWantState {
 		t.Fatalf("acquisition state = %v, want StateWantState", il.State())
 	}
-	return il
+	wireNodes, err := source.WalkWireNodes()
+	if err != nil {
+		t.Fatalf("walk wire nodes: %v", err)
+	}
+	nodes := make([]message.LedgerNode, 0, len(wireNodes)-1)
+	for _, wire := range wireNodes {
+		nodeID, err := shamap.ParseNodeID(wire.NodeID)
+		if err != nil {
+			t.Fatalf("parse node ID: %v", err)
+		}
+		if nodeID.IsRoot() {
+			continue
+		}
+		nodes = append(nodes, message.LedgerNode{NodeID: wire.NodeID, NodeData: wire.Data})
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		left, _ := shamap.ParseNodeID(nodes[i].NodeID)
+		right, _ := shamap.ParseNodeID(nodes[j].NodeID)
+		return left.Depth() < right.Depth()
+	})
+	return il, nodes
 }
 
 func TestLedger_OnTimer_FailsAfterSevenConsecutiveQuietIntervals(t *testing.T) {
@@ -134,6 +161,89 @@ func TestLedger_OnTimer_AlternatingProgressAndQuietPreservesCumulativeTimeouts(t
 	}
 	if got := il.Timeouts(); got != quietIntervals {
 		t.Fatalf("timeouts = %d, want cumulative total %d", got, quietIntervals)
+	}
+}
+
+func TestLedger_OnTimer_UsefulProgressAfterRepeatedStallsCompletes(t *testing.T) {
+	t.Parallel()
+	il, nodes := incompleteStateAcquisitionFixture(t)
+	progressIntervals := ledgerTimeoutRetriesMax + 2
+	if len(nodes) <= progressIntervals {
+		t.Fatalf("fixture has %d nodes, need more than %d", len(nodes), progressIntervals)
+	}
+
+	base := time.Unix(1_700_000_000, 0)
+	il.mu.Lock()
+	il.lastTimer = base
+	il.mu.Unlock()
+	now := base.Add(acquireTimerInterval)
+	if got := il.OnTimer(now); got != TimerRefresh {
+		t.Fatalf("base progress: got %v, want TimerRefresh", got)
+	}
+
+	for i := range progressIntervals {
+		now = now.Add(acquireTimerInterval)
+		if got := il.OnTimer(now); got != TimerEscalate {
+			t.Fatalf("quiet interval %d: got %v, want TimerEscalate", i+1, got)
+		}
+		il.RearmTimer(now)
+
+		useful, err := il.GotStateNodesUseful([]message.LedgerNode{nodes[i]})
+		if err != nil {
+			t.Fatalf("useful interval %d: %v", i+1, err)
+		}
+		if useful != 1 {
+			t.Fatalf("useful interval %d added %d nodes, want 1", i+1, useful)
+		}
+		now = now.Add(acquireTimerInterval)
+		if got := il.OnTimer(now); got != TimerRefresh {
+			t.Fatalf("progress interval %d: got %v, want TimerRefresh", i+1, got)
+		}
+	}
+
+	if err := il.GotStateNodes(nodes[progressIntervals:]); err != nil {
+		t.Fatalf("complete state tree: %v", err)
+	}
+	il.CollectMissingRequest(false)
+	if il.State() != StateComplete {
+		t.Fatalf("state = %v, want StateComplete", il.State())
+	}
+}
+
+func TestLedger_OnTimer_ProgressResetsOnlyConsecutiveFailureBudget(t *testing.T) {
+	t.Parallel()
+	il := New([32]byte{0xAD}, 44, 1, discardLogger())
+	il.state = StateWantState
+	now := time.Unix(1_700_000_000, 0)
+	il.lastTimer = now
+
+	fireQuiet := func(count int) {
+		t.Helper()
+		for range count {
+			now = now.Add(acquireTimerInterval)
+			if got := il.OnTimer(now); got != TimerEscalate {
+				t.Fatalf("quiet timeout %d: got %v, want TimerEscalate", il.Timeouts(), got)
+			}
+			il.RearmTimer(now)
+		}
+	}
+
+	fireQuiet(ledgerTimeoutRetriesMax)
+	il.mu.Lock()
+	il.markProgressLocked()
+	il.mu.Unlock()
+	now = now.Add(acquireTimerInterval)
+	if got := il.OnTimer(now); got != TimerRefresh {
+		t.Fatalf("progress reset: got %v, want TimerRefresh", got)
+	}
+	fireQuiet(ledgerTimeoutRetriesMax)
+
+	now = now.Add(acquireTimerInterval)
+	if got := il.OnTimer(now); got != TimerFailed {
+		t.Fatalf("seventh consecutive timeout: got %v, want TimerFailed", got)
+	}
+	if got := il.Timeouts(); got != 2*ledgerTimeoutRetriesMax+1 {
+		t.Fatalf("cumulative timeouts = %d, want %d", got, 2*ledgerTimeoutRetriesMax+1)
 	}
 }
 

--- a/internal/ledger/inbound/onloop_test.go
+++ b/internal/ledger/inbound/onloop_test.go
@@ -48,10 +48,7 @@ func incompleteStateAcquisition(t *testing.T) *Ledger {
 	return il
 }
 
-// TestLedger_OnTimer_FailsCleanlyAfterBudget pins the core of issue #985: a
-// non-progressing acquisition escalates for ledgerTimeoutRetriesMax no-progress
-// intervals, then fails cleanly instead of re-arming the same stall forever.
-func TestLedger_OnTimer_FailsCleanlyAfterBudget(t *testing.T) {
+func TestLedger_OnTimer_FailsAfterSevenConsecutiveQuietIntervals(t *testing.T) {
 	t.Parallel()
 	il := New([32]byte{0xAB}, 42, 1, discardLogger())
 	il.state = StateWantState
@@ -75,8 +72,8 @@ func TestLedger_OnTimer_FailsCleanlyAfterBudget(t *testing.T) {
 	if il.State() != StateFailed {
 		t.Fatalf("state = %v, want StateFailed", il.State())
 	}
-	if il.Err() == nil {
-		t.Fatal("a failed acquisition must carry a terminal error")
+	if err := il.Err(); err == nil || !strings.Contains(err.Error(), "7 consecutive timeouts") {
+		t.Fatalf("terminal error = %v, want seven consecutive timeouts", err)
 	}
 }
 
@@ -108,51 +105,35 @@ func TestLedger_OnTimer_ReportsIntervalStallWithLifetimeTotals(t *testing.T) {
 	}
 }
 
-// TestLedger_OnTimer_ProgressPreservesCumulativeFailureBudget confirms useful
-// intervals do not count as timeouts but also do not erase prior no-progress
-// strikes, matching rippled's TimeoutCounter.
-func TestLedger_OnTimer_ProgressPreservesCumulativeFailureBudget(t *testing.T) {
+func TestLedger_OnTimer_AlternatingProgressAndQuietPreservesCumulativeTimeouts(t *testing.T) {
 	t.Parallel()
 	il := New([32]byte{0x01}, 7, 1, discardLogger())
 	il.state = StateWantState
 	base := time.Unix(1_700_000_000, 0)
 	il.lastTimer = base
 
-	for i := 1; i <= 5; i++ {
-		il.OnTimer(base.Add(time.Duration(i) * acquireTimerInterval))
-	}
-	if il.Timeouts() != 5 {
-		t.Fatalf("timeouts = %d, want 5 after five no-progress fires", il.Timeouts())
-	}
+	now := base
+	quietIntervals := ledgerTimeoutRetriesMax + 2
+	for i := 1; i <= quietIntervals; i++ {
+		now = now.Add(acquireTimerInterval)
+		if got := il.OnTimer(now); got != TimerEscalate {
+			t.Fatalf("quiet interval %d: got %v, want TimerEscalate", i, got)
+		}
+		il.RearmTimer(now)
 
-	il.mu.Lock()
-	il.markProgressLocked()
-	il.mu.Unlock()
-	if got := il.OnTimer(base.Add(6 * acquireTimerInterval)); got != TimerRefresh {
-		t.Fatalf("progress fire: got %v, want TimerRefresh", got)
+		il.mu.Lock()
+		il.markProgressLocked()
+		il.mu.Unlock()
+		now = now.Add(acquireTimerInterval)
+		if got := il.OnTimer(now); got != TimerRefresh {
+			t.Fatalf("progress interval %d: got %v, want TimerRefresh", i, got)
+		}
+		if il.State() == StateFailed {
+			t.Fatalf("alternating progress failed after %d cumulative quiet intervals", i)
+		}
 	}
-	if il.Timeouts() != 5 {
-		t.Fatalf("a progressing interval must not count a timeout, got %d", il.Timeouts())
-	}
-
-	next := base.Add(7 * acquireTimerInterval)
-	if got := il.OnTimer(next); got != TimerEscalate {
-		t.Fatalf("sixth no-progress fire: got %v, want TimerEscalate", got)
-	}
-	il.RearmTimer(next)
-
-	il.mu.Lock()
-	il.markProgressLocked()
-	il.mu.Unlock()
-	if got := il.OnTimer(base.Add(8 * acquireTimerInterval)); got != TimerRefresh {
-		t.Fatalf("second progress fire: got %v, want TimerRefresh", got)
-	}
-	if got := il.Timeouts(); got != ledgerTimeoutRetriesMax {
-		t.Fatalf("progress erased the cumulative budget: got %d, want %d", got, ledgerTimeoutRetriesMax)
-	}
-
-	if got := il.OnTimer(base.Add(9 * acquireTimerInterval)); got != TimerFailed {
-		t.Fatalf("seventh no-progress fire: got %v, want TimerFailed", got)
+	if got := il.Timeouts(); got != quietIntervals {
+		t.Fatalf("timeouts = %d, want cumulative total %d", got, quietIntervals)
 	}
 }
 

--- a/internal/peermanagement/bootstrap_source_test.go
+++ b/internal/peermanagement/bootstrap_source_test.go
@@ -102,7 +102,7 @@ func TestDiscoveryBootstrapPartialFailureExtendsCooldown(t *testing.T) {
 	observeBootstrapRate(t, d, address, 360_735)
 
 	now = now.Add(9 * time.Minute)
-	d.delayBootstrapRetry(address, bootstrapPartialRetry)
+	d.delayConnectRetry(address, bootstrapPartialRetry)
 	now = now.Add(time.Minute)
 	assert.Empty(t, d.selectPeersToConnect(1, true), "the original cooldown expired but the partial failure extended it")
 	assert.True(t, d.bootstrapSourceSummary().allUnviable())

--- a/internal/peermanagement/bootstrap_test.go
+++ b/internal/peermanagement/bootstrap_test.go
@@ -3,6 +3,7 @@ package peermanagement
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -242,7 +243,7 @@ func TestBootstrapFlowRotatesTwoCutoffSourcesAndCompletesFromThird(t *testing.T)
 		{address: secondAddress, lease: second},
 	} {
 		failed.lease.release()
-		discovery.delayBootstrapRetry(failed.address, bootstrapPartialRetry)
+		discovery.delayConnectRetry(failed.address, bootstrapPartialRetry)
 		discovery.finishConnectAttempt(failed.address, connectAttemptReleased)
 		assert.LessOrEqual(t, governor.activeCount(), 2)
 	}
@@ -385,7 +386,7 @@ func TestDiscoveryBootstrapRetryDelayStartsAtDisconnect(t *testing.T) {
 	}, nil)
 	d.AddPeer(address, 0, 0)
 	d.MarkConnected(address, 1)
-	d.delayBootstrapRetry(address, recentConnectAttempt)
+	d.delayConnectRetry(address, recentConnectAttempt)
 	d.MarkDisconnected(1)
 
 	assert.Empty(t, d.selectPeersToConnect(1, true))
@@ -401,12 +402,86 @@ func TestDiscoveryPartialBootstrapFailureIsQuarantined(t *testing.T) {
 		Clock:       func() time.Time { return now },
 	}, nil)
 	d.AddPeer(address, 0, 0)
-	d.delayBootstrapRetry(address, bootstrapPartialRetry)
+	d.delayConnectRetry(address, bootstrapPartialRetry)
 
 	now = now.Add(recentConnectAttempt)
 	assert.Empty(t, d.selectPeersToConnect(1, true))
 	now = now.Add(bootstrapPartialRetry - recentConnectAttempt)
 	assert.Equal(t, []string{address}, d.selectPeersToConnect(1, true))
+}
+
+func TestOverlayPartialManifestFailureQuarantinesOrdinarySource(t *testing.T) {
+	now := time.Unix(4_500, 0)
+	address := "192.0.2.1:51235"
+	discovery := NewDiscovery(&Config{
+		MaxOutbound: 1,
+		Clock:       func() time.Time { return now },
+	}, nil)
+	discovery.AddPeer(address, 0, 0)
+	overlay := &Overlay{discovery: discovery}
+
+	overlay.delayPeerRetry(address, false, &FrameReadError{
+		MessageType: TypeManifests,
+		WireSize:    1024,
+		BytesRead:   1,
+		Err:         errors.New("connection reset"),
+	}, false)
+
+	assert.Empty(t, discovery.SelectPeersToConnect(1))
+	now = now.Add(bootstrapPartialRetry - time.Nanosecond)
+	assert.Empty(t, discovery.SelectPeersToConnect(1))
+	now = now.Add(time.Nanosecond)
+	assert.Equal(t, []string{address}, discovery.SelectPeersToConnect(1))
+}
+
+func TestOverlayOrdinaryPeerFailuresDoNotTriggerManifestQuarantine(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		stopping bool
+	}{
+		{
+			name: "non-frame failure",
+			err:  errors.New("connection reset"),
+		},
+		{
+			name: "partial non-manifest frame",
+			err: &FrameReadError{
+				MessageType: TypePing,
+				BytesRead:   1,
+				Err:         errors.New("connection reset"),
+			},
+		},
+		{
+			name: "zero-byte manifest frame",
+			err: &FrameReadError{
+				MessageType: TypeManifests,
+				Err:         errors.New("connection reset"),
+			},
+		},
+		{
+			name: "shutdown",
+			err: &FrameReadError{
+				MessageType: TypeManifests,
+				BytesRead:   1,
+				Err:         context.Canceled,
+			},
+			stopping: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			address := "192.0.2.1:51235"
+			discovery := NewDiscovery(&Config{MaxOutbound: 1}, nil)
+			discovery.AddPeer(address, 0, 0)
+			overlay := &Overlay{discovery: discovery}
+
+			overlay.delayPeerRetry(address, false, tt.err, tt.stopping)
+
+			assert.Equal(t, []string{address}, discovery.SelectPeersToConnect(1))
+		})
+	}
 }
 
 func TestPeerBootstrapAcknowledgementFiresOnce(t *testing.T) {

--- a/internal/peermanagement/bootstrap_test.go
+++ b/internal/peermanagement/bootstrap_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
+	"syscall"
 	"testing"
 	"time"
 
@@ -402,7 +404,13 @@ func TestDiscoveryPartialBootstrapFailureIsQuarantined(t *testing.T) {
 		Clock:       func() time.Time { return now },
 	}, nil)
 	d.AddPeer(address, 0, 0)
-	d.delayConnectRetry(address, bootstrapPartialRetry)
+	overlay := &Overlay{discovery: d}
+	overlay.delayPeerRetry(address, true, &FrameReadError{
+		MessageType: TypeManifests,
+		WireSize:    1024,
+		BytesRead:   1,
+		Err:         errors.New("connection reset"),
+	}, false)
 
 	now = now.Add(recentConnectAttempt)
 	assert.Empty(t, d.selectPeersToConnect(1, true))
@@ -410,8 +418,62 @@ func TestDiscoveryPartialBootstrapFailureIsQuarantined(t *testing.T) {
 	assert.Equal(t, []string{address}, d.selectPeersToConnect(1, true))
 }
 
-func TestOverlayPartialManifestFailureQuarantinesOrdinarySource(t *testing.T) {
+func TestOverlayPartialManifestFailurePreservesOrdinarySourceSquelch(t *testing.T) {
 	now := time.Unix(4_500, 0)
+	address := "192.0.2.1:51235"
+	discovery := NewDiscovery(&Config{
+		MaxOutbound: 1,
+		Clock:       func() time.Time { return now },
+	}, nil)
+	discovery.AddPeer(address, 0, 0)
+	require.Equal(t, []string{address}, discovery.SelectPeersToConnect(1))
+	now = now.Add(10 * time.Second)
+	discovery.MarkConnected(address, 1)
+	overlay := &Overlay{discovery: discovery}
+
+	now = now.Add(20 * time.Second)
+	overlay.delayPeerRetry(address, false, &FrameReadError{
+		MessageType: TypeManifests,
+		WireSize:    1024,
+		BytesRead:   1,
+		Err:         errors.New("connection reset"),
+	}, false)
+	discovery.MarkDisconnected(1)
+
+	assert.Empty(t, discovery.SelectPeersToConnect(1))
+	now = now.Add(recentConnectAttempt/2 - time.Nanosecond)
+	assert.Empty(t, discovery.SelectPeersToConnect(1))
+	now = now.Add(time.Nanosecond)
+	assert.Equal(t, []string{address}, discovery.SelectPeersToConnect(1))
+}
+
+func TestOverlayLongLivedOrdinaryManifestFailureDoesNotRestartSquelch(t *testing.T) {
+	now := time.Unix(4_600, 0)
+	address := "192.0.2.1:51235"
+	discovery := NewDiscovery(&Config{
+		MaxOutbound: 1,
+		Clock:       func() time.Time { return now },
+	}, nil)
+	discovery.AddPeer(address, 0, 0)
+	require.Equal(t, []string{address}, discovery.SelectPeersToConnect(1))
+	now = now.Add(10 * time.Second)
+	discovery.MarkConnected(address, 1)
+	overlay := &Overlay{discovery: discovery}
+
+	now = now.Add(2 * recentConnectAttempt)
+	overlay.delayPeerRetry(address, false, &FrameReadError{
+		MessageType: TypeManifests,
+		WireSize:    1024,
+		BytesRead:   1,
+		Err:         errors.New("connection reset"),
+	}, false)
+	discovery.MarkDisconnected(1)
+
+	assert.Equal(t, []string{address}, discovery.SelectPeersToConnect(1))
+}
+
+func TestOverlayLocalSpoolFailureDoesNotExtendBootstrapQuarantine(t *testing.T) {
+	now := time.Unix(4_750, 0)
 	address := "192.0.2.1:51235"
 	discovery := NewDiscovery(&Config{
 		MaxOutbound: 1,
@@ -420,18 +482,24 @@ func TestOverlayPartialManifestFailureQuarantinesOrdinarySource(t *testing.T) {
 	discovery.AddPeer(address, 0, 0)
 	overlay := &Overlay{discovery: discovery}
 
-	overlay.delayPeerRetry(address, false, &FrameReadError{
+	overlay.delayPeerRetry(address, true, &FrameReadError{
 		MessageType: TypeManifests,
 		WireSize:    1024,
 		BytesRead:   1,
-		Err:         errors.New("connection reset"),
+		Err: &manifestSpoolLocalError{
+			operation: "spool manifest payload",
+			err: &os.PathError{
+				Op:   "write",
+				Path: "manifest-spool",
+				Err:  syscall.ETIMEDOUT,
+			},
+		},
 	}, false)
 
-	assert.Empty(t, discovery.SelectPeersToConnect(1))
-	now = now.Add(bootstrapPartialRetry - time.Nanosecond)
-	assert.Empty(t, discovery.SelectPeersToConnect(1))
+	now = now.Add(recentConnectAttempt - time.Nanosecond)
+	assert.Empty(t, discovery.selectPeersToConnect(1, true))
 	now = now.Add(time.Nanosecond)
-	assert.Equal(t, []string{address}, discovery.SelectPeersToConnect(1))
+	assert.Equal(t, []string{address}, discovery.selectPeersToConnect(1, true))
 }
 
 func TestOverlayOrdinaryPeerFailuresDoNotTriggerManifestQuarantine(t *testing.T) {

--- a/internal/peermanagement/discovery.go
+++ b/internal/peermanagement/discovery.go
@@ -1084,7 +1084,7 @@ func (d *Discovery) markNegotiatedCompression(address string, enabled bool) {
 	peer.supportsCompression = enabled
 }
 
-func (d *Discovery) delayBootstrapRetry(address string, delay time.Duration) {
+func (d *Discovery) delayConnectRetry(address string, delay time.Duration) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	host := connectAttemptHost(address)

--- a/internal/peermanagement/discovery.go
+++ b/internal/peermanagement/discovery.go
@@ -871,7 +871,11 @@ func (d *Discovery) selectPeersToConnect(count int, bootstrap bool) []string {
 	seenHosts := make(map[string]struct{})
 	for _, peer := range d.peers {
 		if peer.Connected {
-			seenHosts[connectAttemptHost(peer.Address)] = struct{}{}
+			host := connectAttemptHost(peer.Address)
+			seenHosts[host] = struct{}{}
+			if !bootstrap && count > 0 {
+				d.recentAttempts[host] = now.Add(recentConnectAttempt)
+			}
 		}
 	}
 	eligible := func(address string) bool {
@@ -1137,10 +1141,6 @@ func (d *Discovery) finishConnectAttempt(address string, result connectAttemptRe
 }
 
 func (d *Discovery) markConnectSucceededLocked(address string) {
-	if d.recentAttempts == nil {
-		d.recentAttempts = make(map[string]time.Time)
-	}
-	d.recentAttempts[connectAttemptHost(address)] = d.now().Add(recentConnectAttempt)
 	if !d.fixedPeers[address] {
 		delete(d.connectAttempts, address)
 		return

--- a/internal/peermanagement/discovery_test.go
+++ b/internal/peermanagement/discovery_test.go
@@ -824,6 +824,28 @@ func TestDiscoveryConnectedHostSuppressesOtherPorts(t *testing.T) {
 	assert.Empty(t, d.SelectPeersToConnect(2))
 }
 
+func TestDiscoveryAutoconnectTouchesActiveHostSquelch(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	active := "192.0.2.20:51235"
+	candidate := "192.0.2.30:51235"
+	d := NewDiscovery(&Config{
+		MaxPeers:    50,
+		MaxInbound:  25,
+		MaxOutbound: 25,
+		Clock:       func() time.Time { return now },
+	}, make(chan Event, 1))
+	d.MarkConnected(active, PeerID(1))
+	d.AddPeer(candidate, 0, 0)
+
+	now = now.Add(2 * recentConnectAttempt)
+	require.Equal(t, []string{candidate}, d.SelectPeersToConnect(1))
+	d.MarkDisconnected(PeerID(1))
+	assert.Empty(t, d.SelectPeersToConnect(1))
+
+	now = now.Add(recentConnectAttempt)
+	assert.Equal(t, []string{active}, d.SelectPeersToConnect(1))
+}
+
 func TestDiscoveryInFlightHostSuppressionOutlivesCooldown(t *testing.T) {
 	now := time.Unix(10_000, 0)
 	d := NewDiscovery(&Config{MaxOutbound: 25, Clock: func() time.Time { return now }}, make(chan Event, 1))

--- a/internal/peermanagement/manifest_frame.go
+++ b/internal/peermanagement/manifest_frame.go
@@ -21,6 +21,35 @@ var (
 	ErrManifestFrameMaterialized = errors.New("manifest frame already materialized")
 )
 
+type manifestSpoolLocalError struct {
+	operation string
+	err       error
+}
+
+func (e *manifestSpoolLocalError) Error() string {
+	return fmt.Sprintf("%s: %v", e.operation, e.err)
+}
+
+func (e *manifestSpoolLocalError) Unwrap() error {
+	return e.err
+}
+
+type manifestSpoolWriter struct {
+	writer io.Writer
+	err    error
+}
+
+func (w *manifestSpoolWriter) Write(p []byte) (int, error) {
+	n, err := w.writer.Write(p)
+	if err == nil && n != len(p) {
+		err = io.ErrShortWrite
+	}
+	if err != nil && w.err == nil {
+		w.err = err
+	}
+	return n, err
+}
+
 // ManifestFrame is a disk-backed inbound manifest payload.
 type ManifestFrame struct {
 	mu sync.Mutex
@@ -155,7 +184,7 @@ func spoolManifestFrame(
 ) (*ManifestFrame, error) {
 	file, err := os.CreateTemp(dir, "goxrpl-manifests-*")
 	if err != nil {
-		return nil, fmt.Errorf("create manifest spool: %w", err)
+		return nil, &manifestSpoolLocalError{operation: "create manifest spool", err: err}
 	}
 	path := file.Name()
 	cleanup := func() {
@@ -163,26 +192,37 @@ func spoolManifestFrame(
 		_ = os.Remove(path)
 	}
 
-	n, copyErr := io.CopyBuffer(
-		file,
-		io.LimitReader(r, int64(header.PayloadSize)),
-		make([]byte, manifestSpoolBufferSize),
-	)
+	copyErr := copyManifestPayload(file, r, header.PayloadSize)
 	closeErr := file.Close()
 	if copyErr != nil {
 		cleanup()
-		return nil, fmt.Errorf("spool manifest payload: %w", copyErr)
-	}
-	if n != int64(header.PayloadSize) {
-		cleanup()
-		return nil, fmt.Errorf("spool manifest payload: copied %d of %d bytes: %w",
-			n, header.PayloadSize, io.ErrUnexpectedEOF)
+		return nil, copyErr
 	}
 	if closeErr != nil {
 		cleanup()
-		return nil, fmt.Errorf("close manifest spool: %w", closeErr)
+		return nil, &manifestSpoolLocalError{operation: "close manifest spool", err: closeErr}
 	}
 	return newManifestFrame(path, header, budget), nil
+}
+
+func copyManifestPayload(dst io.Writer, src io.Reader, size uint32) error {
+	writer := &manifestSpoolWriter{writer: dst}
+	n, err := io.CopyBuffer(
+		writer,
+		io.LimitReader(src, int64(size)),
+		make([]byte, manifestSpoolBufferSize),
+	)
+	if writer.err != nil {
+		return &manifestSpoolLocalError{operation: "spool manifest payload", err: writer.err}
+	}
+	if err != nil {
+		return fmt.Errorf("spool manifest payload: %w", err)
+	}
+	if n != int64(size) {
+		return fmt.Errorf("spool manifest payload: copied %d of %d bytes: %w",
+			n, size, io.ErrUnexpectedEOF)
+	}
+	return nil
 }
 
 func prepareManifestSpoolDir(dataDir string) (string, error) {

--- a/internal/peermanagement/manifest_frame_test.go
+++ b/internal/peermanagement/manifest_frame_test.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -21,6 +23,49 @@ func manifestAndLedgerFrames(t *testing.T, manifest, ledger []byte) []byte {
 	require.NoError(t, message.WriteMessage(&wire, message.TypeManifests, manifest))
 	require.NoError(t, message.WriteMessage(&wire, message.TypeLedgerData, ledger))
 	return wire.Bytes()
+}
+
+type failingManifestSpoolWriter struct {
+	err error
+}
+
+func (w failingManifestSpoolWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+type failingManifestSpoolReader struct {
+	err error
+}
+
+func (r failingManifestSpoolReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func TestCopyManifestPayloadClassifiesLocalTimeoutWriteFailure(t *testing.T) {
+	writeErr := &os.PathError{Op: "write", Path: "manifest-spool", Err: syscall.ETIMEDOUT}
+	err := copyManifestPayload(
+		failingManifestSpoolWriter{err: writeErr},
+		bytes.NewReader([]byte("manifest")),
+		uint32(len("manifest")),
+	)
+
+	var localErr *manifestSpoolLocalError
+	require.ErrorAs(t, err, &localErr)
+	require.ErrorIs(t, err, writeErr)
+	require.Equal(t, err, normalizeManifestSpoolReadError(err, true))
+}
+
+func TestCopyManifestPayloadKeepsSourceFailuresRemote(t *testing.T) {
+	readErr := errors.New("connection reset")
+	err := copyManifestPayload(
+		&bytes.Buffer{},
+		failingManifestSpoolReader{err: readErr},
+		1,
+	)
+
+	var localErr *manifestSpoolLocalError
+	require.NotErrorAs(t, err, &localErr)
+	require.ErrorIs(t, err, readErr)
 }
 
 func TestOversizedManifestPeersDoNotBlockLedgerFrames(t *testing.T) {

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -170,7 +170,12 @@ func (o *Overlay) delayPeerRetry(addr string, bootstrap bool, err error, stoppin
 		retry = recentConnectAttempt
 	}
 	var frameErr *FrameReadError
-	if errors.As(err, &frameErr) && frameErr.MessageType == TypeManifests && frameErr.BytesRead > 0 {
+	var localSpoolErr *manifestSpoolLocalError
+	if bootstrap &&
+		errors.As(err, &frameErr) &&
+		frameErr.MessageType == TypeManifests &&
+		frameErr.BytesRead > 0 &&
+		!errors.As(frameErr.Err, &localSpoolErr) {
 		retry = bootstrapPartialRetry
 		slog.Info("Manifest source quarantined", "t", "Overlay", "addr", addr,
 			"retry_after", retry, "wire_size", frameErr.WireSize,

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -148,20 +148,9 @@ func (o *Overlay) connectReserved(addr string, bootstrapLease *bootstrapLease) e
 	go func() {
 		defer o.peerWG.Done()
 		err := peer.Run(baseCtx)
-		if bootstrapLease != nil && baseCtx.Err() == nil {
-			retry := recentConnectAttempt
-			var frameErr *FrameReadError
-			if errors.As(err, &frameErr) && frameErr.MessageType == TypeManifests && frameErr.BytesRead > 0 {
-				retry = bootstrapPartialRetry
-				slog.Info("Bootstrap source quarantined", "t", "Overlay", "addr", addr,
-					"retry_after", retry, "wire_size", frameErr.WireSize,
-					"compressed", frameErr.Compressed, "bytes_read", frameErr.BytesRead,
-					"elapsed", frameErr.Elapsed, "rate", frameReadRate(frameErr.BytesRead, frameErr.Elapsed),
-					"projected", projectedFrameDuration(frameErr.WireSize, frameErr.BytesRead, frameErr.Elapsed))
-			}
-			o.discovery.delayBootstrapRetry(addr, retry)
-		}
-		o.onBootstrapTransportEnd(peerID, bootstrapLease != nil && peer.bootstrapManifestPending.Load(), baseCtx.Err() != nil)
+		stopping := baseCtx.Err() != nil
+		o.delayPeerRetry(addr, bootstrapLease != nil, err, stopping)
+		o.onBootstrapTransportEnd(peerID, bootstrapLease != nil && peer.bootstrapManifestPending.Load(), stopping)
 		if err != nil {
 			slog.Info("Peer run ended", "t", "Overlay", "addr", addr, "err", err)
 			o.notePeerRunEnded(err)
@@ -170,6 +159,28 @@ func (o *Overlay) connectReserved(addr string, bootstrapLease *bootstrapLease) e
 	}()
 
 	return nil
+}
+
+func (o *Overlay) delayPeerRetry(addr string, bootstrap bool, err error, stopping bool) {
+	if stopping {
+		return
+	}
+	retry := time.Duration(0)
+	if bootstrap {
+		retry = recentConnectAttempt
+	}
+	var frameErr *FrameReadError
+	if errors.As(err, &frameErr) && frameErr.MessageType == TypeManifests && frameErr.BytesRead > 0 {
+		retry = bootstrapPartialRetry
+		slog.Info("Manifest source quarantined", "t", "Overlay", "addr", addr,
+			"retry_after", retry, "wire_size", frameErr.WireSize,
+			"compressed", frameErr.Compressed, "bytes_read", frameErr.BytesRead,
+			"elapsed", frameErr.Elapsed, "rate", frameReadRate(frameErr.BytesRead, frameErr.Elapsed),
+			"projected", projectedFrameDuration(frameErr.WireSize, frameErr.BytesRead, frameErr.Elapsed))
+	}
+	if retry > 0 {
+		o.discovery.delayConnectRetry(addr, retry)
+	}
 }
 
 func (o *Overlay) trackPeerBootstrap(peerID PeerID, lease *bootstrapLease) {

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -1131,6 +1131,24 @@ func (p *Peer) frameProgressBlocksPing(progress inboundFrameProgress, ping pingI
 		now.Sub(progress.lastProgress) < p.readPolicy.idleTimeout
 }
 
+func normalizeManifestSpoolReadError(err error, budgetDeadlineArmed bool) error {
+	var localSpoolErr *manifestSpoolLocalError
+	if errors.As(err, &localSpoolErr) {
+		return err
+	}
+	if errors.Is(err, ErrFrameReadTooSlow) {
+		return ErrFrameReadTooSlow
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		if budgetDeadlineArmed {
+			return ErrFrameReadTooSlow
+		}
+		return ErrReadIdle
+	}
+	return err
+}
+
 func (p *Peer) readLoop(ctx context.Context) error {
 	var outstandingManifest <-chan struct{}
 	for {
@@ -1188,17 +1206,10 @@ func (p *Peer) readLoop(ctx context.Context) error {
 				if p.closed.Load() {
 					return nil
 				}
-				if errors.Is(spoolErr, ErrFrameReadTooSlow) {
-					return frameReader.failure(ErrFrameReadTooSlow, now)
-				}
-				var ne net.Error
-				if errors.As(spoolErr, &ne) && ne.Timeout() {
-					if frameReader.budgetDeadlineArmed {
-						return frameReader.failure(ErrFrameReadTooSlow, now)
-					}
-					return frameReader.failure(ErrReadIdle, now)
-				}
-				return frameReader.failure(spoolErr, now)
+				return frameReader.failure(
+					normalizeManifestSpoolReadError(spoolErr, frameReader.budgetDeadlineArmed),
+					now,
+				)
 			}
 
 			payloadWireSize := uint64(header.PayloadSize)


### PR DESCRIPTION
## Summary
- preserve long-running inbound-ledger progress by separating cumulative timeout diagnostics from the consecutive terminal stall budget
- keep the active recovery anchor pinned while newer validation targets arrive
- quarantine ordinary and bootstrap outbound sources after partial oversized-manifest failures
- validate queued acquisition targets against the live peer session and immediately retarget stale work

## Test plan
- [x] `go test ./internal/ledger/inbound -count=1`
- [x] `go test ./internal/consensus/adaptor -count=1`
- [x] `go test ./internal/peermanagement/... -count=1`
- [x] `just test-core`
- [x] `go test -race ./internal/ledger/inbound ./internal/consensus/adaptor ./internal/peermanagement -count=1`
- [x] `just vet`
- [x] `golangci-lint run`
- [x] `just lint`
- [x] `just build`

Fixes #1479
