### PR TITLE
refactor(rpc): make construction dependencies explicit

### DIFF
--- a/internal/cli/rpc_test.go
+++ b/internal/cli/rpc_test.go
@@ -772,7 +772,7 @@ func TestRPCStopUsesAdminCredentialsWithRPCServer(t *testing.T) {
 					shutdown <- struct{}{}
 				},
 			}
-			server := rpcserver.NewServer(time.Second, services)
+			server := rpcserver.NewServer(rpcserver.ServerOptions{Timeout: time.Second, Services: services})
 			_, adminNet, err := net.ParseCIDR("127.0.0.0/8")
 			if err != nil {
 				t.Fatal(err)

--- a/internal/node/lifecycle_test.go
+++ b/internal/node/lifecycle_test.go
@@ -14,10 +14,35 @@ import (
 	"github.com/LeJamon/go-xrpl/config"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/rpc"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 	"github.com/LeJamon/go-xrpl/storage/nodestore"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
+
+func TestBindRPCWiresExplicitSharedServices(t *testing.T) {
+	runtime := &nodeRuntime{
+		appConfig:  &config.Config{},
+		services:   types.NewServiceContainer(nil),
+		serverLog:  xrpllog.Discard(),
+		shutdownCh: make(chan struct{}, 1),
+	}
+	runtime.services.ClientLoad = types.NewClientLoadShedder()
+	if err := runtime.bindRPC(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = runtime.wsServer.Close(context.Background()) }()
+
+	if runtime.services.Dispatcher != runtime.httpServer {
+		t.Fatal("bindRPC did not install the HTTP dispatcher")
+	}
+	if runtime.services.URLSubscriptions != runtime.wsServer.URLSubscriptionService() {
+		t.Fatal("bindRPC did not install the WebSocket URL subscription service")
+	}
+	if runtime.services.ClientLoad == nil {
+		t.Fatal("bindRPC lost the configured client-load shedder")
+	}
+}
 
 func TestRunReturnsCanceledContextBeforeStartup(t *testing.T) {
 	t.Parallel()
@@ -338,7 +363,7 @@ func TestNodeRuntimeShutdownLeavesStoresOpenWhileTransportHandlerIsRunning(t *te
 			close(started)
 			<-release
 		}),
-		rpc.NewWebSocketServer(time.Second, nil),
+		rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second}),
 		nil,
 		systemListen,
 	)

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -23,6 +23,7 @@ import (
 	rpcadapter "github.com/LeJamon/go-xrpl/internal/rpc/adapter"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
+	"github.com/LeJamon/go-xrpl/internal/rpc/subscription"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	validatorlist "github.com/LeJamon/go-xrpl/internal/validator/list"
 	"github.com/LeJamon/go-xrpl/internal/watchdog"
@@ -251,6 +252,7 @@ func (r *nodeRuntime) configureMaintenance() error {
 
 	r.ledgerAdapter = rpcadapter.NewLedgerServiceAdapter(r.ledger)
 	r.services = types.NewServiceContainer(r.ledgerAdapter)
+	r.services.ClientLoad = types.NewClientLoadShedder()
 	r.services.ServerInfoConfig = serverInfoConfigSnapshot(r.appConfig)
 
 	// Gate the beta RPC API (api_version 3) on the operator's beta_rpc_api
@@ -825,27 +827,34 @@ func (r *nodeRuntime) configureConsensus() error {
 
 func (r *nodeRuntime) bindRPC() error {
 	transportLoad := loadtrack.New()
+	var peerSource types.PeerSource
+	if r.consensus != nil && r.consensus.Overlay != nil {
+		peerSource = r.consensus.Overlay
+	}
+	manager := subscription.NewManager()
 
 	// Create HTTP JSON-RPC server. The dispatch timeout stays strictly below
 	// the transport WriteTimeout (see httpWriteTimeout) so a timed-out request
 	// can still serialize its error envelope.
-	r.httpServer = rpc.NewServerWithLoadTracker(rpcDispatchTimeout, r.services, transportLoad)
-	if r.consensus != nil && r.consensus.Overlay != nil {
-		r.httpServer.SetPeerSource(r.consensus.Overlay)
-	}
+	r.httpServer = rpc.NewServer(rpc.ServerOptions{
+		Timeout:     rpcDispatchTimeout,
+		Services:    r.services,
+		LoadTracker: transportLoad,
+		PeerSource:  peerSource,
+	})
+	r.services.Dispatcher = r.httpServer
 
-	r.services.SetDispatcher(r.httpServer)
-
-	r.wsServer = rpc.NewWebSocketServerWithLoadTracker(rpcDispatchTimeout, r.services, transportLoad)
-	if r.appConfig.WebsocketPingFrequency > 0 {
-		r.wsServer.SetPingInterval(time.Duration(r.appConfig.WebsocketPingFrequency) * time.Second)
-	}
-	r.wsServer.RegisterAllMethods()
-	if r.consensus != nil && r.consensus.Overlay != nil {
-		r.wsServer.SetPeerSource(r.consensus.Overlay)
-	}
-
-	r.wsServer.SetLedgerInfoProvider(&ledgerInfoAdapter{ledgerService: r.ledger})
+	pingInterval := time.Duration(r.appConfig.WebsocketPingFrequency) * time.Second
+	r.wsServer = rpc.NewWebSocketServer(rpc.WebSocketServerOptions{
+		Timeout:             rpcDispatchTimeout,
+		Services:            r.services,
+		LoadTracker:         transportLoad,
+		PeerSource:          peerSource,
+		PingInterval:        pingInterval,
+		LedgerInfoProvider:  &ledgerInfoAdapter{ledgerService: r.ledger},
+		SubscriptionManager: manager,
+	})
+	r.services.URLSubscriptions = r.wsServer.URLSubscriptionService()
 
 	r.publisher = rpc.NewPublisher(r.wsServer.SubscriptionManager())
 	return nil
@@ -989,13 +998,13 @@ func (r *nodeRuntime) bindStreams() error {
 
 func (r *nodeRuntime) bindTransports() error {
 	ctx := r.ctx
-	r.services.SetShutdownFunc(func() {
+	r.services.ShutdownFunc = func() {
 		r.serverLog.Info("Shutdown requested via RPC stop command")
 		select {
 		case r.shutdownCh <- struct{}{}:
 		default:
 		}
-	})
+	}
 
 	if err := context.Cause(ctx); err != nil {
 		return err

--- a/internal/node/send_queue_test.go
+++ b/internal/node/send_queue_test.go
@@ -18,7 +18,7 @@ import (
 func TestWebSocketInvalidSendQueueReleasesListenerSlot(t *testing.T) {
 	for _, value := range []int{-1, 65536} {
 		t.Run(strconv.Itoa(value), func(t *testing.T) {
-			ws := rpc.NewWebSocketServer(time.Second, nil)
+			ws := rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second})
 			bound, err := bindRPCTransports(
 				t.Context(),
 				xrpllog.Discard(),

--- a/internal/node/transports_test.go
+++ b/internal/node/transports_test.go
@@ -37,7 +37,7 @@ func newConnectionLimitTestTransports(t *testing.T, protocol string, limit int) 
 			w.Header().Set("Content-Type", "text/plain")
 			_, _ = w.Write([]byte("ok"))
 		}),
-		rpc.NewWebSocketServer(time.Second, nil),
+		rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second}),
 		nil,
 		systemListen,
 	)
@@ -194,7 +194,7 @@ func TestRPCConnectionLimitReleasesRejectedHTTPTransportConnections(t *testing.T
 			},
 		}},
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
-		rpc.NewWebSocketServer(time.Second, nil),
+		rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second}),
 		nil,
 		systemListen,
 	)
@@ -252,7 +252,7 @@ func TestRPCConnectionLimitReleasesRejectedHTTPTransportConnections(t *testing.T
 }
 
 func TestRPCConnectionLimitReleasesRejectedWebSocketConnections(t *testing.T) {
-	wsServer := rpc.NewWebSocketServer(time.Second, nil)
+	wsServer := rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second})
 	bound, err := bindRPCTransports(
 		t.Context(),
 		xrpllog.Discard(),
@@ -334,7 +334,7 @@ func TestRPCConnectionLimitReleasesRejectedWebSocketConnections(t *testing.T) {
 }
 
 func TestRPCConnectionLimitIsGlobalAcrossHTTPAndWebSocketPorts(t *testing.T) {
-	wsServer := rpc.NewWebSocketServer(time.Second, nil)
+	wsServer := rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second})
 	bound, err := bindRPCTransports(
 		t.Context(),
 		xrpllog.Discard(),
@@ -403,7 +403,7 @@ func TestBindRPCTransportsValidatesAllPortsBeforeBinding(t *testing.T) {
 		xrpllog.Discard(),
 		cfg,
 		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
-		rpc.NewWebSocketServer(time.Second, nil),
+		rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second}),
 		nil,
 		func(context.Context, string, string) (net.Listener, error) {
 			calls.Add(1)
@@ -429,7 +429,7 @@ func TestBindRPCTransportsClosesEarlierListenersOnLaterFailure(t *testing.T) {
 		xrpllog.Discard(),
 		cfg,
 		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
-		rpc.NewWebSocketServer(time.Second, nil),
+		rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second}),
 		nil,
 		func(context.Context, string, string) (net.Listener, error) {
 			if calls.Add(1) == 2 {
@@ -461,7 +461,7 @@ func TestBindRPCTransportsClosesHTTPWhenGRPCBindFails(t *testing.T) {
 		xrpllog.Discard(),
 		cfg,
 		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
-		rpc.NewWebSocketServer(time.Second, nil),
+		rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second}),
 		&stubLookup{},
 		func(context.Context, string, string) (net.Listener, error) {
 			if calls.Add(1) == 2 {
@@ -502,7 +502,7 @@ func TestBoundRPCTransportsDoNotServeBeforeCommit(t *testing.T) {
 		xrpllog.Discard(),
 		cfg,
 		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
-		rpc.NewWebSocketServer(time.Second, nil),
+		rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second}),
 		nil,
 		func(context.Context, string, string) (net.Listener, error) { return tracked, nil },
 	)
@@ -530,7 +530,7 @@ func TestBoundRPCTransportsHealthUsesTransportBasicAuth(t *testing.T) {
 			},
 		}},
 		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
-		rpc.NewWebSocketServer(time.Second, nil),
+		rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second}),
 		nil,
 		systemListen,
 	)
@@ -578,7 +578,7 @@ func TestBoundRPCTransportsServeAndJoinAllProtocols(t *testing.T) {
 		xrpllog.Discard(),
 		cfg,
 		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
-		rpc.NewWebSocketServer(time.Second, nil),
+		rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second}),
 		&stubLookup{},
 		systemListen,
 	)
@@ -619,7 +619,7 @@ func TestBoundRPCTransportsPreStoppedServersDoNotBlockServe(t *testing.T) {
 		xrpllog.Discard(),
 		cfg,
 		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
-		rpc.NewWebSocketServer(time.Second, nil),
+		rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second}),
 		&stubLookup{},
 		systemListen,
 	)
@@ -654,7 +654,7 @@ func TestShutdownTransportsForceClosesStuckHTTPHandler(t *testing.T) {
 			close(started)
 			<-release
 		}),
-		rpc.NewWebSocketServer(time.Second, nil),
+		rpc.NewWebSocketServer(rpc.WebSocketServerOptions{Timeout: time.Second}),
 		nil,
 		systemListen,
 	)

--- a/internal/rpc/admin_credentials_test.go
+++ b/internal/rpc/admin_credentials_test.go
@@ -74,7 +74,7 @@ func TestHTTPBatchAdminCredentialsArePerElement(t *testing.T) {
 }
 
 func TestWebSocketAdminCredentials(t *testing.T) {
-	ws := NewWebSocketServer(2*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 2 * time.Second})
 	ws.methodRegistry.Register("stop", &stubHandler{role: types.RoleAdmin})
 	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ws.ServeHTTP(w, r.WithContext(WithPortContext(r.Context(), credentialedAdminPort())))

--- a/internal/rpc/admin_forbidden_test.go
+++ b/internal/rpc/admin_forbidden_test.go
@@ -168,7 +168,7 @@ func TestHTTPBatchAdminDenialForbidden(t *testing.T) {
 // i.e. the "forbidden" token with code 3. A non-admin role is forced by
 // configuring AdminNets that exclude the loopback test peer.
 func TestWSAdminDenialForbidden(t *testing.T) {
-	ws := NewWebSocketServer(2*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 2 * time.Second})
 	ws.methodRegistry.Register("stop", &stubHandler{role: types.RoleAdmin})
 
 	_, adminNet, _ := net.ParseCIDR("10.0.0.0/8")

--- a/internal/rpc/admin_transport_test.go
+++ b/internal/rpc/admin_transport_test.go
@@ -27,7 +27,7 @@ func transportTestPort() *PortContext {
 
 func transportTestServer(t *testing.T, calls *atomic.Int32) *Server {
 	t.Helper()
-	srv := NewServer(time.Second, types.NewServiceContainer(nil))
+	srv := NewServer(ServerOptions{Timeout: time.Second, Services: types.NewServiceContainer(nil)})
 	srv.registry.Register("stop", &stubHandler{
 		role: types.RoleGuest,
 		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
@@ -138,7 +138,7 @@ func TestHTTPTransportNoOriginCLI(t *testing.T) {
 
 func wsTransportServer(t *testing.T, pc *PortContext) (*httptest.Server, *WebSocketServer) {
 	t.Helper()
-	ws := NewWebSocketServer(time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second})
 	ws.methodRegistry.Register("ping", &stubHandler{role: types.RoleGuest})
 	httpSrv := httptest.NewServer(PortMiddleware(pc, http.HandlerFunc(ws.ServeHTTP)))
 	t.Cleanup(func() {

--- a/internal/rpc/api_version_gate_test.go
+++ b/internal/rpc/api_version_gate_test.go
@@ -178,7 +178,7 @@ func TestApiVersion_BatchV3RejectedWithoutBeta(t *testing.T) {
 // given beta flag.
 func versionEchoWSServer(t *testing.T, beta bool) *WebSocketServer {
 	t.Helper()
-	ws := NewWebSocketServer(30*time.Second, types.NewServiceContainer(nil))
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second, Services: types.NewServiceContainer(nil)})
 	ws.services.BetaRPCAPI = beta
 	ws.methodRegistry.Register("ping", &stubHandler{
 		apiVers: []int{types.ApiVersion1, types.ApiVersion2, types.ApiVersion3},

--- a/internal/rpc/dispatch_gate_order_test.go
+++ b/internal/rpc/dispatch_gate_order_test.go
@@ -102,7 +102,8 @@ func TestDispatchGateOrder(t *testing.T) {
 // precedes the unknown-command failure.
 func TestHTTPForbiddenBeatsBusy(t *testing.T) {
 	services := types.NewServiceContainer(nil)
-	srv := NewServer(time.Second, services)
+	services.ClientLoad = types.NewClientLoadShedder()
+	srv := NewServer(ServerOptions{Timeout: time.Second, Services: services})
 	srv.registry.Register("stop", &stubHandler{role: types.RoleAdmin})
 
 	for i := int64(0); i <= types.MaxJobQueueClients; i++ {
@@ -146,7 +147,7 @@ func TestHTTPForbiddenBeatsBusy(t *testing.T) {
 // invalid_API_version bare token.
 func TestHTTPKnownMethodUnsupportedVersionIsUnknownCommand(t *testing.T) {
 	services := types.NewServiceContainer(nil)
-	srv := NewServer(time.Second, services)
+	srv := NewServer(ServerOptions{Timeout: time.Second, Services: services})
 	srv.registry.Register("v1only", &stubHandler{role: types.RoleGuest, apiVers: []int{types.ApiVersion1}})
 
 	post := func(body string) *httptest.ResponseRecorder {

--- a/internal/rpc/dispatch_parity_test.go
+++ b/internal/rpc/dispatch_parity_test.go
@@ -134,7 +134,7 @@ func TestLoadWarningNestedInResultOnHTTP(t *testing.T) {
 // alias for `command`, and an unresolvable command yields a bare missingCommand
 // token that echoes the request and id (ServerHandler.cpp:446-468).
 func TestWSCommandAliasAndMissingCommand(t *testing.T) {
-	ws := NewWebSocketServer(2*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 2 * time.Second})
 	ws.methodRegistry.Register("ping", &stubHandler{})
 
 	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))

--- a/internal/rpc/json_proxy_regression_test.go
+++ b/internal/rpc/json_proxy_regression_test.go
@@ -16,8 +16,9 @@ import (
 
 func TestJSONProxyUsesSingleDispatchAccounting(t *testing.T) {
 	services := types.NewServiceContainer(nil)
-	server := NewServer(time.Second, services)
-	services.SetDispatcher(server)
+	services.ClientLoad = types.NewClientLoadShedder()
+	server := NewServer(ServerOptions{Timeout: time.Second, Services: services})
+	services.Dispatcher = server
 
 	for range types.MaxJobQueueClients - 1 {
 		services.ClientLoad.Begin()
@@ -113,8 +114,8 @@ func TestHTTPStructuredIDRedactionAcrossDispatchShapes(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			services := types.NewServiceContainer(nil)
-			server := NewServer(time.Second, services)
-			services.SetDispatcher(server)
+			server := NewServer(ServerOptions{Timeout: time.Second, Services: services})
+			services.Dispatcher = server
 			server.registry.Register("capture", &stubHandler{
 				handle: func(_ *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 					var received map[string]any
@@ -147,7 +148,7 @@ func TestURLUserinfoIsRedactedAcrossTransportEchoes(t *testing.T) {
 			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 		},
 	}
-	httpServer := NewServer(time.Second, types.NewServiceContainer(nil))
+	httpServer := NewServer(ServerOptions{Timeout: time.Second, Services: types.NewServiceContainer(nil)})
 	httpServer.registry.Register("userinfo_fail", fail)
 
 	urls := []struct {
@@ -178,7 +179,7 @@ func TestURLUserinfoIsRedactedAcrossTransportEchoes(t *testing.T) {
 			}
 
 			t.Run("WebSocket", func(t *testing.T) {
-				server := NewWebSocketServer(time.Second, nil)
+				server := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second})
 				server.methodRegistry.Register("userinfo_fail", fail)
 				body := wsRawRoundTrip(t, server,
 					`{"command":"userinfo_fail","url":"`+testURL.value+`"}`,

--- a/internal/rpc/load_shed_http_test.go
+++ b/internal/rpc/load_shed_http_test.go
@@ -12,18 +12,19 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
-func TestNewServerWiresClientLoadShedder(t *testing.T) {
+func TestNewServerLeavesServiceContainerUntouched(t *testing.T) {
 	services := types.NewServiceContainer(nil)
-	_ = NewServer(time.Second, services)
+	_ = NewServer(ServerOptions{Timeout: time.Second, Services: services})
 
-	if services.ClientLoad == nil {
-		t.Fatal("NewServer did not wire services.ClientLoad")
+	if services.ClientLoad != nil {
+		t.Fatal("NewServer mutated services.ClientLoad")
 	}
 }
 
 func TestRpcTooBusyUsesLegacyHTTP200(t *testing.T) {
 	services := types.NewServiceContainer(nil)
-	srv := NewServer(time.Second, services)
+	services.ClientLoad = types.NewClientLoadShedder()
+	srv := NewServer(ServerOptions{Timeout: time.Second, Services: services})
 	srv.registry.Register("book_offers", &handlers.BookOffersMethod{})
 
 	for i := int64(0); i <= types.MaxJobQueueClients; i++ {
@@ -65,7 +66,8 @@ func TestRpcTooBusyUsesLegacyHTTP200(t *testing.T) {
 
 func TestRequestUnderThresholdReturnsHTTP200(t *testing.T) {
 	services := types.NewServiceContainer(nil)
-	srv := NewServer(time.Second, services)
+	services.ClientLoad = types.NewClientLoadShedder()
+	srv := NewServer(ServerOptions{Timeout: time.Second, Services: services})
 	srv.registry.Register("book_offers", &handlers.BookOffersMethod{})
 
 	body := `{"method":"book_offers","params":[{}]}`

--- a/internal/rpc/overload_gate_test.go
+++ b/internal/rpc/overload_gate_test.go
@@ -196,7 +196,7 @@ func TestWSOverloadClosesBeforeRequestValidation(t *testing.T) {
 	}
 	for _, request := range tests {
 		t.Run(request, func(t *testing.T) {
-			ws := NewWebSocketServer(2*time.Second, nil)
+			ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 2 * time.Second})
 			ws.methodRegistry.Register("stop", &stubHandler{role: types.RoleAdmin})
 			ws.loadTracker = loadtrack.New()
 			pushOverDropThreshold(t, ws.loadTracker, "127.0.0.1")
@@ -253,7 +253,7 @@ func TestWSEarlyMalformedResponsesChargeWithoutLoadWarning(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ws := NewWebSocketServer(2*time.Second, nil)
+			ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 2 * time.Second})
 			ws.loadTracker.Import("warning-peer", loadtrack.Gossip{Items: []loadtrack.GossipItem{{
 				Key:     "127.0.0.1",
 				Balance: loadtrack.WarningThreshold - int(loadtrack.ChargeMalformed/uint32(loadtrack.DecayWindow/time.Second)),

--- a/internal/rpc/path_find_refresh_test.go
+++ b/internal/rpc/path_find_refresh_test.go
@@ -17,7 +17,7 @@ import (
 
 func newPathFindRefreshTestServer(t *testing.T, count int) (*WebSocketServer, []*websocketConnection) {
 	t.Helper()
-	ws := NewWebSocketServer(time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second})
 	manager := ws.ensurePathFindRefreshManager()
 	connections := make([]*websocketConnection, 0, count)
 	ws.connectionsMutex.Lock()

--- a/internal/rpc/path_find_session_concurrency_test.go
+++ b/internal/rpc/path_find_session_concurrency_test.go
@@ -17,7 +17,7 @@ func TestPathFindCreateInvalidReplacementClearsOldSession(t *testing.T) {
 	conn.installPathFindSession(old)
 	before := conn.pathFindGeneration
 
-	ws := NewWebSocketServer(0, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 0})
 	_, rpcErr := ws.executePathFindCreate(conn, &types.RpcContext{Context: ctx}, types.WebSocketCommand{
 		ID:     1,
 		Params: json.RawMessage(`{"subcommand":"create"}`),

--- a/internal/rpc/print_wire_test.go
+++ b/internal/rpc/print_wire_test.go
@@ -32,18 +32,13 @@ func printTestServer(t *testing.T) *Server {
 		}
 	}
 
-	srv := &Server{
-		registry: types.NewMethodRegistry(),
-		timeout:  time.Second,
-		services: svc,
-	}
-	srv.registry.Register("print", &handlers.PrintMethod{})
-	srv.SetPeerSource(&stubPeerSource{
+	srv := NewServer(ServerOptions{Timeout: time.Second, Services: svc, PeerSource: &stubPeerSource{
 		peers:                  []map[string]any{{"address": "192.0.2.1:51235"}},
 		cluster:                map[string]any{},
 		criticalFailuresLocal:  4,
 		criticalFailuresShared: 2,
-	})
+	}})
+	srv.registry.Register("print", &handlers.PrintMethod{})
 	return srv
 }
 

--- a/internal/rpc/rpcsub_test.go
+++ b/internal/rpc/rpcsub_test.go
@@ -93,10 +93,15 @@ func (s *rpcSubSink) expectNone(t *testing.T) {
 // carries the url-subscription registry, plus admin/guest contexts for
 // driving the plain JSON-RPC handlers.
 func newRPCSubTestServer(t *testing.T) (*WebSocketServer, *types.ServiceContainer) {
+	return newRPCSubTestServerWithProvider(t, nil)
+}
+
+func newRPCSubTestServerWithProvider(t *testing.T, provider types.LedgerInfoProvider) (*WebSocketServer, *types.ServiceContainer) {
 	t.Helper()
 	services := types.NewServiceContainer(nil)
-	ws := NewWebSocketServer(time.Second, services)
-	require.NotNil(t, services.URLSubscriptions, "NewWebSocketServer must expose the url registry")
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second, Services: services, LedgerInfoProvider: provider})
+	services.URLSubscriptions = ws.URLSubscriptionService()
+	require.NotNil(t, services.URLSubscriptions, "composition must expose the url registry explicitly")
 	return ws, services
 }
 
@@ -382,8 +387,7 @@ func TestRPCSub_AccountsDontBlockRemoval(t *testing.T) {
 // field gating: network_id is always present (even 0) and fee_ref appears
 // only while XRPFees is disabled.
 func TestRPCSub_SubscribeAckCarriesLedgerInfo(t *testing.T) {
-	ws, services := newRPCSubTestServer(t)
-	ws.SetLedgerInfoProvider(stubLedgerInfoProvider{ledgerAvailable: true})
+	_, services := newRPCSubTestServerWithProvider(t, stubLedgerInfoProvider{ledgerAvailable: true})
 	sink := newRPCSubSink(t)
 
 	result, rpcErr := subscribeURL(t, services, `{"url":"`+sink.srv.URL+`","streams":["ledger"]}`)
@@ -404,8 +408,7 @@ func TestRPCSub_SubscribeAckCarriesLedgerInfo(t *testing.T) {
 // from the ack once the XRPFees amendment is enabled, mirroring rippled's
 // subLedger gate.
 func TestRPCSub_SubscribeAckOmitsFeeRefUnderXRPFees(t *testing.T) {
-	ws, services := newRPCSubTestServer(t)
-	ws.SetLedgerInfoProvider(stubLedgerInfoProvider{ledgerAvailable: true, xrpFees: true})
+	_, services := newRPCSubTestServerWithProvider(t, stubLedgerInfoProvider{ledgerAvailable: true, xrpFees: true})
 	sink := newRPCSubSink(t)
 
 	result, rpcErr := subscribeURL(t, services, `{"url":"`+sink.srv.URL+`","streams":["ledger"]}`)
@@ -430,8 +433,7 @@ func TestSubLedgerWireMatrix(t *testing.T) {
 							if validatedLedgersPresent {
 								validatedLedgers = complete
 							}
-							ws, _ := newRPCSubTestServer(t)
-							ws.SetLedgerInfoProvider(stubLedgerInfoProvider{
+							ws, _ := newRPCSubTestServerWithProvider(t, stubLedgerInfoProvider{
 								ledgerAvailable:         true,
 								xrpFees:                 xrpFees,
 								validatedLedgers:        validatedLedgers,
@@ -475,8 +477,7 @@ func TestSubLedgerWireMatrixWithoutValidatedLedger(t *testing.T) {
 						if validatedLedgersPresent {
 							validatedLedgers = complete
 						}
-						ws, _ := newRPCSubTestServer(t)
-						ws.SetLedgerInfoProvider(stubLedgerInfoProvider{
+						ws, _ := newRPCSubTestServerWithProvider(t, stubLedgerInfoProvider{
 							validatedLedgers:        validatedLedgers,
 							validatedLedgersPresent: validatedLedgersPresent,
 							networkID:               networkID,

--- a/internal/rpc/send_queue_test.go
+++ b/internal/rpc/send_queue_test.go
@@ -56,7 +56,7 @@ func TestWebSocketSendQueueLimitRealHandshake(t *testing.T) {
 		{name: "maximum explicit value", value: maxSendQueueLimit, want: maxSendQueueLimit},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			ws := NewWebSocketServer(time.Second, nil)
+			ws := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second})
 			httpServer := httptest.NewServer(PortMiddleware(
 				&PortContext{SendQueue: test.value},
 				http.HandlerFunc(ws.ServeHTTP),
@@ -90,7 +90,7 @@ func TestWebSocketSendQueueLimitRealHandshake(t *testing.T) {
 func TestWebSocketSendQueueLimitInvalidConfigFailsBeforeUpgrade(t *testing.T) {
 	for _, value := range []int{-1, maxSendQueueLimit + 1} {
 		t.Run(strings.ReplaceAll(strconv.Itoa(value), "-", "negative_"), func(t *testing.T) {
-			ws := NewWebSocketServer(time.Second, nil)
+			ws := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second})
 			httpServer := httptest.NewServer(PortMiddleware(
 				&PortContext{SendQueue: value},
 				http.HandlerFunc(ws.ServeHTTP),

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -52,20 +52,24 @@ type Server struct {
 	loadTracker *loadtrack.Tracker
 }
 
+// ServerOptions controls construction of an HTTP JSON-RPC server.
+// Services may be nil for routing-only tests; constructors never mutate it.
+type ServerOptions struct {
+	Timeout     time.Duration
+	Services    *types.ServiceContainer
+	LoadTracker *loadtrack.Tracker
+	PeerSource  types.PeerSource
+}
+
 var _ types.MethodDispatcher = (*Server)(nil)
 
 // peerSourceHolder is the atomic peer-source slot embedded by both the HTTP
-// and WebSocket servers, exposed through the `peers` RPC. Embedding it gives
-// both the same SetPeerSource / loadPeerSource without duplicating the field
-// and methods on each server.
+// and WebSocket servers, exposed through the `peers` RPC.
 type peerSourceHolder struct {
 	peerSource atomic.Pointer[types.PeerSource]
 }
 
-// SetPeerSource registers the source of per-peer entries served by the
-// `peers` RPC handler. Passing nil detaches the source so the handler
-// returns an empty list. Safe to call concurrently with reads.
-func (h *peerSourceHolder) SetPeerSource(src types.PeerSource) {
+func (h *peerSourceHolder) setPeerSource(src types.PeerSource) {
 	if src == nil {
 		h.peerSource.Store(nil)
 		return
@@ -80,40 +84,25 @@ func (h *peerSourceHolder) loadPeerSource() types.PeerSource {
 	return nil
 }
 
-// NewServer creates a new RPC server with the given timeout and the
-// service container handlers will read through ctx.Services. The
-// container may be nil for test contexts that exercise routing only.
-func NewServer(timeout time.Duration, services *types.ServiceContainer) *Server {
-	return NewServerWithLoadTracker(timeout, services, nil)
-}
-
-// NewServerWithLoadTracker creates a server using tracker for transport-level
-// admission and charging. A nil tracker preserves NewServer's standalone
-// default.
-func NewServerWithLoadTracker(timeout time.Duration, services *types.ServiceContainer, tracker *loadtrack.Tracker) *Server {
+// NewServer creates a new RPC server. The service container is read by
+// handlers through ctx.Services and is never changed by this constructor.
+func NewServer(options ServerOptions) *Server {
+	tracker := options.LoadTracker
 	if tracker == nil {
 		tracker = loadtrack.New()
 	}
 	server := &Server{
 		registry:    types.NewMethodRegistry(),
-		timeout:     timeout,
-		services:    services,
+		timeout:     options.Timeout,
+		services:    options.Services,
 		loadTracker: tracker,
 	}
-
-	if services != nil && services.ClientLoad == nil {
-		services.ClientLoad = types.NewClientLoadShedder()
-	}
+	server.setPeerSource(options.PeerSource)
 
 	server.registerAllMethods()
 
 	return server
 }
-
-// Services returns the service container wired to this server. Used by
-// callers that need to attach the dispatcher (this server itself) or
-// the shutdown hook after construction.
-func (s *Server) Services() *types.ServiceContainer { return s.services }
 
 // JsonRpcResponseOptions contains optional fields for JSON-RPC responses
 // These fields are at the top level, not inside the result object

--- a/internal/rpc/transport_regression_test.go
+++ b/internal/rpc/transport_regression_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/rpc/loadtrack"
+	"github.com/LeJamon/go-xrpl/internal/rpc/subscription"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,19 +42,64 @@ func newTransportRegressionServer(t *testing.T) *Server {
 
 func TestTransportConstructorsShareInjectedLoadTracker(t *testing.T) {
 	tracker := loadtrack.New()
-	httpServer := NewServerWithLoadTracker(time.Second, nil, tracker)
-	wsServer := NewWebSocketServerWithLoadTracker(time.Second, nil, tracker)
+	httpServer := NewServer(ServerOptions{Timeout: time.Second, Services: nil, LoadTracker: tracker})
+	wsServer := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second, Services: nil, LoadTracker: tracker})
 
 	require.Same(t, tracker, httpServer.loadTracker)
 	require.Same(t, tracker, wsServer.loadTracker)
 	tracker.Charge("shared-client", loadtrack.LoadMalformed)
 	assert.Greater(t, wsServer.loadTracker.Balance("shared-client"), float64(0))
 
-	defaultHTTP := NewServer(time.Second, nil)
-	defaultWS := NewWebSocketServer(time.Second, nil)
+	defaultHTTP := NewServer(ServerOptions{Timeout: time.Second})
+	defaultWS := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second})
 	require.NotNil(t, defaultHTTP.loadTracker)
 	require.NotNil(t, defaultWS.loadTracker)
 	require.NotSame(t, defaultHTTP.loadTracker, defaultWS.loadTracker)
+}
+
+func TestRPCConstructorsUseExplicitDependencies(t *testing.T) {
+	services := types.NewServiceContainer(nil)
+	clientLoad := types.NewClientLoadShedder()
+	services.ClientLoad = clientLoad
+	manager := subscription.NewManager()
+	provider := stubLedgerInfoProvider{ledgerAvailable: true}
+	peerSource := &stubPeerSource{}
+
+	httpServer := NewServer(ServerOptions{
+		Timeout:     time.Second,
+		Services:    services,
+		LoadTracker: loadtrack.New(),
+		PeerSource:  peerSource,
+	})
+	wsServer := NewWebSocketServer(WebSocketServerOptions{
+		Timeout:             time.Second,
+		Services:            services,
+		LoadTracker:         httpServer.loadTracker,
+		PeerSource:          peerSource,
+		PingInterval:        5 * time.Second,
+		LedgerInfoProvider:  provider,
+		SubscriptionManager: manager,
+	})
+
+	if services.ClientLoad != clientLoad || services.Dispatcher != nil || services.URLSubscriptions != nil {
+		t.Fatal("RPC constructors mutated the service container")
+	}
+	clientLoad.Begin()
+	if httpServer.services.ClientLoad.InFlight() != 1 || wsServer.services.ClientLoad.InFlight() != 1 {
+		t.Fatal("HTTP and WebSocket servers did not observe the shared client-load shedder")
+	}
+	if wsServer.SubscriptionManager() != manager {
+		t.Fatal("WebSocket server did not retain the explicitly supplied subscription manager")
+	}
+	if wsServer.pingInterval != 5*time.Second || wsServer.ledgerInfoProvider != provider {
+		t.Fatal("WebSocket options were not applied")
+	}
+	if _, ok := httpServer.registry.Get("ping"); !ok {
+		t.Fatal("HTTP method registry was not ready at construction return")
+	}
+	if _, ok := wsServer.methodRegistry.Get("ping"); !ok {
+		t.Fatal("WebSocket method registry was not ready at construction return")
+	}
 }
 
 func seedTransportRegressionLoad(tracker *loadtrack.Tracker, balance int) {

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -1514,20 +1514,10 @@ type NFTOffersResult struct {
 }
 
 // NewServiceContainer constructs a ServiceContainer wired to the given
-// ledger service. Callers attach the dispatcher, peer hooks, manifest
-// cache, etc. afterwards as components come online.
+// ledger service. Callers attach the runtime services as components come
+// online.
 func NewServiceContainer(ledger LedgerService) *ServiceContainer {
 	return &ServiceContainer{
 		Ledger: ledger,
 	}
-}
-
-// SetDispatcher sets the method dispatcher on the service container.
-func (sc *ServiceContainer) SetDispatcher(d MethodDispatcher) {
-	sc.Dispatcher = d
-}
-
-// SetShutdownFunc sets the shutdown function on the service container.
-func (sc *ServiceContainer) SetShutdownFunc(f func()) {
-	sc.ShutdownFunc = f
 }

--- a/internal/rpc/websocket.go
+++ b/internal/rpc/websocket.go
@@ -67,9 +67,8 @@ type WebSocketServer struct {
 	loadTracker       *loadtrack.Tracker
 	pathFindRefreshMu sync.Mutex
 	pathFindRefresh   *pathFindRefreshManager
-	// pingInterval is how often pingLoop sends a keepalive ping. Settable
-	// so concurrency tests can drive the ping path without waiting on the
-	// production cadence.
+	// pingInterval is how often pingLoop sends a keepalive ping, selected at
+	// construction so tests and node composition can choose their cadence.
 	pingInterval time.Duration
 	// wg tracks admitted HTTP handlers and per-connection goroutines so Close
 	// can join them on shutdown.
@@ -77,6 +76,20 @@ type WebSocketServer struct {
 	closeOnce sync.Once
 	closeDone chan struct{}
 	forceDone chan struct{}
+}
+
+// WebSocketServerOptions controls construction of a WebSocket RPC server.
+// The service container is read by handlers and is never changed by the
+// constructor. A nil subscription manager selects a new manager for the
+// standalone server.
+type WebSocketServerOptions struct {
+	Timeout             time.Duration
+	Services            *types.ServiceContainer
+	LoadTracker         *loadtrack.Tracker
+	PeerSource          types.PeerSource
+	PingInterval        time.Duration
+	LedgerInfoProvider  types.LedgerInfoProvider
+	SubscriptionManager *subscription.Manager
 }
 
 // websocketConnection owns the transport-specific state for one logical
@@ -103,23 +116,20 @@ type websocketConnection struct {
 	closeOnce    sync.Once
 }
 
-// NewWebSocketServer creates a new WebSocket server. The provided
-// service container is attached to every RpcContext routed through the
-// server so handlers reach the ledger via ctx.Services. May be nil for
-// test contexts.
-func NewWebSocketServer(timeout time.Duration, services *types.ServiceContainer) *WebSocketServer {
-	return NewWebSocketServerWithLoadTracker(timeout, services, nil)
-}
-
-// NewWebSocketServerWithLoadTracker creates a WebSocket server using tracker
-// for transport-level admission and charging. A nil tracker preserves
-// NewWebSocketServer's standalone default.
-func NewWebSocketServerWithLoadTracker(timeout time.Duration, services *types.ServiceContainer, tracker *loadtrack.Tracker) *WebSocketServer {
+// NewWebSocketServer creates a new WebSocket RPC server. All method handlers
+// are registered before the constructor returns.
+func NewWebSocketServer(options WebSocketServerOptions) *WebSocketServer {
+	tracker := options.LoadTracker
 	if tracker == nil {
 		tracker = loadtrack.New()
 	}
-	if services != nil && services.ClientLoad == nil {
-		services.ClientLoad = types.NewClientLoadShedder()
+	manager := options.SubscriptionManager
+	if manager == nil {
+		manager = subscription.NewManager()
+	}
+	pingInterval := options.PingInterval
+	if pingInterval <= 0 {
+		pingInterval = 30 * time.Second
 	}
 	ws := &WebSocketServer{
 		upgrader: websocket.Upgrader{
@@ -128,41 +138,25 @@ func NewWebSocketServerWithLoadTracker(timeout time.Duration, services *types.Se
 			CheckOrigin: func(r *http.Request) bool { return true },
 			// Don't require specific subprotocol - xrpl.js doesn't use one
 		},
-		subscriptionManager: subscription.NewManager(),
+		subscriptionManager: manager,
 		methodRegistry:      types.NewMethodRegistry(),
 		connections:         make(map[string]*websocketConnection),
-		timeout:             timeout,
-		services:            services,
+		timeout:             options.Timeout,
+		services:            options.Services,
 		loadTracker:         tracker,
-		pingInterval:        30 * time.Second,
+		pingInterval:        pingInterval,
+		ledgerInfoProvider:  options.LedgerInfoProvider,
 		closeDone:           make(chan struct{}),
 		forceDone:           make(chan struct{}),
 	}
 	ws.pathFindRefresh = newPathFindRefreshManager(ws)
-	// The url (RPCSub) registry lives on the WebSocket server because url
-	// subscribers share its subscription manager's broadcast fan-out.
-	// Exposing it through the service container lets the plain JSON-RPC
-	// subscribe/unsubscribe handlers reach it.
+	// The URL (RPCSub) registry lives on the WebSocket server because URL
+	// subscribers share its subscription manager's broadcast fan-out. Node
+	// composition installs the returned service on the shared container.
 	ws.urlSubs = newURLSubscriptionRegistry(ws)
-	if services != nil {
-		services.URLSubscriptions = ws.urlSubs
-	}
+	ws.setPeerSource(options.PeerSource)
+	ws.registerAllMethods()
 	return ws
-}
-
-// SetPingInterval overrides the keepalive ping cadence (the operator's
-// websocket_ping_frequency key). Non-positive values are ignored. Must
-// be called before connections are accepted.
-func (ws *WebSocketServer) SetPingInterval(d time.Duration) {
-	if d > 0 {
-		ws.pingInterval = d
-	}
-}
-
-// SetLedgerInfoProvider sets the provider used to return current ledger info
-// in subscribe responses (e.g., when subscribing to the "ledger" stream).
-func (ws *WebSocketServer) SetLedgerInfoProvider(provider types.LedgerInfoProvider) {
-	ws.ledgerInfoProvider = provider
 }
 
 func (ws *WebSocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -1289,17 +1283,19 @@ func resolveWSClientIP(peerIP, upgradeForwardedFor string, portCtx *PortContext)
 	return upgradeForwardedFor
 }
 
-// RegisterAllMethods registers every RPC method available on the WebSocket
-// endpoint. subscribe/unsubscribe are part of the common table (as in
-// rippled); the WebSocket dispatch intercepts both before registry lookup
-// and runs the real subscription implementation.
-func (ws *WebSocketServer) RegisterAllMethods() {
+func (ws *WebSocketServer) registerAllMethods() {
 	handlers.RegisterAll(ws.methodRegistry)
 }
 
 // SubscriptionManager returns the subscription manager for event publishing
 func (ws *WebSocketServer) SubscriptionManager() *subscription.Manager {
 	return ws.subscriptionManager
+}
+
+// URLSubscriptionService returns the URL subscription registry that node
+// composition installs on the shared service container after construction.
+func (ws *WebSocketServer) URLSubscriptionService() types.URLSubscriptionService {
+	return ws.urlSubs
 }
 
 // Close gracefully closes all active WebSocket connections and url (RPCSub)

--- a/internal/rpc/websocket_peers_test.go
+++ b/internal/rpc/websocket_peers_test.go
@@ -24,9 +24,7 @@ func TestWebSocket_PeersRPC_UsesPeerSource(t *testing.T) {
 	ledger := &mockLedgerService{}
 	services := &types.ServiceContainer{Ledger: ledger}
 
-	ws := NewWebSocketServer(30*time.Second, services)
-	ws.RegisterAllMethods()
-	ws.SetPeerSource(src)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second, Services: services, PeerSource: src})
 
 	pc := loopbackAdminPortContext()
 	pc.PortName = "test_admin"
@@ -61,11 +59,10 @@ func wsCall(t *testing.T, conn *websocket.Conn, req map[string]any) map[string]a
 	return resp
 }
 
-func TestWebSocket_SetPeerSource_NilDetaches(t *testing.T) {
+func TestWebSocketPeerSourceDefaultsToNil(t *testing.T) {
 	src := &stubPeerSource{peers: []map[string]any{{"address": "192.0.2.1:51235"}}}
-	ws := NewWebSocketServer(30*time.Second, nil)
-	ws.SetPeerSource(src)
-	require.NotNil(t, ws.loadPeerSource())
-	ws.SetPeerSource(nil)
-	require.Nil(t, ws.loadPeerSource())
+	withSource := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second, PeerSource: src})
+	require.NotNil(t, withSource.loadPeerSource())
+	withoutSource := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
+	require.Nil(t, withoutSource.loadPeerSource())
 }

--- a/internal/rpc/websocket_special_dispatch_test.go
+++ b/internal/rpc/websocket_special_dispatch_test.go
@@ -15,7 +15,7 @@ import (
 func newSpecialDispatchHarness(t *testing.T) (*WebSocketServer, *websocketConnection, *types.RpcContext) {
 	t.Helper()
 	services := &types.ServiceContainer{ClientLoad: types.NewClientLoadShedder()}
-	ws := NewWebSocketServerWithLoadTracker(time.Second, services, loadtrack.New())
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second, Services: services, LoadTracker: loadtrack.New()})
 	ws.methodRegistry.Register("subscribe", &stubHandler{})
 	ws.methodRegistry.Register("path_find", &stubHandler{})
 	send := make(chan []byte, 1)

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -66,8 +66,7 @@ func (l *blockingWriteListener) Accept() (net.Conn, error) {
 // all per-connection goroutines (read loop, send pump, ping loop) have exited.
 // Regression test for issue #186.
 func TestWebSocketServer_Close_JoinsHandlers(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
-	ws.RegisterAllMethods()
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 
 	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
 	defer httpSrv.Close()
@@ -136,7 +135,7 @@ func TestWebSocketServer_Close_JoinsHandlers(t *testing.T) {
 // TestWebSocketServer_Close_RespectsContext verifies Close returns promptly
 // when the context expires, even if handlers might otherwise linger.
 func TestWebSocketServer_Close_RespectsContext(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 
 	// Inflate the WaitGroup so it never reaches zero on its own.
 	ws.wg.Add(1)
@@ -171,7 +170,7 @@ func TestWebSocketServer_Close_RespectsContext(t *testing.T) {
 }
 
 func TestWebSocketServer_Close_ContextInterruptsBlockedControlWrite(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 	pc := &PortContext{PortName: "wsport", Limit: 1}
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -257,7 +256,7 @@ func TestWebSocketServer_Close_ContextInterruptsBlockedControlWrite(t *testing.T
 // TestWebSocketServer_Close_NoConnections verifies Close is safe with no
 // active connections and returns immediately.
 func TestWebSocketServer_Close_NoConnections(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := ws.Close(ctx); err != nil {
@@ -266,7 +265,7 @@ func TestWebSocketServer_Close_NoConnections(t *testing.T) {
 }
 
 func TestWebSocketConnectionCloseSocketUnblocksRead(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
 	defer httpSrv.Close()
 
@@ -327,7 +326,7 @@ func TestWebSocketConnectionCloseSocketUnblocksRead(t *testing.T) {
 }
 
 func TestWebSocketServer_Close_RejectsNewConnections(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 	pc := &PortContext{PortName: "wsport", Limit: 1}
 	httpSrv := httptest.NewServer(PortMiddleware(pc, http.HandlerFunc(ws.ServeHTTP)))
 	defer httpSrv.Close()
@@ -357,7 +356,7 @@ func TestWebSocketServer_Close_RejectsNewConnections(t *testing.T) {
 }
 
 func TestWebSocketServer_Close_WaitsForInFlightUpgrade(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 	upgradeStarted := make(chan struct{})
 	continueUpgrade := make(chan struct{})
 	ws.upgrader.CheckOrigin = func(*http.Request) bool {
@@ -454,8 +453,7 @@ func TestWebSocketServer_Close_WaitsForInFlightUpgrade(t *testing.T) {
 // calls touched gorilla's unguarded single-writer state and raced handleSend.
 // Run under -race to catch a regression. Regression test for issue #746.
 func TestWebSocketServer_ConcurrentWrites_NoRace(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
-	ws.RegisterAllMethods()
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 	ws.pingInterval = time.Millisecond // hammer the ping path during the test
 
 	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
@@ -524,7 +522,7 @@ func TestWebSocketServer_New_Concurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = NewWebSocketServer(time.Second, nil)
+			_ = NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second})
 		}()
 	}
 	wg.Wait()
@@ -536,8 +534,7 @@ func TestWebSocketServer_New_Concurrent(t *testing.T) {
 // ErrorCodes.cpp default text in `error_message` (issue #828 regression —
 // these envelopes previously went out as `"error": ""` with code 31).
 func TestWebSocketSubscribeErrorWireEnvelope(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
-	ws.RegisterAllMethods()
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 
 	httpSrv := httptest.NewServer(http.HandlerFunc(ws.ServeHTTP))
 	defer httpSrv.Close()
@@ -632,7 +629,7 @@ func TestWebSocketSubscribeErrorWireEnvelope(t *testing.T) {
 
 func TestWebSocketHandlerPanicWireEnvelope(t *testing.T) {
 	const panicCause = "websocket panic must stay private"
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 	ws.methodRegistry.Register("panic", &stubHandler{
 		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
 			panic(panicCause)
@@ -678,7 +675,7 @@ func TestWebSocketHandlerPanicWireEnvelope(t *testing.T) {
 }
 
 func TestWebSocketOrdinaryErrorWireEnvelope(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 	ws.methodRegistry.Register("fail", &stubHandler{
 		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
 			return nil, rpcInternalError()
@@ -694,7 +691,7 @@ func TestWebSocketOrdinaryErrorWireEnvelope(t *testing.T) {
 
 func TestWebSocketRedactsIDAndPreservesItInHandlerParams(t *testing.T) {
 	received := make(chan json.RawMessage, 1)
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 	ws.methodRegistry.Register("capture", &stubHandler{
 		handle: func(_ *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 			received <- append(json.RawMessage(nil), params...)
@@ -763,8 +760,7 @@ func TestWebSocketSpecialCommandDecodeErrorsAreFixed(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ws := NewWebSocketServer(time.Second, nil)
-			ws.RegisterAllMethods()
+			ws := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second})
 			wsConn := &websocketConnection{Connection: types.NewConnectionWithContext(context.Background(), "decode-test", make(chan []byte, 1))}
 			cmd := types.WebSocketCommand{
 				Command: test.command,
@@ -786,7 +782,7 @@ func TestWebSocketSpecialCommandDecodeErrorsAreFixed(t *testing.T) {
 }
 
 func TestWebSocketRejectsTrailingJSON(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 	ws.methodRegistry.Register("ping", &stubHandler{})
 
 	body := wsRawRoundTrip(t, ws, `{"command":"ping","id":7}{"command":"ping","id":8}`)
@@ -797,7 +793,7 @@ func TestWebSocketRejectsTrailingJSON(t *testing.T) {
 }
 
 func TestWebSocketJSONInvalidWireEnvelope(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 	tests := []struct {
 		name    string
 		request string
@@ -823,7 +819,7 @@ func TestWebSocketJSONInvalidWireEnvelope(t *testing.T) {
 }
 
 func TestWebSocketJSONIntegerBounds(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 	ws.methodRegistry.Register("ping", &stubHandler{})
 
 	for _, request := range []string{
@@ -863,7 +859,7 @@ func TestWebSocketJSONIntegerBounds(t *testing.T) {
 }
 
 func TestWebSocketErrorExceptionWireEnvelope(t *testing.T) {
-	ws := NewWebSocketServer(30*time.Second, nil)
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: 30 * time.Second})
 	ws.methodRegistry.Register("simulate", &stubHandler{
 		handle: func(*types.RpcContext, json.RawMessage) (any, *types.RpcError) {
 			return nil, types.RpcErrorInvalidTransaction("invalid transaction detail")
@@ -880,22 +876,19 @@ func TestWebSocketErrorExceptionWireEnvelope(t *testing.T) {
 	}
 }
 
-// TestSetPingInterval guards the websocket_ping_frequency wiring: a
-// configured cadence must replace the default, and non-positive values
-// must be ignored.
-func TestSetPingInterval(t *testing.T) {
-	ws := NewWebSocketServer(time.Second, nil)
+func TestWebSocketServerOptionsPingInterval(t *testing.T) {
+	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second})
 	if ws.pingInterval != 30*time.Second {
 		t.Fatalf("default pingInterval = %v, want 30s", ws.pingInterval)
 	}
 
-	ws.SetPingInterval(5 * time.Second)
-	if ws.pingInterval != 5*time.Second {
-		t.Errorf("pingInterval = %v, want 5s", ws.pingInterval)
+	configured := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second, PingInterval: 5 * time.Second})
+	if configured.pingInterval != 5*time.Second {
+		t.Errorf("configured pingInterval = %v, want 5s", configured.pingInterval)
 	}
 
-	ws.SetPingInterval(0)
-	if ws.pingInterval != 5*time.Second {
-		t.Errorf("pingInterval = %v after SetPingInterval(0), want 5s", ws.pingInterval)
+	zero := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second, PingInterval: 0})
+	if zero.pingInterval != 30*time.Second {
+		t.Errorf("zero pingInterval = %v, want default 30s", zero.pingInterval)
 	}
 }


### PR DESCRIPTION
## Summary

- Replace positional transport constructors and post-construction setters with explicit option structs.
- Make node composition own the shared load controls, subscription manager, dispatcher, URL subscriptions, and shutdown hook.
- Register both method tables before constructors return without mutating the service container.

## Verification

- Constructor and node wiring contract tests
- RPC/node/CLI normal suites and focused construction race stress tests

Refs #1483
