### PR TITLE
refactor: narrow negative UNL voting API

### DIFF
--- a/internal/consensus/adaptor/negative_unl_vote.go
+++ b/internal/consensus/adaptor/negative_unl_vote.go
@@ -24,16 +24,13 @@ import (
 //   - prevLedger is not a *LedgerWrapper (test ledger types)
 //   - the skip-list contains fewer than FlagLedgerInterval ancestors
 //     (early ledgers near genesis)
-//   - local participation is below MinLocalValsToVote (230/256) —
+//   - local participation is below the strict voting threshold —
 //     local view too narrow to trust
 //   - no candidates qualify
 //
-// These normal zero-vote paths are silent — an operator on a
-// NegativeUNL-enabled network sees no errors or warnings when the round
-// simply has nothing to do. The sole exception is the impossible
-// above-window case (local count > FlagLedgerInterval), which DoVoting
-// surfaces as ErrLocalCountExceedsWindow and is logged at Error here as
-// a likely duplicate-validation bug.
+// These normal zero-vote paths are silent. Exact-threshold and above-window
+// counts are surfaced and logged because rippled treats both as error
+// diagnostics while producing no vote.
 func (a *Adaptor) GenerateNegativeUNLPseudoTx(prev consensus.Ledger) [][]byte {
 	a.trustUpdateMu.Lock()
 	a.mu.Lock()
@@ -80,20 +77,30 @@ func (a *Adaptor) GenerateNegativeUNLPseudoTx(prev consensus.Ledger) [][]byte {
 	// gate; don't duplicate either here.
 	blobs, err := voter.DoVoting(prevSeq, prevHash, unlKeys, state, scoreTable)
 	if err != nil {
-		if errors.Is(err, negativeunlvote.ErrLocalCountExceedsWindow) {
-			a.logger.Error("NegativeUNL: local validation count exceeds window — likely duplicate-validation bug",
-				"prev_seq", prevSeq,
-				"err", err,
-			)
-			return nil
-		}
+		a.logNegativeUNLVoteError(prevSeq, err)
+		return nil
+	}
+	return blobs
+}
+
+func (a *Adaptor) logNegativeUNLVoteError(prevSeq uint32, err error) {
+	switch {
+	case errors.Is(err, negativeunlvote.ErrLocalCountAtThreshold):
+		a.logger.Error("NegativeUNL: local validation count equals strict voting threshold; abstaining",
+			"prev_seq", prevSeq,
+			"err", err,
+		)
+	case errors.Is(err, negativeunlvote.ErrLocalCountExceedsWindow):
+		a.logger.Error("NegativeUNL: local validation count exceeds window — likely duplicate-validation bug",
+			"prev_seq", prevSeq,
+			"err", err,
+		)
+	default:
 		a.logger.Warn("NegativeUNL: DoVoting failed",
 			"prev_seq", prevSeq,
 			"err", err,
 		)
-		return nil
 	}
-	return blobs
 }
 
 // OnUNLChange registers validators newly added to the operator-trusted
@@ -172,10 +179,8 @@ func (a *Adaptor) negativeUNLState(l interface {
 //
 // Returns (nil, false) only when the parent's skip-list is shorter
 // than FlagLedgerInterval (early ledgers near genesis). The
-// local-participation gate ([MinLocalValsToVote, FlagLedgerInterval])
-// is NOT enforced here — it lives solely in DoVoting, which abstains on
-// low participation and surfaces ErrLocalCountExceedsWindow on the
-// impossible above-window case so the caller can log at error severity.
+// The local-participation gate is enforced by DoVoting. It abstains on low
+// participation and surfaces exact-threshold and above-window diagnostics.
 // DoVoting also restricts this table to the UNL, so an over-populated
 // table (NodeIDs that have since left the UNL) is harmless.
 func (a *Adaptor) buildNegativeUNLScoreTable(

--- a/internal/consensus/adaptor/negative_unl_vote.go
+++ b/internal/consensus/adaptor/negative_unl_vote.go
@@ -178,7 +178,7 @@ func (a *Adaptor) negativeUNLState(l interface {
 //     it and increment a per-NodeID counter.
 //
 // Returns (nil, false) only when the parent's skip-list is shorter
-// than FlagLedgerInterval (early ledgers near genesis). The
+// than FlagLedgerInterval (early ledgers near genesis).
 // The local-participation gate is enforced by DoVoting. It abstains on low
 // participation and surfaces exact-threshold and above-window diagnostics.
 // DoVoting also restricts this table to the UNL, so an over-populated

--- a/internal/consensus/adaptor/negative_unl_vote_test.go
+++ b/internal/consensus/adaptor/negative_unl_vote_test.go
@@ -1,6 +1,9 @@
 package adaptor
 
 import (
+	"bytes"
+	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -112,6 +115,18 @@ func TestAdaptor_NegativeUNL_NonWrappedLedgerReturnsNil(t *testing.T) {
 	assert.Nil(t, blobs)
 }
 
+func TestAdaptor_NegativeUNL_ExactThresholdLogsError(t *testing.T) {
+	a := newTestAdaptor(t)
+	var output bytes.Buffer
+	a.logger = slog.New(slog.NewTextHandler(&output, nil))
+
+	a.logNegativeUNLVoteError(1024, fmt.Errorf("wrapped: %w", negativeunlvote.ErrLocalCountAtThreshold))
+
+	assert.Contains(t, output.String(), "level=ERROR")
+	assert.Contains(t, output.String(), "equals strict voting threshold")
+	assert.Contains(t, output.String(), "prev_seq=1024")
+}
+
 func TestNegativeUNLState_ParsesEmptySLE(t *testing.T) {
 	a := newTestAdaptor(t)
 	state, err := a.negativeUNLState(&stubLedgerReader{negativeUNLBytes: nil})
@@ -161,13 +176,6 @@ func TestBuildScoreTable_RejectsShortSkipList(t *testing.T) {
 	assert.Nil(t, scoreTable)
 }
 
-// TestBuildScoreTable_DoesNotGateOnLocalParticipation pins C2: the
-// local-participation gate ([MinLocalValsToVote, FlagLedgerInterval])
-// now lives solely in DoVoting, not in buildNegativeUNLScoreTable. The
-// builder must return the full tally regardless of the local node's
-// count — even when it is below MinLocalValsToVote — so DoVoting is the
-// single gate authority (and ErrLocalCountExceedsWindow can surface for
-// the impossible above-window case instead of being swallowed here).
 func TestBuildScoreTable_DoesNotGateOnLocalParticipation(t *testing.T) {
 	a := newTestAdaptor(t)
 
@@ -179,12 +187,11 @@ func TestBuildScoreTable_DoesNotGateOnLocalParticipation(t *testing.T) {
 	myID := consensus.NodeID{0x99}
 	otherID := consensus.NodeID{0xAA}
 
-	// Local node validates fewer than MinLocalValsToVote slots. Under the
-	// old duplicated gate this aborted the build; now it must not.
+	const localCount = protocol.FlagLedgerInterval / 2
 	byLedger := make(map[consensus.LedgerID][]*consensus.Validation, len(ancestors))
 	for i, h := range ancestors {
 		vals := []*consensus.Validation{{NodeID: otherID, LedgerID: consensus.LedgerID(h)}}
-		if uint32(i) < negativeunlvote.MinLocalValsToVote-1 {
+		if uint32(i) < localCount {
 			vals = append(vals, &consensus.Validation{NodeID: myID, LedgerID: consensus.LedgerID(h)})
 		}
 		byLedger[consensus.LedgerID(h)] = vals
@@ -196,8 +203,7 @@ func TestBuildScoreTable_DoesNotGateOnLocalParticipation(t *testing.T) {
 	)
 	require.True(t, ok, "a full skip-list must build a table regardless of local participation")
 	require.NotNil(t, scoreTable)
-	assert.Less(t, scoreTable[myID], negativeunlvote.MinLocalValsToVote,
-		"local count is intentionally below the threshold; gating is DoVoting's job now")
+	assert.Equal(t, localCount, scoreTable[myID])
 }
 
 func TestBuildScoreTable_TalliesAcrossAncestors(t *testing.T) {
@@ -275,34 +281,12 @@ func TestAdaptor_OnUNLChange_NoVoterIsNoOp(t *testing.T) {
 	a.OnUNLChange(0, nil)
 }
 
-// TestAdaptor_OnUNLChange_GracePeriodAndExpiry ports the two cases of
-// rippled's NegativeUNLVoteNewValidator_test::testDoVoting
-// (rippled/src/test/consensus/NegativeUNL_test.cpp:1735):
-//
-//  1. After OnUNLChange registers a new validator with `nowTrusted`,
-//     a bad score within NewValidatorDisableSkip ledgers must NOT
-//     produce a ToDisable pseudo-tx (grace period honored).
-//  2. After NewValidatorDisableSkip+1 ledgers have passed, the voting
-//     path's purge (Voter.PurgeNewValidators, called from
-//     GenerateNegativeUNLPseudoTx — mirrors rippled doVoting at
-//     NegativeUNLVote.cpp:339-355) drops both fresh entries; the same
-//     bad score now becomes a ToDisable candidate.
-//
-// Exercises the wiring: Adaptor.OnUNLChange records via
-// Voter.NewValidators; the existing voting-path purge owns expiry.
-// OnUNLChange intentionally does NOT purge, matching rippled's
-// preStartRound (RCLConsensus.cpp:1041-1043) which only registers.
 func TestAdaptor_OnUNLChange_GracePeriodAndExpiry(t *testing.T) {
 	a := newTestAdaptorWithMasters(t)
 	require.NotNil(t, a.negUNLVoter, "fixture must construct a voter")
 	voter := a.negUNLVoter
 	myKey := a.identity.MasterKey
 
-	// Build a UNL with the local node + two stable peers + two
-	// freshly-added validators. The UNL passed to DoVoting is
-	// independent of the adaptor's configured trustedMasterKeys; we
-	// supply our own multi-member list so MaxListedFraction permits
-	// at least one ToDisable candidate.
 	stable1 := makeRawMasterKey(0xAA)
 	stable2 := makeRawMasterKey(0xBB)
 	fresh1 := makeRawMasterKey(0xCC)
@@ -312,22 +296,16 @@ func TestAdaptor_OnUNLChange_GracePeriodAndExpiry(t *testing.T) {
 	fresh1NodeID := consensus.CalcNodeID(fresh1)
 	fresh2NodeID := consensus.CalcNodeID(fresh2)
 
-	// Score table: local node + stable peers participate at the
-	// HighWaterMark; fresh validators score 0 (the bad-score
-	// condition rippled's test exercises).
 	scoreTable := map[consensus.NodeID]uint32{
-		voter.MyID():                  negativeunlvote.MinLocalValsToVote + 1,
-		consensus.CalcNodeID(stable1): negativeunlvote.HighWaterMark + 1,
-		consensus.CalcNodeID(stable2): negativeunlvote.HighWaterMark + 1,
+		a.identity.NodeID:             protocol.FlagLedgerInterval,
+		consensus.CalcNodeID(stable1): protocol.FlagLedgerInterval,
+		consensus.CalcNodeID(stable2): protocol.FlagLedgerInterval,
 		fresh1NodeID:                  0,
 		fresh2NodeID:                  0,
 	}
 
 	const addedAtSeq uint32 = 256
 
-	// Case 1: register the fresh validators, then run a voting round
-	// within the NewValidatorDisableSkip window. Expect no ToDisable
-	// pseudo-tx.
 	a.OnUNLChange(addedAtSeq, []consensus.NodeID{fresh1NodeID, fresh2NodeID})
 
 	prevHash := [32]byte{0x42}
@@ -335,38 +313,29 @@ func TestAdaptor_OnUNLChange_GracePeriodAndExpiry(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, blobs, "fresh validators within the grace window must not be ToDisable candidates")
 
-	// Case 2: advance well past NewValidatorDisableSkip. The voting
-	// path's purge — the same call GenerateNegativeUNLPseudoTx makes
-	// before invoking DoVoting (negative_unl_vote.go:74) — drops both
-	// fresh entries; a follow-up vote at the same seq now sees them
-	// as bad-score candidates. OnUNLChange must NOT be called here:
-	// no UNL change occurred (rippled's preStartRound would see an
-	// empty `nowTrusted` and skip newValidators entirely).
-	purgeSeq := addedAtSeq + negativeunlvote.NewValidatorDisableSkip + 2
-	voter.PurgeNewValidators(purgeSeq)
-
-	blobs, err = voter.DoVoting(purgeSeq, prevHash, unl, negativeunlvote.State{}, scoreTable)
+	expiredPrevSeq := addedAtSeq + 2*protocol.FlagLedgerInterval
+	blobs, err = voter.DoVoting(expiredPrevSeq, prevHash, unl, negativeunlvote.State{}, scoreTable)
 	require.NoError(t, err)
 	require.Len(t, blobs, 1, "after grace expiry, a bad-score new validator is eligible for a single ToDisable pseudo-tx")
 }
 
-// TestAdaptor_OnUNLChange_EmptyTrustedSetIsNoOp covers the
-// nowTrusted-empty short-circuit that mirrors rippled's
-// `!nowTrusted.empty()` gate at RCLConsensus.cpp:1042. The Voter's
-// newValidators map must remain untouched so future bad-score evals
-// still see no registered grace-period entries.
 func TestAdaptor_OnUNLChange_EmptyTrustedSetIsNoOp(t *testing.T) {
 	a := newTestAdaptorWithMasters(t)
 	require.NotNil(t, a.negUNLVoter)
 	a.OnUNLChange(512, nil)
 	a.OnUNLChange(512, []consensus.NodeID{})
-	// Purge a freshly-registered key to prove the map is empty: if
-	// OnUNLChange had inadvertently inserted something, the purge
-	// (using a seq within the grace window) would leave it in place.
-	a.negUNLVoter.NewValidators(512, []consensus.NodeID{{0xEE}})
-	a.negUNLVoter.PurgeNewValidators(512) // within window — keeps {0xEE}
-	// If OnUNLChange had ever modified the map, this single-entry
-	// expectation would fail.
+
+	weak := makeRawMasterKey(0xEE)
+	unl := [][33]byte{a.identity.MasterKey, makeRawMasterKey(0xAA), makeRawMasterKey(0xBB), weak}
+	scores := map[consensus.NodeID]uint32{
+		a.identity.NodeID:            protocol.FlagLedgerInterval,
+		consensus.CalcNodeID(unl[1]): protocol.FlagLedgerInterval,
+		consensus.CalcNodeID(unl[2]): protocol.FlagLedgerInterval,
+		consensus.CalcNodeID(weak):   0,
+	}
+	blobs, err := a.negUNLVoter.DoVoting(512, [32]byte{0x42}, unl, negativeunlvote.State{}, scores)
+	require.NoError(t, err)
+	require.Len(t, blobs, 1)
 }
 
 // makeRawMasterKey builds a deterministic 33-byte master pubkey

--- a/internal/consensus/negativeunlvote/vote.go
+++ b/internal/consensus/negativeunlvote/vote.go
@@ -1,15 +1,12 @@
-// Package negativeunlvote decides whether to inject a UNLModify pseudo-tx
-// into the consensus tx set at a flag-ledger boundary, scoring each
-// validator's participation over the last FlagLedgerInterval ledgers and
-// picking candidates deterministically. Mirrors rippled NegativeUNLVote.
+// Package negativeunlvote produces UNLModify pseudo-transactions for flag ledgers.
 package negativeunlvote
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"maps"
-	"math"
 	"sync"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
@@ -19,34 +16,26 @@ import (
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
-// ErrLocalCountExceedsWindow signals the local node's validation count
-// exceeded FlagLedgerInterval — an impossible state pointing to an upstream
-// bug. Callers treat it as a no-vote (nil blobs) and surface it for visibility.
-var ErrLocalCountExceedsWindow = errors.New("negativeunlvote: local validation count exceeds flag-ledger window")
-
-const (
-	// below this score a validator is unreliable → ToDisable candidate
-	LowWaterMark uint32 = protocol.FlagLedgerInterval * 50 / 100
-
-	// above this score a disabled validator → ToReEnable candidate
-	HighWaterMark uint32 = protocol.FlagLedgerInterval * 80 / 100
-
-	// minimum local validations to trust our own view; below it, abstain
-	MinLocalValsToVote uint32 = protocol.FlagLedgerInterval * 90 / 100
-
-	// ledgers a freshly-added validator is exempt from ToDisable voting
-	NewValidatorDisableSkip uint32 = protocol.FlagLedgerInterval * 2
-
-	// max fraction of the UNL that may be on the NegativeUNL at once
-	MaxListedFraction float64 = 0.25
+var (
+	// ErrLocalCountAtThreshold signals the strict voting threshold was met but
+	// not exceeded. The caller abstains and surfaces the diagnostic.
+	ErrLocalCountAtThreshold = errors.New("negativeunlvote: local validation count equals voting threshold")
+	// ErrLocalCountExceedsWindow signals an impossible validation count.
+	ErrLocalCountExceedsWindow = errors.New("negativeunlvote: local validation count exceeds flag-ledger window")
 )
 
-// Modify identifies the direction of a UNLModify pseudo-tx.
-type Modify uint8
+const (
+	lowWaterMark            uint32 = protocol.FlagLedgerInterval * 50 / 100
+	highWaterMark           uint32 = protocol.FlagLedgerInterval * 80 / 100
+	minLocalValsToVote      uint32 = protocol.FlagLedgerInterval * 90 / 100
+	newValidatorDisableSkip uint32 = protocol.FlagLedgerInterval * 2
+)
+
+type modify uint8
 
 const (
-	ToDisable  Modify = 1 // UNLModify with sfUNLModifyDisabling=1
-	ToReEnable Modify = 0 // UNLModify with sfUNLModifyDisabling=0
+	toReEnable modify = iota
+	toDisable
 )
 
 // State captures the parent ledger's NegativeUNL entry: the disabled set
@@ -80,19 +69,15 @@ func (s State) effectiveNegUNL() map[[33]byte]struct{} {
 	return out
 }
 
-// Voter is the producer state: the local node ID and the new-validator
-// skip table, which must persist across rounds (newly-trusted validators
-// are exempt from ToDisable for NewValidatorDisableSkip ledgers). The mutex
-// guards that table; methods are safe for concurrent use.
+// Voter retains the local identity and new-validator grace periods across rounds.
 type Voter struct {
 	myID consensus.NodeID
 
 	mu            sync.Mutex
-	newValidators map[consensus.NodeID]uint32 // ledger seq when added
+	newValidators map[consensus.NodeID]uint32
 }
 
-// NewVoter constructs a Voter; myID is the 20-byte NodeID that also keys
-// the score table.
+// NewVoter constructs a Voter for the local node.
 func NewVoter(myID consensus.NodeID) *Voter {
 	return &Voter{
 		myID:          myID,
@@ -100,14 +85,7 @@ func NewVoter(myID consensus.NodeID) *Voter {
 	}
 }
 
-// MyID returns the local NodeID, exposed so callers can look up their own
-// score before invoking DoVoting.
-func (v *Voter) MyID() consensus.NodeID {
-	return v.myID
-}
-
-// NewValidators registers newly-trusted validators at seq, exempting them
-// from ToDisable for the next NewValidatorDisableSkip ledgers.
+// NewValidators registers newly trusted validators for the disable grace period.
 func (v *Voter) NewValidators(seq uint32, nowTrusted []consensus.NodeID) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
@@ -118,13 +96,11 @@ func (v *Voter) NewValidators(seq uint32, nowTrusted []consensus.NodeID) {
 	}
 }
 
-// PurgeNewValidators drops entries older than NewValidatorDisableSkip
-// ledgers relative to seq.
-func (v *Voter) PurgeNewValidators(seq uint32) {
+func (v *Voter) purgeNewValidators(seq uint32) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	for n, addedSeq := range v.newValidators {
-		if seq-addedSeq > NewValidatorDisableSkip {
+		if seq-addedSeq > newValidatorDisableSkip {
 			delete(v.newValidators, n)
 		}
 	}
@@ -140,8 +116,8 @@ func keyToNodeID(k [33]byte) consensus.NodeID {
 // DoVoting runs the producer end-to-end and returns the UNLModify blobs to
 // inject (at most one ToDisable plus one ToReEnable). The upcoming ledger is
 // prevLedgerSeq + 1; prevLedgerHash is the deterministic pad for picking.
-// Returns nil when there's nothing to vote (insufficient local participation
-// or no candidates).
+// Counts below the participation threshold and rounds without candidates return
+// nil without an error. Rejected local counts return nil with a diagnostic error.
 //
 // scoreTable contract: callers may pass any table; DoVoting restricts it to
 // the UNL (missing UNL keys score 0, non-UNL keys dropped), so no pre-fill or
@@ -153,7 +129,6 @@ func (v *Voter) DoVoting(
 	state State,
 	scoreTable map[consensus.NodeID]uint32,
 ) ([][]byte, error) {
-	// Build the trusted-key index once.
 	unlNodeIDs := make(map[consensus.NodeID][33]byte, len(unlKeys))
 	for _, k := range unlKeys {
 		unlNodeIDs[keyToNodeID(k)] = k
@@ -167,20 +142,22 @@ func (v *Voter) DoVoting(
 		filledScoreTable[n] = scoreTable[n]
 	}
 
-	// Refuse to vote if local participation is insufficient. The <= gate is
-	// exact: == MinLocalValsToVote is also a no-vote (rippled's else-if uses
-	// strict >). A count above the window is impossible → surface the error.
+	// Counts below the threshold abstain normally. The exact threshold and an
+	// impossible above-window count retain rippled's error observability.
 	myCount := filledScoreTable[v.myID]
-	if myCount <= MinLocalValsToVote {
+	if myCount < minLocalValsToVote {
 		return nil, nil
+	}
+	if myCount == minLocalValsToVote {
+		return nil, fmt.Errorf("%w: %d", ErrLocalCountAtThreshold, myCount)
 	}
 	if myCount > protocol.FlagLedgerInterval {
 		return nil, fmt.Errorf("%w: %d > %d", ErrLocalCountExceedsWindow, myCount, protocol.FlagLedgerInterval)
 	}
 
-	// effective negUNL for the upcoming flag ledger (current ± pending)
 	negUnlKeys := state.effectiveNegUNL()
 	negUnlNodeIDs := make(map[consensus.NodeID]struct{}, len(negUnlKeys))
+	// Every candidate comes from the UNL or effective NegativeUNL, both indexed here.
 	keyByNode := make(map[consensus.NodeID][33]byte, len(unlKeys)+len(negUnlKeys))
 	maps.Copy(keyByNode, unlNodeIDs)
 	for k := range negUnlKeys {
@@ -192,30 +169,22 @@ func (v *Voter) DoVoting(
 	}
 
 	upcomingSeq := prevLedgerSeq + 1
-	v.PurgeNewValidators(upcomingSeq)
+	v.purgeNewValidators(upcomingSeq)
 
 	candidates := v.findAllCandidates(unlNodeIDs, negUnlNodeIDs, filledScoreTable)
 
 	var blobs [][]byte
 	if len(candidates.toDisable) > 0 {
-		picked := choose(prevLedgerHash, candidates.toDisable)
-		key, ok := keyByNode[picked]
-		if !ok {
-			return nil, fmt.Errorf("negativeunlvote: picked toDisable candidate has no master key in lookup table")
-		}
-		blob, err := buildUNLModifyTx(upcomingSeq, key, ToDisable)
+		key := keyByNode[choose(prevLedgerHash, candidates.toDisable)]
+		blob, err := buildUNLModifyTx(upcomingSeq, key, toDisable)
 		if err != nil {
 			return nil, fmt.Errorf("negativeunlvote: serialize toDisable: %w", err)
 		}
 		blobs = append(blobs, blob)
 	}
 	if len(candidates.toReEnable) > 0 {
-		picked := choose(prevLedgerHash, candidates.toReEnable)
-		key, ok := keyByNode[picked]
-		if !ok {
-			return nil, fmt.Errorf("negativeunlvote: picked toReEnable candidate has no master key in lookup table")
-		}
-		blob, err := buildUNLModifyTx(upcomingSeq, key, ToReEnable)
+		key := keyByNode[choose(prevLedgerHash, candidates.toReEnable)]
+		blob, err := buildUNLModifyTx(upcomingSeq, key, toReEnable)
 		if err != nil {
 			return nil, fmt.Errorf("negativeunlvote: serialize toReEnable: %w", err)
 		}
@@ -230,14 +199,12 @@ type candidateSet struct {
 	toReEnable []consensus.NodeID
 }
 
-// findAllCandidates turns the score table into candidates: 25% cap,
-// new-validator skip, and the left-the-UNL ToReEnable fallback.
 func (v *Voter) findAllCandidates(
 	unl map[consensus.NodeID][33]byte,
 	negUNL map[consensus.NodeID]struct{},
 	scoreTable map[consensus.NodeID]uint32,
 ) candidateSet {
-	maxListed := int(math.Ceil(float64(len(unl)) * MaxListedFraction))
+	maxListed := (len(unl) + 3) / 4
 	listed := 0
 	for n := range unl {
 		if _, ok := negUNL[n]; ok {
@@ -254,10 +221,10 @@ func (v *Voter) findAllCandidates(
 		_, isNegUNL := negUNL[nodeID]
 		_, isNew := v.newValidators[nodeID]
 
-		if canAdd && score < LowWaterMark && !isNegUNL && !isNew {
+		if canAdd && score < lowWaterMark && !isNegUNL && !isNew {
 			c.toDisable = append(c.toDisable, nodeID)
 		}
-		if score > HighWaterMark && isNegUNL {
+		if score > highWaterMark && isNegUNL {
 			c.toReEnable = append(c.toReEnable, nodeID)
 		}
 	}
@@ -280,15 +247,11 @@ func (v *Voter) findAllCandidates(
 // without coordination. NodeID is already rippled's 20-byte digest, so the
 // XOR is direct (no rehash) and matches rippled byte-for-byte.
 func choose(randomPad [32]byte, candidates []consensus.NodeID) consensus.NodeID {
-	if len(candidates) == 0 {
-		var zero consensus.NodeID
-		return zero
-	}
 	best := candidates[0]
 	bestKey := xorCalcNodeID(best, randomPad)
 	for i := 1; i < len(candidates); i++ {
 		k := xorCalcNodeID(candidates[i], randomPad)
-		if compareNodeID20(k, bestKey) < 0 {
+		if bytes.Compare(k[:], bestKey[:]) < 0 {
 			best = candidates[i]
 			bestKey = k
 		}
@@ -296,7 +259,6 @@ func choose(randomPad [32]byte, candidates []consensus.NodeID) consensus.NodeID 
 	return best
 }
 
-// xorCalcNodeID computes NodeID ^ randomPad[:20].
 func xorCalcNodeID(n consensus.NodeID, pad [32]byte) [20]byte {
 	var out [20]byte
 	for i := range 20 {
@@ -305,21 +267,7 @@ func xorCalcNodeID(n consensus.NodeID, pad [32]byte) [20]byte {
 	return out
 }
 
-func compareNodeID20(a, b [20]byte) int {
-	for i := range 20 {
-		switch {
-		case a[i] < b[i]:
-			return -1
-		case a[i] > b[i]:
-			return 1
-		}
-	}
-	return 0
-}
-
-// buildUNLModifyTx serializes a UNLModify pseudo-tx: zero account/fee/key,
-// sequence 0.
-func buildUNLModifyTx(seq uint32, validator [33]byte, modify Modify) ([]byte, error) {
+func buildUNLModifyTx(seq uint32, validator [33]byte, modify modify) ([]byte, error) {
 	disabling := uint8(modify)
 	return common.BuildPseudoTx(tx.TypeUNLModify, func(base tx.BaseTx) tx.Transaction {
 		return &pseudo.UNLModify{

--- a/internal/consensus/negativeunlvote/vote.go
+++ b/internal/consensus/negativeunlvote/vote.go
@@ -77,7 +77,6 @@ type Voter struct {
 	newValidators map[consensus.NodeID]uint32
 }
 
-// NewVoter constructs a Voter for the local node.
 func NewVoter(myID consensus.NodeID) *Voter {
 	return &Voter{
 		myID:          myID,

--- a/internal/consensus/negativeunlvote/vote_test.go
+++ b/internal/consensus/negativeunlvote/vote_test.go
@@ -3,6 +3,7 @@ package negativeunlvote
 import (
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
@@ -12,875 +13,494 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// makeKey produces a deterministic 33-byte master pubkey for a
-// given byte tag. The first byte is a valid secp256k1 prefix (0x02
-// or 0x03) so the codec accepts the field as a Blob; subsequent
-// bytes are filled with the tag for human readability in failures.
 func makeKey(tag byte) [33]byte {
-	var k [33]byte
-	k[0] = 0x02
-	for i := 1; i < 33; i++ {
-		k[i] = tag
+	var key [33]byte
+	key[0] = 0x02
+	for i := 1; i < len(key); i++ {
+		key[i] = tag
 	}
-	return k
+	return key
+}
+
+func makeKeyN(index int) [33]byte {
+	var key [33]byte
+	key[0] = 0x02
+	key[1] = byte(index >> 8)
+	key[2] = byte(index)
+	return key
 }
 
 func nodeID(tag byte) consensus.NodeID {
-	return consensus.CalcNodeID(makeKey(tag))
+	return keyToNodeID(makeKey(tag))
 }
 
-// fullScoreTable returns scoreTable[nid] = HighWaterMark+1 for every
-// non-local key in keys, plus the local node at MinLocalValsToVote+1
-// so DoVoting clears the local-participation gate by default. The
-// local node is set unconditionally — including the case where myID
-// is also a member of keys — so the helper is robust to call sites
-// that include myKey in the UNL list.
-func fullScoreTable(myID consensus.NodeID, keys [][33]byte) map[consensus.NodeID]uint32 {
-	st := map[consensus.NodeID]uint32{
-		myID: MinLocalValsToVote + 1,
+func healthyScores(myID consensus.NodeID, keys [][33]byte) map[consensus.NodeID]uint32 {
+	scores := make(map[consensus.NodeID]uint32, len(keys))
+	for _, key := range keys {
+		scores[keyToNodeID(key)] = highWaterMark + 1
 	}
-	for _, k := range keys {
-		nid := keyToNodeID(k)
-		if nid == myID {
-			continue
-		}
-		st[nid] = HighWaterMark + 1
-	}
-	return st
+	scores[myID] = minLocalValsToVote + 1
+	return scores
 }
 
-func TestDoVoting_RefusesWhenLocalParticipationLow(t *testing.T) {
-	myKey := makeKey(0xAA)
-	other := makeKey(0xBB)
-	v := NewVoter(keyToNodeID(myKey))
-
-	scoreTable := map[consensus.NodeID]uint32{
-		v.myID:             MinLocalValsToVote - 1, // below threshold
-		keyToNodeID(other): 0,                      // would normally be disabled
-	}
-
-	blobs, err := v.DoVoting(1024, [32]byte{0xDE, 0xAD}, [][33]byte{myKey, other}, State{}, scoreTable)
-	require.NoError(t, err)
-	assert.Nil(t, blobs, "must not vote when local participation is below MinLocalValsToVote")
+type expectedVote struct {
+	disabling uint8
+	validator [33]byte
 }
 
-// TestDoVoting_LocalNotInUNLAbstains pins that the participation gate
-// reads the local count from the UNL-restricted table, not the raw caller
-// table: a local node absent from the UNL counts 0 and abstains even when
-// the caller scored it above the threshold — matching rippled, whose
-// myValidationCount comes from the UNL-seeded scoreTable
-// (NegativeUNLVote.cpp:216-220). Reading the raw count instead would let a
-// non-UNL local node vote (and disable a weak member) where rippled would
-// not.
-func TestDoVoting_LocalNotInUNLAbstains(t *testing.T) {
-	myKey := makeKey(0xAA)
-	v := NewVoter(keyToNodeID(myKey))
-
-	// A UNL of four members (so the 25% toDisable cap allows one) with one
-	// weak member that WOULD be disabled if the round proceeded. myKey is
-	// deliberately absent from this UNL.
-	unl := make([][33]byte, 0, 4)
-	for i := range 4 {
-		unl = append(unl, makeKey(byte(0xB0+i)))
-	}
-	weak := unl[0]
-
-	scoreTable := map[consensus.NodeID]uint32{
-		v.myID: MinLocalValsToVote + 1, // high raw count, but myID ∉ UNL
-	}
-	for _, k := range unl {
-		scoreTable[keyToNodeID(k)] = HighWaterMark + 1
-	}
-	scoreTable[keyToNodeID(weak)] = LowWaterMark - 1
-
-	blobs, err := v.DoVoting(1024, [32]byte{0x07}, unl, State{}, scoreTable)
-	require.NoError(t, err)
-	assert.Nil(t, blobs,
-		"a local node absent from the UNL must abstain regardless of its raw score")
-}
-
-func TestDoVoting_NoCandidatesWhenAllParticipating(t *testing.T) {
-	myKey := makeKey(0xAA)
-	other := makeKey(0xBB)
-	v := NewVoter(keyToNodeID(myKey))
-
-	scoreTable := fullScoreTable(v.myID, [][33]byte{myKey, other})
-	blobs, err := v.DoVoting(1024, [32]byte{0xDE, 0xAD}, [][33]byte{myKey, other}, State{}, scoreTable)
-	require.NoError(t, err)
-	assert.Nil(t, blobs, "no candidates → no tx")
-}
-
-func TestDoVoting_ToDisableWhenScoreLow(t *testing.T) {
-	myKey := makeKey(0xAA)
-	good := makeKey(0xBB)
-	weak := makeKey(0xCC)
-	v := NewVoter(keyToNodeID(myKey))
-	unl := [][33]byte{myKey, good, weak}
-
-	scoreTable := fullScoreTable(v.myID, unl)
-	scoreTable[keyToNodeID(weak)] = LowWaterMark - 1 // unreliable
-
-	blobs, err := v.DoVoting(1024, [32]byte{0x01}, unl, State{}, scoreTable)
-	require.NoError(t, err)
-	require.Len(t, blobs, 1, "expected one ToDisable pseudo-tx")
-
-	tx := decodeTx(t, blobs[0])
-	assert.EqualValues(t, 1, asUint(tx["UNLModifyDisabling"]),
-		"sfUNLModifyDisabling must be 1 for ToDisable")
-	assert.Equal(t, hex.EncodeToString(weak[:]),
-		stringFold(tx["UNLModifyValidator"]),
-		"validator field must be the weak validator's master key")
-	assert.EqualValues(t, 1025, asUint(tx["LedgerSequence"]))
-}
-
-func TestDoVoting_ToReEnableWhenDisabledScoreHigh(t *testing.T) {
-	myKey := makeKey(0xAA)
-	good := makeKey(0xBB)
-	recovered := makeKey(0xCC)
-	v := NewVoter(keyToNodeID(myKey))
-	unl := [][33]byte{myKey, good, recovered}
-
-	scoreTable := fullScoreTable(v.myID, unl) // recovered's score is already > HighWaterMark
-	state := State{
-		DisabledKeys: [][33]byte{recovered}, // currently on negUNL
-	}
-
-	blobs, err := v.DoVoting(1024, [32]byte{0x02}, unl, state, scoreTable)
-	require.NoError(t, err)
-	require.Len(t, blobs, 1)
-
-	tx := decodeTx(t, blobs[0])
-	assert.EqualValues(t, 0, asUint(tx["UNLModifyDisabling"]),
-		"sfUNLModifyDisabling must be 0 for ToReEnable")
-	assert.Equal(t, hex.EncodeToString(recovered[:]),
-		stringFold(tx["UNLModifyValidator"]))
-}
-
-func TestDoVoting_RespectsMaxListedFraction(t *testing.T) {
-	// 4-validator UNL → 25% cap = ceil(1) = 1 listed allowed.
-	// One already disabled, one weak: cap reached → no new ToDisable.
-	myKey := makeKey(0xAA)
-	good := makeKey(0xBB)
-	weak := makeKey(0xCC)
-	disabled := makeKey(0xDD)
-	v := NewVoter(keyToNodeID(myKey))
-	unl := [][33]byte{myKey, good, weak, disabled}
-
-	scoreTable := fullScoreTable(v.myID, unl)
-	scoreTable[keyToNodeID(weak)] = LowWaterMark - 1
-
-	state := State{DisabledKeys: [][33]byte{disabled}}
-
-	blobs, err := v.DoVoting(1024, [32]byte{0x03}, unl, state, scoreTable)
-	require.NoError(t, err)
-	for _, b := range blobs {
-		tx := decodeTx(t, b)
-		// Whatever blobs are returned must NOT be a ToDisable for `weak`.
-		if asUint(tx["UNLModifyDisabling"]) == 1 {
-			t.Fatalf("MaxListedFraction cap exceeded — got new ToDisable: %v", tx)
-		}
-	}
-}
-
-func TestDoVoting_NewValidatorSkip(t *testing.T) {
-	myKey := makeKey(0xAA)
-	good := makeKey(0xBB)
-	freshWeak := makeKey(0xCC)
-	v := NewVoter(keyToNodeID(myKey))
-	unl := [][33]byte{myKey, good, freshWeak}
-
-	upcomingSeq := uint32(1025)
-	// Register freshWeak as new at seq=900; the upcoming seq=1025 is
-	// within the NewValidatorDisableSkip window, so freshWeak is not
-	// a ToDisable candidate even with a low score.
-	v.NewValidators(900, []consensus.NodeID{keyToNodeID(freshWeak)})
-	require.True(t, upcomingSeq-900 <= NewValidatorDisableSkip)
-
-	scoreTable := fullScoreTable(v.myID, unl)
-	scoreTable[keyToNodeID(freshWeak)] = LowWaterMark - 1
-
-	blobs, err := v.DoVoting(upcomingSeq-1, [32]byte{0x04}, unl, State{}, scoreTable)
-	require.NoError(t, err)
-	assert.Nil(t, blobs, "new validator within skip window must not be a ToDisable candidate")
-}
-
-func TestDoVoting_RemovedFromUNL_ReEnableFallback(t *testing.T) {
-	// A validator currently on the negUNL is no longer in the trusted
-	// UNL — fallback path at NegativeUNLVote.cpp:309-318 must
-	// re-enable it (so the negUNL doesn't keep a non-validator
-	// listed forever).
-	myKey := makeKey(0xAA)
-	good := makeKey(0xBB)
-	stale := makeKey(0xCC)
-	v := NewVoter(keyToNodeID(myKey))
-	unl := [][33]byte{myKey, good} // stale is NOT in the UNL
-	scoreTable := fullScoreTable(v.myID, unl)
-
-	state := State{DisabledKeys: [][33]byte{stale}}
-	blobs, err := v.DoVoting(1024, [32]byte{0x05}, unl, state, scoreTable)
-	require.NoError(t, err)
-	require.Len(t, blobs, 1)
-
-	tx := decodeTx(t, blobs[0])
-	assert.EqualValues(t, 0, asUint(tx["UNLModifyDisabling"]),
-		"fallback re-enable for validator no longer in UNL")
-	assert.Equal(t, hex.EncodeToString(stale[:]),
-		stringFold(tx["UNLModifyValidator"]))
-}
-
-func TestChoose_DeterministicAcrossCalls(t *testing.T) {
-	candidates := []consensus.NodeID{nodeID(0x01), nodeID(0x02), nodeID(0x03)}
-	pad := [32]byte{0xCA, 0xFE, 0xBA, 0xBE}
-
-	first := choose(pad, candidates)
-	for range 8 {
-		got := choose(pad, candidates)
-		assert.Equal(t, first, got, "choose must be deterministic across repeated calls")
-	}
-}
-
-func TestChoose_OrderIndependent(t *testing.T) {
-	a, b, c := nodeID(0x01), nodeID(0x02), nodeID(0x03)
-	pad := [32]byte{0x42}
-
-	picked := choose(pad, []consensus.NodeID{a, b, c})
-	pickedReordered := choose(pad, []consensus.NodeID{c, b, a})
-	assert.Equal(t, picked, pickedReordered,
-		"choose must be input-order-independent — every validator on the network must converge on the same pick")
-}
-
-// decodeTx round-trips the serialized blob back to a JSON-ish map
-// for field-level assertions. Mirrors how rippled's wire receiver
-// would parse the pseudo-tx; if this fails, the on-wire format is
-// malformed.
-func decodeTx(t *testing.T, blob []byte) map[string]any {
+func requireVotes(t *testing.T, blobs [][]byte, seq uint32, expected ...expectedVote) {
 	t.Helper()
-	out, err := binarycodec.Decode(hex.EncodeToString(blob))
-	require.NoError(t, err, "serialized UNLModify must round-trip through binarycodec.Decode")
-	return out
+	require.Len(t, blobs, len(expected))
+	for i, want := range expected {
+		decoded, err := binarycodec.Decode(hex.EncodeToString(blobs[i]))
+		require.NoError(t, err)
+		assert.EqualValues(t, want.disabling, decoded["UNLModifyDisabling"])
+		assert.EqualValues(t, seq, decoded["LedgerSequence"])
+		validator, ok := decoded["UNLModifyValidator"].(string)
+		require.True(t, ok)
+		assert.True(t, strings.EqualFold(hex.EncodeToString(want.validator[:]), validator))
+	}
 }
 
-// asUint coerces a JSON-decoded numeric field to uint64. binarycodec.
-// Decode returns small unsigned ints as float64 / uint via its codec
-// definitions; we accept the common shapes.
-func asUint(v any) uint64 {
-	switch n := v.(type) {
-	case uint8:
-		return uint64(n)
-	case uint16:
-		return uint64(n)
-	case uint32:
-		return uint64(n)
-	case uint64:
-		return n
-	case int:
-		return uint64(n)
-	case int64:
-		return uint64(n)
-	case float64:
-		return uint64(n)
-	case string:
-		// uint64 may decode as a hex string under some codec paths.
-		var x uint64
-		for _, c := range n {
-			x <<= 4
-			switch {
-			case c >= '0' && c <= '9':
-				x |= uint64(c - '0')
-			case c >= 'a' && c <= 'f':
-				x |= uint64(c-'a') + 10
-			case c >= 'A' && c <= 'F':
-				x |= uint64(c-'A') + 10
+func TestStateEffectiveNegUNL(t *testing.T) {
+	a := makeKey(0xA1)
+	b := makeKey(0xB2)
+	c := makeKey(0xC3)
+
+	tests := []struct {
+		name  string
+		state State
+		want  [][33]byte
+	}{
+		{name: "disabled", state: State{DisabledKeys: [][33]byte{a, b}}, want: [][33]byte{a, b}},
+		{name: "pending disable", state: State{DisabledKeys: [][33]byte{a, b}, ToDisablePending: &c}, want: [][33]byte{a, b, c}},
+		{name: "pending re-enable", state: State{DisabledKeys: [][33]byte{a, b}, ToReEnablePending: &b}, want: [][33]byte{a}},
+		{name: "both pending", state: State{DisabledKeys: [][33]byte{a, b}, ToDisablePending: &c, ToReEnablePending: &a}, want: [][33]byte{b, c}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.state.effectiveNegUNL()
+			require.Len(t, got, len(tt.want))
+			for _, key := range tt.want {
+				assert.Contains(t, got, key)
 			}
-		}
-		return x
-	}
-	return 0
-}
-
-func stringFold(v any) string {
-	switch s := v.(type) {
-	case string:
-		// Lowercase hex for stable comparison.
-		out := make([]byte, len(s))
-		for i := 0; i < len(s); i++ {
-			c := s[i]
-			if c >= 'A' && c <= 'F' {
-				c = c - 'A' + 'a'
-			}
-			out[i] = c
-		}
-		return string(out)
-	}
-	return ""
-}
-
-// expectedChoose mirrors choose() byte-for-byte using the same
-// NodeID-XOR-pad comparator. Used as the oracle for parity tests
-// against rippled's NegativeUNLVote::choose at NegativeUNLVote.cpp:
-// 142-161. consensus.NodeID is the 20-byte calcNodeID(masterKey)
-// digest already, so the XOR is direct (no rehash). If choose's
-// comparator drifts, these tests will catch the divergence.
-func expectedChoose(pad [32]byte, cands []consensus.NodeID) consensus.NodeID {
-	var bestKey [20]byte
-	var best consensus.NodeID
-	for i, c := range cands {
-		var k [20]byte
-		for j := range 20 {
-			k[j] = c[j] ^ pad[j]
-		}
-		if i == 0 {
-			best, bestKey = c, k
-			continue
-		}
-		less := false
-		for j := range 20 {
-			if k[j] != bestKey[j] {
-				less = k[j] < bestKey[j]
-				break
-			}
-		}
-		if less {
-			best, bestKey = c, k
-		}
-	}
-	return best
-}
-
-// TestChoose_RippledParity_PicksMinCalcNodeIDXorPad asserts that
-// choose() picks the candidate whose calcNodeID(pubkey) XOR pad[:20]
-// is minimal — the exact comparator rippled uses at
-// NegativeUNLVote.cpp:142-161 + PublicKey.cpp:319-327. This test
-// would fail if choose() reverted to comparing the raw 33-byte
-// pubkey with a 32-byte pad, which would silently desync Go votes
-// from rippled votes on a mixed validator network.
-func TestChoose_RippledParity_PicksMinCalcNodeIDXorPad(t *testing.T) {
-	cands := []consensus.NodeID{nodeID(0x11), nodeID(0x22), nodeID(0x33), nodeID(0x44)}
-
-	for _, padTag := range []byte{0x00, 0xFF, 0xA5, 0x5A} {
-		var pad [32]byte
-		for i := range pad {
-			pad[i] = padTag
-		}
-		got := choose(pad, cands)
-		want := expectedChoose(pad, cands)
-		assert.Equal(t, want, got,
-			"pad=0x%02X: choose picked the wrong candidate; comparator must use calcNodeID(pubkey) XOR pad[:20]", padTag)
+		})
 	}
 }
 
-// TestChoose_PadAffectsPick asserts that two distinct pads can
-// produce different picks. This catches a comparator that ignores
-// the pad (e.g. a stub that always returns candidates[0]).
-func TestChoose_PadAffectsPick(t *testing.T) {
-	cands := []consensus.NodeID{nodeID(0x11), nodeID(0x22), nodeID(0x33), nodeID(0x44), nodeID(0x55)}
-
-	var padZero [32]byte
-	var padFF [32]byte
-	for i := range padFF {
-		padFF[i] = 0xFF
-	}
-
-	pickZero := choose(padZero, cands)
-	pickFF := choose(padFF, cands)
-	assert.NotEqual(t, pickZero, pickFF,
-		"choose with all-0 vs all-FF pads must produce different picks for this candidate set")
-}
-
-// TestFindAllCandidates_BoundaryScores asserts the strict-inequality
-// boundary in NegativeUNLVote.cpp:282 (`score < negativeUNLLowWaterMark`)
-// and :292 (`score > negativeUNLHighWaterMark`): a validator with
-// score == LowWaterMark is NOT a toDisable candidate, and one with
-// score == HighWaterMark is NOT a toReEnable candidate. rippled's
-// testFindAllCandidatesCombination at NegativeUNL_test.cpp:1175-1183
-// includes these boundary scores in its grid; we cover them
-// directly here.
-func TestFindAllCandidates_BoundaryScores(t *testing.T) {
+func TestDoVotingParticipationGate(t *testing.T) {
 	myKey := makeKey(0xAA)
-	atLow := makeKey(0xBB)
-	atHigh := makeKey(0xCC)
-	other := makeKey(0xDD)
-	v := NewVoter(keyToNodeID(myKey))
+	weak := makeKey(0xBB)
 
-	unlKeys := [][33]byte{myKey, atLow, atHigh, other}
-	unl := map[consensus.NodeID][33]byte{}
-	for _, k := range unlKeys {
-		unl[keyToNodeID(k)] = k
-	}
-	negUNL := map[consensus.NodeID]struct{}{
-		keyToNodeID(atHigh): {},
-	}
-	scoreTable := map[consensus.NodeID]uint32{
-		keyToNodeID(myKey):  HighWaterMark + 1,
-		keyToNodeID(atLow):  LowWaterMark,  // exactly at boundary — NOT a candidate
-		keyToNodeID(atHigh): HighWaterMark, // exactly at boundary — NOT a candidate
-		keyToNodeID(other):  HighWaterMark + 1,
+	tests := []struct {
+		name       string
+		count      uint32
+		localInUNL bool
+		wantErr    error
+		wantVote   bool
+	}{
+		{name: "below threshold", count: minLocalValsToVote - 1, localInUNL: true},
+		{name: "exact threshold", count: minLocalValsToVote, localInUNL: true, wantErr: ErrLocalCountAtThreshold},
+		{name: "above threshold", count: minLocalValsToVote + 1, localInUNL: true, wantVote: true},
+		{name: "at window", count: protocol.FlagLedgerInterval, localInUNL: true, wantVote: true},
+		{name: "above window", count: protocol.FlagLedgerInterval + 1, localInUNL: true, wantErr: ErrLocalCountExceedsWindow},
+		{name: "local not in UNL", count: protocol.FlagLedgerInterval, localInUNL: false},
 	}
 
-	c := v.findAllCandidates(unl, negUNL, scoreTable)
-	assert.Empty(t, c.toDisable, "score == LowWaterMark must not be a toDisable candidate (rippled uses strict `<`)")
-	assert.Empty(t, c.toReEnable, "score == HighWaterMark must not be a toReEnable candidate (rippled uses strict `>`)")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			voter := NewVoter(keyToNodeID(myKey))
+			unl := [][33]byte{weak}
+			if tt.localInUNL {
+				unl = append(unl, myKey)
+			}
+			scores := map[consensus.NodeID]uint32{
+				voter.myID:        tt.count,
+				keyToNodeID(weak): lowWaterMark - 1,
+			}
+
+			blobs, err := voter.DoVoting(1024, [32]byte{0xDE, 0xAD}, unl, State{}, scores)
+			if tt.wantVote {
+				require.Len(t, blobs, 1)
+			} else {
+				assert.Nil(t, blobs)
+			}
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tt.wantErr)
+			}
+		})
+	}
 }
 
-// TestDoVoting_AllBadScores_CapEnforced exercises the
-// MaxListedFraction cap with a UNL large enough that the cap is >1
-// and many candidates qualify. With 8 validators and 0% currently
-// disabled, ceil(8*0.25)=2 are allowed on the negUNL; canAdd is true
-// (since listed=0 < 2), so the candidate scan runs, but DoVoting
-// always picks at most one toDisable per round. The 25% cap is
-// re-tested when votes are applied, so producing one tx per round
-// matches rippled's behavior.
-func TestDoVoting_AllBadScores_CapEnforced(t *testing.T) {
-	myKey := makeKey(0xAA)
-	v := NewVoter(keyToNodeID(myKey))
-
-	unl := [][33]byte{myKey}
-	for i := byte(1); i <= 7; i++ {
-		unl = append(unl, makeKey(0xB0+i))
-	}
-
-	// Local node above MinLocalValsToVote, every other validator
-	// below LowWaterMark.
-	scoreTable := map[consensus.NodeID]uint32{
-		keyToNodeID(myKey): MinLocalValsToVote + 1,
-	}
-	for _, k := range unl {
-		nid := keyToNodeID(k)
-		if nid == keyToNodeID(myKey) {
-			continue
-		}
-		scoreTable[nid] = LowWaterMark - 1
-	}
-
-	blobs, err := v.DoVoting(1024, [32]byte{0xAB, 0xCD}, unl, State{}, scoreTable)
-	require.NoError(t, err)
-	require.Len(t, blobs, 1, "DoVoting returns at most one toDisable per round")
-
-	tx := decodeTx(t, blobs[0])
-	assert.EqualValues(t, 1, asUint(tx["UNLModifyDisabling"]),
-		"the single emitted tx must be a ToDisable")
-}
-
-// TestDoVoting_NewValidatorExpired_BecomesCandidate covers rippled's
-// case 9 in testFindAllCandidates (NegativeUNL_test.cpp:1136-1144):
-// a validator added via NewValidators is exempt from ToDisable while
-// inside the skip window; once seq advances past
-// NewValidatorDisableSkip, PurgeNewValidators removes it and a bad
-// score makes it a candidate. PR #375 shipped only the not-yet-
-// expired half of this case.
-func TestDoVoting_NewValidatorExpired_BecomesCandidate(t *testing.T) {
+func TestDoVotingOutcomes(t *testing.T) {
 	myKey := makeKey(0xAA)
 	good := makeKey(0xBB)
-	exFresh := makeKey(0xCC)
-	v := NewVoter(keyToNodeID(myKey))
-	unl := [][33]byte{myKey, good, exFresh}
+	good2 := makeKey(0xBC)
+	weak := makeKey(0xCC)
+	weak2 := makeKey(0xCD)
+	disabled := makeKey(0xDD)
+	stale := makeKey(0xEE)
+	stray := makeKey(0xEF)
 
-	addedAt := uint32(900)
-	v.NewValidators(addedAt, []consensus.NodeID{keyToNodeID(exFresh)})
+	tests := []struct {
+		name     string
+		unl      [][33]byte
+		state    State
+		pad      [32]byte
+		mutate   func(map[consensus.NodeID]uint32)
+		expected []expectedVote
+	}{
+		{
+			name: "all participating",
+			unl:  [][33]byte{myKey, good},
+		},
+		{
+			name: "disable low score",
+			unl:  [][33]byte{myKey, good, weak},
+			mutate: func(scores map[consensus.NodeID]uint32) {
+				scores[keyToNodeID(weak)] = lowWaterMark - 1
+			},
+			expected: []expectedVote{{disabling: 1, validator: weak}},
+		},
+		{
+			name:     "re-enable recovered validator",
+			unl:      [][33]byte{myKey, good, disabled},
+			state:    State{DisabledKeys: [][33]byte{disabled}},
+			expected: []expectedVote{{disabling: 0, validator: disabled}},
+		},
+		{
+			name:  "listed cap prevents disable",
+			unl:   [][33]byte{myKey, good, weak, disabled},
+			state: State{DisabledKeys: [][33]byte{disabled}},
+			mutate: func(scores map[consensus.NodeID]uint32) {
+				scores[keyToNodeID(weak)] = lowWaterMark - 1
+				scores[keyToNodeID(disabled)] = highWaterMark
+			},
+		},
+		{
+			name:     "retired validator fallback",
+			unl:      [][33]byte{myKey, good},
+			state:    State{DisabledKeys: [][33]byte{stale}},
+			expected: []expectedVote{{disabling: 0, validator: stale}},
+		},
+		{
+			name: "missing score is zero",
+			unl:  [][33]byte{myKey, good, weak},
+			mutate: func(scores map[consensus.NodeID]uint32) {
+				delete(scores, keyToNodeID(weak))
+			},
+			expected: []expectedVote{{disabling: 1, validator: weak}},
+		},
+		{
+			name: "stray score is ignored",
+			unl:  [][33]byte{myKey, weak},
+			pad: func() [32]byte {
+				var pad [32]byte
+				strayID := keyToNodeID(stray)
+				copy(pad[:], strayID[:])
+				return pad
+			}(),
+			mutate: func(scores map[consensus.NodeID]uint32) {
+				scores[keyToNodeID(weak)] = lowWaterMark - 1
+				scores[keyToNodeID(stray)] = 0
+			},
+			expected: []expectedVote{{disabling: 1, validator: weak}},
+		},
+		{
+			name: "multiple disable candidates emit one vote",
+			unl:  [][33]byte{myKey, good, weak, weak2},
+			pad: func() [32]byte {
+				var pad [32]byte
+				weakID := keyToNodeID(weak)
+				copy(pad[:], weakID[:])
+				return pad
+			}(),
+			mutate: func(scores map[consensus.NodeID]uint32) {
+				scores[keyToNodeID(weak)] = lowWaterMark - 1
+				scores[keyToNodeID(weak2)] = lowWaterMark - 1
+			},
+			expected: []expectedVote{{disabling: 1, validator: weak}},
+		},
+		{
+			name:  "one vote in each direction",
+			unl:   [][33]byte{myKey, good, good2, weak, disabled},
+			state: State{DisabledKeys: [][33]byte{disabled}},
+			mutate: func(scores map[consensus.NodeID]uint32) {
+				scores[keyToNodeID(weak)] = lowWaterMark - 1
+			},
+			expected: []expectedVote{{disabling: 1, validator: weak}, {disabling: 0, validator: disabled}},
+		},
+		{
+			name:     "pending disable is effective",
+			unl:      [][33]byte{myKey, good, disabled},
+			state:    State{ToDisablePending: &disabled},
+			expected: []expectedVote{{disabling: 0, validator: disabled}},
+		},
+		{
+			name:  "pending re-enable is effective",
+			unl:   [][33]byte{myKey, good, disabled},
+			state: State{DisabledKeys: [][33]byte{disabled}, ToReEnablePending: &disabled},
+			mutate: func(scores map[consensus.NodeID]uint32) {
+				scores[keyToNodeID(disabled)] = lowWaterMark - 1
+			},
+			expected: []expectedVote{{disabling: 1, validator: disabled}},
+		},
+	}
 
-	// Upcoming seq is past the skip window:
-	//   addedAt + NewValidatorDisableSkip + 2  → strictly > skip,
-	//   so PurgeNewValidators removes the entry.
-	upcomingSeq := addedAt + NewValidatorDisableSkip + 2
-	require.Greater(t, upcomingSeq-addedAt, NewValidatorDisableSkip,
-		"sanity: upcoming seq must be past the skip window")
-
-	scoreTable := fullScoreTable(v.myID, unl)
-	scoreTable[keyToNodeID(exFresh)] = LowWaterMark - 1
-
-	blobs, err := v.DoVoting(upcomingSeq-1, [32]byte{0x06}, unl, State{}, scoreTable)
-	require.NoError(t, err)
-	require.Len(t, blobs, 1, "expired new validator with bad score must produce a ToDisable")
-
-	tx := decodeTx(t, blobs[0])
-	assert.EqualValues(t, 1, asUint(tx["UNLModifyDisabling"]),
-		"sfUNLModifyDisabling must be 1 for the expired-then-bad-score case")
-	assert.Equal(t, hex.EncodeToString(exFresh[:]),
-		stringFold(tx["UNLModifyValidator"]),
-		"validator field must be the (now-expired) fresh validator")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			voter := NewVoter(keyToNodeID(myKey))
+			scores := healthyScores(voter.myID, tt.unl)
+			if tt.mutate != nil {
+				tt.mutate(scores)
+			}
+			blobs, err := voter.DoVoting(1024, tt.pad, tt.unl, tt.state, scores)
+			require.NoError(t, err)
+			requireVotes(t, blobs, 1025, tt.expected...)
+		})
+	}
 }
 
-// TestDoVoting_BoundaryParticipation covers the rippled boundary
-// where myValidationCount == MinLocalValsToVote. Rippled's else-if
-// at NegativeUNLVote.cpp:230-231 uses strict `>`, so the boundary
-// falls into the "Too many!" else-branch and returns empty. The Go
-// port must match: at exactly MinLocalValsToVote, do not vote.
-func TestDoVoting_BoundaryParticipation(t *testing.T) {
+func TestDoVotingNewValidatorGrace(t *testing.T) {
 	myKey := makeKey(0xAA)
-	weak := makeKey(0xBB)
-	v := NewVoter(keyToNodeID(myKey))
-	unl := [][33]byte{myKey, weak}
+	good := makeKey(0xBB)
+	fresh := makeKey(0xCC)
+	unl := [][33]byte{myKey, good, fresh}
+	voter := NewVoter(keyToNodeID(myKey))
+	scores := healthyScores(voter.myID, unl)
+	scores[keyToNodeID(fresh)] = lowWaterMark - 1
 
-	scoreTable := map[consensus.NodeID]uint32{
-		v.myID:            MinLocalValsToVote, // exactly at boundary
-		keyToNodeID(weak): LowWaterMark - 1,   // would be toDisable if we voted
+	const addedAt = uint32(900)
+	voter.NewValidators(addedAt, []consensus.NodeID{keyToNodeID(fresh)})
+	voter.NewValidators(addedAt+newValidatorDisableSkip-10, []consensus.NodeID{keyToNodeID(fresh)})
+
+	tests := []struct {
+		name     string
+		prevSeq  uint32
+		expected []expectedVote
+	}{
+		{name: "within grace", prevSeq: addedAt},
+		{name: "exact grace boundary", prevSeq: addedAt + newValidatorDisableSkip - 1},
+		{name: "after original grace despite repeat", prevSeq: addedAt + newValidatorDisableSkip, expected: []expectedVote{{disabling: 1, validator: fresh}}},
 	}
 
-	blobs, err := v.DoVoting(1024, [32]byte{0xDE, 0xAD}, unl, State{}, scoreTable)
-	require.NoError(t, err)
-	assert.Nil(t, blobs, "myCount == MinLocalValsToVote must NOT vote (rippled uses strict `>`)")
-}
-
-// TestDoVoting_LocalCountAboveWindow covers the rippled "Too many!"
-// branch at NegativeUNLVote.cpp:236-244 — myValidationCount >
-// FlagLedgerInterval. Rippled logs at error severity and returns
-// empty (no vote). The Go port returns nil blobs (no vote) AND
-// surfaces ErrLocalCountExceedsWindow so the caller can log at
-// error severity, matching rippled's observability.
-func TestDoVoting_LocalCountAboveWindow(t *testing.T) {
-	myKey := makeKey(0xAA)
-	weak := makeKey(0xBB)
-	v := NewVoter(keyToNodeID(myKey))
-	unl := [][33]byte{myKey, weak}
-
-	scoreTable := map[consensus.NodeID]uint32{
-		v.myID:            protocol.FlagLedgerInterval + 1,
-		keyToNodeID(weak): LowWaterMark - 1,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blobs, err := voter.DoVoting(tt.prevSeq, [32]byte{0x04}, unl, State{}, scores)
+			require.NoError(t, err)
+			requireVotes(t, blobs, tt.prevSeq+1, tt.expected...)
+		})
 	}
 
-	blobs, err := v.DoVoting(1024, [32]byte{0xDE, 0xAD}, unl, State{}, scoreTable)
-	require.ErrorIs(t, err, ErrLocalCountExceedsWindow,
-		"above-window must surface ErrLocalCountExceedsWindow so the caller can log at error severity")
-	assert.Nil(t, blobs, "myCount > FlagLedgerInterval must NOT vote")
+	t.Run("fresh disabled validator can re-enable", func(t *testing.T) {
+		voter := NewVoter(keyToNodeID(myKey))
+		voter.NewValidators(addedAt, []consensus.NodeID{keyToNodeID(fresh)})
+		blobs, err := voter.DoVoting(
+			addedAt,
+			[32]byte{0x04},
+			unl,
+			State{DisabledKeys: [][33]byte{fresh}},
+			healthyScores(voter.myID, unl),
+		)
+		require.NoError(t, err)
+		requireVotes(t, blobs, addedAt+1, expectedVote{disabling: 0, validator: fresh})
+	})
 }
 
-// TestDoVoting_ScoreTableMissingUNLMember covers the API-boundary
-// invariant introduced to match rippled's buildScoreTable at
-// NegativeUNLVote.cpp:197-200: every UNL member is treated as score
-// 0 if absent from the supplied scoreTable. Without the zero-fill
-// inside DoVoting, a UNL member silently absent would never become
-// a toDisable candidate even though rippled would always count it
-// as a non-validator with score 0.
-func TestDoVoting_ScoreTableMissingUNLMember(t *testing.T) {
-	myKey := makeKey(0xAA)
-	silent := makeKey(0xBB) // never validated — missing from scoreTable
-	other := makeKey(0xCC)
-	v := NewVoter(keyToNodeID(myKey))
-	unl := [][33]byte{myKey, silent, other}
+func TestChooseOracleGoldens(t *testing.T) {
+	var one, two, three consensus.NodeID
+	one[len(one)-1] = 1
+	two[len(two)-1] = 2
+	three[len(three)-1] = 3
 
-	scoreTable := map[consensus.NodeID]uint32{
-		v.myID:             MinLocalValsToVote + 1,
-		keyToNodeID(other): HighWaterMark + 1,
-		// silent intentionally omitted
+	var allFF [32]byte
+	for i := range allFF {
+		allFF[i] = 0xFF
+	}
+	lastBytesOnly := [32]byte{}
+	for i := len(one); i < len(lastBytesOnly); i++ {
+		lastBytesOnly[i] = 0xFF
 	}
 
-	blobs, err := v.DoVoting(1024, [32]byte{0x07}, unl, State{}, scoreTable)
-	require.NoError(t, err)
-	require.Len(t, blobs, 1, "silent UNL member (missing from scoreTable) must be treated as score 0 → toDisable")
-
-	tx := decodeTx(t, blobs[0])
-	assert.EqualValues(t, 1, asUint(tx["UNLModifyDisabling"]))
-	assert.Equal(t, hex.EncodeToString(silent[:]),
-		stringFold(tx["UNLModifyValidator"]),
-		"the silent (missing-from-scoreTable) validator must be the picked candidate")
-}
-
-// TestDoVoting_StrayNonUNLScoreDropped pins rippled's scoreTable ⊆ UNL
-// invariant (NegativeUNLVote.cpp:197-211, where the table is seeded with
-// exactly the UNL and only existing keys are incremented). A validator
-// removed from the UNL mid-window still carries a decaying score-table
-// entry; DoVoting must drop it. Leaving it in lets its score fall below
-// the low-water mark and turns it into a phantom ToDisable candidate
-// that can either displace the legitimate pick every rippled peer
-// chooses — a flag-ledger vote fork — or, when it wins `choose` but has
-// no master key in the lookup table, abort the whole round.
-func TestDoVoting_StrayNonUNLScoreDropped(t *testing.T) {
-	myKey := makeKey(0xAA)
-	weakUNL := makeKey(0xBB) // legitimate UNL member with a low score
-	v := NewVoter(keyToNodeID(myKey))
-	unl := [][33]byte{myKey, weakUNL} // the stray is deliberately NOT here
-
-	myNID := v.myID
-	weakNID := keyToNodeID(weakUNL)
-
-	// Pick a stray master key whose NodeID sorts strictly below the weak
-	// UNL member's. With an all-zero pad, choose() returns the candidate
-	// with the smallest NodeID — so if the stray were (incorrectly)
-	// retained it would WIN the toDisable pick. Since it has no master
-	// key in the lookup table, a reverted fix would then error out,
-	// aborting the round. Restricting the table to the UNL drops it.
-	var stray [33]byte
-	found := false
-	for idx := range 4096 {
-		cand := makeKeyN(idx)
-		nid := keyToNodeID(cand)
-		if nid == myNID || nid == weakNID {
-			continue
-		}
-		if compareNodeID20([20]byte(nid), [20]byte(weakNID)) < 0 {
-			stray = cand
-			found = true
-			break
-		}
-	}
-	require.True(t, found, "test setup: need a stray NodeID below the weak member's")
-
-	var zeroPad [32]byte
-	scoreTable := map[consensus.NodeID]uint32{
-		myNID:              MinLocalValsToVote + 1,
-		weakNID:            LowWaterMark - 1, // the only legitimate toDisable
-		keyToNodeID(stray): 0,                // decayed; a phantom candidate if retained
+	tests := []struct {
+		name       string
+		pad        [32]byte
+		candidates []consensus.NodeID
+		want       consensus.NodeID
+	}{
+		{name: "single zero pad", candidates: []consensus.NodeID{one}, want: one},
+		{name: "single FF pad", pad: allFF, candidates: []consensus.NodeID{one}, want: one},
+		{name: "zero pad", candidates: []consensus.NodeID{one, two, three}, want: one},
+		{name: "zero pad reversed", candidates: []consensus.NodeID{three, two, one}, want: one},
+		{name: "FF pad", pad: allFF, candidates: []consensus.NodeID{one, two, three}, want: three},
+		{name: "FF pad reversed", pad: allFF, candidates: []consensus.NodeID{three, two, one}, want: three},
+		{name: "last twelve pad bytes ignored", pad: lastBytesOnly, candidates: []consensus.NodeID{three, two, one}, want: one},
 	}
 
-	blobs, err := v.DoVoting(1024, zeroPad, unl, State{}, scoreTable)
-	require.NoError(t, err, "a stray non-UNL score must never abort the round")
-	require.Len(t, blobs, 1, "the weak UNL member is the only eligible toDisable")
-
-	tx := decodeTx(t, blobs[0])
-	assert.EqualValues(t, 1, asUint(tx["UNLModifyDisabling"]))
-	assert.Equal(t, hex.EncodeToString(weakUNL[:]), stringFold(tx["UNLModifyValidator"]),
-		"the picked toDisable must be the UNL member, never the stray that left the UNL")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, choose(tt.pad, tt.candidates))
+		})
+	}
 }
 
-// makeKeyN produces a deterministic 33-byte master pubkey indexed by
-// idx. Unlike makeKey (which fills bytes 1..32 with the same byte
-// tag and so collides above 256 distinct values), makeKeyN encodes
-// the index across the first three bytes so up to 65535 distinct
-// pubkeys can be generated for the combination tests.
-func makeKeyN(idx int) [33]byte {
-	var k [33]byte
-	k[0] = 0x02
-	k[1] = byte(idx >> 8)
-	k[2] = byte(idx)
-	return k
-}
-
-// buildCombinationFixture builds the (unl, negUNL, scoreTable) tuple
-// rippled's testFindAllCandidatesCombination uses for combination 1
-// (NegativeUNL_test.cpp:1185-1257): every UNL member gets the same
-// score, the first floor(unlSize * nUnlPercent / 100) members are
-// placed on the negUNL.
-func buildCombinationFixture(unlSize, nUnlPercent int, score uint32) (
+func buildCandidateFixture(unlSize, negPercent int, scores []uint32) (
 	map[consensus.NodeID][33]byte,
 	map[consensus.NodeID]struct{},
 	map[consensus.NodeID]uint32,
 ) {
 	nodeIDs := make([]consensus.NodeID, unlSize)
-	keys := make([][33]byte, unlSize)
-	for i := range unlSize {
-		keys[i] = makeKeyN(i)
-		nodeIDs[i] = keyToNodeID(keys[i])
-	}
 	unl := make(map[consensus.NodeID][33]byte, unlSize)
 	scoreTable := make(map[consensus.NodeID]uint32, unlSize)
-	for i, n := range nodeIDs {
-		unl[n] = keys[i]
-		scoreTable[n] = score
+	for i := range unlSize {
+		key := makeKeyN(i)
+		nodeIDs[i] = keyToNodeID(key)
+		unl[nodeIDs[i]] = key
+		scoreTable[nodeIDs[i]] = scores[i]
 	}
-	negSize := unlSize * nUnlPercent / 100
-	negUNL := make(map[consensus.NodeID]struct{}, negSize)
-	for i := range negSize {
-		negUNL[nodeIDs[i]] = struct{}{}
+	negUNL := make(map[consensus.NodeID]struct{})
+	if negPercent == 100 {
+		for _, id := range nodeIDs {
+			negUNL[id] = struct{}{}
+		}
+	} else if negPercent == 50 {
+		for i := 1; i < len(nodeIDs); i += 2 {
+			negUNL[nodeIDs[i]] = struct{}{}
+		}
 	}
 	return unl, negUNL, scoreTable
 }
 
-// TestFindAllCandidates_RippledCombination1 mirrors rippled's
-// testFindAllCandidatesCombination combination 1
-// (NegativeUNL_test.cpp:1185-1257) — a parameterized grid over
-// (unlSize, nUnlPercent, score) covering every boundary score and
-// the no-/half-/full-negUNL cases. This is rippled's parity bar for
-// findAllCandidates and catches off-by-one drift in the canAdd cap
-// or the strict-inequality watermark thresholds.
-func TestFindAllCandidates_RippledCombination1(t *testing.T) {
+func TestFindAllCandidatesOracleCombinations(t *testing.T) {
 	unlSizes := []int{34, 35, 80}
-	nUnlPercents := []int{0, 50, 100}
-	scores := []uint32{
-		0,
-		LowWaterMark - 1,
-		LowWaterMark,
-		LowWaterMark + 1,
-		HighWaterMark - 1,
-		HighWaterMark,
-		HighWaterMark + 1,
-		MinLocalValsToVote,
+	negPercents := []int{0, 50, 100}
+	scoreCases := []struct {
+		name     string
+		score    uint32
+		disable  bool
+		reEnable bool
+	}{
+		{name: "zero", score: 0, disable: true},
+		{name: "below low", score: lowWaterMark - 1, disable: true},
+		{name: "at low", score: lowWaterMark},
+		{name: "above low", score: lowWaterMark + 1},
+		{name: "below high", score: highWaterMark - 1},
+		{name: "at high", score: highWaterMark},
+		{name: "above high", score: highWaterMark + 1, reEnable: true},
+		{name: "local threshold", score: minLocalValsToVote, reEnable: true},
 	}
+	voter := NewVoter(nodeID(0xA0))
 
-	v := NewVoter(nodeID(0xA0))
+	t.Run("uniform scores", func(t *testing.T) {
+		for _, size := range unlSizes {
+			for _, negPercent := range negPercents {
+				for _, scoreCase := range scoreCases {
+					name := fmt.Sprintf("size=%d/neg=%d/%s", size, negPercent, scoreCase.name)
+					t.Run(name, func(t *testing.T) {
+						scores := make([]uint32, size)
+						for i := range scores {
+							scores[i] = scoreCase.score
+						}
+						unl, negUNL, scoreTable := buildCandidateFixture(size, negPercent, scores)
+						got := voter.findAllCandidates(unl, negUNL, scoreTable)
 
-	for _, us := range unlSizes {
-		for _, np := range nUnlPercents {
-			for _, score := range scores {
-				name := fmt.Sprintf("us=%d/np=%d/score=%d", us, np, score)
+						wantDisable := 0
+						if negPercent == 0 && scoreCase.disable {
+							wantDisable = size
+						}
+						wantReEnable := 0
+						if negPercent != 0 && scoreCase.reEnable {
+							wantReEnable = len(negUNL)
+						}
+						assert.Len(t, got.toDisable, wantDisable)
+						assert.Len(t, got.toReEnable, wantReEnable)
+					})
+				}
+			}
+		}
+	})
+
+	t.Run("mixed scores", func(t *testing.T) {
+		mixed := []uint32{
+			0, 0,
+			lowWaterMark - 1, lowWaterMark - 1,
+			lowWaterMark, lowWaterMark,
+			lowWaterMark + 1, lowWaterMark + 1,
+			highWaterMark - 1, highWaterMark - 1,
+			highWaterMark, highWaterMark,
+			highWaterMark + 1, highWaterMark + 1,
+			minLocalValsToVote, minLocalValsToVote,
+		}
+		for _, size := range unlSizes {
+			for _, negPercent := range negPercents {
+				name := fmt.Sprintf("size=%d/neg=%d", size, negPercent)
 				t.Run(name, func(t *testing.T) {
-					unl, negUNL, scoreTable := buildCombinationFixture(us, np, score)
-					require.Equal(t, us, len(unl))
-					require.Equal(t, us*np/100, len(negUNL))
-					require.Equal(t, us, len(scoreTable))
-
-					var toDisableExpect, toReEnableExpect int
-					switch np {
-					case 0:
-						if score < LowWaterMark {
-							toDisableExpect = us
-						}
-					case 50:
-						if score > HighWaterMark {
-							toReEnableExpect = us * np / 100
-						}
-					case 100:
-						if score > HighWaterMark {
-							toReEnableExpect = us
-						}
+					scores := make([]uint32, size)
+					copy(scores, mixed)
+					for i := len(mixed); i < size; i++ {
+						scores[i] = minLocalValsToVote
 					}
+					unl, negUNL, scoreTable := buildCandidateFixture(size, negPercent, scores)
+					got := voter.findAllCandidates(unl, negUNL, scoreTable)
 
-					c := v.findAllCandidates(unl, negUNL, scoreTable)
-					assert.Equal(t, toDisableExpect, len(c.toDisable),
-						"toDisable count mismatch")
-					assert.Equal(t, toReEnableExpect, len(c.toReEnable),
-						"toReEnable count mismatch")
+					wantDisable := 0
+					wantReEnable := 0
+					switch negPercent {
+					case 0:
+						wantDisable = 4
+					case 50:
+						wantReEnable = len(negUNL) - 6
+					case 100:
+						wantReEnable = len(negUNL) - 12
+					}
+					assert.Len(t, got.toDisable, wantDisable)
+					assert.Len(t, got.toReEnable, wantReEnable)
 				})
 			}
 		}
-	}
+	})
 }
 
-// TestFindAllCandidates_RippledCombination2 mirrors rippled's
-// testFindAllCandidatesCombination combination 2
-// (NegativeUNL_test.cpp:1258-1334) — the first 16 nodes get pairs of
-// scores from the boundary array, every node beyond gets
-// MinLocalValsToVote (= scores.back()), and the negUNL is built per
-// percent rule. The expected counts encode the cap-and-watermark
-// arithmetic across (unlSize, nUnlPercent) without enumerating every
-// score: a single failure here flags drift in the candidate-set
-// composition that combination 1 cannot reach.
-func TestFindAllCandidates_RippledCombination2(t *testing.T) {
-	unlSizes := []int{34, 35, 80}
-	nUnlPercents := []int{0, 50, 100}
-	scores := []uint32{
-		0,
-		LowWaterMark - 1,
-		LowWaterMark,
-		LowWaterMark + 1,
-		HighWaterMark - 1,
-		HighWaterMark,
-		HighWaterMark + 1,
-		MinLocalValsToVote,
+func TestFindAllCandidatesFallbackPriority(t *testing.T) {
+	a := makeKey(0xA1)
+	b := makeKey(0xB2)
+	retired := makeKey(0xC3)
+	unl := map[consensus.NodeID][33]byte{
+		keyToNodeID(a): a,
+		keyToNodeID(b): b,
 	}
-
-	v := NewVoter(nodeID(0xA0))
-
-	build := func(unlSize, nUnlPercent int) (
-		map[consensus.NodeID][33]byte,
-		map[consensus.NodeID]struct{},
-		map[consensus.NodeID]uint32,
-	) {
-		nodeIDs := make([]consensus.NodeID, unlSize)
-		keys := make([][33]byte, unlSize)
-		for i := range unlSize {
-			keys[i] = makeKeyN(i)
-			nodeIDs[i] = keyToNodeID(keys[i])
-		}
-		unl := make(map[consensus.NodeID][33]byte, unlSize)
-		for i, n := range nodeIDs {
-			unl[n] = keys[i]
-		}
-		scoreTable := make(map[consensus.NodeID]uint32, unlSize)
-		nIdx := 0
-		for _, sc := range scores {
-			scoreTable[nodeIDs[nIdx]] = sc
-			nIdx++
-			scoreTable[nodeIDs[nIdx]] = sc
-			nIdx++
-		}
-		tail := scores[len(scores)-1]
-		for ; nIdx < unlSize; nIdx++ {
-			scoreTable[nodeIDs[nIdx]] = tail
-		}
-		negUNL := make(map[consensus.NodeID]struct{})
-		switch nUnlPercent {
-		case 100:
-			for _, n := range nodeIDs {
-				negUNL[n] = struct{}{}
-			}
-		case 50:
-			for i := 1; i < unlSize; i += 2 {
-				negUNL[nodeIDs[i]] = struct{}{}
-			}
-		}
-		return unl, negUNL, scoreTable
+	negUNL := map[consensus.NodeID]struct{}{
+		keyToNodeID(b):       {},
+		keyToNodeID(retired): {},
 	}
+	voter := NewVoter(nodeID(0xA0))
 
-	for _, us := range unlSizes {
-		for _, np := range nUnlPercents {
-			name := fmt.Sprintf("us=%d/np=%d", us, np)
-			t.Run(name, func(t *testing.T) {
-				unl, negUNL, scoreTable := build(us, np)
-				require.Equal(t, us, len(unl))
-				require.Equal(t, us*np/100, len(negUNL))
-				require.Equal(t, us, len(scoreTable))
+	scores := map[consensus.NodeID]uint32{keyToNodeID(a): highWaterMark, keyToNodeID(b): highWaterMark}
+	got := voter.findAllCandidates(unl, negUNL, scores)
+	assert.Equal(t, []consensus.NodeID{keyToNodeID(retired)}, got.toReEnable)
 
-				var toDisableExpect, toReEnableExpect int
-				switch np {
-				case 0:
-					toDisableExpect = 4
-				case 50:
-					toReEnableExpect = len(negUNL) - 6
-				case 100:
-					toReEnableExpect = len(negUNL) - 12
-				}
-
-				c := v.findAllCandidates(unl, negUNL, scoreTable)
-				assert.Equal(t, toDisableExpect, len(c.toDisable),
-					"toDisable count mismatch")
-				assert.Equal(t, toReEnableExpect, len(c.toReEnable),
-					"toReEnable count mismatch")
-			})
-		}
-	}
+	scores[keyToNodeID(b)] = highWaterMark + 1
+	got = voter.findAllCandidates(unl, negUNL, scores)
+	assert.Equal(t, []consensus.NodeID{keyToNodeID(b)}, got.toReEnable)
 }
 
-// TestBuildUNLModifyTx_PseudoTxWireFormat pins the UNLModify
-// pseudo-tx wire shape against rippled's REQUIRED/OPTIONAL common
-// field rules. This guards the byte-level output of
-// buildUNLModifyTx, which now routes through pseudo.EncodePseudoTx
-// — a behaviour change from the previous in-place serialization
-// that omitted sfSigningPubKey and emitted sfFlags=0.
-//
-// rippled references:
-//   - TxFormats.cpp:34, 44 — sfFlags is soeOPTIONAL,
-//     sfSigningPubKey is soeREQUIRED
-//   - STObject.cpp:162-168 — set(SOTemplate) writes
-//     defaultObject for REQUIRED (empty VL for SigningPubKey) and
-//     nonPresentObject for OPTIONAL (Flags)
-//   - STObject.cpp:907-921 — STI_NOTPRESENT fields are filtered
-//     out of the serialized blob
-//   - NegativeUNLVote.cpp:110-140 — addTx assembles the pseudo-tx
-//     without setting sfFlags
-//
-// Asserting the bytes here means a regression in the encoder
-// (e.g., a future "always emit Flags" change) fails this test
-// with a precise message rather than silently diverging the
-// transaction ID and breaking flag-ledger SHAMap consensus on
-// the negative-UNL pseudo-tx position.
-func TestBuildUNLModifyTx_PseudoTxWireFormat(t *testing.T) {
+func TestBuildUNLModifyTxWireFormat(t *testing.T) {
 	validator := makeKey(0x42)
-	blob, err := buildUNLModifyTx(99999, validator, ToDisable)
+	blob, err := buildUNLModifyTx(99999, validator, toDisable)
 	require.NoError(t, err)
-	require.NotNil(t, blob)
 
 	hexBlob := hex.EncodeToString(blob)
-	// sfSigningPubKey (field id 0x73 = type 7 / fieldCode 3) must
-	// appear as VL(0) — bytes "7300". For UNLModify the next
-	// field in canonical sort order is sfUNLModifyValidator
-	// (0x70 0x13), so SigningPubKey ends with "73007013" rather
-	// than the "730081" pattern used by SetFee.
-	assert.Contains(t, hexBlob, "73007013",
-		"UNLModify blob must carry sfSigningPubKey VL(0) immediately before sfUNLModifyValidator")
-	// sfFlags (UInt32 type marker 0x22 + 4 zero bytes) must not
-	// appear; rippled marks sfFlags as soeOPTIONAL and
-	// NegativeUNLVote::addTx never sets it. STObject::add filters
-	// STI_NOTPRESENT optionals out of the serialized blob.
-	assert.NotContains(t, hexBlob, "2200000000",
-		"UNLModify blob must not carry sfFlags=0 (rippled omits soeOPTIONAL nonPresent fields)")
+	assert.Contains(t, hexBlob, "73007013")
+	assert.NotContains(t, hexBlob, "2200000000")
 
-	stx, err := binarycodec.Decode(hexBlob)
-	require.NoError(t, err, "UNLModify blob must round-trip through binarycodec.Decode")
-
-	got, ok := stx["SigningPubKey"]
-	assert.True(t, ok, "decoded UNLModify must include SigningPubKey")
-	assert.Equal(t, "", got, "SigningPubKey must decode as empty")
-
-	_, hasFlags := stx["Flags"]
-	assert.False(t, hasFlags, "decoded UNLModify must not include Flags")
+	decoded, err := binarycodec.Decode(hexBlob)
+	require.NoError(t, err)
+	assert.Equal(t, "", decoded["SigningPubKey"])
+	_, hasFlags := decoded["Flags"]
+	assert.False(t, hasFlags)
+	assert.EqualValues(t, 1, decoded["UNLModifyDisabling"])
+	assert.EqualValues(t, uint32(99999), decoded["LedgerSequence"])
 }


### PR DESCRIPTION
## Summary
- narrow NegativeUNL voting exports and encode candidate/key and non-empty selection invariants directly
- preserve vote output while making the exact local participation threshold error-observable
- replace duplicated selection logic with fixed rippled goldens and consolidate pending, grace, cap, fallback, and wire coverage

## Test plan
- [x] `go test -count=1 ./internal/consensus/negativeunlvote ./internal/consensus/adaptor`
- [x] `go test -race -count=1 ./internal/consensus/negativeunlvote ./internal/consensus/adaptor`
- [x] `go test -race -count=1 -timeout 15m ./internal/consensus/...`
- [x] `just test-core`
- [x] `just vet`
- [x] `golangci-lint run --config .golangci.yml`
- [x] `golangci-lint run --config .golangci-warnings.yml`
- [x] `just build && just build-all && just build-nocgo`

Fixes #1461


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Negative UNL voting diagnostics for abstentions, exact-threshold participation, and invalid validation counts.
  * Corrected voting behavior around participation thresholds, validator grace periods, empty trusted sets, and validator re-enablement.
  * Improved deterministic candidate selection and score handling.

* **Tests**
  * Expanded coverage for threshold boundaries, state transitions, validator expiry, candidate limits, and transaction formatting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->