### PR TITLE
fix: bound transactional URL subscriptions

### DIFF
--- a/internal/rpc/rpcsub.go
+++ b/internal/rpc/rpcsub.go
@@ -18,25 +18,83 @@ import (
 )
 
 const (
-	// rpcSubQueueLimit bounds the per-url outbound event queue. rippled
-	// buffers RPCSub events without limit; a bound keeps a dead or slow
-	// endpoint from growing memory indefinitely. Overflowing events are
-	// dropped by Connection.TrySend (the registry never installs a
-	// Disconnect callback, so a slow endpoint is throttled, not removed —
-	// rippled keeps retrying forever too).
+	// rpcSubQueueLimit bounds each URL's outbound event queue so a dead or slow
+	// endpoint cannot grow memory indefinitely. Overflowing events are dropped
+	// by Connection.TrySend.
 	rpcSubQueueLimit = 256
 
 	// rpcSubRequestTimeout matches rippled's RPC_WEBHOOK_TIMEOUT.
 	rpcSubRequestTimeout = 30 * time.Second
+
+	// These limits bound both the registry memory footprint and the number of
+	// delivery goroutines an administrator can create. A zero/negative custom
+	// limit disables that dimension; the constructor installs bounded defaults.
+	rpcSubMaxEntries      = 256
+	rpcSubMaxWorkers      = 256
+	rpcSubMaxPerPrincipal = 32
 )
 
-// URLSubscriptionRegistry implements rippled's url-based (RPCSub) admin
-// subscriptions: each url maps to one long-lived subscriber registered with
-// the shared subscription manager, so stream/account/book broadcasts fan
-// out to urls exactly like they do to WebSocket connections. A per-url
-// delivery goroutine drains the subscriber's queue and POSTs every event to
-// the url as a JSON-RPC "event" call with an injected per-url sequence
-// number and basic auth.
+type rpcSubMetrics struct {
+	queued           atomic.Uint64
+	dropped          atomic.Uint64
+	deliveryFailures atomic.Uint64
+	capacityRejects  atomic.Uint64
+}
+
+type rpcSubMetricsSnapshot struct {
+	Queued           uint64
+	Dropped          uint64
+	DeliveryFailures uint64
+	CapacityRejects  uint64
+}
+
+func (m *rpcSubMetrics) snapshot() rpcSubMetricsSnapshot {
+	if m == nil {
+		return rpcSubMetricsSnapshot{}
+	}
+	return rpcSubMetricsSnapshot{
+		Queued:           m.queued.Load(),
+		Dropped:          m.dropped.Load(),
+		DeliveryFailures: m.deliveryFailures.Load(),
+		CapacityRejects:  m.capacityRejects.Load(),
+	}
+}
+
+// rpcSubMetricMilestone keeps runtime telemetry useful without emitting one
+// log record for every event on a busy subscription. The first observation
+// and powers of two provide an inexpensive cumulative signal as pressure
+// grows.
+func rpcSubMetricMilestone(value uint64) bool {
+	return value == 1 || value&(value-1) == 0
+}
+
+func (m *rpcSubMetrics) recordQueued(endpoint string) {
+	value := m.queued.Add(1)
+	if rpcSubMetricMilestone(value) {
+		wsLog().Debug("rpcsub: outbound event queued", "url", endpoint, "count", value, "queue_limit", rpcSubQueueLimit)
+	}
+}
+
+func (m *rpcSubMetrics) recordDropped(endpoint string) {
+	value := m.dropped.Add(1)
+	if rpcSubMetricMilestone(value) {
+		wsLog().Warn("rpcsub: outbound queue drops", "url", endpoint, "count", value, "queue_limit", rpcSubQueueLimit)
+	}
+}
+
+func (m *rpcSubMetrics) recordDeliveryFailure(endpoint, reason string, details ...any) {
+	value := m.deliveryFailures.Add(1)
+	if !rpcSubMetricMilestone(value) {
+		return
+	}
+	args := make([]any, 0, 6+len(details))
+	args = append(args, "url", endpoint, "count", value, "reason", reason)
+	args = append(args, details...)
+	wsLog().Warn("rpcsub: delivery failures", args...)
+}
+
+// URLSubscriptionRegistry owns URL-based admin subscriptions. Each URL maps
+// to one subscriber in the shared manager and one delivery goroutine.
 type URLSubscriptionRegistry struct {
 	ws     *WebSocketServer
 	client *http.Client
@@ -45,117 +103,173 @@ type URLSubscriptionRegistry struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	mu        sync.Mutex
-	subs      map[string]*rpcSub
-	closed    bool
-	closeDone chan struct{}
+	mu               sync.Mutex
+	subs             map[string]*rpcSub
+	principalCounts  map[string]int
+	maxEntries       int
+	maxWorkers       int
+	maxPerPrincipal  int
+	workers          int
+	principalWorkers map[string]int
+	workerWG         sync.WaitGroup
+	metrics          rpcSubMetrics
+	closed           bool
+	closeDone        chan struct{}
 }
 
 func newURLSubscriptionRegistry(ws *WebSocketServer) *URLSubscriptionRegistry {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &URLSubscriptionRegistry{
-		ws:        ws,
-		client:    &http.Client{Timeout: rpcSubRequestTimeout},
-		ctx:       ctx,
-		cancel:    cancel,
-		subs:      make(map[string]*rpcSub),
-		closeDone: make(chan struct{}),
+		ws: ws,
+		client: &http.Client{
+			Timeout: rpcSubRequestTimeout,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		ctx:              ctx,
+		cancel:           cancel,
+		subs:             make(map[string]*rpcSub),
+		principalCounts:  make(map[string]int),
+		maxEntries:       rpcSubMaxEntries,
+		maxWorkers:       rpcSubMaxWorkers,
+		maxPerPrincipal:  rpcSubMaxPerPrincipal,
+		closeDone:        make(chan struct{}),
+		principalWorkers: make(map[string]int),
 	}
 }
 
+func (r *URLSubscriptionRegistry) metricsSnapshot() rpcSubMetricsSnapshot {
+	return r.metrics.snapshot()
+}
+
 // Subscribe finds or creates the url's subscriber, applies the requested
-// streams/accounts/books to it, and returns the subscribe ack. Mirrors
-// doSubscribe's url branch: an unparseable url or unsupported scheme is
-// rpcINVALID_PARAMS; on reuse, credentials are only updated via the
-// deprecated username/password members. The caller has already verified the
-// admin role.
+// streams/accounts/books to it transactionally, and returns the subscribe ack.
+// Mirrors doSubscribe's URL branch for credential reuse: on an existing
+// destination only deprecated username/password members update credentials.
+// The caller has already verified the admin role.
 func (r *URLSubscriptionRegistry) Subscribe(ctx *types.RpcContext, request types.SubscriptionRequest) (map[string]any, *types.RpcError) {
-	request.ApiVersion = ctx.ApiVersion
-	sub, rpcErr := r.findOrCreate(request)
+	if ctx != nil {
+		request.ApiVersion = ctx.ApiVersion
+	}
+	principal := rpcSubPrincipal(ctx)
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		wsLog().Error("rpcsub: subscription requested after registry closed")
+		return nil, types.RpcErrorInternal()
+	}
+	key, rpcErr := canonicalRPCSubURL(request.URL)
 	if rpcErr != nil {
+		r.mu.Unlock()
 		return nil, rpcErr
 	}
-	// Like rippled, a failing stream/account/book parse leaves the freshly
-	// created registry entry in place.
-	if rpcErr := r.ws.subscriptionManager.HandleSubscribe(sub.conn, request.WithoutBooks(), true); rpcErr != nil {
+	lookup, rpcErr := r.findOrCreateLocked(request, key, principal)
+	if rpcErr != nil {
+		r.mu.Unlock()
 		return nil, rpcErr
 	}
-	if rpcErr := applyURLSubscriptionBooks(request, func(bookRequest types.SubscriptionRequest) *types.RpcError {
-		if rpcErr := r.ws.subscriptionManager.HandleSubscribe(sub.conn, bookRequest, true); rpcErr != nil {
-			return rpcErr
+
+	if rpcErr := r.ws.subscriptionManager.HandleSubscribeTransactional(lookup.sub.conn, request, true); rpcErr != nil {
+		var stopped *rpcSub
+		if lookup.created {
+			r.removeLocked(key, lookup.sub)
+			stopped = lookup.sub
+		} else {
+			lookup.sub.updateCredentials(lookup.username, true, lookup.password, true)
 		}
-		setSubscriptionLoadCost(ctx, bookRequest)
-		return nil
-	}); rpcErr != nil {
+		r.mu.Unlock()
+		waitRPCSub(stopped)
 		return nil, rpcErr
 	}
+	for _, book := range request.Books {
+		setSubscriptionLoadCost(ctx, types.SubscriptionRequest{Books: []types.BookRequest{book}})
+	}
+	r.mu.Unlock()
 	return r.ws.buildSubscribeAck(ctx, request), nil
 }
 
 // Unsubscribe removes the listed streams/accounts/books from the url's
 // subscriber and drops the registry entry once no stream subscriptions
-// remain. An unknown url is silent success (Unsubscribe.cpp:52-53).
+// remain. An unknown URL is a silent success.
 func (r *URLSubscriptionRegistry) Unsubscribe(ctx *types.RpcContext, request types.SubscriptionRequest) (map[string]any, *types.RpcError) {
-	r.mu.Lock()
-	sub, ok := r.subs[request.URL]
-	r.mu.Unlock()
-	if !ok {
+	key, rpcErr := canonicalRPCSubURL(request.URL)
+	if rpcErr != nil {
+		// Unsubscribe has always treated an unknown destination as a no-op.
+		// Preserve that behavior for malformed or unsupported URLs too; valid
+		// forms still pass through canonical lookup below so equivalent spellings
+		// reach an existing subscription.
 		return map[string]any{}, nil
 	}
-	if rpcErr := r.ws.subscriptionManager.HandleUnsubscribe(sub.conn, request.WithoutBooks(), true); rpcErr != nil {
+	r.mu.Lock()
+	sub, ok := r.subs[key]
+	if !ok {
+		r.mu.Unlock()
+		return map[string]any{}, nil
+	}
+	if rpcErr := r.ws.subscriptionManager.HandleUnsubscribeTransactional(sub.conn, request, true); rpcErr != nil {
+		r.mu.Unlock()
 		return nil, rpcErr
 	}
-	if rpcErr := applyURLSubscriptionBooks(request, func(bookRequest types.SubscriptionRequest) *types.RpcError {
-		return r.ws.subscriptionManager.HandleUnsubscribe(sub.conn, bookRequest, true)
-	}); rpcErr != nil {
-		return nil, rpcErr
-	}
-	r.tryRemove(request.URL)
+	stopped := r.tryRemoveLocked(key)
+	r.mu.Unlock()
+	waitRPCSub(stopped)
 	return map[string]any{}, nil
 }
 
-func applyURLSubscriptionBooks(request types.SubscriptionRequest, apply func(types.SubscriptionRequest) *types.RpcError) *types.RpcError {
-	wire := request.WireArrays()
-	if wire.Present {
-		return applySubscriptionBooks(wire.Books, apply)
-	}
-	for _, book := range request.Books {
-		if rpcErr := apply(types.SubscriptionRequest{Books: []types.BookRequest{book}}); rpcErr != nil {
-			return rpcErr
-		}
-	}
-	return nil
+type rpcSubLookup struct {
+	sub      *rpcSub
+	created  bool
+	username string
+	password string
 }
 
-func (r *URLSubscriptionRegistry) findOrCreate(request types.SubscriptionRequest) (*rpcSub, *types.RpcError) {
+func (r *URLSubscriptionRegistry) findOrCreateLocked(request types.SubscriptionRequest, key, principal string) (rpcSubLookup, *types.RpcError) {
+	if r.subs == nil {
+		r.subs = make(map[string]*rpcSub)
+	}
+	if r.principalCounts == nil {
+		r.principalCounts = make(map[string]int)
+	}
+	if r.principalWorkers == nil {
+		r.principalWorkers = make(map[string]int)
+	}
 	username, password, usernameSet, passwordSet := request.URLCredentials()
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.closed {
-		wsLog().Error("rpcsub: subscription requested after registry closed")
-		return nil, types.RpcErrorInternal()
-	}
-	if sub, ok := r.subs[request.URL]; ok {
-		// Credentials on an existing url subscription are only updated via
-		// the deprecated username/password members; url_username and
-		// url_password are ignored on reuse, exactly like doSubscribe.
+	if sub, ok := r.subs[key]; ok {
+		oldUsername, oldPassword := sub.credentials()
+		// Credentials on an existing URL subscription are only updated via the
+		// deprecated username/password members; url_username/url_password are
+		// ignored on reuse, exactly like doSubscribe.
 		sub.updateCredentials(username, usernameSet, password, passwordSet)
-		return sub, nil
+		return rpcSubLookup{sub: sub, username: oldUsername, password: oldPassword}, nil
+	}
+	if r.maxEntries > 0 && len(r.subs) >= r.maxEntries {
+		return rpcSubLookup{}, r.capacityError("registry entries", principal)
+	}
+	if r.maxWorkers > 0 && r.workers >= r.maxWorkers {
+		return rpcSubLookup{}, r.capacityError("delivery workers", principal)
+	}
+	if r.maxPerPrincipal > 0 && r.principalCounts[principal] >= r.maxPerPrincipal {
+		return rpcSubLookup{}, r.capacityError("principal entries", principal)
+	}
+	if r.maxPerPrincipal > 0 && r.principalWorkers[principal] >= r.maxPerPrincipal {
+		return rpcSubLookup{}, r.capacityError("principal workers", principal)
 	}
 
-	endpoint, rpcErr := parseRPCSubURL(request.URL)
-	if rpcErr != nil {
-		return nil, rpcErr
-	}
+	subCtx, subCancel := context.WithCancel(r.ctx) //nolint:gosec // The subscription owns and calls cancel during teardown.
+	metrics := &r.metrics
 	sub := &rpcSub{
-		endpoint: endpoint,
-		client:   r.client,
-		ctx:      r.ctx,
-		username: username,
-		password: password,
+		endpoint:  key,
+		client:    r.client,
+		ctx:       subCtx,
+		cancel:    subCancel,
+		registry:  r,
+		principal: principal,
+		metrics:   metrics,
+		username:  username,
+		password:  password,
 		conn: &types.Connection{
-			ID:            "rpcsub:" + request.URL,
+			ID:            "rpcsub:" + key,
 			Subscriptions: make(map[types.SubscriptionType]types.SubscriptionConfig),
 			SendChannel:   make(chan []byte, rpcSubQueueLimit),
 			CloseChannel:  make(chan struct{}),
@@ -164,31 +278,62 @@ func (r *URLSubscriptionRegistry) findOrCreate(request types.SubscriptionRequest
 		finished: make(chan struct{}),
 	}
 	sub.conn.EncodeOutbound = sub.encodeOutbound
+	sub.conn.SendObserver = func(queued bool) {
+		if queued {
+			metrics.recordQueued(key)
+		} else {
+			metrics.recordDropped(key)
+		}
+	}
+	r.subs[key] = sub
+	r.principalCounts[principal]++
+	r.principalWorkers[principal]++
+	r.workers++
+	r.workerWG.Add(1)
 	r.ws.subscriptionManager.AddConnection(sub.conn)
 	go sub.run()
-	r.subs[request.URL] = sub
-	return sub, nil
+	return rpcSubLookup{sub: sub, created: true}, nil
 }
 
-// tryRemove drops the url's registry entry once it holds no stream
-// subscriptions, mirroring NetworkOPs::tryRemoveRPCSub. Account and book
-// subscriptions don't keep the entry alive: in rippled the registry holds
-// the only strong reference, so removal destroys the subscriber and its
-// remaining subscriptions with it — here the manager connection and the
-// delivery goroutine are torn down the same way.
-func (r *URLSubscriptionRegistry) tryRemove(rawURL string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	sub, ok := r.subs[rawURL]
+func (r *URLSubscriptionRegistry) capacityError(kind, principal string) *types.RpcError {
+	value := r.metrics.capacityRejects.Add(1)
+	if rpcSubMetricMilestone(value) {
+		wsLog().Warn("rpcsub: subscription capacity exhausted", "kind", kind, "principal", principal, "count", value, "entries", len(r.subs), "workers", r.workers)
+	}
+	return types.RpcErrorTooBusy()
+}
+
+func (r *URLSubscriptionRegistry) tryRemoveLocked(key string) *rpcSub {
+	sub, ok := r.subs[key]
 	if !ok {
-		return
+		return nil
 	}
 	if r.ws.subscriptionManager.HasStreamSubscriptions(sub.conn.ID) {
-		return
+		return nil
 	}
-	delete(r.subs, rawURL)
+	return r.removeLocked(key, sub)
+}
+
+func (r *URLSubscriptionRegistry) removeLocked(key string, sub *rpcSub) *rpcSub {
+	if current, ok := r.subs[key]; !ok || current != sub {
+		return nil
+	}
+	delete(r.subs, key)
+	if r.principalCounts[sub.principal] > 0 {
+		r.principalCounts[sub.principal]--
+		if r.principalCounts[sub.principal] == 0 {
+			delete(r.principalCounts, sub.principal)
+		}
+	}
 	r.ws.subscriptionManager.RemoveConnection(sub.conn.ID)
 	sub.stop()
+	return sub
+}
+
+func waitRPCSub(sub *rpcSub) {
+	if sub != nil && sub.finished != nil {
+		<-sub.finished
+	}
 }
 
 // Close stops every url subscription, cancelling in-flight deliveries, and
@@ -204,6 +349,7 @@ func (r *URLSubscriptionRegistry) Close() {
 	r.closed = true
 	subs := r.subs
 	r.subs = make(map[string]*rpcSub)
+	r.principalCounts = make(map[string]int)
 	r.mu.Unlock()
 	defer close(r.closeDone)
 
@@ -213,26 +359,39 @@ func (r *URLSubscriptionRegistry) Close() {
 		sub.stop()
 	}
 	for _, sub := range subs {
-		<-sub.finished
+		if sub.finished != nil {
+			<-sub.finished
+		}
 	}
+	r.workerWG.Wait()
 }
 
-// parseRPCSubURL validates a subscription url the way RPCSub's constructor
-// does — http or https only, default ports 80/443 — and returns the
-// normalised endpoint to POST events to. The invalidParams messages match
-// rippled's verbatim ("Failed to parse url." / "Only http and https is
-// supported."). An empty host ("http://") is accepted, matching rippled's
-// parseUrl host group: registration succeeds and each delivery just fails
-// harmlessly at connect.
-func parseRPCSubURL(raw string) (string, *types.RpcError) {
+// canonicalRPCSubURL validates and canonicalises a destination before it is
+// used as a registry key or HTTP endpoint. Scheme/host casing and implicit
+// default ports are equivalent; path and query remain part of the identity.
+// HTTP basic-auth fields are mutable subscription state rather than identity,
+// matching the reuse semantics above; URL userinfo is rejected. Fragments,
+// opaque URLs, whitespace and empty hosts are also rejected because they do
+// not identify an unambiguous HTTP destination.
+func canonicalRPCSubURL(raw string) (string, *types.RpcError) {
 	parseErr := types.RpcErrorInvalidParams("Failed to parse url.")
-	u, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil || u.Scheme == "" {
+	if raw == "" || raw != strings.TrimSpace(raw) {
+		return "", parseErr
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" || u.Opaque != "" || u.User != nil || u.Fragment != "" {
 		return "", parseErr
 	}
 	scheme := strings.ToLower(u.Scheme)
 	if scheme != "http" && scheme != "https" {
 		return "", types.RpcErrorInvalidParams("Only http and https is supported.")
+	}
+	hostname := strings.ToLower(u.Hostname())
+	if hostname == "" {
+		return "", parseErr
+	}
+	if ip := net.ParseIP(hostname); ip != nil {
+		hostname = ip.String()
 	}
 	port := u.Port()
 	if port == "" {
@@ -241,22 +400,45 @@ func parseRPCSubURL(raw string) (string, *types.RpcError) {
 		} else {
 			port = "80"
 		}
-	} else if n, err := strconv.Atoi(port); err != nil || n < 1 || n > 65535 {
-		return "", parseErr
+	} else {
+		n, err := strconv.Atoi(port)
+		if err != nil || n < 1 || n > 65535 {
+			return "", parseErr
+		}
+		port = strconv.Itoa(n)
 	}
-	return scheme + "://" + net.JoinHostPort(u.Hostname(), port) + u.RequestURI(), nil
+	requestURI := u.RequestURI()
+	if requestURI == "/" && u.RawQuery == "" && !u.ForceQuery {
+		requestURI = ""
+	}
+	return scheme + "://" + net.JoinHostPort(hostname, port) + requestURI, nil
+}
+
+func rpcSubPrincipal(ctx *types.RpcContext) string {
+	if ctx == nil {
+		return "unknown"
+	}
+	if principal := strings.TrimSpace(ctx.ClientIP); principal != "" {
+		return principal
+	}
+	return "unknown"
 }
 
 // rpcSub is one url subscription: a subscription-manager connection whose
 // send channel is drained by a delivery goroutine POSTing each event to the
 // url, one at a time and in order, like RPCSub::sendThread.
 type rpcSub struct {
-	endpoint string
-	client   *http.Client
-	ctx      context.Context
-	conn     *types.Connection
-	done     chan struct{}
-	finished chan struct{}
+	endpoint  string
+	client    *http.Client
+	ctx       context.Context
+	cancel    context.CancelFunc
+	registry  *URLSubscriptionRegistry
+	principal string
+	metrics   *rpcSubMetrics
+	conn      *types.Connection
+	done      chan struct{}
+	finished  chan struct{}
+	stopOnce  sync.Once
 
 	credMu   sync.Mutex
 	username string
@@ -309,12 +491,34 @@ func (s *rpcSub) credentials() (string, string) {
 }
 
 func (s *rpcSub) stop() {
-	close(s.done)
+	s.stopOnce.Do(func() {
+		if s.cancel != nil {
+			s.cancel()
+		}
+		if s.done != nil {
+			close(s.done)
+		}
+	})
 }
 
 func (s *rpcSub) run() {
-	defer close(s.finished)
+	defer func() {
+		if s.registry != nil {
+			s.registry.workerStopped(s.principal)
+		}
+		if s.finished != nil {
+			close(s.finished)
+		}
+		if s.registry != nil {
+			s.registry.workerWG.Done()
+		}
+	}()
 	for {
+		select {
+		case <-s.done:
+			return
+		default:
+		}
 		select {
 		case data := <-s.conn.SendChannel:
 			s.deliver(data)
@@ -322,6 +526,20 @@ func (s *rpcSub) run() {
 			return
 		}
 	}
+}
+
+func (r *URLSubscriptionRegistry) workerStopped(principal string) {
+	r.mu.Lock()
+	if r.workers > 0 {
+		r.workers--
+	}
+	if r.principalWorkers[principal] > 0 {
+		r.principalWorkers[principal]--
+		if r.principalWorkers[principal] == 0 {
+			delete(r.principalWorkers, principal)
+		}
+	}
+	r.mu.Unlock()
 }
 
 // deliver POSTs one already-encoded event — the JSON-RPC call rippled's
@@ -332,6 +550,7 @@ func (s *rpcSub) run() {
 func (s *rpcSub) deliver(body []byte) {
 	req, err := http.NewRequestWithContext(s.ctx, http.MethodPost, s.endpoint, bytes.NewReader(body))
 	if err != nil {
+		s.recordDeliveryFailure("request_build", "err", err)
 		wsLog().Error("rpcsub: request build failed", "url", s.endpoint, "err", err)
 		return
 	}
@@ -345,9 +564,28 @@ func (s *rpcSub) deliver(body []byte) {
 
 	resp, err := s.client.Do(req)
 	if err != nil {
-		wsLog().Info("rpcsub: event delivery failed", "url", s.endpoint, "err", err)
+		if s.ctx.Err() == nil {
+			s.recordDeliveryFailure("request", "err", err)
+			wsLog().Debug("rpcsub: event delivery failed", "url", s.endpoint, "err", err)
+		}
 		return
 	}
-	_, _ = io.Copy(io.Discard, resp.Body)
+	failed := resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices
+	if failed {
+		s.recordDeliveryFailure("status", "status", resp.StatusCode)
+		wsLog().Debug("rpcsub: event delivery returned failure", "url", s.endpoint, "status", resp.StatusCode)
+	}
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		if !failed {
+			s.recordDeliveryFailure("response_read", "err", err)
+		}
+		wsLog().Debug("rpcsub: event response read failed", "url", s.endpoint, "err", err)
+	}
 	_ = resp.Body.Close()
+}
+
+func (s *rpcSub) recordDeliveryFailure(reason string, details ...any) {
+	if s.metrics != nil {
+		s.metrics.recordDeliveryFailure(s.endpoint, reason, details...)
+	}
 }

--- a/internal/rpc/rpcsub_test.go
+++ b/internal/rpc/rpcsub_test.go
@@ -1,15 +1,18 @@
 package rpc
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
-	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,6 +31,23 @@ type rpcSubEvent struct {
 	ID            any            `json:"id"`
 	authorization string
 	userAgent     string
+}
+
+type blockingRPCSubTransport struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (t *blockingRPCSubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.once.Do(func() { close(t.started) })
+	<-t.release
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader("{}")),
+		Request:    req,
+	}, nil
 }
 
 func newRPCSubSink(t *testing.T) *rpcSubSink {
@@ -217,6 +237,10 @@ func TestRPCSub_URLValidation(t *testing.T) {
 	}{
 		{"unsupported scheme", `{"url":"ftp://example.com/events"}`, "Only http and https is supported."},
 		{"empty url member", `{"url":""}`, "Failed to parse url."},
+		{"empty host", `{"url":"http://"}`, "Failed to parse url."},
+		{"embedded credentials", `{"url":"http://alice:secret@example.com/events"}`, "Failed to parse url."},
+		{"fragment", `{"url":"http://example.com/events#fragment"}`, "Failed to parse url."},
+		{"outer whitespace", `{"url":" http://example.com/events"}`, "Failed to parse url."},
 		{"port out of range", `{"url":"http://example.com:99999/x"}`, "Failed to parse url."},
 		{"not a url", `{"url":"::not a url::"}`, "Failed to parse url."},
 	}
@@ -232,7 +256,7 @@ func TestRPCSub_URLValidation(t *testing.T) {
 	}
 }
 
-func TestRPCSubBooksApplyInWireOrder(t *testing.T) {
+func TestRPCSubBooksApplyTransactionally(t *testing.T) {
 	const account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
 	ws, services := newRPCSubTestServer(t)
 	sink := newRPCSubSink(t)
@@ -244,16 +268,16 @@ func TestRPCSubBooksApplyInWireOrder(t *testing.T) {
 
 	_, rpcErr := method.Handle(ctx, json.RawMessage(params))
 	require.NotNil(t, rpcErr)
-	assert.Equal(t, uint32(loadtrack.LoadMedium), ctx.LoadCost)
+	assert.Zero(t, ctx.LoadCost, "a failed transactional request must not charge per-book work")
 
 	ws.urlSubs.mu.Lock()
 	sub := ws.urlSubs.subs[sink.srv.URL]
 	ws.urlSubs.mu.Unlock()
-	require.NotNil(t, sub)
-	assert.Len(t, sub.conn.Subscriptions[types.SubBook].Books, 1)
+	assert.Nil(t, sub, "a failed new URL request must remove its worker and registry entry")
+	assert.Zero(t, ws.SubscriptionManager().ConnectionCount())
 }
 
-func TestRPCSubBookUnsubscribeAppliesInWireOrder(t *testing.T) {
+func TestRPCSubBookUnsubscribeTransactionally(t *testing.T) {
 	const account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
 	ws, services := newRPCSubTestServer(t)
 	sink := newRPCSubSink(t)
@@ -271,27 +295,20 @@ func TestRPCSubBookUnsubscribeAppliesInWireOrder(t *testing.T) {
 	ws.urlSubs.mu.Unlock()
 	require.NotNil(t, sub)
 	books := sub.conn.Subscriptions[types.SubBook].Books
-	require.Len(t, books, 1)
-	encoded, err := json.Marshal(books[0])
-	require.NoError(t, err)
-	assert.JSONEq(t, second, string(encoded))
+	require.Len(t, books, 2, "a failed unsubscribe must restore the earlier book removal")
+	assert.Equal(t, 2, len(books))
 }
 
-// TestRPCSub_EmptyHostAcceptedAtSubscribe mirrors rippled's parseUrl host
-// group matching the empty string: "http://" registers successfully and a
-// delivery only fails (harmlessly) at connect time, fire-and-forget.
-func TestRPCSub_EmptyHostAcceptedAtSubscribe(t *testing.T) {
+// TestRPCSub_EmptyHostRejectedAtSubscribe rejects an ambiguous destination
+// before allocating a registry entry or delivery worker.
+func TestRPCSub_EmptyHostRejectedAtSubscribe(t *testing.T) {
 	ws, services := newRPCSubTestServer(t)
 
 	result, rpcErr := subscribeURL(t, services, `{"url":"http://","streams":["ledger"]}`)
-	require.Nil(t, rpcErr, "empty-host url must register, like rippled")
-	assert.NotNil(t, result)
-	assert.Equal(t, 1, ws.SubscriptionManager().ConnectionCount())
-
-	// A broadcast to the unconnectable endpoint must not panic or block —
-	// the delivery goroutine logs and drops it.
-	data, _ := json.Marshal(map[string]any{"type": "ledgerClosed"})
-	ws.SubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Zero(t, ws.SubscriptionManager().ConnectionCount())
 }
 
 // TestRPCSub_UnsubscribeRemovesEntry verifies the tryRemoveRPCSub
@@ -326,6 +343,21 @@ func TestRPCSub_UnsubscribeRemovesEntry(t *testing.T) {
 	result, rpcErr := unsubscribeURL(t, services, `{"url":"http://example.com/none","streams":["ledger"]}`)
 	require.Nil(t, rpcErr)
 	assert.Equal(t, map[string]any{}, result)
+}
+
+func TestRPCSub_UnsubscribeMalformedUnknownURLsAreSilent(t *testing.T) {
+	_, services := newRPCSubTestServer(t)
+	for _, params := range []string{
+		`{"url":""}`,
+		`{"url":"::not a url::"}`,
+		`{"url":"ftp://example.com/events"}`,
+		`{"url":"http://"}`,
+		`{"url":" http://example.com/events"}`,
+	} {
+		result, rpcErr := unsubscribeURL(t, services, params)
+		assert.Nil(t, rpcErr, "params=%s", params)
+		assert.Equal(t, map[string]any{}, result, "params=%s", params)
+	}
 }
 
 // TestRPCSub_AccountsDontBlockRemoval mirrors NetworkOPs::tryRemoveRPCSub
@@ -523,18 +555,375 @@ func TestRPCSub_ReuseSharesSubscriber(t *testing.T) {
 	sink.expectNone(t)
 }
 
-// TestRPCSub_MalformedStreamKeepsEntry mirrors doSubscribe creating the
-// registry entry before parsing streams: a bad stream name errors but the
-// url remains registered for reuse.
-func TestRPCSub_MalformedStreamKeepsEntry(t *testing.T) {
+func TestRPCSub_ExistingSubscribeRollsBackStateAndCredentials(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	sink := newRPCSubSink(t)
+	urlParam := `"url":"` + sink.srv.URL + `"`
+
+	_, rpcErr := subscribeURL(t, services, `{`+urlParam+`,"url_username":"before","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	ws.urlSubs.mu.Lock()
+	sub := ws.urlSubs.subs[sink.srv.URL]
+	before := ws.SubscriptionManager().ConnectionSubscriptions(sub.conn.ID)
+	ws.urlSubs.mu.Unlock()
+	require.NotNil(t, sub)
+
+	_, rpcErr = subscribeURL(t, services, `{`+urlParam+`,"username":"after","streams":["transactions","invalid"]}`)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcSTREAM_MALFORMED, rpcErr.Code)
+
+	after := ws.SubscriptionManager().ConnectionSubscriptions(sub.conn.ID)
+	assert.Equal(t, before, after)
+	username, _ := sub.credentials()
+	assert.Equal(t, "before", username, "failed application must restore credentials")
+}
+
+func TestRPCSub_CanonicalURLReuseAndUnsubscribe(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	sink := newRPCSubSink(t)
+	rawURL := sink.srv.URL
+	canonicalVariant := strings.ToUpper("http") + strings.TrimPrefix(rawURL, "http") + "/"
+
+	_, rpcErr := subscribeURL(t, services, `{"url":"`+rawURL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	_, rpcErr = subscribeURL(t, services, `{"url":"`+canonicalVariant+`","streams":["transactions"]}`)
+	require.Nil(t, rpcErr)
+	assert.Equal(t, 1, ws.SubscriptionManager().ConnectionCount())
+	ws.urlSubs.mu.Lock()
+	assert.Len(t, ws.urlSubs.subs, 1)
+	ws.urlSubs.mu.Unlock()
+
+	_, rpcErr = unsubscribeURL(t, services, `{"url":"`+canonicalVariant+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	_, rpcErr = unsubscribeURL(t, services, `{"url":"`+rawURL+`","streams":["transactions"]}`)
+	require.Nil(t, rpcErr)
+	assert.Zero(t, ws.SubscriptionManager().ConnectionCount())
+	ws.urlSubs.mu.Lock()
+	assert.Empty(t, ws.urlSubs.subs)
+	ws.urlSubs.mu.Unlock()
+}
+
+func TestRPCSub_IPLiteralCanonicalReuseAndUnsubscribe(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	defer ws.urlSubs.Close()
+	ctx := adminCtx(services)
+	expanded := "http://[0:0:0:0:0:0:0:1]:18080/events?token=one"
+	compressed := "http://[::1]:18080/events?token=one"
+
+	_, rpcErr := ws.urlSubs.Subscribe(ctx, types.SubscriptionRequest{
+		URL: expanded, Streams: []types.SubscriptionType{types.SubLedger},
+	})
+	require.Nil(t, rpcErr)
+	_, rpcErr = ws.urlSubs.Subscribe(ctx, types.SubscriptionRequest{
+		URL: compressed, Streams: []types.SubscriptionType{types.SubTransactions},
+	})
+	require.Nil(t, rpcErr)
+	assert.Equal(t, 1, ws.SubscriptionManager().ConnectionCount())
+
+	_, rpcErr = ws.urlSubs.Unsubscribe(ctx, types.SubscriptionRequest{
+		URL: expanded, Streams: []types.SubscriptionType{types.SubLedger},
+	})
+	require.Nil(t, rpcErr)
+	_, rpcErr = ws.urlSubs.Unsubscribe(ctx, types.SubscriptionRequest{
+		URL: compressed, Streams: []types.SubscriptionType{types.SubTransactions},
+	})
+	require.Nil(t, rpcErr)
+	assert.Zero(t, ws.SubscriptionManager().ConnectionCount())
+}
+
+func TestRPCSub_SubscribeAfterClosePrecedesURLValidation(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	ws.urlSubs.Close()
+
+	for _, params := range []string{
+		`{"url":"not a url"}`,
+		`{"url":"ftp://example.com/events"}`,
+	} {
+		result, rpcErr := subscribeURL(t, services, params)
+		assert.Nil(t, result, "params=%s", params)
+		require.NotNil(t, rpcErr, "params=%s", params)
+		assert.Equal(t, types.RpcINTERNAL, rpcErr.Code, "params=%s", params)
+	}
+}
+
+func TestRPCSub_BoundsGlobalAndPerPrincipal(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	first := newRPCSubSink(t)
+	second := newRPCSubSink(t)
+	third := newRPCSubSink(t)
+	ws.urlSubs.maxEntries = 1
+	ws.urlSubs.maxWorkers = 1
+	ws.urlSubs.maxPerPrincipal = 100
+
+	_, rpcErr := subscribeURL(t, services, `{"url":"`+first.srv.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	_, rpcErr = subscribeURL(t, services, `{"url":"`+second.srv.URL+`","streams":["ledger"]}`)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcTOO_BUSY, rpcErr.Code)
+	assert.Equal(t, 1, ws.SubscriptionManager().ConnectionCount())
+	ws.urlSubs.mu.Lock()
+	assert.Len(t, ws.urlSubs.subs, 1)
+	ws.urlSubs.mu.Unlock()
+	assert.Equal(t, uint64(1), ws.urlSubs.metricsSnapshot().CapacityRejects)
+
+	_, rpcErr = unsubscribeURL(t, services, `{"url":"`+first.srv.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	assert.Eventually(t, func() bool {
+		ws.urlSubs.mu.Lock()
+		defer ws.urlSubs.mu.Unlock()
+		return ws.urlSubs.workers == 0
+	}, time.Second, time.Millisecond)
+	_, rpcErr = subscribeURL(t, services, `{"url":"`+second.srv.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+
+	ws.urlSubs.maxEntries = 0
+	ws.urlSubs.maxWorkers = 0
+	ws.urlSubs.maxPerPrincipal = 1
+	ctx := adminCtx(services)
+	ctx.ClientIP = "principal-a"
+	_, rpcErr = ws.urlSubs.Subscribe(ctx, types.SubscriptionRequest{URL: third.srv.URL, Streams: []types.SubscriptionType{types.SubLedger}})
+	require.Nil(t, rpcErr)
+	fourth := newRPCSubSink(t)
+	_, rpcErr = ws.urlSubs.Subscribe(ctx, types.SubscriptionRequest{URL: fourth.srv.URL, Streams: []types.SubscriptionType{types.SubLedger}})
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcTOO_BUSY, rpcErr.Code)
+	ctx.ClientIP = "principal-b"
+	_, rpcErr = ws.urlSubs.Subscribe(ctx, types.SubscriptionRequest{URL: fourth.srv.URL, Streams: []types.SubscriptionType{types.SubLedger}})
+	require.Nil(t, rpcErr)
+}
+
+func TestRPCSub_WorkerCapacityReclaimedBeforeUnsubscribeReturns(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	first := newRPCSubSink(t)
+	second := newRPCSubSink(t)
+	ws.urlSubs.maxWorkers = 1
+
+	_, rpcErr := subscribeURL(t, services, `{"url":"`+first.srv.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	_, rpcErr = unsubscribeURL(t, services, `{"url":"`+first.srv.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+
+	ws.urlSubs.mu.Lock()
+	workers := ws.urlSubs.workers
+	ws.urlSubs.mu.Unlock()
+	assert.Zero(t, workers, "unsubscribe must not return before worker-cap accounting is released")
+
+	_, rpcErr = subscribeURL(t, services, `{"url":"`+second.srv.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr, "an immediate replacement must fit the reclaimed worker slot")
+}
+
+func TestRPCSub_PrincipalWorkerCapDuringRetirement(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	defer ws.urlSubs.Close()
+	ws.urlSubs.maxEntries = 8
+	ws.urlSubs.maxWorkers = 8
+	ws.urlSubs.maxPerPrincipal = 1
+
+	transport := &blockingRPCSubTransport{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	ws.urlSubs.client.Transport = transport
+	ctx := adminCtx(services)
+	ctx.ClientIP = "principal-retiring"
+	first := types.SubscriptionRequest{
+		URL: "http://127.0.0.1:18081/blocked", Streams: []types.SubscriptionType{types.SubLedger},
+	}
+	replacement := types.SubscriptionRequest{
+		URL: "http://127.0.0.1:18082/replacement", Streams: []types.SubscriptionType{types.SubLedger},
+	}
+	_, rpcErr := ws.urlSubs.Subscribe(ctx, first)
+	require.Nil(t, rpcErr)
+
+	data, err := json.Marshal(map[string]any{"type": "ledgerClosed"})
+	require.NoError(t, err)
+	ws.SubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
+	select {
+	case <-transport.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for blocked delivery")
+	}
+
+	unsubDone := make(chan *types.RpcError, 1)
+	go func() {
+		_, unsubErr := ws.urlSubs.Unsubscribe(ctx, first)
+		unsubDone <- unsubErr
+	}()
+
+	assert.Eventually(t, func() bool {
+		ws.urlSubs.mu.Lock()
+		defer ws.urlSubs.mu.Unlock()
+		return len(ws.urlSubs.subs) == 0 && ws.urlSubs.principalCounts[ctx.ClientIP] == 0 && ws.urlSubs.principalWorkers[ctx.ClientIP] == 1
+	}, time.Second, time.Millisecond, "retiring worker must retain the principal charge")
+
+	maxLive := 0
+	for i := 0; i < 100; i++ {
+		_, rpcErr = ws.urlSubs.Subscribe(ctx, replacement)
+		require.NotNil(t, rpcErr, "replacement %d should remain blocked while the old worker is retiring", i)
+		assert.Equal(t, types.RpcTOO_BUSY, rpcErr.Code)
+		ws.urlSubs.mu.Lock()
+		live := ws.urlSubs.principalWorkers[ctx.ClientIP]
+		ws.urlSubs.mu.Unlock()
+		if live > maxLive {
+			maxLive = live
+		}
+	}
+	assert.LessOrEqual(t, maxLive, ws.urlSubs.maxPerPrincipal)
+
+	close(transport.release)
+	select {
+	case unsubErr := <-unsubDone:
+		require.Nil(t, unsubErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("unsubscribe did not join the retiring worker")
+	}
+
+	ws.urlSubs.mu.Lock()
+	live := ws.urlSubs.principalWorkers[ctx.ClientIP]
+	ws.urlSubs.mu.Unlock()
+	assert.Zero(t, live)
+	_, rpcErr = ws.urlSubs.Subscribe(ctx, replacement)
+	require.Nil(t, rpcErr, "replacement should fit once the old worker exits")
+	_, rpcErr = ws.urlSubs.Unsubscribe(ctx, replacement)
+	require.Nil(t, rpcErr)
+}
+
+func TestRPCSub_ConcurrentSubscribeUnsubscribeWorkerAccounting(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	const (
+		goroutines = 8
+		iterations = 20
+	)
+	ws.urlSubs.maxEntries = goroutines
+	ws.urlSubs.maxWorkers = goroutines
+	ws.urlSubs.maxPerPrincipal = goroutines
+
+	sinks := make([]*rpcSubSink, goroutines)
+	for i := range sinks {
+		sinks[i] = newRPCSubSink(t)
+	}
+
+	var wg sync.WaitGroup
+	for _, sink := range sinks {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx := adminCtx(services)
+			ctx.ClientIP = sink.srv.URL
+			request := types.SubscriptionRequest{URL: sink.srv.URL, Streams: []types.SubscriptionType{types.SubLedger}}
+			for i := 0; i < iterations; i++ {
+				if _, rpcErr := ws.urlSubs.Subscribe(ctx, request); rpcErr != nil {
+					t.Errorf("subscribe iteration %d: %v", i, rpcErr)
+					return
+				}
+				if _, rpcErr := ws.urlSubs.Unsubscribe(ctx, request); rpcErr != nil {
+					t.Errorf("unsubscribe iteration %d: %v", i, rpcErr)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	ws.urlSubs.mu.Lock()
+	workers, entries := ws.urlSubs.workers, len(ws.urlSubs.subs)
+	ws.urlSubs.mu.Unlock()
+	assert.Zero(t, workers)
+	assert.Zero(t, entries)
+}
+
+func TestRPCSub_DeliveryObservability(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	sink := newRPCSubSink(t)
+	_, rpcErr := subscribeURL(t, services, `{"url":"`+sink.srv.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	ws.urlSubs.mu.Lock()
+	sub := ws.urlSubs.subs[sink.srv.URL]
+	ws.urlSubs.mu.Unlock()
+	require.NotNil(t, sub)
+	sub.stop()
+	<-sub.finished
+	data, _ := json.Marshal(map[string]any{"type": "ledgerClosed"})
+	for i := 0; i < rpcSubQueueLimit+4; i++ {
+		ws.SubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
+	}
+	snapshot := ws.urlSubs.metricsSnapshot()
+	assert.Equal(t, uint64(rpcSubQueueLimit), snapshot.Queued)
+	assert.Equal(t, uint64(4), snapshot.Dropped)
+
+	failing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer failing.Close()
+	failed := &rpcSub{endpoint: failing.URL, client: failing.Client(), ctx: context.Background(), metrics: &rpcSubMetrics{}}
+	failed.deliver([]byte(`{"method":"event"}`))
+	assert.Equal(t, uint64(1), failed.metrics.snapshot().DeliveryFailures)
+
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", failing.URL)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer redirect.Close()
+	redirectClient := redirect.Client()
+	redirectClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	redirected := &rpcSub{endpoint: redirect.URL, client: redirectClient, ctx: context.Background(), metrics: &rpcSubMetrics{}}
+	redirected.deliver([]byte(`{"method":"event"}`))
+	assert.Equal(t, uint64(1), redirected.metrics.snapshot().DeliveryFailures)
+}
+
+func TestRPCSub_ProductionClientTreatsRedirectAsFailure(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	defer ws.urlSubs.Close()
+	redirectHits := make(chan struct{}, 1)
+	targetHits := make(chan struct{}, 1)
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		targetHits <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case redirectHits <- struct{}{}:
+		default:
+		}
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer redirect.Close()
+
+	_, rpcErr := subscribeURL(t, services, `{"url":"`+redirect.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	data, err := json.Marshal(map[string]any{"type": "ledgerClosed"})
+	require.NoError(t, err)
+	ws.SubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
+	select {
+	case <-redirectHits:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for production URL client request")
+	}
+	assert.Eventually(t, func() bool {
+		return ws.urlSubs.metricsSnapshot().DeliveryFailures == 1
+	}, time.Second, time.Millisecond)
+	select {
+	case <-targetHits:
+		t.Fatal("redirect target must not receive a request")
+	default:
+	}
+}
+
+// TestRPCSub_MalformedStreamRollsBackEntry ensures a failed new URL request
+// leaves no registry entry or manager connection behind.
+func TestRPCSub_MalformedStreamRollsBackEntry(t *testing.T) {
 	ws, services := newRPCSubTestServer(t)
 	sink := newRPCSubSink(t)
 
 	_, rpcErr := subscribeURL(t, services, `{"url":"`+sink.srv.URL+`","streams":["nonsense"]}`)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcSTREAM_MALFORMED, rpcErr.Code)
-	assert.Equal(t, 1, ws.SubscriptionManager().ConnectionCount(),
-		"failed stream parse leaves the freshly created url entry, like rippled")
+	assert.Equal(t, 0, ws.SubscriptionManager().ConnectionCount(),
+		"failed stream parse must roll back the newly created URL entry")
 }
 
 // TestRPCSub_CloseStopsDelivery verifies registry shutdown through
@@ -552,6 +941,142 @@ func TestRPCSub_CloseStopsDelivery(t *testing.T) {
 	data, _ := json.Marshal(map[string]any{"type": "ledgerClosed"})
 	ws.SubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
 	sink.expectNone(t)
+}
+
+func TestRPCSub_CloseCancelsInFlightDelivery(t *testing.T) {
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		close(started)
+		<-r.Context().Done()
+		close(canceled)
+	}))
+	t.Cleanup(sink.Close)
+
+	ws, services := newRPCSubTestServer(t)
+	_, rpcErr := subscribeURL(t, services, `{"url":"`+sink.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	ws.urlSubs.mu.Lock()
+	sub := ws.urlSubs.subs[sink.URL]
+	ws.urlSubs.mu.Unlock()
+	require.NotNil(t, sub)
+	data, err := json.Marshal(map[string]any{"type": "ledgerClosed"})
+	require.NoError(t, err)
+	ws.SubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for in-flight delivery")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- ws.Close(t.Context())
+	}()
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not cancel and join in-flight delivery")
+	}
+	assert.Error(t, sub.ctx.Err())
+	select {
+	case <-canceled:
+	case <-time.After(2 * time.Second):
+		sink.CloseClientConnections()
+		t.Fatal("in-flight request context was not canceled")
+	}
+}
+
+func TestRPCSub_CloseJoinsRetiringWorker(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	ws.urlSubs.maxEntries = 4
+	ws.urlSubs.maxWorkers = 4
+	ws.urlSubs.maxPerPrincipal = 1
+	transport := &blockingRPCSubTransport{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	ws.urlSubs.client.Transport = transport
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			close(transport.release)
+		}
+		ws.urlSubs.Close()
+	})
+
+	ctx := adminCtx(services)
+	ctx.ClientIP = "principal-close"
+	request := types.SubscriptionRequest{
+		URL: "http://127.0.0.1:18084/blocked", Streams: []types.SubscriptionType{types.SubLedger},
+	}
+	_, rpcErr := ws.urlSubs.Subscribe(ctx, request)
+	require.Nil(t, rpcErr)
+	ws.urlSubs.mu.Lock()
+	sub := ws.urlSubs.subs[request.URL]
+	ws.urlSubs.mu.Unlock()
+	require.NotNil(t, sub)
+	data, err := json.Marshal(map[string]any{"type": "ledgerClosed"})
+	require.NoError(t, err)
+	ws.SubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
+	select {
+	case <-transport.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for blocked delivery")
+	}
+
+	unsubDone := make(chan *types.RpcError, 1)
+	go func() {
+		_, unsubErr := ws.urlSubs.Unsubscribe(ctx, request)
+		unsubDone <- unsubErr
+	}()
+	assert.Eventually(t, func() bool {
+		ws.urlSubs.mu.Lock()
+		defer ws.urlSubs.mu.Unlock()
+		return len(ws.urlSubs.subs) == 0 && ws.urlSubs.principalWorkers[ctx.ClientIP] == 1
+	}, time.Second, time.Millisecond)
+
+	closeDone := make(chan struct{})
+	go func() {
+		ws.urlSubs.Close()
+		close(closeDone)
+	}()
+	select {
+	case <-closeDone:
+		t.Fatal("Close returned while a removed worker was still retiring")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(transport.release)
+	released = true
+	select {
+	case unsubErr := <-unsubDone:
+		require.Nil(t, unsubErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("unsubscribe did not join the retiring worker")
+	}
+	select {
+	case <-closeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not join the retiring worker")
+	}
+
+	ws.urlSubs.mu.Lock()
+	workers := ws.urlSubs.workers
+	principalWorkers := ws.urlSubs.principalWorkers[ctx.ClientIP]
+	ws.urlSubs.mu.Unlock()
+	assert.Zero(t, workers)
+	assert.Zero(t, principalWorkers)
+	select {
+	case <-sub.finished:
+	default:
+		t.Fatal("Close returned before the worker signaled finished")
+	}
 }
 
 func TestRPCSub_ConcurrentCloseWaitsForDeliveryLoops(t *testing.T) {

--- a/internal/rpc/rpcsub_test.go
+++ b/internal/rpc/rpcsub_test.go
@@ -299,8 +299,6 @@ func TestRPCSubBookUnsubscribeTransactionally(t *testing.T) {
 	assert.Equal(t, 2, len(books))
 }
 
-// TestRPCSub_EmptyHostRejectedAtSubscribe rejects an ambiguous destination
-// before allocating a registry entry or delivery worker.
 func TestRPCSub_EmptyHostRejectedAtSubscribe(t *testing.T) {
 	ws, services := newRPCSubTestServer(t)
 
@@ -913,8 +911,6 @@ func TestRPCSub_ProductionClientTreatsRedirectAsFailure(t *testing.T) {
 	}
 }
 
-// TestRPCSub_MalformedStreamRollsBackEntry ensures a failed new URL request
-// leaves no registry entry or manager connection behind.
 func TestRPCSub_MalformedStreamRollsBackEntry(t *testing.T) {
 	ws, services := newRPCSubTestServer(t)
 	sink := newRPCSubSink(t)

--- a/internal/rpc/subscription/manager.go
+++ b/internal/rpc/subscription/manager.go
@@ -65,6 +65,28 @@ func NewManager() *Manager {
 	}
 }
 
+func cloneSubscriptions(src map[types.SubscriptionType]types.SubscriptionConfig) map[types.SubscriptionType]types.SubscriptionConfig {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[types.SubscriptionType]types.SubscriptionConfig, len(src))
+	for key, cfg := range src {
+		copyCfg := cfg
+		copyCfg.Accounts = append([]string(nil), cfg.Accounts...)
+		if cfg.Books != nil {
+			copyCfg.Books = make([]types.BookRequest, len(cfg.Books))
+			for i, book := range cfg.Books {
+				copyBook := book
+				copyBook.TakerPays = append([]byte(nil), book.TakerPays...)
+				copyBook.TakerGets = append([]byte(nil), book.TakerGets...)
+				copyCfg.Books[i] = copyBook
+			}
+		}
+		dst[key] = copyCfg
+	}
+	return dst
+}
+
 // AddConnection adds a connection to the subscription manager
 func (sm *Manager) AddConnection(conn *types.Connection) {
 	sm.mu.Lock()
@@ -91,10 +113,33 @@ func (sm *Manager) RemoveConnection(connID string) {
 // URLSubscriptionRegistry, whose per-url connection is what gets
 // subscribed here.
 func (sm *Manager) HandleSubscribe(conn *types.Connection, request types.SubscriptionRequest, isAdmin bool) *types.RpcError {
-	w := request.WireArrays()
-
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
+	return sm.handleSubscribeLocked(conn, request, isAdmin)
+}
+
+// HandleSubscribeTransactional applies a subscribe request as one atomic
+// operation. The regular WebSocket path intentionally preserves rippled's
+// per-item mutation semantics; URL subscriptions use this variant so a
+// malformed later field cannot leave an earlier stream/account/book attached.
+func (sm *Manager) HandleSubscribeTransactional(conn *types.Connection, request types.SubscriptionRequest, isAdmin bool) *types.RpcError {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	snapshot := cloneSubscriptions(conn.Subscriptions)
+	original := conn.Subscriptions
+	apiVersion := conn.APIVersion()
+	if rpcErr := sm.handleSubscribeLocked(conn, request, isAdmin); rpcErr != nil {
+		conn.Subscriptions = original
+		restoreSubscriptions(conn.Subscriptions, snapshot)
+		conn.SetAPIVersion(apiVersion)
+		return rpcErr
+	}
+	return nil
+}
+
+func (sm *Manager) handleSubscribeLocked(conn *types.Connection, request types.SubscriptionRequest, isAdmin bool) *types.RpcError {
+	w := request.WireArrays()
 	conn.SetAPIVersion(request.ApiVersion)
 
 	// Streams. "rt_transactions" is the deprecated alias rippled keeps around
@@ -578,10 +623,40 @@ func isValidDomainHex(domain string) bool {
 // can also unsubscribe with the alias (Unsubscribe.cpp:88-93). Like
 // HandleSubscribe, the url (RPCSub) branch is resolved by the caller.
 func (sm *Manager) HandleUnsubscribe(conn *types.Connection, request types.SubscriptionRequest, isAdmin bool) *types.RpcError {
-	w := request.WireArrays()
-
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
+	return sm.handleUnsubscribeLocked(conn, request, isAdmin)
+}
+
+// HandleUnsubscribeTransactional applies a URL unsubscribe request as one
+// atomic operation. This keeps an invalid later stream/account/book from
+// removing earlier entries from an existing URL subscription.
+func (sm *Manager) HandleUnsubscribeTransactional(conn *types.Connection, request types.SubscriptionRequest, isAdmin bool) *types.RpcError {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	snapshot := cloneSubscriptions(conn.Subscriptions)
+	original := conn.Subscriptions
+	if rpcErr := sm.handleUnsubscribeLocked(conn, request, isAdmin); rpcErr != nil {
+		conn.Subscriptions = original
+		restoreSubscriptions(conn.Subscriptions, snapshot)
+		return rpcErr
+	}
+	return nil
+}
+
+func restoreSubscriptions(dst, snapshot map[types.SubscriptionType]types.SubscriptionConfig) {
+	if dst == nil {
+		return
+	}
+	clear(dst)
+	for key, cfg := range snapshot {
+		dst[key] = cfg
+	}
+}
+
+func (sm *Manager) handleUnsubscribeLocked(conn *types.Connection, request types.SubscriptionRequest, isAdmin bool) *types.RpcError {
+	w := request.WireArrays()
 
 	_, streams, rpcErr := resolveStreams(w.Present, w.Streams, request.Streams)
 	if rpcErr != nil {

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -545,6 +545,10 @@ type Connection struct {
 	// rippled's mSeq++ in send(): a number is consumed even when the
 	// bounded queue then drops the event, so the remote sees a gap.
 	EncodeOutbound func([]byte) []byte
+	// SendObserver receives the result of each non-blocking enqueue. It is
+	// intentionally narrow so internal subscription implementations can expose
+	// queue observability without widening the broadcast API.
+	SendObserver func(queued bool)
 
 	// consecutiveDrops counts back-to-back send failures. Reset to 0
 	// on every successful TrySend.
@@ -587,8 +591,14 @@ func (c *Connection) TrySend(data []byte) bool {
 	select {
 	case c.SendChannel <- data:
 		c.consecutiveDrops.Store(0)
+		if c.SendObserver != nil {
+			c.SendObserver(true)
+		}
 		return true
 	default:
+		if c.SendObserver != nil {
+			c.SendObserver(false)
+		}
 		if c.consecutiveDrops.Add(1) >= MaxConsecutiveDrops {
 			if c.Disconnect != nil {
 				c.Disconnect()


### PR DESCRIPTION
## Summary

- Canonicalize safe URL subscription destinations and apply subscribe/unsubscribe changes transactionally.
- Bound entries, delivery workers, queues, and per-principal ownership while refusing redirects.
- Join active and retiring delivery workers during shutdown.

## Verification

- RPCSub lifecycle, capacity, redirect, cancellation, and teardown tests
- Repeated focused race tests

Refs #1483
