### PR TITLE
fix: enforce pathfinding admission contracts (#1486)

### DIFF
--- a/internal/rpc/amendment_blocked_test.go
+++ b/internal/rpc/amendment_blocked_test.go
@@ -33,7 +33,6 @@ var blockedMethods = []string{
 	"get_aggregate_price",
 	"simulate",
 	"tx",
-	"ripple_path_find",
 	"ledger_cleaner",
 }
 
@@ -69,6 +68,7 @@ var unblockedMethods = []string{
 	"nft_sell_offers",
 	"transaction_entry",
 	"tx_history",
+	"ripple_path_find",
 	"wallet_propose",
 	"subscribe",
 	"unsubscribe",
@@ -229,7 +229,7 @@ func TestAmendmentBlockedConditionClassification(t *testing.T) {
 		counts[types.NeedsCurrentLedger], counts[types.NeedsClosedLedger], counts[types.NeedsNetworkConnection])
 
 	// Verify specific condition counts based on rippled
-	assert.Equal(t, 11, counts[types.NeedsCurrentLedger], "NeedsCurrentLedger count")
+	assert.Equal(t, 10, counts[types.NeedsCurrentLedger], "NeedsCurrentLedger count")
 	assert.Equal(t, 1, counts[types.NeedsClosedLedger], "NeedsClosedLedger count")
 	assert.Equal(t, 2, counts[types.NeedsNetworkConnection], "NeedsNetworkConnection count")
 

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -91,6 +91,16 @@ func RequireTxTables(services *types.ServiceContainer) *types.RpcError {
 	return nil
 }
 
+// RequirePathSearch gates the path-finding RPCs on the startup path-search
+// capability. The check belongs at each transport/handler entry point so a
+// disabled server rejects before parsing request parameters or charging load.
+func RequirePathSearch(ctx *types.RpcContext) *types.RpcError {
+	if ctx == nil || ctx.Services == nil || ctx.Services.Capabilities.PathSearchMax == 0 {
+		return types.RpcErrorNotSupported("")
+	}
+	return nil
+}
+
 // shedCheck returns the shedder when a gate should run: nil otherwise.
 // Skips when ctx is missing, the shedder isn't wired, or the caller is
 // unlimited (admin/identified) — mirroring rippled's isUnlimited(role)
@@ -131,17 +141,31 @@ func RequireNotBusyBookOffers(ctx *types.RpcContext) *types.RpcError {
 // AcquirePathfind admits a path-finding request, mirroring the
 // LegacyPathFind ctor at rippled LegacyPathFind.cpp:30-60:
 //
-//  1. Admin/unlimited callers bypass the gate.
+//  1. Admin/unlimited callers bypass the load and concurrency gates but still
+//     increment the shared in-progress counter.
 //  2. If in-flight RPCs exceed Tuning::maxPathfindJobCount (50), shed.
 //  3. Otherwise CAS-increment the concurrent-path-find counter; if it
 //     would exceed Tuning::maxPathfindsInProgress (2), shed.
 //
 // Returns a release func the caller MUST invoke (typically via defer)
-// when admitted; release is nil on shed. The isLoadedLocal() check
-// rippled performs in the same ctor will land alongside the LoadFeeTrack
-// subsystem (ServiceContainer.LoadFactorFees is nil today).
+// when admitted; release is nil on shed. Local fee pressure is checked even
+// when the in-flight client counter is not wired.
 func AcquirePathfind(ctx *types.RpcContext) (release func(), rpcErr *types.RpcError) {
-	s := shedCheck(ctx)
+	if ctx == nil || ctx.Services == nil {
+		return func() {}, nil
+	}
+	services := ctx.Services
+	s := services.ClientLoad
+	if ctx.Unlimited {
+		if s == nil {
+			return func() {}, nil
+		}
+		s.AcquirePathfindUnlimited()
+		return s.ReleasePathfind, nil
+	}
+	if services.IsLoadedLocal != nil && services.IsLoadedLocal() {
+		return nil, types.RpcErrorTooBusy()
+	}
 	if s == nil {
 		return func() {}, nil
 	}

--- a/internal/rpc/handlers/helpers.go
+++ b/internal/rpc/handlers/helpers.go
@@ -178,6 +178,18 @@ func AcquirePathfind(ctx *types.RpcContext) (release func(), rpcErr *types.RpcEr
 	return s.ReleasePathfind, nil
 }
 
+// WaitPathfind queues a default-ledger request behind the bounded path-finding
+// workers until a slot is available or the request is canceled.
+func WaitPathfind(ctx *types.RpcContext) (release func(), rpcErr *types.RpcError) {
+	if ctx == nil || ctx.Services == nil || ctx.Services.ClientLoad == nil {
+		return func() {}, nil
+	}
+	if !ctx.Services.ClientLoad.WaitPathfind(ctx.Context) {
+		return nil, types.RpcErrorTooBusy()
+	}
+	return ctx.Services.ClientLoad.ReleasePathfind, nil
+}
+
 // ParseParams unmarshals JSON params into dest, returning an RpcError on failure.
 // If params is nil, dest is left untouched (zero value).
 func ParseParams(params json.RawMessage, dest any) *types.RpcError {

--- a/internal/rpc/handlers/load_shed_test.go
+++ b/internal/rpc/handlers/load_shed_test.go
@@ -98,7 +98,13 @@ func TestGates_UnlimitedBypass(t *testing.T) {
 	if rpcErr != nil {
 		t.Fatalf("admin must bypass pathfind gate, got %v", rpcErr)
 	}
-	release() // must be a safe no-op
+	if got := s.PathfindActive(); got != 1 {
+		t.Fatalf("admin pathfind active = %d, want 1", got)
+	}
+	release()
+	if got := s.PathfindActive(); got != 0 {
+		t.Fatalf("admin pathfind active after release = %d, want 0", got)
+	}
 }
 
 // AcquirePathfind mirrors LegacyPathFind ctor (LegacyPathFind.cpp:30-60):
@@ -120,6 +126,59 @@ func TestAcquirePathfind_JobCountGate(t *testing.T) {
 	if got := s.PathfindActive(); got != 0 {
 		t.Errorf("pathfindActive leaked: got %d, want 0", got)
 	}
+}
+
+func TestAcquirePathfind_LocalLoadGateWithoutClientCounter(t *testing.T) {
+	ctx := &types.RpcContext{Services: &types.ServiceContainer{
+		IsLoadedLocal: func() bool { return true },
+	}}
+	if _, rpcErr := AcquirePathfind(ctx); rpcErr == nil || rpcErr.ErrorString != "tooBusy" {
+		t.Fatalf("local load should shed without ClientLoad, got %v", rpcErr)
+	}
+}
+
+func TestAcquirePathfind_UnlimitedBypassesLocalLoad(t *testing.T) {
+	s := types.NewClientLoadShedder()
+	ctx := &types.RpcContext{
+		Unlimited: true,
+		Services: &types.ServiceContainer{
+			ClientLoad:    s,
+			IsLoadedLocal: func() bool { return true },
+		},
+	}
+	release, rpcErr := AcquirePathfind(ctx)
+	if rpcErr != nil {
+		t.Fatalf("unlimited caller should bypass local load, got %v", rpcErr)
+	}
+	if got := s.PathfindActive(); got != 1 {
+		t.Fatalf("unlimited pathfind active = %d, want 1", got)
+	}
+	release()
+}
+
+func TestAcquirePathfind_UnlimitedExceedsCapButConsumesSlot(t *testing.T) {
+	s := types.NewClientLoadShedder()
+	r1, rpcErr := AcquirePathfind(gatedCtx(s))
+	if rpcErr != nil {
+		t.Fatalf("first regular acquire: %v", rpcErr)
+	}
+	r2, rpcErr := AcquirePathfind(gatedCtx(s))
+	if rpcErr != nil {
+		t.Fatalf("second regular acquire: %v", rpcErr)
+	}
+	adminRelease, rpcErr := AcquirePathfind(unlimitedCtx(s))
+	if rpcErr != nil {
+		t.Fatalf("admin acquire above cap: %v", rpcErr)
+	}
+	if got := s.PathfindActive(); got != types.MaxPathfindsInProgress+1 {
+		t.Fatalf("pathfind active with admin = %d, want %d", got, types.MaxPathfindsInProgress+1)
+	}
+	if _, rpcErr := AcquirePathfind(gatedCtx(s)); rpcErr == nil {
+		t.Fatal("regular caller should remain capped while admin is active")
+	}
+	adminRelease()
+	r2()
+	r1()
 }
 
 // AcquirePathfind enforces the concurrent-in-progress cap from

--- a/internal/rpc/handlers/load_shed_test.go
+++ b/internal/rpc/handlers/load_shed_test.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/LeJamon/go-xrpl/internal/rpc/types"
 )
@@ -212,4 +214,57 @@ func TestAcquirePathfind_InProgressCap(t *testing.T) {
 	if got := s.PathfindActive(); got != 0 {
 		t.Errorf("PathfindActive leaked after all release: %d", got)
 	}
+}
+
+func TestWaitPathfindWaitsForRelease(t *testing.T) {
+	s := types.NewClientLoadShedder()
+	r1, err1 := AcquirePathfind(gatedCtx(s))
+	if err1 != nil {
+		t.Fatalf("first acquire should succeed: %v", err1)
+	}
+	r2, err2 := AcquirePathfind(gatedCtx(s))
+	if err2 != nil {
+		t.Fatalf("second acquire should succeed: %v", err2)
+	}
+
+	acquired := make(chan bool, 1)
+	go func() {
+		acquired <- s.WaitPathfind(context.Background())
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("third pathfind should wait while both slots are occupied")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	r1()
+	select {
+	case ok := <-acquired:
+		if !ok {
+			t.Fatal("waiting pathfind should acquire the released slot")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waiting pathfind did not acquire the released slot")
+	}
+
+	s.ReleasePathfind()
+	r2()
+	if got := s.PathfindActive(); got != 0 {
+		t.Fatalf("PathfindActive leaked after wait: %d", got)
+	}
+}
+
+func TestWaitPathfindHonorsCancellation(t *testing.T) {
+	s := types.NewClientLoadShedder()
+	s.AcquirePathfindUnlimited()
+	s.AcquirePathfindUnlimited()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if s.WaitPathfind(ctx) {
+		t.Fatal("canceled pathfind wait should fail")
+	}
+	s.ReleasePathfind()
+	s.ReleasePathfind()
 }

--- a/internal/rpc/handlers/loadkinds_test.go
+++ b/internal/rpc/handlers/loadkinds_test.go
@@ -58,7 +58,11 @@ func TestRipplePathFindBusyAdmissionIsHeavy(t *testing.T) {
 	ctx := &types.RpcContext{
 		Context:  context.Background(),
 		LoadCost: uint32(loadtrack.LoadReference),
-		Services: &types.ServiceContainer{ClientLoad: shedder},
+		Services: &types.ServiceContainer{
+			Ledger:       &loadAdmissionLedger{serverInfo: &types.LedgerServerInfo{Standalone: true}},
+			ClientLoad:   shedder,
+			Capabilities: types.RPCCapabilities{PathSearchMax: 3},
+		},
 	}
 
 	_, rpcErr := (&RipplePathFindMethod{}).Handle(ctx, json.RawMessage(`{}`))

--- a/internal/rpc/handlers/mpt_rpc_test.go
+++ b/internal/rpc/handlers/mpt_rpc_test.go
@@ -74,15 +74,18 @@ func TestPathFindMPTSourceAndFormatting(t *testing.T) {
 }
 
 func TestPathFindMPTSourceRejectsConflictingMembers(t *testing.T) {
-	for _, sourceCurrencies := range []string{
-		`[{"mpt_issuance_id":"` + rpcMPTID + `","currency":null}]`,
-		`[{"mpt_issuance_id":"` + rpcMPTID + `","issuer":null}]`,
+	for _, tc := range []struct {
+		sourceCurrencies string
+		want             string
+	}{
+		{`[{"mpt_issuance_id":"` + rpcMPTID + `","currency":null}]`, "srcCurMalformed"},
+		{`[{"mpt_issuance_id":"` + rpcMPTID + `","issuer":null}]`, "srcIsrMalformed"},
 	} {
 		_, rpcErr := parseSourceCurrencies(map[string]json.RawMessage{
-			"source_currencies": json.RawMessage(sourceCurrencies),
+			"source_currencies": json.RawMessage(tc.sourceCurrencies),
 		}, [20]byte{1}, nil)
 		require.NotNil(t, rpcErr)
-		require.Equal(t, "srcCurMalformed", rpcErr.ErrorString)
+		require.Equal(t, tc.want, rpcErr.ErrorString)
 	}
 }
 

--- a/internal/rpc/handlers/path_find.go
+++ b/internal/rpc/handlers/path_find.go
@@ -21,6 +21,24 @@ import (
 type PathFindMethod struct{ BaseHandler }
 
 func (m *PathFindMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
+	if rpcErr := RequirePathSearch(ctx); rpcErr != nil {
+		return nil, rpcErr
+	}
+	if len(params) == 0 {
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(params, &fields); err != nil || fields == nil {
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	rawSubcommand, ok := fields["subcommand"]
+	if !ok {
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
+	var subcommand *string
+	if err := json.Unmarshal(rawSubcommand, &subcommand); err != nil || subcommand == nil {
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
+	}
 	return nil, types.RpcErrorNoEvents("")
 }
 

--- a/internal/rpc/handlers/path_find_test.go
+++ b/internal/rpc/handlers/path_find_test.go
@@ -1,0 +1,204 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/LeJamon/go-xrpl/internal/rpc/types"
+	"github.com/LeJamon/go-xrpl/keylet"
+	"github.com/LeJamon/go-xrpl/protocol"
+)
+
+func pathFindTestContext(pathSearchMax int) *types.RpcContext {
+	return &types.RpcContext{Services: &types.ServiceContainer{
+		Capabilities: types.RPCCapabilities{PathSearchMax: pathSearchMax},
+	}}
+}
+
+func TestPathFindCapabilityPrecedesValidation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		handle func(*types.RpcContext, json.RawMessage) (any, *types.RpcError)
+	}{
+		{name: "path_find", handle: (&PathFindMethod{}).Handle},
+		{name: "ripple_path_find", handle: (&RipplePathFindMethod{}).Handle},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, rpcErr := test.handle(pathFindTestContext(0), json.RawMessage("{not json"))
+			if rpcErr == nil || rpcErr.ErrorString != "notSupported" {
+				t.Fatalf("disabled path-finding error = %v, want notSupported", rpcErr)
+			}
+		})
+	}
+}
+
+func TestRipplePathFindRequiredCondition(t *testing.T) {
+	if got := (&RipplePathFindMethod{}).RequiredCondition(); got != types.NoCondition {
+		t.Fatalf("RequiredCondition = %v, want NoCondition", got)
+	}
+}
+
+func TestPathFindPlainValidationAndNoEvents(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		params string
+		want   string
+	}{
+		{name: "missing", params: `{}`, want: "invalidParams"},
+		{name: "nonstring", params: `{"subcommand":7}`, want: "invalidParams"},
+		{name: "malformed", params: `{not json`, want: "invalidParams"},
+		{name: "known", params: `{"subcommand":"create"}`, want: "noEvents"},
+		{name: "unknown", params: `{"subcommand":"future"}`, want: "noEvents"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, rpcErr := (&PathFindMethod{}).Handle(pathFindTestContext(3), json.RawMessage(test.params))
+			if rpcErr == nil || rpcErr.ErrorString != test.want {
+				t.Fatalf("path_find error = %v, want %s", rpcErr, test.want)
+			}
+			if test.want == "invalidParams" && rpcErr.Message != "Invalid parameters." {
+				t.Fatalf("path_find invalid message = %q, want canonical", rpcErr.Message)
+			}
+		})
+	}
+}
+
+type pathFindTestReader struct {
+	types.LedgerReader
+	sequence  uint32
+	hash      [32]byte
+	closed    bool
+	validated bool
+}
+
+func (r *pathFindTestReader) Sequence() uint32  { return r.sequence }
+func (r *pathFindTestReader) Hash() [32]byte    { return r.hash }
+func (r *pathFindTestReader) IsClosed() bool    { return r.closed }
+func (r *pathFindTestReader) IsValidated() bool { return r.validated }
+
+type pathFindTestView struct {
+	types.LedgerStateView
+	existsFn func() (bool, error)
+}
+
+func (v *pathFindTestView) Exists(keylet.Keylet) (bool, error) {
+	if v.existsFn == nil {
+		return true, nil
+	}
+	return v.existsFn()
+}
+
+type pathFindTestLedger struct {
+	types.LedgerService
+	info   types.LedgerServerInfo
+	view   types.LedgerStateView
+	reader types.LedgerReader
+}
+
+func (s *pathFindTestLedger) GetServerInfo() types.LedgerServerInfo { return s.info }
+func (s *pathFindTestLedger) GetClosedLedgerView() (types.LedgerStateView, error) {
+	return s.view, nil
+}
+func (s *pathFindTestLedger) GetLedgerViewBySeq(seq uint32) (types.LedgerStateView, types.LedgerReader, error) {
+	if seq != 7 {
+		return nil, nil, errors.New("ledger not found")
+	}
+	return s.view, s.reader, nil
+}
+func (s *pathFindTestLedger) GetLedgerViewByHash(hash [32]byte) (types.LedgerStateView, types.LedgerReader, error) {
+	if s.reader == nil || hash != s.reader.Hash() {
+		return nil, nil, errors.New("ledger not found")
+	}
+	return s.view, s.reader, nil
+}
+
+func freshPathFindInfo() types.LedgerServerInfo {
+	return types.LedgerServerInfo{
+		HaveValidated:            true,
+		ValidatedLedgerCloseTime: time.Now().Unix() - protocol.RippleEpochUnix,
+	}
+}
+
+func TestRipplePathFindStaleDefaultUsesApiVersionError(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		api  int
+		want string
+	}{
+		{name: "v1", api: types.ApiVersion1, want: "noNetwork"},
+		{name: "v2", api: types.ApiVersion2, want: "notSynced"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ledger := &pathFindTestLedger{info: types.LedgerServerInfo{}}
+			ctx := &types.RpcContext{
+				ApiVersion: test.api,
+				Services: &types.ServiceContainer{
+					Ledger:       ledger,
+					Capabilities: types.RPCCapabilities{PathSearchMax: 3},
+				},
+			}
+			_, rpcErr := (&RipplePathFindMethod{}).Handle(ctx, json.RawMessage(`{}`))
+			if rpcErr == nil || rpcErr.ErrorString != test.want {
+				t.Fatalf("stale default error = %v, want %s", rpcErr, test.want)
+			}
+		})
+	}
+}
+
+func TestRipplePathFindExplicitHistoricalBypassesStaleDefaultGate(t *testing.T) {
+	view := &pathFindTestView{}
+	reader := &pathFindTestReader{sequence: 7, closed: true, validated: true}
+	ledger := &pathFindTestLedger{info: types.LedgerServerInfo{}, view: view, reader: reader}
+	ctx := &types.RpcContext{
+		ApiVersion: types.ApiVersion2,
+		Services: &types.ServiceContainer{
+			Ledger:       ledger,
+			Capabilities: types.RPCCapabilities{PathSearchMax: 3},
+			ClientLoad:   types.NewClientLoadShedder(),
+		},
+	}
+	_, rpcErr := (&RipplePathFindMethod{}).Handle(ctx, json.RawMessage(`{"ledger_index":7}`))
+	if rpcErr == nil || rpcErr.ErrorString != "srcActMissing" {
+		t.Fatalf("explicit historical error = %v, want srcActMissing after lookup", rpcErr)
+	}
+	if got := ctx.Services.ClientLoad.PathfindActive(); got != 0 {
+		t.Fatalf("pathfind admission leaked after validation error: %d", got)
+	}
+}
+
+func TestRipplePathFindExistsErrorsAreInternal(t *testing.T) {
+	const account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+	for _, test := range []struct {
+		name   string
+		exists func() (bool, error)
+	}{
+		{name: "source", exists: func() (bool, error) { return false, errors.New("source storage failed") }},
+		{name: "destination", exists: func() (bool, error) { return true, nil }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			existsFn := test.exists
+			if test.name == "destination" {
+				calls := 0
+				existsFn = func() (bool, error) {
+					calls++
+					if calls == 1 {
+						return true, nil
+					}
+					return false, errors.New("destination storage failed")
+				}
+			}
+			view := &pathFindTestView{existsFn: existsFn}
+			ledger := &pathFindTestLedger{info: freshPathFindInfo(), view: view}
+			ctx := &types.RpcContext{Services: &types.ServiceContainer{
+				Ledger:       ledger,
+				Capabilities: types.RPCCapabilities{PathSearchMax: 3},
+			}}
+			params := json.RawMessage(`{"source_account":"` + account + `","destination_account":"` + account + `","destination_amount":"10"}`)
+			_, rpcErr := (&RipplePathFindMethod{}).Handle(ctx, params)
+			if rpcErr == nil || rpcErr.ErrorString != "internal" || rpcErr.Message != "Internal error." {
+				t.Fatalf("exists error = %v, want sanitized internal", rpcErr)
+			}
+		})
+	}
+}

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -194,6 +194,13 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 	}
 
 	// Run pathfinding at the production search level (rippled PATH_SEARCH).
+	if !usesLookup {
+		release, rpcErr := WaitPathfind(ctx)
+		if rpcErr != nil {
+			return nil, rpcErr
+		}
+		defer release()
+	}
 	pr := pathfinder.NewPathRequest(srcAccount, dstAccount, dstAmount, sendMax, srcCurrencies, convertAll)
 	pr.SetDomainID(domainID)
 	result := pr.Execute(view)
@@ -316,8 +323,11 @@ func parseSourceCurrencies(
 		rawCurrency, hasCurrency := fields["currency"]
 		rawMPT, hasMPT := fields["mpt_issuance_id"]
 		_, hasIssuer := fields["issuer"]
-		if hasCurrency == hasMPT || hasMPT && hasIssuer {
+		if hasCurrency == hasMPT {
 			return nil, types.RpcErrorSrcCurMalformed("Source currency is malformed.")
+		}
+		if hasMPT && hasIssuer {
+			return nil, types.RpcErrorSrcIsrMalformed("Source issuer is malformed.")
 		}
 		if hasMPT {
 			var mptID string

--- a/internal/rpc/handlers/ripple_path_find.go
+++ b/internal/rpc/handlers/ripple_path_find.go
@@ -51,12 +51,10 @@ type pathAlternativeJSON struct {
 type RipplePathFindMethod struct{ BaseHandler }
 
 func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMessage) (any, *types.RpcError) {
-	setLoadHeavy(ctx)
-	release, rpcErr := AcquirePathfind(ctx)
-	if rpcErr != nil {
+	if rpcErr := RequirePathSearch(ctx); rpcErr != nil {
 		return nil, rpcErr
 	}
-	defer release()
+	setLoadHeavy(ctx)
 
 	probe := map[string]json.RawMessage{}
 	if params != nil {
@@ -68,13 +66,33 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 	if ledgerSpecErr != nil {
 		return nil, ledgerSpecErr
 	}
+	if rpcErr := RequireLedgerService(ctx.Services); rpcErr != nil {
+		return nil, rpcErr
+	}
 	var view types.LedgerStateView
 	var meta *pathFindLedgerMeta
+	var rpcErr *types.RpcError
 	standalone := ctx != nil && ctx.Services != nil && ctx.Services.Ledger != nil &&
 		ctx.Services.Ledger.GetServerInfo().Standalone
 	usesLookup := hasLedgerSelector || standalone
 	if usesLookup {
 		view, meta, rpcErr = resolvePathFindLedger(ctx, ledgerSpec, true)
+		if rpcErr != nil {
+			return nil, rpcErr
+		}
+		release, rpcErr := AcquirePathfind(ctx)
+		if rpcErr != nil {
+			return nil, rpcErr
+		}
+		defer release()
+	} else {
+		if types.ValidatedLedgerStale(ctx.Services.Ledger.GetServerInfo()) {
+			if ctx.ApiVersion == types.ApiVersion1 {
+				return nil, types.RpcErrorNoNetwork("")
+			}
+			return nil, types.RpcErrorNotSynced("")
+		}
+		view, meta, rpcErr = resolvePathFindLedger(ctx, types.LedgerSpecifier{}, false)
 		if rpcErr != nil {
 			return nil, rpcErr
 		}
@@ -141,23 +159,19 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 			return nil, types.RpcErrorDomainMalformed("Domain is malformed.")
 		}
 	}
-
-	// Ledger selection: an explicit ledger_hash/ledger_index resolves a
-	// specific ledger and merges its metadata into the response, mirroring
-	// rippled's RPC::lookupLedger merge; otherwise the closed ledger is used
-	// with no ledger fields in the reply.
-	if !usesLookup {
-		view, meta, rpcErr = resolvePathFindLedger(ctx, types.LedgerSpecifier{}, false)
-		if rpcErr != nil {
-			return nil, rpcErr
-		}
+	if view == nil {
+		return nil, types.NewRpcError(types.RpcNO_CURRENT, "noCurrent", "noCurrent", "Current ledger is unavailable.")
 	}
 
 	// Existence checks. Reference: rippled PathRequest::isValid.
-	if exists, _ := view.Exists(keylet.Account(srcAccount)); !exists {
+	if exists, err := view.Exists(keylet.Account(srcAccount)); err != nil {
+		return nil, rpcInternalError("ripple_path_find: source account lookup failed", err)
+	} else if !exists {
 		return nil, types.RpcErrorSrcActNotFound("Source account not found.")
 	}
-	if exists, _ := view.Exists(keylet.Account(dstAccount)); !exists {
+	if exists, err := view.Exists(keylet.Account(dstAccount)); err != nil {
+		return nil, rpcInternalError("ripple_path_find: destination account lookup failed", err)
+	} else if !exists {
 		// Only XRP can be sent to a non-existent account, and the payment
 		// must meet the account reserve.
 		if !dstAmount.IsNative() {
@@ -244,10 +258,6 @@ func (m *RipplePathFindMethod) Handle(ctx *types.RpcContext, params json.RawMess
 		return nil, rpcInternalError("ripple_path_find: response normalization failed", uErr)
 	}
 	return flat, nil
-}
-
-func (m *RipplePathFindMethod) RequiredCondition() types.Condition {
-	return types.NeedsCurrentLedger
 }
 
 // decodeAccountRaw decodes a JSON string into an AccountID. Returns false

--- a/internal/rpc/handlers/ripple_path_find_mpt_test.go
+++ b/internal/rpc/handlers/ripple_path_find_mpt_test.go
@@ -41,7 +41,12 @@ func TestRipplePathFindRejectsMPTWithZeroIssuer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, rpcErr := (&RipplePathFindMethod{}).Handle(&types.RpcContext{}, test.params)
+			_, rpcErr := (&RipplePathFindMethod{}).Handle(&types.RpcContext{
+				Services: &types.ServiceContainer{
+					Ledger:       &pathFindTestLedger{info: freshPathFindInfo(), view: &pathFindTestView{}},
+					Capabilities: types.RPCCapabilities{PathSearchMax: 3},
+				},
+			}, test.params)
 			require.NotNil(t, rpcErr)
 			require.Equal(t, test.token, rpcErr.ErrorString)
 		})
@@ -93,4 +98,13 @@ func TestParseSourceCurrenciesAcceptsZeroMPTLiteral(t *testing.T) {
 	require.Len(t, issues, 1)
 	require.True(t, issues[0].IsMPT)
 	require.Equal(t, [24]byte{}, issues[0].MPTID)
+}
+
+func TestParseSourceCurrenciesMPTIssuerIsCurrencyMalformed(t *testing.T) {
+	probe := map[string]json.RawMessage{
+		"source_currencies": json.RawMessage(`[{"mpt_issuance_id":"0","issuer":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"}]`),
+	}
+	_, rpcErr := parseSourceCurrencies(probe, [20]byte{1}, nil)
+	require.NotNil(t, rpcErr)
+	require.Equal(t, "srcCurMalformed", rpcErr.ErrorString)
 }

--- a/internal/rpc/handlers/ripple_path_find_mpt_test.go
+++ b/internal/rpc/handlers/ripple_path_find_mpt_test.go
@@ -100,11 +100,11 @@ func TestParseSourceCurrenciesAcceptsZeroMPTLiteral(t *testing.T) {
 	require.Equal(t, [24]byte{}, issues[0].MPTID)
 }
 
-func TestParseSourceCurrenciesMPTIssuerIsCurrencyMalformed(t *testing.T) {
+func TestParseSourceCurrenciesMPTIssuerIsIssuerMalformed(t *testing.T) {
 	probe := map[string]json.RawMessage{
 		"source_currencies": json.RawMessage(`[{"mpt_issuance_id":"0","issuer":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"}]`),
 	}
 	_, rpcErr := parseSourceCurrencies(probe, [20]byte{1}, nil)
 	require.NotNil(t, rpcErr)
-	require.Equal(t, "srcCurMalformed", rpcErr.ErrorString)
+	require.Equal(t, "srcIsrMalformed", rpcErr.ErrorString)
 }

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -720,6 +720,15 @@ func (s *ClientLoadShedder) AcquirePathfind() bool {
 	}
 }
 
+// AcquirePathfindUnlimited enters the path-finding critical section without
+// enforcing the non-admin concurrency cap.
+func (s *ClientLoadShedder) AcquirePathfindUnlimited() {
+	if s == nil {
+		return
+	}
+	s.pathfindActive.Add(1)
+}
+
 func (s *ClientLoadShedder) ReleasePathfind() {
 	if s == nil {
 		return

--- a/internal/rpc/types/services.go
+++ b/internal/rpc/types/services.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -669,10 +670,19 @@ const (
 type ClientLoadShedder struct {
 	inFlight       atomic.Int64
 	pathfindActive atomic.Int64
+	pathfindOnce   sync.Once
+	pathfindReady  chan struct{}
 }
 
 func NewClientLoadShedder() *ClientLoadShedder {
 	return &ClientLoadShedder{}
+}
+
+func (s *ClientLoadShedder) pathfindSignal() chan struct{} {
+	s.pathfindOnce.Do(func() {
+		s.pathfindReady = make(chan struct{}, int(MaxPathfindsInProgress))
+	})
+	return s.pathfindReady
 }
 
 // Begin records the start of a client-RPC dispatch.
@@ -720,6 +730,25 @@ func (s *ClientLoadShedder) AcquirePathfind() bool {
 	}
 }
 
+// WaitPathfind blocks until a bounded path-finding slot is available or the
+// request is canceled.
+func (s *ClientLoadShedder) WaitPathfind(ctx context.Context) bool {
+	if s == nil {
+		return true
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for !s.AcquirePathfind() {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-s.pathfindSignal():
+		}
+	}
+	return true
+}
+
 // AcquirePathfindUnlimited enters the path-finding critical section without
 // enforcing the non-admin concurrency cap.
 func (s *ClientLoadShedder) AcquirePathfindUnlimited() {
@@ -734,6 +763,10 @@ func (s *ClientLoadShedder) ReleasePathfind() {
 		return
 	}
 	s.pathfindActive.Add(-1)
+	select {
+	case s.pathfindSignal() <- struct{}{}:
+	default:
+	}
 }
 
 // PathfindActive returns the current concurrent-path-find count.

--- a/internal/rpc/websocket_pathfind.go
+++ b/internal/rpc/websocket_pathfind.go
@@ -15,17 +15,20 @@ type pathFindUpdateTarget struct {
 }
 
 func (ws *WebSocketServer) executePathFind(wsConn *websocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
+	if rpcErr := handlers.RequirePathSearch(ctx); rpcErr != nil {
+		return nil, rpcErr
+	}
 	var params map[string]json.RawMessage
 	if len(cmd.Params) == 0 || json.Unmarshal(cmd.Params, &params) != nil {
 		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 	}
 	rawSubcommand, exists := params["subcommand"]
 	if !exists {
-		return nil, types.RpcErrorInvalidParams("Invalid field 'subcommand'.")
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 	}
 	var subcommand *string
 	if err := json.Unmarshal(rawSubcommand, &subcommand); err != nil || subcommand == nil {
-		return nil, types.RpcErrorInvalidParams("Invalid field 'subcommand'.")
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 	}
 	wsConn.SetAPIVersion(ctx.ApiVersion)
 
@@ -38,7 +41,7 @@ func (ws *WebSocketServer) executePathFind(wsConn *websocketConnection, ctx *typ
 	case "status":
 		return ws.executePathFindStatus(wsConn, ctx, cmd)
 	default:
-		return nil, types.RpcErrorInvalidParams("Invalid field 'subcommand'.")
+		return nil, types.RpcErrorInvalidParams("Invalid parameters.")
 	}
 }
 
@@ -47,12 +50,6 @@ func (ws *WebSocketServer) executePathFind(wsConn *websocketConnection, ctx *typ
 func (ws *WebSocketServer) executePathFindCreate(wsConn *websocketConnection, ctx *types.RpcContext, cmd types.WebSocketCommand) (any, *types.RpcError) {
 	ws.bindPathFindRefreshManager(wsConn)
 	wsConn.clearPathFindSession()
-
-	release, rpcErr := handlers.AcquirePathfind(ctx)
-	if rpcErr != nil {
-		return nil, rpcErr
-	}
-	defer release()
 
 	session, rpcErr := ParseAndCreateSession(cmd.Params, cmd.ID)
 	if rpcErr != nil {

--- a/internal/rpc/websocket_special_dispatch_test.go
+++ b/internal/rpc/websocket_special_dispatch_test.go
@@ -14,7 +14,10 @@ import (
 
 func newSpecialDispatchHarness(t *testing.T) (*WebSocketServer, *websocketConnection, *types.RpcContext) {
 	t.Helper()
-	services := &types.ServiceContainer{ClientLoad: types.NewClientLoadShedder()}
+	services := &types.ServiceContainer{
+		ClientLoad:   types.NewClientLoadShedder(),
+		Capabilities: types.RPCCapabilities{PathSearchMax: 3},
+	}
 	ws := NewWebSocketServer(WebSocketServerOptions{Timeout: time.Second, Services: services, LoadTracker: loadtrack.New()})
 	ws.methodRegistry.Register("subscribe", &stubHandler{})
 	ws.methodRegistry.Register("path_find", &stubHandler{})
@@ -186,6 +189,38 @@ func TestWebSocketPathFindDynamicLoadCost(t *testing.T) {
 			_, _ = ws.executePathFind(conn, ctx, cmd)
 			if got := loadtrack.LoadKind(ctx.LoadCost); got != test.want {
 				t.Fatalf("load kind = %d, want %d", got, test.want)
+			}
+		})
+	}
+}
+
+func TestWebSocketPathFindCapabilityPrecedesSubcommandValidation(t *testing.T) {
+	ws, conn, ctx := newSpecialDispatchHarness(t)
+	ctx.Services.Capabilities.PathSearchMax = 0
+	_, rpcErr := ws.executePathFind(conn, ctx, types.WebSocketCommand{Params: json.RawMessage(`{not json`)})
+	if rpcErr == nil || rpcErr.ErrorString != "notSupported" {
+		t.Fatalf("disabled path_find error = %v, want notSupported", rpcErr)
+	}
+}
+
+func TestWebSocketPathFindCreateDoesNotUseLegacyBusyGate(t *testing.T) {
+	ws, conn, ctx := newSpecialDispatchHarness(t)
+	ctx.Services.IsLoadedLocal = func() bool { return true }
+	_, rpcErr := ws.executePathFind(conn, ctx, types.WebSocketCommand{
+		Params: json.RawMessage(`{"subcommand":"create"}`),
+	})
+	if rpcErr == nil || rpcErr.ErrorString != "invalidParams" || rpcErr.Message != "Missing field 'source_account'." {
+		t.Fatalf("path_find create error = %v, want field validation after admission", rpcErr)
+	}
+}
+
+func TestWebSocketPathFindSubcommandValidationUsesCanonicalParams(t *testing.T) {
+	for _, params := range []string{`{}`, `{"subcommand":7}`, `{"subcommand":"future"}`, `{not json`} {
+		t.Run(params, func(t *testing.T) {
+			ws, conn, ctx := newSpecialDispatchHarness(t)
+			_, rpcErr := ws.executePathFind(conn, ctx, types.WebSocketCommand{Params: json.RawMessage(params)})
+			if rpcErr == nil || rpcErr.ErrorString != "invalidParams" || rpcErr.Message != "Invalid parameters." {
+				t.Fatalf("path_find error = %v, want canonical invalidParams", rpcErr)
 			}
 		})
 	}

--- a/internal/rpc/websocket_test.go
+++ b/internal/rpc/websocket_test.go
@@ -778,7 +778,10 @@ func TestWebSocketSpecialCommandDecodeErrorsAreFixed(t *testing.T) {
 				Request: map[string]any{"command": test.command, "id": int32(7)},
 			}
 
-			test.invoke(ws, wsConn, &types.RpcContext{ApiVersion: types.DefaultApiVersion}, cmd)
+			test.invoke(ws, wsConn, &types.RpcContext{
+				ApiVersion: types.DefaultApiVersion,
+				Services:   &types.ServiceContainer{Capabilities: types.RPCCapabilities{PathSearchMax: 3}},
+			}, cmd)
 			body := <-wsConn.SendChannel
 			if got := string(body); got != test.want {
 				t.Fatalf("response = %s, want %s", got, test.want)

--- a/internal/testing/rpcenv/rpcenv.go
+++ b/internal/testing/rpcenv/rpcenv.go
@@ -37,10 +37,12 @@ func Wrap(t testing.TB, env *jtx.TestEnv) *Env {
 	registry := types.NewMethodRegistry()
 	handlers.RegisterAll(registry)
 	adapter := newLedgerAdapter(env)
+	services := types.NewServiceContainer(adapter)
+	services.Capabilities.PathSearchMax = 3
 	return &Env{
 		TestEnv:  env,
 		t:        t,
-		services: types.NewServiceContainer(adapter),
+		services: services,
 		registry: registry,
 	}
 }


### PR DESCRIPTION
## Summary
- Enforce path-search capability, load, concurrency, and ledger admission gates.
- Preserve WebSocket lifecycle semantics and fail closed on pathfinding storage errors.

## Verification
- Pathfinding and full RPC tests
- Targeted race, vet, strict lint, build, and oracle review

Refs #1486

Stack layer 7 of 16; depends on #1572.