### PR TITLE
fix: own consensus component lifecycles (#1453)

### DIFF
--- a/internal/consensus/adaptor/acquisition_work.go
+++ b/internal/consensus/adaptor/acquisition_work.go
@@ -697,7 +697,7 @@ func (r *Router) handleAcquisitionWorkResult(result acquisitionWorkResult) {
 			for _, request := range result.requests {
 				ledger.ReleaseMissingRequest(request.PeerID, request.NodeHashes)
 			}
-			r.retireAcquisitionStore(context.TODO(), ledger)
+			r.retireAcquisitionStore(r.lifecycleContext(), ledger)
 		}
 		return
 	}
@@ -716,7 +716,7 @@ func (r *Router) handleAcquisitionWorkResult(result acquisitionWorkResult) {
 	if result.persistenceErr != nil {
 		r.logger.Warn("inbound ledger: verified-node persistence failed", "error", result.persistenceErr, "seq", ledger.Seq())
 		if r.fetchTracker.DiscardExpected(ledger) {
-			r.retireAcquisitionStore(context.TODO(), ledger)
+			r.retireAcquisitionStore(r.lifecycleContext(), ledger)
 		}
 		return
 	}
@@ -728,11 +728,11 @@ func (r *Router) handleAcquisitionWorkResult(result acquisitionWorkResult) {
 			r.failInboundAcquisitionWithSnapshot(ledger, result.snapshot)
 		} else if result.haveSnapshot {
 			if r.fetchTracker.RemoveExpectedWithSnapshot(ledger, result.snapshot, false) {
-				r.retireAcquisitionStore(context.TODO(), ledger)
+				r.retireAcquisitionStore(r.lifecycleContext(), ledger)
 			}
 		} else {
 			if r.fetchTracker.RemoveExpectedWithSnapshot(ledger, ledger.Snapshot(), false) {
-				r.retireAcquisitionStore(context.TODO(), ledger)
+				r.retireAcquisitionStore(r.lifecycleContext(), ledger)
 			}
 		}
 		return

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -277,6 +277,7 @@ func ParseRelayValidationsPolicy(s string) RelayValidationsPolicy {
 type Config struct {
 	LedgerService *service.Service
 	Sender        NetworkSender
+	OnTxSetBuilt  func(consensus.TxSetID)
 	Identity      *ValidatorIdentity
 	Validators    []consensus.NodeID // UNL
 	// ValidatorMasterKeys are the 33-byte master pubkeys index-aligned with
@@ -420,6 +421,7 @@ func New(cfg Config) *Adaptor {
 		peerLCLs:          make(map[uint64]consensus.LedgerID),
 		reqLedgerLast:     make(map[consensus.LedgerID]time.Time),
 		announcedSets:     make(map[consensus.TxSetID]struct{}),
+		onTxSetBuilt:      cfg.OnTxSetBuilt,
 		maxDisallowedSeq:  maxDisallowedSeq,
 		cookie:            cookie,
 		feeVote:           feeVote,
@@ -933,12 +935,6 @@ func (a *Adaptor) BuildTxSet(txs [][]byte) (consensus.TxSet, error) {
 		}
 	}
 	return ts, nil
-}
-
-// SetOnTxSetBuilt installs a callback invoked once per BuildTxSet (after
-// caching); the CLI wires it to Overlay.BroadcastHaveTxSet. nil clears.
-func (a *Adaptor) SetOnTxSetBuilt(cb func(consensus.TxSetID)) {
-	a.onTxSetBuilt = cb
 }
 
 // HasTx reports whether the persistent open view contains this tx.

--- a/internal/consensus/adaptor/adaptor_methods_cov_test.go
+++ b/internal/consensus/adaptor/adaptor_methods_cov_test.go
@@ -2,6 +2,7 @@ package adaptor
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -125,14 +126,14 @@ func TestAdg_GetPendingTxs(t *testing.T) {
 	_ = txs
 }
 
-func TestAdg_SetOnTxSetBuilt(t *testing.T) {
-	a := newTestAdaptor(t)
-
+func TestAdg_OnTxSetBuilt(t *testing.T) {
 	var calls int
 	var calledID consensus.TxSetID
-	a.SetOnTxSetBuilt(func(id consensus.TxSetID) {
-		calls++
-		calledID = id
+	a := New(Config{
+		OnTxSetBuilt: func(id consensus.TxSetID) {
+			calls++
+			calledID = id
+		},
 	})
 
 	// The empty set (all-zero ID) is never announced — it recurs every
@@ -151,10 +152,44 @@ func TestAdg_SetOnTxSetBuilt(t *testing.T) {
 	_, err = a.BuildTxSet([][]byte{blob})
 	require.NoError(t, err)
 	assert.Equal(t, 1, calls, "same set hash must be announced at most once")
+}
 
-	a.SetOnTxSetBuilt(nil)
-	_, err = a.BuildTxSet(nil)
-	assert.NoError(t, err)
+func TestAdg_OnTxSetBuiltConcurrentUniqueSets(t *testing.T) {
+	const setCount = 64
+
+	announced := make(chan consensus.TxSetID, setCount)
+	a := New(Config{
+		OnTxSetBuilt: func(id consensus.TxSetID) {
+			announced <- id
+		},
+	})
+
+	var wg sync.WaitGroup
+	errs := make(chan error, setCount)
+	for i := range setCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			blob := []byte{
+				0x12, 0x00, 0x34, 0x01, 0x02, 0x03,
+				0x04, 0x05, 0x06, 0x07, byte(i >> 8), byte(i),
+			}
+			_, err := a.BuildTxSet([][]byte{blob})
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	close(announced)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	ids := make(map[consensus.TxSetID]struct{}, setCount)
+	for id := range announced {
+		ids[id] = struct{}{}
+	}
+	assert.Len(t, ids, setCount)
 }
 
 func TestAdg_GetValidatorSigningKey(t *testing.T) {

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -198,11 +198,18 @@ type Router struct {
 	// Nil when online-delete is off, leaving acquisition/serving unrestricted.
 	floor MinimumOnlineFloor
 
+	lifecycleMu     sync.RWMutex
+	lifecycleState  routerLifecycleState
+	lifecycleCtx    context.Context
+	lifecycleCancel context.CancelFunc
+	lifecycleWG     sync.WaitGroup
+	lifecycleReady  chan struct{}
+
+	prewarmSignatures func(context.Context, [][]byte)
+
 	// txJobs is the bounded queue draining inbound peer transactions off the
-	// Run message loop, mirroring rippled's jtTRANSACTION job queue. Created
-	// and drained by startTxWorkers from Run; nil until then, in which case
-	// submitTxJob runs the handler inline (tests that drive handleMessage
-	// synchronously). Only written on the Run goroutine.
+	// Run message loop, mirroring rippled's jtTRANSACTION job queue. It is nil
+	// before Run and after shutdown.
 	txJobs chan *peermanagement.InboundMessage
 
 	// droppedTxJobs counts inbound transactions shed because the worker pool
@@ -213,10 +220,7 @@ type Router struct {
 	// serveJobs is the bounded queue draining inbound mtGET_LEDGER serve work
 	// (handleGetLedger / serveTxSet, which builds the largest map — the
 	// 15k-tx tx-set — inline) off the Run message loop onto a small worker
-	// pool. Created and drained by startServeWorkers from Run; nil until
-	// then, in which case submitServeJob runs handleGetLedger inline (tests
-	// that drive handleMessage synchronously). Only written on the Run
-	// goroutine.
+	// pool. It is nil before Run and after shutdown.
 	serveJobs chan *peermanagement.InboundMessage
 
 	// droppedServeJobs counts inbound get_ledger requests shed because the
@@ -362,6 +366,7 @@ func NewRouter(engine consensus.RouterEngine, adaptor *Adaptor, inbox <-chan *pe
 		txSetAcquire:       make(map[consensus.TxSetID]*txSetAcquireState),
 		txSetRetryKnobs:    defaultTxSetRetryKnobs(),
 		seqHash:            make(map[uint32]ledgerHashEntry),
+		lifecycleCtx:       context.Background(),
 	}
 	// Wire the stash → acquisition hook so quorum decisions on unknown
 	// ledgers don't sit silently in pendingLedgerValidations.
@@ -383,6 +388,7 @@ func NewRouter(engine consensus.RouterEngine, adaptor *Adaptor, inbox <-chan *pe
 		}
 		if svc := adaptor.LedgerService(); svc != nil {
 			svc.SetOnPendingValidationStashed(r.armValidationStashAcquisition)
+			r.prewarmSignatures = svc.PrewarmSignaturesContext
 		}
 		// Wire the still-needed re-arm so every consensus re-ask of an
 		// in-flight tx-set clears the per-acquisition throttle and
@@ -653,8 +659,12 @@ func (r *Router) removePeerFromAcquisitions(peerID uint64) {
 // also runs in this loop to time out stuck inbound replay-delta
 // acquisitions and fall back to the legacy mtGET_LEDGER path.
 func (r *Router) Run(ctx context.Context) {
+	runCtx, ok := r.startLifecycle(ctx)
+	if !ok {
+		return
+	}
 	if r.acquisitionStore != nil {
-		r.acquisitionStore.start(ctx)
+		r.acquisitionStore.start(runCtx)
 		defer r.acquisitionStore.stopDrain()
 	}
 	r.acquisitionWorkMu.Lock()
@@ -665,7 +675,7 @@ func (r *Router) Run(ctx context.Context) {
 	}
 	r.acquisitionWorkMu.Unlock()
 	workLane.flush = r.flushAcquisitionStore
-	workLane.start(ctx)
+	workLane.start(runCtx)
 	defer func() {
 		workLane.stop()
 		r.acquisitionWorkMu.Lock()
@@ -675,7 +685,7 @@ func (r *Router) Run(ctx context.Context) {
 		r.acquisitionWorkMu.Unlock()
 	}()
 
-	disconnectCtx, stopDisconnectCleanup := context.WithCancel(ctx)
+	disconnectCtx, stopDisconnectCleanup := context.WithCancel(runCtx)
 	disconnectCleanupDone := make(chan struct{})
 	go func() {
 		defer close(disconnectCleanupDone)
@@ -686,22 +696,21 @@ func (r *Router) Run(ctx context.Context) {
 		<-disconnectCleanupDone
 	}()
 
-	r.startTxWorkers(ctx)
-	r.startServeWorkers(ctx)
-	r.startManifestWorker(ctx)
+	r.startManifestWorker(runCtx)
 	defer r.stopManifestWorker()
 	if r.validationWork != nil {
-		r.validationWork.start(ctx)
+		r.validationWork.start(runCtx)
 		defer r.validationWork.stop()
 	}
 	ticker := time.NewTicker(inboundReplayDeltaTickInterval)
 	defer ticker.Stop()
+	defer r.stopLifecycle()
 	r.drainPeerConnects()
 	for {
-		if !r.drainTrustedValidationResults(ctx) {
+		if !r.drainTrustedValidationResults(runCtx) {
 			return
 		}
-		if !r.drainConsensusInbox(ctx) {
+		if !r.drainConsensusInbox(runCtx) {
 			return
 		}
 		acqInbox := r.acqInbox
@@ -709,7 +718,7 @@ func (r *Router) Run(ctx context.Context) {
 			acqInbox = nil
 		}
 		select {
-		case <-ctx.Done():
+		case <-runCtx.Done():
 			return
 		case msg, ok := <-r.inbox:
 			if !ok {
@@ -755,7 +764,7 @@ func (r *Router) Run(ctx context.Context) {
 		case result := <-r.trustedValidationWorkResults():
 			r.handleValidationWorkResult(result)
 		case result := <-r.untrustedValidationWorkResults():
-			if !r.drainTrustedValidationResults(ctx) {
+			if !r.drainTrustedValidationResults(runCtx) {
 				return
 			}
 			r.handleValidationWorkResult(result)
@@ -818,45 +827,31 @@ func (r *Router) drainAcquisitionInboxBeforeMaintenance(workLane *acquisitionWor
 	return drained
 }
 
-// startTxWorkers builds the bounded inbound-transaction queue and launches its
-// drainers. Called once at the top of Run, before the message loop, so the
-// first dispatched transaction sees a live pool. Workers exit on ctx.Done.
-func (r *Router) startTxWorkers(ctx context.Context) {
-	r.txJobs = make(chan *peermanagement.InboundMessage, txQueueDepth)
-	jobs := r.txJobs
-	for range txWorkerCount {
-		go func() {
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case msg := <-jobs:
-					r.handleTransaction(msg)
-				}
-			}
-		}()
-	}
-}
-
 // submitTxJob hands an inbound transaction to the worker pool, off the Run
-// message loop. When the pool isn't running (tests that drive handleMessage
-// synchronously without Run), it runs the handler inline to preserve the
-// synchronous contract. On a saturated queue it sheds the frame and bumps
-// droppedTxJobs — the originating peer resends and reduce-relay means other
-// peers relay it too, so a dropped relay frame is recoverable. Mirrors
-// rippled's "Transaction queue is full" overflow drop.
+// message loop. Before the first Run it handles synchronously for direct
+// dispatch tests. Once shutdown begins, admission remains closed.
 func (r *Router) submitTxJob(msg *peermanagement.InboundMessage) {
-	if r.txJobs == nil {
+	r.lifecycleMu.RLock()
+	state := r.lifecycleState
+	jobs := r.txJobs
+	if state == routerLifecycleInitial {
+		r.lifecycleMu.RUnlock()
 		r.handleTransaction(msg)
 		return
 	}
+	if state != routerLifecycleRunning || jobs == nil {
+		r.lifecycleMu.RUnlock()
+		r.droppedTxJobs.Add(1)
+		return
+	}
 	select {
-	case r.txJobs <- msg:
+	case jobs <- msg:
 	default:
 		r.droppedTxJobs.Add(1)
 		r.logger.Debug("inbound tx dropped: worker pool saturated",
 			"t", "consensus", "event", "tx-shed", "peer", msg.PeerID)
 	}
+	r.lifecycleMu.RUnlock()
 }
 
 // DroppedTxJobs returns the cumulative count of inbound transactions shed
@@ -865,44 +860,31 @@ func (r *Router) DroppedTxJobs() uint64 {
 	return r.droppedTxJobs.Load()
 }
 
-// startServeWorkers builds the bounded get_ledger serve queue and launches
-// its drainers. Called once at the top of Run, before the message loop, so
-// the first dispatched request sees a live pool. Workers exit on ctx.Done.
-func (r *Router) startServeWorkers(ctx context.Context) {
-	r.serveJobs = make(chan *peermanagement.InboundMessage, serveQueueDepth)
-	jobs := r.serveJobs
-	for range serveWorkerCount {
-		go func() {
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case msg := <-jobs:
-					r.handleGetLedger(msg)
-				}
-			}
-		}()
-	}
-}
-
 // submitServeJob hands an inbound get_ledger request to the serve pool, off
-// the Run message loop. When the pool isn't running (tests that drive
-// handleMessage synchronously without Run), it runs the handler inline to
-// preserve the synchronous contract. On a saturated queue it sheds the
-// request and bumps droppedServeJobs — the requesting peer retries elsewhere,
-// so a dropped serve is recoverable load-shedding.
+// the Run message loop. Before the first Run it handles synchronously for
+// direct dispatch tests. Once shutdown begins, admission remains closed.
 func (r *Router) submitServeJob(msg *peermanagement.InboundMessage) {
-	if r.serveJobs == nil {
+	r.lifecycleMu.RLock()
+	state := r.lifecycleState
+	jobs := r.serveJobs
+	if state == routerLifecycleInitial {
+		r.lifecycleMu.RUnlock()
 		r.handleGetLedger(msg)
 		return
 	}
+	if state != routerLifecycleRunning || jobs == nil {
+		r.lifecycleMu.RUnlock()
+		r.droppedServeJobs.Add(1)
+		return
+	}
 	select {
-	case r.serveJobs <- msg:
+	case jobs <- msg:
 	default:
 		r.droppedServeJobs.Add(1)
 		r.logger.Debug("inbound get_ledger dropped: serve pool saturated",
 			"t", "consensus", "event", "serve-shed", "peer", msg.PeerID)
 	}
+	r.lifecycleMu.RUnlock()
 }
 
 // DroppedServeJobs returns the cumulative count of inbound get_ledger
@@ -1033,7 +1015,7 @@ func (r *Router) maintenanceTick() {
 		// continues to run).
 		seq := rd.Seq()
 		hash := rd.Hash()
-		go func() {
+		r.runLifecycleTask(func(context.Context) {
 			if err := r.adaptor.RequestReplayDelta(newPeer, hash); err != nil {
 				r.logger.Debug("replay-delta retry request failed",
 					"seq", seq,
@@ -1042,7 +1024,7 @@ func (r *Router) maintenanceTick() {
 					"err", err,
 				)
 			}
-		}()
+		})
 	}
 
 	// Reap acquisitions that exceeded the OUTER budget. At this point

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -1173,7 +1173,7 @@ func (r *Router) armHistoryBackfill() {
 				"error", err, "seq", target.seq)
 			return
 		}
-		if err = svc.IngestHistoricalLedgerWithState(context.TODO(), &hdr, stateMap, txMap); err != nil {
+		if err = svc.IngestHistoricalLedgerWithState(r.lifecycleContext(), &hdr, stateMap, txMap); err != nil {
 			r.logger.Warn("history backfill: held ledger ingest failed",
 				"error", err, "seq", target.seq)
 			return
@@ -1257,7 +1257,7 @@ func (r *Router) retireLegacyAcquisitions(ledgers []*inbound.Ledger) {
 		if lane := r.currentAcquisitionWork(); lane != nil {
 			lane.cancelLedger(ledger)
 		}
-		r.retireAcquisitionStore(context.TODO(), ledger)
+		r.retireAcquisitionStore(r.lifecycleContext(), ledger)
 	}
 }
 
@@ -1536,11 +1536,7 @@ func (r *Router) adoptVerifiedLedger(l *ledger.Ledger) error {
 	if err != nil {
 		return fmt.Errorf("snapshot tx map: %w", err)
 	}
-	// context.TODO: adoptVerifiedLedger is reached from a peer-message
-	// handler stack that does not currently carry a context. Threading
-	// one through the message-dispatch chain is tracked separately from
-	// this issue (#185).
-	initialCandidate, err := svc.BootstrapLedgerWithState(context.TODO(), &hdr, stateMap, txMap)
+	initialCandidate, err := svc.BootstrapLedgerWithState(r.lifecycleContext(), &hdr, stateMap, txMap)
 	if err != nil {
 		return fmt.Errorf("store replay-delta ledger: %w", err)
 	}
@@ -2223,7 +2219,7 @@ func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerD
 		if len(ld.Nodes) < 2 {
 			r.logger.Debug("inbound ledger: response has < 2 nodes", "nodes", len(ld.Nodes))
 			if r.fetchTracker.RemoveExpectedWithSnapshot(il, il.Snapshot(), false) {
-				r.retireAcquisitionStore(context.TODO(), il)
+				r.retireAcquisitionStore(r.lifecycleContext(), il)
 			}
 			return true
 		}
@@ -2234,7 +2230,7 @@ func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerD
 			} else {
 				r.adaptor.IncPeerBadData(peerID, "ledger-data-base")
 				if r.fetchTracker.RemoveExpectedWithSnapshot(il, il.Snapshot(), false) {
-					r.retireAcquisitionStore(context.TODO(), il)
+					r.retireAcquisitionStore(r.lifecycleContext(), il)
 				}
 			}
 			return true
@@ -2524,7 +2520,7 @@ func (r *Router) failInboundAcquisitionWithSnapshot(il *inbound.Ledger, snapshot
 	if !r.fetchTracker.RemoveExpectedWithSnapshot(il, snapshot, false) {
 		return
 	}
-	r.retireAcquisitionStore(context.TODO(), il)
+	r.retireAcquisitionStore(r.lifecycleContext(), il)
 	r.logger.Warn("inbound ledger acquisition failed",
 		"seq", il.Seq(),
 		"hash", fmt.Sprintf("%x", hash[:8]),
@@ -2608,10 +2604,10 @@ func (r *Router) sendNodesByHash(peers []uint64, ledgerHash [32]byte, seq uint32
 // for querying but does not flip operating mode or notify consensus, so an
 // arbitrary historical fetch can't disturb the active chain.
 func (r *Router) completeInboundLedger(il *inbound.Ledger) {
-	if err := r.flushAcquisitionStore(context.TODO(), il); err != nil {
+	if err := r.flushAcquisitionStore(r.lifecycleContext(), il); err != nil {
 		r.logger.Warn("inbound ledger: verified-node persistence failed", "error", err, "seq", il.Seq())
 		if r.fetchTracker.DiscardExpected(il) {
-			r.retireAcquisitionStore(context.TODO(), il)
+			r.retireAcquisitionStore(r.lifecycleContext(), il)
 		}
 		return
 	}
@@ -2623,32 +2619,32 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 	if err != nil {
 		r.logger.Warn("inbound ledger: failed to get result", "error", err)
 		if r.fetchTracker.DiscardExpected(il) {
-			r.retireAcquisitionStore(context.TODO(), il)
+			r.retireAcquisitionStore(r.lifecycleContext(), il)
 		}
 		return
 	}
 	if r.adaptor == nil {
 		if r.fetchTracker.DiscardExpected(il) {
-			r.retireAcquisitionStore(context.TODO(), il)
+			r.retireAcquisitionStore(r.lifecycleContext(), il)
 		}
 		return
 	}
 	svc := r.adaptor.LedgerService()
 	if svc == nil {
 		if r.fetchTracker.DiscardExpected(il) {
-			r.retireAcquisitionStore(context.TODO(), il)
+			r.retireAcquisitionStore(r.lifecycleContext(), il)
 		}
 		return
 	}
-	if err = r.promoteAcquisitionStore(context.TODO(), il); err != nil {
+	if err = r.promoteAcquisitionStore(r.lifecycleContext(), il); err != nil {
 		r.logger.Warn("inbound ledger: failed to promote persistence scope", "error", err, "seq", il.Seq())
 		if r.fetchTracker.DiscardExpected(il) {
-			r.retireAcquisitionStore(context.TODO(), il)
+			r.retireAcquisitionStore(r.lifecycleContext(), il)
 		}
 		return
 	}
 	if !r.fetchTracker.RemoveExpectedWithSnapshot(il, il.Snapshot(), true) {
-		r.retireAcquisitionStore(context.TODO(), il)
+		r.retireAcquisitionStore(r.lifecycleContext(), il)
 		return
 	}
 	peerID := il.PeerID()
@@ -2660,7 +2656,7 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 	// then advances the backward walk to its parent. It never touches operating
 	// mode or the consensus engine.
 	if il.Reason() == inbound.ReasonHistory {
-		if err = svc.IngestHistoricalLedgerWithState(context.TODO(), h, stateMap, txMap); err != nil {
+		if err = svc.IngestHistoricalLedgerWithState(r.lifecycleContext(), h, stateMap, txMap); err != nil {
 			r.logger.Warn("inbound ledger: history backfill ingest failed",
 				"error", err, "seq", h.LedgerIndex)
 			return
@@ -2677,13 +2673,10 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 	// is nil only when the ledger has no transactions (empty tx tree), in which
 	// case the service installs the genesis-shaped empty tx map.
 	//
-	// context.TODO: same as adoptVerifiedLedger — reached from a peer-message
-	// handler stack with no plumbed context. See note there.
-	//
 	// Generic acquisitions are queryable by hash but never mutate the service's
 	// canonical frontier or feed consensus.
 	if il.Reason() == inbound.ReasonGeneric {
-		if err = svc.StoreLedgerWithState(context.TODO(), h, stateMap, txMap); err != nil {
+		if err = svc.StoreLedgerWithState(r.lifecycleContext(), h, stateMap, txMap); err != nil {
 			r.logger.Warn("inbound ledger: generic store failed", "error", err, "seq", h.LedgerIndex)
 			return
 		}
@@ -2697,7 +2690,7 @@ func (r *Router) completeInboundLedgerReady(il *inbound.Ledger) {
 		return
 	}
 
-	initialCandidate, err := svc.BootstrapLedgerWithState(context.TODO(), h, stateMap, txMap)
+	initialCandidate, err := svc.BootstrapLedgerWithState(r.lifecycleContext(), h, stateMap, txMap)
 	if err != nil {
 		r.logger.Warn("inbound ledger: failed to store consensus ledger", "error", err, "seq", h.LedgerIndex)
 		return

--- a/internal/consensus/adaptor/router_lifecycle.go
+++ b/internal/consensus/adaptor/router_lifecycle.go
@@ -1,0 +1,128 @@
+package adaptor
+
+import (
+	"context"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+)
+
+type routerLifecycleState uint8
+
+const (
+	routerLifecycleInitial routerLifecycleState = iota
+	routerLifecycleRunning
+	routerLifecycleStopped
+)
+
+func (r *Router) startLifecycle(parent context.Context) (context.Context, bool) {
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+	if r.lifecycleState != routerLifecycleInitial {
+		return nil, false
+	}
+
+	ctx, cancel := context.WithCancel(parent)
+	r.lifecycleState = routerLifecycleRunning
+	r.lifecycleCtx = ctx
+	r.lifecycleCancel = cancel
+	r.txJobs = make(chan *peermanagement.InboundMessage, txQueueDepth)
+	r.serveJobs = make(chan *peermanagement.InboundMessage, serveQueueDepth)
+	if r.lifecycleReady == nil {
+		r.lifecycleReady = make(chan struct{})
+	}
+
+	txJobs := r.txJobs
+	serveJobs := r.serveJobs
+	r.lifecycleWG.Add(txWorkerCount + serveWorkerCount)
+	for range txWorkerCount {
+		go func() {
+			defer r.lifecycleWG.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case msg := <-txJobs:
+					r.handleTransaction(msg)
+				}
+			}
+		}()
+	}
+	for range serveWorkerCount {
+		go func() {
+			defer r.lifecycleWG.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case msg := <-serveJobs:
+					r.handleGetLedger(msg)
+				}
+			}
+		}()
+	}
+	close(r.lifecycleReady)
+	return ctx, true
+}
+
+func (r *Router) lifecycleReadyChannel() <-chan struct{} {
+	r.lifecycleMu.Lock()
+	defer r.lifecycleMu.Unlock()
+	if r.lifecycleReady == nil {
+		r.lifecycleReady = make(chan struct{})
+	}
+	return r.lifecycleReady
+}
+
+func (r *Router) stopLifecycle() {
+	r.lifecycleMu.Lock()
+	if r.lifecycleState != routerLifecycleRunning {
+		r.lifecycleMu.Unlock()
+		return
+	}
+	r.lifecycleState = routerLifecycleStopped
+	r.txJobs = nil
+	r.serveJobs = nil
+	cancel := r.lifecycleCancel
+	r.lifecycleCancel = nil
+	cancel()
+	r.lifecycleMu.Unlock()
+
+	r.lifecycleWG.Wait()
+}
+
+func (r *Router) lifecycleContext() context.Context {
+	r.lifecycleMu.RLock()
+	defer r.lifecycleMu.RUnlock()
+	return r.lifecycleCtx
+}
+
+func (r *Router) runLifecycleTask(fn func(context.Context)) bool {
+	r.lifecycleMu.Lock()
+	switch r.lifecycleState {
+	case routerLifecycleInitial:
+		r.lifecycleMu.Unlock()
+		return false
+	case routerLifecycleRunning:
+		ctx := r.lifecycleCtx
+		r.lifecycleWG.Add(1)
+		go func() {
+			defer r.lifecycleWG.Done()
+			fn(ctx)
+		}()
+		r.lifecycleMu.Unlock()
+		return true
+	default:
+		r.lifecycleMu.Unlock()
+		return false
+	}
+}

--- a/internal/consensus/adaptor/router_lifecycle_test.go
+++ b/internal/consensus/adaptor/router_lifecycle_test.go
@@ -1,0 +1,207 @@
+package adaptor
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/stretchr/testify/require"
+)
+
+func startLifecycleTestRouter(t *testing.T) (*Router, chan *peermanagement.InboundMessage, <-chan struct{}) {
+	t.Helper()
+	inbox := make(chan *peermanagement.InboundMessage)
+	router := NewRouter(&mockEngine{}, newTestAdaptor(t), inbox)
+	done := make(chan struct{})
+	go func() {
+		router.Run(context.Background())
+		close(done)
+	}()
+	inbox <- &peermanagement.InboundMessage{}
+	return router, inbox, done
+}
+
+func TestRouterRunJoinsOwnedTasksOnInboxClose(t *testing.T) {
+	router, inbox, done := startLifecycleTestRouter(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	require.True(t, router.runLifecycleTask(func(context.Context) {
+		close(started)
+		<-release
+	}))
+	<-started
+
+	close(inbox)
+	select {
+	case <-done:
+		t.Fatal("Run returned while router-owned work was still active")
+	default:
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after router-owned work exited")
+	}
+
+	router.lifecycleMu.RLock()
+	require.Equal(t, routerLifecycleStopped, router.lifecycleState)
+	require.Nil(t, router.txJobs)
+	require.Nil(t, router.serveJobs)
+	router.lifecycleMu.RUnlock()
+	require.ErrorIs(t, router.lifecycleContext().Err(), context.Canceled)
+}
+
+func TestRouterRejectsWorkAfterTerminalStop(t *testing.T) {
+	router, inbox, done := startLifecycleTestRouter(t)
+	close(inbox)
+	<-done
+
+	var ran atomic.Bool
+	require.False(t, router.runLifecycleTask(func(context.Context) {
+		ran.Store(true)
+	}))
+	require.False(t, ran.Load())
+
+	dropped := router.DroppedTxJobs()
+	router.submitTxJob(&peermanagement.InboundMessage{})
+	require.Equal(t, dropped+1, router.DroppedTxJobs())
+
+	droppedServe := router.DroppedServeJobs()
+	router.submitServeJob(&peermanagement.InboundMessage{})
+	require.Equal(t, droppedServe+1, router.DroppedServeJobs())
+	require.False(t, ran.Load())
+}
+
+func TestRouterRejectsTrackedTasksBeforeRun(t *testing.T) {
+	router := NewRouter(&mockEngine{}, newTestAdaptor(t), nil)
+	var ran atomic.Bool
+
+	require.False(t, router.runLifecycleTask(func(context.Context) {
+		ran.Store(true)
+	}))
+	require.False(t, ran.Load())
+	require.NoError(t, router.lifecycleContext().Err())
+}
+
+func TestRouterRunJoinsOwnedTasksOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	inbox := make(chan *peermanagement.InboundMessage)
+	router := NewRouter(&mockEngine{}, newTestAdaptor(t), inbox)
+	done := make(chan struct{})
+	go func() {
+		router.Run(ctx)
+		close(done)
+	}()
+	inbox <- &peermanagement.InboundMessage{}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	require.True(t, router.runLifecycleTask(func(context.Context) {
+		close(started)
+		<-release
+	}))
+	<-started
+
+	cancel()
+	select {
+	case <-done:
+		t.Fatal("Run returned while router-owned work was still active")
+	default:
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after router-owned work exited")
+	}
+}
+
+func TestRouterRunJoinsSignaturePrewarm(t *testing.T) {
+	engine := &mockEngine{}
+	inbox := make(chan *peermanagement.InboundMessage)
+	router := NewRouter(engine, newTestAdaptor(t), inbox)
+	done := make(chan struct{})
+	go func() {
+		router.Run(context.Background())
+		close(done)
+	}()
+	inbox <- &peermanagement.InboundMessage{}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	router.prewarmSignatures = func(context.Context, [][]byte) {
+		close(started)
+		<-release
+	}
+	txSetID := consensus.TxSetID{1}
+	router.submitTxSetToEngine(txSetID, [][]byte{{1}})
+	<-started
+
+	engine.mu.Lock()
+	txSets := append([]consensus.TxSetID(nil), engine.txSets...)
+	engine.mu.Unlock()
+	require.Equal(t, []consensus.TxSetID{txSetID}, txSets)
+
+	close(inbox)
+	select {
+	case <-done:
+		t.Fatal("Run returned while signature prewarm was active")
+	default:
+	}
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after signature prewarm exited")
+	}
+}
+
+func TestRouterLifecycleAdmissionRacesShutdown(t *testing.T) {
+	const submitters = 128
+
+	inbox := make(chan *peermanagement.InboundMessage)
+	router := NewRouter(&mockEngine{}, newTestAdaptor(t), inbox)
+	var returned atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		router.Run(context.Background())
+		returned.Store(true)
+		close(done)
+	}()
+	inbox <- &peermanagement.InboundMessage{}
+
+	start := make(chan struct{})
+	var submissions sync.WaitGroup
+	var accepted atomic.Int32
+	var ran atomic.Int32
+	var ranAfterReturn atomic.Bool
+	for range submitters {
+		submissions.Add(1)
+		go func() {
+			defer submissions.Done()
+			<-start
+			if router.runLifecycleTask(func(context.Context) {
+				if returned.Load() {
+					ranAfterReturn.Store(true)
+				}
+				ran.Add(1)
+			}) {
+				accepted.Add(1)
+			}
+		}()
+	}
+
+	close(start)
+	close(inbox)
+	submissions.Wait()
+	<-done
+	require.Equal(t, accepted.Load(), ran.Load())
+	require.False(t, ranAfterReturn.Load())
+}

--- a/internal/consensus/adaptor/router_txpool_test.go
+++ b/internal/consensus/adaptor/router_txpool_test.go
@@ -46,6 +46,7 @@ func TestSubmitTxJobShedsWhenPoolSaturated(t *testing.T) {
 	r := NewRouter(&mockEngine{}, newTestAdaptor(t), make(chan *peermanagement.InboundMessage, 1))
 
 	// Install a full queue with no drainers so every submit sheds.
+	r.lifecycleState = routerLifecycleRunning
 	r.txJobs = make(chan *peermanagement.InboundMessage, 1)
 	r.txJobs <- &peermanagement.InboundMessage{}
 
@@ -121,11 +122,14 @@ func TestRunDrainsTxLane(t *testing.T) {
 // `go test -race` is what makes this test meaningful — it verifies the
 // channel / atomic-counter / worker handoff is free of data races.
 func TestSubmitTxJobConcurrent(t *testing.T) {
-	r := NewRouter(&mockEngine{}, newTestAdaptor(t), make(chan *peermanagement.InboundMessage, 1))
-
-	// Workers exit when t.Context() is canceled at test cleanup, so they
-	// don't leak across tests.
-	r.startTxWorkers(t.Context())
+	inbox := make(chan *peermanagement.InboundMessage)
+	r := NewRouter(&mockEngine{}, newTestAdaptor(t), inbox)
+	done := make(chan struct{})
+	go func() {
+		r.Run(t.Context())
+		close(done)
+	}()
+	inbox <- &peermanagement.InboundMessage{}
 
 	const n = 500 // < txQueueDepth (1024): the buffer absorbs all, so 0 sheds
 	var wg sync.WaitGroup
@@ -142,4 +146,6 @@ func TestSubmitTxJobConcurrent(t *testing.T) {
 	wg.Wait()
 
 	require.Equal(t, uint64(0), r.DroppedTxJobs())
+	close(inbox)
+	<-done
 }

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -1,6 +1,7 @@
 package adaptor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -562,8 +563,10 @@ func (r *Router) submitTxSetToEngine(txSetID consensus.TxSetID, blobs [][]byte) 
 	// Verify signatures off-strand so the accept build hits the sig-cache
 	// instead of a cold check per acquired tx under the apply mutex. Async:
 	// consensus sees the set immediately; anything unreached verifies in-strand.
-	if svc := r.adaptor.LedgerService(); svc != nil {
-		go svc.PrewarmSignatures(blobs)
+	if prewarm := r.prewarmSignatures; prewarm != nil {
+		r.runLifecycleTask(func(ctx context.Context) {
+			prewarm(ctx, blobs)
+		})
 	}
 	if err := r.engine.OnTxSet(txSetID, blobs); err != nil {
 		r.logger.Info("engine rejected tx-set",

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -67,17 +67,18 @@ type Components struct {
 	// without re-resolving from config.
 	Archive *archive.Archive
 
-	// cancel functions for background goroutines
-	overlayCancel    context.CancelFunc
-	routerCancel     context.CancelFunc
-	sitePollerCancel context.CancelFunc
-	vlTickCancel     context.CancelFunc
+	startStopMu sync.Mutex
+	lifecycleMu sync.Mutex
+	runCancel   context.CancelFunc
+	errors      chan error
+	started     bool
+	stopped     bool
+	stopOnce    sync.Once
+	fatalOnce   sync.Once
 
-	// routerDone is closed when the Router.Run loop returns, so Stop can join it
-	// rather than fire-and-forgetting: an in-process restart cycle would
-	// otherwise double-start Run loops, and a still-running loop could touch the
-	// engine Stop has already torn down.
-	routerDone chan struct{}
+	overlayDone chan struct{}
+	routerDone  chan struct{}
+	vlTickDone  chan struct{}
 }
 
 // validatorListTickInterval is how often Components.Start fires
@@ -87,72 +88,164 @@ type Components struct {
 // minute in the worst case.
 const validatorListTickInterval = 30 * time.Second
 
-// Start launches all background goroutines (overlay, engine, router).
-func (c *Components) Start() error {
-	// Start overlay. Capture Run's error so a listener bind failure (a stale
-	// process on the peer port, EACCES on a privileged port, a bad [port_peer]
-	// address) is loud and fatal at boot instead of leaving the node running
-	// deaf with no diagnostics. Run binds the listener before signalling
-	// ListenerReady, so a bind failure returns before that signal fires; wait
-	// for whichever happens first. A later (post-ready) exit is logged by the
-	// goroutine and left buffered so it never blocks.
-	overlayCtx, overlayCancel := context.WithCancel(context.Background())
-	c.overlayCancel = overlayCancel
-	overlayErr := make(chan error, 1)
-	go func() {
-		err := c.Overlay.Run(overlayCtx)
-		if err != nil && overlayCtx.Err() == nil {
-			slog.Error("overlay Run exited with error", "t", "consensus", "err", err)
+// Errors reports an unexpected exit from a component background loop.
+func (c *Components) Errors() <-chan error {
+	c.lifecycleMu.Lock()
+	defer c.lifecycleMu.Unlock()
+	if c.errors == nil {
+		c.errors = make(chan error, 1)
+	}
+	return c.errors
+}
+
+func (c *Components) reportFatal(err error) {
+	if err == nil {
+		return
+	}
+	c.fatalOnce.Do(func() {
+		c.lifecycleMu.Lock()
+		if c.errors == nil {
+			c.errors = make(chan error, 1)
 		}
-		overlayErr <- err
+		errors := c.errors
+		cancel := c.runCancel
+		c.lifecycleMu.Unlock()
+
+		errors <- err
+		if cancel != nil {
+			cancel()
+		}
+	})
+}
+
+func (c *Components) startupError(ctx context.Context) error {
+	select {
+	case err := <-c.Errors():
+		return err
+	default:
+		return context.Cause(ctx)
+	}
+}
+
+// Start launches all background goroutines (overlay, engine, router).
+func (c *Components) Start(ctx context.Context) error {
+	c.startStopMu.Lock()
+	defer c.startStopMu.Unlock()
+
+	if err := context.Cause(ctx); err != nil {
+		return fmt.Errorf("start consensus components: %w", err)
+	}
+	if c.Overlay == nil {
+		return fmt.Errorf("start consensus components: overlay is nil")
+	}
+	if c.Engine == nil {
+		return fmt.Errorf("start consensus components: engine is nil")
+	}
+	if c.Router == nil {
+		return fmt.Errorf("start consensus components: router is nil")
+	}
+
+	c.lifecycleMu.Lock()
+	if c.started {
+		c.lifecycleMu.Unlock()
+		return fmt.Errorf("start consensus components: already started")
+	}
+	if c.stopped {
+		c.lifecycleMu.Unlock()
+		return fmt.Errorf("start consensus components: already stopped")
+	}
+	runCtx, cancel := context.WithCancel(ctx) //nolint:gosec // G118: cancel is stored and called by Stop
+	c.runCancel = cancel
+	if c.errors == nil {
+		c.errors = make(chan error, 1)
+	}
+	c.started = true
+	c.overlayDone = make(chan struct{})
+	c.lifecycleMu.Unlock()
+
+	overlayResult := make(chan error, 1)
+	go func() {
+		err := c.Overlay.Run(runCtx)
+		overlayResult <- err
+		close(c.overlayDone)
 	}()
 
 	select {
 	case <-c.Overlay.ListenerReady():
-		// Listener bound (or none configured) — boot can proceed.
-	case err := <-overlayErr:
-		overlayCancel()
+	case err := <-overlayResult:
 		if err == nil {
 			err = fmt.Errorf("overlay exited before the listener was ready")
 		}
+		c.stop()
 		return fmt.Errorf("start overlay: %w", err)
+	case <-ctx.Done():
+		c.stop()
+		return fmt.Errorf("start overlay: %w", context.Cause(ctx))
 	}
 
-	// Start consensus engine
-	if err := c.Engine.Start(context.Background()); err != nil {
-		overlayCancel()
+	go func() {
+		err := <-overlayResult
+		if runCtx.Err() == nil {
+			if err == nil {
+				err = fmt.Errorf("overlay exited unexpectedly")
+			}
+			c.reportFatal(fmt.Errorf("overlay stopped: %w", err))
+		}
+	}()
+
+	if err := c.Engine.Start(runCtx); err != nil {
+		c.stop()
 		return fmt.Errorf("start consensus engine: %w", err)
 	}
 
-	// Start message router
-	routerCtx, routerCancel := context.WithCancel(context.Background())
-	c.routerCancel = routerCancel
+	c.lifecycleMu.Lock()
 	c.routerDone = make(chan struct{})
+	routerDone := c.routerDone
+	c.lifecycleMu.Unlock()
+	routerReady := c.Router.lifecycleReadyChannel()
 	go func() {
-		defer close(c.routerDone)
-		c.Router.Run(routerCtx)
+		c.Router.Run(runCtx)
+		close(routerDone)
+		if runCtx.Err() == nil {
+			c.reportFatal(fmt.Errorf("consensus router stopped unexpectedly"))
+		}
 	}()
+	select {
+	case <-routerReady:
+	case err := <-c.Errors():
+		c.stop()
+		return fmt.Errorf("start consensus components: %w", err)
+	case <-runCtx.Done():
+		c.stop()
+		return fmt.Errorf("start consensus router: %w", c.startupError(runCtx))
+	}
 
-	// Start the publisher-list HTTP poller. Cancellation propagates to
-	// per-URL goroutines via the poller's own stop channel.
 	if c.ValidatorListPoller != nil {
-		pollerCtx, pollerCancel := context.WithCancel(context.Background())
-		c.sitePollerCancel = pollerCancel
-		c.ValidatorListPoller.Start(pollerCtx)
+		c.ValidatorListPoller.Start(runCtx)
 	}
 
-	// Periodic ValidatorList.Tick promotes future-dated remaining
-	// rotations and emits OnChange when the trusted union changes.
-	// Without this, a rotation announced during a quiet period (no
-	// peer gossip, no site polls) would only land when the next
-	// ingest happens.
 	if c.ValidatorList != nil {
-		tickCtx, tickCancel := context.WithCancel(context.Background())
-		c.vlTickCancel = tickCancel
-		go c.runValidatorListTick(tickCtx, validatorListTickInterval)
+		c.lifecycleMu.Lock()
+		c.vlTickDone = make(chan struct{})
+		vlTickDone := c.vlTickDone
+		c.lifecycleMu.Unlock()
+		go func() {
+			defer close(vlTickDone)
+			c.runValidatorListTick(runCtx, validatorListTickInterval)
+		}()
 	}
 
-	return nil
+	if err := context.Cause(ctx); err != nil {
+		c.stop()
+		return fmt.Errorf("start consensus components: %w", err)
+	}
+	select {
+	case err := <-c.Errors():
+		c.stop()
+		return fmt.Errorf("start consensus components: %w", err)
+	default:
+		return nil
+	}
 }
 
 func (c *Components) runValidatorListTick(ctx context.Context, interval time.Duration) {
@@ -172,54 +265,56 @@ func (c *Components) runValidatorListTick(ctx context.Context, interval time.Dur
 }
 
 // Stop gracefully shuts down all components.
-func (c *Components) Stop() error {
-	var engineErr error
-	if c.vlTickCancel != nil {
-		c.vlTickCancel()
-	}
-	if c.sitePollerCancel != nil {
-		c.sitePollerCancel()
-	}
-	if c.ValidatorListPoller != nil {
-		c.ValidatorListPoller.Stop()
-	}
-	if c.routerCancel != nil {
-		c.routerCancel()
-	}
-	// Join the router loop before tearing down the engine, so it can't be
-	// mid-handleMessage touching an already-stopped engine. Bounded so a wedged
-	// handler can't hang shutdown.
-	if c.routerDone != nil {
-		select {
-		case <-c.routerDone:
-		case <-time.After(5 * time.Second):
-			slog.Warn("router loop did not exit within shutdown budget", "t", "Components.Stop")
+func (c *Components) Stop() {
+	c.startStopMu.Lock()
+	defer c.startStopMu.Unlock()
+	c.stop()
+}
+
+func (c *Components) stop() {
+	c.stopOnce.Do(func() {
+		c.lifecycleMu.Lock()
+		c.stopped = true
+		cancel := c.runCancel
+		routerDone := c.routerDone
+		vlTickDone := c.vlTickDone
+		overlayDone := c.overlayDone
+		c.lifecycleMu.Unlock()
+
+		if cancel != nil {
+			cancel()
 		}
-	}
-	if c.Adaptor != nil {
-		c.Adaptor.StopConsensusPhaseDispatcher()
-	}
-	if c.Engine != nil {
-		engineErr = c.Engine.Stop()
-	}
-	// Drain both acquisition paths after the router loop has stopped. Components
-	// are one-shot; a process restart constructs a fresh Router.
-	if c.Router != nil {
-		legacy, replay := c.Router.StopAcquisitions()
-		if legacy > 0 || replay > 0 {
-			slog.Info("ledger acquisitions drained at shutdown",
-				"t", "Components.Stop",
-				"legacy_in_flight_at_stop", legacy,
-				"replay_in_flight_at_stop", replay)
+		if c.ValidatorListPoller != nil {
+			c.ValidatorListPoller.Stop()
 		}
-	}
-	if c.overlayCancel != nil {
-		c.overlayCancel()
-	}
-	if c.Overlay != nil {
-		_ = c.Overlay.Stop()
-	}
-	return engineErr
+		if c.Overlay != nil {
+			_ = c.Overlay.Stop()
+		}
+		if routerDone != nil {
+			<-routerDone
+		}
+		if vlTickDone != nil {
+			<-vlTickDone
+		}
+		if overlayDone != nil {
+			<-overlayDone
+		}
+		if c.Router != nil {
+			legacy, replay := c.Router.StopAcquisitions()
+			if legacy > 0 || replay > 0 {
+				slog.Info("ledger acquisitions drained at shutdown",
+					"t", "Components.Stop",
+					"legacy_in_flight_at_stop", legacy,
+					"replay_in_flight_at_stop", replay)
+			}
+		}
+		if c.Adaptor != nil {
+			c.Adaptor.StopConsensusPhaseDispatcher()
+		}
+		if c.Engine != nil {
+			_ = c.Engine.Stop()
+		}
+	})
 }
 
 // NewFromConfig creates and wires all consensus/networking components from the app config.
@@ -288,6 +383,9 @@ func NewFromConfig(
 		Identity:            identity,
 		Validators:          validators,
 		ValidatorMasterKeys: masterKeys,
+		OnTxSetBuilt: func(id consensus.TxSetID) {
+			overlay.BroadcastHaveTxSet([32]byte(id))
+		},
 		// Source vote stances from the same amendment table the ledger service
 		// resyncs from validated ledgers, so operator veto/upvote ([amendments]
 		// config) drives consensus voting.
@@ -320,24 +418,6 @@ func NewFromConfig(
 	}
 
 	engine := rcl.NewEngine(adaptor, rcl.DefaultConfig())
-
-	// On-disk validation archive. Skipped when the relational DB is
-	// unavailable or the operator has disabled the section in TOML —
-	// either way the engine runs unchanged with the tracker in pure
-	// in-memory mode. When enabled, ExpireOld in the fully-validated
-	// callback streams pruned validations into the writer goroutine.
-	var validationArchive *archive.Archive
-	if validationRepo != nil && appCfg.ValidationArchive.Enabled {
-		archCfg := appCfg.ValidationArchive.WithDefaults()
-		validationArchive = archive.New(validationRepo, archive.Config{
-			RetentionLedgers: archCfg.RetentionLedgers,
-			BatchSize:        archCfg.BatchSize,
-			FlushInterval:    time.Duration(archCfg.FlushIntervalMs) * time.Millisecond,
-			DeleteBatch:      archCfg.DeleteBatch,
-		}, slog.Default().With("component", "validation_archive"))
-		engine.SetArchive(validationArchive)
-		engine.SetInMemoryLedgers(archCfg.InMemoryLedgers)
-	}
 
 	engine.SetLedgerAncestryProvider(rcl.NewAncestryProvider(ledgerSvc))
 
@@ -424,6 +504,22 @@ func NewFromConfig(
 				return nil, fmt.Errorf("validator-list site poller: %w", err)
 			}
 		}
+	}
+
+	// Create resources with active workers only after all fallible
+	// validator-list construction has completed. From here to the returned
+	// Components, startup performs wiring only and cannot strand the archive.
+	var validationArchive *archive.Archive
+	if validationRepo != nil && appCfg.ValidationArchive.Enabled {
+		archCfg := appCfg.ValidationArchive.WithDefaults()
+		validationArchive = archive.New(validationRepo, archive.Config{
+			RetentionLedgers: archCfg.RetentionLedgers,
+			BatchSize:        archCfg.BatchSize,
+			FlushInterval:    time.Duration(archCfg.FlushIntervalMs) * time.Millisecond,
+			DeleteBatch:      archCfg.DeleteBatch,
+		}, slog.Default().With("component", "validation_archive"))
+		engine.SetArchive(validationArchive)
+		engine.SetInMemoryLedgers(archCfg.InMemoryLedgers)
 	}
 
 	// Queue peer disconnect notifications for router-owned cleanup so

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -74,6 +74,7 @@ type Components struct {
 	started     bool
 	stopped     bool
 	stopOnce    sync.Once
+	stopErr     error
 	fatalOnce   sync.Once
 
 	overlayDone chan struct{}
@@ -265,10 +266,11 @@ func (c *Components) runValidatorListTick(ctx context.Context, interval time.Dur
 }
 
 // Stop gracefully shuts down all components.
-func (c *Components) Stop() {
+func (c *Components) Stop() error {
 	c.startStopMu.Lock()
 	defer c.startStopMu.Unlock()
 	c.stop()
+	return c.stopErr
 }
 
 func (c *Components) stop() {
@@ -312,7 +314,7 @@ func (c *Components) stop() {
 			c.Adaptor.StopConsensusPhaseDispatcher()
 		}
 		if c.Engine != nil {
-			_ = c.Engine.Stop()
+			c.stopErr = c.Engine.Stop()
 		}
 	})
 }

--- a/internal/consensus/adaptor/startup_cov_test.go
+++ b/internal/consensus/adaptor/startup_cov_test.go
@@ -473,28 +473,6 @@ func TestStup_ComponentsStop_NilSafe(t *testing.T) {
 	assert.NotPanics(t, func() { c.Stop() })
 }
 
-func TestStup_ComponentsStop_CancelsAllFunctions(t *testing.T) {
-	var called [4]bool
-	c := &Components{
-		vlTickCancel: func() {
-			called[0] = true
-		},
-		sitePollerCancel: func() {
-			called[1] = true
-		},
-		routerCancel: func() {
-			called[2] = true
-		},
-		overlayCancel: func() {
-			called[3] = true
-		},
-	}
-	c.Stop()
-	for i, v := range called {
-		assert.True(t, v, "cancel[%d] was not called", i)
-	}
-}
-
 func TestStup_ComponentsStop_NilEngineAndOverlaySafe(t *testing.T) {
 	c := &Components{
 		Engine:  nil,
@@ -544,13 +522,13 @@ func TestStup_ComponentsStart_AndStop(t *testing.T) {
 	}
 	_ = svc
 
-	err = c.Start()
+	err = c.Start(t.Context())
 	require.NoError(t, err)
 
-	assert.NotNil(t, c.overlayCancel)
-	assert.NotNil(t, c.routerCancel)
-	assert.Nil(t, c.sitePollerCancel, "no poller configured")
-	assert.Nil(t, c.vlTickCancel, "no ValidatorList configured")
+	assert.NotNil(t, c.runCancel)
+	assert.NotNil(t, c.overlayDone)
+	assert.NotNil(t, c.routerDone)
+	assert.Nil(t, c.vlTickDone, "no ValidatorList configured")
 
 	assert.NotPanics(t, func() { c.Stop() })
 }
@@ -563,13 +541,17 @@ func TestStup_ComponentsStart_ListenerBindFailure(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = overlay.Stop() })
 
+	eng := &mockEngine{}
+	ad := newTestAdaptor(t)
 	c := &Components{
 		Overlay: overlay,
-		Engine:  &mockEngine{},
+		Engine:  eng,
+		Adaptor: ad,
+		Router:  NewRouter(eng, ad, overlay.ConsensusMessages()),
 	}
 
 	done := make(chan error, 1)
-	go func() { done <- c.Start() }()
+	go func() { done <- c.Start(t.Context()) }()
 	select {
 	case startErr := <-done:
 		require.Error(t, startErr, "a listener bind failure must fail boot")
@@ -586,11 +568,14 @@ func TestStup_ComponentsStart_EngineStartError(t *testing.T) {
 	t.Cleanup(func() { _ = overlay.Stop() })
 
 	eng := &stup_errStartEngine{err: assert.AnError}
+	ad := newTestAdaptor(t)
 	c := &Components{
 		Overlay: overlay,
 		Engine:  eng,
+		Adaptor: ad,
+		Router:  NewRouter(eng, ad, overlay.ConsensusMessages()),
 	}
-	startErr := c.Start()
+	startErr := c.Start(t.Context())
 	assert.Error(t, startErr)
 }
 

--- a/internal/consensus/adaptor/startup_lifecycle_test.go
+++ b/internal/consensus/adaptor/startup_lifecycle_test.go
@@ -1,0 +1,164 @@
+package adaptor
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/stretchr/testify/require"
+)
+
+type lifecycleTestEngine struct {
+	mockEngine
+	startErr  error
+	stopCount atomic.Int32
+	stopCheck func()
+}
+
+func (e *lifecycleTestEngine) Start(context.Context) error {
+	return e.startErr
+}
+
+func (e *lifecycleTestEngine) Stop() error {
+	if e.stopCheck != nil {
+		e.stopCheck()
+	}
+	e.stopCount.Add(1)
+	return nil
+}
+
+func newLifecycleTestComponents(
+	t *testing.T,
+	engine *lifecycleTestEngine,
+	inbox <-chan *peermanagement.InboundMessage,
+) *Components {
+	t.Helper()
+	overlay, err := peermanagement.New()
+	require.NoError(t, err)
+	adaptor := newTestAdaptor(t)
+	if inbox == nil {
+		inbox = overlay.ConsensusMessages()
+	}
+	return &Components{
+		Overlay: overlay,
+		Engine:  engine,
+		Adaptor: adaptor,
+		Router:  NewRouter(engine, adaptor, inbox),
+	}
+}
+
+func TestComponentsStartEngineFailureRollsBack(t *testing.T) {
+	startErr := errors.New("engine start failed")
+	engine := &lifecycleTestEngine{startErr: startErr}
+	components := newLifecycleTestComponents(t, engine, nil)
+
+	err := components.Start(t.Context())
+	require.ErrorIs(t, err, startErr)
+	require.Equal(t, int32(1), engine.stopCount.Load())
+	require.NotNil(t, components.overlayDone)
+	select {
+	case <-components.overlayDone:
+	default:
+		t.Fatal("Start returned before the overlay stopped")
+	}
+
+	components.Stop()
+	require.Equal(t, int32(1), engine.stopCount.Load())
+}
+
+func TestComponentsReportsPostReadyOverlayExit(t *testing.T) {
+	engine := &lifecycleTestEngine{}
+	components := newLifecycleTestComponents(t, engine, nil)
+	require.NoError(t, components.Start(t.Context()))
+
+	require.NoError(t, components.Overlay.Stop())
+	select {
+	case err := <-components.Errors():
+		require.Error(t, err)
+		require.True(t, strings.Contains(err.Error(), "overlay stopped"), err.Error())
+	case <-time.After(2 * time.Second):
+		t.Fatal("unexpected overlay exit was not reported")
+	}
+
+	components.Stop()
+	select {
+	case <-components.routerDone:
+	default:
+		t.Fatal("Stop returned before the router stopped")
+	}
+}
+
+func TestComponentsReportsRouterExit(t *testing.T) {
+	inbox := make(chan *peermanagement.InboundMessage)
+	engine := &lifecycleTestEngine{}
+	components := newLifecycleTestComponents(t, engine, inbox)
+	require.NoError(t, components.Start(t.Context()))
+
+	close(inbox)
+	select {
+	case err := <-components.Errors():
+		require.Error(t, err)
+		require.True(t, strings.Contains(err.Error(), "router stopped"), err.Error())
+	case <-time.After(2 * time.Second):
+		t.Fatal("unexpected router exit was not reported")
+	}
+
+	components.Stop()
+	select {
+	case <-components.overlayDone:
+	default:
+		t.Fatal("Stop returned before the overlay stopped")
+	}
+}
+
+func TestComponentsStopJoinsValidatorTickBeforeEngine(t *testing.T) {
+	engine := &lifecycleTestEngine{}
+	components := newLifecycleTestComponents(t, engine, nil)
+	components.ValidatorList = stup_newAggregator(t)
+	engine.stopCheck = func() {
+		select {
+		case <-components.vlTickDone:
+		default:
+			t.Error("engine stopped before ValidatorList tick exited")
+		}
+	}
+
+	require.NoError(t, components.Start(t.Context()))
+	require.NotNil(t, components.vlTickDone)
+	components.Stop()
+	require.Equal(t, int32(1), engine.stopCount.Load())
+}
+
+func TestComponentsStopJoinsRouterWorkBeforeEngine(t *testing.T) {
+	engine := &lifecycleTestEngine{}
+	components := newLifecycleTestComponents(t, engine, nil)
+	require.NoError(t, components.Start(t.Context()))
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	require.True(t, components.Router.runLifecycleTask(func(context.Context) {
+		close(started)
+		<-release
+	}))
+	<-started
+
+	stopped := make(chan struct{})
+	go func() {
+		components.Stop()
+		close(stopped)
+	}()
+	<-components.Router.lifecycleContext().Done()
+	require.Zero(t, engine.stopCount.Load(), "engine stopped while Router work was active")
+
+	close(release)
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Components.Stop did not finish after Router work exited")
+	}
+	require.Equal(t, int32(1), engine.stopCount.Load())
+}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -871,6 +871,12 @@ func (s *Service) SubmitOpenLedgerTx(blob []byte, local bool) (openledger.Result
 // concurrently; unparseable blobs are skipped (the in-strand preflight rejects
 // them authoritatively).
 func (s *Service) PrewarmSignatures(blobs [][]byte) {
+	s.PrewarmSignaturesContext(context.Background(), blobs)
+}
+
+// PrewarmSignaturesContext verifies transaction signatures until ctx is
+// canceled.
+func (s *Service) PrewarmSignaturesContext(ctx context.Context, blobs [][]byte) {
 	if len(blobs) == 0 {
 		return
 	}
@@ -888,15 +894,33 @@ func (s *Service) PrewarmSignatures(blobs [][]byte) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for blob := range work {
-				if ptx, err := openledger.ParsePendingTx(blob); err == nil {
-					txengine.PrewarmSignature(ptx.Parsed)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case blob, ok := <-work:
+					if !ok {
+						return
+					}
+					if ptx, err := openledger.ParsePendingTx(blob); err == nil {
+						txengine.PrewarmSignature(ptx.Parsed)
+					}
 				}
 			}
 		}()
 	}
+feed:
 	for _, blob := range blobs {
-		work <- blob
+		select {
+		case <-ctx.Done():
+			break feed
+		case work <- blob:
+		}
 	}
 	close(work)
 	wg.Wait()

--- a/internal/node/lifecycle_test.go
+++ b/internal/node/lifecycle_test.go
@@ -39,6 +39,7 @@ func TestWaitForShutdownReturnsContextCause(t *testing.T) {
 			make(chan struct{}),
 			make(chan error),
 			nil,
+			nil,
 			"",
 		)
 	}()
@@ -51,5 +52,28 @@ func TestWaitForShutdownReturnsContextCause(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("waitForShutdown() did not return after context cancellation")
+	}
+}
+
+func TestWaitForShutdownReturnsComponentError(t *testing.T) {
+	t.Parallel()
+
+	componentErr := errors.New("consensus router stopped")
+	componentErrCh := make(chan error, 1)
+	componentErrCh <- componentErr
+
+	err := waitForShutdown(
+		context.Background(),
+		xrpllog.Discard(),
+		make(chan os.Signal),
+		make(chan os.Signal),
+		make(chan struct{}),
+		make(chan error),
+		componentErrCh,
+		nil,
+		"",
+	)
+	if !errors.Is(err, componentErr) {
+		t.Fatalf("waitForShutdown() error = %v, want %v", err, componentErr)
 	}
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -155,6 +155,7 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 		wsSrvs              []*http.Server
 		wsServer            *rpc.WebSocketServer
 		grpcSrv             *googlegrpc.Server
+		stallWatchdog       *watchdog.Watchdog
 	)
 	defer func() {
 		doShutdown(httpSrvs, wsSrvs, wsServer, grpcSrv, ledgerService, ledgerCleaner, consensusComponents, rotator, db, repoManager, serverLog)
@@ -525,12 +526,6 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 			}
 		}
 
-		if err := context.Cause(ctx); err != nil {
-			return err
-		}
-		if err := consensusComponents.Start(); err != nil {
-			return fmt.Errorf("start consensus components: %w", err)
-		}
 		if router := consensusComponents.Router; router != nil && cleanerSource != nil {
 			cleanerSource.SetReacquire(func(ctx context.Context, seq uint32) error {
 				if err := ctx.Err(); err != nil {
@@ -571,15 +566,6 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 		// Wire OpenLedger.Accept's relay callback so recovered txs are
 		// re-broadcast post-LCL (rippled OpenLedger.cpp:120-150).
 		ledgerService.SetTxRelay(broadcastTx)
-
-		// Wire the tx-set "we have this" announce: BuildTxSet fires
-		// onTxSetBuilt → overlay broadcasts TMHaveTransactionSet{tsHAVE}.
-		// Mirrors rippled's post-consensus mtHAVE_SET emission so peers
-		// acquiring the same set via mtHAVE_SET{tsNEED} can find a
-		// source without polling.
-		consensusComponents.Adaptor.SetOnTxSetBuilt(func(id consensus.TxSetID) {
-			overlay.BroadcastHaveTxSet([32]byte(id))
-		})
 
 		// Wire the open-ledger tx lookup used by the tx-reduce-relay
 		// reply path (TMGetObjectByHash{otTRANSACTIONS} → TMTransactions
@@ -1060,6 +1046,37 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 		)
 	}))
 
+	if !standalone && appConfig.Watchdog.IsEnabled() {
+		wdCfg := watchdog.ConfigFromSeconds(
+			appConfig.Watchdog.WarnSecondsResolved(),
+			appConfig.Watchdog.FatalSecondsResolved(),
+			appConfig.Watchdog.AbortSecondsResolved(),
+		)
+		stallWatchdog = watchdog.New(wdCfg, nil)
+		if consensusComponents != nil {
+			if sp, ok := consensusComponents.Engine.(stallPinger); ok {
+				sp.SetStallPing(stallWatchdog.Register("consensus"))
+			}
+		}
+	}
+
+	shutdownCh := make(chan struct{}, 1)
+	services.SetShutdownFunc(func() {
+		serverLog.Info("Shutdown requested via RPC stop command")
+		select {
+		case shutdownCh <- struct{}{}:
+		default:
+		}
+	})
+
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
+	if consensusComponents != nil {
+		if err := consensusComponents.Start(ctx); err != nil {
+			return fmt.Errorf("start consensus components: %w", err)
+		}
+	}
 	if err := context.Cause(ctx); err != nil {
 		return err
 	}
@@ -1090,24 +1107,10 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 	// watchdog runs on its own goroutine and aborts the process if a monitored
 	// loop wedges, so a deadlocked node screams and can be restarted instead of
 	// going quiet.
-	if !standalone && appConfig.Watchdog.IsEnabled() {
-		wdCfg := watchdog.ConfigFromSeconds(
-			appConfig.Watchdog.WarnSecondsResolved(),
-			appConfig.Watchdog.FatalSecondsResolved(),
-			appConfig.Watchdog.AbortSecondsResolved(),
-		)
-		wd := watchdog.New(wdCfg, nil)
-		// Monitor only the tick-driven consensus loop: rippled's LoadManager
-		// watches loop liveness, never ledger-close progress, so a catching-up
-		// node self-heals via checkLedger rather than aborting.
-		if consensusComponents != nil {
-			if sp, ok := consensusComponents.Engine.(stallPinger); ok {
-				sp.SetStallPing(wd.Register("consensus"))
-			}
-		}
+	if stallWatchdog != nil {
 		wdCtx, cancelWatchdog := context.WithCancel(context.Background())
 		defer cancelWatchdog()
-		go wd.Run(wdCtx)
+		go stallWatchdog.Run(wdCtx)
 		serverLog.Info("Stall watchdog armed",
 			"warn_s", appConfig.Watchdog.WarnSecondsResolved(),
 			"fatal_s", appConfig.Watchdog.FatalSecondsResolved(),
@@ -1130,20 +1133,21 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 	signal.Notify(reloadCh, syscall.SIGHUP)
 	defer signal.Stop(reloadCh)
 
-	// shutdownCh lets the RPC stop command trigger the same path
-	shutdownCh := make(chan struct{}, 1)
-
-	services.SetShutdownFunc(func() {
-		serverLog.Info("Shutdown requested via RPC stop command")
-		// Non-blocking: the main loop drains one value and returns, so a
-		// second concurrent stop must not park its handler goroutine forever.
-		select {
-		case shutdownCh <- struct{}{}:
-		default:
-		}
-	})
-
-	return waitForShutdown(ctx, serverLog, sigCh, reloadCh, shutdownCh, listenerErrCh, consensusComponents, configPath)
+	var componentErrCh <-chan error
+	if consensusComponents != nil {
+		componentErrCh = consensusComponents.Errors()
+	}
+	return waitForShutdown(
+		ctx,
+		serverLog,
+		sigCh,
+		reloadCh,
+		shutdownCh,
+		listenerErrCh,
+		componentErrCh,
+		consensusComponents,
+		configPath,
+	)
 }
 
 func configuredLedgerLoadFees(appConfig *config.Config) drops.Fees {
@@ -1176,9 +1180,10 @@ func validateTrustedValidatorConfig(appConfig *config.Config, standalone bool) e
 }
 
 // waitForShutdown blocks until a terminating event arrives: an OS signal, an
-// RPC stop, or a listener goroutine failure. SIGHUP is non-terminating — it
-// reloads the trusted validator set in place and keeps waiting. It returns the
-// listener error (if any) so the caller's deferred cleanup runs.
+// RPC stop, or a listener or consensus-component failure. SIGHUP is
+// non-terminating — it reloads the trusted validator set in place and keeps
+// waiting. It returns the fatal error (if any) so the caller's deferred cleanup
+// runs.
 
 func waitForShutdown(
 	ctx context.Context,
@@ -1186,6 +1191,7 @@ func waitForShutdown(
 	sigCh, reloadCh chan os.Signal,
 	shutdownCh chan struct{},
 	listenerErrCh chan error,
+	componentErrCh <-chan error,
 	consensusComponents *adaptor.Components,
 	configPath string,
 ) error {
@@ -1200,6 +1206,16 @@ func waitForShutdown(
 			return nil
 		case err := <-listenerErrCh:
 			log.Error("Listener failed — initiating shutdown", "err", err)
+			return err
+		case err, ok := <-componentErrCh:
+			if !ok {
+				componentErrCh = nil
+				continue
+			}
+			if err == nil {
+				err = errors.New("consensus component stopped unexpectedly")
+			}
+			log.Error("Consensus component failed — initiating shutdown", "err", err)
 			return err
 		case <-reloadCh:
 			reloadTrustedValidators(log, consensusComponents, configPath)


### PR DESCRIPTION
Part of #1453.

## Summary
- give Router one terminal lifecycle that closes admission, cancels, and joins transaction/serve workers, signature prewarming, replay retries, and existing acquisition/validation workers
- propagate Router cancellation through peer-driven persistence and ledger adoption
- install callbacks, providers, subscriptions, watchdog heartbeat, and RPC shutdown wiring before concurrent components or listeners start
- roll back partial component startup, supervise unexpected overlay/router exits, and join the validator-list ticker before engine teardown
- defer validation archive construction until all remaining fallible validator-list setup has succeeded

## Verification
- `just test`
- `GOCACHE=/private/tmp/goxrpl-1453-core-cache just test-core`
- `go test -race -count=1 ./internal/consensus/adaptor ./internal/ledger/service ./internal/node`
- `just vet`
- `just build-all`
- `just build-nocgo`
- `just lint`
- strict `golangci-lint run --config .golangci.yml`
- `go mod tidy` (module files unchanged)
- `git diff --check`

## Integration notes
- this PR is based independently on `main`; it does not depend on #1488
- when integrating #1477, preserve its `Components.Stop() error` / archive-close error propagation
- when integrating #1482, preserve its ModeManager removal and narrowed router engine interface alongside this lifecycle ownership

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved startup and shutdown coordination for consensus services.
  - Added graceful cancellation and cleanup for background processing.
  - Improved handling of unexpected component failures during node operation.
  - Increased reliability when submitting transactions and ledger work during startup, normal operation, and shutdown.
  - Added safer concurrent transaction-set processing, ensuring unique sets are announced once.
  - Signature prewarming can now stop promptly when shutdown or cancellation occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->