### PR TITLE
fix: restore peer proto2 contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,24 +48,26 @@ jobs:
           args: --config .golangci-warnings.yml
 
   generate:
-    name: Generate (ledger-entry drift check)
+    name: Generate (drift check)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
         with:
           cgo: "false"
-      # Re-run the ledger-entry generator and fail if any *_gen.go file
-      # changes — a spec edit without `go generate` would otherwise silently
-      # ship a stale typed decoder.
+      - uses: arduino/setup-protoc@v3
+        with:
+          version: "34.1"
+      - name: Install protoc-gen-go
+        run: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
       - name: Re-run go generate
-        run: go generate ./ledger/entry/...
+        run: go generate ./ledger/entry/... ./internal/peermanagement/proto
       - name: Fail on tree diff
         run: |
-          if ! git diff --exit-code -- ledger/entry; then
-            echo "::error::ledger-entry generated files are out of date."
-            echo "Run: go generate ./ledger/entry/..."
-            echo "Then commit the regenerated *_gen.go files."
+          if ! git diff --exit-code -- ledger/entry internal/peermanagement/proto/xrpl.pb.go; then
+            echo "::error::generated files are out of date."
+            echo "Run: go generate ./ledger/entry/... ./internal/peermanagement/proto"
+            echo "Then commit the regenerated files."
             exit 1
           fi
 

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,6 @@ require (
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
-	google.golang.org/protobuf v1.36.10
+	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20251029180050-ab9386a59fda h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251029180050-ab9386a59fda/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
 google.golang.org/grpc v1.78.0 h1:K1XZG/yGDJnzMdd/uZHAkVqJE+xIDOcmdSFZkBUicNc=
 google.golang.org/grpc v1.78.0/go.mod h1:I47qjTo4OKbMkjA/aOOwxDIiPSBofUtQUI5EfpWvW7U=
-google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
-google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/internal/consensus/adaptor/router_catchup.go
+++ b/internal/consensus/adaptor/router_catchup.go
@@ -2098,13 +2098,13 @@ func (r *Router) handleLedgerData(msg *peermanagement.InboundMessage) bool {
 		r.acquisition.IncPeerBadData(uint64(msg.PeerID), "ledger-data-sequence")
 		return false
 	}
-	if ld.Error != message.ReplyErrorNone &&
+	if ld.HasError() &&
 		(ld.Error < message.ReplyErrorNoLedger || ld.Error > message.ReplyErrorBadRequest) {
 		r.logger.Warn("invalid ledger_data reply error", "peer", msg.PeerID, "error", ld.Error)
 		r.acquisition.IncPeerBadData(uint64(msg.PeerID), "ledger-data-error")
 		return false
 	}
-	if ld.Error != message.ReplyErrorNone {
+	if ld.HasError() {
 		r.logger.Warn("inbound ledger: peer returned reply error",
 			"peer", msg.PeerID,
 			"seq", ld.LedgerSeq,

--- a/internal/consensus/adaptor/router_ledger_serve_ltype_test.go
+++ b/internal/consensus/adaptor/router_ledger_serve_ltype_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 // TestRouter_GetLedger_HashSeqlessGatesOnLtype pins rippled's
@@ -15,7 +16,7 @@ import (
 // ledger_hash nor a ledger_seq serves the closed ledger only when ltype ==
 // ltCLOSED; any other (or absent) ltype is a malformed "Invalid request" that
 // charges the peer and serves nothing. An ltype outside [ltACCEPTED, ltCLOSED]
-// is rejected as an invalid ledger type.
+// is treated as absent by the proto2 parser.
 func TestRouter_GetLedger_HashSeqlessGatesOnLtype(t *testing.T) {
 	send := func(t *testing.T, req *message.GetLedger) (*Router, []badDataCall, []sentFrame) {
 		t.Helper()
@@ -50,15 +51,40 @@ func TestRouter_GetLedger_HashSeqlessGatesOnLtype(t *testing.T) {
 		assert.Empty(t, sent, "hash/seq-less ltCURRENT must not serve the closed ledger")
 	})
 
-	t.Run("out-of-range ltype charges bad data, serves nothing", func(t *testing.T) {
+	t.Run("unknown ltype normalizes to absent", func(t *testing.T) {
+		r, rs := makeRouterWithQueryTypeRecorder(t)
+		payload := encodePayload(t, &message.GetLedger{InfoType: message.LedgerInfoBase})
+		payload = protowire.AppendTag(payload, 2, protowire.VarintType)
+		payload = protowire.AppendVarint(payload, 7)
+
+		r.handleMessage(&peermanagement.InboundMessage{
+			PeerID:  11,
+			Type:    message.TypeGetLedger,
+			Payload: payload,
+		})
+		bd, sent := rs.snapshot()
+		require.Len(t, bd, 1, "an unknown optional enum is absent after proto2 parsing")
+		assert.Equal(t, "get-ledger-invalid-request", bd[0].reason)
+		assert.Empty(t, sent, "an absent ltype must not serve anything")
+	})
+
+	t.Run("absent ltype with hash skips ltype validation", func(t *testing.T) {
 		_, bd, sent := send(t, &message.GetLedger{
 			InfoType:   message.LedgerInfoBase,
 			LedgerHash: bytes.Repeat([]byte{0xAB}, 32),
-			LType:      message.LedgerType(7),
 		})
-		require.Len(t, bd, 1, "an ltype outside [ltACCEPTED, ltCLOSED] is malformed")
-		assert.Equal(t, "get-ledger-invalid-ltype", bd[0].reason)
-		assert.Empty(t, sent, "malformed ltype must not serve anything")
+		assert.Empty(t, bd)
+		assert.Empty(t, sent)
+	})
+
+	t.Run("explicit ltACCEPTED with hash is valid", func(t *testing.T) {
+		_, bd, sent := send(t, &message.GetLedger{
+			InfoType:   message.LedgerInfoBase,
+			LTypeSet:   true,
+			LedgerHash: bytes.Repeat([]byte{0xAB}, 32),
+		})
+		assert.Empty(t, bd)
+		assert.Empty(t, sent)
 	})
 
 	t.Run("ltCLOSED serves the closed ledger", func(t *testing.T) {

--- a/internal/consensus/adaptor/router_ledger_serve_ltype_test.go
+++ b/internal/consensus/adaptor/router_ledger_serve_ltype_test.go
@@ -107,4 +107,14 @@ func TestRouter_GetLedger_HashSeqlessGatesOnLtype(t *testing.T) {
 		assert.Equal(t, l.Sequence(), ld.LedgerSeq, "served seq must be the closed ledger's")
 		assert.Equal(t, hash[:], ld.LedgerHash, "served hash must be the closed ledger's")
 	})
+
+	t.Run("explicit empty hash is invalid and does not serve the closed ledger", func(t *testing.T) {
+		_, bd, sent := send(t, &message.GetLedger{
+			InfoType:   message.LedgerInfoBase,
+			LType:      message.LedgerTypeClosed,
+			LedgerHash: []byte{},
+		})
+		require.Equal(t, []badDataCall{{peerID: 11, reason: "get-ledger-invalid-hash"}}, bd)
+		assert.Empty(t, sent)
+	})
 }

--- a/internal/consensus/adaptor/router_querytype_test.go
+++ b/internal/consensus/adaptor/router_querytype_test.go
@@ -12,9 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// querytypeRecorder records both IncPeerBadData and SendToPeer so the
-// query_type validation tests. badDataCall and sentFrame are shared with the
-// other router tests in this package.
 type querytypeRecorder struct {
 	recordingSender
 	qmu     sync.Mutex

--- a/internal/consensus/adaptor/router_querytype_test.go
+++ b/internal/consensus/adaptor/router_querytype_test.go
@@ -13,10 +13,8 @@ import (
 )
 
 // querytypeRecorder records both IncPeerBadData and SendToPeer so the
-// query_type validation test can assert that a present-but-invalid query_type
-// charges the peer and serves nothing, while a valid (qtINDIRECT) or absent
-// one serves normally. badDataCall and sentFrame are shared with the other
-// router tests in this package.
+// query_type validation tests. badDataCall and sentFrame are shared with the
+// other router tests in this package.
 type querytypeRecorder struct {
 	recordingSender
 	qmu     sync.Mutex
@@ -59,42 +57,39 @@ func makeRouterWithQueryTypeRecorder(t *testing.T) (*Router, *querytypeRecorder)
 	return r, rs
 }
 
-// TestRouter_GetLedger_QueryTypeValidation pins rippled's
-// onMessage(TMGetLedger) query_type rule: qtINDIRECT is the only valid value.
-// A present-but-different value is invalid data — charge the peer and drop the
-// request without disconnecting; an absent or qtINDIRECT value is served. The
-// tx-set is served via a cached liTS_CANDIDATE request because that path is
-// exempt from load-shedding, so the positive cases are deterministic.
+// TestRouter_GetLedger_QueryTypeValidation pins proto2 closed-enum behavior:
+// unknown wire values become unknown fields, so rippled observes query_type as
+// absent. The tx-set path is exempt from load-shedding, keeping the cases
+// deterministic.
 func TestRouter_GetLedger_QueryTypeValidation(t *testing.T) {
 	blobs := [][]byte{
 		bytes.Repeat([]byte{0x11}, 16),
 		bytes.Repeat([]byte{0x55}, 16),
 	}
 
-	t.Run("invalid query_type charges peer and serves nothing", func(t *testing.T) {
+	t.Run("unknown query_type is treated as absent", func(t *testing.T) {
 		r, rs := makeRouterWithQueryTypeRecorder(t)
 		ts, err := r.adaptor.BuildTxSet(blobs)
 		require.NoError(t, err)
 		id := ts.ID()
 
-		invalid := message.LedgerQueryType(7)
 		req := &message.GetLedger{
 			InfoType:   message.LedgerInfoTsCandidate,
 			LedgerHash: id[:],
 			NodeIDs:    [][]byte{rootNodeID()},
-			QueryType:  &invalid,
 		}
+		payload := encodePayload(t, req)
+		payload = append(payload, 0x38, 0x07)
 		r.handleMessage(&peermanagement.InboundMessage{
 			PeerID:  42,
 			Type:    message.TypeGetLedger,
-			Payload: encodePayload(t, req),
+			Payload: payload,
 		})
 
 		bd, sent := rs.snapshot()
-		require.Len(t, bd, 1, "invalid query_type must charge bad data exactly once")
-		assert.Equal(t, uint64(42), bd[0].peerID)
-		assert.Equal(t, "get-ledger-bad-querytype", bd[0].reason)
-		assert.Empty(t, sent, "invalid query_type must not serve a response")
+		assert.Empty(t, bd)
+		require.Len(t, sent, 1)
+		assert.Equal(t, uint64(42), sent[0].peerID)
 	})
 
 	t.Run("qtINDIRECT serves normally", func(t *testing.T) {

--- a/internal/consensus/adaptor/router_relay_test.go
+++ b/internal/consensus/adaptor/router_relay_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 // relayRecorder records SendToPeer / NotePeerHasTxSet
@@ -343,28 +344,12 @@ func TestRouter_LedgerData_ValidatesBeforeCookieRelay(t *testing.T) {
 			reason: "ledger-data-hash",
 		},
 		{
-			name: "info type",
-			data: &message.LedgerData{
-				LedgerHash: validHash, InfoType: message.LedgerInfoType(99),
-				Nodes: []message.LedgerNode{{NodeData: []byte{1}}},
-			},
-			reason: "ledger-data-type",
-		},
-		{
 			name: "candidate sequence",
 			data: &message.LedgerData{
 				LedgerHash: validHash, LedgerSeq: 1, InfoType: message.LedgerInfoTsCandidate,
 				Nodes: []message.LedgerNode{{NodeData: []byte{1}}},
 			},
 			reason: "ledger-data-sequence",
-		},
-		{
-			name: "reply error",
-			data: &message.LedgerData{
-				LedgerHash: validHash, InfoType: message.LedgerInfoBase, Error: message.ReplyError(99),
-				Nodes: []message.LedgerNode{{NodeData: []byte{1}}},
-			},
-			reason: "ledger-data-error",
 		},
 		{
 			name: "node count",
@@ -407,6 +392,22 @@ func TestRouter_LedgerData_ValidatesBeforeCookieRelay(t *testing.T) {
 		},
 	}
 
+	t.Run("unknown required info type", func(t *testing.T) {
+		payload := append([]byte{0x0a, 0x20}, validHash...)
+		payload = append(payload, 0x10, 0x00, 0x18, 0x63, 0x28, 0x4d)
+		_, err := message.Decode(message.TypeLedgerData, payload)
+		require.Error(t, err)
+
+		r, rs := makeRouterWithRelayRecorder(t)
+		r.handleMessage(&peermanagement.InboundMessage{
+			PeerID:  5,
+			Type:    message.TypeLedgerData,
+			Payload: payload,
+		})
+		assert.Empty(t, rs.sentFrames())
+		assert.Equal(t, []badDataCall{{peerID: 5, reason: "ledger-data-decode"}}, rs.badDataCalls())
+	})
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r, rs := makeRouterWithRelayRecorder(t)
@@ -422,6 +423,33 @@ func TestRouter_LedgerData_ValidatesBeforeCookieRelay(t *testing.T) {
 			assert.Equal(t, []badDataCall{{peerID: 5, reason: tt.reason}}, rs.badDataCalls())
 		})
 	}
+}
+
+func TestRouter_LedgerData_RawZeroErrorNormalizesToAbsent(t *testing.T) {
+	r, rs := makeRouterWithRelayRecorder(t)
+	data := &message.LedgerData{
+		LedgerHash:       bytes.Repeat([]byte{0xEE}, 32),
+		InfoType:         message.LedgerInfoBase,
+		Nodes:            []message.LedgerNode{{NodeData: []byte{1}}},
+		RequestCookie:    77,
+		RequestCookieSet: true,
+	}
+	payload := encodePayload(t, data)
+	payload = protowire.AppendTag(payload, 6, protowire.VarintType)
+	payload = protowire.AppendVarint(payload, 0)
+	decoded, err := message.Decode(message.TypeLedgerData, payload)
+	require.NoError(t, err)
+	require.False(t, decoded.(*message.LedgerData).HasError())
+
+	r.handleMessage(&peermanagement.InboundMessage{
+		PeerID:  5,
+		Type:    message.TypeLedgerData,
+		Payload: payload,
+	})
+
+	assert.Empty(t, rs.badDataCalls())
+	require.Len(t, rs.sentFrames(), 1)
+	assert.Equal(t, uint64(77), rs.sentFrames()[0].peerID)
 }
 
 // TestRouter_HaveSet_RecordsTxSetAdvertisement pins that an inbound

--- a/internal/consensus/adaptor/router_serve.go
+++ b/internal/consensus/adaptor/router_serve.go
@@ -45,12 +45,12 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 		r.serve.IncPeerBadData(uint64(msg.PeerID), "get-ledger-invalid-itype")
 		return
 	}
-	if req.InfoType == message.LedgerInfoTsCandidate && len(req.LedgerHash) == 0 {
+	if req.InfoType == message.LedgerInfoTsCandidate && !req.HasLedgerHash() {
 		r.serve.IncPeerBadData(uint64(msg.PeerID), "get-ledger-missing-txset-hash")
 		return
 	}
 	if req.InfoType != message.LedgerInfoTsCandidate &&
-		len(req.LedgerHash) == 0 && !req.HasLedgerSeq() &&
+		!req.HasLedgerHash() && !req.HasLedgerSeq() &&
 		(!req.HasLType() || req.LType != message.LedgerTypeClosed) {
 		r.serve.IncPeerBadData(uint64(msg.PeerID), "get-ledger-invalid-request")
 		return
@@ -59,7 +59,7 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 		r.serve.IncPeerBadData(uint64(msg.PeerID), "get-ledger-invalid-ltype")
 		return
 	}
-	if len(req.LedgerHash) != 0 && len(req.LedgerHash) != 32 {
+	if req.HasLedgerHash() && len(req.LedgerHash) != 32 {
 		r.serve.IncPeerBadData(uint64(msg.PeerID), "get-ledger-invalid-hash")
 		return
 	}
@@ -133,7 +133,7 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 	}
 
 	var l *ledger.Ledger
-	if len(req.LedgerHash) == 32 {
+	if req.HasLedgerHash() {
 		var hash [32]byte
 		copy(hash[:], req.LedgerHash)
 		l, err = svc.GetLedgerByHash(hash)

--- a/internal/consensus/adaptor/router_serve.go
+++ b/internal/consensus/adaptor/router_serve.go
@@ -50,11 +50,12 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 		return
 	}
 	if req.InfoType != message.LedgerInfoTsCandidate &&
-		len(req.LedgerHash) == 0 && !req.HasLedgerSeq() && req.LType != message.LedgerTypeClosed {
+		len(req.LedgerHash) == 0 && !req.HasLedgerSeq() &&
+		(!req.HasLType() || req.LType != message.LedgerTypeClosed) {
 		r.serve.IncPeerBadData(uint64(msg.PeerID), "get-ledger-invalid-request")
 		return
 	}
-	if req.LType < message.LedgerTypeAccepted || req.LType > message.LedgerTypeClosed {
+	if req.HasLType() && (req.LType < message.LedgerTypeAccepted || req.LType > message.LedgerTypeClosed) {
 		r.serve.IncPeerBadData(uint64(msg.PeerID), "get-ledger-invalid-ltype")
 		return
 	}
@@ -141,7 +142,7 @@ func (r *Router) handleGetLedger(msg *peermanagement.InboundMessage) {
 			return
 		}
 		l, err = svc.GetLedgerBySequence(req.LedgerSeq)
-	} else if req.LType == message.LedgerTypeClosed {
+	} else if req.HasLType() && req.LType == message.LedgerTypeClosed {
 		l = svc.GetClosedLedger()
 	}
 	if err != nil || l == nil {

--- a/internal/consensus/adaptor/suppression_hash_test.go
+++ b/internal/consensus/adaptor/suppression_hash_test.go
@@ -169,8 +169,8 @@ func TestSuppression_ProposalSemanticIdentity_SameHash(t *testing.T) {
 		NodePubKey:     set.NodePubKey,
 		CloseTime:      pb.Uint32(set.CloseTime),
 		Signature:      set.Signature,
-		PreviousLedger: set.PreviousLedger,
-		Hops:           7,
+		Previousledger: set.PreviousLedger,
+		Hops:           pb.Uint32(7),
 	}
 	payloadB, err := pb.Marshal(protoB)
 	require.NoError(t, err)
@@ -249,7 +249,7 @@ func TestSuppression_ValidationInnerBlobDomain_SameHash(t *testing.T) {
 	// so both envelopes round-trip to an identical inner blob.
 	envelopeB, err := pb.Marshal(&proto.TMValidation{
 		Validation: blob,
-		Hops:       3,
+		Hops:       pb.Uint32(3),
 	})
 	require.NoError(t, err)
 

--- a/internal/ledger/inbound/replay_delta.go
+++ b/internal/ledger/inbound/replay_delta.go
@@ -550,7 +550,7 @@ func (r *ReplayDelta) verifyAndBuild(resp *message.ReplayDeltaResponse) error {
 	if resp == nil {
 		return errors.New("nil response")
 	}
-	if resp.Error != message.ReplyErrorNone {
+	if resp.HasError() {
 		return fmt.Errorf("peer signaled error: %d", resp.Error)
 	}
 	if len(resp.LedgerHeader) == 0 {

--- a/internal/ledger/inbound/replay_delta_test.go
+++ b/internal/ledger/inbound/replay_delta_test.go
@@ -240,18 +240,30 @@ func TestInboundReplayDelta_MalformedTxBlob(t *testing.T) {
 // TestInboundReplayDelta_ResponseError verifies that a peer-signaled
 // error response is rejected without further parsing.
 func TestInboundReplayDelta_ResponseError(t *testing.T) {
-	t.Parallel()
-	parent := makeGenesisLedger(t)
-	resp := &message.ReplayDeltaResponse{
-		LedgerHash: make([]byte, 32),
-		Error:      message.ReplyErrorNoLedger,
+	tests := []struct {
+		name  string
+		error message.ReplyError
+	}{
+		{name: "explicit zero"},
+		{name: "nonzero", error: message.ReplyErrorNoLedger},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			parent := makeGenesisLedger(t)
+			resp := &message.ReplayDeltaResponse{
+				LedgerHash: make([]byte, 32),
+				Error:      tt.error,
+				ErrorSet:   true,
+			}
 
-	rd := NewReplayDelta([32]byte{}, 42, parent, nil)
-	err := rd.GotResponse(resp)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "peer signaled error")
-	assert.Equal(t, StateFailed, rd.State())
+			rd := NewReplayDelta([32]byte{}, 42, parent, nil)
+			err := rd.GotResponse(resp)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "peer signaled error")
+			assert.Equal(t, StateFailed, rd.State())
+		})
+	}
 }
 
 // TestInboundReplayDelta_EmptyHeader verifies that a response missing

--- a/internal/peermanagement/fetchpack_test.go
+++ b/internal/peermanagement/fetchpack_test.go
@@ -194,6 +194,24 @@ func TestServeFetchPack_BadHashCharged(t *testing.T) {
 	assert.NotZero(t, peer.BadDataCount(), "a malformed fetch-pack hash must be charged")
 }
 
+func TestHandleGetObjects_ExplicitEmptyGenericLedgerHashCharged(t *testing.T) {
+	o, peer := newFetchPackTestOverlay(t, &fakeFetchPackProvider{})
+	payload, err := message.Encode(&message.GetObjectByHash{
+		ObjType:    message.ObjectTypeLedger,
+		Query:      true,
+		LedgerHash: []byte{},
+	})
+	require.NoError(t, err)
+
+	o.onMessageReceived(Event{
+		PeerID:      peer.ID(),
+		MessageType: message.TypeGetObjects,
+		Payload:     payload,
+	})
+
+	assert.NotZero(t, peer.BadDataCount())
+}
+
 // TestHandleGetObjects_FetchPackReplyForwardedToRouter: a query=false
 // fetch-pack reply is forwarded to the overlay→router channel for consumption.
 func TestHandleGetObjects_FetchPackReplyForwardedToRouter(t *testing.T) {

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -297,7 +297,7 @@ func (o *Overlay) handleGetObjectsMessage(evt Event) {
 		// Generic node-store object fetch by hash. Mirrors rippled's
 		// fetchNodeObject loop at PeerImp.cpp:2483-2538. Offloaded to the
 		// serve-worker pool — up to N node-store fetches per request.
-		if len(gob.LedgerHash) != 0 && len(gob.LedgerHash) != 32 {
+		if gob.HasLedgerHash() && len(gob.LedgerHash) != 32 {
 			o.IncPeerBadData(evt.PeerID, "get-objects-ledgerhash")
 			return
 		}

--- a/internal/peermanagement/message/manifests.go
+++ b/internal/peermanagement/message/manifests.go
@@ -1,6 +1,10 @@
 package message
 
-import "google.golang.org/protobuf/encoding/protowire"
+import (
+	"errors"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
 
 // WalkManifests validates a TMManifests payload before visiting its entries.
 // The returned byte slices alias payload and are only valid during the call.
@@ -59,6 +63,7 @@ func validateManifests(payload []byte, visitEntries bool, visit func([]byte)) (i
 
 func manifestSTObject(payload []byte) ([]byte, error) {
 	var stObject []byte
+	found := false
 	for len(payload) > 0 {
 		num, typ, tagLen := protowire.ConsumeTag(payload)
 		if tagLen < 0 {
@@ -72,6 +77,7 @@ func manifestSTObject(payload []byte) ([]byte, error) {
 				return nil, protowire.ParseError(valueLen)
 			}
 			stObject = value
+			found = true
 			payload = payload[valueLen:]
 			continue
 		}
@@ -81,6 +87,9 @@ func manifestSTObject(payload []byte) ([]byte, error) {
 			return nil, protowire.ParseError(valueLen)
 		}
 		payload = payload[valueLen:]
+	}
+	if !found {
+		return nil, errors.New("TMManifest: missing required stobject")
 	}
 	return stObject, nil
 }

--- a/internal/peermanagement/message/manifests_test.go
+++ b/internal/peermanagement/message/manifests_test.go
@@ -22,6 +22,20 @@ func TestWalkManifestsValidatesBeforeVisiting(t *testing.T) {
 	require.Zero(t, visits)
 }
 
+func TestWalkManifestsRejectsMissingRequiredSTObjectBeforeVisiting(t *testing.T) {
+	validEntry := protowire.AppendTag(nil, 1, protowire.BytesType)
+	validEntry = protowire.AppendBytes(validEntry, []byte("manifest"))
+	payload := protowire.AppendTag(nil, 1, protowire.BytesType)
+	payload = protowire.AppendBytes(payload, validEntry)
+	payload = protowire.AppendTag(payload, 1, protowire.BytesType)
+	payload = protowire.AppendBytes(payload, nil)
+
+	visits := 0
+	_, err := WalkManifests(payload, func([]byte) { visits++ })
+	require.ErrorContains(t, err, "missing required stobject")
+	require.Zero(t, visits)
+}
+
 func TestWalkManifestsVisitsAliasedEntriesInOrder(t *testing.T) {
 	var payload []byte
 	for _, wire := range [][]byte{[]byte("first"), []byte("second")} {

--- a/internal/peermanagement/message/messages.go
+++ b/internal/peermanagement/message/messages.go
@@ -63,16 +63,36 @@ func (t *Transactions) Type() MessageType { return TypeTransactions }
 // StatusChange represents a node status change.
 type StatusChange struct {
 	NewStatus          NodeStatus `json:"new_status,omitempty"`
+	NewStatusSet       bool       `json:"-"`
 	NewEvent           NodeEvent  `json:"new_event,omitempty"`
+	NewEventSet        bool       `json:"-"`
 	LedgerSeq          uint32     `json:"ledger_seq,omitempty"`
+	LedgerSeqSet       bool       `json:"-"`
 	LedgerHash         []byte     `json:"ledger_hash,omitempty"`
 	LedgerHashPrevious []byte     `json:"ledger_hash_previous,omitempty"`
 	NetworkTime        uint64     `json:"network_time,omitempty"`
+	NetworkTimeSet     bool       `json:"-"`
 	FirstSeq           *uint32    `json:"first_seq,omitempty"`
 	LastSeq            *uint32    `json:"last_seq,omitempty"`
 }
 
 func (s *StatusChange) Type() MessageType { return TypeStatusChange }
+
+func (s *StatusChange) HasNewStatus() bool {
+	return s != nil && (s.NewStatusSet || s.NewStatus != 0)
+}
+
+func (s *StatusChange) HasNewEvent() bool {
+	return s != nil && (s.NewEventSet || s.NewEvent != 0)
+}
+
+func (s *StatusChange) HasLedgerSeq() bool {
+	return s != nil && (s.LedgerSeqSet || s.LedgerSeq != 0)
+}
+
+func (s *StatusChange) HasNetworkTime() bool {
+	return s != nil && (s.NetworkTimeSet || s.NetworkTime != 0)
+}
 
 // ProposeSet represents a ledger proposal.
 type ProposeSet struct {
@@ -178,6 +198,7 @@ type LedgerNode struct {
 type GetLedger struct {
 	InfoType         LedgerInfoType   `json:"itype"`
 	LType            LedgerType       `json:"ltype,omitempty"`
+	LTypeSet         bool             `json:"-"`
 	LedgerHash       []byte           `json:"ledger_hash,omitempty"`
 	LedgerSeq        uint32           `json:"ledger_seq,omitempty"`
 	LedgerSeqSet     bool             `json:"-"`
@@ -190,6 +211,10 @@ type GetLedger struct {
 }
 
 func (g *GetLedger) Type() MessageType { return TypeGetLedger }
+
+func (g *GetLedger) HasLType() bool {
+	return g != nil && (g.LTypeSet || g.LType != 0)
+}
 
 // HasLedgerSeq reports protobuf field presence, including an explicit zero.
 func (g *GetLedger) HasLedgerSeq() bool {
@@ -215,6 +240,7 @@ type LedgerData struct {
 	RequestCookie    uint32         `json:"request_cookie,omitempty"`
 	RequestCookieSet bool           `json:"-"`
 	Error            ReplyError     `json:"error,omitempty"`
+	ErrorSet         bool           `json:"-"`
 }
 
 func (l *LedgerData) Type() MessageType { return TypeLedgerData }
@@ -224,15 +250,34 @@ func (l *LedgerData) HasRequestCookie() bool {
 	return l != nil && (l.RequestCookieSet || l.RequestCookie != 0)
 }
 
+func (l *LedgerData) HasError() bool {
+	return l != nil && (l.ErrorSet || l.Error != ReplyErrorNone)
+}
+
 // Ping represents a ping/pong message for keepalive and latency measurement.
 type Ping struct {
-	PType    PingType `json:"type"`
-	Seq      uint32   `json:"seq,omitempty"`
-	PingTime uint64   `json:"ping_time,omitempty"`
-	NetTime  uint64   `json:"net_time,omitempty"`
+	PType       PingType `json:"type"`
+	Seq         uint32   `json:"seq,omitempty"`
+	SeqSet      bool     `json:"-"`
+	PingTime    uint64   `json:"ping_time,omitempty"`
+	PingTimeSet bool     `json:"-"`
+	NetTime     uint64   `json:"net_time,omitempty"`
+	NetTimeSet  bool     `json:"-"`
 }
 
 func (p *Ping) Type() MessageType { return TypePing }
+
+func (p *Ping) HasSeq() bool {
+	return p != nil && (p.SeqSet || p.Seq != 0)
+}
+
+func (p *Ping) HasPingTime() bool {
+	return p != nil && (p.PingTimeSet || p.PingTime != 0)
+}
+
+func (p *Ping) HasNetTime() bool {
+	return p != nil && (p.NetTimeSet || p.NetTime != 0)
+}
 
 // Squelch represents a squelch message for reduce-relay.
 type Squelch struct {
@@ -260,9 +305,14 @@ type ProofPathResponse struct {
 	LedgerHeader []byte        `json:"ledger_header,omitempty"`
 	Path         [][]byte      `json:"path,omitempty"`
 	Error        ReplyError    `json:"error,omitempty"`
+	ErrorSet     bool          `json:"-"`
 }
 
 func (p *ProofPathResponse) Type() MessageType { return TypeProofPathResponse }
+
+func (p *ProofPathResponse) HasError() bool {
+	return p != nil && (p.ErrorSet || p.Error != ReplyErrorNone)
+}
 
 // ReplayDeltaRequest requests replay delta.
 type ReplayDeltaRequest struct {
@@ -277,9 +327,14 @@ type ReplayDeltaResponse struct {
 	LedgerHeader []byte     `json:"ledger_header,omitempty"`
 	Transactions [][]byte   `json:"transaction,omitempty"`
 	Error        ReplyError `json:"error,omitempty"`
+	ErrorSet     bool       `json:"-"`
 }
 
 func (r *ReplayDeltaResponse) Type() MessageType { return TypeReplayDeltaResponse }
+
+func (r *ReplayDeltaResponse) HasError() bool {
+	return r != nil && (r.ErrorSet || r.Error != ReplyErrorNone)
+}
 
 // HaveTransactions indicates available transaction hashes.
 type HaveTransactions struct {

--- a/internal/peermanagement/message/messages.go
+++ b/internal/peermanagement/message/messages.go
@@ -94,6 +94,10 @@ func (s *StatusChange) HasNetworkTime() bool {
 	return s != nil && (s.NetworkTimeSet || s.NetworkTime != 0)
 }
 
+func (s *StatusChange) HasLedgerHash() bool {
+	return s != nil && s.LedgerHash != nil
+}
+
 // ProposeSet represents a ledger proposal.
 type ProposeSet struct {
 	ProposeSeq          uint32   `json:"propose_seq"`
@@ -131,6 +135,10 @@ type ValidatorBlobInfo struct {
 	Manifest  []byte `json:"manifest,omitempty"`
 	Blob      []byte `json:"blob"`
 	Signature []byte `json:"signature"`
+}
+
+func (v *ValidatorBlobInfo) HasManifest() bool {
+	return v != nil && v.Manifest != nil
 }
 
 // ValidatorListCollection represents a collection of v2 validator lists.
@@ -188,6 +196,10 @@ type GetObjectByHash struct {
 
 func (g *GetObjectByHash) Type() MessageType { return TypeGetObjects }
 
+func (g *GetObjectByHash) HasLedgerHash() bool {
+	return g != nil && g.LedgerHash != nil
+}
+
 // LedgerNode represents a node in the ledger.
 type LedgerNode struct {
 	NodeData []byte `json:"nodedata"`
@@ -214,6 +226,10 @@ func (g *GetLedger) Type() MessageType { return TypeGetLedger }
 
 func (g *GetLedger) HasLType() bool {
 	return g != nil && (g.LTypeSet || g.LType != 0)
+}
+
+func (g *GetLedger) HasLedgerHash() bool {
+	return g != nil && g.LedgerHash != nil
 }
 
 // HasLedgerSeq reports protobuf field presence, including an explicit zero.

--- a/internal/peermanagement/message/serialize_proto.go
+++ b/internal/peermanagement/message/serialize_proto.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/proto"
+	"google.golang.org/protobuf/encoding/protowire"
 	pb "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // msgCodec bundles the three operations every message type needs:
@@ -27,6 +29,108 @@ func assertMessage[T Message](msg Message) (T, error) {
 	return m, nil
 }
 
+func requiredBytes(value []byte) []byte {
+	if value == nil {
+		return []byte{}
+	}
+	return value
+}
+
+func validateEnums(message protoreflect.Message, normalizeOptional bool) error {
+	fields := message.Descriptor().Fields()
+	for i := 0; i < fields.Len(); i++ {
+		field := fields.Get(i)
+		if field.Kind() == protoreflect.EnumKind && message.Has(field) {
+			value := message.Get(field).Enum()
+			if field.Enum().Values().ByNumber(value) == nil {
+				if field.Cardinality() == protoreflect.Required {
+					return fmt.Errorf("invalid required enum %s: %d", field.FullName(), value)
+				}
+				if !normalizeOptional {
+					return fmt.Errorf("invalid optional enum %s: %d", field.FullName(), value)
+				}
+				message.Clear(field)
+			}
+		}
+
+		if field.Kind() != protoreflect.MessageKind && field.Kind() != protoreflect.GroupKind {
+			continue
+		}
+		if field.Cardinality() == protoreflect.Repeated {
+			list := message.Get(field).List()
+			for j := 0; j < list.Len(); j++ {
+				if err := validateEnums(list.Get(j).Message(), normalizeOptional); err != nil {
+					return err
+				}
+			}
+		} else if message.Has(field) {
+			if err := validateEnums(message.Get(field).Message(), normalizeOptional); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func normalizeEnumWire(data []byte, descriptor protoreflect.MessageDescriptor) ([]byte, error) {
+	var normalized []byte
+	for offset := 0; offset < len(data); {
+		fieldStart := offset
+		number, wireType, tagLen := protowire.ConsumeTag(data[offset:])
+		if tagLen < 0 {
+			return nil, protowire.ParseError(tagLen)
+		}
+		offset += tagLen
+
+		valueLen := protowire.ConsumeFieldValue(number, wireType, data[offset:])
+		if valueLen < 0 {
+			return nil, protowire.ParseError(valueLen)
+		}
+		fieldEnd := offset + valueLen
+		field := descriptor.Fields().ByNumber(number)
+
+		drop := false
+		var nested []byte
+		nestedChanged := false
+		if field != nil && field.Kind() == protoreflect.EnumKind && wireType == protowire.VarintType {
+			value, n := protowire.ConsumeVarint(data[offset:])
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			drop = field.Enum().Values().ByNumber(protoreflect.EnumNumber(value)) == nil
+		} else if field != nil && field.Kind() == protoreflect.MessageKind && wireType == protowire.BytesType {
+			value, n := protowire.ConsumeBytes(data[offset:])
+			if n < 0 {
+				return nil, protowire.ParseError(n)
+			}
+			var err error
+			nested, err = normalizeEnumWire(value, field.Message())
+			if err != nil {
+				return nil, err
+			}
+			nestedChanged = len(nested) != len(value)
+		}
+
+		if drop || nestedChanged {
+			if normalized == nil {
+				normalized = make([]byte, 0, len(data))
+				normalized = append(normalized, data[:fieldStart]...)
+			}
+			if nestedChanged {
+				normalized = append(normalized, data[fieldStart:offset]...)
+				normalized = protowire.AppendBytes(normalized, nested)
+			}
+		} else if normalized != nil {
+			normalized = append(normalized, data[fieldStart:fieldEnd]...)
+		}
+		offset = fieldEnd
+	}
+	if normalized == nil {
+		return data, nil
+	}
+	return normalized, nil
+}
+
 // codecs is the per-MessageType registry. Order in this map carries
 // no semantics — keep it sorted by MessageType constant order for
 // reviewer sanity.
@@ -40,9 +144,13 @@ var codecs = map[MessageType]msgCodec{
 			}
 			list := make([]*proto.TMManifest, len(m.List))
 			for i, manifest := range m.List {
-				list[i] = &proto.TMManifest{Stobject: manifest.STObject}
+				list[i] = &proto.TMManifest{Stobject: requiredBytes(manifest.STObject)}
 			}
-			return &proto.TMManifests{List: list, History: m.History}, nil
+			out := &proto.TMManifests{List: list}
+			if m.History {
+				out.History = pb.Bool(true)
+			}
+			return out, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
 			p := pmsg.(*proto.TMManifests)
@@ -50,7 +158,7 @@ var codecs = map[MessageType]msgCodec{
 			for i, m := range p.List {
 				list[i] = Manifest{STObject: m.Stobject}
 			}
-			return &Manifests{List: list, History: p.History}, nil
+			return &Manifests{List: list, History: p.GetHistory()}, nil
 		},
 	},
 	TypePing: {
@@ -60,21 +168,29 @@ var codecs = map[MessageType]msgCodec{
 			if err != nil {
 				return nil, err
 			}
-			pingType := proto.TMPing_PingType(m.PType)
-			return &proto.TMPing{
-				Type:     &pingType,
-				Seq:      &m.Seq,
-				PingTime: &m.PingTime,
-				NetTime:  &m.NetTime,
-			}, nil
+			pingType := proto.TMPingPingType(m.PType)
+			out := &proto.TMPing{Type: &pingType}
+			if m.HasSeq() {
+				out.Seq = pb.Uint32(m.Seq)
+			}
+			if m.HasPingTime() {
+				out.PingTime = pb.Uint64(m.PingTime)
+			}
+			if m.HasNetTime() {
+				out.NetTime = pb.Uint64(m.NetTime)
+			}
+			return out, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
 			p := pmsg.(*proto.TMPing)
 			return &Ping{
-				PType:    PingType(p.GetType()),
-				Seq:      p.GetSeq(),
-				PingTime: p.GetPingTime(),
-				NetTime:  p.GetNetTime(),
+				PType:       PingType(p.GetType()),
+				Seq:         p.GetSeq(),
+				SeqSet:      p.Seq != nil,
+				PingTime:    p.GetPingTime(),
+				PingTimeSet: p.PingTime != nil,
+				NetTime:     p.GetNetTime(),
+				NetTimeSet:  p.NetTime != nil,
 			}, nil
 		},
 	},
@@ -87,21 +203,29 @@ var codecs = map[MessageType]msgCodec{
 			}
 			nodes := make([]*proto.TMClusterNode, len(m.ClusterNodes))
 			for i, n := range m.ClusterNodes {
-				nodes[i] = &proto.TMClusterNode{
+				node := &proto.TMClusterNode{
 					PublicKey:  pb.String(n.PublicKey),
 					ReportTime: pb.Uint32(n.ReportTime),
 					NodeLoad:   pb.Uint32(n.NodeLoad),
-					NodeName:   n.NodeName,
-					Address:    n.Address,
 				}
+				if n.NodeName != "" {
+					node.NodeName = pb.String(n.NodeName)
+				}
+				if n.Address != "" {
+					node.Address = pb.String(n.Address)
+				}
+				nodes[i] = node
 			}
 			sources := make([]*proto.TMLoadSource, len(m.LoadSources))
 			for i, s := range m.LoadSources {
-				sources[i] = &proto.TMLoadSource{
-					Name:  pb.String(s.Name),
-					Cost:  pb.Uint32(s.Cost),
-					Count: s.Count,
+				source := &proto.TMLoadSource{
+					Name: pb.String(s.Name),
+					Cost: pb.Uint32(s.Cost),
 				}
+				if s.Count != 0 {
+					source.Count = pb.Uint32(s.Count)
+				}
+				sources[i] = source
 			}
 			return &proto.TMCluster{ClusterNodes: nodes, LoadSources: sources}, nil
 		},
@@ -164,12 +288,17 @@ var codecs = map[MessageType]msgCodec{
 				return nil, err
 			}
 			txStatus := proto.TransactionStatus(m.Status)
-			return &proto.TMTransaction{
-				RawTransaction:   m.RawTransaction,
-				Status:           &txStatus,
-				ReceiveTimestamp: m.ReceiveTimestamp,
-				Deferred:         m.Deferred,
-			}, nil
+			out := &proto.TMTransaction{
+				RawTransaction: requiredBytes(m.RawTransaction),
+				Status:         &txStatus,
+			}
+			if m.ReceiveTimestamp != 0 {
+				out.ReceiveTimestamp = pb.Uint64(m.ReceiveTimestamp)
+			}
+			if m.Deferred {
+				out.Deferred = pb.Bool(true)
+			}
+			return out, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
 			p := pmsg.(*proto.TMTransaction)
@@ -189,12 +318,14 @@ var codecs = map[MessageType]msgCodec{
 				return nil, err
 			}
 			itype := proto.TMLedgerInfoType(m.InfoType)
-			ltype := proto.TMLedgerType(m.LType)
 			out := &proto.TMGetLedger{
 				Itype:      &itype,
-				Ltype:      &ltype,
 				LedgerHash: m.LedgerHash,
-				NodeIds:    m.NodeIDs,
+				NodeIDs:    m.NodeIDs,
+			}
+			if m.HasLType() {
+				ltype := proto.TMLedgerType(m.LType)
+				out.Ltype = &ltype
 			}
 			if m.HasLedgerSeq() {
 				out.LedgerSeq = pb.Uint32(m.LedgerSeq)
@@ -216,10 +347,11 @@ var codecs = map[MessageType]msgCodec{
 			g := &GetLedger{
 				InfoType:         LedgerInfoType(p.GetItype()),
 				LType:            LedgerType(p.GetLtype()),
+				LTypeSet:         p.Ltype != nil,
 				LedgerHash:       p.GetLedgerHash(),
 				LedgerSeq:        p.GetLedgerSeq(),
 				LedgerSeqSet:     p.LedgerSeq != nil,
-				NodeIDs:          p.GetNodeIds(),
+				NodeIDs:          p.GetNodeIDs(),
 				RequestCookie:    p.GetRequestCookie(),
 				RequestCookieSet: p.RequestCookie != nil,
 				QueryDepth:       p.GetQueryDepth(),
@@ -242,20 +374,23 @@ var codecs = map[MessageType]msgCodec{
 			nodes := make([]*proto.TMLedgerNode, len(m.Nodes))
 			for i, n := range m.Nodes {
 				nodes[i] = &proto.TMLedgerNode{
-					Nodedata: n.NodeData,
+					Nodedata: requiredBytes(n.NodeData),
 					Nodeid:   n.NodeID,
 				}
 			}
 			ledgerInfoType := proto.TMLedgerInfoType(m.InfoType)
 			out := &proto.TMLedgerData{
-				LedgerHash: m.LedgerHash,
+				LedgerHash: requiredBytes(m.LedgerHash),
 				LedgerSeq:  pb.Uint32(m.LedgerSeq),
 				Type:       &ledgerInfoType,
 				Nodes:      nodes,
-				Error:      proto.TMReplyError(m.Error),
 			}
 			if m.HasRequestCookie() {
 				out.RequestCookie = pb.Uint32(m.RequestCookie)
+			}
+			if m.HasError() {
+				replyError := proto.TMReplyError(m.Error)
+				out.Error = &replyError
 			}
 			return out, nil
 		},
@@ -268,15 +403,19 @@ var codecs = map[MessageType]msgCodec{
 					NodeID:   n.GetNodeid(),
 				}
 			}
-			return &LedgerData{
+			out := &LedgerData{
 				LedgerHash:       p.GetLedgerHash(),
 				LedgerSeq:        p.GetLedgerSeq(),
 				InfoType:         LedgerInfoType(p.GetType()),
 				Nodes:            nodes,
 				RequestCookie:    p.GetRequestCookie(),
 				RequestCookieSet: p.RequestCookie != nil,
-				Error:            ReplyError(p.GetError()),
-			}, nil
+				ErrorSet:         p.Error != nil,
+			}
+			if p.Error != nil {
+				out.Error = ReplyError(*p.Error)
+			}
+			return out, nil
 		},
 	},
 	TypeProposeLedger: {
@@ -288,11 +427,11 @@ var codecs = map[MessageType]msgCodec{
 			}
 			return &proto.TMProposeSet{
 				ProposeSeq:          pb.Uint32(m.ProposeSeq),
-				CurrentTxHash:       m.CurrentTxHash,
-				NodePubKey:          m.NodePubKey,
+				CurrentTxHash:       requiredBytes(m.CurrentTxHash),
+				NodePubKey:          requiredBytes(m.NodePubKey),
 				CloseTime:           pb.Uint32(m.CloseTime),
-				Signature:           m.Signature,
-				PreviousLedger:      m.PreviousLedger,
+				Signature:           requiredBytes(m.Signature),
+				Previousledger:      requiredBytes(m.PreviousLedger),
 				AddedTransactions:   m.AddedTransactions,
 				RemovedTransactions: m.RemovedTransactions,
 			}, nil
@@ -305,7 +444,7 @@ var codecs = map[MessageType]msgCodec{
 				NodePubKey:          p.GetNodePubKey(),
 				CloseTime:           p.GetCloseTime(),
 				Signature:           p.GetSignature(),
-				PreviousLedger:      p.GetPreviousLedger(),
+				PreviousLedger:      p.GetPreviousledger(),
 				AddedTransactions:   p.GetAddedTransactions(),
 				RemovedTransactions: p.GetRemovedTransactions(),
 			}, nil
@@ -318,29 +457,49 @@ var codecs = map[MessageType]msgCodec{
 			if err != nil {
 				return nil, err
 			}
-			return &proto.TMStatusChange{
-				NewStatus:          proto.NodeStatus(m.NewStatus),
-				NewEvent:           proto.NodeEvent(m.NewEvent),
-				LedgerSeq:          m.LedgerSeq,
+			out := &proto.TMStatusChange{
 				LedgerHash:         m.LedgerHash,
 				LedgerHashPrevious: m.LedgerHashPrevious,
-				NetworkTime:        m.NetworkTime,
 				FirstSeq:           m.FirstSeq,
 				LastSeq:            m.LastSeq,
-			}, nil
+			}
+			if m.HasNewStatus() {
+				status := proto.NodeStatus(m.NewStatus)
+				out.NewStatus = &status
+			}
+			if m.HasNewEvent() {
+				event := proto.NodeEvent(m.NewEvent)
+				out.NewEvent = &event
+			}
+			if m.HasLedgerSeq() {
+				out.LedgerSeq = pb.Uint32(m.LedgerSeq)
+			}
+			if m.HasNetworkTime() {
+				out.NetworkTime = pb.Uint64(m.NetworkTime)
+			}
+			return out, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
 			p := pmsg.(*proto.TMStatusChange)
-			return &StatusChange{
-				NewStatus:          NodeStatus(p.GetNewStatus()),
-				NewEvent:           NodeEvent(p.GetNewEvent()),
+			out := &StatusChange{
+				NewStatusSet:       p.NewStatus != nil,
+				NewEventSet:        p.NewEvent != nil,
 				LedgerSeq:          p.GetLedgerSeq(),
+				LedgerSeqSet:       p.LedgerSeq != nil,
 				LedgerHash:         p.GetLedgerHash(),
 				LedgerHashPrevious: p.GetLedgerHashPrevious(),
 				NetworkTime:        p.GetNetworkTime(),
+				NetworkTimeSet:     p.NetworkTime != nil,
 				FirstSeq:           p.FirstSeq,
 				LastSeq:            p.LastSeq,
-			}, nil
+			}
+			if p.NewStatus != nil {
+				out.NewStatus = NodeStatus(*p.NewStatus)
+			}
+			if p.NewEvent != nil {
+				out.NewEvent = NodeEvent(*p.NewEvent)
+			}
+			return out, nil
 		},
 	},
 	TypeHaveSet: {
@@ -353,7 +512,7 @@ var codecs = map[MessageType]msgCodec{
 			txSetStatus := proto.TxSetStatus(m.Status)
 			return &proto.TMHaveTransactionSet{
 				Status: &txSetStatus,
-				Hash:   m.Hash,
+				Hash:   requiredBytes(m.Hash),
 			}, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
@@ -371,7 +530,7 @@ var codecs = map[MessageType]msgCodec{
 			if err != nil {
 				return nil, err
 			}
-			return &proto.TMValidation{Validation: m.Validation}, nil
+			return &proto.TMValidation{Validation: requiredBytes(m.Validation)}, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
 			p := pmsg.(*proto.TMValidation)
@@ -388,21 +547,26 @@ var codecs = map[MessageType]msgCodec{
 			objects := make([]*proto.TMIndexedObject, len(m.Objects))
 			for i, o := range m.Objects {
 				objects[i] = &proto.TMIndexedObject{
-					Hash:      o.Hash,
-					NodeId:    o.NodeID,
-					Index:     o.Index,
-					Data:      o.Data,
-					LedgerSeq: o.LedgerSeq,
+					Hash:   o.Hash,
+					NodeID: o.NodeID,
+					Index:  o.Index,
+					Data:   o.Data,
+				}
+				if o.LedgerSeq != 0 {
+					objects[i].LedgerSeq = pb.Uint32(o.LedgerSeq)
 				}
 			}
-			objType := proto.ObjectType(m.ObjType)
-			return &proto.TMGetObjectByHash{
+			objType := proto.TMGetObjectByHash_ObjectType(m.ObjType)
+			out := &proto.TMGetObjectByHash{
 				Type:       &objType,
 				Query:      pb.Bool(m.Query),
 				LedgerHash: m.LedgerHash,
-				Fat:        m.Fat,
 				Objects:    objects,
-			}, nil
+			}
+			if m.Fat {
+				out.Fat = pb.Bool(true)
+			}
+			return out, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
 			p := pmsg.(*proto.TMGetObjectByHash)
@@ -410,7 +574,7 @@ var codecs = map[MessageType]msgCodec{
 			for i, o := range p.Objects {
 				objects[i] = IndexedObject{
 					Hash:      o.GetHash(),
-					NodeID:    o.GetNodeId(),
+					NodeID:    o.GetNodeID(),
 					Index:     o.GetIndex(),
 					Data:      o.GetData(),
 					LedgerSeq: o.GetLedgerSeq(),
@@ -433,9 +597,9 @@ var codecs = map[MessageType]msgCodec{
 				return nil, err
 			}
 			return &proto.TMValidatorList{
-				Manifest:  m.Manifest,
-				Blob:      m.Blob,
-				Signature: m.Signature,
+				Manifest:  requiredBytes(m.Manifest),
+				Blob:      requiredBytes(m.Blob),
+				Signature: requiredBytes(m.Signature),
 				Version:   pb.Uint32(m.Version),
 			}, nil
 		},
@@ -456,11 +620,14 @@ var codecs = map[MessageType]msgCodec{
 			if err != nil {
 				return nil, err
 			}
-			return &proto.TMSquelch{
+			out := &proto.TMSquelch{
 				Squelch:         pb.Bool(m.Squelch),
-				ValidatorPubKey: m.ValidatorPubKey,
-				SquelchDuration: m.SquelchDuration,
-			}, nil
+				ValidatorPubKey: requiredBytes(m.ValidatorPubKey),
+			}
+			if m.SquelchDuration != 0 {
+				out.SquelchDuration = pb.Uint32(m.SquelchDuration)
+			}
+			return out, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
 			p := pmsg.(*proto.TMSquelch)
@@ -482,13 +649,13 @@ var codecs = map[MessageType]msgCodec{
 			for i, b := range m.Blobs {
 				blobs[i] = &proto.ValidatorBlobInfo{
 					Manifest:  b.Manifest,
-					Blob:      b.Blob,
-					Signature: b.Signature,
+					Blob:      requiredBytes(b.Blob),
+					Signature: requiredBytes(b.Signature),
 				}
 			}
 			return &proto.TMValidatorListCollection{
 				Version:  pb.Uint32(m.Version),
-				Manifest: m.Manifest,
+				Manifest: requiredBytes(m.Manifest),
 				Blobs:    blobs,
 			}, nil
 		},
@@ -518,8 +685,8 @@ var codecs = map[MessageType]msgCodec{
 			}
 			mapType := proto.TMLedgerMapType(m.MapType)
 			return &proto.TMProofPathRequest{
-				Key:        m.Key,
-				LedgerHash: m.LedgerHash,
+				Key:        requiredBytes(m.Key),
+				LedgerHash: requiredBytes(m.LedgerHash),
 				Type:       &mapType,
 			}, nil
 		},
@@ -540,25 +707,33 @@ var codecs = map[MessageType]msgCodec{
 				return nil, err
 			}
 			mapType := proto.TMLedgerMapType(m.MapType)
-			return &proto.TMProofPathResponse{
-				Key:          m.Key,
-				LedgerHash:   m.LedgerHash,
+			out := &proto.TMProofPathResponse{
+				Key:          requiredBytes(m.Key),
+				LedgerHash:   requiredBytes(m.LedgerHash),
 				Type:         &mapType,
 				LedgerHeader: m.LedgerHeader,
 				Path:         m.Path,
-				Error:        proto.TMReplyError(m.Error),
-			}, nil
+			}
+			if m.HasError() {
+				replyError := proto.TMReplyError(m.Error)
+				out.Error = &replyError
+			}
+			return out, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
 			p := pmsg.(*proto.TMProofPathResponse)
-			return &ProofPathResponse{
+			out := &ProofPathResponse{
 				Key:          p.GetKey(),
 				LedgerHash:   p.GetLedgerHash(),
 				MapType:      LedgerMapType(p.GetType()),
 				LedgerHeader: p.GetLedgerHeader(),
 				Path:         p.GetPath(),
-				Error:        ReplyError(p.GetError()),
-			}, nil
+				ErrorSet:     p.Error != nil,
+			}
+			if p.Error != nil {
+				out.Error = ReplyError(*p.Error)
+			}
+			return out, nil
 		},
 	},
 	TypeReplayDeltaReq: {
@@ -568,7 +743,7 @@ var codecs = map[MessageType]msgCodec{
 			if err != nil {
 				return nil, err
 			}
-			return &proto.TMReplayDeltaRequest{LedgerHash: m.LedgerHash}, nil
+			return &proto.TMReplayDeltaRequest{LedgerHash: requiredBytes(m.LedgerHash)}, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
 			p := pmsg.(*proto.TMReplayDeltaRequest)
@@ -582,21 +757,29 @@ var codecs = map[MessageType]msgCodec{
 			if err != nil {
 				return nil, err
 			}
-			return &proto.TMReplayDeltaResponse{
-				LedgerHash:   m.LedgerHash,
+			out := &proto.TMReplayDeltaResponse{
+				LedgerHash:   requiredBytes(m.LedgerHash),
 				LedgerHeader: m.LedgerHeader,
 				Transaction:  m.Transactions,
-				Error:        proto.TMReplyError(m.Error),
-			}, nil
+			}
+			if m.HasError() {
+				replyError := proto.TMReplyError(m.Error)
+				out.Error = &replyError
+			}
+			return out, nil
 		},
 		decode: func(pmsg pb.Message) (Message, error) {
 			p := pmsg.(*proto.TMReplayDeltaResponse)
-			return &ReplayDeltaResponse{
+			out := &ReplayDeltaResponse{
 				LedgerHash:   p.GetLedgerHash(),
 				LedgerHeader: p.GetLedgerHeader(),
 				Transactions: p.GetTransaction(),
-				Error:        ReplyError(p.GetError()),
-			}, nil
+				ErrorSet:     p.Error != nil,
+			}
+			if p.Error != nil {
+				out.Error = ReplyError(*p.Error)
+			}
+			return out, nil
 		},
 	},
 	TypeHaveTransactions: {
@@ -624,10 +807,14 @@ var codecs = map[MessageType]msgCodec{
 			for i, tx := range m.Transactions {
 				txStatus := proto.TransactionStatus(tx.Status)
 				txs[i] = &proto.TMTransaction{
-					RawTransaction:   tx.RawTransaction,
-					Status:           &txStatus,
-					ReceiveTimestamp: tx.ReceiveTimestamp,
-					Deferred:         tx.Deferred,
+					RawTransaction: requiredBytes(tx.RawTransaction),
+					Status:         &txStatus,
+				}
+				if tx.ReceiveTimestamp != 0 {
+					txs[i].ReceiveTimestamp = pb.Uint64(tx.ReceiveTimestamp)
+				}
+				if tx.Deferred {
+					txs[i].Deferred = pb.Bool(true)
 				}
 			}
 			return &proto.TMTransactions{Transactions: txs}, nil
@@ -658,6 +845,9 @@ func Encode(msg Message) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := validateEnums(pmsg.ProtoReflect(), false); err != nil {
+		return nil, err
+	}
 	return pb.Marshal(pmsg)
 }
 
@@ -668,8 +858,15 @@ func Decode(msgType MessageType, data []byte) (Message, error) {
 		return nil, fmt.Errorf("unknown message type: %d", msgType)
 	}
 	pmsg := c.newProto()
-	if err := pb.Unmarshal(data, pmsg); err != nil {
+	normalized, err := normalizeEnumWire(data, pmsg.ProtoReflect().Descriptor())
+	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal: %w", err)
+	}
+	if err := pb.Unmarshal(normalized, pmsg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal: %w", err)
+	}
+	if err := validateEnums(pmsg.ProtoReflect(), true); err != nil {
+		return nil, fmt.Errorf("failed to validate: %w", err)
 	}
 	return c.decode(pmsg)
 }

--- a/internal/peermanagement/message/serialize_test.go
+++ b/internal/peermanagement/message/serialize_test.go
@@ -3,7 +3,10 @@ package message
 import (
 	"bytes"
 	"reflect"
+	"strings"
 	"testing"
+
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 func TestPingRoundtrip(t *testing.T) {
@@ -341,10 +344,6 @@ func TestGetLedgerQueryDepthPresence(t *testing.T) {
 	}
 }
 
-// TestGetLedgerQueryTypePresence pins that query_type presence survives the
-// wire round-trip: an absent field decodes to nil (so the serve path treats
-// it as "accept"), while a present non-qtINDIRECT value is preserved as a
-// distinct non-nil value the serve path can reject.
 func TestGetLedgerQueryTypePresence(t *testing.T) {
 	t.Run("absent stays nil", func(t *testing.T) {
 		encoded, err := Encode(&GetLedger{InfoType: LedgerInfoBase})
@@ -360,9 +359,9 @@ func TestGetLedgerQueryTypePresence(t *testing.T) {
 		}
 	})
 
-	t.Run("present non-indirect preserved", func(t *testing.T) {
-		invalid := LedgerQueryType(7)
-		encoded, err := Encode(&GetLedger{InfoType: LedgerInfoBase, QueryType: &invalid})
+	t.Run("explicit indirect stays present", func(t *testing.T) {
+		value := QueryTypeIndirect
+		encoded, err := Encode(&GetLedger{InfoType: LedgerInfoBase, QueryType: &value})
 		if err != nil {
 			t.Fatalf("Encode error: %v", err)
 		}
@@ -370,12 +369,85 @@ func TestGetLedgerQueryTypePresence(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Decode error: %v", err)
 		}
-		qt := decoded.(*GetLedger).QueryType
-		if qt == nil {
-			t.Fatal("QueryType = nil, want present")
+		if qt := decoded.(*GetLedger).QueryType; qt == nil || *qt != value {
+			t.Fatalf("QueryType = %v, want present qtINDIRECT", qt)
 		}
-		if *qt != invalid {
-			t.Errorf("QueryType = %d, want %d", *qt, invalid)
+	})
+
+	t.Run("unknown wire value becomes absent", func(t *testing.T) {
+		wire := []byte{0x08, 0x00, 0x38, 0x07}
+		decoded, err := Decode(TypeGetLedger, wire)
+		if err != nil {
+			t.Fatalf("Decode error: %v", err)
+		}
+		if qt := decoded.(*GetLedger).QueryType; qt != nil {
+			t.Fatalf("QueryType = %d, want nil", *qt)
+		}
+	})
+
+	t.Run("unknown outbound value is rejected", func(t *testing.T) {
+		invalid := LedgerQueryType(7)
+		if _, err := Encode(&GetLedger{InfoType: LedgerInfoBase, QueryType: &invalid}); err == nil {
+			t.Fatal("Encode accepted an unknown optional enum")
+		}
+	})
+
+	for _, test := range []struct {
+		name string
+		wire []byte
+	}{
+		{name: "valid then unknown", wire: []byte{0x08, 0x00, 0x38, 0x00, 0x38, 0x07}},
+		{name: "unknown then valid", wire: []byte{0x08, 0x00, 0x38, 0x07, 0x38, 0x00}},
+	} {
+		t.Run(test.name+" preserves optional valid enum", func(t *testing.T) {
+			decoded, err := Decode(TypeGetLedger, test.wire)
+			if err != nil {
+				t.Fatal(err)
+			}
+			queryType := decoded.(*GetLedger).QueryType
+			if queryType == nil || *queryType != QueryTypeIndirect {
+				t.Fatalf("QueryType = %v, want present qtINDIRECT", queryType)
+			}
+		})
+	}
+}
+
+func TestDuplicateRequiredEnumKeepsLastRecognizedValue(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		wire []byte
+	}{
+		{name: "valid then unknown", wire: []byte{0x08, 0x00, 0x08, 0x07}},
+		{name: "unknown then valid", wire: []byte{0x08, 0x07, 0x08, 0x00}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			decoded, err := Decode(TypePing, test.wire)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := decoded.(*Ping).PType; got != PingTypePing {
+				t.Fatalf("PType = %d, want ptPING", got)
+			}
+		})
+	}
+
+	t.Run("nested valid then unknown", func(t *testing.T) {
+		transaction := protowire.AppendTag(nil, 1, protowire.BytesType)
+		transaction = protowire.AppendBytes(transaction, nil)
+		transaction = protowire.AppendTag(transaction, 2, protowire.VarintType)
+		transaction = protowire.AppendVarint(transaction, uint64(TxStatusNew))
+		transaction = protowire.AppendTag(transaction, 2, protowire.VarintType)
+		transaction = protowire.AppendVarint(transaction, 99)
+		wire := protowire.AppendTag(nil, 1, protowire.BytesType)
+		wire = protowire.AppendBytes(wire, transaction)
+
+		decoded, err := Decode(TypeTransactions, wire)
+		if err != nil {
+			t.Fatal(err)
+		}
+		transactions := decoded.(*Transactions).Transactions
+		if len(transactions) != 1 || transactions[0].Status != TxStatusNew {
+			t.Fatalf("Transactions = %+v, want one tsNEW", transactions)
 		}
 	})
 }
@@ -415,6 +487,16 @@ func TestGetLedgerZeroValuePresence(t *testing.T) {
 		}
 		if got.LedgerSeq != 0 || got.RequestCookie != 0 {
 			t.Fatalf("explicit zero values changed: seq=%d cookie=%d", got.LedgerSeq, got.RequestCookie)
+		}
+	})
+
+	t.Run("unknown ltype wire value becomes absent", func(t *testing.T) {
+		decoded, err := Decode(TypeGetLedger, []byte{0x08, 0x00, 0x10, 0x07})
+		if err != nil {
+			t.Fatalf("Decode error: %v", err)
+		}
+		if got := decoded.(*GetLedger); got.HasLType() {
+			t.Fatalf("LType = %d, want absent", got.LType)
 		}
 	})
 }
@@ -585,7 +667,7 @@ func TestGenericEncodeDecode(t *testing.T) {
 		&Manifests{History: true},
 		&Endpoints{Version: 2},
 		&StatusChange{NewStatus: NodeStatusConnected},
-		&Transaction{RawTransaction: []byte{1, 2, 3}},
+		&Transaction{RawTransaction: []byte{1, 2, 3}, Status: TxStatusNew},
 		&Validation{Validation: []byte{4, 5, 6}},
 		&Squelch{Squelch: true, ValidatorPubKey: []byte{7, 8, 9}},
 	}
@@ -625,5 +707,269 @@ func TestEncodeUnknownType(t *testing.T) {
 	_, err := Encode(&unknownMsg{})
 	if err == nil {
 		t.Error("Expected error for unknown message type")
+	}
+}
+
+func TestDecodeRejectsMissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		msgType MessageType
+		wire    []byte
+	}{
+		{name: "top level", msgType: TypePing},
+		{name: "nested", msgType: TypeManifests, wire: []byte{0x0a, 0x00}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := Decode(test.msgType, test.wire); err == nil {
+				t.Fatal("expected missing required field error")
+			}
+		})
+	}
+}
+
+func TestDecodeRejectsUnknownRequiredEnums(t *testing.T) {
+	transaction := []byte{0x0a, 0x01, 0x01, 0x10, 0x63}
+	tests := []struct {
+		name    string
+		msgType MessageType
+		wire    []byte
+	}{
+		{name: "top level", msgType: TypeTransaction, wire: transaction},
+		{name: "nested", msgType: TypeTransactions, wire: append([]byte{0x0a, byte(len(transaction))}, transaction...)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := Decode(test.msgType, test.wire); err == nil {
+				t.Fatal("expected unknown required enum error")
+			} else if !strings.Contains(err.Error(), "required field") {
+				t.Fatalf("error = %q, want required-field validation", err)
+			}
+		})
+	}
+}
+
+func TestEncodeRejectsUnknownRequiredEnums(t *testing.T) {
+	tests := []Message{
+		&Transaction{Status: TransactionStatus(99)},
+		&Transactions{Transactions: []Transaction{{Status: TransactionStatus(99)}}},
+	}
+	for _, message := range tests {
+		if _, err := Encode(message); err == nil {
+			t.Fatalf("Encode(%T) accepted an unknown required enum", message)
+		} else if !strings.Contains(err.Error(), "invalid required enum") {
+			t.Fatalf("Encode(%T) error = %q, want required enum validation", message, err)
+		}
+	}
+}
+
+func TestRequiredZeroValuesEncode(t *testing.T) {
+	tests := []struct {
+		name    string
+		message Message
+		wire    []byte
+	}{
+		{name: "enum and bool", message: &GetObjectByHash{}, wire: []byte{0x08, 0x00, 0x10, 0x00}},
+		{name: "empty bytes", message: &Validation{}, wire: []byte{0x0a, 0x00}},
+		{name: "nested empty bytes", message: &Manifests{List: []Manifest{{}}}, wire: []byte{0x0a, 0x02, 0x0a, 0x00}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			wire, err := Encode(test.message)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(wire, test.wire) {
+				t.Fatalf("wire = %x, want %x", wire, test.wire)
+			}
+		})
+	}
+}
+
+func TestGetLedgerLTypePresence(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *GetLedger
+		present bool
+	}{
+		{name: "absent", request: &GetLedger{InfoType: LedgerInfoBase}},
+		{name: "explicit zero", request: &GetLedger{InfoType: LedgerInfoBase, LTypeSet: true}, present: true},
+		{name: "nonzero", request: &GetLedger{InfoType: LedgerInfoBase, LType: LedgerTypeClosed}, present: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			wire, err := Encode(test.request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			decoded, err := Decode(TypeGetLedger, wire)
+			if err != nil {
+				t.Fatal(err)
+			}
+			request := decoded.(*GetLedger)
+			if request.HasLType() != test.present || request.LTypeSet != test.present {
+				t.Fatalf("ltype presence = %v/%v, want %v", request.HasLType(), request.LTypeSet, test.present)
+			}
+			if request.LType != test.request.LType {
+				t.Fatalf("ltype = %d, want %d", request.LType, test.request.LType)
+			}
+		})
+	}
+}
+
+func TestPingOptionalScalarPresence(t *testing.T) {
+	tests := []struct {
+		name string
+		ping *Ping
+		set  bool
+	}{
+		{name: "absent", ping: &Ping{PType: PingTypePing}},
+		{name: "explicit zero", ping: &Ping{PType: PingTypePing, SeqSet: true, PingTimeSet: true, NetTimeSet: true}, set: true},
+		{name: "nonzero", ping: &Ping{PType: PingTypePong, Seq: 1, PingTime: 2, NetTime: 3}, set: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			wire, err := Encode(test.ping)
+			if err != nil {
+				t.Fatal(err)
+			}
+			decoded, err := Decode(TypePing, wire)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ping := decoded.(*Ping)
+			if ping.SeqSet != test.set || ping.PingTimeSet != test.set || ping.NetTimeSet != test.set {
+				t.Fatalf("scalar presence = %v/%v/%v, want %v", ping.SeqSet, ping.PingTimeSet, ping.NetTimeSet, test.set)
+			}
+		})
+	}
+}
+
+func TestStatusChangeOptionalScalarPresence(t *testing.T) {
+	tests := []struct {
+		name   string
+		status *StatusChange
+		set    bool
+	}{
+		{name: "absent", status: &StatusChange{}},
+		{name: "explicit zero", status: &StatusChange{LedgerSeqSet: true, NetworkTimeSet: true}, set: true},
+		{name: "nonzero", status: &StatusChange{NewStatus: NodeStatusConnected, NewEvent: NodeEventAcceptedLedger, LedgerSeq: 1, NetworkTime: 2}, set: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			wire, err := Encode(test.status)
+			if err != nil {
+				t.Fatal(err)
+			}
+			decoded, err := Decode(TypeStatusChange, wire)
+			if err != nil {
+				t.Fatal(err)
+			}
+			status := decoded.(*StatusChange)
+			wantEnums := test.status.NewStatus != 0
+			if status.NewStatusSet != wantEnums || status.NewEventSet != wantEnums || status.LedgerSeqSet != test.set || status.NetworkTimeSet != test.set {
+				t.Fatalf("presence = %v/%v/%v/%v, want enums=%v scalars=%v", status.NewStatusSet, status.NewEventSet, status.LedgerSeqSet, status.NetworkTimeSet, wantEnums, test.set)
+			}
+			if status.NewStatus != test.status.NewStatus || status.NewEvent != test.status.NewEvent {
+				t.Fatalf("status/event = %d/%d, want %d/%d", status.NewStatus, status.NewEvent, test.status.NewStatus, test.status.NewEvent)
+			}
+		})
+	}
+
+	t.Run("unknown enum wire values become absent", func(t *testing.T) {
+		decoded, err := Decode(TypeStatusChange, []byte{0x08, 0x00, 0x10, 0x00})
+		if err != nil {
+			t.Fatal(err)
+		}
+		status := decoded.(*StatusChange)
+		if status.NewStatusSet || status.NewEventSet {
+			t.Fatalf("unknown enum presence retained: status=%v event=%v", status.NewStatusSet, status.NewEventSet)
+		}
+	})
+}
+
+func TestReplyErrorPresence(t *testing.T) {
+	tests := []struct {
+		name    string
+		message Message
+		msgType MessageType
+	}{
+		{name: "ledger data absent", message: &LedgerData{}, msgType: TypeLedgerData},
+		{name: "ledger data present", message: &LedgerData{Error: ReplyErrorNoLedger}, msgType: TypeLedgerData},
+		{name: "proof path absent", message: &ProofPathResponse{MapType: LedgerMapTransaction}, msgType: TypeProofPathResponse},
+		{name: "proof path present", message: &ProofPathResponse{MapType: LedgerMapTransaction, Error: ReplyErrorNoNode}, msgType: TypeProofPathResponse},
+		{name: "replay delta absent", message: &ReplayDeltaResponse{}, msgType: TypeReplayDeltaResponse},
+		{name: "replay delta present", message: &ReplayDeltaResponse{Error: ReplyErrorBadRequest}, msgType: TypeReplayDeltaResponse},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			wire, err := Encode(test.message)
+			if err != nil {
+				t.Fatal(err)
+			}
+			decoded, err := Decode(test.msgType, wire)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var set bool
+			switch message := decoded.(type) {
+			case *LedgerData:
+				set = message.ErrorSet
+			case *ProofPathResponse:
+				set = message.ErrorSet
+			case *ReplayDeltaResponse:
+				set = message.ErrorSet
+			}
+			wantSet := strings.Contains(test.name, "present")
+			if set != wantSet {
+				t.Fatalf("error presence = %v, want %v", set, wantSet)
+			}
+		})
+	}
+
+	for _, message := range []Message{
+		&LedgerData{ErrorSet: true},
+		&ProofPathResponse{MapType: LedgerMapTransaction, ErrorSet: true},
+		&ReplayDeltaResponse{ErrorSet: true},
+	} {
+		if _, err := Encode(message); err == nil {
+			t.Fatalf("Encode(%T) accepted an unknown optional enum", message)
+		}
+	}
+
+	for _, test := range []struct {
+		name    string
+		message Message
+		msgType MessageType
+		field   protowire.Number
+	}{
+		{name: "ledger data", message: &LedgerData{}, msgType: TypeLedgerData, field: 6},
+		{name: "proof path", message: &ProofPathResponse{MapType: LedgerMapTransaction}, msgType: TypeProofPathResponse, field: 6},
+		{name: "replay delta", message: &ReplayDeltaResponse{}, msgType: TypeReplayDeltaResponse, field: 4},
+	} {
+		t.Run(test.name+" unknown wire value becomes absent", func(t *testing.T) {
+			wire, err := Encode(test.message)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wire = protowire.AppendTag(wire, test.field, protowire.VarintType)
+			wire = protowire.AppendVarint(wire, 0)
+			decoded, err := Decode(test.msgType, wire)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var set bool
+			switch message := decoded.(type) {
+			case *LedgerData:
+				set = message.HasError()
+			case *ProofPathResponse:
+				set = message.HasError()
+			case *ReplayDeltaResponse:
+				set = message.HasError()
+			}
+			if set {
+				t.Fatal("unknown optional enum remained present")
+			}
+		})
 	}
 }

--- a/internal/peermanagement/message/serialize_test.go
+++ b/internal/peermanagement/message/serialize_test.go
@@ -501,6 +501,84 @@ func TestGetLedgerZeroValuePresence(t *testing.T) {
 	})
 }
 
+func TestOptionalBytesPresence(t *testing.T) {
+	t.Run("get ledger hash", func(t *testing.T) {
+		for _, test := range []struct {
+			name    string
+			hash    []byte
+			present bool
+		}{
+			{name: "absent"},
+			{name: "explicit empty", hash: []byte{}, present: true},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				wire, err := Encode(&GetLedger{InfoType: LedgerInfoBase, LedgerHash: test.hash})
+				if err != nil {
+					t.Fatal(err)
+				}
+				decoded, err := Decode(TypeGetLedger, wire)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got := decoded.(*GetLedger).HasLedgerHash(); got != test.present {
+					t.Fatalf("HasLedgerHash = %v, want %v", got, test.present)
+				}
+			})
+		}
+	})
+
+	t.Run("get objects hash", func(t *testing.T) {
+		wire, err := Encode(&GetObjectByHash{LedgerHash: []byte{}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		decoded, err := Decode(TypeGetObjects, wire)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !decoded.(*GetObjectByHash).HasLedgerHash() {
+			t.Fatal("explicit empty ledger hash became absent")
+		}
+	})
+
+	t.Run("status ledger hash", func(t *testing.T) {
+		wire, err := Encode(&StatusChange{LedgerHash: []byte{}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		decoded, err := Decode(TypeStatusChange, wire)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !decoded.(*StatusChange).HasLedgerHash() {
+			t.Fatal("explicit empty ledger hash became absent")
+		}
+	})
+
+	t.Run("validator blob manifest", func(t *testing.T) {
+		wire, err := Encode(&ValidatorListCollection{
+			Version:  2,
+			Manifest: []byte{1},
+			Blobs: []ValidatorBlobInfo{{
+				Manifest:  []byte{},
+				Blob:      []byte{1},
+				Signature: []byte{1},
+			}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		decoded, err := Decode(TypeValidatorListCollection, wire)
+		if err != nil {
+			t.Fatal(err)
+		}
+		blobs := decoded.(*ValidatorListCollection).Blobs
+		if len(blobs) != 1 || !blobs[0].HasManifest() {
+			t.Fatalf("explicit empty nested manifest lost: %+v", blobs)
+		}
+	})
+}
+
 func TestLedgerDataRoundtrip(t *testing.T) {
 	original := &LedgerData{
 		LedgerHash: bytes.Repeat([]byte{0xAA}, 32),

--- a/internal/peermanagement/message/types.go
+++ b/internal/peermanagement/message/types.go
@@ -3,137 +3,97 @@
 // protocol buffer format and wire protocol.
 package message
 
+import "github.com/LeJamon/go-xrpl/internal/peermanagement/proto"
+
 // MessageType represents the type of a peer protocol message.
 // Reference: rippled ripple.proto MessageType enum
 type MessageType uint16
 
 const (
 	TypeUnknown                 MessageType = 0
-	TypeManifests               MessageType = 2
-	TypePing                    MessageType = 3
-	TypeCluster                 MessageType = 5
-	TypeEndpoints               MessageType = 15
-	TypeTransaction             MessageType = 30
-	TypeGetLedger               MessageType = 31
-	TypeLedgerData              MessageType = 32
-	TypeProposeLedger           MessageType = 33
-	TypeStatusChange            MessageType = 34
-	TypeHaveSet                 MessageType = 35
-	TypeValidation              MessageType = 41
-	TypeGetObjects              MessageType = 42
-	TypeValidatorList           MessageType = 54
-	TypeSquelch                 MessageType = 55
-	TypeValidatorListCollection MessageType = 56
-	TypeProofPathReq            MessageType = 57
-	TypeProofPathResponse       MessageType = 58
-	TypeReplayDeltaReq          MessageType = 59
-	TypeReplayDeltaResponse     MessageType = 60
-	TypeHaveTransactions        MessageType = 63
-	TypeTransactions            MessageType = 64
+	TypeManifests               MessageType = MessageType(proto.MessageType_mtMANIFESTS)
+	TypePing                    MessageType = MessageType(proto.MessageType_mtPING)
+	TypeCluster                 MessageType = MessageType(proto.MessageType_mtCLUSTER)
+	TypeEndpoints               MessageType = MessageType(proto.MessageType_mtENDPOINTS)
+	TypeTransaction             MessageType = MessageType(proto.MessageType_mtTRANSACTION)
+	TypeGetLedger               MessageType = MessageType(proto.MessageType_mtGET_LEDGER)
+	TypeLedgerData              MessageType = MessageType(proto.MessageType_mtLEDGER_DATA)
+	TypeProposeLedger           MessageType = MessageType(proto.MessageType_mtPROPOSE_LEDGER)
+	TypeStatusChange            MessageType = MessageType(proto.MessageType_mtSTATUS_CHANGE)
+	TypeHaveSet                 MessageType = MessageType(proto.MessageType_mtHAVE_SET)
+	TypeValidation              MessageType = MessageType(proto.MessageType_mtVALIDATION)
+	TypeGetObjects              MessageType = MessageType(proto.MessageType_mtGET_OBJECTS)
+	TypeValidatorList           MessageType = MessageType(proto.MessageType_mtVALIDATOR_LIST)
+	TypeSquelch                 MessageType = MessageType(proto.MessageType_mtSQUELCH)
+	TypeValidatorListCollection MessageType = MessageType(proto.MessageType_mtVALIDATOR_LIST_COLLECTION)
+	TypeProofPathReq            MessageType = MessageType(proto.MessageType_mtPROOF_PATH_REQ)
+	TypeProofPathResponse       MessageType = MessageType(proto.MessageType_mtPROOF_PATH_RESPONSE)
+	TypeReplayDeltaReq          MessageType = MessageType(proto.MessageType_mtREPLAY_DELTA_REQ)
+	TypeReplayDeltaResponse     MessageType = MessageType(proto.MessageType_mtREPLAY_DELTA_RESPONSE)
+	TypeHaveTransactions        MessageType = MessageType(proto.MessageType_mtHAVE_TRANSACTIONS)
+	TypeTransactions            MessageType = MessageType(proto.MessageType_mtTRANSACTIONS)
 )
 
 // String returns the string representation of a MessageType.
 func (t MessageType) String() string {
-	switch t {
-	case TypeManifests:
-		return "mtMANIFESTS"
-	case TypePing:
-		return "mtPING"
-	case TypeCluster:
-		return "mtCLUSTER"
-	case TypeEndpoints:
-		return "mtENDPOINTS"
-	case TypeTransaction:
-		return "mtTRANSACTION"
-	case TypeGetLedger:
-		return "mtGET_LEDGER"
-	case TypeLedgerData:
-		return "mtLEDGER_DATA"
-	case TypeProposeLedger:
-		return "mtPROPOSE_LEDGER"
-	case TypeStatusChange:
-		return "mtSTATUS_CHANGE"
-	case TypeHaveSet:
-		return "mtHAVE_SET"
-	case TypeValidation:
-		return "mtVALIDATION"
-	case TypeGetObjects:
-		return "mtGET_OBJECTS"
-	case TypeValidatorList:
-		return "mtVALIDATORLIST"
-	case TypeSquelch:
-		return "mtSQUELCH"
-	case TypeValidatorListCollection:
-		return "mtVALIDATORLISTCOLLECTION"
-	case TypeProofPathReq:
-		return "mtPROOF_PATH_REQ"
-	case TypeProofPathResponse:
-		return "mtPROOF_PATH_RESPONSE"
-	case TypeReplayDeltaReq:
-		return "mtREPLAY_DELTA_REQ"
-	case TypeReplayDeltaResponse:
-		return "mtREPLAY_DELTA_RESPONSE"
-	case TypeHaveTransactions:
-		return "mtHAVE_TRANSACTIONS"
-	case TypeTransactions:
-		return "mtTRANSACTIONS"
-	default:
-		return "mtUNKNOWN"
+	if name, ok := proto.MessageType_name[int32(t)]; ok {
+		return name
 	}
+	return "mtUNKNOWN"
 }
 
 // TransactionStatus represents the status of a transaction.
 type TransactionStatus int32
 
 const (
-	TxStatusNew            TransactionStatus = 1
-	TxStatusCurrent        TransactionStatus = 2
-	TxStatusCommitted      TransactionStatus = 3
-	TxStatusRejectConflict TransactionStatus = 4
-	TxStatusRejectInvalid  TransactionStatus = 5
-	TxStatusRejectFunds    TransactionStatus = 6
-	TxStatusHeldSeq        TransactionStatus = 7
-	TxStatusHeldLedger     TransactionStatus = 8
+	TxStatusNew            TransactionStatus = TransactionStatus(proto.TransactionStatus_tsNEW)
+	TxStatusCurrent        TransactionStatus = TransactionStatus(proto.TransactionStatus_tsCURRENT)
+	TxStatusCommitted      TransactionStatus = TransactionStatus(proto.TransactionStatus_tsCOMMITTED)
+	TxStatusRejectConflict TransactionStatus = TransactionStatus(proto.TransactionStatus_tsREJECT_CONFLICT)
+	TxStatusRejectInvalid  TransactionStatus = TransactionStatus(proto.TransactionStatus_tsREJECT_INVALID)
+	TxStatusRejectFunds    TransactionStatus = TransactionStatus(proto.TransactionStatus_tsREJECT_FUNDS)
+	TxStatusHeldSeq        TransactionStatus = TransactionStatus(proto.TransactionStatus_tsHELD_SEQ)
+	TxStatusHeldLedger     TransactionStatus = TransactionStatus(proto.TransactionStatus_tsHELD_LEDGER)
 )
 
 // NodeStatus represents the status of a node.
 type NodeStatus int32
 
 const (
-	NodeStatusConnecting NodeStatus = 1
-	NodeStatusConnected  NodeStatus = 2
-	NodeStatusMonitoring NodeStatus = 3
-	NodeStatusValidating NodeStatus = 4
-	NodeStatusShutting   NodeStatus = 5
+	NodeStatusConnecting NodeStatus = NodeStatus(proto.NodeStatus_nsCONNECTING)
+	NodeStatusConnected  NodeStatus = NodeStatus(proto.NodeStatus_nsCONNECTED)
+	NodeStatusMonitoring NodeStatus = NodeStatus(proto.NodeStatus_nsMONITORING)
+	NodeStatusValidating NodeStatus = NodeStatus(proto.NodeStatus_nsVALIDATING)
+	NodeStatusShutting   NodeStatus = NodeStatus(proto.NodeStatus_nsSHUTTING)
 )
 
 // NodeEvent represents an event on a node.
 type NodeEvent int32
 
 const (
-	NodeEventClosingLedger  NodeEvent = 1
-	NodeEventAcceptedLedger NodeEvent = 2
-	NodeEventSwitchedLedger NodeEvent = 3
-	NodeEventLostSync       NodeEvent = 4
+	NodeEventClosingLedger  NodeEvent = NodeEvent(proto.NodeEvent_neCLOSING_LEDGER)
+	NodeEventAcceptedLedger NodeEvent = NodeEvent(proto.NodeEvent_neACCEPTED_LEDGER)
+	NodeEventSwitchedLedger NodeEvent = NodeEvent(proto.NodeEvent_neSWITCHED_LEDGER)
+	NodeEventLostSync       NodeEvent = NodeEvent(proto.NodeEvent_neLOST_SYNC)
 )
 
 // TxSetStatus represents the status of a transaction set.
 type TxSetStatus int32
 
 const (
-	TxSetStatusHave   TxSetStatus = 1
-	TxSetStatusCanGet TxSetStatus = 2
-	TxSetStatusNeed   TxSetStatus = 3
+	TxSetStatusHave   TxSetStatus = TxSetStatus(proto.TxSetStatus_tsHAVE)
+	TxSetStatusCanGet TxSetStatus = TxSetStatus(proto.TxSetStatus_tsCAN_GET)
+	TxSetStatusNeed   TxSetStatus = TxSetStatus(proto.TxSetStatus_tsNEED)
 )
 
 // LedgerInfoType represents types of ledger information.
 type LedgerInfoType int32
 
 const (
-	LedgerInfoBase        LedgerInfoType = 0
-	LedgerInfoTxNode      LedgerInfoType = 1
-	LedgerInfoAsNode      LedgerInfoType = 2
-	LedgerInfoTsCandidate LedgerInfoType = 3
+	LedgerInfoBase        LedgerInfoType = LedgerInfoType(proto.TMLedgerInfoType_liBASE)
+	LedgerInfoTxNode      LedgerInfoType = LedgerInfoType(proto.TMLedgerInfoType_liTX_NODE)
+	LedgerInfoAsNode      LedgerInfoType = LedgerInfoType(proto.TMLedgerInfoType_liAS_NODE)
+	LedgerInfoTsCandidate LedgerInfoType = LedgerInfoType(proto.TMLedgerInfoType_liTS_CANDIDATE)
 )
 
 // LedgerQueryType represents the GetLedger query routing mode. qtINDIRECT
@@ -144,16 +104,16 @@ const (
 type LedgerQueryType int32
 
 const (
-	QueryTypeIndirect LedgerQueryType = 0
+	QueryTypeIndirect LedgerQueryType = LedgerQueryType(proto.TMQueryType_qtINDIRECT)
 )
 
 // LedgerType represents types of ledgers.
 type LedgerType int32
 
 const (
-	LedgerTypeAccepted LedgerType = 0
-	LedgerTypeCurrent  LedgerType = 1
-	LedgerTypeClosed   LedgerType = 2
+	LedgerTypeAccepted LedgerType = LedgerType(proto.TMLedgerType_ltACCEPTED)
+	LedgerTypeCurrent  LedgerType = LedgerType(proto.TMLedgerType_ltCURRENT)
+	LedgerTypeClosed   LedgerType = LedgerType(proto.TMLedgerType_ltCLOSED)
 )
 
 // ReplyError represents error codes in replies.
@@ -161,37 +121,37 @@ type ReplyError int32
 
 const (
 	ReplyErrorNone       ReplyError = 0
-	ReplyErrorNoLedger   ReplyError = 1
-	ReplyErrorNoNode     ReplyError = 2
-	ReplyErrorBadRequest ReplyError = 3
+	ReplyErrorNoLedger   ReplyError = ReplyError(proto.TMReplyError_reNO_LEDGER)
+	ReplyErrorNoNode     ReplyError = ReplyError(proto.TMReplyError_reNO_NODE)
+	ReplyErrorBadRequest ReplyError = ReplyError(proto.TMReplyError_reBAD_REQUEST)
 )
 
 // PingType represents the type of a ping message.
 type PingType int32
 
 const (
-	PingTypePing PingType = 0
-	PingTypePong PingType = 1
+	PingTypePing PingType = PingType(proto.TMPing_ptPING)
+	PingTypePong PingType = PingType(proto.TMPing_ptPONG)
 )
 
 // ObjectType represents types of objects that can be requested.
 type ObjectType int32
 
 const (
-	ObjectTypeUnknown         ObjectType = 0
-	ObjectTypeLedger          ObjectType = 1
-	ObjectTypeTransaction     ObjectType = 2
-	ObjectTypeTransactionNode ObjectType = 3
-	ObjectTypeStateNode       ObjectType = 4
-	ObjectTypeCasObject       ObjectType = 5
-	ObjectTypeFetchPack       ObjectType = 6
-	ObjectTypeTransactions    ObjectType = 7
+	ObjectTypeUnknown         ObjectType = ObjectType(proto.TMGetObjectByHash_otUNKNOWN)
+	ObjectTypeLedger          ObjectType = ObjectType(proto.TMGetObjectByHash_otLEDGER)
+	ObjectTypeTransaction     ObjectType = ObjectType(proto.TMGetObjectByHash_otTRANSACTION)
+	ObjectTypeTransactionNode ObjectType = ObjectType(proto.TMGetObjectByHash_otTRANSACTION_NODE)
+	ObjectTypeStateNode       ObjectType = ObjectType(proto.TMGetObjectByHash_otSTATE_NODE)
+	ObjectTypeCasObject       ObjectType = ObjectType(proto.TMGetObjectByHash_otCAS_OBJECT)
+	ObjectTypeFetchPack       ObjectType = ObjectType(proto.TMGetObjectByHash_otFETCH_PACK)
+	ObjectTypeTransactions    ObjectType = ObjectType(proto.TMGetObjectByHash_otTRANSACTIONS)
 )
 
 // LedgerMapType represents types of ledger maps.
 type LedgerMapType int32
 
 const (
-	LedgerMapTransaction  LedgerMapType = 1
-	LedgerMapAccountState LedgerMapType = 2
+	LedgerMapTransaction  LedgerMapType = LedgerMapType(proto.TMLedgerMapType_lmTRANSACTION)
+	LedgerMapAccountState LedgerMapType = LedgerMapType(proto.TMLedgerMapType_lmACCOUNT_STATE)
 )

--- a/internal/peermanagement/overlay_message.go
+++ b/internal/peermanagement/overlay_message.go
@@ -509,7 +509,7 @@ func (o *Overlay) handleStatusChange(evt Event) {
 		// clears that storage and the all-zeros 64-char hex string is
 		// emitted.
 		var ledgerHash string
-		if len(sc.LedgerHash) > 0 {
+		if sc.HasLedgerHash() {
 			if h, ok := peer.ClosedLedger(); ok {
 				ledgerHash = strings.ToUpper(hex.EncodeToString(h[:]))
 			} else {

--- a/internal/peermanagement/overlay_message.go
+++ b/internal/peermanagement/overlay_message.go
@@ -476,12 +476,9 @@ func (o *Overlay) handleStatusChange(evt Event) {
 	if !exists {
 		return
 	}
-	// Stamp the wire's networktime with the local clock when the peer
-	// didn't include it, so the peer_status emit always carries a
-	// `date`. Mutate sc so the auto-filled value is observable to
-	// subscribers.
-	if sc.NetworkTime == 0 {
+	if !sc.HasNetworkTime() {
 		sc.NetworkTime = uint64(protocol.RippleSeconds(time.Now()))
+		sc.NetworkTimeSet = true
 	}
 
 	effectiveStatus := peer.applyStatusChange(sc)
@@ -489,14 +486,14 @@ func (o *Overlay) handleStatusChange(evt Event) {
 	// lostSync returns before either the tracking check or the
 	// publish runs, so a lostSync update never surfaces as a
 	// peer_status WebSocket event.
-	if sc.NewEvent == message.NodeEventLostSync {
+	if sc.HasNewEvent() && sc.NewEvent == message.NodeEventLostSync {
 		return
 	}
 
 	// The tracking check is gated on a fresh (<2 min) validated
 	// ledger. The gate must NOT short-circuit the publish below,
 	// which runs unconditionally for non-lostSync messages.
-	if sc.LedgerSeq != 0 {
+	if sc.HasLedgerSeq() {
 		if provider := o.validLedgerProviderSnapshot(); provider != nil {
 			if validSeq, age, ok := provider(); ok && validSeq != 0 && age < 2*time.Minute {
 				peer.CheckTracking(sc.LedgerSeq, validSeq)
@@ -527,24 +524,29 @@ func (o *Overlay) handleStatusChange(evt Event) {
 			f, l := *sc.FirstSeq, *sc.LastSeq
 			minSeq, maxSeq = &f, &l
 		}
-		// The decoder loses proto-presence for ledger_seq (see
-		// internal/peermanagement/proto/ripple.pb.go), so use 0 as
-		// the absence proxy — XRPL ledger sequences start at the
-		// genesis ledger 1, no real peer broadcasts has_ledgerseq=0.
 		var ledgerIndex *uint32
-		if sc.LedgerSeq != 0 {
+		if sc.HasLedgerSeq() {
 			ls := sc.LedgerSeq
 			ledgerIndex = &ls
 		}
-		// Date is always set thanks to the auto-fill above. Truncate
-		// uint64 → uint32 to match the uint32 date rippled emits.
-		dateVal := uint32(sc.NetworkTime)
+		var status, action string
+		if sc.HasNewStatus() {
+			status = peerStatusUpperName(effectiveStatus)
+		}
+		if sc.HasNewEvent() {
+			action = peerStatusActionName(sc.NewEvent)
+		}
+		var date *uint32
+		if sc.HasNetworkTime() {
+			value := uint32(sc.NetworkTime)
+			date = &value
+		}
 		pub(PeerStatusUpdate{
-			Status:         peerStatusUpperName(effectiveStatus),
-			Action:         peerStatusActionName(sc.NewEvent),
+			Status:         status,
+			Action:         action,
 			LedgerIndex:    ledgerIndex,
 			LedgerHash:     ledgerHash,
-			Date:           &dateVal,
+			Date:           date,
 			LedgerIndexMin: minSeq,
 			LedgerIndexMax: maxSeq,
 		})
@@ -614,18 +616,15 @@ func (o *Overlay) handlePing(evt Event) bool {
 
 	switch ping.PType {
 	case message.PingTypePing:
-		pong := &message.Ping{
-			PType:    message.PingTypePong,
-			Seq:      ping.Seq,
-			PingTime: ping.PingTime,
-		}
-		wireMsg, err := message.EncodeFrame(pong)
+		pong := *ping
+		pong.PType = message.PingTypePong
+		wireMsg, err := message.EncodeFrame(&pong)
 		if err != nil {
 			return false
 		}
 		o.Send(evt.PeerID, wireMsg)
 	case message.PingTypePong:
-		if peer, exists := o.getPeer(evt.PeerID); exists {
+		if peer, exists := o.getPeer(evt.PeerID); exists && ping.HasSeq() {
 			peer.OnPong(ping.Seq, time.Now())
 		}
 	default:

--- a/internal/peermanagement/overlay_ping_test.go
+++ b/internal/peermanagement/overlay_ping_test.go
@@ -1,0 +1,85 @@
+package peermanagement
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverlayHandlePingPongEchoesOptionalFields(t *testing.T) {
+	peer := newTestPeer(t, 7)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{7: peer})
+
+	tests := []struct {
+		name string
+		ping *message.Ping
+	}{
+		{name: "absent", ping: &message.Ping{PType: message.PingTypePing}},
+		{
+			name: "explicit zero",
+			ping: &message.Ping{
+				PType:       message.PingTypePing,
+				SeqSet:      true,
+				PingTimeSet: true,
+				NetTimeSet:  true,
+			},
+		},
+		{
+			name: "nonzero",
+			ping: &message.Ping{
+				PType:    message.PingTypePing,
+				Seq:      11,
+				PingTime: 22,
+				NetTime:  33,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := message.Encode(tt.ping)
+			require.NoError(t, err)
+			require.True(t, o.handlePing(Event{PeerID: 7, Payload: payload}))
+
+			frame := requireOutboundFrame(t, peer)
+			header, replyPayload, err := message.ReadMessage(bytes.NewReader(frame))
+			require.NoError(t, err)
+			require.Equal(t, message.TypePing, header.MessageType)
+			decoded, err := message.Decode(message.TypePing, replyPayload)
+			require.NoError(t, err)
+			pong := decoded.(*message.Ping)
+
+			assert.Equal(t, message.PingTypePong, pong.PType)
+			assert.Equal(t, tt.ping.Seq, pong.Seq)
+			assert.Equal(t, tt.ping.HasSeq(), pong.HasSeq())
+			assert.Equal(t, tt.ping.PingTime, pong.PingTime)
+			assert.Equal(t, tt.ping.HasPingTime(), pong.HasPingTime())
+			assert.Equal(t, tt.ping.NetTime, pong.NetTime)
+			assert.Equal(t, tt.ping.HasNetTime(), pong.HasNetTime())
+		})
+	}
+}
+
+func TestOverlayHandlePongRequiresSeqPresence(t *testing.T) {
+	peer := newTestPeer(t, 7)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{7: peer})
+	peer.recordPingSent(0, time.Now().Add(-time.Millisecond))
+
+	absent, err := message.Encode(&message.Ping{PType: message.PingTypePong})
+	require.NoError(t, err)
+	require.True(t, o.handlePing(Event{PeerID: 7, Payload: absent}))
+	_, measured := peer.Latency()
+	assert.False(t, measured)
+
+	explicitZero, err := message.Encode(&message.Ping{
+		PType:  message.PingTypePong,
+		SeqSet: true,
+	})
+	require.NoError(t, err)
+	require.True(t, o.handlePing(Event{PeerID: 7, Payload: explicitZero}))
+	_, measured = peer.Latency()
+	assert.True(t, measured)
+}

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -219,7 +219,8 @@ type Peer struct {
 	firstLedgerSeq uint32
 	lastLedgerSeq  uint32
 
-	lastStatus message.NodeStatus
+	lastStatus    message.NodeStatus
+	lastStatusSet bool
 
 	latencyMu     sync.RWMutex
 	pingsInFlight map[uint32]pingInFlight
@@ -553,18 +554,9 @@ func (p *Peer) applyHandshakeExtras(x HandshakeExtras) {
 // ledger only; the (firstSeq, lastSeq) range is updated only when both
 // fields are present, then clamped to (0,0) if either is zero or inverted.
 //
-// newStatus mirrors rippled PeerImp.cpp:1799-1810. Read carefully: rippled's
-// branches both end with `last_status_ = *m;`, which copy-assigns the
-// inbound proto verbatim — so the stored last_status_.newstatus() is
-// dropped whenever the wire message has no newstatus. The else-branch
-// additionally mutates the local `m` to carry the prior enum, so the
-// pubPeerStatus callback (which reads `m`, not last_status_) still sees
-// the inherited value once. We model the same split:
-//   - lastStatus is overwritten verbatim with the wire's NewStatus (zero
-//     argument drops the prior value, matching rippled's `peers` RPC).
-//   - The returned effective status is the wire value when set, or the
-//     prior lastStatus otherwise — consumed by handleStatusChange's
-//     pubPeerStatus emit so subscribers receive the inherited enum.
+// newStatus mirrors rippled's lastStatus copy and one-message inheritance:
+// an absent status inherits the prior present value for publishing, while the
+// stored message is replaced by the original absence.
 //
 // The lostSync early-return runs after the lastStatus write, so a
 // lostSync update carrying a NewStatus still records it — but
@@ -575,12 +567,20 @@ func (p *Peer) applyStatusChange(sc *message.StatusChange) message.NodeStatus {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	wireHadStatus := sc.HasNewStatus()
 	effective := sc.NewStatus
-	if sc.NewStatus == 0 {
+	if !wireHadStatus && p.lastStatusSet {
 		effective = p.lastStatus
+		sc.NewStatus = effective
+		sc.NewStatusSet = true
 	}
-	p.lastStatus = sc.NewStatus
-	if sc.NewEvent == message.NodeEventLostSync {
+	if wireHadStatus {
+		p.lastStatus = effective
+	} else {
+		p.lastStatus = 0
+	}
+	p.lastStatusSet = wireHadStatus
+	if sc.HasNewEvent() && sc.NewEvent == message.NodeEventLostSync {
 		p.hasClosedLedger = false
 		p.hasPreviousLedger = false
 		p.closedLedger = [32]byte{}

--- a/internal/peermanagement/peer_status_test.go
+++ b/internal/peermanagement/peer_status_test.go
@@ -2,6 +2,7 @@ package peermanagement
 
 import (
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/stretchr/testify/assert"
@@ -301,6 +302,34 @@ func TestOverlay_handleStatusChange_AutoFillsDate(t *testing.T) {
 
 	require.NotNil(t, got.Date, "PeerImp.cpp:1796-1797 — networktime auto-filled")
 	assert.Greater(t, *got.Date, uint32(0))
+}
+
+func TestOverlay_handleStatusChange_PreservesExplicitZeroScalarPresence(t *testing.T) {
+	peer := newTestPeer(t, 7)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{7: peer})
+
+	providerCalls := 0
+	o.SetValidLedgerProvider(func() (uint32, time.Duration, bool) {
+		providerCalls++
+		return 1, 0, true
+	})
+	var got PeerStatusUpdate
+	o.SetPeerStatusPublisher(func(update PeerStatusUpdate) { got = update })
+
+	payload, err := message.Encode(&message.StatusChange{
+		LedgerSeqSet:   true,
+		NetworkTimeSet: true,
+	})
+	require.NoError(t, err)
+	o.handleStatusChange(Event{PeerID: 7, Payload: payload})
+
+	assert.Empty(t, got.Status)
+	assert.Empty(t, got.Action)
+	require.NotNil(t, got.LedgerIndex)
+	assert.Zero(t, *got.LedgerIndex)
+	require.NotNil(t, got.Date)
+	assert.Zero(t, *got.Date)
+	assert.Equal(t, 1, providerCalls, "present ledger_seq=0 passes the has-ledgerseq gate")
 }
 
 // TestOverlay_SetPeerStatusPublisher_Disconnect verifies the doc

--- a/internal/peermanagement/peer_status_test.go
+++ b/internal/peermanagement/peer_status_test.go
@@ -1,6 +1,7 @@
 package peermanagement
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -274,6 +275,19 @@ func TestOverlay_handleStatusChange_LedgerHashZerosOnMalformedWire(t *testing.T)
 		"0000000000000000000000000000000000000000000000000000000000000000",
 		got.LedgerHash,
 		"PeerImp.cpp:1948 emits hex of the cleared closedLedgerHash_, not the wire bytes")
+}
+
+func TestOverlay_handleStatusChange_ExplicitEmptyLedgerHashIsPublished(t *testing.T) {
+	peer := newTestPeer(t, 7)
+	o := newTestOverlayWithPeers(map[PeerID]*Peer{7: peer})
+	var got PeerStatusUpdate
+	o.SetPeerStatusPublisher(func(update PeerStatusUpdate) { got = update })
+
+	payload, err := message.Encode(&message.StatusChange{LedgerHash: []byte{}})
+	require.NoError(t, err)
+	o.handleStatusChange(Event{PeerID: 7, Payload: payload})
+
+	assert.Equal(t, strings.Repeat("0", 64), got.LedgerHash)
 }
 
 // TestOverlay_handleStatusChange_AutoFillsDate covers

--- a/internal/peermanagement/proto/generate.go
+++ b/internal/peermanagement/proto/generate.go
@@ -1,0 +1,3 @@
+package proto
+
+//go:generate go run ./internal/protogen

--- a/internal/peermanagement/proto/internal/protogen/main.go
+++ b/internal/peermanagement/proto/internal/protogen/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const (
+	protocVersion      = "libprotoc 34.1"
+	protocGenGoVersion = "protoc-gen-go v1.36.11"
+)
+
+func main() {
+	checkVersion("protoc", protocVersion)
+	checkVersion("protoc-gen-go", protocGenGoVersion)
+
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		fatal(err)
+	}
+	moduleRoot, err := filepath.Abs(filepath.Join(workingDirectory, "../../.."))
+	if err != nil {
+		fatal(err)
+	}
+	command := exec.CommandContext(
+		context.Background(),
+		"protoc",
+		"--go_out=.",
+		"--go_opt=paths=source_relative",
+		"--go_opt=Minternal/peermanagement/proto/xrpl.proto=github.com/LeJamon/go-xrpl/internal/peermanagement/proto",
+		"internal/peermanagement/proto/xrpl.proto",
+	)
+	command.Dir = moduleRoot
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Run(); err != nil {
+		fatal(err)
+	}
+}
+
+func checkVersion(name, expected string) {
+	output, err := exec.CommandContext(context.Background(), name, "--version").Output()
+	if err != nil {
+		fatal(err)
+	}
+	actual := string(bytes.TrimSpace(output))
+	if actual != expected {
+		fatal(fmt.Errorf("%s version is %q, want %q", name, actual, expected))
+	}
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}

--- a/internal/peermanagement/proto/xrpl.pb.go
+++ b/internal/peermanagement/proto/xrpl.pb.go
@@ -21,38 +21,38 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Message types for the XRPL peer protocol
+// Unused numbers in the list below may have been used previously. Please don't
+// reassign them for reuse unless you are 100% certain that there won't be a
+// conflict. Even if you're sure, it's probably best to assign a new type.
 type MessageType int32
 
 const (
-	MessageType_mtUNKNOWN                 MessageType = 0
-	MessageType_mtMANIFESTS               MessageType = 2
-	MessageType_mtPING                    MessageType = 3
-	MessageType_mtCLUSTER                 MessageType = 5
-	MessageType_mtENDPOINTS               MessageType = 15
-	MessageType_mtTRANSACTION             MessageType = 30
-	MessageType_mtGET_LEDGER              MessageType = 31
-	MessageType_mtLEDGER_DATA             MessageType = 32
-	MessageType_mtPROPOSE_LEDGER          MessageType = 33
-	MessageType_mtSTATUS_CHANGE           MessageType = 34
-	MessageType_mtHAVE_SET                MessageType = 35
-	MessageType_mtVALIDATION              MessageType = 41
-	MessageType_mtGET_OBJECTS             MessageType = 42
-	MessageType_mtVALIDATORLIST           MessageType = 54
-	MessageType_mtSQUELCH                 MessageType = 55
-	MessageType_mtVALIDATORLISTCOLLECTION MessageType = 56
-	MessageType_mtPROOF_PATH_REQ          MessageType = 57
-	MessageType_mtPROOF_PATH_RESPONSE     MessageType = 58
-	MessageType_mtREPLAY_DELTA_REQ        MessageType = 59
-	MessageType_mtREPLAY_DELTA_RESPONSE   MessageType = 60
-	MessageType_mtHAVE_TRANSACTIONS       MessageType = 63
-	MessageType_mtTRANSACTIONS            MessageType = 64
+	MessageType_mtMANIFESTS                 MessageType = 2
+	MessageType_mtPING                      MessageType = 3
+	MessageType_mtCLUSTER                   MessageType = 5
+	MessageType_mtENDPOINTS                 MessageType = 15
+	MessageType_mtTRANSACTION               MessageType = 30
+	MessageType_mtGET_LEDGER                MessageType = 31
+	MessageType_mtLEDGER_DATA               MessageType = 32
+	MessageType_mtPROPOSE_LEDGER            MessageType = 33
+	MessageType_mtSTATUS_CHANGE             MessageType = 34
+	MessageType_mtHAVE_SET                  MessageType = 35
+	MessageType_mtVALIDATION                MessageType = 41
+	MessageType_mtGET_OBJECTS               MessageType = 42
+	MessageType_mtVALIDATOR_LIST            MessageType = 54
+	MessageType_mtSQUELCH                   MessageType = 55
+	MessageType_mtVALIDATOR_LIST_COLLECTION MessageType = 56
+	MessageType_mtPROOF_PATH_REQ            MessageType = 57
+	MessageType_mtPROOF_PATH_RESPONSE       MessageType = 58
+	MessageType_mtREPLAY_DELTA_REQ          MessageType = 59
+	MessageType_mtREPLAY_DELTA_RESPONSE     MessageType = 60
+	MessageType_mtHAVE_TRANSACTIONS         MessageType = 63
+	MessageType_mtTRANSACTIONS              MessageType = 64
 )
 
 // Enum value maps for MessageType.
 var (
 	MessageType_name = map[int32]string{
-		0:  "mtUNKNOWN",
 		2:  "mtMANIFESTS",
 		3:  "mtPING",
 		5:  "mtCLUSTER",
@@ -65,9 +65,9 @@ var (
 		35: "mtHAVE_SET",
 		41: "mtVALIDATION",
 		42: "mtGET_OBJECTS",
-		54: "mtVALIDATORLIST",
+		54: "mtVALIDATOR_LIST",
 		55: "mtSQUELCH",
-		56: "mtVALIDATORLISTCOLLECTION",
+		56: "mtVALIDATOR_LIST_COLLECTION",
 		57: "mtPROOF_PATH_REQ",
 		58: "mtPROOF_PATH_RESPONSE",
 		59: "mtREPLAY_DELTA_REQ",
@@ -76,28 +76,27 @@ var (
 		64: "mtTRANSACTIONS",
 	}
 	MessageType_value = map[string]int32{
-		"mtUNKNOWN":                 0,
-		"mtMANIFESTS":               2,
-		"mtPING":                    3,
-		"mtCLUSTER":                 5,
-		"mtENDPOINTS":               15,
-		"mtTRANSACTION":             30,
-		"mtGET_LEDGER":              31,
-		"mtLEDGER_DATA":             32,
-		"mtPROPOSE_LEDGER":          33,
-		"mtSTATUS_CHANGE":           34,
-		"mtHAVE_SET":                35,
-		"mtVALIDATION":              41,
-		"mtGET_OBJECTS":             42,
-		"mtVALIDATORLIST":           54,
-		"mtSQUELCH":                 55,
-		"mtVALIDATORLISTCOLLECTION": 56,
-		"mtPROOF_PATH_REQ":          57,
-		"mtPROOF_PATH_RESPONSE":     58,
-		"mtREPLAY_DELTA_REQ":        59,
-		"mtREPLAY_DELTA_RESPONSE":   60,
-		"mtHAVE_TRANSACTIONS":       63,
-		"mtTRANSACTIONS":            64,
+		"mtMANIFESTS":                 2,
+		"mtPING":                      3,
+		"mtCLUSTER":                   5,
+		"mtENDPOINTS":                 15,
+		"mtTRANSACTION":               30,
+		"mtGET_LEDGER":                31,
+		"mtLEDGER_DATA":               32,
+		"mtPROPOSE_LEDGER":            33,
+		"mtSTATUS_CHANGE":             34,
+		"mtHAVE_SET":                  35,
+		"mtVALIDATION":                41,
+		"mtGET_OBJECTS":               42,
+		"mtVALIDATOR_LIST":            54,
+		"mtSQUELCH":                   55,
+		"mtVALIDATOR_LIST_COLLECTION": 56,
+		"mtPROOF_PATH_REQ":            57,
+		"mtPROOF_PATH_RESPONSE":       58,
+		"mtREPLAY_DELTA_REQ":          59,
+		"mtREPLAY_DELTA_RESPONSE":     60,
+		"mtHAVE_TRANSACTIONS":         63,
+		"mtTRANSACTIONS":              64,
 	}
 )
 
@@ -123,33 +122,40 @@ func (x MessageType) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
+// Deprecated: Do not use.
+func (x *MessageType) UnmarshalJSON(b []byte) error {
+	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
+	if err != nil {
+		return err
+	}
+	*x = MessageType(num)
+	return nil
+}
+
 // Deprecated: Use MessageType.Descriptor instead.
 func (MessageType) EnumDescriptor() ([]byte, []int) {
 	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{0}
 }
 
-// Transaction status
 type TransactionStatus int32
 
 const (
-	TransactionStatus_tsUNKNOWN         TransactionStatus = 0
-	TransactionStatus_tsNEW             TransactionStatus = 1
-	TransactionStatus_tsCURRENT         TransactionStatus = 2
-	TransactionStatus_tsCOMMITED        TransactionStatus = 3
+	TransactionStatus_tsNEW             TransactionStatus = 1 // origin node did/could not validate
+	TransactionStatus_tsCURRENT         TransactionStatus = 2 // scheduled to go in this ledger
+	TransactionStatus_tsCOMMITTED       TransactionStatus = 3 // in a closed ledger
 	TransactionStatus_tsREJECT_CONFLICT TransactionStatus = 4
 	TransactionStatus_tsREJECT_INVALID  TransactionStatus = 5
 	TransactionStatus_tsREJECT_FUNDS    TransactionStatus = 6
 	TransactionStatus_tsHELD_SEQ        TransactionStatus = 7
-	TransactionStatus_tsHELD_LEDGER     TransactionStatus = 8
+	TransactionStatus_tsHELD_LEDGER     TransactionStatus = 8 // held for future ledger
 )
 
 // Enum value maps for TransactionStatus.
 var (
 	TransactionStatus_name = map[int32]string{
-		0: "tsUNKNOWN",
 		1: "tsNEW",
 		2: "tsCURRENT",
-		3: "tsCOMMITED",
+		3: "tsCOMMITTED",
 		4: "tsREJECT_CONFLICT",
 		5: "tsREJECT_INVALID",
 		6: "tsREJECT_FUNDS",
@@ -157,10 +163,9 @@ var (
 		8: "tsHELD_LEDGER",
 	}
 	TransactionStatus_value = map[string]int32{
-		"tsUNKNOWN":         0,
 		"tsNEW":             1,
 		"tsCURRENT":         2,
-		"tsCOMMITED":        3,
+		"tsCOMMITTED":       3,
 		"tsREJECT_CONFLICT": 4,
 		"tsREJECT_INVALID":  5,
 		"tsREJECT_FUNDS":    6,
@@ -191,27 +196,34 @@ func (x TransactionStatus) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
+// Deprecated: Do not use.
+func (x *TransactionStatus) UnmarshalJSON(b []byte) error {
+	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
+	if err != nil {
+		return err
+	}
+	*x = TransactionStatus(num)
+	return nil
+}
+
 // Deprecated: Use TransactionStatus.Descriptor instead.
 func (TransactionStatus) EnumDescriptor() ([]byte, []int) {
 	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{1}
 }
 
-// Node status
 type NodeStatus int32
 
 const (
-	NodeStatus_nsUNKNOWN    NodeStatus = 0
-	NodeStatus_nsCONNECTING NodeStatus = 1
-	NodeStatus_nsCONNECTED  NodeStatus = 2
-	NodeStatus_nsMONITORING NodeStatus = 3
-	NodeStatus_nsVALIDATING NodeStatus = 4
-	NodeStatus_nsSHUTTING   NodeStatus = 5
+	NodeStatus_nsCONNECTING NodeStatus = 1 // acquiring connections
+	NodeStatus_nsCONNECTED  NodeStatus = 2 // convinced we are connected to the real network
+	NodeStatus_nsMONITORING NodeStatus = 3 // we know what the previous ledger is
+	NodeStatus_nsVALIDATING NodeStatus = 4 // we have the full ledger contents
+	NodeStatus_nsSHUTTING   NodeStatus = 5 // node is shutting down
 )
 
 // Enum value maps for NodeStatus.
 var (
 	NodeStatus_name = map[int32]string{
-		0: "nsUNKNOWN",
 		1: "nsCONNECTING",
 		2: "nsCONNECTED",
 		3: "nsMONITORING",
@@ -219,7 +231,6 @@ var (
 		5: "nsSHUTTING",
 	}
 	NodeStatus_value = map[string]int32{
-		"nsUNKNOWN":    0,
 		"nsCONNECTING": 1,
 		"nsCONNECTED":  2,
 		"nsMONITORING": 3,
@@ -250,33 +261,39 @@ func (x NodeStatus) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
+// Deprecated: Do not use.
+func (x *NodeStatus) UnmarshalJSON(b []byte) error {
+	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
+	if err != nil {
+		return err
+	}
+	*x = NodeStatus(num)
+	return nil
+}
+
 // Deprecated: Use NodeStatus.Descriptor instead.
 func (NodeStatus) EnumDescriptor() ([]byte, []int) {
 	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{2}
 }
 
-// Node events
 type NodeEvent int32
 
 const (
-	NodeEvent_neUNKNOWN         NodeEvent = 0
-	NodeEvent_neCLOSING_LEDGER  NodeEvent = 1
-	NodeEvent_neACCEPTED_LEDGER NodeEvent = 2
-	NodeEvent_neSWITCHED_LEDGER NodeEvent = 3
+	NodeEvent_neCLOSING_LEDGER  NodeEvent = 1 // closing a ledger because its close time has come
+	NodeEvent_neACCEPTED_LEDGER NodeEvent = 2 // accepting a closed ledger, we have finished computing it
+	NodeEvent_neSWITCHED_LEDGER NodeEvent = 3 // changing due to network consensus
 	NodeEvent_neLOST_SYNC       NodeEvent = 4
 )
 
 // Enum value maps for NodeEvent.
 var (
 	NodeEvent_name = map[int32]string{
-		0: "neUNKNOWN",
 		1: "neCLOSING_LEDGER",
 		2: "neACCEPTED_LEDGER",
 		3: "neSWITCHED_LEDGER",
 		4: "neLOST_SYNC",
 	}
 	NodeEvent_value = map[string]int32{
-		"neUNKNOWN":         0,
 		"neCLOSING_LEDGER":  1,
 		"neACCEPTED_LEDGER": 2,
 		"neSWITCHED_LEDGER": 3,
@@ -306,34 +323,40 @@ func (x NodeEvent) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
+// Deprecated: Do not use.
+func (x *NodeEvent) UnmarshalJSON(b []byte) error {
+	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
+	if err != nil {
+		return err
+	}
+	*x = NodeEvent(num)
+	return nil
+}
+
 // Deprecated: Use NodeEvent.Descriptor instead.
 func (NodeEvent) EnumDescriptor() ([]byte, []int) {
 	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{3}
 }
 
-// Transaction set status
 type TxSetStatus int32
 
 const (
-	TxSetStatus_tsUNKNOWN_SET TxSetStatus = 0
-	TxSetStatus_tsHAVE        TxSetStatus = 1
-	TxSetStatus_tsCAN_GET     TxSetStatus = 2
-	TxSetStatus_tsNEED        TxSetStatus = 3
+	TxSetStatus_tsHAVE    TxSetStatus = 1 // We have this set locally
+	TxSetStatus_tsCAN_GET TxSetStatus = 2 // We have a peer with this set
+	TxSetStatus_tsNEED    TxSetStatus = 3 // We need this set and can't get it
 )
 
 // Enum value maps for TxSetStatus.
 var (
 	TxSetStatus_name = map[int32]string{
-		0: "tsUNKNOWN_SET",
 		1: "tsHAVE",
 		2: "tsCAN_GET",
 		3: "tsNEED",
 	}
 	TxSetStatus_value = map[string]int32{
-		"tsUNKNOWN_SET": 0,
-		"tsHAVE":        1,
-		"tsCAN_GET":     2,
-		"tsNEED":        3,
+		"tsHAVE":    1,
+		"tsCAN_GET": 2,
+		"tsNEED":    3,
 	}
 )
 
@@ -359,84 +382,28 @@ func (x TxSetStatus) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
+// Deprecated: Do not use.
+func (x *TxSetStatus) UnmarshalJSON(b []byte) error {
+	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
+	if err != nil {
+		return err
+	}
+	*x = TxSetStatus(num)
+	return nil
+}
+
 // Deprecated: Use TxSetStatus.Descriptor instead.
 func (TxSetStatus) EnumDescriptor() ([]byte, []int) {
 	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{4}
 }
 
-// Object types
-type ObjectType int32
-
-const (
-	ObjectType_otUNKNOWN          ObjectType = 0
-	ObjectType_otLEDGER           ObjectType = 1
-	ObjectType_otTRANSACTION      ObjectType = 2
-	ObjectType_otTRANSACTION_NODE ObjectType = 3
-	ObjectType_otSTATE_NODE       ObjectType = 4
-	ObjectType_otCAS_OBJECT       ObjectType = 5
-	ObjectType_otFETCH_PACK       ObjectType = 6
-	ObjectType_otTRANSACTIONS     ObjectType = 7
-)
-
-// Enum value maps for ObjectType.
-var (
-	ObjectType_name = map[int32]string{
-		0: "otUNKNOWN",
-		1: "otLEDGER",
-		2: "otTRANSACTION",
-		3: "otTRANSACTION_NODE",
-		4: "otSTATE_NODE",
-		5: "otCAS_OBJECT",
-		6: "otFETCH_PACK",
-		7: "otTRANSACTIONS",
-	}
-	ObjectType_value = map[string]int32{
-		"otUNKNOWN":          0,
-		"otLEDGER":           1,
-		"otTRANSACTION":      2,
-		"otTRANSACTION_NODE": 3,
-		"otSTATE_NODE":       4,
-		"otCAS_OBJECT":       5,
-		"otFETCH_PACK":       6,
-		"otTRANSACTIONS":     7,
-	}
-)
-
-func (x ObjectType) Enum() *ObjectType {
-	p := new(ObjectType)
-	*p = x
-	return p
-}
-
-func (x ObjectType) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (ObjectType) Descriptor() protoreflect.EnumDescriptor {
-	return file_internal_peermanagement_proto_xrpl_proto_enumTypes[5].Descriptor()
-}
-
-func (ObjectType) Type() protoreflect.EnumType {
-	return &file_internal_peermanagement_proto_xrpl_proto_enumTypes[5]
-}
-
-func (x ObjectType) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use ObjectType.Descriptor instead.
-func (ObjectType) EnumDescriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{5}
-}
-
-// Ledger info types
 type TMLedgerInfoType int32
 
 const (
-	TMLedgerInfoType_liBASE         TMLedgerInfoType = 0
-	TMLedgerInfoType_liTX_NODE      TMLedgerInfoType = 1
-	TMLedgerInfoType_liAS_NODE      TMLedgerInfoType = 2
-	TMLedgerInfoType_liTS_CANDIDATE TMLedgerInfoType = 3
+	TMLedgerInfoType_liBASE         TMLedgerInfoType = 0 // basic ledger info
+	TMLedgerInfoType_liTX_NODE      TMLedgerInfoType = 1 // transaction node
+	TMLedgerInfoType_liAS_NODE      TMLedgerInfoType = 2 // account state node
+	TMLedgerInfoType_liTS_CANDIDATE TMLedgerInfoType = 3 // candidate transaction set
 )
 
 // Enum value maps for TMLedgerInfoType.
@@ -466,28 +433,37 @@ func (x TMLedgerInfoType) String() string {
 }
 
 func (TMLedgerInfoType) Descriptor() protoreflect.EnumDescriptor {
-	return file_internal_peermanagement_proto_xrpl_proto_enumTypes[6].Descriptor()
+	return file_internal_peermanagement_proto_xrpl_proto_enumTypes[5].Descriptor()
 }
 
 func (TMLedgerInfoType) Type() protoreflect.EnumType {
-	return &file_internal_peermanagement_proto_xrpl_proto_enumTypes[6]
+	return &file_internal_peermanagement_proto_xrpl_proto_enumTypes[5]
 }
 
 func (x TMLedgerInfoType) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use TMLedgerInfoType.Descriptor instead.
-func (TMLedgerInfoType) EnumDescriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{6}
+// Deprecated: Do not use.
+func (x *TMLedgerInfoType) UnmarshalJSON(b []byte) error {
+	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
+	if err != nil {
+		return err
+	}
+	*x = TMLedgerInfoType(num)
+	return nil
 }
 
-// Ledger types
+// Deprecated: Use TMLedgerInfoType.Descriptor instead.
+func (TMLedgerInfoType) EnumDescriptor() ([]byte, []int) {
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{5}
+}
+
 type TMLedgerType int32
 
 const (
 	TMLedgerType_ltACCEPTED TMLedgerType = 0
-	TMLedgerType_ltCURRENT  TMLedgerType = 1
+	TMLedgerType_ltCURRENT  TMLedgerType = 1 // no longer supported
 	TMLedgerType_ltCLOSED   TMLedgerType = 2
 )
 
@@ -516,23 +492,32 @@ func (x TMLedgerType) String() string {
 }
 
 func (TMLedgerType) Descriptor() protoreflect.EnumDescriptor {
-	return file_internal_peermanagement_proto_xrpl_proto_enumTypes[7].Descriptor()
+	return file_internal_peermanagement_proto_xrpl_proto_enumTypes[6].Descriptor()
 }
 
 func (TMLedgerType) Type() protoreflect.EnumType {
-	return &file_internal_peermanagement_proto_xrpl_proto_enumTypes[7]
+	return &file_internal_peermanagement_proto_xrpl_proto_enumTypes[6]
 }
 
 func (x TMLedgerType) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use TMLedgerType.Descriptor instead.
-func (TMLedgerType) EnumDescriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{7}
+// Deprecated: Do not use.
+func (x *TMLedgerType) UnmarshalJSON(b []byte) error {
+	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
+	if err != nil {
+		return err
+	}
+	*x = TMLedgerType(num)
+	return nil
 }
 
-// Query type
+// Deprecated: Use TMLedgerType.Descriptor instead.
+func (TMLedgerType) EnumDescriptor() ([]byte, []int) {
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{6}
+}
+
 type TMQueryType int32
 
 const (
@@ -560,42 +545,48 @@ func (x TMQueryType) String() string {
 }
 
 func (TMQueryType) Descriptor() protoreflect.EnumDescriptor {
-	return file_internal_peermanagement_proto_xrpl_proto_enumTypes[8].Descriptor()
+	return file_internal_peermanagement_proto_xrpl_proto_enumTypes[7].Descriptor()
 }
 
 func (TMQueryType) Type() protoreflect.EnumType {
-	return &file_internal_peermanagement_proto_xrpl_proto_enumTypes[8]
+	return &file_internal_peermanagement_proto_xrpl_proto_enumTypes[7]
 }
 
 func (x TMQueryType) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use TMQueryType.Descriptor instead.
-func (TMQueryType) EnumDescriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{8}
+// Deprecated: Do not use.
+func (x *TMQueryType) UnmarshalJSON(b []byte) error {
+	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
+	if err != nil {
+		return err
+	}
+	*x = TMQueryType(num)
+	return nil
 }
 
-// Reply errors
+// Deprecated: Use TMQueryType.Descriptor instead.
+func (TMQueryType) EnumDescriptor() ([]byte, []int) {
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{7}
+}
+
 type TMReplyError int32
 
 const (
-	TMReplyError_reNO_ERROR    TMReplyError = 0
-	TMReplyError_reNO_LEDGER   TMReplyError = 1
-	TMReplyError_reNO_NODE     TMReplyError = 2
-	TMReplyError_reBAD_REQUEST TMReplyError = 3
+	TMReplyError_reNO_LEDGER   TMReplyError = 1 // We don't have the ledger you are asking about
+	TMReplyError_reNO_NODE     TMReplyError = 2 // We don't have any of the nodes you are asking for
+	TMReplyError_reBAD_REQUEST TMReplyError = 3 // The request is wrong, e.g. wrong format
 )
 
 // Enum value maps for TMReplyError.
 var (
 	TMReplyError_name = map[int32]string{
-		0: "reNO_ERROR",
 		1: "reNO_LEDGER",
 		2: "reNO_NODE",
 		3: "reBAD_REQUEST",
 	}
 	TMReplyError_value = map[string]int32{
-		"reNO_ERROR":    0,
 		"reNO_LEDGER":   1,
 		"reNO_NODE":     2,
 		"reBAD_REQUEST": 3,
@@ -613,40 +604,46 @@ func (x TMReplyError) String() string {
 }
 
 func (TMReplyError) Descriptor() protoreflect.EnumDescriptor {
-	return file_internal_peermanagement_proto_xrpl_proto_enumTypes[9].Descriptor()
+	return file_internal_peermanagement_proto_xrpl_proto_enumTypes[8].Descriptor()
 }
 
 func (TMReplyError) Type() protoreflect.EnumType {
-	return &file_internal_peermanagement_proto_xrpl_proto_enumTypes[9]
+	return &file_internal_peermanagement_proto_xrpl_proto_enumTypes[8]
 }
 
 func (x TMReplyError) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use TMReplyError.Descriptor instead.
-func (TMReplyError) EnumDescriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{9}
+// Deprecated: Do not use.
+func (x *TMReplyError) UnmarshalJSON(b []byte) error {
+	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
+	if err != nil {
+		return err
+	}
+	*x = TMReplyError(num)
+	return nil
 }
 
-// Ledger map types
+// Deprecated: Use TMReplyError.Descriptor instead.
+func (TMReplyError) EnumDescriptor() ([]byte, []int) {
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{8}
+}
+
 type TMLedgerMapType int32
 
 const (
-	TMLedgerMapType_lmUNKNOWN       TMLedgerMapType = 0
-	TMLedgerMapType_lmTRANSACTION   TMLedgerMapType = 1
-	TMLedgerMapType_lmACCOUNT_STATE TMLedgerMapType = 2
+	TMLedgerMapType_lmTRANSACTION   TMLedgerMapType = 1 // transaction map
+	TMLedgerMapType_lmACCOUNT_STATE TMLedgerMapType = 2 // account state map
 )
 
 // Enum value maps for TMLedgerMapType.
 var (
 	TMLedgerMapType_name = map[int32]string{
-		0: "lmUNKNOWN",
 		1: "lmTRANSACTION",
 		2: "lmACCOUNT_STATE",
 	}
 	TMLedgerMapType_value = map[string]int32{
-		"lmUNKNOWN":       0,
 		"lmTRANSACTION":   1,
 		"lmACCOUNT_STATE": 2,
 	}
@@ -663,72 +660,167 @@ func (x TMLedgerMapType) String() string {
 }
 
 func (TMLedgerMapType) Descriptor() protoreflect.EnumDescriptor {
-	return file_internal_peermanagement_proto_xrpl_proto_enumTypes[10].Descriptor()
+	return file_internal_peermanagement_proto_xrpl_proto_enumTypes[9].Descriptor()
 }
 
 func (TMLedgerMapType) Type() protoreflect.EnumType {
-	return &file_internal_peermanagement_proto_xrpl_proto_enumTypes[10]
+	return &file_internal_peermanagement_proto_xrpl_proto_enumTypes[9]
 }
 
 func (x TMLedgerMapType) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use TMLedgerMapType.Descriptor instead.
-func (TMLedgerMapType) EnumDescriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{10}
+// Deprecated: Do not use.
+func (x *TMLedgerMapType) UnmarshalJSON(b []byte) error {
+	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
+	if err != nil {
+		return err
+	}
+	*x = TMLedgerMapType(num)
+	return nil
 }
 
-type TMPing_PingType int32
+// Deprecated: Use TMLedgerMapType.Descriptor instead.
+func (TMLedgerMapType) EnumDescriptor() ([]byte, []int) {
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{9}
+}
+
+type TMGetObjectByHash_ObjectType int32
 
 const (
-	TMPing_ptPING TMPing_PingType = 0
-	TMPing_ptPONG TMPing_PingType = 1
+	TMGetObjectByHash_otUNKNOWN          TMGetObjectByHash_ObjectType = 0
+	TMGetObjectByHash_otLEDGER           TMGetObjectByHash_ObjectType = 1
+	TMGetObjectByHash_otTRANSACTION      TMGetObjectByHash_ObjectType = 2
+	TMGetObjectByHash_otTRANSACTION_NODE TMGetObjectByHash_ObjectType = 3
+	TMGetObjectByHash_otSTATE_NODE       TMGetObjectByHash_ObjectType = 4
+	TMGetObjectByHash_otCAS_OBJECT       TMGetObjectByHash_ObjectType = 5
+	TMGetObjectByHash_otFETCH_PACK       TMGetObjectByHash_ObjectType = 6
+	TMGetObjectByHash_otTRANSACTIONS     TMGetObjectByHash_ObjectType = 7
 )
 
-// Enum value maps for TMPing_PingType.
+// Enum value maps for TMGetObjectByHash_ObjectType.
 var (
-	TMPing_PingType_name = map[int32]string{
+	TMGetObjectByHash_ObjectType_name = map[int32]string{
+		0: "otUNKNOWN",
+		1: "otLEDGER",
+		2: "otTRANSACTION",
+		3: "otTRANSACTION_NODE",
+		4: "otSTATE_NODE",
+		5: "otCAS_OBJECT",
+		6: "otFETCH_PACK",
+		7: "otTRANSACTIONS",
+	}
+	TMGetObjectByHash_ObjectType_value = map[string]int32{
+		"otUNKNOWN":          0,
+		"otLEDGER":           1,
+		"otTRANSACTION":      2,
+		"otTRANSACTION_NODE": 3,
+		"otSTATE_NODE":       4,
+		"otCAS_OBJECT":       5,
+		"otFETCH_PACK":       6,
+		"otTRANSACTIONS":     7,
+	}
+)
+
+func (x TMGetObjectByHash_ObjectType) Enum() *TMGetObjectByHash_ObjectType {
+	p := new(TMGetObjectByHash_ObjectType)
+	*p = x
+	return p
+}
+
+func (x TMGetObjectByHash_ObjectType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TMGetObjectByHash_ObjectType) Descriptor() protoreflect.EnumDescriptor {
+	return file_internal_peermanagement_proto_xrpl_proto_enumTypes[10].Descriptor()
+}
+
+func (TMGetObjectByHash_ObjectType) Type() protoreflect.EnumType {
+	return &file_internal_peermanagement_proto_xrpl_proto_enumTypes[10]
+}
+
+func (x TMGetObjectByHash_ObjectType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Do not use.
+func (x *TMGetObjectByHash_ObjectType) UnmarshalJSON(b []byte) error {
+	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
+	if err != nil {
+		return err
+	}
+	*x = TMGetObjectByHash_ObjectType(num)
+	return nil
+}
+
+// Deprecated: Use TMGetObjectByHash_ObjectType.Descriptor instead.
+func (TMGetObjectByHash_ObjectType) EnumDescriptor() ([]byte, []int) {
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{18, 0}
+}
+
+type TMPingPingType int32
+
+const (
+	TMPing_ptPING TMPingPingType = 0 // we want a reply
+	TMPing_ptPONG TMPingPingType = 1 // this is a reply
+)
+
+// Enum value maps for TMPingPingType.
+var (
+	TMPingPingType_name = map[int32]string{
 		0: "ptPING",
 		1: "ptPONG",
 	}
-	TMPing_PingType_value = map[string]int32{
+	TMPingPingType_value = map[string]int32{
 		"ptPING": 0,
 		"ptPONG": 1,
 	}
 )
 
-func (x TMPing_PingType) Enum() *TMPing_PingType {
-	p := new(TMPing_PingType)
+func (x TMPingPingType) Enum() *TMPingPingType {
+	p := new(TMPingPingType)
 	*p = x
 	return p
 }
 
-func (x TMPing_PingType) String() string {
+func (x TMPingPingType) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (TMPing_PingType) Descriptor() protoreflect.EnumDescriptor {
+func (TMPingPingType) Descriptor() protoreflect.EnumDescriptor {
 	return file_internal_peermanagement_proto_xrpl_proto_enumTypes[11].Descriptor()
 }
 
-func (TMPing_PingType) Type() protoreflect.EnumType {
+func (TMPingPingType) Type() protoreflect.EnumType {
 	return &file_internal_peermanagement_proto_xrpl_proto_enumTypes[11]
 }
 
-func (x TMPing_PingType) Number() protoreflect.EnumNumber {
+func (x TMPingPingType) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use TMPing_PingType.Descriptor instead.
-func (TMPing_PingType) EnumDescriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{21, 0}
+// Deprecated: Do not use.
+func (x *TMPingPingType) UnmarshalJSON(b []byte) error {
+	num, err := protoimpl.X.UnmarshalJSONEnum(x.Descriptor(), b)
+	if err != nil {
+		return err
+	}
+	*x = TMPingPingType(num)
+	return nil
 }
 
-// Provides the current ephemeral key for a validator
+// Deprecated: Use TMPingPingType.Descriptor instead.
+func (TMPingPingType) EnumDescriptor() ([]byte, []int) {
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{22, 0}
+}
+
+// Provides the current ephemeral key for a validator.
 type TMManifest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Stobject      []byte                 `protobuf:"bytes,1,opt,name=stobject,proto3,oneof" json:"stobject,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A Manifest object in the XRPL serialization format.
+	Stobject      []byte `protobuf:"bytes,1,req,name=stobject" json:"stobject,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -772,9 +864,11 @@ func (x *TMManifest) GetStobject() []byte {
 
 type TMManifests struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	List  []*TMManifest          `protobuf:"bytes,1,rep,name=list,proto3" json:"list,omitempty"`
+	List  []*TMManifest          `protobuf:"bytes,1,rep,name=list" json:"list,omitempty"`
+	// The manifests sent when a peer first connects to another peer are `history`.
+	//
 	// Deprecated: Marked as deprecated in internal/peermanagement/proto/xrpl.proto.
-	History       bool `protobuf:"varint,2,opt,name=history,proto3" json:"history,omitempty"`
+	History       *bool `protobuf:"varint,2,opt,name=history" json:"history,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -818,20 +912,20 @@ func (x *TMManifests) GetList() []*TMManifest {
 
 // Deprecated: Marked as deprecated in internal/peermanagement/proto/xrpl.proto.
 func (x *TMManifests) GetHistory() bool {
-	if x != nil {
-		return x.History
+	if x != nil && x.History != nil {
+		return *x.History
 	}
 	return false
 }
 
-// Cluster node status
+// The status of a node in our cluster
 type TMClusterNode struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	PublicKey     *string                `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3,oneof" json:"public_key,omitempty"`
-	ReportTime    *uint32                `protobuf:"varint,2,opt,name=report_time,json=reportTime,proto3,oneof" json:"report_time,omitempty"`
-	NodeLoad      *uint32                `protobuf:"varint,3,opt,name=node_load,json=nodeLoad,proto3,oneof" json:"node_load,omitempty"`
-	NodeName      string                 `protobuf:"bytes,4,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
-	Address       string                 `protobuf:"bytes,5,opt,name=address,proto3" json:"address,omitempty"`
+	PublicKey     *string                `protobuf:"bytes,1,req,name=publicKey" json:"publicKey,omitempty"`
+	ReportTime    *uint32                `protobuf:"varint,2,req,name=reportTime" json:"reportTime,omitempty"`
+	NodeLoad      *uint32                `protobuf:"varint,3,req,name=nodeLoad" json:"nodeLoad,omitempty"`
+	NodeName      *string                `protobuf:"bytes,4,opt,name=nodeName" json:"nodeName,omitempty"`
+	Address       *string                `protobuf:"bytes,5,opt,name=address" json:"address,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -888,25 +982,25 @@ func (x *TMClusterNode) GetNodeLoad() uint32 {
 }
 
 func (x *TMClusterNode) GetNodeName() string {
-	if x != nil {
-		return x.NodeName
+	if x != nil && x.NodeName != nil {
+		return *x.NodeName
 	}
 	return ""
 }
 
 func (x *TMClusterNode) GetAddress() string {
-	if x != nil {
-		return x.Address
+	if x != nil && x.Address != nil {
+		return *x.Address
 	}
 	return ""
 }
 
-// Load sources
+// Sources that are placing load on the server
 type TMLoadSource struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          *string                `protobuf:"bytes,1,opt,name=name,proto3,oneof" json:"name,omitempty"`
-	Cost          *uint32                `protobuf:"varint,2,opt,name=cost,proto3,oneof" json:"cost,omitempty"`
-	Count         uint32                 `protobuf:"varint,3,opt,name=count,proto3" json:"count,omitempty"`
+	Name          *string                `protobuf:"bytes,1,req,name=name" json:"name,omitempty"`
+	Cost          *uint32                `protobuf:"varint,2,req,name=cost" json:"cost,omitempty"`
+	Count         *uint32                `protobuf:"varint,3,opt,name=count" json:"count,omitempty"` // number of connections
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -956,17 +1050,17 @@ func (x *TMLoadSource) GetCost() uint32 {
 }
 
 func (x *TMLoadSource) GetCount() uint32 {
-	if x != nil {
-		return x.Count
+	if x != nil && x.Count != nil {
+		return *x.Count
 	}
 	return 0
 }
 
-// Cluster status
+// The status of all nodes in the cluster
 type TMCluster struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	ClusterNodes  []*TMClusterNode       `protobuf:"bytes,1,rep,name=cluster_nodes,json=clusterNodes,proto3" json:"cluster_nodes,omitempty"`
-	LoadSources   []*TMLoadSource        `protobuf:"bytes,2,rep,name=load_sources,json=loadSources,proto3" json:"load_sources,omitempty"`
+	ClusterNodes  []*TMClusterNode       `protobuf:"bytes,1,rep,name=clusterNodes" json:"clusterNodes,omitempty"`
+	LoadSources   []*TMLoadSource        `protobuf:"bytes,2,rep,name=loadSources" json:"loadSources,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1015,17 +1109,64 @@ func (x *TMCluster) GetLoadSources() []*TMLoadSource {
 	return nil
 }
 
-// Public key
+// Node public key
+type TMLink struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Deprecated: Marked as deprecated in internal/peermanagement/proto/xrpl.proto.
+	NodePubKey    []byte `protobuf:"bytes,1,req,name=nodePubKey" json:"nodePubKey,omitempty"` // node public key
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TMLink) Reset() {
+	*x = TMLink{}
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TMLink) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TMLink) ProtoMessage() {}
+
+func (x *TMLink) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TMLink.ProtoReflect.Descriptor instead.
+func (*TMLink) Descriptor() ([]byte, []int) {
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{5}
+}
+
+// Deprecated: Marked as deprecated in internal/peermanagement/proto/xrpl.proto.
+func (x *TMLink) GetNodePubKey() []byte {
+	if x != nil {
+		return x.NodePubKey
+	}
+	return nil
+}
+
+// Peer public key
 type TMPublicKey struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	PublicKey     []byte                 `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3,oneof" json:"public_key,omitempty"`
+	PublicKey     []byte                 `protobuf:"bytes,1,req,name=publicKey" json:"publicKey,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMPublicKey) Reset() {
 	*x = TMPublicKey{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[5]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1037,7 +1178,7 @@ func (x *TMPublicKey) String() string {
 func (*TMPublicKey) ProtoMessage() {}
 
 func (x *TMPublicKey) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[5]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1050,7 +1191,7 @@ func (x *TMPublicKey) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMPublicKey.ProtoReflect.Descriptor instead.
 func (*TMPublicKey) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{5}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *TMPublicKey) GetPublicKey() []byte {
@@ -1062,17 +1203,17 @@ func (x *TMPublicKey) GetPublicKey() []byte {
 
 type TMTransaction struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
-	RawTransaction   []byte                 `protobuf:"bytes,1,opt,name=raw_transaction,json=rawTransaction,proto3,oneof" json:"raw_transaction,omitempty"`
-	Status           *TransactionStatus     `protobuf:"varint,2,opt,name=status,proto3,enum=protocol.TransactionStatus,oneof" json:"status,omitempty"`
-	ReceiveTimestamp uint64                 `protobuf:"varint,3,opt,name=receive_timestamp,json=receiveTimestamp,proto3" json:"receive_timestamp,omitempty"`
-	Deferred         bool                   `protobuf:"varint,4,opt,name=deferred,proto3" json:"deferred,omitempty"`
+	RawTransaction   []byte                 `protobuf:"bytes,1,req,name=rawTransaction" json:"rawTransaction,omitempty"`
+	Status           *TransactionStatus     `protobuf:"varint,2,req,name=status,enum=protocol.TransactionStatus" json:"status,omitempty"`
+	ReceiveTimestamp *uint64                `protobuf:"varint,3,opt,name=receiveTimestamp" json:"receiveTimestamp,omitempty"`
+	Deferred         *bool                  `protobuf:"varint,4,opt,name=deferred" json:"deferred,omitempty"` // not applied to open ledger
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
 
 func (x *TMTransaction) Reset() {
 	*x = TMTransaction{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[6]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1084,7 +1225,7 @@ func (x *TMTransaction) String() string {
 func (*TMTransaction) ProtoMessage() {}
 
 func (x *TMTransaction) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[6]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1097,7 +1238,7 @@ func (x *TMTransaction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMTransaction.ProtoReflect.Descriptor instead.
 func (*TMTransaction) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{6}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *TMTransaction) GetRawTransaction() []byte {
@@ -1111,33 +1252,33 @@ func (x *TMTransaction) GetStatus() TransactionStatus {
 	if x != nil && x.Status != nil {
 		return *x.Status
 	}
-	return TransactionStatus_tsUNKNOWN
+	return TransactionStatus_tsNEW
 }
 
 func (x *TMTransaction) GetReceiveTimestamp() uint64 {
-	if x != nil {
-		return x.ReceiveTimestamp
+	if x != nil && x.ReceiveTimestamp != nil {
+		return *x.ReceiveTimestamp
 	}
 	return 0
 }
 
 func (x *TMTransaction) GetDeferred() bool {
-	if x != nil {
-		return x.Deferred
+	if x != nil && x.Deferred != nil {
+		return *x.Deferred
 	}
 	return false
 }
 
 type TMTransactions struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Transactions  []*TMTransaction       `protobuf:"bytes,1,rep,name=transactions,proto3" json:"transactions,omitempty"`
+	Transactions  []*TMTransaction       `protobuf:"bytes,1,rep,name=transactions" json:"transactions,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMTransactions) Reset() {
 	*x = TMTransactions{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[7]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1149,7 +1290,7 @@ func (x *TMTransactions) String() string {
 func (*TMTransactions) ProtoMessage() {}
 
 func (x *TMTransactions) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[7]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1162,7 +1303,7 @@ func (x *TMTransactions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMTransactions.ProtoReflect.Descriptor instead.
 func (*TMTransactions) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{7}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *TMTransactions) GetTransactions() []*TMTransaction {
@@ -1174,21 +1315,21 @@ func (x *TMTransactions) GetTransactions() []*TMTransaction {
 
 type TMStatusChange struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
-	NewStatus          NodeStatus             `protobuf:"varint,1,opt,name=new_status,json=newStatus,proto3,enum=protocol.NodeStatus" json:"new_status,omitempty"`
-	NewEvent           NodeEvent              `protobuf:"varint,2,opt,name=new_event,json=newEvent,proto3,enum=protocol.NodeEvent" json:"new_event,omitempty"`
-	LedgerSeq          uint32                 `protobuf:"varint,3,opt,name=ledger_seq,json=ledgerSeq,proto3" json:"ledger_seq,omitempty"`
-	LedgerHash         []byte                 `protobuf:"bytes,4,opt,name=ledger_hash,json=ledgerHash,proto3" json:"ledger_hash,omitempty"`
-	LedgerHashPrevious []byte                 `protobuf:"bytes,5,opt,name=ledger_hash_previous,json=ledgerHashPrevious,proto3" json:"ledger_hash_previous,omitempty"`
-	NetworkTime        uint64                 `protobuf:"varint,6,opt,name=network_time,json=networkTime,proto3" json:"network_time,omitempty"`
-	FirstSeq           *uint32                `protobuf:"varint,7,opt,name=first_seq,json=firstSeq,proto3,oneof" json:"first_seq,omitempty"`
-	LastSeq            *uint32                `protobuf:"varint,8,opt,name=last_seq,json=lastSeq,proto3,oneof" json:"last_seq,omitempty"`
+	NewStatus          *NodeStatus            `protobuf:"varint,1,opt,name=newStatus,enum=protocol.NodeStatus" json:"newStatus,omitempty"`
+	NewEvent           *NodeEvent             `protobuf:"varint,2,opt,name=newEvent,enum=protocol.NodeEvent" json:"newEvent,omitempty"`
+	LedgerSeq          *uint32                `protobuf:"varint,3,opt,name=ledgerSeq" json:"ledgerSeq,omitempty"`
+	LedgerHash         []byte                 `protobuf:"bytes,4,opt,name=ledgerHash" json:"ledgerHash,omitempty"`
+	LedgerHashPrevious []byte                 `protobuf:"bytes,5,opt,name=ledgerHashPrevious" json:"ledgerHashPrevious,omitempty"`
+	NetworkTime        *uint64                `protobuf:"varint,6,opt,name=networkTime" json:"networkTime,omitempty"`
+	FirstSeq           *uint32                `protobuf:"varint,7,opt,name=firstSeq" json:"firstSeq,omitempty"`
+	LastSeq            *uint32                `protobuf:"varint,8,opt,name=lastSeq" json:"lastSeq,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
 
 func (x *TMStatusChange) Reset() {
 	*x = TMStatusChange{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[8]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1200,7 +1341,7 @@ func (x *TMStatusChange) String() string {
 func (*TMStatusChange) ProtoMessage() {}
 
 func (x *TMStatusChange) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[8]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1213,26 +1354,26 @@ func (x *TMStatusChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMStatusChange.ProtoReflect.Descriptor instead.
 func (*TMStatusChange) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{8}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *TMStatusChange) GetNewStatus() NodeStatus {
-	if x != nil {
-		return x.NewStatus
+	if x != nil && x.NewStatus != nil {
+		return *x.NewStatus
 	}
-	return NodeStatus_nsUNKNOWN
+	return NodeStatus_nsCONNECTING
 }
 
 func (x *TMStatusChange) GetNewEvent() NodeEvent {
-	if x != nil {
-		return x.NewEvent
+	if x != nil && x.NewEvent != nil {
+		return *x.NewEvent
 	}
-	return NodeEvent_neUNKNOWN
+	return NodeEvent_neCLOSING_LEDGER
 }
 
 func (x *TMStatusChange) GetLedgerSeq() uint32 {
-	if x != nil {
-		return x.LedgerSeq
+	if x != nil && x.LedgerSeq != nil {
+		return *x.LedgerSeq
 	}
 	return 0
 }
@@ -1252,8 +1393,8 @@ func (x *TMStatusChange) GetLedgerHashPrevious() []byte {
 }
 
 func (x *TMStatusChange) GetNetworkTime() uint64 {
-	if x != nil {
-		return x.NetworkTime
+	if x != nil && x.NetworkTime != nil {
+		return *x.NetworkTime
 	}
 	return 0
 }
@@ -1272,28 +1413,32 @@ func (x *TMStatusChange) GetLastSeq() uint32 {
 	return 0
 }
 
-// Ledger proposal
+// Announce to the network our position on a closing ledger
 type TMProposeSet struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	ProposeSeq     *uint32                `protobuf:"varint,1,opt,name=propose_seq,json=proposeSeq,proto3,oneof" json:"propose_seq,omitempty"`
-	CurrentTxHash  []byte                 `protobuf:"bytes,2,opt,name=current_tx_hash,json=currentTxHash,proto3,oneof" json:"current_tx_hash,omitempty"`
-	NodePubKey     []byte                 `protobuf:"bytes,3,opt,name=node_pub_key,json=nodePubKey,proto3,oneof" json:"node_pub_key,omitempty"`
-	CloseTime      *uint32                `protobuf:"varint,4,opt,name=close_time,json=closeTime,proto3,oneof" json:"close_time,omitempty"`
-	Signature      []byte                 `protobuf:"bytes,5,opt,name=signature,proto3,oneof" json:"signature,omitempty"`
-	PreviousLedger []byte                 `protobuf:"bytes,6,opt,name=previous_ledger,json=previousLedger,proto3,oneof" json:"previous_ledger,omitempty"`
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	ProposeSeq          *uint32                `protobuf:"varint,1,req,name=proposeSeq" json:"proposeSeq,omitempty"`
+	CurrentTxHash       []byte                 `protobuf:"bytes,2,req,name=currentTxHash" json:"currentTxHash,omitempty"` // the hash of the ledger we are proposing
+	NodePubKey          []byte                 `protobuf:"bytes,3,req,name=nodePubKey" json:"nodePubKey,omitempty"`
+	CloseTime           *uint32                `protobuf:"varint,4,req,name=closeTime" json:"closeTime,omitempty"`
+	Signature           []byte                 `protobuf:"bytes,5,req,name=signature" json:"signature,omitempty"` // signature of above fields
+	Previousledger      []byte                 `protobuf:"bytes,6,req,name=previousledger" json:"previousledger,omitempty"`
+	AddedTransactions   [][]byte               `protobuf:"bytes,10,rep,name=addedTransactions" json:"addedTransactions,omitempty"`     // not required if number is large
+	RemovedTransactions [][]byte               `protobuf:"bytes,11,rep,name=removedTransactions" json:"removedTransactions,omitempty"` // not required if number is large
+	// node vouches signature is correct
+	//
 	// Deprecated: Marked as deprecated in internal/peermanagement/proto/xrpl.proto.
-	CheckedSignature    bool     `protobuf:"varint,7,opt,name=checked_signature,json=checkedSignature,proto3" json:"checked_signature,omitempty"`
-	AddedTransactions   [][]byte `protobuf:"bytes,10,rep,name=added_transactions,json=addedTransactions,proto3" json:"added_transactions,omitempty"`
-	RemovedTransactions [][]byte `protobuf:"bytes,11,rep,name=removed_transactions,json=removedTransactions,proto3" json:"removed_transactions,omitempty"`
+	CheckedSignature *bool `protobuf:"varint,7,opt,name=checkedSignature" json:"checkedSignature,omitempty"`
+	// Number of hops traveled
+	//
 	// Deprecated: Marked as deprecated in internal/peermanagement/proto/xrpl.proto.
-	Hops          uint32 `protobuf:"varint,12,opt,name=hops,proto3" json:"hops,omitempty"`
+	Hops          *uint32 `protobuf:"varint,12,opt,name=hops" json:"hops,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMProposeSet) Reset() {
 	*x = TMProposeSet{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[9]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1305,7 +1450,7 @@ func (x *TMProposeSet) String() string {
 func (*TMProposeSet) ProtoMessage() {}
 
 func (x *TMProposeSet) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[9]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1318,7 +1463,7 @@ func (x *TMProposeSet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMProposeSet.ProtoReflect.Descriptor instead.
 func (*TMProposeSet) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{9}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *TMProposeSet) GetProposeSeq() uint32 {
@@ -1356,19 +1501,11 @@ func (x *TMProposeSet) GetSignature() []byte {
 	return nil
 }
 
-func (x *TMProposeSet) GetPreviousLedger() []byte {
+func (x *TMProposeSet) GetPreviousledger() []byte {
 	if x != nil {
-		return x.PreviousLedger
+		return x.Previousledger
 	}
 	return nil
-}
-
-// Deprecated: Marked as deprecated in internal/peermanagement/proto/xrpl.proto.
-func (x *TMProposeSet) GetCheckedSignature() bool {
-	if x != nil {
-		return x.CheckedSignature
-	}
-	return false
 }
 
 func (x *TMProposeSet) GetAddedTransactions() [][]byte {
@@ -1386,24 +1523,32 @@ func (x *TMProposeSet) GetRemovedTransactions() [][]byte {
 }
 
 // Deprecated: Marked as deprecated in internal/peermanagement/proto/xrpl.proto.
+func (x *TMProposeSet) GetCheckedSignature() bool {
+	if x != nil && x.CheckedSignature != nil {
+		return *x.CheckedSignature
+	}
+	return false
+}
+
+// Deprecated: Marked as deprecated in internal/peermanagement/proto/xrpl.proto.
 func (x *TMProposeSet) GetHops() uint32 {
-	if x != nil {
-		return x.Hops
+	if x != nil && x.Hops != nil {
+		return *x.Hops
 	}
 	return 0
 }
 
 type TMHaveTransactionSet struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Status        *TxSetStatus           `protobuf:"varint,1,opt,name=status,proto3,enum=protocol.TxSetStatus,oneof" json:"status,omitempty"`
-	Hash          []byte                 `protobuf:"bytes,2,opt,name=hash,proto3,oneof" json:"hash,omitempty"`
+	Status        *TxSetStatus           `protobuf:"varint,1,req,name=status,enum=protocol.TxSetStatus" json:"status,omitempty"`
+	Hash          []byte                 `protobuf:"bytes,2,req,name=hash" json:"hash,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMHaveTransactionSet) Reset() {
 	*x = TMHaveTransactionSet{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[10]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1415,7 +1560,7 @@ func (x *TMHaveTransactionSet) String() string {
 func (*TMHaveTransactionSet) ProtoMessage() {}
 
 func (x *TMHaveTransactionSet) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[10]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1428,14 +1573,14 @@ func (x *TMHaveTransactionSet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMHaveTransactionSet.ProtoReflect.Descriptor instead.
 func (*TMHaveTransactionSet) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{10}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *TMHaveTransactionSet) GetStatus() TxSetStatus {
 	if x != nil && x.Status != nil {
 		return *x.Status
 	}
-	return TxSetStatus_tsUNKNOWN_SET
+	return TxSetStatus_tsHAVE
 }
 
 func (x *TMHaveTransactionSet) GetHash() []byte {
@@ -1445,20 +1590,20 @@ func (x *TMHaveTransactionSet) GetHash() []byte {
 	return nil
 }
 
-// Validator list
+// Validator list (UNL)
 type TMValidatorList struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Manifest      []byte                 `protobuf:"bytes,1,opt,name=manifest,proto3,oneof" json:"manifest,omitempty"`
-	Blob          []byte                 `protobuf:"bytes,2,opt,name=blob,proto3,oneof" json:"blob,omitempty"`
-	Signature     []byte                 `protobuf:"bytes,3,opt,name=signature,proto3,oneof" json:"signature,omitempty"`
-	Version       *uint32                `protobuf:"varint,4,opt,name=version,proto3,oneof" json:"version,omitempty"`
+	Manifest      []byte                 `protobuf:"bytes,1,req,name=manifest" json:"manifest,omitempty"`
+	Blob          []byte                 `protobuf:"bytes,2,req,name=blob" json:"blob,omitempty"`
+	Signature     []byte                 `protobuf:"bytes,3,req,name=signature" json:"signature,omitempty"`
+	Version       *uint32                `protobuf:"varint,4,req,name=version" json:"version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMValidatorList) Reset() {
 	*x = TMValidatorList{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[11]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1470,7 +1615,7 @@ func (x *TMValidatorList) String() string {
 func (*TMValidatorList) ProtoMessage() {}
 
 func (x *TMValidatorList) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[11]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1483,7 +1628,7 @@ func (x *TMValidatorList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMValidatorList.ProtoReflect.Descriptor instead.
 func (*TMValidatorList) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{11}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *TMValidatorList) GetManifest() []byte {
@@ -1514,19 +1659,19 @@ func (x *TMValidatorList) GetVersion() uint32 {
 	return 0
 }
 
-// Validator list v2
+// Validator List v2
 type ValidatorBlobInfo struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Manifest      []byte                 `protobuf:"bytes,1,opt,name=manifest,proto3" json:"manifest,omitempty"`
-	Blob          []byte                 `protobuf:"bytes,2,opt,name=blob,proto3,oneof" json:"blob,omitempty"`
-	Signature     []byte                 `protobuf:"bytes,3,opt,name=signature,proto3,oneof" json:"signature,omitempty"`
+	Manifest      []byte                 `protobuf:"bytes,1,opt,name=manifest" json:"manifest,omitempty"`
+	Blob          []byte                 `protobuf:"bytes,2,req,name=blob" json:"blob,omitempty"`
+	Signature     []byte                 `protobuf:"bytes,3,req,name=signature" json:"signature,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ValidatorBlobInfo) Reset() {
 	*x = ValidatorBlobInfo{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[12]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1538,7 +1683,7 @@ func (x *ValidatorBlobInfo) String() string {
 func (*ValidatorBlobInfo) ProtoMessage() {}
 
 func (x *ValidatorBlobInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[12]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1551,7 +1696,7 @@ func (x *ValidatorBlobInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValidatorBlobInfo.ProtoReflect.Descriptor instead.
 func (*ValidatorBlobInfo) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{12}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ValidatorBlobInfo) GetManifest() []byte {
@@ -1575,18 +1720,19 @@ func (x *ValidatorBlobInfo) GetSignature() []byte {
 	return nil
 }
 
+// Collection of Validator List v2 (UNL)
 type TMValidatorListCollection struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Version       *uint32                `protobuf:"varint,1,opt,name=version,proto3,oneof" json:"version,omitempty"`
-	Manifest      []byte                 `protobuf:"bytes,2,opt,name=manifest,proto3,oneof" json:"manifest,omitempty"`
-	Blobs         []*ValidatorBlobInfo   `protobuf:"bytes,3,rep,name=blobs,proto3" json:"blobs,omitempty"`
+	Version       *uint32                `protobuf:"varint,1,req,name=version" json:"version,omitempty"`
+	Manifest      []byte                 `protobuf:"bytes,2,req,name=manifest" json:"manifest,omitempty"`
+	Blobs         []*ValidatorBlobInfo   `protobuf:"bytes,3,rep,name=blobs" json:"blobs,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMValidatorListCollection) Reset() {
 	*x = TMValidatorListCollection{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[13]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1598,7 +1744,7 @@ func (x *TMValidatorListCollection) String() string {
 func (*TMValidatorListCollection) ProtoMessage() {}
 
 func (x *TMValidatorListCollection) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[13]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1611,7 +1757,7 @@ func (x *TMValidatorListCollection) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMValidatorListCollection.ProtoReflect.Descriptor instead.
 func (*TMValidatorListCollection) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{13}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *TMValidatorListCollection) GetVersion() uint32 {
@@ -1635,21 +1781,26 @@ func (x *TMValidatorListCollection) GetBlobs() []*ValidatorBlobInfo {
 	return nil
 }
 
-// Validation message
+// Used to sign a final closed ledger after reprocessing
 type TMValidation struct {
-	state      protoimpl.MessageState `protogen:"open.v1"`
-	Validation []byte                 `protobuf:"bytes,1,opt,name=validation,proto3,oneof" json:"validation,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The serialized validation
+	Validation []byte `protobuf:"bytes,1,req,name=validation" json:"validation,omitempty"`
+	// node vouches signature is correct
+	//
 	// Deprecated: Marked as deprecated in internal/peermanagement/proto/xrpl.proto.
-	CheckedSignature bool `protobuf:"varint,2,opt,name=checked_signature,json=checkedSignature,proto3" json:"checked_signature,omitempty"`
+	CheckedSignature *bool `protobuf:"varint,2,opt,name=checkedSignature" json:"checkedSignature,omitempty"`
+	// Number of hops traveled
+	//
 	// Deprecated: Marked as deprecated in internal/peermanagement/proto/xrpl.proto.
-	Hops          uint32 `protobuf:"varint,3,opt,name=hops,proto3" json:"hops,omitempty"`
+	Hops          *uint32 `protobuf:"varint,3,opt,name=hops" json:"hops,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMValidation) Reset() {
 	*x = TMValidation{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[14]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1661,7 +1812,7 @@ func (x *TMValidation) String() string {
 func (*TMValidation) ProtoMessage() {}
 
 func (x *TMValidation) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[14]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1674,7 +1825,7 @@ func (x *TMValidation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMValidation.ProtoReflect.Descriptor instead.
 func (*TMValidation) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{14}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *TMValidation) GetValidation() []byte {
@@ -1686,32 +1837,34 @@ func (x *TMValidation) GetValidation() []byte {
 
 // Deprecated: Marked as deprecated in internal/peermanagement/proto/xrpl.proto.
 func (x *TMValidation) GetCheckedSignature() bool {
-	if x != nil {
-		return x.CheckedSignature
+	if x != nil && x.CheckedSignature != nil {
+		return *x.CheckedSignature
 	}
 	return false
 }
 
 // Deprecated: Marked as deprecated in internal/peermanagement/proto/xrpl.proto.
 func (x *TMValidation) GetHops() uint32 {
-	if x != nil {
-		return x.Hops
+	if x != nil && x.Hops != nil {
+		return *x.Hops
 	}
 	return 0
 }
 
-// Endpoints for peer discovery
+// An array of Endpoint messages
 type TMEndpoints struct {
-	state         protoimpl.MessageState      `protogen:"open.v1"`
-	Version       *uint32                     `protobuf:"varint,1,opt,name=version,proto3,oneof" json:"version,omitempty"`
-	EndpointsV2   []*TMEndpoints_TMEndpointv2 `protobuf:"bytes,3,rep,name=endpoints_v2,json=endpointsV2,proto3" json:"endpoints_v2,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// This field is used to allow the TMEndpoints message format to be
+	// modified as necessary in the future.
+	Version       *uint32                     `protobuf:"varint,1,req,name=version" json:"version,omitempty"`
+	EndpointsV2   []*TMEndpoints_TMEndpointv2 `protobuf:"bytes,3,rep,name=endpoints_v2,json=endpointsV2" json:"endpoints_v2,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMEndpoints) Reset() {
 	*x = TMEndpoints{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[15]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1723,7 +1876,7 @@ func (x *TMEndpoints) String() string {
 func (*TMEndpoints) ProtoMessage() {}
 
 func (x *TMEndpoints) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[15]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1736,7 +1889,7 @@ func (x *TMEndpoints) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMEndpoints.ProtoReflect.Descriptor instead.
 func (*TMEndpoints) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{15}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *TMEndpoints) GetVersion() uint32 {
@@ -1753,21 +1906,20 @@ func (x *TMEndpoints) GetEndpointsV2() []*TMEndpoints_TMEndpointv2 {
 	return nil
 }
 
-// Indexed object
 type TMIndexedObject struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Hash          []byte                 `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
-	NodeId        []byte                 `protobuf:"bytes,2,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`
-	Index         []byte                 `protobuf:"bytes,3,opt,name=index,proto3" json:"index,omitempty"`
-	Data          []byte                 `protobuf:"bytes,4,opt,name=data,proto3" json:"data,omitempty"`
-	LedgerSeq     uint32                 `protobuf:"varint,5,opt,name=ledger_seq,json=ledgerSeq,proto3" json:"ledger_seq,omitempty"`
+	Hash          []byte                 `protobuf:"bytes,1,opt,name=hash" json:"hash,omitempty"`
+	NodeID        []byte                 `protobuf:"bytes,2,opt,name=nodeID" json:"nodeID,omitempty"`
+	Index         []byte                 `protobuf:"bytes,3,opt,name=index" json:"index,omitempty"`
+	Data          []byte                 `protobuf:"bytes,4,opt,name=data" json:"data,omitempty"`
+	LedgerSeq     *uint32                `protobuf:"varint,5,opt,name=ledgerSeq" json:"ledgerSeq,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMIndexedObject) Reset() {
 	*x = TMIndexedObject{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[16]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1779,7 +1931,7 @@ func (x *TMIndexedObject) String() string {
 func (*TMIndexedObject) ProtoMessage() {}
 
 func (x *TMIndexedObject) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[16]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1792,7 +1944,7 @@ func (x *TMIndexedObject) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMIndexedObject.ProtoReflect.Descriptor instead.
 func (*TMIndexedObject) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{16}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *TMIndexedObject) GetHash() []byte {
@@ -1802,9 +1954,9 @@ func (x *TMIndexedObject) GetHash() []byte {
 	return nil
 }
 
-func (x *TMIndexedObject) GetNodeId() []byte {
+func (x *TMIndexedObject) GetNodeID() []byte {
 	if x != nil {
-		return x.NodeId
+		return x.NodeID
 	}
 	return nil
 }
@@ -1824,26 +1976,26 @@ func (x *TMIndexedObject) GetData() []byte {
 }
 
 func (x *TMIndexedObject) GetLedgerSeq() uint32 {
-	if x != nil {
-		return x.LedgerSeq
+	if x != nil && x.LedgerSeq != nil {
+		return *x.LedgerSeq
 	}
 	return 0
 }
 
 type TMGetObjectByHash struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Type          *ObjectType            `protobuf:"varint,1,opt,name=type,proto3,enum=protocol.ObjectType,oneof" json:"type,omitempty"`
-	Query         *bool                  `protobuf:"varint,2,opt,name=query,proto3,oneof" json:"query,omitempty"`
-	LedgerHash    []byte                 `protobuf:"bytes,4,opt,name=ledger_hash,json=ledgerHash,proto3" json:"ledger_hash,omitempty"`
-	Fat           bool                   `protobuf:"varint,5,opt,name=fat,proto3" json:"fat,omitempty"`
-	Objects       []*TMIndexedObject     `protobuf:"bytes,6,rep,name=objects,proto3" json:"objects,omitempty"`
+	state         protoimpl.MessageState        `protogen:"open.v1"`
+	Type          *TMGetObjectByHash_ObjectType `protobuf:"varint,1,req,name=type,enum=protocol.TMGetObjectByHash_ObjectType" json:"type,omitempty"`
+	Query         *bool                         `protobuf:"varint,2,req,name=query" json:"query,omitempty"`          // is this a query or a reply?
+	LedgerHash    []byte                        `protobuf:"bytes,4,opt,name=ledgerHash" json:"ledgerHash,omitempty"` // the hash of the ledger these queries are for
+	Fat           *bool                         `protobuf:"varint,5,opt,name=fat" json:"fat,omitempty"`              // return related nodes
+	Objects       []*TMIndexedObject            `protobuf:"bytes,6,rep,name=objects" json:"objects,omitempty"`       // the specific objects requested
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMGetObjectByHash) Reset() {
 	*x = TMGetObjectByHash{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[17]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1855,7 +2007,7 @@ func (x *TMGetObjectByHash) String() string {
 func (*TMGetObjectByHash) ProtoMessage() {}
 
 func (x *TMGetObjectByHash) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[17]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1868,14 +2020,14 @@ func (x *TMGetObjectByHash) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMGetObjectByHash.ProtoReflect.Descriptor instead.
 func (*TMGetObjectByHash) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{17}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{18}
 }
 
-func (x *TMGetObjectByHash) GetType() ObjectType {
+func (x *TMGetObjectByHash) GetType() TMGetObjectByHash_ObjectType {
 	if x != nil && x.Type != nil {
 		return *x.Type
 	}
-	return ObjectType_otUNKNOWN
+	return TMGetObjectByHash_otUNKNOWN
 }
 
 func (x *TMGetObjectByHash) GetQuery() bool {
@@ -1893,8 +2045,8 @@ func (x *TMGetObjectByHash) GetLedgerHash() []byte {
 }
 
 func (x *TMGetObjectByHash) GetFat() bool {
-	if x != nil {
-		return x.Fat
+	if x != nil && x.Fat != nil {
+		return *x.Fat
 	}
 	return false
 }
@@ -1906,18 +2058,17 @@ func (x *TMGetObjectByHash) GetObjects() []*TMIndexedObject {
 	return nil
 }
 
-// Ledger node
 type TMLedgerNode struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Nodedata      []byte                 `protobuf:"bytes,1,opt,name=nodedata,proto3,oneof" json:"nodedata,omitempty"`
-	Nodeid        []byte                 `protobuf:"bytes,2,opt,name=nodeid,proto3" json:"nodeid,omitempty"`
+	Nodedata      []byte                 `protobuf:"bytes,1,req,name=nodedata" json:"nodedata,omitempty"`
+	Nodeid        []byte                 `protobuf:"bytes,2,opt,name=nodeid" json:"nodeid,omitempty"` // missing for ledger base data
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMLedgerNode) Reset() {
 	*x = TMLedgerNode{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[18]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1929,7 +2080,7 @@ func (x *TMLedgerNode) String() string {
 func (*TMLedgerNode) ProtoMessage() {}
 
 func (x *TMLedgerNode) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[18]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1942,7 +2093,7 @@ func (x *TMLedgerNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMLedgerNode.ProtoReflect.Descriptor instead.
 func (*TMLedgerNode) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{18}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *TMLedgerNode) GetNodedata() []byte {
@@ -1961,21 +2112,21 @@ func (x *TMLedgerNode) GetNodeid() []byte {
 
 type TMGetLedger struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Itype         *TMLedgerInfoType      `protobuf:"varint,1,opt,name=itype,proto3,enum=protocol.TMLedgerInfoType,oneof" json:"itype,omitempty"`
-	Ltype         *TMLedgerType          `protobuf:"varint,2,opt,name=ltype,proto3,enum=protocol.TMLedgerType,oneof" json:"ltype,omitempty"`
-	LedgerHash    []byte                 `protobuf:"bytes,3,opt,name=ledger_hash,json=ledgerHash,proto3" json:"ledger_hash,omitempty"`
-	LedgerSeq     *uint32                `protobuf:"varint,4,opt,name=ledger_seq,json=ledgerSeq,proto3,oneof" json:"ledger_seq,omitempty"`
-	NodeIds       [][]byte               `protobuf:"bytes,5,rep,name=node_ids,json=nodeIds,proto3" json:"node_ids,omitempty"`
-	RequestCookie *uint64                `protobuf:"varint,6,opt,name=request_cookie,json=requestCookie,proto3,oneof" json:"request_cookie,omitempty"`
-	QueryType     *TMQueryType           `protobuf:"varint,7,opt,name=query_type,json=queryType,proto3,enum=protocol.TMQueryType,oneof" json:"query_type,omitempty"`
-	QueryDepth    *uint32                `protobuf:"varint,8,opt,name=query_depth,json=queryDepth,proto3,oneof" json:"query_depth,omitempty"`
+	Itype         *TMLedgerInfoType      `protobuf:"varint,1,req,name=itype,enum=protocol.TMLedgerInfoType" json:"itype,omitempty"`
+	Ltype         *TMLedgerType          `protobuf:"varint,2,opt,name=ltype,enum=protocol.TMLedgerType" json:"ltype,omitempty"`
+	LedgerHash    []byte                 `protobuf:"bytes,3,opt,name=ledgerHash" json:"ledgerHash,omitempty"` // Can also be the transaction set hash if liTS_CANDIDATE
+	LedgerSeq     *uint32                `protobuf:"varint,4,opt,name=ledgerSeq" json:"ledgerSeq,omitempty"`
+	NodeIDs       [][]byte               `protobuf:"bytes,5,rep,name=nodeIDs" json:"nodeIDs,omitempty"`
+	RequestCookie *uint64                `protobuf:"varint,6,opt,name=requestCookie" json:"requestCookie,omitempty"`
+	QueryType     *TMQueryType           `protobuf:"varint,7,opt,name=queryType,enum=protocol.TMQueryType" json:"queryType,omitempty"`
+	QueryDepth    *uint32                `protobuf:"varint,8,opt,name=queryDepth" json:"queryDepth,omitempty"` // How deep to go, number of extra levels
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMGetLedger) Reset() {
 	*x = TMGetLedger{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[19]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1987,7 +2138,7 @@ func (x *TMGetLedger) String() string {
 func (*TMGetLedger) ProtoMessage() {}
 
 func (x *TMGetLedger) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[19]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2000,7 +2151,7 @@ func (x *TMGetLedger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMGetLedger.ProtoReflect.Descriptor instead.
 func (*TMGetLedger) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{19}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *TMGetLedger) GetItype() TMLedgerInfoType {
@@ -2031,9 +2182,9 @@ func (x *TMGetLedger) GetLedgerSeq() uint32 {
 	return 0
 }
 
-func (x *TMGetLedger) GetNodeIds() [][]byte {
+func (x *TMGetLedger) GetNodeIDs() [][]byte {
 	if x != nil {
-		return x.NodeIds
+		return x.NodeIDs
 	}
 	return nil
 }
@@ -2061,19 +2212,19 @@ func (x *TMGetLedger) GetQueryDepth() uint32 {
 
 type TMLedgerData struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	LedgerHash    []byte                 `protobuf:"bytes,1,opt,name=ledger_hash,json=ledgerHash,proto3,oneof" json:"ledger_hash,omitempty"`
-	LedgerSeq     *uint32                `protobuf:"varint,2,opt,name=ledger_seq,json=ledgerSeq,proto3,oneof" json:"ledger_seq,omitempty"`
-	Type          *TMLedgerInfoType      `protobuf:"varint,3,opt,name=type,proto3,enum=protocol.TMLedgerInfoType,oneof" json:"type,omitempty"`
-	Nodes         []*TMLedgerNode        `protobuf:"bytes,4,rep,name=nodes,proto3" json:"nodes,omitempty"`
-	RequestCookie *uint32                `protobuf:"varint,5,opt,name=request_cookie,json=requestCookie,proto3,oneof" json:"request_cookie,omitempty"`
-	Error         TMReplyError           `protobuf:"varint,6,opt,name=error,proto3,enum=protocol.TMReplyError" json:"error,omitempty"`
+	LedgerHash    []byte                 `protobuf:"bytes,1,req,name=ledgerHash" json:"ledgerHash,omitempty"`
+	LedgerSeq     *uint32                `protobuf:"varint,2,req,name=ledgerSeq" json:"ledgerSeq,omitempty"`
+	Type          *TMLedgerInfoType      `protobuf:"varint,3,req,name=type,enum=protocol.TMLedgerInfoType" json:"type,omitempty"`
+	Nodes         []*TMLedgerNode        `protobuf:"bytes,4,rep,name=nodes" json:"nodes,omitempty"`
+	RequestCookie *uint32                `protobuf:"varint,5,opt,name=requestCookie" json:"requestCookie,omitempty"`
+	Error         *TMReplyError          `protobuf:"varint,6,opt,name=error,enum=protocol.TMReplyError" json:"error,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMLedgerData) Reset() {
 	*x = TMLedgerData{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[20]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2085,7 +2236,7 @@ func (x *TMLedgerData) String() string {
 func (*TMLedgerData) ProtoMessage() {}
 
 func (x *TMLedgerData) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[20]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2098,7 +2249,7 @@ func (x *TMLedgerData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMLedgerData.ProtoReflect.Descriptor instead.
 func (*TMLedgerData) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{20}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *TMLedgerData) GetLedgerHash() []byte {
@@ -2137,26 +2288,25 @@ func (x *TMLedgerData) GetRequestCookie() uint32 {
 }
 
 func (x *TMLedgerData) GetError() TMReplyError {
-	if x != nil {
-		return x.Error
+	if x != nil && x.Error != nil {
+		return *x.Error
 	}
-	return TMReplyError_reNO_ERROR
+	return TMReplyError_reNO_LEDGER
 }
 
-// Ping/Pong
 type TMPing struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Type          *TMPing_PingType       `protobuf:"varint,1,opt,name=type,proto3,enum=protocol.TMPing_PingType,oneof" json:"type,omitempty"`
-	Seq           *uint32                `protobuf:"varint,2,opt,name=seq,proto3,oneof" json:"seq,omitempty"`
-	PingTime      *uint64                `protobuf:"varint,3,opt,name=ping_time,json=pingTime,proto3,oneof" json:"ping_time,omitempty"`
-	NetTime       *uint64                `protobuf:"varint,4,opt,name=net_time,json=netTime,proto3,oneof" json:"net_time,omitempty"`
+	Type          *TMPingPingType        `protobuf:"varint,1,req,name=type,enum=protocol.TMPingPingType" json:"type,omitempty"`
+	Seq           *uint32                `protobuf:"varint,2,opt,name=seq" json:"seq,omitempty"`           // detect stale replies, ensure other side is reading
+	PingTime      *uint64                `protobuf:"varint,3,opt,name=pingTime" json:"pingTime,omitempty"` // know when we think we sent the ping
+	NetTime       *uint64                `protobuf:"varint,4,opt,name=netTime" json:"netTime,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMPing) Reset() {
 	*x = TMPing{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[21]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2168,7 +2318,7 @@ func (x *TMPing) String() string {
 func (*TMPing) ProtoMessage() {}
 
 func (x *TMPing) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[21]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2181,10 +2331,10 @@ func (x *TMPing) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMPing.ProtoReflect.Descriptor instead.
 func (*TMPing) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{21}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{22}
 }
 
-func (x *TMPing) GetType() TMPing_PingType {
+func (x *TMPing) GetType() TMPingPingType {
 	if x != nil && x.Type != nil {
 		return *x.Type
 	}
@@ -2212,19 +2362,18 @@ func (x *TMPing) GetNetTime() uint64 {
 	return 0
 }
 
-// Squelch for reduce-relay
 type TMSquelch struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
-	Squelch         *bool                  `protobuf:"varint,1,opt,name=squelch,proto3,oneof" json:"squelch,omitempty"`
-	ValidatorPubKey []byte                 `protobuf:"bytes,2,opt,name=validator_pub_key,json=validatorPubKey,proto3,oneof" json:"validator_pub_key,omitempty"`
-	SquelchDuration uint32                 `protobuf:"varint,3,opt,name=squelch_duration,json=squelchDuration,proto3" json:"squelch_duration,omitempty"`
+	Squelch         *bool                  `protobuf:"varint,1,req,name=squelch" json:"squelch,omitempty"`                 // squelch if true, otherwise unsquelch
+	ValidatorPubKey []byte                 `protobuf:"bytes,2,req,name=validatorPubKey" json:"validatorPubKey,omitempty"`  // validator's public key
+	SquelchDuration *uint32                `protobuf:"varint,3,opt,name=squelchDuration" json:"squelchDuration,omitempty"` // squelch duration in seconds
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
 
 func (x *TMSquelch) Reset() {
 	*x = TMSquelch{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[22]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2236,7 +2385,7 @@ func (x *TMSquelch) String() string {
 func (*TMSquelch) ProtoMessage() {}
 
 func (x *TMSquelch) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[22]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2249,7 +2398,7 @@ func (x *TMSquelch) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMSquelch.ProtoReflect.Descriptor instead.
 func (*TMSquelch) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{22}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *TMSquelch) GetSquelch() bool {
@@ -2267,25 +2416,24 @@ func (x *TMSquelch) GetValidatorPubKey() []byte {
 }
 
 func (x *TMSquelch) GetSquelchDuration() uint32 {
-	if x != nil {
-		return x.SquelchDuration
+	if x != nil && x.SquelchDuration != nil {
+		return *x.SquelchDuration
 	}
 	return 0
 }
 
-// Proof path request/response
 type TMProofPathRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Key           []byte                 `protobuf:"bytes,1,opt,name=key,proto3,oneof" json:"key,omitempty"`
-	LedgerHash    []byte                 `protobuf:"bytes,2,opt,name=ledger_hash,json=ledgerHash,proto3,oneof" json:"ledger_hash,omitempty"`
-	Type          *TMLedgerMapType       `protobuf:"varint,3,opt,name=type,proto3,enum=protocol.TMLedgerMapType,oneof" json:"type,omitempty"`
+	Key           []byte                 `protobuf:"bytes,1,req,name=key" json:"key,omitempty"`
+	LedgerHash    []byte                 `protobuf:"bytes,2,req,name=ledgerHash" json:"ledgerHash,omitempty"`
+	Type          *TMLedgerMapType       `protobuf:"varint,3,req,name=type,enum=protocol.TMLedgerMapType" json:"type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMProofPathRequest) Reset() {
 	*x = TMProofPathRequest{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[23]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2297,7 +2445,7 @@ func (x *TMProofPathRequest) String() string {
 func (*TMProofPathRequest) ProtoMessage() {}
 
 func (x *TMProofPathRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[23]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2310,7 +2458,7 @@ func (x *TMProofPathRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMProofPathRequest.ProtoReflect.Descriptor instead.
 func (*TMProofPathRequest) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{23}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *TMProofPathRequest) GetKey() []byte {
@@ -2331,24 +2479,24 @@ func (x *TMProofPathRequest) GetType() TMLedgerMapType {
 	if x != nil && x.Type != nil {
 		return *x.Type
 	}
-	return TMLedgerMapType_lmUNKNOWN
+	return TMLedgerMapType_lmTRANSACTION
 }
 
 type TMProofPathResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Key           []byte                 `protobuf:"bytes,1,opt,name=key,proto3,oneof" json:"key,omitempty"`
-	LedgerHash    []byte                 `protobuf:"bytes,2,opt,name=ledger_hash,json=ledgerHash,proto3,oneof" json:"ledger_hash,omitempty"`
-	Type          *TMLedgerMapType       `protobuf:"varint,3,opt,name=type,proto3,enum=protocol.TMLedgerMapType,oneof" json:"type,omitempty"`
-	LedgerHeader  []byte                 `protobuf:"bytes,4,opt,name=ledger_header,json=ledgerHeader,proto3" json:"ledger_header,omitempty"`
-	Path          [][]byte               `protobuf:"bytes,5,rep,name=path,proto3" json:"path,omitempty"`
-	Error         TMReplyError           `protobuf:"varint,6,opt,name=error,proto3,enum=protocol.TMReplyError" json:"error,omitempty"`
+	Key           []byte                 `protobuf:"bytes,1,req,name=key" json:"key,omitempty"`
+	LedgerHash    []byte                 `protobuf:"bytes,2,req,name=ledgerHash" json:"ledgerHash,omitempty"`
+	Type          *TMLedgerMapType       `protobuf:"varint,3,req,name=type,enum=protocol.TMLedgerMapType" json:"type,omitempty"`
+	LedgerHeader  []byte                 `protobuf:"bytes,4,opt,name=ledgerHeader" json:"ledgerHeader,omitempty"`
+	Path          [][]byte               `protobuf:"bytes,5,rep,name=path" json:"path,omitempty"`
+	Error         *TMReplyError          `protobuf:"varint,6,opt,name=error,enum=protocol.TMReplyError" json:"error,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMProofPathResponse) Reset() {
 	*x = TMProofPathResponse{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[24]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2360,7 +2508,7 @@ func (x *TMProofPathResponse) String() string {
 func (*TMProofPathResponse) ProtoMessage() {}
 
 func (x *TMProofPathResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[24]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2373,7 +2521,7 @@ func (x *TMProofPathResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMProofPathResponse.ProtoReflect.Descriptor instead.
 func (*TMProofPathResponse) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{24}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *TMProofPathResponse) GetKey() []byte {
@@ -2394,7 +2542,7 @@ func (x *TMProofPathResponse) GetType() TMLedgerMapType {
 	if x != nil && x.Type != nil {
 		return *x.Type
 	}
-	return TMLedgerMapType_lmUNKNOWN
+	return TMLedgerMapType_lmTRANSACTION
 }
 
 func (x *TMProofPathResponse) GetLedgerHeader() []byte {
@@ -2412,23 +2560,22 @@ func (x *TMProofPathResponse) GetPath() [][]byte {
 }
 
 func (x *TMProofPathResponse) GetError() TMReplyError {
-	if x != nil {
-		return x.Error
+	if x != nil && x.Error != nil {
+		return *x.Error
 	}
-	return TMReplyError_reNO_ERROR
+	return TMReplyError_reNO_LEDGER
 }
 
-// Replay delta for ledger sync
 type TMReplayDeltaRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	LedgerHash    []byte                 `protobuf:"bytes,1,opt,name=ledger_hash,json=ledgerHash,proto3,oneof" json:"ledger_hash,omitempty"`
+	LedgerHash    []byte                 `protobuf:"bytes,1,req,name=ledgerHash" json:"ledgerHash,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMReplayDeltaRequest) Reset() {
 	*x = TMReplayDeltaRequest{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[25]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2440,7 +2587,7 @@ func (x *TMReplayDeltaRequest) String() string {
 func (*TMReplayDeltaRequest) ProtoMessage() {}
 
 func (x *TMReplayDeltaRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[25]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2453,7 +2600,7 @@ func (x *TMReplayDeltaRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMReplayDeltaRequest.ProtoReflect.Descriptor instead.
 func (*TMReplayDeltaRequest) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{25}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *TMReplayDeltaRequest) GetLedgerHash() []byte {
@@ -2465,17 +2612,17 @@ func (x *TMReplayDeltaRequest) GetLedgerHash() []byte {
 
 type TMReplayDeltaResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	LedgerHash    []byte                 `protobuf:"bytes,1,opt,name=ledger_hash,json=ledgerHash,proto3,oneof" json:"ledger_hash,omitempty"`
-	LedgerHeader  []byte                 `protobuf:"bytes,2,opt,name=ledger_header,json=ledgerHeader,proto3" json:"ledger_header,omitempty"`
-	Transaction   [][]byte               `protobuf:"bytes,3,rep,name=transaction,proto3" json:"transaction,omitempty"`
-	Error         TMReplyError           `protobuf:"varint,4,opt,name=error,proto3,enum=protocol.TMReplyError" json:"error,omitempty"`
+	LedgerHash    []byte                 `protobuf:"bytes,1,req,name=ledgerHash" json:"ledgerHash,omitempty"`
+	LedgerHeader  []byte                 `protobuf:"bytes,2,opt,name=ledgerHeader" json:"ledgerHeader,omitempty"`
+	Transaction   [][]byte               `protobuf:"bytes,3,rep,name=transaction" json:"transaction,omitempty"`
+	Error         *TMReplyError          `protobuf:"varint,4,opt,name=error,enum=protocol.TMReplyError" json:"error,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMReplayDeltaResponse) Reset() {
 	*x = TMReplayDeltaResponse{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[26]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2487,7 +2634,7 @@ func (x *TMReplayDeltaResponse) String() string {
 func (*TMReplayDeltaResponse) ProtoMessage() {}
 
 func (x *TMReplayDeltaResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[26]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2500,7 +2647,7 @@ func (x *TMReplayDeltaResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMReplayDeltaResponse.ProtoReflect.Descriptor instead.
 func (*TMReplayDeltaResponse) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{26}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *TMReplayDeltaResponse) GetLedgerHash() []byte {
@@ -2525,23 +2672,22 @@ func (x *TMReplayDeltaResponse) GetTransaction() [][]byte {
 }
 
 func (x *TMReplayDeltaResponse) GetError() TMReplyError {
-	if x != nil {
-		return x.Error
+	if x != nil && x.Error != nil {
+		return *x.Error
 	}
-	return TMReplyError_reNO_ERROR
+	return TMReplyError_reNO_LEDGER
 }
 
-// Have transactions (reduce-relay)
 type TMHaveTransactions struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Hashes        [][]byte               `protobuf:"bytes,1,rep,name=hashes,proto3" json:"hashes,omitempty"`
+	Hashes        [][]byte               `protobuf:"bytes,1,rep,name=hashes" json:"hashes,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMHaveTransactions) Reset() {
 	*x = TMHaveTransactions{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[27]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2553,7 +2699,7 @@ func (x *TMHaveTransactions) String() string {
 func (*TMHaveTransactions) ProtoMessage() {}
 
 func (x *TMHaveTransactions) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[27]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2566,7 +2712,7 @@ func (x *TMHaveTransactions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMHaveTransactions.ProtoReflect.Descriptor instead.
 func (*TMHaveTransactions) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{27}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *TMHaveTransactions) GetHashes() [][]byte {
@@ -2576,17 +2722,19 @@ func (x *TMHaveTransactions) GetHashes() [][]byte {
 	return nil
 }
 
+// An update to the Endpoint type that uses a string
+// to represent endpoints, thus allowing ipv6 or ipv4 addresses
 type TMEndpoints_TMEndpointv2 struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Endpoint      *string                `protobuf:"bytes,1,opt,name=endpoint,proto3,oneof" json:"endpoint,omitempty"`
-	Hops          *uint32                `protobuf:"varint,2,opt,name=hops,proto3,oneof" json:"hops,omitempty"`
+	Endpoint      *string                `protobuf:"bytes,1,req,name=endpoint" json:"endpoint,omitempty"`
+	Hops          *uint32                `protobuf:"varint,2,req,name=hops" json:"hops,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TMEndpoints_TMEndpointv2) Reset() {
 	*x = TMEndpoints_TMEndpointv2{}
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[28]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2598,7 +2746,7 @@ func (x *TMEndpoints_TMEndpointv2) String() string {
 func (*TMEndpoints_TMEndpointv2) ProtoMessage() {}
 
 func (x *TMEndpoints_TMEndpointv2) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[28]
+	mi := &file_internal_peermanagement_proto_xrpl_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2611,7 +2759,7 @@ func (x *TMEndpoints_TMEndpointv2) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TMEndpoints_TMEndpointv2.ProtoReflect.Descriptor instead.
 func (*TMEndpoints_TMEndpointv2) Descriptor() ([]byte, []int) {
-	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{15, 0}
+	return file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP(), []int{16, 0}
 }
 
 func (x *TMEndpoints_TMEndpointv2) GetEndpoint() string {
@@ -2632,240 +2780,188 @@ var File_internal_peermanagement_proto_xrpl_proto protoreflect.FileDescriptor
 
 const file_internal_peermanagement_proto_xrpl_proto_rawDesc = "" +
 	"\n" +
-	"(internal/peermanagement/proto/xrpl.proto\x12\bprotocol\":\n" +
+	"(internal/peermanagement/proto/xrpl.proto\x12\bprotocol\"(\n" +
 	"\n" +
-	"TMManifest\x12\x1f\n" +
-	"\bstobject\x18\x01 \x01(\fH\x00R\bstobject\x88\x01\x01B\v\n" +
-	"\t_stobject\"U\n" +
+	"TMManifest\x12\x1a\n" +
+	"\bstobject\x18\x01 \x02(\fR\bstobject\"U\n" +
 	"\vTMManifests\x12(\n" +
 	"\x04list\x18\x01 \x03(\v2\x14.protocol.TMManifestR\x04list\x12\x1c\n" +
-	"\ahistory\x18\x02 \x01(\bB\x02\x18\x01R\ahistory\"\xdf\x01\n" +
-	"\rTMClusterNode\x12\"\n" +
+	"\ahistory\x18\x02 \x01(\bB\x02\x18\x01R\ahistory\"\x9f\x01\n" +
+	"\rTMClusterNode\x12\x1c\n" +
+	"\tpublicKey\x18\x01 \x02(\tR\tpublicKey\x12\x1e\n" +
 	"\n" +
-	"public_key\x18\x01 \x01(\tH\x00R\tpublicKey\x88\x01\x01\x12$\n" +
-	"\vreport_time\x18\x02 \x01(\rH\x01R\n" +
-	"reportTime\x88\x01\x01\x12 \n" +
-	"\tnode_load\x18\x03 \x01(\rH\x02R\bnodeLoad\x88\x01\x01\x12\x1b\n" +
-	"\tnode_name\x18\x04 \x01(\tR\bnodeName\x12\x18\n" +
-	"\aaddress\x18\x05 \x01(\tR\aaddressB\r\n" +
-	"\v_public_keyB\x0e\n" +
-	"\f_report_timeB\f\n" +
+	"reportTime\x18\x02 \x02(\rR\n" +
+	"reportTime\x12\x1a\n" +
+	"\bnodeLoad\x18\x03 \x02(\rR\bnodeLoad\x12\x1a\n" +
+	"\bnodeName\x18\x04 \x01(\tR\bnodeName\x12\x18\n" +
+	"\aaddress\x18\x05 \x01(\tR\aaddress\"L\n" +
+	"\fTMLoadSource\x12\x12\n" +
+	"\x04name\x18\x01 \x02(\tR\x04name\x12\x12\n" +
+	"\x04cost\x18\x02 \x02(\rR\x04cost\x12\x14\n" +
+	"\x05count\x18\x03 \x01(\rR\x05count\"\x82\x01\n" +
+	"\tTMCluster\x12;\n" +
+	"\fclusterNodes\x18\x01 \x03(\v2\x17.protocol.TMClusterNodeR\fclusterNodes\x128\n" +
+	"\vloadSources\x18\x02 \x03(\v2\x16.protocol.TMLoadSourceR\vloadSources\",\n" +
+	"\x06TMLink\x12\"\n" +
 	"\n" +
-	"_node_load\"h\n" +
-	"\fTMLoadSource\x12\x17\n" +
-	"\x04name\x18\x01 \x01(\tH\x00R\x04name\x88\x01\x01\x12\x17\n" +
-	"\x04cost\x18\x02 \x01(\rH\x01R\x04cost\x88\x01\x01\x12\x14\n" +
-	"\x05count\x18\x03 \x01(\rR\x05countB\a\n" +
-	"\x05_nameB\a\n" +
-	"\x05_cost\"\x84\x01\n" +
-	"\tTMCluster\x12<\n" +
-	"\rcluster_nodes\x18\x01 \x03(\v2\x17.protocol.TMClusterNodeR\fclusterNodes\x129\n" +
-	"\fload_sources\x18\x02 \x03(\v2\x16.protocol.TMLoadSourceR\vloadSources\"@\n" +
-	"\vTMPublicKey\x12\"\n" +
-	"\n" +
-	"public_key\x18\x01 \x01(\fH\x00R\tpublicKey\x88\x01\x01B\r\n" +
-	"\v_public_key\"\xdf\x01\n" +
-	"\rTMTransaction\x12,\n" +
-	"\x0fraw_transaction\x18\x01 \x01(\fH\x00R\x0erawTransaction\x88\x01\x01\x128\n" +
-	"\x06status\x18\x02 \x01(\x0e2\x1b.protocol.TransactionStatusH\x01R\x06status\x88\x01\x01\x12+\n" +
-	"\x11receive_timestamp\x18\x03 \x01(\x04R\x10receiveTimestamp\x12\x1a\n" +
-	"\bdeferred\x18\x04 \x01(\bR\bdeferredB\x12\n" +
-	"\x10_raw_transactionB\t\n" +
-	"\a_status\"M\n" +
+	"nodePubKey\x18\x01 \x02(\fB\x02\x18\x01R\n" +
+	"nodePubKey\"+\n" +
+	"\vTMPublicKey\x12\x1c\n" +
+	"\tpublicKey\x18\x01 \x02(\fR\tpublicKey\"\xb4\x01\n" +
+	"\rTMTransaction\x12&\n" +
+	"\x0erawTransaction\x18\x01 \x02(\fR\x0erawTransaction\x123\n" +
+	"\x06status\x18\x02 \x02(\x0e2\x1b.protocol.TransactionStatusR\x06status\x12*\n" +
+	"\x10receiveTimestamp\x18\x03 \x01(\x04R\x10receiveTimestamp\x12\x1a\n" +
+	"\bdeferred\x18\x04 \x01(\bR\bdeferred\"M\n" +
 	"\x0eTMTransactions\x12;\n" +
-	"\ftransactions\x18\x01 \x03(\v2\x17.protocol.TMTransactionR\ftransactions\"\xe9\x02\n" +
-	"\x0eTMStatusChange\x123\n" +
+	"\ftransactions\x18\x01 \x03(\v2\x17.protocol.TMTransactionR\ftransactions\"\xbb\x02\n" +
+	"\x0eTMStatusChange\x122\n" +
+	"\tnewStatus\x18\x01 \x01(\x0e2\x14.protocol.NodeStatusR\tnewStatus\x12/\n" +
+	"\bnewEvent\x18\x02 \x01(\x0e2\x13.protocol.NodeEventR\bnewEvent\x12\x1c\n" +
+	"\tledgerSeq\x18\x03 \x01(\rR\tledgerSeq\x12\x1e\n" +
 	"\n" +
-	"new_status\x18\x01 \x01(\x0e2\x14.protocol.NodeStatusR\tnewStatus\x120\n" +
-	"\tnew_event\x18\x02 \x01(\x0e2\x13.protocol.NodeEventR\bnewEvent\x12\x1d\n" +
+	"ledgerHash\x18\x04 \x01(\fR\n" +
+	"ledgerHash\x12.\n" +
+	"\x12ledgerHashPrevious\x18\x05 \x01(\fR\x12ledgerHashPrevious\x12 \n" +
+	"\vnetworkTime\x18\x06 \x01(\x04R\vnetworkTime\x12\x1a\n" +
+	"\bfirstSeq\x18\a \x01(\rR\bfirstSeq\x12\x18\n" +
+	"\alastSeq\x18\b \x01(\rR\alastSeq\"\x80\x03\n" +
+	"\fTMProposeSet\x12\x1e\n" +
 	"\n" +
-	"ledger_seq\x18\x03 \x01(\rR\tledgerSeq\x12\x1f\n" +
-	"\vledger_hash\x18\x04 \x01(\fR\n" +
-	"ledgerHash\x120\n" +
-	"\x14ledger_hash_previous\x18\x05 \x01(\fR\x12ledgerHashPrevious\x12!\n" +
-	"\fnetwork_time\x18\x06 \x01(\x04R\vnetworkTime\x12 \n" +
-	"\tfirst_seq\x18\a \x01(\rH\x00R\bfirstSeq\x88\x01\x01\x12\x1e\n" +
-	"\blast_seq\x18\b \x01(\rH\x01R\alastSeq\x88\x01\x01B\f\n" +
+	"proposeSeq\x18\x01 \x02(\rR\n" +
+	"proposeSeq\x12$\n" +
+	"\rcurrentTxHash\x18\x02 \x02(\fR\rcurrentTxHash\x12\x1e\n" +
 	"\n" +
-	"_first_seqB\v\n" +
-	"\t_last_seq\"\x8e\x04\n" +
-	"\fTMProposeSet\x12$\n" +
-	"\vpropose_seq\x18\x01 \x01(\rH\x00R\n" +
-	"proposeSeq\x88\x01\x01\x12+\n" +
-	"\x0fcurrent_tx_hash\x18\x02 \x01(\fH\x01R\rcurrentTxHash\x88\x01\x01\x12%\n" +
-	"\fnode_pub_key\x18\x03 \x01(\fH\x02R\n" +
-	"nodePubKey\x88\x01\x01\x12\"\n" +
-	"\n" +
-	"close_time\x18\x04 \x01(\rH\x03R\tcloseTime\x88\x01\x01\x12!\n" +
-	"\tsignature\x18\x05 \x01(\fH\x04R\tsignature\x88\x01\x01\x12,\n" +
-	"\x0fprevious_ledger\x18\x06 \x01(\fH\x05R\x0epreviousLedger\x88\x01\x01\x12/\n" +
-	"\x11checked_signature\x18\a \x01(\bB\x02\x18\x01R\x10checkedSignature\x12-\n" +
-	"\x12added_transactions\x18\n" +
-	" \x03(\fR\x11addedTransactions\x121\n" +
-	"\x14removed_transactions\x18\v \x03(\fR\x13removedTransactions\x12\x16\n" +
-	"\x04hops\x18\f \x01(\rB\x02\x18\x01R\x04hopsB\x0e\n" +
-	"\f_propose_seqB\x12\n" +
-	"\x10_current_tx_hashB\x0f\n" +
-	"\r_node_pub_keyB\r\n" +
-	"\v_close_timeB\f\n" +
-	"\n" +
-	"_signatureB\x12\n" +
-	"\x10_previous_ledger\"w\n" +
-	"\x14TMHaveTransactionSet\x122\n" +
-	"\x06status\x18\x01 \x01(\x0e2\x15.protocol.TxSetStatusH\x00R\x06status\x88\x01\x01\x12\x17\n" +
-	"\x04hash\x18\x02 \x01(\fH\x01R\x04hash\x88\x01\x01B\t\n" +
-	"\a_statusB\a\n" +
-	"\x05_hash\"\xbd\x01\n" +
-	"\x0fTMValidatorList\x12\x1f\n" +
-	"\bmanifest\x18\x01 \x01(\fH\x00R\bmanifest\x88\x01\x01\x12\x17\n" +
-	"\x04blob\x18\x02 \x01(\fH\x01R\x04blob\x88\x01\x01\x12!\n" +
-	"\tsignature\x18\x03 \x01(\fH\x02R\tsignature\x88\x01\x01\x12\x1d\n" +
-	"\aversion\x18\x04 \x01(\rH\x03R\aversion\x88\x01\x01B\v\n" +
-	"\t_manifestB\a\n" +
-	"\x05_blobB\f\n" +
-	"\n" +
-	"_signatureB\n" +
-	"\n" +
-	"\b_version\"\x82\x01\n" +
+	"nodePubKey\x18\x03 \x02(\fR\n" +
+	"nodePubKey\x12\x1c\n" +
+	"\tcloseTime\x18\x04 \x02(\rR\tcloseTime\x12\x1c\n" +
+	"\tsignature\x18\x05 \x02(\fR\tsignature\x12&\n" +
+	"\x0epreviousledger\x18\x06 \x02(\fR\x0epreviousledger\x12,\n" +
+	"\x11addedTransactions\x18\n" +
+	" \x03(\fR\x11addedTransactions\x120\n" +
+	"\x13removedTransactions\x18\v \x03(\fR\x13removedTransactions\x12.\n" +
+	"\x10checkedSignature\x18\a \x01(\bB\x02\x18\x01R\x10checkedSignature\x12\x16\n" +
+	"\x04hops\x18\f \x01(\rB\x02\x18\x01R\x04hops\"Y\n" +
+	"\x14TMHaveTransactionSet\x12-\n" +
+	"\x06status\x18\x01 \x02(\x0e2\x15.protocol.TxSetStatusR\x06status\x12\x12\n" +
+	"\x04hash\x18\x02 \x02(\fR\x04hash\"y\n" +
+	"\x0fTMValidatorList\x12\x1a\n" +
+	"\bmanifest\x18\x01 \x02(\fR\bmanifest\x12\x12\n" +
+	"\x04blob\x18\x02 \x02(\fR\x04blob\x12\x1c\n" +
+	"\tsignature\x18\x03 \x02(\fR\tsignature\x12\x18\n" +
+	"\aversion\x18\x04 \x02(\rR\aversion\"a\n" +
 	"\x11ValidatorBlobInfo\x12\x1a\n" +
-	"\bmanifest\x18\x01 \x01(\fR\bmanifest\x12\x17\n" +
-	"\x04blob\x18\x02 \x01(\fH\x00R\x04blob\x88\x01\x01\x12!\n" +
-	"\tsignature\x18\x03 \x01(\fH\x01R\tsignature\x88\x01\x01B\a\n" +
-	"\x05_blobB\f\n" +
+	"\bmanifest\x18\x01 \x01(\fR\bmanifest\x12\x12\n" +
+	"\x04blob\x18\x02 \x02(\fR\x04blob\x12\x1c\n" +
+	"\tsignature\x18\x03 \x02(\fR\tsignature\"\x84\x01\n" +
+	"\x19TMValidatorListCollection\x12\x18\n" +
+	"\aversion\x18\x01 \x02(\rR\aversion\x12\x1a\n" +
+	"\bmanifest\x18\x02 \x02(\fR\bmanifest\x121\n" +
+	"\x05blobs\x18\x03 \x03(\v2\x1b.protocol.ValidatorBlobInfoR\x05blobs\"v\n" +
+	"\fTMValidation\x12\x1e\n" +
 	"\n" +
-	"_signature\"\xa7\x01\n" +
-	"\x19TMValidatorListCollection\x12\x1d\n" +
-	"\aversion\x18\x01 \x01(\rH\x00R\aversion\x88\x01\x01\x12\x1f\n" +
-	"\bmanifest\x18\x02 \x01(\fH\x01R\bmanifest\x88\x01\x01\x121\n" +
-	"\x05blobs\x18\x03 \x03(\v2\x1b.protocol.ValidatorBlobInfoR\x05blobsB\n" +
-	"\n" +
-	"\b_versionB\v\n" +
-	"\t_manifest\"\x8b\x01\n" +
-	"\fTMValidation\x12#\n" +
-	"\n" +
-	"validation\x18\x01 \x01(\fH\x00R\n" +
-	"validation\x88\x01\x01\x12/\n" +
-	"\x11checked_signature\x18\x02 \x01(\bB\x02\x18\x01R\x10checkedSignature\x12\x16\n" +
-	"\x04hops\x18\x03 \x01(\rB\x02\x18\x01R\x04hopsB\r\n" +
-	"\v_validation\"\xdf\x01\n" +
-	"\vTMEndpoints\x12\x1d\n" +
-	"\aversion\x18\x01 \x01(\rH\x00R\aversion\x88\x01\x01\x12E\n" +
-	"\fendpoints_v2\x18\x03 \x03(\v2\".protocol.TMEndpoints.TMEndpointv2R\vendpointsV2\x1a^\n" +
-	"\fTMEndpointv2\x12\x1f\n" +
-	"\bendpoint\x18\x01 \x01(\tH\x00R\bendpoint\x88\x01\x01\x12\x17\n" +
-	"\x04hops\x18\x02 \x01(\rH\x01R\x04hops\x88\x01\x01B\v\n" +
-	"\t_endpointB\a\n" +
-	"\x05_hopsB\n" +
-	"\n" +
-	"\b_version\"\x87\x01\n" +
+	"validation\x18\x01 \x02(\fR\n" +
+	"validation\x12.\n" +
+	"\x10checkedSignature\x18\x02 \x01(\bB\x02\x18\x01R\x10checkedSignature\x12\x16\n" +
+	"\x04hops\x18\x03 \x01(\rB\x02\x18\x01R\x04hops\"\xb4\x01\n" +
+	"\vTMEndpoints\x12\x18\n" +
+	"\aversion\x18\x01 \x02(\rR\aversion\x12E\n" +
+	"\fendpoints_v2\x18\x03 \x03(\v2\".protocol.TMEndpoints.TMEndpointv2R\vendpointsV2\x1a>\n" +
+	"\fTMEndpointv2\x12\x1a\n" +
+	"\bendpoint\x18\x01 \x02(\tR\bendpoint\x12\x12\n" +
+	"\x04hops\x18\x02 \x02(\rR\x04hopsJ\x04\b\x02\x10\x03\"\x85\x01\n" +
 	"\x0fTMIndexedObject\x12\x12\n" +
-	"\x04hash\x18\x01 \x01(\fR\x04hash\x12\x17\n" +
-	"\anode_id\x18\x02 \x01(\fR\x06nodeId\x12\x14\n" +
+	"\x04hash\x18\x01 \x01(\fR\x04hash\x12\x16\n" +
+	"\x06nodeID\x18\x02 \x01(\fR\x06nodeID\x12\x14\n" +
 	"\x05index\x18\x03 \x01(\fR\x05index\x12\x12\n" +
-	"\x04data\x18\x04 \x01(\fR\x04data\x12\x1d\n" +
+	"\x04data\x18\x04 \x01(\fR\x04data\x12\x1c\n" +
+	"\tledgerSeq\x18\x05 \x01(\rR\tledgerSeq\"\xf3\x02\n" +
+	"\x11TMGetObjectByHash\x12:\n" +
+	"\x04type\x18\x01 \x02(\x0e2&.protocol.TMGetObjectByHash.ObjectTypeR\x04type\x12\x14\n" +
+	"\x05query\x18\x02 \x02(\bR\x05query\x12\x1e\n" +
 	"\n" +
-	"ledger_seq\x18\x05 \x01(\rR\tledgerSeq\"\xde\x01\n" +
-	"\x11TMGetObjectByHash\x12-\n" +
-	"\x04type\x18\x01 \x01(\x0e2\x14.protocol.ObjectTypeH\x00R\x04type\x88\x01\x01\x12\x19\n" +
-	"\x05query\x18\x02 \x01(\bH\x01R\x05query\x88\x01\x01\x12\x1f\n" +
-	"\vledger_hash\x18\x04 \x01(\fR\n" +
+	"ledgerHash\x18\x04 \x01(\fR\n" +
 	"ledgerHash\x12\x10\n" +
 	"\x03fat\x18\x05 \x01(\bR\x03fat\x123\n" +
-	"\aobjects\x18\x06 \x03(\v2\x19.protocol.TMIndexedObjectR\aobjectsB\a\n" +
-	"\x05_typeB\b\n" +
-	"\x06_queryJ\x04\b\x03\x10\x04\"T\n" +
-	"\fTMLedgerNode\x12\x1f\n" +
-	"\bnodedata\x18\x01 \x01(\fH\x00R\bnodedata\x88\x01\x01\x12\x16\n" +
-	"\x06nodeid\x18\x02 \x01(\fR\x06nodeidB\v\n" +
-	"\t_nodedata\"\xb9\x03\n" +
-	"\vTMGetLedger\x125\n" +
-	"\x05itype\x18\x01 \x01(\x0e2\x1a.protocol.TMLedgerInfoTypeH\x00R\x05itype\x88\x01\x01\x121\n" +
-	"\x05ltype\x18\x02 \x01(\x0e2\x16.protocol.TMLedgerTypeH\x01R\x05ltype\x88\x01\x01\x12\x1f\n" +
-	"\vledger_hash\x18\x03 \x01(\fR\n" +
-	"ledgerHash\x12\"\n" +
+	"\aobjects\x18\x06 \x03(\v2\x19.protocol.TMIndexedObjectR\aobjects\"\x9e\x01\n" +
 	"\n" +
-	"ledger_seq\x18\x04 \x01(\rH\x02R\tledgerSeq\x88\x01\x01\x12\x19\n" +
-	"\bnode_ids\x18\x05 \x03(\fR\anodeIds\x12*\n" +
-	"\x0erequest_cookie\x18\x06 \x01(\x04H\x03R\rrequestCookie\x88\x01\x01\x129\n" +
+	"ObjectType\x12\r\n" +
+	"\totUNKNOWN\x10\x00\x12\f\n" +
+	"\botLEDGER\x10\x01\x12\x11\n" +
+	"\rotTRANSACTION\x10\x02\x12\x16\n" +
+	"\x12otTRANSACTION_NODE\x10\x03\x12\x10\n" +
+	"\fotSTATE_NODE\x10\x04\x12\x10\n" +
+	"\fotCAS_OBJECT\x10\x05\x12\x10\n" +
+	"\fotFETCH_PACK\x10\x06\x12\x12\n" +
+	"\x0eotTRANSACTIONS\x10\aJ\x04\b\x03\x10\x04\"B\n" +
+	"\fTMLedgerNode\x12\x1a\n" +
+	"\bnodedata\x18\x01 \x02(\fR\bnodedata\x12\x16\n" +
+	"\x06nodeid\x18\x02 \x01(\fR\x06nodeid\"\xc0\x02\n" +
+	"\vTMGetLedger\x120\n" +
+	"\x05itype\x18\x01 \x02(\x0e2\x1a.protocol.TMLedgerInfoTypeR\x05itype\x12,\n" +
+	"\x05ltype\x18\x02 \x01(\x0e2\x16.protocol.TMLedgerTypeR\x05ltype\x12\x1e\n" +
 	"\n" +
-	"query_type\x18\a \x01(\x0e2\x15.protocol.TMQueryTypeH\x04R\tqueryType\x88\x01\x01\x12$\n" +
-	"\vquery_depth\x18\b \x01(\rH\x05R\n" +
-	"queryDepth\x88\x01\x01B\b\n" +
-	"\x06_itypeB\b\n" +
-	"\x06_ltypeB\r\n" +
-	"\v_ledger_seqB\x11\n" +
-	"\x0f_request_cookieB\r\n" +
-	"\v_query_typeB\x0e\n" +
-	"\f_query_depth\"\xd0\x02\n" +
-	"\fTMLedgerData\x12$\n" +
-	"\vledger_hash\x18\x01 \x01(\fH\x00R\n" +
-	"ledgerHash\x88\x01\x01\x12\"\n" +
+	"ledgerHash\x18\x03 \x01(\fR\n" +
+	"ledgerHash\x12\x1c\n" +
+	"\tledgerSeq\x18\x04 \x01(\rR\tledgerSeq\x12\x18\n" +
+	"\anodeIDs\x18\x05 \x03(\fR\anodeIDs\x12$\n" +
+	"\rrequestCookie\x18\x06 \x01(\x04R\rrequestCookie\x123\n" +
+	"\tqueryType\x18\a \x01(\x0e2\x15.protocol.TMQueryTypeR\tqueryType\x12\x1e\n" +
 	"\n" +
-	"ledger_seq\x18\x02 \x01(\rH\x01R\tledgerSeq\x88\x01\x01\x123\n" +
-	"\x04type\x18\x03 \x01(\x0e2\x1a.protocol.TMLedgerInfoTypeH\x02R\x04type\x88\x01\x01\x12,\n" +
-	"\x05nodes\x18\x04 \x03(\v2\x16.protocol.TMLedgerNodeR\x05nodes\x12*\n" +
-	"\x0erequest_cookie\x18\x05 \x01(\rH\x03R\rrequestCookie\x88\x01\x01\x12,\n" +
-	"\x05error\x18\x06 \x01(\x0e2\x16.protocol.TMReplyErrorR\x05errorB\x0e\n" +
-	"\f_ledger_hashB\r\n" +
-	"\v_ledger_seqB\a\n" +
-	"\x05_typeB\x11\n" +
-	"\x0f_request_cookie\"\xe5\x01\n" +
-	"\x06TMPing\x122\n" +
-	"\x04type\x18\x01 \x01(\x0e2\x19.protocol.TMPing.PingTypeH\x00R\x04type\x88\x01\x01\x12\x15\n" +
-	"\x03seq\x18\x02 \x01(\rH\x01R\x03seq\x88\x01\x01\x12 \n" +
-	"\tping_time\x18\x03 \x01(\x04H\x02R\bpingTime\x88\x01\x01\x12\x1e\n" +
-	"\bnet_time\x18\x04 \x01(\x04H\x03R\anetTime\x88\x01\x01\"\"\n" +
-	"\bPingType\x12\n" +
+	"queryDepth\x18\b \x01(\rR\n" +
+	"queryDepth\"\xfe\x01\n" +
+	"\fTMLedgerData\x12\x1e\n" +
+	"\n" +
+	"ledgerHash\x18\x01 \x02(\fR\n" +
+	"ledgerHash\x12\x1c\n" +
+	"\tledgerSeq\x18\x02 \x02(\rR\tledgerSeq\x12.\n" +
+	"\x04type\x18\x03 \x02(\x0e2\x1a.protocol.TMLedgerInfoTypeR\x04type\x12,\n" +
+	"\x05nodes\x18\x04 \x03(\v2\x16.protocol.TMLedgerNodeR\x05nodes\x12$\n" +
+	"\rrequestCookie\x18\x05 \x01(\rR\rrequestCookie\x12,\n" +
+	"\x05error\x18\x06 \x01(\x0e2\x16.protocol.TMReplyErrorR\x05error\"\xa3\x01\n" +
+	"\x06TMPing\x12-\n" +
+	"\x04type\x18\x01 \x02(\x0e2\x19.protocol.TMPing.pingTypeR\x04type\x12\x10\n" +
+	"\x03seq\x18\x02 \x01(\rR\x03seq\x12\x1a\n" +
+	"\bpingTime\x18\x03 \x01(\x04R\bpingTime\x12\x18\n" +
+	"\anetTime\x18\x04 \x01(\x04R\anetTime\"\"\n" +
+	"\bpingType\x12\n" +
 	"\n" +
 	"\x06ptPING\x10\x00\x12\n" +
 	"\n" +
-	"\x06ptPONG\x10\x01B\a\n" +
-	"\x05_typeB\x06\n" +
-	"\x04_seqB\f\n" +
+	"\x06ptPONG\x10\x01\"y\n" +
+	"\tTMSquelch\x12\x18\n" +
+	"\asquelch\x18\x01 \x02(\bR\asquelch\x12(\n" +
+	"\x0fvalidatorPubKey\x18\x02 \x02(\fR\x0fvalidatorPubKey\x12(\n" +
+	"\x0fsquelchDuration\x18\x03 \x01(\rR\x0fsquelchDuration\"u\n" +
+	"\x12TMProofPathRequest\x12\x10\n" +
+	"\x03key\x18\x01 \x02(\fR\x03key\x12\x1e\n" +
 	"\n" +
-	"_ping_timeB\v\n" +
-	"\t_net_time\"\xa8\x01\n" +
-	"\tTMSquelch\x12\x1d\n" +
-	"\asquelch\x18\x01 \x01(\bH\x00R\asquelch\x88\x01\x01\x12/\n" +
-	"\x11validator_pub_key\x18\x02 \x01(\fH\x01R\x0fvalidatorPubKey\x88\x01\x01\x12)\n" +
-	"\x10squelch_duration\x18\x03 \x01(\rR\x0fsquelchDurationB\n" +
+	"ledgerHash\x18\x02 \x02(\fR\n" +
+	"ledgerHash\x12-\n" +
+	"\x04type\x18\x03 \x02(\x0e2\x19.protocol.TMLedgerMapTypeR\x04type\"\xdc\x01\n" +
+	"\x13TMProofPathResponse\x12\x10\n" +
+	"\x03key\x18\x01 \x02(\fR\x03key\x12\x1e\n" +
 	"\n" +
-	"\b_squelchB\x14\n" +
-	"\x12_validator_pub_key\"\xa6\x01\n" +
-	"\x12TMProofPathRequest\x12\x15\n" +
-	"\x03key\x18\x01 \x01(\fH\x00R\x03key\x88\x01\x01\x12$\n" +
-	"\vledger_hash\x18\x02 \x01(\fH\x01R\n" +
-	"ledgerHash\x88\x01\x01\x122\n" +
-	"\x04type\x18\x03 \x01(\x0e2\x19.protocol.TMLedgerMapTypeH\x02R\x04type\x88\x01\x01B\x06\n" +
-	"\x04_keyB\x0e\n" +
-	"\f_ledger_hashB\a\n" +
-	"\x05_type\"\x8e\x02\n" +
-	"\x13TMProofPathResponse\x12\x15\n" +
-	"\x03key\x18\x01 \x01(\fH\x00R\x03key\x88\x01\x01\x12$\n" +
-	"\vledger_hash\x18\x02 \x01(\fH\x01R\n" +
-	"ledgerHash\x88\x01\x01\x122\n" +
-	"\x04type\x18\x03 \x01(\x0e2\x19.protocol.TMLedgerMapTypeH\x02R\x04type\x88\x01\x01\x12#\n" +
-	"\rledger_header\x18\x04 \x01(\fR\fledgerHeader\x12\x12\n" +
+	"ledgerHash\x18\x02 \x02(\fR\n" +
+	"ledgerHash\x12-\n" +
+	"\x04type\x18\x03 \x02(\x0e2\x19.protocol.TMLedgerMapTypeR\x04type\x12\"\n" +
+	"\fledgerHeader\x18\x04 \x01(\fR\fledgerHeader\x12\x12\n" +
 	"\x04path\x18\x05 \x03(\fR\x04path\x12,\n" +
-	"\x05error\x18\x06 \x01(\x0e2\x16.protocol.TMReplyErrorR\x05errorB\x06\n" +
-	"\x04_keyB\x0e\n" +
-	"\f_ledger_hashB\a\n" +
-	"\x05_type\"L\n" +
-	"\x14TMReplayDeltaRequest\x12$\n" +
-	"\vledger_hash\x18\x01 \x01(\fH\x00R\n" +
-	"ledgerHash\x88\x01\x01B\x0e\n" +
-	"\f_ledger_hash\"\xc2\x01\n" +
-	"\x15TMReplayDeltaResponse\x12$\n" +
-	"\vledger_hash\x18\x01 \x01(\fH\x00R\n" +
-	"ledgerHash\x88\x01\x01\x12#\n" +
-	"\rledger_header\x18\x02 \x01(\fR\fledgerHeader\x12 \n" +
+	"\x05error\x18\x06 \x01(\x0e2\x16.protocol.TMReplyErrorR\x05error\"6\n" +
+	"\x14TMReplayDeltaRequest\x12\x1e\n" +
+	"\n" +
+	"ledgerHash\x18\x01 \x02(\fR\n" +
+	"ledgerHash\"\xab\x01\n" +
+	"\x15TMReplayDeltaResponse\x12\x1e\n" +
+	"\n" +
+	"ledgerHash\x18\x01 \x02(\fR\n" +
+	"ledgerHash\x12\"\n" +
+	"\fledgerHeader\x18\x02 \x01(\fR\fledgerHeader\x12 \n" +
 	"\vtransaction\x18\x03 \x03(\fR\vtransaction\x12,\n" +
-	"\x05error\x18\x04 \x01(\x0e2\x16.protocol.TMReplyErrorR\x05errorB\x0e\n" +
-	"\f_ledger_hash\",\n" +
+	"\x05error\x18\x04 \x01(\x0e2\x16.protocol.TMReplyErrorR\x05error\",\n" +
 	"\x12TMHaveTransactions\x12\x16\n" +
-	"\x06hashes\x18\x01 \x03(\fR\x06hashes*\xc7\x03\n" +
-	"\vMessageType\x12\r\n" +
-	"\tmtUNKNOWN\x10\x00\x12\x0f\n" +
+	"\x06hashes\x18\x01 \x03(\fR\x06hashes*\xbb\x03\n" +
+	"\vMessageType\x12\x0f\n" +
 	"\vmtMANIFESTS\x10\x02\x12\n" +
 	"\n" +
 	"\x06mtPING\x10\x03\x12\r\n" +
@@ -2879,60 +2975,45 @@ const file_internal_peermanagement_proto_xrpl_proto_rawDesc = "" +
 	"\n" +
 	"mtHAVE_SET\x10#\x12\x10\n" +
 	"\fmtVALIDATION\x10)\x12\x11\n" +
-	"\rmtGET_OBJECTS\x10*\x12\x13\n" +
-	"\x0fmtVALIDATORLIST\x106\x12\r\n" +
-	"\tmtSQUELCH\x107\x12\x1d\n" +
-	"\x19mtVALIDATORLISTCOLLECTION\x108\x12\x14\n" +
+	"\rmtGET_OBJECTS\x10*\x12\x14\n" +
+	"\x10mtVALIDATOR_LIST\x106\x12\r\n" +
+	"\tmtSQUELCH\x107\x12\x1f\n" +
+	"\x1bmtVALIDATOR_LIST_COLLECTION\x108\x12\x14\n" +
 	"\x10mtPROOF_PATH_REQ\x109\x12\x19\n" +
 	"\x15mtPROOF_PATH_RESPONSE\x10:\x12\x16\n" +
 	"\x12mtREPLAY_DELTA_REQ\x10;\x12\x1b\n" +
 	"\x17mtREPLAY_DELTA_RESPONSE\x10<\x12\x17\n" +
 	"\x13mtHAVE_TRANSACTIONS\x10?\x12\x12\n" +
-	"\x0emtTRANSACTIONS\x10@*\xb0\x01\n" +
-	"\x11TransactionStatus\x12\r\n" +
-	"\ttsUNKNOWN\x10\x00\x12\t\n" +
+	"\x0emtTRANSACTIONS\x10@*\xa2\x01\n" +
+	"\x11TransactionStatus\x12\t\n" +
 	"\x05tsNEW\x10\x01\x12\r\n" +
-	"\ttsCURRENT\x10\x02\x12\x0e\n" +
-	"\n" +
-	"tsCOMMITED\x10\x03\x12\x15\n" +
+	"\ttsCURRENT\x10\x02\x12\x0f\n" +
+	"\vtsCOMMITTED\x10\x03\x12\x15\n" +
 	"\x11tsREJECT_CONFLICT\x10\x04\x12\x14\n" +
 	"\x10tsREJECT_INVALID\x10\x05\x12\x12\n" +
 	"\x0etsREJECT_FUNDS\x10\x06\x12\x0e\n" +
 	"\n" +
 	"tsHELD_SEQ\x10\a\x12\x11\n" +
-	"\rtsHELD_LEDGER\x10\b*r\n" +
+	"\rtsHELD_LEDGER\x10\b*c\n" +
 	"\n" +
-	"NodeStatus\x12\r\n" +
-	"\tnsUNKNOWN\x10\x00\x12\x10\n" +
+	"NodeStatus\x12\x10\n" +
 	"\fnsCONNECTING\x10\x01\x12\x0f\n" +
 	"\vnsCONNECTED\x10\x02\x12\x10\n" +
 	"\fnsMONITORING\x10\x03\x12\x10\n" +
 	"\fnsVALIDATING\x10\x04\x12\x0e\n" +
 	"\n" +
-	"nsSHUTTING\x10\x05*o\n" +
-	"\tNodeEvent\x12\r\n" +
-	"\tneUNKNOWN\x10\x00\x12\x14\n" +
+	"nsSHUTTING\x10\x05*`\n" +
+	"\tNodeEvent\x12\x14\n" +
 	"\x10neCLOSING_LEDGER\x10\x01\x12\x15\n" +
 	"\x11neACCEPTED_LEDGER\x10\x02\x12\x15\n" +
 	"\x11neSWITCHED_LEDGER\x10\x03\x12\x0f\n" +
-	"\vneLOST_SYNC\x10\x04*G\n" +
-	"\vTxSetStatus\x12\x11\n" +
-	"\rtsUNKNOWN_SET\x10\x00\x12\n" +
+	"\vneLOST_SYNC\x10\x04*4\n" +
+	"\vTxSetStatus\x12\n" +
 	"\n" +
 	"\x06tsHAVE\x10\x01\x12\r\n" +
 	"\ttsCAN_GET\x10\x02\x12\n" +
 	"\n" +
-	"\x06tsNEED\x10\x03*\x9e\x01\n" +
-	"\n" +
-	"ObjectType\x12\r\n" +
-	"\totUNKNOWN\x10\x00\x12\f\n" +
-	"\botLEDGER\x10\x01\x12\x11\n" +
-	"\rotTRANSACTION\x10\x02\x12\x16\n" +
-	"\x12otTRANSACTION_NODE\x10\x03\x12\x10\n" +
-	"\fotSTATE_NODE\x10\x04\x12\x10\n" +
-	"\fotCAS_OBJECT\x10\x05\x12\x10\n" +
-	"\fotFETCH_PACK\x10\x06\x12\x12\n" +
-	"\x0eotTRANSACTIONS\x10\a*P\n" +
+	"\x06tsNEED\x10\x03*P\n" +
 	"\x10TMLedgerInfoType\x12\n" +
 	"\n" +
 	"\x06liBASE\x10\x00\x12\r\n" +
@@ -2946,17 +3027,14 @@ const file_internal_peermanagement_proto_xrpl_proto_rawDesc = "" +
 	"\bltCLOSED\x10\x02*\x1d\n" +
 	"\vTMQueryType\x12\x0e\n" +
 	"\n" +
-	"qtINDIRECT\x10\x00*Q\n" +
-	"\fTMReplyError\x12\x0e\n" +
-	"\n" +
-	"reNO_ERROR\x10\x00\x12\x0f\n" +
+	"qtINDIRECT\x10\x00*A\n" +
+	"\fTMReplyError\x12\x0f\n" +
 	"\vreNO_LEDGER\x10\x01\x12\r\n" +
 	"\treNO_NODE\x10\x02\x12\x11\n" +
-	"\rreBAD_REQUEST\x10\x03*H\n" +
-	"\x0fTMLedgerMapType\x12\r\n" +
-	"\tlmUNKNOWN\x10\x00\x12\x11\n" +
+	"\rreBAD_REQUEST\x10\x03*9\n" +
+	"\x0fTMLedgerMapType\x12\x11\n" +
 	"\rlmTRANSACTION\x10\x01\x12\x13\n" +
-	"\x0flmACCOUNT_STATE\x10\x02B:Z8github.com/LeJamon/go-xrpl/internal/peermanagement/protob\x06proto3"
+	"\x0flmACCOUNT_STATE\x10\x02"
 
 var (
 	file_internal_peermanagement_proto_xrpl_proto_rawDescOnce sync.Once
@@ -2971,74 +3049,75 @@ func file_internal_peermanagement_proto_xrpl_proto_rawDescGZIP() []byte {
 }
 
 var file_internal_peermanagement_proto_xrpl_proto_enumTypes = make([]protoimpl.EnumInfo, 12)
-var file_internal_peermanagement_proto_xrpl_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_internal_peermanagement_proto_xrpl_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_internal_peermanagement_proto_xrpl_proto_goTypes = []any{
 	(MessageType)(0),                  // 0: protocol.MessageType
 	(TransactionStatus)(0),            // 1: protocol.TransactionStatus
 	(NodeStatus)(0),                   // 2: protocol.NodeStatus
 	(NodeEvent)(0),                    // 3: protocol.NodeEvent
 	(TxSetStatus)(0),                  // 4: protocol.TxSetStatus
-	(ObjectType)(0),                   // 5: protocol.ObjectType
-	(TMLedgerInfoType)(0),             // 6: protocol.TMLedgerInfoType
-	(TMLedgerType)(0),                 // 7: protocol.TMLedgerType
-	(TMQueryType)(0),                  // 8: protocol.TMQueryType
-	(TMReplyError)(0),                 // 9: protocol.TMReplyError
-	(TMLedgerMapType)(0),              // 10: protocol.TMLedgerMapType
-	(TMPing_PingType)(0),              // 11: protocol.TMPing.PingType
+	(TMLedgerInfoType)(0),             // 5: protocol.TMLedgerInfoType
+	(TMLedgerType)(0),                 // 6: protocol.TMLedgerType
+	(TMQueryType)(0),                  // 7: protocol.TMQueryType
+	(TMReplyError)(0),                 // 8: protocol.TMReplyError
+	(TMLedgerMapType)(0),              // 9: protocol.TMLedgerMapType
+	(TMGetObjectByHash_ObjectType)(0), // 10: protocol.TMGetObjectByHash.ObjectType
+	(TMPingPingType)(0),               // 11: protocol.TMPing.pingType
 	(*TMManifest)(nil),                // 12: protocol.TMManifest
 	(*TMManifests)(nil),               // 13: protocol.TMManifests
 	(*TMClusterNode)(nil),             // 14: protocol.TMClusterNode
 	(*TMLoadSource)(nil),              // 15: protocol.TMLoadSource
 	(*TMCluster)(nil),                 // 16: protocol.TMCluster
-	(*TMPublicKey)(nil),               // 17: protocol.TMPublicKey
-	(*TMTransaction)(nil),             // 18: protocol.TMTransaction
-	(*TMTransactions)(nil),            // 19: protocol.TMTransactions
-	(*TMStatusChange)(nil),            // 20: protocol.TMStatusChange
-	(*TMProposeSet)(nil),              // 21: protocol.TMProposeSet
-	(*TMHaveTransactionSet)(nil),      // 22: protocol.TMHaveTransactionSet
-	(*TMValidatorList)(nil),           // 23: protocol.TMValidatorList
-	(*ValidatorBlobInfo)(nil),         // 24: protocol.ValidatorBlobInfo
-	(*TMValidatorListCollection)(nil), // 25: protocol.TMValidatorListCollection
-	(*TMValidation)(nil),              // 26: protocol.TMValidation
-	(*TMEndpoints)(nil),               // 27: protocol.TMEndpoints
-	(*TMIndexedObject)(nil),           // 28: protocol.TMIndexedObject
-	(*TMGetObjectByHash)(nil),         // 29: protocol.TMGetObjectByHash
-	(*TMLedgerNode)(nil),              // 30: protocol.TMLedgerNode
-	(*TMGetLedger)(nil),               // 31: protocol.TMGetLedger
-	(*TMLedgerData)(nil),              // 32: protocol.TMLedgerData
-	(*TMPing)(nil),                    // 33: protocol.TMPing
-	(*TMSquelch)(nil),                 // 34: protocol.TMSquelch
-	(*TMProofPathRequest)(nil),        // 35: protocol.TMProofPathRequest
-	(*TMProofPathResponse)(nil),       // 36: protocol.TMProofPathResponse
-	(*TMReplayDeltaRequest)(nil),      // 37: protocol.TMReplayDeltaRequest
-	(*TMReplayDeltaResponse)(nil),     // 38: protocol.TMReplayDeltaResponse
-	(*TMHaveTransactions)(nil),        // 39: protocol.TMHaveTransactions
-	(*TMEndpoints_TMEndpointv2)(nil),  // 40: protocol.TMEndpoints.TMEndpointv2
+	(*TMLink)(nil),                    // 17: protocol.TMLink
+	(*TMPublicKey)(nil),               // 18: protocol.TMPublicKey
+	(*TMTransaction)(nil),             // 19: protocol.TMTransaction
+	(*TMTransactions)(nil),            // 20: protocol.TMTransactions
+	(*TMStatusChange)(nil),            // 21: protocol.TMStatusChange
+	(*TMProposeSet)(nil),              // 22: protocol.TMProposeSet
+	(*TMHaveTransactionSet)(nil),      // 23: protocol.TMHaveTransactionSet
+	(*TMValidatorList)(nil),           // 24: protocol.TMValidatorList
+	(*ValidatorBlobInfo)(nil),         // 25: protocol.ValidatorBlobInfo
+	(*TMValidatorListCollection)(nil), // 26: protocol.TMValidatorListCollection
+	(*TMValidation)(nil),              // 27: protocol.TMValidation
+	(*TMEndpoints)(nil),               // 28: protocol.TMEndpoints
+	(*TMIndexedObject)(nil),           // 29: protocol.TMIndexedObject
+	(*TMGetObjectByHash)(nil),         // 30: protocol.TMGetObjectByHash
+	(*TMLedgerNode)(nil),              // 31: protocol.TMLedgerNode
+	(*TMGetLedger)(nil),               // 32: protocol.TMGetLedger
+	(*TMLedgerData)(nil),              // 33: protocol.TMLedgerData
+	(*TMPing)(nil),                    // 34: protocol.TMPing
+	(*TMSquelch)(nil),                 // 35: protocol.TMSquelch
+	(*TMProofPathRequest)(nil),        // 36: protocol.TMProofPathRequest
+	(*TMProofPathResponse)(nil),       // 37: protocol.TMProofPathResponse
+	(*TMReplayDeltaRequest)(nil),      // 38: protocol.TMReplayDeltaRequest
+	(*TMReplayDeltaResponse)(nil),     // 39: protocol.TMReplayDeltaResponse
+	(*TMHaveTransactions)(nil),        // 40: protocol.TMHaveTransactions
+	(*TMEndpoints_TMEndpointv2)(nil),  // 41: protocol.TMEndpoints.TMEndpointv2
 }
 var file_internal_peermanagement_proto_xrpl_proto_depIdxs = []int32{
 	12, // 0: protocol.TMManifests.list:type_name -> protocol.TMManifest
-	14, // 1: protocol.TMCluster.cluster_nodes:type_name -> protocol.TMClusterNode
-	15, // 2: protocol.TMCluster.load_sources:type_name -> protocol.TMLoadSource
+	14, // 1: protocol.TMCluster.clusterNodes:type_name -> protocol.TMClusterNode
+	15, // 2: protocol.TMCluster.loadSources:type_name -> protocol.TMLoadSource
 	1,  // 3: protocol.TMTransaction.status:type_name -> protocol.TransactionStatus
-	18, // 4: protocol.TMTransactions.transactions:type_name -> protocol.TMTransaction
-	2,  // 5: protocol.TMStatusChange.new_status:type_name -> protocol.NodeStatus
-	3,  // 6: protocol.TMStatusChange.new_event:type_name -> protocol.NodeEvent
+	19, // 4: protocol.TMTransactions.transactions:type_name -> protocol.TMTransaction
+	2,  // 5: protocol.TMStatusChange.newStatus:type_name -> protocol.NodeStatus
+	3,  // 6: protocol.TMStatusChange.newEvent:type_name -> protocol.NodeEvent
 	4,  // 7: protocol.TMHaveTransactionSet.status:type_name -> protocol.TxSetStatus
-	24, // 8: protocol.TMValidatorListCollection.blobs:type_name -> protocol.ValidatorBlobInfo
-	40, // 9: protocol.TMEndpoints.endpoints_v2:type_name -> protocol.TMEndpoints.TMEndpointv2
-	5,  // 10: protocol.TMGetObjectByHash.type:type_name -> protocol.ObjectType
-	28, // 11: protocol.TMGetObjectByHash.objects:type_name -> protocol.TMIndexedObject
-	6,  // 12: protocol.TMGetLedger.itype:type_name -> protocol.TMLedgerInfoType
-	7,  // 13: protocol.TMGetLedger.ltype:type_name -> protocol.TMLedgerType
-	8,  // 14: protocol.TMGetLedger.query_type:type_name -> protocol.TMQueryType
-	6,  // 15: protocol.TMLedgerData.type:type_name -> protocol.TMLedgerInfoType
-	30, // 16: protocol.TMLedgerData.nodes:type_name -> protocol.TMLedgerNode
-	9,  // 17: protocol.TMLedgerData.error:type_name -> protocol.TMReplyError
-	11, // 18: protocol.TMPing.type:type_name -> protocol.TMPing.PingType
-	10, // 19: protocol.TMProofPathRequest.type:type_name -> protocol.TMLedgerMapType
-	10, // 20: protocol.TMProofPathResponse.type:type_name -> protocol.TMLedgerMapType
-	9,  // 21: protocol.TMProofPathResponse.error:type_name -> protocol.TMReplyError
-	9,  // 22: protocol.TMReplayDeltaResponse.error:type_name -> protocol.TMReplyError
+	25, // 8: protocol.TMValidatorListCollection.blobs:type_name -> protocol.ValidatorBlobInfo
+	41, // 9: protocol.TMEndpoints.endpoints_v2:type_name -> protocol.TMEndpoints.TMEndpointv2
+	10, // 10: protocol.TMGetObjectByHash.type:type_name -> protocol.TMGetObjectByHash.ObjectType
+	29, // 11: protocol.TMGetObjectByHash.objects:type_name -> protocol.TMIndexedObject
+	5,  // 12: protocol.TMGetLedger.itype:type_name -> protocol.TMLedgerInfoType
+	6,  // 13: protocol.TMGetLedger.ltype:type_name -> protocol.TMLedgerType
+	7,  // 14: protocol.TMGetLedger.queryType:type_name -> protocol.TMQueryType
+	5,  // 15: protocol.TMLedgerData.type:type_name -> protocol.TMLedgerInfoType
+	31, // 16: protocol.TMLedgerData.nodes:type_name -> protocol.TMLedgerNode
+	8,  // 17: protocol.TMLedgerData.error:type_name -> protocol.TMReplyError
+	11, // 18: protocol.TMPing.type:type_name -> protocol.TMPing.pingType
+	9,  // 19: protocol.TMProofPathRequest.type:type_name -> protocol.TMLedgerMapType
+	9,  // 20: protocol.TMProofPathResponse.type:type_name -> protocol.TMLedgerMapType
+	8,  // 21: protocol.TMProofPathResponse.error:type_name -> protocol.TMReplyError
+	8,  // 22: protocol.TMReplayDeltaResponse.error:type_name -> protocol.TMReplyError
 	23, // [23:23] is the sub-list for method output_type
 	23, // [23:23] is the sub-list for method input_type
 	23, // [23:23] is the sub-list for extension type_name
@@ -3051,37 +3130,13 @@ func file_internal_peermanagement_proto_xrpl_proto_init() {
 	if File_internal_peermanagement_proto_xrpl_proto != nil {
 		return
 	}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[0].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[2].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[3].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[5].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[6].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[8].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[9].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[10].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[11].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[12].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[13].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[14].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[15].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[17].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[18].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[19].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[20].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[21].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[22].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[23].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[24].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[25].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[26].OneofWrappers = []any{}
-	file_internal_peermanagement_proto_xrpl_proto_msgTypes[28].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_peermanagement_proto_xrpl_proto_rawDesc), len(file_internal_peermanagement_proto_xrpl_proto_rawDesc)),
 			NumEnums:      12,
-			NumMessages:   29,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/peermanagement/proto/xrpl.proto
+++ b/internal/peermanagement/proto/xrpl.proto
@@ -1,331 +1,345 @@
-syntax = "proto3";
+syntax = "proto2";
 package protocol;
-option go_package = "github.com/LeJamon/go-xrpl/internal/peermanagement/proto";
 
-// Message types for the XRPL peer protocol
+// Unused numbers in the list below may have been used previously. Please don't
+// reassign them for reuse unless you are 100% certain that there won't be a
+// conflict. Even if you're sure, it's probably best to assign a new type.
 enum MessageType {
-    mtUNKNOWN                   = 0;
-    mtMANIFESTS                 = 2;
-    mtPING                      = 3;
-    mtCLUSTER                   = 5;
-    mtENDPOINTS                 = 15;
-    mtTRANSACTION               = 30;
-    mtGET_LEDGER                = 31;
-    mtLEDGER_DATA               = 32;
-    mtPROPOSE_LEDGER            = 33;
-    mtSTATUS_CHANGE             = 34;
-    mtHAVE_SET                  = 35;
-    mtVALIDATION                = 41;
-    mtGET_OBJECTS               = 42;
-    mtVALIDATORLIST             = 54;
-    mtSQUELCH                   = 55;
-    mtVALIDATORLISTCOLLECTION   = 56;
-    mtPROOF_PATH_REQ            = 57;
-    mtPROOF_PATH_RESPONSE       = 58;
-    mtREPLAY_DELTA_REQ          = 59;
-    mtREPLAY_DELTA_RESPONSE     = 60;
-    mtHAVE_TRANSACTIONS         = 63;
-    mtTRANSACTIONS              = 64;
+  mtMANIFESTS = 2;
+  mtPING = 3;
+  mtCLUSTER = 5;
+  mtENDPOINTS = 15;
+  mtTRANSACTION = 30;
+  mtGET_LEDGER = 31;
+  mtLEDGER_DATA = 32;
+  mtPROPOSE_LEDGER = 33;
+  mtSTATUS_CHANGE = 34;
+  mtHAVE_SET = 35;
+  mtVALIDATION = 41;
+  mtGET_OBJECTS = 42;
+  mtVALIDATOR_LIST = 54;
+  mtSQUELCH = 55;
+  mtVALIDATOR_LIST_COLLECTION = 56;
+  mtPROOF_PATH_REQ = 57;
+  mtPROOF_PATH_RESPONSE = 58;
+  mtREPLAY_DELTA_REQ = 59;
+  mtREPLAY_DELTA_RESPONSE = 60;
+  mtHAVE_TRANSACTIONS = 63;
+  mtTRANSACTIONS = 64;
 }
 
-// Provides the current ephemeral key for a validator
+// token, iterations, target, challenge = issue demand for proof of work
+// token, response = give solution to proof of work
+// token, result = report result of pow
+
+//------------------------------------------------------------------------------
+
+/* Provides the current ephemeral key for a validator. */
 message TMManifest {
-    optional bytes stobject = 1;
+  // A Manifest object in the XRPL serialization format.
+  required bytes stobject = 1;
 }
 
 message TMManifests {
-    repeated TMManifest list = 1;
-    bool history = 2 [deprecated=true];
+  repeated TMManifest list = 1;
+
+  // The manifests sent when a peer first connects to another peer are `history`.
+  optional bool history = 2 [deprecated = true];
 }
 
-// Cluster node status
+//------------------------------------------------------------------------------
+
+// The status of a node in our cluster
 message TMClusterNode {
-    optional string public_key = 1;
-    optional uint32 report_time = 2;
-    optional uint32 node_load = 3;
-    string node_name = 4;
-    string address = 5;
+  required string publicKey = 1;
+  required uint32 reportTime = 2;
+  required uint32 nodeLoad = 3;
+  optional string nodeName = 4;
+  optional string address = 5;
 }
 
-// Load sources
+// Sources that are placing load on the server
 message TMLoadSource {
-    optional string name = 1;
-    optional uint32 cost = 2;
-    uint32 count = 3;
+  required string name = 1;
+  required uint32 cost = 2;
+  optional uint32 count = 3;  // number of connections
 }
 
-// Cluster status
+// The status of all nodes in the cluster
 message TMCluster {
-    repeated TMClusterNode cluster_nodes = 1;
-    repeated TMLoadSource load_sources = 2;
+  repeated TMClusterNode clusterNodes = 1;
+  repeated TMLoadSource loadSources = 2;
 }
 
-// Public key
+// Node public key
+message TMLink {
+  required bytes nodePubKey = 1 [deprecated = true];  // node public key
+}
+
+// Peer public key
 message TMPublicKey {
-    optional bytes public_key = 1;
+  required bytes publicKey = 1;
 }
 
-// Transaction status
+// A transaction can have only one input and one output.
+// If you want to send an amount that is greater than any single address of yours
+// you must first combine coins from one address to another.
+
 enum TransactionStatus {
-    tsUNKNOWN           = 0;
-    tsNEW               = 1;
-    tsCURRENT           = 2;
-    tsCOMMITED          = 3;
-    tsREJECT_CONFLICT   = 4;
-    tsREJECT_INVALID    = 5;
-    tsREJECT_FUNDS      = 6;
-    tsHELD_SEQ          = 7;
-    tsHELD_LEDGER       = 8;
+  tsNEW = 1;        // origin node did/could not validate
+  tsCURRENT = 2;    // scheduled to go in this ledger
+  tsCOMMITTED = 3;  // in a closed ledger
+  tsREJECT_CONFLICT = 4;
+  tsREJECT_INVALID = 5;
+  tsREJECT_FUNDS = 6;
+  tsHELD_SEQ = 7;
+  tsHELD_LEDGER = 8;  // held for future ledger
 }
 
 message TMTransaction {
-    optional bytes raw_transaction = 1;
-    optional TransactionStatus status = 2;
-    uint64 receive_timestamp = 3;
-    bool deferred = 4;
+  required bytes rawTransaction = 1;
+  required TransactionStatus status = 2;
+  optional uint64 receiveTimestamp = 3;
+  optional bool deferred = 4;  // not applied to open ledger
 }
 
 message TMTransactions {
-    repeated TMTransaction transactions = 1;
+  repeated TMTransaction transactions = 1;
 }
 
-// Node status
 enum NodeStatus {
-    nsUNKNOWN       = 0;
-    nsCONNECTING    = 1;
-    nsCONNECTED     = 2;
-    nsMONITORING    = 3;
-    nsVALIDATING    = 4;
-    nsSHUTTING      = 5;
+  nsCONNECTING = 1;  // acquiring connections
+  nsCONNECTED = 2;   // convinced we are connected to the real network
+  nsMONITORING = 3;  // we know what the previous ledger is
+  nsVALIDATING = 4;  // we have the full ledger contents
+  nsSHUTTING = 5;    // node is shutting down
 }
 
-// Node events
 enum NodeEvent {
-    neUNKNOWN           = 0;
-    neCLOSING_LEDGER    = 1;
-    neACCEPTED_LEDGER   = 2;
-    neSWITCHED_LEDGER   = 3;
-    neLOST_SYNC         = 4;
+  neCLOSING_LEDGER = 1;   // closing a ledger because its close time has come
+  neACCEPTED_LEDGER = 2;  // accepting a closed ledger, we have finished computing it
+  neSWITCHED_LEDGER = 3;  // changing due to network consensus
+  neLOST_SYNC = 4;
 }
 
 message TMStatusChange {
-    NodeStatus new_status = 1;
-    NodeEvent new_event = 2;
-    uint32 ledger_seq = 3;
-    bytes ledger_hash = 4;
-    bytes ledger_hash_previous = 5;
-    uint64 network_time = 6;
-    optional uint32 first_seq = 7;
-    optional uint32 last_seq = 8;
+  optional NodeStatus newStatus = 1;
+  optional NodeEvent newEvent = 2;
+  optional uint32 ledgerSeq = 3;
+  optional bytes ledgerHash = 4;
+  optional bytes ledgerHashPrevious = 5;
+  optional uint64 networkTime = 6;
+  optional uint32 firstSeq = 7;
+  optional uint32 lastSeq = 8;
 }
 
-// Ledger proposal
+// Announce to the network our position on a closing ledger
 message TMProposeSet {
-    optional uint32 propose_seq = 1;
-    optional bytes current_tx_hash = 2;
-    optional bytes node_pub_key = 3;
-    optional uint32 close_time = 4;
-    optional bytes signature = 5;
-    optional bytes previous_ledger = 6;
-    bool checked_signature = 7 [deprecated=true];
-    repeated bytes added_transactions = 10;
-    repeated bytes removed_transactions = 11;
-    uint32 hops = 12 [deprecated=true];
+  required uint32 proposeSeq = 1;
+  required bytes currentTxHash = 2;  // the hash of the ledger we are proposing
+  required bytes nodePubKey = 3;
+  required uint32 closeTime = 4;
+  required bytes signature = 5;  // signature of above fields
+  required bytes previousledger = 6;
+  repeated bytes addedTransactions = 10;    // not required if number is large
+  repeated bytes removedTransactions = 11;  // not required if number is large
+
+  // node vouches signature is correct
+  optional bool checkedSignature = 7 [deprecated = true];
+
+  // Number of hops traveled
+  optional uint32 hops = 12 [deprecated = true];
 }
 
-// Transaction set status
 enum TxSetStatus {
-    tsUNKNOWN_SET   = 0;
-    tsHAVE          = 1;
-    tsCAN_GET       = 2;
-    tsNEED          = 3;
+  tsHAVE = 1;     // We have this set locally
+  tsCAN_GET = 2;  // We have a peer with this set
+  tsNEED = 3;     // We need this set and can't get it
 }
 
 message TMHaveTransactionSet {
-    optional TxSetStatus status = 1;
-    optional bytes hash = 2;
+  required TxSetStatus status = 1;
+  required bytes hash = 2;
 }
 
-// Validator list
+// Validator list (UNL)
 message TMValidatorList {
-    optional bytes manifest = 1;
-    optional bytes blob = 2;
-    optional bytes signature = 3;
-    optional uint32 version = 4;
+  required bytes manifest = 1;
+  required bytes blob = 2;
+  required bytes signature = 3;
+  required uint32 version = 4;
 }
 
-// Validator list v2
+// Validator List v2
 message ValidatorBlobInfo {
-    bytes manifest = 1;
-    optional bytes blob = 2;
-    optional bytes signature = 3;
+  optional bytes manifest = 1;
+  required bytes blob = 2;
+  required bytes signature = 3;
 }
 
+// Collection of Validator List v2 (UNL)
 message TMValidatorListCollection {
-    optional uint32 version = 1;
-    optional bytes manifest = 2;
-    repeated ValidatorBlobInfo blobs = 3;
+  required uint32 version = 1;
+  required bytes manifest = 2;
+  repeated ValidatorBlobInfo blobs = 3;
 }
 
-// Validation message
+// Used to sign a final closed ledger after reprocessing
 message TMValidation {
-    optional bytes validation = 1;
-    bool checked_signature = 2 [deprecated=true];
-    uint32 hops = 3 [deprecated=true];
+  // The serialized validation
+  required bytes validation = 1;
+
+  // node vouches signature is correct
+  optional bool checkedSignature = 2 [deprecated = true];
+
+  // Number of hops traveled
+  optional uint32 hops = 3 [deprecated = true];
 }
 
-// Endpoints for peer discovery
+// An array of Endpoint messages
 message TMEndpoints {
-    optional uint32 version = 1;
+  // Previously used - don't reuse.
+  reserved 2;
 
-    message TMEndpointv2 {
-        optional string endpoint = 1;
-        optional uint32 hops = 2;
-    }
-    repeated TMEndpointv2 endpoints_v2 = 3;
-}
+  // This field is used to allow the TMEndpoints message format to be
+  // modified as necessary in the future.
+  required uint32 version = 1;
 
-// Indexed object
+  // An update to the Endpoint type that uses a string
+  // to represent endpoints, thus allowing ipv6 or ipv4 addresses
+  message TMEndpointv2 {
+    required string endpoint = 1;
+    required uint32 hops = 2;
+  }
+  repeated TMEndpointv2 endpoints_v2 = 3;
+};
+
 message TMIndexedObject {
-    bytes hash = 1;
-    bytes node_id = 2;
-    bytes index = 3;
-    bytes data = 4;
-    uint32 ledger_seq = 5;
-}
-
-// Object types
-enum ObjectType {
-    otUNKNOWN           = 0;
-    otLEDGER            = 1;
-    otTRANSACTION       = 2;
-    otTRANSACTION_NODE  = 3;
-    otSTATE_NODE        = 4;
-    otCAS_OBJECT        = 5;
-    otFETCH_PACK        = 6;
-    otTRANSACTIONS      = 7;
+  optional bytes hash = 1;
+  optional bytes nodeID = 2;
+  optional bytes index = 3;
+  optional bytes data = 4;
+  optional uint32 ledgerSeq = 5;
 }
 
 message TMGetObjectByHash {
-    // Previously used - don't reuse.
-    reserved 3;
+  enum ObjectType {
+    otUNKNOWN = 0;
+    otLEDGER = 1;
+    otTRANSACTION = 2;
+    otTRANSACTION_NODE = 3;
+    otSTATE_NODE = 4;
+    otCAS_OBJECT = 5;
+    otFETCH_PACK = 6;
+    otTRANSACTIONS = 7;
+  }
 
-    optional ObjectType type = 1;
-    optional bool query = 2;
-    bytes ledger_hash = 4;
-    bool fat = 5;
-    repeated TMIndexedObject objects = 6;
+  // Previously used - don't reuse.
+  reserved 3;
+
+  required ObjectType type = 1;
+  required bool query = 2;               // is this a query or a reply?
+  optional bytes ledgerHash = 4;         // the hash of the ledger these queries are for
+  optional bool fat = 5;                 // return related nodes
+  repeated TMIndexedObject objects = 6;  // the specific objects requested
 }
 
-// Ledger node
 message TMLedgerNode {
-    optional bytes nodedata = 1;
-    bytes nodeid = 2;
+  required bytes nodedata = 1;
+  optional bytes nodeid = 2;  // missing for ledger base data
 }
 
-// Ledger info types
 enum TMLedgerInfoType {
-    liBASE          = 0;
-    liTX_NODE       = 1;
-    liAS_NODE       = 2;
-    liTS_CANDIDATE  = 3;
+  liBASE = 0;          // basic ledger info
+  liTX_NODE = 1;       // transaction node
+  liAS_NODE = 2;       // account state node
+  liTS_CANDIDATE = 3;  // candidate transaction set
 }
 
-// Ledger types
 enum TMLedgerType {
-    ltACCEPTED      = 0;
-    ltCURRENT       = 1;
-    ltCLOSED        = 2;
+  ltACCEPTED = 0;
+  ltCURRENT = 1;  // no longer supported
+  ltCLOSED = 2;
 }
 
-// Query type
 enum TMQueryType {
-    qtINDIRECT      = 0;
+  qtINDIRECT = 0;
 }
 
 message TMGetLedger {
-    optional TMLedgerInfoType itype = 1;
-    optional TMLedgerType ltype = 2;
-    bytes ledger_hash = 3;
-    optional uint32 ledger_seq = 4;
-    repeated bytes node_ids = 5;
-    optional uint64 request_cookie = 6;
-    optional TMQueryType query_type = 7;
-    optional uint32 query_depth = 8;
+  required TMLedgerInfoType itype = 1;
+  optional TMLedgerType ltype = 2;
+  optional bytes ledgerHash = 3;  // Can also be the transaction set hash if liTS_CANDIDATE
+  optional uint32 ledgerSeq = 4;
+  repeated bytes nodeIDs = 5;
+  optional uint64 requestCookie = 6;
+  optional TMQueryType queryType = 7;
+  optional uint32 queryDepth = 8;  // How deep to go, number of extra levels
 }
 
-// Reply errors
 enum TMReplyError {
-    reNO_ERROR      = 0;
-    reNO_LEDGER     = 1;
-    reNO_NODE       = 2;
-    reBAD_REQUEST   = 3;
+  reNO_LEDGER = 1;    // We don't have the ledger you are asking about
+  reNO_NODE = 2;      // We don't have any of the nodes you are asking for
+  reBAD_REQUEST = 3;  // The request is wrong, e.g. wrong format
 }
 
 message TMLedgerData {
-    optional bytes ledger_hash = 1;
-    optional uint32 ledger_seq = 2;
-    optional TMLedgerInfoType type = 3;
-    repeated TMLedgerNode nodes = 4;
-    optional uint32 request_cookie = 5;
-    TMReplyError error = 6;
+  required bytes ledgerHash = 1;
+  required uint32 ledgerSeq = 2;
+  required TMLedgerInfoType type = 3;
+  repeated TMLedgerNode nodes = 4;
+  optional uint32 requestCookie = 5;
+  optional TMReplyError error = 6;
 }
 
-// Ping/Pong
 message TMPing {
-    enum PingType {
-        ptPING = 0;
-        ptPONG = 1;
-    }
-    optional PingType type = 1;
-    optional uint32 seq = 2;
-    optional uint64 ping_time = 3;
-    optional uint64 net_time = 4;
+  enum pingType {
+    ptPING = 0;  // we want a reply
+    ptPONG = 1;  // this is a reply
+  }
+  required pingType type = 1;
+  optional uint32 seq = 2;       // detect stale replies, ensure other side is reading
+  optional uint64 pingTime = 3;  // know when we think we sent the ping
+  optional uint64 netTime = 4;
 }
 
-// Squelch for reduce-relay
 message TMSquelch {
-    optional bool squelch = 1;
-    optional bytes validator_pub_key = 2;
-    uint32 squelch_duration = 3;
+  required bool squelch = 1;            // squelch if true, otherwise unsquelch
+  required bytes validatorPubKey = 2;   // validator's public key
+  optional uint32 squelchDuration = 3;  // squelch duration in seconds
 }
 
-// Ledger map types
 enum TMLedgerMapType {
-    lmUNKNOWN       = 0;
-    lmTRANSACTION   = 1;
-    lmACCOUNT_STATE = 2;
+  lmTRANSACTION = 1;    // transaction map
+  lmACCOUNT_STATE = 2;  // account state map
 }
 
-// Proof path request/response
 message TMProofPathRequest {
-    optional bytes key = 1;
-    optional bytes ledger_hash = 2;
-    optional TMLedgerMapType type = 3;
+  required bytes key = 1;
+  required bytes ledgerHash = 2;
+  required TMLedgerMapType type = 3;
 }
 
 message TMProofPathResponse {
-    optional bytes key = 1;
-    optional bytes ledger_hash = 2;
-    optional TMLedgerMapType type = 3;
-    bytes ledger_header = 4;
-    repeated bytes path = 5;
-    TMReplyError error = 6;
+  required bytes key = 1;
+  required bytes ledgerHash = 2;
+  required TMLedgerMapType type = 3;
+  optional bytes ledgerHeader = 4;
+  repeated bytes path = 5;
+  optional TMReplyError error = 6;
 }
 
-// Replay delta for ledger sync
 message TMReplayDeltaRequest {
-    optional bytes ledger_hash = 1;
+  required bytes ledgerHash = 1;
 }
 
 message TMReplayDeltaResponse {
-    optional bytes ledger_hash = 1;
-    bytes ledger_header = 2;
-    repeated bytes transaction = 3;
-    TMReplyError error = 4;
+  required bytes ledgerHash = 1;
+  optional bytes ledgerHeader = 2;
+  repeated bytes transaction = 3;
+  optional TMReplyError error = 4;
 }
 
-// Have transactions (reduce-relay)
 message TMHaveTransactions {
-    repeated bytes hashes = 1;
+  repeated bytes hashes = 1;
 }

--- a/internal/peermanagement/proto/xrpl_proto_test.go
+++ b/internal/peermanagement/proto/xrpl_proto_test.go
@@ -1,0 +1,175 @@
+package proto
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"testing"
+
+	pb "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func TestSchemaProvenance(t *testing.T) {
+	schema, err := os.ReadFile("xrpl.proto")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const expected = "d52b004814cbe9d243fd132166c18da7923ddf5608827277bf5928457ee4bbe5"
+	if actual := fmt.Sprintf("%x", sha256.Sum256(schema)); actual != expected {
+		t.Fatalf("xrpl.proto SHA256 = %s, want %s", actual, expected)
+	}
+
+	generated, err := os.ReadFile("xrpl.pb.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, marker := range [][]byte{
+		[]byte("protoc-gen-go v1.36.11"),
+		[]byte("protoc        v7.34.1"),
+	} {
+		if !bytes.Contains(generated, marker) {
+			t.Fatalf("xrpl.pb.go does not contain %q", marker)
+		}
+	}
+}
+
+func TestSchemaDescriptorShape(t *testing.T) {
+	file := File_internal_peermanagement_proto_xrpl_proto
+	if file.Syntax() != protoreflect.Proto2 {
+		t.Fatalf("syntax = %v, want proto2", file.Syntax())
+	}
+
+	messages, required, optional, repeated := descriptorCounts(file.Messages())
+	if messages != 30 || required != 48 || optional != 43 || repeated != 14 {
+		t.Fatalf("descriptor counts = messages:%d required:%d optional:%d repeated:%d, want 30/48/43/14", messages, required, optional, repeated)
+	}
+
+	endpoints := file.Messages().ByName("TMEndpoints")
+	if endpoints == nil || !endpoints.ReservedRanges().Has(2) {
+		t.Fatal("TMEndpoints must reserve field 2")
+	}
+	objects := file.Messages().ByName("TMGetObjectByHash")
+	if objects == nil || !objects.ReservedRanges().Has(3) {
+		t.Fatal("TMGetObjectByHash must reserve field 3")
+	}
+	if file.Messages().ByName("TMLink") == nil {
+		t.Fatal("TMLink descriptor is missing")
+	}
+}
+
+func descriptorCounts(messages protoreflect.MessageDescriptors) (messageCount, required, optional, repeated int) {
+	for i := 0; i < messages.Len(); i++ {
+		message := messages.Get(i)
+		messageCount++
+		fields := message.Fields()
+		for j := 0; j < fields.Len(); j++ {
+			switch fields.Get(j).Cardinality() {
+			case protoreflect.Required:
+				required++
+			case protoreflect.Optional:
+				optional++
+			case protoreflect.Repeated:
+				repeated++
+			}
+		}
+		nestedMessages, nestedRequired, nestedOptional, nestedRepeated := descriptorCounts(message.Messages())
+		messageCount += nestedMessages
+		required += nestedRequired
+		optional += nestedOptional
+		repeated += nestedRepeated
+	}
+	return messageCount, required, optional, repeated
+}
+
+func TestSchemaEnums(t *testing.T) {
+	file := File_internal_peermanagement_proto_xrpl_proto
+	tests := []struct {
+		descriptor protoreflect.EnumDescriptor
+		fullName   protoreflect.FullName
+		values     map[protoreflect.Name]protoreflect.EnumNumber
+	}{
+		{file.Enums().ByName("MessageType"), "protocol.MessageType", map[protoreflect.Name]protoreflect.EnumNumber{"mtMANIFESTS": 2, "mtPING": 3, "mtCLUSTER": 5, "mtENDPOINTS": 15, "mtTRANSACTION": 30, "mtGET_LEDGER": 31, "mtLEDGER_DATA": 32, "mtPROPOSE_LEDGER": 33, "mtSTATUS_CHANGE": 34, "mtHAVE_SET": 35, "mtVALIDATION": 41, "mtGET_OBJECTS": 42, "mtVALIDATOR_LIST": 54, "mtSQUELCH": 55, "mtVALIDATOR_LIST_COLLECTION": 56, "mtPROOF_PATH_REQ": 57, "mtPROOF_PATH_RESPONSE": 58, "mtREPLAY_DELTA_REQ": 59, "mtREPLAY_DELTA_RESPONSE": 60, "mtHAVE_TRANSACTIONS": 63, "mtTRANSACTIONS": 64}},
+		{file.Enums().ByName("TransactionStatus"), "protocol.TransactionStatus", map[protoreflect.Name]protoreflect.EnumNumber{"tsNEW": 1, "tsCURRENT": 2, "tsCOMMITTED": 3, "tsREJECT_CONFLICT": 4, "tsREJECT_INVALID": 5, "tsREJECT_FUNDS": 6, "tsHELD_SEQ": 7, "tsHELD_LEDGER": 8}},
+		{file.Enums().ByName("NodeStatus"), "protocol.NodeStatus", map[protoreflect.Name]protoreflect.EnumNumber{"nsCONNECTING": 1, "nsCONNECTED": 2, "nsMONITORING": 3, "nsVALIDATING": 4, "nsSHUTTING": 5}},
+		{file.Enums().ByName("NodeEvent"), "protocol.NodeEvent", map[protoreflect.Name]protoreflect.EnumNumber{"neCLOSING_LEDGER": 1, "neACCEPTED_LEDGER": 2, "neSWITCHED_LEDGER": 3, "neLOST_SYNC": 4}},
+		{file.Enums().ByName("TxSetStatus"), "protocol.TxSetStatus", map[protoreflect.Name]protoreflect.EnumNumber{"tsHAVE": 1, "tsCAN_GET": 2, "tsNEED": 3}},
+		{file.Enums().ByName("TMLedgerInfoType"), "protocol.TMLedgerInfoType", map[protoreflect.Name]protoreflect.EnumNumber{"liBASE": 0, "liTX_NODE": 1, "liAS_NODE": 2, "liTS_CANDIDATE": 3}},
+		{file.Enums().ByName("TMLedgerType"), "protocol.TMLedgerType", map[protoreflect.Name]protoreflect.EnumNumber{"ltACCEPTED": 0, "ltCURRENT": 1, "ltCLOSED": 2}},
+		{file.Enums().ByName("TMQueryType"), "protocol.TMQueryType", map[protoreflect.Name]protoreflect.EnumNumber{"qtINDIRECT": 0}},
+		{file.Enums().ByName("TMReplyError"), "protocol.TMReplyError", map[protoreflect.Name]protoreflect.EnumNumber{"reNO_LEDGER": 1, "reNO_NODE": 2, "reBAD_REQUEST": 3}},
+		{file.Enums().ByName("TMLedgerMapType"), "protocol.TMLedgerMapType", map[protoreflect.Name]protoreflect.EnumNumber{"lmTRANSACTION": 1, "lmACCOUNT_STATE": 2}},
+		{file.Messages().ByName("TMGetObjectByHash").Enums().ByName("ObjectType"), "protocol.TMGetObjectByHash.ObjectType", map[protoreflect.Name]protoreflect.EnumNumber{"otUNKNOWN": 0, "otLEDGER": 1, "otTRANSACTION": 2, "otTRANSACTION_NODE": 3, "otSTATE_NODE": 4, "otCAS_OBJECT": 5, "otFETCH_PACK": 6, "otTRANSACTIONS": 7}},
+		{file.Messages().ByName("TMPing").Enums().ByName("pingType"), "protocol.TMPing.pingType", map[protoreflect.Name]protoreflect.EnumNumber{"ptPING": 0, "ptPONG": 1}},
+	}
+
+	for _, test := range tests {
+		if test.descriptor == nil {
+			t.Fatalf("enum %s is missing", test.fullName)
+		}
+		if test.descriptor.FullName() != test.fullName {
+			t.Errorf("enum full name = %s, want %s", test.descriptor.FullName(), test.fullName)
+		}
+		if !test.descriptor.IsClosed() {
+			t.Errorf("enum %s is not closed", test.fullName)
+		}
+		if test.descriptor.Values().Len() != len(test.values) {
+			t.Errorf("enum %s has %d values, want %d", test.fullName, test.descriptor.Values().Len(), len(test.values))
+		}
+		for name, number := range test.values {
+			value := test.descriptor.Values().ByName(name)
+			if value == nil || value.Number() != number {
+				t.Errorf("enum %s value %s = %v, want %d", test.fullName, name, value, number)
+			}
+		}
+	}
+}
+
+func TestRequiredFieldsUseDefaultMarshalValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		marshal pb.Message
+		wire    []byte
+		decode  pb.Message
+	}{
+		{name: "marshal", marshal: &TMManifest{}},
+		{name: "marshal nested", marshal: &TMManifests{List: []*TMManifest{{}}}},
+		{name: "unmarshal", wire: nil, decode: &TMManifest{}},
+		{name: "unmarshal nested", wire: []byte{0x0a, 0x00}, decode: &TMManifests{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var err error
+			if test.marshal != nil {
+				_, err = pb.Marshal(test.marshal)
+			} else {
+				err = pb.Unmarshal(test.wire, test.decode)
+			}
+			if err == nil {
+				t.Fatal("expected missing required field error")
+			}
+		})
+	}
+}
+
+func TestRequiredZeroValuesMarshal(t *testing.T) {
+	objectType := TMGetObjectByHash_otUNKNOWN
+	message := &TMGetObjectByHash{Type: &objectType, Query: pb.Bool(false)}
+	wire, err := pb.Marshal(message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(wire, []byte{0x08, 0x00, 0x10, 0x00}) {
+		t.Fatalf("wire = %x, want 08001000", wire)
+	}
+}
+
+func TestGeneratedAPIGolden(t *testing.T) {
+	_ = &TMLink{NodePubKey: []byte{}}
+	_ = &TMProposeSet{Previousledger: []byte{}}
+	_ = &TMIndexedObject{NodeID: []byte{}}
+	_ = &TMGetLedger{NodeIDs: [][]byte{}}
+	var _ TMGetObjectByHash_ObjectType = TMGetObjectByHash_otUNKNOWN
+	var _ TMPingPingType = TMPing_ptPING
+}

--- a/internal/validator/list/aggregator.go
+++ b/internal/validator/list/aggregator.go
@@ -1380,7 +1380,7 @@ func (a *Aggregator) ApplyCollection(coll *message.ValidatorListCollection, site
 		// rippled applyList(globalManifest, localManifest, ...) at
 		// ValidatorList.cpp:1140-1151.
 		mf := blob.Manifest
-		if len(mf) == 0 {
+		if !blob.HasManifest() {
 			mf = coll.Manifest
 		}
 		disp, pk, seq := a.ApplyList(mf, blob.Blob, blob.Signature, coll.Version, siteURI)

--- a/internal/validator/list/aggregator_test.go
+++ b/internal/validator/list/aggregator_test.go
@@ -450,6 +450,31 @@ func TestAggregator_ApplyCollection_AcceptedAndStale(t *testing.T) {
 	}
 }
 
+func TestAggregator_ApplyCollection_ExplicitEmptyLocalManifestDoesNotFallback(t *testing.T) {
+	pub := newPublisher(t, 0x01, 0x02)
+	validator := derivedValidatorKey(0x10)
+	agg, _ := list.New(list.Config{
+		PublisherKeys:      []list.PublisherKey{list.PublisherKey(pub.masterPub)},
+		Threshold:          1,
+		ValidatorManifests: manifest.NewCache(),
+		PublisherManifests: manifest.NewCache(),
+		Clock:              fixedClock(),
+	})
+	blob, signature := pub.signList(t, 1, 0, fixedClock()().Add(24*time.Hour).Unix(), [][33]byte{validator})
+
+	dispositions, _, _ := agg.ApplyCollection(&message.ValidatorListCollection{
+		Version:  2,
+		Manifest: pub.manifestB64,
+		Blobs: []message.ValidatorBlobInfo{{
+			Manifest:  []byte{},
+			Blob:      blob,
+			Signature: signature,
+		}},
+	}, "test://")
+
+	require.Equal(t, []list.Disposition{list.Malformed}, dispositions)
+}
+
 func deterministicKey(seed byte) (pub32 []byte, priv ed25519.PrivateKey) {
 	s := bytes.Repeat([]byte{seed}, ed25519.SeedSize)
 	priv = ed25519.NewKeyFromSeed(s)


### PR DESCRIPTION
## Summary

- Restore the exact rippled v3.2.0 proto2 peer schema and generated API contracts.
- Reject missing required fields and unknown required enum values before domain conversion, including streamed manifests.
- Preserve behaviorally relevant optional-field presence and pin deterministic protobuf generation with CI drift coverage.

## Verification

- `go test -count=1 ./internal/peermanagement/proto/... ./internal/peermanagement/message ./internal/peermanagement ./internal/consensus/adaptor`
- `go generate ./ledger/entry/... ./internal/peermanagement/proto` (clean tree)
- Exact schema SHA-256: `d52b004814cbe9d243fd132166c18da7923ddf5608827277bf5928457ee4bbe5`

Part of #1474.

Stack 1/3; followed by #1558.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional and explicitly zero-valued protocol fields.
  * Corrected ledger, peer status, ping/pong, and replay response validation.
  * Rejected malformed messages missing required data or containing unknown required fields.
  * Preserved valid status, timing, sequence, and routing information during message processing.
  * Corrected handling of unknown protocol enum values and malformed manifests.

* **Chores**
  * Updated protocol definitions, code generation, and CI validation.
  * Improved serialization and required-field validation.
  * Updated protocol tooling dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->