### PR TITLE
fix: align replay and proof serving (#1472)

### DIFF
--- a/internal/consensus/adaptor/ledger_provider.go
+++ b/internal/consensus/adaptor/ledger_provider.go
@@ -325,7 +325,7 @@ func (p *LedgerProvider) GetProofPathContext(
 		return nil, nil, peermanagement.ErrKeyNotFound
 	}
 
-	return l.SerializeHeader(), proof.Path, nil
+	return header.AddRaw(l.Header(), false), proof.Path, nil
 }
 
 func (p *LedgerProvider) getLedgerContext(ctx context.Context, hash [32]byte) (*ledger.Ledger, error) {

--- a/internal/consensus/adaptor/ledger_provider.go
+++ b/internal/consensus/adaptor/ledger_provider.go
@@ -9,6 +9,8 @@
 package adaptor
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger"
@@ -28,6 +30,10 @@ import (
 type ledgerLookup interface {
 	GetLedgerByHash(hash [32]byte) (*ledger.Ledger, error)
 	EarliestFetch() uint32
+}
+
+type ledgerLookupContext interface {
+	GetLedgerByHashContext(ctx context.Context, hash [32]byte) (*ledger.Ledger, error)
 }
 
 // MinimumOnlineFloor reports the lowest ledger sequence the node still retains
@@ -88,19 +94,32 @@ func (p *LedgerProvider) belowFloor(seq uint32) bool {
 //   - Look up the ledger by hash.
 //   - Reject if it is unknown OR not yet immutable. Returning
 //     (nil, nil, nil) is the LedgerProvider contract for
-//     "unknown / not immutable", which the handler maps to reNO_LEDGER.
+//     "unknown / not immutable", which the handler charges and drops.
 //   - Otherwise return the serialized header and every tx leaf blob in
 //     tx-map iteration order. Each leaf blob is a fresh copy: although
 //     shamap.Item.Data() already copies, we double-copy via append so
 //     the contract stays correct even if Item ever switches to returning
 //     its internal slice.
 func (p *LedgerProvider) GetReplayDelta(ledgerHash []byte) ([]byte, [][]byte, error) {
+	return p.GetReplayDeltaContext(context.Background(), ledgerHash)
+}
+
+func (p *LedgerProvider) GetReplayDeltaContext(ctx context.Context, ledgerHash []byte) ([]byte, [][]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	hash, ok := inbound.ToHash32(ledgerHash)
 	if !ok {
 		// Bad-length hash never matches a real ledger; treat as unknown.
 		return nil, nil, nil
 	}
-	l, err := p.svc.GetLedgerByHash(hash)
+	l, err := p.getLedgerContext(ctx, hash)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, nil, ctxErr
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil, nil, err
+	}
 	if err != nil || l == nil || !l.IsImmutable() || p.belowFloor(l.Sequence()) {
 		return nil, nil, nil
 	}
@@ -118,12 +137,21 @@ func (p *LedgerProvider) GetReplayDelta(ledgerHash []byte) ([]byte, [][]byte, er
 	}
 
 	var leaves [][]byte
-	if err := txMap.ForEach(func(item *shamap.Item) bool {
+	if err := txMap.ForEachCtx(ctx, func(item *shamap.Item) bool {
+		if ctx.Err() != nil {
+			return false
+		}
 		raw := item.Data()
 		leaves = append(leaves, append([]byte(nil), raw...))
 		return true
 	}); err != nil {
+		if ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		}
 		return nil, nil, fmt.Errorf("iterate tx map: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
 	}
 
 	return headerBytes, leaves, nil
@@ -228,10 +256,10 @@ func appendFetchPackNodes(objects []message.IndexedObject, m *shamap.SHAMap, max
 //     (only mtREPLAY_DELTA_REQ does). Missing →
 //     peermanagement.ErrLedgerNotFound.
 //   - mapType selects the source SHAMap; an unsupported value yields a
-//     generic error so the handler emits reBAD_REQUEST. Defense in depth —
+//     generic error so the handler charges and drops. Defense in depth —
 //     the handler itself rejects bad map types up front.
 //   - Missing leaf → peermanagement.ErrKeyNotFound (the handler then
-//     returns reNO_NODE without serializing a header).
+//     charges and drops without serializing a header).
 //
 // Path orientation is leaf-to-root, matching shamap.GetProofPath's wire
 // ordering.
@@ -240,6 +268,18 @@ func (p *LedgerProvider) GetProofPath(
 	key []byte,
 	mapType message.LedgerMapType,
 ) ([]byte, [][]byte, error) {
+	return p.GetProofPathContext(context.Background(), ledgerHash, key, mapType)
+}
+
+func (p *LedgerProvider) GetProofPathContext(
+	ctx context.Context,
+	ledgerHash []byte,
+	key []byte,
+	mapType message.LedgerMapType,
+) ([]byte, [][]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	hash, ok := inbound.ToHash32(ledgerHash)
 	if !ok {
 		return nil, nil, peermanagement.ErrLedgerNotFound
@@ -250,7 +290,13 @@ func (p *LedgerProvider) GetProofPath(
 		return nil, nil, peermanagement.ErrKeyNotFound
 	}
 
-	l, err := p.svc.GetLedgerByHash(hash)
+	l, err := p.getLedgerContext(ctx, hash)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, nil, ctxErr
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil, nil, err
+	}
 	if err != nil || l == nil || p.belowFloor(l.Sequence()) {
 		return nil, nil, peermanagement.ErrLedgerNotFound
 	}
@@ -268,7 +314,10 @@ func (p *LedgerProvider) GetProofPath(
 		return nil, nil, fmt.Errorf("snapshot map: %w", err)
 	}
 
-	proof, err := snap.GetProofPath(keyArr)
+	proof, err := snap.GetProofPathContext(ctx, keyArr)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, nil, ctxErr
+	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("get proof path: %w", err)
 	}
@@ -277,4 +326,16 @@ func (p *LedgerProvider) GetProofPath(
 	}
 
 	return l.SerializeHeader(), proof.Path, nil
+}
+
+func (p *LedgerProvider) getLedgerContext(ctx context.Context, hash [32]byte) (*ledger.Ledger, error) {
+	if lookup, ok := p.svc.(ledgerLookupContext); ok {
+		return lookup.GetLedgerByHashContext(ctx, hash)
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	return p.svc.GetLedgerByHash(hash)
 }

--- a/internal/consensus/adaptor/ledger_provider_test.go
+++ b/internal/consensus/adaptor/ledger_provider_test.go
@@ -1,7 +1,9 @@
 package adaptor
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -15,6 +17,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type cancelOnNthErrContext struct {
+	cancelAt int
+	calls    int
+	canceled bool
+}
+
+func (c *cancelOnNthErrContext) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (c *cancelOnNthErrContext) Done() <-chan struct{}       { return nil }
+func (c *cancelOnNthErrContext) Value(any) any               { return nil }
+
+func (c *cancelOnNthErrContext) Err() error {
+	c.calls++
+	if c.calls >= c.cancelAt {
+		c.canceled = true
+		return context.Canceled
+	}
+	return nil
+}
+
 // fakeLookup is a hand-rolled ledgerLookup double. It maps a ledger hash to
 // a *ledger.Ledger so each test can inject the exact graph it wants without
 // spinning up a full *service.Service. Sequence-based lookups are used by
@@ -23,6 +44,19 @@ import (
 type fakeLookup struct {
 	byHash        map[[32]byte]*ledger.Ledger
 	earliestFetch uint32
+}
+
+type contextErrorLookup struct {
+	*fakeLookup
+	err          error
+	beforeReturn func()
+}
+
+func (f *contextErrorLookup) GetLedgerByHashContext(context.Context, [32]byte) (*ledger.Ledger, error) {
+	if f.beforeReturn != nil {
+		f.beforeReturn()
+	}
+	return nil, f.err
 }
 
 func newFakeLookup() *fakeLookup {
@@ -148,6 +182,89 @@ func TestLedgerProvider_GetReplayDelta_ImmutableLedger(t *testing.T) {
 	for i, want := range txs {
 		assert.Equal(t, want.blob, leavesAgain[i],
 			"leaf %d must be unchanged after caller-side mutation (defensive copy)", i)
+	}
+}
+
+func TestLedgerProvider_GetReplayDelta_ContextCancellationNeverReturnsPartialDelta(t *testing.T) {
+	closed := makeClosedLedgerWithTxs(t, []struct {
+		key  [32]byte
+		blob []byte
+	}{
+		{fixedKey32(1), []byte("tx-blob-one--padded")},
+		{fixedKey32(2), []byte("tx-blob-two--padded")},
+	})
+	lookup := newFakeLookup()
+	lookup.add(closed)
+	provider := newLedgerProviderForTest(lookup)
+	hash := closed.Hash()
+
+	for cancelAt := 2; cancelAt <= 256; cancelAt++ {
+		ctx := &cancelOnNthErrContext{cancelAt: cancelAt}
+		headerBytes, leaves, err := provider.GetReplayDeltaContext(ctx, hash[:])
+		if !ctx.canceled {
+			continue
+		}
+		require.ErrorIs(t, err, context.Canceled, "cancelAt=%d", cancelAt)
+		assert.Nil(t, headerBytes, "cancelAt=%d", cancelAt)
+		assert.Nil(t, leaves, "cancelAt=%d", cancelAt)
+	}
+}
+
+func TestLedgerProvider_GetReplayDelta_PropagatesLookupCancellation(t *testing.T) {
+	provider := newLedgerProviderForTest(&contextErrorLookup{
+		fakeLookup: newFakeLookup(),
+		err:        fmt.Errorf("lookup canceled: %w", context.Canceled),
+	})
+	headerBytes, leaves, err := provider.GetReplayDeltaContext(context.Background(), make([]byte, 32))
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, headerBytes)
+	assert.Nil(t, leaves)
+}
+
+func TestLedgerProvider_GetProofPath_PropagatesLookupDeadline(t *testing.T) {
+	provider := newLedgerProviderForTest(&contextErrorLookup{
+		fakeLookup: newFakeLookup(),
+		err:        fmt.Errorf("lookup timed out: %w", context.DeadlineExceeded),
+	})
+	headerBytes, path, err := provider.GetProofPathContext(
+		context.Background(), make([]byte, 32), make([]byte, 32), message.LedgerMapAccountState,
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Nil(t, headerBytes)
+	assert.Nil(t, path)
+}
+
+func TestLedgerProvider_ContextCancellationWinsOverLookupErrorTranslation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(*LedgerProvider, context.Context) error
+	}{
+		{
+			name: "replay delta",
+			call: func(provider *LedgerProvider, ctx context.Context) error {
+				_, _, err := provider.GetReplayDeltaContext(ctx, make([]byte, 32))
+				return err
+			},
+		},
+		{
+			name: "proof path",
+			call: func(provider *LedgerProvider, ctx context.Context) error {
+				_, _, err := provider.GetProofPathContext(
+					ctx, make([]byte, 32), make([]byte, 32), message.LedgerMapAccountState,
+				)
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			provider := newLedgerProviderForTest(&contextErrorLookup{
+				fakeLookup:   newFakeLookup(),
+				err:          errors.New("storage unavailable"),
+				beforeReturn: cancel,
+			})
+			require.ErrorIs(t, tc.call(provider, ctx), context.Canceled)
+		})
 	}
 }
 

--- a/internal/consensus/adaptor/ledger_provider_test.go
+++ b/internal/consensus/adaptor/ledger_provider_test.go
@@ -321,9 +321,10 @@ func TestLedgerProvider_GetProofPath_TxMap_Existing(t *testing.T) {
 	provider := newLedgerProviderForTest(lookup)
 
 	hash := closed.Hash()
-	header, path, err := provider.GetProofPath(hash[:], txs[0].key[:], message.LedgerMapTransaction)
+	headerBytes, path, err := provider.GetProofPath(hash[:], txs[0].key[:], message.LedgerMapTransaction)
 	require.NoError(t, err)
-	assert.Equal(t, closed.SerializeHeader(), header)
+	assert.Equal(t, header.AddRaw(closed.Header(), false), headerBytes)
+	assert.Len(t, headerBytes, header.SizeBase)
 	require.NotEmpty(t, path, "proof path for an existing key must be non-empty")
 }
 
@@ -352,9 +353,10 @@ func TestLedgerProvider_GetProofPath_StateMap_Existing(t *testing.T) {
 	provider := newLedgerProviderForTest(lookup)
 
 	hash := closed.Hash()
-	header, path, err := provider.GetProofPath(hash[:], targetKey[:], message.LedgerMapAccountState)
+	headerBytes, path, err := provider.GetProofPath(hash[:], targetKey[:], message.LedgerMapAccountState)
 	require.NoError(t, err)
-	assert.Equal(t, closed.SerializeHeader(), header)
+	assert.Equal(t, header.AddRaw(closed.Header(), false), headerBytes)
+	assert.Len(t, headerBytes, header.SizeBase)
 	require.NotEmpty(t, path, "proof path for an existing state key must be non-empty")
 }
 

--- a/internal/peermanagement/inbound_budget_test.go
+++ b/internal/peermanagement/inbound_budget_test.go
@@ -290,6 +290,69 @@ func TestServePeerCancellationReleasesQueuedDecodedBudget(t *testing.T) {
 	require.Zero(t, readBudgetUsed(budget))
 }
 
+func TestReplayAndProofRequestsRetainBudgetUntilServeCompletion(t *testing.T) {
+	tests := []struct {
+		name    string
+		msgType message.MessageType
+		request message.Message
+	}{
+		{
+			name:    "replay delta",
+			msgType: message.TypeReplayDeltaReq,
+			request: &message.ReplayDeltaRequest{LedgerHash: bytes.Repeat([]byte{0x01}, 32)},
+		},
+		{
+			name:    "proof path",
+			msgType: message.TypeProofPathReq,
+			request: &message.ProofPathRequest{
+				Key:        bytes.Repeat([]byte{0x02}, 32),
+				LedgerHash: bytes.Repeat([]byte{0x03}, 32),
+				MapType:    message.LedgerMapAccountState,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := message.Encode(tt.request)
+			require.NoError(t, err)
+			budget := newReadBudget(int64(len(payload)))
+			require.NoError(t, budget.acquire(context.Background(), nil, int64(len(payload))))
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			scheduler := newServeScheduler(ctx, 1, 1, 1, 1)
+			peer := newLatencyTestPeer(t)
+			capabilities := NewPeerCapabilities()
+			capabilities.Features.Enable(FeatureLedgerReplay)
+			peer.capabilities = capabilities
+			cfg := DefaultConfig()
+			cfg.EnableLedgerReplay = true
+			overlay := &Overlay{
+				cfg:            cfg,
+				peers:          map[PeerID]*Peer{peer.ID(): peer},
+				serveScheduler: scheduler,
+				ctx:            ctx,
+				lifecycleState: overlayLifecycleRunning,
+				ledgerSync:     NewLedgerSyncHandler(nil),
+			}
+			overlay.onMessageReceived(Event{
+				Type:        EventMessageReceived,
+				PeerID:      peer.ID(),
+				MessageType: uint16(tt.msgType),
+				Payload:     payload,
+				reservation: newInboundReservation(budget, int64(len(payload))),
+			})
+			require.Equal(t, int64(len(payload)), readBudgetUsed(budget))
+
+			task, ok := scheduler.take(ctx)
+			require.True(t, ok)
+			task.run(task.ctx)
+			scheduler.finish(task)
+			require.Zero(t, readBudgetUsed(budget))
+		})
+	}
+}
+
 func TestStopDrainsRetainedEventsQueuedAfterRunCompletion(t *testing.T) {
 	o, err := New(WithDataDir(t.TempDir()))
 	require.NoError(t, err)

--- a/internal/peermanagement/ledgersync.go
+++ b/internal/peermanagement/ledgersync.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 )
 
 // Sentinel errors returned by LedgerProvider methods so handlers can map
@@ -18,35 +19,43 @@ import (
 // rippled/src/xrpld/app/ledger/detail/LedgerReplayMsgHandler.cpp:62-90.
 var (
 	// ErrLedgerNotFound signals the requested ledger is unknown to the
-	// provider or not yet immutable. The handler responds with
-	// ReplyErrorNoLedger.
+	// provider or not yet immutable. The handler charges and drops the request.
 	ErrLedgerNotFound = errors.New("ledger not found")
 	// ErrKeyNotFound signals the ledger exists but the requested key has
-	// no leaf in the selected map. The handler responds with
-	// ReplyErrorNoNode.
+	// no leaf in the selected map. The handler charges and drops the request.
 	ErrKeyNotFound = errors.New("key not found in ledger map")
 	// ErrFetchPackTooEarly signals that the requested HAVE ledger is below
 	// the configured peer-serving range.
 	ErrFetchPackTooEarly = errors.New("fetch pack ledger is too early")
+	// ErrFetchPackOpen signals that the requested HAVE ledger is known but
+	// still open. Rippled treats this malformed fetch-pack request differently
+	// from an unknown ledger when charging the requester.
+	ErrFetchPackOpen = errors.New("fetch pack ledger is open")
 	// ErrPeerBadRequest is returned by LedgerSyncHandler.HandleMessage
 	// when the inbound request was malformed (e.g. bad field lengths,
-	// invalid enum values) and we replied with ReplyErrorBadRequest. The
-	// overlay dispatcher uses it to attribute the failure to the
-	// originating peer via IncPeerBadData. Mirrors rippled's
-	// fee.update(feeInvalidData) path for reBAD_REQUEST replies.
+	// invalid enum values). The handler charges and drops the request; the
+	// overlay dispatcher uses this error to attribute the
+	// failure to the originating peer, mirroring rippled's malformed-request
+	// charge path.
 	ErrPeerBadRequest = errors.New("peer sent bad request")
 )
 
+// ContextLedgerProvider is implemented by providers that can stop storage
+// traversal when the serving request is canceled. The legacy methods remain
+// part of LedgerProvider so embedders and tests can migrate independently.
+type ContextLedgerProvider interface {
+	GetReplayDeltaContext(context.Context, []byte) (header []byte, txLeaves [][]byte, err error)
+	GetProofPathContext(context.Context, []byte, []byte, message.LedgerMapType) (header []byte, path [][]byte, err error)
+}
+
 // Ledger sync constants.
 const (
-	// MaxReplayDeltaResponseBytes caps the total uncompressed payload size of
-	// a single mtREPLAY_DELTA_RESPONSE we will emit. Rippled does not enforce
-	// an upstream cap, but our framing layer enforces its own limit
-	// (message.MaxMessageSize = 64 MiB) and any response above that boundary
-	// would be dropped at the codec layer. A 16 MiB ceiling leaves comfortable
-	// headroom for the wire envelope and protects the event channel from
-	// arbitrarily large allocations driven by remote requests.
+	// MaxReplayDeltaResponseBytes caps the complete encoded wire frame of a
+	// replay/proof response. The check deliberately includes protobuf field
+	// tags, varints, and the six-byte XRPL frame header rather than only raw
+	// ledger node bytes.
 	MaxReplayDeltaResponseBytes = 16 * 1024 * 1024
+	MaxProofPathResponseBytes   = MaxReplayDeltaResponseBytes
 )
 
 // LedgerProvider is called to retrieve ledger data for responses.
@@ -57,7 +66,7 @@ type LedgerProvider interface {
 	// (mirrors rippled's ledger->isImmutable() check in
 	// LedgerReplayMsgHandler::processReplayDeltaRequest). When the ledger
 	// is unknown or not yet immutable, return (nil, nil, nil) so the
-	// handler can reply with reNO_LEDGER.
+	// handler can charge and drop the request.
 	GetReplayDelta(ledgerHash []byte) (header []byte, txLeaves [][]byte, err error)
 	// GetProofPath returns the serialized ledger header and the wire-order
 	// node path proving the existence of `key` in the requested map of
@@ -74,16 +83,16 @@ type LedgerProvider interface {
 	//
 	// Return contract:
 	//   - (nil, nil, ErrLedgerNotFound) when the ledger is unknown or not
-	//     yet immutable. The handler emits ReplyErrorNoLedger.
+	//     yet immutable. The handler charges and drops the request.
 	//   - (nil, nil, ErrKeyNotFound) when the ledger exists but the key
-	//     has no leaf in the selected map. The handler emits
-	//     ReplyErrorNoNode. Rippled returns reNO_NODE without a header
-	//     in this case (LedgerReplayMsgHandler.cpp:84-90, where header
-	//     packing happens AFTER the no-path early-return), so we mirror
-	//     that and do not require the header here.
+	//     has no leaf in the selected map. The handler charges and drops
+	//     the request. Rippled returns reNO_NODE without a header in this
+	//     case (LedgerReplayMsgHandler.cpp:84-90, where header packing
+	//     happens AFTER the no-path early-return), so we retain the
+	//     provider distinction for accounting without serializing an error.
 	//   - (header, path, nil) on success.
-	//   - any other error → handler emits ReplyErrorBadRequest and logs
-	//     at warn.
+	//   - any other error → handler charges the no-reply fee, logs at warn,
+	//     and drops the request.
 	GetProofPath(ledgerHash []byte, key []byte, mapType message.LedgerMapType) (header []byte, path [][]byte, err error)
 	// MakeFetchPack builds a fetch-pack for the predecessor of the ledger
 	// named by haveLedgerHash, mirroring rippled's LedgerMaster::makeFetchPack
@@ -91,9 +100,10 @@ type LedgerProvider interface {
 	// HAS, and the provider returns the SHAMap nodes of its parent ("want") —
 	// a header object followed by the account-state and transaction tree
 	// nodes, each tagged with want's sequence. Returns ErrFetchPackTooEarly
-	// when HAVE is below the configured range. Unknown, open, or parentless
-	// ledgers return (nil, nil), so the handler drops the request without
-	// replying. maxObjects <= 0 lets the provider apply its own cap.
+	// when HAVE is below the configured range. Unknown or parentless ledgers
+	// return (nil, nil), while an open HAVE returns ErrFetchPackOpen so the
+	// handler can apply rippled's malformed-request charge. maxObjects <= 0
+	// lets the provider apply its own cap.
 	MakeFetchPack(haveLedgerHash [32]byte, maxObjects int) ([]message.IndexedObject, error)
 }
 
@@ -107,10 +117,19 @@ type LedgerSyncHandler struct {
 	// Event channel for sending responses
 	events chan<- Event
 
+	// prioritySender delivers completed responses directly to the peer's
+	// bounded acquisition lane. It avoids routing replies through the lossy
+	// shared event channel when the overlay is running.
+	prioritySender func(context.Context, PeerID, []byte) error
+
 	// droppedResponses counts how many response events we had to drop
 	// because the events channel was full (slow consumer). Exposed via
 	// DroppedResponses so the overlay can aggregate into server_info.
 	droppedResponses atomic.Uint64
+
+	// chargePeer is wired by the Overlay so request accounting stays with the
+	// peer that originated the work. It is optional for standalone handlers.
+	chargePeer func(PeerID, resource.Charge, string)
 
 	// peerHintLookup is wired by the Overlay (see SetPeerLedgerHintLookup).
 	peerHintLookup func(target [32]byte) []PeerID
@@ -135,6 +154,27 @@ func (h *LedgerSyncHandler) SetProvider(provider LedgerProvider) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.provider = provider
+}
+
+func (h *LedgerSyncHandler) SetChargePeer(fn func(PeerID, resource.Charge, string)) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.chargePeer = fn
+}
+
+func (h *LedgerSyncHandler) SetPrioritySender(fn func(context.Context, PeerID, []byte) error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.prioritySender = fn
+}
+
+func (h *LedgerSyncHandler) charge(peerID PeerID, fee resource.Charge, reason string) {
+	h.mu.RLock()
+	fn := h.chargePeer
+	h.mu.RUnlock()
+	if fn != nil {
+		fn(peerID, fee, reason)
+	}
 }
 
 // MakeFetchPack delegates to the configured provider so the overlay's
@@ -196,9 +236,8 @@ func (h *LedgerSyncHandler) HandleMessage(ctx context.Context, peerID PeerID, ms
 // Mirrors rippled's LedgerReplayMsgHandler::processProofPathRequest
 // (rippled/src/xrpld/app/ledger/detail/LedgerReplayMsgHandler.cpp:40-104):
 //  1. Validate len(key) == 32, len(ledgerHash) == 32, type ∈ {1, 2}.
-//     Any failure → reply with reBAD_REQUEST. The fields key/ledgerHash/
-//     type are echoed back on every reply, even on validation errors —
-//     rippled sets them before any further checks.
+//     Any failure is charged and dropped by PeerImp; no error response is
+//     sent. The decoded request fields are not echoed on this path.
 //  2. Look up the ledger by hash. Missing → reBAD_REQUEST is wrong; the
 //     spec says reNO_LEDGER. Provider returns ErrLedgerNotFound here.
 //  3. Walk the selected map (tx or account-state) toward the key. If the
@@ -210,20 +249,14 @@ func (h *LedgerSyncHandler) HandleMessage(ctx context.Context, peerID PeerID, ms
 //  4. On success, emit (header, path) with leaf-to-root path order
 //     matching rippled's wire format (see GetProofPath docstring).
 //
-// The encoded response is pushed onto the events channel as
-// EventLedgerResponse so the overlay can ship it to the requesting peer
-// (mirrors handleReplayDeltaRequest).
-func (h *LedgerSyncHandler) handleProofPathRequest(_ context.Context, peerID PeerID, req *message.ProofPathRequest) error {
+// Successful responses use the peer's bounded acquisition lane when wired by
+// the overlay; standalone handlers fall back to EventLedgerResponse.
+func (h *LedgerSyncHandler) handleProofPathRequest(ctx context.Context, peerID PeerID, req *message.ProofPathRequest) error {
 	// Validate up-front: independent of any configured provider, matching
 	// rippled's ordering at LedgerReplayMsgHandler.cpp:46-54.
 	if len(req.Key) != 32 || len(req.LedgerHash) != 32 ||
 		(req.MapType != message.LedgerMapTransaction && req.MapType != message.LedgerMapAccountState) {
-		h.sendProofPathResponse(peerID, &message.ProofPathResponse{
-			Key:        req.Key,
-			LedgerHash: req.LedgerHash,
-			MapType:    req.MapType,
-			Error:      message.ReplyErrorBadRequest,
-		})
+		h.charge(peerID, resource.FeeMalformedRequest, "proof path request")
 		return ErrPeerBadRequest
 	}
 
@@ -232,30 +265,35 @@ func (h *LedgerSyncHandler) handleProofPathRequest(_ context.Context, peerID Pee
 	h.mu.RUnlock()
 
 	if provider == nil {
-		// No provider wired: silently drop (matches handleReplayDeltaRequest).
+		h.charge(peerID, resource.FeeRequestNoReply, "proof path request unavailable")
 		return nil
 	}
 
-	header, path, err := provider.GetProofPath(req.LedgerHash, req.Key, req.MapType)
+	var header []byte
+	var path [][]byte
+	var err error
+	if contextProvider, ok := provider.(ContextLedgerProvider); ok {
+		header, path, err = contextProvider.GetProofPathContext(ctx, req.LedgerHash, req.Key, req.MapType)
+	} else {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		header, path, err = provider.GetProofPath(req.LedgerHash, req.Key, req.MapType)
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
 	switch {
 	case errors.Is(err, ErrLedgerNotFound):
-		h.sendProofPathResponse(peerID, &message.ProofPathResponse{
-			Key:        req.Key,
-			LedgerHash: req.LedgerHash,
-			MapType:    req.MapType,
-			Error:      message.ReplyErrorNoLedger,
-		})
+		h.charge(peerID, resource.FeeRequestNoReply, "proof path request no ledger")
 		return nil
 	case errors.Is(err, ErrKeyNotFound):
 		// Rippled does not pack the header on the no-node path —
 		// LedgerReplayMsgHandler.cpp:84-90 returns before the header is
 		// serialized at line 92. Mirror that here.
-		h.sendProofPathResponse(peerID, &message.ProofPathResponse{
-			Key:        req.Key,
-			LedgerHash: req.LedgerHash,
-			MapType:    req.MapType,
-			Error:      message.ReplyErrorNoNode,
-		})
+		h.charge(peerID, resource.FeeRequestNoReply, "proof path request no node")
 		return nil
 	case err != nil:
 		slog.Warn("ProofPath provider error",
@@ -263,19 +301,18 @@ func (h *LedgerSyncHandler) handleProofPathRequest(_ context.Context, peerID Pee
 			"peer", peerID,
 			"err", err,
 		)
-		// Provider returned an unexpected error; we reply with
-		// reBAD_REQUEST but the fault is ours, not the peer's, so do
-		// not signal ErrPeerBadRequest here.
-		h.sendProofPathResponse(peerID, &message.ProofPathResponse{
-			Key:        req.Key,
-			LedgerHash: req.LedgerHash,
-			MapType:    req.MapType,
-			Error:      message.ReplyErrorBadRequest,
-		})
+		// Provider returned an unexpected error; the fault is ours, not the
+		// peer's, so charge the no-reply fee without signaling bad input.
+		h.charge(peerID, resource.FeeRequestNoReply, "proof path request provider error")
 		return nil
 	}
 
-	h.sendProofPathResponse(peerID, &message.ProofPathResponse{
+	if proofPathResponseOversized(req, header, path) {
+		h.charge(peerID, resource.FeeRequestNoReply, "proof path response oversized")
+		return nil
+	}
+
+	h.sendProofPathResponse(ctx, peerID, &message.ProofPathResponse{
 		Key:          req.Key,
 		LedgerHash:   req.LedgerHash,
 		MapType:      req.MapType,
@@ -286,17 +323,19 @@ func (h *LedgerSyncHandler) handleProofPathRequest(_ context.Context, peerID Pee
 }
 
 // sendProofPathResponse encodes the response, wraps it in the XRPL
-// wire-frame header (6-byte type/size envelope), and best-effort delivers
-// it onto the events channel for the overlay to ship to the requesting
-// peer. Drops the response (with a warn log) if the events channel is
-// full — same non-blocking pattern as sendReplayDeltaResponse.
+// wire-frame header (6-byte type/size envelope), and delivers it through the
+// bounded priority lane. Standalone handlers without a priority sender use
+// the legacy non-blocking event fallback.
 //
 // The wire-frame wrap lives here (not in the overlay) so the Event
 // payload is a fully-formed frame that Overlay.onLedgerResponse can
 // hand straight to the peer's send queue. Mirrors the handlePing
 // round-trip in overlay.go, which also emits a complete wire frame.
-func (h *LedgerSyncHandler) sendProofPathResponse(peerID PeerID, resp *message.ProofPathResponse) {
-	if h.events == nil {
+func (h *LedgerSyncHandler) sendProofPathResponse(ctx context.Context, peerID PeerID, resp *message.ProofPathResponse) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
 		return
 	}
 	frame, err := message.EncodeFrame(resp)
@@ -304,8 +343,27 @@ func (h *LedgerSyncHandler) sendProofPathResponse(peerID PeerID, resp *message.P
 		slog.Warn("ProofPath encode failed", "t", "LedgerSync", "peer", peerID, "err", err)
 		return
 	}
+	if len(frame) > MaxProofPathResponseBytes {
+		h.charge(peerID, resource.FeeRequestNoReply, "proof path response oversized")
+		return
+	}
+	h.mu.RLock()
+	prioritySender := h.prioritySender
+	events := h.events
+	h.mu.RUnlock()
+	if prioritySender != nil {
+		if err := prioritySender(ctx, peerID, frame); err != nil && ctx.Err() == nil {
+			h.droppedResponses.Add(1)
+			h.charge(peerID, resource.FeeRequestNoReply, "proof path response send failed")
+			slog.Debug("ProofPath priority response failed", "t", "LedgerSync", "peer", peerID, "err", err)
+		}
+		return
+	}
+	if events == nil {
+		return
+	}
 	select {
-	case h.events <- Event{Type: EventLedgerResponse, PeerID: peerID, Payload: frame}:
+	case events <- Event{Type: EventLedgerResponse, PeerID: peerID, Payload: frame}:
 	default:
 		h.droppedResponses.Add(1)
 		slog.Warn("ProofPath response dropped: events channel full",
@@ -313,34 +371,44 @@ func (h *LedgerSyncHandler) sendProofPathResponse(peerID PeerID, resp *message.P
 	}
 }
 
+func replayDeltaResponseOversized(ledgerHash, header []byte, txLeaves [][]byte) bool {
+	frame, err := message.EncodeFrame(&message.ReplayDeltaResponse{
+		LedgerHash:   ledgerHash,
+		LedgerHeader: header,
+		Transactions: txLeaves,
+	})
+	return err != nil || len(frame) > MaxReplayDeltaResponseBytes
+}
+
+func proofPathResponseOversized(req *message.ProofPathRequest, header []byte, path [][]byte) bool {
+	frame, err := message.EncodeFrame(&message.ProofPathResponse{
+		Key:          req.Key,
+		LedgerHash:   req.LedgerHash,
+		MapType:      req.MapType,
+		LedgerHeader: header,
+		Path:         path,
+	})
+	return err != nil || len(frame) > MaxProofPathResponseBytes
+}
+
 // handleReplayDeltaRequest serves an inbound mtREPLAY_DELTA_REQUEST.
 //
 // Mirrors rippled's LedgerReplayMsgHandler::processReplayDeltaRequest
 // (rippled/src/xrpld/app/ledger/detail/LedgerReplayMsgHandler.cpp:179-219):
-//  1. Validate ledger_hash length == 32, else reply with reBAD_REQUEST.
-//  2. Look up the ledger and require it to be immutable, else reply with
-//     reNO_LEDGER. Both checks are folded into LedgerProvider.GetReplayDelta.
+//  1. Validate ledger_hash length == 32, else charge and drop.
+//  2. Look up the ledger and require it to be immutable, else charge and drop.
 //  3. Pack the ledger header (addRaw on LedgerInfo) and every leaf blob in
 //     the tx map, in tx-map iteration order.
 //  4. Defensive size cap: if the response payload would exceed
-//     MaxReplayDeltaResponseBytes, reply with reNO_LEDGER and drop the
-//     populated transaction list. TMReplyError has no reTOO_BUSY; we
-//     pick reNO_LEDGER over reBAD_REQUEST because the request itself is
-//     well-formed — we just can't serve a response of this size. The
-//     lighter error avoids charging the requester feeMalformedRequest
-//     on rippled's side (PeerImp.cpp:1545-1548).
+//     MaxReplayDeltaResponseBytes, charge and drop the populated list.
 //
-// The encoded response is pushed onto the events channel as
-// EventLedgerResponse so the overlay can ship it to the requesting peer
-// (mirrors handleProofPathRequest).
-func (h *LedgerSyncHandler) handleReplayDeltaRequest(_ context.Context, peerID PeerID, req *message.ReplayDeltaRequest) error {
+// Successful responses use the peer's bounded acquisition lane when wired by
+// the overlay; standalone handlers fall back to EventLedgerResponse.
+func (h *LedgerSyncHandler) handleReplayDeltaRequest(ctx context.Context, peerID PeerID, req *message.ReplayDeltaRequest) error {
 	// Validate ledger_hash length first — this check is independent of any
 	// configured provider, matching the rippled ordering.
 	if len(req.LedgerHash) != 32 {
-		h.sendReplayDeltaResponse(peerID, &message.ReplayDeltaResponse{
-			LedgerHash: req.LedgerHash,
-			Error:      message.ReplyErrorBadRequest,
-		})
+		h.charge(peerID, resource.FeeMalformedRequest, "replay delta request")
 		return ErrPeerBadRequest
 	}
 
@@ -349,45 +417,45 @@ func (h *LedgerSyncHandler) handleReplayDeltaRequest(_ context.Context, peerID P
 	h.mu.RUnlock()
 
 	if provider == nil {
-		// No provider wired: silently drop (matches handleProofPathRequest).
+		h.charge(peerID, resource.FeeRequestNoReply, "replay delta request unavailable")
 		return nil
 	}
 
-	header, txLeaves, err := provider.GetReplayDelta(req.LedgerHash)
+	var header []byte
+	var txLeaves [][]byte
+	var err error
+	if contextProvider, ok := provider.(ContextLedgerProvider); ok {
+		header, txLeaves, err = contextProvider.GetReplayDeltaContext(ctx, req.LedgerHash)
+	} else {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		header, txLeaves, err = provider.GetReplayDelta(req.LedgerHash)
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
 	if err != nil || len(header) == 0 {
-		h.sendReplayDeltaResponse(peerID, &message.ReplayDeltaResponse{
-			LedgerHash: req.LedgerHash,
-			Error:      message.ReplyErrorNoLedger,
-		})
+		h.charge(peerID, resource.FeeRequestNoReply, "replay delta request no ledger")
 		return nil
 	}
 
-	// Defensive size cap: refuse to encode a response above our ceiling.
-	// Use ReplyErrorNoLedger rather than ReplyErrorBadRequest — the
-	// request isn't malformed, we just can't serve the response at this
-	// size. Rippled's PeerImp.cpp:1545-1548 charges feeMalformedRequest
-	// (200 drops) for reBAD_REQUEST vs feeRequestNoReply (10 drops) for
-	// everything else, so the lighter error code avoids wrongly fee-
-	// charging an honest requester.
-	total := len(header)
-	for _, tx := range txLeaves {
-		total += len(tx)
-	}
-	if total > MaxReplayDeltaResponseBytes {
+	// Defensive size cap: refuse to encode a response above our ceiling and
+	// charge the no-reply fee; the request itself is well-formed.
+	if replayDeltaResponseOversized(req.LedgerHash, header, txLeaves) {
 		slog.Warn("ReplayDelta response oversized; refusing",
 			"t", "LedgerSync",
 			"peer", peerID,
-			"size", total,
+			"size", len(header),
 			"limit", MaxReplayDeltaResponseBytes,
 		)
-		h.sendReplayDeltaResponse(peerID, &message.ReplayDeltaResponse{
-			LedgerHash: req.LedgerHash,
-			Error:      message.ReplyErrorNoLedger,
-		})
+		h.charge(peerID, resource.FeeRequestNoReply, "replay delta response oversized")
 		return nil
 	}
 
-	h.sendReplayDeltaResponse(peerID, &message.ReplayDeltaResponse{
+	h.sendReplayDeltaResponse(ctx, peerID, &message.ReplayDeltaResponse{
 		LedgerHash:   req.LedgerHash,
 		LedgerHeader: header,
 		Transactions: txLeaves,
@@ -396,11 +464,9 @@ func (h *LedgerSyncHandler) handleReplayDeltaRequest(_ context.Context, peerID P
 }
 
 // sendReplayDeltaResponse encodes the response, wraps it in the XRPL
-// wire-frame header (6-byte type/size envelope), and best-effort delivers
-// it onto the events channel for the overlay to ship to the requesting
-// peer. Drops the response (with a warn log) if the events channel is
-// full — same non-blocking pattern as Overlay.onMessageReceived, to keep
-// a slow consumer from deadlocking the message dispatch path.
+// wire-frame header (6-byte type/size envelope), and delivers it through the
+// bounded priority lane. Standalone handlers without a priority sender use
+// the legacy non-blocking event fallback.
 //
 // The wire-frame wrap lives here (not in the overlay) so the Event
 // payload is a fully-formed frame that Overlay.onLedgerResponse can
@@ -408,8 +474,11 @@ func (h *LedgerSyncHandler) handleReplayDeltaRequest(_ context.Context, peerID P
 // peer on the other end parses the first 6 protobuf bytes as a garbage
 // frame header and stalls reading the phantom payload — the regression
 // this commit fixes.
-func (h *LedgerSyncHandler) sendReplayDeltaResponse(peerID PeerID, resp *message.ReplayDeltaResponse) {
-	if h.events == nil {
+func (h *LedgerSyncHandler) sendReplayDeltaResponse(ctx context.Context, peerID PeerID, resp *message.ReplayDeltaResponse) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
 		return
 	}
 	frame, err := message.EncodeFrame(resp)
@@ -417,8 +486,27 @@ func (h *LedgerSyncHandler) sendReplayDeltaResponse(peerID PeerID, resp *message
 		slog.Warn("ReplayDelta encode failed", "t", "LedgerSync", "peer", peerID, "err", err)
 		return
 	}
+	if len(frame) > MaxReplayDeltaResponseBytes {
+		h.charge(peerID, resource.FeeRequestNoReply, "replay delta response oversized")
+		return
+	}
+	h.mu.RLock()
+	prioritySender := h.prioritySender
+	events := h.events
+	h.mu.RUnlock()
+	if prioritySender != nil {
+		if err := prioritySender(ctx, peerID, frame); err != nil && ctx.Err() == nil {
+			h.droppedResponses.Add(1)
+			h.charge(peerID, resource.FeeRequestNoReply, "replay delta response send failed")
+			slog.Debug("ReplayDelta priority response failed", "t", "LedgerSync", "peer", peerID, "err", err)
+		}
+		return
+	}
+	if events == nil {
+		return
+	}
 	select {
-	case h.events <- Event{Type: EventLedgerResponse, PeerID: peerID, Payload: frame}:
+	case events <- Event{Type: EventLedgerResponse, PeerID: peerID, Payload: frame}:
 	default:
 		h.droppedResponses.Add(1)
 		slog.Warn("ReplayDelta response dropped: events channel full",

--- a/internal/peermanagement/ledgersync_context_test.go
+++ b/internal/peermanagement/ledgersync_context_test.go
@@ -1,0 +1,83 @@
+package peermanagement
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
+)
+
+type contextLedgerProvider struct {
+	canceled bool
+	started  chan struct{}
+}
+
+func (p *contextLedgerProvider) GetReplayDelta([]byte) ([]byte, [][]byte, error) {
+	return []byte("header"), [][]byte{[]byte("tx")}, nil
+}
+
+func (p *contextLedgerProvider) GetProofPath([]byte, []byte, message.LedgerMapType) ([]byte, [][]byte, error) {
+	return []byte("header"), [][]byte{[]byte("path")}, nil
+}
+
+func (p *contextLedgerProvider) MakeFetchPack([32]byte, int) ([]message.IndexedObject, error) {
+	return nil, nil
+}
+
+func (p *contextLedgerProvider) GetReplayDeltaContext(ctx context.Context, _ []byte) ([]byte, [][]byte, error) {
+	if p.started != nil {
+		close(p.started)
+	}
+	<-ctx.Done()
+	p.canceled = true
+	return nil, nil, ctx.Err()
+}
+
+func (p *contextLedgerProvider) GetProofPathContext(ctx context.Context, _ []byte, _ []byte, _ message.LedgerMapType) ([]byte, [][]byte, error) {
+	<-ctx.Done()
+	p.canceled = true
+	return nil, nil, ctx.Err()
+}
+
+func TestLedgerSyncContextProviderCancellation(t *testing.T) {
+	events := make(chan Event, 1)
+	provider := &contextLedgerProvider{started: make(chan struct{})}
+	h := NewLedgerSyncHandler(events)
+	h.SetProvider(provider)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- h.HandleMessage(ctx, 1, &message.ReplayDeltaRequest{LedgerHash: make([]byte, 32)})
+	}()
+	<-provider.started
+	cancel()
+	err := <-errCh
+	if !errors.Is(err, context.Canceled) || !provider.canceled {
+		t.Fatalf("HandleMessage error/provider cancellation = %v/%v, want context canceled/true", err, provider.canceled)
+	}
+	if len(events) != 0 {
+		t.Fatal("canceled request emitted a response")
+	}
+}
+
+func TestLedgerSyncChargesMalformedAndUnavailable(t *testing.T) {
+	events := make(chan Event, 4)
+	h := NewLedgerSyncHandler(events)
+	var charges []resource.Charge
+	h.SetChargePeer(func(_ PeerID, fee resource.Charge, _ string) { charges = append(charges, fee) })
+	if err := h.HandleMessage(context.Background(), 1, &message.ReplayDeltaRequest{LedgerHash: []byte{1}}); !errors.Is(err, ErrPeerBadRequest) {
+		t.Fatalf("malformed request error = %v, want ErrPeerBadRequest", err)
+	}
+	if len(charges) != 1 || charges[0] != resource.FeeMalformedRequest {
+		t.Fatalf("malformed charges = %#v, want FeeMalformedRequest", charges)
+	}
+	charges = nil
+	if err := h.HandleMessage(context.Background(), 1, &message.ReplayDeltaRequest{LedgerHash: make([]byte, 32)}); err != nil {
+		t.Fatalf("unavailable provider error = %v", err)
+	}
+	if len(charges) != 1 || charges[0] != resource.FeeRequestNoReply {
+		t.Fatalf("unavailable charges = %#v, want FeeRequestNoReply", charges)
+	}
+}

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -891,6 +891,17 @@ func New(opts ...Option) (*Overlay, error) {
 	o.relay = NewRelay(&cfg, o.handleSquelch, o.chargeIgnoredSquelch)
 
 	o.ledgerSync.SetPeerLedgerHintLookup(o.PeersWithClosedLedger)
+	o.ledgerSync.SetChargePeer(func(peerID PeerID, fee resource.Charge, reason string) {
+		if peer, ok := o.getPeer(peerID); ok {
+			peer.Charge(fee, reason)
+		}
+	})
+	o.ledgerSync.SetPrioritySender(func(ctx context.Context, peerID PeerID, frame []byte) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return o.SendPriority(peerID, frame)
+	})
 
 	return o, nil
 }

--- a/internal/peermanagement/overlay_message.go
+++ b/internal/peermanagement/overlay_message.go
@@ -2,6 +2,7 @@ package peermanagement
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"log/slog"
@@ -157,7 +158,9 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		if !o.peerNegotiatedLedgerReplay(evt.PeerID) {
 			slog.Debug("ReplayDeltaRequest from peer without ledgerreplay feature; dropping",
 				"t", "Overlay", "peer", evt.PeerID)
-			o.IncPeerBadData(evt.PeerID, "replay-delta-req-unnegotiated")
+			if peer, ok := o.getPeer(evt.PeerID); ok {
+				peer.Charge(resource.FeeMalformedRequest, "replay delta request disabled")
+			}
 			return
 		}
 		o.dispatchReplayDeltaRequest(evt)
@@ -171,7 +174,9 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		if !o.peerNegotiatedLedgerReplay(evt.PeerID) {
 			slog.Debug("ProofPathRequest from peer without ledgerreplay feature; dropping",
 				"t", "Overlay", "peer", evt.PeerID)
-			o.IncPeerBadData(evt.PeerID, "proof-path-req-unnegotiated")
+			if peer, ok := o.getPeer(evt.PeerID); ok {
+				peer.Charge(resource.FeeMalformedRequest, "proof path request disabled")
+			}
 			return
 		}
 		o.dispatchProofPathRequest(evt)
@@ -187,7 +192,9 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		if !o.peerNegotiatedLedgerReplay(evt.PeerID) {
 			slog.Debug("TMReplayDeltaResponse from peer without ledgerreplay feature; dropping",
 				"t", "Overlay", "peer", evt.PeerID)
-			o.IncPeerBadData(evt.PeerID, "replay-delta-resp-unnegotiated")
+			if peer, ok := o.getPeer(evt.PeerID); ok {
+				peer.Charge(resource.FeeMalformedRequest, "replay delta response disabled")
+			}
 			return
 		}
 	}
@@ -195,7 +202,9 @@ func (o *Overlay) onMessageReceived(evt Event) {
 		if !o.peerNegotiatedLedgerReplay(evt.PeerID) {
 			slog.Debug("TMProofPathResponse from peer without ledgerreplay feature; dropping",
 				"t", "Overlay", "peer", evt.PeerID)
-			o.IncPeerBadData(evt.PeerID, "proof-path-resp-unnegotiated")
+			if peer, ok := o.getPeer(evt.PeerID); ok {
+				peer.Charge(resource.FeeMalformedRequest, "proof path response disabled")
+			}
 			return
 		}
 	}
@@ -417,12 +426,13 @@ func (o *Overlay) dispatchReplayDeltaRequest(evt Event) {
 	if !ok {
 		return
 	}
-	if err := o.ledgerSync.HandleMessage(o.ctx, evt.PeerID, req); err != nil {
-		slog.Debug("ReplayDeltaRequest handler error", "t", "Overlay", "peer", evt.PeerID, "err", err)
-		if errors.Is(err, ErrPeerBadRequest) {
-			o.IncPeerBadData(evt.PeerID, "replay-delta-req-bad")
-		}
-	}
+	o.submitRetainedServe(evt, resource.FeeModerateBurdenPeer,
+		func(ctx context.Context) {
+			if err := o.ledgerSync.HandleMessage(ctx, evt.PeerID, req); err != nil &&
+				!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+				slog.Debug("ReplayDeltaRequest handler error", "t", "Overlay", "peer", evt.PeerID, "err", err)
+			}
+		})
 }
 
 // dispatchProofPathRequest decodes an inbound mtPROOF_PATH_REQ frame and
@@ -443,12 +453,13 @@ func (o *Overlay) dispatchProofPathRequest(evt Event) {
 	if !ok {
 		return
 	}
-	if err := o.ledgerSync.HandleMessage(o.ctx, evt.PeerID, req); err != nil {
-		slog.Debug("ProofPathRequest handler error", "t", "Overlay", "peer", evt.PeerID, "err", err)
-		if errors.Is(err, ErrPeerBadRequest) {
-			o.IncPeerBadData(evt.PeerID, "proof-path-req-bad")
-		}
-	}
+	o.submitRetainedServe(evt, resource.FeeModerateBurdenPeer,
+		func(ctx context.Context) {
+			if err := o.ledgerSync.HandleMessage(ctx, evt.PeerID, req); err != nil &&
+				!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+				slog.Debug("ProofPathRequest handler error", "t", "Overlay", "peer", evt.PeerID, "err", err)
+			}
+		})
 }
 
 func (o *Overlay) handleStatusChange(evt Event) {
@@ -631,5 +642,5 @@ func (o *Overlay) handlePing(evt Event) bool {
 // wire header and stall for the phantom payload, which was the
 // post-handshake I/O regression fixed alongside this comment.
 func (o *Overlay) onLedgerResponse(evt Event) {
-	o.Send(evt.PeerID, evt.Payload)
+	o.SendPriority(evt.PeerID, evt.Payload)
 }

--- a/internal/peermanagement/proof_path_test.go
+++ b/internal/peermanagement/proof_path_test.go
@@ -110,6 +110,30 @@ func TestProofPathRequest_Success(t *testing.T) {
 	assert.Equal(t, message.LedgerMapAccountState, provider.gotMapType)
 }
 
+func TestProofPathRequest_PrioritySenderBypassesSharedEvents(t *testing.T) {
+	provider := &fakeProofPathProvider{header: []byte("header"), path: [][]byte{[]byte("node")}}
+	events := make(chan Event)
+	h := NewLedgerSyncHandler(events)
+	h.SetProvider(provider)
+	var gotPeer PeerID
+	var gotFrame []byte
+	h.SetPrioritySender(func(_ context.Context, peerID PeerID, frame []byte) error {
+		gotPeer = peerID
+		gotFrame = append([]byte(nil), frame...)
+		return nil
+	})
+	require.NoError(t, h.HandleMessage(context.Background(), PeerID(9), &message.ProofPathRequest{
+		Key: fixedKey(), LedgerHash: fixedHash(), MapType: message.LedgerMapAccountState,
+	}))
+	assert.Equal(t, PeerID(9), gotPeer)
+	require.NotEmpty(t, gotFrame)
+	header, _, err := message.ReadMessage(bytes.NewReader(gotFrame))
+	require.NoError(t, err)
+	assert.Equal(t, message.TypeProofPathResponse, header.MessageType)
+	assert.Empty(t, events, "completed replies must not depend on the shared event channel")
+	assert.Zero(t, h.DroppedResponses())
+}
+
 // TestProofPathRequest_BadKeyLength verifies the key length precheck:
 // any key whose length is not 32 must yield reBAD_REQUEST without
 // touching the provider. Mirrors rippled's `key().size() !=
@@ -134,13 +158,7 @@ func TestProofPathRequest_BadKeyLength(t *testing.T) {
 	require.ErrorIs(t, err, ErrPeerBadRequest,
 		"malformed request must be signaled as ErrPeerBadRequest so the dispatcher can charge the peer")
 
-	resp := drainProofPathResponse(t, events)
-	assert.Equal(t, message.ReplyErrorBadRequest, resp.Error)
-	assert.Equal(t, shortKey, resp.Key)
-	assert.Equal(t, hash, resp.LedgerHash)
-	assert.Equal(t, message.LedgerMapTransaction, resp.MapType)
-	assert.Empty(t, resp.LedgerHeader)
-	assert.Empty(t, resp.Path)
+	assert.Empty(t, events, "malformed requests are charged and dropped without a reply")
 	assert.Zero(t, provider.calls, "provider must not be called for bad-key-length requests")
 }
 
@@ -166,12 +184,7 @@ func TestProofPathRequest_BadHashLength(t *testing.T) {
 	require.ErrorIs(t, err, ErrPeerBadRequest,
 		"malformed ledger hash must be signaled as ErrPeerBadRequest")
 
-	resp := drainProofPathResponse(t, events)
-	assert.Equal(t, message.ReplyErrorBadRequest, resp.Error)
-	assert.Equal(t, key, resp.Key)
-	assert.Equal(t, shortHash, resp.LedgerHash)
-	assert.Empty(t, resp.LedgerHeader)
-	assert.Empty(t, resp.Path)
+	assert.Empty(t, events, "malformed requests are charged and dropped without a reply")
 	assert.Zero(t, provider.calls, "provider must not be called for bad-hash-length requests")
 }
 
@@ -201,13 +214,7 @@ func TestProofPathRequest_BadType(t *testing.T) {
 			require.ErrorIs(t, err, ErrPeerBadRequest,
 				"invalid map type must be signaled as ErrPeerBadRequest")
 
-			resp := drainProofPathResponse(t, events)
-			assert.Equal(t, message.ReplyErrorBadRequest, resp.Error)
-			assert.Equal(t, key, resp.Key)
-			assert.Equal(t, hash, resp.LedgerHash)
-			assert.Equal(t, badType, resp.MapType)
-			assert.Empty(t, resp.LedgerHeader)
-			assert.Empty(t, resp.Path)
+			assert.Empty(t, events, "malformed requests are charged and dropped without a reply")
 			assert.Zero(t, provider.calls, "provider must not be called for bad-type requests")
 		})
 	}
@@ -249,13 +256,7 @@ func TestProofPathRequest_UnknownLedger(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	resp := drainProofPathResponse(t, events)
-	assert.Equal(t, message.ReplyErrorNoLedger, resp.Error)
-	assert.Equal(t, key, resp.Key)
-	assert.Equal(t, hash, resp.LedgerHash)
-	assert.Equal(t, message.LedgerMapAccountState, resp.MapType)
-	assert.Empty(t, resp.LedgerHeader)
-	assert.Empty(t, resp.Path)
+	assert.Empty(t, events, "unknown ledgers are charged and dropped without a reply")
 	assert.Equal(t, 1, provider.calls)
 }
 
@@ -285,13 +286,7 @@ func TestProofPathRequest_KeyNotFound(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	resp := drainProofPathResponse(t, events)
-	assert.Equal(t, message.ReplyErrorNoNode, resp.Error)
-	assert.Equal(t, key, resp.Key)
-	assert.Equal(t, hash, resp.LedgerHash)
-	assert.Equal(t, message.LedgerMapTransaction, resp.MapType)
-	assert.Empty(t, resp.LedgerHeader, "no-node reply must NOT carry the ledger header (matches rippled)")
-	assert.Empty(t, resp.Path)
+	assert.Empty(t, events, "missing nodes are charged and dropped without a reply")
 	assert.Equal(t, 1, provider.calls)
 }
 
@@ -316,12 +311,7 @@ func TestProofPathRequest_ProviderError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	resp := drainProofPathResponse(t, events)
-	assert.Equal(t, message.ReplyErrorBadRequest, resp.Error)
-	assert.Equal(t, key, resp.Key)
-	assert.Equal(t, hash, resp.LedgerHash)
-	assert.Empty(t, resp.LedgerHeader)
-	assert.Empty(t, resp.Path)
+	assert.Empty(t, events, "provider errors are charged and dropped without a reply")
 }
 
 // TestProofPathRequest_NoProvider verifies that with no provider wired

--- a/internal/peermanagement/replay_delta_test.go
+++ b/internal/peermanagement/replay_delta_test.go
@@ -91,6 +91,28 @@ func TestReplayDeltaRequest_Success(t *testing.T) {
 	assert.Equal(t, 1, provider.calls)
 }
 
+func TestReplayDeltaRequest_PrioritySenderBypassesSharedEvents(t *testing.T) {
+	provider := &fakeReplayDeltaProvider{header: []byte("header")}
+	events := make(chan Event)
+	h := NewLedgerSyncHandler(events)
+	h.SetProvider(provider)
+	var gotPeer PeerID
+	var gotFrame []byte
+	h.SetPrioritySender(func(_ context.Context, peerID PeerID, frame []byte) error {
+		gotPeer = peerID
+		gotFrame = append([]byte(nil), frame...)
+		return nil
+	})
+	require.NoError(t, h.HandleMessage(context.Background(), PeerID(9), &message.ReplayDeltaRequest{LedgerHash: fixedHash()}))
+	assert.Equal(t, PeerID(9), gotPeer)
+	require.NotEmpty(t, gotFrame)
+	header, _, err := message.ReadMessage(bytes.NewReader(gotFrame))
+	require.NoError(t, err)
+	assert.Equal(t, message.TypeReplayDeltaResponse, header.MessageType)
+	assert.Empty(t, events, "completed replies must not depend on the shared event channel")
+	assert.Zero(t, h.DroppedResponses())
+}
+
 // TestReplayDeltaRequest_BadHashLength verifies the length precheck:
 // any ledger_hash whose length is not 32 must yield reBAD_REQUEST without
 // touching the provider. Mirrors rippled's `ledgerhash().size() !=
@@ -110,11 +132,7 @@ func TestReplayDeltaRequest_BadHashLength(t *testing.T) {
 	require.ErrorIs(t, err, ErrPeerBadRequest,
 		"malformed ledger hash must be signaled as ErrPeerBadRequest so the dispatcher can charge the peer")
 
-	resp := drainReplayDeltaResponse(t, events)
-	assert.Equal(t, message.ReplyErrorBadRequest, resp.Error)
-	assert.Equal(t, short, resp.LedgerHash)
-	assert.Empty(t, resp.LedgerHeader)
-	assert.Empty(t, resp.Transactions)
+	assert.Empty(t, events, "malformed requests are charged and dropped without a reply")
 	assert.Zero(t, provider.calls, "provider must not be called for bad-length requests")
 }
 
@@ -133,11 +151,7 @@ func TestReplayDeltaRequest_UnknownLedger(t *testing.T) {
 	err := h.HandleMessage(context.Background(), PeerID(2), &message.ReplayDeltaRequest{LedgerHash: hash})
 	require.NoError(t, err)
 
-	resp := drainReplayDeltaResponse(t, events)
-	assert.Equal(t, message.ReplyErrorNoLedger, resp.Error)
-	assert.Equal(t, hash, resp.LedgerHash)
-	assert.Empty(t, resp.LedgerHeader)
-	assert.Empty(t, resp.Transactions)
+	assert.Empty(t, events, "unknown ledgers are charged and dropped without a reply")
 	assert.Equal(t, 1, provider.calls)
 }
 
@@ -156,8 +170,7 @@ func TestReplayDeltaRequest_ProviderError(t *testing.T) {
 	err := h.HandleMessage(context.Background(), PeerID(3), &message.ReplayDeltaRequest{LedgerHash: hash})
 	require.NoError(t, err)
 
-	resp := drainReplayDeltaResponse(t, events)
-	assert.Equal(t, message.ReplyErrorNoLedger, resp.Error)
+	assert.Empty(t, events, "provider errors are charged and dropped without a reply")
 }
 
 // TestReplayDeltaRequest_NoProvider verifies that with no provider wired
@@ -207,9 +220,5 @@ func TestReplayDeltaRequest_OversizedResponse(t *testing.T) {
 	err := h.HandleMessage(context.Background(), PeerID(5), &message.ReplayDeltaRequest{LedgerHash: hash})
 	require.NoError(t, err)
 
-	resp := drainReplayDeltaResponse(t, events)
-	assert.Equal(t, message.ReplyErrorNoLedger, resp.Error)
-	assert.Equal(t, hash, resp.LedgerHash)
-	assert.Empty(t, resp.LedgerHeader, "oversized response must drop the header")
-	assert.Empty(t, resp.Transactions, "oversized response must drop the tx list")
+	assert.Empty(t, events, "oversized responses are charged and dropped without a reply")
 }


### PR DESCRIPTION
Part of #1472. Stack PR 6/11.\n\nAligns replay and proof serving with cancellation, reservation ownership, and terminal-error semantics.