### PR TITLE
fix: make cluster registry snapshots safe

### DIFF
--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -581,9 +581,6 @@ func (r *nodeRuntime) configureConsensus() error {
 			})
 		}
 
-		// Cluster freshness and report timestamps use consensus-adjusted time.
-		overlay.SetNetworkTimeProvider(r.consensus.Adaptor.Now)
-
 		// LoadFeeTrack ingress + outbound self-load advertisement.
 		// Mirrors the rippled wiring split:
 		//   - PeerImp.cpp:1193 setClusterFee(median) on inbound TMCluster

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -581,6 +581,9 @@ func (r *nodeRuntime) configureConsensus() error {
 			})
 		}
 
+		// Cluster freshness and report timestamps use consensus-adjusted time.
+		overlay.SetNetworkTimeProvider(r.consensus.Adaptor.Now)
+
 		// LoadFeeTrack ingress + outbound self-load advertisement.
 		// Mirrors the rippled wiring split:
 		//   - PeerImp.cpp:1193 setClusterFee(median) on inbound TMCluster

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -584,10 +584,13 @@ func (r *nodeRuntime) configureConsensus() error {
 		// LoadFeeTrack ingress + outbound self-load advertisement.
 		// Mirrors the rippled wiring split:
 		//   - PeerImp.cpp:1193 setClusterFee(median) on inbound TMCluster
-		//   - NetworkOPs.cpp:1126-1132 self-entry sources getLocalFee()
+		//   - NetworkOPs.cpp:1189-1195 self-entry sources getLocalFee()
+		//     only while the validated ledger is at most four minutes old
 		if ft := r.ledger.FeeTrack(); ft != nil {
 			overlay.SetClusterFeeSink(ft.SetClusterFee)
-			overlay.SetLocalLoadFeeProvider(ft.LocalFee)
+			overlay.SetLocalLoadFeeProvider(func() (uint32, time.Duration) {
+				return ft.LocalFee(), r.ledger.GetValidatedLedgerAge()
+			})
 		}
 
 		r.services.NodePublicKey = r.consensus.Overlay.NodePublicKey()

--- a/internal/peermanagement/cluster/cluster.go
+++ b/internal/peermanagement/cluster/cluster.go
@@ -10,49 +10,65 @@
 package cluster
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
 
-	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/crypto"
 )
 
-// Member is one entry in the cluster registry. Identity is the raw
-// 33-byte node public key (post-addresscodec decode).
+// Identity is a fixed-width raw NodePublic key.
+type Identity [addresscodec.NodePublicKeyLength]byte
+
+// Member is one entry in the cluster registry.
 type Member struct {
-	Identity   []byte
+	Identity   Identity
 	Name       string
 	LoadFee    uint32
 	ReportTime time.Time
 }
 
-// Registry is a thread-safe set of cluster members keyed by raw
-// NodePublic bytes.
+// Registry is a thread-safe set of cluster members. Its zero value is ready to
+// use. Nil receivers behave as empty registries; mutating them fails.
 type Registry struct {
 	mu    sync.RWMutex
-	nodes map[string]Member
+	nodes map[Identity]Member
 }
 
 // New returns an empty registry.
 func New() *Registry {
-	return &Registry{nodes: make(map[string]Member)}
+	return new(Registry)
 }
 
-// Member looks up an entry by raw NodePublic bytes. A nil receiver and
-// an empty key both yield (zero, false). A member with an empty Name
-// still returns ok=true.
+func identityFromBytes(raw []byte) (Identity, bool) {
+	if crypto.PublicKeyType(raw) == crypto.KeyTypeUnknown {
+		return Identity{}, false
+	}
+	var identity Identity
+	copy(identity[:], raw)
+	return identity, true
+}
+
+// Member looks up an entry by raw NodePublic bytes. Invalid identities and nil
+// receivers yield (zero, false). A member with an empty Name still returns
+// ok=true.
 func (r *Registry) Member(identity []byte) (Member, bool) {
-	if r == nil || len(identity) == 0 {
+	if r == nil {
+		return Member{}, false
+	}
+	key, valid := identityFromBytes(identity)
+	if !valid {
 		return Member{}, false
 	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	m, ok := r.nodes[string(identity)]
+	m, ok := r.nodes[key]
 	return m, ok
 }
 
@@ -66,22 +82,25 @@ func (r *Registry) Size() int {
 	return len(r.nodes)
 }
 
-// ForEach invokes fn once per member, in deterministic order (sorted
-// by raw identity bytes). The read lock is held for the whole walk so
-// fn must not call back into Update/Load.
+// ForEach invokes fn once per member from a stable snapshot, in raw identity
+// byte order. Callbacks run without the registry lock and may call back into r;
+// their updates are visible to later walks, not the current one.
 func (r *Registry) ForEach(fn func(Member)) {
 	if r == nil || fn == nil {
 		return
 	}
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	keys := make([]string, 0, len(r.nodes))
-	for k := range r.nodes {
-		keys = append(keys, k)
+	members := make([]Member, 0, len(r.nodes))
+	for _, member := range r.nodes {
+		members = append(members, member)
 	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		fn(r.nodes[k])
+	r.mu.RUnlock()
+
+	slices.SortFunc(members, func(a, b Member) int {
+		return bytes.Compare(a.Identity[:], b.Identity[:])
+	})
+	for _, member := range members {
+		fn(member)
 	}
 }
 
@@ -92,13 +111,16 @@ func (r *Registry) ForEach(fn func(Member)) {
 //   - a freshly-empty name preserves the previously-recorded name;
 //   - the first insert always succeeds.
 func (r *Registry) Update(identity []byte, name string, loadFee uint32, reportTime time.Time) bool {
-	if len(identity) == 0 {
+	if r == nil {
+		return false
+	}
+	key, valid := identityFromBytes(identity)
+	if !valid {
 		return false
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	key := string(identity)
 	if prev, exists := r.nodes[key]; exists {
 		if !reportTime.After(prev.ReportTime) {
 			return false
@@ -107,8 +129,11 @@ func (r *Registry) Update(identity []byte, name string, loadFee uint32, reportTi
 			name = prev.Name
 		}
 	}
+	if r.nodes == nil {
+		r.nodes = make(map[Identity]Member)
+	}
 	r.nodes[key] = Member{
-		Identity:   append([]byte(nil), identity...),
+		Identity:   key,
 		Name:       name,
 		LoadFee:    loadFee,
 		ReportTime: reportTime,
@@ -165,6 +190,12 @@ func (r *Registry) Load(entries []string) error {
 		idBytes, err := addresscodec.DecodeNodePublicKey(groups[1])
 		if err != nil {
 			return fmt.Errorf("cluster_nodes[%d]: invalid node identity %q: %w", i, groups[1], err)
+		}
+		if _, valid := identityFromBytes(idBytes); !valid {
+			return fmt.Errorf(
+				"cluster_nodes[%d]: invalid node identity %q: expected a %d-byte public key",
+				i, groups[1], addresscodec.NodePublicKeyLength,
+			)
 		}
 		if _, dup := r.Member(idBytes); dup {
 			continue

--- a/internal/peermanagement/cluster/cluster_test.go
+++ b/internal/peermanagement/cluster/cluster_test.go
@@ -1,10 +1,12 @@
 package cluster_test
 
 import (
+	"bytes"
+	"sync"
 	"testing"
 	"time"
 
-	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/cluster"
 )
 
@@ -22,15 +24,19 @@ func mustDecode(t *testing.T, k string) []byte {
 	return b
 }
 
+func identityBytes(fill byte) []byte {
+	identity := bytes.Repeat([]byte{fill}, addresscodec.NodePublicKeyLength)
+	identity[0] = 0x02
+	return identity
+}
+
 func TestRegistry_MedianFee(t *testing.T) {
 	r := cluster.New()
 	now := time.Unix(2_000_000_000, 0)
 	r.Update(mustDecode(t, pubA), "a", 320, now)
 	r.Update(mustDecode(t, pubB), "b", 400, now)
 	// Older-than-window entry is excluded from the median.
-	stale := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
-		0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
-		0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21}
+	stale := identityBytes(0x01)
 	r.Update(stale, "stale", 9999, now.Add(-2*time.Minute))
 
 	fee, ok := r.MedianFee(now.Add(-90 * time.Second))
@@ -52,22 +58,39 @@ func TestRegistry_MedianFee_EmptyWindow(t *testing.T) {
 	}
 }
 
-func TestRegistry_MedianFee_NilSafe(t *testing.T) {
+func TestRegistry_ReceiverSemantics(t *testing.T) {
 	var r *cluster.Registry
-	if _, ok := r.MedianFee(time.Now()); ok {
-		t.Fatal("nil registry MedianFee should report ok=false")
-	}
-}
-
-func TestRegistry_NilSafe(t *testing.T) {
-	var r *cluster.Registry
-	if _, ok := r.Member([]byte{0x01}); ok {
+	id := mustDecode(t, pubA)
+	if _, ok := r.Member(id); ok {
 		t.Fatalf("nil registry should never report membership")
 	}
 	if r.Size() != 0 {
 		t.Fatalf("nil Size = %d; want 0", r.Size())
 	}
 	r.ForEach(func(cluster.Member) { t.Fatal("ForEach on nil should be no-op") })
+	if r.Update(id, "node", 1, time.Time{}) {
+		t.Fatal("Update on nil registry should fail")
+	}
+	if err := r.Load([]string{pubA}); err == nil {
+		t.Fatal("Load on nil registry should return an error")
+	}
+	if _, ok := r.MedianFee(time.Now()); ok {
+		t.Fatal("MedianFee on nil registry should report ok=false")
+	}
+
+	var zero cluster.Registry
+	if !zero.Update(id, "node", 1, time.Time{}) {
+		t.Fatal("zero-value registry Update should succeed")
+	}
+	if _, ok := zero.Member(id); !ok {
+		t.Fatal("zero-value registry should retain updates")
+	}
+	if err := zero.Load([]string{pubB}); err != nil {
+		t.Fatalf("zero-value registry Load: %v", err)
+	}
+	if zero.Size() != 2 {
+		t.Fatalf("zero-value registry Size = %d; want 2", zero.Size())
+	}
 }
 
 func TestRegistry_LoadAndMember(t *testing.T) {
@@ -140,6 +163,27 @@ func TestRegistry_LoadRejectsInvalidPubkey(t *testing.T) {
 	}
 }
 
+func TestRegistry_LoadRejectsWrongIdentityLength(t *testing.T) {
+	r := cluster.New()
+	encoded := addresscodec.Base58CheckEncode(
+		identityBytes(0x01)[:addresscodec.NodePublicKeyLength-1],
+		addresscodec.NodePublicKeyPrefix,
+	)
+	if err := r.Load([]string{encoded}); err == nil {
+		t.Fatal("expected error for wrong-length node identity")
+	}
+}
+
+func TestRegistry_LoadRejectsInvalidKeyType(t *testing.T) {
+	r := cluster.New()
+	identity := identityBytes(0x01)
+	identity[0] = 0x01
+	encoded := addresscodec.Base58CheckEncode(identity, addresscodec.NodePublicKeyPrefix)
+	if err := r.Load([]string{encoded}); err == nil {
+		t.Fatal("expected error for invalid node public key type")
+	}
+}
+
 func TestRegistry_LoadDeduplicates(t *testing.T) {
 	r := cluster.New()
 	err := r.Load([]string{
@@ -191,6 +235,47 @@ func TestRegistry_UpdateReportTime(t *testing.T) {
 	}
 }
 
+func TestRegistry_IdentityBoundariesAndOwnership(t *testing.T) {
+	r := cluster.New()
+	for _, invalid := range [][]byte{
+		nil,
+		identityBytes(0x01)[:addresscodec.NodePublicKeyLength-1],
+		append(identityBytes(0x01), 0x01),
+		append([]byte{0x01}, identityBytes(0x01)[1:]...),
+	} {
+		if r.Update(invalid, "invalid", 1, time.Time{}) {
+			t.Fatalf("Update accepted %d-byte identity", len(invalid))
+		}
+		if _, ok := r.Member(invalid); ok {
+			t.Fatalf("Member accepted %d-byte identity", len(invalid))
+		}
+	}
+
+	id := mustDecode(t, pubA)
+	original := append([]byte(nil), id...)
+	if !r.Update(id, "node", 1, time.Time{}) {
+		t.Fatal("Update rejected valid identity")
+	}
+	id[0] ^= 0xff
+	member, ok := r.Member(original)
+	if !ok {
+		t.Fatal("mutating Update input changed the stored key")
+	}
+	member.Identity[0] ^= 0xff
+	again, ok := r.Member(original)
+	if !ok || !bytes.Equal(again.Identity[:], original) {
+		t.Fatal("mutating Member result changed registry-owned state")
+	}
+
+	r.ForEach(func(snapshot cluster.Member) {
+		snapshot.Identity[0] ^= 0xff
+	})
+	again, ok = r.Member(original)
+	if !ok || !bytes.Equal(again.Identity[:], original) {
+		t.Fatal("mutating ForEach snapshot changed registry-owned state")
+	}
+}
+
 func TestRegistry_ForEachIteratesAll(t *testing.T) {
 	r := cluster.New()
 	if err := r.Load([]string{pubA + " a", pubB + " b"}); err != nil {
@@ -210,12 +295,134 @@ func TestRegistry_ForEachIteratesAll(t *testing.T) {
 	}
 }
 
+func TestRegistry_ForEachDeterministicOrder(t *testing.T) {
+	r := cluster.New()
+	for _, fill := range []byte{0x03, 0x01, 0x02} {
+		if !r.Update(identityBytes(fill), "", 0, time.Time{}) {
+			t.Fatalf("Update(%x) failed", fill)
+		}
+	}
+	var got []byte
+	r.ForEach(func(member cluster.Member) {
+		got = append(got, member.Identity[1])
+	})
+	if !bytes.Equal(got, []byte{0x01, 0x02, 0x03}) {
+		t.Fatalf("ForEach order = %x; want 010203", got)
+	}
+}
+
+func TestRegistry_ForEachAllowsReentrantAccess(t *testing.T) {
+	r := cluster.New()
+	for _, fill := range []byte{0x01, 0x02} {
+		if !r.Update(identityBytes(fill), "", 0, time.Time{}) {
+			t.Fatalf("Update(%x) failed", fill)
+		}
+	}
+
+	callbackStarted := make(chan struct{})
+	releaseCallback := make(chan struct{})
+	type walkResult struct {
+		visited   []cluster.Identity
+		reentrant bool
+	}
+	walkDone := make(chan walkResult, 1)
+	go func() {
+		var visited []cluster.Identity
+		reentrant := true
+		r.ForEach(func(member cluster.Member) {
+			if len(visited) == 0 {
+				close(callbackStarted)
+				<-releaseCallback
+			}
+			if _, ok := r.Member(member.Identity[:]); !ok {
+				reentrant = false
+			}
+			if r.Size() == 0 {
+				reentrant = false
+			}
+			if !r.Update(member.Identity[:], "updated", 1, member.ReportTime.Add(time.Second)) {
+				reentrant = false
+			}
+			visited = append(visited, member.Identity)
+		})
+		walkDone <- walkResult{visited: visited, reentrant: reentrant}
+	}()
+	<-callbackStarted
+
+	writerDone := make(chan bool, 1)
+	go func() {
+		writerDone <- r.Update(identityBytes(0x03), "concurrent", 0, time.Time{})
+	}()
+	select {
+	case updated := <-writerDone:
+		if !updated {
+			t.Fatal("concurrent writer did not update the registry")
+		}
+	case <-time.After(2 * time.Second):
+		close(releaseCallback)
+		t.Fatal("concurrent writer blocked while ForEach callback was running")
+	}
+	close(releaseCallback)
+
+	var result walkResult
+	select {
+	case result = <-walkDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ForEach callback deadlocked on nested registry access")
+	}
+	if !result.reentrant {
+		t.Fatal("ForEach callback could not access the registry")
+	}
+	if len(result.visited) != 2 {
+		t.Fatalf("current snapshot visited %d members; want 2", len(result.visited))
+	}
+	if r.Size() != 3 {
+		t.Fatalf("registry Size = %d after concurrent update; want 3", r.Size())
+	}
+}
+
+func TestRegistry_ConcurrentSnapshotsDoNotAlias(t *testing.T) {
+	r := cluster.New()
+	id := mustDecode(t, pubA)
+	if !r.Update(id, "node", 0, time.Time{}) {
+		t.Fatal("initial Update failed")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 1; i <= 1_000; i++ {
+			r.Update(id, "", uint32(i), time.Unix(int64(i), 0))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 1_000 {
+			member, ok := r.Member(id)
+			if ok {
+				member.Identity[0] ^= 0xff
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 1_000 {
+			r.ForEach(func(member cluster.Member) {
+				member.Identity[0] ^= 0xff
+			})
+		}
+	}()
+	wg.Wait()
+	member, ok := r.Member(id)
+	if !ok || !bytes.Equal(member.Identity[:], id) {
+		t.Fatal("concurrent snapshot mutation corrupted registry identity")
+	}
+}
+
 func makeNodePub(t *testing.T, salt byte) string {
 	t.Helper()
-	raw := make([]byte, 33)
-	for i := range raw {
-		raw[i] = salt
-	}
+	raw := identityBytes(salt)
 	enc, err := addresscodec.EncodeNodePublicKey(raw)
 	if err != nil {
 		t.Fatalf("EncodeNodePublicKey: %v", err)
@@ -288,9 +495,7 @@ func TestRegistry_LoadConfigParity(t *testing.T) {
 		}
 	})
 
-	t.Run("malformed entry aborts load and rejects subsequent entries", func(t *testing.T) {
-		// cluster_test.cpp:248-258 — a bad entry must prevent every
-		// other entry, including subsequent ones, from being inserted.
+	t.Run("malformed first entry stops subsequent entries", func(t *testing.T) {
 		r := cluster.New()
 		err := r.Load([]string{
 			pubs[0] + "XXX",
@@ -303,6 +508,28 @@ func TestRegistry_LoadConfigParity(t *testing.T) {
 			id, _ := addresscodec.DecodeNodePublicKey(p)
 			if _, ok := r.Member(id); ok {
 				t.Fatalf("entry %d unexpectedly present after Load failed", i)
+			}
+		}
+	})
+
+	t.Run("valid entries before an error are retained", func(t *testing.T) {
+		r := cluster.New()
+		err := r.Load([]string{
+			pubs[0],
+			pubs[1] + "XXX",
+			pubs[2],
+		})
+		if err == nil {
+			t.Fatal("expected error from malformed second entry")
+		}
+		first, _ := addresscodec.DecodeNodePublicKey(pubs[0])
+		if _, ok := r.Member(first); !ok {
+			t.Fatal("valid entry before load error was not retained")
+		}
+		for _, pub := range pubs[1:3] {
+			id, _ := addresscodec.DecodeNodePublicKey(pub)
+			if _, ok := r.Member(id); ok {
+				t.Fatalf("entry %q unexpectedly present after load error", pub)
 			}
 		}
 	})

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -147,7 +147,10 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 	// Recompute the cluster-fee median and forward it through the
 	// LoadFeeTrack sink. An empty fresh set publishes zero.
 	if sink := o.clusterFeeSinkSnapshot(); sink != nil {
-		now := o.networkTime()
+		now := time.Now()
+		if o.clock != nil {
+			now = o.clock()
+		}
 		fee, _ := o.cluster.MedianFee(now.Add(-clusterFeeWindow))
 		sink(fee)
 	}

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -147,10 +147,7 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 	// Recompute the cluster-fee median and forward it through the
 	// LoadFeeTrack sink. An empty fresh set publishes zero.
 	if sink := o.clusterFeeSinkSnapshot(); sink != nil {
-		now := time.Now()
-		if o.clock != nil {
-			now = o.clock()
-		}
+		now := o.networkTime()
 		fee, _ := o.cluster.MedianFee(now.Add(-clusterFeeWindow))
 		sink(fee)
 	}

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -137,7 +137,10 @@ func (o *Overlay) handleClusterMessage(evt Event) {
 			// bad-data charge that rippled would not.
 			continue
 		}
-		reportTime := time.Unix(int64(node.ReportTime), 0)
+		var reportTime time.Time
+		if node.ReportTime != 0 {
+			reportTime = protocol.FromRippleTime(node.ReportTime)
+		}
 		o.cluster.Update(identity, node.NodeName, node.NodeLoad, reportTime)
 	}
 

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/cluster"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // TestHandleClusterMessage_DropsNonClusterPeer pins issue #497 audit
@@ -106,11 +107,11 @@ func TestHandleClusterMessage_FiresClusterFeeSink(t *testing.T) {
 	// Pre-register the other identity so the registry update accepts it.
 	require.NoError(t, clusterReg.Load([]string{otherPub + " other"}))
 
-	now := uint32(time.Now().Unix())
+	now := time.Now().UTC().Truncate(time.Second)
 	cm := &message.Cluster{
 		ClusterNodes: []message.ClusterNode{
-			{PublicKey: peerNodePubEncoded, NodeName: "peer", NodeLoad: 320, ReportTime: now},
-			{PublicKey: otherPub, NodeName: "other", NodeLoad: 400, ReportTime: now},
+			{PublicKey: peerNodePubEncoded, NodeName: "peer", NodeLoad: 320, ReportTime: protocol.ToRippleTime(now)},
+			{PublicKey: otherPub, NodeName: "other", NodeLoad: 400, ReportTime: protocol.ToRippleTime(now)},
 		},
 	}
 	payload, err := message.Encode(cm)
@@ -124,6 +125,9 @@ func TestHandleClusterMessage_FiresClusterFeeSink(t *testing.T) {
 
 	require.Len(t, sinkCalls, 1, "clusterFeeSink must fire exactly once per ingress")
 	assert.Equal(t, uint32(400), sinkCalls[0])
+	member, ok := clusterReg.Member(peerNodePub)
+	require.True(t, ok)
+	assert.Equal(t, now, member.ReportTime)
 }
 
 func TestHandleClusterMessage_ClearsStaleClusterFee(t *testing.T) {
@@ -192,7 +196,7 @@ func TestHandleClusterMessage_ClearsClusterFeeAfterReportAgesOut(t *testing.T) {
 	o.peers[peer.ID()] = peer
 
 	payload, err := message.Encode(&message.Cluster{ClusterNodes: []message.ClusterNode{
-		{PublicKey: peerNodePubEncoded, NodeName: "peer", NodeLoad: 512, ReportTime: uint32(now.Unix())},
+		{PublicKey: peerNodePubEncoded, NodeName: "peer", NodeLoad: 512, ReportTime: protocol.ToRippleTime(now)},
 	}})
 	require.NoError(t, err)
 	o.onMessageReceived(Event{PeerID: peer.ID(), MessageType: message.TypeCluster, Payload: payload})

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -183,13 +183,11 @@ func TestHandleClusterMessage_ClearsClusterFeeAfterReportAgesOut(t *testing.T) {
 		peers:   make(map[PeerID]*Peer),
 		events:  make(chan Event, 8),
 		cluster: clusterReg,
-		clock: func() time.Time {
-			return now
-		},
 		clusterFeeSink: func(fee uint32) {
 			clusterFee = fee
 		},
 	}
+	o.SetNetworkTimeProvider(func() time.Time { return now })
 
 	peer := NewPeer(PeerID(35), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
 	peer.remotePubKey = peerToken

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -183,11 +183,13 @@ func TestHandleClusterMessage_ClearsClusterFeeAfterReportAgesOut(t *testing.T) {
 		peers:   make(map[PeerID]*Peer),
 		events:  make(chan Event, 8),
 		cluster: clusterReg,
+		clock: func() time.Time {
+			return now
+		},
 		clusterFeeSink: func(fee uint32) {
 			clusterFee = fee
 		},
 	}
-	o.SetNetworkTimeProvider(func() time.Time { return now })
 
 	peer := NewPeer(PeerID(35), Endpoint{Host: "127.0.0.1", Port: 51235}, false, id, make(chan Event, 1))
 	peer.remotePubKey = peerToken

--- a/internal/peermanagement/outbound_emit.go
+++ b/internal/peermanagement/outbound_emit.go
@@ -126,7 +126,7 @@ func (o *Overlay) sendClusterUpdate() {
 				selfFee = fee
 			}
 		}
-		reportTime := protocol.FromRippleTime(protocol.ToRippleTime(o.networkTime()))
+		reportTime := protocol.FromRippleTime(protocol.ToRippleTime(time.Now()))
 		if !o.cluster.Update(o.localNodeIdentity, "", selfFee, reportTime) {
 			return
 		}

--- a/internal/peermanagement/outbound_emit.go
+++ b/internal/peermanagement/outbound_emit.go
@@ -30,6 +30,8 @@ import (
 // us within the first close-cycle they participate in.
 const clusterBroadcastInterval = 10 * time.Second
 
+const clusterLocalLoadMaxValidatedAge = 4 * time.Minute
+
 // txQueueBroadcastInterval drives the periodic tx-reduce-relay outbound
 // emission. Matches rippled's OverlayImpl::Timer::on_timer at 1s
 // (OverlayImpl.cpp:104-108).
@@ -114,12 +116,15 @@ func (o *Overlay) sendClusterUpdate() {
 	// NetworkOPs.cpp:1126-1139, where a stale reportTime returns
 	// false and the broadcast is skipped (with "Too soon to send
 	// cluster update" log). The self-entry's loadFee is sourced from
-	// localLoadFeeProvider (LoadFeeTrack.GetLocalFee); 0 when unwired,
-	// matching the pre-LoadFeeTrack behaviour.
+	// localLoadFeeProvider and forced to 0 when the validated ledger is
+	// older than four minutes, matching rippled's stale-ledger gate.
 	if len(o.localNodeIdentity) > 0 {
 		var selfFee uint32
 		if provider := o.localLoadFeeProviderSnapshot(); provider != nil {
-			selfFee = provider()
+			fee, validatedAge := provider()
+			if validatedAge <= clusterLocalLoadMaxValidatedAge {
+				selfFee = fee
+			}
 		}
 		reportTime := protocol.FromRippleTime(protocol.ToRippleTime(time.Now()))
 		if !o.cluster.Update(o.localNodeIdentity, "", selfFee, reportTime) {

--- a/internal/peermanagement/outbound_emit.go
+++ b/internal/peermanagement/outbound_emit.go
@@ -126,7 +126,7 @@ func (o *Overlay) sendClusterUpdate() {
 				selfFee = fee
 			}
 		}
-		reportTime := protocol.FromRippleTime(protocol.ToRippleTime(time.Now()))
+		reportTime := protocol.FromRippleTime(protocol.ToRippleTime(o.networkTime()))
 		if !o.cluster.Update(o.localNodeIdentity, "", selfFee, reportTime) {
 			return
 		}

--- a/internal/peermanagement/outbound_emit.go
+++ b/internal/peermanagement/outbound_emit.go
@@ -21,6 +21,7 @@ import (
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/cluster"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // clusterBroadcastInterval matches rippled's setClusterTimer cadence
@@ -120,7 +121,8 @@ func (o *Overlay) sendClusterUpdate() {
 		if provider := o.localLoadFeeProviderSnapshot(); provider != nil {
 			selfFee = provider()
 		}
-		if !o.cluster.Update(o.localNodeIdentity, "", selfFee, time.Now()) {
+		reportTime := protocol.FromRippleTime(protocol.ToRippleTime(time.Now()))
+		if !o.cluster.Update(o.localNodeIdentity, "", selfFee, reportTime) {
 			return
 		}
 	}
@@ -129,13 +131,13 @@ func (o *Overlay) sendClusterUpdate() {
 		ClusterNodes: make([]message.ClusterNode, 0, o.cluster.Size()),
 	}
 	o.cluster.ForEach(func(m cluster.Member) {
-		encoded, err := addresscodec.EncodeNodePublicKey(m.Identity)
+		encoded, err := addresscodec.EncodeNodePublicKey(m.Identity[:])
 		if err != nil {
 			return
 		}
 		clusterMsg.ClusterNodes = append(clusterMsg.ClusterNodes, message.ClusterNode{
 			PublicKey:  encoded,
-			ReportTime: uint32(m.ReportTime.Unix()),
+			ReportTime: protocol.ToRippleTime(m.ReportTime),
 			NodeLoad:   m.LoadFee,
 			NodeName:   m.Name,
 		})

--- a/internal/peermanagement/outbound_emit_test.go
+++ b/internal/peermanagement/outbound_emit_test.go
@@ -134,10 +134,6 @@ func TestSendClusterUpdate_GatesSelfLoadOnValidatedLedgerAge(t *testing.T) {
 			o.SetLocalLoadFeeProvider(func() (uint32, time.Duration) {
 				return 512, test.age
 			})
-			const reportTime = uint32(800_000_100)
-			o.SetNetworkTimeProvider(func() time.Time {
-				return protocol.FromRippleTime(reportTime)
-			})
 
 			peer := NewPeer(
 				PeerID(304),
@@ -164,7 +160,6 @@ func TestSendClusterUpdate_GatesSelfLoadOnValidatedLedgerAge(t *testing.T) {
 			for _, node := range cm.ClusterNodes {
 				if node.PublicKey == localPublic {
 					assert.Equal(t, test.want, node.NodeLoad)
-					assert.Equal(t, reportTime, node.ReportTime)
 					return
 				}
 			}

--- a/internal/peermanagement/outbound_emit_test.go
+++ b/internal/peermanagement/outbound_emit_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/cluster"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
@@ -98,6 +99,73 @@ func TestSendClusterUpdate_EmitsExportedConsumerGossip(t *testing.T) {
 		"load-source name must be the normalised inbound address (port stripped)")
 	assert.GreaterOrEqual(t, cm.LoadSources[0].Cost, uint32(resource.MinimumGossipBalance),
 		"exported cost must clear the gossip threshold")
+}
+
+func TestSendClusterUpdate_GatesSelfLoadOnValidatedLedgerAge(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		age  time.Duration
+		want uint32
+	}{
+		{name: "fresh boundary", age: 4 * time.Minute, want: 512},
+		{name: "stale", age: 4*time.Minute + time.Second, want: 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			localIdentity, err := NewIdentity()
+			require.NoError(t, err)
+			peerIdentity, err := NewIdentity()
+			require.NoError(t, err)
+			peerToken := NewPublicKeyTokenFromBtcec(peerIdentity.BtcecPublicKey())
+
+			clusterReg := cluster.New()
+			require.True(t, clusterReg.Update(
+				peerToken.Bytes(),
+				"peer",
+				0,
+				protocol.FromRippleTime(800_000_000),
+			))
+
+			o := &Overlay{
+				peers:             make(map[PeerID]*Peer),
+				events:            make(chan Event, 8),
+				cluster:           clusterReg,
+				localNodeIdentity: localIdentity.PublicKey(),
+			}
+			o.SetLocalLoadFeeProvider(func() (uint32, time.Duration) {
+				return 512, test.age
+			})
+
+			peer := NewPeer(
+				PeerID(304),
+				Endpoint{Host: "127.0.0.1", Port: 51235},
+				false,
+				localIdentity,
+				make(chan Event, 1),
+			)
+			peer.remotePubKey = peerToken
+			peer.setState(PeerStateConnected)
+			o.peers[peer.ID()] = peer
+
+			o.sendClusterUpdate()
+			frame := requireOutboundFrame(t, peer)
+			_, payload, err := message.ReadMessage(bytes.NewReader(frame))
+			require.NoError(t, err)
+			decoded, err := message.Decode(message.TypeCluster, payload)
+			require.NoError(t, err)
+			cm, ok := decoded.(*message.Cluster)
+			require.True(t, ok)
+
+			localPublic, err := addresscodec.EncodeNodePublicKey(localIdentity.PublicKey())
+			require.NoError(t, err)
+			for _, node := range cm.ClusterNodes {
+				if node.PublicKey == localPublic {
+					assert.Equal(t, test.want, node.NodeLoad)
+					return
+				}
+			}
+			t.Fatalf("local cluster entry %q not found", localPublic)
+		})
+	}
 }
 
 // TestSendTxQueueAnnounce_FeatureDisabled_NoEmit pins the

--- a/internal/peermanagement/outbound_emit_test.go
+++ b/internal/peermanagement/outbound_emit_test.go
@@ -134,6 +134,10 @@ func TestSendClusterUpdate_GatesSelfLoadOnValidatedLedgerAge(t *testing.T) {
 			o.SetLocalLoadFeeProvider(func() (uint32, time.Duration) {
 				return 512, test.age
 			})
+			const reportTime = uint32(800_000_100)
+			o.SetNetworkTimeProvider(func() time.Time {
+				return protocol.FromRippleTime(reportTime)
+			})
 
 			peer := NewPeer(
 				PeerID(304),
@@ -160,6 +164,7 @@ func TestSendClusterUpdate_GatesSelfLoadOnValidatedLedgerAge(t *testing.T) {
 			for _, node := range cm.ClusterNodes {
 				if node.PublicKey == localPublic {
 					assert.Equal(t, test.want, node.NodeLoad)
+					assert.Equal(t, reportTime, node.ReportTime)
 					return
 				}
 			}

--- a/internal/peermanagement/outbound_emit_test.go
+++ b/internal/peermanagement/outbound_emit_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/cluster"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
+	"github.com/LeJamon/go-xrpl/protocol"
 )
 
 // TestSendClusterUpdate_NoClusterConfigured_NoOp pins the
@@ -56,7 +57,8 @@ func TestSendClusterUpdate_EmitsExportedConsumerGossip(t *testing.T) {
 	// Register the receiving peer as a cluster member so it both appears
 	// in the broadcast registry and is selected as a send target.
 	clusterReg := cluster.New()
-	require.True(t, clusterReg.Update(peerToken.Bytes(), "peer", 0, time.Now()))
+	reportTime := protocol.FromRippleTime(800_000_000)
+	require.True(t, clusterReg.Update(peerToken.Bytes(), "peer", 0, reportTime))
 
 	// Seed the resource manager with an inbound consumer whose balance
 	// clears the gossip-export threshold.
@@ -88,6 +90,8 @@ func TestSendClusterUpdate_EmitsExportedConsumerGossip(t *testing.T) {
 	require.NoError(t, err)
 	cm, ok := decoded.(*message.Cluster)
 	require.True(t, ok)
+	require.Len(t, cm.ClusterNodes, 1)
+	assert.Equal(t, protocol.ToRippleTime(reportTime), cm.ClusterNodes[0].ReportTime)
 
 	require.Len(t, cm.LoadSources, 1, "exported consumer must appear as a load source")
 	assert.Equal(t, "203.0.113.7", cm.LoadSources[0].Name,

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -205,6 +205,10 @@ type Overlay struct {
 	// when unwired. Guarded by providersMu.
 	localLoadFeeProvider func() (uint32, time.Duration)
 
+	// networkTimeProvider returns the consensus-adjusted network time used by
+	// cluster report freshness and timestamps. Guarded by providersMu.
+	networkTimeProvider func() time.Time
+
 	// localNodeIdentity is the raw 33-byte compressed NodePublic of
 	// THIS node. Used by the cluster timer to insert ourselves into
 	// the gossip frame so peers can correlate validator load. Set in New

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -199,12 +199,11 @@ type Overlay struct {
 	// Guarded by providersMu.
 	clusterFeeSink func(fee uint32)
 
-	// localLoadFeeProvider returns the local node's current load fee
-	// factor (LoadFeeTrack.getLocalFee). Wired into sendClusterUpdate
-	// so the self-entry in each outbound TMCluster gossip advertises
-	// real load instead of 0. nil-safe — sendClusterUpdate falls back
-	// to 0 when unwired. Guarded by providersMu.
-	localLoadFeeProvider func() uint32
+	// localLoadFeeProvider returns the local node's current load fee and
+	// validated-ledger age. Wired into sendClusterUpdate so stale nodes
+	// advertise zero load. nil-safe — sendClusterUpdate falls back to 0
+	// when unwired. Guarded by providersMu.
+	localLoadFeeProvider func() (uint32, time.Duration)
 
 	// localNodeIdentity is the raw 33-byte compressed NodePublic of
 	// THIS node. Used by the cluster timer to insert ourselves into

--- a/internal/peermanagement/overlay.go
+++ b/internal/peermanagement/overlay.go
@@ -205,10 +205,6 @@ type Overlay struct {
 	// when unwired. Guarded by providersMu.
 	localLoadFeeProvider func() (uint32, time.Duration)
 
-	// networkTimeProvider returns the consensus-adjusted network time used by
-	// cluster report freshness and timestamps. Guarded by providersMu.
-	networkTimeProvider func() time.Time
-
 	// localNodeIdentity is the raw 33-byte compressed NodePublic of
 	// THIS node. Used by the cluster timer to insert ourselves into
 	// the gossip frame so peers can correlate validator load. Set in New

--- a/internal/peermanagement/overlay_callbacks_test.go
+++ b/internal/peermanagement/overlay_callbacks_test.go
@@ -135,7 +135,6 @@ func TestClusterFeeProviderSettersConcurrentAccess(t *testing.T) {
 		for range iterations {
 			o.SetClusterFeeSink(func(uint32) {})
 			o.SetLocalLoadFeeProvider(func() (uint32, time.Duration) { return 0, 0 })
-			o.SetNetworkTimeProvider(time.Now)
 		}
 	}()
 
@@ -148,7 +147,6 @@ func TestClusterFeeProviderSettersConcurrentAccess(t *testing.T) {
 			if p := o.localLoadFeeProviderSnapshot(); p != nil {
 				p()
 			}
-			o.networkTime()
 		}
 	}()
 

--- a/internal/peermanagement/overlay_callbacks_test.go
+++ b/internal/peermanagement/overlay_callbacks_test.go
@@ -135,6 +135,7 @@ func TestClusterFeeProviderSettersConcurrentAccess(t *testing.T) {
 		for range iterations {
 			o.SetClusterFeeSink(func(uint32) {})
 			o.SetLocalLoadFeeProvider(func() (uint32, time.Duration) { return 0, 0 })
+			o.SetNetworkTimeProvider(time.Now)
 		}
 	}()
 
@@ -147,6 +148,7 @@ func TestClusterFeeProviderSettersConcurrentAccess(t *testing.T) {
 			if p := o.localLoadFeeProviderSnapshot(); p != nil {
 				p()
 			}
+			o.networkTime()
 		}
 	}()
 

--- a/internal/peermanagement/overlay_callbacks_test.go
+++ b/internal/peermanagement/overlay_callbacks_test.go
@@ -3,6 +3,7 @@ package peermanagement
 import (
 	"sync"
 	"testing"
+	"time"
 )
 
 // TestPeerLifecycleCallbacksConcurrentAccess guards the providersMu
@@ -133,7 +134,7 @@ func TestClusterFeeProviderSettersConcurrentAccess(t *testing.T) {
 		defer wg.Done()
 		for range iterations {
 			o.SetClusterFeeSink(func(uint32) {})
-			o.SetLocalLoadFeeProvider(func() uint32 { return 0 })
+			o.SetLocalLoadFeeProvider(func() (uint32, time.Duration) { return 0, 0 })
 		}
 	}()
 

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -462,6 +462,27 @@ func (o *Overlay) localLoadFeeProviderSnapshot() func() (uint32, time.Duration) 
 	return o.localLoadFeeProvider
 }
 
+// SetNetworkTimeProvider installs the consensus-adjusted clock used for
+// protocol timestamps and freshness checks in cluster gossip.
+func (o *Overlay) SetNetworkTimeProvider(fn func() time.Time) {
+	o.providersMu.Lock()
+	o.networkTimeProvider = fn
+	o.providersMu.Unlock()
+}
+
+func (o *Overlay) networkTime() time.Time {
+	o.providersMu.RLock()
+	provider := o.networkTimeProvider
+	o.providersMu.RUnlock()
+	if provider != nil {
+		return provider()
+	}
+	if o.clock != nil {
+		return o.clock()
+	}
+	return time.Now()
+}
+
 // clusterFeeWindow is the freshness threshold for cluster-fee median
 // inclusion — entries reporting older than this are dropped before the
 // median is taken.

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -462,27 +462,6 @@ func (o *Overlay) localLoadFeeProviderSnapshot() func() (uint32, time.Duration) 
 	return o.localLoadFeeProvider
 }
 
-// SetNetworkTimeProvider installs the consensus-adjusted clock used for
-// protocol timestamps and freshness checks in cluster gossip.
-func (o *Overlay) SetNetworkTimeProvider(fn func() time.Time) {
-	o.providersMu.Lock()
-	o.networkTimeProvider = fn
-	o.providersMu.Unlock()
-}
-
-func (o *Overlay) networkTime() time.Time {
-	o.providersMu.RLock()
-	provider := o.networkTimeProvider
-	o.providersMu.RUnlock()
-	if provider != nil {
-		return provider()
-	}
-	if o.clock != nil {
-		return o.clock()
-	}
-	return time.Now()
-}
-
 // clusterFeeWindow is the freshness threshold for cluster-fee median
 // inclusion — entries reporting older than this are dropped before the
 // median is taken.

--- a/internal/peermanagement/overlay_peers.go
+++ b/internal/peermanagement/overlay_peers.go
@@ -445,18 +445,18 @@ func (o *Overlay) clusterFeeSinkSnapshot() func(fee uint32) {
 	return o.clusterFeeSink
 }
 
-// SetLocalLoadFeeProvider installs the reader that supplies our own
-// LoadFee for the outbound TMCluster gossip self-entry. nil-safe —
-// sendClusterUpdate falls back to 0 when unwired. Guarded by providersMu:
-// read concurrently by the maintenance loop's sendClusterUpdate while the
-// server wires it after Run has launched.
-func (o *Overlay) SetLocalLoadFeeProvider(fn func() uint32) {
+// SetLocalLoadFeeProvider installs the reader that supplies our own LoadFee
+// and validated-ledger age for the outbound TMCluster gossip self-entry.
+// nil-safe — sendClusterUpdate falls back to 0 when unwired. Guarded by
+// providersMu: read concurrently by the maintenance loop's sendClusterUpdate
+// while the server wires it after Run has launched.
+func (o *Overlay) SetLocalLoadFeeProvider(fn func() (uint32, time.Duration)) {
 	o.providersMu.Lock()
 	o.localLoadFeeProvider = fn
 	o.providersMu.Unlock()
 }
 
-func (o *Overlay) localLoadFeeProviderSnapshot() func() uint32 {
+func (o *Overlay) localLoadFeeProviderSnapshot() func() (uint32, time.Duration) {
 	o.providersMu.RLock()
 	defer o.providersMu.RUnlock()
 	return o.localLoadFeeProvider

--- a/internal/peermanagement/overlay_rpc.go
+++ b/internal/peermanagement/overlay_rpc.go
@@ -143,10 +143,10 @@ func (o *Overlay) ClusterJSON() map[string]any {
 	now := o.cfg.Clock()
 
 	o.cluster.ForEach(func(m cluster.Member) {
-		if len(selfKey) > 0 && bytes.Equal(selfKey, m.Identity) {
+		if len(selfKey) > 0 && bytes.Equal(selfKey, m.Identity[:]) {
 			return
 		}
-		encoded, err := addresscodec.EncodeNodePublicKey(m.Identity)
+		encoded, err := addresscodec.EncodeNodePublicKey(m.Identity[:])
 		if err != nil || encoded == "" {
 			return
 		}


### PR DESCRIPTION
## Summary
- store validated NodePublic identities as fixed-size values so registry members and snapshots cannot alias mutable caller bytes
- invoke deterministic `ForEach` callbacks after releasing the registry lock, with consistent nil/zero-value behavior and rippled-compatible load semantics
- encode cluster report times with XRPL network time and preserve the zero/unreported sentinel

## Test plan
- [x] `go test -count=20 -cover ./internal/peermanagement/cluster`
- [x] `go test -race -count=10 ./internal/peermanagement/cluster`
- [x] `go test -race -count=2 ./internal/peermanagement/... ./internal/consensus/adaptor`
- [x] `just vet`
- [x] `just lint`
- [x] `just build-all`

Fixes #1473


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster member identity validation and handling of invalid keys.
  * Preserved cluster report timestamps accurately, including zero timestamps.
  * Improved loading behavior so valid entries remain available when later data is invalid.
  * Prevented stale ledger information from being reported as current load data.
* **Reliability**
  * Made member iteration deterministic and safe during concurrent or reentrant updates.
  * Added safer behavior for empty registries, nil receivers, and concurrent access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->