### PR TITLE
fix: bound consensus adaptor state (#1453)

### DIFF
--- a/internal/consensus/adaptor/adaptor_test.go
+++ b/internal/consensus/adaptor/adaptor_test.go
@@ -308,30 +308,6 @@ func TestTxSetContains(t *testing.T) {
 	assert.False(t, ts.Contains(id3))
 }
 
-func TestTxSetAddRemove(t *testing.T) {
-	blob1 := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C}
-	blob2 := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C}
-
-	ts, err := NewTxSet([][]byte{blob1})
-	require.NoError(t, err)
-	assert.Equal(t, 1, ts.Size())
-
-	originalID := ts.ID()
-
-	// Add
-	err = ts.Add(blob2)
-	require.NoError(t, err)
-	assert.Equal(t, 2, ts.Size())
-	assert.NotEqual(t, originalID, ts.ID()) // ID should change
-
-	// Remove
-	id1 := computeTxID(blob1)
-	err = ts.Remove(id1)
-	require.NoError(t, err)
-	assert.Equal(t, 1, ts.Size())
-	assert.False(t, ts.Contains(id1))
-}
-
 func TestProposalSignVerify(t *testing.T) {
 	identity, err := NewValidatorIdentity("snoPBrXtMeMyMHUVTgbuqAfg1SUTb")
 	require.NoError(t, err)

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -346,7 +346,7 @@ const serveQueueDepth = 256
 // messageDedupTTL matches rippled's five-minute suppression hold.
 const messageDedupTTL = 300 * time.Second
 
-const messageDedupSweepThreshold = 4096
+const messageDedupMaxEntries = 4096
 
 // NewRouter creates a new Router.
 func NewRouter(engine consensus.RouterEngine, adaptor *Adaptor, inbox <-chan *peermanagement.InboundMessage) *Router {
@@ -362,7 +362,7 @@ func NewRouter(engine consensus.RouterEngine, adaptor *Adaptor, inbox <-chan *pe
 		replayer:           inbound.NewReplayer(logger, inbound.SystemClock, inbound.DefaultMaxInFlightReplays),
 		fetchTracker:       inbound.NewTracker(),
 		fetchPacks:         newFetchPackCache(),
-		messageSeen:        newMessageSuppression(messageDedupTTL, messageDedupSweepThreshold),
+		messageSeen:        newMessageSuppression(messageDedupTTL, messageDedupMaxEntries),
 		txSetAcquire:       make(map[consensus.TxSetID]*txSetAcquireState),
 		txSetRetryKnobs:    defaultTxSetRetryKnobs(),
 		seqHash:            make(map[uint32]ledgerHashEntry),

--- a/internal/consensus/adaptor/router_dedup.go
+++ b/internal/consensus/adaptor/router_dedup.go
@@ -1,6 +1,7 @@
 package adaptor
 
 import (
+	"container/list"
 	"encoding/binary"
 	"sync"
 	"time"
@@ -99,32 +100,29 @@ func appendVLPrefix(buf []byte, n int) []byte {
 // duplicates, accelerating selection N-fold and producing squelches
 // earlier and more aggressively than the rest of the network expects.
 type messageSuppression struct {
-	mu sync.Mutex
-	// seen maps a suppression hash to the most recent observation time.
-	// TTL-evicted on observe once the sweep threshold is reached.
-	seen map[[32]byte]time.Time
-	// peers maps a suppression hash to the set of peer IDs known to
-	// already have the message. Populated both on inbound observe (the
-	// sender now has it because they sent it to us) and on outbound
-	// broadcast (the recipient now has it because we sent it to them).
-	// Used by validator-list broadcast to skip peers known to already have
-	// the same content.
-	peers          map[[32]byte]map[uint64]struct{}
-	ttl            time.Duration
-	sweepThreshold int
-	nextSweep      time.Time
-	now            func() time.Time
+	mu      sync.Mutex
+	entries map[[32]byte]*suppressionEntry
+	order   list.List
+	ttl     time.Duration
+	maxSize int
+	now     func() time.Time
 }
 
-// newMessageSuppression returns a dedup tracker. ttl bounds how long a
-// hash is remembered; sweepThreshold controls when stale-entry scans begin.
-func newMessageSuppression(ttl time.Duration, sweepThreshold int) *messageSuppression {
+type suppressionEntry struct {
+	seenAt time.Time
+	peers  map[uint64]struct{}
+	order  *list.Element
+}
+
+func newMessageSuppression(ttl time.Duration, maxSize int) *messageSuppression {
+	if maxSize < 1 {
+		maxSize = 1
+	}
 	return &messageSuppression{
-		seen:           make(map[[32]byte]time.Time),
-		peers:          make(map[[32]byte]map[uint64]struct{}),
-		ttl:            ttl,
-		sweepThreshold: sweepThreshold,
-		now:            time.Now,
+		entries: make(map[[32]byte]*suppressionEntry),
+		ttl:     ttl,
+		maxSize: maxSize,
+		now:     time.Now,
 	}
 }
 
@@ -141,35 +139,13 @@ func (s *messageSuppression) observe(hash [32]byte) (firstSeen bool, lastSeenAt 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	now := s.now()
-
-	if len(s.seen) >= s.sweepThreshold &&
-		(s.nextSweep.IsZero() || !now.Before(s.nextSweep)) {
-		cutoff := now.Add(-s.ttl)
-		for h, seenAt := range s.seen {
-			if seenAt.Before(cutoff) {
-				delete(s.seen, h)
-				delete(s.peers, h)
-			}
-		}
-		sweepInterval := s.ttl / 4
-		if sweepInterval <= 0 {
-			sweepInterval = s.ttl
-		}
-		s.nextSweep = now.Add(sweepInterval)
-	}
-
-	if seenAt, ok := s.seen[hash]; ok && now.Sub(seenAt) < s.ttl {
-		s.seen[hash] = now // refresh so a steady stream of duplicates stays live
-		return false, seenAt
-	}
-	s.seen[hash] = now
-	return true, time.Time{}
+	_, firstSeen, lastSeenAt = s.touchLocked(hash, s.now())
+	return firstSeen, lastSeenAt
 }
 
 func (s *messageSuppression) allowRetry(hash [32]byte) {
 	s.mu.Lock()
-	delete(s.seen, hash)
+	s.removeLocked(hash)
 	s.mu.Unlock()
 }
 
@@ -177,11 +153,16 @@ func (s *messageSuppression) seenRecently(hash [32]byte) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	now := s.now()
-	seenAt, ok := s.seen[hash]
-	if !ok || now.Sub(seenAt) >= s.ttl {
+	entry, ok := s.entries[hash]
+	if !ok {
 		return false
 	}
-	s.seen[hash] = now
+	if s.expired(entry, now) {
+		s.removeLocked(hash)
+		return false
+	}
+	entry.seenAt = now
+	s.order.MoveToBack(entry.order)
 	return true
 }
 
@@ -200,18 +181,14 @@ func (s *messageSuppression) recordPeer(hash [32]byte, peerID uint64) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	now := s.now()
-	s.seen[hash] = now
-
-	peers, ok := s.peers[hash]
-	if !ok {
-		peers = make(map[uint64]struct{})
-		s.peers[hash] = peers
+	entry, _, _ := s.touchLocked(hash, s.now())
+	if entry.peers == nil {
+		entry.peers = make(map[uint64]struct{})
 	}
-	if _, present := peers[peerID]; present {
+	if _, present := entry.peers[peerID]; present {
 		return false
 	}
-	peers[peerID] = struct{}{}
+	entry.peers[peerID] = struct{}{}
 	return true
 }
 
@@ -221,10 +198,64 @@ func (s *messageSuppression) recordPeer(hash [32]byte, peerID uint64) bool {
 func (s *messageSuppression) peerHasHash(hash [32]byte, peerID uint64) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	peers, ok := s.peers[hash]
+	entry, ok := s.entries[hash]
 	if !ok {
 		return false
 	}
-	_, present := peers[peerID]
+	if s.expired(entry, s.now()) {
+		s.removeLocked(hash)
+		return false
+	}
+	_, present := entry.peers[peerID]
 	return present
+}
+
+func (s *messageSuppression) touchLocked(hash [32]byte, now time.Time) (*suppressionEntry, bool, time.Time) {
+	if entry, ok := s.entries[hash]; ok {
+		if !s.expired(entry, now) {
+			lastSeenAt := entry.seenAt
+			entry.seenAt = now
+			s.order.MoveToBack(entry.order)
+			return entry, false, lastSeenAt
+		}
+		s.removeLocked(hash)
+	}
+
+	s.expireLocked(now)
+	for len(s.entries) >= s.maxSize {
+		oldest := s.order.Front()
+		if oldest == nil {
+			break
+		}
+		s.removeLocked(oldest.Value.([32]byte))
+	}
+
+	entry := &suppressionEntry{seenAt: now}
+	entry.order = s.order.PushBack(hash)
+	s.entries[hash] = entry
+	return entry, true, time.Time{}
+}
+
+func (s *messageSuppression) expireLocked(now time.Time) {
+	for oldest := s.order.Front(); oldest != nil; oldest = s.order.Front() {
+		hash := oldest.Value.([32]byte)
+		entry := s.entries[hash]
+		if entry != nil && !s.expired(entry, now) {
+			return
+		}
+		s.removeLocked(hash)
+	}
+}
+
+func (s *messageSuppression) expired(entry *suppressionEntry, now time.Time) bool {
+	return now.Sub(entry.seenAt) >= s.ttl
+}
+
+func (s *messageSuppression) removeLocked(hash [32]byte) {
+	entry, ok := s.entries[hash]
+	if !ok {
+		return
+	}
+	s.order.Remove(entry.order)
+	delete(s.entries, hash)
 }

--- a/internal/consensus/adaptor/router_dedup_test.go
+++ b/internal/consensus/adaptor/router_dedup_test.go
@@ -1,11 +1,27 @@
 package adaptor
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type proposalAdmissionEngine struct {
+	mockEngine
+	err   error
+	calls int
+}
+
+func (e *proposalAdmissionEngine) OnProposal(*consensus.Proposal, uint64) error {
+	e.calls++
+	return e.err
+}
 
 // TestMessageSuppression_ObserveReturnsLastSeen pins R5.7: observe()
 // must return both first-seen and the prior observation time so the
@@ -159,4 +175,45 @@ func TestMessageSuppression_AllowRetryRemovesWholeEntry(t *testing.T) {
 
 	assert.NotContains(t, s.entries, hash)
 	assert.False(t, s.peerHasHash(hash, 11))
+}
+
+func TestProposalSuppression_AdmitsOnlyAfterEngineAcceptance(t *testing.T) {
+	router, _ := newRetryRouter(t)
+	engine := &proposalAdmissionEngine{err: errors.New("invalid proposal")}
+	router.engine = engine
+	router.messageSeen = newMessageSuppression(time.Minute, 2)
+
+	first := [32]byte{1}
+	second := [32]byte{2}
+	router.messageSeen.observe(first)
+	router.messageSeen.observe(second)
+
+	proposal := &message.ProposeSet{
+		ProposeSeq:     1,
+		CurrentTxHash:  make([]byte, 32),
+		NodePubKey:     make([]byte, 33),
+		CloseTime:      timeToXrplEpoch(time.Unix(1_700_000_000, 0)),
+		Signature:      make([]byte, signatureMinLen),
+		PreviousLedger: make([]byte, 32),
+	}
+	proposal.NodePubKey[0] = 0x02
+	hash := hashProposalSuppression(ProposalFromMessage(proposal))
+	inbound := &peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    uint16(message.TypeProposeLedger),
+		Payload: encodePayload(t, proposal),
+	}
+
+	router.handleProposal(inbound)
+	assert.NotContains(t, router.messageSeen.entries, hash)
+	assert.Contains(t, router.messageSeen.entries, first)
+	assert.Contains(t, router.messageSeen.entries, second)
+
+	engine.err = nil
+	router.handleProposal(inbound)
+	require.Contains(t, router.messageSeen.entries, hash)
+	assert.Equal(t, 2, engine.calls)
+
+	router.handleProposal(inbound)
+	assert.Equal(t, 2, engine.calls, "accepted duplicate must bypass the engine")
 }

--- a/internal/consensus/adaptor/router_dedup_test.go
+++ b/internal/consensus/adaptor/router_dedup_test.go
@@ -94,19 +94,69 @@ func TestMessageSuppression_RecordPeerAndHasHash(t *testing.T) {
 		"peer-set must be scoped per hash")
 }
 
-func TestMessageSuppression_DoesNotEvictLiveEntriesAtSweepThreshold(t *testing.T) {
+func TestMessageSuppression_EvictsLeastRecentlyUsedAtCapacity(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
-	s := newMessageSuppression(5*time.Minute, 4)
+	s := newMessageSuppression(5*time.Minute, 3)
 	s.now = func() time.Time { return now }
 
 	first := [32]byte{1}
-	firstSeen, _ := s.observe(first)
-	assert.True(t, firstSeen)
-	for i := byte(2); i <= 8; i++ {
-		hash := [32]byte{i}
-		s.observe(hash)
-	}
+	second := [32]byte{2}
+	third := [32]byte{3}
+	fourth := [32]byte{4}
+	s.observe(first)
+	s.observe(second)
+	s.observe(third)
+	s.observe(first)
+	s.observe(fourth)
 
-	firstSeen, _ = s.observe(first)
-	assert.False(t, firstSeen)
+	assert.Contains(t, s.entries, first)
+	assert.NotContains(t, s.entries, second)
+	assert.Contains(t, s.entries, third)
+	assert.Contains(t, s.entries, fourth)
+	assert.Len(t, s.entries, 3)
+}
+
+func TestMessageSuppression_RecordPeerUsesSharedCapacity(t *testing.T) {
+	s := newMessageSuppression(5*time.Minute, 2)
+	first := [32]byte{1}
+	second := [32]byte{2}
+	third := [32]byte{3}
+
+	assert.True(t, s.recordPeer(first, 11))
+	assert.True(t, s.recordPeer(second, 22))
+	assert.False(t, s.recordPeer(first, 11))
+	assert.True(t, s.recordPeer(third, 33))
+
+	assert.True(t, s.peerHasHash(first, 11))
+	assert.False(t, s.peerHasHash(second, 22))
+	assert.True(t, s.peerHasHash(third, 33))
+	assert.Len(t, s.entries, 2)
+}
+
+func TestMessageSuppression_PeerAssociationsExpireAsOneEntry(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	const ttl = 30 * time.Second
+	s := newMessageSuppression(ttl, 4)
+	s.now = func() time.Time { return now }
+	hash := [32]byte{1}
+
+	assert.True(t, s.recordPeer(hash, 11))
+	now = now.Add(ttl)
+	assert.False(t, s.peerHasHash(hash, 11))
+	assert.NotContains(t, s.entries, hash)
+
+	assert.True(t, s.recordPeer(hash, 22))
+	assert.False(t, s.peerHasHash(hash, 11))
+	assert.True(t, s.peerHasHash(hash, 22))
+}
+
+func TestMessageSuppression_AllowRetryRemovesWholeEntry(t *testing.T) {
+	s := newMessageSuppression(time.Minute, 4)
+	hash := [32]byte{1}
+	s.recordPeer(hash, 11)
+
+	s.allowRetry(hash)
+
+	assert.NotContains(t, s.entries, hash)
+	assert.False(t, s.peerHasHash(hash, 11))
 }

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -186,7 +186,8 @@ func (r *Router) handleProposal(msg *peermanagement.InboundMessage) {
 	r.resolveMasterNodeID(&proposal.NodeID, proposal.SigningPubKey)
 	originPeer := uint64(msg.PeerID)
 
-	// Record duplicate-status + last-sighting BEFORE OnProposal.
+	// Check duplicate-status before OnProposal, but do not admit a new hash to
+	// durable suppression until signature verification and engine acceptance.
 	// Hash the DECODED fields via hashProposalSuppression. Hashing
 	// the raw protobuf envelope would desync dedup from peers
 	// that see the same message with different optional-field framing
@@ -198,8 +199,6 @@ func (r *Router) handleProposal(msg *peermanagement.InboundMessage) {
 	suppressionHash := hashProposalSuppression(proposal)
 	proposal.SuppressionHash = suppressionHash
 	r.adaptor.RecordMessageSource(suppressionHash, originPeer)
-	firstSeen, _ := r.messageSeen.observe(suppressionHash)
-
 	// Drop duplicates before the engine path (re-running OnProposal
 	// just re-verifies ECDSA). Still feed the IDLED-gated relay slot
 	// on dupes for squelch accounting.
@@ -207,7 +206,7 @@ func (r *Router) handleProposal(msg *peermanagement.InboundMessage) {
 	// Rippled counts a duplicate for reduce-relay only after the first copy
 	// was relayed. Sources received before that point are accumulated and
 	// counted atomically by RelayFromValidator.
-	if !firstSeen {
+	if r.messageSeen.seenRecently(suppressionHash) {
 		if r.adaptor.MessageRelayedRecently(suppressionHash) {
 			r.adaptor.UpdateRelaySlot(proposal.SigningPubKey[:], originPeer, nil)
 		}
@@ -218,6 +217,7 @@ func (r *Router) handleProposal(msg *peermanagement.InboundMessage) {
 		r.logger.Debug("engine rejected proposal", "error", err, "peer", msg.PeerID)
 		return
 	}
+	r.messageSeen.observe(suppressionHash)
 }
 
 func (r *Router) handleValidation(msg *peermanagement.InboundMessage) {

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -15,9 +15,10 @@ import (
 )
 
 type txSetAcquireState struct {
-	txMap      *shamap.SHAMap
-	startedAt  time.Time
-	lastUpdate time.Time
+	txMap         *shamap.SHAMap
+	startedAt     time.Time
+	lastUpdate    time.Time
+	retainedBytes int64
 
 	// Retry bookkeeping. lastRequest is when we most recently broadcast a
 	// RequestTxSetMissingNodes. attempts is pure telemetry (the broadcast
@@ -60,9 +61,144 @@ type txSetAcquireState struct {
 	done bool
 }
 
-// 60s covers a consensus round (~15s) plus retries with margin while
-// bounding memory under a stalled consumer.
-const txSetAcquireTTL = 60 * time.Second
+const (
+	// 60s covers a consensus round (~15s) plus retries with margin.
+	txSetAcquireTTL = 60 * time.Second
+
+	// Acquisition limits bound both the number of independently addressable
+	// SHAMaps and the work or payload that any one peer response can retain.
+	// The node ceiling matches the production serve-path hard cap. The byte
+	// limits independently prevent a peer from turning a requested set into
+	// unbounded process memory.
+	txSetAcquireMaxActive      = 64
+	txSetAcquireMaxReplyNodes  = 12288
+	txSetAcquireMaxReplyBytes  = int64(message.MaxMessageSize)
+	txSetAcquireMaxSetBytes    = int64(message.MaxMessageSize)
+	txSetAcquireMaxGlobalBytes = 4 * txSetAcquireMaxSetBytes
+)
+
+func txSetReplyBytes(ld *message.LedgerData) (int64, bool) {
+	if len(ld.Nodes) > txSetAcquireMaxReplyNodes {
+		return 0, false
+	}
+	var total int64
+	for _, node := range ld.Nodes {
+		nodeBytes := int64(len(node.NodeID)) + int64(len(node.NodeData))
+		if nodeBytes > txSetAcquireMaxReplyBytes-total {
+			return 0, false
+		}
+		total += nodeBytes
+	}
+	return total, true
+}
+
+// Caller must hold r.txSetAcquireMu.
+func (r *Router) txSetRetainedBytesLocked() int64 {
+	var total int64
+	for _, state := range r.txSetAcquire {
+		total += state.retainedBytes
+	}
+	return total
+}
+
+// Caller must hold r.txSetAcquireMu.
+func (r *Router) makeTxSetByteRoomLocked(state *txSetAcquireState, additional int64) bool {
+	if additional < 0 || additional > txSetAcquireMaxSetBytes-state.retainedBytes {
+		return false
+	}
+	for additional > txSetAcquireMaxGlobalBytes-r.txSetRetainedBytesLocked() {
+		oldestID, ok := r.oldestDoneTxSetAcquireLocked(true, true, state)
+		if !ok {
+			return false
+		}
+		r.deleteTxSetAcquireLocked(oldestID)
+	}
+	return true
+}
+
+func (r *Router) reserveTxSetNodeBytes(txSetID consensus.TxSetID, state *txSetAcquireState, txMap *shamap.SHAMap, nodeBytes int64) bool {
+	r.txSetAcquireMu.Lock()
+	defer r.txSetAcquireMu.Unlock()
+	current, ok := r.txSetAcquire[txSetID]
+	if !ok || current != state || current.txMap != txMap || current.done ||
+		!r.makeTxSetByteRoomLocked(current, nodeBytes) {
+		return false
+	}
+	current.retainedBytes += nodeBytes
+	return true
+}
+
+func (r *Router) releaseTxSetNodeBytes(txSetID consensus.TxSetID, state *txSetAcquireState, txMap *shamap.SHAMap, nodeBytes int64) {
+	r.txSetAcquireMu.Lock()
+	defer r.txSetAcquireMu.Unlock()
+	current, ok := r.txSetAcquire[txSetID]
+	if !ok || current != state || current.txMap != txMap {
+		return
+	}
+	current.retainedBytes -= nodeBytes
+}
+
+// Caller must hold r.txSetAcquireMu.
+func (r *Router) releaseTxSetMapLocked(state *txSetAcquireState) {
+	state.txMap = nil
+	state.retainedBytes = 0
+}
+
+// Caller must hold r.txSetAcquireMu.
+func (r *Router) deleteTxSetAcquireLocked(txSetID consensus.TxSetID) {
+	if state, ok := r.txSetAcquire[txSetID]; ok {
+		r.releaseTxSetMapLocked(state)
+		delete(r.txSetAcquire, txSetID)
+	}
+}
+
+func txSetIDLess(left, right consensus.TxSetID) bool {
+	for i := range left {
+		if left[i] != right[i] {
+			return left[i] < right[i]
+		}
+	}
+	return false
+}
+
+// Caller must hold r.txSetAcquireMu.
+func (r *Router) oldestDoneTxSetAcquireLocked(
+	dormant bool,
+	retainedOnly bool,
+	exclude *txSetAcquireState,
+) (consensus.TxSetID, bool) {
+	var oldestID consensus.TxSetID
+	var oldestUpdate time.Time
+	found := false
+	for id, state := range r.txSetAcquire {
+		if state == exclude || !state.done || state.dormant != dormant ||
+			(retainedOnly && state.retainedBytes == 0) {
+			continue
+		}
+		if !found || state.lastUpdate.Before(oldestUpdate) ||
+			(state.lastUpdate.Equal(oldestUpdate) && txSetIDLess(id, oldestID)) {
+			oldestID = id
+			oldestUpdate = state.lastUpdate
+			found = true
+		}
+	}
+	return oldestID, found
+}
+
+// Caller must hold r.txSetAcquireMu.
+func (r *Router) makeTxSetAcquireRoomLocked() bool {
+	if len(r.txSetAcquire) < txSetAcquireMaxActive {
+		return true
+	}
+	for _, dormant := range []bool{false, true} {
+		oldestID, ok := r.oldestDoneTxSetAcquireLocked(dormant, false, nil)
+		if ok {
+			r.deleteTxSetAcquireLocked(oldestID)
+			return true
+		}
+	}
+	return false
+}
 
 // txSetRetryKnobs collects the tunable parameters of the tx-set acquire
 // retry loop. The inbound path pipelines a re-request on every
@@ -191,13 +327,27 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 	if len(ld.LedgerHash) != 32 {
 		return
 	}
+	_, withinReplyLimit := txSetReplyBytes(ld)
+	if !withinReplyLimit {
+		r.logger.Info("tx-set sync: reply exceeds resource limit",
+			"t", "consensus", "event", "txset-resource-limit",
+			"node_count", len(ld.Nodes))
+		return
+	}
 	var txSetID consensus.TxSetID
 	copy(txSetID[:], ld.LedgerHash)
 
 	r.txSetAcquireMu.Lock()
 	r.sweepStaleTxSetAcquireLocked()
 	state, exists := r.txSetAcquire[txSetID]
-	if !exists || state.done {
+	if !exists {
+		r.txSetAcquireMu.Unlock()
+		if originPeer != 0 {
+			r.adaptor.IncPeerBadData(originPeer, "txset-useless-unneeded")
+		}
+		return
+	}
+	if state.done {
 		r.txSetAcquireMu.Unlock()
 		if originPeer != 0 {
 			r.adaptor.IncPeerBadData(originPeer, "txset-useless-unneeded")
@@ -206,9 +356,7 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 	}
 
 	if len(ld.Nodes) == 0 {
-		if originPeer != 0 {
-			state.peerNonProgress[originPeer]++
-		}
+		state.peerNonProgress[originPeer]++
 		r.txSetAcquireMu.Unlock()
 		if originPeer != 0 {
 			r.adaptor.IncPeerBadData(originPeer, "txset-useless-nonprogress")
@@ -233,8 +381,9 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 	}
 
 	if state.txMap == nil {
-		txMap := shamap.New(shamap.TypeTransaction)
-		if err := txMap.StartSync(); err != nil {
+		state.txMap = shamap.New(shamap.TypeTransaction)
+		if err := state.txMap.StartSync(); err != nil {
+			r.deleteTxSetAcquireLocked(txSetID)
 			r.txSetAcquireMu.Unlock()
 			r.logger.Info("tx-set sync: StartSync failed",
 				"t", "consensus", "event", "txset-reject",
@@ -242,38 +391,80 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 				"error", err.Error())
 			return
 		}
-		state.txMap = txMap
 	}
+	state.lastUpdate = time.Now()
 	txMap := state.txMap
 	haveRoot := state.haveRoot
 	r.txSetAcquireMu.Unlock()
 
-	// Process nodes in wire order. A bad root is tolerated and processing
-	// continues, while a bad non-root invalidates the reply immediately.
-	// This ordering lets a later valid root recover from an earlier bad root,
-	// but does not let a later root rescue a non-root that arrived before it.
+	resourceLimited := false
+	defer func() {
+		if !resourceLimited {
+			return
+		}
+		r.txSetAcquireMu.Lock()
+		state, exists := r.txSetAcquire[txSetID]
+		if !exists || state.retainedBytes != 0 {
+			r.txSetAcquireMu.Unlock()
+			return
+		}
+		r.deleteTxSetAcquireLocked(txSetID)
+		r.txSetAcquireMu.Unlock()
+	}()
+
+	// Root NodeID is 33 zero bytes. AddRootNode is idempotent
+	// (ErrRootAlreadySet treated as success). rootAccepted feeds
+	// per-peer progress accounting so a peer whose reply contains
+	// only the root still counts as making progress.
 	rootAccepted := false
 	badRootProvided := false
+	for _, node := range ld.Nodes {
+		if !isShamapRootNodeID(node.NodeID) {
+			continue
+		}
+		nodeBytes := int64(len(node.NodeID)) + int64(len(node.NodeData))
+		reserved := haveRoot || r.reserveTxSetNodeBytes(txSetID, state, txMap, nodeBytes)
+		if !reserved {
+			resourceLimited = true
+			continue
+		}
+		err := txMap.AddRootNode([32]byte(txSetID), node.NodeData)
+		switch {
+		case err == nil:
+			rootAccepted = true
+		case errors.Is(err, shamap.ErrRootAlreadySet):
+			rootAccepted = true
+			if !haveRoot {
+				r.releaseTxSetNodeBytes(txSetID, state, txMap, nodeBytes)
+			}
+		default:
+			badRootProvided = true
+			if !haveRoot {
+				r.releaseTxSetNodeBytes(txSetID, state, txMap, nodeBytes)
+			}
+			r.logger.Info("tx-set sync: AddRootNode failed",
+				"t", "consensus", "event", "txset-reject",
+				"txset", fmt.Sprintf("%x", txSetID[:8]),
+				"error", err.Error())
+		}
+		continue
+	}
+	if rootAccepted && !haveRoot {
+		haveRoot = true
+		r.txSetAcquireMu.Lock()
+		state.haveRoot = true
+		r.txSetAcquireMu.Unlock()
+	}
+
+	// Process nodes in wire order. A bad root is tolerated and processing
+	// continues, while a bad non-root invalidates the reply immediately.
 	added := 0
 	duplicates := 0
 	replyValid := true
 	for _, node := range ld.Nodes {
 		if isShamapRootNodeID(node.NodeID) {
-			err := txMap.AddRootNode([32]byte(txSetID), node.NodeData)
-			switch {
-			case err == nil, errors.Is(err, shamap.ErrRootAlreadySet):
-				rootAccepted = true
-				haveRoot = true
-			default:
-				badRootProvided = true
-				r.logger.Info("tx-set sync: AddRootNode failed",
-					"t", "consensus", "event", "txset-reject",
-					"txset", fmt.Sprintf("%x", txSetID[:8]),
-					"error", err.Error())
-			}
 			continue
 		}
-
 		parsedID, err := shamap.ParseNodeID(node.NodeID)
 		if err != nil {
 			replyValid = false
@@ -284,7 +475,15 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 				"error", err.Error())
 			break
 		}
+		nodeBytes := int64(len(node.NodeID)) + int64(len(node.NodeData))
+		if !r.reserveTxSetNodeBytes(txSetID, state, txMap, nodeBytes) {
+			resourceLimited = true
+			continue
+		}
 		res, err := txMap.AddKnownNodeByID(parsedID, node.NodeData)
+		if res != shamap.NodeUseful {
+			r.releaseTxSetNodeBytes(txSetID, state, txMap, nodeBytes)
+		}
 		if res == shamap.NodeReRequest {
 			continue
 		}
@@ -304,12 +503,6 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 		}
 		added++
 		r.learnTxFromLeaf(originPeer, node.NodeData)
-	}
-
-	if haveRoot && !state.haveRoot {
-		r.txSetAcquireMu.Lock()
-		state.haveRoot = true
-		r.txSetAcquireMu.Unlock()
 	}
 
 	if !replyValid {
@@ -369,10 +562,7 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 		// Request the missing nodes. Before going to peers, fill any
 		// missing TX-leaf nodes from our own pending pool. For
 		// tnTRANSACTION_NM the leaf-node hash equals the tx ID, so a
-		// single tx-ID lookup resolves the leaf. This is a round-trip
-		// optimization, not a correctness requirement: a peer DOES return
-		// a leaf requested directly by node ID, but local sourcing avoids
-		// the extra request for a tx we already relayed.
+		// single tx-ID lookup resolves the leaf.
 		missing := txMap.GetMissingNodes(256, nil)
 		if len(missing) == 0 {
 			// Root present but the map is inconsistent: terminal. Latch done
@@ -387,7 +577,9 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			return
 		}
 
-		filledFromPool := r.fillTxSetFromLocalPool(txMap, missing)
+		r.txSetAcquireMu.Lock()
+		filledFromPool := r.fillTxSetFromLocalPool(txSetID, state, missing)
+		r.txSetAcquireMu.Unlock()
 		var remaining []shamap.MissingNode
 		if filledFromPool > 0 {
 			if syncErr := txMap.FinishSync(); syncErr == nil {
@@ -420,9 +612,8 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			if !madeProgress && !validAllDuplicate {
 				// No fresh attach: do NOT re-request inline — that would let a
 				// junk/empty-reply peer amplify into a broadcast storm; let the
-				// 250ms stall timer drive it. Charge the peer's non-progress
-				// counter.
-				if originPeer != 0 {
+				// 250ms stall timer drive it.
+				if originPeer != 0 && !resourceLimited {
 					state.peerNonProgress[originPeer]++
 				}
 				r.txSetAcquireMu.Unlock()
@@ -467,8 +658,6 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 				"excluded_peers", len(excluded),
 				"indirect", indirect,
 			)
-			// Pipeline UNICAST to the replying peer (RTT rate-limits, no storm);
-			// the 250ms timer owns the broadcast fallback for silent peers.
 			if reqErr := r.requestTxSetMissingNodesUnicast(txSetID, nodeIDs, originPeer, excluded, indirect); reqErr != nil {
 				r.logger.Info("tx-set sync: missing-nodes request failed",
 					"t", "consensus", "event", "txset-reject",
@@ -477,13 +666,11 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 			}
 			return
 		}
-		// fall through: tree complete via local fill
 	}
 
-	// Walk leaves into blobs, feed the engine, then latch the acquire done and
-	// KEEP it: stragglers for the finished set are dropped (see the top of
-	// handleTxSetData) rather than recreating a fresh empty acquire. The TTL
-	// sweep reclaims it.
+	// Walk leaves into blobs, then replace the completed map with a lightweight
+	// terminal tombstone. Stragglers are dropped without retaining the SHAMap
+	// payload until the TTL sweep.
 	blobs := make([][]byte, 0, added+1)
 	if err := txMap.ForEach(func(item *shamap.Item) bool {
 		blobs = append(blobs, item.Data())
@@ -509,7 +696,7 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 
 func (r *Router) deleteTxSetAcquire(txSetID consensus.TxSetID) {
 	r.txSetAcquireMu.Lock()
-	delete(r.txSetAcquire, txSetID)
+	r.deleteTxSetAcquireLocked(txSetID)
 	r.txSetAcquireMu.Unlock()
 }
 
@@ -518,6 +705,7 @@ func (r *Router) markTxSetComplete(txSetID consensus.TxSetID) {
 	if state, ok := r.txSetAcquire[txSetID]; ok {
 		state.done = true
 		state.completed = true
+		r.releaseTxSetMapLocked(state)
 	}
 	r.txSetAcquireMu.Unlock()
 }
@@ -582,17 +770,24 @@ func (r *Router) submitTxSetToEngine(txSetID consensus.TxSetID, blobs [][]byte) 
 // filled. For tnTRANSACTION_NM the leaf-node hash equals the tx ID, so a
 // single GetTx lookup resolves the leaf — avoiding a peer round-trip for a
 // tx we already hold. Shared by the inbound (handleTxSetData) and timer
-// (retryStalledTxSetAcquires) paths. The caller owns txMap (both callers
-// run on the Run() goroutine) and decides how to recompute the remaining
-// set afterward.
-func (r *Router) fillTxSetFromLocalPool(txMap *shamap.SHAMap, missing []shamap.MissingNode) int {
+// (retryStalledTxSetAcquires) paths. Both callers run on the Run() goroutine
+// and hold txSetAcquireMu while this updates retained-byte accounting.
+func (r *Router) fillTxSetFromLocalPool(txSetID consensus.TxSetID, state *txSetAcquireState, missing []shamap.MissingNode) int {
 	filled := 0
 	for _, m := range missing {
 		blob, err := r.adaptor.GetTx(consensus.TxID(m.Hash))
 		if err != nil || len(blob) == 0 {
 			continue
 		}
-		if addErr := txMap.AddKnownNode(m.Hash, txLeafWire(blob)); addErr == nil {
+		wire := txLeafWire(blob)
+		nodeBytes := int64(shamap.NodeIDSize) + int64(len(wire))
+		current, ok := r.txSetAcquire[txSetID]
+		if !ok || current != state || current.txMap == nil ||
+			!r.makeTxSetByteRoomLocked(current, nodeBytes) {
+			continue
+		}
+		if addErr := current.txMap.AddKnownNode(m.Hash, wire); addErr == nil {
+			current.retainedBytes += nodeBytes
 			filled++
 		}
 	}
@@ -608,6 +803,9 @@ func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
 	now := time.Now()
 	state, ok := r.txSetAcquire[txSetID]
 	if !ok {
+		if !r.makeTxSetAcquireRoomLocked() {
+			return
+		}
 		r.txSetAcquire[txSetID] = &txSetAcquireState{
 			startedAt:       now,
 			lastUpdate:      now,
@@ -633,7 +831,7 @@ func (r *Router) sweepStaleTxSetAcquireLocked() {
 	cutoff := time.Now().Add(-txSetAcquireTTL)
 	for id, state := range r.txSetAcquire {
 		if state.lastUpdate.Before(cutoff) {
-			delete(r.txSetAcquire, id)
+			r.deleteTxSetAcquireLocked(id)
 		}
 	}
 }
@@ -750,7 +948,7 @@ func (r *Router) retryStalledTxSetAcquires() {
 		// last inbound reply it can complete the tree outright. GetTx is a
 		// local pool read and txMap is owned by this (Run) goroutine, so the
 		// fill is safe under txSetAcquireMu.
-		filled := r.fillTxSetFromLocalPool(state.txMap, missing)
+		filled := r.fillTxSetFromLocalPool(id, state, missing)
 		var finishErr error
 		if filled > 0 {
 			finishErr = state.txMap.FinishSync()
@@ -858,8 +1056,8 @@ func (r *Router) finalizeCompletedTxSet(txSetID consensus.TxSetID, txMap *shamap
 		r.deleteTxSetAcquire(txSetID)
 		return
 	}
-	// Latch done + KEEP the entry so stragglers are dropped rather than
-	// recreating a fresh empty acquire; the TTL sweep reclaims it.
+	// Keep a lightweight tombstone so stragglers are dropped; the retained
+	// SHAMap payload is released immediately.
 	r.markTxSetComplete(txSetID)
 	if len(blobs) == 0 {
 		return

--- a/internal/consensus/adaptor/router_txset.go
+++ b/internal/consensus/adaptor/router_txset.go
@@ -197,7 +197,29 @@ func (r *Router) makeTxSetAcquireRoomLocked() bool {
 			return true
 		}
 	}
-	return false
+
+	// Every entry is active. A newly requested consensus position must not be
+	// suppressed by older work, so replace the least-recently-updated acquire.
+	// The ID tie-break keeps admission deterministic when timestamps match.
+	var oldestID consensus.TxSetID
+	var oldestUpdate time.Time
+	found := false
+	for id, state := range r.txSetAcquire {
+		if state.done {
+			continue
+		}
+		if !found || state.lastUpdate.Before(oldestUpdate) ||
+			(state.lastUpdate.Equal(oldestUpdate) && txSetIDLess(id, oldestID)) {
+			oldestID = id
+			oldestUpdate = state.lastUpdate
+			found = true
+		}
+	}
+	if !found {
+		return false
+	}
+	r.deleteTxSetAcquireLocked(oldestID)
+	return true
 }
 
 // txSetRetryKnobs collects the tunable parameters of the tx-set acquire
@@ -332,6 +354,9 @@ func (r *Router) handleTxSetData(ld *message.LedgerData, originPeer uint64) {
 		r.logger.Info("tx-set sync: reply exceeds resource limit",
 			"t", "consensus", "event", "txset-resource-limit",
 			"node_count", len(ld.Nodes))
+		if originPeer != 0 {
+			r.adaptor.IncPeerBadData(originPeer, "txset-resource-limit")
+		}
 		return
 	}
 	var txSetID consensus.TxSetID
@@ -796,7 +821,10 @@ func (r *Router) fillTxSetFromLocalPool(txSetID consensus.TxSetID, state *txSetA
 
 // MarkTxSetStillNeeded revives recoverable acquisitions while leaving completed
 // acquisitions latched. Timeout history is clamped rather than reset.
-func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
+func (r *Router) admitTxSetStillNeeded(txSetID consensus.TxSetID) bool {
+	if txSetID == (consensus.TxSetID{}) {
+		return false
+	}
 	r.txSetAcquireMu.Lock()
 	defer r.txSetAcquireMu.Unlock()
 	r.sweepStaleTxSetAcquireLocked()
@@ -804,7 +832,7 @@ func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
 	state, ok := r.txSetAcquire[txSetID]
 	if !ok {
 		if !r.makeTxSetAcquireRoomLocked() {
-			return
+			return false
 		}
 		r.txSetAcquire[txSetID] = &txSetAcquireState{
 			startedAt:       now,
@@ -812,17 +840,22 @@ func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
 			lastRequest:     now,
 			peerNonProgress: make(map[uint64]int),
 		}
-		return
+		return true
 	}
 	state.lastUpdate = now
 	if state.done && state.completed {
-		return
+		return true
 	}
 	state.done = false
 	state.dormant = false
 	state.stallTicks = min(state.stallTicks, r.txSetRetryKnobs.NormalTimeouts)
 	state.attempts = 0
 	state.lastRequest = now
+	return true
+}
+
+func (r *Router) MarkTxSetStillNeeded(txSetID consensus.TxSetID) {
+	_ = r.admitTxSetStillNeeded(txSetID)
 }
 
 // sweepStaleTxSetAcquireLocked drops entries older than txSetAcquireTTL.

--- a/internal/consensus/adaptor/router_txset_limits_test.go
+++ b/internal/consensus/adaptor/router_txset_limits_test.go
@@ -64,11 +64,12 @@ func resourceAcquireState(t *testing.T, retained int64) *txSetAcquireState {
 
 func TestTxSetAcquire_ActiveCountBound(t *testing.T) {
 	router, _ := newRetryRouter(t)
+	oldestUpdate := time.Now().Add(-time.Second)
 
 	for i := 0; i < txSetAcquireMaxActive; i++ {
 		id := resourceTxSetID(byte(i + 1))
 		state := resourceAcquireState(t, int64(i+1))
-		state.lastUpdate = time.Unix(int64(i+1), 0)
+		state.lastUpdate = oldestUpdate.Add(time.Duration(i) * time.Millisecond)
 		router.txSetAcquire[id] = state
 	}
 

--- a/internal/consensus/adaptor/router_txset_limits_test.go
+++ b/internal/consensus/adaptor/router_txset_limits_test.go
@@ -1,0 +1,331 @@
+package adaptor
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/shamap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resourceTxSetID(value byte) consensus.TxSetID {
+	var id consensus.TxSetID
+	id[0] = value
+	return id
+}
+
+func resourceLedgerData(id consensus.TxSetID, nodes []message.LedgerNode) *message.LedgerData {
+	return &message.LedgerData{
+		LedgerHash: append([]byte(nil), id[:]...),
+		Nodes:      nodes,
+	}
+}
+
+func resourceAcquireState(t *testing.T, retained int64) *txSetAcquireState {
+	t.Helper()
+	txMap := shamap.New(shamap.TypeTransaction)
+	require.NoError(t, txMap.StartSync())
+	return &txSetAcquireState{
+		txMap:           txMap,
+		startedAt:       time.Now(),
+		lastUpdate:      time.Now(),
+		retainedBytes:   retained,
+		peerNonProgress: make(map[uint64]int),
+	}
+}
+
+func TestTxSetAcquire_ActiveCountBound(t *testing.T) {
+	router, _ := newRetryRouter(t)
+
+	for i := 0; i < txSetAcquireMaxActive; i++ {
+		id := resourceTxSetID(byte(i + 1))
+		router.MarkTxSetStillNeeded(id)
+		router.handleTxSetData(resourceLedgerData(id, nil), 1)
+	}
+
+	rejectedID := resourceTxSetID(0xff)
+	router.MarkTxSetStillNeeded(rejectedID)
+	router.handleTxSetData(resourceLedgerData(rejectedID, nil), 1)
+
+	router.txSetAcquireMu.Lock()
+	defer router.txSetAcquireMu.Unlock()
+	assert.Len(t, router.txSetAcquire, txSetAcquireMaxActive)
+	assert.NotContains(t, router.txSetAcquire, rejectedID)
+}
+
+func TestTxSetAcquire_ActiveCountReclaimsDormantState(t *testing.T) {
+	router, _ := newRetryRouter(t)
+	dormantID := resourceTxSetID(1)
+	dormant := resourceAcquireState(t, 1024)
+	dormant.done = true
+	dormant.dormant = true
+	dormant.lastUpdate = time.Now().Add(-time.Second)
+	router.txSetAcquire[dormantID] = dormant
+	for i := 1; i < txSetAcquireMaxActive; i++ {
+		id := resourceTxSetID(byte(i + 1))
+		router.txSetAcquire[id] = resourceAcquireState(t, 0)
+	}
+
+	newID := resourceTxSetID(0xff)
+	router.MarkTxSetStillNeeded(newID)
+	router.handleTxSetData(resourceLedgerData(newID, nil), 1)
+
+	router.txSetAcquireMu.Lock()
+	defer router.txSetAcquireMu.Unlock()
+	assert.Len(t, router.txSetAcquire, txSetAcquireMaxActive)
+	assert.NotContains(t, router.txSetAcquire, dormantID)
+	assert.Contains(t, router.txSetAcquire, newID)
+	assert.Nil(t, dormant.txMap)
+	assert.Zero(t, dormant.retainedBytes)
+}
+
+func TestTxSetAcquire_ReplyWorkBound(t *testing.T) {
+	oversizedChunk := make([]byte, txSetAcquireMaxReplyBytes/8+1)
+	oversizedNodes := make([]message.LedgerNode, 8)
+	for i := range oversizedNodes {
+		oversizedNodes[i].NodeData = oversizedChunk
+	}
+	tests := []struct {
+		name  string
+		nodes []message.LedgerNode
+	}{
+		{
+			name:  "node count",
+			nodes: make([]message.LedgerNode, txSetAcquireMaxReplyNodes+1),
+		},
+		{
+			name:  "bytes",
+			nodes: oversizedNodes,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router, _ := newRetryRouter(t)
+			id := resourceTxSetID(byte(i + 1))
+			router.handleTxSetData(resourceLedgerData(id, tt.nodes), 1)
+
+			router.txSetAcquireMu.Lock()
+			defer router.txSetAcquireMu.Unlock()
+			assert.NotContains(t, router.txSetAcquire, id)
+		})
+	}
+}
+
+func TestTxSetAcquire_RetainedByteBounds(t *testing.T) {
+	t.Run("per set", func(t *testing.T) {
+		router, _ := newRetryRouter(t)
+		id := resourceTxSetID(1)
+		state := resourceAcquireState(t, txSetAcquireMaxSetBytes-4)
+		router.txSetAcquire[id] = state
+
+		nodes := []message.LedgerNode{{NodeID: []byte{1}, NodeData: make([]byte, 4)}}
+		router.handleTxSetData(resourceLedgerData(id, nodes), 1)
+
+		router.txSetAcquireMu.Lock()
+		defer router.txSetAcquireMu.Unlock()
+		assert.Equal(t, txSetAcquireMaxSetBytes-4, state.retainedBytes)
+		assert.Same(t, state, router.txSetAcquire[id])
+	})
+
+	t.Run("global", func(t *testing.T) {
+		router, _ := newRetryRouter(t)
+		currentID := resourceTxSetID(1)
+		current := resourceAcquireState(t, 0)
+		router.txSetAcquire[currentID] = current
+		for i := 0; i < int(txSetAcquireMaxGlobalBytes/txSetAcquireMaxSetBytes); i++ {
+			id := resourceTxSetID(byte(i + 2))
+			router.txSetAcquire[id] = resourceAcquireState(t, txSetAcquireMaxSetBytes)
+		}
+
+		nodes := []message.LedgerNode{{NodeID: []byte{1}, NodeData: []byte{1}}}
+		router.handleTxSetData(resourceLedgerData(currentID, nodes), 1)
+
+		router.txSetAcquireMu.Lock()
+		defer router.txSetAcquireMu.Unlock()
+		assert.Zero(t, current.retainedBytes)
+		assert.Equal(t, txSetAcquireMaxGlobalBytes, router.txSetRetainedBytesLocked())
+	})
+
+	t.Run("global pressure reclaims oldest dormant map", func(t *testing.T) {
+		router, _ := newRetryRouter(t)
+		ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
+		var oldestID consensus.TxSetID
+		for i := 0; i < int(txSetAcquireMaxGlobalBytes/txSetAcquireMaxSetBytes); i++ {
+			id := resourceTxSetID(byte(0xa0 + i))
+			if id == txSetID {
+				id[1] = 1
+			}
+			if i == 0 {
+				oldestID = id
+			}
+			state := resourceAcquireState(t, txSetAcquireMaxSetBytes)
+			state.done = true
+			state.dormant = true
+			state.lastUpdate = time.Unix(int64(i+1), 0)
+			router.txSetAcquire[id] = state
+		}
+
+		router.MarkTxSetStillNeeded(txSetID)
+		router.handleTxSetData(ld, 1)
+
+		router.txSetAcquireMu.Lock()
+		defer router.txSetAcquireMu.Unlock()
+		assert.NotContains(t, router.txSetAcquire, oldestID)
+		state := router.txSetAcquire[txSetID]
+		require.NotNil(t, state)
+		assert.Positive(t, state.retainedBytes)
+		assert.LessOrEqual(t, router.txSetRetainedBytesLocked(), txSetAcquireMaxGlobalBytes)
+	})
+
+	t.Run("rejected first reply leaves no state", func(t *testing.T) {
+		for _, rootData := range [][]byte{nil, {1}} {
+			router, _ := newRetryRouter(t)
+			for i := 0; i < int(txSetAcquireMaxGlobalBytes/txSetAcquireMaxSetBytes); i++ {
+				id := resourceTxSetID(byte(i + 2))
+				router.txSetAcquire[id] = resourceAcquireState(t, txSetAcquireMaxSetBytes)
+			}
+
+			newID := resourceTxSetID(1)
+			nodes := []message.LedgerNode{{NodeID: make([]byte, shamap.NodeIDSize), NodeData: rootData}}
+			router.handleTxSetData(resourceLedgerData(newID, nodes), 1)
+
+			router.txSetAcquireMu.Lock()
+			assert.NotContains(t, router.txSetAcquire, newID)
+			assert.Len(t, router.txSetAcquire, int(txSetAcquireMaxGlobalBytes/txSetAcquireMaxSetBytes))
+			assert.Equal(t, txSetAcquireMaxGlobalBytes, router.txSetRetainedBytesLocked())
+			router.txSetAcquireMu.Unlock()
+		}
+	})
+}
+
+func TestTxSetAcquire_DuplicateNodesDoNotInflateRetainedBytes(t *testing.T) {
+	router, _ := newRetryRouter(t)
+	ld, txSetID := rootOnlyTxSetLedgerData(t, 8)
+	router.MarkTxSetStillNeeded(txSetID)
+
+	router.handleTxSetData(ld, 1)
+	router.txSetAcquireMu.Lock()
+	state := router.txSetAcquire[txSetID]
+	first := state.retainedBytes
+	router.txSetAcquireMu.Unlock()
+	require.Positive(t, first)
+
+	router.handleTxSetData(ld, 1)
+	router.txSetAcquireMu.Lock()
+	second := state.retainedBytes
+	router.txSetAcquireMu.Unlock()
+	assert.Equal(t, first, second)
+}
+
+func TestTxSetAcquire_DuplicateHeavyReplyCanUseRemainingSetBudget(t *testing.T) {
+	router, _ := newRetryRouter(t)
+	_, rawID, wireNodes := buildTxSetForTest(t, 8)
+	txSetID := consensus.TxSetID(rawID)
+	root := message.LedgerNode{NodeID: wireNodes[0].NodeID, NodeData: wireNodes[0].Data}
+	router.MarkTxSetStillNeeded(txSetID)
+	router.handleTxSetData(resourceLedgerData(txSetID, []message.LedgerNode{root}), 1)
+
+	findWireNode := func(nodeID []byte) message.LedgerNode {
+		for _, node := range wireNodes[1:] {
+			if bytes.Equal(node.NodeID, nodeID) {
+				return message.LedgerNode{NodeID: node.NodeID, NodeData: node.Data}
+			}
+		}
+		return message.LedgerNode{}
+	}
+
+	router.txSetAcquireMu.Lock()
+	state := router.txSetAcquire[txSetID]
+	require.NotNil(t, state)
+	missing := state.txMap.GetMissingNodes(256, nil)
+	require.NotEmpty(t, missing)
+	duplicate := findWireNode(missing[0].NodeID.Bytes())
+	router.txSetAcquireMu.Unlock()
+	require.NotEmpty(t, duplicate.NodeData)
+	router.handleTxSetData(resourceLedgerData(txSetID, []message.LedgerNode{duplicate}), 1)
+
+	router.txSetAcquireMu.Lock()
+	missing = state.txMap.GetMissingNodes(256, nil)
+	require.NotEmpty(t, missing)
+	targetID := missing[0].NodeID.Bytes()
+	target := findWireNode(targetID)
+	require.NotEmpty(t, target.NodeData)
+	targetBytes := int64(len(target.NodeID)) + int64(len(target.NodeData))
+	state.retainedBytes = txSetAcquireMaxSetBytes - targetBytes
+	router.txSetAcquireMu.Unlock()
+
+	nodes := make([]message.LedgerNode, 0, 9)
+	for range 8 {
+		nodes = append(nodes, duplicate)
+	}
+	nodes = append(nodes, target)
+	router.handleTxSetData(resourceLedgerData(txSetID, nodes), 1)
+
+	router.txSetAcquireMu.Lock()
+	defer router.txSetAcquireMu.Unlock()
+	require.Same(t, state, router.txSetAcquire[txSetID])
+	assert.Equal(t, txSetAcquireMaxSetBytes, state.retainedBytes)
+	for _, node := range state.txMap.GetMissingNodes(256, nil) {
+		assert.False(t, bytes.Equal(node.NodeID.Bytes(), targetID),
+			"the useful node must attach even when duplicates make total reply bytes exceed remaining set budget")
+	}
+}
+
+func TestTxSetAcquire_CleanupReleasesRetainedBytes(t *testing.T) {
+	t.Run("completion", func(t *testing.T) {
+		router, _ := newRetryRouter(t)
+		_, rawID, wireNodes := buildTxSetForTest(t, 4)
+		txSetID := consensus.TxSetID(rawID)
+		router.MarkTxSetStillNeeded(txSetID)
+
+		router.handleTxSetData(ldFromWire(rawID, wireNodes), 1)
+
+		router.txSetAcquireMu.Lock()
+		defer router.txSetAcquireMu.Unlock()
+		state := router.txSetAcquire[txSetID]
+		require.NotNil(t, state)
+		assert.True(t, state.done)
+		assert.Nil(t, state.txMap)
+		assert.Zero(t, state.retainedBytes)
+		assert.Zero(t, router.txSetRetainedBytesLocked())
+	})
+
+	t.Run("terminal failure", func(t *testing.T) {
+		router, _ := newRetryRouter(t)
+		id := resourceTxSetID(1)
+		state := resourceAcquireState(t, 1024)
+		router.txSetAcquire[id] = state
+
+		router.markTxSetDone(id)
+
+		router.txSetAcquireMu.Lock()
+		defer router.txSetAcquireMu.Unlock()
+		assert.True(t, state.done)
+		assert.Nil(t, state.txMap)
+		assert.Zero(t, router.txSetRetainedBytesLocked())
+	})
+
+	t.Run("ttl sweep", func(t *testing.T) {
+		router, _ := newRetryRouter(t)
+		id := resourceTxSetID(1)
+		state := resourceAcquireState(t, 1024)
+		state.lastUpdate = time.Now().Add(-txSetAcquireTTL - time.Second)
+		router.txSetAcquire[id] = state
+
+		router.txSetAcquireMu.Lock()
+		router.sweepStaleTxSetAcquireLocked()
+		_, exists := router.txSetAcquire[id]
+		total := router.txSetRetainedBytesLocked()
+		router.txSetAcquireMu.Unlock()
+
+		assert.False(t, exists)
+		assert.Zero(t, total)
+		assert.Nil(t, state.txMap)
+		assert.Zero(t, state.retainedBytes)
+	})
+}

--- a/internal/consensus/adaptor/router_txset_limits_test.go
+++ b/internal/consensus/adaptor/router_txset_limits_test.go
@@ -2,6 +2,7 @@ package adaptor
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 	"time"
 
@@ -11,6 +12,29 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type txSetResourceRecordingSender struct {
+	retryRecordingSender
+	mu      sync.Mutex
+	charges []txSetResourceCharge
+}
+
+type txSetResourceCharge struct {
+	peerID uint64
+	reason string
+}
+
+func (s *txSetResourceRecordingSender) IncPeerBadData(peerID uint64, reason string) {
+	s.mu.Lock()
+	s.charges = append(s.charges, txSetResourceCharge{peerID: peerID, reason: reason})
+	s.mu.Unlock()
+}
+
+func (s *txSetResourceRecordingSender) badDataCharges() []txSetResourceCharge {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]txSetResourceCharge(nil), s.charges...)
+}
 
 func resourceTxSetID(value byte) consensus.TxSetID {
 	var id consensus.TxSetID
@@ -43,18 +67,30 @@ func TestTxSetAcquire_ActiveCountBound(t *testing.T) {
 
 	for i := 0; i < txSetAcquireMaxActive; i++ {
 		id := resourceTxSetID(byte(i + 1))
-		router.MarkTxSetStillNeeded(id)
-		router.handleTxSetData(resourceLedgerData(id, nil), 1)
+		state := resourceAcquireState(t, int64(i+1))
+		state.lastUpdate = time.Unix(int64(i+1), 0)
+		router.txSetAcquire[id] = state
 	}
 
-	rejectedID := resourceTxSetID(0xff)
-	router.MarkTxSetStillNeeded(rejectedID)
-	router.handleTxSetData(resourceLedgerData(rejectedID, nil), 1)
+	oldestID := resourceTxSetID(1)
+	oldest := router.txSetAcquire[oldestID]
+	admittedID := resourceTxSetID(0xff)
+	assert.True(t, router.admitTxSetStillNeeded(admittedID))
 
 	router.txSetAcquireMu.Lock()
 	defer router.txSetAcquireMu.Unlock()
 	assert.Len(t, router.txSetAcquire, txSetAcquireMaxActive)
-	assert.NotContains(t, router.txSetAcquire, rejectedID)
+	assert.NotContains(t, router.txSetAcquire, oldestID)
+	assert.Contains(t, router.txSetAcquire, admittedID)
+	assert.Nil(t, oldest.txMap)
+	assert.Zero(t, oldest.retainedBytes)
+}
+
+func TestTxSetAcquire_AdmissionRejectsZeroID(t *testing.T) {
+	router, _ := newRetryRouter(t)
+
+	assert.False(t, router.admitTxSetStillNeeded(consensus.TxSetID{}))
+	assert.Empty(t, router.txSetAcquire)
 }
 
 func TestTxSetAcquire_ActiveCountReclaimsDormantState(t *testing.T) {
@@ -106,12 +142,18 @@ func TestTxSetAcquire_ReplyWorkBound(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router, _ := newRetryRouter(t)
+			sender := &txSetResourceRecordingSender{}
+			router.adaptor.sender = sender
 			id := resourceTxSetID(byte(i + 1))
-			router.handleTxSetData(resourceLedgerData(id, tt.nodes), 1)
+			router.handleTxSetData(resourceLedgerData(id, tt.nodes), 7)
 
 			router.txSetAcquireMu.Lock()
-			defer router.txSetAcquireMu.Unlock()
 			assert.NotContains(t, router.txSetAcquire, id)
+			router.txSetAcquireMu.Unlock()
+			assert.Equal(t,
+				[]txSetResourceCharge{{peerID: 7, reason: "txset-resource-limit"}},
+				sender.badDataCharges(),
+			)
 		})
 	}
 }

--- a/internal/consensus/adaptor/router_txset_limits_test.go
+++ b/internal/consensus/adaptor/router_txset_limits_test.go
@@ -337,19 +337,21 @@ func TestTxSetAcquire_CleanupReleasesRetainedBytes(t *testing.T) {
 		assert.Zero(t, router.txSetRetainedBytesLocked())
 	})
 
-	t.Run("terminal failure", func(t *testing.T) {
+	t.Run("recoverable failure", func(t *testing.T) {
 		router, _ := newRetryRouter(t)
 		id := resourceTxSetID(1)
 		state := resourceAcquireState(t, 1024)
 		router.txSetAcquire[id] = state
 
-		router.markTxSetDone(id)
+		router.markTxSetFailed(id)
 
 		router.txSetAcquireMu.Lock()
 		defer router.txSetAcquireMu.Unlock()
 		assert.True(t, state.done)
-		assert.Nil(t, state.txMap)
-		assert.Zero(t, router.txSetRetainedBytesLocked())
+		assert.True(t, state.dormant)
+		assert.False(t, state.completed)
+		assert.NotNil(t, state.txMap)
+		assert.Equal(t, int64(1024), router.txSetRetainedBytesLocked())
 	})
 
 	t.Run("ttl sweep", func(t *testing.T) {

--- a/internal/consensus/adaptor/router_validator_list_cov_test.go
+++ b/internal/consensus/adaptor/router_validator_list_cov_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
@@ -485,6 +486,8 @@ func TestRvl_SendList_SuppressionDedup(t *testing.T) {
 	ts := &rvl_trackingSender{}
 	r, _ := makeRouterWithBadDataRecorder(t)
 	b := r.NewValidatorListBroadcaster(nil, ts)
+	now := time.Unix(1_700_000_000, 0)
+	r.messageSeen.now = func() time.Time { return now }
 
 	manifest := []byte("manifest")
 	blob := []byte("blob")
@@ -496,6 +499,10 @@ func TestRvl_SendList_SuppressionDedup(t *testing.T) {
 
 	require.NoError(t, b.SendList(10, manifest, blob, sig, version))
 	assert.Len(t, ts.getCalls(), 1, "second send to already-seen peer must be suppressed")
+
+	now = now.Add(messageDedupTTL)
+	require.NoError(t, b.SendList(10, manifest, blob, sig, version))
+	assert.Len(t, ts.getCalls(), 2, "expired peer association must not suppress a send")
 }
 
 func TestRvl_SendList_DifferentPeers(t *testing.T) {
@@ -548,12 +555,18 @@ func TestRvl_SendCollection_SuppressionDedup(t *testing.T) {
 	ts := &rvl_trackingSender{}
 	r, _ := makeRouterWithBadDataRecorder(t)
 	b := r.NewValidatorListBroadcaster(nil, ts)
+	now := time.Unix(1_700_000_000, 0)
+	r.messageSeen.now = func() time.Time { return now }
 
 	blobs := []validatorlist.BroadcastBlob{{Blob: []byte("b"), Signature: []byte("s")}}
 	require.NoError(t, b.SendCollection(77, []byte("m"), blobs, 2))
 	require.NoError(t, b.SendCollection(77, []byte("m"), blobs, 2))
 
 	assert.Len(t, ts.getCalls(), 1, "second send to same peer must be suppressed")
+
+	now = now.Add(messageDedupTTL)
+	require.NoError(t, b.SendCollection(77, []byte("m"), blobs, 2))
+	assert.Len(t, ts.getCalls(), 2, "expired peer association must not suppress a send")
 }
 
 func TestRvl_SendCollection_SendError(t *testing.T) {

--- a/internal/consensus/adaptor/txset.go
+++ b/internal/consensus/adaptor/txset.go
@@ -172,6 +172,7 @@ func (c *TxSetCache) Remove(id consensus.TxSetID) {
 	delete(c.cache, id)
 	delete(c.added, id)
 }
+
 // sweepLocked evicts entries older than txSetCacheTTL. Runs opportunistically
 // on Put — frequent enough at round cadence to keep the map bounded without a
 // dedicated timer. Caller holds c.mu.

--- a/internal/consensus/adaptor/txset.go
+++ b/internal/consensus/adaptor/txset.go
@@ -1,7 +1,6 @@
 package adaptor
 
 import (
-	"bytes"
 	"fmt"
 	"sync"
 	"time"
@@ -12,85 +11,67 @@ import (
 	"github.com/LeJamon/go-xrpl/shamap"
 )
 
-// TxSetImpl implements consensus.TxSet backed by a SHAMap of transaction
-// blobs keyed by txID. The SHAMap is the canonical storage, and
-// Txs/TxIDs/Bytes derive from it.
+// TxSetImpl implements consensus.TxSet backed by an immutable SHAMap of
+// transaction blobs keyed by txID.
 //
 // Complexity profile (N = set size):
-//   - Add/Remove/Contains: O(log N) via SHAMap descent + incremental
-//     hash propagation up the dirty path.
-//   - ID():                O(1) — the SHAMap caches the root hash and
-//     refreshes it on every mutation.
+//   - Contains:            O(log N) via SHAMap descent.
+//   - ID/Size:             O(1).
 //   - Txs/TxIDs:           O(N) walk of the leaves in canonical key order.
 //     The two methods walk identically, so callers can zip them.
-//   - Bytes:               O(N) walk.
-//
-// SHAMap errors. For an unbacked, mutable SHAMap — which is how we use it
-// here — the only error source on Has/Hash is the private invalid state,
-// which TxSetImpl never enters. (Backed maps additionally propagate I/O
-// errors from descend(); mutators reject immutable and syncing maps.)
-// Contains treats any such error as "fail open"
-// (false); ID treats it as the zero hash, which collides with the
-// canonical hash of the empty SHAMap. Reaching that path is a
-// programmer-error condition.
-//
-// Aliasing. shamap() (package-internal) exposes the live backing map.
-// Add and Remove mutate it in place — there is no copy-on-write. The
-// production caller (router.go serveTxSet, now driven by concurrent serve-pool
-// workers) only reads the pointer, and it walks a cached set that is never
-// mutated in place while served — SHAMap reads are themselves lock-protected —
-// so the aliasing stays dormant. A snapshot on every round-trip would avoid it
-// but requires O(1) SHAMap COW, which the unbacked path here does not yet have
-// (Snapshot does a deep clone). The accessor stays unexported so the aliasing
-// concern cannot leak out of this package.
-//
-// Concurrency. The backing *shamap.SHAMap is internally lock-protected,
-// but TxSetImpl maintains a shadow `count` field for O(1) Size(); the
-// mutex below brackets every count read (Size, Txs, TxIDs) against
-// Add/Remove writers. The extra field exists because our consensus
-// engine logs and gates on tx counts from hot paths, so we pay for it
-// rather than walk the tree.
 type TxSetImpl struct {
 	txMap *shamap.SHAMap
-	mu    sync.Mutex
+	id    consensus.TxSetID
 	count int
 }
+
+var _ consensus.TxSet = (*TxSetImpl)(nil)
 
 // NewTxSet creates a TxSet from raw transaction blobs. The ID is the
 // canonical SHAMap root hash.
 //
-// Returns an error if shamap.New fails or any blob is rejected by the
-// backing SHAMap. Neither path is reachable today — shamap.New is
-// unconditional and the only blob gate is the <12-byte rejection, far
-// below any real transaction blob. We propagate both as errors rather
-// than panicking or silently dropping the blob: a truncated set
-// computes the wrong root hash and would break consensus, and keeping
-// a single error-return contract (no mixed panic/error) means callers
-// who already check err do not have to also wrap recover().
+// Construction fails instead of publishing a partial set when the backing
+// SHAMap rejects a blob.
 func NewTxSet(txBlobs [][]byte) (*TxSetImpl, error) {
 	txMap := shamap.New(shamap.TypeTransaction)
-	ts := &TxSetImpl{txMap: txMap}
+	count := 0
 	for i, blob := range txBlobs {
-		if err := ts.Add(blob); err != nil {
+		txID := computeTxID(blob)
+		key := [32]byte(txID)
+		exists, err := txMap.Has(key)
+		if err != nil {
 			return nil, fmt.Errorf("NewTxSet: blob %d (%d bytes): %w", i, len(blob), err)
 		}
+		if exists {
+			continue
+		}
+		if err := txMap.PutWithNodeType(key, blob, shamap.NodeTypeTransactionNoMeta); err != nil {
+			return nil, fmt.Errorf("NewTxSet: blob %d (%d bytes): %w", i, len(blob), err)
+		}
+		count++
 	}
-	return ts, nil
+	if err := txMap.SetImmutable(); err != nil {
+		return nil, fmt.Errorf("NewTxSet: freeze: %w", err)
+	}
+	hash, err := txMap.Hash()
+	if err != nil {
+		return nil, fmt.Errorf("NewTxSet: hash: %w", err)
+	}
+	return &TxSetImpl{
+		txMap: txMap,
+		id:    consensus.TxSetID(hash),
+		count: count,
+	}, nil
 }
 
 func (ts *TxSetImpl) ID() consensus.TxSetID {
-	h, err := ts.txMap.Hash()
-	if err != nil {
-		return consensus.TxSetID{}
-	}
-	return consensus.TxSetID(h)
+	return ts.id
 }
 
 // Txs returns every transaction blob in canonical key order. The
 // ordering matches TxIDs() so callers can zip the two slices. Each
 // blob is a defensive copy (shamap.Item.Data()) — callers may retain
-// or mutate the returned slices safely; see Bytes() for the zero-copy
-// counterpart used internally.
+// or mutate the returned slices safely.
 func (ts *TxSetImpl) Txs() [][]byte {
 	result := make([][]byte, 0, ts.Size())
 	_ = ts.txMap.ForEach(func(it *shamap.Item) bool {
@@ -116,87 +97,12 @@ func (ts *TxSetImpl) Contains(id consensus.TxID) bool {
 	return err == nil && ok
 }
 
-// Add inserts a transaction blob into the set, always with the
-// no-metadata node type; there is no untyped fallback.
-//
-// Has errors are propagated (unlike Contains, which fails open) — the
-// mutation path is where SHAMap state transitions surface, and a
-// surprised Has on a corrupted root is more useful as a diagnostic
-// than as a silent fall-through into PutWithNodeType.
-//
-// Invalidates any pointer previously returned by shamap(): the
-// underlying tree is mutated in place. See the TxSetImpl doc comment
-// for the aliasing contract.
-func (ts *TxSetImpl) Add(tx []byte) error {
-	txID := computeTxID(tx)
-	key := [32]byte(txID)
-	ok, err := ts.txMap.Has(key)
-	if err != nil {
-		return err
-	}
-	if ok {
-		return nil
-	}
-	if err := ts.txMap.PutWithNodeType(key, tx, shamap.NodeTypeTransactionNoMeta); err != nil {
-		return err
-	}
-	ts.mu.Lock()
-	ts.count++
-	ts.mu.Unlock()
-	return nil
-}
-
-// Remove deletes a transaction by ID. Propagates Has errors for the
-// same reason Add does. Invalidates any pointer previously returned
-// by shamap(); see the TxSetImpl doc comment.
-func (ts *TxSetImpl) Remove(id consensus.TxID) error {
-	key := [32]byte(id)
-	ok, err := ts.txMap.Has(key)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return nil
-	}
-	if err := ts.txMap.Delete(key); err != nil {
-		return err
-	}
-	ts.mu.Lock()
-	ts.count--
-	ts.mu.Unlock()
-	return nil
-}
-
 func (ts *TxSetImpl) Size() int {
-	ts.mu.Lock()
-	defer ts.mu.Unlock()
 	return ts.count
 }
 
-// Bytes returns the tx blobs concatenated with a 4-byte length prefix
-// each, walked in canonical SHAMap key order.
-//
-// Not currently wired to the wire or to disk. If it ever is,
-// consumers must accept the canonical-order framing (insertion order
-// is no longer observable).
-func (ts *TxSetImpl) Bytes() []byte {
-	var buf bytes.Buffer
-	_ = ts.txMap.ForEach(func(it *shamap.Item) bool {
-		blob := it.Data()
-		l := uint32(len(blob))
-		buf.Write([]byte{byte(l >> 24), byte(l >> 16), byte(l >> 8), byte(l)})
-		buf.Write(blob)
-		return true
-	})
-	return buf.Bytes()
-}
-
-// shamap returns the canonical tx-set SHAMap. Package-internal: the
-// pointer aliases the live backing store, so subsequent Add/Remove
-// calls on this TxSetImpl mutate the returned map in place. Callers
-// must treat it as read-only and finish any walk before mutating the
-// parent TxSetImpl. See the TxSetImpl doc comment for the broader
-// aliasing contract.
+// shamap returns the immutable canonical transaction tree used by the serving
+// path.
 func (ts *TxSetImpl) shamap() *shamap.SHAMap {
 	return ts.txMap
 }
@@ -266,7 +172,6 @@ func (c *TxSetCache) Remove(id consensus.TxSetID) {
 	delete(c.cache, id)
 	delete(c.added, id)
 }
-
 // sweepLocked evicts entries older than txSetCacheTTL. Runs opportunistically
 // on Put — frequent enough at round cadence to keep the map bounded without a
 // dedicated timer. Caller holds c.mu.

--- a/internal/consensus/adaptor/txset_cache_test.go
+++ b/internal/consensus/adaptor/txset_cache_test.go
@@ -38,7 +38,6 @@ func TestTxSetCache_TTLEviction(t *testing.T) {
 		t.Error("fresh entry should remain after the sweep")
 	}
 }
-
 // TestTxSetCache_Remove covers explicit removal.
 func TestTxSetCache_Remove(t *testing.T) {
 	c := NewTxSetCache()

--- a/internal/consensus/adaptor/txset_cache_test.go
+++ b/internal/consensus/adaptor/txset_cache_test.go
@@ -38,6 +38,7 @@ func TestTxSetCache_TTLEviction(t *testing.T) {
 		t.Error("fresh entry should remain after the sweep")
 	}
 }
+
 // TestTxSetCache_Remove covers explicit removal.
 func TestTxSetCache_Remove(t *testing.T) {
 	c := NewTxSetCache()

--- a/internal/consensus/adaptor/txset_test.go
+++ b/internal/consensus/adaptor/txset_test.go
@@ -3,9 +3,11 @@ package adaptor
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+	"sync"
 	"testing"
 
-	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/shamap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -89,29 +91,16 @@ func TestTxSet_IDStableAcrossInsertionOrder(t *testing.T) {
 		"tx-set ID must be insertion-order independent")
 }
 
-// TestTxSet_IDChangesOnMutation pins that ID() refreshes after
-// Add/Remove — the SHAMap's incremental dirty propagation must
-// have updated the root hash by the time ID() returns.
-func TestTxSet_IDChangesOnMutation(t *testing.T) {
-	blob1 := makeBlob(1)
-	blob2 := makeBlob(2)
-
-	ts, err := NewTxSet([][]byte{blob1})
+func TestTxSet_DuplicateInputIsDeduplicated(t *testing.T) {
+	blob := makeBlob(1)
+	single, err := NewTxSet([][]byte{blob})
 	require.NoError(t, err)
-	id0 := ts.ID()
-	require.NotEqual(t, consensus.TxSetID{}, id0)
+	duplicates, err := NewTxSet([][]byte{blob, blob, blob})
+	require.NoError(t, err)
 
-	require.NoError(t, ts.Add(blob2))
-	id1 := ts.ID()
-	assert.NotEqual(t, id0, id1, "Add must change the tx-set ID")
-
-	// Adding the same blob a second time is a no-op.
-	require.NoError(t, ts.Add(blob2))
-	assert.Equal(t, id1, ts.ID(), "duplicate Add must not change ID")
-
-	require.NoError(t, ts.Remove(computeTxID(blob2)))
-	assert.Equal(t, id0, ts.ID(),
-		"Remove of a just-added tx must restore the prior ID")
+	assert.Equal(t, single.ID(), duplicates.ID())
+	assert.Equal(t, 1, duplicates.Size())
+	assert.Equal(t, single.Txs(), duplicates.Txs())
 }
 
 // TestTxSet_RejectsInvalidBlobs pins that NewTxSet surfaces SHAMap
@@ -128,119 +117,48 @@ func TestTxSet_RejectsInvalidBlobs(t *testing.T) {
 	assert.Nil(t, ts, "failed construction must not return a partial tx-set")
 }
 
-// TestTxSet_ConcurrentSizeReader pins that Size() is safe to call
-// while a single writer goroutine drives Add/Remove. The shadow
-// `count` field is shielded by an internal mutex; without it the
-// race detector would flag the increment vs. read. Run with
-// `go test -race`.
-func TestTxSet_ConcurrentSizeReader(t *testing.T) {
-	const ops = 200
-	blobs := make([][]byte, ops)
+func TestTxSet_ConcurrentReaders(t *testing.T) {
+	const count = 200
+	blobs := make([][]byte, count)
 	for i := range blobs {
 		blobs[i] = makeBlob(uint32(i + 1))
 	}
 
-	ts, err := NewTxSet(nil)
+	ts, err := NewTxSet(blobs)
 	require.NoError(t, err)
 
-	stop := make(chan struct{})
-	done := make(chan struct{})
-
-	go func() {
-		defer close(done)
-		for {
-			select {
-			case <-stop:
-				return
-			default:
-				_ = ts.Size()
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				assert.Equal(t, count, ts.Size())
+				assert.NotZero(t, ts.ID())
+				assert.True(t, ts.Contains(computeTxID(blobs[0])))
+				assert.Len(t, ts.Txs(), count)
+				assert.Len(t, ts.TxIDs(), count)
 			}
-		}
-	}()
-
-	for _, blob := range blobs {
-		require.NoError(t, ts.Add(blob))
+		}()
 	}
-	for i := range ops / 2 {
-		require.NoError(t, ts.Remove(computeTxID(blobs[i])))
-	}
-	close(stop)
-	<-done
-
-	assert.Equal(t, ops-ops/2, ts.Size())
+	wg.Wait()
 }
 
-// TestTxSet_BytesIsCanonical pins that the Bytes() framing walks
-// leaves in canonical order so the serialized form is independent
-// of insertion order.
-func TestTxSet_BytesIsCanonical(t *testing.T) {
-	blobs := make([][]byte, 6)
-	for i := range blobs {
-		blobs[i] = makeBlob(uint32(i + 1))
-	}
-
-	forwardTs, err := NewTxSet(blobs)
+func TestTxSet_BackingMapIsImmutable(t *testing.T) {
+	blob := makeBlob(1)
+	ts, err := NewTxSet([][]byte{blob})
 	require.NoError(t, err)
-	forward := forwardTs.Bytes()
-	reversed := make([][]byte, len(blobs))
-	for i, b := range blobs {
-		reversed[len(blobs)-1-i] = b
-	}
-	backwardTs, err := NewTxSet(reversed)
-	require.NoError(t, err)
-	backward := backwardTs.Bytes()
-	assert.Equal(t, forward, backward,
-		"Bytes() output must be insertion-order independent")
-}
+	originalID := ts.ID()
 
-// BenchmarkTxSetAdd_Incremental measures the per-Add cost on
-// successively larger sets. Each Add does O(log N) work, so
-// growth from N=128 → N=8192 should be ~6x (log2 of 64), not 64x.
-func BenchmarkTxSetAdd_Incremental(b *testing.B) {
-	for _, n := range []int{128, 512, 2048, 8192} {
-		b.Run(sizeLabel(n), func(b *testing.B) {
-			// Pre-seed the set so each timed Add lands at depth ~log2(n).
-			seed := make([][]byte, n)
-			for i := range seed {
-				seed[i] = makeBlob(uint32(i + 1))
-			}
-
-			// Pre-build the candidate blobs the timed loop will Add.
-			adds := make([][]byte, b.N)
-			for i := 0; i < b.N; i++ {
-				adds[i] = makeBlob(uint32(n + i + 1))
-			}
-
-			b.ReportAllocs()
-			b.ResetTimer()
-			b.StopTimer()
-			for i := 0; i < b.N; i++ {
-				// Re-seed a fresh tx-set every iteration so the timed
-				// Add always lands on a set of size ~n. Otherwise the
-				// loop just grows N unbounded and the per-Add cost
-				// shifts as N doubles.
-				ts, err := NewTxSet(seed)
-				if err != nil {
-					b.Fatal(err)
-				}
-				b.StartTimer()
-				_ = ts.Add(adds[i])
-				b.StopTimer()
-			}
-		})
-	}
-}
-
-func sizeLabel(n int) string {
-	switch n {
-	case 128:
-		return "N=128"
-	case 512:
-		return "N=512"
-	case 2048:
-		return "N=2048"
-	case 8192:
-		return "N=8192"
-	}
-	return "N=?"
+	newBlob := makeBlob(2)
+	err = ts.shamap().PutWithNodeType(
+		[32]byte(computeTxID(newBlob)),
+		newBlob,
+		shamap.NodeTypeTransactionNoMeta,
+	)
+	require.True(t, errors.Is(err, shamap.ErrImmutable))
+	require.True(t, errors.Is(ts.shamap().Delete([32]byte(computeTxID(blob))), shamap.ErrImmutable))
+	assert.Equal(t, originalID, ts.ID())
+	assert.Equal(t, 1, ts.Size())
+	assert.Equal(t, [][]byte{blob}, ts.Txs())
 }

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -514,13 +514,7 @@ type TxSet interface {
 
 	Contains(id TxID) bool
 
-	Add(tx []byte) error
-
-	Remove(id TxID) error
-
 	Size() int
-
-	Bytes() []byte
 }
 
 // OperatingMode represents the node's overall operating state.

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -79,14 +79,6 @@ func (ts *mockTxSet) Contains(id consensus.TxID) bool {
 	}
 	return false
 }
-func (ts *mockTxSet) Add(tx []byte) error { ts.txs = append(ts.txs, tx); return nil }
-func (ts *mockTxSet) Remove(id consensus.TxID) error {
-	if ts.containsTxs != nil {
-		delete(ts.containsTxs, id)
-	}
-	return nil
-}
-func (ts *mockTxSet) Bytes() []byte { return nil }
 
 // mockAdaptor implements consensus.Adaptor for testing
 type mockAdaptor struct {


### PR DESCRIPTION
Part of #1453.

## Summary

- cap active transaction-set acquisitions, per-reply work, per-set retained bytes, and global retained bytes with exact rollback and release accounting
- reclaim the oldest dormant partial set deterministically when byte pressure would otherwise starve live acquisition progress
- centralize suppression TTL, peer associations, and deterministic LRU capacity across inbound and outbound paths
- publish immutable transaction sets and remove production-dead mutation, serialization, and cache-removal surface

## Verification

- `go test -race -count=1 ./internal/consensus/adaptor ./internal/consensus/rcl ./internal/consensus/csf ./internal/peermanagement/...`
- `just test-core`
- `just test`
- `just build-all`
- `just build-nocgo`
- linux/386 full-module build
- `just vet`
- strict and advisory `golangci-lint` — zero issues
- `git diff --check`

`go mod tidy -diff` reports only the existing missing `hashicorp/golang-lru/v2` sums; this PR does not modify module files.

## Integration notes

This is an independent PR from `main`. PR #1488 overlaps `router_txset.go`, `txset.go`, and `txset_cache_test.go`; manual resolution must keep its demand-first acquisition intent, apply the 64-entry cap when that intent is inserted, reject unneeded data before reply work or allocation, and construct its permanent zero transaction set through immutable `NewTxSet(nil)`. PR #1514 applies cleanly; retain its lifecycle-owned signature-prewarm task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Transaction sets are now immutable after creation, with duplicate transactions removed automatically.
  - Added resource limits for transaction-set acquisition to control memory use and prevent oversized or excessive requests.
  - Improved cleanup of incomplete, expired, and failed transaction-set acquisitions.

- **Bug Fixes**
  - Rejected proposals no longer interfere with later duplicate detection.
  - Duplicate messages and proposals are suppressed more reliably while allowing retransmission after expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->