### PR TITLE
fix(consensus): recover ancestry and trie state

### DIFF
--- a/internal/consensus/rcl/ledger_provider.go
+++ b/internal/consensus/rcl/ledger_provider.go
@@ -27,10 +27,19 @@ var _ LedgerHeader = (*ledger.Ledger)(nil)
 
 type hashLookupFunc func(hash [32]byte) (LedgerHeader, error)
 
+// hashOfSeqHeader is implemented by the concrete ledger header when its
+// embedded rolling skip-list can answer ancestry without loading every
+// intervening ledger. Keep this optional so the provider remains useful for
+// narrow test doubles and other header implementations.
+type hashOfSeqHeader interface {
+	HashOfSeq(seq uint32) ([32]byte, bool, error)
+}
+
 // AncestryProvider satisfies LedgerAncestryProvider. It materialises a
 // ledger's ancestor slice once per LedgerID and caches it in an LRU,
 // avoiding O(depth²) ParentHash walks across the trie's many
-// Ancestor(s) calls. Cached chains are immutable so never invalidated.
+// Ancestor(s) calls. Partial chains carry a retry marker and are rechecked
+// before reuse so acquisition can repair them in place.
 type AncestryProvider struct {
 	lookup hashLookupFunc
 
@@ -38,11 +47,17 @@ type AncestryProvider struct {
 	maxItems int
 	cache    map[consensus.LedgerID]*list.Element
 	lru      *list.List // front=most recent, back=least recent
+	inflight map[consensus.LedgerID]*ancestryFlight
 }
 
 type cacheEntry struct {
 	id consensus.LedgerID
 	pl *providerLedger
+}
+
+type ancestryFlight struct {
+	done   chan struct{}
+	result *providerLedger
 }
 
 // NewAncestryProvider wraps the ledger service. A nil svc returns a
@@ -66,6 +81,7 @@ func newAncestryProviderFromLookup(fn hashLookupFunc) *AncestryProvider {
 		maxItems: providerCacheCapacity,
 		cache:    make(map[consensus.LedgerID]*list.Element),
 		lru:      list.New(),
+		inflight: make(map[consensus.LedgerID]*ancestryFlight),
 	}
 }
 
@@ -75,21 +91,71 @@ func (p *AncestryProvider) LedgerByID(id consensus.LedgerID) (ledgertrie.Ledger,
 		return nil, false
 	}
 	if cached, ok := p.cacheGet(id); ok {
+		if !cached.partial {
+			return cached, true
+		}
+		// A failed parent lookup is a transient acquisition state, not a
+		// permanent property of this ledger. Recheck the exact missing hash
+		// before reusing the truncated suffix; once it arrives, rebuild the
+		// chain so MinSeq/Ancestor and trie support recover automatically.
+		if !p.headerAvailable(cached.retryHash, cached.retrySeq) {
+			return cached, true
+		}
+		p.cacheDelete(id, cached)
+	}
+
+	p.mu.Lock()
+	if cached, ok := p.cacheGetLocked(id); ok {
+		p.mu.Unlock()
 		return cached, true
 	}
-
-	built := p.buildChain(id)
-	if built == nil {
-		return nil, false
+	if flight, ok := p.inflight[id]; ok {
+		p.mu.Unlock()
+		<-flight.done
+		if flight.result == nil {
+			return nil, false
+		}
+		return flight.result, true
 	}
+	if p.inflight == nil {
+		p.inflight = make(map[consensus.LedgerID]*ancestryFlight)
+	}
+	flight := &ancestryFlight{done: make(chan struct{})}
+	p.inflight[id] = flight
+	p.mu.Unlock()
 
-	p.cachePut(id, built)
-	return built, true
+	built := p.buildAndFinish(id, flight)
+	return built, built != nil
+}
+
+func (p *AncestryProvider) buildAndFinish(id consensus.LedgerID, flight *ancestryFlight) (built *providerLedger) {
+	defer func() {
+		p.mu.Lock()
+		flight.result = built
+		delete(p.inflight, id)
+		close(flight.done)
+		p.mu.Unlock()
+	}()
+
+	built = p.buildChain(id)
+	if built != nil {
+		p.cachePut(id, built)
+	}
+	return built
+}
+
+func (p *AncestryProvider) headerAvailable(hash [32]byte, seq uint32) bool {
+	header, err := p.lookup(hash)
+	return err == nil && !isNilInterface(header) && header.Hash() == hash && header.Sequence() == seq
 }
 
 func (p *AncestryProvider) cacheGet(id consensus.LedgerID) (*providerLedger, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	return p.cacheGetLocked(id)
+}
+
+func (p *AncestryProvider) cacheGetLocked(id consensus.LedgerID) (*providerLedger, bool) {
 	elem, ok := p.cache[id]
 	if !ok {
 		return nil, false
@@ -98,11 +164,28 @@ func (p *AncestryProvider) cacheGet(id consensus.LedgerID) (*providerLedger, boo
 	return elem.Value.(*cacheEntry).pl, true
 }
 
+func (p *AncestryProvider) cacheDelete(id consensus.LedgerID, expected *providerLedger) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	elem, ok := p.cache[id]
+	if !ok || elem.Value.(*cacheEntry).pl != expected {
+		return
+	}
+	delete(p.cache, id)
+	p.lru.Remove(elem)
+}
+
 func (p *AncestryProvider) cachePut(id consensus.LedgerID, pl *providerLedger) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if elem, ok := p.cache[id]; ok {
-		// Race: another goroutine populated concurrently.
+		// Keep the complete chain when a concurrent lookup only observed a
+		// transient gap. A complete result must be allowed to replace a
+		// previously cached partial result so recovery is not lost to a race.
+		entry := elem.Value.(*cacheEntry)
+		if entry.pl.partial && !pl.partial {
+			elem.Value = &cacheEntry{id: id, pl: pl}
+		}
 		p.lru.MoveToFront(elem)
 		return
 	}
@@ -121,10 +204,13 @@ func (p *AncestryProvider) cachePut(id consensus.LedgerID, pl *providerLedger) {
 
 // buildChain walks parent hashes backwards from id, up to
 // maxProviderAncestors links. Returns nil if the tip is unresolvable;
-// partial chains are returned with a higher minSeq.
+// partial chains are returned with a higher minSeq and marked retryable.
 func (p *AncestryProvider) buildChain(id consensus.LedgerID) *providerLedger {
 	tip, err := p.lookup([32]byte(id))
-	if err != nil || tip == nil {
+	if err != nil || isNilInterface(tip) {
+		return nil
+	}
+	if consensus.LedgerID(tip.Hash()) != id {
 		return nil
 	}
 	tipSeq := tip.Sequence()
@@ -143,9 +229,37 @@ func (p *AncestryProvider) buildChain(id consensus.LedgerID) *providerLedger {
 	curr := tip
 	filled := uint32(0)
 	myMinSeq := tipSeq - targetDepth
+	var retryHash [32]byte
+	var retrySeq uint32
+	partial := false
+
+	// A concrete ledger carries the same rolling skip-list used by
+	// rippled's RCLValidatedLedger. Prefer it when every sequence in the
+	// bounded window is available: this remains correct even if an
+	// intervening ledger object is temporarily absent from the service.
+	if resolver, ok := tip.(hashOfSeqHeader); ok {
+		resolved := true
+		for seq := myMinSeq; seq < tipSeq; seq++ {
+			hash, available, hashErr := resolver.HashOfSeq(seq)
+			if hashErr != nil || !available {
+				resolved = false
+				break
+			}
+			ancestors[seq-myMinSeq] = consensus.LedgerID(hash)
+		}
+		if resolved {
+			return &providerLedger{
+				id:        id,
+				seq:       tipSeq,
+				minSeq:    myMinSeq,
+				ancestors: ancestors,
+			}
+		}
+	}
 
 	for filled < targetDepth {
 		parentHash := consensus.LedgerID(curr.ParentHash())
+		currSeq := curr.Sequence()
 		idx := targetDepth - 1 - filled
 		ancestors[idx] = parentHash
 		filled++
@@ -154,8 +268,12 @@ func (p *AncestryProvider) buildChain(id consensus.LedgerID) *providerLedger {
 			break
 		}
 
-		// If parent's chain is already cached, borrow its entries.
-		if cached, hit := p.cacheGet(parentHash); hit {
+		// If the exact parent's chain is already cached, borrow its entries.
+		// A stale or corrupted cache entry must fall through to the validated
+		// direct lookup below rather than poisoning this chain.
+		expectedSeq := currSeq - 1
+		if cached, hit := p.cacheGet(parentHash); hit && !cached.partial &&
+			cached.ID() == parentHash && currSeq != 0 && cached.Seq() == expectedSeq {
 			for j := range idx {
 				wantSeq := myMinSeq + j
 				if wantSeq >= cached.minSeq && wantSeq < cached.seq {
@@ -171,10 +289,14 @@ func (p *AncestryProvider) buildChain(id consensus.LedgerID) *providerLedger {
 		}
 
 		parent, err := p.lookup([32]byte(parentHash))
-		if err != nil || parent == nil {
+		if currSeq == 0 || err != nil || isNilInterface(parent) ||
+			parent.Hash() != [32]byte(parentHash) || parent.Sequence() != expectedSeq {
 			// Partial chain — truncate to the populated suffix.
 			ancestors = ancestors[idx:]
 			myMinSeq = tipSeq - filled
+			retryHash = [32]byte(parentHash)
+			retrySeq = expectedSeq
+			partial = true
 			break
 		}
 		curr = parent
@@ -185,6 +307,9 @@ func (p *AncestryProvider) buildChain(id consensus.LedgerID) *providerLedger {
 		seq:       tipSeq,
 		minSeq:    myMinSeq,
 		ancestors: ancestors,
+		retryHash: retryHash,
+		retrySeq:  retrySeq,
+		partial:   partial,
 	}
 }
 
@@ -195,6 +320,15 @@ type providerLedger struct {
 	seq       uint32
 	minSeq    uint32
 	ancestors []consensus.LedgerID
+
+	// partial marks a suffix truncated because retryHash was unavailable or
+	// malformed. retrySeq is the sequence the missing/corrected header must
+	// carry before the suffix is retried.
+	// The cache may retain such a suffix for cheap repeated reads, but
+	// LedgerByID probes retryHash before reusing it.
+	retryHash [32]byte
+	retrySeq  uint32
+	partial   bool
 }
 
 func (l *providerLedger) ID() consensus.LedgerID { return l.id }
@@ -210,3 +344,8 @@ func (l *providerLedger) Ancestor(s uint32) consensus.LedgerID {
 	}
 	return l.ancestors[s-l.minSeq]
 }
+
+// retryable reports whether this ledger's ancestry is a temporarily
+// incomplete suffix. The tracker keeps such a ledger parked rather than
+// treating the truncated path as a complete trie branch.
+func (l *providerLedger) retryable() bool { return l.partial }

--- a/internal/consensus/rcl/ledger_provider.go
+++ b/internal/consensus/rcl/ledger_provider.go
@@ -56,8 +56,9 @@ type cacheEntry struct {
 }
 
 type ancestryFlight struct {
-	done   chan struct{}
-	result *providerLedger
+	done     chan struct{}
+	result   *providerLedger
+	fallback *providerLedger
 }
 
 // NewAncestryProvider wraps the ledger service. A nil svc returns a
@@ -90,6 +91,7 @@ func (p *AncestryProvider) LedgerByID(id consensus.LedgerID) (ledgertrie.Ledger,
 	if p == nil || p.lookup == nil {
 		return nil, false
 	}
+	var fallback *providerLedger
 	if cached, ok := p.cacheGet(id); ok {
 		if !cached.partial {
 			return cached, true
@@ -101,15 +103,23 @@ func (p *AncestryProvider) LedgerByID(id consensus.LedgerID) (ledgertrie.Ledger,
 		if !p.headerAvailable(cached.retryHash, cached.retrySeq) {
 			return cached, true
 		}
-		p.cacheDelete(id, cached)
+		fallback = cached
 	}
 
 	p.mu.Lock()
 	if cached, ok := p.cacheGetLocked(id); ok {
-		p.mu.Unlock()
-		return cached, true
+		if fallback == nil || cached != fallback {
+			p.mu.Unlock()
+			return cached, true
+		}
+		elem := p.cache[id]
+		delete(p.cache, id)
+		p.lru.Remove(elem)
 	}
 	if flight, ok := p.inflight[id]; ok {
+		if flight.fallback == nil {
+			flight.fallback = fallback
+		}
 		p.mu.Unlock()
 		<-flight.done
 		if flight.result == nil {
@@ -120,7 +130,7 @@ func (p *AncestryProvider) LedgerByID(id consensus.LedgerID) (ledgertrie.Ledger,
 	if p.inflight == nil {
 		p.inflight = make(map[consensus.LedgerID]*ancestryFlight)
 	}
-	flight := &ancestryFlight{done: make(chan struct{})}
+	flight := &ancestryFlight{done: make(chan struct{}), fallback: fallback}
 	p.inflight[id] = flight
 	p.mu.Unlock()
 
@@ -128,9 +138,21 @@ func (p *AncestryProvider) LedgerByID(id consensus.LedgerID) (ledgertrie.Ledger,
 	return built, built != nil
 }
 
-func (p *AncestryProvider) buildAndFinish(id consensus.LedgerID, flight *ancestryFlight) (built *providerLedger) {
+func (p *AncestryProvider) buildAndFinish(
+	id consensus.LedgerID,
+	flight *ancestryFlight,
+) (built *providerLedger) {
 	defer func() {
 		p.mu.Lock()
+		if built == nil ||
+			(built.partial && flight.fallback != nil &&
+				(built.id != flight.fallback.id || built.seq != flight.fallback.seq ||
+					built.minSeq > flight.fallback.minSeq)) {
+			built = flight.fallback
+		}
+		if built != nil {
+			p.cachePutLocked(id, built)
+		}
 		flight.result = built
 		delete(p.inflight, id)
 		close(flight.done)
@@ -138,9 +160,6 @@ func (p *AncestryProvider) buildAndFinish(id consensus.LedgerID, flight *ancestr
 	}()
 
 	built = p.buildChain(id)
-	if built != nil {
-		p.cachePut(id, built)
-	}
 	return built
 }
 
@@ -164,20 +183,13 @@ func (p *AncestryProvider) cacheGetLocked(id consensus.LedgerID) (*providerLedge
 	return elem.Value.(*cacheEntry).pl, true
 }
 
-func (p *AncestryProvider) cacheDelete(id consensus.LedgerID, expected *providerLedger) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	elem, ok := p.cache[id]
-	if !ok || elem.Value.(*cacheEntry).pl != expected {
-		return
-	}
-	delete(p.cache, id)
-	p.lru.Remove(elem)
-}
-
 func (p *AncestryProvider) cachePut(id consensus.LedgerID, pl *providerLedger) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.cachePutLocked(id, pl)
+}
+
+func (p *AncestryProvider) cachePutLocked(id consensus.LedgerID, pl *providerLedger) {
 	if elem, ok := p.cache[id]; ok {
 		// Keep the complete chain when a concurrent lookup only observed a
 		// transient gap. A complete result must be allowed to replace a

--- a/internal/consensus/rcl/ledger_provider.go
+++ b/internal/consensus/rcl/ledger_provider.go
@@ -27,10 +27,6 @@ var _ LedgerHeader = (*ledger.Ledger)(nil)
 
 type hashLookupFunc func(hash [32]byte) (LedgerHeader, error)
 
-// hashOfSeqHeader is implemented by the concrete ledger header when its
-// embedded rolling skip-list can answer ancestry without loading every
-// intervening ledger. Keep this optional so the provider remains useful for
-// narrow test doubles and other header implementations.
 type hashOfSeqHeader interface {
 	HashOfSeq(seq uint32) ([32]byte, bool, error)
 }
@@ -245,10 +241,8 @@ func (p *AncestryProvider) buildChain(id consensus.LedgerID) *providerLedger {
 	var retrySeq uint32
 	partial := false
 
-	// A concrete ledger carries the same rolling skip-list used by
-	// rippled's RCLValidatedLedger. Prefer it when every sequence in the
-	// bounded window is available: this remains correct even if an
-	// intervening ledger object is temporarily absent from the service.
+	// Embedded ancestry remains usable when intervening ledger objects are
+	// temporarily absent from the service.
 	if resolver, ok := tip.(hashOfSeqHeader); ok {
 		resolved := true
 		for seq := myMinSeq; seq < tipSeq; seq++ {
@@ -333,11 +327,8 @@ type providerLedger struct {
 	minSeq    uint32
 	ancestors []consensus.LedgerID
 
-	// partial marks a suffix truncated because retryHash was unavailable or
-	// malformed. retrySeq is the sequence the missing/corrected header must
-	// carry before the suffix is retried.
-	// The cache may retain such a suffix for cheap repeated reads, but
-	// LedgerByID probes retryHash before reusing it.
+	// retryHash and retrySeq identify the unavailable or malformed header that
+	// truncated a partial suffix.
 	retryHash [32]byte
 	retrySeq  uint32
 	partial   bool
@@ -357,7 +348,4 @@ func (l *providerLedger) Ancestor(s uint32) consensus.LedgerID {
 	return l.ancestors[s-l.minSeq]
 }
 
-// retryable reports whether this ledger's ancestry is a temporarily
-// incomplete suffix. The tracker keeps such a ledger parked rather than
-// treating the truncated path as a complete trie branch.
 func (l *providerLedger) retryable() bool { return l.partial }

--- a/internal/consensus/rcl/ledger_provider_test.go
+++ b/internal/consensus/rcl/ledger_provider_test.go
@@ -2,11 +2,14 @@ package rcl
 
 import (
 	"errors"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrie"
 )
 
 // fakeHeader is a minimal LedgerHeader for unit tests. We build a
@@ -163,6 +166,163 @@ func TestAncestryProvider_MissingLinkRepairsAfterArrival(t *testing.T) {
 	}
 }
 
+func TestAncestryProvider_RetainsPartialWhenRepairIsTransientlyUnavailable(t *testing.T) {
+	tip, byHash := buildChain(5, 'u')
+	var missingHash [32]byte
+	var unstableHash [32]byte
+	for hash, header := range byHash {
+		switch header.Sequence() {
+		case 3:
+			missingHash = hash
+		case 4:
+			unstableHash = hash
+		}
+	}
+	missing := byHash[missingHash]
+	unstable := byHash[unstableHash]
+	delete(byHash, missingHash)
+
+	failTip := false
+	p := newAncestryProviderFromLookup(func(hash [32]byte) (LedgerHeader, error) {
+		if failTip && hash == tip.hash {
+			failTip = false
+			return nil, errors.New("transient tip failure")
+		}
+		if header, ok := byHash[hash]; ok {
+			return header, nil
+		}
+		return nil, errors.New("not found")
+	})
+	partial, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("partial lookup should resolve the tip suffix")
+	}
+	if got := partial.MinSeq(); got != 3 {
+		t.Fatalf("partial MinSeq = %d, want 3", got)
+	}
+
+	byHash[missingHash] = missing
+	failTip = true
+	retained, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("transient repair failure should retain the cached suffix")
+	}
+	if got := retained.MinSeq(); got != 3 {
+		t.Fatalf("retained MinSeq = %d, want 3", got)
+	}
+
+	delete(byHash, unstableHash)
+	retained, ok = p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("poorer partial repair should retain the cached suffix")
+	}
+	if got := retained.MinSeq(); got != 3 {
+		t.Fatalf("retained MinSeq after poorer repair = %d, want 3", got)
+	}
+	byHash[unstableHash] = unstable
+
+	repaired, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("subsequent repair should resolve")
+	}
+	if got := repaired.MinSeq(); got != 1 {
+		t.Fatalf("repaired MinSeq = %d, want 1", got)
+	}
+}
+
+func TestAncestryProvider_EvictedPartialJoinsInflightFallback(t *testing.T) {
+	tip, byHash := buildChain(5, 'v')
+	var missingHash [32]byte
+	for hash, header := range byHash {
+		if header.Sequence() == 3 {
+			missingHash = hash
+			break
+		}
+	}
+	missing := byHash[missingHash]
+	delete(byHash, missingHash)
+
+	p := newTestProvider(byHash)
+	partial, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("partial lookup should resolve the tip suffix")
+	}
+	byHash[missingHash] = missing
+
+	retryProbe := make(chan struct{})
+	releaseRetryProbe := make(chan struct{})
+	buildTip := make(chan struct{})
+	releaseBuildTip := make(chan struct{})
+	p.lookup = func(hash [32]byte) (LedgerHeader, error) {
+		switch hash {
+		case missingHash:
+			close(retryProbe)
+			<-releaseRetryProbe
+			return missing, nil
+		case tip.hash:
+			close(buildTip)
+			<-releaseBuildTip
+			return nil, errors.New("transient tip failure")
+		default:
+			return byHash[hash], nil
+		}
+	}
+
+	type result struct {
+		ledger ledgertrie.Ledger
+		ok     bool
+	}
+	id := consensus.LedgerID(tip.hash)
+	first := make(chan result, 1)
+	go func() {
+		ledger, resolved := p.LedgerByID(id)
+		first <- result{ledger: ledger, ok: resolved}
+	}()
+	<-retryProbe
+
+	p.mu.Lock()
+	elem := p.cache[id]
+	delete(p.cache, id)
+	p.lru.Remove(elem)
+	p.mu.Unlock()
+
+	second := make(chan result, 1)
+	go func() {
+		ledger, resolved := p.LedgerByID(id)
+		second <- result{ledger: ledger, ok: resolved}
+	}()
+	<-buildTip
+	close(releaseRetryProbe)
+
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	for {
+		p.mu.Lock()
+		flight := p.inflight[id]
+		hasFallback := flight != nil && flight.fallback != nil
+		p.mu.Unlock()
+		if hasFallback {
+			break
+		}
+		select {
+		case <-deadline.C:
+			t.Fatal("retrying caller did not attach its cached fallback to the in-flight build")
+		default:
+			runtime.Gosched()
+		}
+	}
+	close(releaseBuildTip)
+
+	for _, got := range []result{<-first, <-second} {
+		if !got.ok {
+			t.Fatal("shared transient failure should retain the cached suffix")
+		}
+		if minSeq := got.ledger.MinSeq(); minSeq != partial.MinSeq() {
+			t.Fatalf("retained MinSeq = %d, want %d", minSeq, partial.MinSeq())
+		}
+	}
+}
+
 func TestAncestryProvider_RejectsParentHashMismatchAndRepairs(t *testing.T) {
 	tip, byHash := buildChain(5, 'm')
 	var parentHash [32]byte
@@ -194,8 +354,11 @@ func TestAncestryProvider_RejectsParentHashMismatchAndRepairs(t *testing.T) {
 
 	byHash[parentHash] = correct
 	repaired, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
-	if !ok || repaired.MinSeq() != 1 {
-		t.Fatalf("corrected parent did not rebuild full chain: ok=%v min=%d", ok, repaired.MinSeq())
+	if !ok {
+		t.Fatal("corrected parent did not rebuild full chain")
+	}
+	if got := repaired.MinSeq(); got != 1 {
+		t.Fatalf("corrected parent MinSeq = %d, want 1", got)
 	}
 }
 
@@ -228,8 +391,11 @@ func TestAncestryProvider_RejectsParentSequenceGapAndRepairs(t *testing.T) {
 
 	byHash[parentHash] = correct
 	repaired, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
-	if !ok || repaired.MinSeq() != 1 {
-		t.Fatalf("corrected sequence gap did not rebuild full chain: ok=%v min=%d", ok, repaired.MinSeq())
+	if !ok {
+		t.Fatal("corrected sequence gap did not rebuild full chain")
+	}
+	if got := repaired.MinSeq(); got != 1 {
+		t.Fatalf("corrected sequence gap MinSeq = %d, want 1", got)
 	}
 }
 

--- a/internal/consensus/rcl/ledger_provider_test.go
+++ b/internal/consensus/rcl/ledger_provider_test.go
@@ -2,6 +2,8 @@ package rcl
 
 import (
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/consensus"
@@ -123,6 +125,221 @@ func TestAncestryProvider_MissingLinkTruncates(t *testing.T) {
 	if lgr.Ancestor(3)[1] != 'b' {
 		t.Errorf("Ancestor(3) tag should be 'b'")
 	}
+}
+
+func TestAncestryProvider_MissingLinkRepairsAfterArrival(t *testing.T) {
+	tip, byHash := buildChain(5, 'r')
+	var missingHash [32]byte
+	for hash, header := range byHash {
+		if header.Sequence() == 3 {
+			missingHash = hash
+			break
+		}
+	}
+	missing := byHash[missingHash]
+	delete(byHash, missingHash)
+
+	p := newTestProvider(byHash)
+	first, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("partial lookup should resolve the tip suffix")
+	}
+	if first.MinSeq() != 3 {
+		t.Fatalf("partial MinSeq = %d, want 3", first.MinSeq())
+	}
+
+	// The missing header arrives after the partial suffix was cached. The
+	// retry marker must invalidate that suffix and rebuild the full window.
+	byHash[missingHash] = missing
+	second, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("repaired lookup should resolve")
+	}
+	if second.MinSeq() != 1 {
+		t.Fatalf("repaired MinSeq = %d, want 1", second.MinSeq())
+	}
+	if got := second.Ancestor(2); got[1] != 'r' {
+		t.Fatalf("repaired Ancestor(2) = %x, want chain tag r", got)
+	}
+}
+
+func TestAncestryProvider_RejectsParentHashMismatchAndRepairs(t *testing.T) {
+	tip, byHash := buildChain(5, 'm')
+	var parentHash [32]byte
+	var correct LedgerHeader
+	for hash, header := range byHash {
+		if header.Sequence() == 4 {
+			parentHash = hash
+			correct = header
+			break
+		}
+	}
+	wrongHash := parentHash
+	wrongHash[0]++
+	malformed := &fakeHeader{seq: 4, hash: wrongHash, parent: correct.ParentHash()}
+	byHash[parentHash] = malformed
+
+	p := newTestProvider(byHash)
+	partial, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("hash-mismatched parent should leave a retryable suffix")
+	}
+	pl, ok := partial.(*providerLedger)
+	if !ok || !pl.retryable() {
+		t.Fatalf("hash-mismatched parent returned non-retryable ledger: %#v", partial)
+	}
+	if got := partial.MinSeq(); got != 4 {
+		t.Fatalf("hash-mismatched parent MinSeq = %d, want 4", got)
+	}
+
+	byHash[parentHash] = correct
+	repaired, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok || repaired.MinSeq() != 1 {
+		t.Fatalf("corrected parent did not rebuild full chain: ok=%v min=%d", ok, repaired.MinSeq())
+	}
+}
+
+func TestAncestryProvider_RejectsParentSequenceGapAndRepairs(t *testing.T) {
+	tip, byHash := buildChain(5, 'n')
+	var parentHash [32]byte
+	var correct LedgerHeader
+	for hash, header := range byHash {
+		if header.Sequence() == 4 {
+			parentHash = hash
+			correct = header
+			break
+		}
+	}
+	// Keep the requested hash but return a header from the wrong sequence.
+	byHash[parentHash] = &fakeHeader{seq: 2, hash: parentHash, parent: correct.ParentHash()}
+
+	p := newTestProvider(byHash)
+	partial, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("sequence-gap parent should leave a retryable suffix")
+	}
+	pl, ok := partial.(*providerLedger)
+	if !ok || !pl.retryable() {
+		t.Fatalf("sequence-gap parent returned non-retryable ledger: %#v", partial)
+	}
+	if got := partial.MinSeq(); got != 4 {
+		t.Fatalf("sequence-gap parent MinSeq = %d, want 4", got)
+	}
+
+	byHash[parentHash] = correct
+	repaired, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok || repaired.MinSeq() != 1 {
+		t.Fatalf("corrected sequence gap did not rebuild full chain: ok=%v min=%d", ok, repaired.MinSeq())
+	}
+}
+
+func TestAncestryProvider_NilHeadersAreUnknown(t *testing.T) {
+	tip, byHash := buildChain(3, 'z')
+	var typedNil *fakeHeader
+	byHash[tip.hash] = typedNil
+	p := newTestProvider(byHash)
+	if _, ok := p.LedgerByID(consensus.LedgerID(tip.hash)); ok {
+		t.Fatal("typed-nil tip header must not resolve")
+	}
+
+	tip, byHash = buildChain(3, 'y')
+	var parentHash [32]byte
+	for hash, header := range byHash {
+		if header.Sequence() == 2 {
+			parentHash = hash
+			break
+		}
+	}
+	byHash[parentHash] = typedNil
+	p = newTestProvider(byHash)
+	partial, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok || partial.MinSeq() != 2 {
+		t.Fatalf("typed-nil parent should be retryable suffix: ok=%v ledger=%v", ok, partial)
+	}
+}
+
+func TestAncestryProvider_SameTipConcurrentLookupIsBounded(t *testing.T) {
+	tip, byHash := buildChain(12, 'q')
+	const workers = 32
+	var calls atomic.Int32
+	start := make(chan struct{})
+	p := newAncestryProviderFromLookup(func(hash [32]byte) (LedgerHeader, error) {
+		calls.Add(1)
+		if lh, ok := byHash[hash]; ok {
+			return lh, nil
+		}
+		return nil, errors.New("not found")
+	})
+
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			lgr, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+			if !ok {
+				t.Errorf("concurrent lookup returned ok=false")
+				return
+			}
+			if lgr.MinSeq() != 1 {
+				t.Errorf("concurrent lookup returned min=%d, want 1", lgr.MinSeq())
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	// The shared in-flight result keeps cold fan-in close to one ancestry
+	// walk. Allow a small scheduling tail of late callers to begin a second
+	// flight, but reject the full workers-times-depth hammering this test
+	// exposes without the gate.
+	if got, want := calls.Load(), int32(workers*2); got > want {
+		t.Fatalf("same-tip lookup duplicated service work: got %d calls, want <=%d", got, want)
+	}
+}
+
+func TestAncestryProvider_UsesEmbeddedHashOfSeq(t *testing.T) {
+	const tipSeq = uint32(5)
+	tip, byHash := buildChain(tipSeq, 's')
+
+	// Replace the tip with a header whose embedded ancestry is complete, then
+	// remove intervening records. The provider should use the rolling skip
+	// list rather than treating those records as unavailable.
+	hashes := make(map[uint32][32]byte, tipSeq)
+	for hash, header := range byHash {
+		hashes[header.Sequence()] = hash
+	}
+	byHash[tip.hash] = &skipListHeader{fakeHeader: *tip, ancestors: hashes}
+	for hash, header := range byHash {
+		if header.Sequence() < tipSeq {
+			delete(byHash, hash)
+		}
+	}
+
+	p := newTestProvider(byHash)
+	lgr, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("embedded ancestry should resolve without parent records")
+	}
+	if lgr.MinSeq() != 1 {
+		t.Fatalf("embedded ancestry MinSeq = %d, want 1", lgr.MinSeq())
+	}
+	for seq := uint32(1); seq < tipSeq; seq++ {
+		if got, want := lgr.Ancestor(seq), consensus.LedgerID(hashes[seq]); got != want {
+			t.Fatalf("Ancestor(%d) = %x, want %x", seq, got, want)
+		}
+	}
+}
+
+type skipListHeader struct {
+	fakeHeader
+	ancestors map[uint32][32]byte
+}
+
+func (h *skipListHeader) HashOfSeq(seq uint32) ([32]byte, bool, error) {
+	hash, ok := h.ancestors[seq]
+	return hash, ok, nil
 }
 
 func TestAncestryProvider_BoundedAtMaxAncestors(t *testing.T) {
@@ -298,6 +515,42 @@ func TestAncestryProvider_SplicesCachedPrefix(t *testing.T) {
 	extra := calls - warmCalls
 	if extra > 6 {
 		t.Errorf("splice didn't short-circuit: extra lookups = %d (expected ≤6)", extra)
+	}
+}
+
+func TestAncestryProvider_BypassesWrongSequenceCachedParent(t *testing.T) {
+	tip, byHash := buildChain(6, 'w')
+	var parentHash [32]byte
+	for hash, header := range byHash {
+		if header.Sequence() == tip.seq-1 {
+			parentHash = hash
+			break
+		}
+	}
+	if parentHash == ([32]byte{}) {
+		t.Fatal("test chain did not expose the child parent")
+	}
+
+	p := newTestProvider(byHash)
+	// This entry is deliberately keyed by the correct parent hash but carries
+	// the wrong sequence. The child walk must ignore it and validate the
+	// direct parent header instead.
+	p.cachePut(consensus.LedgerID(parentHash), &providerLedger{
+		id:        consensus.LedgerID(parentHash),
+		seq:       tip.seq - 2,
+		minSeq:    tip.seq - 2,
+		ancestors: nil,
+	})
+
+	lgr, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
+	if !ok {
+		t.Fatal("child lookup failed with wrong-sequence cached parent")
+	}
+	if lgr.MinSeq() != 1 {
+		t.Fatalf("child MinSeq = %d, want 1", lgr.MinSeq())
+	}
+	if got := lgr.Ancestor(tip.seq - 1); got != consensus.LedgerID(parentHash) {
+		t.Fatalf("child parent = %x, want %x", got, parentHash)
 	}
 }
 

--- a/internal/consensus/rcl/ledger_provider_test.go
+++ b/internal/consensus/rcl/ledger_provider_test.go
@@ -151,8 +151,6 @@ func TestAncestryProvider_MissingLinkRepairsAfterArrival(t *testing.T) {
 		t.Fatalf("partial MinSeq = %d, want 3", first.MinSeq())
 	}
 
-	// The missing header arrives after the partial suffix was cached. The
-	// retry marker must invalidate that suffix and rebuild the full window.
 	byHash[missingHash] = missing
 	second, ok := p.LedgerByID(consensus.LedgerID(tip.hash))
 	if !ok {
@@ -373,7 +371,6 @@ func TestAncestryProvider_RejectsParentSequenceGapAndRepairs(t *testing.T) {
 			break
 		}
 	}
-	// Keep the requested hash but return a header from the wrong sequence.
 	byHash[parentHash] = &fakeHeader{seq: 2, hash: parentHash, parent: correct.ParentHash()}
 
 	p := newTestProvider(byHash)
@@ -469,9 +466,6 @@ func TestAncestryProvider_UsesEmbeddedHashOfSeq(t *testing.T) {
 	const tipSeq = uint32(5)
 	tip, byHash := buildChain(tipSeq, 's')
 
-	// Replace the tip with a header whose embedded ancestry is complete, then
-	// remove intervening records. The provider should use the rolling skip
-	// list rather than treating those records as unavailable.
 	hashes := make(map[uint32][32]byte, tipSeq)
 	for hash, header := range byHash {
 		hashes[header.Sequence()] = hash
@@ -698,9 +692,6 @@ func TestAncestryProvider_BypassesWrongSequenceCachedParent(t *testing.T) {
 	}
 
 	p := newTestProvider(byHash)
-	// This entry is deliberately keyed by the correct parent hash but carries
-	// the wrong sequence. The child walk must ignore it and validate the
-	// direct parent header instead.
 	p.cachePut(consensus.LedgerID(parentHash), &providerLedger{
 		id:        consensus.LedgerID(parentHash),
 		seq:       tip.seq - 2,

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -842,8 +842,6 @@ func (vt *ValidationTracker) ProposersFinished(prev consensus.Ledger) int {
 	for attempt := 0; attempt < 2; attempt++ {
 		vt.checkAcquired()
 
-		// Trie fast path — getNodesAfter at Validations.h:973-993:
-		// branchSupport(ledger) - tipSupport(ledger).
 		vt.mu.RLock()
 		trie := vt.trie
 		ancestry := vt.ancestry

--- a/internal/consensus/rcl/validations.go
+++ b/internal/consensus/rcl/validations.go
@@ -14,9 +14,9 @@ import (
 // invariant panic (LedgerTrie.h:553-style XRPL_ASSERT or our equivalent
 // at trie.go:143/173/306) does not fail-stop the consensus goroutine.
 // rippled responds to these with a process abort; in Go we'd rather
-// log + continue and let the next operation rebuild the trie on its
-// own. Returns true if the call panicked. Caller must already hold the
-// lock that protects the trie state.
+// log + continue and let the caller replace the derived state from tracked
+// validations. Returns true if the call panicked. Caller must already hold
+// the lock that protects the trie state.
 func safeTrieCall(fn string, op func()) (panicked bool) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -484,11 +484,9 @@ func (vt *ValidationTracker) AddStatus(validation *consensus.Validation) ValStat
 	ancestrySnap := vt.ancestry
 	trieSnap := vt.trie
 	vt.mu.RUnlock()
-	var preResolvedLedger ledgertrie.Ledger
+	var preResolvedLedger ancestryResolution
 	if trieSnap != nil && ancestrySnap != nil {
-		if l, ok := ancestrySnap.LedgerByID(validation.LedgerID); ok {
-			preResolvedLedger = l
-		}
+		preResolvedLedger, _ = resolveAncestry(ancestrySnap, validation.LedgerID, &validation.LedgerSeq)
 	}
 
 	vt.mu.Lock()
@@ -765,6 +763,7 @@ func (vt *ValidationTracker) GetPreferred(largestIssued uint32) (consensus.Ledge
 	if safeTrieCall("GetPreferred", func() {
 		tip, ok = vt.trie.GetPreferred(largestIssued)
 	}) {
+		vt.resetTrieLocked()
 		return consensus.LedgerID{}, 0, false
 	}
 	if !ok {
@@ -838,22 +837,40 @@ func (vt *ValidationTracker) ProposersFinished(prev consensus.Ledger) int {
 	if prev == nil {
 		return 0
 	}
-	vt.checkAcquired()
+	prevID := prev.ID()
+	prevSeq := prev.Seq()
+	for attempt := 0; attempt < 2; attempt++ {
+		vt.checkAcquired()
 
-	// Trie fast path — getNodesAfter at Validations.h:973-993:
-	// branchSupport(ledger) - tipSupport(ledger).
-	vt.mu.RLock()
-	trie := vt.trie
-	ancestry := vt.ancestry
-	vt.mu.RUnlock()
-	if trie != nil && ancestry != nil {
-		if lgr, ok := ancestry.LedgerByID(prev.ID()); ok {
+		// Trie fast path — getNodesAfter at Validations.h:973-993:
+		// branchSupport(ledger) - tipSupport(ledger).
+		vt.mu.RLock()
+		trie := vt.trie
+		ancestry := vt.ancestry
+		vt.mu.RUnlock()
+		if trie == nil || ancestry == nil {
+			break
+		}
+		if resolved, ok := resolveAncestry(ancestry, prevID, &prevSeq); ok && !resolved.retryable {
 			vt.mu.Lock()
 			current := vt.trie == trie
 			var branch, tip uint32
+			panicked := false
 			if current {
-				branch = trie.BranchSupport(lgr)
-				tip = trie.TipSupport(lgr)
+				if safeTrieCall("BranchSupport", func() {
+					branch = trie.BranchSupport(resolved.ledger)
+				}) {
+					panicked = true
+				} else if safeTrieCall("TipSupport", func() {
+					tip = trie.TipSupport(resolved.ledger)
+				}) {
+					panicked = true
+				}
+			}
+			if panicked {
+				vt.resetTrieLocked()
+				vt.mu.Unlock()
+				continue
 			}
 			vt.mu.Unlock()
 			if current {
@@ -863,6 +880,7 @@ func (vt *ValidationTracker) ProposersFinished(prev consensus.Ledger) int {
 				return int(branch - tip)
 			}
 		}
+		break
 	}
 
 	// Seq-only fallback when trie/ancestry isn't wired for prev (boot or
@@ -874,7 +892,6 @@ func (vt *ValidationTracker) ProposersFinished(prev consensus.Ledger) int {
 	vt.mu.RLock()
 	defer vt.mu.RUnlock()
 	count := 0
-	prevSeq := prev.Seq()
 	for nodeID, v := range vt.byNode {
 		if !vt.trusted[nodeID] {
 			continue
@@ -988,10 +1005,7 @@ func (vt *ValidationTracker) FlushStale() {
 		}
 		delete(vt.byNode, nodeID)
 		vt.unparkLocked(acquiringKey{seq: v.LedgerSeq, id: v.LedgerID}, nodeID)
-		if prev, ok := vt.trieTips[nodeID]; ok {
-			safeTrieCall("Remove", func() { vt.trie.Remove(prev, 1) })
-			delete(vt.trieTips, nodeID)
-		}
+		vt.removeTipLocked(nodeID)
 	}
 
 	// Age out by-seq evidence and idle enforcer floors — rippled's
@@ -1051,14 +1065,7 @@ func (vt *ValidationTracker) ExpireOld(minSeq uint32) {
 			if latest, ok := vt.byNode[nodeID]; ok && latest == v {
 				delete(vt.byNode, nodeID)
 				vt.unparkLocked(acquiringKey{seq: v.LedgerSeq, id: v.LedgerID}, nodeID)
-				if vt.trie != nil {
-					if prev, ok := vt.trieTips[nodeID]; ok {
-						safeTrieCall("Remove", func() {
-							vt.trie.Remove(prev, 1)
-						})
-						delete(vt.trieTips, nodeID)
-					}
-				}
+				vt.removeTipLocked(nodeID)
 			}
 		}
 		delete(vt.validations, ledgerID)

--- a/internal/consensus/rcl/validations_helpers_test.go
+++ b/internal/consensus/rcl/validations_helpers_test.go
@@ -31,42 +31,62 @@ func (vt *ValidationTracker) SetQuorum(quorum int) {
 // ledger or one of its descendants. It mirrors the old test-facing query;
 // production callers use the finality and preferred-ledger APIs directly.
 func (vt *ValidationTracker) TrustedSupport(ledgerID consensus.LedgerID) int {
-	vt.checkAcquired()
+	for attempt := 0; attempt < 2; attempt++ {
+		vt.checkAcquired()
 
-	vt.mu.RLock()
-	trie := vt.trie
-	ancestry := vt.ancestry
-	vt.mu.RUnlock()
+		vt.mu.RLock()
+		trie := vt.trie
+		ancestry := vt.ancestry
+		vt.mu.RUnlock()
 
-	if trie == nil || ancestry == nil {
-		return vt.TrustedValidationCount(ledgerID)
-	}
-
-	lgr, ok := ancestry.LedgerByID(ledgerID)
-	if !ok {
-		return vt.TrustedValidationCount(ledgerID)
-	}
-
-	vt.mu.Lock()
-	defer vt.mu.Unlock()
-	if vt.trie != trie {
-		ledgerVals, exists := vt.validations[ledgerID]
-		if !exists {
-			return 0
+		if trie == nil || ancestry == nil {
+			return vt.TrustedValidationCount(ledgerID)
 		}
-		ledgerVals.touch(vt.now())
-		return vt.countTrustedExcludingNegUNLLocked(ledgerVals.vals)
+
+		resolved, ok := resolveAncestry(ancestry, ledgerID, nil)
+		if !ok || resolved.retryable {
+			return vt.TrustedValidationCount(ledgerID)
+		}
+
+		vt.mu.Lock()
+		if vt.trie != trie {
+			ledgerVals, exists := vt.validations[ledgerID]
+			if !exists {
+				vt.mu.Unlock()
+				return 0
+			}
+			ledgerVals.touch(vt.now())
+			count := vt.countTrustedExcludingNegUNLLocked(ledgerVals.vals)
+			vt.mu.Unlock()
+			return count
+		}
+		var support int
+		if safeTrieCall("BranchSupport", func() {
+			support = vt.branchSupportExcludingNegUNLLocked(resolved.ledger)
+		}) {
+			vt.resetTrieLocked()
+			vt.mu.Unlock()
+			continue
+		}
+		vt.mu.Unlock()
+		return support
 	}
-	return vt.branchSupportExcludingNegUNLLocked(lgr)
+	return vt.TrustedValidationCount(ledgerID)
 }
 
 func (vt *ValidationTracker) branchSupportExcludingNegUNLLocked(lgr ledgertrie.Ledger) int {
+	if !isValidAncestryLedger(lgr) {
+		panic("invalid target ledger")
+	}
 	targetSeq := lgr.Seq()
 	targetID := lgr.ID()
 	count := 0
 	for nodeID, tip := range vt.trieTips {
 		if vt.negUNL[nodeID] {
 			continue
+		}
+		if !isValidAncestryLedger(tip) {
+			panic("invalid trie tip")
 		}
 		if tip.Seq() >= targetSeq && tip.Ancestor(targetSeq) == targetID {
 			count++

--- a/internal/consensus/rcl/validations_trie.go
+++ b/internal/consensus/rcl/validations_trie.go
@@ -1,6 +1,9 @@
 package rcl
 
 import (
+	"log/slog"
+	"reflect"
+
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/consensus/ledgertrie"
 )
@@ -10,6 +13,97 @@ import (
 // history is not locally known.
 type LedgerAncestryProvider interface {
 	LedgerByID(id consensus.LedgerID) (ledgertrie.Ledger, bool)
+}
+
+type retryableAncestryLedger interface {
+	retryable() bool
+}
+
+// ancestryResolution is the provider result plus metadata captured while the
+// provider boundary is outside ValidationTracker.mu. Callers holding the
+// tracker lock must use these values instead of invoking methods on the
+// provider-owned ledger again.
+type ancestryResolution struct {
+	ledger    ledgertrie.Ledger
+	id        consensus.LedgerID
+	seq       uint32
+	retryable bool
+}
+
+// safeAncestryCall contains panics from provider code and custom ledger
+// metadata methods. Provider and ledger objects are external to the tracker,
+// so a malformed implementation must degrade to an unresolved result rather
+// than unwind a consensus goroutine.
+func safeAncestryCall(fn string, op func()) (panicked bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			panicked = true
+			slog.Error("ancestry provider panic recovered",
+				"t", "consensus",
+				"event", "ancestry-provider-panic",
+				"fn", fn,
+				"err", r,
+			)
+		}
+	}()
+	op()
+	return false
+}
+
+// resolveAncestry performs a provider lookup and captures retryable/ID/Seq
+// metadata without holding ValidationTracker.mu. A result is usable only when
+// the provider returned the requested ID and, when expectedSeq is non-nil, the
+// exact requested sequence. Nil, typed-nil, panicking, and mismatched results
+// are all treated as unresolved so callers park or use their flat fallback.
+func resolveAncestry(
+	provider LedgerAncestryProvider,
+	expectedID consensus.LedgerID,
+	expectedSeq *uint32,
+) (resolved ancestryResolution, ok bool) {
+	if isNilInterface(provider) {
+		return ancestryResolution{}, false
+	}
+	var ledger ledgertrie.Ledger
+	var found bool
+	if safeAncestryCall("LedgerByID", func() {
+		ledger, found = provider.LedgerByID(expectedID)
+	}) || !found || !isValidAncestryLedger(ledger) {
+		return ancestryResolution{}, false
+	}
+	resolved.ledger = ledger
+	if safeAncestryCall("LedgerMetadata", func() {
+		resolved.id = ledger.ID()
+		resolved.seq = ledger.Seq()
+		if partial, hasRetry := ledger.(retryableAncestryLedger); hasRetry {
+			resolved.retryable = partial.retryable()
+		}
+	}) {
+		return ancestryResolution{}, false
+	}
+	if resolved.id != expectedID || expectedSeq != nil && resolved.seq != *expectedSeq {
+		return ancestryResolution{}, false
+	}
+	return resolved, true
+}
+
+// isNilInterface catches both a nil interface and an interface containing a
+// typed nil pointer. Providers are external to the tracker and must not be
+// able to make an ok=true result panic a read path.
+func isNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	rv := reflect.ValueOf(value)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}
+
+func isValidAncestryLedger(lgr ledgertrie.Ledger) bool {
+	return !isNilInterface(lgr)
 }
 
 // acquiringKey identifies a ledger referenced by trusted validations but
@@ -24,7 +118,7 @@ type acquiringKey struct {
 // The trie is rebuilt from the current byNode / trusted / negUNL state.
 func (vt *ValidationTracker) SetLedgerAncestryProvider(p LedgerAncestryProvider) {
 	vt.mu.Lock()
-	if p == nil {
+	if isNilInterface(p) {
 		vt.ancestry = nil
 		vt.trie = nil
 		vt.trieTips = nil
@@ -76,7 +170,7 @@ func (vt *ValidationTracker) rebuildTrieLocked() {
 func (vt *ValidationTracker) updateTrieLocked(
 	nodeID consensus.NodeID,
 	validation *consensus.Validation,
-	preResolved ledgertrie.Ledger,
+	preResolved ancestryResolution,
 	preResolvedTrie *ledgertrie.Trie,
 	prior *acquiringKey,
 ) {
@@ -88,8 +182,9 @@ func (vt *ValidationTracker) updateTrieLocked(
 		vt.unparkLocked(*prior, nodeID)
 	}
 	key := acquiringKey{seq: validation.LedgerSeq, id: validation.LedgerID}
-	if preResolved != nil && preResolved.ID() == validation.LedgerID &&
-		preResolved.Seq() == validation.LedgerSeq && vt.trie == preResolvedTrie {
+	if preResolved.ledger != nil && !preResolved.retryable &&
+		preResolved.id == validation.LedgerID &&
+		preResolved.seq == validation.LedgerSeq && vt.trie == preResolvedTrie {
 		if parked, ok := vt.acquiring[key]; ok {
 			parked[nodeID] = struct{}{}
 			for parkedNode := range parked {
@@ -97,12 +192,14 @@ func (vt *ValidationTracker) updateTrieLocked(
 				if current == nil || current.LedgerSeq != key.seq || current.LedgerID != key.id || !vt.trusted[parkedNode] {
 					continue
 				}
-				vt.insertTipLocked(parkedNode, preResolved)
+				if !vt.insertTipLocked(parkedNode, preResolved.ledger) {
+					return
+				}
 			}
 			delete(vt.acquiring, key)
 			return
 		}
-		vt.insertTipLocked(nodeID, preResolved)
+		vt.insertTipLocked(nodeID, preResolved.ledger)
 		return
 	}
 	vt.parkLocked(key, nodeID)
@@ -125,9 +222,9 @@ func (vt *ValidationTracker) checkAcquired() {
 	}
 	vt.mu.RUnlock()
 
-	resolved := make(map[acquiringKey]ledgertrie.Ledger, len(keys))
+	resolved := make(map[acquiringKey]ancestryResolution, len(keys))
 	for _, key := range keys {
-		if lgr, ok := ancestry.LedgerByID(key.id); ok && lgr.ID() == key.id && lgr.Seq() == key.seq {
+		if lgr, ok := resolveAncestry(ancestry, key.id, &key.seq); ok && !lgr.retryable {
 			resolved[key] = lgr
 		}
 	}
@@ -150,7 +247,9 @@ func (vt *ValidationTracker) checkAcquired() {
 			if current == nil || current.LedgerSeq != key.seq || current.LedgerID != key.id || !vt.trusted[nodeID] {
 				continue
 			}
-			vt.insertTipLocked(nodeID, lgr)
+			if !vt.insertTipLocked(nodeID, lgr.ledger) {
+				return
+			}
 		}
 		delete(vt.acquiring, key)
 	}
@@ -183,17 +282,62 @@ func (vt *ValidationTracker) unparkLocked(key acquiringKey, nodeID consensus.Nod
 
 // insertTipLocked replaces nodeID's previous trie tip (if any) with lgr.
 // Caller must hold vt.mu (write).
-func (vt *ValidationTracker) insertTipLocked(nodeID consensus.NodeID, lgr ledgertrie.Ledger) {
+func (vt *ValidationTracker) insertTipLocked(nodeID consensus.NodeID, lgr ledgertrie.Ledger) bool {
+	if vt.trie == nil || lgr == nil {
+		return false
+	}
 	if prev, existed := vt.trieTips[nodeID]; existed {
 		if safeTrieCall("Remove", func() { vt.trie.Remove(prev, 1) }) {
-			return
+			vt.resetTrieLocked()
+			return false
 		}
 		delete(vt.trieTips, nodeID)
 	}
 	if safeTrieCall("Insert", func() { vt.trie.Insert(lgr, 1) }) {
-		return
+		vt.resetTrieLocked()
+		return false
 	}
 	vt.trieTips[nodeID] = lgr
+	return true
+}
+
+// resetTrieLocked discards all derived trie state after a mutation panic.
+// The tracked validation maps are authoritative, so rebuildTrieLocked can
+// safely re-park every trusted latest validation. The next checkAcquired poll
+// resolves available ledgers and repopulates the replacement trie.
+// Caller must hold vt.mu.
+func (vt *ValidationTracker) resetTrieLocked() {
+	if vt.ancestry == nil {
+		if vt.trie != nil {
+			vt.trie = ledgertrie.New(genesisLedger{})
+		}
+		vt.trieTips = make(map[consensus.NodeID]ledgertrie.Ledger)
+		vt.acquiring = make(map[acquiringKey]map[consensus.NodeID]struct{})
+		return
+	}
+	vt.rebuildTrieLocked()
+}
+
+// removeTipLocked removes a validator's derived trie tip while keeping the
+// trieTips index coupled to the trie. A panic can leave ledgertrie partially
+// mutated, so discard and rebuild the entire derived state instead of
+// continuing against a corrupted instance.
+// Caller must hold vt.mu.
+func (vt *ValidationTracker) removeTipLocked(nodeID consensus.NodeID) bool {
+	if vt.trie == nil {
+		delete(vt.trieTips, nodeID)
+		return true
+	}
+	prev, ok := vt.trieTips[nodeID]
+	if !ok {
+		return true
+	}
+	if safeTrieCall("Remove", func() { vt.trie.Remove(prev, 1) }) {
+		vt.resetTrieLocked()
+		return false
+	}
+	delete(vt.trieTips, nodeID)
+	return true
 }
 
 // GetJSONTrie returns a JSON-serializable snapshot of the ancestry trie's
@@ -201,13 +345,14 @@ func (vt *ValidationTracker) insertTipLocked(nodeID consensus.NodeID, lgr ledger
 // the trie is disabled (no ancestry provider wired) or a serialization panic
 // is trapped. Guarded by vt.mu.
 func (vt *ValidationTracker) GetJSONTrie() map[string]any {
-	vt.mu.RLock()
-	defer vt.mu.RUnlock()
+	vt.mu.Lock()
+	defer vt.mu.Unlock()
 	if vt.trie == nil {
 		return nil
 	}
 	var res map[string]any
 	if safeTrieCall("GetJSON", func() { res = vt.trie.GetJSON() }) {
+		vt.resetTrieLocked()
 		return nil
 	}
 	return res

--- a/internal/consensus/rcl/validations_trie_test.go
+++ b/internal/consensus/rcl/validations_trie_test.go
@@ -326,6 +326,12 @@ func TestValidationTracker_ProviderTypedNilResultStaysParked(t *testing.T) {
 	if got := vt.TrustedSupport(valid.ID()); got != 1 {
 		t.Fatalf("corrected typed-nil provider result did not restore support: got %d", got)
 	}
+	vt.mu.RLock()
+	tips, parked := len(vt.trieTips), len(vt.acquiring)
+	vt.mu.RUnlock()
+	if tips != 1 || parked != 0 {
+		t.Fatalf("corrected provider result did not repopulate the trie: tips=%d acquiring=%d", tips, parked)
+	}
 }
 
 func TestValidationTracker_TypedNilProviderDisablesSafely(t *testing.T) {

--- a/internal/consensus/rcl/validations_trie_test.go
+++ b/internal/consensus/rcl/validations_trie_test.go
@@ -15,6 +15,14 @@ type mapAncestryProvider struct {
 	byID map[consensus.LedgerID]ledgertrie.Ledger
 }
 
+type nilAncestryProvider struct {
+	ledger ledgertrie.Ledger
+}
+
+func (p nilAncestryProvider) LedgerByID(consensus.LedgerID) (ledgertrie.Ledger, bool) {
+	return p.ledger, true
+}
+
 func newMapAncestryProvider() *mapAncestryProvider {
 	return &mapAncestryProvider{byID: make(map[consensus.LedgerID]ledgertrie.Ledger)}
 }
@@ -32,6 +40,72 @@ func (maxSequenceLedger) ID() consensus.LedgerID             { return consensus.
 func (maxSequenceLedger) Seq() uint32                        { return math.MaxUint32 }
 func (maxSequenceLedger) MinSeq() uint32                     { return 0 }
 func (maxSequenceLedger) Ancestor(uint32) consensus.LedgerID { return consensus.LedgerID{} }
+
+// mismatchedLedger has an ID present in the trie but an incompatible
+// sequence, making ledgertrie.Remove deterministically panic before it can
+// mutate the node. It exercises the tracker-level rebuild seam without
+// adding production-only failure hooks.
+type mismatchedLedger struct {
+	id  consensus.LedgerID
+	seq uint32
+}
+
+func (l mismatchedLedger) ID() consensus.LedgerID             { return l.id }
+func (l mismatchedLedger) Seq() uint32                        { return l.seq }
+func (l mismatchedLedger) MinSeq() uint32                     { return 0 }
+func (l mismatchedLedger) Ancestor(uint32) consensus.LedgerID { return l.id }
+
+type panicAncestorLedger struct {
+	id  consensus.LedgerID
+	seq uint32
+}
+
+func (l panicAncestorLedger) ID() consensus.LedgerID { return l.id }
+func (l panicAncestorLedger) Seq() uint32            { return l.seq }
+func (l panicAncestorLedger) MinSeq() uint32         { return 0 }
+func (l panicAncestorLedger) Ancestor(uint32) consensus.LedgerID {
+	panic("hostile ancestry")
+}
+
+type panicProvider struct{}
+
+func (panicProvider) LedgerByID(consensus.LedgerID) (ledgertrie.Ledger, bool) {
+	panic("hostile provider")
+}
+
+type panicMetadataLedger struct {
+	id         consensus.LedgerID
+	seq        uint32
+	panicID    bool
+	panicSeq   bool
+	panicRetry bool
+}
+
+func (l panicMetadataLedger) ID() consensus.LedgerID {
+	if l.panicID {
+		panic("hostile ledger ID")
+	}
+	return l.id
+}
+
+func (l panicMetadataLedger) Seq() uint32 {
+	if l.panicSeq {
+		panic("hostile ledger sequence")
+	}
+	return l.seq
+}
+
+func (l panicMetadataLedger) MinSeq() uint32 { return 0 }
+func (l panicMetadataLedger) Ancestor(uint32) consensus.LedgerID {
+	return l.id
+}
+
+func (l panicMetadataLedger) retryable() bool {
+	if l.panicRetry {
+		panic("hostile retry metadata")
+	}
+	return false
+}
 
 // makeTrustedValidation constructs a trusted validation at the given
 // seq from nodeID pointing at ledgerID. Close enough to the isCurrent
@@ -68,6 +142,352 @@ func TestValidationTracker_InsertTipDoesNotRecordRejectedLedger(t *testing.T) {
 	}
 	if _, ok := vt.trie.GetPreferred(0); ok {
 		t.Fatal("rejected ledger left support in the trie")
+	}
+}
+
+func TestValidationTracker_TrieMutationPanicRebuildsForRecovery(t *testing.T) {
+	vt := NewValidationTracker(1)
+	b := ledgertrietest.NewTestLedgerBuilder()
+	valid := b.Build("valid")
+	nodeID := consensus.NodeID{1}
+	provider := newMapAncestryProvider()
+	provider.add(valid)
+	vt.ancestry = provider
+	vt.trusted[nodeID] = true
+	vt.trie = ledgertrie.New(genesisLedger{})
+	vt.trieTips = make(map[consensus.NodeID]ledgertrie.Ledger)
+
+	vt.mu.Lock()
+	if !vt.insertTipLocked(nodeID, valid) {
+		t.Fatal("initial trie insert failed")
+	}
+	// Keep the authoritative state aligned with the valid tip while replacing
+	// only the derived pointer with a bad sequence. Remove now panics; the
+	// tracker must discard the old trie rather than retain a phantom tip.
+	vt.byNode[nodeID] = &consensus.Validation{LedgerID: valid.ID(), LedgerSeq: valid.Seq()}
+	vt.trieTips[nodeID] = mismatchedLedger{id: valid.ID(), seq: valid.Seq() + 1}
+	if vt.insertTipLocked(nodeID, valid) {
+		t.Fatal("mismatched remove unexpectedly succeeded")
+	}
+	vt.mu.Unlock()
+
+	if got := vt.TrustedSupport(valid.ID()); got != 1 {
+		t.Fatalf("panic recovery failed to rebuild authoritative support: got %d, want 1", got)
+	}
+
+	vt.mu.Lock()
+	if !vt.insertTipLocked(nodeID, valid) {
+		t.Fatal("tracker did not permit safe trie recovery")
+	}
+	vt.mu.Unlock()
+	if got := vt.TrustedSupport(valid.ID()); got != 1 {
+		t.Fatalf("safe trie recovery support: got %d, want 1", got)
+	}
+}
+
+func TestValidationTracker_StaleCleanupPanicClearsDerivedState(t *testing.T) {
+	vt := NewValidationTracker(1)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+	b := ledgertrietest.NewTestLedgerBuilder()
+	valid := b.Build("stale")
+	nodeID := consensus.NodeID{1}
+	provider := newMapAncestryProvider()
+	provider.add(valid)
+	vt.SetTrusted([]consensus.NodeID{nodeID})
+	vt.SetLedgerAncestryProvider(provider)
+	if !vt.Add(makeTrustedValidation(nodeID, valid.ID(), valid.Seq(), now)) {
+		t.Fatal("precondition validation was rejected")
+	}
+
+	vt.mu.Lock()
+	vt.trieTips[nodeID] = mismatchedLedger{id: valid.ID(), seq: valid.Seq() + 1}
+	vt.mu.Unlock()
+	now = now.Add(validationCurrentEarly + time.Second)
+	vt.FlushStale()
+
+	if got := vt.TrustedSupport(valid.ID()); got != 0 {
+		t.Fatalf("stale cleanup left phantom support: got %d", got)
+	}
+	if _, _, ok := vt.GetPreferred(0); ok {
+		t.Fatal("stale cleanup left a preferred tip")
+	}
+}
+
+func TestValidationTracker_PartialAncestryRepairsPreferredSupport(t *testing.T) {
+	tip, byHash := buildChain(5, 'p')
+	var missingHash [32]byte
+	var ancestor *fakeHeader
+	for hash, header := range byHash {
+		switch header.Sequence() {
+		case 2:
+			ancestor = header.(*fakeHeader)
+		case 3:
+			missingHash = hash
+		}
+	}
+	missing := byHash[missingHash]
+	delete(byHash, missingHash)
+
+	provider := newTestProvider(byHash)
+	vt := NewValidationTracker(1)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+	n1 := consensus.NodeID{1}
+	n2 := consensus.NodeID{2}
+	n3 := consensus.NodeID{3}
+	vt.SetTrusted([]consensus.NodeID{n1, n2, n3})
+	vt.SetLedgerAncestryProvider(provider)
+
+	if !vt.Add(makeTrustedValidation(n1, consensus.LedgerID(tip.hash), tip.seq, now)) {
+		t.Fatal("partial tip validation was rejected")
+	}
+	if !vt.Add(makeTrustedValidation(n2, consensus.LedgerID(tip.hash), tip.seq, now)) {
+		t.Fatal("second partial tip validation was rejected")
+	}
+	if !vt.Add(makeTrustedValidation(n3, consensus.LedgerID(ancestor.hash), ancestor.seq, now)) {
+		t.Fatal("ancestor validation was rejected")
+	}
+	if got := vt.TrustedSupport(consensus.LedgerID(ancestor.hash)); got != 1 {
+		t.Fatalf("partial tip was treated as complete support: got %d, want 1", got)
+	}
+
+	byHash[missingHash] = missing
+	if got := vt.TrustedSupport(consensus.LedgerID(ancestor.hash)); got != 3 {
+		t.Fatalf("repaired preferred support = %d, want 3", got)
+	}
+	if id, seq, ok := vt.GetPreferred(tip.seq); !ok || id != consensus.LedgerID(tip.hash) || seq != tip.seq {
+		t.Fatalf("preferred after ancestry repair = (%x, %d, %t), want tip", id, seq, ok)
+	}
+}
+
+func TestValidationTracker_ProviderNilResultsStayParked(t *testing.T) {
+	vt := NewValidationTracker(1)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+	nodeID := consensus.NodeID{0xD1}
+	ledgerID := consensus.LedgerID{0xE1}
+	vt.SetTrusted([]consensus.NodeID{nodeID})
+	vt.SetLedgerAncestryProvider(nilAncestryProvider{})
+
+	if !vt.Add(makeTrustedValidation(nodeID, ledgerID, 7, now)) {
+		t.Fatal("validation with nil provider result was rejected")
+	}
+	if _, _, ok := vt.GetPreferred(0); !ok {
+		t.Fatal("parked validation should remain available through acquiring fallback")
+	}
+	if got := vt.TrustedSupport(ledgerID); got != 1 {
+		t.Fatalf("nil provider result should use flat fallback support: got %d", got)
+	}
+	vt.mu.RLock()
+	if len(vt.trieTips) != 0 || len(vt.acquiring) != 1 {
+		t.Fatalf("nil provider result changed derived indexes: tips=%d acquiring=%d", len(vt.trieTips), len(vt.acquiring))
+	}
+	vt.mu.RUnlock()
+
+	b := ledgertrietest.NewTestLedgerBuilder()
+	valid := b.Build("valid-provider")
+	provider := &mapAncestryProvider{byID: map[consensus.LedgerID]ledgertrie.Ledger{valid.ID(): valid}}
+	// Keep the validation's ID/sequence aligned with the eventual provider
+	// result in a fresh tracker; the first tracker above specifically covers
+	// a nil interface result and must not dereference it.
+	vt = NewValidationTracker(1)
+	vt.SetNow(func() time.Time { return now })
+	vt.SetTrusted([]consensus.NodeID{nodeID})
+	vt.SetLedgerAncestryProvider(provider)
+	if !vt.Add(makeTrustedValidation(nodeID, valid.ID(), valid.Seq(), now)) {
+		t.Fatal("validation with corrected provider result was rejected")
+	}
+	if got := vt.TrustedSupport(valid.ID()); got != 1 {
+		t.Fatalf("correct provider result did not restore support: got %d", got)
+	}
+}
+
+func TestValidationTracker_ProviderTypedNilResultStaysParked(t *testing.T) {
+	vt := NewValidationTracker(1)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+	nodeID := consensus.NodeID{0xD2}
+	b := ledgertrietest.NewTestLedgerBuilder()
+	valid := b.Build("typed-nil")
+	var typedNil *ledgertrietest.TestLedger
+	provider := &mapAncestryProvider{byID: map[consensus.LedgerID]ledgertrie.Ledger{valid.ID(): typedNil}}
+	vt.SetTrusted([]consensus.NodeID{nodeID})
+	vt.SetLedgerAncestryProvider(provider)
+
+	if !vt.Add(makeTrustedValidation(nodeID, valid.ID(), valid.Seq(), now)) {
+		t.Fatal("validation with typed-nil provider result was rejected")
+	}
+	if got := vt.TrustedSupport(valid.ID()); got != 1 {
+		t.Fatalf("typed-nil provider result should use flat fallback support: got %d", got)
+	}
+
+	provider.byID[valid.ID()] = valid
+	if got := vt.TrustedSupport(valid.ID()); got != 1 {
+		t.Fatalf("corrected typed-nil provider result did not restore support: got %d", got)
+	}
+}
+
+func TestValidationTracker_TypedNilProviderDisablesSafely(t *testing.T) {
+	vt := NewValidationTracker(1)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+	nodeID := consensus.NodeID{0xD3}
+	b := ledgertrietest.NewTestLedgerBuilder()
+	valid := b.Build("typed-provider")
+	var provider *mapAncestryProvider
+	vt.SetTrusted([]consensus.NodeID{nodeID})
+	vt.SetLedgerAncestryProvider(provider)
+
+	vt.mu.RLock()
+	if vt.ancestry != nil || vt.trie != nil || vt.trieTips != nil || vt.acquiring != nil {
+		t.Fatal("typed-nil provider was installed instead of disabling the trie")
+	}
+	vt.mu.RUnlock()
+
+	if !vt.Add(makeTrustedValidation(nodeID, valid.ID(), valid.Seq(), now)) {
+		t.Fatal("validation after typed-nil provider installation was rejected")
+	}
+	if got := vt.TrustedSupport(valid.ID()); got != 1 {
+		t.Fatalf("typed-nil provider altered flat support: got %d, want 1", got)
+	}
+	prev := &mockLedger{id: b.Genesis().ID(), seq: b.Genesis().Seq()}
+	if got := vt.ProposersFinished(prev); got != 1 {
+		t.Fatalf("typed-nil provider altered proposer fallback: got %d, want 1", got)
+	}
+}
+
+func TestValidationTracker_ProviderPanicFallsBackWithoutCorruption(t *testing.T) {
+	vt := NewValidationTracker(1)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+	b := ledgertrietest.NewTestLedgerBuilder()
+	tip := b.Build("provider-panic")
+	nodeID := consensus.NodeID{0xD6}
+	vt.SetTrusted([]consensus.NodeID{nodeID})
+	vt.SetLedgerAncestryProvider(panicProvider{})
+	if !vt.Add(makeTrustedValidation(nodeID, tip.ID(), tip.Seq(), now)) {
+		t.Fatal("validation with panicking provider was rejected")
+	}
+	if got := vt.TrustedSupport(tip.ID()); got != 1 {
+		t.Fatalf("provider panic flat support = %d, want 1", got)
+	}
+	prev := &mockLedger{id: consensus.LedgerID{0xD7}, seq: tip.Seq() - 1}
+	if got := vt.ProposersFinished(prev); got != 1 {
+		t.Fatalf("provider panic proposer fallback = %d, want 1", got)
+	}
+}
+
+func TestValidationTracker_MetadataPanicsParkAndRepair(t *testing.T) {
+	metadataCases := []struct {
+		name string
+		make func(id consensus.LedgerID, seq uint32) ledgertrie.Ledger
+	}{
+		{name: "id", make: func(id consensus.LedgerID, seq uint32) ledgertrie.Ledger {
+			return panicMetadataLedger{id: id, seq: seq, panicID: true}
+		}},
+		{name: "seq", make: func(id consensus.LedgerID, seq uint32) ledgertrie.Ledger {
+			return panicMetadataLedger{id: id, seq: seq, panicSeq: true}
+		}},
+		{name: "retryable", make: func(id consensus.LedgerID, seq uint32) ledgertrie.Ledger {
+			return panicMetadataLedger{id: id, seq: seq, panicRetry: true}
+		}},
+	}
+
+	for _, tc := range metadataCases {
+		t.Run(tc.name, func(t *testing.T) {
+			vt := NewValidationTracker(1)
+			now := time.Now()
+			vt.SetNow(func() time.Time { return now })
+			b := ledgertrietest.NewTestLedgerBuilder()
+			ancestor := b.Build("a")
+			tip := b.Build("ab")
+			nodeID := consensus.NodeID{0xD8}
+			provider := &mapAncestryProvider{byID: map[consensus.LedgerID]ledgertrie.Ledger{
+				ancestor.ID(): ancestor,
+				tip.ID():      tc.make(tip.ID(), tip.Seq()),
+			}}
+			vt.SetTrusted([]consensus.NodeID{nodeID})
+			vt.SetLedgerAncestryProvider(provider)
+			if !vt.Add(makeTrustedValidation(nodeID, tip.ID(), tip.Seq(), now)) {
+				t.Fatal("validation with panicking metadata was rejected")
+			}
+			if got := vt.TrustedSupport(tip.ID()); got != 1 {
+				t.Fatalf("metadata panic flat support = %d, want 1", got)
+			}
+			prevTip := &mockLedger{id: tip.ID(), seq: tip.Seq()}
+			if got := vt.ProposersFinished(prevTip); got != 0 {
+				t.Fatalf("metadata panic proposer fallback = %d, want 0", got)
+			}
+
+			provider.byID[tip.ID()] = tip
+			if got := vt.TrustedSupport(tip.ID()); got != 1 {
+				t.Fatalf("repaired metadata support = %d, want 1", got)
+			}
+			prevAncestor := &mockLedger{id: ancestor.ID(), seq: ancestor.Seq()}
+			if got := vt.ProposersFinished(prevAncestor); got != 1 {
+				t.Fatalf("repaired metadata proposer support = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func TestValidationTracker_TrustedSupportRecoversFromHostileTip(t *testing.T) {
+	vt := NewValidationTracker(1)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+	b := ledgertrietest.NewTestLedgerBuilder()
+	valid := b.Build("hostile-support")
+	nodeID := consensus.NodeID{0xD4}
+	provider := newMapAncestryProvider()
+	provider.add(valid)
+	vt.SetTrusted([]consensus.NodeID{nodeID})
+	vt.SetLedgerAncestryProvider(provider)
+	if !vt.Add(makeTrustedValidation(nodeID, valid.ID(), valid.Seq(), now)) {
+		t.Fatal("precondition validation was rejected")
+	}
+
+	vt.mu.Lock()
+	vt.trieTips[nodeID] = panicAncestorLedger{id: valid.ID(), seq: valid.Seq()}
+	vt.mu.Unlock()
+
+	if got := vt.TrustedSupport(valid.ID()); got != 1 {
+		t.Fatalf("hostile tip support = %d, want recovered support 1", got)
+	}
+	if got := vt.TrustedSupport(valid.ID()); got != 1 {
+		t.Fatalf("support after hostile tip rebuild = %d, want 1", got)
+	}
+}
+
+func TestValidationTracker_ProposersFinishedRecoversFromHostileTip(t *testing.T) {
+	vt := NewValidationTracker(1)
+	now := time.Now()
+	vt.SetNow(func() time.Time { return now })
+	b := ledgertrietest.NewTestLedgerBuilder()
+	ancestor := b.Build("a")
+	valid := b.Build("ab")
+	nodeID := consensus.NodeID{0xD5}
+	provider := newMapAncestryProvider()
+	provider.add(ancestor)
+	provider.add(valid)
+	vt.SetTrusted([]consensus.NodeID{nodeID})
+	vt.SetLedgerAncestryProvider(provider)
+	if !vt.Add(makeTrustedValidation(nodeID, valid.ID(), valid.Seq(), now)) {
+		t.Fatal("precondition validation was rejected")
+	}
+
+	prev := &mockLedger{id: ancestor.ID(), seq: ancestor.Seq()}
+	provider.byID[ancestor.ID()] = panicAncestorLedger{id: ancestor.ID(), seq: ancestor.Seq()}
+	if got := vt.ProposersFinished(prev); got != 1 {
+		t.Fatalf("hostile target proposer support = %d, want recovered fallback 1", got)
+	}
+	if got := vt.TrustedSupport(valid.ID()); got != 1 {
+		t.Fatalf("hostile target corrupted descendant support: got %d, want 1", got)
+	}
+
+	provider.byID[ancestor.ID()] = ancestor
+	if got := vt.ProposersFinished(prev); got != 1 {
+		t.Fatalf("proposer support after hostile target repair = %d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve ledger ancestry from rolling skip-list history when available and repair cached partial chains after missing ledgers arrive
- validate exact parent IDs and sequences and coalesce concurrent ancestry builds safely
- contain provider and ledger-metadata panics outside tracker locks, including typed-nil and malformed results
- discard and rebuild derived trie state after invariant panics, with safe flat-count fallbacks while ancestry remains unavailable

## Verification

- `just test`
- `go test -race ./internal/consensus/rcl`
- `go test ./internal/consensus/...`
- `go test -race ./internal/consensus/rcl ./internal/ledger/...`
- `go vet ./...`
- `golangci-lint run ./internal/consensus/rcl/... ./internal/ledger/...`
- `git diff --check`

Part of #1463


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ledger ancestry resolution when headers arrive late or contain inconsistent metadata.
  * Added automatic recovery for incomplete, outdated, or partially available ancestry information.
  * Improved handling of missing, invalid, or unavailable ledger data without corrupting validation state.
  * Added safer recovery from unexpected validation failures while preserving trusted support and fallback behavior.
  * Improved recovery of validation state after temporary data or processing errors.

* **Performance**
  * Reduced redundant work when multiple requests resolve the same ancestry concurrently.
  * Improved ancestry resolution efficiency using available embedded skip information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->