### PR TITLE
fix: secure admin RPC transports

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -229,6 +229,9 @@ ports = ["port_test"]
 admin = ["127.0.0.1"]
 admin_user = "common-user"
 admin_password = "common-password"
+user = "operator"
+password = "transport-password"
+allowed_origins = ["https://console.example"]
 secure_gateway = ["10.0.0.0/8"]
 
 [port_test]
@@ -250,6 +253,9 @@ path = "/tmp/test/db"
 	assert.Equal(t, []string{"127.0.0.1", "::1"}, port.Admin)
 	assert.Equal(t, "common-user", port.AdminUser)
 	assert.Equal(t, "port-password", port.AdminPassword)
+	assert.Equal(t, "operator", port.User)
+	assert.Equal(t, "transport-password", port.Password)
+	assert.Equal(t, []string{"https://console.example"}, port.AllowedOrigins)
 	assert.Equal(t, []string{"10.0.0.0/8", "192.168.0.0/16"}, port.SecureGateway)
 }
 

--- a/config/examples/xrpld.toml
+++ b/config/examples/xrpld.toml
@@ -82,6 +82,8 @@ ports = ["port_rpc_admin_local", "port_rpc_public", "port_peer", "port_ws_admin_
 # Optional fields:
 #   - limit             → max concurrent connections (0 = unlimited)
 #   - send_queue_limit  → WS send buffer per connection (default 100)
+#   - user/password     → HTTP Basic Auth, required together when set
+#   - allowed_origins   → exact http(s) browser origins; omitted denies browser origins
 # =============================================================================
 
 # --- Admin ports (localhost only) ---
@@ -91,6 +93,11 @@ port = 5005
 ip = "127.0.0.1"
 admin = ["127.0.0.1"]
 protocol = "http"
+# To expose this admin port to a browser, configure both an exact origin and
+# Basic Auth credentials. CLI requests without an Origin header remain allowed.
+# allowed_origins = ["https://admin.example"]
+# user = "operator"
+# password = "replace-with-a-secret"
 
 [port_ws_admin_local]
 port = 6006

--- a/config/loader.go
+++ b/config/loader.go
@@ -264,4 +264,7 @@ func applyServerDefaults(portViper *viper.Viper, serverDefaults ServerConfig) {
 	if serverDefaults.AdminPassword != "" {
 		portViper.SetDefault("admin_password", serverDefaults.AdminPassword)
 	}
+	if len(serverDefaults.AllowedOrigins) > 0 {
+		portViper.SetDefault("allowed_origins", serverDefaults.AllowedOrigins)
+	}
 }

--- a/config/origin.go
+++ b/config/origin.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// NormalizeOrigins validates and canonicalizes HTTP(S) origin values. Origins
+// are compared as scheme plus host (including an explicit port); paths,
+// credentials, queries, fragments, wildcards, and opaque URLs are rejected.
+func NormalizeOrigins(origins []string) ([]string, error) {
+	if len(origins) == 0 {
+		return nil, nil
+	}
+
+	normalized := make([]string, 0, len(origins))
+	seen := make(map[string]struct{}, len(origins))
+	for _, raw := range origins {
+		origin := strings.TrimSpace(raw)
+		if origin == "" {
+			return nil, fmt.Errorf("allowed_origins contains an empty origin")
+		}
+		canonical, err := CanonicalOrigin(origin)
+		if err != nil {
+			return nil, fmt.Errorf("allowed_origins entry %q: %w", raw, err)
+		}
+		if _, ok := seen[canonical]; ok {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		normalized = append(normalized, canonical)
+	}
+	return normalized, nil
+}
+
+// CanonicalOrigin validates one HTTP(S) origin and returns its canonical
+// scheme://host[:port] form for exact comparisons.
+func CanonicalOrigin(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL: %w", err)
+	}
+	if !strings.EqualFold(u.Scheme, "http") && !strings.EqualFold(u.Scheme, "https") {
+		return "", fmt.Errorf("origin scheme must be http or https")
+	}
+	if u.Opaque != "" || u.User != nil || u.Host == "" || u.Path != "" || u.RawPath != "" || u.RawQuery != "" || u.Fragment != "" || u.ForceQuery || strings.ContainsAny(raw, "?#") {
+		return "", fmt.Errorf("origin must contain only scheme and host[:port]")
+	}
+	if strings.TrimSpace(u.Host) != u.Host || u.Hostname() == "" {
+		return "", fmt.Errorf("origin host is invalid")
+	}
+	if strings.HasSuffix(u.Host, ":") {
+		return "", fmt.Errorf("origin host is invalid")
+	}
+	if strings.HasPrefix(u.Host, "[") {
+		closeBracket := strings.IndexByte(u.Host, ']')
+		if closeBracket < 0 || (len(u.Host) > closeBracket+1 && (u.Host[closeBracket+1] != ':' || strings.Count(u.Host[closeBracket+1:], ":") > 1)) {
+			return "", fmt.Errorf("origin host is invalid")
+		}
+	} else if strings.Count(u.Host, ":") > 1 {
+		return "", fmt.Errorf("origin host is invalid")
+	}
+	if port := u.Port(); port != "" {
+		value, err := strconv.Atoi(port)
+		if err != nil || value < 1 || value > 65535 {
+			return "", fmt.Errorf("origin port is invalid")
+		}
+	}
+	if _, err := url.ParseRequestURI(raw); err != nil {
+		return "", fmt.Errorf("origin is invalid: %w", err)
+	}
+	return strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host), nil
+}

--- a/config/origin_test.go
+++ b/config/origin_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeOriginsRequiresExactHTTPOrigin(t *testing.T) {
+	valid, err := NormalizeOrigins([]string{"HTTPS://Example.COM:8443", "https://example.com:8443"})
+	if err != nil {
+		t.Fatalf("NormalizeOrigins returned error: %v", err)
+	}
+	if got, want := strings.Join(valid, ","), "https://example.com:8443"; got != want {
+		t.Fatalf("normalized origins = %q, want %q", got, want)
+	}
+
+	for _, origin := range []string{
+		"*",
+		"https://example.com/",
+		"https://user:pass@example.com",
+		"https://example.com/path",
+		"https://example.com?query=1",
+		"https://example.com?",
+		"https://example.com#",
+		"https://example.com:bad",
+		"https://example.com:",
+		"https://example.com:443:444",
+		"https://example.com:99999",
+		"ftp://example.com",
+		"https://",
+	} {
+		t.Run(origin, func(t *testing.T) {
+			if _, err := NormalizeOrigins([]string{origin}); err == nil {
+				t.Fatalf("NormalizeOrigins(%q) unexpectedly succeeded", origin)
+			}
+		})
+	}
+}
+
+func TestPortValidateRejectsPartialBasicAuth(t *testing.T) {
+	p := &PortConfig{Port: 5005, IP: "127.0.0.1", Protocol: "http", User: "operator"}
+	if err := p.Validate(); err == nil || !strings.Contains(err.Error(), "user and password") {
+		t.Fatalf("Validate error = %v, want partial Basic Auth rejection", err)
+	}
+}
+
+func TestValidatePortsRejectsCredentiallessBrowserAdmin(t *testing.T) {
+	ports := map[string]PortConfig{
+		"admin": {
+			Port:           5005,
+			IP:             "127.0.0.1",
+			Protocol:       "http",
+			Admin:          []string{"127.0.0.1"},
+			AllowedOrigins: []string{"https://admin.example"},
+		},
+	}
+	errs := validatePorts(ports)
+	if len(errs) == 0 || !strings.Contains(errs[0].Error(), "browser listener requires both user and password") {
+		t.Fatalf("validatePorts errors = %v, want credentialed browser-admin rejection", errs)
+	}
+}
+
+func TestValidateConfigRejectsInvalidServerOrigin(t *testing.T) {
+	cfg := validCompleteConfig()
+	cfg.Server.AllowedOrigins = []string{"*"}
+
+	err := ValidateConfig(cfg)
+	if err == nil || !strings.Contains(err.Error(), "server allowed_origins") {
+		t.Fatalf("ValidateConfig error = %v, want invalid server allowed_origins", err)
+	}
+}

--- a/config/server.go
+++ b/config/server.go
@@ -10,17 +10,18 @@ import (
 // ServerConfig represents the [server] section
 // This defines the ports that the server will listen on and default values
 type ServerConfig struct {
-	Ports         []string `toml:"ports" mapstructure:"ports"`       // List of port names to enable
-	Port          int      `toml:"port" mapstructure:"port"`         // Default port number
-	IP            string   `toml:"ip" mapstructure:"ip"`             // Default IP address
-	Protocol      string   `toml:"protocol" mapstructure:"protocol"` // Default protocol
-	Limit         int      `toml:"limit" mapstructure:"limit"`       // Default connection limit
-	User          string   `toml:"user" mapstructure:"user"`         // Default HTTP basic auth user
-	Password      string   `toml:"password" mapstructure:"password"` // Default HTTP basic auth password
-	Admin         []string `toml:"admin" mapstructure:"admin"`       // Default administrative networks
-	AdminUser     string   `toml:"admin_user" mapstructure:"admin_user"`
-	AdminPassword string   `toml:"admin_password" mapstructure:"admin_password"`
-	SecureGateway []string `toml:"secure_gateway" mapstructure:"secure_gateway"` // Default trusted proxy networks
+	Ports          []string `toml:"ports" mapstructure:"ports"`       // List of port names to enable
+	Port           int      `toml:"port" mapstructure:"port"`         // Default port number
+	IP             string   `toml:"ip" mapstructure:"ip"`             // Default IP address
+	Protocol       string   `toml:"protocol" mapstructure:"protocol"` // Default protocol
+	Limit          int      `toml:"limit" mapstructure:"limit"`       // Default connection limit
+	User           string   `toml:"user" mapstructure:"user"`         // Default HTTP basic auth user
+	Password       string   `toml:"password" mapstructure:"password"` // Default HTTP basic auth password
+	Admin          []string `toml:"admin" mapstructure:"admin"`       // Default administrative networks
+	AdminUser      string   `toml:"admin_user" mapstructure:"admin_user"`
+	AdminPassword  string   `toml:"admin_password" mapstructure:"admin_password"`
+	AllowedOrigins []string `toml:"allowed_origins" mapstructure:"allowed_origins"` // Exact browser origins allowed on HTTP/WS ports
+	SecureGateway  []string `toml:"secure_gateway" mapstructure:"secure_gateway"`   // Default trusted proxy networks
 	// MaxConnections is the process-wide ceiling on concurrent HTTP + WebSocket
 	// connections. 0 keeps the bounded built-in default; a negative value
 	// disables the global cap (per-port limits still apply).
@@ -41,9 +42,10 @@ type PortConfig struct {
 	Password string `toml:"password" mapstructure:"password"`
 
 	// Administrative access control
-	Admin         []string `toml:"admin" mapstructure:"admin"`
-	AdminUser     string   `toml:"admin_user" mapstructure:"admin_user"`
-	AdminPassword string   `toml:"admin_password" mapstructure:"admin_password"`
+	Admin          []string `toml:"admin" mapstructure:"admin"`
+	AdminUser      string   `toml:"admin_user" mapstructure:"admin_user"`
+	AdminPassword  string   `toml:"admin_password" mapstructure:"admin_password"`
+	AllowedOrigins []string `toml:"allowed_origins" mapstructure:"allowed_origins"`
 
 	// Secure gateway (for proxies)
 	SecureGateway []string `toml:"secure_gateway" mapstructure:"secure_gateway"`
@@ -103,6 +105,14 @@ func (p *PortConfig) Validate() error {
 	if p.Protocol == "" {
 		return errors.New("protocol is required")
 	}
+	if (p.User == "") != (p.Password == "") {
+		return errors.New("user and password must be configured together")
+	}
+	origins, err := NormalizeOrigins(p.AllowedOrigins)
+	if err != nil {
+		return err
+	}
+	p.AllowedOrigins = origins
 
 	// Validate protocol combinations
 	if err := p.validateProtocols(); err != nil {

--- a/config/validation.go
+++ b/config/validation.go
@@ -23,6 +23,12 @@ func ValidateConfig(config *Config) error {
 	}
 
 	// 2. Validate port configurations (if ports exist)
+	if (config.Server.User == "") != (config.Server.Password == "") {
+		errs = append(errs, errors.New("server user and password must be configured together"))
+	}
+	if _, err := NormalizeOrigins(config.Server.AllowedOrigins); err != nil {
+		errs = append(errs, fmt.Errorf("server allowed_origins: %w", err))
+	}
 	if len(config.Ports) > 0 {
 		errs = append(errs, validatePorts(config.Ports)...)
 	}
@@ -132,6 +138,10 @@ func validatePorts(ports map[string]PortConfig) []error {
 	for portName, portConfig := range ports {
 		if err := portConfig.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("port %s: %w", portName, err))
+		}
+		if (len(portConfig.Admin) > 0 || portConfig.AdminUser != "" || portConfig.AdminPassword != "") &&
+			len(portConfig.AllowedOrigins) > 0 && (portConfig.User == "" || portConfig.Password == "") {
+			errs = append(errs, fmt.Errorf("port %s: admin-capable browser listener requires both user and password", portName))
 		}
 
 		portKey := fmt.Sprintf("%s:%d", portConfig.IP, portConfig.Port)

--- a/docs/operating.md
+++ b/docs/operating.md
@@ -149,6 +149,11 @@ loopback requests also receive admin role; other clients receive **guest** role.
 Always set `secure_gateway` on a same-host public proxy backend so loopback does
 not trigger that admin fallback.
 
+The JSON-RPC handler accepts POST requests only. `GET /health` remains available
+as the liveness endpoint, but it is still subject to the configured per-port
+Origin and HTTP Basic Auth policy. Arbitrary GET query parameters are never
+dispatched as RPC commands.
+
 `server_info` and `server_state` omit rippled's optional job-queue `load`,
 requested `counters`, and `current_activities` fields. go-xrpl does not yet have
 equivalent job/performance instrumentation, so these fields remain unsupported
@@ -240,7 +245,12 @@ keys to precede any `[section]` header.
 `[port_<name>]` requires `port`, `ip`, and `protocol` (`http`, `ws`, `peer`, or
 `grpc`); optional `limit` caps concurrent connections (`0` = unlimited) and
 `send_queue_limit` sizes the per-connection WebSocket send buffer (default 100).
-List IPs in `admin` to grant those clients admin role.
+List IPs in `admin` to grant those clients admin role. `user` and `password`
+enable HTTP Basic Auth and must be configured together. `allowed_origins` is an
+exact list of HTTP(S) origins shared by HTTP CORS and WebSocket upgrades; an
+empty list rejects browser-originated requests while clients without an Origin
+header (including the CLI) remain usable. An admin-capable port that enables a
+browser origin must also configure Basic Auth.
 
 ### `[node_db]` — content-addressed state store
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"runtime/debug"
 	"sort"
@@ -465,11 +466,18 @@ func parsePortConfig(protocol, name string, p config.PortConfig) (*rpc.PortConte
 	if err != nil {
 		return nil, fmt.Errorf("parse secure_gateway nets for %s port %q: %w", protocol, name, err)
 	}
+	allowedOrigins, err := config.NormalizeOrigins(p.AllowedOrigins)
+	if err != nil {
+		return nil, fmt.Errorf("parse allowed_origins for %s port %q: %w", protocol, name, err)
+	}
 	return &rpc.PortContext{
 		PortName:          name,
-		AdminNets:         adminNets,
+		AdminNets:         append([]net.IPNet(nil), adminNets...),
 		AdminUser:         p.AdminUser,
 		AdminPassword:     p.AdminPassword,
+		User:              p.User,
+		Password:          p.Password,
+		AllowedOrigins:    append([]string(nil), allowedOrigins...),
 		SecureGatewayNets: secureGW,
 		Limit:             p.Limit,
 		SendQueue:         p.SendQueueLimit,

--- a/internal/node/port_context_test.go
+++ b/internal/node/port_context_test.go
@@ -9,12 +9,18 @@ import (
 
 func TestParsePortConfigCarriesAdminCredentials(t *testing.T) {
 	pc, err := parsePortConfig("http", "admin", config.PortConfig{
-		Admin:         []string{"127.0.0.0/8"},
-		AdminUser:     "root",
-		AdminPassword: "secret",
+		Admin:          []string{"127.0.0.0/8"},
+		AdminUser:      "root",
+		AdminPassword:  "secret",
+		User:           "operator",
+		Password:       "transport-secret",
+		AllowedOrigins: []string{"https://console.example"},
 	})
 	require.NoError(t, err)
 	require.Equal(t, "root", pc.AdminUser)
 	require.Equal(t, "secret", pc.AdminPassword)
+	require.Equal(t, "operator", pc.User)
+	require.Equal(t, "transport-secret", pc.Password)
+	require.Equal(t, []string{"https://console.example"}, pc.AllowedOrigins)
 	require.Len(t, pc.AdminNets, 1)
 }

--- a/internal/node/transports_test.go
+++ b/internal/node/transports_test.go
@@ -147,6 +147,57 @@ func TestBoundRPCTransportsDoNotServeBeforeCommit(t *testing.T) {
 	bound.wait()
 }
 
+func TestBoundRPCTransportsHealthUsesTransportBasicAuth(t *testing.T) {
+	bound, err := bindRPCTransports(
+		context.Background(),
+		xrpllog.Discard(),
+		&config.Config{Ports: map[string]config.PortConfig{
+			"http": {
+				IP:       "127.0.0.1",
+				Port:     0,
+				Protocol: "http",
+				User:     "operator",
+				Password: "transport-secret",
+			},
+		}},
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		rpc.NewWebSocketServer(time.Second, nil),
+		nil,
+		systemListen,
+	)
+	require.NoError(t, err)
+	require.NoError(t, bound.serve(xrpllog.Discard()))
+	defer func() {
+		_ = bound.http[0].server.Shutdown(context.Background())
+		_ = bound.closeListeners()
+		bound.wait()
+	}()
+
+	healthURL := "http://" + bound.http[0].address + "/health"
+	for _, test := range []struct {
+		name     string
+		user     string
+		password string
+		want     int
+	}{
+		{name: "correct credentials", user: "operator", password: "transport-secret", want: http.StatusOK},
+		{name: "missing credentials", want: http.StatusUnauthorized},
+		{name: "incorrect credentials", user: "operator", password: "wrong", want: http.StatusUnauthorized},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req, requestErr := http.NewRequest(http.MethodGet, healthURL, nil)
+			require.NoError(t, requestErr)
+			if test.user != "" || test.password != "" {
+				req.SetBasicAuth(test.user, test.password)
+			}
+			response, doErr := http.DefaultClient.Do(req)
+			require.NoError(t, doErr)
+			defer response.Body.Close()
+			require.Equal(t, test.want, response.StatusCode)
+		})
+	}
+}
+
 func TestBoundRPCTransportsServeAndJoinAllProtocols(t *testing.T) {
 	cfg := &config.Config{Ports: map[string]config.PortConfig{
 		"http": {IP: "127.0.0.1", Port: 0, Protocol: "http"},

--- a/internal/rpc/admin_transport_test.go
+++ b/internal/rpc/admin_transport_test.go
@@ -1,0 +1,205 @@
+package rpc
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+func transportTestPort() *PortContext {
+	return &PortContext{
+		PortName:       "admin",
+		User:           "operator",
+		Password:       "secret",
+		AllowedOrigins: []string{"https://console.example"},
+	}
+}
+
+func transportTestServer(t *testing.T, calls *atomic.Int32) *Server {
+	t.Helper()
+	srv := NewServer(time.Second, types.NewServiceContainer(nil))
+	srv.registry.Register("stop", &stubHandler{
+		role: types.RoleGuest,
+		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
+			calls.Add(1)
+			return map[string]any{"stopped": true}, nil
+		},
+	})
+	return srv
+}
+
+func transportRequest(origin, user, password string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"method":"stop","params":[{}]}`))
+	req.RemoteAddr = "203.0.113.9:1234"
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+	if user != "" || password != "" {
+		req.SetBasicAuth(user, password)
+	}
+	return req
+}
+
+func TestHTTPTransportOriginAndBasicAuth(t *testing.T) {
+	var calls atomic.Int32
+	srv := transportTestServer(t, &calls)
+	limiter := NewConnLimiter()
+	limiter.SetGlobalLimit(1)
+	handler := PortMiddleware(transportTestPort(), limiter, srv)
+
+	t.Run("allowed browser preflight does not need credentials", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/", nil)
+		req.Header.Set("Origin", "https://console.example")
+		req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+		require.Equal(t, "https://console.example", rr.Header().Get("Access-Control-Allow-Origin"))
+		require.Equal(t, int32(0), calls.Load())
+	})
+
+	t.Run("GET never dispatches an RPC command", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/?command=stop", nil)
+		req.RemoteAddr = "203.0.113.9:1234"
+		req.SetBasicAuth("operator", "secret")
+		req.Header.Set("Origin", "https://console.example")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+		require.Equal(t, int32(0), calls.Load())
+	})
+
+	t.Run("rejected origin cannot reach stop", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, transportRequest("https://attacker.example", "operator", "secret"))
+		require.Equal(t, http.StatusForbidden, rr.Code)
+		require.Equal(t, int32(0), calls.Load())
+		require.Equal(t, 0, limiter.Count("admin"), "rejected origin consumed a limiter slot")
+	})
+
+	t.Run("duplicate origin headers are rejected", func(t *testing.T) {
+		req := transportRequest("https://console.example", "operator", "secret")
+		req.Header.Add("Origin", "https://attacker.example")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusForbidden, rr.Code)
+		require.Equal(t, int32(0), calls.Load())
+		require.Equal(t, 0, limiter.Count("admin"), "duplicate origins consumed a limiter slot")
+	})
+
+	t.Run("allowed origin and credentials reach stop", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, transportRequest("https://console.example", "operator", "secret"))
+		require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+		require.Equal(t, "https://console.example", rr.Header().Get("Access-Control-Allow-Origin"))
+		require.Equal(t, "true", rr.Header().Get("Access-Control-Allow-Credentials"))
+		require.Equal(t, int32(1), calls.Load())
+	})
+
+	for _, test := range []struct {
+		name     string
+		user     string
+		password string
+	}{
+		{name: "missing", user: "", password: ""},
+		{name: "wrong user", user: "attacker", password: "secret"},
+		{name: "wrong password", user: "operator", password: "wrong"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, transportRequest("", test.user, test.password))
+			require.Equal(t, http.StatusUnauthorized, rr.Code)
+			require.Equal(t, `Basic realm="xrpld"`, rr.Header().Get("WWW-Authenticate"))
+			require.Equal(t, int32(1), calls.Load(), "rejected credentials reached the handler")
+			require.Equal(t, 0, limiter.Count("admin"), "rejected credentials consumed a limiter slot")
+		})
+	}
+}
+
+func TestHTTPTransportNoOriginCLI(t *testing.T) {
+	var calls atomic.Int32
+	srv := transportTestServer(t, &calls)
+	port := transportTestPort()
+	port.AllowedOrigins = []string{"https://console.example"}
+	rr := httptest.NewRecorder()
+	PortMiddleware(port, nil, srv).ServeHTTP(rr, transportRequest("", "operator", "secret"))
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	require.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+	require.Equal(t, int32(1), calls.Load())
+}
+
+func wsTransportServer(t *testing.T, pc *PortContext) (*httptest.Server, *WebSocketServer) {
+	t.Helper()
+	ws := NewWebSocketServer(time.Second, nil)
+	ws.methodRegistry.Register("ping", &stubHandler{role: types.RoleGuest})
+	httpSrv := httptest.NewServer(PortMiddleware(pc, nil, http.HandlerFunc(ws.ServeHTTP)))
+	t.Cleanup(func() {
+		httpSrv.Close()
+		_ = ws.Close(context.Background())
+	})
+	return httpSrv, ws
+}
+
+func dialTransport(t *testing.T, httpSrv *httptest.Server, origin, user, password string) (*websocket.Conn, *http.Response, error) {
+	t.Helper()
+	header := http.Header{}
+	if origin != "" {
+		header.Set("Origin", origin)
+	}
+	if user != "" || password != "" {
+		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(user+":"+password)))
+	}
+	url := "ws" + strings.TrimPrefix(httpSrv.URL, "http")
+	return websocket.DefaultDialer.Dial(url, header)
+}
+
+func TestWebSocketTransportOriginAndBasicAuth(t *testing.T) {
+	pc := transportTestPort()
+	httpSrv, _ := wsTransportServer(t, pc)
+
+	_, response, err := dialTransport(t, httpSrv, "https://attacker.example", "operator", "secret")
+	require.Error(t, err)
+	require.NotNil(t, response)
+	require.Equal(t, http.StatusForbidden, response.StatusCode)
+
+	_, response, err = dialTransport(t, httpSrv, "https://console.example", "", "")
+	require.Error(t, err)
+	require.NotNil(t, response)
+	require.Equal(t, http.StatusUnauthorized, response.StatusCode)
+	require.Equal(t, `Basic realm="xrpld"`, response.Header.Get("WWW-Authenticate"))
+
+	_, response, err = dialTransport(t, httpSrv, "https://console.example", "operator", "wrong")
+	require.Error(t, err)
+	require.NotNil(t, response)
+	require.Equal(t, http.StatusUnauthorized, response.StatusCode)
+
+	conn, response, err := dialTransport(t, httpSrv, "https://console.example", "operator", "secret")
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	require.Equal(t, http.StatusSwitchingProtocols, response.StatusCode)
+	defer conn.Close()
+	require.NoError(t, conn.WriteJSON(map[string]any{"command": "ping", "id": 1}))
+	var reply map[string]any
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(time.Second)))
+	require.NoError(t, conn.ReadJSON(&reply))
+	require.Equal(t, "success", reply["status"])
+}
+
+func TestWebSocketTransportNoOriginCLI(t *testing.T) {
+	httpSrv, _ := wsTransportServer(t, transportTestPort())
+	conn, response, err := dialTransport(t, httpSrv, "", "operator", "secret")
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	require.Equal(t, http.StatusSwitchingProtocols, response.StatusCode)
+	defer conn.Close()
+}

--- a/internal/rpc/credentials.go
+++ b/internal/rpc/credentials.go
@@ -1,0 +1,21 @@
+package rpc
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+)
+
+// constantTimeCredentialsMatch compares both credential fields after hashing
+// them to fixed-size digests. Comparing the digests avoids the length-based
+// early exit in subtle.ConstantTimeCompare while keeping each field check
+// independent of the other.
+func constantTimeCredentialsMatch(user, password, expectedUser, expectedPassword string) bool {
+	userDigest := sha256.Sum256([]byte(user))
+	expectedUserDigest := sha256.Sum256([]byte(expectedUser))
+	passwordDigest := sha256.Sum256([]byte(password))
+	expectedPasswordDigest := sha256.Sum256([]byte(expectedPassword))
+
+	userMatch := subtle.ConstantTimeCompare(userDigest[:], expectedUserDigest[:])
+	passwordMatch := subtle.ConstantTimeCompare(passwordDigest[:], expectedPasswordDigest[:])
+	return (userMatch & passwordMatch) == 1
+}

--- a/internal/rpc/credentials_test.go
+++ b/internal/rpc/credentials_test.go
@@ -1,0 +1,151 @@
+package rpc
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstantTimeCredentialsMatch(t *testing.T) {
+	const (
+		user     = "operator"
+		password = "transport-secret"
+	)
+	for _, test := range []struct {
+		name        string
+		gotUser     string
+		gotPassword string
+		want        bool
+	}{
+		{name: "correct", gotUser: user, gotPassword: password, want: true},
+		{name: "wrong user", gotUser: "attacker", gotPassword: password},
+		{name: "wrong password", gotUser: user, gotPassword: "wrong"},
+		{name: "different length user", gotUser: "op", gotPassword: password},
+		{name: "different length password", gotUser: user, gotPassword: "transport-secret-extra"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := constantTimeCredentialsMatch(test.gotUser, test.gotPassword, user, password); got != test.want {
+				t.Fatalf("constantTimeCredentialsMatch() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestBasicAuthMatches(t *testing.T) {
+	pc := &PortContext{User: "operator", Password: "transport-secret"}
+	for _, test := range []struct {
+		name     string
+		user     string
+		password string
+		setAuth  bool
+		want     bool
+	}{
+		{name: "correct", user: "operator", password: "transport-secret", setAuth: true, want: true},
+		{name: "wrong user", user: "attacker", password: "transport-secret", setAuth: true},
+		{name: "wrong password", user: "operator", password: "wrong", setAuth: true},
+		{name: "missing authorization", want: false},
+		{name: "different length user", user: "op", password: "transport-secret", setAuth: true},
+		{name: "different length password", user: "operator", password: "transport-secret-extra", setAuth: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			if test.setAuth {
+				req.SetBasicAuth(test.user, test.password)
+			}
+			if got := basicAuthMatches(req, pc); got != test.want {
+				t.Fatalf("basicAuthMatches() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestAdminCredentialsMatch(t *testing.T) {
+	pc := &PortContext{AdminUser: "root", AdminPassword: "admin-secret"}
+	for _, test := range []struct {
+		name   string
+		params map[string]any
+		want   bool
+	}{
+		{name: "correct", params: map[string]any{"admin_user": "root", "admin_password": "admin-secret"}, want: true},
+		{name: "wrong user", params: map[string]any{"admin_user": "attacker", "admin_password": "admin-secret"}},
+		{name: "wrong password", params: map[string]any{"admin_user": "root", "admin_password": "wrong"}},
+		{name: "missing credentials", params: map[string]any{}},
+		{name: "different length user", params: map[string]any{"admin_user": "r", "admin_password": "admin-secret"}},
+		{name: "different length password", params: map[string]any{"admin_user": "root", "admin_password": "admin-secret-extra"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := adminCredentialsMatch(test.params, pc); got != test.want {
+				t.Fatalf("adminCredentialsMatch() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestAuthorizeTransportClosesRejectedRequests(t *testing.T) {
+	pc := &PortContext{
+		User:           "operator",
+		Password:       "transport-secret",
+		AllowedOrigins: []string{"https://console.example"},
+	}
+	for _, test := range []struct {
+		name    string
+		request func() *http.Request
+		status  int
+	}{
+		{
+			name: "malformed origin",
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/", nil)
+				req.Header.Set("Origin", "https://")
+				return req
+			},
+			status: http.StatusForbidden,
+		},
+		{
+			name: "disallowed origin",
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/", nil)
+				req.Header.Set("Origin", "https://attacker.example")
+				return req
+			},
+			status: http.StatusForbidden,
+		},
+		{
+			name: "duplicate origin",
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/", nil)
+				req.Header.Add("Origin", "https://console.example")
+				req.Header.Add("Origin", "https://attacker.example")
+				return req
+			},
+			status: http.StatusForbidden,
+		},
+		{
+			name: "missing authorization",
+			request: func() *http.Request {
+				return httptest.NewRequest(http.MethodPost, "/", nil)
+			},
+			status: http.StatusUnauthorized,
+		},
+		{
+			name: "wrong authorization",
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "/", nil)
+				req.SetBasicAuth("operator", "wrong")
+				return req
+			},
+			status: http.StatusUnauthorized,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := test.request()
+			rr := httptest.NewRecorder()
+			require.False(t, authorizeTransport(rr, req, pc))
+			require.Equal(t, test.status, rr.Code)
+			require.True(t, req.Close)
+			require.Equal(t, "close", rr.Header().Get("Connection"))
+		})
+	}
+}

--- a/internal/rpc/middleware.go
+++ b/internal/rpc/middleware.go
@@ -1,10 +1,92 @@
 package rpc
 
 import (
+	"context"
 	"net/http"
+	"strings"
 
+	"github.com/LeJamon/go-xrpl/config"
 	"github.com/gorilla/websocket"
 )
+
+type transportAuthorizedKey struct{}
+
+func transportAuthorized(ctx context.Context) bool {
+	value, _ := ctx.Value(transportAuthorizedKey{}).(bool)
+	return value
+}
+
+func markTransportAuthorized(ctx context.Context) context.Context {
+	return context.WithValue(ctx, transportAuthorizedKey{}, true)
+}
+
+func rejectTransport(w http.ResponseWriter, r *http.Request, status int, message string) {
+	r.Close = true
+	w.Header().Set("Connection", "close")
+	writePlainHTTPError(w, status, message)
+}
+
+// authorizeTransport applies the immutable per-port browser-origin and Basic
+// Auth policy before a request can consume a connection slot or reach a
+// protocol handler.
+func authorizeTransport(w http.ResponseWriter, r *http.Request, pc *PortContext) bool {
+	if pc == nil {
+		return true
+	}
+	if origins := r.Header.Values("Origin"); len(origins) > 1 {
+		rejectTransport(w, r, http.StatusForbidden, "Forbidden")
+		return false
+	}
+	rawOrigin := r.Header.Get("Origin")
+	origin := strings.TrimSpace(rawOrigin)
+	if rawOrigin != origin {
+		rejectTransport(w, r, http.StatusForbidden, "Forbidden")
+		return false
+	}
+	if origin != "" {
+		canonical, err := config.CanonicalOrigin(origin)
+		if err != nil || !allowedOrigin(pc.AllowedOrigins, canonical) {
+			rejectTransport(w, r, http.StatusForbidden, "Forbidden")
+			return false
+		}
+		w.Header().Set("Access-Control-Allow-Origin", canonical)
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Add("Vary", "Origin")
+	}
+	// Browsers intentionally omit credentials from CORS preflight requests.
+	// The actual POST/upgrade remains Basic-Auth protected; an allowed
+	// preflight only exposes the negotiated transport policy.
+	if r.Method == http.MethodOptions && origin != "" {
+		return true
+	}
+	if !basicAuthMatches(r, pc) {
+		w.Header().Set("WWW-Authenticate", `Basic realm="xrpld"`)
+		rejectTransport(w, r, http.StatusUnauthorized, "Unauthorized")
+		return false
+	}
+	return true
+}
+
+func basicAuthMatches(r *http.Request, pc *PortContext) bool {
+	if pc == nil || (pc.User == "" && pc.Password == "") {
+		return true
+	}
+	user, password, present := r.BasicAuth()
+	match := constantTimeCredentialsMatch(user, password, pc.User, pc.Password)
+	if !present {
+		return false
+	}
+	return match
+}
+
+func allowedOrigin(origins []string, canonical string) bool {
+	for _, origin := range origins {
+		if origin == canonical {
+			return true
+		}
+	}
+	return false
+}
 
 // PortMiddleware returns an http.Handler that enforces per-port connection
 // limits and injects the PortContext into the request context.
@@ -14,8 +96,12 @@ import (
 // For regular HTTP requests the slot is released when the handler returns.
 func PortMiddleware(pc *PortContext, limiter *ConnLimiter, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !authorizeTransport(w, r, pc) {
+			return
+		}
+
 		// Enforce connection limit
-		if limiter != nil && !limiter.TryAcquire(pc.PortName, pc.Limit) {
+		if limiter != nil && pc != nil && !limiter.TryAcquire(pc.PortName, pc.Limit) {
 			http.Error(w, "Too many connections", http.StatusServiceUnavailable)
 			return
 		}
@@ -24,12 +110,12 @@ func PortMiddleware(pc *PortContext, limiter *ConnLimiter, next http.Handler) ht
 
 		// For non-WS requests, release the slot when the handler returns.
 		// WS connections are long-lived; their slot is released in closeConnection.
-		if limiter != nil && !isWS {
+		if limiter != nil && pc != nil && !isWS {
 			defer limiter.Release(pc.PortName)
 		}
 
 		// Inject PortContext into request context
-		ctx := WithPortContext(r.Context(), pc)
+		ctx := markTransportAuthorized(WithPortContext(r.Context(), pc))
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/rpc/portcontext.go
+++ b/internal/rpc/portcontext.go
@@ -11,10 +11,13 @@ type portContextKey struct{}
 // It is injected by PortMiddleware and consumed by roleForRequest
 // and WebSocketServer to enforce per-port access control and limits.
 type PortContext struct {
-	PortName      string
-	AdminNets     []net.IPNet
-	AdminUser     string
-	AdminPassword string
+	PortName       string
+	AdminNets      []net.IPNet
+	AdminUser      string
+	AdminPassword  string
+	User           string   // HTTP Basic Auth username
+	Password       string   // HTTP Basic Auth password
+	AllowedOrigins []string // Canonical exact HTTP(S) origins; empty denies browser origins
 	// SecureGatewayNets is the per-port secure_gateway allowlist. A
 	// peer in this set may carry X-Forwarded-For / X-User for
 	// downstream client-IP attribution and (with X-User) is promoted

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -15,7 +15,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -51,16 +50,6 @@ type Server struct {
 	timeout     time.Duration
 	services    *types.ServiceContainer
 	loadTracker *loadtrack.Tracker
-
-	// corsAllowedOrigins, if non-empty, restricts Access-Control-Allow-Origin
-	// to the listed origins (set via SetCORSAllowedOrigins). Empty means
-	// `*` — a deliberate goxrpl divergence from rippled, which emits no
-	// CORS header at all (JSONRPCUtil.cpp:143-145 leaves the
-	// Access-Control-Allow-Origin line commented out). Browser clients
-	// won't work cross-origin against a vanilla rippled; emitting `*` by
-	// default keeps the goxrpl HTTP endpoint usable from web tools.
-	corsMu             sync.RWMutex
-	corsAllowedOrigins []string
 }
 
 var _ types.MethodDispatcher = (*Server)(nil)
@@ -89,43 +78,6 @@ func (h *peerSourceHolder) loadPeerSource() types.PeerSource {
 		return *p
 	}
 	return nil
-}
-
-// SetCORSAllowedOrigins replaces the list of origins accepted for CORS.
-// Pass nil/empty to fall back to `*` (the goxrpl default — rippled emits
-// no CORS header at all). Origins are matched exactly against the
-// request's Origin header; a leading wildcard `*` in the list keeps the
-// permissive behaviour. Safe to call after the server has started.
-func (s *Server) SetCORSAllowedOrigins(origins []string) {
-	s.corsMu.Lock()
-	defer s.corsMu.Unlock()
-	if len(origins) == 0 {
-		s.corsAllowedOrigins = nil
-		return
-	}
-	s.corsAllowedOrigins = append(s.corsAllowedOrigins[:0:0], origins...)
-}
-
-// resolveCORSOrigin returns the value to echo in
-// Access-Control-Allow-Origin. When no allowlist is configured the legacy
-// `*` is returned; otherwise the request's Origin is echoed only when it
-// matches an entry (or `*` is in the list), so misconfigured browsers
-// don't get a cross-origin pass.
-func (s *Server) resolveCORSOrigin(requestOrigin string) string {
-	s.corsMu.RLock()
-	defer s.corsMu.RUnlock()
-	if len(s.corsAllowedOrigins) == 0 {
-		return "*"
-	}
-	for _, o := range s.corsAllowedOrigins {
-		if o == "*" {
-			return "*"
-		}
-		if o == requestOrigin {
-			return requestOrigin
-		}
-	}
-	return ""
 }
 
 // NewServer creates a new RPC server with the given timeout and the
@@ -179,19 +131,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	// Set CORS headers. Default is `*` (goxrpl divergence from rippled,
-	// which emits no CORS header — see Server.corsAllowedOrigins comment).
-	// An explicit allowlist may be configured via SetCORSAllowedOrigins,
-	// in which case we echo back the request's Origin only when it is on
-	// the list.
-	if allow := s.resolveCORSOrigin(r.Header.Get("Origin")); allow != "" {
-		w.Header().Set("Access-Control-Allow-Origin", allow)
-		if allow != "*" {
-			w.Header().Set("Vary", "Origin")
+	if !transportAuthorized(r.Context()) {
+		if !authorizeTransport(w, r, GetPortContext(r.Context())) {
+			return
 		}
 	}
-	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 	w.Header().Set("Content-Type", jsonContentType)
 
 	if r.Method == "OPTIONS" {
@@ -199,42 +145,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Method != "POST" && r.Method != "GET" {
+	if r.Method != "POST" {
 		writePlainHTTPError(w, http.StatusMethodNotAllowed, "Method not allowed")
 		return
 	}
 
-	if r.Method == "GET" {
-		s.handleGetRequest(w, r)
-		return
-	}
-
 	s.handlePostRequest(w, r)
-}
-
-func (s *Server) handleGetRequest(w http.ResponseWriter, r *http.Request) {
-	query := r.URL.Query()
-	method := query.Get("command")
-
-	// Deliberate goxrpl extension: a GET with no `command` defaults to
-	// server_info. rippled has no GET form (it feeds every request body
-	// through the JSON parser); this keeps the endpoint browser-pokeable,
-	// like the permissive default CORS header above.
-	if method == "" {
-		method = "server_info"
-	}
-
-	portCtx := GetPortContext(r.Context())
-	peerIP := remoteAddrIP(r.RemoteAddr)
-	clientIP := resolveClientIP(r, portCtx)
-	user := userHeader(r)
-	role := roleForRequest(peerIP, user, nil, portCtx)
-	dispatchCtx, cancel := s.withTimeout(r.Context())
-	defer cancel()
-	ctx := newRpcContext(dispatchCtx, role, types.DefaultApiVersion, clientIP, s.loadPeerSource(), s.services)
-
-	result, rpcErr := s.executeMethod(method, nil, ctx)
-	s.writeXrplResponseWithOptions(w, nil, result, rpcErr, loadWarningOpts(ctx))
 }
 
 func (s *Server) handlePostRequest(w http.ResponseWriter, r *http.Request) {
@@ -1435,7 +1351,11 @@ func adminCredentialsMatch(params map[string]any, portCtx *PortContext) bool {
 	}
 	user, userOK := params["admin_user"].(string)
 	password, passwordOK := params["admin_password"].(string)
-	return userOK && passwordOK && user == portCtx.AdminUser && password == portCtx.AdminPassword
+	match := constantTimeCredentialsMatch(user, password, portCtx.AdminUser, portCtx.AdminPassword)
+	if !userOK || !passwordOK {
+		return false
+	}
+	return match
 }
 
 func roleParamsFromRawParams(raw json.RawMessage) map[string]any {

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -119,9 +119,8 @@ func NewWebSocketServerWithLoadTracker(timeout time.Duration, services *types.Se
 	}
 	ws := &WebSocketServer{
 		upgrader: websocket.Upgrader{
-			// Accept any Origin, deliberately matching rippled: its WS
-			// server never validates the Origin header — access control
-			// is done via admin IP nets / port configuration instead.
+			// The shared transport middleware validates Origin before this
+			// upgrader runs; direct callers are checked by ServeHTTP.
 			CheckOrigin: func(r *http.Request) bool { return true },
 			// Don't require specific subprotocol - xrpl.js doesn't use one
 		},
@@ -170,6 +169,9 @@ func (ws *WebSocketServer) SetConnLimiter(limiter *ConnLimiter) {
 func (ws *WebSocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	portCtx := GetPortContext(r.Context())
 	isWebSocket := isWebSocketUpgrade(r)
+	if !transportAuthorized(r.Context()) && !authorizeTransport(w, r, portCtx) {
+		return
+	}
 
 	ws.connectionsMutex.Lock()
 	if ws.closing {


### PR DESCRIPTION
## Summary

- Enforce one immutable origin and credential policy across HTTP and WebSocket RPC transports.
- Reject arbitrary GET command execution while retaining the authenticated health endpoint.
- Compare configured credentials in constant time and close rejected connections promptly.

## Verification

- Config and RPC transport tests
- Authentication, origin, and credential timing regressions

Refs #1483


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-port Basic Authentication for HTTP and WebSocket connections.
  * Added exact browser-origin allowlists with validation, normalization, and inheritance from server settings.
  * Preserved CLI access for requests without an `Origin` header.
  * Added CORS preflight support and transport-level authorization.

* **Bug Fixes**
  * Restricted JSON-RPC requests to POST and OPTIONS methods.
  * Improved rejection of invalid credentials, origins, and insecure admin browser access.

* **Documentation**
  * Expanded configuration and operating guidance for authentication, origins, health checks, and HTTP behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->