### PR TITLE
refactor(rpc): unify WebSocket connection state

### DIFF
--- a/internal/rpc/path_find_refresh.go
+++ b/internal/rpc/path_find_refresh.go
@@ -47,9 +47,9 @@ type pathFindRefreshManager struct {
 	generation uint64
 	fairCursor int
 	pending    *pathFindRefreshUpdate
-	jobs       map[*WebSocketConnection]pathFindRefreshJob
-	ready      []*WebSocketConnection
-	running    map[*WebSocketConnection]pathFindRefreshJob
+	jobs       map[*websocketConnection]pathFindRefreshJob
+	ready      []*websocketConnection
+	running    map[*websocketConnection]pathFindRefreshJob
 
 	stop       chan struct{}
 	updateWake chan struct{}
@@ -64,8 +64,8 @@ type pathFindRefreshManager struct {
 func newPathFindRefreshManager(ws *WebSocketServer) *pathFindRefreshManager {
 	return &pathFindRefreshManager{
 		ws:         ws,
-		jobs:       make(map[*WebSocketConnection]pathFindRefreshJob),
-		running:    make(map[*WebSocketConnection]pathFindRefreshJob),
+		jobs:       make(map[*websocketConnection]pathFindRefreshJob),
+		running:    make(map[*websocketConnection]pathFindRefreshJob),
 		stop:       make(chan struct{}),
 		updateWake: make(chan struct{}, 1),
 		workWake:   make(chan struct{}, pathFindRefreshWorkerCount),
@@ -126,7 +126,7 @@ func (m *pathFindRefreshManager) enqueue(getView func() (types.LedgerStateView, 
 	}
 	// A newer generation makes all queued work obsolete. In-flight work is
 	// checked against generation before and after pathfinding.
-	m.jobs = make(map[*WebSocketConnection]pathFindRefreshJob)
+	m.jobs = make(map[*websocketConnection]pathFindRefreshJob)
 	m.ready = m.ready[:0]
 	m.mu.Unlock()
 	m.signal(m.updateWake)
@@ -154,7 +154,7 @@ func (m *pathFindRefreshManager) invalidate() {
 	if !m.closed {
 		m.generation++
 		m.pending = nil
-		m.jobs = make(map[*WebSocketConnection]pathFindRefreshJob)
+		m.jobs = make(map[*websocketConnection]pathFindRefreshJob)
 		m.ready = m.ready[:0]
 	}
 	m.mu.Unlock()
@@ -325,11 +325,11 @@ func (m *pathFindRefreshManager) commit(job pathFindRefreshJob, status *PathFind
 	connection := job.target.connection
 	connection.mutex.Lock()
 	defer connection.mutex.Unlock()
-	if connection.pathFindSession != job.target.session || connection.pathFindGeneration != job.target.generation || connection.legacy == nil {
+	if connection.pathFindSession != job.target.session || connection.pathFindGeneration != job.target.generation || connection.Connection == nil {
 		return
 	}
 	job.target.session.commitBuiltEvent(status)
-	job.target.connection.legacy.TrySend(data)
+	job.target.connection.TrySend(data)
 }
 
 func (m *pathFindRefreshManager) waitForPathfindAdmission(job pathFindRefreshJob) (func(), bool) {
@@ -373,7 +373,7 @@ func (m *pathFindRefreshManager) jobCurrent(job pathFindRefreshJob) bool {
 	return m.generationCurrent(job.generation) && job.target.current()
 }
 
-func (m *pathFindRefreshManager) cancel(connection *WebSocketConnection, session *PathFindSession, generation uint64) {
+func (m *pathFindRefreshManager) cancel(connection *websocketConnection, session *PathFindSession, generation uint64) {
 	m.mu.Lock()
 	if job, ok := m.jobs[connection]; ok && job.target.session == session && job.target.generation == generation {
 		delete(m.jobs, connection)
@@ -393,7 +393,7 @@ func (m *pathFindRefreshManager) shutdown() {
 		m.mu.Lock()
 		m.closed = true
 		m.pending = nil
-		m.jobs = make(map[*WebSocketConnection]pathFindRefreshJob)
+		m.jobs = make(map[*websocketConnection]pathFindRefreshJob)
 		m.ready = nil
 		started := m.started
 		m.mu.Unlock()

--- a/internal/rpc/path_find_refresh_test.go
+++ b/internal/rpc/path_find_refresh_test.go
@@ -15,21 +15,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPathFindRefreshTestServer(t *testing.T, count int) (*WebSocketServer, []*WebSocketConnection) {
+func newPathFindRefreshTestServer(t *testing.T, count int) (*WebSocketServer, []*websocketConnection) {
 	t.Helper()
 	ws := NewWebSocketServer(time.Second, nil)
 	manager := ws.ensurePathFindRefreshManager()
-	connections := make([]*WebSocketConnection, 0, count)
+	connections := make([]*websocketConnection, 0, count)
 	ws.connectionsMutex.Lock()
 	for i := range count {
 		id := fmt.Sprintf("conn-%02d", i)
-		conn := &WebSocketConnection{
-			ID:              id,
+		conn := &websocketConnection{
+			Connection:      types.NewConnection(id, make(chan []byte, 8)),
 			pathFindRefresh: manager,
-			legacy: &types.Connection{
-				ID:          id,
-				SendChannel: make(chan []byte, 8),
-			},
 		}
 		conn.installPathFindSession(&PathFindSession{id: id})
 		ws.connections[id] = conn
@@ -257,7 +253,7 @@ func TestPathFindRefreshCloseSuppressesInFlightResult(t *testing.T) {
 		t.Fatal("in-flight refresh did not finish")
 	}
 	select {
-	case <-connections[0].legacy.SendChannel:
+	case <-connections[0].SendChannel:
 		t.Fatal("closed session received a stale refresh")
 	default:
 	}
@@ -294,7 +290,7 @@ func TestPathFindRefreshReplacementStillRuns(t *testing.T) {
 		t.Fatal("replacement session did not refresh")
 	}
 	select {
-	case data := <-connections[0].legacy.SendChannel:
+	case data := <-connections[0].SendChannel:
 		require.Contains(t, string(data), "replacement")
 	case <-time.After(time.Second):
 		t.Fatal("replacement result was not sent")
@@ -440,7 +436,7 @@ func TestPathFindRefreshDoesNotCommitSupersededResult(t *testing.T) {
 	require.Empty(t, status.Alternatives, "a superseded computation must not commit")
 	close(releaseLatest)
 	select {
-	case <-connections[0].legacy.SendChannel:
+	case <-connections[0].SendChannel:
 	case <-time.After(time.Second):
 		t.Fatal("latest refresh was not published")
 	}
@@ -484,7 +480,7 @@ func TestPathFindRefreshSharesPathfindAdmissionPerConnection(t *testing.T) {
 		t.Fatal("latest queued connection job did not run")
 	}
 	select {
-	case <-connections[0].legacy.SendChannel:
+	case <-connections[0].SendChannel:
 	case <-time.After(time.Second):
 		t.Fatal("latest queued connection job was not published")
 	}

--- a/internal/rpc/path_find_refresh_test.go
+++ b/internal/rpc/path_find_refresh_test.go
@@ -75,12 +75,8 @@ func TestQueuePathFindSessionsIncludesNewConnection(t *testing.T) {
 	defer manager.close()
 
 	computed := make(chan struct{}, 1)
-	conn := &WebSocketConnection{
-		ID: "new-connection",
-		legacy: &types.Connection{
-			ID:          "new-connection",
-			SendChannel: make(chan []byte, 1),
-		},
+	conn := &websocketConnection{
+		Connection: types.NewConnection("new-connection", make(chan []byte, 1)),
 	}
 	conn.installPathFindSession(&PathFindSession{
 		computeFn: func(tx.LedgerView) *pathfinder.PathRequestResult {

--- a/internal/rpc/path_find_session_concurrency_test.go
+++ b/internal/rpc/path_find_session_concurrency_test.go
@@ -12,10 +12,7 @@ import (
 func TestPathFindCreateInvalidReplacementClearsOldSession(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	conn := &WebSocketConnection{
-		ctx:         ctx,
-		sendChannel: make(chan []byte, 1),
-	}
+	conn := &websocketConnection{Connection: types.NewConnectionWithContext(ctx, "", make(chan []byte, 1))}
 	old := &PathFindSession{}
 	conn.installPathFindSession(old)
 	before := conn.pathFindGeneration
@@ -35,17 +32,17 @@ func TestPathFindCreateInvalidReplacementClearsOldSession(t *testing.T) {
 func TestPathFindInFlightUpdateDiscardedAfterSessionChange(t *testing.T) {
 	for _, test := range []struct {
 		name   string
-		mutate func(*WebSocketConnection, *PathFindSession)
+		mutate func(*websocketConnection, *PathFindSession)
 	}{
 		{
 			name: "close",
-			mutate: func(conn *WebSocketConnection, _ *PathFindSession) {
+			mutate: func(conn *websocketConnection, _ *PathFindSession) {
 				require.NotNil(t, conn.clearPathFindSession())
 			},
 		},
 		{
 			name: "replacement",
-			mutate: func(conn *WebSocketConnection, replacement *PathFindSession) {
+			mutate: func(conn *websocketConnection, replacement *PathFindSession) {
 				require.NotNil(t, conn.clearPathFindSession())
 				conn.installPathFindSession(replacement)
 			},
@@ -53,9 +50,7 @@ func TestPathFindInFlightUpdateDiscardedAfterSessionChange(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			outbound := make(chan []byte, 1)
-			conn := &WebSocketConnection{
-				legacy: &types.Connection{SendChannel: outbound},
-			}
+			conn := &websocketConnection{Connection: types.NewConnection("", outbound)}
 			old := &PathFindSession{}
 			replacement := &PathFindSession{}
 			conn.installPathFindSession(old)
@@ -92,7 +87,7 @@ func TestPathFindInFlightUpdateDiscardedAfterSessionChange(t *testing.T) {
 
 func TestPathFindCurrentUpdateEnqueues(t *testing.T) {
 	outbound := make(chan []byte, 1)
-	conn := &WebSocketConnection{legacy: &types.Connection{SendChannel: outbound}}
+	conn := &websocketConnection{Connection: types.NewConnection("", outbound)}
 	conn.installPathFindSession(&PathFindSession{})
 	target, ok := conn.snapshotPathFindUpdate()
 	require.True(t, ok)

--- a/internal/rpc/rpcsub.go
+++ b/internal/rpc/rpcsub.go
@@ -268,14 +268,9 @@ func (r *URLSubscriptionRegistry) findOrCreateLocked(request types.SubscriptionR
 		metrics:   metrics,
 		username:  username,
 		password:  password,
-		conn: &types.Connection{
-			ID:            "rpcsub:" + key,
-			Subscriptions: make(map[types.SubscriptionType]types.SubscriptionConfig),
-			SendChannel:   make(chan []byte, rpcSubQueueLimit),
-			CloseChannel:  make(chan struct{}),
-		},
-		done:     make(chan struct{}),
-		finished: make(chan struct{}),
+		conn:      types.NewConnection("rpcsub:"+key, make(chan []byte, rpcSubQueueLimit)),
+		done:      make(chan struct{}),
+		finished:  make(chan struct{}),
 	}
 	sub.conn.EncodeOutbound = sub.encodeOutbound
 	sub.conn.SendObserver = func(queued bool) {
@@ -520,7 +515,7 @@ func (s *rpcSub) run() {
 		default:
 		}
 		select {
-		case data := <-s.conn.SendChannel:
+		case data := <-s.conn.Outbound():
 			s.deliver(data)
 		case <-s.done:
 			return

--- a/internal/rpc/rpcsub.go
+++ b/internal/rpc/rpcsub.go
@@ -268,7 +268,7 @@ func (r *URLSubscriptionRegistry) findOrCreateLocked(request types.SubscriptionR
 		metrics:   metrics,
 		username:  username,
 		password:  password,
-		conn:      types.NewConnection("rpcsub:"+key, make(chan []byte, rpcSubQueueLimit)),
+		conn:      types.NewConnectionWithContext(subCtx, "rpcsub:"+key, make(chan []byte, rpcSubQueueLimit)),
 		done:      make(chan struct{}),
 		finished:  make(chan struct{}),
 	}

--- a/internal/rpc/rpcsub_test.go
+++ b/internal/rpc/rpcsub_test.go
@@ -710,6 +710,28 @@ func TestRPCSub_WorkerCapacityReclaimedBeforeUnsubscribeReturns(t *testing.T) {
 	require.Nil(t, rpcErr, "an immediate replacement must fit the reclaimed worker slot")
 }
 
+func TestRPCSub_UnsubscribeCancelsConnection(t *testing.T) {
+	ws, services := newRPCSubTestServer(t)
+	sink := newRPCSubSink(t)
+
+	_, rpcErr := subscribeURL(t, services, `{"url":"`+sink.srv.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+	ws.urlSubs.mu.Lock()
+	sub := ws.urlSubs.subs[sink.srv.URL]
+	ws.urlSubs.mu.Unlock()
+	require.NotNil(t, sub)
+
+	_, rpcErr = unsubscribeURL(t, services, `{"url":"`+sink.srv.URL+`","streams":["ledger"]}`)
+	require.Nil(t, rpcErr)
+
+	select {
+	case <-sub.conn.Done():
+	default:
+		t.Fatal("unsubscribed connection remains active")
+	}
+	require.False(t, sub.conn.TrySend([]byte(`{}`)))
+}
+
 func TestRPCSub_PrincipalWorkerCapDuringRetirement(t *testing.T) {
 	ws, services := newRPCSubTestServer(t)
 	defer ws.urlSubs.Close()

--- a/internal/rpc/rpcsub_test.go
+++ b/internal/rpc/rpcsub_test.go
@@ -853,21 +853,20 @@ func TestRPCSub_ConcurrentSubscribeUnsubscribeWorkerAccounting(t *testing.T) {
 }
 
 func TestRPCSub_DeliveryObservability(t *testing.T) {
-	ws, services := newRPCSubTestServer(t)
-	sink := newRPCSubSink(t)
-	_, rpcErr := subscribeURL(t, services, `{"url":"`+sink.srv.URL+`","streams":["ledger"]}`)
-	require.Nil(t, rpcErr)
-	ws.urlSubs.mu.Lock()
-	sub := ws.urlSubs.subs[sink.srv.URL]
-	ws.urlSubs.mu.Unlock()
-	require.NotNil(t, sub)
-	sub.stop()
-	<-sub.finished
+	metrics := &rpcSubMetrics{}
+	conn := types.NewConnection("observability", make(chan []byte, rpcSubQueueLimit))
+	conn.SendObserver = func(queued bool) {
+		if queued {
+			metrics.recordQueued("observability")
+		} else {
+			metrics.recordDropped("observability")
+		}
+	}
 	data, _ := json.Marshal(map[string]any{"type": "ledgerClosed"})
 	for i := 0; i < rpcSubQueueLimit+4; i++ {
-		ws.SubscriptionManager().BroadcastToStream(types.SubLedger, data, nil)
+		conn.TrySend(data)
 	}
-	snapshot := ws.urlSubs.metricsSnapshot()
+	snapshot := metrics.snapshot()
 	assert.Equal(t, uint64(rpcSubQueueLimit), snapshot.Queued)
 	assert.Equal(t, uint64(4), snapshot.Dropped)
 

--- a/internal/rpc/send_queue_test.go
+++ b/internal/rpc/send_queue_test.go
@@ -72,7 +72,7 @@ func TestWebSocketSendQueueLimitRealHandshake(t *testing.T) {
 			require.Equal(t, http.StatusSwitchingProtocols, response.StatusCode)
 			t.Cleanup(func() { _ = client.Close() })
 
-			var connection *WebSocketConnection
+			var connection *websocketConnection
 			require.Eventually(t, func() bool {
 				ws.connectionsMutex.RLock()
 				defer ws.connectionsMutex.RUnlock()
@@ -82,7 +82,7 @@ func TestWebSocketSendQueueLimitRealHandshake(t *testing.T) {
 				}
 				return false
 			}, time.Second, time.Millisecond)
-			require.Equal(t, test.want, cap(connection.sendChannel))
+			require.Equal(t, test.want, cap(connection.SendChannel))
 		})
 	}
 }

--- a/internal/rpc/subscribe_test.go
+++ b/internal/rpc/subscribe_test.go
@@ -21,12 +21,7 @@ func newTestSubscriptionManager() *subscription.Manager {
 
 // newTestConnection creates a new Connection for testing
 func newTestConnection(id string) *types.Connection {
-	return &types.Connection{
-		ID:            id,
-		Subscriptions: make(map[types.SubscriptionType]types.SubscriptionConfig),
-		SendChannel:   make(chan []byte, 100),
-		CloseChannel:  make(chan struct{}),
-	}
+	return types.NewConnection(id, make(chan []byte, 100))
 }
 
 // Stream Subscription Tests

--- a/internal/rpc/types/connection_test.go
+++ b/internal/rpc/types/connection_test.go
@@ -1,0 +1,35 @@
+package types
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestConnectionCancelIsConcurrentAndAuthoritative(t *testing.T) {
+	connection := NewConnection("test", make(chan []byte, 1))
+	if connection.Outbound() != connection.SendChannel {
+		t.Fatal("Outbound did not return the canonical queue")
+	}
+	if !connection.TrySend([]byte("before")) {
+		t.Fatal("initial send was rejected")
+	}
+	<-connection.Outbound()
+
+	var cancelers sync.WaitGroup
+	for range 32 {
+		cancelers.Add(1)
+		go func() {
+			defer cancelers.Done()
+			connection.Cancel()
+		}()
+	}
+	cancelers.Wait()
+	select {
+	case <-connection.Done():
+	default:
+		t.Fatal("connection Done channel remained open after cancellation")
+	}
+	if connection.TrySend([]byte("after")) {
+		t.Fatal("send succeeded after connection cancellation")
+	}
+}

--- a/internal/rpc/types/types.go
+++ b/internal/rpc/types/types.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
@@ -533,7 +534,9 @@ type Connection struct {
 	ID            string
 	Subscriptions map[SubscriptionType]SubscriptionConfig
 	SendChannel   chan []byte
-	CloseChannel  chan struct{}
+	ctx           context.Context
+	cancel        context.CancelFunc
+	cancelOnce    sync.Once
 	// Disconnect is invoked when MaxConsecutiveDrops is reached. The
 	// WS layer populates this with its per-conn cancel func so a
 	// persistently slow client gets torn down once, in one place.
@@ -554,6 +557,63 @@ type Connection struct {
 	// on every successful TrySend.
 	consecutiveDrops atomic.Int32
 	apiVersion       atomic.Int32
+}
+
+// NewConnection creates a subscription connection with a bounded outbound
+// queue and an independent cancellation context.
+func NewConnection(id string, sendChannel chan []byte) *Connection {
+	return NewConnectionWithContext(context.Background(), id, sendChannel)
+}
+
+// NewConnectionWithContext creates a subscription connection whose lifetime
+// is derived from parent.
+func NewConnectionWithContext(parent context.Context, id string, sendChannel chan []byte) *Connection {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent) //nolint:gosec // stored on Connection and invoked by Cancel
+	return &Connection{
+		ID:            id,
+		Subscriptions: make(map[SubscriptionType]SubscriptionConfig),
+		SendChannel:   sendChannel,
+		ctx:           ctx,
+		cancel:        cancel,
+	}
+}
+
+// Context returns the connection lifetime context. Connections built as
+// struct literals retain a non-cancellable background context for backwards
+// compatibility with in-package test fixtures.
+func (c *Connection) Context() context.Context {
+	if c == nil || c.ctx == nil {
+		return context.Background()
+	}
+	return c.ctx
+}
+
+// Done returns the channel closed when the connection is cancelled.
+func (c *Connection) Done() <-chan struct{} {
+	return c.Context().Done()
+}
+
+// Cancel ends the connection lifetime exactly once.
+func (c *Connection) Cancel() {
+	if c == nil {
+		return
+	}
+	c.cancelOnce.Do(func() {
+		if c.cancel != nil {
+			c.cancel()
+		}
+	})
+}
+
+// Outbound returns the bounded outbound queue consumed by the transport.
+func (c *Connection) Outbound() <-chan []byte {
+	if c == nil {
+		return nil
+	}
+	return c.SendChannel
 }
 
 // SetAPIVersion updates the representation used for subsequent subscription
@@ -585,10 +645,17 @@ func (c *Connection) TrySend(data []byte) bool {
 	if c == nil || c.SendChannel == nil {
 		return false
 	}
+	select {
+	case <-c.Done():
+		return false
+	default:
+	}
 	if c.EncodeOutbound != nil {
 		data = c.EncodeOutbound(data)
 	}
 	select {
+	case <-c.Done():
+		return false
 	case c.SendChannel <- data:
 		c.consecutiveDrops.Store(0)
 		if c.SendObserver != nil {

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -737,11 +737,11 @@ func (ws *WebSocketServer) UpdatePathFindSessions(getView func() (types.LedgerSt
 	ws.queuePathFindSessions(getView, nil)
 }
 
-func (ws *WebSocketServer) queuePathFindSessions(getView func() (types.LedgerStateView, error), additional *WebSocketConnection) {
+func (ws *WebSocketServer) queuePathFindSessions(getView func() (types.LedgerStateView, error), additional *websocketConnection) {
 	manager := ws.ensurePathFindRefreshManager()
 	ws.connectionsMutex.RLock()
 	var targets []pathFindUpdateTarget
-	seen := make(map[*WebSocketConnection]struct{}, len(ws.connections)+1)
+	seen := make(map[*websocketConnection]struct{}, len(ws.connections)+1)
 	for _, conn := range ws.connections {
 		seen[conn] = struct{}{}
 		ws.bindPathFindRefreshManager(conn)

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -850,9 +850,6 @@ func (target pathFindUpdateTarget) trySend(data []byte) bool {
 		target.connection.pathFindGeneration != target.generation {
 		return false
 	}
-	if target.connection.Connection == nil {
-		return false
-	}
 	return target.connection.TrySend(data)
 }
 
@@ -916,23 +913,12 @@ func (ws *WebSocketServer) sendCommandResponse(wsConn *websocketConnection, resu
 	ws.deliver(wsConn, data)
 }
 
-// deliver queues an already-marshalled WS frame through the shared TrySend so
-// per-request response delivery and broadcast delivery use the same
-// consecutive-drop counter and the same disconnect-on-N-drops threshold. Test
-// fixtures may build a wsConn without a canonical connection; those fall back
-// to a non-blocking channel send.
+// deliver queues an already-marshalled WS frame through the canonical
+// connection so per-request response delivery and broadcast delivery use the
+// same drop policy.
 func (ws *WebSocketServer) deliver(wsConn *websocketConnection, data []byte) {
-	if wsConn.Connection != nil {
-		if !wsConn.TrySend(data) {
-			wsLog().Debug("WebSocket send dropped (slow consumer)", "connID", wsConn.ID)
-		}
-		return
-	}
-	select {
-	case wsConn.SendChannel <- data:
-	case <-wsConn.Done():
-	default:
-		wsLog().Warn("WebSocket send channel full", "connID", wsConn.ID)
+	if !wsConn.TrySend(data) {
+		wsLog().Debug("WebSocket send dropped (slow consumer)", "connID", wsConn.ID)
 	}
 }
 

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -56,7 +56,7 @@ type WebSocketServer struct {
 	upgrader            websocket.Upgrader
 	subscriptionManager *subscription.Manager
 	methodRegistry      *types.MethodRegistry
-	connections         map[string]*WebSocketConnection
+	connections         map[string]*websocketConnection
 	connectionsMutex    sync.RWMutex
 	closing             bool
 	timeout             time.Duration
@@ -79,16 +79,13 @@ type WebSocketServer struct {
 	forceDone chan struct{}
 }
 
-// WebSocketConnection represents a single WebSocket connection
-type WebSocketConnection struct {
-	ID                 string
+// websocketConnection owns the transport-specific state for one logical
+// client. Subscription and lifetime state lives in the embedded canonical
+// connection shared with the subscription manager.
+type websocketConnection struct {
+	*types.Connection
 	conn               *websocket.Conn
-	subscriptions      map[types.SubscriptionType]types.SubscriptionConfig
-	sendChannel        chan []byte
-	closeChannel       chan struct{}
 	mutex              sync.RWMutex
-	ctx                context.Context
-	cancel             context.CancelFunc
 	pathFindSession    *PathFindSession // At most one active path_find session per connection
 	pathFindGeneration uint64
 	pathFindRefresh    *pathFindRefreshManager
@@ -103,14 +100,7 @@ type WebSocketConnection struct {
 	// SecureGatewayNets allowlist. Mirrors rippled's
 	// WSInfoSub::forwarded_for (ServerHandler.cpp:497-501, :580).
 	forwardedFor string
-	// legacy is the same logical connection viewed through the
-	// subscription-manager data model. Created at AddConnection and
-	// torn down at closeConnection — kept on the WS struct so the
-	// two-map invariant (subscription.Manager.Connections and
-	// WebSocketServer.connections always identify the same set) is
-	// enforced by a single attach/detach helper rather than
-	// independent map operations.
-	legacy *types.Connection
+	closeOnce    sync.Once
 }
 
 // NewWebSocketServer creates a new WebSocket server. The provided
@@ -140,7 +130,7 @@ func NewWebSocketServerWithLoadTracker(timeout time.Duration, services *types.Se
 		},
 		subscriptionManager: subscription.NewManager(),
 		methodRegistry:      types.NewMethodRegistry(),
-		connections:         make(map[string]*WebSocketConnection),
+		connections:         make(map[string]*websocketConnection),
 		timeout:             timeout,
 		services:            services,
 		loadTracker:         tracker,
@@ -212,8 +202,6 @@ func (ws *WebSocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Use Background() not r.Context() because the WebSocket connection
 	// lives beyond the HTTP request lifecycle.
-	ctx, cancel := context.WithCancel(context.Background())
-
 	// Capture proxy-attribution headers at upgrade time. They are only
 	// consulted when the upgrade socket peer is in the per-port
 	// SecureGatewayNets set — see resolveWSClientIP.
@@ -224,17 +212,13 @@ func (ws *WebSocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		fwd = strings.TrimSpace(xri)
 	}
 
-	wsConn := &WebSocketConnection{
-		ID:            generateConnectionID(),
-		conn:          conn,
-		subscriptions: make(map[types.SubscriptionType]types.SubscriptionConfig),
-		sendChannel:   make(chan []byte, sendQueueLimit),
-		closeChannel:  make(chan struct{}),
-		ctx:           ctx,
-		cancel:        cancel,
-		portCtx:       portCtx,
-		user:          userHeader(r),
-		forwardedFor:  fwd,
+	connection := types.NewConnection(generateConnectionID(), make(chan []byte, sendQueueLimit))
+	wsConn := &websocketConnection{
+		Connection:   connection,
+		conn:         conn,
+		portCtx:      portCtx,
+		user:         userHeader(r),
+		forwardedFor: fwd,
 	}
 
 	if !ws.attachConnection(wsConn) {
@@ -256,7 +240,7 @@ func (ws *WebSocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 }
 
-func (ws *WebSocketServer) handleConnection(wsConn *WebSocketConnection) {
+func (ws *WebSocketServer) handleConnection(wsConn *websocketConnection) {
 	defer ws.closeConnection(wsConn)
 	defer recoverPanic("handleConnection", wsConn.ID)
 
@@ -286,7 +270,7 @@ func (ws *WebSocketServer) handleConnection(wsConn *WebSocketConnection) {
 		}
 
 		select {
-		case <-wsConn.ctx.Done():
+		case <-wsConn.Done():
 			return
 		default:
 		}
@@ -295,7 +279,7 @@ func (ws *WebSocketServer) handleConnection(wsConn *WebSocketConnection) {
 	}
 }
 
-func (ws *WebSocketServer) pingLoop(wsConn *WebSocketConnection) {
+func (ws *WebSocketServer) pingLoop(wsConn *websocketConnection) {
 	defer recoverPanic("pingLoop", wsConn.ID)
 	// Fall back to the default when constructed via struct literal: a zero
 	// pingInterval would panic NewTicker. Read into a local rather than
@@ -309,7 +293,7 @@ func (ws *WebSocketServer) pingLoop(wsConn *WebSocketConnection) {
 
 	for {
 		select {
-		case <-wsConn.ctx.Done():
+		case <-wsConn.Done():
 			return
 		case <-ticker.C:
 			// WriteControl carries its own deadline and serializes against
@@ -325,15 +309,13 @@ func (ws *WebSocketServer) pingLoop(wsConn *WebSocketConnection) {
 	}
 }
 
-func (ws *WebSocketServer) handleSend(wsConn *WebSocketConnection) {
+func (ws *WebSocketServer) handleSend(wsConn *websocketConnection) {
 	defer recoverPanic("handleSend", wsConn.ID)
 	for {
 		select {
-		case <-wsConn.ctx.Done():
+		case <-wsConn.Done():
 			return
-		case <-wsConn.closeChannel:
-			return
-		case message := <-wsConn.sendChannel:
+		case message := <-wsConn.Outbound():
 			wsConn.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 			if err := wsConn.conn.WriteMessage(websocket.TextMessage, message); err != nil {
 				wsLog().Debug("WebSocket send failed", "err", err)
@@ -346,7 +328,7 @@ func (ws *WebSocketServer) handleSend(wsConn *WebSocketConnection) {
 	}
 }
 
-func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []byte) {
+func (ws *WebSocketServer) handleMessage(wsConn *websocketConnection, message []byte) {
 	// Per-message recover so one bad command can't tear down the read
 	// loop and drop the connection's pending subscriptions.
 	defer func() {
@@ -383,7 +365,7 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 	peerIP := getWebSocketClientIP(wsConn.conn)
 	clientIP := resolveWSClientIP(peerIP, wsConn.forwardedFor, wsConn.portCtx)
 	role := roleForRequest(peerIP, wsConn.user, cmdMap, wsConn.portCtx)
-	loadCtx := newRpcContext(wsConn.ctx, role, types.DefaultApiVersion, clientIP, ws.loadPeerSource(), ws.services)
+	loadCtx := newRpcContext(wsConn.Context(), role, types.DefaultApiVersion, clientIP, ws.loadPeerSource(), ws.services)
 	if rpcErr := gateLoad(ws.loadTracker, loadCtx, "", wsLog()); rpcErr != nil {
 		wsConn.closeWithPolicyViolation("threshold exceeded")
 		return
@@ -393,7 +375,7 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 	if version, present := apiVersionFromObject(message); present {
 		apiVersion = version
 	}
-	versionCtx := newRpcContext(wsConn.ctx, role, apiVersion, clientIP, ws.loadPeerSource(), ws.services)
+	versionCtx := newRpcContext(wsConn.Context(), role, apiVersion, clientIP, ws.loadPeerSource(), ws.services)
 	if rpcErr := validateApiVersion(versionCtx); rpcErr != nil {
 		chargeLoad(ws.loadTracker, versionCtx, "", loadtrack.LoadMalformed, wsLog())
 		ws.sendErrorResponse(wsConn, rpcErr, id, nil, requestEcho)
@@ -427,10 +409,10 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 	}
 
 	wsLog().Debug("ws request", "cmd", cmd.Command, "remoteAddr", wsConn.conn.RemoteAddr().String(), "clientIP", clientIP, "role", role, "isAdmin", role == types.RoleAdmin)
-	dispatchCtx := wsConn.ctx
+	dispatchCtx := wsConn.Context()
 	var cancel context.CancelFunc
 	if ws.timeout > 0 {
-		dispatchCtx, cancel = context.WithTimeout(wsConn.ctx, ws.timeout)
+		dispatchCtx, cancel = context.WithTimeout(wsConn.Context(), ws.timeout)
 		defer cancel()
 	}
 	rpcCtx := newRpcContext(dispatchCtx, role, apiVersion, clientIP, ws.loadPeerSource(), ws.services)
@@ -450,9 +432,9 @@ func (ws *WebSocketServer) handleMessage(wsConn *WebSocketConnection, message []
 	ws.handleRPCMethod(wsConn, rpcCtx, cmd)
 }
 
-type wsSpecialHandler func(*WebSocketConnection, *types.RpcContext, types.WebSocketCommand) (any, *types.RpcError)
+type wsSpecialHandler func(*websocketConnection, *types.RpcContext, types.WebSocketCommand) (any, *types.RpcError)
 
-func (ws *WebSocketServer) handleSpecialCommand(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand, handler wsSpecialHandler) {
+func (ws *WebSocketServer) handleSpecialCommand(wsConn *websocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand, handler wsSpecialHandler) {
 	ctx.LoadCost = uint32(loadtrack.LoadReference)
 	if rpcErr := handlers.RequireNotBusyClient(ctx); rpcErr != nil {
 		finalizeLoad(ws.loadTracker, ctx, cmd.Command, loadtrack.LoadReference, wsLog())
@@ -492,7 +474,7 @@ func (ws *WebSocketServer) handleSpecialCommand(wsConn *WebSocketConnection, ctx
 	ws.sendCommandResponse(wsConn, result, cmd, wsLoadWarningOpts(ctx))
 }
 
-func invokeWSSpecial(handler wsSpecialHandler, wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (result any, rpcErr *types.RpcError, recovered bool) {
+func invokeWSSpecial(handler wsSpecialHandler, wsConn *websocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (result any, rpcErr *types.RpcError, recovered bool) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			wsLog().Error("rpc handler panic", "err", rec, "stack", string(debug.Stack()), "method", cmd.Command, "client", ctx.ClientIP)
@@ -505,7 +487,7 @@ func invokeWSSpecial(handler wsSpecialHandler, wsConn *WebSocketConnection, ctx 
 	return result, rpcErr, false
 }
 
-func (ws *WebSocketServer) executeSubscribe(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
+func (ws *WebSocketServer) executeSubscribe(wsConn *websocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
 	var request types.SubscriptionRequest
 	if len(cmd.Params) > 0 {
 		if err := json.Unmarshal(cmd.Params, &request); err != nil {
@@ -526,21 +508,20 @@ func (ws *WebSocketServer) executeSubscribe(wsConn *WebSocketConnection, ctx *ty
 		return result, nil
 	}
 
-	// wsConn.legacy is the same connection the subscription manager already
-	// tracks (created in attachConnection, before any message can arrive); it
-	// shares the subscriptions map and carries the Disconnect callback a
-	// freshly-built copy would lack.
+	// The embedded canonical connection is the same object the subscription
+	// manager already tracks and carries the bounded queue and disconnect
+	// callback.
 	prefix, err := subscriptionRequestExcluding(cmd.Params, "books")
 	if err != nil {
 		return nil, types.RpcErrorInvalidParams("Invalid subscription parameters.")
 	}
 	prefix.ApiVersion = ctx.ApiVersion
-	if rpcErr := ws.subscriptionManager.HandleSubscribe(wsConn.legacy, prefix, ctx.IsAdmin); rpcErr != nil {
+	if rpcErr := ws.subscriptionManager.HandleSubscribe(wsConn.Connection, prefix, ctx.IsAdmin); rpcErr != nil {
 		return nil, rpcErr
 	}
 	if rpcErr := applySubscriptionBooks(request.WireArrays().Books, func(bookRequest types.SubscriptionRequest) *types.RpcError {
 		bookRequest.ApiVersion = ctx.ApiVersion
-		if rpcErr := ws.subscriptionManager.HandleSubscribe(wsConn.legacy, bookRequest, ctx.IsAdmin); rpcErr != nil {
+		if rpcErr := ws.subscriptionManager.HandleSubscribe(wsConn.Connection, bookRequest, ctx.IsAdmin); rpcErr != nil {
 			return rpcErr
 		}
 		setSubscriptionLoadCost(ctx, bookRequest)
@@ -614,16 +595,16 @@ func subscriptionRequestForBooks(books json.RawMessage) (types.SubscriptionReque
 	return request, err
 }
 
-func (ws *WebSocketServer) finishUnsubscribe(wsConn *WebSocketConnection, request types.SubscriptionRequest, params json.RawMessage, isAdmin bool) *types.RpcError {
+func (ws *WebSocketServer) finishUnsubscribe(wsConn *websocketConnection, request types.SubscriptionRequest, params json.RawMessage, isAdmin bool) *types.RpcError {
 	prefix, err := subscriptionRequestExcluding(params, "books")
 	if err != nil {
 		return types.RpcErrorInvalidParams("Invalid unsubscription parameters.")
 	}
-	if rpcErr := ws.subscriptionManager.HandleUnsubscribe(wsConn.legacy, prefix, isAdmin); rpcErr != nil {
+	if rpcErr := ws.subscriptionManager.HandleUnsubscribe(wsConn.Connection, prefix, isAdmin); rpcErr != nil {
 		return rpcErr
 	}
 	return applySubscriptionBooks(request.WireArrays().Books, func(bookRequest types.SubscriptionRequest) *types.RpcError {
-		return ws.subscriptionManager.HandleUnsubscribe(wsConn.legacy, bookRequest, isAdmin)
+		return ws.subscriptionManager.HandleUnsubscribe(wsConn.Connection, bookRequest, isAdmin)
 	})
 }
 
@@ -636,7 +617,7 @@ func setSubscriptionLoadCost(ctx *types.RpcContext, request types.SubscriptionRe
 	}
 }
 
-func (ws *WebSocketServer) executeUnsubscribe(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
+func (ws *WebSocketServer) executeUnsubscribe(wsConn *websocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
 	var request types.SubscriptionRequest
 	if len(cmd.Params) > 0 {
 		if err := json.Unmarshal(cmd.Params, &request); err != nil {
@@ -662,7 +643,7 @@ func (ws *WebSocketServer) executeUnsubscribe(wsConn *WebSocketConnection, ctx *
 	return map[string]any{}, nil
 }
 
-func (ws *WebSocketServer) executePathFind(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
+func (ws *WebSocketServer) executePathFind(wsConn *websocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
 	var params map[string]json.RawMessage
 	if len(cmd.Params) == 0 || json.Unmarshal(cmd.Params, &params) != nil {
 		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
@@ -675,7 +656,7 @@ func (ws *WebSocketServer) executePathFind(wsConn *WebSocketConnection, ctx *typ
 	if err := json.Unmarshal(rawSubcommand, &subcommand); err != nil || subcommand == nil {
 		return nil, types.RpcErrorInvalidParams("Invalid field 'subcommand'.")
 	}
-	wsConn.legacy.SetAPIVersion(ctx.ApiVersion)
+	wsConn.SetAPIVersion(ctx.ApiVersion)
 
 	switch *subcommand {
 	case "create":
@@ -692,7 +673,7 @@ func (ws *WebSocketServer) executePathFind(wsConn *WebSocketConnection, ctx *typ
 
 // executePathFindCreate creates a new persistent pathfinding session.
 // Any existing session on this connection is replaced (matching rippled).
-func (ws *WebSocketServer) executePathFindCreate(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
+func (ws *WebSocketServer) executePathFindCreate(wsConn *websocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
 	ws.bindPathFindRefreshManager(wsConn)
 	wsConn.clearPathFindSession()
 
@@ -726,7 +707,7 @@ func (ws *WebSocketServer) executePathFindCreate(wsConn *WebSocketConnection, ct
 }
 
 // executePathFindClose closes the active pathfinding session on this connection.
-func (ws *WebSocketServer) executePathFindClose(wsConn *WebSocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
+func (ws *WebSocketServer) executePathFindClose(wsConn *websocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
 	session := wsConn.clearPathFindSession()
 
 	if session == nil {
@@ -737,7 +718,7 @@ func (ws *WebSocketServer) executePathFindClose(wsConn *WebSocketConnection, _ *
 }
 
 // executePathFindStatus returns the current status of the active pathfinding session.
-func (ws *WebSocketServer) executePathFindStatus(wsConn *WebSocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
+func (ws *WebSocketServer) executePathFindStatus(wsConn *websocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
 	wsConn.mutex.RLock()
 	session := wsConn.pathFindSession
 	wsConn.mutex.RUnlock()
@@ -790,12 +771,12 @@ func currentPathFindView(ledger types.LedgerService) func() (types.LedgerStateVi
 }
 
 type pathFindUpdateTarget struct {
-	connection *WebSocketConnection
+	connection *websocketConnection
 	session    *PathFindSession
 	generation uint64
 }
 
-func (c *WebSocketConnection) clearPathFindSession() *PathFindSession {
+func (c *websocketConnection) clearPathFindSession() *PathFindSession {
 	c.mutex.Lock()
 	session := c.pathFindSession
 	generation := c.pathFindGeneration
@@ -809,7 +790,7 @@ func (c *WebSocketConnection) clearPathFindSession() *PathFindSession {
 	return session
 }
 
-func (c *WebSocketConnection) installPathFindSession(session *PathFindSession) {
+func (c *websocketConnection) installPathFindSession(session *PathFindSession) {
 	c.mutex.Lock()
 	previous := c.pathFindSession
 	previousGeneration := c.pathFindGeneration
@@ -831,7 +812,7 @@ func (ws *WebSocketServer) ensurePathFindRefreshManager() *pathFindRefreshManage
 	return ws.pathFindRefresh
 }
 
-func (ws *WebSocketServer) bindPathFindRefreshManager(conn *WebSocketConnection) {
+func (ws *WebSocketServer) bindPathFindRefreshManager(conn *websocketConnection) {
 	manager := ws.ensurePathFindRefreshManager()
 	conn.mutex.Lock()
 	if conn.pathFindRefresh == nil {
@@ -840,7 +821,7 @@ func (ws *WebSocketServer) bindPathFindRefreshManager(conn *WebSocketConnection)
 	conn.mutex.Unlock()
 }
 
-func (c *WebSocketConnection) snapshotPathFindUpdate() (pathFindUpdateTarget, bool) {
+func (c *websocketConnection) snapshotPathFindUpdate() (pathFindUpdateTarget, bool) {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 
@@ -869,13 +850,13 @@ func (target pathFindUpdateTarget) trySend(data []byte) bool {
 		target.connection.pathFindGeneration != target.generation {
 		return false
 	}
-	if target.connection.legacy == nil {
+	if target.connection.Connection == nil {
 		return false
 	}
-	return target.connection.legacy.TrySend(data)
+	return target.connection.TrySend(data)
 }
 
-func (ws *WebSocketServer) handleRPCMethod(wsConn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+func (ws *WebSocketServer) handleRPCMethod(wsConn *websocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
 	// Shared dispatch core (registry → admin gate → conditionMet →
 	// api-version → busy/load gates → handle → finalize), identical to the
 	// HTTP path. The WS-specific admin gate returns rpcFORBIDDEN instead of
@@ -906,7 +887,7 @@ func wsLoadWarningOpts(ctx *types.RpcContext) *types.WebSocketResponseOptions {
 	return nil
 }
 
-func (ws *WebSocketServer) sendCommandResponse(wsConn *WebSocketConnection, result any, cmd types.WebSocketCommand, opts *types.WebSocketResponseOptions) {
+func (ws *WebSocketServer) sendCommandResponse(wsConn *websocketConnection, result any, cmd types.WebSocketCommand, opts *types.WebSocketResponseOptions) {
 	payload := map[string]any{
 		"type":   "response",
 		"status": "success",
@@ -938,18 +919,18 @@ func (ws *WebSocketServer) sendCommandResponse(wsConn *WebSocketConnection, resu
 // deliver queues an already-marshalled WS frame through the shared TrySend so
 // per-request response delivery and broadcast delivery use the same
 // consecutive-drop counter and the same disconnect-on-N-drops threshold. Test
-// fixtures may build a wsConn without a legacy peer; those fall back to a
-// non-blocking channel send so unit tests stay self-contained.
-func (ws *WebSocketServer) deliver(wsConn *WebSocketConnection, data []byte) {
-	if wsConn.legacy != nil {
-		if !wsConn.legacy.TrySend(data) {
+// fixtures may build a wsConn without a canonical connection; those fall back
+// to a non-blocking channel send.
+func (ws *WebSocketServer) deliver(wsConn *websocketConnection, data []byte) {
+	if wsConn.Connection != nil {
+		if !wsConn.TrySend(data) {
 			wsLog().Debug("WebSocket send dropped (slow consumer)", "connID", wsConn.ID)
 		}
 		return
 	}
 	select {
-	case wsConn.sendChannel <- data:
-	case <-wsConn.ctx.Done():
+	case wsConn.SendChannel <- data:
+	case <-wsConn.Done():
 	default:
 		wsLog().Warn("WebSocket send channel full", "connID", wsConn.ID)
 	}
@@ -987,7 +968,7 @@ func resolveWSCommand(m map[string]any) (string, bool) {
 // `error` token (no error_code/error_message) plus the echoed request and id
 // (ServerHandler.cpp:452-468). Credentials in the echo are redacted — a
 // deliberate goxrpl superset of rippled's raw echo.
-func (ws *WebSocketServer) sendMissingCommand(wsConn *WebSocketConnection, request map[string]any, id any) {
+func (ws *WebSocketServer) sendMissingCommand(wsConn *websocketConnection, request map[string]any, id any) {
 	echo := redactedRequestMap(request)
 	resp := map[string]any{
 		"type":    "response",
@@ -1004,7 +985,7 @@ func (ws *WebSocketServer) sendMissingCommand(wsConn *WebSocketConnection, reque
 	ws.deliver(wsConn, data)
 }
 
-func (ws *WebSocketServer) sendJSONInvalid(wsConn *WebSocketConnection, value any, parsed bool) {
+func (ws *WebSocketServer) sendJSONInvalid(wsConn *websocketConnection, value any, parsed bool) {
 	rawValue := "<redacted>"
 	if parsed {
 		if data, err := marshalWebSocketJSON(redactJSONValue(value)); err == nil {
@@ -1023,11 +1004,11 @@ func (ws *WebSocketServer) sendJSONInvalid(wsConn *WebSocketConnection, value an
 	ws.deliver(wsConn, data)
 }
 
-func (ws *WebSocketServer) sendCommandError(wsConn *WebSocketConnection, rpcErr *types.RpcError, cmd types.WebSocketCommand) {
+func (ws *WebSocketServer) sendCommandError(wsConn *websocketConnection, rpcErr *types.RpcError, cmd types.WebSocketCommand) {
 	ws.sendErrorResponse(wsConn, rpcErr, cmd.ID, nil, cmd.Request)
 }
 
-func (ws *WebSocketServer) sendErrorResponse(wsConn *WebSocketConnection, rpcErr *types.RpcError, id any, opts *types.WebSocketResponseOptions, request map[string]any) {
+func (ws *WebSocketServer) sendErrorResponse(wsConn *websocketConnection, rpcErr *types.RpcError, id any, opts *types.WebSocketResponseOptions, request map[string]any) {
 	response := map[string]any{
 		"type":   "response",
 		"status": "error",
@@ -1102,19 +1083,9 @@ func marshalWebSocketJSON(value any) ([]byte, error) {
 // subscription manager. Pairing this with detachConnection makes it
 // impossible for the two maps to drift on Add/Remove ordering — the
 // "duplicated connection state" concern flagged in the #428 audit.
-func (ws *WebSocketServer) attachConnection(wsConn *WebSocketConnection) bool {
+func (ws *WebSocketServer) attachConnection(wsConn *websocketConnection) bool {
 	ws.bindPathFindRefreshManager(wsConn)
-	legacy := &types.Connection{
-		ID:            wsConn.ID,
-		Subscriptions: wsConn.subscriptions,
-		SendChannel:   wsConn.sendChannel,
-		CloseChannel:  wsConn.closeChannel,
-		// Subscription-manager-driven disconnect closes the socket (not just
-		// cancels the ctx) so a persistently slow subscriber is torn down
-		// immediately — cancel alone leaves the read loop blocked in
-		// ReadMessage until the 90 s deadline.
-		Disconnect: wsConn.closeSocket,
-	}
+	wsConn.Disconnect = wsConn.closeSocket
 
 	ws.connectionsMutex.Lock()
 	if ws.closing {
@@ -1122,15 +1093,14 @@ func (ws *WebSocketServer) attachConnection(wsConn *WebSocketConnection) bool {
 		return false
 	}
 	ws.wg.Add(3)
-	wsConn.legacy = legacy
 	ws.connections[wsConn.ID] = wsConn
 	ws.connectionsMutex.Unlock()
-	ws.subscriptionManager.AddConnection(legacy)
+	ws.subscriptionManager.AddConnection(wsConn.Connection)
 	return true
 }
 
 // detachConnection is the inverse of attachConnection.
-func (ws *WebSocketServer) detachConnection(wsConn *WebSocketConnection) {
+func (ws *WebSocketServer) detachConnection(wsConn *websocketConnection) {
 	ws.connectionsMutex.Lock()
 	delete(ws.connections, wsConn.ID)
 	ws.connectionsMutex.Unlock()
@@ -1143,29 +1113,33 @@ func (ws *WebSocketServer) detachConnection(wsConn *WebSocketConnection) {
 // deadline. Used by the slow-consumer
 // Disconnect callback and the send-error path; idempotent — closeConnection
 // closes again and gorilla tolerates the double close.
-func (c *WebSocketConnection) closeSocket() {
-	c.cancel()
-	c.conn.Close()
+func (c *websocketConnection) closeSocket() {
+	c.Cancel()
+	c.closeOnce.Do(func() {
+		if c.conn != nil {
+			_ = c.conn.Close()
+		}
+	})
 }
 
-func (c *WebSocketConnection) closeWithPolicyViolation(reason string) {
-	c.cancel()
+func (c *websocketConnection) closeWithPolicyViolation(reason string) {
+	c.Cancel()
 	_ = c.conn.WriteControl(
 		websocket.CloseMessage,
 		websocket.FormatCloseMessage(websocket.ClosePolicyViolation, reason),
 		time.Now().Add(time.Second),
 	)
-	c.conn.Close()
+	c.closeSocket()
 }
 
-func (ws *WebSocketServer) closeConnection(wsConn *WebSocketConnection) {
-	wsConn.cancel()
+func (ws *WebSocketServer) closeConnection(wsConn *websocketConnection) {
+	wsConn.Cancel()
 
 	wsConn.clearPathFindSession()
 
 	ws.detachConnection(wsConn)
 
-	wsConn.conn.Close()
+	wsConn.closeSocket()
 
 	wsLog().Debug("WebSocket connection closed", "connID", wsConn.ID)
 }
@@ -1365,7 +1339,7 @@ func (ws *WebSocketServer) shutdown(ctx context.Context) {
 
 	ws.connectionsMutex.Lock()
 	ws.closing = true
-	connections := make([]*WebSocketConnection, 0, len(ws.connections))
+	connections := make([]*websocketConnection, 0, len(ws.connections))
 	for _, conn := range ws.connections {
 		connections = append(connections, conn)
 	}
@@ -1379,7 +1353,7 @@ func (ws *WebSocketServer) shutdown(ctx context.Context) {
 	var closeFrames sync.WaitGroup
 	closeFrames.Add(len(connections))
 	for _, conn := range connections {
-		conn.cancel()
+		conn.Cancel()
 		conn.clearPathFindSession()
 		go func() {
 			defer closeFrames.Done()
@@ -1403,7 +1377,7 @@ func (ws *WebSocketServer) shutdown(ctx context.Context) {
 	}
 
 	for _, conn := range connections {
-		_ = conn.conn.Close()
+		conn.closeSocket()
 	}
 	refreshManager := ws.ensurePathFindRefreshManager()
 	refreshErr := refreshManager.wait(ctx)

--- a/internal/rpc/websocket_special_dispatch_test.go
+++ b/internal/rpc/websocket_special_dispatch_test.go
@@ -12,31 +12,24 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-func newSpecialDispatchHarness(t *testing.T) (*WebSocketServer, *WebSocketConnection, *types.RpcContext) {
+func newSpecialDispatchHarness(t *testing.T) (*WebSocketServer, *websocketConnection, *types.RpcContext) {
 	t.Helper()
 	services := &types.ServiceContainer{ClientLoad: types.NewClientLoadShedder()}
 	ws := NewWebSocketServerWithLoadTracker(time.Second, services, loadtrack.New())
 	ws.methodRegistry.Register("subscribe", &stubHandler{})
 	ws.methodRegistry.Register("path_find", &stubHandler{})
 	send := make(chan []byte, 1)
-	conn := &WebSocketConnection{
-		ID:          "special-dispatch",
-		sendChannel: send,
-		ctx:         context.Background(),
-		legacy: &types.Connection{
-			ID:            "special-dispatch",
-			Subscriptions: make(map[types.SubscriptionType]types.SubscriptionConfig),
-			SendChannel:   send,
-		},
+	conn := &websocketConnection{
+		Connection: types.NewConnectionWithContext(context.Background(), "special-dispatch", send),
 	}
 	ctx := newRpcContext(context.Background(), types.RoleGuest, types.DefaultApiVersion, "192.0.2.1", nil, services)
 	return ws, conn, ctx
 }
 
-func specialDispatchResponse(t *testing.T, conn *WebSocketConnection) map[string]any {
+func specialDispatchResponse(t *testing.T, conn *websocketConnection) map[string]any {
 	t.Helper()
 	select {
-	case body := <-conn.sendChannel:
+	case body := <-conn.SendChannel:
 		var response map[string]any
 		if err := json.Unmarshal(body, &response); err != nil {
 			t.Fatalf("decode response %s: %v", body, err)
@@ -78,7 +71,7 @@ func TestWebSocketSpecialDispatchBusyBoundary(t *testing.T) {
 				}}})
 			}
 			called := false
-			ws.handleSpecialCommand(conn, ctx, specialDispatchCommand("subscribe"), func(_ *WebSocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
+			ws.handleSpecialCommand(conn, ctx, specialDispatchCommand("subscribe"), func(_ *websocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
 				called = true
 				if got := ws.services.ClientLoad.InFlight(); got != int64(test.inFlight+1) {
 					t.Fatalf("in-flight inside handler = %d, want %d", got, test.inFlight+1)
@@ -111,14 +104,14 @@ func TestWebSocketSpecialDispatchWarningVisibility(t *testing.T) {
 	}{
 		{
 			name: "success exposes warning",
-			handler: func(_ *WebSocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
+			handler: func(_ *websocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
 				return map[string]any{}, nil
 			},
 			wantWarning: true,
 		},
 		{
 			name: "error suppresses warning",
-			handler: func(_ *WebSocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
+			handler: func(_ *websocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
 				return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 			},
 		},
@@ -144,7 +137,7 @@ func TestWebSocketSpecialDispatchWarningVisibility(t *testing.T) {
 
 func TestWebSocketSpecialDispatchRecoversPanic(t *testing.T) {
 	ws, conn, ctx := newSpecialDispatchHarness(t)
-	ws.handleSpecialCommand(conn, ctx, specialDispatchCommand("subscribe"), func(_ *WebSocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
+	ws.handleSpecialCommand(conn, ctx, specialDispatchCommand("subscribe"), func(_ *websocketConnection, _ *types.RpcContext, _ types.WebSocketCommand) (any, *types.RpcError) {
 		panic("private panic detail")
 	})
 
@@ -239,7 +232,7 @@ func TestWebSocketSubscribeBothSidesAlias(t *testing.T) {
 	if rpcErr != nil {
 		t.Fatalf("subscribe error = %v", rpcErr)
 	}
-	books := conn.legacy.Subscriptions[types.SubBook].Books
+	books := conn.Subscriptions[types.SubBook].Books
 	if len(books) != 2 {
 		t.Fatalf("book subscriptions = %d, want 2", len(books))
 	}

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -196,7 +196,7 @@ func TestWebSocketServer_Close_ContextInterruptsBlockedControlWrite(t *testing.T
 	defer client.Close()
 	serverConn := <-wrappedListener.accepted
 
-	var wsConn *WebSocketConnection
+	var wsConn *websocketConnection
 	deadline := time.Now().Add(time.Second)
 	for wsConn == nil && time.Now().Before(deadline) {
 		ws.connectionsMutex.RLock()
@@ -212,7 +212,7 @@ func TestWebSocketServer_Close_ContextInterruptsBlockedControlWrite(t *testing.T
 	}
 
 	close(serverConn.armed)
-	wsConn.sendChannel <- []byte("block the server writer")
+	wsConn.SendChannel <- []byte("block the server writer")
 	select {
 	case <-serverConn.writeStarted:
 	case <-time.After(time.Second):
@@ -262,6 +262,67 @@ func TestWebSocketServer_Close_NoConnections(t *testing.T) {
 	defer cancel()
 	if err := ws.Close(ctx); err != nil {
 		t.Fatalf("Close on empty server: %v", err)
+	}
+}
+
+func TestWebSocketConnectionCloseSocketUnblocksRead(t *testing.T) {
+	ws := NewWebSocketServer(30*time.Second, nil)
+	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
+	defer httpSrv.Close()
+
+	client, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(httpSrv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	var serverConn *websocketConnection
+	requireDeadline := time.Now().Add(time.Second)
+	for serverConn == nil && time.Now().Before(requireDeadline) {
+		ws.connectionsMutex.RLock()
+		for _, candidate := range ws.connections {
+			serverConn = candidate
+			break
+		}
+		ws.connectionsMutex.RUnlock()
+		if serverConn == nil {
+			time.Sleep(time.Millisecond)
+		}
+	}
+	if serverConn == nil {
+		t.Fatal("server connection was not registered")
+	}
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, _, readErr := client.ReadMessage()
+		readDone <- readErr
+	}()
+
+	var closers sync.WaitGroup
+	for range 16 {
+		closers.Add(1)
+		go func() {
+			defer closers.Done()
+			serverConn.closeSocket()
+		}()
+	}
+	closers.Wait()
+	select {
+	case <-readDone:
+	case <-time.After(time.Second):
+		t.Fatal("closing the canonical connection did not unblock the client read")
+	}
+	select {
+	case <-serverConn.Done():
+	default:
+		t.Fatal("canonical connection remained active after closeSocket")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := ws.Close(ctx); err != nil {
+		t.Fatalf("close server: %v", err)
 	}
 }
 
@@ -419,7 +480,7 @@ func TestWebSocketServer_ConcurrentWrites_NoRace(t *testing.T) {
 	}()
 
 	// Locate the server-side connection so we can push data frames through it.
-	var wsConn *WebSocketConnection
+	var wsConn *websocketConnection
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		ws.connectionsMutex.RLock()
@@ -439,7 +500,7 @@ func TestWebSocketServer_ConcurrentWrites_NoRace(t *testing.T) {
 	// Feed handleSend a steady stream of data frames while pingLoop fires.
 	for range 500 {
 		select {
-		case wsConn.sendChannel <- []byte(`{"type":"race-probe"}`):
+		case wsConn.SendChannel <- []byte(`{"type":"race-probe"}`):
 		case <-time.After(2 * time.Second):
 			t.Fatal("send channel stalled")
 		}
@@ -673,13 +734,13 @@ func TestWebSocketSpecialCommandDecodeErrorsAreFixed(t *testing.T) {
 		name    string
 		command string
 		want    string
-		invoke  func(*WebSocketServer, *WebSocketConnection, *types.RpcContext, types.WebSocketCommand)
+		invoke  func(*WebSocketServer, *websocketConnection, *types.RpcContext, types.WebSocketCommand)
 	}{
 		{
 			name:    "subscribe",
 			command: "subscribe",
 			want:    `{"error":"invalidParams","error_code":31,"error_message":"Invalid subscription parameters.","id":7,"request":{"command":"subscribe","id":7},"status":"error","type":"response"}`,
-			invoke: func(ws *WebSocketServer, conn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+			invoke: func(ws *WebSocketServer, conn *websocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
 				ws.handleSpecialCommand(conn, ctx, cmd, ws.executeSubscribe)
 			},
 		},
@@ -687,7 +748,7 @@ func TestWebSocketSpecialCommandDecodeErrorsAreFixed(t *testing.T) {
 			name:    "unsubscribe",
 			command: "unsubscribe",
 			want:    `{"error":"invalidParams","error_code":31,"error_message":"Invalid unsubscription parameters.","id":7,"request":{"command":"unsubscribe","id":7},"status":"error","type":"response"}`,
-			invoke: func(ws *WebSocketServer, conn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+			invoke: func(ws *WebSocketServer, conn *websocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
 				ws.handleSpecialCommand(conn, ctx, cmd, ws.executeUnsubscribe)
 			},
 		},
@@ -695,7 +756,7 @@ func TestWebSocketSpecialCommandDecodeErrorsAreFixed(t *testing.T) {
 			name:    "path find",
 			command: "path_find",
 			want:    `{"error":"invalidParams","error_code":31,"error_message":"Invalid parameters.","id":7,"request":{"command":"path_find","id":7},"status":"error","type":"response"}`,
-			invoke: func(ws *WebSocketServer, conn *WebSocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
+			invoke: func(ws *WebSocketServer, conn *websocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) {
 				ws.handleSpecialCommand(conn, ctx, cmd, ws.executePathFind)
 			},
 		},
@@ -704,11 +765,7 @@ func TestWebSocketSpecialCommandDecodeErrorsAreFixed(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ws := NewWebSocketServer(time.Second, nil)
 			ws.RegisterAllMethods()
-			wsConn := &WebSocketConnection{
-				ID:          "decode-test",
-				sendChannel: make(chan []byte, 1),
-				ctx:         context.Background(),
-			}
+			wsConn := &websocketConnection{Connection: types.NewConnectionWithContext(context.Background(), "decode-test", make(chan []byte, 1))}
 			cmd := types.WebSocketCommand{
 				Command: test.command,
 				ID:      int32(7),
@@ -717,7 +774,7 @@ func TestWebSocketSpecialCommandDecodeErrorsAreFixed(t *testing.T) {
 			}
 
 			test.invoke(ws, wsConn, &types.RpcContext{ApiVersion: types.DefaultApiVersion}, cmd)
-			body := <-wsConn.sendChannel
+			body := <-wsConn.SendChannel
 			if got := string(body); got != test.want {
 				t.Fatalf("response = %s, want %s", got, test.want)
 			}


### PR DESCRIPTION
## Summary

- Make one canonical connection object own WebSocket identity, subscriptions, outbound queue, and cancellation.
- Remove duplicate and legacy connection state plus CloseChannel.
- Close sockets exactly once so cancellation and shutdown unblock pending reads promptly.

## Verification

- WebSocket cancellation, concurrent close, send/drop, path refresh, and RPCSub integration tests
- Focused lifecycle race stress tests

Refs #1483
