### PR TITLE
fix(node): make startup atomic

### DIFF
--- a/internal/cli/auxiliary.go
+++ b/internal/cli/auxiliary.go
@@ -26,8 +26,11 @@ type auxiliaryServer struct {
 
 type auxiliaryServers struct {
 	servers      []auxiliaryServer
+	pprof        bool
 	serveWG      sync.WaitGroup
+	startOnce    sync.Once
 	shutdownOnce sync.Once
+	lifecycleMu  sync.Mutex
 	shutdownErr  error
 	stopping     atomic.Bool
 }
@@ -42,6 +45,18 @@ type auxiliaryServerSpec struct {
 func startAuxiliaryServers(
 	ctx context.Context,
 	cancel context.CancelCauseFunc,
+	getenv func(string) string,
+	listen func(string, string) (net.Listener, error),
+) (*auxiliaryServers, error) {
+	aux, err := bindAuxiliaryServers(getenv, listen)
+	if err != nil {
+		return nil, err
+	}
+	aux.Start(ctx, cancel)
+	return aux, nil
+}
+
+func bindAuxiliaryServers(
 	getenv func(string) string,
 	listen func(string, string) (net.Listener, error),
 ) (*auxiliaryServers, error) {
@@ -99,36 +114,45 @@ func startAuxiliaryServers(
 				ReadHeaderTimeout: 5 * time.Second,
 			},
 		})
+		aux.pprof = aux.pprof || spec.pprof
 	}
-
-	for _, spec := range specs {
-		if spec.pprof {
-			observability.EnablePProf()
-			break
-		}
-	}
-
-	for i := range aux.servers {
-		entry := &aux.servers[i]
-		aux.serveWG.Add(1)
-		go func() {
-			defer aux.serveWG.Done()
-			if err := entry.server.Serve(entry.listener); err != nil &&
-				!errors.Is(err, http.ErrServerClosed) &&
-				!aux.stopping.Load() &&
-				ctx.Err() == nil {
-				cancel(fmt.Errorf("%s server on %s failed: %w", entry.name, entry.addr, err))
-			}
-		}()
-	}
-	if len(aux.servers) != 0 {
-		go func() {
-			<-ctx.Done()
-			_ = aux.Shutdown()
-		}()
-	}
-
 	return aux, nil
+}
+
+func (a *auxiliaryServers) Start(ctx context.Context, cancel context.CancelCauseFunc) {
+	if a == nil {
+		return
+	}
+	a.startOnce.Do(func() {
+		a.lifecycleMu.Lock()
+		defer a.lifecycleMu.Unlock()
+		if a.stopping.Load() {
+			return
+		}
+		if a.pprof {
+			observability.EnablePProf()
+		}
+
+		for i := range a.servers {
+			entry := &a.servers[i]
+			a.serveWG.Add(1)
+			go func() {
+				defer a.serveWG.Done()
+				if err := entry.server.Serve(entry.listener); err != nil &&
+					!errors.Is(err, http.ErrServerClosed) &&
+					!a.stopping.Load() &&
+					ctx.Err() == nil {
+					cancel(fmt.Errorf("%s server on %s failed: %w", entry.name, entry.addr, err))
+				}
+			}()
+		}
+		if len(a.servers) != 0 {
+			go func() {
+				<-ctx.Done()
+				_ = a.Shutdown()
+			}()
+		}
+	})
 }
 
 func (a *auxiliaryServers) Addresses() map[string]string {
@@ -144,7 +168,9 @@ func (a *auxiliaryServers) Shutdown() error {
 		return nil
 	}
 	a.shutdownOnce.Do(func() {
+		a.lifecycleMu.Lock()
 		a.stopping.Store(true)
+		a.lifecycleMu.Unlock()
 		ctx, cancel := context.WithTimeout(context.Background(), auxiliaryShutdownTimeout)
 		defer cancel()
 
@@ -154,6 +180,7 @@ func (a *auxiliaryServers) Shutdown() error {
 				errs = append(errs, fmt.Errorf("shutdown %s server: %w", a.servers[i].name, err))
 			}
 		}
+		a.closeListeners()
 		serveDone := make(chan struct{})
 		go func() {
 			a.serveWG.Wait()

--- a/internal/cli/auxiliary_test.go
+++ b/internal/cli/auxiliary_test.go
@@ -129,6 +129,43 @@ func TestStartAuxiliaryServersBindsAllBeforeServing(t *testing.T) {
 	}
 }
 
+func TestBindAuxiliaryServersWaitsForStart(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	serveErr := errors.New("listener failed")
+	var acceptCalled atomic.Bool
+	listener := &testListener{
+		addr: testAddr("127.0.0.1:9100"),
+		accept: func() (net.Conn, error) {
+			acceptCalled.Store(true)
+			return nil, serveErr
+		},
+	}
+	aux, err := bindAuxiliaryServers(
+		envValues(map[string]string{"GOXRPL_METRICS": "127.0.0.1:9100"}),
+		func(_, _ string) (net.Listener, error) { return listener, nil },
+	)
+	if err != nil {
+		t.Fatalf("bindAuxiliaryServers() error = %v", err)
+	}
+	defer aux.Shutdown()
+	if acceptCalled.Load() {
+		t.Fatal("auxiliary server began serving before Start")
+	}
+
+	aux.Start(ctx, cancel)
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("auxiliary server did not begin serving after Start")
+	}
+	if !acceptCalled.Load() {
+		t.Fatal("auxiliary listener was not accepted after Start")
+	}
+}
+
 func TestStartAuxiliaryServersServeFailureCancelsContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -35,6 +35,7 @@ type nodeRunFunc func(
 	service.StartupConfig,
 	xrpllog.Logger,
 	xrpllog.Logger,
+	func(),
 ) error
 
 func runNode(
@@ -45,8 +46,9 @@ func runNode(
 	startup service.StartupConfig,
 	rootLogger,
 	serverLog xrpllog.Logger,
+	ready func(),
 ) error {
-	return node.Run(ctx, cfg, configPath, standalone, startup, rootLogger, serverLog)
+	return node.RunWithReady(ctx, cfg, configPath, standalone, startup, rootLogger, serverLog, ready)
 }
 
 func (a *application) newServerCommand(options *serverOptions) *cobra.Command {
@@ -124,12 +126,15 @@ func (a *application) runServer(cmd *cobra.Command, options *serverOptions) erro
 
 	runCtx, cancel := context.WithCancelCause(cmd.Context())
 	defer cancel(nil)
-	auxiliary, err := startAuxiliaryServers(runCtx, cancel, os.Getenv, net.Listen)
+	auxiliary, err := bindAuxiliaryServers(os.Getenv, net.Listen)
 	if err != nil {
 		return err
 	}
-	for name, address := range auxiliary.Addresses() {
-		serverLog.Info(name+" enabled", "addr", address)
+	ready := func() {
+		auxiliary.Start(runCtx, cancel)
+		for name, address := range auxiliary.Addresses() {
+			serverLog.Info(name+" enabled", "addr", address)
+		}
 	}
 	nodeErr := a.deps.runNode(
 		runCtx,
@@ -139,6 +144,7 @@ func (a *application) runServer(cmd *cobra.Command, options *serverOptions) erro
 		startup,
 		rootLogger,
 		serverLog,
+		ready,
 	)
 	cancel(nil)
 	return errors.Join(nodeErr, auxiliary.Shutdown())

--- a/internal/cli/server_test.go
+++ b/internal/cli/server_test.go
@@ -257,6 +257,7 @@ func TestExplicitServerUsesFlagsBeforeOrAfterSubcommand(t *testing.T) {
 					standalone bool,
 					startup service.StartupConfig,
 					_, _ xrpllog.Logger,
+					_ func(),
 				) error {
 					gotStandalone = standalone
 					gotStartup = startup
@@ -296,6 +297,7 @@ func TestServerBindFailurePreventsNodeStart(t *testing.T) {
 		service.StartupConfig,
 		xrpllog.Logger,
 		xrpllog.Logger,
+		func(),
 	) error {
 		nodeStarted.Store(true)
 		return nil
@@ -324,7 +326,9 @@ func TestServerCancellationShutsDownAuxiliaryListeners(t *testing.T) {
 		_ service.StartupConfig,
 		_,
 		_ xrpllog.Logger,
+		ready func(),
 	) error {
+		ready()
 		close(started)
 		<-ctx.Done()
 		return context.Cause(ctx)

--- a/internal/node/grpc.go
+++ b/internal/node/grpc.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	rtdebug "runtime/debug"
@@ -42,58 +43,88 @@ func grpcRecoveryInterceptor(log xrpllog.Logger) googlegrpc.UnaryServerIntercept
 	}
 }
 
-// startGRPCServer binds a listener for the [port_grpc] section and serves
-// the XRPLedgerAPIService (the binary ledger surface consumed by Clio).
-// It returns the running server and its bound address; Serve runs in a
-// goroutine and reports a non-graceful exit on errCh.
-//
-// Mirrors rippled's GRPCServer: the server only exists when a [port_grpc]
-// section supplies both ip and port. secure_gateway is parsed (and an
-// unspecified address rejected, as rippled does) but does not yet alter
-// per-request handling — go-xrpl's gRPC surface has no resource-limit
-// accounting to bypass.
-func startGRPCServer(
+type boundGRPCServer struct {
+	name      string
+	address   string
+	listener  net.Listener
+	ready     <-chan struct{}
+	markReady func()
+	server    *googlegrpc.Server
+}
+
+func prepareGRPCServer(
+	ctx context.Context,
 	name string,
 	p config.PortConfig,
 	lookup xrplgrpc.LedgerLookup,
 	log xrpllog.Logger,
-	errCh chan<- error,
-) (*googlegrpc.Server, string, error) {
-	if _, err := p.ParseSecureGatewayNets(); err != nil {
-		return nil, "", fmt.Errorf("parse secure_gateway nets for grpc port %q: %w", name, err)
+	listen listenFunc,
+) (*boundGRPCServer, error) {
+	if err := validateGRPCPort(name, p); err != nil {
+		return nil, err
 	}
-	// rippled forbids an unspecified address in grpc secure_gateway
-	// (GRPCServer.cpp:361-368) — match-all would defeat the rate-limit
-	// bypass it scopes to known Clio hosts.
-	for _, entry := range p.SecureGateway {
-		if ip := net.ParseIP(strings.TrimSpace(entry)); ip != nil && ip.IsUnspecified() {
-			return nil, "", fmt.Errorf("grpc port %q: unspecified IP %q in secure_gateway", name, entry)
-		}
-	}
+	return bindGRPCServer(ctx, name, p, lookup, log, listen)
+}
 
+func bindGRPCServer(
+	ctx context.Context,
+	name string,
+	p config.PortConfig,
+	lookup xrplgrpc.LedgerLookup,
+	log xrpllog.Logger,
+	listen listenFunc,
+) (*boundGRPCServer, error) {
 	addr := p.BindAddress()
-	var lc net.ListenConfig
-	lis, err := lc.Listen(context.Background(), "tcp", addr)
+	lis, err := listen(ctx, "tcp", addr)
 	if err != nil {
-		return nil, "", fmt.Errorf("grpc listen on %s: %w", addr, err)
+		return nil, fmt.Errorf("grpc listen on %s: %w", addr, err)
 	}
 	boundAddr := lis.Addr().String()
+	readyListener := newServeReadyListener(lis)
 
 	srv := googlegrpc.NewServer(
 		googlegrpc.ChainUnaryInterceptor(grpcRecoveryInterceptor(log)),
 	)
 	rpcv1.RegisterXRPLedgerAPIServiceServer(srv, xrplgrpc.NewServer(lookup))
 
+	return &boundGRPCServer{
+		name:      name,
+		address:   boundAddr,
+		listener:  readyListener,
+		ready:     readyListener.ready,
+		markReady: readyListener.markReady,
+		server:    srv,
+	}, nil
+}
+
+func validateGRPCPort(name string, p config.PortConfig) error {
+	if _, err := p.ParseSecureGatewayNets(); err != nil {
+		return fmt.Errorf("parse secure_gateway nets for grpc port %q: %w", name, err)
+	}
+	// rippled forbids an unspecified address in grpc secure_gateway
+	// (GRPCServer.cpp:361-368) — match-all would defeat the rate-limit
+	// bypass it scopes to known Clio hosts.
+	for _, entry := range p.SecureGateway {
+		if ip := net.ParseIP(strings.TrimSpace(entry)); ip != nil && ip.IsUnspecified() {
+			return fmt.Errorf("grpc port %q: unspecified IP %q in secure_gateway", name, entry)
+		}
+	}
+	return nil
+}
+
+func (s *boundGRPCServer) serve(log xrpllog.Logger, errCh chan<- error, done func()) {
 	go func() {
-		log.Info("Listening", "protocol", "grpc", "name", name, "addr", boundAddr)
-		if err := srv.Serve(lis); err != nil {
-			log.Error("gRPC server failed", "name", name, "addr", boundAddr, "err", err)
+		if done != nil {
+			defer done()
+		}
+		defer s.markReady()
+		log.Info("Listening", "protocol", "grpc", "name", s.name, "addr", s.address)
+		if err := s.server.Serve(s.listener); err != nil && !errors.Is(err, googlegrpc.ErrServerStopped) {
+			log.Error("gRPC server failed", "name", s.name, "addr", s.address, "err", err)
 			select {
-			case errCh <- fmt.Errorf("grpc %s (%s): %w", name, boundAddr, err):
+			case errCh <- fmt.Errorf("grpc %s (%s): %w", s.name, s.address, err):
 			default:
 			}
 		}
 	}()
-
-	return srv, boundAddr, nil
 }

--- a/internal/node/grpc_test.go
+++ b/internal/node/grpc_test.go
@@ -75,13 +75,16 @@ func TestGRPCServer_RoundTrip(t *testing.T) {
 	p := config.PortConfig{Port: 0, IP: "127.0.0.1", Protocol: "grpc"}
 	errCh := make(chan error, 1)
 
-	srv, addr, err := startGRPCServer("port_grpc", p, lookup, xrpllog.Discard(), errCh)
+	bound, err := prepareGRPCServer(
+		context.Background(), "port_grpc", p, lookup, xrpllog.Discard(), systemListen,
+	)
 	if err != nil {
-		t.Fatalf("startGRPCServer: %v", err)
+		t.Fatalf("prepareGRPCServer: %v", err)
 	}
-	defer srv.GracefulStop()
+	bound.serve(xrpllog.Discard(), errCh, nil)
+	defer bound.server.GracefulStop()
 
-	conn, err := googlegrpc.NewClient(addr, googlegrpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := googlegrpc.NewClient(bound.address, googlegrpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
@@ -139,9 +142,37 @@ func TestGRPCServer_RejectsUnspecifiedSecureGateway(t *testing.T) {
 		Protocol:      "grpc",
 		SecureGateway: []string{"0.0.0.0"},
 	}
-	_, _, err := startGRPCServer("port_grpc", p, lookup, xrpllog.Discard(), make(chan error, 1))
+	_, err := prepareGRPCServer(
+		context.Background(), "port_grpc", p, lookup, xrpllog.Discard(), systemListen,
+	)
 	if err == nil {
-		t.Fatal("expected startGRPCServer to reject unspecified secure_gateway IP")
+		t.Fatal("expected prepareGRPCServer to reject unspecified secure_gateway IP")
+	}
+}
+
+func TestGRPCServer_StopBeforeServeIsNotFatal(t *testing.T) {
+	lookup := &stubLookup{validated: newStubLedger(t)}
+	p := config.PortConfig{Port: 0, IP: "127.0.0.1", Protocol: "grpc"}
+	bound, err := prepareGRPCServer(
+		context.Background(),
+		"port_grpc",
+		p,
+		lookup,
+		xrpllog.Discard(),
+		systemListen,
+	)
+	if err != nil {
+		t.Fatalf("prepareGRPCServer: %v", err)
+	}
+	defer bound.listener.Close()
+
+	bound.server.Stop()
+	errCh := make(chan error, 1)
+	bound.serve(xrpllog.Discard(), errCh, nil)
+	select {
+	case err := <-errCh:
+		t.Fatalf("stopped gRPC server reported a fatal error: %v", err)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
 	"runtime/debug"
@@ -44,7 +43,6 @@ import (
 	"github.com/LeJamon/go-xrpl/storage/relationaldb/postgres"
 	sqlitedb "github.com/LeJamon/go-xrpl/storage/relationaldb/sqlite"
 	"github.com/LeJamon/go-xrpl/version"
-	googlegrpc "google.golang.org/grpc"
 )
 
 type minimumOnlineFloorFunc func() uint32
@@ -132,7 +130,33 @@ func isFullGitHash(value string) bool {
 // Run assembles and starts every node subsystem from the parsed config, then
 // blocks until a terminating signal or fatal error. It is the composition root
 // extracted from the CLI so flag parsing and node wiring stay separable.
-func Run(ctx context.Context, appConfig *config.Config, configPath string, standalone bool, startup service.StartupConfig, rootLogger, serverLog xrpllog.Logger) (runErr error) {
+func Run(ctx context.Context, appConfig *config.Config, configPath string, standalone bool, startup service.StartupConfig, rootLogger, serverLog xrpllog.Logger) error {
+	return run(ctx, appConfig, configPath, standalone, startup, rootLogger, serverLog, nil)
+}
+
+// RunWithReady runs the node and calls ready after every configured service has
+// started successfully. The callback may start callers' pre-bound endpoints.
+func RunWithReady(
+	ctx context.Context,
+	appConfig *config.Config,
+	configPath string,
+	standalone bool,
+	startup service.StartupConfig,
+	rootLogger, serverLog xrpllog.Logger,
+	ready func(),
+) error {
+	return run(ctx, appConfig, configPath, standalone, startup, rootLogger, serverLog, ready)
+}
+
+func run(
+	ctx context.Context,
+	appConfig *config.Config,
+	configPath string,
+	standalone bool,
+	startup service.StartupConfig,
+	rootLogger, serverLog xrpllog.Logger,
+	ready func(),
+) (runErr error) {
 	if err := context.Cause(ctx); err != nil {
 		return err
 	}
@@ -151,17 +175,15 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 		ledgerCleaner       *cleaner.Cleaner
 		consensusComponents *adaptor.Components
 		rotator             *shamapstore.Rotator
-		httpSrvs            []*http.Server
-		wsSrvs              []*http.Server
+		transports          *boundRPCTransports
 		wsServer            *rpc.WebSocketServer
-		grpcSrv             *googlegrpc.Server
 		stallWatchdog       *watchdog.Watchdog
 	)
 	defer func() {
-		runErr = errors.Join(runErr, doShutdown(httpSrvs, wsSrvs, wsServer, grpcSrv, ledgerService, ledgerCleaner, consensusComponents, rotator, db, repoManager, serverLog))
+		runErr = errors.Join(runErr, doShutdown(transports, wsServer, ledgerService, ledgerCleaner, consensusComponents, rotator, db, repoManager, serverLog))
 	}()
 
-	db, repoManager, err = setupStorage(appConfig, serverLog)
+	db, repoManager, err = setupStorage(ctx, appConfig, serverLog)
 	if err != nil {
 		return err
 	}
@@ -1070,6 +1092,21 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 	if err := context.Cause(ctx); err != nil {
 		return err
 	}
+	transports, err = bindRPCTransports(
+		ctx,
+		serverLog,
+		appConfig,
+		httpServer,
+		wsServer,
+		ledgerService,
+		systemListen,
+	)
+	if err != nil {
+		return err
+	}
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 	if consensusComponents != nil {
 		if err := consensusComponents.Start(ctx); err != nil {
 			return fmt.Errorf("start consensus components: %w", err)
@@ -1078,22 +1115,12 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 	if err := context.Cause(ctx); err != nil {
 		return err
 	}
-	var listenerErrCh chan error
-	if httpSrvs, wsSrvs, listenerErrCh, err = startListeners(serverLog, appConfig, httpServer, wsServer); err != nil {
+	if err := transports.serve(serverLog); err != nil {
 		return err
 	}
-
-	// Start the gRPC XRPLedgerAPIService listener when [port_grpc] is
-	// configured. Disabled by default: no section → no listener (mirrors
-	// rippled's GRPCServer). The ledger service already satisfies the
-	// grpc.LedgerLookup surface the service implementation needs.
-	if grpcName, grpcPort, hasGRPC := appConfig.GRPCPort(); hasGRPC {
-		srv, addr, err := startGRPCServer(grpcName, grpcPort, ledgerService, serverLog, listenerErrCh)
-		if err != nil {
-			return fmt.Errorf("start grpc server: %w", err)
-		}
-		grpcSrv = srv
-		serverLog.Info("gRPC server started", "name", grpcName, "addr", addr)
+	listenerErrCh := transports.errors
+	if transports.grpc != nil {
+		serverLog.Info("gRPC server started", "name", transports.grpc.name, "addr", transports.grpc.address)
 	}
 
 	// Arm the out-of-band stall watchdog now that the server is up and
@@ -1134,6 +1161,9 @@ func Run(ctx context.Context, appConfig *config.Config, configPath string, stand
 	var componentErrCh <-chan error
 	if consensusComponents != nil {
 		componentErrCh = consensusComponents.Errors()
+	}
+	if ready != nil {
+		ready()
 	}
 	return waitForShutdown(
 		ctx,
@@ -1223,10 +1253,30 @@ func waitForShutdown(
 
 // setupStorage initializes the node store (pebble or in-memory) and the
 // optional relational DB (PostgreSQL or SQLite, used for transaction indexing)
-// from config. A node-store backend failure is fatal; a relational-DB failure
-// is logged and leaves indexing disabled (repoManager nil), as before.
-func setupStorage(cfg *config.Config, log xrpllog.Logger) (nodestore.Database, relationaldb.RepositoryManager, error) {
-	var db nodestore.Database
+// from config. An explicitly configured backend must open successfully; an
+// empty database path intentionally leaves relational storage disabled.
+func setupStorage(
+	ctx context.Context,
+	cfg *config.Config,
+	log xrpllog.Logger,
+) (db nodestore.Database, repoManager relationaldb.RepositoryManager, err error) {
+	if cause := context.Cause(ctx); cause != nil {
+		return nil, nil, cause
+	}
+	defer func() {
+		if err == nil {
+			return
+		}
+		if repoManager != nil {
+			err = errors.Join(err, repoManager.Close())
+			repoManager = nil
+		}
+		if db != nil {
+			err = errors.Join(err, db.Close())
+			db = nil
+		}
+	}()
+
 	nodestorePath := cfg.NodeDB.Path
 	if nodestorePath != "" {
 		cacheSize, cacheTTL := nodeStoreCacheParams(cfg.NodeDB, cfg.NodeSize)
@@ -1271,27 +1321,27 @@ func setupStorage(cfg *config.Config, log xrpllog.Logger) (nodestore.Database, r
 	} else {
 		log.Info("Storage initialized", "backend", "in-memory")
 	}
+	if cause := context.Cause(ctx); cause != nil {
+		return db, nil, cause
+	}
 
-	var repoManager relationaldb.RepositoryManager
 	dbPath := cfg.DatabasePath
 	if strings.HasPrefix(dbPath, "postgres://") || strings.HasPrefix(dbPath, "postgresql://") {
 		pgConfig := relationaldb.NewConfig()
 		pgConfig.ConnectionString = dbPath
 
 		var err error
-		repoManager, err = postgres.NewRepositoryManager(context.Background(), pgConfig)
+		repoManager, err = postgres.NewRepositoryManager(ctx, pgConfig)
 		if err != nil {
-			log.Warn("PostgreSQL connection failed", "err", err)
-			repoManager = nil
-		} else {
-			log.Info("PostgreSQL connected", "purpose", "transaction indexing")
+			return db, nil, fmt.Errorf("initialize PostgreSQL database: %w", err)
 		}
+		log.Info("PostgreSQL connected", "purpose", "transaction indexing")
 	} else if dbPath != "" {
 		// Default: auto-create SQLite databases at the given directory
 		// path, applying the operator's [sqlite] tuning.
 		journalMode, synchronous, tempStore := cfg.SQLite.EffectiveSettings()
 		var err error
-		repoManager, err = sqlitedb.NewRepositoryManager(context.Background(), dbPath, sqlitedb.Settings{
+		repoManager, err = sqlitedb.NewRepositoryManager(ctx, dbPath, sqlitedb.Settings{
 			JournalMode:      journalMode,
 			Synchronous:      synchronous,
 			TempStore:        tempStore,
@@ -1299,11 +1349,12 @@ func setupStorage(cfg *config.Config, log xrpllog.Logger) (nodestore.Database, r
 			JournalSizeLimit: cfg.SQLite.JournalSizeLimit,
 		})
 		if err != nil {
-			log.Warn("SQLite failed to initialize", "path", dbPath, "err", err)
-			repoManager = nil
-		} else {
-			log.Info("SQLite connected", "path", dbPath, "purpose", "transaction indexing")
+			return db, nil, fmt.Errorf("initialize SQLite database at %q: %w", dbPath, err)
 		}
+		log.Info("SQLite connected", "path", dbPath, "purpose", "transaction indexing")
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return db, repoManager, cause
 	}
 
 	return db, repoManager, nil
@@ -1324,133 +1375,6 @@ func newTxBroadcaster(overlay *peermanagement.Overlay) func([]byte) {
 		}
 		overlay.Broadcast(frame)
 	}
-}
-
-// startListeners wires the shared HTTP mux (JSON-RPC at "/" and "/rpc", health
-// at "/health") and starts one listener per configured HTTP and WebSocket port,
-// each wrapped in its own PortMiddleware so admin/secure-gateway trust is scoped
-// per port. ListenAndServe failures are funnelled into the returned channel so
-// the caller's deferred cleanup runs. On a port-config error the partially
-// started listeners are returned so the caller can still drain them.
-func startListeners(
-	log xrpllog.Logger,
-	cfg *config.Config,
-	httpServer http.Handler,
-	wsServer *rpc.WebSocketServer,
-) (httpSrvs, wsSrvs []*http.Server, listenerErrCh chan error, err error) {
-	// Shared connection limiter for all ports. Seeded with a bounded process-wide
-	// default so an unset per-port limit can't leave WS connections unbounded;
-	// [server] max_connections overrides it (negative disables the global cap).
-	connLimiter := rpc.NewConnLimiter()
-	if cfg.Server.MaxConnections != 0 {
-		connLimiter.SetGlobalLimit(cfg.Server.MaxConnections)
-	}
-	wsServer.SetConnLimiter(connLimiter)
-
-	// Build the base HTTP mux (shared handler logic, wrapped per-port below)
-	httpMux := http.NewServeMux()
-	httpMux.Handle("/", httpServer)
-	httpMux.Handle("/rpc", httpServer)
-	httpMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok","service":"go-xrpl"}`))
-	})
-
-	httpPorts := cfg.HTTPPorts()
-	wsPorts := cfg.WebSocketPorts()
-
-	for name, p := range httpPorts {
-		log.Info("Port configured", "protocol", "http", "name", name, "addr", p.BindAddress())
-	}
-	for name, p := range wsPorts {
-		log.Info("Port configured", "protocol", "ws", "name", name, "addr", p.BindAddress())
-	}
-	if _, peerPort, hasPeer := cfg.PeerPort(); hasPeer {
-		log.Info("Port configured", "protocol", "peer", "addr", peerPort.BindAddress())
-	}
-	if _, grpcPort, hasGRPC := cfg.GRPCPort(); hasGRPC {
-		log.Info("Port configured", "protocol", "grpc", "addr", grpcPort.BindAddress())
-	}
-
-	// listenerErrCh routes ListenAndServe failures back to the main
-	// goroutine so shutdown runs the deferred cleanup chain. Sized for
-	// every WS/HTTP listener plus the optional gRPC listener.
-	listenerErrCh = make(chan error, 2+len(wsPorts)+len(httpPorts))
-
-	// Start WebSocket listeners — each port gets its own mux with PortMiddleware
-	for name, p := range wsPorts {
-		pc, perr := parsePortConfig("ws", name, p)
-		if perr != nil {
-			return httpSrvs, wsSrvs, listenerErrCh, perr
-		}
-		mux := http.NewServeMux()
-		mux.Handle("/", rpc.PortMiddleware(pc, connLimiter, wsServer))
-		srv := &http.Server{Addr: p.BindAddress(), Handler: mux, ReadHeaderTimeout: 10 * time.Second}
-		wsSrvs = append(wsSrvs, srv)
-		go func(n string, s *http.Server) {
-			log.Info("Listening", "protocol", "ws", "name", n, "addr", s.Addr)
-			if err := s.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-				log.Error("WebSocket server failed", "name", n, "addr", s.Addr, "err", err)
-				select {
-				case listenerErrCh <- fmt.Errorf("ws %s (%s): %w", n, s.Addr, err):
-				default:
-				}
-			}
-		}(name, srv)
-	}
-
-	// Start HTTP listeners — each port gets its own mux with PortMiddleware.
-	// SecureGatewayNets are scoped per-port via PortContext so XFF trust
-	// for one port never bleeds across to another (matches rippled, which
-	// passes a single Port& into requestRole / forwardedFor —
-	// ServerHandler.cpp:709-734).
-	httpPortList := make([]struct {
-		name string
-		pc   *rpc.PortContext
-		addr string
-	}, 0, len(httpPorts))
-	for name, p := range httpPorts {
-		pc, perr := parsePortConfig("http", name, p)
-		if perr != nil {
-			return httpSrvs, wsSrvs, listenerErrCh, perr
-		}
-		httpPortList = append(httpPortList, struct {
-			name string
-			pc   *rpc.PortContext
-			addr string
-		}{name, pc, p.BindAddress()})
-	}
-
-	if len(httpPortList) == 0 {
-		return httpSrvs, wsSrvs, listenerErrCh, fmt.Errorf("no HTTP ports configured — at least one HTTP port is required")
-	}
-
-	for _, entry := range httpPortList {
-		wrappedMux := http.NewServeMux()
-		wrappedMux.Handle("/", rpc.PortMiddleware(entry.pc, connLimiter, httpMux))
-		srv := &http.Server{
-			Addr:              entry.addr,
-			Handler:           wrappedMux,
-			ReadHeaderTimeout: httpReadHeaderTimeout,
-			ReadTimeout:       httpReadTimeout,
-			WriteTimeout:      httpWriteTimeout,
-			IdleTimeout:       httpIdleTimeout,
-		}
-		httpSrvs = append(httpSrvs, srv)
-		go func(n, addr string, s *http.Server) {
-			log.Info("Listening", "protocol", "http", "name", n, "addr", addr)
-			if err := s.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-				log.Error("HTTP server failed", "name", n, "addr", addr, "err", err)
-				select {
-				case listenerErrCh <- fmt.Errorf("http %s (%s): %w", n, addr, err):
-				default:
-				}
-			}
-		}(entry.name, entry.addr, srv)
-	}
-
-	return httpSrvs, wsSrvs, listenerErrCh, nil
 }
 
 // HTTP transport timeouts. httpWriteTimeout must stay strictly greater than
@@ -1611,9 +1535,8 @@ func applyValidatorReload(serverLog xrpllog.Logger, reloader staticValidatorRelo
 
 // doShutdown performs graceful shutdown of all server components
 func doShutdown(
-	httpSrvs, wsSrvs []*http.Server,
+	transports *boundRPCTransports,
 	wsServer *rpc.WebSocketServer,
-	grpcSrv *googlegrpc.Server,
 	ledgerService *service.Service,
 	ledgerCleaner *cleaner.Cleaner,
 	consensusComponents *adaptor.Components,
@@ -1628,23 +1551,25 @@ func doShutdown(
 	defer cancel()
 
 	logger.Info("Draining HTTP connections...")
-	for _, srv := range httpSrvs {
-		if err := srv.Shutdown(ctx); err != nil {
-			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("shutdown HTTP server: %w", err))
-			logger.Warn("HTTP server graceful shutdown failed", "err", err)
-			if closeErr := srv.Close(); closeErr != nil {
-				shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close HTTP server: %w", closeErr))
-				logger.Warn("HTTP server forced close failed", "err", closeErr)
+	if transports != nil {
+		for _, bound := range transports.http {
+			if err := bound.server.Shutdown(ctx); err != nil {
+				shutdownErr = errors.Join(shutdownErr, fmt.Errorf("shutdown HTTP server: %w", err))
+				logger.Warn("HTTP server graceful shutdown failed", "err", err)
+				if closeErr := bound.server.Close(); closeErr != nil {
+					shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close HTTP server: %w", closeErr))
+					logger.Warn("HTTP server forced close failed", "err", closeErr)
+				}
 			}
 		}
-	}
-	for _, srv := range wsSrvs {
-		if err := srv.Shutdown(ctx); err != nil {
-			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("shutdown WebSocket HTTP server: %w", err))
-			logger.Warn("WebSocket HTTP server graceful shutdown failed", "err", err)
-			if closeErr := srv.Close(); closeErr != nil {
-				shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close WebSocket HTTP server: %w", closeErr))
-				logger.Warn("WebSocket HTTP server forced close failed", "err", closeErr)
+		for _, bound := range transports.ws {
+			if err := bound.server.Shutdown(ctx); err != nil {
+				shutdownErr = errors.Join(shutdownErr, fmt.Errorf("shutdown WebSocket HTTP server: %w", err))
+				logger.Warn("WebSocket HTTP server graceful shutdown failed", "err", err)
+				if closeErr := bound.server.Close(); closeErr != nil {
+					shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close WebSocket HTTP server: %w", closeErr))
+					logger.Warn("WebSocket HTTP server forced close failed", "err", closeErr)
+				}
 			}
 		}
 	}
@@ -1656,20 +1581,24 @@ func doShutdown(
 		}
 	}
 
-	if grpcSrv != nil {
+	if transports != nil && transports.grpc != nil {
 		logger.Info("Draining gRPC connections...")
 		stopped := make(chan struct{})
 		go func() {
-			grpcSrv.GracefulStop()
+			transports.grpc.server.GracefulStop()
 			close(stopped)
 		}()
 		select {
 		case <-stopped:
 		case <-ctx.Done():
-			grpcSrv.Stop()
+			transports.grpc.server.Stop()
 			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("drain gRPC server: %w", ctx.Err()))
 			logger.Warn("gRPC server graceful shutdown timed out; forced stop")
 		}
+	}
+	if transports != nil {
+		_ = transports.closeListeners()
+		transports.wait()
 	}
 
 	if rotator != nil {

--- a/internal/node/server_test.go
+++ b/internal/node/server_test.go
@@ -284,7 +284,7 @@ func TestDoShutdown_ToleratesNilComponents(t *testing.T) {
 	// criterion is "doesn't crash": WebSocketServer.Close dereferences its
 	// receiver on the first line (connectionsMutex.Lock), so a nil wsServer
 	// would panic without the guard this test pins.
-	if err := doShutdown(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, xrpllog.Discard()); err != nil {
+	if err := doShutdown(nil, nil, nil, nil, nil, nil, nil, nil, xrpllog.Discard()); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -292,7 +292,7 @@ func TestDoShutdown_ToleratesNilComponents(t *testing.T) {
 func TestDoShutdownReturnsConsensusPersistenceFailure(t *testing.T) {
 	want := errors.New("manifest persistence failed")
 	components := &adaptor.Components{Engine: &shutdownErrorEngine{err: want}}
-	err := doShutdown(nil, nil, nil, nil, nil, nil, components, nil, nil, nil, xrpllog.Discard())
+	err := doShutdown(nil, nil, nil, nil, components, nil, nil, nil, xrpllog.Discard())
 	if !errors.Is(err, want) {
 		t.Fatalf("doShutdown error = %v, want %v", err, want)
 	}
@@ -302,8 +302,6 @@ func TestDoShutdownReturnsStorageCloseFailures(t *testing.T) {
 	nodeStoreErr := errors.New("node store close failed")
 	repositoryErr := errors.New("repository close failed")
 	err := doShutdown(
-		nil,
-		nil,
 		nil,
 		nil,
 		nil,

--- a/internal/node/storage_rotation_test.go
+++ b/internal/node/storage_rotation_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -18,14 +19,14 @@ func TestSetupStorageKeepsGenerationManifestWhenOnlineDeleteIsDisabled(t *testin
 			OnlineDelete: 256,
 		},
 	}
-	db, _, err := setupStorage(cfg, xrpllog.Discard())
+	db, _, err := setupStorage(context.Background(), cfg, xrpllog.Discard())
 	require.NoError(t, err)
 	_, ok := db.(nodestore.GenerationDatabase)
 	require.True(t, ok)
 	require.NoError(t, db.Close())
 
 	cfg.NodeDB.OnlineDelete = 0
-	reopened, _, err := setupStorage(cfg, xrpllog.Discard())
+	reopened, _, err := setupStorage(context.Background(), cfg, xrpllog.Discard())
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
 	_, ok = reopened.(nodestore.GenerationDatabase)

--- a/internal/node/storage_startup_test.go
+++ b/internal/node/storage_startup_test.go
@@ -1,0 +1,118 @@
+package node
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/config"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupStorageAllowsUnconfiguredRelationalDatabase(t *testing.T) {
+	db, repo, err := setupStorage(context.Background(), &config.Config{}, xrpllog.Discard())
+	require.NoError(t, err)
+	require.Nil(t, db)
+	require.Nil(t, repo)
+}
+
+func TestSetupStorageRejectsUnavailablePostgreSQL(t *testing.T) {
+	cfg := &config.Config{
+		DatabasePath: "postgres://127.0.0.1:1/xrpl?connect_timeout=1",
+	}
+
+	started := time.Now()
+	db, repo, err := setupStorage(context.Background(), cfg, xrpllog.Discard())
+	require.ErrorContains(t, err, "initialize PostgreSQL database")
+	require.Less(t, time.Since(started), 5*time.Second)
+	require.Nil(t, db)
+	require.Nil(t, repo)
+}
+
+func TestSetupStorageRejectsInvalidSQLitePath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(path, []byte("occupied"), 0o600))
+
+	db, repo, err := setupStorage(context.Background(), &config.Config{DatabasePath: path}, xrpllog.Discard())
+	require.ErrorContains(t, err, "initialize SQLite database")
+	require.Nil(t, db)
+	require.Nil(t, repo)
+}
+
+func TestSetupStorageClosesNodeStoreWhenRelationalStorageFails(t *testing.T) {
+	root := t.TempDir()
+	nodeStorePath := filepath.Join(root, "node-store")
+	databasePath := filepath.Join(root, "not-a-directory")
+	require.NoError(t, os.WriteFile(databasePath, []byte("occupied"), 0o600))
+	cfg := &config.Config{
+		NodeDB:       config.NodeDBConfig{Path: nodeStorePath},
+		DatabasePath: databasePath,
+	}
+
+	db, repo, err := setupStorage(context.Background(), cfg, xrpllog.Discard())
+	require.ErrorContains(t, err, "initialize SQLite database")
+	require.Nil(t, db)
+	require.Nil(t, repo)
+
+	cfg.DatabasePath = ""
+	reopened, _, err := setupStorage(context.Background(), cfg, xrpllog.Discard())
+	require.NoError(t, err)
+	require.NoError(t, reopened.Close())
+}
+
+func TestSetupStorageHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	nodeStorePath := filepath.Join(t.TempDir(), "node-store")
+
+	db, repo, err := setupStorage(ctx, &config.Config{
+		NodeDB:       config.NodeDBConfig{Path: nodeStorePath},
+		DatabasePath: "postgres://127.0.0.1:1/xrpl?connect_timeout=30",
+	}, xrpllog.Discard())
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, db)
+	require.Nil(t, repo)
+	_, statErr := os.Stat(nodeStorePath)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestRunDoesNotBindRPCWhenRelationalStorageFails(t *testing.T) {
+	reserved, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	address := reserved.Addr().String()
+	require.NoError(t, reserved.Close())
+	_, portText, err := net.SplitHostPort(address)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+
+	databasePath := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(databasePath, []byte("occupied"), 0o600))
+	cfg := &config.Config{
+		DatabasePath: databasePath,
+		Ports: map[string]config.PortConfig{
+			"rpc": {IP: "127.0.0.1", Port: port, Protocol: "http"},
+		},
+	}
+
+	err = Run(
+		context.Background(),
+		cfg,
+		"",
+		true,
+		service.StartupConfig{},
+		xrpllog.Discard(),
+		xrpllog.Discard(),
+	)
+	require.ErrorContains(t, err, "initialize SQLite database")
+
+	rebound, err := net.Listen("tcp", address)
+	require.NoError(t, err)
+	require.NoError(t, rebound.Close())
+}

--- a/internal/node/transports.go
+++ b/internal/node/transports.go
@@ -1,0 +1,249 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/config"
+	xrplgrpc "github.com/LeJamon/go-xrpl/internal/grpc"
+	"github.com/LeJamon/go-xrpl/internal/rpc"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+)
+
+type listenFunc func(context.Context, string, string) (net.Listener, error)
+
+func systemListen(ctx context.Context, network, address string) (net.Listener, error) {
+	var cfg net.ListenConfig
+	return cfg.Listen(ctx, network, address)
+}
+
+type boundHTTPServer struct {
+	name      string
+	protocol  string
+	address   string
+	listener  net.Listener
+	ready     <-chan struct{}
+	markReady func()
+	server    *http.Server
+}
+
+type boundRPCTransports struct {
+	http    []*boundHTTPServer
+	ws      []*boundHTTPServer
+	grpc    *boundGRPCServer
+	errors  chan error
+	serveWG sync.WaitGroup
+}
+
+type serveReadyListener struct {
+	net.Listener
+	once  sync.Once
+	ready chan struct{}
+}
+
+func newServeReadyListener(listener net.Listener) *serveReadyListener {
+	return &serveReadyListener{Listener: listener, ready: make(chan struct{})}
+}
+
+func (l *serveReadyListener) Accept() (net.Conn, error) {
+	l.markReady()
+	return l.Listener.Accept()
+}
+
+func (l *serveReadyListener) markReady() {
+	l.once.Do(func() { close(l.ready) })
+}
+
+func bindRPCTransports(
+	ctx context.Context,
+	log xrpllog.Logger,
+	cfg *config.Config,
+	httpHandler http.Handler,
+	wsServer *rpc.WebSocketServer,
+	grpcLookup xrplgrpc.LedgerLookup,
+	listen listenFunc,
+) (_ *boundRPCTransports, err error) {
+	connLimiter := rpc.NewConnLimiter()
+	if cfg.Server.MaxConnections != 0 {
+		connLimiter.SetGlobalLimit(cfg.Server.MaxConnections)
+	}
+	wsServer.SetConnLimiter(connLimiter)
+
+	httpMux := http.NewServeMux()
+	httpMux.Handle("/", httpHandler)
+	httpMux.Handle("/rpc", httpHandler)
+	httpMux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok","service":"go-xrpl"}`))
+	})
+
+	httpPorts := cfg.HTTPPorts()
+	wsPorts := cfg.WebSocketPorts()
+	if len(httpPorts) == 0 {
+		return nil, fmt.Errorf("no HTTP ports configured — at least one HTTP port is required")
+	}
+
+	httpNames := sortedPortNames(httpPorts)
+	wsNames := sortedPortNames(wsPorts)
+	bound := &boundRPCTransports{
+		http:   make([]*boundHTTPServer, 0, len(httpNames)),
+		ws:     make([]*boundHTTPServer, 0, len(wsNames)),
+		errors: make(chan error, 2+len(wsNames)+len(httpNames)),
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, bound.closeListeners())
+		}
+	}()
+
+	for _, name := range wsNames {
+		p := wsPorts[name]
+		pc, parseErr := parsePortConfig("ws", name, p)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		mux := http.NewServeMux()
+		mux.Handle("/", rpc.PortMiddleware(pc, connLimiter, wsServer))
+		srv := &http.Server{Addr: p.BindAddress(), Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+		bound.ws = append(bound.ws, &boundHTTPServer{
+			name: name, protocol: "ws", address: srv.Addr, server: srv,
+		})
+	}
+
+	for _, name := range httpNames {
+		p := httpPorts[name]
+		pc, parseErr := parsePortConfig("http", name, p)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		mux := http.NewServeMux()
+		mux.Handle("/", rpc.PortMiddleware(pc, connLimiter, httpMux))
+		srv := &http.Server{
+			Addr:              p.BindAddress(),
+			Handler:           mux,
+			ReadHeaderTimeout: httpReadHeaderTimeout,
+			ReadTimeout:       httpReadTimeout,
+			WriteTimeout:      httpWriteTimeout,
+			IdleTimeout:       httpIdleTimeout,
+		}
+		bound.http = append(bound.http, &boundHTTPServer{
+			name: name, protocol: "http", address: srv.Addr, server: srv,
+		})
+	}
+
+	grpcName, grpcPort, hasGRPC := cfg.GRPCPort()
+	if hasGRPC {
+		if validateErr := validateGRPCPort(grpcName, grpcPort); validateErr != nil {
+			return nil, validateErr
+		}
+	}
+	for _, server := range append(append([]*boundHTTPServer(nil), bound.ws...), bound.http...) {
+		log.Info("Port configured", "protocol", server.protocol, "name", server.name, "addr", server.address)
+	}
+	if _, peerPort, ok := cfg.PeerPort(); ok {
+		log.Info("Port configured", "protocol", "peer", "addr", peerPort.BindAddress())
+	}
+	if hasGRPC {
+		log.Info("Port configured", "protocol", "grpc", "name", grpcName, "addr", grpcPort.BindAddress())
+	}
+
+	for _, server := range append(append([]*boundHTTPServer(nil), bound.ws...), bound.http...) {
+		listener, listenErr := listen(ctx, "tcp", server.address)
+		if listenErr != nil {
+			return nil, fmt.Errorf("%s %s listen on %s: %w", server.protocol, server.name, server.address, listenErr)
+		}
+		readyListener := newServeReadyListener(listener)
+		server.listener = readyListener
+		server.ready = readyListener.ready
+		server.markReady = readyListener.markReady
+		server.address = listener.Addr().String()
+	}
+
+	if hasGRPC {
+		grpcServer, grpcErr := bindGRPCServer(ctx, grpcName, grpcPort, grpcLookup, log, listen)
+		if grpcErr != nil {
+			return nil, grpcErr
+		}
+		bound.grpc = grpcServer
+	}
+
+	return bound, nil
+}
+
+func sortedPortNames(ports map[string]config.PortConfig) []string {
+	names := make([]string, 0, len(ports))
+	for name := range ports {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (t *boundRPCTransports) serve(log xrpllog.Logger) error {
+	servers := append(append([]*boundHTTPServer(nil), t.ws...), t.http...)
+	t.serveWG.Add(len(servers))
+	for _, bound := range servers {
+		go func(s *boundHTTPServer) {
+			defer t.serveWG.Done()
+			defer s.markReady()
+			log.Info("Listening", "protocol", s.protocol, "name", s.name, "addr", s.address)
+			if err := s.server.Serve(s.listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				log.Error(s.protocol+" server failed", "name", s.name, "addr", s.address, "err", err)
+				select {
+				case t.errors <- fmt.Errorf("%s %s (%s): %w", s.protocol, s.name, s.address, err):
+				default:
+				}
+			}
+		}(bound)
+	}
+	if t.grpc != nil {
+		t.serveWG.Add(1)
+		t.grpc.serve(log, t.errors, t.serveWG.Done)
+	}
+	for _, server := range servers {
+		<-server.ready
+	}
+	if t.grpc != nil {
+		<-t.grpc.ready
+	}
+	select {
+	case err := <-t.errors:
+		return err
+	default:
+		return nil
+	}
+}
+
+func (t *boundRPCTransports) wait() {
+	if t != nil {
+		t.serveWG.Wait()
+	}
+}
+
+func (t *boundRPCTransports) closeListeners() error {
+	if t == nil {
+		return nil
+	}
+	var errs []error
+	for _, bound := range append(append([]*boundHTTPServer(nil), t.ws...), t.http...) {
+		if bound.listener == nil {
+			continue
+		}
+		if err := bound.listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			errs = append(errs, err)
+		}
+	}
+	if t.grpc != nil {
+		if err := t.grpc.listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/internal/node/transports_test.go
+++ b/internal/node/transports_test.go
@@ -1,0 +1,217 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/config"
+	"github.com/LeJamon/go-xrpl/internal/rpc"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindRPCTransportsValidatesAllPortsBeforeBinding(t *testing.T) {
+	cfg := &config.Config{Ports: map[string]config.PortConfig{
+		"a_ws": {
+			IP: "127.0.0.1", Port: 10001, Protocol: "ws",
+		},
+		"b_http": {
+			IP: "127.0.0.1", Port: 10002, Protocol: "http", Admin: []string{"invalid network"},
+		},
+	}}
+	var calls atomic.Int32
+
+	bound, err := bindRPCTransports(
+		context.Background(),
+		xrpllog.Discard(),
+		cfg,
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		rpc.NewWebSocketServer(time.Second, nil),
+		nil,
+		func(context.Context, string, string) (net.Listener, error) {
+			calls.Add(1)
+			return nil, errors.New("must not bind")
+		},
+	)
+	require.ErrorContains(t, err, "parse admin nets")
+	require.Nil(t, bound)
+	require.Zero(t, calls.Load())
+}
+
+func TestBindRPCTransportsClosesEarlierListenersOnLaterFailure(t *testing.T) {
+	cfg := &config.Config{Ports: map[string]config.PortConfig{
+		"a_http": {IP: "127.0.0.1", Port: 10001, Protocol: "http"},
+		"b_http": {IP: "127.0.0.1", Port: 10002, Protocol: "http"},
+	}}
+	wantErr := errors.New("occupied")
+	var first net.Listener
+	var calls atomic.Int32
+
+	bound, err := bindRPCTransports(
+		context.Background(),
+		xrpllog.Discard(),
+		cfg,
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		rpc.NewWebSocketServer(time.Second, nil),
+		nil,
+		func(context.Context, string, string) (net.Listener, error) {
+			if calls.Add(1) == 2 {
+				return nil, wantErr
+			}
+			listener, listenErr := net.Listen("tcp", "127.0.0.1:0")
+			first = listener
+			return listener, listenErr
+		},
+	)
+	require.ErrorIs(t, err, wantErr)
+	require.Nil(t, bound)
+	require.NotNil(t, first)
+	_, acceptErr := first.Accept()
+	require.ErrorIs(t, acceptErr, net.ErrClosed)
+}
+
+func TestBindRPCTransportsClosesHTTPWhenGRPCBindFails(t *testing.T) {
+	cfg := &config.Config{Ports: map[string]config.PortConfig{
+		"a_http": {IP: "127.0.0.1", Port: 10001, Protocol: "http"},
+		"b_grpc": {IP: "127.0.0.1", Port: 10002, Protocol: "grpc"},
+	}}
+	wantErr := errors.New("grpc occupied")
+	var first net.Listener
+	var calls atomic.Int32
+
+	bound, err := bindRPCTransports(
+		context.Background(),
+		xrpllog.Discard(),
+		cfg,
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		rpc.NewWebSocketServer(time.Second, nil),
+		&stubLookup{},
+		func(context.Context, string, string) (net.Listener, error) {
+			if calls.Add(1) == 2 {
+				return nil, wantErr
+			}
+			listener, listenErr := net.Listen("tcp", "127.0.0.1:0")
+			first = listener
+			return listener, listenErr
+		},
+	)
+	require.ErrorIs(t, err, wantErr)
+	require.Nil(t, bound)
+	require.NotNil(t, first)
+	_, acceptErr := first.Accept()
+	require.ErrorIs(t, acceptErr, net.ErrClosed)
+}
+
+type trackingListener struct {
+	net.Listener
+	accepts atomic.Int32
+}
+
+func (l *trackingListener) Accept() (net.Conn, error) {
+	l.accepts.Add(1)
+	return l.Listener.Accept()
+}
+
+func TestBoundRPCTransportsDoNotServeBeforeCommit(t *testing.T) {
+	cfg := &config.Config{Ports: map[string]config.PortConfig{
+		"http": {IP: "127.0.0.1", Port: 10001, Protocol: "http"},
+	}}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	tracked := &trackingListener{Listener: listener}
+
+	bound, err := bindRPCTransports(
+		context.Background(),
+		xrpllog.Discard(),
+		cfg,
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		rpc.NewWebSocketServer(time.Second, nil),
+		nil,
+		func(context.Context, string, string) (net.Listener, error) { return tracked, nil },
+	)
+	require.NoError(t, err)
+	require.Zero(t, tracked.accepts.Load())
+
+	require.NoError(t, bound.serve(xrpllog.Discard()))
+	require.Eventually(t, func() bool { return tracked.accepts.Load() > 0 }, time.Second, time.Millisecond)
+	require.NoError(t, bound.http[0].server.Close())
+	require.NoError(t, bound.closeListeners())
+	bound.wait()
+}
+
+func TestBoundRPCTransportsServeAndJoinAllProtocols(t *testing.T) {
+	cfg := &config.Config{Ports: map[string]config.PortConfig{
+		"http": {IP: "127.0.0.1", Port: 0, Protocol: "http"},
+		"ws":   {IP: "127.0.0.1", Port: 0, Protocol: "ws"},
+		"grpc": {IP: "127.0.0.1", Port: 0, Protocol: "grpc"},
+	}}
+	bound, err := bindRPCTransports(
+		context.Background(),
+		xrpllog.Discard(),
+		cfg,
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		rpc.NewWebSocketServer(time.Second, nil),
+		&stubLookup{},
+		systemListen,
+	)
+	require.NoError(t, err)
+	require.NoError(t, bound.serve(xrpllog.Discard()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	for _, server := range append(append([]*boundHTTPServer(nil), bound.ws...), bound.http...) {
+		require.NoError(t, server.server.Shutdown(ctx))
+	}
+	bound.grpc.server.Stop()
+	require.NoError(t, bound.closeListeners())
+	done := make(chan struct{})
+	go func() {
+		bound.wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("transport Serve goroutines did not stop")
+	}
+	select {
+	case err := <-bound.errors:
+		t.Fatalf("graceful transport stop reported a fatal error: %v", err)
+	default:
+	}
+}
+
+func TestBoundRPCTransportsPreStoppedServersDoNotBlockServe(t *testing.T) {
+	cfg := &config.Config{Ports: map[string]config.PortConfig{
+		"http": {IP: "127.0.0.1", Port: 0, Protocol: "http"},
+		"grpc": {IP: "127.0.0.1", Port: 0, Protocol: "grpc"},
+	}}
+	bound, err := bindRPCTransports(
+		context.Background(),
+		xrpllog.Discard(),
+		cfg,
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		rpc.NewWebSocketServer(time.Second, nil),
+		&stubLookup{},
+		systemListen,
+	)
+	require.NoError(t, err)
+	require.NoError(t, bound.http[0].server.Close())
+	bound.grpc.server.Stop()
+
+	done := make(chan error, 1)
+	go func() { done <- bound.serve(xrpllog.Discard()) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("serve blocked after transports were stopped before serving")
+	}
+	require.NoError(t, bound.closeListeners())
+	bound.wait()
+}


### PR DESCRIPTION
## Summary

- fail startup when explicitly configured PostgreSQL or SQLite storage cannot be opened
- validate and synchronously bind every configured transport before any endpoint serves
- install shutdown hooks and wire consensus providers and callbacks before liveness
- unwind every acquired listener and dependency deterministically on partial startup failure

## Stack

Layer 1 of 5 for #1470. This PR targets main and is followed by #1528.

Part of #1470.

## Testing

- go test ./internal/node ./internal/cli
- go test -race ./internal/node
- just test-core
- just test
- just vet
- just lint
- just build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup sequencing so network endpoints become available only after the node is ready.
  * Improved shutdown handling for HTTP, WebSocket, gRPC, and auxiliary services.
  * Prevented expected server stops from being reported as fatal errors.
  * Startup now fails cleanly when configured storage is unavailable, invalid, or canceled.
  * Improved cleanup of partially initialized resources after startup failures.

* **Reliability**
  * Added stronger validation and cleanup when endpoint binding fails.
  * Improved coordination across service startup, readiness, cancellation, and shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->