### PR TITLE
refactor(consensus): enforce tracker ownership

### DIFF
--- a/internal/consensus/rcl/disputes_test.go
+++ b/internal/consensus/rcl/disputes_test.go
@@ -77,14 +77,14 @@ func TestDisputeTracker_AllStalled(t *testing.T) {
 	parms := consensus.DefaultConsensusParms()
 
 	t.Run("empty set is not stalled", func(t *testing.T) {
-		dt := NewDisputeTracker()
+		dt := newDisputeTracker()
 		if dt.AllStalled(parms, true, parms.StalledRounds+1) {
 			t.Fatalf("empty dispute set must not be stalled")
 		}
 	})
 
 	t.Run("non-terminal avalanche state is not stalled", func(t *testing.T) {
-		dt := NewDisputeTracker()
+		dt := newDisputeTracker()
 		txID := makeTxID(1)
 		dt.CreateDispute(txID, nil, true)
 		d := dt.Dispute(txID)
@@ -100,7 +100,7 @@ func TestDisputeTracker_AllStalled(t *testing.T) {
 	})
 
 	t.Run("active flipping suppresses stall", func(t *testing.T) {
-		dt := NewDisputeTracker()
+		dt := newDisputeTracker()
 		txID := makeTxID(2)
 		dt.CreateDispute(txID, nil, true)
 		d := dt.Dispute(txID)
@@ -115,7 +115,7 @@ func TestDisputeTracker_AllStalled(t *testing.T) {
 	})
 
 	t.Run("frozen + one-sided tally stalls", func(t *testing.T) {
-		dt := NewDisputeTracker()
+		dt := newDisputeTracker()
 		txID := makeTxID(3)
 		dt.CreateDispute(txID, nil, true)
 		d := dt.Dispute(txID)
@@ -140,7 +140,7 @@ func TestDisputeTracker_AllStalled(t *testing.T) {
 	// always false, so the gate is bypassed and the predicate falls
 	// through to the avMIN_ROUNDS dwell + tally checks. Pin both arms.
 	t.Run("observer mode falls through to tally", func(t *testing.T) {
-		dt := NewDisputeTracker()
+		dt := newDisputeTracker()
 		txID := makeTxID(4)
 		dt.CreateDispute(txID, nil, false)
 		d := dt.Dispute(txID)
@@ -161,7 +161,7 @@ func TestDisputeTracker_AllStalled(t *testing.T) {
 	// non-stalled dispute in the set must short-circuit the aggregate
 	// to false, regardless of how many siblings are stalled.
 	t.Run("mixed disputes — one not stalled — aggregate false", func(t *testing.T) {
-		dt := NewDisputeTracker()
+		dt := newDisputeTracker()
 		stalledID := makeTxID(5)
 		dt.CreateDispute(stalledID, nil, true)
 		ds := dt.Dispute(stalledID)
@@ -186,7 +186,7 @@ func TestDisputeTracker_AllStalled(t *testing.T) {
 	})
 
 	t.Run("invalid avalanche state panics", func(t *testing.T) {
-		dt := NewDisputeTracker()
+		dt := newDisputeTracker()
 		txID := makeTxID(7)
 		dt.CreateDispute(txID, nil, true)
 		dt.Dispute(txID).AvalancheState = consensus.AvalancheStuck + 1
@@ -559,7 +559,7 @@ func TestConsensus_BowOut_UnVotesDisputes(t *testing.T) {
 // Acceptance criterion: issue #266 — "threshold rises 50 → 65 → 70 → 95
 // as avalanche state advances."
 func TestConsensus_AvalancheThresholdRamp(t *testing.T) {
-	dt := NewDisputeTracker()
+	dt := newDisputeTracker()
 	parms := consensus.DefaultConsensusParms()
 
 	txID := makeTxID(0xC)

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -96,8 +96,8 @@ type Engine struct {
 	censorship censorshipDetector
 
 	// proposalTracker owns the round-scoped peer-signal maps. Accessed only
-	// under e.mu (see ProposalTracker).
-	proposalTracker *ProposalTracker
+	// under e.mu (see proposalTracker).
+	proposalTracker *proposalTracker
 
 	// validationTracker accumulates trusted validations across ledgers and
 	// fires the fully-validated callback at quorum, driving
@@ -107,7 +107,7 @@ type Engine struct {
 	// disputeTracker owns the per-tx DisputedTx entries and per-peer vote
 	// map. Written by createDisputesAgainst / OnProposal / OnTxSet /
 	// UpdateOurPositions, read during checkConvergence.
-	disputeTracker *DisputeTracker
+	disputeTracker *disputeTracker
 
 	// acquiredTxSets caches peer tx sets in memory by TxSetID, populated by
 	// our BuildTxSet output and OnTxSet. Dispute wiring reads it to learn
@@ -203,7 +203,6 @@ type Engine struct {
 	ourLastValidatedTime time.Time
 
 	// Stats
-	roundCount     uint64
 	consensusCount uint64
 
 	// archive persists stale validations dropped by the tracker (optional;
@@ -381,9 +380,9 @@ func NewEngine(adaptor consensus.Adaptor, config Config) *Engine {
 		eventBus:        consensus.NewEventBus(100),
 		mode:            consensus.ModeObserving,
 		phase:           consensus.PhaseAccepted,
-		proposalTracker: NewProposalTracker(),
+		proposalTracker: newProposalTracker(),
 		closeTime:       newCloseTimeTracker(),
-		disputeTracker:  NewDisputeTracker(),
+		disputeTracker:  newDisputeTracker(),
 		acquiredTxSets:  make(map[consensus.TxSetID]consensus.TxSet),
 		comparesTxSets:  make(map[consensus.TxSetID]struct{}),
 		parms:           consensus.DefaultConsensusParms(),
@@ -488,7 +487,7 @@ func (e *Engine) Start(ctx context.Context) error {
 	// Wire the validation tracker: trusted set + quorum from the adaptor;
 	// its callback flips the ledger service's validated_ledger pointer.
 	trusted, quorum := e.adaptor.GetTrustedValidatorsAndQuorum()
-	e.validationTracker = NewValidationTracker(quorum, 5*time.Minute)
+	e.validationTracker = NewValidationTracker(quorum)
 	e.validationTracker.SetTrustedAndQuorum(trusted, quorum)
 	e.validationTracker.SetQuorumUnavailableFunc(e.adaptor.IsQuorumUnavailable)
 	if wired, ok := e.adaptor.(consensus.WireableAdaptor); ok {
@@ -764,7 +763,7 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 	// Reset tracking maps. Dead-node set is round-scoped, so a validator that
 	// bowed out last round can rejoin.
 	e.proposalTracker.ResetRound()
-	e.disputeTracker = NewDisputeTracker()
+	e.disputeTracker = newDisputeTracker()
 	e.acquiredTxSets = make(map[consensus.TxSetID]consensus.TxSet)
 	e.comparesTxSets = make(map[consensus.TxSetID]struct{})
 	e.peerUnchangedCounter = 0
@@ -812,7 +811,6 @@ func (e *Engine) startRoundLocked(round consensus.RoundID, proposing, recovering
 		}
 	}
 
-	e.roundCount++
 	return nil
 }
 

--- a/internal/consensus/rcl/engine_accept.go
+++ b/internal/consensus/rcl/engine_accept.go
@@ -105,10 +105,9 @@ func (e *Engine) acceptLedger(result consensus.Result) {
 	// clamp track convergence, not the apply.
 	roundTime := e.now().Sub(e.roundStartTime)
 	roundDuration := e.now().Sub(e.state.StartTime)
+	// DisputedNoTxs returns detached blobs; work keeps that snapshot while
+	// the ledger is built after e.mu is released.
 	disputedNoTxs := e.disputeTracker.DisputedNoTxs()
-	for i := range disputedNoTxs {
-		disputedNoTxs[i] = append([]byte(nil), disputedNoTxs[i]...)
-	}
 
 	// Apply the LCL off e.mu, mirroring rippled onAccept→addJob(jtACCEPT)
 	// ("no lock is held during this job"). Snapshot every build input and

--- a/internal/consensus/rcl/engine_handler_convergence_test.go
+++ b/internal/consensus/rcl/engine_handler_convergence_test.go
@@ -43,7 +43,7 @@ func timerDrivenConvergenceEngine(t *testing.T, txSet *mockTxSet) (*Engine, *moc
 	engine.setPhase(consensus.PhaseEstablish)
 	engine.ourTxSet = txSet
 	engine.acquiredTxSets[txSet.ID()] = txSet
-	engine.disputeTracker = NewDisputeTracker()
+	engine.disputeTracker = newDisputeTracker()
 	engine.closeTime.haveConsensus = true
 	engine.state.OurPosition = &consensus.Proposal{
 		Round:          round,

--- a/internal/consensus/rcl/engine_ledger_check.go
+++ b/internal/consensus/rcl/engine_ledger_check.go
@@ -57,12 +57,6 @@ func (e *Engine) run() {
 	}
 }
 
-// MissedHeartbeats returns the count of dropped heartbeat ticks since
-// start.
-func (e *Engine) MissedHeartbeats() uint64 {
-	return e.missedHeartbeats.Load()
-}
-
 // timerEntry is the single heartbeat dispatch; runs each
 // ledgerGRANULARITY and dispatches on current phase.
 func (e *Engine) timerEntry() {
@@ -429,7 +423,7 @@ func (e *Engine) handleWrongLedger(netLedgerID consensus.LedgerID, target consen
 	// Clear consensus state and replay (only for a new target ledger).
 	if e.prevLedger == nil || netLedgerID != e.prevLedger.ID() {
 		e.proposalTracker.ResetProposals()
-		e.disputeTracker = NewDisputeTracker()
+		e.disputeTracker = newDisputeTracker()
 		e.acquiredTxSets = make(map[consensus.TxSetID]consensus.TxSet)
 		e.comparesTxSets = make(map[consensus.TxSetID]struct{})
 		e.peerUnchangedCounter = 0

--- a/internal/consensus/rcl/engine_onledger_test.go
+++ b/internal/consensus/rcl/engine_onledger_test.go
@@ -22,7 +22,7 @@ func chainLedger(seq uint32, idb, pb byte) *mockLedger {
 
 func stageQuorumValidatedLedger(e *Engine, a *mockAdaptor, l consensus.Ledger) {
 	nodes := []consensus.NodeID{{0x21}, {0x22}}
-	e.validationTracker = NewValidationTracker(len(nodes), 5*time.Minute)
+	e.validationTracker = NewValidationTracker(len(nodes))
 	e.validationTracker.SetTrustedAndQuorum(nodes, len(nodes))
 	e.validationTracker.SetNow(a.Now)
 	now := a.Now()

--- a/internal/consensus/rcl/engine_pause_freshness_test.go
+++ b/internal/consensus/rcl/engine_pause_freshness_test.go
@@ -43,7 +43,7 @@ func TestPhaseEstablish_PauseStillRefreshesProposal(t *testing.T) {
 	engine.roundStartTime = now.Add(-500 * time.Millisecond)
 	engine.setMode(consensus.ModeProposing)
 	engine.setPhase(consensus.PhaseEstablish)
-	engine.disputeTracker = NewDisputeTracker()
+	engine.disputeTracker = newDisputeTracker()
 	engine.ourTxSet = buildMockTxSet(consensus.TxSetID{0xA1})
 	engine.state.OurPosition = &consensus.Proposal{
 		Round:          round,

--- a/internal/consensus/rcl/engine_reproposal_test.go
+++ b/internal/consensus/rcl/engine_reproposal_test.go
@@ -28,7 +28,7 @@ func TestEngine_UpdatePosition_FreshnessRepropose(t *testing.T) {
 
 	engine.mu.Lock()
 	engine.setMode(consensus.ModeProposing)
-	engine.disputeTracker = NewDisputeTracker()
+	engine.disputeTracker = newDisputeTracker()
 	set := buildMockTxSet(consensus.TxSetID{0x5E})
 	engine.ourTxSet = set
 	// Position last emitted well beyond ProposeInterval ago.
@@ -76,7 +76,7 @@ func TestEngine_UpdatePosition_FreshPositionNoRepropose(t *testing.T) {
 
 	engine.mu.Lock()
 	engine.setMode(consensus.ModeProposing)
-	engine.disputeTracker = NewDisputeTracker()
+	engine.disputeTracker = newDisputeTracker()
 	set := buildMockTxSet(consensus.TxSetID{0x5E})
 	engine.ourTxSet = set
 	engine.state.OurPosition = &consensus.Proposal{

--- a/internal/consensus/rcl/engine_test.go
+++ b/internal/consensus/rcl/engine_test.go
@@ -3202,7 +3202,7 @@ func TestCheckConsensusState(t *testing.T) {
 		// past prevSeq so ProposersFinished returns 4 ≥ 80% of 4.
 		prev := &mockLedger{id: consensus.LedgerID{0x10}, seq: 100}
 		e.prevLedger = prev
-		vt := NewValidationTracker(3, e.timing.ValidationFreshness)
+		vt := NewValidationTracker(3)
 		for i := range 4 {
 			nodeID := consensus.NodeID{byte(0xA0 + i)}
 			vt.trusted[nodeID] = true

--- a/internal/consensus/rcl/proposal_tracker.go
+++ b/internal/consensus/rcl/proposal_tracker.go
@@ -10,11 +10,11 @@ import (
 // recent positions kept for replay, bounded against gossip floods.
 const recentProposalsPerNode = 10
 
-// ProposalTracker owns a round's peer-signal state: each trusted node's
+// proposalTracker owns a round's peer-signal state: each trusted node's
 // current position, the nodes that bowed out, the cross-round playback
 // buffer, and the validations gathered for the accepted ledger. Not
 // independently synchronized: every method runs under the Engine's e.mu.
-type ProposalTracker struct {
+type proposalTracker struct {
 	// each trusted node's current-round position; reset at round start, removed on bow-out
 	proposals map[consensus.NodeID]*consensus.Proposal
 
@@ -28,8 +28,8 @@ type ProposalTracker struct {
 	validations map[consensus.NodeID]*consensus.Validation
 }
 
-func NewProposalTracker() *ProposalTracker {
-	return &ProposalTracker{
+func newProposalTracker() *proposalTracker {
+	return &proposalTracker{
 		proposals:       make(map[consensus.NodeID]*consensus.Proposal),
 		deadNodes:       make(map[consensus.NodeID]struct{}),
 		recentProposals: make(map[consensus.NodeID][]*consensus.Proposal),
@@ -39,41 +39,46 @@ func NewProposalTracker() *ProposalTracker {
 
 // ResetRound clears per-round positions and dead nodes at round start; it
 // leaves recentProposals and validations (different lifecycles).
-func (pt *ProposalTracker) ResetRound() {
+func (pt *proposalTracker) ResetRound() {
 	pt.proposals = make(map[consensus.NodeID]*consensus.Proposal)
 	pt.deadNodes = make(map[consensus.NodeID]struct{})
 }
 
 // ResetProposals clears current-round positions only (wrong-ledger switch
 // keeps the dead-node set).
-func (pt *ProposalTracker) ResetProposals() {
+func (pt *proposalTracker) ResetProposals() {
 	pt.proposals = make(map[consensus.NodeID]*consensus.Proposal)
 }
 
 // Count returns the number of current-round positions.
-func (pt *ProposalTracker) Count() int {
+func (pt *proposalTracker) Count() int {
 	return len(pt.proposals)
 }
 
-// All returns the current-round positions for read-only iteration; mutate via
-// Store/MarkDead/PruneStale.
-func (pt *ProposalTracker) All() map[consensus.NodeID]*consensus.Proposal {
-	return pt.proposals
+// All returns a detached snapshot of the current-round positions. Callers may
+// inspect or mutate the returned map and proposals without changing tracker
+// state.
+func (pt *proposalTracker) All() map[consensus.NodeID]*consensus.Proposal {
+	out := make(map[consensus.NodeID]*consensus.Proposal, len(pt.proposals))
+	for nodeID, proposal := range pt.proposals {
+		out[nodeID] = cloneProposal(proposal)
+	}
+	return out
 }
 
 // Store records a proposal as its node's position and reports whether it did.
 // A proposal that does not advance the node's ProposeSeq — a re-send or a
 // same-seq equivocation — is dropped.
-func (pt *ProposalTracker) Store(p *consensus.Proposal) bool {
+func (pt *proposalTracker) Store(p *consensus.Proposal) bool {
 	existing, exists := pt.proposals[p.NodeID]
 	if exists && p.Position <= existing.Position {
 		return false
 	}
-	pt.proposals[p.NodeID] = p
+	pt.proposals[p.NodeID] = cloneProposal(p)
 	return true
 }
 
-func (pt *ProposalTracker) CountTrusted(trusted func(consensus.NodeID) bool) int {
+func (pt *proposalTracker) CountTrusted(trusted func(consensus.NodeID) bool) int {
 	n := 0
 	for nodeID := range pt.proposals {
 		if trusted(nodeID) {
@@ -84,22 +89,22 @@ func (pt *ProposalTracker) CountTrusted(trusted func(consensus.NodeID) bool) int
 }
 
 // MarkDead removes a node's position and records it as bowed out for the round.
-func (pt *ProposalTracker) MarkDead(nodeID consensus.NodeID) {
+func (pt *proposalTracker) MarkDead(nodeID consensus.NodeID) {
 	delete(pt.proposals, nodeID)
 	pt.deadNodes[nodeID] = struct{}{}
 }
 
-func (pt *ProposalTracker) IsDead(nodeID consensus.NodeID) bool {
+func (pt *proposalTracker) IsDead(nodeID consensus.NodeID) bool {
 	_, dead := pt.deadNodes[nodeID]
 	return dead
 }
 
-func (pt *ProposalTracker) DeadNodeCount() int {
+func (pt *proposalTracker) DeadNodeCount() int {
 	return len(pt.deadNodes)
 }
 
 // DeadNodeIDs returns the bowed-out node IDs in map order.
-func (pt *ProposalTracker) DeadNodeIDs() []consensus.NodeID {
+func (pt *proposalTracker) DeadNodeIDs() []consensus.NodeID {
 	ids := make([]consensus.NodeID, 0, len(pt.deadNodes))
 	for nodeID := range pt.deadNodes {
 		ids = append(ids, nodeID)
@@ -109,7 +114,7 @@ func (pt *ProposalTracker) DeadNodeIDs() []consensus.NodeID {
 
 // PruneStale removes positions older than cutoff and returns their node IDs so
 // the caller can unvote them from disputes. Zero-timestamp positions are kept.
-func (pt *ProposalTracker) PruneStale(cutoff time.Time) []consensus.NodeID {
+func (pt *proposalTracker) PruneStale(cutoff time.Time) []consensus.NodeID {
 	var removed []consensus.NodeID
 	for nodeID, p := range pt.proposals {
 		if p.Timestamp.IsZero() {
@@ -124,16 +129,16 @@ func (pt *ProposalTracker) PruneStale(cutoff time.Time) []consensus.NodeID {
 }
 
 // BufferRecent appends to the node's playback buffer, capped at recentProposalsPerNode (oldest dropped).
-func (pt *ProposalTracker) BufferRecent(p *consensus.Proposal) {
+func (pt *proposalTracker) BufferRecent(p *consensus.Proposal) {
 	positions := pt.recentProposals[p.NodeID]
 	if len(positions) >= recentProposalsPerNode {
 		positions = positions[1:]
 	}
-	pt.recentProposals[p.NodeID] = append(positions, p)
+	pt.recentProposals[p.NodeID] = append(positions, cloneProposal(p))
 }
 
 // HasBufferedFor reports whether any buffered proposal has prevID as its previous ledger.
-func (pt *ProposalTracker) HasBufferedFor(prevID consensus.LedgerID) bool {
+func (pt *proposalTracker) HasBufferedFor(prevID consensus.LedgerID) bool {
 	for _, positions := range pt.recentProposals {
 		for _, p := range positions {
 			if p.PreviousLedger == prevID {
@@ -146,7 +151,7 @@ func (pt *ProposalTracker) HasBufferedFor(prevID consensus.LedgerID) bool {
 
 // LatestFresh returns each trusted node's newest buffered proposal timestamped
 // within freshness of now. Buffers are in arrival order, so it scans newest-first.
-func (pt *ProposalTracker) LatestFresh(trusted func(consensus.NodeID) bool, now time.Time, freshness time.Duration) map[consensus.NodeID]*consensus.Proposal {
+func (pt *proposalTracker) LatestFresh(trusted func(consensus.NodeID) bool, now time.Time, freshness time.Duration) map[consensus.NodeID]*consensus.Proposal {
 	out := make(map[consensus.NodeID]*consensus.Proposal)
 	for nodeID, positions := range pt.recentProposals {
 		if !trusted(nodeID) {
@@ -156,7 +161,7 @@ func (pt *ProposalTracker) LatestFresh(trusted func(consensus.NodeID) bool, now 
 			if now.Sub(positions[i].Timestamp) > freshness {
 				continue
 			}
-			out[nodeID] = positions[i]
+			out[nodeID] = cloneProposal(positions[i])
 			break
 		}
 	}
@@ -169,7 +174,7 @@ func (pt *ProposalTracker) LatestFresh(trusted func(consensus.NodeID) bool, now 
 // the proposals whose position was (re-)stored, so the caller can re-share them
 // to peers that missed them on this ledger. Buffered duplicates at a
 // non-increasing ProposeSeq are dropped: not counted, not relayed.
-func (pt *ProposalTracker) Replay(prevID consensus.LedgerID, trusted func(consensus.NodeID) bool) (closeTimes []time.Time, trustedReplayed int, relay []*consensus.Proposal) {
+func (pt *proposalTracker) Replay(prevID consensus.LedgerID, trusted func(consensus.NodeID) bool) (closeTimes []time.Time, trustedReplayed int, relay []*consensus.Proposal) {
 	for nodeID, positions := range pt.recentProposals {
 		for _, p := range positions {
 			if p.PreviousLedger != prevID {
@@ -178,7 +183,7 @@ func (pt *ProposalTracker) Replay(prevID consensus.LedgerID, trusted func(consen
 			if !pt.Store(p) {
 				continue
 			}
-			relay = append(relay, p)
+			relay = append(relay, cloneProposal(p))
 			if !trusted(nodeID) {
 				continue
 			}
@@ -191,20 +196,41 @@ func (pt *ProposalTracker) Replay(prevID consensus.LedgerID, trusted func(consen
 	return closeTimes, trustedReplayed, relay
 }
 
-func (pt *ProposalTracker) SetValidation(v *consensus.Validation) {
-	pt.validations[v.NodeID] = v
+func (pt *proposalTracker) SetValidation(v *consensus.Validation) {
+	pt.validations[v.NodeID] = cloneValidation(v)
 }
 
-func (pt *ProposalTracker) ValidationsFor(ledgerID consensus.LedgerID) []*consensus.Validation {
+func (pt *proposalTracker) ValidationsFor(ledgerID consensus.LedgerID) []*consensus.Validation {
 	var out []*consensus.Validation
 	for _, v := range pt.validations {
 		if v.LedgerID == ledgerID {
-			out = append(out, v)
+			out = append(out, cloneValidation(v))
 		}
 	}
 	return out
 }
 
-func (pt *ProposalTracker) ResetValidations() {
+func (pt *proposalTracker) ResetValidations() {
 	pt.validations = make(map[consensus.NodeID]*consensus.Validation)
+}
+
+func cloneProposal(p *consensus.Proposal) *consensus.Proposal {
+	if p == nil {
+		return nil
+	}
+	copy := *p
+	copy.Signature = append([]byte(nil), p.Signature...)
+	return &copy
+}
+
+func cloneValidation(v *consensus.Validation) *consensus.Validation {
+	if v == nil {
+		return nil
+	}
+	copy := *v
+	copy.Signature = append([]byte(nil), v.Signature...)
+	copy.Amendments = append([][32]byte(nil), v.Amendments...)
+	copy.SigningData = append([]byte(nil), v.SigningData...)
+	copy.Raw = append([]byte(nil), v.Raw...)
+	return &copy
 }

--- a/internal/consensus/rcl/proposal_tracker.go
+++ b/internal/consensus/rcl/proposal_tracker.go
@@ -197,14 +197,14 @@ func (pt *proposalTracker) Replay(prevID consensus.LedgerID, trusted func(consen
 }
 
 func (pt *proposalTracker) SetValidation(v *consensus.Validation) {
-	pt.validations[v.NodeID] = cloneValidation(v)
+	pt.validations[v.NodeID] = cloneProposalValidation(v)
 }
 
 func (pt *proposalTracker) ValidationsFor(ledgerID consensus.LedgerID) []*consensus.Validation {
 	var out []*consensus.Validation
 	for _, v := range pt.validations {
 		if v.LedgerID == ledgerID {
-			out = append(out, cloneValidation(v))
+			out = append(out, cloneProposalValidation(v))
 		}
 	}
 	return out
@@ -223,7 +223,7 @@ func cloneProposal(p *consensus.Proposal) *consensus.Proposal {
 	return &copy
 }
 
-func cloneValidation(v *consensus.Validation) *consensus.Validation {
+func cloneProposalValidation(v *consensus.Validation) *consensus.Validation {
 	if v == nil {
 		return nil
 	}

--- a/internal/consensus/rcl/proposal_tracker_test.go
+++ b/internal/consensus/rcl/proposal_tracker_test.go
@@ -203,14 +203,14 @@ func TestStartRound_ClearsDeadNodes(t *testing.T) {
 }
 
 // alwaysTrusted is a trust predicate that accepts every node, used by the
-// ProposalTracker unit tests below.
+// proposalTracker unit tests below.
 func alwaysTrusted(consensus.NodeID) bool { return true }
 
 // TestProposalTracker_StoreMonotonic verifies Store keeps the position with
 // the highest ProposeSeq, drops stale (lower-seq) and same-seq ones, and
 // reports whether it stored.
 func TestProposalTracker_StoreMonotonic(t *testing.T) {
-	pt := NewProposalTracker()
+	pt := newProposalTracker()
 	node := consensus.NodeID{1}
 
 	if !pt.Store(&consensus.Proposal{NodeID: node, Position: 5, TxSet: consensus.TxSetID{5}}) {
@@ -331,7 +331,7 @@ func TestOnProposal_NonIncreasingSeqDropped(t *testing.T) {
 // TestProposalTracker_ReplayDropsNonIncreasing verifies Replay does not count
 // a close-time vote for a buffered duplicate at a non-increasing ProposeSeq.
 func TestProposalTracker_ReplayDropsNonIncreasing(t *testing.T) {
-	pt := NewProposalTracker()
+	pt := newProposalTracker()
 	node := consensus.NodeID{1}
 	prev := consensus.LedgerID{7}
 	ct1 := time.Unix(1000, 0)
@@ -360,7 +360,7 @@ func TestProposalTracker_ReplayDropsNonIncreasing(t *testing.T) {
 // TestProposalTracker_MarkDeadAndReset verifies MarkDead removes the node's
 // position and records it dead, and ResetRound clears both maps.
 func TestProposalTracker_MarkDeadAndReset(t *testing.T) {
-	pt := NewProposalTracker()
+	pt := newProposalTracker()
 	node := consensus.NodeID{1}
 	pt.Store(&consensus.Proposal{NodeID: node, Position: 0})
 
@@ -384,7 +384,7 @@ func TestProposalTracker_MarkDeadAndReset(t *testing.T) {
 // TestProposalTracker_BufferRecentCap verifies the per-node playback buffer
 // caps at recentProposalsPerNode and drops the oldest entry.
 func TestProposalTracker_BufferRecentCap(t *testing.T) {
-	pt := NewProposalTracker()
+	pt := newProposalTracker()
 	node := consensus.NodeID{1}
 	for i := 0; i < recentProposalsPerNode+3; i++ {
 		pt.BufferRecent(&consensus.Proposal{NodeID: node, Position: uint32(i)})
@@ -406,7 +406,7 @@ func TestProposalTracker_BufferRecentCap(t *testing.T) {
 // TestProposalTracker_Replay verifies Replay upserts buffered positions for
 // the target ledger and returns close-time votes and the trusted count.
 func TestProposalTracker_Replay(t *testing.T) {
-	pt := NewProposalTracker()
+	pt := newProposalTracker()
 	target := consensus.LedgerID{9}
 	other := consensus.LedgerID{8}
 	nodeA := consensus.NodeID{1}
@@ -445,7 +445,7 @@ func TestProposalTracker_Replay(t *testing.T) {
 // that loses to an existing higher one is not re-shared, mirroring rippled
 // sharing only when peerProposalInternal accepts the position.
 func TestProposalTracker_ReplayReshareOnlyStored(t *testing.T) {
-	pt := NewProposalTracker()
+	pt := newProposalTracker()
 	target := consensus.LedgerID{9}
 	node := consensus.NodeID{1}
 
@@ -462,7 +462,7 @@ func TestProposalTracker_ReplayReshareOnlyStored(t *testing.T) {
 // TestProposalTracker_PruneStale verifies PruneStale removes positions older
 // than the cutoff (with a non-zero timestamp) and keeps fresh / zero-ts ones.
 func TestProposalTracker_PruneStale(t *testing.T) {
-	pt := NewProposalTracker()
+	pt := newProposalTracker()
 	now := time.Unix(2000, 0)
 	cutoff := now.Add(-10 * time.Second)
 
@@ -491,7 +491,7 @@ func TestProposalTracker_PruneStale(t *testing.T) {
 // TestProposalTracker_LatestFresh verifies LatestFresh returns the newest
 // in-window position per trusted node and skips stale-only / untrusted ones.
 func TestProposalTracker_LatestFresh(t *testing.T) {
-	pt := NewProposalTracker()
+	pt := newProposalTracker()
 	now := time.Unix(3000, 0)
 	freshness := 10 * time.Second
 
@@ -523,7 +523,7 @@ func TestProposalTracker_LatestFresh(t *testing.T) {
 // TestProposalTracker_ValidationsForAndReset verifies round-validation
 // collection by ledger and reset on accept.
 func TestProposalTracker_ValidationsForAndReset(t *testing.T) {
-	pt := NewProposalTracker()
+	pt := newProposalTracker()
 	ledger := consensus.LedgerID{7}
 	other := consensus.LedgerID{8}
 
@@ -537,5 +537,47 @@ func TestProposalTracker_ValidationsForAndReset(t *testing.T) {
 	pt.ResetValidations()
 	if got := pt.ValidationsFor(ledger); len(got) != 0 {
 		t.Errorf("ResetValidations did not clear: %d entries remain", len(got))
+	}
+}
+
+func TestProposalTracker_ValidationSnapshotsOwnSignature(t *testing.T) {
+	pt := newProposalTracker()
+	ledger := consensus.LedgerID{7}
+	input := &consensus.Validation{
+		NodeID:    consensus.NodeID{1},
+		LedgerID:  ledger,
+		Signature: []byte{1, 2},
+	}
+	pt.SetValidation(input)
+
+	input.Signature[0] = 9
+	first := pt.ValidationsFor(ledger)
+	if len(first) != 1 || first[0].Signature[0] != 1 {
+		t.Fatalf("mutating input validation changed tracker state: %#v", first)
+	}
+
+	first[0].Signature[1] = 8
+	second := pt.ValidationsFor(ledger)
+	if len(second) != 1 || second[0].Signature[1] != 2 {
+		t.Fatalf("mutating returned validation snapshot changed tracker state: %#v", second)
+	}
+}
+
+func TestProposalTracker_AllReturnsDetachedSnapshot(t *testing.T) {
+	pt := newProposalTracker()
+	node := consensus.NodeID{1}
+	proposal := &consensus.Proposal{NodeID: node, Position: 3, Signature: []byte{1, 2}}
+	if !pt.Store(proposal) {
+		t.Fatal("Store rejected initial proposal")
+	}
+
+	snapshot := pt.All()
+	snapshot[node].Position = 99
+	snapshot[node].Signature[0] = 9
+	delete(snapshot, node)
+
+	stored := pt.proposals[node]
+	if stored.Position != 3 || stored.Signature[0] != 1 {
+		t.Fatalf("mutating proposal snapshot changed tracker state: %#v", stored)
 	}
 }

--- a/internal/consensus/rcl/proposal_tracker_test.go
+++ b/internal/consensus/rcl/proposal_tracker_test.go
@@ -202,8 +202,6 @@ func TestStartRound_ClearsDeadNodes(t *testing.T) {
 	}
 }
 
-// alwaysTrusted is a trust predicate that accepts every node, used by the
-// proposalTracker unit tests below.
 func alwaysTrusted(consensus.NodeID) bool { return true }
 
 // TestProposalTracker_StoreMonotonic verifies Store keeps the position with

--- a/internal/consensus/rcl/proposals.go
+++ b/internal/consensus/rcl/proposals.go
@@ -35,8 +35,8 @@ type disputeTracker struct {
 	disputes map[consensus.TxID]*consensus.DisputedTx
 }
 
-// newDisputeTracker creates a new dispute tracker. The owning Engine protects
-// all access with e.mu; the tracker deliberately has no second lock.
+// The owning Engine protects all access with e.mu; the tracker deliberately
+// has no second lock.
 func newDisputeTracker() *disputeTracker {
 	return &disputeTracker{
 		disputes: make(map[consensus.TxID]*consensus.DisputedTx),

--- a/internal/consensus/rcl/proposals.go
+++ b/internal/consensus/rcl/proposals.go
@@ -2,7 +2,6 @@ package rcl
 
 import (
 	"bytes"
-	"sync"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 )
@@ -28,19 +27,18 @@ func mostPopularTxSet(counts map[consensus.TxSetID]int) (consensus.TxSetID, int)
 	return bestID, bestCount
 }
 
-// DisputeTracker tracks disputed transactions and their per-peer
+// disputeTracker tracks disputed transactions and their per-peer
 // votes during a consensus round. Mirrors the role of rippled's
 // Result::disputes map plus the DisputedTx<> mutation API
 // (rippled/src/xrpld/consensus/DisputedTx.h).
-type DisputeTracker struct {
-	mu sync.RWMutex
-
+type disputeTracker struct {
 	disputes map[consensus.TxID]*consensus.DisputedTx
 }
 
-// NewDisputeTracker creates a new dispute tracker.
-func NewDisputeTracker() *DisputeTracker {
-	return &DisputeTracker{
+// newDisputeTracker creates a new dispute tracker. The owning Engine protects
+// all access with e.mu; the tracker deliberately has no second lock.
+func newDisputeTracker() *disputeTracker {
+	return &disputeTracker{
 		disputes: make(map[consensus.TxID]*consensus.DisputedTx),
 	}
 }
@@ -52,17 +50,14 @@ func NewDisputeTracker() *DisputeTracker {
 //
 // Matches the construction arm of rippled's createDisputes
 // (Consensus.h:1867-1884).
-func (dt *DisputeTracker) CreateDispute(txID consensus.TxID, tx []byte, ourVote bool) *consensus.DisputedTx {
-	dt.mu.Lock()
-	defer dt.mu.Unlock()
-
+func (dt *disputeTracker) CreateDispute(txID consensus.TxID, tx []byte, ourVote bool) *consensus.DisputedTx {
 	if existing, exists := dt.disputes[txID]; exists {
 		return existing
 	}
 
 	dispute := &consensus.DisputedTx{
 		TxID:           txID,
-		Tx:             tx,
+		Tx:             append([]byte(nil), tx...),
 		OurVote:        ourVote,
 		Votes:          make(map[consensus.NodeID]bool),
 		AvalancheState: consensus.AvalancheInit,
@@ -79,10 +74,7 @@ func (dt *DisputeTracker) CreateDispute(txID consensus.TxID, tx []byte, ourVote 
 // The returned bool matches rippled's DisputedTx::setVote contract:
 // callers use it to reset peerUnchangedCounter_ (Consensus.h:1879,
 // 1906) to detect rounds where some peer is still actively updating.
-func (dt *DisputeTracker) SetVote(txID consensus.TxID, peerID consensus.NodeID, yes bool) bool {
-	dt.mu.Lock()
-	defer dt.mu.Unlock()
-
+func (dt *disputeTracker) SetVote(txID consensus.TxID, peerID consensus.NodeID, yes bool) bool {
 	dispute, exists := dt.disputes[txID]
 	if !exists {
 		return false
@@ -92,7 +84,7 @@ func (dt *DisputeTracker) SetVote(txID consensus.TxID, peerID consensus.NodeID, 
 
 // updateVoteCount records peerID's yes/no vote on dispute, adjusting
 // the Yays/Nays tallies. Returns true iff the vote was newly inserted
-// or changed from a previous value. Caller must hold dt.mu.
+// or changed from a previous value. Caller must hold the owning Engine's e.mu.
 func updateVoteCount(dispute *consensus.DisputedTx, peerID consensus.NodeID, yes bool) bool {
 	prev, had := dispute.Votes[peerID]
 	switch {
@@ -126,10 +118,7 @@ func updateVoteCount(dispute *consensus.DisputedTx, peerID consensus.NodeID, yes
 //
 // Matches rippled's bow-out loop at Consensus.h:807-811 and the
 // stale-proposal loop at Consensus.h:1517-1520.
-func (dt *DisputeTracker) UnVote(peerID consensus.NodeID) {
-	dt.mu.Lock()
-	defer dt.mu.Unlock()
-
+func (dt *disputeTracker) UnVote(peerID consensus.NodeID) {
 	for _, dispute := range dt.disputes {
 		vote, had := dispute.Votes[peerID]
 		if !had {
@@ -149,13 +138,10 @@ func (dt *DisputeTracker) UnVote(peerID consensus.NodeID) {
 // appears in peerTxSet, else NO. Returns true iff any vote changed.
 //
 // Matches rippled's updateDisputes (Consensus.h:1892-1908).
-func (dt *DisputeTracker) UpdateDisputes(peerID consensus.NodeID, peerTxSet consensus.TxSet) bool {
+func (dt *disputeTracker) UpdateDisputes(peerID consensus.NodeID, peerTxSet consensus.TxSet) bool {
 	if peerTxSet == nil {
 		return false
 	}
-	dt.mu.Lock()
-	defer dt.mu.Unlock()
-
 	changed := false
 	for txID, dispute := range dt.disputes {
 		if updateVoteCount(dispute, peerID, peerTxSet.Contains(txID)) {
@@ -182,10 +168,7 @@ func (dt *DisputeTracker) UpdateDisputes(peerID consensus.NodeID, peerTxSet cons
 //
 // Returns the list of TxIDs whose OurVote flipped this call. The
 // engine uses that list to rebuild the proposed tx set.
-func (dt *DisputeTracker) UpdateOurVote(percentTime int, proposing bool, parms consensus.ConsensusParms) []consensus.TxID {
-	dt.mu.Lock()
-	defer dt.mu.Unlock()
-
+func (dt *disputeTracker) UpdateOurVote(percentTime int, proposing bool, parms consensus.ConsensusParms) []consensus.TxID {
 	var changed []consensus.TxID
 	for txID, dispute := range dt.disputes {
 		if dispute.OurVote && dispute.Nays == 0 {
@@ -241,9 +224,7 @@ func (dt *DisputeTracker) UpdateOurVote(percentTime int, proposing bool, parms c
 //
 // Matches rippled's std::ranges::all_of stalled check at
 // Consensus.h:1720-1728.
-func (dt *DisputeTracker) AllStalled(parms consensus.ConsensusParms, proposing bool, peersUnchanged int) bool {
-	dt.mu.RLock()
-	defer dt.mu.RUnlock()
+func (dt *disputeTracker) AllStalled(parms consensus.ConsensusParms, proposing bool, peersUnchanged int) bool {
 	if len(dt.disputes) == 0 {
 		return false
 	}
@@ -303,58 +284,51 @@ func disputeStalled(d *consensus.DisputedTx, parms consensus.ConsensusParms, pro
 }
 
 // Dispute returns a disputed transaction.
-func (dt *DisputeTracker) Dispute(txID consensus.TxID) *consensus.DisputedTx {
-	dt.mu.RLock()
-	defer dt.mu.RUnlock()
+func (dt *disputeTracker) Dispute(txID consensus.TxID) *consensus.DisputedTx {
 	return dt.disputes[txID]
 }
 
 // Has reports whether a dispute exists for the given TxID.
-func (dt *DisputeTracker) Has(txID consensus.TxID) bool {
-	dt.mu.RLock()
-	defer dt.mu.RUnlock()
+func (dt *disputeTracker) Has(txID consensus.TxID) bool {
 	_, ok := dt.disputes[txID]
 	return ok
 }
 
-// DisputedNoTxs returns the raw blobs of every dispute we currently vote NO
-// on — txs peers proposed that end up excluded from the consensus set.
-func (dt *DisputeTracker) DisputedNoTxs() [][]byte {
-	dt.mu.RLock()
-	defer dt.mu.RUnlock()
-
+// DisputedNoTxs returns detached raw blobs of every dispute we currently vote
+// NO on — txs peers proposed that end up excluded from the consensus set.
+func (dt *disputeTracker) DisputedNoTxs() [][]byte {
 	var txs [][]byte
 	for _, d := range dt.disputes {
 		if !d.OurVote {
-			txs = append(txs, d.Tx)
+			txs = append(txs, append([]byte(nil), d.Tx...))
 		}
 	}
 	return txs
 }
 
-// All returns all disputed transactions.
-func (dt *DisputeTracker) All() []*consensus.DisputedTx {
-	dt.mu.RLock()
-	defer dt.mu.RUnlock()
-
+// All returns detached snapshots of all disputed transactions.
+func (dt *disputeTracker) All() []*consensus.DisputedTx {
 	result := make([]*consensus.DisputedTx, 0, len(dt.disputes))
 	for _, d := range dt.disputes {
-		result = append(result, d)
+		result = append(result, cloneDisputedTx(d))
 	}
 	return result
 }
 
 // Count returns the number of disputes.
-func (dt *DisputeTracker) Count() int {
-	dt.mu.RLock()
-	defer dt.mu.RUnlock()
+func (dt *disputeTracker) Count() int {
 	return len(dt.disputes)
 }
 
-// Clear removes all disputes.
-func (dt *DisputeTracker) Clear() {
-	dt.mu.Lock()
-	defer dt.mu.Unlock()
-
-	dt.disputes = make(map[consensus.TxID]*consensus.DisputedTx)
+func cloneDisputedTx(d *consensus.DisputedTx) *consensus.DisputedTx {
+	if d == nil {
+		return nil
+	}
+	copy := *d
+	copy.Tx = append([]byte(nil), d.Tx...)
+	copy.Votes = make(map[consensus.NodeID]bool, len(d.Votes))
+	for nodeID, vote := range d.Votes {
+		copy.Votes[nodeID] = vote
+	}
+	return &copy
 }

--- a/internal/consensus/rcl/proposals_test.go
+++ b/internal/consensus/rcl/proposals_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestDisputeTracker_CreateAndVote(t *testing.T) {
-	dt := NewDisputeTracker()
+	dt := newDisputeTracker()
 
 	txID := consensus.TxID{1}
 	tx := []byte("test tx")
@@ -65,7 +65,7 @@ func TestDisputeTracker_CreateAndVote(t *testing.T) {
 }
 
 func TestDisputeTracker_UnVote(t *testing.T) {
-	dt := NewDisputeTracker()
+	dt := newDisputeTracker()
 
 	tx1 := consensus.TxID{1}
 	tx2 := consensus.TxID{2}
@@ -114,7 +114,7 @@ func TestDisputeTracker_UnVote(t *testing.T) {
 }
 
 func TestDisputeTracker_UpdateDisputes(t *testing.T) {
-	dt := NewDisputeTracker()
+	dt := newDisputeTracker()
 
 	tx1 := consensus.TxID{1}
 	tx2 := consensus.TxID{2}
@@ -147,7 +147,7 @@ func TestDisputeTracker_UpdateDisputes(t *testing.T) {
 }
 
 func TestDisputeTracker_UpdateOurVote_AvalancheRamp(t *testing.T) {
-	dt := NewDisputeTracker()
+	dt := newDisputeTracker()
 	parms := consensus.DefaultConsensusParms()
 
 	txID := consensus.TxID{1}
@@ -233,5 +233,24 @@ func TestDisputeTracker_UpdateOurVote_AvalancheRamp(t *testing.T) {
 	dt.UpdateOurVote(210, true, parms)
 	if ramp.AvalancheState != consensus.AvalancheStuck {
 		t.Errorf("after 210%% time, state = %v, want Stuck", ramp.AvalancheState)
+	}
+}
+
+func TestDisputeTracker_AllReturnsDetachedSnapshots(t *testing.T) {
+	dt := newDisputeTracker()
+	txID := consensus.TxID{1}
+	peer := consensus.NodeID{2}
+	dt.CreateDispute(txID, []byte{1, 2}, true)
+	dt.SetVote(txID, peer, true)
+
+	snapshot := dt.All()[0]
+	snapshot.OurVote = false
+	snapshot.Tx[0] = 9
+	snapshot.Votes[peer] = false
+	snapshot.Votes[consensus.NodeID{3}] = true
+
+	stored := dt.Dispute(txID)
+	if !stored.OurVote || stored.Tx[0] != 1 || !stored.Votes[peer] || len(stored.Votes) != 1 {
+		t.Fatalf("mutating dispute snapshot changed tracker state: %#v", stored)
 	}
 }

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -155,13 +155,8 @@ type ValidationTracker struct {
 	trusted map[consensus.NodeID]bool
 
 	// negUNL is the set of validators disabled via the negative-UNL
-	// mechanism. They do NOT count toward the full-validation quorum for
-	// a ledger, nor toward the quorum/peer-LCL support the engine reads
-	// via the quorum/support read paths — matching rippled, which filters negative-UNL
-	// entries before every quorum comparison. They DO still steer
-	// preferred-ledger selection through the trie: rippled's updateTrie
-	// gates only on trusted(), so a deemed-offline validator still
-	// contributes branch support to GetPreferred / getNodesAfter.
+	// mechanism. They are excluded from full-validation quorum counts but
+	// still steer preferred-ledger selection through the trie.
 	negUNL map[consensus.NodeID]bool
 
 	// quorum is the number of validations needed for finality
@@ -207,12 +202,10 @@ type ValidationTracker struct {
 	// the trie; the tracker then falls back to flat hash-count support.
 	ancestry LedgerAncestryProvider
 
-	// trie holds branchSupport for every trusted validator's latest tip,
-	// INCLUDING validators on the negUNL — mirroring rippled's
-	// trusted()-only updateTrie so negUNL validators still steer
-	// GetPreferred / ProposersFinished. The negUNL-excluded count the
-	// engine's quorum/peer-LCL gates need is derived separately in
-	// the trusted-support helper. nil when ancestry is unset.
+	// trie holds branch support for every trusted validator's latest tip,
+	// including validators on the negUNL, so they continue to steer
+	// GetPreferred and ProposersFinished. Full-validation quorum counts
+	// exclude negUNL validators separately. nil when ancestry is unset.
 	trie *ledgertrie.Trie
 
 	// trieTips records each validator's current trie tip so a newer

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -157,7 +157,7 @@ type ValidationTracker struct {
 	// negUNL is the set of validators disabled via the negative-UNL
 	// mechanism. They do NOT count toward the full-validation quorum for
 	// a ledger, nor toward the quorum/peer-LCL support the engine reads
-	// via GetTrustedSupport — matching rippled, which filters negative-UNL
+	// via the quorum/support read paths — matching rippled, which filters negative-UNL
 	// entries before every quorum comparison. They DO still steer
 	// preferred-ledger selection through the trie: rippled's updateTrie
 	// gates only on trusted(), so a deemed-offline validator still
@@ -171,9 +171,6 @@ type ValidationTracker struct {
 	// between a publisher-status change and installation of the corresponding
 	// trusted/quorum snapshot.
 	quorumUnavailable func() bool
-
-	// freshness is how long validations are considered fresh
-	freshness time.Duration
 
 	// fired records ledgers we've already reported as fully validated,
 	// so the callback fires exactly once per ledger even if more
@@ -215,7 +212,7 @@ type ValidationTracker struct {
 	// trusted()-only updateTrie so negUNL validators still steer
 	// GetPreferred / ProposersFinished. The negUNL-excluded count the
 	// engine's quorum/peer-LCL gates need is derived separately in
-	// branchSupportExcludingNegUNLLocked. nil when ancestry is unset.
+	// the trusted-support helper. nil when ancestry is unset.
 	trie *ledgertrie.Trie
 
 	// trieTips records each validator's current trie tip so a newer
@@ -235,7 +232,7 @@ type ValidationTracker struct {
 // The tracker's freshness clock defaults to time.Now; wire it to
 // adaptor.Now via SetNow before use so isCurrent honors the network
 // close-time offset.
-func NewValidationTracker(quorum int, freshness time.Duration) *ValidationTracker {
+func NewValidationTracker(quorum int) *ValidationTracker {
 	return &ValidationTracker{
 		now:          time.Now,
 		validations:  make(map[consensus.LedgerID]*ledgerValidations),
@@ -245,7 +242,6 @@ func NewValidationTracker(quorum int, freshness time.Duration) *ValidationTracke
 		trusted:      make(map[consensus.NodeID]bool),
 		negUNL:       make(map[consensus.NodeID]bool),
 		quorum:       quorum,
-		freshness:    freshness,
 		fired:        make(map[consensus.LedgerID]struct{}),
 	}
 }
@@ -266,15 +262,6 @@ func (vt *ValidationTracker) SetNow(fn func() time.Time) {
 	vt.now = fn
 }
 
-// SetTrusted updates the set of trusted validators and rebuilds the
-// trie if wired so de-trusted validators stop contributing support.
-func (vt *ValidationTracker) SetTrusted(nodes []consensus.NodeID) {
-	vt.mu.Lock()
-	vt.setTrustedLocked(nodes)
-	vt.mu.Unlock()
-	vt.checkAcquired()
-}
-
 // SetTrustedAndQuorum updates the trusted set and its quorum atomically.
 func (vt *ValidationTracker) SetTrustedAndQuorum(nodes []consensus.NodeID, quorum int) {
 	vt.mu.Lock()
@@ -290,13 +277,6 @@ func (vt *ValidationTracker) setTrustedLocked(nodes []consensus.NodeID) {
 		vt.trusted[node] = true
 	}
 	vt.rebuildTrieLocked()
-}
-
-// SetQuorum updates the quorum requirement.
-func (vt *ValidationTracker) SetQuorum(quorum int) {
-	vt.mu.Lock()
-	defer vt.mu.Unlock()
-	vt.quorum = quorum
 }
 
 // SetQuorumUnavailableFunc installs the live finality safety gate.
@@ -762,72 +742,6 @@ func (vt *ValidationTracker) countTrustedExcludingNegUNLLocked(
 	count := 0
 	for nodeID, v := range ledgerVals {
 		if v.Full && vt.trusted[nodeID] && !vt.negUNL[nodeID] {
-			count++
-		}
-	}
-	return count
-}
-
-// TrustedSupport returns the count of trusted-and-not-negUNL
-// validators committing to this ledger or any descendant — the
-// negUNL-excluded analogue of the trie's branchSupport. The trie itself
-// includes negUNL validators (for GetPreferred steering), so the
-// exclusion is applied here in branchSupportExcludingNegUNLLocked
-// rather than at trie membership. Polls checkAcquired before reading,
-// rippled's withTrie cadence. Falls back to the flat trusted count when
-// the trie or ancestry is unavailable.
-func (vt *ValidationTracker) TrustedSupport(ledgerID consensus.LedgerID) int {
-	vt.checkAcquired()
-
-	// Snapshot pointers, drop the lock for ancestry resolution, then
-	// re-acquire for the cheap trie query.
-	vt.mu.RLock()
-	trie := vt.trie
-	ancestry := vt.ancestry
-	vt.mu.RUnlock()
-
-	if trie == nil || ancestry == nil {
-		return vt.TrustedValidationCount(ledgerID)
-	}
-
-	lgr, ok := ancestry.LedgerByID(ledgerID)
-	if !ok {
-		return vt.TrustedValidationCount(ledgerID)
-	}
-
-	vt.mu.Lock()
-	defer vt.mu.Unlock()
-	// Trie may have been swapped while we resolved ancestry.
-	if vt.trie != trie {
-		ledgerVals, exists := vt.validations[ledgerID]
-		if !exists {
-			return 0
-		}
-		ledgerVals.touch(vt.now())
-		return vt.countTrustedExcludingNegUNLLocked(ledgerVals.vals)
-	}
-	return vt.branchSupportExcludingNegUNLLocked(lgr)
-}
-
-// branchSupportExcludingNegUNLLocked counts the trusted validators whose
-// current trie tip is lgr or one of lgr's descendants, EXCLUDING any on
-// the negUNL. It is the negUNL-aware analogue of trie.BranchSupport: the
-// trie now mirrors rippled's trusted()-only updateTrie and therefore
-// includes negUNL validators for preferred-ledger steering, but the
-// engine's quorum / peer-LCL gates must not credit a deemed-offline
-// validator toward branch support. A tip supports lgr iff lgr lies on
-// the tip's ancestry chain at lgr's sequence — exactly the membership
-// trie.BranchSupport sums, since every validator inserts weight 1.
-// Caller must hold vt.mu.
-func (vt *ValidationTracker) branchSupportExcludingNegUNLLocked(lgr ledgertrie.Ledger) int {
-	targetSeq := lgr.Seq()
-	targetID := lgr.ID()
-	count := 0
-	for nodeID, tip := range vt.trieTips {
-		if vt.negUNL[nodeID] {
-			continue
-		}
-		if tip.Seq() >= targetSeq && tip.Ancestor(targetSeq) == targetID {
 			count++
 		}
 	}

--- a/internal/consensus/rcl/validations_acquire_test.go
+++ b/internal/consensus/rcl/validations_acquire_test.go
@@ -29,7 +29,7 @@ func (p *lockProbeAncestryProvider) LedgerByID(id consensus.LedgerID) (ledgertri
 // the ledger is acquired the next GetPreferred poll replays the parked
 // validations and the trie flips — no new validation needed.
 func TestValidationTracker_UnresolvableValidationParksThenReplays(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -80,7 +80,7 @@ func TestValidationTracker_UnresolvableValidationParksThenReplays(t *testing.T) 
 }
 
 func TestValidationTracker_AncestryLookupDoesNotHoldTrackerLock(t *testing.T) {
-	vt := NewValidationTracker(1, 5*time.Minute)
+	vt := NewValidationTracker(1)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -120,7 +120,7 @@ func TestValidationTracker_AncestryLookupDoesNotHoldTrackerLock(t *testing.T) {
 // The consensus-island shape: the trie decides even when the majority is
 // parked, and flips to the majority branch once its ledger is acquired.
 func TestValidationTracker_TrieDecidesWithMajorityParked(t *testing.T) {
-	vt := NewValidationTracker(3, 5*time.Minute)
+	vt := NewValidationTracker(3)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -169,7 +169,7 @@ func TestValidationTracker_TrieDecidesWithMajorityParked(t *testing.T) {
 // replayed by the read itself — no intervening Add or GetPreferred
 // (rippled testAcquireValidatedLedger, Validations_test.cpp:958-961).
 func TestValidationTracker_ReadPollReplaysParked(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -202,7 +202,7 @@ func TestValidationTracker_ReadPollReplaysParked(t *testing.T) {
 // GetTrustedSupport's read also polls: an acquired-but-unreplayed parked
 // validation counts toward branch support with no intervening call.
 func TestValidationTracker_GetTrustedSupportPollReplaysParked(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -227,7 +227,7 @@ func TestValidationTracker_GetTrustedSupportPollReplaysParked(t *testing.T) {
 // over still-acquiring ledgers: most parked validators first, ties to
 // the greater ledger ID.
 func TestValidationTracker_GetPreferred_AcquiringMajorityFallback(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -252,7 +252,7 @@ func TestValidationTracker_GetPreferred_AcquiringMajorityFallback(t *testing.T) 
 }
 
 func TestValidationTracker_GetPreferred_AcquiringTieBreaksOnGreaterID(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -278,7 +278,7 @@ func TestValidationTracker_GetPreferred_AcquiringTieBreaksOnGreaterID(t *testing
 // A superseding validation removes the node from its prior parked entry,
 // so abandoned acquiring entries don't linger.
 func TestValidationTracker_SupersededValidationUnparks(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -305,7 +305,7 @@ func TestValidationTracker_SupersededValidationUnparks(t *testing.T) {
 // ExpireOld drops parked entries with the validations that reference
 // them — acquiring_ never outlives its validations.
 func TestValidationTracker_ExpireOldUnparks(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -331,7 +331,7 @@ func TestValidationTracker_ExpireOldUnparks(t *testing.T) {
 // the acquiring fallback, and must not be resurrected into the trie as a
 // phantom tip once its ledger is finally acquired.
 func TestValidationTracker_FlushStaleUnparks(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -371,7 +371,7 @@ func TestValidationTracker_FlushStaleUnparks(t *testing.T) {
 // Validations_test.cpp:1098-1124, "Trusted but not acquired ->
 // untrusted").
 func TestValidationTracker_DetrustedParkedValidationNotReplayed(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -403,7 +403,7 @@ func TestValidationTracker_DetrustedParkedValidationNotReplayed(t *testing.T) {
 // node's parked entry drops, and re-trusting re-parks its latest
 // validation.
 func TestValidationTracker_TrustChangeReparksFromByNode(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 

--- a/internal/consensus/rcl/validations_helpers_test.go
+++ b/internal/consensus/rcl/validations_helpers_test.go
@@ -1,10 +1,79 @@
 package rcl
 
-import "github.com/LeJamon/go-xrpl/internal/consensus"
+import (
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrie"
+)
 
 // This file holds ValidationTracker query methods that exist only to
 // support tests. Keeping them out of validations.go keeps the production
 // API surface limited to what the engine actually calls.
+
+// SetTrusted updates the trusted set without changing the test tracker's
+// quorum. Production code uses SetTrustedAndQuorum so the two values always
+// install atomically.
+func (vt *ValidationTracker) SetTrusted(nodes []consensus.NodeID) {
+	vt.mu.Lock()
+	vt.setTrustedLocked(nodes)
+	vt.mu.Unlock()
+	vt.checkAcquired()
+}
+
+// SetQuorum updates the quorum requirement for tests. Production code sets
+// quorum together with the trusted set via SetTrustedAndQuorum.
+func (vt *ValidationTracker) SetQuorum(quorum int) {
+	vt.mu.Lock()
+	vt.quorum = quorum
+	vt.mu.Unlock()
+}
+
+// TrustedSupport returns trusted, non-negative-UNL validators supporting the
+// ledger or one of its descendants. It mirrors the old test-facing query;
+// production callers use the finality and preferred-ledger APIs directly.
+func (vt *ValidationTracker) TrustedSupport(ledgerID consensus.LedgerID) int {
+	vt.checkAcquired()
+
+	vt.mu.RLock()
+	trie := vt.trie
+	ancestry := vt.ancestry
+	vt.mu.RUnlock()
+
+	if trie == nil || ancestry == nil {
+		return vt.TrustedValidationCount(ledgerID)
+	}
+
+	lgr, ok := ancestry.LedgerByID(ledgerID)
+	if !ok {
+		return vt.TrustedValidationCount(ledgerID)
+	}
+
+	vt.mu.Lock()
+	defer vt.mu.Unlock()
+	if vt.trie != trie {
+		ledgerVals, exists := vt.validations[ledgerID]
+		if !exists {
+			return 0
+		}
+		ledgerVals.touch(vt.now())
+		return vt.countTrustedExcludingNegUNLLocked(ledgerVals.vals)
+	}
+	return vt.branchSupportExcludingNegUNLLocked(lgr)
+}
+
+func (vt *ValidationTracker) branchSupportExcludingNegUNLLocked(lgr ledgertrie.Ledger) int {
+	targetSeq := lgr.Seq()
+	targetID := lgr.ID()
+	count := 0
+	for nodeID, tip := range vt.trieTips {
+		if vt.negUNL[nodeID] {
+			continue
+		}
+		if tip.Seq() >= targetSeq && tip.Ancestor(targetSeq) == targetID {
+			count++
+		}
+	}
+	return count
+}
 
 // GetValidationCount returns the count of validations for a ledger.
 func (vt *ValidationTracker) GetValidationCount(ledgerID consensus.LedgerID) int {

--- a/internal/consensus/rcl/validations_partial_test.go
+++ b/internal/consensus/rcl/validations_partial_test.go
@@ -16,7 +16,7 @@ import (
 // but is excluded from the full-validation quorum count, so it cannot by
 // itself fire the fully-validated callback. A later FULL validation does.
 func TestValidationTracker_TrustedPartialSteersButNotQuorum(t *testing.T) {
-	vt := NewValidationTracker(1, 5*time.Minute) // quorum = 1
+	vt := NewValidationTracker(1) // quorum = 1
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -80,7 +80,7 @@ func TestValidationTracker_TrustedPartialSteersButNotQuorum(t *testing.T) {
 func TestValidationTracker_AddStatus_Classification(t *testing.T) {
 	base := time.Unix(1_700_000_000, 0)
 	now := base
-	vt := NewValidationTracker(10, 5*time.Minute)
+	vt := NewValidationTracker(10)
 	vt.SetNow(func() time.Time { return now })
 
 	node := consensus.NodeID{0x9}
@@ -141,7 +141,7 @@ func TestValidationTracker_AddStatus_Classification(t *testing.T) {
 // branch, so a partial equivocation is flagged just like a full one.
 func TestValidationTracker_AddStatus_PartialDoubleSign(t *testing.T) {
 	base := time.Unix(1_700_000_000, 0)
-	vt := NewValidationTracker(10, 5*time.Minute)
+	vt := NewValidationTracker(10)
 	vt.SetNow(func() time.Time { return base })
 
 	node := consensus.NodeID{0x7}

--- a/internal/consensus/rcl/validations_test.go
+++ b/internal/consensus/rcl/validations_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestValidationTracker_Add(t *testing.T) {
-	vt := NewValidationTracker(3, 5*time.Minute)
+	vt := NewValidationTracker(3)
 
 	node1 := consensus.NodeID{1}
 	node2 := consensus.NodeID{2}
@@ -55,7 +55,7 @@ func TestValidationTracker_Add(t *testing.T) {
 
 func TestValidationTrackerUnreachableQuorumDoesNotFinalize(t *testing.T) {
 	nodes := []consensus.NodeID{{1}, {2}}
-	vt := NewValidationTracker(math.MaxInt, 5*time.Minute)
+	vt := NewValidationTracker(math.MaxInt)
 	vt.SetTrusted(nodes)
 
 	fired := false
@@ -77,7 +77,7 @@ func TestValidationTrackerUnreachableQuorumDoesNotFinalize(t *testing.T) {
 
 func TestValidationTrackerLiveQuorumUnavailableGate(t *testing.T) {
 	nodes := []consensus.NodeID{{1}, {2}, {3}}
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	vt.SetTrusted(nodes)
 
 	unavailable := true
@@ -108,7 +108,7 @@ func TestValidationTrackerLiveQuorumUnavailableGate(t *testing.T) {
 }
 
 func TestValidationTracker_TrustedValidations(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 
 	node1 := consensus.NodeID{1}
 	node2 := consensus.NodeID{2}
@@ -135,7 +135,7 @@ func TestValidationTracker_TrustedValidations(t *testing.T) {
 }
 
 func TestValidationTracker_RecheckFullyValidatedFiltersAndRearms(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
 	vt.SetNow(func() time.Time { return now })
 
@@ -194,7 +194,7 @@ func TestValidationTracker_RecheckFullyValidatedFiltersAndRearms(t *testing.T) {
 
 func TestValidationTracker_FullyValidated(t *testing.T) {
 	quorum := 3
-	vt := NewValidationTracker(quorum, 5*time.Minute)
+	vt := NewValidationTracker(quorum)
 
 	nodes := []consensus.NodeID{{1}, {2}, {3}, {4}}
 	vt.SetTrusted(nodes)
@@ -261,7 +261,7 @@ func TestValidationTracker_FullyValidated(t *testing.T) {
 }
 
 func TestValidationTracker_NewerValidation(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 
 	node1 := consensus.NodeID{1}
 	ledger1 := consensus.LedgerID{1}
@@ -314,7 +314,7 @@ func TestValidationTracker_NewerValidation(t *testing.T) {
 // SeqEnforcer, so the by-node guard enforces the same outcome with a
 // strictly-higher-seq supersede rule.
 func TestValidationTracker_SameSeqResignRejected(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 
 	base := time.Unix(1_600_000_000, 0).UTC()
 	vt.SetNow(func() time.Time { return base })
@@ -391,7 +391,7 @@ func TestValidationTracker_SameSeqResignRejected(t *testing.T) {
 // would spuriously contribute to quorum.
 func TestValidationTracker_NegativeUNL_ExcludedFromQuorum(t *testing.T) {
 	nodes := []consensus.NodeID{{1}, {2}, {3}, {4}}
-	vt := NewValidationTracker(3, 5*time.Minute)
+	vt := NewValidationTracker(3)
 	vt.SetTrusted(nodes)
 	// Mark node 4 as negatively-UNL'd.
 	vt.SetNegativeUNL([]consensus.NodeID{nodes[3]})
@@ -451,7 +451,7 @@ func TestValidationTracker_NegativeUNL_ExcludedFromQuorum(t *testing.T) {
 // Filters: trusted only, not-negUNL, Full only.
 func TestValidationTracker_ProposersValidated(t *testing.T) {
 	nodes := []consensus.NodeID{{1}, {2}, {3}, {4}, {5}}
-	vt := NewValidationTracker(3, 5*time.Minute)
+	vt := NewValidationTracker(3)
 	vt.SetTrusted(nodes[:4])                        // 1-4 trusted; 5 is untrusted
 	vt.SetNegativeUNL([]consensus.NodeID{nodes[3]}) // node 4 on negUNL
 
@@ -582,7 +582,7 @@ func TestIsCurrent_WindowBoundaries(t *testing.T) {
 }
 
 func TestValidationTracker_Stats(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 
 	nodes := []consensus.NodeID{{1}, {2}, {3}}
 	vt.SetTrusted(nodes[:2])
@@ -615,7 +615,7 @@ func TestValidationTracker_Stats(t *testing.T) {
 }
 
 func TestValidationTracker_ExpireOld_FiresOnStale(t *testing.T) {
-	vt := NewValidationTracker(1, 5*time.Minute)
+	vt := NewValidationTracker(1)
 
 	nodeA := consensus.NodeID{0xA}
 	nodeB := consensus.NodeID{0xB}
@@ -656,7 +656,7 @@ func TestValidationTracker_ExpireOld_FiresOnStale(t *testing.T) {
 }
 
 func TestValidationTracker_ExpireOld_ClearsByNode(t *testing.T) {
-	vt := NewValidationTracker(1, 5*time.Minute)
+	vt := NewValidationTracker(1)
 
 	nodeA := consensus.NodeID{0xA}
 	ledger := consensus.LedgerID{1}
@@ -677,7 +677,7 @@ func TestValidationTracker_ExpireOld_ClearsByNode(t *testing.T) {
 // ExpireOld's onStale hook runs outside the tracker mutex: a callback that
 // calls back into the tracker must not deadlock.
 func TestValidationTracker_ExpireOld_OnStaleRunsOutsideLock(t *testing.T) {
-	vt := NewValidationTracker(1, 5*time.Minute)
+	vt := NewValidationTracker(1)
 	vt.Add(&consensus.Validation{LedgerID: consensus.LedgerID{1}, LedgerSeq: 100, NodeID: consensus.NodeID{1}, SignTime: time.Now(), Full: true})
 
 	done := make(chan struct{})
@@ -703,7 +703,7 @@ func TestValidationTracker_ExpireOld_OnStaleRunsOutsideLock(t *testing.T) {
 // window keeps recently-used ledgers queryable regardless of how far
 // back their sequence is.
 func TestValidationTracker_ExpireOld_RetainsRecentlyAccessed(t *testing.T) {
-	vt := NewValidationTracker(1, 5*time.Minute)
+	vt := NewValidationTracker(1)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -739,7 +739,7 @@ func TestValidationTracker_ExpireOld_RetainsRecentlyAccessed(t *testing.T) {
 // fast-advancing tip. The pin is selective (sequences below its low still
 // evict) and clearing it restores normal expiry.
 func TestValidationTracker_ExpireOld_HonorsSeqToKeep(t *testing.T) {
-	vt := NewValidationTracker(1, 5*time.Minute)
+	vt := NewValidationTracker(1)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -775,7 +775,7 @@ func TestValidationTracker_ExpireOld_HonorsSeqToKeep(t *testing.T) {
 // keepLow (inclusive) survives. Mirrors rippled setSeqToKeep(C-1, C) dropping
 // the set at C (Validations_test.cpp).
 func TestValidationTracker_ExpireOld_SeqToKeepHighExclusive(t *testing.T) {
-	vt := NewValidationTracker(1, 5*time.Minute)
+	vt := NewValidationTracker(1)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -801,7 +801,7 @@ func TestValidationTracker_ExpireOld_SeqToKeepHighExclusive(t *testing.T) {
 // byLedger touch — so an actively-queried set keeps surviving ExpireOld
 // while an unqueried sibling at the same seq expires.
 func TestValidationTracker_ExpireOld_TouchOnReadExtends(t *testing.T) {
-	vt := NewValidationTracker(1, 5*time.Minute)
+	vt := NewValidationTracker(1)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -835,7 +835,7 @@ func TestValidationTracker_ExpireOld_TouchOnReadExtends(t *testing.T) {
 // validations still expires once its creation/read age passes the
 // window.
 func TestValidationTracker_ExpireOld_WriteDoesNotExtend(t *testing.T) {
-	vt := NewValidationTracker(1, 5*time.Minute)
+	vt := NewValidationTracker(1)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -862,7 +862,7 @@ func TestValidationTracker_ExpireOld_WriteDoesNotExtend(t *testing.T) {
 // Application.cpp:1612): all accumulated validation state is discarded
 // while configuration survives, so the tracker is reusable in-process.
 func TestValidationTracker_Flush(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -922,7 +922,7 @@ func TestValidationTracker_Flush(t *testing.T) {
 // trusted or not, partial or full — excludes entries whose latest validation
 // has aged out, and does not mutate the tracker (FlushStale owns eviction).
 func TestValidationTracker_GetCurrentNodeIDs(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	t0 := time.Now()
 	vt.SetNow(func() time.Time { return t0 })
 

--- a/internal/consensus/rcl/validations_trie_test.go
+++ b/internal/consensus/rcl/validations_trie_test.go
@@ -48,7 +48,7 @@ func makeTrustedValidation(nodeID consensus.NodeID, ledgerID consensus.LedgerID,
 }
 
 func TestValidationTracker_InsertTipDoesNotRecordRejectedLedger(t *testing.T) {
-	vt := NewValidationTracker(1, 5*time.Minute)
+	vt := NewValidationTracker(1)
 	vt.trie = ledgertrie.New(genesisLedger{})
 	vt.trieTips = make(map[consensus.NodeID]ledgertrie.Ledger)
 
@@ -86,7 +86,7 @@ func TestValidationTracker_InsertTipDoesNotRecordRejectedLedger(t *testing.T) {
 // branchSupport(abc) = 1, so the majority-deeper branch correctly
 // wins.
 func TestValidationTracker_TrieDeepestSharedAncestor(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
@@ -145,7 +145,7 @@ func TestValidationTracker_TrieDeepestSharedAncestor(t *testing.T) {
 // abc to abde, the trie must remove abc's tip and insert abde's, so
 // branchSupport reflects the actual current network state.
 func TestValidationTracker_TrieNewerValidationReplacesOld(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -187,7 +187,7 @@ func TestValidationTracker_TrieNewerValidationReplacesOld(t *testing.T) {
 // (post-#939) it now enters the trie for preferred-ledger steering. The
 // exclusion lives on the support read path, not on trie membership.
 func TestValidationTracker_TrieNegUNLExcluded(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -227,7 +227,7 @@ func TestValidationTracker_TrieNegUNLExcluded(t *testing.T) {
 // backing, the shared ancestor a has only n1's 1. The pre-fix trie
 // (which dropped negUNL at insert) would instead have steered to ab.
 func TestValidationTracker_TrieNegUNLSteersButExcludedFromQuorum(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -279,7 +279,7 @@ func TestValidationTracker_TrieNegUNLSteersButExcludedFromQuorum(t *testing.T) {
 // competition through the full Add() path and asserts GetPreferred
 // returns the trie's SpanTip.
 func TestValidationTracker_TrieGetPreferred(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -330,7 +330,7 @@ func TestValidationTracker_TrieGetPreferred(t *testing.T) {
 // descent starts, so the same 3-2 margin no longer beats uncommitted
 // and the descent stops at the common ancestor "a".
 func TestValidationTracker_TrieGetPreferred_LargestIssuedAffectsDescent(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -385,7 +385,7 @@ func TestValidationTracker_TrieGetPreferred_LargestIssuedAffectsDescent(t *testi
 // TestValidationTracker_TrieDisabled_FallsBack keeps the existing
 // flat-count behaviour when no ancestry provider is installed.
 func TestValidationTracker_TrieDisabled_FallsBack(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -416,7 +416,7 @@ func TestValidationTracker_TrieDisabled_FallsBack(t *testing.T) {
 // Mirrors rippled's removeTrie call in Validations::eraseFromCurrent
 // (Validations.h:519-523).
 func TestValidationTracker_ExpireOldDropsTrieTip(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -463,7 +463,7 @@ func TestValidationTracker_ExpireOldDropsTrieTip(t *testing.T) {
 // quorum count. Exercises the seq-only fallback (no ancestry provider)
 // where the prior code wrongly skipped negUNL.
 func TestValidationTracker_ProposersFinishedIncludesNegUNL(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 	now := time.Now()
 	vt.SetNow(func() time.Time { return now })
 
@@ -487,7 +487,7 @@ func TestValidationTracker_ProposersFinishedIncludesNegUNL(t *testing.T) {
 // nil while the trie is disabled, and a marshalable support snapshot once an
 // ancestry provider is wired and a trusted validation is inserted.
 func TestValidationTracker_GetJSONTrie(t *testing.T) {
-	vt := NewValidationTracker(2, 5*time.Minute)
+	vt := NewValidationTracker(2)
 
 	if js := vt.GetJSONTrie(); js != nil {
 		t.Fatalf("GetJSONTrie with no ancestry provider must be nil, got %v", js)

--- a/internal/consensus/types.go
+++ b/internal/consensus/types.go
@@ -544,7 +544,7 @@ type DisputedTx struct {
 
 	// Votes tracks per-peer yes/no votes on this transaction. A peer
 	// without an entry has not yet reported a position that lets us
-	// count it. Maintained by DisputeTracker.SetVote / UnVote.
+	// count it. Maintained by rcl's dispute tracker.
 	Votes map[NodeID]bool
 
 	// AvalancheState is the current threshold bracket for this

--- a/internal/testing/validationarchive/archive_test.go
+++ b/internal/testing/validationarchive/archive_test.go
@@ -60,7 +60,7 @@ func TestValidationArchive_StaleValidationWrittenOnPrune(t *testing.T) {
 	}, nil)
 	defer a.Close(context.Background())
 
-	tracker := rcl.NewValidationTracker(1, 5*time.Minute)
+	tracker := rcl.NewValidationTracker(1)
 	tracker.SetOnStale(a.OnStale)
 
 	v := mkValidation(100, 0x01)
@@ -233,9 +233,9 @@ func TestValidationArchive_EngineDrivenFlow(t *testing.T) {
 	}, nil)
 	defer a.Close(context.Background())
 
-	tracker := rcl.NewValidationTracker(2, 5*time.Minute)
+	tracker := rcl.NewValidationTracker(2)
 	trustedNodes := []consensus.NodeID{{1}, {2}, {3}}
-	tracker.SetTrusted(trustedNodes)
+	tracker.SetTrustedAndQuorum(trustedNodes, 2)
 	tracker.SetOnStale(a.OnStale)
 
 	// Pretend the engine wired its fully-validated callback to drive


### PR DESCRIPTION
## Summary

- make proposal and dispute trackers package-private and consistently owned by `Engine.mu`
- clone mutable proposal, validation, and dispute data at tracker boundaries
- remove dead counters, getters, tracker methods, and test-only production APIs
- remove the unused validation freshness constructor state and update consumers

## Test plan

- `just test`
- `go test -race ./internal/consensus/rcl ./internal/testing/validationarchive`
- `go test ./internal/consensus/...`
- `just vet`
- `just build-all`
- `just build-nocgo`
- `golangci-lint run ./internal/consensus/rcl/... ./internal/testing/validationarchive/...`
- `just lint`
- `git diff --check`

`go mod tidy -diff` reports only the pre-existing missing `github.com/hashicorp/golang-lru/v2` checksums; this branch does not modify module files.

Part of #1463


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consensus state safety by isolating stored proposal, validation, dispute, transaction, and vote data from external mutations.
  * Streamlined ledger acceptance by using detached dispute snapshots directly.
* **Refactor**
  * Simplified validation tracking and removed obsolete configuration and interfaces.
  * Removed unused consensus statistics and accessors.
* **Tests**
  * Added coverage confirming proposal and dispute snapshots remain independent from tracker state.
  * Updated consensus and validation tests for the streamlined tracking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->