### PR TITLE
fix(node): supervise runtime lifecycle

### DIFF
--- a/internal/cli/auxiliary.go
+++ b/internal/cli/auxiliary.go
@@ -135,6 +135,7 @@ func (a *auxiliaryServers) Start(ctx context.Context, cancel context.CancelCause
 
 		for i := range a.servers {
 			entry := &a.servers[i]
+			entry.server.BaseContext = func(net.Listener) context.Context { return ctx }
 			a.serveWG.Add(1)
 			go func() {
 				defer a.serveWG.Done()

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -32,6 +32,7 @@ type commandDependencies struct {
 	loadConfig func(config.Paths) (*config.Config, error)
 	httpClient *http.Client
 	runNode    nodeRunFunc
+	reload     <-chan os.Signal
 }
 
 type application struct {
@@ -130,8 +131,21 @@ func (a *application) requireConfig(skipValidators bool) (*config.Config, error)
 }
 
 func Run(ctx context.Context, args []string, streams IOStreams) int {
-	root := NewRootCommand(streams)
-	return executeRoot(ctx, root, args)
+	return runWithSignalSource(ctx, args, streams, systemProcessSignals)
+}
+
+func runWithSignalSource(
+	ctx context.Context,
+	args []string,
+	streams IOStreams,
+	source processSignalSource,
+) int {
+	signals := source(ctx)
+	defer signals.stop()
+	deps := defaultCommandDependencies()
+	deps.reload = signals.reload
+	root := newRootCommand(streams, deps)
+	return executeRoot(signals.ctx, root, args)
 }
 
 func executeRoot(ctx context.Context, root *cobra.Command, args []string) int {

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -36,6 +36,8 @@ type nodeRunFunc func(
 	xrpllog.Logger,
 	xrpllog.Logger,
 	func(),
+	func(),
+	<-chan os.Signal,
 ) error
 
 func runNode(
@@ -47,8 +49,14 @@ func runNode(
 	rootLogger,
 	serverLog xrpllog.Logger,
 	ready func(),
+	stopping func(),
+	reload <-chan os.Signal,
 ) error {
-	return node.RunWithReady(ctx, cfg, configPath, standalone, startup, rootLogger, serverLog, ready)
+	return node.RunWithOptions(ctx, cfg, configPath, standalone, startup, rootLogger, serverLog, node.RunOptions{
+		Ready:    ready,
+		Stopping: stopping,
+		Reload:   reload,
+	})
 }
 
 func (a *application) newServerCommand(options *serverOptions) *cobra.Command {
@@ -85,13 +93,28 @@ func (a *application) serverRunner(options *serverOptions) func(*cobra.Command, 
 	}
 }
 
-func (a *application) runServer(cmd *cobra.Command, options *serverOptions) error {
+func (a *application) runServer(cmd *cobra.Command, options *serverOptions) (resultErr error) {
+	runCtx, cancel := context.WithCancelCause(cmd.Context())
+	defer cancel(nil)
+	defer func() {
+		cause := context.Cause(runCtx)
+		if isProcessSignal(cause) && wrapsOnly(resultErr, cause) {
+			resultErr = nil
+		}
+	}()
+	if cause := context.Cause(runCtx); cause != nil {
+		return cause
+	}
+
 	cfg, err := a.requireConfig(options.standalone)
 	if err != nil {
 		// Fold the guidance into the error so Execute() prints it once. A bare
 		// pre-print here would duplicate the message Execute() emits.
 		return fmt.Errorf("%w\n  Use 'xrpld generate-config' to create an initial configuration file."+
 			"\n  Example: xrpld server --conf /path/to/xrpld.toml", err)
+	}
+	if cause := context.Cause(runCtx); cause != nil {
+		return cause
 	}
 
 	startup, err := startupConfig(
@@ -124,8 +147,6 @@ func (a *application) runServer(cmd *cobra.Command, options *serverOptions) erro
 
 	serverLog.Info("Starting go-xrpl", "version", version.Version)
 
-	runCtx, cancel := context.WithCancelCause(cmd.Context())
-	defer cancel(nil)
 	auxiliary, err := bindAuxiliaryServers(os.Getenv, net.Listen)
 	if err != nil {
 		return err
@@ -145,6 +166,8 @@ func (a *application) runServer(cmd *cobra.Command, options *serverOptions) erro
 		rootLogger,
 		serverLog,
 		ready,
+		func() { cancel(nil) },
+		a.deps.reload,
 	)
 	cancel(nil)
 	return errors.Join(nodeErr, auxiliary.Shutdown())

--- a/internal/cli/server_test.go
+++ b/internal/cli/server_test.go
@@ -258,6 +258,8 @@ func TestExplicitServerUsesFlagsBeforeOrAfterSubcommand(t *testing.T) {
 					startup service.StartupConfig,
 					_, _ xrpllog.Logger,
 					_ func(),
+					_ func(),
+					_ <-chan os.Signal,
 				) error {
 					gotStandalone = standalone
 					gotStartup = startup
@@ -298,6 +300,8 @@ func TestServerBindFailurePreventsNodeStart(t *testing.T) {
 		xrpllog.Logger,
 		xrpllog.Logger,
 		func(),
+		func(),
+		<-chan os.Signal,
 	) error {
 		nodeStarted.Store(true)
 		return nil
@@ -327,6 +331,8 @@ func TestServerCancellationShutsDownAuxiliaryListeners(t *testing.T) {
 		_,
 		_ xrpllog.Logger,
 		ready func(),
+		_ func(),
+		_ <-chan os.Signal,
 	) error {
 		ready()
 		close(started)
@@ -360,6 +366,51 @@ func TestServerCancellationShutsDownAuxiliaryListeners(t *testing.T) {
 	listener, err := net.Listen("tcp", address)
 	require.NoError(t, err, "auxiliary listener was not released")
 	require.NoError(t, listener.Close())
+}
+
+func TestServerProcessSignalCancelsNodeBeforeReady(t *testing.T) {
+	configPath := writeServerTestConfig(t)
+	address := availableLoopbackAddress(t)
+	t.Setenv("GOXRPL_PPROF", "")
+	t.Setenv("GOXRPL_METRICS", address)
+	t.Setenv("GOXRPL_PPROF_ALLOW_UNSAFE", "")
+
+	nodeStarted := make(chan struct{})
+	deps := defaultCommandDependencies()
+	deps.runNode = func(
+		ctx context.Context,
+		_ *config.Config,
+		_ string,
+		_ bool,
+		_ service.StartupConfig,
+		_, _ xrpllog.Logger,
+		_ func(),
+		_ func(),
+		_ <-chan os.Signal,
+	) error {
+		close(nodeStarted)
+		<-ctx.Done()
+		return context.Cause(ctx)
+	}
+	root := newRootCommand(IOStreams{Out: bytes.NewBuffer(nil), ErrOut: bytes.NewBuffer(nil)}, deps)
+	root.SetArgs([]string{"--conf", configPath, "server", "--standalone"})
+	ctx, cancel := context.WithCancelCause(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := root.ExecuteContextC(ctx)
+		result <- err
+	}()
+	<-nodeStarted
+	cancel(&processSignalError{signal: os.Interrupt})
+	select {
+	case err := <-result:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("server did not stop after process signal")
+	}
+	rebound, err := net.Listen("tcp", address)
+	require.NoError(t, err)
+	require.NoError(t, rebound.Close())
 }
 
 func writeServerTestConfig(t *testing.T) string {

--- a/internal/cli/signals.go
+++ b/internal/cli/signals.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+type processSignalError struct {
+	signal os.Signal
+}
+
+func (e *processSignalError) Error() string {
+	return fmt.Sprintf("received %s", e.signal)
+}
+
+type processSignals struct {
+	ctx    context.Context
+	reload <-chan os.Signal
+	stop   func()
+}
+
+type processSignalSource func(context.Context) processSignals
+
+func systemProcessSignals(parent context.Context) processSignals {
+	return subscribeProcessSignals(parent, signal.Notify, signal.Stop)
+}
+
+func subscribeProcessSignals(
+	parent context.Context,
+	notify func(chan<- os.Signal, ...os.Signal),
+	stop func(chan<- os.Signal),
+) processSignals {
+	termination := make(chan os.Signal, 1)
+	reload := make(chan os.Signal, 1)
+	notify(termination, syscall.SIGINT, syscall.SIGTERM)
+	notify(reload, syscall.SIGHUP)
+
+	ctx, cancel := context.WithCancelCause(parent)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		select {
+		case received := <-termination:
+			cancel(&processSignalError{signal: received})
+		case <-ctx.Done():
+		}
+	}()
+
+	var stopOnce sync.Once
+	return processSignals{
+		ctx:    ctx,
+		reload: reload,
+		stop: func() {
+			stopOnce.Do(func() {
+				stop(termination)
+				stop(reload)
+				cancel(nil)
+				<-done
+			})
+		},
+	}
+}
+
+func isProcessSignal(err error) bool {
+	var signalErr *processSignalError
+	return errors.As(err, &signalErr)
+}
+
+func wrapsOnly(err, target error) bool {
+	if err == nil || err == target {
+		return true
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		children := joined.Unwrap()
+		if len(children) == 0 {
+			return false
+		}
+		for _, child := range children {
+			if !wrapsOnly(child, target) {
+				return false
+			}
+		}
+		return true
+	}
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+		return wrapsOnly(wrapped.Unwrap(), target)
+	}
+	return false
+}

--- a/internal/cli/signals_test.go
+++ b/internal/cli/signals_test.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestWrapsOnlyDistinguishesShutdownFailure(t *testing.T) {
+	cause := &processSignalError{signal: os.Interrupt}
+	if !wrapsOnly(fmt.Errorf("startup: %w", cause), cause) {
+		t.Fatal("single wrapped signal should be normalized")
+	}
+	if wrapsOnly(errors.Join(cause, errors.New("shutdown failed")), cause) {
+		t.Fatal("signal must not hide a shutdown failure")
+	}
+}
+
+func TestSubscribeProcessSignalsOwnsAndReleasesRegistrations(t *testing.T) {
+	t.Parallel()
+
+	type registration struct {
+		channel chan<- os.Signal
+		signals []os.Signal
+	}
+	var mu sync.Mutex
+	var registrations []registration
+	var stopped []chan<- os.Signal
+	subscription := subscribeProcessSignals(
+		context.Background(),
+		func(ch chan<- os.Signal, signals ...os.Signal) {
+			mu.Lock()
+			defer mu.Unlock()
+			registrations = append(registrations, registration{channel: ch, signals: signals})
+		},
+		func(ch chan<- os.Signal) {
+			mu.Lock()
+			defer mu.Unlock()
+			stopped = append(stopped, ch)
+		},
+	)
+
+	mu.Lock()
+	if len(registrations) != 2 {
+		t.Fatalf("registrations = %d, want 2", len(registrations))
+	}
+	termination := registrations[0]
+	reload := registrations[1]
+	mu.Unlock()
+	if cap(termination.channel) != 1 || cap(reload.channel) != 1 {
+		t.Fatal("process signal channels must coalesce with capacity 1")
+	}
+	if len(termination.signals) != 2 || termination.signals[0] != syscall.SIGINT || termination.signals[1] != syscall.SIGTERM {
+		t.Fatalf("termination signals = %v, want SIGINT and SIGTERM", termination.signals)
+	}
+	if len(reload.signals) != 1 || reload.signals[0] != syscall.SIGHUP {
+		t.Fatalf("reload signals = %v, want SIGHUP", reload.signals)
+	}
+
+	reload.channel <- syscall.SIGHUP
+	select {
+	case signal := <-subscription.reload:
+		if signal != syscall.SIGHUP {
+			t.Fatalf("reload signal = %v, want SIGHUP", signal)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("reload signal was not delivered")
+	}
+	termination.channel <- syscall.SIGTERM
+	select {
+	case <-subscription.ctx.Done():
+		if !isProcessSignal(context.Cause(subscription.ctx)) {
+			t.Fatalf("context cause = %v, want process signal", context.Cause(subscription.ctx))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("termination signal did not cancel process context")
+	}
+
+	subscription.stop()
+	subscription.stop()
+	mu.Lock()
+	defer mu.Unlock()
+	if len(stopped) != 2 {
+		t.Fatalf("stopped registrations = %d, want 2", len(stopped))
+	}
+}

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -76,9 +76,10 @@ type Components struct {
 	fatalOnce     sync.Once
 	manifestStore manifest.Store
 
-	overlayDone chan struct{}
-	routerDone  chan struct{}
-	vlTickDone  chan struct{}
+	overlayDone       chan struct{}
+	routerDone        chan struct{}
+	engineMonitorDone chan struct{}
+	vlTickDone        chan struct{}
 }
 
 // validatorListTickInterval is how often Components.Start fires
@@ -197,6 +198,28 @@ func (c *Components) Start(ctx context.Context) error {
 		c.stop()
 		return fmt.Errorf("start consensus engine: %w", err)
 	}
+	if terminal, ok := c.Engine.(consensus.EngineTerminal); ok {
+		if engineDone := terminal.Done(); engineDone != nil {
+			c.lifecycleMu.Lock()
+			c.engineMonitorDone = make(chan struct{})
+			monitorDone := c.engineMonitorDone
+			c.lifecycleMu.Unlock()
+			go func() {
+				defer close(monitorDone)
+				select {
+				case err, ok := <-engineDone:
+					if runCtx.Err() != nil {
+						return
+					}
+					if !ok || err == nil {
+						err = errors.New("engine stopped unexpectedly")
+					}
+					c.reportFatal(fmt.Errorf("consensus engine stopped: %w", err))
+				case <-runCtx.Done():
+				}
+			}()
+		}
+	}
 
 	c.lifecycleMu.Lock()
 	c.routerDone = make(chan struct{})
@@ -278,6 +301,7 @@ func (c *Components) stop() {
 		c.stopped = true
 		cancel := c.runCancel
 		routerDone := c.routerDone
+		engineMonitorDone := c.engineMonitorDone
 		vlTickDone := c.vlTickDone
 		overlayDone := c.overlayDone
 		c.lifecycleMu.Unlock()
@@ -299,6 +323,9 @@ func (c *Components) stop() {
 		}
 		if overlayDone != nil {
 			<-overlayDone
+		}
+		if engineMonitorDone != nil {
+			<-engineMonitorDone
 		}
 		if c.Router != nil {
 			legacy, replay := c.Router.StopAcquisitions()

--- a/internal/consensus/adaptor/startup_lifecycle_test.go
+++ b/internal/consensus/adaptor/startup_lifecycle_test.go
@@ -17,6 +17,7 @@ type lifecycleTestEngine struct {
 	startErr  error
 	stopCount atomic.Int32
 	stopCheck func()
+	terminal  <-chan error
 }
 
 func (e *lifecycleTestEngine) Start(context.Context) error {
@@ -29,6 +30,10 @@ func (e *lifecycleTestEngine) Stop() error {
 	}
 	e.stopCount.Add(1)
 	return nil
+}
+
+func (e *lifecycleTestEngine) Done() <-chan error {
+	return e.terminal
 }
 
 func newLifecycleTestComponents(
@@ -112,6 +117,37 @@ func TestComponentsReportsRouterExit(t *testing.T) {
 	case <-components.overlayDone:
 	default:
 		t.Fatal("Stop returned before the overlay stopped")
+	}
+}
+
+func TestComponentsReportsEngineExit(t *testing.T) {
+	terminal := make(chan error, 1)
+	engine := &lifecycleTestEngine{terminal: terminal}
+	components := newLifecycleTestComponents(t, engine, nil)
+	require.NoError(t, components.Start(t.Context()))
+
+	terminalErr := errors.New("engine loop failed")
+	terminal <- terminalErr
+	select {
+	case err := <-components.Errors():
+		require.ErrorIs(t, err, terminalErr)
+		require.Contains(t, err.Error(), "consensus engine stopped")
+	case <-time.After(2 * time.Second):
+		t.Fatal("unexpected engine exit was not reported")
+	}
+	require.NoError(t, components.Stop())
+}
+
+func TestComponentsNormalStopDoesNotReportEngineFailure(t *testing.T) {
+	terminal := make(chan error)
+	engine := &lifecycleTestEngine{terminal: terminal}
+	components := newLifecycleTestComponents(t, engine, nil)
+	require.NoError(t, components.Start(t.Context()))
+	require.NoError(t, components.Stop())
+	select {
+	case err := <-components.Errors():
+		t.Fatalf("normal stop reported engine failure: %v", err)
+	default:
 	}
 }
 

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -11,6 +11,11 @@ type EngineLifecycle interface {
 	Stop() error
 }
 
+// EngineTerminal is implemented by engines that expose background-loop exit.
+type EngineTerminal interface {
+	Done() <-chan error
+}
+
 type EngineRoundDriver interface {
 	// StartRound begins a round; proposing enables this node's proposal.
 	StartRound(round RoundID, proposing bool) error

--- a/internal/consensus/engine.go
+++ b/internal/consensus/engine.go
@@ -11,7 +11,6 @@ type EngineLifecycle interface {
 	Stop() error
 }
 
-// EngineTerminal is implemented by engines that expose background-loop exit.
 type EngineTerminal interface {
 	Done() <-chan error
 }

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -134,9 +134,11 @@ type Engine struct {
 	heartbeat *time.Ticker
 
 	// Lifecycle
-	ctx    context.Context
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
+	ctx      context.Context
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	done     chan error
+	doneOnce sync.Once
 
 	// now is the wall-clock source for round/phase DURATION metrics
 	// (time.Now in prod, a csf virtual clock under simulation). Distinct
@@ -306,6 +308,8 @@ func (e *Engine) refreshValidationConfig() int {
 	tracker.checkAcquired()
 	return quorum
 }
+
+var _ consensus.EngineTerminal = (*Engine)(nil)
 
 // ValidationArchive is the archive API subset the engine consumes,
 // decoupling rcl from the concrete archive type.
@@ -631,6 +635,7 @@ func (e *Engine) Start(ctx context.Context) error {
 		ctx = context.Background()
 	}
 	e.ctx, e.cancel = context.WithCancel(ctx)
+	e.done = make(chan error, 1)
 	e.prevLedger = ledger
 
 	trusted, quorum, negativeUNL := validationConfig(e.adaptor)
@@ -716,10 +721,29 @@ func (e *Engine) Start(ctx context.Context) error {
 	// Start the main loop, unless an external driver advances ticks.
 	if !e.manualTick {
 		e.wg.Add(1)
-		go e.run()
+		go func() {
+			e.run()
+			e.finish(context.Cause(e.ctx))
+		}()
 	}
 
 	return nil
+}
+
+// Done reports termination of the engine-owned background loop.
+func (e *Engine) Done() <-chan error {
+	e.lifecycleMu.Lock()
+	defer e.lifecycleMu.Unlock()
+	return e.done
+}
+
+func (e *Engine) finish(err error) {
+	e.doneOnce.Do(func() {
+		if e.done != nil {
+			e.done <- err
+			close(e.done)
+		}
+	})
 }
 
 // Stop shuts down the engine. A wired archive is drained and committed
@@ -736,6 +760,11 @@ func (e *Engine) Stop() error {
 		e.cancel()
 	}
 	e.wg.Wait()
+	var cause error
+	if e.ctx != nil {
+		cause = context.Cause(e.ctx)
+	}
+	e.finish(cause)
 	e.eventBus.Stop()
 
 	arc := e.loadArchive()

--- a/internal/consensus/rcl/engine.go
+++ b/internal/consensus/rcl/engine.go
@@ -730,7 +730,6 @@ func (e *Engine) Start(ctx context.Context) error {
 	return nil
 }
 
-// Done reports termination of the engine-owned background loop.
 func (e *Engine) Done() <-chan error {
 	e.lifecycleMu.Lock()
 	defer e.lifecycleMu.Unlock()

--- a/internal/node/grpc.go
+++ b/internal/node/grpc.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	rtdebug "runtime/debug"
 	"strings"
+	"sync"
 
 	googlegrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -50,6 +51,9 @@ type boundGRPCServer struct {
 	ready     <-chan struct{}
 	markReady func()
 	server    *googlegrpc.Server
+	requestMu sync.Mutex
+	requestWG sync.WaitGroup
+	stopping  bool
 }
 
 func prepareGRPCServer(
@@ -82,19 +86,71 @@ func bindGRPCServer(
 	boundAddr := lis.Addr().String()
 	readyListener := newServeReadyListener(lis)
 
-	srv := googlegrpc.NewServer(
-		googlegrpc.ChainUnaryInterceptor(grpcRecoveryInterceptor(log)),
-	)
-	rpcv1.RegisterXRPLedgerAPIServiceServer(srv, xrplgrpc.NewServer(lookup))
-
-	return &boundGRPCServer{
+	bound := &boundGRPCServer{
 		name:      name,
 		address:   boundAddr,
 		listener:  readyListener,
 		ready:     readyListener.ready,
 		markReady: readyListener.markReady,
-		server:    srv,
-	}, nil
+	}
+	srv := googlegrpc.NewServer(
+		googlegrpc.ChainUnaryInterceptor(bound.trackUnary, grpcRecoveryInterceptor(log)),
+		googlegrpc.ChainStreamInterceptor(bound.trackStream),
+	)
+	rpcv1.RegisterXRPLedgerAPIServiceServer(srv, xrplgrpc.NewServer(lookup))
+	bound.server = srv
+	return bound, nil
+}
+
+func (s *boundGRPCServer) admitRequest() bool {
+	s.requestMu.Lock()
+	defer s.requestMu.Unlock()
+	if s.stopping {
+		return false
+	}
+	s.requestWG.Add(1)
+	return true
+}
+
+func (s *boundGRPCServer) trackUnary(
+	ctx context.Context,
+	req any,
+	_ *googlegrpc.UnaryServerInfo,
+	handler googlegrpc.UnaryHandler,
+) (any, error) {
+	if !s.admitRequest() {
+		return nil, status.Error(codes.Unavailable, "server shutting down")
+	}
+	defer s.requestWG.Done()
+	return handler(ctx, req)
+}
+
+func (s *boundGRPCServer) trackStream(
+	srv any,
+	stream googlegrpc.ServerStream,
+	_ *googlegrpc.StreamServerInfo,
+	handler googlegrpc.StreamHandler,
+) error {
+	if !s.admitRequest() {
+		return status.Error(codes.Unavailable, "server shutting down")
+	}
+	defer s.requestWG.Done()
+	return handler(srv, stream)
+}
+
+func (s *boundGRPCServer) stopRequests() {
+	if s == nil {
+		return
+	}
+	s.requestMu.Lock()
+	s.stopping = true
+	s.requestMu.Unlock()
+}
+
+func (s *boundGRPCServer) waitRequests() {
+	if s != nil {
+		s.requestWG.Wait()
+	}
 }
 
 func validateGRPCPort(name string, p config.PortConfig) error {

--- a/internal/node/lifecycle_test.go
+++ b/internal/node/lifecycle_test.go
@@ -3,12 +3,19 @@ package node
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/config"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	"github.com/LeJamon/go-xrpl/internal/rpc"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
+	"github.com/LeJamon/go-xrpl/storage/nodestore"
+	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
 
 func TestRunReturnsCanceledContextBeforeStartup(t *testing.T) {
@@ -34,7 +41,6 @@ func TestWaitForShutdownReturnsContextCause(t *testing.T) {
 		result <- waitForShutdown(
 			ctx,
 			xrpllog.Discard(),
-			make(chan os.Signal),
 			make(chan os.Signal),
 			make(chan struct{}),
 			make(chan error),
@@ -66,7 +72,6 @@ func TestWaitForShutdownReturnsComponentError(t *testing.T) {
 		context.Background(),
 		xrpllog.Discard(),
 		make(chan os.Signal),
-		make(chan os.Signal),
 		make(chan struct{}),
 		make(chan error),
 		componentErrCh,
@@ -75,5 +80,281 @@ func TestWaitForShutdownReturnsComponentError(t *testing.T) {
 	)
 	if !errors.Is(err, componentErr) {
 		t.Fatalf("waitForShutdown() error = %v, want %v", err, componentErr)
+	}
+}
+
+func TestValidatorReloadLoopCancellationDoesNotWaitForLoader(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	requests := make(chan os.Signal, 1)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	sink := &recordingSink{}
+	go func() {
+		defer close(done)
+		runValidatorReloadLoop(
+			ctx,
+			xrpllog.Discard(),
+			sink,
+			"blocked.toml",
+			requests,
+			func(config.Paths) (*config.Config, error) {
+				close(started)
+				<-release
+				return nil, errors.New("released")
+			},
+		)
+	}()
+	requests <- os.Interrupt
+	<-started
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("reload loop did not stop after cancellation")
+	}
+	close(release)
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if len(sink.calls) != 0 {
+		t.Fatal("canceled reload mutated the trusted validator set")
+	}
+}
+
+func TestValidatorReloadLoaderDoesNotAccumulateAfterTimeout(t *testing.T) {
+	t.Parallel()
+
+	loadGate := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var calls atomic.Int32
+	load := func(config.Paths) (*config.Config, error) {
+		calls.Add(1)
+		<-release
+		return nil, errors.New("released")
+	}
+	for range 2 {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		applyValidatorReloadContextWithGate(
+			ctx,
+			xrpllog.Discard(),
+			&recordingSink{},
+			"blocked.toml",
+			load,
+			loadGate,
+		)
+		cancel()
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("blocked loader goroutines = %d, want 1", got)
+	}
+	close(release)
+}
+
+func TestValidatorReloadLoopSerializesAndCoalescesRequests(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	requests := make(chan os.Signal, 1)
+	started := make(chan int, 2)
+	releaseFirst := make(chan struct{})
+	done := make(chan struct{})
+	var calls atomic.Int32
+	var active atomic.Int32
+	var maxActive atomic.Int32
+	go func() {
+		defer close(done)
+		runValidatorReloadLoop(
+			ctx,
+			xrpllog.Discard(),
+			&recordingSink{},
+			"reload.toml",
+			requests,
+			func(config.Paths) (*config.Config, error) {
+				call := int(calls.Add(1))
+				current := active.Add(1)
+				for {
+					previous := maxActive.Load()
+					if current <= previous || maxActive.CompareAndSwap(previous, current) {
+						break
+					}
+				}
+				started <- call
+				if call == 1 {
+					<-releaseFirst
+				}
+				active.Add(-1)
+				return nil, errors.New("test reload")
+			},
+		)
+	}()
+
+	requests <- os.Interrupt
+	if call := <-started; call != 1 {
+		t.Fatalf("first reload call = %d", call)
+	}
+	for range 100 {
+		select {
+		case requests <- os.Interrupt:
+		default:
+		}
+	}
+	close(releaseFirst)
+	select {
+	case call := <-started:
+		if call != 2 {
+			t.Fatalf("pending reload call = %d, want 2", call)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("coalesced pending reload was not processed")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("reload loop did not stop")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("reload calls = %d, want 2", got)
+	}
+	if got := maxActive.Load(); got != 1 {
+		t.Fatalf("concurrent reloads = %d, want 1", got)
+	}
+}
+
+type shutdownProbeDB struct {
+	nodestore.Database
+	close func() error
+}
+
+func (d *shutdownProbeDB) Close() error { return d.close() }
+
+type shutdownProbeRepository struct {
+	relationaldb.RepositoryManager
+	close func() error
+}
+
+func (r *shutdownProbeRepository) Close() error { return r.close() }
+
+func TestDoShutdownReportsCloseErrorsInDependencyOrder(t *testing.T) {
+	t.Parallel()
+
+	dbErr := errors.New("node store close failed")
+	repoErr := errors.New("repository close failed")
+	var mu sync.Mutex
+	var order []string
+	db := &shutdownProbeDB{close: func() error {
+		mu.Lock()
+		order = append(order, "node-store")
+		mu.Unlock()
+		return dbErr
+	}}
+	repo := &shutdownProbeRepository{close: func() error {
+		mu.Lock()
+		order = append(order, "repository")
+		mu.Unlock()
+		return repoErr
+	}}
+
+	err := doShutdownWithin(time.Second, nil, nil, nil, nil, nil, nil, db, repo, xrpllog.Discard())
+	if !errors.Is(err, dbErr) || !errors.Is(err, repoErr) {
+		t.Fatalf("shutdown error = %v, want both close errors", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != 2 || order[0] != "node-store" || order[1] != "repository" {
+		t.Fatalf("close order = %v, want node-store then repository", order)
+	}
+}
+
+func TestDoShutdownBoundsBlockingStoreClose(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	repo := &shutdownProbeRepository{close: func() error {
+		close(started)
+		<-release
+		return nil
+	}}
+	result := make(chan error, 1)
+	go func() {
+		result <- doShutdownWithin(50*time.Millisecond, nil, nil, nil, nil, nil, nil, nil, repo, xrpllog.Discard())
+	}()
+	<-started
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("shutdown error = %v, want deadline exceeded", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("shutdown exceeded its total budget")
+	}
+	close(release)
+}
+
+func TestDoShutdownLeavesStoresOpenWhileTransportHandlerIsRunning(t *testing.T) {
+	runtimeCtx, cancelRuntime := context.WithCancel(context.Background())
+	defer cancelRuntime()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	bound, err := bindRPCTransports(
+		runtimeCtx,
+		xrpllog.Discard(),
+		&config.Config{Ports: map[string]config.PortConfig{
+			"http": {IP: "127.0.0.1", Port: 0, Protocol: "http"},
+		}},
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			close(started)
+			<-release
+		}),
+		rpc.NewWebSocketServer(time.Second, nil),
+		nil,
+		systemListen,
+	)
+	if err != nil {
+		t.Fatalf("bind transports: %v", err)
+	}
+	if err := bound.serve(xrpllog.Discard()); err != nil {
+		t.Fatalf("serve transports: %v", err)
+	}
+	requestDone := make(chan struct{})
+	go func() {
+		defer close(requestDone)
+		response, _ := http.Get("http://" + bound.http[0].address + "/")
+		if response != nil {
+			_ = response.Body.Close()
+		}
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("HTTP handler did not start")
+	}
+
+	var storeClosed atomic.Bool
+	db := &shutdownProbeDB{close: func() error {
+		storeClosed.Store(true)
+		return nil
+	}}
+	startedAt := time.Now()
+	err = doShutdownWithin(50*time.Millisecond, bound, nil, nil, nil, nil, nil, db, nil, xrpllog.Discard())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("shutdown error = %v, want deadline exceeded", err)
+	}
+	if time.Since(startedAt) >= time.Second {
+		t.Fatal("shutdown exceeded its total budget")
+	}
+	if storeClosed.Load() {
+		t.Fatal("node store closed while a transport handler was still running")
+	}
+
+	close(release)
+	select {
+	case <-requestDone:
+	case <-time.After(time.Second):
+		t.Fatal("transport handler did not exit after release")
 	}
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -140,7 +140,6 @@ type RunOptions struct {
 	Reload   <-chan os.Signal
 }
 
-// RunWithOptions runs the node with process-owned lifecycle options.
 func RunWithOptions(
 	ctx context.Context,
 	appConfig *config.Config,
@@ -1655,7 +1654,6 @@ const (
 	storeShutdownGrace     = 5 * time.Second
 )
 
-// doShutdown performs bounded shutdown of all server components.
 func doShutdown(
 	transports *boundRPCTransports,
 	wsServer *rpc.WebSocketServer,

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -6,12 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
-	"os/signal"
 	"runtime/debug"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/amendment"
@@ -131,7 +130,27 @@ func isFullGitHash(value string) bool {
 // blocks until a terminating signal or fatal error. It is the composition root
 // extracted from the CLI so flag parsing and node wiring stay separable.
 func Run(ctx context.Context, appConfig *config.Config, configPath string, standalone bool, startup service.StartupConfig, rootLogger, serverLog xrpllog.Logger) error {
-	return run(ctx, appConfig, configPath, standalone, startup, rootLogger, serverLog, nil)
+	return run(ctx, appConfig, configPath, standalone, startup, rootLogger, serverLog, RunOptions{})
+}
+
+// RunOptions supplies process-owned lifecycle events to the node runtime.
+type RunOptions struct {
+	Ready    func()
+	Stopping func()
+	Reload   <-chan os.Signal
+}
+
+// RunWithOptions runs the node with process-owned lifecycle options.
+func RunWithOptions(
+	ctx context.Context,
+	appConfig *config.Config,
+	configPath string,
+	standalone bool,
+	startup service.StartupConfig,
+	rootLogger, serverLog xrpllog.Logger,
+	options RunOptions,
+) error {
+	return run(ctx, appConfig, configPath, standalone, startup, rootLogger, serverLog, options)
 }
 
 // RunWithReady runs the node and calls ready after every configured service has
@@ -145,7 +164,7 @@ func RunWithReady(
 	rootLogger, serverLog xrpllog.Logger,
 	ready func(),
 ) error {
-	return run(ctx, appConfig, configPath, standalone, startup, rootLogger, serverLog, ready)
+	return RunWithOptions(ctx, appConfig, configPath, standalone, startup, rootLogger, serverLog, RunOptions{Ready: ready})
 }
 
 func run(
@@ -155,8 +174,10 @@ func run(
 	standalone bool,
 	startup service.StartupConfig,
 	rootLogger, serverLog xrpllog.Logger,
-	ready func(),
+	options RunOptions,
 ) (runErr error) {
+	ctx, cancelRuntime := context.WithCancelCause(ctx)
+	defer cancelRuntime(nil)
 	if err := context.Cause(ctx); err != nil {
 		return err
 	}
@@ -180,7 +201,13 @@ func run(
 		stallWatchdog       *watchdog.Watchdog
 	)
 	defer func() {
-		runErr = errors.Join(runErr, doShutdown(transports, wsServer, ledgerService, ledgerCleaner, consensusComponents, rotator, db, repoManager, serverLog))
+		cancelRuntime(nil)
+		if options.Stopping != nil {
+			options.Stopping()
+		}
+		if shutdownErr := doShutdown(transports, wsServer, ledgerService, ledgerCleaner, consensusComponents, rotator, db, repoManager, serverLog); shutdownErr != nil {
+			runErr = errors.Join(runErr, shutdownErr)
+		}
 	}()
 
 	db, repoManager, err = setupStorage(ctx, appConfig, serverLog)
@@ -247,7 +274,10 @@ func run(
 	// One instance is shared between the ledger service (which folds validated
 	// flag ledgers into it) and the consensus adaptor (which sources vote
 	// stances from it).
-	amendmentTable := buildTable(appConfig.Amendments, repoManager, serverLog)
+	amendmentTable := buildTable(ctx, appConfig.Amendments, repoManager, serverLog)
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 
 	// Build the transaction-queue config from the operator's
 	// [transaction_queue] stanza layered over the rippled defaults.
@@ -343,7 +373,7 @@ func run(
 				}
 				minimumOnline := rotator.MinimumOnline()
 				if minimumOnline == 0 && repoManager != nil {
-					minSeq, minErr := repoManager.Ledger().GetMinLedgerSeq(context.Background())
+					minSeq, minErr := repoManager.Ledger().GetMinLedgerSeq(ctx)
 					if minErr != nil {
 						return fmt.Errorf("load online-delete minimum ledger: %w", minErr)
 					}
@@ -603,7 +633,7 @@ func run(
 		// the request without charging.
 		if db != nil {
 			overlay.SetNodeObjectProvider(func(hash [32]byte) ([]byte, bool) {
-				node, err := db.Fetch(context.Background(), nodestore.Hash256(hash))
+				node, err := db.Fetch(ctx, nodestore.Hash256(hash))
 				if err != nil || node == nil {
 					return nil, false
 				}
@@ -1133,7 +1163,7 @@ func run(
 	// loop wedges, so a deadlocked node screams and can be restarted instead of
 	// going quiet.
 	if stallWatchdog != nil {
-		wdCtx, cancelWatchdog := context.WithCancel(context.Background())
+		wdCtx, cancelWatchdog := context.WithCancel(ctx)
 		defer cancelWatchdog()
 		go stallWatchdog.Run(wdCtx)
 		serverLog.Info("Stall watchdog armed",
@@ -1143,33 +1173,17 @@ func run(
 		)
 	}
 
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
-	defer signal.Stop(sigCh)
-
-	// SIGHUP triggers a UNL reload: re-read the config from --conf and
-	// replace the adaptor's trusted validator set. Per-round delta
-	// detection in the consensus engine then drives OnUNLChange so
-	// newly-added validators get the NegativeUNL grace period.
-	// Mirrors the operator-trigger surface of rippled's ValidatorList
-	// (applyLists → updateTrusted) without (yet) the publisher-trust
-	// subsystem. Buffered so a flurry of HUPs coalesces.
-	reloadCh := make(chan os.Signal, 1)
-	signal.Notify(reloadCh, syscall.SIGHUP)
-	defer signal.Stop(reloadCh)
-
 	var componentErrCh <-chan error
 	if consensusComponents != nil {
 		componentErrCh = consensusComponents.Errors()
 	}
-	if ready != nil {
-		ready()
+	if options.Ready != nil {
+		options.Ready()
 	}
 	return waitForShutdown(
 		ctx,
 		serverLog,
-		sigCh,
-		reloadCh,
+		options.Reload,
 		shutdownCh,
 		listenerErrCh,
 		componentErrCh,
@@ -1207,29 +1221,46 @@ func validateTrustedValidatorConfig(appConfig *config.Config, standalone bool) e
 	return errors.New("trusted validator configuration is empty: configure validators or validator_list_keys, or use --standalone")
 }
 
-// waitForShutdown blocks until a terminating event arrives: an OS signal, an
-// RPC stop, or a listener or consensus-component failure. SIGHUP is
-// non-terminating — it reloads the trusted validator set in place and keeps
-// waiting. It returns the fatal error (if any) so the caller's deferred cleanup
-// runs.
+// waitForShutdown blocks until context cancellation, an RPC stop, or a listener
+// or consensus-component failure. Validator reloads run on a separate serialized
+// worker so they cannot prevent a terminating event from being observed.
 
 func waitForShutdown(
 	ctx context.Context,
 	log xrpllog.Logger,
-	sigCh, reloadCh chan os.Signal,
+	reloadCh <-chan os.Signal,
 	shutdownCh chan struct{},
 	listenerErrCh chan error,
 	componentErrCh <-chan error,
 	consensusComponents *adaptor.Components,
 	configPath string,
 ) error {
+	reloadCtx, cancelReload := context.WithCancel(ctx)
+	reloadDone := make(chan struct{})
+	var reloader staticValidatorReloader
+	if consensusComponents != nil {
+		reloader = consensusComponents
+	}
+	go func() {
+		defer close(reloadDone)
+		runValidatorReloadLoop(
+			reloadCtx,
+			log,
+			reloader,
+			configPath,
+			reloadCh,
+			config.LoadConfig,
+		)
+	}()
+	defer func() {
+		cancelReload()
+		<-reloadDone
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return context.Cause(ctx)
-		case sig := <-sigCh:
-			log.Info("Received signal, shutting down", "signal", sig)
-			return nil
 		case <-shutdownCh:
 			return nil
 		case err := <-listenerErrCh:
@@ -1245,8 +1276,6 @@ func waitForShutdown(
 			}
 			log.Error("Consensus component failed — initiating shutdown", "err", err)
 			return err
-		case <-reloadCh:
-			reloadTrustedValidators(log, consensusComponents, configPath)
 		}
 	}
 }
@@ -1472,6 +1501,10 @@ type staticValidatorReloader interface {
 	ValidateValidatorReload(publisherKeys [][33]byte, publisherSites []string, publisherThreshold, staticValidatorCount int) error
 }
 
+type validatorConfigLoader func(config.Paths) (*config.Config, error)
+
+const validatorReloadTimeout = 5 * time.Second
+
 // stallPinger is the optional surface the stall watchdog installs on the
 // consensus engine. Kept off the core consensus.Engine interface so test
 // mocks and alternative engines need not implement it; *rcl.Engine satisfies
@@ -1490,6 +1523,33 @@ func reloadTrustedValidators(serverLog xrpllog.Logger, components *adaptor.Compo
 	applyValidatorReload(serverLog, components, configPath)
 }
 
+func runValidatorReloadLoop(
+	ctx context.Context,
+	serverLog xrpllog.Logger,
+	reloader staticValidatorReloader,
+	configPath string,
+	requests <-chan os.Signal,
+	load validatorConfigLoader,
+) {
+	loadGate := make(chan struct{}, 1)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-requests:
+			if !ok {
+				return
+			}
+			if reloader == nil {
+				continue
+			}
+			reloadCtx, cancel := context.WithTimeout(ctx, validatorReloadTimeout)
+			applyValidatorReloadContextWithGate(reloadCtx, serverLog, reloader, configPath, load, loadGate)
+			cancel()
+		}
+	}
+}
+
 // applyValidatorReload re-reads configPath, re-parses the [validators]
 // stanza, and pushes the result into reloader. Errors are logged and
 // the previous trusted set is retained — a bad reload must not wedge
@@ -1498,11 +1558,60 @@ func reloadTrustedValidators(serverLog xrpllog.Logger, components *adaptor.Compo
 // Skipped silently when configPath is empty (validator config can't
 // be re-read from nothing).
 func applyValidatorReload(serverLog xrpllog.Logger, reloader staticValidatorReloader, configPath string) {
+	applyValidatorReloadContext(context.Background(), serverLog, reloader, configPath, config.LoadConfig)
+}
+
+func applyValidatorReloadContext(
+	ctx context.Context,
+	serverLog xrpllog.Logger,
+	reloader staticValidatorReloader,
+	configPath string,
+	load validatorConfigLoader,
+) {
+	applyValidatorReloadContextWithGate(ctx, serverLog, reloader, configPath, load, make(chan struct{}, 1))
+}
+
+func applyValidatorReloadContextWithGate(
+	ctx context.Context,
+	serverLog xrpllog.Logger,
+	reloader staticValidatorReloader,
+	configPath string,
+	load validatorConfigLoader,
+	loadGate chan struct{},
+) {
 	if configPath == "" {
 		serverLog.Warn("SIGHUP received but no --conf path set; skipping UNL reload")
 		return
 	}
-	cfg, err := config.LoadConfig(config.Paths{Main: configPath})
+	if err := context.Cause(ctx); err != nil {
+		serverLog.Warn("SIGHUP UNL reload canceled", "err", err)
+		return
+	}
+	type loadResult struct {
+		cfg *config.Config
+		err error
+	}
+	select {
+	case loadGate <- struct{}{}:
+	case <-ctx.Done():
+		serverLog.Warn("SIGHUP UNL reload canceled", "err", context.Cause(ctx))
+		return
+	}
+	loaded := make(chan loadResult, 1)
+	go func() {
+		defer func() { <-loadGate }()
+		cfg, err := load(config.Paths{Main: configPath})
+		loaded <- loadResult{cfg: cfg, err: err}
+	}()
+
+	var result loadResult
+	select {
+	case <-ctx.Done():
+		serverLog.Warn("SIGHUP UNL reload canceled", "err", context.Cause(ctx))
+		return
+	case result = <-loaded:
+	}
+	cfg, err := result.cfg, result.err
 	if err != nil {
 		serverLog.Error("SIGHUP UNL reload: re-load config failed", "err", err)
 		return
@@ -1526,6 +1635,10 @@ func applyValidatorReload(serverLog xrpllog.Logger, reloader staticValidatorRelo
 		serverLog.Error("SIGHUP UNL reload rejected", "err", err)
 		return
 	}
+	if err := context.Cause(ctx); err != nil {
+		serverLog.Warn("SIGHUP UNL reload canceled", "err", err)
+		return
+	}
 	reloader.ReloadStaticValidators(validators, masterKeys)
 	serverLog.Info("SIGHUP UNL reload applied",
 		"validators_count", len(validators),
@@ -1533,7 +1646,16 @@ func applyValidatorReload(serverLog xrpllog.Logger, reloader staticValidatorRelo
 	)
 }
 
-// doShutdown performs graceful shutdown of all server components
+const nodeShutdownTimeout = 30 * time.Second
+
+const (
+	transportShutdownGrace = 5 * time.Second
+	producerShutdownGrace  = 5 * time.Second
+	serviceShutdownGrace   = 10 * time.Second
+	storeShutdownGrace     = 5 * time.Second
+)
+
+// doShutdown performs bounded shutdown of all server components.
 func doShutdown(
 	transports *boundRPCTransports,
 	wsServer *rpc.WebSocketServer,
@@ -1545,83 +1667,81 @@ func doShutdown(
 	repoManager relationaldb.RepositoryManager,
 	logger xrpllog.Logger,
 ) error {
-	var shutdownErr error
-	const drainTimeout = 30 * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), drainTimeout)
+	return doShutdownWithin(
+		nodeShutdownTimeout,
+		transports,
+		wsServer,
+		ledgerService,
+		ledgerCleaner,
+		consensusComponents,
+		rotator,
+		kvDB,
+		repoManager,
+		logger,
+	)
+}
+
+func doShutdownWithin(
+	timeout time.Duration,
+	transports *boundRPCTransports,
+	wsServer *rpc.WebSocketServer,
+	ledgerService *service.Service,
+	ledgerCleaner *cleaner.Cleaner,
+	consensusComponents *adaptor.Components,
+	rotator *shamapstore.Rotator,
+	kvDB nodestore.Database,
+	repoManager relationaldb.RepositoryManager,
+	logger xrpllog.Logger,
+) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+	var errs []error
 
-	logger.Info("Draining HTTP connections...")
-	if transports != nil {
-		for _, bound := range transports.http {
-			if err := bound.server.Shutdown(ctx); err != nil {
-				shutdownErr = errors.Join(shutdownErr, fmt.Errorf("shutdown HTTP server: %w", err))
-				logger.Warn("HTTP server graceful shutdown failed", "err", err)
-				if closeErr := bound.server.Close(); closeErr != nil {
-					shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close HTTP server: %w", closeErr))
-					logger.Warn("HTTP server forced close failed", "err", closeErr)
-				}
-			}
-		}
-		for _, bound := range transports.ws {
-			if err := bound.server.Shutdown(ctx); err != nil {
-				shutdownErr = errors.Join(shutdownErr, fmt.Errorf("shutdown WebSocket HTTP server: %w", err))
-				logger.Warn("WebSocket HTTP server graceful shutdown failed", "err", err)
-				if closeErr := bound.server.Close(); closeErr != nil {
-					shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close WebSocket HTTP server: %w", closeErr))
-					logger.Warn("WebSocket HTTP server forced close failed", "err", closeErr)
-				}
-			}
-		}
+	transportsStopped, err := shutdownTransports(ctx, transports, wsServer, logger)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	if !transportsStopped {
+		errs = append(errs, errors.New("shutdown incomplete: dependencies left running because transport handlers did not stop"))
+		return errors.Join(errs...)
 	}
 
-	if wsServer != nil {
-		if err := wsServer.Close(ctx); err != nil {
-			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close WebSocket server: %w", err))
-			logger.Warn("WebSocket server shutdown timed out", "err", err)
-		}
-	}
-
-	if transports != nil && transports.grpc != nil {
-		logger.Info("Draining gRPC connections...")
-		stopped := make(chan struct{})
-		go func() {
-			transports.grpc.server.GracefulStop()
-			close(stopped)
-		}()
-		select {
-		case <-stopped:
-		case <-ctx.Done():
-			transports.grpc.server.Stop()
-			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("drain gRPC server: %w", ctx.Err()))
-			logger.Warn("gRPC server graceful shutdown timed out; forced stop")
-		}
-	}
-	if transports != nil {
-		_ = transports.closeListeners()
-		transports.wait()
-	}
-
+	producersStopped := true
 	if rotator != nil {
-		rotator.Stop()
-		logger.Info("Online delete rotator stopped")
+		completed, err := runShutdownPhaseWithin(ctx, producerShutdownGrace, "stop online delete rotator", func() error {
+			rotator.Stop()
+			return nil
+		})
+		producersStopped = producersStopped && completed
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			logger.Info("Online delete rotator stopped")
+		}
 	}
-
 	if ledgerCleaner != nil {
-		ledgerCleaner.Stop()
-		logger.Info("Ledger cleaner stopped")
+		completed, err := runShutdownPhaseWithin(ctx, producerShutdownGrace, "stop ledger cleaner", func() error {
+			ledgerCleaner.Stop()
+			return nil
+		})
+		producersStopped = producersStopped && completed
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			logger.Info("Ledger cleaner stopped")
+		}
 	}
-
 	if consensusComponents != nil {
-		stopErr := consensusComponents.Stop()
-		if stopErr != nil {
-			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("stop consensus components: %w", stopErr))
-			logger.Warn("Consensus component shutdown failed", "err", stopErr)
-			if consensusComponents.Archive != nil {
-				waitCtx, waitCancel := context.WithTimeout(context.Background(), 5*time.Second)
-				terminalErr := consensusComponents.Archive.Close(waitCtx)
-				waitCancel()
-				if terminalErr != nil && !errors.Is(stopErr, terminalErr) {
-					shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close validation archive: %w", terminalErr))
+		completed, err := runShutdownPhaseWithin(ctx, producerShutdownGrace, "stop consensus components", consensusComponents.Stop)
+		producersStopped = producersStopped && completed
+		if err != nil {
+			errs = append(errs, err)
+			if completed && consensusComponents.Archive != nil {
+				archiveCtx, cancelArchive := context.WithTimeout(context.Background(), producerShutdownGrace)
+				terminalErr := consensusComponents.Archive.Close(archiveCtx)
+				cancelArchive()
+				if terminalErr != nil && !errors.Is(err, terminalErr) {
+					errs = append(errs, fmt.Errorf("close validation archive: %w", terminalErr))
 					logger.Warn("Validation archive terminal shutdown failed", "err", terminalErr)
 				}
 			}
@@ -1641,38 +1761,213 @@ func doShutdown(
 				)
 			}
 		}
-		logger.Info("Consensus components stopped")
+		if completed {
+			logger.Info("Consensus components stopped")
+		}
 	}
 
-	// Drain and join the persistence worker before closing its stores, so
-	// queued ledger persists become durable instead of being
-	// abandoned (and so no StoreBatch races kvDB.Close). Ordered after the
-	// consensus components stop, so no new ledger closes past this point.
-	if ledgerService != nil {
-		ledgerService.Stop()
-		logger.Info("Ledger service persistence drained")
+	if !producersStopped {
+		errs = append(errs, errors.New("shutdown incomplete: stores left open because producers did not stop"))
+		return errors.Join(errs...)
 	}
+
+	serviceStopped := true
+	if ledgerService != nil {
+		completed, err := runShutdownPhaseWithin(ctx, serviceShutdownGrace, "stop ledger service", func() error {
+			ledgerService.Stop()
+			return nil
+		})
+		serviceStopped = completed
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			logger.Info("Ledger service persistence drained")
+		}
+	}
+	if !serviceStopped {
+		errs = append(errs, errors.New("shutdown incomplete: stores left open because ledger service did not stop"))
+		return errors.Join(errs...)
+	}
+
 	if kvDB != nil {
-		if err := kvDB.Close(); err != nil {
-			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close node store: %w", err))
-			logger.Warn("Node store close failed", "err", err)
+		_, err := runShutdownPhaseWithin(ctx, storeShutdownGrace, "close node store", kvDB.Close)
+		if err != nil {
+			errs = append(errs, err)
 		}
 	}
 	if repoManager != nil {
-		if err := repoManager.Close(); err != nil {
-			shutdownErr = errors.Join(shutdownErr, fmt.Errorf("close relational DB: %w", err))
-			logger.Warn("Relational DB close failed", "err", err)
+		_, err := runShutdownPhaseWithin(ctx, storeShutdownGrace, "close relational database", repoManager.Close)
+		if err != nil {
+			errs = append(errs, err)
 		}
 	}
 
-	logger.Info("Shutdown complete")
+	shutdownErr := errors.Join(errs...)
+	if shutdownErr != nil {
+		logger.Warn("Shutdown completed with errors", "err", shutdownErr)
+	} else {
+		logger.Info("Shutdown complete")
+	}
 	return shutdownErr
+}
+
+func runShutdownPhase(ctx context.Context, name string, stop func() error) (bool, error) {
+	if err := context.Cause(ctx); err != nil {
+		return false, fmt.Errorf("%s: %w", name, err)
+	}
+	result := make(chan error, 1)
+	go func() { result <- stop() }()
+	select {
+	case err := <-result:
+		if err != nil {
+			return true, fmt.Errorf("%s: %w", name, err)
+		}
+		return true, nil
+	case <-ctx.Done():
+		return false, fmt.Errorf("%s: %w", name, context.Cause(ctx))
+	}
+}
+
+func runShutdownPhaseWithin(
+	ctx context.Context,
+	timeout time.Duration,
+	name string,
+	stop func() error,
+) (bool, error) {
+	phaseCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return runShutdownPhase(phaseCtx, name, stop)
+}
+
+func shutdownTransports(
+	ctx context.Context,
+	transports *boundRPCTransports,
+	wsServer *rpc.WebSocketServer,
+	logger xrpllog.Logger,
+) (bool, error) {
+	var errs []error
+	var servers []*http.Server
+	if transports != nil {
+		transports.stopRequests()
+		for _, bound := range transports.http {
+			servers = append(servers, bound.server)
+		}
+		for _, bound := range transports.ws {
+			servers = append(servers, bound.server)
+		}
+	}
+
+	type shutdownResult struct {
+		name string
+		err  error
+	}
+	graceCtx, cancelGrace := context.WithTimeout(ctx, transportShutdownGrace)
+	defer cancelGrace()
+
+	resultCount := len(servers)
+	if wsServer != nil {
+		resultCount++
+	}
+	if transports != nil && transports.grpc != nil {
+		resultCount++
+	}
+	results := make(chan shutdownResult, resultCount)
+	for _, server := range servers {
+		go func() {
+			results <- shutdownResult{
+				name: "drain HTTP server " + server.Addr,
+				err:  server.Shutdown(graceCtx),
+			}
+		}()
+	}
+	if wsServer != nil {
+		go func() {
+			results <- shutdownResult{name: "close WebSocket sessions", err: wsServer.Close(graceCtx)}
+		}()
+	}
+	if transports != nil && transports.grpc != nil {
+		logger.Info("Draining gRPC connections...")
+		go func() {
+			transports.grpc.server.GracefulStop()
+			results <- shutdownResult{name: "drain gRPC server"}
+		}()
+	}
+
+	graceful := true
+	for remaining := resultCount; remaining > 0; remaining-- {
+		select {
+		case result := <-results:
+			if result.err != nil {
+				graceful = false
+				errs = append(errs, fmt.Errorf("%s: %w", result.name, result.err))
+			}
+		case <-graceCtx.Done():
+			graceful = false
+			errs = append(errs, fmt.Errorf("drain transports: %w", context.Cause(graceCtx)))
+			remaining = 0
+		}
+	}
+
+	if !graceful {
+		for _, server := range servers {
+			if err := server.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("force close HTTP server %s: %w", server.Addr, err))
+			}
+		}
+		if transports != nil && transports.grpc != nil {
+			transports.grpc.server.Stop()
+		}
+	}
+	if transports != nil {
+		if err := transports.closeListeners(); err != nil {
+			errs = append(errs, fmt.Errorf("close transport listeners: %w", err))
+		}
+	}
+
+	type joinResult struct {
+		name string
+		err  error
+	}
+	joinCount := 0
+	joined := make(chan joinResult, 3)
+	if transports != nil {
+		joinCount += 2
+		go func() {
+			transports.wait()
+			joined <- joinResult{name: "join transport servers"}
+		}()
+		go func() {
+			transports.waitRequests()
+			joined <- joinResult{name: "join transport handlers"}
+		}()
+	}
+	if wsServer != nil {
+		joinCount++
+		go func() {
+			joined <- joinResult{name: "join WebSocket sessions", err: wsServer.Close(ctx)}
+		}()
+	}
+	complete := true
+	for remaining := joinCount; remaining > 0; remaining-- {
+		select {
+		case result := <-joined:
+			if result.err != nil {
+				complete = false
+				errs = append(errs, fmt.Errorf("%s: %w", result.name, result.err))
+			}
+		case <-ctx.Done():
+			complete = false
+			errs = append(errs, fmt.Errorf("join transports: %w", context.Cause(ctx)))
+			remaining = 0
+		}
+	}
+	return complete, errors.Join(errs...)
 }
 
 // ledgerCleanerSource adapts the ledger service + node store to the
 // cleaner.LedgerSource interface the ledger-integrity verifier consumes.
 
-func buildTable(cfg config.AmendmentsConfig, repo relationaldb.RepositoryManager, log xrpllog.Logger) *amendment.Table {
+func buildTable(ctx context.Context, cfg config.AmendmentsConfig, repo relationaldb.RepositoryManager, log xrpllog.Logger) *amendment.Table {
 	t := amendment.NewTable()
 	for _, name := range cfg.Upvote {
 		f := amendment.FeatureByName(name)
@@ -1694,7 +1989,7 @@ func buildTable(cfg config.AmendmentsConfig, repo relationaldb.RepositoryManager
 	if repo == nil || repo.Amendment() == nil {
 		return t
 	}
-	recs, err := repo.Amendment().LoadAmendmentVotes(context.Background())
+	recs, err := repo.Amendment().LoadAmendmentVotes(ctx)
 	if err != nil {
 		log.Warn("failed to load persisted amendment votes; using config only", "err", err)
 		return t

--- a/internal/node/transports.go
+++ b/internal/node/transports.go
@@ -34,11 +34,14 @@ type boundHTTPServer struct {
 }
 
 type boundRPCTransports struct {
-	http    []*boundHTTPServer
-	ws      []*boundHTTPServer
-	grpc    *boundGRPCServer
-	errors  chan error
-	serveWG sync.WaitGroup
+	http      []*boundHTTPServer
+	ws        []*boundHTTPServer
+	grpc      *boundGRPCServer
+	errors    chan error
+	serveWG   sync.WaitGroup
+	requestMu sync.Mutex
+	requestWG sync.WaitGroup
+	stopping  bool
 }
 
 type serveReadyListener struct {
@@ -110,8 +113,13 @@ func bindRPCTransports(
 			return nil, parseErr
 		}
 		mux := http.NewServeMux()
-		mux.Handle("/", rpc.PortMiddleware(pc, connLimiter, wsServer))
-		srv := &http.Server{Addr: p.BindAddress(), Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+		mux.Handle("/", bound.trackHandler(rpc.PortMiddleware(pc, connLimiter, wsServer)))
+		srv := &http.Server{
+			Addr:              p.BindAddress(),
+			Handler:           mux,
+			ReadHeaderTimeout: 10 * time.Second,
+			BaseContext:       func(net.Listener) context.Context { return ctx },
+		}
 		bound.ws = append(bound.ws, &boundHTTPServer{
 			name: name, protocol: "ws", address: srv.Addr, server: srv,
 		})
@@ -124,7 +132,7 @@ func bindRPCTransports(
 			return nil, parseErr
 		}
 		mux := http.NewServeMux()
-		mux.Handle("/", rpc.PortMiddleware(pc, connLimiter, httpMux))
+		mux.Handle("/", bound.trackHandler(rpc.PortMiddleware(pc, connLimiter, httpMux)))
 		srv := &http.Server{
 			Addr:              p.BindAddress(),
 			Handler:           mux,
@@ -132,6 +140,7 @@ func bindRPCTransports(
 			ReadTimeout:       httpReadTimeout,
 			WriteTimeout:      httpWriteTimeout,
 			IdleTimeout:       httpIdleTimeout,
+			BaseContext:       func(net.Listener) context.Context { return ctx },
 		}
 		bound.http = append(bound.http, &boundHTTPServer{
 			name: name, protocol: "http", address: srv.Addr, server: srv,
@@ -224,6 +233,43 @@ func (t *boundRPCTransports) serve(log xrpllog.Logger) error {
 func (t *boundRPCTransports) wait() {
 	if t != nil {
 		t.serveWG.Wait()
+	}
+}
+
+func (t *boundRPCTransports) trackHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.requestMu.Lock()
+		if t.stopping {
+			t.requestMu.Unlock()
+			http.Error(w, "server shutting down", http.StatusServiceUnavailable)
+			return
+		}
+		t.requestWG.Add(1)
+		t.requestMu.Unlock()
+		defer t.requestWG.Done()
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (t *boundRPCTransports) stopRequests() {
+	if t == nil {
+		return
+	}
+	t.requestMu.Lock()
+	t.stopping = true
+	t.requestMu.Unlock()
+	if t.grpc != nil {
+		t.grpc.stopRequests()
+	}
+}
+
+func (t *boundRPCTransports) waitRequests() {
+	if t != nil {
+		t.requestWG.Wait()
+		if t.grpc != nil {
+			t.grpc.waitRequests()
+		}
 	}
 }
 

--- a/internal/node/transports_test.go
+++ b/internal/node/transports_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/stretchr/testify/require"
+	googlegrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestBindRPCTransportsValidatesAllPortsBeforeBinding(t *testing.T) {
@@ -214,4 +217,106 @@ func TestBoundRPCTransportsPreStoppedServersDoNotBlockServe(t *testing.T) {
 	}
 	require.NoError(t, bound.closeListeners())
 	bound.wait()
+}
+
+func TestShutdownTransportsForceClosesStuckHTTPHandler(t *testing.T) {
+	runtimeCtx, cancelRuntime := context.WithCancel(context.Background())
+	defer cancelRuntime()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	bound, err := bindRPCTransports(
+		runtimeCtx,
+		xrpllog.Discard(),
+		&config.Config{Ports: map[string]config.PortConfig{
+			"http": {IP: "127.0.0.1", Port: 0, Protocol: "http"},
+		}},
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			close(started)
+			<-release
+		}),
+		rpc.NewWebSocketServer(time.Second, nil),
+		nil,
+		systemListen,
+	)
+	require.NoError(t, err)
+	require.NoError(t, bound.serve(xrpllog.Discard()))
+	requestDone := make(chan error, 1)
+	go func() {
+		response, requestErr := http.Get("http://" + bound.http[0].address + "/")
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		requestDone <- requestErr
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("HTTP handler did not start")
+	}
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	startedAt := time.Now()
+	complete, err := shutdownTransports(shutdownCtx, bound, nil, xrpllog.Discard())
+	cancelShutdown()
+	require.False(t, complete)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(startedAt), time.Second)
+	close(release)
+	select {
+	case <-requestDone:
+	case <-time.After(time.Second):
+		t.Fatal("forced transport close did not release the client")
+	}
+}
+
+func TestShutdownTransportsDoesNotCompleteWithStuckGRPCHandler(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	grpcServer := &boundGRPCServer{
+		listener: listener,
+		server:   googlegrpc.NewServer(),
+	}
+	bound := &boundRPCTransports{grpc: grpcServer}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		_, _ = grpcServer.trackUnary(
+			context.Background(),
+			nil,
+			nil,
+			func(context.Context, any) (any, error) {
+				close(started)
+				<-release
+				return nil, nil
+			},
+		)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("gRPC handler did not start")
+	}
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	complete, err := shutdownTransports(shutdownCtx, bound, nil, xrpllog.Discard())
+	cancelShutdown()
+	require.False(t, complete)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	_, admissionErr := grpcServer.trackUnary(
+		context.Background(),
+		nil,
+		nil,
+		func(context.Context, any) (any, error) { return nil, nil },
+	)
+	require.Equal(t, codes.Unavailable, status.Code(admissionErr))
+
+	close(release)
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("gRPC handler did not exit after release")
+	}
 }

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -60,7 +60,10 @@ type WebSocketServer struct {
 	pingInterval time.Duration
 	// wg tracks admitted HTTP handlers and per-connection goroutines so Close
 	// can join them on shutdown.
-	wg sync.WaitGroup
+	wg        sync.WaitGroup
+	closeOnce sync.Once
+	closeDone chan struct{}
+	forceDone chan struct{}
 }
 
 // WebSocketConnection represents a single WebSocket connection
@@ -129,6 +132,8 @@ func NewWebSocketServerWithLoadTracker(timeout time.Duration, services *types.Se
 		services:            services,
 		loadTracker:         tracker,
 		pingInterval:        30 * time.Second,
+		closeDone:           make(chan struct{}),
+		forceDone:           make(chan struct{}),
 	}
 	// The url (RPCSub) registry lives on the WebSocket server because url
 	// subscribers share its subscription manager's broadcast fan-out.
@@ -1311,6 +1316,21 @@ func (ws *WebSocketServer) SubscriptionManager() *subscription.Manager {
 // misbehaving handler cannot stall shutdown indefinitely; if ctx expires first,
 // Close returns ctx.Err().
 func (ws *WebSocketServer) Close(ctx context.Context) error {
+	ws.closeOnce.Do(func() {
+		go ws.shutdown(ctx)
+	})
+	select {
+	case <-ws.closeDone:
+		return nil
+	case <-ctx.Done():
+		<-ws.forceDone
+		return ctx.Err()
+	}
+}
+
+func (ws *WebSocketServer) shutdown(ctx context.Context) {
+	defer close(ws.closeDone)
+
 	ws.connectionsMutex.Lock()
 	ws.closing = true
 	connections := make([]*WebSocketConnection, 0, len(ws.connections))
@@ -1344,32 +1364,17 @@ func (ws *WebSocketServer) Close(ctx context.Context) error {
 		close(closeFramesDone)
 	}()
 
-	var shutdownErr error
 	select {
 	case <-closeFramesDone:
-		shutdownErr = ctx.Err()
 	case <-ctx.Done():
-		shutdownErr = ctx.Err()
 	}
 
 	for _, conn := range connections {
 		_ = conn.conn.Close()
 	}
+	close(ws.forceDone)
 
-	done := make(chan struct{})
-	go func() {
-		closeFrames.Wait()
-		ws.wg.Wait()
-		ws.urlSubs.Close()
-		close(done)
-	}()
-	if shutdownErr != nil {
-		return shutdownErr
-	}
-	select {
-	case <-done:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	closeFrames.Wait()
+	ws.wg.Wait()
+	ws.urlSubs.Close()
 }

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -140,7 +140,12 @@ func TestWebSocketServer_Close_RespectsContext(t *testing.T) {
 
 	// Inflate the WaitGroup so it never reaches zero on its own.
 	ws.wg.Add(1)
-	defer ws.wg.Done()
+	released := false
+	defer func() {
+		if !released {
+			ws.wg.Done()
+		}
+	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
@@ -154,6 +159,14 @@ func TestWebSocketServer_Close_RespectsContext(t *testing.T) {
 	}
 	if elapsed > 500*time.Millisecond {
 		t.Errorf("Close took too long despite ctx deadline: %v", elapsed)
+	}
+
+	ws.wg.Done()
+	released = true
+	joinCtx, cancelJoin := context.WithTimeout(context.Background(), time.Second)
+	defer cancelJoin()
+	if err := ws.Close(joinCtx); err != nil {
+		t.Fatalf("second Close did not join the in-flight shutdown: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- install and release signal handling at process entry and keep reload work serialized and cancellable
- supervise post-readiness transport, consensus, and ledger-service failures
- make normal gRPC shutdown non-fatal
- enforce bounded transport, producer, service, and storage shutdown phases with dependency-safe ordering and aggregated errors

## Stack

Layer 2 of 5 for #1470. This PR targets #1527 and is followed by #1529.

Part of #1470.

## Testing

- focused and repeated node lifecycle and transport tests
- go test -race ./internal/node
- go test ./...
- just test-core
- just vet
- just lint
- just build-all