### PR TITLE
fix: bound persistent path-find refreshes

### DIFF
--- a/internal/rpc/handlers/path_find.go
+++ b/internal/rpc/handlers/path_find.go
@@ -15,8 +15,9 @@ import (
 // pushing updated paths on every ledger close) is a WebSocket-only feature
 // implemented separately on the WS transport: see
 // (*WebSocketServer).handlePathFind in internal/rpc/websocket.go and the
-// PathFindSession in internal/rpc/path_find_session.go, refreshed via
-// UpdatePathFindSessions on each ledger close (wired in cli/server.go).
+// PathFindSession in internal/rpc/path_find_session.go, refreshed by the
+// bounded asynchronous UpdatePathFindSessions pipeline after each ledger
+// close (wired in internal/node/runtime.go).
 type PathFindMethod struct{ BaseHandler }
 
 func (m *PathFindMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"sort"
 
@@ -136,17 +135,10 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 
 	var domainID *[32]byte
 	if rawDomain, ok := probe["domain"]; ok {
-		var domainStr string
-		if err := json.Unmarshal(rawDomain, &domainStr); err != nil {
+		var parsed bool
+		domainID, parsed = types.ParsePathFindDomain(rawDomain)
+		if !parsed {
 			return nil, types.RpcErrorDomainMalformed("Domain is malformed.")
-		}
-		domainID = new([32]byte)
-		if domainStr != "0" {
-			decoded, err := hex.DecodeString(domainStr)
-			if err != nil || len(decoded) != 32 {
-				return nil, types.RpcErrorDomainMalformed("Domain is malformed.")
-			}
-			copy(domainID[:], decoded)
 		}
 	}
 

--- a/internal/rpc/path_find_refresh.go
+++ b/internal/rpc/path_find_refresh.go
@@ -1,0 +1,429 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment/pathfinder"
+)
+
+// Persistent path_find computations are deliberately kept off the ordered
+// ledger-close callback. The pathfinder does not currently accept a context,
+// so a running computation cannot be interrupted; the fixed worker count
+// bounds that unavoidable work and generation checks suppress its result.
+const (
+	pathFindRefreshWorkerCount   = int(types.MaxPathfindsInProgress)
+	pathFindRefreshRetryInterval = 10 * time.Millisecond
+)
+
+type pathFindRefreshUpdate struct {
+	generation uint64
+	getView    func() (types.LedgerStateView, error)
+	targets    []pathFindUpdateTarget
+}
+
+type pathFindRefreshJob struct {
+	target     pathFindUpdateTarget
+	view       types.LedgerStateView
+	generation uint64
+}
+
+// pathFindRefreshManager owns the bounded asynchronous refresh pipeline for a
+// WebSocketServer. At most one queued job exists per connection. A newer
+// ledger generation clears all queued jobs and supersedes in-flight results;
+// active pathfinder calls are allowed to finish because they are not
+// cooperatively cancellable yet.
+type pathFindRefreshManager struct {
+	ws *WebSocketServer
+
+	mu         sync.Mutex
+	started    bool
+	closed     bool
+	generation uint64
+	fairCursor int
+	pending    *pathFindRefreshUpdate
+	jobs       map[*WebSocketConnection]pathFindRefreshJob
+	ready      []*WebSocketConnection
+	running    map[*WebSocketConnection]pathFindRefreshJob
+
+	stop       chan struct{}
+	updateWake chan struct{}
+	workWake   chan struct{}
+	done       sync.WaitGroup
+	doneCh     chan struct{}
+	remaining  atomic.Int32
+	doneOnce   sync.Once
+	stopOnce   sync.Once
+}
+
+func newPathFindRefreshManager(ws *WebSocketServer) *pathFindRefreshManager {
+	return &pathFindRefreshManager{
+		ws:         ws,
+		jobs:       make(map[*WebSocketConnection]pathFindRefreshJob),
+		running:    make(map[*WebSocketConnection]pathFindRefreshJob),
+		stop:       make(chan struct{}),
+		updateWake: make(chan struct{}, 1),
+		workWake:   make(chan struct{}, pathFindRefreshWorkerCount),
+		doneCh:     make(chan struct{}),
+	}
+}
+
+func (m *pathFindRefreshManager) start() {
+	m.mu.Lock()
+	if m.started || m.closed {
+		m.mu.Unlock()
+		return
+	}
+	m.started = true
+	m.done.Add(1 + pathFindRefreshWorkerCount)
+	m.remaining.Store(int32(1 + pathFindRefreshWorkerCount))
+	m.mu.Unlock()
+
+	go m.coordinate()
+	for range pathFindRefreshWorkerCount {
+		go m.worker()
+	}
+}
+
+func (m *pathFindRefreshManager) goroutineDone() {
+	defer m.done.Done()
+	if m.remaining.Add(-1) == 0 {
+		m.doneOnce.Do(func() { close(m.doneCh) })
+	}
+}
+
+func (m *pathFindRefreshManager) enqueue(getView func() (types.LedgerStateView, error), targets []pathFindUpdateTarget) {
+	if len(targets) == 0 {
+		m.invalidate()
+		return
+	}
+
+	m.start()
+
+	// Sorting makes the round-robin cursor deterministic. Rotating the sorted
+	// list between generations prevents a connection at the end of the list
+	// from being perpetually superseded by the first workers.
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i].connection.ID < targets[j].connection.ID
+	})
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return
+	}
+	m.generation++
+	targets = rotatePathFindTargets(targets, m.fairCursor)
+	m.fairCursor++
+	m.pending = &pathFindRefreshUpdate{
+		generation: m.generation,
+		getView:    getView,
+		targets:    targets,
+	}
+	// A newer generation makes all queued work obsolete. In-flight work is
+	// checked against generation before and after pathfinding.
+	m.jobs = make(map[*WebSocketConnection]pathFindRefreshJob)
+	m.ready = m.ready[:0]
+	m.mu.Unlock()
+	m.signal(m.updateWake)
+}
+
+func rotatePathFindTargets(targets []pathFindUpdateTarget, offset int) []pathFindUpdateTarget {
+	if len(targets) == 0 {
+		return targets
+	}
+	offset %= len(targets)
+	if offset == 0 {
+		return targets
+	}
+	rotated := make([]pathFindUpdateTarget, 0, len(targets))
+	rotated = append(rotated, targets[offset:]...)
+	rotated = append(rotated, targets[:offset]...)
+	return rotated
+}
+
+// invalidate advances the generation without starting workers. This is used
+// when a ledger close observes no active sessions, ensuring in-flight work
+// from a previous generation cannot publish after all sessions are gone.
+func (m *pathFindRefreshManager) invalidate() {
+	m.mu.Lock()
+	if !m.closed {
+		m.generation++
+		m.pending = nil
+		m.jobs = make(map[*WebSocketConnection]pathFindRefreshJob)
+		m.ready = m.ready[:0]
+	}
+	m.mu.Unlock()
+}
+
+func (m *pathFindRefreshManager) coordinate() {
+	defer m.goroutineDone()
+	for {
+		select {
+		case <-m.stop:
+			return
+		case <-m.updateWake:
+		}
+
+		for {
+			update := m.takePending()
+			if update == nil {
+				break
+			}
+
+			view, err := getPathFindRefreshView(update.getView)
+			if err != nil {
+				// A failed view lookup must not poison subsequent generations.
+				wsLog().Error("Failed to get ledger view for path_find updates", "err", err)
+				continue
+			}
+			if view == nil || !m.generationCurrent(update.generation) {
+				continue
+			}
+
+			for _, target := range update.targets {
+				if !m.generationCurrent(update.generation) {
+					break
+				}
+				if !target.current() {
+					continue
+				}
+				m.enqueueJob(pathFindRefreshJob{target: target, view: view, generation: update.generation}, update.generation)
+			}
+		}
+	}
+}
+
+func getPathFindRefreshView(getView func() (types.LedgerStateView, error)) (view types.LedgerStateView, err error) {
+	if getView == nil {
+		return nil, nil
+	}
+	return getView()
+}
+
+func (m *pathFindRefreshManager) takePending() *pathFindRefreshUpdate {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	update := m.pending
+	m.pending = nil
+	return update
+}
+
+func (m *pathFindRefreshManager) enqueueJob(job pathFindRefreshJob, generation uint64) {
+	m.mu.Lock()
+	if m.closed || m.generation != generation || !job.target.current() {
+		m.mu.Unlock()
+		return
+	}
+	if _, exists := m.jobs[job.target.connection]; !exists {
+		m.ready = append(m.ready, job.target.connection)
+	}
+	m.jobs[job.target.connection] = job
+	m.mu.Unlock()
+	m.signal(m.workWake)
+}
+
+func (m *pathFindRefreshManager) worker() {
+	defer m.goroutineDone()
+	for {
+		job, ok := m.takeJob()
+		if !ok {
+			select {
+			case <-m.stop:
+				return
+			case <-m.workWake:
+			}
+			continue
+		}
+
+		m.runJob(job)
+	}
+}
+
+func (m *pathFindRefreshManager) runJob(job pathFindRefreshJob) {
+	defer m.finishJob(job)
+	release, admitted := m.waitForPathfindAdmission(job)
+	if !admitted {
+		return
+	}
+	defer release()
+	if !m.jobCurrent(job) {
+		return
+	}
+
+	result := m.execute(job)
+	if result == nil || !m.jobCurrent(job) {
+		return
+	}
+	status := job.target.session.BuildEvent(result, true)
+	event := clonePathFindEvent(status)
+	event.Type = "path_find"
+	data, err := json.Marshal(event)
+	if err != nil {
+		wsLog().Error("Failed to marshal path_find update", "err", err)
+		return
+	}
+	m.commit(job, status, data)
+}
+
+func (m *pathFindRefreshManager) takeJob() (pathFindRefreshJob, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for len(m.ready) != 0 {
+		for i, connection := range m.ready {
+			if _, running := m.running[connection]; running {
+				continue
+			}
+			job, ok := m.jobs[connection]
+			if !ok {
+				m.ready = append(m.ready[:i], m.ready[i+1:]...)
+				break
+			}
+			m.ready = append(m.ready[:i], m.ready[i+1:]...)
+			delete(m.jobs, connection)
+			m.running[connection] = job
+			return job, true
+		}
+		break
+	}
+	return pathFindRefreshJob{}, false
+}
+
+func (m *pathFindRefreshManager) finishJob(job pathFindRefreshJob) {
+	m.mu.Lock()
+	if running, ok := m.running[job.target.connection]; ok && running.target.session == job.target.session && running.target.generation == job.target.generation && running.generation == job.generation {
+		delete(m.running, job.target.connection)
+		if !m.closed {
+			if _, queued := m.jobs[job.target.connection]; queued {
+				m.signal(m.workWake)
+			}
+		}
+	}
+	m.mu.Unlock()
+}
+
+func (m *pathFindRefreshManager) execute(job pathFindRefreshJob) (result *pathfinder.PathRequestResult) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			wsLog().Error("path_find refresh panic", "conn", job.target.connection.ID, "err", rec)
+			result = nil
+		}
+	}()
+	return job.target.session.Compute(job.view)
+}
+
+func (m *pathFindRefreshManager) commit(job pathFindRefreshJob, status *PathFindEvent, data []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed || m.generation != job.generation {
+		return
+	}
+	connection := job.target.connection
+	connection.mutex.Lock()
+	defer connection.mutex.Unlock()
+	if connection.pathFindSession != job.target.session || connection.pathFindGeneration != job.target.generation || connection.legacy == nil {
+		return
+	}
+	job.target.session.commitBuiltEvent(status)
+	job.target.connection.legacy.TrySend(data)
+}
+
+func (m *pathFindRefreshManager) waitForPathfindAdmission(job pathFindRefreshJob) (func(), bool) {
+	shedder := m.pathFindShedder()
+	if shedder == nil {
+		return func() {}, m.jobCurrent(job)
+	}
+	for {
+		if !m.jobCurrent(job) {
+			return nil, false
+		}
+		if shedder.AcquirePathfind() {
+			return shedder.ReleasePathfind, true
+		}
+		timer := time.NewTimer(pathFindRefreshRetryInterval)
+		select {
+		case <-m.stop:
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return nil, false
+		case <-timer.C:
+		}
+	}
+}
+
+func (m *pathFindRefreshManager) pathFindShedder() *types.ClientLoadShedder {
+	if m.ws == nil || m.ws.services == nil {
+		return nil
+	}
+	return m.ws.services.ClientLoad
+}
+
+func (m *pathFindRefreshManager) generationCurrent(generation uint64) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return !m.closed && m.generation == generation
+}
+
+func (m *pathFindRefreshManager) jobCurrent(job pathFindRefreshJob) bool {
+	return m.generationCurrent(job.generation) && job.target.current()
+}
+
+func (m *pathFindRefreshManager) cancel(connection *WebSocketConnection, session *PathFindSession, generation uint64) {
+	m.mu.Lock()
+	if job, ok := m.jobs[connection]; ok && job.target.session == session && job.target.generation == generation {
+		delete(m.jobs, connection)
+		ready := m.ready[:0]
+		for _, candidate := range m.ready {
+			if candidate != connection {
+				ready = append(ready, candidate)
+			}
+		}
+		m.ready = ready
+	}
+	m.mu.Unlock()
+}
+
+func (m *pathFindRefreshManager) shutdown() {
+	m.stopOnce.Do(func() {
+		m.mu.Lock()
+		m.closed = true
+		m.pending = nil
+		m.jobs = make(map[*WebSocketConnection]pathFindRefreshJob)
+		m.ready = nil
+		started := m.started
+		m.mu.Unlock()
+		if !started {
+			m.doneOnce.Do(func() { close(m.doneCh) })
+			return
+		}
+		close(m.stop)
+		m.signal(m.updateWake)
+		m.signal(m.workWake)
+	})
+}
+
+func (m *pathFindRefreshManager) wait(ctx context.Context) error {
+	m.shutdown()
+	select {
+	case <-m.doneCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (m *pathFindRefreshManager) close() {
+	_ = m.wait(context.Background())
+}
+
+func (m *pathFindRefreshManager) signal(ch chan struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}

--- a/internal/rpc/path_find_refresh.go
+++ b/internal/rpc/path_find_refresh.go
@@ -313,7 +313,7 @@ func (m *pathFindRefreshManager) execute(job pathFindRefreshJob) (result *pathfi
 			result = nil
 		}
 	}()
-	return job.target.session.Compute(job.view)
+	return job.target.session.Compute(job.view, false)
 }
 
 func (m *pathFindRefreshManager) commit(job pathFindRefreshJob, status *PathFindEvent, data []byte) {

--- a/internal/rpc/path_find_refresh_test.go
+++ b/internal/rpc/path_find_refresh_test.go
@@ -1,0 +1,492 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	tx "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment/pathfinder"
+	"github.com/stretchr/testify/require"
+)
+
+func newPathFindRefreshTestServer(t *testing.T, count int) (*WebSocketServer, []*WebSocketConnection) {
+	t.Helper()
+	ws := NewWebSocketServer(time.Second, nil)
+	manager := ws.ensurePathFindRefreshManager()
+	connections := make([]*WebSocketConnection, 0, count)
+	ws.connectionsMutex.Lock()
+	for i := range count {
+		id := fmt.Sprintf("conn-%02d", i)
+		conn := &WebSocketConnection{
+			ID:              id,
+			pathFindRefresh: manager,
+			legacy: &types.Connection{
+				ID:          id,
+				SendChannel: make(chan []byte, 8),
+			},
+		}
+		conn.installPathFindSession(&PathFindSession{id: id})
+		ws.connections[id] = conn
+		connections = append(connections, conn)
+	}
+	ws.connectionsMutex.Unlock()
+	return ws, connections
+}
+
+func testLedgerView() types.LedgerStateView {
+	return &stubAmendmentsView{}
+}
+
+func TestUpdatePathFindSessionsDoesNotBlockLedgerCallback(t *testing.T) {
+	ws, _ := newPathFindRefreshTestServer(t, 1)
+	manager := ws.ensurePathFindRefreshManager()
+	defer manager.close()
+
+	viewStarted := make(chan struct{})
+	releaseView := make(chan struct{})
+	updateDone := make(chan struct{})
+	go func() {
+		ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) {
+			close(viewStarted)
+			<-releaseView
+			return testLedgerView(), nil
+		})
+		close(updateDone)
+	}()
+
+	select {
+	case <-viewStarted:
+	case <-time.After(time.Second):
+		t.Fatal("refresh worker did not start view lookup")
+	}
+	select {
+	case <-updateDone:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("ledger callback waited for view lookup")
+	}
+	close(releaseView)
+}
+
+func TestPathFindRefreshMaximumConcurrency(t *testing.T) {
+	ws, connections := newPathFindRefreshTestServer(t, 3)
+	manager := ws.ensurePathFindRefreshManager()
+	defer manager.close()
+
+	var running, maximum atomic.Int32
+	started := make(chan struct{}, 3)
+	finished := make(chan struct{}, 3)
+	release := make(chan struct{})
+	connections[0].pathFindSession.computeFn = func(tx.LedgerView) *pathfinder.PathRequestResult {
+		current := running.Add(1)
+		for {
+			previous := maximum.Load()
+			if current <= previous || maximum.CompareAndSwap(previous, current) {
+				break
+			}
+		}
+		started <- struct{}{}
+		<-release
+		running.Add(-1)
+		finished <- struct{}{}
+		return &pathfinder.PathRequestResult{}
+	}
+	for _, connection := range connections[1:] {
+		connection.pathFindSession.computeFn = connections[0].pathFindSession.computeFn
+	}
+
+	ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) { return testLedgerView(), nil })
+	for range pathFindRefreshWorkerCount {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("worker did not start")
+		}
+	}
+	require.Equal(t, int32(pathFindRefreshWorkerCount), maximum.Load())
+	require.Equal(t, int32(pathFindRefreshWorkerCount), running.Load())
+	select {
+	case <-started:
+		t.Fatal("path-find refresh exceeded worker cap")
+	default:
+	}
+	close(release)
+	for range 3 {
+		select {
+		case <-finished:
+		case <-time.After(time.Second):
+			t.Fatal("worker did not finish")
+		}
+	}
+}
+
+func TestPathFindRefreshLatestGenerationWins(t *testing.T) {
+	ws, connections := newPathFindRefreshTestServer(t, 1)
+	manager := ws.ensurePathFindRefreshManager()
+	defer manager.close()
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondViewed := make(chan struct{})
+	computed := make(chan struct{}, 2)
+	var calls atomic.Int32
+	connections[0].pathFindSession.computeFn = func(tx.LedgerView) *pathfinder.PathRequestResult {
+		calls.Add(1)
+		computed <- struct{}{}
+		return &pathfinder.PathRequestResult{}
+	}
+
+	go ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) {
+		close(firstStarted)
+		<-releaseFirst
+		return testLedgerView(), nil
+	})
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first view lookup did not start")
+	}
+	ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) {
+		close(secondViewed)
+		return testLedgerView(), nil
+	})
+	close(releaseFirst)
+	select {
+	case <-secondViewed:
+	case <-time.After(time.Second):
+		t.Fatal("latest generation view lookup did not run")
+	}
+	select {
+	case <-computed:
+	case <-time.After(time.Second):
+		t.Fatal("latest generation was not computed")
+	}
+	require.Equal(t, int32(1), calls.Load())
+	select {
+	case <-computed:
+		t.Fatal("superseded generation was computed")
+	default:
+	}
+}
+
+func TestPathFindRefreshViewErrorRecovers(t *testing.T) {
+	ws, connections := newPathFindRefreshTestServer(t, 1)
+	manager := ws.ensurePathFindRefreshManager()
+	defer manager.close()
+
+	firstDone := make(chan struct{})
+	computed := make(chan struct{}, 1)
+	connections[0].pathFindSession.computeFn = func(tx.LedgerView) *pathfinder.PathRequestResult {
+		computed <- struct{}{}
+		return &pathfinder.PathRequestResult{}
+	}
+	ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) {
+		close(firstDone)
+		return nil, errors.New("view unavailable")
+	})
+	<-firstDone
+	ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) { return testLedgerView(), nil })
+	select {
+	case <-computed:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not recover after a view error")
+	}
+}
+
+func TestPathFindRefreshCloseSuppressesInFlightResult(t *testing.T) {
+	ws, connections := newPathFindRefreshTestServer(t, 1)
+	manager := ws.ensurePathFindRefreshManager()
+	defer manager.close()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	finished := make(chan struct{})
+	connections[0].pathFindSession.computeFn = func(tx.LedgerView) *pathfinder.PathRequestResult {
+		close(started)
+		<-release
+		close(finished)
+		return &pathfinder.PathRequestResult{}
+	}
+	ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) { return testLedgerView(), nil })
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not start")
+	}
+	require.NotNil(t, connections[0].clearPathFindSession())
+	close(release)
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("in-flight refresh did not finish")
+	}
+	select {
+	case <-connections[0].legacy.SendChannel:
+		t.Fatal("closed session received a stale refresh")
+	default:
+	}
+}
+
+func TestPathFindRefreshReplacementStillRuns(t *testing.T) {
+	ws, connections := newPathFindRefreshTestServer(t, 1)
+	manager := ws.ensurePathFindRefreshManager()
+	defer manager.close()
+
+	old := connections[0].pathFindSession
+	replacement := &PathFindSession{id: "replacement"}
+	startedOld := make(chan struct{})
+	replacementDone := make(chan struct{})
+	releaseOld := make(chan struct{})
+	old.computeFn = func(tx.LedgerView) *pathfinder.PathRequestResult {
+		close(startedOld)
+		<-releaseOld
+		return &pathfinder.PathRequestResult{}
+	}
+	replacement.computeFn = func(tx.LedgerView) *pathfinder.PathRequestResult {
+		close(replacementDone)
+		return &pathfinder.PathRequestResult{}
+	}
+	ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) { return testLedgerView(), nil })
+	<-startedOld
+	connections[0].clearPathFindSession()
+	connections[0].installPathFindSession(replacement)
+	ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) { return testLedgerView(), nil })
+	close(releaseOld)
+	select {
+	case <-replacementDone:
+	case <-time.After(time.Second):
+		t.Fatal("replacement session did not refresh")
+	}
+	select {
+	case data := <-connections[0].legacy.SendChannel:
+		require.Contains(t, string(data), "replacement")
+	case <-time.After(time.Second):
+		t.Fatal("replacement result was not sent")
+	}
+}
+
+func TestPathFindRefreshCloseJoinsWorkers(t *testing.T) {
+	ws, connections := newPathFindRefreshTestServer(t, 1)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	finished := make(chan struct{})
+	connections[0].pathFindSession.computeFn = func(tx.LedgerView) *pathfinder.PathRequestResult {
+		close(started)
+		<-release
+		close(finished)
+		return &pathfinder.PathRequestResult{}
+	}
+	ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) { return testLedgerView(), nil })
+	<-started
+	ws.connectionsMutex.Lock()
+	delete(ws.connections, connections[0].ID)
+	ws.connectionsMutex.Unlock()
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- ws.Close(context.Background()) }()
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before path-find worker joined: %v", err)
+	default:
+	}
+	close(release)
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not finish")
+	}
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Close did not join refresh workers")
+	}
+}
+
+func TestPathFindRefreshCloseDeadlineWithBlockedView(t *testing.T) {
+	ws, connections := newPathFindRefreshTestServer(t, 1)
+	manager := ws.ensurePathFindRefreshManager()
+	viewStarted := make(chan struct{})
+	releaseView := make(chan struct{})
+	ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) {
+		close(viewStarted)
+		<-releaseView
+		return testLedgerView(), nil
+	})
+	<-viewStarted
+	ws.connectionsMutex.Lock()
+	delete(ws.connections, connections[0].ID)
+	ws.connectionsMutex.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	err := ws.Close(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(start), time.Second)
+	select {
+	case <-manager.doneCh:
+		t.Fatal("blocked view unexpectedly completed before release")
+	default:
+	}
+	close(releaseView)
+	select {
+	case <-manager.doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("refresh manager did not clean up after view release")
+	}
+	require.NoError(t, ws.Close(context.Background()))
+}
+
+func TestPathFindRefreshCloseDeadlineWithBlockedExecute(t *testing.T) {
+	ws, connections := newPathFindRefreshTestServer(t, 1)
+	manager := ws.ensurePathFindRefreshManager()
+	executeStarted := make(chan struct{})
+	releaseExecute := make(chan struct{})
+	connections[0].pathFindSession.computeFn = func(tx.LedgerView) *pathfinder.PathRequestResult {
+		close(executeStarted)
+		<-releaseExecute
+		return &pathfinder.PathRequestResult{}
+	}
+	ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) { return testLedgerView(), nil })
+	<-executeStarted
+	ws.connectionsMutex.Lock()
+	delete(ws.connections, connections[0].ID)
+	ws.connectionsMutex.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	err := ws.Close(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	select {
+	case <-manager.doneCh:
+		t.Fatal("blocked execute unexpectedly completed before release")
+	default:
+	}
+	close(releaseExecute)
+	select {
+	case <-manager.doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("refresh worker did not clean up after execute release")
+	}
+	require.NoError(t, ws.Close(context.Background()))
+}
+
+func TestPathFindRefreshDoesNotCommitSupersededResult(t *testing.T) {
+	ws, connections := newPathFindRefreshTestServer(t, 1)
+	manager := ws.ensurePathFindRefreshManager()
+	session := connections[0].pathFindSession
+	initial := pathfinder.PathRequestResult{}
+	oldResult := pathfinder.PathRequestResult{Alternatives: []pathfinder.PathAlternative{{DestinationAmount: state.NewXRPAmountFromInt(2)}}}
+	latestResult := pathfinder.PathRequestResult{Alternatives: []pathfinder.PathAlternative{{DestinationAmount: state.NewXRPAmountFromInt(3)}}}
+	session.convertAll = true
+	session.CommitResult(&initial, false)
+	oldStarted := make(chan struct{})
+	latestStarted := make(chan struct{})
+	releaseOld := make(chan struct{})
+	releaseLatest := make(chan struct{})
+	var calls atomic.Int32
+	session.computeFn = func(tx.LedgerView) *pathfinder.PathRequestResult {
+		if calls.Add(1) == 1 {
+			close(oldStarted)
+			<-releaseOld
+			return &oldResult
+		}
+		close(latestStarted)
+		<-releaseLatest
+		return &latestResult
+	}
+	ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) { return testLedgerView(), nil })
+	<-oldStarted
+	ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) { return testLedgerView(), nil })
+	close(releaseOld)
+	<-latestStarted
+	status := session.Status()
+	require.Empty(t, status.Alternatives, "a superseded computation must not commit")
+	close(releaseLatest)
+	select {
+	case <-connections[0].legacy.SendChannel:
+	case <-time.After(time.Second):
+		t.Fatal("latest refresh was not published")
+	}
+	status = session.Status()
+	require.Len(t, status.Alternatives, 1)
+	require.Equal(t, `"3"`, string(status.Alternatives[0].DestinationAmount))
+	manager.close()
+}
+
+func TestPathFindRefreshSharesPathfindAdmissionPerConnection(t *testing.T) {
+	ws, connections := newPathFindRefreshTestServer(t, 1)
+	manager := ws.ensurePathFindRefreshManager()
+	shedder := types.NewClientLoadShedder()
+	ws.services = &types.ServiceContainer{ClientLoad: shedder}
+	firstStarted := make(chan struct{})
+	latestStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var calls atomic.Int32
+	connections[0].pathFindSession.computeFn = func(tx.LedgerView) *pathfinder.PathRequestResult {
+		if calls.Add(1) == 1 {
+			close(firstStarted)
+			<-releaseFirst
+			return &pathfinder.PathRequestResult{}
+		}
+		close(latestStarted)
+		return &pathfinder.PathRequestResult{}
+	}
+	ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) { return testLedgerView(), nil })
+	<-firstStarted
+	require.Equal(t, int64(1), shedder.PathfindActive())
+	ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) { return testLedgerView(), nil })
+	select {
+	case <-latestStarted:
+		t.Fatal("one connection occupied two pathfind workers")
+	default:
+	}
+	close(releaseFirst)
+	select {
+	case <-latestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("latest queued connection job did not run")
+	}
+	select {
+	case <-connections[0].legacy.SendChannel:
+	case <-time.After(time.Second):
+		t.Fatal("latest queued connection job was not published")
+	}
+	require.Equal(t, int64(0), shedder.PathfindActive())
+	manager.close()
+}
+
+func TestPathFindRefreshCancellationStress(t *testing.T) {
+	ws, connections := newPathFindRefreshTestServer(t, 4)
+	manager := ws.ensurePathFindRefreshManager()
+	defer manager.close()
+
+	var calls atomic.Int32
+	started := make(chan struct{}, 1)
+	for _, connection := range connections {
+		connection.pathFindSession.computeFn = func(tx.LedgerView) *pathfinder.PathRequestResult {
+			calls.Add(1)
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			return &pathfinder.PathRequestResult{}
+		}
+	}
+	for range 100 {
+		ws.UpdatePathFindSessions(func() (types.LedgerStateView, error) { return testLedgerView(), nil })
+		if calls.Load() > int32(len(connections)) {
+			break
+		}
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("stress loop did not admit any refresh")
+	}
+}

--- a/internal/rpc/path_find_refresh_test.go
+++ b/internal/rpc/path_find_refresh_test.go
@@ -73,6 +73,37 @@ func TestUpdatePathFindSessionsDoesNotBlockLedgerCallback(t *testing.T) {
 	close(releaseView)
 }
 
+func TestQueuePathFindSessionsIncludesNewConnection(t *testing.T) {
+	ws, _ := newPathFindRefreshTestServer(t, 0)
+	manager := ws.ensurePathFindRefreshManager()
+	defer manager.close()
+
+	computed := make(chan struct{}, 1)
+	conn := &WebSocketConnection{
+		ID: "new-connection",
+		legacy: &types.Connection{
+			ID:          "new-connection",
+			SendChannel: make(chan []byte, 1),
+		},
+	}
+	conn.installPathFindSession(&PathFindSession{
+		computeFn: func(tx.LedgerView) *pathfinder.PathRequestResult {
+			computed <- struct{}{}
+			return &pathfinder.PathRequestResult{}
+		},
+	})
+
+	ws.queuePathFindSessions(func() (types.LedgerStateView, error) {
+		return testLedgerView(), nil
+	}, conn)
+
+	select {
+	case <-computed:
+	case <-time.After(time.Second):
+		t.Fatal("new path-find session was not queued for a full update")
+	}
+}
+
 func TestPathFindRefreshMaximumConcurrency(t *testing.T) {
 	ws, connections := newPathFindRefreshTestServer(t, 3)
 	manager := ws.ensurePathFindRefreshManager()

--- a/internal/rpc/path_find_session.go
+++ b/internal/rpc/path_find_session.go
@@ -18,6 +18,7 @@ import (
 type PathFindSession struct {
 	mu        sync.Mutex
 	computeMu sync.Mutex
+	computeFn func(tx.LedgerView) *pathfinder.PathRequestResult
 
 	// Request parameters (immutable after creation)
 	srcAccount    [20]byte
@@ -26,6 +27,7 @@ type PathFindSession struct {
 	sendMax       *tx.Amount
 	srcCurrencies []payment.Issue
 	convertAll    bool
+	domainID      *[32]byte
 
 	// Canonical account strings for response formatting
 	srcAccountStr string
@@ -46,6 +48,7 @@ type pathFindCreateRequest struct {
 	DestinationAmount  json.RawMessage `json:"destination_amount"`
 	SendMax            json.RawMessage `json:"send_max,omitempty"`
 	SourceCurrencies   json.RawMessage `json:"source_currencies,omitempty"`
+	Domain             json.RawMessage `json:"domain,omitempty"`
 }
 
 // ParseAndCreateSession parses a path_find create request and creates a session.
@@ -200,6 +203,15 @@ func ParseAndCreateSession(params json.RawMessage, id any) (*PathFindSession, *r
 		}
 	}
 
+	var domainID *[32]byte
+	if request.Domain != nil {
+		var parsed bool
+		domainID, parsed = rpctypes.ParsePathFindDomain(request.Domain)
+		if !parsed {
+			return nil, rpctypes.RpcErrorDomainMalformed("Domain is malformed.")
+		}
+	}
+
 	session := &PathFindSession{
 		srcAccount:    srcAccount,
 		dstAccount:    dstAccount,
@@ -207,6 +219,7 @@ func ParseAndCreateSession(params json.RawMessage, id any) (*PathFindSession, *r
 		sendMax:       sendMax,
 		srcCurrencies: srcCurrencies,
 		convertAll:    convertAll,
+		domainID:      domainID,
 		srcAccountStr: state.EncodeAccountIDSafe(srcAccount),
 		dstAccountStr: state.EncodeAccountIDSafe(dstAccount),
 		id:            id,
@@ -215,43 +228,56 @@ func ParseAndCreateSession(params json.RawMessage, id any) (*PathFindSession, *r
 	return session, nil
 }
 
-// Execute runs pathfinding against the given ledger view and stores the result.
-// Full updates are returned in pushed-event form; the initial fast result is
-// returned in response-result form.
-func (s *PathFindSession) Execute(view tx.LedgerView, fullReply bool) *PathFindEvent {
+// Compute runs pathfinding while serializing computations for this session.
+// The returned result is not made visible through Status until CommitResult.
+func (s *PathFindSession) Compute(view tx.LedgerView) *pathfinder.PathRequestResult {
+	s.computeMu.Lock()
+	defer s.computeMu.Unlock()
+	if s.computeFn != nil {
+		return s.computeFn(view)
+	}
+
 	pr := pathfinder.NewPathRequest(
 		s.srcAccount, s.dstAccount,
 		s.dstAmount, s.sendMax,
 		s.srcCurrencies, s.convertAll,
 	)
-	return s.executeAndStore(func() *pathfinder.PathRequestResult {
-		return pr.Execute(view)
-	}, fullReply)
+	pr.SetDomainID(s.domainID)
+	return pr.Execute(view)
 }
 
-func (s *PathFindSession) executeAndStore(
-	execute func() *pathfinder.PathRequestResult,
-	fullReply bool,
-) *PathFindEvent {
-	s.computeMu.Lock()
-	defer s.computeMu.Unlock()
+// Execute runs pathfinding against the given ledger view and stores the result.
+// Full updates are returned in pushed-event form; the initial fast result is
+// returned in response-result form.
+func (s *PathFindSession) Execute(view tx.LedgerView, fullReply bool) *PathFindEvent {
+	return s.CommitResult(s.Compute(view), fullReply)
+}
 
-	result := execute()
+// CommitResult publishes a computed path result as the session's latest
+// status. Callers that need an external generation check should build an event
+// first and use commitBuiltEvent while holding that check's locks.
+func (s *PathFindSession) CommitResult(result *pathfinder.PathRequestResult, fullReply bool) *PathFindEvent {
+	status := s.BuildEvent(result, fullReply)
+	return s.commitBuiltEvent(status)
+}
 
+func (s *PathFindSession) commitBuiltEvent(status *PathFindEvent) *PathFindEvent {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.storeResultLocked(result, fullReply)
-}
-
-func (s *PathFindSession) storeResultLocked(result *pathfinder.PathRequestResult, fullReply bool) *PathFindEvent {
-	status := s.buildEvent(result, fullReply)
-	s.lastStatus = status
-
+	s.lastStatus = clonePathFindEvent(status)
 	event := clonePathFindEvent(status)
-	if fullReply {
+	if status.FullReply {
 		event.Type = "path_find"
 	}
 	return event
+}
+
+// BuildEvent formats a path result without changing the session status.
+func (s *PathFindSession) BuildEvent(result *pathfinder.PathRequestResult, fullReply bool) *PathFindEvent {
+	if result == nil {
+		result = &pathfinder.PathRequestResult{}
+	}
+	return s.buildEvent(result, fullReply)
 }
 
 // Status returns the stored response state with rippled's success marker.

--- a/internal/rpc/path_find_session.go
+++ b/internal/rpc/path_find_session.go
@@ -19,6 +19,7 @@ type PathFindSession struct {
 	mu        sync.Mutex
 	computeMu sync.Mutex
 	computeFn func(tx.LedgerView) *pathfinder.PathRequestResult
+	request   *pathfinder.PathRequest
 
 	// Request parameters (immutable after creation)
 	srcAccount    [20]byte
@@ -212,7 +213,16 @@ func ParseAndCreateSession(params json.RawMessage, id any) (*PathFindSession, *r
 		}
 	}
 
+	pathRequest := pathfinder.NewPathRequest(
+		srcAccount, dstAccount,
+		dstAmount, sendMax,
+		srcCurrencies, convertAll,
+	)
+	pathRequest.SetDomainID(domainID)
+	pathRequest.SetSearchLevel(0)
+
 	session := &PathFindSession{
+		request:       pathRequest,
 		srcAccount:    srcAccount,
 		dstAccount:    dstAccount,
 		dstAmount:     dstAmount,
@@ -230,27 +240,30 @@ func ParseAndCreateSession(params json.RawMessage, id any) (*PathFindSession, *r
 
 // Compute runs pathfinding while serializing computations for this session.
 // The returned result is not made visible through Status until CommitResult.
-func (s *PathFindSession) Compute(view tx.LedgerView) *pathfinder.PathRequestResult {
+func (s *PathFindSession) Compute(view tx.LedgerView, fast bool) *pathfinder.PathRequestResult {
 	s.computeMu.Lock()
 	defer s.computeMu.Unlock()
 	if s.computeFn != nil {
 		return s.computeFn(view)
 	}
 
-	pr := pathfinder.NewPathRequest(
-		s.srcAccount, s.dstAccount,
-		s.dstAmount, s.sendMax,
-		s.srcCurrencies, s.convertAll,
-	)
-	pr.SetDomainID(s.domainID)
-	return pr.Execute(view)
+	if s.request == nil {
+		s.request = pathfinder.NewPathRequest(
+			s.srcAccount, s.dstAccount,
+			s.dstAmount, s.sendMax,
+			s.srcCurrencies, s.convertAll,
+		)
+		s.request.SetDomainID(s.domainID)
+		s.request.SetSearchLevel(0)
+	}
+	return s.request.ExecuteUpdate(view, fast, false)
 }
 
 // Execute runs pathfinding against the given ledger view and stores the result.
 // Full updates are returned in pushed-event form; the initial fast result is
 // returned in response-result form.
 func (s *PathFindSession) Execute(view tx.LedgerView, fullReply bool) *PathFindEvent {
-	return s.CommitResult(s.Compute(view), fullReply)
+	return s.CommitResult(s.Compute(view, !fullReply), fullReply)
 }
 
 // CommitResult publishes a computed path result as the session's latest

--- a/internal/rpc/path_find_session_execute_test.go
+++ b/internal/rpc/path_find_session_execute_test.go
@@ -1,0 +1,292 @@
+package rpc
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/drops"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+type pathFindSessionLedger struct {
+	entries map[[32]byte][]byte
+}
+
+func newPathFindSessionLedger() *pathFindSessionLedger {
+	return &pathFindSessionLedger{entries: make(map[[32]byte][]byte)}
+}
+
+func (m *pathFindSessionLedger) Read(k keylet.Keylet) ([]byte, error) {
+	return m.entries[k.Key], nil
+}
+
+func (m *pathFindSessionLedger) Exists(k keylet.Keylet) (bool, error) {
+	_, ok := m.entries[k.Key]
+	return ok, nil
+}
+
+func (m *pathFindSessionLedger) Insert(k keylet.Keylet, data []byte) error {
+	m.entries[k.Key] = data
+	return nil
+}
+
+func (m *pathFindSessionLedger) Update(k keylet.Keylet, data []byte) error {
+	m.entries[k.Key] = data
+	return nil
+}
+
+func (m *pathFindSessionLedger) Erase(k keylet.Keylet) error {
+	delete(m.entries, k.Key)
+	return nil
+}
+
+func (m *pathFindSessionLedger) AdjustDropsDestroyed(drops.XRPAmount) error { return nil }
+
+func (m *pathFindSessionLedger) ForEach(fn func([32]byte, []byte) bool) error {
+	for key, data := range m.entries {
+		if !fn(key, data) {
+			break
+		}
+	}
+	return nil
+}
+
+func (m *pathFindSessionLedger) Succ(key [32]byte) ([32]byte, []byte, bool, error) {
+	var best [32]byte
+	var bestData []byte
+	found := false
+	for candidate, data := range m.entries {
+		if pathFindSessionCompareKeys(candidate, key) <= 0 {
+			continue
+		}
+		if !found || pathFindSessionCompareKeys(candidate, best) < 0 {
+			best = candidate
+			bestData = data
+			found = true
+		}
+	}
+	return best, bestData, found, nil
+}
+
+func (m *pathFindSessionLedger) TxExists([32]byte) (bool, error) { return false, nil }
+
+func (m *pathFindSessionLedger) Rules() *amendment.Rules { return nil }
+
+func (m *pathFindSessionLedger) LedgerSeq() uint32 { return 0 }
+
+func pathFindSessionCompareKeys(a, b [32]byte) int {
+	for i := range a {
+		if a[i] < b[i] {
+			return -1
+		}
+		if a[i] > b[i] {
+			return 1
+		}
+	}
+	return 0
+}
+
+func pathFindSessionAccount(seed byte) [20]byte {
+	var account [20]byte
+	account[0] = seed
+	for i := 1; i < len(account); i++ {
+		account[i] = seed + byte(i)
+	}
+	return account
+}
+
+func pathFindSessionAccountAddress(account [20]byte) string {
+	return state.EncodeAccountIDSafe(account)
+}
+
+func pathFindSessionAddAccount(t *testing.T, ledger *pathFindSessionLedger, account [20]byte) {
+	t.Helper()
+	data, err := state.SerializeAccountRoot(&state.AccountRoot{
+		Account:  pathFindSessionAccountAddress(account),
+		Balance:  10_000_000_000,
+		Sequence: 1,
+	})
+	require.NoError(t, err)
+	ledger.entries[keylet.Account(account).Key] = data
+}
+
+func pathFindSessionAddRippleState(
+	t *testing.T,
+	ledger *pathFindSessionLedger,
+	lowAccount, highAccount [20]byte,
+	currency string,
+	balance float64,
+) {
+	t.Helper()
+	data, err := state.SerializeRippleState(&state.RippleState{
+		Balance:   state.NewIssuedAmountFromFloat64(balance, currency, state.AccountOneAddress),
+		LowLimit:  state.NewIssuedAmountFromFloat64(10000, currency, pathFindSessionAccountAddress(lowAccount)),
+		HighLimit: state.NewIssuedAmountFromFloat64(10000, currency, pathFindSessionAccountAddress(highAccount)),
+	})
+	require.NoError(t, err)
+	lineKey := keylet.Line(lowAccount, highAccount, currency)
+	ledger.entries[lineKey.Key] = data
+	pathFindSessionAddOwnerDirectoryEntry(t, ledger, lowAccount, lineKey.Key)
+	pathFindSessionAddOwnerDirectoryEntry(t, ledger, highAccount, lineKey.Key)
+}
+
+func pathFindSessionAddOwnerDirectoryEntry(
+	t *testing.T,
+	ledger *pathFindSessionLedger,
+	account [20]byte,
+	itemKey [32]byte,
+) {
+	t.Helper()
+	directoryKey := keylet.OwnerDir(account)
+	directory := &state.DirectoryNode{
+		Owner:     account,
+		RootIndex: directoryKey.Key,
+		Indexes:   [][32]byte{itemKey},
+	}
+	if existing, ok := ledger.entries[directoryKey.Key]; ok {
+		var err error
+		directory, err = state.ParseDirectoryNode(existing)
+		require.NoError(t, err)
+		for _, existingKey := range directory.Indexes {
+			if existingKey == itemKey {
+				return
+			}
+		}
+		directory.Indexes = append(directory.Indexes, itemKey)
+	}
+	data, err := state.SerializeDirectoryNode(directory, false)
+	require.NoError(t, err)
+	ledger.entries[directoryKey.Key] = data
+}
+
+func pathFindSessionAddDomain(t *testing.T, ledger *pathFindSessionLedger, domainID [32]byte, owner [20]byte) {
+	t.Helper()
+	data, err := state.SerializePermissionedDomain(&state.PermissionedDomainData{
+		Owner:    owner,
+		Sequence: 1,
+	}, pathFindSessionAccountAddress(owner))
+	require.NoError(t, err)
+	ledger.entries[keylet.PermissionedDomainByID(domainID).Key] = data
+}
+
+func pathFindSessionBookSide(amount state.Amount) keylet.BookSide {
+	issue := payment.GetIssue(amount)
+	return keylet.IssueSide(keylet.CurrencyBytes(issue.Currency), issue.Issuer)
+}
+
+func pathFindSessionAddOffer(
+	t *testing.T,
+	ledger *pathFindSessionLedger,
+	account [20]byte,
+	sequence uint32,
+	takerPays, takerGets state.Amount,
+	domainID [32]byte,
+) (offerKey, bookKey [32]byte) {
+	t.Helper()
+	var domainPtr *[32]byte
+	if domainID != ([32]byte{}) {
+		domainPtr = &domainID
+	}
+	quality := payment.QualityFromAmounts(
+		payment.ToEitherAmount(takerPays),
+		payment.ToEitherAmount(takerGets),
+	)
+	bookKey = keylet.Quality(keylet.BookBase(
+		pathFindSessionBookSide(takerPays),
+		pathFindSessionBookSide(takerGets),
+		domainPtr,
+	), quality.Value).Key
+	offer := &state.LedgerOffer{
+		Account:       pathFindSessionAccountAddress(account),
+		Sequence:      sequence,
+		TakerPays:     takerPays,
+		TakerGets:     takerGets,
+		BookDirectory: bookKey,
+		DomainID:      domainID,
+	}
+	offerData, err := state.SerializeLedgerOffer(offer)
+	require.NoError(t, err)
+	offerKey = keylet.Offer(account, sequence).Key
+	ledger.entries[offerKey] = offerData
+	directoryData, err := state.SerializeDirectoryNode(&state.DirectoryNode{
+		RootIndex: bookKey,
+		Indexes:   [][32]byte{offerKey},
+	}, true)
+	require.NoError(t, err)
+	ledger.entries[bookKey] = directoryData
+	return offerKey, bookKey
+}
+
+func TestPathFindSessionExecuteRetainsDomain(t *testing.T) {
+	ledger := newPathFindSessionLedger()
+	source := pathFindSessionAccount(1)
+	destination := pathFindSessionAccount(2)
+	issuer := pathFindSessionAccount(3)
+	targetOwner := pathFindSessionAccount(4)
+	unrelatedOwner := pathFindSessionAccount(5)
+	openOwner := pathFindSessionAccount(6)
+	for _, account := range [][20]byte{source, destination, issuer, targetOwner, unrelatedOwner, openOwner} {
+		pathFindSessionAddAccount(t, ledger, account)
+	}
+
+	low, high := destination, issuer
+	if state.CompareAccountIDs(low, high) > 0 {
+		low, high = high, low
+	}
+	pathFindSessionAddRippleState(t, ledger, low, high, "USD", 0)
+	for _, owner := range [][20]byte{targetOwner, unrelatedOwner, openOwner} {
+		low, high = owner, issuer
+		if state.CompareAccountIDs(low, high) > 0 {
+			low, high = high, low
+		}
+		balance := -500.0
+		if low == owner {
+			balance = 500
+		}
+		pathFindSessionAddRippleState(t, ledger, low, high, "USD", balance)
+	}
+
+	var targetDomain, unrelatedDomain [32]byte
+	targetDomain[31] = 1
+	unrelatedDomain[31] = 2
+	pathFindSessionAddDomain(t, ledger, targetDomain, targetOwner)
+	pathFindSessionAddDomain(t, ledger, unrelatedDomain, unrelatedOwner)
+
+	takerPays := state.NewXRPAmountFromInt(10_000_000)
+	takerGets := state.NewIssuedAmountFromFloat64(100, "USD", pathFindSessionAccountAddress(issuer))
+	targetOffer, targetBook := pathFindSessionAddOffer(t, ledger, targetOwner, 1, takerPays, takerGets, targetDomain)
+	pathFindSessionAddOffer(t, ledger, unrelatedOwner, 1, takerPays, takerGets, unrelatedDomain)
+	pathFindSessionAddOffer(t, ledger, openOwner, 1, takerPays, takerGets, [32]byte{})
+
+	baseParams := `{"source_account":"` + pathFindSessionAccountAddress(source) +
+		`","destination_account":"` + pathFindSessionAccountAddress(destination) +
+		`","destination_amount":{"currency":"USD","issuer":"` + pathFindSessionAccountAddress(issuer) +
+		`","value":"50"},"source_currencies":[{"currency":"XRP"}]`
+	params := baseParams + `,"domain":"` + hex.EncodeToString(targetDomain[:]) + `"}`
+	session, rpcErr := ParseAndCreateSession([]byte(params), "session-id")
+	require.Nil(t, rpcErr)
+
+	initial := session.Execute(ledger, false)
+	require.False(t, initial.FullReply)
+	require.Empty(t, initial.Type)
+	require.Len(t, initial.Alternatives, 1)
+	require.Equal(t, `"5000000"`, string(initial.Alternatives[0].SourceAmount))
+
+	delete(ledger.entries, targetOffer)
+	delete(ledger.entries, targetBook)
+	unscopedSession, rpcErr := ParseAndCreateSession([]byte(baseParams+`}`), "unscoped")
+	require.Nil(t, rpcErr)
+	unscoped := unscopedSession.Execute(ledger, false)
+	require.NotEmpty(t, unscoped.Alternatives,
+		"the open/unrelated fixture must provide liquidity when no domain is requested")
+
+	refresh := session.Execute(ledger, true)
+	require.True(t, refresh.FullReply)
+	require.Equal(t, "path_find", refresh.Type)
+	require.Empty(t, refresh.Alternatives,
+		"the refresh must not use open or unrelated-domain offers after target liquidity is removed")
+}

--- a/internal/rpc/path_find_session_test.go
+++ b/internal/rpc/path_find_session_test.go
@@ -2,7 +2,10 @@ package rpc
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+
+	rpctypes "github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
 // The WS path_find session must enforce the same post-parse amount guards as
@@ -70,5 +73,79 @@ func TestParseAndCreateSession_DecodeErrorIsFixed(t *testing.T) {
 	}
 	if rpcErr.ErrorString != "invalidParams" || rpcErr.Message != "Invalid parameters." {
 		t.Fatalf("error = %#v, want fixed invalidParams message", rpcErr)
+	}
+}
+
+func TestParseAndCreateSession_Domain(t *testing.T) {
+	const acct = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	const domain = "AB"
+	base := `{"source_account":"` + acct + `","destination_account":"` + acct + `","destination_amount":"1000000"`
+
+	params := func(value string) json.RawMessage {
+		return json.RawMessage(base + `,"domain":` + value + `}`)
+	}
+
+	t.Run("absent is unrestricted", func(t *testing.T) {
+		session, rpcErr := ParseAndCreateSession(json.RawMessage(base+`}`), nil)
+		if rpcErr != nil {
+			t.Fatalf("unexpected error: %v", rpcErr)
+		}
+		if session.domainID != nil {
+			t.Fatalf("domainID = %v, want nil", session.domainID)
+		}
+	})
+
+	for _, test := range []struct {
+		name  string
+		value string
+		want  *[32]byte
+	}{
+		{name: `"0" uses zero-value uint256 exception`, value: `"0"`, want: &[32]byte{}},
+		{name: "full hex domain", value: `"` + strings.Repeat(domain, 32) + `"`, want: func() *[32]byte {
+			var id [32]byte
+			for i := range id {
+				id[i] = 0xab
+			}
+			return &id
+		}()},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			session, rpcErr := ParseAndCreateSession(params(test.value), nil)
+			if rpcErr != nil {
+				t.Fatalf("unexpected error: %v", rpcErr)
+			}
+			if session.domainID == nil {
+				t.Fatal("domainID = nil")
+			}
+			if *session.domainID != *test.want {
+				t.Fatalf("domainID = %x, want %x", session.domainID, test.want)
+			}
+		})
+	}
+
+	for _, test := range []struct {
+		name  string
+		value string
+	}{
+		{name: "short hex", value: `"` + strings.Repeat("AB", 31) + `"`},
+		{name: "long hex", value: `"` + strings.Repeat("AB", 33) + `"`},
+		{name: "invalid hex", value: `"not-hex"`},
+		{name: "number", value: `12345`},
+		{name: "boolean", value: `true`},
+		{name: "null", value: `null`},
+		{name: "object", value: `{}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			session, rpcErr := ParseAndCreateSession(params(test.value), nil)
+			if session != nil {
+				t.Fatal("got session for malformed domain")
+			}
+			if rpcErr == nil {
+				t.Fatal("expected domainMalformed error")
+			}
+			if rpcErr.Code != rpctypes.RpcDOMAIN_MALFORMED || rpcErr.ErrorString != "domainMalformed" || rpcErr.Message != "Domain is malformed." {
+				t.Fatalf("error = %#v, want rpcDOMAIN_MALFORMED/domainMalformed/Domain is malformed.", rpcErr)
+			}
+		})
 	}
 }

--- a/internal/rpc/types/path_find_domain.go
+++ b/internal/rpc/types/path_find_domain.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"encoding/hex"
+	"encoding/json"
+)
+
+// ParsePathFindDomain parses the optional path-finding domain value. A missing
+// field is represented by the caller as a nil raw message and is unrestricted;
+// a present "0" uses rippled's zero-value uint256 exception, while other
+// values must be a full 256-bit hexadecimal ID.
+func ParsePathFindDomain(raw json.RawMessage) (*[32]byte, bool) {
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, false
+	}
+
+	var domainID [32]byte
+	if value == "0" {
+		return &domainID, true
+	}
+
+	decoded, err := hex.DecodeString(value)
+	if err != nil || len(decoded) != len(domainID) {
+		return nil, false
+	}
+	copy(domainID[:], decoded)
+	return &domainID, true
+}

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -720,6 +720,7 @@ func (ws *WebSocketServer) executePathFindCreate(wsConn *WebSocketConnection, ct
 	event := session.Execute(view, false)
 
 	wsConn.installPathFindSession(session)
+	ws.queuePathFindSessions(currentPathFindView(ctx.Services.Ledger), wsConn)
 
 	return event, nil
 }
@@ -752,18 +753,40 @@ func (ws *WebSocketServer) executePathFindStatus(wsConn *WebSocketConnection, _ 
 // asynchronous refresh generation. The ledger-close callback must not perform
 // ledger-view acquisition or path computation itself.
 func (ws *WebSocketServer) UpdatePathFindSessions(getView func() (types.LedgerStateView, error)) {
+	ws.queuePathFindSessions(getView, nil)
+}
+
+func (ws *WebSocketServer) queuePathFindSessions(getView func() (types.LedgerStateView, error), additional *WebSocketConnection) {
 	manager := ws.ensurePathFindRefreshManager()
 	ws.connectionsMutex.RLock()
 	var targets []pathFindUpdateTarget
+	seen := make(map[*WebSocketConnection]struct{}, len(ws.connections)+1)
 	for _, conn := range ws.connections {
+		seen[conn] = struct{}{}
 		ws.bindPathFindRefreshManager(conn)
 		if target, ok := conn.snapshotPathFindUpdate(); ok {
 			targets = append(targets, target)
 		}
 	}
 	ws.connectionsMutex.RUnlock()
+	if _, exists := seen[additional]; additional != nil && !exists {
+		ws.bindPathFindRefreshManager(additional)
+		if target, ok := additional.snapshotPathFindUpdate(); ok {
+			targets = append(targets, target)
+		}
+	}
 
 	manager.enqueue(getView, targets)
+}
+
+func currentPathFindView(ledger types.LedgerService) func() (types.LedgerStateView, error) {
+	return func() (types.LedgerStateView, error) {
+		if source, ok := ledger.(types.LedgerViewSource); ok {
+			view, _, err := source.GetLedgerViewBySeq(ledger.GetCurrentLedgerIndex())
+			return view, err
+		}
+		return ledger.GetClosedLedgerView()
+	}
 }
 
 type pathFindUpdateTarget struct {

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -64,7 +64,9 @@ type WebSocketServer struct {
 	services            *types.ServiceContainer
 	urlSubs             *URLSubscriptionRegistry
 	peerSourceHolder
-	loadTracker *loadtrack.Tracker
+	loadTracker       *loadtrack.Tracker
+	pathFindRefreshMu sync.Mutex
+	pathFindRefresh   *pathFindRefreshManager
 	// pingInterval is how often pingLoop sends a keepalive ping. Settable
 	// so concurrency tests can drive the ping path without waiting on the
 	// production cadence.
@@ -89,6 +91,7 @@ type WebSocketConnection struct {
 	cancel             context.CancelFunc
 	pathFindSession    *PathFindSession // At most one active path_find session per connection
 	pathFindGeneration uint64
+	pathFindRefresh    *pathFindRefreshManager
 	portCtx            *PortContext // per-port config for role determination
 	// user is the X-User header captured at upgrade time. Used by
 	// roleForRequest for RoleIdentified promotion when the connection
@@ -145,6 +148,7 @@ func NewWebSocketServerWithLoadTracker(timeout time.Duration, services *types.Se
 		closeDone:           make(chan struct{}),
 		forceDone:           make(chan struct{}),
 	}
+	ws.pathFindRefresh = newPathFindRefreshManager(ws)
 	// The url (RPCSub) registry lives on the WebSocket server because url
 	// subscribers share its subscription manager's broadcast fan-out.
 	// Exposing it through the service container lets the plain JSON-RPC
@@ -689,6 +693,7 @@ func (ws *WebSocketServer) executePathFind(wsConn *WebSocketConnection, ctx *typ
 // executePathFindCreate creates a new persistent pathfinding session.
 // Any existing session on this connection is replaced (matching rippled).
 func (ws *WebSocketServer) executePathFindCreate(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
+	ws.bindPathFindRefreshManager(wsConn)
 	wsConn.clearPathFindSession()
 
 	release, rpcErr := handlers.AcquirePathfind(ctx)
@@ -743,45 +748,22 @@ func (ws *WebSocketServer) executePathFindStatus(wsConn *WebSocketConnection, _ 
 	return session.Status(), nil
 }
 
-// UpdatePathFindSessions re-runs pathfinding for all active sessions on ledger close.
-// Called from the ledger close callback in server.go.
+// UpdatePathFindSessions snapshots active sessions and queues one bounded,
+// asynchronous refresh generation. The ledger-close callback must not perform
+// ledger-view acquisition or path computation itself.
 func (ws *WebSocketServer) UpdatePathFindSessions(getView func() (types.LedgerStateView, error)) {
+	manager := ws.ensurePathFindRefreshManager()
 	ws.connectionsMutex.RLock()
 	var targets []pathFindUpdateTarget
 	for _, conn := range ws.connections {
+		ws.bindPathFindRefreshManager(conn)
 		if target, ok := conn.snapshotPathFindUpdate(); ok {
 			targets = append(targets, target)
 		}
 	}
 	ws.connectionsMutex.RUnlock()
 
-	if len(targets) == 0 {
-		return
-	}
-
-	view, err := getView()
-	if err != nil {
-		wsLog().Error("Failed to get ledger view for path_find updates", "err", err)
-		return
-	}
-
-	for _, target := range targets {
-		if !target.current() {
-			continue
-		}
-
-		event := target.session.Execute(view, true)
-
-		data, marshalErr := json.Marshal(event)
-		if marshalErr != nil {
-			continue
-		}
-
-		// The identity check and non-blocking enqueue share the connection lock.
-		// A close/replacement therefore either happens before this check and
-		// suppresses the stale event, or after the event is already ordered.
-		target.trySend(data)
-	}
+	manager.enqueue(getView, targets)
 }
 
 type pathFindUpdateTarget struct {
@@ -792,20 +774,47 @@ type pathFindUpdateTarget struct {
 
 func (c *WebSocketConnection) clearPathFindSession() *PathFindSession {
 	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
 	session := c.pathFindSession
+	generation := c.pathFindGeneration
+	manager := c.pathFindRefresh
 	c.pathFindSession = nil
 	c.pathFindGeneration++
+	c.mutex.Unlock()
+	if manager != nil && session != nil {
+		manager.cancel(c, session, generation)
+	}
 	return session
 }
 
 func (c *WebSocketConnection) installPathFindSession(session *PathFindSession) {
 	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
+	previous := c.pathFindSession
+	previousGeneration := c.pathFindGeneration
+	manager := c.pathFindRefresh
 	c.pathFindSession = session
 	c.pathFindGeneration++
+	c.mutex.Unlock()
+	if manager != nil && previous != nil {
+		manager.cancel(c, previous, previousGeneration)
+	}
+}
+
+func (ws *WebSocketServer) ensurePathFindRefreshManager() *pathFindRefreshManager {
+	ws.pathFindRefreshMu.Lock()
+	defer ws.pathFindRefreshMu.Unlock()
+	if ws.pathFindRefresh == nil {
+		ws.pathFindRefresh = newPathFindRefreshManager(ws)
+	}
+	return ws.pathFindRefresh
+}
+
+func (ws *WebSocketServer) bindPathFindRefreshManager(conn *WebSocketConnection) {
+	manager := ws.ensurePathFindRefreshManager()
+	conn.mutex.Lock()
+	if conn.pathFindRefresh == nil {
+		conn.pathFindRefresh = manager
+	}
+	conn.mutex.Unlock()
 }
 
 func (c *WebSocketConnection) snapshotPathFindUpdate() (pathFindUpdateTarget, bool) {
@@ -835,6 +844,9 @@ func (target pathFindUpdateTarget) trySend(data []byte) bool {
 
 	if target.connection.pathFindSession != target.session ||
 		target.connection.pathFindGeneration != target.generation {
+		return false
+	}
+	if target.connection.legacy == nil {
 		return false
 	}
 	return target.connection.legacy.TrySend(data)
@@ -1068,6 +1080,7 @@ func marshalWebSocketJSON(value any) ([]byte, error) {
 // impossible for the two maps to drift on Add/Remove ordering — the
 // "duplicated connection state" concern flagged in the #428 audit.
 func (ws *WebSocketServer) attachConnection(wsConn *WebSocketConnection) bool {
+	ws.bindPathFindRefreshManager(wsConn)
 	legacy := &types.Connection{
 		ID:            wsConn.ID,
 		Subscriptions: wsConn.subscriptions,
@@ -1344,6 +1357,7 @@ func (ws *WebSocketServer) shutdown(ctx context.Context) {
 	closeFrames.Add(len(connections))
 	for _, conn := range connections {
 		conn.cancel()
+		conn.clearPathFindSession()
 		go func() {
 			defer closeFrames.Done()
 			_ = conn.conn.WriteControl(
@@ -1368,7 +1382,15 @@ func (ws *WebSocketServer) shutdown(ctx context.Context) {
 	for _, conn := range connections {
 		_ = conn.conn.Close()
 	}
+	refreshManager := ws.ensurePathFindRefreshManager()
+	refreshErr := refreshManager.wait(ctx)
 	close(ws.forceDone)
+	if refreshErr != nil {
+		// The close caller has already been released at its deadline. Keep this
+		// shutdown goroutine joining the fixed refresh worker set so eventual
+		// release of a non-cooperative pathfinder leaves no worker behind.
+		_ = refreshManager.wait(context.Background())
+	}
 
 	closeFrames.Wait()
 	ws.wg.Wait()

--- a/internal/tx/payment/pathfinder/path_request.go
+++ b/internal/tx/payment/pathfinder/path_request.go
@@ -59,6 +59,8 @@ type PathRequest struct {
 	maxPaths         int
 	searchLevel      int
 	domainID         *[32]byte
+	lastSuccess      bool
+	context          map[payment.Issue][][]payment.PathStep
 }
 
 // IsValidAsset reports whether an amount carries an asset that path finding
@@ -97,6 +99,7 @@ func NewPathRequest(
 		convertAll:       convertAll,
 		maxPaths:         maxReturnedPaths,
 		searchLevel:      SearchLevelDefault,
+		context:          make(map[payment.Issue][][]payment.PathStep),
 	}
 }
 
@@ -111,6 +114,39 @@ func (pr *PathRequest) SetSearchLevel(level int) {
 // permissioned domain.
 func (pr *PathRequest) SetDomainID(domainID *[32]byte) {
 	pr.domainID = domainID
+}
+
+// ExecuteUpdate adapts the search depth and retains paths found by earlier
+// updates of the same persistent request.
+func (pr *PathRequest) ExecuteUpdate(ledger tx.LedgerView, fast, loaded bool) *PathRequestResult {
+	pr.adjustSearchLevel(fast, loaded)
+	result := pr.Execute(ledger)
+	pr.lastSuccess = result != nil && len(result.Alternatives) != 0
+	return result
+}
+
+func (pr *PathRequest) adjustSearchLevel(fast, loaded bool) {
+	switch {
+	case pr.searchLevel == 0:
+		if loaded || fast {
+			pr.searchLevel = SearchLevelFast
+		} else {
+			pr.searchLevel = SearchLevelDefault
+		}
+	case pr.searchLevel == SearchLevelFast && !fast:
+		pr.searchLevel = SearchLevelDefault
+		if loaded && SearchLevelDefault > SearchLevelFast {
+			pr.searchLevel--
+		}
+	case pr.lastSuccess:
+		if pr.searchLevel > SearchLevelDefault || loaded && pr.searchLevel > SearchLevelFast {
+			pr.searchLevel--
+		}
+	case !loaded && pr.searchLevel < SearchLevelMax:
+		pr.searchLevel++
+	case loaded && pr.searchLevel > SearchLevelFast:
+		pr.searchLevel--
+	}
 }
 
 // Execute runs the pathfinding algorithm and returns the result.
@@ -188,8 +224,9 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 		result.DestinationCurrencies = append(result.DestinationCurrencies, currency)
 	}
 
-	// Track previously found paths per source currency (mContext in rippled)
-	context := make(map[payment.Issue][][]payment.PathStep)
+	if pr.context == nil {
+		pr.context = make(map[payment.Issue][][]payment.PathStep)
+	}
 
 	// When convertAll is true, replace destination amount with largest possible.
 	// Reference: rippled convertAmount(saDstAmount, convert_all_) in PathRequest::findPaths()
@@ -234,9 +271,9 @@ func (pr *PathRequest) Execute(ledger tx.LedgerView) *PathRequestResult {
 
 		pf.ComputePathRanks(pr.maxPaths)
 
-		extraPaths := context[srcIssue]
+		extraPaths := pr.context[srcIssue]
 		bestPaths, fullLiquidityPath := pf.GetBestPaths(pr.maxPaths, extraPaths, srcIssue.Issuer)
-		context[srcIssue] = bestPaths
+		pr.context[srcIssue] = bestPaths
 
 		// An empty path set is still tried: rippled runs rippleCalc with
 		// default paths allowed, so a working default path yields an

--- a/internal/tx/payment/pathfinder/pathfinder_test.go
+++ b/internal/tx/payment/pathfinder/pathfinder_test.go
@@ -203,6 +203,48 @@ func addOffer(
 	ledger.entries[offerKey.Key] = data
 }
 
+func addOfferToBook(
+	t *testing.T,
+	ledger *mockLedgerView,
+	account [20]byte,
+	seq uint32,
+	takerPays, takerGets state.Amount,
+	domainID [32]byte,
+) {
+	t.Helper()
+	var domainPtr *[32]byte
+	if domainID != ([32]byte{}) {
+		domainPtr = &domainID
+	}
+	book := keylet.Quality(keylet.BookBase(
+		bookSide(issueFromAmount(takerPays)),
+		bookSide(issueFromAmount(takerGets)),
+		domainPtr,
+	), payment.QualityFromAmounts(
+		payment.ToEitherAmount(takerPays),
+		payment.ToEitherAmount(takerGets),
+	).Value)
+	offer := &state.LedgerOffer{
+		Account:       testAccountAddress(account),
+		Sequence:      seq,
+		TakerPays:     takerPays,
+		TakerGets:     takerGets,
+		BookDirectory: book.Key,
+		DomainID:      domainID,
+	}
+	offerData, err := state.SerializeLedgerOffer(offer)
+	require.NoError(t, err, "serialize LedgerOffer")
+	offerKey := keylet.Offer(account, seq)
+	ledger.entries[offerKey.Key] = offerData
+
+	dirData, err := state.SerializeDirectoryNode(&state.DirectoryNode{
+		RootIndex: book.Key,
+		Indexes:   [][32]byte{offerKey.Key},
+	}, true)
+	require.NoError(t, err, "serialize BookDir")
+	ledger.entries[book.Key] = dirData
+}
+
 // ensureOwnerDirContains adds itemKey to the owner directory of the given account.
 // If no directory exists yet, creates one. If one exists, appends.
 func ensureOwnerDirContains(t *testing.T, ledger *mockLedgerView, account [20]byte, itemKey [32]byte) {
@@ -1321,6 +1363,84 @@ func TestFindPaths_XRPToIOU_ThroughOfferBook(t *testing.T) {
 	// With the offer present, the BookIndex should discover the XRP->USD book.
 	paths := pf.CompletePaths()
 	t.Logf("Found %d complete paths for XRP->USD", len(paths))
+}
+
+func TestPathRequestDomainFiltersUnrelatedOfferBooks(t *testing.T) {
+	ledger := newMockLedger()
+	alice := testAccountID(1)
+	bob := testAccountID(2)
+	gw := testAccountID(3)
+	mmDomain := testAccountID(4)
+	mmOther := testAccountID(5)
+	gwAddr := testAccountAddress(gw)
+
+	for _, account := range [][20]byte{alice, bob, gw, mmDomain, mmOther} {
+		addAccount(t, ledger, account, 10000000000, 0)
+	}
+
+	low, high := bob, gw
+	if compareAccountIDs(low, high) > 0 {
+		low, high = high, low
+	}
+	addRippleState(t, ledger, low, high, "USD", 0, 1000, 1000, 0)
+	for _, account := range [][20]byte{mmDomain, mmOther} {
+		low, high = account, gw
+		if compareAccountIDs(low, high) > 0 {
+			low, high = high, low
+		}
+		balance := -500.0
+		if low == account {
+			balance = 500
+		}
+		addRippleState(t, ledger, low, high, "USD", balance, 10000, 10000, 0)
+	}
+
+	var domainID, otherDomainID [32]byte
+	domainID[31] = 1
+	otherDomainID[31] = 2
+	for _, domain := range []struct {
+		id    [32]byte
+		owner [20]byte
+	}{
+		{id: domainID, owner: mmDomain},
+		{id: otherDomainID, owner: mmOther},
+	} {
+		data, err := state.SerializePermissionedDomain(&state.PermissionedDomainData{
+			Owner:    domain.owner,
+			Sequence: 1,
+		}, testAccountAddress(domain.owner))
+		require.NoError(t, err, "serialize PermissionedDomain")
+		ledger.entries[keylet.PermissionedDomainByID(domain.id).Key] = data
+	}
+	addOfferToBook(t, ledger, mmDomain, 1,
+		state.NewXRPAmountFromInt(10000000),
+		state.NewIssuedAmountFromFloat64(100, "USD", gwAddr),
+		domainID)
+	addOfferToBook(t, ledger, mmOther, 1,
+		state.NewXRPAmountFromInt(10000000),
+		state.NewIssuedAmountFromFloat64(100, "USD", gwAddr),
+		otherDomainID)
+
+	dstAmount := state.NewIssuedAmountFromFloat64(50, "USD", gwAddr)
+	sendMax := state.NewXRPAmountFromInt(99999999999)
+	request := NewPathRequest(
+		alice, bob, dstAmount, &sendMax,
+		[]payment.Issue{{Currency: "XRP"}}, false,
+	)
+	request.SetDomainID(&domainID)
+	result := request.Execute(ledger)
+	require.NotEmpty(t, result.Alternatives, "domain offer should provide liquidity")
+	require.Len(t, result.Alternatives, 1)
+	require.True(t, result.Alternatives[0].SourceAmount.IsNative())
+	require.Equal(t, int64(5_000_000), result.Alternatives[0].SourceAmount.Drops(),
+		"the matching domain offer should price 50 USD at 10 XRP per 100 USD")
+
+	// Removing the matching offer leaves only the same-pair offer in another
+	// domain. A request restricted to domainID must not use that unrelated book.
+	delete(ledger.entries, keylet.Offer(mmDomain, 1).Key)
+	withoutMatchingDomain := request.Execute(ledger)
+	require.Empty(t, withoutMatchingDomain.Alternatives,
+		"an offer from another domain must not provide liquidity")
 }
 
 func TestGetPathLiquidityDoesNotReuseConsumedOffer(t *testing.T) {

--- a/internal/tx/payment/pathfinder/pathfinder_test.go
+++ b/internal/tx/payment/pathfinder/pathfinder_test.go
@@ -1672,6 +1672,25 @@ func TestNewPathRequest_Defaults(t *testing.T) {
 	require.Equal(t, dst, pr.dstAccount)
 	require.Equal(t, maxReturnedPaths, pr.maxPaths)
 	require.False(t, pr.convertAll)
+	require.NotNil(t, pr.context)
+}
+
+func TestPathRequestAdjustsPersistentSearchLevel(t *testing.T) {
+	request := &PathRequest{}
+
+	request.adjustSearchLevel(true, false)
+	require.Equal(t, SearchLevelFast, request.searchLevel)
+
+	request.adjustSearchLevel(false, false)
+	require.Equal(t, SearchLevelDefault, request.searchLevel)
+
+	request.adjustSearchLevel(false, false)
+	require.Equal(t, SearchLevelDefault, request.searchLevel)
+
+	request.searchLevel = SearchLevelMax
+	request.lastSuccess = true
+	request.adjustSearchLevel(false, false)
+	require.Equal(t, SearchLevelDefault, request.searchLevel)
 }
 
 func TestNewPathRequest_WithSendMax(t *testing.T) {


### PR DESCRIPTION
## Summary

- Retain strict path_find domains for persistent sessions and every refresh.
- Run refreshes through a fixed, load-admitted worker pool with per-connection coalescing.
- Reject stale generations and make shutdown bounded without leaking workers.

## Verification

- Persistent domain and real session execution tests
- Focused path refresh normal and race stress tests

Refs #1483
