### PR TITLE
fix: centralize RPC transaction preprocessing (#1486)

### DIFF
--- a/internal/rpc/adapter/adapter_contract_test.go
+++ b/internal/rpc/adapter/adapter_contract_test.go
@@ -23,3 +23,16 @@ func TestAdapterLedgerSelectionPropagatesStorageErrors(t *testing.T) {
 	_, err = adapter.GetLedgerByHashContext(context.Background(), [32]byte{2})
 	require.Error(t, err)
 }
+
+func TestAdapterOpenLedgerViewReturnsSnapshot(t *testing.T) {
+	svc, err := service.New(service.Config{Standalone: true, GenesisConfig: genesis.DefaultConfig()})
+	require.NoError(t, err)
+	require.NoError(t, svc.Start())
+	t.Cleanup(svc.Stop)
+
+	view, err := NewLedgerServiceAdapter(svc).GetOpenLedgerView()
+	require.NoError(t, err)
+	require.NotNil(t, view)
+	require.NotNil(t, view.Rules())
+	require.NotZero(t, view.LedgerSeq())
+}

--- a/internal/rpc/adapter/core.go
+++ b/internal/rpc/adapter/core.go
@@ -25,6 +25,7 @@ var _ types.RangedTransactionLookup = (*LedgerServiceAdapter)(nil)
 var _ types.TransactionSearcher = (*LedgerServiceAdapter)(nil)
 var _ types.LedgerContextReader = (*LedgerServiceAdapter)(nil)
 var _ types.LedgerViewSource = (*LedgerServiceAdapter)(nil)
+var _ types.OpenLedgerViewSource = (*LedgerServiceAdapter)(nil)
 var _ types.TransactionRulesSource = (*LedgerServiceAdapter)(nil)
 
 // NewLedgerServiceAdapter creates a new adapter

--- a/internal/rpc/adapter/ledger.go
+++ b/internal/rpc/adapter/ledger.go
@@ -142,6 +142,19 @@ func (a *LedgerServiceAdapter) GetClosedLedgerView() (types.LedgerStateView, err
 	return l, nil
 }
 
+// GetOpenLedgerView returns an immutable snapshot of the current open ledger.
+func (a *LedgerServiceAdapter) GetOpenLedgerView() (types.LedgerStateView, error) {
+	l := a.svc.GetOpenLedger()
+	if l == nil {
+		return nil, fmt.Errorf("no open ledger available")
+	}
+	snapshot, err := l.Snapshot()
+	if err != nil {
+		return nil, err
+	}
+	return snapshot, nil
+}
+
 // GetLedgerViewBySeq returns a state view of the ledger with the given
 // sequence, plus its metadata reader.
 func (a *LedgerServiceAdapter) GetLedgerViewBySeq(seq uint32) (types.LedgerStateView, types.LedgerReader, error) {

--- a/internal/rpc/handlers/sign_for.go
+++ b/internal/rpc/handlers/sign_for.go
@@ -2,20 +2,18 @@ package handlers
 
 import (
 	"bytes"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
-	"reflect"
 	"sort"
-	"strings"
+	"strconv"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
-	"github.com/LeJamon/go-xrpl/crypto/ed25519"
-	"github.com/LeJamon/go-xrpl/crypto/secp256k1"
-	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 )
 
 // SignForMethod handles the sign_for RPC method
@@ -58,8 +56,14 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (r
 
 	signatureTargetPresent := jsonFieldPresent(params, "signature_target")
 	var txMap map[string]any
-	if err := json.Unmarshal(request.TxJson, &txMap); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(request.TxJson))
+	decoder.UseNumber()
+	if err := decoder.Decode(&txMap); err != nil {
 		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid tx_json: %v", err))
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, types.RpcErrorInvalidParams("Invalid tx_json: expected object")
 	}
 	if txMap == nil {
 		return nil, types.RpcErrorExpectedField("tx_json", "object")
@@ -75,8 +79,7 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (r
 			if !ok {
 				return nil, types.RpcErrorMissingField("tx_json.NetworkID")
 			}
-			n, ok := v.(float64)
-			if !ok || n != math.Trunc(n) || n < 0 || uint32(n) != networkID {
+			if n, ok := integralNetworkID(v); !ok || n != networkID {
 				return nil, types.RpcErrorInvalidField("tx_json.NetworkID")
 			}
 		}
@@ -98,7 +101,7 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (r
 		}
 	}
 
-	privateKey, publicKey, keyType, rpcErr := request.signCredentials.deriveKeypair(ctx.ApiVersion, params)
+	privateKey, publicKey, _, rpcErr := request.signCredentials.deriveKeypair(ctx.ApiVersion, params)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
@@ -121,20 +124,23 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (r
 		return nil, rpcErrorAlreadySingleSigned()
 	}
 
-	// sigContainer holds the Signers array the new signature is appended to:
-	// the transaction itself, or the nested CounterpartySignature object.
-	sigContainer := txMap
 	if signatureTargetPresent {
 		nested, targetErr := signatureTargetObject(txMap, request.SignatureTarget)
 		if targetErr != nil {
 			return nil, targetErr
 		}
 		nested["SigningPubKey"] = ""
-		sigContainer = nested
 	}
-	transaction, rpcErr := parseTransactionForSigning(txMap)
+	transaction, rpcErr := preprocessTransaction(txMap, transactionPreprocessOptions{
+		mode:            transactionPreprocessSignFor,
+		preserveSigners: true,
+	})
 	if rpcErr != nil {
 		return nil, rpcErr
+	}
+	feePayer := transaction.GetCommon().Account
+	if transaction.GetCommon().Delegate != "" {
+		feePayer = transaction.GetCommon().Delegate
 	}
 	derivedAccount, derivationErr := addresscodec.EncodeClassicAddressFromPublicKeyHex(publicKey)
 	if derivationErr != nil {
@@ -144,68 +150,99 @@ func (m *SignForMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (r
 		return nil, rpcErr
 	}
 
-	signers := make([]map[string]any, 0, 1)
-	if existing, ok := sigContainer["Signers"]; ok {
-		var signerErr *types.RpcError
-		signers, signerErr = signerMaps(existing)
-		if signerErr != nil {
-			return nil, signerErr
-		}
-	}
-
-	txMapForSigning := make(map[string]any)
-	for k, v := range txMap {
-		if k != "Signers" {
-			txMapForSigning[k] = v
-		}
-	}
-
-	// Encode for multisigning (adds the signer's account as suffix)
-	var signingPayload string
-	var err error
+	common := transaction.GetCommon()
+	signers := common.Signers
 	if signatureTargetPresent {
-		signingPayload, err = binarycodec.EncodeForMultisigningTarget(txMapForSigning, request.Account)
-	} else {
-		signingPayload, err = binarycodec.EncodeForMultisigning(txMapForSigning, request.Account)
+		if common.CounterpartySignature == nil {
+			return nil, types.RpcErrorInvalidParams("Invalid field 'tx_json.CounterpartySignature'.")
+		}
+		signers = common.CounterpartySignature.Signers
 	}
-	if err != nil {
-		return nil, rpcInternalError("sign_for: multisigning payload encoding failed", err)
-	}
-
-	// Sign the payload
-	signature, err := signPayload(signingPayload, privateKey, keyType)
-	if err != nil {
-		return nil, rpcInternalError("sign_for: transaction signing failed", err)
-	}
-
-	newSigner := map[string]any{
-		"Signer": map[string]any{
-			"Account":       request.Account,
-			"SigningPubKey": publicKey,
-			"TxnSignature":  signature,
-		},
-	}
-
-	signers = append(signers, newSigner)
-	feePayer := transaction.GetCommon().Account
-	if transaction.GetCommon().Delegate != "" {
-		feePayer = transaction.GetCommon().Delegate
-	}
-	if signerErr := sortAndValidateSignerMaps(signers, feePayer); signerErr != nil {
+	canonicalSigners, signerErr := normalizeTypedSigners(signers, feePayer)
+	if signerErr != nil {
 		return nil, signerErr
 	}
 
-	sigContainer["Signers"] = signers
+	// Sign the canonical transaction representation. The signature target only
+	// changes the multisigning preimage; the parsed transaction remains the
+	// object that receives the new signer and is flattened below.
+	var signature string
+	var err error
+	if signatureTargetPresent {
+		signature, err = sign.SignTransactionForMultiSignTarget(transaction, request.Account, privateKey)
+	} else {
+		signature, err = sign.SignTransactionForMultiSign(transaction, request.Account, privateKey)
+	}
+	if err != nil {
+		return nil, rpcInternalError("sign_for: multisigning payload signing failed", err)
+	}
 
-	txBlob, err := binarycodec.Encode(txMap)
+	canonicalAccount, accountErr := canonicalAccountID(request.Account)
+	if accountErr != nil {
+		return nil, types.RpcErrorInvalidParams("Invalid field 'account'.")
+	}
+	canonicalSigners = append(canonicalSigners, tx.SignerWrapper{Signer: tx.Signer{
+		Account:       canonicalAccount,
+		SigningPubKey: publicKey,
+		TxnSignature:  signature,
+	}})
+	canonicalSigners, signerErr = normalizeTypedSigners(canonicalSigners, feePayer)
+	if signerErr != nil {
+		return nil, signerErr
+	}
+
+	if signatureTargetPresent {
+		common.CounterpartySignature.Signers = canonicalSigners
+	} else {
+		common.Signers = canonicalSigners
+	}
+
+	canonicalMap, err := flattenCanonicalTransaction(transaction, txMap)
+	if err != nil {
+		return nil, rpcInternalError("sign_for: transaction flattening failed", err)
+	}
+	normalizeSignerResponseContainers(canonicalMap)
+	txBlob, err := binarycodec.Encode(canonicalMap)
 	if err != nil {
 		return nil, rpcInternalError("sign_for: transaction encoding failed", err)
 	}
 
 	txHash := CalculateTxHash(txBlob)
-	txMap["hash"] = txHash
+	canonicalMap["hash"] = txHash
 
-	return formatSignResult(signResult{TxMap: txMap, TxBlob: txBlob}, ctx.ApiVersion), nil
+	return formatSignResult(signResult{TxMap: canonicalMap, TxBlob: txBlob}, ctx.ApiVersion), nil
+}
+
+func integralNetworkID(value any) (uint32, bool) {
+	switch number := value.(type) {
+	case json.Number:
+		parsed, err := strconv.ParseUint(string(number), 10, 32)
+		return uint32(parsed), err == nil
+	case float64:
+		if number < 0 || number > math.MaxUint32 || number != math.Trunc(number) {
+			return 0, false
+		}
+		return uint32(number), true
+	case uint32:
+		return number, true
+	case uint64:
+		if number > math.MaxUint32 {
+			return 0, false
+		}
+		return uint32(number), true
+	case int:
+		if number < 0 {
+			return 0, false
+		}
+		return uint32(number), uint64(number) <= math.MaxUint32
+	case int64:
+		if number < 0 || uint64(number) > math.MaxUint32 {
+			return 0, false
+		}
+		return uint32(number), true
+	default:
+		return 0, false
+	}
 }
 
 func validateSignForPreConflict(txMap map[string]any, params json.RawMessage) *types.RpcError {
@@ -216,45 +253,7 @@ func validateSignForPreConflict(txMap map[string]any, params json.RawMessage) *t
 	if transactionType != "Payment" {
 		return nil
 	}
-
-	if deliverMax, ok := txMap["DeliverMax"]; ok {
-		if amount, present := txMap["Amount"]; present && !reflect.DeepEqual(amount, deliverMax) {
-			return types.RpcErrorInvalidParams("Cannot specify differing 'Amount' and 'DeliverMax'")
-		}
-		if _, present := txMap["Amount"]; !present {
-			txMap["Amount"] = deliverMax
-		}
-		delete(txMap, "DeliverMax")
-	}
-	amount, ok := txMap["Amount"]
-	if !ok {
-		return types.RpcErrorMissingField("tx_json.Amount")
-	}
-	encodedAmount, err := json.Marshal(amount)
-	if err != nil {
-		return types.RpcErrorInvalidField("tx_json.Amount")
-	}
-	if _, err := state.AmountFromJSON(encodedAmount); err != nil {
-		return types.RpcErrorInvalidField("tx_json.Amount")
-	}
-	destination, ok := txMap["Destination"].(string)
-	if !ok || !addresscodec.IsValidClassicAddress(destination) {
-		if _, present := txMap["Destination"]; !present {
-			return types.RpcErrorMissingField("tx_json.Destination")
-		}
-		return types.RpcErrorInvalidField("tx_json.Destination")
-	}
-	if jsonFieldPresent(params, "build_path") {
-		return types.RpcErrorInvalidParams("Field 'build_path' not allowed in this context.")
-	}
-	if domain, ok := txMap["DomainID"]; ok {
-		domainString, ok := domain.(string)
-		decoded, err := hex.DecodeString(domainString)
-		if !ok || err != nil || len(decoded) != 32 {
-			return types.RpcErrorDomainMalformed("Unable to parse 'DomainID'.")
-		}
-	}
-	return nil
+	return checkPayment(txMap, params, false, nil)
 }
 
 func validateSigningTxJSONShape(txMap map[string]any) *types.RpcError {
@@ -271,46 +270,56 @@ func validateSigningTxJSONShape(txMap map[string]any) *types.RpcError {
 	return nil
 }
 
-func signerMaps(value any) ([]map[string]any, *types.RpcError) {
+func normalizeSigners(value any, feePayer string) ([]map[string]any, *types.RpcError) {
+	const malformedSigners = "Signers array may only contain Signer entries."
+
+	var values []any
 	switch signers := value.(type) {
 	case []any:
-		result := make([]map[string]any, 0, len(signers))
-		for _, value := range signers {
-			signer, ok := value.(map[string]any)
-			if !ok {
-				return nil, types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
-			}
-			result = append(result, signer)
-		}
-		return result, nil
+		values = signers
 	case []map[string]any:
-		return append([]map[string]any(nil), signers...), nil
+		values = make([]any, len(signers))
+		for i := range signers {
+			values[i] = signers[i]
+		}
 	default:
-		return nil, types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
+		return nil, types.RpcErrorInvalidParams(malformedSigners)
 	}
-}
 
-func sortAndValidateSignerMaps(signers []map[string]any, feePayer string) *types.RpcError {
 	type signerEntry struct {
 		wrapper map[string]any
 		account string
 		id      []byte
 	}
-	entries := make([]signerEntry, 0, len(signers))
-	for _, wrapper := range signers {
+	entries := make([]signerEntry, 0, len(values))
+	for _, value := range values {
+		wrapper, ok := value.(map[string]any)
+		if !ok || len(wrapper) != 1 {
+			return nil, types.RpcErrorInvalidParams(malformedSigners)
+		}
 		signer, ok := wrapper["Signer"].(map[string]any)
-		if !ok {
-			return types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
+		if !ok || len(signer) != 3 {
+			return nil, types.RpcErrorInvalidParams(malformedSigners)
+		}
+		for _, field := range []string{"Account", "SigningPubKey", "TxnSignature"} {
+			if _, ok := signer[field].(string); !ok {
+				return nil, types.RpcErrorInvalidParams(malformedSigners)
+			}
 		}
 		account, ok := signer["Account"].(string)
 		if !ok {
-			return types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
+			return nil, types.RpcErrorInvalidParams(malformedSigners)
 		}
-		_, id, err := addresscodec.DecodeClassicAddressToAccountID(account)
+		canonicalAccount, err := canonicalAccountID(account)
 		if err != nil {
-			return types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
+			return nil, types.RpcErrorInvalidParams(malformedSigners)
 		}
-		entries = append(entries, signerEntry{wrapper: wrapper, account: account, id: id})
+		_, id, err := addresscodec.DecodeClassicAddressToAccountID(canonicalAccount)
+		if err != nil {
+			return nil, types.RpcErrorInvalidParams(malformedSigners)
+		}
+		signer["Account"] = canonicalAccount
+		entries = append(entries, signerEntry{wrapper: wrapper, account: canonicalAccount, id: id})
 	}
 
 	sort.Slice(entries, func(i, j int) bool {
@@ -318,51 +327,53 @@ func sortAndValidateSignerMaps(signers []map[string]any, feePayer string) *types
 	})
 	for i := 1; i < len(entries); i++ {
 		if bytes.Equal(entries[i-1].id, entries[i].id) {
-			return types.RpcErrorInvalidParams(
+			return nil, types.RpcErrorInvalidParams(
 				"Duplicate Signers:Signer:Account entries (" + entries[i].account + ") are not allowed.")
 		}
 	}
 
-	_, feePayerID, err := addresscodec.DecodeClassicAddressToAccountID(feePayer)
+	canonicalFeePayer, err := canonicalAccountID(feePayer)
 	if err != nil {
-		return types.RpcErrorInvalidParams("Invalid field 'tx_json.Account'.")
+		return nil, types.RpcErrorInvalidParams("Invalid field 'tx_json.Account'.")
 	}
+	_, feePayerID, err := addresscodec.DecodeClassicAddressToAccountID(canonicalFeePayer)
+	if err != nil {
+		return nil, types.RpcErrorInvalidParams("Invalid field 'tx_json.Account'.")
+	}
+	result := make([]map[string]any, len(entries))
 	for i, entry := range entries {
 		if bytes.Equal(entry.id, feePayerID) {
-			return types.RpcErrorInvalidParams(
+			return nil, types.RpcErrorInvalidParams(
 				"A Signer may not be the transaction's Account (" + feePayer + ").")
 		}
-		signers[i] = entry.wrapper
+		result[i] = entry.wrapper
 	}
-	return nil
+	return result, nil
 }
 
-// signPayload signs a hex-encoded payload with the given private key
-func signPayload(payloadHex string, privateKeyHex string, keyType string) (string, error) {
-	// Decode the payload
-	payloadBytes, err := hex.DecodeString(payloadHex)
-	if err != nil {
-		return "", err
+func normalizeTypedSigners(signers []tx.SignerWrapper, feePayer string) ([]tx.SignerWrapper, *types.RpcError) {
+	value := make([]any, len(signers))
+	for i, signer := range signers {
+		value[i] = map[string]any{"Signer": map[string]any{
+			"Account":       signer.Signer.Account,
+			"SigningPubKey": signer.Signer.SigningPubKey,
+			"TxnSignature":  signer.Signer.TxnSignature,
+		}}
 	}
-
-	// Convert to string for crypto functions
-	payloadStr := string(payloadBytes)
-
-	var signature string
-
-	if keyType == "ed25519" {
-		algo := ed25519.Algorithm{}
-		signature, err = algo.Sign(payloadStr, privateKeyHex)
-	} else {
-		algo := secp256k1.Algorithm{}
-		signature, err = algo.Sign(payloadStr, privateKeyHex)
+	normalized, rpcErr := normalizeSigners(value, feePayer)
+	if rpcErr != nil {
+		return nil, rpcErr
 	}
-
-	if err != nil {
-		return "", err
+	result := make([]tx.SignerWrapper, len(normalized))
+	for i, wrapper := range normalized {
+		inner := wrapper["Signer"].(map[string]any)
+		result[i] = tx.SignerWrapper{Signer: tx.Signer{
+			Account:       inner["Account"].(string),
+			SigningPubKey: inner["SigningPubKey"].(string),
+			TxnSignature:  inner["TxnSignature"].(string),
+		}}
 	}
-
-	return strings.ToUpper(signature), nil
+	return result, nil
 }
 
 func (m *SignForMethod) RequiredRole() types.Role {

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -223,7 +223,6 @@ func jsonFieldPresent(params json.RawMessage, field string) bool {
 	return ok
 }
 
-// checkPayment validates and normalizes payment fields shared by signing and submission.
 func checkPayment(txMap map[string]any, params json.RawMessage, doPath bool, rpcCtx *types.RpcContext) *types.RpcError {
 	if txMap["TransactionType"] != "Payment" {
 		return nil

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -2,18 +2,23 @@ package handlers
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
+	"reflect"
 	"strconv"
 
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/rpc/txprojection"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/payment/pathfinder"
 	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 	"github.com/LeJamon/go-xrpl/ledger/entry"
 )
@@ -218,6 +223,176 @@ func jsonFieldPresent(params json.RawMessage, field string) bool {
 	return ok
 }
 
+// checkPayment validates and normalizes payment fields shared by signing and submission.
+func checkPayment(txMap map[string]any, params json.RawMessage, doPath bool, rpcCtx *types.RpcContext) *types.RpcError {
+	if txMap["TransactionType"] != "Payment" {
+		return nil
+	}
+
+	if deliverMax, ok := txMap["DeliverMax"]; ok {
+		if amount, present := txMap["Amount"]; present {
+			if !reflect.DeepEqual(amount, deliverMax) {
+				return types.RpcErrorInvalidParams(
+					"Cannot specify differing 'Amount' and 'DeliverMax'")
+			}
+		} else {
+			txMap["Amount"] = deliverMax
+		}
+		delete(txMap, "DeliverMax")
+	}
+
+	amountValue, ok := txMap["Amount"]
+	if !ok {
+		return types.RpcErrorMissingField("tx_json.Amount")
+	}
+	amountJSON, err := json.Marshal(amountValue)
+	if err != nil {
+		return types.RpcErrorInvalidField("tx_json.Amount")
+	}
+	amount, err := state.AmountFromJSON(amountJSON)
+	if err != nil {
+		return types.RpcErrorInvalidField("tx_json.Amount")
+	}
+
+	destinationValue, present := txMap["Destination"]
+	destination, destinationIsString := destinationValue.(string)
+	if !present {
+		return types.RpcErrorMissingField("tx_json.Destination")
+	}
+	if !destinationIsString || !addresscodec.IsValidClassicAddress(destination) {
+		return types.RpcErrorInvalidField("tx_json.Destination")
+	}
+
+	buildPath := jsonFieldPresent(params, "build_path")
+	if buildPath && !doPath {
+		return types.RpcErrorInvalidParams(
+			"Field 'build_path' not allowed in this context.")
+	}
+	if buildPath && amount.IsMPT() {
+		if rpcCtx == nil || rpcCtx.Services == nil || rpcCtx.Services.Ledger == nil {
+			return types.RpcErrorInvalidParams(
+				"Field 'build_path' not allowed in this context.")
+		}
+		rulesSource, ok := rpcCtx.Services.Ledger.(types.TransactionRulesSource)
+		if !ok {
+			return types.RpcErrorInvalidParams(
+				"Field 'build_path' not allowed in this context.")
+		}
+		rules := rulesSource.TransactionRules()
+		if rules == nil || !rules.MPTokensV2Enabled() {
+			return types.RpcErrorInvalidParams(
+				"Field 'build_path' not allowed in this context.")
+		}
+	}
+	_, pathsPresent := txMap["Paths"]
+	if buildPath && pathsPresent {
+		return types.RpcErrorInvalidParams(
+			"Cannot specify both 'tx_json.Paths' and 'build_path'")
+	}
+	var domainID *[32]byte
+	if domain, ok := txMap["DomainID"]; ok {
+		domainString, isString := domain.(string)
+		decoded, decodeErr := hex.DecodeString(domainString)
+		if !isString || decodeErr != nil || len(decoded) != 32 {
+			return types.RpcErrorDomainMalformed("Unable to parse 'DomainID'.")
+		}
+		var parsed [32]byte
+		copy(parsed[:], decoded)
+		domainID = &parsed
+	}
+	if buildPath {
+		var sendMax *state.Amount
+		if sendMaxValue, present := txMap["SendMax"]; present {
+			sendMaxJSON, marshalErr := json.Marshal(sendMaxValue)
+			if marshalErr != nil {
+				return types.RpcErrorInvalidField("tx_json.SendMax")
+			}
+			parsedSendMax, parseErr := state.AmountFromJSON(sendMaxJSON)
+			if parseErr != nil {
+				return types.RpcErrorInvalidField("tx_json.SendMax")
+			}
+			sendMax = &parsedSendMax
+			if parsedSendMax.IsNative() && amount.IsNative() {
+				return types.RpcErrorInvalidParams(
+					"Cannot build XRP to XRP paths.")
+			}
+		} else if amount.IsNative() {
+			// A missing SendMax defaults to Amount. This is only relevant to
+			// the native/native rejection; issued amounts remain pathable.
+			return types.RpcErrorInvalidParams(
+				"Cannot build XRP to XRP paths.")
+		}
+		if rpcCtx == nil || rpcCtx.Services == nil || rpcCtx.Services.Ledger == nil {
+			return rpcInternalInvariantError("payment: ledger service unavailable for path construction")
+		}
+		release, rpcErr := AcquirePathfind(rpcCtx)
+		if rpcErr != nil {
+			return rpcErr
+		}
+		defer release()
+		viewSource, ok := rpcCtx.Services.Ledger.(types.OpenLedgerViewSource)
+		if !ok {
+			return rpcInternalInvariantError("payment: open ledger view unavailable for path construction")
+		}
+		view, viewErr := viewSource.GetOpenLedgerView()
+		if viewErr != nil || view == nil {
+			if viewErr == nil {
+				viewErr = errors.New("open ledger view is nil")
+			}
+			return rpcInternalError("payment: open ledger view unavailable", viewErr)
+		}
+		source, sourceOK := txMap["Account"].(string)
+		if !sourceOK {
+			return rpcInternalInvariantError("payment: source account unavailable for path construction")
+		}
+		_, sourceID, sourceErr := addresscodec.DecodeClassicAddressToAccountID(source)
+		if sourceErr != nil {
+			return rpcInternalError("payment: source account decode failed", sourceErr)
+		}
+		_, destinationID, destinationErr := addresscodec.DecodeClassicAddressToAccountID(destination)
+		if destinationErr != nil {
+			return rpcInternalError("payment: destination account decode failed", destinationErr)
+		}
+		var sourceAccountID, destinationAccountID [20]byte
+		copy(sourceAccountID[:], sourceID)
+		copy(destinationAccountID[:], destinationID)
+		if sendMax == nil {
+			defaultSendMax := amount
+			if !defaultSendMax.IsNative() && !defaultSendMax.IsMPT() {
+				defaultSendMax.Issuer = source
+			}
+			sendMax = &defaultSendMax
+		}
+		request := pathfinder.NewPathRequest(sourceAccountID, destinationAccountID, amount, sendMax, nil, false)
+		request.SetDomainID(domainID)
+		pathResult := request.Execute(view)
+		if pathResult == nil {
+			return rpcInternalInvariantError("payment: path construction returned no result")
+		}
+		if pathResult.SourceCurrencyOverflow {
+			return rpcInternalInvariantError("payment: source currency limit exceeded")
+		}
+		if len(pathResult.Alternatives) == 0 {
+			return nil
+		}
+		paths := pathResult.Alternatives[0].PathsComputed
+		if len(paths) == 0 {
+			return nil
+		}
+		encodedPaths, marshalErr := json.Marshal(paths)
+		if marshalErr != nil {
+			return rpcInternalError("payment: path serialization failed", marshalErr)
+		}
+		var pathJSON []any
+		if unmarshalErr := json.Unmarshal(encodedPaths, &pathJSON); unmarshalErr != nil {
+			return rpcInternalError("payment: path serialization failed", unmarshalErr)
+		}
+		txMap["Paths"] = pathJSON
+	}
+
+	return nil
+}
+
 func rpcErrorAlreadyMultisigned() *types.RpcError {
 	return types.NewRpcError(
 		types.RpcALREADY_MULTISIG, "alreadyMultisig", "alreadyMultisig", "Already multisigned.")
@@ -268,8 +443,14 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 
 	// Parse the transaction JSON
 	var txMap map[string]any
-	if err := json.Unmarshal(txJSON, &txMap); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(txJSON))
+	decoder.UseNumber()
+	if err := decoder.Decode(&txMap); err != nil {
 		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid tx_json: %v", err))
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, types.RpcErrorInvalidParams("Invalid tx_json: expected object")
 	}
 	if txMap == nil {
 		return nil, types.RpcErrorExpectedField("tx_json", "object")
@@ -391,6 +572,9 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 			return nil, types.RpcErrorMissingField("tx_json.Fee")
 		}
 	}
+	if rpcErr := checkPayment(txMap, rawParams, !offline, rpcCtx); rpcErr != nil {
+		return nil, rpcErr
+	}
 	if _, ok := txMap["Signers"]; ok {
 		return nil, rpcErrorAlreadyMultisigned()
 	}
@@ -430,7 +614,7 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 		targetObj["SigningPubKey"] = publicKey
 	}
 
-	transaction, rpcErr := parseTransactionForSigning(txMap)
+	transaction, rpcErr := preprocessTransaction(txMap, transactionPreprocessOptions{mode: transactionPreprocessSign})
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
@@ -441,21 +625,29 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 	}
 
 	if !signatureTargetPresent {
-		txMap["TxnSignature"] = signature
+		transaction.GetCommon().TxnSignature = signature
 	} else {
-		targetObj["TxnSignature"] = signature
+		if transaction.GetCommon().CounterpartySignature == nil {
+			return nil, rpcInternalInvariantError("sign: counterparty signature target unavailable")
+		}
+		transaction.GetCommon().CounterpartySignature.TxnSignature = signature
 	}
 
-	txBlob, err := binarycodec.Encode(txMap)
+	canonicalMap, err := flattenCanonicalTransaction(transaction, txMap)
+	if err != nil {
+		return nil, rpcInternalError("sign: transaction flattening failed", err)
+	}
+	normalizeSignerResponseContainers(canonicalMap)
+	txBlob, err := binarycodec.Encode(canonicalMap)
 	if err != nil {
 		return nil, rpcInternalError("sign: transaction encoding failed", err)
 	}
 
 	txHash := CalculateTxHash(txBlob)
-	txMap["hash"] = txHash
+	canonicalMap["hash"] = txHash
 
 	return &signResult{
-		TxMap:  txMap,
+		TxMap:  canonicalMap,
 		TxBlob: txBlob,
 	}, nil
 }

--- a/internal/rpc/handlers/signing_load_admission_test.go
+++ b/internal/rpc/handlers/signing_load_admission_test.go
@@ -624,7 +624,6 @@ func TestSubmitMultisignedUsesCanonicalFieldParsingAfterAdmission(t *testing.T) 
 		for i, account := range accounts {
 			signers[i] = map[string]any{"Signer": map[string]any{
 				"Account":       account,
-				"hash":          strings.Repeat("0", 64),
 				"SigningPubKey": "",
 				"TxnSignature":  "",
 			}}
@@ -655,9 +654,6 @@ func TestSubmitMultisignedUsesCanonicalFieldParsingAfterAdmission(t *testing.T) 
 		previousID := []byte(nil)
 		for _, wrapped := range gotSigners {
 			signer := wrapped.(map[string]any)["Signer"].(map[string]any)
-			if _, ok := signer["hash"]; ok {
-				t.Fatal("submit_multisigned echoed discardable inner hash")
-			}
 			account := signer["Account"].(string)
 			_, accountID, err := addresscodec.DecodeClassicAddressToAccountID(account)
 			if err != nil {

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
-	binarycodecdefs "github.com/LeJamon/go-xrpl/codec/binarycodec/definitions"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/tx"
@@ -100,8 +99,6 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	if _, ok := txJsonMap["Account"]; !ok {
 		return nil, types.RpcErrorMissingField("tx.Account")
 	}
-	transactionType := txJsonMap["TransactionType"]
-
 	// rippled autofillTx() — Simulate.cpp:71-156. Steps run in the same
 	// order so rippled's error precedence is preserved:
 	//   1. Fee        (→ rpcHIGH_FEE)
@@ -198,53 +195,30 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		return nil, types.RpcErrorInvalidField("tx.Account")
 	}
 
-	// Reject Batch — rippled Simulate.cpp:345-348.
-	if txType, ok := txJsonMap["TransactionType"].(string); ok && txType == "Batch" {
+	// Parse and validate the canonical transaction once. The simulation mode
+	// preserves STTx's invalidTransaction error envelope while the shared
+	// preprocessor handles serialized-field normalization and array limits.
+	parsedTx, rpcErr := preprocessTransaction(txJsonMap, transactionPreprocessOptions{
+		mode: transactionPreprocessSimulate,
+	})
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	// Batch simulation is intentionally unsupported, but the type must be
+	// checked after the full serialized parse so malformed Batch JSON reports
+	// its structural error first and numeric TransactionType values are covered.
+	if parsedTx.TxType() == tx.TypeBatch {
 		return nil, types.RpcErrorNotImpl()
 	}
 
-	// STParsedJSONObject parity — unknown-field surface (rippled
-	// Simulate.cpp:328-330). Each top-level tx_json key must resolve to
-	// a known SField; otherwise rippled returns
-	// `error_message: "Field 'tx_json.<key>' is unknown."` from
-	// STParsedJSONObject. binarycodec.definitions.Get() carries the
-	// same registry rippled's STParsedJSONObject consults.
-	defs := binarycodecdefs.Get()
-	if parseMessage := serializedFieldParseMessage(txJsonMap, "tx_json", defs); parseMessage != "" {
-		return nil, types.RpcErrorInvalidParams(parseMessage)
+	canonicalMap, err := flattenCanonicalTransaction(parsedTx, txJsonMap)
+	if err != nil {
+		return nil, rpcInternalError("simulate: transaction flattening failed", err)
 	}
-	// STParsedJSONObject stores TransactionType as its UInt16 code, while the
-	// Go transaction registry selects concrete types by their JSON name.
-	txJsonMap["TransactionType"] = transactionType
-
-	// STParsedJSONObject also caps each JSON array field at MaxJSONArrayElements
-	// (rippled maxSTParsedJSONArraySize); surface an overflow as invalidParams
-	// before the transaction is parsed and simulated. Other encode failures are
-	// left to the parse/validate path below.
-	if _, encErr := binarycodec.Encode(txJsonMap); encErr != nil {
-		if e := arraySizeRpcError(encErr); e != nil {
-			return nil, e
-		}
-	}
-
-	// Marshal tx_json for parse + service call.
-	txJSON, err := json.Marshal(txJsonMap)
+	// Marshal the canonical transaction for the ledger service call.
+	txJSON, err := json.Marshal(canonicalMap)
 	if err != nil {
 		return nil, rpcInternalError("simulate: transaction marshaling failed", err)
-	}
-
-	// STTx ctor parity — rippled Simulate.cpp:332-343. A parse failure or
-	// missing-required-field surface as
-	// `error: "invalidTransaction"` + `error_exception: <reason>`
-	// instead of flowing into the engine as a TER. This early structural
-	// validation guarantees the error envelope shape matches rippled even
-	// when type-specific engine preflight is rules-aware.
-	parsedTx, parseErr := tx.ParseJSON(txJSON)
-	if parseErr != nil {
-		return nil, types.RpcErrorInvalidTransaction(parseErr.Error())
-	}
-	if templateErr := tx.ValidateTemplateFields(parsedTx.TxType(), txJsonMap); templateErr != nil {
-		return nil, types.RpcErrorInvalidTransaction(templateErr.Error())
 	}
 
 	result, err := ctx.Services.Ledger.SimulateTransaction(txJSON)
@@ -276,7 +250,7 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		if binaryOutput {
 			response["meta_blob"] = strings.ToUpper(hex.EncodeToString(result.Metadata.Blob))
 		} else if metaMap := metadataToMap(result.Metadata.JSON); metaMap != nil {
-			enrichSimulateMeta(metaMap, txJsonMap, SyntheticMetadataContext{
+			enrichSimulateMeta(metaMap, canonicalMap, SyntheticMetadataContext{
 				LedgerSequence: result.CurrentLedger,
 				CloseTime:      result.CurrentLedgerCloseTime,
 			})
@@ -287,11 +261,11 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	}
 
 	if binaryOutput {
-		if encoded, err := binarycodec.Encode(txJsonMap); err == nil {
+		if encoded, err := binarycodec.Encode(canonicalMap); err == nil {
 			response["tx_blob"] = encoded
 		}
 	} else {
-		response["tx_json"] = txJsonMap
+		response["tx_json"] = canonicalMap
 	}
 
 	return response, nil

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -215,7 +215,6 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	if err != nil {
 		return nil, rpcInternalError("simulate: transaction flattening failed", err)
 	}
-	// Marshal the canonical transaction for the ledger service call.
 	txJSON, err := json.Marshal(canonicalMap)
 	if err != nil {
 		return nil, rpcInternalError("simulate: transaction marshaling failed", err)

--- a/internal/rpc/handlers/stparsed.go
+++ b/internal/rpc/handlers/stparsed.go
@@ -56,6 +56,11 @@ func serializedFieldParseMessage(value any, path string, defs *binarycodecdefs.D
 			if !ok {
 				return fmt.Sprintf("Field '%s' is not a JSON array.", fieldPath)
 			}
+			if len(items) > binarycodectypes.MaxJSONArrayElements {
+				return fmt.Sprintf(
+					"Field '%s' exceeds allowed JSON array size of %d elements per field.",
+					fieldPath, binarycodectypes.MaxJSONArrayElements)
+			}
 			for i, item := range items {
 				itemObject, ok := item.(map[string]any)
 				if !ok || len(itemObject) != 1 {

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -8,10 +8,9 @@ import (
 	"strconv"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
-	binarycodecdefs "github.com/LeJamon/go-xrpl/codec/binarycodec/definitions"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
+	"github.com/LeJamon/go-xrpl/internal/ledger/state"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
-	"github.com/LeJamon/go-xrpl/internal/tx"
 )
 
 // SubmitMultisignedMethod handles the submit_multisigned RPC method
@@ -91,39 +90,20 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	if rpcErr := validateSignForPreConflict(txMap, params); rpcErr != nil {
 		return nil, rpcErr
 	}
-
-	definitions := binarycodecdefs.Get()
-	if parseMessage := serializedFieldParseMessage(txMap, "tx_json", definitions); parseMessage != "" {
-		return nil, types.RpcErrorInvalidParams(parseMessage)
+	if feeString, ok := txMap["Fee"].(string); ok {
+		feeJSON, marshalErr := json.Marshal(feeString)
+		feeAmount, parseErr := state.AmountFromJSON(feeJSON)
+		if marshalErr == nil && parseErr == nil && !feeAmount.IsNative() {
+			return nil, types.RpcErrorInvalidParams("Invalid Fee field.  Fees must be specified in XRP.")
+		}
 	}
-	transactionTypeCode, ok := txMap["TransactionType"].(uint16)
-	if !ok {
-		return nil, types.RpcErrorInvalidParams("Field 'tx_json.TransactionType' has invalid data.")
-	}
-	transactionTypeName, err := definitions.TransactionTypeName(int32(transactionTypeCode))
-	if err != nil {
-		return nil, types.RpcErrorInvalidTransactionType(transactionTypeCode)
-	}
-	txMap["TransactionType"] = transactionTypeName
-	transactionType, _ := tx.TypeFromName(transactionTypeName)
-	if err := tx.ValidateTemplateFields(transactionType, txMap); err != nil {
-		return nil, types.RpcErrorInvalidParams(err.Error())
-	}
-	if reason := tx.TransactionMapLocalChecksFailureReason(transactionType, txMap); reason != "" {
-		return nil, types.RpcErrorInvalidParams(reason)
-	}
-	if _, ok := txMap["Fee"].(string); !ok {
-		return nil, types.RpcErrorInvalidParams("Invalid Fee field.  Fees must be specified in XRP.")
-	}
-	_, rpcErr := parseTransactionForSigning(txMap)
+	transaction, rpcErr := preprocessTransaction(txMap, transactionPreprocessOptions{
+		mode:               transactionPreprocessSubmitMultisigned,
+		preserveSigners:    true,
+		rejectTxnSignature: true,
+	})
 	if rpcErr != nil {
 		return nil, rpcErr
-	}
-
-	// TxnSignature must NOT be present on a multi-signed transaction.
-	// Matches rippled: rpcError(rpcSIGNING_MALFORMED) -> code 63, "signingMalformed"
-	if _, ok := txMap["TxnSignature"]; ok {
-		return nil, types.RpcErrorSigningMalformed()
 	}
 
 	// Matches rippled: "Invalid Fee field.  Fees must be specified in XRP." /
@@ -147,27 +127,29 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, types.RpcErrorMissingField("tx_json.Signers")
 	}
 	signers, ok := signersValue.([]any)
-	if !ok || len(signers) == 0 {
+	if ok && len(signers) == 0 {
 		return nil, types.RpcErrorInvalidParams("tx_json.Signers array may not be empty.")
 	}
+	if _, ok := txMap["Fee"].(string); !ok {
+		return nil, types.RpcErrorInvalidParams("Invalid Fee field.  Fees must be specified in XRP.")
+	}
 
-	signerMapList, rpcErr := signerMaps(signers)
+	feePayer := transaction.GetCommon().Account
+	if delegate := transaction.GetCommon().Delegate; delegate != "" {
+		feePayer = delegate
+	}
+	normalizedSigners, rpcErr := normalizeTypedSigners(transaction.GetCommon().Signers, feePayer)
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
-	feePayer := txAccount
-	if delegate, ok := txMap["Delegate"].(string); ok {
-		feePayer = delegate
-	}
-	if rpcErr := sortAndValidateSignerMaps(signerMapList, feePayer); rpcErr != nil {
-		return nil, rpcErr
-	}
-	for i := range signerMapList {
-		signers[i] = signerMapList[i]
-	}
+	transaction.GetCommon().Signers = normalizedSigners
 
+	canonicalMap, encErr := flattenCanonicalTransaction(transaction, txMap)
+	if encErr != nil {
+		return nil, rpcInternalError("submit_multisigned: transaction flattening failed", encErr)
+	}
 	// Encode the transaction to binary
-	txBlob, encErr := binarycodec.Encode(txMap)
+	txBlob, encErr := binarycodec.Encode(canonicalMap)
 	if encErr != nil {
 		return nil, rpcInternalError("submit_multisigned: transaction encoding failed", encErr)
 	}
@@ -176,7 +158,7 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 	txHash := CalculateTxHash(txBlob)
 
 	// Submit the transaction
-	txJSON, encErr := json.Marshal(txMap)
+	txJSON, encErr := json.Marshal(canonicalMap)
 	if encErr != nil {
 		return nil, rpcInternalError("submit_multisigned: transaction marshaling failed", encErr)
 	}
@@ -189,14 +171,14 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, rpcTransactionSubmissionError("submit_multisigned: transaction submission failed", submitErr)
 	}
 
-	txMap["hash"] = txHash
+	canonicalMap["hash"] = txHash
 
 	response := map[string]any{
 		"engine_result":         result.EngineResult,
 		"engine_result_code":    result.EngineResultCode,
 		"engine_result_message": result.EngineResultMessage,
 		"tx_blob":               txBlob,
-		"tx_json":               txMap,
+		"tx_json":               canonicalMap,
 	}
 
 	if result.Applied {

--- a/internal/rpc/handlers/transaction_preprocess.go
+++ b/internal/rpc/handlers/transaction_preprocess.go
@@ -1,0 +1,341 @@
+package handlers
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"math"
+	"strings"
+
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	binarycodecdefs "github.com/LeJamon/go-xrpl/codec/binarycodec/definitions"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+type transactionPreprocessMode uint8
+
+const (
+	transactionPreprocessSign transactionPreprocessMode = iota
+	transactionPreprocessSignFor
+	transactionPreprocessSubmitMultisigned
+	transactionPreprocessSimulate
+)
+
+type transactionPreprocessOptions struct {
+	mode               transactionPreprocessMode
+	preserveSigners    bool
+	rejectTxnSignature bool
+}
+
+// preprocessTransaction performs the serialized-field validation and returns
+// the parsed transaction that the caller subsequently mutates. Callers must
+// flatten the object after mutation; the parser's raw bytes are retained only
+// for signing preimages and are never used for the final response/submit blob.
+func preprocessTransaction(
+	txMap map[string]any,
+	options transactionPreprocessOptions,
+) (tx.Transaction, *types.RpcError) {
+	var rawSigners any
+	strictSignerError := false
+	if options.preserveSigners {
+		if value, ok := txMap["Signers"]; ok {
+			rawSigners = cloneJSONValue(value)
+		}
+	}
+
+	if message := serializedFieldParseMessage(txMap, "tx_json", binarycodecdefs.Get()); message != "" {
+		if options.preserveSigners && signerShapeMessage(message) {
+			return nil, types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
+		}
+		return nil, types.RpcErrorInvalidParams(message)
+	}
+	if options.preserveSigners && rawSigners != nil {
+		strictSignerError = strictSignerExtra(rawSigners)
+	}
+	if rpcErr := canonicalizeAccountFields(txMap); rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	transactionTypeCode, rpcErr := parseTransactionTypeCode(txMap["TransactionType"])
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+	transactionTypeName, err := binarycodecdefs.Get().TransactionTypeName(int32(transactionTypeCode))
+	if err != nil {
+		return nil, types.RpcErrorInvalidTransactionType(transactionTypeCode)
+	}
+	txMap["TransactionType"] = transactionTypeName
+	txType, _ := tx.TypeFromName(transactionTypeName)
+
+	if err := tx.ValidateTemplateFields(txType, txMap); err != nil {
+		if options.mode == transactionPreprocessSimulate {
+			return nil, types.RpcErrorInvalidTransaction(err.Error())
+		}
+		return nil, types.RpcErrorInvalidParams(err.Error())
+	}
+	if options.mode != transactionPreprocessSimulate {
+		if reason := tx.TransactionMapLocalChecksFailureReason(txType, txMap); reason != "" {
+			return nil, types.RpcErrorInvalidParams(reason)
+		}
+	}
+
+	transaction, rpcErr := parseTransactionForSigning(txMap)
+	if rpcErr != nil {
+		if options.mode == transactionPreprocessSimulate {
+			return nil, types.RpcErrorInvalidTransaction(rpcErr.Message)
+		}
+		return nil, rpcErr
+	}
+	if options.rejectTxnSignature {
+		if _, present := txMap["TxnSignature"]; present {
+			return nil, types.RpcErrorSigningMalformed()
+		}
+	}
+	if strictSignerError {
+		return nil, types.RpcErrorInvalidParams("Signers array may only contain Signer entries.")
+	}
+	return transaction, nil
+}
+
+func parseTransactionTypeCode(value any) (uint16, *types.RpcError) {
+	switch value := value.(type) {
+	case string:
+		code, err := binarycodecdefs.Get().TransactionTypeCode(value)
+		if err != nil {
+			return 0, types.RpcErrorInvalidParams("Field 'tx_json.TransactionType' has invalid data.")
+		}
+		return uint16(code), nil
+	case uint16:
+		return value, nil
+	case uint8:
+		return uint16(value), nil
+	case uint32:
+		if value > math.MaxUint16 {
+			return 0, types.RpcErrorInvalidParams("Field 'tx_json.TransactionType' has invalid data.")
+		}
+		return uint16(value), nil
+	case int:
+		if value < 0 || value > math.MaxUint16 {
+			return 0, types.RpcErrorInvalidParams("Field 'tx_json.TransactionType' has invalid data.")
+		}
+		return uint16(value), nil
+	case int64:
+		if value < 0 || value > math.MaxUint16 {
+			return 0, types.RpcErrorInvalidParams("Field 'tx_json.TransactionType' has invalid data.")
+		}
+		return uint16(value), nil
+	case float64:
+		if value < 0 || value > math.MaxUint16 || value != math.Trunc(value) {
+			return 0, types.RpcErrorInvalidParams("Field 'tx_json.TransactionType' has invalid data.")
+		}
+		return uint16(value), nil
+	case json.Number:
+		parsed, err := value.Int64()
+		if err != nil || parsed < 0 || parsed > math.MaxUint16 {
+			return 0, types.RpcErrorInvalidParams("Field 'tx_json.TransactionType' has invalid data.")
+		}
+		return uint16(parsed), nil
+	default:
+		return 0, types.RpcErrorInvalidParams("Field 'tx_json.TransactionType' has invalid data.")
+	}
+}
+
+func cloneJSONValue(value any) any {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return value
+	}
+	var clone any
+	if err := json.Unmarshal(encoded, &clone); err != nil {
+		return value
+	}
+	return clone
+}
+
+func signerShapeMessage(message string) bool {
+	return strings.Contains(message, "tx_json.Signers.") && strings.Contains(message, ".Signer.") &&
+		(strings.Contains(message, "unknown.") || strings.Contains(message, "disallowed location."))
+}
+
+func strictSignerExtra(value any) bool {
+	items, ok := value.([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range items {
+		wrapper, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		inner, ok := wrapper["Signer"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if len(wrapper) != 1 || len(inner) != 3 {
+			return true
+		}
+		if _, ok := inner["Account"]; !ok {
+			continue
+		}
+		if _, ok := inner["SigningPubKey"]; !ok {
+			continue
+		}
+		if _, ok := inner["TxnSignature"]; !ok {
+			continue
+		}
+	}
+	return false
+}
+
+func canonicalizeAccountFields(value any) *types.RpcError {
+	switch value := value.(type) {
+	case map[string]any:
+		for field, child := range value {
+			if field == "Account" || field == "Destination" || field == "Delegate" || field == "Issuer" {
+				if text, ok := child.(string); ok {
+					canonical, err := canonicalAccountID(text)
+					if err != nil {
+						continue
+					}
+					value[field] = canonical
+					continue
+				}
+			}
+			if rpcErr := canonicalizeAccountFields(child); rpcErr != nil {
+				return rpcErr
+			}
+		}
+	case []any:
+		for _, child := range value {
+			if rpcErr := canonicalizeAccountFields(child); rpcErr != nil {
+				return rpcErr
+			}
+		}
+	}
+	return nil
+}
+
+func canonicalAccountID(value string) (string, error) {
+	if _, _, err := addresscodec.DecodeClassicAddressToAccountID(value); err == nil {
+		return value, nil
+	}
+	if len(value) != 40 {
+		return "", addresscodec.ErrInvalidClassicAddress
+	}
+	decoded, err := hex.DecodeString(value)
+	if err != nil || len(decoded) != 20 {
+		return "", addresscodec.ErrInvalidClassicAddress
+	}
+	return addresscodec.EncodeAccountIDToClassicAddress(decoded)
+}
+
+func flattenCanonicalTransaction(transaction tx.Transaction, source map[string]any) (map[string]any, error) {
+	flat, err := transaction.Flatten()
+	if err != nil {
+		return nil, err
+	}
+	tx.PopulateRequiredWireFields(flat, transaction.GetCommon())
+	mergeExplicitEmptyFields(flat, source)
+	flat = normalizeJSONContainers(flat).(map[string]any)
+	return flat, nil
+}
+
+func normalizeJSONContainers(value any) any {
+	switch value := value.(type) {
+	case map[string]any:
+		for field, child := range value {
+			value[field] = normalizeJSONContainers(child)
+		}
+		return value
+	case []any:
+		for i, child := range value {
+			value[i] = normalizeJSONContainers(child)
+		}
+		return value
+	case []map[string]any:
+		result := make([]any, len(value))
+		for i, child := range value {
+			result[i] = normalizeJSONContainers(child)
+		}
+		return result
+	default:
+		return value
+	}
+}
+
+func normalizeSignerResponseContainers(transactionMap map[string]any) {
+	normalizeSignerResponseContainer(transactionMap)
+	if counterparty, ok := transactionMap["CounterpartySignature"].(map[string]any); ok {
+		normalizeSignerResponseContainer(counterparty)
+	}
+}
+
+func normalizeSignerResponseContainer(fields map[string]any) {
+	signers, ok := fields["Signers"].([]any)
+	if !ok {
+		return
+	}
+	result := make([]map[string]any, len(signers))
+	for i, signer := range signers {
+		wrapper, ok := signer.(map[string]any)
+		if !ok {
+			return
+		}
+		result[i] = wrapper
+	}
+	fields["Signers"] = result
+}
+
+func mergeExplicitEmptyFields(destination, source map[string]any) {
+	for field, sourceValue := range source {
+		destinationValue, present := destination[field]
+		if !present {
+			if isEmptyJSONValue(sourceValue) {
+				destination[field] = sourceValue
+			}
+			continue
+		}
+		mergeExplicitEmptyValue(destinationValue, sourceValue)
+	}
+}
+
+func mergeExplicitEmptyValue(destination, source any) {
+	sourceMap, sourceIsMap := source.(map[string]any)
+	if sourceIsMap {
+		if destinationMap, ok := destination.(map[string]any); ok {
+			mergeExplicitEmptyFields(destinationMap, sourceMap)
+		}
+		return
+	}
+	sourceSlice, sourceIsSlice := source.([]any)
+	if !sourceIsSlice {
+		return
+	}
+	switch destinationSlice := destination.(type) {
+	case []any:
+		for i := 0; i < len(sourceSlice) && i < len(destinationSlice); i++ {
+			mergeExplicitEmptyValue(destinationSlice[i], sourceSlice[i])
+		}
+	case []map[string]any:
+		for i := 0; i < len(sourceSlice) && i < len(destinationSlice); i++ {
+			if sourceMap, ok := sourceSlice[i].(map[string]any); ok {
+				mergeExplicitEmptyFields(destinationSlice[i], sourceMap)
+			}
+		}
+	}
+}
+
+func isEmptyJSONValue(value any) bool {
+	switch value := value.(type) {
+	case nil:
+		return true
+	case string:
+		return value == ""
+	case []any:
+		return len(value) == 0
+	case map[string]any:
+		return len(value) == 0
+	default:
+		return false
+	}
+}

--- a/internal/rpc/handlers/transaction_preprocess_test.go
+++ b/internal/rpc/handlers/transaction_preprocess_test.go
@@ -1,0 +1,286 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/amendment"
+	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	binarycodectypes "github.com/LeJamon/go-xrpl/codec/binarycodec/types"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+)
+
+func signerValue(account string) map[string]any {
+	return map[string]any{"Signer": map[string]any{
+		"Account":       account,
+		"SigningPubKey": "",
+		"TxnSignature":  "",
+	}}
+}
+
+func TestNormalizeSignersStrictAndLossless(t *testing.T) {
+	first := signerValue(loadAdmissionSigner)
+	second := signerValue(loadAdmissionSigningAccount)
+	_, firstID, _ := addresscodec.DecodeClassicAddressToAccountID(loadAdmissionSigner)
+	_, secondID, _ := addresscodec.DecodeClassicAddressToAccountID(loadAdmissionSigningAccount)
+	if bytes.Compare(firstID, secondID) < 0 {
+		first, second = second, first
+	}
+	valid := []any{first, second}
+	for _, test := range []struct {
+		name       string
+		value      any
+		feePayer   string
+		wantError  string
+		wantSorted bool
+	}{
+		{name: "non-array", value: map[string]any{}, feePayer: loadAdmissionAccount, wantError: "Signers array may only contain Signer entries."},
+		{name: "wrapper extra field", value: []any{map[string]any{"Signer": map[string]any{
+			"Account": loadAdmissionSigner, "SigningPubKey": "", "TxnSignature": "", "Extra": "x",
+		}, "Other": map[string]any{}}}, feePayer: loadAdmissionAccount, wantError: "Signers array may only contain Signer entries."},
+		{name: "wrong wrapper key", value: []any{map[string]any{"NotSigner": map[string]any{}}}, feePayer: loadAdmissionAccount, wantError: "Signers array may only contain Signer entries."},
+		{name: "inner missing field", value: []any{map[string]any{"Signer": map[string]any{
+			"Account": loadAdmissionSigner, "SigningPubKey": "",
+		}}}, feePayer: loadAdmissionAccount, wantError: "Signers array may only contain Signer entries."},
+		{name: "inner wrong type", value: []any{map[string]any{"Signer": map[string]any{
+			"Account": loadAdmissionSigner, "SigningPubKey": 1, "TxnSignature": "",
+		}}}, feePayer: loadAdmissionAccount, wantError: "Signers array may only contain Signer entries."},
+		{name: "invalid account", value: []any{signerValue("not-an-account")}, feePayer: loadAdmissionAccount, wantError: "Signers array may only contain Signer entries."},
+		{name: "duplicate", value: []any{signerValue(loadAdmissionSigner), signerValue(loadAdmissionSigner)}, feePayer: loadAdmissionAccount, wantError: "Duplicate Signers:Signer:Account entries (" + loadAdmissionSigner + ") are not allowed."},
+		{name: "delegated self-sign", value: []any{signerValue(loadAdmissionSigner)}, feePayer: loadAdmissionSigner, wantError: "A Signer may not be the transaction's Account (" + loadAdmissionSigner + ")."},
+		{name: "unsorted decoded account IDs", value: valid, feePayer: loadAdmissionAccount, wantSorted: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, rpcErr := normalizeSigners(test.value, test.feePayer)
+			if test.wantError != "" {
+				if rpcErr == nil || rpcErr.Message != test.wantError {
+					t.Fatalf("error = %#v, want %q", rpcErr, test.wantError)
+				}
+				return
+			}
+			if rpcErr != nil {
+				t.Fatalf("normalizeSigners: %v", rpcErr)
+			}
+			if !test.wantSorted {
+				return
+			}
+			if len(got) != len(valid) {
+				t.Fatalf("got %d signers, want %d", len(got), len(valid))
+			}
+			for i := 1; i < len(got); i++ {
+				previous := got[i-1]["Signer"].(map[string]any)["Account"].(string)
+				current := got[i]["Signer"].(map[string]any)["Account"].(string)
+				_, previousID, _ := addresscodec.DecodeClassicAddressToAccountID(previous)
+				_, currentID, _ := addresscodec.DecodeClassicAddressToAccountID(current)
+				if bytes.Compare(previousID, currentID) >= 0 {
+					t.Fatalf("accounts are not sorted by decoded ID: %v", got)
+				}
+			}
+			if !reflect.DeepEqual(got[0], valid[0]) && !reflect.DeepEqual(got[0], valid[1]) {
+				t.Fatal("normalized signer lost fields")
+			}
+		})
+	}
+
+	got, rpcErr := normalizeSigners([]any{}, loadAdmissionAccount)
+	if rpcErr != nil || len(got) != 0 {
+		t.Fatalf("empty array = %#v, %#v; want empty success", got, rpcErr)
+	}
+}
+
+func TestPreprocessTransactionCanonicalizesAndValidatesSigners(t *testing.T) {
+	base := func(signers any) map[string]any {
+		return map[string]any{
+			"TransactionType": "AccountSet",
+			"Account":         loadAdmissionAccount,
+			"Sequence":        1,
+			"Fee":             "10",
+			"SigningPubKey":   "",
+			"Signers":         signers,
+		}
+	}
+	preprocess := func(signers any) (*types.RpcError, string) {
+		transaction, rpcErr := preprocessTransaction(base(signers), transactionPreprocessOptions{
+			mode:            transactionPreprocessSubmitMultisigned,
+			preserveSigners: true,
+		})
+		if rpcErr != nil {
+			return rpcErr, ""
+		}
+		return nil, transaction.GetCommon().Signers[0].Signer.Account
+	}
+
+	t.Run("non-array", func(t *testing.T) {
+		rpcErr, _ := preprocess(map[string]any{})
+		if rpcErr == nil || rpcErr.Message != "Field 'tx_json.Signers' is not a JSON array." {
+			t.Fatalf("error = %#v", rpcErr)
+		}
+	})
+
+	t.Run("malformed signer blob", func(t *testing.T) {
+		value := signerValue(loadAdmissionSigner)
+		value["Signer"].(map[string]any)["SigningPubKey"] = "not-hex"
+		rpcErr, _ := preprocess([]any{value})
+		want := "Error at 'tx_json.Signers.[0].Signer'. Field 'tx_json.Signers.[0].Signer.SigningPubKey' has invalid data."
+		if rpcErr == nil || rpcErr.Message != want {
+			t.Fatalf("error = %#v, want %q", rpcErr, want)
+		}
+	})
+
+	t.Run("hex account ID", func(t *testing.T) {
+		_, accountID, err := addresscodec.DecodeClassicAddressToAccountID(loadAdmissionSigner)
+		if err != nil {
+			t.Fatal(err)
+		}
+		value := signerValue(strings.ToUpper(hex.EncodeToString(accountID)))
+		rpcErr, account := preprocess([]any{value})
+		if rpcErr != nil {
+			t.Fatalf("preprocess: %v", rpcErr)
+		}
+		if account != loadAdmissionSigner {
+			t.Fatalf("canonical account = %q, want %q", account, loadAdmissionSigner)
+		}
+	})
+
+	t.Run("array limit", func(t *testing.T) {
+		items := make([]any, binarycodectypes.MaxJSONArrayElements+1)
+		for i := range items {
+			items[i] = signerValue(loadAdmissionSigner)
+		}
+		rpcErr, _ := preprocess(items)
+		want := fmt.Sprintf(
+			"Field 'tx_json.Signers' exceeds allowed JSON array size of %d elements per field.",
+			binarycodectypes.MaxJSONArrayElements)
+		if rpcErr == nil || rpcErr.Message != want {
+			t.Fatalf("error = %#v, want %q", rpcErr, want)
+		}
+	})
+}
+
+type paymentRulesLedger struct {
+	loadAdmissionLedger
+	rules *amendment.Rules
+}
+
+func (l *paymentRulesLedger) TransactionRules() *amendment.Rules {
+	return l.rules
+}
+
+func TestCheckPaymentMPTGatePrecedesLaterValidation(t *testing.T) {
+	ledger := &paymentRulesLedger{rules: amendment.NewRules(nil)}
+	txMap := map[string]any{
+		"TransactionType": "Payment",
+		"Account":         loadAdmissionAccount,
+		"Destination":     loadAdmissionSigner,
+		"Amount": map[string]any{
+			"mpt_issuance_id": strings.Repeat("A", 48),
+			"value":           "1",
+		},
+		"Paths":    []any{},
+		"DomainID": "00",
+	}
+	ctx := &types.RpcContext{Services: &types.ServiceContainer{Ledger: ledger}}
+	rpcErr := checkPayment(txMap, json.RawMessage(`{"build_path":true}`), true, ctx)
+	if rpcErr == nil || rpcErr.Message != "Field 'build_path' not allowed in this context." {
+		t.Fatalf("error = %#v", rpcErr)
+	}
+}
+
+func TestCheckPaymentValidationAndMutation(t *testing.T) {
+	base := func() map[string]any {
+		return map[string]any{
+			"TransactionType": "Payment",
+			"Amount":          "1",
+			"Destination":     loadAdmissionSigner,
+		}
+	}
+	for _, test := range []struct {
+		name       string
+		tx         func() map[string]any
+		params     string
+		doPath     bool
+		wantError  string
+		wantPath   bool
+		wantAmount any
+	}{
+		{name: "non-payment", tx: func() map[string]any { return map[string]any{"TransactionType": "AccountSet"} }},
+		{name: "missing amount", tx: func() map[string]any { tx := base(); delete(tx, "Amount"); return tx }, wantError: "Missing field 'tx_json.Amount'."},
+		{name: "invalid amount", tx: func() map[string]any { tx := base(); tx["Amount"] = "not-an-amount"; return tx }, wantError: "Invalid field 'tx_json.Amount'."},
+		{name: "missing destination", tx: func() map[string]any { tx := base(); delete(tx, "Destination"); return tx }, wantError: "Missing field 'tx_json.Destination'."},
+		{name: "invalid destination", tx: func() map[string]any { tx := base(); tx["Destination"] = "not-an-account"; return tx }, wantError: "Invalid field 'tx_json.Destination'."},
+		{name: "differing amount aliases", tx: func() map[string]any { tx := base(); tx["DeliverMax"] = "2"; return tx }, wantError: "Cannot specify differing 'Amount' and 'DeliverMax'"},
+		{name: "deliver max mutation", tx: func() map[string]any { tx := base(); delete(tx, "Amount"); tx["DeliverMax"] = "2"; return tx }, wantAmount: "2"},
+		{name: "build path forbidden", tx: base, params: `{"build_path":true}`, wantError: "Field 'build_path' not allowed in this context."},
+		{name: "paths plus build path", tx: func() map[string]any { tx := base(); tx["Paths"] = []any{}; return tx }, params: `{"build_path":true}`, doPath: true, wantError: "Cannot specify both 'tx_json.Paths' and 'build_path'"},
+		{name: "invalid domain", tx: func() map[string]any { tx := base(); tx["DomainID"] = "00"; return tx }, wantError: "Unable to parse 'DomainID'."},
+		{name: "invalid send max", tx: base, params: `{"build_path":true}`, doPath: true, wantError: "Invalid field 'tx_json.SendMax'.", wantAmount: "1"},
+		{name: "xrp to xrp", tx: func() map[string]any { return base() }, params: `{"build_path":true}`, doPath: true, wantError: "Cannot build XRP to XRP paths."},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tx := test.tx()
+			if test.name == "invalid send max" {
+				tx["SendMax"] = "not-an-amount"
+			}
+			rpcErr := checkPayment(tx, json.RawMessage(test.params), test.doPath, nil)
+			if test.wantError != "" {
+				if rpcErr == nil || rpcErr.Message != test.wantError {
+					t.Fatalf("error = %#v, want %q", rpcErr, test.wantError)
+				}
+				return
+			}
+			if rpcErr != nil {
+				t.Fatalf("checkPayment: %v", rpcErr)
+			}
+			if test.wantPath {
+				t.Fatal("path construction unexpectedly succeeded without an open-ledger context")
+			}
+			if test.wantAmount != nil && tx["Amount"] != test.wantAmount {
+				t.Fatalf("Amount = %#v, want %#v", tx["Amount"], test.wantAmount)
+			}
+		})
+	}
+
+	issued := map[string]any{
+		"TransactionType": "Payment",
+		"Amount":          "1/USD/" + loadAdmissionAccount,
+		"Destination":     loadAdmissionSigner,
+		"SendMax":         "2/USD/" + loadAdmissionAccount,
+	}
+	rpcErr := checkPayment(issued, json.RawMessage(`{"build_path":true}`), true, nil)
+	if rpcErr == nil {
+		t.Fatal("issued build_path unexpectedly succeeded without an open-ledger context")
+	}
+}
+
+func TestSubmitMultisignedRejectsMalformedSignerBeforeBinaryEncoding(t *testing.T) {
+	params, err := json.Marshal(map[string]any{"tx_json": map[string]any{
+		"TransactionType": "AccountSet",
+		"Account":         loadAdmissionAccount,
+		"Sequence":        1,
+		"Fee":             "10",
+		"SigningPubKey":   "",
+		"Signers": []any{map[string]any{"Signer": map[string]any{
+			"Account":       loadAdmissionSigner,
+			"SigningPubKey": "",
+			"TxnSignature":  "",
+			"Extra":         "must reject",
+		}}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := &types.RpcContext{
+		Context:  context.Background(),
+		Services: &types.ServiceContainer{Ledger: &loadAdmissionLedger{}},
+	}
+	_, rpcErr := (&SubmitMultisignedMethod{}).Handle(ctx, params)
+	if rpcErr == nil || rpcErr.Message != "Signers array may only contain Signer entries." {
+		t.Fatalf("error = %#v, want strict signer error", rpcErr)
+	}
+}

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -497,9 +497,44 @@ func TestSimulateMethod_BatchRejection(t *testing.T) {
 
 	_, rpcErr := method.Handle(ctx, paramsJSON)
 	require.NotNil(t, rpcErr)
-	assert.Equal(t, types.RpcNOT_IMPL, rpcErr.Code)
-	assert.Equal(t, "notImpl", rpcErr.ErrorString)
-	assert.Equal(t, "Not implemented.", rpcErr.Message)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Equal(t, "invalidTransaction", rpcErr.ErrorString)
+	assert.NotEmpty(t, rpcErr.ErrorException)
+
+	batch := func(transactionType any) map[string]any {
+		inner := func(sequence int) map[string]any {
+			return map[string]any{
+				"RawTransaction": map[string]any{
+					"TransactionType": "AccountSet",
+					"Account":         validAccountAddress,
+					"Fee":             "10",
+					"Sequence":        sequence,
+					"SigningPubKey":   "",
+				},
+			}
+		}
+		return map[string]any{
+			"TransactionType": transactionType,
+			"Account":         validAccountAddress,
+			"Fee":             "10",
+			"Sequence":        1,
+			"SigningPubKey":   "",
+			"Flags":           0x00080000,
+			"RawTransactions": []any{inner(1), inner(2)},
+		}
+	}
+	for _, transactionType := range []any{"Batch", 71} {
+		t.Run(fmt.Sprint(transactionType), func(t *testing.T) {
+			params := map[string]any{"tx_json": batch(transactionType)}
+			paramsJSON, err := json.Marshal(params)
+			require.NoError(t, err)
+			_, rpcErr := method.Handle(ctx, paramsJSON)
+			require.NotNil(t, rpcErr)
+			assert.Equal(t, types.RpcNOT_IMPL, rpcErr.Code)
+			assert.Equal(t, "notImpl", rpcErr.ErrorString)
+			assert.Equal(t, "Not implemented.", rpcErr.Message)
+		})
+	}
 }
 
 func TestSimulateMethod_SuccessfulSimulation(t *testing.T) {

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -918,6 +918,13 @@ type LedgerViewSource interface {
 	GetLedgerViewByHash(hash [32]byte) (LedgerStateView, LedgerReader, error)
 }
 
+// OpenLedgerViewSource provides an immutable snapshot of the current
+// open-ledger state for operations such as transaction path construction.
+// It is optional so lightweight RPC mocks can continue to omit the view.
+type OpenLedgerViewSource interface {
+	GetOpenLedgerView() (LedgerStateView, error)
+}
+
 // LedgerStateView provides low-level read access to ledger state.
 // This interface matches tx.LedgerView for pathfinding and other operations
 // that need direct state access. Any *ledger.Ledger satisfies this.


### PR DESCRIPTION
## Summary
- Centralize mode-driven transaction preprocessing for signing, submission, and simulation.
- Normalize multisigners by decoded AccountID and preserve rippled validation order.

## Verification
- Transaction preprocessing and full RPC tests
- Targeted race, vet, strict lint, and diff checks

Refs #1486

Stack layer 3 of 16; depends on #1568.