### PR TITLE
fix: persist and isolate manifest caches

### DIFF
--- a/internal/consensus/adaptor/identity.go
+++ b/internal/consensus/adaptor/identity.go
@@ -147,15 +147,15 @@ func NewValidatorIdentityFromToken(block string) (*ValidatorIdentity, error) {
 	}
 	var derived [33]byte
 	copy(derived[:], pub)
-	if derived != m.SigningKey {
+	if derived != m.SigningKey() {
 		return nil, ErrTokenManifestKeyMismatch
 	}
 
 	vi := &ValidatorIdentity{
-		MasterKey:      m.MasterKey,
-		SigningKey:     m.SigningKey,
+		MasterKey:      m.MasterKey(),
+		SigningKey:     m.SigningKey(),
 		Manifest:       m,
-		SerializedMfst: append([]byte(nil), m.Serialized...),
+		SerializedMfst: m.Serialized(),
 		signingPriv:    hex.EncodeToString(tok.ValidationSecret[:]),
 	}
 	vi.NodeID = consensus.CalcNodeID(vi.MasterKey)

--- a/internal/consensus/adaptor/identity_token_test.go
+++ b/internal/consensus/adaptor/identity_token_test.go
@@ -36,11 +36,15 @@ type tokenFixture struct {
 //
 // All randomness is seeded by `seed` so tests stay deterministic.
 func newTokenFixture(t *testing.T, seed byte, sequence uint32) tokenFixture {
+	return newTokenFixtureWithSeeds(t, seed, seed, sequence)
+}
+
+func newTokenFixtureWithSeeds(t *testing.T, masterSeed, signingSeed byte, sequence uint32) tokenFixture {
 	t.Helper()
 
 	// Master: ed25519. Use deterministic-from-seed key material so the
 	// fixture is reproducible across runs.
-	masterSeedBytes := bytes.Repeat([]byte{seed}, ed25519.SeedSize)
+	masterSeedBytes := bytes.Repeat([]byte{masterSeed}, ed25519.SeedSize)
 	masterPriv := ed25519.NewKeyFromSeed(masterSeedBytes)
 	masterPubBytes := masterPriv.Public().(ed25519.PublicKey)
 	master33 := append([]byte{0xED}, masterPubBytes...)
@@ -50,7 +54,7 @@ func newTokenFixture(t *testing.T, seed byte, sequence uint32) tokenFixture {
 	// is, and 0xFF is also fine. Tests use small seeds so this holds.
 	var sec [32]byte
 	for i := range sec {
-		sec[i] = seed ^ byte(i+1)
+		sec[i] = signingSeed ^ byte(i+1)
 	}
 	algo := secp256k1.Algorithm{}
 	signingPubBytes, err := algo.DerivePublicKeyFromSecret(sec[:])
@@ -172,8 +176,8 @@ func TestNewValidatorIdentityFromToken_HappyPath(t *testing.T) {
 	if id.Manifest == nil {
 		t.Fatal("Manifest must be populated")
 	}
-	if id.Manifest.Sequence != fix.sequence {
-		t.Errorf("manifest sequence: got %d want %d", id.Manifest.Sequence, fix.sequence)
+	if id.Manifest.Sequence() != fix.sequence {
+		t.Errorf("manifest sequence: got %d want %d", id.Manifest.Sequence(), fix.sequence)
 	}
 	if len(id.SerializedMfst) == 0 {
 		t.Error("SerializedMfst must be populated for #372 emission")

--- a/internal/consensus/adaptor/manifest_emit_test.go
+++ b/internal/consensus/adaptor/manifest_emit_test.go
@@ -264,11 +264,11 @@ func TestRouter_SendLocalManifestTo_EmitsExpectedFrame(t *testing.T) {
 	if err != nil {
 		t.Fatalf("emitted manifest fails Deserialize: %v", err)
 	}
-	if parsed.MasterKey != id.MasterKey {
+	if parsed.MasterKey() != id.MasterKey {
 		t.Errorf("emitted manifest master key mismatch")
 	}
-	if parsed.Sequence != id.Manifest.Sequence {
-		t.Errorf("emitted manifest sequence: got %d want %d", parsed.Sequence, id.Manifest.Sequence)
+	if parsed.Sequence() != id.Manifest.Sequence() {
+		t.Errorf("emitted manifest sequence: got %d want %d", parsed.Sequence(), id.Manifest.Sequence())
 	}
 }
 
@@ -620,13 +620,9 @@ func TestRouter_CachedManifestFrame_RebuiltOnSequenceAdvance(t *testing.T) {
 	router.SendLocalManifestTo(peermanagement.PeerID(1))
 	first := router.manifestFrames[0]
 
-	// Mint a higher-sequence manifest under the SAME master+ephemeral
-	// keypair (newTokenFixture is seed-deterministic — same seed byte
-	// = same keys; only the sequence differs). This hits the update
-	// branch in cache.ApplyManifest. Every accept bumps Sequence in
-	// rippled 3.2.0 (#6059), so after the setup first-insert (=1) this
-	// update takes it to 2.
-	rotated := newTokenFixture(t, 0xC2, 7)
+	// Mint a higher-sequence manifest under the same master with a new
+	// ephemeral key. Reusing the current ephemeral is a cache collision.
+	rotated := newTokenFixtureWithSeeds(t, 0xC2, 0xC3, 7)
 	rotatedID, err := NewValidatorIdentityFromToken(rotated.tokenBlock)
 	if err != nil {
 		t.Fatalf("rotated identity: %v", err)

--- a/internal/consensus/adaptor/manifest_persistence_test.go
+++ b/internal/consensus/adaptor/manifest_persistence_test.go
@@ -95,6 +95,47 @@ func TestRestoreManifestsRejectsInvalidRowsAndKeepsRevocation(t *testing.T) {
 	require.True(t, cache.Revoked(revocation.MasterKey()))
 }
 
+func TestSeedLocalManifestToleratesPersistedKeyCollisions(t *testing.T) {
+	tests := []struct {
+		name      string
+		persisted []byte
+		local     []byte
+		want      manifest.Disposition
+	}{
+		{
+			name:      "master already used as signing key",
+			persisted: buildWireManifest(t, 1, 0x51, 0x52),
+			local:     buildWireManifest(t, 1, 0x52, 0x53),
+			want:      manifest.BadMasterKey,
+		},
+		{
+			name:      "signing key already used",
+			persisted: buildWireManifest(t, 1, 0x54, 0x55),
+			local:     buildWireManifest(t, 1, 0x56, 0x55),
+			want:      manifest.BadEphemeralKey,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			persisted, err := manifest.Deserialize(test.persisted)
+			require.NoError(t, err)
+			local, err := manifest.Deserialize(test.local)
+			require.NoError(t, err)
+
+			cache := manifest.NewCache()
+			require.Equal(t, manifest.Accepted, cache.ApplyManifest(persisted))
+			require.Equal(t, test.want, cache.ApplyManifest(local))
+			require.NoError(t, seedLocalManifest(cache, local))
+		})
+	}
+
+	invalidWire := buildWireManifest(t, 1, 0x57, 0x58)
+	invalidWire[len(invalidWire)-1] ^= 1
+	invalid, err := manifest.Deserialize(invalidWire)
+	require.NoError(t, err)
+	require.ErrorContains(t, seedLocalManifest(manifest.NewCache(), invalid), "disposition=invalid")
+}
+
 func TestNewFromConfigFailsWhenManifestStoreCannotLoad(t *testing.T) {
 	dir := t.TempDir()
 	db, err := sql.Open("sqlite", filepath.Join(dir, "manifests.db"))

--- a/internal/consensus/adaptor/manifest_persistence_test.go
+++ b/internal/consensus/adaptor/manifest_persistence_test.go
@@ -1,0 +1,149 @@
+package adaptor
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/config"
+	"github.com/LeJamon/go-xrpl/internal/manifest"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingManifestStore struct {
+	stored     manifest.StoredManifests
+	events     []string
+	replaceErr error
+	closeErr   error
+	onReplace  func()
+}
+
+func (s *recordingManifestStore) Load(context.Context) (manifest.StoredManifests, error) {
+	return manifest.StoredManifests{}, nil
+}
+
+func (s *recordingManifestStore) Replace(_ context.Context, stored manifest.StoredManifests) error {
+	s.events = append(s.events, "replace")
+	if s.onReplace != nil {
+		s.onReplace()
+	}
+	s.stored = stored
+	return s.replaceErr
+}
+
+func (s *recordingManifestStore) Close() error {
+	s.events = append(s.events, "close")
+	return s.closeErr
+}
+
+func TestComponentsStopPersistsRoleFilteredManifestsAndReportsFailures(t *testing.T) {
+	validatorCache := manifest.NewCache()
+	publisherCache := manifest.NewCache()
+
+	unlisted := applyTokenManifest(t, validatorCache, 0x41, 0x42, 1)
+	validatorRevocation := revokedManifest(t, 0x43)
+	require.Equal(t, manifest.Accepted, validatorCache.ApplyManifest(validatorRevocation))
+
+	configured := applyTokenManifest(t, publisherCache, 0x44, 0x45, 1)
+	_ = applyTokenManifest(t, publisherCache, 0x46, 0x47, 1)
+	publisherRevocation := revokedManifest(t, 0x48)
+	require.Equal(t, manifest.Accepted, publisherCache.ApplyManifest(publisherRevocation))
+
+	saveErr := errors.New("save failed")
+	closeErr := errors.New("close failed")
+	engineStopped := false
+	store := &recordingManifestStore{
+		replaceErr: saveErr,
+		closeErr:   closeErr,
+		onReplace: func() {
+			require.True(t, engineStopped, "manifest snapshot ran before the engine stopped")
+		},
+	}
+	engine := &lifecycleTestEngine{stopCheck: func() { engineStopped = true }}
+	components := &Components{
+		Engine:                  engine,
+		ValidatorManifests:      validatorCache,
+		PublisherManifests:      publisherCache,
+		configuredPublisherKeys: [][33]byte{configured},
+		manifestStore:           store,
+	}
+
+	err := components.Stop()
+	require.ErrorIs(t, err, saveErr)
+	require.ErrorIs(t, err, closeErr)
+	require.Equal(t, []string{"replace", "close"}, store.events)
+	require.NotContains(t, manifestMasters(t, store.stored.Validators), unlisted)
+	require.Contains(t, manifestMasters(t, store.stored.Validators), validatorRevocation.MasterKey())
+	require.Contains(t, manifestMasters(t, store.stored.Publishers), configured)
+	require.Contains(t, manifestMasters(t, store.stored.Publishers), publisherRevocation.MasterKey())
+	require.Len(t, store.stored.Publishers, 2)
+
+	require.ErrorIs(t, components.Stop(), saveErr)
+	require.Equal(t, []string{"replace", "close"}, store.events)
+}
+
+func TestRestoreManifestsRejectsInvalidRowsAndKeepsRevocation(t *testing.T) {
+	revocation := revokedManifest(t, 0x49)
+	cache := manifest.NewCache()
+	restoreManifests("validator", cache, [][]byte{{0xff}, revocation.Serialized()})
+	require.True(t, cache.Revoked(revocation.MasterKey()))
+}
+
+func TestNewFromConfigFailsWhenManifestStoreCannotLoad(t *testing.T) {
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "manifests.db"))
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE ValidatorManifests (WrongColumn BLOB NOT NULL)`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	components, err := NewFromConfig(context.Background(), &config.Config{DatabasePath: dir}, nil, nil, nil)
+	require.Nil(t, components)
+	require.ErrorContains(t, err, "load manifest store")
+	require.ErrorContains(t, err, "RawData")
+}
+
+func applyTokenManifest(t *testing.T, cache *manifest.Cache, masterSeed, signingSeed byte, sequence uint32) [33]byte {
+	t.Helper()
+	fixture := newTokenFixtureWithSeeds(t, masterSeed, signingSeed, sequence)
+	identity, err := NewValidatorIdentityFromToken(fixture.tokenBlock)
+	require.NoError(t, err)
+	require.Equal(t, manifest.Accepted, cache.ApplyManifest(identity.Manifest))
+	return identity.MasterKey
+}
+
+func revokedManifest(t *testing.T, seed byte) *manifest.Manifest {
+	t.Helper()
+	private := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{seed}, ed25519.SeedSize))
+	public := private.Public().(ed25519.PublicKey)
+	master := append([]byte{0xed}, public...)
+	fields := map[string]any{
+		"PublicKey": hex.EncodeToString(master),
+		"Sequence":  manifest.RevokedSequence,
+	}
+	fields["MasterSignature"] = hex.EncodeToString(ed25519.Sign(private, manifestSigningPreimage(t, fields)))
+	wireHex, err := binarycodec.Encode(fields)
+	require.NoError(t, err)
+	wire, err := hex.DecodeString(wireHex)
+	require.NoError(t, err)
+	parsed, err := manifest.Deserialize(wire)
+	require.NoError(t, err)
+	return parsed
+}
+
+func manifestMasters(t *testing.T, rows [][]byte) [][33]byte {
+	t.Helper()
+	out := make([][33]byte, 0, len(rows))
+	for _, row := range rows {
+		parsed, err := manifest.Deserialize(row)
+		require.NoError(t, err)
+		out = append(out, parsed.MasterKey())
+	}
+	return out
+}

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -122,7 +122,7 @@ func (r *Router) handleManifests(msg *peermanagement.InboundMessage) bool {
 			badManifest = true
 			return
 		}
-		if r.manifestAdmission != nil && !r.manifestAdmission(parsed.MasterKey) {
+		if r.manifestAdmission != nil && !r.manifestAdmission(parsed.MasterKey()) {
 			valid = true
 			return
 		}

--- a/internal/consensus/adaptor/router_manifests_test.go
+++ b/internal/consensus/adaptor/router_manifests_test.go
@@ -129,19 +129,19 @@ func TestRouter_HandleManifests_AppliesAccepted(t *testing.T) {
 	// can't assume immediate visibility.
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
-		if _, ok := cache.GetSigningKey(parsed.MasterKey); ok {
+		if _, ok := cache.GetSigningKey(parsed.MasterKey()); ok {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
-	if _, ok := cache.GetSigningKey(parsed.MasterKey); !ok {
+	if _, ok := cache.GetSigningKey(parsed.MasterKey()); !ok {
 		t.Fatal("router did not apply manifest to cache")
 	}
-	stored, ok := cache.GetManifest(parsed.MasterKey)
+	stored, ok := cache.GetManifest(parsed.MasterKey())
 	if !ok || !bytes.Equal(stored, serialized) {
 		t.Fatalf("stored manifest bytes mismatch: ok=%v", ok)
 	}
-	if got, _ := cache.GetSequence(parsed.MasterKey); got != 3 {
+	if got, _ := cache.GetSequence(parsed.MasterKey()); got != 3 {
 		t.Fatalf("stored sequence: got %d want 3", got)
 	}
 }
@@ -190,7 +190,7 @@ func TestRouter_ProcessManifestSpoolAppliesAndReleasesPeer(t *testing.T) {
 
 	parsed, err := manifest.Deserialize(wire)
 	require.NoError(t, err)
-	stored, ok := cache.GetManifest(parsed.MasterKey)
+	stored, ok := cache.GetManifest(parsed.MasterKey())
 	require.True(t, ok)
 	require.Equal(t, wire, stored)
 	_, err = inbound.ManifestFrame.Materialize(context.Background())
@@ -240,7 +240,7 @@ func TestRouter_HandleManifests_InvalidDoesNotStore(t *testing.T) {
 	// Give the router a moment to process the frame.
 	time.Sleep(50 * time.Millisecond)
 
-	if _, ok := cache.GetSigningKey(parsed.MasterKey); ok {
+	if _, ok := cache.GetSigningKey(parsed.MasterKey()); ok {
 		t.Fatal("cache stored a manifest whose master signature was corrupted")
 	}
 }
@@ -261,13 +261,13 @@ func TestRouter_HandleManifests_AdmissionBoundsDurableCache(t *testing.T) {
 
 	router.SetManifestAdmission(func([33]byte) bool { return false })
 	require.True(t, router.handleManifests(msg))
-	_, stored := cache.GetManifest(parsed.MasterKey)
+	_, stored := cache.GetManifest(parsed.MasterKey())
 	require.False(t, stored)
 	require.Empty(t, sender.bcastsExcept)
 
-	router.SetManifestAdmission(func(master [33]byte) bool { return master == parsed.MasterKey })
+	router.SetManifestAdmission(func(master [33]byte) bool { return master == parsed.MasterKey() })
 	require.True(t, router.handleManifests(msg))
-	storedWire, stored := cache.GetManifest(parsed.MasterKey)
+	storedWire, stored := cache.GetManifest(parsed.MasterKey())
 	require.True(t, stored)
 	require.Equal(t, wire, storedWire)
 	require.Len(t, sender.bcastsExcept, 1)
@@ -347,7 +347,7 @@ func TestRouter_ManifestAcceptedAfterPeerRemovalCompletesBootstrap(t *testing.T)
 
 	parsed, err := manifest.Deserialize(wire)
 	require.NoError(t, err)
-	stored, ok := cache.GetManifest(parsed.MasterKey)
+	stored, ok := cache.GetManifest(parsed.MasterKey())
 	require.True(t, ok)
 	require.Equal(t, wire, stored)
 	select {
@@ -412,7 +412,7 @@ func TestRouter_ManifestWorkerDoesNotBlockDispatch(t *testing.T) {
 	var blockOnce sync.Once
 	releaseWorker := func() { releaseOnce.Do(func() { close(release) }) }
 	defer releaseWorker()
-	cache.SetOnAccepted(func(*manifest.Manifest) {
+	cache.SubscribeAccepted(func(*manifest.Manifest) {
 		blockOnce.Do(func() {
 			close(entered)
 			<-release
@@ -459,7 +459,7 @@ func TestRouter_ManifestWorkerDoesNotBlockDispatch(t *testing.T) {
 	releaseWorker()
 	require.Eventually(t, func() bool {
 		for _, parsed := range queued {
-			if _, ok := cache.GetSigningKey(parsed.MasterKey); !ok {
+			if _, ok := cache.GetSigningKey(parsed.MasterKey()); !ok {
 				return false
 			}
 		}
@@ -483,7 +483,7 @@ func TestRouter_ManifestWorkerJoinsOnShutdown(t *testing.T) {
 	var blockOnce sync.Once
 	releaseWorker := func() { releaseOnce.Do(func() { close(release) }) }
 	defer releaseWorker()
-	cache.SetOnAccepted(func(*manifest.Manifest) {
+	cache.SubscribeAccepted(func(*manifest.Manifest) {
 		blockOnce.Do(func() {
 			close(entered)
 			<-release
@@ -543,7 +543,7 @@ func TestRouter_ManifestWorkerJoinsOnShutdown(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("router did not join its manifest worker")
 	}
-	_, ok := cache.GetSigningKey(queuedManifest.MasterKey)
+	_, ok := cache.GetSigningKey(queuedManifest.MasterKey())
 	require.True(t, ok, "shutdown must drain queued manifest jobs")
 	sender.mu.Lock()
 	broadcasts := len(sender.bcastsExcept)

--- a/internal/consensus/adaptor/router_resolve_master_nodeid_test.go
+++ b/internal/consensus/adaptor/router_resolve_master_nodeid_test.go
@@ -57,7 +57,7 @@ func installManifest(t *testing.T, cache *manifest.Cache, masterSeed, ephSeed by
 	if disp := cache.ApplyManifest(parsed); disp != manifest.Accepted {
 		t.Fatalf("ApplyManifest disposition: got %v want Accepted", disp)
 	}
-	return parsed.MasterKey, parsed.SigningKey
+	return parsed.MasterKey(), parsed.SigningKey()
 }
 
 // TestRouter_ResolveMasterNodeID_Validation_RewritesToMaster is the

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -3,6 +3,7 @@ package adaptor
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -31,11 +32,8 @@ type Components struct {
 	Adaptor *Adaptor
 	Router  *Router
 
-	// Manifests is the validator-manifest cache shared by the router
-	// (wire ingest), the consensus engine (ephemeral→master
-	// translation), and the RPC layer (manifest method). Always
-	// non-nil — starts empty and fills as peers gossip manifests.
-	Manifests *manifest.Cache
+	ValidatorManifests *manifest.Cache
+	PublisherManifests *manifest.Cache
 
 	// ValidatorList is the publisher-trust subsystem. Nil when no
 	// validator_list_keys are configured. When non-nil, peer-gossiped
@@ -67,15 +65,16 @@ type Components struct {
 	// without re-resolving from config.
 	Archive *archive.Archive
 
-	startStopMu sync.Mutex
-	lifecycleMu sync.Mutex
-	runCancel   context.CancelFunc
-	errors      chan error
-	started     bool
-	stopped     bool
-	stopOnce    sync.Once
-	stopErr     error
-	fatalOnce   sync.Once
+	startStopMu   sync.Mutex
+	lifecycleMu   sync.Mutex
+	runCancel     context.CancelFunc
+	errors        chan error
+	started       bool
+	stopped       bool
+	stopOnce      sync.Once
+	stopErr       error
+	fatalOnce     sync.Once
+	manifestStore manifest.Store
 
 	overlayDone chan struct{}
 	routerDone  chan struct{}
@@ -311,13 +310,46 @@ func (c *Components) stop() {
 			}
 		}
 		if c.Engine != nil {
-			c.stopErr = c.Engine.Stop()
+			c.stopErr = errors.Join(c.stopErr, c.Engine.Stop())
+		}
+		if c.manifestStore != nil {
+			stored := manifest.StoredManifests{
+				Validators: persistedManifests(c.ValidatorManifests, func(master [33]byte) bool {
+					if c.Adaptor != nil && c.Adaptor.IsTrusted(consensus.CalcNodeID(master)) {
+						return true
+					}
+					return c.ValidatorList != nil && c.ValidatorList.IsMasterListed(master)
+				}),
+				Publishers: persistedManifests(c.PublisherManifests, func(master [33]byte) bool {
+					for _, configured := range c.configuredPublisherKeys {
+						if configured == master {
+							return true
+						}
+					}
+					return false
+				}),
+			}
+			c.stopErr = errors.Join(c.stopErr, c.manifestStore.Replace(context.Background(), stored))
+			c.stopErr = errors.Join(c.stopErr, c.manifestStore.Close())
 		}
 	})
 }
 
+func persistedManifests(cache *manifest.Cache, keep func([33]byte) bool) [][]byte {
+	if cache == nil {
+		return nil
+	}
+	var out [][]byte
+	for _, entry := range cache.Snapshot() {
+		if !entry.Revoked() && (keep == nil || !keep(entry.MasterKey())) {
+			continue
+		}
+		out = append(out, entry.Serialized())
+	}
+	return out
+}
+
 // NewFromConfig creates and wires all consensus/networking components from the app config.
-// Returns nil Components if the node is in standalone mode.
 //
 // validationRepo is optional — pass nil to disable the on-disk validation
 // archive. When non-nil and [validation_archive] is enabled in config,
@@ -326,11 +358,12 @@ func (c *Components) stop() {
 // production). Pass nil when online_delete is off: acquisition and serving are
 // then unrestricted, leaving the standalone / feature-disabled path unchanged.
 func NewFromConfig(
+	ctx context.Context,
 	appCfg *config.Config,
 	ledgerSvc *service.Service,
 	validationRepo relationaldb.ValidationRepository,
 	floor MinimumOnlineFloor,
-) (*Components, error) {
+) (_ *Components, err error) {
 	// Create validator identity first (nil if not a validator) so we can
 	// pass its pubkey into the overlay for the self-target TMSquelch
 	// filter: without this a peer could silence our own validator's
@@ -339,6 +372,28 @@ func NewFromConfig(
 	if err != nil {
 		return nil, fmt.Errorf("create validator identity: %w", err)
 	}
+	publisherKeys, err := ParseValidatorListPublisherKeys(appCfg)
+	if err != nil {
+		return nil, fmt.Errorf("parse validator_list_keys: %w", err)
+	}
+
+	validatorManifests := manifest.NewCache()
+	publisherManifests := manifest.NewCache()
+	manifestStore, err := manifest.OpenSQLiteStore(ctx, appCfg.LocalStateDir())
+	if err != nil {
+		return nil, fmt.Errorf("open manifest store: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, manifestStore.Close())
+		}
+	}()
+	stored, err := manifestStore.Load(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load manifest store: %w", err)
+	}
+	restoreManifests("validator", validatorManifests, stored.Validators)
+	restoreManifests("publisher", publisherManifests, stored.Publishers)
 
 	// Build overlay options from app config
 	overlayOpts := OverlayOptionsFromConfig(appCfg)
@@ -394,25 +449,13 @@ func NewFromConfig(
 		RelayValidations: ParseRelayValidationsPolicy(appCfg.RelayValidations),
 	})
 
-	// Validator manifest cache. Shared across the engine (for
-	// ephemeral→master translation in ValidationTracker), the router
-	// (for ingesting + relaying TMManifests), and the RPC layer (for
-	// the `manifest` method). Peers gossip manifests; until one
-	// arrives the cache is empty and every ephemeral key round-trips
-	// as itself.
-	manifestCache := manifest.NewCache()
-
-	// Seed the local validator's manifest into the cache when running
-	// in token mode so the post-handshake TMManifests emission walks
-	// every cached entry — local + aggregated remote. In observer /
-	// seed-only mode there is nothing to seed and the cache stays cold
-	// until peers gossip something.
+	// Seed the local token manifest after durable validator state has loaded.
 	if identity != nil && identity.Manifest != nil {
-		if d := manifestCache.ApplyManifest(identity.Manifest); d != manifest.Accepted {
+		if d := validatorManifests.ApplyManifest(identity.Manifest); d != manifest.Accepted && d != manifest.Stale {
 			return nil, fmt.Errorf("seed local manifest into cache: disposition=%s", d)
 		}
 	} else {
-		slog.Info("local validator manifest not configured; TMManifests emission limited to peer-gossiped entries",
+		slog.Info("local validator manifest not configured",
 			"t", "adaptor.NewFromConfig")
 	}
 
@@ -431,7 +474,7 @@ func NewFromConfig(
 	router.SetTxInbox(overlay.TxMessages())
 	router.SetAcqInbox(overlay.LedgerDataMessages())
 	router.SetManifestInbox(overlay.ManifestMessages())
-	router.SetManifestCache(manifestCache, overlay)
+	router.SetManifestCache(validatorManifests, overlay)
 	router.SetManifestAdmission(func(master [33]byte) bool {
 		nodeID := consensus.CalcNodeID(master)
 		return adaptor.IsTrusted(nodeID) || adaptor.IsListed(nodeID)
@@ -445,10 +488,6 @@ func NewFromConfig(
 	// validator_list_sites. The aggregator pushes its recomputed
 	// trusted UNL into adaptor.SetTrustedValidators on every change —
 	// the same write path SIGHUP reload uses.
-	publisherKeys, err := ParseValidatorListPublisherKeys(appCfg)
-	if err != nil {
-		return nil, fmt.Errorf("parse validator_list_keys: %w", err)
-	}
 	var vlAgg *validatorlist.Aggregator
 	var vlPoller *validatorlist.SitePoller
 	if len(publisherKeys) > 0 {
@@ -461,7 +500,8 @@ func NewFromConfig(
 			SiteURIs:             append([]string(nil), appCfg.Validators.ValidatorListSites...),
 			Threshold:            appCfg.Validators.EffectiveListThreshold(),
 			StaticValidatorCount: len(masterKeys),
-			Manifests:            manifestCache,
+			ValidatorManifests:   validatorManifests,
+			PublisherManifests:   publisherManifests,
 			Logger:               slog.Default().With("component", "validator-list-aggregator"),
 		})
 		if err != nil {
@@ -553,7 +593,8 @@ func NewFromConfig(
 		Engine:                       engine,
 		Adaptor:                      adaptor,
 		Router:                       router,
-		Manifests:                    manifestCache,
+		ValidatorManifests:           validatorManifests,
+		PublisherManifests:           publisherManifests,
 		ValidatorList:                vlAgg,
 		ValidatorListPoller:          vlPoller,
 		staticValidators:             append([]consensus.NodeID(nil), staticValidators...),
@@ -562,6 +603,7 @@ func NewFromConfig(
 		configuredPublisherSites:     append([]string(nil), appCfg.Validators.ValidatorListSites...),
 		configuredPublisherThreshold: appCfg.Validators.EffectiveListThreshold(),
 		Archive:                      validationArchive,
+		manifestStore:                manifestStore,
 	}
 
 	// Capturing the boot values directly here would let a SIGHUP removal
@@ -569,6 +611,21 @@ func NewFromConfig(
 	wireValidatorListTrust(c)
 
 	return c, nil
+}
+
+func restoreManifests(role string, cache *manifest.Cache, rows [][]byte) {
+	for i, raw := range rows {
+		parsed, err := manifest.Deserialize(raw)
+		if err != nil {
+			slog.Warn("stored manifest rejected", "role", role, "row", i, "error", err)
+			continue
+		}
+		switch disposition := cache.ApplyManifest(parsed); disposition {
+		case manifest.Accepted, manifest.Stale:
+		default:
+			slog.Warn("stored manifest rejected", "role", role, "row", i, "disposition", disposition.String())
+		}
+	}
 }
 
 func wireValidatorListTrust(c *Components) {

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -309,6 +309,9 @@ func (c *Components) stop() {
 					"replay_in_flight_at_stop", replay)
 			}
 		}
+		if c.ValidatorList != nil {
+			c.ValidatorList.Tick()
+		}
 		if c.Engine != nil {
 			c.stopErr = errors.Join(c.stopErr, c.Engine.Stop())
 		}
@@ -451,8 +454,8 @@ func NewFromConfig(
 
 	// Seed the local token manifest after durable validator state has loaded.
 	if identity != nil && identity.Manifest != nil {
-		if d := validatorManifests.ApplyManifest(identity.Manifest); d != manifest.Accepted && d != manifest.Stale {
-			return nil, fmt.Errorf("seed local manifest into cache: disposition=%s", d)
+		if err := seedLocalManifest(validatorManifests, identity.Manifest); err != nil {
+			return nil, err
 		}
 	} else {
 		slog.Info("local validator manifest not configured",
@@ -611,6 +614,14 @@ func NewFromConfig(
 	wireValidatorListTrust(c)
 
 	return c, nil
+}
+
+func seedLocalManifest(cache *manifest.Cache, local *manifest.Manifest) error {
+	disposition := cache.ApplyManifest(local)
+	if disposition == manifest.Invalid {
+		return fmt.Errorf("seed local manifest into cache: disposition=%s", disposition)
+	}
+	return nil
 }
 
 func restoreManifests(role string, cache *manifest.Cache, rows [][]byte) {

--- a/internal/consensus/adaptor/startup_cov_test.go
+++ b/internal/consensus/adaptor/startup_cov_test.go
@@ -397,10 +397,11 @@ func stup_newAggregator(t *testing.T) *validatorlist.Aggregator {
 	t.Helper()
 	pk := validatorlist.PublisherKey{0xED, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}
 	agg, err := validatorlist.New(validatorlist.Config{
-		PublisherKeys: []validatorlist.PublisherKey{pk},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Logger:        slog.Default(),
+		PublisherKeys:      []validatorlist.PublisherKey{pk},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Logger:             slog.Default(),
 	})
 	require.NoError(t, err)
 	return agg

--- a/internal/manifest/cache.go
+++ b/internal/manifest/cache.go
@@ -1,11 +1,12 @@
 package manifest
 
 import (
+	"log/slog"
+	"sort"
 	"sync"
 )
 
-// Disposition reports the outcome of ApplyManifest. Matches rippled's
-// ManifestDisposition enum in Manifest.h.
+// Disposition reports the outcome of ApplyManifest.
 type Disposition int
 
 const (
@@ -24,13 +25,11 @@ const (
 
 	// BadMasterKey: the incoming manifest's master key is already
 	// recorded as another manifest's ephemeral key — a key-reuse
-	// contradiction. Rejecting prevents a confusing ambiguity in
-	// signingToMasterKeys. Rippled Manifest.cpp:436-444.
+	// contradiction. Rejecting prevents an ambiguous inverse lookup.
 	BadMasterKey
 
-	// BadEphemeralKey: the incoming manifest's ephemeral key collides
-	// with either an ephemeral or master key that the cache already
-	// knows for a different master. Rippled Manifest.cpp:459-477.
+	// BadEphemeralKey: the incoming manifest's ephemeral key is already
+	// known as either an ephemeral or master key in this cache.
 	BadEphemeralKey
 )
 
@@ -72,7 +71,7 @@ type Cache struct {
 	// Entries persist across revocations: a revoked manifest is kept so
 	// lookups see Revoked==true and can refuse to treat the master as
 	// trusted.
-	byMaster map[[33]byte]*Manifest
+	byMaster map[[33]byte]Manifest
 
 	// signingToMaster maps ephemeral signing key → master key. Cleared
 	// when the master rotates (old ephemeral removed) or revokes
@@ -81,30 +80,27 @@ type Cache struct {
 
 	// seq advances on every accepted manifest — both a first-insert for
 	// a newly-seen master key and a replacement with a higher-sequence
-	// manifest. Mirrors rippled 3.2.0's ManifestCache::seq_ (#6059): the
-	// counter is the "something has changed" signal a downstream emitter
-	// (here, the Router's TMManifests frame cache) consults to decide
-	// whether the previously-encoded frame is still current. Before #6059
-	// first-inserts did not bump the counter, so a freshly-seen
-	// validator's manifest could fail to trigger list publication/relay.
+	// manifest. Downstream emitters use it to invalidate encoded frames.
 	seq uint64
 
-	// onAccepted is invoked from ApplyManifest after a manifest has
-	// been verified and stored. nil-safe. The callback runs while
-	// applyMu is held but AFTER the c.mu write lock has been released,
-	// so subscribers may freely call any of the Cache's read methods.
-	// The callback must not block — long work belongs in a worker
-	// goroutine the subscriber owns. Mirrors rippled's pubManifest
-	// fan-out (NetworkOPs.cpp:2234-2261) which feeds the manifests
-	// WebSocket stream.
-	onAccepted func(*Manifest)
+	eventMu        sync.Mutex
+	subscribers    map[uint64]func(*Manifest)
+	nextSubscriber uint64
+	events         []acceptedEvent
+	dispatching    bool
+}
+
+type acceptedEvent struct {
+	manifest    *Manifest
+	subscribers []uint64
 }
 
 // NewCache returns an empty Cache.
 func NewCache() *Cache {
 	return &Cache{
-		byMaster:        make(map[[33]byte]*Manifest),
+		byMaster:        make(map[[33]byte]Manifest),
 		signingToMaster: make(map[[33]byte][33]byte),
+		subscribers:     make(map[uint64]func(*Manifest)),
 	}
 }
 
@@ -112,21 +108,21 @@ func NewCache() *Cache {
 // checks pass — stores it atomically. Returns the disposition so the
 // caller can decide whether to relay (Accepted) or charge the sender
 // (Invalid / BadMasterKey / BadEphemeralKey). Stale is a no-op.
-//
-// Mirrors ManifestCache::applyManifest at rippled Manifest.cpp:382-580,
-// including the two-phase shared→unique pattern that keeps lookups
-// unblocked across the expensive signature verify.
 func (c *Cache) ApplyManifest(m *Manifest) Disposition {
 	if m == nil {
 		return Invalid
 	}
+	owned, err := Deserialize(m.serialized)
+	if err != nil {
+		return Invalid
+	}
 
 	c.applyMu.Lock()
-	defer c.applyMu.Unlock()
 
 	c.mu.RLock()
-	if existing, ok := c.byMaster[m.MasterKey]; ok && m.Sequence <= existing.Sequence {
+	if existing, ok := c.byMaster[owned.masterKey]; ok && owned.sequence <= existing.sequence {
 		c.mu.RUnlock()
+		c.applyMu.Unlock()
 		return Stale
 	}
 	c.mu.RUnlock()
@@ -134,89 +130,144 @@ func (c *Cache) ApplyManifest(m *Manifest) Disposition {
 	// Verify outside any map lock — GetMasterKey / GetSigningKey
 	// lookups proceed unblocked through the (potentially) expensive
 	// secp256k1 verify.
-	if err := m.Verify(); err != nil {
+	if err := owned.Verify(); err != nil {
+		c.applyMu.Unlock()
 		return Invalid
 	}
 
-	disp, cb := c.applyLocked(m)
-	if disp == Accepted && cb != nil {
-		cb(m)
+	disp := c.applyLocked(owned)
+	drain := false
+	if disp == Accepted {
+		drain = c.enqueueAccepted(owned)
+	}
+	c.applyMu.Unlock()
+	if drain {
+		c.drainAccepted()
 	}
 	return disp
 }
 
-// applyLocked performs the write-locked half of ApplyManifest and
-// returns both the resulting disposition and (for Accepted) the
-// snapshot of the onAccepted callback. The callback is fired by the
-// caller after c.mu is released so subscribers may read the cache from
-// inside the callback without recursion.
-func (c *Cache) applyLocked(m *Manifest) (Disposition, func(*Manifest)) {
+// applyLocked performs the write-locked half of ApplyManifest.
+func (c *Cache) applyLocked(m *Manifest) Disposition {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	// Re-check Stale under the write lock against any direct map
 	// writer that bypassed applyMu.
-	if existing, ok := c.byMaster[m.MasterKey]; ok && m.Sequence <= existing.Sequence {
-		return Stale, nil
+	if existing, ok := c.byMaster[m.masterKey]; ok && m.sequence <= existing.sequence {
+		return Stale
 	}
 
 	// The manifest's master key must not already be recorded as
 	// another manifest's ephemeral key — otherwise a subsequent
-	// getMasterKey(m.MasterKey) would be ambiguous.
-	if other, ok := c.signingToMaster[m.MasterKey]; ok && other != m.MasterKey {
-		return BadMasterKey, nil
+	// GetMasterKey(m.masterKey) would be ambiguous.
+	if _, ok := c.signingToMaster[m.masterKey]; ok {
+		return BadMasterKey
 	}
 
 	if !m.Revoked() {
-		// The ephemeral key must not already be used as ANOTHER
-		// master's ephemeral key (rippled Manifest.cpp:459-468).
-		if other, ok := c.signingToMaster[m.SigningKey]; ok && other != m.MasterKey {
-			return BadEphemeralKey, nil
+		if _, ok := c.signingToMaster[m.signingKey]; ok {
+			return BadEphemeralKey
 		}
-		// Nor may it collide with a known master key (rippled
-		// Manifest.cpp:470-477).
-		if _, ok := c.byMaster[m.SigningKey]; ok {
-			return BadEphemeralKey, nil
+		if _, ok := c.byMaster[m.signingKey]; ok {
+			return BadEphemeralKey
 		}
 	}
 
 	// Drop the previous ephemeral mapping (if any) before installing
 	// the new one; otherwise a validation signed with the OLD
 	// ephemeral would still resolve to the master after rotation.
-	prev, isUpdate := c.byMaster[m.MasterKey]
+	prev, isUpdate := c.byMaster[m.masterKey]
 	if isUpdate && !prev.Revoked() {
-		delete(c.signingToMaster, prev.SigningKey)
+		delete(c.signingToMaster, prev.signingKey)
 	}
 
-	c.byMaster[m.MasterKey] = m
+	c.byMaster[m.masterKey] = *cloneManifest(m)
 	if !m.Revoked() {
-		c.signingToMaster[m.SigningKey] = m.MasterKey
+		c.signingToMaster[m.signingKey] = m.masterKey
 	}
-	// Something has changed. Advance the counter so downstream emitters
-	// re-encode. rippled 3.2.0 (#6059) bumps on first-insert too, not
-	// just replacement (isUpdate), so a freshly-seen validator's manifest
-	// triggers list publication/relay.
+	// Advance on insert, rotation, and revocation so emitters re-encode.
 	c.seq++
-	return Accepted, c.onAccepted
+	return Accepted
 }
 
-// SetOnAccepted installs a callback invoked from ApplyManifest after
-// every Accepted disposition. Passing nil detaches the callback. Safe
-// to call concurrently with ApplyManifest — the assignment runs under
-// c.mu so apply's snapshot read sees a coherent value.
-func (c *Cache) SetOnAccepted(fn func(*Manifest)) {
-	c.mu.Lock()
-	c.onAccepted = fn
-	c.mu.Unlock()
+// SubscribeAccepted registers a subscriber for newly accepted manifests and
+// returns an idempotent unsubscribe function. Delivery preserves acceptance
+// order, runs after cache locks are released, and isolates subscriber panics.
+func (c *Cache) SubscribeAccepted(fn func(*Manifest)) func() {
+	if fn == nil {
+		return func() {}
+	}
+	c.eventMu.Lock()
+	c.nextSubscriber++
+	id := c.nextSubscriber
+	c.subscribers[id] = fn
+	c.eventMu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			c.eventMu.Lock()
+			delete(c.subscribers, id)
+			c.eventMu.Unlock()
+		})
+	}
+}
+
+func (c *Cache) enqueueAccepted(m *Manifest) bool {
+	c.eventMu.Lock()
+	defer c.eventMu.Unlock()
+	if len(c.subscribers) == 0 {
+		return false
+	}
+	ids := make([]uint64, 0, len(c.subscribers))
+	for id := range c.subscribers {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	c.events = append(c.events, acceptedEvent{manifest: cloneManifest(m), subscribers: ids})
+	if c.dispatching {
+		return false
+	}
+	c.dispatching = true
+	return true
+}
+
+func (c *Cache) drainAccepted() {
+	for {
+		c.eventMu.Lock()
+		if len(c.events) == 0 {
+			c.dispatching = false
+			c.eventMu.Unlock()
+			return
+		}
+		event := c.events[0]
+		c.events[0] = acceptedEvent{}
+		c.events = c.events[1:]
+		c.eventMu.Unlock()
+
+		for _, id := range event.subscribers {
+			c.eventMu.Lock()
+			fn := c.subscribers[id]
+			c.eventMu.Unlock()
+			if fn != nil {
+				invokeAccepted(fn, cloneManifest(event.manifest))
+			}
+		}
+	}
+}
+
+func invokeAccepted(fn func(*Manifest), m *Manifest) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			slog.Error("manifest subscriber panicked", "panic", recovered)
+		}
+	}()
+	fn(m)
 }
 
 // Sequence returns the cache's "something has changed" counter.
-// Increments every time an existing master's manifest is replaced with
-// a higher-sequence one (key rotation or revocation). First-inserts
-// don't advance it — see ApplyManifest. Mirrors rippled
-// ManifestCache::sequence() at Manifest.h:278-281, used by emitters to
-// short-circuit re-encoding the TMManifests frame when nothing has
-// changed since the last build.
+// It increments for every accepted insertion, rotation, and revocation.
 func (c *Cache) Sequence() uint64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -225,9 +276,7 @@ func (c *Cache) Sequence() uint64 {
 
 // GetMasterKey returns the master key associated with a signing key.
 // If the signing key is not recorded in any manifest, returns the input
-// unchanged — matching rippled's ManifestCache::getMasterKey
-// (Manifest.cpp:322-332), which lets callers use the return value
-// directly in UNL lookups: a non-validator peer's pubkey maps to itself.
+// unchanged so callers can use the result directly in UNL lookups.
 func (c *Cache) GetMasterKey(signingKey [33]byte) [33]byte {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -239,10 +288,7 @@ func (c *Cache) GetMasterKey(signingKey [33]byte) [33]byte {
 
 // GetSigningKey returns the current ephemeral signing key for a master
 // key. The second return is false when the master is unknown or
-// revoked — callers should treat "revoked or unknown" identically
-// (rippled Manifest.cpp:310-320 returns the input key itself in that
-// case, but the caller contexts here — RPC and consensus — want to
-// distinguish "have a valid mapping" from "don't").
+// revoked — callers should treat "revoked or unknown" identically.
 func (c *Cache) GetSigningKey(masterKey [33]byte) ([33]byte, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -250,7 +296,7 @@ func (c *Cache) GetSigningKey(masterKey [33]byte) ([33]byte, bool) {
 	if !ok || m.Revoked() {
 		return [33]byte{}, false
 	}
-	return m.SigningKey, true
+	return m.signingKey, true
 }
 
 // GetManifest returns the raw serialized manifest bytes for a master
@@ -262,7 +308,7 @@ func (c *Cache) GetManifest(masterKey [33]byte) ([]byte, bool) {
 	if !ok || m.Revoked() {
 		return nil, false
 	}
-	return append([]byte(nil), m.Serialized...), true
+	return append([]byte(nil), m.serialized...), true
 }
 
 // GetSequence returns the stored manifest's sequence number. Second
@@ -274,7 +320,7 @@ func (c *Cache) GetSequence(masterKey [33]byte) (uint32, bool) {
 	if !ok || m.Revoked() {
 		return 0, false
 	}
-	return m.Sequence, true
+	return m.sequence, true
 }
 
 // GetDomain returns the stored manifest's domain string. Second return
@@ -283,10 +329,10 @@ func (c *Cache) GetDomain(masterKey [33]byte) (string, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	m, ok := c.byMaster[masterKey]
-	if !ok || m.Revoked() || m.Domain == "" {
+	if !ok || m.Revoked() || m.domain == "" {
 		return "", false
 	}
-	return m.Domain, true
+	return m.domain, true
 }
 
 // Revoked reports whether the cached manifest for masterKey is a
@@ -303,10 +349,7 @@ func (c *Cache) Revoked(masterKey [33]byte) bool {
 }
 
 // MasterToSigning returns a snapshot of the master→signing key map for
-// every cached (non-revoked) manifest. Used by the `validators` RPC to
-// emit the `signing_keys` object, mirroring rippled's
-// ValidatorManifests::for_each_manifest walk in getJson at
-// ValidatorList.cpp:1725-1734.
+// every cached non-revoked manifest.
 func (c *Cache) MasterToSigning() map[[33]byte][33]byte {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -315,20 +358,35 @@ func (c *Cache) MasterToSigning() map[[33]byte][33]byte {
 	}
 	out := make(map[[33]byte][33]byte, len(c.byMaster))
 	for master, m := range c.byMaster {
-		if m == nil || m.Revoked() {
+		if m.Revoked() {
 			continue
 		}
-		out[master] = m.SigningKey
+		out[master] = m.signingKey
 	}
 	return out
 }
 
+// Snapshot returns independent copies of all cached manifests, including
+// revocations.
+func (c *Cache) Snapshot() []*Manifest {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if len(c.byMaster) == 0 {
+		return nil
+	}
+	out := make([]*Manifest, 0, len(c.byMaster))
+	for _, m := range c.byMaster {
+		manifest := m
+		out = append(out, cloneManifest(&manifest))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return string(out[i].masterKey[:]) < string(out[j].masterKey[:])
+	})
+	return out
+}
+
 // SerializedAll returns the wire bytes of every cached manifest in
-// arbitrary order, with each entry defensively copied. Used by the
-// post-handshake TMManifests emission to gossip the entire aggregated
-// cache to a freshly-connected peer, mirroring rippled's
-// OverlayImpl::getManifestsMessage which calls
-// ValidatorManifests::for_each_manifest (Manifest.cpp:1184-1212).
+// arbitrary order, with each entry defensively copied.
 func (c *Cache) SerializedAll() [][]byte {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -337,10 +395,10 @@ func (c *Cache) SerializedAll() [][]byte {
 	}
 	out := make([][]byte, 0, len(c.byMaster))
 	for _, m := range c.byMaster {
-		if len(m.Serialized) == 0 {
+		if len(m.serialized) == 0 {
 			continue
 		}
-		out = append(out, append([]byte(nil), m.Serialized...))
+		out = append(out, append([]byte(nil), m.serialized...))
 	}
 	return out
 }

--- a/internal/manifest/cache.go
+++ b/internal/manifest/cache.go
@@ -147,7 +147,6 @@ func (c *Cache) ApplyManifest(m *Manifest) Disposition {
 	return disp
 }
 
-// applyLocked performs the write-locked half of ApplyManifest.
 func (c *Cache) applyLocked(m *Manifest) Disposition {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,5 +1,5 @@
-// Package manifest implements validator manifest parsing, verification, and
-// caching — the equivalent of rippled's ValidatorManifests service.
+// Package manifest implements validator manifest parsing, verification, caching,
+// and persistence.
 //
 // A manifest binds a validator's long-term master key to a rotatable
 // ephemeral signing key. Peers gossip manifests so every node on the
@@ -8,7 +8,7 @@
 // this translation a validator that rotates its ephemeral key appears as
 // a new untrusted node and breaks mainnet quorum arithmetic.
 //
-// Wire format (rippled Manifest.cpp:53-164):
+// Wire format:
 //
 //	STObject with fields
 //	  PublicKey        (required) — master public key
@@ -43,7 +43,6 @@ import (
 )
 
 // RevokedSequence marks a manifest as a master-key revocation.
-// Rippled: Manifest::revoked returns sequence == numeric_limits::max.
 const RevokedSequence uint32 = math.MaxUint32
 
 const maxSerializedSize = 1024
@@ -52,56 +51,77 @@ const maxSerializedSize = 1024
 // Signature verification is separate — callers invoke Verify before
 // trusting the struct's key bindings.
 type Manifest struct {
-	// MasterKey is the 33-byte master public key (ed25519 0xED prefix or
-	// secp256k1 0x02/0x03 prefix).
-	MasterKey [33]byte
+	masterKey       [33]byte
+	signingKey      [33]byte
+	sequence        uint32
+	domain          string
+	serialized      []byte
+	masterSignature string
+	signature       string
+	signingPreimage []byte
+}
 
-	// SigningKey is the 33-byte ephemeral signing key. Zero when Revoked.
-	SigningKey [33]byte
+// MasterKey returns the manifest's long-term public key.
+func (m *Manifest) MasterKey() [33]byte {
+	if m == nil {
+		return [33]byte{}
+	}
+	return m.masterKey
+}
 
-	// Sequence is the manifest's monotonic counter. RevokedSequence
-	// (MaxUint32) indicates master-key revocation; in that case
-	// SigningKey is zero and both Signature and MasterSignature are
-	// present only on the master side.
-	Sequence uint32
+// SigningKey returns the current ephemeral public key, or zero for a revocation.
+func (m *Manifest) SigningKey() [33]byte {
+	if m == nil {
+		return [33]byte{}
+	}
+	return m.signingKey
+}
 
-	// Domain is the optional TOML domain string.
-	Domain string
+// Sequence returns the manifest sequence number.
+func (m *Manifest) Sequence() uint32 {
+	if m == nil {
+		return 0
+	}
+	return m.sequence
+}
 
-	// Serialized is the original wire bytes — kept so the cache can
-	// relay the exact payload peers gossiped and the RPC can return it.
-	Serialized []byte
+// Domain returns the optional validator domain.
+func (m *Manifest) Domain() string {
+	if m == nil {
+		return ""
+	}
+	return m.domain
+}
+
+// Serialized returns an owned copy of the original wire bytes.
+func (m *Manifest) Serialized() []byte {
+	if m == nil {
+		return nil
+	}
+	return append([]byte(nil), m.serialized...)
 }
 
 // Revoked reports whether the manifest revokes its master key.
 func (m *Manifest) Revoked() bool {
-	return m.Sequence == RevokedSequence
+	return m != nil && m.sequence == RevokedSequence
 }
 
-// Signatures extracts the master signature (always present) and the
-// ephemeral-key signature (empty on revocations) from the manifest's
-// serialized wire form. Used by the WebSocket manifests stream to emit
-// the rippled-shape pubManifest payload (NetworkOPs.cpp:2229-2265)
-// without requiring callers to re-decode the blob themselves. Returns
-// empty strings when the blob cannot be decoded — the caller should
-// treat that as "fields absent" rather than an error.
+func cloneManifest(m *Manifest) *Manifest {
+	if m == nil {
+		return nil
+	}
+	cloned := *m
+	cloned.serialized = append([]byte(nil), m.serialized...)
+	cloned.signingPreimage = append([]byte(nil), m.signingPreimage...)
+	return &cloned
+}
+
+// Signatures returns the wire signatures captured during parsing.
 func (m *Manifest) Signatures() (masterSigHex, signatureHex string) {
-	if m == nil || len(m.Serialized) == 0 {
+	if m == nil {
 		return "", ""
 	}
-	decoded, err := binarycodec.DecodeBytes(m.Serialized)
-	if err != nil {
-		return "", ""
-	}
-	if v, ok := decoded["MasterSignature"].(string); ok {
-		masterSigHex = v
-	}
-	if !m.Revoked() {
-		if v, ok := decoded["Signature"].(string); ok {
-			signatureHex = v
-		}
-	}
-	return masterSigHex, signatureHex
+	return m.masterSignature, m.signature
 }
 
 // Deserialize parses a wire-format manifest. Returns a non-nil error if
@@ -131,10 +151,9 @@ func Deserialize(data []byte) (*Manifest, error) {
 		}
 	}
 
-	// Version default is 0; anything else is an unsupported manifest
-	// format per rippled Manifest.cpp:92-93.
+	// Version defaults to 0; any other value is unsupported.
 	if raw, ok := decoded["Version"]; ok {
-		v, ok := toUint32(raw)
+		v, ok := raw.(int)
 		if !ok {
 			return nil, errors.New("manifest: Version is not numeric")
 		}
@@ -156,19 +175,21 @@ func Deserialize(data []byte) (*Manifest, error) {
 	if !ok {
 		return nil, errors.New("manifest: missing required Sequence")
 	}
-	seq, ok := toUint32(seqRaw)
+	seq, ok := seqRaw.(uint32)
 	if !ok {
 		return nil, errors.New("manifest: Sequence is not numeric")
 	}
 
-	if _, err := requireHexField(decoded, "MasterSignature"); err != nil {
+	masterSignature, err := requireHexField(decoded, "MasterSignature")
+	if err != nil {
 		return nil, err
 	}
 
 	m := &Manifest{
-		MasterKey:  master,
-		Sequence:   seq,
-		Serialized: append([]byte(nil), data...),
+		masterKey:       master,
+		sequence:        seq,
+		serialized:      append([]byte(nil), data...),
+		masterSignature: masterSignature,
 	}
 
 	if dom, ok := decoded["Domain"]; ok {
@@ -182,8 +203,8 @@ func Deserialize(data []byte) (*Manifest, error) {
 		if err != nil {
 			return nil, fmt.Errorf("manifest: Domain not hex: %w", err)
 		}
-		m.Domain = string(b)
-		if !stringutil.IsProperlyFormedTomlDomain(m.Domain) {
+		m.domain = string(b)
+		if !stringutil.IsProperlyFormedTomlDomain(m.domain) {
 			return nil, errors.New("manifest: Domain is not a properly formed TOML domain")
 		}
 	}
@@ -194,6 +215,10 @@ func Deserialize(data []byte) (*Manifest, error) {
 	if m.Revoked() {
 		if hasSigningKey || hasSignature {
 			return nil, errors.New("manifest: revoked manifest must not carry ephemeral fields")
+		}
+		m.signingPreimage, err = signingPreimageFromDecoded(decoded)
+		if err != nil {
+			return nil, fmt.Errorf("manifest: build signing preimage: %w", err)
 		}
 		return m, nil
 	}
@@ -210,39 +235,38 @@ func Deserialize(data []byte) (*Manifest, error) {
 	if signing == master {
 		return nil, errors.New("manifest: signing key equals master key")
 	}
-	m.SigningKey = signing
+	signature, err := requireHexField(decoded, "Signature")
+	if err != nil {
+		return nil, err
+	}
+	m.signingKey = signing
+	m.signature = signature
+	m.signingPreimage, err = signingPreimageFromDecoded(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("manifest: build signing preimage: %w", err)
+	}
 	return m, nil
 }
 
 // Verify checks both the master signature and (for non-revoked
 // manifests) the ephemeral-key signature against the canonical signing
 // preimage: HashPrefix("MAN\0") || STObject(manifest without Signature
-// and MasterSignature). Mirrors Manifest::verify at Manifest.cpp:195-214.
+// and MasterSignature).
 func (m *Manifest) Verify() error {
-	decoded, err := binarycodec.DecodeBytes(m.Serialized)
-	if err != nil {
-		return fmt.Errorf("manifest: decode for verify: %w", err)
+	if m == nil {
+		return errors.New("manifest: nil manifest")
 	}
-	masterSigHex, _ := decoded["MasterSignature"].(string)
-	if masterSigHex == "" {
+	if m.masterSignature == "" {
 		return errors.New("manifest: MasterSignature missing on verify")
 	}
-	var sigHex string
-	if !m.Revoked() {
-		sigHex, _ = decoded["Signature"].(string)
-		if sigHex == "" {
-			return errors.New("manifest: Signature missing on verify")
-		}
+	if !m.Revoked() && m.signature == "" {
+		return errors.New("manifest: Signature missing on verify")
 	}
-	preimage, err := signingPreimageFromDecoded(decoded)
-	if err != nil {
-		return fmt.Errorf("manifest: build signing preimage: %w", err)
-	}
-	if !VerifyKeyTypeSignature(m.MasterKey, preimage, masterSigHex) {
+	if !VerifyKeyTypeSignature(m.masterKey, m.signingPreimage, m.masterSignature) {
 		return errors.New("manifest: master signature invalid")
 	}
 	if !m.Revoked() {
-		if !VerifyKeyTypeSignature(m.SigningKey, preimage, sigHex) {
+		if !VerifyKeyTypeSignature(m.signingKey, m.signingPreimage, m.signature) {
 			return errors.New("manifest: ephemeral signature invalid")
 		}
 	}
@@ -252,9 +276,7 @@ func (m *Manifest) Verify() error {
 // signingPreimageFromDecoded returns HashPrefix("MAN\0") || STObject
 // (manifest without signing fields). The caller owns `decoded`; this
 // function mutates it (deletes non-signing fields), so callers that
-// still need the original map must pass a clone. Mirrors rippled's
-// ripple::verify pattern (Sign.cpp:47-62) where ss.add32(prefix)
-// precedes st.addWithoutSigningFields(ss).
+// still need the original map must pass a clone.
 func signingPreimageFromDecoded(decoded map[string]any) ([]byte, error) {
 	for k := range decoded {
 		fi, _ := definitions.Get().FieldInstanceByName(k)
@@ -277,19 +299,14 @@ func signingPreimageFromDecoded(decoded map[string]any) ([]byte, error) {
 // pubKey, dispatching on the 33-byte key's type prefix (ed25519 vs
 // secp256k1). The raw message bytes are passed as a Go string (the crypto
 // packages treat string as an opaque byte sequence). secp256k1 requires a
-// fully-canonical (low-S) signature, matching rippled's PublicKey::verify
-// default. Returns false for an unrecognized key type or malformed
-// signature.
+// fully-canonical (low-S) signature. Returns false for an unrecognized key
+// type or malformed signature.
 func VerifyKeyTypeSignature(pubKey [33]byte, message []byte, sigHex string) bool {
 	pubHex := hex.EncodeToString(pubKey[:])
 	switch crypto.PublicKeyType(pubKey[:]) {
 	case crypto.KeyTypeEd25519:
 		return ed25519.Algorithm{}.Validate(string(message), pubHex, sigHex)
 	case crypto.KeyTypeSecp256k1:
-		// rippled's manifest verify path Sign.cpp:47-62 → PublicKey::verify
-		// uses the header-default mustBeFullyCanonical=true
-		// (PublicKey.h:256), so non-low-S manifest signatures must be
-		// rejected.
 		return secp256k1.Algorithm{}.Validate(string(message), pubHex, sigHex)
 	default:
 		return false
@@ -336,33 +353,4 @@ func hasField(m map[string]any, name string) bool {
 		return true
 	}
 	return s != ""
-}
-
-// toUint32 accepts the several numeric shapes the JSON map may contain
-// for a UInt32 field (float64 from json.Unmarshal, int / int64 from
-// some codec paths, uint32/uint64 direct).
-func toUint32(v any) (uint32, bool) {
-	switch t := v.(type) {
-	case uint32:
-		return t, true
-	case uint64:
-		return uint32(t), true
-	case int:
-		if t < 0 {
-			return 0, false
-		}
-		return uint32(t), true
-	case int64:
-		if t < 0 {
-			return 0, false
-		}
-		return uint32(t), true
-	case float64:
-		if t < 0 {
-			return 0, false
-		}
-		return uint32(t), true
-	default:
-		return 0, false
-	}
 }

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -342,15 +342,6 @@ func requireHexField(m map[string]any, name string) (string, error) {
 }
 
 func hasField(m map[string]any, name string) bool {
-	v, ok := m[name]
-	if !ok {
-		return false
-	}
-	s, ok := v.(string)
-	if !ok {
-		// Non-string fields (numeric) are always "present" if the key
-		// is in the map.
-		return true
-	}
-	return s != ""
+	_, ok := m[name]
+	return ok
 }

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -77,7 +77,6 @@ func (m *Manifest) SigningKey() [33]byte {
 	return m.signingKey
 }
 
-// Sequence returns the manifest sequence number.
 func (m *Manifest) Sequence() uint32 {
 	if m == nil {
 		return 0

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -740,6 +740,24 @@ func TestManifest_Revoked_WithEphemeral_Rejected(t *testing.T) {
 	}
 }
 
+func TestManifest_Revoked_WithEmptyEphemeralField_Rejected(t *testing.T) {
+	serialized, _, _ := buildManifest(t, manifest.RevokedSequence, true, 0x0E, 0)
+	for _, field := range []string{"SigningPubKey", "Signature"} {
+		t.Run(field, func(t *testing.T) {
+			decoded, err := binarycodec.DecodeBytes(serialized)
+			require.NoError(t, err)
+			decoded[field] = ""
+			encoded, err := binarycodec.Encode(decoded)
+			require.NoError(t, err)
+			withEmptyField, err := hex.DecodeString(encoded)
+			require.NoError(t, err)
+
+			_, err = manifest.Deserialize(withEmptyField)
+			require.ErrorContains(t, err, "revoked manifest contains ephemeral key/signature")
+		})
+	}
+}
+
 // buildManifestSecpMaster builds a serialized manifest with a
 // secp256k1 master key and ed25519 ephemeral key, both signing the
 // canonical preimage. The returned master signature is forced to its

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -2,11 +2,13 @@ package manifest_test
 
 import (
 	"bytes"
+	"context"
 	"crypto/ed25519"
 	"encoding/hex"
 	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	rootcrypto "github.com/LeJamon/go-xrpl/crypto"
@@ -148,6 +150,51 @@ func TestManifest_RejectsOversizedPayloadBeforeDecode(t *testing.T) {
 	require.ErrorContains(t, err, "payload exceeds 1024 bytes")
 }
 
+func TestDispositionString(t *testing.T) {
+	tests := []struct {
+		disposition manifest.Disposition
+		want        string
+	}{
+		{manifest.Accepted, "accepted"},
+		{manifest.Stale, "stale"},
+		{manifest.Invalid, "invalid"},
+		{manifest.BadMasterKey, "bad_master_key"},
+		{manifest.BadEphemeralKey, "bad_ephemeral_key"},
+		{manifest.Disposition(99), "unknown"},
+	}
+	for _, test := range tests {
+		require.Equal(t, test.want, test.disposition.String())
+	}
+}
+
+func TestManifestSignaturesComeFromImmutableParsedState(t *testing.T) {
+	for _, revoked := range []bool{false, true} {
+		sequence := uint32(7)
+		if revoked {
+			sequence = manifest.RevokedSequence
+		}
+		wire, _, _ := buildManifest(t, sequence, revoked, 0x0a, 0x0b)
+		decoded, err := binarycodec.DecodeBytes(wire)
+		require.NoError(t, err)
+		parsed, err := manifest.Deserialize(wire)
+		require.NoError(t, err)
+
+		masterSignature, signature := parsed.Signatures()
+		require.Equal(t, decoded["MasterSignature"], masterSignature)
+		if revoked {
+			require.Empty(t, signature)
+		} else {
+			require.Equal(t, decoded["Signature"], signature)
+		}
+
+		serialized := parsed.Serialized()
+		serialized[0] ^= 0xff
+		gotMaster, gotSigning := parsed.Signatures()
+		require.Equal(t, masterSignature, gotMaster)
+		require.Equal(t, signature, gotSigning)
+	}
+}
+
 // deterministicEd25519Keypair returns a 33-byte xrpl-style public key
 // (0xED prefix + 32 bytes) and a 64-byte ed25519 private key seeded
 // from `seed`. Tests use a byte seed so they're reproducible and each
@@ -170,9 +217,10 @@ func TestManifest_OnAccepted_FiresOnce(t *testing.T) {
 
 	c := manifest.NewCache()
 	var fired []*manifest.Manifest
-	c.SetOnAccepted(func(got *manifest.Manifest) {
+	unsubscribe := c.SubscribeAccepted(func(got *manifest.Manifest) {
 		fired = append(fired, got)
 	})
+	defer unsubscribe()
 
 	if d := c.ApplyManifest(m); d != manifest.Accepted {
 		t.Fatalf("ApplyManifest: got %s want accepted", d)
@@ -180,8 +228,8 @@ func TestManifest_OnAccepted_FiresOnce(t *testing.T) {
 	if len(fired) != 1 {
 		t.Fatalf("OnAccepted fired %d times, want 1", len(fired))
 	}
-	if fired[0].MasterKey != m.MasterKey {
-		t.Fatalf("OnAccepted manifest mismatch: got master %x want %x", fired[0].MasterKey, m.MasterKey)
+	if fired[0].MasterKey() != m.MasterKey() {
+		t.Fatalf("OnAccepted manifest mismatch: got master %x want %x", fired[0].MasterKey(), m.MasterKey())
 	}
 
 	// Re-applying the same manifest is Stale; the callback must not fire again.
@@ -193,6 +241,290 @@ func TestManifest_OnAccepted_FiresOnce(t *testing.T) {
 	}
 }
 
+func TestManifest_CacheOwnsAcceptedState(t *testing.T) {
+	serialized, master, signing := buildManifest(t, 1, false, 0x12, 0x13)
+	m, err := manifest.Deserialize(serialized)
+	require.NoError(t, err)
+
+	c := manifest.NewCache()
+	var callback *manifest.Manifest
+	c.SubscribeAccepted(func(got *manifest.Manifest) {
+		callback = got
+		wire := got.Serialized()
+		wire[0] ^= 0xff
+	})
+	require.Equal(t, manifest.Accepted, c.ApplyManifest(m))
+	require.NotNil(t, callback)
+
+	inputWire := m.Serialized()
+	inputWire[0] ^= 0xff
+
+	require.Equal(t, signing, mustSigningKey(t, c, master))
+	require.Equal(t, uint32(1), mustSequence(t, c, master))
+	stored, ok := c.GetManifest(master)
+	require.True(t, ok)
+	require.Equal(t, serialized, stored)
+
+	stored[0] ^= 0xff
+	require.Equal(t, serialized, mustManifest(t, c, master))
+	all := c.SerializedAll()
+	require.Len(t, all, 1)
+	all[0][0] ^= 0xff
+	require.Equal(t, serialized, mustManifest(t, c, master))
+	mapping := c.MasterToSigning()
+	mapping[master] = [33]byte{}
+	require.Equal(t, signing, mustSigningKey(t, c, master))
+	snapshot := c.Snapshot()
+	require.Len(t, snapshot, 1)
+	snapshotWire := snapshot[0].Serialized()
+	snapshotWire[0] ^= 0xff
+	require.Equal(t, serialized, mustManifest(t, c, master))
+	require.Equal(t, uint32(1), mustSequence(t, c, master))
+}
+
+func TestManifest_SubscribersReceiveIndependentCopies(t *testing.T) {
+	serialized, master, _ := buildManifest(t, 1, false, 0x14, 0x15)
+	m, err := manifest.Deserialize(serialized)
+	require.NoError(t, err)
+
+	c := manifest.NewCache()
+	var first *manifest.Manifest
+	c.SubscribeAccepted(func(got *manifest.Manifest) {
+		first = got
+		wire := got.Serialized()
+		wire[0] ^= 0xff
+	})
+	var second *manifest.Manifest
+	c.SubscribeAccepted(func(got *manifest.Manifest) {
+		second = got
+	})
+	require.Equal(t, manifest.Accepted, c.ApplyManifest(m))
+	require.NotNil(t, first)
+	require.NotNil(t, second)
+	require.NotSame(t, first, second)
+	require.Equal(t, master, second.MasterKey())
+	require.Equal(t, serialized, second.Serialized())
+}
+
+func TestManifest_CallbackReentryPreservesOrder(t *testing.T) {
+	firstWire, _, _ := buildManifest(t, 1, false, 0x16, 0x17)
+	secondWire, _, _ := buildManifest(t, 2, false, 0x16, 0x18)
+	first, err := manifest.Deserialize(firstWire)
+	require.NoError(t, err)
+	second, err := manifest.Deserialize(secondWire)
+	require.NoError(t, err)
+
+	c := manifest.NewCache()
+	var delivered []uint32
+	c.SubscribeAccepted(func(got *manifest.Manifest) {
+		delivered = append(delivered, got.Sequence())
+		if got.Sequence() == 1 {
+			require.Equal(t, manifest.Accepted, c.ApplyManifest(second))
+		}
+	})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		require.Equal(t, manifest.Accepted, c.ApplyManifest(first))
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("ApplyManifest deadlocked during callback re-entry")
+	}
+	require.Equal(t, []uint32{1, 2}, delivered)
+}
+
+func TestManifest_SlowSubscriberDoesNotBlockConcurrentApply(t *testing.T) {
+	firstWire, _, _ := buildManifest(t, 1, false, 0x19, 0x1a)
+	secondWire, _, _ := buildManifest(t, 2, false, 0x19, 0x1b)
+	first, err := manifest.Deserialize(firstWire)
+	require.NoError(t, err)
+	second, err := manifest.Deserialize(secondWire)
+	require.NoError(t, err)
+
+	c := manifest.NewCache()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	c.SubscribeAccepted(func(got *manifest.Manifest) {
+		if got.Sequence() == 1 {
+			close(entered)
+			<-release
+		}
+	})
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		require.Equal(t, manifest.Accepted, c.ApplyManifest(first))
+	}()
+	<-entered
+	secondDone := make(chan manifest.Disposition, 1)
+	go func() { secondDone <- c.ApplyManifest(second) }()
+	select {
+	case got := <-secondDone:
+		require.Equal(t, manifest.Accepted, got)
+	case <-time.After(time.Second):
+		t.Fatal("concurrent ApplyManifest blocked on slow subscriber")
+	}
+	close(release)
+	<-firstDone
+}
+
+func TestManifest_ConcurrentApply(t *testing.T) {
+	const count = 32
+	manifests := make([]*manifest.Manifest, 0, count)
+	for i := 0; i < count; i++ {
+		wire, _, _ := buildManifest(t, 1, false, byte(i+1), byte(i+65))
+		parsed, err := manifest.Deserialize(wire)
+		require.NoError(t, err)
+		manifests = append(manifests, parsed)
+	}
+
+	cache := manifest.NewCache()
+	accepted := make(chan struct{}, count)
+	cache.SubscribeAccepted(func(*manifest.Manifest) { accepted <- struct{}{} })
+	results := make(chan manifest.Disposition, count)
+	for _, parsed := range manifests {
+		go func() { results <- cache.ApplyManifest(parsed) }()
+	}
+	for range count {
+		require.Equal(t, manifest.Accepted, <-results)
+	}
+	require.Len(t, accepted, count)
+	require.Equal(t, uint64(count), cache.Sequence())
+	require.Len(t, cache.SerializedAll(), count)
+}
+
+func TestManifest_SubscriberPanicAndRemovalAreIsolated(t *testing.T) {
+	c := manifest.NewCache()
+	c.SubscribeAccepted(func(*manifest.Manifest) { panic("subscriber failure") })
+	count := 0
+	unsubscribe := c.SubscribeAccepted(func(*manifest.Manifest) { count++ })
+
+	firstWire, _, _ := buildManifest(t, 1, false, 0x1c, 0x1d)
+	first, err := manifest.Deserialize(firstWire)
+	require.NoError(t, err)
+	require.Equal(t, manifest.Accepted, c.ApplyManifest(first))
+	require.Equal(t, 1, count)
+
+	unsubscribe()
+	unsubscribe()
+	secondWire, _, _ := buildManifest(t, 2, false, 0x1c, 0x1e)
+	second, err := manifest.Deserialize(secondWire)
+	require.NoError(t, err)
+	require.Equal(t, manifest.Accepted, c.ApplyManifest(second))
+	require.Equal(t, 1, count)
+}
+
+func TestManifest_KeyCollisionDispositions(t *testing.T) {
+	tests := []struct {
+		name     string
+		first    [3]byte
+		second   [3]byte
+		expected manifest.Disposition
+	}{
+		{name: "same master same ephemeral higher sequence", first: [3]byte{1, 0x21, 0x22}, second: [3]byte{2, 0x21, 0x22}, expected: manifest.BadEphemeralKey},
+		{name: "different master same ephemeral", first: [3]byte{1, 0x23, 0x24}, second: [3]byte{1, 0x25, 0x24}, expected: manifest.BadEphemeralKey},
+		{name: "master already used as ephemeral", first: [3]byte{1, 0x26, 0x27}, second: [3]byte{1, 0x27, 0x28}, expected: manifest.BadMasterKey},
+		{name: "ephemeral already used as master", first: [3]byte{1, 0x29, 0x2a}, second: [3]byte{1, 0x2b, 0x29}, expected: manifest.BadEphemeralKey},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			firstWire, _, _ := buildManifest(t, uint32(test.first[0]), false, test.first[1], test.first[2])
+			secondWire, _, _ := buildManifest(t, uint32(test.second[0]), false, test.second[1], test.second[2])
+			first, err := manifest.Deserialize(firstWire)
+			require.NoError(t, err)
+			second, err := manifest.Deserialize(secondWire)
+			require.NoError(t, err)
+			c := manifest.NewCache()
+			require.Equal(t, manifest.Accepted, c.ApplyManifest(first))
+			require.Equal(t, test.expected, c.ApplyManifest(second))
+		})
+	}
+}
+
+func TestManifest_KeyCollisionsAreCacheLocal(t *testing.T) {
+	wire, _, _ := buildManifest(t, 1, false, 0x2c, 0x2d)
+	parsed, err := manifest.Deserialize(wire)
+	require.NoError(t, err)
+	validators := manifest.NewCache()
+	publishers := manifest.NewCache()
+	require.Equal(t, manifest.Accepted, validators.ApplyManifest(parsed))
+	require.Equal(t, manifest.Accepted, publishers.ApplyManifest(parsed))
+}
+
+func TestManifest_PersistencePreservesRevocationAndRotation(t *testing.T) {
+	revokedOldWire, revokedMaster, revokedSigning := buildManifest(t, 1, false, 0x2e, 0x2f)
+	revokedOld, err := manifest.Deserialize(revokedOldWire)
+	require.NoError(t, err)
+	revocationWire, _, _ := buildManifest(t, manifest.RevokedSequence, true, 0x2e, 0)
+	revocation, err := manifest.Deserialize(revocationWire)
+	require.NoError(t, err)
+
+	rotationOldWire, rotationMaster, rotationOldSigning := buildManifest(t, 1, false, 0x30, 0x31)
+	rotationOld, err := manifest.Deserialize(rotationOldWire)
+	require.NoError(t, err)
+	rotationWire, _, rotationSigning := buildManifest(t, 2, false, 0x30, 0x32)
+	rotation, err := manifest.Deserialize(rotationWire)
+	require.NoError(t, err)
+
+	before := manifest.NewCache()
+	require.Equal(t, manifest.Accepted, before.ApplyManifest(revokedOld))
+	require.Equal(t, manifest.Accepted, before.ApplyManifest(revocation))
+	require.Equal(t, manifest.Accepted, before.ApplyManifest(rotationOld))
+	require.Equal(t, manifest.Accepted, before.ApplyManifest(rotation))
+
+	rows := make([][]byte, 0, 2)
+	for _, entry := range before.Snapshot() {
+		rows = append(rows, entry.Serialized())
+	}
+	ctx := context.Background()
+	dir := t.TempDir()
+	store, err := manifest.OpenSQLiteStore(ctx, dir)
+	require.NoError(t, err)
+	require.NoError(t, store.Replace(ctx, manifest.StoredManifests{Validators: rows}))
+	require.NoError(t, store.Close())
+
+	store, err = manifest.OpenSQLiteStore(ctx, dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	stored, err := store.Load(ctx)
+	require.NoError(t, err)
+	after := manifest.NewCache()
+	for _, raw := range stored.Validators {
+		parsed, parseErr := manifest.Deserialize(raw)
+		require.NoError(t, parseErr)
+		require.Equal(t, manifest.Accepted, after.ApplyManifest(parsed))
+	}
+
+	require.True(t, after.Revoked(revokedMaster))
+	require.Equal(t, manifest.Stale, after.ApplyManifest(revokedOld))
+	require.NotEqual(t, revokedMaster, after.GetMasterKey(revokedSigning))
+	require.Equal(t, rotationSigning, mustSigningKey(t, after, rotationMaster))
+	require.NotEqual(t, rotationMaster, after.GetMasterKey(rotationOldSigning))
+}
+
+func mustManifest(t *testing.T, c *manifest.Cache, master [33]byte) []byte {
+	t.Helper()
+	got, ok := c.GetManifest(master)
+	require.True(t, ok)
+	return got
+}
+
+func mustSequence(t *testing.T, c *manifest.Cache, master [33]byte) uint32 {
+	t.Helper()
+	got, ok := c.GetSequence(master)
+	require.True(t, ok)
+	return got
+}
+
+func mustSigningKey(t *testing.T, c *manifest.Cache, master [33]byte) [33]byte {
+	t.Helper()
+	got, ok := c.GetSigningKey(master)
+	require.True(t, ok)
+	return got
+}
+
 func TestManifest_WireDecode_ValidMasterSig_Accepted(t *testing.T) {
 	serialized, master, ephemeral := buildManifest(t, 1, false, 0x01, 0x02)
 
@@ -200,14 +532,14 @@ func TestManifest_WireDecode_ValidMasterSig_Accepted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Deserialize: %v", err)
 	}
-	if m.MasterKey != master {
-		t.Fatalf("MasterKey mismatch: got %x want %x", m.MasterKey, master)
+	if m.MasterKey() != master {
+		t.Fatalf("MasterKey mismatch: got %x want %x", m.MasterKey(), master)
 	}
-	if m.SigningKey != ephemeral {
-		t.Fatalf("SigningKey mismatch: got %x want %x", m.SigningKey, ephemeral)
+	if m.SigningKey() != ephemeral {
+		t.Fatalf("SigningKey mismatch: got %x want %x", m.SigningKey(), ephemeral)
 	}
-	if m.Sequence != 1 {
-		t.Fatalf("Sequence: got %d want 1", m.Sequence)
+	if m.Sequence() != 1 {
+		t.Fatalf("Sequence: got %d want 1", m.Sequence())
 	}
 	if m.Revoked() {
 		t.Fatal("Revoked: true, want false")
@@ -649,8 +981,8 @@ func TestManifest_Domain_Validation(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Deserialize(%q): unexpected error: %v", tc.domain, err)
 				}
-				if m.Domain != tc.domain {
-					t.Errorf("Domain: got %q want %q", m.Domain, tc.domain)
+				if m.Domain() != tc.domain {
+					t.Errorf("Domain: got %q want %q", m.Domain(), tc.domain)
 				}
 				return
 			}
@@ -668,6 +1000,6 @@ func TestManifest_MaximumDomainFitsSerializedLimit(t *testing.T) {
 	require.Less(t, len(serialized), 1024)
 	parsed, err := manifest.Deserialize(serialized)
 	require.NoError(t, err)
-	require.Equal(t, domain, parsed.Domain)
+	require.Equal(t, domain, parsed.Domain())
 	require.NoError(t, parsed.Verify())
 }

--- a/internal/manifest/store.go
+++ b/internal/manifest/store.go
@@ -14,7 +14,6 @@ import (
 
 const storeFilename = "manifests.db"
 
-// StoredManifests contains the raw validator and publisher manifest rows.
 type StoredManifests struct {
 	Validators [][]byte
 	Publishers [][]byte
@@ -39,7 +38,6 @@ const (
 	publisherNamespace
 )
 
-// OpenSQLiteStore opens the node-local manifest database in dir.
 func OpenSQLiteStore(ctx context.Context, dir string) (Store, error) {
 	if dir == "" {
 		return nil, errors.New("manifest store: empty directory")

--- a/internal/manifest/store.go
+++ b/internal/manifest/store.go
@@ -1,0 +1,202 @@
+package manifest
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	_ "modernc.org/sqlite"
+)
+
+const storeFilename = "manifests.db"
+
+// StoredManifests contains the raw validator and publisher manifest rows.
+type StoredManifests struct {
+	Validators [][]byte
+	Publishers [][]byte
+}
+
+// Store persists the two manifest cache namespaces atomically.
+type Store interface {
+	Load(context.Context) (StoredManifests, error)
+	Replace(context.Context, StoredManifests) error
+	Close() error
+}
+
+type sqliteStore struct {
+	mu sync.RWMutex
+	db *sql.DB
+}
+
+type manifestNamespace uint8
+
+const (
+	validatorNamespace manifestNamespace = iota
+	publisherNamespace
+)
+
+// OpenSQLiteStore opens the node-local manifest database in dir.
+func OpenSQLiteStore(ctx context.Context, dir string) (Store, error) {
+	if dir == "" {
+		return nil, errors.New("manifest store: empty directory")
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("manifest store: create directory: %w", err)
+	}
+	db, err := sql.Open("sqlite", filepath.Join(dir, storeFilename))
+	if err != nil {
+		return nil, fmt.Errorf("manifest store: open: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	closeOnError := func(cause error) (Store, error) {
+		return nil, errors.Join(cause, db.Close())
+	}
+	if err := db.PingContext(ctx); err != nil {
+		return closeOnError(fmt.Errorf("manifest store: ping: %w", err))
+	}
+	for _, statement := range []string{
+		"PRAGMA journal_mode=WAL",
+		"PRAGMA synchronous=FULL",
+		"PRAGMA busy_timeout=5000",
+		"CREATE TABLE IF NOT EXISTS ValidatorManifests (RawData BLOB NOT NULL)",
+		"CREATE TABLE IF NOT EXISTS PublisherManifests (RawData BLOB NOT NULL)",
+	} {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			return closeOnError(fmt.Errorf("manifest store: initialize: %w", err))
+		}
+	}
+	return &sqliteStore{db: db}, nil
+}
+
+func (s *sqliteStore) Load(ctx context.Context) (StoredManifests, error) {
+	if s == nil {
+		return StoredManifests{}, errors.New("manifest store: closed")
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return StoredManifests{}, errors.New("manifest store: closed")
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return StoredManifests{}, fmt.Errorf("manifest store: begin load: %w", err)
+	}
+	defer tx.Rollback()
+	validators, err := loadManifestRows(ctx, tx, validatorNamespace)
+	if err != nil {
+		return StoredManifests{}, fmt.Errorf("manifest store: load validators: %w", err)
+	}
+	publishers, err := loadManifestRows(ctx, tx, publisherNamespace)
+	if err != nil {
+		return StoredManifests{}, fmt.Errorf("manifest store: load publishers: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return StoredManifests{}, fmt.Errorf("manifest store: commit load: %w", err)
+	}
+	return StoredManifests{Validators: validators, Publishers: publishers}, nil
+}
+
+func loadManifestRows(ctx context.Context, tx *sql.Tx, namespace manifestNamespace) ([][]byte, error) {
+	var query string
+	switch namespace {
+	case validatorNamespace:
+		query = "SELECT RawData FROM ValidatorManifests"
+	case publisherNamespace:
+		query = "SELECT RawData FROM PublisherManifests"
+	default:
+		return nil, errors.New("unknown manifest namespace")
+	}
+	rows, err := tx.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out [][]byte
+	for rows.Next() {
+		var raw []byte
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		out = append(out, append([]byte(nil), raw...))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *sqliteStore) Replace(ctx context.Context, manifests StoredManifests) error {
+	if s == nil {
+		return errors.New("manifest store: closed")
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.db == nil {
+		return errors.New("manifest store: closed")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("manifest store: begin replace: %w", err)
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, "DELETE FROM ValidatorManifests"); err != nil {
+		return fmt.Errorf("manifest store: clear validators: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM PublisherManifests"); err != nil {
+		return fmt.Errorf("manifest store: clear publishers: %w", err)
+	}
+	if err := insertManifestRows(ctx, tx, validatorNamespace, manifests.Validators); err != nil {
+		return fmt.Errorf("manifest store: replace validators: %w", err)
+	}
+	if err := insertManifestRows(ctx, tx, publisherNamespace, manifests.Publishers); err != nil {
+		return fmt.Errorf("manifest store: replace publishers: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("manifest store: commit replace: %w", err)
+	}
+	return nil
+}
+
+func insertManifestRows(ctx context.Context, tx *sql.Tx, namespace manifestNamespace, rows [][]byte) error {
+	var query string
+	switch namespace {
+	case validatorNamespace:
+		query = "INSERT INTO ValidatorManifests (RawData) VALUES (?)"
+	case publisherNamespace:
+		query = "INSERT INTO PublisherManifests (RawData) VALUES (?)"
+	default:
+		return errors.New("unknown manifest namespace")
+	}
+	statement, err := tx.PrepareContext(ctx, query)
+	if err != nil {
+		return err
+	}
+	defer statement.Close()
+	for _, raw := range rows {
+		if _, err := statement.ExecContext(ctx, append([]byte(nil), raw...)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *sqliteStore) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return nil
+	}
+	err := s.db.Close()
+	s.db = nil
+	if err != nil {
+		return fmt.Errorf("manifest store: close: %w", err)
+	}
+	return nil
+}

--- a/internal/manifest/store_test.go
+++ b/internal/manifest/store_test.go
@@ -1,0 +1,106 @@
+package manifest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLiteStoreReplaceLoadAndNamespaceIsolation(t *testing.T) {
+	ctx := context.Background()
+	store, err := OpenSQLiteStore(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	want := StoredManifests{
+		Validators: [][]byte{{0x01}, {0x02, 0x03}},
+		Publishers: [][]byte{{0x04, 0x05, 0x06}},
+	}
+	require.NoError(t, store.Replace(ctx, want))
+	got, err := store.Load(ctx)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+	got.Validators[0][0] = 0xff
+	again, err := store.Load(ctx)
+	require.NoError(t, err)
+	require.Equal(t, want, again)
+}
+
+func TestSQLiteStoreReplaceRollsBackBothNamespaces(t *testing.T) {
+	ctx := context.Background()
+	storeAPI, err := OpenSQLiteStore(ctx, t.TempDir())
+	require.NoError(t, err)
+	store := storeAPI.(*sqliteStore)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	original := StoredManifests{Validators: [][]byte{{0x10}}, Publishers: [][]byte{{0x20}}}
+	require.NoError(t, store.Replace(ctx, original))
+	_, err = store.db.ExecContext(ctx, `CREATE TRIGGER reject_publisher
+		BEFORE INSERT ON PublisherManifests
+		BEGIN SELECT RAISE(ABORT, 'injected publisher failure'); END`)
+	require.NoError(t, err)
+
+	err = store.Replace(ctx, StoredManifests{Validators: [][]byte{{0x11}}, Publishers: [][]byte{{0x21}}})
+	require.ErrorContains(t, err, "injected publisher failure")
+	got, err := store.Load(ctx)
+	require.NoError(t, err)
+	require.Equal(t, original, got)
+}
+
+func TestSQLiteStoreErrorsAreVisible(t *testing.T) {
+	ctx := context.Background()
+	file := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o600))
+	_, err := OpenSQLiteStore(ctx, file)
+	require.Error(t, err)
+
+	storeAPI, err := OpenSQLiteStore(ctx, t.TempDir())
+	require.NoError(t, err)
+	store := storeAPI.(*sqliteStore)
+	require.NoError(t, store.Close())
+	_, err = store.Load(ctx)
+	require.ErrorContains(t, err, "closed")
+	require.ErrorContains(t, store.Replace(ctx, StoredManifests{}), "closed")
+	require.NoError(t, store.Close())
+}
+
+func TestSQLiteStoreConcurrentClose(t *testing.T) {
+	ctx := context.Background()
+	storeAPI, err := OpenSQLiteStore(ctx, t.TempDir())
+	require.NoError(t, err)
+	store := storeAPI.(*sqliteStore)
+	require.NoError(t, store.Replace(ctx, StoredManifests{Validators: [][]byte{{0x01}}}))
+
+	const workers = 64
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if i%2 == 0 {
+				_, err := store.Load(ctx)
+				errs <- err
+				return
+			}
+			errs <- store.Replace(ctx, StoredManifests{Publishers: [][]byte{{byte(i)}}})
+		}()
+	}
+	close(start)
+	require.NoError(t, store.Close())
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			require.ErrorContains(t, err, "closed")
+		}
+	}
+	require.NoError(t, store.Close())
+}

--- a/internal/manifest/token_test.go
+++ b/internal/manifest/token_test.go
@@ -59,7 +59,7 @@ func TestLoadValidatorToken_DecodeManifest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Deserialize embedded manifest: %v", err)
 	}
-	if m.Sequence == 0 {
+	if m.Sequence() == 0 {
 		t.Errorf("expected non-zero manifest sequence, got 0")
 	}
 }

--- a/internal/node/adapters.go
+++ b/internal/node/adapters.go
@@ -496,10 +496,12 @@ func buildManifestEvent(m *manifest.Manifest) *rpc.ManifestEvent {
 	if m == nil {
 		return nil
 	}
-	masterEnc, _ := addresscodec.EncodeNodePublicKey(m.MasterKey[:])
+	master := m.MasterKey()
+	masterEnc, _ := addresscodec.EncodeNodePublicKey(master[:])
 	var signingEnc string
 	if !m.Revoked() {
-		signingEnc, _ = addresscodec.EncodeNodePublicKey(m.SigningKey[:])
+		signing := m.SigningKey()
+		signingEnc, _ = addresscodec.EncodeNodePublicKey(signing[:])
 	}
 	masterSig, sig := m.Signatures()
 	return rpc.NewManifestEvent(
@@ -507,9 +509,9 @@ func buildManifestEvent(m *manifest.Manifest) *rpc.ManifestEvent {
 		signingEnc,
 		masterSig,
 		sig,
-		m.Domain,
-		upperHex(m.Serialized),
-		m.Sequence,
+		m.Domain(),
+		upperHex(m.Serialized()),
+		m.Sequence(),
 	)
 }
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -132,7 +132,7 @@ func isFullGitHash(value string) bool {
 // Run assembles and starts every node subsystem from the parsed config, then
 // blocks until a terminating signal or fatal error. It is the composition root
 // extracted from the CLI so flag parsing and node wiring stay separable.
-func Run(ctx context.Context, appConfig *config.Config, configPath string, standalone bool, startup service.StartupConfig, rootLogger, serverLog xrpllog.Logger) error {
+func Run(ctx context.Context, appConfig *config.Config, configPath string, standalone bool, startup service.StartupConfig, rootLogger, serverLog xrpllog.Logger) (runErr error) {
 	if err := context.Cause(ctx); err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 		stallWatchdog       *watchdog.Watchdog
 	)
 	defer func() {
-		doShutdown(httpSrvs, wsSrvs, wsServer, grpcSrv, ledgerService, ledgerCleaner, consensusComponents, rotator, db, repoManager, serverLog)
+		runErr = errors.Join(runErr, doShutdown(httpSrvs, wsSrvs, wsServer, grpcSrv, ledgerService, ledgerCleaner, consensusComponents, rotator, db, repoManager, serverLog))
 	}()
 
 	db, repoManager, err = setupStorage(appConfig, serverLog)
@@ -495,7 +495,7 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 		if appConfig.NodeDB.EarliestSeq > 0 || rotator != nil {
 			floor = minimumOnlineFloorFunc(retentionFloor)
 		}
-		consensusComponents, compErr = adaptor.NewFromConfig(appConfig, ledgerService, validationRepo, floor)
+		consensusComponents, compErr = adaptor.NewFromConfig(ctx, appConfig, ledgerService, validationRepo, floor)
 		if compErr != nil {
 			return fmt.Errorf("create consensus components: %w", compErr)
 		}
@@ -720,7 +720,7 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 		// The cache is shared — the router writes inbound manifests,
 		// the engine reads for ephemeral→master translation, and this
 		// RPC reads for external queries.
-		services.Manifests = consensusComponents.Manifests
+		services.Manifests = consensusComponents.ValidatorManifests
 
 		// Expose the publisher-list aggregator (when configured) to
 		// the `validators` and `validator_list_sites` RPC methods.
@@ -764,7 +764,7 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 			}
 			return out
 		}
-		if mc := consensusComponents.Manifests; mc != nil {
+		if mc := consensusComponents.ValidatorManifests; mc != nil {
 			// Mirrors rippled getJson at ValidatorList.cpp:1726-1734 —
 			// `signing_keys` only surfaces master→signing pairs for
 			// masters present in keyListings_, i.e. validators listed
@@ -898,8 +898,8 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 		// installed on the cache, fed by every accepted manifest
 		// regardless of source (overlay relay, startup, validator-list
 		// aggregator, local-manifest emit).
-		if consensusComponents.Manifests != nil {
-			consensusComponents.Manifests.SetOnAccepted(func(m *manifest.Manifest) {
+		if consensusComponents.ValidatorManifests != nil {
+			consensusComponents.ValidatorManifests.SubscribeAccepted(func(m *manifest.Manifest) {
 				publishManifestIfSubscribed(publisher, m)
 			})
 		}
@@ -912,7 +912,7 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 		if consensusComponents.Engine != nil {
 			consensusComponents.Engine.Subscribe(&rpcEventBridge{
 				publisher: publisher,
-				manifests: consensusComponents.Manifests,
+				manifests: consensusComponents.ValidatorManifests,
 				networkID: uint32(networkID),
 			})
 		}
@@ -1623,21 +1623,37 @@ func doShutdown(
 	kvDB nodestore.Database,
 	repoManager relationaldb.RepositoryManager,
 	logger xrpllog.Logger,
-) {
+) error {
+	var shutdownErr error
 	const drainTimeout = 30 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), drainTimeout)
 	defer cancel()
 
 	logger.Info("Draining HTTP connections...")
 	for _, srv := range httpSrvs {
-		_ = srv.Shutdown(ctx)
+		if err := srv.Shutdown(ctx); err != nil {
+			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("shutdown HTTP server: %w", err))
+			logger.Warn("HTTP server graceful shutdown failed", "err", err)
+			if closeErr := srv.Close(); closeErr != nil {
+				shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close HTTP server: %w", closeErr))
+				logger.Warn("HTTP server forced close failed", "err", closeErr)
+			}
+		}
 	}
 	for _, srv := range wsSrvs {
-		_ = srv.Shutdown(ctx)
+		if err := srv.Shutdown(ctx); err != nil {
+			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("shutdown WebSocket HTTP server: %w", err))
+			logger.Warn("WebSocket HTTP server graceful shutdown failed", "err", err)
+			if closeErr := srv.Close(); closeErr != nil {
+				shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close WebSocket HTTP server: %w", closeErr))
+				logger.Warn("WebSocket HTTP server forced close failed", "err", closeErr)
+			}
+		}
 	}
 
 	if wsServer != nil {
 		if err := wsServer.Close(ctx); err != nil {
+			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close WebSocket server: %w", err))
 			logger.Warn("WebSocket server shutdown timed out", "err", err)
 		}
 	}
@@ -1653,6 +1669,7 @@ func doShutdown(
 		case <-stopped:
 		case <-ctx.Done():
 			grpcSrv.Stop()
+			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("drain gRPC server: %w", ctx.Err()))
 			logger.Warn("gRPC server graceful shutdown timed out; forced stop")
 		}
 	}
@@ -1670,12 +1687,14 @@ func doShutdown(
 	if consensusComponents != nil {
 		stopErr := consensusComponents.Stop()
 		if stopErr != nil {
+			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("stop consensus components: %w", stopErr))
 			logger.Warn("Consensus component shutdown failed", "err", stopErr)
 			if consensusComponents.Archive != nil {
 				waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				terminalErr := consensusComponents.Archive.Close(waitCtx)
 				waitCancel()
 				if terminalErr != nil && !errors.Is(stopErr, terminalErr) {
+					shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close validation archive: %w", terminalErr))
 					logger.Warn("Validation archive terminal shutdown failed", "err", terminalErr)
 				}
 			}
@@ -1708,16 +1727,19 @@ func doShutdown(
 	}
 	if kvDB != nil {
 		if err := kvDB.Close(); err != nil {
+			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close node store: %w", err))
 			logger.Warn("Node store close failed", "err", err)
 		}
 	}
 	if repoManager != nil {
 		if err := repoManager.Close(); err != nil {
+			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close relational DB: %w", err))
 			logger.Warn("Relational DB close failed", "err", err)
 		}
 	}
 
 	logger.Info("Shutdown complete")
+	return shutdownErr
 }
 
 // ledgerCleanerSource adapts the ledger service + node store to the

--- a/internal/node/server_helpers_test.go
+++ b/internal/node/server_helpers_test.go
@@ -266,6 +266,29 @@ type manifestPublisherSpy struct {
 	events      []*rpc.ManifestEvent
 }
 
+func unverifiedManifest(t testing.TB, sequence uint32) *manifest.Manifest {
+	t.Helper()
+	encoded, err := binarycodec.Encode(map[string]any{
+		"PublicKey":       "ED" + strings.Repeat("00", 32),
+		"SigningPubKey":   "ED" + strings.Repeat("01", 32),
+		"Sequence":        sequence,
+		"MasterSignature": "00",
+		"Signature":       "00",
+	})
+	if err != nil {
+		t.Fatalf("encode manifest: %v", err)
+	}
+	wire, err := hex.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	parsed, err := manifest.Deserialize(wire)
+	if err != nil {
+		t.Fatalf("deserialize manifest: %v", err)
+	}
+	return parsed
+}
+
 func (p *manifestPublisherSpy) PublishManifest(event *rpc.ManifestEvent) {
 	p.events = append(p.events, event)
 }
@@ -276,7 +299,7 @@ func (p *manifestPublisherSpy) GetSubscriberCount(stream types.SubscriptionType)
 }
 
 func TestPublishManifestIfSubscribed(t *testing.T) {
-	m := &manifest.Manifest{Sequence: 7}
+	m := unverifiedManifest(t, 7)
 
 	withoutSubscribers := &manifestPublisherSpy{}
 	publishManifestIfSubscribed(withoutSubscribers, m)
@@ -292,14 +315,14 @@ func TestPublishManifestIfSubscribed(t *testing.T) {
 	if len(withSubscriber.events) != 1 {
 		t.Fatalf("published %d events, want 1", len(withSubscriber.events))
 	}
-	if withSubscriber.events[0] == nil || withSubscriber.events[0].Sequence != m.Sequence {
+	if withSubscriber.events[0] == nil || withSubscriber.events[0].Sequence != m.Sequence() {
 		t.Fatalf("published event = %+v", withSubscriber.events[0])
 	}
 }
 
 func BenchmarkPublishManifestWithoutSubscribers(b *testing.B) {
 	publisher := &manifestPublisherSpy{}
-	m := &manifest.Manifest{Sequence: 7}
+	m := unverifiedManifest(b, 7)
 	b.ReportAllocs()
 	for b.Loop() {
 		publishManifestIfSubscribed(publisher, m)

--- a/internal/node/server_test.go
+++ b/internal/node/server_test.go
@@ -10,8 +10,11 @@ import (
 
 	"github.com/LeJamon/go-xrpl/config"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/consensus/adaptor"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
+	"github.com/LeJamon/go-xrpl/storage/nodestore"
+	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,6 +36,27 @@ type recordingSinkCall struct {
 	validators []consensus.NodeID
 	masterKeys [][33]byte
 }
+
+type shutdownErrorEngine struct {
+	consensus.Engine
+	err error
+}
+
+func (e *shutdownErrorEngine) Stop() error { return e.err }
+
+type shutdownErrorNodeStore struct {
+	nodestore.Database
+	err error
+}
+
+func (s *shutdownErrorNodeStore) Close() error { return s.err }
+
+type shutdownErrorRepositoryManager struct {
+	relationaldb.RepositoryManager
+	err error
+}
+
+func (m *shutdownErrorRepositoryManager) Close() error { return m.err }
 
 func TestEffectivePeerFetchDepth(t *testing.T) {
 	tests := []struct {
@@ -260,5 +284,40 @@ func TestDoShutdown_ToleratesNilComponents(t *testing.T) {
 	// criterion is "doesn't crash": WebSocketServer.Close dereferences its
 	// receiver on the first line (connectionsMutex.Lock), so a nil wsServer
 	// would panic without the guard this test pins.
-	doShutdown(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, xrpllog.Discard())
+	if err := doShutdown(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, xrpllog.Discard()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDoShutdownReturnsConsensusPersistenceFailure(t *testing.T) {
+	want := errors.New("manifest persistence failed")
+	components := &adaptor.Components{Engine: &shutdownErrorEngine{err: want}}
+	err := doShutdown(nil, nil, nil, nil, nil, nil, components, nil, nil, nil, xrpllog.Discard())
+	if !errors.Is(err, want) {
+		t.Fatalf("doShutdown error = %v, want %v", err, want)
+	}
+}
+
+func TestDoShutdownReturnsStorageCloseFailures(t *testing.T) {
+	nodeStoreErr := errors.New("node store close failed")
+	repositoryErr := errors.New("repository close failed")
+	err := doShutdown(
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		&shutdownErrorNodeStore{err: nodeStoreErr},
+		&shutdownErrorRepositoryManager{err: repositoryErr},
+		xrpllog.Discard(),
+	)
+	if !errors.Is(err, nodeStoreErr) {
+		t.Fatalf("doShutdown error = %v, want %v", err, nodeStoreErr)
+	}
+	if !errors.Is(err, repositoryErr) {
+		t.Fatalf("doShutdown error = %v, want %v", err, repositoryErr)
+	}
 }

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -220,15 +220,8 @@ type Aggregator struct {
 	// validator_list_sites. Updated by the HTTP poller; read by RPC.
 	sites []*SiteState
 
-	// manifests is the validator manifest cache. Used to:
-	//   1. Apply incoming publisher manifests (verify + cache the
-	//      ephemeral signing key for blob verification).
-	//   2. Resolve ephemeral validator signing keys back to master keys
-	//      when emitting the trusted set for consensus.
-	//
-	// Shared with the consensus engine and the TMManifests gossip path
-	// so the same manifest seen via a VL applies everywhere.
-	manifests *manifest.Cache
+	validatorManifests *manifest.Cache
+	publisherManifests *manifest.Cache
 
 	// threshold is the minimum number of publishers from `publishers`
 	// that must list a validator before that validator is admitted to
@@ -265,7 +258,8 @@ type Aggregator struct {
 	// the consensus validation path, which runs under the engine's lock
 	// while the OnChange → SetTrustedValidators → engine trust-refresh
 	// chain runs under a.mu — reading a.mu here would be an ABBA deadlock.
-	listed atomic.Pointer[map[consensus.NodeID]struct{}]
+	listed        atomic.Pointer[map[consensus.NodeID]struct{}]
+	listedMasters atomic.Pointer[map[[33]byte]struct{}]
 
 	// unlBlocked mirrors rippled's NetworkOPs unlBlocked_ (NetworkOPs.cpp:750):
 	// the sticky UNL lock-down. Written under a.mu by recomputeAndEmitLocked
@@ -334,14 +328,15 @@ type Aggregator struct {
 }
 
 // Config carries Aggregator construction parameters. All fields are
-// optional; Defaults handle nil Logger / Clock / Manifests so the type
+// optional; defaults handle nil logger, clock, and manifest caches so the type
 // is usable in narrowly-scoped tests.
 type Config struct {
 	PublisherKeys        []PublisherKey
 	SiteURIs             []string
 	Threshold            int
 	StaticValidatorCount int
-	Manifests            *manifest.Cache
+	ValidatorManifests   *manifest.Cache
+	PublisherManifests   *manifest.Cache
 	Clock                func() time.Time
 	Logger               *slog.Logger
 }
@@ -405,11 +400,25 @@ func New(cfg Config) (*Aggregator, error) {
 	if threshold > len(publishers) {
 		return nil, fmt.Errorf("threshold %d exceeds publisher count %d", threshold, len(publishers))
 	}
+	validatorManifests := cfg.ValidatorManifests
+	publisherManifests := cfg.PublisherManifests
+	if validatorManifests == nil {
+		validatorManifests = manifest.NewCache()
+	}
+	if publisherManifests == nil {
+		publisherManifests = manifest.NewCache()
+	}
+	for key := range publishers {
+		if publisherManifests.Revoked([33]byte(key)) {
+			state[key].Status = StatusRevoked
+		}
+	}
 	return &Aggregator{
 		publishers:           publishers,
 		state:                state,
 		sites:                sites,
-		manifests:            cfg.Manifests,
+		validatorManifests:   validatorManifests,
+		publisherManifests:   publisherManifests,
 		threshold:            threshold,
 		staticValidatorCount: cfg.StaticValidatorCount,
 		clock:                clock,
@@ -664,7 +673,8 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 		a.logger.Debug("validator list: manifest deserialize failed", "error", err, "site", siteURI)
 		return Untrusted, PublisherKey{}, 0
 	}
-	pubKey := PublisherKey(parsed.MasterKey)
+	masterKey := parsed.MasterKey()
+	pubKey := PublisherKey(masterKey)
 
 	// Reject lists from publishers we don't trust. Per rippled this is
 	// a silent drop — gossip carries lists from many publishers and we
@@ -689,8 +699,8 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 	// a stale revocation (cache already holds a higher-sequence
 	// non-revoked manifest) returns untrusted without clearing state.
 	manifestAccepted := false
-	if a.manifests != nil {
-		switch d := a.manifests.ApplyManifest(parsed); d {
+	if a.publisherManifests != nil {
+		switch d := a.publisherManifests.ApplyManifest(parsed); d {
 		case manifest.Accepted:
 			manifestAccepted = true
 		case manifest.Stale:
@@ -749,9 +759,9 @@ func (a *Aggregator) ApplyList(manifestBytes, blob, signature []byte, version ui
 	// later manifest arrived first via gossip. Rippled also uses
 	// publisherManifests_.getSigningKey here, which is the latest
 	// cached key, not the one in `manifestBytes`.
-	signingKey := parsed.SigningKey
-	if a.manifests != nil {
-		if k, ok := a.manifests.GetSigningKey(parsed.MasterKey); ok {
+	signingKey := parsed.SigningKey()
+	if a.publisherManifests != nil {
+		if k, ok := a.publisherManifests.GetSigningKey(masterKey); ok {
 			signingKey = k
 		} else {
 			// Cache says the master is unknown or revoked. If revoked
@@ -920,7 +930,7 @@ func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, sign
 	// above via `keys`). Manifests for unlisted validators are dropped:
 	// a malicious publisher must not be able to pollute the cache with
 	// manifests for validators they don't actually attest to.
-	if a.manifests != nil {
+	if a.validatorManifests != nil {
 		listed := make(map[[33]byte]struct{}, len(keys)+8)
 		for _, k := range keys {
 			listed[k] = struct{}{}
@@ -945,12 +955,13 @@ func (a *Aggregator) applyAcceptedLocked(s *PublisherState, blob *blobJSON, sign
 			if err != nil {
 				continue
 			}
-			if _, ok := listed[parsed.MasterKey]; !ok {
+			masterKey := parsed.MasterKey()
+			if _, ok := listed[masterKey]; !ok {
 				a.logger.Debug("validator list: dropping embedded manifest for unlisted master",
-					"master", hex.EncodeToString(parsed.MasterKey[:]))
+					"master", hex.EncodeToString(masterKey[:]))
 				continue
 			}
-			_ = a.manifests.ApplyManifest(parsed)
+			_ = a.validatorManifests.ApplyManifest(parsed)
 		}
 	}
 
@@ -1156,10 +1167,13 @@ func (a *Aggregator) computeValidatorCountsLocked(now time.Time) map[[33]byte]in
 		}
 	}
 	listed := make(map[consensus.NodeID]struct{}, len(counts))
+	listedMasters := make(map[[33]byte]struct{}, len(counts))
 	for k := range counts {
 		listed[consensus.CalcNodeID(k)] = struct{}{}
+		listedMasters[k] = struct{}{}
 	}
 	a.listed.Store(&listed)
+	a.listedMasters.Store(&listedMasters)
 	return counts
 }
 
@@ -1173,6 +1187,17 @@ func (a *Aggregator) IsListed(node consensus.NodeID) bool {
 		return false
 	}
 	_, ok := (*listed)[node]
+	return ok
+}
+
+// IsMasterListed reports whether a validator master key appears in a live
+// configured publisher list.
+func (a *Aggregator) IsMasterListed(master [33]byte) bool {
+	listed := a.listedMasters.Load()
+	if listed == nil {
+		return false
+	}
+	_, ok := (*listed)[master]
 	return ok
 }
 

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -573,6 +573,9 @@ func TestAggregator_ApplyList_PendingThenKnownSequence(t *testing.T) {
 	if _, m := agg.TrustedValidators(); len(m) != 0 {
 		t.Fatalf("trusted before promotion: want 0, got %d", len(m))
 	}
+	if agg.IsMasterListed(v1) {
+		t.Fatal("validator reported listed before promotion")
+	}
 
 	// Same sequence again — KnownSequence (re-arrival at a queued seq).
 	d, _, _ = agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://")
@@ -587,6 +590,9 @@ func TestAggregator_ApplyList_PendingThenKnownSequence(t *testing.T) {
 	_, masters := agg.TrustedValidators()
 	if len(masters) != 1 || masters[0] != v1 {
 		t.Fatalf("post-Tick trusted: want [v1] got %d entries", len(masters))
+	}
+	if !agg.IsMasterListed(v1) {
+		t.Fatal("validator not reported listed after promotion tick")
 	}
 }
 

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/internal/validator/list"
 	"github.com/LeJamon/go-xrpl/protocol"
+	"github.com/stretchr/testify/require"
 )
 
 // fixedClock yields a deterministic "now" so test expectations don't
@@ -56,6 +57,26 @@ func newPublisher(t *testing.T, masterSeed, ephSeed byte) *publisherFixture {
 		ephPriv:     ephPriv,
 		manifestB64: b64,
 	}
+}
+
+func TestAggregator_NewRestoresPublisherRevocationStatus(t *testing.T) {
+	pub := newPublisher(t, 0x03, 0x04)
+	publisherManifests := manifest.NewCache()
+	revocationRaw := buildRevocation(t, pub.masterPub, pub.masterPriv)
+	revocation, err := manifest.Deserialize(revocationRaw)
+	require.NoError(t, err)
+	require.Equal(t, manifest.Accepted, publisherManifests.ApplyManifest(revocation))
+
+	agg, err := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: publisherManifests,
+		Clock:              fixedClock(),
+	})
+	require.NoError(t, err)
+	snapshot := agg.PublisherSnapshot()
+	require.Len(t, snapshot, 1)
+	require.Equal(t, list.StatusRevoked, snapshot[0].Status)
 }
 
 // signList produces the (blob, signature) pair the aggregator expects:
@@ -101,10 +122,11 @@ func TestAggregator_ApplyList_Accepted_SinglePublisher_SingleValidator(t *testin
 	val1 := derivedValidatorKey(0x10)
 
 	agg, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -165,9 +187,10 @@ func TestAggregator_ApplyList_Threshold_TwoOfThree(t *testing.T) {
 			list.PublisherKey(pub2.masterPub),
 			list.PublisherKey(pub3.masterPub),
 		},
-		Threshold: 2,
-		Manifests: manifest.NewCache(),
-		Clock:     fixedClock(),
+		Threshold:          2,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -219,10 +242,11 @@ func TestAggregator_ApplyList_Stale(t *testing.T) {
 	v1 := derivedValidatorKey(0x10)
 
 	agg, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -249,10 +273,11 @@ func TestAggregator_ApplyList_UntrustedPublisher(t *testing.T) {
 	v1 := derivedValidatorKey(0x10)
 
 	agg, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pubInTrust.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pubInTrust.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -274,10 +299,11 @@ func TestAggregator_ApplyList_BadSignature(t *testing.T) {
 	v1 := derivedValidatorKey(0x10)
 
 	agg, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -298,10 +324,11 @@ func TestAggregator_ApplyList_Expired(t *testing.T) {
 	v1 := derivedValidatorKey(0x10)
 
 	agg, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -323,10 +350,11 @@ func TestAggregator_ApplyList_Expired(t *testing.T) {
 func TestAggregator_ApplyList_UnsupportedVersion(t *testing.T) {
 	pub := newPublisher(t, 0x01, 0x02)
 	agg, _ := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	d, _, _ := agg.ApplyList(pub.manifestB64, []byte("garbage"), []byte("00"), 99, "test://")
 	if d != list.UnsupportedVersion {
@@ -362,10 +390,11 @@ func TestAggregator_ApplyList_BadManifest(t *testing.T) {
 func TestAggregator_ApplyList_MissingRequiredField(t *testing.T) {
 	pub := newPublisher(t, 0x01, 0x02)
 	agg, _ := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	// Blob with only `sequence` and `expiration`, no `validators` array.
 	now := fixedClock()()
@@ -387,10 +416,11 @@ func TestAggregator_ApplyCollection_AcceptedAndStale(t *testing.T) {
 	v1 := derivedValidatorKey(0x10)
 
 	agg, _ := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 
 	now := fixedClock()()
@@ -462,6 +492,20 @@ func buildManifest(t *testing.T, masterPub [33]byte, masterPriv ed25519.PrivateK
 	return raw
 }
 
+func buildRevocation(t *testing.T, masterPub [33]byte, masterPriv ed25519.PrivateKey) []byte {
+	t.Helper()
+	obj := map[string]any{
+		"PublicKey": hex.EncodeToString(masterPub[:]),
+		"Sequence":  manifest.RevokedSequence,
+	}
+	obj["MasterSignature"] = hex.EncodeToString(ed25519.Sign(masterPriv, manifestSigningPreimage(t, obj)))
+	encoded, err := binarycodec.Encode(obj)
+	require.NoError(t, err)
+	wire, err := hex.DecodeString(encoded)
+	require.NoError(t, err)
+	return wire
+}
+
 func manifestSigningPreimage(t *testing.T, src map[string]any) []byte {
 	t.Helper()
 	filtered := make(map[string]any, len(src))
@@ -507,10 +551,11 @@ func TestAggregator_ApplyList_PendingThenKnownSequence(t *testing.T) {
 	clk := func() time.Time { return mutableNow }
 
 	agg, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         clk,
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              clk,
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -555,10 +600,11 @@ func TestAggregator_ApplyList_EffectiveSet_Sentinel(t *testing.T) {
 	v1 := derivedValidatorKey(0x10)
 
 	agg, _ := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	now := fixedClock()()
 	// signList passes validFromUnix=0 which means we OMIT `effective`.
@@ -584,10 +630,11 @@ func TestAggregator_ApplyList_Expired_ClearsValidators(t *testing.T) {
 	v1 := derivedValidatorKey(0x10)
 
 	agg, _ := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	now := fixedClock()()
 	exp := now.Add(-1 * time.Hour).Unix() // expired
@@ -654,17 +701,28 @@ func TestAggregator_ApplyList_Expired_SeedsEmbeddedManifests(t *testing.T) {
 	sigBytes := ed25519.Sign(pub.ephPriv, jsonBytes)
 	sig := []byte(hex.EncodeToString(sigBytes))
 
-	cache := manifest.NewCache()
+	validatorCache := manifest.NewCache()
+	publisherCache := manifest.NewCache()
 	agg, _ := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     cache,
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: validatorCache,
+		PublisherManifests: publisherCache,
+		Clock:              fixedClock(),
 	})
 	if d, _, _ := agg.ApplyList(pub.manifestB64, blob, sig, 1, "test://"); d != list.Expired {
 		t.Fatalf("disposition: %s", d)
 	}
-	if _, ok := cache.GetSigningKey(valMaster); !ok {
+	if _, ok := validatorCache.GetSigningKey(valMaster); !ok {
 		t.Fatalf("expired ingest must seed embedded validator manifests into the cache (rippled ValidatorList.cpp:1117-1133, reached via updatePublisherList at line 1294)")
+	}
+	if _, ok := publisherCache.GetSigningKey(valMaster); ok {
+		t.Fatal("embedded validator manifest contaminated the publisher cache")
+	}
+	if _, ok := publisherCache.GetSigningKey(pub.masterPub); !ok {
+		t.Fatal("publisher manifest was not applied to the publisher cache")
+	}
+	if _, ok := validatorCache.GetSigningKey(pub.masterPub); ok {
+		t.Fatal("publisher manifest contaminated the validator cache")
 	}
 }

--- a/internal/validator/list/broadcaster_test.go
+++ b/internal/validator/list/broadcaster_test.go
@@ -95,10 +95,11 @@ func TestBroadcastLatest_V2PeerGetsCollection_NoRemaining(t *testing.T) {
 	v1 := derivedValidatorKey(0x60)
 
 	agg, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -146,10 +147,11 @@ func TestBroadcastLatest_V2PeerSkippedWhenAtMaxSeq(t *testing.T) {
 	v1 := derivedValidatorKey(0x61)
 
 	agg, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/internal/validator/list/cache_test.go
+++ b/internal/validator/list/cache_test.go
@@ -21,10 +21,11 @@ func TestAggregator_Cache_WriteThenRoundTripLoad(t *testing.T) {
 
 	// First aggregator: write the cache by applying an accepted list.
 	src, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{pubKey},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{pubKey},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	if err != nil {
 		t.Fatalf("New src: %v", err)
@@ -72,10 +73,11 @@ func TestAggregator_Cache_WriteThenRoundTripLoad(t *testing.T) {
 	// Second aggregator: hydrate from the same directory and check
 	// the publisher reached StatusAvailable at the expected sequence.
 	dst, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{pubKey},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{pubKey},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	if err != nil {
 		t.Fatalf("New dst: %v", err)
@@ -108,10 +110,11 @@ func TestAggregator_Cache_LoadSkipsAlreadyAvailable(t *testing.T) {
 	pubKey := list.PublisherKey(pub.masterPub)
 
 	agg, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{pubKey},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{pubKey},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -155,10 +158,11 @@ func TestAggregator_Cache_DisabledDirNoFile(t *testing.T) {
 	dir := t.TempDir()
 
 	agg, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/internal/validator/list/site_poller_test.go
+++ b/internal/validator/list/site_poller_test.go
@@ -65,10 +65,11 @@ func TestSitePoller_DoubleStartSingleLoop(t *testing.T) {
 	defer srv.Close()
 
 	agg, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		SiteURIs:      []string{srv.URL},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		SiteURIs:           []string{srv.URL},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -121,10 +122,11 @@ func TestSitePoller_RefreshesNextRefreshBeforeFetch(t *testing.T) {
 	defer srv.Close()
 
 	a, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		SiteURIs:      []string{srv.URL},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		SiteURIs:           []string{srv.URL},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -169,10 +171,11 @@ func TestAggregator_CacheWriteFailureDoesNotBlockIngest(t *testing.T) {
 	}
 
 	agg, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
-		Clock:         fixedClock(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -219,10 +222,11 @@ func TestSitePoller_RestartAfterStop(t *testing.T) {
 	defer srv.Close()
 
 	agg, err := list.New(list.Config{
-		PublisherKeys: []list.PublisherKey{list.PublisherKey(pub.masterPub)},
-		SiteURIs:      []string{srv.URL},
-		Threshold:     1,
-		Manifests:     manifest.NewCache(),
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		SiteURIs:           []string{srv.URL},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)


### PR DESCRIPTION
## Summary

- make accepted manifests cache-owned and immutable, with exact cache-local collision handling and ordered reentrant-safe subscribers
- keep validator and publisher manifests in separate caches across validator-list, peer, consensus, RPC, and WebSocket paths
- restore and atomically persist both namespaces in a dedicated SQLite store, retaining revocations and filtering non-revoked rows by current relevance
- load before ingress, save after quiescence, and propagate startup, persistence, server-drain, archive, and storage-close failures
- add collision, mutation, callback, role-isolation, restart, rollback, close-race, and lifecycle regression coverage

## Oracle review

Compared protocol-bearing behavior with the pinned rippled v3.2.0 manifest, wallet persistence, application lifecycle, validator-list, overlay, and manifest-test implementations. The local oracle source was used read-only; its linked-worktree Git metadata was stale, so its clean status could not be independently re-queried.

## Test plan

- `go test -count=1 ./internal/manifest ./internal/validator/list ./internal/consensus/adaptor ./internal/node ./internal/rpc/handlers`
- `go test -race -count=1 ./internal/node ./internal/manifest ./internal/consensus/adaptor`
- `just test`
- `just vet`
- `just lint`
- `golangci-lint run --config .golangci.yml`
- `just build`
- `just build-all`
- `just build-nocgo`
- `git diff --check`

Fixes #1469


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifest data is now persisted locally and restored across restarts.
  * Validator and publisher manifests are maintained separately for more accurate state and revocation handling.
  * Manifest caches provide ordered snapshots, safer data access, and reliable subscription notifications.
* **Bug Fixes**
  * Improved handling of malformed, stale, revoked, and conflicting manifests.
  * Shutdown now reports combined failures from multiple services while preserving cleanup behavior.
* **Tests**
  * Expanded coverage for persistence, recovery, concurrency, cache behavior, and shutdown error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->