### PR TITLE
fix: align clawback wire format

### DIFF
--- a/internal/testing/clawback/builder.go
+++ b/internal/testing/clawback/builder.go
@@ -1,77 +1,37 @@
 package clawback
 
 import (
-	"fmt"
-
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/clawback"
 )
 
-// ClawbackBuilder provides a fluent interface for building Clawback transactions.
-type ClawbackBuilder struct {
-	issuer   *jtx.Account
-	holder   *jtx.Account
-	currency string
-	amount   float64
-	fee      uint64
-	sequence *uint32
-	flags    uint32
+type clawbackBuilder struct {
+	issuer *jtx.Account
+	amount tx.Amount
+	flags  uint32
 }
 
-// Claw creates a new ClawbackBuilder.
-// issuer is the token issuer performing the clawback.
-// holder is the token holder from whom tokens are clawed back.
-// currency is the currency code (e.g. "USD").
-// amount is the amount to claw back (positive).
-// Matches rippled's claw(alice, bob["USD"](200)).
-func Claw(issuer, holder *jtx.Account, currency string, amount float64) *ClawbackBuilder {
-	return &ClawbackBuilder{
-		issuer:   issuer,
-		holder:   holder,
-		currency: currency,
-		amount:   amount,
-		fee:      10, // Default fee: 10 drops
-	}
+// Claw creates an IOU clawback with an exact integer amount.
+func Claw(issuer, holder *jtx.Account, currency string, amount int64) *clawbackBuilder {
+	return ClawAmount(issuer, holder, tx.NewIssuedAmount(amount, 0, currency, holder.Address))
 }
 
-// Fee sets the transaction fee in drops.
-func (b *ClawbackBuilder) Fee(f uint64) *ClawbackBuilder {
-	b.fee = f
-	return b
-}
-
-// Sequence sets the sequence number explicitly.
-func (b *ClawbackBuilder) Sequence(seq uint32) *ClawbackBuilder {
-	b.sequence = &seq
-	return b
+func ClawAmount(issuer, holder *jtx.Account, amount tx.Amount) *clawbackBuilder {
+	amount.Issuer = holder.Address
+	return &clawbackBuilder{issuer: issuer, amount: amount}
 }
 
 // Flags sets the transaction flags.
-func (b *ClawbackBuilder) Flags(flags uint32) *ClawbackBuilder {
+func (b *clawbackBuilder) Flags(flags uint32) *clawbackBuilder {
 	b.flags = flags
 	return b
 }
 
-// Build constructs the Clawback transaction.
-func (b *ClawbackBuilder) Build() tx.Transaction {
-	// For IOU clawback, the Amount.Issuer field is the holder (not the issuer).
-	// The transaction Account is the issuer.
-	amount := tx.NewIssuedAmountFromFloat64(b.amount, b.currency, b.holder.Address)
-	cb := clawback.NewClawback(b.issuer.Address, amount)
-	cb.Fee = fmt.Sprintf("%d", b.fee)
-
-	if b.sequence != nil {
-		cb.SetSequence(*b.sequence)
-	}
+func (b *clawbackBuilder) Build() *clawback.Clawback {
+	cb := clawback.NewClawback(b.issuer.Address, b.amount)
 	if b.flags != 0 {
 		cb.SetFlags(b.flags)
 	}
-
 	return cb
-}
-
-// BuildClawback is a convenience method that returns the concrete *clawback.Clawback type.
-func (b *ClawbackBuilder) BuildClawback() *clawback.Clawback {
-	return b.Build().(*clawback.Clawback)
 }

--- a/internal/testing/clawback/clawback_test.go
+++ b/internal/testing/clawback/clawback_test.go
@@ -821,7 +821,7 @@ func TestClawback_FrozenLine(t *testing.T) {
 	require.NotNil(t, data)
 	line, err := state.ParseRippleState(data)
 	require.NoError(t, err)
-	expected, opposite := uint32(state.LsfHighFreeze), uint32(state.LsfLowFreeze)
+	expected, opposite := state.LsfHighFreeze, state.LsfLowFreeze
 	if state.CompareAccountIDs(alice.ID, bob.ID) < 0 {
 		expected, opposite = state.LsfLowFreeze, state.LsfHighFreeze
 	}

--- a/internal/testing/clawback/clawback_test.go
+++ b/internal/testing/clawback/clawback_test.go
@@ -13,8 +13,23 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	accounttx "github.com/LeJamon/go-xrpl/internal/tx/account"
+	clawbacktx "github.com/LeJamon/go-xrpl/internal/tx/clawback"
+	"github.com/LeJamon/go-xrpl/keylet"
 	"github.com/stretchr/testify/require"
 )
+
+type clawbackWithTopLevelMPTID struct {
+	*clawbacktx.Clawback
+}
+
+func (c *clawbackWithTopLevelMPTID) Flatten() (map[string]any, error) {
+	values, err := c.Clawback.Flatten()
+	if err != nil {
+		return nil, err
+	}
+	values["MPTokenIssuanceID"] = "000000000000000000000001000000000000000000000001"
+	return values, nil
+}
 
 // TestClawback_AllowTrustLineClawbackFlag tests the AllowTrustLineClawback flag.
 // Reference: rippled Clawback_test.cpp testAllowTrustLineClawbackFlag (lines 64-191)
@@ -236,7 +251,7 @@ func TestClawback_Validation(t *testing.T) {
 
 		// fails because amount is in XRP
 		{
-			cb := clawback.Claw(alice, bob, "USD", 5).BuildClawback()
+			cb := clawback.Claw(alice, bob, "USD", 5).Build()
 			cb.Amount = tx.NewXRPAmount(jtx.XRP(10))
 			result = env.Submit(cb)
 			require.Equal(t, "temBAD_AMOUNT", result.Code)
@@ -280,6 +295,19 @@ func TestClawback_Validation(t *testing.T) {
 	})
 }
 
+func TestClawback_TypedSubmissionRejectsTopLevelMPTID(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.Fund(alice, bob)
+	transaction := &clawbackWithTopLevelMPTID{Clawback: clawbacktx.NewMPTokenClawback(
+		alice.Address,
+		bob.Address,
+		state.NewMPTAmountWithIssuanceID(1, alice.Address, "000000000000000000000001000000000000000000000001"),
+	)}
+	jtx.RequireTxFail(t, env.Submit(transaction), jtx.TemMALFORMED)
+}
+
 // TestClawback_Permission tests clawback permission checks (preclaim).
 // Reference: rippled Clawback_test.cpp testPermission (lines 323-458)
 func TestClawback_Permission(t *testing.T) {
@@ -307,7 +335,7 @@ func TestClawback_Permission(t *testing.T) {
 	})
 
 	// Test that trustline cannot be clawed by someone who is not the issuer
-	t.Run("NonIssuerClawback", func(t *testing.T) {
+	t.Run("ThirdPartyWithoutTrustLine", func(t *testing.T) {
 		env := jtx.NewTestEnv(t)
 
 		alice := jtx.NewAccount("alice")
@@ -340,8 +368,12 @@ func TestClawback_Permission(t *testing.T) {
 
 		// cindy tries to claw from bob, and fails because trustline does not exist
 		result = env.Submit(clawback.Claw(cindy, bob, "USD", 200).Build())
-		require.Equal(t, "tecNO_LINE", result.Code)
+		jtx.RequireTxClaimed(t, result, "tecNO_LINE")
 		env.Close()
+		jtx.RequireIOUBalance(t, env, bob, alice, "USD", 1000)
+		jtx.RequireIOUBalance(t, env, alice, bob, "USD", -1000)
+		jtx.RequireOwnerCount(t, env, bob, 1)
+		jtx.RequireOwnerCount(t, env, cindy, 0)
 	})
 
 	// When a trustline is created between issuer and holder,
@@ -384,8 +416,11 @@ func TestClawback_Permission(t *testing.T) {
 
 			// bob cannot claw back USD from alice because he's not the issuer
 			result = env.Submit(clawback.Claw(bob, alice, "USD", 5).Build())
-			require.Equal(t, "tecNO_PERMISSION", result.Code)
+			jtx.RequireTxClaimed(t, result, "tecNO_PERMISSION")
 			env.Close()
+			jtx.RequireIOUBalance(t, env, bob, alice, "USD", 10)
+			jtx.RequireIOUBalance(t, env, alice, bob, "USD", -10)
+			jtx.RequireOwnerCount(t, env, bob, 1)
 		})
 
 		// bob issues 10 CAD to alice.
@@ -403,8 +438,11 @@ func TestClawback_Permission(t *testing.T) {
 
 			// alice cannot claw back CAD from bob because she's not the issuer
 			result = env.Submit(clawback.Claw(alice, bob, "CAD", 5).Build())
-			require.Equal(t, "tecNO_PERMISSION", result.Code)
+			jtx.RequireTxClaimed(t, result, "tecNO_PERMISSION")
 			env.Close()
+			jtx.RequireIOUBalance(t, env, bob, alice, "CAD", -10)
+			jtx.RequireIOUBalance(t, env, alice, bob, "CAD", 10)
+			jtx.RequireOwnerCount(t, env, alice, 1)
 		})
 	})
 }
@@ -643,8 +681,12 @@ func TestClawback_BidirectionalLine(t *testing.T) {
 	// alice fails to clawback. Even though she is also an issuer,
 	// the trustline balance is positive from her perspective
 	result = env.Submit(clawback.Claw(alice, bob, "USD", 200).Build())
-	require.Equal(t, "tecNO_PERMISSION", result.Code)
+	jtx.RequireTxClaimed(t, result, "tecNO_PERMISSION")
 	env.Close()
+	jtx.RequireIOUBalance(t, env, bob, alice, "USD", -500)
+	jtx.RequireIOUBalance(t, env, alice, bob, "USD", 500)
+	jtx.RequireOwnerCount(t, env, alice, 1)
+	jtx.RequireOwnerCount(t, env, bob, 1)
 
 	// bob is able to successfully clawback from alice because
 	// the trustline balance is negative from his perspective
@@ -667,8 +709,12 @@ func TestClawback_BidirectionalLine(t *testing.T) {
 
 	// bob is now the holder and fails to clawback
 	result = env.Submit(clawback.Claw(bob, alice, "USD", 200).Build())
-	require.Equal(t, "tecNO_PERMISSION", result.Code)
+	jtx.RequireTxClaimed(t, result, "tecNO_PERMISSION")
 	env.Close()
+	jtx.RequireIOUBalance(t, env, bob, alice, "USD", 700)
+	jtx.RequireIOUBalance(t, env, alice, bob, "USD", -700)
+	jtx.RequireOwnerCount(t, env, alice, 1)
+	jtx.RequireOwnerCount(t, env, bob, 1)
 
 	// alice successfully claws back
 	result = env.Submit(clawback.Claw(alice, bob, "USD", 200).Build())
@@ -725,6 +771,10 @@ func TestClawback_DeleteDefaultLine(t *testing.T) {
 	// bob no longer owns the trustline because it was deleted
 	jtx.RequireOwnerCount(t, env, alice, 0)
 	jtx.RequireOwnerCount(t, env, bob, 0)
+	jtx.RequireTrustLineNotExists(t, env, alice, bob, "USD")
+	jtx.RequireLedgerEntryNotExists(t, env, keylet.Line(alice.ID, bob.ID, "USD"))
+	jtx.RequireLines(t, env, alice, 0)
+	jtx.RequireLines(t, env, bob, 0)
 }
 
 // TestClawback_FrozenLine tests clawback on frozen trust lines.
@@ -766,14 +816,17 @@ func TestClawback_FrozenLine(t *testing.T) {
 	jtx.RequireIOUBalance(t, env, bob, alice, "USD", 800)
 	jtx.RequireIOUBalance(t, env, alice, bob, "USD", -800)
 
-	// trustline remains frozen - check the freeze flag
-	// The freeze flag is on alice's side of the trustline
-	flags := env.TrustLineFlags(alice, bob, "USD")
-	isAliceLow := alice.ID[0] < bob.ID[0] // simplified comparison
-	_ = isAliceLow
-	// Check that either LsfLowFreeze or LsfHighFreeze is set (depending on which is alice)
-	isFrozen := (flags&state.LsfLowFreeze != 0) || (flags&state.LsfHighFreeze != 0)
-	require.True(t, isFrozen, "Trust line should remain frozen after clawback")
+	data, err := env.Ledger().Read(keylet.Line(alice.ID, bob.ID, "USD"))
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	line, err := state.ParseRippleState(data)
+	require.NoError(t, err)
+	expected, opposite := uint32(state.LsfHighFreeze), uint32(state.LsfLowFreeze)
+	if state.CompareAccountIDs(alice.ID, bob.ID) < 0 {
+		expected, opposite = state.LsfLowFreeze, state.LsfHighFreeze
+	}
+	require.NotZero(t, line.Flags&expected, "issuer-side freeze flag must remain set")
+	require.Zero(t, line.Flags&opposite, "holder-side freeze flag must remain clear")
 }
 
 // TestClawback_AmountExceedsAvailable tests clawback when amount exceeds balance.
@@ -825,58 +878,8 @@ func TestClawback_AmountExceedsAvailable(t *testing.T) {
 	// verify that bob's trustline was deleted
 	jtx.RequireOwnerCount(t, env, alice, 0)
 	jtx.RequireOwnerCount(t, env, bob, 0)
-}
-
-// TestClawback_Tickets tests clawback using tickets.
-// Reference: rippled Clawback_test.cpp testTickets (lines 876-930)
-func TestClawback_Tickets(t *testing.T) {
-	env := jtx.NewTestEnv(t)
-	alice := jtx.NewAccount("alice")
-	bob := jtx.NewAccount("bob")
-
-	env.Fund(alice, bob)
-	env.Close()
-
-	// alice sets asfAllowTrustLineClawback
-	result := env.Submit(accountset.AccountSet(alice).AllowClawback().Build())
-	jtx.RequireTxSuccess(t, result)
-	env.Close()
-	jtx.RequireFlagSet(t, env, alice, state.LsfAllowTrustLineClawback)
-
-	// alice issues 100 USD to bob
-	env.Trust(bob, tx.NewIssuedAmountFromFloat64(1000, "USD", alice.Address))
-	result = env.Submit(payment.PayIssued(alice, bob, tx.NewIssuedAmountFromFloat64(100, "USD", alice.Address)).Build())
-	jtx.RequireTxSuccess(t, result)
-	env.Close()
-
-	jtx.RequireIOUBalance(t, env, bob, alice, "USD", 100)
-	jtx.RequireIOUBalance(t, env, alice, bob, "USD", -100)
-
-	// alice creates 10 tickets
-	ticketCount := uint32(10)
-	aliceTicketSeq := env.CreateTickets(alice, ticketCount)
-	env.Close()
-	aliceSeq := env.Seq(alice)
-	jtx.RequireOwnerCount(t, env, alice, ticketCount)
-
-	remaining := ticketCount
-	for remaining > 0 {
-		// alice claws back 5 USD using a ticket
-		clawTx := clawback.Claw(alice, bob, "USD", 5).Build()
-		clawTx = jtx.WithTicketSeq(clawTx, aliceTicketSeq)
-		result = env.Submit(clawTx)
-		jtx.RequireTxSuccess(t, result)
-		env.Close()
-
-		aliceTicketSeq++
-		remaining--
-		jtx.RequireOwnerCount(t, env, alice, remaining)
-	}
-
-	// alice clawed back 50 USD total, trustline has 50 USD remaining
-	jtx.RequireIOUBalance(t, env, bob, alice, "USD", 50)
-	jtx.RequireIOUBalance(t, env, alice, bob, "USD", -50)
-
-	// Verify that the account sequence numbers did not advance.
-	require.Equal(t, aliceSeq, env.Seq(alice))
+	jtx.RequireTrustLineNotExists(t, env, alice, bob, "USD")
+	jtx.RequireLedgerEntryNotExists(t, env, keylet.Line(alice.ID, bob.ID, "USD"))
+	jtx.RequireLines(t, env, alice, 0)
+	jtx.RequireLines(t, env, bob, 0)
 }

--- a/internal/testing/clawback/failure_ticket_test.go
+++ b/internal/testing/clawback/failure_ticket_test.go
@@ -1,0 +1,126 @@
+package clawback_test
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/accountset"
+	"github.com/LeJamon/go-xrpl/internal/testing/clawback"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/testing/trustset"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClawback_DeleteDefaultLineRollbackOnCorruptDirectory(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.Fund(alice, bob)
+	env.Close()
+
+	jtx.RequireTxSuccess(t, env.Submit(accountset.AccountSet(alice).AllowClawback().Build()))
+	env.Trust(bob, tx.NewIssuedAmountFromFloat64(1000, "USD", alice.Address))
+	jtx.RequireTxSuccess(t, env.Submit(payment.PayIssued(alice, bob, tx.NewIssuedAmountFromFloat64(1000, "USD", alice.Address)).Build()))
+	jtx.RequireTxSuccess(t, env.Submit(trustset.TrustSet(bob, tx.NewIssuedAmountFromFloat64(0, "USD", alice.Address)).Build()))
+	env.Close()
+
+	lineKey := keylet.Line(alice.ID, bob.ID, "USD")
+	dirKey := keylet.OwnerDir(bob.ID)
+	dirBytes, err := env.LedgerEntry(dirKey)
+	require.NoError(t, err)
+	dir, err := state.ParseDirectoryNode(dirBytes)
+	require.NoError(t, err)
+	dir.Indexes = nil
+	dirBytes, err = state.SerializeDirectoryNode(dir, false)
+	require.NoError(t, err)
+	require.NoError(t, env.Ledger().Update(dirKey, dirBytes))
+
+	lineBefore, err := env.LedgerEntry(lineKey)
+	require.NoError(t, err)
+	dirBefore, err := env.LedgerEntry(dirKey)
+	require.NoError(t, err)
+	aliceBefore, err := env.LedgerEntry(keylet.Account(alice.ID))
+	require.NoError(t, err)
+	bobBefore, err := env.LedgerEntry(keylet.Account(bob.ID))
+	require.NoError(t, err)
+	aliceSequence := env.Seq(alice)
+	aliceBalance := env.Balance(alice)
+	bobBalance := env.Balance(bob)
+
+	result := env.Submit(clawback.Claw(alice, bob, "USD", 1000).Build())
+	jtx.RequireTxFail(t, result, jtx.TefBAD_LEDGER)
+	require.Nil(t, result.Metadata)
+	require.Equal(t, aliceSequence, env.Seq(alice))
+	require.Equal(t, aliceBalance, env.Balance(alice))
+	require.Equal(t, bobBalance, env.Balance(bob))
+	jtx.RequireIOUBalance(t, env, bob, alice, "USD", 1000)
+	jtx.RequireIOUBalance(t, env, alice, bob, "USD", -1000)
+
+	lineAfter, err := env.LedgerEntry(lineKey)
+	require.NoError(t, err)
+	dirAfter, err := env.LedgerEntry(dirKey)
+	require.NoError(t, err)
+	aliceAfter, err := env.LedgerEntry(keylet.Account(alice.ID))
+	require.NoError(t, err)
+	bobAfter, err := env.LedgerEntry(keylet.Account(bob.ID))
+	require.NoError(t, err)
+	require.Equal(t, lineBefore, lineAfter)
+	require.Equal(t, dirBefore, dirAfter)
+	require.Equal(t, aliceBefore, aliceAfter)
+	require.Equal(t, bobBefore, bobAfter)
+}
+
+func TestClawback_Tickets(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.Fund(alice, bob)
+	env.Close()
+
+	result := env.Submit(accountset.AccountSet(alice).AllowClawback().Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+	jtx.RequireFlagSet(t, env, alice, state.LsfAllowTrustLineClawback)
+
+	env.Trust(bob, tx.NewIssuedAmountFromFloat64(1000, "USD", alice.Address))
+	result = env.Submit(payment.PayIssued(alice, bob, tx.NewIssuedAmountFromFloat64(100, "USD", alice.Address)).Build())
+	jtx.RequireTxSuccess(t, result)
+	env.Close()
+	jtx.RequireIOUBalance(t, env, bob, alice, "USD", 100)
+	jtx.RequireIOUBalance(t, env, alice, bob, "USD", -100)
+
+	ticketCount := uint32(10)
+	aliceTicketSeq := env.CreateTickets(alice, ticketCount)
+	env.Close()
+	aliceSeq := env.Seq(alice)
+	jtx.RequireOwnerCount(t, env, alice, ticketCount)
+
+	remaining := ticketCount
+	for remaining > 0 {
+		clawTx := jtx.WithTicketSeq(clawback.Claw(alice, bob, "USD", 5).Build(), aliceTicketSeq)
+		result = env.Submit(clawTx)
+		jtx.RequireTxSuccess(t, result)
+		env.Close()
+		aliceTicketSeq++
+		remaining--
+		jtx.RequireOwnerCount(t, env, alice, remaining)
+	}
+
+	jtx.RequireIOUBalance(t, env, bob, alice, "USD", 50)
+	jtx.RequireIOUBalance(t, env, alice, bob, "USD", -50)
+	require.Equal(t, aliceSeq, env.Seq(alice))
+	jtx.RequireTicketCount(t, env, alice, 0)
+
+	consumed := jtx.WithTicketSeq(clawback.Claw(alice, bob, "USD", 5).Build(), aliceTicketSeq-ticketCount)
+	jtx.RequireTxFail(t, env.Submit(consumed), "tefNO_TICKET")
+	future := jtx.WithTicketSeq(clawback.Claw(alice, bob, "USD", 5).Build(), aliceSeq)
+	jtx.RequireTxFail(t, env.Submit(future), "terPRE_TICKET")
+	jtx.RequireIOUBalance(t, env, bob, alice, "USD", 50)
+	jtx.RequireIOUBalance(t, env, alice, bob, "USD", -50)
+	jtx.RequireOwnerCount(t, env, alice, 0)
+	jtx.RequireTicketCount(t, env, alice, 0)
+	require.Equal(t, aliceSeq, env.Seq(alice))
+}

--- a/internal/testing/mpt/builder.go
+++ b/internal/testing/mpt/builder.go
@@ -508,15 +508,9 @@ func (m *MPTTester) PayFull(src, dest *jtx.Account, amount, sendMax, deliverMin 
 func (m *MPTTester) Claw(issuer, holder *jtx.Account, amount int64, expectedErr ...string) {
 	m.t.Helper()
 
-	// Use stored issuance ID, or compute it from current sequence if not yet created
-	id := m.id
-	if id == "" {
-		id = makeMPTIDHex(m.env.Seq(m.issuer), m.issuer)
-	}
-
 	// MPT clawback carries the issuance ID inside Amount and identifies the
 	// account to claw back from with Holder.
-	mptAmount := state.NewMPTAmountWithIssuanceID(amount, m.issuer.Address, id)
+	mptAmount := m.MPTAmount(amount)
 
 	cb := clawback.NewMPTokenClawback(issuer.Address, holder.Address, mptAmount)
 

--- a/internal/testing/mpt/builder.go
+++ b/internal/testing/mpt/builder.go
@@ -514,13 +514,11 @@ func (m *MPTTester) Claw(issuer, holder *jtx.Account, amount int64, expectedErr 
 		id = makeMPTIDHex(m.env.Seq(m.issuer), m.issuer)
 	}
 
-	// MPT clawback uses the Amount field with the MPT issuance info
-	// (mpt_issuance_id is required so IsMPT() returns true in preflight) and
-	// the Holder field to specify who to claw back from.
+	// MPT clawback carries the issuance ID inside Amount and identifies the
+	// account to claw back from with Holder.
 	mptAmount := state.NewMPTAmountWithIssuanceID(amount, m.issuer.Address, id)
 
-	cb := clawback.NewMPTokenClawback(issuer.Address, holder.Address, id, mptAmount)
-	cb.Fee = "10"
+	cb := clawback.NewMPTokenClawback(issuer.Address, holder.Address, mptAmount)
 
 	result := m.env.Submit(cb)
 

--- a/internal/testing/mpt/mpt_test.go
+++ b/internal/testing/mpt/mpt_test.go
@@ -4,11 +4,27 @@
 package mpt_test
 
 import (
+	"encoding/hex"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
 	"github.com/LeJamon/go-xrpl/internal/testing/mpt"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	clawbacktx "github.com/LeJamon/go-xrpl/internal/tx/clawback"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/stretchr/testify/require"
 )
+
+func mptID(t *testing.T, value string) [24]byte {
+	t.Helper()
+	decoded, err := hex.DecodeString(value)
+	require.NoError(t, err)
+	require.Len(t, decoded, 24)
+	var id [24]byte
+	copy(id[:], decoded)
+	return id
+}
 
 // --------------------------------------------------------------------------
 // TestMPT_CreateValidation
@@ -1447,6 +1463,32 @@ func TestMPT_Payment(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestMPT_ClawbackValidation(t *testing.T) {
+	t.Run("ClawbackFeatureDisabledPrecedesFlags", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		env.DisableFeature("Clawback")
+		env.Close()
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		tester := mpt.NewMPTTesterNoFund(t, env, alice)
+		transaction := clawbacktx.NewMPTokenClawback(alice.Address, bob.Address, tester.MPTAmount(1))
+		transaction.SetFlags(tx.TfUniversalMask)
+		jtx.RequireTxFail(t, env.Submit(transaction), jtx.TemDISABLED)
+	})
+
+	t.Run("InvalidFlagsPrecedeMPTokensFeatureGate", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		env.DisableFeature("MPTokensV1")
+		env.Close()
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		tester := mpt.NewMPTTesterNoFund(t, env, alice)
+		transaction := clawbacktx.NewMPTokenClawback(alice.Address, bob.Address, tester.MPTAmount(1))
+		transaction.SetFlags(tx.TfUniversalMask)
+		jtx.RequireTxFail(t, env.Submit(transaction), jtx.TemINVALID_FLAG)
+	})
+
 	t.Run("FeatureDisabled", func(t *testing.T) {
 		// Reference: rippled lines 2360-2380
 		env := jtx.NewTestEnv(t)
@@ -1562,9 +1604,17 @@ func TestMPT_Clawback(t *testing.T) {
 
 		mptAlice.Authorize(mpt.AuthorizeOpts{Account: bob})
 		mptAlice.Pay(alice, bob, 100)
+		mptAlice.RequireMPTokenAmount(bob, 100)
+		require.Equal(t, uint64(100), mptAlice.IssuanceOutstandingAmount())
 
 		mptAlice.Claw(alice, bob, 1)
+		mptAlice.RequireMPTokenAmount(bob, 99)
+		require.Equal(t, uint64(99), mptAlice.IssuanceOutstandingAmount())
 		mptAlice.Claw(alice, bob, 1000) // clawback more than balance - should take remaining
+		mptAlice.RequireMPTokenAmount(bob, 0)
+		require.Equal(t, uint64(0), mptAlice.IssuanceOutstandingAmount())
+		jtx.RequireLedgerEntryExists(t, env, keylet.MPTokenByID(mptID(t, mptAlice.IssuanceID()), bob.ID))
+		jtx.RequireOwnerCount(t, env, bob, 1)
 
 		// Now balance is zero, fails
 		mptAlice.Claw(alice, bob, 1, jtx.TecINSUFFICIENT_FUNDS)
@@ -1590,6 +1640,8 @@ func TestMPT_Clawback(t *testing.T) {
 
 		mptAlice.Set(mpt.SetOpts{Account: alice, Flags: mpt.TfMPTLock})
 		mptAlice.Claw(alice, bob, 100)
+		mptAlice.RequireMPTokenAmount(bob, 0)
+		require.Equal(t, uint64(0), mptAlice.IssuanceOutstandingAmount())
 	})
 
 	t.Run("ClawbackIndividualLocked", func(t *testing.T) {
@@ -1612,6 +1664,8 @@ func TestMPT_Clawback(t *testing.T) {
 
 		mptAlice.Set(mpt.SetOpts{Account: alice, Holder: bob, Flags: mpt.TfMPTLock})
 		mptAlice.Claw(alice, bob, 100)
+		mptAlice.RequireMPTokenAmount(bob, 0)
+		require.Equal(t, uint64(0), mptAlice.IssuanceOutstandingAmount())
 	})
 
 	t.Run("ClawbackUnauthorized", func(t *testing.T) {
@@ -1642,6 +1696,8 @@ func TestMPT_Clawback(t *testing.T) {
 
 		// alice can still clawback even though bob is unauthorized
 		mptAlice.Claw(alice, bob, 100)
+		mptAlice.RequireMPTokenAmount(bob, 0)
+		require.Equal(t, uint64(0), mptAlice.IssuanceOutstandingAmount())
 	})
 
 	t.Run("ClawbackNonexistentHolder", func(t *testing.T) {
@@ -1663,6 +1719,99 @@ func TestMPT_Clawback(t *testing.T) {
 		// carol is never funded, so her AccountRoot does not exist.
 		carol := jtx.NewAccount("carol")
 		mptAlice.Claw(alice, carol, 1, jtx.TerNO_ACCOUNT)
+	})
+
+	t.Run("MultipleIssuancesAndHoldersRemainIndependent", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		carol := jtx.NewAccount("carol")
+		dave := jtx.NewAccount("dave")
+		env.Fund(alice, bob, carol, dave)
+
+		aliceMPT := mpt.NewMPTTester(t, env, alice, mpt.MPTInit{Holders: []*jtx.Account{bob, dave}})
+		aliceMPT.Create(mpt.CreateOpts{Flags: mpt.TfMPTCanClawback})
+		aliceMPT.Authorize(mpt.AuthorizeOpts{Account: bob})
+		aliceMPT.Authorize(mpt.AuthorizeOpts{Account: dave})
+		aliceMPT.Pay(alice, bob, 100)
+		aliceMPT.Pay(alice, dave, 200)
+
+		carolMPT := mpt.NewMPTTester(t, env, carol, mpt.MPTInit{Holders: []*jtx.Account{bob}})
+		carolMPT.Create(mpt.CreateOpts{Flags: mpt.TfMPTCanClawback})
+		carolMPT.Authorize(mpt.AuthorizeOpts{Account: bob})
+		carolMPT.Pay(carol, bob, 300)
+
+		aliceMPT.Claw(alice, bob, 40)
+		aliceMPT.RequireMPTokenAmount(bob, 60)
+		aliceMPT.RequireMPTokenAmount(dave, 200)
+		require.Equal(t, uint64(260), aliceMPT.IssuanceOutstandingAmount())
+		carolMPT.RequireMPTokenAmount(bob, 300)
+		require.Equal(t, uint64(300), carolMPT.IssuanceOutstandingAmount())
+
+		carolMPT.Claw(carol, bob, 125)
+		aliceMPT.RequireMPTokenAmount(bob, 60)
+		aliceMPT.RequireMPTokenAmount(dave, 200)
+		carolMPT.RequireMPTokenAmount(bob, 175)
+		require.Equal(t, uint64(175), carolMPT.IssuanceOutstandingAmount())
+	})
+
+	t.Run("OutstandingUnderflowIsInternalAndAtomic", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		tester := mpt.NewMPTTester(t, env, alice, mpt.MPTInit{Holders: []*jtx.Account{bob}})
+		tester.Create(mpt.CreateOpts{Flags: mpt.TfMPTCanClawback})
+		tester.Authorize(mpt.AuthorizeOpts{Account: bob})
+		tester.Pay(alice, bob, 100)
+
+		issuanceKey := keylet.MPTIssuance(mptID(t, tester.IssuanceID()))
+		raw, err := env.Ledger().Read(issuanceKey)
+		require.NoError(t, err)
+		issuance, err := state.ParseMPTokenIssuance(raw)
+		require.NoError(t, err)
+		issuance.OutstandingAmount = 50
+		raw, err = state.SerializeMPTokenIssuance(issuance)
+		require.NoError(t, err)
+		require.NoError(t, env.Ledger().Update(issuanceKey, raw))
+
+		tester.Claw(alice, bob, 100, jtx.TecINTERNAL)
+		tester.RequireMPTokenAmount(bob, 100)
+		require.Equal(t, uint64(50), tester.IssuanceOutstandingAmount())
+	})
+
+	t.Run("Tickets", func(t *testing.T) {
+		env := jtx.NewTestEnv(t)
+		alice := jtx.NewAccount("alice")
+		bob := jtx.NewAccount("bob")
+		env.Fund(alice, bob)
+		tester := mpt.NewMPTTester(t, env, alice, mpt.MPTInit{Holders: []*jtx.Account{bob}})
+		tester.Create(mpt.CreateOpts{Flags: mpt.TfMPTCanClawback})
+		tester.Authorize(mpt.AuthorizeOpts{Account: bob})
+		tester.Pay(alice, bob, 100)
+		firstTicket := env.CreateTickets(alice, 10)
+		sequence := env.Seq(alice)
+		jtx.RequireOwnerCount(t, env, alice, 11)
+
+		for offset := uint32(0); offset < 10; offset++ {
+			transaction := clawbacktx.NewMPTokenClawback(alice.Address, bob.Address, tester.MPTAmount(5))
+			result := env.Submit(jtx.WithTicketSeq(transaction, firstTicket+offset))
+			jtx.RequireTxSuccess(t, result)
+		}
+		tester.RequireMPTokenAmount(bob, 50)
+		require.Equal(t, uint64(50), tester.IssuanceOutstandingAmount())
+		jtx.RequireTicketCount(t, env, alice, 0)
+		jtx.RequireOwnerCount(t, env, alice, 1)
+		jtx.RequireSequence(t, env, alice, sequence)
+
+		consumed := clawbacktx.NewMPTokenClawback(alice.Address, bob.Address, tester.MPTAmount(5))
+		jtx.RequireTxFail(t, env.Submit(jtx.WithTicketSeq(consumed, firstTicket)), "tefNO_TICKET")
+		future := clawbacktx.NewMPTokenClawback(alice.Address, bob.Address, tester.MPTAmount(5))
+		jtx.RequireTxFail(t, env.Submit(jtx.WithTicketSeq(future, sequence)), "terPRE_TICKET")
+		tester.RequireMPTokenAmount(bob, 50)
+		require.Equal(t, uint64(50), tester.IssuanceOutstandingAmount())
+		jtx.RequireOwnerCount(t, env, alice, 1)
+		jtx.RequireSequence(t, env, alice, sequence)
 	})
 }
 

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -129,6 +129,7 @@ var (
 	ErrBatchInnerSeqAndTicket     = ter.Errorf(ter.TemSEQ_AND_TICKET, "inner transaction must have exactly one of Sequence and TicketSequence")
 	ErrBatchInnerTicketAndTxnID   = ter.Errorf(ter.TemINVALID_INNER_BATCH, "inner transaction must not carry AccountTxnID when using a ticket")
 	ErrBatchInnerDupSeqOrTicket   = ter.Errorf(ter.TemREDUNDANT, "duplicate inner Sequence or TicketSequence for account")
+	ErrBatchInvalidInnerTx        = ter.Errorf(ter.TemINVALID_INNER_BATCH, "inner transaction failed validation")
 	ErrBatchInnerHashUncomputable = ter.Errorf(ter.TemINVALID, "failed to compute inner transaction hash")
 )
 
@@ -227,7 +228,7 @@ func (b *Batch) validateInnerTransactions() (map[string]struct{}, error) {
 		}
 		if inner.TxType() == tx.TypeClawback {
 			if err := tx.ValidateTransactionTemplateAllowlist(inner); err != nil {
-				return nil, ErrBatchInnerHashUncomputable
+				return nil, ErrBatchInvalidInnerTx
 			}
 		}
 
@@ -396,7 +397,7 @@ func (b *Batch) Flatten() (map[string]any, error) {
 		}
 		if rt.RawTransaction.InnerTx.TxType() == tx.TypeClawback {
 			if err := tx.ValidateTransactionTemplateAllowlist(rt.RawTransaction.InnerTx); err != nil {
-				return nil, fmt.Errorf("invalid inner transaction %d: %w", i, err)
+				return nil, ter.Errorf(ter.TemMALFORMED, "invalid inner transaction %d: %v", i, err)
 			}
 		}
 		innerMap, err := rt.RawTransaction.InnerTx.Flatten()

--- a/internal/tx/batch/batch.go
+++ b/internal/tx/batch/batch.go
@@ -225,6 +225,11 @@ func (b *Batch) validateInnerTransactions() (map[string]struct{}, error) {
 		if inner == nil {
 			return nil, ErrBatchNilInnerTx
 		}
+		if inner.TxType() == tx.TypeClawback {
+			if err := tx.ValidateTransactionTemplateAllowlist(inner); err != nil {
+				return nil, ErrBatchInnerHashUncomputable
+			}
+		}
 
 		hash, err := tx.ComputeTransactionHash(inner)
 		if err != nil {
@@ -388,6 +393,11 @@ func (b *Batch) Flatten() (map[string]any, error) {
 	for i, rt := range b.RawTransactions {
 		if rt.RawTransaction.InnerTx == nil {
 			return nil, fmt.Errorf("inner transaction %d is nil", i)
+		}
+		if rt.RawTransaction.InnerTx.TxType() == tx.TypeClawback {
+			if err := tx.ValidateTransactionTemplateAllowlist(rt.RawTransaction.InnerTx); err != nil {
+				return nil, fmt.Errorf("invalid inner transaction %d: %w", i, err)
+			}
 		}
 		innerMap, err := rt.RawTransaction.InnerTx.Flatten()
 		if err != nil {

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LeJamon/go-xrpl/amendment"
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/clawback"
 	"github.com/LeJamon/go-xrpl/internal/tx/lending"
 	"github.com/LeJamon/go-xrpl/internal/tx/payment"
 )
@@ -141,6 +142,19 @@ const (
 	testSigner1 = "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
 	testSigner2 = "rB5Ux4Lv2nRx6eeoAAsZmtctnBQ2LiACnk"
 )
+
+type clawbackWithTopLevelMPTID struct {
+	*clawback.Clawback
+}
+
+func (c *clawbackWithTopLevelMPTID) Flatten() (map[string]any, error) {
+	fields, err := c.Clawback.Flatten()
+	if err != nil {
+		return nil, err
+	}
+	fields["MPTokenIssuanceID"] = "000000000000000000000001000000000000000000000001"
+	return fields, nil
+}
 
 // Auto-incremented so successive inners hash uniquely (Batch.Validate rejects
 // duplicates per rippled Batch.cpp:253-259).
@@ -466,6 +480,17 @@ func TestBatchFlatten(t *testing.T) {
 		signers, ok := flat["BatchSigners"].([]map[string]any)
 		require.True(t, ok)
 		assert.Len(t, signers, 1)
+	})
+
+	t.Run("rejects disallowed Clawback field", func(t *testing.T) {
+		b := NewBatch(testOuter)
+		b.AddInnerTransaction(&clawbackWithTopLevelMPTID{Clawback: clawback.NewClawback(
+			testOuter,
+			tx.NewIssuedAmountFromFloat64(1, "USD", testSigner1),
+		)})
+
+		_, err := b.Flatten()
+		require.EqualError(t, err, "invalid inner transaction 0: Field 'MPTokenIssuanceID' found in disallowed location.")
 	})
 }
 

--- a/internal/tx/batch/batch_test.go
+++ b/internal/tx/batch/batch_test.go
@@ -372,6 +372,22 @@ func TestBatchValidation(t *testing.T) {
 			wantErr: true,
 			errMsg:  "inner transaction cannot be nil",
 		},
+		{
+			name: "invalid - Clawback field outside template",
+			tx: func() *Batch {
+				b := NewBatch(testOuter)
+				b.AddInnerTransaction(&clawbackWithTopLevelMPTID{Clawback: clawback.NewClawback(
+					testOuter,
+					tx.NewIssuedAmount(1, 0, "USD", testSigner1),
+				)})
+				b.AddInnerTransaction(makeTestPayment())
+				flags := BatchFlagAllOrNothing
+				b.Common.Flags = &flags
+				return b
+			}(),
+			wantErr: true,
+			errMsg:  "temINVALID_INNER_BATCH",
+		},
 
 		// Invalid cases - batch signers
 		{
@@ -486,11 +502,11 @@ func TestBatchFlatten(t *testing.T) {
 		b := NewBatch(testOuter)
 		b.AddInnerTransaction(&clawbackWithTopLevelMPTID{Clawback: clawback.NewClawback(
 			testOuter,
-			tx.NewIssuedAmountFromFloat64(1, "USD", testSigner1),
+			tx.NewIssuedAmount(1, 0, "USD", testSigner1),
 		)})
 
 		_, err := b.Flatten()
-		require.EqualError(t, err, "invalid inner transaction 0: Field 'MPTokenIssuanceID' found in disallowed location.")
+		require.EqualError(t, err, "temMALFORMED: invalid inner transaction 0: Field 'MPTokenIssuanceID' found in disallowed location.")
 	})
 }
 

--- a/internal/tx/clawback/clawback.go
+++ b/internal/tx/clawback/clawback.go
@@ -30,9 +30,6 @@ type Clawback struct {
 
 	// Holder is the MPToken holder (optional, for MPToken clawback only)
 	Holder string `json:"Holder,omitempty" xrpl:"Holder,omitempty"`
-
-	// MPTokenIssuanceID is the issuance ID for MPToken clawback (required when Holder is set)
-	MPTokenIssuanceID string `json:"MPTokenIssuanceID,omitempty" xrpl:"MPTokenIssuanceID,omitempty"`
 }
 
 // NewClawback creates a new Clawback transaction for IOU tokens
@@ -44,12 +41,11 @@ func NewClawback(account string, amount state.Amount) *Clawback {
 }
 
 // NewMPTokenClawback creates a new Clawback transaction for MPTokens
-func NewMPTokenClawback(account, holder, issuanceID string, amount state.Amount) *Clawback {
+func NewMPTokenClawback(account, holder string, amount state.Amount) *Clawback {
 	return &Clawback{
-		BaseTx:            *tx.NewBaseTx(tx.TypeClawback, account),
-		Amount:            amount,
-		Holder:            holder,
-		MPTokenIssuanceID: issuanceID,
+		BaseTx: *tx.NewBaseTx(tx.TypeClawback, account),
+		Amount: amount,
+		Holder: holder,
 	}
 }
 
@@ -147,15 +143,8 @@ func (c *Clawback) applyMPT(ctx *tx.ApplyContext) ter.Result {
 		return result
 	}
 
-	// Get the MPT issuance ID: prefer the legacy field, fall back to Amount's embedded ID
-	mptIDHex := c.MPTokenIssuanceID
-	if mptIDHex == "" {
-		mptIDHex = c.Amount.MPTIssuanceID()
-	}
-
-	// Parse MPTokenIssuanceID
 	var mptID [24]byte
-	issuanceIDBytes, err := hex.DecodeString(mptIDHex)
+	issuanceIDBytes, err := hex.DecodeString(c.Amount.MPTIssuanceID())
 	if err != nil || len(issuanceIDBytes) != 24 {
 		// If the ID is invalid/empty, the issuance won't be found
 		return ter.TecOBJECT_NOT_FOUND
@@ -209,14 +198,12 @@ func (c *Clawback) applyMPT(ctx *tx.ApplyContext) ter.Result {
 
 	// Compute actual clawback amount = min(balance, requested)
 	actual := min(requested, token.MPTAmount)
+	if issuance.OutstandingAmount < actual {
+		return ter.TecINTERNAL
+	}
 
 	token.MPTAmount -= actual
-
-	if issuance.OutstandingAmount >= actual {
-		issuance.OutstandingAmount -= actual
-	} else {
-		issuance.OutstandingAmount = 0
-	}
+	issuance.OutstandingAmount -= actual
 
 	updatedToken, err := state.SerializeMPToken(token)
 	if err != nil {

--- a/internal/tx/clawback/clawback_test.go
+++ b/internal/tx/clawback/clawback_test.go
@@ -336,6 +336,28 @@ func TestMPTokenClawbackTypedSerializationRejectsTopLevelIssuanceID(t *testing.T
 	require.EqualError(t, err, "Field 'MPTokenIssuanceID' found in disallowed location.")
 }
 
+func TestMPTokenClawbackRawHashRejectsTopLevelIssuanceID(t *testing.T) {
+	transaction := NewMPTokenClawback(
+		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"r3kmLJN5D28dHuH8vZNUZpMC43pEHpaocV",
+		newTestMPTAmount(100, "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"),
+	)
+	seq := uint32(1)
+	transaction.Sequence = &seq
+	transaction.Fee = "10"
+
+	fields, err := transaction.Flatten()
+	require.NoError(t, err)
+	tx.PopulateRequiredWireFields(fields, transaction.GetCommon())
+	fields["MPTokenIssuanceID"] = testMPTIssuanceID
+	wire, err := binarycodec.EncodeBytes(fields)
+	require.NoError(t, err)
+	transaction.SetRawBytes(wire)
+
+	_, err = tx.ComputeTransactionHash(transaction)
+	require.EqualError(t, err, "Field 'MPTokenIssuanceID' found in disallowed location.")
+}
+
 // Amendment Tests
 
 func TestClawbackRequiredAmendments(t *testing.T) {

--- a/internal/tx/clawback/clawback_test.go
+++ b/internal/tx/clawback/clawback_test.go
@@ -1,9 +1,13 @@
 package clawback
 
 import (
+	"encoding/hex"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -15,6 +19,19 @@ const testMPTIssuanceID = "000000000000000000000001000000000000000000000001"
 
 func newTestMPTAmount(value int64, issuer string) state.Amount {
 	return state.NewMPTAmountWithIssuanceID(value, issuer, testMPTIssuanceID)
+}
+
+type clawbackWithTopLevelMPTID struct {
+	*Clawback
+}
+
+func (c *clawbackWithTopLevelMPTID) Flatten() (map[string]any, error) {
+	values, err := c.Clawback.Flatten()
+	if err != nil {
+		return nil, err
+	}
+	values["MPTokenIssuanceID"] = testMPTIssuanceID
+	return values, nil
 }
 
 // preflightClawback runs Clawback's preflight body in engine order: the
@@ -223,7 +240,7 @@ func TestClawbackFlatten(t *testing.T) {
 	t.Run("MPToken clawback", func(t *testing.T) {
 		clawbackTx := &Clawback{
 			BaseTx: *tx.NewBaseTx(tx.TypeClawback, "rIssuer"),
-			Amount: tx.NewIssuedAmountFromFloat64(100.0, "MPT", "rIssuer"),
+			Amount: newTestMPTAmount(100, "rIssuer"),
 			Holder: "rHolder",
 		}
 
@@ -232,6 +249,11 @@ func TestClawbackFlatten(t *testing.T) {
 
 		assert.Equal(t, "rIssuer", flat["Account"])
 		assert.Equal(t, "rHolder", flat["Holder"])
+		assert.NotContains(t, flat, "MPTokenIssuanceID")
+		amtMap, ok := flat["Amount"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "100", amtMap["value"])
+		assert.Equal(t, testMPTIssuanceID, amtMap["mpt_issuance_id"])
 	})
 }
 
@@ -249,12 +271,69 @@ func TestClawbackConstructors(t *testing.T) {
 	})
 
 	t.Run("NewMPTokenClawback", func(t *testing.T) {
-		clawbackTx := NewMPTokenClawback("rIssuer", "rHolder", "000000000000000000000001", tx.NewIssuedAmountFromFloat64(100.0, "MPT", "rIssuer"))
+		clawbackTx := NewMPTokenClawback("rIssuer", "rHolder", newTestMPTAmount(100, "rIssuer"))
 		require.NotNil(t, clawbackTx)
 		assert.Equal(t, "rIssuer", clawbackTx.Account)
 		assert.Equal(t, "rHolder", clawbackTx.Holder)
+		assert.Equal(t, testMPTIssuanceID, clawbackTx.Amount.MPTIssuanceID())
 		assert.Equal(t, tx.TypeClawback, clawbackTx.TxType())
 	})
+}
+
+func TestMPTokenClawbackWireGolden(t *testing.T) {
+	clawbackTx := NewMPTokenClawback(
+		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"r3kmLJN5D28dHuH8vZNUZpMC43pEHpaocV",
+		newTestMPTAmount(100, "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"),
+	)
+	seq := uint32(1)
+	clawbackTx.Sequence = &seq
+	clawbackTx.Fee = "10"
+
+	jsonBytes, err := json.Marshal(clawbackTx)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"Account":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"Amount":{"value":"100","mpt_issuance_id":"000000000000000000000001000000000000000000000001"},
+		"Fee":"10",
+		"Holder":"r3kmLJN5D28dHuH8vZNUZpMC43pEHpaocV",
+		"Sequence":1,
+		"TransactionType":"Clawback"
+	}`, string(jsonBytes))
+	assert.NotContains(t, string(jsonBytes), "MPTokenIssuanceID")
+
+	wire, err := tx.SerializeTransaction(clawbackTx)
+	require.NoError(t, err)
+	assert.Equal(t,
+		"12001E24000000016160000000000000006400000000000000000000000100000000000000000000000168400000000000000A73008114B5F762798A53D543A014CAF8B297CFF8F2F937E88B14550FC62003E785DC231A1058A05E56E3F09CF4E6",
+		strings.ToUpper(hex.EncodeToString(wire)),
+	)
+	hash, err := tx.ComputeTransactionHash(clawbackTx)
+	require.NoError(t, err)
+	assert.Equal(t, "5C251B4B59260C9A86355912E7767860BAFF08E6E9FD93202B305202A4ECE3A1", strings.ToUpper(hex.EncodeToString(hash[:])))
+
+	_, err = tx.ParseFromBinary(wire)
+	require.NoError(t, err)
+	flat, err := binarycodec.DecodeBytes(wire)
+	require.NoError(t, err)
+	assert.NotContains(t, flat, "MPTokenIssuanceID")
+	amountJSON, err := json.Marshal(flat["Amount"])
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"value":"100","mpt_issuance_id":"000000000000000000000001000000000000000000000001"}`, string(amountJSON))
+}
+
+func TestMPTokenClawbackTypedSerializationRejectsTopLevelIssuanceID(t *testing.T) {
+	transaction := &clawbackWithTopLevelMPTID{Clawback: NewMPTokenClawback(
+		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"r3kmLJN5D28dHuH8vZNUZpMC43pEHpaocV",
+		newTestMPTAmount(100, "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"),
+	)}
+	seq := uint32(1)
+	transaction.Sequence = &seq
+	transaction.Fee = "10"
+
+	_, err := tx.SerializeTransaction(transaction)
+	require.EqualError(t, err, "Field 'MPTokenIssuanceID' found in disallowed location.")
 }
 
 // Amendment Tests
@@ -268,7 +347,7 @@ func TestClawbackRequiredAmendments(t *testing.T) {
 	})
 
 	t.Run("MPToken clawback gates on Clawback only; MPTokensV1 is a preflight-arm gate", func(t *testing.T) {
-		clawbackTx := NewMPTokenClawback("rIssuer", "rHolder", testMPTIssuanceID, newTestMPTAmount(100, "rIssuer"))
+		clawbackTx := NewMPTokenClawback("rIssuer", "rHolder", newTestMPTAmount(100, "rIssuer"))
 		amendments := clawbackTx.RequiredAmendments()
 		assert.Equal(t, [][32]byte{amendment.FeatureClawback}, amendments)
 		// MPTokensV1 is enforced inside the MPT preflight arm (temDISABLED), not

--- a/internal/tx/engine/preflight.go
+++ b/internal/tx/engine/preflight.go
@@ -95,6 +95,11 @@ func (e *Engine) preflight(tx txcore.Transaction) (result ter.Result) {
 // Reference: rippled Transactor.h Transactor::invokePreflight<T>.
 func (e *Engine) preflightStructure(tx txcore.Transaction, common *txcore.Common) ter.Result {
 	rules := e.rules()
+	if tx.TxType() == txcore.TypeClawback {
+		if err := txcore.ValidateTransactionTemplateAllowlist(tx); err != nil {
+			return ter.TemMALFORMED
+		}
+	}
 
 	// The transactions.macro amendment gate (rippled Permission::getTxFeature →
 	// temDISABLED) is the FIRST check, before checkExtraFeatures and preflight1,

--- a/internal/tx/engine_config.go
+++ b/internal/tx/engine_config.go
@@ -273,6 +273,15 @@ func ComputeTransactionHash(tx Transaction) ([32]byte, error) {
 // transaction ID and transaction-map leaf.
 func SerializeTransaction(tx Transaction) ([]byte, error) {
 	if rawBytes := tx.GetRawBytes(); len(rawBytes) > 0 {
+		if tx.TxType() == TypeClawback {
+			decoded, err := binarycodec.DecodeBytes(rawBytes)
+			if err != nil {
+				return nil, err
+			}
+			if err := ValidateTemplateFields(tx.TxType(), decoded); err != nil {
+				return nil, err
+			}
+		}
 		return append([]byte(nil), rawBytes...), nil
 	}
 	txMap, err := tx.Flatten()
@@ -280,6 +289,11 @@ func SerializeTransaction(tx Transaction) ([]byte, error) {
 		return nil, err
 	}
 	PopulateRequiredWireFields(txMap, tx.GetCommon())
+	if tx.TxType() == TypeClawback {
+		if err := ValidateTemplateFields(tx.TxType(), txMap); err != nil {
+			return nil, err
+		}
+	}
 	hexStr, err := binarycodec.Encode(txMap)
 	if err != nil {
 		return nil, err

--- a/internal/tx/engine_config.go
+++ b/internal/tx/engine_config.go
@@ -324,6 +324,15 @@ func computeTransactionHash(tx Transaction) ([32]byte, error) {
 		if c != nil && c.txIDCached {
 			return c.cachedTxID, nil
 		}
+		if tx.TxType() == TypeClawback {
+			fields, err := binarycodec.DecodeBytes(rawBytes)
+			if err != nil {
+				return [32]byte{}, err
+			}
+			if err := ValidateTemplateFields(TypeClawback, fields); err != nil {
+				return [32]byte{}, err
+			}
+		}
 		hash := hashWithTxnPrefix(rawBytes)
 		if c != nil {
 			c.cachedTxID = hash

--- a/internal/tx/registry.go
+++ b/internal/tx/registry.go
@@ -53,6 +53,15 @@ func FromJSON(data []byte) (Transaction, error) {
 	if !ok {
 		return nil, ErrUnknownTransactionType
 	}
+	presentFields, err := jsonPresentFields(data)
+	if err != nil {
+		return nil, err
+	}
+	if txType == TypeClawback {
+		if err := checkTemplate(txType, presentFields); err != nil {
+			return nil, err
+		}
+	}
 
 	tx, err := NewFromType(txType)
 	if err != nil {
@@ -60,10 +69,6 @@ func FromJSON(data []byte) (Transaction, error) {
 	}
 
 	if err := json.Unmarshal(data, tx); err != nil {
-		return nil, err
-	}
-	presentFields, err := jsonPresentFields(data)
-	if err != nil {
 		return nil, err
 	}
 	tx.GetCommon().SetPresentFields(presentFields)

--- a/internal/tx/sign/clawback_mpt_golden_test.go
+++ b/internal/tx/sign/clawback_mpt_golden_test.go
@@ -1,0 +1,76 @@
+package sign
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/clawback"
+)
+
+type clawbackWithTopLevelMPTID struct {
+	*clawback.Clawback
+}
+
+func (c *clawbackWithTopLevelMPTID) Flatten() (map[string]any, error) {
+	values, err := c.Clawback.Flatten()
+	if err != nil {
+		return nil, err
+	}
+	values["MPTokenIssuanceID"] = "000000000000000000000001000000000000000000000001"
+	return values, nil
+}
+
+func TestMPTokenClawbackSigningPayloadGolden(t *testing.T) {
+	amount := state.NewMPTAmountWithIssuanceID(
+		100,
+		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"000000000000000000000001000000000000000000000001",
+	)
+	transaction := clawback.NewMPTokenClawback(
+		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"r3kmLJN5D28dHuH8vZNUZpMC43pEHpaocV",
+		amount,
+	)
+	seq := uint32(1)
+	transaction.Sequence = &seq
+	transaction.Fee = "10"
+
+	payload, err := getSigningPayload(transaction)
+	if err != nil {
+		t.Fatalf("getSigningPayload: %v", err)
+	}
+	want := "5354580012001E24000000016160000000000000006400000000000000000000000100000000000000000000000168400000000000000A73008114B5F762798A53D543A014CAF8B297CFF8F2F937E88B14550FC62003E785DC231A1058A05E56E3F09CF4E6"
+	if payload != want {
+		t.Fatalf("signing payload = %s, want %s", payload, want)
+	}
+
+	flat, err := transaction.Flatten()
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	txcore.PopulateRequiredWireFields(flat, transaction.GetCommon())
+	if err := txcore.ValidateTemplateFields(txcore.TypeClawback, flat); err != nil {
+		t.Fatalf("ValidateTemplateFields: %v", err)
+	}
+}
+
+func TestMPTokenClawbackSigningRejectsTopLevelIssuanceID(t *testing.T) {
+	transaction := &clawbackWithTopLevelMPTID{Clawback: clawback.NewMPTokenClawback(
+		"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"r3kmLJN5D28dHuH8vZNUZpMC43pEHpaocV",
+		state.NewMPTAmountWithIssuanceID(
+			100,
+			"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"000000000000000000000001000000000000000000000001",
+		),
+	)}
+	seq := uint32(1)
+	transaction.Sequence = &seq
+	transaction.Fee = "10"
+
+	_, err := getSigningPayload(transaction)
+	if err == nil || err.Error() != "Field 'MPTokenIssuanceID' found in disallowed location." {
+		t.Fatalf("getSigningPayload error = %v", err)
+	}
+}

--- a/internal/tx/sign/signature.go
+++ b/internal/tx/sign/signature.go
@@ -477,13 +477,27 @@ func copyMap(m map[string]any) map[string]any {
 
 func flattenForSigning(tx txcore.Transaction) (map[string]any, error) {
 	if raw := tx.GetRawBytes(); len(raw) > 0 {
-		return binarycodec.DecodeBytes(raw)
+		txMap, err := binarycodec.DecodeBytes(raw)
+		if err != nil {
+			return nil, err
+		}
+		if tx.TxType() == txcore.TypeClawback {
+			if err := txcore.ValidateTemplateFields(tx.TxType(), txMap); err != nil {
+				return nil, err
+			}
+		}
+		return txMap, nil
 	}
 	txMap, err := tx.Flatten()
 	if err != nil {
 		return nil, err
 	}
 	txcore.PopulateRequiredWireFields(txMap, tx.GetCommon())
+	if tx.TxType() == txcore.TypeClawback {
+		if err := txcore.ValidateTemplateFields(tx.TxType(), txMap); err != nil {
+			return nil, err
+		}
+	}
 	return txMap, nil
 }
 

--- a/internal/tx/template.go
+++ b/internal/tx/template.go
@@ -647,6 +647,20 @@ func ValidateTemplateFields(txType Type, values map[string]any) error {
 	return validateTemplateAllowlist(txType, fields)
 }
 
+// ValidateTransactionTemplateAllowlist rejects fields that are not legal for
+// the concrete transaction type without requiring submission-layer defaults.
+func ValidateTransactionTemplateAllowlist(transaction Transaction) error {
+	values, err := transaction.Flatten()
+	if err != nil {
+		return err
+	}
+	fields := make(map[string]bool, len(values))
+	for name := range values {
+		fields[name] = true
+	}
+	return validateTemplateAllowlist(transaction.TxType(), fields)
+}
+
 func isExplicitDefault(value any) bool {
 	if value == nil {
 		return true

--- a/internal/tx/template_test.go
+++ b/internal/tx/template_test.go
@@ -110,6 +110,26 @@ func TestParseFromBinary_DisallowedField(t *testing.T) {
 	}
 }
 
+func TestParseJSON_ClawbackDisallowedField(t *testing.T) {
+	_, err := ParseJSON([]byte(`{
+		"TransactionType":"Clawback",
+		"Account":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"Amount":{"value":"100","mpt_issuance_id":"000000000000000000000001000000000000000000000001"},
+		"Holder":"rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+		"MPTokenIssuanceID":"000000000000000000000001000000000000000000000001"
+	}`))
+	if err == nil {
+		t.Fatal("expected JSON parse to reject Clawback carrying MPTokenIssuanceID")
+	}
+	re, ok := ter.AsResultError(err)
+	if !ok {
+		t.Fatalf("expected a ResultError, got %T: %v", err, err)
+	}
+	if re.Code != ter.TemMALFORMED {
+		t.Fatalf("expected TemMALFORMED, got %v: %v", re.Code, err)
+	}
+}
+
 func TestParseFromBinary_MissingRequiredField(t *testing.T) {
 	fields := baseCommon("Payment")
 	fields["Amount"] = "1000000"

--- a/internal/tx/template_test.go
+++ b/internal/tx/template_test.go
@@ -80,6 +80,12 @@ func TestParseFromBinary_DisallowedField(t *testing.T) {
 			disallowedKey: "Destination",
 			disallowedVal: testDestination,
 		},
+		{
+			name:          "Clawback carrying top-level MPTokenIssuanceID",
+			txType:        "Clawback",
+			disallowedKey: "MPTokenIssuanceID",
+			disallowedVal: "000000000000000000000001000000000000000000000001",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

- remove the invalid top-level `MPTokenIssuanceID` from Clawback and derive the MPT issuance exclusively from `Amount`
- enforce the Clawback transaction template for typed submission, serialization, signing, and raw canonical paths
- align impossible MPT outstanding-supply underflow with rippled's `tecINTERNAL` behavior
- make Clawback test builders exact and fee-neutral, and expand MPT/IOU coverage for wire goldens, state isolation, locks/auth, clamp, persistence, directory cleanup, rollback, and tickets

## Test plan

- `go test -count=10 ./internal/tx/clawback ./internal/tx/sign ./internal/testing/clawback ./internal/testing/mpt`
- `go test -race ./internal/tx/clawback ./internal/tx/sign ./internal/testing/clawback ./internal/testing/mpt`
- `just test`
- `just vet`
- `just lint`
- `just build`

Fixes #1501


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MPToken clawback handling by associating issuance details with the clawback amount.
  - Transactions with unsupported or misplaced fields are now rejected as malformed before signing, serialization, batching, or submission.
  - Invalid clawbacks can no longer reduce outstanding issuance amounts below zero.
  - Added rollback protection for corrupted owner-directory data.

- **Enhancements**
  - Added support for ticket-based clawbacks, including ticket consumption and validation.
  - Expanded validation for balances, trust lines, ownership counts, flags, and multiple issuances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->