### PR TITLE
fix: snapshot RPC submission state (#1486)

### DIFF
--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -48,6 +48,21 @@ type SubmitResult struct {
 
 	// ValidatedLedger is the highest validated ledger sequence
 	ValidatedLedger uint32
+
+	// CurrentLedgerState is the immutable state snapshot captured at submit
+	// time. It is nil when no validated ledger exists or the authoritative
+	// account/fee state could not be derived.
+	CurrentLedgerState *SubmitLedgerState
+}
+
+// SubmitLedgerState contains the current-ledger values returned by submit.
+// The pointer on SubmitResult distinguishes an unavailable snapshot from
+// valid zero-valued fields.
+type SubmitLedgerState struct {
+	ValidatedLedgerIndex     uint32
+	OpenLedgerCost           uint64
+	AccountSequenceNext      uint32
+	AccountSequenceAvailable uint32
 }
 
 // SubmitTransaction is the RPC entry point for tx ingress. It mirrors
@@ -129,7 +144,8 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 
 	outcome := s.openLedgerView.SubmitDetailed(ptx, cfg, s.txQueue)
 
-	currentSeq := s.openLedgerView.Current().Sequence()
+	current := s.openLedgerView.Current()
+	currentSeq := current.Sequence()
 	result := &SubmitResult{
 		Result:        outcome.Result,
 		Applied:       outcome.Applied,
@@ -140,6 +156,7 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 	}
 	if s.validatedLedger != nil {
 		result.ValidatedLedger = s.validatedLedger.Sequence()
+		result.CurrentLedgerState = s.submitLedgerStateLocked(current, ptx.Parsed, cfg)
 	}
 	if outcome.Class == openledger.ResultSuccess {
 		s.rememberRelayTransaction(ptx.Hash, ptx.Blob, outcome.Queued)
@@ -186,6 +203,74 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 	}
 
 	return result, nil
+}
+
+// submitLedgerStateLocked derives the four submit-state fields from the same
+// post-submit view and TxQ snapshot while the service lock is held. Any read or
+// decode failure omits the complete snapshot rather than returning mixed state.
+func (s *Service) submitLedgerStateLocked(
+	current *ledger.Ledger,
+	parsedTx tx.Transaction,
+	cfg openledger.ApplyConfig,
+) *SubmitLedgerState {
+	if current == nil || parsedTx == nil {
+		return nil
+	}
+
+	common := parsedTx.GetCommon()
+	if common == nil {
+		return nil
+	}
+	accountID, err := state.DecodeAccountID(common.Account)
+	if err != nil {
+		return nil
+	}
+	account, err := state.ReadAccountRoot(current, accountID)
+	if err != nil {
+		return nil
+	}
+	accountSeq := uint32(0)
+	if account != nil {
+		accountSeq = account.Sequence
+	}
+
+	baseFee, reserveBase, reserveIncrement, err := readFeesFromLedgerContext(context.Background(), current)
+	if err != nil {
+		return nil
+	}
+	feeConfig := tx.EngineConfig{
+		BaseFee:                   baseFee,
+		ReserveBase:               reserveBase,
+		ReserveIncrement:          reserveIncrement,
+		LedgerSequence:            current.Sequence(),
+		ParentCloseTime:           cfg.ParentCloseTime,
+		ApplicationCloseTime:      cfg.ApplicationCloseTime,
+		ApplicationCloseTimeSet:   cfg.ApplicationCloseTimeSet,
+		ParentHash:                current.ParentHash(),
+		NetworkID:                 s.config.NetworkID,
+		SkipSignatureVerification: cfg.SkipSignatureVerification,
+		ApplyFlags:                cfg.ApplyFlags,
+		ViewOpen:                  cfg.Mode == openledger.OpenLedgerMode,
+		Standalone:                s.config.Standalone,
+		Rules:                     cfg.Rules,
+		FeeTrack:                  s.feeTrack,
+		Logger:                    s.config.Logger,
+	}
+	baseFeeForTx := computeBaseFeeForTx(current, parsedTx, feeConfig)
+	availableSeq := accountSeq
+	openLedgerCost := baseFeeForTx
+	if s.txQueue != nil {
+		feeAndSeq := s.txQueue.TxRequiredFeeAndSeq(accountID, accountSeq, baseFeeForTx, current.TxCount())
+		openLedgerCost = feeAndSeq.RequiredFee
+		availableSeq = feeAndSeq.AvailableSeq
+	}
+
+	return &SubmitLedgerState{
+		ValidatedLedgerIndex:     s.validatedLedger.Sequence(),
+		OpenLedgerCost:           openLedgerCost,
+		AccountSequenceNext:      accountSeq,
+		AccountSequenceAvailable: availableSeq,
+	}
 }
 
 // dispatchProposedTransaction publishes only transactions committed to the

--- a/internal/ledger/service/tx_query_submit_state_test.go
+++ b/internal/ledger/service/tx_query_submit_state_test.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/LeJamon/go-xrpl/internal/ledger/genesis"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+func TestSubmitTransactionOmitsStateWithoutValidatedLedger(t *testing.T) {
+	svc, err := New(Config{Standalone: true, GenesisConfig: genesis.DefaultConfig()})
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("service.Start: %v", err)
+	}
+	t.Cleanup(svc.Stop)
+
+	svc.mu.Lock()
+	svc.validatedLedger = nil
+	svc.mu.Unlock()
+
+	env := jtx.NewTestEnv(t)
+	master := jtx.MasterAccount()
+	destination := jtx.NewAccount("submit-state-destination")
+	txn := payment.Pay(master, destination, 100_000_000).Fee(10).Sequence(1).Build()
+	env.SignWith(txn, master)
+	blob, err := tx.SerializeTransaction(txn)
+	if err != nil {
+		t.Fatalf("SerializeTransaction: %v", err)
+	}
+	parsed, err := tx.ParseFromBinary(blob)
+	if err != nil {
+		t.Fatalf("ParseFromBinary: %v", err)
+	}
+	result, err := svc.SubmitTransaction(parsed, blob, false)
+	if err != nil {
+		t.Fatalf("SubmitTransaction: %v", err)
+	}
+	if result.CurrentLedgerState != nil {
+		t.Fatalf("submit state = %+v, want nil without validated ledger", result.CurrentLedgerState)
+	}
+}

--- a/internal/ledger/service/tx_query_submit_test.go
+++ b/internal/ledger/service/tx_query_submit_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
+	"github.com/LeJamon/go-xrpl/internal/txq"
 )
 
 // signedPaymentWithFee builds a signed Payment blob carrying an explicit
@@ -93,6 +94,9 @@ func TestService_SubmitTransaction_RejectsOversizedMemo(t *testing.T) {
 	if res.Applied {
 		t.Errorf("Applied = true, want false for a memo-rejected tx")
 	}
+	if res.CurrentLedgerState != nil {
+		t.Errorf("local rejection must omit current-ledger state, got %+v", res.CurrentLedgerState)
+	}
 }
 
 func submitBlob(t *testing.T, svc *service.Service, blob []byte, failHard bool) *service.SubmitResult {
@@ -135,6 +139,18 @@ func TestService_SubmitTransaction_AppliesAtOrAboveFeeLevel(t *testing.T) {
 	if !openLedgerHasTx(t, svc, hash) {
 		t.Errorf("applied tx not present in open view")
 	}
+	if res.CurrentLedgerState == nil {
+		t.Fatal("applied submit must include current-ledger state")
+	}
+	if got := res.CurrentLedgerState.AccountSequenceNext; got != 2 {
+		t.Errorf("account_sequence_next = %d, want post-apply sequence 2", got)
+	}
+	if got := res.CurrentLedgerState.AccountSequenceAvailable; got != 2 {
+		t.Errorf("account_sequence_available = %d, want 2", got)
+	}
+	if res.CurrentLedgerState.OpenLedgerCost == 0 || res.CurrentLedgerState.ValidatedLedgerIndex == 0 {
+		t.Errorf("submit state missing fee/validated index: %+v", res.CurrentLedgerState)
+	}
 }
 
 // TestService_SubmitTransaction_QueuesBelowFeeLevel verifies that a tx
@@ -163,6 +179,62 @@ func TestService_SubmitTransaction_QueuesBelowFeeLevel(t *testing.T) {
 	}
 	if openLedgerHasTx(t, svc, hash) {
 		t.Errorf("queued tx must not be present in the open view")
+	}
+	if res.CurrentLedgerState == nil {
+		t.Fatal("queued submit must include current-ledger state")
+	}
+	if got := res.CurrentLedgerState.AccountSequenceNext; got != 1 {
+		t.Errorf("queued account_sequence_next = %d, want unchanged sequence 1", got)
+	}
+	if got := res.CurrentLedgerState.AccountSequenceAvailable; got != 2 {
+		t.Errorf("queued account_sequence_available = %d, want just-admitted sequence 2", got)
+	}
+}
+
+func TestService_SubmitTransaction_QueuedSnapshotUsesEscalatedFee(t *testing.T) {
+	cfg := service.DefaultConfig()
+	cfg.Standalone = true
+	queueCfg := txq.StandaloneConfig()
+	queueCfg.MinimumTxnInLedgerStandalone = 1
+	queueCfg.TargetTxnInLedger = 1
+	cfg.TxQ = &queueCfg
+	svc, err := service.New(cfg)
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("service.Start: %v", err)
+	}
+	t.Cleanup(svc.Stop)
+
+	env := jtx.NewTestEnv(t)
+	master := jtx.MasterAccount()
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	firstBlob, _ := signedPaymentWithFee(t, env, master, alice, 100_000_000, 10, 1)
+	if first := submitBlob(t, svc, firstBlob, false); first.Result != ter.TesSUCCESS {
+		t.Fatalf("first payment result = %s, want tesSUCCESS", first.Result)
+	}
+	secondBlob, _ := signedPaymentWithFee(t, env, master, bob, 100_000_000, 10, 2)
+	if second := submitBlob(t, svc, secondBlob, false); second.Result != ter.TesSUCCESS {
+		t.Fatalf("second payment result = %s, want tesSUCCESS", second.Result)
+	}
+	queuedBlob, _ := signedPaymentWithFee(t, env, master, jtx.NewAccount("carol"), 100_000_000, 1, 3)
+	queued := submitBlob(t, svc, queuedBlob, false)
+	if queued.Result != ter.TerQUEUED {
+		t.Fatalf("queued payment result = %s, want terQUEUED", queued.Result)
+	}
+	if queued.CurrentLedgerState == nil {
+		t.Fatal("queued submit must include current-ledger state")
+	}
+	if got := queued.CurrentLedgerState.AccountSequenceNext; got != 3 {
+		t.Errorf("account_sequence_next = %d, want unchanged sequence 3", got)
+	}
+	if got := queued.CurrentLedgerState.AccountSequenceAvailable; got != 4 {
+		t.Errorf("account_sequence_available = %d, want just-admitted sequence 4", got)
+	}
+	if got := queued.CurrentLedgerState.OpenLedgerCost; got <= 10 {
+		t.Errorf("open_ledger_cost = %d, want escalated fee above base 10", got)
 	}
 }
 

--- a/internal/rpc/adapter/adapter_submission_test.go
+++ b/internal/rpc/adapter/adapter_submission_test.go
@@ -10,8 +10,33 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/accountset"
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAdaptSubmitResultCopiesLedgerState(t *testing.T) {
+	source := &service.SubmitResult{
+		Result: ter.TesSUCCESS,
+		CurrentLedgerState: &service.SubmitLedgerState{
+			ValidatedLedgerIndex:     17,
+			OpenLedgerCost:           123,
+			AccountSequenceNext:      9,
+			AccountSequenceAvailable: 11,
+		},
+	}
+	adapted := adaptSubmitResult(source, true, false)
+	require.NotNil(t, adapted.CurrentLedgerState)
+	require.NotSame(t, source.CurrentLedgerState, adapted.CurrentLedgerState)
+	require.Equal(t, uint32(17), adapted.CurrentLedgerState.ValidatedLedgerIndex)
+	require.Equal(t, uint64(123), adapted.CurrentLedgerState.OpenLedgerCost)
+	require.Equal(t, uint32(9), adapted.CurrentLedgerState.AccountSequenceNext)
+	require.Equal(t, uint32(11), adapted.CurrentLedgerState.AccountSequenceAvailable)
+
+	source.CurrentLedgerState.OpenLedgerCost = 999
+	adapted.CurrentLedgerState.AccountSequenceNext = 42
+	require.Equal(t, uint64(123), adapted.CurrentLedgerState.OpenLedgerCost)
+	require.Equal(t, uint32(9), source.CurrentLedgerState.AccountSequenceNext)
+}
 
 func TestAdapterSubmissionSmoke(t *testing.T) {
 	svc, err := service.New(service.Config{Standalone: true, GenesisConfig: genesis.DefaultConfig()})

--- a/internal/rpc/adapter/submission.go
+++ b/internal/rpc/adapter/submission.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	ledgerService "github.com/LeJamon/go-xrpl/internal/ledger/service"
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
@@ -42,6 +43,35 @@ func malformedSubmitResult() *types.SubmitResult {
 
 func internalSubmitResult() *types.SubmitResult {
 	return errorSubmitResult(ter.TefINTERNAL)
+}
+
+func adaptSubmitResult(result *ledgerService.SubmitResult, broadcast, failHard bool) *types.SubmitResult {
+	if result == nil {
+		return nil
+	}
+	rpcResult := &types.SubmitResult{
+		EngineResult:           result.Result.String(),
+		EngineResultCode:       int(result.Result),
+		EngineResultMessage:    result.Message,
+		Applied:                result.Applied,
+		Broadcast:              broadcast,
+		Queued:                 result.Result == ter.TerQUEUED,
+		Kept:                   (!failHard || result.Result == ter.TesSUCCESS) && result.Result != ter.TefALREADY,
+		Fee:                    result.Fee,
+		CurrentLedger:          result.CurrentLedger,
+		CurrentLedgerCloseTime: result.CurrentLedgerCloseTime,
+		ValidatedLedger:        result.ValidatedLedger,
+	}
+	if result.CurrentLedgerState != nil {
+		state := *result.CurrentLedgerState
+		rpcResult.CurrentLedgerState = &types.SubmitLedgerState{
+			ValidatedLedgerIndex:     state.ValidatedLedgerIndex,
+			OpenLedgerCost:           state.OpenLedgerCost,
+			AccountSequenceNext:      state.AccountSequenceNext,
+			AccountSequenceAvailable: state.AccountSequenceAvailable,
+		}
+	}
+	return rpcResult
 }
 
 func (a *LedgerServiceAdapter) submitTransaction(txJSON []byte, txBlobHex string, failHard bool) (*types.SubmitResult, error) {
@@ -124,23 +154,5 @@ func (a *LedgerServiceAdapter) submitTransaction(txJSON []byte, txBlobHex string
 		broadcast = true
 	}
 
-	// Keep regular submissions except duplicate transactions. Fail-hard keeps
-	// only an applied result.
-	queued := result.Result == ter.TerQUEUED
-	kept := (!failHard || result.Result == ter.TesSUCCESS) &&
-		result.Result != ter.TefALREADY
-
-	return &types.SubmitResult{
-		EngineResult:           result.Result.String(),
-		EngineResultCode:       int(result.Result),
-		EngineResultMessage:    result.Message,
-		Applied:                result.Applied,
-		Broadcast:              broadcast,
-		Queued:                 queued,
-		Kept:                   kept,
-		Fee:                    result.Fee,
-		CurrentLedger:          result.CurrentLedger,
-		CurrentLedgerCloseTime: result.CurrentLedgerCloseTime,
-		ValidatedLedger:        result.ValidatedLedger,
-	}, nil
+	return adaptSubmitResult(result, broadcast, failHard), nil
 }

--- a/internal/rpc/handlers/submit.go
+++ b/internal/rpc/handlers/submit.go
@@ -13,7 +13,6 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/sign"
-	xrpllog "github.com/LeJamon/go-xrpl/log"
 )
 
 // SubmitMethod handles the submit RPC method.
@@ -151,39 +150,12 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (re
 	}
 	txHashStr := CalculateTxHash(txBlobHex)
 
-	// Store transaction for later lookup if applied. The submit response is
-	// still successful even when persistence fails — the tx is already in the
-	// open ledger and will be re-applied on close — but we log so silent
-	// storage failures don't go unnoticed.
-	if submitResult.Applied && txHashStr != "" {
-		if txHashBytes, err := hex.DecodeString(txHashStr); err == nil && len(txHashBytes) == 32 {
-			var txHash [32]byte
-			copy(txHash[:], txHashBytes)
-			storedTx := StoredTransaction{
-				TxJSON: txJsonMap,
-				Meta: map[string]any{
-					"TransactionResult": submitResult.EngineResult,
-					"TransactionIndex":  0,
-					"AffectedNodes":     []any{},
-				},
-			}
-			storedData, mErr := json.Marshal(storedTx)
-			if mErr != nil {
-				xrpllog.Named(xrpllog.PartitionRPC).Warn("submit: marshal stored tx failed", "hash", txHashStr, "err", mErr)
-			} else if sErr := ctx.Services.Ledger.StoreTransaction(txHash, storedData); sErr != nil {
-				xrpllog.Named(xrpllog.PartitionRPC).Warn("submit: StoreTransaction failed", "hash", txHashStr, "err", sErr)
-			}
-		}
-	}
-
 	projectedTxJSON := txprojection.ProjectJSONForPath(
 		txJsonMap,
 		txHashStr,
 		ctx.ApiVersion,
 		projectionPath,
 	)
-
-	baseFee, _, _ := ctx.Services.Ledger.GetCurrentFees()
 
 	// Build response with independent boolean fields matching rippled's
 	// Transaction::SubmitResult struct. "accepted" = any() in rippled.
@@ -198,7 +170,6 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (re
 		"broadcast":             submitResult.Broadcast,
 		"kept":                  submitResult.Kept,
 		"queued":                submitResult.Queued,
-		"open_ledger_cost":      fmt.Sprintf("%d", baseFee),
 	}
 
 	// Signed paths use the modern root hash for API v2+. Raw-blob submit keeps
@@ -207,17 +178,11 @@ func (m *SubmitMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (re
 		response["hash"] = txHashStr
 	}
 
-	// Add validated_ledger_index only if we have one
-	if submitResult.ValidatedLedger > 0 {
-		response["validated_ledger_index"] = submitResult.ValidatedLedger
-	}
-
-	// Add account_sequence_next and account_sequence_available
-	if account, ok := txJsonMap["Account"].(string); ok {
-		if acctInfo, err := ctx.Services.Ledger.GetAccountInfo(ctx.Context, account, "current"); err == nil {
-			response["account_sequence_next"] = acctInfo.Sequence
-			response["account_sequence_available"] = acctInfo.Sequence
-		}
+	if state := submitResult.CurrentLedgerState; state != nil {
+		response["account_sequence_next"] = state.AccountSequenceNext
+		response["account_sequence_available"] = state.AccountSequenceAvailable
+		response["open_ledger_cost"] = fmt.Sprintf("%d", state.OpenLedgerCost)
+		response["validated_ledger_index"] = state.ValidatedLedgerIndex
 	}
 
 	return response, nil

--- a/internal/rpc/submit_test.go
+++ b/internal/rpc/submit_test.go
@@ -23,11 +23,13 @@ import (
 // mockLedgerServiceSubmit extends mockLedgerService with submit-specific behavior
 type mockLedgerServiceSubmit struct {
 	*mockLedgerService
-	submitResult *types.SubmitResult
-	submitError  error
-	storedTxs    map[string][]byte
-	submitCalls  int
-	lastTxBlob   string
+	submitResult     *types.SubmitResult
+	submitError      error
+	storedTxs        map[string][]byte
+	submitCalls      int
+	lastTxBlob       string
+	currentFeesCalls int
+	accountInfoCalls int
 }
 
 func newMockLedgerServiceSubmit() *mockLedgerServiceSubmit {
@@ -53,6 +55,16 @@ func (m *mockLedgerServiceSubmit) SubmitTransaction(txJSON []byte, txBlobHex str
 		return nil, m.submitError
 	}
 	return m.submitResult, nil
+}
+
+func (m *mockLedgerServiceSubmit) GetCurrentFees() (baseFee, reserveBase, reserveIncrement uint64) {
+	m.currentFeesCalls++
+	return 10, 10000000, 2000000
+}
+
+func (m *mockLedgerServiceSubmit) GetAccountInfo(ctx context.Context, account string, ledgerIndex string) (*types.AccountInfo, error) {
+	m.accountInfoCalls++
+	return m.mockLedgerService.GetAccountInfo(ctx, account, ledgerIndex)
 }
 
 func TestSubmitMethodRawBlobPresenceAndProjection(t *testing.T) {
@@ -527,7 +539,7 @@ func TestSubmitMethodValidTxJson(t *testing.T) {
 	}
 }
 
-func TestSubmitMethodStoredMetadataIncludesAffectedNodes(t *testing.T) {
+func TestSubmitMethodDoesNotPersistSyntheticMetadata(t *testing.T) {
 	mock := newMockLedgerServiceSubmit()
 	ctx := &types.RpcContext{
 		Context:    context.Background(),
@@ -539,14 +551,9 @@ func TestSubmitMethodStoredMetadataIncludesAffectedNodes(t *testing.T) {
 
 	_, rpcErr := (&handlers.SubmitMethod{}).Handle(ctx, params)
 	require.Nil(t, rpcErr)
-	require.Len(t, mock.storedTxs, 1)
-	for _, storedData := range mock.storedTxs {
-		var stored handlers.StoredTransaction
-		require.NoError(t, json.Unmarshal(storedData, &stored))
-		nodes, ok := stored.Meta["AffectedNodes"].([]any)
-		require.True(t, ok)
-		assert.Empty(t, nodes)
-	}
+	require.Empty(t, mock.storedTxs)
+	assert.Zero(t, mock.currentFeesCalls)
+	assert.Zero(t, mock.accountInfoCalls)
 }
 
 // TestSubmitMethodResponseFields tests that response contains expected fields
@@ -570,6 +577,12 @@ func TestSubmitMethodResponseFields(t *testing.T) {
 		Fee:                 10,
 		CurrentLedger:       3,
 		ValidatedLedger:     2,
+		CurrentLedgerState: &types.SubmitLedgerState{
+			ValidatedLedgerIndex:     2,
+			OpenLedgerCost:           12,
+			AccountSequenceNext:      7,
+			AccountSequenceAvailable: 9,
+		},
 	}
 
 	t.Run("Response contains all required fields", func(t *testing.T) {
@@ -606,6 +619,7 @@ func TestSubmitMethodResponseFields(t *testing.T) {
 		assert.Contains(t, resp, "tx_blob")
 		assert.Contains(t, resp, "account_sequence_next")
 		assert.Contains(t, resp, "account_sequence_available")
+		assert.Contains(t, resp, "open_ledger_cost")
 
 		// Verify field values for successful submission
 		assert.Equal(t, "tesSUCCESS", resp["engine_result"])
@@ -614,6 +628,10 @@ func TestSubmitMethodResponseFields(t *testing.T) {
 		assert.Equal(t, true, resp["accepted"])
 		assert.Equal(t, true, resp["applied"])
 		assert.Equal(t, false, resp["queued"])
+		assert.Equal(t, float64(2), resp["validated_ledger_index"])
+		assert.Equal(t, float64(7), resp["account_sequence_next"])
+		assert.Equal(t, float64(9), resp["account_sequence_available"])
+		assert.Equal(t, "12", resp["open_ledger_cost"])
 	})
 
 	t.Run("tx_json is included in response", func(t *testing.T) {
@@ -642,6 +660,37 @@ func TestSubmitMethodResponseFields(t *testing.T) {
 		assert.Equal(t, "Payment", txJson["TransactionType"])
 		assert.Equal(t, "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh", txJson["Account"])
 	})
+}
+
+func TestSubmitMethodOmitsLedgerStateFieldsWithoutSnapshot(t *testing.T) {
+	mock := newMockLedgerServiceSubmit()
+	mock.submitResult = &types.SubmitResult{
+		EngineResult:        "tesSUCCESS",
+		EngineResultCode:    0,
+		EngineResultMessage: "The transaction was applied.",
+		Applied:             true,
+		ValidatedLedger:     99,
+	}
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleUser,
+		ApiVersion: types.ApiVersion1,
+		Services:   newSubmitTestServices(mock),
+	}
+	result, rpcErr := (&handlers.SubmitMethod{}).Handle(ctx, rawSubmitParams(t, validStoredPaymentTransaction(), nil))
+	require.Nil(t, rpcErr)
+	resultJSON, err := json.Marshal(result)
+	require.NoError(t, err)
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(resultJSON, &response))
+	for _, field := range []string{
+		"account_sequence_next",
+		"account_sequence_available",
+		"open_ledger_cost",
+		"validated_ledger_index",
+	} {
+		assert.NotContains(t, response, field, "field %q must be absent without a snapshot", field)
+	}
 }
 
 // TestSubmitMethodEngineResults tests various engine result codes

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -1136,8 +1136,23 @@ type SubmitResult struct {
 	// ValidatedLedger is the highest validated ledger sequence
 	ValidatedLedger uint32
 
+	// CurrentLedgerState is the immutable state snapshot captured at submit
+	// time. It is nil when no validated ledger exists or the authoritative
+	// account/fee state could not be derived.
+	CurrentLedgerState *SubmitLedgerState
+
 	// Metadata is nil when the transaction produced no metadata.
 	Metadata *SubmitMetadata
+}
+
+// SubmitLedgerState contains the four current-ledger values returned by
+// submit. The pointer on SubmitResult distinguishes an unavailable snapshot
+// from valid zero-valued fields.
+type SubmitLedgerState struct {
+	ValidatedLedgerIndex     uint32
+	OpenLedgerCost           uint64
+	AccountSequenceNext      uint32
+	AccountSequenceAvailable uint32
 }
 
 // SubmitMetadata carries simulation metadata in JSON and binary form

--- a/internal/txq/process.go
+++ b/internal/txq/process.go
@@ -1,5 +1,7 @@
 package txq
 
+import "math"
+
 // ClosedLedgerContext provides the context from a closed ledger for updating fee metrics.
 type ClosedLedgerContext interface {
 	// GetLedgerSequence returns the closed ledger's sequence number.
@@ -100,4 +102,41 @@ func (q *TxQ) NextQueuableSeq(account [20]byte, acctSeq uint32) uint32 {
 	}
 
 	return q.getNextQueuableSeq(aq, acctSeq)
+}
+
+// GetFeeAndSeq returns the required fee and next sequence for a transaction.
+// This is useful for RPC methods that help users construct transactions.
+type FeeAndSeq struct {
+	// RequiredFee is the minimum fee in drops to bypass the queue
+	RequiredFee uint64
+
+	// AccountSeq is the account's current sequence number
+	AccountSeq uint32
+
+	// AvailableSeq is the next queueable sequence number
+	AvailableSeq uint32
+}
+
+// TxRequiredFeeAndSeq returns fee and sequence information for constructing transactions.
+func (q *TxQ) TxRequiredFeeAndSeq(account [20]byte, acctSeq uint32, baseFee uint64, txInLedger uint32) FeeAndSeq {
+	q.stateMu.RLock()
+	defer q.stateMu.RUnlock()
+
+	snapshot := q.feeMetrics.snapshot()
+	feeLevel := scaleFeeLevel(snapshot, txInLedger)
+	requiredFee := feeLevel.ToDrops(baseFee)
+	if requiredFee > math.MaxInt64 {
+		requiredFee = math.MaxInt64
+	}
+
+	availableSeq := acctSeq
+	if aq, exists := q.byAccount[account]; exists {
+		availableSeq = q.getNextQueuableSeq(aq, acctSeq)
+	}
+
+	return FeeAndSeq{
+		RequiredFee:  requiredFee,
+		AccountSeq:   acctSeq,
+		AvailableSeq: availableSeq,
+	}
 }

--- a/internal/txq/txq_test.go
+++ b/internal/txq/txq_test.go
@@ -1,8 +1,19 @@
 package txq
 
 import (
+	"math"
 	"testing"
 )
+
+func TestTxRequiredFeeAndSeqSaturatesAtMaxXRPAmount(t *testing.T) {
+	queue := mustNew(DefaultConfig())
+
+	result := queue.TxRequiredFeeAndSeq([20]byte{}, 1, math.MaxUint64, 0)
+
+	if result.RequiredFee != math.MaxInt64 {
+		t.Fatalf("RequiredFee = %d, want %d", result.RequiredFee, uint64(math.MaxInt64))
+	}
+}
 
 // TestNew tests TxQ creation with various configurations
 func TestNew(t *testing.T) {


### PR DESCRIPTION
## Summary
- Capture immutable ledger and TxQ state at submission time.
- Stop reconstructing queue cost, sequence, and validated-ledger fields in handlers.

## Verification
- Submit, service, adapter, and TxQ tests
- Targeted race, vet, strict lint, build, and oracle review

Refs #1486

Stack layer 5 of 16; depends on #1570.