### PR TITLE
fix: make transaction reduce relay lossless (#1472)

### DIFF
--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
@@ -681,7 +682,13 @@ func (r *Router) relayTransaction(except peermanagement.PeerID, blob []byte) {
 	}
 	// Reduce-relay peer selection: relays the full frame to a subset of
 	// peers and lets the rest learn via the TMHaveTransactions announce.
-	r.overlay.RelayTransaction(except, frame)
+	var txHash [32]byte
+	if parsed, parseErr := tx.ParseFromBinary(blob); parseErr == nil {
+		if hash, hashErr := tx.ComputeTransactionHash(parsed); hashErr == nil {
+			txHash = hash
+		}
+	}
+	r.overlay.RelayTransactionWithHash(except, txHash, frame)
 }
 
 func (r *Router) handleHaveSet(msg *peermanagement.InboundMessage) {

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -14,7 +14,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
-	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/protocol"
 )
 
@@ -680,15 +679,10 @@ func (r *Router) relayTransaction(except peermanagement.PeerID, blob []byte) {
 		r.logger.Warn("relay transaction encode failed", "error", err)
 		return
 	}
-	// Reduce-relay peer selection: relays the full frame to a subset of
-	// peers and lets the rest learn via the TMHaveTransactions announce.
-	var txHash [32]byte
-	if parsed, parseErr := tx.ParseFromBinary(blob); parseErr == nil {
-		if hash, hashErr := tx.ComputeTransactionHash(parsed); hashErr == nil {
-			txHash = hash
-		}
-	}
-	r.overlay.RelayTransactionWithHash(except, txHash, frame)
+	// Reduce-relay peer selection derives the transaction ID from the wire
+	// frame itself. If the frame cannot be decoded, the overlay falls back to
+	// full relay rather than announcing an unfulfillable hash.
+	r.overlay.RelayTransaction(except, frame)
 }
 
 func (r *Router) handleHaveSet(msg *peermanagement.InboundMessage) {

--- a/internal/ledger/service/relay_cache_test.go
+++ b/internal/ledger/service/relay_cache_test.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestServiceRelayCacheRetainsBlobAndUsesNewStatus(t *testing.T) {
+	s := &Service{}
+	hash := [32]byte{0xA1}
+	blob := []byte{0x01, 0x02}
+	s.rememberRelayTransaction(hash, blob, false)
+	blob[0] = 0xFF
+
+	got, included, deferred, ok := s.TransactionForRelay(hash)
+	if !ok || included || deferred {
+		t.Fatalf("TransactionForRelay() = (%x, %v, %v, %v), want retained cache record", got, included, deferred, ok)
+	}
+	if got[0] != 0x01 {
+		t.Fatalf("retained blob was not copied: %x", got)
+	}
+}
+
+func TestServiceRelayCacheIsBoundedAndExpires(t *testing.T) {
+	s := &Service{relayTxCache: make(map[[32]byte]relayTxRecord)}
+	for i := 0; i < relayTxCacheMaxEntries+1; i++ {
+		var hash [32]byte
+		hash[0] = byte(i >> 8)
+		hash[1] = byte(i)
+		s.rememberRelayTransaction(hash, []byte{byte(i)}, true)
+	}
+	if got := len(s.relayTxCache); got > relayTxCacheMaxEntries {
+		t.Fatalf("relay cache size = %d, max %d", got, relayTxCacheMaxEntries)
+	}
+
+	hash := [32]byte{0xFE}
+	s.rememberRelayTransaction(hash, []byte{0xAA}, true)
+	s.relayTxCacheMu.Lock()
+	record := s.relayTxCache[hash]
+	record.seenAt = time.Now().Add(-relayTxCacheTTL - time.Second)
+	s.relayTxCache[hash] = record
+	s.relayTxCacheMu.Unlock()
+	if _, _, _, ok := s.relayCacheGet(hash); ok {
+		t.Fatal("expired relay cache record was returned")
+	}
+	if got := len(s.relayTxCacheOrder) - s.relayTxCacheHead; got > relayTxCacheMaxEntries {
+		t.Fatalf("active order entries = %d, max %d", got, relayTxCacheMaxEntries)
+	}
+}
+
+func TestServiceRelayCacheIsByteBounded(t *testing.T) {
+	s := &Service{
+		relayTxCache:      make(map[[32]byte]relayTxRecord),
+		relayTxCacheLimit: 4,
+	}
+	first := [32]byte{0x01}
+	second := [32]byte{0x02}
+	s.rememberRelayTransaction(first, []byte{1, 2, 3}, false)
+	s.rememberRelayTransaction(second, []byte{4, 5, 6}, false)
+
+	if s.relayTxCacheBytes > s.relayTxCacheLimit {
+		t.Fatalf("relay cache bytes = %d, limit %d", s.relayTxCacheBytes, s.relayTxCacheLimit)
+	}
+	if _, _, _, ok := s.relayCacheGet(first); ok {
+		t.Fatal("oldest record survived byte-bound eviction")
+	}
+	if _, _, _, ok := s.relayCacheGet(second); !ok {
+		t.Fatal("newest record was evicted despite fitting the byte bound")
+	}
+
+	s.rememberRelayTransaction(second, []byte{7, 8}, true)
+	if s.relayTxCacheBytes != 2 {
+		t.Fatalf("replacement bytes = %d, want 2", s.relayTxCacheBytes)
+	}
+}
+
+func TestServiceRelayCacheCompactsExpiredOrderTombstones(t *testing.T) {
+	s := &Service{relayTxCache: make(map[[32]byte]relayTxRecord)}
+	anchor := [32]byte{0xFF}
+	s.rememberRelayTransaction(anchor, []byte{0x01}, false)
+	for i := 0; i < 2*relayTxCacheMaxEntries+16; i++ {
+		var hash [32]byte
+		hash[0] = byte(i >> 16)
+		hash[1] = byte(i >> 8)
+		hash[2] = byte(i)
+		s.rememberRelayTransaction(hash, []byte{0x02}, false)
+		s.relayTxCacheMu.Lock()
+		record := s.relayTxCache[hash]
+		record.seenAt = time.Now().Add(-relayTxCacheTTL - time.Second)
+		s.relayTxCache[hash] = record
+		s.relayTxCacheMu.Unlock()
+		_, _, _, _ = s.relayCacheGet(hash)
+	}
+
+	if got := len(s.relayTxCacheOrder) - s.relayTxCacheHead; got > 2*relayTxCacheMaxEntries {
+		t.Fatalf("active order entries = %d, max %d", got, 2*relayTxCacheMaxEntries)
+	}
+}

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -1014,6 +1014,24 @@ func (s *Service) OpenLedgerGetTx(hash [32]byte) ([]byte, bool) {
 	return raw, true
 }
 
+// TransactionForRelay looks up a transaction in the authoritative local
+// transaction cache used by reduce-relay replies. Open-ledger transactions
+// are current; transactions retained by TxQ are new and deferred until a
+// later ledger. The returned blob is a private copy.
+func (s *Service) TransactionForRelay(hash [32]byte) (blob []byte, included, deferred, ok bool) {
+	if blob, ok = s.OpenLedgerGetTx(hash); ok {
+		return append([]byte(nil), blob...), true, false, true
+	}
+	s.mu.RLock()
+	queue := s.txQueue
+	s.mu.RUnlock()
+	if queue == nil {
+		return nil, false, false, false
+	}
+	blob, ok = queue.GetTxBlob(hash)
+	return blob, false, ok, ok
+}
+
 // GetOpenLedger returns the current open ledger
 func (s *Service) GetOpenLedger() *ledger.Ledger {
 	s.mu.RLock()

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -240,6 +240,18 @@ type Service struct {
 	// Nil when overlay broadcast is unwired (tests).
 	txRelay func(blob []byte)
 
+	// relayTxCache retains accepted transaction blobs after they leave the
+	// current open ledger or transaction queue. Reduce-relay announcements may
+	// arrive during that handoff, so the cache spans the request horizon while
+	// remaining explicitly bounded.
+	relayTxCacheMu    sync.Mutex
+	relayTxCache      map[[32]byte]relayTxRecord
+	relayTxCacheOrder []relayTxOrderEntry
+	relayTxCacheHead  int
+	relayTxCacheBytes int64
+	relayTxCacheLimit int64
+	relayTxCacheNext  uint64
+
 	// feeTrack is the local LoadFeeTrack mirror, always non-nil. Drivers:
 	//   - Raise/LowerLocalFee: per ledger close via tickLoadFeeLocked.
 	//   - SetRemoteFee: after validated-ledger promotion, median of trusted LoadFees.
@@ -259,6 +271,24 @@ type Service struct {
 	configCacheMu     sync.Mutex
 	configCacheLedger *ledger.Ledger
 	configCache       openledger.ApplyConfig
+}
+
+const (
+	relayTxCacheMaxEntries = 20_000
+	relayTxCacheMaxBytes   = 64 * 1024 * 1024
+	relayTxCacheTTL        = 5 * time.Minute
+)
+
+type relayTxRecord struct {
+	blob     []byte
+	deferred bool
+	seenAt   time.Time
+	orderID  uint64
+}
+
+type relayTxOrderEntry struct {
+	hash [32]byte
+	id   uint64
 }
 
 type serviceLifecycleState uint8
@@ -333,6 +363,8 @@ func New(cfg Config) (*Service, error) {
 		heldAdoptions:            make(map[uint32]*pendingAdopt),
 		txQueue:                  txq.New(txqCfg),
 		localTxs:                 localtxs.New(),
+		relayTxCache:             make(map[[32]byte]relayTxRecord),
+		relayTxCacheLimit:        relayTxCacheMaxBytes,
 		feeTrack:                 feetrack.New(),
 		validatedAgeNow:          time.Now,
 	}
@@ -743,13 +775,11 @@ func (s *Service) acceptOpenLedgerViewLocked(closedSeq uint32, retriableTxs []op
 	// Seed retries with the disputed/build-pass set; Accept drains then re-fills it.
 	retries := append([]openledger.PendingTx(nil), retriableTxs...)
 	relay := s.txRelay
-	relayCB := func(_ [32]byte, blob []byte) {
+	relayCB := func(hash [32]byte, blob []byte) {
+		s.rememberRelayTransaction(hash, blob, false)
 		if relay != nil {
 			relay(blob)
 		}
-	}
-	if relay == nil {
-		relayCB = nil
 	}
 	if err := s.openLedgerView.Accept(s.closedLedger, locals, anyDisputes, &retries, cfg, s.txQueue, modifier, relayCB); err != nil {
 		s.logger.Error("openLedger.Accept failed", "err", err, "seq", closedSeq)
@@ -853,7 +883,6 @@ func (s *Service) SubmitOpenLedgerTx(blob []byte, local bool) (openledger.Result
 	if !cfg.SkipSignatureVerification {
 		txengine.PrewarmSignature(ptx.Parsed)
 	}
-
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.openLedgerView == nil {
@@ -864,6 +893,9 @@ func (s *Service) SubmitOpenLedgerTx(blob []byte, local bool) (openledger.Result
 		return openledger.ResultFailure, cfgErr
 	}
 	outcome := s.openLedgerView.SubmitDetailed(ptx, cfg, s.txQueue)
+	if outcome.Class == openledger.ResultSuccess {
+		s.rememberRelayTransaction(ptx.Hash, ptx.Blob, outcome.Queued)
+	}
 	current := s.openLedgerView.Current()
 	if local && s.localTxs != nil && outcome.Class != openledger.ResultFailure {
 		s.localTxs.PushBack(current.Sequence(), ptx)
@@ -1003,6 +1035,9 @@ func (s *Service) OpenLedgerGetTx(hash [32]byte) ([]byte, bool) {
 		return nil, false
 	}
 	view := ov.Current()
+	if view == nil {
+		return nil, false
+	}
 	data, found, err := view.GetTransaction(hash)
 	if err != nil || !found {
 		return nil, false
@@ -1015,9 +1050,10 @@ func (s *Service) OpenLedgerGetTx(hash [32]byte) ([]byte, bool) {
 }
 
 // TransactionForRelay looks up a transaction in the authoritative local
-// transaction cache used by reduce-relay replies. Open-ledger transactions
-// are current; transactions retained by TxQ are new and deferred until a
-// later ledger. The returned blob is a private copy.
+// transaction cache used by reduce-relay replies. Only membership in the live
+// open-ledger view is current; TxQ and retained-cache fallbacks are new, with
+// the cache preserving whether a queued transaction is deferred. The returned
+// blob is a private copy.
 func (s *Service) TransactionForRelay(hash [32]byte) (blob []byte, included, deferred, ok bool) {
 	if blob, ok = s.OpenLedgerGetTx(hash); ok {
 		return append([]byte(nil), blob...), true, false, true
@@ -1026,10 +1062,102 @@ func (s *Service) TransactionForRelay(hash [32]byte) (blob []byte, included, def
 	queue := s.txQueue
 	s.mu.RUnlock()
 	if queue == nil {
-		return nil, false, false, false
+		return s.relayCacheGet(hash)
 	}
 	blob, ok = queue.GetTxBlob(hash)
-	return blob, false, ok, ok
+	if ok {
+		return blob, false, true, true
+	}
+	return s.relayCacheGet(hash)
+}
+
+func (s *Service) rememberRelayTransaction(hash [32]byte, blob []byte, deferred bool) {
+	if hash == ([32]byte{}) || len(blob) == 0 {
+		return
+	}
+	now := time.Now()
+	s.relayTxCacheMu.Lock()
+	defer s.relayTxCacheMu.Unlock()
+	limit := s.relayTxCacheLimit
+	if limit <= 0 {
+		limit = relayTxCacheMaxBytes
+	}
+	if int64(len(blob)) > limit {
+		return
+	}
+	if s.relayTxCache == nil {
+		s.relayTxCache = make(map[[32]byte]relayTxRecord)
+	}
+	orderID := uint64(0)
+	if existing, exists := s.relayTxCache[hash]; exists {
+		s.relayTxCacheBytes -= int64(len(existing.blob))
+		orderID = existing.orderID
+	} else {
+		s.relayTxCacheNext++
+		if s.relayTxCacheNext == 0 {
+			s.relayTxCacheNext++
+		}
+		orderID = s.relayTxCacheNext
+		s.relayTxCacheOrder = append(s.relayTxCacheOrder, relayTxOrderEntry{hash: hash, id: orderID})
+	}
+	s.relayTxCache[hash] = relayTxRecord{
+		blob:     append([]byte(nil), blob...),
+		deferred: deferred,
+		seenAt:   now,
+		orderID:  orderID,
+	}
+	s.relayTxCacheBytes += int64(len(blob))
+	for (len(s.relayTxCache) > relayTxCacheMaxEntries || s.relayTxCacheBytes > limit) &&
+		s.relayTxCacheHead < len(s.relayTxCacheOrder) {
+		old := s.relayTxCacheOrder[s.relayTxCacheHead]
+		s.relayTxCacheHead++
+		if record, stillPresent := s.relayTxCache[old.hash]; stillPresent && record.orderID == old.id {
+			s.relayTxCacheBytes -= int64(len(record.blob))
+			delete(s.relayTxCache, old.hash)
+		}
+	}
+	s.compactRelayCacheOrderLocked()
+}
+
+func (s *Service) relayCacheGet(hash [32]byte) (blob []byte, included, deferred, ok bool) {
+	s.relayTxCacheMu.Lock()
+	defer s.relayTxCacheMu.Unlock()
+	record, found := s.relayTxCache[hash]
+	if !found {
+		return nil, false, false, false
+	}
+	if time.Since(record.seenAt) >= relayTxCacheTTL {
+		delete(s.relayTxCache, hash)
+		s.relayTxCacheBytes -= int64(len(record.blob))
+		s.compactRelayCacheOrderLocked()
+		return nil, false, false, false
+	}
+	// The retained blob is no longer guaranteed to be in the current open
+	// ledger. Callers derive tsCURRENT only from the live view above; cache
+	// fallback is always a tsNEW-style record.
+	return append([]byte(nil), record.blob...), false, record.deferred, true
+}
+
+func (s *Service) compactRelayCacheOrderLocked() {
+	if len(s.relayTxCache) == 0 {
+		s.relayTxCacheOrder = nil
+		s.relayTxCacheHead = 0
+		s.relayTxCacheBytes = 0
+		return
+	}
+	activeOrder := len(s.relayTxCacheOrder) - s.relayTxCacheHead
+	if !(s.relayTxCacheHead > 1024 && s.relayTxCacheHead*2 > len(s.relayTxCacheOrder)) &&
+		activeOrder <= 2*relayTxCacheMaxEntries {
+		return
+	}
+	order := make([]relayTxOrderEntry, 0, len(s.relayTxCache))
+	for _, entry := range s.relayTxCacheOrder[s.relayTxCacheHead:] {
+		if record, ok := s.relayTxCache[entry.hash]; ok && record.orderID == entry.id {
+			order = append(order, entry)
+		}
+	}
+	s.relayTxCacheOrder = order
+	s.relayTxCacheHead = 0
 }
 
 // GetOpenLedger returns the current open ledger

--- a/internal/ledger/service/service_openledger_test.go
+++ b/internal/ledger/service/service_openledger_test.go
@@ -255,6 +255,9 @@ func TestService_AcceptConsensusResult_IncludedTxsNotDuplicated(t *testing.T) {
 	if res != openledger.ResultSuccess {
 		t.Fatalf("SubmitOpenLedgerTx result = %v, want ResultSuccess", res)
 	}
+	if got, included, deferred, ok := svc.TransactionForRelay(hash1); !ok || !bytes.Equal(got, blob1) || !included || deferred {
+		t.Fatalf("TransactionForRelay before close = (%x, %v, %v, %v), want live current tx", got, included, deferred, ok)
+	}
 
 	parent := svc.GetClosedLedger()
 	if parent == nil {
@@ -280,6 +283,9 @@ func TestService_AcceptConsensusResult_IncludedTxsNotDuplicated(t *testing.T) {
 	}
 	if got := svc.OpenLedgerTxs(); len(got) != 0 {
 		t.Errorf("post-Accept OpenLedgerTxs len = %d, want 0", len(got))
+	}
+	if got, included, deferred, ok := svc.TransactionForRelay(hash1); !ok || !bytes.Equal(got, blob1) || included || deferred {
+		t.Fatalf("TransactionForRelay after close = (%x, %v, %v, %v), want cached tsNEW record", got, included, deferred, ok)
 	}
 }
 

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -141,6 +141,9 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 	if s.validatedLedger != nil {
 		result.ValidatedLedger = s.validatedLedger.Sequence()
 	}
+	if outcome.Class == openledger.ResultSuccess {
+		s.rememberRelayTransaction(ptx.Hash, ptx.Blob, outcome.Queued)
+	}
 
 	// LocalTxs push: rippled NetworkOPs.cpp:1674-1683 holds a locally-
 	// submitted tx whenever addLocal && !enforceFailHard, where

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -18,6 +18,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/observability"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/internal/rpc"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
@@ -541,13 +542,28 @@ func (r *nodeRuntime) configureConsensus() error {
 		// re-broadcast post-LCL (rippled OpenLedger.cpp:120-150).
 		r.ledger.SetTxRelay(broadcastTx)
 
-		// Wire the open-ledger tx lookup used by the tx-reduce-relay
-		// reply path (TMGetObjectByHash{otTRANSACTIONS} → TMTransactions
-		// reply) and the periodic TMHaveTransactions announce.
+		// Wire the authoritative transaction-cache lookup used by the
+		// tx-reduce-relay reply path (TMGetObjectByHash{otTRANSACTIONS} →
+		// TMTransactions reply). It includes queued transactions, not just
+		// the current open-ledger view.
 		// Feature-gated downstream by Config.EnableTxReduceRelay; the
 		// providers themselves are always wired so a flip of the
 		// config flag doesn't require a restart-and-rewire.
-		overlay.SetTxProvider(r.ledger.OpenLedgerGetTx)
+		overlay.SetTxRecordProvider(func(hash [32]byte) (peermanagement.TxRecord, bool) {
+			blob, included, deferred, ok := r.ledger.TransactionForRelay(hash)
+			if !ok {
+				return peermanagement.TxRecord{}, false
+			}
+			status := message.TxStatusNew
+			if included {
+				status = message.TxStatusCurrent
+			}
+			return peermanagement.TxRecord{
+				RawTransaction: blob,
+				Status:         status,
+				Deferred:       deferred,
+			}, true
+		})
 		overlay.SetOpenLedgerHashesProvider(r.ledger.OpenLedgerTxHashes)
 
 		// Wire the generic node-object lookup used by the

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -690,7 +690,7 @@ func (o *Overlay) serveDoTransactionsContext(ctx context.Context, peerID PeerID,
 		return
 	}
 	if len(req.Objects) > maxQueueSize {
-		o.IncPeerBadData(peerID, "get-objects-txn-too-big")
+		o.chargeMalformedTransactionRequest(peerID, "get-objects-txn-too-big")
 		return
 	}
 	if o.txRecordProviderSnapshot() == nil && o.txProviderSnapshot() == nil {
@@ -709,14 +709,14 @@ func (o *Overlay) serveDoTransactionsContext(ctx context.Context, peerID PeerID,
 			return
 		}
 		if len(obj.Hash) != 32 {
-			o.IncPeerBadData(peerID, "get-objects-txn-hashsize")
+			o.chargeMalformedTransactionRequest(peerID, "get-objects-txn-hashsize")
 			return
 		}
 		var hash [32]byte
 		copy(hash[:], obj.Hash)
 		record, ok := o.lookupTxRecord(hash)
 		if !ok {
-			o.IncPeerBadData(peerID, "get-objects-txn-missing")
+			o.chargeMalformedTransactionRequest(peerID, "get-objects-txn-missing")
 			return
 		}
 		if !budget.reserve(serveReplyTransactionOverhead, record.RawTransaction) {
@@ -743,6 +743,13 @@ func (o *Overlay) serveDoTransactionsContext(ctx context.Context, peerID PeerID,
 		return
 	}
 	encodeAndSendPriority(peer, reply, "TMTransactions reply")
+}
+
+func (o *Overlay) chargeMalformedTransactionRequest(peerID PeerID, reason string) {
+	peer, ok := o.getPeer(peerID)
+	if ok {
+		peer.Charge(resource.FeeMalformedRequest, reason)
+	}
 }
 
 func (o *Overlay) lookupTxRecord(hash [32]byte) (TxRecord, bool) {

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -470,8 +470,7 @@ func (o *Overlay) handleHaveTransactionsMessage(evt Event) {
 	// hash would amplify network load for a load-reduction feature.
 	// Drop the announcement silently in that case (the peer that
 	// negotiated tx-reduce-relay isn't malformed).
-	txProvider := o.txProviderSnapshot()
-	if txProvider == nil {
+	if o.txRecordProviderSnapshot() == nil && o.txProviderSnapshot() == nil {
 		return
 	}
 
@@ -483,7 +482,12 @@ func (o *Overlay) handleHaveTransactionsMessage(evt Event) {
 		}
 		var hash [32]byte
 		copy(hash[:], h)
-		if _, present := txProvider(hash); present {
+		if _, present := o.lookupTxRecord(hash); present {
+			// Rippled removes this hash from the peer's deferred queue when the
+			// peer confirms it already has the transaction.
+			if peer, exists := o.getPeer(evt.PeerID); exists {
+				peer.removeTxQueue(hash)
+			}
 			continue
 		}
 		missing = append(missing, message.IndexedObject{
@@ -671,9 +675,8 @@ func (o *Overlay) handleEndpointsMessage(evt Event) {
 // type is otTRANSACTIONS. Mirrors rippled PeerImp::doTransactions
 // (PeerImp.cpp:2787-2839): walk the requested hashes, look each up,
 // build a TMTransactions reply containing the blobs we have, and
-// emit it. Hashes we don't have are charged feeMalformedRequest in
-// rippled — we treat them as "skip", matching the more permissive
-// go-xrpl stance that the peer may legitimately be a hop ahead.
+// emit it. Hashes we don't have are charged feeMalformedRequest and
+// abort the reply, matching rippled's doTransactions path.
 func (o *Overlay) serveDoTransactions(peerID PeerID, req *message.GetObjectByHash) {
 	o.serveDoTransactionsContext(context.Background(), peerID, req)
 }
@@ -682,7 +685,7 @@ func (o *Overlay) serveDoTransactionsContext(ctx context.Context, peerID PeerID,
 	if err := ctx.Err(); err != nil {
 		return
 	}
-	const maxQueueSize = 64 // matches rippled reduce_relay::MAX_TX_QUEUE_SIZE
+	const maxQueueSize = peerTxQueueMax
 	if len(req.Objects) == 0 {
 		return
 	}
@@ -690,11 +693,10 @@ func (o *Overlay) serveDoTransactionsContext(ctx context.Context, peerID PeerID,
 		o.IncPeerBadData(peerID, "get-objects-txn-too-big")
 		return
 	}
-	txProvider := o.txProviderSnapshot()
-	if txProvider == nil {
+	if o.txRecordProviderSnapshot() == nil && o.txProviderSnapshot() == nil {
 		// Negotiated tx-reduce-relay but no lookup wired — silently
 		// drop. An operator who flipped EnableTxReduceRelay but
-		// hasn't wired SetTxProvider would otherwise spam this log.
+		// hasn't wired a transaction provider would otherwise spam this log.
 		return
 	}
 
@@ -712,17 +714,24 @@ func (o *Overlay) serveDoTransactionsContext(ctx context.Context, peerID PeerID,
 		}
 		var hash [32]byte
 		copy(hash[:], obj.Hash)
-		blob, ok := txProvider(hash)
+		record, ok := o.lookupTxRecord(hash)
 		if !ok {
-			continue
+			o.IncPeerBadData(peerID, "get-objects-txn-missing")
+			return
 		}
-		if !budget.reserve(serveReplyTransactionOverhead, blob) {
+		if !budget.reserve(serveReplyTransactionOverhead, record.RawTransaction) {
 			break
 		}
+		status := record.Status
+		if status == 0 {
+			status = message.TxStatusCurrent
+		}
+		receiveTimestamp := uint64(protocol.RippleSeconds(time.Now()))
 		reply.Transactions = append(reply.Transactions, message.Transaction{
-			RawTransaction:   blob,
-			Status:           message.TxStatusCurrent,
-			ReceiveTimestamp: uint64(protocol.RippleSeconds(time.Now())),
+			RawTransaction:   append([]byte(nil), record.RawTransaction...),
+			Status:           status,
+			ReceiveTimestamp: receiveTimestamp,
+			Deferred:         record.Deferred,
 		})
 	}
 	if len(reply.Transactions) == 0 {
@@ -734,6 +743,28 @@ func (o *Overlay) serveDoTransactionsContext(ctx context.Context, peerID PeerID,
 		return
 	}
 	encodeAndSendPriority(peer, reply, "TMTransactions reply")
+}
+
+func (o *Overlay) lookupTxRecord(hash [32]byte) (TxRecord, bool) {
+	if provider := o.txRecordProviderSnapshot(); provider != nil {
+		record, ok := provider(hash)
+		if ok {
+			record.RawTransaction = append([]byte(nil), record.RawTransaction...)
+		}
+		return record, ok
+	}
+	provider := o.txProviderSnapshot()
+	if provider == nil {
+		return TxRecord{}, false
+	}
+	blob, ok := provider(hash)
+	if !ok {
+		return TxRecord{}, false
+	}
+	return TxRecord{
+		RawTransaction: append([]byte(nil), blob...),
+		Status:         message.TxStatusCurrent,
+	}, true
 }
 
 // hardMaxReplyNodes bounds a single generic by-hash request. Mirrors
@@ -929,9 +960,9 @@ func (o *Overlay) serveGetObjectsContext(ctx context.Context, peerID PeerID, req
 // TMTransaction frame. Like rippled, which
 // hands the decoded inner straight to handleTransaction, we never
 // re-serialize: the decode happened once when the batch was parsed.
-// The only behavioural difference rippled draws between batched and
-// unbatched is the eraseTxQueue path on a duplicate hit, which go-xrpl
-// doesn't implement (no tx-reduce-relay outbound queue to erase from).
+// The batched path shares the same per-peer deferred queue as the unbatched
+// path; HAVE_TRANSACTIONS acknowledgements remove queued hashes before this
+// handler forwards the batch to the transaction router.
 func (o *Overlay) handleTransactionsBatchMessage(evt Event) {
 	if !o.cfg.EnableTxReduceRelay || !o.PeerSupports(evt.PeerID, FeatureTxReduceRelay) {
 		slog.Debug("TMTransactions batch without negotiated tx-reduce-relay; dropping",

--- a/internal/peermanagement/outbound_emit.go
+++ b/internal/peermanagement/outbound_emit.go
@@ -29,19 +29,14 @@ import (
 // us within the first close-cycle they participate in.
 const clusterBroadcastInterval = 10 * time.Second
 
-// txQueueBroadcastInterval drives the periodic tx-reduce-relay
-// outbound emission. Matches rippled's OverlayImpl::Timer::on_timer
-// at 1s (OverlayImpl.cpp:104-108). Rippled only emits when the
-// per-peer txQueue_ has at least one entry; go-xrpl doesn't maintain
-// per-peer queues, so the emit body itself early-returns on an empty
-// open-ledger hashes snapshot (see sendTxQueueAnnounce) — same effect
-// for the (common) empty-mempool case.
+// txQueueBroadcastInterval drives the periodic tx-reduce-relay outbound
+// emission. Matches rippled's OverlayImpl::Timer::on_timer at 1s
+// (OverlayImpl.cpp:104-108).
 const txQueueBroadcastInterval = 1 * time.Second
 
 // txQueueMaxEntriesPerFrame caps a single outbound TMHaveTransactions
-// frame. Matches rippled reduce_relay::MAX_TX_QUEUE_SIZE (64). Beyond
-// that, rippled rotates to a fresh frame; we drop the tail since
-// go-xrpl has no per-peer cursor state.
+// frame. Matches rippled reduce_relay::kMaxTxQueueSize (64). A peer's
+// deferred queue retains the remainder for the next timer tick.
 const txQueueMaxEntriesPerFrame = 64
 
 func buildFrame(msg message.Message, opName string, logAttrs ...any) []byte {
@@ -193,40 +188,22 @@ func (o *Overlay) sendClusterUpdate() {
 // every tx-reduce-relay-negotiated peer. Mirrors rippled's
 // OverlayImpl::sendTxQueue at OverlayImpl.cpp:1366-1373 except that
 // rippled maintains per-peer txQueue_ accumulators (PeerImp.cpp:303-
-// 320) while go-xrpl announces the open-ledger snapshot.
+// 320), which go-xrpl also retains until each frame is admitted.
 //
 // Skipped entirely when EnableTxReduceRelay is off — that's the
 // operator opt-in that gates whether we advertise the feature in
 // handshake at all. Without the advertisement no peer will negotiate,
 // so the gossip would land on deaf ears.
 func (o *Overlay) sendTxQueueAnnounce() {
+	o.sendTxQueueAnnounceWith(func(peer *Peer) error {
+		return peer.sendTxQueue()
+	})
+}
+
+func (o *Overlay) sendTxQueueAnnounceWith(send func(*Peer) error) {
 	if !o.cfg.EnableTxReduceRelay {
 		return
 	}
-	provider := o.openLedgerHashesProviderSnapshot()
-	if provider == nil {
-		return
-	}
-
-	hashes := provider()
-	if len(hashes) == 0 {
-		return
-	}
-	if len(hashes) > txQueueMaxEntriesPerFrame {
-		hashes = hashes[:txQueueMaxEntriesPerFrame]
-	}
-
-	wire := make([][]byte, 0, len(hashes))
-	for _, h := range hashes {
-		hh := h
-		wire = append(wire, hh[:])
-	}
-	msg := &message.HaveTransactions{Hashes: wire}
-	frame := buildFrame(msg, "HaveTransactions")
-	if frame == nil {
-		return
-	}
-
 	// Resolve the peer set and negotiated capabilities while holding peersMu,
 	// then release it before enqueueing. PeerSupports performs its own peer-map
 	// lookup, so calling it while this read lock is held can deadlock when a
@@ -252,7 +229,7 @@ func (o *Overlay) sendTxQueueAnnounce() {
 	o.peersMu.RUnlock()
 
 	for _, target := range targets {
-		if err := target.peer.Send(frame); err != nil {
+		if err := send(target.peer); err != nil {
 			slog.Debug("HaveTransactions send failed",
 				"t", "Overlay", "peer", target.id, "err", err)
 		}

--- a/internal/peermanagement/outbound_emit_test.go
+++ b/internal/peermanagement/outbound_emit_test.go
@@ -127,22 +127,108 @@ func TestSendTxQueueAnnounce_FeatureDisabled_NoEmit(t *testing.T) {
 		"sendTxQueueAnnounce must skip the provider call when EnableTxReduceRelay=false")
 }
 
-// TestSendTxQueueAnnounce_NoProvider_NoOp covers the operator-flipped-
-// flag-without-wiring case: EnableTxReduceRelay=true but
-// SetOpenLedgerHashesProvider was never called. Without this guard
-// we'd nil-deref on the provider invocation; with it the emitter
-// silently no-ops.
+// TestSendTxQueueAnnounce_NoProvider_NoOp covers an opted-in overlay with no
+// connected peers carrying deferred transaction hashes. The emitter must
+// silently no-op when there is no per-peer queue to drain.
 func TestSendTxQueueAnnounce_NoProvider_NoOp(t *testing.T) {
 	o := &Overlay{
-		cfg:                      Config{EnableTxReduceRelay: true},
-		peers:                    make(map[PeerID]*Peer),
-		events:                   make(chan Event, 8),
-		cluster:                  cluster.New(),
-		openLedgerHashesProvider: nil,
+		cfg:     Config{EnableTxReduceRelay: true},
+		peers:   make(map[PeerID]*Peer),
+		events:  make(chan Event, 8),
+		cluster: cluster.New(),
 	}
 	o.sendTxQueueAnnounce()
-	// No panic == pass; explicit assertion below is a redundant guard.
-	assert.Nil(t, o.openLedgerHashesProvider)
+	// No panic == pass; an empty overlay has no outbound frame.
+}
+
+func TestSendTxQueueAnnounce_DrainsPerPeerQueueWithoutStarvation(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	caps := NewPeerCapabilities()
+	caps.Features.Enable(FeatureTxReduceRelay)
+	peer := NewPeer(PeerID(7), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
+	peer.setState(PeerStateConnected)
+	peer.capabilities = caps
+	o := &Overlay{
+		cfg:   Config{EnableTxReduceRelay: true},
+		peers: map[PeerID]*Peer{peer.ID(): peer},
+	}
+
+	for i := 1; i <= txQueueMaxEntriesPerFrame*2+1; i++ {
+		var hash [32]byte
+		hash[0] = byte(i >> 8)
+		hash[1] = byte(i)
+		peer.addTxQueue(hash)
+	}
+	require.Equal(t, txQueueMaxEntriesPerFrame*2+1, peer.txQueueLen())
+
+	for want := range 3 {
+		o.sendTxQueueAnnounce()
+		frame := requireOutboundFrame(t, peer)
+		_, payload, readErr := message.ReadMessage(bytes.NewReader(frame))
+		require.NoError(t, readErr)
+		decoded, decodeErr := message.Decode(message.TypeHaveTransactions, payload)
+		require.NoError(t, decodeErr)
+		have, ok := decoded.(*message.HaveTransactions)
+		require.True(t, ok)
+		wantCount := txQueueMaxEntriesPerFrame
+		if want == 2 {
+			wantCount = 1
+		}
+		require.Len(t, have.Hashes, wantCount)
+		var first [32]byte
+		copy(first[:], have.Hashes[0])
+		firstIndex := want*txQueueMaxEntriesPerFrame + 1
+		assert.Equal(t, byte(firstIndex>>8), first[0])
+		assert.Equal(t, byte(firstIndex), first[1])
+	}
+	assert.Zero(t, peer.txQueueLen())
+}
+
+func TestSendTxQueueAnnounce_ReleasesPeersLockBeforeEnqueue(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	caps := NewPeerCapabilities()
+	caps.Features.Enable(FeatureTxReduceRelay)
+	peer := NewPeer(PeerID(10), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
+	peer.setState(PeerStateConnected)
+	peer.capabilities = caps
+	o := &Overlay{
+		cfg:   Config{EnableTxReduceRelay: true},
+		peers: map[PeerID]*Peer{peer.ID(): peer},
+	}
+	peer.addTxQueue([32]byte{0xA1})
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		o.sendTxQueueAnnounceWith(func(*Peer) error {
+			close(started)
+			<-release
+			return nil
+		})
+		close(done)
+	}()
+	<-started
+
+	writerAcquired := make(chan struct{})
+	go func() {
+		o.peersMu.Lock()
+		o.peersMu.Unlock()
+		close(writerAcquired)
+	}()
+	select {
+	case <-writerAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("peersMu writer blocked while relay enqueue was in progress")
+	}
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("relay announce did not finish")
+	}
 }
 
 // TestBroadcastHaveTxSet_BuildsValidFrame pins the wire shape of the
@@ -227,4 +313,91 @@ func TestServeDoTransactions_FetchesViaProvider(t *testing.T) {
 	// assert on it. The behavioural guarantee is that the provider
 	// was consulted for both hashes and the handler returned cleanly.
 	_ = time.Now()
+}
+
+func TestServeDoTransactions_UsesCacheStateAndRejectsMissing(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	includedHash := [32]byte{0xC1}
+	queuedHash := [32]byte{0xC2}
+	missingHash := [32]byte{0xC3}
+	o := &Overlay{
+		cfg:   Config{EnableTxReduceRelay: true},
+		peers: make(map[PeerID]*Peer),
+		txRecordProvider: func(hash [32]byte) (TxRecord, bool) {
+			switch hash {
+			case includedHash:
+				return TxRecord{RawTransaction: []byte{0x01}, Status: message.TxStatusCurrent}, true
+			case queuedHash:
+				return TxRecord{RawTransaction: []byte{0x02}, Status: message.TxStatusNew, Deferred: true}, true
+			default:
+				return TxRecord{}, false
+			}
+		},
+	}
+	peer := NewPeer(PeerID(8), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
+	o.peers[peer.ID()] = peer
+
+	o.serveDoTransactions(peer.ID(), &message.GetObjectByHash{
+		ObjType: message.ObjectTypeTransactions,
+		Query:   true,
+		Objects: []message.IndexedObject{{Hash: includedHash[:]}, {Hash: queuedHash[:]}},
+	})
+	frame := requireOutboundFrame(t, peer)
+	_, payload, err := message.ReadMessage(bytes.NewReader(frame))
+	require.NoError(t, err)
+	decoded, err := message.Decode(message.TypeTransactions, payload)
+	require.NoError(t, err)
+	reply, ok := decoded.(*message.Transactions)
+	require.True(t, ok)
+	require.Len(t, reply.Transactions, 2)
+	assert.Equal(t, message.TxStatusCurrent, reply.Transactions[0].Status)
+	assert.False(t, reply.Transactions[0].Deferred)
+	assert.Equal(t, message.TxStatusNew, reply.Transactions[1].Status)
+	assert.True(t, reply.Transactions[1].Deferred)
+	assert.NotZero(t, reply.Transactions[0].ReceiveTimestamp)
+	assert.NotZero(t, reply.Transactions[1].ReceiveTimestamp)
+
+	o.serveDoTransactions(peer.ID(), &message.GetObjectByHash{
+		ObjType: message.ObjectTypeTransactions,
+		Query:   true,
+		Objects: []message.IndexedObject{{Hash: includedHash[:]}, {Hash: missingHash[:]}},
+	})
+	assert.False(t, func() bool {
+		_, ok := takeOutboundFrame(peer)
+		return ok
+	}(), "missing hashes must abort the TMTransactions reply")
+	assert.Positive(t, peer.BadDataCount())
+}
+
+func TestServeDoTransactions_RejectsMoreThanCacheCap(t *testing.T) {
+	id, err := NewIdentity()
+	require.NoError(t, err)
+	lookups := 0
+	o := &Overlay{
+		cfg:   Config{EnableTxReduceRelay: true},
+		peers: make(map[PeerID]*Peer),
+		txRecordProvider: func([32]byte) (TxRecord, bool) {
+			lookups++
+			return TxRecord{RawTransaction: []byte{0x01}}, true
+		},
+	}
+	peer := NewPeer(PeerID(9), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
+	o.peers[peer.ID()] = peer
+	objects := make([]message.IndexedObject, peerTxQueueMax+1)
+	for i := range objects {
+		objects[i].Hash = make([]byte, 32)
+		objects[i].Hash[0] = byte(i)
+	}
+	o.serveDoTransactions(peer.ID(), &message.GetObjectByHash{
+		ObjType: message.ObjectTypeTransactions,
+		Query:   true,
+		Objects: objects,
+	})
+	assert.Zero(t, lookups)
+	assert.Positive(t, peer.BadDataCount())
+	assert.False(t, func() bool {
+		_, ok := takeOutboundFrame(peer)
+		return ok
+	}())
 }

--- a/internal/peermanagement/outbound_emit_test.go
+++ b/internal/peermanagement/outbound_emit_test.go
@@ -266,10 +266,10 @@ func TestBroadcastHaveTxSet_BuildsValidFrame(t *testing.T) {
 // TestServeDoTransactions_FetchesViaProvider verifies the
 // TMGetObjectByHash{otTRANSACTIONS} reply path: requested hashes are
 // looked up via the configured txProvider, found blobs are packed
-// into a TMTransactions reply, missing hashes are silently skipped.
+// into a TMTransactions reply, and a missing hash aborts with a malformed
+// request charge.
 // Mirrors rippled's PeerImp::doTransactions
-// (PeerImp.cpp:2787-2839) for the go-xrpl-permissive variant
-// (skip-on-miss instead of charge-on-miss).
+// (PeerImp.cpp:2787-2839).
 func TestServeDoTransactions_FetchesViaProvider(t *testing.T) {
 	id, err := NewIdentity()
 	require.NoError(t, err)

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -167,15 +167,15 @@ type Overlay struct {
 	// block. Guarded by providersMu.
 	onPeerConnect func(PeerID)
 
-	// txProvider returns the raw tx blob for hash if it is in the
-	// open-ledger view. Wired by the consensus adaptor at startup so
-	// the tx-reduce-relay reply path (handleGetObjectsMessage,
-	// otTRANSACTIONS branch) can answer a peer's TMGetObjectByHash
-	// query without importing internal/ledger/service into this
-	// package. nil-safe — the reply path drops without charging when
-	// the provider isn't wired (tests, or operators running the
-	// overlay without a ledger backend). Guarded by providersMu.
+	// txProvider is the legacy open-ledger-only lookup retained for embedded
+	// callers. Production wiring uses txRecordProvider so queued transactions
+	// are included in reduce-relay replies. Guarded by providersMu.
 	txProvider func(hash [32]byte) ([]byte, bool)
+
+	// txRecordProvider is the authoritative transaction-cache lookup used by
+	// reduce-relay replies. It includes queued transactions, which are not part
+	// of the open-ledger view exposed by txProvider.
+	txRecordProvider func(hash [32]byte) (TxRecord, bool)
 
 	// nodeObjectProvider returns the raw node-store blob for a content
 	// hash. Wired by the server at startup so the generic TMGetObjectByHash serve
@@ -186,10 +186,9 @@ type Overlay struct {
 	// store, or tests). Guarded by providersMu.
 	nodeObjectProvider func(hash [32]byte) ([]byte, bool)
 
-	// openLedgerHashesProvider returns the set of tx hashes currently
-	// in the open-ledger view. Drives the periodic tx-reduce-relay
-	// TMHaveTransactions emission in sendTxQueueAnnounce. nil-safe —
-	// the emitter skips when unwired. Guarded by providersMu.
+	// openLedgerHashesProvider is retained for compatibility with older
+	// embedded callers; per-peer deferred queues now drive
+	// TMHaveTransactions emission. Guarded by providersMu.
 	openLedgerHashesProvider func() [][32]byte
 
 	// clusterFeeSink is invoked by handleClusterMessage after the
@@ -301,6 +300,16 @@ const (
 	overlayLifecycleStopping
 	overlayLifecycleStopped
 )
+
+// TxRecord is the transaction-cache state needed to build a rippled-compatible
+// TMTransactions reply. Status is normally TxStatusCurrent for an open-ledger
+// transaction and TxStatusNew for a queued transaction; Deferred identifies a
+// transaction held by the transaction queue.
+type TxRecord struct {
+	RawTransaction []byte
+	Status         message.TransactionStatus
+	Deferred       bool
+}
 
 // LedgerSync returns the overlay's ledger-sync handler so callers in a
 // higher layer (e.g., consensus startup) can wire a LedgerProvider that

--- a/internal/peermanagement/overlay_broadcast.go
+++ b/internal/peermanagement/overlay_broadcast.go
@@ -280,6 +280,11 @@ func (o *Overlay) RelayFromValidator(validator []byte, suppressionHash [32]byte,
 		for _, id := range sources {
 			o.OnValidatorMessage(validator, id)
 		}
+	} else {
+		// A failed or fully-filtered fanout did not relay the message. Restore
+		// the source snapshot so a later retry can still suppress the peers that
+		// already delivered it and account the relay correctly.
+		o.restoreMessageSources(suppressionHash, sources)
 	}
 	return err
 }
@@ -399,6 +404,37 @@ func (o *Overlay) markMessageRelayed(suppressionHash [32]byte) {
 		entry.seenAt = now
 	}
 	o.relayedIndexMu.Unlock()
+}
+
+func (o *Overlay) restoreMessageSources(suppressionHash [32]byte, sources []PeerID) {
+	if o.relayedIndex == nil || len(sources) == 0 {
+		return
+	}
+	clock := o.clockForIndex
+	if clock == nil {
+		clock = time.Now
+	}
+	now := clock()
+	o.relayedIndexMu.Lock()
+	defer o.relayedIndexMu.Unlock()
+	entry, ok := o.relayedIndex[suppressionHash]
+	if !ok || now.Sub(entry.seenAt) >= RelayedIndexTTL {
+		if !ok {
+			entry = &relayedEntry{peers: make(map[PeerID]struct{})}
+			o.relayedIndex[suppressionHash] = entry
+		} else {
+			delete(o.relayedIndex, suppressionHash)
+			entry = &relayedEntry{peers: make(map[PeerID]struct{})}
+			o.relayedIndex[suppressionHash] = entry
+		}
+	}
+	if entry.peers == nil {
+		entry.peers = make(map[PeerID]struct{})
+	}
+	for _, id := range sources {
+		entry.peers[id] = struct{}{}
+	}
+	entry.seenAt = now
 }
 
 // MessageRelayedRecently reports whether this hash was relayed within the

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -364,6 +364,7 @@ func (o *Overlay) Cluster() *cluster.Registry { return o.cluster }
 func (o *Overlay) SetTxProvider(fn func(hash [32]byte) ([]byte, bool)) {
 	o.providersMu.Lock()
 	o.txProvider = fn
+	o.txRecordProvider = nil
 	o.providersMu.Unlock()
 }
 
@@ -371,6 +372,22 @@ func (o *Overlay) txProviderSnapshot() func(hash [32]byte) ([]byte, bool) {
 	o.providersMu.RLock()
 	defer o.providersMu.RUnlock()
 	return o.txProvider
+}
+
+// SetTxRecordProvider installs the authoritative transaction-cache lookup for
+// tx-reduce-relay. Unlike SetTxProvider, this provider may return transactions
+// held by the transaction queue and carries their status/deferred state.
+func (o *Overlay) SetTxRecordProvider(fn func(hash [32]byte) (TxRecord, bool)) {
+	o.providersMu.Lock()
+	o.txRecordProvider = fn
+	o.txProvider = nil
+	o.providersMu.Unlock()
+}
+
+func (o *Overlay) txRecordProviderSnapshot() func(hash [32]byte) (TxRecord, bool) {
+	o.providersMu.RLock()
+	defer o.providersMu.RUnlock()
+	return o.txRecordProvider
 }
 
 // SetNodeObjectProvider installs the node-store lookup used by the
@@ -392,11 +409,10 @@ func (o *Overlay) nodeObjectProviderSnapshot() func(hash [32]byte) ([]byte, bool
 	return o.nodeObjectProvider
 }
 
-// SetOpenLedgerHashesProvider installs the tx-hash snapshot reader
-// used by the periodic TMHaveTransactions emission. The provider
-// returns a (possibly empty) slice of 32-byte tx hashes currently in
-// the open-ledger view. The emitter only fires when EnableTxReduceRelay
-// is true AND this provider is wired; nil leaves the gossip dark.
+// SetOpenLedgerHashesProvider installs the legacy open-ledger hash snapshot
+// reader. Per-peer deferred queues now drive periodic TMHaveTransactions
+// emission; this hook remains available to embedded callers that use it for
+// diagnostics.
 func (o *Overlay) SetOpenLedgerHashesProvider(fn func() [][32]byte) {
 	o.providersMu.Lock()
 	o.openLedgerHashesProvider = fn

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -198,6 +198,13 @@ type Peer struct {
 	// past the cap, and the ring is never cleared (not even on LostSync).
 	recentLedgers [][32]byte
 
+	// txQueue holds transaction hashes deferred by reduce-relay. It mirrors
+	// rippled PeerImp::txQueue_: hashes remain queued until a HaveTransactions
+	// frame is successfully admitted to this peer's outbound queue.
+	txQueueMu  sync.Mutex
+	txQueue    [][32]byte
+	txQueueSet map[[32]byte]struct{}
+
 	// protocolVersion: negotiated peer-protocol token (e.g. "XRPL/2.2").
 	// Mirrors rippled PeerImp::protocol_, surfaced via `protocol` in the
 	// peers RPC (PeerImp.cpp:419). Rippled constructs PeerImp only after
@@ -264,6 +271,7 @@ func NewPeer(id PeerID, endpoint Endpoint, inbound bool, identity *Identity, eve
 		traffic:       NewTrafficCounter(),
 		metrics:       newPeerMetrics(nil),
 		squelchMap:    make(map[string]time.Time),
+		txQueueSet:    make(map[[32]byte]struct{}),
 		pingsInFlight: make(map[uint32]pingInFlight),
 		readPolicy: peerReadPolicy{
 			now:               time.Now,

--- a/internal/peermanagement/peer_tx_queue.go
+++ b/internal/peermanagement/peer_tx_queue.go
@@ -1,0 +1,105 @@
+package peermanagement
+
+import "github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+
+// peerTxQueueMax is rippled reduce_relay::kMaxTxQueueSize. The queue is
+// drained in txQueueMaxEntriesPerFrame-sized batches, so a large backlog makes
+// progress on every timer tick instead of repeatedly starving its tail.
+const peerTxQueueMax = 10_000
+
+// addTxQueue records a transaction for the next reduce-relay announcement.
+// Hashes are de-duplicated per peer. When the cap is reached, one frame is
+// drained before admitting the new hash, matching rippled's addTxQueue
+// behaviour.
+func (p *Peer) addTxQueue(hash [32]byte) {
+	if hash == ([32]byte{}) {
+		return
+	}
+	for {
+		p.txQueueMu.Lock()
+		if p.txQueueSet == nil {
+			p.txQueueSet = make(map[[32]byte]struct{})
+		}
+		if _, exists := p.txQueueSet[hash]; exists {
+			p.txQueueMu.Unlock()
+			return
+		}
+		if len(p.txQueue) < peerTxQueueMax {
+			p.txQueue = append(p.txQueue, hash)
+			p.txQueueSet[hash] = struct{}{}
+			p.txQueueMu.Unlock()
+			return
+		}
+		p.txQueueMu.Unlock()
+
+		// sendTxQueue removes hashes only after Send successfully admits the
+		// frame. If admission fails, retaining the full queue is safer than
+		// evicting a transaction that has not yet been announced.
+		if err := p.sendTxQueue(); err != nil {
+			return
+		}
+	}
+}
+
+// removeTxQueue forgets a hash after this peer confirms it already has the
+// transaction. Removing by value preserves FIFO order for the remaining
+// deferred announcements.
+func (p *Peer) removeTxQueue(hash [32]byte) {
+	p.txQueueMu.Lock()
+	defer p.txQueueMu.Unlock()
+	if _, exists := p.txQueueSet[hash]; !exists {
+		return
+	}
+	delete(p.txQueueSet, hash)
+	for i, queued := range p.txQueue {
+		if queued != hash {
+			continue
+		}
+		copy(p.txQueue[i:], p.txQueue[i+1:])
+		p.txQueue[len(p.txQueue)-1] = [32]byte{}
+		p.txQueue = p.txQueue[:len(p.txQueue)-1]
+		return
+	}
+}
+
+func (p *Peer) txQueueLen() int {
+	p.txQueueMu.Lock()
+	defer p.txQueueMu.Unlock()
+	return len(p.txQueue)
+}
+
+// sendTxQueue emits one queued hash batch. The queue is committed only after
+// the frame is accepted by Peer.Send, so a bounded-queue failure leaves the
+// hashes available for the next timer tick.
+func (p *Peer) sendTxQueue() error {
+	p.txQueueMu.Lock()
+	defer p.txQueueMu.Unlock()
+
+	n := len(p.txQueue)
+	if n > txQueueMaxEntriesPerFrame {
+		n = txQueueMaxEntriesPerFrame
+	}
+	if n == 0 {
+		return nil
+	}
+	wire := make([][]byte, n)
+	for i, hash := range p.txQueue[:n] {
+		wire[i] = append([]byte(nil), hash[:]...)
+	}
+	frame, err := message.EncodeFrame(&message.HaveTransactions{Hashes: wire})
+	if err != nil {
+		return err
+	}
+	if err := p.Send(frame); err != nil {
+		return err
+	}
+	for _, hash := range p.txQueue[:n] {
+		delete(p.txQueueSet, hash)
+	}
+	copy(p.txQueue, p.txQueue[n:])
+	for i := len(p.txQueue) - n; i < len(p.txQueue); i++ {
+		p.txQueue[i] = [32]byte{}
+	}
+	p.txQueue = p.txQueue[:len(p.txQueue)-n]
+	return nil
+}

--- a/internal/peermanagement/peer_tx_queue.go
+++ b/internal/peermanagement/peer_tx_queue.go
@@ -10,10 +10,11 @@ const peerTxQueueMax = 10_000
 // addTxQueue records a transaction for the next reduce-relay announcement.
 // Hashes are de-duplicated per peer. When the cap is reached, one frame is
 // drained before admitting the new hash, matching rippled's addTxQueue
-// behaviour.
-func (p *Peer) addTxQueue(hash [32]byte) {
+// behaviour. A false return means the hash was not retained and the caller
+// must use a full-transaction fallback.
+func (p *Peer) addTxQueue(hash [32]byte) bool {
 	if hash == ([32]byte{}) {
-		return
+		return false
 	}
 	for {
 		p.txQueueMu.Lock()
@@ -22,13 +23,13 @@ func (p *Peer) addTxQueue(hash [32]byte) {
 		}
 		if _, exists := p.txQueueSet[hash]; exists {
 			p.txQueueMu.Unlock()
-			return
+			return true
 		}
 		if len(p.txQueue) < peerTxQueueMax {
 			p.txQueue = append(p.txQueue, hash)
 			p.txQueueSet[hash] = struct{}{}
 			p.txQueueMu.Unlock()
-			return
+			return true
 		}
 		p.txQueueMu.Unlock()
 
@@ -36,7 +37,7 @@ func (p *Peer) addTxQueue(hash [32]byte) {
 		// frame. If admission fails, retaining the full queue is safer than
 		// evicting a transaction that has not yet been announced.
 		if err := p.sendTxQueue(); err != nil {
-			return
+			return false
 		}
 	}
 }

--- a/internal/peermanagement/relay_transaction.go
+++ b/internal/peermanagement/relay_transaction.go
@@ -20,16 +20,24 @@ func peerTxReduceRelayEnabled(p *Peer) bool {
 // minimum (TxReduceRelayMinPeers + peers without the feature), the full frame
 // is sent to every candidate peer. Otherwise it is sent to all peers without
 // the feature plus a TxRelayPercentage share of the enabled peers; the
-// remaining enabled peers learn of the transaction via the periodic
-// TMHaveTransactions announce (sendTxQueueAnnounce) — go-xrpl's analogue of
-// rippled's per-peer addTxQueue, since that announce already gossips the
-// open-ledger tx hashes to every tx-reduce-relay peer each second.
+// remaining enabled peers learn of the transaction via their per-peer
+// TMHaveTransactions queue, drained by the periodic sendTxQueueAnnounce tick.
 //
 // except is the originating peer: go-xrpl's single-element toSkip. rippled also
 // skips peers a HashRouter marks as already holding the tx, which go-xrpl does
 // not track (see router.relayTransaction); suppressed is therefore reported as
 // the single origin peer.
 func (o *Overlay) RelayTransaction(except PeerID, frame []byte) {
+	o.relayTransaction(except, [32]byte{}, frame)
+}
+
+// RelayTransactionWithHash is RelayTransaction with the transaction ID used
+// to populate suppressed peers' lossless reduce-relay queues.
+func (o *Overlay) RelayTransactionWithHash(except PeerID, hash [32]byte, frame []byte) {
+	o.relayTransaction(except, hash, frame)
+}
+
+func (o *Overlay) relayTransaction(except PeerID, hash [32]byte, frame []byte) {
 	// getActivePeers (OverlayImpl.cpp:1062-1094): total counts every active
 	// peer; disabled counts peers without the feature; candidates are the
 	// peers not in toSkip; enabledInSkip counts skipped peers that have the
@@ -103,7 +111,12 @@ func (o *Overlay) RelayTransaction(except PeerID, frame []byte) {
 	}
 
 	enabledAndRelayed := enabledInSkip
-	relayTransactionCandidates(candidates, enabledAndRelayed, enabledTarget, sendFull)
+	relayTransactionCandidates(candidates, enabledAndRelayed, enabledTarget, sendFull,
+		func(peer *Peer) {
+			if hash != ([32]byte{}) {
+				peer.addTxQueue(hash)
+			}
+		})
 }
 
 func relayTransactionCandidates(
@@ -111,6 +124,7 @@ func relayTransactionCandidates(
 	enabledAndRelayed uint64,
 	enabledTarget uint64,
 	sendFull func(*Peer) bool,
+	queue ...func(*Peer),
 ) {
 	for _, p := range candidates {
 		switch {
@@ -121,8 +135,11 @@ func relayTransactionCandidates(
 				enabledAndRelayed++
 			}
 		default:
-			// Remaining enabled peers learn of the tx via the periodic
-			// TMHaveTransactions announce (rippled's addTxQueue analogue).
+			// Remaining enabled peers learn of the tx via their per-peer
+			// TMHaveTransactions queue.
+			if len(queue) > 0 && queue[0] != nil {
+				queue[0](p)
+			}
 		}
 	}
 }

--- a/internal/peermanagement/relay_transaction.go
+++ b/internal/peermanagement/relay_transaction.go
@@ -1,7 +1,12 @@
 package peermanagement
 
 import (
+	"bytes"
 	"math/rand/v2"
+
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // peerTxReduceRelayEnabled reports whether a peer negotiated the
@@ -28,16 +33,31 @@ func peerTxReduceRelayEnabled(p *Peer) bool {
 // not track (see router.relayTransaction); suppressed is therefore reported as
 // the single origin peer.
 func (o *Overlay) RelayTransaction(except PeerID, frame []byte) {
-	o.relayTransaction(except, [32]byte{}, frame)
+	hash, ok := transactionHashFromFrame(frame)
+	o.relayTransaction(except, hash, ok, frame)
 }
 
-// RelayTransactionWithHash is RelayTransaction with the transaction ID used
-// to populate suppressed peers' lossless reduce-relay queues.
-func (o *Overlay) RelayTransactionWithHash(except PeerID, hash [32]byte, frame []byte) {
-	o.relayTransaction(except, hash, frame)
+// transactionHashFromFrame extracts the canonical transaction blob from a
+// wire TMTransaction frame and derives the XRPL transaction ID. A false
+// result means the caller must not suppress the full transaction: without a
+// usable hash a HAVE_TRANSACTIONS announcement could never be fulfilled.
+func transactionHashFromFrame(frame []byte) ([32]byte, bool) {
+	header, payload, err := message.ReadMessage(bytes.NewReader(frame))
+	if err != nil || header.MessageType != message.TypeTransaction {
+		return [32]byte{}, false
+	}
+	decoded, err := message.Decode(message.TypeTransaction, payload)
+	if err != nil {
+		return [32]byte{}, false
+	}
+	txn, ok := decoded.(*message.Transaction)
+	if !ok || len(txn.RawTransaction) == 0 {
+		return [32]byte{}, false
+	}
+	return sha512half.Sum(protocol.HashPrefixTransactionID().Bytes(), txn.RawTransaction), true
 }
 
-func (o *Overlay) relayTransaction(except PeerID, hash [32]byte, frame []byte) {
+func (o *Overlay) relayTransaction(except PeerID, hash [32]byte, hashOK bool, frame []byte) {
 	// getActivePeers (OverlayImpl.cpp:1062-1094): total counts every active
 	// peer; disabled counts peers without the feature; candidates are the
 	// peers not in toSkip; enabledInSkip counts skipped peers that have the
@@ -112,10 +132,8 @@ func (o *Overlay) relayTransaction(except PeerID, hash [32]byte, frame []byte) {
 
 	enabledAndRelayed := enabledInSkip
 	relayTransactionCandidates(candidates, enabledAndRelayed, enabledTarget, sendFull,
-		func(peer *Peer) {
-			if hash != ([32]byte{}) {
-				peer.addTxQueue(hash)
-			}
+		func(peer *Peer) bool {
+			return hashOK && peer.addTxQueue(hash)
 		})
 }
 
@@ -124,7 +142,7 @@ func relayTransactionCandidates(
 	enabledAndRelayed uint64,
 	enabledTarget uint64,
 	sendFull func(*Peer) bool,
-	queue ...func(*Peer),
+	queue ...func(*Peer) bool,
 ) {
 	for _, p := range candidates {
 		switch {
@@ -138,7 +156,16 @@ func relayTransactionCandidates(
 			// Remaining enabled peers learn of the tx via their per-peer
 			// TMHaveTransactions queue.
 			if len(queue) > 0 && queue[0] != nil {
-				queue[0](p)
+				if !queue[0](p) {
+					// A suppressed announcement is only safe when the hash was
+					// retained. Fall back to the full frame if queue admission
+					// fails or the frame did not contain a usable transaction ID.
+					sendFull(p)
+				}
+			} else {
+				// Keep the helper's standalone behaviour lossless for callers that
+				// do not provide a queue implementation.
+				sendFull(p)
 			}
 		}
 	}

--- a/internal/peermanagement/relay_transaction_test.go
+++ b/internal/peermanagement/relay_transaction_test.go
@@ -6,7 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/LeJamon/go-xrpl/crypto/sha512half"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 func relayTestPeer(t *testing.T, ident *Identity, id PeerID, txrr bool) *Peer {
@@ -22,6 +24,16 @@ func relayTestPeer(t *testing.T, ident *Identity, id PeerID, txrr bool) *Peer {
 }
 
 func gotFrame(p *Peer) bool { return p.SendQueueLen() > 0 }
+
+func relayTestFrame(t *testing.T) []byte {
+	t.Helper()
+	frame, err := message.EncodeFrame(&message.Transaction{
+		RawTransaction: []byte{0xAA},
+		Status:         message.TxStatusCurrent,
+	})
+	require.NoError(t, err)
+	return frame
+}
 
 // TestRelayTransaction_FeatureOff relays to every candidate peer and records
 // no metrics when tx-reduce-relay is disabled (OverlayImpl.cpp:1251-1259 with
@@ -40,7 +52,7 @@ func TestRelayTransaction_FeatureOff(t *testing.T) {
 		o.peers[id] = relayTestPeer(t, ident, id, true)
 	}
 
-	o.RelayTransaction(1, []byte{0xAA})
+	o.RelayTransaction(1, relayTestFrame(t))
 
 	assert.False(t, gotFrame(origin), "origin must be excluded")
 	for id := PeerID(2); id <= 4; id++ {
@@ -65,7 +77,7 @@ func TestRelayTransaction_BelowMinRelaysToAll(t *testing.T) {
 		o.peers[id] = relayTestPeer(t, ident, id, true)
 	}
 
-	o.RelayTransaction(1, []byte{0xAA})
+	o.RelayTransaction(1, relayTestFrame(t))
 
 	for id := PeerID(2); id <= 4; id++ {
 		assert.True(t, gotFrame(o.peers[id]), "peer %d should get the full frame", id)
@@ -99,7 +111,7 @@ func TestRelayTransaction_ReducePathSelectsSubset(t *testing.T) {
 		o.peers[id] = relayTestPeer(t, ident, id, false)
 	}
 
-	o.RelayTransaction(1, []byte{0xAA})
+	o.RelayTransaction(1, relayTestFrame(t))
 
 	disabledSent := 0
 	for _, id := range disabled {
@@ -121,6 +133,81 @@ func TestRelayTransaction_ReducePathSelectsSubset(t *testing.T) {
 	assert.Equal(t, uint64(3), o.txm.selected.accum, "selected = enabledTarget")
 	assert.Equal(t, uint64(1), o.txm.suppressed.accum, "suppressed = origin")
 	assert.Equal(t, uint64(2), o.txm.notEnabled.accum, "notEnabled = disabled count")
+}
+
+func TestRelayTransaction_DerivesHashForSuppressedPeers(t *testing.T) {
+	ident, err := NewIdentity()
+	require.NoError(t, err)
+	o := &Overlay{
+		cfg:   Config{EnableTxReduceRelay: true, TxReduceRelayMinPeers: 1, TxRelayPercentage: 0},
+		peers: make(map[PeerID]*Peer),
+	}
+	o.peers[1] = relayTestPeer(t, ident, 1, true)
+	for id := PeerID(2); id <= 3; id++ {
+		o.peers[id] = relayTestPeer(t, ident, id, true)
+	}
+	frame := relayTestFrame(t)
+	o.RelayTransaction(1, frame)
+
+	want := sha512half.Sum(protocol.HashPrefixTransactionID().Bytes(), []byte{0xAA})
+	queued := 0
+	for id := PeerID(2); id <= 3; id++ {
+		if o.peers[id].txQueueLen() == 1 {
+			queued++
+			p := o.peers[id]
+			p.txQueueMu.Lock()
+			assert.Equal(t, want, p.txQueue[0])
+			p.txQueueMu.Unlock()
+		}
+	}
+	assert.Equal(t, 2, queued, "the suppressed peers must retain the derived tx hash")
+}
+
+func TestRelayTransaction_InvalidFrameFallsBackToFullRelay(t *testing.T) {
+	ident, err := NewIdentity()
+	require.NoError(t, err)
+	o := &Overlay{
+		cfg:   Config{EnableTxReduceRelay: true, TxReduceRelayMinPeers: 1, TxRelayPercentage: 0},
+		peers: make(map[PeerID]*Peer),
+	}
+	o.peers[1] = relayTestPeer(t, ident, 1, true)
+	for id := PeerID(2); id <= 3; id++ {
+		o.peers[id] = relayTestPeer(t, ident, id, true)
+	}
+	o.RelayTransaction(1, []byte{0xAA})
+	for id := PeerID(2); id <= 3; id++ {
+		assert.True(t, gotFrame(o.peers[id]), "peer %d should receive the fallback full frame", id)
+		assert.Zero(t, o.peers[id].txQueueLen())
+	}
+}
+
+func TestRelayTransaction_FullQueueSendFailureRetainsBoundedQueue(t *testing.T) {
+	ident, err := NewIdentity()
+	require.NoError(t, err)
+	o := &Overlay{
+		cfg:   Config{EnableTxReduceRelay: true, TxReduceRelayMinPeers: 1, TxRelayPercentage: 0},
+		peers: make(map[PeerID]*Peer),
+	}
+	origin := relayTestPeer(t, ident, 1, true)
+	suppressed := relayTestPeer(t, ident, 2, true)
+	o.peers[1] = origin
+	o.peers[2] = suppressed
+	for i := 1; i <= peerTxQueueMax; i++ {
+		var hash [32]byte
+		hash[0] = byte(i >> 8)
+		hash[1] = byte(i)
+		require.True(t, suppressed.addTxQueue(hash))
+	}
+	for range ordinarySendMaximum {
+		require.NoError(t, suppressed.Send([]byte{0xBB}))
+	}
+	beforeDrops := suppressed.SendDrops()
+	o.RelayTransaction(1, relayTestFrame(t))
+
+	assert.Equal(t, peerTxQueueMax, suppressed.txQueueLen(),
+		"a failed announcement send must retain the bounded queue")
+	assert.GreaterOrEqual(t, suppressed.SendDrops(), beforeDrops+2,
+		"queue admission failure must trigger an attempted full-frame fallback")
 }
 
 func TestRelayTransactionCandidatesReplacesFailedEnabledSend(t *testing.T) {

--- a/internal/peermanagement/relayed_index_test.go
+++ b/internal/peermanagement/relayed_index_test.go
@@ -150,6 +150,8 @@ func TestOverlay_RelayFromValidatorMarksOnlySuccessfulEnqueue(t *testing.T) {
 	require.ErrorIs(t, o.RelayFromValidator([]byte("validator"), hash, 0, []byte{0xBB}), ErrSendBufferFull)
 	assert.False(t, o.MessageRelayedRecently(hash),
 		"a failed relay must not enter the duplicate-counting window")
+	assert.Equal(t, []PeerID{source.ID()}, o.PeersThatHave(hash),
+		"a failed relay must restore the source snapshot")
 
 	// A later relay that is accepted by a peer does enter the window.
 	destination = NewPeer(PeerID(3), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
@@ -159,4 +161,6 @@ func TestOverlay_RelayFromValidatorMarksOnlySuccessfulEnqueue(t *testing.T) {
 	o.RecordMessageSource(hash, source.ID())
 	require.ErrorIs(t, o.RelayFromValidator([]byte("validator"), hash, 0, []byte{0xBC}), ErrSendBufferFull)
 	assert.True(t, o.MessageRelayedRecently(hash))
+	assert.Empty(t, o.PeersThatHave(hash),
+		"a partially successful relay consumes the source snapshot")
 }

--- a/internal/txq/process.go
+++ b/internal/txq/process.go
@@ -68,6 +68,7 @@ func (q *TxQ) Clear() {
 	defer q.mu.Unlock()
 
 	q.byFee = make([]*Candidate, 0)
+	q.byID = make(map[[32]byte]*Candidate)
 	q.byAccount = make(map[[20]byte]*AccountQueue)
 }
 

--- a/internal/txq/txq.go
+++ b/internal/txq/txq.go
@@ -137,6 +137,26 @@ func (q *TxQ) Size() int {
 	return len(q.byFee)
 }
 
+// GetTxBlob returns a copy of the raw transaction held by the queue. The
+// transaction queue is an authoritative cache for reduce-relay replies: a
+// terQUEUED transaction is not present in the open-ledger view yet, but peers
+// must still be able to fetch it by hash.
+func (q *TxQ) GetTxBlob(txID [32]byte) ([]byte, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for _, candidate := range q.byFee {
+		if candidate == nil || candidate.TxID != txID || candidate.Txn == nil {
+			continue
+		}
+		raw := candidate.Txn.GetRawBytes()
+		if len(raw) == 0 {
+			return nil, false
+		}
+		return append([]byte(nil), raw...), true
+	}
+	return nil, false
+}
+
 // RequiredFeeLevel returns the fee level required to bypass the queue
 // and get directly into the open ledger.
 func (q *TxQ) RequiredFeeLevel(txInLedger uint32) FeeLevel {

--- a/internal/txq/txq.go
+++ b/internal/txq/txq.go
@@ -23,6 +23,11 @@ type TxQ struct {
 	// transactions into the open ledger.
 	byFee []*Candidate
 
+	// byID is the authoritative transaction lookup used by reduce-relay
+	// backfill. It is maintained alongside byFee so a request for many hashes
+	// does not rescan the fee-ordered queue for every object.
+	byID map[[32]byte]*Candidate
+
 	// byAccount maps account ID to their AccountQueue.
 	// This allows efficient lookup and enforcement of per-account limits.
 	byAccount map[[20]byte]*AccountQueue
@@ -52,6 +57,7 @@ func New(config Config) *TxQ {
 		config:     config,
 		feeMetrics: NewFeeMetrics(config),
 		byFee:      make([]*Candidate, 0),
+		byID:       make(map[[32]byte]*Candidate),
 		byAccount:  make(map[[20]byte]*AccountQueue),
 		// maxSize starts as nil (no limit) matching rippled's std::optional nullopt.
 		// It gets set on the first processClosedLedger call.
@@ -144,17 +150,18 @@ func (q *TxQ) Size() int {
 func (q *TxQ) GetTxBlob(txID [32]byte) ([]byte, bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	for _, candidate := range q.byFee {
-		if candidate == nil || candidate.TxID != txID || candidate.Txn == nil {
-			continue
-		}
-		raw := candidate.Txn.GetRawBytes()
-		if len(raw) == 0 {
-			return nil, false
-		}
-		return append([]byte(nil), raw...), true
+	if q.byID == nil {
+		q.rebuildByID()
 	}
-	return nil, false
+	candidate := q.byID[txID]
+	if candidate == nil || candidate.Txn == nil {
+		return nil, false
+	}
+	raw := candidate.Txn.GetRawBytes()
+	if len(raw) == 0 {
+		return nil, false
+	}
+	return append([]byte(nil), raw...), true
 }
 
 // RequiredFeeLevel returns the fee level required to bypass the queue
@@ -171,10 +178,17 @@ func (q *TxQ) RequiredFeeLevel(txInLedger uint32) FeeLevel {
 // Candidates with the same fee are ordered by txID XOR parentHash for deterministic ordering.
 // Caller must hold the lock.
 func (q *TxQ) insertByFee(c *Candidate) {
+	if c == nil {
+		return
+	}
+	if q.byID == nil {
+		q.byID = make(map[[32]byte]*Candidate)
+	}
 	pos := q.findInsertPosition(c)
 	q.byFee = append(q.byFee, nil)
 	copy(q.byFee[pos+1:], q.byFee[pos:])
 	q.byFee[pos] = c
+	q.byID[c.TxID] = c
 }
 
 // findInsertPosition finds where to insert a candidate to maintain order.
@@ -221,6 +235,9 @@ func (q *TxQ) removeByFee(c *Candidate) {
 	for i, candidate := range q.byFee {
 		if candidate == c {
 			q.byFee = append(q.byFee[:i], q.byFee[i+1:]...)
+			if q.byID != nil && q.byID[c.TxID] == c {
+				delete(q.byID, c.TxID)
+			}
 			return
 		}
 	}
@@ -244,7 +261,9 @@ func (q *TxQ) erase(c *Candidate) {
 // Walks accounts in sorted order and candidates via GetSortedCandidates
 // so the rebuilt byFee slice is bit-identical across validators.
 func (q *TxQ) rebuildByFee() {
-	q.byFee = make([]*Candidate, 0, len(q.byFee))
+	capacity := len(q.byFee)
+	q.byFee = make([]*Candidate, 0, capacity)
+	q.byID = make(map[[32]byte]*Candidate, capacity)
 
 	accounts := make([][20]byte, 0, len(q.byAccount))
 	for a := range q.byAccount {
@@ -257,6 +276,18 @@ func (q *TxQ) rebuildByFee() {
 	for _, a := range accounts {
 		for _, c := range q.byAccount[a].SortedCandidates() {
 			q.insertByFee(c)
+		}
+	}
+}
+
+// rebuildByID reconstructs the transaction lookup from byFee. It is used only
+// for zero-value/test queues; production queues maintain the index on every
+// insertion and removal.
+func (q *TxQ) rebuildByID() {
+	q.byID = make(map[[32]byte]*Candidate, len(q.byFee))
+	for _, candidate := range q.byFee {
+		if candidate != nil {
+			q.byID[candidate.TxID] = candidate
 		}
 	}
 }

--- a/internal/txq/txq_test.go
+++ b/internal/txq/txq_test.go
@@ -78,6 +78,26 @@ func TestTxQ_InsertByFee(t *testing.T) {
 	}
 }
 
+func TestTxQ_GetTxBlobUsesByIDIndex(t *testing.T) {
+	q := New(DefaultConfig())
+	hash := [32]byte{0xA1}
+	candidate := &Candidate{
+		TxID:     hash,
+		Txn:      &mockTx{id: 7},
+		FeeLevel: FeeLevel(BaseLevel),
+	}
+	q.insertByFee(candidate)
+
+	blob, ok := q.GetTxBlob(hash)
+	if !ok || len(blob) != 1 || blob[0] != 7 {
+		t.Fatalf("GetTxBlob() = (%x, %v), want (07, true)", blob, ok)
+	}
+	q.removeByFee(candidate)
+	if _, ok := q.GetTxBlob(hash); ok {
+		t.Fatal("GetTxBlob returned a candidate after removeByFee")
+	}
+}
+
 // TestTxQ_GetMetrics tests metrics retrieval
 func TestTxQ_GetMetrics(t *testing.T) {
 	cfg := DefaultConfig()


### PR DESCRIPTION
Part of #1472. Stack PR 9/11.\n\nMakes reduced transaction relay lossless while enforcing hard per-entry and aggregate relay-cache limits with bounded compaction.