### PR TITLE
fix: make transaction lookup lifecycle authoritative (#1486)

### DIFF
--- a/internal/ledger/localtxs/localtxs.go
+++ b/internal/ledger/localtxs/localtxs.go
@@ -187,6 +187,22 @@ func (l *LocalTxs) GetTxSet() []openledger.PendingTx {
 	return snapshot
 }
 
+// Get returns an owned copy of a held transaction by hash. Unlike GetTxSet it
+// does not sort or scan the pool, so query paths can inspect a single entry
+// without turning the bounded held pool into an O(n log n) lookup.
+func (l *LocalTxs) Get(hash [32]byte) (openledger.PendingTx, bool) {
+	l.mu.RLock()
+	entry, ok := l.txs[hash]
+	if ok {
+		entry.Ptx = clonePendingTx(entry.Ptx)
+	}
+	l.mu.RUnlock()
+	if !ok {
+		return openledger.PendingTx{}, false
+	}
+	return entry.Ptx, true
+}
+
 func (l *LocalTxs) Size() int {
 	l.mu.RLock()
 	defer l.mu.RUnlock()

--- a/internal/ledger/localtxs/localtxs_test.go
+++ b/internal/ledger/localtxs/localtxs_test.go
@@ -232,6 +232,29 @@ func TestLocalTxs_GetTxSet_CanonicalOrder(t *testing.T) {
 	}
 }
 
+func TestLocalTxs_GetReturnsOwnedTransaction(t *testing.T) {
+	env := jtx.NewTestEnv(t)
+	alice := jtx.NewAccount("alice")
+	bob := jtx.NewAccount("bob")
+	env.Fund(alice, bob)
+	ptx, _ := pendingFromPay(t, env, alice, bob, env.Seq(alice)+10)
+
+	pool := localtxs.New()
+	pool.PushBack(1, ptx)
+	got, ok := pool.Get(ptx.Hash)
+	if !ok {
+		t.Fatal("Get returned ok=false for a held transaction")
+	}
+	if !bytes.Equal(got.Blob, ptx.Blob) {
+		t.Fatal("Get returned a different transaction blob")
+	}
+	got.Blob[0] ^= 0xff
+	again, ok := pool.Get(ptx.Hash)
+	if !ok || !bytes.Equal(again.Blob, ptx.Blob) {
+		t.Fatal("Get did not return an owned blob copy")
+	}
+}
+
 // TestLocalTxs_GetTxSet_SortsBySequenceWithinAccount verifies that two
 // pending txs from the same account are returned in ascending sequence
 // order regardless of push order.

--- a/internal/ledger/service/service.go
+++ b/internal/ledger/service/service.go
@@ -42,6 +42,7 @@ var (
 	ErrInvalidLedgerIndex = svcerr.ErrInvalidLedgerIndex
 	ErrInvalidLedgerHash  = svcerr.ErrInvalidLedgerHash
 	ErrTxnNotFound        = svcerr.ErrTxnNotFound
+	ErrTxnDataCorrupt     = svcerr.ErrTxnDataCorrupt
 )
 
 var (

--- a/internal/ledger/service/service_openledger_test.go
+++ b/internal/ledger/service/service_openledger_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
 	"github.com/LeJamon/go-xrpl/internal/tx/pseudo"
+	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 )
 
 func openLedgerHasTx(t *testing.T, svc *service.Service, hash [32]byte) bool {
@@ -114,6 +115,69 @@ func TestService_OpenLedgerSubmit_Roundtrip(t *testing.T) {
 	}
 	if !bytes.Equal(got, blob) {
 		t.Errorf("OpenLedgerGetTx returned mismatched blob")
+	}
+}
+
+func TestService_GetTransaction_OpenThenClosedLifecycle(t *testing.T) {
+	svc := newServiceForOpenLedgerTest(t)
+	t.Cleanup(svc.Stop)
+
+	env := jtx.NewTestEnv(t)
+	blob, hash := buildSignedPaymentBlob(t, env, jtx.MasterAccount(), jtx.NewAccount("lookup-destination"), 50_000_000, 1)
+	if result, err := svc.SubmitOpenLedgerTx(blob, true); err != nil || result != openledger.ResultSuccess {
+		t.Fatalf("SubmitOpenLedgerTx = (%v, %v), want success", result, err)
+	}
+
+	openResult, err := svc.GetTransaction(hash)
+	if err != nil {
+		t.Fatalf("GetTransaction(open): %v", err)
+	}
+	if openResult.LedgerIndex != 0 || openResult.LedgerHash != ([32]byte{}) || openResult.Validated || openResult.CloseTime != 0 {
+		t.Fatalf("open transaction advertised closed-ledger state: %+v", openResult)
+	}
+	if openResult.TxIndex != ^uint32(0) {
+		t.Fatalf("open transaction index = %d, want invalid", openResult.TxIndex)
+	}
+	txBlob, metaBlob, err := tx.SplitTxWithMetaBlob(openResult.TxData)
+	if err != nil {
+		t.Fatalf("split open transaction: %v", err)
+	}
+	if !bytes.Equal(txBlob, blob) || metaBlob != nil {
+		t.Fatalf("open transaction payload = (%x, %x), want tx-only input", txBlob, metaBlob)
+	}
+	ranged, searched, err := svc.GetTransactionWithRange(context.Background(), hash, 999, 1000)
+	if err != nil || ranged == nil || searched != relationaldb.TxSearchAll || ranged.LedgerIndex != 0 {
+		t.Fatalf("GetTransactionWithRange(open) = (%+v, %v, %v), want cache-first open result", ranged, searched, err)
+	}
+
+	parent := svc.GetClosedLedger()
+	if parent == nil {
+		t.Fatal("GetClosedLedger returned nil before close")
+	}
+	closedSeq, err := svc.AcceptConsensusResult(context.Background(), parent, [][]byte{blob}, nil, time.Now(), true)
+	if err != nil {
+		t.Fatalf("AcceptConsensusResult: %v", err)
+	}
+	closedResult, err := svc.GetTransaction(hash)
+	if err != nil {
+		t.Fatalf("GetTransaction(closed): %v", err)
+	}
+	if closedResult.LedgerIndex != closedSeq || closedResult.LedgerHash == ([32]byte{}) || closedResult.TxIndex == ^uint32(0) {
+		t.Fatalf("closed transaction state = %+v, want closed ledger metadata", closedResult)
+	}
+	closedTx, closedMeta, err := tx.SplitTxWithMetaBlobStrict(closedResult.TxData)
+	if err != nil || len(closedMeta) == 0 {
+		t.Fatalf("closed transaction payload = (%x, %v), want strict tx+metadata: %v", closedTx, closedMeta, err)
+	}
+	metadata, err := binarycodec.DecodeBytes(closedMeta)
+	if err != nil {
+		t.Fatalf("decode closed transaction metadata: %v", err)
+	}
+	if metadata["TransactionResult"] != "tesSUCCESS" || metadata["TransactionIndex"] != closedResult.TxIndex {
+		t.Fatalf("closed transaction metadata = %+v, want canonical result/index", metadata)
+	}
+	if nodes, ok := metadata["AffectedNodes"].([]any); !ok || len(nodes) == 0 {
+		t.Fatalf("closed transaction AffectedNodes = %#v, want real ledger changes", metadata["AffectedNodes"])
 	}
 }
 

--- a/internal/ledger/service/svcerr/svcerr.go
+++ b/internal/ledger/service/svcerr/svcerr.go
@@ -48,6 +48,11 @@ var (
 	// matching transaction (rippled rpcTXN_NOT_FOUND).
 	ErrTxnNotFound = errors.New("transaction not found")
 
+	// ErrTxnDataCorrupt is returned when a transaction lookup finds malformed
+	// stored/cache data or a blob whose contents do not hash to the requested
+	// transaction ID. RPC handlers map it to dbDeserialization.
+	ErrTxnDataCorrupt = errors.New("transaction data corrupt")
+
 	// ErrAccountMalformed wraps a malformed-address decode failure so
 	// handlers can map it to rpcACT_MALFORMED via errors.Is.
 	ErrAccountMalformed = errors.New("invalid account address")

--- a/internal/ledger/service/tx_query.go
+++ b/internal/ledger/service/tx_query.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LeJamon/go-xrpl/drops"
 	"github.com/LeJamon/go-xrpl/internal/feetrack"
 	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/localtxs"
 	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
 	"github.com/LeJamon/go-xrpl/internal/ledger/state"
@@ -135,6 +136,7 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 			CurrentLedger: s.openLedgerView.Current().Sequence(),
 		}, nil
 	}
+	preprocessValid := sign.CheckSTTxSignature(ptx.Parsed, cfg.Rules, !cfg.SkipSignatureVerification) == ""
 	// Verify the signature before SubmitDetailed acquires the apply mutex so the
 	// in-strand check reuses the cached verdict (#1105). Skipped in standalone
 	// mode, matching cfg.SkipSignatureVerification above.
@@ -183,7 +185,7 @@ func (s *Service) SubmitTransaction(transaction tx.Transaction, rawBlob []byte, 
 	// enforceFailHard (NetworkOPs.cpp:1674) suppresses both this push (1677)
 	// and relay (1685-1689) so the caller learns about the failure
 	// immediately without a delayed re-application.
-	if rawBlob != nil && s.localTxs != nil {
+	if preprocessValid && rawBlob != nil && s.localTxs != nil {
 		tr := outcome.Result
 		if (!failHard || tr == ter.TesSUCCESS) && tr != ter.TefALREADY {
 			s.localTxs.PushBack(currentSeq, ptx)
@@ -591,8 +593,117 @@ type LedgerContext struct {
 	CloseTime int64
 }
 
-// GetTransaction retrieves a transaction by its hash
+// getOpenTransactionLocked looks up an accepted transaction in the
+// authoritative open-ledger view. The caller must hold s.mu.RLock or s.mu.
+// Open leaves are always transaction+metadata records; validate and split the
+// complete leaf before exposing the transaction-only bytes to RPC callers.
+func (s *Service) getOpenTransactionLocked(txHash [32]byte) (*TransactionResult, bool, error) {
+	if s.openLedgerView == nil {
+		return nil, false, nil
+	}
+	current := s.openLedgerView.Current()
+	if current == nil {
+		return nil, false, errors.New("open ledger view has no current ledger")
+	}
+
+	data, found, err := current.GetTransaction(txHash)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: get open-ledger transaction: %v", svcerr.ErrTxnDataCorrupt, err)
+	}
+	if !found {
+		return nil, false, nil
+	}
+
+	accepted := ParseAcceptedTransaction(data)
+	if err := accepted.ParseError(); err != nil {
+		return nil, false, fmt.Errorf("%w: decode open-ledger transaction: %v", svcerr.ErrTxnDataCorrupt, err)
+	}
+	result, err := transactionResultFromRawBlob(accepted.TransactionBlob(), txHash, "open-ledger")
+	if err != nil {
+		return nil, false, err
+	}
+	return result, true, nil
+}
+
+func transactionResultFromRawBlob(blob []byte, txHash [32]byte, source string) (*TransactionResult, error) {
+	parsed, err := tx.ParseFromBinary(blob)
+	if err != nil {
+		return nil, fmt.Errorf("%w: parse %s transaction: %v", svcerr.ErrTxnDataCorrupt, source, err)
+	}
+	computedHash, err := tx.ComputeTransactionHash(parsed)
+	if err != nil {
+		return nil, fmt.Errorf("%w: hash %s transaction: %v", svcerr.ErrTxnDataCorrupt, source, err)
+	}
+	if computedHash != txHash {
+		return nil, fmt.Errorf("%w: %s transaction hash mismatch: key=%x computed=%x", svcerr.ErrTxnDataCorrupt, source, txHash, computedHash)
+	}
+	txData, err := tx.EncodeWithVL(blob)
+	if err != nil {
+		return nil, fmt.Errorf("%w: encode %s transaction: %v", svcerr.ErrTxnDataCorrupt, source, err)
+	}
+	return &TransactionResult{
+		TxData: txData,
+		// Transactions outside a closed ledger are not validated and have no
+		// ledger metadata. Keep the closed-ledger fields at zero/invalid values.
+		TxIndex: invalidTransactionIndex,
+	}, nil
+}
+
+func (s *Service) getPendingTransaction(queue *txq.TxQ, locals *localtxs.LocalTxs, txHash [32]byte) (*TransactionResult, bool, error) {
+	if queue != nil {
+		if blob, ok := queue.GetTxBlob(txHash); ok {
+			result, err := transactionResultFromRawBlob(blob, txHash, "queued")
+			return result, true, err
+		}
+	}
+	blob, _, _, ok := s.relayCacheGet(txHash)
+	if ok {
+		result, err := transactionResultFromRawBlob(blob, txHash, "relay-cache")
+		return result, true, err
+	}
+	if locals != nil {
+		if pending, ok := locals.Get(txHash); ok {
+			result, err := transactionResultFromRawBlob(pending.Blob, txHash, "held")
+			return result, true, err
+		}
+	}
+	return nil, false, nil
+}
+
+// GetTransaction retrieves a transaction by its hash. The current open view
+// is checked first, before historical/index lookups, matching rippled's
+// transaction-cache behavior.
 func (s *Service) GetTransaction(txHash [32]byte) (*TransactionResult, error) {
+	s.mu.RLock()
+	openResult, found, openErr := s.getOpenTransactionLocked(txHash)
+	queue := s.txQueue
+	locals := s.localTxs
+	s.mu.RUnlock()
+	if openErr != nil {
+		return nil, openErr
+	}
+	if found {
+		return openResult, nil
+	}
+
+	historyResult, historyErr := s.getHistoricalTransaction(txHash)
+	if historyErr == nil {
+		return historyResult, nil
+	}
+	if !errors.Is(historyErr, svcerr.ErrTxnNotFound) {
+		return nil, historyErr
+	}
+	queuedResult, found, queuedErr := s.getPendingTransaction(queue, locals, txHash)
+	if queuedErr != nil {
+		return nil, queuedErr
+	}
+	if found {
+		return queuedResult, nil
+	}
+	return nil, svcerr.ErrTxnNotFound
+}
+
+func (s *Service) getHistoricalTransaction(txHash [32]byte) (*TransactionResult, error) {
 	s.historyComponent.mu.RLock()
 	defer s.historyComponent.mu.RUnlock()
 
@@ -632,16 +743,23 @@ func (s *Service) GetTransaction(txHash [32]byte) (*TransactionResult, error) {
 }
 
 func (s *Service) SearchTransaction(ctx context.Context, txHash [32]byte, ledgerRange *relationaldb.LedgerRange) (*TransactionSearchResult, error) {
+	cached, cacheErr := s.GetTransaction(txHash)
+	if cacheErr != nil && !errors.Is(cacheErr, svcerr.ErrTxnNotFound) {
+		return nil, cacheErr
+	}
+
 	s.mu.RLock()
 	db := s.relationalDB
 	s.mu.RUnlock()
+	if cacheErr == nil && !cached.Validated {
+		return &TransactionSearchResult{Transaction: cached, Searched: relationaldb.TxSearchAll}, nil
+	}
 
-	if db == nil {
-		result, err := s.GetTransaction(txHash)
-		if err != nil {
-			return nil, err
+	if db == nil || db.Transaction() == nil {
+		if cacheErr != nil {
+			return nil, cacheErr
 		}
-		return &TransactionSearchResult{Transaction: result, Searched: relationaldb.TxSearchUnknown}, nil
+		return &TransactionSearchResult{Transaction: cached, Searched: relationaldb.TxSearchUnknown}, nil
 	}
 
 	info, searched, err := db.Transaction().GetTransaction(ctx, relationaldb.Hash(txHash), ledgerRange)
@@ -709,23 +827,24 @@ func (s *Service) GetLedgerContext(ctx context.Context, sequence uint32) (*Ledge
 	}, nil
 }
 
-// GetTransactionWithRange preserves the in-memory lookup fast path, then uses
-// the relational transaction table to report rippled-compatible searched-all
-// semantics when the hash is absent. The hash lookup itself is deliberately
-// unrestricted by the supplied range.
+// GetTransactionWithRange returns an unvalidated in-memory transaction before
+// consulting the relational transaction table for the requested range.
 func (s *Service) GetTransactionWithRange(ctx context.Context, txHash [32]byte, minLedger, maxLedger uint32) (*TransactionResult, relationaldb.TxSearchResult, error) {
-	result, cacheErr := s.GetTransaction(txHash)
-	if cacheErr == nil {
-		return result, relationaldb.TxSearchAll, nil
-	}
-	if !errors.Is(cacheErr, svcerr.ErrTxnNotFound) {
+	cached, cacheErr := s.GetTransaction(txHash)
+	if cacheErr != nil && !errors.Is(cacheErr, svcerr.ErrTxnNotFound) {
 		return nil, relationaldb.TxSearchUnknown, cacheErr
 	}
-	if s.relationalDB == nil || s.relationalDB.Transaction() == nil {
-		return nil, relationaldb.TxSearchUnknown, cacheErr
+	s.mu.RLock()
+	db := s.relationalDB
+	s.mu.RUnlock()
+	if cacheErr == nil && !cached.Validated {
+		return cached, relationaldb.TxSearchAll, nil
+	}
+	if db == nil || db.Transaction() == nil {
+		return cached, relationaldb.TxSearchUnknown, cacheErr
 	}
 
-	dbResult, searched, err := s.relationalDB.Transaction().GetTransaction(ctx, relationaldb.Hash(txHash), &relationaldb.LedgerRange{
+	dbResult, searched, err := db.Transaction().GetTransaction(ctx, relationaldb.Hash(txHash), &relationaldb.LedgerRange{
 		Min: relationaldb.LedgerIndex(minLedger),
 		Max: relationaldb.LedgerIndex(maxLedger),
 	})
@@ -756,7 +875,7 @@ func (s *Service) GetTransactionWithRange(ctx context.Context, txHash [32]byte, 
 	var ledgerHash [32]byte
 	var closeTime int64
 	validated := false
-	if ledgerRepo := s.relationalDB.Ledger(); ledgerRepo != nil && dbResult.LedgerSeq != 0 {
+	if ledgerRepo := db.Ledger(); ledgerRepo != nil && dbResult.LedgerSeq != 0 {
 		ledgerInfo, ledgerErr := ledgerRepo.GetLedgerInfoBySeq(ctx, dbResult.LedgerSeq)
 		if ledgerErr != nil {
 			return nil, searched, fmt.Errorf("get transaction ledger: %w", ledgerErr)
@@ -777,28 +896,6 @@ func (s *Service) GetTransactionWithRange(ctx context.Context, txHash [32]byte, 
 		TxIndex:     txIndex,
 		CloseTime:   closeTime,
 	}, searched, nil
-}
-
-// StoreTransaction stores a transaction in the current open ledger
-func (s *Service) StoreTransaction(txHash [32]byte, txData []byte) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.historyComponent.mu.Lock()
-	defer s.historyComponent.mu.Unlock()
-
-	if s.openLedger == nil {
-		return ErrNoOpenLedger
-	}
-
-	// Add to the open ledger's transaction map
-	if err := s.openLedger.AddTransaction(txHash, txData); err != nil {
-		return err
-	}
-
-	// Index the transaction to the current open ledger sequence
-	s.txIndex[txHash] = s.openLedger.Sequence()
-
-	return nil
 }
 
 // SimulateTransaction runs a transaction against a snapshot of the open ledger

--- a/internal/ledger/service/tx_query_open_lookup_test.go
+++ b/internal/ledger/service/tx_query_open_lookup_test.go
@@ -1,0 +1,113 @@
+package service
+
+import (
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/localtxs"
+	"github.com/LeJamon/go-xrpl/internal/ledger/openledger"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
+	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	"github.com/LeJamon/go-xrpl/internal/testing/payment"
+	"github.com/LeJamon/go-xrpl/internal/tx"
+)
+
+func TestGetTransactionOpenHashMismatchIsOperationalError(t *testing.T) {
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("service.Start: %v", err)
+	}
+	t.Cleanup(svc.Stop)
+
+	env := jtx.NewTestEnv(t)
+	env.SetVerifySignatures(true)
+	transaction := payment.Pay(jtx.MasterAccount(), jtx.NewAccount("open-lookup-mismatch"), 50_000_000).Sequence(1).Build()
+	env.SignWith(transaction, jtx.MasterAccount())
+	txMap, err := transaction.Flatten()
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	hexBlob, err := binarycodec.Encode(txMap)
+	if err != nil {
+		t.Fatalf("binarycodec.Encode: %v", err)
+	}
+	blob, err := hex.DecodeString(hexBlob)
+	if err != nil {
+		t.Fatalf("hex.DecodeString: %v", err)
+	}
+	hash, err := tx.ComputeTransactionHash(transaction)
+	if err != nil {
+		t.Fatalf("ComputeTransactionHash: %v", err)
+	}
+	if result, err := svc.SubmitOpenLedgerTx(blob, true); err != nil || result != openledger.ResultSuccess {
+		t.Fatalf("SubmitOpenLedgerTx = (%v, %v), want success", result, err)
+	}
+
+	var mismatch [32]byte
+	mismatch[0] = 0xA5
+	svc.mu.Lock()
+	data, found, err := svc.openLedgerView.Current().GetTransaction(hash)
+	if err != nil || !found {
+		svc.mu.Unlock()
+		t.Fatalf("read submitted open leaf = (%v, %v, %v)", len(data), found, err)
+	}
+	var modifyErr error
+	svc.openLedgerView.Modify(func(view *ledger.Ledger) bool {
+		modifyErr = view.AddTransactionWithMeta(mismatch, data)
+		return modifyErr == nil
+	})
+	svc.mu.Unlock()
+	if modifyErr != nil {
+		t.Fatalf("inject mismatched open leaf: %v", modifyErr)
+	}
+
+	_, err = svc.GetTransaction(mismatch)
+	if err == nil {
+		t.Fatal("hash-mismatched open leaf unexpectedly succeeded")
+	}
+	if errors.Is(err, svcerr.ErrTxnNotFound) {
+		t.Fatalf("hash-mismatched open leaf collapsed to not found: %v", err)
+	}
+	if !errors.Is(err, svcerr.ErrTxnDataCorrupt) {
+		t.Fatalf("hash-mismatched open leaf error = %v, want ErrTxnDataCorrupt", err)
+	}
+}
+
+func TestGetTransactionRelayCacheRejectsCorruptData(t *testing.T) {
+	svc := &Service{relayTxCache: make(map[[32]byte]relayTxRecord)}
+	var hash [32]byte
+	hash[0] = 0xC1
+	svc.rememberRelayTransaction(hash, []byte{0x01, 0x02}, false)
+
+	_, err := svc.GetTransaction(hash)
+	if !errors.Is(err, svcerr.ErrTxnDataCorrupt) {
+		t.Fatalf("corrupt relay-cache error = %v, want ErrTxnDataCorrupt", err)
+	}
+}
+
+func TestGetTransactionHeldPoolReturnsTxOnly(t *testing.T) {
+	raw, hash := validRelationalTestTransaction(t, 1)
+	svc := &Service{localTxs: localtxs.New()}
+	svc.localTxs.PushBack(1, openledger.PendingTx{Hash: hash, Blob: raw})
+
+	result, err := svc.GetTransaction(hash)
+	if err != nil {
+		t.Fatalf("held transaction lookup: %v", err)
+	}
+	if result.LedgerIndex != 0 || result.Validated || result.TxIndex != invalidTransactionIndex {
+		t.Fatalf("held transaction advertised closed-ledger state: %+v", result)
+	}
+	txBlob, metaBlob, err := tx.SplitTxWithMetaBlob(result.TxData)
+	if err != nil {
+		t.Fatalf("split held transaction: %v", err)
+	}
+	if string(txBlob) != string(raw) || metaBlob != nil {
+		t.Fatalf("held transaction payload = (%x, %x), want tx-only input", txBlob, metaBlob)
+	}
+}

--- a/internal/ledger/service/tx_query_range_test.go
+++ b/internal/ledger/service/tx_query_range_test.go
@@ -7,6 +7,7 @@ import (
 
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/storage/relationaldb"
 	sqlitedb "github.com/LeJamon/go-xrpl/storage/relationaldb/sqlite"
 )
@@ -101,5 +102,104 @@ func TestGetTransactionWithRangeRelationalFallback(t *testing.T) {
 	_, searched, err = svc.GetTransactionWithRange(ctx, missingHash, 1, 4)
 	if err == nil || searched != relationaldb.TxSearchSome {
 		t.Fatalf("partial miss = (%v, %d), want error and TxSearchSome", err, searched)
+	}
+}
+
+func TestTransactionSearchReturnsUnvalidatedHistoryBeforeDatabase(t *testing.T) {
+	ctx := context.Background()
+	repositories, err := sqlitedb.NewRepositoryManager(ctx, t.TempDir(), sqlitedb.Settings{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = repositories.Close() })
+
+	svc, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.mu.Lock()
+	svc.relationalDB = repositories
+	svc.mu.Unlock()
+
+	rawTxn, hash := validRelationalTestTransaction(t, 1)
+	combined, err := tx.CreateTxWithMetaBlob(rawTxn, &tx.Metadata{
+		TransactionResult: ter.TesSUCCESS,
+		TransactionIndex:  7,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	historyLedger := relationalTestLedger(t, hash, combined)
+	svc.historyComponent.mu.Lock()
+	svc.putHistoryLocked(historyLedger)
+	svc.txIndex[hash] = historyLedger.Sequence()
+	svc.historyComponent.mu.Unlock()
+
+	ranged, searched, err := svc.GetTransactionWithRange(ctx, hash, 999, 1000)
+	if err != nil {
+		t.Fatalf("GetTransactionWithRange: %v", err)
+	}
+	if ranged == nil || ranged.LedgerIndex != historyLedger.Sequence() || ranged.Validated {
+		t.Fatalf("range lookup = %+v, want unvalidated history result", ranged)
+	}
+	if searched != relationaldb.TxSearchAll {
+		t.Fatalf("range search = %d, want TxSearchAll", searched)
+	}
+
+	searchedResult, err := svc.SearchTransaction(ctx, hash, &relationaldb.LedgerRange{Min: 999, Max: 1000})
+	if err != nil {
+		t.Fatalf("SearchTransaction: %v", err)
+	}
+	if searchedResult == nil || searchedResult.Transaction == nil || searchedResult.Transaction.LedgerIndex != historyLedger.Sequence() || searchedResult.Transaction.Validated {
+		t.Fatalf("search result = %+v, want unvalidated history result", searchedResult)
+	}
+	if searchedResult.Searched != relationaldb.TxSearchAll {
+		t.Fatalf("search result searched = %d, want TxSearchAll", searchedResult.Searched)
+	}
+
+	if err := historyLedger.SetValidated(); err != nil {
+		t.Fatalf("SetValidated: %v", err)
+	}
+	dbCombined, err := tx.CreateTxWithMetaBlob(rawTxn, &tx.Metadata{
+		TransactionResult: ter.TesSUCCESS,
+		TransactionIndex:  9,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbRaw, dbMeta, err := tx.SplitTxWithMetaBlobStrict(dbCombined)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledgerHash := relationaldb.Hash(historyLedger.Hash())
+	if err := repositories.Ledger().SaveValidatedLedger(ctx, relationaldb.LedgerInfo{
+		Hash:     ledgerHash,
+		Sequence: relationaldb.LedgerIndex(historyLedger.Sequence()),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repositories.Transaction().SaveTransaction(ctx, relationaldb.TransactionInfo{
+		Hash:      relationaldb.Hash(hash),
+		LedgerSeq: relationaldb.LedgerIndex(historyLedger.Sequence()),
+		Status:    "validated",
+		RawTxn:    dbRaw,
+		TxnMeta:   dbMeta,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	validatedRange, _, err := svc.GetTransactionWithRange(ctx, hash, 999, 1000)
+	if err != nil {
+		t.Fatalf("GetTransactionWithRange(validated): %v", err)
+	}
+	if validatedRange == nil || !validatedRange.Validated || validatedRange.TxIndex != 9 {
+		t.Fatalf("validated range lookup = %+v, want DB result with index 9", validatedRange)
+	}
+	validatedSearch, err := svc.SearchTransaction(ctx, hash, &relationaldb.LedgerRange{Min: 999, Max: 1000})
+	if err != nil {
+		t.Fatalf("SearchTransaction(validated): %v", err)
+	}
+	if validatedSearch == nil || validatedSearch.Transaction == nil || !validatedSearch.Transaction.Validated || validatedSearch.Transaction.TxIndex != 9 {
+		t.Fatalf("validated search result = %+v, want DB result with index 9", validatedSearch)
 	}
 }

--- a/internal/ledger/service/tx_query_submit_test.go
+++ b/internal/ledger/service/tx_query_submit_test.go
@@ -2,14 +2,18 @@ package service_test
 
 import (
 	"encoding/hex"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/LeJamon/go-xrpl/amendment"
 	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
 	"github.com/LeJamon/go-xrpl/internal/ledger/service"
 	jtx "github.com/LeJamon/go-xrpl/internal/testing"
+	batchtesting "github.com/LeJamon/go-xrpl/internal/testing/batch"
 	"github.com/LeJamon/go-xrpl/internal/testing/payment"
 	"github.com/LeJamon/go-xrpl/internal/tx"
+	batchtx "github.com/LeJamon/go-xrpl/internal/tx/batch"
 	"github.com/LeJamon/go-xrpl/internal/tx/ter"
 	"github.com/LeJamon/go-xrpl/internal/txq"
 )
@@ -153,6 +157,135 @@ func TestService_SubmitTransaction_AppliesAtOrAboveFeeLevel(t *testing.T) {
 	}
 }
 
+func TestService_SubmitTransaction_BadSignatureIsNotQueryable(t *testing.T) {
+	cfg := defaultServiceConfig()
+	cfg.Standalone = false
+	svc, err := service.New(cfg)
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("service.Start: %v", err)
+	}
+	t.Cleanup(svc.Stop)
+
+	env := jtx.NewTestEnv(t)
+	blob, _ := signedPaymentWithFee(t, env, jtx.MasterAccount(), jtx.NewAccount("alice"), 100_000_000, 10, 1)
+	wire, err := binarycodec.DecodeBytes(blob)
+	if err != nil {
+		t.Fatalf("DecodeBytes: %v", err)
+	}
+	wire["TxnSignature"] = strings.Repeat("00", 64)
+	badHex, err := binarycodec.Encode(wire)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	badBlob, err := hex.DecodeString(badHex)
+	if err != nil {
+		t.Fatalf("DecodeString: %v", err)
+	}
+	parsed, err := tx.ParseFromBinary(badBlob)
+	if err != nil {
+		t.Fatalf("ParseFromBinary: %v", err)
+	}
+	hash, err := tx.ComputeTransactionHash(parsed)
+	if err != nil {
+		t.Fatalf("ComputeTransactionHash: %v", err)
+	}
+
+	result, err := svc.SubmitTransaction(parsed, badBlob, false)
+	if err != nil {
+		t.Fatalf("SubmitTransaction: %v", err)
+	}
+	if result.Result != ter.TemINVALID {
+		t.Fatalf("Result = %s, want temINVALID", result.Result)
+	}
+	if _, err := svc.GetTransaction(hash); !errors.Is(err, service.ErrTxnNotFound) {
+		t.Fatalf("GetTransaction(bad signature) = %v, want ErrTxnNotFound", err)
+	}
+}
+
+func TestService_SubmitTransaction_BatchSignerFailureRemainsQueryable(t *testing.T) {
+	cfg := defaultServiceConfig()
+	cfg.Standalone = false
+	cfg.Startup.Mode = service.StartupFresh
+	cfg.GenesisConfig.Amendments = append(cfg.GenesisConfig.Amendments, amendment.FeatureBatch)
+	svc, err := service.New(cfg)
+	if err != nil {
+		t.Fatalf("service.New: %v", err)
+	}
+	if err := svc.Start(); err != nil {
+		t.Fatalf("service.Start: %v", err)
+	}
+	t.Cleanup(svc.Stop)
+	if !svc.TransactionRules().Enabled(amendment.FeatureBatch) {
+		t.Fatal("Batch amendment not enabled in service rules")
+	}
+
+	env := jtx.NewTestEnv(t)
+	env.EnableFeatureNow("Batch")
+	env.SetVerifySignatures(true)
+	outer := jtx.MasterAccount()
+	innerSigner := jtx.NewAccount("batch-signer")
+	batch := batchtesting.NewBatchBuilder(
+		outer,
+		1,
+		batchtesting.CalcBatchFeeFromEnv(env, 1, 2),
+		batchtx.BatchFlagAllOrNothing,
+	).
+		AddInnerTx(batchtesting.MakeInnerPaymentXRP(outer, innerSigner, 1, 2)).
+		AddInnerTx(batchtesting.MakeInnerPaymentXRP(innerSigner, outer, 1, 1)).
+		AddGarbageSigner(innerSigner).
+		Build()
+	env.SignWith(batch, outer)
+
+	txMap, err := batch.Flatten()
+	if err != nil {
+		t.Fatalf("Flatten: %v", err)
+	}
+	blobHex, err := binarycodec.Encode(txMap)
+	if err != nil {
+		t.Fatalf("binarycodec.Encode: %v", err)
+	}
+	blob, err := hex.DecodeString(blobHex)
+	if err != nil {
+		t.Fatalf("hex.DecodeString: %v", err)
+	}
+	parsed, err := tx.ParseFromBinary(blob)
+	if err != nil {
+		t.Fatalf("ParseFromBinary: %v", err)
+	}
+	hash, err := tx.ComputeTransactionHash(parsed)
+	if err != nil {
+		t.Fatalf("ComputeTransactionHash: %v", err)
+	}
+
+	result, err := svc.SubmitTransaction(parsed, blob, false)
+	if err != nil {
+		t.Fatalf("SubmitTransaction: %v", err)
+	}
+	if result.Result != ter.TemBAD_SIGNATURE {
+		t.Fatalf("Result = %s, want temBAD_SIGNATURE", result.Result)
+	}
+	if result.Applied {
+		t.Fatal("invalid BatchSigner signature must not apply")
+	}
+	hold, err := svc.GetTransaction(hash)
+	if err != nil {
+		t.Fatalf("GetTransaction(held batch) = %v", err)
+	}
+	if hold.Validated || hold.LedgerIndex != 0 || hold.TxIndex != ^uint32(0) {
+		t.Fatalf("held batch advertised validated-ledger state: %+v", hold)
+	}
+	heldBlob, metaBlob, err := tx.SplitTxWithMetaBlob(hold.TxData)
+	if err != nil {
+		t.Fatalf("split held batch: %v", err)
+	}
+	if string(heldBlob) != string(blob) || metaBlob != nil {
+		t.Fatalf("held batch payload = (%x, %x), want tx-only input", heldBlob, metaBlob)
+	}
+}
+
 // TestService_SubmitTransaction_QueuesBelowFeeLevel verifies that a tx
 // paying below the open-ledger fee level is held by TxQ and surfaces
 // terQUEUED through SubmitTransaction (Applied=false) instead of applying.
@@ -179,6 +312,20 @@ func TestService_SubmitTransaction_QueuesBelowFeeLevel(t *testing.T) {
 	}
 	if openLedgerHasTx(t, svc, hash) {
 		t.Errorf("queued tx must not be present in the open view")
+	}
+	queuedResult, err := svc.GetTransaction(hash)
+	if err != nil {
+		t.Fatalf("queued tx lookup: %v", err)
+	}
+	if queuedResult.LedgerIndex != 0 || queuedResult.Validated || queuedResult.TxIndex != ^uint32(0) {
+		t.Fatalf("queued tx advertised closed-ledger state: %+v", queuedResult)
+	}
+	queuedBlob, metaBlob, err := tx.SplitTxWithMetaBlob(queuedResult.TxData)
+	if err != nil {
+		t.Fatalf("split queued tx: %v", err)
+	}
+	if string(queuedBlob) != string(blob) || metaBlob != nil {
+		t.Fatalf("queued tx payload = (%x, %x), want tx-only input", queuedBlob, metaBlob)
 	}
 	if res.CurrentLedgerState == nil {
 		t.Fatal("queued submit must include current-ledger state")

--- a/internal/rpc/adapter/transactions.go
+++ b/internal/rpc/adapter/transactions.go
@@ -69,11 +69,6 @@ func (a *LedgerServiceAdapter) SearchTransaction(ctx context.Context, txHash [32
 	return response, nil
 }
 
-// StoreTransaction stores a transaction in the current ledger
-func (a *LedgerServiceAdapter) StoreTransaction(txHash [32]byte, txData []byte) error {
-	return a.svc.StoreTransaction(txHash, txData)
-}
-
 // GetTransactionHistory retrieves recent transactions
 func (a *LedgerServiceAdapter) GetTransactionHistory(ctx context.Context, startIndex uint32) (*types.TxHistoryResult, error) {
 	result, err := a.svc.GetTransactionHistory(ctx, startIndex)

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -842,6 +842,29 @@ func decodeTxBlobForTx(data []byte) (StoredTransaction, error) {
 	return decodeTxBlobWithMetadataMode(data, true, false, false)
 }
 
+// decodeOpenTxBlob decodes the transaction-only VL form returned for an
+// accepted transaction that is still in the open ledger. Open rows must not
+// carry metadata; closed transaction rows continue through decodeTxBlobForTx
+// and retain their strict metadata validation.
+func decodeOpenTxBlob(data []byte) (StoredTransaction, error) {
+	txBytes, metaBytes, err := tx.SplitTxWithMetaBlob(data)
+	if err != nil {
+		return StoredTransaction{}, err
+	}
+	if metaBytes != nil {
+		return StoredTransaction{}, errors.New("open transaction unexpectedly contains metadata")
+	}
+	txJSON, err := binarycodec.DecodeBytes(txBytes)
+	if err != nil {
+		return StoredTransaction{}, fmt.Errorf("decode open transaction: %w", err)
+	}
+	stored := StoredTransaction{TxJSON: txJSON}
+	if err := validateStoredTransaction(&stored, false); err != nil {
+		return StoredTransaction{}, err
+	}
+	return stored, nil
+}
+
 func decodeTxBlobForTransactionEntry(data []byte) (StoredTransaction, error) {
 	return decodeTxBlobWithMetadataMode(data, false, true, true)
 }

--- a/internal/rpc/handlers/tx.go
+++ b/internal/rpc/handlers/tx.go
@@ -117,12 +117,19 @@ func (m *TxMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *
 		txInfo, err = ctx.Services.Ledger.GetTransaction(txHash)
 	}
 	if err != nil && !errors.Is(err, svcerr.ErrTxnNotFound) {
+		if errors.Is(err, svcerr.ErrTxnDataCorrupt) {
+			return nil, rpcDBDeserializationError("tx: transaction lookup failed", err)
+		}
 		return nil, rpcInternalError("tx: transaction lookup failed", err)
 	}
 	if err != nil || txInfo == nil {
 		return nil, txNotFoundForSearch(hasLedgerRange, searched)
 	}
-	storedTx, err := decodeTxBlobForTx(txInfo.TxData)
+	decode := decodeTxBlobForTx
+	if txInfo.LedgerIndex == 0 {
+		decode = decodeOpenTxBlob
+	}
+	storedTx, err := decode(txInfo.TxData)
 	if err != nil {
 		return nil, rpcDBDeserializationError("tx: transaction deserialization failed", err)
 	}

--- a/internal/rpc/tx_open_test.go
+++ b/internal/rpc/tx_open_test.go
@@ -1,0 +1,191 @@
+package rpc
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+
+	binarycodec "github.com/LeJamon/go-xrpl/codec/binarycodec"
+	"github.com/LeJamon/go-xrpl/internal/ledger/service/svcerr"
+	"github.com/LeJamon/go-xrpl/internal/rpc/handlers"
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	txcore "github.com/LeJamon/go-xrpl/internal/tx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxMethodOpenTransactionResponseOmitsClosedFields(t *testing.T) {
+	txBytes, err := binarycodec.EncodeBytes(validStoredPaymentTransaction())
+	require.NoError(t, err)
+	openData, err := txcore.EncodeWithVL(txBytes)
+	require.NoError(t, err)
+
+	const hash = "1111111111111111111111111111111111111111111111111111111111111111"
+	mock := newMockLedgerServiceTx()
+	mock.transactions[hash] = &types.TransactionInfo{
+		TxData:      openData,
+		Validated:   false,
+		LedgerIndex: 0,
+	}
+
+	for _, apiVersion := range []int{types.ApiVersion1, types.ApiVersion2} {
+		for _, binary := range []bool{false, true} {
+			t.Run(apiVersionName(apiVersion, binary), func(t *testing.T) {
+				ctx := &types.RpcContext{
+					Context:    context.Background(),
+					Role:       types.RoleGuest,
+					ApiVersion: apiVersion,
+					Services:   servicesForTx(mock),
+				}
+				result, rpcErr := (&handlers.TxMethod{}).Handle(ctx, txRequest(hash, binary))
+				require.Nil(t, rpcErr)
+				response, ok := result.(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, hash, response["hash"])
+				assert.Equal(t, false, response["validated"])
+				for _, field := range []string{"meta", "meta_blob", "ledger_hash", "ledger_index", "inLedger", "date", "close_time_iso", "ctid"} {
+					assert.NotContains(t, response, field, "open tx must omit %s", field)
+				}
+				if binary {
+					if apiVersion == types.ApiVersion1 {
+						assert.Contains(t, response, "tx")
+					} else {
+						assert.Contains(t, response, "tx_blob")
+					}
+				} else if apiVersion == types.ApiVersion1 {
+					assert.Equal(t, "Payment", response["TransactionType"])
+				} else {
+					txJSON, ok := response["tx_json"].(map[string]any)
+					require.True(t, ok)
+					assert.Equal(t, "Payment", txJSON["TransactionType"])
+				}
+			})
+		}
+	}
+}
+
+func txRequest(hash string, binary bool) []byte {
+	request := `{"transaction":"` + hash + `"}`
+	if binary {
+		request = `{"transaction":"` + hash + `","binary":true}`
+	}
+	return []byte(request)
+}
+
+func apiVersionName(version int, binary bool) string {
+	name := "v1"
+	if version > 1 {
+		name = "v2"
+	}
+	if binary {
+		return name + "-binary"
+	}
+	return name + "-json"
+}
+
+func TestTxMethodOpenTransactionRejectsMetadata(t *testing.T) {
+	txBytes, err := binarycodec.EncodeBytes(validStoredPaymentTransaction())
+	require.NoError(t, err)
+	vlTx, err := txcore.EncodeWithVL(txBytes)
+	require.NoError(t, err)
+	vlMeta, err := txcore.EncodeWithVL([]byte{0x01})
+	require.NoError(t, err)
+	openData := append(append([]byte(nil), vlTx...), vlMeta...)
+
+	const hash = "2222222222222222222222222222222222222222222222222222222222222222"
+	mock := newMockLedgerServiceTx()
+	mock.transactions[hash] = &types.TransactionInfo{TxData: openData}
+	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleGuest, ApiVersion: types.ApiVersion2, Services: servicesForTx(mock)}
+	result, rpcErr := (&handlers.TxMethod{}).Handle(ctx, txRequest(hash, false))
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcDB_DESERIALIZATION, rpcErr.Code)
+}
+
+func TestTxMethodCorruptLookupMapsDBDeserialization(t *testing.T) {
+	const hash = "5555555555555555555555555555555555555555555555555555555555555555"
+	mock := newMockLedgerServiceTx()
+	mock.txLookupError = fmt.Errorf("%w: cached transaction hash mismatch", svcerr.ErrTxnDataCorrupt)
+	ctx := &types.RpcContext{
+		Context:    context.Background(),
+		Role:       types.RoleGuest,
+		ApiVersion: types.ApiVersion2,
+		Services:   servicesForTx(mock),
+	}
+	result, rpcErr := (&handlers.TxMethod{}).Handle(ctx, txRequest(hash, false))
+	assert.Nil(t, result)
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, types.RpcDB_DESERIALIZATION, rpcErr.Code)
+}
+
+func TestTxMethodOpenTransactionBinaryIsCanonical(t *testing.T) {
+	txBytes, err := binarycodec.EncodeBytes(validStoredPaymentTransaction())
+	require.NoError(t, err)
+	openData, err := txcore.EncodeWithVL(txBytes)
+	require.NoError(t, err)
+	const hash = "3333333333333333333333333333333333333333333333333333333333333333"
+	mock := newMockLedgerServiceTx()
+	mock.transactions[hash] = &types.TransactionInfo{TxData: openData}
+	ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleGuest, ApiVersion: types.ApiVersion2, Services: servicesForTx(mock)}
+	result, rpcErr := (&handlers.TxMethod{}).Handle(ctx, txRequest(hash, true))
+	require.Nil(t, rpcErr)
+	response := result.(map[string]any)
+	blob, ok := response["tx_blob"].(string)
+	require.True(t, ok)
+	decoded, err := hex.DecodeString(blob)
+	require.NoError(t, err)
+	canonical, err := binarycodec.EncodeBytes(validStoredPaymentTransaction())
+	require.NoError(t, err)
+	assert.Equal(t, canonical, decoded)
+}
+
+func TestTxMethodClosedTransactionRetainsRealMetadataAndLedgerFields(t *testing.T) {
+	txBytes, err := binarycodec.EncodeBytes(validStoredPaymentTransaction())
+	require.NoError(t, err)
+	meta := validStoredMetadata()
+	meta["TransactionIndex"] = uint32(7)
+	metaBytes, err := binarycodec.EncodeBytes(meta)
+	require.NoError(t, err)
+	vlTx, err := txcore.EncodeWithVL(txBytes)
+	require.NoError(t, err)
+	vlMeta, err := txcore.EncodeWithVL(metaBytes)
+	require.NoError(t, err)
+	closedData := append(append([]byte(nil), vlTx...), vlMeta...)
+
+	const hash = "4444444444444444444444444444444444444444444444444444444444444444"
+	mock := newMockLedgerServiceTx()
+	mock.transactions[hash] = &types.TransactionInfo{
+		TxData:      closedData,
+		LedgerIndex: 100,
+		LedgerHash:  strings.Repeat("A", 64),
+		Validated:   true,
+		TxIndex:     7,
+		CloseTime:   123,
+	}
+	for _, apiVersion := range []int{types.ApiVersion1, types.ApiVersion2} {
+		ctx := &types.RpcContext{Context: context.Background(), Role: types.RoleGuest, ApiVersion: apiVersion, Services: servicesForTx(mock)}
+		result, rpcErr := (&handlers.TxMethod{}).Handle(ctx, txRequest(hash, false))
+		require.Nil(t, rpcErr)
+		response := result.(map[string]any)
+		responseMeta, ok := response["meta"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "tesSUCCESS", responseMeta["TransactionResult"])
+		assert.Equal(t, uint32(7), responseMeta["TransactionIndex"])
+		assert.Equal(t, []any{}, responseMeta["AffectedNodes"])
+		assert.Equal(t, true, response["validated"])
+		if apiVersion == types.ApiVersion1 {
+			assert.Equal(t, uint32(100), response["ledger_index"])
+			assert.Equal(t, uint32(100), response["inLedger"])
+			assert.Equal(t, int64(123), response["date"])
+		} else {
+			assert.Equal(t, uint32(100), response["ledger_index"])
+			assert.Equal(t, strings.Repeat("A", 64), response["ledger_hash"])
+			txJSON, ok := response["tx_json"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, uint32(100), txJSON["ledger_index"])
+			assert.Equal(t, int64(123), txJSON["date"])
+		}
+	}
+}

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -805,7 +805,6 @@ type TransactionSubmitter interface {
 	SubmitTransaction(txJSON []byte, txBlobHex string) (*SubmitResult, error)
 	SimulateTransaction(txJSON []byte) (*SubmitResult, error)
 	GetTransaction(txHash [32]byte) (*TransactionInfo, error)
-	StoreTransaction(txHash [32]byte, txData []byte) error
 	GetTransactionHistory(ctx context.Context, startIndex uint32) (*TxHistoryResult, error)
 
 	// GetAutofillFee returns the Fee a transaction should carry to enter


### PR DESCRIPTION
## Summary
- Move authoritative transaction and metadata persistence into the ledger lifecycle.
- Support correct open, held, queued, and validated lookup before and after close.

## Verification
- Transaction lifecycle, service, and full RPC tests
- Targeted race, vet, strict lint, build, and oracle review

Refs #1486

Stack layer 6 of 16; depends on #1571.