### PR TITLE
fix: establish RPC handler foundations (#1486)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,10 @@ type Config struct {
 	// 9. Misc Settings
 	NodeSize   string `toml:"node_size" mapstructure:"node_size"` // optional; "" = default ("medium")
 	BetaRPCAPI int    `toml:"beta_rpc_api" mapstructure:"beta_rpc_api"`
+	// PathSearchMax is a pointer so an explicit zero remains distinct from
+	// the absent default.
+	PathSearchMax  *int `toml:"path_search_max" mapstructure:"path_search_max"`
+	SigningSupport bool `toml:"signing_support" mapstructure:"signing_support"`
 
 	// WebsocketPingFrequency is the keepalive ping cadence in seconds for
 	// WebSocket clients. 0 = use the built-in default (30 seconds).
@@ -168,6 +172,20 @@ func (c *Config) GetFetchDepthUint32() uint32 {
 // IsValidator returns true if this node is configured as a validator
 func (c *Config) IsValidator() bool {
 	return c.ValidationSeed != "" || c.ValidatorToken != ""
+}
+
+const defaultPathSearchMax = 3
+
+// ResolvedPathSearchMax returns the startup path-search limit. Validators
+// disable pathfinding unless the operator explicitly configures a limit.
+func (c *Config) ResolvedPathSearchMax() int {
+	if c.PathSearchMax != nil {
+		return *c.PathSearchMax
+	}
+	if c.IsValidator() {
+		return 0
+	}
+	return defaultPathSearchMax
 }
 
 // PeerPort returns the port configured for peer protocol

--- a/config/misc.go
+++ b/config/misc.go
@@ -71,6 +71,14 @@ func ValidateBetaRPCAPI(betaAPI int) error {
 	return validateZeroOrOne("beta_rpc_api", betaAPI)
 }
 
+// ValidatePathSearchMax validates the maximum path-search level.
+func ValidatePathSearchMax(pathSearchMax *int) error {
+	if pathSearchMax == nil {
+		return nil
+	}
+	return validateNonNegative("path_search_max", *pathSearchMax)
+}
+
 // ValidateWebsocketPingFrequency validates the websocket ping frequency
 func ValidateWebsocketPingFrequency(frequency int) error {
 	return validateNonNegative("websocket_ping_frequency", frequency)

--- a/config/rpc_capabilities_test.go
+++ b/config/rpc_capabilities_test.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRPCCapabilityConfigLoad(t *testing.T) {
+	tests := []struct {
+		name        string
+		settings    string
+		wantSigning bool
+		wantPathMax int
+		wantPathSet bool
+	}{
+		{name: "defaults", wantPathMax: 3},
+		{name: "signing enabled", settings: "signing_support = true\n", wantSigning: true, wantPathMax: 3},
+		{name: "explicit zero", settings: "path_search_max = 0\n", wantPathSet: true},
+		{name: "explicit limit", settings: "path_search_max = 7\n", wantPathMax: 7, wantPathSet: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := writeConfig(t, t.TempDir(), "xrpld.toml", test.settings+minimalTestConfig())
+			cfg, err := LoadConfig(Paths{Main: path, SkipValidators: true})
+			require.NoError(t, err)
+			require.Equal(t, test.wantSigning, cfg.SigningSupport)
+			require.Equal(t, test.wantPathMax, cfg.ResolvedPathSearchMax())
+			if test.wantPathSet {
+				require.NotNil(t, cfg.PathSearchMax)
+			} else {
+				require.Nil(t, cfg.PathSearchMax)
+			}
+		})
+	}
+}
+
+func TestResolvedPathSearchMaxValidatorDefault(t *testing.T) {
+	explicit := 5
+	tests := []struct {
+		name string
+		cfg  Config
+		want int
+	}{
+		{name: "non-validator", cfg: Config{}, want: 3},
+		{name: "validation seed", cfg: Config{ValidationSeed: "seed"}, want: 0},
+		{name: "validator token", cfg: Config{ValidatorToken: "token"}, want: 0},
+		{name: "validator explicit override", cfg: Config{ValidationSeed: "seed", PathSearchMax: &explicit}, want: 5},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, test.cfg.ResolvedPathSearchMax())
+		})
+	}
+}
+
+func TestPathSearchMaxRejectsNegative(t *testing.T) {
+	path := writeConfig(t, t.TempDir(), "xrpld.toml", "path_search_max = -1\n"+minimalTestConfig())
+	_, err := LoadConfig(Paths{Main: path, SkipValidators: true})
+	require.ErrorContains(t, err, "path_search_max must be non-negative")
+}

--- a/config/validation.go
+++ b/config/validation.go
@@ -225,6 +225,9 @@ func validateMiscSettings(config *Config) []error {
 	if err := ValidateBetaRPCAPI(config.BetaRPCAPI); err != nil {
 		errs = append(errs, err)
 	}
+	if err := ValidatePathSearchMax(config.PathSearchMax); err != nil {
+		errs = append(errs, err)
+	}
 	if err := ValidateWebsocketPingFrequency(config.WebsocketPingFrequency); err != nil {
 		errs = append(errs, err)
 	}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -87,6 +87,27 @@ func serverInfoConfigSnapshot(cfg *config.Config) types.ServerInfoConfigSnapshot
 	}
 }
 
+func rpcCapabilities(cfg *config.Config) types.RPCCapabilities {
+	if cfg == nil {
+		return types.RPCCapabilities{}
+	}
+	return types.RPCCapabilities{
+		SigningEnabled: cfg.SigningSupport,
+		PathSearchMax:  cfg.ResolvedPathSearchMax(),
+	}
+}
+
+func newRPCServiceContainer(ledger types.LedgerService, cfg *config.Config) *types.ServiceContainer {
+	services := types.NewServiceContainer(ledger)
+	services.ClientLoad = types.NewClientLoadShedder()
+	services.ServerInfoConfig = serverInfoConfigSnapshot(cfg)
+	services.Capabilities = rpcCapabilities(cfg)
+	if cfg != nil {
+		services.BetaRPCAPI = cfg.BetaRPCAPI != 0
+	}
+	return services
+}
+
 func goBuildRevision() string {
 	info, ok := debug.ReadBuildInfo()
 	return resolveBuildRevision(info, ok, version.Version)

--- a/internal/node/rpc_capabilities_test.go
+++ b/internal/node/rpc_capabilities_test.go
@@ -1,0 +1,34 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRPCServiceContainerFreezesCapabilities(t *testing.T) {
+	pathMax := 0
+	cfg := &config.Config{
+		SigningSupport: true,
+		PathSearchMax:  &pathMax,
+		BetaRPCAPI:     1,
+	}
+
+	services := newRPCServiceContainer(nil, cfg)
+	require.True(t, services.Capabilities.SigningEnabled)
+	require.Zero(t, services.Capabilities.PathSearchMax)
+	require.True(t, services.BetaRPCAPI)
+	require.NotNil(t, services.ClientLoad)
+
+	cfg.SigningSupport = false
+	pathMax = 9
+	require.True(t, services.Capabilities.SigningEnabled)
+	require.Zero(t, services.Capabilities.PathSearchMax)
+}
+
+func TestRPCCapabilitiesDefaults(t *testing.T) {
+	services := newRPCServiceContainer(nil, &config.Config{})
+	require.False(t, services.Capabilities.SigningEnabled)
+	require.Equal(t, 3, services.Capabilities.PathSearchMax)
+}

--- a/internal/node/runtime.go
+++ b/internal/node/runtime.go
@@ -251,13 +251,7 @@ func (r *nodeRuntime) configureMaintenance() error {
 	r.stopSampler = sampler.Stop
 
 	r.ledgerAdapter = rpcadapter.NewLedgerServiceAdapter(r.ledger)
-	r.services = types.NewServiceContainer(r.ledgerAdapter)
-	r.services.ClientLoad = types.NewClientLoadShedder()
-	r.services.ServerInfoConfig = serverInfoConfigSnapshot(r.appConfig)
-
-	// Gate the beta RPC API (api_version 3) on the operator's beta_rpc_api
-	// knob, mirroring rippled Config::BETA_RPC_API.
-	r.services.BetaRPCAPI = r.appConfig.BetaRPCAPI != 0
+	r.services = newRPCServiceContainer(r.ledgerAdapter, r.appConfig)
 
 	// Advisory-delete state (can_delete RPC). Available in both standalone and
 	// consensus modes; gated by node_db advisory_delete and persisted under
@@ -425,6 +419,10 @@ func (r *nodeRuntime) configureMaintenance() error {
 	r.services.IsLoadedCluster = func() bool {
 		ft := ledgerSvcRef.FeeTrack()
 		return ft != nil && ft.IsLoadedCluster()
+	}
+	r.services.IsLoadedLocal = func() bool {
+		ft := ledgerSvcRef.FeeTrack()
+		return ft != nil && ft.IsLoadedLocal()
 	}
 
 	// Background ledger-integrity verification requires the same durable SHAMap

--- a/internal/rpc/handlers/feature.go
+++ b/internal/rpc/handlers/feature.go
@@ -30,11 +30,11 @@ type amendmentVoteController interface {
 
 func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	var request struct {
-		Feature string `json:"feature,omitempty"`
-		Vetoed  *bool  `json:"vetoed,omitempty"`
+		Feature requestField[string] `json:"feature"`
+		Vetoed  jsonCppBoolField     `json:"vetoed"`
 	}
-	if params != nil {
-		_ = json.Unmarshal(params, &request)
+	if rpcErr := decodeRequestObject(params, &request); rpcErr != nil {
+		return nil, rpcErr
 	}
 
 	enabledSet, majorities := m.getAmendmentState(ctx.Services)
@@ -48,22 +48,32 @@ func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		lastVote = tbl.LastVote()
 	}
 
+	if !request.Feature.present {
+		allFeatures := amendment.AllFeatures()
+		features := make(map[string]any, len(allFeatures))
+		for _, f := range allFeatures {
+			hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
+			features[hexID] = buildFeatureInfo(f, enabledSet, majorities, tbl, lastVote, ctx.IsAdmin)
+		}
+		return map[string]any{
+			"features": features,
+		}, nil
+	}
+
+	f := resolveFeature(request.Feature.value)
+	if f == nil {
+		return nil, types.RpcErrorBadFeature("Feature not found: " + request.Feature.value)
+	}
+
 	// Admin vote mutation: set or clear a veto on a specific amendment.
-	if request.Vetoed != nil {
+	if request.Vetoed.present {
 		if !ctx.IsAdmin {
 			return nil, types.RpcErrorNoPermission("feature")
-		}
-		if request.Feature == "" {
-			return nil, types.RpcErrorInvalidParams("feature required to set a vote")
-		}
-		f := resolveFeature(request.Feature)
-		if f == nil {
-			return nil, types.RpcErrorBadFeature("Feature not found: " + request.Feature)
 		}
 		if ctrl == nil || tbl == nil {
 			return nil, types.RpcErrorNotSupported("amendment voting is not available on this server")
 		}
-		if err := ctrl.SetAmendmentVote(ctx.Context, f.ID, *request.Vetoed); err != nil {
+		if err := ctrl.SetAmendmentVote(ctx.Context, f.ID, request.Vetoed.value); err != nil {
 			return nil, rpcInternalError("feature: recording amendment vote failed", err)
 		}
 		hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
@@ -72,27 +82,9 @@ func (m *FeatureMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 		}, nil
 	}
 
-	// Single feature lookup.
-	if request.Feature != "" {
-		f := resolveFeature(request.Feature)
-		if f == nil {
-			return nil, types.RpcErrorBadFeature("Feature not found: " + request.Feature)
-		}
-		hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
-		return map[string]any{
-			hexID: buildFeatureInfo(f, enabledSet, majorities, tbl, lastVote, ctx.IsAdmin),
-		}, nil
-	}
-
-	// All features wrapped in "features" (matches rippled).
-	allFeatures := amendment.AllFeatures()
-	features := make(map[string]any, len(allFeatures))
-	for _, f := range allFeatures {
-		hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
-		features[hexID] = buildFeatureInfo(f, enabledSet, majorities, tbl, lastVote, ctx.IsAdmin)
-	}
+	hexID := strings.ToUpper(hex.EncodeToString(f.ID[:]))
 	return map[string]any{
-		"features": features,
+		hexID: buildFeatureInfo(f, enabledSet, majorities, tbl, lastVote, ctx.IsAdmin),
 	}, nil
 }
 

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -180,6 +180,69 @@ func ParseParams(params json.RawMessage, dest any) *types.RpcError {
 	return nil
 }
 
+type requestField[T any] struct {
+	value   T
+	present bool
+}
+
+func (f *requestField[T]) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return errors.New("null request field")
+	}
+	if err := json.Unmarshal(data, &f.value); err != nil {
+		return err
+	}
+	f.present = true
+	return nil
+}
+
+type jsonCppBoolField struct {
+	value   bool
+	present bool
+}
+
+func (f *jsonCppBoolField) UnmarshalJSON(data []byte) error {
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	f.value = jsonCppBoolRaw(data)
+	f.present = true
+	return nil
+}
+
+type jsonCppStringField struct {
+	value   string
+	present bool
+}
+
+func (f *jsonCppStringField) UnmarshalJSON(data []byte) error {
+	value, ok := jsonCppStringRaw(data)
+	if !ok {
+		return errors.New("request field is not string-convertible")
+	}
+	f.value = value
+	f.present = true
+	return nil
+}
+
+func decodeRequestObject(params json.RawMessage, dest any) *types.RpcError {
+	if len(params) == 0 {
+		params = json.RawMessage(`{}`)
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(params, &object); err != nil || object == nil {
+		return types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	if rpcErr := validateJsonCppIntegerRange(params); rpcErr != nil {
+		return rpcErr
+	}
+	if err := json.Unmarshal(params, dest); err != nil {
+		return types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	return nil
+}
+
 func parseLedgerSpecifier(params json.RawMessage) (types.LedgerSpecifier, bool, *types.RpcError) {
 	if rpcErr := validateJsonCppIntegerRange(params); rpcErr != nil {
 		return types.LedgerSpecifier{}, false, rpcErr

--- a/internal/rpc/handlers/request_object_test.go
+++ b/internal/rpc/handlers/request_object_test.go
@@ -1,0 +1,242 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	xrpllog "github.com/LeJamon/go-xrpl/log"
+	"github.com/stretchr/testify/require"
+)
+
+type requestRejectAdvisory struct {
+	setCalls int
+	getCalls int
+}
+
+type requestRejectAmendmentController struct {
+	types.LedgerService
+	table    *amendment.Table
+	setCalls int
+}
+
+func (c *requestRejectAmendmentController) Table() *amendment.Table { return c.table }
+func (c *requestRejectAmendmentController) SetAmendmentVote(context.Context, [32]byte, bool) error {
+	c.setCalls++
+	return nil
+}
+func (*requestRejectAmendmentController) GetClosedLedgerView() (types.LedgerStateView, error) {
+	return nil, nil
+}
+
+func (*requestRejectAdvisory) AdvisoryDelete() bool   { return true }
+func (*requestRejectAdvisory) GetLastRotated() uint32 { return 0 }
+func (s *requestRejectAdvisory) GetCanDelete() uint32 {
+	s.getCalls++
+	return 0
+}
+func (s *requestRejectAdvisory) SetCanDelete(uint32) (uint32, error) {
+	s.setCalls++
+	return 0, nil
+}
+
+func TestStrictRequestObjects(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler types.MethodHandler
+		params  json.RawMessage
+	}{
+		{name: "feature malformed", handler: &FeatureMethod{}, params: json.RawMessage(`{"feature":`)},
+		{name: "feature array", handler: &FeatureMethod{}, params: json.RawMessage(`[]`)},
+		{name: "feature wrong field", handler: &FeatureMethod{}, params: json.RawMessage(`{"feature":1}`)},
+		{name: "fetch info malformed", handler: &FetchInfoMethod{}, params: json.RawMessage(`{"clear":`)},
+		{name: "fetch info null", handler: &FetchInfoMethod{}, params: json.RawMessage(`null`)},
+		{name: "log level malformed", handler: &LogLevelMethod{}, params: json.RawMessage(`{"severity":`)},
+		{name: "log level scalar", handler: &LogLevelMethod{}, params: json.RawMessage(`7`)},
+		{name: "log level object field", handler: &LogLevelMethod{}, params: json.RawMessage(`{"severity":{}}`)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := &types.RpcContext{Context: context.Background(), IsAdmin: true}
+			result, rpcErr := test.handler.Handle(ctx, test.params)
+			require.Nil(t, result)
+			require.NotNil(t, rpcErr)
+			require.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+			require.Equal(t, "invalidParams", rpcErr.ErrorString)
+			require.Equal(t, "Invalid parameters.", rpcErr.Message)
+		})
+	}
+}
+
+func TestDecodeRejectionDoesNotInvokeCallbacks(t *testing.T) {
+	controller := &requestRejectAmendmentController{table: amendment.NewTable()}
+	_, rpcErr := (&FeatureMethod{}).Handle(
+		&types.RpcContext{Context: context.Background(), IsAdmin: true, Services: &types.ServiceContainer{Ledger: controller}},
+		json.RawMessage(`{"feature":1,"vetoed":true}`),
+	)
+	require.NotNil(t, rpcErr)
+	require.Zero(t, controller.setCalls)
+
+	clearCalls := 0
+	fetchCalls := 0
+	services := &types.ServiceContainer{
+		FetchInfoClear: func() { clearCalls++ },
+		FetchInfo: func() map[string]any {
+			fetchCalls++
+			return nil
+		},
+	}
+	_, rpcErr = (&FetchInfoMethod{}).Handle(
+		&types.RpcContext{Services: services},
+		json.RawMessage(`{"clear":true`),
+	)
+	require.NotNil(t, rpcErr)
+	require.Zero(t, clearCalls)
+	require.Zero(t, fetchCalls)
+
+	store := &requestRejectAdvisory{}
+	_, rpcErr = (&CanDeleteMethod{}).Handle(
+		&types.RpcContext{Context: context.Background(), Services: &types.ServiceContainer{AdvisoryDeleteState: store}},
+		json.RawMessage(`{"can_delete":true}`),
+	)
+	require.NotNil(t, rpcErr)
+	require.Zero(t, store.getCalls)
+	require.Zero(t, store.setCalls)
+}
+
+func TestRequestObjectJsonCppCoercions(t *testing.T) {
+	clearCalls := 0
+	services := &types.ServiceContainer{
+		FetchInfoClear: func() { clearCalls++ },
+		FetchInfo:      func() map[string]any { return nil },
+	}
+	result, rpcErr := (&FetchInfoMethod{}).Handle(
+		&types.RpcContext{Services: services},
+		json.RawMessage(`{"clear":"true"}`),
+	)
+	require.Nil(t, rpcErr)
+	require.Equal(t, 1, clearCalls)
+	require.Equal(t, true, result.(map[string]any)["clear"])
+
+	controller := &requestRejectAmendmentController{table: amendment.NewTable()}
+	_, rpcErr = (&FeatureMethod{}).Handle(
+		&types.RpcContext{Context: context.Background(), IsAdmin: true, Services: &types.ServiceContainer{Ledger: controller}},
+		json.RawMessage(`{"feature":"fixMasterKeyAsRegularKey","vetoed":"true"}`),
+	)
+	require.Nil(t, rpcErr)
+	require.Equal(t, 1, controller.setCalls)
+
+	controller = &requestRejectAmendmentController{table: amendment.NewTable()}
+	result, rpcErr = (&FeatureMethod{}).Handle(
+		&types.RpcContext{Context: context.Background(), IsAdmin: true, Services: &types.ServiceContainer{Ledger: controller}},
+		json.RawMessage(`{"vetoed":true}`),
+	)
+	require.Nil(t, rpcErr)
+	require.Zero(t, controller.setCalls)
+	require.Contains(t, result.(map[string]any), "features")
+}
+
+func TestJsonCppRequestFields(t *testing.T) {
+	boolTests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "null", raw: `null`},
+		{name: "zero", raw: `0`},
+		{name: "number", raw: `2`, want: true},
+		{name: "empty string", raw: `""`},
+		{name: "string", raw: `"false"`, want: true},
+		{name: "empty array", raw: `[]`},
+		{name: "array", raw: `[0]`, want: true},
+		{name: "object", raw: `{"value":false}`, want: true},
+	}
+	for _, test := range boolTests {
+		t.Run("bool "+test.name, func(t *testing.T) {
+			var field jsonCppBoolField
+			require.NoError(t, json.Unmarshal([]byte(test.raw), &field))
+			require.True(t, field.present)
+			require.Equal(t, test.want, field.value)
+		})
+	}
+
+	stringTests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "null", raw: `null`},
+		{name: "boolean", raw: `true`, want: "true"},
+		{name: "integer", raw: `12`, want: "12"},
+		{name: "string", raw: `"debug"`, want: "debug"},
+	}
+	for _, test := range stringTests {
+		t.Run("string "+test.name, func(t *testing.T) {
+			var field jsonCppStringField
+			require.NoError(t, json.Unmarshal([]byte(test.raw), &field))
+			require.True(t, field.present)
+			require.Equal(t, test.want, field.value)
+		})
+	}
+
+	var field jsonCppStringField
+	require.Error(t, json.Unmarshal([]byte(`{}`), &field))
+}
+
+func TestCanDeleteNotEnabledPrecedesDecode(t *testing.T) {
+	_, rpcErr := (&CanDeleteMethod{}).Handle(
+		&types.RpcContext{Services: &types.ServiceContainer{}},
+		json.RawMessage(`{"can_delete":`),
+	)
+	require.NotNil(t, rpcErr)
+	require.Equal(t, types.RpcNOT_ENABLED, rpcErr.Code)
+}
+
+func TestCanDeleteStrictRequestObjects(t *testing.T) {
+	tests := []struct {
+		name   string
+		params json.RawMessage
+	}{
+		{name: "malformed", params: json.RawMessage(`{"can_delete":`)},
+		{name: "array", params: json.RawMessage(`[]`)},
+		{name: "wrong field", params: json.RawMessage(`{"can_delete":true}`)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := &requestRejectAdvisory{}
+			_, rpcErr := (&CanDeleteMethod{}).Handle(
+				&types.RpcContext{Context: context.Background(), Services: &types.ServiceContainer{AdvisoryDeleteState: store}},
+				test.params,
+			)
+			require.NotNil(t, rpcErr)
+			require.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+			require.Equal(t, "Invalid parameters.", rpcErr.Message)
+			require.Zero(t, store.getCalls)
+			require.Zero(t, store.setCalls)
+		})
+	}
+}
+
+func TestLogLevelDecodeRejectionDoesNotMutateLevels(t *testing.T) {
+	globalBefore, partitionsBefore := xrpllog.Levels()
+	_, rpcErr := (&LogLevelMethod{}).Handle(
+		&types.RpcContext{},
+		json.RawMessage(`{"severity":"debug","partition":{}}`),
+	)
+	require.NotNil(t, rpcErr)
+	globalAfter, partitionsAfter := xrpllog.Levels()
+	require.Equal(t, globalBefore, globalAfter)
+	require.Equal(t, partitionsBefore, partitionsAfter)
+}
+
+func TestRequestObjectPreservesJsonCppIntegerRange(t *testing.T) {
+	_, rpcErr := (&FetchInfoMethod{}).Handle(
+		&types.RpcContext{},
+		json.RawMessage(`{"unknown":4294967296}`),
+	)
+	require.NotNil(t, rpcErr)
+	require.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+}

--- a/internal/rpc/handlers/stubs_admin.go
+++ b/internal/rpc/handlers/stubs_admin.go
@@ -147,6 +147,22 @@ func printSection(params json.RawMessage) string {
 // configured, matching rippled's getSHAMapStore().advisoryDelete() gate.
 type CanDeleteMethod struct{ AdminHandler }
 
+type canDeleteParam json.RawMessage
+
+func (p *canDeleteParam) UnmarshalJSON(data []byte) error {
+	var number uint32
+	if err := json.Unmarshal(data, &number); err == nil {
+		*p = append((*p)[:0], data...)
+		return nil
+	}
+	var text string
+	if err := json.Unmarshal(data, &text); err != nil {
+		return err
+	}
+	*p = append((*p)[:0], data...)
+	return nil
+}
+
 func (m *CanDeleteMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	if ctx.Services == nil {
 		return nil, types.RpcErrorNotEnabled("")
@@ -157,17 +173,17 @@ func (m *CanDeleteMethod) Handle(ctx *types.RpcContext, params json.RawMessage) 
 	}
 
 	var request struct {
-		CanDelete json.RawMessage `json:"can_delete,omitempty"`
+		CanDelete requestField[canDeleteParam] `json:"can_delete"`
 	}
-	if params != nil {
-		_ = json.Unmarshal(params, &request)
+	if rpcErr := decodeRequestObject(params, &request); rpcErr != nil {
+		return nil, rpcErr
 	}
 
-	if len(request.CanDelete) == 0 {
+	if !request.CanDelete.present {
 		return map[string]any{"can_delete": store.GetCanDelete()}, nil
 	}
 
-	seq, rpcErr := resolveCanDeleteSeq(ctx, store, request.CanDelete)
+	seq, rpcErr := resolveCanDeleteSeq(ctx, store, json.RawMessage(request.CanDelete.value))
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
@@ -364,16 +380,16 @@ func rippledSeverityName(l xrpllog.Level) string {
 
 func (m *LogLevelMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	var request struct {
-		Severity  string `json:"severity,omitempty"`
-		Partition string `json:"partition,omitempty"`
+		Severity  jsonCppStringField `json:"severity"`
+		Partition jsonCppStringField `json:"partition"`
 	}
 
-	if params != nil {
-		_ = json.Unmarshal(params, &request)
+	if rpcErr := decodeRequestObject(params, &request); rpcErr != nil {
+		return nil, rpcErr
 	}
 
 	// GET: return current levels snapshot
-	if request.Severity == "" {
+	if !request.Severity.present {
 		global, partitions := xrpllog.Levels()
 		levels := map[string]string{
 			"base": rippledSeverityName(global),
@@ -385,13 +401,13 @@ func (m *LogLevelMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	}
 
 	// SET: parse and apply the new level
-	lvl, ok := xrpllog.ParseLevel(request.Severity)
+	lvl, ok := xrpllog.ParseLevel(request.Severity.value)
 	if !ok {
 		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 	}
 
-	if request.Partition != "" && !strings.EqualFold(request.Partition, "base") {
-		xrpllog.SetPartitionLevel(request.Partition, lvl)
+	if request.Partition.present && !strings.EqualFold(request.Partition.value, "base") {
+		xrpllog.SetPartitionLevel(request.Partition.value, lvl)
 	} else {
 		xrpllog.SetLevel(lvl)
 	}

--- a/internal/rpc/handlers/stubs_network.go
+++ b/internal/rpc/handlers/stubs_network.go
@@ -20,15 +20,15 @@ type FetchInfoMethod struct{ AdminHandler }
 
 func (m *FetchInfoMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
 	var request struct {
-		Clear bool `json:"clear,omitempty"`
+		Clear jsonCppBoolField `json:"clear"`
 	}
-	if params != nil {
-		_ = json.Unmarshal(params, &request)
+	if rpcErr := decodeRequestObject(params, &request); rpcErr != nil {
+		return nil, rpcErr
 	}
 
 	response := make(map[string]any)
 
-	if request.Clear {
+	if request.Clear.value {
 		if ctx.Services != nil && ctx.Services.FetchInfoClear != nil {
 			ctx.Services.FetchInfoClear()
 		}

--- a/internal/rpc/path_find_session.go
+++ b/internal/rpc/path_find_session.go
@@ -16,10 +16,11 @@ import (
 // Each WebSocket connection can have at most one active session (matching rippled).
 // Reference: rippled PathRequest class + PathFind.cpp handler
 type PathFindSession struct {
-	mu        sync.Mutex
-	computeMu sync.Mutex
-	computeFn func(tx.LedgerView) *pathfinder.PathRequestResult
-	request   *pathfinder.PathRequest
+	mu             sync.Mutex
+	computeMu      sync.Mutex
+	computeFn      func(tx.LedgerView) *pathfinder.PathRequestResult
+	request        *pathfinder.PathRequest
+	searchLevelMax int
 
 	// Request parameters (immutable after creation)
 	srcAccount    [20]byte
@@ -222,20 +223,30 @@ func ParseAndCreateSession(params json.RawMessage, id any) (*PathFindSession, *r
 	pathRequest.SetSearchLevel(0)
 
 	session := &PathFindSession{
-		request:       pathRequest,
-		srcAccount:    srcAccount,
-		dstAccount:    dstAccount,
-		dstAmount:     dstAmount,
-		sendMax:       sendMax,
-		srcCurrencies: srcCurrencies,
-		convertAll:    convertAll,
-		domainID:      domainID,
-		srcAccountStr: state.EncodeAccountIDSafe(srcAccount),
-		dstAccountStr: state.EncodeAccountIDSafe(dstAccount),
-		id:            id,
+		request:        pathRequest,
+		srcAccount:     srcAccount,
+		dstAccount:     dstAccount,
+		dstAmount:      dstAmount,
+		sendMax:        sendMax,
+		srcCurrencies:  srcCurrencies,
+		convertAll:     convertAll,
+		domainID:       domainID,
+		searchLevelMax: pathfinder.SearchLevelMax,
+		srcAccountStr:  state.EncodeAccountIDSafe(srcAccount),
+		dstAccountStr:  state.EncodeAccountIDSafe(dstAccount),
+		id:             id,
 	}
 
 	return session, nil
+}
+
+func (s *PathFindSession) setSearchLevelMax(level int) {
+	s.computeMu.Lock()
+	defer s.computeMu.Unlock()
+	s.searchLevelMax = level
+	if s.request != nil {
+		s.request.SetSearchLevelMax(level)
+	}
 }
 
 // Compute runs pathfinding while serializing computations for this session.
@@ -255,6 +266,7 @@ func (s *PathFindSession) Compute(view tx.LedgerView, fast bool) *pathfinder.Pat
 		)
 		s.request.SetDomainID(s.domainID)
 		s.request.SetSearchLevel(0)
+		s.request.SetSearchLevelMax(s.searchLevelMax)
 	}
 	return s.request.ExecuteUpdate(view, fast, false)
 }

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -169,6 +169,12 @@ type ServerInfoConfigSnapshot struct {
 	GitHash      string
 }
 
+// RPCCapabilities is the immutable startup policy used by RPC handlers.
+type RPCCapabilities struct {
+	SigningEnabled bool
+	PathSearchMax  int
+}
+
 // ManifestLookup is the read-only facet of the validator-manifest cache
 // that the `manifest` RPC needs. Expressed as an interface (not a
 // concrete type) so internal/rpc/types doesn't import
@@ -207,6 +213,9 @@ type ServiceContainer struct {
 	// ServerInfoConfig is the immutable startup configuration and build
 	// metadata surfaced by server_info and server_state.
 	ServerInfoConfig ServerInfoConfigSnapshot
+
+	// Capabilities freezes operator-controlled RPC policy before listeners serve.
+	Capabilities RPCCapabilities
 
 	// LastCloseInfo returns proposer count and convergence time (ms) from the last consensus round
 	LastCloseInfo func() (proposers int, convergeTimeMs int)
@@ -353,6 +362,10 @@ type ServiceContainer struct {
 
 	// Nil in RPC-only test contexts, which handlers treat as unloaded.
 	IsLoadedCluster func() bool
+
+	// IsLoadedLocal reports whether local fee pressure is elevated. Nil in
+	// RPC-only test contexts, which handlers treat as unloaded.
+	IsLoadedLocal func() bool
 
 	// ClientLoad is the shared in-flight client-RPC counter that drives
 	// the rpcTOO_BUSY load-shedding gates. Approximates rippled's

--- a/internal/rpc/websocket_pathfind.go
+++ b/internal/rpc/websocket_pathfind.go
@@ -63,6 +63,7 @@ func (ws *WebSocketServer) executePathFindCreate(wsConn *websocketConnection, ct
 		return nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",
 			"No closed ledger available")
 	}
+	session.setSearchLevelMax(ctx.Services.Capabilities.PathSearchMax)
 	view, err := ctx.Services.Ledger.GetClosedLedgerView()
 	if err != nil {
 		return nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent",

--- a/internal/tx/payment/pathfinder/path_request.go
+++ b/internal/tx/payment/pathfinder/path_request.go
@@ -16,9 +16,8 @@ import (
 // Pathfinding search levels mirror rippled's config defaults
 // (Config.h: PATH_SEARCH_FAST=2, PATH_SEARCH=2, PATH_SEARCH_MAX=3).
 // A fast update runs at SearchLevelFast and a full update at
-// SearchLevelDefault; repeated updates never exceed SearchLevelMax
-// (PathRequest::doUpdate). Tests ported from rippled's Path_test raise
-// the level to 7, matching that suite's pathTestEnv configuration.
+// SearchLevelDefault. SearchLevelMax is the default ceiling for repeated
+// updates.
 const (
 	SearchLevelFast    = 2
 	SearchLevelDefault = 2
@@ -58,6 +57,7 @@ type PathRequest struct {
 	convertAll       bool
 	maxPaths         int
 	searchLevel      int
+	searchLevelMax   int
 	domainID         *[32]byte
 	lastSuccess      bool
 	context          map[payment.Issue][][]payment.PathStep
@@ -99,6 +99,7 @@ func NewPathRequest(
 		convertAll:       convertAll,
 		maxPaths:         maxReturnedPaths,
 		searchLevel:      SearchLevelDefault,
+		searchLevelMax:   SearchLevelMax,
 		context:          make(map[payment.Issue][][]payment.PathStep),
 	}
 }
@@ -108,6 +109,11 @@ func NewPathRequest(
 // uses 7).
 func (pr *PathRequest) SetSearchLevel(level int) {
 	pr.searchLevel = level
+}
+
+// SetSearchLevelMax sets the ceiling for adaptive persistent searches.
+func (pr *PathRequest) SetSearchLevelMax(level int) {
+	pr.searchLevelMax = level
 }
 
 // SetDomainID restricts pathfinding and liquidity calculation to one
@@ -142,7 +148,7 @@ func (pr *PathRequest) adjustSearchLevel(fast, loaded bool) {
 		if pr.searchLevel > SearchLevelDefault || loaded && pr.searchLevel > SearchLevelFast {
 			pr.searchLevel--
 		}
-	case !loaded && pr.searchLevel < SearchLevelMax:
+	case !loaded && pr.searchLevel < pr.searchLevelMax:
 		pr.searchLevel++
 	case loaded && pr.searchLevel > SearchLevelFast:
 		pr.searchLevel--

--- a/internal/tx/payment/pathfinder/pathfinder_test.go
+++ b/internal/tx/payment/pathfinder/pathfinder_test.go
@@ -1676,7 +1676,7 @@ func TestNewPathRequest_Defaults(t *testing.T) {
 }
 
 func TestPathRequestAdjustsPersistentSearchLevel(t *testing.T) {
-	request := &PathRequest{}
+	request := &PathRequest{searchLevelMax: SearchLevelMax}
 
 	request.adjustSearchLevel(true, false)
 	require.Equal(t, SearchLevelFast, request.searchLevel)
@@ -1691,6 +1691,17 @@ func TestPathRequestAdjustsPersistentSearchLevel(t *testing.T) {
 	request.lastSuccess = true
 	request.adjustSearchLevel(false, false)
 	require.Equal(t, SearchLevelDefault, request.searchLevel)
+}
+
+func TestPathRequestAdjustsToConfiguredSearchLevelMax(t *testing.T) {
+	request := &PathRequest{searchLevel: SearchLevelDefault + 1, searchLevelMax: 5}
+
+	request.adjustSearchLevel(false, false)
+	require.Equal(t, 4, request.searchLevel)
+	request.adjustSearchLevel(false, false)
+	require.Equal(t, 5, request.searchLevel)
+	request.adjustSearchLevel(false, false)
+	require.Equal(t, 5, request.searchLevel)
 }
 
 func TestNewPathRequest_WithSendMax(t *testing.T) {


### PR DESCRIPTION
## Summary
- Freeze signing and pathfinding capability policy at startup.
- Reject malformed request objects while preserving required JsonCpp coercions.

## Verification
- Focused and full RPC tests
- Targeted race, vet, strict lint, build, and diff checks

Refs #1486

Stack layer 1 of 16.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable RPC signing support and path-search limits.
  * Added RPC capability reporting and local ledger-load status.
  * Pathfinding now respects configured maximum search levels.

* **Bug Fixes**
  * Improved RPC request validation and error reporting for malformed or invalid JSON.
  * Preserved field presence and value distinctions for administrative and network requests.
  * Feature requests now handle omitted and specified feature names consistently.

* **Tests**
  * Added coverage for capability configuration, path-search limits, strict request decoding, and RPC behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->