### PR TITLE
fix: make peer state persistence durable (#1472)

### DIFF
--- a/internal/peermanagement/config_bootcache_test.go
+++ b/internal/peermanagement/config_bootcache_test.go
@@ -1,9 +1,12 @@
 package peermanagement
 
 import (
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -56,6 +59,140 @@ func TestBootCache_SaveDirtyHandling(t *testing.T) {
 	assert.True(t, bad.dirty, "a failed Save must retain dirty for the next retry")
 }
 
+func TestBootCacheAtomicSavePreservesPreviousFileOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	bc := NewBootCache(dir)
+	bc.Insert("198.51.100.10:51235", 51235)
+	require.NoError(t, bc.Save())
+	want, err := os.ReadFile(filepath.Join(dir, DefaultBootCacheFile))
+	require.NoError(t, err)
+
+	blocker := filepath.Join(dir, "not-a-directory")
+	require.NoError(t, os.WriteFile(blocker, []byte("block"), 0o600))
+	bc.filePath = filepath.Join(blocker, "nested", DefaultBootCacheFile)
+	bc.Insert("198.51.100.11:51235", 51235)
+	require.Error(t, bc.Save())
+	assert.True(t, bc.dirty, "failed durable save must retain dirty state")
+
+	got, err := os.ReadFile(filepath.Join(dir, DefaultBootCacheFile))
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "failed save must not replace the previous snapshot")
+}
+
+func TestBootCachePostRenameErrorKeepsCommittedSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	bc := NewBootCache(dir)
+	bc.Insert("198.51.100.13:51235", 51235)
+	bc.writeFile = func(path string, data []byte, mode os.FileMode) (bool, error) {
+		committed, err := writeAtomicFile(path, data, mode)
+		require.NoError(t, err)
+		return committed, errors.New("directory durability uncertain")
+	}
+
+	err := bc.Save()
+	require.EqualError(t, err, "directory durability uncertain")
+	assert.False(t, bc.dirty, "rename committed the snapshot despite the durability error")
+
+	reloaded := NewBootCache(dir)
+	require.NoError(t, reloaded.Load())
+	assert.Len(t, reloaded.Endpoints(0), 1)
+	assert.Equal(t, "198.51.100.13:51235", reloaded.Endpoints(0)[0].Address)
+}
+
+func TestOverlayStopWaitsForRunCompletionBeforeFinalCacheSave(t *testing.T) {
+	dir := t.TempDir()
+	o, err := New(WithDataDir(dir), WithPrivateMode(true))
+	require.NoError(t, err)
+	require.NotNil(t, o.discovery.bootCache)
+	o.discovery.bootCache.Insert("198.51.100.14:51235", 51235)
+
+	runComplete := make(chan struct{})
+	o.lifecycleMu.Lock()
+	o.runComplete = runComplete
+	o.lifecycleMu.Unlock()
+	stopDone := make(chan struct{})
+	go func() {
+		_ = o.Stop()
+		close(stopDone)
+	}()
+	select {
+	case <-stopDone:
+		t.Fatal("Stop saved the cache before Run completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(runComplete)
+	select {
+	case <-stopDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop did not complete after Run completion")
+	}
+
+	reloaded := NewBootCache(dir)
+	require.NoError(t, reloaded.Load())
+	assert.Len(t, reloaded.Endpoints(0), 1)
+	assert.Equal(t, "198.51.100.14:51235", reloaded.Endpoints(0)[0].Address)
+}
+
+func TestOverlayRunRejectsCorruptReservationBeforeReadiness(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, DefaultReservationFile)
+	require.NoError(t, os.WriteFile(path, []byte(`[{"node_id":"not-a-node-public"}]`), 0o600))
+	o, err := New(
+		WithDataDir(dir),
+		WithListenAddr("127.0.0.1:0"),
+		WithPrivateMode(true),
+	)
+	require.NoError(t, err)
+	runDone := make(chan error, 1)
+	go func() { runDone <- o.Run(t.Context()) }()
+	select {
+	case err := <-runDone:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "discovery error")
+	case <-o.ListenerReady():
+		t.Fatal("corrupt persisted state was reported ready")
+	case <-time.After(5 * time.Second):
+		t.Fatal("overlay did not reject corrupt persisted state")
+	}
+	require.NoError(t, o.Stop())
+}
+
+func TestBootCacheLoadRejectsMalformedAndNullEntries(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, DefaultBootCacheFile)
+	for _, raw := range []string{
+		"null",
+		"[null]",
+		`[{"address":"not-an-endpoint","port":51235,"last_seen":"2026-08-02T00:00:00Z"}]`,
+	} {
+		require.NoError(t, os.WriteFile(path, []byte(raw), 0o600))
+		bc := NewBootCache(dir)
+		require.Error(t, bc.Load(), "malformed boot-cache payload %q must be rejected", raw)
+	}
+}
+
+func TestBootCacheConcurrentMutationsAndSaves(t *testing.T) {
+	dir := t.TempDir()
+	bc := NewBootCache(dir)
+	var wg sync.WaitGroup
+	for i := range 32 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			address := "198.51.100." + strconv.Itoa(i+1) + ":51235"
+			bc.Insert(address, 51235)
+			bc.MarkSuccess(address)
+			_ = bc.Save()
+		}(i)
+	}
+	wg.Wait()
+	require.NoError(t, bc.Save())
+
+	reloaded := NewBootCache(dir)
+	require.NoError(t, reloaded.Load())
+	assert.Len(t, reloaded.Endpoints(0), 32)
+}
+
 // TestDiscovery_MarkConnected_FeedsBootCache pins finding 7: a successful
 // (outbound) connect must populate the boot cache so a restart can
 // reconnect to known-good peers. Before wiring, the cache was permanently
@@ -75,4 +212,17 @@ func TestDiscovery_MarkConnected_FeedsBootCache(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "MarkConnected must feed the boot cache")
+}
+
+func TestDiscoveryStopPersistsFinalBootCacheMutation(t *testing.T) {
+	dir := t.TempDir()
+	d := NewDiscovery(&Config{DataDir: dir, Clock: time.Now}, make(chan Event, 1))
+	require.NoError(t, d.Start(t.Context()))
+	d.MarkConnected("198.51.100.12:51235", PeerID(2))
+	d.Stop()
+
+	reloaded := NewBootCache(dir)
+	require.NoError(t, reloaded.Load())
+	assert.Len(t, reloaded.Endpoints(0), 1)
+	assert.Equal(t, "198.51.100.12:51235", reloaded.Endpoints(0)[0].Address)
 }

--- a/internal/peermanagement/discovery.go
+++ b/internal/peermanagement/discovery.go
@@ -4,6 +4,7 @@ import (
 	"container/list"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"math/rand/v2"
 	"net"
@@ -13,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 )
 
 // Discovery constants.
@@ -59,22 +62,30 @@ type CachedEndpoint struct {
 
 // BootCache persists known peer addresses across restarts.
 type BootCache struct {
-	mu       sync.RWMutex
-	cache    map[string]*CachedEndpoint
-	filePath string
-	dirty    bool
+	mu        sync.RWMutex
+	cache     map[string]*CachedEndpoint
+	filePath  string
+	dirty     bool
+	writeFile atomicFileWriter
 }
 
 // NewBootCache creates a new boot cache.
 func NewBootCache(dataDir string) *BootCache {
+	var filePath string
+	if dataDir != "" {
+		filePath = filepath.Join(dataDir, DefaultBootCacheFile)
+	}
 	return &BootCache{
 		cache:    make(map[string]*CachedEndpoint),
-		filePath: filepath.Join(dataDir, DefaultBootCacheFile),
+		filePath: filePath,
 	}
 }
 
 // Load loads the cache from disk.
 func (bc *BootCache) Load() error {
+	if bc == nil || bc.filePath == "" {
+		return nil
+	}
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
@@ -90,23 +101,36 @@ func (bc *BootCache) Load() error {
 	if err := json.Unmarshal(data, &entries); err != nil {
 		return err
 	}
+	if entries == nil {
+		return fmt.Errorf("cache must be a JSON array")
+	}
 
-	bc.cache = make(map[string]*CachedEndpoint)
+	loaded := make(map[string]*CachedEndpoint, len(entries))
 	now := time.Now()
-	for _, entry := range entries {
+	for i, entry := range entries {
+		if err := validateCachedEndpoint(entry); err != nil {
+			return fmt.Errorf("boot cache entry %d: %w", i, err)
+		}
 		if now.Sub(entry.LastSeen) <= CacheEntryTTL {
-			bc.cache[entry.Address] = entry
+			if _, exists := loaded[entry.Address]; exists {
+				return fmt.Errorf("boot cache entry %d: duplicate address %q", i, entry.Address)
+			}
+			loaded[entry.Address] = cloneCachedEndpoint(entry)
 		}
 	}
+	bc.cache = loaded
+	bc.dirty = false
 	return nil
 }
 
-// Save writes the cache to disk. Holds the write lock for the whole
-// operation (Save runs on shutdown, not a hot path) so dirty is never
-// mutated under a read lock, and clears dirty only after a successful
-// write so a failed write retains the flag and the next Save retries
-// instead of dropping the pending data.
+// Save writes the cache to disk. The complete snapshot and durable rename are
+// serialized with mutations so a concurrent save cannot overwrite newer
+// state. Once rename succeeds the in-memory snapshot matches the file even if
+// the subsequent directory sync reports an uncertain durability error.
 func (bc *BootCache) Save() error {
+	if bc == nil || bc.filePath == "" {
+		return nil
+	}
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
@@ -116,27 +140,36 @@ func (bc *BootCache) Save() error {
 
 	entries := make([]*CachedEndpoint, 0, len(bc.cache))
 	for _, entry := range bc.cache {
-		entries = append(entries, entry)
+		if err := validateCachedEndpoint(entry); err != nil {
+			return err
+		}
+		entries = append(entries, cloneCachedEndpoint(entry))
 	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Address < entries[j].Address })
 
 	data, err := json.MarshalIndent(entries, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(bc.filePath), 0o755); err != nil {
-		return err
+	writer := bc.writeFile
+	if writer == nil {
+		writer = writeAtomicFile
 	}
-
-	if err := os.WriteFile(bc.filePath, data, 0o600); err != nil {
-		return err
+	committed, err := writer(bc.filePath, data, 0o600)
+	if committed {
+		// Rename made the new snapshot visible. Keep memory aligned with that
+		// snapshot even when directory durability is uncertain.
+		bc.dirty = false
 	}
-	bc.dirty = false
-	return nil
+	return err
 }
 
 // Insert adds or updates an endpoint in the cache.
 func (bc *BootCache) Insert(address string, port uint16) {
+	if bc == nil || strings.TrimSpace(address) == "" || port == 0 {
+		return
+	}
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
@@ -185,17 +218,21 @@ func (bc *BootCache) MarkSuccess(address string) {
 
 // Endpoints returns endpoints sorted by valence.
 func (bc *BootCache) Endpoints(limit int) []*CachedEndpoint {
+	if bc == nil {
+		return nil
+	}
 	bc.mu.RLock()
 	defer bc.mu.RUnlock()
 
 	entries := make([]*CachedEndpoint, 0, len(bc.cache))
 	for _, entry := range bc.cache {
 		entries = append(entries, &CachedEndpoint{
-			Address:   entry.Address,
-			Port:      entry.Port,
-			LastSeen:  entry.LastSeen,
-			Valence:   entry.Valence,
-			FailCount: entry.FailCount,
+			Address:    entry.Address,
+			Port:       entry.Port,
+			LastSeen:   entry.LastSeen,
+			Valence:    entry.Valence,
+			FailCount:  entry.FailCount,
+			LastFailed: entry.LastFailed,
 		})
 	}
 
@@ -220,6 +257,7 @@ type ReservationTable struct {
 	mu           sync.RWMutex
 	reservations map[string]*PeerReservation
 	filePath     string
+	writeFile    atomicFileWriter
 }
 
 // NewReservationTable creates a new reservation table.
@@ -236,9 +274,16 @@ func NewReservationTable(dataDir string) *ReservationTable {
 
 // Contains returns true if the node has a reservation.
 func (t *ReservationTable) Contains(nodeID string) bool {
+	if t == nil {
+		return false
+	}
+	canonical, err := canonicalNodePublicKey(nodeID)
+	if err != nil {
+		return false
+	}
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	_, exists := t.reservations[nodeID]
+	_, exists := t.reservations[canonical]
 	return exists
 }
 
@@ -247,42 +292,84 @@ func (t *ReservationTable) Contains(nodeID string) bool {
 // error. Mirrors rippled's PeerReservationTable::insert_or_assign, whose DB
 // write surfaces failures to the caller.
 func (t *ReservationTable) Insert(r *PeerReservation) (*PeerReservation, error) {
+	if t == nil {
+		return nil, fmt.Errorf("reservation table is nil")
+	}
+	normalized, err := normalizeReservation(r)
+	if err != nil {
+		return nil, err
+	}
 	t.mu.Lock()
-	prev := t.reservations[r.NodeID]
-	t.reservations[r.NodeID] = r
-	t.mu.Unlock()
-	return prev, t.Save()
+	defer t.mu.Unlock()
+	if t.reservations == nil {
+		t.reservations = make(map[string]*PeerReservation)
+	}
+	prev := cloneReservation(t.reservations[normalized.NodeID])
+	t.reservations[normalized.NodeID] = normalized
+	committed, err := t.saveLocked()
+	if err != nil && !committed {
+		if prev == nil {
+			delete(t.reservations, normalized.NodeID)
+		} else {
+			t.reservations[normalized.NodeID] = prev
+		}
+		return prev, err
+	}
+	return prev, err
 }
 
 // Erase removes a reservation and persists the table, returning the removed
 // entry (nil if none existed) and any persistence error. Mirrors rippled's
 // PeerReservationTable::erase.
 func (t *ReservationTable) Erase(nodeID string) (*PeerReservation, error) {
-	t.mu.Lock()
-	prev, ok := t.reservations[nodeID]
-	if ok {
-		delete(t.reservations, nodeID)
+	if t == nil {
+		return nil, fmt.Errorf("reservation table is nil")
 	}
-	t.mu.Unlock()
+	canonical, err := canonicalNodePublicKey(nodeID)
+	if err != nil {
+		return nil, err
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	prev, ok := t.reservations[canonical]
+	if ok {
+		delete(t.reservations, canonical)
+	}
 	if !ok {
 		return nil, nil
 	}
-	return prev, t.Save()
+	committed, err := t.saveLocked()
+	if err != nil && !committed {
+		t.reservations[canonical] = prev
+		return cloneReservation(prev), err
+	}
+	return cloneReservation(prev), err
 }
 
 // List returns a snapshot of all reservations.
 func (t *ReservationTable) List() []PeerReservation {
+	if t == nil {
+		return nil
+	}
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	out := make([]PeerReservation, 0, len(t.reservations))
 	for _, r := range t.reservations {
-		out = append(out, *r)
+		if r != nil {
+			out = append(out, *cloneReservation(r))
+		}
 	}
+	sort.Slice(out, func(i, j int) bool { return out[i].NodeID < out[j].NodeID })
 	return out
 }
 
 // Load reads the reservation table from disk. A missing file is not an error.
 func (t *ReservationTable) Load() error {
+	if t == nil {
+		return fmt.Errorf("reservation table is nil")
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	if t.filePath == "" {
 		return nil
 	}
@@ -297,38 +384,189 @@ func (t *ReservationTable) Load() error {
 	if err := json.Unmarshal(data, &entries); err != nil {
 		return err
 	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.reservations = make(map[string]*PeerReservation, len(entries))
-	for _, e := range entries {
-		if e != nil && e.NodeID != "" {
-			t.reservations[e.NodeID] = e
-		}
+	if entries == nil {
+		return fmt.Errorf("reservations must be a JSON array")
 	}
+	loaded := make(map[string]*PeerReservation, len(entries))
+	for i, entry := range entries {
+		normalized, err := normalizeReservation(entry)
+		if err != nil {
+			return fmt.Errorf("reservation entry %d: %w", i, err)
+		}
+		if _, exists := loaded[normalized.NodeID]; exists {
+			return fmt.Errorf("reservation entry %d: duplicate node id %q", i, normalized.NodeID)
+		}
+		loaded[normalized.NodeID] = normalized
+	}
+	t.reservations = loaded
 	return nil
 }
 
 // Save writes the reservation table to disk. It is a no-op when no data
 // directory is configured (e.g. standalone / in-memory tests).
 func (t *ReservationTable) Save() error {
+	if t == nil {
+		return fmt.Errorf("reservation table is nil")
+	}
 	if t.filePath == "" {
 		return nil
 	}
-	t.mu.RLock()
-	entries := make([]*PeerReservation, 0, len(t.reservations))
-	for _, r := range t.reservations {
-		entries = append(entries, r)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	_, err := t.saveLocked()
+	return err
+}
+
+func (t *ReservationTable) saveLocked() (bool, error) {
+	if t.filePath == "" {
+		return true, nil
 	}
-	t.mu.RUnlock()
+	entries := make([]*PeerReservation, 0, len(t.reservations))
+	seen := make(map[string]struct{}, len(t.reservations))
+	for _, r := range t.reservations {
+		normalized, err := normalizeReservation(r)
+		if err != nil {
+			return false, err
+		}
+		if _, exists := seen[normalized.NodeID]; exists {
+			return false, fmt.Errorf("duplicate node id %q", normalized.NodeID)
+		}
+		seen[normalized.NodeID] = struct{}{}
+		entries = append(entries, normalized)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].NodeID < entries[j].NodeID })
 
 	data, err := json.MarshalIndent(entries, "", "  ")
 	if err != nil {
-		return err
+		return false, err
 	}
-	if err := os.MkdirAll(filepath.Dir(t.filePath), 0o755); err != nil {
-		return err
+	writer := t.writeFile
+	if writer == nil {
+		writer = writeAtomicFile
 	}
-	return os.WriteFile(t.filePath, data, 0o600)
+	return writer(t.filePath, data, 0o600)
+}
+
+func cloneCachedEndpoint(entry *CachedEndpoint) *CachedEndpoint {
+	if entry == nil {
+		return nil
+	}
+	copy := *entry
+	return &copy
+}
+
+func validateCachedEndpoint(entry *CachedEndpoint) error {
+	if entry == nil {
+		return fmt.Errorf("nil endpoint")
+	}
+	if strings.TrimSpace(entry.Address) == "" {
+		return fmt.Errorf("empty address")
+	}
+	if entry.Port == 0 {
+		return fmt.Errorf("invalid port 0")
+	}
+	endpoint, err := ParseEndpoint(entry.Address)
+	if err != nil {
+		return fmt.Errorf("invalid address %q: %w", entry.Address, err)
+	}
+	if endpoint.Port != entry.Port {
+		return fmt.Errorf("address port %d does not match port %d", endpoint.Port, entry.Port)
+	}
+	if entry.LastSeen.IsZero() {
+		return fmt.Errorf("missing last_seen")
+	}
+	if entry.Valence < 0 || entry.FailCount < 0 {
+		return fmt.Errorf("negative counters")
+	}
+	return nil
+}
+
+func cloneReservation(r *PeerReservation) *PeerReservation {
+	if r == nil {
+		return nil
+	}
+	copy := *r
+	return &copy
+}
+
+func normalizeReservation(r *PeerReservation) (*PeerReservation, error) {
+	if r == nil {
+		return nil, fmt.Errorf("nil reservation")
+	}
+	canonical, err := canonicalNodePublicKey(r.NodeID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid node id %q: %w", r.NodeID, err)
+	}
+	normalized := cloneReservation(r)
+	normalized.NodeID = canonical
+	return normalized, nil
+}
+
+func canonicalNodePublicKey(nodeID string) (string, error) {
+	if strings.TrimSpace(nodeID) != nodeID || nodeID == "" {
+		return "", fmt.Errorf("empty or whitespace-padded node id")
+	}
+	raw, err := addresscodec.DecodeNodePublicKey(nodeID)
+	if err != nil {
+		return "", err
+	}
+	if len(raw) != 33 || (raw[0] != 0xED && raw[0] != 0x02 && raw[0] != 0x03) {
+		return "", fmt.Errorf("invalid node public key type or length")
+	}
+	canonical, err := addresscodec.EncodeNodePublicKey(raw)
+	if err != nil {
+		return "", err
+	}
+	return canonical, nil
+}
+
+type atomicFileWriter func(path string, data []byte, mode os.FileMode) (committed bool, err error)
+
+func writeAtomicFile(path string, data []byte, mode os.FileMode) (bool, error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return false, err
+	}
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return false, err
+	}
+	tmpName := tmp.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return false, err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return false, err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return false, err
+	}
+	if err := tmp.Close(); err != nil {
+		return false, err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return false, err
+	}
+	removeTemp = false
+	dirFile, err := os.Open(dir)
+	if err != nil {
+		return true, err
+	}
+	syncErr := dirFile.Sync()
+	closeErr := dirFile.Close()
+	if syncErr != nil {
+		return true, syncErr
+	}
+	return true, closeErr
 }
 
 // Reservations exposes the reservation table backing the peer_reservations_*
@@ -470,14 +708,12 @@ func (d *Discovery) now() time.Time {
 func (d *Discovery) Start(ctx context.Context) error {
 	if d.bootCache != nil {
 		if err := d.bootCache.Load(); err != nil {
-			slog.Warn("Peer boot cache could not be loaded; continuing with an empty cache",
-				"t", "Discovery", "path", d.bootCache.filePath, "err", err)
+			return fmt.Errorf("load peer boot cache %q: %w", d.bootCache.filePath, err)
 		}
 	}
 	if d.reservation != nil {
 		if err := d.reservation.Load(); err != nil {
-			slog.Warn("Peer reservations could not be loaded; continuing with an empty table",
-				"t", "Discovery", "path", d.reservation.filePath, "err", err)
+			return fmt.Errorf("load peer reservations %q: %w", d.reservation.filePath, err)
 		}
 	}
 
@@ -608,7 +844,9 @@ func (d *Discovery) Stop() {
 		d.wg.Wait()
 
 		if d.bootCache != nil {
-			d.bootCache.Save()
+			if err := d.bootCache.Save(); err != nil {
+				slog.Warn("Peer boot cache could not be saved", "t", "Discovery", "path", d.bootCache.filePath, "err", err)
+			}
 		}
 	})
 }

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -93,7 +93,11 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 	// Recompute the cluster-fee median and forward it through the
 	// LoadFeeTrack sink. An empty fresh set publishes zero.
 	if sink := o.clusterFeeSinkSnapshot(); sink != nil {
-		fee, _ := o.cluster.MedianFee(time.Now().Add(-clusterFeeWindow))
+		now := time.Now()
+		if o.clockForCluster != nil {
+			now = o.clockForCluster()
+		}
+		fee, _ := o.cluster.MedianFee(now.Add(-clusterFeeWindow))
 		sink(fee)
 	}
 

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -162,6 +162,51 @@ func TestHandleClusterMessage_ClearsStaleClusterFee(t *testing.T) {
 	assert.Zero(t, clusterFee)
 }
 
+func TestHandleClusterMessage_ClearsClusterFeeAfterReportAgesOut(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	peerIdentity, err := NewIdentity()
+	require.NoError(t, err)
+	peerToken := NewPublicKeyTokenFromBtcec(peerIdentity.BtcecPublicKey())
+	peerNodePubEncoded, err := addresscodec.EncodeNodePublicKey(peerToken.Bytes())
+	require.NoError(t, err)
+
+	clusterReg := cluster.New()
+	require.NoError(t, clusterReg.Load([]string{peerNodePubEncoded + " peer"}))
+	clusterFee := uint32(0)
+	now := time.Unix(2_000_000_000, 0)
+	o := &Overlay{
+		peers:   make(map[PeerID]*Peer),
+		events:  make(chan Event, 8),
+		cluster: clusterReg,
+		clockForCluster: func() time.Time {
+			return now
+		},
+		clusterFeeSink: func(fee uint32) {
+			clusterFee = fee
+		},
+	}
+
+	peer := NewPeer(PeerID(35), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
+	peer.remotePubKey = peerToken
+	o.peers[peer.ID()] = peer
+
+	payload, err := message.Encode(&message.Cluster{ClusterNodes: []message.ClusterNode{
+		{PublicKey: peerNodePubEncoded, NodeName: "peer", NodeLoad: 512, ReportTime: uint32(now.Unix())},
+	}})
+	require.NoError(t, err)
+	o.onMessageReceived(Event{PeerID: peer.ID(), MessageType: uint16(message.TypeCluster), Payload: payload})
+	assert.Equal(t, uint32(512), clusterFee)
+
+	now = now.Add(clusterFeeWindow + time.Second)
+	// An otherwise valid frame from the trusted peer must recompute the
+	// median, including the empty result, so stale fee state cannot persist.
+	payload, err = message.Encode(&message.Cluster{})
+	require.NoError(t, err)
+	o.onMessageReceived(Event{PeerID: peer.ID(), MessageType: uint16(message.TypeCluster), Payload: payload})
+	assert.Zero(t, clusterFee)
+}
+
 // TestHandleClusterMessage_ImportsLoadSourceGossip pins issue #765: a
 // TMCluster frame from a registered cluster peer must fold its
 // TMLoadSource entries into the resource manager (importConsumers),

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -96,9 +96,10 @@ type Overlay struct {
 
 	// relayedIndex maps a suppression hash to peers that delivered the
 	// corresponding message to us. Outbound recipients are never recorded.
-	relayedIndex   map[[32]byte]*relayedEntry
-	relayedIndexMu sync.Mutex
-	clockForIndex  func() time.Time
+	relayedIndex    map[[32]byte]*relayedEntry
+	relayedIndexMu  sync.Mutex
+	clockForIndex   func() time.Time
+	clockForCluster func() time.Time
 
 	fanoutLogMu         sync.Mutex
 	fanoutLogLast       time.Time
@@ -281,30 +282,30 @@ type Overlay struct {
 	listenerReadyOnce sync.Once
 
 	// Lifecycle
-	// lifecycleMu owns the one-shot lifecycle state and the context used by
-	// every resource started by Run. An Overlay cannot be restarted: a
-	// stopped instance remains stopped for the rest of its lifetime.
-	lifecycleMu sync.Mutex
-	ctx         context.Context
-	cancel      context.CancelFunc
-	stopOnce    sync.Once
-	state       overlayState
-	runFinished chan struct{}
-	shutdownErr error
+	// lifecycleMu guards the one-shot state transition, context ownership,
+	// and shutdown channels. An Overlay admits exactly one Run lifetime.
+	lifecycleMu    sync.Mutex
+	lifecycleState overlayLifecycleState
+	ctx            context.Context
+	cancel         context.CancelFunc
+	shutdownOnce   sync.Once
+	shutdownDone   chan struct{}
+	stopRequested  bool
 
 	// stopCh is closed by Stop to release any lifecycle send blocked on an
 	// event loop that has already exited during shutdown.
-	stopCh  chan struct{}
-	runDone <-chan struct{}
+	stopCh      chan struct{}
+	runDone     <-chan struct{}
+	runComplete <-chan struct{}
 }
 
-type overlayState uint8
+type overlayLifecycleState uint8
 
 const (
-	overlayNew overlayState = iota
-	overlayRunning
-	overlayStopping
-	overlayStopped
+	overlayLifecycleNew overlayLifecycleState = iota
+	overlayLifecycleRunning
+	overlayLifecycleStopping
+	overlayLifecycleStopped
 )
 
 // LedgerSync returns the overlay's ledger-sync handler so callers in a
@@ -871,9 +872,9 @@ func New(opts ...Option) (*Overlay, error) {
 		lifecycle:                make(chan Event, lifecycleBufferSize(&cfg)),
 		stopCh:                   make(chan struct{}),
 		listenerReady:            make(chan struct{}),
-		runFinished:              make(chan struct{}),
 		relayedIndex:             make(map[[32]byte]*relayedEntry),
 		clockForIndex:            time.Now,
+		clockForCluster:          time.Now,
 		inboundSem:               make(chan struct{}, inboundCap),
 		outboundSem:              make(chan struct{}, outboundCap),
 		resourceManager:          resource.NewManager(nil, nil),
@@ -957,70 +958,101 @@ func loadOrCreateIdentity(dataDir string) (*Identity, error) {
 	return id, nil
 }
 
-// Run starts the overlay and blocks until the context is cancelled or one of
-// its owned loops fails. Run is intentionally one-shot: an Overlay owns the
-// listener, discovery state, and resource manager for one lifetime only.
-func (o *Overlay) Run(parent context.Context) (runErr error) {
+// Run starts the overlay and blocks until the context is cancelled. An
+// Overlay has one lifecycle; a second or post-shutdown Run is rejected before
+// it can bind a listener or publish readiness.
+func (o *Overlay) Run(ctx context.Context) error {
 	o.lifecycleMu.Lock()
-	if o.state != overlayNew {
-		err := ErrAlreadyRunning
-		if o.state == overlayStopping || o.state == overlayStopped {
-			err = ErrShutdown
+	if o.lifecycleState != overlayLifecycleNew {
+		err := ErrShutdown
+		if o.lifecycleState == overlayLifecycleRunning {
+			err = ErrAlreadyRunning
 		}
 		o.lifecycleMu.Unlock()
 		return err
 	}
-	if o.stopCh == nil {
-		o.stopCh = make(chan struct{})
-	}
-	if o.runFinished == nil {
-		o.runFinished = make(chan struct{})
-	}
-	runCtx, cancel := context.WithCancel(parent) //nolint:gosec // G118: cancellation is owned by this Run/Stop pair
+	runCtx, cancel := context.WithCancel(ctx) //nolint:gosec // G118: cancel is stored and called by requestStop
+	runComplete := make(chan struct{})
 	o.ctx = runCtx
 	o.cancel = cancel
-	o.state = overlayRunning
-	finished := o.runFinished
+	o.runComplete = runComplete
+	o.shutdownDone = make(chan struct{})
+	o.stopRequested = false
+	o.lifecycleState = overlayLifecycleRunning
 	o.lifecycleMu.Unlock()
 
 	defer func() {
-		cleanupErr := o.shutdown()
-		if runErr == nil {
-			runErr = cleanupErr
+		o.requestStop()
+		// runComplete means that the errgroup/event loops are joined. The
+		// shutdown barrier waits peer producers after this closes before it
+		// performs Discovery.Stop's one-shot final save.
+		close(runComplete)
+		o.shutdown()
+	}()
+	go func() {
+		select {
+		case <-runCtx.Done():
+			o.requestStop()
+		case <-runComplete:
 		}
-		o.lifecycleMu.Lock()
-		o.shutdownErr = cleanupErr
-		o.state = overlayStopped
-		close(finished)
-		o.lifecycleMu.Unlock()
 	}()
 
-	// Start listener if configured.
-	if o.cfg.ListenAddr != "" {
-		if err := o.startListener(); err != nil {
-			runErr = fmt.Errorf("listener error: %w", err)
-			return runErr
+	// Load persistent state and start discovery before publishing readiness.
+	// This keeps corrupt state from being reported as a ready listener and
+	// gives startup callers a deterministic Run error.
+	if o.discovery != nil {
+		if err := o.discovery.Start(runCtx); err != nil {
+			return fmt.Errorf("discovery error: %w", err)
 		}
 	}
-	o.signalListenerReady()
+	if err := o.requireRunning(); err != nil {
+		return err
+	}
+
+	// Bind under lifecycleMu so Stop cannot transition the state between the
+	// running check and listener publication.
+	if o.cfg.ListenAddr != "" {
+		o.lifecycleMu.Lock()
+		if o.lifecycleState != overlayLifecycleRunning {
+			o.lifecycleMu.Unlock()
+			return ErrShutdown
+		}
+		err := o.startListener()
+		o.lifecycleMu.Unlock()
+		if err != nil {
+			return fmt.Errorf("listener error: %w", err)
+		}
+	}
 
 	// Start resource manager (per-endpoint consumer table). The
 	// periodic-activity goroutine ages out inactive entries; the
 	// charge-time decay runs inline.
 	if o.resourceManager != nil {
+		o.lifecycleMu.Lock()
+		if o.lifecycleState != overlayLifecycleRunning {
+			o.lifecycleMu.Unlock()
+			return ErrShutdown
+		}
 		o.resourceManager.Start()
+		o.lifecycleMu.Unlock()
 	}
 
-	// Start discovery.
-	if o.discovery != nil {
-		if err := o.discovery.Start(runCtx); err != nil {
-			runErr = fmt.Errorf("discovery error: %w", err)
-			return runErr
-		}
+	o.lifecycleMu.Lock()
+	if o.lifecycleState != overlayLifecycleRunning {
+		o.lifecycleMu.Unlock()
+		return ErrShutdown
 	}
+	if err := runCtx.Err(); err != nil {
+		o.lifecycleMu.Unlock()
+		return err
+	}
+	o.signalListenerReady()
+	o.lifecycleMu.Unlock()
 
 	g, gCtx := errgroup.WithContext(runCtx)
+	o.lifecycleMu.Lock()
 	o.runDone = gCtx.Done()
+	o.lifecycleMu.Unlock()
 
 	// Closing the listener is the cancellation bridge for Accept: net.Listener
 	// does not observe context cancellation on its own. This watcher belongs to
@@ -1062,69 +1094,65 @@ func (o *Overlay) Run(parent context.Context) (runErr error) {
 	// Maintenance loop (cleanup, ping, etc.).
 	g.Go(func() error { return o.maintenanceLoop(gCtx) })
 
-	runErr = g.Wait()
-	return runErr
+	return g.Wait()
 }
 
-// Stop requests shutdown and waits for Run to finish. It is safe to call
-// before Run, while Run is starting, or repeatedly after Run has returned.
-// Cleanup errors are retained so every caller observes the same result.
+// Stop gracefully shuts down the overlay. It is safe before Run, while Run is
+// starting, and after Run returns. All callers share one shutdown barrier so a
+// context-only Run cancellation performs the same final Discovery save as an
+// external Stop.
 func (o *Overlay) Stop() error {
+	o.requestStop()
+	o.shutdown()
+	return nil
+}
+
+func (o *Overlay) requireRunning() error {
 	o.lifecycleMu.Lock()
-	switch o.state {
-	case overlayNew:
-		o.state = overlayStopped
-		if o.stopCh == nil {
-			o.stopCh = make(chan struct{})
-		}
-		finished := o.runFinished
-		if finished == nil {
-			o.runFinished = make(chan struct{})
-		}
-		o.lifecycleMu.Unlock()
-		o.signalStop()
-		if o.discovery != nil {
-			o.discovery.Stop()
-		}
-		if o.resourceManager != nil {
-			o.resourceManager.Stop()
-		}
-		_ = finished
+	defer o.lifecycleMu.Unlock()
+	if o.lifecycleState == overlayLifecycleRunning {
 		return nil
-	case overlayRunning:
-		o.state = overlayStopping
-	case overlayStopping:
-		// Another caller owns the signal; all callers join Run below.
-	case overlayStopped:
-		err := o.shutdownErr
-		o.lifecycleMu.Unlock()
-		return err
+	}
+	return ErrShutdown
+}
+
+func (o *Overlay) requestStop() {
+	o.peerStartMu.Lock()
+	o.peerStartsClosed = true
+	o.peerStartMu.Unlock()
+
+	o.lifecycleMu.Lock()
+	if o.lifecycleState == overlayLifecycleNew || o.lifecycleState == overlayLifecycleRunning {
+		o.lifecycleState = overlayLifecycleStopping
+	}
+	if o.shutdownDone == nil {
+		o.shutdownDone = make(chan struct{})
 	}
 	cancel := o.cancel
-	finished := o.runFinished
+	if !o.stopRequested {
+		o.stopRequested = true
+		if o.stopCh != nil {
+			close(o.stopCh)
+		}
+	}
 	o.lifecycleMu.Unlock()
 
-	o.signalStop()
 	if cancel != nil {
 		cancel()
 	}
-	if finished != nil {
-		<-finished
-	}
-	o.lifecycleMu.Lock()
-	err := o.shutdownErr
-	o.lifecycleMu.Unlock()
-	return err
-}
 
-// signalStop closes the stop gate exactly once. The gate is independent from
-// the Run context because lifecycle dispatchers may be unwinding before the
-// errgroup context has propagated cancellation to every child.
-func (o *Overlay) signalStop() {
-	if o.stopCh == nil {
-		return
+	o.listenerMu.RLock()
+	l := o.listener
+	o.listenerMu.RUnlock()
+	if l != nil {
+		_ = l.Close()
 	}
-	o.stopOnce.Do(func() { close(o.stopCh) })
+
+	o.peersMu.Lock()
+	for _, p := range o.peers {
+		p.Close()
+	}
+	o.peersMu.Unlock()
 }
 
 func (o *Overlay) closeListener() error {
@@ -1140,43 +1168,38 @@ func (o *Overlay) closeListener() error {
 	return nil
 }
 
-// shutdown owns teardown for every resource started by Run. It is called by
-// Run's deferred finalizer after g.Wait, so peer start/run WaitGroups are safe
-// to join without racing a future Add.
-func (o *Overlay) shutdown() error {
-	o.signalStop()
+func (o *Overlay) shutdown() {
 	o.lifecycleMu.Lock()
-	cancel := o.cancel
+	if o.shutdownDone == nil {
+		o.shutdownDone = make(chan struct{})
+	}
+	done := o.shutdownDone
 	o.lifecycleMu.Unlock()
-	if cancel != nil {
-		cancel()
-	}
 
-	var errs []error
-	if err := o.closeListener(); err != nil {
-		errs = append(errs, err)
-	}
-	if o.discovery != nil {
-		o.discovery.Stop()
-	}
+	o.shutdownOnce.Do(func() {
+		o.peerStartWG.Wait()
+		o.peerWG.Wait()
 
-	o.peerStartMu.Lock()
-	o.peerStartsClosed = true
-	o.peerStartMu.Unlock()
+		o.lifecycleMu.Lock()
+		runComplete := o.runComplete
+		o.lifecycleMu.Unlock()
+		if runComplete != nil {
+			<-runComplete
+		}
 
-	o.peersMu.Lock()
-	for _, p := range o.peers {
-		p.Close()
-	}
-	o.peersMu.Unlock()
+		if o.discovery != nil {
+			o.discovery.Stop()
+		}
+		if o.resourceManager != nil {
+			o.resourceManager.Stop()
+		}
 
-	o.peerStartWG.Wait()
-	o.peerWG.Wait()
-
-	if o.resourceManager != nil {
-		o.resourceManager.Stop()
-	}
-	return errors.Join(errs...)
+		o.lifecycleMu.Lock()
+		o.lifecycleState = overlayLifecycleStopped
+		o.lifecycleMu.Unlock()
+		close(done)
+	})
+	<-done
 }
 
 // eventLoop processes internal events. It drains both the dedicated

--- a/internal/peermanagement/overlay_lifecycle_test.go
+++ b/internal/peermanagement/overlay_lifecycle_test.go
@@ -2,10 +2,13 @@ package peermanagement
 
 import (
 	"context"
-	"errors"
 	"net"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newLifecycleTestOverlay(t *testing.T, opts ...Option) *Overlay {
@@ -18,94 +21,189 @@ func newLifecycleTestOverlay(t *testing.T, opts ...Option) *Overlay {
 		WithMaxOutbound(1),
 	}
 	o, err := New(append(base, opts...)...)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	require.NoError(t, err)
 	return o
 }
 
-func waitRun(t *testing.T, done <-chan error) error {
-	t.Helper()
-	select {
-	case err := <-done:
-		return err
-	case <-time.After(5 * time.Second):
-		t.Fatal("overlay Run did not return")
-		return nil
-	}
-}
-
-func TestOverlayRunCancellationOwnsResources(t *testing.T) {
-	o := newLifecycleTestOverlay(t)
+func TestOverlayRunCancellationClosesListener(t *testing.T) {
+	o, err := New(WithDataDir(t.TempDir()), WithListenAddr("127.0.0.1:0"), WithPrivateMode(true))
+	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- o.Run(ctx) }()
-
+	runDone := make(chan error, 1)
+	go func() { runDone <- o.Run(ctx) }()
 	select {
 	case <-o.ListenerReady():
+	case err := <-runDone:
+		t.Fatalf("overlay stopped before startup: %v", err)
 	case <-time.After(5 * time.Second):
-		t.Fatal("listener did not become ready")
+		t.Fatal("overlay did not become ready")
 	}
 	addr := o.ListenAddr()
+
 	cancel()
-	if err := waitRun(t, done); !errors.Is(err, context.Canceled) {
-		t.Fatalf("Run error = %v, want context.Canceled", err)
+	select {
+	case err := <-runDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("overlay did not stop after cancellation")
 	}
-	if err := o.Stop(); err != nil {
-		t.Fatalf("Stop after Run: %v", err)
-	}
+	require.NoError(t, o.Stop())
 
 	conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
 	if err == nil {
-		conn.Close()
+		_ = conn.Close()
 		t.Fatal("listener still accepted connections after cancellation")
 	}
 }
 
-func TestOverlayRunIsOneShot(t *testing.T) {
-	o := newLifecycleTestOverlay(t, WithListenAddr(""))
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- o.Run(ctx) }()
+func TestOverlayRunStartupFailureUnwinds(t *testing.T) {
+	o, err := New(WithDataDir(t.TempDir()), WithListenAddr("127.0.0.1:not-a-port"))
+	require.NoError(t, err)
+	require.Error(t, o.Run(context.Background()))
+	require.NoError(t, o.Stop())
+}
 
+func TestOverlayStopPersistsLatePeerMutation(t *testing.T) {
+	dir := t.TempDir()
+	o, err := New(WithDataDir(dir), WithListenAddr("127.0.0.1:0"), WithPrivateMode(true))
+	require.NoError(t, err)
+	runDone := make(chan error, 1)
+	go func() { runDone <- o.Run(context.Background()) }()
 	select {
 	case <-o.ListenerReady():
+	case err := <-runDone:
+		t.Fatalf("overlay stopped before startup: %v", err)
 	case <-time.After(5 * time.Second):
-		t.Fatal("Run did not finish startup")
+		t.Fatal("overlay did not become ready")
 	}
-	if err := o.Run(context.Background()); !errors.Is(err, ErrAlreadyRunning) {
-		t.Fatalf("concurrent Run error = %v, want ErrAlreadyRunning", err)
+
+	const address = "198.51.100.20:51235"
+	release := make(chan struct{})
+	o.peerWG.Add(1)
+	go func() {
+		defer o.peerWG.Done()
+		<-release
+		o.discovery.MarkConnected(address, PeerID(20))
+	}()
+
+	stopDone := make(chan struct{})
+	go func() {
+		_ = o.Stop()
+		close(stopDone)
+	}()
+	select {
+	case <-stopDone:
+		t.Fatal("Stop completed before the in-flight peer producer joined")
+	case <-time.After(20 * time.Millisecond):
 	}
+	close(release)
+	select {
+	case <-stopDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop did not complete after the peer producer joined")
+	}
+	<-runDone
+
+	reloaded := NewBootCache(filepath.Clean(dir))
+	require.NoError(t, reloaded.Load())
+	assert.Len(t, reloaded.Endpoints(0), 1)
+	assert.Equal(t, address, reloaded.Endpoints(0)[0].Address)
+}
+
+func TestOverlayContextCancellationPersistsLatePeerMutation(t *testing.T) {
+	dir := t.TempDir()
+	o, err := New(WithDataDir(dir), WithListenAddr("127.0.0.1:0"), WithPrivateMode(true))
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() { runDone <- o.Run(ctx) }()
+	select {
+	case <-o.ListenerReady():
+	case err := <-runDone:
+		t.Fatalf("overlay stopped before startup: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("overlay did not become ready")
+	}
+
+	const address = "198.51.100.21:51235"
+	release := make(chan struct{})
+	o.peerWG.Add(1)
+	go func() {
+		defer o.peerWG.Done()
+		<-release
+		o.discovery.MarkConnected(address, PeerID(21))
+	}()
 	cancel()
-	if err := waitRun(t, done); !errors.Is(err, context.Canceled) {
-		t.Fatalf("first Run error = %v, want context.Canceled", err)
+	select {
+	case <-runDone:
+		t.Fatal("Run returned before the in-flight peer producer joined")
+	case <-time.After(20 * time.Millisecond):
 	}
-	if err := o.Run(context.Background()); !errors.Is(err, ErrShutdown) {
-		t.Fatalf("second Run error = %v, want ErrShutdown", err)
+	close(release)
+	select {
+	case <-runDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not complete after the peer producer joined")
+	}
+
+	reloaded := NewBootCache(filepath.Clean(dir))
+	require.NoError(t, reloaded.Load())
+	assert.Len(t, reloaded.Endpoints(0), 1)
+	assert.Equal(t, address, reloaded.Endpoints(0)[0].Address)
+}
+
+func TestOverlayStopBeforeRunRejectsRun(t *testing.T) {
+	o, err := New(WithDataDir(t.TempDir()), WithListenAddr("127.0.0.1:0"))
+	require.NoError(t, err)
+	require.NoError(t, o.Stop())
+	err = o.Run(context.Background())
+	assert.ErrorIs(t, err, ErrShutdown)
+	assert.Empty(t, o.ListenAddr())
+}
+
+func TestOverlayConcurrentStopRejectsStartupBeforeReadiness(t *testing.T) {
+	o, err := New(WithDataDir(t.TempDir()), WithListenAddr("127.0.0.1:0"))
+	require.NoError(t, err)
+	o.discovery.cfg.BootstrapPeers = []string{"blocked.example:51235"}
+	entered := make(chan struct{})
+	o.discovery.lookupIP = func(ctx context.Context, _ string) ([]net.IPAddr, error) {
+		close(entered)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	runDone := make(chan error, 1)
+	go func() { runDone <- o.Run(context.Background()) }()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("discovery startup did not enter the blocking resolver")
+	}
+	require.NoError(t, o.Stop())
+	err = <-runDone
+	assert.ErrorIs(t, err, ErrShutdown)
+	assert.Empty(t, o.ListenAddr())
+	select {
+	case <-o.ListenerReady():
+		t.Fatal("concurrent Stop allowed startup readiness")
+	default:
 	}
 }
 
-func TestOverlayRunAfterStop(t *testing.T) {
-	o := newLifecycleTestOverlay(t, WithListenAddr(""))
-	if err := o.Stop(); err != nil {
-		t.Fatalf("Stop before Run: %v", err)
+func TestOverlayRejectsDoubleRun(t *testing.T) {
+	o, err := New(WithDataDir(t.TempDir()), WithListenAddr("127.0.0.1:0"), WithPrivateMode(true))
+	require.NoError(t, err)
+	runDone := make(chan error, 1)
+	go func() { runDone <- o.Run(context.Background()) }()
+	select {
+	case <-o.ListenerReady():
+	case err := <-runDone:
+		t.Fatalf("overlay stopped before startup: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("overlay did not become ready")
 	}
-	if err := o.Stop(); err != nil {
-		t.Fatalf("repeated Stop before Run: %v", err)
-	}
-	if err := o.Run(context.Background()); !errors.Is(err, ErrShutdown) {
-		t.Fatalf("Run after Stop error = %v, want ErrShutdown", err)
-	}
-}
 
-func TestOverlayRunStartupFailureUnwinds(t *testing.T) {
-	o := newLifecycleTestOverlay(t, WithListenAddr("127.0.0.1:not-a-port"))
-	done := make(chan error, 1)
-	go func() { done <- o.Run(context.Background()) }()
-	if err := waitRun(t, done); err == nil {
-		t.Fatal("Run unexpectedly succeeded with an invalid listener address")
-	}
-	if err := o.Stop(); err != nil {
-		t.Fatalf("Stop after startup failure: %v", err)
-	}
+	assert.ErrorIs(t, o.Run(context.Background()), ErrAlreadyRunning)
+	require.NoError(t, o.Stop())
+	<-runDone
+	assert.ErrorIs(t, o.Run(context.Background()), ErrShutdown)
 }

--- a/internal/peermanagement/reservation_test.go
+++ b/internal/peermanagement/reservation_test.go
@@ -1,24 +1,42 @@
 package peermanagement
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/cluster"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func testReservationNodeID(t *testing.T, seed byte) string {
+	t.Helper()
+	raw := make([]byte, 33)
+	raw[0] = 0x02
+	for i := 1; i < len(raw); i++ {
+		raw[i] = seed + byte(i)
+	}
+	nodeID, err := addresscodec.EncodeNodePublicKey(raw)
+	require.NoError(t, err)
+	return nodeID
+}
 
 func TestReservationTablePersistence(t *testing.T) {
 	dir := t.TempDir()
 	tbl := NewReservationTable(dir)
+	nodeID := testReservationNodeID(t, 1)
 
-	if prev, err := tbl.Insert(&PeerReservation{NodeID: "nABC", Description: "first"}); err != nil || prev != nil {
+	if prev, err := tbl.Insert(&PeerReservation{NodeID: nodeID, Description: "first"}); err != nil || prev != nil {
 		t.Fatalf("first insert should have no previous and no error, got prev=%+v err=%v", prev, err)
 	}
-	if prev, err := tbl.Insert(&PeerReservation{NodeID: "nABC", Description: "second"}); err != nil || prev == nil || prev.Description != "first" {
+	if prev, err := tbl.Insert(&PeerReservation{NodeID: nodeID, Description: "second"}); err != nil || prev == nil || prev.Description != "first" {
 		t.Fatalf("replace should return previous 'first' and no error, got prev=%+v err=%v", prev, err)
 	}
-	if !tbl.Contains("nABC") {
+	if !tbl.Contains(nodeID) {
 		t.Fatal("Contains should be true after insert")
 	}
 
@@ -28,12 +46,12 @@ func TestReservationTablePersistence(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 	list := reloaded.List()
-	if len(list) != 1 || list[0].NodeID != "nABC" || list[0].Description != "second" {
+	if len(list) != 1 || list[0].NodeID != nodeID || list[0].Description != "second" {
 		t.Fatalf("reloaded list mismatch: %+v", list)
 	}
 
 	// Erase persists too.
-	if prev, err := reloaded.Erase("nABC"); err != nil || prev == nil || prev.Description != "second" {
+	if prev, err := reloaded.Erase(nodeID); err != nil || prev == nil || prev.Description != "second" {
 		t.Fatalf("erase should return previous 'second' and no error, got prev=%+v err=%v", prev, err)
 	}
 	final := NewReservationTable(dir)
@@ -43,6 +61,123 @@ func TestReservationTablePersistence(t *testing.T) {
 	if len(final.List()) != 0 {
 		t.Fatalf("expected empty after erase+reload, got %+v", final.List())
 	}
+}
+
+func TestReservationTableCopiesCallerOwnedValues(t *testing.T) {
+	tbl := NewReservationTable("")
+	nodeID := testReservationNodeID(t, 2)
+	input := &PeerReservation{NodeID: nodeID, Description: "original"}
+	_, err := tbl.Insert(input)
+	require.NoError(t, err)
+	input.Description = "mutated caller"
+	assert.Equal(t, "original", tbl.List()[0].Description)
+
+	previous, err := tbl.Insert(&PeerReservation{NodeID: nodeID, Description: "replacement"})
+	require.NoError(t, err)
+	previous.Description = "mutated returned value"
+	assert.Equal(t, "replacement", tbl.List()[0].Description)
+
+	list := tbl.List()
+	list[0].Description = "mutated list"
+	assert.Equal(t, "replacement", tbl.List()[0].Description)
+}
+
+func TestReservationTableRejectsNilAndMalformedEntries(t *testing.T) {
+	tbl := NewReservationTable("")
+	_, err := tbl.Insert(nil)
+	require.Error(t, err)
+	_, err = tbl.Insert(&PeerReservation{NodeID: "  "})
+	require.Error(t, err)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, DefaultReservationFile)
+	wrongType := make([]byte, 33)
+	wrongType[0] = 0x04
+	wrongTypeEncoded, err := addresscodec.EncodeNodePublicKey(wrongType)
+	require.NoError(t, err)
+	for _, raw := range []string{"null", "[null]", `[{"node_id":""}]`, `[{"node_id":"nA"},{"node_id":"nA"}]`, `[{"node_id":"` + wrongTypeEncoded + `"}]`} {
+		require.NoError(t, os.WriteFile(path, []byte(raw), 0o600))
+		loaded := NewReservationTable(dir)
+		require.Error(t, loaded.Load(), "malformed reservation payload %q must be rejected", raw)
+	}
+}
+
+func TestReservationTablePostRenameErrorsKeepMemoryAligned(t *testing.T) {
+	dir := t.TempDir()
+	tbl := NewReservationTable(dir)
+	nodeID := testReservationNodeID(t, 4)
+	tbl.writeFile = func(path string, data []byte, mode os.FileMode) (bool, error) {
+		committed, err := writeAtomicFile(path, data, mode)
+		require.NoError(t, err)
+		return committed, errors.New("directory durability uncertain")
+	}
+
+	prev, err := tbl.Insert(&PeerReservation{NodeID: nodeID, Description: "inserted"})
+	assert.Nil(t, prev)
+	require.EqualError(t, err, "directory durability uncertain")
+	assert.True(t, tbl.Contains(nodeID), "post-rename insert must remain in memory")
+	reloaded := NewReservationTable(dir)
+	require.NoError(t, reloaded.Load())
+	assert.Len(t, reloaded.List(), 1)
+
+	prev, err = tbl.Erase(nodeID)
+	require.NotNil(t, prev)
+	require.EqualError(t, err, "directory durability uncertain")
+	assert.False(t, tbl.Contains(nodeID), "post-rename erase must remain erased in memory")
+	reloaded = NewReservationTable(dir)
+	require.NoError(t, reloaded.Load())
+	assert.Empty(t, reloaded.List())
+}
+
+func TestReservationTablePreRenameErrorsRollbackMemory(t *testing.T) {
+	dir := t.TempDir()
+	tbl := NewReservationTable(dir)
+	nodeID := testReservationNodeID(t, 5)
+	tbl.writeFile = func(string, []byte, os.FileMode) (bool, error) {
+		return false, errors.New("write failed before rename")
+	}
+
+	prev, err := tbl.Insert(&PeerReservation{NodeID: nodeID, Description: "not committed"})
+	assert.Nil(t, prev)
+	require.EqualError(t, err, "write failed before rename")
+	assert.False(t, tbl.Contains(nodeID), "pre-rename insert must roll back in memory")
+
+	tbl.writeFile = nil
+	_, err = tbl.Insert(&PeerReservation{NodeID: nodeID, Description: "committed"})
+	require.NoError(t, err)
+	tbl.writeFile = func(string, []byte, os.FileMode) (bool, error) {
+		return false, errors.New("write failed before rename")
+	}
+	prev, err = tbl.Erase(nodeID)
+	require.NotNil(t, prev)
+	require.EqualError(t, err, "write failed before rename")
+	assert.True(t, tbl.Contains(nodeID), "pre-rename erase must roll back in memory")
+}
+
+func TestReservationTableConcurrentMutationsAreSerialized(t *testing.T) {
+	dir := t.TempDir()
+	tbl := NewReservationTable(dir)
+	var wg sync.WaitGroup
+	for i := range 24 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = tbl.Insert(&PeerReservation{NodeID: testReservationNodeID(t, byte(i)), Description: "peer"})
+		}(i)
+	}
+	wg.Wait()
+	reloaded := NewReservationTable(dir)
+	require.NoError(t, reloaded.Load())
+	assert.Len(t, reloaded.List(), 24)
+}
+
+func TestDiscoveryStartSurfacesReservationLoadFailure(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, DefaultReservationFile), []byte("null"), 0o600))
+	d := NewDiscovery(&Config{DataDir: dir}, make(chan Event, 1))
+	err := d.Start(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load peer reservations")
 }
 
 // TestHasInboundSlot_ReservedBypassesCap verifies the reserved/cluster bypass
@@ -107,10 +242,11 @@ func TestHasInboundSlot_ReservedBypassesCap(t *testing.T) {
 // A table with no data directory persists nothing and never errors.
 func TestReservationTableInMemory(t *testing.T) {
 	tbl := NewReservationTable("")
-	if _, err := tbl.Insert(&PeerReservation{NodeID: "nXYZ", Description: "mem"}); err != nil {
+	nodeID := testReservationNodeID(t, 3)
+	if _, err := tbl.Insert(&PeerReservation{NodeID: nodeID, Description: "mem"}); err != nil {
 		t.Fatalf("in-memory insert should not error, got %v", err)
 	}
-	if !tbl.Contains("nXYZ") {
+	if !tbl.Contains(nodeID) {
 		t.Fatal("in-memory reservation should be present")
 	}
 	if err := tbl.Save(); err != nil {


### PR DESCRIPTION
Part of #1472. Stack PR 3/11.\n\nMakes peer state persistence durable across restart and failure paths while preserving bounded, consistent stored state.