### PR TITLE
fix: prevent peer relay deadlocks (#1472)

### DIFF
--- a/internal/peermanagement/outbound_emit.go
+++ b/internal/peermanagement/outbound_emit.go
@@ -227,18 +227,34 @@ func (o *Overlay) sendTxQueueAnnounce() {
 		return
 	}
 
+	// Resolve the peer set and negotiated capabilities while holding peersMu,
+	// then release it before enqueueing. PeerSupports performs its own peer-map
+	// lookup, so calling it while this read lock is held can deadlock when a
+	// writer is waiting for peersMu: the nested RLock is blocked by the queued
+	// writer while the outer RLock cannot be released until the nested call
+	// returns.
+	type txRelayPeer struct {
+		id   PeerID
+		peer *Peer
+	}
 	o.peersMu.RLock()
-	defer o.peersMu.RUnlock()
+	targets := make([]txRelayPeer, 0, len(o.peers))
 	for id, peer := range o.peers {
 		if peer.State() != PeerStateConnected {
 			continue
 		}
-		if !o.PeerSupports(id, FeatureTxReduceRelay) {
+		caps := peer.Capabilities()
+		if caps == nil || !caps.HasFeature(FeatureTxReduceRelay) {
 			continue
 		}
-		if err := peer.Send(frame); err != nil {
+		targets = append(targets, txRelayPeer{id: id, peer: peer})
+	}
+	o.peersMu.RUnlock()
+
+	for _, target := range targets {
+		if err := target.peer.Send(frame); err != nil {
 			slog.Debug("HaveTransactions send failed",
-				"t", "Overlay", "peer", id, "err", err)
+				"t", "Overlay", "peer", target.id, "err", err)
 		}
 	}
 }

--- a/internal/peermanagement/overlay_broadcast.go
+++ b/internal/peermanagement/overlay_broadcast.go
@@ -254,18 +254,32 @@ func (o *Overlay) broadcastExceptSet(excluded map[PeerID]bool, msg []byte, prior
 // by a separate code path (see Broadcast) that skips the filter
 // entirely.
 func (o *Overlay) RelayFromValidator(validator []byte, suppressionHash [32]byte, exceptPeer PeerID, msg []byte) error {
-	sources := o.releaseMessageSources(suppressionHash)
+	// Hold source evidence until at least one recipient accepts the relay. A
+	// failed enqueue is not a relay: marking the suppression bucket as
+	// relayed in that case would gate future duplicate accounting despite the
+	// message never leaving this node.
+	sources := o.takeMessageSources(suppressionHash)
 	sourceSet := make(map[PeerID]struct{}, len(sources))
 	for _, id := range sources {
 		sourceSet[id] = struct{}{}
 	}
 
-	err := o.forEachConnected(msg, "relay-from-validator", false, func(id PeerID, peer *Peer) bool {
+	result := fanoutResult{operation: "relay-from-validator"}
+	for _, target := range o.connectedPeers() {
+		id, peer := target.id, target.peer
 		_, wasSource := sourceSet[id]
-		return wasSource || id == exceptPeer || !peer.ExpireSquelch(validator)
-	})
-	for _, id := range sources {
-		o.OnValidatorMessage(validator, id)
+		if wasSource || id == exceptPeer || !peer.ExpireSquelch(validator) {
+			continue
+		}
+		result.record(sendPeer(peer, msg, false))
+	}
+	err := result.err()
+	o.logFanoutFailure(err)
+	if result.attempted > result.failed {
+		o.markMessageRelayed(suppressionHash)
+		for _, id := range sources {
+			o.OnValidatorMessage(validator, id)
+		}
 	}
 	return err
 }
@@ -335,6 +349,56 @@ func (o *Overlay) PeersThatHave(suppressionHash [32]byte) []PeerID {
 
 func (o *Overlay) releaseMessageSources(suppressionHash [32]byte) []PeerID {
 	return o.messageSources(suppressionHash, true)
+}
+
+// takeMessageSources removes the current inbound source set without marking
+// the message as relayed. RelayFromValidator marks it only after a recipient
+// successfully accepts the frame.
+func (o *Overlay) takeMessageSources(suppressionHash [32]byte) []PeerID {
+	if o.relayedIndex == nil {
+		return nil
+	}
+	clock := o.clockForIndex
+	if clock == nil {
+		clock = time.Now
+	}
+
+	o.relayedIndexMu.Lock()
+	defer o.relayedIndexMu.Unlock()
+
+	entry, ok := o.relayedIndex[suppressionHash]
+	if !ok {
+		return nil
+	}
+	now := clock()
+	if now.Sub(entry.seenAt) >= RelayedIndexTTL {
+		delete(o.relayedIndex, suppressionHash)
+		return nil
+	}
+	out := make([]PeerID, 0, len(entry.peers))
+	for id := range entry.peers {
+		out = append(out, id)
+	}
+	entry.peers = make(map[PeerID]struct{})
+	entry.seenAt = now
+	return out
+}
+
+func (o *Overlay) markMessageRelayed(suppressionHash [32]byte) {
+	if o.relayedIndex == nil {
+		return
+	}
+	clock := o.clockForIndex
+	if clock == nil {
+		clock = time.Now
+	}
+	now := clock()
+	o.relayedIndexMu.Lock()
+	if entry, ok := o.relayedIndex[suppressionHash]; ok {
+		entry.relayedAt = now
+		entry.seenAt = now
+	}
+	o.relayedIndexMu.Unlock()
 }
 
 // MessageRelayedRecently reports whether this hash was relayed within the

--- a/internal/peermanagement/relayed_index_test.go
+++ b/internal/peermanagement/relayed_index_test.go
@@ -124,3 +124,39 @@ func TestOverlay_MessageRelayedRecentlyWindow(t *testing.T) {
 	now = now.Add(Idled)
 	assert.False(t, o.MessageRelayedRecently(hash))
 }
+
+func TestOverlay_RelayFromValidatorMarksOnlySuccessfulEnqueue(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	o := &Overlay{
+		cfg:          Config{},
+		peers:        make(map[PeerID]*Peer),
+		relayedIndex: make(map[[32]byte]*relayedEntry),
+	}
+	source := NewPeer(PeerID(1), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
+	destination := NewPeer(PeerID(2), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
+	source.setState(PeerStateConnected)
+	destination.setState(PeerStateConnected)
+	o.peers[source.ID()] = source
+	o.peers[destination.ID()] = destination
+
+	// Saturate the destination's ordinary lane so RelayFromValidator has no
+	// successful enqueue to account for.
+	for range ordinarySendMaximum {
+		require.NoError(t, destination.Send([]byte{0xAA}))
+	}
+	hash := [32]byte{0xD1}
+	o.RecordMessageSource(hash, source.ID())
+	require.ErrorIs(t, o.RelayFromValidator([]byte("validator"), hash, 0, []byte{0xBB}), ErrSendBufferFull)
+	assert.False(t, o.MessageRelayedRecently(hash),
+		"a failed relay must not enter the duplicate-counting window")
+
+	// A later relay that is accepted by a peer does enter the window.
+	destination = NewPeer(PeerID(3), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
+	destination.setState(PeerStateConnected)
+	o.peers[destination.ID()] = destination
+	hash = [32]byte{0xD2}
+	o.RecordMessageSource(hash, source.ID())
+	require.ErrorIs(t, o.RelayFromValidator([]byte("validator"), hash, 0, []byte{0xBC}), ErrSendBufferFull)
+	assert.True(t, o.MessageRelayedRecently(hash))
+}


### PR DESCRIPTION
Part of #1472. Stack PR 8/11.\n\nRemoves lock-order and callback interactions that could deadlock peer relay paths.