### PR TITLE
fix: authorize RPC signing keys (#1486)

### DIFF
--- a/internal/rpc/channel_authorize_test.go
+++ b/internal/rpc/channel_authorize_test.go
@@ -17,11 +17,28 @@ import (
 
 // Test vectors from rippled's RPCCall_test.cpp and PayChan_test.cpp
 
+func channelAuthorizeTestContext(apiVersion int) *types.RpcContext {
+	return &types.RpcContext{
+		ApiVersion: apiVersion,
+		Services: &types.ServiceContainer{
+			Capabilities: types.RPCCapabilities{SigningEnabled: true},
+		},
+	}
+}
+
+func TestChannelAuthorizeSigningDisabledPrecedesValidation(t *testing.T) {
+	_, rpcErr := (&handlers.ChannelAuthorizeMethod{}).Handle(
+		&types.RpcContext{ApiVersion: types.ApiVersion2, Services: &types.ServiceContainer{}},
+		json.RawMessage(`{}`),
+	)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcNOT_SUPPORTED, rpcErr.Code)
+	assert.Equal(t, "Signing is not supported by this server.", rpcErr.Message)
+}
+
 func TestChannelAuthorize_MissingChannelID(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	params := json.RawMessage(`{
 		"secret": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
@@ -36,9 +53,7 @@ func TestChannelAuthorize_MissingChannelID(t *testing.T) {
 
 func TestChannelAuthorize_MissingAmount(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	params := json.RawMessage(`{
 		"secret": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
@@ -53,9 +68,7 @@ func TestChannelAuthorize_MissingAmount(t *testing.T) {
 
 func TestChannelAuthorize_MissingSecret(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	params := json.RawMessage(`{
 		"channel_id": "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
@@ -70,7 +83,7 @@ func TestChannelAuthorize_MissingSecret(t *testing.T) {
 
 func TestChannelAuthorize_PresentEmptyRequiredFields(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion2}
+	ctx := channelAuthorizeTestContext(types.ApiVersion2)
 	const channelID = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
 	const secret = "snoPBrXtMeMyMHUVTgbuqAfg1SUTb"
 
@@ -102,9 +115,7 @@ func TestChannelAuthorize_PresentEmptyRequiredFields(t *testing.T) {
 
 func TestChannelAuthorize_MultipleSecrets(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	params := json.RawMessage(`{
 		"secret": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
@@ -121,9 +132,7 @@ func TestChannelAuthorize_MultipleSecrets(t *testing.T) {
 
 func TestChannelAuthorize_SecretNotAllowedWithKeyType(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	params := json.RawMessage(`{
 		"secret": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
@@ -140,9 +149,7 @@ func TestChannelAuthorize_SecretNotAllowedWithKeyType(t *testing.T) {
 
 func TestChannelAuthorize_BadKeyType(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion2,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion2)
 
 	params := json.RawMessage(`{
 		"seed": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
@@ -159,9 +166,7 @@ func TestChannelAuthorize_BadKeyType(t *testing.T) {
 
 func TestChannelAuthorize_ChannelIDTooShort(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	params := json.RawMessage(`{
 		"secret": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
@@ -177,9 +182,7 @@ func TestChannelAuthorize_ChannelIDTooShort(t *testing.T) {
 
 func TestChannelAuthorize_ChannelIDTooLong(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	params := json.RawMessage(`{
 		"secret": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
@@ -194,9 +197,7 @@ func TestChannelAuthorize_ChannelIDTooLong(t *testing.T) {
 
 func TestChannelAuthorize_ChannelIDNotHex(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	params := json.RawMessage(`{
 		"secret": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
@@ -211,9 +212,7 @@ func TestChannelAuthorize_ChannelIDNotHex(t *testing.T) {
 
 func TestChannelAuthorize_NegativeAmount(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	params := json.RawMessage(`{
 		"secret": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
@@ -229,9 +228,7 @@ func TestChannelAuthorize_NegativeAmount(t *testing.T) {
 
 func TestChannelAuthorize_AmountOverflow(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	params := json.RawMessage(`{
 		"secret": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
@@ -246,9 +243,7 @@ func TestChannelAuthorize_AmountOverflow(t *testing.T) {
 
 func TestChannelAuthorize_ValidWithSecret(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	// Use masterpassphrase seed which generates a known keypair
 	params := json.RawMessage(`{
@@ -270,7 +265,7 @@ func TestChannelAuthorize_ValidWithSecret(t *testing.T) {
 
 func TestChannelAuthorize_LegacyRFC1751Secret(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{ApiVersion: types.ApiVersion1}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 	base := map[string]any{
 		"channel_id": strings.Repeat("A", 64),
 		"amount":     "1",
@@ -302,9 +297,7 @@ func TestChannelAuthorize_LegacyRFC1751Secret(t *testing.T) {
 
 func TestChannelAuthorize_ValidWithSeed(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	params := json.RawMessage(`{
 		"seed": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb",
@@ -324,9 +317,7 @@ func TestChannelAuthorize_ValidWithSeed(t *testing.T) {
 
 func TestChannelAuthorize_ValidWithPassphrase(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	params := json.RawMessage(`{
 		"passphrase": "masterpassphrase",
@@ -346,9 +337,7 @@ func TestChannelAuthorize_ValidWithPassphrase(t *testing.T) {
 
 func TestChannelAuthorize_ValidWithSeedHex(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	// masterpassphrase SHA512Half first 16 bytes = DEDCE9CE67B451D852FD4E846FCDE31C
 	params := json.RawMessage(`{
@@ -369,9 +358,7 @@ func TestChannelAuthorize_ValidWithSeedHex(t *testing.T) {
 
 func TestChannelAuthorize_ValidEd25519(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	// Ed25519 seed
 	params := json.RawMessage(`{
@@ -394,9 +381,7 @@ func TestChannelAuthorize_ValidEd25519(t *testing.T) {
 
 func TestChannelAuthorize_MaxAmount(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	// Max uint64 value
 	params := json.RawMessage(`{
@@ -427,9 +412,7 @@ func TestChannelAuthorizeAndVerify_Integration(t *testing.T) {
 
 	// Authorize
 	authorizeHandler := &handlers.ChannelAuthorizeMethod{}
-	authorizeCtx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	authorizeCtx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	authorizeParams := json.RawMessage(`{
 		"passphrase": "masterpassphrase",
@@ -479,9 +462,7 @@ func TestChannelAuthorizeAndVerify_IntegrationEd25519(t *testing.T) {
 
 	// Authorize
 	authorizeHandler := &handlers.ChannelAuthorizeMethod{}
-	authorizeCtx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	authorizeCtx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	authorizeParams := json.RawMessage(`{
 		"passphrase": "masterpassphrase",
@@ -544,9 +525,7 @@ func TestChannelAuthorize_MessageFormat(t *testing.T) {
 
 func TestChannelAuthorize_BadSeed(t *testing.T) {
 	handler := &handlers.ChannelAuthorizeMethod{}
-	ctx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	ctx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	params := json.RawMessage(`{
 		"seed": "invalid_seed",

--- a/internal/rpc/channel_verify_test.go
+++ b/internal/rpc/channel_verify_test.go
@@ -356,9 +356,7 @@ func TestChannelVerify_ZeroAmount(t *testing.T) {
 func TestChannelVerify_WrongSignatureForAmount(t *testing.T) {
 	// First create a valid signature for amount "1000000"
 	authorizeHandler := &handlers.ChannelAuthorizeMethod{}
-	authorizeCtx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	authorizeCtx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	authorizeParams := json.RawMessage(`{
 		"passphrase": "masterpassphrase",
@@ -399,9 +397,7 @@ func TestChannelVerify_WrongSignatureForAmount(t *testing.T) {
 func TestChannelVerify_WrongChannelID(t *testing.T) {
 	// First create a valid signature for channel_id
 	authorizeHandler := &handlers.ChannelAuthorizeMethod{}
-	authorizeCtx := &types.RpcContext{
-		ApiVersion: types.ApiVersion1,
-	}
+	authorizeCtx := channelAuthorizeTestContext(types.ApiVersion1)
 
 	authorizeParams := json.RawMessage(`{
 		"passphrase": "masterpassphrase",

--- a/internal/rpc/handlers/channel_authorize.go
+++ b/internal/rpc/handlers/channel_authorize.go
@@ -27,6 +27,10 @@ type channelAuthorizeRequest struct {
 }
 
 func (m *ChannelAuthorizeMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+	if rpcErr := rejectDisabledSigning(ctx); rpcErr != nil {
+		return nil, rpcErr
+	}
+
 	var request channelAuthorizeRequest
 
 	if params != nil {
@@ -121,7 +125,5 @@ func signMessage(message []byte, privateKeyHex string, keyType string) (string, 
 }
 
 func (m *ChannelAuthorizeMethod) RequiredRole() types.Role {
-	// Note: rippled requires admin role OR signing enabled
-	// For now, allow user role since we're implementing the signing functionality
 	return types.RoleUser
 }

--- a/internal/rpc/handlers/loadkinds_test.go
+++ b/internal/rpc/handlers/loadkinds_test.go
@@ -37,6 +37,7 @@ func TestLoadCostEarlyErrorTiming(t *testing.T) {
 			ctx := &types.RpcContext{
 				Context:  context.Background(),
 				LoadCost: uint32(loadtrack.LoadReference),
+				Services: &types.ServiceContainer{Capabilities: types.RPCCapabilities{SigningEnabled: true}},
 			}
 			_, rpcErr := test.handler.Handle(ctx, test.params)
 			if rpcErr == nil {

--- a/internal/rpc/handlers/sign.go
+++ b/internal/rpc/handlers/sign.go
@@ -10,7 +10,14 @@ import (
 // SignMethod handles the sign RPC method
 type SignMethod struct{ BaseHandler }
 
-func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+func (m *SignMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (result any, rpcErr *types.RpcError) {
+	if rpcErr := rejectDisabledSigning(ctx); rpcErr != nil {
+		return nil, rpcErr
+	}
+	defer func() {
+		result, rpcErr = addSigningDeprecation(result, rpcErr)
+	}()
+
 	setLoadHeavy(ctx)
 	var request signingRequest
 

--- a/internal/rpc/handlers/sign_authorization_test.go
+++ b/internal/rpc/handlers/sign_authorization_test.go
@@ -1,0 +1,292 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
+)
+
+type signingAuthorizationLedger struct {
+	types.LedgerService
+	accounts map[string]*types.AccountInfo
+}
+
+func (l *signingAuthorizationLedger) GetAccountInfo(_ context.Context, account, _ string) (*types.AccountInfo, error) {
+	info, ok := l.accounts[account]
+	if !ok {
+		return nil, svcerr.ErrAccountNotFound
+	}
+	copy := *info
+	return &copy, nil
+}
+
+func (l *signingAuthorizationLedger) GetServerInfo() types.LedgerServerInfo {
+	return types.LedgerServerInfo{Standalone: true}
+}
+
+func signingAuthorizationContext(ledger types.LedgerService) *types.RpcContext {
+	return &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+		Services: &types.ServiceContainer{
+			Ledger:       ledger,
+			Capabilities: types.RPCCapabilities{SigningEnabled: true},
+		},
+	}
+}
+
+func authorizationSignParams(account string, delegate any) json.RawMessage {
+	txJSON := map[string]any{
+		"TransactionType": "AccountSet",
+		"Account":         account,
+		"Sequence":        1,
+		"Fee":             "10",
+	}
+	if delegate != nil {
+		txJSON["Delegate"] = delegate
+	}
+	params, _ := json.Marshal(map[string]any{
+		"seed_hex": loadAdmissionSeedHex,
+		"key_type": "ed25519",
+		"tx_json":  txJSON,
+	})
+	return params
+}
+
+func authorizationSignForParams(signer, txAccount string) json.RawMessage {
+	params, _ := json.Marshal(map[string]any{
+		"account":  signer,
+		"seed_hex": loadAdmissionSeedHex,
+		"key_type": "ed25519",
+		"tx_json": map[string]any{
+			"TransactionType": "AccountSet",
+			"Account":         txAccount,
+			"Sequence":        1,
+			"Fee":             "10",
+			"SigningPubKey":   "",
+		},
+	})
+	return params
+}
+
+func requireSigningDeprecation(t *testing.T, rpcErr *types.RpcError) {
+	t.Helper()
+	if rpcErr == nil || rpcErr.Extra["deprecated"] != signingDeprecation {
+		t.Fatalf("error = %#v, want signing deprecation", rpcErr)
+	}
+}
+
+func TestSigningCapabilityGuardPrecedesParsingAndLoad(t *testing.T) {
+	methods := []struct {
+		name   string
+		handle func(*types.RpcContext, json.RawMessage) (any, *types.RpcError)
+	}{
+		{name: "sign", handle: (&SignMethod{}).Handle},
+		{name: "sign_for", handle: (&SignForMethod{}).Handle},
+	}
+	for _, method := range methods {
+		t.Run(method.name, func(t *testing.T) {
+			loadedCalled := false
+			ctx := &types.RpcContext{
+				Role:       types.RoleIdentified,
+				Unlimited:  true,
+				ApiVersion: types.ApiVersion2,
+				Services: &types.ServiceContainer{IsLoadedCluster: func() bool {
+					loadedCalled = true
+					return true
+				}},
+			}
+			_, rpcErr := method.handle(ctx, json.RawMessage(`{`))
+			if rpcErr == nil || rpcErr.Code != types.RpcNOT_SUPPORTED || rpcErr.Message != "Signing is not supported by this server." {
+				t.Fatalf("error = %#v, want signing notSupported", rpcErr)
+			}
+			if rpcErr.Extra != nil {
+				t.Fatalf("guard error extras = %#v, want none", rpcErr.Extra)
+			}
+			if loadedCalled || ctx.LoadCost != 0 {
+				t.Fatalf("guard reached load admission: called=%v cost=%d", loadedCalled, ctx.LoadCost)
+			}
+		})
+	}
+}
+
+func TestSigningCapabilityAdminBypassAndDeprecation(t *testing.T) {
+	for _, method := range []struct {
+		name   string
+		handle func(*types.RpcContext, json.RawMessage) (any, *types.RpcError)
+	}{
+		{name: "sign", handle: (&SignMethod{}).Handle},
+		{name: "sign_for", handle: (&SignForMethod{}).Handle},
+	} {
+		t.Run(method.name, func(t *testing.T) {
+			ctx := &types.RpcContext{Role: types.RoleAdmin, ApiVersion: types.ApiVersion2}
+			_, rpcErr := method.handle(ctx, nil)
+			if rpcErr == nil || rpcErr.Code != types.RpcINVALID_PARAMS {
+				t.Fatalf("error = %#v, want invalidParams after admin bypass", rpcErr)
+			}
+			requireSigningDeprecation(t, rpcErr)
+		})
+	}
+
+	ctx := signingAuthorizationContext(nil)
+	params := json.RawMessage(`{"seed_hex":"` + loadAdmissionSeedHex + `","key_type":"ed25519","offline":true,"tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionSigningAccount + `","Sequence":1,"Fee":"10"}}`)
+	result, rpcErr := (&SignMethod{}).Handle(ctx, params)
+	if rpcErr != nil {
+		t.Fatalf("offline sign: %v", rpcErr)
+	}
+	response := result.(map[string]any)
+	if response["deprecated"] != signingDeprecation {
+		t.Fatalf("deprecated = %#v", response["deprecated"])
+	}
+}
+
+func TestSignSigningKeyAuthorization(t *testing.T) {
+	tests := []struct {
+		name      string
+		account   string
+		info      *types.AccountInfo
+		wantCode  int
+		wantToken string
+	}{
+		{name: "master", account: loadAdmissionSigningAccount, info: &types.AccountInfo{}},
+		{name: "regular key", account: loadAdmissionAccount, info: &types.AccountInfo{RegularKey: loadAdmissionSigningAccount}},
+		{name: "disabled master", account: loadAdmissionSigningAccount, info: &types.AccountInfo{Flags: entry.LsfDisableMaster}, wantCode: types.RpcMASTER_DISABLED, wantToken: "masterDisabled"},
+		{name: "wrong key", account: loadAdmissionAccount, info: &types.AccountInfo{}, wantCode: types.RpcBAD_SECRET, wantToken: "badSecret"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ledger := &signingAuthorizationLedger{accounts: map[string]*types.AccountInfo{test.account: test.info}}
+			result, rpcErr := (&SignMethod{}).Handle(signingAuthorizationContext(ledger), authorizationSignParams(test.account, nil))
+			if test.wantCode == 0 {
+				if rpcErr != nil {
+					t.Fatalf("sign: %v", rpcErr)
+				}
+				if result.(map[string]any)["deprecated"] != signingDeprecation {
+					t.Fatal("successful sign omitted deprecation")
+				}
+				return
+			}
+			if rpcErr == nil || rpcErr.Code != test.wantCode || rpcErr.ErrorString != test.wantToken {
+				t.Fatalf("error = %#v, want %d/%s", rpcErr, test.wantCode, test.wantToken)
+			}
+			requireSigningDeprecation(t, rpcErr)
+		})
+	}
+}
+
+func TestSignDelegateSigningKeyAuthorization(t *testing.T) {
+	source := &types.AccountInfo{}
+	tests := []struct {
+		name      string
+		delegate  any
+		accounts  map[string]*types.AccountInfo
+		wantCode  int
+		wantToken string
+	}{
+		{
+			name:     "delegate master",
+			delegate: loadAdmissionSigningAccount,
+			accounts: map[string]*types.AccountInfo{loadAdmissionAccount: source, loadAdmissionSigningAccount: {}},
+		},
+		{
+			name:      "missing delegate",
+			delegate:  loadAdmissionSigningAccount,
+			accounts:  map[string]*types.AccountInfo{loadAdmissionAccount: source},
+			wantCode:  types.RpcDELEGATE_ACT_NOT_FOUND,
+			wantToken: "delegateActNotFound",
+		},
+		{
+			name:      "malformed delegate",
+			delegate:  7,
+			accounts:  map[string]*types.AccountInfo{loadAdmissionAccount: source},
+			wantCode:  types.RpcSRC_ACT_MALFORMED,
+			wantToken: "srcActMalformed",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ledger := &signingAuthorizationLedger{accounts: test.accounts}
+			_, rpcErr := (&SignMethod{}).Handle(signingAuthorizationContext(ledger), authorizationSignParams(loadAdmissionAccount, test.delegate))
+			if test.wantCode == 0 {
+				if rpcErr != nil {
+					t.Fatalf("sign: %v", rpcErr)
+				}
+				return
+			}
+			if rpcErr == nil || rpcErr.Code != test.wantCode || rpcErr.ErrorString != test.wantToken {
+				t.Fatalf("error = %#v, want %d/%s", rpcErr, test.wantCode, test.wantToken)
+			}
+			if test.wantCode == types.RpcSRC_ACT_MALFORMED && rpcErr.Message != "Invalid field 'tx_json.Delegate'." {
+				t.Fatalf("message = %q", rpcErr.Message)
+			}
+			requireSigningDeprecation(t, rpcErr)
+		})
+	}
+}
+
+func TestSignForSigningKeyAuthorization(t *testing.T) {
+	tests := []struct {
+		name      string
+		signer    string
+		txAccount string
+		accounts  map[string]*types.AccountInfo
+		wantCode  int
+	}{
+		{
+			name:      "absent master",
+			signer:    loadAdmissionSigningAccount,
+			txAccount: loadAdmissionAccount,
+			accounts:  map[string]*types.AccountInfo{loadAdmissionAccount: {}},
+		},
+		{
+			name:      "regular key",
+			signer:    loadAdmissionAccount,
+			txAccount: loadAdmissionSigner,
+			accounts: map[string]*types.AccountInfo{
+				loadAdmissionAccount: {RegularKey: loadAdmissionSigningAccount},
+				loadAdmissionSigner:  {},
+			},
+		},
+		{
+			name:      "disabled master",
+			signer:    loadAdmissionSigningAccount,
+			txAccount: loadAdmissionAccount,
+			accounts: map[string]*types.AccountInfo{
+				loadAdmissionSigningAccount: {Flags: entry.LsfDisableMaster},
+				loadAdmissionAccount:        {},
+			},
+			wantCode: types.RpcMASTER_DISABLED,
+		},
+		{
+			name:      "wrong key",
+			signer:    loadAdmissionSigner,
+			txAccount: loadAdmissionAccount,
+			accounts: map[string]*types.AccountInfo{
+				loadAdmissionSigner:  {},
+				loadAdmissionAccount: {},
+			},
+			wantCode: types.RpcBAD_SECRET,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ledger := &signingAuthorizationLedger{accounts: test.accounts}
+			_, rpcErr := (&SignForMethod{}).Handle(signingAuthorizationContext(ledger), authorizationSignForParams(test.signer, test.txAccount))
+			if test.wantCode == 0 {
+				if rpcErr != nil {
+					t.Fatalf("sign_for: %v", rpcErr)
+				}
+				return
+			}
+			if rpcErr == nil || rpcErr.Code != test.wantCode {
+				t.Fatalf("error = %#v, want code %d", rpcErr, test.wantCode)
+			}
+			requireSigningDeprecation(t, rpcErr)
+		})
+	}
+}

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -22,7 +22,14 @@ import (
 // This adds a signature to a transaction for multi-signing
 type SignForMethod struct{ BaseHandler }
 
-func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (result any, rpcErr *types.RpcError) {
+	if rpcErr := rejectDisabledSigning(ctx); rpcErr != nil {
+		return nil, rpcErr
+	}
+	defer func() {
+		result, rpcErr = addSigningDeprecation(result, rpcErr)
+	}()
+
 	setLoadHeavy(ctx)
 	var request struct {
 		signingRequest
@@ -127,6 +134,13 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (a
 	}
 	transaction, rpcErr := parseTransactionForSigning(txMap)
 	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	derivedAccount, derivationErr := addresscodec.EncodeClassicAddressFromPublicKeyHex(publicKey)
+	if derivationErr != nil {
+		return nil, rpcInternalError("sign_for: account address derivation failed", derivationErr)
+	}
+	if rpcErr := authorizeSigningKey(ctx, request.Account, derivedAccount, false); rpcErr != nil {
 		return nil, rpcErr
 	}
 

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -15,11 +15,14 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/sign"
+	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
 
 // counterpartySignatureField is the only inner-object SField a signature_target
 // may name, matching rippled (the LoanSet sfCounterpartySignature).
 const counterpartySignatureField = "CounterpartySignature"
+
+const signingDeprecation = "This command has been deprecated and will be removed in a future version of the server. Please migrate to a standalone signing tool."
 
 // signCredentials holds the signing credential parameters common to both
 // the sign and submit RPC methods.
@@ -186,6 +189,26 @@ func formatSignResult(result signResult, apiVersion int) map[string]any {
 	return response
 }
 
+func rejectDisabledSigning(ctx *types.RpcContext) *types.RpcError {
+	if ctx != nil && ctx.Role == types.RoleAdmin {
+		return nil
+	}
+	if ctx != nil && ctx.Services != nil && ctx.Services.Capabilities.SigningEnabled {
+		return nil
+	}
+	return types.RpcErrorNotSupported("Signing is not supported by this server.")
+}
+
+func addSigningDeprecation(result any, rpcErr *types.RpcError) (any, *types.RpcError) {
+	if rpcErr != nil {
+		return result, rpcErr.WithExtra(map[string]any{"deprecated": signingDeprecation})
+	}
+	if response, ok := result.(map[string]any); ok {
+		response["deprecated"] = signingDeprecation
+	}
+	return result, nil
+}
+
 func jsonFieldPresent(params json.RawMessage, field string) bool {
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(params, &fields); err != nil {
@@ -285,10 +308,8 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 	if rpcErr := rejectSigningWhenLoaded(services, rpcCtx.Unlimited); rpcErr != nil {
 		return nil, rpcErr
 	}
-	if !signatureTargetPresent && txAccount != address {
-		return nil, types.RpcErrorInvalidParams("Account in tx_json does not match signing key")
-	}
 	srcAddress := txAccount
+	var sourceAccountInfo *types.AccountInfo
 
 	// Fill in missing fields if not offline. Order matches rippled's
 	// transactionPreProcessImpl (TransactionSign.cpp:454-505): source
@@ -296,7 +317,9 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 	if !offline {
 		// The source account must exist in the current ledger, whether or
 		// not Sequence is supplied (rpcSRC_ACT_NOT_FOUND).
-		if _, err := services.Ledger.GetAccountInfo(ctx, srcAddress, "current"); err != nil {
+		var err error
+		sourceAccountInfo, err = services.Ledger.GetAccountInfo(ctx, srcAddress, "current")
+		if err != nil {
 			if errors.Is(err, svcerr.ErrAccountNotFound) {
 				return nil, types.RpcErrorSrcActNotFound("Source account not found.")
 			}
@@ -371,6 +394,25 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 	if _, ok := txMap["Signers"]; ok {
 		return nil, rpcErrorAlreadyMultisigned()
 	}
+	if !signatureTargetPresent && !offline {
+		authorizationAccount := txAccount
+		delegatePresent := false
+		if delegateValue, present := txMap["Delegate"]; present {
+			delegatePresent = true
+			delegate, ok := delegateValue.(string)
+			if !ok || !addresscodec.IsValidClassicAddress(delegate) {
+				return nil, types.RpcErrorSrcActMalformed("Invalid field 'tx_json.Delegate'.")
+			}
+			authorizationAccount = delegate
+		}
+		if !delegatePresent {
+			if rpcErr := signingKeyAuthorization(authorizationAccount, address, sourceAccountInfo, false); rpcErr != nil {
+				return nil, rpcErr
+			}
+		} else if rpcErr := authorizeSigningKey(rpcCtx, authorizationAccount, address, true); rpcErr != nil {
+			return nil, rpcErr
+		}
+	}
 
 	// Without a target the signing key is the transaction's own key, placed at
 	// the top level. With a target the top-level SigningPubKey (the primary
@@ -416,6 +458,44 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 		TxMap:  txMap,
 		TxBlob: txBlob,
 	}, nil
+}
+
+func authorizeSigningKey(ctx *types.RpcContext, account, derivedAccount string, requireAccount bool) *types.RpcError {
+	var accountInfo *types.AccountInfo
+	if ctx != nil && ctx.Services != nil && ctx.Services.Ledger != nil {
+		info, err := ctx.Services.Ledger.GetAccountInfo(ctx.Context, account, "current")
+		if err != nil {
+			if !errors.Is(err, svcerr.ErrAccountNotFound) {
+				return rpcInternalError("signing authorization account lookup failed", err)
+			}
+		} else {
+			accountInfo = info
+		}
+	}
+
+	return signingKeyAuthorization(account, derivedAccount, accountInfo, requireAccount)
+}
+
+func signingKeyAuthorization(account, derivedAccount string, accountInfo *types.AccountInfo, requireAccount bool) *types.RpcError {
+	if accountInfo == nil {
+		if requireAccount {
+			return types.RpcErrorDelegateActNotFound()
+		}
+		if derivedAccount == account {
+			return nil
+		}
+		return types.RpcErrorBadSecret()
+	}
+	if derivedAccount == account {
+		if accountInfo.Flags&entry.LsfDisableMaster != 0 {
+			return types.RpcErrorMasterDisabled()
+		}
+		return nil
+	}
+	if accountInfo.RegularKey == derivedAccount {
+		return nil
+	}
+	return types.RpcErrorBadSecret()
 }
 
 func rejectSigningWhenLoaded(services *types.ServiceContainer, unlimited bool) *types.RpcError {

--- a/internal/rpc/handlers/signing_load_admission_test.go
+++ b/internal/rpc/handlers/signing_load_admission_test.go
@@ -19,6 +19,14 @@ const (
 	loadAdmissionSigner         = "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK"
 )
 
+func signingEnabledHandlerContext(ctx *types.RpcContext) *types.RpcContext {
+	if ctx.Services == nil {
+		ctx.Services = &types.ServiceContainer{}
+	}
+	ctx.Services.Capabilities.SigningEnabled = true
+	return ctx
+}
+
 type loadAdmissionLedger struct {
 	types.LedgerService
 	accountLookups   int
@@ -129,7 +137,7 @@ func TestSignRejectsClusterOnlyAndArmedLocalLoad(t *testing.T) {
 				ApiVersion: 2,
 				Services:   &types.ServiceContainer{IsLoadedCluster: track.IsLoadedCluster},
 			}
-			_, rpcErr := (&SignMethod{}).Handle(ctx, signingLoadParams(true))
+			_, rpcErr := (&SignMethod{}).Handle(signingEnabledHandlerContext(ctx), signingLoadParams(true))
 			assertTooBusy(t, rpcErr)
 		})
 	}
@@ -149,7 +157,7 @@ func TestSignRejectsLoadedOnlineAndOfflineBeforeLedgerWork(t *testing.T) {
 				Services:   services,
 			}
 
-			_, rpcErr := (&SignMethod{}).Handle(ctx, signingLoadParams(offline))
+			_, rpcErr := (&SignMethod{}).Handle(signingEnabledHandlerContext(ctx), signingLoadParams(offline))
 			assertTooBusy(t, rpcErr)
 			if ledger.accountLookups != 0 || ledger.sequenceFills != 0 || ledger.feeFills != 0 || ledger.transactionSends != 0 {
 				t.Fatalf("downstream calls = lookup:%d sequence:%d fee:%d submit:%d", ledger.accountLookups, ledger.sequenceFills, ledger.feeFills, ledger.transactionSends)
@@ -200,7 +208,7 @@ func TestOnlineSigningRejectsStaleLedgerBeforeLoad(t *testing.T) {
 					},
 				}
 
-				_, rpcErr := method.handle(ctx, method.params)
+				_, rpcErr := method.handle(signingEnabledHandlerContext(ctx), method.params)
 				if rpcErr == nil {
 					t.Fatal("expected stale-ledger error")
 				}
@@ -260,7 +268,7 @@ func TestSigningLoadAdmissionValidatesCredentialsAndShapeFirst(t *testing.T) {
 					return true
 				}},
 			}
-			_, rpcErr := (&SignMethod{}).Handle(ctx, test.params)
+			_, rpcErr := (&SignMethod{}).Handle(signingEnabledHandlerContext(ctx), test.params)
 			if rpcErr == nil || rpcErr.ErrorString != test.want {
 				t.Fatalf("error = %#v, want %s", rpcErr, test.want)
 			}
@@ -285,7 +293,7 @@ func TestSigningLoadAdmissionUnlimitedExemption(t *testing.T) {
 			Unlimited:  true,
 			Services:   &types.ServiceContainer{IsLoadedCluster: loaded},
 		}
-		result, rpcErr := (&SignMethod{}).Handle(ctx, signingLoadParams(true))
+		result, rpcErr := (&SignMethod{}).Handle(signingEnabledHandlerContext(ctx), signingLoadParams(true))
 		if rpcErr != nil {
 			t.Fatalf("unlimited offline sign: %v", rpcErr)
 		}
@@ -295,14 +303,14 @@ func TestSigningLoadAdmissionUnlimitedExemption(t *testing.T) {
 	})
 
 	t.Run("sign for", func(t *testing.T) {
-		params := json.RawMessage(`{"account":"` + loadAdmissionSigner + `","seed_hex":"` + loadAdmissionSeedHex + `","key_type":"ed25519","tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
+		params := json.RawMessage(`{"account":"` + loadAdmissionSigningAccount + `","seed_hex":"` + loadAdmissionSeedHex + `","key_type":"ed25519","tx_json":{"TransactionType":"AccountSet","Account":"` + loadAdmissionAccount + `","Sequence":1,"Fee":"10","SigningPubKey":""}}`)
 		ctx := &types.RpcContext{
 			Context:    context.Background(),
 			ApiVersion: 2,
 			Unlimited:  true,
 			Services:   &types.ServiceContainer{IsLoadedCluster: loaded},
 		}
-		_, rpcErr := (&SignForMethod{}).Handle(ctx, params)
+		_, rpcErr := (&SignForMethod{}).Handle(signingEnabledHandlerContext(ctx), params)
 		if rpcErr != nil {
 			t.Fatalf("unlimited sign_for: %v", rpcErr)
 		}
@@ -355,7 +363,7 @@ func TestCredentialedSubmitAndMultisignMethodsRejectLoaded(t *testing.T) {
 			ApiVersion: 2,
 			Services:   &types.ServiceContainer{IsLoadedCluster: func() bool { return true }},
 		}
-		_, rpcErr := (&SignForMethod{}).Handle(ctx, params)
+		_, rpcErr := (&SignForMethod{}).Handle(signingEnabledHandlerContext(ctx), params)
 		assertTooBusy(t, rpcErr)
 	})
 
@@ -390,7 +398,7 @@ func TestMultisignLoadAdmissionValidationPrecedence(t *testing.T) {
 				return true
 			}},
 		}
-		_, rpcErr := (&SignForMethod{}).Handle(ctx, params)
+		_, rpcErr := (&SignForMethod{}).Handle(signingEnabledHandlerContext(ctx), params)
 		if rpcErr == nil || rpcErr.ErrorString != "invalidParams" {
 			t.Fatalf("error = %#v, want credential validation error", rpcErr)
 		}
@@ -410,7 +418,7 @@ func TestMultisignLoadAdmissionValidationPrecedence(t *testing.T) {
 				return true
 			}},
 		}
-		_, rpcErr := (&SignForMethod{}).Handle(ctx, params)
+		_, rpcErr := (&SignForMethod{}).Handle(signingEnabledHandlerContext(ctx), params)
 		if rpcErr == nil || rpcErr.ErrorString != "invalidParams" {
 			t.Fatalf("error = %#v, want transaction validation error", rpcErr)
 		}

--- a/internal/rpc/sign_counterparty_test.go
+++ b/internal/rpc/sign_counterparty_test.go
@@ -22,7 +22,7 @@ func signOffline(t *testing.T, params json.RawMessage) map[string]any {
 	t.Helper()
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
-	result, rpcErr := handler.Handle(ctx, params)
+	result, rpcErr := handler.Handle(signingEnabledContext(ctx), params)
 	require.Nil(t, rpcErr)
 	require.NotNil(t, result)
 	return result.(map[string]any)
@@ -113,7 +113,7 @@ func TestSign_SignatureTarget_Invalid(t *testing.T) {
 		"offline": true,
 		"signature_target": "NotAValidField"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
 	assert.Contains(t, err.Message, "NotAValidField")
@@ -136,7 +136,7 @@ func TestSign_SignatureTarget_RequiresTopLevelSigningPubKey(t *testing.T) {
 		"offline": true,
 		"signature_target": "CounterpartySignature"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
 	assert.Contains(t, err.Message, "SigningPubKey")
@@ -160,7 +160,7 @@ func TestSign_SignatureTarget_DisallowedForTransaction(t *testing.T) {
 		"offline": true,
 		"signature_target": "CounterpartySignature"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
 	assert.Contains(t, err.Message, "disallowed location")
@@ -198,7 +198,7 @@ func TestSignFor_SignatureTarget(t *testing.T) {
 		"signature_target": "CounterpartySignature",
 	})
 	require.NoError(t, err)
-	result, rpcErr := handler.Handle(ctx, params)
+	result, rpcErr := handler.Handle(signingEnabledContext(ctx), params)
 	require.Nil(t, rpcErr)
 	response := result.(map[string]any)
 	resTx := response["tx_json"].(map[string]any)
@@ -244,7 +244,7 @@ func TestSignFor_SignatureTarget_DisallowedForTransaction(t *testing.T) {
 		"key_type": "secp256k1",
 		"signature_target": "CounterpartySignature"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
 	assert.Contains(t, err.Message, "disallowed location")
@@ -267,7 +267,7 @@ func TestSignFor_SignatureTarget_Invalid(t *testing.T) {
 		"key_type": "secp256k1",
 		"signature_target": "Memo"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
 	assert.Contains(t, err.Message, "Memo")
@@ -277,7 +277,7 @@ func TestSignatureTarget_ExplicitEmptyRejected(t *testing.T) {
 	t.Run("sign", func(t *testing.T) {
 		handler := &handlers.SignMethod{}
 		ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
-		_, rpcErr := handler.Handle(ctx, json.RawMessage(`{
+		_, rpcErr := handler.Handle(signingEnabledContext(ctx), json.RawMessage(`{
 			"tx_json": {
 				"TransactionType": "LoanSet",
 				"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -298,7 +298,7 @@ func TestSignatureTarget_ExplicitEmptyRejected(t *testing.T) {
 	t.Run("sign_for", func(t *testing.T) {
 		handler := &handlers.SignForMethod{}
 		ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
-		_, rpcErr := handler.Handle(ctx, json.RawMessage(`{
+		_, rpcErr := handler.Handle(signingEnabledContext(ctx), json.RawMessage(`{
 			"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			"tx_json": {
 				"TransactionType": "Payment",
@@ -320,7 +320,7 @@ func TestSignatureTarget_ExplicitEmptyRejected(t *testing.T) {
 func TestSignFor_RejectsTopLevelTxnSignature(t *testing.T) {
 	handler := &handlers.SignForMethod{}
 	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
-	_, rpcErr := handler.Handle(ctx, json.RawMessage(`{
+	_, rpcErr := handler.Handle(signingEnabledContext(ctx), json.RawMessage(`{
 		"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 		"tx_json": {
 			"TransactionType": "LoanSet",
@@ -343,7 +343,7 @@ func TestSignFor_RejectsTopLevelTxnSignature(t *testing.T) {
 func TestSignFor_TxnSignatureDoesNotMaskMissingAccount(t *testing.T) {
 	handler := &handlers.SignForMethod{}
 	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
-	_, rpcErr := handler.Handle(ctx, json.RawMessage(`{
+	_, rpcErr := handler.Handle(signingEnabledContext(ctx), json.RawMessage(`{
 		"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 		"tx_json": {
 			"TransactionType": "LoanSet",
@@ -366,7 +366,7 @@ func TestSignFor_TxnSignatureDoesNotMaskMissingAccount(t *testing.T) {
 func TestSignFor_TxnSignatureDoesNotMaskMissingSequence(t *testing.T) {
 	handler := &handlers.SignForMethod{}
 	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
-	_, rpcErr := handler.Handle(ctx, json.RawMessage(`{
+	_, rpcErr := handler.Handle(signingEnabledContext(ctx), json.RawMessage(`{
 		"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 		"tx_json": {
 			"TransactionType": "LoanSet",
@@ -419,7 +419,7 @@ func TestSignFor_MissingSequencePrecedesLaterValidation(t *testing.T) {
 				`"PrincipalRequested":"1","Fee":"10"}` + test.extra + `}`)
 			handler := &handlers.SignForMethod{}
 			ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
-			_, rpcErr := handler.Handle(ctx, params)
+			_, rpcErr := handler.Handle(signingEnabledContext(ctx), params)
 			require.NotNil(t, rpcErr)
 			assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
 			assert.Equal(t, "Missing field 'tx_json.Sequence'.", rpcErr.Message)
@@ -430,7 +430,7 @@ func TestSignFor_MissingSequencePrecedesLaterValidation(t *testing.T) {
 func TestSignFor_TxnSignatureDoesNotMaskNonEmptySigningPubKey(t *testing.T) {
 	handler := &handlers.SignForMethod{}
 	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
-	_, rpcErr := handler.Handle(ctx, json.RawMessage(`{
+	_, rpcErr := handler.Handle(signingEnabledContext(ctx), json.RawMessage(`{
 		"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 		"tx_json": {
 			"TransactionType": "Payment",
@@ -453,7 +453,7 @@ func TestSignFor_TxnSignatureDoesNotMaskNonEmptySigningPubKey(t *testing.T) {
 func TestSignFor_TargetTxnSignaturePrecedesTargetLocationValidation(t *testing.T) {
 	handler := &handlers.SignForMethod{}
 	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
-	_, rpcErr := handler.Handle(ctx, json.RawMessage(`{
+	_, rpcErr := handler.Handle(signingEnabledContext(ctx), json.RawMessage(`{
 		"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 		"tx_json": {
 			"TransactionType": "Payment",
@@ -476,7 +476,7 @@ func TestSignFor_TargetTxnSignaturePrecedesTargetLocationValidation(t *testing.T
 func TestSignFor_MissingFeePrecedesTxnSignature(t *testing.T) {
 	handler := &handlers.SignForMethod{}
 	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
-	_, rpcErr := handler.Handle(ctx, json.RawMessage(`{
+	_, rpcErr := handler.Handle(signingEnabledContext(ctx), json.RawMessage(`{
 		"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 		"tx_json": {
 			"TransactionType": "Payment",
@@ -623,7 +623,7 @@ func TestSignFor_PaymentFieldsPrecedeTxnSignature(t *testing.T) {
 func TestSign_SignatureTargetRejectsTopLevelSigners(t *testing.T) {
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
-	_, rpcErr := handler.Handle(ctx, json.RawMessage(`{
+	_, rpcErr := handler.Handle(signingEnabledContext(ctx), json.RawMessage(`{
 		"tx_json": {
 			"TransactionType": "LoanSet",
 			"Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -645,7 +645,7 @@ func TestSign_SignatureTargetRejectsTopLevelSigners(t *testing.T) {
 func TestSign_SignersDoesNotMaskInvalidAccount(t *testing.T) {
 	handler := &handlers.SignMethod{}
 	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
-	_, rpcErr := handler.Handle(ctx, json.RawMessage(`{
+	_, rpcErr := handler.Handle(signingEnabledContext(ctx), json.RawMessage(`{
 		"tx_json": {
 			"TransactionType": "LoanSet",
 			"Account": "not-an-account",
@@ -746,7 +746,7 @@ func callSignFor(t *testing.T, txJSON map[string]any, account string) (map[strin
 	require.NoError(t, err)
 	handler := &handlers.SignForMethod{}
 	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
-	result, rpcErr := handler.Handle(ctx, params)
+	result, rpcErr := handler.Handle(signingEnabledContext(ctx), params)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
@@ -765,7 +765,7 @@ func callTargetSignFor(t *testing.T, txJSON map[string]any) *types.RpcError {
 	require.NoError(t, err)
 	handler := &handlers.SignForMethod{}
 	ctx := &types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion1}
-	_, rpcErr := handler.Handle(ctx, params)
+	_, rpcErr := handler.Handle(signingEnabledContext(ctx), params)
 	return rpcErr
 }
 

--- a/internal/rpc/sign_for_networkid_test.go
+++ b/internal/rpc/sign_for_networkid_test.go
@@ -27,7 +27,10 @@ func TestSignFor_NetworkIDEnforcement(t *testing.T) {
 		return &types.RpcContext{
 			Context:    context.Background(),
 			ApiVersion: types.ApiVersion1,
-			Services:   &types.ServiceContainer{Ledger: mock},
+			Services: &types.ServiceContainer{
+				Ledger:       mock,
+				Capabilities: types.RPCCapabilities{SigningEnabled: true},
+			},
 		}
 	}
 

--- a/internal/rpc/sign_test.go
+++ b/internal/rpc/sign_test.go
@@ -12,6 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func signingEnabledContext(ctx *types.RpcContext) *types.RpcContext {
+	if ctx.Services == nil {
+		ctx.Services = &types.ServiceContainer{}
+	}
+	ctx.Services.Capabilities.SigningEnabled = true
+	return ctx
+}
+
 // WalletPropose Tests
 
 func TestWalletPropose_RandomGeneration(t *testing.T) {
@@ -264,7 +272,7 @@ func TestSign_MissingTxJson(t *testing.T) {
 	}
 
 	params := json.RawMessage(`{"secret": "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9"}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
 	assert.Contains(t, err.Message, "tx_json")
@@ -289,7 +297,7 @@ func TestSign_MissingCredentials(t *testing.T) {
 			"Amount": "1000000"
 		}
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
 	assert.Contains(t, err.Message, "Missing field 'secret'.")
@@ -394,7 +402,7 @@ func TestSign_CredentialFieldPresence(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			params := json.RawMessage(`{"tx_json":{},"offline":true,` + tc.credentials + `}`)
-			_, rpcErr := handler.Handle(&types.RpcContext{ApiVersion: tc.apiVersion}, params)
+			_, rpcErr := handler.Handle(signingEnabledContext(&types.RpcContext{ApiVersion: tc.apiVersion}), params)
 			require.NotNil(t, rpcErr)
 			assert.Equal(t, tc.code, rpcErr.Code)
 			assert.Equal(t, tc.message, rpcErr.Message)
@@ -412,7 +420,7 @@ func TestSign_LegacySecretRejectsKeyTokens(t *testing.T) {
 	} {
 		t.Run(secret[:1], func(t *testing.T) {
 			params := json.RawMessage(`{"tx_json":{},"offline":true,"secret":"` + secret + `"}`)
-			_, rpcErr := (&handlers.SignMethod{}).Handle(&types.RpcContext{ApiVersion: types.ApiVersion1}, params)
+			_, rpcErr := (&handlers.SignMethod{}).Handle(signingEnabledContext(&types.RpcContext{ApiVersion: types.ApiVersion1}), params)
 			require.NotNil(t, rpcErr)
 			assert.Equal(t, types.RpcBAD_SEED, rpcErr.Code)
 			assert.Equal(t, "Invalid field 'secret'.", rpcErr.Message)
@@ -441,7 +449,7 @@ func TestSign_InvalidKeyType(t *testing.T) {
 		"seed_hex": "DEDCE9CE67B451D852FD4E846FCDE31C",
 		"key_type": "invalid"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	// API v1: rippled returns invalidParams for bad key_type
 	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
@@ -467,7 +475,7 @@ func TestSign_InvalidSeed(t *testing.T) {
 		},
 		"secret": "invalid_seed"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	// The shared credential helper treats "invalid_seed" as a passphrase
 	// (fallback after base58 and hex parsing fail), so it succeeds in
@@ -499,10 +507,11 @@ func TestSign_AccountMismatch(t *testing.T) {
 		"seed_hex": "DEDCE9CE67B451D852FD4E846FCDE31C",
 		"key_type": "secp256k1"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
-	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
-	assert.Contains(t, err.Message, "does not match")
+	assert.Equal(t, types.RpcBAD_SECRET, err.Code)
+	assert.Equal(t, "badSecret", err.ErrorString)
+	assert.Equal(t, "Secret does not match account.", err.Message)
 }
 
 func TestSign_LedgerServiceUnavailable(t *testing.T) {
@@ -523,7 +532,7 @@ func TestSign_LedgerServiceUnavailable(t *testing.T) {
 		"seed_hex": "DEDCE9CE67B451D852FD4E846FCDE31C",
 		"key_type": "secp256k1"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcINTERNAL, err.Code)
 	assert.Equal(t, "Internal error.", err.Message)
@@ -553,7 +562,7 @@ func TestSign_OfflineMode(t *testing.T) {
 		"key_type": "secp256k1",
 		"offline": true
 	}`)
-	result, err := handler.Handle(ctx, params)
+	result, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.Nil(t, err)
 	require.NotNil(t, result)
 
@@ -596,7 +605,7 @@ func TestSign_SrcActNotFound(t *testing.T) {
 		"passphrase": "masterpassphrase",
 		"key_type": "secp256k1"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcSRC_ACT_NOT_FOUND, err.Code)
 	assert.Equal(t, "srcActNotFound", err.ErrorString)
@@ -626,7 +635,7 @@ func TestSign_AutofillSequence(t *testing.T) {
 		"passphrase": "masterpassphrase",
 		"key_type": "secp256k1"
 	}`)
-	result, err := handler.Handle(ctx, params)
+	result, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.Nil(t, err)
 	require.NotNil(t, result)
 
@@ -657,7 +666,7 @@ func TestSign_Offline_MissingSequence(t *testing.T) {
 		"key_type": "secp256k1",
 		"offline": true
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
 	assert.Equal(t, "Missing field 'tx_json.Sequence'.", err.Message)
@@ -684,7 +693,7 @@ func TestSign_Offline_MissingFee(t *testing.T) {
 		"key_type": "secp256k1",
 		"offline": true
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
 	assert.Equal(t, "Missing field 'tx_json.Fee'.", err.Message)
@@ -715,7 +724,7 @@ func TestSign_TicketSequence_AutofillsSequenceZero(t *testing.T) {
 		"passphrase": "masterpassphrase",
 		"key_type": "secp256k1"
 	}`)
-	result, err := handler.Handle(ctx, params)
+	result, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.Nil(t, err)
 	require.NotNil(t, result)
 
@@ -766,7 +775,7 @@ func TestSign_FeeMultMax_DefaultAccepted(t *testing.T) {
 		"key_type": "secp256k1",
 		"offline": false
 	}`)
-	result, err := handler.Handle(ctx, params)
+	result, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.Nil(t, err)
 	require.NotNil(t, result)
 
@@ -800,7 +809,7 @@ func TestSign_FeeMultMax_ZeroRejects(t *testing.T) {
 		"key_type": "secp256k1",
 		"fee_mult_max": 0
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcHIGH_FEE, err.Code)
 	assert.Contains(t, err.Message, "exceeds the requested tx limit")
@@ -830,7 +839,7 @@ func TestSign_FeeDivMax_LargeRejects(t *testing.T) {
 		"key_type": "secp256k1",
 		"fee_div_max": 100
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcHIGH_FEE, err.Code)
 	assert.Contains(t, err.Message, "exceeds the requested tx limit")
@@ -861,7 +870,7 @@ func TestSign_FeeMultMax_NegativeRejectsInvalidParams(t *testing.T) {
 		"key_type": "secp256k1",
 		"fee_mult_max": -1
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
 	assert.Contains(t, err.Message, "fee_mult_max")
@@ -893,7 +902,7 @@ func TestSign_FeeDivMax_ZeroRejectsInvalidParams(t *testing.T) {
 		"key_type": "secp256k1",
 		"fee_div_max": 0
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
 	assert.Contains(t, err.Message, "fee_div_max")
@@ -925,7 +934,7 @@ func TestSign_FeeDivMax_NegativeRejectsInvalidParams(t *testing.T) {
 		"key_type": "secp256k1",
 		"fee_div_max": -5
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcINVALID_PARAMS, err.Code)
 	assert.Contains(t, err.Message, "fee_div_max")
@@ -956,7 +965,7 @@ func TestSign_FeeMultMax_FloatRejectsHighFee(t *testing.T) {
 		"key_type": "secp256k1",
 		"fee_mult_max": 1.5
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcHIGH_FEE, err.Code)
 	assert.Contains(t, err.Message, "fee_mult_max")
@@ -987,7 +996,7 @@ func TestSign_FeeMultMax_StringRejectsHighFee(t *testing.T) {
 		"key_type": "secp256k1",
 		"fee_mult_max": "ten"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcHIGH_FEE, err.Code)
 	assert.Contains(t, err.Message, "fee_mult_max")
@@ -1020,7 +1029,7 @@ func TestSign_FeeAlreadySet_IgnoresFeeMultMax(t *testing.T) {
 		"offline": true,
 		"fee_mult_max": "garbage"
 	}`)
-	result, err := handler.Handle(ctx, params)
+	result, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.Nil(t, err, "fee_mult_max must not be read when Fee is in tx_json")
 	require.NotNil(t, result)
 }
@@ -1049,7 +1058,7 @@ func TestSign_DeliverMax_APIv1(t *testing.T) {
 		"key_type": "secp256k1",
 		"offline": true
 	}`)
-	result, err := handler.Handle(ctx, params)
+	result, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.Nil(t, err)
 
 	resultMap := result.(map[string]any)
@@ -1082,7 +1091,7 @@ func TestSign_DeliverMax_APIv2(t *testing.T) {
 		"key_type": "secp256k1",
 		"offline": true
 	}`)
-	result, err := handler.Handle(ctx, params)
+	result, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.Nil(t, err)
 
 	resultMap := result.(map[string]any)
@@ -1117,7 +1126,7 @@ func TestSign_NoDeliverMax_NonPayment(t *testing.T) {
 		"key_type": "secp256k1",
 		"offline": true
 	}`)
-	result, err := handler.Handle(ctx, params)
+	result, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.Nil(t, err)
 
 	resultMap := result.(map[string]any)
@@ -1144,7 +1153,7 @@ func TestSignFor_MissingAccount(t *testing.T) {
 		},
 		"secret": "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Contains(t, err.Message, "account")
 }
@@ -1160,7 +1169,7 @@ func TestSignFor_MissingTxJson(t *testing.T) {
 		"account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 		"secret": "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Contains(t, err.Message, "tx_json")
 }
@@ -1183,7 +1192,7 @@ func TestSignFor_MissingCredentials(t *testing.T) {
 			"Sequence": 1
 		}
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Contains(t, err.Message, "Missing field 'secret'.")
 }
@@ -1205,7 +1214,7 @@ func TestSignFor_InvalidAccountAddress(t *testing.T) {
 		},
 		"secret": "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	// rippled's transactionSignFor emits srcActMalformed with
 	// "Invalid field 'account'." for an unparseable signer account.
@@ -1228,7 +1237,7 @@ func TestSignFor_InvalidAccountPrecedesMissingTxJson(t *testing.T) {
 		"account": "invalid_address",
 		"secret": "sn3nxiW7v8KXzPzAqzyHXbSSKNuN9"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	assert.Equal(t, types.RpcSRC_ACT_MALFORMED, err.Code)
 	assert.Equal(t, "srcActMalformed", err.ErrorString)
@@ -1253,7 +1262,7 @@ func TestSignFor_InvalidKeyType(t *testing.T) {
 		"seed_hex": "DEDCE9CE67B451D852FD4E846FCDE31C",
 		"key_type": "invalid"
 	}`)
-	_, err := handler.Handle(ctx, params)
+	_, err := handler.Handle(signingEnabledContext(ctx), params)
 	require.NotNil(t, err)
 	// API v1: rippled returns invalidParams for bad key_type
 	// API v2+: returns RpcBAD_KEY_TYPE
@@ -1292,7 +1301,7 @@ func TestSignFor_ValidMultiSign(t *testing.T) {
 	}
 	paramsJSON, _ := json.Marshal(paramsMap)
 
-	result, err := handler.Handle(ctx, paramsJSON)
+	result, err := handler.Handle(signingEnabledContext(ctx), paramsJSON)
 	require.Nil(t, err, "sign_for should succeed: %v", err)
 	require.NotNil(t, result)
 

--- a/internal/rpc/types/errors.go
+++ b/internal/rpc/types/errors.go
@@ -618,6 +618,18 @@ func RpcErrorSrcActMalformed(message string) *RpcError {
 	return NewRpcError(RpcSRC_ACT_MALFORMED, "srcActMalformed", "srcActMalformed", message)
 }
 
+func RpcErrorMasterDisabled() *RpcError {
+	return NewRpcError(RpcMASTER_DISABLED, "masterDisabled", "masterDisabled", "Master key is disabled.")
+}
+
+func RpcErrorBadSecret() *RpcError {
+	return NewRpcError(RpcBAD_SECRET, "badSecret", "badSecret", "Secret does not match account.")
+}
+
+func RpcErrorDelegateActNotFound() *RpcError {
+	return NewRpcError(RpcDELEGATE_ACT_NOT_FOUND, "delegateActNotFound", "delegateActNotFound", "Delegate account not found.")
+}
+
 // RpcErrorNotImpl returns an error for unimplemented features
 // (matches rippled rpcNOT_IMPL, code 74, token "notImpl").
 func RpcErrorNotImpl() *RpcError {


### PR DESCRIPTION
## Summary
- Enforce the default-off signing boundary and exact deprecation envelopes.
- Authorize master, RegularKey, and delegated signing keys against ledger state.

## Verification
- Signing authorization and full RPC tests
- Targeted race, vet, strict lint, build, and oracle review

Refs #1486

Stack layer 2 of 16; depends on #1567.