### PR TITLE
fix: bound peer protobuf expansion

### DIFF
--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -105,23 +105,10 @@ func (r *Router) handleManifests(msg *peermanagement.InboundMessage) bool {
 		return false
 	}
 
-	count, err := message.WalkManifests(msg.Payload, nil)
-	if err != nil {
-		r.logger.Warn("failed to decode manifests frame", "error", err, "peer", msg.PeerID)
-		r.gossip.IncPeerBadData(uint64(msg.PeerID), "manifests-decode")
-		return false
-	}
-	if count == 0 {
-		return true
-	}
-	if count > manifestFrameMaxEntries {
-		r.gossip.IncPeerBadData(uint64(msg.PeerID), "manifests-oversize")
-	}
-	accepted := make([][]byte, 0, min(count, manifestFrameMaxEntries))
+	accepted := make([][]byte, 0, manifestFrameMaxEntries)
 	valid := false
 	badManifest := false
-	charged := count > manifestFrameMaxEntries
-	_, _ = message.WalkManifests(msg.Payload, func(wire []byte) {
+	count, err := message.WalkManifests(msg.Payload, func(wire []byte) {
 		hash := sha512half.Sum(wire)
 		if r.messageSeen != nil && r.messageSeen.seenRecently(hash) {
 			valid = true
@@ -152,11 +139,21 @@ func (r *Router) handleManifests(msg *peermanagement.InboundMessage) bool {
 			if r.messageSeen != nil {
 				r.messageSeen.observe(hash)
 			}
-			// Expected and harmless: a peer gossiped a manifest we
-			// already have at equal or higher seq. No action.
 		}
 	})
-	if badManifest && !charged {
+	if err != nil {
+		r.logger.Warn("failed to decode manifests frame", "error", err, "peer", msg.PeerID)
+		reason := "manifests-decode"
+		if errors.Is(err, message.ErrWireLimit) {
+			reason = "manifests-oversize"
+		}
+		r.gossip.IncPeerBadData(uint64(msg.PeerID), reason)
+		return false
+	}
+	if count == 0 {
+		return true
+	}
+	if badManifest {
 		r.gossip.IncPeerBadData(uint64(msg.PeerID), "manifest-invalid")
 	}
 	r.relayManifests(msg.PeerID, accepted)

--- a/internal/consensus/adaptor/router_dispatch.go
+++ b/internal/consensus/adaptor/router_dispatch.go
@@ -144,8 +144,11 @@ func (r *Router) handleManifests(msg *peermanagement.InboundMessage) bool {
 	if err != nil {
 		r.logger.Warn("failed to decode manifests frame", "error", err, "peer", msg.PeerID)
 		reason := "manifests-decode"
-		if errors.Is(err, message.ErrWireLimit) {
+		var limitErr *message.WireLimitError
+		if errors.As(err, &limitErr) && limitErr.Reason == message.WireLimitManifests {
 			reason = "manifests-oversize"
+		} else if errors.Is(err, message.ErrWireLimit) {
+			reason = "wire-invalid"
 		}
 		r.gossip.IncPeerBadData(uint64(msg.PeerID), reason)
 		return false

--- a/internal/consensus/adaptor/router_manifests_test.go
+++ b/internal/consensus/adaptor/router_manifests_test.go
@@ -105,6 +105,17 @@ func rawManifestCollection(entries ...[]byte) []byte {
 	return payload
 }
 
+func nestedManifestGroups(depth int) []byte {
+	var payload []byte
+	for range depth {
+		payload = protowire.AppendTag(payload, 100, protowire.StartGroupType)
+	}
+	for range depth {
+		payload = protowire.AppendTag(payload, 100, protowire.EndGroupType)
+	}
+	return payload
+}
+
 // TestRouter_HandleManifests_AppliesAccepted drives an inbound
 // TMManifests frame through the router's Run loop and asserts that
 // after processing the cache contains the master→ephemeral binding
@@ -267,6 +278,21 @@ func TestRouter_ProcessManifestSpoolRejectsOversizeBeforeApply(t *testing.T) {
 // cache must reject it; no state change is the whole guarantee.
 // (The bad-data attribution surface is exercised in
 // router_bad_data_test.go — here we only verify the cache side.)
+func TestRouter_HandleManifests_GenericWireLimitUsesInvalidData(t *testing.T) {
+	router, _, _ := routerWithCache(t, nil, 0, 0)
+	badData := &badDataRecordingSender{}
+	router.gossip = badData
+
+	processed := router.handleManifests(&peermanagement.InboundMessage{
+		PeerID:  7,
+		Type:    message.TypeManifests,
+		Payload: nestedManifestGroups(16),
+	})
+
+	require.False(t, processed)
+	require.Equal(t, []badDataCall{{peerID: 7, reason: "wire-invalid"}}, badData.getBadDataCalls())
+}
+
 func TestRouter_HandleManifests_InvalidDoesNotStore(t *testing.T) {
 	engine := &mockEngine{}
 	adaptor := newTestAdaptor(t)

--- a/internal/consensus/adaptor/router_manifests_test.go
+++ b/internal/consensus/adaptor/router_manifests_test.go
@@ -94,6 +94,17 @@ func buildWireManifest(t *testing.T, seq uint32, masterSeed, ephSeed byte) []byt
 	return raw
 }
 
+func rawManifestCollection(entries ...[]byte) []byte {
+	var payload []byte
+	for _, wire := range entries {
+		entry := protowire.AppendTag(nil, 1, protowire.BytesType)
+		entry = protowire.AppendBytes(entry, wire)
+		payload = protowire.AppendTag(payload, 1, protowire.BytesType)
+		payload = protowire.AppendBytes(payload, entry)
+	}
+	return payload
+}
+
 // TestRouter_HandleManifests_AppliesAccepted drives an inbound
 // TMManifests frame through the router's Run loop and asserts that
 // after processing the cache contains the master→ephemeral binding
@@ -193,6 +204,60 @@ func TestRouter_ProcessManifestSpoolAppliesAndReleasesPeer(t *testing.T) {
 	stored, ok := cache.GetManifest(parsed.MasterKey())
 	require.True(t, ok)
 	require.Equal(t, wire, stored)
+	_, err = inbound.ManifestFrame.Materialize(context.Background())
+	require.ErrorIs(t, err, peermanagement.ErrManifestFrameClosed)
+}
+
+func TestRouter_ProcessManifestSpoolRejectsOversizeBeforeApply(t *testing.T) {
+	connections := make(chan manifestOverlayConnection, 1)
+	source := startRunningManifestOverlay(t, peermanagement.WithCompression(false))
+	source.overlay.SetPeerConnectCallback(func(peerID peermanagement.PeerID) {
+		connections <- manifestOverlayConnection{overlay: source, peerID: peerID}
+	})
+	client := startRunningManifestOverlay(t,
+		peermanagement.WithDataDir(t.TempDir()),
+		peermanagement.WithCompression(false),
+		peermanagement.WithMaxOutbound(1),
+		peermanagement.WithFixedPeers(source.overlay.ListenAddr()),
+	)
+
+	var connection manifestOverlayConnection
+	select {
+	case connection = <-connections:
+	case <-time.After(5 * time.Second):
+		t.Fatal("manifest source did not connect")
+	}
+
+	wire := buildWireManifest(t, 1, 0x26, 0x27)
+	entries := make([][]byte, manifestFrameMaxEntries+1)
+	for i := range entries {
+		entries[i] = wire
+	}
+	payload := rawManifestCollection(entries...)
+	payload = protowire.AppendTag(payload, 9, protowire.BytesType)
+	payload = protowire.AppendBytes(payload, make([]byte, 1<<20))
+	frame, err := message.BuildWireMessage(message.TypeManifests, payload)
+	require.NoError(t, err)
+	require.NoError(t, connection.overlay.overlay.Send(connection.peerID, frame))
+
+	var inbound *peermanagement.InboundMessage
+	select {
+	case inbound = <-client.overlay.ManifestMessages():
+	case <-time.After(5 * time.Second):
+		t.Fatal("spooled manifest did not reach the processing lane")
+	}
+	require.NotNil(t, inbound.ManifestFrame)
+
+	router, cache, _ := routerWithCache(t, nil, 0, 0)
+	badData := &badDataRecordingSender{}
+	router.gossip = badData
+	router.processManifestJob(inbound)
+
+	parsed, err := manifest.Deserialize(wire)
+	require.NoError(t, err)
+	_, stored := cache.GetManifest(parsed.MasterKey())
+	require.False(t, stored)
+	require.Equal(t, []badDataCall{{peerID: uint64(inbound.PeerID), reason: "manifests-oversize"}}, badData.getBadDataCalls())
 	_, err = inbound.ManifestFrame.Materialize(context.Background())
 	require.ErrorIs(t, err, peermanagement.ErrManifestFrameClosed)
 }
@@ -357,43 +422,33 @@ func TestRouter_ManifestAcceptedAfterPeerRemovalCompletesBootstrap(t *testing.T)
 	}
 }
 
-func TestRouter_HandleManifests_RelaysAcceptedEntriesExceptSource(t *testing.T) {
+func TestRouter_HandleManifests_RejectsOversizeBeforeRelay(t *testing.T) {
 	sender := &fakeManifestSender{broadcastErr: peermanagement.ErrSendBufferFull}
-	router, _, _ := routerWithCache(t, sender, 0, 0)
+	router, cache, _ := routerWithCache(t, sender, 0, 0)
 	badData := &badDataRecordingSender{}
 	router.gossip = badData
 
-	const acceptedCount = 100
-	wires := make([][]byte, 0, acceptedCount)
-	list := make([]message.Manifest, 0, acceptedCount+2)
-	for i := range acceptedCount {
-		wire := buildWireManifest(t, 1, byte(i), byte(i+acceptedCount))
-		wires = append(wires, wire)
-		list = append(list, message.Manifest{STObject: wire})
+	wire := buildWireManifest(t, 1, 0x43, 0x44)
+	wires := make([][]byte, manifestFrameMaxEntries+1)
+	for i := range wires {
+		wires[i] = wire
 	}
-	list = append(list,
-		message.Manifest{STObject: wires[0]},
-		message.Manifest{STObject: []byte{0x01}},
-	)
 
 	router.handleMessage(&peermanagement.InboundMessage{
 		PeerID:  7,
 		Type:    message.TypeManifests,
-		Payload: encodePayload(t, &message.Manifests{List: list}),
+		Payload: rawManifestCollection(wires...),
 	})
 
 	sender.mu.Lock()
 	broadcasts := append([]broadcastExceptCall(nil), sender.bcastsExcept...)
 	sender.mu.Unlock()
-	require.Len(t, broadcasts, 1, "one inbound collection must produce one relay attempt")
+	require.Empty(t, broadcasts)
 	require.Empty(t, sender.bcasts)
-	require.Equal(t, peermanagement.PeerID(7), broadcasts[0].peerID)
-
-	got := frameToManifestBytes(t, broadcasts[0].frame)
-	require.Len(t, got, acceptedCount)
-	for i := range wires {
-		require.Equal(t, wires[i], got[i], "accepted manifests must retain input order and bytes")
-	}
+	parsed, err := manifest.Deserialize(wire)
+	require.NoError(t, err)
+	_, stored := cache.GetManifest(parsed.MasterKey())
+	require.False(t, stored)
 	require.Equal(t, []badDataCall{{peerID: 7, reason: "manifests-oversize"}}, badData.getBadDataCalls())
 }
 

--- a/internal/consensus/adaptor/router_stale_state_test.go
+++ b/internal/consensus/adaptor/router_stale_state_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/LeJamon/go-xrpl/shamap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 func TestRouter_LateAccountStateNodesEnterFetchPackOnly(t *testing.T) {
@@ -74,19 +75,22 @@ func TestRouter_RejectsInvalidLedgerDataNodeCountsBeforeCaching(t *testing.T) {
 	require.NoError(t, err)
 	hash := [32]byte{0xB2}
 
-	nodes := make([]message.LedgerNode, 12289)
-	nodes[0] = message.LedgerNode{NodeID: wire[0].NodeID, NodeData: wire[0].Data}
-	for i, replyNodes := range [][]message.LedgerNode{nil, nodes} {
-		reply := &message.LedgerData{
-			LedgerHash: hash[:],
-			LedgerSeq:  closed.Sequence(),
-			InfoType:   message.LedgerInfoAsNode,
-			Nodes:      replyNodes,
-		}
+	reply := &message.LedgerData{
+		LedgerHash: hash[:],
+		LedgerSeq:  closed.Sequence(),
+		InfoType:   message.LedgerInfoAsNode,
+	}
+	emptyPayload := encodePayload(t, reply)
+	oversizedPayload := append([]byte(nil), emptyPayload...)
+	for range 12289 {
+		oversizedPayload = protowire.AppendTag(oversizedPayload, 4, protowire.BytesType)
+		oversizedPayload = protowire.AppendVarint(oversizedPayload, 0)
+	}
+	for i, payload := range [][]byte{emptyPayload, oversizedPayload} {
 		r.handleMessage(&peermanagement.InboundMessage{
 			PeerID:  peermanagement.PeerID(20 + i),
 			Type:    message.TypeLedgerData,
-			Payload: encodePayload(t, reply),
+			Payload: payload,
 		})
 	}
 
@@ -94,9 +98,8 @@ func TestRouter_RejectsInvalidLedgerDataNodeCountsBeforeCaching(t *testing.T) {
 	assert.False(t, ok, "oversized reply must be rejected before any node is cached")
 	calls := sender.getBadDataCalls()
 	require.Len(t, calls, 2)
-	for _, call := range calls {
-		assert.Equal(t, "ledger-data-count", call.reason)
-	}
+	assert.Equal(t, "ledger-data-count", calls[0].reason)
+	assert.Equal(t, "ledger-data-decode", calls[1].reason)
 }
 
 func TestRouter_LateAccountStateNodeRequiresNodeID(t *testing.T) {

--- a/internal/peermanagement/inbound_budget_test.go
+++ b/internal/peermanagement/inbound_budget_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 func readBudgetUsed(budget *readBudget) int64 {
@@ -20,7 +21,8 @@ func readBudgetUsed(budget *readBudget) int64 {
 }
 
 func TestInboundBulkBudgetFollowsMessageThroughConsumer(t *testing.T) {
-	payload := bytes.Repeat([]byte{0x4c}, 32*1024)
+	payload := protowire.AppendTag(nil, 100, protowire.BytesType)
+	payload = protowire.AppendBytes(payload, bytes.Repeat([]byte{0x4c}, 32*1024))
 	var wire bytes.Buffer
 	require.NoError(t, message.WriteMessage(&wire, message.TypeLedgerData, payload))
 	frame := wire.Bytes()

--- a/internal/peermanagement/inbound_handlers.go
+++ b/internal/peermanagement/inbound_handlers.go
@@ -582,7 +582,11 @@ func (o *Overlay) handleEndpointsMessage(evt Event) {
 
 	decoded, err := message.Decode(message.TypeEndpoints, evt.Payload)
 	if err != nil {
-		o.IncPeerBadData(evt.PeerID, "endpoints-decode")
+		reason := "endpoints-decode"
+		if errors.Is(err, message.ErrWireLimit) {
+			reason = wirePreflightChargeReason(err)
+		}
+		o.IncPeerBadData(evt.PeerID, reason)
 		return
 	}
 	eps, ok := decoded.(*message.Endpoints)

--- a/internal/peermanagement/inbound_handlers_test.go
+++ b/internal/peermanagement/inbound_handlers_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/cluster"
@@ -913,11 +914,11 @@ func TestHandleEndpoints_ChargesMalformedEntry(t *testing.T) {
 func TestHandleEndpoints_RejectsOversizedFrame(t *testing.T) {
 	o, peer := newEndpointsTestOverlay(t, PeerID(16))
 
-	eps := make([]message.Endpointv2, endpointsIngestMaxEntries)
-	for i := range eps {
-		eps[i] = message.Endpointv2{Endpoint: "10.0.0.1:51235", Hops: 1}
+	payload := make([]byte, 0, 2*endpointsIngestMaxEntries)
+	for range endpointsIngestMaxEntries {
+		payload = protowire.AppendTag(payload, 3, protowire.BytesType)
+		payload = protowire.AppendVarint(payload, 0)
 	}
-	payload := encodeEndpoints(t, 2, eps)
 	o.onMessageReceived(Event{
 		PeerID:      peer.ID(),
 		MessageType: message.TypeEndpoints,

--- a/internal/peermanagement/manifest_frame_test.go
+++ b/internal/peermanagement/manifest_frame_test.go
@@ -15,13 +15,19 @@ import (
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
 )
+
+func opaqueTestPayload(value []byte) []byte {
+	payload := protowire.AppendTag(nil, 100, protowire.BytesType)
+	return protowire.AppendBytes(payload, value)
+}
 
 func manifestAndLedgerFrames(t *testing.T, manifest, ledger []byte) []byte {
 	t.Helper()
 	var wire bytes.Buffer
 	require.NoError(t, message.WriteMessage(&wire, message.TypeManifests, manifest))
-	require.NoError(t, message.WriteMessage(&wire, message.TypeLedgerData, ledger))
+	require.NoError(t, message.WriteMessage(&wire, message.TypeLedgerData, opaqueTestPayload(ledger)))
 	return wire.Bytes()
 }
 
@@ -73,9 +79,10 @@ func TestOversizedManifestPeersDoNotBlockLedgerFrames(t *testing.T) {
 	require.NoError(t, err)
 
 	manifestPayload := bytes.Repeat([]byte{0x4d}, manifestSpoolThreshold+1)
+	ledgerPayloadSize := len(opaqueTestPayload([]byte{1}))
 	manifestMessages := make(chan *InboundMessage, 2)
 	acquisitionEvents := make(chan Event, 2)
-	budget := newReadBudget(int64(4*len(manifestPayload) + 2))
+	budget := newReadBudget(int64(4*len(manifestPayload) + 2*ledgerPayloadSize))
 	done := make(chan error, 2)
 
 	for i := 1; i <= 2; i++ {
@@ -108,8 +115,8 @@ func TestOversizedManifestPeersDoNotBlockLedgerFrames(t *testing.T) {
 		ledgers[event.PeerID] = event.Payload
 		event.release()
 	}
-	require.Equal(t, []byte{1}, ledgers[1])
-	require.Equal(t, []byte{2}, ledgers[2])
+	require.Equal(t, opaqueTestPayload([]byte{1}), ledgers[1])
+	require.Equal(t, opaqueTestPayload([]byte{2}), ledgers[2])
 	budget.mu.Lock()
 	require.Equal(t, int64(4*len(manifestPayload)), budget.used)
 	budget.mu.Unlock()
@@ -130,18 +137,20 @@ func TestSecondOversizedManifestBlocksOnlyItsPeer(t *testing.T) {
 	require.NoError(t, err)
 
 	manifestPayload := bytes.Repeat([]byte{0x4d}, manifestSpoolThreshold+1)
+	firstPayload := opaqueTestPayload([]byte("first"))
+	secondPayload := opaqueTestPayload([]byte("second"))
 	var wire bytes.Buffer
 	require.NoError(t, message.WriteMessage(&wire, message.TypeManifests, manifestPayload))
-	require.NoError(t, message.WriteMessage(&wire, message.TypeLedgerData, []byte("first")))
+	require.NoError(t, message.WriteMessage(&wire, message.TypeLedgerData, firstPayload))
 	require.NoError(t, message.WriteMessage(&wire, message.TypeManifests, manifestPayload))
-	require.NoError(t, message.WriteMessage(&wire, message.TypeLedgerData, []byte("second")))
+	require.NoError(t, message.WriteMessage(&wire, message.TypeLedgerData, secondPayload))
 
 	peer := newLatencyTestPeer(t)
 	peer.bufReader = bufio.NewReader(bytes.NewReader(wire.Bytes()))
 	manifestMessages := make(chan *InboundMessage, 2)
 	acquisitionEvents := make(chan Event, 2)
 	peer.SetManifestMessages(manifestMessages)
-	peer.SetInboundReadBudget(newReadBudget(int64(2*len(manifestPayload) + len("first") + len("second"))))
+	peer.SetInboundReadBudget(newReadBudget(int64(2*len(manifestPayload) + len(firstPayload) + len(secondPayload))))
 	peer.SetManifestSpoolDir(spoolDir)
 	peer.SetAcquisitionEvents(acquisitionEvents)
 	var bootstrapReady atomic.Int32
@@ -157,7 +166,7 @@ func TestSecondOversizedManifestBlocksOnlyItsPeer(t *testing.T) {
 	first := <-manifestMessages
 	require.NotNil(t, first.ManifestFrame)
 	firstLedger := <-acquisitionEvents
-	require.Equal(t, []byte("first"), firstLedger.Payload)
+	require.Equal(t, firstPayload, firstLedger.Payload)
 	firstLedger.release()
 	require.True(t, peer.bootstrapManifestPending.Load())
 	require.Zero(t, bootstrapReady.Load())
@@ -173,7 +182,7 @@ func TestSecondOversizedManifestBlocksOnlyItsPeer(t *testing.T) {
 	second := <-manifestMessages
 	require.NotNil(t, second.ManifestFrame)
 	secondLedger := <-acquisitionEvents
-	require.Equal(t, []byte("second"), secondLedger.Payload)
+	require.Equal(t, secondPayload, secondLedger.Payload)
 	secondLedger.release()
 	require.ErrorIs(t, <-done, io.EOF)
 	require.NoError(t, second.ManifestFrame.Close())

--- a/internal/peermanagement/message/manifests.go
+++ b/internal/peermanagement/message/manifests.go
@@ -9,6 +9,9 @@ import (
 // WalkManifests validates a TMManifests payload before visiting its entries.
 // The returned byte slices alias payload and are only valid during the call.
 func WalkManifests(payload []byte, visit func([]byte)) (int, error) {
+	if err := Preflight(TypeManifests, payload); err != nil {
+		return 0, err
+	}
 	count, err := validateManifests(payload, false, nil)
 	if err != nil {
 		return 0, err

--- a/internal/peermanagement/message/manifests_test.go
+++ b/internal/peermanagement/message/manifests_test.go
@@ -97,3 +97,22 @@ func TestWalkManifestsMatchesDecoderKnownFieldWireErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestWalkManifestsEnforcesCollectionLimitBeforeVisiting(t *testing.T) {
+	entry := protowire.AppendTag(nil, 1, protowire.BytesType)
+	entry = protowire.AppendBytes(entry, []byte("manifest"))
+	atLimit := repeatedMessageField(1, maxManifests, entry)
+
+	visits := 0
+	count, err := WalkManifests(atLimit, func([]byte) { visits++ })
+	require.NoError(t, err)
+	require.Equal(t, maxManifests, count)
+	require.Equal(t, maxManifests, visits)
+
+	overLimit := append(atLimit, repeatedMessageField(1, 1, entry)...)
+	visits = 0
+	count, err = WalkManifests(overLimit, func([]byte) { visits++ })
+	require.Zero(t, count)
+	requireWireLimit(t, err, WireLimitManifests, maxManifests, maxManifests+1)
+	require.Zero(t, visits)
+}

--- a/internal/peermanagement/message/serialize_proto.go
+++ b/internal/peermanagement/message/serialize_proto.go
@@ -848,7 +848,14 @@ func Encode(msg Message) ([]byte, error) {
 	if err := validateEnums(pmsg.ProtoReflect(), false); err != nil {
 		return nil, err
 	}
-	return pb.Marshal(pmsg)
+	encoded, err := pb.Marshal(pmsg)
+	if err != nil {
+		return nil, err
+	}
+	if err := Preflight(msg.Type(), encoded); err != nil {
+		return nil, err
+	}
+	return encoded, nil
 }
 
 // Decode decodes a message from bytes using protobuf.
@@ -857,12 +864,15 @@ func Decode(msgType MessageType, data []byte) (Message, error) {
 	if !ok {
 		return nil, fmt.Errorf("unknown message type: %d", msgType)
 	}
+	if err := Preflight(msgType, data); err != nil {
+		return nil, fmt.Errorf("failed to preflight: %w", err)
+	}
 	pmsg := c.newProto()
 	normalized, err := normalizeEnumWire(data, pmsg.ProtoReflect().Descriptor())
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal: %w", err)
 	}
-	if err := pb.Unmarshal(normalized, pmsg); err != nil {
+	if err := (pb.UnmarshalOptions{RecursionLimit: maxWireDepth, DiscardUnknown: true}).Unmarshal(normalized, pmsg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal: %w", err)
 	}
 	if err := validateEnums(pmsg.ProtoReflect(), true); err != nil {

--- a/internal/peermanagement/message/wire_preflight.go
+++ b/internal/peermanagement/message/wire_preflight.go
@@ -30,16 +30,17 @@ var (
 type WireLimitReason string
 
 const (
-	WireLimitDepth          WireLimitReason = "nesting-depth"
-	WireLimitFieldCount     WireLimitReason = "field-count"
-	WireLimitTransactions   WireLimitReason = "transactions"
-	WireLimitGetObjects     WireLimitReason = "get-objects"
-	WireLimitLedgerData     WireLimitReason = "ledger-data-nodes"
-	WireLimitEndpoints      WireLimitReason = "endpoints"
-	WireLimitValidatorBlobs WireLimitReason = "validator-blobs"
-	WireLimitManifests      WireLimitReason = "manifests"
-	WireLimitClusterNodes   WireLimitReason = "cluster-nodes"
-	WireLimitLoadSources    WireLimitReason = "load-sources"
+	WireLimitDepth                 WireLimitReason = "nesting-depth"
+	WireLimitFieldCount            WireLimitReason = "field-count"
+	WireLimitTransactions          WireLimitReason = "transactions"
+	WireLimitGetObjects            WireLimitReason = "get-objects"
+	WireLimitGetObjectTransactions WireLimitReason = "get-object-transactions"
+	WireLimitLedgerData            WireLimitReason = "ledger-data-nodes"
+	WireLimitEndpoints             WireLimitReason = "endpoints"
+	WireLimitValidatorBlobs        WireLimitReason = "validator-blobs"
+	WireLimitManifests             WireLimitReason = "manifests"
+	WireLimitClusterNodes          WireLimitReason = "cluster-nodes"
+	WireLimitLoadSources           WireLimitReason = "load-sources"
 )
 
 type WireLimitError struct {
@@ -88,11 +89,13 @@ func Preflight(msgType MessageType, data []byte) error {
 	}
 	if msgType == TypeGetObjects {
 		limit := maxGetObjects
+		reason := WireLimitGetObjects
 		if state.getObjectTransactions {
 			limit = maxTransactions
+			reason = WireLimitGetObjectTransactions
 		}
 		if state.getObjects > limit {
-			return wireLimit(WireLimitGetObjects, limit, state.getObjects)
+			return wireLimit(reason, limit, state.getObjects)
 		}
 	}
 	return nil

--- a/internal/peermanagement/message/wire_preflight.go
+++ b/internal/peermanagement/message/wire_preflight.go
@@ -1,0 +1,299 @@
+package message
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/proto"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+const (
+	maxWireDepth       = 16
+	maxWireFieldCount  = 131_072
+	maxTransactions    = 10_000
+	maxGetObjects      = 12_288
+	maxLedgerDataNodes = 12_288
+	maxEndpoints       = 1_023
+	maxValidatorBlobs  = 5
+	maxManifests       = 100
+	maxClusterNodes    = 1_024
+	maxLoadSources     = 1_024
+)
+
+var (
+	ErrWireLimit     = errors.New("protobuf wire resource limit")
+	ErrMalformedWire = errors.New("malformed protobuf wire")
+)
+
+type WireLimitReason string
+
+const (
+	WireLimitDepth          WireLimitReason = "nesting-depth"
+	WireLimitFieldCount     WireLimitReason = "field-count"
+	WireLimitTransactions   WireLimitReason = "transactions"
+	WireLimitGetObjects     WireLimitReason = "get-objects"
+	WireLimitLedgerData     WireLimitReason = "ledger-data-nodes"
+	WireLimitEndpoints      WireLimitReason = "endpoints"
+	WireLimitValidatorBlobs WireLimitReason = "validator-blobs"
+	WireLimitManifests      WireLimitReason = "manifests"
+	WireLimitClusterNodes   WireLimitReason = "cluster-nodes"
+	WireLimitLoadSources    WireLimitReason = "load-sources"
+)
+
+type WireLimitError struct {
+	Reason   WireLimitReason
+	Limit    int
+	Observed int
+}
+
+func (e *WireLimitError) Error() string {
+	return fmt.Sprintf("%s: %s: got %d, limit %d", ErrWireLimit, e.Reason, e.Observed, e.Limit)
+}
+
+func (e *WireLimitError) Unwrap() error {
+	return ErrWireLimit
+}
+
+var wireDescriptors = func() map[MessageType]protoreflect.MessageDescriptor {
+	descriptors := make(map[MessageType]protoreflect.MessageDescriptor, len(codecs))
+	for msgType, codec := range codecs {
+		descriptors[msgType] = codec.newProto().ProtoReflect().Descriptor()
+	}
+	return descriptors
+}()
+
+type wireScanState struct {
+	msgType               MessageType
+	fields                int
+	collection            int
+	loadSources           int
+	getObjects            int
+	getObjectTransactions bool
+}
+
+func Preflight(msgType MessageType, data []byte) error {
+	descriptor, ok := wireDescriptors[msgType]
+	if !ok {
+		return fmt.Errorf("unknown message type: %d", msgType)
+	}
+	state := wireScanState{msgType: msgType}
+	consumed, err := state.scanMessage(data, descriptor, 1, 0)
+	if err != nil {
+		return err
+	}
+	if consumed != len(data) {
+		return malformedWire(consumed, "unexpected end group")
+	}
+	if msgType == TypeGetObjects {
+		limit := maxGetObjects
+		if state.getObjectTransactions {
+			limit = maxTransactions
+		}
+		if state.getObjects > limit {
+			return wireLimit(WireLimitGetObjects, limit, state.getObjects)
+		}
+	}
+	return nil
+}
+
+func (s *wireScanState) scanMessage(
+	data []byte,
+	descriptor protoreflect.MessageDescriptor,
+	depth int,
+	endGroup protowire.Number,
+) (int, error) {
+	for offset := 0; offset < len(data); {
+		fieldOffset := offset
+		number, wireType, tagLen := protowire.ConsumeTag(data[offset:])
+		if tagLen < 0 || number < protowire.MinValidNumber || number > protowire.MaxValidNumber {
+			return 0, malformedWire(fieldOffset, "invalid tag")
+		}
+		offset += tagLen
+
+		if wireType == protowire.EndGroupType {
+			if endGroup == 0 || number != endGroup {
+				return 0, malformedWire(fieldOffset, "unexpected end group")
+			}
+			return offset, nil
+		}
+
+		s.fields++
+		if s.fields > maxWireFieldCount {
+			return 0, wireLimit(WireLimitFieldCount, maxWireFieldCount, s.fields)
+		}
+
+		var field protoreflect.FieldDescriptor
+		if descriptor != nil {
+			field = descriptor.Fields().ByNumber(number)
+		}
+		value := data[offset:]
+		valueLen, err := s.scanValue(value, field, number, wireType, depth)
+		if err != nil {
+			return 0, malformedWireAt(err, fieldOffset)
+		}
+		if depth == 1 {
+			if err := s.observeRootField(field, wireType, value); err != nil {
+				return 0, malformedWireAt(err, fieldOffset)
+			}
+		}
+		offset += valueLen
+	}
+	if endGroup != 0 {
+		return 0, malformedWire(len(data), "unterminated group")
+	}
+	return len(data), nil
+}
+
+func (s *wireScanState) scanValue(
+	data []byte,
+	field protoreflect.FieldDescriptor,
+	number protowire.Number,
+	wireType protowire.Type,
+	depth int,
+) (int, error) {
+	switch wireType {
+	case protowire.VarintType:
+		_, n := protowire.ConsumeVarint(data)
+		if n < 0 {
+			return 0, protowire.ParseError(n)
+		}
+		return n, nil
+	case protowire.Fixed32Type:
+		if len(data) < 4 {
+			return 0, errors.New("truncated fixed32")
+		}
+		return 4, nil
+	case protowire.Fixed64Type:
+		if len(data) < 8 {
+			return 0, errors.New("truncated fixed64")
+		}
+		return 8, nil
+	case protowire.BytesType:
+		value, n := protowire.ConsumeBytes(data)
+		if n < 0 {
+			return 0, protowire.ParseError(n)
+		}
+		if field != nil && field.Kind() == protoreflect.MessageKind {
+			if depth >= maxWireDepth {
+				return 0, wireLimit(WireLimitDepth, maxWireDepth, depth+1)
+			}
+			if _, err := s.scanMessage(value, field.Message(), depth+1, 0); err != nil {
+				return 0, err
+			}
+		}
+		return n, nil
+	case protowire.StartGroupType:
+		if depth >= maxWireDepth {
+			return 0, wireLimit(WireLimitDepth, maxWireDepth, depth+1)
+		}
+		var nested protoreflect.MessageDescriptor
+		if field != nil && field.Kind() == protoreflect.GroupKind {
+			nested = field.Message()
+		}
+		return s.scanMessage(data, nested, depth+1, number)
+	default:
+		return 0, errors.New("invalid wire type")
+	}
+}
+
+func (s *wireScanState) observeRootField(
+	field protoreflect.FieldDescriptor,
+	wireType protowire.Type,
+	data []byte,
+) error {
+	if field == nil {
+		return nil
+	}
+	if s.msgType == TypeGetObjects && field.Number() == 1 &&
+		field.Kind() == protoreflect.EnumKind && wireType == protowire.VarintType {
+		value, n := protowire.ConsumeVarint(data)
+		if n < 0 {
+			return protowire.ParseError(n)
+		}
+		number := protoreflect.EnumNumber(value)
+		if field.Enum().Values().ByNumber(number) != nil {
+			s.getObjectTransactions = number == protoreflect.EnumNumber(proto.TMGetObjectByHash_otTRANSACTIONS)
+		}
+	}
+	if wireType != protowire.BytesType || !field.IsList() || field.Kind() != protoreflect.MessageKind {
+		return nil
+	}
+
+	var reason WireLimitReason
+	limit := 0
+	switch s.msgType {
+	case TypeTransactions:
+		if field.Number() == 1 {
+			reason, limit = WireLimitTransactions, maxTransactions
+		}
+	case TypeGetObjects:
+		if field.Number() == 6 {
+			s.getObjects++
+			return nil
+		}
+	case TypeLedgerData:
+		if field.Number() == 4 {
+			reason, limit = WireLimitLedgerData, maxLedgerDataNodes
+		}
+	case TypeEndpoints:
+		if field.Number() == 3 {
+			reason, limit = WireLimitEndpoints, maxEndpoints
+		}
+	case TypeValidatorListCollection:
+		if field.Number() == 3 {
+			reason, limit = WireLimitValidatorBlobs, maxValidatorBlobs
+		}
+	case TypeManifests:
+		if field.Number() == 1 {
+			reason, limit = WireLimitManifests, maxManifests
+		}
+	case TypeCluster:
+		switch field.Number() {
+		case 1:
+			reason, limit = WireLimitClusterNodes, maxClusterNodes
+		case 2:
+			reason, limit = WireLimitLoadSources, maxLoadSources
+		}
+	}
+	if limit == 0 {
+		return nil
+	}
+	count := s.collectionCount(reason) + 1
+	s.setCollectionCount(reason, count)
+	if count > limit {
+		return wireLimit(reason, limit, count)
+	}
+	return nil
+}
+
+func (s *wireScanState) collectionCount(reason WireLimitReason) int {
+	if reason == WireLimitLoadSources {
+		return s.loadSources
+	}
+	return s.collection
+}
+
+func (s *wireScanState) setCollectionCount(reason WireLimitReason, count int) {
+	if reason == WireLimitLoadSources {
+		s.loadSources = count
+		return
+	}
+	s.collection = count
+}
+
+func wireLimit(reason WireLimitReason, limit, observed int) error {
+	return &WireLimitError{Reason: reason, Limit: limit, Observed: observed}
+}
+
+func malformedWire(offset int, reason string) error {
+	return fmt.Errorf("%w at byte %d: %s", ErrMalformedWire, offset, reason)
+}
+
+func malformedWireAt(err error, offset int) error {
+	if errors.Is(err, ErrWireLimit) || errors.Is(err, ErrMalformedWire) {
+		return err
+	}
+	return malformedWire(offset, err.Error())
+}

--- a/internal/peermanagement/message/wire_preflight_test.go
+++ b/internal/peermanagement/message/wire_preflight_test.go
@@ -1,0 +1,346 @@
+package message
+
+import (
+	"errors"
+	"testing"
+	"unsafe"
+
+	peerproto "github.com/LeJamon/go-xrpl/internal/peermanagement/proto"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+	pb "google.golang.org/protobuf/proto"
+)
+
+func repeatedMessageField(field protowire.Number, count int, entry []byte) []byte {
+	wire := make([]byte, 0, count*(len(entry)+2))
+	for range count {
+		wire = protowire.AppendTag(wire, field, protowire.BytesType)
+		wire = protowire.AppendBytes(wire, entry)
+	}
+	return wire
+}
+
+func requireWireLimit(t *testing.T, err error, reason WireLimitReason, limit, observed int) {
+	t.Helper()
+	require.ErrorIs(t, err, ErrWireLimit)
+	var limitErr *WireLimitError
+	require.ErrorAs(t, err, &limitErr)
+	require.Equal(t, reason, limitErr.Reason)
+	require.Equal(t, limit, limitErr.Limit)
+	require.Equal(t, observed, limitErr.Observed)
+}
+
+func TestPreflightCollectionLimitsInclusive(t *testing.T) {
+	tests := []struct {
+		name    string
+		msgType MessageType
+		field   protowire.Number
+		limit   int
+		reason  WireLimitReason
+		prefix  []byte
+	}{
+		{name: "transactions", msgType: TypeTransactions, field: 1, limit: maxTransactions, reason: WireLimitTransactions},
+		{name: "get objects transactions", msgType: TypeGetObjects, field: 6, limit: maxTransactions, reason: WireLimitGetObjects, prefix: enumField(1, uint64(ObjectTypeTransactions))},
+		{name: "ledger data", msgType: TypeLedgerData, field: 4, limit: maxLedgerDataNodes, reason: WireLimitLedgerData},
+		{name: "endpoints", msgType: TypeEndpoints, field: 3, limit: maxEndpoints, reason: WireLimitEndpoints},
+		{name: "validator blobs", msgType: TypeValidatorListCollection, field: 3, limit: maxValidatorBlobs, reason: WireLimitValidatorBlobs},
+		{name: "manifests", msgType: TypeManifests, field: 1, limit: maxManifests, reason: WireLimitManifests},
+		{name: "cluster nodes", msgType: TypeCluster, field: 1, limit: maxClusterNodes, reason: WireLimitClusterNodes},
+		{name: "load sources", msgType: TypeCluster, field: 2, limit: maxLoadSources, reason: WireLimitLoadSources},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			atLimit := append(append([]byte(nil), test.prefix...), repeatedMessageField(test.field, test.limit, nil)...)
+			require.NoError(t, Preflight(test.msgType, atLimit))
+
+			overLimit := append(atLimit, repeatedMessageField(test.field, 1, nil)...)
+			requireWireLimit(t, Preflight(test.msgType, overLimit), test.reason, test.limit, test.limit+1)
+		})
+	}
+}
+
+func TestPreflightClusterLimitsAreIndependent(t *testing.T) {
+	wire := repeatedMessageField(1, maxClusterNodes, nil)
+	wire = append(wire, repeatedMessageField(2, maxLoadSources, nil)...)
+	require.NoError(t, Preflight(TypeCluster, wire))
+
+	overNodes := append(append([]byte(nil), wire...), repeatedMessageField(1, 1, nil)...)
+	requireWireLimit(t, Preflight(TypeCluster, overNodes), WireLimitClusterNodes, maxClusterNodes, maxClusterNodes+1)
+
+	overSources := append(append([]byte(nil), wire...), repeatedMessageField(2, 1, nil)...)
+	requireWireLimit(t, Preflight(TypeCluster, overSources), WireLimitLoadSources, maxLoadSources, maxLoadSources+1)
+}
+
+func enumField(field protowire.Number, value uint64) []byte {
+	wire := protowire.AppendTag(nil, field, protowire.VarintType)
+	return protowire.AppendVarint(wire, value)
+}
+
+func TestPreflightGetObjectsUsesLastRecognizedType(t *testing.T) {
+	objects10001 := repeatedMessageField(6, maxTransactions+1, nil)
+	objects12288 := repeatedMessageField(6, maxGetObjects, nil)
+	unknown := uint64(99)
+
+	tests := []struct {
+		name   string
+		types  []uint64
+		wire   []byte
+		limit  int
+		reject bool
+	}{
+		{name: "absent type uses general cap", wire: objects12288},
+		{name: "unknown type uses general cap", types: []uint64{unknown}, wire: objects12288},
+		{name: "transactions then unknown stays transactions", types: []uint64{uint64(ObjectTypeTransactions), unknown}, wire: objects10001, limit: maxTransactions, reject: true},
+		{name: "transactions then ledger uses general cap", types: []uint64{uint64(ObjectTypeTransactions), uint64(ObjectTypeLedger)}, wire: objects12288},
+		{name: "ledger unknown transactions uses transactions cap", types: []uint64{uint64(ObjectTypeLedger), unknown, uint64(ObjectTypeTransactions)}, wire: objects10001, limit: maxTransactions, reject: true},
+		{name: "unknown transactions unknown stays transactions", types: []uint64{unknown, uint64(ObjectTypeTransactions), unknown}, wire: objects10001, limit: maxTransactions, reject: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var wire []byte
+			for _, value := range test.types {
+				wire = append(wire, enumField(1, value)...)
+			}
+			wire = append(wire, test.wire...)
+			err := Preflight(TypeGetObjects, wire)
+			if !test.reject {
+				require.NoError(t, err)
+				return
+			}
+			requireWireLimit(t, err, WireLimitGetObjects, test.limit, maxTransactions+1)
+		})
+	}
+
+	overGeneral := repeatedMessageField(6, maxGetObjects+1, nil)
+	requireWireLimit(t, Preflight(TypeGetObjects, overGeneral), WireLimitGetObjects, maxGetObjects, maxGetObjects+1)
+}
+
+func TestPreflightMalformedWire(t *testing.T) {
+	nestedTruncatedFixed32 := protowire.AppendTag(nil, 100, protowire.Fixed32Type)
+	nestedTruncatedFixed32 = append(nestedTruncatedFixed32, 1, 2, 3)
+	nestedFixed := protowire.AppendTag(nil, 1, protowire.BytesType)
+	nestedFixed = protowire.AppendBytes(nestedFixed, nestedTruncatedFixed32)
+
+	tests := []struct {
+		name    string
+		msgType MessageType
+		wire    []byte
+	}{
+		{name: "zero tag", msgType: TypePing, wire: []byte{0}},
+		{name: "invalid wire type", msgType: TypePing, wire: []byte{0x0e}},
+		{name: "overflowing tag", msgType: TypePing, wire: []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02}},
+		{name: "overflowing varint", msgType: TypePing, wire: append([]byte{0x08}, []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02}...)},
+		{name: "truncated fixed32", msgType: TypePing, wire: []byte{0x15, 1, 2, 3}},
+		{name: "truncated fixed64", msgType: TypePing, wire: []byte{0x11, 1, 2, 3, 4, 5, 6, 7}},
+		{name: "truncated length", msgType: TypeTransactions, wire: []byte{0x0a, 0x02, 0x08}},
+		{name: "malformed nested tag", msgType: TypeTransactions, wire: []byte{0x0a, 0x01, 0x00}},
+		{name: "malformed nested fixed", msgType: TypeTransactions, wire: nestedFixed},
+		{name: "unexpected end group", msgType: TypePing, wire: []byte{0x0c}},
+		{name: "mismatched end group", msgType: TypePing, wire: []byte{0x0b, 0x14}},
+		{name: "unterminated group", msgType: TypePing, wire: []byte{0x0b}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := Preflight(test.msgType, test.wire)
+			require.ErrorIs(t, err, ErrMalformedWire)
+			require.NotErrorIs(t, err, ErrWireLimit)
+		})
+	}
+}
+
+func TestPreflightMalformedCapCrossingFieldIsMalformed(t *testing.T) {
+	wire := repeatedMessageField(3, maxEndpoints, nil)
+	wire = protowire.AppendTag(wire, 3, protowire.BytesType)
+	wire = protowire.AppendVarint(wire, 4)
+	wire = append(wire, 0)
+
+	err := Preflight(TypeEndpoints, wire)
+	require.ErrorIs(t, err, ErrMalformedWire)
+	require.NotErrorIs(t, err, ErrWireLimit)
+}
+
+func nestedGroups(depth int) []byte {
+	wire := make([]byte, 0, depth*2)
+	for range depth {
+		wire = protowire.AppendTag(wire, 1, protowire.StartGroupType)
+	}
+	for range depth {
+		wire = protowire.AppendTag(wire, 1, protowire.EndGroupType)
+	}
+	return wire
+}
+
+func TestPreflightDepthLimitInclusive(t *testing.T) {
+	require.NoError(t, Preflight(TypePing, nestedGroups(maxWireDepth-1)))
+	requireWireLimit(t, Preflight(TypePing, nestedGroups(maxWireDepth)), WireLimitDepth, maxWireDepth, maxWireDepth+1)
+}
+
+func repeatedVarintFields(count int) []byte {
+	wire := make([]byte, 0, count*3)
+	for range count {
+		wire = protowire.AppendTag(wire, 100, protowire.VarintType)
+		wire = protowire.AppendVarint(wire, 0)
+	}
+	return wire
+}
+
+func TestPreflightFieldCountLimitInclusive(t *testing.T) {
+	require.NoError(t, Preflight(TypePing, repeatedVarintFields(maxWireFieldCount)))
+	requireWireLimit(t, Preflight(TypePing, repeatedVarintFields(maxWireFieldCount+1)), WireLimitFieldCount, maxWireFieldCount, maxWireFieldCount+1)
+}
+
+func TestPreflightUnknownBytesAreOpaque(t *testing.T) {
+	opaque := append([]byte{0x00, 0x0b}, nestedGroups(maxWireDepth+1)...)
+	wire := protowire.AppendTag(nil, 100, protowire.BytesType)
+	wire = protowire.AppendBytes(wire, opaque)
+	require.NoError(t, Preflight(TypePing, wire))
+}
+
+func TestPreflightKnownWrongWireTypeIsUnknownCompatible(t *testing.T) {
+	wire := protowire.AppendTag(nil, 1, protowire.VarintType)
+	wire = protowire.AppendVarint(wire, 0)
+	require.NoError(t, Preflight(TypeTransactions, wire))
+	decoded, err := Decode(TypeTransactions, wire)
+	require.NoError(t, err)
+	require.Empty(t, decoded.(*Transactions).Transactions)
+}
+
+func TestPreflightValidInputAllocations(t *testing.T) {
+	representative := repeatedMessageField(3, 16, nil)
+	atCap := repeatedMessageField(1, maxTransactions, nil)
+
+	var err error
+	require.Zero(t, testing.AllocsPerRun(1_000, func() {
+		err = Preflight(TypeEndpoints, representative)
+	}))
+	require.NoError(t, err)
+	require.Zero(t, testing.AllocsPerRun(100, func() {
+		err = Preflight(TypeTransactions, atCap)
+	}))
+	require.NoError(t, err)
+}
+
+func TestDecodeClassifiesPreflightErrors(t *testing.T) {
+	_, err := Decode(TypePing, []byte{0})
+	require.ErrorIs(t, err, ErrMalformedWire)
+
+	_, err = Decode(TypeEndpoints, repeatedMessageField(3, maxEndpoints+1, nil))
+	requireWireLimit(t, err, WireLimitEndpoints, maxEndpoints, maxEndpoints+1)
+}
+
+func TestEncodeAppliesWireCollectionPolicy(t *testing.T) {
+	_, err := Encode(&Endpoints{EndpointsV2: make([]Endpointv2, maxEndpoints)})
+	require.NoError(t, err)
+	_, err = Encode(&Endpoints{EndpointsV2: make([]Endpointv2, maxEndpoints+1)})
+	requireWireLimit(t, err, WireLimitEndpoints, maxEndpoints, maxEndpoints+1)
+
+	transactions := make([]Transaction, maxTransactions+1)
+	for i := range transactions {
+		transactions[i].Status = TxStatusNew
+	}
+	_, err = Encode(&Transactions{Transactions: transactions})
+	requireWireLimit(t, err, WireLimitTransactions, maxTransactions, maxTransactions+1)
+
+	_, err = Encode(&Manifests{List: make([]Manifest, maxManifests+1)})
+	requireWireLimit(t, err, WireLimitManifests, maxManifests, maxManifests+1)
+}
+
+func TestMaximumAcceptedCollectionStructuralMemoryEnvelope(t *testing.T) {
+	domainInput := &GetObjectByHash{
+		ObjType: ObjectTypeUnknown,
+		Objects: make([]IndexedObject, maxGetObjects),
+	}
+	wire, err := Encode(domainInput)
+	require.NoError(t, err)
+
+	generated := &peerproto.TMGetObjectByHash{}
+	err = (pb.UnmarshalOptions{RecursionLimit: maxWireDepth, DiscardUnknown: true}).Unmarshal(wire, generated)
+	require.NoError(t, err)
+	require.Len(t, generated.Objects, maxGetObjects)
+
+	decoded, err := Decode(TypeGetObjects, wire)
+	require.NoError(t, err)
+	domain := decoded.(*GetObjectByHash)
+	require.Len(t, domain.Objects, maxGetObjects)
+
+	const allocationHeader = uintptr(16)
+	generatedObjectBytes := uintptr(len(generated.Objects)) *
+		(unsafe.Sizeof(peerproto.TMIndexedObject{}) + allocationHeader)
+	generatedSliceBytes := uintptr(cap(generated.Objects)) * unsafe.Sizeof((*peerproto.TMIndexedObject)(nil))
+	domainSliceBytes := uintptr(cap(domain.Objects)) * unsafe.Sizeof(IndexedObject{})
+	// A compressed frame can overlap its decompressed payload, an enum-filtered
+	// copy, and protobuf-owned known bytes until domain conversion completes.
+	maxWireBytes := uintptr(MaxPayloadSize + HeaderSizeCompressed)
+	maxDecompressedBytes := uintptr(MaxMessageSize)
+	maxNormalizedBytes := uintptr(MaxMessageSize)
+	maxGeneratedKnownBytes := uintptr(MaxMessageSize)
+	// Capacity slack and per-field overhead cover allocator rounding, byte-field
+	// allocation metadata, optional scalar pointees, and protobuf bookkeeping.
+	maxGeneratedCapacitySlack := maxGeneratedKnownBytes / 8
+	maxPerFieldHeapOverhead := uintptr(maxWireFieldCount) * 64
+	const maxTopLevelHeapOverhead = uintptr(1 << 20)
+	peakStructuralBytes := maxWireBytes + maxDecompressedBytes + maxNormalizedBytes +
+		maxGeneratedKnownBytes + maxGeneratedCapacitySlack + maxPerFieldHeapOverhead +
+		maxTopLevelHeapOverhead + generatedObjectBytes + generatedSliceBytes + domainSliceBytes
+
+	const envelope = uintptr(280 << 20)
+	require.LessOrEqual(t, peakStructuralBytes, envelope)
+	t.Logf("maximum accepted get-objects frame: wire=%d decompressed=%d normalized=%d generated=%d allocator=%d domain=%d peak envelope=%d/%d bytes",
+		maxWireBytes, maxDecompressedBytes, maxNormalizedBytes,
+		maxGeneratedKnownBytes+generatedObjectBytes+generatedSliceBytes,
+		maxGeneratedCapacitySlack+maxPerFieldHeapOverhead+maxTopLevelHeapOverhead,
+		domainSliceBytes, peakStructuralBytes, envelope)
+}
+
+func FuzzPreflight(f *testing.F) {
+	f.Add(uint8(0), []byte{})
+	f.Add(uint8(3), []byte{0})
+	f.Add(uint8(7), nestedGroups(maxWireDepth))
+	types := []MessageType{
+		TypeManifests,
+		TypePing,
+		TypeCluster,
+		TypeEndpoints,
+		TypeTransaction,
+		TypeGetLedger,
+		TypeLedgerData,
+		TypeProposeLedger,
+		TypeStatusChange,
+		TypeHaveSet,
+		TypeValidation,
+		TypeGetObjects,
+		TypeValidatorList,
+		TypeSquelch,
+		TypeValidatorListCollection,
+		TypeProofPathReq,
+		TypeProofPathResponse,
+		TypeReplayDeltaReq,
+		TypeReplayDeltaResponse,
+		TypeHaveTransactions,
+		TypeTransactions,
+	}
+	f.Fuzz(func(t *testing.T, selector uint8, wire []byte) {
+		msgType := types[int(selector)%len(types)]
+		first := Preflight(msgType, wire)
+		second := Preflight(msgType, wire)
+		if first == nil {
+			require.NoError(t, second)
+			return
+		}
+		require.Error(t, second)
+		firstLimit := errors.Is(first, ErrWireLimit)
+		firstMalformed := errors.Is(first, ErrMalformedWire)
+		require.True(t, firstLimit || firstMalformed)
+		require.Equal(t, firstLimit, errors.Is(second, ErrWireLimit))
+		require.Equal(t, firstMalformed, errors.Is(second, ErrMalformedWire))
+		if firstLimit {
+			var firstDetail, secondDetail *WireLimitError
+			require.ErrorAs(t, first, &firstDetail)
+			require.ErrorAs(t, second, &secondDetail)
+			require.Equal(t, firstDetail, secondDetail)
+		}
+	})
+}

--- a/internal/peermanagement/message/wire_preflight_test.go
+++ b/internal/peermanagement/message/wire_preflight_test.go
@@ -40,7 +40,7 @@ func TestPreflightCollectionLimitsInclusive(t *testing.T) {
 		prefix  []byte
 	}{
 		{name: "transactions", msgType: TypeTransactions, field: 1, limit: maxTransactions, reason: WireLimitTransactions},
-		{name: "get objects transactions", msgType: TypeGetObjects, field: 6, limit: maxTransactions, reason: WireLimitGetObjects, prefix: enumField(1, uint64(ObjectTypeTransactions))},
+		{name: "get objects transactions", msgType: TypeGetObjects, field: 6, limit: maxTransactions, reason: WireLimitGetObjectTransactions, prefix: enumField(1, uint64(ObjectTypeTransactions))},
 		{name: "ledger data", msgType: TypeLedgerData, field: 4, limit: maxLedgerDataNodes, reason: WireLimitLedgerData},
 		{name: "endpoints", msgType: TypeEndpoints, field: 3, limit: maxEndpoints, reason: WireLimitEndpoints},
 		{name: "validator blobs", msgType: TypeValidatorListCollection, field: 3, limit: maxValidatorBlobs, reason: WireLimitValidatorBlobs},
@@ -109,7 +109,7 @@ func TestPreflightGetObjectsUsesLastRecognizedType(t *testing.T) {
 				require.NoError(t, err)
 				return
 			}
-			requireWireLimit(t, err, WireLimitGetObjects, test.limit, maxTransactions+1)
+			requireWireLimit(t, err, WireLimitGetObjectTransactions, test.limit, maxTransactions+1)
 		})
 	}
 

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -1739,6 +1739,7 @@ func chargeForReason(reason string) resource.Charge {
 		"replay-delta-resp-unnegotiated",
 		"proof-path-resp-unnegotiated",
 		"compression-unnegotiated",
+		"get-objects-transactions-oversize",
 		"get-objects-ledgerhash",
 		"have-set-hashsize",
 		"proposal-decode",
@@ -1776,6 +1777,8 @@ func wirePreflightChargeReason(err error) string {
 			return "endpoints-too-large"
 		case message.WireLimitManifests:
 			return "manifests-oversize"
+		case message.WireLimitGetObjectTransactions:
+			return "get-objects-transactions-oversize"
 		}
 	}
 	return "wire-invalid"

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -1236,6 +1236,15 @@ func (p *Peer) readLoop(ctx context.Context) error {
 				retainedReservation -= int64(header.PayloadSize)
 			}
 		}
+		if err := message.Preflight(header.MessageType, payload); err != nil {
+			reason := wirePreflightChargeReason(err)
+			p.IncBadData(reason)
+			releaseRetainedReservation()
+			if header.MessageType == message.TypeManifests && p.onBootstrapReady != nil {
+				return fmt.Errorf("bootstrap manifests wire preflight failed: %w", err)
+			}
+			continue
+		}
 		p.traffic.AddCount(CategorizeMessage(header.MessageType), true, len(payload))
 
 		delivered := p.dispatchEvent(Event{
@@ -1706,7 +1715,8 @@ func chargeForReason(reason string) resource.Charge {
 		"squelch-map-full",
 		"squelch-malformed-pubkey",
 		"decompress-lz4-failed",
-		"message-too-large":
+		"message-too-large",
+		"wire-invalid":
 		return resource.FeeInvalidData
 	case "endpoints-too-large":
 		return resource.FeeUselessData
@@ -1756,6 +1766,19 @@ func chargeForReason(reason string) resource.Charge {
 		return resource.FeeUselessData
 	}
 	return resource.FeeInvalidData
+}
+
+func wirePreflightChargeReason(err error) string {
+	var limitErr *message.WireLimitError
+	if errors.As(err, &limitErr) {
+		switch limitErr.Reason {
+		case message.WireLimitEndpoints:
+			return "endpoints-too-large"
+		case message.WireLimitManifests:
+			return "manifests-oversize"
+		}
+	}
+	return "wire-invalid"
 }
 
 // IncBadData routes a reason-keyed charge through the resource

--- a/internal/peermanagement/peer_frame_liveness_test.go
+++ b/internal/peermanagement/peer_frame_liveness_test.go
@@ -206,8 +206,9 @@ func (r *countingReader) Read(dst []byte) (int, error) {
 
 func TestPeerManifestReadBudgetBoundsPayloadAllocation(t *testing.T) {
 	payload := bytes.Repeat([]byte{0x4d}, 32*1024)
+	wirePayload := opaqueTestPayload(payload)
 	frame := manifestFrame(t, payload)
-	budget := newReadBudget(int64(len(payload)))
+	budget := newReadBudget(int64(len(wirePayload)))
 
 	firstQueue := make(chan *InboundMessage, 1)
 	firstQueue <- &InboundMessage{}
@@ -220,7 +221,7 @@ func TestPeerManifestReadBudgetBoundsPayloadAllocation(t *testing.T) {
 	require.Eventually(t, func() bool {
 		budget.mu.Lock()
 		defer budget.mu.Unlock()
-		return budget.used == int64(len(payload))
+		return budget.used == int64(len(wirePayload))
 	}, time.Second, time.Millisecond)
 
 	secondReader := &countingReader{reader: bytes.NewReader(frame)}
@@ -242,7 +243,7 @@ func TestPeerManifestReadBudgetBoundsPayloadAllocation(t *testing.T) {
 	require.NoError(t, firstInbound.Close())
 	require.Eventually(t, func() bool { return secondReader.read.Load() == int64(len(frame)) }, time.Second, time.Millisecond)
 	secondInbound := <-secondQueue
-	require.Equal(t, payload, secondInbound.Payload)
+	require.Equal(t, wirePayload, secondInbound.Payload)
 	require.NoError(t, secondInbound.Close())
 	require.ErrorIs(t, <-firstDone, io.EOF)
 	require.ErrorIs(t, <-secondDone, io.EOF)
@@ -292,7 +293,7 @@ func newFrameLivenessPeer(t *testing.T, clock *livenessClock, conn net.Conn) (*P
 func manifestFrame(t *testing.T, payload []byte) []byte {
 	t.Helper()
 	var frame bytes.Buffer
-	require.NoError(t, message.WriteMessage(&frame, message.TypeManifests, payload))
+	require.NoError(t, message.WriteMessage(&frame, message.TypeManifests, opaqueTestPayload(payload)))
 	return frame.Bytes()
 }
 
@@ -319,7 +320,7 @@ func TestPeerReadLoopAllowsProgressBeyondIdleInterval(t *testing.T) {
 	require.Len(t, events, 1)
 	event := <-events
 	assert.Equal(t, message.TypeManifests, event.MessageType)
-	assert.Equal(t, []byte("manifest"), event.Payload)
+	assert.Equal(t, opaqueTestPayload([]byte("manifest")), event.Payload)
 	assert.Equal(t, 12*time.Second, clock.current().Sub(time.Unix(1_000, 0)))
 	require.GreaterOrEqual(t, len(conn.deadlines), 4)
 	for i := 1; i < 4; i++ {
@@ -367,7 +368,7 @@ func TestPeerReadLoopReportsPartialFrameProgress(t *testing.T) {
 	require.ErrorAs(t, err, &frameErr)
 	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 	assert.Equal(t, message.TypeManifests, frameErr.MessageType)
-	assert.Equal(t, uint32(len(payload)), frameErr.WireSize)
+	assert.Equal(t, uint32(len(opaqueTestPayload(payload))), frameErr.WireSize)
 	assert.False(t, frameErr.Compressed)
 	assert.Equal(t, uint64(3), frameErr.BytesRead)
 	assert.Equal(t, 2*time.Second, frameErr.Elapsed)
@@ -404,7 +405,10 @@ func TestPeerReadLoopRejectsTricklePastFrameBudget(t *testing.T) {
 			{after: time.Second, data: frame[6:7]},
 			{after: time.Second, data: frame[7:8]},
 			{after: time.Second, data: frame[8:9]},
-			{after: time.Second, data: frame[9:]},
+			{after: time.Second, data: frame[9:10]},
+			{after: time.Second, data: frame[10:11]},
+			{after: time.Second, data: frame[11:12]},
+			{after: time.Second, data: frame[12:]},
 		},
 	}
 	peer, events := newFrameLivenessPeer(t, clock, conn)

--- a/internal/peermanagement/peer_wire_preflight_test.go
+++ b/internal/peermanagement/peer_wire_preflight_test.go
@@ -23,6 +23,12 @@ func peerRepeatedMessageField(field protowire.Number, count int) []byte {
 	return wire
 }
 
+func peerGetObjectTransactionsPayload(count int) []byte {
+	wire := protowire.AppendTag(nil, 1, protowire.VarintType)
+	wire = protowire.AppendVarint(wire, uint64(message.ObjectTypeTransactions))
+	return append(wire, peerRepeatedMessageField(6, count)...)
+}
+
 func TestPeerWirePreflightChargesAndDropsBeforeDispatch(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -53,6 +59,13 @@ func TestPeerWirePreflightChargesAndDropsBeforeDispatch(t *testing.T) {
 			payload: peerRepeatedMessageField(1, 10_001),
 			reason:  "wire-invalid",
 			charge:  resource.FeeInvalidData,
+		},
+		{
+			name:    "get object transactions",
+			msgType: message.TypeGetObjects,
+			payload: peerGetObjectTransactionsPayload(10_001),
+			reason:  "get-objects-transactions-oversize",
+			charge:  resource.FeeMalformedRequest,
 		},
 	}
 

--- a/internal/peermanagement/peer_wire_preflight_test.go
+++ b/internal/peermanagement/peer_wire_preflight_test.go
@@ -1,0 +1,97 @@
+package peermanagement
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/resource"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+func peerRepeatedMessageField(field protowire.Number, count int) []byte {
+	wire := make([]byte, 0, count*2)
+	for range count {
+		wire = protowire.AppendTag(wire, field, protowire.BytesType)
+		wire = protowire.AppendBytes(wire, nil)
+	}
+	return wire
+}
+
+func TestPeerWirePreflightChargesAndDropsBeforeDispatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		msgType  message.MessageType
+		payload  []byte
+		reason   string
+		charge   resource.Charge
+		compress bool
+	}{
+		{
+			name:     "endpoints",
+			msgType:  message.TypeEndpoints,
+			payload:  peerRepeatedMessageField(3, 1_024),
+			reason:   "endpoints-too-large",
+			charge:   resource.FeeUselessData,
+			compress: true,
+		},
+		{
+			name:    "manifests",
+			msgType: message.TypeManifests,
+			payload: peerRepeatedMessageField(1, 101),
+			reason:  "manifests-oversize",
+			charge:  resource.FeeModerateBurdenPeer,
+		},
+		{
+			name:    "transactions",
+			msgType: message.TypeTransactions,
+			payload: peerRepeatedMessageField(1, 10_001),
+			reason:  "wire-invalid",
+			charge:  resource.FeeInvalidData,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			frame, err := message.BuildWireMessage(test.msgType, test.payload)
+			require.NoError(t, err)
+			if test.compress {
+				var compressed bool
+				frame, compressed = message.CompressFrameIfWorthwhile(frame)
+				require.True(t, compressed)
+			}
+
+			identity, err := NewIdentity()
+			require.NoError(t, err)
+			events := make(chan Event, 1)
+			peer := NewPeer(PeerID(i+1), Endpoint{Host: "192.0.2.1", Port: 51235}, false, identity, events)
+			manager := resource.NewManager(nil, nil)
+			consumer := manager.NewInboundEndpoint(peer.Endpoint().String())
+			peer.attachUsage(consumer, func() {})
+			peer.handshakeCfg.EnableCompression = test.compress
+			if test.compress {
+				peer.capabilities = NewPeerCapabilities()
+				peer.capabilities.Features.Enable(FeatureCompression)
+			}
+			peer.bufReader = bufio.NewReader(bytes.NewReader(frame))
+
+			err = peer.readLoop(context.Background())
+			require.ErrorIs(t, err, io.EOF)
+			require.Empty(t, events)
+			require.Positive(t, peer.BadDataCount())
+			require.Equal(t, test.charge, chargeForReason(test.reason))
+			require.Zero(t, peer.traffic.TotalStats().MessagesIn)
+		})
+	}
+}
+
+func TestPeerWirePreflightMalformedUsesInvalidDataClass(t *testing.T) {
+	reason := wirePreflightChargeReason(errors.Join(message.ErrMalformedWire, errors.New("bad tag")))
+	require.Equal(t, "wire-invalid", reason)
+	require.Equal(t, resource.FeeInvalidData, chargeForReason(reason))
+}


### PR DESCRIPTION
## Summary

- Add descriptor-driven, zero-allocation protobuf wire preflight before unmarshal.
- Enforce message-specific collection limits plus recursion and field-count ceilings.
- Apply preflight and classified resource charging after decompression and before dispatch, including spooled manifests.
- Demonstrate a conservative maximum accepted-frame live-memory envelope below 280 MiB.

## Verification

- `go test -count=1 ./internal/peermanagement/message ./internal/peermanagement ./internal/consensus/adaptor`
- `go test -race -count=1 ./internal/peermanagement/message ./internal/peermanagement`
- Boundary, malformed-wire, allocation, fuzz-seed, peer, spool, and memory-envelope regressions

Part of #1474.

Stack 2/3; depends on #1557 and is followed by #1559.
