### PR TITLE
fix: enforce symmetric peer frame contracts

### DIFF
--- a/internal/consensus/adaptor/manifest_emit_test.go
+++ b/internal/consensus/adaptor/manifest_emit_test.go
@@ -132,9 +132,11 @@ func (f *fakeManifestSender) Peers() []peermanagement.PeerInfo {
 func frameToManifestBytes(t *testing.T, frame []byte) [][]byte {
 	t.Helper()
 	r := bytes.NewReader(frame)
-	hdr, payload, err := message.ReadMessage(r)
+	hdr, err := message.ReadHeader(r)
+	require.NoError(t, err)
+	payload, err := message.ReadPayload(r, *hdr)
 	if err != nil {
-		t.Fatalf("ReadMessage: %v", err)
+		t.Fatalf("ReadPayload: %v", err)
 	}
 	if hdr.MessageType != message.TypeManifests {
 		t.Fatalf("frame type: got %v want TypeManifests", hdr.MessageType)

--- a/internal/consensus/adaptor/router.go
+++ b/internal/consensus/adaptor/router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/ledger/inbound"
 	"github.com/LeJamon/go-xrpl/internal/manifest"
 	"github.com/LeJamon/go-xrpl/internal/peermanagement"
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
 	validatorlist "github.com/LeJamon/go-xrpl/internal/validator/list"
 	"github.com/LeJamon/go-xrpl/shamap"
 )
@@ -1007,6 +1008,9 @@ func (r *Router) processManifestJobContext(ctx context.Context, msg *peermanagem
 		}()
 		payload, err := msg.ManifestFrame.Materialize(ctx)
 		if err != nil {
+			if errors.Is(err, message.ErrDecompressFailed) && r.gossip != nil {
+				r.gossip.IncPeerBadData(uint64(msg.PeerID), "decompress-lz4-failed")
+			}
 			r.logger.Warn("failed to materialize manifest spool", "error", err, "peer", msg.PeerID)
 			return
 		}

--- a/internal/consensus/adaptor/router_catchup_test.go
+++ b/internal/consensus/adaptor/router_catchup_test.go
@@ -5,7 +5,6 @@
 package adaptor
 
 import (
-	"bytes"
 	"context"
 	"testing"
 	"time"
@@ -30,8 +29,6 @@ func statusChangeMessage(t *testing.T, peerID peermanagement.PeerID, seq uint32,
 	}
 	encoded, err := message.Encode(sc)
 	require.NoError(t, err)
-	var buf bytes.Buffer
-	require.NoError(t, message.WriteMessage(&buf, message.TypeStatusChange, encoded))
 	return &peermanagement.InboundMessage{
 		PeerID:  peerID,
 		Type:    message.TypeStatusChange,

--- a/internal/consensus/adaptor/router_manifests_test.go
+++ b/internal/consensus/adaptor/router_manifests_test.go
@@ -273,6 +273,56 @@ func TestRouter_ProcessManifestSpoolRejectsOversizeBeforeApply(t *testing.T) {
 	require.ErrorIs(t, err, peermanagement.ErrManifestFrameClosed)
 }
 
+func TestRouter_ProcessManifestSpoolChargesDecompressionFailure(t *testing.T) {
+	connections := make(chan manifestOverlayConnection, 1)
+	source := startRunningManifestOverlay(t, peermanagement.WithCompression(true))
+	source.overlay.SetPeerConnectCallback(func(peerID peermanagement.PeerID) {
+		connections <- manifestOverlayConnection{overlay: source, peerID: peerID}
+	})
+	client := startRunningManifestOverlay(t,
+		peermanagement.WithDataDir(t.TempDir()),
+		peermanagement.WithCompression(true),
+		peermanagement.WithMaxOutbound(1),
+		peermanagement.WithFixedPeers(source.overlay.ListenAddr()),
+	)
+
+	var connection manifestOverlayConnection
+	select {
+	case connection = <-connections:
+	case <-time.After(5 * time.Second):
+		t.Fatal("manifest source did not connect")
+	}
+
+	payload := bytes.Repeat([]byte("manifest"), 1<<20/len("manifest")+1)
+	frame, err := message.BuildWireMessage(message.TypeManifests, payload)
+	require.NoError(t, err)
+	frame, compressed := message.CompressFrameIfWorthwhile(frame)
+	require.True(t, compressed)
+	for i := message.HeaderSizeCompressed; i < len(frame); i++ {
+		frame[i] = 0xff
+	}
+	header, err := message.DecodeHeader(frame)
+	require.NoError(t, err)
+	_, err = message.DecompressLZ4(frame[message.HeaderSizeCompressed:], int(header.UncompressedSize))
+	require.Error(t, err)
+	require.NoError(t, connection.overlay.overlay.Send(connection.peerID, frame))
+
+	var inbound *peermanagement.InboundMessage
+	select {
+	case inbound = <-client.overlay.ManifestMessages():
+	case <-time.After(5 * time.Second):
+		t.Fatal("spooled manifest did not reach the processing lane")
+	}
+	require.NotNil(t, inbound.ManifestFrame)
+
+	router, _, _ := routerWithCache(t, nil, 0, 0)
+	badData := &badDataRecordingSender{}
+	router.gossip = badData
+	router.processManifestJob(inbound)
+
+	require.Equal(t, []badDataCall{{peerID: uint64(inbound.PeerID), reason: "decompress-lz4-failed"}}, badData.getBadDataCalls())
+}
+
 // TestRouter_HandleManifests_InvalidDoesNotStore drives a
 // parse-valid-but-signature-invalid manifest through the router. The
 // cache must reject it; no state change is the whole guarantee.

--- a/internal/peermanagement/bootstrap_test.go
+++ b/internal/peermanagement/bootstrap_test.go
@@ -1,7 +1,6 @@
 package peermanagement
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -668,9 +667,9 @@ func TestOverlayConnectsOutboundTargetBeforeStartupFrameCompletes(t *testing.T) 
 			List: []message.Manifest{{STObject: []byte{1}}},
 		})
 		require.NoError(t, err)
-		var frame bytes.Buffer
-		require.NoError(t, message.WriteMessage(&frame, message.TypeManifests, payload))
-		require.NoError(t, connected.overlay.Send(connected.peerID, frame.Bytes()))
+		frame, err := message.BuildWireMessage(message.TypeManifests, payload)
+		require.NoError(t, err)
+		require.NoError(t, connected.overlay.Send(connected.peerID, frame))
 		select {
 		case inbound := <-client.ManifestMessages():
 			_, err := message.Decode(message.TypeManifests, inbound.Payload)

--- a/internal/peermanagement/errors.go
+++ b/internal/peermanagement/errors.go
@@ -114,7 +114,7 @@ func (e *FanoutError) Unwrap() error {
 	return e.Err
 }
 
-var errCompressionUnnegotiated = errors.New("outbound compressed frame without negotiated compression")
+var errCompressionUnnegotiated = errors.New("compressed frame without negotiated compression")
 var errBootstrapManifestDropped = errors.New("bootstrap manifests could not be delivered")
 
 // FrameReadError describes a failed payload transfer after its header was read.

--- a/internal/peermanagement/frame_test.go
+++ b/internal/peermanagement/frame_test.go
@@ -1,0 +1,44 @@
+package peermanagement
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/LeJamon/go-xrpl/internal/peermanagement/message"
+)
+
+func readTestFrame(r io.Reader) (*message.Header, []byte, error) {
+	header, err := message.ReadHeader(r)
+	if err != nil {
+		return nil, nil, err
+	}
+	payload, err := message.ReadPayload(r, *header)
+	if err != nil {
+		return nil, nil, err
+	}
+	return header, payload, nil
+}
+
+func rawTestWireMessage(
+	msgType message.MessageType,
+	payload []byte,
+	algorithm message.CompressionAlgorithm,
+	uncompressedSize uint32,
+) []byte {
+	headerSize := message.HeaderSizeUncompressed
+	if algorithm != message.AlgorithmNone {
+		headerSize = message.HeaderSizeCompressed
+	}
+	frame := make([]byte, headerSize+len(payload))
+	firstFour := uint32(len(payload))
+	if algorithm != message.AlgorithmNone {
+		firstFour |= uint32(algorithm) << 24
+	}
+	binary.BigEndian.PutUint32(frame[:4], firstFour)
+	binary.BigEndian.PutUint16(frame[4:6], uint16(msgType))
+	if algorithm != message.AlgorithmNone {
+		binary.BigEndian.PutUint32(frame[6:10], uncompressedSize)
+	}
+	copy(frame[headerSize:], payload)
+	return frame
+}

--- a/internal/peermanagement/get_objects_serve_test.go
+++ b/internal/peermanagement/get_objects_serve_test.go
@@ -18,7 +18,7 @@ import (
 func decodeGetObjectsReply(t *testing.T, peer *Peer) *message.GetObjectByHash {
 	t.Helper()
 	if frame, ok := takeOutboundFrame(peer); ok {
-		hdr, payload, err := message.ReadMessage(bytes.NewReader(frame))
+		hdr, payload, err := readTestFrame(bytes.NewReader(frame))
 		require.NoError(t, err)
 		require.Equal(t, message.TypeGetObjects, hdr.MessageType)
 		decoded, err := message.Decode(message.TypeGetObjects, payload)

--- a/internal/peermanagement/inbound_budget_test.go
+++ b/internal/peermanagement/inbound_budget_test.go
@@ -109,6 +109,29 @@ func TestCompressedManifestSpoolSharesInboundBudget(t *testing.T) {
 	require.ErrorIs(t, <-done, io.EOF)
 }
 
+func TestUnnegotiatedCompressedManifestRejectedBeforeSpooling(t *testing.T) {
+	spoolDir, err := prepareManifestSpoolDir(t.TempDir())
+	require.NoError(t, err)
+	budget := newReadBudget(int64(3 * message.MaxMessageSize))
+	peer := newLatencyTestPeer(t)
+	peer.bufReader = bufio.NewReader(bytes.NewReader(rawTestWireMessage(
+		message.TypeManifests,
+		[]byte{0xff},
+		message.AlgorithmLZ4,
+		manifestSpoolThreshold+1,
+	)))
+	peer.SetInboundReadBudget(budget)
+	peer.SetManifestSpoolDir(spoolDir)
+
+	err = peer.readLoop(context.Background())
+	require.ErrorIs(t, err, errCompressionUnnegotiated)
+	require.Positive(t, peer.BadDataCount())
+	require.Zero(t, readBudgetUsed(budget))
+	entries, readErr := os.ReadDir(spoolDir)
+	require.NoError(t, readErr)
+	require.Empty(t, entries)
+}
+
 func TestInboundRetainedBytesValidation(t *testing.T) {
 	cfg := DefaultConfig()
 	require.Equal(t, DefaultInboundRetainedBytes, cfg.InboundRetainedBytes)

--- a/internal/peermanagement/inbound_budget_test.go
+++ b/internal/peermanagement/inbound_budget_test.go
@@ -23,9 +23,8 @@ func readBudgetUsed(budget *readBudget) int64 {
 func TestInboundBulkBudgetFollowsMessageThroughConsumer(t *testing.T) {
 	payload := protowire.AppendTag(nil, 100, protowire.BytesType)
 	payload = protowire.AppendBytes(payload, bytes.Repeat([]byte{0x4c}, 32*1024))
-	var wire bytes.Buffer
-	require.NoError(t, message.WriteMessage(&wire, message.TypeLedgerData, payload))
-	frame := wire.Bytes()
+	frame, err := message.BuildWireMessage(message.TypeLedgerData, payload)
+	require.NoError(t, err)
 
 	budget := newReadBudget(int64(len(payload)))
 	events := make(chan Event, 2)
@@ -412,15 +411,15 @@ func TestTransactionsBatchRetainsBudgetUntilAllChildrenClose(t *testing.T) {
 
 func TestOverlayShutdownReleasesQueuedManifestSpool(t *testing.T) {
 	payload := bytes.Repeat([]byte{0x4d}, manifestSpoolThreshold+1)
-	var wire bytes.Buffer
-	require.NoError(t, message.WriteMessage(&wire, message.TypeManifests, payload))
+	wire, err := message.BuildWireMessage(message.TypeManifests, payload)
+	require.NoError(t, err)
 
 	spoolDir, err := prepareManifestSpoolDir(t.TempDir())
 	require.NoError(t, err)
 	budget := newReadBudget(int64(2 * len(payload)))
 	manifests := make(chan *InboundMessage, 1)
 	peer := newLatencyTestPeer(t)
-	peer.bufReader = bufio.NewReader(bytes.NewReader(wire.Bytes()))
+	peer.bufReader = bufio.NewReader(bytes.NewReader(wire))
 	peer.SetManifestMessages(manifests)
 	peer.SetInboundReadBudget(budget)
 	peer.SetManifestSpoolDir(spoolDir)

--- a/internal/peermanagement/ledgersync.go
+++ b/internal/peermanagement/ledgersync.go
@@ -61,12 +61,11 @@ type ContextFetchPackProvider interface {
 
 // Ledger sync constants.
 const (
-	// MaxReplayDeltaResponseBytes caps the complete encoded wire frame of a
-	// replay/proof response. The check deliberately includes protobuf field
+	// MaxProofPathResponseBytes caps the complete encoded wire frame of a
+	// proof response. The check deliberately includes protobuf field
 	// tags, varints, and the six-byte XRPL frame header rather than only raw
 	// ledger node bytes.
-	MaxReplayDeltaResponseBytes = 16 * 1024 * 1024
-	MaxProofPathResponseBytes   = MaxReplayDeltaResponseBytes
+	MaxProofPathResponseBytes = 16 * 1024 * 1024
 )
 
 // LedgerProvider is called to retrieve ledger data for responses.
@@ -402,12 +401,12 @@ func (h *LedgerSyncHandler) sendProofPathResponse(ctx context.Context, peerID Pe
 }
 
 func replayDeltaResponseOversized(ledgerHash, header []byte, txLeaves [][]byte) bool {
-	frame, err := message.EncodeFrame(&message.ReplayDeltaResponse{
+	_, err := message.EncodeFrame(&message.ReplayDeltaResponse{
 		LedgerHash:   ledgerHash,
 		LedgerHeader: header,
 		Transactions: txLeaves,
 	})
-	return err != nil || len(frame) > MaxReplayDeltaResponseBytes
+	return err != nil
 }
 
 func proofPathResponseOversized(req *message.ProofPathRequest, header []byte, path [][]byte) bool {
@@ -429,8 +428,8 @@ func proofPathResponseOversized(req *message.ProofPathRequest, header []byte, pa
 //  2. Look up the ledger and require it to be immutable, else charge and drop.
 //  3. Pack the ledger header (addRaw on LedgerInfo) and every leaf blob in
 //     the tx map, in tx-map iteration order.
-//  4. Defensive size cap: if the response payload would exceed
-//     MaxReplayDeltaResponseBytes, charge and drop the populated list.
+//  4. Refuse a response that cannot be represented within the protocol frame
+//     ceiling, and charge the no-reply fee.
 //
 // Successful responses use the peer's bounded acquisition lane when wired by
 // the overlay; standalone handlers fall back to EventLedgerResponse.
@@ -479,7 +478,7 @@ func (h *LedgerSyncHandler) handleReplayDeltaRequest(ctx context.Context, peerID
 			"t", "LedgerSync",
 			"peer", peerID,
 			"size", len(header),
-			"limit", MaxReplayDeltaResponseBytes,
+			"limit", message.MaxMessageSize,
 		)
 		h.charge(peerID, resource.FeeRequestNoReply, "replay delta response oversized")
 		return nil
@@ -514,10 +513,6 @@ func (h *LedgerSyncHandler) sendReplayDeltaResponse(ctx context.Context, peerID 
 	frame, err := message.EncodeFrame(resp)
 	if err != nil {
 		slog.Warn("ReplayDelta encode failed", "t", "LedgerSync", "peer", peerID, "err", err)
-		return
-	}
-	if len(frame) > MaxReplayDeltaResponseBytes {
-		h.charge(peerID, resource.FeeRequestNoReply, "replay delta response oversized")
 		return
 	}
 	h.mu.RLock()

--- a/internal/peermanagement/manifest_frame_test.go
+++ b/internal/peermanagement/manifest_frame_test.go
@@ -25,10 +25,11 @@ func opaqueTestPayload(value []byte) []byte {
 
 func manifestAndLedgerFrames(t *testing.T, manifest, ledger []byte) []byte {
 	t.Helper()
-	var wire bytes.Buffer
-	require.NoError(t, message.WriteMessage(&wire, message.TypeManifests, manifest))
-	require.NoError(t, message.WriteMessage(&wire, message.TypeLedgerData, opaqueTestPayload(ledger)))
-	return wire.Bytes()
+	manifestFrame, err := message.BuildWireMessage(message.TypeManifests, manifest)
+	require.NoError(t, err)
+	ledgerFrame, err := message.BuildWireMessage(message.TypeLedgerData, opaqueTestPayload(ledger))
+	require.NoError(t, err)
+	return append(manifestFrame, ledgerFrame...)
 }
 
 type failingManifestSpoolWriter struct {
@@ -140,10 +141,19 @@ func TestSecondOversizedManifestBlocksOnlyItsPeer(t *testing.T) {
 	firstPayload := opaqueTestPayload([]byte("first"))
 	secondPayload := opaqueTestPayload([]byte("second"))
 	var wire bytes.Buffer
-	require.NoError(t, message.WriteMessage(&wire, message.TypeManifests, manifestPayload))
-	require.NoError(t, message.WriteMessage(&wire, message.TypeLedgerData, firstPayload))
-	require.NoError(t, message.WriteMessage(&wire, message.TypeManifests, manifestPayload))
-	require.NoError(t, message.WriteMessage(&wire, message.TypeLedgerData, secondPayload))
+	for _, candidate := range []struct {
+		msgType message.MessageType
+		payload []byte
+	}{
+		{message.TypeManifests, manifestPayload},
+		{message.TypeLedgerData, firstPayload},
+		{message.TypeManifests, manifestPayload},
+		{message.TypeLedgerData, secondPayload},
+	} {
+		frame, err := message.BuildWireMessage(candidate.msgType, candidate.payload)
+		require.NoError(t, err)
+		wire.Write(frame)
+	}
 
 	peer := newLatencyTestPeer(t)
 	peer.bufReader = bufio.NewReader(bytes.NewReader(wire.Bytes()))

--- a/internal/peermanagement/message/codec.go
+++ b/internal/peermanagement/message/codec.go
@@ -7,7 +7,7 @@ import (
 	"io"
 )
 
-// Per-MessageType payload-size caps applied by ReadMessage BEFORE
+// Per-MessageType payload-size caps applied during header validation before
 // allocating. Without these, a peer can claim MaxPayloadSize for any
 // type and force a 64MB allocation per claim — trivial OOM vector.
 // Values are ~10× typical observed traffic per known type.
@@ -47,9 +47,10 @@ func payloadSizeLimit(t MessageType) uint32 {
 		TypeReplayDeltaReq,
 		TypeTransaction:
 		return mediumMsgMax
-	case TypeProofPathResponse,
-		TypeReplayDeltaResponse:
+	case TypeProofPathResponse:
 		return largeMsgMax
+	case TypeReplayDeltaResponse:
+		return MaxMessageSize
 	case TypeManifests,
 		TypeValidatorList,
 		TypeValidatorListCollection,
@@ -65,7 +66,7 @@ func payloadSizeLimit(t MessageType) uint32 {
 		// TMValidatorList / TMValidatorListCollection blob is bounded only
 		// by the ceiling. A tighter local cap would tear down a peer
 		// mid-sync, so these rely on the protocol ceiling (enforced in
-		// ReadMessage) rather than a stricter limit.
+		// framing validation) rather than a stricter limit.
 		return MaxMessageSize
 	default:
 		return MaxMessageSize
@@ -82,7 +83,7 @@ const (
 	HeaderSizeCompressed = 10
 
 	// MaxMessageSize is the hard protocol ceiling (rippled's single 64 MB
-	// cap). ReadMessage rejects any message whose on-wire or uncompressed
+	// cap). Header validation rejects any message whose on-wire or uncompressed
 	// claim exceeds it; the per-type caps above add stricter, type-aware
 	// hardening on top.
 	MaxMessageSize = 64 * 1024 * 1024
@@ -147,7 +148,7 @@ const (
 )
 
 // HeaderSize returns the size of the header based on compression.
-func (h *Header) HeaderSize() int {
+func (h Header) HeaderSize() int {
 	if h.Compressed {
 		return HeaderSizeCompressed
 	}
@@ -155,7 +156,7 @@ func (h *Header) HeaderSize() int {
 }
 
 // TotalSize returns the total size of the message (header + payload).
-func (h *Header) TotalSize() int {
+func (h Header) TotalSize() int {
 	return h.HeaderSize() + int(h.PayloadSize)
 }
 
@@ -163,46 +164,28 @@ func (h *Header) TotalSize() int {
 // For uncompressed messages, buf must be at least 6 bytes.
 // For compressed messages, buf must be at least 10 bytes.
 func EncodeHeader(buf []byte, payloadSize uint32, msgType MessageType, algorithm CompressionAlgorithm, uncompressedSize uint32) error {
-	if payloadSize > MaxPayloadSize {
-		return ErrMessageTooLarge
+	header, err := newHeader(payloadSize, msgType, algorithm, uncompressedSize)
+	if err != nil {
+		return err
 	}
 
-	compressed := algorithm != AlgorithmNone
-	requiredSize := HeaderSizeUncompressed
-	if compressed {
-		requiredSize = HeaderSizeCompressed
+	if len(buf) < header.HeaderSize() {
+		return fmt.Errorf("buffer too small: need %d, got %d", header.HeaderSize(), len(buf))
 	}
-
-	if len(buf) < requiredSize {
-		return fmt.Errorf("buffer too small: need %d, got %d", requiredSize, len(buf))
-	}
-
-	// First 4 bytes: the top byte holds the algorithm nibble, the low 26 bits
-	// hold the payload size. The algorithm value already carries the
-	// compression flag in its high bit.
-	sizeWithFlags := payloadSize
-	if compressed {
-		sizeWithFlags |= uint32(algorithm) << 24
-	}
-
-	buf[0] = byte((sizeWithFlags >> 24) & 0xFF)
-	buf[1] = byte((sizeWithFlags >> 16) & 0xFF)
-	buf[2] = byte((sizeWithFlags >> 8) & 0xFF)
-	buf[3] = byte(sizeWithFlags & 0xFF)
-
-	// Pack message type (2 bytes, big endian)
-	buf[4] = byte((msgType >> 8) & 0xFF)
-	buf[5] = byte(msgType & 0xFF)
-
-	// For compressed messages, add uncompressed size
-	if compressed {
-		buf[6] = byte((uncompressedSize >> 24) & 0xFF)
-		buf[7] = byte((uncompressedSize >> 16) & 0xFF)
-		buf[8] = byte((uncompressedSize >> 8) & 0xFF)
-		buf[9] = byte(uncompressedSize & 0xFF)
-	}
-
+	encodeHeader(buf, header)
 	return nil
+}
+
+func encodeHeader(buf []byte, header Header) {
+	sizeWithFlags := header.PayloadSize
+	if header.Compressed {
+		sizeWithFlags |= uint32(header.Algorithm) << 24
+	}
+	binary.BigEndian.PutUint32(buf[:4], sizeWithFlags)
+	binary.BigEndian.PutUint16(buf[4:6], uint16(header.MessageType))
+	if header.Compressed {
+		binary.BigEndian.PutUint32(buf[6:10], header.UncompressedSize)
+	}
 }
 
 // DecodeHeader decodes a message header from the provided buffer.
@@ -213,71 +196,48 @@ func DecodeHeader(buf []byte) (*Header, error) {
 		return nil, ErrTruncatedMessage
 	}
 
-	h := &Header{}
-
-	// Parse first 4 bytes
 	firstFour := binary.BigEndian.Uint32(buf[0:4])
-
-	// Validate the framing marker.
+	algorithm := AlgorithmNone
 	if buf[0]&0x80 != 0 {
 		if buf[0]&CompressionReservedMask != 0 {
 			return nil, ErrInvalidHeader
 		}
-		if buf[0]&CompressionFlagMask != byte(AlgorithmLZ4) {
-			return nil, ErrUnknownCompression
-		}
-		h.Compressed = true
-		h.Algorithm = AlgorithmLZ4
+		algorithm = CompressionAlgorithm(buf[0] & CompressionFlagMask)
 	} else if buf[0]&UncompressedFlagMask != 0 {
 		return nil, ErrInvalidHeader
 	}
 
-	// Extract payload size (26 bits); the mask strips the flag/algorithm bits.
-	h.PayloadSize = firstFour & MaxPayloadSize
-
-	// Extract message type (2 bytes)
-	h.MessageType = MessageType(binary.BigEndian.Uint16(buf[4:6]))
-
-	// For compressed messages, read the uncompressed size from the wire;
-	// for uncompressed frames the original size is the on-wire payload
-	// size, mirroring rippled (ProtocolMessage.h:247) so the 64 MB
-	// protocol-ceiling check sees the same value on both fields.
-	if h.Compressed {
+	payloadSize := firstFour & MaxPayloadSize
+	msgType := MessageType(binary.BigEndian.Uint16(buf[4:6]))
+	uncompressedSize := payloadSize
+	if algorithm != AlgorithmNone {
 		if len(buf) < HeaderSizeCompressed {
 			return nil, ErrTruncatedMessage
 		}
-		h.UncompressedSize = binary.BigEndian.Uint32(buf[6:10])
-	} else {
-		h.UncompressedSize = h.PayloadSize
+		uncompressedSize = binary.BigEndian.Uint32(buf[6:10])
 	}
-
-	return h, nil
-}
-
-// ReadMessage reads a complete message from the reader.
-// Returns the header and the payload.
-func ReadMessage(r io.Reader) (*Header, []byte, error) {
-	return readMessage(r, nil)
+	header, err := newHeader(payloadSize, msgType, algorithm, uncompressedSize)
+	if err != nil {
+		return nil, err
+	}
+	return &header, nil
 }
 
 // ReadHeader reads and validates exactly one message header.
 func ReadHeader(r io.Reader) (*Header, error) {
 	headerBuf := make([]byte, HeaderSizeCompressed)
 	if _, err := io.ReadFull(r, headerBuf[:HeaderSizeUncompressed]); err != nil {
-		return nil, fmt.Errorf("failed to read header: %w", err)
+		return nil, fmt.Errorf("failed to read header: %w: %w", ErrTruncatedMessage, err)
 	}
 
 	if headerBuf[0]&0x80 != 0 {
 		if _, err := io.ReadFull(r, headerBuf[HeaderSizeUncompressed:HeaderSizeCompressed]); err != nil {
-			return nil, fmt.Errorf("failed to read compressed header: %w", err)
+			return nil, fmt.Errorf("failed to read compressed header: %w: %w", ErrTruncatedMessage, err)
 		}
 	}
 
 	header, err := DecodeHeader(headerBuf)
 	if err != nil {
-		return nil, err
-	}
-	if err := validateHeaderClaims(*header); err != nil {
 		return nil, err
 	}
 	return header, nil
@@ -291,39 +251,54 @@ func ReadPayload(r io.Reader, header Header) ([]byte, error) {
 	payload := make([]byte, header.PayloadSize)
 	if header.PayloadSize > 0 {
 		if _, err := io.ReadFull(r, payload); err != nil {
-			return nil, fmt.Errorf("failed to read payload: %w", err)
+			return nil, fmt.Errorf("failed to read payload: %w: %w", ErrTruncatedMessage, err)
 		}
 	}
 	return payload, nil
 }
 
-// ReadMessageWithHeader reads a complete message and calls onHeader after the
-// header and size claims have been validated but before the payload is
-// allocated.
-func ReadMessageWithHeader(r io.Reader, onHeader func(Header) error) (*Header, []byte, error) {
-	return readMessage(r, onHeader)
-}
-
-func readMessage(r io.Reader, onHeader func(Header) error) (*Header, []byte, error) {
-	header, err := ReadHeader(r)
-	if err != nil {
-		return nil, nil, err
+func newHeader(
+	payloadSize uint32,
+	msgType MessageType,
+	algorithm CompressionAlgorithm,
+	uncompressedSize uint32,
+) (Header, error) {
+	header := Header{
+		PayloadSize: payloadSize,
+		MessageType: msgType,
+		Algorithm:   algorithm,
 	}
-
-	if onHeader != nil {
-		if err := onHeader(*header); err != nil {
-			return nil, nil, err
-		}
+	switch algorithm {
+	case AlgorithmNone:
+		header.UncompressedSize = payloadSize
+	case AlgorithmLZ4:
+		header.Compressed = true
+		header.UncompressedSize = uncompressedSize
+	default:
+		return Header{}, fmt.Errorf("%w: %#02x", ErrUnknownCompression, uint8(algorithm))
 	}
-
-	payload, err := ReadPayload(r, *header)
-	if err != nil {
-		return nil, nil, err
+	if err := validateHeaderClaims(header); err != nil {
+		return Header{}, err
 	}
-	return header, payload, nil
+	return header, nil
 }
 
 func validateHeaderClaims(header Header) error {
+	switch header.Algorithm {
+	case AlgorithmNone:
+		if header.Compressed || header.UncompressedSize != header.PayloadSize {
+			return ErrInvalidHeader
+		}
+	case AlgorithmLZ4:
+		if !header.Compressed {
+			return ErrInvalidHeader
+		}
+	default:
+		return fmt.Errorf("%w: %#02x", ErrUnknownCompression, uint8(header.Algorithm))
+	}
+	if header.PayloadSize > MaxPayloadSize {
+		return fmt.Errorf("%w: payload exceeds 26-bit wire limit %d bytes", ErrMessageTooLarge, MaxPayloadSize)
+	}
 	// Hard protocol ceiling: rippled drops any message whose on-wire or
 	// uncompressed claim exceeds a single 64 MB cap, on both fields
 	// (ProtocolMessage.h:362-367). This is the absolute upper bound; the
@@ -348,48 +323,30 @@ func validateHeaderClaims(header Header) error {
 	return nil
 }
 
-// WriteMessage writes a message with header to the writer.
-func WriteMessage(w io.Writer, msgType MessageType, payload []byte) error {
-	return WriteMessageCompressed(w, msgType, payload, AlgorithmNone, 0)
-}
-
-// WriteMessageCompressed writes a potentially compressed message.
-func WriteMessageCompressed(w io.Writer, msgType MessageType, payload []byte, algorithm CompressionAlgorithm, uncompressedSize uint32) error {
-	headerSize := HeaderSizeUncompressed
-	if algorithm != AlgorithmNone {
-		headerSize = HeaderSizeCompressed
-	}
-
-	buf := make([]byte, headerSize+len(payload))
-
-	if err := EncodeHeader(buf, uint32(len(payload)), msgType, algorithm, uncompressedSize); err != nil {
-		return err
-	}
-
-	copy(buf[headerSize:], payload)
-
-	_, err := w.Write(buf)
-	return err
-}
-
 // BuildWireMessage creates a complete wire-protocol message (header + payload) as bytes.
 func BuildWireMessage(msgType MessageType, payload []byte) ([]byte, error) {
-	if len(payload) > MaxPayloadSize {
+	if uint64(len(payload)) > uint64(MaxPayloadSize) {
 		return nil, ErrMessageTooLarge
 	}
-	buf := make([]byte, HeaderSizeUncompressed+len(payload))
-	if err := EncodeHeader(buf, uint32(len(payload)), msgType, AlgorithmNone, 0); err != nil {
+	header, err := newHeader(uint32(len(payload)), msgType, AlgorithmNone, 0)
+	if err != nil {
 		return nil, err
 	}
+	buf := make([]byte, header.TotalSize())
+	encodeHeader(buf, header)
 	copy(buf[HeaderSizeUncompressed:], payload)
 	return buf, nil
 }
 
 // EncodeFrame serializes a message and wraps it in its wire-protocol header.
 func EncodeFrame(msg Message) ([]byte, error) {
-	payload, err := Encode(msg)
+	msgType, err := typeOfMessage(msg)
 	if err != nil {
 		return nil, err
 	}
-	return BuildWireMessage(msg.Type(), payload)
+	payload, err := encode(msg, msgType)
+	if err != nil {
+		return nil, err
+	}
+	return BuildWireMessage(msgType, payload)
 }

--- a/internal/peermanagement/message/codec_test.go
+++ b/internal/peermanagement/message/codec_test.go
@@ -2,10 +2,45 @@ package message
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
+	"testing/iotest"
 )
+
+var _ interface{ HeaderSize() int } = Header{}
+
+func readTestMessage(r io.Reader) (*Header, []byte, error) {
+	header, err := ReadHeader(r)
+	if err != nil {
+		return nil, nil, err
+	}
+	payload, err := ReadPayload(r, *header)
+	if err != nil {
+		return nil, nil, err
+	}
+	return header, payload, nil
+}
+
+func rawTestHeader(payloadSize uint32, msgType MessageType, algorithm CompressionAlgorithm, uncompressedSize uint32) []byte {
+	size := HeaderSizeUncompressed
+	if algorithm != AlgorithmNone {
+		size = HeaderSizeCompressed
+	}
+	buf := make([]byte, size)
+	firstFour := payloadSize
+	if algorithm != AlgorithmNone {
+		firstFour |= uint32(algorithm) << 24
+	}
+	binary.BigEndian.PutUint32(buf[:4], firstFour)
+	binary.BigEndian.PutUint16(buf[4:6], uint16(msgType))
+	if algorithm != AlgorithmNone {
+		binary.BigEndian.PutUint32(buf[6:10], uncompressedSize)
+	}
+	return buf
+}
 
 func TestHeaderEncodeDecodeUncompressed(t *testing.T) {
 	tests := []struct {
@@ -96,8 +131,177 @@ func TestHeaderEncodeDecodeCompressed(t *testing.T) {
 func TestHeaderTooLarge(t *testing.T) {
 	buf := make([]byte, HeaderSizeUncompressed)
 	err := EncodeHeader(buf, MaxPayloadSize+1, TypePing, AlgorithmNone, 0)
-	if err != ErrMessageTooLarge {
+	if !errors.Is(err, ErrMessageTooLarge) {
 		t.Errorf("Expected ErrMessageTooLarge, got %v", err)
+	}
+}
+
+func TestEncodeHeaderRejectsUnknownAlgorithmsWithoutMutation(t *testing.T) {
+	for _, raw := range []CompressionAlgorithm{0x01, 0x10, 0x80, 0x94, 0xA0, 0xF0} {
+		t.Run(fmt.Sprintf("%#02x", raw), func(t *testing.T) {
+			buf := bytes.Repeat([]byte{0x5a}, HeaderSizeCompressed)
+			before := append([]byte(nil), buf...)
+			err := EncodeHeader(buf, 1, TypePing, raw, 1)
+			if !errors.Is(err, ErrUnknownCompression) {
+				t.Fatalf("EncodeHeader error = %v, want ErrUnknownCompression", err)
+			}
+			if !bytes.Equal(buf, before) {
+				t.Fatal("EncodeHeader mutated destination")
+			}
+		})
+	}
+}
+
+func TestHeaderClaimBoundariesAreSymmetric(t *testing.T) {
+	tests := []struct {
+		name             string
+		payloadSize      uint32
+		msgType          MessageType
+		algorithm        CompressionAlgorithm
+		uncompressedSize uint32
+		wantErr          bool
+	}{
+		{"ping exact", 2048, TypePing, AlgorithmNone, 0, false},
+		{"ping over", 2049, TypePing, AlgorithmNone, 0, true},
+		{"ping compressed wire over", 2049, TypePing, AlgorithmLZ4, 100, true},
+		{"ping compressed claim over", 100, TypePing, AlgorithmLZ4, 2049, true},
+		{"proof exact", largeMsgMax, TypeProofPathResponse, AlgorithmLZ4, largeMsgMax, false},
+		{"proof over", 100, TypeProofPathResponse, AlgorithmLZ4, largeMsgMax + 1, true},
+		{"replay above proof", 100, TypeReplayDeltaResponse, AlgorithmLZ4, largeMsgMax + 1, false},
+		{"replay universal exact", 100, TypeReplayDeltaResponse, AlgorithmLZ4, MaxMessageSize, false},
+		{"replay universal over", 100, TypeReplayDeltaResponse, AlgorithmLZ4, MaxMessageSize + 1, true},
+		{"wire representable exact", MaxPayloadSize, TypeReplayDeltaResponse, AlgorithmLZ4, MaxMessageSize, false},
+		{"wire unrepresentable", MaxPayloadSize + 1, TypeReplayDeltaResponse, AlgorithmLZ4, MaxMessageSize, true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			buf := bytes.Repeat([]byte{0x5a}, HeaderSizeCompressed)
+			before := append([]byte(nil), buf...)
+			err := EncodeHeader(buf, test.payloadSize, test.msgType, test.algorithm, test.uncompressedSize)
+			if test.wantErr {
+				if !errors.Is(err, ErrMessageTooLarge) {
+					t.Fatalf("EncodeHeader error = %v, want ErrMessageTooLarge", err)
+				}
+				if !bytes.Equal(buf, before) {
+					t.Fatal("EncodeHeader mutated destination")
+				}
+			} else if err != nil {
+				t.Fatalf("EncodeHeader error = %v", err)
+			}
+
+			raw := rawTestHeader(test.payloadSize, test.msgType, test.algorithm, test.uncompressedSize)
+			_, readErr := ReadHeader(bytes.NewReader(raw))
+			if test.payloadSize > MaxPayloadSize {
+				if !errors.Is(readErr, ErrInvalidHeader) {
+					t.Fatalf("ReadHeader error = %v, want ErrInvalidHeader", readErr)
+				}
+				return
+			}
+			if test.wantErr && !errors.Is(readErr, ErrMessageTooLarge) {
+				t.Fatalf("ReadHeader error = %v, want ErrMessageTooLarge", readErr)
+			}
+			if !test.wantErr && readErr != nil {
+				t.Fatalf("ReadHeader error = %v", readErr)
+			}
+		})
+	}
+}
+
+func TestBuildWireMessagePingBoundary(t *testing.T) {
+	frame, err := BuildWireMessage(TypePing, make([]byte, 2048))
+	if err != nil {
+		t.Fatalf("BuildWireMessage exact boundary: %v", err)
+	}
+	if _, err := ReadHeader(bytes.NewReader(frame)); err != nil {
+		t.Fatalf("ReadHeader exact boundary: %v", err)
+	}
+	if _, err := BuildWireMessage(TypePing, make([]byte, 2049)); !errors.Is(err, ErrMessageTooLarge) {
+		t.Fatalf("BuildWireMessage over boundary error = %v, want ErrMessageTooLarge", err)
+	}
+}
+
+func TestReplayAndProofOutboundBoundaries(t *testing.T) {
+	payload := make([]byte, largeMsgMax+1)
+	replayFrame, err := BuildWireMessage(TypeReplayDeltaResponse, payload)
+	if err != nil {
+		t.Fatalf("BuildWireMessage replay above proof limit: %v", err)
+	}
+	if _, err := ReadHeader(bytes.NewReader(replayFrame)); err != nil {
+		t.Fatalf("ReadHeader replay above proof limit: %v", err)
+	}
+	if _, err := BuildWireMessage(TypeProofPathResponse, payload); !errors.Is(err, ErrMessageTooLarge) {
+		t.Fatalf("BuildWireMessage proof above limit error = %v, want ErrMessageTooLarge", err)
+	}
+
+	replayFrame, err = EncodeFrame(&ReplayDeltaResponse{Transactions: [][]byte{payload}})
+	if err != nil {
+		t.Fatalf("EncodeFrame replay above proof limit: %v", err)
+	}
+	replayHeader, err := ReadHeader(bytes.NewReader(replayFrame))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replayHeader.PayloadSize <= largeMsgMax {
+		t.Fatalf("replay protobuf payload = %d, want above %d", replayHeader.PayloadSize, largeMsgMax)
+	}
+
+	if _, err := EncodeFrame(&ProofPathResponse{MapType: LedgerMapTransaction, Path: [][]byte{payload}}); !errors.Is(err, ErrMessageTooLarge) {
+		t.Fatalf("EncodeFrame proof above limit error = %v, want ErrMessageTooLarge", err)
+	}
+}
+
+func TestPartialReadsPreserveTruncationAndCause(t *testing.T) {
+	cause := errors.New("reader failed")
+	compressed := rawTestHeader(1, TypeTransaction, AlgorithmLZ4, 100)
+	payloadHeader, err := BuildWireMessage(TypePing, []byte{1, 2, 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		read      func() error
+		wantCause error
+	}{
+		{
+			name: "base header EOF",
+			read: func() error {
+				_, err := ReadHeader(bytes.NewReader(nil))
+				return err
+			},
+			wantCause: io.EOF,
+		},
+		{
+			name: "compressed suffix unexpected EOF",
+			read: func() error {
+				_, err := ReadHeader(bytes.NewReader(compressed[:HeaderSizeUncompressed+2]))
+				return err
+			},
+			wantCause: io.ErrUnexpectedEOF,
+		},
+		{
+			name: "payload custom cause",
+			read: func() error {
+				reader := io.MultiReader(bytes.NewReader(payloadHeader[:HeaderSizeUncompressed+1]), iotest.ErrReader(cause))
+				header, err := ReadHeader(reader)
+				if err != nil {
+					return err
+				}
+				_, err = ReadPayload(reader, *header)
+				return err
+			},
+			wantCause: cause,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.read()
+			if !errors.Is(err, ErrTruncatedMessage) || !errors.Is(err, test.wantCause) {
+				t.Fatalf("error = %v, want ErrTruncatedMessage and %v", err, test.wantCause)
+			}
+		})
 	}
 }
 
@@ -156,7 +360,7 @@ func TestDecodeHeaderFramingMarker(t *testing.T) {
 			buf[0] = tt.firstByte
 
 			header, err := DecodeHeader(buf)
-			if err != tt.wantErr {
+			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("DecodeHeader(first byte %#02x) error = %v, want %v", tt.firstByte, err, tt.wantErr)
 			}
 			if tt.wantErr != nil {
@@ -170,7 +374,7 @@ func TestDecodeHeaderFramingMarker(t *testing.T) {
 	}
 }
 
-func TestReadWriteMessage(t *testing.T) {
+func TestBuildAndReadFrame(t *testing.T) {
 	tests := []struct {
 		name    string
 		msgType MessageType
@@ -183,18 +387,14 @@ func TestReadWriteMessage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var buf bytes.Buffer
-
-			// Write message
-			err := WriteMessage(&buf, tt.msgType, tt.payload)
+			frame, err := BuildWireMessage(tt.msgType, tt.payload)
 			if err != nil {
-				t.Fatalf("WriteMessage failed: %v", err)
+				t.Fatalf("BuildWireMessage failed: %v", err)
 			}
 
-			// Read message
-			header, payload, err := ReadMessage(&buf)
+			header, payload, err := readTestMessage(bytes.NewReader(frame))
 			if err != nil {
-				t.Fatalf("ReadMessage failed: %v", err)
+				t.Fatalf("readTestMessage failed: %v", err)
 			}
 
 			if header.MessageType != tt.msgType {
@@ -207,19 +407,13 @@ func TestReadWriteMessage(t *testing.T) {
 	}
 }
 
-func TestReadWriteMessageCompressed(t *testing.T) {
-	var buf bytes.Buffer
+func TestReadCompressedMessage(t *testing.T) {
 	payload := bytes.Repeat([]byte{0x42}, 100)
 	compressed := []byte{0x01, 0x02, 0x03} // Fake compressed data for test
-
-	err := WriteMessageCompressed(&buf, TypeTransaction, compressed, AlgorithmLZ4, uint32(len(payload)))
+	frame := append(rawTestHeader(uint32(len(compressed)), TypeTransaction, AlgorithmLZ4, uint32(len(payload))), compressed...)
+	header, readPayload, err := readTestMessage(bytes.NewReader(frame))
 	if err != nil {
-		t.Fatalf("WriteMessageCompressed failed: %v", err)
-	}
-
-	header, readPayload, err := ReadMessage(&buf)
-	if err != nil {
-		t.Fatalf("ReadMessage failed: %v", err)
+		t.Fatalf("readTestMessage failed: %v", err)
 	}
 
 	if header.MessageType != TypeTransaction {
@@ -238,23 +432,18 @@ func TestReadWriteMessageCompressed(t *testing.T) {
 
 // compressedFrame builds a complete LZ4-flagged wire frame: a small
 // on-wire payload with an arbitrary uncompressed-size claim. It lets the
-// cap tests exercise ReadMessage's size gates without materializing a
+// cap tests exercise header size gates without materializing a
 // large payload.
 func compressedFrame(t *testing.T, msgType MessageType, wirePayload []byte, uncompressedSize uint32) []byte {
 	t.Helper()
-	buf := make([]byte, HeaderSizeCompressed+len(wirePayload))
-	if err := EncodeHeader(buf, uint32(len(wirePayload)), msgType, AlgorithmLZ4, uncompressedSize); err != nil {
-		t.Fatalf("EncodeHeader: %v", err)
-	}
-	copy(buf[HeaderSizeCompressed:], wirePayload)
-	return buf
+	return append(rawTestHeader(uint32(len(wirePayload)), msgType, AlgorithmLZ4, uncompressedSize), wirePayload...)
 }
 
-// TestReadMessageCaps covers the per-type cap table and the hard 64 MB
+// TestReadFrameCaps covers the per-type cap table and the hard 64 MB
 // protocol ceiling. Bulk response types may approach the ceiling;
 // request-shaped types keep stricter hardening; nothing may exceed the
 // ceiling.
-func TestReadMessageCaps(t *testing.T) {
+func TestReadFrameCaps(t *testing.T) {
 	const mib = 1024 * 1024
 	wire := []byte{0x01, 0x02, 0x03}
 
@@ -285,53 +474,17 @@ func TestReadMessageCaps(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			frame := compressedFrame(t, tt.msgType, wire, tt.uncompSize)
-			_, _, err := ReadMessage(bytes.NewReader(frame))
+			_, _, err := readTestMessage(bytes.NewReader(frame))
 			if tt.wantTooBig {
 				if !errors.Is(err, ErrMessageTooLarge) {
-					t.Fatalf("ReadMessage err = %v, want ErrMessageTooLarge", err)
+					t.Fatalf("readTestMessage err = %v, want ErrMessageTooLarge", err)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("ReadMessage err = %v, want nil (cap should permit)", err)
+				t.Fatalf("readTestMessage err = %v, want nil (cap should permit)", err)
 			}
 		})
-	}
-}
-
-func TestReadMessageWithHeaderRunsCallbackAfterSizeValidation(t *testing.T) {
-	frame := compressedFrame(t, TypeManifests, []byte{1}, MaxMessageSize+1)
-	called := false
-
-	_, _, err := ReadMessageWithHeader(bytes.NewReader(frame), func(Header) error {
-		called = true
-		return nil
-	})
-
-	if !errors.Is(err, ErrMessageTooLarge) {
-		t.Fatalf("ReadMessageWithHeader err = %v, want ErrMessageTooLarge", err)
-	}
-	if called {
-		t.Fatal("header callback ran before rejecting an oversized payload claim")
-	}
-}
-
-func TestReadMessageWithHeaderRunsCallbackBeforePayloadRead(t *testing.T) {
-	header := make([]byte, HeaderSizeUncompressed)
-	if err := EncodeHeader(header, 10, TypeManifests, AlgorithmNone, 0); err != nil {
-		t.Fatalf("EncodeHeader: %v", err)
-	}
-	want := errors.New("stop before payload")
-
-	_, _, err := ReadMessageWithHeader(bytes.NewReader(header), func(got Header) error {
-		if got.PayloadSize != 10 || got.MessageType != TypeManifests {
-			t.Fatalf("callback header = %+v", got)
-		}
-		return want
-	})
-
-	if !errors.Is(err, want) {
-		t.Fatalf("ReadMessageWithHeader err = %v, want callback error", err)
 	}
 }
 
@@ -368,10 +521,7 @@ func TestReadHeaderDoesNotConsumePayload(t *testing.T) {
 }
 
 func TestReadHeaderAndPayloadRejectClaimsBeforeAllocation(t *testing.T) {
-	headerBytes := make([]byte, HeaderSizeUncompressed, HeaderSizeUncompressed+1)
-	if err := EncodeHeader(headerBytes, mediumMsgMax+1, TypePing, AlgorithmNone, 0); err != nil {
-		t.Fatalf("EncodeHeader: %v", err)
-	}
+	headerBytes := rawTestHeader(mediumMsgMax+1, TypePing, AlgorithmNone, 0)
 	reader := bytes.NewReader(append(headerBytes, 0x7f))
 
 	if _, err := ReadHeader(reader); !errors.Is(err, ErrMessageTooLarge) {
@@ -392,19 +542,17 @@ func TestReadHeaderAndPayloadRejectClaimsBeforeAllocation(t *testing.T) {
 }
 
 func TestHeaderSize(t *testing.T) {
-	uncompressed := &Header{Compressed: false}
-	if uncompressed.HeaderSize() != HeaderSizeUncompressed {
-		t.Errorf("Uncompressed HeaderSize = %d, want %d", uncompressed.HeaderSize(), HeaderSizeUncompressed)
+	if got := (Header{Compressed: false}).HeaderSize(); got != HeaderSizeUncompressed {
+		t.Errorf("Uncompressed HeaderSize = %d, want %d", got, HeaderSizeUncompressed)
 	}
 
-	compressed := &Header{Compressed: true}
-	if compressed.HeaderSize() != HeaderSizeCompressed {
-		t.Errorf("Compressed HeaderSize = %d, want %d", compressed.HeaderSize(), HeaderSizeCompressed)
+	if got := (Header{Compressed: true}).HeaderSize(); got != HeaderSizeCompressed {
+		t.Errorf("Compressed HeaderSize = %d, want %d", got, HeaderSizeCompressed)
 	}
 }
 
 func TestHeaderTotalSize(t *testing.T) {
-	header := &Header{
+	header := Header{
 		PayloadSize: 1000,
 		Compressed:  false,
 	}
@@ -479,14 +627,6 @@ func TestBuildWireMessage(t *testing.T) {
 	if !bytes.Equal(frame[HeaderSizeUncompressed:], payload) {
 		t.Fatalf("payload = %x, want %x", frame[HeaderSizeUncompressed:], payload)
 	}
-	var viaWriter bytes.Buffer
-	if err := WriteMessage(&viaWriter, TypeManifests, payload); err != nil {
-		t.Fatalf("WriteMessage: %v", err)
-	}
-	if !bytes.Equal(frame, viaWriter.Bytes()) {
-		t.Fatalf("frame = %x, WriteMessage = %x", frame, viaWriter.Bytes())
-	}
-
 	payload[0] = 0
 	if frame[HeaderSizeUncompressed] != 0xde {
 		t.Fatal("wire message aliases input payload")

--- a/internal/peermanagement/message/compression.go
+++ b/internal/peermanagement/message/compression.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/pierrec/lz4"
 )
@@ -43,17 +44,20 @@ func CompressLZ4(data []byte) ([]byte, error) {
 // decompressed length does not match the claim.
 func DecompressLZ4(compressed []byte, uncompressedSize int) ([]byte, error) {
 	if uncompressedSize <= 0 {
-		return nil, ErrDecompressFailed
+		return nil, fmt.Errorf("%w: invalid uncompressed size %d", ErrDecompressFailed, uncompressedSize)
+	}
+	if uint64(uncompressedSize) > uint64(MaxMessageSize) {
+		return nil, fmt.Errorf("%w: uncompressed size %d exceeds protocol max %d", ErrMessageTooLarge, uncompressedSize, MaxMessageSize)
 	}
 
 	decompressed := make([]byte, uncompressedSize)
 	n, err := lz4.UncompressBlock(compressed, decompressed)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrDecompressFailed, err)
 	}
 
 	if n != uncompressedSize {
-		return nil, ErrDecompressFailed
+		return nil, fmt.Errorf("%w: decompressed length %d does not match claim %d", ErrDecompressFailed, n, uncompressedSize)
 	}
 
 	return decompressed, nil

--- a/internal/peermanagement/message/compression_test.go
+++ b/internal/peermanagement/message/compression_test.go
@@ -4,12 +4,43 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/sha512"
+	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/pierrec/lz4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDecompressLZ4ErrorContracts(t *testing.T) {
+	for _, size := range []int{0, -1} {
+		if _, err := DecompressLZ4([]byte{1}, size); !errors.Is(err, ErrDecompressFailed) {
+			t.Fatalf("DecompressLZ4 size %d error = %v, want ErrDecompressFailed", size, err)
+		}
+	}
+
+	if _, err := DecompressLZ4([]byte{1}, MaxMessageSize+1); !errors.Is(err, ErrMessageTooLarge) {
+		t.Fatalf("DecompressLZ4 oversized error = %v, want ErrMessageTooLarge", err)
+	}
+
+	corrupt := []byte{0x10}
+	dst := make([]byte, 64)
+	_, cause := lz4.UncompressBlock(corrupt, dst)
+	require.Error(t, cause)
+	_, err := DecompressLZ4(corrupt, len(dst))
+	if !errors.Is(err, ErrDecompressFailed) || !errors.Is(err, cause) {
+		t.Fatalf("DecompressLZ4 corrupt error = %v, want ErrDecompressFailed and %v", err, cause)
+	}
+
+	original := bytes.Repeat([]byte{0x42}, 1024)
+	compressed, err := CompressLZ4(original)
+	require.NoError(t, err)
+	require.NotEmpty(t, compressed)
+	if _, err := DecompressLZ4(compressed, len(original)+1); !errors.Is(err, ErrDecompressFailed) {
+		t.Fatalf("DecompressLZ4 length mismatch error = %v, want ErrDecompressFailed", err)
+	}
+}
 
 // Reference: rippled src/test/overlay/compression_test.cpp
 //

--- a/internal/peermanagement/message/fuzz_test.go
+++ b/internal/peermanagement/message/fuzz_test.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 )
 
@@ -115,9 +116,9 @@ func FuzzDecodeHeader(f *testing.F) {
 	})
 }
 
-// FuzzReadMessage wraps arbitrary bytes in a reader and calls ReadMessage.
+// FuzzReadFrame wraps arbitrary bytes in a reader and reads one frame.
 // It must never panic. On success it validates payload length matches the header.
-func FuzzReadMessage(f *testing.F) {
+func FuzzReadFrame(f *testing.F) {
 	// Seed: empty
 	f.Add([]byte{})
 
@@ -153,7 +154,7 @@ func FuzzReadMessage(f *testing.F) {
 		}
 
 		r := bytes.NewReader(data)
-		header, payload, err := ReadMessage(r)
+		header, payload, err := readTestMessage(r)
 		if err != nil {
 			return
 		}
@@ -214,39 +215,34 @@ func FuzzHeaderRoundTrip(f *testing.F) {
 	// Seed: uncompressed Ping
 	f.Add(uint32(100), uint16(3), uint8(0), uint32(0))
 	// Seed: compressed Transaction
-	f.Add(uint32(50), uint16(30), uint8(1), uint32(200))
+	f.Add(uint32(50), uint16(30), uint8(AlgorithmLZ4), uint32(200))
 	// Seed: zero values
 	f.Add(uint32(0), uint16(0), uint8(0), uint32(0))
 	// Seed: max payload uncompressed
 	f.Add(uint32(MaxPayloadSize), uint16(41), uint8(0), uint32(0))
 	// Seed: compressed with large uncompressed size
-	f.Add(uint32(1000), uint16(32), uint8(1), uint32(50000))
+	f.Add(uint32(1000), uint16(32), uint8(AlgorithmLZ4), uint32(50000))
+	for _, algorithm := range []uint8{0x01, 0x10, 0x80, 0x94, 0xA0, 0xF0} {
+		f.Add(uint32(100), uint16(TypePing), algorithm, uint32(200))
+	}
 
 	f.Fuzz(func(t *testing.T, payloadSize uint32, msgType uint16, algorithm uint8, uncompressedSize uint32) {
-		if payloadSize > MaxPayloadSize {
-			t.Skip("payload size exceeds maximum")
-		}
-		if algorithm > 1 {
-			t.Skip("fuzz input maps only 0 and 1 to valid algorithms")
-		}
-
-		algo := AlgorithmNone
-		if algorithm == 1 {
-			algo = AlgorithmLZ4
-		}
+		algo := CompressionAlgorithm(algorithm)
 		mt := MessageType(msgType)
-
-		bufSize := HeaderSizeUncompressed
-		if algo != AlgorithmNone {
-			bufSize = HeaderSizeCompressed
-		}
-		buf := make([]byte, bufSize)
+		buf := bytes.Repeat([]byte{0xa5}, HeaderSizeCompressed)
+		before := append([]byte(nil), buf...)
 
 		if err := EncodeHeader(buf, payloadSize, mt, algo, uncompressedSize); err != nil {
-			t.Fatalf("EncodeHeader failed: %v", err)
+			if algo != AlgorithmNone && algo != AlgorithmLZ4 && !errors.Is(err, ErrUnknownCompression) {
+				t.Fatalf("EncodeHeader error = %v, want ErrUnknownCompression", err)
+			}
+			if !bytes.Equal(buf, before) {
+				t.Fatal("EncodeHeader mutated destination on error")
+			}
+			return
 		}
 
-		h, err := DecodeHeader(buf)
+		h, err := DecodeHeader(buf[:(Header{Compressed: algo == AlgorithmLZ4}).HeaderSize()])
 		if err != nil {
 			t.Fatalf("DecodeHeader failed after successful EncodeHeader: %v", err)
 		}

--- a/internal/peermanagement/message/outbound_compression_test.go
+++ b/internal/peermanagement/message/outbound_compression_test.go
@@ -31,7 +31,7 @@ func TestCompressFrameIfWorthwhilePolicy(t *testing.T) {
 		{
 			name:     "ineligible",
 			msgType:  TypePing,
-			payload:  bytes.Repeat([]byte{'A'}, 4096),
+			payload:  bytes.Repeat([]byte{'A'}, 1024),
 			compress: false,
 		},
 	}

--- a/internal/peermanagement/message/serialize_proto.go
+++ b/internal/peermanagement/message/serialize_proto.go
@@ -1,13 +1,17 @@
 package message
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/LeJamon/go-xrpl/internal/peermanagement/proto"
 	"google.golang.org/protobuf/encoding/protowire"
 	pb "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
+
+var ErrNilMessage = errors.New("cannot encode nil message")
 
 // msgCodec bundles the three operations every message type needs:
 // proto constructor, encoder, decoder. A missing table entry surfaces
@@ -837,9 +841,31 @@ var codecs = map[MessageType]msgCodec{
 
 // Encode encodes a message to bytes using protobuf.
 func Encode(msg Message) ([]byte, error) {
-	c, ok := codecs[msg.Type()]
+	msgType, err := typeOfMessage(msg)
+	if err != nil {
+		return nil, err
+	}
+	return encode(msg, msgType)
+}
+
+func typeOfMessage(msg Message) (MessageType, error) {
+	if msg == nil {
+		return 0, ErrNilMessage
+	}
+	value := reflect.ValueOf(msg)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		if value.IsNil() {
+			return 0, ErrNilMessage
+		}
+	}
+	return msg.Type(), nil
+}
+
+func encode(msg Message, msgType MessageType) ([]byte, error) {
+	c, ok := codecs[msgType]
 	if !ok {
-		return nil, fmt.Errorf("unknown message type: %d", msg.Type())
+		return nil, fmt.Errorf("unknown message type: %d", msgType)
 	}
 	pmsg, err := c.encode(msg)
 	if err != nil {
@@ -852,7 +878,7 @@ func Encode(msg Message) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := Preflight(msg.Type(), encoded); err != nil {
+	if err := Preflight(msgType, encoded); err != nil {
 		return nil, err
 	}
 	return encoded, nil

--- a/internal/peermanagement/message/serialize_test.go
+++ b/internal/peermanagement/message/serialize_test.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"bytes"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -780,6 +781,35 @@ func TestDecodeUnknownType(t *testing.T) {
 type unknownMsg struct{}
 
 func (u *unknownMsg) Type() MessageType { return MessageType(9999) }
+
+type nilMapMessage map[string]struct{}
+
+func (nilMapMessage) Type() MessageType { return TypePing }
+
+func TestEncodeRejectsNilMessages(t *testing.T) {
+	var (
+		nilInterface Message
+		nilPing      *Ping
+		nilMap       nilMapMessage
+	)
+	for _, test := range []struct {
+		name string
+		msg  Message
+	}{
+		{"nil interface", nilInterface},
+		{"typed nil pointer", nilPing},
+		{"typed nil map", nilMap},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := Encode(test.msg); !errors.Is(err, ErrNilMessage) {
+				t.Fatalf("Encode error = %v, want ErrNilMessage", err)
+			}
+			if _, err := EncodeFrame(test.msg); !errors.Is(err, ErrNilMessage) {
+				t.Fatalf("EncodeFrame error = %v, want ErrNilMessage", err)
+			}
+		})
+	}
+}
 
 func TestEncodeUnknownType(t *testing.T) {
 	_, err := Encode(&unknownMsg{})

--- a/internal/peermanagement/outbound_emit_test.go
+++ b/internal/peermanagement/outbound_emit_test.go
@@ -85,7 +85,7 @@ func TestSendClusterUpdate_EmitsExportedConsumerGossip(t *testing.T) {
 
 	frame := requireOutboundFrame(t, peer)
 
-	_, payload, err := message.ReadMessage(bytes.NewReader(frame))
+	_, payload, err := readTestFrame(bytes.NewReader(frame))
 	require.NoError(t, err)
 	decoded, err := message.Decode(message.TypeCluster, payload)
 	require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestSendClusterUpdate_GatesSelfLoadOnValidatedLedgerAge(t *testing.T) {
 
 			o.sendClusterUpdate()
 			frame := requireOutboundFrame(t, peer)
-			_, payload, err := message.ReadMessage(bytes.NewReader(frame))
+			_, payload, err := readTestFrame(bytes.NewReader(frame))
 			require.NoError(t, err)
 			decoded, err := message.Decode(message.TypeCluster, payload)
 			require.NoError(t, err)
@@ -233,7 +233,7 @@ func TestSendTxQueueAnnounce_DrainsPerPeerQueueWithoutStarvation(t *testing.T) {
 	for want := range 3 {
 		o.sendTxQueueAnnounce()
 		frame := requireOutboundFrame(t, peer)
-		_, payload, readErr := message.ReadMessage(bytes.NewReader(frame))
+		_, payload, readErr := readTestFrame(bytes.NewReader(frame))
 		require.NoError(t, readErr)
 		decoded, decodeErr := message.Decode(message.TypeHaveTransactions, payload)
 		require.NoError(t, decodeErr)
@@ -412,7 +412,7 @@ func TestServeDoTransactions_UsesCacheStateAndRejectsMissing(t *testing.T) {
 		Objects: []message.IndexedObject{{Hash: includedHash[:]}, {Hash: queuedHash[:]}},
 	})
 	frame := requireOutboundFrame(t, peer)
-	_, payload, err := message.ReadMessage(bytes.NewReader(frame))
+	_, payload, err := readTestFrame(bytes.NewReader(frame))
 	require.NoError(t, err)
 	decoded, err := message.Decode(message.TypeTransactions, payload)
 	require.NoError(t, err)

--- a/internal/peermanagement/outbound_queue_test.go
+++ b/internal/peermanagement/outbound_queue_test.go
@@ -2,7 +2,6 @@ package peermanagement
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"net"
@@ -455,7 +454,7 @@ func TestValidationBurstBlockedWritersPreservesEveryAcceptedFrame(t *testing.T) 
 
 func outboundTestFrame(t *testing.T, messageType message.MessageType, payload []byte) []byte {
 	t.Helper()
-	var frame bytes.Buffer
-	require.NoError(t, message.WriteMessage(&frame, messageType, payload))
-	return frame.Bytes()
+	frame, err := message.BuildWireMessage(messageType, payload)
+	require.NoError(t, err)
+	return frame
 }

--- a/internal/peermanagement/overlay_ping_test.go
+++ b/internal/peermanagement/overlay_ping_test.go
@@ -45,7 +45,7 @@ func TestOverlayHandlePingPongEchoesOptionalFields(t *testing.T) {
 			require.True(t, o.handlePing(Event{PeerID: 7, Payload: payload}))
 
 			frame := requireOutboundFrame(t, peer)
-			header, replyPayload, err := message.ReadMessage(bytes.NewReader(frame))
+			header, replyPayload, err := readTestFrame(bytes.NewReader(frame))
 			require.NoError(t, err)
 			require.Equal(t, message.TypePing, header.MessageType)
 			decoded, err := message.Decode(message.TypePing, replyPayload)

--- a/internal/peermanagement/peer.go
+++ b/internal/peermanagement/peer.go
@@ -1054,6 +1054,11 @@ func (p *Peer) readLoop(ctx context.Context) error {
 
 		frameReader := p.newFrameProgressReader(reader, conn)
 		header, err := message.ReadHeader(frameReader)
+		if err == nil && header.Compressed && !p.compressionNegotiated() {
+			p.IncBadData("compression-unnegotiated")
+			frameReader.finish(false, p.readPolicy.now())
+			return errCompressionUnnegotiated
+		}
 		if err == nil &&
 			header.MessageType == message.TypeManifests &&
 			p.manifestSpoolDir != "" &&
@@ -1193,18 +1198,6 @@ func (p *Peer) readLoop(ctx context.Context) error {
 			wireBytes += message.HeaderSizeUncompressed
 		}
 		p.metrics.recv.addMessage(wireBytes)
-
-		if header.Compressed {
-			// rippled rejects a compressed frame outright when compression
-			// was not negotiated for the connection (ProtocolMessage.h:369-
-			// 375). A peer shipping LZ4 frames we never agreed to is a
-			// protocol violation — charge and tear the connection down.
-			if !p.compressionNegotiated() {
-				p.IncBadData("compression-unnegotiated")
-				releaseRetainedReservation()
-				return fmt.Errorf("peer sent a compressed frame without negotiating compression")
-			}
-		}
 
 		if !message.IsKnownMessageType(header.MessageType) {
 			releaseRetainedReservation()

--- a/internal/peermanagement/peer_frame_liveness_test.go
+++ b/internal/peermanagement/peer_frame_liveness_test.go
@@ -292,9 +292,9 @@ func newFrameLivenessPeer(t *testing.T, clock *livenessClock, conn net.Conn) (*P
 
 func manifestFrame(t *testing.T, payload []byte) []byte {
 	t.Helper()
-	var frame bytes.Buffer
-	require.NoError(t, message.WriteMessage(&frame, message.TypeManifests, opaqueTestPayload(payload)))
-	return frame.Bytes()
+	frame, err := message.BuildWireMessage(message.TypeManifests, opaqueTestPayload(payload))
+	require.NoError(t, err)
+	return frame
 }
 
 func TestPeerReadLoopAllowsProgressBeyondIdleInterval(t *testing.T) {
@@ -367,6 +367,7 @@ func TestPeerReadLoopReportsPartialFrameProgress(t *testing.T) {
 	var frameErr *FrameReadError
 	require.ErrorAs(t, err, &frameErr)
 	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	require.ErrorIs(t, err, message.ErrTruncatedMessage)
 	assert.Equal(t, message.TypeManifests, frameErr.MessageType)
 	assert.Equal(t, uint32(len(opaqueTestPayload(payload))), frameErr.WireSize)
 	assert.False(t, frameErr.Compressed)

--- a/internal/peermanagement/peer_test.go
+++ b/internal/peermanagement/peer_test.go
@@ -252,16 +252,19 @@ func TestPeerReadLoopSkipsUnknownMessage(t *testing.T) {
 	malformedCompressed := []byte{0xff}
 
 	var frames bytes.Buffer
-	require.NoError(t, message.WriteMessageCompressed(
-		&frames,
+	frames.Write(rawTestWireMessage(
 		message.MessageType(9999),
 		malformedCompressed,
 		message.AlgorithmLZ4,
 		message.MaxMessageSize,
 	))
-	require.NoError(t, message.WriteMessage(&frames, message.MessageType(9998), unknownPayload))
+	unknownFrame, err := message.BuildWireMessage(message.MessageType(9998), unknownPayload)
+	require.NoError(t, err)
+	frames.Write(unknownFrame)
 	knownPayload := []byte{0x08, 0x00}
-	require.NoError(t, message.WriteMessage(&frames, message.TypePing, knownPayload))
+	knownFrame, err := message.BuildWireMessage(message.TypePing, knownPayload)
+	require.NoError(t, err)
+	frames.Write(knownFrame)
 	peer.bufReader = bufio.NewReader(bytes.NewReader(frames.Bytes()))
 
 	err = peer.readLoop(context.Background())

--- a/internal/peermanagement/proof_path_test.go
+++ b/internal/peermanagement/proof_path_test.go
@@ -56,7 +56,7 @@ func drainProofPathResponse(t *testing.T, events chan Event) *message.ProofPathR
 	require.Equal(t, 1, len(events), "expected exactly one event on the channel")
 	evt := <-events
 	require.Equal(t, EventLedgerResponse, evt.Type)
-	header, body, err := message.ReadMessage(bytes.NewReader(evt.Payload))
+	header, body, err := readTestFrame(bytes.NewReader(evt.Payload))
 	require.NoError(t, err, "event payload must be a valid wire frame")
 	require.Equal(t, message.TypeProofPathResponse, header.MessageType)
 	decoded, err := message.Decode(message.TypeProofPathResponse, body)
@@ -127,7 +127,7 @@ func TestProofPathRequest_PrioritySenderBypassesSharedEvents(t *testing.T) {
 	}))
 	assert.Equal(t, PeerID(9), gotPeer)
 	require.NotEmpty(t, gotFrame)
-	header, _, err := message.ReadMessage(bytes.NewReader(gotFrame))
+	header, _, err := readTestFrame(bytes.NewReader(gotFrame))
 	require.NoError(t, err)
 	assert.Equal(t, message.TypeProofPathResponse, header.MessageType)
 	assert.Empty(t, events, "completed replies must not depend on the shared event channel")
@@ -333,4 +333,20 @@ func TestProofPathRequest_NoProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, len(events), "no event should be emitted when provider is nil")
+}
+
+func TestProofPathRequest_ResponseAbove16MiBRejected(t *testing.T) {
+	provider := &fakeProofPathProvider{
+		header: []byte("hdr"),
+		path:   [][]byte{make([]byte, MaxProofPathResponseBytes)},
+	}
+	events := make(chan Event, 1)
+	h := NewLedgerSyncHandler(events)
+	h.SetProvider(provider)
+
+	err := h.HandleMessage(context.Background(), PeerID(10), &message.ProofPathRequest{
+		Key: fixedKey(), LedgerHash: fixedHash(), MapType: message.LedgerMapAccountState,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, events)
 }

--- a/internal/peermanagement/relay_transaction.go
+++ b/internal/peermanagement/relay_transaction.go
@@ -42,7 +42,12 @@ func (o *Overlay) RelayTransaction(except PeerID, frame []byte) {
 // result means the caller must not suppress the full transaction: without a
 // usable hash a HAVE_TRANSACTIONS announcement could never be fulfilled.
 func transactionHashFromFrame(frame []byte) ([32]byte, bool) {
-	header, payload, err := message.ReadMessage(bytes.NewReader(frame))
+	reader := bytes.NewReader(frame)
+	header, err := message.ReadHeader(reader)
+	if err != nil {
+		return [32]byte{}, false
+	}
+	payload, err := message.ReadPayload(reader, *header)
 	if err != nil || header.MessageType != message.TypeTransaction {
 		return [32]byte{}, false
 	}

--- a/internal/peermanagement/replay_delta_test.go
+++ b/internal/peermanagement/replay_delta_test.go
@@ -53,7 +53,7 @@ func drainReplayDeltaResponse(t *testing.T, events chan Event) *message.ReplayDe
 		t.Fatal("expected an event on the channel, got none")
 	}
 	require.Equal(t, EventLedgerResponse, evt.Type)
-	header, body, err := message.ReadMessage(bytes.NewReader(evt.Payload))
+	header, body, err := readTestFrame(bytes.NewReader(evt.Payload))
 	require.NoError(t, err, "event payload must be a valid wire frame")
 	require.Equal(t, message.TypeReplayDeltaResponse, header.MessageType)
 	decoded, err := message.Decode(message.TypeReplayDeltaResponse, body)
@@ -106,7 +106,7 @@ func TestReplayDeltaRequest_PrioritySenderBypassesSharedEvents(t *testing.T) {
 	require.NoError(t, h.HandleMessage(context.Background(), PeerID(9), &message.ReplayDeltaRequest{LedgerHash: fixedHash()}))
 	assert.Equal(t, PeerID(9), gotPeer)
 	require.NotEmpty(t, gotFrame)
-	header, _, err := message.ReadMessage(bytes.NewReader(gotFrame))
+	header, _, err := readTestFrame(bytes.NewReader(gotFrame))
 	require.NoError(t, err)
 	assert.Equal(t, message.TypeReplayDeltaResponse, header.MessageType)
 	assert.Empty(t, events, "completed replies must not depend on the shared event channel")
@@ -188,23 +188,14 @@ func TestReplayDeltaRequest_NoProvider(t *testing.T) {
 	assert.Equal(t, 0, len(events), "no event should be emitted when provider is nil")
 }
 
-// TestReplayDeltaRequest_OversizedResponse drives the defensive size cap.
-// A provider returns a payload whose total bytes exceed
-// MaxReplayDeltaResponseBytes; the handler must refuse to encode the tx
-// list and reply with reNO_LEDGER — NOT reBAD_REQUEST. The request
-// itself is well-formed; we just can't serve at this size, so the
-// lighter "no ledger available" code avoids charging the requester
-// feeMalformedRequest on rippled's side (PeerImp.cpp:1545-1548).
-func TestReplayDeltaRequest_OversizedResponse(t *testing.T) {
-	// Header is small; the tx leaves push us past the cap.
+func TestReplayDeltaRequest_ResponseAbove16MiBAccepted(t *testing.T) {
 	header := []byte("hdr")
 	chunkSize := 1 << 20 // 1 MiB
 	chunk := make([]byte, chunkSize)
 	for i := range chunk {
 		chunk[i] = 0xAB
 	}
-	// 17 leaves of 1 MiB each = 17 MiB > 16 MiB cap.
-	numLeaves := (MaxReplayDeltaResponseBytes / chunkSize) + 1
+	const numLeaves = 17
 	txLeaves := make([][]byte, numLeaves)
 	for i := range txLeaves {
 		txLeaves[i] = chunk
@@ -220,5 +211,10 @@ func TestReplayDeltaRequest_OversizedResponse(t *testing.T) {
 	err := h.HandleMessage(context.Background(), PeerID(5), &message.ReplayDeltaRequest{LedgerHash: hash})
 	require.NoError(t, err)
 
-	assert.Empty(t, events, "oversized responses are charged and dropped without a reply")
+	require.Len(t, events, 1)
+	event := <-events
+	frameHeader, payload, err := readTestFrame(bytes.NewReader(event.Payload))
+	require.NoError(t, err)
+	assert.Equal(t, message.TypeReplayDeltaResponse, frameHeader.MessageType)
+	assert.Greater(t, len(payload), 16*1024*1024)
 }

--- a/internal/testing/p2p/two_overlay_test.go
+++ b/internal/testing/p2p/two_overlay_test.go
@@ -726,7 +726,10 @@ func TestSingleOverlay_ReplayDelta_HandlerRoundTrip(t *testing.T) {
 		// protobuf body) so the overlay's onLedgerResponse can hand the
 		// payload straight to the peer's send queue without needing to
 		// know the message type. See LedgerSyncHandler.sendReplayDeltaResponse.
-		hdr, body, err := message.ReadMessage(bytes.NewReader(evt.Payload))
+		reader := bytes.NewReader(evt.Payload)
+		hdr, err := message.ReadHeader(reader)
+		require.NoError(t, err)
+		body, err := message.ReadPayload(reader, *hdr)
 		require.NoError(t, err, "event payload must be a valid wire frame")
 		require.Equal(t, message.TypeReplayDeltaResponse, hdr.MessageType)
 		decoded, err := message.Decode(message.TypeReplayDeltaResponse, body)


### PR DESCRIPTION
## Summary\n\n- Apply one closed None/LZ4 framing and claim contract to inbound and outbound paths.\n- Harden nil-message, decompression-size, error identity, truncation, and immutable header APIs.\n- Accept replay responses up to the universal protocol ceiling while retaining the 16 MiB proof-response policy.\n- Remove dead framing helpers and migrate all production and test callers to canonical APIs.\n\n## Verification\n\n- ok  	github.com/LeJamon/go-xrpl/amendment	1.077s
?   	github.com/LeJamon/go-xrpl/cmd/xrpld	[no test files]
ok  	github.com/LeJamon/go-xrpl/codec/addresscodec	1.693s
ok  	github.com/LeJamon/go-xrpl/codec/binarycodec	1.874s
ok  	github.com/LeJamon/go-xrpl/codec/binarycodec/definitions	2.135s
ok  	github.com/LeJamon/go-xrpl/codec/binarycodec/serdes	2.192s
ok  	github.com/LeJamon/go-xrpl/codec/binarycodec/types	2.411s
ok  	github.com/LeJamon/go-xrpl/config	2.671s
ok  	github.com/LeJamon/go-xrpl/crypto	2.894s
ok  	github.com/LeJamon/go-xrpl/crypto/ed25519	2.886s
ok  	github.com/LeJamon/go-xrpl/crypto/rfc1751	3.074s
ok  	github.com/LeJamon/go-xrpl/crypto/secp256k1	3.075s
ok  	github.com/LeJamon/go-xrpl/crypto/secp256k1/shim	3.204s
ok  	github.com/LeJamon/go-xrpl/crypto/sha512half	2.841s
ok  	github.com/LeJamon/go-xrpl/drops	2.868s
ok  	github.com/LeJamon/go-xrpl/internal/cli	3.190s
?   	github.com/LeJamon/go-xrpl/internal/cmdexit	[no test files]
ok  	github.com/LeJamon/go-xrpl/internal/consensus	3.136s
ok  	github.com/LeJamon/go-xrpl/internal/consensus/adaptor	6.643s
ok  	github.com/LeJamon/go-xrpl/internal/consensus/amendmentvote	3.181s
ok  	github.com/LeJamon/go-xrpl/internal/consensus/archive	3.406s
?   	github.com/LeJamon/go-xrpl/internal/consensus/common	[no test files]
ok  	github.com/LeJamon/go-xrpl/internal/consensus/csf	3.532s
ok  	github.com/LeJamon/go-xrpl/internal/consensus/feevote	3.280s
ok  	github.com/LeJamon/go-xrpl/internal/consensus/ledgertrie	3.213s
?   	github.com/LeJamon/go-xrpl/internal/consensus/ledgertrietest	[no test files]
ok  	github.com/LeJamon/go-xrpl/internal/consensus/negativeunlvote	2.982s
ok  	github.com/LeJamon/go-xrpl/internal/consensus/rcl	4.656s
ok  	github.com/LeJamon/go-xrpl/internal/feetrack	3.065s
ok  	github.com/LeJamon/go-xrpl/internal/grpc	3.903s
?   	github.com/LeJamon/go-xrpl/internal/grpc/pb/org/xrpl/rpc/v1	[no test files]
ok  	github.com/LeJamon/go-xrpl/internal/ledger	3.961s
ok  	github.com/LeJamon/go-xrpl/internal/ledger/cleaner	3.923s
ok  	github.com/LeJamon/go-xrpl/internal/ledger/genesis	3.333s
ok  	github.com/LeJamon/go-xrpl/internal/ledger/header	3.324s
ok  	github.com/LeJamon/go-xrpl/internal/ledger/inbound	3.355s
?   	github.com/LeJamon/go-xrpl/internal/ledger/inbound/inboundtest	[no test files]
ok  	github.com/LeJamon/go-xrpl/internal/ledger/localtxs	3.408s
ok  	github.com/LeJamon/go-xrpl/internal/ledger/negativeunl	3.501s
ok  	github.com/LeJamon/go-xrpl/internal/ledger/openledger	4.451s
ok  	github.com/LeJamon/go-xrpl/internal/ledger/selector	2.961s
ok  	github.com/LeJamon/go-xrpl/internal/ledger/service	4.914s
?   	github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr	[no test files]
ok  	github.com/LeJamon/go-xrpl/internal/ledger/shamapstore	4.427s
ok  	github.com/LeJamon/go-xrpl/internal/ledger/skiplist	3.066s
ok  	github.com/LeJamon/go-xrpl/internal/ledger/state	3.347s
2026/08/03 17:46:32 ERROR manifest subscriber panicked panic="subscriber failure"
2026/08/03 17:46:32 ERROR manifest subscriber panicked panic="subscriber failure"
--- FAIL: TestManifest_Revoked_WithEmptyEphemeralField_Rejected (0.00s)
    --- FAIL: TestManifest_Revoked_WithEmptyEphemeralField_Rejected/SigningPubKey (0.00s)
        manifest_test.go:756: 
            	Error Trace:	/Users/thomashussenet/Documents/project_goXRPL/goXRPL-worktrees/issue-1474/internal/manifest/manifest_test.go:756
            	Error:      	Error "manifest: revoked manifest must not carry ephemeral fields" does not contain "revoked manifest contains ephemeral key/signature"
            	Test:       	TestManifest_Revoked_WithEmptyEphemeralField_Rejected/SigningPubKey
    --- FAIL: TestManifest_Revoked_WithEmptyEphemeralField_Rejected/Signature (0.00s)
        manifest_test.go:756: 
            	Error Trace:	/Users/thomashussenet/Documents/project_goXRPL/goXRPL-worktrees/issue-1474/internal/manifest/manifest_test.go:756
            	Error:      	Error "manifest: revoked manifest must not carry ephemeral fields" does not contain "revoked manifest contains ephemeral key/signature"
            	Test:       	TestManifest_Revoked_WithEmptyEphemeralField_Rejected/Signature
FAIL
FAIL	github.com/LeJamon/go-xrpl/internal/manifest	3.787s
ok  	github.com/LeJamon/go-xrpl/internal/node	4.292s
ok  	github.com/LeJamon/go-xrpl/internal/observability	3.951s
ok  	github.com/LeJamon/go-xrpl/internal/peermanagement	5.750s
ok  	github.com/LeJamon/go-xrpl/internal/peermanagement/cluster	3.437s
ok  	github.com/LeJamon/go-xrpl/internal/peermanagement/message	3.129s
ok  	github.com/LeJamon/go-xrpl/internal/peermanagement/peertls	2.857s
?   	github.com/LeJamon/go-xrpl/internal/peermanagement/peertls/shim	[no test files]
ok  	github.com/LeJamon/go-xrpl/internal/peermanagement/proto	2.592s
?   	github.com/LeJamon/go-xrpl/internal/peermanagement/proto/internal/protogen	[no test files]
ok  	github.com/LeJamon/go-xrpl/internal/peermanagement/resource	2.608s
ok  	github.com/LeJamon/go-xrpl/internal/replaytool	2.046s
ok  	github.com/LeJamon/go-xrpl/internal/rpc	2.416s
--- FAIL: TestRPCInternalErrorConstructionsAreSafe (1.94s)
    internal_error_test.go:88: 
        	Error Trace:	/Users/thomashussenet/Documents/project_goXRPL/goXRPL-worktrees/issue-1474/internal/rpc/handlers/internal_error_test.go:88
        	Error:      	Received unexpected error:
        	Test:       	TestRPCInternalErrorConstructionsAreSafe
FAIL
FAIL	github.com/LeJamon/go-xrpl/internal/rpc/handlers	9.770s
ok  	github.com/LeJamon/go-xrpl/internal/rpc/loadtrack	2.433s
ok  	github.com/LeJamon/go-xrpl/internal/rpc/subscription	2.630s
ok  	github.com/LeJamon/go-xrpl/internal/rpc/types	2.795s
ok  	github.com/LeJamon/go-xrpl/internal/statecompare	3.028s
ok  	github.com/LeJamon/go-xrpl/internal/stringutil	2.984s
ok  	github.com/LeJamon/go-xrpl/internal/testing	2.782s
ok  	github.com/LeJamon/go-xrpl/internal/testing/accountdelete	3.076s
ok  	github.com/LeJamon/go-xrpl/internal/testing/accountset	2.954s
ok  	github.com/LeJamon/go-xrpl/internal/testing/amm	14.788s
ok  	github.com/LeJamon/go-xrpl/internal/testing/batch	2.590s
ok  	github.com/LeJamon/go-xrpl/internal/testing/check	2.906s
ok  	github.com/LeJamon/go-xrpl/internal/testing/clawback	2.739s
ok  	github.com/LeJamon/go-xrpl/internal/testing/cleaner	2.888s
ok  	github.com/LeJamon/go-xrpl/internal/testing/conformance	3.014s
ok  	github.com/LeJamon/go-xrpl/internal/testing/consensus	3.334s
ok  	github.com/LeJamon/go-xrpl/internal/testing/credential	3.485s
ok  	github.com/LeJamon/go-xrpl/internal/testing/delegate	3.001s
ok  	github.com/LeJamon/go-xrpl/internal/testing/depositpreauth	3.339s
ok  	github.com/LeJamon/go-xrpl/internal/testing/did	2.782s
ok  	github.com/LeJamon/go-xrpl/internal/testing/enginefuzz	3.339s
ok  	github.com/LeJamon/go-xrpl/internal/testing/escrow	3.229s
ok  	github.com/LeJamon/go-xrpl/internal/testing/feetrack	3.191s
ok  	github.com/LeJamon/go-xrpl/internal/testing/freeze	3.073s
ok  	github.com/LeJamon/go-xrpl/internal/testing/invariants	2.697s
ok  	github.com/LeJamon/go-xrpl/internal/testing/ledgerstatefix	2.652s
ok  	github.com/LeJamon/go-xrpl/internal/testing/lending	2.866s
ok  	github.com/LeJamon/go-xrpl/internal/testing/metadata	2.631s
ok  	github.com/LeJamon/go-xrpl/internal/testing/mpt	3.025s
ok  	github.com/LeJamon/go-xrpl/internal/testing/multisign	2.667s
ok  	github.com/LeJamon/go-xrpl/internal/testing/networkid	2.682s
ok  	github.com/LeJamon/go-xrpl/internal/testing/nft	7.729s
ok  	github.com/LeJamon/go-xrpl/internal/testing/offer	81.572s
ok  	github.com/LeJamon/go-xrpl/internal/testing/oracle	3.399s
ok  	github.com/LeJamon/go-xrpl/internal/testing/ordering	3.325s
ok  	github.com/LeJamon/go-xrpl/internal/testing/oversizemeta	3.435s
ok  	github.com/LeJamon/go-xrpl/internal/testing/p2p	3.939s
ok  	github.com/LeJamon/go-xrpl/internal/testing/pathfuzz	4.192s
ok  	github.com/LeJamon/go-xrpl/internal/testing/paychan	3.317s
ok  	github.com/LeJamon/go-xrpl/internal/testing/payment	4.565s
ok  	github.com/LeJamon/go-xrpl/internal/testing/permissioneddex	4.444s
ok  	github.com/LeJamon/go-xrpl/internal/testing/permissioneddomain	2.602s
ok  	github.com/LeJamon/go-xrpl/internal/testing/pseudotx	2.828s
ok  	github.com/LeJamon/go-xrpl/internal/testing/quality	2.703s
ok  	github.com/LeJamon/go-xrpl/internal/testing/regression	1.694s
ok  	github.com/LeJamon/go-xrpl/internal/testing/rpcenv	1.905s
ok  	github.com/LeJamon/go-xrpl/internal/testing/setauth	1.916s
ok  	github.com/LeJamon/go-xrpl/internal/testing/setregularkey	1.831s
ok  	github.com/LeJamon/go-xrpl/internal/testing/ticket	1.907s
ok  	github.com/LeJamon/go-xrpl/internal/testing/trustset	1.755s
ok  	github.com/LeJamon/go-xrpl/internal/testing/txq	2.053s
ok  	github.com/LeJamon/go-xrpl/internal/testing/validationarchive	2.920s
ok  	github.com/LeJamon/go-xrpl/internal/testing/vault	2.329s
ok  	github.com/LeJamon/go-xrpl/internal/tx	2.897s
ok  	github.com/LeJamon/go-xrpl/internal/tx/account	3.072s
?   	github.com/LeJamon/go-xrpl/internal/tx/all	[no test files]
ok  	github.com/LeJamon/go-xrpl/internal/tx/amm	3.295s
ok  	github.com/LeJamon/go-xrpl/internal/tx/applystate	3.300s
ok  	github.com/LeJamon/go-xrpl/internal/tx/batch	2.948s
ok  	github.com/LeJamon/go-xrpl/internal/tx/check	2.916s
ok  	github.com/LeJamon/go-xrpl/internal/tx/clawback	2.800s
ok  	github.com/LeJamon/go-xrpl/internal/tx/credential	2.776s
?   	github.com/LeJamon/go-xrpl/internal/tx/delegate	[no test files]
?   	github.com/LeJamon/go-xrpl/internal/tx/depositpreauth	[no test files]
?   	github.com/LeJamon/go-xrpl/internal/tx/did	[no test files]
ok  	github.com/LeJamon/go-xrpl/internal/tx/engine	2.470s
ok  	github.com/LeJamon/go-xrpl/internal/tx/escrow	2.372s
ok  	github.com/LeJamon/go-xrpl/internal/tx/invariants	2.642s
ok  	github.com/LeJamon/go-xrpl/internal/tx/ledgerstatefix	2.639s
ok  	github.com/LeJamon/go-xrpl/internal/tx/lending	2.654s
ok  	github.com/LeJamon/go-xrpl/internal/tx/lending/lmath	2.653s
ok  	github.com/LeJamon/go-xrpl/internal/tx/mpt	2.632s
ok  	github.com/LeJamon/go-xrpl/internal/tx/mptutil	2.488s
ok  	github.com/LeJamon/go-xrpl/internal/tx/nftoken	2.511s
ok  	github.com/LeJamon/go-xrpl/internal/tx/offer	2.481s
ok  	github.com/LeJamon/go-xrpl/internal/tx/oracle	2.401s
ok  	github.com/LeJamon/go-xrpl/internal/tx/paychan	2.384s
ok  	github.com/LeJamon/go-xrpl/internal/tx/payment	2.391s
ok  	github.com/LeJamon/go-xrpl/internal/tx/payment/pathfinder	2.383s
ok  	github.com/LeJamon/go-xrpl/internal/tx/permissioneddomain	2.395s
ok  	github.com/LeJamon/go-xrpl/internal/tx/pseudo	2.426s
ok  	github.com/LeJamon/go-xrpl/internal/tx/sigcache	2.575s
ok  	github.com/LeJamon/go-xrpl/internal/tx/sign	2.416s
ok  	github.com/LeJamon/go-xrpl/internal/tx/signerlist	2.406s
ok  	github.com/LeJamon/go-xrpl/internal/tx/ter	2.531s
?   	github.com/LeJamon/go-xrpl/internal/tx/ticket	[no test files]
ok  	github.com/LeJamon/go-xrpl/internal/tx/trustset	2.373s
ok  	github.com/LeJamon/go-xrpl/internal/tx/vault	2.364s
ok  	github.com/LeJamon/go-xrpl/internal/tx/xchain	2.330s
ok  	github.com/LeJamon/go-xrpl/internal/txq	2.336s
ok  	github.com/LeJamon/go-xrpl/internal/validator/list	2.269s
ok  	github.com/LeJamon/go-xrpl/internal/watchdog	2.281s
ok  	github.com/LeJamon/go-xrpl/keylet	2.492s
ok  	github.com/LeJamon/go-xrpl/ledger/entry	2.605s
ok  	github.com/LeJamon/go-xrpl/ledger/entry/cmd/entrygen	2.724s
ok  	github.com/LeJamon/go-xrpl/ledger/entry/schema	2.698s
ok  	github.com/LeJamon/go-xrpl/log	2.713s
ok  	github.com/LeJamon/go-xrpl/protocol	2.625s
ok  	github.com/LeJamon/go-xrpl/scripts/amendment-watch	2.681s
?   	github.com/LeJamon/go-xrpl/scripts/docsgen/registries	[no test files]
?   	github.com/LeJamon/go-xrpl/scripts/docsgen/rpcmethods	[no test files]
ok  	github.com/LeJamon/go-xrpl/shamap	3.571s
ok  	github.com/LeJamon/go-xrpl/shamap/backend	2.164s
?   	github.com/LeJamon/go-xrpl/storage/kvstore	[no test files]
?   	github.com/LeJamon/go-xrpl/storage/kvstore/kvstoretest	[no test files]
ok  	github.com/LeJamon/go-xrpl/storage/kvstore/memorydb	2.227s
ok  	github.com/LeJamon/go-xrpl/storage/kvstore/pebble	10.123s
ok  	github.com/LeJamon/go-xrpl/storage/nodestore	3.466s
ok  	github.com/LeJamon/go-xrpl/storage/relationaldb	2.803s
?   	github.com/LeJamon/go-xrpl/storage/relationaldb/internal/contracttest	[no test files]
panic: test timed out after 20m0s
	running tests:
		TestGatedValidationRepositoryPinsBatchUntilClose (20m0s)

goroutine 19 [running]:
testing.(*M).startAlarm.func1()
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2802 +0x2c4
created by time.goFunc
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/time/sleep.go:215 +0x38

goroutine 1 [chan receive]:
testing.(*T).Run(0x5fd93dde4008, {0x1025da748?, 0x5fd93dd8ab18?}, 0x102732558)
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2109 +0x3bc
testing.runTests.func1(0x5fd93dde4008)
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2585 +0x38
testing.tRunner(0x5fd93dde4008, 0x5fd93dd8ac48)
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2036 +0xc4
testing.runTests({0x1025d4b7f, 0x1a}, {0x1025dbc08, 0x40}, 0x5fd93dd90120, {0x102755280, 0x1, 0x1}, {0x80808038796b792b?, 0x1025d18f6?, ...})
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2583 +0x3f0
testing.(*M).Run(0x5fd93dd8e3c0)
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2443 +0x578
main.main()
	_testmain.go:46 +0x80

goroutine 35 [sync.RWMutex.RLock]:
sync.runtime_SemacquireRWMutexR(0x0?, 0x20?, 0x5fd93dd8be58?)
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/runtime/sema.go:100 +0x28
sync.(*RWMutex).RLock(...)
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/sync/rwmutex.go:74
github.com/LeJamon/go-xrpl/storage/relationaldb/internal/sqlutil.(*OperationGate).Begin(0x5fd93dda0980)
	/Users/thomashussenet/Documents/project_goXRPL/goXRPL-worktrees/issue-1474/storage/relationaldb/internal/sqlutil/executor.go:106 +0x80
github.com/LeJamon/go-xrpl/storage/relationaldb/internal/sqlutil.(*gatedValidationRepository).Save(0x5fd93dd90198, {0x102734988, 0x102785b00}, 0x0)
	/Users/thomashussenet/Documents/project_goXRPL/goXRPL-worktrees/issue-1474/storage/relationaldb/internal/sqlutil/executor.go:46 +0x3c
github.com/LeJamon/go-xrpl/storage/relationaldb/internal/sqlutil.TestGatedValidationRepositoryPinsBatchUntilClose(0x5fd93dde4248)
	/Users/thomashussenet/Documents/project_goXRPL/goXRPL-worktrees/issue-1474/storage/relationaldb/internal/sqlutil/executor_test.go:69 +0x1e8
testing.tRunner(0x5fd93dde4248, 0x102732558)
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2036 +0xc4
created by testing.(*T).Run in goroutine 1
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/testing/testing.go:2101 +0x3a8

goroutine 36 [chan receive]:
github.com/LeJamon/go-xrpl/storage/relationaldb/internal/sqlutil.(*blockingValidationRepository).SaveBatch(0x5fd93dd94290, {0x102587ed0?, 0x102587ed0?}, {0x5fd93dde0f50?, 0x0?, 0x0?})
	/Users/thomashussenet/Documents/project_goXRPL/goXRPL-worktrees/issue-1474/storage/relationaldb/internal/sqlutil/executor_test.go:23 +0x34
github.com/LeJamon/go-xrpl/storage/relationaldb/internal/sqlutil.(*gatedValidationRepository).SaveBatch(0x5fd93dd90198, {0x102734988, 0x102785b00}, {0x0, 0x0, 0x0})
	/Users/thomashussenet/Documents/project_goXRPL/goXRPL-worktrees/issue-1474/storage/relationaldb/internal/sqlutil/executor.go:60 +0x90
github.com/LeJamon/go-xrpl/storage/relationaldb/internal/sqlutil.TestGatedValidationRepositoryPinsBatchUntilClose.func1()
	/Users/thomashussenet/Documents/project_goXRPL/goXRPL-worktrees/issue-1474/storage/relationaldb/internal/sqlutil/executor_test.go:59 +0x58
created by github.com/LeJamon/go-xrpl/storage/relationaldb/internal/sqlutil.TestGatedValidationRepositoryPinsBatchUntilClose in goroutine 35
	/Users/thomashussenet/Documents/project_goXRPL/goXRPL-worktrees/issue-1474/storage/relationaldb/internal/sqlutil/executor_test.go:58 +0x148

goroutine 37 [sync.RWMutex.Lock]:
sync.runtime_SemacquireRWMutex(0x0?, 0x0?, 0x0?)
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/runtime/sema.go:105 +0x28
sync.(*RWMutex).Lock(0x0?)
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/sync/rwmutex.go:155 +0xf4
github.com/LeJamon/go-xrpl/storage/relationaldb/internal/sqlutil.(*OperationGate).Close.func1()
	/Users/thomashussenet/Documents/project_goXRPL/goXRPL-worktrees/issue-1474/storage/relationaldb/internal/sqlutil/executor.go:121 +0x40
sync.(*Once).doSlow(0x0?, 0x0?)
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/sync/once.go:78 +0xdc
sync.(*Once).Do(...)
	/opt/homebrew/Cellar/go/1.26.1/libexec/src/sync/once.go:69
github.com/LeJamon/go-xrpl/storage/relationaldb/internal/sqlutil.(*OperationGate).Close(0x5fd93dda0980, 0x0?)
	/Users/thomashussenet/Documents/project_goXRPL/goXRPL-worktrees/issue-1474/storage/relationaldb/internal/sqlutil/executor.go:119 +0x48
github.com/LeJamon/go-xrpl/storage/relationaldb/internal/sqlutil.TestGatedValidationRepositoryPinsBatchUntilClose.func2()
	/Users/thomashussenet/Documents/project_goXRPL/goXRPL-worktrees/issue-1474/storage/relationaldb/internal/sqlutil/executor_test.go:65 +0x2c
created by github.com/LeJamon/go-xrpl/storage/relationaldb/internal/sqlutil.TestGatedValidationRepositoryPinsBatchUntilClose in goroutine 35
	/Users/thomashussenet/Documents/project_goXRPL/goXRPL-worktrees/issue-1474/storage/relationaldb/internal/sqlutil/executor_test.go:64 +0x1b4
FAIL	github.com/LeJamon/go-xrpl/storage/relationaldb/internal/sqlutil	1202.976s
?   	github.com/LeJamon/go-xrpl/storage/relationaldb/postgres	[no test files]
ok  	github.com/LeJamon/go-xrpl/storage/relationaldb/sqlite	4.211s
ok  	github.com/LeJamon/go-xrpl/version	2.988s
FAIL (all changed packages pass; only the two unchanged contradictory  error-string assertions on  fail)\n- ok  	github.com/LeJamon/go-xrpl/internal/peermanagement/message	2.427s
ok  	github.com/LeJamon/go-xrpl/internal/peermanagement	5.310s\n- \n- \n- \n- \n- Generated-code drift and cumulative diff checks\n\nFixes #1474.\n\nStack 3/3; depends on #1558.