### PR TITLE
fix: make peer serving bounded and fair (#1472)

### DIFF
--- a/internal/peermanagement/get_objects_serve_test.go
+++ b/internal/peermanagement/get_objects_serve_test.go
@@ -40,6 +40,27 @@ func newServeTestPeer(t *testing.T, id PeerID) *Peer {
 	return NewPeer(id, endpoint, true, identity, make(chan Event, 1))
 }
 
+func TestServeReplyBudget(t *testing.T) {
+	budget := serveReplyBudget{remaining: 10}
+	require.True(t, budget.reserve(2, []byte{1, 2, 3}, []byte{4}))
+	require.Equal(t, int64(4), budget.remaining)
+	require.False(t, budget.reserve(2, []byte{1, 2, 3}))
+	require.Equal(t, int64(4), budget.remaining)
+	require.True(t, budget.reserve(4))
+	require.Zero(t, budget.remaining)
+}
+
+func TestLimitIndexedObjectsToReplyBudgetReleasesTail(t *testing.T) {
+	objects := []message.IndexedObject{
+		{Hash: []byte{1}, Data: []byte{2}},
+		{Hash: []byte{3}, Data: make([]byte, message.MaxMessageSize)},
+	}
+	limited := limitIndexedObjectsToReplyBudget(objects)
+	require.Len(t, limited, 1)
+	require.Nil(t, objects[1].Hash)
+	require.Nil(t, objects[1].Data)
+}
+
 // TestServeGetObjects_FetchesAndReplies covers the happy path of the
 // generic TMGetObjectByHash serve branch (rippled PeerImp.cpp:2483-2538):
 // found hashes are packed into a query=false reply echoing the request's

--- a/internal/peermanagement/inbound_budget_test.go
+++ b/internal/peermanagement/inbound_budget_test.go
@@ -173,23 +173,30 @@ func TestGetObjectsQueryRetainsBudgetUntilServeCompletion(t *testing.T) {
 
 	budget := newReadBudget(int64(len(payload)))
 	require.NoError(t, budget.acquire(context.Background(), nil, int64(len(payload))))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler := newServeScheduler(ctx, 1, 1, 1, 1)
+	peer := newLatencyTestPeer(t)
 	overlay := &Overlay{
-		cfg:       DefaultConfig(),
-		peers:     make(map[PeerID]*Peer),
-		serveJobs: make(chan overlayServeJob, 1),
-		runDone:   make(chan struct{}),
+		cfg:            DefaultConfig(),
+		peers:          map[PeerID]*Peer{peer.ID(): peer},
+		serveScheduler: scheduler,
+		ctx:            ctx,
+		lifecycleState: overlayLifecycleRunning,
 	}
 	overlay.onMessageReceived(Event{
 		Type:        EventMessageReceived,
-		PeerID:      1,
+		PeerID:      peer.ID(),
 		MessageType: uint16(message.TypeGetObjects),
 		Payload:     payload,
 		reservation: newInboundReservation(budget, int64(len(payload))),
 	})
 
 	require.Equal(t, int64(len(payload)), readBudgetUsed(budget))
-	job := <-overlay.serveJobs
-	job.run()
+	task, ok := scheduler.take(ctx)
+	require.True(t, ok)
+	task.run(task.ctx)
+	scheduler.finish(task)
 	require.Zero(t, readBudgetUsed(budget))
 }
 
@@ -199,17 +206,21 @@ func TestDroppedGetObjectsQueryReleasesBudget(t *testing.T) {
 
 	budget := newReadBudget(int64(len(payload)))
 	require.NoError(t, budget.acquire(context.Background(), nil, int64(len(payload))))
-	jobs := make(chan overlayServeJob, 1)
-	jobs <- overlayServeJob{run: func() {}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler := newServeScheduler(ctx, 1, 1, 1, 1)
+	peer := newLatencyTestPeer(t)
+	require.True(t, scheduler.Submit(ctx, peer.ID(), func(context.Context) {}))
 	overlay := &Overlay{
-		cfg:       DefaultConfig(),
-		peers:     make(map[PeerID]*Peer),
-		serveJobs: jobs,
-		runDone:   make(chan struct{}),
+		cfg:            DefaultConfig(),
+		peers:          map[PeerID]*Peer{peer.ID(): peer},
+		serveScheduler: scheduler,
+		ctx:            ctx,
+		lifecycleState: overlayLifecycleRunning,
 	}
 	overlay.onMessageReceived(Event{
 		Type:        EventMessageReceived,
-		PeerID:      1,
+		PeerID:      peer.ID(),
 		MessageType: uint16(message.TypeGetObjects),
 		Payload:     payload,
 		reservation: newInboundReservation(budget, int64(len(payload))),
@@ -225,22 +236,57 @@ func TestServeShutdownReleasesQueuedDecodedBudget(t *testing.T) {
 
 	budget := newReadBudget(int64(len(payload)))
 	require.NoError(t, budget.acquire(context.Background(), nil, int64(len(payload))))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler := newServeScheduler(ctx, 1, 1, 1, 1)
+	peer := newLatencyTestPeer(t)
 	overlay := &Overlay{
-		cfg:       DefaultConfig(),
-		peers:     make(map[PeerID]*Peer),
-		serveJobs: make(chan overlayServeJob, 1),
-		runDone:   make(chan struct{}),
+		cfg:            DefaultConfig(),
+		peers:          map[PeerID]*Peer{peer.ID(): peer},
+		serveScheduler: scheduler,
+		ctx:            ctx,
+		lifecycleState: overlayLifecycleRunning,
 	}
 	overlay.onMessageReceived(Event{
 		Type:        EventMessageReceived,
-		PeerID:      1,
+		PeerID:      peer.ID(),
 		MessageType: uint16(message.TypeGetObjects),
 		Payload:     payload,
 		reservation: newInboundReservation(budget, int64(len(payload))),
 	})
 	require.Equal(t, int64(len(payload)), readBudgetUsed(budget))
 
-	overlay.discardServeJobs()
+	scheduler.close()
+	require.Zero(t, readBudgetUsed(budget))
+}
+
+func TestServePeerCancellationReleasesQueuedDecodedBudget(t *testing.T) {
+	payload, err := message.Encode(&message.GetObjectByHash{Query: true})
+	require.NoError(t, err)
+
+	budget := newReadBudget(int64(len(payload)))
+	require.NoError(t, budget.acquire(context.Background(), nil, int64(len(payload))))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler := newServeScheduler(ctx, 1, 1, 1, 1)
+	peer := newLatencyTestPeer(t)
+	overlay := &Overlay{
+		cfg:            DefaultConfig(),
+		peers:          map[PeerID]*Peer{peer.ID(): peer},
+		serveScheduler: scheduler,
+		ctx:            ctx,
+		lifecycleState: overlayLifecycleRunning,
+	}
+	overlay.onMessageReceived(Event{
+		Type:        EventMessageReceived,
+		PeerID:      peer.ID(),
+		MessageType: uint16(message.TypeGetObjects),
+		Payload:     payload,
+		reservation: newInboundReservation(budget, int64(len(payload))),
+	})
+	require.Equal(t, int64(len(payload)), readBudgetUsed(budget))
+
+	scheduler.CancelPeer(peer.ID())
 	require.Zero(t, readBudgetUsed(budget))
 }
 

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -5,11 +5,13 @@
 package peermanagement
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"math/rand/v2"
 	"net"
 	"strconv"
+	"sync"
 	"time"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
@@ -25,6 +27,55 @@ import (
 // go-xrpl refuses new work before peer.Send returns
 // ErrSendBufferFull.
 const peerSendQueueDropThreshold = (DefaultSendBufferSize * 3) / 4
+
+const (
+	// These allowances exceed the protobuf tags, lengths, and repeated-message
+	// envelope for one reply item, keeping the pre-marshal budget conservative.
+	serveReplyObjectOverhead      = int64(64)
+	serveReplyTransactionOverhead = int64(32)
+)
+
+type serveReplyBudget struct {
+	remaining int64
+}
+
+func newServeReplyBudget() serveReplyBudget {
+	return serveReplyBudget{remaining: int64(message.MaxMessageSize)}
+}
+
+func (b *serveReplyBudget) reserve(overhead int64, fields ...[]byte) bool {
+	if overhead < 0 || overhead > b.remaining {
+		return false
+	}
+	required := overhead
+	for _, field := range fields {
+		if int64(len(field)) > b.remaining-required {
+			return false
+		}
+		required += int64(len(field))
+	}
+	b.remaining -= required
+	return true
+}
+
+func limitIndexedObjectsToReplyBudget(objects []message.IndexedObject, fixedFields ...[]byte) []message.IndexedObject {
+	budget := newServeReplyBudget()
+	if !budget.reserve(serveReplyObjectOverhead, fixedFields...) {
+		clear(objects)
+		return objects[:0]
+	}
+	kept := 0
+	for i := range objects {
+		object := &objects[i]
+		if !budget.reserve(serveReplyObjectOverhead, object.Hash, object.NodeID, object.Index, object.Data) {
+			break
+		}
+		objects[kept] = *object
+		kept++
+	}
+	clear(objects[kept:])
+	return objects[:kept]
+}
 
 // handleClusterMessage processes mtCLUSTER from a peer. Mirrors rippled
 // PeerImp::onMessage(TMCluster) at PeerImp.cpp:1125-1194.
@@ -198,13 +249,18 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 		}
 		switch gob.ObjType {
 		case message.ObjectTypeFetchPack:
+			if len(gob.LedgerHash) != 32 {
+				o.IncPeerBadData(evt.PeerID, "fetch-pack-bad-hash")
+				return
+			}
 			// Rippled at PeerImp.cpp:2458-2462 forwards to doFetchPack.
 			// Build a pack of the predecessor ledger's SHAMap nodes and
 			// reply (serveFetchPack), mirroring makeFetchPack. Offloaded
 			// to the serve-worker pool — building a pack snapshots the
 			// state+tx tree (capped at fetchPackMaxObjects nodes) and
 			// must not run on the event loop.
-			o.submitRetainedServe(evt, func() { o.serveFetchPack(evt.PeerID, gob) })
+			o.submitRetainedServe(evt, resource.FeeHeavyBurdenPeer,
+				func(ctx context.Context) { o.serveFetchPackContext(ctx, evt.PeerID, gob) })
 			return
 		case message.ObjectTypeTransactions:
 			// Tx-reduce-relay back-fill request. Rippled gates on
@@ -220,14 +276,26 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 				o.IncPeerBadData(evt.PeerID, "get-objects-txn-unnegotiated")
 				return
 			}
-			o.submitRetainedServe(evt, func() { o.serveDoTransactions(evt.PeerID, gob) })
+			o.submitRetainedServe(evt, resource.FeeModerateBurdenPeer,
+				func(ctx context.Context) { o.serveDoTransactionsContext(ctx, evt.PeerID, gob) })
 			return
 		}
 
 		// Generic node-store object fetch by hash. Mirrors rippled's
 		// fetchNodeObject loop at PeerImp.cpp:2483-2538. Offloaded to the
 		// serve-worker pool — up to N node-store fetches per request.
-		o.submitRetainedServe(evt, func() { o.serveGetObjects(evt.PeerID, gob) })
+		if len(gob.LedgerHash) != 0 && len(gob.LedgerHash) != 32 {
+			o.IncPeerBadData(evt.PeerID, "get-objects-ledgerhash")
+			return
+		}
+		if len(gob.Objects) > hardMaxReplyNodes {
+			if peer, ok := o.getPeer(evt.PeerID); ok {
+				peer.Charge(resource.FeeInvalidData, "oversized get object request")
+			}
+			return
+		}
+		o.submitRetainedServe(evt, resource.FeeModerateBurdenPeer,
+			func(ctx context.Context) { o.serveGetObjectsContext(ctx, evt.PeerID, gob) })
 		return
 	}
 
@@ -248,15 +316,20 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 		"t", "Overlay", "peer", evt.PeerID)
 }
 
-func (o *Overlay) submitRetainedServe(evt Event, job func()) {
+func (o *Overlay) submitRetainedServe(
+	evt Event,
+	admission resource.Charge,
+	job func(context.Context),
+) {
 	reservation := evt.reservation.retain()
-	o.submitServeJob(overlayServeJob{
-		run: func() {
-			defer reservation.release()
-			job()
-		},
-		discard: reservation.release,
-	})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(reservation.release) }
+	if !o.submitServeForPeerOwned(evt.PeerID, admission, func(ctx context.Context) {
+		defer release()
+		job(ctx)
+	}, release) {
+		release()
+	}
 }
 
 // serveFetchPack answers an inbound mtGET_OBJECTS{otFETCH_PACK, query=true}.
@@ -274,6 +347,18 @@ func (o *Overlay) submitRetainedServe(evt Event, job func()) {
 // so the send-queue back-pressure gate in handleGetObjectsMessage stands in for
 // rippled's isLoadedLocal / jtPACK busy guards (PeerImp.cpp:2758-2762).
 func (o *Overlay) serveFetchPack(peerID PeerID, req *message.GetObjectByHash) {
+	if len(req.LedgerHash) == 32 {
+		if peer, ok := o.getPeer(peerID); ok {
+			peer.Charge(resource.FeeHeavyBurdenPeer, "fetch pack request")
+		}
+	}
+	o.serveFetchPackContext(context.Background(), peerID, req)
+}
+
+func (o *Overlay) serveFetchPackContext(ctx context.Context, peerID PeerID, req *message.GetObjectByHash) {
+	if err := ctx.Err(); err != nil {
+		return
+	}
 	if len(req.LedgerHash) != 32 {
 		o.IncPeerBadData(peerID, "fetch-pack-bad-hash")
 		return
@@ -283,8 +368,6 @@ func (o *Overlay) serveFetchPack(peerID PeerID, req *message.GetObjectByHash) {
 	if !exists {
 		return
 	}
-	peer.Charge(resource.FeeHeavyBurdenPeer, "fetch pack request")
-
 	var haveHash [32]byte
 	copy(haveHash[:], req.LedgerHash)
 
@@ -301,6 +384,10 @@ func (o *Overlay) serveFetchPack(peerID PeerID, req *message.GetObjectByHash) {
 	if len(objects) == 0 {
 		return
 	}
+	objects = limitIndexedObjectsToReplyBudget(objects, req.LedgerHash)
+	if len(objects) == 0 {
+		return
+	}
 
 	reply := &message.GetObjectByHash{
 		ObjType:    message.ObjectTypeFetchPack,
@@ -308,7 +395,10 @@ func (o *Overlay) serveFetchPack(peerID PeerID, req *message.GetObjectByHash) {
 		LedgerHash: append([]byte(nil), req.LedgerHash...),
 		Objects:    objects,
 	}
-	encodeAndSend(peer, reply, "fetch-pack reply")
+	if ctx.Err() != nil {
+		return
+	}
+	encodeAndSendPriority(peer, reply, "fetch-pack reply")
 }
 
 // handleHaveTransactionsMessage processes mtHAVE_TRANSACTIONS from a
@@ -547,6 +637,13 @@ func (o *Overlay) handleEndpointsMessage(evt Event) {
 // rippled — we treat them as "skip", matching the more permissive
 // go-xrpl stance that the peer may legitimately be a hop ahead.
 func (o *Overlay) serveDoTransactions(peerID PeerID, req *message.GetObjectByHash) {
+	o.serveDoTransactionsContext(context.Background(), peerID, req)
+}
+
+func (o *Overlay) serveDoTransactionsContext(ctx context.Context, peerID PeerID, req *message.GetObjectByHash) {
+	if err := ctx.Err(); err != nil {
+		return
+	}
 	const maxQueueSize = 64 // matches rippled reduce_relay::MAX_TX_QUEUE_SIZE
 	if len(req.Objects) == 0 {
 		return
@@ -566,7 +663,11 @@ func (o *Overlay) serveDoTransactions(peerID PeerID, req *message.GetObjectByHas
 	reply := &message.Transactions{
 		Transactions: make([]message.Transaction, 0, len(req.Objects)),
 	}
+	budget := newServeReplyBudget()
 	for _, obj := range req.Objects {
+		if ctx.Err() != nil {
+			return
+		}
 		if len(obj.Hash) != 32 {
 			o.IncPeerBadData(peerID, "get-objects-txn-hashsize")
 			return
@@ -576,6 +677,9 @@ func (o *Overlay) serveDoTransactions(peerID PeerID, req *message.GetObjectByHas
 		blob, ok := txProvider(hash)
 		if !ok {
 			continue
+		}
+		if !budget.reserve(serveReplyTransactionOverhead, blob) {
+			break
 		}
 		reply.Transactions = append(reply.Transactions, message.Transaction{
 			RawTransaction:   blob,
@@ -591,7 +695,7 @@ func (o *Overlay) serveDoTransactions(peerID PeerID, req *message.GetObjectByHas
 	if !exists {
 		return
 	}
-	encodeAndSend(peer, reply, "TMTransactions reply")
+	encodeAndSendPriority(peer, reply, "TMTransactions reply")
 }
 
 // hardMaxReplyNodes bounds a single generic by-hash request. Mirrors
@@ -663,6 +767,20 @@ func getObjectByHashFee(requested, found int) resource.Charge {
 // PeerImp.cpp:2538 so a requester polling several peers can tell "I
 // don't have these" from a peer that never answered.
 func (o *Overlay) serveGetObjects(peerID PeerID, req *message.GetObjectByHash) {
+	if o.nodeObjectProviderSnapshot() != nil &&
+		(len(req.LedgerHash) == 0 || len(req.LedgerHash) == 32) &&
+		len(req.Objects) <= hardMaxReplyNodes {
+		if peer, ok := o.getPeer(peerID); ok {
+			peer.Charge(resource.FeeModerateBurdenPeer, "get object by hash request")
+		}
+	}
+	o.serveGetObjectsContext(context.Background(), peerID, req)
+}
+
+func (o *Overlay) serveGetObjectsContext(ctx context.Context, peerID PeerID, req *message.GetObjectByHash) {
+	if err := ctx.Err(); err != nil {
+		return
+	}
 	peer, exists := o.getPeer(peerID)
 	if !exists {
 		return
@@ -700,8 +818,6 @@ func (o *Overlay) serveGetObjects(peerID PeerID, req *message.GetObjectByHash) {
 	// fetch loop; the work-proportional differential is added afterwards.
 	// Rippled charges the base at admission in onMessage and the
 	// differential in the worker (PeerImp.cpp:2544, 2656).
-	peer.Charge(resource.FeeModerateBurdenPeer, "get object by hash request")
-
 	reply := &message.GetObjectByHash{
 		Query:   false,
 		ObjType: req.ObjType,
@@ -709,6 +825,10 @@ func (o *Overlay) serveGetObjects(peerID PeerID, req *message.GetObjectByHash) {
 	}
 	if len(req.LedgerHash) != 0 {
 		reply.LedgerHash = append([]byte(nil), req.LedgerHash...)
+	}
+	budget := newServeReplyBudget()
+	if !budget.reserve(serveReplyObjectOverhead, req.LedgerHash) {
+		return
 	}
 
 	// Defense in depth: the oversize gate above already rejects requests
@@ -721,6 +841,9 @@ func (o *Overlay) serveGetObjects(peerID PeerID, req *message.GetObjectByHash) {
 		iterLimit = hardMaxReplyNodes
 	}
 	for i := 0; i < iterLimit; i++ {
+		if ctx.Err() != nil {
+			return
+		}
 		obj := req.Objects[i]
 		// Rippled only processes objects carrying a uint256-sized hash
 		// (PeerImp.cpp:2511); others are silently skipped.
@@ -732,6 +855,9 @@ func (o *Overlay) serveGetObjects(peerID PeerID, req *message.GetObjectByHash) {
 		blob, ok := fetch(hash)
 		if !ok {
 			continue
+		}
+		if !budget.reserve(serveReplyObjectOverhead, obj.Hash, obj.NodeID, blob) {
+			break
 		}
 		// Rippled echoes the request's nodeid into the reply's index
 		// field and copies the ledger seq back (PeerImp.cpp:2526-2529).
@@ -752,7 +878,7 @@ func (o *Overlay) serveGetObjects(peerID PeerID, req *message.GetObjectByHash) {
 	// (computeGetObjectByHashFee, PeerImp.cpp:2656).
 	peer.Charge(getObjectByHashFee(requested, len(reply.Objects)), "processed get object by hash request")
 
-	encodeAndSend(peer, reply, "TMGetObjectByHash reply")
+	encodeAndSendPriority(peer, reply, "TMGetObjectByHash reply")
 }
 
 // handleTransactionsBatchMessage processes mtTRANSACTIONS (a batched

--- a/internal/peermanagement/listener_lifecycle_test.go
+++ b/internal/peermanagement/listener_lifecycle_test.go
@@ -1,0 +1,69 @@
+package peermanagement
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverlayStopDuringListenerBindClosesUnpublishedListener(t *testing.T) {
+	o, err := New(
+		WithListenAddr("127.0.0.1:0"),
+		WithDataDir(t.TempDir()),
+		WithMaxPeers(1),
+		WithMaxInbound(1),
+		WithMaxOutbound(0),
+	)
+	require.NoError(t, err)
+
+	opened := make(chan net.Listener, 1)
+	release := make(chan struct{})
+	o.listenFunc = func(_ context.Context, network, address string) (net.Listener, error) {
+		listener, err := net.Listen(network, address)
+		if err != nil {
+			return nil, err
+		}
+		opened <- listener
+		<-release
+		return listener, nil
+	}
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- o.Run(context.Background()) }()
+	var bound net.Listener
+	select {
+	case bound = <-opened:
+	case <-time.After(time.Second):
+		t.Fatal("listener bind hook did not run")
+	}
+	addr := bound.Addr().String()
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- o.Stop() }()
+	select {
+	case err := <-stopDone:
+		t.Fatalf("Stop returned before listener preparation completed: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case err := <-runDone:
+		require.ErrorIs(t, err, ErrShutdown)
+	case <-time.After(time.Second):
+		t.Fatal("Run did not finish after Stop during listener preparation")
+	}
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not finish after Run unwound")
+	}
+
+	probe, err := net.Listen("tcp", addr)
+	require.NoError(t, err, "unpublished listener must be closed on the Stop race path")
+	require.NoError(t, probe.Close())
+}

--- a/internal/peermanagement/listener_lifecycle_test.go
+++ b/internal/peermanagement/listener_lifecycle_test.go
@@ -36,7 +36,7 @@ func TestOverlayStopDuringListenerBindClosesUnpublishedListener(t *testing.T) {
 	var bound net.Listener
 	select {
 	case bound = <-opened:
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("listener bind hook did not run")
 	}
 	addr := bound.Addr().String()
@@ -53,13 +53,13 @@ func TestOverlayStopDuringListenerBindClosesUnpublishedListener(t *testing.T) {
 	select {
 	case err := <-runDone:
 		require.ErrorIs(t, err, ErrShutdown)
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("Run did not finish after Stop during listener preparation")
 	}
 	select {
 	case err := <-stopDone:
 		require.NoError(t, err)
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("Stop did not finish after Run unwound")
 	}
 

--- a/internal/peermanagement/outbound_emit.go
+++ b/internal/peermanagement/outbound_emit.go
@@ -65,6 +65,20 @@ func encodeAndSend(peer *Peer, msg message.Message, opName string) {
 	}
 }
 
+// encodeAndSendPriority uses the acquisition lane for a direct response to a
+// peer request. Direct replies must not sit behind ordinary relay traffic in
+// the per-peer reliable queue.
+func encodeAndSendPriority(peer *Peer, msg message.Message, opName string) {
+	frame := buildFrame(msg, opName, "peer", peer.ID())
+	if frame == nil {
+		return
+	}
+	if err := peer.SendPriority(frame); err != nil {
+		slog.Debug(opName+" priority send failed",
+			"t", "Overlay", "peer", peer.ID(), "err", err)
+	}
+}
+
 // BroadcastHaveTxSet announces that we hold a particular transaction
 // set, mirroring rippled's post-consensus mtHAVE_SET emission. The
 // consensus adaptor calls this once per BuildTxSet so peers acquiring

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -1035,18 +1035,6 @@ func (o *Overlay) Run(ctx context.Context) error {
 		o.lifecycleMu.Unlock()
 	}
 
-	o.lifecycleMu.Lock()
-	if o.lifecycleState != overlayLifecycleRunning {
-		o.lifecycleMu.Unlock()
-		return ErrShutdown
-	}
-	if err := runCtx.Err(); err != nil {
-		o.lifecycleMu.Unlock()
-		return err
-	}
-	o.signalListenerReady()
-	o.lifecycleMu.Unlock()
-
 	g, gCtx := errgroup.WithContext(runCtx)
 	o.lifecycleMu.Lock()
 	o.runDone = gCtx.Done()
@@ -1070,9 +1058,18 @@ func (o *Overlay) Run(ctx context.Context) error {
 	if o.lifecycleState != overlayLifecycleRunning {
 		o.lifecycleMu.Unlock()
 		scheduler.close()
+		if err := runCtx.Err(); err != nil {
+			return err
+		}
 		return ErrShutdown
 	}
+	if err := runCtx.Err(); err != nil {
+		o.lifecycleMu.Unlock()
+		scheduler.close()
+		return err
+	}
 	o.serveScheduler = scheduler
+	o.signalListenerReady()
 	o.lifecycleMu.Unlock()
 	g.Go(func() error { return scheduler.Run(gCtx) })
 

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -22,25 +22,15 @@ import (
 )
 
 // serveWorkerCount bounds concurrent heavy serve operations (fetch-pack /
-// get-objects / tx back-fill) handled off the event loop, and
-// serveQueueDepth bounds the pending backlog before submitServe sheds
-// load. Mirrors rippled bounding these behind its job queue rather than
-// the read strand.
+// get-objects / tx back-fill) handled off the event loop. The scheduler also
+// applies a per-peer active and queued limit so one peer cannot monopolize
+// workers or backlog.
 const (
-	serveWorkerCount = 4
-	serveQueueDepth  = 64
+	serveWorkerCount        = 4
+	serveQueueDepth         = 64
+	servePerPeerQueue       = 8
+	servePerPeerConcurrency = 2
 )
-
-type overlayServeJob struct {
-	run     func()
-	discard func()
-}
-
-func (j overlayServeJob) drop() {
-	if j.discard != nil {
-		j.discard()
-	}
-}
 
 // Overlay is the central orchestrator for XRPL peer-to-peer networking.
 // It manages peer connections, discovery, message routing, and the reduce-relay system.
@@ -156,15 +146,11 @@ type Overlay struct {
 	// prevents unrelated traffic from discarding replies required for catch-up.
 	ledgerData chan *InboundMessage
 
-	// serveJobs carries heavy inbound serve work (fetch-pack, generic
-	// get-objects, tx back-fill) off the event-loop goroutine onto a
-	// bounded worker pool, so a single expensive serve can't stall ping
-	// replies and lifecycle handling. Created in Run; nil when the overlay
-	// was built without Run (submitServe then runs the job inline, which
-	// preserves the synchronous behaviour unit tests rely on). Mirrors
-	// rippled offloading these to its job queue (jtPACK et al.) rather than
-	// running them on the peer read strand.
-	serveJobs chan overlayServeJob
+	// serveScheduler carries heavy inbound serve work off the event-loop
+	// goroutine. It is created in Run; nil when the overlay was built without
+	// Run (submitServe then runs the job inline, preserving synchronous unit
+	// test behaviour).
+	serveScheduler *serveScheduler
 
 	// Peer lifecycle callbacks wired by higher layers (e.g., consensus
 	// router) that need to clean up per-peer state on disconnect. Fired
@@ -276,14 +262,12 @@ type Overlay struct {
 	peerDisconnects atomic.Uint64
 
 	// Network
-	// listenerMu guards listener: written once by startListener (called
-	// from Run before any concurrent reader exists). Read under RLock
-	// from ListenAddr and Stop (other goroutines). The reads in Run and
-	// acceptLoop are unlocked: Run's read at "if o.listener != nil" is
-	// in the same goroutine as the write, and acceptLoop is spawned via
-	// g.Go after the write returns, so happens-before applies.
+	// listenerMu guards listener publication. Run publishes only after the
+	// complete TCP/TLS listener has been prepared; reads under RLock are used
+	// by ListenAddr and Stop, while acceptLoop starts after publication.
 	listenerMu sync.RWMutex
 	listener   net.Listener
+	listenFunc func(context.Context, string, string) (net.Listener, error)
 
 	// listenerReady is closed once Run has finished its listener-bind
 	// phase — after startListener publishes o.listener, or immediately
@@ -1022,16 +1006,20 @@ func (o *Overlay) Run(ctx context.Context) error {
 	// Bind under lifecycleMu so Stop cannot transition the state between the
 	// running check and listener publication.
 	if o.cfg.ListenAddr != "" {
-		o.lifecycleMu.Lock()
-		if o.lifecycleState != overlayLifecycleRunning {
-			o.lifecycleMu.Unlock()
-			return ErrShutdown
-		}
-		err := o.startListener()
-		o.lifecycleMu.Unlock()
+		listener, err := o.startListener(runCtx)
 		if err != nil {
 			return fmt.Errorf("listener error: %w", err)
 		}
+		o.lifecycleMu.Lock()
+		if o.lifecycleState != overlayLifecycleRunning {
+			o.lifecycleMu.Unlock()
+			_ = listener.Close()
+			return ErrShutdown
+		}
+		o.listenerMu.Lock()
+		o.listener = listener
+		o.listenerMu.Unlock()
+		o.lifecycleMu.Unlock()
 	}
 
 	// Start resource manager (per-endpoint consumer table). The
@@ -1073,14 +1061,20 @@ func (o *Overlay) Run(ctx context.Context) error {
 		return nil
 	})
 
-	// Start the bounded serve-worker pool before the event loop so heavy
+	// Start the fair, bounded serve scheduler before the event loop so heavy
 	// inbound serve work (handleGetObjectsMessage) runs off the loop. The
-	// channel is assigned before eventLoop is launched (happens-before the
-	// only reader, submitServe, which runs on the loop).
-	o.serveJobs = make(chan overlayServeJob, serveQueueDepth)
-	for range serveWorkerCount {
-		g.Go(func() error { return o.serveWorker(gCtx) })
+	// scheduler context is canceled with the overlay and cancels queued or
+	// running work during shutdown.
+	scheduler := newServeScheduler(gCtx, serveWorkerCount, serveQueueDepth, servePerPeerQueue, servePerPeerConcurrency)
+	o.lifecycleMu.Lock()
+	if o.lifecycleState != overlayLifecycleRunning {
+		o.lifecycleMu.Unlock()
+		scheduler.close()
+		return ErrShutdown
 	}
+	o.serveScheduler = scheduler
+	o.lifecycleMu.Unlock()
+	g.Go(func() error { return scheduler.Run(gCtx) })
 
 	// Accept incoming connections.
 	o.listenerMu.RLock()
@@ -1141,6 +1135,7 @@ func (o *Overlay) requestStop() {
 		o.shutdownDone = make(chan struct{})
 	}
 	cancel := o.cancel
+	scheduler := o.serveScheduler
 	if !o.stopRequested {
 		o.stopRequested = true
 		if o.stopCh != nil {
@@ -1165,6 +1160,9 @@ func (o *Overlay) requestStop() {
 		p.Close()
 	}
 	o.peersMu.Unlock()
+	if scheduler != nil {
+		scheduler.close()
+	}
 }
 
 func (o *Overlay) closeListener() error {
@@ -1247,7 +1245,6 @@ func (o *Overlay) releaseQueuedInbound() {
 	drainMessages(o.txMessages)
 	drainMessages(o.manifestMessages)
 	drainMessages(o.ledgerData)
-	o.discardServeJobs()
 }
 
 // eventLoop processes internal events. It drains both the dedicated
@@ -1299,57 +1296,76 @@ func (o *Overlay) consensusControlEventLoop(ctx context.Context) error {
 	}
 }
 
-// serveWorker drains the bounded serve-job queue. Multiple workers run
-// concurrently; the serve paths (fetch-pack / get-objects / tx back-fill)
-// are read-only against the ledger/node store and peer-safe, so parallel
-// execution is sound.
-func (o *Overlay) serveWorker(ctx context.Context) error {
-	for {
-		select {
-		case <-ctx.Done():
-			o.discardServeJobs()
-			return ctx.Err()
-		case job := <-o.serveJobs:
-			job.run()
-		}
-	}
+// submitServe preserves the small synchronous helper used by tests and by
+// callers that do not need peer attribution. Production request paths use
+// submitServeForPeer so admission charges and fairness are applied.
+func (o *Overlay) submitServe(job func()) {
+	o.submitServeForPeer(0, resource.Charge{}, func(context.Context) { job() })
 }
 
-func (o *Overlay) submitServeJob(job overlayServeJob) bool {
-	if o.serveJobs == nil {
-		job.run()
-		return true
-	}
-	select {
-	case <-o.runDone:
-		job.drop()
+// submitServeForPeer admits a heavy serve request to the fair scheduler. The
+// admission charge is applied before queueing; a shed request receives the
+// inexpensive no-reply charge so repeatedly filling the queue is not free.
+func (o *Overlay) submitServeForPeer(peerID PeerID, admission resource.Charge, job func(context.Context)) bool {
+	return o.submitServeForPeerOwned(peerID, admission, job, nil)
+}
+
+func (o *Overlay) submitServeForPeerOwned(
+	peerID PeerID,
+	admission resource.Charge,
+	job func(context.Context),
+	discard func(),
+) bool {
+	if job == nil {
 		return false
-	default:
 	}
-	select {
-	case o.serveJobs <- job:
-		return true
-	default:
-		job.drop()
+	peer, exists := o.getPeer(peerID)
+	if peerID != 0 && !exists {
+		return false
+	}
+	if exists && admission.Cost() > 0 {
+		peer.Charge(admission, "serve request admission")
+	}
+	o.lifecycleMu.Lock()
+	scheduler := o.serveScheduler
+	serveCtx := o.ctx
+	lifecycleState := o.lifecycleState
+	o.lifecycleMu.Unlock()
+	if lifecycleState == overlayLifecycleStopping || lifecycleState == overlayLifecycleStopped {
 		o.droppedServeJobs.Add(1)
-		slog.Debug("serve job dropped: worker pool saturated", "t", "Overlay")
+		if exists {
+			peer.Charge(resource.FeeRequestNoReply, "serve scheduler stopped")
+		}
 		return false
 	}
+	if scheduler == nil {
+		job(context.Background())
+		return true
+	}
+	if scheduler.SubmitOwned(serveCtx, peerID, job, discard) {
+		return true
+	}
+	o.droppedServeJobs.Add(1)
+	if exists {
+		peer.Charge(resource.FeeRequestNoReply, "serve scheduler saturated")
+	}
+	slog.Debug("serve job dropped: scheduler saturated", "t", "Overlay", "peer", peerID)
+	return false
 }
 
-func (o *Overlay) discardServeJobs() {
-	for {
-		select {
-		case job := <-o.serveJobs:
-			job.drop()
-		default:
-			return
-		}
+// cancelServePeer disposes queued work and propagates cancellation to any
+// active provider calls when a peer disconnects.
+func (o *Overlay) cancelServePeer(peerID PeerID) {
+	o.lifecycleMu.Lock()
+	scheduler := o.serveScheduler
+	o.lifecycleMu.Unlock()
+	if scheduler != nil {
+		scheduler.CancelPeer(peerID)
 	}
 }
 
 // DroppedServeJobs returns the cumulative count of heavy serve jobs shed
-// because the worker pool was saturated.
+// because the scheduler was saturated or stopping.
 func (o *Overlay) DroppedServeJobs() uint64 {
 	return o.droppedServeJobs.Load()
 }

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -148,8 +148,8 @@ type Overlay struct {
 
 	// serveScheduler carries heavy inbound serve work off the event-loop
 	// goroutine. It is created in Run; nil when the overlay was built without
-	// Run (submitServe then runs the job inline, preserving synchronous unit
-	// test behaviour).
+	// Run (submitServeForPeerOwned then runs the job inline, preserving
+	// synchronous unit test behaviour).
 	serveScheduler *serveScheduler
 
 	// Peer lifecycle callbacks wired by higher layers (e.g., consensus
@@ -1294,20 +1294,6 @@ func (o *Overlay) consensusControlEventLoop(ctx context.Context) error {
 			o.onMessageReceived(evt)
 		}
 	}
-}
-
-// submitServe preserves the small synchronous helper used by tests and by
-// callers that do not need peer attribution. Production request paths use
-// submitServeForPeer so admission charges and fairness are applied.
-func (o *Overlay) submitServe(job func()) {
-	o.submitServeForPeer(0, resource.Charge{}, func(context.Context) { job() })
-}
-
-// submitServeForPeer admits a heavy serve request to the fair scheduler. The
-// admission charge is applied before queueing; a shed request receives the
-// inexpensive no-reply charge so repeatedly filling the queue is not free.
-func (o *Overlay) submitServeForPeer(peerID PeerID, admission resource.Charge, job func(context.Context)) bool {
-	return o.submitServeForPeerOwned(peerID, admission, job, nil)
 }
 
 func (o *Overlay) submitServeForPeerOwned(

--- a/internal/peermanagement/overlay_inbound.go
+++ b/internal/peermanagement/overlay_inbound.go
@@ -134,28 +134,30 @@ func (o *Overlay) admitInboundEndpoint(addr string) bool {
 	return !c.Disconnect()
 }
 
-// startListener creates and starts the TCP/TLS listener.
-func (o *Overlay) startListener() error {
+// startListener creates the TCP/TLS listener without publishing it. Run owns
+// publication under lifecycleMu so Stop cannot miss a socket that is still
+// being prepared.
+func (o *Overlay) startListener(ctx context.Context) (net.Listener, error) {
 	var lc net.ListenConfig
-	tcpListener, err := lc.Listen(o.ctx, "tcp", o.cfg.ListenAddr)
+	listen := lc.Listen
+	if o.listenFunc != nil {
+		listen = o.listenFunc
+	}
+	tcpListener, err := listen(ctx, "tcp", o.cfg.ListenAddr)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	certPEM, keyPEM, err := o.identity.TLSCertificatePEM()
 	if err != nil {
 		tcpListener.Close()
-		return fmt.Errorf("overlay: build TLS cert: %w", err)
+		return nil, fmt.Errorf("overlay: build TLS cert: %w", err)
 	}
 
-	l := peertls.NewListener(tcpListener, &peertls.Config{
+	return peertls.NewListener(tcpListener, &peertls.Config{
 		CertPEM: certPEM,
 		KeyPEM:  keyPEM,
-	})
-	o.listenerMu.Lock()
-	o.listener = l
-	o.listenerMu.Unlock()
-	return nil
+	}), nil
 }
 
 // acceptLoop accepts incoming connections. acceptBackoff throttles

--- a/internal/peermanagement/overlay_message.go
+++ b/internal/peermanagement/overlay_message.go
@@ -37,6 +37,7 @@ func (o *Overlay) onPeerConnected(evt Event) {
 
 func (o *Overlay) onPeerDisconnected(evt Event) {
 	o.peerDisconnects.Add(1)
+	o.cancelServePeer(evt.PeerID)
 	o.relay.RemovePeer(evt.PeerID)
 	// Fire the higher-layer disconnect callback so per-peer state in
 	// consumers (router peerStates, adaptor peerLCLs) gets cleaned.

--- a/internal/peermanagement/serve_scheduler.go
+++ b/internal/peermanagement/serve_scheduler.go
@@ -1,0 +1,363 @@
+package peermanagement
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// serveScheduler bounds expensive peer-serving work independently from the
+// overlay event loop. Jobs are kept in per-peer queues and selected in
+// round-robin order. A per-peer active limit prevents one peer from occupying
+// every worker while a bounded queue prevents unbounded retention.
+type serveScheduler struct {
+	mu sync.Mutex
+
+	ctx context.Context
+
+	queues  map[PeerID][]serveTask
+	active  map[PeerID]int
+	running map[PeerID]map[uint64]context.CancelFunc
+	round   []PeerID
+	next    int
+	nextID  uint64
+	pending int
+
+	workers       int
+	maxPending    int
+	perPeerQueue  int
+	perPeerActive int
+
+	notify chan struct{}
+	done   chan struct{}
+	closed bool
+	idle   atomic.Int32
+
+	dropped atomic.Uint64
+}
+
+type serveTask struct {
+	peerID  PeerID
+	id      uint64
+	ctx     context.Context
+	cancel  context.CancelFunc
+	run     func(context.Context)
+	discard func()
+}
+
+func newServeScheduler(ctx context.Context, workers, maxPending, perPeerQueue, perPeerActive int) *serveScheduler {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if workers < 1 {
+		workers = 1
+	}
+	if maxPending < 1 {
+		maxPending = 1
+	}
+	if perPeerQueue < 1 {
+		perPeerQueue = 1
+	}
+	if perPeerActive < 1 {
+		perPeerActive = 1
+	}
+	s := &serveScheduler{
+		ctx:           ctx,
+		queues:        make(map[PeerID][]serveTask),
+		active:        make(map[PeerID]int),
+		running:       make(map[PeerID]map[uint64]context.CancelFunc),
+		workers:       workers,
+		maxPending:    maxPending,
+		perPeerQueue:  perPeerQueue,
+		perPeerActive: perPeerActive,
+		notify:        make(chan struct{}),
+		done:          make(chan struct{}),
+	}
+	go func() {
+		<-ctx.Done()
+		s.close()
+	}()
+	return s
+}
+
+func (s *serveScheduler) Workers() int { return s.workers }
+
+func (s *serveScheduler) Dropped() uint64 { return s.dropped.Load() }
+
+func (s *serveScheduler) Pending() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pending
+}
+
+// Submit queues a job without waiting for capacity. The request context is
+// derived once so queued work can be canceled on peer disconnect or shutdown.
+func (s *serveScheduler) Submit(ctx context.Context, peerID PeerID, run func(context.Context)) bool {
+	return s.SubmitOwned(ctx, peerID, run, nil)
+}
+
+// SubmitOwned queues work whose caller retains resources until the task runs
+// or is discarded. A rejected submission remains owned by the caller.
+func (s *serveScheduler) SubmitOwned(
+	ctx context.Context,
+	peerID PeerID,
+	run func(context.Context),
+	discard func(),
+) bool {
+	if run == nil {
+		return false
+	}
+	if ctx == nil {
+		ctx = s.ctx
+	}
+	jobCtx, cancel := context.WithCancel(ctx)
+	s.mu.Lock()
+	if s.closed || s.pending >= s.maxPending {
+		s.mu.Unlock()
+		cancel()
+		s.dropped.Add(1)
+		return false
+	}
+	queue := s.queues[peerID]
+	if len(queue) >= s.perPeerQueue {
+		s.mu.Unlock()
+		cancel()
+		s.dropped.Add(1)
+		return false
+	}
+	if len(queue) == 0 {
+		s.round = append(s.round, peerID)
+	}
+	queue = append(queue, serveTask{
+		peerID:  peerID,
+		ctx:     jobCtx,
+		cancel:  cancel,
+		run:     run,
+		discard: discard,
+	})
+	s.queues[peerID] = queue
+	s.pending++
+	s.signalLocked()
+	s.mu.Unlock()
+	return true
+}
+
+// CancelPeer disposes queued work and cancels work currently executing for a
+// peer. It is safe to call after the peer has already been removed.
+func (s *serveScheduler) CancelPeer(peerID PeerID) {
+	s.mu.Lock()
+	queue := s.queues[peerID]
+	delete(s.queues, peerID)
+	s.pending -= len(queue)
+	for _, task := range queue {
+		task.cancel()
+	}
+	// Running tasks are represented by a context in the activeRuns map. The
+	// scheduler intentionally keeps this separate from active counts so that
+	// finishing a canceled task still releases exactly one slot.
+	if runs := s.running[peerID]; len(runs) != 0 {
+		for _, cancel := range runs {
+			cancel()
+		}
+	}
+	s.removePeerLocked(peerID)
+	s.signalLocked()
+	s.mu.Unlock()
+	for _, task := range queue {
+		task.discardTask()
+	}
+}
+
+// Close cancels all queued and running work. It is idempotent.
+func (s *serveScheduler) close() {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = true
+	close(s.done)
+	queued := make([]serveTask, 0, s.pending)
+	for peerID, queue := range s.queues {
+		for _, task := range queue {
+			task.cancel()
+		}
+		queued = append(queued, queue...)
+		delete(s.queues, peerID)
+	}
+	s.pending = 0
+	for _, runs := range s.running {
+		for _, cancel := range runs {
+			cancel()
+		}
+	}
+	s.round = nil
+	s.next = 0
+	close(s.notify)
+	s.mu.Unlock()
+	for _, task := range queued {
+		task.discardTask()
+	}
+}
+
+// signalLocked wakes every worker currently waiting for scheduler state. A
+// fresh channel is installed while holding s.mu, so a worker that observes an
+// empty queue cannot miss a concurrent enqueue between its state check and
+// entering the wait select.
+func (s *serveScheduler) signalLocked() {
+	if s.closed {
+		return
+	}
+	close(s.notify)
+	s.notify = make(chan struct{})
+}
+
+// Run starts the fixed worker set and returns when the scheduler context is
+// canceled or all workers have exited. Overlay.Run owns the returned error.
+func (s *serveScheduler) Run(ctx context.Context) error {
+	if ctx == nil {
+		ctx = s.ctx
+	}
+	var wg sync.WaitGroup
+	wg.Add(s.workers)
+	for range s.workers {
+		go func() {
+			defer wg.Done()
+			s.worker(ctx)
+		}()
+	}
+	<-ctx.Done()
+	s.close()
+	wg.Wait()
+	return ctx.Err()
+}
+
+func (s *serveScheduler) worker(ctx context.Context) {
+	for {
+		task, ok := s.take(ctx)
+		if !ok {
+			return
+		}
+		if task.ctx.Err() == nil {
+			task.run(task.ctx)
+		} else {
+			task.discardTask()
+		}
+		s.finish(task)
+	}
+}
+
+func (t serveTask) discardTask() {
+	if t.discard != nil {
+		t.discard()
+	}
+}
+
+func (s *serveScheduler) take(ctx context.Context) (serveTask, bool) {
+	for {
+		s.mu.Lock()
+		if s.closed {
+			s.mu.Unlock()
+			return serveTask{}, false
+		}
+		if task, ok := s.takeLocked(); ok {
+			s.mu.Unlock()
+			return task, true
+		}
+		wait := s.notify
+		s.idle.Add(1)
+		s.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			s.idle.Add(-1)
+			return serveTask{}, false
+		case <-s.done:
+			s.idle.Add(-1)
+			return serveTask{}, false
+		case <-wait:
+			s.idle.Add(-1)
+		}
+	}
+}
+
+func (s *serveScheduler) takeLocked() (serveTask, bool) {
+	if len(s.round) == 0 {
+		return serveTask{}, false
+	}
+	for checked := 0; checked < len(s.round); checked++ {
+		if s.next >= len(s.round) {
+			s.next = 0
+		}
+		peerID := s.round[s.next]
+		s.next++
+		queue := s.queues[peerID]
+		if len(queue) == 0 || s.active[peerID] >= s.perPeerActive {
+			continue
+		}
+		task := queue[0]
+		if len(queue) == 1 {
+			delete(s.queues, peerID)
+			for i, id := range s.round {
+				if id == peerID {
+					s.round = append(s.round[:i], s.round[i+1:]...)
+					if i < s.next {
+						s.next--
+					}
+					break
+				}
+			}
+		} else {
+			s.queues[peerID] = queue[1:]
+		}
+		s.pending--
+		s.active[peerID]++
+		if s.nextID == 0 {
+			s.nextID = 1
+		}
+		task.id = s.nextID
+		s.nextID++
+		if s.running[peerID] == nil {
+			s.running[peerID] = make(map[uint64]context.CancelFunc)
+		}
+		s.running[peerID][task.id] = task.cancel
+		return task, true
+	}
+	return serveTask{}, false
+}
+
+func (s *serveScheduler) finish(task serveTask) {
+	task.cancel()
+	s.mu.Lock()
+	if count := s.active[task.peerID]; count <= 1 {
+		delete(s.active, task.peerID)
+	} else {
+		s.active[task.peerID] = count - 1
+	}
+	if runs := s.running[task.peerID]; runs != nil {
+		delete(runs, task.id)
+	}
+	if len(s.running[task.peerID]) == 0 {
+		delete(s.running, task.peerID)
+	}
+	s.signalLocked()
+	s.mu.Unlock()
+}
+
+func (s *serveScheduler) removePeerLocked(peerID PeerID) {
+	for i := 0; i < len(s.round); {
+		if s.round[i] != peerID {
+			i++
+			continue
+		}
+		s.round = append(s.round[:i], s.round[i+1:]...)
+		if i < s.next {
+			s.next--
+		}
+	}
+	if s.next < 0 {
+		s.next = 0
+	}
+	if s.next > len(s.round) {
+		s.next = len(s.round)
+	}
+}

--- a/internal/peermanagement/serve_scheduler_test.go
+++ b/internal/peermanagement/serve_scheduler_test.go
@@ -1,0 +1,296 @@
+package peermanagement
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestServeSchedulerPerPeerFairness(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := newServeScheduler(ctx, 2, 32, 16, 1)
+	go func() {
+		_ = s.Run(ctx)
+	}()
+
+	var mu sync.Mutex
+	order := make([]PeerID, 0, 4)
+	var release atomic.Int32
+	started := make(chan struct{}, 4)
+	job := func(peerID PeerID) func(context.Context) {
+		return func(context.Context) {
+			mu.Lock()
+			order = append(order, peerID)
+			mu.Unlock()
+			started <- struct{}{}
+			for release.Load() == 0 {
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}
+	for range 2 {
+		if !s.Submit(ctx, 1, job(1)) {
+			t.Fatal("peer 1 submission rejected")
+		}
+	}
+	if !s.Submit(ctx, 2, job(2)) {
+		t.Fatal("peer 2 submission rejected")
+	}
+	for range 2 {
+		<-started
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != 2 || order[0] != 1 || order[1] != 2 {
+		t.Fatalf("start order = %v, want one job from each peer", order)
+	}
+	release.Store(1)
+	mu.Unlock()
+	time.Sleep(10 * time.Millisecond)
+	mu.Lock()
+}
+
+func TestServeSchedulerBoundsAndCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := newServeScheduler(ctx, 1, 1, 1, 1)
+	started := make(chan struct{})
+	block := make(chan struct{})
+	if !s.Submit(ctx, 1, func(context.Context) {
+		close(started)
+		<-block
+	}) {
+		t.Fatal("first submission rejected")
+	}
+	if s.Submit(ctx, 1, func(context.Context) {}) {
+		t.Fatal("per-peer queue accepted over-limit submission")
+	}
+	if got := s.Dropped(); got != 1 {
+		t.Fatalf("dropped = %d, want 1", got)
+	}
+	go func() { _ = s.Run(ctx) }()
+	<-started
+	s.CancelPeer(1)
+	close(block)
+	cancel()
+	select {
+	case <-s.done:
+	case <-time.After(time.Second):
+		t.Fatal("scheduler did not shut down after cancellation")
+	}
+}
+
+func TestServeSchedulerCancelPeerTracksCompletedTasks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := newServeScheduler(ctx, 2, 8, 8, 2)
+	go func() { _ = s.Run(ctx) }()
+
+	startedFirst := make(chan struct{})
+	startedSecond := make(chan struct{})
+	firstCanceled := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	if !s.Submit(ctx, 1, func(ctx context.Context) {
+		close(startedFirst)
+		<-ctx.Done()
+		close(firstCanceled)
+	}) {
+		t.Fatal("first submission rejected")
+	}
+	if !s.Submit(ctx, 1, func(context.Context) {
+		close(startedSecond)
+		<-releaseSecond
+	}) {
+		t.Fatal("second submission rejected")
+	}
+	select {
+	case <-startedFirst:
+	case <-time.After(time.Second):
+		t.Fatal("first task did not start")
+	}
+	select {
+	case <-startedSecond:
+	case <-time.After(time.Second):
+		t.Fatal("second task did not start")
+	}
+	close(releaseSecond)
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		s.mu.Lock()
+		running := len(s.running[1])
+		s.mu.Unlock()
+		if running == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("second task did not finish")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	s.CancelPeer(1)
+	select {
+	case <-firstCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("canceling peer did not cancel the remaining task")
+	}
+	cancel()
+}
+
+func TestServeSchedulerCancelPeerRemovesRoundEntry(t *testing.T) {
+	ctx := context.Background()
+	s := newServeScheduler(ctx, 1, 256, 1, 1)
+	for peerID := PeerID(1); peerID <= 128; peerID++ {
+		if !s.Submit(ctx, peerID, func(context.Context) {}) {
+			t.Fatalf("submission for peer %d rejected", peerID)
+		}
+		s.CancelPeer(peerID)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.round) != 0 {
+		t.Fatalf("round retains %d canceled peers", len(s.round))
+	}
+	if s.pending != 0 {
+		t.Fatalf("pending = %d after canceling all peers", s.pending)
+	}
+}
+
+func TestServeSchedulerWakesEveryIdleWorkerForBurst(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	const workers = 4
+	s := newServeScheduler(ctx, workers, workers, 1, 1)
+	done := make(chan struct{})
+	go func() {
+		_ = s.Run(ctx)
+		close(done)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for s.idle.Load() != workers {
+		if time.Now().After(deadline) {
+			t.Fatalf("idle workers = %d, want %d before burst", s.idle.Load(), workers)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	started := make(chan struct{}, workers)
+	release := make(chan struct{})
+	for peerID := PeerID(1); peerID <= workers; peerID++ {
+		if !s.Submit(ctx, peerID, func(context.Context) {
+			started <- struct{}{}
+			<-release
+		}) {
+			t.Fatalf("submission for peer %d rejected", peerID)
+		}
+	}
+
+	deadline = time.Now().Add(time.Second)
+	for len(started) != workers {
+		if time.Now().After(deadline) {
+			t.Fatalf("started workers = %d, want %d after burst", len(started), workers)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(release)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("scheduler did not stop after burst")
+	}
+}
+
+func TestServeSchedulerDiscardsOwnedQueuedTaskOnPeerCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := newServeScheduler(ctx, 1, 1, 1, 1)
+	var discarded atomic.Int32
+	requireSubmitted := s.SubmitOwned(ctx, 1, func(context.Context) {
+		t.Fatal("canceled queued task ran")
+	}, func() {
+		discarded.Add(1)
+	})
+	if !requireSubmitted {
+		t.Fatal("owned task submission rejected")
+	}
+
+	s.CancelPeer(1)
+	s.close()
+	if got := discarded.Load(); got != 1 {
+		t.Fatalf("discard count = %d, want 1", got)
+	}
+}
+
+func TestServeSchedulerRejectedOwnedTaskRemainsCallerOwned(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := newServeScheduler(ctx, 1, 1, 1, 1)
+	if !s.Submit(ctx, 1, func(context.Context) {}) {
+		t.Fatal("first submission rejected")
+	}
+	var discarded atomic.Int32
+	if s.SubmitOwned(ctx, 2, func(context.Context) {}, func() { discarded.Add(1) }) {
+		t.Fatal("over-limit owned task accepted")
+	}
+	if got := discarded.Load(); got != 0 {
+		t.Fatalf("scheduler discarded caller-owned rejected task %d times", got)
+	}
+}
+
+func TestServeSchedulerDiscardsOwnedQueuedTaskOnClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := newServeScheduler(ctx, 1, 1, 1, 1)
+	var discarded atomic.Int32
+	if !s.SubmitOwned(ctx, 1, func(context.Context) {
+		t.Fatal("closed queued task ran")
+	}, func() {
+		discarded.Add(1)
+	}) {
+		t.Fatal("owned task submission rejected")
+	}
+
+	s.close()
+	s.close()
+	if got := discarded.Load(); got != 1 {
+		t.Fatalf("discard count = %d, want 1", got)
+	}
+}
+
+func TestServeSchedulerActiveCancellationUsesRunCleanup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := newServeScheduler(ctx, 1, 1, 1, 1)
+	go func() { _ = s.Run(ctx) }()
+	started := make(chan struct{})
+	cleaned := make(chan struct{})
+	var discarded atomic.Int32
+	if !s.SubmitOwned(ctx, 1, func(ctx context.Context) {
+		defer close(cleaned)
+		close(started)
+		<-ctx.Done()
+	}, func() {
+		discarded.Add(1)
+	}) {
+		t.Fatal("owned task submission rejected")
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("owned task did not start")
+	}
+
+	s.CancelPeer(1)
+	select {
+	case <-cleaned:
+	case <-time.After(time.Second):
+		t.Fatal("active task did not observe peer cancellation")
+	}
+	if got := discarded.Load(); got != 0 {
+		t.Fatalf("active task discard count = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
Part of #1472. Stack PR 5/11.\n\nBounds peer-serving concurrency and scheduling so large or slow requests cannot monopolize shared serving capacity.