### PR TITLE
fix: bound retained peer frame memory (#1472)

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -677,6 +677,16 @@ func TestOverlayConfig_VerifyEndpointsValidation(t *testing.T) {
 	}
 }
 
+func TestOverlayConfig_InboundRetainedBytesValidation(t *testing.T) {
+	o := OverlayConfig{InboundRetainedBytes: 3 * 64 * 1024 * 1024}
+	require.NoError(t, o.Validate())
+
+	o.InboundRetainedBytes--
+	err := o.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inbound_retained_bytes")
+}
+
 func TestConfigValidation_CompleteConfig(t *testing.T) {
 	assert.NoError(t, ValidateConfig(validCompleteConfig()))
 }

--- a/config/peer.go
+++ b/config/peer.go
@@ -17,11 +17,12 @@ import (
 //     0 skips validation for local dev networks — a security risk on a
 //     public network
 type OverlayConfig struct {
-	PublicIP        string `toml:"public_ip" mapstructure:"public_ip"`
-	IPLimit         int    `toml:"ip_limit" mapstructure:"ip_limit"`
-	MaxUnknownTime  int    `toml:"max_unknown_time" mapstructure:"max_unknown_time"`
-	MaxDivergedTime int    `toml:"max_diverged_time" mapstructure:"max_diverged_time"`
-	VerifyEndpoints *int   `toml:"verify_endpoints" mapstructure:"verify_endpoints"`
+	PublicIP             string `toml:"public_ip" mapstructure:"public_ip"`
+	IPLimit              int    `toml:"ip_limit" mapstructure:"ip_limit"`
+	MaxUnknownTime       int    `toml:"max_unknown_time" mapstructure:"max_unknown_time"`
+	MaxDivergedTime      int    `toml:"max_diverged_time" mapstructure:"max_diverged_time"`
+	VerifyEndpoints      *int   `toml:"verify_endpoints" mapstructure:"verify_endpoints"`
+	InboundRetainedBytes int64  `toml:"inbound_retained_bytes" mapstructure:"inbound_retained_bytes"`
 }
 
 // TransactionQueueConfig represents the [transaction_queue] section (EXPERIMENTAL).
@@ -68,6 +69,9 @@ func (o *OverlayConfig) Validate() error {
 		if err := validateZeroOrOne("verify_endpoints", *o.VerifyEndpoints); err != nil {
 			return err
 		}
+	}
+	if o.InboundRetainedBytes != 0 && o.InboundRetainedBytes < 3*64*1024*1024 {
+		return fmt.Errorf("inbound_retained_bytes must be at least %d, got %d", 3*64*1024*1024, o.InboundRetainedBytes)
 	}
 
 	return nil

--- a/internal/consensus/adaptor/acquisition_work.go
+++ b/internal/consensus/adaptor/acquisition_work.go
@@ -58,6 +58,7 @@ type ledgerAcquisitionNetwork interface {
 type acquisitionWorkEvent struct {
 	kind       acquisitionWorkKind
 	data       *message.LedgerData
+	owner      *peermanagement.InboundMessage
 	peerID     uint64
 	resume     bool
 	useful     int
@@ -69,6 +70,20 @@ type acquisitionWorkEvent struct {
 	queryDepth uint32
 	collect    bool
 	at         time.Time
+}
+
+func (e *acquisitionWorkEvent) release() {
+	if e == nil || e.owner == nil {
+		return
+	}
+	_ = e.owner.Close()
+	e.owner = nil
+}
+
+func releaseAcquisitionWorkEvents(events []acquisitionWorkEvent) {
+	for i := range events {
+		events[i].release()
+	}
 }
 
 type acquisitionWorkBatch struct {
@@ -264,6 +279,7 @@ func (l *acquisitionWorkLane) submit(ledger *inbound.Ledger, event acquisitionWo
 
 func (l *acquisitionWorkLane) run() {
 	defer close(l.done)
+	defer l.releasePending()
 	for {
 		select {
 		case <-l.ctx.Done():
@@ -287,6 +303,12 @@ func (l *acquisitionWorkLane) runBatch(batch *acquisitionWorkBatch) bool {
 	events := append([]acquisitionWorkEvent(nil), batch.events...)
 	batch.events = batch.events[:0]
 	l.mu.Unlock()
+	retained := false
+	defer func() {
+		if !retained {
+			releaseAcquisitionWorkEvents(events)
+		}
+	}()
 
 	result := l.process(batch.ctx, batch.ledger, events)
 	if errors.Is(result.err, shamap.ErrTraversalBudget) && batch.ctx.Err() == nil {
@@ -324,12 +346,16 @@ func (l *acquisitionWorkLane) runBatch(batch *acquisitionWorkBatch) bool {
 	case <-result.ack:
 	}
 
+	var discarded []acquisitionWorkEvent
 	l.mu.Lock()
 	if result.complete || result.remove || batch.ctx.Err() != nil {
 		delete(l.pending, batch.ledger)
 		batch.cancel()
+		discarded = append(discarded, batch.events...)
+		batch.events = nil
 	} else if result.yielded {
 		batch.events = append(batch.events, events...)
+		retained = true
 		l.ready = append(l.ready, batch)
 		l.notifyLocked()
 	} else if len(batch.events) == 0 {
@@ -340,7 +366,25 @@ func (l *acquisitionWorkLane) runBatch(batch *acquisitionWorkBatch) bool {
 		l.notifyLocked()
 	}
 	l.mu.Unlock()
+	releaseAcquisitionWorkEvents(discarded)
 	return true
+}
+
+func (l *acquisitionWorkLane) releasePending() {
+	l.mu.Lock()
+	batches := make([]*acquisitionWorkBatch, 0, len(l.pending))
+	for _, batch := range l.pending {
+		batches = append(batches, batch)
+	}
+	l.pending = make(map[*inbound.Ledger]*acquisitionWorkBatch)
+	l.ready = nil
+	l.mu.Unlock()
+
+	for _, batch := range batches {
+		batch.cancel()
+		releaseAcquisitionWorkEvents(batch.events)
+		batch.events = nil
+	}
 }
 
 func (l *acquisitionWorkLane) takeReady() *acquisitionWorkBatch {

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -763,19 +763,19 @@ func (r *Router) Run(ctx context.Context) {
 			if !ok {
 				return
 			}
-			r.handleMessage(msg)
+			r.handleInboundMessage(msg)
 		case msg, ok := <-r.serviceInbox:
 			if !ok {
 				r.serviceInbox = nil
 				continue
 			}
-			r.handleMessage(msg)
+			r.handleInboundMessage(msg)
 		case msg, ok := <-r.consensusControlInbox:
 			if !ok {
 				r.consensusControlInbox = nil
 				continue
 			}
-			r.handleMessage(msg)
+			r.handleInboundMessage(msg)
 		case msg, ok := <-acqInbox:
 			// Dedicated acquisition-reply lane (liBASE and the replay-delta /
 			// proof-path responses). Its own buffered lane keeps a flood on
@@ -788,7 +788,7 @@ func (r *Router) Run(ctx context.Context) {
 				r.acqInbox = nil
 				continue
 			}
-			r.handleMessage(msg)
+			r.handleInboundMessage(msg)
 		case msg, ok := <-r.txInbox:
 			if !ok {
 				// Lane closed (or never wired): stop selecting it so we
@@ -840,7 +840,7 @@ func (r *Router) drainConsensusInbox(ctx context.Context) bool {
 			if !ok {
 				return false
 			}
-			r.handleMessage(msg)
+			r.handleInboundMessage(msg)
 		default:
 			return true
 		}
@@ -857,7 +857,7 @@ func (r *Router) drainAcquisitionInboxBeforeMaintenance(workLane *acquisitionWor
 				r.acqInbox = nil
 				return drained
 			}
-			r.handleMessage(msg)
+			r.handleInboundMessage(msg)
 			drained++
 		default:
 			return drained
@@ -870,23 +870,29 @@ func (r *Router) drainAcquisitionInboxBeforeMaintenance(workLane *acquisitionWor
 // message loop. Before the first Run it handles synchronously for direct
 // dispatch tests. Once shutdown begins, admission remains closed.
 func (r *Router) submitTxJob(msg *peermanagement.InboundMessage) {
+	if msg == nil {
+		return
+	}
 	r.lifecycleMu.RLock()
 	state := r.lifecycleState
 	jobs := r.txJobs
 	if state == routerLifecycleInitial {
 		r.lifecycleMu.RUnlock()
+		defer func() { _ = msg.Close() }()
 		r.handleTransaction(msg)
 		return
 	}
 	if state != routerLifecycleRunning || jobs == nil {
 		r.lifecycleMu.RUnlock()
 		r.droppedTxJobs.Add(1)
+		_ = msg.Close()
 		return
 	}
 	select {
 	case jobs <- msg:
 	default:
 		r.droppedTxJobs.Add(1)
+		_ = msg.Close()
 		r.logger.Debug("inbound tx dropped: worker pool saturated",
 			"t", "consensus", "event", "tx-shed", "peer", msg.PeerID)
 	}
@@ -903,23 +909,29 @@ func (r *Router) DroppedTxJobs() uint64 {
 // the Run message loop. Before the first Run it handles synchronously for
 // direct dispatch tests. Once shutdown begins, admission remains closed.
 func (r *Router) submitServeJob(msg *peermanagement.InboundMessage) {
+	if msg == nil {
+		return
+	}
 	r.lifecycleMu.RLock()
 	state := r.lifecycleState
 	jobs := r.serveJobs
 	if state == routerLifecycleInitial {
 		r.lifecycleMu.RUnlock()
+		defer func() { _ = msg.Close() }()
 		r.handleGetLedger(msg)
 		return
 	}
 	if state != routerLifecycleRunning || jobs == nil {
 		r.lifecycleMu.RUnlock()
 		r.droppedServeJobs.Add(1)
+		_ = msg.Close()
 		return
 	}
 	select {
 	case jobs <- msg:
 	default:
 		r.droppedServeJobs.Add(1)
+		_ = msg.Close()
 		r.logger.Debug("inbound get_ledger dropped: serve pool saturated",
 			"t", "consensus", "event", "serve-shed", "peer", msg.PeerID)
 	}
@@ -977,6 +989,7 @@ func (r *Router) processManifestJob(msg *peermanagement.InboundMessage) {
 }
 
 func (r *Router) processManifestJobContext(ctx context.Context, msg *peermanagement.InboundMessage) {
+	defer func() { _ = msg.Close() }()
 	processed := false
 	defer func() {
 		if !processed {

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -2071,38 +2071,38 @@ func (r *Router) ourLCLMatchesPeers() bool {
 	return matching > total/2
 }
 
-func (r *Router) handleLedgerData(msg *peermanagement.InboundMessage) {
+func (r *Router) handleLedgerData(msg *peermanagement.InboundMessage) bool {
 	decoded, err := message.Decode(message.TypeLedgerData, msg.Payload)
 	if err != nil {
 		r.logger.Warn("failed to decode ledger_data", "error", err, "peer", msg.PeerID)
 		r.acquisition.IncPeerBadData(uint64(msg.PeerID), "ledger-data-decode")
-		return
+		return false
 	}
 	ld, ok := decoded.(*message.LedgerData)
 	if !ok {
-		return
+		return false
 	}
 	if len(ld.LedgerHash) != 32 {
 		r.logger.Warn("invalid ledger_data ledger hash", "peer", msg.PeerID, "length", len(ld.LedgerHash))
 		r.acquisition.IncPeerBadData(uint64(msg.PeerID), "ledger-data-hash")
-		return
+		return false
 	}
 	if ld.InfoType < message.LedgerInfoBase || ld.InfoType > message.LedgerInfoTsCandidate {
 		r.logger.Warn("invalid ledger_data info type", "peer", msg.PeerID, "info_type", ld.InfoType)
 		r.acquisition.IncPeerBadData(uint64(msg.PeerID), "ledger-data-type")
-		return
+		return false
 	}
 	if (ld.InfoType == message.LedgerInfoTsCandidate && ld.LedgerSeq != 0) ||
 		(ld.InfoType != message.LedgerInfoTsCandidate && r.invalidFutureLedgerSequence(ld.LedgerSeq)) {
 		r.logger.Warn("invalid ledger_data ledger sequence", "peer", msg.PeerID, "seq", ld.LedgerSeq)
 		r.acquisition.IncPeerBadData(uint64(msg.PeerID), "ledger-data-sequence")
-		return
+		return false
 	}
 	if ld.Error != message.ReplyErrorNone &&
 		(ld.Error < message.ReplyErrorNoLedger || ld.Error > message.ReplyErrorBadRequest) {
 		r.logger.Warn("invalid ledger_data reply error", "peer", msg.PeerID, "error", ld.Error)
 		r.acquisition.IncPeerBadData(uint64(msg.PeerID), "ledger-data-error")
-		return
+		return false
 	}
 	if ld.Error != message.ReplyErrorNone {
 		r.logger.Warn("inbound ledger: peer returned reply error",
@@ -2123,17 +2123,17 @@ func (r *Router) handleLedgerData(msg *peermanagement.InboundMessage) {
 			"nodes", len(ld.Nodes),
 		)
 		r.acquisition.IncPeerBadData(uint64(msg.PeerID), "ledger-data-count")
-		return
+		return false
 	}
 	if ld.InfoType == message.LedgerInfoAsNode || ld.InfoType == message.LedgerInfoTxNode {
 		for _, node := range ld.Nodes {
 			if len(node.NodeData) == 0 {
 				r.acquisition.IncPeerBadData(uint64(msg.PeerID), "ledger-data-node")
-				return
+				return false
 			}
 			if _, err := shamap.ParseNodeID(node.NodeID); err != nil {
 				r.acquisition.IncPeerBadData(uint64(msg.PeerID), "ledger-data-node")
-				return
+				return false
 			}
 		}
 	}
@@ -2144,7 +2144,7 @@ func (r *Router) handleLedgerData(msg *peermanagement.InboundMessage) {
 	// onMessage(TMLedgerData).
 	if ld.HasRequestCookie() {
 		r.routeRelayedLedgerData(ld, msg.PeerID)
-		return
+		return false
 	}
 
 	var il *inbound.Ledger
@@ -2166,17 +2166,18 @@ func (r *Router) handleLedgerData(msg *peermanagement.InboundMessage) {
 	// (consensus-time only).
 	if ld.InfoType == message.LedgerInfoTsCandidate {
 		r.handleTxSetData(ld, uint64(msg.PeerID))
-		return
+		return false
 	}
 
 	if il != nil {
-		if r.handleInboundLedgerData(il, ld, uint64(msg.PeerID)) {
-			return
+		if consumed, transferred := r.handleInboundLedgerDataOwned(il, ld, uint64(msg.PeerID), msg); consumed {
+			return transferred
 		}
 	}
 	if il == nil && ld.InfoType == message.LedgerInfoAsNode {
 		r.cacheStaleStateNodes(ld)
 	}
+	return false
 }
 
 func (r *Router) cacheStaleStateNodes(ld *message.LedgerData) {
@@ -2197,20 +2198,30 @@ func (r *Router) cacheStaleStateNodes(ld *message.LedgerData) {
 // acquisition (already matched by hash in handleLedgerData). Returns true if
 // the data was consumed by the acquisition.
 func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerData, peerID uint64) bool {
+	consumed, _ := r.handleInboundLedgerDataOwned(il, ld, peerID, nil)
+	return consumed
+}
+
+func (r *Router) handleInboundLedgerDataOwned(
+	il *inbound.Ledger,
+	ld *message.LedgerData,
+	peerID uint64,
+	owner *peermanagement.InboundMessage,
+) (bool, bool) {
 	if il == nil {
-		return false
+		return false, false
 	}
 	if lane := r.currentAcquisitionWork(); lane != nil {
 		switch ld.InfoType {
 		case message.LedgerInfoBase, message.LedgerInfoAsNode, message.LedgerInfoTxNode:
 			if lane.submit(il, acquisitionWorkEvent{
-				kind: acquisitionWorkData, data: ld, peerID: peerID,
+				kind: acquisitionWorkData, data: ld, owner: owner, peerID: peerID,
 			}) {
-				return true
+				return true, owner != nil
 			}
 			r.logger.Warn("inbound ledger reply deferred: acquisition worker saturated",
 				"peer", peerID, "seq", il.Seq(), "info_type", ld.InfoType)
-			return true
+			return true, false
 		}
 	}
 
@@ -2221,7 +2232,7 @@ func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerD
 			if r.fetchTracker.RemoveExpectedWithSnapshot(il, il.Snapshot(), false) {
 				r.retireAcquisitionStore(r.lifecycleContext(), il)
 			}
-			return true
+			return true, false
 		}
 		if err := il.GotBase(ld.Nodes); err != nil {
 			r.logger.Warn("inbound ledger: GotBase failed", "error", err)
@@ -2233,18 +2244,18 @@ func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerD
 					r.retireAcquisitionStore(r.lifecycleContext(), il)
 				}
 			}
-			return true
+			return true, false
 		}
 
 		if il.IsComplete() {
 			r.completeInboundLedger(il)
-			return true
+			return true, false
 		}
 
 		// Re-request the missing state and transaction nodes from the peer
 		// that answered, mirroring rippled trigger(peer) on a reply.
 		r.requestMissingAcquisitionNodes(il, peerID)
-		return true
+		return true, false
 
 	case message.LedgerInfoAsNode:
 		il.ReleaseMissingPeer(peerID)
@@ -2252,18 +2263,18 @@ func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerD
 		if err != nil {
 			r.logger.Warn("inbound ledger: GotStateNodes failed", "error", err)
 			r.acquisition.IncPeerBadData(peerID, "ledger-data-state")
-			return true
+			return true, false
 		}
 
 		if il.IsComplete() {
 			r.completeInboundLedger(il)
-			return true
+			return true, false
 		}
 
 		if useful > 0 {
 			r.requestMissingAcquisitionNodes(il, peerID)
 		}
-		return true
+		return true, false
 
 	case message.LedgerInfoTxNode:
 		il.ReleaseMissingPeer(peerID)
@@ -2271,21 +2282,21 @@ func (r *Router) handleInboundLedgerData(il *inbound.Ledger, ld *message.LedgerD
 		if err != nil {
 			r.logger.Warn("inbound ledger: GotTransactionNodes failed", "error", err)
 			r.acquisition.IncPeerBadData(peerID, "ledger-data-tx")
-			return true
+			return true, false
 		}
 
 		if il.IsComplete() {
 			r.completeInboundLedger(il)
-			return true
+			return true, false
 		}
 
 		if useful > 0 {
 			r.requestMissingAcquisitionNodes(il, peerID)
 		}
-		return true
+		return true, false
 	}
 
-	return false
+	return false, false
 }
 
 // requestMissingAcquisitionNodes asks for the acquisition's outstanding nodes,

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -25,13 +25,13 @@ type gossipNetwork interface {
 	RelayValidation(validation *consensus.Validation, exceptPeer uint64) error
 }
 
-func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
+func (r *Router) handleMessage(msg *peermanagement.InboundMessage) (transferred bool) {
 	defer r.recoverFrame(msg, "dispatch")
 
 	msgType := message.MessageType(msg.Type)
 	if r.peerSessions != nil && !r.peerSessions.IsPeerConnected(msg.PeerID) &&
 		msgType != message.TypeManifests {
-		return
+		return false
 	}
 	defer func() {
 		if r.peerSessions != nil && !r.peerSessions.IsPeerConnected(msg.PeerID) {
@@ -51,6 +51,7 @@ func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
 		// TMTransaction onto its jtTRANSACTION job queue rather than handling
 		// it on the read strand.
 		r.submitTxJob(msg)
+		transferred = true
 	case message.TypeHaveSet:
 		r.handleHaveSet(msg)
 	case message.TypeStatusChange:
@@ -61,8 +62,9 @@ func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
 		// proposal / validation / acquisition-reply handling on this
 		// goroutine. Inline when the pool isn't running (synchronous tests).
 		r.submitServeJob(msg)
+		transferred = true
 	case message.TypeLedgerData:
-		r.handleLedgerData(msg)
+		transferred = r.handleLedgerData(msg)
 	case message.TypeGetObjects:
 		// Only fetch-pack REPLIES reach the router; the overlay serves
 		// otFETCH_PACK requests inline and forwards replies here (see
@@ -78,6 +80,16 @@ func (r *Router) handleMessage(msg *peermanagement.InboundMessage) {
 	case message.TypeValidatorListCollection:
 		r.handleValidatorListCollection(msg)
 	default:
+	}
+	return transferred
+}
+
+func (r *Router) handleInboundMessage(msg *peermanagement.InboundMessage) {
+	if msg == nil {
+		return
+	}
+	if !r.handleMessage(msg) {
+		_ = msg.Close()
 	}
 }
 

--- a/internal/consensus/adaptor/router_lifecycle.go
+++ b/internal/consensus/adaptor/router_lifecycle.go
@@ -47,7 +47,10 @@ func (r *Router) startLifecycle(parent context.Context) (context.Context, bool) 
 				case <-ctx.Done():
 					return
 				case msg := <-txJobs:
-					r.handleTransaction(msg)
+					func() {
+						defer func() { _ = msg.Close() }()
+						r.handleTransaction(msg)
+					}()
 				}
 			}
 		}()
@@ -65,7 +68,10 @@ func (r *Router) startLifecycle(parent context.Context) (context.Context, bool) 
 				case <-ctx.Done():
 					return
 				case msg := <-serveJobs:
-					r.handleGetLedger(msg)
+					func() {
+						defer func() { _ = msg.Close() }()
+						r.handleGetLedger(msg)
+					}()
 				}
 			}
 		}()
@@ -90,6 +96,8 @@ func (r *Router) stopLifecycle() {
 		return
 	}
 	r.lifecycleState = routerLifecycleStopped
+	txJobs := r.txJobs
+	serveJobs := r.serveJobs
 	r.txJobs = nil
 	r.serveJobs = nil
 	cancel := r.lifecycleCancel
@@ -98,6 +106,19 @@ func (r *Router) stopLifecycle() {
 	r.lifecycleMu.Unlock()
 
 	r.lifecycleWG.Wait()
+	drainInboundMessages(txJobs)
+	drainInboundMessages(serveJobs)
+}
+
+func drainInboundMessages(messages <-chan *peermanagement.InboundMessage) {
+	for {
+		select {
+		case msg := <-messages:
+			_ = msg.Close()
+		default:
+			return
+		}
+	}
 }
 
 func (r *Router) lifecycleContext() context.Context {

--- a/internal/consensus/adaptor/startup.go
+++ b/internal/consensus/adaptor/startup.go
@@ -983,6 +983,9 @@ func OverlayOptionsFromConfig(appCfg *config.Config) []peermanagement.Option {
 	if appCfg.Overlay.VerifyEndpoints != nil {
 		opts = append(opts, peermanagement.WithVerifyEndpoints(*appCfg.Overlay.VerifyEndpoints != 0))
 	}
+	if appCfg.Overlay.InboundRetainedBytes != 0 {
+		opts = append(opts, peermanagement.WithInboundRetainedBytes(appCfg.Overlay.InboundRetainedBytes))
+	}
 
 	return opts
 }

--- a/internal/consensus/adaptor/startup_test.go
+++ b/internal/consensus/adaptor/startup_test.go
@@ -70,6 +70,18 @@ func TestOverlayOptionsFromConfig_UnsetDomainAndIPEmitNoOption(t *testing.T) {
 	assert.Nil(t, cfg.PublicIP)
 }
 
+func TestOverlayOptionsFromConfig_InboundRetainedBytes(t *testing.T) {
+	const budget = 4 * 64 * 1024 * 1024
+	cfg := peermanagement.DefaultConfig()
+	for _, opt := range OverlayOptionsFromConfig(&config.Config{
+		Overlay: config.OverlayConfig{InboundRetainedBytes: budget},
+	}) {
+		opt(&cfg)
+	}
+
+	assert.EqualValues(t, budget, cfg.InboundRetainedBytes)
+}
+
 func TestOverlayOptionsFromConfig_BootstrapPrecedence(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/peermanagement/config.go
+++ b/internal/peermanagement/config.go
@@ -23,6 +23,7 @@ const (
 	DefaultEventBufferSize             = 256
 	DefaultMessageBufferSize           = 256
 	DefaultSendBufferSize              = 64
+	DefaultInboundRetainedBytes  int64 = 3 * MaxMessageSize
 	DefaultOutboundRetainedBytes int64 = 8 * MaxMessageSize
 	acquisitionEventBufferSize         = 16
 
@@ -121,6 +122,9 @@ type Config struct {
 	// across all peers. Noncritical traffic cannot consume the critical
 	// reserve derived from MaxPeers.
 	OutboundRetainedBytes int64
+	// InboundRetainedBytes bounds bulk wire, decoded, and spooled payload bytes
+	// across all peers until downstream processing completes.
+	InboundRetainedBytes int64
 
 	// MaxTransactions sizes the overlay's dedicated inbound
 	// TMTransaction lane. Inbound tx frames past this ceiling are shed
@@ -222,6 +226,7 @@ func DefaultConfig() Config {
 		EventBufferSize:       DefaultEventBufferSize,
 		MessageBufferSize:     DefaultMessageBufferSize,
 		MaxTransactions:       DefaultMaxTransactions,
+		InboundRetainedBytes:  DefaultInboundRetainedBytes,
 		OutboundRetainedBytes: DefaultOutboundRetainedBytes,
 
 		// Reduce-relay is opt-in. Leaving these zero-valued avoids
@@ -291,6 +296,13 @@ func WithIPLimit(n int) Option {
 func WithOutboundRetainedBytes(bytes int64) Option {
 	return func(c *Config) {
 		c.OutboundRetainedBytes = bytes
+	}
+}
+
+// WithInboundRetainedBytes sets the shared inbound bulk-payload budget.
+func WithInboundRetainedBytes(bytes int64) Option {
+	return func(c *Config) {
+		c.InboundRetainedBytes = bytes
 	}
 }
 
@@ -473,6 +485,12 @@ func (c *Config) Validate() error {
 	}
 	if c.OutboundRetainedBytes == 0 {
 		c.OutboundRetainedBytes = DefaultOutboundRetainedBytes
+	}
+	if c.InboundRetainedBytes == 0 {
+		c.InboundRetainedBytes = DefaultInboundRetainedBytes
+	}
+	if c.InboundRetainedBytes < 3*int64(MaxMessageSize) {
+		return fmt.Errorf("InboundRetainedBytes must be at least %d", 3*int64(MaxMessageSize))
 	}
 	minimumOutboundBytes := MinimumOutboundRetainedBytes(c.MaxPeers)
 	if c.OutboundRetainedBytes < minimumOutboundBytes {

--- a/internal/peermanagement/events.go
+++ b/internal/peermanagement/events.go
@@ -4,6 +4,7 @@ package peermanagement
 import (
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 )
@@ -126,6 +127,45 @@ type Event struct {
 
 	// Error is set for failure events.
 	Error error
+
+	reservation *inboundReservation
+}
+
+func (e *Event) release() {
+	if e == nil {
+		return
+	}
+	if e.ManifestFrame != nil {
+		_ = e.ManifestFrame.Close()
+		e.ManifestFrame = nil
+	}
+	if e.reservation != nil {
+		e.reservation.release()
+		e.reservation = nil
+	}
+}
+
+func (e *Event) inboundMessage() *InboundMessage {
+	msg := &InboundMessage{
+		PeerID:        e.PeerID,
+		Type:          e.MessageType,
+		Payload:       e.Payload,
+		ManifestFrame: e.ManifestFrame,
+		reservation:   e.reservation,
+	}
+	e.reservation = nil
+	e.ManifestFrame = nil
+	return msg
+}
+
+func (e *Event) retainedInboundMessage() *InboundMessage {
+	return &InboundMessage{
+		PeerID:        e.PeerID,
+		Type:          e.MessageType,
+		Payload:       e.Payload,
+		ManifestFrame: e.ManifestFrame,
+		reservation:   e.reservation.retain(),
+	}
 }
 
 // InboundMessage represents a message received from a peer.
@@ -148,4 +188,23 @@ type InboundMessage struct {
 	// Payload. It is nil for messages read off the wire, whose decoded
 	// form lives in Payload.
 	Tx *message.Transaction
+
+	reservation *inboundReservation
+	closeOnce   sync.Once
+	closeErr    error
+}
+
+// Close releases retained inbound bytes and removes any spool file.
+func (m *InboundMessage) Close() error {
+	if m == nil {
+		return nil
+	}
+	m.closeOnce.Do(func() {
+		if m.ManifestFrame != nil {
+			m.closeErr = m.ManifestFrame.Close()
+		}
+		m.reservation.release()
+		m.reservation = nil
+	})
+	return m.closeErr
 }

--- a/internal/peermanagement/inbound_budget_test.go
+++ b/internal/peermanagement/inbound_budget_test.go
@@ -1,0 +1,331 @@
+package peermanagement
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/require"
+)
+
+func readBudgetUsed(budget *readBudget) int64 {
+	budget.mu.Lock()
+	defer budget.mu.Unlock()
+	return budget.used
+}
+
+func TestInboundBulkBudgetFollowsMessageThroughConsumer(t *testing.T) {
+	payload := bytes.Repeat([]byte{0x4c}, 32*1024)
+	var wire bytes.Buffer
+	require.NoError(t, message.WriteMessage(&wire, message.TypeLedgerData, payload))
+	frame := wire.Bytes()
+
+	budget := newReadBudget(int64(len(payload)))
+	events := make(chan Event, 2)
+	first := newLatencyTestPeer(t)
+	first.bufReader = bufio.NewReader(bytes.NewReader(frame))
+	first.SetAcquisitionEvents(events)
+	first.SetInboundReadBudget(budget)
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- first.readLoop(context.Background()) }()
+
+	firstEvent := <-events
+	require.Equal(t, int64(len(payload)), readBudgetUsed(budget))
+
+	secondReader := &countingReader{reader: bytes.NewReader(frame)}
+	second := newLatencyTestPeer(t)
+	second.bufReader = bufio.NewReader(secondReader)
+	second.SetAcquisitionEvents(events)
+	second.SetInboundReadBudget(budget)
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- second.readLoop(context.Background()) }()
+
+	require.Eventually(t, func() bool { return secondReader.read.Load() > 0 }, time.Second, time.Millisecond)
+	time.Sleep(25 * time.Millisecond)
+	require.Less(t, secondReader.read.Load(), int64(len(frame)))
+
+	overlay := &Overlay{
+		cfg:        DefaultConfig(),
+		ledgerData: make(chan *InboundMessage, 1),
+		stopCh:     make(chan struct{}),
+	}
+	overlay.onMessageReceived(firstEvent)
+	require.Equal(t, int64(len(payload)), readBudgetUsed(budget))
+	firstMessage := <-overlay.ledgerData
+	require.NoError(t, firstMessage.Close())
+
+	require.Eventually(t, func() bool { return secondReader.read.Load() == int64(len(frame)) }, time.Second, time.Millisecond)
+	secondEvent := <-events
+	secondEvent.release()
+	require.ErrorIs(t, <-firstDone, io.EOF)
+	require.ErrorIs(t, <-secondDone, io.EOF)
+	require.Zero(t, readBudgetUsed(budget))
+}
+
+func TestCompressedManifestSpoolSharesInboundBudget(t *testing.T) {
+	payload := bytes.Repeat([]byte("manifest"), manifestSpoolThreshold/len("manifest")+1)
+	frame, err := message.BuildWireMessage(message.TypeManifests, payload)
+	require.NoError(t, err)
+	wire, compressed := message.CompressFrameIfWorthwhile(frame)
+	require.True(t, compressed)
+	header, err := message.DecodeHeader(wire)
+	require.NoError(t, err)
+
+	spoolDir, err := prepareManifestSpoolDir(t.TempDir())
+	require.NoError(t, err)
+	budget := newReadBudget(int64(3 * len(payload)))
+	manifests := make(chan *InboundMessage, 1)
+	peer := newLatencyTestPeer(t)
+	peer.bufReader = bufio.NewReader(bytes.NewReader(wire))
+	peer.handshakeCfg.EnableCompression = true
+	peer.capabilities = NewPeerCapabilities()
+	peer.capabilities.Features.Enable(FeatureCompression)
+	peer.SetManifestMessages(manifests)
+	peer.SetInboundReadBudget(budget)
+	peer.SetManifestSpoolDir(spoolDir)
+	done := make(chan error, 1)
+	go func() { done <- peer.readLoop(context.Background()) }()
+
+	inbound := <-manifests
+	require.NotNil(t, inbound.ManifestFrame)
+	require.Equal(t, 2*int64(header.PayloadSize)+int64(len(payload)), readBudgetUsed(budget))
+	spoolPath := inbound.ManifestFrame.path
+	materialized, err := inbound.ManifestFrame.Materialize(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, payload, materialized)
+	require.Equal(t, int64(header.PayloadSize)+int64(len(payload)), readBudgetUsed(budget))
+	require.NoError(t, inbound.Close())
+	require.ErrorIs(t, func() error {
+		_, err := os.Stat(spoolPath)
+		return err
+	}(), os.ErrNotExist)
+	require.Zero(t, readBudgetUsed(budget))
+	require.ErrorIs(t, <-done, io.EOF)
+}
+
+func TestInboundRetainedBytesValidation(t *testing.T) {
+	cfg := DefaultConfig()
+	require.Equal(t, DefaultInboundRetainedBytes, cfg.InboundRetainedBytes)
+
+	cfg.InboundRetainedBytes = 0
+	require.NoError(t, cfg.Validate())
+	require.Equal(t, DefaultInboundRetainedBytes, cfg.InboundRetainedBytes)
+
+	cfg = DefaultConfig()
+	cfg.InboundRetainedBytes = 3*int64(MaxMessageSize) - 1
+	err := cfg.Validate()
+	require.EqualError(t, err, "InboundRetainedBytes must be at least 201326592")
+}
+
+func TestRetainedEventReservationReleasesAfterLastOwner(t *testing.T) {
+	budget := newReadBudget(1024)
+	require.NoError(t, budget.acquire(context.Background(), nil, 512))
+	event := Event{reservation: newInboundReservation(budget, 512)}
+	retained := event.retainedInboundMessage()
+
+	event.release()
+	require.Equal(t, int64(512), readBudgetUsed(budget))
+
+	require.NoError(t, retained.Close())
+	require.Zero(t, readBudgetUsed(budget))
+}
+
+func TestGetObjectsReplyRetainsBudgetUntilRouterConsumption(t *testing.T) {
+	payload, err := message.Encode(&message.GetObjectByHash{
+		ObjType: message.ObjectTypeFetchPack,
+		Query:   false,
+		Objects: []message.IndexedObject{{Hash: bytes.Repeat([]byte{0x01}, 32), Data: []byte{0x09}}},
+	})
+	require.NoError(t, err)
+
+	budget := newReadBudget(int64(len(payload)))
+	require.NoError(t, budget.acquire(context.Background(), nil, int64(len(payload))))
+	overlay := &Overlay{
+		cfg:        DefaultConfig(),
+		ledgerData: make(chan *InboundMessage, 1),
+		stopCh:     make(chan struct{}),
+	}
+	overlay.onMessageReceived(Event{
+		Type:        EventMessageReceived,
+		PeerID:      1,
+		MessageType: uint16(message.TypeGetObjects),
+		Payload:     payload,
+		reservation: newInboundReservation(budget, int64(len(payload))),
+	})
+
+	require.Equal(t, int64(len(payload)), readBudgetUsed(budget))
+	inbound := <-overlay.ledgerData
+	require.NoError(t, inbound.Close())
+	require.Zero(t, readBudgetUsed(budget))
+}
+
+func TestGetObjectsQueryRetainsBudgetUntilServeCompletion(t *testing.T) {
+	payload, err := message.Encode(&message.GetObjectByHash{
+		Query:   true,
+		Objects: []message.IndexedObject{{Hash: bytes.Repeat([]byte{0x02}, 32)}},
+	})
+	require.NoError(t, err)
+
+	budget := newReadBudget(int64(len(payload)))
+	require.NoError(t, budget.acquire(context.Background(), nil, int64(len(payload))))
+	overlay := &Overlay{
+		cfg:       DefaultConfig(),
+		peers:     make(map[PeerID]*Peer),
+		serveJobs: make(chan overlayServeJob, 1),
+		runDone:   make(chan struct{}),
+	}
+	overlay.onMessageReceived(Event{
+		Type:        EventMessageReceived,
+		PeerID:      1,
+		MessageType: uint16(message.TypeGetObjects),
+		Payload:     payload,
+		reservation: newInboundReservation(budget, int64(len(payload))),
+	})
+
+	require.Equal(t, int64(len(payload)), readBudgetUsed(budget))
+	job := <-overlay.serveJobs
+	job.run()
+	require.Zero(t, readBudgetUsed(budget))
+}
+
+func TestDroppedGetObjectsQueryReleasesBudget(t *testing.T) {
+	payload, err := message.Encode(&message.GetObjectByHash{Query: true})
+	require.NoError(t, err)
+
+	budget := newReadBudget(int64(len(payload)))
+	require.NoError(t, budget.acquire(context.Background(), nil, int64(len(payload))))
+	jobs := make(chan overlayServeJob, 1)
+	jobs <- overlayServeJob{run: func() {}}
+	overlay := &Overlay{
+		cfg:       DefaultConfig(),
+		peers:     make(map[PeerID]*Peer),
+		serveJobs: jobs,
+		runDone:   make(chan struct{}),
+	}
+	overlay.onMessageReceived(Event{
+		Type:        EventMessageReceived,
+		PeerID:      1,
+		MessageType: uint16(message.TypeGetObjects),
+		Payload:     payload,
+		reservation: newInboundReservation(budget, int64(len(payload))),
+	})
+
+	require.Zero(t, readBudgetUsed(budget))
+	require.Equal(t, uint64(1), overlay.DroppedServeJobs())
+}
+
+func TestServeShutdownReleasesQueuedDecodedBudget(t *testing.T) {
+	payload, err := message.Encode(&message.GetObjectByHash{Query: true})
+	require.NoError(t, err)
+
+	budget := newReadBudget(int64(len(payload)))
+	require.NoError(t, budget.acquire(context.Background(), nil, int64(len(payload))))
+	overlay := &Overlay{
+		cfg:       DefaultConfig(),
+		peers:     make(map[PeerID]*Peer),
+		serveJobs: make(chan overlayServeJob, 1),
+		runDone:   make(chan struct{}),
+	}
+	overlay.onMessageReceived(Event{
+		Type:        EventMessageReceived,
+		PeerID:      1,
+		MessageType: uint16(message.TypeGetObjects),
+		Payload:     payload,
+		reservation: newInboundReservation(budget, int64(len(payload))),
+	})
+	require.Equal(t, int64(len(payload)), readBudgetUsed(budget))
+
+	overlay.discardServeJobs()
+	require.Zero(t, readBudgetUsed(budget))
+}
+
+func TestStopDrainsRetainedEventsQueuedAfterRunCompletion(t *testing.T) {
+	o, err := New(WithDataDir(t.TempDir()))
+	require.NoError(t, err)
+
+	budget := newReadBudget(1)
+	require.NoError(t, budget.acquire(context.Background(), nil, 1))
+	o.events <- Event{reservation: newInboundReservation(budget, 1)}
+
+	runComplete := make(chan struct{})
+	close(runComplete)
+	o.lifecycleMu.Lock()
+	o.runComplete = runComplete
+	o.lifecycleMu.Unlock()
+
+	require.NoError(t, o.Stop())
+	require.Zero(t, readBudgetUsed(budget))
+}
+
+func TestTransactionsBatchRetainsBudgetUntilAllChildrenClose(t *testing.T) {
+	identity, err := NewIdentity()
+	require.NoError(t, err)
+	peer := NewPeer(1, Endpoint{Host: "127.0.0.1", Port: 51235}, false, identity, nil)
+	capabilities := NewPeerCapabilities()
+	capabilities.Features.Enable(FeatureTxReduceRelay)
+	peer.capabilities = capabilities
+
+	payload, err := message.Encode(&message.Transactions{Transactions: []message.Transaction{
+		{RawTransaction: []byte{0x12, 0x00, 0x01}, Status: message.TxStatusCurrent},
+		{RawTransaction: []byte{0x12, 0x00, 0x02}, Status: message.TxStatusCurrent},
+	}})
+	require.NoError(t, err)
+	budget := newReadBudget(int64(len(payload)))
+	require.NoError(t, budget.acquire(context.Background(), nil, int64(len(payload))))
+	overlay := &Overlay{
+		cfg:        Config{EnableTxReduceRelay: true},
+		peers:      map[PeerID]*Peer{peer.ID(): peer},
+		txMessages: make(chan *InboundMessage, 2),
+	}
+	overlay.onMessageReceived(Event{
+		Type:        EventMessageReceived,
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeTransactions),
+		Payload:     payload,
+		reservation: newInboundReservation(budget, int64(len(payload))),
+	})
+
+	require.Equal(t, int64(len(payload)), readBudgetUsed(budget))
+	first := <-overlay.txMessages
+	second := <-overlay.txMessages
+	require.NoError(t, first.Close())
+	require.Equal(t, int64(len(payload)), readBudgetUsed(budget))
+	require.NoError(t, second.Close())
+	require.Zero(t, readBudgetUsed(budget))
+}
+
+func TestOverlayShutdownReleasesQueuedManifestSpool(t *testing.T) {
+	payload := bytes.Repeat([]byte{0x4d}, manifestSpoolThreshold+1)
+	var wire bytes.Buffer
+	require.NoError(t, message.WriteMessage(&wire, message.TypeManifests, payload))
+
+	spoolDir, err := prepareManifestSpoolDir(t.TempDir())
+	require.NoError(t, err)
+	budget := newReadBudget(int64(2 * len(payload)))
+	manifests := make(chan *InboundMessage, 1)
+	peer := newLatencyTestPeer(t)
+	peer.bufReader = bufio.NewReader(bytes.NewReader(wire.Bytes()))
+	peer.SetManifestMessages(manifests)
+	peer.SetInboundReadBudget(budget)
+	peer.SetManifestSpoolDir(spoolDir)
+	done := make(chan error, 1)
+	go func() { done <- peer.readLoop(context.Background()) }()
+
+	inbound := <-manifests
+	spoolPath := inbound.ManifestFrame.path
+	require.Equal(t, int64(2*len(payload)), readBudgetUsed(budget))
+
+	overlay := &Overlay{manifestMessages: manifests}
+	overlay.manifestMessages <- inbound
+	overlay.releaseQueuedInbound()
+
+	require.Zero(t, readBudgetUsed(budget))
+	_, err = os.Stat(spoolPath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.ErrorIs(t, <-done, io.EOF)
+}

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -204,7 +204,7 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 			// to the serve-worker pool — building a pack snapshots the
 			// state+tx tree (capped at fetchPackMaxObjects nodes) and
 			// must not run on the event loop.
-			o.submitServe(func() { o.serveFetchPack(evt.PeerID, gob) })
+			o.submitRetainedServe(evt, func() { o.serveFetchPack(evt.PeerID, gob) })
 			return
 		case message.ObjectTypeTransactions:
 			// Tx-reduce-relay back-fill request. Rippled gates on
@@ -220,14 +220,14 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 				o.IncPeerBadData(evt.PeerID, "get-objects-txn-unnegotiated")
 				return
 			}
-			o.submitServe(func() { o.serveDoTransactions(evt.PeerID, gob) })
+			o.submitRetainedServe(evt, func() { o.serveDoTransactions(evt.PeerID, gob) })
 			return
 		}
 
 		// Generic node-store object fetch by hash. Mirrors rippled's
 		// fetchNodeObject loop at PeerImp.cpp:2483-2538. Offloaded to the
 		// serve-worker pool — up to N node-store fetches per request.
-		o.submitServe(func() { o.serveGetObjects(evt.PeerID, gob) })
+		o.submitRetainedServe(evt, func() { o.serveGetObjects(evt.PeerID, gob) })
 		return
 	}
 
@@ -241,15 +241,22 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 	// are dropped.
 	switch gob.ObjType {
 	case message.ObjectTypeFetchPack, message.ObjectTypeStateNode, message.ObjectTypeTransactionNode:
-		o.forwardLedgerData(&InboundMessage{
-			PeerID:  evt.PeerID,
-			Type:    evt.MessageType,
-			Payload: evt.Payload,
-		})
+		o.forwardLedgerData(evt.retainedInboundMessage())
 		return
 	}
 	slog.Debug("TMGetObjects reply received without outstanding request; dropping",
 		"t", "Overlay", "peer", evt.PeerID)
+}
+
+func (o *Overlay) submitRetainedServe(evt Event, job func()) {
+	reservation := evt.reservation.retain()
+	o.submitServeJob(overlayServeJob{
+		run: func() {
+			defer reservation.release()
+			job()
+		},
+		discard: reservation.release,
+	})
 }
 
 // serveFetchPack answers an inbound mtGET_OBJECTS{otFETCH_PACK, query=true}.
@@ -789,10 +796,10 @@ func (o *Overlay) handleTransactionsBatchMessage(evt Event) {
 	// is shared with the wire path, so batch frames are subject to the
 	// same MaxTransactions ceiling and jq_trans_overflow accounting.
 	for i := range batch.Transactions {
-		o.forwardTransaction(&InboundMessage{
-			PeerID: evt.PeerID,
-			Type:   uint16(message.TypeTransaction),
-			Tx:     &batch.Transactions[i],
-		})
+		inbound := evt.retainedInboundMessage()
+		inbound.Type = uint16(message.TypeTransaction)
+		inbound.Payload = nil
+		inbound.Tx = &batch.Transactions[i]
+		o.forwardTransaction(inbound)
 	}
 }

--- a/internal/peermanagement/manifest_frame.go
+++ b/internal/peermanagement/manifest_frame.go
@@ -65,12 +65,13 @@ type ManifestFrame struct {
 	reservation   int64
 }
 
-func newManifestFrame(path string, header MessageHeader, budget *readBudget) *ManifestFrame {
+func newManifestFrame(path string, header MessageHeader, budget *readBudget, reservation int64) *ManifestFrame {
 	return &ManifestFrame{
-		path:   path,
-		header: header,
-		budget: budget,
-		done:   make(chan struct{}),
+		path:        path,
+		header:      header,
+		budget:      budget,
+		done:        make(chan struct{}),
+		reservation: reservation,
 	}
 }
 
@@ -104,35 +105,35 @@ func (f *ManifestFrame) Materialize(ctx context.Context) ([]byte, error) {
 	}
 	f.mu.Unlock()
 
-	reservation := manifestReadReservation(f.header)
-	if f.budget != nil {
-		if err := f.budget.acquire(ctx, f.done, reservation); err != nil {
-			f.mu.Lock()
-			f.materializing = false
-			closed := f.closed
-			f.mu.Unlock()
-			if closed {
-				return nil, ErrManifestFrameClosed
-			}
-			return nil, err
-		}
-	}
-
 	f.mu.Lock()
 	if f.closed {
 		f.mu.Unlock()
-		if f.budget != nil {
-			f.budget.release(reservation)
-		}
 		return nil, ErrManifestFrameClosed
 	}
-	f.reservation = reservation
-	payload, err := os.ReadFile(f.path)
+	err := ctx.Err()
+	var payload []byte
+	if err == nil {
+		payload, err = os.ReadFile(f.path)
+	}
 	if err == nil && uint32(len(payload)) != f.header.PayloadSize {
 		err = fmt.Errorf("manifest payload size: got %d, want %d", len(payload), f.header.PayloadSize)
 	}
 	if err == nil {
+		err = ctx.Err()
+	}
+	if err == nil && f.header.Compressed {
+		payload, err = DecompressLZ4(payload, int(f.header.UncompressedSize))
+	}
+	if err == nil {
+		err = ctx.Err()
+	}
+	var releaseBytes int64
+	if err == nil {
 		f.materialized = true
+		if f.header.Compressed {
+			releaseBytes = int64(f.header.PayloadSize)
+			f.reservation -= releaseBytes
+		}
 	}
 	f.materializing = false
 	f.mu.Unlock()
@@ -140,6 +141,9 @@ func (f *ManifestFrame) Materialize(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		_ = f.Close()
 		return nil, err
+	}
+	if releaseBytes > 0 && f.budget != nil {
+		f.budget.release(releaseBytes)
 	}
 	return payload, nil
 }
@@ -177,11 +181,26 @@ func (f *ManifestFrame) completion() <-chan struct{} {
 }
 
 func spoolManifestFrame(
+	ctx context.Context,
+	closeCh <-chan struct{},
 	r io.Reader,
 	header MessageHeader,
 	budget *readBudget,
 	dir string,
 ) (*ManifestFrame, error) {
+	reservation := manifestFrameReservation(header)
+	if budget != nil {
+		if err := budget.acquire(ctx, closeCh, reservation); err != nil {
+			return nil, err
+		}
+	}
+	releaseBudget := true
+	defer func() {
+		if releaseBudget && budget != nil {
+			budget.release(reservation)
+		}
+	}()
+
 	file, err := os.CreateTemp(dir, "goxrpl-manifests-*")
 	if err != nil {
 		return nil, &manifestSpoolLocalError{operation: "create manifest spool", err: err}
@@ -202,7 +221,18 @@ func spoolManifestFrame(
 		cleanup()
 		return nil, &manifestSpoolLocalError{operation: "close manifest spool", err: closeErr}
 	}
-	return newManifestFrame(path, header, budget), nil
+	releaseBudget = false
+	return newManifestFrame(path, header, budget, reservation), nil
+}
+
+func manifestFrameReservation(header MessageHeader) int64 {
+	wireBytes := int64(header.PayloadSize)
+	decodedBytes := wireBytes
+	if header.Compressed {
+		decodedBytes = int64(header.UncompressedSize)
+		return 2*wireBytes + decodedBytes
+	}
+	return wireBytes + decodedBytes
 }
 
 func copyManifestPayload(dst io.Writer, src io.Reader, size uint32) error {

--- a/internal/peermanagement/manifest_frame_test.go
+++ b/internal/peermanagement/manifest_frame_test.go
@@ -75,7 +75,7 @@ func TestOversizedManifestPeersDoNotBlockLedgerFrames(t *testing.T) {
 	manifestPayload := bytes.Repeat([]byte{0x4d}, manifestSpoolThreshold+1)
 	manifestMessages := make(chan *InboundMessage, 2)
 	acquisitionEvents := make(chan Event, 2)
-	budget := newReadBudget(int64(2 * len(manifestPayload)))
+	budget := newReadBudget(int64(4*len(manifestPayload) + 2))
 	done := make(chan error, 2)
 
 	for i := 1; i <= 2; i++ {
@@ -85,7 +85,7 @@ func TestOversizedManifestPeersDoNotBlockLedgerFrames(t *testing.T) {
 			manifestAndLedgerFrames(t, manifestPayload, []byte{byte(i)}),
 		))
 		peer.SetManifestMessages(manifestMessages)
-		peer.SetManifestReadBudget(budget)
+		peer.SetInboundReadBudget(budget)
 		peer.SetManifestSpoolDir(spoolDir)
 		peer.SetAcquisitionEvents(acquisitionEvents)
 		go func() {
@@ -106,11 +106,12 @@ func TestOversizedManifestPeersDoNotBlockLedgerFrames(t *testing.T) {
 	for range 2 {
 		event := <-acquisitionEvents
 		ledgers[event.PeerID] = event.Payload
+		event.release()
 	}
 	require.Equal(t, []byte{1}, ledgers[1])
 	require.Equal(t, []byte{2}, ledgers[2])
 	budget.mu.Lock()
-	require.Zero(t, budget.used)
+	require.Equal(t, int64(4*len(manifestPayload)), budget.used)
 	budget.mu.Unlock()
 
 	for range 2 {
@@ -140,7 +141,7 @@ func TestSecondOversizedManifestBlocksOnlyItsPeer(t *testing.T) {
 	manifestMessages := make(chan *InboundMessage, 2)
 	acquisitionEvents := make(chan Event, 2)
 	peer.SetManifestMessages(manifestMessages)
-	peer.SetManifestReadBudget(newReadBudget(int64(2 * len(manifestPayload))))
+	peer.SetInboundReadBudget(newReadBudget(int64(2*len(manifestPayload) + len("first") + len("second"))))
 	peer.SetManifestSpoolDir(spoolDir)
 	peer.SetAcquisitionEvents(acquisitionEvents)
 	var bootstrapReady atomic.Int32
@@ -155,7 +156,9 @@ func TestSecondOversizedManifestBlocksOnlyItsPeer(t *testing.T) {
 
 	first := <-manifestMessages
 	require.NotNil(t, first.ManifestFrame)
-	require.Equal(t, []byte("first"), (<-acquisitionEvents).Payload)
+	firstLedger := <-acquisitionEvents
+	require.Equal(t, []byte("first"), firstLedger.Payload)
+	firstLedger.release()
 	require.True(t, peer.bootstrapManifestPending.Load())
 	require.Zero(t, bootstrapReady.Load())
 
@@ -169,7 +172,9 @@ func TestSecondOversizedManifestBlocksOnlyItsPeer(t *testing.T) {
 	require.NoError(t, first.ManifestFrame.Close())
 	second := <-manifestMessages
 	require.NotNil(t, second.ManifestFrame)
-	require.Equal(t, []byte("second"), (<-acquisitionEvents).Payload)
+	secondLedger := <-acquisitionEvents
+	require.Equal(t, []byte("second"), secondLedger.Payload)
+	secondLedger.release()
 	require.ErrorIs(t, <-done, io.EOF)
 	require.NoError(t, second.ManifestFrame.Close())
 	require.Zero(t, bootstrapReady.Load())
@@ -198,7 +203,7 @@ func TestManifestFrameCleanupIsPrivateExactAndIdempotent(t *testing.T) {
 		MessageType:      TypeManifests,
 		UncompressedSize: 8,
 	}
-	_, err = spoolManifestFrame(bytes.NewReader([]byte("short")), header, nil, spoolDir)
+	_, err = spoolManifestFrame(context.Background(), nil, bytes.NewReader([]byte("short")), header, nil, spoolDir)
 	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 	entries, err := os.ReadDir(spoolDir)
 	require.NoError(t, err)
@@ -208,9 +213,10 @@ func TestManifestFrameCleanupIsPrivateExactAndIdempotent(t *testing.T) {
 	payload := []byte("manifest")
 	header.PayloadSize = uint32(len(payload))
 	header.UncompressedSize = uint32(len(payload))
-	budget := newReadBudget(int64(len(payload)))
-	frame, err := spoolManifestFrame(bytes.NewReader(payload), header, budget, spoolDir)
+	budget := newReadBudget(int64(2 * len(payload)))
+	frame, err := spoolManifestFrame(context.Background(), nil, bytes.NewReader(payload), header, budget, spoolDir)
 	require.NoError(t, err)
+	require.Equal(t, int64(2*len(payload)), readBudgetUsed(budget))
 	fileInfo, err := os.Stat(frame.path)
 	require.NoError(t, err)
 	require.Equal(t, os.FileMode(0o600), fileInfo.Mode().Perm())
@@ -219,7 +225,7 @@ func TestManifestFrameCleanupIsPrivateExactAndIdempotent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, payload, got)
 	budget.mu.Lock()
-	require.Equal(t, int64(len(payload)), budget.used)
+	require.Equal(t, int64(2*len(payload)), budget.used)
 	budget.mu.Unlock()
 
 	require.NoError(t, frame.Close())
@@ -240,4 +246,41 @@ func TestManifestFrameCleanupIsPrivateExactAndIdempotent(t *testing.T) {
 	budget.mu.Lock()
 	require.Zero(t, budget.used)
 	budget.mu.Unlock()
+}
+
+func TestEventReleaseClosesOwnedManifestFrame(t *testing.T) {
+	payload := []byte("manifest")
+	spoolDir := t.TempDir()
+	budget := newReadBudget(int64(2 * len(payload)))
+	header := MessageHeader{
+		PayloadSize:      uint32(len(payload)),
+		MessageType:      TypeManifests,
+		UncompressedSize: uint32(len(payload)),
+	}
+	frame, err := spoolManifestFrame(context.Background(), nil, bytes.NewReader(payload), header, budget, spoolDir)
+	require.NoError(t, err)
+	path := frame.path
+
+	event := Event{ManifestFrame: frame}
+	event.release()
+	require.Nil(t, event.ManifestFrame)
+	require.Zero(t, readBudgetUsed(budget))
+	_, err = os.Stat(path)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestInboundMessageTakesManifestFrameOwnership(t *testing.T) {
+	payload := []byte("manifest")
+	path := filepath.Join(t.TempDir(), "manifest")
+	require.NoError(t, os.WriteFile(path, payload, 0o600))
+	frame := newManifestFrame(path, MessageHeader{PayloadSize: uint32(len(payload))}, nil, 0)
+	event := Event{ManifestFrame: frame}
+
+	msg := event.inboundMessage()
+	require.Nil(t, event.ManifestFrame)
+	event.release()
+	got, err := msg.ManifestFrame.Materialize(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+	require.NoError(t, msg.Close())
 }

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -27,10 +27,20 @@ import (
 // load. Mirrors rippled bounding these behind its job queue rather than
 // the read strand.
 const (
-	serveWorkerCount        = 4
-	serveQueueDepth         = 64
-	manifestReadBudgetBytes = int64(2 * message.MaxMessageSize)
+	serveWorkerCount = 4
+	serveQueueDepth  = 64
 )
+
+type overlayServeJob struct {
+	run     func()
+	discard func()
+}
+
+func (j overlayServeJob) drop() {
+	if j.discard != nil {
+		j.discard()
+	}
+}
 
 // Overlay is the central orchestrator for XRPL peer-to-peer networking.
 // It manages peer connections, discovery, message routing, and the reduce-relay system.
@@ -137,9 +147,9 @@ type Overlay struct {
 	// manifestMessages is fed directly by peer read loops with bounded
 	// backpressure. Signature verification is intentionally isolated from both
 	// the overlay event loop and the consensus router.
-	manifestMessages   chan *InboundMessage
-	manifestReadBudget *readBudget
-	manifestSpoolDir   string
+	manifestMessages  chan *InboundMessage
+	inboundReadBudget *readBudget
+	manifestSpoolDir  string
 
 	// ledgerData carries acquisition replies (mtLEDGER_DATA, by-hash objects,
 	// and replay/proof-path responses) on a bounded backpressure path. This
@@ -154,7 +164,7 @@ type Overlay struct {
 	// preserves the synchronous behaviour unit tests rely on). Mirrors
 	// rippled offloading these to its job queue (jtPACK et al.) rather than
 	// running them on the peer read strand.
-	serveJobs chan func()
+	serveJobs chan overlayServeJob
 
 	// Peer lifecycle callbacks wired by higher layers (e.g., consensus
 	// router) that need to clean up per-peer state on disconnect. Fired
@@ -866,7 +876,7 @@ func New(opts ...Option) (*Overlay, error) {
 		messages:                 make(chan *InboundMessage, messageBufferSize(cfg.MessageBufferSize)),
 		txMessages:               make(chan *InboundMessage, txLaneBufferSize(cfg.MaxTransactions)),
 		manifestMessages:         make(chan *InboundMessage, manifestMessageBufferSize(cfg.MaxPeers)),
-		manifestReadBudget:       newReadBudget(manifestReadBudgetBytes),
+		inboundReadBudget:        newReadBudget(cfg.InboundRetainedBytes),
 		manifestSpoolDir:         manifestSpoolDir,
 		ledgerData:               make(chan *InboundMessage, DefaultLedgerDataBufferSize),
 		lifecycle:                make(chan Event, lifecycleBufferSize(&cfg)),
@@ -1067,7 +1077,7 @@ func (o *Overlay) Run(ctx context.Context) error {
 	// inbound serve work (handleGetObjectsMessage) runs off the loop. The
 	// channel is assigned before eventLoop is launched (happens-before the
 	// only reader, submitServe, which runs on the loop).
-	o.serveJobs = make(chan func(), serveQueueDepth)
+	o.serveJobs = make(chan overlayServeJob, serveQueueDepth)
 	for range serveWorkerCount {
 		g.Go(func() error { return o.serveWorker(gCtx) })
 	}
@@ -1094,7 +1104,9 @@ func (o *Overlay) Run(ctx context.Context) error {
 	// Maintenance loop (cleanup, ping, etc.).
 	g.Go(func() error { return o.maintenanceLoop(gCtx) })
 
-	return g.Wait()
+	err := g.Wait()
+	o.releaseQueuedInbound()
+	return err
 }
 
 // Stop gracefully shuts down the overlay. It is safe before Run, while Run is
@@ -1186,6 +1198,7 @@ func (o *Overlay) shutdown() {
 		if runComplete != nil {
 			<-runComplete
 		}
+		o.releaseQueuedInbound()
 
 		if o.discovery != nil {
 			o.discovery.Stop()
@@ -1200,6 +1213,41 @@ func (o *Overlay) shutdown() {
 		close(done)
 	})
 	<-done
+}
+
+func (o *Overlay) releaseQueuedInbound() {
+	drainEvents := func(events <-chan Event) {
+		for {
+			select {
+			case evt := <-events:
+				evt.release()
+			default:
+				return
+			}
+		}
+	}
+	drainMessages := func(messages <-chan *InboundMessage) {
+		for {
+			select {
+			case msg := <-messages:
+				_ = msg.Close()
+			default:
+				return
+			}
+		}
+	}
+
+	drainEvents(o.events)
+	drainEvents(o.consensusEvents)
+	drainEvents(o.consensusControlEvents)
+	drainEvents(o.acquisitionEvents)
+	drainMessages(o.consensusMessages)
+	drainMessages(o.consensusControlMessages)
+	drainMessages(o.messages)
+	drainMessages(o.txMessages)
+	drainMessages(o.manifestMessages)
+	drainMessages(o.ledgerData)
+	o.discardServeJobs()
 }
 
 // eventLoop processes internal events. It drains both the dedicated
@@ -1259,28 +1307,44 @@ func (o *Overlay) serveWorker(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
+			o.discardServeJobs()
 			return ctx.Err()
 		case job := <-o.serveJobs:
-			job()
+			job.run()
 		}
 	}
 }
 
-// submitServe hands a heavy serve job to the worker pool. When the overlay
-// was built without Run (no pool — most unit tests), it runs the job
-// inline to preserve synchronous behaviour. On a saturated queue it sheds
-// the job and bumps droppedServeJobs: the requesting peer's query goes
-// unanswered and it retries elsewhere.
-func (o *Overlay) submitServe(job func()) {
+func (o *Overlay) submitServeJob(job overlayServeJob) bool {
 	if o.serveJobs == nil {
-		job()
-		return
+		job.run()
+		return true
+	}
+	select {
+	case <-o.runDone:
+		job.drop()
+		return false
+	default:
 	}
 	select {
 	case o.serveJobs <- job:
+		return true
 	default:
+		job.drop()
 		o.droppedServeJobs.Add(1)
 		slog.Debug("serve job dropped: worker pool saturated", "t", "Overlay")
+		return false
+	}
+}
+
+func (o *Overlay) discardServeJobs() {
+	for {
+		select {
+		case job := <-o.serveJobs:
+			job.drop()
+		default:
+			return
+		}
 	}
 }
 

--- a/internal/peermanagement/overlay_inbound.go
+++ b/internal/peermanagement/overlay_inbound.go
@@ -238,7 +238,7 @@ func (o *Overlay) handleInbound(ctx context.Context, conn net.Conn) {
 	peer.SetConsensusControlEvents(o.consensusControlEvents)
 	peer.SetAcquisitionEvents(o.acquisitionEvents)
 	peer.SetManifestMessages(o.manifestMessages)
-	peer.SetManifestReadBudget(o.manifestReadBudget)
+	peer.SetInboundReadBudget(o.inboundReadBudget)
 	peer.SetManifestSpoolDir(o.manifestSpoolDir)
 	if !o.reserveInboundIP(endpoint.Host) {
 		slog.Info("Inbound rejected: IP connection limit reached",

--- a/internal/peermanagement/overlay_message.go
+++ b/internal/peermanagement/overlay_message.go
@@ -96,6 +96,7 @@ func (o *Overlay) onPeerFailed(evt Event) {
 }
 
 func (o *Overlay) onMessageReceived(evt Event) {
+	defer evt.release()
 	msgType := message.MessageType(evt.MessageType)
 
 	// Record reduce-relay traffic metrics before dispatch: counted on
@@ -221,48 +222,30 @@ func (o *Overlay) onMessageReceived(evt Event) {
 	slog.Debug("Message received", "t", "Overlay", "type", msgType.String(), "peer", evt.PeerID, "size", len(evt.Payload))
 
 	if msgType == message.TypeTransaction {
-		o.forwardTransaction(&InboundMessage{
-			PeerID:  evt.PeerID,
-			Type:    evt.MessageType,
-			Payload: evt.Payload,
-		})
+		o.forwardTransaction(evt.inboundMessage())
 		return
 	}
 
 	switch msgType {
 	case message.TypeLedgerData, message.TypeReplayDeltaResponse, message.TypeProofPathResponse:
-		o.forwardLedgerData(&InboundMessage{
-			PeerID:  evt.PeerID,
-			Type:    evt.MessageType,
-			Payload: evt.Payload,
-		})
+		o.forwardLedgerData(evt.inboundMessage())
 		return
 	}
 
 	if isConsensusPriorityMessageType(msgType) {
-		o.forwardConsensus(&InboundMessage{
-			PeerID:  evt.PeerID,
-			Type:    evt.MessageType,
-			Payload: evt.Payload,
-		})
+		o.forwardConsensus(evt.inboundMessage())
 		return
 	}
 	if isConsensusControlMessageType(msgType) {
-		o.forwardConsensusControl(&InboundMessage{
-			PeerID:  evt.PeerID,
-			Type:    evt.MessageType,
-			Payload: evt.Payload,
-		})
+		o.forwardConsensusControl(evt.inboundMessage())
 		return
 	}
 
+	msg := evt.inboundMessage()
 	select {
-	case o.messages <- &InboundMessage{
-		PeerID:  evt.PeerID,
-		Type:    evt.MessageType,
-		Payload: evt.Payload,
-	}:
+	case o.messages <- msg:
 	default:
+		_ = msg.Close()
 		o.droppedMessages.Add(1)
 		slog.Warn("Message dropped: channel full", "t", "Overlay", "type", msgType.String())
 		if msgType == message.TypeManifests {
@@ -273,23 +256,29 @@ func (o *Overlay) onMessageReceived(evt Event) {
 
 func (o *Overlay) forwardConsensus(msg *InboundMessage) {
 	if o.consensusMessages == nil {
+		_ = msg.Close()
 		return
 	}
 	select {
 	case o.consensusMessages <- msg:
 	case <-o.stopCh:
+		_ = msg.Close()
 	case <-o.runDone:
+		_ = msg.Close()
 	}
 }
 
 func (o *Overlay) forwardConsensusControl(msg *InboundMessage) {
 	if o.consensusControlMessages == nil {
+		_ = msg.Close()
 		return
 	}
 	select {
 	case o.consensusControlMessages <- msg:
 	case <-o.stopCh:
+		_ = msg.Close()
 	case <-o.runDone:
+		_ = msg.Close()
 	}
 }
 
@@ -303,6 +292,7 @@ func (o *Overlay) forwardTransaction(msg *InboundMessage) {
 	select {
 	case o.txMessages <- msg:
 	default:
+		_ = msg.Close()
 		// Counted via droppedTransactions (jq_trans_overflow); log at Debug so a
 		// shed storm under load cannot itself flood the single log writer.
 		o.droppedTransactions.Add(1)
@@ -323,12 +313,15 @@ func (o *Overlay) DroppedTransactions() uint64 {
 // of discarding a reply needed to complete catch-up.
 func (o *Overlay) forwardLedgerData(msg *InboundMessage) {
 	if o.ledgerData == nil {
+		_ = msg.Close()
 		return
 	}
 	select {
 	case o.ledgerData <- msg:
 	case <-o.stopCh:
+		_ = msg.Close()
 	case <-o.runDone:
+		_ = msg.Close()
 	}
 }
 

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -86,7 +86,7 @@ func (o *Overlay) connectReserved(addr string, bootstrapLease *bootstrapLease) e
 	peer.SetConsensusControlEvents(o.consensusControlEvents)
 	peer.SetAcquisitionEvents(o.acquisitionEvents)
 	peer.SetManifestMessages(o.manifestMessages)
-	peer.SetManifestReadBudget(o.manifestReadBudget)
+	peer.SetInboundReadBudget(o.inboundReadBudget)
 	peer.SetManifestSpoolDir(o.manifestSpoolDir)
 	peer.handshakeCfg = o.handshakeConfigFor()
 	peer.onRedirect = func(peerIPs []string) {

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -100,7 +100,7 @@ type Peer struct {
 	consensusControlEvents chan<- Event
 	acquisitionEvents      chan<- Event
 	manifestMessages       chan<- *InboundMessage
-	manifestReadBudget     *readBudget
+	inboundReadBudget      *readBudget
 	manifestSpoolDir       string
 
 	// droppedEvents counts non-blocking event sends that fell through
@@ -298,15 +298,22 @@ func (p *Peer) SetManifestMessages(messages chan<- *InboundMessage) {
 	p.manifestMessages = messages
 }
 
-func (p *Peer) SetManifestReadBudget(budget *readBudget) {
-	p.manifestReadBudget = budget
+func (p *Peer) SetInboundReadBudget(budget *readBudget) {
+	p.inboundReadBudget = budget
 }
 
 func (p *Peer) SetManifestSpoolDir(dir string) {
 	p.manifestSpoolDir = dir
 }
 
-func manifestReadReservation(header MessageHeader) int64 {
+func isInboundBulkMessageType(msgType message.MessageType) bool {
+	return !message.IsKnownMessageType(msgType) || message.MaxPayloadSizeForType(msgType) > 64*1024
+}
+
+func inboundFrameReservation(header MessageHeader) int64 {
+	if !isInboundBulkMessageType(header.MessageType) {
+		return 0
+	}
 	size := int64(header.PayloadSize)
 	if header.Compressed {
 		size += int64(header.UncompressedSize)
@@ -319,15 +326,12 @@ func manifestReadReservation(header MessageHeader) int64 {
 // peer releases a read loop waiting for capacity.
 func (p *Peer) dispatchEvent(evt Event) bool {
 	if evt.Type == EventMessageReceived && message.MessageType(evt.MessageType) == message.TypeManifests && p.manifestMessages != nil {
+		msg := evt.inboundMessage()
 		select {
-		case p.manifestMessages <- &InboundMessage{
-			PeerID:        evt.PeerID,
-			Type:          evt.MessageType,
-			Payload:       evt.Payload,
-			ManifestFrame: evt.ManifestFrame,
-		}:
+		case p.manifestMessages <- msg:
 			return true
 		case <-p.closeCh:
+			_ = msg.Close()
 			return false
 		}
 	}
@@ -336,6 +340,7 @@ func (p *Peer) dispatchEvent(evt Event) bool {
 		case p.consensusEvents <- evt:
 			return true
 		case <-p.closeCh:
+			evt.release()
 			return false
 		}
 	}
@@ -344,6 +349,7 @@ func (p *Peer) dispatchEvent(evt Event) bool {
 		case p.consensusControlEvents <- evt:
 			return true
 		case <-p.closeCh:
+			evt.release()
 			return false
 		}
 	}
@@ -352,16 +358,19 @@ func (p *Peer) dispatchEvent(evt Event) bool {
 		case p.acquisitionEvents <- evt:
 			return true
 		case <-p.closeCh:
+			evt.release()
 			return false
 		}
 	}
 	if p.events == nil {
+		evt.release()
 		return false
 	}
 	select {
 	case p.events <- evt:
 		return true
 	default:
+		evt.release()
 		if p.droppedEvents != nil {
 			p.droppedEvents.Add(1)
 		}
@@ -1178,9 +1187,8 @@ func (p *Peer) readLoop(ctx context.Context) error {
 		header, err := readMessageHeader(frameReader)
 		if err == nil &&
 			header.MessageType == TypeManifests &&
-			!header.Compressed &&
 			p.manifestSpoolDir != "" &&
-			header.PayloadSize > manifestSpoolThreshold {
+			(header.PayloadSize > manifestSpoolThreshold || header.UncompressedSize > manifestSpoolThreshold) {
 			if outstandingManifest != nil {
 				select {
 				case <-outstandingManifest:
@@ -1197,9 +1205,11 @@ func (p *Peer) readLoop(ctx context.Context) error {
 			frameReader.startedAt = p.readPolicy.now()
 			_ = frameReader.setHeader(*header)
 			manifestFrame, spoolErr := spoolManifestFrame(
+				ctx,
+				p.closeCh,
 				frameReader,
 				*header,
-				p.manifestReadBudget,
+				p.inboundReadBudget,
 				p.manifestSpoolDir,
 			)
 			now := p.readPolicy.now()
@@ -1218,7 +1228,11 @@ func (p *Peer) readLoop(ctx context.Context) error {
 			}
 
 			payloadWireSize := uint64(header.PayloadSize)
-			p.metrics.recv.addMessage(payloadWireSize + HeaderSizeUncompressed)
+			headerSize := uint64(HeaderSizeUncompressed)
+			if header.Compressed {
+				headerSize = HeaderSizeCompressed
+			}
+			p.metrics.recv.addMessage(payloadWireSize + headerSize)
 			p.bootstrapManifest.Store(true)
 			p.traffic.AddCount(CategorizeMessage(uint16(header.MessageType)), true, int(header.PayloadSize))
 
@@ -1243,14 +1257,14 @@ func (p *Peer) readLoop(ctx context.Context) error {
 			continue
 		}
 
-		var manifestReservation int64
+		var retainedReservation int64
 		if err == nil {
-			if header.MessageType == TypeManifests && p.manifestReadBudget != nil {
-				reservation := manifestReadReservation(*header)
-				if acquireErr := p.manifestReadBudget.acquire(ctx, p.closeCh, reservation); acquireErr != nil {
+			if p.inboundReadBudget != nil {
+				reservation := inboundFrameReservation(*header)
+				if acquireErr := p.inboundReadBudget.acquire(ctx, p.closeCh, reservation); acquireErr != nil {
 					err = acquireErr
 				} else {
-					manifestReservation = reservation
+					retainedReservation = reservation
 					frameReader.startedAt = p.readPolicy.now()
 				}
 			}
@@ -1258,10 +1272,10 @@ func (p *Peer) readLoop(ctx context.Context) error {
 				_ = frameReader.setHeader(*header)
 			}
 		}
-		releaseManifestReservation := func() {
-			if manifestReservation > 0 {
-				p.manifestReadBudget.release(manifestReservation)
-				manifestReservation = 0
+		releaseRetainedReservation := func() {
+			if retainedReservation > 0 {
+				p.inboundReadBudget.release(retainedReservation)
+				retainedReservation = 0
 			}
 		}
 		var payload []byte
@@ -1274,7 +1288,7 @@ func (p *Peer) readLoop(ctx context.Context) error {
 		}
 		frameReader.finish(err == nil, now)
 		if err != nil {
-			releaseManifestReservation()
+			releaseRetainedReservation()
 			if p.closed.Load() {
 				return nil
 			}
@@ -1318,13 +1332,13 @@ func (p *Peer) readLoop(ctx context.Context) error {
 			// protocol violation — charge and tear the connection down.
 			if !p.compressionNegotiated() {
 				p.IncBadData("compression-unnegotiated")
-				releaseManifestReservation()
+				releaseRetainedReservation()
 				return fmt.Errorf("peer sent a compressed frame without negotiating compression")
 			}
 		}
 
 		if !message.IsKnownMessageType(header.MessageType) {
-			releaseManifestReservation()
+			releaseRetainedReservation()
 			continue
 		}
 		if header.MessageType == TypeManifests {
@@ -1336,18 +1350,22 @@ func (p *Peer) readLoop(ctx context.Context) error {
 			if err != nil {
 				p.IncBadData("decompress-lz4-failed")
 				if header.MessageType == TypeManifests && p.onBootstrapReady != nil {
-					releaseManifestReservation()
+					releaseRetainedReservation()
 					return fmt.Errorf("bootstrap manifests decompression failed: %w", err)
 				}
 				if p.consecutiveDecompressFailures.Add(1) >= maxConsecutiveDecompressFailures {
-					releaseManifestReservation()
+					releaseRetainedReservation()
 					return fmt.Errorf("decompress-lz4 failed %d times in a row: %w",
 						maxConsecutiveDecompressFailures, err)
 				}
-				releaseManifestReservation()
+				releaseRetainedReservation()
 				continue
 			}
 			p.consecutiveDecompressFailures.Store(0)
+			if retainedReservation > 0 {
+				p.inboundReadBudget.release(int64(header.PayloadSize))
+				retainedReservation -= int64(header.PayloadSize)
+			}
 		}
 		p.traffic.AddCount(CategorizeMessage(uint16(header.MessageType)), true, len(payload))
 
@@ -1357,8 +1375,9 @@ func (p *Peer) readLoop(ctx context.Context) error {
 			MessageType: uint16(header.MessageType),
 			Payload:     payload,
 			WireSize:    payloadWireSize,
+			reservation: newInboundReservation(p.inboundReadBudget, retainedReservation),
 		})
-		releaseManifestReservation()
+		retainedReservation = 0
 		if !delivered && header.MessageType == TypeManifests && p.onBootstrapReady != nil {
 			return errBootstrapManifestDropped
 		}

--- a/internal/peermanagement/peer_frame_liveness_test.go
+++ b/internal/peermanagement/peer_frame_liveness_test.go
@@ -214,7 +214,7 @@ func TestPeerManifestReadBudgetBoundsPayloadAllocation(t *testing.T) {
 	first := newLatencyTestPeer(t)
 	first.bufReader = bufio.NewReader(bytes.NewReader(frame))
 	first.SetManifestMessages(firstQueue)
-	first.SetManifestReadBudget(budget)
+	first.SetInboundReadBudget(budget)
 	firstDone := make(chan error, 1)
 	go func() { firstDone <- first.readLoop(context.Background()) }()
 	require.Eventually(t, func() bool {
@@ -228,7 +228,7 @@ func TestPeerManifestReadBudgetBoundsPayloadAllocation(t *testing.T) {
 	second := newLatencyTestPeer(t)
 	second.bufReader = bufio.NewReader(secondReader)
 	second.SetManifestMessages(secondQueue)
-	second.SetManifestReadBudget(budget)
+	second.SetInboundReadBudget(budget)
 	secondDone := make(chan error, 1)
 	go func() { secondDone <- second.readLoop(context.Background()) }()
 
@@ -236,9 +236,14 @@ func TestPeerManifestReadBudgetBoundsPayloadAllocation(t *testing.T) {
 	time.Sleep(25 * time.Millisecond)
 	require.Less(t, secondReader.read.Load(), int64(len(frame)))
 
-	<-firstQueue
+	queued := <-firstQueue
+	require.NoError(t, queued.Close())
+	firstInbound := <-firstQueue
+	require.NoError(t, firstInbound.Close())
 	require.Eventually(t, func() bool { return secondReader.read.Load() == int64(len(frame)) }, time.Second, time.Millisecond)
-	require.Equal(t, payload, (<-secondQueue).Payload)
+	secondInbound := <-secondQueue
+	require.Equal(t, payload, secondInbound.Payload)
+	require.NoError(t, secondInbound.Close())
 	require.ErrorIs(t, <-firstDone, io.EOF)
 	require.ErrorIs(t, <-secondDone, io.EOF)
 }

--- a/internal/peermanagement/read_budget.go
+++ b/internal/peermanagement/read_budget.go
@@ -3,9 +3,49 @@ package peermanagement
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 )
+
+type inboundReservation struct {
+	budget *readBudget
+	size   int64
+	refs   atomic.Int64
+}
+
+func newInboundReservation(budget *readBudget, size int64) *inboundReservation {
+	if budget == nil || size <= 0 {
+		return nil
+	}
+	r := &inboundReservation{budget: budget, size: size}
+	r.refs.Store(1)
+	return r
+}
+
+func (r *inboundReservation) retain() *inboundReservation {
+	if r == nil {
+		return nil
+	}
+	for {
+		refs := r.refs.Load()
+		if refs <= 0 {
+			return nil
+		}
+		if r.refs.CompareAndSwap(refs, refs+1) {
+			return r
+		}
+	}
+}
+
+func (r *inboundReservation) release() {
+	if r == nil {
+		return
+	}
+	if r.refs.Add(-1) == 0 {
+		r.budget.release(r.size)
+	}
+}
 
 type readBudget struct {
 	mu       sync.Mutex
@@ -51,6 +91,10 @@ func (b *readBudget) release(size int64) {
 	}
 	b.mu.Lock()
 	b.used -= size
+	if b.used < 0 {
+		b.mu.Unlock()
+		panic("peermanagement: inbound read budget released below zero")
+	}
 	wake := b.wake
 	b.wake = make(chan struct{})
 	close(wake)


### PR DESCRIPTION
Part of #1472. Stack PR 4/11.\n\nApplies a shared byte budget across wire, decoded, queued, and spooled bulk frames, with complete release and spool cleanup semantics.