### PR TITLE
fix: harden fee load admission

### DIFF
--- a/internal/consensus/adaptor/consensus_events.go
+++ b/internal/consensus/adaptor/consensus_events.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/protocol"
@@ -402,7 +403,7 @@ func (a *Adaptor) refreshRemoteFee(seq uint32, ledgerID, parentID consensus.Ledg
 	if ft == nil {
 		return
 	}
-	base := ft.LoadBase()
+	base := feetrack.LoadBase
 
 	fees := collectValidationFees(historian, ledgerID, base)
 	fees = append(fees, collectValidationFees(historian, parentID, base)...)

--- a/internal/consensus/adaptor/refresh_remote_fee_test.go
+++ b/internal/consensus/adaptor/refresh_remote_fee_test.go
@@ -118,8 +118,8 @@ func TestRefreshRemoteFee_EmptyValidations(t *testing.T) {
 		byLedger: map[consensus.LedgerID][]*consensus.Validation{},
 	})
 	a.OnLedgerFullyValidated(consensus.LedgerID(closed.Hash()), seq)
-	if got := ft.RemoteFee(); got != ft.LoadBase() {
-		t.Fatalf("RemoteFee = %d on empty validations; want LoadBase %d", got, ft.LoadBase())
+	if got := ft.RemoteFee(); got != feetrack.LoadBase {
+		t.Fatalf("RemoteFee = %d on empty validations; want LoadBase %d", got, feetrack.LoadBase)
 	}
 }
 

--- a/internal/consensus/adaptor/trust_oracle.go
+++ b/internal/consensus/adaptor/trust_oracle.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/consensus/amendmentvote"
+	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -357,7 +358,7 @@ func (a *Adaptor) GetLoadFee() uint32 {
 	if c := ft.ClusterFee(); c > fee {
 		fee = c
 	}
-	if fee <= ft.LoadBase() {
+	if fee <= feetrack.LoadBase {
 		return 0
 	}
 	return fee

--- a/internal/feetrack/feetrack.go
+++ b/internal/feetrack/feetrack.go
@@ -9,7 +9,8 @@ package feetrack
 
 import (
 	"errors"
-	"math/big"
+	"math"
+	"math/bits"
 	"sync"
 )
 
@@ -18,19 +19,12 @@ const (
 	// expressed as multiples of this base.
 	LoadBase uint32 = 256
 
-	// FeeIncFraction controls how fast the local fee ramps up on a raise:
-	// fee += fee / FeeIncFraction.
-	FeeIncFraction uint32 = 4
-
-	// FeeDecFraction controls the decay step on a lower:
-	// fee -= fee / FeeDecFraction. Symmetric with FeeIncFraction.
-	FeeDecFraction uint32 = 4
-
-	// FeeMax caps the local fee at LoadBase * 1_000_000.
-	FeeMax uint32 = 256 * 1_000_000
+	feeIncFraction uint32 = 4
+	feeDecFraction uint32 = 4
+	feeMax         uint32 = LoadBase * 1_000_000
 )
 
-// ErrOverflow indicates ScaleFeeLoad multiplication overflowed uint64.
+// ErrOverflow indicates ScaleFeeLoad exceeded the signed XRP amount range.
 var ErrOverflow = errors.New("feetrack: scaleFeeLoad overflow")
 
 // LoadFeeTrack tracks the local-node fee factor and accepts remote / cluster
@@ -88,9 +82,6 @@ func (t *LoadFeeTrack) LocalFee() uint32 {
 	return t.localFee
 }
 
-// LoadBase returns the reference (normal) fee factor.
-func (t *LoadFeeTrack) LoadBase() uint32 { return LoadBase }
-
 // LoadFactor returns max(cluster, local, remote).
 func (t *LoadFeeTrack) LoadFactor() uint32 {
 	t.mu.RLock()
@@ -98,9 +89,7 @@ func (t *LoadFeeTrack) LoadFactor() uint32 {
 	return max(t.clusterFee, t.localFee, t.remoteFee)
 }
 
-// ScalingFactors returns (max(local,remote), max(remote,cluster)), the pair
-// consumed by ScaleFeeLoad.
-func (t *LoadFeeTrack) ScalingFactors() (feeFactor, remFee uint32) {
+func (t *LoadFeeTrack) scalingFactors() (feeFactor, remFee uint32) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return max(t.localFee, t.remoteFee), max(t.remoteFee, t.clusterFee)
@@ -113,9 +102,16 @@ func (t *LoadFeeTrack) IsLoadedLocal() bool {
 	return t.raiseCount != 0 || t.localFee != LoadBase
 }
 
+// IsLoadedCluster reports whether the cluster-load admission gate is active.
+func (t *LoadFeeTrack) IsLoadedCluster() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.raiseCount != 0 || t.localFee != LoadBase || t.clusterFee != LoadBase
+}
+
 // RaiseLocalFee bumps the local fee factor and reports whether the stored
 // factor actually changed. The first call only arms raiseCount; the second and
-// subsequent calls scale the local fee up toward FeeMax, tracking the remote
+// subsequent calls scale the local fee up toward its cap, tracking the remote
 // fee floor.
 func (t *LoadFeeTrack) RaiseLocalFee() bool {
 	t.mu.Lock()
@@ -126,13 +122,12 @@ func (t *LoadFeeTrack) RaiseLocalFee() bool {
 	}
 
 	orig := t.localFee
-	if t.localFee < t.remoteFee {
-		t.localFee = t.remoteFee
+	base := max(t.localFee, t.remoteFee)
+	raised := uint64(base) + uint64(base)/uint64(feeIncFraction)
+	if raised > uint64(feeMax) {
+		raised = uint64(feeMax)
 	}
-	t.localFee += t.localFee / FeeIncFraction
-	if t.localFee > FeeMax {
-		t.localFee = FeeMax
-	}
+	t.localFee = uint32(raised)
 	return orig != t.localFee
 }
 
@@ -144,7 +139,7 @@ func (t *LoadFeeTrack) LowerLocalFee() bool {
 	defer t.mu.Unlock()
 	orig := t.localFee
 	t.raiseCount = 0
-	t.localFee -= t.localFee / FeeDecFraction
+	t.localFee -= t.localFee / feeDecFraction
 	if t.localFee < LoadBase {
 		t.localFee = LoadBase
 	}
@@ -162,20 +157,24 @@ func ScaleFeeLoad(fee uint64, t *LoadFeeTrack, unlimited bool) (uint64, error) {
 	if fee == 0 {
 		return 0, nil
 	}
+	if fee > math.MaxInt64 {
+		return 0, ErrOverflow
+	}
 	if t == nil {
 		return fee, nil
 	}
-	feeFactor, remFee := t.ScalingFactors()
+	feeFactor, remFee := t.scalingFactors()
 	if unlimited && feeFactor > remFee && feeFactor < 4*remFee {
 		feeFactor = remFee
 	}
 
-	// fee * feeFactor / LoadBase in big.Int to avoid uint64 overflow and keep
-	// exact integer truncation.
-	num := new(big.Int).Mul(new(big.Int).SetUint64(fee), new(big.Int).SetUint64(uint64(feeFactor)))
-	num.Quo(num, new(big.Int).SetUint64(uint64(LoadBase)))
-	if !num.IsUint64() {
+	productHi, productLo := bits.Mul64(fee, uint64(feeFactor))
+	if productHi >= uint64(LoadBase) {
 		return 0, ErrOverflow
 	}
-	return num.Uint64(), nil
+	scaled, _ := bits.Div64(productHi, productLo, uint64(LoadBase))
+	if scaled > math.MaxInt64 {
+		return 0, ErrOverflow
+	}
+	return scaled, nil
 }

--- a/internal/feetrack/feetrack.go
+++ b/internal/feetrack/feetrack.go
@@ -102,7 +102,6 @@ func (t *LoadFeeTrack) IsLoadedLocal() bool {
 	return t.raiseCount != 0 || t.localFee != LoadBase
 }
 
-// IsLoadedCluster reports whether the cluster-load admission gate is active.
 func (t *LoadFeeTrack) IsLoadedCluster() bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/internal/feetrack/feetrack_test.go
+++ b/internal/feetrack/feetrack_test.go
@@ -1,12 +1,11 @@
 package feetrack
 
 import (
+	"errors"
+	"math"
 	"testing"
 )
 
-// TestScaleFeeLoad_Identity: with a fresh tracker the factor is LoadBase,
-// so ScaleFeeLoad returns the input fee unchanged (including the 0
-// short-circuit).
 func TestScaleFeeLoad_Identity(t *testing.T) {
 	tr := New()
 	cases := []uint64{0, 1, 10, 10000, 1<<32 + 7}
@@ -21,12 +20,13 @@ func TestScaleFeeLoad_Identity(t *testing.T) {
 	}
 }
 
-// TestScaleFeeLoad_NilTracker keeps fee handling safe when no tracker
-// is wired (services starting up, simulate paths during construction).
 func TestScaleFeeLoad_NilTracker(t *testing.T) {
 	got, err := ScaleFeeLoad(123, nil, false)
 	if err != nil || got != 123 {
 		t.Fatalf("nil tracker = (%d,%v); want (123,nil)", got, err)
+	}
+	if _, err := ScaleFeeLoad(uint64(math.MaxInt64)+1, nil, false); !errors.Is(err, ErrOverflow) {
+		t.Fatalf("nil tracker MaxInt64+1 error = %v, want ErrOverflow", err)
 	}
 }
 
@@ -44,7 +44,7 @@ func TestRaiseLowerLocalFee(t *testing.T) {
 	if changed := tr.RaiseLocalFee(); !changed {
 		t.Fatal("second raise must lift local fee above LoadBase")
 	}
-	want := LoadBase + LoadBase/FeeIncFraction
+	want := LoadBase + LoadBase/feeIncFraction
 	if tr.LocalFee() != want {
 		t.Fatalf("local fee after second raise = %d; want %d", tr.LocalFee(), want)
 	}
@@ -52,9 +52,7 @@ func TestRaiseLowerLocalFee(t *testing.T) {
 		t.Fatal("IsLoadedLocal must be true once localFee != LoadBase")
 	}
 
-	// Drive it back down. LowerLocalFee should clear the raise count
-	// and decay; running enough cycles must clamp at LoadBase, not
-	// below it.
+	// Repeated decay must clamp at LoadBase.
 	for range 10 {
 		tr.LowerLocalFee()
 	}
@@ -66,9 +64,6 @@ func TestRaiseLowerLocalFee(t *testing.T) {
 	}
 }
 
-// TestScaleFeeLoad_Loaded checks scaling under a raised local fee.
-// After two raises, local = LoadBase + LoadBase/4 = 320; ScaleFeeLoad
-// applies fee * 320 / 256 = fee * 5/4.
 func TestScaleFeeLoad_Loaded(t *testing.T) {
 	tr := New()
 	tr.RaiseLocalFee()
@@ -80,11 +75,15 @@ func TestScaleFeeLoad_Loaded(t *testing.T) {
 	if got != 1250 {
 		t.Fatalf("ScaleFeeLoad(1000) under 5/4 load = %d; want 1250", got)
 	}
+	got, err = ScaleFeeLoad(1, tr, false)
+	if err != nil {
+		t.Fatalf("ScaleFeeLoad truncation: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("truncated scaled fee = %d; want 1", got)
+	}
 }
 
-// TestScaleFeeLoad_UnlimitedBranch pins the unlimited carve-out: when
-// only local load is elevated and stays under 4x remote, an unlimited
-// caller pays the remote-rate factor.
 func TestScaleFeeLoad_UnlimitedBranch(t *testing.T) {
 	tr := New()
 	tr.RaiseLocalFee()
@@ -97,9 +96,7 @@ func TestScaleFeeLoad_UnlimitedBranch(t *testing.T) {
 		t.Fatalf("unlimited caller under moderate local load = %d; want identity 1000", got)
 	}
 
-	// Drive local above 4x remote. Each raise multiplies by 5/4, so
-	// after >=7 raises beyond the latch local >= 4*remote and the
-	// privileged carve-out drops away.
+	// The privileged carve-out ends at four times the remote factor.
 	for range 8 {
 		tr.RaiseLocalFee()
 	}
@@ -115,22 +112,98 @@ func TestScaleFeeLoad_UnlimitedBranch(t *testing.T) {
 	}
 }
 
-// TestScaleFeeLoad_Overflow protects the multiplication: a huge fee
-// times a large factor must surface ErrOverflow rather than silently
-// truncate.
 func TestScaleFeeLoad_Overflow(t *testing.T) {
 	tr := New()
 	for range 80 {
 		tr.RaiseLocalFee()
 	}
 	_, err := ScaleFeeLoad(^uint64(0), tr, false)
-	if err == nil {
-		t.Fatal("expected ErrOverflow on max-fee max-factor; got nil")
+	if !errors.Is(err, ErrOverflow) {
+		t.Fatalf("max-fee max-factor error = %v, want ErrOverflow", err)
 	}
 }
 
-// TestLoadFactorAggregates pins max(cluster, local, remote) and the
-// (max(local,remote), max(remote,cluster)) pair consumed by ScaleFeeLoad.
+func TestScaleFeeLoadSignedBoundary(t *testing.T) {
+	tr := New()
+
+	got, err := ScaleFeeLoad(math.MaxInt64, tr, false)
+	if err != nil || got != math.MaxInt64 {
+		t.Fatalf("MaxInt64 scale = (%d, %v), want (%d, nil)", got, err, uint64(math.MaxInt64))
+	}
+	if _, err := ScaleFeeLoad(uint64(math.MaxInt64)+1, tr, false); !errors.Is(err, ErrOverflow) {
+		t.Fatalf("MaxInt64+1 error = %v, want ErrOverflow", err)
+	}
+
+	tr.SetRemoteFee(512)
+	fee := uint64(math.MaxInt64 / 2)
+	got, err = ScaleFeeLoad(fee, tr, false)
+	if err != nil || got != uint64(math.MaxInt64)-1 {
+		t.Fatalf("wide product scale = (%d, %v), want (%d, nil)", got, err, uint64(math.MaxInt64)-1)
+	}
+
+	tr.SetRemoteFee(feeMax)
+	if _, err := ScaleFeeLoad(10_000_000_000_000, tr, false); !errors.Is(err, ErrOverflow) {
+		t.Fatalf("signed XRP overflow error = %v, want ErrOverflow", err)
+	}
+}
+
+func TestScaleFeeLoadAllocations(t *testing.T) {
+	tr := New()
+	tr.SetRemoteFee(512)
+	var (
+		got uint64
+		err error
+	)
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, err = ScaleFeeLoad(1_000_000, tr, false)
+	})
+	if err != nil || got != 2_000_000 {
+		t.Fatalf("scale = (%d, %v), want (2000000, nil)", got, err)
+	}
+	if allocs != 0 {
+		t.Fatalf("ScaleFeeLoad allocations = %v, want 0", allocs)
+	}
+}
+
+func TestIsLoadedCluster(t *testing.T) {
+	tr := New()
+	if tr.IsLoadedCluster() {
+		t.Fatal("fresh tracker must not be cluster-loaded")
+	}
+
+	tr.RaiseLocalFee()
+	if !tr.IsLoadedCluster() {
+		t.Fatal("armed first raise must report cluster load")
+	}
+	tr.LowerLocalFee()
+	if tr.IsLoadedCluster() {
+		t.Fatal("lowering the armed tracker must clear cluster load")
+	}
+
+	tr.SetClusterFee(LoadBase + 1)
+	if !tr.IsLoadedCluster() {
+		t.Fatal("cluster-only fee divergence must report cluster load")
+	}
+	tr.SetClusterFee(LoadBase)
+	if tr.IsLoadedCluster() {
+		t.Fatal("normal cluster fee must clear cluster load")
+	}
+	tr.SetClusterFee(0)
+	if !tr.IsLoadedCluster() {
+		t.Fatal("zero cluster fee is distinct from the normal factor")
+	}
+}
+
+func TestRaiseLocalFeeClampsRemoteOverflow(t *testing.T) {
+	tr := New()
+	tr.SetRemoteFee(3_435_973_837)
+	tr.RaiseLocalFee()
+	tr.RaiseLocalFee()
+	if got := tr.LocalFee(); got != feeMax {
+		t.Fatalf("local fee after overflowing remote raise = %d, want %d", got, feeMax)
+	}
+}
+
 func TestLoadFactorAggregates(t *testing.T) {
 	tr := New()
 	tr.SetRemoteFee(400)
@@ -144,7 +217,7 @@ func TestLoadFactorAggregates(t *testing.T) {
 	if lf := tr.LoadFactor(); lf != 500 {
 		t.Fatalf("load factor = %d; want max(cluster=300, local=500, remote=400) = 500", lf)
 	}
-	feeFactor, remFee := tr.ScalingFactors()
+	feeFactor, remFee := tr.scalingFactors()
 	if feeFactor != 500 || remFee != 400 {
 		t.Fatalf("scaling factors = (%d,%d); want (500,400)", feeFactor, remFee)
 	}

--- a/internal/feetrack/feetrack_test.go
+++ b/internal/feetrack/feetrack_test.go
@@ -52,7 +52,6 @@ func TestRaiseLowerLocalFee(t *testing.T) {
 		t.Fatal("IsLoadedLocal must be true once localFee != LoadBase")
 	}
 
-	// Repeated decay must clamp at LoadBase.
 	for range 10 {
 		tr.LowerLocalFee()
 	}

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -113,7 +113,7 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 	// in the consensus-critical engine preflight. A relayed or consensus-applied
 	// transaction carrying an oversized/invalid memo still applies, so this
 	// refusal cannot fork the ledger.
-	if localResult := tx.PassesLocalChecks(ptx.Parsed.GetCommon()); localResult != ter.TesSUCCESS {
+	if localResult := tx.PassesTransactionLocalChecks(ptx.Parsed); localResult != ter.TesSUCCESS {
 		return &SubmitResult{
 			Result:        localResult,
 			Message:       localResult.Message(),

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -445,6 +445,10 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 			Cluster: ft.ClusterFee(),
 		}
 	}
+	services.IsLoadedCluster = func() bool {
+		ft := ledgerSvcRef.FeeTrack()
+		return ft != nil && ft.IsLoadedCluster()
+	}
 
 	// Background ledger-integrity verification requires the same durable SHAMap
 	// family used by the ledger service. A private in-memory fallback cannot

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -91,17 +91,10 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 	}
 
 	// Recompute the cluster-fee median and forward it through the
-	// LoadFeeTrack sink. Mirrors rippled PeerImp.cpp:1175-1193: take
-	// the median of cluster-member LoadFees reported within the last
-	// clusterFeeWindow, then setClusterFee. An empty set (no fresh
-	// reports) yields no setClusterFee call — rippled also falls
-	// through with clusterFee=0 in that case but we leave the prior
-	// value intact, mirroring the more general "no signal → no
-	// change" pattern.
+	// LoadFeeTrack sink. An empty fresh set publishes zero.
 	if sink := o.clusterFeeSinkSnapshot(); sink != nil {
-		if fee, ok := o.cluster.MedianFee(time.Now().Add(-clusterFeeWindow)); ok {
-			sink(fee)
-		}
+		fee, _ := o.cluster.MedianFee(time.Now().Add(-clusterFeeWindow))
+		sink(fee)
 	}
 
 	// LoadSource gossip → resource manager. Mirrors rippled

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -126,6 +126,42 @@ func TestHandleClusterMessage_FiresClusterFeeSink(t *testing.T) {
 	assert.Equal(t, uint32(400), sinkCalls[0])
 }
 
+func TestHandleClusterMessage_ClearsStaleClusterFee(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	peerIdentity, err := NewIdentity()
+	require.NoError(t, err)
+	peerToken := NewPublicKeyTokenFromBtcec(peerIdentity.BtcecPublicKey())
+	peerNodePubEncoded, err := addresscodec.EncodeNodePublicKey(peerToken.Bytes())
+	require.NoError(t, err)
+
+	clusterReg := cluster.New()
+	require.NoError(t, clusterReg.Load([]string{peerNodePubEncoded + " peer"}))
+	clusterFee := uint32(777)
+	o := &Overlay{
+		peers:   make(map[PeerID]*Peer),
+		events:  make(chan Event, 8),
+		cluster: clusterReg,
+		clusterFeeSink: func(fee uint32) {
+			clusterFee = fee
+		},
+	}
+
+	peer := NewPeer(PeerID(34), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
+	peer.remotePubKey = peerToken
+	o.peers[peer.ID()] = peer
+	payload, err := message.Encode(&message.Cluster{})
+	require.NoError(t, err)
+
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeCluster),
+		Payload:     payload,
+	})
+
+	assert.Zero(t, clusterFee)
+}
+
 // TestHandleClusterMessage_ImportsLoadSourceGossip pins issue #765: a
 // TMCluster frame from a registered cluster peer must fold its
 // TMLoadSource entries into the resource manager (importConsumers),

--- a/internal/rpc/handlers/internal_error_test.go
+++ b/internal/rpc/handlers/internal_error_test.go
@@ -291,6 +291,15 @@ func (a *rpcInternalErrorAuditor) approvedInternalConstructorCalls(pkg *packages
 		if !ok {
 			continue
 		}
+		if function.Name.Name == "RpcErrorInvalidTransactionType" {
+			call, exact := exactInvalidTransactionTypeConstructor(pkg, function)
+			if !exact {
+				a.report(pkg, function, "RpcErrorInvalidTransactionType must remain the constrained transaction-type constructor")
+				continue
+			}
+			approved[call] = struct{}{}
+			continue
+		}
 		message, fixed := fixedInternalConstructorMessage(function.Name.Name)
 		if !fixed {
 			continue
@@ -309,6 +318,42 @@ func (a *rpcInternalErrorAuditor) approvedInternalConstructorCalls(pkg *packages
 		}
 	}
 	return approved
+}
+
+func exactInvalidTransactionTypeConstructor(pkg *packages.Package, function *ast.FuncDecl) (*ast.CallExpr, bool) {
+	object, _ := pkg.TypesInfo.Defs[function.Name].(*gotypes.Func)
+	if object == nil {
+		return nil, false
+	}
+	signature, _ := object.Type().(*gotypes.Signature)
+	if signature == nil || function.Recv != nil || function.Type.TypeParams != nil ||
+		signature.Params().Len() != 1 || !isBasicType(signature.Params().At(0).Type(), gotypes.Uint16) ||
+		signature.Results().Len() != 1 || !isRpcErrorPointer(signature.Results().At(0).Type()) ||
+		function.Body == nil || len(function.Body.List) != 1 {
+		return nil, false
+	}
+	result, ok := function.Body.List[0].(*ast.ReturnStmt)
+	if !ok || len(result.Results) != 1 {
+		return nil, false
+	}
+	call, ok := unparen(result.Results[0]).(*ast.CallExpr)
+	if !ok || !isRPCFunction(auditUsedFunction(pkg, call.Fun), "NewRpcError") || len(call.Args) != 4 ||
+		!isRPCInternalConstant(pkg.TypesInfo.Types[call.Args[0]].Value) ||
+		!isStringConstant(pkg, call.Args[1], "internal") ||
+		!isStringConstant(pkg, call.Args[2], "internal") {
+		return nil, false
+	}
+	messageCall, ok := unparen(call.Args[3]).(*ast.CallExpr)
+	if !ok || len(messageCall.Args) != 2 || !isNamedFunction(auditUsedFunction(pkg, messageCall.Fun), "fmt", "Sprintf") ||
+		!isStringConstant(pkg, messageCall.Args[0], "Exception while serializing transaction: Invalid transaction type %d") {
+		return nil, false
+	}
+	argument, ok := unparen(messageCall.Args[1]).(*ast.Ident)
+	return call, ok && pkg.TypesInfo.Uses[argument] == signature.Params().At(0)
+}
+
+func isNamedFunction(function *gotypes.Func, packagePath, name string) bool {
+	return function != nil && function.Pkg() != nil && function.Pkg().Path() == packagePath && function.Name() == name
 }
 
 func (a *rpcInternalErrorAuditor) approvedRpcErrorFactoryLiterals(pkg *packages.Package, file *ast.File) map[*ast.CompositeLit]struct{} {

--- a/internal/rpc/handlers/sign.go
+++ b/internal/rpc/handlers/sign.go
@@ -25,7 +25,7 @@ func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any,
 	}
 
 	// Sign the transaction using the shared helper
-	signed, rpcErr := signTransactionJSON(ctx.Context, ctx.Services, request.TxJson, request.signCredentials, request.Offline, ctx.Unlimited, ctx.ApiVersion, params, request.SignatureTarget)
+	signed, rpcErr := signTransactionJSON(ctx, request.TxJson, request.signCredentials, request.Offline, params, request.SignatureTarget)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -101,6 +101,9 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 	if rpcErr := validateSigningTxJSONShape(txMap); rpcErr != nil {
 		return nil, rpcErr
 	}
+	if rpcErr := rejectOnlineSigningWithoutCurrentLedger(ctx.Services, request.Offline, ctx.ApiVersion); rpcErr != nil {
+		return nil, rpcErr
+	}
 	if rpcErr := rejectSigningWhenLoaded(ctx.Services, ctx.Unlimited); rpcErr != nil {
 		return nil, rpcErr
 	}

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -98,6 +98,12 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 	if signatureTargetPresent && request.SignatureTarget != counterpartySignatureField {
 		return nil, types.RpcErrorInvalidParams(request.SignatureTarget)
 	}
+	if rpcErr := validateSigningTxJSONShape(txMap); rpcErr != nil {
+		return nil, rpcErr
+	}
+	if rpcErr := rejectSigningWhenLoaded(ctx.Services, ctx.Unlimited); rpcErr != nil {
+		return nil, rpcErr
+	}
 	if rpcErr := validateSignForPreConflict(txMap, params); rpcErr != nil {
 		return nil, rpcErr
 	}
@@ -186,20 +192,10 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 }
 
 func validateSignForPreConflict(txMap map[string]any, params json.RawMessage) *types.RpcError {
-	transactionType, ok := txMap["TransactionType"]
-	if !ok {
-		return types.RpcErrorMissingField("tx_json.TransactionType")
-	}
-	account, ok := txMap["Account"].(string)
-	if !ok || !addresscodec.IsValidClassicAddress(account) {
-		if _, present := txMap["Account"]; !present {
-			return types.RpcErrorSrcActMissing("Missing field 'tx_json.Account'.")
-		}
-		return types.RpcErrorSrcActMalformed("Invalid field 'tx_json.Account'.")
-	}
 	if _, ok := txMap["Fee"]; !ok {
 		return types.RpcErrorMissingField("tx_json.Fee")
 	}
+	transactionType := txMap["TransactionType"]
 	if transactionType != "Payment" {
 		return nil
 	}
@@ -240,6 +236,20 @@ func validateSignForPreConflict(txMap map[string]any, params json.RawMessage) *t
 		if !ok || err != nil || len(decoded) != 32 {
 			return types.RpcErrorDomainMalformed("Unable to parse 'DomainID'.")
 		}
+	}
+	return nil
+}
+
+func validateSigningTxJSONShape(txMap map[string]any) *types.RpcError {
+	if _, ok := txMap["TransactionType"]; !ok {
+		return types.RpcErrorMissingField("tx_json.TransactionType")
+	}
+	account, ok := txMap["Account"].(string)
+	if !ok || !addresscodec.IsValidClassicAddress(account) {
+		if _, present := txMap["Account"]; !present {
+			return types.RpcErrorSrcActMissing("Missing field 'tx_json.Account'.")
+		}
+		return types.RpcErrorSrcActMalformed("Invalid field 'tx_json.Account'.")
 	}
 	return nil
 }

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -221,9 +220,11 @@ func submitWithFailHard(ledger types.LedgerService, txJSON []byte, txBlob string
 //
 // rawParams carries the caller's request so fee_mult_max / fee_div_max are
 // read only when Fee is actually autofilled — rippled's checkFee returns
-// before inspecting them when Fee is present or offline. unlimited mirrors
-// rippled's isUnlimited(role) load-scaling carve-out.
-func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, txJSON json.RawMessage, creds signCredentials, offline bool, unlimited bool, apiVersion int, rawParams json.RawMessage, signatureTarget string) (*signResult, *types.RpcError) {
+// before inspecting them when Fee is present or offline.
+func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds signCredentials, offline bool, rawParams json.RawMessage, signatureTarget string) (*signResult, *types.RpcError) {
+	ctx := rpcCtx.Context
+	services := rpcCtx.Services
+	apiVersion := rpcCtx.ApiVersion
 	// Check if ledger service is available (needed for auto-filling fields)
 	if !offline && (services == nil || services.Ledger == nil) {
 		return nil, rpcInternalInvariantError("sign: ledger service unavailable")
@@ -277,7 +278,10 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 	if !ok || !types.IsValidClassicAddress(txAccount) {
 		return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx_json.Account'.")
 	}
-	if rpcErr := rejectSigningWhenLoaded(services, unlimited); rpcErr != nil {
+	if rpcErr := rejectOnlineSigningWithoutCurrentLedger(services, offline, apiVersion); rpcErr != nil {
+		return nil, rpcErr
+	}
+	if rpcErr := rejectSigningWhenLoaded(services, rpcCtx.Unlimited); rpcErr != nil {
 		return nil, rpcErr
 	}
 	if !signatureTargetPresent && txAccount != address {
@@ -342,7 +346,7 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 			if mErr != nil {
 				return nil, rpcInternalError("sign: fee probe marshaling failed", mErr)
 			}
-			fee, feeErr := services.Ledger.GetAutofillFee(probe, unlimited, feeOpts.Mult, feeOpts.Div)
+			fee, feeErr := services.Ledger.GetAutofillFee(probe, rpcCtx.Unlimited, feeOpts.Mult, feeOpts.Div)
 			if feeErr != nil {
 				var hfe *svcerr.HighFeeError
 				if errors.As(feeErr, &hfe) {
@@ -418,6 +422,17 @@ func rejectSigningWhenLoaded(services *types.ServiceContainer, unlimited bool) *
 		return nil
 	}
 	return types.RpcErrorTooBusy()
+}
+
+func rejectOnlineSigningWithoutCurrentLedger(services *types.ServiceContainer, offline bool, apiVersion int) *types.RpcError {
+	if offline || services == nil || services.Ledger == nil {
+		return nil
+	}
+	info := services.Ledger.GetServerInfo()
+	if info.Standalone || !types.ValidatedLedgerStale(info) {
+		return nil
+	}
+	return types.CurrentLedgerUnavailable(apiVersion)
 }
 
 func signatureTargetObject(txMap map[string]any, target string) (map[string]any, *types.RpcError) {

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -246,6 +246,9 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 	if err := json.Unmarshal(txJSON, &txMap); err != nil {
 		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid tx_json: %v", err))
 	}
+	if txMap == nil {
+		return nil, types.RpcErrorExpectedField("tx_json", "object")
+	}
 	// signature_target directs the signature into a nested inner object instead
 	// of the top level. Only CounterpartySignature is a valid target; any other
 	// field name is rejected with the field name as the message, matching
@@ -262,28 +265,25 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 	// belongs to the counterparty, so account and secret need not correspond:
 	// the caller's Account (the primary signer) is the source and its ownership
 	// is not checked.
-	srcAddress := address
-	if !signatureTargetPresent {
-		if txAccount, ok := txMap["Account"].(string); ok {
-			if !types.IsValidClassicAddress(txAccount) {
-				return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx_json.Account'.")
-			}
-			if txAccount != address {
-				return nil, types.RpcErrorInvalidParams("Account in tx_json does not match signing key")
-			}
-		} else {
-			txMap["Account"] = address
-		}
-	} else {
-		txAccount, ok := txMap["Account"].(string)
-		if !ok || txAccount == "" {
-			return nil, types.RpcErrorMissingField("tx_json.Account")
-		}
-		if !types.IsValidClassicAddress(txAccount) {
-			return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx_json.Account'.")
-		}
-		srcAddress = txAccount
+	if _, ok := txMap["TransactionType"]; !ok {
+		return nil, types.RpcErrorMissingField("tx_json.TransactionType")
 	}
+
+	txAccountValue, accountPresent := txMap["Account"]
+	if !accountPresent {
+		return nil, types.RpcErrorSrcActMissing("Missing field 'tx_json.Account'.")
+	}
+	txAccount, ok := txAccountValue.(string)
+	if !ok || !types.IsValidClassicAddress(txAccount) {
+		return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx_json.Account'.")
+	}
+	if rpcErr := rejectSigningWhenLoaded(services, unlimited); rpcErr != nil {
+		return nil, rpcErr
+	}
+	if !signatureTargetPresent && txAccount != address {
+		return nil, types.RpcErrorInvalidParams("Account in tx_json does not match signing key")
+	}
+	srcAddress := txAccount
 
 	// Fill in missing fields if not offline. Order matches rippled's
 	// transactionPreProcessImpl (TransactionSign.cpp:454-505): source
@@ -411,6 +411,13 @@ func signTransactionJSON(ctx context.Context, services *types.ServiceContainer, 
 		TxMap:  txMap,
 		TxBlob: txBlob,
 	}, nil
+}
+
+func rejectSigningWhenLoaded(services *types.ServiceContainer, unlimited bool) *types.RpcError {
+	if unlimited || services == nil || services.IsLoadedCluster == nil || !services.IsLoadedCluster() {
+		return nil
+	}
+	return types.RpcErrorTooBusy()
 }
 
 func signatureTargetObject(txMap map[string]any, target string) (map[string]any, *types.RpcError) {

--- a/internal/rpc/handlers/sign_helper_test.go
+++ b/internal/rpc/handlers/sign_helper_test.go
@@ -120,7 +120,7 @@ func TestSignTransactionJSONPreservesExplicitEmptyFields(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, rpcErr := signTransactionJSON(context.Background(), nil, test.txJSON, signCredentials{}, true, false, 2, params, "")
+			result, rpcErr := signTransactionJSON(&types.RpcContext{Context: context.Background(), ApiVersion: 2}, test.txJSON, signCredentials{}, true, params, "")
 			if rpcErr != nil {
 				t.Fatalf("sign transaction: %v", rpcErr)
 			}

--- a/internal/rpc/handlers/sign_helper_test.go
+++ b/internal/rpc/handlers/sign_helper_test.go
@@ -100,19 +100,19 @@ func TestSignTransactionJSONPreservesExplicitEmptyFields(t *testing.T) {
 	}{
 		{
 			name:     "empty array",
-			txJSON:   json.RawMessage(`{"TransactionType":"AccountSet","Fee":"10","Sequence":1,"Memos":[]}`),
+			txJSON:   json.RawMessage(`{"TransactionType":"AccountSet","Account":"r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7","Fee":"10","Sequence":1,"Memos":[]}`),
 			field:    "Memos",
 			expected: []any{},
 		},
 		{
 			name:     "empty blob",
-			txJSON:   json.RawMessage(`{"TransactionType":"AccountSet","Fee":"10","Sequence":1,"Domain":""}`),
+			txJSON:   json.RawMessage(`{"TransactionType":"AccountSet","Account":"r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7","Fee":"10","Sequence":1,"Domain":""}`),
 			field:    "Domain",
 			expected: "",
 		},
 		{
 			name:     "nested empty blob",
-			txJSON:   json.RawMessage(`{"TransactionType":"AccountSet","Fee":"10","Sequence":1,"Memos":[{"Memo":{"MemoData":""}}]}`),
+			txJSON:   json.RawMessage(`{"TransactionType":"AccountSet","Account":"r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7","Fee":"10","Sequence":1,"Memos":[{"Memo":{"MemoData":""}}]}`),
 			field:    "Memos",
 			expected: []any{map[string]any{"Memo": map[string]any{"MemoData": ""}}},
 		},

--- a/internal/rpc/handlers/signing_load_admission_test.go
+++ b/internal/rpc/handlers/signing_load_admission_test.go
@@ -1,0 +1,418 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/feetrack"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+const (
+	loadAdmissionSeedHex        = "00000000000000000000000000000000"
+	loadAdmissionSigningAccount = "r9zRhGr7b6xPekLvT6wP4qNdWMryaumZS7"
+	loadAdmissionAccount        = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	loadAdmissionSigner         = "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
+)
+
+type loadAdmissionLedger struct {
+	types.LedgerService
+	accountLookups   int
+	sequenceFills    int
+	feeFills         int
+	transactionSends int
+}
+
+func (l *loadAdmissionLedger) GetAccountInfo(context.Context, string, string) (*types.AccountInfo, error) {
+	l.accountLookups++
+	return &types.AccountInfo{Sequence: 1}, nil
+}
+
+func (l *loadAdmissionLedger) GetAutofillSequence(string, bool) (uint32, error) {
+	l.sequenceFills++
+	return 1, nil
+}
+
+func (l *loadAdmissionLedger) GetAutofillFee([]byte, bool, int, int) (uint64, error) {
+	l.feeFills++
+	return 10, nil
+}
+
+func (l *loadAdmissionLedger) SubmitTransaction([]byte, ...string) (*types.SubmitResult, error) {
+	l.transactionSends++
+	return &types.SubmitResult{}, nil
+}
+
+func (l *loadAdmissionLedger) GetCurrentFees() (uint64, uint64, uint64) {
+	return 10, 0, 0
+}
+
+func signingLoadParams(offline bool) json.RawMessage {
+	offlineField := ""
+	if offline {
+		offlineField = `,"offline":true`
+	}
+	return json.RawMessage(`{"seed_hex":"` + loadAdmissionSeedHex + `","key_type":"ed25519"` + offlineField + `,"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionSigningAccount + `","Sequence":1,"Fee":"10"}}`)
+}
+
+func assertTooBusy(t *testing.T, rpcErr *types.RpcError) {
+	t.Helper()
+	if rpcErr == nil || rpcErr.Code != types.RpcTOO_BUSY || rpcErr.ErrorString != "tooBusy" {
+		t.Fatalf("error = %#v, want rpcTOO_BUSY", rpcErr)
+	}
+}
+
+func TestSigningLoadAdmissionTracksLiveClusterAndLocalState(t *testing.T) {
+	track := feetrack.New()
+	services := &types.ServiceContainer{IsLoadedCluster: track.IsLoadedCluster}
+	if services.IsLoadedCluster() {
+		t.Fatal("new fee track reports loaded")
+	}
+
+	track.SetRemoteFee(feetrack.LoadBase + 1)
+	if services.IsLoadedCluster() {
+		t.Fatal("remote-only load reports cluster loaded")
+	}
+
+	track.SetClusterFee(feetrack.LoadBase + 1)
+	if !services.IsLoadedCluster() {
+		t.Fatal("cluster fee elevation was not observed through callback")
+	}
+	track.SetClusterFee(feetrack.LoadBase)
+	if services.IsLoadedCluster() {
+		t.Fatal("cleared cluster fee still reports loaded")
+	}
+
+	if changed := track.RaiseLocalFee(); changed {
+		t.Fatal("first local raise unexpectedly changed the fee")
+	}
+	if !services.IsLoadedCluster() {
+		t.Fatal("armed local raise was not observed through callback")
+	}
+}
+
+func TestSignRejectsClusterOnlyAndArmedLocalLoad(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		apply func(*feetrack.LoadFeeTrack)
+	}{
+		{
+			name: "cluster only",
+			apply: func(track *feetrack.LoadFeeTrack) {
+				track.SetClusterFee(feetrack.LoadBase + 1)
+			},
+		},
+		{
+			name: "armed local raise",
+			apply: func(track *feetrack.LoadFeeTrack) {
+				track.RaiseLocalFee()
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			track := feetrack.New()
+			test.apply(track)
+			ctx := &types.RpcContext{
+				Context:    context.Background(),
+				ApiVersion: 2,
+				Services:   &types.ServiceContainer{IsLoadedCluster: track.IsLoadedCluster},
+			}
+			_, rpcErr := (&SignMethod{}).Handle(ctx, signingLoadParams(true))
+			assertTooBusy(t, rpcErr)
+		})
+	}
+}
+
+func TestSignRejectsLoadedOnlineAndOfflineBeforeLedgerWork(t *testing.T) {
+	for _, offline := range []bool{false, true} {
+		t.Run(map[bool]string{false: "online", true: "offline"}[offline], func(t *testing.T) {
+			ledger := &loadAdmissionLedger{}
+			services := &types.ServiceContainer{
+				Ledger:          ledger,
+				IsLoadedCluster: func() bool { return true },
+			}
+			ctx := &types.RpcContext{
+				Context:    context.Background(),
+				ApiVersion: 2,
+				Services:   services,
+			}
+
+			_, rpcErr := (&SignMethod{}).Handle(ctx, signingLoadParams(offline))
+			assertTooBusy(t, rpcErr)
+			if ledger.accountLookups != 0 || ledger.sequenceFills != 0 || ledger.feeFills != 0 || ledger.transactionSends != 0 {
+				t.Fatalf("downstream calls = lookup:%d sequence:%d fee:%d submit:%d", ledger.accountLookups, ledger.sequenceFills, ledger.feeFills, ledger.transactionSends)
+			}
+		})
+	}
+}
+
+func TestSigningLoadAdmissionValidatesCredentialsAndShapeFirst(t *testing.T) {
+	tests := []struct {
+		name   string
+		params json.RawMessage
+		want   string
+	}{
+		{
+			name:   "credentials",
+			params: json.RawMessage(`{"offline":true,"tx_json":{"TransactionType":"AccountSet","Sequence":1,"Fee":"10"}}`),
+			want:   "invalidParams",
+		},
+		{
+			name:   "transaction type",
+			params: json.RawMessage(`{"seed_hex":"` + loadAdmissionSeedHex + `","key_type":"ed25519","offline":true,"tx_json":{"Sequence":1,"Fee":"10"}}`),
+			want:   "invalidParams",
+		},
+		{
+			name:   "account",
+			params: json.RawMessage(`{"seed_hex":"` + loadAdmissionSeedHex + `","key_type":"ed25519","offline":true,"tx_json":{"TransactionType":"AccountSet","Account":7,"Sequence":1,"Fee":"10"}}`),
+			want:   "srcActMalformed",
+		},
+		{
+			name:   "account missing",
+			params: json.RawMessage(`{"seed_hex":"` + loadAdmissionSeedHex + `","key_type":"ed25519","offline":true,"tx_json":{"TransactionType":"AccountSet","Sequence":1,"Fee":"10"}}`),
+			want:   "srcActMissing",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			loadChecks := 0
+			ctx := &types.RpcContext{
+				Context:    context.Background(),
+				ApiVersion: 2,
+				Services: &types.ServiceContainer{IsLoadedCluster: func() bool {
+					loadChecks++
+					return true
+				}},
+			}
+			_, rpcErr := (&SignMethod{}).Handle(ctx, test.params)
+			if rpcErr == nil || rpcErr.ErrorString != test.want {
+				t.Fatalf("error = %#v, want %s", rpcErr, test.want)
+			}
+			if loadChecks != 0 {
+				t.Fatalf("load callback called %d times before validation completed", loadChecks)
+			}
+		})
+	}
+}
+
+func TestSigningLoadAdmissionUnlimitedExemption(t *testing.T) {
+	loadChecks := 0
+	loaded := func() bool {
+		loadChecks++
+		return true
+	}
+
+	t.Run("sign", func(t *testing.T) {
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			ApiVersion: 2,
+			Unlimited:  true,
+			Services:   &types.ServiceContainer{IsLoadedCluster: loaded},
+		}
+		result, rpcErr := (&SignMethod{}).Handle(ctx, signingLoadParams(true))
+		if rpcErr != nil {
+			t.Fatalf("unlimited offline sign: %v", rpcErr)
+		}
+		if result == nil {
+			t.Fatal("unlimited offline sign returned no result")
+		}
+	})
+
+	t.Run("sign for", func(t *testing.T) {
+		params := json.RawMessage(`{"account":"` + loadAdmissionSigner + `","seed_hex":"` + loadAdmissionSeedHex + `","key_type":"ed25519","tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			ApiVersion: 2,
+			Unlimited:  true,
+			Services:   &types.ServiceContainer{IsLoadedCluster: loaded},
+		}
+		_, rpcErr := (&SignForMethod{}).Handle(ctx, params)
+		if rpcErr != nil {
+			t.Fatalf("unlimited sign_for: %v", rpcErr)
+		}
+	})
+
+	t.Run("submit multisigned", func(t *testing.T) {
+		params := json.RawMessage(`{"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			ApiVersion: 2,
+			Unlimited:  true,
+			Services: &types.ServiceContainer{
+				Ledger:          &loadAdmissionLedger{},
+				IsLoadedCluster: loaded,
+			},
+		}
+		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+		if rpcErr != nil && rpcErr.ErrorString == "tooBusy" {
+			t.Fatalf("unlimited submit_multisigned was load-gated: %#v", rpcErr)
+		}
+	})
+
+	if loadChecks != 0 {
+		t.Fatalf("unlimited requests consulted load callback %d times", loadChecks)
+	}
+}
+
+func TestCredentialedSubmitAndMultisignMethodsRejectLoaded(t *testing.T) {
+	t.Run("credentialed submit", func(t *testing.T) {
+		ledger := &loadAdmissionLedger{}
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			ApiVersion: 2,
+			Services: &types.ServiceContainer{
+				Ledger:          ledger,
+				IsLoadedCluster: func() bool { return true },
+			},
+		}
+		_, rpcErr := (&SubmitMethod{}).Handle(ctx, signingLoadParams(false))
+		assertTooBusy(t, rpcErr)
+		if ledger.accountLookups != 0 || ledger.sequenceFills != 0 || ledger.feeFills != 0 || ledger.transactionSends != 0 {
+			t.Fatalf("credentialed submit performed downstream work: %#v", ledger)
+		}
+	})
+
+	t.Run("sign for", func(t *testing.T) {
+		params := json.RawMessage(`{"account":"` + loadAdmissionSigner + `","seed_hex":"` + loadAdmissionSeedHex + `","key_type":"ed25519","tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			ApiVersion: 2,
+			Services:   &types.ServiceContainer{IsLoadedCluster: func() bool { return true }},
+		}
+		_, rpcErr := (&SignForMethod{}).Handle(ctx, params)
+		assertTooBusy(t, rpcErr)
+	})
+
+	t.Run("submit multisigned", func(t *testing.T) {
+		ledger := &loadAdmissionLedger{}
+		params := json.RawMessage(`{"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			ApiVersion: 2,
+			Services: &types.ServiceContainer{
+				Ledger:          ledger,
+				IsLoadedCluster: func() bool { return true },
+			},
+		}
+		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+		assertTooBusy(t, rpcErr)
+		if ledger.accountLookups != 0 {
+			t.Fatalf("account lookups = %d, want 0", ledger.accountLookups)
+		}
+	})
+}
+
+func TestMultisignLoadAdmissionValidationPrecedence(t *testing.T) {
+	t.Run("sign for credentials", func(t *testing.T) {
+		loadChecks := 0
+		params := json.RawMessage(`{"account":"` + loadAdmissionSigner + `","tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			ApiVersion: 2,
+			Services: &types.ServiceContainer{IsLoadedCluster: func() bool {
+				loadChecks++
+				return true
+			}},
+		}
+		_, rpcErr := (&SignForMethod{}).Handle(ctx, params)
+		if rpcErr == nil || rpcErr.ErrorString != "invalidParams" {
+			t.Fatalf("error = %#v, want credential validation error", rpcErr)
+		}
+		if loadChecks != 0 {
+			t.Fatalf("load callback called %d times", loadChecks)
+		}
+	})
+
+	t.Run("sign for transaction shape", func(t *testing.T) {
+		loadChecks := 0
+		params := json.RawMessage(`{"account":"` + loadAdmissionSigner + `","seed_hex":"` + loadAdmissionSeedHex + `","key_type":"ed25519","tx_json":{"Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
+		ctx := &types.RpcContext{
+			Context:    context.Background(),
+			ApiVersion: 2,
+			Services: &types.ServiceContainer{IsLoadedCluster: func() bool {
+				loadChecks++
+				return true
+			}},
+		}
+		_, rpcErr := (&SignForMethod{}).Handle(ctx, params)
+		if rpcErr == nil || rpcErr.ErrorString != "invalidParams" {
+			t.Fatalf("error = %#v, want transaction validation error", rpcErr)
+		}
+		if loadChecks != 0 {
+			t.Fatalf("load callback called %d times", loadChecks)
+		}
+	})
+
+	t.Run("submit multisigned transaction shape", func(t *testing.T) {
+		loadChecks := 0
+		ledger := &loadAdmissionLedger{}
+		params := json.RawMessage(`{"tx_json":{"Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
+		ctx := &types.RpcContext{
+			Context: context.Background(),
+			Services: &types.ServiceContainer{
+				Ledger: ledger,
+				IsLoadedCluster: func() bool {
+					loadChecks++
+					return true
+				},
+			},
+		}
+		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+		if rpcErr == nil || rpcErr.ErrorString != "invalidParams" {
+			t.Fatalf("error = %#v, want transaction validation error", rpcErr)
+		}
+		if loadChecks != 0 || ledger.accountLookups != 0 {
+			t.Fatalf("load checks = %d, account lookups = %d", loadChecks, ledger.accountLookups)
+		}
+	})
+
+	t.Run("submit multisigned sequence value", func(t *testing.T) {
+		ledger := &loadAdmissionLedger{}
+		params := json.RawMessage(`{"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":"bad","Fee":"10","SigningPubKey":""}}`)
+		ctx := &types.RpcContext{
+			Context: context.Background(),
+			Services: &types.ServiceContainer{
+				Ledger:          ledger,
+				IsLoadedCluster: func() bool { return true },
+			},
+		}
+		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+		assertTooBusy(t, rpcErr)
+		if ledger.accountLookups != 0 {
+			t.Fatalf("account lookups = %d, want 0", ledger.accountLookups)
+		}
+	})
+}
+
+func TestSubmitWithoutCredentialsDoesNotConsultSigningLoad(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		params json.RawMessage
+	}{
+		{name: "blob", params: json.RawMessage(`{"tx_blob":"00"}`)},
+		{name: "unsigned json", params: json.RawMessage(`{"tx_json":{"TransactionType":"AccountSet"}}`)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			loadChecks := 0
+			ctx := &types.RpcContext{
+				Context: context.Background(),
+				Services: &types.ServiceContainer{
+					Ledger: &loadAdmissionLedger{},
+					IsLoadedCluster: func() bool {
+						loadChecks++
+						return true
+					},
+				},
+			}
+			_, rpcErr := (&SubmitMethod{}).Handle(ctx, test.params)
+			if rpcErr != nil && rpcErr.ErrorString == "tooBusy" {
+				t.Fatalf("unsigned submit was load-gated: %#v", rpcErr)
+			}
+			if loadChecks != 0 {
+				t.Fatalf("load callback called %d times", loadChecks)
+			}
+		})
+	}
+}

--- a/internal/rpc/handlers/signing_load_admission_test.go
+++ b/internal/rpc/handlers/signing_load_admission_test.go
@@ -1,10 +1,13 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
@@ -22,6 +25,7 @@ type loadAdmissionLedger struct {
 	sequenceFills    int
 	feeFills         int
 	transactionSends int
+	serverInfo       *types.LedgerServerInfo
 }
 
 func (l *loadAdmissionLedger) GetAccountInfo(context.Context, string, string) (*types.AccountInfo, error) {
@@ -46,6 +50,13 @@ func (l *loadAdmissionLedger) SubmitTransaction([]byte, ...string) (*types.Submi
 
 func (l *loadAdmissionLedger) GetCurrentFees() (uint64, uint64, uint64) {
 	return 10, 0, 0
+}
+
+func (l *loadAdmissionLedger) GetServerInfo() types.LedgerServerInfo {
+	if l.serverInfo != nil {
+		return *l.serverInfo
+	}
+	return types.LedgerServerInfo{Standalone: true}
 }
 
 func signingLoadParams(offline bool) json.RawMessage {
@@ -144,6 +155,69 @@ func TestSignRejectsLoadedOnlineAndOfflineBeforeLedgerWork(t *testing.T) {
 				t.Fatalf("downstream calls = lookup:%d sequence:%d fee:%d submit:%d", ledger.accountLookups, ledger.sequenceFills, ledger.feeFills, ledger.transactionSends)
 			}
 		})
+	}
+}
+
+func TestOnlineSigningRejectsStaleLedgerBeforeLoad(t *testing.T) {
+	methods := []struct {
+		name   string
+		params json.RawMessage
+		handle func(*types.RpcContext, json.RawMessage) (any, *types.RpcError)
+	}{
+		{
+			name:   "sign",
+			params: signingLoadParams(false),
+			handle: (&SignMethod{}).Handle,
+		},
+		{
+			name:   "sign for",
+			params: json.RawMessage(`{"account":"` + loadAdmissionSigner + `","seed_hex":"` + loadAdmissionSeedHex + `","key_type":"ed25519","tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`),
+			handle: (&SignForMethod{}).Handle,
+		},
+	}
+
+	apiVersions := []struct {
+		name    string
+		version int
+	}{
+		{name: "api v1", version: types.ApiVersion1},
+		{name: "api v2", version: types.ApiVersion2},
+	}
+	for _, method := range methods {
+		for _, api := range apiVersions {
+			t.Run(method.name+" "+api.name, func(t *testing.T) {
+				ledger := &loadAdmissionLedger{serverInfo: &types.LedgerServerInfo{}}
+				loadChecks := 0
+				ctx := &types.RpcContext{
+					Context:    context.Background(),
+					ApiVersion: api.version,
+					Services: &types.ServiceContainer{
+						Ledger: ledger,
+						IsLoadedCluster: func() bool {
+							loadChecks++
+							return true
+						},
+					},
+				}
+
+				_, rpcErr := method.handle(ctx, method.params)
+				if rpcErr == nil {
+					t.Fatal("expected stale-ledger error")
+				}
+				wantCode := types.RpcNOT_SYNCED
+				wantToken := "notSynced"
+				if api.version == types.ApiVersion1 {
+					wantCode = types.RpcNO_CURRENT
+					wantToken = "noCurrent"
+				}
+				if rpcErr.Code != wantCode || rpcErr.ErrorString != wantToken {
+					t.Fatalf("error = %#v, want %s (%d)", rpcErr, wantToken, wantCode)
+				}
+				if loadChecks != 0 || ledger.accountLookups != 0 {
+					t.Fatalf("load checks = %d, account lookups = %d", loadChecks, ledger.accountLookups)
+				}
+			})
+		}
 	}
 }
 
@@ -382,6 +456,233 @@ func TestMultisignLoadAdmissionValidationPrecedence(t *testing.T) {
 		assertTooBusy(t, rpcErr)
 		if ledger.accountLookups != 0 {
 			t.Fatalf("account lookups = %d, want 0", ledger.accountLookups)
+		}
+	})
+}
+
+func TestSubmitMultisignedUsesCanonicalFieldParsingAfterAdmission(t *testing.T) {
+	t.Run("numeric string sequence and numeric fee", func(t *testing.T) {
+		ledger := &loadAdmissionLedger{}
+		params := json.RawMessage(`{"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":"1","Fee":50,"SigningPubKey":""}}`)
+		ctx := &types.RpcContext{
+			Context:  context.Background(),
+			Services: &types.ServiceContainer{Ledger: ledger},
+		}
+
+		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+		if rpcErr == nil || rpcErr.Message != "Missing field 'tx_json.Signers'." {
+			t.Fatalf("error = %#v, want missing Signers after canonical parsing", rpcErr)
+		}
+	})
+
+	t.Run("sequence parse precedes transaction signature", func(t *testing.T) {
+		ledger := &loadAdmissionLedger{}
+		params := json.RawMessage(`{"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":"4294967296","Fee":"10","SigningPubKey":"","TxnSignature":""}}`)
+		ctx := &types.RpcContext{
+			Context:  context.Background(),
+			Services: &types.ServiceContainer{Ledger: ledger},
+		}
+
+		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+		if rpcErr == nil || rpcErr.ErrorString != "invalidParams" || rpcErr.Message != "Field 'tx_json.Sequence' has invalid data." {
+			t.Fatalf("error = %#v, want Sequence parse failure", rpcErr)
+		}
+	})
+
+	t.Run("numeric transaction type", func(t *testing.T) {
+		ledger := &loadAdmissionLedger{}
+		params := json.RawMessage(`{"tx_json":{"TransactionType":3,"Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
+		ctx := &types.RpcContext{
+			Context:  context.Background(),
+			Services: &types.ServiceContainer{Ledger: ledger},
+		}
+
+		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+		if rpcErr == nil || rpcErr.Message != "Missing field 'tx_json.Signers'." {
+			t.Fatalf("error = %#v, want missing Signers after numeric TransactionType", rpcErr)
+		}
+	})
+
+	t.Run("numeric string transaction type", func(t *testing.T) {
+		ledger := &loadAdmissionLedger{}
+		params := json.RawMessage(`{"tx_json":{"TransactionType":"3","Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
+		ctx := &types.RpcContext{
+			Context:  context.Background(),
+			Services: &types.ServiceContainer{Ledger: ledger},
+		}
+
+		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+		if rpcErr == nil || rpcErr.Message != "Missing field 'tx_json.Signers'." {
+			t.Fatalf("error = %#v, want missing Signers after numeric-string TransactionType", rpcErr)
+		}
+	})
+
+	t.Run("local checks precede transaction signature", func(t *testing.T) {
+		ledger := &loadAdmissionLedger{}
+		params, err := json.Marshal(map[string]any{"tx_json": map[string]any{
+			"TransactionType": "AccountSet",
+			"Account":         loadAdmissionAccount,
+			"Sequence":        1,
+			"Fee":             "10",
+			"SigningPubKey":   "",
+			"TxnSignature":    "",
+			"Memos": []any{map[string]any{"Memo": map[string]any{
+				"MemoData": strings.Repeat("AA", 1020),
+			}}},
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := &types.RpcContext{
+			Context:  context.Background(),
+			Services: &types.ServiceContainer{Ledger: ledger},
+		}
+
+		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+		if rpcErr == nil || rpcErr.ErrorString != "invalidParams" || rpcErr.Message != "The memo exceeds the maximum allowed size." {
+			t.Fatalf("error = %#v, want local-check failure", rpcErr)
+		}
+	})
+
+	t.Run("template errors are returned verbatim before transaction signature", func(t *testing.T) {
+		ledger := &loadAdmissionLedger{}
+		params := json.RawMessage(`{"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Destination":"` + loadAdmissionSigner + `","Sequence":1,"Fee":"10","SigningPubKey":"","TxnSignature":""}}`)
+		ctx := &types.RpcContext{
+			Context:  context.Background(),
+			Services: &types.ServiceContainer{Ledger: ledger},
+		}
+
+		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+		if rpcErr == nil || rpcErr.ErrorString != "invalidParams" || rpcErr.Message != "Field 'Destination' found in disallowed location." {
+			t.Fatalf("error = %#v, want verbatim template failure", rpcErr)
+		}
+	})
+
+	t.Run("local MPT fee rejection precedes transaction signature", func(t *testing.T) {
+		ledger := &loadAdmissionLedger{}
+		params, err := json.Marshal(map[string]any{"tx_json": map[string]any{
+			"TransactionType": "AccountSet",
+			"Account":         loadAdmissionAccount,
+			"Sequence":        1,
+			"Fee": map[string]any{
+				"value":           "10",
+				"mpt_issuance_id": strings.Repeat("A", 48),
+			},
+			"SigningPubKey": "",
+			"TxnSignature":  "",
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := &types.RpcContext{
+			Context:  context.Background(),
+			Services: &types.ServiceContainer{Ledger: ledger},
+		}
+
+		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+		if rpcErr == nil || rpcErr.ErrorString != "invalidParams" || rpcErr.Message != "Amount can not be MPT." {
+			t.Fatalf("error = %#v, want local MPT rejection", rpcErr)
+		}
+	})
+
+	t.Run("issued fee uses the XRP fee error", func(t *testing.T) {
+		ledger := &loadAdmissionLedger{}
+		params := json.RawMessage(`{"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"1/USD/` + loadAdmissionSigner + `","SigningPubKey":"","TxnSignature":""}}`)
+		ctx := &types.RpcContext{
+			Context:  context.Background(),
+			Services: &types.ServiceContainer{Ledger: ledger},
+		}
+
+		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+		if rpcErr == nil || rpcErr.ErrorString != "invalidParams" || rpcErr.Message != "Invalid Fee field.  Fees must be specified in XRP." {
+			t.Fatalf("error = %#v, want XRP fee rejection", rpcErr)
+		}
+	})
+
+	t.Run("sorts signers by account ID", func(t *testing.T) {
+		accounts := []string{loadAdmissionSigner, loadAdmissionSigningAccount}
+		_, firstID, err := addresscodec.DecodeClassicAddressToAccountID(accounts[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, secondID, err := addresscodec.DecodeClassicAddressToAccountID(accounts[1])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Compare(firstID, secondID) < 0 {
+			accounts[0], accounts[1] = accounts[1], accounts[0]
+		}
+		signers := make([]any, len(accounts))
+		for i, account := range accounts {
+			signers[i] = map[string]any{"Signer": map[string]any{
+				"Account":       account,
+				"SigningPubKey": "",
+				"TxnSignature":  "",
+			}}
+		}
+		params, err := json.Marshal(map[string]any{"tx_json": map[string]any{
+			"TransactionType": "AccountSet",
+			"Account":         loadAdmissionAccount,
+			"Sequence":        1,
+			"Fee":             "10",
+			"SigningPubKey":   "",
+			"Signers":         signers,
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := &types.RpcContext{
+			Context:  context.Background(),
+			Services: &types.ServiceContainer{Ledger: &loadAdmissionLedger{}},
+		}
+
+		result, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+		if rpcErr != nil {
+			t.Fatalf("submit_multisigned: %#v", rpcErr)
+		}
+		response := result.(map[string]any)
+		txJSON := response["tx_json"].(map[string]any)
+		gotSigners := txJSON["Signers"].([]any)
+		previousID := []byte(nil)
+		for _, wrapped := range gotSigners {
+			account := wrapped.(map[string]any)["Signer"].(map[string]any)["Account"].(string)
+			_, accountID, err := addresscodec.DecodeClassicAddressToAccountID(account)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if previousID != nil && bytes.Compare(previousID, accountID) >= 0 {
+				t.Fatalf("Signers not sorted by AccountID: %v", gotSigners)
+			}
+			previousID = accountID
+		}
+	})
+
+	t.Run("delegate is the fee payer", func(t *testing.T) {
+		ledger := &loadAdmissionLedger{}
+		params, err := json.Marshal(map[string]any{"tx_json": map[string]any{
+			"TransactionType": "AccountSet",
+			"Account":         loadAdmissionAccount,
+			"Delegate":        loadAdmissionSigner,
+			"Sequence":        1,
+			"Fee":             "10",
+			"SigningPubKey":   "",
+			"Signers": []any{map[string]any{"Signer": map[string]any{
+				"Account":       loadAdmissionSigner,
+				"SigningPubKey": "",
+				"TxnSignature":  "",
+			}}},
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := &types.RpcContext{
+			Context:  context.Background(),
+			Services: &types.ServiceContainer{Ledger: ledger},
+		}
+
+		_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+		if rpcErr == nil || rpcErr.Message != "A Signer may not be the transaction's Account ("+loadAdmissionSigner+")." {
+			t.Fatalf("error = %#v, want delegated fee-payer rejection", rpcErr)
 		}
 	})
 }

--- a/internal/rpc/handlers/stparsed.go
+++ b/internal/rpc/handlers/stparsed.go
@@ -11,6 +11,7 @@ import (
 
 	binarycodecdefs "github.com/LeJamon/go-xrpl/codec/binarycodec/definitions"
 	binarycodectypes "github.com/LeJamon/go-xrpl/codec/binarycodec/types"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
@@ -223,13 +224,40 @@ func validateSerializedLeaf(
 	case "UInt8":
 		return validateUInt8(name, value, path, defs)
 	case "UInt16":
-		return validateUInt16(value, path, defs)
+		return validateUInt16(name, value, path, defs)
 	case "UInt32":
 		return validateUInt32(name, value, path, defs)
 	case "UInt64":
 		return validateUInt64(name, value, path)
 	case "Int32":
 		return validateInt32(value, path)
+	case "Amount":
+		switch value.(type) {
+		case string, json.Number:
+			raw, err := json.Marshal(value)
+			if err != nil {
+				return value, fmt.Sprintf("Field '%s' has invalid data.", path)
+			}
+			amount, err := state.AmountFromJSON(raw)
+			if err != nil {
+				return value, fmt.Sprintf("Field '%s' has invalid data.", path)
+			}
+			switch {
+			case amount.IsNative():
+				value = amount.Value()
+			case amount.IsMPT():
+				value = map[string]any{
+					"value":           amount.Value(),
+					"mpt_issuance_id": amount.MPTIssuanceID(),
+				}
+			default:
+				value = map[string]any{
+					"value":    amount.Value(),
+					"currency": amount.Currency,
+					"issuer":   amount.Issuer,
+				}
+			}
+		}
 	case "Hash128":
 		return validateHash(value, path, 16)
 	case "Hash160":
@@ -292,13 +320,20 @@ func validateUInt8(name string, value any, path string, defs *binarycodecdefs.De
 	return uint8(n), ""
 }
 
-func validateUInt16(value any, path string, defs *binarycodecdefs.Definitions) (any, string) {
+func validateUInt16(name string, value any, path string, defs *binarycodecdefs.Definitions) (any, string) {
 	if text, ok := value.(string); ok {
-		if code, err := defs.TransactionTypeCode(text); err == nil {
-			return uint16(code), ""
+		switch name {
+		case "TransactionType":
+			if code, err := defs.TransactionTypeCode(text); err == nil {
+				return uint16(code), ""
+			}
+		case "LedgerEntryType":
+			if code, err := defs.LedgerEntryTypeCode(text); err == nil {
+				return uint16(code), ""
+			}
 		}
-		if code, err := defs.LedgerEntryTypeCode(text); err == nil {
-			return uint16(code), ""
+		if text == "" || text[0] < '0' || text[0] > '9' {
+			return value, fmt.Sprintf("Field '%s' has invalid data.", path)
 		}
 		n, err := strconv.ParseUint(text, 10, 16)
 		if err != nil {

--- a/internal/rpc/handlers/stparsed_test.go
+++ b/internal/rpc/handlers/stparsed_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	binarycodecdefs "github.com/LeJamon/go-xrpl/codec/binarycodec/definitions"
@@ -31,6 +32,18 @@ func TestSerializedFieldParseMessageLeafValidation(t *testing.T) {
 			field:   "CloseResolution",
 			value:   json.Number("256"),
 			message: "Field 'tx_json.CloseResolution' is out of range.",
+		},
+		{
+			name:    "transaction type does not accept ledger entry name",
+			field:   "TransactionType",
+			value:   "AccountRoot",
+			message: "Field 'tx_json.TransactionType' has invalid data.",
+		},
+		{
+			name:    "UInt16 string does not accept leading plus",
+			field:   "SignerWeight",
+			value:   "+1",
+			message: "Field 'tx_json.SignerWeight' has invalid data.",
 		},
 		{
 			name:    "hash bad type",
@@ -74,6 +87,34 @@ func TestSerializedFieldParseMessageLeafValidation(t *testing.T) {
 			value:   []any{},
 			message: "Field 'tx_json.Amount' has invalid data.",
 		},
+		{
+			name:  "numeric amount",
+			field: "Fee",
+			value: json.Number("50"),
+		},
+		{
+			name:    "numeric amount outside JSON uint range",
+			field:   "Fee",
+			value:   json.Number("4294967296"),
+			message: "Field 'tx_json.Fee' has invalid data.",
+		},
+		{
+			name:    "numeric amount exponent",
+			field:   "Fee",
+			value:   json.Number("1e2"),
+			message: "Field 'tx_json.Fee' has invalid data.",
+		},
+		{
+			name:  "string amount integral exponent",
+			field: "Fee",
+			value: "1e2",
+		},
+		{
+			name:    "string amount leading zero",
+			field:   "Fee",
+			value:   "010",
+			message: "Field 'tx_json.Fee' has invalid data.",
+		},
 	}
 
 	defs := binarycodecdefs.Get()
@@ -84,6 +125,31 @@ func TestSerializedFieldParseMessageLeafValidation(t *testing.T) {
 				t.Fatalf("message = %q, want %q", got, test.message)
 			}
 		})
+	}
+}
+
+func TestSerializedFieldParseMessageCanonicalizesNativeAmount(t *testing.T) {
+	object := map[string]any{"Fee": "1e2"}
+	if message := serializedFieldParseMessage(object, "tx_json", binarycodecdefs.Get()); message != "" {
+		t.Fatalf("message = %q, want success", message)
+	}
+	if got := object["Fee"]; got != "100" {
+		t.Fatalf("Fee = %#v, want canonical drops string", got)
+	}
+}
+
+func TestSerializedFieldParseMessageCanonicalizesIssuedAmountString(t *testing.T) {
+	object := map[string]any{"Amount": "1/USD/rMRxj8jED6ZCjtjgFxB4cz1MGVNtYqCEyS"}
+	if message := serializedFieldParseMessage(object, "tx_json", binarycodecdefs.Get()); message != "" {
+		t.Fatalf("message = %q, want success", message)
+	}
+	want := map[string]any{
+		"value":    "1",
+		"currency": "USD",
+		"issuer":   "rMRxj8jED6ZCjtjgFxB4cz1MGVNtYqCEyS",
+	}
+	if got := object["Amount"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Amount = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -60,7 +60,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 	} else if hasSigningCreds {
 		// Sign-and-submit path: sign the transaction first, then submit the blob.
 		// This matches rippled's behavior in doSubmit() when tx_blob is absent.
-		signed, rpcErr := signTransactionJSON(ctx.Context, ctx.Services, request.TxJson, request.signCredentials, request.Offline, ctx.Unlimited, ctx.ApiVersion, params, request.SignatureTarget)
+		signed, rpcErr := signTransactionJSON(ctx, request.TxJson, request.signCredentials, request.Offline, params, request.SignatureTarget)
 		if rpcErr != nil {
 			return nil, rpcErr
 		}

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -1,14 +1,17 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	binarycodecdefs "github.com/LeJamon/go-xrpl/codec/binarycodec/definitions"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/internal/tx"
 )
 
 // SubmitMultisignedMethod handles the submit_multisigned RPC method
@@ -36,7 +39,9 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 
 	// Parse the transaction JSON
 	var txMap map[string]any
-	if err := json.Unmarshal(request.TxJson, &txMap); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(request.TxJson))
+	decoder.UseNumber()
+	if err := decoder.Decode(&txMap); err != nil {
 		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid tx_json: %v", err))
 	}
 
@@ -83,7 +88,42 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, rpcInternalError("submit_multisigned: source account lookup failed", err)
 	}
 
-	// --- Post-serialization validation (rippled TransactionSign.cpp:1325-1391) ---
+	if rpcErr := validateSignForPreConflict(txMap, params); rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	definitions := binarycodecdefs.Get()
+	if parseMessage := serializedFieldParseMessage(txMap, "tx_json", definitions); parseMessage != "" {
+		return nil, types.RpcErrorInvalidParams(parseMessage)
+	}
+	transactionTypeCode, ok := txMap["TransactionType"].(uint16)
+	if !ok {
+		return nil, types.RpcErrorInvalidParams("Field 'tx_json.TransactionType' has invalid data.")
+	}
+	transactionTypeName, err := definitions.TransactionTypeName(int32(transactionTypeCode))
+	if err != nil {
+		return nil, types.NewRpcError(
+			types.RpcINTERNAL,
+			"internal",
+			"internal",
+			fmt.Sprintf("Exception while serializing transaction: Invalid transaction type %d", transactionTypeCode),
+		)
+	}
+	txMap["TransactionType"] = transactionTypeName
+	transactionType, _ := tx.TypeFromName(transactionTypeName)
+	if err := tx.ValidateTemplateFields(transactionType, txMap); err != nil {
+		return nil, types.RpcErrorInvalidParams(err.Error())
+	}
+	if reason := tx.TransactionMapLocalChecksFailureReason(transactionType, txMap); reason != "" {
+		return nil, types.RpcErrorInvalidParams(reason)
+	}
+	if _, ok := txMap["Fee"].(string); !ok {
+		return nil, types.RpcErrorInvalidParams("Invalid Fee field.  Fees must be specified in XRP.")
+	}
+	_, rpcErr := parseTransactionForSigning(txMap)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
 
 	// TxnSignature must NOT be present on a multi-signed transaction.
 	// Matches rippled: rpcError(rpcSIGNING_MALFORMED) -> code 63, "signingMalformed"
@@ -91,13 +131,10 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, types.RpcErrorSigningMalformed()
 	}
 
-	// Fee must be present, must be XRP drops (string of digits), and must be > 0.
+	// Fee must be XRP drops and must be > 0.
 	// Matches rippled: "Invalid Fee field.  Fees must be specified in XRP." /
 	// "Invalid Fee field.  Fees must be greater than zero."
-	feeVal, feePresent := txMap["Fee"]
-	if !feePresent {
-		return nil, types.RpcErrorInvalidParams("Invalid Fee field.  Fees must be specified in XRP.")
-	}
+	feeVal := txMap["Fee"]
 	feeStr, ok := feeVal.(string)
 	if !ok {
 		return nil, types.RpcErrorInvalidParams("Invalid Fee field.  Fees must be specified in XRP.")
@@ -110,71 +147,29 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, types.RpcErrorInvalidParams("Invalid Fee field.  Fees must be greater than zero.")
 	}
 
-	// Sequence value parsing occurs after load admission and account lookup.
-	switch seq := txMap["Sequence"].(type) {
-	case float64:
-		if seq < 0 || seq != float64(int64(seq)) {
-			return nil, types.RpcErrorInvalidField("tx_json.Sequence")
-		}
-	case json.Number:
-		if _, err := seq.Int64(); err != nil {
-			return nil, types.RpcErrorInvalidField("tx_json.Sequence")
-		}
-	default:
-		return nil, types.RpcErrorInvalidField("tx_json.Sequence")
-	}
-
 	// Check that Signers array exists and is not empty
-	signers, ok := txMap["Signers"].([]any)
+	signersValue, signersPresent := txMap["Signers"]
+	if !signersPresent {
+		return nil, types.RpcErrorMissingField("tx_json.Signers")
+	}
+	signers, ok := signersValue.([]any)
 	if !ok || len(signers) == 0 {
 		return nil, types.RpcErrorInvalidParams("tx_json.Signers array may not be empty.")
 	}
 
-	// Validate signer entries and collect accounts for duplicate/self-sign checks
-	seenAccounts := make(map[string]bool, len(signers))
-	var prevAccount string
-	for i, signerEntry := range signers {
-		signerWrapper, ok := signerEntry.(map[string]any)
-		if !ok {
-			return nil, types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
-		}
-
-		signer, ok := signerWrapper["Signer"].(map[string]any)
-		if !ok {
-			return nil, types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
-		}
-
-		// A Signer object always contains exactly Account, SigningPubKey,
-		// and TxnSignature; rippled reports one combined error for any
-		// missing or extra field (getCount() == 3).
-		account, hasAccount := signer["Account"].(string)
-		_, hasPubKey := signer["SigningPubKey"].(string)
-		_, hasSig := signer["TxnSignature"].(string)
-		if !hasAccount || account == "" || !hasPubKey || !hasSig || len(signer) != 3 {
-			return nil, types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
-		}
-
-		// Check signers are sorted by account (XRPL protocol requirement)
-		if i > 0 && account < prevAccount {
-			return nil, types.RpcErrorInvalidParams("Signers must be sorted by Account")
-		}
-
-		// Duplicate signer detection.
-		// Matches rippled sortAndValidateSigners: "Duplicate Signers:Signer:Account entries (<addr>) are not allowed."
-		if seenAccounts[account] {
-			return nil, types.RpcErrorInvalidParams(
-				"Duplicate Signers:Signer:Account entries (" + account + ") are not allowed.")
-		}
-		seenAccounts[account] = true
-
-		// Self-signing detection: a signer may not be the transaction's Account.
-		// Matches rippled sortAndValidateSigners: "A Signer may not be the transaction's Account (<addr>)."
-		if account == txAccount {
-			return nil, types.RpcErrorInvalidParams(
-				"A Signer may not be the transaction's Account (" + txAccount + ").")
-		}
-
-		prevAccount = account
+	signerMapList, rpcErr := signerMaps(signers)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	feePayer := txAccount
+	if delegate, ok := txMap["Delegate"].(string); ok {
+		feePayer = delegate
+	}
+	if rpcErr := sortAndValidateSignerMaps(signerMapList, feePayer); rpcErr != nil {
+		return nil, rpcErr
+	}
+	for i := range signerMapList {
+		signers[i] = signerMapList[i]
 	}
 
 	// Encode the transaction to binary

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -48,20 +48,6 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, types.RpcErrorMissingField("tx_json.Sequence")
 	}
 
-	// Validate that Sequence is a valid number (JSON numbers unmarshal as float64).
-	switch seq := txMap["Sequence"].(type) {
-	case float64:
-		if seq < 0 || seq != float64(int64(seq)) {
-			return nil, types.RpcErrorInvalidField("tx_json.Sequence")
-		}
-	case json.Number:
-		if _, err := seq.Int64(); err != nil {
-			return nil, types.RpcErrorInvalidField("tx_json.Sequence")
-		}
-	default:
-		return nil, types.RpcErrorInvalidField("tx_json.Sequence")
-	}
-
 	// SigningPubKey must be present and empty.
 	// Matches rippled: missing_field_error("tx_json.SigningPubKey") /
 	// "When multi-signing 'tx_json.SigningPubKey' must be empty."
@@ -75,19 +61,15 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 
 	// --- checkTxJsonFields (rippled TransactionSign.cpp:315-375) ---
 
-	// Validate required fields for multi-signed transaction
-	if _, ok := txMap["Account"]; !ok {
-		return nil, types.RpcErrorMissingField("tx_json.Account")
+	if rpcErr := validateSigningTxJSONShape(txMap); rpcErr != nil {
+		return nil, rpcErr
+	}
+	if rpcErr := rejectSigningWhenLoaded(ctx.Services, ctx.Unlimited); rpcErr != nil {
+		return nil, rpcErr
 	}
 
 	// Get the source account address for self-signing detection later.
-	txAccount, _ := txMap["Account"].(string)
-
-	// rippled checkTxJsonFields: an Account that parseBase58<AccountID>
-	// rejects is rpcSRC_ACT_MALFORMED (TransactionSign.cpp:345-354).
-	if !types.IsValidClassicAddress(txAccount) {
-		return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx_json.Account'.")
-	}
+	txAccount := txMap["Account"].(string)
 
 	// The source account must exist in the current ledger
 	// (TransactionSign.cpp:1259-1270 → rpcSRC_ACT_NOT_FOUND). Signer-list
@@ -126,6 +108,20 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	}
 	if feeDrops <= 0 {
 		return nil, types.RpcErrorInvalidParams("Invalid Fee field.  Fees must be greater than zero.")
+	}
+
+	// Sequence value parsing occurs after load admission and account lookup.
+	switch seq := txMap["Sequence"].(type) {
+	case float64:
+		if seq < 0 || seq != float64(int64(seq)) {
+			return nil, types.RpcErrorInvalidField("tx_json.Sequence")
+		}
+	case json.Number:
+		if _, err := seq.Int64(); err != nil {
+			return nil, types.RpcErrorInvalidField("tx_json.Sequence")
+		}
+	default:
+		return nil, types.RpcErrorInvalidField("tx_json.Sequence")
 	}
 
 	// Check that Signers array exists and is not empty

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -126,7 +126,6 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, types.RpcErrorSigningMalformed()
 	}
 
-	// Fee must be XRP drops and must be > 0.
 	// Matches rippled: "Invalid Fee field.  Fees must be specified in XRP." /
 	// "Invalid Fee field.  Fees must be greater than zero."
 	feeVal := txMap["Fee"]

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -102,12 +102,7 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	}
 	transactionTypeName, err := definitions.TransactionTypeName(int32(transactionTypeCode))
 	if err != nil {
-		return nil, types.NewRpcError(
-			types.RpcINTERNAL,
-			"internal",
-			"internal",
-			fmt.Sprintf("Exception while serializing transaction: Invalid transaction type %d", transactionTypeCode),
-		)
+		return nil, types.RpcErrorInvalidTransactionType(transactionTypeCode)
 	}
 	txMap["TransactionType"] = transactionTypeName
 	transactionType, _ := tx.TypeFromName(transactionTypeName)

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -24,7 +24,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
-	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // MaxRequestBytes caps the size of a single JSON-RPC request body.
@@ -1092,11 +1091,6 @@ func handlerSupportsVersion(handler types.MethodHandler, version int) bool {
 	return len(supportedVersions) == 0 || slices.Contains(supportedVersions, version)
 }
 
-// maxValidatedLedgerAge mirrors rippled's Tuning::maxValidatedLedgerAge
-// (2 minutes): a non-standalone node whose validated ledger is older than this
-// is treated as out of sync.
-const maxValidatedLedgerAge = 120 * time.Second
-
 // conditionMet mirrors rippled's RPC::conditionMet (Handler.h:78-139). A method
 // whose RequiredCondition is NoCondition is always allowed. Otherwise the node
 // must be usable: not amendment-blocked, at least SYNCING, not lagging the
@@ -1133,7 +1127,7 @@ func conditionMet(cond types.Condition, ctx *types.RpcContext) *types.RpcError {
 	}
 
 	if !info.Standalone {
-		if validatedLedgerStale(info) || info.OpenLedgerSeq+10 < info.ValidatedLedgerSeq {
+		if types.ValidatedLedgerStale(info) || info.OpenLedgerSeq+10 < info.ValidatedLedgerSeq {
 			return notSyncedError(ctx.ApiVersion, syncFailureNoCurrent)
 		}
 	}
@@ -1175,18 +1169,6 @@ func serverStateRank(serverState string) int {
 	}
 }
 
-// validatedLedgerStale reports whether the node lacks a validated ledger or its
-// validated ledger is older than maxValidatedLedgerAge (rippled
-// getValidatedLedgerAge > Tuning::maxValidatedLedgerAge).
-func validatedLedgerStale(info types.LedgerServerInfo) bool {
-	if !info.HaveValidated || info.ValidatedLedgerCloseTime == 0 {
-		return true
-	}
-	nowRipple := time.Now().Unix() - protocol.RippleEpochUnix
-	age := nowRipple - info.ValidatedLedgerCloseTime
-	return age > int64(maxValidatedLedgerAge/time.Second)
-}
-
 type syncFailure uint8
 
 const (
@@ -1199,7 +1181,7 @@ func notSyncedError(apiVersion int, failure syncFailure) *types.RpcError {
 	if apiVersion == types.ApiVersion1 {
 		switch failure {
 		case syncFailureNoCurrent:
-			return types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent", "Current ledger is unavailable.")
+			return types.CurrentLedgerUnavailable(apiVersion)
 		case syncFailureNoClosed:
 			return types.NewRpcError(types.RpcNO_CLOSED, "noClosed", "noClosed", "Closed ledger is unavailable.")
 		default:

--- a/internal/rpc/sign_counterparty_test.go
+++ b/internal/rpc/sign_counterparty_test.go
@@ -173,6 +173,7 @@ func TestSignFor_SignatureTarget(t *testing.T) {
 	primary := signOffline(t, json.RawMessage(`{
 		"tx_json": {
 			"TransactionType": "LoanSet",
+			"Account": "rHSXa2gvfegaC7767QZGFZjebqkWKMCkTf",
 			"LoanBrokerID": "0000000000000000000000000000000000000000000000000000000000000000",
 			"PrincipalRequested": "1",
 			"Fee": "10",

--- a/internal/rpc/sign_for_networkid_test.go
+++ b/internal/rpc/sign_for_networkid_test.go
@@ -23,7 +23,7 @@ func TestSignFor_NetworkIDEnforcement(t *testing.T) {
 
 	ctxWith := func(networkID uint32) *types.RpcContext {
 		mock := newMockLedgerService()
-		mock.serverInfo = types.LedgerServerInfo{NetworkID: networkID}
+		mock.serverInfo.NetworkID = networkID
 		return &types.RpcContext{
 			Context:    context.Background(),
 			ApiVersion: types.ApiVersion1,

--- a/internal/rpc/sign_test.go
+++ b/internal/rpc/sign_test.go
@@ -1456,7 +1456,7 @@ func TestSubmitMultisigned_InvalidSignerFormat(t *testing.T) {
 	}`)
 	_, err := handler.Handle(ctx, params)
 	require.NotNil(t, err)
-	assert.Contains(t, err.Message, "Signer entr")
+	assert.Equal(t, "Field 'tx_json.Signers.InvalidField' is unknown.", err.Message)
 }
 
 func TestSubmitMultisigned_MissingSignerAccount(t *testing.T) {
@@ -1491,7 +1491,7 @@ func TestSubmitMultisigned_MissingSignerAccount(t *testing.T) {
 	}`)
 	_, err := handler.Handle(ctx, params)
 	require.NotNil(t, err)
-	assert.Equal(t, "Signers array may only contain Signer entries.", err.Message)
+	assert.Equal(t, "Error at 'tx_json.Signers.[0].Signer'. Object 'Signer' contents did not meet requirements for that type.", err.Message)
 }
 
 func TestSubmitMultisigned_MissingSigningPubKey(t *testing.T) {
@@ -1526,7 +1526,7 @@ func TestSubmitMultisigned_MissingSigningPubKey(t *testing.T) {
 	}`)
 	_, err := handler.Handle(ctx, params)
 	require.NotNil(t, err)
-	assert.Equal(t, "Signers array may only contain Signer entries.", err.Message)
+	assert.Equal(t, "Error at 'tx_json.Signers.[0].Signer'. Object 'Signer' contents did not meet requirements for that type.", err.Message)
 }
 
 func TestSubmitMultisigned_MissingTxnSignature(t *testing.T) {
@@ -1561,10 +1561,10 @@ func TestSubmitMultisigned_MissingTxnSignature(t *testing.T) {
 	}`)
 	_, err := handler.Handle(ctx, params)
 	require.NotNil(t, err)
-	assert.Equal(t, "Signers array may only contain Signer entries.", err.Message)
+	assert.Equal(t, "Error at 'tx_json.Signers.[0].Signer'. Object 'Signer' contents did not meet requirements for that type.", err.Message)
 }
 
-func TestSubmitMultisigned_SignersNotSorted(t *testing.T) {
+func TestSubmitMultisigned_SortsSigners(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
 	services := newSubmitTestServices(mock)
 
@@ -1575,7 +1575,6 @@ func TestSubmitMultisigned_SignersNotSorted(t *testing.T) {
 		Services:   services,
 	}
 
-	// Signers not sorted by account (rP... < rH... is false alphabetically)
 	params := json.RawMessage(`{
 		"tx_json": {
 			"TransactionType": "Payment",
@@ -1603,9 +1602,14 @@ func TestSubmitMultisigned_SignersNotSorted(t *testing.T) {
 			]
 		}
 	}`)
-	_, err := handler.Handle(ctx, params)
-	require.NotNil(t, err)
-	assert.Contains(t, err.Message, "sorted")
+	result, err := handler.Handle(ctx, params)
+	require.Nil(t, err)
+	signers := result.(map[string]any)["tx_json"].(map[string]any)["Signers"].([]any)
+	require.Len(t, signers, 2)
+	first := signers[0].(map[string]any)["Signer"].(map[string]any)["Account"]
+	second := signers[1].(map[string]any)["Signer"].(map[string]any)["Account"]
+	assert.Equal(t, "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh", first)
+	assert.Equal(t, "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK", second)
 }
 
 func TestSubmitMultisigned_LedgerServiceUnavailable(t *testing.T) {

--- a/internal/rpc/submit_multisigned_test.go
+++ b/internal/rpc/submit_multisigned_test.go
@@ -18,7 +18,7 @@ func validMultisignedTxJSON() map[string]any {
 	return map[string]any{
 		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 		"TransactionType": "Payment",
-		"Destination":     "rPMh7Pi9ct699iZUTWzJaUOVnFNaREiPik",
+		"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 		"Amount":          "1000000",
 		"Fee":             "12",
 		"Sequence":        float64(1),
@@ -26,7 +26,7 @@ func validMultisignedTxJSON() map[string]any {
 		"Signers": []any{
 			map[string]any{
 				"Signer": map[string]any{
-					"Account":       "rPMh7Pi9ct699iZUTWzJaUOVnFNaREiPik",
+					"Account":       "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 					"SigningPubKey": "0379F17CFA0FFD7518181594BE69FE9A10C2089E0FF0C4AE1DEF230657210000ED",
 					"TxnSignature":  "3045022100DEADBEEF",
 				},
@@ -99,9 +99,9 @@ func TestSubmitMultisigned_FeeNotPresent(t *testing.T) {
 	assert.Equal(t, "Invalid Fee field.  Fees must be specified in XRP.", rpcErr.Message)
 }
 
-// TestSubmitMultisigned_FeeNotString verifies that a non-string Fee is rejected.
-// Fee must be a string of drops.
-func TestSubmitMultisigned_FeeNotString(t *testing.T) {
+// TestSubmitMultisigned_FeeNumeric verifies that a JSON integer Fee is
+// canonicalized to an XRP drops string before submission.
+func TestSubmitMultisigned_FeeNumeric(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
 	services := newSubmitTestServices(mock)
 
@@ -109,12 +109,13 @@ func TestSubmitMultisigned_FeeNotString(t *testing.T) {
 	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
 	txJSON := validMultisignedTxJSON()
-	txJSON["Fee"] = 12 // numeric, not string
+	txJSON["Fee"] = 12
 
-	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
-	require.NotNil(t, rpcErr)
-	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
-	assert.Equal(t, "Invalid Fee field.  Fees must be specified in XRP.", rpcErr.Message)
+	result, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
+	require.Nil(t, rpcErr)
+	require.NotNil(t, result)
+	response := result.(map[string]any)
+	assert.Equal(t, "12", response["tx_json"].(map[string]any)["Fee"])
 }
 
 // TestSubmitMultisigned_FeeZero verifies that Fee "0" is rejected.
@@ -166,7 +167,7 @@ func TestSubmitMultisigned_FeeNotNumericString(t *testing.T) {
 	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
-	assert.Equal(t, "Invalid Fee field.  Fees must be specified in XRP.", rpcErr.Message)
+	assert.Equal(t, "Field 'tx_json.Fee' has invalid data.", rpcErr.Message)
 }
 
 // TestSubmitMultisigned_TxnSignaturePresent verifies that a TxnSignature field on the
@@ -226,7 +227,7 @@ func TestSubmitMultisigned_DuplicateSigners(t *testing.T) {
 	handler := &handlers.SubmitMultisignedMethod{}
 	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1, Services: services}
 
-	dupAccount := "rPMh7Pi9ct699iZUTWzJaUOVnFNaREiPik"
+	dupAccount := "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
 	txJSON := validMultisignedTxJSON()
 	txJSON["Signers"] = []any{
 		map[string]any{

--- a/internal/rpc/submit_multisigned_test.go
+++ b/internal/rpc/submit_multisigned_test.go
@@ -81,8 +81,6 @@ func TestSubmitMultisigned_InvalidSequenceType(t *testing.T) {
 	assert.Contains(t, rpcErr.Message, "tx_json.Sequence")
 }
 
-// TestSubmitMultisigned_FeeNotPresent verifies that missing Fee is rejected.
-// Matches rippled: "Invalid Fee field.  Fees must be specified in XRP."
 func TestSubmitMultisigned_FeeNotPresent(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
 	services := newSubmitTestServices(mock)
@@ -96,7 +94,7 @@ func TestSubmitMultisigned_FeeNotPresent(t *testing.T) {
 	_, rpcErr := handler.Handle(ctx, makeSubmitMultisignedParams(t, txJSON))
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
-	assert.Equal(t, "Invalid Fee field.  Fees must be specified in XRP.", rpcErr.Message)
+	assert.Equal(t, "Missing field 'tx_json.Fee'.", rpcErr.Message)
 }
 
 // TestSubmitMultisigned_FeeNumeric verifies that a JSON integer Fee is

--- a/internal/rpc/submit_multisigned_test.go
+++ b/internal/rpc/submit_multisigned_test.go
@@ -97,8 +97,6 @@ func TestSubmitMultisigned_FeeNotPresent(t *testing.T) {
 	assert.Equal(t, "Missing field 'tx_json.Fee'.", rpcErr.Message)
 }
 
-// TestSubmitMultisigned_FeeNumeric verifies that a JSON integer Fee is
-// canonicalized to an XRP drops string before submission.
 func TestSubmitMultisigned_FeeNumeric(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
 	services := newSubmitTestServices(mock)

--- a/internal/rpc/submit_test.go
+++ b/internal/rpc/submit_test.go
@@ -985,12 +985,14 @@ func TestSubmitMethodSigningCredentials(t *testing.T) {
 		signingParam string
 		signingValue string
 		keyType      string
+		account      string
 		description  string
 	}{
 		{
 			name:         "secret parameter",
 			signingParam: "secret",
 			signingValue: "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9",
+			account:      "rMCcNuTcajgw7YTgBy1sys3b89QqjUrMpH",
 			description:  "Traditional secret format for signing",
 		},
 		{
@@ -998,6 +1000,7 @@ func TestSubmitMethodSigningCredentials(t *testing.T) {
 			signingParam: "seed",
 			signingValue: "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9",
 			keyType:      "secp256k1",
+			account:      "rMCcNuTcajgw7YTgBy1sys3b89QqjUrMpH",
 			description:  "Seed format for signing",
 		},
 		{
@@ -1005,6 +1008,7 @@ func TestSubmitMethodSigningCredentials(t *testing.T) {
 			signingParam: "seed_hex",
 			signingValue: "DEDCE9CE67B451D852FD4E846FCDE31C",
 			keyType:      "secp256k1",
+			account:      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			description:  "Hex-encoded seed for signing",
 		},
 		{
@@ -1012,6 +1016,7 @@ func TestSubmitMethodSigningCredentials(t *testing.T) {
 			signingParam: "passphrase",
 			signingValue: "masterpassphrase",
 			keyType:      "secp256k1",
+			account:      "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			description:  "Passphrase-based key derivation",
 		},
 	}
@@ -1020,11 +1025,10 @@ func TestSubmitMethodSigningCredentials(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("Parameter: %s, Description: %s", tc.signingParam, tc.description)
 
-			// Omit Account so the signing helper auto-fills it from the
-			// derived key. This avoids account mismatch errors.
 			params := map[string]any{
 				"tx_json": map[string]any{
 					"TransactionType": "Payment",
+					"Account":         tc.account,
 					"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
 					"Amount":          "1000000",
 				},

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -1,5 +1,7 @@
 package types
 
+import "fmt"
+
 // XRPL RPC error codes.
 //
 // rippled serializes the numeric error_code field over the wire and documents
@@ -350,6 +352,17 @@ func RpcErrorInternal() *RpcError {
 
 func RpcErrorTransactionSubmission() *RpcError {
 	return NewRpcError(RpcINTERNAL, "internal", "internal", "Exception occurred during transaction submission.")
+}
+
+// RpcErrorInvalidTransactionType returns rippled's internal serialization
+// error for an unknown numeric transaction type.
+func RpcErrorInvalidTransactionType(transactionType uint16) *RpcError {
+	return NewRpcError(
+		RpcINTERNAL,
+		"internal",
+		"internal",
+		fmt.Sprintf("Exception while serializing transaction: Invalid transaction type %d", transactionType),
+	)
 }
 
 func RpcErrorDBDeserialization() *RpcError {

--- a/internal/rpc/types/errors_test.go
+++ b/internal/rpc/types/errors_test.go
@@ -212,6 +212,17 @@ func TestRpcErrorDBDeserialization(t *testing.T) {
 	}
 }
 
+func TestRpcErrorInvalidTransactionType(t *testing.T) {
+	err := RpcErrorInvalidTransactionType(65535)
+	if err.Code != RpcINTERNAL || err.ErrorString != "internal" {
+		t.Fatalf("error = %#v, want internal RPC error", err)
+	}
+	want := "Exception while serializing transaction: Invalid transaction type 65535"
+	if err.Message != want {
+		t.Fatalf("message = %q, want %q", err.Message, want)
+	}
+}
+
 // Bare-token errors mirror rippled handlers that set jvResult[jss::error]
 // directly (e.g. VaultInfo.cpp:101, TransactionEntry.cpp:71): only `error` is
 // wired, never error_code or error_message. Errors built through inject_error

--- a/internal/rpc/types/ledger_freshness.go
+++ b/internal/rpc/types/ledger_freshness.go
@@ -1,0 +1,25 @@
+package types
+
+import (
+	"time"
+
+	"github.com/LeJamon/go-xrpl/protocol"
+)
+
+const maxValidatedLedgerAge = 120 * time.Second
+
+func ValidatedLedgerStale(info LedgerServerInfo) bool {
+	if !info.HaveValidated || info.ValidatedLedgerCloseTime == 0 {
+		return true
+	}
+	nowRipple := time.Now().Unix() - protocol.RippleEpochUnix
+	age := nowRipple - info.ValidatedLedgerCloseTime
+	return age > int64(maxValidatedLedgerAge/time.Second)
+}
+
+func CurrentLedgerUnavailable(apiVersion int) *RpcError {
+	if apiVersion == ApiVersion1 {
+		return NewRpcError(RpcNO_CURRENT, "noCurrent", "noCurrent", "Current ledger is unavailable.")
+	}
+	return RpcErrorNotSynced("")
+}

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -351,7 +351,6 @@ type ServiceContainer struct {
 	// subsystem lands — handler suppresses the fields when nil.
 	LoadFactorFees func() LoadFactorFees
 
-	// IsLoadedCluster reports whether the signing load-admission gate is active.
 	// Nil in RPC-only test contexts, which handlers treat as unloaded.
 	IsLoadedCluster func() bool
 

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -351,6 +351,10 @@ type ServiceContainer struct {
 	// subsystem lands — handler suppresses the fields when nil.
 	LoadFactorFees func() LoadFactorFees
 
+	// IsLoadedCluster reports whether the signing load-admission gate is active.
+	// Nil in RPC-only test contexts, which handlers treat as unloaded.
+	IsLoadedCluster func() bool
+
 	// ClientLoad is the shared in-flight client-RPC counter that drives
 	// the rpcTOO_BUSY load-shedding gates. Approximates rippled's
 	// jtCLIENT backpressure via in-flight RPC count: rippled measures

--- a/internal/tx/local_checks.go
+++ b/internal/tx/local_checks.go
@@ -1,9 +1,14 @@
 package tx
 
 import (
+	"bytes"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec/definitions"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 )
 
@@ -13,66 +18,288 @@ import (
 // per-field size caps. Reference: rippled STTx.cpp isMemoOkay.
 const MaxSerializedMemosSize = 1024
 
-// PassesLocalChecks runs the submission-only validation rippled performs in
-// STTx::passesLocalChecks (invoked from NetworkOPs at the ingress), NOT in the
-// consensus-critical preflight. It must be applied only on the local submission
-// path: a relayed or consensus-applied transaction carrying the same memo still
-// applies, because rippled treats a memo violation as a local, non-TER refusal
-// (Validity::SigGoodOnly), which the engine preflight accepts. Applying it in
-// preflight would exclude a memo-violating transaction from an agreed tx set
-// that rippled applies with tesSUCCESS — a ledger fork.
-//
-// It returns TemMALFORMED on any violation, matching rippled's rejection of a
-// locally-submitted transaction that fails passesLocalChecks.
+// PassesLocalChecks preserves the common-field memo check for callers that do
+// not have a parsed transaction. Submission paths should use
+// PassesTransactionLocalChecks so the transaction-specific checks also run.
 func PassesLocalChecks(common *Common) ter.Result {
-	return validateMemosLocal(common)
+	if LocalChecksFailureReason(common) != "" {
+		return ter.TemMALFORMED
+	}
+	return ter.TesSUCCESS
 }
 
-// validateMemosLocal mirrors rippled isMemoOkay: the whole Memos array must
-// serialize to at most 1024 bytes (field headers included), every present
-// MemoType/MemoData/MemoFormat field must be valid hex, and the decoded
-// MemoType/MemoFormat bytes may contain only RFC 3986 URL characters (MemoData
-// is unrestricted). There are no per-field size caps.
-func validateMemosLocal(common *Common) ter.Result {
+// PassesTransactionLocalChecks runs the non-consensus checks applied only at
+// local transaction-submission ingress.
+func PassesTransactionLocalChecks(transaction Transaction) ter.Result {
+	if TransactionLocalChecksFailureReason(transaction) != "" {
+		return ter.TemMALFORMED
+	}
+	return ter.TesSUCCESS
+}
+
+// TransactionLocalChecksFailureReason returns the first local-submission
+// rejection reason in protocol order.
+func TransactionLocalChecksFailureReason(transaction Transaction) string {
+	if raw := transaction.GetRawBytes(); len(raw) != 0 {
+		if fields, err := binarycodec.DecodeBytes(raw); err == nil {
+			return TransactionMapLocalChecksFailureReason(transaction.TxType(), fields)
+		}
+	}
+	if reason := LocalChecksFailureReason(transaction.GetCommon()); reason != "" {
+		return reason
+	}
+
+	fields, err := transaction.Flatten()
+	if err != nil {
+		return err.Error()
+	}
+	if reason := transactionFieldsLocalChecksFailureReason(transaction.TxType(), fields); reason != "" {
+		return reason
+	}
+	if transaction.TxType() == TypeBatch {
+		if signers, ok := transaction.(BatchSignerProvider); ok && len(signers.GetBatchSigners()) > 8 {
+			return "Batch Signers array exceeds max entries."
+		}
+		if outer, ok := transaction.(interface{ InnerTransactions() []Transaction }); ok {
+			inners := outer.InnerTransactions()
+			if len(inners) > 8 {
+				return "Raw Transactions array exceeds max entries."
+			}
+			for _, inner := range inners {
+				if inner != nil && inner.TxType() == TypeBatch {
+					return "Raw Transactions may not contain batch transactions."
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+// TransactionMapLocalChecksFailureReason applies local-submission checks to a
+// canonically parsed transaction map before it is converted to a Go transaction.
+func TransactionMapLocalChecksFailureReason(txType Type, fields map[string]any) string {
+	if memos, ok := fields["Memos"]; ok {
+		if reason := localChecksMemosFromMap(memos); reason != "" {
+			return reason
+		}
+	}
+	if reason := transactionFieldsLocalChecksFailureReason(txType, fields); reason != "" {
+		return reason
+	}
+	if txType == TypeBatch {
+		if batchSigners, ok := fields["BatchSigners"].([]any); ok && len(batchSigners) > 8 {
+			return "Batch Signers array exceeds max entries."
+		}
+		rawTransactions, ok := fields["RawTransactions"].([]any)
+		if !ok {
+			return ""
+		}
+		if len(rawTransactions) > 8 {
+			return "Raw Transactions array exceeds max entries."
+		}
+		for _, raw := range rawTransactions {
+			wrapper, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			inner, ok := wrapper["RawTransaction"].(map[string]any)
+			if !ok {
+				continue
+			}
+			innerTypeValue, present := inner["TransactionType"]
+			if !present {
+				return "Field not found: TransactionType"
+			}
+			innerType, ok := transactionTypeFromCanonicalMap(inner)
+			if !ok {
+				if code, numeric := innerTypeValue.(uint16); numeric {
+					return fmt.Sprintf("Invalid transaction type %d", code)
+				}
+				return "Field 'TransactionType' has invalid data."
+			}
+			if innerType == TypeBatch {
+				return "Raw Transactions may not contain batch transactions."
+			}
+			inner["TransactionType"] = innerType.String()
+			if err := ValidateTemplateFields(innerType, inner); err != nil {
+				return err.Error()
+			}
+		}
+	}
+	return ""
+}
+
+func localChecksMemosFromMap(memos any) string {
+	full, err := binarycodec.EncodeBytes(map[string]any{"Memos": memos})
+	if err != nil {
+		return "The MemoType, MemoData and MemoFormat fields may only contain hex-encoded data."
+	}
+	overhead, err := binarycodec.EncodeBytes(map[string]any{"Memos": []map[string]any{}})
+	if err != nil {
+		return "The MemoType, MemoData and MemoFormat fields may only contain hex-encoded data."
+	}
+	if len(full)-len(overhead) > MaxSerializedMemosSize {
+		return "The memo exceeds the maximum allowed size."
+	}
+
+	raw, err := json.Marshal(memos)
+	if err != nil {
+		return "The MemoType, MemoData and MemoFormat fields may only contain hex-encoded data."
+	}
+	var entries []map[string]map[string]any
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return "The MemoType, MemoData and MemoFormat fields may only contain hex-encoded data."
+	}
+	for _, wrapper := range entries {
+		memo := wrapper["Memo"]
+		for _, name := range []string{"MemoType", "MemoData", "MemoFormat"} {
+			value, present := memo[name]
+			if !present {
+				continue
+			}
+			text, ok := value.(string)
+			if !ok {
+				return "The MemoType, MemoData and MemoFormat fields may only contain hex-encoded data."
+			}
+			decoded, err := hex.DecodeString(text)
+			if err != nil {
+				return "The MemoType, MemoData and MemoFormat fields may only contain hex-encoded data."
+			}
+			if name != "MemoData" && !isValidURLBytes(decoded) {
+				return "The MemoType and MemoFormat fields may only contain characters that are allowed in URLs under RFC 3986."
+			}
+		}
+	}
+	return ""
+}
+
+func transactionFieldsLocalChecksFailureReason(txType Type, fields map[string]any) string {
+	if hasDefaultAccountField(fields) {
+		return "An account field is invalid."
+	}
+	if txType.IsPseudoTransaction() {
+		return "Cannot submit pseudo transactions."
+	}
+	if hasUnsupportedMPTField(txType, fields) {
+		return "Amount can not be MPT."
+	}
+	return ""
+}
+
+func transactionTypeFromCanonicalMap(fields map[string]any) (Type, bool) {
+	switch value := fields["TransactionType"].(type) {
+	case uint16:
+		txType := Type(value)
+		_, known := TypeFromName(txType.String())
+		return txType, known
+	case string:
+		return TypeFromName(value)
+	default:
+		return 0, false
+	}
+}
+
+func hasDefaultAccountField(fields map[string]any) bool {
+	defs := definitions.Get()
+	for name, value := range fields {
+		field, err := defs.FieldInstanceByName(name)
+		if err != nil || field.Type != "AccountID" {
+			continue
+		}
+		account, ok := value.(string)
+		if !ok {
+			continue
+		}
+		if account == "" {
+			return true
+		}
+		if decoded, err := hex.DecodeString(account); err == nil && len(decoded) == 20 {
+			if bytes.Equal(decoded, make([]byte, 20)) {
+				return true
+			}
+			continue
+		}
+		_, decoded, err := addresscodec.DecodeClassicAddressToAccountID(account)
+		if err == nil && bytes.Equal(decoded, make([]byte, 20)) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasUnsupportedMPTField(txType Type, fields map[string]any) bool {
+	for name, value := range fields {
+		object, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, isMPT := object["mpt_issuance_id"]; !isMPT {
+			continue
+		}
+		if !mptSupportedFields[txType][name] {
+			return true
+		}
+	}
+	return false
+}
+
+var mptSupportedFields = map[Type]map[string]bool{
+	TypePayment:                 {"Amount": true, "SendMax": true, "DeliverMin": true},
+	TypeEscrowCreate:            {"Amount": true},
+	TypeOfferCreate:             {"TakerPays": true, "TakerGets": true},
+	TypeCheckCreate:             {"SendMax": true},
+	TypeCheckCash:               {"Amount": true, "DeliverMin": true},
+	TypeClawback:                {"Amount": true},
+	TypeAMMClawback:             {"Asset": true, "Asset2": true, "Amount": true},
+	TypeAMMCreate:               {"Amount": true, "Amount2": true},
+	TypeAMMDeposit:              {"Asset": true, "Asset2": true, "Amount": true, "Amount2": true},
+	TypeAMMWithdraw:             {"Asset": true, "Asset2": true, "Amount": true, "Amount2": true},
+	TypeAMMVote:                 {"Asset": true, "Asset2": true},
+	TypeAMMBid:                  {"Asset": true, "Asset2": true},
+	TypeAMMDelete:               {"Asset": true, "Asset2": true},
+	TypeVaultCreate:             {"Asset": true},
+	TypeVaultDeposit:            {"Amount": true},
+	TypeVaultWithdraw:           {"Amount": true},
+	TypeVaultClawback:           {"Amount": true},
+	TypeLoanBrokerCoverDeposit:  {"Amount": true},
+	TypeLoanBrokerCoverWithdraw: {"Amount": true},
+	TypeLoanBrokerCoverClawback: {"Amount": true},
+	TypeLoanPay:                 {"Amount": true},
+}
+
+func LocalChecksFailureReason(common *Common) string {
 	if len(common.Memos) == 0 {
-		return ter.TesSUCCESS
+		return ""
 	}
 
 	serializedLen, err := serializedMemosLength(common.Memos)
 	if err != nil {
-		return ter.TemMALFORMED
+		return "The MemoType, MemoData and MemoFormat fields may only contain hex-encoded data."
 	}
 	if serializedLen > MaxSerializedMemosSize {
-		return ter.TemMALFORMED
+		return "The memo exceeds the maximum allowed size."
 	}
 
 	for _, memoWrapper := range common.Memos {
 		memo := memoWrapper.Memo
-		// MemoType and MemoFormat are URL-charset-restricted; MemoData is not.
-		if !memoHexFieldOkay(memo.MemoType, true) ||
-			!memoHexFieldOkay(memo.MemoData, false) ||
-			!memoHexFieldOkay(memo.MemoFormat, true) {
-			return ter.TemMALFORMED
+		for _, value := range []string{memo.MemoType, memo.MemoData, memo.MemoFormat} {
+			if value == "" {
+				continue
+			}
+			if _, err := hex.DecodeString(value); err != nil {
+				return "The MemoType, MemoData and MemoFormat fields may only contain hex-encoded data."
+			}
+		}
+		for _, value := range []string{memo.MemoType, memo.MemoFormat} {
+			decoded, _ := hex.DecodeString(value)
+			if !isValidURLBytes(decoded) {
+				return "The MemoType and MemoFormat fields may only contain characters that are allowed in URLs under RFC 3986."
+			}
 		}
 	}
 
-	return ter.TesSUCCESS
-}
-
-// memoHexFieldOkay reports whether a memo field is absent, or is valid hex whose
-// decoded bytes satisfy the RFC 3986 URL charset when urlRestricted is set.
-func memoHexFieldOkay(value string, urlRestricted bool) bool {
-	if value == "" {
-		return true
-	}
-	decoded, err := hex.DecodeString(value)
-	if err != nil {
-		return false
-	}
-	if urlRestricted && !isValidURLBytes(decoded) {
-		return false
-	}
-	return true
+	return ""
 }
 
 // serializedMemosLength returns the serialized length of the Memos array

--- a/internal/tx/local_checks_test.go
+++ b/internal/tx/local_checks_test.go
@@ -80,3 +80,197 @@ func TestPassesLocalChecks_NoMemos(t *testing.T) {
 		t.Fatalf("PassesLocalChecks(no memos) = %v, want TesSUCCESS", got)
 	}
 }
+
+func TestLocalChecksFailureReason(t *testing.T) {
+	tests := []struct {
+		name string
+		memo Memo
+		want string
+	}{
+		{
+			name: "oversized",
+			memo: Memo{MemoData: strings.Repeat("AA", 1020)},
+			want: "The memo exceeds the maximum allowed size.",
+		},
+		{
+			name: "invalid hex",
+			memo: Memo{MemoData: "GG"},
+			want: "The MemoType, MemoData and MemoFormat fields may only contain hex-encoded data.",
+		},
+		{
+			name: "invalid URL character",
+			memo: Memo{MemoType: "01"},
+			want: "The MemoType and MemoFormat fields may only contain characters that are allowed in URLs under RFC 3986.",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := LocalChecksFailureReason(memoCommon(test.memo)); got != test.want {
+				t.Fatalf("LocalChecksFailureReason = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+type localChecksTransaction struct {
+	BaseTx
+	fields map[string]any
+}
+
+func newLocalChecksTransaction(txType Type, fields map[string]any) *localChecksTransaction {
+	return &localChecksTransaction{BaseTx: *NewBaseTx(txType, "rMRxj8jED6ZCjtjgFxB4cz1MGVNtYqCEyS"), fields: fields}
+}
+
+func (transaction *localChecksTransaction) Flatten() (map[string]any, error) {
+	return transaction.fields, nil
+}
+
+type localChecksBatch struct {
+	*localChecksTransaction
+	inners  []Transaction
+	signers []BatchSignerInfo
+}
+
+func (batch *localChecksBatch) InnerTransactions() []Transaction {
+	return batch.inners
+}
+
+func (batch *localChecksBatch) GetBatchSigners() []BatchSignerInfo {
+	return batch.signers
+}
+
+func TestTransactionLocalChecksFailureReason(t *testing.T) {
+	mpt := map[string]any{"value": "1", "mpt_issuance_id": strings.Repeat("A", 48)}
+	zeroAccount := strings.Repeat("0", 40)
+
+	tests := []struct {
+		name        string
+		transaction Transaction
+		want        string
+	}{
+		{
+			name:        "default account field",
+			transaction: newLocalChecksTransaction(TypePayment, map[string]any{"Destination": zeroAccount}),
+			want:        "An account field is invalid.",
+		},
+		{
+			name:        "zero length account field",
+			transaction: newLocalChecksTransaction(TypePayment, map[string]any{"Destination": ""}),
+			want:        "An account field is invalid.",
+		},
+		{
+			name:        "pseudo transaction",
+			transaction: newLocalChecksTransaction(TypeFee, map[string]any{}),
+			want:        "Cannot submit pseudo transactions.",
+		},
+		{
+			name:        "MPT supported field",
+			transaction: newLocalChecksTransaction(TypePayment, map[string]any{"Amount": mpt}),
+		},
+		{
+			name:        "MPT unsupported common fee",
+			transaction: newLocalChecksTransaction(TypePayment, map[string]any{"Fee": mpt}),
+			want:        "Amount can not be MPT.",
+		},
+		{
+			name:        "MPT unsupported transaction field",
+			transaction: newLocalChecksTransaction(TypePaymentChannelCreate, map[string]any{"Amount": mpt}),
+			want:        "Amount can not be MPT.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := TransactionLocalChecksFailureReason(test.transaction); got != test.want {
+				t.Fatalf("TransactionLocalChecksFailureReason = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestTransactionMapLocalChecksBatchInnerType(t *testing.T) {
+	tests := []struct {
+		name      string
+		innerType any
+		want      string
+	}{
+		{
+			name: "missing",
+			want: "Field not found: TransactionType",
+		},
+		{
+			name:      "unknown",
+			innerType: uint16(65535),
+			want:      "Invalid transaction type 65535",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			inner := map[string]any{}
+			if test.innerType != nil {
+				inner["TransactionType"] = test.innerType
+			}
+			fields := map[string]any{
+				"RawTransactions": []any{map[string]any{"RawTransaction": inner}},
+			}
+			if got := TransactionMapLocalChecksFailureReason(TypeBatch, fields); got != test.want {
+				t.Fatalf("TransactionMapLocalChecksFailureReason = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestTransactionMapLocalChecksCountsPresentEmptyMemoFields(t *testing.T) {
+	fields := map[string]any{
+		"Memos": []any{map[string]any{"Memo": map[string]any{
+			"MemoData": strings.Repeat("AA", 1019),
+			"MemoType": "",
+		}}},
+	}
+	if got := TransactionMapLocalChecksFailureReason(TypePayment, fields); got != "The memo exceeds the maximum allowed size." {
+		t.Fatalf("TransactionMapLocalChecksFailureReason = %q, want memo size rejection", got)
+	}
+}
+
+func TestTransactionLocalChecksBatchLimits(t *testing.T) {
+	inner := newLocalChecksTransaction(TypePayment, map[string]any{})
+	nested := newLocalChecksTransaction(TypeBatch, map[string]any{})
+	tests := []struct {
+		name  string
+		batch *localChecksBatch
+		want  string
+	}{
+		{
+			name: "batch signers limit",
+			batch: &localChecksBatch{
+				localChecksTransaction: newLocalChecksTransaction(TypeBatch, map[string]any{}),
+				signers:                make([]BatchSignerInfo, 9),
+			},
+			want: "Batch Signers array exceeds max entries.",
+		},
+		{
+			name: "raw transactions limit",
+			batch: &localChecksBatch{
+				localChecksTransaction: newLocalChecksTransaction(TypeBatch, map[string]any{}),
+				inners:                 make([]Transaction, 9),
+			},
+			want: "Raw Transactions array exceeds max entries.",
+		},
+		{
+			name: "nested batch",
+			batch: &localChecksBatch{
+				localChecksTransaction: newLocalChecksTransaction(TypeBatch, map[string]any{}),
+				inners:                 []Transaction{inner, nested},
+			},
+			want: "Raw Transactions may not contain batch transactions.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := TransactionLocalChecksFailureReason(test.batch); got != test.want {
+				t.Fatalf("TransactionLocalChecksFailureReason = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- restore rippled-compatible cluster-load admission for `sign`, credentialed `submit`, `sign_for`, and `submit_multisigned`, including validation precedence and unlimited exemptions
- replace `math/big` fee scaling with allocation-free fixed-width arithmetic bounded to signed XRP amounts, and clamp remote-driven local raises safely
- clear stale cluster fees on empty recomputation and narrow redundant fee-track exports

## Verification

- [x] `go test -race -count=1 -timeout 15m ./internal/ledger/... ./internal/txq/... ./internal/rpc/... ./internal/consensus/... ./internal/peermanagement/...`
- [x] `go test -race -count=1 ./internal/feetrack ./internal/tx/engine ./internal/node`
- [x] `just vet`
- [x] `golangci-lint run`
- [x] `just lint`
- [x] `just build`
- [x] `git diff --check`

Fixes #1464


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added load-aware admission for signing and multisigning requests, with exemptions for unlimited requests.
  * Added support for canonicalizing serialized native and issued-currency amounts.
  * Added clearer ledger freshness and availability handling across API versions.

* **Bug Fixes**
  * Improved transaction validation for accounts, memos, batch transactions, and supported fields.
  * Prevented stale cluster fees from persisting when no fresh reports are available.
  * Improved fee scaling safety and overflow handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->