### PR TITLE
fix(streams): match accepted-ledger semantics

### DIFF
--- a/drops/xrp_amount.go
+++ b/drops/xrp_amount.go
@@ -1,6 +1,7 @@
 package drops
 
 import (
+	"math"
 	"strconv"
 )
 
@@ -23,6 +24,17 @@ func NewXRPAmount(drops int64) XRPAmount {
 // Drops returns the amount as an integer number of drops.
 func (x XRPAmount) Drops() int64 {
 	return int64(x)
+}
+
+// JSONClipped returns the signed 32-bit value used by rippled's JSON API.
+func (x XRPAmount) JSONClipped() int32 {
+	if x < math.MinInt32 {
+		return math.MinInt32
+	}
+	if x > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return int32(x)
 }
 
 // DecimalXRP returns the amount expressed in XRP (drops divided by 1e6).

--- a/drops/xrp_amount_test.go
+++ b/drops/xrp_amount_test.go
@@ -13,6 +13,28 @@ func TestXRPAmount_String(t *testing.T) {
 	require.Equal(t, "0", NewXRPAmount(0).String())
 }
 
+func TestXRPAmount_JSONClipped(t *testing.T) {
+	tests := []struct {
+		value int64
+		want  int32
+	}{
+		{math.MinInt64, math.MinInt32},
+		{math.MinInt32 - 1, math.MinInt32},
+		{math.MinInt32, math.MinInt32},
+		{-1, -1},
+		{0, 0},
+		{math.MaxInt32, math.MaxInt32},
+		{math.MaxInt32 + 1, math.MaxInt32},
+		{int64(MaxDrops), math.MaxInt32},
+	}
+	for _, test := range tests {
+		require.Equal(t, test.want, XRPAmount(test.value).JSONClipped(), "value %d", test.value)
+	}
+	negative := XRPAmount(-15)
+	wrapped := uint64(negative)
+	require.Equal(t, int32(-15), XRPAmount(int64(wrapped)).JSONClipped())
+}
+
 // Add/Sub/Mul mirror rippled's plain int64 arithmetic and wrap silently on
 // overflow rather than erroring.
 func TestXRPAmount_UncheckedWrap(t *testing.T) {

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -66,6 +66,8 @@ type Adaptor struct {
 
 	operatingMode consensus.OperatingMode
 	onModeChange  func(consensus.OperatingMode)
+	modeChanges   []operatingModeChange
+	modeDraining  bool
 
 	// stateAcct tracks transition counts and cumulative durations per
 	// operating mode for server_info.state_accounting.

--- a/internal/consensus/adaptor/adaptor.go
+++ b/internal/consensus/adaptor/adaptor.go
@@ -65,6 +65,7 @@ type Adaptor struct {
 	trustedMasterKeys [][33]byte
 
 	operatingMode consensus.OperatingMode
+	onModeChange  func(consensus.OperatingMode)
 
 	// stateAcct tracks transition counts and cumulative durations per
 	// operating mode for server_info.state_accounting.

--- a/internal/consensus/adaptor/adaptor_test.go
+++ b/internal/consensus/adaptor/adaptor_test.go
@@ -180,6 +180,96 @@ func TestOperatingModeChangeCallbackRunsAfterEffectiveTransition(t *testing.T) {
 	}
 }
 
+func TestOperatingModeChangeCallbacksPreserveConcurrentTransitionOrder(t *testing.T) {
+	a := New(Config{})
+	callbackEntered := make(chan struct{})
+	releaseCallback := make(chan struct{})
+	callbacks := make(chan consensus.OperatingMode, 2)
+	a.SetOnOperatingModeChange(func(mode consensus.OperatingMode) {
+		if mode == consensus.OpModeConnected {
+			close(callbackEntered)
+			<-releaseCallback
+		}
+		callbacks <- mode
+	})
+
+	firstDone := make(chan struct{})
+	go func() {
+		a.SetOperatingMode(consensus.OpModeConnected)
+		close(firstDone)
+	}()
+	select {
+	case <-callbackEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first mode callback did not start")
+	}
+
+	secondDone := make(chan struct{})
+	go func() {
+		a.SetOperatingMode(consensus.OpModeSyncing)
+		close(secondDone)
+	}()
+	select {
+	case <-secondDone:
+	case <-time.After(time.Second):
+		t.Fatal("second mode transition blocked behind callback")
+	}
+	select {
+	case mode := <-callbacks:
+		t.Fatalf("later mode callback overtook blocked transition: %v", mode)
+	default:
+	}
+
+	close(releaseCallback)
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("mode callback drain did not complete")
+	}
+	for _, want := range []consensus.OperatingMode{consensus.OpModeConnected, consensus.OpModeSyncing} {
+		select {
+		case got := <-callbacks:
+			if got != want {
+				t.Fatalf("callback mode = %v, want %v", got, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("missing callback for mode %v", want)
+		}
+	}
+}
+
+func TestOperatingModeChangeCallbackMaySetOperatingMode(t *testing.T) {
+	a := New(Config{})
+	callbacks := make(chan consensus.OperatingMode, 2)
+	a.SetOnOperatingModeChange(func(mode consensus.OperatingMode) {
+		callbacks <- mode
+		if mode == consensus.OpModeConnected {
+			a.SetOperatingMode(consensus.OpModeSyncing)
+		}
+	})
+
+	done := make(chan struct{})
+	go func() {
+		a.SetOperatingMode(consensus.OpModeConnected)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("recursive mode transition deadlocked")
+	}
+	for _, want := range []consensus.OperatingMode{consensus.OpModeConnected, consensus.OpModeSyncing} {
+		select {
+		case got := <-callbacks:
+			if got != want {
+				t.Fatalf("callback mode = %v, want %v", got, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("missing callback for mode %v", want)
+		}
+	}
+}
+
 func TestAdaptorGetLastClosedLedger(t *testing.T) {
 	a := newTestAdaptor(t)
 

--- a/internal/consensus/adaptor/adaptor_test.go
+++ b/internal/consensus/adaptor/adaptor_test.go
@@ -152,6 +152,34 @@ func TestAdaptorOperatingMode(t *testing.T) {
 	assert.Equal(t, consensus.OpModeFull, a.GetOperatingMode())
 }
 
+func TestOperatingModeChangeCallbackRunsAfterEffectiveTransition(t *testing.T) {
+	a := New(Config{})
+	changed := make(chan consensus.OperatingMode, 1)
+	a.SetOnOperatingModeChange(func(mode consensus.OperatingMode) {
+		if got := a.GetOperatingMode(); got != mode {
+			t.Errorf("callback mode = %v, current mode = %v", mode, got)
+		}
+		changed <- mode
+	})
+
+	a.SetOperatingMode(consensus.OpModeDisconnected)
+	select {
+	case mode := <-changed:
+		t.Fatalf("same-mode update published %v", mode)
+	default:
+	}
+
+	go a.SetOperatingMode(consensus.OpModeConnected)
+	select {
+	case mode := <-changed:
+		if mode != consensus.OpModeConnected {
+			t.Fatalf("callback mode = %v", mode)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("mode callback deadlocked on adaptor re-entry")
+	}
+}
+
 func TestAdaptorGetLastClosedLedger(t *testing.T) {
 	a := newTestAdaptor(t)
 

--- a/internal/consensus/adaptor/consensus_events.go
+++ b/internal/consensus/adaptor/consensus_events.go
@@ -16,6 +16,11 @@ import (
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
+type operatingModeChange struct {
+	mode     consensus.OperatingMode
+	callback func(consensus.OperatingMode)
+}
+
 func (a *Adaptor) GetOperatingMode() consensus.OperatingMode {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -38,10 +43,10 @@ func (a *Adaptor) SetOperatingMode(mode consensus.OperatingMode) {
 		}
 	}
 	changed := a.setOperatingModeLocked(mode)
-	onModeChange := a.onModeChange
+	startDraining := changed && a.enqueueOperatingModeChangeLocked(mode)
 	a.mu.Unlock()
-	if changed && onModeChange != nil {
-		onModeChange(mode)
+	if startDraining {
+		a.drainOperatingModeChanges()
 	}
 }
 
@@ -65,16 +70,45 @@ func (a *Adaptor) SetOnOperatingModeChange(fn func(consensus.OperatingMode)) {
 	a.mu.Unlock()
 }
 
+func (a *Adaptor) enqueueOperatingModeChangeLocked(mode consensus.OperatingMode) bool {
+	if a.onModeChange == nil {
+		return false
+	}
+	a.modeChanges = append(a.modeChanges, operatingModeChange{mode: mode, callback: a.onModeChange})
+	if a.modeDraining {
+		return false
+	}
+	a.modeDraining = true
+	return true
+}
+
+func (a *Adaptor) drainOperatingModeChanges() {
+	for {
+		a.mu.Lock()
+		if len(a.modeChanges) == 0 {
+			a.modeDraining = false
+			a.mu.Unlock()
+			return
+		}
+		change := a.modeChanges[0]
+		a.modeChanges[0] = operatingModeChange{}
+		a.modeChanges = a.modeChanges[1:]
+		a.mu.Unlock()
+
+		change.callback(change.mode)
+	}
+}
+
 func (a *Adaptor) demoteOperatingModeForWrongLedger() {
 	a.mu.Lock()
 	changed := false
 	if a.operatingMode == consensus.OpModeFull || a.operatingMode == consensus.OpModeTracking {
 		changed = a.setOperatingModeLocked(consensus.OpModeConnected)
 	}
-	onModeChange := a.onModeChange
+	startDraining := changed && a.enqueueOperatingModeChangeLocked(consensus.OpModeConnected)
 	a.mu.Unlock()
-	if changed && onModeChange != nil {
-		onModeChange(consensus.OpModeConnected)
+	if startDraining {
+		a.drainOperatingModeChanges()
 	}
 }
 

--- a/internal/consensus/adaptor/consensus_events.go
+++ b/internal/consensus/adaptor/consensus_events.go
@@ -24,7 +24,6 @@ func (a *Adaptor) GetOperatingMode() consensus.OperatingMode {
 
 func (a *Adaptor) SetOperatingMode(mode consensus.OperatingMode) {
 	a.mu.Lock()
-	defer a.mu.Unlock()
 
 	// A blocked node is never more than connected: it cannot safely
 	// participate in consensus, so it must not claim to be synced.
@@ -38,24 +37,44 @@ func (a *Adaptor) SetOperatingMode(mode consensus.OperatingMode) {
 			mode = consensus.OpModeConnected
 		}
 	}
-	a.setOperatingModeLocked(mode)
+	changed := a.setOperatingModeLocked(mode)
+	onModeChange := a.onModeChange
+	a.mu.Unlock()
+	if changed && onModeChange != nil {
+		onModeChange(mode)
+	}
 }
 
-func (a *Adaptor) setOperatingModeLocked(mode consensus.OperatingMode) {
+func (a *Adaptor) setOperatingModeLocked(mode consensus.OperatingMode) bool {
+	if a.operatingMode == mode {
+		return false
+	}
 	a.operatingMode = mode
 	if a.stateAcct != nil {
 		// Held under a.mu so the field and the accounting transition share one
 		// serialization order; the tracker's own mutex never re-enters a.mu.
 		a.stateAcct.transition(mode)
 	}
+	return true
+}
+
+// SetOnOperatingModeChange installs a callback for effective mode changes.
+func (a *Adaptor) SetOnOperatingModeChange(fn func(consensus.OperatingMode)) {
+	a.mu.Lock()
+	a.onModeChange = fn
+	a.mu.Unlock()
 }
 
 func (a *Adaptor) demoteOperatingModeForWrongLedger() {
 	a.mu.Lock()
-	defer a.mu.Unlock()
-
+	changed := false
 	if a.operatingMode == consensus.OpModeFull || a.operatingMode == consensus.OpModeTracking {
-		a.setOperatingModeLocked(consensus.OpModeConnected)
+		changed = a.setOperatingModeLocked(consensus.OpModeConnected)
+	}
+	onModeChange := a.onModeChange
+	a.mu.Unlock()
+	if changed && onModeChange != nil {
+		onModeChange(consensus.OpModeConnected)
 	}
 }
 

--- a/internal/consensus/adaptor/stvalidation.go
+++ b/internal/consensus/adaptor/stvalidation.go
@@ -6,9 +6,30 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 )
+
+// CanonicalSTValidation returns the canonical serialized validation while
+// preserving the presence and values of optional fields received on the wire.
+func CanonicalSTValidation(v *consensus.Validation) ([]byte, error) {
+	if v == nil {
+		return nil, errors.New("nil validation")
+	}
+	if len(v.Raw) == 0 {
+		return SerializeSTValidation(v), nil
+	}
+	fields, err := binarycodec.DecodeBytes(v.Raw)
+	if err != nil {
+		return nil, fmt.Errorf("decode validation: %w", err)
+	}
+	canonical, err := binarycodec.EncodeBytesTrusted(fields)
+	if err != nil {
+		return nil, fmt.Errorf("encode validation: %w", err)
+	}
+	return canonical, nil
+}
 
 // XRPL SField type codes. An off-by-2 for UINT384/UINT512 would be
 // latent (no validation field uses these types) but would break the

--- a/internal/consensus/adaptor/stvalidation_template_test.go
+++ b/internal/consensus/adaptor/stvalidation_template_test.go
@@ -1,6 +1,7 @@
 package adaptor
 
 import (
+	"bytes"
 	"encoding/binary"
 	"sort"
 	"testing"
@@ -176,6 +177,17 @@ func TestParseSTValidation_TemplateShape(t *testing.T) {
 		validation, err := parseSTValidation(blob)
 		require.NoError(t, err)
 		assert.NoError(t, VerifyValidation(validation))
+
+		canonical, err := CanonicalSTValidation(validation)
+		require.NoError(t, err)
+		assert.False(t, bytes.Equal(blob, canonical))
+		canonicalFields := decodeValidationWireFields(t, canonical)
+		assert.True(t, sort.SliceIsSorted(canonicalFields, func(i, j int) bool {
+			return canonicalFields[i].key < canonicalFields[j].key
+		}))
+		reparsed, err := parseSTValidation(canonical)
+		require.NoError(t, err)
+		assert.NoError(t, VerifyValidation(reparsed))
 	})
 
 	t.Run("unexpected field", func(t *testing.T) {

--- a/internal/feetrack/feetrack.go
+++ b/internal/feetrack/feetrack.go
@@ -35,6 +35,7 @@ type LoadFeeTrack struct {
 	remoteFee  uint32
 	clusterFee uint32
 	raiseCount uint32
+	onChange   func()
 }
 
 // New returns a LoadFeeTrack initialised to the normal fee with no pending
@@ -50,8 +51,13 @@ func New() *LoadFeeTrack {
 // SetRemoteFee records a remote-reported fee factor.
 func (t *LoadFeeTrack) SetRemoteFee(f uint32) {
 	t.mu.Lock()
+	changed := t.remoteFee != f
 	t.remoteFee = f
+	onChange := t.onChange
 	t.mu.Unlock()
+	if changed && onChange != nil {
+		onChange()
+	}
 }
 
 // RemoteFee returns the last remote-reported fee factor.
@@ -64,7 +70,19 @@ func (t *LoadFeeTrack) RemoteFee() uint32 {
 // SetClusterFee records the cluster-aggregated fee factor.
 func (t *LoadFeeTrack) SetClusterFee(f uint32) {
 	t.mu.Lock()
+	changed := t.clusterFee != f
 	t.clusterFee = f
+	onChange := t.onChange
+	t.mu.Unlock()
+	if changed && onChange != nil {
+		onChange()
+	}
+}
+
+// SetOnChange installs a callback for effective fee-factor changes.
+func (t *LoadFeeTrack) SetOnChange(fn func()) {
+	t.mu.Lock()
+	t.onChange = fn
 	t.mu.Unlock()
 }
 
@@ -114,9 +132,9 @@ func (t *LoadFeeTrack) IsLoadedCluster() bool {
 // fee floor.
 func (t *LoadFeeTrack) RaiseLocalFee() bool {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	t.raiseCount++
 	if t.raiseCount < 2 {
+		t.mu.Unlock()
 		return false
 	}
 
@@ -127,7 +145,13 @@ func (t *LoadFeeTrack) RaiseLocalFee() bool {
 		raised = uint64(feeMax)
 	}
 	t.localFee = uint32(raised)
-	return orig != t.localFee
+	changed := orig != t.localFee
+	onChange := t.onChange
+	t.mu.Unlock()
+	if changed && onChange != nil {
+		onChange()
+	}
+	return changed
 }
 
 // LowerLocalFee decays the local fee back toward LoadBase and reports whether
@@ -135,14 +159,19 @@ func (t *LoadFeeTrack) RaiseLocalFee() bool {
 // next RaiseLocalFee again needs two ticks to take effect (hysteresis).
 func (t *LoadFeeTrack) LowerLocalFee() bool {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	orig := t.localFee
 	t.raiseCount = 0
 	t.localFee -= t.localFee / feeDecFraction
 	if t.localFee < LoadBase {
 		t.localFee = LoadBase
 	}
-	return orig != t.localFee
+	changed := orig != t.localFee
+	onChange := t.onChange
+	t.mu.Unlock()
+	if changed && onChange != nil {
+		onChange()
+	}
+	return changed
 }
 
 // ScaleFeeLoad scales fee by the current local/remote/cluster load.

--- a/internal/feetrack/feetrack_test.go
+++ b/internal/feetrack/feetrack_test.go
@@ -221,3 +221,24 @@ func TestLoadFactorAggregates(t *testing.T) {
 		t.Fatalf("scaling factors = (%d,%d); want (500,400)", feeFactor, remFee)
 	}
 }
+
+func TestOnChangeReportsOnlyEffectiveFactorChanges(t *testing.T) {
+	tr := New()
+	calls := 0
+	tr.SetOnChange(func() { calls++ })
+
+	tr.SetRemoteFee(LoadBase)
+	tr.SetClusterFee(LoadBase)
+	tr.RaiseLocalFee()
+	if calls != 0 {
+		t.Fatalf("callbacks before effective change = %d", calls)
+	}
+
+	tr.SetRemoteFee(512)
+	tr.SetClusterFee(384)
+	tr.RaiseLocalFee()
+	tr.LowerLocalFee()
+	if calls != 4 {
+		t.Fatalf("callbacks after effective changes = %d, want 4", calls)
+	}
+}

--- a/internal/ledger/service/components.go
+++ b/internal/ledger/service/components.go
@@ -29,6 +29,7 @@ type eventPublisher struct {
 	publicationQueue        []publicationEvent
 	publicationLimit        int
 	publicationFailed       bool
+	serverStatusQueued      bool
 	publicationErrors       chan error
 	ledgerEventCandidates   map[uint32]*LedgerAcceptedEvent
 	ledgerEventFrontierSeq  uint32
@@ -42,6 +43,7 @@ type eventPublisher struct {
 	subscriberMu            sync.RWMutex
 	eventSink               EventSink
 	submittedTxCallback     SubmittedTxCallback
+	serverStatusCallback    ServerStatusCallback
 }
 
 type historyComponent struct {

--- a/internal/ledger/service/events.go
+++ b/internal/ledger/service/events.go
@@ -87,11 +87,15 @@ type SubmittedTxCallback func(SubmittedTxEvent)
 // and must not call Service.Stop synchronously.
 type ServerStatusCallback func(mode *string)
 
+// ServerModePublication delivers a status snapshot captured at an effective
+// operating-mode transition. It follows the ServerStatusCallback contract.
+type ServerModePublication func()
+
 type publicationEvent struct {
 	ledger       *LedgerAcceptedEvent
 	submitted    *SubmittedTxEvent
 	serverStatus bool
-	serverMode   *string
+	serverMode   ServerModePublication
 }
 
 // Errors reports fatal publication failures that require runtime shutdown.
@@ -198,18 +202,20 @@ func (p *eventPublisher) dispatchServerStatusEvent() bool {
 	return true
 }
 
-func (p *eventPublisher) dispatchServerModeEvent(mode string) bool {
+func (p *eventPublisher) dispatchServerModeEvent(publication ServerModePublication) bool {
 	p.ledgerEventMu.Lock()
 	defer p.ledgerEventMu.Unlock()
 	if p.ledgerEventStopping || p.publicationFailed {
 		return false
 	}
+	if publication == nil {
+		return true
+	}
 	startDispatcher := p.startLedgerEventDispatcherLocked()
 	if startDispatcher {
 		go p.runLedgerEventDispatcher()
 	}
-	copy := mode
-	return p.enqueuePublicationLocked(publicationEvent{serverMode: &copy})
+	return p.enqueuePublicationLocked(publicationEvent{serverMode: publication})
 }
 
 func (p *eventPublisher) enqueuePublicationLocked(event publicationEvent) bool {
@@ -383,12 +389,16 @@ func (p *eventPublisher) deliverPublication(event publicationEvent) error {
 	if event.ledger != nil {
 		return p.deliverLedgerEvent(event.ledger)
 	}
-	if event.serverStatus || event.serverMode != nil {
+	if event.serverMode != nil {
+		event.serverMode()
+		return nil
+	}
+	if event.serverStatus {
 		p.subscriberMu.RLock()
 		callback := p.serverStatusCallback
 		p.subscriberMu.RUnlock()
 		if callback != nil {
-			callback(event.serverMode)
+			callback(nil)
 		}
 	}
 	return nil
@@ -454,11 +464,11 @@ func (s *Service) SignalServerStatus() bool {
 	return s.eventPublisher.dispatchServerStatusEvent()
 }
 
-// SignalServerMode schedules an exact effective operating-mode transition on
-// the shared publication FIFO. Unlike fee/load samples, mode changes do not
-// coalesce because subscribers must observe transition order.
-func (s *Service) SignalServerMode(mode string) bool {
-	return s.eventPublisher.dispatchServerModeEvent(mode)
+// SignalServerMode queues a status publication captured at an effective
+// operating-mode transition. Mode publications do not coalesce because
+// subscribers must observe transition order.
+func (s *Service) SignalServerMode(publication ServerModePublication) bool {
+	return s.eventPublisher.dispatchServerModeEvent(publication)
 }
 
 // SetTxRelay registers the per-tx broadcast handler invoked by

--- a/internal/ledger/service/events.go
+++ b/internal/ledger/service/events.go
@@ -83,9 +83,15 @@ type Result struct {
 // and must not call Service.Stop synchronously.
 type SubmittedTxCallback func(SubmittedTxEvent)
 
+// ServerStatusCallback runs on the publication worker. It must return promptly
+// and must not call Service.Stop synchronously.
+type ServerStatusCallback func(mode *string)
+
 type publicationEvent struct {
-	ledger    *LedgerAcceptedEvent
-	submitted *SubmittedTxEvent
+	ledger       *LedgerAcceptedEvent
+	submitted    *SubmittedTxEvent
+	serverStatus bool
+	serverMode   *string
 }
 
 // Errors reports fatal publication failures that require runtime shutdown.
@@ -121,6 +127,12 @@ func (p *eventPublisher) hasSubmittedTxCallback() bool {
 	p.subscriberMu.RLock()
 	defer p.subscriberMu.RUnlock()
 	return p.submittedTxCallback != nil
+}
+
+func (p *eventPublisher) setServerStatusCallback(fn ServerStatusCallback) {
+	p.subscriberMu.Lock()
+	defer p.subscriberMu.Unlock()
+	p.serverStatusCallback = fn
 }
 
 // dispatchLedgerEvent enqueues accepted ledgers for FIFO, single-threaded
@@ -164,6 +176,40 @@ func (p *eventPublisher) dispatchSubmittedTxEvent(event SubmittedTxEvent) {
 	copy := event
 	p.enqueuePublicationLocked(publicationEvent{submitted: &copy})
 	p.ledgerEventMu.Unlock()
+}
+
+func (p *eventPublisher) dispatchServerStatusEvent() bool {
+	p.ledgerEventMu.Lock()
+	defer p.ledgerEventMu.Unlock()
+	if p.ledgerEventStopping || p.publicationFailed {
+		return false
+	}
+	startDispatcher := p.startLedgerEventDispatcherLocked()
+	if startDispatcher {
+		go p.runLedgerEventDispatcher()
+	}
+	if p.serverStatusQueued {
+		return true
+	}
+	if !p.enqueuePublicationLocked(publicationEvent{serverStatus: true}) {
+		return false
+	}
+	p.serverStatusQueued = true
+	return true
+}
+
+func (p *eventPublisher) dispatchServerModeEvent(mode string) bool {
+	p.ledgerEventMu.Lock()
+	defer p.ledgerEventMu.Unlock()
+	if p.ledgerEventStopping || p.publicationFailed {
+		return false
+	}
+	startDispatcher := p.startLedgerEventDispatcherLocked()
+	if startDispatcher {
+		go p.runLedgerEventDispatcher()
+	}
+	copy := mode
+	return p.enqueuePublicationLocked(publicationEvent{serverMode: &copy})
 }
 
 func (p *eventPublisher) enqueuePublicationLocked(event publicationEvent) bool {
@@ -301,6 +347,9 @@ func (p *eventPublisher) runLedgerEventDispatcher() {
 				ev := p.publicationQueue[0]
 				p.publicationQueue[0] = publicationEvent{}
 				p.publicationQueue = p.publicationQueue[1:]
+				if ev.serverStatus {
+					p.serverStatusQueued = false
+				}
 				p.ledgerEventMu.Unlock()
 				if err := p.deliverPublication(ev); err != nil {
 					p.ledgerEventMu.Lock()
@@ -333,6 +382,14 @@ func (p *eventPublisher) deliverPublication(event publicationEvent) error {
 	}
 	if event.ledger != nil {
 		return p.deliverLedgerEvent(event.ledger)
+	}
+	if event.serverStatus || event.serverMode != nil {
+		p.subscriberMu.RLock()
+		callback := p.serverStatusCallback
+		p.subscriberMu.RUnlock()
+		if callback != nil {
+			callback(event.serverMode)
+		}
 	}
 	return nil
 }
@@ -383,6 +440,25 @@ func (p *eventPublisher) deliverLedgerEvent(event *LedgerAcceptedEvent) error {
 // unwire. The callback contract is documented on SubmittedTxCallback.
 func (s *Service) SetSubmittedTxCallback(fn SubmittedTxCallback) {
 	s.eventPublisher.setSubmittedTxCallback(fn)
+}
+
+// SetServerStatusCallback registers the callback used to sample and publish
+// the current server status. Pass nil to unwire.
+func (s *Service) SetServerStatusCallback(fn ServerStatusCallback) {
+	s.eventPublisher.setServerStatusCallback(fn)
+}
+
+// SignalServerStatus schedules a coalesced server-status sample on the shared
+// publication FIFO. It reports false after publication has stopped or failed.
+func (s *Service) SignalServerStatus() bool {
+	return s.eventPublisher.dispatchServerStatusEvent()
+}
+
+// SignalServerMode schedules an exact effective operating-mode transition on
+// the shared publication FIFO. Unlike fee/load samples, mode changes do not
+// coalesce because subscribers must observe transition order.
+func (s *Service) SignalServerMode(mode string) bool {
+	return s.eventPublisher.dispatchServerModeEvent(mode)
 }
 
 // SetTxRelay registers the per-tx broadcast handler invoked by

--- a/internal/ledger/service/events.go
+++ b/internal/ledger/service/events.go
@@ -87,15 +87,15 @@ type SubmittedTxCallback func(SubmittedTxEvent)
 // and must not call Service.Stop synchronously.
 type ServerStatusCallback func(mode *string)
 
-// ServerModePublication delivers a status snapshot captured at an effective
-// operating-mode transition. It follows the ServerStatusCallback contract.
-type ServerModePublication func()
+// ServerStatusPublication delivers a status snapshot captured when its
+// triggering state changes.
+type ServerStatusPublication func()
 
 type publicationEvent struct {
-	ledger       *LedgerAcceptedEvent
-	submitted    *SubmittedTxEvent
-	serverStatus bool
-	serverMode   ServerModePublication
+	ledger         *LedgerAcceptedEvent
+	submitted      *SubmittedTxEvent
+	serverStatus   bool
+	serverSnapshot ServerStatusPublication
 }
 
 // Errors reports fatal publication failures that require runtime shutdown.
@@ -202,7 +202,7 @@ func (p *eventPublisher) dispatchServerStatusEvent() bool {
 	return true
 }
 
-func (p *eventPublisher) dispatchServerModeEvent(publication ServerModePublication) bool {
+func (p *eventPublisher) dispatchServerStatusPublication(publication ServerStatusPublication) bool {
 	p.ledgerEventMu.Lock()
 	defer p.ledgerEventMu.Unlock()
 	if p.ledgerEventStopping || p.publicationFailed {
@@ -215,7 +215,7 @@ func (p *eventPublisher) dispatchServerModeEvent(publication ServerModePublicati
 	if startDispatcher {
 		go p.runLedgerEventDispatcher()
 	}
-	return p.enqueuePublicationLocked(publicationEvent{serverMode: publication})
+	return p.enqueuePublicationLocked(publicationEvent{serverSnapshot: publication})
 }
 
 func (p *eventPublisher) enqueuePublicationLocked(event publicationEvent) bool {
@@ -389,8 +389,8 @@ func (p *eventPublisher) deliverPublication(event publicationEvent) error {
 	if event.ledger != nil {
 		return p.deliverLedgerEvent(event.ledger)
 	}
-	if event.serverMode != nil {
-		event.serverMode()
+	if event.serverSnapshot != nil {
+		event.serverSnapshot()
 		return nil
 	}
 	if event.serverStatus {
@@ -464,11 +464,11 @@ func (s *Service) SignalServerStatus() bool {
 	return s.eventPublisher.dispatchServerStatusEvent()
 }
 
-// SignalServerMode queues a status publication captured at an effective
-// operating-mode transition. Mode publications do not coalesce because
-// subscribers must observe transition order.
-func (s *Service) SignalServerMode(publication ServerModePublication) bool {
-	return s.eventPublisher.dispatchServerModeEvent(publication)
+// SignalServerStatusPublication queues a captured status snapshot. Captured
+// publications do not coalesce because subscribers must observe state changes
+// in trigger order.
+func (s *Service) SignalServerStatusPublication(publication ServerStatusPublication) bool {
+	return s.eventPublisher.dispatchServerStatusPublication(publication)
 }
 
 // SetTxRelay registers the per-tx broadcast handler invoked by

--- a/internal/ledger/service/publication_order_test.go
+++ b/internal/ledger/service/publication_order_test.go
@@ -203,3 +203,171 @@ func TestPublicationDispatcherRejectsAfterStop(t *testing.T) {
 	default:
 	}
 }
+
+func TestServerStatusSignalPreservesPublicationOrder(t *testing.T) {
+	publisher := &eventPublisher{
+		service:               &Service{},
+		publicationLimit:      4,
+		publicationErrors:     make(chan error, 1),
+		ledgerEventCandidates: make(map[uint32]*LedgerAcceptedEvent),
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	var mu sync.Mutex
+	var order []string
+	publisher.setSubmittedTxCallback(func(event SubmittedTxEvent) {
+		mu.Lock()
+		order = append(order, "proposed")
+		mu.Unlock()
+		if event.CurrentLedger == 1 {
+			close(started)
+			<-release
+		}
+		if event.CurrentLedger == 2 {
+			close(done)
+		}
+	})
+	publisher.setServerStatusCallback(func(*string) {
+		mu.Lock()
+		order = append(order, "server")
+		mu.Unlock()
+	})
+	publisher.start()
+	publisher.dispatchSubmittedTxEvent(SubmittedTxEvent{CurrentLedger: 1})
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first publication did not start")
+	}
+	if !publisher.dispatchServerStatusEvent() {
+		t.Fatal("server status signal was rejected")
+	}
+	publisher.dispatchSubmittedTxEvent(SubmittedTxEvent{CurrentLedger: 2})
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("publication queue did not drain")
+	}
+	publisher.stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got := strings.Join(order, ","); got != "proposed,server,proposed" {
+		t.Fatalf("publication order = %s", got)
+	}
+}
+
+func TestServerStatusSignalCoalescesAndAllowsCallbackReentry(t *testing.T) {
+	publisher := &eventPublisher{
+		service:               &Service{},
+		publicationLimit:      2,
+		publicationErrors:     make(chan error, 1),
+		ledgerEventCandidates: make(map[uint32]*LedgerAcceptedEvent),
+	}
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	thirdDone := make(chan struct{})
+	var mu sync.Mutex
+	calls := 0
+	publisher.setServerStatusCallback(func(*string) {
+		mu.Lock()
+		calls++
+		call := calls
+		mu.Unlock()
+		switch call {
+		case 1:
+			close(firstStarted)
+			<-releaseFirst
+		case 2:
+			if !publisher.dispatchServerStatusEvent() {
+				t.Error("reentrant status signal was rejected")
+			}
+		case 3:
+			close(thirdDone)
+		}
+	})
+	publisher.start()
+	if !publisher.dispatchServerStatusEvent() {
+		t.Fatal("first status signal was rejected")
+	}
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first status callback did not start")
+	}
+	for range 10 {
+		if !publisher.dispatchServerStatusEvent() {
+			t.Fatal("coalesced status signal was rejected")
+		}
+	}
+	close(releaseFirst)
+	select {
+	case <-thirdDone:
+	case <-time.After(time.Second):
+		t.Fatal("reentrant status callback did not run")
+	}
+	publisher.stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 3 {
+		t.Fatalf("status callbacks = %d, want 3", calls)
+	}
+}
+
+func TestServerStatusSignalDrainsOnStopAndRejectsAfter(t *testing.T) {
+	publisher := &eventPublisher{
+		service:               &Service{},
+		publicationLimit:      2,
+		publicationErrors:     make(chan error, 1),
+		ledgerEventCandidates: make(map[uint32]*LedgerAcceptedEvent),
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	drained := make(chan struct{})
+	var mu sync.Mutex
+	calls := 0
+	publisher.setServerStatusCallback(func(*string) {
+		mu.Lock()
+		calls++
+		call := calls
+		mu.Unlock()
+		if call == 1 {
+			close(started)
+			<-release
+		}
+	})
+	publisher.start()
+	publisher.dispatchServerStatusEvent()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("status callback did not start")
+	}
+	publisher.dispatchServerStatusEvent()
+	go func() {
+		publisher.stop()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+		t.Fatal("stop returned before queued status drained")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case <-drained:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not return after status drain")
+	}
+	if publisher.dispatchServerStatusEvent() {
+		t.Fatal("status signal was accepted after stop")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 2 {
+		t.Fatalf("status callbacks = %d, want 2", calls)
+	}
+}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -869,7 +869,9 @@ func (s *Service) SubmitOpenLedgerTx(blob []byte, local bool) (openledger.Result
 		s.localTxs.PushBack(current.Sequence(), ptx)
 	}
 	s.dispatchProposedTransaction(ptx, blob, outcome, current)
-	s.eventPublisher.dispatchServerStatusEvent()
+	if outcome.Applied {
+		s.eventPublisher.dispatchServerStatusEvent()
+	}
 	return outcome.Class, nil
 }
 

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -869,6 +869,7 @@ func (s *Service) SubmitOpenLedgerTx(blob []byte, local bool) (openledger.Result
 		s.localTxs.PushBack(current.Sequence(), ptx)
 	}
 	s.dispatchProposedTransaction(ptx, blob, outcome, current)
+	s.eventPublisher.dispatchServerStatusEvent()
 	return outcome.Class, nil
 }
 

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -178,7 +178,9 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 	}
 
 	s.dispatchProposedTransaction(ptx, rawBlob, outcome, s.openLedgerView.Current())
-	s.eventPublisher.dispatchServerStatusEvent()
+	if outcome.Applied {
+		s.eventPublisher.dispatchServerStatusEvent()
+	}
 
 	return result, nil
 }

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -178,6 +178,7 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 	}
 
 	s.dispatchProposedTransaction(ptx, rawBlob, outcome, s.openLedgerView.Current())
+	s.eventPublisher.dispatchServerStatusEvent()
 
 	return result, nil
 }

--- a/internal/node/adapters.go
+++ b/internal/node/adapters.go
@@ -590,14 +590,18 @@ func (p *serverStatusPublisher) publish(mode *string) {
 	p.publishCaptured(snapshot, event)
 }
 
-func (p *serverStatusPublisher) modePublication(mode string) service.ServerModePublication {
-	snapshot, event := p.capture(&mode)
+func (p *serverStatusPublisher) statusPublication(mode *string) service.ServerStatusPublication {
+	snapshot, event := p.capture(mode)
 	if event == nil {
 		return nil
 	}
 	return func() {
 		p.publishCaptured(snapshot, event)
 	}
+}
+
+func (p *serverStatusPublisher) modePublication(mode string) service.ServerStatusPublication {
+	return p.statusPublication(&mode)
 }
 
 func (p *serverStatusPublisher) capture(mode *string) (serverStatusSnapshot, *rpc.ServerStatusEvent) {

--- a/internal/node/adapters.go
+++ b/internal/node/adapters.go
@@ -16,6 +16,7 @@ import (
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec/definitions"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
+	consensusadaptor "github.com/LeJamon/go-xrpl/internal/consensus/adaptor"
 	"github.com/LeJamon/go-xrpl/internal/ledger/cleaner"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/manifest"
@@ -25,6 +26,7 @@ import (
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/internal/txq"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
@@ -134,24 +136,69 @@ func (a *ledgerInfoAdapter) GetCurrentLedgerInfo() *types.LedgerSubscribeInfo {
 		return nil
 	}
 
-	baseFee, reserveBase, reserveInc := a.ledgerService.GetCurrentFees()
+	baseFee, reserveBase, reserveInc := service.FeesFromLedger(validatedLedger)
 
 	ledgerTime := protocol.ToRippleTime(validatedLedger.CloseTime())
 
 	hash := validatedLedger.Hash()
 	serverInfo := a.ledgerService.GetServerInfo()
+	validatedLedgers := ""
+	if serverPublishesValidatedRange(serverInfo.ServerState) && !serverInfo.NeedsNetworkLedger {
+		validatedLedgers = serverInfo.CompleteLedgers
+	}
+	xrpFeesEnabled := validatedLedger.Rules() != nil && validatedLedger.Rules().XRPFeesEnabled()
 
 	return &types.LedgerSubscribeInfo{
 		LedgerIndex:      validatedLedger.Sequence(),
 		LedgerHash:       upperHex(hash[:]),
 		LedgerTime:       ledgerTime,
 		FeeBase:          baseFee,
-		FeeRef:           baseFee,
+		FeeRef:           deprecatedFeeReferenceUnits,
 		ReserveBase:      reserveBase,
 		ReserveInc:       reserveInc,
-		ValidatedLedgers: serverInfo.CompleteLedgers,
+		ValidatedLedgers: validatedLedgers,
 		NetworkID:        serverInfo.NetworkID,
-		XRPFeesEnabled:   a.ledgerService.XRPFeesEnabled(),
+		XRPFeesEnabled:   xrpFeesEnabled,
+	}
+}
+
+const deprecatedFeeReferenceUnits uint64 = 10
+
+func serverPublishesValidatedRange(state string) bool {
+	switch state {
+	case "syncing", "tracking", "full", "proposing", "validating":
+		return true
+	default:
+		return false
+	}
+}
+
+func buildLedgerCloseEvent(event *service.LedgerAcceptedEvent, serverInfo service.ServerInfo) *rpc.LedgerCloseEvent {
+	if event == nil || event.LedgerInfo == nil || event.Ledger == nil {
+		return nil
+	}
+	baseFee, reserveBase, reserveInc := service.FeesFromLedger(event.Ledger)
+	var feeRef *uint64
+	if rules := event.Ledger.Rules(); rules == nil || !rules.XRPFeesEnabled() {
+		value := deprecatedFeeReferenceUnits
+		feeRef = &value
+	}
+	validatedLedgers := ""
+	if serverPublishesValidatedRange(serverInfo.ServerState) {
+		validatedLedgers = serverInfo.CompleteLedgers
+	}
+	return &rpc.LedgerCloseEvent{
+		Type:             "ledgerClosed",
+		LedgerIndex:      event.LedgerInfo.Sequence,
+		LedgerHash:       upperHex(event.LedgerInfo.Hash[:]),
+		LedgerTime:       protocol.ToRippleTime(event.LedgerInfo.CloseTime),
+		FeeBase:          baseFee,
+		FeeRef:           feeRef,
+		NetworkID:        serverInfo.NetworkID,
+		ReserveBase:      reserveBase,
+		ReserveInc:       reserveInc,
+		TxnCount:         len(event.TransactionResults),
+		ValidatedLedgers: validatedLedgers,
 	}
 }
 
@@ -260,7 +307,12 @@ func (b *rpcEventBridge) OnEvent(event consensus.Event) {
 		if e == nil || e.Validation == nil {
 			return
 		}
-		b.publisher.PublishValidation(buildValidationEvent(e, b.manifests, b.networkID))
+		validationEvent, err := buildValidationEvent(e, b.manifests, b.networkID)
+		if err != nil {
+			xrpllog.Named(xrpllog.PartitionRPC).Error("Skipping invalid validation event", "err", err)
+			return
+		}
+		b.publisher.PublishValidation(validationEvent)
 	case *consensus.PhaseChangedEvent:
 		if e == nil {
 			return
@@ -286,26 +338,30 @@ func consensusPhaseName(p consensus.Phase) string {
 // from a ValidationReceivedEvent. master_key is emitted only when the
 // manifest cache resolves a master distinct from the signing key
 // (NetworkOPs.cpp:2434-2438); validation_public_key carries the signing
-// (ephemeral) key in every case. The raw STValidation wire bytes are
-// surfaced via the `data` field (NetworkOPs.cpp:2422) and network_id
+// (ephemeral) key in every case. Canonical STValidation bytes are
+// surfaced via the `data` field and network_id
 // from the local config (NetworkOPs.cpp:2423).
-func buildValidationEvent(e *consensus.ValidationReceivedEvent, manifests *manifest.Cache, networkID uint32) *rpc.ValidationEvent {
+func buildValidationEvent(e *consensus.ValidationReceivedEvent, manifests *manifest.Cache, networkID uint32) (*rpc.ValidationEvent, error) {
 	v := e.Validation
+	canonical, err := consensusadaptor.CanonicalSTValidation(v)
+	if err != nil {
+		return nil, err
+	}
 	signingEnc, _ := addresscodec.EncodeNodePublicKey(v.SigningPubKey[:])
 	ev := rpc.NewValidationEvent(
 		upperHex(v.LedgerID[:]),
-		strconv.FormatUint(uint64(v.LedgerSeq), 10),
+		v.LedgerSeq,
 		signingEnc,
 		upperHex(v.Signature),
 		protocol.ToRippleTime(v.SignTime),
 		v.Flags,
 		v.Full,
 	)
-	if len(v.Raw) > 0 {
-		ev.Data = upperHex(v.Raw)
-	}
-	if networkID > 0 {
-		ev.NetworkID = networkID
+	ev.Data = upperHex(canonical)
+	ev.NetworkID = networkID
+	if !v.CloseTime.IsZero() {
+		closeTime := protocol.ToRippleTime(v.CloseTime)
+		ev.CloseTime = &closeTime
 	}
 	if manifests != nil {
 		master := manifests.GetMasterKey(v.SigningPubKey)
@@ -352,7 +408,7 @@ func buildValidationEvent(e *consensus.ValidationReceivedEvent, manifests *manif
 	if v.ValidatedHash != [32]byte{} {
 		ev.ValidatedHash = upperHex(v.ValidatedHash[:])
 	}
-	return ev
+	return ev, nil
 }
 
 func jsonClippedXRPAmount(value int64) int32 {

--- a/internal/node/adapters.go
+++ b/internal/node/adapters.go
@@ -568,7 +568,7 @@ type serverStatusSnapshot struct {
 }
 
 type serverStatusEventPublisher interface {
-	PublishServerStatus(*rpc.ServerStatusEvent)
+	PublishServerStatus(*rpc.ServerStatusEvent) bool
 }
 
 type serverStatusPublisher struct {
@@ -586,12 +586,27 @@ func newServerStatusPublisher(services *types.ServiceContainer, publisher server
 }
 
 func (p *serverStatusPublisher) publish(mode *string) {
+	snapshot, event := p.capture(mode)
+	p.publishCaptured(snapshot, event)
+}
+
+func (p *serverStatusPublisher) modePublication(mode string) service.ServerModePublication {
+	snapshot, event := p.capture(&mode)
+	if event == nil {
+		return nil
+	}
+	return func() {
+		p.publishCaptured(snapshot, event)
+	}
+}
+
+func (p *serverStatusPublisher) capture(mode *string) (serverStatusSnapshot, *rpc.ServerStatusEvent) {
 	if p == nil || p.services == nil || p.services.Ledger == nil || p.publisher == nil {
-		return
+		return serverStatusSnapshot{}, nil
 	}
 	p.mu.Lock()
-	baseFee, _, _ := p.services.Ledger.GetCurrentFees()
-	load := handlers.ComputeServerLoad(p.services)
+	defer p.mu.Unlock()
+
 	serverStatus := "full"
 	if mode != nil {
 		serverStatus = *mode
@@ -606,13 +621,8 @@ func (p *serverStatusPublisher) publish(mode *string) {
 		p.mode = serverStatus
 		p.haveMode = true
 	}
-	baseFeeClipped := jsonClippedXRPAmount(int64(baseFee))
-	loadBase := clipServerLoad(load.LoadBase)
-	loadFactor := clipServerLoad(load.LoadFactor)
-	loadFactorFeeEscalation := clipServerLoad(load.LoadFactorFeeEscalation)
-	loadFactorFeeQueue := clipServerLoad(load.LoadFactorFeeQueue)
-	loadFactorFeeReference := clipServerLoad(load.LoadFactorFeeReference)
-	loadFactorServer := clipServerLoad(load.LoadFactorServer)
+	baseFee, _, _ := p.services.Ledger.GetCurrentFees()
+	load := handlers.ComputeServerLoad(p.services)
 	snapshot := serverStatusSnapshot{
 		baseFee:                 baseFee,
 		loadBase:                load.LoadBase,
@@ -623,26 +633,32 @@ func (p *serverStatusPublisher) publish(mode *string) {
 		loadFactorServer:        load.LoadFactorServer,
 		serverStatus:            serverStatus,
 	}
+	return snapshot, &rpc.ServerStatusEvent{
+		Type:                    "serverStatus",
+		BaseFee:                 jsonClippedXRPAmount(int64(baseFee)),
+		LoadBase:                clipServerLoad(load.LoadBase),
+		LoadFactor:              clipServerLoad(load.LoadFactor),
+		LoadFactorFeeEscalation: clipServerLoad(load.LoadFactorFeeEscalation),
+		LoadFactorFeeQueue:      clipServerLoad(load.LoadFactorFeeQueue),
+		LoadFactorFeeReference:  clipServerLoad(load.LoadFactorFeeReference),
+		LoadFactorServer:        clipServerLoad(load.LoadFactorServer),
+		ServerStatus:            serverStatus,
+	}
+}
 
-	if p.haveLast && snapshot == p.last {
-		p.mu.Unlock()
+func (p *serverStatusPublisher) publishCaptured(snapshot serverStatusSnapshot, event *rpc.ServerStatusEvent) {
+	if event == nil {
 		return
 	}
-	p.last = snapshot
-	p.haveLast = true
-	p.mu.Unlock()
-
-	p.publisher.PublishServerStatus(&rpc.ServerStatusEvent{
-		Type:                    "serverStatus",
-		BaseFee:                 baseFeeClipped,
-		LoadBase:                loadBase,
-		LoadFactor:              loadFactor,
-		LoadFactorFeeEscalation: loadFactorFeeEscalation,
-		LoadFactorFeeQueue:      loadFactorFeeQueue,
-		LoadFactorFeeReference:  loadFactorFeeReference,
-		LoadFactorServer:        loadFactorServer,
-		ServerStatus:            serverStatus,
-	})
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.haveLast && snapshot == p.last {
+		return
+	}
+	if p.publisher.PublishServerStatus(event) {
+		p.last = snapshot
+		p.haveLast = true
+	}
 }
 
 func clipServerLoad(value uint64) uint32 {

--- a/internal/node/adapters.go
+++ b/internal/node/adapters.go
@@ -565,14 +565,82 @@ type serverStatusSnapshot struct {
 	baseFee                 uint64
 	loadBase                uint64
 	loadFactor              uint64
-	loadFactorLocal         uint64
-	loadFactorNet           uint64
-	loadFactorCluster       uint64
 	loadFactorFeeEscalation uint64
 	loadFactorFeeQueue      uint64
 	loadFactorFeeReference  uint64
 	loadFactorServer        uint64
 	serverStatus            string
+}
+
+type serverStatusEventPublisher interface {
+	PublishServerStatus(*rpc.ServerStatusEvent)
+}
+
+type serverStatusPublisher struct {
+	mu        sync.Mutex
+	services  *types.ServiceContainer
+	publisher serverStatusEventPublisher
+	haveLast  bool
+	last      serverStatusSnapshot
+	haveMode  bool
+	mode      string
+}
+
+func newServerStatusPublisher(services *types.ServiceContainer, publisher serverStatusEventPublisher) *serverStatusPublisher {
+	return &serverStatusPublisher{services: services, publisher: publisher}
+}
+
+func (p *serverStatusPublisher) publish(mode *string) {
+	if p == nil || p.services == nil || p.services.Ledger == nil || p.publisher == nil {
+		return
+	}
+	p.mu.Lock()
+	baseFee, _, _ := p.services.Ledger.GetCurrentFees()
+	load := handlers.ComputeServerLoad(p.services)
+	serverStatus := "full"
+	if mode != nil {
+		serverStatus = *mode
+		p.mode = serverStatus
+		p.haveMode = true
+	} else if p.haveMode {
+		serverStatus = p.mode
+	} else {
+		if info := p.services.Ledger.GetServerInfo(); info.ServerState != "" {
+			serverStatus = info.ServerState
+		}
+		p.mode = serverStatus
+		p.haveMode = true
+	}
+	snapshot := serverStatusSnapshot{
+		baseFee:                 baseFee,
+		loadBase:                load.LoadBase,
+		loadFactor:              load.LoadFactor,
+		loadFactorFeeEscalation: load.LoadFactorFeeEscalation,
+		loadFactorFeeQueue:      load.LoadFactorFeeQueue,
+		loadFactorFeeReference:  load.LoadFactorFeeReference,
+		loadFactorServer:        load.LoadFactorServer,
+		serverStatus:            serverStatus,
+	}
+
+	if p.haveLast && snapshot == p.last {
+		p.mu.Unlock()
+		return
+	}
+	p.last = snapshot
+	p.haveLast = true
+	p.mu.Unlock()
+
+	p.publisher.PublishServerStatus(&rpc.ServerStatusEvent{
+		Type:                    "serverStatus",
+		BaseFee:                 baseFee,
+		LoadBase:                int(load.LoadBase),
+		LoadFactor:              int(load.LoadFactor),
+		LoadFactorFeeEscalation: int(load.LoadFactorFeeEscalation),
+		LoadFactorFeeQueue:      int(load.LoadFactorFeeQueue),
+		LoadFactorFeeReference:  int(load.LoadFactorFeeReference),
+		LoadFactorServer:        int(load.LoadFactorServer),
+		ServerStatus:            serverStatus,
+	})
 }
 
 // acceptedLedgerView adapts a LedgerAcceptedEvent to the

--- a/internal/node/adapters.go
+++ b/internal/node/adapters.go
@@ -15,6 +15,7 @@ import (
 	"github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec/definitions"
+	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	consensusadaptor "github.com/LeJamon/go-xrpl/internal/consensus/adaptor"
 	"github.com/LeJamon/go-xrpl/internal/ledger/cleaner"
@@ -152,10 +153,10 @@ func (a *ledgerInfoAdapter) GetCurrentLedgerInfo() *types.LedgerSubscribeInfo {
 		LedgerIndex:      validatedLedger.Sequence(),
 		LedgerHash:       upperHex(hash[:]),
 		LedgerTime:       ledgerTime,
-		FeeBase:          baseFee,
+		FeeBase:          jsonClippedXRPAmount(int64(baseFee)),
 		FeeRef:           deprecatedFeeReferenceUnits,
-		ReserveBase:      reserveBase,
-		ReserveInc:       reserveInc,
+		ReserveBase:      jsonClippedXRPAmount(int64(reserveBase)),
+		ReserveInc:       jsonClippedXRPAmount(int64(reserveInc)),
 		ValidatedLedgers: validatedLedgers,
 		NetworkID:        serverInfo.NetworkID,
 		XRPFeesEnabled:   xrpFeesEnabled,
@@ -192,11 +193,11 @@ func buildLedgerCloseEvent(event *service.LedgerAcceptedEvent, serverInfo servic
 		LedgerIndex:      event.LedgerInfo.Sequence,
 		LedgerHash:       upperHex(event.LedgerInfo.Hash[:]),
 		LedgerTime:       protocol.ToRippleTime(event.LedgerInfo.CloseTime),
-		FeeBase:          baseFee,
+		FeeBase:          jsonClippedXRPAmount(int64(baseFee)),
 		FeeRef:           feeRef,
 		NetworkID:        serverInfo.NetworkID,
-		ReserveBase:      reserveBase,
-		ReserveInc:       reserveInc,
+		ReserveBase:      jsonClippedXRPAmount(int64(reserveBase)),
+		ReserveInc:       jsonClippedXRPAmount(int64(reserveInc)),
 		TxnCount:         len(event.TransactionResults),
 		ValidatedLedgers: validatedLedgers,
 	}
@@ -412,13 +413,7 @@ func buildValidationEvent(e *consensus.ValidationReceivedEvent, manifests *manif
 }
 
 func jsonClippedXRPAmount(value int64) int32 {
-	if value < math.MinInt32 {
-		return math.MinInt32
-	}
-	if value > math.MaxInt32 {
-		return math.MaxInt32
-	}
-	return int32(value)
+	return drops.XRPAmount(value).JSONClipped()
 }
 
 func extractBookPairsFromMetadata(metaJSON []byte) []types.OrderBookSpec {
@@ -611,6 +606,13 @@ func (p *serverStatusPublisher) publish(mode *string) {
 		p.mode = serverStatus
 		p.haveMode = true
 	}
+	baseFeeClipped := jsonClippedXRPAmount(int64(baseFee))
+	loadBase := clipServerLoad(load.LoadBase)
+	loadFactor := clipServerLoad(load.LoadFactor)
+	loadFactorFeeEscalation := clipServerLoad(load.LoadFactorFeeEscalation)
+	loadFactorFeeQueue := clipServerLoad(load.LoadFactorFeeQueue)
+	loadFactorFeeReference := clipServerLoad(load.LoadFactorFeeReference)
+	loadFactorServer := clipServerLoad(load.LoadFactorServer)
 	snapshot := serverStatusSnapshot{
 		baseFee:                 baseFee,
 		loadBase:                load.LoadBase,
@@ -632,15 +634,22 @@ func (p *serverStatusPublisher) publish(mode *string) {
 
 	p.publisher.PublishServerStatus(&rpc.ServerStatusEvent{
 		Type:                    "serverStatus",
-		BaseFee:                 baseFee,
-		LoadBase:                int(load.LoadBase),
-		LoadFactor:              int(load.LoadFactor),
-		LoadFactorFeeEscalation: int(load.LoadFactorFeeEscalation),
-		LoadFactorFeeQueue:      int(load.LoadFactorFeeQueue),
-		LoadFactorFeeReference:  int(load.LoadFactorFeeReference),
-		LoadFactorServer:        int(load.LoadFactorServer),
+		BaseFee:                 baseFeeClipped,
+		LoadBase:                loadBase,
+		LoadFactor:              loadFactor,
+		LoadFactorFeeEscalation: loadFactorFeeEscalation,
+		LoadFactorFeeQueue:      loadFactorFeeQueue,
+		LoadFactorFeeReference:  loadFactorFeeReference,
+		LoadFactorServer:        loadFactorServer,
 		ServerStatus:            serverStatus,
 	})
+}
+
+func clipServerLoad(value uint64) uint32 {
+	if value > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(value)
 }
 
 // acceptedLedgerView adapts a LedgerAcceptedEvent to the

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -35,7 +35,6 @@ import (
 	validatorlist "github.com/LeJamon/go-xrpl/internal/validator/list"
 	"github.com/LeJamon/go-xrpl/internal/watchdog"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
-	"github.com/LeJamon/go-xrpl/protocol"
 	"github.com/LeJamon/go-xrpl/shamap/backend"
 	kvpebble "github.com/LeJamon/go-xrpl/storage/kvstore/pebble"
 	"github.com/LeJamon/go-xrpl/storage/nodestore"
@@ -1004,44 +1003,13 @@ func run(
 			rotator.Notify(event.LedgerInfo.Sequence)
 		}
 
-		baseFee, reserveBase, reserveInc := ledgerService.GetCurrentFees()
-
-		ledgerTime := protocol.ToRippleTime(event.LedgerInfo.CloseTime)
-
-		ledgerCloseEvent := &rpc.LedgerCloseEvent{
-			Type:             "ledgerClosed",
-			LedgerIndex:      event.LedgerInfo.Sequence,
-			LedgerHash:       upperHex(event.LedgerInfo.Hash[:]),
-			LedgerTime:       ledgerTime,
-			FeeBase:          baseFee,
-			FeeRef:           baseFee,
-			ReserveBase:      reserveBase,
-			ReserveInc:       reserveInc,
-			TxnCount:         len(event.TransactionResults),
-			ValidatedLedgers: "",
+		serverInfo := ledgerService.GetServerInfo()
+		ledgerCloseEvent := buildLedgerCloseEvent(event, serverInfo)
+		if ledgerCloseEvent == nil {
+			return fmt.Errorf("accepted ledger event %d has no source ledger", event.LedgerInfo.Sequence)
 		}
 		publisher.PublishLedgerClosed(ledgerCloseEvent)
 
-		for _, publication := range transactions {
-			txResult := publication.result
-			txEvent := publication.event
-			engineResult := publication.engineResult
-			publisher.PublishTransaction(txEvent, txResult.AffectedAccounts)
-
-			// Per-book delivery is tesSUCCESS-only — rippled gates
-			// getOrderBookDB().processTxn on the engine result
-			// (NetworkOPs.cpp:3409-3410). Subscribers receive the
-			// full tx + meta JSON, matching the transactions-stream
-			// payload (rippled fans the same MultiApiJson into both).
-			if engineResult != ter.TesSUCCESS {
-				continue
-			}
-			pairs := extractBookPairsFromMetadata(txEvent.Meta)
-			if len(pairs) == 0 {
-				continue
-			}
-			publisher.PublishOrderBookChange(txEvent, pairs)
-		}
 
 		// pubBookChanges → book_changes aggregate stream
 		// (Subscribe.cpp:139-142 + NetworkOPs.cpp:3160-3174). Feed the
@@ -1052,6 +1020,17 @@ func run(
 		payload := handlers.ComputeBookChanges(bookView)
 		if data, err := json.Marshal(payload); err == nil {
 			wsServer.SubscriptionManager().BroadcastToStream(types.SubBookChanges, data, nil)
+		}
+
+		for _, publication := range transactions {
+			publisher.PublishTransaction(publication.event, publication.result.AffectedAccounts)
+			if publication.engineResult != ter.TesSUCCESS {
+				continue
+			}
+			pairs := extractBookPairsFromMetadata(publication.event.Meta)
+			if len(pairs) != 0 {
+				publisher.PublishOrderBookChange(publication.event, pairs)
+			}
 		}
 
 		// pubServer → server stream (NetworkOPs.cpp:2308-2373 +
@@ -1065,7 +1044,7 @@ func run(
 			serverStatus = info.ServerState
 		}
 		nextSnap := serverStatusSnapshot{
-			baseFee:                 baseFee,
+			baseFee:                 ledgerCloseEvent.FeeBase,
 			loadBase:                load.LoadBase,
 			loadFactor:              load.LoadFactor,
 			loadFactorLocal:         load.LoadFactorLocal,
@@ -1081,7 +1060,7 @@ func run(
 			lastServerSnapshot = nextSnap
 			publisher.PublishServerStatus(&rpc.ServerStatusEvent{
 				Type:                    "serverStatus",
-				BaseFee:                 baseFee,
+				BaseFee:                 ledgerCloseEvent.FeeBase,
 				LoadBase:                int(load.LoadBase),
 				LoadFactor:              int(load.LoadFactor),
 				LoadFactorLocal:         int(load.LoadFactorLocal),

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -974,12 +974,18 @@ func run(
 		)
 	})
 
-	// pubServer cache: rippled gates the serverStatus emit on the
-	// ServerFeeSummary changing (NetworkOPs.cpp:3209-3225 reportFeeChange);
-	// the server stream is silent in steady state. We track the
-	// previous snapshot here so a constant-fee ledger run does not
-	// flood subscribers.
-	var lastServerSnapshot serverStatusSnapshot
+	serverStatus := newServerStatusPublisher(services, publisher)
+	ledgerService.SetServerStatusCallback(serverStatus.publish)
+	if feeTrack := ledgerService.FeeTrack(); feeTrack != nil {
+		feeTrack.SetOnChange(func() {
+			ledgerService.SignalServerStatus()
+		})
+	}
+	if consensusComponents != nil && consensusComponents.Adaptor != nil {
+		consensusComponents.Adaptor.SetOnOperatingModeChange(func(mode consensus.OperatingMode) {
+			ledgerService.SignalServerMode(mode.String())
+		})
+	}
 
 	// Wire up ledger service events to WebSocket broadcasts
 	ledgerService.SetEventSink(service.EventSinkFunc(func(event *service.LedgerAcceptedEvent) error {
@@ -1033,46 +1039,7 @@ func run(
 			}
 		}
 
-		// pubServer → server stream (NetworkOPs.cpp:2308-2373 +
-		// 3209-3225 reportFeeChange). Diff-check against the previous
-		// snapshot so a constant-fee ledger does not flood subscribers.
-		// server_status is sourced from the live operating mode (the
-		// same value server_info returns), not a hardcoded "full".
-		load := handlers.ComputeServerLoad(services)
-		serverStatus := "full"
-		if info := services.Ledger.GetServerInfo(); info.ServerState != "" {
-			serverStatus = info.ServerState
-		}
-		nextSnap := serverStatusSnapshot{
-			baseFee:                 ledgerCloseEvent.FeeBase,
-			loadBase:                load.LoadBase,
-			loadFactor:              load.LoadFactor,
-			loadFactorLocal:         load.LoadFactorLocal,
-			loadFactorNet:           load.LoadFactorNet,
-			loadFactorCluster:       load.LoadFactorCluster,
-			loadFactorFeeEscalation: load.LoadFactorFeeEscalation,
-			loadFactorFeeQueue:      load.LoadFactorFeeQueue,
-			loadFactorFeeReference:  load.LoadFactorFeeReference,
-			loadFactorServer:        load.LoadFactorServer,
-			serverStatus:            serverStatus,
-		}
-		if nextSnap != lastServerSnapshot {
-			lastServerSnapshot = nextSnap
-			publisher.PublishServerStatus(&rpc.ServerStatusEvent{
-				Type:                    "serverStatus",
-				BaseFee:                 ledgerCloseEvent.FeeBase,
-				LoadBase:                int(load.LoadBase),
-				LoadFactor:              int(load.LoadFactor),
-				LoadFactorLocal:         int(load.LoadFactorLocal),
-				LoadFactorNet:           int(load.LoadFactorNet),
-				LoadFactorCluster:       int(load.LoadFactorCluster),
-				LoadFactorFeeEscalation: int(load.LoadFactorFeeEscalation),
-				LoadFactorFeeQueue:      int(load.LoadFactorFeeQueue),
-				LoadFactorFeeReference:  int(load.LoadFactorFeeReference),
-				LoadFactorServer:        int(load.LoadFactorServer),
-				ServerStatus:            serverStatus,
-			})
-		}
+		serverStatus.publish(nil)
 
 		// Update persistent path_find sessions on ledger close
 		wsServer.UpdatePathFindSessions(func() (types.LedgerStateView, error) {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -978,12 +978,12 @@ func run(
 	ledgerService.SetServerStatusCallback(serverStatus.publish)
 	if feeTrack := ledgerService.FeeTrack(); feeTrack != nil {
 		feeTrack.SetOnChange(func() {
-			ledgerService.SignalServerStatus()
+			ledgerService.SignalServerStatusPublication(serverStatus.statusPublication(nil))
 		})
 	}
 	if consensusComponents != nil && consensusComponents.Adaptor != nil {
 		consensusComponents.Adaptor.SetOnOperatingModeChange(func(mode consensus.OperatingMode) {
-			ledgerService.SignalServerMode(serverStatus.modePublication(mode.String()))
+			ledgerService.SignalServerStatusPublication(serverStatus.modePublication(mode.String()))
 		})
 	}
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -983,7 +983,7 @@ func run(
 	}
 	if consensusComponents != nil && consensusComponents.Adaptor != nil {
 		consensusComponents.Adaptor.SetOnOperatingModeChange(func(mode consensus.OperatingMode) {
-			ledgerService.SignalServerMode(mode.String())
+			ledgerService.SignalServerMode(serverStatus.modePublication(mode.String()))
 		})
 	}
 
@@ -1015,7 +1015,6 @@ func run(
 			return fmt.Errorf("accepted ledger event %d has no source ledger", event.LedgerInfo.Sequence)
 		}
 		publisher.PublishLedgerClosed(ledgerCloseEvent)
-
 
 		// pubBookChanges → book_changes aggregate stream
 		// (Subscribe.cpp:139-142 + NetworkOPs.cpp:3160-3174). Feed the

--- a/internal/node/server_helpers_test.go
+++ b/internal/node/server_helpers_test.go
@@ -9,11 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/config"
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/consensus"
 	"github.com/LeJamon/go-xrpl/internal/ledger/cleaner"
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/rpc"
@@ -41,6 +43,95 @@ func TestConsensusPhaseName(t *testing.T) {
 	// An out-of-range phase falls through to Phase.String().
 	if got := consensusPhaseName(consensus.Phase(99)); got == "" {
 		t.Error("default phase name should be non-empty")
+	}
+}
+
+func TestBuildLedgerCloseEventUsesSourceLedgerAndWirePresence(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		xrpFees    bool
+		wantFeeRef bool
+	}{
+		{name: "legacy", wantFeeRef: true},
+		{name: "xrp fees", xrpFees: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			genesisConfig := genesis.DefaultConfig()
+			if test.xrpFees {
+				genesisConfig.Amendments = append(genesisConfig.Amendments, amendment.FeatureXRPFees)
+			}
+			svc, err := service.New(service.Config{
+				Standalone:    true,
+				Startup:       service.StartupConfig{Mode: service.StartupFresh},
+				GenesisConfig: genesisConfig,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := svc.Start(); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(svc.Stop)
+			source := svc.GetValidatedLedger()
+			if source == nil {
+				t.Fatal("missing validated source ledger")
+			}
+			hash := source.Hash()
+			event := &service.LedgerAcceptedEvent{
+				Ledger: source,
+				LedgerInfo: &service.LedgerInfo{
+					Sequence:  source.Sequence(),
+					Hash:      hash,
+					CloseTime: source.CloseTime(),
+				},
+				TransactionResults: make([]service.TransactionResultEvent, 2),
+			}
+			got := buildLedgerCloseEvent(event, service.ServerInfo{
+				ServerState:     "full",
+				CompleteLedgers: "1-2,4",
+				NetworkID:       0,
+			})
+			if got == nil {
+				t.Fatal("nil ledger event")
+			}
+			base, reserve, increment := service.FeesFromLedger(source)
+			if got.FeeBase != base || got.ReserveBase != reserve || got.ReserveInc != increment {
+				t.Fatalf("fees = (%d,%d,%d), want source ledger (%d,%d,%d)", got.FeeBase, got.ReserveBase, got.ReserveInc, base, reserve, increment)
+			}
+			if (got.FeeRef != nil) != test.wantFeeRef {
+				t.Fatalf("fee_ref presence = %t, want %t", got.FeeRef != nil, test.wantFeeRef)
+			}
+			if got.FeeRef != nil && *got.FeeRef != deprecatedFeeReferenceUnits {
+				t.Fatalf("fee_ref = %d, want %d", *got.FeeRef, deprecatedFeeReferenceUnits)
+			}
+			if got.NetworkID != 0 || got.ValidatedLedgers != "1-2,4" || got.TxnCount != 2 {
+				t.Fatalf("event fields = %+v", got)
+			}
+
+			subscribeInfo := (&ledgerInfoAdapter{ledgerService: svc}).GetCurrentLedgerInfo()
+			if subscribeInfo == nil {
+				t.Fatal("nil ledger subscribe info")
+			}
+			if subscribeInfo.FeeBase != base || subscribeInfo.ReserveBase != reserve || subscribeInfo.ReserveInc != increment {
+				t.Fatalf("subscribe fees = (%d,%d,%d), want validated ledger (%d,%d,%d)", subscribeInfo.FeeBase, subscribeInfo.ReserveBase, subscribeInfo.ReserveInc, base, reserve, increment)
+			}
+			if subscribeInfo.FeeRef != deprecatedFeeReferenceUnits || subscribeInfo.XRPFeesEnabled != test.xrpFees {
+				t.Fatalf("subscribe fee gate = ref %d, XRPFees %t", subscribeInfo.FeeRef, subscribeInfo.XRPFeesEnabled)
+			}
+		})
+	}
+}
+
+func TestServerPublishesValidatedRange(t *testing.T) {
+	for _, state := range []string{"syncing", "tracking", "full", "proposing", "validating"} {
+		if !serverPublishesValidatedRange(state) {
+			t.Errorf("%s must publish validated range", state)
+		}
+	}
+	for _, state := range []string{"", "disconnected", "connected"} {
+		if serverPublishesValidatedRange(state) {
+			t.Errorf("%s must omit validated range", state)
+		}
 	}
 }
 
@@ -358,6 +449,15 @@ func TestUpperHex(t *testing.T) {
 	}
 }
 
+func mustBuildValidationEvent(t *testing.T, v *consensus.Validation, networkID uint32) *rpc.ValidationEvent {
+	t.Helper()
+	event, err := buildValidationEvent(&consensus.ValidationReceivedEvent{Validation: v}, nil, networkID)
+	if err != nil {
+		t.Fatalf("build validation event: %v", err)
+	}
+	return event
+}
+
 func TestBuildValidationEvent_UppercaseHexFields(t *testing.T) {
 	// Bytes chosen so every hex field contains A-F digits, exposing any
 	// lowercase formatting in the stream layer (#787).
@@ -367,9 +467,8 @@ func TestBuildValidationEvent_UppercaseHexFields(t *testing.T) {
 		Signature:     []byte{0xde, 0xad, 0xbe, 0xef},
 		Amendments:    [][32]byte{{0xfe, 0xed}, {0xba, 0xbe}},
 		ValidatedHash: [32]byte{0xca, 0xfe},
-		Raw:           []byte{0xfa, 0xce},
 	}
-	ev := buildValidationEvent(&consensus.ValidationReceivedEvent{Validation: v}, nil, 0)
+	ev := mustBuildValidationEvent(t, v, 0)
 	if ev == nil {
 		t.Fatal("nil event")
 	}
@@ -396,19 +495,64 @@ func TestBuildValidationEvent_UppercaseHexFields(t *testing.T) {
 	}
 }
 
+func TestBuildValidationEvent_RequiredFieldsAndCloseTimePresence(t *testing.T) {
+	withoutClose := mustBuildValidationEvent(t, &consensus.Validation{LedgerSeq: 42}, 0)
+	encoded, err := json.Marshal(withoutClose)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := fields["network_id"]; !ok || string(got) != "0" {
+		t.Fatalf("network_id = %s, present=%t; want explicit 0", got, ok)
+	}
+	if got, ok := fields["data"]; !ok || string(got) == `""` {
+		t.Fatalf("data = %s, present=%t; want canonical validation bytes", got, ok)
+	}
+	if _, ok := fields["close_time"]; ok {
+		t.Fatalf("close_time must be absent: %s", encoded)
+	}
+
+	withEpochClose := mustBuildValidationEvent(t, &consensus.Validation{
+		LedgerSeq: 42,
+		CloseTime: time.Unix(protocol.RippleEpochUnix, 0).UTC(),
+	}, 0)
+	encoded, err = json.Marshal(withEpochClose)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := fields["close_time"]; !ok || string(got) != "0" {
+		t.Fatalf("close_time = %s, present=%t; want explicit 0", got, ok)
+	}
+}
+
+func TestBuildValidationEventRejectsInvalidRawData(t *testing.T) {
+	_, err := buildValidationEvent(&consensus.ValidationReceivedEvent{
+		Validation: &consensus.Validation{Raw: []byte{0xff}},
+	}, nil, 0)
+	if err == nil {
+		t.Fatal("invalid raw validation must not be published")
+	}
+}
+
 func TestBuildValidationEvent_CookieDecimal(t *testing.T) {
 	// rippled emits cookie as std::to_string(*cookie) — base-10 decimal
 	// (NetworkOPs.cpp:2429), unlike the hash/sig/blob fields which are
 	// hex. 0xAB = 171: "171" (decimal) ≠ "ab"/"AB" (hex).
 	v := &consensus.Validation{Cookie: 0xAB}
-	ev := buildValidationEvent(&consensus.ValidationReceivedEvent{Validation: v}, nil, 0)
+	ev := mustBuildValidationEvent(t, v, 0)
 	if ev.Cookie != "171" {
 		t.Errorf("cookie = %q, want decimal \"171\"", ev.Cookie)
 	}
 
 	// Cookie 0 is the absent proxy → field omitted.
 	v0 := &consensus.Validation{}
-	if ev0 := buildValidationEvent(&consensus.ValidationReceivedEvent{Validation: v0}, nil, 0); ev0.Cookie != "" {
+	if ev0 := mustBuildValidationEvent(t, v0, 0); ev0.Cookie != "" {
 		t.Errorf("cookie = %q, want empty when absent", ev0.Cookie)
 	}
 }
@@ -418,14 +562,14 @@ func TestBuildValidationEvent_ServerVersionDecimal(t *testing.T) {
 	// decimal (NetworkOPs.cpp:2426). The go-xrpl server version tag
 	// 0x4000_0000_0000_0000 = 4611686018427387904 decimal.
 	v := &consensus.Validation{ServerVersion: 0x4000_0000_0000_0000}
-	ev := buildValidationEvent(&consensus.ValidationReceivedEvent{Validation: v}, nil, 0)
+	ev := mustBuildValidationEvent(t, v, 0)
 	if ev.ServerVersion != "4611686018427387904" {
 		t.Errorf("server_version = %q, want decimal \"4611686018427387904\"", ev.ServerVersion)
 	}
 
 	// ServerVersion 0 is the absent proxy → field omitted.
 	v0 := &consensus.Validation{}
-	if ev0 := buildValidationEvent(&consensus.ValidationReceivedEvent{Validation: v0}, nil, 0); ev0.ServerVersion != "" {
+	if ev0 := mustBuildValidationEvent(t, v0, 0); ev0.ServerVersion != "" {
 		t.Errorf("server_version = %q, want empty when absent", ev0.ServerVersion)
 	}
 }
@@ -445,7 +589,7 @@ func TestBuildValidationEvent_LoadFeePresence(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			event := buildValidationEvent(&consensus.ValidationReceivedEvent{Validation: test.validation}, nil, 0)
+			event := mustBuildValidationEvent(t, test.validation, 0)
 			encoded, err := json.Marshal(event)
 			if err != nil {
 				t.Fatalf("marshal validation event: %v", err)
@@ -538,7 +682,7 @@ func TestBuildValidationEvent_FeeVotePresenceAndSign(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			event := buildValidationEvent(&consensus.ValidationReceivedEvent{Validation: test.validation}, nil, 0)
+			event := mustBuildValidationEvent(t, test.validation, 0)
 			encoded, err := json.Marshal(event)
 			if err != nil {
 				t.Fatalf("marshal validation event: %v", err)

--- a/internal/node/server_helpers_test.go
+++ b/internal/node/server_helpers_test.go
@@ -95,7 +95,10 @@ func TestBuildLedgerCloseEventUsesSourceLedgerAndWirePresence(t *testing.T) {
 				t.Fatal("nil ledger event")
 			}
 			base, reserve, increment := service.FeesFromLedger(source)
-			if got.FeeBase != base || got.ReserveBase != reserve || got.ReserveInc != increment {
+			wantBase := jsonClippedXRPAmount(int64(base))
+			wantReserve := jsonClippedXRPAmount(int64(reserve))
+			wantIncrement := jsonClippedXRPAmount(int64(increment))
+			if got.FeeBase != wantBase || got.ReserveBase != wantReserve || got.ReserveInc != wantIncrement {
 				t.Fatalf("fees = (%d,%d,%d), want source ledger (%d,%d,%d)", got.FeeBase, got.ReserveBase, got.ReserveInc, base, reserve, increment)
 			}
 			if (got.FeeRef != nil) != test.wantFeeRef {
@@ -112,7 +115,7 @@ func TestBuildLedgerCloseEventUsesSourceLedgerAndWirePresence(t *testing.T) {
 			if subscribeInfo == nil {
 				t.Fatal("nil ledger subscribe info")
 			}
-			if subscribeInfo.FeeBase != base || subscribeInfo.ReserveBase != reserve || subscribeInfo.ReserveInc != increment {
+			if subscribeInfo.FeeBase != wantBase || subscribeInfo.ReserveBase != wantReserve || subscribeInfo.ReserveInc != wantIncrement {
 				t.Fatalf("subscribe fees = (%d,%d,%d), want validated ledger (%d,%d,%d)", subscribeInfo.FeeBase, subscribeInfo.ReserveBase, subscribeInfo.ReserveInc, base, reserve, increment)
 			}
 			if subscribeInfo.FeeRef != deprecatedFeeReferenceUnits || subscribeInfo.XRPFeesEnabled != test.xrpFees {

--- a/internal/node/server_status_test.go
+++ b/internal/node/server_status_test.go
@@ -1,0 +1,135 @@
+package node
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/consensus"
+	"github.com/LeJamon/go-xrpl/internal/consensus/adaptor"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	"github.com/LeJamon/go-xrpl/internal/rpc"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+type serverStatusRecorder struct {
+	mu     sync.Mutex
+	events []*rpc.ServerStatusEvent
+	ready  chan *rpc.ServerStatusEvent
+}
+
+func newServerStatusRecorder() *serverStatusRecorder {
+	return &serverStatusRecorder{ready: make(chan *rpc.ServerStatusEvent, 8)}
+}
+
+func (r *serverStatusRecorder) PublishServerStatus(event *rpc.ServerStatusEvent) {
+	copy := *event
+	r.mu.Lock()
+	r.events = append(r.events, &copy)
+	r.mu.Unlock()
+	r.ready <- &copy
+}
+
+func (r *serverStatusRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.events)
+}
+
+func serverStatusTestServices(svc *service.Service) *types.ServiceContainer {
+	services := types.NewServiceContainer(rpc.NewLedgerServiceAdapter(svc))
+	services.TxQMetrics = func() types.TxQServerMetrics {
+		metrics := svc.TxQMetrics()
+		return types.TxQServerMetrics{
+			ReferenceFeeLevel:     metrics.ReferenceFeeLevel,
+			MinProcessingFeeLevel: metrics.MinProcessingFeeLevel,
+			OpenLedgerFeeLevel:    metrics.OpenLedgerFeeLevel,
+		}
+	}
+	services.LoadFactorFees = func() types.LoadFactorFees {
+		fees := svc.FeeTrack()
+		return types.LoadFactorFees{
+			Local:   fees.LocalFee(),
+			Net:     fees.RemoteFee(),
+			Cluster: fees.ClusterFee(),
+		}
+	}
+	return services
+}
+
+func waitForServerStatus(t *testing.T, recorder *serverStatusRecorder) *rpc.ServerStatusEvent {
+	t.Helper()
+	select {
+	case event := <-recorder.ready:
+		return event
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for server status")
+		return nil
+	}
+}
+
+func TestServerStatusPublishesModeAndLoadWithoutLedgerAcceptance(t *testing.T) {
+	svc, err := service.New(service.Config{Standalone: true})
+	if err != nil {
+		t.Fatalf("New service: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start service: %v", err)
+	}
+	t.Cleanup(svc.Stop)
+
+	consensusAdaptor := adaptor.New(adaptor.Config{LedgerService: svc})
+	svc.SetServerStateFunc(func() string { return consensusAdaptor.GetOperatingMode().String() })
+	recorder := newServerStatusRecorder()
+	status := newServerStatusPublisher(serverStatusTestServices(svc), recorder)
+	svc.SetServerStatusCallback(status.publish)
+	consensusAdaptor.SetOnOperatingModeChange(func(mode consensus.OperatingMode) { svc.SignalServerMode(mode.String()) })
+	svc.FeeTrack().SetOnChange(func() { svc.SignalServerStatus() })
+
+	status.publish(nil)
+	initial := waitForServerStatus(t, recorder)
+	if initial.ServerStatus != consensus.OpModeDisconnected.String() {
+		t.Fatalf("initial server status = %q", initial.ServerStatus)
+	}
+
+	consensusAdaptor.SetOperatingMode(consensus.OpModeConnected)
+	modeEvent := waitForServerStatus(t, recorder)
+	if modeEvent.ServerStatus != consensus.OpModeConnected.String() {
+		t.Fatalf("mode-change server status = %q", modeEvent.ServerStatus)
+	}
+	svc.FeeTrack().SetRemoteFee(512)
+	consensusAdaptor.SetOperatingMode(consensus.OpModeSyncing)
+	consensusAdaptor.SetOperatingMode(consensus.OpModeTracking)
+	loadEvent := waitForServerStatus(t, recorder)
+	if loadEvent.ServerStatus != consensus.OpModeConnected.String() ||
+		loadEvent.LoadFactorServer != 512 || loadEvent.LoadFactor != 512 {
+		t.Fatalf("load event = status %q, server %d, overall %d",
+			loadEvent.ServerStatus, loadEvent.LoadFactorServer, loadEvent.LoadFactor)
+	}
+	if event := waitForServerStatus(t, recorder); event.ServerStatus != consensus.OpModeSyncing.String() {
+		t.Fatalf("first rapid mode status = %q", event.ServerStatus)
+	}
+	if event := waitForServerStatus(t, recorder); event.ServerStatus != consensus.OpModeTracking.String() {
+		t.Fatalf("second rapid mode status = %q", event.ServerStatus)
+	}
+}
+
+func TestServerStatusPublisherSuppressesUnchangedSnapshot(t *testing.T) {
+	svc, err := service.New(service.Config{Standalone: true})
+	if err != nil {
+		t.Fatalf("New service: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start service: %v", err)
+	}
+	t.Cleanup(svc.Stop)
+
+	recorder := newServerStatusRecorder()
+	status := newServerStatusPublisher(serverStatusTestServices(svc), recorder)
+	status.publish(nil)
+	waitForServerStatus(t, recorder)
+	status.publish(nil)
+	if got := recorder.count(); got != 1 {
+		t.Fatalf("unchanged snapshot published %d events, want 1", got)
+	}
+}

--- a/internal/node/server_status_test.go
+++ b/internal/node/server_status_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -131,5 +132,34 @@ func TestServerStatusPublisherSuppressesUnchangedSnapshot(t *testing.T) {
 	status.publish(nil)
 	if got := recorder.count(); got != 1 {
 		t.Fatalf("unchanged snapshot published %d events, want 1", got)
+	}
+}
+
+func TestServerStatusPublisherClipsSaturatedTxQLoad(t *testing.T) {
+	svc, err := service.New(service.Config{Standalone: true})
+	if err != nil {
+		t.Fatalf("New service: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start service: %v", err)
+	}
+	t.Cleanup(svc.Stop)
+	services := serverStatusTestServices(svc)
+	services.TxQMetrics = func() types.TxQServerMetrics {
+		return types.TxQServerMetrics{
+			ReferenceFeeLevel:     256,
+			MinProcessingFeeLevel: math.MaxUint64,
+			OpenLedgerFeeLevel:    math.MaxUint64,
+		}
+	}
+	recorder := newServerStatusRecorder()
+	status := newServerStatusPublisher(services, recorder)
+	status.publish(nil)
+
+	event := waitForServerStatus(t, recorder)
+	if event.LoadFactor != math.MaxUint32 ||
+		event.LoadFactorFeeEscalation != math.MaxUint32 ||
+		event.LoadFactorFeeQueue != math.MaxUint32 {
+		t.Fatalf("saturated load event = %+v", event)
 	}
 }

--- a/internal/node/server_status_test.go
+++ b/internal/node/server_status_test.go
@@ -87,9 +87,11 @@ func TestServerStatusPublishesModeAndLoadWithoutLedgerAcceptance(t *testing.T) {
 	status := newServerStatusPublisher(serverStatusTestServices(svc), recorder)
 	svc.SetServerStatusCallback(status.publish)
 	consensusAdaptor.SetOnOperatingModeChange(func(mode consensus.OperatingMode) {
-		svc.SignalServerMode(status.modePublication(mode.String()))
+		svc.SignalServerStatusPublication(status.modePublication(mode.String()))
 	})
-	svc.FeeTrack().SetOnChange(func() { svc.SignalServerStatus() })
+	svc.FeeTrack().SetOnChange(func() {
+		svc.SignalServerStatusPublication(status.statusPublication(nil))
+	})
 
 	status.publish(nil)
 	initial := waitForServerStatus(t, recorder)
@@ -167,7 +169,7 @@ func TestServerStatusPublisherDoesNotCacheWithoutSubscribers(t *testing.T) {
 	}
 }
 
-func TestServerModePublicationUsesTransitionSnapshot(t *testing.T) {
+func TestServerStatusPublicationUsesTransitionSnapshot(t *testing.T) {
 	svc, err := service.New(service.Config{Standalone: true})
 	if err != nil {
 		t.Fatalf("New service: %v", err)

--- a/internal/node/server_status_test.go
+++ b/internal/node/server_status_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/consensus/adaptor"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/rpc"
+	"github.com/LeJamon/go-xrpl/internal/rpc/subscription"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
@@ -23,12 +24,13 @@ func newServerStatusRecorder() *serverStatusRecorder {
 	return &serverStatusRecorder{ready: make(chan *rpc.ServerStatusEvent, 8)}
 }
 
-func (r *serverStatusRecorder) PublishServerStatus(event *rpc.ServerStatusEvent) {
+func (r *serverStatusRecorder) PublishServerStatus(event *rpc.ServerStatusEvent) bool {
 	copy := *event
 	r.mu.Lock()
 	r.events = append(r.events, &copy)
 	r.mu.Unlock()
 	r.ready <- &copy
+	return true
 }
 
 func (r *serverStatusRecorder) count() int {
@@ -84,7 +86,9 @@ func TestServerStatusPublishesModeAndLoadWithoutLedgerAcceptance(t *testing.T) {
 	recorder := newServerStatusRecorder()
 	status := newServerStatusPublisher(serverStatusTestServices(svc), recorder)
 	svc.SetServerStatusCallback(status.publish)
-	consensusAdaptor.SetOnOperatingModeChange(func(mode consensus.OperatingMode) { svc.SignalServerMode(mode.String()) })
+	consensusAdaptor.SetOnOperatingModeChange(func(mode consensus.OperatingMode) {
+		svc.SignalServerMode(status.modePublication(mode.String()))
+	})
 	svc.FeeTrack().SetOnChange(func() { svc.SignalServerStatus() })
 
 	status.publish(nil)
@@ -132,6 +136,56 @@ func TestServerStatusPublisherSuppressesUnchangedSnapshot(t *testing.T) {
 	status.publish(nil)
 	if got := recorder.count(); got != 1 {
 		t.Fatalf("unchanged snapshot published %d events, want 1", got)
+	}
+}
+
+func TestServerStatusPublisherDoesNotCacheWithoutSubscribers(t *testing.T) {
+	svc, err := service.New(service.Config{Standalone: true})
+	if err != nil {
+		t.Fatalf("New service: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start service: %v", err)
+	}
+	t.Cleanup(svc.Stop)
+
+	manager := subscription.NewManager()
+	status := newServerStatusPublisher(serverStatusTestServices(svc), rpc.NewPublisher(manager))
+	status.publish(nil)
+
+	conn := &types.Connection{
+		ID:            "server-subscriber",
+		Subscriptions: map[types.SubscriptionType]types.SubscriptionConfig{types.SubServer: {}},
+		SendChannel:   make(chan []byte, 1),
+	}
+	manager.AddConnection(conn)
+	status.publish(nil)
+	select {
+	case <-conn.SendChannel:
+	case <-time.After(time.Second):
+		t.Fatal("first status after subscribing was suppressed")
+	}
+}
+
+func TestServerModePublicationUsesTransitionSnapshot(t *testing.T) {
+	svc, err := service.New(service.Config{Standalone: true})
+	if err != nil {
+		t.Fatalf("New service: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("Start service: %v", err)
+	}
+	t.Cleanup(svc.Stop)
+
+	recorder := newServerStatusRecorder()
+	status := newServerStatusPublisher(serverStatusTestServices(svc), recorder)
+	publication := status.modePublication(consensus.OpModeTracking.String())
+	svc.FeeTrack().SetRemoteFee(512)
+	publication()
+
+	event := waitForServerStatus(t, recorder)
+	if event.ServerStatus != consensus.OpModeTracking.String() || event.LoadFactorServer != 256 {
+		t.Fatalf("mode transition snapshot = status %q, load %d", event.ServerStatus, event.LoadFactorServer)
 	}
 }
 

--- a/internal/rpc/events.go
+++ b/internal/rpc/events.go
@@ -100,9 +100,6 @@ type ServerStatusEvent struct {
 	BaseFee                 uint64 `json:"base_fee,omitempty"`                   // Base fee
 	LoadBase                int    `json:"load_base"`                            // Load base (256 = normal)
 	LoadFactor              int    `json:"load_factor"`                          // Current load factor
-	LoadFactorLocal         int    `json:"load_factor_local,omitempty"`          // Local load factor
-	LoadFactorNet           int    `json:"load_factor_net,omitempty"`            // Network load factor
-	LoadFactorCluster       int    `json:"load_factor_cluster,omitempty"`        // Cluster load factor
 	LoadFactorFeeEscalation int    `json:"load_factor_fee_escalation,omitempty"` // Fee escalation load factor
 	LoadFactorFeeQueue      int    `json:"load_factor_fee_queue,omitempty"`      // Fee queue load factor
 	LoadFactorFeeReference  int    `json:"load_factor_fee_reference,omitempty"`  // TxQ reference fee level (NetworkOPs.cpp:2345)

--- a/internal/rpc/events.go
+++ b/internal/rpc/events.go
@@ -10,14 +10,14 @@ import (
 // This matches the rippled ledgerClosed stream message format
 type LedgerCloseEvent struct {
 	Type             string  `json:"type"`                        // Always "ledgerClosed"
-	FeeBase          uint64  `json:"fee_base"`                    // Transaction cost in fee units
+	FeeBase          int32   `json:"fee_base"`                    // Transaction cost in fee units
 	FeeRef           *uint64 `json:"fee_ref,omitempty"`           // Deprecated reference fee units, before XRPFees
 	LedgerHash       string  `json:"ledger_hash"`                 // Hash of the ledger that closed
 	LedgerIndex      uint32  `json:"ledger_index"`                // Sequence number of the ledger
 	LedgerTime       uint32  `json:"ledger_time"`                 // Close time in seconds since Ripple epoch
 	NetworkID        uint32  `json:"network_id"`                  // Network identifier, including network 0
-	ReserveBase      uint64  `json:"reserve_base"`                // Minimum reserve requirement in drops
-	ReserveInc       uint64  `json:"reserve_inc"`                 // Owner reserve increment in drops
+	ReserveBase      int32   `json:"reserve_base"`                // Minimum reserve requirement in drops
+	ReserveInc       int32   `json:"reserve_inc"`                 // Owner reserve increment in drops
 	TxnCount         int     `json:"txn_count"`                   // Number of transactions in the ledger
 	ValidatedLedgers string  `json:"validated_ledgers,omitempty"` // Range of validated ledgers (e.g., "1-100")
 }
@@ -97,14 +97,14 @@ func NewValidationEvent(
 // Mirrors rippled NetworkOPs.cpp:2308-2373 (pubServer).
 type ServerStatusEvent struct {
 	Type                    string `json:"type"`                                 // Always "serverStatus"
-	BaseFee                 uint64 `json:"base_fee,omitempty"`                   // Base fee
-	LoadBase                int    `json:"load_base"`                            // Load base (256 = normal)
-	LoadFactor              int    `json:"load_factor"`                          // Current load factor
-	LoadFactorFeeEscalation int    `json:"load_factor_fee_escalation,omitempty"` // Fee escalation load factor
-	LoadFactorFeeQueue      int    `json:"load_factor_fee_queue,omitempty"`      // Fee queue load factor
-	LoadFactorFeeReference  int    `json:"load_factor_fee_reference,omitempty"`  // TxQ reference fee level (NetworkOPs.cpp:2345)
-	LoadFactorServer        int    `json:"load_factor_server,omitempty"`         // Server load factor
-	ServerStatus            string `json:"server_status,omitempty"`              // Operating mode (disconnected/connected/syncing/tracking/full)
+	BaseFee                 int32  `json:"base_fee"`                             // Base fee
+	LoadBase                uint32 `json:"load_base"`                            // Load base (256 = normal)
+	LoadFactor              uint32 `json:"load_factor"`                          // Current load factor
+	LoadFactorFeeEscalation uint32 `json:"load_factor_fee_escalation,omitempty"` // Fee escalation load factor
+	LoadFactorFeeQueue      uint32 `json:"load_factor_fee_queue,omitempty"`      // Fee queue load factor
+	LoadFactorFeeReference  uint32 `json:"load_factor_fee_reference,omitempty"`  // TxQ reference fee level (NetworkOPs.cpp:2345)
+	LoadFactorServer        uint32 `json:"load_factor_server"`                   // Server load factor
+	ServerStatus            string `json:"server_status"`                        // Operating mode (disconnected/connected/syncing/tracking/full)
 }
 
 // ConsensusEvent represents consensus phase changes

--- a/internal/rpc/events.go
+++ b/internal/rpc/events.go
@@ -9,19 +9,17 @@ import (
 // LedgerCloseEvent represents a ledger close notification sent to subscribers
 // This matches the rippled ledgerClosed stream message format
 type LedgerCloseEvent struct {
-	Type             string `json:"type"`              // Always "ledgerClosed"
-	FeeBase          uint64 `json:"fee_base"`          // Transaction cost in fee units
-	FeeRef           uint64 `json:"fee_ref"`           // Transaction cost in fee units for reference tx
-	LedgerHash       string `json:"ledger_hash"`       // Hash of the ledger that closed
-	LedgerIndex      uint32 `json:"ledger_index"`      // Sequence number of the ledger
-	LedgerTime       uint32 `json:"ledger_time"`       // Close time in seconds since Ripple epoch
-	ReserveBase      uint64 `json:"reserve_base"`      // Minimum reserve requirement in drops
-	ReserveInc       uint64 `json:"reserve_inc"`       // Owner reserve increment in drops
-	TxnCount         int    `json:"txn_count"`         // Number of transactions in the ledger
-	ValidatedLedgers string `json:"validated_ledgers"` // Range of validated ledgers (e.g., "1-100")
-	// Optional fields for API v2+
-	ValidatedHash string `json:"validated_hash,omitempty"` // Hash of the validated ledger (API v2)
-	Validated     bool   `json:"validated,omitempty"`      // Whether this ledger is validated
+	Type             string  `json:"type"`                        // Always "ledgerClosed"
+	FeeBase          uint64  `json:"fee_base"`                    // Transaction cost in fee units
+	FeeRef           *uint64 `json:"fee_ref,omitempty"`           // Deprecated reference fee units, before XRPFees
+	LedgerHash       string  `json:"ledger_hash"`                 // Hash of the ledger that closed
+	LedgerIndex      uint32  `json:"ledger_index"`                // Sequence number of the ledger
+	LedgerTime       uint32  `json:"ledger_time"`                 // Close time in seconds since Ripple epoch
+	NetworkID        uint32  `json:"network_id"`                  // Network identifier, including network 0
+	ReserveBase      uint64  `json:"reserve_base"`                // Minimum reserve requirement in drops
+	ReserveInc       uint64  `json:"reserve_inc"`                 // Owner reserve increment in drops
+	TxnCount         int     `json:"txn_count"`                   // Number of transactions in the ledger
+	ValidatedLedgers string  `json:"validated_ledgers,omitempty"` // Range of validated ledgers (e.g., "1-100")
 }
 
 // TransactionEvent represents a transaction notification sent to subscribers
@@ -54,14 +52,15 @@ type ValidationEvent struct {
 	Amendments          []string `json:"amendments,omitempty"`     // Amendments this validator is voting for
 	BaseFee             any      `json:"base_fee,omitempty"`       // Unscaled transaction cost
 	Cookie              string   `json:"cookie,omitempty"`         // Unique cookie value (if any)
-	Data                string   `json:"data,omitempty"`           // Raw STValidation wire bytes, hex-encoded (NetworkOPs.cpp:2422)
+	Data                string   `json:"data"`                     // Canonical STValidation wire bytes, hex-encoded
 	Flags               uint32   `json:"flags"`                    // Validation flags
 	Full                bool     `json:"full"`                     // Whether this is a full validation
 	LedgerHash          string   `json:"ledger_hash"`              // Hash of proposed ledger
-	LedgerIndex         string   `json:"ledger_index"`             // Index of proposed ledger (as string)
+	LedgerIndex         uint32   `json:"ledger_index"`             // Index of proposed ledger (string in API v1)
+	CloseTime           *uint32  `json:"close_time,omitempty"`     // Optional validation close time
 	LoadFee             *uint32  `json:"load_fee,omitempty"`       // Local load-scaled transaction cost
 	MasterKey           string   `json:"master_key,omitempty"`     // Master public key — emitted only when the manifest cache resolves a master distinct from the signing key (NetworkOPs.cpp:2434-2438)
-	NetworkID           uint32   `json:"network_id,omitempty"`     // Network identifier (NetworkOPs.cpp:2423)
+	NetworkID           uint32   `json:"network_id"`               // Network identifier, including network 0
 	ReserveBase         any      `json:"reserve_base,omitempty"`   // Minimum reserve
 	ReserveInc          any      `json:"reserve_inc,omitempty"`    // Owner reserve increment
 	ServerVersion       string   `json:"server_version,omitempty"` // Version of rippled
@@ -74,7 +73,7 @@ type ValidationEvent struct {
 // NewValidationEvent creates a new ValidationEvent
 func NewValidationEvent(
 	ledgerHash string,
-	ledgerIndex string,
+	ledgerIndex uint32,
 	validationPublicKey string,
 	signature string,
 	signingTime uint32,

--- a/internal/rpc/events_test.go
+++ b/internal/rpc/events_test.go
@@ -1,0 +1,22 @@
+package rpc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestServerStatusEventRequiredFieldsPreserveZero(t *testing.T) {
+	data, err := json.Marshal(ServerStatusEvent{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var event map[string]any
+	if err := json.Unmarshal(data, &event); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"base_fee", "load_base", "load_factor", "load_factor_server", "server_status"} {
+		if _, ok := event[field]; !ok {
+			t.Fatalf("required field %q omitted from %s", field, data)
+		}
+	}
+}

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"math/bits"
 	"os"
 	"strconv"
 	"strings"
@@ -277,7 +278,7 @@ func buildServerInfo(ctx *types.RpcContext, human bool) map[string]any {
 	feeEscalation, feeQueue, feeReference := resolveLoadFactorFees(services)
 	loadFactorFeeEscalation := feeEscalation
 	if feeReference != 0 {
-		loadFactorFeeEscalation = feeEscalation * loadBase / feeReference
+		loadFactorFeeEscalation = mulDivSaturating(feeEscalation, loadBase, feeReference)
 	}
 	var loadFactorFees types.LoadFactorFees
 	if services != nil && services.LoadFactorFees != nil {
@@ -591,8 +592,9 @@ func ComputeServerLoad(services *types.ServiceContainer) ServerLoadSnapshot {
 		LoadFactorNet:           loadBase,
 		LoadFactorCluster:       loadBase,
 	}
+	scaledFeeEscalation := feeEscalation
 	if feeReference != 0 {
-		snap.LoadFactorFeeEscalation = feeEscalation * loadBase / feeReference
+		scaledFeeEscalation = mulDivSaturating(feeEscalation, loadBase, feeReference)
 	}
 	if services != nil && services.LoadFactorFees != nil {
 		fees := services.LoadFactorFees()
@@ -607,8 +609,20 @@ func ComputeServerLoad(services *types.ServiceContainer) ServerLoadSnapshot {
 		}
 	}
 	snap.LoadFactorServer = max(snap.LoadFactorLocal, snap.LoadFactorNet, snap.LoadFactorCluster)
-	snap.LoadFactor = max(snap.LoadFactorServer, snap.LoadFactorFeeEscalation)
+	snap.LoadFactor = max(snap.LoadFactorServer, scaledFeeEscalation)
 	return snap
+}
+
+func mulDivSaturating(a, b, divisor uint64) uint64 {
+	if divisor == 0 {
+		return ^uint64(0)
+	}
+	hi, lo := bits.Mul64(a, b)
+	if hi >= divisor {
+		return ^uint64(0)
+	}
+	quotient, _ := bits.Div64(hi, lo, divisor)
+	return quotient
 }
 
 // stateAccountingResolved is the rendered shape consumed by

--- a/internal/rpc/handlers/server_info.go
+++ b/internal/rpc/handlers/server_info.go
@@ -594,9 +594,6 @@ func ComputeServerLoad(services *types.ServiceContainer) ServerLoadSnapshot {
 	if feeReference != 0 {
 		snap.LoadFactorFeeEscalation = feeEscalation * loadBase / feeReference
 	}
-	if snap.LoadFactorFeeEscalation > snap.LoadFactor {
-		snap.LoadFactor = snap.LoadFactorFeeEscalation
-	}
 	if services != nil && services.LoadFactorFees != nil {
 		fees := services.LoadFactorFees()
 		if fees.Local > 0 {
@@ -609,6 +606,8 @@ func ComputeServerLoad(services *types.ServiceContainer) ServerLoadSnapshot {
 			snap.LoadFactorCluster = uint64(fees.Cluster)
 		}
 	}
+	snap.LoadFactorServer = max(snap.LoadFactorLocal, snap.LoadFactorNet, snap.LoadFactorCluster)
+	snap.LoadFactor = max(snap.LoadFactorServer, snap.LoadFactorFeeEscalation)
 	return snap
 }
 

--- a/internal/rpc/handlers/server_load_test.go
+++ b/internal/rpc/handlers/server_load_test.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"math"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+func TestMulDivSaturating(t *testing.T) {
+	tests := []struct {
+		a, b, divisor uint64
+		want          uint64
+	}{
+		{math.MaxUint64, 256, 256, math.MaxUint64},
+		{math.MaxUint64, math.MaxUint64, 1, math.MaxUint64},
+		{257, 256, 256, 257},
+		{1, 1, 2, 0},
+		{1, 1, 0, math.MaxUint64},
+	}
+	for _, test := range tests {
+		if got := mulDivSaturating(test.a, test.b, test.divisor); got != test.want {
+			t.Fatalf("mulDivSaturating(%d, %d, %d) = %d, want %d", test.a, test.b, test.divisor, got, test.want)
+		}
+	}
+}
+
+func TestComputeServerLoadKeepsRawAndScaledEscalationDistinct(t *testing.T) {
+	services := &types.ServiceContainer{
+		TxQMetrics: func() types.TxQServerMetrics {
+			return types.TxQServerMetrics{
+				ReferenceFeeLevel:  128,
+				OpenLedgerFeeLevel: 256,
+			}
+		},
+	}
+
+	load := ComputeServerLoad(services)
+	if load.LoadFactorFeeEscalation != 256 {
+		t.Fatalf("raw fee escalation = %d, want 256", load.LoadFactorFeeEscalation)
+	}
+	if load.LoadFactor != 512 {
+		t.Fatalf("scaled overall load = %d, want 512", load.LoadFactor)
+	}
+}

--- a/internal/rpc/publisher.go
+++ b/internal/rpc/publisher.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"encoding/json"
+	"strconv"
 
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/subscription"
@@ -121,13 +122,32 @@ func (p *Publisher) PublishValidation(event *ValidationEvent) {
 		return
 	}
 
-	data, err := json.Marshal(event)
+	v1, err := marshalValidationEvent(event, types.ApiVersion1)
+	if err != nil {
+		xrpllog.Named(xrpllog.PartitionRPC).Error("Failed to marshal ValidationEvent", "err", err)
+		return
+	}
+	v2, err := marshalValidationEvent(event, types.ApiVersion2)
 	if err != nil {
 		xrpllog.Named(xrpllog.PartitionRPC).Error("Failed to marshal ValidationEvent", "err", err)
 		return
 	}
 
-	p.manager.BroadcastToStream(types.SubValidations, data, nil)
+	p.manager.BroadcastToStreamVersioned(types.SubValidations, v1, v2)
+}
+
+func marshalValidationEvent(event *ValidationEvent, apiVersion int) ([]byte, error) {
+	if apiVersion != types.ApiVersion1 {
+		return json.Marshal(event)
+	}
+	type validationEvent ValidationEvent
+	return json.Marshal(struct {
+		*validationEvent
+		LedgerIndex string `json:"ledger_index"`
+	}{
+		validationEvent: (*validationEvent)(event),
+		LedgerIndex:     strconv.FormatUint(uint64(event.LedgerIndex), 10),
+	})
 }
 
 // PublishServerStatus broadcasts a server status event to server stream subscribers

--- a/internal/rpc/publisher.go
+++ b/internal/rpc/publisher.go
@@ -24,8 +24,9 @@ type EventPublisher interface {
 	// PublishValidation publishes a validation event to validation stream subscribers
 	PublishValidation(event *ValidationEvent)
 
-	// PublishServerStatus publishes a server status event to server stream subscribers
-	PublishServerStatus(event *ServerStatusEvent)
+	// PublishServerStatus publishes a server status event and reports whether
+	// at least one server-stream subscriber was targeted.
+	PublishServerStatus(event *ServerStatusEvent) bool
 
 	// PublishConsensusPhase publishes a consensus phase change to consensus stream subscribers
 	PublishConsensusPhase(phase string)
@@ -150,19 +151,19 @@ func marshalValidationEvent(event *ValidationEvent, apiVersion int) ([]byte, err
 	})
 }
 
-// PublishServerStatus broadcasts a server status event to server stream subscribers
-func (p *Publisher) PublishServerStatus(event *ServerStatusEvent) {
+// PublishServerStatus broadcasts a server status event to server stream subscribers.
+func (p *Publisher) PublishServerStatus(event *ServerStatusEvent) bool {
 	if event == nil || p.manager == nil {
-		return
+		return false
 	}
 
 	data, err := json.Marshal(event)
 	if err != nil {
 		xrpllog.Named(xrpllog.PartitionRPC).Error("Failed to marshal ServerStatusEvent", "err", err)
-		return
+		return false
 	}
 
-	p.manager.BroadcastToStream(types.SubServer, data, nil)
+	return p.manager.BroadcastToStream(types.SubServer, data, nil) != 0
 }
 
 // PublishConsensusPhase broadcasts a consensus phase change event
@@ -290,7 +291,7 @@ func NewNoOpPublisher() *NoOpPublisher {
 func (p *NoOpPublisher) PublishLedgerClosed(event *LedgerCloseEvent)                   {}
 func (p *NoOpPublisher) PublishTransaction(event *TransactionEvent, accounts []string) {}
 func (p *NoOpPublisher) PublishValidation(event *ValidationEvent)                      {}
-func (p *NoOpPublisher) PublishServerStatus(event *ServerStatusEvent)                  {}
+func (p *NoOpPublisher) PublishServerStatus(event *ServerStatusEvent) bool             { return false }
 func (p *NoOpPublisher) PublishConsensusPhase(phase string)                            {}
 func (p *NoOpPublisher) PublishManifest(event *ManifestEvent)                          {}
 func (p *NoOpPublisher) PublishPeerStatus(event *PeerStatusEvent)                      {}

--- a/internal/rpc/publisher_transaction_test.go
+++ b/internal/rpc/publisher_transaction_test.go
@@ -113,6 +113,88 @@ func TestPublishOrderBookChangeUsesSubscriberAPIVersion(t *testing.T) {
 	assertPublishedTransactionVersion(t, readPublisherTestEvent(t, bookV2), types.ApiVersion2)
 }
 
+func TestPublishValidationUsesSubscriberAPIVersion(t *testing.T) {
+	manager := subscription.NewManager()
+	v1 := addPublisherTestConnection(manager, "validation-v1")
+	v2 := addPublisherTestConnection(manager, "validation-v2")
+	v3 := addPublisherTestConnection(manager, "validation-v3")
+	none := addPublisherTestConnection(manager, "validation-none")
+	for _, test := range []struct {
+		conn    *types.Connection
+		version int
+	}{
+		{v1, types.ApiVersion1},
+		{v2, types.ApiVersion2},
+		{v3, types.ApiVersion3},
+	} {
+		test.conn.Subscriptions[types.SubValidations] = types.SubscriptionConfig{}
+		test.conn.SetAPIVersion(test.version)
+	}
+
+	closeTime := uint32(0)
+	event := &ValidationEvent{
+		Type:                "validationReceived",
+		Data:                "ABCD",
+		Flags:               1,
+		Full:                true,
+		LedgerHash:          strings.Repeat("A", 64),
+		LedgerIndex:         42,
+		CloseTime:           &closeTime,
+		NetworkID:           0,
+		Signature:           "CAFE",
+		SigningTime:         800000000,
+		ValidationPublicKey: "n9Example",
+	}
+	NewPublisher(manager).PublishValidation(event)
+
+	for _, test := range []struct {
+		conn       *types.Connection
+		wantLedger string
+	}{
+		{v1, `"42"`},
+		{v2, "42"},
+		{v3, "42"},
+	} {
+		var payload map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(readPublisherTestEvent(t, test.conn), &payload))
+		require.Equal(t, test.wantLedger, string(payload["ledger_index"]))
+		require.Equal(t, "0", string(payload["network_id"]))
+		require.Equal(t, "0", string(payload["close_time"]))
+		require.Equal(t, `"ABCD"`, string(payload["data"]))
+	}
+	select {
+	case <-none.SendChannel:
+		t.Fatal("non-subscriber received validation")
+	default:
+	}
+}
+
+func TestPublishLedgerClosedFieldPresence(t *testing.T) {
+	manager := subscription.NewManager()
+	conn := addPublisherTestConnection(manager, "ledger")
+	conn.Subscriptions[types.SubLedger] = types.SubscriptionConfig{}
+	publisher := NewPublisher(manager)
+	event := &LedgerCloseEvent{
+		Type:        "ledgerClosed",
+		LedgerIndex: 42,
+		NetworkID:   0,
+	}
+	publisher.PublishLedgerClosed(event)
+	var payload map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(readPublisherTestEvent(t, conn), &payload))
+	require.Equal(t, "0", string(payload["network_id"]))
+	require.NotContains(t, payload, "fee_ref")
+	require.NotContains(t, payload, "validated_ledgers")
+
+	feeRef := uint64(10)
+	event.FeeRef = &feeRef
+	event.ValidatedLedgers = "1-42"
+	publisher.PublishLedgerClosed(event)
+	require.NoError(t, json.Unmarshal(readPublisherTestEvent(t, conn), &payload))
+	require.Equal(t, "10", string(payload["fee_ref"]))
+	require.Equal(t, `"1-42"`, string(payload["validated_ledgers"]))
+}
+
 func TestPublishOrderBookChangeDeduplicatesAcrossAffectedBooks(t *testing.T) {
 	const (
 		issuer = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"

--- a/internal/rpc/rpcsub_test.go
+++ b/internal/rpc/rpcsub_test.go
@@ -361,7 +361,7 @@ func TestRPCSub_SubscribeAckCarriesLedgerInfo(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, uint32(42), ack["ledger_index"])
 	assert.Equal(t, "ABCD", ack["ledger_hash"])
-	assert.Equal(t, uint64(10), ack["fee_base"])
+	assert.Equal(t, int32(10), ack["fee_base"])
 	// network_id is emitted unconditionally, even when zero.
 	require.Contains(t, ack, "network_id")
 	assert.Equal(t, uint32(0), ack["network_id"])

--- a/internal/rpc/server_info_test.go
+++ b/internal/rpc/server_info_test.go
@@ -1438,6 +1438,29 @@ func TestServerInfo_MachineMode_LoadFactorFees(t *testing.T) {
 	assert.EqualValues(t, 256, state["load_base"])
 }
 
+func TestServerInfo_LoadFactorEscalationAvoidsIntermediateOverflow(t *testing.T) {
+	mock := newMockLedgerServiceServerInfo()
+	services := servicesForServerInfo(mock)
+	services.TxQMetrics = func() types.TxQServerMetrics {
+		return types.TxQServerMetrics{
+			ReferenceFeeLevel:  256,
+			OpenLedgerFeeLevel: 1 << 56,
+		}
+	}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	machine := callServerStatus(t, ctx, false)
+	assert.EqualValues(t, math.MaxUint32, machine["load_factor"])
+
+	human := callServerStatus(t, ctx, true)
+	assert.Equal(t, float64(uint64(1)<<48), human["load_factor"])
+}
+
 // TestServerInfo_ValidatedLedgerAge_HighAgeThreshold guards against
 // regressing the threshold below rippled's 1,000,000-second limit
 // (NetworkOPs.cpp:2951). A 1-hour-old ledger must report an actual

--- a/internal/rpc/subscribe_conformance_test.go
+++ b/internal/rpc/subscribe_conformance_test.go
@@ -403,9 +403,9 @@ func TestSubscribeConformanceLedgerResponseFields(t *testing.T) {
 	assert.Equal(t, uint32(2), response.LedgerIndex, "LedgerIndex should match")
 	assert.NotEmpty(t, response.LedgerHash, "LedgerHash should be present")
 	assert.Equal(t, uint32(735000000), response.LedgerTime, "LedgerTime should match")
-	assert.Equal(t, uint64(10), response.FeeBase, "FeeBase should match")
-	assert.Equal(t, uint64(10000000), response.ReserveBase, "ReserveBase should match")
-	assert.Equal(t, uint64(2000000), response.ReserveInc, "ReserveInc should match")
+	assert.Equal(t, int32(10), response.FeeBase, "FeeBase should match")
+	assert.Equal(t, int32(10000000), response.ReserveBase, "ReserveBase should match")
+	assert.Equal(t, int32(2000000), response.ReserveInc, "ReserveInc should match")
 }
 
 // book_changes Stream Tests

--- a/internal/rpc/subscribe_test.go
+++ b/internal/rpc/subscribe_test.go
@@ -1302,9 +1302,9 @@ func TestGetSubscribeResponse(t *testing.T) {
 	assert.Equal(t, uint32(100), response.LedgerIndex)
 	assert.Equal(t, "4BC50C9B0D8515D3EAAE1E74B29A95804346C491EE1A95BF25E4AAB854A6A652", response.LedgerHash)
 	assert.Equal(t, uint32(735000000), response.LedgerTime)
-	assert.Equal(t, uint64(10), response.FeeBase)
-	assert.Equal(t, uint64(10000000), response.ReserveBase)
-	assert.Equal(t, uint64(2000000), response.ReserveInc)
+	assert.Equal(t, int32(10), response.FeeBase)
+	assert.Equal(t, int32(10000000), response.ReserveBase)
+	assert.Equal(t, int32(2000000), response.ReserveInc)
 }
 
 // Subscribe/Unsubscribe Method Tests (RPC Handler level)

--- a/internal/rpc/subscribe_test.go
+++ b/internal/rpc/subscribe_test.go
@@ -1865,6 +1865,36 @@ func TestComputeServerLoad_TracksTxQ(t *testing.T) {
 		"server-wide load_factor must rise to escalation when it exceeds loadBase")
 }
 
+func TestComputeServerLoad_UsesServerAndOverallMaxima(t *testing.T) {
+	mock := newMockLedgerService()
+	services := types.NewServiceContainer(mock)
+	services.LoadFactorFees = func() types.LoadFactorFees {
+		return types.LoadFactorFees{Local: 700, Net: 900, Cluster: 800}
+	}
+	services.TxQMetrics = func() types.TxQServerMetrics {
+		return types.TxQServerMetrics{
+			ReferenceFeeLevel:     256,
+			MinProcessingFeeLevel: 256,
+			OpenLedgerFeeLevel:    600,
+		}
+	}
+
+	load := handlers.ComputeServerLoad(services)
+	assert.Equal(t, uint64(900), load.LoadFactorServer)
+	assert.Equal(t, uint64(900), load.LoadFactor)
+
+	services.TxQMetrics = func() types.TxQServerMetrics {
+		return types.TxQServerMetrics{
+			ReferenceFeeLevel:     256,
+			MinProcessingFeeLevel: 256,
+			OpenLedgerFeeLevel:    1200,
+		}
+	}
+	load = handlers.ComputeServerLoad(services)
+	assert.Equal(t, uint64(900), load.LoadFactorServer)
+	assert.Equal(t, uint64(1200), load.LoadFactor)
+}
+
 // TestSubscribeRtTransactionsAlias verifies the deprecated
 // "rt_transactions" stream name is accepted as an alias for
 // "transactions_proposed" (rippled Subscribe.cpp:151-156).

--- a/internal/rpc/subscription/manager.go
+++ b/internal/rpc/subscription/manager.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/keylet"
 )
@@ -954,8 +955,8 @@ func (sm *Manager) SubscribeResponse(ledgerIndex uint32, ledgerHash string, ledg
 		LedgerIndex: ledgerIndex,
 		LedgerHash:  ledgerHash,
 		LedgerTime:  ledgerTime,
-		FeeBase:     feeBase,
-		ReserveBase: reserveBase,
-		ReserveInc:  reserveInc,
+		FeeBase:     drops.XRPAmount(int64(feeBase)).JSONClipped(),
+		ReserveBase: drops.XRPAmount(int64(reserveBase)).JSONClipped(),
+		ReserveInc:  drops.XRPAmount(int64(reserveInc)).JSONClipped(),
 	}
 }

--- a/internal/rpc/subscription/manager.go
+++ b/internal/rpc/subscription/manager.go
@@ -725,15 +725,18 @@ func (sm *Manager) HasStreamSubscriptions(connID string) bool {
 }
 
 // BroadcastToStream sends a message to every connection subscribed to a
-// stream. Broadcasts snapshot subscriber connections under sm.mu, then
-// send after the lock is released — a slow consumer never stalls
-// HandleSubscribe / HandleUnsubscribe / RemoveConnection or other
-// broadcasts (#428 race fix). Delivery uses types.Connection.TrySend so
-// the per-connection consecutive-drop counter is updated and the
-// connection is disconnected after MaxConsecutiveDrops back-to-back
-// failures — unifies the slow-consumer policy across all outbound paths.
-func (sm *Manager) BroadcastToStream(streamType types.SubscriptionType, data []byte, _ any) {
-	deliver(sm.collectStreamTargets(streamType), data)
+// stream and returns the number of snapshotted targets. Broadcasts snapshot
+// subscriber connections under sm.mu, then send after the lock is released —
+// a slow consumer never stalls HandleSubscribe / HandleUnsubscribe /
+// RemoveConnection or other broadcasts (#428 race fix). Delivery uses
+// types.Connection.TrySend so the per-connection consecutive-drop counter is
+// updated and the connection is disconnected after MaxConsecutiveDrops
+// back-to-back failures — unifies the slow-consumer policy across all outbound
+// paths.
+func (sm *Manager) BroadcastToStream(streamType types.SubscriptionType, data []byte, _ any) int {
+	targets := sm.collectStreamTargets(streamType)
+	deliver(targets, data)
+	return len(targets)
 }
 
 // BroadcastToStreamVersioned selects the transaction representation recorded

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -611,9 +611,9 @@ type SubscribeResponse struct {
 	LedgerIndex uint32 `json:"ledger_index"`
 	LedgerHash  string `json:"ledger_hash"`
 	LedgerTime  uint32 `json:"ledger_time"`
-	FeeBase     uint64 `json:"fee_base"`
-	ReserveBase uint64 `json:"reserve_base"`
-	ReserveInc  uint64 `json:"reserve_inc"`
+	FeeBase     int32  `json:"fee_base"`
+	ReserveBase int32  `json:"reserve_base"`
+	ReserveInc  int32  `json:"reserve_inc"`
 }
 
 // IsValidXRPLAddress validates an XRPL address using the address codec
@@ -684,10 +684,10 @@ type LedgerSubscribeInfo struct {
 	LedgerIndex      uint32 `json:"ledger_index"`
 	LedgerHash       string `json:"ledger_hash"`
 	LedgerTime       uint32 `json:"ledger_time"`
-	FeeBase          uint64 `json:"fee_base"`
+	FeeBase          int32  `json:"fee_base"`
 	FeeRef           uint64 `json:"fee_ref"`
-	ReserveBase      uint64 `json:"reserve_base"`
-	ReserveInc       uint64 `json:"reserve_inc"`
+	ReserveBase      int32  `json:"reserve_base"`
+	ReserveInc       int32  `json:"reserve_inc"`
 	ValidatedLedgers string `json:"validated_ledgers,omitempty"`
 	NetworkID        uint32 `json:"network_id"`
 	// XRPFeesEnabled gates fee_ref: rippled emits the deprecated fee_ref


### PR DESCRIPTION
## Summary

- derive ledger stream fees, ranges, amendment fields, and network ID from the selected accepted or validated ledger
- publish validation notifications with canonical raw data and API-version-correct ledger indexes
- serialize server-status publication across ledger, operating-mode, fee, load, and TxQ transitions
- use rippled-compatible fee and load clipping with overflow-safe scaling
- preserve oracle-correct LOST_SYNC state handling and public-stream suppression

## Stack

Layer 4 of 5 for #1470. This PR targets #1529 and is followed by #1531.

Part of #1470.

## Testing

- focused ledger, validation, server-status, and fee/load tests
- repeated concurrency and affected race tests
- go test ./...
- just vet
- just lint
- just build-all
- independent rippled v3.2.0 conformance review