### PR TITLE
fix: canonicalize RPC transaction submission (#1486)

### DIFF
--- a/internal/rpc/adapter/submission.go
+++ b/internal/rpc/adapter/submission.go
@@ -45,21 +45,45 @@ func internalSubmitResult() *types.SubmitResult {
 }
 
 func (a *LedgerServiceAdapter) submitTransaction(txJSON []byte, txBlobHex string, failHard bool) (*types.SubmitResult, error) {
-	// Parse the transaction from JSON
-	transaction, err := tx.ParseJSON(txJSON)
-	if err != nil {
-		return malformedSubmitResult(), nil
-	}
-
-	// Use the original signed blob if provided, otherwise re-encode
+	// Parse and canonicalize a supplied blob before handing it to the ledger.
+	// STTx serialization orders fields canonically, so accepted non-canonical
+	// input must not change the transaction ID or relayed bytes.
 	var rawBlob []byte
+	var transaction tx.Transaction
 	if txBlobHex != "" {
 		var decodeErr error
 		rawBlob, decodeErr = hex.DecodeString(txBlobHex)
 		if decodeErr != nil {
 			return nil, fmt.Errorf("decode tx_blob: %w", decodeErr)
 		}
+		var parseErr error
+		transaction, parseErr = tx.ParseFromBinary(rawBlob)
+		if parseErr != nil {
+			return malformedSubmitResult(), nil
+		}
+		fields, canonicalErr := binarycodec.DecodeBytes(rawBlob)
+		if canonicalErr != nil {
+			return malformedSubmitResult(), nil
+		}
+		canonicalHex, canonicalErr := binarycodec.Encode(fields)
+		if canonicalErr != nil {
+			return malformedSubmitResult(), nil
+		}
+		rawBlob, canonicalErr = hex.DecodeString(canonicalHex)
+		if canonicalErr != nil {
+			return nil, fmt.Errorf("decode canonical tx_blob: %w", canonicalErr)
+		}
+		transaction.SetRawBytes(rawBlob)
+	} else {
+		var parseErr error
+		transaction, parseErr = tx.ParseJSON(txJSON)
+		if parseErr != nil {
+			return malformedSubmitResult(), nil
+		}
 	}
+
+	// If no signed blob was supplied, encode the parsed JSON transaction for
+	// open-ledger processing and relay.
 	if rawBlob == nil {
 		if txMap, fErr := transaction.Flatten(); fErr == nil {
 			if hexStr, eErr := binarycodec.Encode(txMap); eErr == nil {

--- a/internal/rpc/adapter/submission.go
+++ b/internal/rpc/adapter/submission.go
@@ -82,8 +82,6 @@ func (a *LedgerServiceAdapter) submitTransaction(txJSON []byte, txBlobHex string
 		}
 	}
 
-	// If no signed blob was supplied, encode the parsed JSON transaction for
-	// open-ledger processing and relay.
 	if rawBlob == nil {
 		if txMap, fErr := transaction.Flatten(); fErr == nil {
 			if hexStr, eErr := binarycodec.Encode(txMap); eErr == nil {

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -422,6 +422,13 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 	if rpcErr != nil {
 		return nil, rpcErr
 	}
+	signatureTargetPresent := jsonFieldPresent(rawParams, "signature_target")
+	if signatureTargetPresent && signatureTarget != counterpartySignatureField {
+		return nil, types.RpcErrorInvalidParams(signatureTarget)
+	}
+	if len(txJSON) == 0 {
+		return nil, types.RpcErrorMissingField("tx_json")
+	}
 
 	// Check if ledger service is available (needed for auto-filling fields)
 	// only after credentials have entered the shared signing preprocessing.
@@ -436,28 +443,24 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 	}
 
 	// Parse the transaction JSON
-	var txMap map[string]any
+	var txValue any
 	decoder := json.NewDecoder(bytes.NewReader(txJSON))
 	decoder.UseNumber()
-	if err := decoder.Decode(&txMap); err != nil {
+	if err := decoder.Decode(&txValue); err != nil {
 		return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid tx_json: %v", err))
 	}
 	var trailing any
 	if err := decoder.Decode(&trailing); err != io.EOF {
 		return nil, types.RpcErrorInvalidParams("Invalid tx_json: expected object")
 	}
-	if txMap == nil {
+	txMap, ok := txValue.(map[string]any)
+	if !ok {
 		return nil, types.RpcErrorExpectedField("tx_json", "object")
 	}
 	// signature_target directs the signature into a nested inner object instead
 	// of the top level. Only CounterpartySignature is a valid target; any other
 	// field name is rejected with the field name as the message, matching
 	// rippled TransactionSign.cpp.
-	signatureTargetPresent := jsonFieldPresent(rawParams, "signature_target")
-	if signatureTargetPresent && signatureTarget != counterpartySignatureField {
-		return nil, types.RpcErrorInvalidParams(signatureTarget)
-	}
-
 	// srcAddress is the account whose Sequence/Fee are autofilled and whose
 	// existence is checked. Without a target it is the signing key's account,
 	// which must match a supplied Account (rippled checkTxJsonFields →

--- a/internal/rpc/handlers/sign_helper.go
+++ b/internal/rpc/handlers/sign_helper.go
@@ -27,7 +27,10 @@ import (
 // may name, matching rippled (the LoanSet sfCounterpartySignature).
 const counterpartySignatureField = "CounterpartySignature"
 
-const signingDeprecation = "This command has been deprecated and will be removed in a future version of the server. Please migrate to a standalone signing tool."
+const (
+	signingDeprecation       = "This command has been deprecated and will be removed in a future version of the server. Please migrate to a standalone signing tool."
+	submitSigningDeprecation = "Signing support in the 'submit' command has been deprecated and will be removed in a future version of the server. Please migrate to a standalone signing tool."
+)
 
 // signCredentials holds the signing credential parameters common to both
 // the sign and submit RPC methods.
@@ -37,17 +40,6 @@ type signCredentials struct {
 	SeedHex    json.RawMessage `json:"seed_hex,omitempty"`
 	Passphrase json.RawMessage `json:"passphrase,omitempty"`
 	KeyType    json.RawMessage `json:"key_type,omitempty"`
-}
-
-func (c signCredentials) any(params json.RawMessage) bool {
-	var fields map[string]json.RawMessage
-	_ = json.Unmarshal(params, &fields)
-	for _, field := range []string{"secret", "seed", "seed_hex", "passphrase"} {
-		if _, ok := fields[field]; ok {
-			return true
-		}
-	}
-	return false
 }
 
 func (c signCredentials) deriveKeypair(apiVersion int, params json.RawMessage) (string, string, string, *types.RpcError) {
@@ -181,17 +173,14 @@ type signResult struct {
 }
 
 func formatSignResult(result signResult, apiVersion int) map[string]any {
-	txprojection.InjectDeliverMax(result.TxMap, apiVersion)
-	response := map[string]any{
-		"tx_blob": result.TxBlob,
-		"tx_json": result.TxMap,
-	}
-	if apiVersion > 1 {
-		if hash, ok := result.TxMap["hash"].(string); ok {
-			response["hash"] = hash
-		}
-	}
-	return response
+	hash, _ := result.TxMap["hash"].(string)
+	return txprojection.FormatResult(
+		result.TxMap,
+		result.TxBlob,
+		hash,
+		apiVersion,
+		txprojection.PathSigned,
+	)
 }
 
 func rejectDisabledSigning(ctx *types.RpcContext) *types.RpcError {
@@ -205,11 +194,15 @@ func rejectDisabledSigning(ctx *types.RpcContext) *types.RpcError {
 }
 
 func addSigningDeprecation(result any, rpcErr *types.RpcError) (any, *types.RpcError) {
+	return addDeprecation(result, rpcErr, signingDeprecation)
+}
+
+func addDeprecation(result any, rpcErr *types.RpcError, message string) (any, *types.RpcError) {
 	if rpcErr != nil {
-		return result, rpcErr.WithExtra(map[string]any{"deprecated": signingDeprecation})
+		return result, rpcErr.WithExtra(map[string]any{"deprecated": message})
 	}
 	if response, ok := result.(map[string]any); ok {
-		response["deprecated"] = signingDeprecation
+		response["deprecated"] = message
 	}
 	return result, nil
 }
@@ -423,15 +416,17 @@ func signTransactionJSON(rpcCtx *types.RpcContext, txJSON json.RawMessage, creds
 	ctx := rpcCtx.Context
 	services := rpcCtx.Services
 	apiVersion := rpcCtx.ApiVersion
-	// Check if ledger service is available (needed for auto-filling fields)
-	if !offline && (services == nil || services.Ledger == nil) {
-		return nil, rpcInternalInvariantError("sign: ledger service unavailable")
-	}
 
 	// Parse credentials and derive keypair using the shared helper
 	privateKey, publicKey, _, rpcErr := creds.deriveKeypair(apiVersion, rawParams)
 	if rpcErr != nil {
 		return nil, rpcErr
+	}
+
+	// Check if ledger service is available (needed for auto-filling fields)
+	// only after credentials have entered the shared signing preprocessing.
+	if !offline && (services == nil || services.Ledger == nil) {
+		return nil, rpcInternalInvariantError("sign: ledger service unavailable")
 	}
 
 	// Derive address from public key

--- a/internal/rpc/handlers/sign_helper_test.go
+++ b/internal/rpc/handlers/sign_helper_test.go
@@ -156,3 +156,40 @@ func TestSignTransactionJSONPreservesExplicitEmptyFields(t *testing.T) {
 		})
 	}
 }
+
+func TestSignTransactionJSONValidatesTargetBeforeTransactionPresence(t *testing.T) {
+	params := json.RawMessage(`{
+		"seed_hex":"00000000000000000000000000000000",
+		"key_type":"ed25519",
+		"signature_target":"NotASignatureField"
+	}`)
+	_, rpcErr := signTransactionJSON(
+		&types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion2},
+		nil,
+		signCredentials{},
+		true,
+		params,
+		"NotASignatureField",
+	)
+	if rpcErr == nil || rpcErr.Code != types.RpcINVALID_PARAMS || rpcErr.Message != "NotASignatureField" {
+		t.Fatalf("unexpected error: %#v", rpcErr)
+	}
+}
+
+func TestSignTransactionJSONRejectsNonObjectTransaction(t *testing.T) {
+	params := json.RawMessage(`{
+		"seed_hex":"00000000000000000000000000000000",
+		"key_type":"ed25519"
+	}`)
+	_, rpcErr := signTransactionJSON(
+		&types.RpcContext{Context: context.Background(), ApiVersion: types.ApiVersion2},
+		json.RawMessage(`[]`),
+		signCredentials{},
+		true,
+		params,
+		"",
+	)
+	if rpcErr == nil || rpcErr.Code != types.RpcINVALID_PARAMS || rpcErr.Message != "Invalid field 'tx_json', not object." {
+		t.Fatalf("unexpected error: %#v", rpcErr)
+	}
+}

--- a/internal/rpc/handlers/sign_helper_test.go
+++ b/internal/rpc/handlers/sign_helper_test.go
@@ -57,13 +57,24 @@ func TestFormatSignResult(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			txMap := map[string]any{"TransactionType": "Payment", "Amount": "10", "hash": "HASH"}
 			response := formatSignResult(signResult{TxMap: txMap, TxBlob: "BLOB"}, test.apiVersion)
-			if response["tx_blob"] != "BLOB" || txMap["DeliverMax"] != "10" {
+			if response["tx_blob"] != "BLOB" {
 				t.Fatalf("unexpected response: %#v", response)
 			}
 			_, hasRootHash := response["hash"]
-			_, hasAmount := txMap["Amount"]
-			if hasRootHash != (test.apiVersion > 1) || hasAmount != (test.apiVersion == 1) {
+			txJSON, ok := response["tx_json"].(map[string]any)
+			if !ok {
+				t.Fatalf("missing tx_json: %#v", response)
+			}
+			_, sourceHasDeliverMax := txMap["DeliverMax"]
+			_, sourceHasHash := txMap["hash"]
+			_, hasAmount := txJSON["Amount"]
+			_, hasDeliverMax := txJSON["DeliverMax"]
+			_, hasNestedHash := txJSON["hash"]
+			if sourceHasDeliverMax || !sourceHasHash || hasRootHash != (test.apiVersion > 1) || hasAmount != (test.apiVersion == 1) || !hasDeliverMax || hasNestedHash != (test.apiVersion == 1) {
 				t.Fatalf("api %d response = %#v", test.apiVersion, response)
+			}
+			if test.apiVersion > 1 && response["hash"] != "HASH" {
+				t.Fatalf("api %d root hash = %#v", test.apiVersion, response["hash"])
 			}
 		})
 	}

--- a/internal/rpc/handlers/signing_load_admission_test.go
+++ b/internal/rpc/handlers/signing_load_admission_test.go
@@ -349,7 +349,7 @@ func TestCredentialedSubmitAndMultisignMethodsRejectLoaded(t *testing.T) {
 				IsLoadedCluster: func() bool { return true },
 			},
 		}
-		_, rpcErr := (&SubmitMethod{}).Handle(ctx, signingLoadParams(false))
+		_, rpcErr := (&SubmitMethod{}).Handle(signingEnabledHandlerContext(ctx), signingLoadParams(false))
 		assertTooBusy(t, rpcErr)
 		if ledger.accountLookups != 0 || ledger.sequenceFills != 0 || ledger.feeFills != 0 || ledger.transactionSends != 0 {
 			t.Fatalf("credentialed submit performed downstream work: %#v", ledger)

--- a/internal/rpc/handlers/simulate.go
+++ b/internal/rpc/handlers/simulate.go
@@ -12,6 +12,7 @@ import (
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
+	"github.com/LeJamon/go-xrpl/internal/rpc/txprojection"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 )
@@ -32,13 +33,15 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 		rawParams = make(map[string]json.RawMessage)
 	}
 
-	// Validate `binary` field type if present — must be a boolean.
-	// rippled: if context.params.isMember(jss::binary) && !context.params[jss::binary].isBool()
+	// Validate `binary` field type if present — must be a JSON boolean.
+	// JsonCpp's isBool() rejects null and numeric values.
 	var binaryOutput bool
 	if raw, ok := rawParams["binary"]; ok {
-		if err := json.Unmarshal(raw, &binaryOutput); err != nil {
+		trimmed := bytes.TrimSpace(raw)
+		if !bytes.Equal(trimmed, []byte("true")) && !bytes.Equal(trimmed, []byte("false")) {
 			return nil, types.RpcErrorInvalidField("binary")
 		}
+		_ = json.Unmarshal(raw, &binaryOutput)
 	}
 
 	// Reject forbidden fields: secret, seed, seed_hex, passphrase.
@@ -67,22 +70,25 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 
 	if hasTxBlobRaw {
 		var txBlobStr string
-		if err := json.Unmarshal(rawParams["tx_blob"], &txBlobStr); err != nil {
+		if err := json.Unmarshal(rawParams["tx_blob"], &txBlobStr); err != nil || txBlobStr == "" {
 			return nil, types.RpcErrorInvalidField("tx_blob")
 		}
-		if txBlobStr == "" {
+		rawBlob, err := hex.DecodeString(txBlobStr)
+		if err != nil || len(rawBlob) == 0 {
 			return nil, types.RpcErrorInvalidField("tx_blob")
 		}
-		decoded, err := binarycodec.Decode(txBlobStr)
+		txJsonMap, err = binarycodec.DecodeBytes(rawBlob)
 		if err != nil {
 			return nil, types.RpcErrorInvalidField("tx_blob")
 		}
-		txJsonMap = decoded
 	} else {
 		var txObj map[string]any
 		decoder := json.NewDecoder(bytes.NewReader(rawParams["tx_json"]))
 		decoder.UseNumber()
 		if err := decoder.Decode(&txObj); err != nil {
+			return nil, types.RpcErrorExpectedField("tx_json", "object")
+		}
+		if txObj == nil {
 			return nil, types.RpcErrorExpectedField("tx_json", "object")
 		}
 		var trailing any
@@ -215,6 +221,11 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	if err != nil {
 		return nil, rpcInternalError("simulate: transaction flattening failed", err)
 	}
+	canonicalBlob, err := binarycodec.Encode(canonicalMap)
+	if err != nil {
+		return nil, rpcInternalError("simulate: transaction encoding failed", err)
+	}
+	canonicalHash := CalculateTxHash(canonicalBlob)
 	txJSON, err := json.Marshal(canonicalMap)
 	if err != nil {
 		return nil, rpcInternalError("simulate: transaction marshaling failed", err)
@@ -260,11 +271,14 @@ func (m *SimulateMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (
 	}
 
 	if binaryOutput {
-		if encoded, err := binarycodec.Encode(canonicalMap); err == nil {
-			response["tx_blob"] = encoded
-		}
+		response["tx_blob"] = canonicalBlob
 	} else {
-		response["tx_json"] = canonicalMap
+		response["tx_json"] = txprojection.ProjectJSONForPath(
+			canonicalMap,
+			canonicalHash,
+			ctx.ApiVersion,
+			txprojection.PathCanonical,
+		)
 	}
 
 	return response, nil

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -10,6 +11,8 @@ import (
 	"github.com/LeJamon/go-xrpl/crypto/sha512half"
 	"github.com/LeJamon/go-xrpl/internal/rpc/txprojection"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/sign"
 	xrpllog "github.com/LeJamon/go-xrpl/log"
 )
 
@@ -17,80 +20,124 @@ import (
 // Supports both tx_blob (pre-signed hex) and tx_json submissions.
 type SubmitMethod struct{ BaseHandler }
 
-func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (result any, rpcErr *types.RpcError) {
 	setLoadMedium(ctx)
-	var request struct {
-		signingRequest
-		TxBlob   string `json:"tx_blob,omitempty"`
-		FailHard bool   `json:"fail_hard,omitempty"`
-	}
-
-	if err := ParseParams(params, &request); err != nil {
+	rawParams, err := decodeSubmitParams(params)
+	if err != nil {
 		return nil, err
 	}
 
-	if request.TxBlob == "" && len(request.TxJson) == 0 {
-		return nil, types.RpcErrorInvalidParams("Either tx_blob or tx_json must be provided")
-	}
-
-	if err := RequireLedgerService(ctx.Services); err != nil {
-		return nil, err
-	}
+	_, hasTxBlob := rawParams["tx_blob"]
 
 	var txJSON []byte
 	var txJsonMap map[string]any
 	var txBlobHex string
+	var failHard bool
+	projectionPath := txprojection.PathSigned
 
-	// Determine if this is a sign-and-submit request (tx_json + credentials)
-	hasSigningCreds := request.signCredentials.any(params)
-
-	if request.TxBlob != "" {
-		// Decode tx_blob to get tx_json
-		decoded, err := binarycodec.Decode(request.TxBlob)
-		if err != nil {
-			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid tx_blob: %v", err))
+	if hasTxBlob {
+		projectionPath = txprojection.PathCanonical
+		blobHex, ok := submitJSONString(rawParams["tx_blob"])
+		if !ok || blobHex == "" {
+			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 		}
-		txJsonMap = decoded
-		txBlobHex = request.TxBlob
-
-		// Marshal back to JSON for submission
-		txJSON, err = json.Marshal(decoded)
-		if err != nil {
-			return nil, rpcInternalError("submit: decoded transaction marshaling failed", err)
-		}
-	} else if hasSigningCreds {
-		// Sign-and-submit path: sign the transaction first, then submit the blob.
-		// This matches rippled's behavior in doSubmit() when tx_blob is absent.
-		signed, rpcErr := signTransactionJSON(ctx, request.TxJson, request.signCredentials, request.Offline, params, request.SignatureTarget)
-		if rpcErr != nil {
-			return nil, rpcErr
+		rawBlob, decodeErr := hex.DecodeString(blobHex)
+		if decodeErr != nil || len(rawBlob) == 0 {
+			return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 		}
 
-		txJsonMap = signed.TxMap
-		txBlobHex = signed.TxBlob
+		parsed, txParseErr := tx.ParseFromBinary(rawBlob)
+		if txParseErr != nil {
+			return nil, types.RpcErrorInvalidTransaction(txParseErr.Error())
+		}
+		canonical, canonicalErr := binarycodec.DecodeBytes(rawBlob)
+		if canonicalErr != nil {
+			return nil, types.RpcErrorInvalidTransaction(canonicalErr.Error())
+		}
+		canonicalBlobHex, canonicalEncodeErr := binarycodec.Encode(canonical)
+		if canonicalEncodeErr != nil {
+			return nil, types.RpcErrorInvalidTransaction(canonicalEncodeErr.Error())
+		}
+		canonicalBlob, canonicalDecodeErr := hex.DecodeString(canonicalBlobHex)
+		if canonicalDecodeErr != nil {
+			return nil, rpcInternalError("submit: canonical transaction decoding failed", canonicalDecodeErr)
+		}
+		parsed.SetRawBytes(canonicalBlob)
 
-		// Use the signed JSON for submission
-		var err error
-		txJSON, err = json.Marshal(txJsonMap)
-		if err != nil {
-			return nil, rpcInternalError("submit: signed transaction marshaling failed", err)
+		signatureReason := ""
+		signatureChecked := false
+		checkSigs := ctx.Services == nil || ctx.Services.Ledger == nil || !ctx.Services.Ledger.IsStandalone()
+		if ctx.Services != nil && ctx.Services.Ledger != nil {
+			if rulesSource, ok := ctx.Services.Ledger.(types.TransactionRulesSource); ok {
+				signatureReason = sign.CheckSTTxSignature(parsed, rulesSource.TransactionRules(), checkSigs)
+				signatureChecked = true
+			}
+		}
+		if !signatureChecked {
+			signatureReason = sign.CheckSTTxSignature(parsed, nil, checkSigs)
+		}
+		if signatureReason != "" {
+			return nil, types.RpcErrorInvalidTransaction("fails local checks: " + signatureReason)
+		}
+		if reason := tx.TransactionLocalChecksFailureReason(parsed); reason != "" {
+			return nil, types.RpcErrorInvalidTransaction("fails local checks: " + reason)
+		}
+		var parseErr *types.RpcError
+		failHard, parseErr = parseSubmitFailHard(rawParams["fail_hard"])
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		txJsonMap = canonical
+		txBlobHex = strings.ToUpper(canonicalBlobHex)
+		if marshaled, marshalErr := json.Marshal(txJsonMap); marshalErr != nil {
+			return nil, rpcInternalError("submit: decoded transaction marshaling failed", marshalErr)
+		} else {
+			txJSON = marshaled
 		}
 	} else {
-		// Submit using tx_json directly (no signing)
-		txJSON = request.TxJson
+		var parseErr *types.RpcError
+		failHard, parseErr = parseSubmitFailHard(rawParams["fail_hard"])
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		if gateErr := rejectDisabledSigning(ctx); gateErr != nil {
+			return nil, gateErr
+		}
+		defer func() {
+			result, rpcErr = addDeprecation(result, rpcErr, submitSigningDeprecation)
+		}()
 
-		if err := json.Unmarshal(txJSON, &txJsonMap); err != nil {
-			return nil, types.RpcErrorExpectedField("tx_json", "object")
+		var request struct{ signingRequest }
+		requestParams := params
+		if len(requestParams) == 0 || bytes.Equal(bytes.TrimSpace(requestParams), []byte("null")) {
+			requestParams = json.RawMessage(`{}`)
+		}
+		if unmarshalErr := json.Unmarshal(requestParams, &request); unmarshalErr != nil {
+			return nil, types.RpcErrorInvalidParams(fmt.Sprintf("Invalid parameters: %v", unmarshalErr))
+		}
+
+		signed, signErr := signTransactionJSON(
+			ctx,
+			request.TxJson,
+			request.signCredentials,
+			request.Offline,
+			params,
+			request.SignatureTarget,
+		)
+		if signErr != nil {
+			return nil, signErr
+		}
+		txJsonMap = signed.TxMap
+		txBlobHex = strings.ToUpper(signed.TxBlob)
+		if marshaled, marshalErr := json.Marshal(txJsonMap); marshalErr != nil {
+			return nil, rpcInternalError("submit: signed transaction marshaling failed", marshalErr)
+		} else {
+			txJSON = marshaled
 		}
 	}
 
-	// Ensure we have the tx_blob hex for both submission and hash calculation
-	if txBlobHex == "" {
-		encoded, err := binarycodec.Encode(txJsonMap)
-		if err != nil {
-			return nil, rpcInternalError("submit: transaction encoding failed", err)
-		}
-		txBlobHex = encoded
+	if err := RequireLedgerService(ctx.Services); err != nil {
+		return nil, err
 	}
 
 	// Submit the transaction with the original signed blob.
@@ -98,7 +145,7 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 	// When the client passed fail_hard:true and the ledger service
 	// implements the FailHardSubmitter surface, route through it so
 	// non-applying submissions are not held or relayed.
-	result, submitErr := submitWithFailHard(ctx.Services.Ledger, txJSON, txBlobHex, request.FailHard)
+	submitResult, submitErr := submitWithFailHard(ctx.Services.Ledger, txJSON, txBlobHex, failHard)
 	if submitErr != nil {
 		return nil, rpcTransactionSubmissionError("submit: transaction submission failed", submitErr)
 	}
@@ -108,14 +155,14 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 	// still successful even when persistence fails — the tx is already in the
 	// open ledger and will be re-applied on close — but we log so silent
 	// storage failures don't go unnoticed.
-	if result.Applied && txHashStr != "" {
+	if submitResult.Applied && txHashStr != "" {
 		if txHashBytes, err := hex.DecodeString(txHashStr); err == nil && len(txHashBytes) == 32 {
 			var txHash [32]byte
 			copy(txHash[:], txHashBytes)
 			storedTx := StoredTransaction{
 				TxJSON: txJsonMap,
 				Meta: map[string]any{
-					"TransactionResult": result.EngineResult,
+					"TransactionResult": submitResult.EngineResult,
 					"TransactionIndex":  0,
 					"AffectedNodes":     []any{},
 				},
@@ -129,43 +176,40 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 		}
 	}
 
-	// Inject DeliverMax for Payment transactions, matching rippled's
-	// RPC::insertDeliverMax behavior in TransactionSign.cpp.
-	txprojection.InjectDeliverMax(txJsonMap, ctx.ApiVersion)
-
-	// For API v2+: add hash at root level of response, matching
-	// transactionFormatResultImpl in TransactionSign.cpp.
-	// For API v1: hash goes inside tx_json only.
-	if txHashStr != "" {
-		txJsonMap["hash"] = txHashStr
-	}
+	projectedTxJSON := txprojection.ProjectJSONForPath(
+		txJsonMap,
+		txHashStr,
+		ctx.ApiVersion,
+		projectionPath,
+	)
 
 	baseFee, _, _ := ctx.Services.Ledger.GetCurrentFees()
 
 	// Build response with independent boolean fields matching rippled's
 	// Transaction::SubmitResult struct. "accepted" = any() in rippled.
 	response := map[string]any{
-		"engine_result":         result.EngineResult,
-		"engine_result_code":    result.EngineResultCode,
-		"engine_result_message": result.EngineResultMessage,
-		"tx_json":               txJsonMap,
+		"engine_result":         submitResult.EngineResult,
+		"engine_result_code":    submitResult.EngineResultCode,
+		"engine_result_message": submitResult.EngineResultMessage,
+		"tx_json":               projectedTxJSON,
 		"tx_blob":               txBlobHex,
-		"accepted":              result.Accepted(),
-		"applied":               result.Applied,
-		"broadcast":             result.Broadcast,
-		"kept":                  result.Kept,
-		"queued":                result.Queued,
+		"accepted":              submitResult.Accepted(),
+		"applied":               submitResult.Applied,
+		"broadcast":             submitResult.Broadcast,
+		"kept":                  submitResult.Kept,
+		"queued":                submitResult.Queued,
 		"open_ledger_cost":      fmt.Sprintf("%d", baseFee),
 	}
 
-	// API v2+: add hash at the root level of the response
-	if ctx.ApiVersion > 1 && txHashStr != "" {
+	// Signed paths use the modern root hash for API v2+. Raw-blob submit keeps
+	// its legacy nested hash shape on every API version.
+	if projectionPath != txprojection.PathCanonical && ctx.ApiVersion > 1 && txHashStr != "" {
 		response["hash"] = txHashStr
 	}
 
 	// Add validated_ledger_index only if we have one
-	if result.ValidatedLedger > 0 {
-		response["validated_ledger_index"] = result.ValidatedLedger
+	if submitResult.ValidatedLedger > 0 {
+		response["validated_ledger_index"] = submitResult.ValidatedLedger
 	}
 
 	// Add account_sequence_next and account_sequence_available
@@ -176,12 +220,43 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (an
 		}
 	}
 
-	// Add deprecated warning when sign-and-submit credentials are used
-	if hasSigningCreds {
-		response["deprecated"] = "Signing support in the 'submit' command has been deprecated and will be removed in a future version of the server. Please migrate to a standalone signing tool."
-	}
-
 	return response, nil
+}
+
+func decodeSubmitParams(params json.RawMessage) (map[string]json.RawMessage, *types.RpcError) {
+	if len(params) == 0 || bytes.Equal(bytes.TrimSpace(params), []byte("null")) {
+		return map[string]json.RawMessage{}, nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(params, &raw); err != nil || raw == nil {
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	return raw, nil
+}
+
+func parseSubmitFailHard(raw json.RawMessage) (bool, *types.RpcError) {
+	if len(raw) == 0 {
+		return false, nil
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if bytes.Equal(trimmed, []byte("true")) {
+		return true, nil
+	}
+	if bytes.Equal(trimmed, []byte("false")) {
+		return false, nil
+	}
+	return false, types.RpcErrorExpectedField("fail_hard", "boolean")
+}
+
+func submitJSONString(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return "", false
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false
+	}
+	return value, true
 }
 
 // CalculateTxHash calculates the hash of a signed transaction

--- a/internal/rpc/handlers/submit_multisigned.go
+++ b/internal/rpc/handlers/submit_multisigned.go
@@ -10,6 +10,7 @@ import (
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
+	"github.com/LeJamon/go-xrpl/internal/rpc/txprojection"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
 
@@ -171,14 +172,22 @@ func (m *SubmitMultisignedMethod) Handle(ctx *types.RpcContext, params json.RawM
 		return nil, rpcTransactionSubmissionError("submit_multisigned: transaction submission failed", submitErr)
 	}
 
-	canonicalMap["hash"] = txHash
+	projectedTxJSON := txprojection.ProjectJSONForPath(
+		canonicalMap,
+		txHash,
+		ctx.ApiVersion,
+		txprojection.PathSigned,
+	)
 
 	response := map[string]any{
 		"engine_result":         result.EngineResult,
 		"engine_result_code":    result.EngineResultCode,
 		"engine_result_message": result.EngineResultMessage,
 		"tx_blob":               txBlob,
-		"tx_json":               canonicalMap,
+		"tx_json":               projectedTxJSON,
+	}
+	if ctx.ApiVersion > 1 {
+		response["hash"] = txHash
 	}
 
 	if result.Applied {

--- a/internal/rpc/simulate_test.go
+++ b/internal/rpc/simulate_test.go
@@ -2,8 +2,10 @@ package rpc
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +13,7 @@ import (
 
 	"github.com/LeJamon/go-xrpl/amendment"
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
@@ -578,6 +581,78 @@ func TestSimulateMethod_SuccessfulSimulation(t *testing.T) {
 	assert.Equal(t, validAccountAddress, txJSON["Account"])
 	assert.Equal(t, "", txJSON["SigningPubKey"])
 	assert.Equal(t, "", txJSON["TxnSignature"])
+}
+
+func TestSimulateMethodCanonicalBlobAndHashProjection(t *testing.T) {
+	baseTx := map[string]any{
+		"TransactionType": "AccountSet",
+		"Account":         validAccountAddress,
+		"Fee":             "10",
+		"Sequence":        1,
+		"SigningPubKey":   "",
+		"TxnSignature":    "",
+	}
+	blob, err := binarycodec.Encode(baseTx)
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		name   string
+		api    int
+		binary bool
+		params map[string]any
+	}{
+		{
+			name:   "binary blob",
+			api:    types.ApiVersion2,
+			binary: true,
+			params: map[string]any{"tx_blob": strings.ToLower(blob), "binary": true},
+		},
+		{
+			name:   "json v1",
+			api:    types.ApiVersion1,
+			params: map[string]any{"tx_json": baseTx},
+		},
+		{
+			name:   "json v2",
+			api:    types.ApiVersion2,
+			params: map[string]any{"tx_json": baseTx},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mock := newMockLedgerServiceSimulate()
+			ctx := &types.RpcContext{
+				Context:    context.Background(),
+				Role:       types.RoleUser,
+				ApiVersion: test.api,
+				Services:   newSimulateTestServices(mock),
+			}
+			paramsJSON, err := json.Marshal(test.params)
+			require.NoError(t, err)
+
+			result, rpcErr := (&handlers.SimulateMethod{}).Handle(ctx, paramsJSON)
+			require.Nil(t, rpcErr)
+			response, ok := result.(map[string]any)
+			require.True(t, ok)
+
+			assert.NotContains(t, response, "hash")
+
+			if test.binary {
+				canonicalBlob, ok := response["tx_blob"].(string)
+				require.True(t, ok)
+				decoded, err := hex.DecodeString(canonicalBlob)
+				require.NoError(t, err)
+				assert.NotEmpty(t, decoded)
+				return
+			}
+
+			txJSON, ok := response["tx_json"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "AccountSet", txJSON["TransactionType"])
+			assert.Equal(t, "", txJSON["SigningPubKey"])
+			assert.Equal(t, "", txJSON["TxnSignature"])
+			assert.Equal(t, handlers.CalculateTxHash(blob), txJSON["hash"])
+		})
+	}
 }
 
 func TestSimulateMethod_MPTokensV2UsesCurrentRules(t *testing.T) {

--- a/internal/rpc/submit_test.go
+++ b/internal/rpc/submit_test.go
@@ -1,15 +1,21 @@
 package rpc
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"maps"
+	"strings"
 	"testing"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/crypto/ed25519"
 	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+	txsign "github.com/LeJamon/go-xrpl/internal/tx/sign"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,6 +26,8 @@ type mockLedgerServiceSubmit struct {
 	submitResult *types.SubmitResult
 	submitError  error
 	storedTxs    map[string][]byte
+	submitCalls  int
+	lastTxBlob   string
 }
 
 func newMockLedgerServiceSubmit() *mockLedgerServiceSubmit {
@@ -39,10 +47,196 @@ func newMockLedgerServiceSubmit() *mockLedgerServiceSubmit {
 }
 
 func (m *mockLedgerServiceSubmit) SubmitTransaction(txJSON []byte, txBlobHex string) (*types.SubmitResult, error) {
+	m.submitCalls++
+	m.lastTxBlob = txBlobHex
 	if m.submitError != nil {
 		return nil, m.submitError
 	}
 	return m.submitResult, nil
+}
+
+func TestSubmitMethodRawBlobPresenceAndProjection(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+		Services:   newSubmitTestServices(mock),
+	}
+
+	rawMap := map[string]any{
+		"TransactionType": "Payment",
+		"Account":         validAccountAddress,
+		"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+		"Amount":          "1000000",
+		"Fee":             "10",
+		"Memos":           []map[string]any{},
+		"Sequence":        1,
+	}
+	rawBlob := rawSubmitBlob(t, rawMap)
+	params, err := json.Marshal(map[string]any{
+		"tx_blob": strings.ToLower(rawBlob),
+		"tx_json": []any{},
+		"secret":  map[string]any{},
+	})
+	require.NoError(t, err)
+
+	result, rpcErr := (&handlers.SubmitMethod{}).Handle(ctx, params)
+	require.Nil(t, rpcErr)
+	response, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, strings.ToUpper(rawBlob), response["tx_blob"])
+	assert.Empty(t, response["deprecated"])
+	assert.NotContains(t, response, "hash", "raw submit retains legacy nested-hash shape")
+	assert.Equal(t, strings.ToUpper(rawBlob), mock.lastTxBlob)
+
+	txJSON, ok := response["tx_json"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Payment", txJSON["TransactionType"])
+	assert.Equal(t, "1000000", txJSON["Amount"])
+	assert.NotEmpty(t, txJSON["SigningPubKey"])
+	assert.NotEmpty(t, txJSON["TxnSignature"])
+	assert.Empty(t, txJSON["Memos"])
+	assert.Equal(t, handlers.CalculateTxHash(rawBlob), txJSON["hash"])
+	assert.NotContains(t, txJSON, "DeliverMax", "raw submit does not apply DeliverMax projection")
+	assert.Equal(t, 1, mock.submitCalls)
+}
+
+func TestSubmitMethodRawBlobInvalidTransactionEnvelope(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+		Services:   newSubmitTestServices(mock),
+	}
+	params, err := json.Marshal(map[string]any{"tx_blob": "00"})
+	require.NoError(t, err)
+
+	result, rpcErr := (&handlers.SubmitMethod{}).Handle(ctx, params)
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, "invalidTransaction", rpcErr.ErrorString)
+	assert.NotEmpty(t, rpcErr.ErrorException)
+	assert.Zero(t, mock.submitCalls)
+}
+
+func TestSubmitMethodRawBlobRejectsBadSignatureBeforeSubmission(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	mock.standalone = false
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+		Services:   newSubmitTestServices(mock),
+	}
+	blob := rawSubmitBlob(t, map[string]any{
+		"TransactionType": "AccountSet",
+		"Account":         validAccountAddress,
+		"Fee":             "10",
+		"Sequence":        1,
+	})
+	decoded, err := binarycodec.Decode(blob)
+	require.NoError(t, err)
+	signature, ok := decoded["TxnSignature"].(string)
+	require.True(t, ok)
+	decoded["TxnSignature"] = strings.Repeat("00", len(signature)/2)
+	badBlob, err := binarycodec.Encode(decoded)
+	require.NoError(t, err)
+	params, err := json.Marshal(map[string]any{"tx_blob": badBlob})
+	require.NoError(t, err)
+
+	result, rpcErr := (&handlers.SubmitMethod{}).Handle(ctx, params)
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, "invalidTransaction", rpcErr.ErrorString)
+	assert.Equal(t, "fails local checks: Invalid signature.", rpcErr.ErrorException)
+	assert.Zero(t, mock.submitCalls)
+}
+
+func TestSubmitMethodRawBlobCanonicalizesFieldOrder(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+		Services:   newSubmitTestServices(mock),
+	}
+	canonicalBlob := rawSubmitBlob(t, map[string]any{
+		"TransactionType": "AccountSet",
+		"Account":         validAccountAddress,
+		"Fee":             "10",
+		"Sequence":        1,
+	})
+	canonicalBytes, err := hex.DecodeString(canonicalBlob)
+	require.NoError(t, err)
+	accountOffset := bytes.LastIndex(canonicalBytes, []byte{0x81, 0x14})
+	require.GreaterOrEqual(t, accountOffset, 0)
+	require.GreaterOrEqual(t, len(canonicalBytes), accountOffset+22)
+	accountField := append([]byte(nil), canonicalBytes[accountOffset:accountOffset+22]...)
+	nonCanonical := append(accountField, canonicalBytes[:accountOffset]...)
+	nonCanonical = append(nonCanonical, canonicalBytes[accountOffset+22:]...)
+	require.NotEqual(t, canonicalBytes, nonCanonical)
+	params, err := json.Marshal(map[string]any{"tx_blob": hex.EncodeToString(nonCanonical)})
+	require.NoError(t, err)
+
+	result, rpcErr := (&handlers.SubmitMethod{}).Handle(ctx, params)
+	require.Nil(t, rpcErr)
+	response, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, canonicalBlob, response["tx_blob"])
+	assert.Equal(t, canonicalBlob, mock.lastTxBlob)
+	txJSON, ok := response["tx_json"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, handlers.CalculateTxHash(canonicalBlob), txJSON["hash"])
+}
+
+func TestSubmitMethodAbsentBlobRequiresSigningCapability(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+		Services:   newSubmitTestServices(mock),
+	}
+	params, err := json.Marshal(map[string]any{
+		"tx_json": map[string]any{
+			"TransactionType": "AccountSet",
+			"Account":         validAccountAddress,
+		},
+	})
+	require.NoError(t, err)
+
+	result, rpcErr := (&handlers.SubmitMethod{}).Handle(ctx, params)
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcNOT_SUPPORTED, rpcErr.Code)
+	assert.Equal(t, "Signing is not supported by this server.", rpcErr.Message)
+	assert.NotContains(t, rpcErr.Extra, "deprecated")
+	assert.Zero(t, mock.submitCalls)
+}
+
+func TestSubmitMethodAbsentBlobValidatesFailHardBeforeSigningCapability(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion2,
+		Services:   newSubmitTestServices(mock),
+	}
+	params, err := json.Marshal(map[string]any{
+		"tx_json":   map[string]any{},
+		"fail_hard": "true",
+	})
+	require.NoError(t, err)
+
+	result, rpcErr := (&handlers.SubmitMethod{}).Handle(ctx, params)
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+	assert.Equal(t, "Invalid field 'fail_hard', not boolean.", rpcErr.Message)
+	assert.NotContains(t, rpcErr.Extra, "deprecated")
+	assert.Zero(t, mock.submitCalls)
 }
 
 func (m *mockLedgerServiceSubmit) StoreTransaction(txHash [32]byte, txData []byte) error {
@@ -59,6 +253,53 @@ func newSubmitTestServices(mock *mockLedgerServiceSubmit) *types.ServiceContaine
 	}
 }
 
+func rawSubmitParams(t *testing.T, txJSON map[string]any, extra map[string]any) json.RawMessage {
+	t.Helper()
+	txBlob := rawSubmitBlob(t, txJSON)
+	params := map[string]any{"tx_blob": txBlob}
+	maps.Copy(params, extra)
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+	return paramsJSON
+}
+
+func rawSubmitBlob(t *testing.T, txJSON map[string]any) string {
+	t.Helper()
+	entropy := make([]byte, 16)
+	for i := range entropy {
+		entropy[i] = 0x11
+	}
+	privateKey, publicKey, err := ed25519.Algorithm{}.DeriveKeypair(entropy, false)
+	require.NoError(t, err)
+
+	wireJSON := maps.Clone(txJSON)
+	wireJSON["SigningPubKey"] = publicKey
+	delete(wireJSON, "TxnSignature")
+	encodedJSON, err := json.Marshal(wireJSON)
+	require.NoError(t, err)
+	transaction, err := tx.ParseJSON(encodedJSON)
+	require.NoError(t, err)
+	signature, err := txsign.SignTransaction(transaction, privateKey)
+	require.NoError(t, err)
+	wireJSON["TxnSignature"] = signature
+	blob, err := binarycodec.Encode(wireJSON)
+	require.NoError(t, err)
+	return blob
+}
+
+func signedSubmitParams(t *testing.T, txJSON map[string]any, extra map[string]any) json.RawMessage {
+	t.Helper()
+	params := map[string]any{
+		"tx_json":  txJSON,
+		"seed_hex": "DEDCE9CE67B451D852FD4E846FCDE31C",
+		"key_type": "secp256k1",
+	}
+	maps.Copy(params, extra)
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+	return paramsJSON
+}
+
 // TestSubmitMethodErrorValidation tests error handling for invalid inputs
 func TestSubmitMethodErrorValidation(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
@@ -71,7 +312,6 @@ func TestSubmitMethodErrorValidation(t *testing.T) {
 		ApiVersion: types.ApiVersion1,
 		Services:   services,
 	}
-
 	tests := []struct {
 		name          string
 		params        any
@@ -82,21 +322,21 @@ func TestSubmitMethodErrorValidation(t *testing.T) {
 		{
 			name:          "Missing tx_blob and tx_json - empty params",
 			params:        map[string]any{},
-			expectedError: "Either tx_blob or tx_json must be provided",
-			expectedCode:  types.RpcINVALID_PARAMS,
+			expectedError: "Signing is not supported by this server.",
+			expectedCode:  types.RpcNOT_SUPPORTED,
 		},
 		{
 			name:          "Missing tx_blob and tx_json - nil params",
 			params:        nil,
-			expectedError: "Either tx_blob or tx_json must be provided",
-			expectedCode:  types.RpcINVALID_PARAMS,
+			expectedError: "Signing is not supported by this server.",
+			expectedCode:  types.RpcNOT_SUPPORTED,
 		},
 		{
 			name: "Empty tx_blob",
 			params: map[string]any{
 				"tx_blob": "",
 			},
-			expectedError: "Either tx_blob or tx_json must be provided",
+			expectedError: "Invalid parameters.",
 			expectedCode:  types.RpcINVALID_PARAMS,
 		},
 		{
@@ -128,7 +368,7 @@ func TestSubmitMethodErrorValidation(t *testing.T) {
 			params: map[string]any{
 				"tx_blob": "ZZZZ",
 			},
-			expectedError: "Invalid tx_blob",
+			expectedError: "Invalid parameters.",
 			expectedCode:  types.RpcINVALID_PARAMS,
 		},
 	}
@@ -269,11 +509,7 @@ func TestSubmitMethodValidTxJson(t *testing.T) {
 			mock.submitResult = tc.mockResult
 			mock.submitError = nil
 
-			params := map[string]any{
-				"tx_json": tc.txJson,
-			}
-			paramsJSON, err := json.Marshal(params)
-			require.NoError(t, err)
+			paramsJSON := rawSubmitParams(t, tc.txJson, nil)
 
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 			require.Nil(t, rpcErr, "Expected no error")
@@ -299,8 +535,7 @@ func TestSubmitMethodStoredMetadataIncludesAffectedNodes(t *testing.T) {
 		ApiVersion: types.ApiVersion1,
 		Services:   newSubmitTestServices(mock),
 	}
-	params, err := json.Marshal(map[string]any{"tx_json": validStoredPaymentTransaction()})
-	require.NoError(t, err)
+	params := rawSubmitParams(t, validStoredPaymentTransaction(), nil)
 
 	_, rpcErr := (&handlers.SubmitMethod{}).Handle(ctx, params)
 	require.Nil(t, rpcErr)
@@ -338,18 +573,14 @@ func TestSubmitMethodResponseFields(t *testing.T) {
 	}
 
 	t.Run("Response contains all required fields", func(t *testing.T) {
-		params := map[string]any{
-			"tx_json": map[string]any{
-				"TransactionType": "Payment",
-				"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-				"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
-				"Amount":          "1000000",
-				"Fee":             "10",
-				"Sequence":        1,
-			},
-		}
-		paramsJSON, err := json.Marshal(params)
-		require.NoError(t, err)
+		paramsJSON := rawSubmitParams(t, map[string]any{
+			"TransactionType": "Payment",
+			"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount":          "1000000",
+			"Fee":             "10",
+			"Sequence":        1,
+		}, nil)
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)
@@ -386,18 +617,14 @@ func TestSubmitMethodResponseFields(t *testing.T) {
 	})
 
 	t.Run("tx_json is included in response", func(t *testing.T) {
-		params := map[string]any{
-			"tx_json": map[string]any{
-				"TransactionType": "Payment",
-				"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-				"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
-				"Amount":          "1000000",
-				"Fee":             "10",
-				"Sequence":        1,
-			},
-		}
-		paramsJSON, err := json.Marshal(params)
-		require.NoError(t, err)
+		paramsJSON := rawSubmitParams(t, map[string]any{
+			"TransactionType": "Payment",
+			"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount":          "1000000",
+			"Fee":             "10",
+			"Sequence":        1,
+		}, nil)
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)
@@ -564,11 +791,7 @@ func TestSubmitMethodEngineResults(t *testing.T) {
 				ValidatedLedger:     2,
 			}
 
-			params := map[string]any{
-				"tx_json": baseTxJson,
-			}
-			paramsJSON, err := json.Marshal(params)
-			require.NoError(t, err)
+			paramsJSON := rawSubmitParams(t, baseTxJson, nil)
 
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 			require.Nil(t, rpcErr, "Submit should not return RPC error even for transaction failures")
@@ -592,10 +815,8 @@ func TestSubmitMethodEngineResults(t *testing.T) {
 }
 
 // TestSubmitMethodMalformedTransaction tests malformed transaction handling.
-// A tx_json that is not a JSON object cannot be unmarshalled into a transaction
-// map, so the handler rejects it with invalidParams rather than silently
-// proceeding with an empty map. Object-shaped tx_json is accepted and validated
-// downstream by the ledger service.
+// Without tx_blob, submit is a signed path and capability admission precedes
+// tx_json validation. These fixtures verify the disabled-signing response.
 func TestSubmitMethodMalformedTransaction(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
 	services := newSubmitTestServices(mock)
@@ -619,34 +840,35 @@ func TestSubmitMethodMalformedTransaction(t *testing.T) {
 			name:        "String tx_json - rejected",
 			txJson:      "not a valid json object",
 			expectError: true,
-			errorMsg:    "Invalid field 'tx_json'",
+			errorMsg:    "Signing is not supported by this server.",
 			description: "A JSON string is not a transaction object",
 		},
 		{
 			name:        "Number tx_json - rejected",
 			txJson:      12345,
 			expectError: true,
-			errorMsg:    "Invalid field 'tx_json'",
+			errorMsg:    "Signing is not supported by this server.",
 			description: "A JSON number is not a transaction object",
 		},
 		{
 			name:        "Boolean tx_json - rejected",
 			txJson:      true,
 			expectError: true,
-			errorMsg:    "Invalid field 'tx_json'",
+			errorMsg:    "Signing is not supported by this server.",
 			description: "A JSON boolean is not a transaction object",
 		},
 		{
 			name:        "Array tx_json - rejected",
 			txJson:      []any{1, 2, 3},
 			expectError: true,
-			errorMsg:    "Invalid field 'tx_json'",
+			errorMsg:    "Signing is not supported by this server.",
 			description: "A JSON array is not a transaction object",
 		},
 		{
 			name:        "Empty tx_json object - accepted",
 			txJson:      map[string]any{},
-			expectError: false,
+			expectError: true,
+			errorMsg:    "Signing is not supported by this server.",
 			description: "Empty object is valid, ledger service validates content",
 		},
 		{
@@ -655,7 +877,8 @@ func TestSubmitMethodMalformedTransaction(t *testing.T) {
 				"TransactionType": "Payment",
 				"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
 			},
-			expectError: false,
+			expectError: true,
+			errorMsg:    "Signing is not supported by this server.",
 			description: "Minimal valid transaction structure",
 		},
 	}
@@ -675,7 +898,7 @@ func TestSubmitMethodMalformedTransaction(t *testing.T) {
 			if tc.expectError {
 				assert.Nil(t, result, "Expected nil result for error case")
 				require.NotNil(t, rpcErr, "Expected RPC error")
-				assert.Equal(t, types.RpcINVALID_PARAMS, rpcErr.Code)
+				assert.Equal(t, types.RpcNOT_SUPPORTED, rpcErr.Code)
 				assert.Contains(t, rpcErr.Message, tc.errorMsg)
 			} else {
 				require.Nil(t, rpcErr, "Expected no error - validation in ledger service")
@@ -695,16 +918,14 @@ func TestSubmitMethodServiceUnavailable(t *testing.T) {
 		Services:   nil,
 	}
 
-	params := map[string]any{
-		"tx_json": map[string]any{
-			"TransactionType": "Payment",
-			"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-			"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
-			"Amount":          "1000000",
-		},
-	}
-	paramsJSON, err := json.Marshal(params)
-	require.NoError(t, err)
+	paramsJSON := rawSubmitParams(t, map[string]any{
+		"TransactionType": "Payment",
+		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+		"Amount":          "1000000",
+		"Fee":             "10",
+		"Sequence":        1,
+	}, nil)
 
 	result, rpcErr := method.Handle(ctx, paramsJSON)
 
@@ -724,16 +945,14 @@ func TestSubmitMethodServiceNilLedger(t *testing.T) {
 		Services:   &types.ServiceContainer{Ledger: nil},
 	}
 
-	params := map[string]any{
-		"tx_json": map[string]any{
-			"TransactionType": "Payment",
-			"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-			"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
-			"Amount":          "1000000",
-		},
-	}
-	paramsJSON, err := json.Marshal(params)
-	require.NoError(t, err)
+	paramsJSON := rawSubmitParams(t, map[string]any{
+		"TransactionType": "Payment",
+		"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+		"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+		"Amount":          "1000000",
+		"Fee":             "10",
+		"Sequence":        1,
+	}, nil)
 
 	result, rpcErr := method.Handle(ctx, paramsJSON)
 
@@ -778,16 +997,14 @@ func TestSubmitMethodSubmitError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mock.submitError = tc.submitError
 
-			params := map[string]any{
-				"tx_json": map[string]any{
-					"TransactionType": "Payment",
-					"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-					"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
-					"Amount":          "1000000",
-				},
-			}
-			paramsJSON, err := json.Marshal(params)
-			require.NoError(t, err)
+			paramsJSON := rawSubmitParams(t, map[string]any{
+				"TransactionType": "Payment",
+				"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+				"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+				"Amount":          "1000000",
+				"Fee":             "10",
+				"Sequence":        1,
+			}, nil)
 
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 
@@ -941,14 +1158,7 @@ func TestSubmitMethodOptionalParams(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			params := map[string]any{
-				"tx_json": baseTxJson,
-			}
-			// Add extra params
-			maps.Copy(params, tc.extraParams)
-
-			paramsJSON, err := json.Marshal(params)
-			require.NoError(t, err)
+			paramsJSON := rawSubmitParams(t, baseTxJson, tc.extraParams)
 
 			result, rpcErr := method.Handle(ctx, paramsJSON)
 			require.Nil(t, rpcErr, "Expected no error")
@@ -971,6 +1181,7 @@ func TestSubmitMethodOptionalParams(t *testing.T) {
 func TestSubmitMethodSigningCredentials(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
 	services := newSubmitTestServices(mock)
+	services.Capabilities.SigningEnabled = true
 
 	method := &handlers.SubmitMethod{}
 	ctx := &types.RpcContext{
@@ -1054,8 +1265,10 @@ func TestSubmitMethodSigningCredentials(t *testing.T) {
 			require.NoError(t, err)
 
 			// The response must contain the deprecated warning
-			assert.Contains(t, resp, "deprecated",
-				"sign-and-submit response must include deprecation warning")
+			assert.Equal(t,
+				"Signing support in the 'submit' command has been deprecated and will be removed in a future version of the server. Please migrate to a standalone signing tool.",
+				resp["deprecated"],
+			)
 
 			// The tx_json in the response must contain a signature
 			txJson, ok := resp["tx_json"].(map[string]any)
@@ -1080,6 +1293,8 @@ func TestSubmitMethodSigningCredentials(t *testing.T) {
 
 func TestSubmitMethodEmptyCredentialIsPresent(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
+	services := newSubmitTestServices(mock)
+	services.Capabilities.SigningEnabled = true
 	params := json.RawMessage(`{
 		"tx_json": {
 			"TransactionType": "Payment",
@@ -1092,13 +1307,17 @@ func TestSubmitMethodEmptyCredentialIsPresent(t *testing.T) {
 		Context:    context.Background(),
 		Role:       types.RoleUser,
 		ApiVersion: types.ApiVersion1,
-		Services:   newSubmitTestServices(mock),
+		Services:   services,
 	}
 
 	_, rpcErr := (&handlers.SubmitMethod{}).Handle(ctx, params)
 	require.NotNil(t, rpcErr)
 	assert.Equal(t, types.RpcBAD_SEED, rpcErr.Code)
 	assert.Equal(t, "Invalid field 'secret'.", rpcErr.Message)
+	assert.Equal(t,
+		"Signing support in the 'submit' command has been deprecated and will be removed in a future version of the server. Please migrate to a standalone signing tool.",
+		rpcErr.Extra["deprecated"],
+	)
 }
 
 // TestSubmitMethodApiV2Response tests API v2 specific response formatting.
@@ -1106,6 +1325,7 @@ func TestSubmitMethodEmptyCredentialIsPresent(t *testing.T) {
 func TestSubmitMethodApiV2Response(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
 	services := newSubmitTestServices(mock)
+	services.Capabilities.SigningEnabled = true
 
 	method := &handlers.SubmitMethod{}
 
@@ -1126,11 +1346,7 @@ func TestSubmitMethodApiV2Response(t *testing.T) {
 			Services:   services,
 		}
 
-		params := map[string]any{
-			"tx_json": baseTxJson,
-		}
-		paramsJSON, err := json.Marshal(params)
-		require.NoError(t, err)
+		paramsJSON := signedSubmitParams(t, baseTxJson, nil)
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)
@@ -1160,11 +1376,7 @@ func TestSubmitMethodApiV2Response(t *testing.T) {
 			Services:   services,
 		}
 
-		params := map[string]any{
-			"tx_json": baseTxJson,
-		}
-		paramsJSON, err := json.Marshal(params)
-		require.NoError(t, err)
+		paramsJSON := signedSubmitParams(t, baseTxJson, nil)
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)
@@ -1181,10 +1393,10 @@ func TestSubmitMethodApiV2Response(t *testing.T) {
 		assert.True(t, hasRootHash, "API v2 should have hash at root level")
 		assert.NotEmpty(t, rootHash)
 
-		// Also in tx_json
+		// API v2+: hash moves to the response root; it is not a serialized field.
 		txJson, ok := resp["tx_json"].(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, rootHash, txJson["hash"], "root hash and tx_json hash should match")
+		assert.NotContains(t, txJson, "hash")
 	})
 
 	t.Run("API v3 has hash at root", func(t *testing.T) {
@@ -1195,11 +1407,7 @@ func TestSubmitMethodApiV2Response(t *testing.T) {
 			Services:   services,
 		}
 
-		params := map[string]any{
-			"tx_json": baseTxJson,
-		}
-		paramsJSON, err := json.Marshal(params)
-		require.NoError(t, err)
+		paramsJSON := signedSubmitParams(t, baseTxJson, nil)
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)
@@ -1224,6 +1432,7 @@ func TestSubmitMethodApiV2Response(t *testing.T) {
 func TestSubmitMethodDeliverMax(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
 	services := newSubmitTestServices(mock)
+	services.Capabilities.SigningEnabled = true
 
 	method := &handlers.SubmitMethod{}
 
@@ -1235,18 +1444,14 @@ func TestSubmitMethodDeliverMax(t *testing.T) {
 			Services:   services,
 		}
 
-		params := map[string]any{
-			"tx_json": map[string]any{
-				"TransactionType": "Payment",
-				"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-				"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
-				"Amount":          "1000000",
-				"Fee":             "10",
-				"Sequence":        1,
-			},
-		}
-		paramsJSON, err := json.Marshal(params)
-		require.NoError(t, err)
+		paramsJSON := signedSubmitParams(t, map[string]any{
+			"TransactionType": "Payment",
+			"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount":          "1000000",
+			"Fee":             "10",
+			"Sequence":        1,
+		}, nil)
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)
@@ -1277,18 +1482,14 @@ func TestSubmitMethodDeliverMax(t *testing.T) {
 			Services:   services,
 		}
 
-		params := map[string]any{
-			"tx_json": map[string]any{
-				"TransactionType": "Payment",
-				"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-				"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
-				"Amount":          "1000000",
-				"Fee":             "10",
-				"Sequence":        1,
-			},
-		}
-		paramsJSON, err := json.Marshal(params)
-		require.NoError(t, err)
+		paramsJSON := signedSubmitParams(t, map[string]any{
+			"TransactionType": "Payment",
+			"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Destination":     "rPMh7Pi9ct699iZUTWaytJUoHcJ7cgyziK",
+			"Amount":          "1000000",
+			"Fee":             "10",
+			"Sequence":        1,
+		}, nil)
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)
@@ -1320,17 +1521,13 @@ func TestSubmitMethodDeliverMax(t *testing.T) {
 			Services:   services,
 		}
 
-		params := map[string]any{
-			"tx_json": map[string]any{
-				"TransactionType": "AccountSet",
-				"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-				"Fee":             "12",
-				"Sequence":        5,
-				"SetFlag":         8,
-			},
-		}
-		paramsJSON, err := json.Marshal(params)
-		require.NoError(t, err)
+		paramsJSON := signedSubmitParams(t, map[string]any{
+			"TransactionType": "AccountSet",
+			"Account":         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+			"Fee":             "12",
+			"Sequence":        5,
+			"SetFlag":         8,
+		}, nil)
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)
@@ -1388,8 +1585,7 @@ func TestSubmitMethodIndependentBooleans(t *testing.T) {
 			ValidatedLedger:     2,
 		}
 
-		params := map[string]any{"tx_json": baseTxJson}
-		paramsJSON, _ := json.Marshal(params)
+		paramsJSON := rawSubmitParams(t, baseTxJson, nil)
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)
@@ -1418,8 +1614,7 @@ func TestSubmitMethodIndependentBooleans(t *testing.T) {
 			ValidatedLedger:     2,
 		}
 
-		params := map[string]any{"tx_json": baseTxJson}
-		paramsJSON, _ := json.Marshal(params)
+		paramsJSON := rawSubmitParams(t, baseTxJson, nil)
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)
@@ -1448,8 +1643,7 @@ func TestSubmitMethodIndependentBooleans(t *testing.T) {
 			ValidatedLedger:     2,
 		}
 
-		params := map[string]any{"tx_json": baseTxJson}
-		paramsJSON, _ := json.Marshal(params)
+		paramsJSON := rawSubmitParams(t, baseTxJson, nil)
 
 		result, rpcErr := method.Handle(ctx, paramsJSON)
 		require.Nil(t, rpcErr)

--- a/internal/rpc/submit_test.go
+++ b/internal/rpc/submit_test.go
@@ -1320,6 +1320,50 @@ func TestSubmitMethodEmptyCredentialIsPresent(t *testing.T) {
 	)
 }
 
+func TestSubmitMethodMissingTxJSONPreservesCredentialPrecedence(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	services := newSubmitTestServices(mock)
+	services.Capabilities.SigningEnabled = true
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion1,
+		Services:   services,
+	}
+
+	tests := []struct {
+		name    string
+		secret  string
+		code    int
+		message string
+	}{
+		{
+			name:    "valid credential",
+			secret:  "masterpassphrase",
+			code:    types.RpcINVALID_PARAMS,
+			message: "Missing field 'tx_json'.",
+		},
+		{
+			name:    "invalid credential",
+			secret:  "",
+			code:    types.RpcBAD_SEED,
+			message: "Invalid field 'secret'.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			params, err := json.Marshal(map[string]any{"secret": test.secret})
+			require.NoError(t, err)
+			_, rpcErr := (&handlers.SubmitMethod{}).Handle(ctx, params)
+			require.NotNil(t, rpcErr)
+			assert.Equal(t, test.code, rpcErr.Code)
+			assert.Equal(t, test.message, rpcErr.Message)
+		})
+	}
+	assert.Zero(t, mock.submitCalls)
+}
+
 // TestSubmitMethodApiV2Response tests API v2 specific response formatting.
 // API v2 should include "hash" at the root level of the response.
 func TestSubmitMethodApiV2Response(t *testing.T) {

--- a/internal/rpc/txprojection/projection.go
+++ b/internal/rpc/txprojection/projection.go
@@ -9,6 +9,14 @@ import (
 	"strings"
 )
 
+// Path identifies the response contract that owns transaction projection.
+type Path uint8
+
+const (
+	PathSigned Path = iota
+	PathCanonical
+)
+
 // ProjectJSON returns a projected copy of a transaction JSON object. The
 // source map and all values reachable through it are left untouched.
 func ProjectJSON(txJSON map[string]any, hash string, apiVersion int) map[string]any {
@@ -19,6 +27,42 @@ func ProjectJSON(txJSON map[string]any, hash string, apiVersion int) map[string]
 		projected["hash"] = strings.ToUpper(hash)
 	}
 	return projected
+}
+
+// ProjectJSONForPath returns an immutable transaction copy using the endpoint
+// and API-version-specific response contract. Values reachable through the
+// source map are never changed by the projection.
+func ProjectJSONForPath(txJSON map[string]any, hash string, apiVersion int, path Path) map[string]any {
+	projected := make(map[string]any, len(txJSON)+1)
+	maps.Copy(projected, txJSON)
+
+	// Hash is a response field, not a serialized transaction field. Remove any
+	// source copy before applying the path-specific placement below.
+	delete(projected, "hash")
+	if path != PathCanonical {
+		InjectDeliverMax(projected, apiVersion)
+	}
+
+	if hash == "" {
+		return projected
+	}
+	hash = strings.ToUpper(hash)
+	if path == PathCanonical || apiVersion == 1 {
+		projected["hash"] = hash
+	}
+	return projected
+}
+
+// FormatResult builds a transaction response without mutating the source map.
+func FormatResult(txJSON map[string]any, txBlob, hash string, apiVersion int, path Path) map[string]any {
+	response := map[string]any{
+		"tx_blob": txBlob,
+		"tx_json": ProjectJSONForPath(txJSON, hash, apiVersion, path),
+	}
+	if path != PathCanonical && apiVersion > 1 && hash != "" {
+		response["hash"] = strings.ToUpper(hash)
+	}
+	return response
 }
 
 // ProjectRaw applies the API-specific transaction projection to raw JSON

--- a/internal/tx/sign/signature.go
+++ b/internal/tx/sign/signature.go
@@ -11,6 +11,7 @@ import (
 
 	txcore "github.com/LeJamon/go-xrpl/internal/tx"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	addresscodec "github.com/LeJamon/go-xrpl/codec/addresscodec"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
@@ -90,6 +91,133 @@ var ErrInternalLookup = ter.Errorf(ter.TefINTERNAL, "internal error during signe
 func IsMultiSigned(tx txcore.Transaction) bool {
 	common := tx.GetCommon()
 	return len(common.Signers) > 0 && common.SigningPubKey == ""
+}
+
+// CheckSTTxSignature mirrors the signature portion of rippled's checkValidity.
+// It returns rippled's failure reason, or an empty string when the outer and
+// optional counterparty signatures are valid.
+func CheckSTTxSignature(transaction txcore.Transaction, rules *amendment.Rules, checkSigs bool) string {
+	common := transaction.GetCommon()
+	if common.GetFlags()&txcore.TfInnerBatchTxn != 0 && rules != nil && rules.Enabled(amendment.FeatureBatch) {
+		if common.HasField("TxnSignature") || common.SigningPubKey != "" || common.HasField("Signers") {
+			return "Malformed: Invalid inner batch transaction."
+		}
+		if !rules.Enabled(amendment.FeatureFixBatchInnerSigs) {
+			return ""
+		}
+	}
+	if !checkSigs {
+		return ""
+	}
+
+	var reason string
+	if common.SigningPubKey == "" {
+		reason = checkSTTxMultiSign(transaction)
+	} else {
+		if common.HasField("Signers") {
+			return "Cannot both single- and multi-sign."
+		}
+		if err := VerifySignature(transaction, true); err != nil {
+			return "Invalid signature."
+		}
+	}
+	if reason != "" {
+		return reason
+	}
+
+	if common.CounterpartySignature != nil {
+		if reason := checkSTTxCounterpartySignature(transaction, common.CounterpartySignature); reason != "" {
+			return reason
+		}
+	}
+	return ""
+}
+
+func checkSTTxCounterpartySignature(transaction txcore.Transaction, cp *txcore.CounterpartySignature) string {
+	hasSigners := len(cp.Signers) > 0
+	hasTxnSignature := cp.TxnSignature != ""
+	if raw := transaction.GetRawBytes(); len(raw) > 0 {
+		if fields, err := binarycodec.DecodeBytes(raw); err == nil {
+			if object, ok := fields["CounterpartySignature"].(map[string]any); ok {
+				_, hasSigners = object["Signers"]
+				_, hasTxnSignature = object["TxnSignature"]
+			}
+		}
+	}
+
+	if cp.SigningPubKey != "" {
+		if hasSigners {
+			return counterpartyPrefix + "Cannot both single- and multi-sign."
+		}
+		if err := verifyCounterpartySingleSign(transaction, cp, true); err != nil {
+			return err.Error()
+		}
+		return ""
+	}
+	if !hasSigners {
+		return counterpartyPrefix + "Empty SigningPubKey."
+	}
+	if hasTxnSignature {
+		return counterpartyPrefix + "Cannot both single- and multi-sign."
+	}
+	if len(cp.Signers) < MinMultiSigners || len(cp.Signers) > MaxMultiSigners {
+		return counterpartyPrefix + "Invalid Signers array size."
+	}
+	if err := verifyCounterpartyMultiSign(transaction, cp, true); err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+func checkSTTxMultiSign(transaction txcore.Transaction) string {
+	common := transaction.GetCommon()
+	if !common.HasField("Signers") {
+		return "Empty SigningPubKey."
+	}
+	if common.HasField("TxnSignature") {
+		return "Cannot both single- and multi-sign."
+	}
+	if len(common.Signers) < MinMultiSigners || len(common.Signers) > MaxMultiSigners {
+		return "Invalid Signers array size."
+	}
+
+	feePayer := common.Account
+	if common.Delegate != "" {
+		feePayer = common.Delegate
+	}
+	feePayerID, err := state.DecodeAccountID(feePayer)
+	if err != nil {
+		return "Invalid multisigner."
+	}
+	txMap, err := flattenForSigning(transaction)
+	if err != nil {
+		return "Internal signature check failure."
+	}
+
+	var previous [20]byte
+	for _, wrapper := range common.Signers {
+		signer := wrapper.Signer
+		signerID, err := state.DecodeAccountID(signer.Account)
+		if err != nil {
+			return "Invalid multisigner."
+		}
+		if signerID == feePayerID {
+			return "Invalid multisigner."
+		}
+		if signerID == previous {
+			return "Duplicate Signers not allowed."
+		}
+		if bytes.Compare(previous[:], signerID[:]) > 0 {
+			return "Unsorted Signers array."
+		}
+		previous = signerID
+
+		payload, err := binarycodec.EncodeForMultisigning(copyMap(txMap), signer.Account)
+		if err != nil || !verifySignatureForKey(payload, signer.SigningPubKey, signer.TxnSignature, true) {
+			return "Invalid signature on account " + signer.Account + "."
+		}
+	}
+	return ""
 }
 
 // VerifySignature verifies that a transaction is properly signed.

--- a/internal/tx/sign/signature_wire_presence_test.go
+++ b/internal/tx/sign/signature_wire_presence_test.go
@@ -2,6 +2,7 @@ package sign
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/LeJamon/go-xrpl/codec/binarycodec"
@@ -42,5 +43,97 @@ func TestVerifySignaturePreservesExplicitEmptyMemos(t *testing.T) {
 
 	if err := VerifySignature(txn, true); err != nil {
 		t.Fatalf("verify signature: %v", err)
+	}
+	if reason := CheckSTTxSignature(txn, nil, true); reason != "" {
+		t.Fatalf("check STTx signature: %s", reason)
+	}
+
+	wire["TxnSignature"] = strings.Repeat("00", 64)
+	badBlob, err := binarycodec.EncodeBytes(wire)
+	if err != nil {
+		t.Fatalf("encode bad signature: %v", err)
+	}
+	badTxn, err := txcore.ParseFromBinary(badBlob)
+	if err != nil {
+		t.Fatalf("parse bad signature: %v", err)
+	}
+	if reason := CheckSTTxSignature(badTxn, nil, true); reason != "Invalid signature." {
+		t.Fatalf("bad signature reason = %q", reason)
+	}
+	if reason := CheckSTTxSignature(badTxn, nil, false); reason != "" {
+		t.Fatalf("disabled signature checking reason = %q", reason)
+	}
+
+	_, signerPubKey, signerAccount := cpKeypair(t, 0x22)
+	for _, test := range []struct {
+		name         string
+		parsed       *txcore.CounterpartySignature
+		counterparty map[string]any
+		want         string
+	}{
+		{
+			name: "single sign with explicit empty signers",
+			parsed: &txcore.CounterpartySignature{
+				SigningPubKey: signerPubKey,
+				TxnSignature:  "00",
+			},
+			counterparty: map[string]any{
+				"SigningPubKey": signerPubKey,
+				"TxnSignature":  "00",
+				"Signers":       []map[string]any{},
+			},
+			want: "Counterparty: Cannot both single- and multi-sign.",
+		},
+		{
+			name:   "multi sign with explicit empty signers",
+			parsed: &txcore.CounterpartySignature{},
+			counterparty: map[string]any{
+				"SigningPubKey": "",
+				"Signers":       []map[string]any{},
+			},
+			want: "Counterparty: Invalid Signers array size.",
+		},
+		{
+			name: "multi sign with explicit empty transaction signature",
+			parsed: &txcore.CounterpartySignature{
+				Signers: []txcore.SignerWrapper{{
+					Signer: txcore.Signer{
+						Account:       signerAccount,
+						SigningPubKey: signerPubKey,
+						TxnSignature:  "00",
+					},
+				}},
+			},
+			counterparty: map[string]any{
+				"SigningPubKey": "",
+				"TxnSignature":  "",
+				"Signers": []map[string]any{{
+					"Signer": map[string]any{
+						"Account":       signerAccount,
+						"SigningPubKey": signerPubKey,
+						"TxnSignature":  "00",
+					},
+				}},
+			},
+			want: "Counterparty: Cannot both single- and multi-sign.",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			transaction := primarySignedTx(t)
+			transaction.GetCommon().CounterpartySignature = test.parsed
+			candidate, err := transaction.Flatten()
+			if err != nil {
+				t.Fatalf("flatten transaction: %v", err)
+			}
+			candidate["CounterpartySignature"] = test.counterparty
+			blob, err := binarycodec.EncodeBytes(candidate)
+			if err != nil {
+				t.Fatalf("encode transaction: %v", err)
+			}
+			transaction.SetRawBytes(blob)
+			if reason := CheckSTTxSignature(transaction, nil, true); reason != test.want {
+				t.Fatalf("counterparty signature reason = %q, want %q", reason, test.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Canonicalize blob and signing-submit validation and endpoint projection.
- Return canonical simulation output and preserve v1/v2 transaction wire contracts.

## Verification
- Submission, signing, simulation, and full RPC tests
- Targeted race, vet, strict lint, build, and oracle review

Refs #1486

Stack layer 4 of 16; depends on #1569.