### PR TITLE
fix: harden peer handshake admission (#1472)

### DIFF
--- a/internal/peermanagement/errors.go
+++ b/internal/peermanagement/errors.go
@@ -25,13 +25,15 @@ var (
 	ErrWriteIdle             = errors.New("peer write idle deadline exceeded")
 
 	// Handshake errors
-	ErrHandshakeFailed  = errors.New("handshake failed")
-	ErrInvalidHandshake = errors.New("invalid handshake data")
-	ErrHandshakeTimeout = errors.New("handshake timeout")
-	ErrProtocolMismatch = errors.New("protocol version mismatch")
-	ErrInvalidPublicKey = errors.New("invalid public key")
-	ErrInvalidSignature = errors.New("invalid signature")
-	ErrNetworkMismatch  = errors.New("network ID mismatch")
+	ErrHandshakeFailed          = errors.New("handshake failed")
+	ErrInvalidHandshake         = errors.New("invalid handshake data")
+	ErrHandshakeHeadersTooLarge = errors.New("handshake headers too large")
+	ErrHandshakeBodyTooLarge    = errors.New("handshake body too large")
+	ErrHandshakeTimeout         = errors.New("handshake timeout")
+	ErrProtocolMismatch         = errors.New("protocol version mismatch")
+	ErrInvalidPublicKey         = errors.New("invalid public key")
+	ErrInvalidSignature         = errors.New("invalid signature")
+	ErrNetworkMismatch          = errors.New("network ID mismatch")
 
 	// Discovery errors
 	ErrPeerNotFound    = errors.New("peer not found")

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -129,6 +129,69 @@ func BuildHandshakeRequest(id *Identity, sharedValue []byte, cfg HandshakeConfig
 	return req, nil
 }
 
+// validateHandshakeRequest checks the HTTP envelope before any XRPL-specific
+// verification. Rippled accepts a GET carrying an Upgrade token over HTTP
+// 1.1 or newer; role admission and peer authentication run afterwards.
+func validateHandshakeRequest(req *http.Request) error {
+	if req == nil {
+		return fmt.Errorf("%w: missing request", ErrInvalidHandshake)
+	}
+	if req.Method != http.MethodGet {
+		return fmt.Errorf("%w: method must be GET, got %q", ErrInvalidHandshake, req.Method)
+	}
+	if !httpVersionAtLeast11(req.ProtoMajor, req.ProtoMinor) {
+		return fmt.Errorf("%w: protocol must be HTTP/1.1 or newer, got %q", ErrInvalidHandshake, req.Proto)
+	}
+	if !headerToken(req.Header, HeaderConnection, "upgrade") {
+		return fmt.Errorf("%w: %s header must include upgrade", ErrInvalidHandshake, HeaderConnection)
+	}
+	upgrade := strings.TrimSpace(req.Header.Get(HeaderUpgrade))
+	if upgrade == "" {
+		return fmt.Errorf("%w: missing %s", ErrInvalidHandshake, HeaderUpgrade)
+	}
+	if len(parseProtocolVersions(upgrade)) == 0 {
+		return fmt.Errorf("%w: %s header contains no valid XRPL protocol version", ErrInvalidHandshake, HeaderUpgrade)
+	}
+	return nil
+}
+
+// validateHandshakeResponse enforces the response half of the same envelope:
+// HTTP/1.1-or-newer 101, Connection: Upgrade, and exactly one supported XRPL
+// version.
+func validateHandshakeResponse(resp *http.Response) error {
+	if resp == nil {
+		return fmt.Errorf("%w: missing response", ErrInvalidHandshake)
+	}
+	if !httpVersionAtLeast11(resp.ProtoMajor, resp.ProtoMinor) {
+		return fmt.Errorf("%w: protocol must be HTTP/1.1 or newer, got %q", ErrInvalidHandshake, resp.Proto)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		return fmt.Errorf("%w: got status %d", ErrInvalidHandshake, resp.StatusCode)
+	}
+	if !headerToken(resp.Header, HeaderConnection, "upgrade") {
+		return fmt.Errorf("%w: %s header must include upgrade", ErrInvalidHandshake, HeaderConnection)
+	}
+	if VerifyOutboundProtocolVersion(resp.Header.Get(HeaderUpgrade)) == "" {
+		return fmt.Errorf("%w: response must contain exactly one supported %s version", ErrInvalidHandshake, HeaderUpgrade)
+	}
+	return nil
+}
+
+func httpVersionAtLeast11(major, minor int) bool {
+	return major > 1 || (major == 1 && minor >= 1)
+}
+
+func headerToken(h http.Header, key, want string) bool {
+	for _, value := range h.Values(key) {
+		for _, token := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(token), want) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // WriteRawHandshakeRequest writes the request without the extra headers
 // (Host, Content-Length, ...) that http.Request.Write adds — rippled's
 // parser rejects them.

--- a/internal/peermanagement/handshake.go
+++ b/internal/peermanagement/handshake.go
@@ -233,12 +233,19 @@ func BuildHandshakeResponse(request *http.Request, id *Identity, sharedValue []b
 	if negotiated == "" {
 		negotiated = supportedProtocols[len(supportedProtocols)-1].String()
 	}
+	proto, protoMajor, protoMinor := "HTTP/1.1", 1, 1
+	if request != nil && request.ProtoMajor > 0 {
+		proto, protoMajor, protoMinor = request.Proto, request.ProtoMajor, request.ProtoMinor
+		if proto == "" {
+			proto = fmt.Sprintf("HTTP/%d.%d", protoMajor, protoMinor)
+		}
+	}
 	resp := &http.Response{
 		StatusCode: http.StatusSwitchingProtocols,
 		Status:     "101 Switching Protocols",
-		Proto:      "HTTP/1.1",
-		ProtoMajor: 1,
-		ProtoMinor: 1,
+		Proto:      proto,
+		ProtoMajor: protoMajor,
+		ProtoMinor: protoMinor,
 		Header:     make(http.Header),
 	}
 

--- a/internal/peermanagement/handshake_envelope_test.go
+++ b/internal/peermanagement/handshake_envelope_test.go
@@ -1,0 +1,503 @@
+package peermanagement
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/peertls"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateHandshakeRequestEnvelope(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	req, err := BuildHandshakeRequest(id, make([]byte, 32), DefaultHandshakeConfig())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		edit func(*http.Request)
+	}{
+		{name: "method", edit: func(r *http.Request) { r.Method = http.MethodPost }},
+		{name: "version", edit: func(r *http.Request) { r.ProtoMajor, r.ProtoMinor, r.Proto = 1, 0, "HTTP/1.0" }},
+		{name: "connection token", edit: func(r *http.Request) { r.Header.Set(HeaderConnection, "keep-alive") }},
+		{name: "upgrade missing", edit: func(r *http.Request) { r.Header.Del(HeaderUpgrade) }},
+		{name: "upgrade malformed", edit: func(r *http.Request) { r.Header.Set(HeaderUpgrade, "not-an-xrpl-version") }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			copyReq := req.Clone(context.Background())
+			copyReq.Header = req.Header.Clone()
+			tc.edit(copyReq)
+			require.ErrorIs(t, validateHandshakeRequest(copyReq), ErrInvalidHandshake)
+		})
+	}
+	require.NoError(t, validateHandshakeRequest(req))
+	missingPublicKey := req.Clone(context.Background())
+	missingPublicKey.Header = req.Header.Clone()
+	missingPublicKey.Header.Del(HeaderPublicKey)
+	require.NoError(t, validateHandshakeRequest(missingPublicKey))
+	withBody := req.Clone(context.Background())
+	withBody.Header = req.Header.Clone()
+	withBody.ContentLength = 1
+	require.NoError(t, validateHandshakeRequest(withBody), "positive Content-Length is accepted by the dynamic-body upgrade predicate")
+	withTransferEncoding := req.Clone(context.Background())
+	withTransferEncoding.Header = req.Header.Clone()
+	withTransferEncoding.TransferEncoding = []string{"chunked"}
+	require.NoError(t, validateHandshakeRequest(withTransferEncoding), "transfer encoding is accepted by the dynamic-body upgrade predicate")
+	missingConnectAs := req.Clone(context.Background())
+	missingConnectAs.Header = req.Header.Clone()
+	missingConnectAs.Header.Del(HeaderConnectAs)
+	require.NoError(t, validateHandshakeRequest(missingConnectAs), "Connect-As is handled by admission redirect logic")
+	for _, version := range []struct {
+		major int
+		minor int
+		proto string
+	}{
+		{major: 1, minor: 2, proto: "HTTP/1.2"},
+		{major: 2, minor: 0, proto: "HTTP/2.0"},
+	} {
+		copyReq := req.Clone(context.Background())
+		copyReq.Header = req.Header.Clone()
+		copyReq.ProtoMajor, copyReq.ProtoMinor, copyReq.Proto = version.major, version.minor, version.proto
+		require.NoErrorf(t, validateHandshakeRequest(copyReq), "HTTP version %s", version.proto)
+	}
+}
+
+func TestValidateHandshakeResponseEnvelope(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	resp := BuildHandshakeResponse(&http.Request{Header: make(http.Header)}, id, make([]byte, 32), DefaultHandshakeConfig(), "XRPL/2.2")
+
+	tests := []struct {
+		name string
+		edit func(*http.Response)
+	}{
+		{name: "status", edit: func(r *http.Response) { r.StatusCode = http.StatusOK }},
+		{name: "version", edit: func(r *http.Response) { r.ProtoMajor, r.ProtoMinor, r.Proto = 1, 0, "HTTP/1.0" }},
+		{name: "connection token", edit: func(r *http.Response) { r.Header.Set(HeaderConnection, "close") }},
+		{name: "upgrade version", edit: func(r *http.Response) { r.Header.Set(HeaderUpgrade, SupportedProtocolVersions()) }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			copyResp := *resp
+			copyResp.Header = resp.Header.Clone()
+			tc.edit(&copyResp)
+			require.ErrorIs(t, validateHandshakeResponse(&copyResp), ErrInvalidHandshake)
+		})
+	}
+	require.NoError(t, validateHandshakeResponse(resp))
+	for _, version := range []struct {
+		major int
+		minor int
+		proto string
+	}{
+		{major: 1, minor: 2, proto: "HTTP/1.2"},
+		{major: 2, minor: 0, proto: "HTTP/2.0"},
+	} {
+		copyResp := *resp
+		copyResp.Header = resp.Header.Clone()
+		copyResp.ProtoMajor, copyResp.ProtoMinor, copyResp.Proto = version.major, version.minor, version.proto
+		require.NoErrorf(t, validateHandshakeResponse(&copyResp), "HTTP version %s", version.proto)
+	}
+}
+
+func TestHandshakeHeaderReaderBoundsAndPreservesFrames(t *testing.T) {
+	header := "GET / HTTP/1.1\r\nConnection: Upgrade\r\nUpgrade: XRPL/2.2\r\n\r\n"
+	const payload = "\x01\x02\x03"
+	reader := &handshakeHeaderReader{r: strings.NewReader(header + payload), limit: maxHandshakeHeaderBytes}
+	buffered := bufio.NewReader(reader)
+	req, err := http.ReadRequest(buffered)
+	require.NoError(t, err)
+	require.Equal(t, http.MethodGet, req.Method)
+	got, err := io.ReadAll(buffered)
+	require.NoError(t, err)
+	require.Equal(t, []byte(payload), got)
+
+	oversized := &handshakeHeaderReader{
+		r:     strings.NewReader("GET / HTTP/1.1\r\nX-Bloat: " + strings.Repeat("x", maxHandshakeHeaderBytes) + "\r\n"),
+		limit: maxHandshakeHeaderBytes,
+	}
+	_, err = http.ReadRequest(bufio.NewReader(oversized))
+	require.ErrorIs(t, err, ErrHandshakeHeadersTooLarge)
+}
+
+func TestHandshakeHeaderReaderAcceptsLFOnlyAndPreservesFrames(t *testing.T) {
+	header := "GET / HTTP/1.1\nConnection: Upgrade\nUpgrade: XRPL/2.2\n\n"
+	const payload = "\x01\x02\x03"
+	reader := &handshakeHeaderReader{r: strings.NewReader(header + payload), limit: maxHandshakeHeaderBytes}
+	buffered := bufio.NewReader(reader)
+	req, err := http.ReadRequest(buffered)
+	require.NoError(t, err)
+	require.Equal(t, http.MethodGet, req.Method)
+	got, err := io.ReadAll(buffered)
+	require.NoError(t, err)
+	require.Equal(t, []byte(payload), got)
+	require.True(t, reader.done)
+}
+
+func TestHandshakeHeaderReaderExactBoundary(t *testing.T) {
+	prefix := "GET / HTTP/1.1\r\nConnection: Upgrade\r\nUpgrade: XRPL/2.2\r\n"
+	suffix := "\r\n"
+	makeHeader := func(total int) string {
+		target := total - len(prefix) - len(suffix)
+		line := "X-Pad: x\r\n"
+		lines := target / len(line)
+		remaining := target - lines*len(line)
+		const minLine = len("X-Pad: \r\n")
+		if remaining > 0 && remaining < minLine {
+			lines--
+			remaining += len(line)
+		}
+		padding := strings.Repeat(line, lines)
+		if remaining > 0 {
+			padding += "X-Pad: " + strings.Repeat("x", remaining-minLine) + "\r\n"
+		}
+		return prefix + padding + suffix
+	}
+
+	exactHeader := makeHeader(maxHandshakeHeaderBytes)
+	require.Len(t, exactHeader, maxHandshakeHeaderBytes)
+	exactReader := &handshakeHeaderReader{r: strings.NewReader(exactHeader), limit: maxHandshakeHeaderBytes}
+	_, err := http.ReadRequest(bufio.NewReader(exactReader))
+	require.NoError(t, err)
+
+	tooLargeHeader := makeHeader(maxHandshakeHeaderBytes + 1)
+	require.Len(t, tooLargeHeader, maxHandshakeHeaderBytes+1)
+	tooLargeReader := &handshakeHeaderReader{r: strings.NewReader(tooLargeHeader), limit: maxHandshakeHeaderBytes}
+	_, err = io.ReadAll(tooLargeReader)
+	require.ErrorIs(t, err, ErrHandshakeHeadersTooLarge)
+}
+
+type closeErrorBody struct {
+	io.Reader
+}
+
+func (closeErrorBody) Close() error { return errors.New("body close failed") }
+
+var (
+	errBodyReadPastLimit   = errors.New("body read past limit")
+	errBodyCloseWouldDrain = errors.New("body close would drain unread bytes")
+)
+
+type handshakeBodyProbe struct {
+	io.ReadCloser
+	expected int64
+	readN    int64
+	closeN   int
+}
+
+func (b *handshakeBodyProbe) Read(p []byte) (int, error) {
+	if b.readN >= b.expected {
+		return 0, errBodyReadPastLimit
+	}
+	remaining := b.expected - b.readN
+	if int64(len(p)) > remaining {
+		p = p[:remaining]
+	}
+	n, err := b.ReadCloser.Read(p)
+	b.readN += int64(n)
+	return n, err
+}
+
+func (b *handshakeBodyProbe) Close() error {
+	b.closeN++
+	if b.readN < b.expected {
+		return errBodyCloseWouldDrain
+	}
+	return b.ReadCloser.Close()
+}
+
+func parseHandshakeBodyRequest(t *testing.T, wire string) *http.Request {
+	t.Helper()
+	req, err := http.ReadRequest(bufio.NewReader(strings.NewReader(wire)))
+	require.NoError(t, err)
+	return req
+}
+
+func TestReadHandshakeBodyBoundsAndErrors(t *testing.T) {
+	exact := parseHandshakeBodyRequest(t, fmt.Sprintf(
+		"GET / HTTP/1.1\r\nContent-Length: %d\r\n\r\n%s",
+		maxHandshakeBodyBytes,
+		strings.Repeat("x", maxHandshakeBodyBytes),
+	))
+	exactProbe := &handshakeBodyProbe{
+		ReadCloser: exact.Body,
+		expected:   maxHandshakeBodyBytes,
+	}
+	exact.Body = exactProbe
+	require.NoError(t, readHandshakeBody(exact))
+	require.Equal(t, int64(maxHandshakeBodyBytes), exactProbe.readN)
+	require.Equal(t, 1, exactProbe.closeN)
+
+	fixedTooLarge := parseHandshakeBodyRequest(t, fmt.Sprintf(
+		"GET / HTTP/1.1\r\nContent-Length: %d\r\n\r\n%s",
+		maxHandshakeBodyBytes+1,
+		strings.Repeat("x", maxHandshakeBodyBytes+1),
+	))
+	fixedProbe := &handshakeBodyProbe{
+		ReadCloser: fixedTooLarge.Body,
+		expected:   maxHandshakeBodyBytes + 1,
+	}
+	fixedTooLarge.Body = fixedProbe
+	require.ErrorIs(t, readHandshakeBody(fixedTooLarge), ErrHandshakeBodyTooLarge)
+	require.Zero(t, fixedProbe.readN, "oversized fixed bodies are rejected before reading")
+	require.Zero(t, fixedProbe.closeN, "oversized fixed bodies are left for connection close")
+
+	chunkedTooLarge := parseHandshakeBodyRequest(t, fmt.Sprintf(
+		"GET / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n%x\r\n%s\r\n0\r\n\r\n",
+		maxHandshakeBodyBytes+1,
+		strings.Repeat("x", maxHandshakeBodyBytes+1),
+	))
+	chunkedProbe := &handshakeBodyProbe{
+		ReadCloser: chunkedTooLarge.Body,
+		expected:   maxHandshakeBodyBytes + 1,
+	}
+	chunkedTooLarge.Body = chunkedProbe
+	require.ErrorIs(t, readHandshakeBody(chunkedTooLarge), ErrHandshakeBodyTooLarge)
+	require.Equal(t, int64(maxHandshakeBodyBytes+1), chunkedProbe.readN,
+		"chunked bodies are read only through the first byte over the limit")
+	require.Zero(t, chunkedProbe.closeN, "oversized chunked bodies are not drained by Close")
+
+	truncatedWire := "GET / HTTP/1.1\r\nContent-Length: 3\r\n\r\nx"
+	truncated, err := http.ReadRequest(bufio.NewReader(strings.NewReader(truncatedWire)))
+	require.NoError(t, err)
+	require.ErrorIs(t, readHandshakeBody(truncated), io.ErrUnexpectedEOF)
+
+	validChunkedWire := "GET / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nbody\r\n0\r\n\r\n"
+	validChunked, err := http.ReadRequest(bufio.NewReader(strings.NewReader(validChunkedWire)))
+	require.NoError(t, err)
+	require.NoError(t, readHandshakeBody(validChunked))
+
+	chunkedWire := "GET / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\nZ\r\nnot-a-chunk\r\n0\r\n\r\n"
+	chunked, err := http.ReadRequest(bufio.NewReader(strings.NewReader(chunkedWire)))
+	require.NoError(t, err)
+	require.Error(t, readHandshakeBody(chunked))
+
+	closeErr := &http.Request{Body: closeErrorBody{Reader: strings.NewReader("body")}, ContentLength: 4}
+	require.Error(t, readHandshakeBody(closeErr))
+}
+
+type deadlinePeerConn struct {
+	data      *bytes.Reader
+	deadlines []time.Time
+	writes    bytes.Buffer
+}
+
+var _ peertls.PeerConn = (*deadlinePeerConn)(nil)
+
+func (c *deadlinePeerConn) Read(p []byte) (int, error) { return c.data.Read(p) }
+func (c *deadlinePeerConn) Write(p []byte) (int, error) {
+	return c.writes.Write(p)
+}
+func (c *deadlinePeerConn) Close() error         { return nil }
+func (c *deadlinePeerConn) LocalAddr() net.Addr  { return &net.TCPAddr{} }
+func (c *deadlinePeerConn) RemoteAddr() net.Addr { return &net.TCPAddr{IP: net.ParseIP("192.0.2.1")} }
+func (c *deadlinePeerConn) SetDeadline(deadline time.Time) error {
+	c.deadlines = append(c.deadlines, deadline)
+	return nil
+}
+func (c *deadlinePeerConn) SetReadDeadline(time.Time) error        { return nil }
+func (c *deadlinePeerConn) SetWriteDeadline(time.Time) error       { return nil }
+func (c *deadlinePeerConn) HandshakeContext(context.Context) error { return nil }
+func (c *deadlinePeerConn) SharedValue() ([]byte, error)           { return make([]byte, 32), nil }
+
+func TestInboundHandshakeInstallsAndResetsDeadline(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	o := &Overlay{cfg: DefaultConfig(), identity: id}
+	peer := NewPeer(1, Endpoint{Host: "192.0.2.1", Port: 51235}, true, id, nil)
+	conn := &deadlinePeerConn{data: bytes.NewReader([]byte("not an HTTP request\r\n"))}
+	err = o.performInboundHandshake(context.Background(), peer, conn)
+	require.Error(t, err)
+	require.GreaterOrEqual(t, len(conn.deadlines), 2)
+	require.False(t, conn.deadlines[0].IsZero())
+	require.True(t, conn.deadlines[len(conn.deadlines)-1].IsZero())
+}
+
+func TestMissingConnectAsUsesRedirect(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	req, err := BuildHandshakeRequest(id, make([]byte, 32), DefaultHandshakeConfig())
+	require.NoError(t, err)
+	req.Header.Del(HeaderConnectAs)
+	req.Header.Del(HeaderPublicKey)
+	req.Header.Del(HeaderSessionSignature)
+	var wire bytes.Buffer
+	require.NoError(t, WriteRawHandshakeRequest(&wire, req))
+
+	o := newLifecycleTestOverlay(t, WithListenAddr(""))
+	peer := NewPeer(1, Endpoint{Host: "192.0.2.1", Port: 51235}, true, o.identity, nil)
+	conn := &deadlinePeerConn{data: bytes.NewReader(wire.Bytes())}
+	err = o.performInboundHandshake(context.Background(), peer, conn)
+	require.ErrorIs(t, err, errInboundRejected)
+	require.Contains(t, conn.writes.String(), "HTTP/1.1 503 Service Unavailable")
+	require.NotContains(t, conn.writes.String(), "HTTP/1.1 400 Bad Request")
+}
+
+func TestMalformedUpgradeUsesEnvelopeErrorBeforeRedirect(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	req, err := BuildHandshakeRequest(id, make([]byte, 32), DefaultHandshakeConfig())
+	require.NoError(t, err)
+	req.Header.Set(HeaderUpgrade, "not-an-xrpl-version")
+	req.Header.Set(HeaderConnectAs, "crawler")
+	var wire bytes.Buffer
+	require.NoError(t, WriteRawHandshakeRequest(&wire, req))
+
+	o := newLifecycleTestOverlay(t, WithListenAddr(""))
+	peer := NewPeer(1, Endpoint{Host: "192.0.2.1", Port: 51235}, true, o.identity, nil)
+	conn := &deadlinePeerConn{data: bytes.NewReader(wire.Bytes())}
+	err = o.performInboundHandshake(context.Background(), peer, conn)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errInboundRejected)
+	require.Contains(t, conn.writes.String(), "HTTP/1.1 400 Bad Request")
+}
+
+func runInboundHandshakeRequest(t *testing.T, edit func(*http.Request)) (*deadlinePeerConn, error) {
+	t.Helper()
+	remoteID, err := NewIdentity()
+	require.NoError(t, err)
+	req, err := BuildHandshakeRequest(remoteID, make([]byte, 32), DefaultHandshakeConfig())
+	require.NoError(t, err)
+	edit(req)
+	var wire bytes.Buffer
+	require.NoError(t, WriteRawHandshakeRequest(&wire, req))
+	return runRawInboundHandshakeRequest(t, wire.Bytes())
+}
+
+func runRawInboundHandshakeRequest(t *testing.T, wire []byte) (*deadlinePeerConn, error) {
+	t.Helper()
+	o := newLifecycleTestOverlay(t, WithListenAddr(""))
+	peer := NewPeer(1, Endpoint{Host: "192.0.2.1", Port: 51235}, true, o.identity, nil)
+	conn := &deadlinePeerConn{data: bytes.NewReader(wire)}
+	err := o.performInboundHandshake(context.Background(), peer, conn)
+	return conn, err
+}
+
+func TestNegotiationPrecedesAuthentication(t *testing.T) {
+	conn, err := runInboundHandshakeRequest(t, func(req *http.Request) {
+		req.Header.Set(HeaderUpgrade, "XRPL/9.9")
+		req.Header.Del(HeaderPublicKey)
+		req.Header.Del(HeaderSessionSignature)
+	})
+	require.Error(t, err)
+	require.Contains(t, conn.writes.String(), "HTTP/1.1 400 Bad Request")
+	require.Contains(t, conn.writes.String(), "unable to agree on a protocol version")
+	require.NotContains(t, conn.writes.String(), "missing Public-Key")
+}
+
+func TestInboundBodyErrorPrecedesAdmission(t *testing.T) {
+	remoteID, err := NewIdentity()
+	require.NoError(t, err)
+	req, err := BuildHandshakeRequest(remoteID, make([]byte, 32), DefaultHandshakeConfig())
+	require.NoError(t, err)
+	req.Header.Del(HeaderConnectAs)
+	req.Header.Del(HeaderPublicKey)
+	req.Header.Del(HeaderSessionSignature)
+	req.ContentLength = 3
+	req.Body = io.NopCloser(strings.NewReader("abc"))
+	var wire bytes.Buffer
+	require.NoError(t, req.Write(&wire))
+	truncated := append([]byte(nil), wire.Bytes()[:wire.Len()-2]...)
+
+	o := newLifecycleTestOverlay(t, WithListenAddr(""))
+	peer := NewPeer(1, Endpoint{Host: "192.0.2.1", Port: 51235}, true, o.identity, nil)
+	conn := &deadlinePeerConn{data: bytes.NewReader(truncated)}
+	err = o.performInboundHandshake(context.Background(), peer, conn)
+	require.Error(t, err)
+	require.Contains(t, conn.writes.String(), "HTTP/1.1 400 Bad Request")
+	require.NotContains(t, conn.writes.String(), "HTTP/1.1 503 Service Unavailable")
+}
+
+func TestInboundOversizedBodyWritesBadRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		wire string
+	}{
+		{
+			name: "fixed content length",
+			wire: fmt.Sprintf(
+				"GET / HTTP/1.1\r\nContent-Length: %d\r\n\r\n%s",
+				maxHandshakeBodyBytes+1,
+				strings.Repeat("x", maxHandshakeBodyBytes+1),
+			),
+		},
+		{
+			name: "chunked body",
+			wire: fmt.Sprintf(
+				"GET / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n%x\r\n%s\r\n0\r\n\r\n",
+				maxHandshakeBodyBytes+1,
+				strings.Repeat("x", maxHandshakeBodyBytes+1),
+			),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, err := runRawInboundHandshakeRequest(t, []byte(tc.wire))
+			require.Error(t, err)
+			require.Contains(t, conn.writes.String(), "HTTP/1.1 400 Bad Request")
+		})
+	}
+}
+
+func TestInboundVerificationErrorsWriteBadRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(*http.Request)
+	}{
+		{name: "server domain", edit: func(req *http.Request) { req.Header.Set(HeaderServerDomain, "-bad.example.com") }},
+		{name: "network id", edit: func(req *http.Request) { req.Header.Set(HeaderNetworkID, "not-a-number") }},
+		{name: "network time", edit: func(req *http.Request) { req.Header.Set(HeaderNetworkTime, "not-a-time") }},
+		{name: "public key", edit: func(req *http.Request) { req.Header.Del(HeaderPublicKey) }},
+		{name: "session signature", edit: func(req *http.Request) { req.Header.Del(HeaderSessionSignature) }},
+		{name: "local ip", edit: func(req *http.Request) { req.Header.Set(HeaderLocalIP, "not-an-ip") }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, err := runInboundHandshakeRequest(t, tc.edit)
+			require.Error(t, err)
+			require.Contains(t, conn.writes.String(), "HTTP/1.1 400 Bad Request")
+		})
+	}
+}
+
+func TestOutboundResourceAdmissionPrecedesDial(t *testing.T) {
+	o := newLifecycleTestOverlay(t, WithListenAddr(""))
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- o.Run(ctx) }()
+	select {
+	case <-o.ListenerReady():
+	case <-time.After(2 * time.Second):
+		t.Fatal("overlay did not become ready")
+	}
+
+	const addr = "127.0.0.1:1"
+	consumer := o.resourceManager.NewOutboundEndpoint(addr)
+	for consumer.Disposition() != resource.Drop {
+		if consumer.Charge(resource.NewCharge(resource.DropThreshold+1, "test"), "") == resource.Drop {
+			break
+		}
+	}
+	consumer.Release()
+	if err := o.Connect(addr); !errors.Is(err, ErrEndpointBanned) {
+		t.Fatalf("Connect error = %v, want ErrEndpointBanned before dial", err)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("overlay Run did not stop")
+	}
+}

--- a/internal/peermanagement/handshake_test.go
+++ b/internal/peermanagement/handshake_test.go
@@ -123,6 +123,21 @@ func TestBuildHandshakeResponse(t *testing.T) {
 	assert.Equal(t, cfg.UserAgent, resp.Header.Get(HeaderServer))
 }
 
+func TestBuildHandshakeResponseMirrorsHTTPVersion(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+
+	request := emptyHandshakeRequest()
+	request.Proto = "HTTP/2.0"
+	request.ProtoMajor = 2
+	request.ProtoMinor = 0
+
+	resp := BuildHandshakeResponse(request, id, make([]byte, 32), DefaultHandshakeConfig(), "")
+	assert.Equal(t, request.Proto, resp.Proto)
+	assert.Equal(t, request.ProtoMajor, resp.ProtoMajor)
+	assert.Equal(t, request.ProtoMinor, resp.ProtoMinor)
+}
+
 func TestBuildHandshakeResponseNegotiatesFeatures(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)

--- a/internal/peermanagement/overlay_inbound.go
+++ b/internal/peermanagement/overlay_inbound.go
@@ -2,9 +2,11 @@ package peermanagement
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -22,6 +24,97 @@ const inboundBacklogSlack = 8
 // a non-fatal error (typically EMFILE-class) so the loop does not
 // spin at CPU speed under FD pressure.
 const acceptBackoff = 100 * time.Millisecond
+
+const (
+	maxHandshakeHeaderBytes = 8 * 1024
+	maxHandshakeBodyBytes   = 1 << 20
+)
+
+// handshakeHeaderReader bounds the bytes consumed by http.ReadRequest until
+// the end-of-headers marker. Once the marker is seen it becomes transparent,
+// preserving any already-buffered peer frames for the Peer read loop.
+type handshakeHeaderReader struct {
+	r       io.Reader
+	used    int64
+	limit   int64
+	tail    [3]byte
+	tailLen int
+	done    bool
+}
+
+func (r *handshakeHeaderReader) Read(p []byte) (int, error) {
+	if r.done {
+		return r.r.Read(p)
+	}
+	if r.used >= r.limit {
+		return 0, ErrHandshakeHeadersTooLarge
+	}
+	remaining := r.limit - r.used
+	if int64(len(p)) > remaining {
+		p = p[:int(remaining)]
+	}
+	n, err := r.r.Read(p)
+	if n == 0 {
+		return n, err
+	}
+	r.used += int64(n)
+	var marker bytes.Buffer
+	marker.Grow(r.tailLen + n)
+	marker.Write(r.tail[:r.tailLen])
+	marker.Write(p[:n])
+	// net/http accepts both conventional CRLF and the LF-only form. Once
+	// either header terminator is parsed, stop enforcing the handshake limit so
+	// binary peer frames cannot be mistaken for oversized headers.
+	if bytes.Contains(marker.Bytes(), []byte("\r\n\r\n")) || bytes.Contains(marker.Bytes(), []byte("\n\n")) {
+		r.done = true
+		return n, err
+	}
+	if marker.Len() > len(r.tail) {
+		copy(r.tail[:], marker.Bytes()[marker.Len()-len(r.tail):])
+		r.tailLen = len(r.tail)
+	} else {
+		copy(r.tail[:], marker.Bytes())
+		r.tailLen = marker.Len()
+	}
+	return n, err
+}
+
+func readHandshakeBody(req *http.Request) error {
+	if req == nil {
+		return nil
+	}
+	// A declared length is available before reading the body. Reject it now so
+	// http.body.Close cannot drain an oversized fixed-length payload.
+	if req.ContentLength > maxHandshakeBodyBytes {
+		return fmt.Errorf("%w: declared length %d", ErrHandshakeBodyTooLarge, req.ContentLength)
+	}
+	if req.Body == nil {
+		if req.ContentLength > 0 || len(req.TransferEncoding) > 0 {
+			return fmt.Errorf("%w: body is missing", ErrInvalidHandshake)
+		}
+		return nil
+	}
+	readN, readErr := io.Copy(io.Discard, io.LimitReader(req.Body, maxHandshakeBodyBytes+1))
+	if readErr != nil {
+		return fmt.Errorf("%w: read request body: %w", ErrInvalidHandshake, readErr)
+	}
+	if readN > maxHandshakeBodyBytes {
+		// The connection is closed by the caller after a failed handshake. Do not
+		// call http.body.Close here: for fixed and chunked bodies it may drain an
+		// arbitrary amount of unread input before returning.
+		return fmt.Errorf("%w: got at least %d bytes", ErrHandshakeBodyTooLarge, readN)
+	}
+	if req.ContentLength >= 0 && readN != req.ContentLength {
+		return fmt.Errorf("%w: body length %d, want %d", ErrInvalidHandshake, readN, req.ContentLength)
+	}
+	// At this point the body was read to EOF, so Close cannot perform an
+	// unbounded drain. Preserve close errors for callers that provide them.
+	closeErr := req.Body.Close()
+	if closeErr != nil {
+		return fmt.Errorf("%w: close request body: %w", ErrInvalidHandshake, closeErr)
+	}
+	return nil
+}
 
 // admitInboundEndpoint reports whether an inbound connection from addr
 // may proceed. It refuses an endpoint whose resource Consumer is already
@@ -237,15 +330,36 @@ func (o *Overlay) performInboundHandshake(ctx context.Context, peer *Peer, tlsCo
 	}
 
 	deadline := time.Now().Add(o.cfg.HandshakeTimeout)
-	tlsConn.SetDeadline(deadline)
-	defer tlsConn.SetDeadline(time.Time{})
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	if err := tlsConn.SetDeadline(deadline); err != nil {
+		return NewHandshakeError(peer.Endpoint(), "set_deadline", err)
+	}
+	defer func() {
+		if err := tlsConn.SetDeadline(time.Time{}); err != nil {
+			slog.Debug("Inbound handshake deadline reset failed", "t", "Overlay", "err", err)
+		}
+	}()
 
-	bufReader := bufio.NewReader(tlsConn)
+	bufReader := bufio.NewReader(&handshakeHeaderReader{
+		r:     tlsConn,
+		limit: maxHandshakeHeaderBytes,
+	})
+	hsCfg := o.handshakeConfigFor()
 	req, err := http.ReadRequest(bufReader)
 	if err != nil {
+		writeInboundHandshakeError(tlsConn, hsCfg, tcpRemoteIP(tlsConn), err)
 		return NewHandshakeError(peer.Endpoint(), "read_request", err)
 	}
-	req.Body.Close()
+	if err := readHandshakeBody(req); err != nil {
+		writeInboundHandshakeError(tlsConn, hsCfg, tcpRemoteIP(tlsConn), err)
+		return NewHandshakeError(peer.Endpoint(), "read_body", err)
+	}
+	if err := validateHandshakeRequest(req); err != nil {
+		writeInboundHandshakeError(tlsConn, hsCfg, tcpRemoteIP(tlsConn), err)
+		return NewHandshakeError(peer.Endpoint(), "validate_envelope", err)
+	}
 
 	// A dialer that does not advertise the "peer" role (a crawler or a
 	// misdirected client) is handed alternates and closed rather than
@@ -258,16 +372,19 @@ func (o *Overlay) performInboundHandshake(ctx context.Context, peer *Peer, tlsCo
 		o.writeInboundRedirect(tlsConn)
 		return errInboundRejected
 	}
+	protocol := NegotiateProtocolVersion(req.Header.Get(HeaderUpgrade))
+	if protocol == "" {
+		err := fmt.Errorf("%w: unable to agree on a protocol version (peer offered %q)",
+			ErrInvalidHandshake, req.Header.Get(HeaderUpgrade))
+		writeInboundHandshakeError(tlsConn, hsCfg, tcpRemoteIP(tlsConn), err)
+		return NewHandshakeError(peer.Endpoint(), "negotiate", err)
+	}
 
 	// Server-Domain runs first in the verify chain.
 	if _, err := ValidateServerDomain(req.Header); err != nil {
+		writeInboundHandshakeError(tlsConn, hsCfg, tcpRemoteIP(tlsConn), err)
 		return NewHandshakeError(peer.Endpoint(), "verify_extras", err)
 	}
-
-	// Build the handshake config once and share it with both
-	// VerifyPeerHandshake and BuildHandshakeResponse so the inbound
-	// and outbound paths cannot diverge.
-	hsCfg := o.handshakeConfigFor()
 
 	// Full session-signature verification — the whole point of #269.
 	peerPubKey, verifyErr := VerifyPeerHandshake(
@@ -277,6 +394,7 @@ func (o *Overlay) performInboundHandshake(ctx context.Context, peer *Peer, tlsCo
 		hsCfg,
 	)
 	if verifyErr != nil {
+		writeInboundHandshakeError(tlsConn, hsCfg, tcpRemoteIP(tlsConn), verifyErr)
 		return NewHandshakeError(peer.Endpoint(), "verify", verifyErr)
 	}
 	peer.mu.Lock()
@@ -290,30 +408,10 @@ func (o *Overlay) performInboundHandshake(ctx context.Context, peer *Peer, tlsCo
 		peerRemote,
 	)
 	if extraErr != nil {
+		writeInboundHandshakeError(tlsConn, hsCfg, tcpRemoteIP(tlsConn), extraErr)
 		return NewHandshakeError(peer.Endpoint(), "verify_extras", extraErr)
 	}
 	peer.applyHandshakeExtras(extras)
-
-	protocol := NegotiateProtocolVersion(req.Header.Get(HeaderUpgrade))
-	if protocol == "" {
-		// Write a 400 Bad Request back so a misconfigured peer sees
-		// the rejection reason instead of a TCP RST. Best-effort: a
-		// write error here is shadowed by the negotiation failure we
-		// are already returning.
-		var remoteAddr string
-		if peerRemote != nil {
-			remoteAddr = peerRemote.String()
-		}
-		errResp := BuildHandshakeErrorResponse( //nolint:bodyclose // locally-built response serialized via Write; nothing to close
-			hsCfg.UserAgent,
-			remoteAddr,
-			"Unable to agree on a protocol version",
-		)
-		_ = errResp.Write(tlsConn)
-		return NewHandshakeError(peer.Endpoint(), "verify",
-			fmt.Errorf("%w: unable to agree on a protocol version (peer offered %q)",
-				ErrInvalidHandshake, req.Header.Get(HeaderUpgrade)))
-	}
 
 	// Decide admission before sending the 101 upgrade, mirroring rippled's
 	// onHandoff: a duplicate or slot-full dialer gets a rejection in lieu
@@ -349,6 +447,15 @@ func (o *Overlay) performInboundHandshake(ctx context.Context, peer *Peer, tlsCo
 
 	reservedKey = false
 	return nil
+}
+
+func writeInboundHandshakeError(tlsConn peertls.PeerConn, cfg HandshakeConfig, remoteIP net.IP, err error) {
+	remoteAddr := ""
+	if remoteIP != nil {
+		remoteAddr = remoteIP.String()
+	}
+	resp := BuildHandshakeErrorResponse(cfg.UserAgent, remoteAddr, err.Error()) //nolint:bodyclose // locally-built response serialized via Write
+	_ = resp.Write(tlsConn)
 }
 
 func setInboundHandshakeState(

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -65,6 +65,20 @@ func (o *Overlay) connectReserved(addr string, bootstrapLease *bootstrapLease) e
 		return ErrMaxPeersReached
 	}
 
+	var outboundUsage *resource.Consumer
+	if o.resourceManager != nil {
+		outboundUsage = o.resourceManager.NewOutboundEndpoint(endpoint.String())
+		if outboundUsage.Disconnect() {
+			outboundUsage.Release()
+			return ErrEndpointBanned
+		}
+		defer func() {
+			if outboundUsage != nil {
+				outboundUsage.Release()
+			}
+		}()
+	}
+
 	peerID := PeerID(o.nextID.Add(1))
 	peer := NewPeer(peerID, endpoint, false, o.identity, o.events)
 	peer.SetDroppedEventsCounter(&o.droppedEvents)
@@ -136,10 +150,11 @@ func (o *Overlay) connectReserved(addr string, bootstrapLease *bootstrapLease) e
 		return ErrAlreadyConnected
 	}
 
-	if err := o.addPeer(peer); err != nil {
+	if err := o.addPeerWithUsage(peer, outboundUsage); err != nil {
 		peer.Close()
 		return err
 	}
+	outboundUsage = nil
 	if bootstrapLease != nil {
 		o.trackPeerBootstrap(peerID, bootstrapLease)
 	}
@@ -514,6 +529,10 @@ func (o *Overlay) IsValidatorSquelchedOnPeer(peerID PeerID, validator []byte) bo
 // reconnects from the same address inherits its prior balance — this
 // is what enables charge-based blacklisting.
 func (o *Overlay) addPeer(peer *Peer) error {
+	return o.addPeerWithUsage(peer, nil)
+}
+
+func (o *Overlay) addPeerWithUsage(peer *Peer, usage *resource.Consumer) error {
 	key, hasKey := remotePeerKey(peer)
 	endpoint := endpointKey(postHandshakeEndpoint(peer, peer.Endpoint()))
 	o.peersMu.Lock()
@@ -540,13 +559,15 @@ func (o *Overlay) addPeer(peer *Peer) error {
 
 	if o.resourceManager != nil {
 		addr := peer.Endpoint().String()
-		var c *resource.Consumer
-		if o.isClusterPeer(peer) {
-			c = o.resourceManager.NewUnlimitedEndpoint(addr)
-		} else if peer.Inbound() {
-			c = o.resourceManager.NewInboundEndpoint(addr)
-		} else {
-			c = o.resourceManager.NewOutboundEndpoint(addr)
+		c := usage
+		if c == nil {
+			if o.isClusterPeer(peer) {
+				c = o.resourceManager.NewUnlimitedEndpoint(addr)
+			} else if peer.Inbound() {
+				c = o.resourceManager.NewInboundEndpoint(addr)
+			} else {
+				c = o.resourceManager.NewOutboundEndpoint(addr)
+			}
 		}
 		peer.attachUsage(c, o.bumpPeerDisconnectCharges)
 	}

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -880,6 +880,10 @@ func (p *Peer) performHandshake(ctx context.Context, tlsConn peertls.PeerConn) e
 			fmt.Errorf("%w: got status %d, headers: %v, body: %s",
 				ErrInvalidHandshake, resp.StatusCode, resp.Header, string(body)))
 	}
+	if err := validateHandshakeResponse(resp); err != nil {
+		resp.Body.Close()
+		return NewHandshakeError(p.endpoint, "validate_envelope", err)
+	}
 	resp.Body.Close()
 
 	// Server-Domain check runs first (rippled verify order).


### PR DESCRIPTION
Part of #1472. Stack PR 2/11.\n\nValidates both HTTP upgrade envelopes, bounds inbound parsing, and acquires outbound resource ownership before network handshakes.