### PR TITLE
fix: preserve ledger RPC error and event contracts

### DIFF
--- a/internal/ledger/constructors.go
+++ b/internal/ledger/constructors.go
@@ -85,6 +85,7 @@ func newOpen(parent *Ledger, closeTime time.Time, building bool) (*Ledger, error
 
 	newHeader := header.LedgerHeader{
 		LedgerIndex:         newLedgerSeq,
+		Hash:                incrementHash(parentHeader.Hash),
 		ParentHash:          parentHeader.Hash,
 		ParentCloseTime:     parentHeader.CloseTime,
 		CloseTime:           closeTime,
@@ -104,6 +105,16 @@ func newOpen(parent *Ledger, closeTime time.Time, building bool) (*Ledger, error
 		dropsDestroyed: 0,
 		rules:          parentRules,
 	}, nil
+}
+
+func incrementHash(hash [32]byte) [32]byte {
+	for i := len(hash) - 1; i >= 0; i-- {
+		hash[i]++
+		if hash[i] != 0 {
+			break
+		}
+	}
+	return hash
 }
 
 func FromGenesis(

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -134,6 +134,73 @@ func TestLedger_Close_UsesDynamicResolution(t *testing.T) {
 	}
 }
 
+func TestNewOpenUsesProvisionalSuccessorHeader(t *testing.T) {
+	parent := newParentAt(t, 2, 30, true)
+	parent.header.Hash = [32]byte{0: 0x10, 1: 0xff}
+	parent.header.TxHash = [32]byte{0x20}
+	parent.header.AccountHash = [32]byte{0x30}
+	parent.header.CloseFlags = header.LCFNoConsensusTime
+	parent.header.Validated = true
+	parent.header.Accepted = true
+	closeTime := parent.CloseTime().Add(10 * time.Second)
+
+	child, err := NewOpen(parent, closeTime)
+	if err != nil {
+		t.Fatalf("NewOpen: %v", err)
+	}
+	got := child.Header()
+	wantHash := [32]byte{0: 0x10, 1: 0xff, 31: 0x01}
+	if got.Hash != wantHash {
+		t.Fatalf("provisional hash = %x, want parent hash + 1 = %x", got.Hash, wantHash)
+	}
+	if got.TxHash != ([32]byte{}) || got.AccountHash != ([32]byte{}) {
+		t.Fatalf("open roots = tx %x/account %x, want zero roots", got.TxHash, got.AccountHash)
+	}
+	if got.CloseFlags != 0 || got.Validated || got.Accepted {
+		t.Fatalf("open closed-only flags = close %d validated %t accepted %t", got.CloseFlags, got.Validated, got.Accepted)
+	}
+	if got.LedgerIndex != parent.header.LedgerIndex+1 || got.ParentHash != parent.header.Hash ||
+		!got.ParentCloseTime.Equal(parent.header.CloseTime) || !got.CloseTime.Equal(closeTime) ||
+		got.Drops != parent.header.Drops {
+		t.Fatalf("successor header = %+v", got)
+	}
+}
+
+func TestIncrementHash(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		in   [32]byte
+		want [32]byte
+	}{
+		{
+			name: "ordinary increment",
+			in:   [32]byte{31: 0x2a},
+			want: [32]byte{31: 0x2b},
+		},
+		{
+			name: "trailing byte carry",
+			in:   [32]byte{30: 0x12, 31: 0xff},
+			want: [32]byte{30: 0x13},
+		},
+		{
+			name: "modular wrap",
+			in: [32]byte{
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			},
+			want: [32]byte{},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := incrementHash(test.in); got != test.want {
+				t.Fatalf("incrementHash(%x) = %x, want %x", test.in, got, test.want)
+			}
+		})
+	}
+}
+
 func TestNewOpenForBuildUsesProvisionalApplicationTime(t *testing.T) {
 	parent := newParentAt(t, 17, 10, true)
 	parent.header.CloseTime = protocol.FromRippleTime(835360951)

--- a/internal/node/ledger_streams.go
+++ b/internal/node/ledger_streams.go
@@ -26,9 +26,19 @@ func (a *ledgerInfoAdapter) GetCurrentLedgerInfo() *types.LedgerSubscribeInfo {
 		return nil
 	}
 
+	serverInfo := a.ledgerService.GetServerInfo()
 	validatedLedger := a.ledgerService.GetValidatedLedger()
+	validatedLedgers := ""
+	validatedLedgersPresent := serverPublishesValidatedRange(serverInfo.ServerState) && !serverInfo.NeedsNetworkLedger
+	if validatedLedgersPresent {
+		validatedLedgers = serverInfo.CompleteLedgers
+	}
 	if validatedLedger == nil {
-		return nil
+		return &types.LedgerSubscribeInfo{
+			ValidatedLedgers:        validatedLedgers,
+			ValidatedLedgersPresent: validatedLedgersPresent,
+			NetworkID:               serverInfo.NetworkID,
+		}
 	}
 
 	baseFee, reserveBase, reserveInc := service.FeesFromLedger(validatedLedger)
@@ -36,24 +46,21 @@ func (a *ledgerInfoAdapter) GetCurrentLedgerInfo() *types.LedgerSubscribeInfo {
 	ledgerTime := protocol.ToRippleTime(validatedLedger.CloseTime())
 
 	hash := validatedLedger.Hash()
-	serverInfo := a.ledgerService.GetServerInfo()
-	validatedLedgers := ""
-	if serverPublishesValidatedRange(serverInfo.ServerState) && !serverInfo.NeedsNetworkLedger {
-		validatedLedgers = serverInfo.CompleteLedgers
-	}
 	xrpFeesEnabled := validatedLedger.Rules() != nil && validatedLedger.Rules().XRPFeesEnabled()
 
 	return &types.LedgerSubscribeInfo{
-		LedgerIndex:      validatedLedger.Sequence(),
-		LedgerHash:       upperHex(hash[:]),
-		LedgerTime:       ledgerTime,
-		FeeBase:          jsonClippedXRPAmount(int64(baseFee)),
-		FeeRef:           deprecatedFeeReferenceUnits,
-		ReserveBase:      jsonClippedXRPAmount(int64(reserveBase)),
-		ReserveInc:       jsonClippedXRPAmount(int64(reserveInc)),
-		ValidatedLedgers: validatedLedgers,
-		NetworkID:        serverInfo.NetworkID,
-		XRPFeesEnabled:   xrpFeesEnabled,
+		LedgerAvailable:         true,
+		LedgerIndex:             validatedLedger.Sequence(),
+		LedgerHash:              upperHex(hash[:]),
+		LedgerTime:              ledgerTime,
+		FeeBase:                 jsonClippedXRPAmount(int64(baseFee)),
+		FeeRef:                  deprecatedFeeReferenceUnits,
+		ReserveBase:             jsonClippedXRPAmount(int64(reserveBase)),
+		ReserveInc:              jsonClippedXRPAmount(int64(reserveInc)),
+		ValidatedLedgers:        validatedLedgers,
+		ValidatedLedgersPresent: validatedLedgersPresent,
+		NetworkID:               serverInfo.NetworkID,
+		XRPFeesEnabled:          xrpFeesEnabled,
 	}
 }
 
@@ -79,21 +86,23 @@ func buildLedgerCloseEvent(event *service.LedgerAcceptedEvent, serverInfo servic
 		feeRef = &value
 	}
 	validatedLedgers := ""
-	if serverPublishesValidatedRange(serverInfo.ServerState) {
+	validatedLedgersPresent := serverPublishesValidatedRange(serverInfo.ServerState)
+	if validatedLedgersPresent {
 		validatedLedgers = serverInfo.CompleteLedgers
 	}
 	return &rpc.LedgerCloseEvent{
-		Type:             "ledgerClosed",
-		LedgerIndex:      event.LedgerInfo.Sequence,
-		LedgerHash:       upperHex(event.LedgerInfo.Hash[:]),
-		LedgerTime:       protocol.ToRippleTime(event.LedgerInfo.CloseTime),
-		FeeBase:          jsonClippedXRPAmount(int64(baseFee)),
-		FeeRef:           feeRef,
-		NetworkID:        serverInfo.NetworkID,
-		ReserveBase:      jsonClippedXRPAmount(int64(reserveBase)),
-		ReserveInc:       jsonClippedXRPAmount(int64(reserveInc)),
-		TxnCount:         len(event.TransactionResults),
-		ValidatedLedgers: validatedLedgers,
+		Type:                    "ledgerClosed",
+		LedgerIndex:             event.LedgerInfo.Sequence,
+		LedgerHash:              upperHex(event.LedgerInfo.Hash[:]),
+		LedgerTime:              protocol.ToRippleTime(event.LedgerInfo.CloseTime),
+		FeeBase:                 jsonClippedXRPAmount(int64(baseFee)),
+		FeeRef:                  feeRef,
+		NetworkID:               serverInfo.NetworkID,
+		ReserveBase:             jsonClippedXRPAmount(int64(reserveBase)),
+		ReserveInc:              jsonClippedXRPAmount(int64(reserveInc)),
+		TxnCount:                len(event.TransactionResults),
+		ValidatedLedgers:        validatedLedgers,
+		ValidatedLedgersPresent: validatedLedgersPresent,
 	}
 }
 

--- a/internal/node/ledger_streams_test.go
+++ b/internal/node/ledger_streams_test.go
@@ -1,0 +1,59 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+)
+
+type noValidatedLedgerInfoService struct {
+	info service.ServerInfo
+}
+
+func (s noValidatedLedgerInfoService) GetValidatedLedger() *ledger.Ledger {
+	return nil
+}
+
+func (s noValidatedLedgerInfoService) GetServerInfo() service.ServerInfo {
+	return s.info
+}
+
+func TestLedgerInfoAdapterWithoutValidatedLedger(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		serverState      string
+		needsNetwork     bool
+		completeLedgers  string
+		expectedComplete string
+	}{
+		{name: "disconnected", serverState: "disconnected", completeLedgers: "1-2"},
+		{name: "syncing", serverState: "syncing", completeLedgers: "1-2", expectedComplete: "1-2"},
+		{name: "syncing needs network ledger", serverState: "syncing", needsNetwork: true, completeLedgers: "1-2"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			info := (&ledgerInfoAdapter{ledgerService: noValidatedLedgerInfoService{info: service.ServerInfo{
+				ServerState:        test.serverState,
+				NeedsNetworkLedger: test.needsNetwork,
+				CompleteLedgers:    test.completeLedgers,
+				NetworkID:          42,
+			}}}).GetCurrentLedgerInfo()
+			if info == nil {
+				t.Fatal("nil subscribe info without validated ledger")
+			}
+			if info.LedgerAvailable {
+				t.Fatal("LedgerAvailable = true without validated ledger")
+			}
+			if info.ValidatedLedgers != test.expectedComplete {
+				t.Fatalf("ValidatedLedgers = %q, want %q", info.ValidatedLedgers, test.expectedComplete)
+			}
+			wantPresent := test.serverState == "syncing" && !test.needsNetwork
+			if info.ValidatedLedgersPresent != wantPresent {
+				t.Fatalf("ValidatedLedgersPresent = %t, want %t", info.ValidatedLedgersPresent, wantPresent)
+			}
+			if info.NetworkID != 42 {
+				t.Fatalf("NetworkID = %d, want 42", info.NetworkID)
+			}
+		})
+	}
+}

--- a/internal/node/server_helpers_test.go
+++ b/internal/node/server_helpers_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -104,7 +105,7 @@ func TestBuildLedgerCloseEventUsesSourceLedgerAndWirePresence(t *testing.T) {
 			if got.FeeRef != nil && *got.FeeRef != deprecatedFeeReferenceUnits {
 				t.Fatalf("fee_ref = %d, want %d", *got.FeeRef, deprecatedFeeReferenceUnits)
 			}
-			if got.NetworkID != 0 || got.ValidatedLedgers != "1-2,4" || got.TxnCount != 2 {
+			if got.NetworkID != 0 || got.ValidatedLedgers != "1-2,4" || !got.ValidatedLedgersPresent || got.TxnCount != 2 {
 				t.Fatalf("event fields = %+v", got)
 			}
 
@@ -117,6 +118,87 @@ func TestBuildLedgerCloseEventUsesSourceLedgerAndWirePresence(t *testing.T) {
 			}
 			if subscribeInfo.FeeRef != deprecatedFeeReferenceUnits || subscribeInfo.XRPFeesEnabled != test.xrpFees {
 				t.Fatalf("subscribe fee gate = ref %d, XRPFees %t", subscribeInfo.FeeRef, subscribeInfo.XRPFeesEnabled)
+			}
+		})
+	}
+}
+
+func TestLedgerClosedWireMatrix(t *testing.T) {
+	states := []string{"", "disconnected", "connected", "syncing", "tracking", "full", "proposing", "validating"}
+	completeLedgers := []string{"", "1-2,4"}
+
+	for _, xrpFees := range []bool{false, true} {
+		t.Run(fmt.Sprintf("xrp_fees_%t", xrpFees), func(t *testing.T) {
+			genesisConfig := genesis.DefaultConfig()
+			if xrpFees {
+				genesisConfig.Amendments = append(genesisConfig.Amendments, amendment.FeatureXRPFees)
+			}
+			svc, err := service.New(service.Config{
+				Standalone:    true,
+				Startup:       service.StartupConfig{Mode: service.StartupFresh},
+				GenesisConfig: genesisConfig,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := svc.Start(); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(svc.Stop)
+
+			source := svc.GetValidatedLedger()
+			if source == nil {
+				t.Fatal("missing validated source ledger")
+			}
+			hash := source.Hash()
+			base, reserveBase, reserveInc := service.FeesFromLedger(source)
+			wantBase := jsonClippedXRPAmount(int64(base))
+			wantReserveBase := jsonClippedXRPAmount(int64(reserveBase))
+			wantReserveInc := jsonClippedXRPAmount(int64(reserveInc))
+			for _, state := range states {
+				for _, needsNetworkLedger := range []bool{false, true} {
+					for _, networkID := range []uint32{0, 42} {
+						for _, complete := range completeLedgers {
+							name := fmt.Sprintf("%s/needs_%t/network_%d/complete_%t", state, needsNetworkLedger, networkID, complete != "")
+							t.Run(name, func(t *testing.T) {
+								event := buildLedgerCloseEvent(&service.LedgerAcceptedEvent{
+									Ledger: source,
+									LedgerInfo: &service.LedgerInfo{
+										Sequence:  source.Sequence(),
+										Hash:      hash,
+										CloseTime: source.CloseTime(),
+									},
+									TransactionResults: make([]service.TransactionResultEvent, 2),
+								}, service.ServerInfo{
+									ServerState:        state,
+									NeedsNetworkLedger: needsNetworkLedger,
+									CompleteLedgers:    complete,
+									NetworkID:          networkID,
+								})
+								if event == nil {
+									t.Fatal("nil ledger close event")
+								}
+								got, err := json.Marshal(event)
+								if err != nil {
+									t.Fatal(err)
+								}
+
+								want := fmt.Sprintf(`{"type":"ledgerClosed","fee_base":%d`, wantBase)
+								if !xrpFees {
+									want += `,"fee_ref":10`
+								}
+								want += fmt.Sprintf(`,"ledger_hash":"%s","ledger_index":%d,"ledger_time":%d,"network_id":%d,"reserve_base":%d,"reserve_inc":%d,"txn_count":2`, upperHex(hash[:]), source.Sequence(), protocol.ToRippleTime(source.CloseTime()), networkID, wantReserveBase, wantReserveInc)
+								if serverPublishesValidatedRange(state) {
+									want += fmt.Sprintf(`,"validated_ledgers":"%s"`, complete)
+								}
+								want += `}`
+								if string(got) != want {
+									t.Fatalf("ledgerClosed JSON = %s, want %s", got, want)
+								}
+							})
+						}
+					}
+				}
 			}
 		})
 	}

--- a/internal/rpc/book_changes_test.go
+++ b/internal/rpc/book_changes_test.go
@@ -340,6 +340,24 @@ func TestBookChangesContextReadError(t *testing.T) {
 	assert.True(t, ledger.called)
 }
 
+func TestBookChangesMalformedTransactionReturnsInternal(t *testing.T) {
+	mock := newMockLedgerServiceBC()
+	ledger := newMockLedgerReaderBC(2)
+	ledger.txs[[32]byte{1}] = []byte{0xff}
+	mock.addLedger(ledger)
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   newTestServicesBC(mock),
+	}
+
+	result, rpcErr := (&handlers.BookChangesMethod{}).Handle(ctx, json.RawMessage(`{"ledger_index":2}`))
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+}
+
 func TestBookChangesDomainAndOrdering(t *testing.T) {
 	const (
 		issuer = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"

--- a/internal/rpc/events.go
+++ b/internal/rpc/events.go
@@ -9,17 +9,36 @@ import (
 // LedgerCloseEvent represents a ledger close notification sent to subscribers
 // This matches the rippled ledgerClosed stream message format
 type LedgerCloseEvent struct {
-	Type             string  `json:"type"`                        // Always "ledgerClosed"
-	FeeBase          int32   `json:"fee_base"`                    // Transaction cost in fee units
-	FeeRef           *uint64 `json:"fee_ref,omitempty"`           // Deprecated reference fee units, before XRPFees
-	LedgerHash       string  `json:"ledger_hash"`                 // Hash of the ledger that closed
-	LedgerIndex      uint32  `json:"ledger_index"`                // Sequence number of the ledger
-	LedgerTime       uint32  `json:"ledger_time"`                 // Close time in seconds since Ripple epoch
-	NetworkID        uint32  `json:"network_id"`                  // Network identifier, including network 0
-	ReserveBase      int32   `json:"reserve_base"`                // Minimum reserve requirement in drops
-	ReserveInc       int32   `json:"reserve_inc"`                 // Owner reserve increment in drops
-	TxnCount         int     `json:"txn_count"`                   // Number of transactions in the ledger
-	ValidatedLedgers string  `json:"validated_ledgers,omitempty"` // Range of validated ledgers (e.g., "1-100")
+	Type                    string  `json:"type"`                        // Always "ledgerClosed"
+	FeeBase                 int32   `json:"fee_base"`                    // Transaction cost in fee units
+	FeeRef                  *uint64 `json:"fee_ref,omitempty"`           // Deprecated reference fee units, before XRPFees
+	LedgerHash              string  `json:"ledger_hash"`                 // Hash of the ledger that closed
+	LedgerIndex             uint32  `json:"ledger_index"`                // Sequence number of the ledger
+	LedgerTime              uint32  `json:"ledger_time"`                 // Close time in seconds since Ripple epoch
+	NetworkID               uint32  `json:"network_id"`                  // Network identifier, including network 0
+	ReserveBase             int32   `json:"reserve_base"`                // Minimum reserve requirement in drops
+	ReserveInc              int32   `json:"reserve_inc"`                 // Owner reserve increment in drops
+	TxnCount                int     `json:"txn_count"`                   // Number of transactions in the ledger
+	ValidatedLedgers        string  `json:"validated_ledgers,omitempty"` // Range of validated ledgers (e.g., "1-100")
+	ValidatedLedgersPresent bool    `json:"-"`
+}
+
+// MarshalJSON preserves the distinction between an omitted validated range and
+// a gate-enabled range whose value is currently empty.
+func (e LedgerCloseEvent) MarshalJSON() ([]byte, error) {
+	type alias LedgerCloseEvent
+	value := alias(e)
+	var validatedLedgers *string
+	if e.ValidatedLedgersPresent {
+		validatedLedgers = &value.ValidatedLedgers
+	}
+	return json.Marshal(struct {
+		alias
+		ValidatedLedgers *string `json:"validated_ledgers,omitempty"`
+	}{
+		alias:            value,
+		ValidatedLedgers: validatedLedgers,
+	})
 }
 
 // TransactionEvent represents a transaction notification sent to subscribers

--- a/internal/rpc/get_aggregate_price_conformance_test.go
+++ b/internal/rpc/get_aggregate_price_conformance_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -20,8 +21,10 @@ import (
 
 type aggregatePriceLedgerService struct {
 	*mockLedgerService
-	entries      map[[32]byte]*types.LedgerEntryResult
-	transactions map[[32]byte]*types.TransactionInfo
+	entries        map[[32]byte]*types.LedgerEntryResult
+	transactions   map[[32]byte]*types.TransactionInfo
+	entryErr       error
+	transactionErr error
 }
 
 func newAggregatePriceLedgerService() *aggregatePriceLedgerService {
@@ -33,17 +36,23 @@ func newAggregatePriceLedgerService() *aggregatePriceLedgerService {
 }
 
 func (m *aggregatePriceLedgerService) GetLedgerEntry(_ context.Context, entryKey [32]byte, _ string) (*types.LedgerEntryResult, error) {
+	if m.entryErr != nil {
+		return nil, m.entryErr
+	}
 	entry, ok := m.entries[entryKey]
 	if !ok {
-		return nil, errors.New("ledger entry not found")
+		return nil, svcerr.ErrLedgerEntryNotFound
 	}
 	return entry, nil
 }
 
 func (m *aggregatePriceLedgerService) GetTransaction(hash [32]byte) (*types.TransactionInfo, error) {
+	if m.transactionErr != nil {
+		return nil, m.transactionErr
+	}
 	transaction, ok := m.transactions[hash]
 	if !ok {
-		return nil, errors.New("transaction not found")
+		return nil, svcerr.ErrTxnNotFound
 	}
 	return transaction, nil
 }
@@ -80,6 +89,131 @@ func TestGetAggregatePriceProjectionAndXRPLArithmetic(t *testing.T) {
 	assert.Equal(t, strings.Repeat("0", 64), result["ledger_hash"])
 	assert.Equal(t, true, result["validated"])
 	assert.NotContains(t, result, "ledger_current_index")
+}
+
+func TestGetAggregatePriceSkipsMissingOracleEntries(t *testing.T) {
+	const owner = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	service := newAggregatePriceLedgerService()
+	key, node := aggregateOracleNode(t, owner, 1, 100, "XRP", "USD", 740, 0, "", 0)
+	service.entries[key] = &types.LedgerEntryResult{Node: node}
+
+	result := callAggregatePrice(t, service, map[string]any{
+		"base_asset":  "XRP",
+		"quote_asset": "USD",
+		"oracles": []map[string]any{
+			{"account": owner, "oracle_document_id": 999},
+			{"account": owner, "oracle_document_id": 1},
+		},
+	})
+	assert.Equal(t, uint16(1), result["entire_set"].(map[string]any)["size"])
+}
+
+func TestGetAggregatePriceLookupErrorReturnsInternal(t *testing.T) {
+	service := newAggregatePriceLedgerService()
+	service.entryErr = errors.New("node store unavailable")
+	result, rpcErr := callAggregatePriceError(t, service, map[string]any{
+		"base_asset":  "XRP",
+		"quote_asset": "USD",
+		"oracles": []map[string]any{{
+			"account":            ownerForAggregatePriceTest,
+			"oracle_document_id": 1,
+		}},
+	})
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+}
+
+func TestGetAggregatePriceMalformedOracleBytesReturnsInternal(t *testing.T) {
+	service := newAggregatePriceLedgerService()
+	key, _ := aggregateOracleNode(t, ownerForAggregatePriceTest, 1, 100, "XRP", "USD", 740, 0, "", 0)
+	service.entries[key] = &types.LedgerEntryResult{Node: []byte{0xff}}
+
+	result, rpcErr := callAggregatePriceError(t, service, map[string]any{
+		"base_asset":  "XRP",
+		"quote_asset": "USD",
+		"oracles": []map[string]any{{
+			"account":            ownerForAggregatePriceTest,
+			"oracle_document_id": 1,
+		}},
+	})
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+}
+
+func TestGetAggregatePriceHistoricalLookupErrorReturnsInternal(t *testing.T) {
+	service := newAggregatePriceLedgerService()
+	service.transactionErr = errors.New("transaction store unavailable")
+	key, node := aggregateOracleNode(t, ownerForAggregatePriceTest, 1, 100, "XRP", "EUR", 740, 0, strings.Repeat("A", 64), 5)
+	service.entries[key] = &types.LedgerEntryResult{Node: node}
+
+	result, rpcErr := callAggregatePriceError(t, service, map[string]any{
+		"base_asset":  "XRP",
+		"quote_asset": "USD",
+		"oracles": []map[string]any{{
+			"account":            ownerForAggregatePriceTest,
+			"oracle_document_id": 1,
+		}},
+	})
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+}
+
+func TestGetAggregatePriceMissingHistoricalTransactionReturnsObjectNotFound(t *testing.T) {
+	service := newAggregatePriceLedgerService()
+	key, node := aggregateOracleNode(t, ownerForAggregatePriceTest, 1, 100, "XRP", "EUR", 740, 0, strings.Repeat("A", 64), 5)
+	service.entries[key] = &types.LedgerEntryResult{Node: node}
+
+	result, rpcErr := callAggregatePriceError(t, service, map[string]any{
+		"base_asset":  "XRP",
+		"quote_asset": "USD",
+		"oracles": []map[string]any{{
+			"account":            ownerForAggregatePriceTest,
+			"oracle_document_id": 1,
+		}},
+	})
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcOBJECT_NOT_FOUND, rpcErr.Code)
+}
+
+func TestGetAggregatePriceMalformedHistoricalTransactionReturnsInternal(t *testing.T) {
+	service := newAggregatePriceLedgerService()
+	key, node := aggregateOracleNode(t, ownerForAggregatePriceTest, 1, 100, "XRP", "EUR", 740, 0, strings.Repeat("A", 64), 5)
+	service.entries[key] = &types.LedgerEntryResult{Node: node}
+	service.transactions[aggregateHash(t, strings.Repeat("A", 64))] = &types.TransactionInfo{
+		TxData:      []byte{0xff},
+		LedgerIndex: 5,
+	}
+
+	result, rpcErr := callAggregatePriceError(t, service, map[string]any{
+		"base_asset":  "XRP",
+		"quote_asset": "USD",
+		"oracles": []map[string]any{{
+			"account":            ownerForAggregatePriceTest,
+			"oracle_document_id": 1,
+		}},
+	})
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
+}
+
+const ownerForAggregatePriceTest = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+
+func callAggregatePriceError(t *testing.T, service types.LedgerService, request map[string]any) (any, *types.RpcError) {
+	t.Helper()
+	encoded, err := json.Marshal(request)
+	require.NoError(t, err)
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: service},
+	}
+	return (&handlers.GetAggregatePriceMethod{}).Handle(ctx, encoded)
 }
 
 func TestGetAggregatePriceThresholdIncludesBoundary(t *testing.T) {

--- a/internal/rpc/handlers/account_info.go
+++ b/internal/rpc/handlers/account_info.go
@@ -139,11 +139,9 @@ func (m *AccountInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 	accountFlags["disallowIncomingPayChan"] = flags&lsfDisallowIncomingPayChan != 0
 	accountFlags["disallowIncomingTrustline"] = flags&lsfDisallowIncomingTrustln != 0
 
-	rules := amendment.EmptyRules()
-	if source, ok := ledger.(types.LedgerAmendmentRulesSource); ok {
-		if ledgerRules := source.LedgerAmendmentRules(); ledgerRules != nil {
-			rules = ledgerRules
-		}
+	rules, rulesErr := ledgerAmendmentRules(ledger)
+	if rulesErr != nil {
+		return nil, rpcInternalError("account_info: amendment rules lookup failed", rulesErr)
 	}
 	if rules.Enabled(amendment.FeatureClawback) {
 		accountFlags["allowTrustLineClawback"] = flags&lsfAllowTrustLineClawback != 0

--- a/internal/rpc/handlers/book_changes.go
+++ b/internal/rpc/handlers/book_changes.go
@@ -166,11 +166,13 @@ func (m *BookChangesMethod) Handle(ctx *types.RpcContext, params json.RawMessage
 // publisher can call it without duplicating the metadata walk.
 func collectBookChanges(ctx context.Context, targetLedger LedgerWithTransactions) (map[string]*bookChange, error) {
 	changes := make(map[string]*bookChange)
+	var decodeErr error
 
 	visit := func(txHash [32]byte, txData []byte) bool {
 		storedTx, err := decodeTxBlob(txData)
 		if err != nil {
-			return true
+			decodeErr = err
+			return false
 		}
 		accumulateBookChanges(changes, storedTx.TxJSON, storedTx.Meta)
 		return true
@@ -184,7 +186,13 @@ func collectBookChanges(ctx context.Context, targetLedger LedgerWithTransactions
 	} else {
 		err = targetLedger.ForEachTransaction(visit)
 	}
-	return changes, err
+	if err != nil {
+		return nil, err
+	}
+	if decodeErr != nil {
+		return nil, decodeErr
+	}
+	return changes, nil
 }
 
 func accumulateBookChanges(changes map[string]*bookChange, txJSON, metadata map[string]any) {

--- a/internal/rpc/handlers/get_aggregate_price.go
+++ b/internal/rpc/handlers/get_aggregate_price.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"sort"
@@ -11,6 +12,7 @@ import (
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/keylet"
@@ -140,21 +142,29 @@ func (m *GetAggregatePriceMethod) Handle(ctx *types.RpcContext, params json.RawM
 		}
 
 		entry, err := ctx.Services.Ledger.GetLedgerEntry(ctx.Context, keylet.Oracle(accountID, documentID).Key, ledgerIndex)
-		if err != nil || entry == nil {
+		if err != nil {
+			if errors.Is(err, svcerr.ErrLedgerEntryNotFound) {
+				continue
+			}
+			return nil, rpcInternalError("get_aggregate_price: oracle lookup failed", err).WithExtra(lookupFields)
+		}
+		if entry == nil {
 			continue
 		}
 		decoded, err := binarycodec.Decode(hex.EncodeToString(entry.Node))
 		if err != nil {
-			continue
+			return nil, rpcInternalError("get_aggregate_price: oracle decoding failed", err).WithExtra(lookupFields)
 		}
 
-		iterateAggregatePriceData(ctx, decoded, func(node map[string]any) bool {
+		if err := iterateAggregatePriceData(ctx, decoded, func(node map[string]any) bool {
 			point, found := aggregatePriceFromNode(node, baseAsset, quoteAsset)
 			if found {
 				prices = append(prices, point)
 			}
 			return found
-		})
+		}); err != nil {
+			return nil, rpcInternalError("get_aggregate_price: transaction decoding failed", err).WithExtra(lookupFields)
+		}
 	}
 
 	if len(prices) == 0 {
@@ -257,30 +267,36 @@ func parseCurrencyParam(raw json.RawMessage) (string, error) {
 	return value, nil
 }
 
-func iterateAggregatePriceData(ctx *types.RpcContext, initial map[string]any, visit func(map[string]any) bool) {
+func iterateAggregatePriceData(ctx *types.RpcContext, initial map[string]any, visit func(map[string]any) bool) error {
 	oracle := initial
 	chain := initial
 	isNew := false
 	for history := uint8(0); ; {
 		if oracle == nil || visit(oracle) || isNew {
-			return
+			return nil
 		}
 		history++
 		if history > 3 {
-			return
+			return nil
 		}
 
 		previousID, previousSequence, ok := aggregatePreviousTransaction(chain)
 		if !ok {
-			return
+			return nil
 		}
 		transaction, err := ctx.Services.Ledger.GetTransaction(previousID)
-		if err != nil || transaction == nil || transaction.LedgerIndex != previousSequence {
-			return
+		if err != nil {
+			if errors.Is(err, svcerr.ErrTxnNotFound) || errors.Is(err, svcerr.ErrLedgerNotFound) {
+				return nil
+			}
+			return err
+		}
+		if transaction == nil || transaction.LedgerIndex != previousSequence {
+			return nil
 		}
 		stored, err := decodeTxBlob(transaction.TxData)
 		if err != nil {
-			return
+			return err
 		}
 
 		found := false
@@ -292,7 +308,7 @@ func iterateAggregatePriceData(ctx *types.RpcContext, initial map[string]any, vi
 			chain = inner
 			oracle, isNew = inner["NewFields"].(map[string]any)
 			if isNew && history == 1 {
-				return
+				return nil
 			}
 			if !isNew {
 				oracle, _ = inner["FinalFields"].(map[string]any)
@@ -301,7 +317,7 @@ func iterateAggregatePriceData(ctx *types.RpcContext, initial map[string]any, vi
 			break
 		}
 		if !found {
-			return
+			return nil
 		}
 	}
 }

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -44,23 +44,8 @@ func rpcDBDeserializationError(operation string, err error) *types.RpcError {
 	return types.RpcErrorDBDeserialization()
 }
 
-// ledgerMapHashes reads both ledger roots without allowing a production
-// adapter's SHAMap error to be replaced with a zero hash. Legacy readers keep
-// the value-only methods, so the error-aware facet is optional for test and
-// embedded implementations.
-func ledgerMapHashes(l types.LedgerReader) (txHash, stateHash [32]byte, err error) {
-	if source, ok := l.(types.LedgerMapHashSource); ok {
-		txHash, err = source.TxMapHashWithError()
-		if err != nil {
-			return [32]byte{}, [32]byte{}, err
-		}
-		stateHash, err = source.StateMapHashWithError()
-		if err != nil {
-			return [32]byte{}, [32]byte{}, err
-		}
-		return txHash, stateHash, nil
-	}
-	return l.TxMapHash(), l.StateMapHash(), nil
+func ledgerMapHashes(l types.LedgerReader) (txHash, stateHash [32]byte) {
+	return l.TxMapHash(), l.StateMapHash()
 }
 
 func ledgerAmendmentRules(l types.LedgerReader) (*amendment.Rules, error) {

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	ledgerselector "github.com/LeJamon/go-xrpl/internal/ledger/selector"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
@@ -41,6 +42,43 @@ func rpcTransactionSubmissionError(operation string, err error) *types.RpcError 
 func rpcDBDeserializationError(operation string, err error) *types.RpcError {
 	logRpcError(operation, err)
 	return types.RpcErrorDBDeserialization()
+}
+
+// ledgerMapHashes reads both ledger roots without allowing a production
+// adapter's SHAMap error to be replaced with a zero hash. Legacy readers keep
+// the value-only methods, so the error-aware facet is optional for test and
+// embedded implementations.
+func ledgerMapHashes(l types.LedgerReader) (txHash, stateHash [32]byte, err error) {
+	if source, ok := l.(types.LedgerMapHashSource); ok {
+		txHash, err = source.TxMapHashWithError()
+		if err != nil {
+			return [32]byte{}, [32]byte{}, err
+		}
+		stateHash, err = source.StateMapHashWithError()
+		if err != nil {
+			return [32]byte{}, [32]byte{}, err
+		}
+		return txHash, stateHash, nil
+	}
+	return l.TxMapHash(), l.StateMapHash(), nil
+}
+
+func ledgerAmendmentRules(l types.LedgerReader) (*amendment.Rules, error) {
+	if source, ok := l.(types.LedgerAmendmentRulesErrorSource); ok {
+		rules, err := source.LedgerAmendmentRulesWithError()
+		if err != nil {
+			return nil, err
+		}
+		if rules != nil {
+			return rules, nil
+		}
+	}
+	if source, ok := l.(types.LedgerAmendmentRulesSource); ok {
+		if rules := source.LedgerAmendmentRules(); rules != nil {
+			return rules, nil
+		}
+	}
+	return amendment.EmptyRules(), nil
 }
 
 // RequireLedgerService checks that the ledger service is available

--- a/internal/rpc/handlers/ledger.go
+++ b/internal/rpc/handlers/ledger.go
@@ -219,10 +219,7 @@ func buildLedgerJSON(l types.LedgerReader, binaryMode, full bool, apiVersion int
 		if !l.IsClosed() {
 			return map[string]any{"closed": false}, nil
 		}
-		txHash, stateHash, err := ledgerMapHashes(l)
-		if err != nil {
-			return nil, err
-		}
+		txHash, stateHash := ledgerMapHashes(l)
 		return map[string]any{
 			"closed": true,
 			"ledger_data": strings.ToUpper(hex.EncodeToString(ledgerheader.AddRaw(ledgerheader.LedgerHeader{
@@ -256,10 +253,7 @@ func buildLedgerJSON(l types.LedgerReader, binaryMode, full bool, apiVersion int
 		return result, nil
 	}
 
-	txHash, stateHash, err := ledgerMapHashes(l)
-	if err != nil {
-		return nil, err
-	}
+	txHash, stateHash := ledgerMapHashes(l)
 	result["ledger_hash"] = FormatLedgerHash(l.Hash())
 	result["transaction_hash"] = FormatLedgerHash(txHash)
 	result["account_hash"] = FormatLedgerHash(stateHash)
@@ -386,17 +380,9 @@ func ledgerDefaultResponse(ctx *types.RpcContext) (map[string]any, *types.RpcErr
 	if err != nil || open == nil {
 		return nil, types.RpcErrorLgrNotFound("ledgerNotFound")
 	}
-	closedJSON, err := buildLedgerSummaryJSON(closed, true, ctx.ApiVersion)
-	if err != nil {
-		return nil, rpcInternalError("ledger: closed ledger map root lookup failed", err)
-	}
-	openJSON, err := buildLedgerSummaryJSON(open, false, ctx.ApiVersion)
-	if err != nil {
-		return nil, rpcInternalError("ledger: open ledger map root lookup failed", err)
-	}
 	return map[string]any{
-		"closed": closedJSON,
-		"open":   openJSON,
+		"closed": buildLedgerSummaryJSON(closed, true, ctx.ApiVersion),
+		"open":   buildLedgerSummaryJSON(open, false, ctx.ApiVersion),
 	}, nil
 }
 

--- a/internal/rpc/handlers/ledger.go
+++ b/internal/rpc/handlers/ledger.go
@@ -83,7 +83,10 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 		request.Accounts = true
 	}
 
-	ledgerInfo := buildLedgerJSON(targetLedger, request.Binary, request.Full, ctx.ApiVersion)
+	ledgerInfo, ledgerInfoErr := buildLedgerJSON(targetLedger, request.Binary, request.Full, ctx.ApiVersion)
+	if ledgerInfoErr != nil {
+		return nil, rpcInternalError("ledger: map root lookup failed", ledgerInfoErr)
+	}
 	ledgerHash := FormatLedgerHash(targetLedger.Hash())
 
 	closeTimeSec := targetLedger.CloseTime()
@@ -106,10 +109,15 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 	if request.Transactions {
 		var txList []any
 		apiVersion := ctx.ApiVersion
+		var decodeErr error
 		visit := func(txHashKey [32]byte, txData []byte) bool {
 			hashStr := strings.ToUpper(hex.EncodeToString(txHashKey[:]))
 			if request.Expand {
-				txEntry := expandTransaction(txData, hashStr, request.Binary, apiVersion, syntheticContext)
+				txEntry, err := expandTransaction(txData, hashStr, request.Binary, apiVersion, syntheticContext)
+				if err != nil {
+					decodeErr = err
+					return false
+				}
 				// Add per-entry context fields for v2+
 				if apiVersion > 1 && !request.Binary {
 					if targetLedger.IsClosed() {
@@ -124,7 +132,11 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 					}
 				}
 				if ownerFundsView != nil {
-					storedTx, _ := decodeTxBlob(txData)
+					storedTx, err := decodeTxBlob(txData)
+					if err != nil {
+						decodeErr = err
+						return false
+					}
 					if !annotateOwnerFunds(txEntry, storedTx.TxJSON, ownerFundsView, ownerFundsReserveBase, ownerFundsReserveInc) {
 						return false
 					}
@@ -145,6 +157,13 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 		}
 		if iterErr != nil {
 			return nil, rpcInternalError("ledger: transaction iteration failed", iterErr)
+		}
+		if decodeErr != nil {
+			// LedgerToJson treats a malformed stored transaction as a corrupt
+			// leaf, logs it, and returns the entries decoded before that leaf.
+			// Keep that partial-success behavior instead of turning the entire
+			// ledger response into a database-deserialization RPC error.
+			logRpcError("ledger: transaction decoding failed", decodeErr)
 		}
 		if txList == nil {
 			txList = []any{}
@@ -195,10 +214,14 @@ func (m *LedgerMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 	return response, nil
 }
 
-func buildLedgerJSON(l types.LedgerReader, binaryMode, full bool, apiVersion int) map[string]any {
+func buildLedgerJSON(l types.LedgerReader, binaryMode, full bool, apiVersion int) (map[string]any, error) {
 	if binaryMode {
 		if !l.IsClosed() {
-			return map[string]any{"closed": false}
+			return map[string]any{"closed": false}, nil
+		}
+		txHash, stateHash, err := ledgerMapHashes(l)
+		if err != nil {
+			return nil, err
 		}
 		return map[string]any{
 			"closed": true,
@@ -206,14 +229,14 @@ func buildLedgerJSON(l types.LedgerReader, binaryMode, full bool, apiVersion int
 				LedgerIndex:         l.Sequence(),
 				ParentCloseTime:     protocol.FromRippleTime(uint32(max(l.ParentCloseTime(), 0))),
 				ParentHash:          l.ParentHash(),
-				TxHash:              l.TxMapHash(),
-				AccountHash:         l.StateMapHash(),
+				TxHash:              txHash,
+				AccountHash:         stateHash,
 				Drops:               l.TotalDrops(),
 				CloseFlags:          l.CloseFlags(),
 				CloseTimeResolution: uint8(l.CloseTimeResolution()),
 				CloseTime:           protocol.FromRippleTime(uint32(max(l.CloseTime(), 0))),
 			}, false))),
-		}
+		}, nil
 	}
 
 	parentHash := l.ParentHash()
@@ -230,12 +253,16 @@ func buildLedgerJSON(l types.LedgerReader, binaryMode, full bool, apiVersion int
 		result["closed"] = true
 	} else if !full {
 		result["closed"] = false
-		return result
+		return result, nil
 	}
 
+	txHash, stateHash, err := ledgerMapHashes(l)
+	if err != nil {
+		return nil, err
+	}
 	result["ledger_hash"] = FormatLedgerHash(l.Hash())
-	result["transaction_hash"] = FormatLedgerHash(l.TxMapHash())
-	result["account_hash"] = FormatLedgerHash(l.StateMapHash())
+	result["transaction_hash"] = FormatLedgerHash(txHash)
+	result["account_hash"] = FormatLedgerHash(stateHash)
 	result["total_coins"] = strconv.FormatUint(l.TotalDrops(), 10)
 	result["close_flags"] = l.CloseFlags()
 	result["parent_close_time"] = l.ParentCloseTime()
@@ -249,7 +276,7 @@ func buildLedgerJSON(l types.LedgerReader, binaryMode, full bool, apiVersion int
 			result["close_time_estimated"] = true
 		}
 	}
-	return result
+	return result, nil
 }
 
 func addLedgerTypeWarning(response map[string]any, params json.RawMessage) {
@@ -359,9 +386,17 @@ func ledgerDefaultResponse(ctx *types.RpcContext) (map[string]any, *types.RpcErr
 	if err != nil || open == nil {
 		return nil, types.RpcErrorLgrNotFound("ledgerNotFound")
 	}
+	closedJSON, err := buildLedgerSummaryJSON(closed, true, ctx.ApiVersion)
+	if err != nil {
+		return nil, rpcInternalError("ledger: closed ledger map root lookup failed", err)
+	}
+	openJSON, err := buildLedgerSummaryJSON(open, false, ctx.ApiVersion)
+	if err != nil {
+		return nil, rpcInternalError("ledger: open ledger map root lookup failed", err)
+	}
 	return map[string]any{
-		"closed": buildLedgerSummaryJSON(closed, true, ctx.ApiVersion),
-		"open":   buildLedgerSummaryJSON(open, false, ctx.ApiVersion),
+		"closed": closedJSON,
+		"open":   openJSON,
 	}, nil
 }
 
@@ -618,19 +653,15 @@ func expandTransaction(
 	binary bool,
 	apiVersion int,
 	ctx SyntheticMetadataContext,
-) map[string]any {
+) (map[string]any, error) {
 	storedTx, err := decodeTxBlob(txData)
-	if err == nil && storedTx.TxJSON != nil {
+	if err != nil {
+		return nil, err
+	}
+	if storedTx.TxJSON != nil {
 		return expandStoredTransaction(storedTx, hashStr, binary, apiVersion, ctx)
 	}
-
-	// Cannot decode: return raw blob
-	txEntry := map[string]any{}
-	txEntry["tx_blob"] = strings.ToUpper(hex.EncodeToString(txData))
-	if apiVersion > 1 || !binary {
-		txEntry["hash"] = hashStr
-	}
-	return txEntry
+	return nil, fmt.Errorf("stored transaction has no transaction JSON")
 }
 
 // expandStoredTransaction formats a JSON-stored transaction for the response.
@@ -640,7 +671,7 @@ func expandStoredTransaction(
 	binary bool,
 	apiVersion int,
 	ctx SyntheticMetadataContext,
-) map[string]any {
+) (map[string]any, error) {
 	txEntry := map[string]any{}
 
 	if binary {
@@ -648,6 +679,8 @@ func expandStoredTransaction(
 		txBlob, err := binarycodec.Encode(storedTx.TxJSON)
 		if err == nil {
 			txEntry["tx_blob"] = txBlob
+		} else {
+			return nil, fmt.Errorf("encode transaction: %w", err)
 		}
 		if apiVersion > 1 {
 			txEntry["hash"] = hashStr
@@ -661,9 +694,11 @@ func expandStoredTransaction(
 				} else {
 					txEntry["meta"] = metaBlob
 				}
+			} else {
+				return nil, fmt.Errorf("encode transaction metadata: %w", err)
 			}
 		}
-		return txEntry
+		return txEntry, nil
 	}
 
 	if apiVersion > 1 {
@@ -682,7 +717,7 @@ func expandStoredTransaction(
 			txEntry["metaData"] = storedTx.Meta
 		}
 	}
-	return txEntry
+	return txEntry, nil
 }
 
 func injectExpandedLedgerDeliveredAmount(txJSON, meta map[string]any, ctx SyntheticMetadataContext) {

--- a/internal/rpc/handlers/ledger_adapter_errors_test.go
+++ b/internal/rpc/handlers/ledger_adapter_errors_test.go
@@ -9,13 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLedgerMapHashesPropagatesAdapterFailure(t *testing.T) {
-	wantErr := errors.New("state map read failed")
-	reader := failingLedgerReader{err: wantErr}
-	_, _, err := ledgerMapHashes(reader)
-	require.ErrorIs(t, err, wantErr)
-}
-
 func TestLedgerAmendmentRulesPropagatesAdapterFailure(t *testing.T) {
 	wantErr := errors.New("amendment rules read failed")
 	reader := failingLedgerReader{rulesErr: wantErr}
@@ -25,16 +18,7 @@ func TestLedgerAmendmentRulesPropagatesAdapterFailure(t *testing.T) {
 
 type failingLedgerReader struct {
 	types.LedgerReader
-	err      error
 	rulesErr error
-}
-
-func (r failingLedgerReader) TxMapHashWithError() ([32]byte, error) {
-	return [32]byte{}, r.err
-}
-
-func (r failingLedgerReader) StateMapHashWithError() ([32]byte, error) {
-	return [32]byte{}, r.err
 }
 
 func (r failingLedgerReader) LedgerAmendmentRulesWithError() (*amendment.Rules, error) {

--- a/internal/rpc/handlers/ledger_adapter_errors_test.go
+++ b/internal/rpc/handlers/ledger_adapter_errors_test.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLedgerMapHashesPropagatesAdapterFailure(t *testing.T) {
+	wantErr := errors.New("state map read failed")
+	reader := failingLedgerReader{err: wantErr}
+	_, _, err := ledgerMapHashes(reader)
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestLedgerAmendmentRulesPropagatesAdapterFailure(t *testing.T) {
+	wantErr := errors.New("amendment rules read failed")
+	reader := failingLedgerReader{rulesErr: wantErr}
+	_, err := ledgerAmendmentRules(reader)
+	require.ErrorIs(t, err, wantErr)
+}
+
+type failingLedgerReader struct {
+	types.LedgerReader
+	err      error
+	rulesErr error
+}
+
+func (r failingLedgerReader) TxMapHashWithError() ([32]byte, error) {
+	return [32]byte{}, r.err
+}
+
+func (r failingLedgerReader) StateMapHashWithError() ([32]byte, error) {
+	return [32]byte{}, r.err
+}
+
+func (r failingLedgerReader) LedgerAmendmentRulesWithError() (*amendment.Rules, error) {
+	return nil, r.rulesErr
+}

--- a/internal/rpc/handlers/ledger_data.go
+++ b/internal/rpc/handlers/ledger_data.go
@@ -141,7 +141,11 @@ func (m *LedgerDataMethod) Handle(ctx *types.RpcContext, params json.RawMessage)
 
 	// Include ledger header info on first query (when no marker was provided)
 	if !hasMarker {
-		response["ledger"] = buildLedgerJSON(targetLedger, binaryMode, false, ctx.ApiVersion)
+		ledgerJSON, ledgerErr := buildLedgerJSON(targetLedger, binaryMode, false, ctx.ApiVersion)
+		if ledgerErr != nil {
+			return nil, rpcInternalError("ledger_data: map root lookup failed", ledgerErr)
+		}
+		response["ledger"] = ledgerJSON
 	}
 
 	if result.Marker != "" {

--- a/internal/rpc/handlers/ledger_header.go
+++ b/internal/rpc/handlers/ledger_header.go
@@ -56,12 +56,16 @@ func (m *LedgerHeaderMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 	//   uint32 seq, uint64 drops, hash256 parentHash, hash256 txHash,
 	//   hash256 accountHash, uint32 parentCloseTime, uint32 closeTime,
 	//   uint8 closeTimeResolution, uint8 closeFlags
+	txHash, stateHash, hashErr := ledgerMapHashes(targetLedger)
+	if hashErr != nil {
+		return nil, rpcInternalError("ledger_header: map root lookup failed", hashErr)
+	}
 	ledgerData := ledgerheader.AddRaw(ledgerheader.LedgerHeader{
 		LedgerIndex:         targetLedger.Sequence(),
 		ParentCloseTime:     protocol.FromRippleTime(uint32(max(targetLedger.ParentCloseTime(), 0))),
 		ParentHash:          targetLedger.ParentHash(),
-		TxHash:              targetLedger.TxMapHash(),
-		AccountHash:         targetLedger.StateMapHash(),
+		TxHash:              txHash,
+		AccountHash:         stateHash,
 		Drops:               targetLedger.TotalDrops(),
 		CloseFlags:          targetLedger.CloseFlags(),
 		CloseTimeResolution: uint8(targetLedger.CloseTimeResolution()),
@@ -71,7 +75,10 @@ func (m *LedgerHeaderMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 
 	// Build the nested "ledger" JSON object (equivalent to addJson with options=0).
 	// Reference: rippled LedgerToJson.cpp fillJson()
-	ledgerObj := buildLedgerHeaderJSON(targetLedger, closed)
+	ledgerObj, err := buildLedgerHeaderJSON(targetLedger, closed)
+	if err != nil {
+		return nil, rpcInternalError("ledger_header: map root lookup failed", err)
+	}
 	response["ledger"] = ledgerObj
 
 	return response, nil
@@ -80,11 +87,11 @@ func (m *LedgerHeaderMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 // buildLedgerHeaderJSON builds the "ledger" JSON object matching rippled's
 // fillJson(json, closed, info, bFull=false, apiVersion=1).
 // Reference: rippled/src/xrpld/app/ledger/detail/LedgerToJson.cpp fillJson()
-func buildLedgerHeaderJSON(lr types.LedgerReader, closed bool) map[string]any {
+func buildLedgerHeaderJSON(lr types.LedgerReader, closed bool) (map[string]any, error) {
 	return buildLedgerSummaryJSON(lr, closed, types.ApiVersion1)
 }
 
-func buildLedgerSummaryJSON(lr types.LedgerReader, closed bool, apiVersion int) map[string]any {
+func buildLedgerSummaryJSON(lr types.LedgerReader, closed bool, apiVersion int) (map[string]any, error) {
 	ledgerObj := map[string]any{}
 
 	// parent_hash is always present
@@ -99,15 +106,17 @@ func buildLedgerSummaryJSON(lr types.LedgerReader, closed bool, apiVersion int) 
 
 	if !closed {
 		ledgerObj["closed"] = false
-		return ledgerObj
+		return ledgerObj, nil
 	}
 
 	// For closed ledgers, include full header fields
 	ledgerObj["closed"] = true
 
 	hash := lr.Hash()
-	txHash := lr.TxMapHash()
-	stateHash := lr.StateMapHash()
+	txHash, stateHash, err := ledgerMapHashes(lr)
+	if err != nil {
+		return nil, err
+	}
 
 	ledgerObj["ledger_hash"] = FormatLedgerHash(hash)
 	ledgerObj["transaction_hash"] = FormatLedgerHash(txHash)
@@ -135,7 +144,7 @@ func buildLedgerSummaryJSON(lr types.LedgerReader, closed bool, apiVersion int) 
 		}
 	}
 
-	return ledgerObj
+	return ledgerObj, nil
 }
 
 func (m *LedgerHeaderMethod) SupportedApiVersions() []int {

--- a/internal/rpc/handlers/ledger_header.go
+++ b/internal/rpc/handlers/ledger_header.go
@@ -56,10 +56,7 @@ func (m *LedgerHeaderMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 	//   uint32 seq, uint64 drops, hash256 parentHash, hash256 txHash,
 	//   hash256 accountHash, uint32 parentCloseTime, uint32 closeTime,
 	//   uint8 closeTimeResolution, uint8 closeFlags
-	txHash, stateHash, hashErr := ledgerMapHashes(targetLedger)
-	if hashErr != nil {
-		return nil, rpcInternalError("ledger_header: map root lookup failed", hashErr)
-	}
+	txHash, stateHash := ledgerMapHashes(targetLedger)
 	ledgerData := ledgerheader.AddRaw(ledgerheader.LedgerHeader{
 		LedgerIndex:         targetLedger.Sequence(),
 		ParentCloseTime:     protocol.FromRippleTime(uint32(max(targetLedger.ParentCloseTime(), 0))),
@@ -75,11 +72,7 @@ func (m *LedgerHeaderMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 
 	// Build the nested "ledger" JSON object (equivalent to addJson with options=0).
 	// Reference: rippled LedgerToJson.cpp fillJson()
-	ledgerObj, err := buildLedgerHeaderJSON(targetLedger, closed)
-	if err != nil {
-		return nil, rpcInternalError("ledger_header: map root lookup failed", err)
-	}
-	response["ledger"] = ledgerObj
+	response["ledger"] = buildLedgerHeaderJSON(targetLedger, closed)
 
 	return response, nil
 }
@@ -87,11 +80,11 @@ func (m *LedgerHeaderMethod) Handle(ctx *types.RpcContext, params json.RawMessag
 // buildLedgerHeaderJSON builds the "ledger" JSON object matching rippled's
 // fillJson(json, closed, info, bFull=false, apiVersion=1).
 // Reference: rippled/src/xrpld/app/ledger/detail/LedgerToJson.cpp fillJson()
-func buildLedgerHeaderJSON(lr types.LedgerReader, closed bool) (map[string]any, error) {
+func buildLedgerHeaderJSON(lr types.LedgerReader, closed bool) map[string]any {
 	return buildLedgerSummaryJSON(lr, closed, types.ApiVersion1)
 }
 
-func buildLedgerSummaryJSON(lr types.LedgerReader, closed bool, apiVersion int) (map[string]any, error) {
+func buildLedgerSummaryJSON(lr types.LedgerReader, closed bool, apiVersion int) map[string]any {
 	ledgerObj := map[string]any{}
 
 	// parent_hash is always present
@@ -106,17 +99,14 @@ func buildLedgerSummaryJSON(lr types.LedgerReader, closed bool, apiVersion int) 
 
 	if !closed {
 		ledgerObj["closed"] = false
-		return ledgerObj, nil
+		return ledgerObj
 	}
 
 	// For closed ledgers, include full header fields
 	ledgerObj["closed"] = true
 
 	hash := lr.Hash()
-	txHash, stateHash, err := ledgerMapHashes(lr)
-	if err != nil {
-		return nil, err
-	}
+	txHash, stateHash := ledgerMapHashes(lr)
 
 	ledgerObj["ledger_hash"] = FormatLedgerHash(hash)
 	ledgerObj["transaction_hash"] = FormatLedgerHash(txHash)
@@ -144,7 +134,7 @@ func buildLedgerSummaryJSON(lr types.LedgerReader, closed bool, apiVersion int) 
 		}
 	}
 
-	return ledgerObj, nil
+	return ledgerObj
 }
 
 func (m *LedgerHeaderMethod) SupportedApiVersions() []int {

--- a/internal/rpc/handlers/ledger_request.go
+++ b/internal/rpc/handlers/ledger_request.go
@@ -16,11 +16,13 @@ import (
 // ledgerInfoJSON renders the closed-ledger header fields shared by the `ledger`
 // and `ledger_request` RPCs, mirroring rippled's LedgerFill at info level 0
 // (LedgerToJson.cpp fillJson).
-func ledgerInfoJSON(l types.LedgerReader) map[string]any {
+func ledgerInfoJSON(l types.LedgerReader) (map[string]any, error) {
 	hash := l.Hash()
 	parent := l.ParentHash()
-	txHash := l.TxMapHash()
-	stateHash := l.StateMapHash()
+	txHash, stateHash, err := ledgerMapHashes(l)
+	if err != nil {
+		return nil, err
+	}
 	closeTimeSec := l.CloseTime()
 	closeTime := protocol.FromRippleTime(uint32(max(closeTimeSec, 0)))
 	seqStr := strconv.FormatUint(uint64(l.Sequence()), 10)
@@ -42,7 +44,7 @@ func ledgerInfoJSON(l types.LedgerReader) map[string]any {
 		"totalCoins":            strconv.FormatUint(l.TotalDrops(), 10),
 		"total_coins":           strconv.FormatUint(l.TotalDrops(), 10),
 		"transaction_hash":      strings.ToUpper(hex.EncodeToString(txHash[:])),
-	}
+	}, nil
 }
 
 // LedgerRequestMethod handles the ledger_request RPC method: it returns a
@@ -90,7 +92,11 @@ func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 
 		l, err := getLedgerByHashContext(ctx.Context, ctx.Services.Ledger, targetHash)
 		if err == nil && l != nil {
-			return ledgerRequestSuccess(l), nil
+			result, resultErr := ledgerRequestSuccess(l)
+			if resultErr != nil {
+				return nil, rpcInternalError("ledger_request: map root lookup failed", resultErr)
+			}
+			return result, nil
 		}
 		if err != nil && !errors.Is(err, svcerr.ErrLedgerNotFound) {
 			return nil, rpcInternalError("ledger_request: hash lookup failed", err)
@@ -125,7 +131,11 @@ func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		targetSeq = uint32(idx)
 
 		if l, err := ctx.Services.Ledger.GetLedgerBySequence(targetSeq); err == nil && l != nil {
-			return ledgerRequestSuccess(l), nil
+			result, resultErr := ledgerRequestSuccess(l)
+			if resultErr != nil {
+				return nil, rpcInternalError("ledger_request: map root lookup failed", resultErr)
+			}
+			return result, nil
 		}
 	}
 
@@ -155,9 +165,13 @@ func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 
 // ledgerRequestSuccess builds the success response for a locally-available
 // ledger: {ledger_index, ledger} per rippled doLedgerRequest.
-func ledgerRequestSuccess(l types.LedgerReader) map[string]any {
+func ledgerRequestSuccess(l types.LedgerReader) (map[string]any, error) {
+	ledger, err := ledgerInfoJSON(l)
+	if err != nil {
+		return nil, err
+	}
 	return map[string]any{
 		"ledger_index": l.Sequence(),
-		"ledger":       ledgerInfoJSON(l),
-	}
+		"ledger":       ledger,
+	}, nil
 }

--- a/internal/rpc/handlers/ledger_request.go
+++ b/internal/rpc/handlers/ledger_request.go
@@ -16,13 +16,10 @@ import (
 // ledgerInfoJSON renders the closed-ledger header fields shared by the `ledger`
 // and `ledger_request` RPCs, mirroring rippled's LedgerFill at info level 0
 // (LedgerToJson.cpp fillJson).
-func ledgerInfoJSON(l types.LedgerReader) (map[string]any, error) {
+func ledgerInfoJSON(l types.LedgerReader) map[string]any {
 	hash := l.Hash()
 	parent := l.ParentHash()
-	txHash, stateHash, err := ledgerMapHashes(l)
-	if err != nil {
-		return nil, err
-	}
+	txHash, stateHash := ledgerMapHashes(l)
 	closeTimeSec := l.CloseTime()
 	closeTime := protocol.FromRippleTime(uint32(max(closeTimeSec, 0)))
 	seqStr := strconv.FormatUint(uint64(l.Sequence()), 10)
@@ -44,7 +41,7 @@ func ledgerInfoJSON(l types.LedgerReader) (map[string]any, error) {
 		"totalCoins":            strconv.FormatUint(l.TotalDrops(), 10),
 		"total_coins":           strconv.FormatUint(l.TotalDrops(), 10),
 		"transaction_hash":      strings.ToUpper(hex.EncodeToString(txHash[:])),
-	}, nil
+	}
 }
 
 // LedgerRequestMethod handles the ledger_request RPC method: it returns a
@@ -92,11 +89,7 @@ func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 
 		l, err := getLedgerByHashContext(ctx.Context, ctx.Services.Ledger, targetHash)
 		if err == nil && l != nil {
-			result, resultErr := ledgerRequestSuccess(l)
-			if resultErr != nil {
-				return nil, rpcInternalError("ledger_request: map root lookup failed", resultErr)
-			}
-			return result, nil
+			return ledgerRequestSuccess(l), nil
 		}
 		if err != nil && !errors.Is(err, svcerr.ErrLedgerNotFound) {
 			return nil, rpcInternalError("ledger_request: hash lookup failed", err)
@@ -131,11 +124,7 @@ func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 		targetSeq = uint32(idx)
 
 		if l, err := ctx.Services.Ledger.GetLedgerBySequence(targetSeq); err == nil && l != nil {
-			result, resultErr := ledgerRequestSuccess(l)
-			if resultErr != nil {
-				return nil, rpcInternalError("ledger_request: map root lookup failed", resultErr)
-			}
-			return result, nil
+			return ledgerRequestSuccess(l), nil
 		}
 	}
 
@@ -165,13 +154,9 @@ func (m *LedgerRequestMethod) Handle(ctx *types.RpcContext, params json.RawMessa
 
 // ledgerRequestSuccess builds the success response for a locally-available
 // ledger: {ledger_index, ledger} per rippled doLedgerRequest.
-func ledgerRequestSuccess(l types.LedgerReader) (map[string]any, error) {
-	ledger, err := ledgerInfoJSON(l)
-	if err != nil {
-		return nil, err
-	}
+func ledgerRequestSuccess(l types.LedgerReader) map[string]any {
 	return map[string]any{
 		"ledger_index": l.Sequence(),
-		"ledger":       ledger,
-	}, nil
+		"ledger":       ledgerInfoJSON(l),
+	}
 }

--- a/internal/rpc/handlers/synthetic_meta_test.go
+++ b/internal/rpc/handlers/synthetic_meta_test.go
@@ -222,17 +222,18 @@ func TestExpandStoredTransactionSyntheticMetadata(t *testing.T) {
 		{name: "api v2", apiVersion: 2, metaKey: "meta"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			response := expandStoredTransaction(StoredTransaction{
+			response, err := expandStoredTransaction(StoredTransaction{
 				TxJSON: map[string]any{"TransactionType": "MPTokenIssuanceCreate"},
 				Meta:   newMPTMeta(),
 			}, strings.Repeat("0", 64), false, tc.apiVersion, modernSyntheticMetadataContext())
+			require.NoError(t, err)
 			meta := response[tc.metaKey].(map[string]any)
 			assert.Equal(t, want, meta["mpt_issuance_id"])
 		})
 	}
 
 	offerID := strings.Repeat("A", 64)
-	response := expandStoredTransaction(StoredTransaction{
+	response, err := expandStoredTransaction(StoredTransaction{
 		TxJSON: map[string]any{"TransactionType": "NFTokenCreateOffer"},
 		Meta: map[string]any{
 			"TransactionResult": "tesSUCCESS",
@@ -244,6 +245,7 @@ func TestExpandStoredTransactionSyntheticMetadata(t *testing.T) {
 			},
 		},
 	}, strings.Repeat("0", 64), false, 2, modernSyntheticMetadataContext())
+	require.NoError(t, err)
 	assert.NotContains(t, response["meta"].(map[string]any), "offer_id")
 }
 
@@ -256,32 +258,37 @@ func TestExpandStoredTransactionProjection(t *testing.T) {
 		}
 	}
 
-	v1 := expandStoredTransaction(newPayment(), hash, false, 1, modernSyntheticMetadataContext())
+	v1, err := expandStoredTransaction(newPayment(), hash, false, 1, modernSyntheticMetadataContext())
+	require.NoError(t, err)
 	assert.Equal(t, "100", v1["Amount"])
 	assert.Equal(t, "100", v1["DeliverMax"])
 	assert.Equal(t, hash, v1["hash"])
 	assert.Equal(t, "100", v1["metaData"].(map[string]any)["delivered_amount"])
 
-	v2 := expandStoredTransaction(newPayment(), hash, false, 2, modernSyntheticMetadataContext())
+	v2, err := expandStoredTransaction(newPayment(), hash, false, 2, modernSyntheticMetadataContext())
+	require.NoError(t, err)
 	v2Tx := v2["tx_json"].(map[string]any)
 	assert.NotContains(t, v2Tx, "Amount")
 	assert.Equal(t, "100", v2Tx["DeliverMax"])
 	assert.Equal(t, hash, v2["hash"])
 	assert.Equal(t, "100", v2["meta"].(map[string]any)["delivered_amount"])
 
-	v1Binary := expandStoredTransaction(newPayment(), hash, true, 1, modernSyntheticMetadataContext())
+	v1Binary, err := expandStoredTransaction(newPayment(), hash, true, 1, modernSyntheticMetadataContext())
+	require.NoError(t, err)
 	assert.NotContains(t, v1Binary, "hash")
-	v2Binary := expandStoredTransaction(newPayment(), hash, true, 2, modernSyntheticMetadataContext())
+	v2Binary, err := expandStoredTransaction(newPayment(), hash, true, 2, modernSyntheticMetadataContext())
+	require.NoError(t, err)
 	assert.Equal(t, hash, v2Binary["hash"])
 
-	v1Malformed := expandTransaction([]byte{0xFF}, hash, true, 1, modernSyntheticMetadataContext())
-	assert.NotContains(t, v1Malformed, "hash")
-	v2Malformed := expandTransaction([]byte{0xFF}, hash, true, 2, modernSyntheticMetadataContext())
-	assert.Equal(t, hash, v2Malformed["hash"])
+	_, err = expandTransaction([]byte{0xFF}, hash, true, 1, modernSyntheticMetadataContext())
+	assert.Error(t, err)
+	_, err = expandTransaction([]byte{0xFF}, hash, true, 2, modernSyntheticMetadataContext())
+	assert.Error(t, err)
 
-	accountDelete := expandStoredTransaction(StoredTransaction{
+	accountDelete, err := expandStoredTransaction(StoredTransaction{
 		TxJSON: map[string]any{"TransactionType": "AccountDelete"},
 		Meta:   map[string]any{"TransactionResult": "tesSUCCESS"},
 	}, hash, false, 2, modernSyntheticMetadataContext())
+	require.NoError(t, err)
 	assert.NotContains(t, accountDelete["meta"].(map[string]any), "delivered_amount")
 }

--- a/internal/rpc/handlers/tx_history.go
+++ b/internal/rpc/handlers/tx_history.go
@@ -44,13 +44,7 @@ func (m *TxHistoryMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 		// Decode to full JSON
 		decoded, err := decodeBinaryObject(tx.TxBlob)
 		if err != nil {
-			// Fallback to hex blob
-			txs[i] = map[string]any{
-				"hash":         hashStr,
-				"ledger_index": tx.LedgerIndex,
-				"tx_blob":      strings.ToUpper(hex.EncodeToString(tx.TxBlob)),
-			}
-			continue
+			return nil, rpcInternalError("tx_history: transaction decoding failed", err)
 		}
 
 		decoded["hash"] = hashStr

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -180,13 +180,33 @@ func (a *ledgerReaderAdapter) ParentCloseTime() int64 {
 }
 
 func (a *ledgerReaderAdapter) TxMapHash() [32]byte {
-	h, _ := a.l.TxMapHash()
-	return h
+	hash, err := a.TxMapHashWithError()
+	if err != nil {
+		return a.l.Header().TxHash
+	}
+	return hash
 }
 
 func (a *ledgerReaderAdapter) StateMapHash() [32]byte {
-	h, _ := a.l.StateMapHash()
-	return h
+	hash, err := a.StateMapHashWithError()
+	if err != nil {
+		return a.l.Header().AccountHash
+	}
+	return hash
+}
+
+func (a *ledgerReaderAdapter) TxMapHashWithError() ([32]byte, error) {
+	if _, err := a.l.TxMapHash(); err != nil {
+		return [32]byte{}, err
+	}
+	return a.l.Header().TxHash, nil
+}
+
+func (a *ledgerReaderAdapter) StateMapHashWithError() ([32]byte, error) {
+	if _, err := a.l.StateMapHash(); err != nil {
+		return [32]byte{}, err
+	}
+	return a.l.Header().AccountHash, nil
 }
 
 func (a *ledgerReaderAdapter) ForEachTransaction(fn func(txHash [32]byte, txData []byte) bool) error {
@@ -210,11 +230,15 @@ func (a *ledgerReaderAdapter) ForEachLedgerStateContext(ctx context.Context, fn 
 }
 
 func (a *ledgerReaderAdapter) LedgerAmendmentRules() *amendment.Rules {
-	rules, err := ledger.LoadAmendmentsFromLedger(a.l)
-	if err != nil || rules == nil {
-		return amendment.EmptyRules()
+	return a.l.Rules()
+}
+
+func (a *ledgerReaderAdapter) LedgerAmendmentRulesWithError() (*amendment.Rules, error) {
+	rules := a.l.Rules()
+	if rules == nil {
+		return nil, fmt.Errorf("ledger %d amendment rules unavailable", a.l.Sequence())
 	}
-	return rules
+	return rules, nil
 }
 
 // SubmitTransaction submits a transaction to the open ledger.
@@ -267,12 +291,20 @@ func (a *LedgerServiceAdapter) submitTransaction(txJSON []byte, txBlobHex string
 	// Use the original signed blob if provided, otherwise re-encode
 	var rawBlob []byte
 	if txBlobHex != "" {
-		rawBlob, _ = hex.DecodeString(txBlobHex)
+		var decodeErr error
+		rawBlob, decodeErr = hex.DecodeString(txBlobHex)
+		if decodeErr != nil {
+			return nil, fmt.Errorf("decode tx_blob: %w", decodeErr)
+		}
 	}
 	if rawBlob == nil {
 		if txMap, fErr := transaction.Flatten(); fErr == nil {
 			if hexStr, eErr := binarycodec.Encode(txMap); eErr == nil {
-				rawBlob, _ = hex.DecodeString(hexStr)
+				var decodeErr error
+				rawBlob, decodeErr = hex.DecodeString(hexStr)
+				if decodeErr != nil {
+					return nil, fmt.Errorf("decode encoded transaction: %w", decodeErr)
+				}
 			}
 		}
 	}
@@ -280,7 +312,11 @@ func (a *LedgerServiceAdapter) submitTransaction(txJSON []byte, txBlobHex string
 		var jsonMap map[string]any
 		if jErr := json.Unmarshal(txJSON, &jsonMap); jErr == nil {
 			if hexStr, eErr := binarycodec.Encode(jsonMap); eErr == nil {
-				rawBlob, _ = hex.DecodeString(hexStr)
+				var decodeErr error
+				rawBlob, decodeErr = hex.DecodeString(hexStr)
+				if decodeErr != nil {
+					return nil, fmt.Errorf("decode encoded transaction: %w", decodeErr)
+				}
 			}
 		}
 	}

--- a/internal/rpc/ledger_adapter.go
+++ b/internal/rpc/ledger_adapter.go
@@ -180,33 +180,11 @@ func (a *ledgerReaderAdapter) ParentCloseTime() int64 {
 }
 
 func (a *ledgerReaderAdapter) TxMapHash() [32]byte {
-	hash, err := a.TxMapHashWithError()
-	if err != nil {
-		return a.l.Header().TxHash
-	}
-	return hash
+	return a.l.Header().TxHash
 }
 
 func (a *ledgerReaderAdapter) StateMapHash() [32]byte {
-	hash, err := a.StateMapHashWithError()
-	if err != nil {
-		return a.l.Header().AccountHash
-	}
-	return hash
-}
-
-func (a *ledgerReaderAdapter) TxMapHashWithError() ([32]byte, error) {
-	if _, err := a.l.TxMapHash(); err != nil {
-		return [32]byte{}, err
-	}
-	return a.l.Header().TxHash, nil
-}
-
-func (a *ledgerReaderAdapter) StateMapHashWithError() ([32]byte, error) {
-	if _, err := a.l.StateMapHash(); err != nil {
-		return [32]byte{}, err
-	}
-	return a.l.Header().AccountHash, nil
+	return a.l.Header().AccountHash
 }
 
 func (a *ledgerReaderAdapter) ForEachTransaction(fn func(txHash [32]byte, txData []byte) bool) error {

--- a/internal/rpc/ledger_adapter_errors_test.go
+++ b/internal/rpc/ledger_adapter_errors_test.go
@@ -1,0 +1,114 @@
+package rpc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLedgerReaderAdapterPreservesHeaderRootsAndRules(t *testing.T) {
+	svc, err := service.New(service.Config{Standalone: true, GenesisConfig: genesis.DefaultConfig()})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	closed := svc.GetClosedLedger()
+	require.NotNil(t, closed)
+	reader, err := NewLedgerServiceAdapter(svc).GetLedgerBySequence(closed.Sequence())
+	require.NoError(t, err)
+
+	rootSource, ok := reader.(types.LedgerMapHashSource)
+	require.True(t, ok)
+	header := closed.Header()
+	txHash, err := rootSource.TxMapHashWithError()
+	require.NoError(t, err)
+	stateHash, err := rootSource.StateMapHashWithError()
+	require.NoError(t, err)
+	require.Equal(t, header.TxHash, txHash)
+	require.Equal(t, header.AccountHash, stateHash)
+	require.Equal(t, header.TxHash, reader.TxMapHash())
+	require.Equal(t, header.AccountHash, reader.StateMapHash())
+
+	rulesSource, ok := reader.(types.LedgerAmendmentRulesErrorSource)
+	require.True(t, ok)
+	rules, err := rulesSource.LedgerAmendmentRulesWithError()
+	require.NoError(t, err)
+	require.NotNil(t, rules)
+	require.Same(t, rules, reader.(types.LedgerAmendmentRulesSource).LedgerAmendmentRules())
+}
+
+func TestLedgerReaderAdapterValidatesOpenMapsButReturnsHeaderRoots(t *testing.T) {
+	svc, err := service.New(service.Config{Standalone: true, GenesisConfig: genesis.DefaultConfig()})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	open := svc.GetOpenLedger()
+	require.NotNil(t, open)
+	parent := svc.GetClosedLedger()
+	require.NotNil(t, parent)
+	header := open.Header()
+	parentHeader := parent.Header()
+	require.NotEqual(t, parentHeader.Hash, header.Hash)
+	require.Equal(t, [32]byte{}, header.TxHash)
+	require.Equal(t, [32]byte{}, header.AccountHash)
+	require.Zero(t, header.CloseFlags)
+
+	// Mutating an open view changes its live SHAMap roots, but does not change
+	// the reset provisional header roots exposed by ledger RPC responses.
+	require.NoError(t, open.AddTransaction([32]byte{0x01}, make([]byte, 12)))
+	require.NoError(t, open.Insert(keylet.Keylet{Key: [32]byte{0x02}}, make([]byte, 12)))
+	liveTxHash, err := open.TxMapHash()
+	require.NoError(t, err)
+	liveStateHash, err := open.StateMapHash()
+	require.NoError(t, err)
+	require.NotEqual(t, header.TxHash, liveTxHash)
+	require.NotEqual(t, header.AccountHash, liveStateHash)
+
+	reader := &ledgerReaderAdapter{l: open}
+	txHash, err := reader.TxMapHashWithError()
+	require.NoError(t, err)
+	stateHash, err := reader.StateMapHashWithError()
+	require.NoError(t, err)
+	require.Equal(t, header.TxHash, txHash)
+	require.Equal(t, header.AccountHash, stateHash)
+	require.Equal(t, header.TxHash, reader.TxMapHash())
+	require.Equal(t, header.AccountHash, reader.StateMapHash())
+}
+
+func TestLedgerServiceAdapterRejectsMalformedTransactionBlob(t *testing.T) {
+	svc, err := service.New(service.Config{Standalone: true, GenesisConfig: genesis.DefaultConfig()})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	txJSON := []byte(`{"TransactionType":"AccountSet","Account":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh","Fee":"10","Sequence":1,"SigningPubKey":""}`)
+	_, err = NewLedgerServiceAdapter(svc).SubmitTransaction(txJSON, "not-hex")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "decode tx_blob")
+}
+
+func TestLedgerMapHashSourceErrorsAreNotSuppressed(t *testing.T) {
+	wantErr := errors.New("SHAMap unavailable")
+	reader := failingLedgerReader{err: wantErr}
+	_, err := reader.TxMapHashWithError()
+	require.ErrorIs(t, err, wantErr)
+}
+
+type failingLedgerReader struct {
+	types.LedgerReader
+	err error
+}
+
+func (r failingLedgerReader) TxMapHashWithError() ([32]byte, error) {
+	return [32]byte{}, r.err
+}
+
+func (r failingLedgerReader) StateMapHashWithError() ([32]byte, error) {
+	return [32]byte{}, r.err
+}

--- a/internal/rpc/ledger_adapter_errors_test.go
+++ b/internal/rpc/ledger_adapter_errors_test.go
@@ -1,7 +1,6 @@
 package rpc
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
@@ -22,15 +21,7 @@ func TestLedgerReaderAdapterPreservesHeaderRootsAndRules(t *testing.T) {
 	reader, err := NewLedgerServiceAdapter(svc).GetLedgerBySequence(closed.Sequence())
 	require.NoError(t, err)
 
-	rootSource, ok := reader.(types.LedgerMapHashSource)
-	require.True(t, ok)
 	header := closed.Header()
-	txHash, err := rootSource.TxMapHashWithError()
-	require.NoError(t, err)
-	stateHash, err := rootSource.StateMapHashWithError()
-	require.NoError(t, err)
-	require.Equal(t, header.TxHash, txHash)
-	require.Equal(t, header.AccountHash, stateHash)
 	require.Equal(t, header.TxHash, reader.TxMapHash())
 	require.Equal(t, header.AccountHash, reader.StateMapHash())
 
@@ -42,7 +33,7 @@ func TestLedgerReaderAdapterPreservesHeaderRootsAndRules(t *testing.T) {
 	require.Same(t, rules, reader.(types.LedgerAmendmentRulesSource).LedgerAmendmentRules())
 }
 
-func TestLedgerReaderAdapterValidatesOpenMapsButReturnsHeaderRoots(t *testing.T) {
+func TestLedgerReaderAdapterReturnsOpenHeaderRoots(t *testing.T) {
 	svc, err := service.New(service.Config{Standalone: true, GenesisConfig: genesis.DefaultConfig()})
 	require.NoError(t, err)
 	require.NoError(t, svc.Start())
@@ -71,12 +62,6 @@ func TestLedgerReaderAdapterValidatesOpenMapsButReturnsHeaderRoots(t *testing.T)
 	require.NotEqual(t, header.AccountHash, liveStateHash)
 
 	reader := &ledgerReaderAdapter{l: open}
-	txHash, err := reader.TxMapHashWithError()
-	require.NoError(t, err)
-	stateHash, err := reader.StateMapHashWithError()
-	require.NoError(t, err)
-	require.Equal(t, header.TxHash, txHash)
-	require.Equal(t, header.AccountHash, stateHash)
 	require.Equal(t, header.TxHash, reader.TxMapHash())
 	require.Equal(t, header.AccountHash, reader.StateMapHash())
 }
@@ -91,24 +76,4 @@ func TestLedgerServiceAdapterRejectsMalformedTransactionBlob(t *testing.T) {
 	_, err = NewLedgerServiceAdapter(svc).SubmitTransaction(txJSON, "not-hex")
 	require.Error(t, err)
 	require.ErrorContains(t, err, "decode tx_blob")
-}
-
-func TestLedgerMapHashSourceErrorsAreNotSuppressed(t *testing.T) {
-	wantErr := errors.New("SHAMap unavailable")
-	reader := failingLedgerReader{err: wantErr}
-	_, err := reader.TxMapHashWithError()
-	require.ErrorIs(t, err, wantErr)
-}
-
-type failingLedgerReader struct {
-	types.LedgerReader
-	err error
-}
-
-func (r failingLedgerReader) TxMapHashWithError() ([32]byte, error) {
-	return [32]byte{}, r.err
-}
-
-func (r failingLedgerReader) StateMapHashWithError() ([32]byte, error) {
-	return [32]byte{}, r.err
 }

--- a/internal/rpc/ledger_header_test.go
+++ b/internal/rpc/ledger_header_test.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	ledgerheader "github.com/LeJamon/go-xrpl/internal/ledger/header"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/stretchr/testify/assert"
@@ -448,6 +451,77 @@ func TestLedgerHeaderOpenLedger(t *testing.T) {
 	// Open ledger should only have parent_hash, ledger_index, closed
 	assert.Contains(t, ledger, "parent_hash")
 	assert.Contains(t, ledger, "ledger_index")
+}
+
+func TestLedgerHeaderProductionOpenRootsAndFlags(t *testing.T) {
+	svc, err := service.New(service.Config{Standalone: true, GenesisConfig: genesis.DefaultConfig()})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+	open := svc.GetOpenLedger()
+	require.NotNil(t, open)
+
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: NewLedgerServiceAdapter(svc)},
+	}
+	result, rpcErr := (&handlers.LedgerHeaderMethod{}).Handle(ctx, json.RawMessage(`{"ledger_index":"current"}`))
+	require.Nil(t, rpcErr)
+	response := resultToMapHeader(t, result)
+	raw, err := hex.DecodeString(response["ledger_data"].(string))
+	require.NoError(t, err)
+	decoded, err := ledgerheader.DeserializeHeader(raw, false)
+	require.NoError(t, err)
+	require.Equal(t, [32]byte{}, decoded.TxHash)
+	require.Equal(t, [32]byte{}, decoded.AccountHash)
+	require.Zero(t, decoded.CloseFlags)
+
+	ctx.Role = types.RoleAdmin
+	ctx.Unlimited = true
+	result, rpcErr = (&handlers.LedgerMethod{}).Handle(ctx, json.RawMessage(`{"ledger_index":"current","full":true}`))
+	require.Nil(t, rpcErr)
+	ledgerResult := result.(map[string]any)["ledger"].(map[string]any)
+	require.Equal(t, handlers.FormatLedgerHash(open.Hash()), ledgerResult["ledger_hash"])
+	require.Equal(t, handlers.FormatLedgerHash([32]byte{}), ledgerResult["transaction_hash"])
+	require.Equal(t, handlers.FormatLedgerHash([32]byte{}), ledgerResult["account_hash"])
+	require.Zero(t, ledgerResult["close_flags"])
+}
+
+type ledgerHeaderMapErrorReader struct {
+	*mockLedgerReader
+	err error
+}
+
+func (r ledgerHeaderMapErrorReader) TxMapHashWithError() ([32]byte, error) {
+	return [32]byte{}, r.err
+}
+
+func (r ledgerHeaderMapErrorReader) StateMapHashWithError() ([32]byte, error) {
+	return [32]byte{}, r.err
+}
+
+func TestLedgerHeaderMapHashFailureReturnsInternal(t *testing.T) {
+	mock := &ledgerMock{mockLedgerService: newMockLedgerService()}
+	reader := ledgerHeaderMapErrorReader{
+		mockLedgerReader: newDefaultLedgerReader(2, true),
+		err:              errors.New("SHAMap unavailable"),
+	}
+	mock.getLedgerBySequenceFn = func(uint32) (types.LedgerReader, error) {
+		return reader, nil
+	}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: mock},
+	}
+
+	result, rpcErr := (&handlers.LedgerHeaderMethod{}).Handle(ctx, json.RawMessage(`{"ledger_index":2}`))
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
 }
 
 // TestLedgerHeaderCloseTimeEstimated tests the close_time_estimated field

--- a/internal/rpc/ledger_header_test.go
+++ b/internal/rpc/ledger_header_test.go
@@ -489,41 +489,6 @@ func TestLedgerHeaderProductionOpenRootsAndFlags(t *testing.T) {
 	require.Zero(t, ledgerResult["close_flags"])
 }
 
-type ledgerHeaderMapErrorReader struct {
-	*mockLedgerReader
-	err error
-}
-
-func (r ledgerHeaderMapErrorReader) TxMapHashWithError() ([32]byte, error) {
-	return [32]byte{}, r.err
-}
-
-func (r ledgerHeaderMapErrorReader) StateMapHashWithError() ([32]byte, error) {
-	return [32]byte{}, r.err
-}
-
-func TestLedgerHeaderMapHashFailureReturnsInternal(t *testing.T) {
-	mock := &ledgerMock{mockLedgerService: newMockLedgerService()}
-	reader := ledgerHeaderMapErrorReader{
-		mockLedgerReader: newDefaultLedgerReader(2, true),
-		err:              errors.New("SHAMap unavailable"),
-	}
-	mock.getLedgerBySequenceFn = func(uint32) (types.LedgerReader, error) {
-		return reader, nil
-	}
-	ctx := &types.RpcContext{
-		Context:    context.Background(),
-		Role:       types.RoleGuest,
-		ApiVersion: types.ApiVersion1,
-		Services:   &types.ServiceContainer{Ledger: mock},
-	}
-
-	result, rpcErr := (&handlers.LedgerHeaderMethod{}).Handle(ctx, json.RawMessage(`{"ledger_index":2}`))
-	assert.Nil(t, result)
-	require.NotNil(t, rpcErr)
-	assert.Equal(t, types.RpcINTERNAL, rpcErr.Code)
-}
-
 // TestLedgerHeaderCloseTimeEstimated tests the close_time_estimated field
 // when the LCFNoConsensusTime flag is set.
 func TestLedgerHeaderCloseTimeEstimated(t *testing.T) {

--- a/internal/rpc/ledger_test.go
+++ b/internal/rpc/ledger_test.go
@@ -491,12 +491,25 @@ func TestLedgerFullOption(t *testing.T) {
 	var txHash1, txHash2 [32]byte
 	txHash1[0] = 0x01
 	txHash2[0] = 0x02
+	storedTxData, err := json.Marshal(handlers.StoredTransaction{
+		TxJSON: map[string]any{
+			"TransactionType": "Payment",
+			"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination":     "rDsbeomae4FXwgQTJp9Rs64Qg9vDiTCdBv",
+			"Amount":          "100",
+			"Fee":             "10",
+			"Sequence":        1,
+			"SigningPubKey":   "",
+		},
+		Meta: map[string]any{"TransactionResult": "tesSUCCESS"},
+	})
+	require.NoError(t, err)
 	reader.transactions = []struct {
 		hash [32]byte
 		data []byte
 	}{
-		{hash: txHash1, data: []byte{0x01, 0x02, 0x03}},
-		{hash: txHash2, data: []byte{0x04, 0x05, 0x06}},
+		{hash: txHash1, data: storedTxData},
+		{hash: txHash2, data: storedTxData},
 	}
 
 	mock.getLedgerBySequenceFn = func(seq uint32) (types.LedgerReader, error) {
@@ -560,6 +573,51 @@ func TestLedgerFullOption(t *testing.T) {
 		assert.True(t, isMap, "With expand, transactions should be objects")
 		assert.Contains(t, txObj, "hash")
 	})
+}
+
+func TestLedgerExpandedTransactionsStopAtMalformedLeaf(t *testing.T) {
+	storedTxData, err := json.Marshal(handlers.StoredTransaction{
+		TxJSON: map[string]any{
+			"TransactionType": "Payment",
+			"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination":     "rDsbeomae4FXwgQTJp9Rs64Qg9vDiTCdBv",
+			"Amount":          "100",
+			"Fee":             "10",
+			"Sequence":        1,
+			"SigningPubKey":   "",
+		},
+		Meta: map[string]any{"TransactionResult": "tesSUCCESS"},
+	})
+	require.NoError(t, err)
+
+	reader := newDefaultLedgerReader(2, true)
+	reader.transactions = []struct {
+		hash [32]byte
+		data []byte
+	}{
+		{hash: [32]byte{1}, data: storedTxData},
+		{hash: [32]byte{2}, data: []byte{0xff}},
+		{hash: [32]byte{3}, data: storedTxData},
+	}
+	mock := &ledgerMock{mockLedgerService: newMockLedgerService()}
+	mock.getLedgerBySequenceFn = func(uint32) (types.LedgerReader, error) {
+		return reader, nil
+	}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion1,
+		Services:   &types.ServiceContainer{Ledger: mock},
+	}
+
+	result, rpcErr := (&handlers.LedgerMethod{}).Handle(ctx, json.RawMessage(`{"ledger_index":2,"transactions":true,"expand":true}`))
+	require.Nil(t, rpcErr)
+	response := result.(map[string]any)
+	ledgerResult := response["ledger"].(map[string]any)
+	txs := ledgerResult["transactions"].([]any)
+	require.Len(t, txs, 1)
+	first := txs[0].(map[string]any)
+	assert.Equal(t, "0100000000000000000000000000000000000000000000000000000000000000", first["hash"])
 }
 
 func TestLedgerExpandedDeliveredAmountHistoricalCloseTime(t *testing.T) {

--- a/internal/rpc/publisher_transaction_test.go
+++ b/internal/rpc/publisher_transaction_test.go
@@ -175,9 +175,10 @@ func TestPublishLedgerClosedFieldPresence(t *testing.T) {
 	conn.Subscriptions[types.SubLedger] = types.SubscriptionConfig{}
 	publisher := NewPublisher(manager)
 	event := &LedgerCloseEvent{
-		Type:        "ledgerClosed",
-		LedgerIndex: 42,
-		NetworkID:   0,
+		Type:             "ledgerClosed",
+		LedgerIndex:      42,
+		NetworkID:        0,
+		ValidatedLedgers: "1-42",
 	}
 	publisher.PublishLedgerClosed(event)
 	var payload map[string]json.RawMessage
@@ -189,6 +190,7 @@ func TestPublishLedgerClosedFieldPresence(t *testing.T) {
 	feeRef := uint64(10)
 	event.FeeRef = &feeRef
 	event.ValidatedLedgers = "1-42"
+	event.ValidatedLedgersPresent = true
 	publisher.PublishLedgerClosed(event)
 	require.NoError(t, json.Unmarshal(readPublisherTestEvent(t, conn), &payload))
 	require.Equal(t, "10", string(payload["fee_ref"]))

--- a/internal/rpc/rpcsub_test.go
+++ b/internal/rpc/rpcsub_test.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -352,7 +353,7 @@ func TestRPCSub_AccountsDontBlockRemoval(t *testing.T) {
 // only while XRPFees is disabled.
 func TestRPCSub_SubscribeAckCarriesLedgerInfo(t *testing.T) {
 	ws, services := newRPCSubTestServer(t)
-	ws.SetLedgerInfoProvider(stubLedgerInfoProvider{})
+	ws.SetLedgerInfoProvider(stubLedgerInfoProvider{ledgerAvailable: true})
 	sink := newRPCSubSink(t)
 
 	result, rpcErr := subscribeURL(t, services, `{"url":"`+sink.srv.URL+`","streams":["ledger"]}`)
@@ -374,7 +375,7 @@ func TestRPCSub_SubscribeAckCarriesLedgerInfo(t *testing.T) {
 // subLedger gate.
 func TestRPCSub_SubscribeAckOmitsFeeRefUnderXRPFees(t *testing.T) {
 	ws, services := newRPCSubTestServer(t)
-	ws.SetLedgerInfoProvider(stubLedgerInfoProvider{xrpFees: true})
+	ws.SetLedgerInfoProvider(stubLedgerInfoProvider{ledgerAvailable: true, xrpFees: true})
 	sink := newRPCSubSink(t)
 
 	result, rpcErr := subscribeURL(t, services, `{"url":"`+sink.srv.URL+`","streams":["ledger"]}`)
@@ -385,18 +386,120 @@ func TestRPCSub_SubscribeAckOmitsFeeRefUnderXRPFees(t *testing.T) {
 	require.Contains(t, ack, "network_id")
 }
 
-type stubLedgerInfoProvider struct{ xrpFees bool }
+func TestSubLedgerWireMatrix(t *testing.T) {
+	states := []string{"", "disconnected", "connected", "syncing", "tracking", "full", "proposing", "validating"}
+	for _, xrpFees := range []bool{false, true} {
+		for _, state := range states {
+			for _, needsNetworkLedger := range []bool{false, true} {
+				for _, networkID := range []uint32{0, 42} {
+					for _, complete := range []string{"", "1-2,4"} {
+						name := fmt.Sprintf("xrp_fees_%t/%s/needs_%t/network_%d/complete_%t", xrpFees, state, needsNetworkLedger, networkID, complete != "")
+						t.Run(name, func(t *testing.T) {
+							validatedLedgers := ""
+							validatedLedgersPresent := publishesValidatedLedgers(state) && !needsNetworkLedger
+							if validatedLedgersPresent {
+								validatedLedgers = complete
+							}
+							ws, _ := newRPCSubTestServer(t)
+							ws.SetLedgerInfoProvider(stubLedgerInfoProvider{
+								ledgerAvailable:         true,
+								xrpFees:                 xrpFees,
+								validatedLedgers:        validatedLedgers,
+								validatedLedgersPresent: validatedLedgersPresent,
+								networkID:               networkID,
+							})
+							ack := ws.buildSubscribeAck(&types.RpcContext{}, types.SubscriptionRequest{Streams: []types.SubscriptionType{types.SubLedger}})
+							got, err := json.Marshal(ack)
+							require.NoError(t, err)
+
+							want := `{"fee_base":10`
+							if !xrpFees {
+								want += `,"fee_ref":10`
+							}
+							want += fmt.Sprintf(`,"ledger_hash":"ABCD","ledger_index":42,"ledger_time":735000000,"network_id":%d,"reserve_base":10000000,"reserve_inc":2000000`, networkID)
+							if validatedLedgersPresent {
+								want += fmt.Sprintf(`,"validated_ledgers":"%s"`, validatedLedgers)
+							}
+							want += `}`
+							if string(got) != want {
+								t.Fatalf("subLedger JSON = %s, want %s", got, want)
+							}
+						})
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestSubLedgerWireMatrixWithoutValidatedLedger(t *testing.T) {
+	states := []string{"", "disconnected", "connected", "syncing", "tracking", "full", "proposing", "validating"}
+	for _, state := range states {
+		for _, needsNetworkLedger := range []bool{false, true} {
+			for _, networkID := range []uint32{0, 42} {
+				for _, complete := range []string{"", "1-2,4"} {
+					name := fmt.Sprintf("%s/needs_%t/network_%d/complete_%t", state, needsNetworkLedger, networkID, complete != "")
+					t.Run(name, func(t *testing.T) {
+						validatedLedgers := ""
+						validatedLedgersPresent := publishesValidatedLedgers(state) && !needsNetworkLedger
+						if validatedLedgersPresent {
+							validatedLedgers = complete
+						}
+						ws, _ := newRPCSubTestServer(t)
+						ws.SetLedgerInfoProvider(stubLedgerInfoProvider{
+							validatedLedgers:        validatedLedgers,
+							validatedLedgersPresent: validatedLedgersPresent,
+							networkID:               networkID,
+						})
+						ack := ws.buildSubscribeAck(&types.RpcContext{}, types.SubscriptionRequest{Streams: []types.SubscriptionType{types.SubLedger}})
+						got, err := json.Marshal(ack)
+						require.NoError(t, err)
+
+						want := "{}"
+						if validatedLedgersPresent {
+							want = fmt.Sprintf(`{"validated_ledgers":"%s"}`, validatedLedgers)
+						}
+						if string(got) != want {
+							t.Fatalf("subLedger JSON without validated ledger = %s, want %s", got, want)
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+func publishesValidatedLedgers(state string) bool {
+	switch state {
+	case "syncing", "tracking", "full", "proposing", "validating":
+		return true
+	default:
+		return false
+	}
+}
+
+type stubLedgerInfoProvider struct {
+	ledgerAvailable         bool
+	xrpFees                 bool
+	validatedLedgers        string
+	validatedLedgersPresent bool
+	networkID               uint32
+}
 
 func (s stubLedgerInfoProvider) GetCurrentLedgerInfo() *types.LedgerSubscribeInfo {
 	return &types.LedgerSubscribeInfo{
-		LedgerIndex:    42,
-		LedgerHash:     "ABCD",
-		LedgerTime:     735000000,
-		FeeBase:        10,
-		FeeRef:         10,
-		ReserveBase:    10000000,
-		ReserveInc:     2000000,
-		XRPFeesEnabled: s.xrpFees,
+		LedgerAvailable:         s.ledgerAvailable,
+		LedgerIndex:             42,
+		LedgerHash:              "ABCD",
+		LedgerTime:              735000000,
+		FeeBase:                 10,
+		FeeRef:                  10,
+		ReserveBase:             10000000,
+		ReserveInc:              2000000,
+		ValidatedLedgers:        s.validatedLedgers,
+		ValidatedLedgersPresent: s.validatedLedgersPresent,
+		NetworkID:               s.networkID,
+		XRPFeesEnabled:          s.xrpFees,
 	}
 }
 

--- a/internal/rpc/tx_history_test.go
+++ b/internal/rpc/tx_history_test.go
@@ -167,6 +167,30 @@ func TestTxHistoryEmptyResult(t *testing.T) {
 	assert.Empty(t, txs, "txs should be empty when no transactions exist")
 }
 
+func TestTxHistoryMalformedTransactionReturnsInternal(t *testing.T) {
+	mock := newMockLedgerServiceTxHistory()
+	mock.txHistoryResult = &types.TxHistoryResult{
+		Index: 5,
+		Transactions: []types.AccountTransaction{{
+			Hash:        [32]byte{1},
+			LedgerIndex: 5,
+			TxBlob:      []byte{0xff},
+		}},
+	}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion1,
+		Services:   newTxHistoryTestServices(mock),
+	}
+
+	result, rpcErr := (&handlers.TxHistoryMethod{}).Handle(ctx, json.RawMessage(`{"start":5}`))
+	require.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, 73, rpcErr.Code)
+	assert.Equal(t, "internal", rpcErr.ErrorString)
+}
+
 // TestTxHistoryResponseStructure tests that the response contains expected fields.
 // Based on rippled TransactionHistory_test.cpp response validation.
 func TestTxHistoryResponseStructure(t *testing.T) {

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -968,6 +968,15 @@ type LedgerReader interface {
 	ForEachTransaction(fn func(txHash [32]byte, txData []byte) bool) error
 }
 
+// LedgerMapHashSource exposes map-root reads that may fail. LedgerReader keeps
+// the historical value-only methods for compatibility with lightweight RPC
+// mocks; production adapters implement this facet so handlers never turn a
+// backing SHAMap failure into an authoritative-looking zero hash.
+type LedgerMapHashSource interface {
+	TxMapHashWithError() ([32]byte, error)
+	StateMapHashWithError() ([32]byte, error)
+}
+
 // LedgerTransactionSource is implemented by ledger readers that can query the
 // transaction tree of that exact ledger.
 type LedgerTransactionSource interface {
@@ -984,6 +993,13 @@ type ContextLedgerStateSource interface {
 
 type LedgerAmendmentRulesSource interface {
 	LedgerAmendmentRules() *amendment.Rules
+}
+
+// LedgerAmendmentRulesErrorSource is the error-aware amendment-rules facet.
+// It is optional to preserve the existing LedgerReader mock contract while
+// allowing production adapters to surface rules-loading failures.
+type LedgerAmendmentRulesErrorSource interface {
+	LedgerAmendmentRulesWithError() (*amendment.Rules, error)
 }
 
 // LedgerServerInfo contains server status information from the ledger service

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -968,15 +968,6 @@ type LedgerReader interface {
 	ForEachTransaction(fn func(txHash [32]byte, txData []byte) bool) error
 }
 
-// LedgerMapHashSource exposes map-root reads that may fail. LedgerReader keeps
-// the historical value-only methods for compatibility with lightweight RPC
-// mocks; production adapters implement this facet so handlers never turn a
-// backing SHAMap failure into an authoritative-looking zero hash.
-type LedgerMapHashSource interface {
-	TxMapHashWithError() ([32]byte, error)
-	StateMapHashWithError() ([32]byte, error)
-}
-
 // LedgerTransactionSource is implemented by ledger readers that can query the
 // transaction tree of that exact ledger.
 type LedgerTransactionSource interface {

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -677,19 +677,26 @@ type LedgerInfoProvider interface {
 // LedgerSubscribeInfo contains ledger info returned in the subscribe
 // response for the `ledger` stream. Field set mirrors rippled's
 // subLedger ack (NetworkOPs::subLedger): fee_ref is emitted only when
-// the XRPFees amendment is disabled, and network_id is always present.
+// the XRPFees amendment is disabled, and network_id is present when a
+// validated ledger is available.
 // The per-ledger streamed event uses LedgerCloseEvent and carries
 // additional fields (txn_count, etc.).
 type LedgerSubscribeInfo struct {
-	LedgerIndex      uint32 `json:"ledger_index"`
-	LedgerHash       string `json:"ledger_hash"`
-	LedgerTime       uint32 `json:"ledger_time"`
-	FeeBase          int32  `json:"fee_base"`
-	FeeRef           uint64 `json:"fee_ref"`
-	ReserveBase      int32  `json:"reserve_base"`
-	ReserveInc       int32  `json:"reserve_inc"`
-	ValidatedLedgers string `json:"validated_ledgers,omitempty"`
-	NetworkID        uint32 `json:"network_id"`
+	// LedgerAvailable is false while the server has no validated ledger. In
+	// that state subLedger still emits validated_ledgers when its independent
+	// operating-mode gate allows it, but must omit all fields derived from a
+	// particular validated ledger.
+	LedgerAvailable         bool   `json:"-"`
+	LedgerIndex             uint32 `json:"ledger_index"`
+	LedgerHash              string `json:"ledger_hash"`
+	LedgerTime              uint32 `json:"ledger_time"`
+	FeeBase                 int32  `json:"fee_base"`
+	FeeRef                  uint64 `json:"fee_ref"`
+	ReserveBase             int32  `json:"reserve_base"`
+	ReserveInc              int32  `json:"reserve_inc"`
+	ValidatedLedgers        string `json:"validated_ledgers,omitempty"`
+	ValidatedLedgersPresent bool   `json:"-"`
+	NetworkID               uint32 `json:"network_id"`
 	// XRPFeesEnabled gates fee_ref: rippled emits the deprecated fee_ref
 	// only while the XRPFees amendment is disabled.
 	XRPFeesEnabled bool `json:"-"`

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -1140,7 +1140,7 @@ func (ws *WebSocketServer) closeConnection(wsConn *WebSocketConnection) {
 // snapshot for any `snapshot:true` book.
 //
 // The ledger ack field set mirrors rippled subLedger: fee_ref only while
-// XRPFees is disabled, network_id always present; per-ledger pubLedger
+// XRPFees is disabled, network_id is present when a validated ledger exists; per-ledger pubLedger
 // events (LedgerCloseEvent) carry txn_count separately. The snapshot block
 // mirrors rippled
 // Subscribe.cpp:339-394: when snapshot is set, the response carries `offers`
@@ -1155,19 +1155,21 @@ func (ws *WebSocketServer) buildSubscribeAck(ctx *types.RpcContext, request type
 		if ws.ledgerInfoProvider != nil {
 			info := ws.ledgerInfoProvider.GetCurrentLedgerInfo()
 			if info != nil {
-				result["ledger_index"] = info.LedgerIndex
-				result["ledger_hash"] = info.LedgerHash
-				result["ledger_time"] = info.LedgerTime
-				result["fee_base"] = info.FeeBase
-				// rippled emits the deprecated fee_ref only while XRPFees
-				// is disabled; network_id is always present.
-				if !info.XRPFeesEnabled {
-					result["fee_ref"] = info.FeeRef
+				if info.LedgerAvailable {
+					result["ledger_index"] = info.LedgerIndex
+					result["ledger_hash"] = info.LedgerHash
+					result["ledger_time"] = info.LedgerTime
+					result["fee_base"] = info.FeeBase
+					// rippled emits the deprecated fee_ref only while XRPFees
+					// is disabled; network_id is present with ledger fields.
+					if !info.XRPFeesEnabled {
+						result["fee_ref"] = info.FeeRef
+					}
+					result["reserve_base"] = info.ReserveBase
+					result["reserve_inc"] = info.ReserveInc
+					result["network_id"] = info.NetworkID
 				}
-				result["reserve_base"] = info.ReserveBase
-				result["reserve_inc"] = info.ReserveInc
-				result["network_id"] = info.NetworkID
-				if info.ValidatedLedgers != "" {
+				if info.ValidatedLedgersPresent {
 					result["validated_ledgers"] = info.ValidatedLedgers
 				}
 			}


### PR DESCRIPTION
## Summary

- Propagate ledger-map, rules, transaction-history, and aggregate-price failures instead of returning zero-value success.
- Align ledgerClosed and subscription acknowledgement fields with rippled v3.2.0 gates.
- Preserve provisional open-ledger parent/hash/root semantics.

## Verification

- Ledger, RPC handler, event publisher, and node tests under normal and race builds
- Behavioral comparison with the local rippled v3.2.0 oracle

Refs #1483
