### PR TITLE
fix: complete fetch pack generation (#1472)

### DIFF
--- a/internal/consensus/adaptor/fetchpack.go
+++ b/internal/consensus/adaptor/fetchpack.go
@@ -312,8 +312,7 @@ func (r *Router) haveLedgerSeq(seq uint32) bool {
 	if svc == nil {
 		return false
 	}
-	l, err := svc.GetLedgerBySequence(seq)
-	return err == nil && l != nil
+	return svc.HasCompleteLedger(seq)
 }
 
 // tryCompleteFromFetchPack runs CheckLocal against the fetch-pack cache for

--- a/internal/consensus/adaptor/fetchpack.go
+++ b/internal/consensus/adaptor/fetchpack.go
@@ -17,6 +17,8 @@ const (
 	// fetchPackCacheTargetSize is the soft target for the fetch-pack node
 	// cache.
 	fetchPackCacheTargetSize = 65536
+	fetchPackCacheMaxBytes   = int64(message.MaxMessageSize)
+	fetchPackCacheMaxNode    = message.MaxMessageSize
 	// fetchPackCacheTTL bounds how long an inbound fetch-pack node lingers
 	// while the cache is within its target size.
 	fetchPackCacheTTL = 45 * time.Second
@@ -32,32 +34,95 @@ type fetchPackCache struct {
 	mu         sync.Mutex
 	nodes      map[[32]byte]fetchPackEntry
 	targetSize int
+	maxEntries int
+	bytes      int64
+	maxBytes   int64
+	maxNode    int
 	ttl        time.Duration
+	sequence   uint64
+	order      []fetchPackOrderEntry
+	orderHead  int
 }
 
 type fetchPackEntry struct {
-	data []byte
-	at   time.Time
+	data     []byte
+	at       time.Time
+	sequence uint64
+}
+
+type fetchPackOrderEntry struct {
+	hash     [32]byte
+	sequence uint64
 }
 
 func newFetchPackCache() *fetchPackCache {
 	return &fetchPackCache{
 		nodes:      make(map[[32]byte]fetchPackEntry),
 		targetSize: fetchPackCacheTargetSize,
+		maxEntries: fetchPackCacheTargetSize,
+		maxBytes:   fetchPackCacheMaxBytes,
+		maxNode:    fetchPackCacheMaxNode,
 		ttl:        fetchPackCacheTTL,
 	}
 }
 
-// add stores a node blob keyed by its hash, stamping it with now. A newcomer is
-// always accepted, even past the target size, so a fresh, immediately-useful
-// node is never refused; the cache is bounded by sweep, not at insert.
-func (c *fetchPackCache) add(hash [32]byte, data []byte, now time.Time) {
-	if c == nil {
-		return
+// add stores a node blob keyed by its hash, evicting the oldest entries when
+// necessary to keep the cache within its byte budget.
+func (c *fetchPackCache) add(hash [32]byte, data []byte, now time.Time) bool {
+	if c == nil || c.maxEntries <= 0 || len(data) == 0 || len(data) > c.maxNode || int64(len(data)) > c.maxBytes {
+		return false
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.nodes[hash] = fetchPackEntry{data: append([]byte(nil), data...), at: now}
+	if previous, ok := c.nodes[hash]; ok {
+		delete(c.nodes, hash)
+		c.bytes -= int64(len(previous.data))
+	}
+	for len(c.nodes) >= c.maxEntries || c.bytes+int64(len(data)) > c.maxBytes {
+		if !c.evictOldestLocked() {
+			return false
+		}
+	}
+	c.sequence++
+	c.nodes[hash] = fetchPackEntry{data: append([]byte(nil), data...), at: now, sequence: c.sequence}
+	c.order = append(c.order, fetchPackOrderEntry{hash: hash, sequence: c.sequence})
+	c.bytes += int64(len(data))
+	c.compactOrderLocked()
+	return true
+}
+
+func (c *fetchPackCache) evictOldestLocked() bool {
+	for c.orderHead < len(c.order) {
+		candidate := c.order[c.orderHead]
+		c.orderHead++
+		entry, ok := c.nodes[candidate.hash]
+		if !ok || entry.sequence != candidate.sequence {
+			continue
+		}
+		delete(c.nodes, candidate.hash)
+		c.bytes -= int64(len(entry.data))
+		c.compactOrderLocked()
+		return true
+	}
+	c.compactOrderLocked()
+	return false
+}
+
+func (c *fetchPackCache) compactOrderLocked() {
+	if c.orderHead < len(c.order)/2 && len(c.order) <= 2*c.maxEntries {
+		return
+	}
+	kept := c.order[:0]
+	for i := c.orderHead; i < len(c.order); i++ {
+		candidate := c.order[i]
+		entry, ok := c.nodes[candidate.hash]
+		if ok && entry.sequence == candidate.sequence {
+			kept = append(kept, candidate)
+		}
+	}
+	clear(c.order[len(kept):])
+	c.order = kept
+	c.orderHead = 0
 }
 
 // get returns the cached blob for hash when present and unexpired, consuming the
@@ -74,6 +139,8 @@ func (c *fetchPackCache) get(hash [32]byte, now time.Time) ([]byte, bool) {
 		return nil, false
 	}
 	delete(c.nodes, hash)
+	c.bytes -= int64(len(e.data))
+	c.compactOrderLocked()
 	if now.Sub(e.at) >= c.ttl {
 		return nil, false
 	}
@@ -88,6 +155,15 @@ func (c *fetchPackCache) Size() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return len(c.nodes)
+}
+
+func (c *fetchPackCache) Bytes() int64 {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.bytes
 }
 
 // FetchPackCacheSize returns the current inbound fetch-pack cache size.
@@ -111,9 +187,11 @@ func (c *fetchPackCache) sweep(now time.Time) {
 	maxAge := c.effectiveMaxAge(len(c.nodes))
 	for h, e := range c.nodes {
 		if now.Sub(e.at) >= maxAge {
+			c.bytes -= int64(len(e.data))
 			delete(c.nodes, h)
 		}
 	}
+	c.compactOrderLocked()
 }
 
 // effectiveMaxAge is how long an entry may linger before the next sweep drops
@@ -135,11 +213,12 @@ func (c *fetchPackCache) effectiveMaxAge(size int) time.Duration {
 // locally from the cache via CheckLocal. A pack's leading ledger-header object
 // and any node that fails hash verification are dropped.
 //
-// The handler runs on the consensus router goroutine, so it bounds the work an
-// inbound reply can impose: replies are ignored unless an acquisition is in
-// flight (an unsolicited pack can complete nothing), at most the serve cap of
-// objects is hashed no matter how large the reply, and a peer that ships
-// poisoned blobs is charged.
+// The handler runs on the consensus router goroutine. Replies are ignored
+// unless an acquisition is in flight (an unsolicited pack can complete
+// nothing), and a peer that ships poisoned blobs is charged. The wire decoder
+// already bounds a reply by message.MaxMessageSize, so every object in a
+// valid frame is processed; the sender's serving cap applies only to locally
+// built packs and must not truncate a legal inbound pack.
 func (r *Router) handleFetchPackReply(msg *peermanagement.InboundMessage) {
 	if r.fetchPacks == nil {
 		return
@@ -170,17 +249,12 @@ func (r *Router) handleFetchPackReply(msg *peermanagement.InboundMessage) {
 	now := time.Now()
 	stored := 0
 	poisoned := 0
-	// Hash-verify at most the serve cap of objects per reply: a peer can
-	// legitimately serve a heavy-delta ledger above our own serve cap, so an
-	// over-large reply is truncated rather than charged, while the work it
-	// imposes on the consensus goroutine stays bounded.
-	limit := min(len(gob.Objects), fetchPackMaxObjects)
 	// Per-ledgerseq "late pack" short-circuit: skip caching nodes for a
 	// ledger we already hold. go-xrpl packs are single-ledger, but track
 	// per-object so a multi-seq pack is handled too.
 	var pLSeq uint32
 	pLDo := true
-	for i := range limit {
+	for i := range gob.Objects {
 		obj := &gob.Objects[i]
 		if len(obj.Hash) != 32 || len(obj.Data) == 0 {
 			continue
@@ -206,8 +280,9 @@ func (r *Router) handleFetchPackReply(msg *peermanagement.InboundMessage) {
 			poisoned++
 			continue
 		}
-		r.fetchPacks.add(hash, obj.Data, now)
-		stored++
+		if r.fetchPacks.add(hash, obj.Data, now) {
+			stored++
+		}
 	}
 	if poisoned > 0 {
 		r.acquisition.IncPeerBadData(uint64(msg.PeerID), "fetch-pack-poison")

--- a/internal/consensus/adaptor/fetchpack_test.go
+++ b/internal/consensus/adaptor/fetchpack_test.go
@@ -500,6 +500,15 @@ func TestHandleFetchPackReply_VerifiesAndCaches(t *testing.T) {
 	}
 }
 
+func TestHaveLedgerSeqRequiresCompleteLedger(t *testing.T) {
+	adaptor := newTestAdaptor(t)
+	r := newTestRouter(nil, adaptor, make(chan *peermanagement.InboundMessage, 1))
+	open := adaptor.LedgerService().GetOpenLedger()
+	require.NotNil(t, open)
+
+	assert.False(t, r.haveLedgerSeq(open.Sequence()))
+}
+
 // TestTryFetchPackEscalation_NoChildIsNoOp confirms the escalation is a no-op
 // (and does not consume its one-shot flag) when no child ledger is known to key
 // the pack request on — the common forward-tip case.

--- a/internal/consensus/adaptor/fetchpack_test.go
+++ b/internal/consensus/adaptor/fetchpack_test.go
@@ -2,6 +2,8 @@ package adaptor
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -24,7 +26,7 @@ func TestFetchPackCache_AddGetConsumeExpiry(t *testing.T) {
 
 	// A successful get returns the node and consumes it: a fetch-pack node is
 	// single-use, so a second get of the same hash misses.
-	c.add(h, data, t0)
+	require.True(t, c.add(h, data, t0))
 	got, ok := c.get(h, t0)
 	require.True(t, ok)
 	require.Equal(t, []byte{9, 8, 7}, got)
@@ -34,7 +36,7 @@ func TestFetchPackCache_AddGetConsumeExpiry(t *testing.T) {
 
 	// The cache copies on insert so a caller mutating its buffer can't corrupt
 	// the stored node.
-	c.add(h, data, t0)
+	require.True(t, c.add(h, data, t0))
 	data[0] = 0xFF
 	got2, ok := c.get(h, t0)
 	require.True(t, ok)
@@ -42,14 +44,99 @@ func TestFetchPackCache_AddGetConsumeExpiry(t *testing.T) {
 
 	// An entry whose age has reached the TTL is not returned (inclusive
 	// boundary), and either way the read consumes it.
-	c.add(h, data, t0)
+	require.True(t, c.add(h, data, t0))
 	if _, ok := c.get(h, t0.Add(fetchPackCacheTTL)); ok {
 		t.Error("entry at the TTL boundary was returned")
 	}
-	c.add(h, data, t0)
+	require.True(t, c.add(h, data, t0))
 	if _, ok := c.get(h, t0.Add(fetchPackCacheTTL+time.Second)); ok {
 		t.Error("expired entry returned")
 	}
+}
+
+func TestMakeFetchPack_DiffsHaveAndTraversesHistory(t *testing.T) {
+	genesisLedger := makeGenesisLedger(t)
+	first, err := ledger.NewOpen(genesisLedger, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, first.Close(time.Now(), 0))
+	second, err := ledger.NewOpen(first, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, second.Close(time.Now(), 0))
+	have, err := ledger.NewOpen(second, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, have.Close(time.Now(), 0))
+
+	lookup := newFakeLookup()
+	lookup.add(genesisLedger)
+	lookup.add(first)
+	lookup.add(second)
+	lookup.add(have)
+	p := newLedgerProviderForTest(lookup)
+	objects, err := p.MakeFetchPack(have.Hash(), 4)
+	require.NoError(t, err)
+	require.NotEmpty(t, objects)
+	assert.Equal(t, second.Sequence(), objects[0].LedgerSeq)
+	foundFirst := false
+	for _, object := range objects[1:] {
+		if object.LedgerSeq == first.Sequence() {
+			foundFirst = true
+			break
+		}
+	}
+	assert.True(t, foundFirst, "historical traversal should include the older predecessor")
+}
+
+func TestMakeFetchPack_GuardsAndCancellation(t *testing.T) {
+	want := makeGenesisLedger(t)
+	have, err := ledger.NewOpen(want, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, have.Close(time.Now(), 0))
+	lookup := newFakeLookup()
+	lookup.add(want)
+	lookup.add(have)
+	p := newLedgerProviderForTest(lookup)
+
+	p.SetFetchPackGuards(func() bool { return true }, nil)
+	objects, err := p.MakeFetchPack(have.Hash(), 0)
+	require.ErrorIs(t, err, peermanagement.ErrFetchPackBusy)
+	assert.Nil(t, objects)
+	p.SetFetchPackGuards(nil, func() time.Duration { return 41 * time.Second })
+	objects, err = p.MakeFetchPack(have.Hash(), 0)
+	require.ErrorIs(t, err, peermanagement.ErrFetchPackBusy)
+	assert.Nil(t, objects)
+
+	p.SetFetchPackGuards(nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	objects, err = p.MakeFetchPackContext(ctx, have.Hash(), 0)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, objects)
+}
+
+func TestMakeFetchPack_LookupCancellationWinsOverStorageError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	lookup := &contextErrorLookup{
+		fakeLookup:   newFakeLookup(),
+		err:          errors.New("storage unavailable"),
+		beforeReturn: cancel,
+	}
+	objects, err := newLedgerProviderForTest(lookup).MakeFetchPackContext(ctx, [32]byte{1}, 0)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, objects)
+}
+
+func TestMakeFetchPack_ExactObjectCap(t *testing.T) {
+	want := makeGenesisLedger(t)
+	have, err := ledger.NewOpen(want, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, have.Close(time.Now(), 0))
+	lookup := newFakeLookup()
+	lookup.add(want)
+	lookup.add(have)
+	p := newLedgerProviderForTest(lookup)
+	objects, err := p.MakeFetchPack(have.Hash(), 1)
+	require.NoError(t, err)
+	assert.Len(t, objects, 1, "the header consumes the exact one-object cap")
 }
 
 func TestFetchPackCache_Sweep(t *testing.T) {
@@ -63,6 +150,101 @@ func TestFetchPackCache_Sweep(t *testing.T) {
 	if _, ok := c.get([32]byte{2}, t0.Add(40*time.Second)); !ok {
 		t.Error("sweep dropped a still-fresh entry")
 	}
+	require.Zero(t, c.Bytes())
+}
+
+func TestFetchPackCache_ByteBoundEvictsOldest(t *testing.T) {
+	t.Parallel()
+	c := newFetchPackCache()
+	c.maxBytes = 6
+	c.maxNode = 4
+	t0 := time.Unix(1000, 0)
+	require.True(t, c.add([32]byte{1}, []byte{1, 1, 1}, t0))
+	require.True(t, c.add([32]byte{2}, []byte{2, 2, 2}, t0.Add(time.Second)))
+	require.True(t, c.add([32]byte{3}, []byte{3, 3, 3}, t0.Add(2*time.Second)))
+
+	require.Equal(t, int64(6), c.Bytes())
+	require.Equal(t, 2, c.Size())
+	_, ok := c.get([32]byte{1}, t0.Add(2*time.Second))
+	require.False(t, ok)
+	_, ok = c.get([32]byte{2}, t0.Add(2*time.Second))
+	require.True(t, ok)
+	require.Equal(t, int64(3), c.Bytes())
+}
+
+func TestFetchPackCache_EntryBoundEvictsOldest(t *testing.T) {
+	t.Parallel()
+	c := newFetchPackCache()
+	c.maxEntries = 2
+	t0 := time.Unix(1000, 0)
+	require.True(t, c.add([32]byte{1}, []byte{1}, t0))
+	require.True(t, c.add([32]byte{2}, []byte{2}, t0.Add(time.Second)))
+	require.True(t, c.add([32]byte{3}, []byte{3}, t0.Add(2*time.Second)))
+
+	require.Equal(t, 2, c.Size())
+	_, ok := c.get([32]byte{1}, t0.Add(2*time.Second))
+	require.False(t, ok)
+	_, ok = c.get([32]byte{3}, t0.Add(2*time.Second))
+	require.True(t, ok)
+}
+
+func TestFetchPackCache_RejectsOversizedNode(t *testing.T) {
+	t.Parallel()
+	c := newFetchPackCache()
+	c.maxBytes = 8
+	c.maxNode = 4
+	require.False(t, c.add([32]byte{1}, make([]byte, 5), time.Unix(1000, 0)))
+	require.Zero(t, c.Size())
+	require.Zero(t, c.Bytes())
+}
+
+func TestFetchPackCache_ReplacementAccounting(t *testing.T) {
+	t.Parallel()
+	c := newFetchPackCache()
+	c.maxBytes = 8
+	c.maxNode = 8
+	h := [32]byte{1}
+	t0 := time.Unix(1000, 0)
+	require.True(t, c.add(h, []byte{1, 2, 3}, t0))
+	require.True(t, c.add(h, []byte{4, 5, 6, 7, 8}, t0.Add(time.Second)))
+	require.Equal(t, int64(5), c.Bytes())
+	require.Equal(t, 1, c.Size())
+}
+
+func TestFetchPackCache_OrderCompactionBoundsReplacementTombstones(t *testing.T) {
+	t.Parallel()
+	c := newFetchPackCache()
+	c.maxEntries = 2
+	c.maxBytes = 8
+	c.maxNode = 8
+	h := [32]byte{1}
+	for i := range 100 {
+		require.True(t, c.add(h, []byte{byte(i)}, time.Unix(int64(i), 0)))
+	}
+	require.LessOrEqual(t, len(c.order), 2*c.maxEntries)
+	require.Equal(t, 1, c.Size())
+}
+
+func TestFetchPackCache_StaleOrderDoesNotEvictReinsertedEntry(t *testing.T) {
+	t.Parallel()
+	c := newFetchPackCache()
+	c.maxEntries = 2
+	t0 := time.Unix(1000, 0)
+	h1 := [32]byte{1}
+	h2 := [32]byte{2}
+	h3 := [32]byte{3}
+	require.True(t, c.add(h1, []byte{1}, t0))
+	require.True(t, c.add(h2, []byte{2}, t0.Add(time.Second)))
+	_, ok := c.get(h1, t0.Add(2*time.Second))
+	require.True(t, ok)
+	require.True(t, c.add(h1, []byte{3}, t0.Add(3*time.Second)))
+	require.True(t, c.add(h3, []byte{4}, t0.Add(4*time.Second)))
+
+	_, ok = c.get(h2, t0.Add(4*time.Second))
+	require.False(t, ok)
+	got, ok := c.get(h1, t0.Add(4*time.Second))
+	require.True(t, ok)
+	require.Equal(t, []byte{3}, got)
 }
 
 func TestFetchPackCache_AcceptsNewcomersOverTarget(t *testing.T) {
@@ -124,12 +306,13 @@ func TestFetchPackCache_EffectiveMaxAge(t *testing.T) {
 func TestFetchPackCache_NilReceiver(t *testing.T) {
 	t.Parallel()
 	var c *fetchPackCache
-	c.add([32]byte{1}, []byte{1}, time.Unix(1, 0))
+	require.False(t, c.add([32]byte{1}, []byte{1}, time.Unix(1, 0)))
 	if _, ok := c.get([32]byte{1}, time.Unix(1, 0)); ok {
 		t.Error("nil cache returned a hit")
 	}
 	c.sweep(time.Unix(1, 0))
 	require.Equal(t, 0, c.Size())
+	require.Zero(t, c.Bytes())
 	require.Equal(t, uint32(0), (*Router)(nil).FetchPackCacheSize())
 }
 
@@ -183,8 +366,49 @@ func TestMakeFetchPack_UnknownOrOpenHaveYieldsNoPack(t *testing.T) {
 	synthetic := [32]byte{0xCD}
 	lookup.byHash[synthetic] = open
 	objs, err = p.MakeFetchPack(synthetic, 0)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, peermanagement.ErrFetchPackOpen)
 	require.Nil(t, objs)
+}
+
+func TestMakeFetchPack_TargetStateCapDoesNotLimitTargetTxOrHistory(t *testing.T) {
+	genesis := makeGenesisLedger(t)
+	state, err := genesis.StateMapSnapshot()
+	require.NoError(t, err)
+	for i := 0; i < fetchPackMaxObjects+128; i++ {
+		var key [32]byte
+		key[0] = byte(i)
+		key[1] = byte(i >> 8)
+		key[31] = 0xA5
+		require.NoError(t, state.Put(key, bytes.Repeat([]byte{byte(i)}, 12)))
+	}
+	txMap, err := genesis.TxMapSnapshot()
+	require.NoError(t, err)
+	want, err := ledger.NewOpenWithHeader(genesis.Header(), state, txMap, genesis.Fees())
+	require.NoError(t, err)
+	require.NoError(t, want.Close(time.Now(), 0))
+	haveHeader := want.Header()
+	haveHeader.ParentHash = want.Hash()
+	haveHeader.LedgerIndex++
+	have, err := ledger.NewOpenWithHeader(
+		haveHeader,
+		shamap.New(shamap.TypeState),
+		shamap.New(shamap.TypeTransaction),
+		want.Fees(),
+	)
+	require.NoError(t, err)
+	require.NoError(t, have.Close(time.Now(), 0))
+
+	lookup := newFakeLookup()
+	lookup.add(want)
+	lookup.add(have)
+	objects, err := newLedgerProviderForTest(lookup).MakeFetchPack(have.Hash(), 0)
+	require.NoError(t, err)
+	assert.Greater(t, len(objects), fetchPackMaxObjects,
+		"the target ledger's state map may exceed the historical continuation gate")
+	for _, object := range objects {
+		assert.Equal(t, want.Sequence(), object.LedgerSeq,
+			"a pack over the gate must not continue to an older ledger")
+	}
 }
 
 func TestMakeFetchPack_RespectsConfiguredFetchDepth(t *testing.T) {
@@ -419,12 +643,11 @@ func TestHandleFetchPackReply_NoActiveAcquisitionDropped(t *testing.T) {
 	assert.Empty(t, rs.getBadDataCalls(), "an unsolicited pack is benign, not a charge")
 }
 
-// TestHandleFetchPackReply_OversizedTruncatedNotCharged confirms a reply
-// carrying more objects than our serve cap is processed only up to the cap and
-// the sender is NOT charged: a peer can legitimately serve a heavy-delta ledger
-// above our cap, so the surplus is truncated — bounding the consensus-goroutine
-// work without penalising an honest sender.
-func TestHandleFetchPackReply_OversizedTruncatedNotCharged(t *testing.T) {
+// TestHandleFetchPackReply_ProcessesAllWireValidObjects confirms the receiver
+// does not apply the local serving cap to an inbound pack. A valid sender may
+// return the larger state-tree allowance, and every object in the bounded wire
+// frame must be available to the acquisition.
+func TestHandleFetchPackReply_ProcessesAllWireValidObjects(t *testing.T) {
 	t.Parallel()
 	nodes := manyValidFetchPackNodes(t, fetchPackMaxObjects+1)
 	payload := encodeFetchPack(t, nodesToObjects(nodes))
@@ -437,8 +660,8 @@ func TestHandleFetchPackReply_OversizedTruncatedNotCharged(t *testing.T) {
 		Payload: payload,
 	})
 
-	assert.Equal(t, fetchPackMaxObjects, r.fetchPacks.Size(),
-		"processing is bounded to the serve cap; surplus objects are ignored")
+	assert.Equal(t, len(nodes), r.fetchPacks.Size(),
+		"every wire-valid object must be cached")
 	assert.Empty(t, rs.getBadDataCalls(),
 		"an over-cap reply from an honest peer must not be charged")
 }

--- a/internal/consensus/adaptor/ledger_provider.go
+++ b/internal/consensus/adaptor/ledger_provider.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/header"
@@ -59,8 +60,10 @@ var _ peermanagement.LedgerProvider = (*LedgerProvider)(nil)
 // internal/ledger, which is forbidden by the layering boundary between the
 // two packages.
 type LedgerProvider struct {
-	svc   ledgerLookup
-	floor MinimumOnlineFloor
+	svc          ledgerLookup
+	floor        MinimumOnlineFloor
+	loadedLocal  func() bool
+	validatedAge func() time.Duration
 }
 
 // NewLedgerProvider constructs a LedgerProvider backed by the supplied
@@ -68,7 +71,19 @@ type LedgerProvider struct {
 // every call delegates to *service.Service, which carries its own
 // synchronization.
 func NewLedgerProvider(svc *service.Service) *LedgerProvider {
-	return &LedgerProvider{svc: svc}
+	return &LedgerProvider{
+		svc:          svc,
+		loadedLocal:  func() bool { return svc.FeeTrack() != nil && svc.FeeTrack().IsLoadedLocal() },
+		validatedAge: svc.GetValidatedLedgerAge,
+	}
+}
+
+// SetFetchPackGuards installs the load and validated-age signals used by the
+// fetch-pack admission guard. It is primarily useful for embedding services
+// whose load tracker is not the standard ledger Service tracker.
+func (p *LedgerProvider) SetFetchPackGuards(loadedLocal func() bool, validatedAge func() time.Duration) {
+	p.loadedLocal = loadedLocal
+	p.validatedAge = validatedAge
 }
 
 // SetMinimumOnlineFloor installs the online-delete retention floor. Once set,
@@ -157,89 +172,185 @@ func (p *LedgerProvider) GetReplayDeltaContext(ctx context.Context, ledgerHash [
 	return headerBytes, leaves, nil
 }
 
-// fetchPackMaxObjects caps the SHAMap nodes a single fetch-pack reply carries.
-// Unlike rippled's have-diff, go-xrpl sends the want ledger's whole state+tx
-// tree — its acquisition SHAMap has no node-hash store to supply un-sent shared
-// nodes (see shamap.SHAMap.WalkFetchPackNodes). The cap bounds the reply: a
-// moderate ledger fits in one pack, while a large (mainnet-scale) tree is
-// truncated to a root-first connected prefix and the receiver completes the
-// remainder via ordinary node-by-hash requests.
-const fetchPackMaxObjects = 12288
+// fetchPackMaxObjects is LedgerMaster's historical stop condition: once a pack
+// has 512 objects, traversal stops before adding an older ledger. The target
+// ledger's state and transaction maps each have their own larger limits.
+const (
+	fetchPackMaxObjects    = 512
+	fetchPackStateMaxNodes = 16384
+	fetchPackTxMaxNodes    = 512
+	fetchPackMaxAge        = time.Second
+	fetchPackMaxBytes      = int64(60 * 1024 * 1024)
+)
 
 // MakeFetchPack builds a fetch-pack for the parent of the ledger named by
 // haveLedgerHash: the requester supplies a ledger hash it HAS, and we serve
 // its predecessor ("want"). The reply carries want's header object (hash ==
 // want's ledger hash) followed by its account-state and, when non-empty, its
 // transaction SHAMap tree nodes, each tagged with want's sequence. It returns
-// ErrFetchPackTooEarly below the configured serving range, or (nil, nil) when
-// have is unknown, not yet immutable, or its parent is unavailable.
+// ErrFetchPackTooEarly below the configured serving range, ErrFetchPackOpen
+// for a known but open HAVE, ErrFetchPackBusy when local state is unavailable
+// for construction, or (nil, nil) when have is unknown or its parent is
+// unavailable.
 func (p *LedgerProvider) MakeFetchPack(haveLedgerHash [32]byte, maxObjects int) ([]message.IndexedObject, error) {
-	have, err := p.svc.GetLedgerByHash(haveLedgerHash)
-	if err != nil || have == nil || !have.IsImmutable() {
+	return p.MakeFetchPackContext(context.Background(), haveLedgerHash, maxObjects)
+}
+
+func (p *LedgerProvider) MakeFetchPackContext(ctx context.Context, haveLedgerHash [32]byte, maxObjects int) ([]message.IndexedObject, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	explicitCap := maxObjects > 0
+	if explicitCap && maxObjects > fetchPackMaxObjects {
+		maxObjects = fetchPackMaxObjects
+	}
+	if p.loadedLocal != nil && p.loadedLocal() {
+		return nil, peermanagement.ErrFetchPackBusy
+	}
+	if p.validatedAge != nil && p.validatedAge() > 40*time.Second {
+		return nil, peermanagement.ErrFetchPackBusy
+	}
+	have, err := p.getLedgerContext(ctx, haveLedgerHash)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil, err
+	}
+	if err != nil || have == nil {
 		return nil, nil
+	}
+	if !have.IsImmutable() {
+		return nil, peermanagement.ErrFetchPackOpen
 	}
 	if have.Sequence() < p.svc.EarliestFetch() {
 		return nil, peermanagement.ErrFetchPackTooEarly
 	}
-	want, err := p.svc.GetLedgerByHash(have.Header().ParentHash)
+	capacity := fetchPackMaxObjects
+	if explicitCap {
+		capacity = maxObjects
+	}
+	objects := make([]message.IndexedObject, 0, capacity)
+	currentHave := have
+	want, err := p.getLedgerContext(ctx, have.Header().ParentHash)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil, err
+	}
 	if err != nil || want == nil || p.belowFloor(want.Sequence()) {
 		return nil, nil
 	}
-	if maxObjects <= 0 || maxObjects > fetchPackMaxObjects {
-		maxObjects = fetchPackMaxObjects
-	}
+	deadline := time.Now().Add(fetchPackMaxAge)
+	remainingBytes := fetchPackMaxBytes
 
-	seq := want.Sequence()
-	wantHdr := want.Header()
-	objects := make([]message.IndexedObject, 0, maxObjects)
-
-	// Lead with the ledger-header object (HashPrefixLedgerMaster + raw
-	// header). Its hash is want's ledger hash and sha512Half(data)
-	// reproduces it, so a peer treats it as the pack's header node. go-xrpl
-	// receivers already hold the header (via the acquisition's GotBase) and
-	// simply ignore it.
-	wantHash := want.Hash()
-	headerData := append(protocol.HashPrefixLedgerMaster().Bytes(), header.AddRaw(wantHdr, false)...)
-	objects = append(objects, message.IndexedObject{
-		Hash:      append([]byte(nil), wantHash[:]...),
-		Data:      headerData,
-		LedgerSeq: seq,
-	})
-
-	stateMap, err := want.StateMapSnapshot()
-	if err != nil {
-		return nil, fmt.Errorf("snapshot state map: %w", err)
-	}
-	objects, err = appendFetchPackNodes(objects, stateMap, maxObjects, seq)
-	if err != nil {
-		return nil, fmt.Errorf("walk state map: %w", err)
-	}
-
-	if wantHdr.TxHash != ([32]byte{}) {
-		txMap, err := want.TxMapSnapshot()
-		if err != nil {
-			return nil, fmt.Errorf("snapshot tx map: %w", err)
+packLoop:
+	for want != nil && (!explicitCap || len(objects) < maxObjects) && time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
-		objects, err = appendFetchPackNodes(objects, txMap, maxObjects, seq)
+		seq := want.Sequence()
+		wantHdr := want.Header()
+		wantHash := want.Hash()
+		headerData := append(protocol.HashPrefixLedgerMaster().Bytes(), header.AddRaw(wantHdr, false)...)
+		if int64(len(headerData)) > remainingBytes {
+			break
+		}
+		objects = append(objects, message.IndexedObject{
+			Hash:      append([]byte(nil), wantHash[:]...),
+			Data:      headerData,
+			LedgerSeq: seq,
+		})
+		remainingBytes -= int64(len(headerData))
+
+		wantState, err := want.StateMapSnapshot()
 		if err != nil {
-			return nil, fmt.Errorf("walk tx map: %w", err)
+			return nil, fmt.Errorf("snapshot state map: %w", err)
+		}
+		haveState, err := currentHave.StateMapSnapshot()
+		if err != nil {
+			return nil, fmt.Errorf("snapshot have state map: %w", err)
+		}
+		stateLimit := fetchPackStateMaxNodes
+		if explicitCap {
+			stateLimit = min(maxObjects-len(objects), stateLimit)
+		}
+		stateNodes, complete, err := wantState.WalkFetchPackDifferencesBounded(ctx, haveState, stateLimit, remainingBytes)
+		if err != nil {
+			return nil, fmt.Errorf("walk state map: %w", err)
+		}
+		objects = appendFetchPackNodesFromWalk(objects, stateNodes, seq)
+		remainingBytes -= fetchPackNodesBytes(stateNodes)
+		if !complete {
+			break packLoop
+		}
+
+		if explicitCap && len(objects) >= maxObjects {
+			break
+		}
+		if wantHdr.TxHash != ([32]byte{}) {
+			txMap, err := want.TxMapSnapshot()
+			if err != nil {
+				return nil, fmt.Errorf("snapshot tx map: %w", err)
+			}
+			txLimit := fetchPackTxMaxNodes
+			if explicitCap {
+				txLimit = min(maxObjects-len(objects), txLimit)
+			}
+			txNodes, complete, err := txMap.WalkFetchPackNodesContextBounded(ctx, txLimit, remainingBytes)
+			if err != nil {
+				return nil, fmt.Errorf("walk tx map: %w", err)
+			}
+			objects = appendFetchPackNodesFromWalk(objects, txNodes, seq)
+			remainingBytes -= fetchPackNodesBytes(txNodes)
+			if !complete {
+				break packLoop
+			}
+		}
+		if explicitCap && len(objects) >= maxObjects {
+			break
+		}
+		if len(objects) >= fetchPackMaxObjects {
+			break
+		}
+		currentHave = want
+		want, err = p.getLedgerContext(ctx, want.Header().ParentHash)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, err
+			}
+			// Historical traversal is opportunistic: once the requested
+			// predecessor has been packed, a missing older ledger simply ends
+			// the useful chain rather than failing the reply.
+			break
+		}
+		if want != nil && p.belowFloor(want.Sequence()) {
+			break
 		}
 	}
-
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return objects, nil
 }
 
-// appendFetchPackNodes walks up to the remaining-object budget of m's SHAMap
-// tree nodes and appends each as a fetch-pack object tagged with seq.
-func appendFetchPackNodes(objects []message.IndexedObject, m *shamap.SHAMap, maxObjects int, seq uint32) ([]message.IndexedObject, error) {
-	remaining := maxObjects - len(objects)
-	if remaining <= 0 {
-		return objects, nil
+func (p *LedgerProvider) getLedgerContext(ctx context.Context, hash [32]byte) (*ledger.Ledger, error) {
+	if lookup, ok := p.svc.(ledgerLookupContext); ok {
+		return lookup.GetLedgerByHashContext(ctx, hash)
 	}
-	nodes, err := m.WalkFetchPackNodes(remaining)
-	if err != nil {
-		return objects, err
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
 	}
+	return p.svc.GetLedgerByHash(hash)
+}
+
+func appendFetchPackNodesFromWalk(objects []message.IndexedObject, nodes []shamap.FetchPackNode, seq uint32) []message.IndexedObject {
 	for i := range nodes {
 		objects = append(objects, message.IndexedObject{
 			Hash:      append([]byte(nil), nodes[i].Hash[:]...),
@@ -247,7 +358,15 @@ func appendFetchPackNodes(objects []message.IndexedObject, m *shamap.SHAMap, max
 			LedgerSeq: seq,
 		})
 	}
-	return objects, nil
+	return objects
+}
+
+func fetchPackNodesBytes(nodes []shamap.FetchPackNode) int64 {
+	var total int64
+	for i := range nodes {
+		total += int64(len(nodes[i].Data))
+	}
+	return total
 }
 
 // GetProofPath serves an mtPROOF_PATH_REQ:
@@ -326,16 +445,4 @@ func (p *LedgerProvider) GetProofPathContext(
 	}
 
 	return header.AddRaw(l.Header(), false), proof.Path, nil
-}
-
-func (p *LedgerProvider) getLedgerContext(ctx context.Context, hash [32]byte) (*ledger.Ledger, error) {
-	if lookup, ok := p.svc.(ledgerLookupContext); ok {
-		return lookup.GetLedgerByHashContext(ctx, hash)
-	}
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
-	return p.svc.GetLedgerByHash(hash)
 }

--- a/internal/consensus/adaptor/ledger_provider_test.go
+++ b/internal/consensus/adaptor/ledger_provider_test.go
@@ -77,6 +77,16 @@ func (f *fakeLookup) GetLedgerByHash(hash [32]byte) (*ledger.Ledger, error) {
 
 func (f *fakeLookup) EarliestFetch() uint32 { return f.earliestFetch }
 
+type contextFakeLookup struct {
+	*fakeLookup
+	contextCalls int
+}
+
+func (f *contextFakeLookup) GetLedgerByHashContext(_ context.Context, hash [32]byte) (*ledger.Ledger, error) {
+	f.contextCalls++
+	return f.GetLedgerByHash(hash)
+}
+
 // makeGenesisLedger returns a genesis-derived, validated (and therefore
 // immutable) ledger. It is the cheapest "real" ledger we can hand the
 // provider for tests that don't need transactions in the tx map.
@@ -120,6 +130,30 @@ func makeOpenLedger(t *testing.T) *ledger.Ledger {
 	open, err := ledger.NewOpen(parent, time.Now())
 	require.NoError(t, err)
 	return open
+}
+
+func TestLedgerProvider_ContextMethodsUseCancellableLedgerLookup(t *testing.T) {
+	closed := makeGenesisLedger(t)
+	lookup := &contextFakeLookup{fakeLookup: newFakeLookup()}
+	lookup.add(closed)
+	provider := newLedgerProviderForTest(lookup)
+	hash := closed.Hash()
+
+	headerBytes, _, err := provider.GetReplayDeltaContext(context.Background(), hash[:])
+	require.NoError(t, err)
+	require.NotEmpty(t, headerBytes)
+	var key [32]byte
+	found := false
+	require.NoError(t, closed.ForEach(func(candidate [32]byte, _ []byte) bool {
+		key = candidate
+		found = true
+		return false
+	}))
+	require.True(t, found)
+	_, _, err = provider.GetProofPathContext(context.Background(), hash[:], key[:], message.LedgerMapAccountState)
+	require.NoError(t, err)
+	assert.Equal(t, 2, lookup.contextCalls,
+		"context serving paths must use the cancellable ledger lookup")
 }
 
 // fixedKey32 produces a deterministic 32-byte key with byte i+offset, so

--- a/internal/ledger/service/cache.go
+++ b/internal/ledger/service/cache.go
@@ -192,6 +192,13 @@ func (s *Service) hasCompleteLedger(l *ledger.Ledger) bool {
 	return s.completeLedgerHashes[l.Sequence()] == l.Hash()
 }
 
+// HasCompleteLedger reports whether seq belongs to the completed-ledger set.
+func (s *Service) HasCompleteLedger(seq uint32) bool {
+	s.completeMu.RLock()
+	defer s.completeMu.RUnlock()
+	return s.completedLedgers != nil && s.completedLedgers.contains(seq)
+}
+
 func (s *Service) completeLedgersString() string {
 	s.completeMu.RLock()
 	defer s.completeMu.RUnlock()

--- a/internal/peermanagement/fetchpack_test.go
+++ b/internal/peermanagement/fetchpack_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/cluster"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,6 +48,9 @@ func newFetchPackTestOverlay(t *testing.T, prov LedgerProvider) (*Overlay, *Peer
 	o.ledgerSync.SetProvider(prov)
 	peer := NewPeer(PeerID(7), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
 	o.peers[peer.ID()] = peer
+	o.ledgerSync.SetChargePeer(func(_ PeerID, fee resource.Charge, reason string) {
+		peer.Charge(fee, reason)
+	})
 	return o, peer
 }
 
@@ -94,12 +98,15 @@ func TestServeFetchPack_RepliesWithPack(t *testing.T) {
 }
 
 // TestServeFetchPack_EmptyPackNoReply: an empty pack (unknown ledger) yields no
-// reply, but the valid request is still charged feeHeavyBurdenPeer up front —
-// mirroring rippled's doFetchPack, which sets the heavy-burden fee before the
-// build regardless of whether the ledger is found (PeerImp.cpp:2773).
+// reply, but the valid request still incurs the heavy-burden and no-reply
+// charges after the provider reports that it is unavailable.
 func TestServeFetchPack_EmptyPackNoReply(t *testing.T) {
 	prov := &fakeFetchPackProvider{objects: nil}
 	o, peer := newFetchPackTestOverlay(t, prov)
+	var charges []resource.Charge
+	o.ledgerSync.SetChargePeer(func(_ PeerID, fee resource.Charge, _ string) {
+		charges = append(charges, fee)
+	})
 
 	payload, err := message.Encode(&message.GetObjectByHash{
 		ObjType:    message.ObjectTypeFetchPack,
@@ -118,20 +125,17 @@ func TestServeFetchPack_EmptyPackNoReply(t *testing.T) {
 	if _, ok := takeOutboundFrame(peer); ok {
 		t.Fatal("an empty pack must not produce a reply")
 	}
-	assert.NotZero(t, peer.BadDataCount(),
-		"a valid fetch-pack request is charged feeHeavyBurdenPeer up front even when the pack is empty")
+	assert.Equal(t, []resource.Charge{resource.FeeHeavyBurdenPeer, resource.FeeRequestNoReply}, charges,
+		"an unavailable valid request must receive heavy and no-reply charges")
 }
 
 func TestServeFetchPack_TooEarlyAddsMalformedCharge(t *testing.T) {
-	controlOverlay, controlPeer := newFetchPackTestOverlay(t, &fakeFetchPackProvider{})
-	controlOverlay.serveFetchPack(controlPeer.ID(), &message.GetObjectByHash{
-		ObjType:    message.ObjectTypeFetchPack,
-		Query:      true,
-		LedgerHash: bytes.Repeat([]byte{0x33}, 32),
-	})
-
 	prov := &fakeFetchPackProvider{err: errors.Join(ErrFetchPackTooEarly)}
 	o, peer := newFetchPackTestOverlay(t, prov)
+	var charges []resource.Charge
+	o.ledgerSync.SetChargePeer(func(_ PeerID, fee resource.Charge, _ string) {
+		charges = append(charges, fee)
+	})
 
 	o.serveFetchPack(peer.ID(), &message.GetObjectByHash{
 		ObjType:    message.ObjectTypeFetchPack,
@@ -140,9 +144,30 @@ func TestServeFetchPack_TooEarlyAddsMalformedCharge(t *testing.T) {
 	})
 
 	require.Equal(t, 1, prov.calls)
-	assert.Greater(t, peer.Load(), controlPeer.Load())
+	assert.Equal(t, []resource.Charge{resource.FeeHeavyBurdenPeer, resource.FeeMalformedRequest}, charges)
 	if _, ok := takeOutboundFrame(peer); ok {
 		t.Fatal("a too-early fetch pack must not produce a reply")
+	}
+}
+
+func TestServeFetchPack_BusyProviderIsNotCharged(t *testing.T) {
+	prov := &fakeFetchPackProvider{err: ErrFetchPackBusy}
+	o, peer := newFetchPackTestOverlay(t, prov)
+	var charges []resource.Charge
+	o.ledgerSync.SetChargePeer(func(_ PeerID, fee resource.Charge, _ string) {
+		charges = append(charges, fee)
+	})
+
+	o.serveFetchPack(peer.ID(), &message.GetObjectByHash{
+		ObjType:    message.ObjectTypeFetchPack,
+		Query:      true,
+		LedgerHash: bytes.Repeat([]byte{0x44}, 32),
+	})
+
+	require.Equal(t, 1, prov.calls)
+	assert.Empty(t, charges, "a busy fetch-pack provider must not incur heavy or no-reply charges")
+	if _, ok := takeOutboundFrame(peer); ok {
+		t.Fatal("a busy fetch pack must not produce a reply")
 	}
 }
 

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -250,7 +250,9 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 		switch gob.ObjType {
 		case message.ObjectTypeFetchPack:
 			if len(gob.LedgerHash) != 32 {
-				o.IncPeerBadData(evt.PeerID, "fetch-pack-bad-hash")
+				if peerOK {
+					peer.Charge(resource.FeeMalformedRequest, "fetch pack ledger hash")
+				}
 				return
 			}
 			// Rippled at PeerImp.cpp:2458-2462 forwards to doFetchPack.
@@ -259,8 +261,16 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 			// to the serve-worker pool — building a pack snapshots the
 			// state+tx tree (capped at fetchPackMaxObjects nodes) and
 			// must not run on the event loop.
-			o.submitRetainedServe(evt, resource.FeeHeavyBurdenPeer,
-				func(ctx context.Context) { o.serveFetchPackContext(ctx, evt.PeerID, gob) })
+			receivedAt := time.Now()
+			// The heavy charge is deferred until the worker has passed the
+			// provider's busy/stale guard. Charging at admission would make a
+			// request that was immediately refused for local load look served.
+			o.submitRetainedServe(evt, resource.Charge{},
+				func(ctx context.Context) {
+					deadlineCtx, cancel := context.WithDeadline(ctx, receivedAt.Add(time.Second))
+					defer cancel()
+					o.serveFetchPackContext(deadlineCtx, evt.PeerID, gob)
+				})
 			return
 		case message.ObjectTypeTransactions:
 			// Tx-reduce-relay back-fill request. Rippled gates on
@@ -339,20 +349,30 @@ func (o *Overlay) submitRetainedServe(
 // query=false TMGetObjectByHash. The requested ledger hash must be 32 bytes; an
 // unknown ledger or unavailable parent yields an empty pack which is dropped.
 // A request below the serving range is dropped with an additional malformed
-// request charge. Every valid-hash request is charged feeHeavyBurdenPeer up
-// front, mirroring rippled's
-// doFetchPack (PeerImp.cpp:2773): building a pack snapshots the want ledger's
+// request charge. The heavy-burden charge is applied after the provider's
+// busy/stale guard, so a locally busy request is dropped without either a
+// heavy or no-reply charge. Building a pack snapshots the want ledger's
 // state+tx tree and walks up to fetchPackMaxObjects nodes — heavier than
 // rippled's diff. go-xrpl builds the pack inline (no jtPACK job queue to bound),
-// so the send-queue back-pressure gate in handleGetObjectsMessage stands in for
-// rippled's isLoadedLocal / jtPACK busy guards (PeerImp.cpp:2758-2762).
+// so the send-queue back-pressure gate in handleGetObjectsMessage handles
+// admission while the provider reports its own busy/stale state at execution.
 func (o *Overlay) serveFetchPack(peerID PeerID, req *message.GetObjectByHash) {
-	if len(req.LedgerHash) == 32 {
-		if peer, ok := o.getPeer(peerID); ok {
-			peer.Charge(resource.FeeHeavyBurdenPeer, "fetch pack request")
+	o.serveFetchPackContext(context.Background(), peerID, req)
+}
+
+func (o *Overlay) chargeServePeer(peerID PeerID, fee resource.Charge, reason string) {
+	if o.ledgerSync != nil {
+		o.ledgerSync.mu.RLock()
+		charge := o.ledgerSync.chargePeer
+		o.ledgerSync.mu.RUnlock()
+		if charge != nil {
+			charge(peerID, fee, reason)
+			return
 		}
 	}
-	o.serveFetchPackContext(context.Background(), peerID, req)
+	if peer, ok := o.getPeer(peerID); ok {
+		peer.Charge(fee, reason)
+	}
 }
 
 func (o *Overlay) serveFetchPackContext(ctx context.Context, peerID PeerID, req *message.GetObjectByHash) {
@@ -360,7 +380,7 @@ func (o *Overlay) serveFetchPackContext(ctx context.Context, peerID PeerID, req 
 		return
 	}
 	if len(req.LedgerHash) != 32 {
-		o.IncPeerBadData(peerID, "fetch-pack-bad-hash")
+		o.chargeServePeer(peerID, resource.FeeMalformedRequest, "fetch pack ledger hash")
 		return
 	}
 
@@ -372,16 +392,27 @@ func (o *Overlay) serveFetchPackContext(ctx context.Context, peerID PeerID, req 
 	copy(haveHash[:], req.LedgerHash)
 
 	// maxObjects=0 lets the provider apply its own per-pack cap.
-	objects, err := o.ledgerSync.MakeFetchPack(haveHash, 0)
+	objects, err := o.ledgerSync.MakeFetchPackContext(ctx, haveHash, 0)
+	if errors.Is(err, ErrFetchPackBusy) {
+		slog.Debug("fetch-pack build busy", "t", "Overlay", "peer", peerID)
+		return
+	}
+	// Charge only after the provider has passed its local busy/stale guard.
+	// Unknown ledgers and other unavailable outcomes still incur the heavy
+	// request cost followed by the protocol's no-reply charge.
+	o.chargeServePeer(peerID, resource.FeeHeavyBurdenPeer, "fetch pack request")
 	if err != nil {
-		if errors.Is(err, ErrFetchPackTooEarly) {
-			peer.Charge(resource.FeeMalformedRequest, "fetch pack request too early")
+		if errors.Is(err, ErrFetchPackTooEarly) || errors.Is(err, ErrFetchPackOpen) {
+			o.chargeServePeer(peerID, resource.FeeMalformedRequest, "fetch pack malformed request")
+		} else if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			o.chargeServePeer(peerID, resource.FeeRequestNoReply, "fetch pack request unavailable")
 		}
 		slog.Debug("fetch-pack build failed",
 			"t", "Overlay", "peer", peerID, "err", err)
 		return
 	}
 	if len(objects) == 0 {
+		o.chargeServePeer(peerID, resource.FeeRequestNoReply, "fetch pack request unavailable")
 		return
 	}
 	objects = limitIndexedObjectsToReplyBudget(objects, req.LedgerHash)
@@ -398,7 +429,14 @@ func (o *Overlay) serveFetchPackContext(ctx context.Context, peerID PeerID, req 
 	if ctx.Err() != nil {
 		return
 	}
-	encodeAndSendPriority(peer, reply, "fetch-pack reply")
+	frame, err := message.EncodeFrame(reply)
+	if err != nil || len(frame) > message.MaxMessageSize {
+		o.chargeServePeer(peerID, resource.FeeRequestNoReply, "fetch pack response oversized")
+		return
+	}
+	if err := peer.SendPriority(frame); err != nil {
+		slog.Debug("fetch-pack priority send failed", "t", "Overlay", "peer", peerID, "err", err)
+	}
 }
 
 // handleHaveTransactionsMessage processes mtHAVE_TRANSACTIONS from a
@@ -801,7 +839,7 @@ func (o *Overlay) serveGetObjectsContext(ctx context.Context, peerID PeerID, req
 	// charges feeMalformedRequest "ledger hash" on a wrong-sized field
 	// and returns (PeerImp.cpp:2492-2501).
 	if len(req.LedgerHash) != 0 && len(req.LedgerHash) != 32 {
-		o.IncPeerBadData(peerID, "get-objects-ledgerhash")
+		peer.Charge(resource.FeeMalformedRequest, "get object ledger hash")
 		return
 	}
 

--- a/internal/peermanagement/ledgersync.go
+++ b/internal/peermanagement/ledgersync.go
@@ -31,6 +31,10 @@ var (
 	// still open. Rippled treats this malformed fetch-pack request differently
 	// from an unknown ledger when charging the requester.
 	ErrFetchPackOpen = errors.New("fetch pack ledger is open")
+	// ErrFetchPackBusy signals that local ledger state is temporarily busy or
+	// stale for fetch-pack construction. Busy requests are dropped before the
+	// heavy-burden charge and are retried by the requester later.
+	ErrFetchPackBusy = errors.New("fetch pack provider busy")
 	// ErrPeerBadRequest is returned by LedgerSyncHandler.HandleMessage
 	// when the inbound request was malformed (e.g. bad field lengths,
 	// invalid enum values). The handler charges and drops the request; the
@@ -46,6 +50,13 @@ var (
 type ContextLedgerProvider interface {
 	GetReplayDeltaContext(context.Context, []byte) (header []byte, txLeaves [][]byte, err error)
 	GetProofPathContext(context.Context, []byte, []byte, message.LedgerMapType) (header []byte, path [][]byte, err error)
+}
+
+// ContextFetchPackProvider is the cancellation-aware fetch-pack extension of
+// LedgerProvider. Providers that do not implement it are still bounded by the
+// scheduler and receive a pre-call cancellation check.
+type ContextFetchPackProvider interface {
+	MakeFetchPackContext(context.Context, [32]byte, int) ([]message.IndexedObject, error)
 }
 
 // Ledger sync constants.
@@ -100,9 +111,10 @@ type LedgerProvider interface {
 	// HAS, and the provider returns the SHAMap nodes of its parent ("want") —
 	// a header object followed by the account-state and transaction tree
 	// nodes, each tagged with want's sequence. Returns ErrFetchPackTooEarly
-	// when HAVE is below the configured range. Unknown or parentless ledgers
-	// return (nil, nil), while an open HAVE returns ErrFetchPackOpen so the
-	// handler can apply rippled's malformed-request charge. maxObjects <= 0
+	// when HAVE is below the configured range. A provider that is locally busy
+	// or stale returns ErrFetchPackBusy before charging; unknown or parentless
+	// ledgers return (nil, nil), while an open HAVE returns ErrFetchPackOpen so
+	// the handler can apply rippled's malformed-request charge. maxObjects <= 0
 	// lets the provider apply its own cap.
 	MakeFetchPack(haveLedgerHash [32]byte, maxObjects int) ([]message.IndexedObject, error)
 }
@@ -187,6 +199,24 @@ func (h *LedgerSyncHandler) MakeFetchPack(haveLedgerHash [32]byte, maxObjects in
 	h.mu.RUnlock()
 	if provider == nil {
 		return nil, nil
+	}
+	return provider.MakeFetchPack(haveLedgerHash, maxObjects)
+}
+
+func (h *LedgerSyncHandler) MakeFetchPackContext(ctx context.Context, haveLedgerHash [32]byte, maxObjects int) ([]message.IndexedObject, error) {
+	h.mu.RLock()
+	provider := h.provider
+	h.mu.RUnlock()
+	if provider == nil {
+		return nil, nil
+	}
+	if contextProvider, ok := provider.(ContextFetchPackProvider); ok {
+		return contextProvider.MakeFetchPackContext(ctx, haveLedgerHash, maxObjects)
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
 	}
 	return provider.MakeFetchPack(haveLedgerHash, maxObjects)
 }

--- a/shamap/fetchpack.go
+++ b/shamap/fetchpack.go
@@ -1,5 +1,7 @@
 package shamap
 
+import "context"
+
 // FetchPackNode is a single SHAMap tree node packaged for a fetch-pack: its
 // node hash (the TMIndexedObject.hash carried on the wire) and its prefix
 // serialization (SerializeWithPrefix — the [HashPrefix][body] blob whose
@@ -44,38 +46,192 @@ func (sm *SHAMap) WalkFetchPackNodes(maxNodes int) ([]FetchPackNode, error) {
 		return nil, nil
 	}
 	out := make([]FetchPackNode, 0, maxNodes)
-	if err := walkFetchPackRec(sm.tree.root, maxNodes, &out); err != nil {
+	if err := walkFetchPackDifferences(context.Background(), sm, nil, sm.tree.root, nil, maxNodes, 0, nil, nil, &out); err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func walkFetchPackRec(node mapNode, maxNodes int, out *[]FetchPackNode) error {
-	if node == nil || len(*out) >= maxNodes {
+// WalkFetchPackNodesContext is the cancellation-aware form of
+// WalkFetchPackNodes used by bounded peer serving.
+func (sm *SHAMap) WalkFetchPackNodesContext(ctx context.Context, maxNodes int) ([]FetchPackNode, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if sm == nil || maxNodes <= 0 {
+		return nil, nil
+	}
+	sm.tree.mu.RLock()
+	defer sm.tree.mu.RUnlock()
+	if sm.tree.root == nil || !sm.tree.root.HasChildren() {
+		return nil, nil
+	}
+	out := make([]FetchPackNode, 0, maxNodes)
+	if err := walkFetchPackDifferences(ctx, sm, nil, sm.tree.root, nil, maxNodes, 0, nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// WalkFetchPackDifferences returns the nodes present in sm but not already
+// represented by have. Shared subtrees are skipped by hash, while changed
+// inner nodes and their descendants are serialized with the same prefix used
+// by fetch-pack wire objects. Traversal is bounded and cancellation-aware.
+func (sm *SHAMap) WalkFetchPackDifferences(ctx context.Context, have *SHAMap, maxNodes int) ([]FetchPackNode, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if maxNodes <= 0 || sm == nil {
+		return nil, nil
+	}
+	sm.tree.mu.RLock()
+	defer sm.tree.mu.RUnlock()
+	if sm.tree.root == nil || !sm.tree.root.HasChildren() {
+		return nil, nil
+	}
+	var haveRoot mapNode
+	sharedTree := have != nil && sm == have
+	if have != nil {
+		if !sharedTree {
+			have.tree.mu.RLock()
+			defer have.tree.mu.RUnlock()
+		}
+		haveRoot = have.tree.root
+	}
+	out := make([]FetchPackNode, 0, maxNodes)
+	if err := walkFetchPackDifferences(ctx, sm, have, sm.tree.root, haveRoot, maxNodes, 0, nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// WalkFetchPackNodesContextBounded is WalkFetchPackNodesContext with an
+// aggregate serialization budget. complete is false when the byte limit stops
+// traversal before the node-count limit does.
+func (sm *SHAMap) WalkFetchPackNodesContextBounded(ctx context.Context, maxNodes int, maxBytes int64) ([]FetchPackNode, bool, error) {
+	return sm.walkFetchPackDifferencesBounded(ctx, nil, maxNodes, maxBytes)
+}
+
+// WalkFetchPackDifferencesBounded is WalkFetchPackDifferences with an aggregate
+// serialization budget. complete is false when another differing node exists
+// but cannot fit.
+func (sm *SHAMap) WalkFetchPackDifferencesBounded(ctx context.Context, have *SHAMap, maxNodes int, maxBytes int64) ([]FetchPackNode, bool, error) {
+	return sm.walkFetchPackDifferencesBounded(ctx, have, maxNodes, maxBytes)
+}
+
+func (sm *SHAMap) walkFetchPackDifferencesBounded(ctx context.Context, have *SHAMap, maxNodes int, maxBytes int64) ([]FetchPackNode, bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if sm == nil || maxNodes <= 0 || maxBytes <= 0 {
+		return nil, false, nil
+	}
+	sm.tree.mu.RLock()
+	defer sm.tree.mu.RUnlock()
+	if sm.tree.root == nil || !sm.tree.root.HasChildren() {
+		return nil, true, nil
+	}
+	var haveRoot mapNode
+	sharedTree := have != nil && sm == have
+	if have != nil {
+		if !sharedTree {
+			have.tree.mu.RLock()
+			defer have.tree.mu.RUnlock()
+		}
+		haveRoot = have.tree.root
+	}
+	out := make([]FetchPackNode, 0, maxNodes)
+	used := int64(0)
+	complete := true
+	if err := walkFetchPackDifferences(ctx, sm, have, sm.tree.root, haveRoot, maxNodes, maxBytes, &used, &complete, &out); err != nil {
+		return nil, false, err
+	}
+	return out, complete, nil
+}
+
+func walkFetchPackDifferences(
+	ctx context.Context,
+	wantMap, haveMap *SHAMap,
+	want, have mapNode,
+	maxNodes int,
+	maxBytes int64,
+	used *int64,
+	complete *bool,
+	out *[]FetchPackNode,
+) error {
+	if want == nil || len(*out) >= maxNodes || complete != nil && !*complete {
 		return nil
 	}
-	data, err := node.SerializeWithPrefix()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	if have != nil && want.Hash() == have.Hash() {
+		return nil
+	}
+	data, err := want.SerializeWithPrefix()
 	if err != nil {
 		return err
 	}
-	*out = append(*out, FetchPackNode{Hash: node.Hash(), Data: data})
-
-	inner, ok := node.(*innerNode)
+	if maxBytes > 0 && int64(len(data)) > maxBytes-*used {
+		*complete = false
+		return nil
+	}
+	*out = append(*out, FetchPackNode{Hash: want.Hash(), Data: data})
+	if used != nil {
+		*used += int64(len(data))
+	}
+	if len(*out) >= maxNodes {
+		return nil
+	}
+	wantInner, ok := want.(*innerNode)
 	if !ok {
 		return nil
 	}
-	inner.mu.RLock()
-	defer inner.mu.RUnlock()
-	for branch := 0; branch < BranchFactor; branch++ {
-		if len(*out) >= maxNodes {
-			break
-		}
-		child := inner.children[branch]
-		if child == nil {
+	var haveInner *innerNode
+	if candidate, ok := have.(*innerNode); ok {
+		haveInner = candidate
+	}
+	for branch := range BranchFactor {
+		child, wantHash, present := wantInner.LoadChild(branch)
+		if !present {
 			continue
 		}
-		if err := walkFetchPackRec(child, maxNodes, out); err != nil {
+		var haveChild mapNode
+		if haveInner != nil {
+			var haveHash [32]byte
+			var havePresent bool
+			haveChild, haveHash, havePresent = haveInner.LoadChild(branch)
+			if child != nil {
+				wantHash = child.Hash()
+			}
+			if haveChild != nil {
+				haveHash = haveChild.Hash()
+			}
+			if havePresent && haveHash == wantHash {
+				continue
+			}
+			if havePresent && haveChild == nil {
+				var err error
+				haveChild, err = haveMap.descendCtx(ctx, haveInner, branch)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		if child == nil {
+			var err error
+			child, err = wantMap.descendCtx(ctx, wantInner, branch)
+			if err != nil {
+				return err
+			}
+		}
+		if err := walkFetchPackDifferences(ctx, wantMap, haveMap, child, haveChild, maxNodes, maxBytes, used, complete, out); err != nil {
 			return err
+		}
+		if len(*out) >= maxNodes || complete != nil && !*complete {
+			return nil
 		}
 	}
 	return nil

--- a/shamap/fetchpack_test.go
+++ b/shamap/fetchpack_test.go
@@ -1,6 +1,9 @@
 package shamap
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 // buildFetchPackTestMap builds a multi-level state SHAMap with deterministic,
 // non-zero keys so the tree has inner nodes above the leaves.
@@ -94,6 +97,51 @@ func TestWalkFetchPackNodes_RespectsCapAndOrder(t *testing.T) {
 	}
 }
 
+func TestWalkFetchPackNodesContextBoundedStopsBeforeByteOverflow(t *testing.T) {
+	sm := New(TypeState)
+	for i := byte(1); i <= 4; i++ {
+		var key [32]byte
+		key[0] = i
+		if err := sm.Put(key, []byte{i, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	all, err := sm.WalkFetchPackNodes(32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) < 2 {
+		t.Fatalf("walk returned %d nodes, want at least 2", len(all))
+	}
+	budget := int64(len(all[0].Data))
+	got, complete, err := sm.WalkFetchPackNodesContextBounded(context.Background(), 32, budget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if complete {
+		t.Fatal("byte-limited walk reported complete")
+	}
+	if len(got) != 1 {
+		t.Fatalf("byte-limited walk returned %d nodes, want 1", len(got))
+	}
+	if int64(len(got[0].Data)) > budget {
+		t.Fatalf("walk exceeded byte budget: %d > %d", len(got[0].Data), budget)
+	}
+}
+
+func TestWalkFetchPackNodesContextBoundedEmptyMap(t *testing.T) {
+	nodes, complete, err := New(TypeState).WalkFetchPackNodesContextBounded(context.Background(), 32, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !complete {
+		t.Fatal("empty map walk reported incomplete")
+	}
+	if len(nodes) != 0 {
+		t.Fatalf("empty map walk returned %d nodes", len(nodes))
+	}
+}
+
 // TestWalkFetchPackNodes_Bounds covers the degenerate inputs.
 func TestWalkFetchPackNodes_Bounds(t *testing.T) {
 	t.Parallel()
@@ -110,6 +158,43 @@ func TestWalkFetchPackNodes_Bounds(t *testing.T) {
 	for i, n := range nodes {
 		if !VerifyFetchPackNode(n.Hash, n.Data) {
 			t.Errorf("empty-map node %d failed VerifyFetchPackNode", i)
+		}
+	}
+}
+
+func TestWalkFetchPackNodes_LoadsPersistedDescendants(t *testing.T) {
+	source := buildFetchPackTestMap(t)
+	expected, err := source.WalkFetchPackNodes(1 << 20)
+	if err != nil {
+		t.Fatalf("source walk: %v", err)
+	}
+	rootHash, err := source.Hash()
+	if err != nil {
+		t.Fatalf("source hash: %v", err)
+	}
+	family := newMemoryFamily()
+	if err := flushToFamily(source, family); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	backed, err := NewFromRootHash(TypeState, rootHash, family)
+	if err != nil {
+		t.Fatalf("NewFromRootHash: %v", err)
+	}
+	for branch := range BranchFactor {
+		if child, _, present := backed.tree.root.LoadChild(branch); present && child != nil {
+			t.Fatalf("branch %d was loaded before fetch-pack walk", branch)
+		}
+	}
+	got, err := backed.WalkFetchPackNodesContext(context.Background(), 1<<20)
+	if err != nil {
+		t.Fatalf("backed walk: %v", err)
+	}
+	if len(got) != len(expected) {
+		t.Fatalf("backed walk returned %d nodes, want %d", len(got), len(expected))
+	}
+	for i := range expected {
+		if got[i].Hash != expected[i].Hash {
+			t.Fatalf("node %d hash = %x, want %x", i, got[i].Hash[:8], expected[i].Hash[:8])
 		}
 	}
 }


### PR DESCRIPTION
Part of #1472. Stack PR 7/11.\n\nCompletes bounded fetch-pack generation, including aggregate ledger budgets, cache limits, eviction, and cancellation behavior.